### PR TITLE
feat(prefs): add a GUI control for the sparse part-file setting (/eMule/CreateSparseFiles)

### DIFF
--- a/po/amule.pot
+++ b/po/amule.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-28 08:06+0200\n"
+"POT-Creation-Date: 2026-07-28 10:19+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -132,7 +132,7 @@ msgstr ""
 msgid "Not now"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:422 src/amuleDlg.cpp:600
+#: src/AppImageIntegration.cpp:422 src/amuleDlg.cpp:665
 msgid "Don't ask again"
 msgstr ""
 
@@ -204,7 +204,7 @@ msgid "Killing amuleweb instance with pid '%d' ... "
 msgstr ""
 
 #: src/amule.cpp:336 src/amule.cpp:349 src/ClientRef.cpp:180
-#: src/SearchDlg.cpp:880 src/ServerListCtrl.cpp:98
+#: src/SearchDlg.cpp:1041 src/ServerListCtrl.cpp:98
 msgid "Failed"
 msgstr ""
 
@@ -546,29 +546,67 @@ msgstr ""
 msgid "ERROR: %s"
 msgstr ""
 
-#: src/amuleDlg.cpp:236
+#: src/amuleDlg.cpp:250
 #, c-format
 msgid "This is aMule %s based on eMule."
 msgstr ""
 
-#: src/amuleDlg.cpp:237
+#: src/amuleDlg.cpp:251
 #, c-format
 msgid "Running on %s"
 msgstr ""
 
-#: src/amuleDlg.cpp:239
+#: src/amuleDlg.cpp:253
 msgid "Visit https://github.com/amule-org/amule/releases/latest to check if a new version is available."
 msgstr ""
 
-#: src/amuleDlg.cpp:268
+#: src/amuleDlg.cpp:282
 msgid "FATAL ERROR: Failed to create Timer"
 msgstr ""
 
-#: src/amuleDlg.cpp:592
+#: src/amuleDlg.cpp:361 src/amuleDlg.cpp:1787 src/amuleDlg.cpp:2033
+#: src/muuli_wdr.cpp:1492 src/muuli_wdr.cpp:3418
+msgid "Networks"
+msgstr ""
+
+#: src/amuleDlg.cpp:362 src/amuleDlg.cpp:1793 src/muuli_wdr.cpp:3419
+msgid "Searches"
+msgstr ""
+
+#: src/amuleDlg.cpp:363 src/amuleDlg.cpp:1799 src/DownloadListCtrl.cpp:740
+#: src/muuli_wdr.cpp:392 src/muuli_wdr.cpp:1585 src/muuli_wdr.cpp:3420
+#: src/Statistics.cpp:829
+msgid "Downloads"
+msgstr ""
+
+#: src/amuleDlg.cpp:364 src/amuleDlg.cpp:1805 src/muuli_wdr.cpp:3294
+msgid "Shared files"
+msgstr ""
+
+#: src/amuleDlg.cpp:365 src/amuleDlg.cpp:1811 src/muuli_wdr.cpp:2926
+#: src/muuli_wdr.cpp:3376 src/muuli_wdr.cpp:3423
+msgid "Messages"
+msgstr ""
+
+#: src/amuleDlg.cpp:366 src/amuleDlg.cpp:1817 src/muuli_wdr.cpp:3424
+#: src/PrefsUnifiedDlg.cpp:312 src/Statistics.cpp:779 src/Statistics.cpp:1235
+msgid "Statistics"
+msgstr ""
+
+#: src/amuleDlg.cpp:368 src/amuleDlg.cpp:1824 src/muuli_wdr.cpp:3426
+#: src/PrefsUnifiedDlg.cpp:328 src/utils/wxCas/src/wxcasprefs.cpp:39
+msgid "Preferences"
+msgstr ""
+
+#: src/amuleDlg.cpp:371
+msgid "Navigate"
+msgstr ""
+
+#: src/amuleDlg.cpp:657
 msgid "New version available"
 msgstr ""
 
-#: src/amuleDlg.cpp:596
+#: src/amuleDlg.cpp:661
 #, c-format
 msgid ""
 "A new version of aMule (%s) is available.\n"
@@ -578,217 +616,184 @@ msgid ""
 "Would you like to open the download page?"
 msgstr ""
 
-#: src/amuleDlg.cpp:678
+#: src/amuleDlg.cpp:743
 msgid "aMule dialog destroyed"
 msgstr ""
 
-#: src/amuleDlg.cpp:701 src/DataToText.cpp:68 src/IPFilter.cpp:547
+#: src/amuleDlg.cpp:766 src/DataToText.cpp:68 src/IPFilter.cpp:547
 msgid "Connecting"
 msgstr ""
 
-#: src/amuleDlg.cpp:893
+#: src/amuleDlg.cpp:958
 msgid "eD2k: Connecting"
 msgstr ""
 
-#: src/amuleDlg.cpp:897
+#: src/amuleDlg.cpp:962
 msgid "eD2k: Disconnected"
 msgstr ""
 
-#: src/amuleDlg.cpp:903
+#: src/amuleDlg.cpp:968
 msgid "Kad: Firewalled"
 msgstr ""
 
-#: src/amuleDlg.cpp:907
+#: src/amuleDlg.cpp:972
 msgid "Kad: Connected"
 msgstr ""
 
-#: src/amuleDlg.cpp:912
+#: src/amuleDlg.cpp:977
 msgid "Kad: Connecting"
 msgstr ""
 
-#: src/amuleDlg.cpp:916
+#: src/amuleDlg.cpp:981
 msgid "Kad: Off"
 msgstr ""
 
-#: src/amuleDlg.cpp:964 src/DownloadListCtrl.cpp:505
+#: src/amuleDlg.cpp:1029 src/DownloadListCtrl.cpp:505
 #: src/DownloadListCtrl.cpp:749 src/FriendListCtrl.cpp:180
 #: src/muuli_wdr.cpp:731 src/muuli_wdr.cpp:782 src/muuli_wdr.cpp:846
-#: src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2224 src/muuli_wdr.cpp:2309
-#: src/muuli_wdr.cpp:3057 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
+#: src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2231 src/muuli_wdr.cpp:2316
+#: src/muuli_wdr.cpp:3064 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
 #: src/ServerListCtrl.cpp:606 src/TransferWnd.cpp:378
 #: src/utils/wxCas/src/wxcasprefs.cpp:235
 msgid "Cancel"
 msgstr ""
 
-#: src/amuleDlg.cpp:965
+#: src/amuleDlg.cpp:1030
 msgid "Stop the current connection attempts"
 msgstr ""
 
-#: src/amuleDlg.cpp:970 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976
-#: src/muuli_wdr.cpp:2447
+#: src/amuleDlg.cpp:1035 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976
+#: src/muuli_wdr.cpp:2454
 msgid "Disconnect"
 msgstr ""
 
-#: src/amuleDlg.cpp:971
+#: src/amuleDlg.cpp:1036
 msgid "Disconnect from the currently connected networks"
 msgstr ""
 
-#: src/amuleDlg.cpp:976 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979
-#: src/muuli_wdr.cpp:2602 src/muuli_wdr.cpp:3054 src/muuli_wdr.cpp:3409
+#: src/amuleDlg.cpp:1041 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979
+#: src/muuli_wdr.cpp:2609 src/muuli_wdr.cpp:3061 src/muuli_wdr.cpp:3416
 msgid "Connect"
 msgstr ""
 
-#: src/amuleDlg.cpp:977
+#: src/amuleDlg.cpp:1042
 msgid "Connect to the currently enabled networks"
 msgstr ""
 
-#: src/amuleDlg.cpp:1089
+#: src/amuleDlg.cpp:1154
 #, c-format
 msgid "Up: %.1f%s (%.1f) | Down: %.1f%s (%.1f)"
 msgstr ""
 
-#: src/amuleDlg.cpp:1091 src/amuleDlg.cpp:1093 src/amuleDlg.cpp:1097
-#: src/amuleDlg.cpp:1099 src/amuleDlg.cpp:1110 src/amuleDlg.cpp:1112
+#: src/amuleDlg.cpp:1156 src/amuleDlg.cpp:1158 src/amuleDlg.cpp:1162
+#: src/amuleDlg.cpp:1164 src/amuleDlg.cpp:1175 src/amuleDlg.cpp:1177
 #: src/MuleTrayIcon.cpp:796 src/MuleTrayIcon.cpp:799
 msgid " MB/s"
 msgstr ""
 
-#: src/amuleDlg.cpp:1091 src/amuleDlg.cpp:1093 src/amuleDlg.cpp:1097
-#: src/amuleDlg.cpp:1099 src/amuleDlg.cpp:1110 src/amuleDlg.cpp:1112
+#: src/amuleDlg.cpp:1156 src/amuleDlg.cpp:1158 src/amuleDlg.cpp:1162
+#: src/amuleDlg.cpp:1164 src/amuleDlg.cpp:1175 src/amuleDlg.cpp:1177
 #: src/MuleTrayIcon.cpp:796 src/MuleTrayIcon.cpp:799
 #: src/utils/wxCas/src/wxcasframe.cpp:1041
 msgid " kB/s"
 msgstr ""
 
-#: src/amuleDlg.cpp:1096
+#: src/amuleDlg.cpp:1161
 #, c-format
 msgid "Up: %.1f%s | Down: %.1f%s"
 msgstr ""
 
-#: src/amuleDlg.cpp:1128
+#: src/amuleDlg.cpp:1193
 #, c-format
 msgid "aMule (%s | Connected)"
 msgstr ""
 
-#: src/amuleDlg.cpp:1130
+#: src/amuleDlg.cpp:1195
 #, c-format
 msgid "aMule (%s | Disconnected)"
 msgstr ""
 
-#: src/amuleDlg.cpp:1183
+#: src/amuleDlg.cpp:1248
 #, c-format
 msgid "Do you really want to exit %s?"
 msgstr ""
 
-#: src/amuleDlg.cpp:1185
+#: src/amuleDlg.cpp:1250
 msgid "Exit confirmation"
 msgstr ""
 
-#: src/amuleDlg.cpp:1548
+#: src/amuleDlg.cpp:1613
 msgid "Launch Command: "
 msgstr ""
 
-#: src/amuleDlg.cpp:1567 src/muuli_wdr.cpp:1971 src/Preferences.cpp:951
+#: src/amuleDlg.cpp:1632 src/muuli_wdr.cpp:1978 src/Preferences.cpp:952
 msgid "- default -"
 msgstr ""
 
-#: src/amuleDlg.cpp:1595
+#: src/amuleDlg.cpp:1660
 #, c-format
 msgid "Skin directory '%s' does not exist"
 msgstr ""
 
-#: src/amuleDlg.cpp:1598
+#: src/amuleDlg.cpp:1663
 #, c-format
 msgid "WARNING: Unable to open skin file '%s' for read"
 msgstr ""
 
-#: src/amuleDlg.cpp:1722 src/amuleDlg.cpp:1968 src/muuli_wdr.cpp:1485
-#: src/muuli_wdr.cpp:3411
-msgid "Networks"
-msgstr ""
-
-#: src/amuleDlg.cpp:1726 src/muuli_wdr.cpp:3411
+#: src/amuleDlg.cpp:1791 src/muuli_wdr.cpp:3418
 msgid "Networks Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1728 src/muuli_wdr.cpp:3412
-msgid "Searches"
-msgstr ""
-
-#: src/amuleDlg.cpp:1732 src/muuli_wdr.cpp:3412
+#: src/amuleDlg.cpp:1797 src/muuli_wdr.cpp:3419
 msgid "Searches Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1734 src/DownloadListCtrl.cpp:740 src/muuli_wdr.cpp:392
-#: src/muuli_wdr.cpp:1578 src/muuli_wdr.cpp:3413 src/Statistics.cpp:829
-msgid "Downloads"
-msgstr ""
-
-#: src/amuleDlg.cpp:1738 src/muuli_wdr.cpp:3413
+#: src/amuleDlg.cpp:1803 src/muuli_wdr.cpp:3420
 msgid "Downloads Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1740 src/muuli_wdr.cpp:3287
-msgid "Shared files"
-msgstr ""
-
-#: src/amuleDlg.cpp:1744 src/muuli_wdr.cpp:3415
+#: src/amuleDlg.cpp:1809 src/muuli_wdr.cpp:3422
 msgid "Shared Files Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1746 src/muuli_wdr.cpp:2919 src/muuli_wdr.cpp:3369
-#: src/muuli_wdr.cpp:3416
-msgid "Messages"
-msgstr ""
-
-#: src/amuleDlg.cpp:1750 src/muuli_wdr.cpp:3416
+#: src/amuleDlg.cpp:1815 src/muuli_wdr.cpp:3423
 msgid "Messages Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1752 src/muuli_wdr.cpp:3417 src/PrefsUnifiedDlg.cpp:312
-#: src/Statistics.cpp:779 src/Statistics.cpp:1235
-msgid "Statistics"
-msgstr ""
-
-#: src/amuleDlg.cpp:1756 src/muuli_wdr.cpp:3417
+#: src/amuleDlg.cpp:1821 src/muuli_wdr.cpp:3424
 msgid "Statistics Graph Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1759 src/muuli_wdr.cpp:3419 src/PrefsUnifiedDlg.cpp:328
-#: src/utils/wxCas/src/wxcasprefs.cpp:39
-msgid "Preferences"
-msgstr ""
-
-#: src/amuleDlg.cpp:1763 src/muuli_wdr.cpp:3419
+#: src/amuleDlg.cpp:1828 src/muuli_wdr.cpp:3426
 msgid "Preferences Settings Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1766 src/muuli_wdr.cpp:3420
+#: src/amuleDlg.cpp:1831 src/muuli_wdr.cpp:3427
 msgid "Import"
 msgstr ""
 
-#: src/amuleDlg.cpp:1770 src/muuli_wdr.cpp:3420
+#: src/amuleDlg.cpp:1835 src/muuli_wdr.cpp:3427
 msgid "The partfile importer tool"
 msgstr ""
 
-#: src/amuleDlg.cpp:1773 src/muuli_wdr.cpp:3421
+#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3428
 #: src/utils/aLinkCreator/src/alcframe.cpp:262
 msgid "About"
 msgstr ""
 
-#: src/amuleDlg.cpp:1773 src/muuli_wdr.cpp:3421
+#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3428
 msgid "About/Help"
 msgstr ""
 
-#: src/amuleDlg.cpp:1971
+#: src/amuleDlg.cpp:2036
 msgid "eD2k network"
 msgstr ""
 
-#: src/amuleDlg.cpp:1974
+#: src/amuleDlg.cpp:2039
 msgid "Kad network"
 msgstr ""
 
-#: src/amuleDlg.cpp:1974
+#: src/amuleDlg.cpp:2039
 msgid "No network"
 msgstr ""
 
@@ -1315,19 +1320,19 @@ msgstr ""
 msgid "Very low"
 msgstr ""
 
-#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:743 src/muuli_wdr.cpp:2275
+#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:743 src/muuli_wdr.cpp:2282
 #: src/ServerListCtrl.cpp:263 src/ServerListCtrl.cpp:456
 #: src/SharedFilesCtrl.cpp:145
 msgid "Low"
 msgstr ""
 
-#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:744 src/muuli_wdr.cpp:2276
+#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:744 src/muuli_wdr.cpp:2283
 #: src/ServerListCtrl.cpp:266 src/ServerListCtrl.cpp:457
 #: src/SharedFilesCtrl.cpp:146
 msgid "Normal"
 msgstr ""
 
-#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:745 src/muuli_wdr.cpp:2277
+#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:745 src/muuli_wdr.cpp:2284
 #: src/ServerListCtrl.cpp:269 src/ServerListCtrl.cpp:458
 #: src/SharedFilesCtrl.cpp:147
 msgid "High"
@@ -1419,8 +1424,8 @@ msgstr ""
 msgid "Remote Server"
 msgstr ""
 
-#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3174
-#: src/SearchDlg.cpp:111 src/TextClient.cpp:911
+#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3181
+#: src/SearchDlg.cpp:119 src/TextClient.cpp:911
 msgid "Kad"
 msgstr ""
 
@@ -1490,7 +1495,7 @@ msgstr ""
 msgid "Size"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3241
+#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3248
 msgid "Transferred"
 msgstr ""
 
@@ -1546,7 +1551,7 @@ msgid ""
 "\n"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:746 src/muuli_wdr.cpp:2278
+#: src/DownloadListCtrl.cpp:746 src/muuli_wdr.cpp:2285
 #: src/SharedFilesCtrl.cpp:150
 msgid "Auto"
 msgstr ""
@@ -1584,7 +1589,7 @@ msgid "Extended Options"
 msgstr ""
 
 #: src/DownloadListCtrl.cpp:770 src/DownloadListCtrl.cpp:822
-#: src/muuli_wdr.cpp:1789
+#: src/muuli_wdr.cpp:1796
 msgid "Preview"
 msgstr ""
 
@@ -2262,19 +2267,19 @@ msgstr ""
 msgid "eD2k"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:349 src/muuli_wdr.cpp:1488
+#: src/FirstRunWizard.cpp:349 src/muuli_wdr.cpp:1495
 msgid "Kademlia"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:359 src/muuli_wdr.cpp:1416
+#: src/FirstRunWizard.cpp:359 src/muuli_wdr.cpp:1423
 msgid "Standard TCP Port "
 msgstr ""
 
-#: src/FirstRunWizard.cpp:365 src/muuli_wdr.cpp:1428
+#: src/FirstRunWizard.cpp:365 src/muuli_wdr.cpp:1435
 msgid "Extended UDP port (Kad / global search) "
 msgstr ""
 
-#: src/FirstRunWizard.cpp:377 src/muuli_wdr.cpp:1435
+#: src/FirstRunWizard.cpp:377 src/muuli_wdr.cpp:1442
 msgid "Enable UPnP for router port forwarding"
 msgstr ""
 
@@ -2299,7 +2304,7 @@ msgstr ""
 msgid "Your peer lists are already in place - nothing to download."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:434 src/muuli_wdr.cpp:1533
+#: src/FirstRunWizard.cpp:434 src/muuli_wdr.cpp:1540
 msgid "Auto-update server list at startup"
 msgstr ""
 
@@ -2345,23 +2350,23 @@ msgid ""
 "want downloads on a different (e.g. larger) disk."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:549 src/FirstRunWizard.cpp:611 src/muuli_wdr.cpp:1701
+#: src/FirstRunWizard.cpp:549 src/FirstRunWizard.cpp:611 src/muuli_wdr.cpp:1708
 msgid "Destination folder for downloads"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:553 src/FirstRunWizard.cpp:569 src/muuli_wdr.cpp:1342
-#: src/muuli_wdr.cpp:1359 src/muuli_wdr.cpp:1676 src/muuli_wdr.cpp:1707
-#: src/muuli_wdr.cpp:1719 src/muuli_wdr.cpp:2762
+#: src/FirstRunWizard.cpp:553 src/FirstRunWizard.cpp:569 src/muuli_wdr.cpp:1349
+#: src/muuli_wdr.cpp:1366 src/muuli_wdr.cpp:1683 src/muuli_wdr.cpp:1714
+#: src/muuli_wdr.cpp:1726 src/muuli_wdr.cpp:2769
 #: src/utils/aLinkCreator/src/alcframe.cpp:135
 #: src/utils/wxCas/src/wxcasprefs.cpp:52 src/utils/wxCas/src/wxcasprefs.cpp:118
 msgid "Browse"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:559 src/muuli_wdr.cpp:1712
+#: src/FirstRunWizard.cpp:559 src/muuli_wdr.cpp:1719
 msgid "(All files in this folder are shared with other peers)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:565 src/FirstRunWizard.cpp:624 src/muuli_wdr.cpp:1714
+#: src/FirstRunWizard.cpp:565 src/FirstRunWizard.cpp:624 src/muuli_wdr.cpp:1721
 msgid "Folder for temporary download files"
 msgstr ""
 
@@ -2392,7 +2397,7 @@ msgstr ""
 msgid "CRITICAL - no client on StartChatSession"
 msgstr ""
 
-#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2668 src/muuli_wdr.cpp:3345
+#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2675 src/muuli_wdr.cpp:3352
 msgid "Friends"
 msgstr ""
 
@@ -2770,7 +2775,7 @@ msgstr ""
 msgid "Uploaded"
 msgstr ""
 
-#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3225
+#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3232
 msgid "Requested"
 msgstr ""
 
@@ -2893,7 +2898,7 @@ msgid "WARNING: "
 msgstr ""
 
 #: src/MuleNotebook.cpp:179 src/muuli_wdr.cpp:817 src/muuli_wdr.cpp:1229
-#: src/muuli_wdr.cpp:3129 src/muuli_wdr.cpp:3385
+#: src/muuli_wdr.cpp:3136 src/muuli_wdr.cpp:3392
 msgid "Close"
 msgstr ""
 
@@ -2906,12 +2911,12 @@ msgstr ""
 msgid "Copy"
 msgstr ""
 
-#: src/MuleTextCtrl.cpp:88
+#: src/MuleTextCtrl.cpp:88 src/SearchDlg.cpp:261
 msgid "Paste"
 msgstr ""
 
 #: src/MuleTextCtrl.cpp:89 src/muuli_wdr.cpp:358 src/muuli_wdr.cpp:757
-#: src/muuli_wdr.cpp:2352 src/muuli_wdr.cpp:2371 src/muuli_wdr.cpp:2393
+#: src/muuli_wdr.cpp:2359 src/muuli_wdr.cpp:2378 src/muuli_wdr.cpp:2400
 #: src/utils/aLinkCreator/src/alcframe.cpp:142
 msgid "Clear"
 msgstr ""
@@ -3002,8 +3007,8 @@ msgid "Exit"
 msgstr ""
 
 #: src/MuleTrayIcon.cpp:579 src/MuleTrayIcon.cpp:945 src/MuleTrayIcon.cpp:965
-#: src/muuli_wdr.cpp:1391 src/muuli_wdr.cpp:1399 src/muuli_wdr.cpp:1406
-#: src/muuli_wdr.cpp:1835 src/muuli_wdr.cpp:1841 src/OtherFunctions.cpp:91
+#: src/muuli_wdr.cpp:1398 src/muuli_wdr.cpp:1406 src/muuli_wdr.cpp:1413
+#: src/muuli_wdr.cpp:1842 src/muuli_wdr.cpp:1848 src/OtherFunctions.cpp:91
 #: src/StatisticsDlg.cpp:93 src/StatisticsDlg.cpp:95
 msgid "kB/s"
 msgstr ""
@@ -3172,7 +3177,7 @@ msgstr ""
 msgid "Type"
 msgstr ""
 
-#: src/muuli_wdr.cpp:215 src/SearchDlg.cpp:110 src/SearchListCtrl.cpp:853
+#: src/muuli_wdr.cpp:215 src/SearchDlg.cpp:118 src/SearchListCtrl.cpp:853
 msgid "Local"
 msgstr ""
 
@@ -3243,7 +3248,7 @@ msgstr ""
 msgid "KB"
 msgstr ""
 
-#: src/muuli_wdr.cpp:274 src/muuli_wdr.cpp:293 src/muuli_wdr.cpp:1620
+#: src/muuli_wdr.cpp:274 src/muuli_wdr.cpp:293 src/muuli_wdr.cpp:1627
 #: src/OtherFunctions.cpp:64
 msgid "MB"
 msgstr ""
@@ -3260,7 +3265,7 @@ msgstr ""
 msgid "Availability"
 msgstr ""
 
-#: src/muuli_wdr.cpp:312 src/muuli_wdr.cpp:398 src/muuli_wdr.cpp:3290
+#: src/muuli_wdr.cpp:312 src/muuli_wdr.cpp:398 src/muuli_wdr.cpp:3297
 msgid "Filter:"
 msgstr ""
 
@@ -3292,7 +3297,7 @@ msgstr ""
 msgid "Stop"
 msgstr ""
 
-#: src/muuli_wdr.cpp:348 src/muuli_wdr.cpp:1385 src/SearchListCtrl.cpp:732
+#: src/muuli_wdr.cpp:348 src/muuli_wdr.cpp:1392 src/SearchListCtrl.cpp:732
 msgid "Download"
 msgstr ""
 
@@ -3323,8 +3328,8 @@ msgstr ""
 #: src/muuli_wdr.cpp:1160 src/muuli_wdr.cpp:1167 src/muuli_wdr.cpp:1172
 #: src/muuli_wdr.cpp:1179 src/muuli_wdr.cpp:1184 src/muuli_wdr.cpp:1191
 #: src/muuli_wdr.cpp:1205 src/muuli_wdr.cpp:1212 src/muuli_wdr.cpp:1217
-#: src/muuli_wdr.cpp:1224 src/muuli_wdr.cpp:3227 src/muuli_wdr.cpp:3235
-#: src/muuli_wdr.cpp:3243
+#: src/muuli_wdr.cpp:1224 src/muuli_wdr.cpp:3234 src/muuli_wdr.cpp:3242
+#: src/muuli_wdr.cpp:3250
 msgid "N/A"
 msgstr ""
 
@@ -3464,7 +3469,7 @@ msgstr ""
 msgid "Album :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:685 src/muuli_wdr.cpp:2247
+#: src/muuli_wdr.cpp:685 src/muuli_wdr.cpp:2254
 msgid "Title :"
 msgstr ""
 
@@ -3570,7 +3575,7 @@ msgstr ""
 msgid "Userhash :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:895 src/muuli_wdr.cpp:1741 src/muuli_wdr.cpp:2442
+#: src/muuli_wdr.cpp:895 src/muuli_wdr.cpp:1748 src/muuli_wdr.cpp:2449
 #: src/utils/aLinkCreator/src/alcframe.cpp:137
 msgid "Add"
 msgstr ""
@@ -3579,15 +3584,15 @@ msgstr ""
 msgid "Download-Speed"
 msgstr ""
 
-#: src/muuli_wdr.cpp:954 src/muuli_wdr.cpp:989 src/muuli_wdr.cpp:2546
+#: src/muuli_wdr.cpp:954 src/muuli_wdr.cpp:989 src/muuli_wdr.cpp:2553
 msgid "Current"
 msgstr ""
 
-#: src/muuli_wdr.cpp:962 src/muuli_wdr.cpp:997 src/muuli_wdr.cpp:2554
+#: src/muuli_wdr.cpp:962 src/muuli_wdr.cpp:997 src/muuli_wdr.cpp:2561
 msgid "Running average"
 msgstr ""
 
-#: src/muuli_wdr.cpp:970 src/muuli_wdr.cpp:1005 src/muuli_wdr.cpp:2562
+#: src/muuli_wdr.cpp:970 src/muuli_wdr.cpp:1005 src/muuli_wdr.cpp:2569
 msgid "Session average"
 msgstr ""
 
@@ -3599,7 +3604,7 @@ msgstr ""
 msgid "Connections"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1024 src/muuli_wdr.cpp:1860
+#: src/muuli_wdr.cpp:1024 src/muuli_wdr.cpp:1867
 msgid "Active downloads"
 msgstr ""
 
@@ -3607,7 +3612,7 @@ msgstr ""
 msgid "Active connections (1:1)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1040 src/muuli_wdr.cpp:1861
+#: src/muuli_wdr.cpp:1040 src/muuli_wdr.cpp:1868
 msgid "Active uploads"
 msgstr ""
 
@@ -3723,8 +3728,8 @@ msgstr ""
 msgid "Language: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1257 src/muuli_wdr.cpp:1323 src/muuli_wdr.cpp:1327
-#: src/muuli_wdr.cpp:1330
+#: src/muuli_wdr.cpp:1257 src/muuli_wdr.cpp:1330 src/muuli_wdr.cpp:1334
+#: src/muuli_wdr.cpp:1337
 msgid "The delay before showing tool-tips."
 msgstr ""
 
@@ -3800,923 +3805,931 @@ msgstr ""
 msgid "Enabling this will make aMule to show notifications when finished downloading."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1322
-msgid "Tooltip delay time: "
+#: src/muuli_wdr.cpp:1323
+msgid "Remember search history"
+msgstr ""
+
+#: src/muuli_wdr.cpp:1324
+msgid "Keeps a dropdown list of your past search terms in the Search tab's Name field. This remembers the queries you typed, not the results they returned."
 msgstr ""
 
 #: src/muuli_wdr.cpp:1329
+msgid "Tooltip delay time: "
+msgstr ""
+
+#: src/muuli_wdr.cpp:1336
 msgid "seconds"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1333
+#: src/muuli_wdr.cpp:1340
 msgid "Browser Selection"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1339
+#: src/muuli_wdr.cpp:1346
 msgid "Enter your browser name here. Leave this field empty to use the system default browser."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1346
+#: src/muuli_wdr.cpp:1353
 msgid "Open in new tab if possible"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1348
+#: src/muuli_wdr.cpp:1355
 msgid "Open the web page in a new tab instead of in a new window when possible"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1352
+#: src/muuli_wdr.cpp:1359
 msgid "Video Player"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1379
+#: src/muuli_wdr.cpp:1386
 msgid "Bandwidth limits"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1393
+#: src/muuli_wdr.cpp:1400
 msgid "Upload"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1401
+#: src/muuli_wdr.cpp:1408
 msgid "Slot Allocation"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1410
+#: src/muuli_wdr.cpp:1417
 msgid "Ports"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1420
+#: src/muuli_wdr.cpp:1427
 msgid "This is the standard eD2k port and cannot be disabled."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1423
+#: src/muuli_wdr.cpp:1430
 msgid "UDP port for server requests (TCP+3):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1425
+#: src/muuli_wdr.cpp:1432
 msgid "4665"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1432
+#: src/muuli_wdr.cpp:1439
 msgid "This UDP port is used for extended eD2k requests and Kad network"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1439
+#: src/muuli_wdr.cpp:1446
 msgid "UPnP TCP Port (Optional):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1449
+#: src/muuli_wdr.cpp:1456
 msgid "Bind local address to IP (empty for any):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1452
+#: src/muuli_wdr.cpp:1459
 msgid "Advanced users only: If you have multiple network interfaces, enter the address of the interface to which aMule should be bound."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1455 src/muuli_wdr.cpp:2054
+#: src/muuli_wdr.cpp:1462 src/muuli_wdr.cpp:2061
 msgid "Bind to network interface (empty for any):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1468
+#: src/muuli_wdr.cpp:1475
 msgid "Advanced users only: pin all of aMule's traffic to one network interface, chosen from the list or typed in by name (e.g. tun0, eth0, en0) or index. Unlike binding to an IP, this stops traffic leaking out via the default route - useful with a VPN. Requires no elevated privileges."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1474
+#: src/muuli_wdr.cpp:1481
 msgid "Max sources per downloading file:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1478
+#: src/muuli_wdr.cpp:1485
 msgid "Max simultaneous connections:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1491 src/muuli_wdr.cpp:3169
+#: src/muuli_wdr.cpp:1498 src/muuli_wdr.cpp:3176
 msgid "ED2K"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1498
+#: src/muuli_wdr.cpp:1505
 msgid "Autoconnect on startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1501
+#: src/muuli_wdr.cpp:1508
 msgid "Reconnect on loss"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1523
+#: src/muuli_wdr.cpp:1530
 msgid "Remove dead server after"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1524
+#: src/muuli_wdr.cpp:1531
 msgid "Static servers are never removed, even when unreachable."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1528
+#: src/muuli_wdr.cpp:1535
 msgid "retries"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1536
+#: src/muuli_wdr.cpp:1543
 msgid "List"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1539
+#: src/muuli_wdr.cpp:1546
 msgid "Update server list when connecting to a server"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1542
+#: src/muuli_wdr.cpp:1549
 msgid "Update server list when a client connects"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1545
+#: src/muuli_wdr.cpp:1552
 msgid "Use priority system"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1549
+#: src/muuli_wdr.cpp:1556
 msgid "Use smart LowID check on connect"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1553
+#: src/muuli_wdr.cpp:1560
 msgid "Safe connect"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1557
+#: src/muuli_wdr.cpp:1564
 msgid "Autoconnect to servers in static list only"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1560
+#: src/muuli_wdr.cpp:1567
 msgid "Set manually added servers to High Priority"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1581
+#: src/muuli_wdr.cpp:1588
 msgid "Add files to download in pause mode"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1583
+#: src/muuli_wdr.cpp:1590
 msgid "Add files to download with auto priority"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1586
+#: src/muuli_wdr.cpp:1593
 msgid "Try to download first and last chunks first"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1590
+#: src/muuli_wdr.cpp:1597
 msgid "Endgame mode: rotate to faster sources for the final blocks"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1593
+#: src/muuli_wdr.cpp:1600
 msgid "Start next paused file when a file completes"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1596
+#: src/muuli_wdr.cpp:1603
 msgid "From the same category"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1598
+#: src/muuli_wdr.cpp:1605
 msgid "In alphabetic order"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1600
+#: src/muuli_wdr.cpp:1607
 msgid "Preallocate disk space for new files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1601
+#: src/muuli_wdr.cpp:1608
 msgid "For new files preallocates disk space for the whole file, thus reduces fragmentation"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1606
+#: src/muuli_wdr.cpp:1613
 msgid "Create new files as sparse files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1607
+#: src/muuli_wdr.cpp:1614
 msgid "A sparse file reserves its full size on disk immediately without writing real data to it -- fast, but unsupported or slow on some filesystems, and free-space accounting stays optimistic while the download is in progress. Turn this off to grow the file only as data arrives."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1612
+#: src/muuli_wdr.cpp:1619
 msgid "Stop downloads when free disk space reaches "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1613
+#: src/muuli_wdr.cpp:1620
 msgid "Select this if you want aMule to check your disk space"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1617
+#: src/muuli_wdr.cpp:1624
 msgid "Enter here the min disk space desired."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1623
+#: src/muuli_wdr.cpp:1630
 msgid "Save 10 sources on rare files (< 20 sources)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1627 src/Statistics.cpp:790
+#: src/muuli_wdr.cpp:1634 src/Statistics.cpp:790
 msgid "Uploads"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1630
+#: src/muuli_wdr.cpp:1637
 msgid "Add new shared files with auto priority"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1636
+#: src/muuli_wdr.cpp:1643
 msgid "Intelligent Corruption Handling (I.C.H.)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1639
+#: src/muuli_wdr.cpp:1646
 msgid "Enable"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1642
+#: src/muuli_wdr.cpp:1649
 msgid "Advanced I.C.H. trusts every hash (not recommended)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1654 src/PrefsUnifiedDlg.cpp:1910
+#: src/muuli_wdr.cpp:1661 src/PrefsUnifiedDlg.cpp:1910
 msgid "Media metadata extraction"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1658
+#: src/muuli_wdr.cpp:1665
 msgid "Extract length / bitrate / codec from shared audio and video files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1660
+#: src/muuli_wdr.cpp:1667
 msgid "When enabled, aMule runs ffprobe on each shared media file to fill in the Length / Bitrate / Codec columns other clients see when they find the file in a search. Requires ffmpeg (the ffprobe binary) to be installed."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1667
+#: src/muuli_wdr.cpp:1674
 msgid "Path to ffprobe:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1672
+#: src/muuli_wdr.cpp:1679
 msgid "Full path to the ffprobe binary. Leave empty to have aMule auto-detect it on startup."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1680
+#: src/muuli_wdr.cpp:1687
 msgid "Detect"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1681
+#: src/muuli_wdr.cpp:1688
 msgid "Search the standard install locations for an ffprobe binary and fill the path field."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1705
+#: src/muuli_wdr.cpp:1712
 msgid ""
 "Completed downloads are stored here. All files in this folder are automatically shared with other peers.\n"
 "If this folder also holds files you don't want to share, point it at an aMule-only sub-folder."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1708
+#: src/muuli_wdr.cpp:1715
 msgid "Pick the folder where completed downloads will be stored. All files in that folder will be shared with other peers."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1722
+#: src/muuli_wdr.cpp:1729
 msgid "Shared folders"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1728
+#: src/muuli_wdr.cpp:1735
 msgid "(Folders shared by the core. Enter a path to add one.)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1736
+#: src/muuli_wdr.cpp:1743
 msgid "Absolute path of a folder on the core's machine, e.g. /home/user/shared"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1738 src/PrefsUnifiedDlg.cpp:2794
+#: src/muuli_wdr.cpp:1745 src/PrefsUnifiedDlg.cpp:2794
 msgid "Recursive"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1739
+#: src/muuli_wdr.cpp:1746
 msgid "Share every sub-folder underneath this one, including ones created later."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1743 src/utils/aLinkCreator/src/alcframe.cpp:141
+#: src/muuli_wdr.cpp:1750 src/utils/aLinkCreator/src/alcframe.cpp:141
 msgid "Remove"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1747
+#: src/muuli_wdr.cpp:1754
 msgid "(Right click on folder icon for recursive share)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1754
+#: src/muuli_wdr.cpp:1761
 msgid "Share hidden files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1760
+#: src/muuli_wdr.cpp:1767
 msgid "Automatically rescan shared folders for changes"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1766
+#: src/muuli_wdr.cpp:1773
 msgid "Follow symbolic links in shared folders"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1772
+#: src/muuli_wdr.cpp:1779
 msgid "Exclude files matching:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1775
+#: src/muuli_wdr.cpp:1782
 msgid "Wildcard patterns separated by '|', e.g. .DS_Store|Thumbs.db|*.tmp. Files whose name matches are not shared. Matching is case-insensitive."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1779
+#: src/muuli_wdr.cpp:1786
 msgid "Patterns are regular expressions"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1780
+#: src/muuli_wdr.cpp:1787
 msgid "When set, the whole field is one regular expression ('|' is alternation). When unset, it is a list of '|'-separated wildcards."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1790
+#: src/muuli_wdr.cpp:1797
 msgid "Show how many shared files the current pattern would exclude."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1811
+#: src/muuli_wdr.cpp:1818
 msgid "Graphs"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1814 src/muuli_wdr.cpp:1876
+#: src/muuli_wdr.cpp:1821 src/muuli_wdr.cpp:1883
 msgid "Update delay : 5 secs"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1818
+#: src/muuli_wdr.cpp:1825
 msgid "Time for average graph: 100 mins"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1822
+#: src/muuli_wdr.cpp:1829
 msgid "Connections Graph Scale: 100 "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1829
+#: src/muuli_wdr.cpp:1836
 msgid "Download graph scale:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1837
+#: src/muuli_wdr.cpp:1844
 msgid "Upload graph scale:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1847
+#: src/muuli_wdr.cpp:1854
 msgid "Colors: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1851
+#: src/muuli_wdr.cpp:1858
 msgid "Background"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1852
+#: src/muuli_wdr.cpp:1859
 msgid "Grid"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1853
+#: src/muuli_wdr.cpp:1860
 msgid "Download current"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1854
+#: src/muuli_wdr.cpp:1861
 msgid "Download running average"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1855
+#: src/muuli_wdr.cpp:1862
 msgid "Download session average"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1856
+#: src/muuli_wdr.cpp:1863
 msgid "Upload current"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1857
+#: src/muuli_wdr.cpp:1864
 msgid "Upload running average"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1858
+#: src/muuli_wdr.cpp:1865
 msgid "Upload session average"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1859
+#: src/muuli_wdr.cpp:1866
 msgid "Active connections"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1862
+#: src/muuli_wdr.cpp:1869
 msgid "Systray Icon Speed Bar"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1863
+#: src/muuli_wdr.cpp:1870
 msgid "Kad-nodes current"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1864
+#: src/muuli_wdr.cpp:1871
 msgid "Kad-nodes running"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1865
+#: src/muuli_wdr.cpp:1872
 msgid "Kad-nodes session"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1869 src/muuli_wdr.cpp:2296
+#: src/muuli_wdr.cpp:1876 src/muuli_wdr.cpp:2303
 msgid "Select"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1873
+#: src/muuli_wdr.cpp:1880
 msgid "Tree"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1883
+#: src/muuli_wdr.cpp:1890
 msgid "Number of Client Versions shown (0=unlimited)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1908
+#: src/muuli_wdr.cpp:1915
 msgid "!!! WARNING !!!"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1923
+#: src/muuli_wdr.cpp:1930
 msgid "Max new connections / 5 secs"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1925
+#: src/muuli_wdr.cpp:1932
 msgid "Concurrent Kad source lookups"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1927
+#: src/muuli_wdr.cpp:1934
 msgid "Kad source re-search interval (minutes)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1929
+#: src/muuli_wdr.cpp:1936
 msgid "Source re-ask interval (minutes)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1933
+#: src/muuli_wdr.cpp:1940
 msgid "File Buffer Size: 240000 bytes"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1937
+#: src/muuli_wdr.cpp:1944
 msgid "Use MMAP: memory-mapped file access (lower memory use)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1938
+#: src/muuli_wdr.cpp:1945
 msgid "Maps part files into memory instead of buffering them on the heap, lowering the process memory footprint. May reduce download speed on some disks; best for memory-constrained or upload-heavy hosts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1940
+#: src/muuli_wdr.cpp:1947
 msgid "Upload Queue Size: 5000 clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1944
+#: src/muuli_wdr.cpp:1951
 msgid "Server connection refresh interval: Disable"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1948
+#: src/muuli_wdr.cpp:1955
 msgid "Disable computer's timed standby mode"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1967
+#: src/muuli_wdr.cpp:1974
 msgid "Skin to use: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1976
+#: src/muuli_wdr.cpp:1983
 msgid "Show \"Fast eD2k Links Handler\" in every window."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1979
+#: src/muuli_wdr.cpp:1986
 msgid "Show extended info on categories tabs"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1982
+#: src/muuli_wdr.cpp:1989
 msgid "Show application version on title"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1984
+#: src/muuli_wdr.cpp:1991
 msgid "Show transfer rates on title"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1986
+#: src/muuli_wdr.cpp:1993
 msgid "Before application name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1988
+#: src/muuli_wdr.cpp:1995
 msgid "After application name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1991
+#: src/muuli_wdr.cpp:1998
 msgid "Show overhead bandwidth"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1995
+#: src/muuli_wdr.cpp:2002
 msgid "Vertical toolbar orientation"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1997
+#: src/muuli_wdr.cpp:2004
 msgid "Live column sorting (auto-reorder rows as their values change)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2004
+#: src/muuli_wdr.cpp:2011
 msgid "Download Queue Files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2007
+#: src/muuli_wdr.cpp:2014
 msgid "Show progress percentage"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2013
+#: src/muuli_wdr.cpp:2020
 msgid "Show progress bar"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2016
+#: src/muuli_wdr.cpp:2023
 msgid "Flat"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2020
+#: src/muuli_wdr.cpp:2027
 msgid "Round"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2038
+#: src/muuli_wdr.cpp:2045
 msgid "External Connection Parameters"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2041
+#: src/muuli_wdr.cpp:2048
 msgid "Accept external connections"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2048 src/muuli_wdr.cpp:2107
+#: src/muuli_wdr.cpp:2055 src/muuli_wdr.cpp:2114
 msgid "IP of the listening interface:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2051
+#: src/muuli_wdr.cpp:2058
 msgid "Enter here a valid ip in the a.b.c.d format for the listening EC interface. An empty field or 0.0.0.0 will mean any interface."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2072 src/muuli_wdr.cpp:2156
+#: src/muuli_wdr.cpp:2079 src/muuli_wdr.cpp:2163
 msgid "TCP port:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2078
+#: src/muuli_wdr.cpp:2085
 msgid "Enable UPnP port forwarding on the EC port"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2082 src/muuli_wdr.cpp:3041
+#: src/muuli_wdr.cpp:2089 src/muuli_wdr.cpp:3048
 #: src/utils/wxCas/src/wxcasprefs.cpp:167
 msgid "Password"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2088
+#: src/muuli_wdr.cpp:2095
 msgid "aMule API server parameters"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2091
+#: src/muuli_wdr.cpp:2098
 msgid "Run amuleapi (REST API) on startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2096
+#: src/muuli_wdr.cpp:2103
 msgid "HTTP port:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2110
+#: src/muuli_wdr.cpp:2117
 msgid "The interface amuleapi's HTTP server listens on. 127.0.0.1 (default) accepts only local connections; use 0.0.0.0 or a specific IP to expose it to other hosts (set an admin password below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2113
+#: src/muuli_wdr.cpp:2120
 msgid "Admin password"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2118 src/muuli_wdr.cpp:2149
+#: src/muuli_wdr.cpp:2125 src/muuli_wdr.cpp:2156
 msgid "Low rights password"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2126
+#: src/muuli_wdr.cpp:2133
 msgid "Web server parameters"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2129
+#: src/muuli_wdr.cpp:2136
 msgid "Run webserver on startup (deprecated)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2135
+#: src/muuli_wdr.cpp:2142
 msgid "Web template"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2140
+#: src/muuli_wdr.cpp:2147
 msgid "Full rights password"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2144
+#: src/muuli_wdr.cpp:2151
 msgid "Enable Low rights User"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2163
+#: src/muuli_wdr.cpp:2170
 msgid "Enable UPnP port forwarding of the web server port"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2168
+#: src/muuli_wdr.cpp:2175
 msgid "Web server UPnP TCP port (Optional)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2176
+#: src/muuli_wdr.cpp:2183
 msgid "Page Refresh Time (in secs)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2183
+#: src/muuli_wdr.cpp:2190
 msgid "Enable Gzip compression"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2217
+#: src/muuli_wdr.cpp:2224
 msgid "Reset page to defaults"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2218
+#: src/muuli_wdr.cpp:2225
 msgid "Reset the settings on the current page to their default values."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2220 src/muuli_wdr.cpp:2306 src/ServerWnd.cpp:274
+#: src/muuli_wdr.cpp:2227 src/muuli_wdr.cpp:2313 src/ServerWnd.cpp:274
 #: src/ServerWnd.cpp:282
 msgid "OK"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2222
+#: src/muuli_wdr.cpp:2229
 msgid "Click here to apply any changes made to the preferences."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2225
+#: src/muuli_wdr.cpp:2232
 msgid "Reset any changes made to the preferences."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2254
+#: src/muuli_wdr.cpp:2261
 msgid "Comment :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2261
+#: src/muuli_wdr.cpp:2268
 msgid "Incoming Dir :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2270
+#: src/muuli_wdr.cpp:2277
 msgid "Change priority for new assigned files :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2274
+#: src/muuli_wdr.cpp:2281
 msgid "Don't change"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2286
+#: src/muuli_wdr.cpp:2293
 msgid "Select color for this Category (currently selected) :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2353 src/muuli_wdr.cpp:2372 src/muuli_wdr.cpp:2394
+#: src/muuli_wdr.cpp:2360 src/muuli_wdr.cpp:2379 src/muuli_wdr.cpp:2401
 msgid "Click this button to reset the log."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2413
+#: src/muuli_wdr.cpp:2420
 msgid "Click on this button to update the servers list from URL ..."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2417
+#: src/muuli_wdr.cpp:2424
 msgid "Server list"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2421
+#: src/muuli_wdr.cpp:2428
 msgid "Enter the url to a server.met file here and press the button to the left to update the list of known servers."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2426
+#: src/muuli_wdr.cpp:2433
 msgid "Add server manually: Name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2429
+#: src/muuli_wdr.cpp:2436
 msgid "Enter the name of the new server here"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2431 src/ServerWnd.cpp:206
+#: src/muuli_wdr.cpp:2438 src/ServerWnd.cpp:206
 msgid "IP:Port"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2434
+#: src/muuli_wdr.cpp:2441
 msgid "Enter the IP of the server here, using the x.x.x.x format."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2440
+#: src/muuli_wdr.cpp:2447
 msgid "Enter the port of the server here."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2443
+#: src/muuli_wdr.cpp:2450
 msgid "Add manually a server (fill fields to the left before) ..."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2472
+#: src/muuli_wdr.cpp:2479
 msgid "aMule Log"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2480
+#: src/muuli_wdr.cpp:2487
 msgid "Server Info"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2484
+#: src/muuli_wdr.cpp:2491
 msgid "ED2K Info"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2488
+#: src/muuli_wdr.cpp:2495
 msgid "Kad Info"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2516
+#: src/muuli_wdr.cpp:2523
 msgid "Click on this button to update the nodes list from URL ..."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2520
+#: src/muuli_wdr.cpp:2527
 msgid "Nodes (0)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2524
+#: src/muuli_wdr.cpp:2531
 msgid "Enter the url to a nodes.dat file here and press the button to the left to update the list of known nodes."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2527
+#: src/muuli_wdr.cpp:2534
 msgid "Nodes stats"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2569
+#: src/muuli_wdr.cpp:2576
 msgid "Bootstrap"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2572
+#: src/muuli_wdr.cpp:2579
 msgid "New node"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2577
+#: src/muuli_wdr.cpp:2584
 msgid "IP:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2597
+#: src/muuli_wdr.cpp:2604
 msgid "Port:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2610
+#: src/muuli_wdr.cpp:2617
 msgid "Bootstrap from known clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2612
+#: src/muuli_wdr.cpp:2619
 msgid "Disconnect Kad"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2646
+#: src/muuli_wdr.cpp:2653
 msgid "Use Secure User Identification"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2648
+#: src/muuli_wdr.cpp:2655
 msgid "It is recommended to enable this option. You will not receive credits if SUI is not enabled."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2650
+#: src/muuli_wdr.cpp:2657
 msgid "Protocol Obfuscation"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2653
+#: src/muuli_wdr.cpp:2660
 msgid "Support Protocol Obfuscation"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2655
+#: src/muuli_wdr.cpp:2662
 msgid "This option enabled Protocol Obfuscation, and makes aMule accept obfuscated connections from other clients."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2657
+#: src/muuli_wdr.cpp:2664
 msgid "Use obfuscation for outgoing connections"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2659
+#: src/muuli_wdr.cpp:2666
 msgid "This option makes aMule use Protocol Obfuscation when connecting other clients/servers."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2661
+#: src/muuli_wdr.cpp:2668
 msgid "Accept only obfuscated connections"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2662
+#: src/muuli_wdr.cpp:2669
 msgid "This option makes aMule only accept obfuscated connections. You will have less sources, but all your traffic will be obfuscated"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2667
+#: src/muuli_wdr.cpp:2674
 msgid "Everybody"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2669
+#: src/muuli_wdr.cpp:2676
 msgid "No one"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2671
+#: src/muuli_wdr.cpp:2678
 msgid "Who can see my shared files:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2672
+#: src/muuli_wdr.cpp:2679
 msgid "Select who can request to view a list of your shared files."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2674
+#: src/muuli_wdr.cpp:2681
 msgid "IP-Filtering"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2681
+#: src/muuli_wdr.cpp:2688
 msgid "Filter clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2683
+#: src/muuli_wdr.cpp:2690
 msgid "Enable filtering of the client IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2685
+#: src/muuli_wdr.cpp:2692
 msgid "Filter servers"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2687
+#: src/muuli_wdr.cpp:2694
 msgid "Enable filtering of the server IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2691
+#: src/muuli_wdr.cpp:2698
 msgid "Reload List"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2692
+#: src/muuli_wdr.cpp:2699
 msgid "Reload the list of IPs to filter from the file ~/.aMule/ipfilter.dat"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2698
+#: src/muuli_wdr.cpp:2705
 msgid "URL:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2702 src/muuli_wdr.cpp:2895
+#: src/muuli_wdr.cpp:2709 src/muuli_wdr.cpp:2902
 msgid "Update now"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2705
+#: src/muuli_wdr.cpp:2712
 msgid "Auto-update ipfilter at startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2709
+#: src/muuli_wdr.cpp:2716
 msgid "Filtering Level:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2715
+#: src/muuli_wdr.cpp:2722
 msgid "Always filter LAN IPs"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2718
+#: src/muuli_wdr.cpp:2725
 msgid "Paranoid handling of non-matching IPs"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2720
+#: src/muuli_wdr.cpp:2727
 msgid "Rejects a packet when its source IP differs from the IP the client claims (an anti-spoofing check). Disable only if it causes connection problems."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2722
+#: src/muuli_wdr.cpp:2729
 msgid "Use system-wide ipfilter.dat if available"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2723
+#: src/muuli_wdr.cpp:2730
 msgid "If there's no local ipfilter.dat found, allow usage of a system-wide ipfilter file."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2740
+#: src/muuli_wdr.cpp:2747
 msgid "Enable Online-Signature"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2742
+#: src/muuli_wdr.cpp:2749
 msgid "Enables the writing of the OS file, which can be used by external apps to create signatures and the like."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2746
+#: src/muuli_wdr.cpp:2753
 msgid "Update Frequency (Secs):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2749
+#: src/muuli_wdr.cpp:2756
 msgid "Change the frequency (in seconds) of Online Signature updates."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2757
+#: src/muuli_wdr.cpp:2764
 msgid "Save online signature file in: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:2763
+#: src/muuli_wdr.cpp:2770
 msgid "Click here to select the directory containing the the Online Signature files."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2796
+#: src/muuli_wdr.cpp:2803
 msgid "Show country flags for clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2797
+#: src/muuli_wdr.cpp:2804
 msgid "Render the country flag column in the transfers, queue and search views. Requires a valid MMDB GeoIP database (see below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2802
+#: src/muuli_wdr.cpp:2809
 msgid "Database"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2818
+#: src/muuli_wdr.cpp:2825
 msgid "Source:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2821
+#: src/muuli_wdr.cpp:2828
 msgid "DB-IP (free, no account)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2822
+#: src/muuli_wdr.cpp:2829
 msgid "MaxMind GeoLite2 (free, account required)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2823
+#: src/muuli_wdr.cpp:2830
 msgid "Custom URL"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2826
+#: src/muuli_wdr.cpp:2833
 msgid "Choose which provider supplies the GeoIP MMDB database. DB-IP is the default - no account required. MaxMind requires a free account + license key. Use Custom URL to point at any other MMDB host (e.g. a local mirror)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2843
+#: src/muuli_wdr.cpp:2850
 msgid ""
 "No configuration required.\n"
 "\n"
@@ -4724,11 +4737,11 @@ msgid ""
 "License: Creative Commons BY 4.0 - https://creativecommons.org/licenses/by/4.0/"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2856
+#: src/muuli_wdr.cpp:2863
 msgid "License key:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2862
+#: src/muuli_wdr.cpp:2869
 msgid ""
 "Sign up for a free MaxMind account, then generate a License Key:\n"
 "https://www.maxmind.com/en/geolite2/signup\n"
@@ -4738,222 +4751,222 @@ msgid ""
 "Requires attribution and account registration; refresh at least every 30 days."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2877
+#: src/muuli_wdr.cpp:2884
 msgid "Download URL:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2883
+#: src/muuli_wdr.cpp:2890
 msgid ""
 "Must point to an .mmdb file or a .gz / .tar.gz containing one.\n"
 "URL may include credentials (https://user:pass@host/...).\n"
 "License and attribution terms are set by the upstream URL - you are responsible."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2896
+#: src/muuli_wdr.cpp:2903
 msgid "Download the GeoIP database from the selected source."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2898
+#: src/muuli_wdr.cpp:2905
 msgid "Auto-update on startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2899
+#: src/muuli_wdr.cpp:2906
 msgid "Re-download the GeoIP database from the selected source every time aMule starts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2922
+#: src/muuli_wdr.cpp:2929
 msgid "Filter incoming messages (except current chat):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2924
+#: src/muuli_wdr.cpp:2931
 msgid "Filter all messages"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2926
+#: src/muuli_wdr.cpp:2933
 msgid "Filter messages from people not on your friend list"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2928
+#: src/muuli_wdr.cpp:2935
 msgid "Filter messages from unknown clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2930
+#: src/muuli_wdr.cpp:2937
 msgid "Filter messages containing (use ',' as separator):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2933 src/muuli_wdr.cpp:2944
+#: src/muuli_wdr.cpp:2940 src/muuli_wdr.cpp:2951
 msgid "add here the words amule should filter and block messages including it"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2935
+#: src/muuli_wdr.cpp:2942
 msgid "Show received messages in the log"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2938
+#: src/muuli_wdr.cpp:2945
 msgid "Comments"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2941
+#: src/muuli_wdr.cpp:2948
 msgid "Filter comments containing (use ',' as separator):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2966
+#: src/muuli_wdr.cpp:2973
 msgid "Enable Proxy"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2967
+#: src/muuli_wdr.cpp:2974
 msgid "Enable/disable proxy support"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2970
+#: src/muuli_wdr.cpp:2977
 msgid "Proxy type:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2981
+#: src/muuli_wdr.cpp:2988
 msgid "Proxy host:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2984
+#: src/muuli_wdr.cpp:2991
 msgid "The proxy host name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2986
+#: src/muuli_wdr.cpp:2993
 msgid "Proxy port:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2989
+#: src/muuli_wdr.cpp:2996
 msgid "The proxy port"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2991
+#: src/muuli_wdr.cpp:2998
 msgid "Enable authentication"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2992
+#: src/muuli_wdr.cpp:2999
 msgid "Enable/disable username/password authentication"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2995
+#: src/muuli_wdr.cpp:3002
 msgid "Username: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:2998
+#: src/muuli_wdr.cpp:3005
 msgid "The username to use to connect to the proxy"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3000
+#: src/muuli_wdr.cpp:3007
 msgid "Password:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3003
+#: src/muuli_wdr.cpp:3010
 msgid "The password to use to connect to the proxy"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3022
+#: src/muuli_wdr.cpp:3029
 msgid "Connect to:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3031
+#: src/muuli_wdr.cpp:3038
 msgid "Login to remote amule"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3036
+#: src/muuli_wdr.cpp:3043
 msgid "User name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3047
+#: src/muuli_wdr.cpp:3054
 msgid "Remember those settings"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3050
+#: src/muuli_wdr.cpp:3057
 msgid "Force ZLIB compression"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3074
+#: src/muuli_wdr.cpp:3081
 msgid "Enable Verbose Debug-Logging."
 msgstr ""
 
-#: src/muuli_wdr.cpp:3076
+#: src/muuli_wdr.cpp:3083
 msgid "Only to Logfile"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3078
+#: src/muuli_wdr.cpp:3085
 msgid "Message Categories:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3102 src/PartFileConvertDlg.cpp:160
+#: src/muuli_wdr.cpp:3109 src/PartFileConvertDlg.cpp:160
 msgid "Waiting..."
 msgstr ""
 
-#: src/muuli_wdr.cpp:3122
+#: src/muuli_wdr.cpp:3129
 msgid "Add imports"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3125
+#: src/muuli_wdr.cpp:3132
 msgid "Retry selected"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3127
+#: src/muuli_wdr.cpp:3134
 msgid "Remove selected"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3190
+#: src/muuli_wdr.cpp:3197
 msgid "Event Types"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3209
+#: src/muuli_wdr.cpp:3216
 msgid "Statistics and queued clients for selected file(s) : Session / All time"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3233
+#: src/muuli_wdr.cpp:3240
 msgid "Active Uploads"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3247
+#: src/muuli_wdr.cpp:3254
 msgid "Percent of total files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3299
+#: src/muuli_wdr.cpp:3306
 msgid "Show Clients for"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3301
+#: src/muuli_wdr.cpp:3308
 msgid "All files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3304
+#: src/muuli_wdr.cpp:3311
 msgid "Selected files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3307
+#: src/muuli_wdr.cpp:3314
 msgid "Active uploads only"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3314
+#: src/muuli_wdr.cpp:3321
 msgid "Reload:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3318
+#: src/muuli_wdr.cpp:3325
 msgid "Reload your shared files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3381
+#: src/muuli_wdr.cpp:3388
 msgid "Send"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3382
+#: src/muuli_wdr.cpp:3389
 msgid "Sends the specified message."
 msgstr ""
 
-#: src/muuli_wdr.cpp:3386
+#: src/muuli_wdr.cpp:3393
 msgid "Close this chat-session."
 msgstr ""
 
-#: src/muuli_wdr.cpp:3409
+#: src/muuli_wdr.cpp:3416
 msgid "Connect to any server and/or Kad"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3415 src/SharedFilesCtrl.cpp:142 src/Statistics.cpp:941
+#: src/muuli_wdr.cpp:3422 src/SharedFilesCtrl.cpp:142 src/Statistics.cpp:941
 msgid "Shared Files"
 msgstr ""
 
@@ -5311,187 +5324,187 @@ msgstr ""
 msgid "ERROR: Failed to open partfile '%s'"
 msgstr ""
 
-#: src/Preferences.cpp:673
+#: src/Preferences.cpp:674
 msgid "System default"
 msgstr ""
 
-#: src/Preferences.cpp:674
+#: src/Preferences.cpp:675
 msgid "Albanian"
 msgstr ""
 
-#: src/Preferences.cpp:675
+#: src/Preferences.cpp:676
 msgid "Arabic"
 msgstr ""
 
-#: src/Preferences.cpp:676
+#: src/Preferences.cpp:677
 msgid "Asturian"
 msgstr ""
 
-#: src/Preferences.cpp:677
+#: src/Preferences.cpp:678
 msgid "Basque"
 msgstr ""
 
-#: src/Preferences.cpp:678
+#: src/Preferences.cpp:679
 msgid "Bulgarian"
 msgstr ""
 
-#: src/Preferences.cpp:679
+#: src/Preferences.cpp:680
 msgid "Catalan"
 msgstr ""
 
-#: src/Preferences.cpp:680
+#: src/Preferences.cpp:681
 msgid "Chinese (Simplified)"
 msgstr ""
 
-#: src/Preferences.cpp:681
+#: src/Preferences.cpp:682
 msgid "Chinese (Traditional)"
 msgstr ""
 
-#: src/Preferences.cpp:682
+#: src/Preferences.cpp:683
 msgid "Croatian"
 msgstr ""
 
-#: src/Preferences.cpp:683
+#: src/Preferences.cpp:684
 msgid "Czech"
 msgstr ""
 
-#: src/Preferences.cpp:684
+#: src/Preferences.cpp:685
 msgid "Danish"
 msgstr ""
 
-#: src/Preferences.cpp:685
+#: src/Preferences.cpp:686
 msgid "Dutch"
 msgstr ""
 
-#: src/Preferences.cpp:686
+#: src/Preferences.cpp:687
 msgid "English (U.K.)"
 msgstr ""
 
-#: src/Preferences.cpp:687
+#: src/Preferences.cpp:688
 msgid "English (U.S.)"
 msgstr ""
 
-#: src/Preferences.cpp:688
+#: src/Preferences.cpp:689
 msgid "Estonian"
 msgstr ""
 
-#: src/Preferences.cpp:689
+#: src/Preferences.cpp:690
 msgid "Finnish"
 msgstr ""
 
-#: src/Preferences.cpp:690
+#: src/Preferences.cpp:691
 msgid "French"
 msgstr ""
 
-#: src/Preferences.cpp:691
+#: src/Preferences.cpp:692
 msgid "Galician"
 msgstr ""
 
-#: src/Preferences.cpp:692
+#: src/Preferences.cpp:693
 msgid "German"
 msgstr ""
 
-#: src/Preferences.cpp:693
+#: src/Preferences.cpp:694
 msgid "Greek"
 msgstr ""
 
-#: src/Preferences.cpp:694
+#: src/Preferences.cpp:695
 msgid "Hebrew"
 msgstr ""
 
-#: src/Preferences.cpp:695
+#: src/Preferences.cpp:696
 msgid "Hungarian"
 msgstr ""
 
-#: src/Preferences.cpp:696
+#: src/Preferences.cpp:697
 msgid "Italian"
 msgstr ""
 
-#: src/Preferences.cpp:697
+#: src/Preferences.cpp:698
 msgid "Japanese"
 msgstr ""
 
-#: src/Preferences.cpp:698
+#: src/Preferences.cpp:699
 msgid "Korean"
 msgstr ""
 
-#: src/Preferences.cpp:699
+#: src/Preferences.cpp:700
 msgid "Latvian"
 msgstr ""
 
-#: src/Preferences.cpp:700
+#: src/Preferences.cpp:701
 msgid "Lithuanian"
 msgstr ""
 
-#: src/Preferences.cpp:701
+#: src/Preferences.cpp:702
 msgid "Norwegian (Nynorsk)"
 msgstr ""
 
-#: src/Preferences.cpp:702
+#: src/Preferences.cpp:703
 msgid "Polish"
 msgstr ""
 
-#: src/Preferences.cpp:703
+#: src/Preferences.cpp:704
 msgid "Portuguese"
 msgstr ""
 
-#: src/Preferences.cpp:704
+#: src/Preferences.cpp:705
 msgid "Portuguese (Brazilian)"
 msgstr ""
 
-#: src/Preferences.cpp:705
+#: src/Preferences.cpp:706
 msgid "Romanian"
 msgstr ""
 
-#: src/Preferences.cpp:706
+#: src/Preferences.cpp:707
 msgid "Russian"
 msgstr ""
 
-#: src/Preferences.cpp:707
+#: src/Preferences.cpp:708
 msgid "Slovenian"
 msgstr ""
 
-#: src/Preferences.cpp:708
+#: src/Preferences.cpp:709
 msgid "Spanish"
 msgstr ""
 
-#: src/Preferences.cpp:709
+#: src/Preferences.cpp:710
 msgid "Swedish"
 msgstr ""
 
-#: src/Preferences.cpp:710
+#: src/Preferences.cpp:711
 msgid "Turkish"
 msgstr ""
 
-#: src/Preferences.cpp:711
+#: src/Preferences.cpp:712
 msgid "Ukrainian"
 msgstr ""
 
-#: src/Preferences.cpp:814
+#: src/Preferences.cpp:815
 msgid "Change Language"
 msgstr ""
 
-#: src/Preferences.cpp:878
+#: src/Preferences.cpp:879
 msgid "There are no translations installed for aMule"
 msgstr ""
 
-#: src/Preferences.cpp:879
+#: src/Preferences.cpp:880
 msgid "No languages available"
 msgstr ""
 
-#: src/Preferences.cpp:1010
+#: src/Preferences.cpp:1011
 msgid "no options available"
 msgstr ""
 
-#: src/Preferences.cpp:2179
+#: src/Preferences.cpp:2182
 msgid "Invalid category found, skipping"
 msgstr ""
 
-#: src/Preferences.cpp:2348
+#: src/Preferences.cpp:2351
 msgid "TCP port can't be higher than 65532 due to server UDP socket being TCP+3"
 msgstr ""
 
-#: src/Preferences.cpp:2349
+#: src/Preferences.cpp:2352
 #, c-format
 msgid "Default port will be used (%d)"
 msgstr ""
@@ -5961,23 +5974,27 @@ msgstr ""
 msgid "Shared folder"
 msgstr ""
 
-#: src/SearchDlg.cpp:425
+#: src/SearchDlg.cpp:280
+msgid "Clear search history"
+msgstr ""
+
+#: src/SearchDlg.cpp:584
 msgid "It's impossible to search when both eD2k and Kademlia are disabled."
 msgstr ""
 
-#: src/SearchDlg.cpp:426 src/SearchListCtrl.cpp:858
+#: src/SearchDlg.cpp:585 src/SearchListCtrl.cpp:858
 msgid "Search error"
 msgstr ""
 
-#: src/SearchDlg.cpp:768
+#: src/SearchDlg.cpp:929
 msgid "Min size must be smaller than max size. Max size ignored."
 msgstr ""
 
-#: src/SearchDlg.cpp:769 src/SearchDlg.cpp:851
+#: src/SearchDlg.cpp:930 src/SearchDlg.cpp:1012
 msgid "Search warning"
 msgstr ""
 
-#: src/SearchDlg.cpp:929 src/SearchListCtrl.cpp:735
+#: src/SearchDlg.cpp:1092 src/SearchListCtrl.cpp:735
 msgid "Main"
 msgstr ""
 

--- a/po/amule.pot
+++ b/po/amule.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-28 10:19+0200\n"
+"POT-Creation-Date: 2026-07-28 12:17+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -189,152 +189,152 @@ msgstr ""
 msgid "WARNING: You can't add yourself as a source for an eD2k link while having a lowid."
 msgstr ""
 
-#: src/amule.cpp:300
+#: src/amule.cpp:301
 msgid "Now, exiting main app..."
 msgstr ""
 
-#: src/amule.cpp:330
+#: src/amule.cpp:331
 #, c-format
 msgid "Terminating amuleweb instance with pid '%d' ... "
 msgstr ""
 
-#: src/amule.cpp:334
+#: src/amule.cpp:335
 #, c-format
 msgid "Killing amuleweb instance with pid '%d' ... "
 msgstr ""
 
-#: src/amule.cpp:336 src/amule.cpp:349 src/ClientRef.cpp:180
+#: src/amule.cpp:337 src/amule.cpp:350 src/ClientRef.cpp:180
 #: src/SearchDlg.cpp:1041 src/ServerListCtrl.cpp:98
 msgid "Failed"
 msgstr ""
 
-#: src/amule.cpp:343
+#: src/amule.cpp:344
 #, c-format
 msgid "Terminating amuleapi instance with pid '%d' ... "
 msgstr ""
 
-#: src/amule.cpp:347
+#: src/amule.cpp:348
 #, c-format
 msgid "Killing amuleapi instance with pid '%d' ... "
 msgstr ""
 
-#: src/amule.cpp:355
+#: src/amule.cpp:356
 msgid "aMule OnExit: Terminating core."
 msgstr ""
 
-#: src/amule.cpp:466
+#: src/amule.cpp:467
 msgid "aMule shutdown completed."
 msgstr ""
 
-#: src/amule.cpp:470
+#: src/amule.cpp:471
 msgid "Memory debug results for aMule exit:"
 msgstr ""
 
-#: src/amule.cpp:651
+#: src/amule.cpp:652
 #, c-format
 msgid "Binding aMule's peer-to-peer traffic to interface: %s (HTTP updates use the default route)"
 msgstr ""
 
-#: src/amule.cpp:655
+#: src/amule.cpp:656
 #, c-format
 msgid "Binding all network traffic to interface: %s"
 msgstr ""
 
-#: src/amule.cpp:659
+#: src/amule.cpp:660
 #, c-format
 msgid "WARNING: configured network interface '%s' was not found - traffic is NOT bound to it and may leave via the default route. Check the interface name in Preferences."
 msgstr ""
 
-#: src/amule.cpp:665
+#: src/amule.cpp:666
 #, c-format
 msgid "WARNING: binding to network interface '%s' requires elevated privileges and was NOT applied - traffic may leave via the default route. Grant the capability (e.g. 'sudo setcap cap_net_raw+ep' on the aMule binary) or run with sufficient privileges."
 msgstr ""
 
-#: src/amule.cpp:673
+#: src/amule.cpp:674
 #, c-format
 msgid "WARNING: could not bind to network interface '%s' - traffic may leave via the default route."
 msgstr ""
 
-#: src/amule.cpp:732
+#: src/amule.cpp:733
 msgid "Your locale has been changed to System Default due to a configuration change. Sorry."
 msgstr ""
 
-#: src/amule.cpp:734 src/amule.cpp:1581 src/CatDialog.cpp:128
+#: src/amule.cpp:735 src/amule.cpp:1589 src/CatDialog.cpp:128
 #: src/CatDialog.cpp:136 src/CatDialog.cpp:149 src/ServerList.cpp:366
 #: src/ServerListCtrl.cpp:152
 msgid "Info"
 msgstr ""
 
-#: src/amule.cpp:741
+#: src/amule.cpp:742
 msgid ""
 "\n"
 "EC configuration"
 msgstr ""
 
-#: src/amule.cpp:744
+#: src/amule.cpp:745
 msgid "Password set and external connections enabled."
 msgstr ""
 
-#: src/amule.cpp:754 src/KadDlg.cpp:176 src/KadDlg.cpp:185
-#: src/PrefsUnifiedDlg.cpp:1387 src/SharedFilesCtrl.cpp:476
+#: src/amule.cpp:755 src/KadDlg.cpp:176 src/KadDlg.cpp:185
+#: src/PrefsUnifiedDlg.cpp:1461 src/SharedFilesCtrl.cpp:476
 msgid "WARNING"
 msgstr ""
 
-#: src/amule.cpp:991
+#: src/amule.cpp:992
 msgid "Network bootstrap"
 msgstr ""
 
-#: src/amule.cpp:996
+#: src/amule.cpp:997
 msgid ""
 "aMule has detected missing network bootstrap files.\n"
 "Select which ones to download:"
 msgstr ""
 
-#: src/amule.cpp:1005 src/FirstRunWizard.cpp:411
+#: src/amule.cpp:1006 src/FirstRunWizard.cpp:411
 msgid "eD2k server list (server.met)"
 msgstr ""
 
-#: src/amule.cpp:1012 src/FirstRunWizard.cpp:416
+#: src/amule.cpp:1013 src/FirstRunWizard.cpp:416
 msgid "Kad bootstrap nodes (nodes.dat)"
 msgstr ""
 
-#: src/amule.cpp:1102
+#: src/amule.cpp:1103
 #, c-format
 msgid "web server running on pid %d"
 msgstr ""
 
-#: src/amule.cpp:1115
+#: src/amule.cpp:1116
 msgid "You requested to run web server on startup, but the amuleweb binary cannot be run. Please install the package containing aMule web server, or build aMule from source with -DBUILD_WEBSERVER=YES and install it."
 msgstr ""
 
-#: src/amule.cpp:1120 src/amule.cpp:1177 src/amule.cpp:1291 src/amule.cpp:1593
+#: src/amule.cpp:1121 src/amule.cpp:1185 src/amule.cpp:1299 src/amule.cpp:1601
 #: src/amule-remote-gui.cpp:603 src/amule-remote-gui.cpp:671
 #: src/amule-remote-gui.cpp:709 src/amule-remote-gui.cpp:1282
 #: src/amule-remote-gui.cpp:1345 src/amule-remote-gui.cpp:1372
-#: src/DownloadQueue.cpp:1481
+#: src/DownloadQueue.cpp:1481 src/PrefsUnifiedDlg.cpp:1247
 msgid "ERROR"
 msgstr ""
 
-#: src/amule.cpp:1166
+#: src/amule.cpp:1174
 #, c-format
 msgid "amuleapi running on pid %d"
 msgstr ""
 
-#: src/amule.cpp:1172
+#: src/amule.cpp:1180
 msgid "You requested to run amuleapi on startup, but the amuleapi binary cannot be run. Please install the package containing aMule's REST API server, or build aMule from source with -DBUILD_AMULEAPI=YES and install it."
 msgstr ""
 
-#: src/amule.cpp:1259
+#: src/amule.cpp:1267
 #, c-format
 msgid "Could not bind ports to the specified address: %s"
 msgstr ""
 
-#: src/amule.cpp:1283
+#: src/amule.cpp:1291
 #, c-format
 msgid "Port %u is not available. You will be LOWID\n"
 msgstr ""
 
-#: src/amule.cpp:1288
+#: src/amule.cpp:1296
 #, c-format
 msgid ""
 "Port %u is not available!\n"
@@ -344,184 +344,184 @@ msgid ""
 "Check your network to make sure the port is open for output and input."
 msgstr ""
 
-#: src/amule.cpp:1385
+#: src/amule.cpp:1393
 msgid "Failed to create OnlineSig File"
 msgstr ""
 
-#: src/amule.cpp:1393
+#: src/amule.cpp:1401
 msgid "Failed to create aMule OnlineSig File"
 msgstr ""
 
-#: src/amule.cpp:1556
+#: src/amule.cpp:1564
 msgid "The selected locale seems not to be installed on your box. (Note: I'll try to set it anyway)"
 msgstr ""
 
-#: src/amule.cpp:1566
+#: src/amule.cpp:1574
 #, c-format
 msgid "This is the first time you run aMule %s"
 msgstr ""
 
-#: src/amule.cpp:1569
+#: src/amule.cpp:1577
 msgid "This version is a testing version, updated daily, and\n"
 msgstr ""
 
-#: src/amule.cpp:1570
+#: src/amule.cpp:1578
 msgid "we give no warranty it won't break anything, burn your house,\n"
 msgstr ""
 
-#: src/amule.cpp:1571
+#: src/amule.cpp:1579
 msgid "or kill your dog. But it *should* be safe to use anyway.\n"
 msgstr ""
 
-#: src/amule.cpp:1576
+#: src/amule.cpp:1584
 msgid "More information, support and new releases can found at our homepage,\n"
 msgstr ""
 
-#: src/amule.cpp:1577
+#: src/amule.cpp:1585
 msgid "at https://amule-org.github.io, or in our IRC channel #aMule at irc.libera.chat.\n"
 msgstr ""
 
-#: src/amule.cpp:1579
+#: src/amule.cpp:1587
 msgid "Feel free to report any bugs to https://github.com/amule-org/amule/issues"
 msgstr ""
 
-#: src/amule.cpp:1591
+#: src/amule.cpp:1599
 msgid ""
 "The folder for Online Signature files you specified is INVALID!\n"
 " OnlineSignature will be DISABLED until you fix it on preferences."
 msgstr ""
 
-#: src/amule.cpp:1654
+#: src/amule.cpp:1662
 msgid "Server hostname notified"
 msgstr ""
 
-#: src/amule.cpp:2031
+#: src/amule.cpp:2039
 #, c-format
 msgid "Disk space preallocation for file '%s' failed: %s"
 msgstr ""
 
-#: src/amule.cpp:2160
+#: src/amule.cpp:2168
 msgid "ERROR: can't open logfile"
 msgstr ""
 
-#: src/amule.cpp:2164
+#: src/amule.cpp:2172
 msgid "WARNING: logfile is empty. Something is wrong."
 msgstr ""
 
-#: src/amule.cpp:2181
+#: src/amule.cpp:2189
 msgid "Log has been reset"
 msgstr ""
 
-#: src/amule.cpp:2205
+#: src/amule.cpp:2213
 #, c-format
 msgid "ServerMessage: %s"
 msgstr ""
 
-#: src/amule.cpp:2248 src/IP2Country.cpp:220 src/IPFilter.cpp:514
+#: src/amule.cpp:2256 src/IP2Country.cpp:220 src/IPFilter.cpp:514
 #: src/ServerList.cpp:875
 #, c-format
 msgid "Skipped download of %s, because requested file is not newer."
 msgstr ""
 
-#: src/amule.cpp:2251
+#: src/amule.cpp:2259
 msgid "Failed to download the nodes list."
 msgstr ""
 
-#: src/amule.cpp:2314
+#: src/amule.cpp:2322
 msgid "Failed to open the downloaded version check file"
 msgstr ""
 
-#: src/amule.cpp:2317 src/amule.cpp:2336
+#: src/amule.cpp:2325 src/amule.cpp:2344
 msgid "Corrupted version check file"
 msgstr ""
 
-#: src/amule.cpp:2359
+#: src/amule.cpp:2367
 msgid "You are using an outdated version of aMule!"
 msgstr ""
 
-#: src/amule.cpp:2361
+#: src/amule.cpp:2369
 #, c-format
 msgid "Your aMule version is %i.%i.%i and the latest version is %li.%li.%li"
 msgstr ""
 
-#: src/amule.cpp:2365
+#: src/amule.cpp:2373
 msgid "The latest version can always be found at https://github.com/amule-org/amule/releases/latest"
 msgstr ""
 
-#: src/amule.cpp:2368
+#: src/amule.cpp:2376
 #, c-format
 msgid "WARNING: Your aMuled version is outdated: %i.%i.%i < %li.%li.%li"
 msgstr ""
 
-#: src/amule.cpp:2374
+#: src/amule.cpp:2382
 msgid "Your copy of aMule is up to date."
 msgstr ""
 
-#: src/amule.cpp:2381
+#: src/amule.cpp:2389
 msgid "Failed to download the version check file"
 msgstr ""
 
-#: src/amule.cpp:2550 src/amule-remote-gui.cpp:1133
+#: src/amule.cpp:2558 src/amule-remote-gui.cpp:1133
 #, c-format
 msgid "Users: %s | Files: %s"
 msgstr ""
 
-#: src/amule.cpp:2551 src/amule-remote-gui.cpp:1134
+#: src/amule.cpp:2559 src/amule-remote-gui.cpp:1134
 #, c-format
 msgid "Users: E: %s K: %s | Files: E: %s K: %s"
 msgstr ""
 
-#: src/amule.cpp:2565 src/amule-remote-gui.cpp:1147
+#: src/amule.cpp:2573 src/amule-remote-gui.cpp:1147
 msgid "No networks selected"
 msgstr ""
 
-#: src/amule.cpp:2633 src/TextClient.cpp:903
+#: src/amule.cpp:2641 src/TextClient.cpp:903
 msgid "with LowID"
 msgstr ""
 
-#: src/amule.cpp:2633 src/TextClient.cpp:904
+#: src/amule.cpp:2641 src/TextClient.cpp:904
 msgid "with HighID"
 msgstr ""
 
-#: src/amule.cpp:2635
+#: src/amule.cpp:2643
 #, c-format
 msgid "Connected to %s %s"
 msgstr ""
 
-#: src/amule.cpp:2640
+#: src/amule.cpp:2648
 #, c-format
 msgid "Connecting to %s"
 msgstr ""
 
-#: src/amule.cpp:2642
+#: src/amule.cpp:2650
 msgid "Disconnected from eD2k"
 msgstr ""
 
-#: src/amule.cpp:2651
+#: src/amule.cpp:2659
 msgid "Kad started."
 msgstr ""
 
-#: src/amule.cpp:2653
+#: src/amule.cpp:2661
 msgid "Kad stopped."
 msgstr ""
 
-#: src/amule.cpp:2661
+#: src/amule.cpp:2669
 msgid "Connected to Kad (ok)"
 msgstr ""
 
-#: src/amule.cpp:2663
+#: src/amule.cpp:2671
 msgid "Connected to Kad (firewalled)"
 msgstr ""
 
-#: src/amule.cpp:2667
+#: src/amule.cpp:2675
 msgid "Disconnected from Kad"
 msgstr ""
 
-#: src/amule.cpp:2699
+#: src/amule.cpp:2707
 msgid "Kad network cannot be used if UDP port is disabled on preferences, not starting."
 msgstr ""
 
-#: src/amule.cpp:2703
+#: src/amule.cpp:2711
 msgid "Kad network disabled on preferences, not connecting."
 msgstr ""
 
@@ -565,36 +565,36 @@ msgid "FATAL ERROR: Failed to create Timer"
 msgstr ""
 
 #: src/amuleDlg.cpp:361 src/amuleDlg.cpp:1787 src/amuleDlg.cpp:2033
-#: src/muuli_wdr.cpp:1492 src/muuli_wdr.cpp:3418
+#: src/muuli_wdr.cpp:1492 src/muuli_wdr.cpp:3449
 msgid "Networks"
 msgstr ""
 
-#: src/amuleDlg.cpp:362 src/amuleDlg.cpp:1793 src/muuli_wdr.cpp:3419
+#: src/amuleDlg.cpp:362 src/amuleDlg.cpp:1793 src/muuli_wdr.cpp:3450
 msgid "Searches"
 msgstr ""
 
 #: src/amuleDlg.cpp:363 src/amuleDlg.cpp:1799 src/DownloadListCtrl.cpp:740
-#: src/muuli_wdr.cpp:392 src/muuli_wdr.cpp:1585 src/muuli_wdr.cpp:3420
+#: src/muuli_wdr.cpp:392 src/muuli_wdr.cpp:1585 src/muuli_wdr.cpp:3451
 #: src/Statistics.cpp:829
 msgid "Downloads"
 msgstr ""
 
-#: src/amuleDlg.cpp:364 src/amuleDlg.cpp:1805 src/muuli_wdr.cpp:3294
+#: src/amuleDlg.cpp:364 src/amuleDlg.cpp:1805 src/muuli_wdr.cpp:3325
 msgid "Shared files"
 msgstr ""
 
-#: src/amuleDlg.cpp:365 src/amuleDlg.cpp:1811 src/muuli_wdr.cpp:2926
-#: src/muuli_wdr.cpp:3376 src/muuli_wdr.cpp:3423
+#: src/amuleDlg.cpp:365 src/amuleDlg.cpp:1811 src/muuli_wdr.cpp:2957
+#: src/muuli_wdr.cpp:3407 src/muuli_wdr.cpp:3454
 msgid "Messages"
 msgstr ""
 
-#: src/amuleDlg.cpp:366 src/amuleDlg.cpp:1817 src/muuli_wdr.cpp:3424
-#: src/PrefsUnifiedDlg.cpp:312 src/Statistics.cpp:779 src/Statistics.cpp:1235
+#: src/amuleDlg.cpp:366 src/amuleDlg.cpp:1817 src/muuli_wdr.cpp:3455
+#: src/PrefsUnifiedDlg.cpp:314 src/Statistics.cpp:779 src/Statistics.cpp:1235
 msgid "Statistics"
 msgstr ""
 
-#: src/amuleDlg.cpp:368 src/amuleDlg.cpp:1824 src/muuli_wdr.cpp:3426
-#: src/PrefsUnifiedDlg.cpp:328 src/utils/wxCas/src/wxcasprefs.cpp:39
+#: src/amuleDlg.cpp:368 src/amuleDlg.cpp:1824 src/muuli_wdr.cpp:3457
+#: src/PrefsUnifiedDlg.cpp:330 src/utils/wxCas/src/wxcasprefs.cpp:39
 msgid "Preferences"
 msgstr ""
 
@@ -651,8 +651,8 @@ msgstr ""
 #: src/amuleDlg.cpp:1029 src/DownloadListCtrl.cpp:505
 #: src/DownloadListCtrl.cpp:749 src/FriendListCtrl.cpp:180
 #: src/muuli_wdr.cpp:731 src/muuli_wdr.cpp:782 src/muuli_wdr.cpp:846
-#: src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2231 src/muuli_wdr.cpp:2316
-#: src/muuli_wdr.cpp:3064 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
+#: src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2262 src/muuli_wdr.cpp:2347
+#: src/muuli_wdr.cpp:3095 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
 #: src/ServerListCtrl.cpp:606 src/TransferWnd.cpp:378
 #: src/utils/wxCas/src/wxcasprefs.cpp:235
 msgid "Cancel"
@@ -663,7 +663,7 @@ msgid "Stop the current connection attempts"
 msgstr ""
 
 #: src/amuleDlg.cpp:1035 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976
-#: src/muuli_wdr.cpp:2454
+#: src/muuli_wdr.cpp:2485
 msgid "Disconnect"
 msgstr ""
 
@@ -672,7 +672,7 @@ msgid "Disconnect from the currently connected networks"
 msgstr ""
 
 #: src/amuleDlg.cpp:1041 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979
-#: src/muuli_wdr.cpp:2609 src/muuli_wdr.cpp:3061 src/muuli_wdr.cpp:3416
+#: src/muuli_wdr.cpp:2640 src/muuli_wdr.cpp:3092 src/muuli_wdr.cpp:3447
 msgid "Connect"
 msgstr ""
 
@@ -726,7 +726,7 @@ msgstr ""
 msgid "Launch Command: "
 msgstr ""
 
-#: src/amuleDlg.cpp:1632 src/muuli_wdr.cpp:1978 src/Preferences.cpp:952
+#: src/amuleDlg.cpp:1632 src/muuli_wdr.cpp:1982 src/Preferences.cpp:979
 msgid "- default -"
 msgstr ""
 
@@ -740,48 +740,48 @@ msgstr ""
 msgid "WARNING: Unable to open skin file '%s' for read"
 msgstr ""
 
-#: src/amuleDlg.cpp:1791 src/muuli_wdr.cpp:3418
+#: src/amuleDlg.cpp:1791 src/muuli_wdr.cpp:3449
 msgid "Networks Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1797 src/muuli_wdr.cpp:3419
+#: src/amuleDlg.cpp:1797 src/muuli_wdr.cpp:3450
 msgid "Searches Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1803 src/muuli_wdr.cpp:3420
+#: src/amuleDlg.cpp:1803 src/muuli_wdr.cpp:3451
 msgid "Downloads Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1809 src/muuli_wdr.cpp:3422
+#: src/amuleDlg.cpp:1809 src/muuli_wdr.cpp:3453
 msgid "Shared Files Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1815 src/muuli_wdr.cpp:3423
+#: src/amuleDlg.cpp:1815 src/muuli_wdr.cpp:3454
 msgid "Messages Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1821 src/muuli_wdr.cpp:3424
+#: src/amuleDlg.cpp:1821 src/muuli_wdr.cpp:3455
 msgid "Statistics Graph Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1828 src/muuli_wdr.cpp:3426
+#: src/amuleDlg.cpp:1828 src/muuli_wdr.cpp:3457
 msgid "Preferences Settings Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1831 src/muuli_wdr.cpp:3427
+#: src/amuleDlg.cpp:1831 src/muuli_wdr.cpp:3458
 msgid "Import"
 msgstr ""
 
-#: src/amuleDlg.cpp:1835 src/muuli_wdr.cpp:3427
+#: src/amuleDlg.cpp:1835 src/muuli_wdr.cpp:3458
 msgid "The partfile importer tool"
 msgstr ""
 
-#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3428
+#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3459
 #: src/utils/aLinkCreator/src/alcframe.cpp:262
 msgid "About"
 msgstr ""
 
-#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3428
+#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3459
 msgid "About/Help"
 msgstr ""
 
@@ -918,7 +918,7 @@ msgstr ""
 msgid "The core rejected these shared folders:%s"
 msgstr ""
 
-#: src/amule-remote-gui.cpp:1336 src/ExternalConn.cpp:2345
+#: src/amule-remote-gui.cpp:1336 src/ExternalConn.cpp:2346
 msgid "Invalid link or already on list."
 msgstr ""
 
@@ -934,7 +934,7 @@ msgstr ""
 #: src/ClientDetailDialog.cpp:123 src/DataToText.cpp:61 src/DataToText.cpp:86
 #: src/DataToText.cpp:101 src/DataToText.cpp:136 src/DataToText.cpp:165
 #: src/DownloadListCtrl.cpp:1172 src/DownloadListCtrl.cpp:1185
-#: src/DownloadListCtrl.cpp:1196 src/ExternalConn.cpp:608
+#: src/DownloadListCtrl.cpp:1196 src/ExternalConn.cpp:609
 #: src/FileDetailDialog.cpp:203 src/FileDetailDialog.cpp:235
 #: src/FileDetailDialog.cpp:242 src/GenericClientListCtrl.cpp:1171
 #: src/GenericClientListCtrl.cpp:1182 src/GenericClientListCtrl.cpp:1192
@@ -1320,19 +1320,19 @@ msgstr ""
 msgid "Very low"
 msgstr ""
 
-#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:743 src/muuli_wdr.cpp:2282
+#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:743 src/muuli_wdr.cpp:2313
 #: src/ServerListCtrl.cpp:263 src/ServerListCtrl.cpp:456
 #: src/SharedFilesCtrl.cpp:145
 msgid "Low"
 msgstr ""
 
-#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:744 src/muuli_wdr.cpp:2283
+#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:744 src/muuli_wdr.cpp:2314
 #: src/ServerListCtrl.cpp:266 src/ServerListCtrl.cpp:457
 #: src/SharedFilesCtrl.cpp:146
 msgid "Normal"
 msgstr ""
 
-#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:745 src/muuli_wdr.cpp:2284
+#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:745 src/muuli_wdr.cpp:2315
 #: src/ServerListCtrl.cpp:269 src/ServerListCtrl.cpp:458
 #: src/SharedFilesCtrl.cpp:147
 msgid "High"
@@ -1424,7 +1424,7 @@ msgstr ""
 msgid "Remote Server"
 msgstr ""
 
-#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3181
+#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3212
 #: src/SearchDlg.cpp:119 src/TextClient.cpp:911
 msgid "Kad"
 msgstr ""
@@ -1495,7 +1495,7 @@ msgstr ""
 msgid "Size"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3248
+#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3279
 msgid "Transferred"
 msgstr ""
 
@@ -1551,7 +1551,7 @@ msgid ""
 "\n"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:746 src/muuli_wdr.cpp:2285
+#: src/DownloadListCtrl.cpp:746 src/muuli_wdr.cpp:2316
 #: src/SharedFilesCtrl.cpp:150
 msgid "Auto"
 msgstr ""
@@ -1589,7 +1589,7 @@ msgid "Extended Options"
 msgstr ""
 
 #: src/DownloadListCtrl.cpp:770 src/DownloadListCtrl.cpp:822
-#: src/muuli_wdr.cpp:1796
+#: src/muuli_wdr.cpp:1800
 msgid "Preview"
 msgstr ""
 
@@ -1762,225 +1762,230 @@ msgstr[1] ""
 msgid "Invalid eD2k link! ERROR: %s"
 msgstr ""
 
-#: src/ExternalConn.cpp:379
+#: src/ExternalConn.cpp:380
 msgid "Client sent packet after authentication failed."
 msgstr ""
 
-#: src/ExternalConn.cpp:396
+#: src/ExternalConn.cpp:397
 msgid "External connection closed."
 msgstr ""
 
-#: src/ExternalConn.cpp:473
+#: src/ExternalConn.cpp:474
 msgid "External connections disabled due to empty password!"
 msgstr ""
 
-#: src/ExternalConn.cpp:494
+#: src/ExternalConn.cpp:495
 msgid "External connections disabled in config file"
 msgstr ""
 
-#: src/ExternalConn.cpp:575
+#: src/ExternalConn.cpp:576
 msgid "New external connection accepted"
 msgstr ""
 
-#: src/ExternalConn.cpp:578
+#: src/ExternalConn.cpp:579
 msgid "ERROR: couldn't accept a new external connection"
 msgstr ""
 
-#: src/ExternalConn.cpp:595
+#: src/ExternalConn.cpp:596
 msgid "External connection refused due to empty password in preferences!"
 msgstr ""
 
-#: src/ExternalConn.cpp:607
+#: src/ExternalConn.cpp:608
 #, c-format
 msgid "Connecting client: %s %s"
 msgstr ""
 
-#: src/ExternalConn.cpp:609
+#: src/ExternalConn.cpp:610
 msgid "Unknown version"
 msgstr ""
 
-#: src/ExternalConn.cpp:622
+#: src/ExternalConn.cpp:623
 msgid "Incorrect EC version ID, there might be binary incompatibility. Use core and remote from same snapshot."
 msgstr ""
 
-#: src/ExternalConn.cpp:630
+#: src/ExternalConn.cpp:631
 msgid "You cannot connect to a release version from an arbitrary development snapshot! *sigh* possible crash prevented"
 msgstr ""
 
-#: src/ExternalConn.cpp:713
+#: src/ExternalConn.cpp:714
 msgid "Invalid protocol version."
 msgstr ""
 
-#: src/ExternalConn.cpp:719
+#: src/ExternalConn.cpp:720
 msgid "Missing protocol version tag."
 msgstr ""
 
-#: src/ExternalConn.cpp:727
+#: src/ExternalConn.cpp:728
 msgid "Authentication failed: invalid hash specified as EC password."
 msgstr ""
 
-#: src/ExternalConn.cpp:775
+#: src/ExternalConn.cpp:776
 msgid "Authentication failed: wrong password."
 msgstr ""
 
-#: src/ExternalConn.cpp:777
+#: src/ExternalConn.cpp:778
 msgid "Authentication failed: missing password."
 msgstr ""
 
-#: src/ExternalConn.cpp:788
+#: src/ExternalConn.cpp:789
 msgid "Invalid request, please authenticate first."
 msgstr ""
 
-#: src/ExternalConn.cpp:793
+#: src/ExternalConn.cpp:794
 msgid "Access granted."
 msgstr ""
 
-#: src/ExternalConn.cpp:801
+#: src/ExternalConn.cpp:802
 #, c-format
 msgid "Sent error message \"%s\" to client."
 msgstr ""
 
-#: src/ExternalConn.cpp:806
+#: src/ExternalConn.cpp:807
 #, c-format
 msgid "Unauthorized access attempt from %s. Connection closed."
 msgstr ""
 
-#: src/ExternalConn.cpp:1419
+#: src/ExternalConn.cpp:1420
 #, c-format
 msgid "Remote PartFile command failed: FileHash not found: %s"
 msgstr ""
 
-#: src/ExternalConn.cpp:1423
+#: src/ExternalConn.cpp:1424
 #, c-format
 msgid "FileHash not found: %s"
 msgstr ""
 
-#: src/ExternalConn.cpp:1470 src/ExternalConn.cpp:1558
-#: src/ExternalConn.cpp:1679
+#: src/ExternalConn.cpp:1471 src/ExternalConn.cpp:1559
+#: src/ExternalConn.cpp:1680
 msgid "OOPS! OpCode processing error!"
 msgstr ""
 
-#: src/ExternalConn.cpp:1501
+#: src/ExternalConn.cpp:1502
 msgid "Server not added"
 msgstr ""
 
-#: src/ExternalConn.cpp:1520
+#: src/ExternalConn.cpp:1521
 #, c-format
 msgid "server not found: %s"
 msgstr ""
 
-#: src/ExternalConn.cpp:1537
+#: src/ExternalConn.cpp:1538
 msgid "need to define server to be removed"
 msgstr ""
 
-#: src/ExternalConn.cpp:1552
+#: src/ExternalConn.cpp:1553
 msgid "eD2k is disabled in preferences."
 msgstr ""
 
-#: src/ExternalConn.cpp:1657
+#: src/ExternalConn.cpp:1658
 msgid "Friend not found."
 msgstr ""
 
-#: src/ExternalConn.cpp:1667
+#: src/ExternalConn.cpp:1668
 msgid "Client not found."
 msgstr ""
 
-#: src/ExternalConn.cpp:1673
+#: src/ExternalConn.cpp:1674
 msgid "EC_TAG_FRIEND_SHARED requires EC_TAG_FRIEND or EC_TAG_CLIENT."
 msgstr ""
 
-#: src/ExternalConn.cpp:1991
+#: src/ExternalConn.cpp:1992
 msgid "WebSearch from remote interface makes no sense."
 msgstr ""
 
-#: src/ExternalConn.cpp:2026
+#: src/ExternalConn.cpp:2027
 msgid "Search in progress. Refetch results in a moment!"
 msgstr ""
 
-#: src/ExternalConn.cpp:2265
+#: src/ExternalConn.cpp:2266
 msgid "No points for graph."
 msgstr ""
 
-#: src/ExternalConn.cpp:2275
+#: src/ExternalConn.cpp:2276
 msgid "Your client is not configured for this detail level."
 msgstr ""
 
-#: src/ExternalConn.cpp:2302
+#: src/ExternalConn.cpp:2303
 msgid "External Connection: shutdown requested"
 msgstr ""
 
-#: src/ExternalConn.cpp:2314
+#: src/ExternalConn.cpp:2315
 msgid "Already shutting down."
 msgstr ""
 
-#: src/ExternalConn.cpp:2332
+#: src/ExternalConn.cpp:2333
 #, c-format
 msgid "ExternalConn: adding link '%s'."
 msgstr ""
 
-#: src/ExternalConn.cpp:2350
+#: src/ExternalConn.cpp:2351
 #, c-format
 msgid "%d of %d links failed (invalid or already on list)."
 msgstr ""
 
-#: src/ExternalConn.cpp:2373
+#: src/ExternalConn.cpp:2374
 msgid "Version check throttled; try again shortly."
 msgstr ""
 
-#: src/ExternalConn.cpp:2378
+#: src/ExternalConn.cpp:2379
 msgid "Version check is not available on this daemon."
 msgstr ""
 
-#: src/ExternalConn.cpp:2508
+#: src/ExternalConn.cpp:2509
 msgid "File not found."
 msgstr ""
 
-#: src/ExternalConn.cpp:2513
+#: src/ExternalConn.cpp:2514
 msgid "Invalid file name."
 msgstr ""
 
-#: src/ExternalConn.cpp:2521
+#: src/ExternalConn.cpp:2522
 msgid "Unable to rename file."
 msgstr ""
 
-#: src/ExternalConn.cpp:2992 src/ExternalConn.cpp:3020
+#: src/ExternalConn.cpp:2839
+#, c-format
+msgid "Could not save the amuleapi password: %s"
+msgstr ""
+
+#: src/ExternalConn.cpp:3004 src/ExternalConn.cpp:3032
 msgid "Kad is disabled in preferences."
 msgstr ""
 
-#: src/ExternalConn.cpp:3033
+#: src/ExternalConn.cpp:3045
 msgid "Already connected to eD2k."
 msgstr ""
 
-#: src/ExternalConn.cpp:3036
+#: src/ExternalConn.cpp:3048
 msgid "Connecting to eD2k..."
 msgstr ""
 
-#: src/ExternalConn.cpp:3045
+#: src/ExternalConn.cpp:3057
 msgid "Already connected to Kad."
 msgstr ""
 
-#: src/ExternalConn.cpp:3048
+#: src/ExternalConn.cpp:3060
 msgid "Connecting to Kad..."
 msgstr ""
 
-#: src/ExternalConn.cpp:3055
+#: src/ExternalConn.cpp:3067
 msgid "All networks are disabled."
 msgstr ""
 
-#: src/ExternalConn.cpp:3064
+#: src/ExternalConn.cpp:3076
 msgid "Disconnected from eD2k."
 msgstr ""
 
-#: src/ExternalConn.cpp:3069
+#: src/ExternalConn.cpp:3081
 msgid "Disconnected from Kad."
 msgstr ""
 
-#: src/ExternalConn.cpp:3078
+#: src/ExternalConn.cpp:3090
 #, c-format
 msgid "External Connection: invalid opcode received: %#x"
 msgstr ""
 
-#: src/ExternalConn.cpp:3083
+#: src/ExternalConn.cpp:3095
 msgid "Invalid opcode (wrong protocol version?)"
 msgstr ""
 
@@ -2350,23 +2355,23 @@ msgid ""
 "want downloads on a different (e.g. larger) disk."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:549 src/FirstRunWizard.cpp:611 src/muuli_wdr.cpp:1708
+#: src/FirstRunWizard.cpp:549 src/FirstRunWizard.cpp:611 src/muuli_wdr.cpp:1712
 msgid "Destination folder for downloads"
 msgstr ""
 
 #: src/FirstRunWizard.cpp:553 src/FirstRunWizard.cpp:569 src/muuli_wdr.cpp:1349
-#: src/muuli_wdr.cpp:1366 src/muuli_wdr.cpp:1683 src/muuli_wdr.cpp:1714
-#: src/muuli_wdr.cpp:1726 src/muuli_wdr.cpp:2769
+#: src/muuli_wdr.cpp:1366 src/muuli_wdr.cpp:1687 src/muuli_wdr.cpp:1718
+#: src/muuli_wdr.cpp:1730 src/muuli_wdr.cpp:2800
 #: src/utils/aLinkCreator/src/alcframe.cpp:135
 #: src/utils/wxCas/src/wxcasprefs.cpp:52 src/utils/wxCas/src/wxcasprefs.cpp:118
 msgid "Browse"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:559 src/muuli_wdr.cpp:1719
+#: src/FirstRunWizard.cpp:559 src/muuli_wdr.cpp:1723
 msgid "(All files in this folder are shared with other peers)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:565 src/FirstRunWizard.cpp:624 src/muuli_wdr.cpp:1721
+#: src/FirstRunWizard.cpp:565 src/FirstRunWizard.cpp:624 src/muuli_wdr.cpp:1725
 msgid "Folder for temporary download files"
 msgstr ""
 
@@ -2397,7 +2402,7 @@ msgstr ""
 msgid "CRITICAL - no client on StartChatSession"
 msgstr ""
 
-#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2675 src/muuli_wdr.cpp:3352
+#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2706 src/muuli_wdr.cpp:3383
 msgid "Friends"
 msgstr ""
 
@@ -2503,8 +2508,8 @@ msgstr ""
 msgid "No"
 msgstr ""
 
-#: src/GenericClientListCtrl.cpp:1216 src/PrefsUnifiedDlg.cpp:2818
-#: src/PrefsUnifiedDlg.cpp:2868 src/ServerListCtrl.cpp:276
+#: src/GenericClientListCtrl.cpp:1216 src/PrefsUnifiedDlg.cpp:2898
+#: src/PrefsUnifiedDlg.cpp:2948 src/ServerListCtrl.cpp:276
 msgid "Yes"
 msgstr ""
 
@@ -2671,10 +2676,10 @@ msgstr ""
 msgid "Please fill all fields required"
 msgstr ""
 
-#: src/KadDlg.cpp:192 src/PartFile.cpp:1031 src/PrefsUnifiedDlg.cpp:1162
-#: src/PrefsUnifiedDlg.cpp:1331 src/PrefsUnifiedDlg.cpp:1589
-#: src/PrefsUnifiedDlg.cpp:1599 src/PrefsUnifiedDlg.cpp:1616
-#: src/PrefsUnifiedDlg.cpp:1658
+#: src/KadDlg.cpp:192 src/PartFile.cpp:1031 src/PrefsUnifiedDlg.cpp:1134
+#: src/PrefsUnifiedDlg.cpp:1204 src/PrefsUnifiedDlg.cpp:1405
+#: src/PrefsUnifiedDlg.cpp:1663 src/PrefsUnifiedDlg.cpp:1673
+#: src/PrefsUnifiedDlg.cpp:1690 src/PrefsUnifiedDlg.cpp:1738
 msgid "Message"
 msgstr ""
 
@@ -2775,7 +2780,7 @@ msgstr ""
 msgid "Uploaded"
 msgstr ""
 
-#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3232
+#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3263
 msgid "Requested"
 msgstr ""
 
@@ -2898,7 +2903,7 @@ msgid "WARNING: "
 msgstr ""
 
 #: src/MuleNotebook.cpp:179 src/muuli_wdr.cpp:817 src/muuli_wdr.cpp:1229
-#: src/muuli_wdr.cpp:3136 src/muuli_wdr.cpp:3392
+#: src/muuli_wdr.cpp:3167 src/muuli_wdr.cpp:3423
 msgid "Close"
 msgstr ""
 
@@ -2916,7 +2921,7 @@ msgid "Paste"
 msgstr ""
 
 #: src/MuleTextCtrl.cpp:89 src/muuli_wdr.cpp:358 src/muuli_wdr.cpp:757
-#: src/muuli_wdr.cpp:2359 src/muuli_wdr.cpp:2378 src/muuli_wdr.cpp:2400
+#: src/muuli_wdr.cpp:2390 src/muuli_wdr.cpp:2409 src/muuli_wdr.cpp:2431
 #: src/utils/aLinkCreator/src/alcframe.cpp:142
 msgid "Clear"
 msgstr ""
@@ -3008,7 +3013,7 @@ msgstr ""
 
 #: src/MuleTrayIcon.cpp:579 src/MuleTrayIcon.cpp:945 src/MuleTrayIcon.cpp:965
 #: src/muuli_wdr.cpp:1398 src/muuli_wdr.cpp:1406 src/muuli_wdr.cpp:1413
-#: src/muuli_wdr.cpp:1842 src/muuli_wdr.cpp:1848 src/OtherFunctions.cpp:91
+#: src/muuli_wdr.cpp:1846 src/muuli_wdr.cpp:1852 src/OtherFunctions.cpp:91
 #: src/StatisticsDlg.cpp:93 src/StatisticsDlg.cpp:95
 msgid "kB/s"
 msgstr ""
@@ -3248,7 +3253,7 @@ msgstr ""
 msgid "KB"
 msgstr ""
 
-#: src/muuli_wdr.cpp:274 src/muuli_wdr.cpp:293 src/muuli_wdr.cpp:1627
+#: src/muuli_wdr.cpp:274 src/muuli_wdr.cpp:293 src/muuli_wdr.cpp:1631
 #: src/OtherFunctions.cpp:64
 msgid "MB"
 msgstr ""
@@ -3265,7 +3270,7 @@ msgstr ""
 msgid "Availability"
 msgstr ""
 
-#: src/muuli_wdr.cpp:312 src/muuli_wdr.cpp:398 src/muuli_wdr.cpp:3297
+#: src/muuli_wdr.cpp:312 src/muuli_wdr.cpp:398 src/muuli_wdr.cpp:3328
 msgid "Filter:"
 msgstr ""
 
@@ -3328,12 +3333,12 @@ msgstr ""
 #: src/muuli_wdr.cpp:1160 src/muuli_wdr.cpp:1167 src/muuli_wdr.cpp:1172
 #: src/muuli_wdr.cpp:1179 src/muuli_wdr.cpp:1184 src/muuli_wdr.cpp:1191
 #: src/muuli_wdr.cpp:1205 src/muuli_wdr.cpp:1212 src/muuli_wdr.cpp:1217
-#: src/muuli_wdr.cpp:1224 src/muuli_wdr.cpp:3234 src/muuli_wdr.cpp:3242
-#: src/muuli_wdr.cpp:3250
+#: src/muuli_wdr.cpp:1224 src/muuli_wdr.cpp:3265 src/muuli_wdr.cpp:3273
+#: src/muuli_wdr.cpp:3281
 msgid "N/A"
 msgstr ""
 
-#: src/muuli_wdr.cpp:508 src/muuli_wdr.cpp:1065 src/PrefsUnifiedDlg.cpp:297
+#: src/muuli_wdr.cpp:508 src/muuli_wdr.cpp:1065 src/PrefsUnifiedDlg.cpp:299
 msgid "General"
 msgstr ""
 
@@ -3469,7 +3474,7 @@ msgstr ""
 msgid "Album :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:685 src/muuli_wdr.cpp:2254
+#: src/muuli_wdr.cpp:685 src/muuli_wdr.cpp:2285
 msgid "Title :"
 msgstr ""
 
@@ -3575,7 +3580,7 @@ msgstr ""
 msgid "Userhash :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:895 src/muuli_wdr.cpp:1748 src/muuli_wdr.cpp:2449
+#: src/muuli_wdr.cpp:895 src/muuli_wdr.cpp:1752 src/muuli_wdr.cpp:2480
 #: src/utils/aLinkCreator/src/alcframe.cpp:137
 msgid "Add"
 msgstr ""
@@ -3584,15 +3589,15 @@ msgstr ""
 msgid "Download-Speed"
 msgstr ""
 
-#: src/muuli_wdr.cpp:954 src/muuli_wdr.cpp:989 src/muuli_wdr.cpp:2553
+#: src/muuli_wdr.cpp:954 src/muuli_wdr.cpp:989 src/muuli_wdr.cpp:2584
 msgid "Current"
 msgstr ""
 
-#: src/muuli_wdr.cpp:962 src/muuli_wdr.cpp:997 src/muuli_wdr.cpp:2561
+#: src/muuli_wdr.cpp:962 src/muuli_wdr.cpp:997 src/muuli_wdr.cpp:2592
 msgid "Running average"
 msgstr ""
 
-#: src/muuli_wdr.cpp:970 src/muuli_wdr.cpp:1005 src/muuli_wdr.cpp:2569
+#: src/muuli_wdr.cpp:970 src/muuli_wdr.cpp:1005 src/muuli_wdr.cpp:2600
 msgid "Session average"
 msgstr ""
 
@@ -3604,7 +3609,7 @@ msgstr ""
 msgid "Connections"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1024 src/muuli_wdr.cpp:1867
+#: src/muuli_wdr.cpp:1024 src/muuli_wdr.cpp:1871
 msgid "Active downloads"
 msgstr ""
 
@@ -3612,7 +3617,7 @@ msgstr ""
 msgid "Active connections (1:1)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1040 src/muuli_wdr.cpp:1868
+#: src/muuli_wdr.cpp:1040 src/muuli_wdr.cpp:1872
 msgid "Active uploads"
 msgstr ""
 
@@ -3885,7 +3890,7 @@ msgstr ""
 msgid "Advanced users only: If you have multiple network interfaces, enter the address of the interface to which aMule should be bound."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1462 src/muuli_wdr.cpp:2061
+#: src/muuli_wdr.cpp:1462 src/muuli_wdr.cpp:2065
 msgid "Bind to network interface (empty for any):"
 msgstr ""
 
@@ -3901,7 +3906,7 @@ msgstr ""
 msgid "Max simultaneous connections:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1498 src/muuli_wdr.cpp:3176
+#: src/muuli_wdr.cpp:1498 src/muuli_wdr.cpp:3207
 msgid "ED2K"
 msgstr ""
 
@@ -3993,743 +3998,763 @@ msgstr ""
 msgid "For new files preallocates disk space for the whole file, thus reduces fragmentation"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1613
+#: src/muuli_wdr.cpp:1617
 msgid "Create new files as sparse files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1614
-msgid "A sparse file reserves its full size on disk immediately without writing real data to it -- fast, but unsupported or slow on some filesystems, and free-space accounting stays optimistic while the download is in progress. Turn this off to grow the file only as data arrives."
+#: src/muuli_wdr.cpp:1618
+msgid "Sparse part files only occupy disk space for the parts already downloaded, so free space is used up gradually as the file fills in. Turn this off to use an ordinary file instead - useful where sparse files are unsupported or slow, or where backup/de-duplication tools handle them badly. Applies only when the core runs on Windows; on Linux and macOS part files are sparse anyway and this setting has no effect."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1619
+#: src/muuli_wdr.cpp:1623
 msgid "Stop downloads when free disk space reaches "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1620
+#: src/muuli_wdr.cpp:1624
 msgid "Select this if you want aMule to check your disk space"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1624
+#: src/muuli_wdr.cpp:1628
 msgid "Enter here the min disk space desired."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1630
+#: src/muuli_wdr.cpp:1634
 msgid "Save 10 sources on rare files (< 20 sources)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1634 src/Statistics.cpp:790
+#: src/muuli_wdr.cpp:1638 src/Statistics.cpp:790
 msgid "Uploads"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1637
+#: src/muuli_wdr.cpp:1641
 msgid "Add new shared files with auto priority"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1643
+#: src/muuli_wdr.cpp:1647
 msgid "Intelligent Corruption Handling (I.C.H.)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1646
+#: src/muuli_wdr.cpp:1650
 msgid "Enable"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1649
+#: src/muuli_wdr.cpp:1653
 msgid "Advanced I.C.H. trusts every hash (not recommended)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1661 src/PrefsUnifiedDlg.cpp:1910
+#: src/muuli_wdr.cpp:1665 src/PrefsUnifiedDlg.cpp:1990
 msgid "Media metadata extraction"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1665
+#: src/muuli_wdr.cpp:1669
 msgid "Extract length / bitrate / codec from shared audio and video files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1667
+#: src/muuli_wdr.cpp:1671
 msgid "When enabled, aMule runs ffprobe on each shared media file to fill in the Length / Bitrate / Codec columns other clients see when they find the file in a search. Requires ffmpeg (the ffprobe binary) to be installed."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1674
+#: src/muuli_wdr.cpp:1678
 msgid "Path to ffprobe:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1679
+#: src/muuli_wdr.cpp:1683
 msgid "Full path to the ffprobe binary. Leave empty to have aMule auto-detect it on startup."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1687
+#: src/muuli_wdr.cpp:1691
 msgid "Detect"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1688
+#: src/muuli_wdr.cpp:1692
 msgid "Search the standard install locations for an ffprobe binary and fill the path field."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1712
+#: src/muuli_wdr.cpp:1716
 msgid ""
 "Completed downloads are stored here. All files in this folder are automatically shared with other peers.\n"
 "If this folder also holds files you don't want to share, point it at an aMule-only sub-folder."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1715
+#: src/muuli_wdr.cpp:1719
 msgid "Pick the folder where completed downloads will be stored. All files in that folder will be shared with other peers."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1729
+#: src/muuli_wdr.cpp:1733
 msgid "Shared folders"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1735
+#: src/muuli_wdr.cpp:1739
 msgid "(Folders shared by the core. Enter a path to add one.)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1743
+#: src/muuli_wdr.cpp:1747
 msgid "Absolute path of a folder on the core's machine, e.g. /home/user/shared"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1745 src/PrefsUnifiedDlg.cpp:2794
+#: src/muuli_wdr.cpp:1749 src/PrefsUnifiedDlg.cpp:2874
 msgid "Recursive"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1746
+#: src/muuli_wdr.cpp:1750
 msgid "Share every sub-folder underneath this one, including ones created later."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1750 src/utils/aLinkCreator/src/alcframe.cpp:141
+#: src/muuli_wdr.cpp:1754 src/utils/aLinkCreator/src/alcframe.cpp:141
 msgid "Remove"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1754
+#: src/muuli_wdr.cpp:1758
 msgid "(Right click on folder icon for recursive share)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1761
+#: src/muuli_wdr.cpp:1765
 msgid "Share hidden files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1767
+#: src/muuli_wdr.cpp:1771
 msgid "Automatically rescan shared folders for changes"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1773
+#: src/muuli_wdr.cpp:1777
 msgid "Follow symbolic links in shared folders"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1779
+#: src/muuli_wdr.cpp:1783
 msgid "Exclude files matching:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1782
+#: src/muuli_wdr.cpp:1786
 msgid "Wildcard patterns separated by '|', e.g. .DS_Store|Thumbs.db|*.tmp. Files whose name matches are not shared. Matching is case-insensitive."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1786
+#: src/muuli_wdr.cpp:1790
 msgid "Patterns are regular expressions"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1787
+#: src/muuli_wdr.cpp:1791
 msgid "When set, the whole field is one regular expression ('|' is alternation). When unset, it is a list of '|'-separated wildcards."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1797
+#: src/muuli_wdr.cpp:1801
 msgid "Show how many shared files the current pattern would exclude."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1818
+#: src/muuli_wdr.cpp:1822
 msgid "Graphs"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1821 src/muuli_wdr.cpp:1883
+#: src/muuli_wdr.cpp:1825 src/muuli_wdr.cpp:1887
 msgid "Update delay : 5 secs"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1825
+#: src/muuli_wdr.cpp:1829
 msgid "Time for average graph: 100 mins"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1829
+#: src/muuli_wdr.cpp:1833
 msgid "Connections Graph Scale: 100 "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1836
+#: src/muuli_wdr.cpp:1840
 msgid "Download graph scale:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1844
+#: src/muuli_wdr.cpp:1848
 msgid "Upload graph scale:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1854
+#: src/muuli_wdr.cpp:1858
 msgid "Colors: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1858
+#: src/muuli_wdr.cpp:1862
 msgid "Background"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1859
+#: src/muuli_wdr.cpp:1863
 msgid "Grid"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1860
+#: src/muuli_wdr.cpp:1864
 msgid "Download current"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1861
+#: src/muuli_wdr.cpp:1865
 msgid "Download running average"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1862
+#: src/muuli_wdr.cpp:1866
 msgid "Download session average"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1863
+#: src/muuli_wdr.cpp:1867
 msgid "Upload current"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1864
+#: src/muuli_wdr.cpp:1868
 msgid "Upload running average"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1865
+#: src/muuli_wdr.cpp:1869
 msgid "Upload session average"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1866
+#: src/muuli_wdr.cpp:1870
 msgid "Active connections"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1869
+#: src/muuli_wdr.cpp:1873
 msgid "Systray Icon Speed Bar"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1870
+#: src/muuli_wdr.cpp:1874
 msgid "Kad-nodes current"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1871
+#: src/muuli_wdr.cpp:1875
 msgid "Kad-nodes running"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1872
+#: src/muuli_wdr.cpp:1876
 msgid "Kad-nodes session"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1876 src/muuli_wdr.cpp:2303
+#: src/muuli_wdr.cpp:1880 src/muuli_wdr.cpp:2334
 msgid "Select"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1880
+#: src/muuli_wdr.cpp:1884
 msgid "Tree"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1890
+#: src/muuli_wdr.cpp:1894
 msgid "Number of Client Versions shown (0=unlimited)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1915
+#: src/muuli_wdr.cpp:1919
 msgid "!!! WARNING !!!"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1930
+#: src/muuli_wdr.cpp:1934
 msgid "Max new connections / 5 secs"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1932
+#: src/muuli_wdr.cpp:1936
 msgid "Concurrent Kad source lookups"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1934
+#: src/muuli_wdr.cpp:1938
 msgid "Kad source re-search interval (minutes)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1936
+#: src/muuli_wdr.cpp:1940
 msgid "Source re-ask interval (minutes)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1940
+#: src/muuli_wdr.cpp:1944
 msgid "File Buffer Size: 240000 bytes"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1944
+#: src/muuli_wdr.cpp:1948
 msgid "Use MMAP: memory-mapped file access (lower memory use)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1945
+#: src/muuli_wdr.cpp:1949
 msgid "Maps part files into memory instead of buffering them on the heap, lowering the process memory footprint. May reduce download speed on some disks; best for memory-constrained or upload-heavy hosts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1947
+#: src/muuli_wdr.cpp:1951
 msgid "Upload Queue Size: 5000 clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1951
+#: src/muuli_wdr.cpp:1955
 msgid "Server connection refresh interval: Disable"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1955
+#: src/muuli_wdr.cpp:1959
 msgid "Disable computer's timed standby mode"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1974
+#: src/muuli_wdr.cpp:1978
 msgid "Skin to use: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1983
+#: src/muuli_wdr.cpp:1987
 msgid "Show \"Fast eD2k Links Handler\" in every window."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1986
+#: src/muuli_wdr.cpp:1990
 msgid "Show extended info on categories tabs"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1989
+#: src/muuli_wdr.cpp:1993
 msgid "Show application version on title"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1991
+#: src/muuli_wdr.cpp:1995
 msgid "Show transfer rates on title"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1993
+#: src/muuli_wdr.cpp:1997
 msgid "Before application name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1995
+#: src/muuli_wdr.cpp:1999
 msgid "After application name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1998
+#: src/muuli_wdr.cpp:2002
 msgid "Show overhead bandwidth"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2002
+#: src/muuli_wdr.cpp:2006
 msgid "Vertical toolbar orientation"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2004
+#: src/muuli_wdr.cpp:2008
 msgid "Live column sorting (auto-reorder rows as their values change)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2011
+#: src/muuli_wdr.cpp:2015
 msgid "Download Queue Files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2014
+#: src/muuli_wdr.cpp:2018
 msgid "Show progress percentage"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2020
+#: src/muuli_wdr.cpp:2024
 msgid "Show progress bar"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2023
+#: src/muuli_wdr.cpp:2027
 msgid "Flat"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2027
+#: src/muuli_wdr.cpp:2031
 msgid "Round"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2045
+#: src/muuli_wdr.cpp:2049
 msgid "External Connection Parameters"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2048
+#: src/muuli_wdr.cpp:2052
 msgid "Accept external connections"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2055 src/muuli_wdr.cpp:2114
+#: src/muuli_wdr.cpp:2059 src/muuli_wdr.cpp:2118
 msgid "IP of the listening interface:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2058
+#: src/muuli_wdr.cpp:2062
 msgid "Enter here a valid ip in the a.b.c.d format for the listening EC interface. An empty field or 0.0.0.0 will mean any interface."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2079 src/muuli_wdr.cpp:2163
+#: src/muuli_wdr.cpp:2083 src/muuli_wdr.cpp:2194
 msgid "TCP port:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2085
+#: src/muuli_wdr.cpp:2089
 msgid "Enable UPnP port forwarding on the EC port"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2089 src/muuli_wdr.cpp:3048
+#: src/muuli_wdr.cpp:2093 src/muuli_wdr.cpp:3079
 #: src/utils/wxCas/src/wxcasprefs.cpp:167
 msgid "Password"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2095
+#: src/muuli_wdr.cpp:2099
 msgid "aMule API server parameters"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2098
+#: src/muuli_wdr.cpp:2102
 msgid "Run amuleapi (REST API) on startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2103
+#: src/muuli_wdr.cpp:2107
 msgid "HTTP port:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2117
+#: src/muuli_wdr.cpp:2121
 msgid "The interface amuleapi's HTTP server listens on. 127.0.0.1 (default) accepts only local connections; use 0.0.0.0 or a specific IP to expose it to other hosts (set an admin password below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2120
+#: src/muuli_wdr.cpp:2126
+msgid "Type a password to set or change it. Stored passwords cannot be shown, so leaving this empty keeps the current one."
+msgstr ""
+
+#: src/muuli_wdr.cpp:2128
 msgid "Admin password"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2125 src/muuli_wdr.cpp:2156
-msgid "Low rights password"
+#: src/muuli_wdr.cpp:2140 src/muuli_wdr.cpp:2157 src/PrefsUnifiedDlg.cpp:1103
+msgid "A password is set."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2133
+#: src/muuli_wdr.cpp:2144
+msgid "Enable guest access"
+msgstr ""
+
+#: src/muuli_wdr.cpp:2145
+msgid "Guest sessions may read status and listings but cannot change anything. Turning this off clears the stored guest password."
+msgstr ""
+
+#: src/muuli_wdr.cpp:2149
+msgid "Guest password"
+msgstr ""
+
+#: src/muuli_wdr.cpp:2164
 msgid "Web server parameters"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2136
+#: src/muuli_wdr.cpp:2167
 msgid "Run webserver on startup (deprecated)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2142
+#: src/muuli_wdr.cpp:2173
 msgid "Web template"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2147
+#: src/muuli_wdr.cpp:2178
 msgid "Full rights password"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2151
+#: src/muuli_wdr.cpp:2182
 msgid "Enable Low rights User"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2170
+#: src/muuli_wdr.cpp:2187
+msgid "Low rights password"
+msgstr ""
+
+#: src/muuli_wdr.cpp:2201
 msgid "Enable UPnP port forwarding of the web server port"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2175
+#: src/muuli_wdr.cpp:2206
 msgid "Web server UPnP TCP port (Optional)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2183
+#: src/muuli_wdr.cpp:2214
 msgid "Page Refresh Time (in secs)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2190
+#: src/muuli_wdr.cpp:2221
 msgid "Enable Gzip compression"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2224
+#: src/muuli_wdr.cpp:2255
 msgid "Reset page to defaults"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2225
+#: src/muuli_wdr.cpp:2256
 msgid "Reset the settings on the current page to their default values."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2227 src/muuli_wdr.cpp:2313 src/ServerWnd.cpp:274
+#: src/muuli_wdr.cpp:2258 src/muuli_wdr.cpp:2344 src/ServerWnd.cpp:274
 #: src/ServerWnd.cpp:282
 msgid "OK"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2229
+#: src/muuli_wdr.cpp:2260
 msgid "Click here to apply any changes made to the preferences."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2232
+#: src/muuli_wdr.cpp:2263
 msgid "Reset any changes made to the preferences."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2261
+#: src/muuli_wdr.cpp:2292
 msgid "Comment :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2268
+#: src/muuli_wdr.cpp:2299
 msgid "Incoming Dir :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2277
+#: src/muuli_wdr.cpp:2308
 msgid "Change priority for new assigned files :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2281
+#: src/muuli_wdr.cpp:2312
 msgid "Don't change"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2293
+#: src/muuli_wdr.cpp:2324
 msgid "Select color for this Category (currently selected) :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2360 src/muuli_wdr.cpp:2379 src/muuli_wdr.cpp:2401
+#: src/muuli_wdr.cpp:2391 src/muuli_wdr.cpp:2410 src/muuli_wdr.cpp:2432
 msgid "Click this button to reset the log."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2420
+#: src/muuli_wdr.cpp:2451
 msgid "Click on this button to update the servers list from URL ..."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2424
+#: src/muuli_wdr.cpp:2455
 msgid "Server list"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2428
+#: src/muuli_wdr.cpp:2459
 msgid "Enter the url to a server.met file here and press the button to the left to update the list of known servers."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2433
+#: src/muuli_wdr.cpp:2464
 msgid "Add server manually: Name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2436
+#: src/muuli_wdr.cpp:2467
 msgid "Enter the name of the new server here"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2438 src/ServerWnd.cpp:206
+#: src/muuli_wdr.cpp:2469 src/ServerWnd.cpp:206
 msgid "IP:Port"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2441
+#: src/muuli_wdr.cpp:2472
 msgid "Enter the IP of the server here, using the x.x.x.x format."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2447
+#: src/muuli_wdr.cpp:2478
 msgid "Enter the port of the server here."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2450
+#: src/muuli_wdr.cpp:2481
 msgid "Add manually a server (fill fields to the left before) ..."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2479
+#: src/muuli_wdr.cpp:2510
 msgid "aMule Log"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2487
+#: src/muuli_wdr.cpp:2518
 msgid "Server Info"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2491
+#: src/muuli_wdr.cpp:2522
 msgid "ED2K Info"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2495
+#: src/muuli_wdr.cpp:2526
 msgid "Kad Info"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2523
+#: src/muuli_wdr.cpp:2554
 msgid "Click on this button to update the nodes list from URL ..."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2527
+#: src/muuli_wdr.cpp:2558
 msgid "Nodes (0)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2531
+#: src/muuli_wdr.cpp:2562
 msgid "Enter the url to a nodes.dat file here and press the button to the left to update the list of known nodes."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2534
+#: src/muuli_wdr.cpp:2565
 msgid "Nodes stats"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2576
+#: src/muuli_wdr.cpp:2607
 msgid "Bootstrap"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2579
+#: src/muuli_wdr.cpp:2610
 msgid "New node"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2584
+#: src/muuli_wdr.cpp:2615
 msgid "IP:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2604
+#: src/muuli_wdr.cpp:2635
 msgid "Port:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2617
+#: src/muuli_wdr.cpp:2648
 msgid "Bootstrap from known clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2619
+#: src/muuli_wdr.cpp:2650
 msgid "Disconnect Kad"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2653
+#: src/muuli_wdr.cpp:2684
 msgid "Use Secure User Identification"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2655
+#: src/muuli_wdr.cpp:2686
 msgid "It is recommended to enable this option. You will not receive credits if SUI is not enabled."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2657
+#: src/muuli_wdr.cpp:2688
 msgid "Protocol Obfuscation"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2660
+#: src/muuli_wdr.cpp:2691
 msgid "Support Protocol Obfuscation"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2662
+#: src/muuli_wdr.cpp:2693
 msgid "This option enabled Protocol Obfuscation, and makes aMule accept obfuscated connections from other clients."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2664
+#: src/muuli_wdr.cpp:2695
 msgid "Use obfuscation for outgoing connections"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2666
+#: src/muuli_wdr.cpp:2697
 msgid "This option makes aMule use Protocol Obfuscation when connecting other clients/servers."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2668
+#: src/muuli_wdr.cpp:2699
 msgid "Accept only obfuscated connections"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2669
+#: src/muuli_wdr.cpp:2700
 msgid "This option makes aMule only accept obfuscated connections. You will have less sources, but all your traffic will be obfuscated"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2674
+#: src/muuli_wdr.cpp:2705
 msgid "Everybody"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2676
+#: src/muuli_wdr.cpp:2707
 msgid "No one"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2678
+#: src/muuli_wdr.cpp:2709
 msgid "Who can see my shared files:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2679
+#: src/muuli_wdr.cpp:2710
 msgid "Select who can request to view a list of your shared files."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2681
+#: src/muuli_wdr.cpp:2712
 msgid "IP-Filtering"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2688
+#: src/muuli_wdr.cpp:2719
 msgid "Filter clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2690
+#: src/muuli_wdr.cpp:2721
 msgid "Enable filtering of the client IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2692
+#: src/muuli_wdr.cpp:2723
 msgid "Filter servers"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2694
+#: src/muuli_wdr.cpp:2725
 msgid "Enable filtering of the server IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2698
+#: src/muuli_wdr.cpp:2729
 msgid "Reload List"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2699
+#: src/muuli_wdr.cpp:2730
 msgid "Reload the list of IPs to filter from the file ~/.aMule/ipfilter.dat"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2705
+#: src/muuli_wdr.cpp:2736
 msgid "URL:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2709 src/muuli_wdr.cpp:2902
+#: src/muuli_wdr.cpp:2740 src/muuli_wdr.cpp:2933
 msgid "Update now"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2712
+#: src/muuli_wdr.cpp:2743
 msgid "Auto-update ipfilter at startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2716
+#: src/muuli_wdr.cpp:2747
 msgid "Filtering Level:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2722
+#: src/muuli_wdr.cpp:2753
 msgid "Always filter LAN IPs"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2725
+#: src/muuli_wdr.cpp:2756
 msgid "Paranoid handling of non-matching IPs"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2727
+#: src/muuli_wdr.cpp:2758
 msgid "Rejects a packet when its source IP differs from the IP the client claims (an anti-spoofing check). Disable only if it causes connection problems."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2729
+#: src/muuli_wdr.cpp:2760
 msgid "Use system-wide ipfilter.dat if available"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2730
+#: src/muuli_wdr.cpp:2761
 msgid "If there's no local ipfilter.dat found, allow usage of a system-wide ipfilter file."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2747
+#: src/muuli_wdr.cpp:2778
 msgid "Enable Online-Signature"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2749
+#: src/muuli_wdr.cpp:2780
 msgid "Enables the writing of the OS file, which can be used by external apps to create signatures and the like."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2753
+#: src/muuli_wdr.cpp:2784
 msgid "Update Frequency (Secs):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2756
+#: src/muuli_wdr.cpp:2787
 msgid "Change the frequency (in seconds) of Online Signature updates."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2764
+#: src/muuli_wdr.cpp:2795
 msgid "Save online signature file in: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:2770
+#: src/muuli_wdr.cpp:2801
 msgid "Click here to select the directory containing the the Online Signature files."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2803
+#: src/muuli_wdr.cpp:2834
 msgid "Show country flags for clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2804
+#: src/muuli_wdr.cpp:2835
 msgid "Render the country flag column in the transfers, queue and search views. Requires a valid MMDB GeoIP database (see below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2809
+#: src/muuli_wdr.cpp:2840
 msgid "Database"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2825
+#: src/muuli_wdr.cpp:2856
 msgid "Source:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2828
+#: src/muuli_wdr.cpp:2859
 msgid "DB-IP (free, no account)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2829
+#: src/muuli_wdr.cpp:2860
 msgid "MaxMind GeoLite2 (free, account required)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2830
+#: src/muuli_wdr.cpp:2861
 msgid "Custom URL"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2833
+#: src/muuli_wdr.cpp:2864
 msgid "Choose which provider supplies the GeoIP MMDB database. DB-IP is the default - no account required. MaxMind requires a free account + license key. Use Custom URL to point at any other MMDB host (e.g. a local mirror)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2850
+#: src/muuli_wdr.cpp:2881
 msgid ""
 "No configuration required.\n"
 "\n"
@@ -4737,11 +4762,11 @@ msgid ""
 "License: Creative Commons BY 4.0 - https://creativecommons.org/licenses/by/4.0/"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2863
+#: src/muuli_wdr.cpp:2894
 msgid "License key:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2869
+#: src/muuli_wdr.cpp:2900
 msgid ""
 "Sign up for a free MaxMind account, then generate a License Key:\n"
 "https://www.maxmind.com/en/geolite2/signup\n"
@@ -4751,222 +4776,222 @@ msgid ""
 "Requires attribution and account registration; refresh at least every 30 days."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2884
+#: src/muuli_wdr.cpp:2915
 msgid "Download URL:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2890
+#: src/muuli_wdr.cpp:2921
 msgid ""
 "Must point to an .mmdb file or a .gz / .tar.gz containing one.\n"
 "URL may include credentials (https://user:pass@host/...).\n"
 "License and attribution terms are set by the upstream URL - you are responsible."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2903
+#: src/muuli_wdr.cpp:2934
 msgid "Download the GeoIP database from the selected source."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2905
+#: src/muuli_wdr.cpp:2936
 msgid "Auto-update on startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2906
+#: src/muuli_wdr.cpp:2937
 msgid "Re-download the GeoIP database from the selected source every time aMule starts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2929
+#: src/muuli_wdr.cpp:2960
 msgid "Filter incoming messages (except current chat):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2931
+#: src/muuli_wdr.cpp:2962
 msgid "Filter all messages"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2933
+#: src/muuli_wdr.cpp:2964
 msgid "Filter messages from people not on your friend list"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2935
+#: src/muuli_wdr.cpp:2966
 msgid "Filter messages from unknown clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2937
+#: src/muuli_wdr.cpp:2968
 msgid "Filter messages containing (use ',' as separator):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2940 src/muuli_wdr.cpp:2951
+#: src/muuli_wdr.cpp:2971 src/muuli_wdr.cpp:2982
 msgid "add here the words amule should filter and block messages including it"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2942
+#: src/muuli_wdr.cpp:2973
 msgid "Show received messages in the log"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2945
+#: src/muuli_wdr.cpp:2976
 msgid "Comments"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2948
+#: src/muuli_wdr.cpp:2979
 msgid "Filter comments containing (use ',' as separator):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2973
+#: src/muuli_wdr.cpp:3004
 msgid "Enable Proxy"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2974
+#: src/muuli_wdr.cpp:3005
 msgid "Enable/disable proxy support"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2977
+#: src/muuli_wdr.cpp:3008
 msgid "Proxy type:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2988
+#: src/muuli_wdr.cpp:3019
 msgid "Proxy host:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2991
+#: src/muuli_wdr.cpp:3022
 msgid "The proxy host name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2993
+#: src/muuli_wdr.cpp:3024
 msgid "Proxy port:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2996
+#: src/muuli_wdr.cpp:3027
 msgid "The proxy port"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2998
+#: src/muuli_wdr.cpp:3029
 msgid "Enable authentication"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2999
+#: src/muuli_wdr.cpp:3030
 msgid "Enable/disable username/password authentication"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3002
+#: src/muuli_wdr.cpp:3033
 msgid "Username: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:3005
+#: src/muuli_wdr.cpp:3036
 msgid "The username to use to connect to the proxy"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3007
+#: src/muuli_wdr.cpp:3038
 msgid "Password:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3010
+#: src/muuli_wdr.cpp:3041
 msgid "The password to use to connect to the proxy"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3029
+#: src/muuli_wdr.cpp:3060
 msgid "Connect to:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3038
+#: src/muuli_wdr.cpp:3069
 msgid "Login to remote amule"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3043
+#: src/muuli_wdr.cpp:3074
 msgid "User name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3054
+#: src/muuli_wdr.cpp:3085
 msgid "Remember those settings"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3057
+#: src/muuli_wdr.cpp:3088
 msgid "Force ZLIB compression"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3081
+#: src/muuli_wdr.cpp:3112
 msgid "Enable Verbose Debug-Logging."
 msgstr ""
 
-#: src/muuli_wdr.cpp:3083
+#: src/muuli_wdr.cpp:3114
 msgid "Only to Logfile"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3085
+#: src/muuli_wdr.cpp:3116
 msgid "Message Categories:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3109 src/PartFileConvertDlg.cpp:160
+#: src/muuli_wdr.cpp:3140 src/PartFileConvertDlg.cpp:160
 msgid "Waiting..."
 msgstr ""
 
-#: src/muuli_wdr.cpp:3129
+#: src/muuli_wdr.cpp:3160
 msgid "Add imports"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3132
+#: src/muuli_wdr.cpp:3163
 msgid "Retry selected"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3134
+#: src/muuli_wdr.cpp:3165
 msgid "Remove selected"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3197
+#: src/muuli_wdr.cpp:3228
 msgid "Event Types"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3216
+#: src/muuli_wdr.cpp:3247
 msgid "Statistics and queued clients for selected file(s) : Session / All time"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3240
+#: src/muuli_wdr.cpp:3271
 msgid "Active Uploads"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3254
+#: src/muuli_wdr.cpp:3285
 msgid "Percent of total files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3306
+#: src/muuli_wdr.cpp:3337
 msgid "Show Clients for"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3308
+#: src/muuli_wdr.cpp:3339
 msgid "All files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3311
+#: src/muuli_wdr.cpp:3342
 msgid "Selected files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3314
+#: src/muuli_wdr.cpp:3345
 msgid "Active uploads only"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3321
+#: src/muuli_wdr.cpp:3352
 msgid "Reload:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3325
+#: src/muuli_wdr.cpp:3356
 msgid "Reload your shared files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3388
+#: src/muuli_wdr.cpp:3419
 msgid "Send"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3389
+#: src/muuli_wdr.cpp:3420
 msgid "Sends the specified message."
 msgstr ""
 
-#: src/muuli_wdr.cpp:3393
+#: src/muuli_wdr.cpp:3424
 msgid "Close this chat-session."
 msgstr ""
 
-#: src/muuli_wdr.cpp:3416
+#: src/muuli_wdr.cpp:3447
 msgid "Connect to any server and/or Kad"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3422 src/SharedFilesCtrl.cpp:142 src/Statistics.cpp:941
+#: src/muuli_wdr.cpp:3453 src/SharedFilesCtrl.cpp:142 src/Statistics.cpp:941
 msgid "Shared Files"
 msgstr ""
 
@@ -5324,263 +5349,263 @@ msgstr ""
 msgid "ERROR: Failed to open partfile '%s'"
 msgstr ""
 
-#: src/Preferences.cpp:674
+#: src/Preferences.cpp:701
 msgid "System default"
 msgstr ""
 
-#: src/Preferences.cpp:675
+#: src/Preferences.cpp:702
 msgid "Albanian"
 msgstr ""
 
-#: src/Preferences.cpp:676
+#: src/Preferences.cpp:703
 msgid "Arabic"
 msgstr ""
 
-#: src/Preferences.cpp:677
+#: src/Preferences.cpp:704
 msgid "Asturian"
 msgstr ""
 
-#: src/Preferences.cpp:678
+#: src/Preferences.cpp:705
 msgid "Basque"
 msgstr ""
 
-#: src/Preferences.cpp:679
+#: src/Preferences.cpp:706
 msgid "Bulgarian"
 msgstr ""
 
-#: src/Preferences.cpp:680
+#: src/Preferences.cpp:707
 msgid "Catalan"
 msgstr ""
 
-#: src/Preferences.cpp:681
+#: src/Preferences.cpp:708
 msgid "Chinese (Simplified)"
 msgstr ""
 
-#: src/Preferences.cpp:682
+#: src/Preferences.cpp:709
 msgid "Chinese (Traditional)"
 msgstr ""
 
-#: src/Preferences.cpp:683
+#: src/Preferences.cpp:710
 msgid "Croatian"
 msgstr ""
 
-#: src/Preferences.cpp:684
+#: src/Preferences.cpp:711
 msgid "Czech"
 msgstr ""
 
-#: src/Preferences.cpp:685
+#: src/Preferences.cpp:712
 msgid "Danish"
 msgstr ""
 
-#: src/Preferences.cpp:686
+#: src/Preferences.cpp:713
 msgid "Dutch"
 msgstr ""
 
-#: src/Preferences.cpp:687
+#: src/Preferences.cpp:714
 msgid "English (U.K.)"
 msgstr ""
 
-#: src/Preferences.cpp:688
+#: src/Preferences.cpp:715
 msgid "English (U.S.)"
 msgstr ""
 
-#: src/Preferences.cpp:689
+#: src/Preferences.cpp:716
 msgid "Estonian"
 msgstr ""
 
-#: src/Preferences.cpp:690
+#: src/Preferences.cpp:717
 msgid "Finnish"
 msgstr ""
 
-#: src/Preferences.cpp:691
+#: src/Preferences.cpp:718
 msgid "French"
 msgstr ""
 
-#: src/Preferences.cpp:692
+#: src/Preferences.cpp:719
 msgid "Galician"
 msgstr ""
 
-#: src/Preferences.cpp:693
+#: src/Preferences.cpp:720
 msgid "German"
 msgstr ""
 
-#: src/Preferences.cpp:694
+#: src/Preferences.cpp:721
 msgid "Greek"
 msgstr ""
 
-#: src/Preferences.cpp:695
+#: src/Preferences.cpp:722
 msgid "Hebrew"
 msgstr ""
 
-#: src/Preferences.cpp:696
+#: src/Preferences.cpp:723
 msgid "Hungarian"
 msgstr ""
 
-#: src/Preferences.cpp:697
+#: src/Preferences.cpp:724
 msgid "Italian"
 msgstr ""
 
-#: src/Preferences.cpp:698
+#: src/Preferences.cpp:725
 msgid "Japanese"
 msgstr ""
 
-#: src/Preferences.cpp:699
+#: src/Preferences.cpp:726
 msgid "Korean"
 msgstr ""
 
-#: src/Preferences.cpp:700
+#: src/Preferences.cpp:727
 msgid "Latvian"
 msgstr ""
 
-#: src/Preferences.cpp:701
+#: src/Preferences.cpp:728
 msgid "Lithuanian"
 msgstr ""
 
-#: src/Preferences.cpp:702
+#: src/Preferences.cpp:729
 msgid "Norwegian (Nynorsk)"
 msgstr ""
 
-#: src/Preferences.cpp:703
+#: src/Preferences.cpp:730
 msgid "Polish"
 msgstr ""
 
-#: src/Preferences.cpp:704
+#: src/Preferences.cpp:731
 msgid "Portuguese"
 msgstr ""
 
-#: src/Preferences.cpp:705
+#: src/Preferences.cpp:732
 msgid "Portuguese (Brazilian)"
 msgstr ""
 
-#: src/Preferences.cpp:706
+#: src/Preferences.cpp:733
 msgid "Romanian"
 msgstr ""
 
-#: src/Preferences.cpp:707
+#: src/Preferences.cpp:734
 msgid "Russian"
 msgstr ""
 
-#: src/Preferences.cpp:708
+#: src/Preferences.cpp:735
 msgid "Slovenian"
 msgstr ""
 
-#: src/Preferences.cpp:709
+#: src/Preferences.cpp:736
 msgid "Spanish"
 msgstr ""
 
-#: src/Preferences.cpp:710
+#: src/Preferences.cpp:737
 msgid "Swedish"
 msgstr ""
 
-#: src/Preferences.cpp:711
+#: src/Preferences.cpp:738
 msgid "Turkish"
 msgstr ""
 
-#: src/Preferences.cpp:712
+#: src/Preferences.cpp:739
 msgid "Ukrainian"
 msgstr ""
 
-#: src/Preferences.cpp:815
+#: src/Preferences.cpp:842
 msgid "Change Language"
 msgstr ""
 
-#: src/Preferences.cpp:879
+#: src/Preferences.cpp:906
 msgid "There are no translations installed for aMule"
 msgstr ""
 
-#: src/Preferences.cpp:880
+#: src/Preferences.cpp:907
 msgid "No languages available"
 msgstr ""
 
-#: src/Preferences.cpp:1011
+#: src/Preferences.cpp:1038
 msgid "no options available"
 msgstr ""
 
-#: src/Preferences.cpp:2182
+#: src/Preferences.cpp:2227
 msgid "Invalid category found, skipping"
 msgstr ""
 
-#: src/Preferences.cpp:2351
+#: src/Preferences.cpp:2396
 msgid "TCP port can't be higher than 65532 due to server UDP socket being TCP+3"
 msgstr ""
 
-#: src/Preferences.cpp:2352
+#: src/Preferences.cpp:2397
 #, c-format
 msgid "Default port will be used (%d)"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:298 src/Statistics.cpp:866
+#: src/PrefsUnifiedDlg.cpp:300 src/Statistics.cpp:866
 msgid "Connection"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:299 src/SearchListCtrl.cpp:117
+#: src/PrefsUnifiedDlg.cpp:301 src/SearchListCtrl.cpp:117
 msgid "Directories"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:300 src/Statistics.cpp:917
+#: src/PrefsUnifiedDlg.cpp:302 src/Statistics.cpp:917
 msgid "Servers"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:301 src/ServerListCtrl.cpp:96
+#: src/PrefsUnifiedDlg.cpp:303 src/ServerListCtrl.cpp:96
 msgid "Files"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:302
+#: src/PrefsUnifiedDlg.cpp:304
 msgid "Security"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:303
+#: src/PrefsUnifiedDlg.cpp:305
 msgid "Interface"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:310
+#: src/PrefsUnifiedDlg.cpp:312
 msgid "IP2Country"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:313
+#: src/PrefsUnifiedDlg.cpp:315
 msgid "Proxy"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:314
+#: src/PrefsUnifiedDlg.cpp:316
 msgid "Filters"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:315
+#: src/PrefsUnifiedDlg.cpp:317
 msgid "Remote Controls"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:316
+#: src/PrefsUnifiedDlg.cpp:318
 msgid "Online Signature"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:317
+#: src/PrefsUnifiedDlg.cpp:319
 msgid "Advanced"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:318
+#: src/PrefsUnifiedDlg.cpp:320
 msgid "Events"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:321
+#: src/PrefsUnifiedDlg.cpp:323
 msgid "Debugging"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:451
+#: src/PrefsUnifiedDlg.cpp:453
 msgid ""
 "The following variables will be substituted:\n"
 "    %PARTFILE - full path to the file\n"
 "    %PARTNAME - file name only"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:472
+#: src/PrefsUnifiedDlg.cpp:474
 msgid "Tray icon support requires libayatana-appindicator3 at compile time."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:488
+#: src/PrefsUnifiedDlg.cpp:490
 msgid "Not available on Wayland: the protocol does not report when a window is minimized, so this option cannot intercept the system minimize button. Workaround: launch aMule with `GDK_BACKEND=x11` to use XWayland instead."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:534
+#: src/PrefsUnifiedDlg.cpp:536
 msgid ""
 "Do not change these setting unless you know\n"
 "what you are doing, otherwise you can easily\n"
@@ -5590,387 +5615,400 @@ msgid ""
 "these settings."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:645
+#: src/PrefsUnifiedDlg.cpp:647
 #, c-format
 msgid "Failed to connect Cfg to widget with the ID %d and key %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:693
+#: src/PrefsUnifiedDlg.cpp:695
 #, c-format
 msgid "Failed to transfer data from Cfg to Widget with the ID %d and key %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:799
+#: src/PrefsUnifiedDlg.cpp:801
 msgid "The type of proxy you are connecting to"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1003
+#: src/PrefsUnifiedDlg.cpp:1020
 #, c-format
 msgid "Failed to transfer data from Widget to Cfg with the ID %d and key %s"
 msgstr ""
 
 #: src/PrefsUnifiedDlg.cpp:1103
+msgid "No password set."
+msgstr ""
+
+#: src/PrefsUnifiedDlg.cpp:1132
+msgid "Guest access needs a password. Type one in the guest password field, or untick Enable guest access."
+msgstr ""
+
+#: src/PrefsUnifiedDlg.cpp:1144
 msgid ""
 "aMule must be restarted to enable these changes:\n"
 "\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1110
+#: src/PrefsUnifiedDlg.cpp:1151
 msgid "- TCP port changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1115
+#: src/PrefsUnifiedDlg.cpp:1156
 msgid "- UDP port changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1120
+#: src/PrefsUnifiedDlg.cpp:1161
 msgid "- Network interface binding changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1125
+#: src/PrefsUnifiedDlg.cpp:1166
 msgid "- External connect port changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1129
+#: src/PrefsUnifiedDlg.cpp:1170
 msgid "- External connect acceptance changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1133
+#: src/PrefsUnifiedDlg.cpp:1174
 msgid "- External connect interface changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1137
+#: src/PrefsUnifiedDlg.cpp:1178
 msgid "- Protocol obfuscation support changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1151
+#: src/PrefsUnifiedDlg.cpp:1193
 msgid "- amuleapi settings changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1160
+#: src/PrefsUnifiedDlg.cpp:1202
 msgid ""
 "Your Auto-update server list is empty.\n"
 "'Auto-update server list at startup' will be disabled."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1171
+#: src/PrefsUnifiedDlg.cpp:1213
 msgid ""
 "You have enabled external connections but have not specified a password.\n"
 "External connections cannot be enabled unless a valid password is specified."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1202
+#: src/PrefsUnifiedDlg.cpp:1246
+#, c-format
+msgid "The amuleapi password could not be saved: %s"
+msgstr ""
+
+#: src/PrefsUnifiedDlg.cpp:1276
 msgid "- Language changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1207
+#: src/PrefsUnifiedDlg.cpp:1281
 msgid "- Temp folder changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1212
+#: src/PrefsUnifiedDlg.cpp:1286
 msgid "- ED2K network enabled.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1245
+#: src/PrefsUnifiedDlg.cpp:1319
 msgid "The shared-file exclusion pattern is not a valid regular expression. The filter has been left disabled."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1247 src/PrefsUnifiedDlg.cpp:1841
+#: src/PrefsUnifiedDlg.cpp:1321 src/PrefsUnifiedDlg.cpp:1921
 msgid "Invalid regular expression"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1324
+#: src/PrefsUnifiedDlg.cpp:1398
 msgid ""
 "Both eD2k and Kad network are disabled.\n"
 "You won't be able to connect until you enable at least one of them."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1329
+#: src/PrefsUnifiedDlg.cpp:1403
 msgid ""
 "Kad will not start if your UDP port is disabled.\n"
 "Enable UDP port or disable Kad."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1385
+#: src/PrefsUnifiedDlg.cpp:1459
 msgid ""
 "\n"
 "You MUST restart aMule now.\n"
 "If you do not restart now, don't complain if anything bad happens.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1450
+#: src/PrefsUnifiedDlg.cpp:1524
 msgid "Could not register aMule for autostart at login. The autostart store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1452
+#: src/PrefsUnifiedDlg.cpp:1526
 msgid "Could not remove the autostart-at-login entry."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1453
+#: src/PrefsUnifiedDlg.cpp:1527
 msgid "Autostart"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1468
+#: src/PrefsUnifiedDlg.cpp:1542
 msgid "Register file type"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1468
+#: src/PrefsUnifiedDlg.cpp:1542
 msgid "Register URL handler"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1476
+#: src/PrefsUnifiedDlg.cpp:1550
 #, c-format
 msgid "aMule only handles eD2k-compatible magnets. If you replace the current magnet handler (%s), BitTorrent magnet links will stop working - aMule cannot download BitTorrent content. Continue?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1481
+#: src/PrefsUnifiedDlg.cpp:1555
 #, c-format
 msgid "Another application currently opens .emulecollection files (%s). Replace it with aMule?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1486
+#: src/PrefsUnifiedDlg.cpp:1560
 #, c-format
 msgid "Another application is currently the default handler for these links (%s). Replace it with aMule?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1511
+#: src/PrefsUnifiedDlg.cpp:1585
 msgid "Could not register aMule for .emulecollection files. The registration store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1513
+#: src/PrefsUnifiedDlg.cpp:1587
 msgid "Could not remove the file type registration."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1515
+#: src/PrefsUnifiedDlg.cpp:1589
 msgid "Could not register aMule as the URL handler. The registration store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1517
+#: src/PrefsUnifiedDlg.cpp:1591
 msgid "Could not remove the URL handler registration."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1587 src/PrefsUnifiedDlg.cpp:1614
+#: src/PrefsUnifiedDlg.cpp:1661 src/PrefsUnifiedDlg.cpp:1688
 msgid "The web server and aMule API require external connections to be enabled."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1597
+#: src/PrefsUnifiedDlg.cpp:1671
 msgid "The aMule web server is deprecated. Consider running the aMule API instead."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1655
+#: src/PrefsUnifiedDlg.cpp:1735
 msgid ""
 "Your Auto-update servers list is in blank.\n"
 "Please fill in at least one URL to point to a valid server.met file.\n"
 "Click on the button \"List\" by this checkbox to enter an URL."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1796
+#: src/PrefsUnifiedDlg.cpp:1876
 msgid "Temporary files"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1801
+#: src/PrefsUnifiedDlg.cpp:1881
 msgid "Incoming files"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1806
+#: src/PrefsUnifiedDlg.cpp:1886
 msgid "Online Signatures"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1819
+#: src/PrefsUnifiedDlg.cpp:1899
 #, c-format
 msgid "Choose a folder for %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1843
+#: src/PrefsUnifiedDlg.cpp:1923
 #, c-format
 msgid "Would exclude %u of %u shared file"
 msgid_plural "Would exclude %u of %u shared files"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/PrefsUnifiedDlg.cpp:1860
+#: src/PrefsUnifiedDlg.cpp:1940
 msgid "Browse for videoplayer"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1864
+#: src/PrefsUnifiedDlg.cpp:1944
 msgid "Select browser"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1868
+#: src/PrefsUnifiedDlg.cpp:1948
 msgid "Select ffprobe binary"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1874
+#: src/PrefsUnifiedDlg.cpp:1954
 #, c-format
 msgid "Executable%s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1908
+#: src/PrefsUnifiedDlg.cpp:1988
 msgid "ffprobe not found on PATH or in the standard install locations. Install ffmpeg (which ships ffprobe) or use Browse to pick a binary manually."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1920
+#: src/PrefsUnifiedDlg.cpp:2000
 msgid "Reset the settings on this page to their default values?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1921
+#: src/PrefsUnifiedDlg.cpp:2001
 msgid "Reset to defaults"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1948
+#: src/PrefsUnifiedDlg.cpp:2028
 msgid "Edit server list"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1949
+#: src/PrefsUnifiedDlg.cpp:2029
 msgid ""
 "Add here URL's to download server.met files.\n"
 "Only one url on each line."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2004
+#: src/PrefsUnifiedDlg.cpp:2084
 msgid "IP2Country update failed"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2149 src/PrefsUnifiedDlg.cpp:2180
+#: src/PrefsUnifiedDlg.cpp:2229 src/PrefsUnifiedDlg.cpp:2260
 msgid "Data by MaxMind GeoLite2"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2151 src/PrefsUnifiedDlg.cpp:2182
+#: src/PrefsUnifiedDlg.cpp:2231 src/PrefsUnifiedDlg.cpp:2262
 msgid "Custom source"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2153 src/PrefsUnifiedDlg.cpp:2184
+#: src/PrefsUnifiedDlg.cpp:2233 src/PrefsUnifiedDlg.cpp:2264
 msgid "Data by DB-IP.com"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2204
+#: src/PrefsUnifiedDlg.cpp:2284
 #, c-format
 msgid "Status: Loaded%s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2206
+#: src/PrefsUnifiedDlg.cpp:2286
 #, c-format
 msgid "Status: Loaded%s - %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2210
+#: src/PrefsUnifiedDlg.cpp:2290
 msgid "Status: Failed to load - click 'Update now' to refresh."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2212
+#: src/PrefsUnifiedDlg.cpp:2292
 msgid "Status: Not found - click 'Update now' to download."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2270 src/PrefsUnifiedDlg.cpp:2294
+#: src/PrefsUnifiedDlg.cpp:2350 src/PrefsUnifiedDlg.cpp:2374
 #, c-format
 msgid "Update delay: %d second"
 msgid_plural "Update delay: %d seconds"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/PrefsUnifiedDlg.cpp:2278
+#: src/PrefsUnifiedDlg.cpp:2358
 #, c-format
 msgid "Time for average graph: %d minute"
 msgid_plural "Time for average graph: %d minutes"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/PrefsUnifiedDlg.cpp:2287
+#: src/PrefsUnifiedDlg.cpp:2367
 #, c-format
 msgid "Connections Graph Scale: %d"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2302
+#: src/PrefsUnifiedDlg.cpp:2382
 #, c-format
 msgid "File Buffer Size: %d byte"
 msgid_plural "File Buffer Size: %d bytes"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/PrefsUnifiedDlg.cpp:2312
+#: src/PrefsUnifiedDlg.cpp:2392
 #, c-format
 msgid "Upload Queue Size: %d client"
 msgid_plural "Upload Queue Size: %d clients"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/PrefsUnifiedDlg.cpp:2322
+#: src/PrefsUnifiedDlg.cpp:2402
 #, c-format
 msgid "Server connection refresh interval: %d minute"
 msgid_plural "Server connection refresh interval: %d minutes"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/PrefsUnifiedDlg.cpp:2327
+#: src/PrefsUnifiedDlg.cpp:2407
 msgid "Server connection refresh interval: Disabled"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2371
+#: src/PrefsUnifiedDlg.cpp:2451
 msgid "disabled"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2397
+#: src/PrefsUnifiedDlg.cpp:2477
 #, c-format
 msgid "Execute command on '%s' event"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2404
+#: src/PrefsUnifiedDlg.cpp:2484
 msgid "Enable command execution on core"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2416
+#: src/PrefsUnifiedDlg.cpp:2496
 msgid "Core command:"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2432
+#: src/PrefsUnifiedDlg.cpp:2512
 msgid "Enable command execution on GUI"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2444
+#: src/PrefsUnifiedDlg.cpp:2524
 msgid "GUI command:"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2460
+#: src/PrefsUnifiedDlg.cpp:2540
 msgid "The following variables will be replaced:"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2628
+#: src/PrefsUnifiedDlg.cpp:2708
 msgid ""
 "The following folders look like system or sensitive locations:\n"
 "\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2633
+#: src/PrefsUnifiedDlg.cpp:2713
 msgid "Sharing them recursively will publish every file underneath on the eD2k/Kad networks. Do you really want to do this?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2636
+#: src/PrefsUnifiedDlg.cpp:2716
 msgid "Confirm shared folders"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2664
+#: src/PrefsUnifiedDlg.cpp:2744
 msgid "Reloading shared files..."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2665
+#: src/PrefsUnifiedDlg.cpp:2745
 msgid "Scanning for subdirectories..."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2666
+#: src/PrefsUnifiedDlg.cpp:2746
 msgid "Updating shared folders"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2693
+#: src/PrefsUnifiedDlg.cpp:2773
 #, c-format
 msgid "Scanned %u directories..."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2743
+#: src/PrefsUnifiedDlg.cpp:2823
 #, c-format
 msgid "Reloading shared files: %u files scanned"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2793
+#: src/PrefsUnifiedDlg.cpp:2873
 msgid "Shared folder"
 msgstr ""
 

--- a/po/amule.pot
+++ b/po/amule.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-28 12:17+0200\n"
+"POT-Creation-Date: 2026-07-28 13:09+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -276,7 +276,7 @@ msgid "Password set and external connections enabled."
 msgstr ""
 
 #: src/amule.cpp:755 src/KadDlg.cpp:176 src/KadDlg.cpp:185
-#: src/PrefsUnifiedDlg.cpp:1461 src/SharedFilesCtrl.cpp:476
+#: src/PrefsUnifiedDlg.cpp:1470 src/SharedFilesCtrl.cpp:476
 msgid "WARNING"
 msgstr ""
 
@@ -311,7 +311,7 @@ msgstr ""
 #: src/amule-remote-gui.cpp:603 src/amule-remote-gui.cpp:671
 #: src/amule-remote-gui.cpp:709 src/amule-remote-gui.cpp:1282
 #: src/amule-remote-gui.cpp:1345 src/amule-remote-gui.cpp:1372
-#: src/DownloadQueue.cpp:1481 src/PrefsUnifiedDlg.cpp:1247
+#: src/DownloadQueue.cpp:1481 src/PrefsUnifiedDlg.cpp:1256
 msgid "ERROR"
 msgstr ""
 
@@ -564,36 +564,36 @@ msgstr ""
 msgid "FATAL ERROR: Failed to create Timer"
 msgstr ""
 
-#: src/amuleDlg.cpp:361 src/amuleDlg.cpp:1787 src/amuleDlg.cpp:2033
-#: src/muuli_wdr.cpp:1492 src/muuli_wdr.cpp:3449
+#: src/amuleDlg.cpp:361 src/amuleDlg.cpp:1810 src/amuleDlg.cpp:2056
+#: src/muuli_wdr.cpp:1492 src/muuli_wdr.cpp:3453
 msgid "Networks"
 msgstr ""
 
-#: src/amuleDlg.cpp:362 src/amuleDlg.cpp:1793 src/muuli_wdr.cpp:3450
+#: src/amuleDlg.cpp:362 src/amuleDlg.cpp:1816 src/muuli_wdr.cpp:3454
 msgid "Searches"
 msgstr ""
 
-#: src/amuleDlg.cpp:363 src/amuleDlg.cpp:1799 src/DownloadListCtrl.cpp:740
-#: src/muuli_wdr.cpp:392 src/muuli_wdr.cpp:1585 src/muuli_wdr.cpp:3451
+#: src/amuleDlg.cpp:363 src/amuleDlg.cpp:1822 src/DownloadListCtrl.cpp:740
+#: src/muuli_wdr.cpp:392 src/muuli_wdr.cpp:1585 src/muuli_wdr.cpp:3455
 #: src/Statistics.cpp:829
 msgid "Downloads"
 msgstr ""
 
-#: src/amuleDlg.cpp:364 src/amuleDlg.cpp:1805 src/muuli_wdr.cpp:3325
+#: src/amuleDlg.cpp:364 src/amuleDlg.cpp:1828 src/muuli_wdr.cpp:3329
 msgid "Shared files"
 msgstr ""
 
-#: src/amuleDlg.cpp:365 src/amuleDlg.cpp:1811 src/muuli_wdr.cpp:2957
-#: src/muuli_wdr.cpp:3407 src/muuli_wdr.cpp:3454
+#: src/amuleDlg.cpp:365 src/amuleDlg.cpp:1834 src/muuli_wdr.cpp:2961
+#: src/muuli_wdr.cpp:3411 src/muuli_wdr.cpp:3458
 msgid "Messages"
 msgstr ""
 
-#: src/amuleDlg.cpp:366 src/amuleDlg.cpp:1817 src/muuli_wdr.cpp:3455
+#: src/amuleDlg.cpp:366 src/amuleDlg.cpp:1840 src/muuli_wdr.cpp:3459
 #: src/PrefsUnifiedDlg.cpp:314 src/Statistics.cpp:779 src/Statistics.cpp:1235
 msgid "Statistics"
 msgstr ""
 
-#: src/amuleDlg.cpp:368 src/amuleDlg.cpp:1824 src/muuli_wdr.cpp:3457
+#: src/amuleDlg.cpp:368 src/amuleDlg.cpp:1847 src/muuli_wdr.cpp:3461
 #: src/PrefsUnifiedDlg.cpp:330 src/utils/wxCas/src/wxcasprefs.cpp:39
 msgid "Preferences"
 msgstr ""
@@ -651,8 +651,8 @@ msgstr ""
 #: src/amuleDlg.cpp:1029 src/DownloadListCtrl.cpp:505
 #: src/DownloadListCtrl.cpp:749 src/FriendListCtrl.cpp:180
 #: src/muuli_wdr.cpp:731 src/muuli_wdr.cpp:782 src/muuli_wdr.cpp:846
-#: src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2262 src/muuli_wdr.cpp:2347
-#: src/muuli_wdr.cpp:3095 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
+#: src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2266 src/muuli_wdr.cpp:2351
+#: src/muuli_wdr.cpp:3099 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
 #: src/ServerListCtrl.cpp:606 src/TransferWnd.cpp:378
 #: src/utils/wxCas/src/wxcasprefs.cpp:235
 msgid "Cancel"
@@ -663,7 +663,7 @@ msgid "Stop the current connection attempts"
 msgstr ""
 
 #: src/amuleDlg.cpp:1035 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976
-#: src/muuli_wdr.cpp:2485
+#: src/muuli_wdr.cpp:2489
 msgid "Disconnect"
 msgstr ""
 
@@ -672,7 +672,7 @@ msgid "Disconnect from the currently connected networks"
 msgstr ""
 
 #: src/amuleDlg.cpp:1041 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979
-#: src/muuli_wdr.cpp:2640 src/muuli_wdr.cpp:3092 src/muuli_wdr.cpp:3447
+#: src/muuli_wdr.cpp:2644 src/muuli_wdr.cpp:3096 src/muuli_wdr.cpp:3451
 msgid "Connect"
 msgstr ""
 
@@ -726,7 +726,7 @@ msgstr ""
 msgid "Launch Command: "
 msgstr ""
 
-#: src/amuleDlg.cpp:1632 src/muuli_wdr.cpp:1982 src/Preferences.cpp:979
+#: src/amuleDlg.cpp:1632 src/muuli_wdr.cpp:1986 src/Preferences.cpp:979
 msgid "- default -"
 msgstr ""
 
@@ -740,60 +740,60 @@ msgstr ""
 msgid "WARNING: Unable to open skin file '%s' for read"
 msgstr ""
 
-#: src/amuleDlg.cpp:1791 src/muuli_wdr.cpp:3449
+#: src/amuleDlg.cpp:1814 src/muuli_wdr.cpp:3453
 msgid "Networks Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1797 src/muuli_wdr.cpp:3450
+#: src/amuleDlg.cpp:1820 src/muuli_wdr.cpp:3454
 msgid "Searches Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1803 src/muuli_wdr.cpp:3451
+#: src/amuleDlg.cpp:1826 src/muuli_wdr.cpp:3455
 msgid "Downloads Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1809 src/muuli_wdr.cpp:3453
+#: src/amuleDlg.cpp:1832 src/muuli_wdr.cpp:3457
 msgid "Shared Files Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1815 src/muuli_wdr.cpp:3454
+#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3458
 msgid "Messages Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1821 src/muuli_wdr.cpp:3455
+#: src/amuleDlg.cpp:1844 src/muuli_wdr.cpp:3459
 msgid "Statistics Graph Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1828 src/muuli_wdr.cpp:3457
+#: src/amuleDlg.cpp:1851 src/muuli_wdr.cpp:3461
 msgid "Preferences Settings Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1831 src/muuli_wdr.cpp:3458
+#: src/amuleDlg.cpp:1854 src/muuli_wdr.cpp:3462
 msgid "Import"
 msgstr ""
 
-#: src/amuleDlg.cpp:1835 src/muuli_wdr.cpp:3458
+#: src/amuleDlg.cpp:1858 src/muuli_wdr.cpp:3462
 msgid "The partfile importer tool"
 msgstr ""
 
-#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3459
+#: src/amuleDlg.cpp:1861 src/muuli_wdr.cpp:3463
 #: src/utils/aLinkCreator/src/alcframe.cpp:262
 msgid "About"
 msgstr ""
 
-#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3459
+#: src/amuleDlg.cpp:1861 src/muuli_wdr.cpp:3463
 msgid "About/Help"
 msgstr ""
 
-#: src/amuleDlg.cpp:2036
+#: src/amuleDlg.cpp:2059
 msgid "eD2k network"
 msgstr ""
 
-#: src/amuleDlg.cpp:2039
+#: src/amuleDlg.cpp:2062
 msgid "Kad network"
 msgstr ""
 
-#: src/amuleDlg.cpp:2039
+#: src/amuleDlg.cpp:2062
 msgid "No network"
 msgstr ""
 
@@ -1320,19 +1320,19 @@ msgstr ""
 msgid "Very low"
 msgstr ""
 
-#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:743 src/muuli_wdr.cpp:2313
+#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:743 src/muuli_wdr.cpp:2317
 #: src/ServerListCtrl.cpp:263 src/ServerListCtrl.cpp:456
 #: src/SharedFilesCtrl.cpp:145
 msgid "Low"
 msgstr ""
 
-#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:744 src/muuli_wdr.cpp:2314
+#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:744 src/muuli_wdr.cpp:2318
 #: src/ServerListCtrl.cpp:266 src/ServerListCtrl.cpp:457
 #: src/SharedFilesCtrl.cpp:146
 msgid "Normal"
 msgstr ""
 
-#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:745 src/muuli_wdr.cpp:2315
+#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:745 src/muuli_wdr.cpp:2319
 #: src/ServerListCtrl.cpp:269 src/ServerListCtrl.cpp:458
 #: src/SharedFilesCtrl.cpp:147
 msgid "High"
@@ -1424,7 +1424,7 @@ msgstr ""
 msgid "Remote Server"
 msgstr ""
 
-#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3212
+#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3216
 #: src/SearchDlg.cpp:119 src/TextClient.cpp:911
 msgid "Kad"
 msgstr ""
@@ -1495,7 +1495,7 @@ msgstr ""
 msgid "Size"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3279
+#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3283
 msgid "Transferred"
 msgstr ""
 
@@ -1551,7 +1551,7 @@ msgid ""
 "\n"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:746 src/muuli_wdr.cpp:2316
+#: src/DownloadListCtrl.cpp:746 src/muuli_wdr.cpp:2320
 #: src/SharedFilesCtrl.cpp:150
 msgid "Auto"
 msgstr ""
@@ -1589,7 +1589,7 @@ msgid "Extended Options"
 msgstr ""
 
 #: src/DownloadListCtrl.cpp:770 src/DownloadListCtrl.cpp:822
-#: src/muuli_wdr.cpp:1800
+#: src/muuli_wdr.cpp:1804
 msgid "Preview"
 msgstr ""
 
@@ -2355,23 +2355,23 @@ msgid ""
 "want downloads on a different (e.g. larger) disk."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:549 src/FirstRunWizard.cpp:611 src/muuli_wdr.cpp:1712
+#: src/FirstRunWizard.cpp:549 src/FirstRunWizard.cpp:611 src/muuli_wdr.cpp:1716
 msgid "Destination folder for downloads"
 msgstr ""
 
 #: src/FirstRunWizard.cpp:553 src/FirstRunWizard.cpp:569 src/muuli_wdr.cpp:1349
-#: src/muuli_wdr.cpp:1366 src/muuli_wdr.cpp:1687 src/muuli_wdr.cpp:1718
-#: src/muuli_wdr.cpp:1730 src/muuli_wdr.cpp:2800
+#: src/muuli_wdr.cpp:1366 src/muuli_wdr.cpp:1691 src/muuli_wdr.cpp:1722
+#: src/muuli_wdr.cpp:1734 src/muuli_wdr.cpp:2804
 #: src/utils/aLinkCreator/src/alcframe.cpp:135
 #: src/utils/wxCas/src/wxcasprefs.cpp:52 src/utils/wxCas/src/wxcasprefs.cpp:118
 msgid "Browse"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:559 src/muuli_wdr.cpp:1723
+#: src/FirstRunWizard.cpp:559 src/muuli_wdr.cpp:1727
 msgid "(All files in this folder are shared with other peers)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:565 src/FirstRunWizard.cpp:624 src/muuli_wdr.cpp:1725
+#: src/FirstRunWizard.cpp:565 src/FirstRunWizard.cpp:624 src/muuli_wdr.cpp:1729
 msgid "Folder for temporary download files"
 msgstr ""
 
@@ -2402,7 +2402,7 @@ msgstr ""
 msgid "CRITICAL - no client on StartChatSession"
 msgstr ""
 
-#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2706 src/muuli_wdr.cpp:3383
+#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2710 src/muuli_wdr.cpp:3387
 msgid "Friends"
 msgstr ""
 
@@ -2508,8 +2508,8 @@ msgstr ""
 msgid "No"
 msgstr ""
 
-#: src/GenericClientListCtrl.cpp:1216 src/PrefsUnifiedDlg.cpp:2898
-#: src/PrefsUnifiedDlg.cpp:2948 src/ServerListCtrl.cpp:276
+#: src/GenericClientListCtrl.cpp:1216 src/PrefsUnifiedDlg.cpp:2907
+#: src/PrefsUnifiedDlg.cpp:2957 src/ServerListCtrl.cpp:276
 msgid "Yes"
 msgstr ""
 
@@ -2676,10 +2676,10 @@ msgstr ""
 msgid "Please fill all fields required"
 msgstr ""
 
-#: src/KadDlg.cpp:192 src/PartFile.cpp:1031 src/PrefsUnifiedDlg.cpp:1134
-#: src/PrefsUnifiedDlg.cpp:1204 src/PrefsUnifiedDlg.cpp:1405
-#: src/PrefsUnifiedDlg.cpp:1663 src/PrefsUnifiedDlg.cpp:1673
-#: src/PrefsUnifiedDlg.cpp:1690 src/PrefsUnifiedDlg.cpp:1738
+#: src/KadDlg.cpp:192 src/PartFile.cpp:1031 src/PrefsUnifiedDlg.cpp:1143
+#: src/PrefsUnifiedDlg.cpp:1213 src/PrefsUnifiedDlg.cpp:1414
+#: src/PrefsUnifiedDlg.cpp:1672 src/PrefsUnifiedDlg.cpp:1682
+#: src/PrefsUnifiedDlg.cpp:1699 src/PrefsUnifiedDlg.cpp:1747
 msgid "Message"
 msgstr ""
 
@@ -2780,7 +2780,7 @@ msgstr ""
 msgid "Uploaded"
 msgstr ""
 
-#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3263
+#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3267
 msgid "Requested"
 msgstr ""
 
@@ -2903,7 +2903,7 @@ msgid "WARNING: "
 msgstr ""
 
 #: src/MuleNotebook.cpp:179 src/muuli_wdr.cpp:817 src/muuli_wdr.cpp:1229
-#: src/muuli_wdr.cpp:3167 src/muuli_wdr.cpp:3423
+#: src/muuli_wdr.cpp:3171 src/muuli_wdr.cpp:3427
 msgid "Close"
 msgstr ""
 
@@ -2921,7 +2921,7 @@ msgid "Paste"
 msgstr ""
 
 #: src/MuleTextCtrl.cpp:89 src/muuli_wdr.cpp:358 src/muuli_wdr.cpp:757
-#: src/muuli_wdr.cpp:2390 src/muuli_wdr.cpp:2409 src/muuli_wdr.cpp:2431
+#: src/muuli_wdr.cpp:2394 src/muuli_wdr.cpp:2413 src/muuli_wdr.cpp:2435
 #: src/utils/aLinkCreator/src/alcframe.cpp:142
 msgid "Clear"
 msgstr ""
@@ -3013,7 +3013,7 @@ msgstr ""
 
 #: src/MuleTrayIcon.cpp:579 src/MuleTrayIcon.cpp:945 src/MuleTrayIcon.cpp:965
 #: src/muuli_wdr.cpp:1398 src/muuli_wdr.cpp:1406 src/muuli_wdr.cpp:1413
-#: src/muuli_wdr.cpp:1846 src/muuli_wdr.cpp:1852 src/OtherFunctions.cpp:91
+#: src/muuli_wdr.cpp:1850 src/muuli_wdr.cpp:1856 src/OtherFunctions.cpp:91
 #: src/StatisticsDlg.cpp:93 src/StatisticsDlg.cpp:95
 msgid "kB/s"
 msgstr ""
@@ -3253,7 +3253,7 @@ msgstr ""
 msgid "KB"
 msgstr ""
 
-#: src/muuli_wdr.cpp:274 src/muuli_wdr.cpp:293 src/muuli_wdr.cpp:1631
+#: src/muuli_wdr.cpp:274 src/muuli_wdr.cpp:293 src/muuli_wdr.cpp:1635
 #: src/OtherFunctions.cpp:64
 msgid "MB"
 msgstr ""
@@ -3270,7 +3270,7 @@ msgstr ""
 msgid "Availability"
 msgstr ""
 
-#: src/muuli_wdr.cpp:312 src/muuli_wdr.cpp:398 src/muuli_wdr.cpp:3328
+#: src/muuli_wdr.cpp:312 src/muuli_wdr.cpp:398 src/muuli_wdr.cpp:3332
 msgid "Filter:"
 msgstr ""
 
@@ -3333,8 +3333,8 @@ msgstr ""
 #: src/muuli_wdr.cpp:1160 src/muuli_wdr.cpp:1167 src/muuli_wdr.cpp:1172
 #: src/muuli_wdr.cpp:1179 src/muuli_wdr.cpp:1184 src/muuli_wdr.cpp:1191
 #: src/muuli_wdr.cpp:1205 src/muuli_wdr.cpp:1212 src/muuli_wdr.cpp:1217
-#: src/muuli_wdr.cpp:1224 src/muuli_wdr.cpp:3265 src/muuli_wdr.cpp:3273
-#: src/muuli_wdr.cpp:3281
+#: src/muuli_wdr.cpp:1224 src/muuli_wdr.cpp:3269 src/muuli_wdr.cpp:3277
+#: src/muuli_wdr.cpp:3285
 msgid "N/A"
 msgstr ""
 
@@ -3474,7 +3474,7 @@ msgstr ""
 msgid "Album :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:685 src/muuli_wdr.cpp:2285
+#: src/muuli_wdr.cpp:685 src/muuli_wdr.cpp:2289
 msgid "Title :"
 msgstr ""
 
@@ -3580,7 +3580,7 @@ msgstr ""
 msgid "Userhash :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:895 src/muuli_wdr.cpp:1752 src/muuli_wdr.cpp:2480
+#: src/muuli_wdr.cpp:895 src/muuli_wdr.cpp:1756 src/muuli_wdr.cpp:2484
 #: src/utils/aLinkCreator/src/alcframe.cpp:137
 msgid "Add"
 msgstr ""
@@ -3589,15 +3589,15 @@ msgstr ""
 msgid "Download-Speed"
 msgstr ""
 
-#: src/muuli_wdr.cpp:954 src/muuli_wdr.cpp:989 src/muuli_wdr.cpp:2584
+#: src/muuli_wdr.cpp:954 src/muuli_wdr.cpp:989 src/muuli_wdr.cpp:2588
 msgid "Current"
 msgstr ""
 
-#: src/muuli_wdr.cpp:962 src/muuli_wdr.cpp:997 src/muuli_wdr.cpp:2592
+#: src/muuli_wdr.cpp:962 src/muuli_wdr.cpp:997 src/muuli_wdr.cpp:2596
 msgid "Running average"
 msgstr ""
 
-#: src/muuli_wdr.cpp:970 src/muuli_wdr.cpp:1005 src/muuli_wdr.cpp:2600
+#: src/muuli_wdr.cpp:970 src/muuli_wdr.cpp:1005 src/muuli_wdr.cpp:2604
 msgid "Session average"
 msgstr ""
 
@@ -3609,7 +3609,7 @@ msgstr ""
 msgid "Connections"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1024 src/muuli_wdr.cpp:1871
+#: src/muuli_wdr.cpp:1024 src/muuli_wdr.cpp:1875
 msgid "Active downloads"
 msgstr ""
 
@@ -3617,7 +3617,7 @@ msgstr ""
 msgid "Active connections (1:1)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1040 src/muuli_wdr.cpp:1872
+#: src/muuli_wdr.cpp:1040 src/muuli_wdr.cpp:1876
 msgid "Active uploads"
 msgstr ""
 
@@ -3890,7 +3890,7 @@ msgstr ""
 msgid "Advanced users only: If you have multiple network interfaces, enter the address of the interface to which aMule should be bound."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1462 src/muuli_wdr.cpp:2065
+#: src/muuli_wdr.cpp:1462 src/muuli_wdr.cpp:2069
 msgid "Bind to network interface (empty for any):"
 msgstr ""
 
@@ -3906,7 +3906,7 @@ msgstr ""
 msgid "Max simultaneous connections:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1498 src/muuli_wdr.cpp:3207
+#: src/muuli_wdr.cpp:1498 src/muuli_wdr.cpp:3211
 msgid "ED2K"
 msgstr ""
 
@@ -3998,763 +3998,763 @@ msgstr ""
 msgid "For new files preallocates disk space for the whole file, thus reduces fragmentation"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1617
+#: src/muuli_wdr.cpp:1621
 msgid "Create new files as sparse files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1618
+#: src/muuli_wdr.cpp:1622
 msgid "Sparse part files only occupy disk space for the parts already downloaded, so free space is used up gradually as the file fills in. Turn this off to use an ordinary file instead - useful where sparse files are unsupported or slow, or where backup/de-duplication tools handle them badly. Applies only when the core runs on Windows; on Linux and macOS part files are sparse anyway and this setting has no effect."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1623
+#: src/muuli_wdr.cpp:1627
 msgid "Stop downloads when free disk space reaches "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1624
+#: src/muuli_wdr.cpp:1628
 msgid "Select this if you want aMule to check your disk space"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1628
+#: src/muuli_wdr.cpp:1632
 msgid "Enter here the min disk space desired."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1634
+#: src/muuli_wdr.cpp:1638
 msgid "Save 10 sources on rare files (< 20 sources)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1638 src/Statistics.cpp:790
+#: src/muuli_wdr.cpp:1642 src/Statistics.cpp:790
 msgid "Uploads"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1641
+#: src/muuli_wdr.cpp:1645
 msgid "Add new shared files with auto priority"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1647
+#: src/muuli_wdr.cpp:1651
 msgid "Intelligent Corruption Handling (I.C.H.)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1650
+#: src/muuli_wdr.cpp:1654
 msgid "Enable"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1653
+#: src/muuli_wdr.cpp:1657
 msgid "Advanced I.C.H. trusts every hash (not recommended)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1665 src/PrefsUnifiedDlg.cpp:1990
+#: src/muuli_wdr.cpp:1669 src/PrefsUnifiedDlg.cpp:1999
 msgid "Media metadata extraction"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1669
+#: src/muuli_wdr.cpp:1673
 msgid "Extract length / bitrate / codec from shared audio and video files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1671
+#: src/muuli_wdr.cpp:1675
 msgid "When enabled, aMule runs ffprobe on each shared media file to fill in the Length / Bitrate / Codec columns other clients see when they find the file in a search. Requires ffmpeg (the ffprobe binary) to be installed."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1678
+#: src/muuli_wdr.cpp:1682
 msgid "Path to ffprobe:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1683
+#: src/muuli_wdr.cpp:1687
 msgid "Full path to the ffprobe binary. Leave empty to have aMule auto-detect it on startup."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1691
+#: src/muuli_wdr.cpp:1695
 msgid "Detect"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1692
+#: src/muuli_wdr.cpp:1696
 msgid "Search the standard install locations for an ffprobe binary and fill the path field."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1716
+#: src/muuli_wdr.cpp:1720
 msgid ""
 "Completed downloads are stored here. All files in this folder are automatically shared with other peers.\n"
 "If this folder also holds files you don't want to share, point it at an aMule-only sub-folder."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1719
+#: src/muuli_wdr.cpp:1723
 msgid "Pick the folder where completed downloads will be stored. All files in that folder will be shared with other peers."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1733
+#: src/muuli_wdr.cpp:1737
 msgid "Shared folders"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1739
+#: src/muuli_wdr.cpp:1743
 msgid "(Folders shared by the core. Enter a path to add one.)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1747
+#: src/muuli_wdr.cpp:1751
 msgid "Absolute path of a folder on the core's machine, e.g. /home/user/shared"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1749 src/PrefsUnifiedDlg.cpp:2874
+#: src/muuli_wdr.cpp:1753 src/PrefsUnifiedDlg.cpp:2883
 msgid "Recursive"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1750
+#: src/muuli_wdr.cpp:1754
 msgid "Share every sub-folder underneath this one, including ones created later."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1754 src/utils/aLinkCreator/src/alcframe.cpp:141
+#: src/muuli_wdr.cpp:1758 src/utils/aLinkCreator/src/alcframe.cpp:141
 msgid "Remove"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1758
+#: src/muuli_wdr.cpp:1762
 msgid "(Right click on folder icon for recursive share)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1765
+#: src/muuli_wdr.cpp:1769
 msgid "Share hidden files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1771
+#: src/muuli_wdr.cpp:1775
 msgid "Automatically rescan shared folders for changes"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1777
+#: src/muuli_wdr.cpp:1781
 msgid "Follow symbolic links in shared folders"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1783
+#: src/muuli_wdr.cpp:1787
 msgid "Exclude files matching:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1786
+#: src/muuli_wdr.cpp:1790
 msgid "Wildcard patterns separated by '|', e.g. .DS_Store|Thumbs.db|*.tmp. Files whose name matches are not shared. Matching is case-insensitive."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1790
+#: src/muuli_wdr.cpp:1794
 msgid "Patterns are regular expressions"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1791
+#: src/muuli_wdr.cpp:1795
 msgid "When set, the whole field is one regular expression ('|' is alternation). When unset, it is a list of '|'-separated wildcards."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1801
+#: src/muuli_wdr.cpp:1805
 msgid "Show how many shared files the current pattern would exclude."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1822
+#: src/muuli_wdr.cpp:1826
 msgid "Graphs"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1825 src/muuli_wdr.cpp:1887
+#: src/muuli_wdr.cpp:1829 src/muuli_wdr.cpp:1891
 msgid "Update delay : 5 secs"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1829
+#: src/muuli_wdr.cpp:1833
 msgid "Time for average graph: 100 mins"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1833
+#: src/muuli_wdr.cpp:1837
 msgid "Connections Graph Scale: 100 "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1840
+#: src/muuli_wdr.cpp:1844
 msgid "Download graph scale:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1848
+#: src/muuli_wdr.cpp:1852
 msgid "Upload graph scale:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1858
+#: src/muuli_wdr.cpp:1862
 msgid "Colors: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1862
+#: src/muuli_wdr.cpp:1866
 msgid "Background"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1863
+#: src/muuli_wdr.cpp:1867
 msgid "Grid"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1864
+#: src/muuli_wdr.cpp:1868
 msgid "Download current"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1865
+#: src/muuli_wdr.cpp:1869
 msgid "Download running average"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1866
+#: src/muuli_wdr.cpp:1870
 msgid "Download session average"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1867
+#: src/muuli_wdr.cpp:1871
 msgid "Upload current"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1868
+#: src/muuli_wdr.cpp:1872
 msgid "Upload running average"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1869
+#: src/muuli_wdr.cpp:1873
 msgid "Upload session average"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1870
+#: src/muuli_wdr.cpp:1874
 msgid "Active connections"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1873
+#: src/muuli_wdr.cpp:1877
 msgid "Systray Icon Speed Bar"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1874
+#: src/muuli_wdr.cpp:1878
 msgid "Kad-nodes current"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1875
+#: src/muuli_wdr.cpp:1879
 msgid "Kad-nodes running"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1876
+#: src/muuli_wdr.cpp:1880
 msgid "Kad-nodes session"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1880 src/muuli_wdr.cpp:2334
+#: src/muuli_wdr.cpp:1884 src/muuli_wdr.cpp:2338
 msgid "Select"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1884
+#: src/muuli_wdr.cpp:1888
 msgid "Tree"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1894
+#: src/muuli_wdr.cpp:1898
 msgid "Number of Client Versions shown (0=unlimited)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1919
+#: src/muuli_wdr.cpp:1923
 msgid "!!! WARNING !!!"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1934
+#: src/muuli_wdr.cpp:1938
 msgid "Max new connections / 5 secs"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1936
+#: src/muuli_wdr.cpp:1940
 msgid "Concurrent Kad source lookups"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1938
+#: src/muuli_wdr.cpp:1942
 msgid "Kad source re-search interval (minutes)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1940
+#: src/muuli_wdr.cpp:1944
 msgid "Source re-ask interval (minutes)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1944
+#: src/muuli_wdr.cpp:1948
 msgid "File Buffer Size: 240000 bytes"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1948
+#: src/muuli_wdr.cpp:1952
 msgid "Use MMAP: memory-mapped file access (lower memory use)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1949
+#: src/muuli_wdr.cpp:1953
 msgid "Maps part files into memory instead of buffering them on the heap, lowering the process memory footprint. May reduce download speed on some disks; best for memory-constrained or upload-heavy hosts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1951
+#: src/muuli_wdr.cpp:1955
 msgid "Upload Queue Size: 5000 clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1955
+#: src/muuli_wdr.cpp:1959
 msgid "Server connection refresh interval: Disable"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1959
+#: src/muuli_wdr.cpp:1963
 msgid "Disable computer's timed standby mode"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1978
+#: src/muuli_wdr.cpp:1982
 msgid "Skin to use: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1987
+#: src/muuli_wdr.cpp:1991
 msgid "Show \"Fast eD2k Links Handler\" in every window."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1990
+#: src/muuli_wdr.cpp:1994
 msgid "Show extended info on categories tabs"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1993
+#: src/muuli_wdr.cpp:1997
 msgid "Show application version on title"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1995
+#: src/muuli_wdr.cpp:1999
 msgid "Show transfer rates on title"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1997
+#: src/muuli_wdr.cpp:2001
 msgid "Before application name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1999
+#: src/muuli_wdr.cpp:2003
 msgid "After application name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2002
+#: src/muuli_wdr.cpp:2006
 msgid "Show overhead bandwidth"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2006
+#: src/muuli_wdr.cpp:2010
 msgid "Vertical toolbar orientation"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2008
+#: src/muuli_wdr.cpp:2012
 msgid "Live column sorting (auto-reorder rows as their values change)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2015
+#: src/muuli_wdr.cpp:2019
 msgid "Download Queue Files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2018
+#: src/muuli_wdr.cpp:2022
 msgid "Show progress percentage"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2024
+#: src/muuli_wdr.cpp:2028
 msgid "Show progress bar"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2027
+#: src/muuli_wdr.cpp:2031
 msgid "Flat"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2031
+#: src/muuli_wdr.cpp:2035
 msgid "Round"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2049
+#: src/muuli_wdr.cpp:2053
 msgid "External Connection Parameters"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2052
+#: src/muuli_wdr.cpp:2056
 msgid "Accept external connections"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2059 src/muuli_wdr.cpp:2118
+#: src/muuli_wdr.cpp:2063 src/muuli_wdr.cpp:2122
 msgid "IP of the listening interface:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2062
+#: src/muuli_wdr.cpp:2066
 msgid "Enter here a valid ip in the a.b.c.d format for the listening EC interface. An empty field or 0.0.0.0 will mean any interface."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2083 src/muuli_wdr.cpp:2194
+#: src/muuli_wdr.cpp:2087 src/muuli_wdr.cpp:2198
 msgid "TCP port:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2089
+#: src/muuli_wdr.cpp:2093
 msgid "Enable UPnP port forwarding on the EC port"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2093 src/muuli_wdr.cpp:3079
+#: src/muuli_wdr.cpp:2097 src/muuli_wdr.cpp:3083
 #: src/utils/wxCas/src/wxcasprefs.cpp:167
 msgid "Password"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2099
+#: src/muuli_wdr.cpp:2103
 msgid "aMule API server parameters"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2102
+#: src/muuli_wdr.cpp:2106
 msgid "Run amuleapi (REST API) on startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2107
+#: src/muuli_wdr.cpp:2111
 msgid "HTTP port:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2121
+#: src/muuli_wdr.cpp:2125
 msgid "The interface amuleapi's HTTP server listens on. 127.0.0.1 (default) accepts only local connections; use 0.0.0.0 or a specific IP to expose it to other hosts (set an admin password below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2126
+#: src/muuli_wdr.cpp:2130
 msgid "Type a password to set or change it. Stored passwords cannot be shown, so leaving this empty keeps the current one."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2128
+#: src/muuli_wdr.cpp:2132
 msgid "Admin password"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2140 src/muuli_wdr.cpp:2157 src/PrefsUnifiedDlg.cpp:1103
+#: src/muuli_wdr.cpp:2144 src/muuli_wdr.cpp:2161 src/PrefsUnifiedDlg.cpp:1112
 msgid "A password is set."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2144
+#: src/muuli_wdr.cpp:2148
 msgid "Enable guest access"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2145
+#: src/muuli_wdr.cpp:2149
 msgid "Guest sessions may read status and listings but cannot change anything. Turning this off clears the stored guest password."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2149
+#: src/muuli_wdr.cpp:2153
 msgid "Guest password"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2164
+#: src/muuli_wdr.cpp:2168
 msgid "Web server parameters"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2167
+#: src/muuli_wdr.cpp:2171
 msgid "Run webserver on startup (deprecated)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2173
+#: src/muuli_wdr.cpp:2177
 msgid "Web template"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2178
+#: src/muuli_wdr.cpp:2182
 msgid "Full rights password"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2182
+#: src/muuli_wdr.cpp:2186
 msgid "Enable Low rights User"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2187
+#: src/muuli_wdr.cpp:2191
 msgid "Low rights password"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2201
+#: src/muuli_wdr.cpp:2205
 msgid "Enable UPnP port forwarding of the web server port"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2206
+#: src/muuli_wdr.cpp:2210
 msgid "Web server UPnP TCP port (Optional)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2214
+#: src/muuli_wdr.cpp:2218
 msgid "Page Refresh Time (in secs)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2221
+#: src/muuli_wdr.cpp:2225
 msgid "Enable Gzip compression"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2255
+#: src/muuli_wdr.cpp:2259
 msgid "Reset page to defaults"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2256
+#: src/muuli_wdr.cpp:2260
 msgid "Reset the settings on the current page to their default values."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2258 src/muuli_wdr.cpp:2344 src/ServerWnd.cpp:274
+#: src/muuli_wdr.cpp:2262 src/muuli_wdr.cpp:2348 src/ServerWnd.cpp:274
 #: src/ServerWnd.cpp:282
 msgid "OK"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2260
+#: src/muuli_wdr.cpp:2264
 msgid "Click here to apply any changes made to the preferences."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2263
+#: src/muuli_wdr.cpp:2267
 msgid "Reset any changes made to the preferences."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2292
+#: src/muuli_wdr.cpp:2296
 msgid "Comment :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2299
+#: src/muuli_wdr.cpp:2303
 msgid "Incoming Dir :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2308
+#: src/muuli_wdr.cpp:2312
 msgid "Change priority for new assigned files :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2312
+#: src/muuli_wdr.cpp:2316
 msgid "Don't change"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2324
+#: src/muuli_wdr.cpp:2328
 msgid "Select color for this Category (currently selected) :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2391 src/muuli_wdr.cpp:2410 src/muuli_wdr.cpp:2432
+#: src/muuli_wdr.cpp:2395 src/muuli_wdr.cpp:2414 src/muuli_wdr.cpp:2436
 msgid "Click this button to reset the log."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2451
+#: src/muuli_wdr.cpp:2455
 msgid "Click on this button to update the servers list from URL ..."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2455
+#: src/muuli_wdr.cpp:2459
 msgid "Server list"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2459
+#: src/muuli_wdr.cpp:2463
 msgid "Enter the url to a server.met file here and press the button to the left to update the list of known servers."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2464
+#: src/muuli_wdr.cpp:2468
 msgid "Add server manually: Name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2467
+#: src/muuli_wdr.cpp:2471
 msgid "Enter the name of the new server here"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2469 src/ServerWnd.cpp:206
+#: src/muuli_wdr.cpp:2473 src/ServerWnd.cpp:206
 msgid "IP:Port"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2472
+#: src/muuli_wdr.cpp:2476
 msgid "Enter the IP of the server here, using the x.x.x.x format."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2478
+#: src/muuli_wdr.cpp:2482
 msgid "Enter the port of the server here."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2481
+#: src/muuli_wdr.cpp:2485
 msgid "Add manually a server (fill fields to the left before) ..."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2510
+#: src/muuli_wdr.cpp:2514
 msgid "aMule Log"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2518
+#: src/muuli_wdr.cpp:2522
 msgid "Server Info"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2522
+#: src/muuli_wdr.cpp:2526
 msgid "ED2K Info"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2526
+#: src/muuli_wdr.cpp:2530
 msgid "Kad Info"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2554
+#: src/muuli_wdr.cpp:2558
 msgid "Click on this button to update the nodes list from URL ..."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2558
+#: src/muuli_wdr.cpp:2562
 msgid "Nodes (0)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2562
+#: src/muuli_wdr.cpp:2566
 msgid "Enter the url to a nodes.dat file here and press the button to the left to update the list of known nodes."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2565
+#: src/muuli_wdr.cpp:2569
 msgid "Nodes stats"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2607
+#: src/muuli_wdr.cpp:2611
 msgid "Bootstrap"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2610
+#: src/muuli_wdr.cpp:2614
 msgid "New node"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2615
+#: src/muuli_wdr.cpp:2619
 msgid "IP:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2635
+#: src/muuli_wdr.cpp:2639
 msgid "Port:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2648
+#: src/muuli_wdr.cpp:2652
 msgid "Bootstrap from known clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2650
+#: src/muuli_wdr.cpp:2654
 msgid "Disconnect Kad"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2684
+#: src/muuli_wdr.cpp:2688
 msgid "Use Secure User Identification"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2686
+#: src/muuli_wdr.cpp:2690
 msgid "It is recommended to enable this option. You will not receive credits if SUI is not enabled."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2688
+#: src/muuli_wdr.cpp:2692
 msgid "Protocol Obfuscation"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2691
+#: src/muuli_wdr.cpp:2695
 msgid "Support Protocol Obfuscation"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2693
+#: src/muuli_wdr.cpp:2697
 msgid "This option enabled Protocol Obfuscation, and makes aMule accept obfuscated connections from other clients."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2695
+#: src/muuli_wdr.cpp:2699
 msgid "Use obfuscation for outgoing connections"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2697
+#: src/muuli_wdr.cpp:2701
 msgid "This option makes aMule use Protocol Obfuscation when connecting other clients/servers."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2699
+#: src/muuli_wdr.cpp:2703
 msgid "Accept only obfuscated connections"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2700
+#: src/muuli_wdr.cpp:2704
 msgid "This option makes aMule only accept obfuscated connections. You will have less sources, but all your traffic will be obfuscated"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2705
+#: src/muuli_wdr.cpp:2709
 msgid "Everybody"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2707
+#: src/muuli_wdr.cpp:2711
 msgid "No one"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2709
+#: src/muuli_wdr.cpp:2713
 msgid "Who can see my shared files:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2710
+#: src/muuli_wdr.cpp:2714
 msgid "Select who can request to view a list of your shared files."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2712
+#: src/muuli_wdr.cpp:2716
 msgid "IP-Filtering"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2719
+#: src/muuli_wdr.cpp:2723
 msgid "Filter clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2721
+#: src/muuli_wdr.cpp:2725
 msgid "Enable filtering of the client IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2723
+#: src/muuli_wdr.cpp:2727
 msgid "Filter servers"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2725
+#: src/muuli_wdr.cpp:2729
 msgid "Enable filtering of the server IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2729
+#: src/muuli_wdr.cpp:2733
 msgid "Reload List"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2730
+#: src/muuli_wdr.cpp:2734
 msgid "Reload the list of IPs to filter from the file ~/.aMule/ipfilter.dat"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2736
+#: src/muuli_wdr.cpp:2740
 msgid "URL:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2740 src/muuli_wdr.cpp:2933
+#: src/muuli_wdr.cpp:2744 src/muuli_wdr.cpp:2937
 msgid "Update now"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2743
+#: src/muuli_wdr.cpp:2747
 msgid "Auto-update ipfilter at startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2747
+#: src/muuli_wdr.cpp:2751
 msgid "Filtering Level:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2753
+#: src/muuli_wdr.cpp:2757
 msgid "Always filter LAN IPs"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2756
+#: src/muuli_wdr.cpp:2760
 msgid "Paranoid handling of non-matching IPs"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2758
+#: src/muuli_wdr.cpp:2762
 msgid "Rejects a packet when its source IP differs from the IP the client claims (an anti-spoofing check). Disable only if it causes connection problems."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2760
+#: src/muuli_wdr.cpp:2764
 msgid "Use system-wide ipfilter.dat if available"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2761
+#: src/muuli_wdr.cpp:2765
 msgid "If there's no local ipfilter.dat found, allow usage of a system-wide ipfilter file."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2778
+#: src/muuli_wdr.cpp:2782
 msgid "Enable Online-Signature"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2780
+#: src/muuli_wdr.cpp:2784
 msgid "Enables the writing of the OS file, which can be used by external apps to create signatures and the like."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2784
+#: src/muuli_wdr.cpp:2788
 msgid "Update Frequency (Secs):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2787
+#: src/muuli_wdr.cpp:2791
 msgid "Change the frequency (in seconds) of Online Signature updates."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2795
+#: src/muuli_wdr.cpp:2799
 msgid "Save online signature file in: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:2801
+#: src/muuli_wdr.cpp:2805
 msgid "Click here to select the directory containing the the Online Signature files."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2834
+#: src/muuli_wdr.cpp:2838
 msgid "Show country flags for clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2835
+#: src/muuli_wdr.cpp:2839
 msgid "Render the country flag column in the transfers, queue and search views. Requires a valid MMDB GeoIP database (see below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2840
+#: src/muuli_wdr.cpp:2844
 msgid "Database"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2856
+#: src/muuli_wdr.cpp:2860
 msgid "Source:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2859
+#: src/muuli_wdr.cpp:2863
 msgid "DB-IP (free, no account)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2860
+#: src/muuli_wdr.cpp:2864
 msgid "MaxMind GeoLite2 (free, account required)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2861
+#: src/muuli_wdr.cpp:2865
 msgid "Custom URL"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2864
+#: src/muuli_wdr.cpp:2868
 msgid "Choose which provider supplies the GeoIP MMDB database. DB-IP is the default - no account required. MaxMind requires a free account + license key. Use Custom URL to point at any other MMDB host (e.g. a local mirror)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2881
+#: src/muuli_wdr.cpp:2885
 msgid ""
 "No configuration required.\n"
 "\n"
@@ -4762,11 +4762,11 @@ msgid ""
 "License: Creative Commons BY 4.0 - https://creativecommons.org/licenses/by/4.0/"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2894
+#: src/muuli_wdr.cpp:2898
 msgid "License key:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2900
+#: src/muuli_wdr.cpp:2904
 msgid ""
 "Sign up for a free MaxMind account, then generate a License Key:\n"
 "https://www.maxmind.com/en/geolite2/signup\n"
@@ -4776,222 +4776,222 @@ msgid ""
 "Requires attribution and account registration; refresh at least every 30 days."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2915
+#: src/muuli_wdr.cpp:2919
 msgid "Download URL:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2921
+#: src/muuli_wdr.cpp:2925
 msgid ""
 "Must point to an .mmdb file or a .gz / .tar.gz containing one.\n"
 "URL may include credentials (https://user:pass@host/...).\n"
 "License and attribution terms are set by the upstream URL - you are responsible."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2934
+#: src/muuli_wdr.cpp:2938
 msgid "Download the GeoIP database from the selected source."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2936
+#: src/muuli_wdr.cpp:2940
 msgid "Auto-update on startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2937
+#: src/muuli_wdr.cpp:2941
 msgid "Re-download the GeoIP database from the selected source every time aMule starts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2960
+#: src/muuli_wdr.cpp:2964
 msgid "Filter incoming messages (except current chat):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2962
+#: src/muuli_wdr.cpp:2966
 msgid "Filter all messages"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2964
+#: src/muuli_wdr.cpp:2968
 msgid "Filter messages from people not on your friend list"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2966
+#: src/muuli_wdr.cpp:2970
 msgid "Filter messages from unknown clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2968
+#: src/muuli_wdr.cpp:2972
 msgid "Filter messages containing (use ',' as separator):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2971 src/muuli_wdr.cpp:2982
+#: src/muuli_wdr.cpp:2975 src/muuli_wdr.cpp:2986
 msgid "add here the words amule should filter and block messages including it"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2973
+#: src/muuli_wdr.cpp:2977
 msgid "Show received messages in the log"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2976
+#: src/muuli_wdr.cpp:2980
 msgid "Comments"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2979
+#: src/muuli_wdr.cpp:2983
 msgid "Filter comments containing (use ',' as separator):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3004
+#: src/muuli_wdr.cpp:3008
 msgid "Enable Proxy"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3005
+#: src/muuli_wdr.cpp:3009
 msgid "Enable/disable proxy support"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3008
+#: src/muuli_wdr.cpp:3012
 msgid "Proxy type:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3019
+#: src/muuli_wdr.cpp:3023
 msgid "Proxy host:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3022
+#: src/muuli_wdr.cpp:3026
 msgid "The proxy host name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3024
+#: src/muuli_wdr.cpp:3028
 msgid "Proxy port:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3027
+#: src/muuli_wdr.cpp:3031
 msgid "The proxy port"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3029
+#: src/muuli_wdr.cpp:3033
 msgid "Enable authentication"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3030
+#: src/muuli_wdr.cpp:3034
 msgid "Enable/disable username/password authentication"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3033
+#: src/muuli_wdr.cpp:3037
 msgid "Username: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:3036
+#: src/muuli_wdr.cpp:3040
 msgid "The username to use to connect to the proxy"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3038
+#: src/muuli_wdr.cpp:3042
 msgid "Password:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3041
+#: src/muuli_wdr.cpp:3045
 msgid "The password to use to connect to the proxy"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3060
+#: src/muuli_wdr.cpp:3064
 msgid "Connect to:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3069
+#: src/muuli_wdr.cpp:3073
 msgid "Login to remote amule"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3074
+#: src/muuli_wdr.cpp:3078
 msgid "User name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3085
+#: src/muuli_wdr.cpp:3089
 msgid "Remember those settings"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3088
+#: src/muuli_wdr.cpp:3092
 msgid "Force ZLIB compression"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3112
+#: src/muuli_wdr.cpp:3116
 msgid "Enable Verbose Debug-Logging."
 msgstr ""
 
-#: src/muuli_wdr.cpp:3114
+#: src/muuli_wdr.cpp:3118
 msgid "Only to Logfile"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3116
+#: src/muuli_wdr.cpp:3120
 msgid "Message Categories:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3140 src/PartFileConvertDlg.cpp:160
+#: src/muuli_wdr.cpp:3144 src/PartFileConvertDlg.cpp:160
 msgid "Waiting..."
 msgstr ""
 
-#: src/muuli_wdr.cpp:3160
+#: src/muuli_wdr.cpp:3164
 msgid "Add imports"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3163
+#: src/muuli_wdr.cpp:3167
 msgid "Retry selected"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3165
+#: src/muuli_wdr.cpp:3169
 msgid "Remove selected"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3228
+#: src/muuli_wdr.cpp:3232
 msgid "Event Types"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3247
+#: src/muuli_wdr.cpp:3251
 msgid "Statistics and queued clients for selected file(s) : Session / All time"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3271
+#: src/muuli_wdr.cpp:3275
 msgid "Active Uploads"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3285
+#: src/muuli_wdr.cpp:3289
 msgid "Percent of total files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3337
+#: src/muuli_wdr.cpp:3341
 msgid "Show Clients for"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3339
+#: src/muuli_wdr.cpp:3343
 msgid "All files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3342
+#: src/muuli_wdr.cpp:3346
 msgid "Selected files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3345
+#: src/muuli_wdr.cpp:3349
 msgid "Active uploads only"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3352
+#: src/muuli_wdr.cpp:3356
 msgid "Reload:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3356
+#: src/muuli_wdr.cpp:3360
 msgid "Reload your shared files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3419
+#: src/muuli_wdr.cpp:3423
 msgid "Send"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3420
+#: src/muuli_wdr.cpp:3424
 msgid "Sends the specified message."
 msgstr ""
 
-#: src/muuli_wdr.cpp:3424
+#: src/muuli_wdr.cpp:3428
 msgid "Close this chat-session."
 msgstr ""
 
-#: src/muuli_wdr.cpp:3447
+#: src/muuli_wdr.cpp:3451
 msgid "Connect to any server and/or Kad"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3453 src/SharedFilesCtrl.cpp:142 src/Statistics.cpp:941
+#: src/muuli_wdr.cpp:3457 src/SharedFilesCtrl.cpp:142 src/Statistics.cpp:941
 msgid "Shared Files"
 msgstr ""
 
@@ -5615,400 +5615,400 @@ msgid ""
 "these settings."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:647
+#: src/PrefsUnifiedDlg.cpp:656
 #, c-format
 msgid "Failed to connect Cfg to widget with the ID %d and key %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:695
+#: src/PrefsUnifiedDlg.cpp:704
 #, c-format
 msgid "Failed to transfer data from Cfg to Widget with the ID %d and key %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:801
+#: src/PrefsUnifiedDlg.cpp:810
 msgid "The type of proxy you are connecting to"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1020
+#: src/PrefsUnifiedDlg.cpp:1029
 #, c-format
 msgid "Failed to transfer data from Widget to Cfg with the ID %d and key %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1103
+#: src/PrefsUnifiedDlg.cpp:1112
 msgid "No password set."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1132
+#: src/PrefsUnifiedDlg.cpp:1141
 msgid "Guest access needs a password. Type one in the guest password field, or untick Enable guest access."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1144
+#: src/PrefsUnifiedDlg.cpp:1153
 msgid ""
 "aMule must be restarted to enable these changes:\n"
 "\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1151
+#: src/PrefsUnifiedDlg.cpp:1160
 msgid "- TCP port changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1156
+#: src/PrefsUnifiedDlg.cpp:1165
 msgid "- UDP port changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1161
+#: src/PrefsUnifiedDlg.cpp:1170
 msgid "- Network interface binding changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1166
+#: src/PrefsUnifiedDlg.cpp:1175
 msgid "- External connect port changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1170
+#: src/PrefsUnifiedDlg.cpp:1179
 msgid "- External connect acceptance changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1174
+#: src/PrefsUnifiedDlg.cpp:1183
 msgid "- External connect interface changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1178
+#: src/PrefsUnifiedDlg.cpp:1187
 msgid "- Protocol obfuscation support changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1193
+#: src/PrefsUnifiedDlg.cpp:1202
 msgid "- amuleapi settings changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1202
+#: src/PrefsUnifiedDlg.cpp:1211
 msgid ""
 "Your Auto-update server list is empty.\n"
 "'Auto-update server list at startup' will be disabled."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1213
+#: src/PrefsUnifiedDlg.cpp:1222
 msgid ""
 "You have enabled external connections but have not specified a password.\n"
 "External connections cannot be enabled unless a valid password is specified."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1246
+#: src/PrefsUnifiedDlg.cpp:1255
 #, c-format
 msgid "The amuleapi password could not be saved: %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1276
+#: src/PrefsUnifiedDlg.cpp:1285
 msgid "- Language changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1281
+#: src/PrefsUnifiedDlg.cpp:1290
 msgid "- Temp folder changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1286
+#: src/PrefsUnifiedDlg.cpp:1295
 msgid "- ED2K network enabled.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1319
+#: src/PrefsUnifiedDlg.cpp:1328
 msgid "The shared-file exclusion pattern is not a valid regular expression. The filter has been left disabled."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1321 src/PrefsUnifiedDlg.cpp:1921
+#: src/PrefsUnifiedDlg.cpp:1330 src/PrefsUnifiedDlg.cpp:1930
 msgid "Invalid regular expression"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1398
+#: src/PrefsUnifiedDlg.cpp:1407
 msgid ""
 "Both eD2k and Kad network are disabled.\n"
 "You won't be able to connect until you enable at least one of them."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1403
+#: src/PrefsUnifiedDlg.cpp:1412
 msgid ""
 "Kad will not start if your UDP port is disabled.\n"
 "Enable UDP port or disable Kad."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1459
+#: src/PrefsUnifiedDlg.cpp:1468
 msgid ""
 "\n"
 "You MUST restart aMule now.\n"
 "If you do not restart now, don't complain if anything bad happens.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1524
+#: src/PrefsUnifiedDlg.cpp:1533
 msgid "Could not register aMule for autostart at login. The autostart store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1526
+#: src/PrefsUnifiedDlg.cpp:1535
 msgid "Could not remove the autostart-at-login entry."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1527
+#: src/PrefsUnifiedDlg.cpp:1536
 msgid "Autostart"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1542
+#: src/PrefsUnifiedDlg.cpp:1551
 msgid "Register file type"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1542
+#: src/PrefsUnifiedDlg.cpp:1551
 msgid "Register URL handler"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1550
+#: src/PrefsUnifiedDlg.cpp:1559
 #, c-format
 msgid "aMule only handles eD2k-compatible magnets. If you replace the current magnet handler (%s), BitTorrent magnet links will stop working - aMule cannot download BitTorrent content. Continue?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1555
+#: src/PrefsUnifiedDlg.cpp:1564
 #, c-format
 msgid "Another application currently opens .emulecollection files (%s). Replace it with aMule?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1560
+#: src/PrefsUnifiedDlg.cpp:1569
 #, c-format
 msgid "Another application is currently the default handler for these links (%s). Replace it with aMule?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1585
+#: src/PrefsUnifiedDlg.cpp:1594
 msgid "Could not register aMule for .emulecollection files. The registration store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1587
+#: src/PrefsUnifiedDlg.cpp:1596
 msgid "Could not remove the file type registration."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1589
+#: src/PrefsUnifiedDlg.cpp:1598
 msgid "Could not register aMule as the URL handler. The registration store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1591
+#: src/PrefsUnifiedDlg.cpp:1600
 msgid "Could not remove the URL handler registration."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1661 src/PrefsUnifiedDlg.cpp:1688
+#: src/PrefsUnifiedDlg.cpp:1670 src/PrefsUnifiedDlg.cpp:1697
 msgid "The web server and aMule API require external connections to be enabled."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1671
+#: src/PrefsUnifiedDlg.cpp:1680
 msgid "The aMule web server is deprecated. Consider running the aMule API instead."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1735
+#: src/PrefsUnifiedDlg.cpp:1744
 msgid ""
 "Your Auto-update servers list is in blank.\n"
 "Please fill in at least one URL to point to a valid server.met file.\n"
 "Click on the button \"List\" by this checkbox to enter an URL."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1876
+#: src/PrefsUnifiedDlg.cpp:1885
 msgid "Temporary files"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1881
+#: src/PrefsUnifiedDlg.cpp:1890
 msgid "Incoming files"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1886
+#: src/PrefsUnifiedDlg.cpp:1895
 msgid "Online Signatures"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1899
+#: src/PrefsUnifiedDlg.cpp:1908
 #, c-format
 msgid "Choose a folder for %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1923
+#: src/PrefsUnifiedDlg.cpp:1932
 #, c-format
 msgid "Would exclude %u of %u shared file"
 msgid_plural "Would exclude %u of %u shared files"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/PrefsUnifiedDlg.cpp:1940
+#: src/PrefsUnifiedDlg.cpp:1949
 msgid "Browse for videoplayer"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1944
+#: src/PrefsUnifiedDlg.cpp:1953
 msgid "Select browser"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1948
+#: src/PrefsUnifiedDlg.cpp:1957
 msgid "Select ffprobe binary"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1954
+#: src/PrefsUnifiedDlg.cpp:1963
 #, c-format
 msgid "Executable%s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1988
+#: src/PrefsUnifiedDlg.cpp:1997
 msgid "ffprobe not found on PATH or in the standard install locations. Install ffmpeg (which ships ffprobe) or use Browse to pick a binary manually."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2000
+#: src/PrefsUnifiedDlg.cpp:2009
 msgid "Reset the settings on this page to their default values?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2001
+#: src/PrefsUnifiedDlg.cpp:2010
 msgid "Reset to defaults"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2028
+#: src/PrefsUnifiedDlg.cpp:2037
 msgid "Edit server list"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2029
+#: src/PrefsUnifiedDlg.cpp:2038
 msgid ""
 "Add here URL's to download server.met files.\n"
 "Only one url on each line."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2084
+#: src/PrefsUnifiedDlg.cpp:2093
 msgid "IP2Country update failed"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2229 src/PrefsUnifiedDlg.cpp:2260
+#: src/PrefsUnifiedDlg.cpp:2238 src/PrefsUnifiedDlg.cpp:2269
 msgid "Data by MaxMind GeoLite2"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2231 src/PrefsUnifiedDlg.cpp:2262
+#: src/PrefsUnifiedDlg.cpp:2240 src/PrefsUnifiedDlg.cpp:2271
 msgid "Custom source"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2233 src/PrefsUnifiedDlg.cpp:2264
+#: src/PrefsUnifiedDlg.cpp:2242 src/PrefsUnifiedDlg.cpp:2273
 msgid "Data by DB-IP.com"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2284
+#: src/PrefsUnifiedDlg.cpp:2293
 #, c-format
 msgid "Status: Loaded%s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2286
+#: src/PrefsUnifiedDlg.cpp:2295
 #, c-format
 msgid "Status: Loaded%s - %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2290
+#: src/PrefsUnifiedDlg.cpp:2299
 msgid "Status: Failed to load - click 'Update now' to refresh."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2292
+#: src/PrefsUnifiedDlg.cpp:2301
 msgid "Status: Not found - click 'Update now' to download."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2350 src/PrefsUnifiedDlg.cpp:2374
+#: src/PrefsUnifiedDlg.cpp:2359 src/PrefsUnifiedDlg.cpp:2383
 #, c-format
 msgid "Update delay: %d second"
 msgid_plural "Update delay: %d seconds"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/PrefsUnifiedDlg.cpp:2358
+#: src/PrefsUnifiedDlg.cpp:2367
 #, c-format
 msgid "Time for average graph: %d minute"
 msgid_plural "Time for average graph: %d minutes"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/PrefsUnifiedDlg.cpp:2367
+#: src/PrefsUnifiedDlg.cpp:2376
 #, c-format
 msgid "Connections Graph Scale: %d"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2382
+#: src/PrefsUnifiedDlg.cpp:2391
 #, c-format
 msgid "File Buffer Size: %d byte"
 msgid_plural "File Buffer Size: %d bytes"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/PrefsUnifiedDlg.cpp:2392
+#: src/PrefsUnifiedDlg.cpp:2401
 #, c-format
 msgid "Upload Queue Size: %d client"
 msgid_plural "Upload Queue Size: %d clients"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/PrefsUnifiedDlg.cpp:2402
+#: src/PrefsUnifiedDlg.cpp:2411
 #, c-format
 msgid "Server connection refresh interval: %d minute"
 msgid_plural "Server connection refresh interval: %d minutes"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/PrefsUnifiedDlg.cpp:2407
+#: src/PrefsUnifiedDlg.cpp:2416
 msgid "Server connection refresh interval: Disabled"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2451
+#: src/PrefsUnifiedDlg.cpp:2460
 msgid "disabled"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2477
+#: src/PrefsUnifiedDlg.cpp:2486
 #, c-format
 msgid "Execute command on '%s' event"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2484
+#: src/PrefsUnifiedDlg.cpp:2493
 msgid "Enable command execution on core"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2496
+#: src/PrefsUnifiedDlg.cpp:2505
 msgid "Core command:"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2512
+#: src/PrefsUnifiedDlg.cpp:2521
 msgid "Enable command execution on GUI"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2524
+#: src/PrefsUnifiedDlg.cpp:2533
 msgid "GUI command:"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2540
+#: src/PrefsUnifiedDlg.cpp:2549
 msgid "The following variables will be replaced:"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2708
+#: src/PrefsUnifiedDlg.cpp:2717
 msgid ""
 "The following folders look like system or sensitive locations:\n"
 "\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2713
+#: src/PrefsUnifiedDlg.cpp:2722
 msgid "Sharing them recursively will publish every file underneath on the eD2k/Kad networks. Do you really want to do this?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2716
+#: src/PrefsUnifiedDlg.cpp:2725
 msgid "Confirm shared folders"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2744
+#: src/PrefsUnifiedDlg.cpp:2753
 msgid "Reloading shared files..."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2745
+#: src/PrefsUnifiedDlg.cpp:2754
 msgid "Scanning for subdirectories..."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2746
+#: src/PrefsUnifiedDlg.cpp:2755
 msgid "Updating shared folders"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2773
+#: src/PrefsUnifiedDlg.cpp:2782
 #, c-format
 msgid "Scanned %u directories..."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2823
+#: src/PrefsUnifiedDlg.cpp:2832
 #, c-format
 msgid "Reloading shared files: %u files scanned"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2873
+#: src/PrefsUnifiedDlg.cpp:2882
 msgid "Shared folder"
 msgstr ""
 
@@ -7636,12 +7636,12 @@ msgstr ""
 msgid "Hashset requested for unknown file: %s"
 msgstr ""
 
-#: src/UploadQueue.cpp:618
+#: src/UploadQueue.cpp:627
 #, c-format
 msgid "Resuming uploads of file: %s"
 msgstr ""
 
-#: src/UploadQueue.cpp:634
+#: src/UploadQueue.cpp:643
 #, c-format
 msgid "Suspending upload of file: %s"
 msgstr ""

--- a/po/amule.pot
+++ b/po/amule.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-28 12:12+0200\n"
+"POT-Creation-Date: 2026-07-28 08:06+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -132,7 +132,7 @@ msgstr ""
 msgid "Not now"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:422 src/amuleDlg.cpp:665
+#: src/AppImageIntegration.cpp:422 src/amuleDlg.cpp:600
 msgid "Don't ask again"
 msgstr ""
 
@@ -189,152 +189,152 @@ msgstr ""
 msgid "WARNING: You can't add yourself as a source for an eD2k link while having a lowid."
 msgstr ""
 
-#: src/amule.cpp:301
+#: src/amule.cpp:300
 msgid "Now, exiting main app..."
 msgstr ""
 
-#: src/amule.cpp:331
+#: src/amule.cpp:330
 #, c-format
 msgid "Terminating amuleweb instance with pid '%d' ... "
 msgstr ""
 
-#: src/amule.cpp:335
+#: src/amule.cpp:334
 #, c-format
 msgid "Killing amuleweb instance with pid '%d' ... "
 msgstr ""
 
-#: src/amule.cpp:337 src/amule.cpp:350 src/ClientRef.cpp:180
-#: src/SearchDlg.cpp:1041 src/ServerListCtrl.cpp:98
+#: src/amule.cpp:336 src/amule.cpp:349 src/ClientRef.cpp:180
+#: src/SearchDlg.cpp:880 src/ServerListCtrl.cpp:98
 msgid "Failed"
 msgstr ""
 
-#: src/amule.cpp:344
+#: src/amule.cpp:343
 #, c-format
 msgid "Terminating amuleapi instance with pid '%d' ... "
 msgstr ""
 
-#: src/amule.cpp:348
+#: src/amule.cpp:347
 #, c-format
 msgid "Killing amuleapi instance with pid '%d' ... "
 msgstr ""
 
-#: src/amule.cpp:356
+#: src/amule.cpp:355
 msgid "aMule OnExit: Terminating core."
 msgstr ""
 
-#: src/amule.cpp:467
+#: src/amule.cpp:466
 msgid "aMule shutdown completed."
 msgstr ""
 
-#: src/amule.cpp:471
+#: src/amule.cpp:470
 msgid "Memory debug results for aMule exit:"
 msgstr ""
 
-#: src/amule.cpp:652
+#: src/amule.cpp:651
 #, c-format
 msgid "Binding aMule's peer-to-peer traffic to interface: %s (HTTP updates use the default route)"
 msgstr ""
 
-#: src/amule.cpp:656
+#: src/amule.cpp:655
 #, c-format
 msgid "Binding all network traffic to interface: %s"
 msgstr ""
 
-#: src/amule.cpp:660
+#: src/amule.cpp:659
 #, c-format
 msgid "WARNING: configured network interface '%s' was not found - traffic is NOT bound to it and may leave via the default route. Check the interface name in Preferences."
 msgstr ""
 
-#: src/amule.cpp:666
+#: src/amule.cpp:665
 #, c-format
 msgid "WARNING: binding to network interface '%s' requires elevated privileges and was NOT applied - traffic may leave via the default route. Grant the capability (e.g. 'sudo setcap cap_net_raw+ep' on the aMule binary) or run with sufficient privileges."
 msgstr ""
 
-#: src/amule.cpp:674
+#: src/amule.cpp:673
 #, c-format
 msgid "WARNING: could not bind to network interface '%s' - traffic may leave via the default route."
 msgstr ""
 
-#: src/amule.cpp:733
+#: src/amule.cpp:732
 msgid "Your locale has been changed to System Default due to a configuration change. Sorry."
 msgstr ""
 
-#: src/amule.cpp:735 src/amule.cpp:1589 src/CatDialog.cpp:128
+#: src/amule.cpp:734 src/amule.cpp:1581 src/CatDialog.cpp:128
 #: src/CatDialog.cpp:136 src/CatDialog.cpp:149 src/ServerList.cpp:366
 #: src/ServerListCtrl.cpp:152
 msgid "Info"
 msgstr ""
 
-#: src/amule.cpp:742
+#: src/amule.cpp:741
 msgid ""
 "\n"
 "EC configuration"
 msgstr ""
 
-#: src/amule.cpp:745
+#: src/amule.cpp:744
 msgid "Password set and external connections enabled."
 msgstr ""
 
-#: src/amule.cpp:755 src/KadDlg.cpp:176 src/KadDlg.cpp:185
-#: src/PrefsUnifiedDlg.cpp:1461 src/SharedFilesCtrl.cpp:476
+#: src/amule.cpp:754 src/KadDlg.cpp:176 src/KadDlg.cpp:185
+#: src/PrefsUnifiedDlg.cpp:1387 src/SharedFilesCtrl.cpp:476
 msgid "WARNING"
 msgstr ""
 
-#: src/amule.cpp:992
+#: src/amule.cpp:991
 msgid "Network bootstrap"
 msgstr ""
 
-#: src/amule.cpp:997
+#: src/amule.cpp:996
 msgid ""
 "aMule has detected missing network bootstrap files.\n"
 "Select which ones to download:"
 msgstr ""
 
-#: src/amule.cpp:1006 src/FirstRunWizard.cpp:411
+#: src/amule.cpp:1005 src/FirstRunWizard.cpp:411
 msgid "eD2k server list (server.met)"
 msgstr ""
 
-#: src/amule.cpp:1013 src/FirstRunWizard.cpp:416
+#: src/amule.cpp:1012 src/FirstRunWizard.cpp:416
 msgid "Kad bootstrap nodes (nodes.dat)"
 msgstr ""
 
-#: src/amule.cpp:1103
+#: src/amule.cpp:1102
 #, c-format
 msgid "web server running on pid %d"
 msgstr ""
 
-#: src/amule.cpp:1116
+#: src/amule.cpp:1115
 msgid "You requested to run web server on startup, but the amuleweb binary cannot be run. Please install the package containing aMule web server, or build aMule from source with -DBUILD_WEBSERVER=YES and install it."
 msgstr ""
 
-#: src/amule.cpp:1121 src/amule.cpp:1185 src/amule.cpp:1299 src/amule.cpp:1601
+#: src/amule.cpp:1120 src/amule.cpp:1177 src/amule.cpp:1291 src/amule.cpp:1593
 #: src/amule-remote-gui.cpp:603 src/amule-remote-gui.cpp:671
 #: src/amule-remote-gui.cpp:709 src/amule-remote-gui.cpp:1282
 #: src/amule-remote-gui.cpp:1345 src/amule-remote-gui.cpp:1372
-#: src/DownloadQueue.cpp:1481 src/PrefsUnifiedDlg.cpp:1247
+#: src/DownloadQueue.cpp:1481
 msgid "ERROR"
 msgstr ""
 
-#: src/amule.cpp:1174
+#: src/amule.cpp:1166
 #, c-format
 msgid "amuleapi running on pid %d"
 msgstr ""
 
-#: src/amule.cpp:1180
+#: src/amule.cpp:1172
 msgid "You requested to run amuleapi on startup, but the amuleapi binary cannot be run. Please install the package containing aMule's REST API server, or build aMule from source with -DBUILD_AMULEAPI=YES and install it."
 msgstr ""
 
-#: src/amule.cpp:1267
+#: src/amule.cpp:1259
 #, c-format
 msgid "Could not bind ports to the specified address: %s"
 msgstr ""
 
-#: src/amule.cpp:1291
+#: src/amule.cpp:1283
 #, c-format
 msgid "Port %u is not available. You will be LOWID\n"
 msgstr ""
 
-#: src/amule.cpp:1296
+#: src/amule.cpp:1288
 #, c-format
 msgid ""
 "Port %u is not available!\n"
@@ -344,184 +344,184 @@ msgid ""
 "Check your network to make sure the port is open for output and input."
 msgstr ""
 
-#: src/amule.cpp:1393
+#: src/amule.cpp:1385
 msgid "Failed to create OnlineSig File"
 msgstr ""
 
-#: src/amule.cpp:1401
+#: src/amule.cpp:1393
 msgid "Failed to create aMule OnlineSig File"
 msgstr ""
 
-#: src/amule.cpp:1564
+#: src/amule.cpp:1556
 msgid "The selected locale seems not to be installed on your box. (Note: I'll try to set it anyway)"
 msgstr ""
 
-#: src/amule.cpp:1574
+#: src/amule.cpp:1566
 #, c-format
 msgid "This is the first time you run aMule %s"
 msgstr ""
 
-#: src/amule.cpp:1577
+#: src/amule.cpp:1569
 msgid "This version is a testing version, updated daily, and\n"
 msgstr ""
 
-#: src/amule.cpp:1578
+#: src/amule.cpp:1570
 msgid "we give no warranty it won't break anything, burn your house,\n"
 msgstr ""
 
-#: src/amule.cpp:1579
+#: src/amule.cpp:1571
 msgid "or kill your dog. But it *should* be safe to use anyway.\n"
 msgstr ""
 
-#: src/amule.cpp:1584
+#: src/amule.cpp:1576
 msgid "More information, support and new releases can found at our homepage,\n"
 msgstr ""
 
-#: src/amule.cpp:1585
+#: src/amule.cpp:1577
 msgid "at https://amule-org.github.io, or in our IRC channel #aMule at irc.libera.chat.\n"
 msgstr ""
 
-#: src/amule.cpp:1587
+#: src/amule.cpp:1579
 msgid "Feel free to report any bugs to https://github.com/amule-org/amule/issues"
 msgstr ""
 
-#: src/amule.cpp:1599
+#: src/amule.cpp:1591
 msgid ""
 "The folder for Online Signature files you specified is INVALID!\n"
 " OnlineSignature will be DISABLED until you fix it on preferences."
 msgstr ""
 
-#: src/amule.cpp:1662
+#: src/amule.cpp:1654
 msgid "Server hostname notified"
 msgstr ""
 
-#: src/amule.cpp:2039
+#: src/amule.cpp:2031
 #, c-format
 msgid "Disk space preallocation for file '%s' failed: %s"
 msgstr ""
 
-#: src/amule.cpp:2168
+#: src/amule.cpp:2160
 msgid "ERROR: can't open logfile"
 msgstr ""
 
-#: src/amule.cpp:2172
+#: src/amule.cpp:2164
 msgid "WARNING: logfile is empty. Something is wrong."
 msgstr ""
 
-#: src/amule.cpp:2189
+#: src/amule.cpp:2181
 msgid "Log has been reset"
 msgstr ""
 
-#: src/amule.cpp:2213
+#: src/amule.cpp:2205
 #, c-format
 msgid "ServerMessage: %s"
 msgstr ""
 
-#: src/amule.cpp:2256 src/IP2Country.cpp:220 src/IPFilter.cpp:514
+#: src/amule.cpp:2248 src/IP2Country.cpp:220 src/IPFilter.cpp:514
 #: src/ServerList.cpp:875
 #, c-format
 msgid "Skipped download of %s, because requested file is not newer."
 msgstr ""
 
-#: src/amule.cpp:2259
+#: src/amule.cpp:2251
 msgid "Failed to download the nodes list."
 msgstr ""
 
-#: src/amule.cpp:2322
+#: src/amule.cpp:2314
 msgid "Failed to open the downloaded version check file"
 msgstr ""
 
-#: src/amule.cpp:2325 src/amule.cpp:2344
+#: src/amule.cpp:2317 src/amule.cpp:2336
 msgid "Corrupted version check file"
 msgstr ""
 
-#: src/amule.cpp:2367
+#: src/amule.cpp:2359
 msgid "You are using an outdated version of aMule!"
 msgstr ""
 
-#: src/amule.cpp:2369
+#: src/amule.cpp:2361
 #, c-format
 msgid "Your aMule version is %i.%i.%i and the latest version is %li.%li.%li"
 msgstr ""
 
-#: src/amule.cpp:2373
+#: src/amule.cpp:2365
 msgid "The latest version can always be found at https://github.com/amule-org/amule/releases/latest"
 msgstr ""
 
-#: src/amule.cpp:2376
+#: src/amule.cpp:2368
 #, c-format
 msgid "WARNING: Your aMuled version is outdated: %i.%i.%i < %li.%li.%li"
 msgstr ""
 
-#: src/amule.cpp:2382
+#: src/amule.cpp:2374
 msgid "Your copy of aMule is up to date."
 msgstr ""
 
-#: src/amule.cpp:2389
+#: src/amule.cpp:2381
 msgid "Failed to download the version check file"
 msgstr ""
 
-#: src/amule.cpp:2558 src/amule-remote-gui.cpp:1133
+#: src/amule.cpp:2550 src/amule-remote-gui.cpp:1133
 #, c-format
 msgid "Users: %s | Files: %s"
 msgstr ""
 
-#: src/amule.cpp:2559 src/amule-remote-gui.cpp:1134
+#: src/amule.cpp:2551 src/amule-remote-gui.cpp:1134
 #, c-format
 msgid "Users: E: %s K: %s | Files: E: %s K: %s"
 msgstr ""
 
-#: src/amule.cpp:2573 src/amule-remote-gui.cpp:1147
+#: src/amule.cpp:2565 src/amule-remote-gui.cpp:1147
 msgid "No networks selected"
 msgstr ""
 
-#: src/amule.cpp:2641 src/TextClient.cpp:903
+#: src/amule.cpp:2633 src/TextClient.cpp:903
 msgid "with LowID"
 msgstr ""
 
-#: src/amule.cpp:2641 src/TextClient.cpp:904
+#: src/amule.cpp:2633 src/TextClient.cpp:904
 msgid "with HighID"
 msgstr ""
 
-#: src/amule.cpp:2643
+#: src/amule.cpp:2635
 #, c-format
 msgid "Connected to %s %s"
 msgstr ""
 
-#: src/amule.cpp:2648
+#: src/amule.cpp:2640
 #, c-format
 msgid "Connecting to %s"
 msgstr ""
 
-#: src/amule.cpp:2650
+#: src/amule.cpp:2642
 msgid "Disconnected from eD2k"
 msgstr ""
 
-#: src/amule.cpp:2659
+#: src/amule.cpp:2651
 msgid "Kad started."
 msgstr ""
 
-#: src/amule.cpp:2661
+#: src/amule.cpp:2653
 msgid "Kad stopped."
 msgstr ""
 
-#: src/amule.cpp:2669
+#: src/amule.cpp:2661
 msgid "Connected to Kad (ok)"
 msgstr ""
 
-#: src/amule.cpp:2671
+#: src/amule.cpp:2663
 msgid "Connected to Kad (firewalled)"
 msgstr ""
 
-#: src/amule.cpp:2675
+#: src/amule.cpp:2667
 msgid "Disconnected from Kad"
 msgstr ""
 
-#: src/amule.cpp:2707
+#: src/amule.cpp:2699
 msgid "Kad network cannot be used if UDP port is disabled on preferences, not starting."
 msgstr ""
 
-#: src/amule.cpp:2711
+#: src/amule.cpp:2703
 msgid "Kad network disabled on preferences, not connecting."
 msgstr ""
 
@@ -546,67 +546,29 @@ msgstr ""
 msgid "ERROR: %s"
 msgstr ""
 
-#: src/amuleDlg.cpp:250
+#: src/amuleDlg.cpp:236
 #, c-format
 msgid "This is aMule %s based on eMule."
 msgstr ""
 
-#: src/amuleDlg.cpp:251
+#: src/amuleDlg.cpp:237
 #, c-format
 msgid "Running on %s"
 msgstr ""
 
-#: src/amuleDlg.cpp:253
+#: src/amuleDlg.cpp:239
 msgid "Visit https://github.com/amule-org/amule/releases/latest to check if a new version is available."
 msgstr ""
 
-#: src/amuleDlg.cpp:282
+#: src/amuleDlg.cpp:268
 msgid "FATAL ERROR: Failed to create Timer"
 msgstr ""
 
-#: src/amuleDlg.cpp:361 src/amuleDlg.cpp:1810 src/amuleDlg.cpp:2056
-#: src/muuli_wdr.cpp:1492 src/muuli_wdr.cpp:3439
-msgid "Networks"
-msgstr ""
-
-#: src/amuleDlg.cpp:362 src/amuleDlg.cpp:1816 src/muuli_wdr.cpp:3440
-msgid "Searches"
-msgstr ""
-
-#: src/amuleDlg.cpp:363 src/amuleDlg.cpp:1822 src/DownloadListCtrl.cpp:740
-#: src/muuli_wdr.cpp:392 src/muuli_wdr.cpp:1585 src/muuli_wdr.cpp:3441
-#: src/Statistics.cpp:829
-msgid "Downloads"
-msgstr ""
-
-#: src/amuleDlg.cpp:364 src/amuleDlg.cpp:1828 src/muuli_wdr.cpp:3315
-msgid "Shared files"
-msgstr ""
-
-#: src/amuleDlg.cpp:365 src/amuleDlg.cpp:1834 src/muuli_wdr.cpp:2947
-#: src/muuli_wdr.cpp:3397 src/muuli_wdr.cpp:3444
-msgid "Messages"
-msgstr ""
-
-#: src/amuleDlg.cpp:366 src/amuleDlg.cpp:1840 src/muuli_wdr.cpp:3445
-#: src/PrefsUnifiedDlg.cpp:314 src/Statistics.cpp:779 src/Statistics.cpp:1235
-msgid "Statistics"
-msgstr ""
-
-#: src/amuleDlg.cpp:368 src/amuleDlg.cpp:1847 src/muuli_wdr.cpp:3447
-#: src/PrefsUnifiedDlg.cpp:330 src/utils/wxCas/src/wxcasprefs.cpp:39
-msgid "Preferences"
-msgstr ""
-
-#: src/amuleDlg.cpp:371
-msgid "Navigate"
-msgstr ""
-
-#: src/amuleDlg.cpp:657
+#: src/amuleDlg.cpp:592
 msgid "New version available"
 msgstr ""
 
-#: src/amuleDlg.cpp:661
+#: src/amuleDlg.cpp:596
 #, c-format
 msgid ""
 "A new version of aMule (%s) is available.\n"
@@ -616,184 +578,217 @@ msgid ""
 "Would you like to open the download page?"
 msgstr ""
 
-#: src/amuleDlg.cpp:743
+#: src/amuleDlg.cpp:678
 msgid "aMule dialog destroyed"
 msgstr ""
 
-#: src/amuleDlg.cpp:766 src/DataToText.cpp:68 src/IPFilter.cpp:547
+#: src/amuleDlg.cpp:701 src/DataToText.cpp:68 src/IPFilter.cpp:547
 msgid "Connecting"
 msgstr ""
 
-#: src/amuleDlg.cpp:958
+#: src/amuleDlg.cpp:893
 msgid "eD2k: Connecting"
 msgstr ""
 
-#: src/amuleDlg.cpp:962
+#: src/amuleDlg.cpp:897
 msgid "eD2k: Disconnected"
 msgstr ""
 
-#: src/amuleDlg.cpp:968
+#: src/amuleDlg.cpp:903
 msgid "Kad: Firewalled"
 msgstr ""
 
-#: src/amuleDlg.cpp:972
+#: src/amuleDlg.cpp:907
 msgid "Kad: Connected"
 msgstr ""
 
-#: src/amuleDlg.cpp:977
+#: src/amuleDlg.cpp:912
 msgid "Kad: Connecting"
 msgstr ""
 
-#: src/amuleDlg.cpp:981
+#: src/amuleDlg.cpp:916
 msgid "Kad: Off"
 msgstr ""
 
-#: src/amuleDlg.cpp:1029 src/DownloadListCtrl.cpp:505
+#: src/amuleDlg.cpp:964 src/DownloadListCtrl.cpp:505
 #: src/DownloadListCtrl.cpp:749 src/FriendListCtrl.cpp:180
 #: src/muuli_wdr.cpp:731 src/muuli_wdr.cpp:782 src/muuli_wdr.cpp:846
-#: src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2252 src/muuli_wdr.cpp:2337
-#: src/muuli_wdr.cpp:3085 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
+#: src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2224 src/muuli_wdr.cpp:2309
+#: src/muuli_wdr.cpp:3057 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
 #: src/ServerListCtrl.cpp:606 src/TransferWnd.cpp:378
 #: src/utils/wxCas/src/wxcasprefs.cpp:235
 msgid "Cancel"
 msgstr ""
 
-#: src/amuleDlg.cpp:1030
+#: src/amuleDlg.cpp:965
 msgid "Stop the current connection attempts"
 msgstr ""
 
-#: src/amuleDlg.cpp:1035 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976
-#: src/muuli_wdr.cpp:2475
+#: src/amuleDlg.cpp:970 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976
+#: src/muuli_wdr.cpp:2447
 msgid "Disconnect"
 msgstr ""
 
-#: src/amuleDlg.cpp:1036
+#: src/amuleDlg.cpp:971
 msgid "Disconnect from the currently connected networks"
 msgstr ""
 
-#: src/amuleDlg.cpp:1041 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979
-#: src/muuli_wdr.cpp:2630 src/muuli_wdr.cpp:3082 src/muuli_wdr.cpp:3437
+#: src/amuleDlg.cpp:976 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979
+#: src/muuli_wdr.cpp:2602 src/muuli_wdr.cpp:3054 src/muuli_wdr.cpp:3409
 msgid "Connect"
 msgstr ""
 
-#: src/amuleDlg.cpp:1042
+#: src/amuleDlg.cpp:977
 msgid "Connect to the currently enabled networks"
 msgstr ""
 
-#: src/amuleDlg.cpp:1154
+#: src/amuleDlg.cpp:1089
 #, c-format
 msgid "Up: %.1f%s (%.1f) | Down: %.1f%s (%.1f)"
 msgstr ""
 
-#: src/amuleDlg.cpp:1156 src/amuleDlg.cpp:1158 src/amuleDlg.cpp:1162
-#: src/amuleDlg.cpp:1164 src/amuleDlg.cpp:1175 src/amuleDlg.cpp:1177
+#: src/amuleDlg.cpp:1091 src/amuleDlg.cpp:1093 src/amuleDlg.cpp:1097
+#: src/amuleDlg.cpp:1099 src/amuleDlg.cpp:1110 src/amuleDlg.cpp:1112
 #: src/MuleTrayIcon.cpp:796 src/MuleTrayIcon.cpp:799
 msgid " MB/s"
 msgstr ""
 
-#: src/amuleDlg.cpp:1156 src/amuleDlg.cpp:1158 src/amuleDlg.cpp:1162
-#: src/amuleDlg.cpp:1164 src/amuleDlg.cpp:1175 src/amuleDlg.cpp:1177
+#: src/amuleDlg.cpp:1091 src/amuleDlg.cpp:1093 src/amuleDlg.cpp:1097
+#: src/amuleDlg.cpp:1099 src/amuleDlg.cpp:1110 src/amuleDlg.cpp:1112
 #: src/MuleTrayIcon.cpp:796 src/MuleTrayIcon.cpp:799
 #: src/utils/wxCas/src/wxcasframe.cpp:1041
 msgid " kB/s"
 msgstr ""
 
-#: src/amuleDlg.cpp:1161
+#: src/amuleDlg.cpp:1096
 #, c-format
 msgid "Up: %.1f%s | Down: %.1f%s"
 msgstr ""
 
-#: src/amuleDlg.cpp:1193
+#: src/amuleDlg.cpp:1128
 #, c-format
 msgid "aMule (%s | Connected)"
 msgstr ""
 
-#: src/amuleDlg.cpp:1195
+#: src/amuleDlg.cpp:1130
 #, c-format
 msgid "aMule (%s | Disconnected)"
 msgstr ""
 
-#: src/amuleDlg.cpp:1248
+#: src/amuleDlg.cpp:1183
 #, c-format
 msgid "Do you really want to exit %s?"
 msgstr ""
 
-#: src/amuleDlg.cpp:1250
+#: src/amuleDlg.cpp:1185
 msgid "Exit confirmation"
 msgstr ""
 
-#: src/amuleDlg.cpp:1613
+#: src/amuleDlg.cpp:1548
 msgid "Launch Command: "
 msgstr ""
 
-#: src/amuleDlg.cpp:1632 src/muuli_wdr.cpp:1972 src/Preferences.cpp:979
+#: src/amuleDlg.cpp:1567 src/muuli_wdr.cpp:1971 src/Preferences.cpp:951
 msgid "- default -"
 msgstr ""
 
-#: src/amuleDlg.cpp:1660
+#: src/amuleDlg.cpp:1595
 #, c-format
 msgid "Skin directory '%s' does not exist"
 msgstr ""
 
-#: src/amuleDlg.cpp:1663
+#: src/amuleDlg.cpp:1598
 #, c-format
 msgid "WARNING: Unable to open skin file '%s' for read"
 msgstr ""
 
-#: src/amuleDlg.cpp:1814 src/muuli_wdr.cpp:3439
+#: src/amuleDlg.cpp:1722 src/amuleDlg.cpp:1968 src/muuli_wdr.cpp:1485
+#: src/muuli_wdr.cpp:3411
+msgid "Networks"
+msgstr ""
+
+#: src/amuleDlg.cpp:1726 src/muuli_wdr.cpp:3411
 msgid "Networks Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1820 src/muuli_wdr.cpp:3440
+#: src/amuleDlg.cpp:1728 src/muuli_wdr.cpp:3412
+msgid "Searches"
+msgstr ""
+
+#: src/amuleDlg.cpp:1732 src/muuli_wdr.cpp:3412
 msgid "Searches Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1826 src/muuli_wdr.cpp:3441
+#: src/amuleDlg.cpp:1734 src/DownloadListCtrl.cpp:740 src/muuli_wdr.cpp:392
+#: src/muuli_wdr.cpp:1578 src/muuli_wdr.cpp:3413 src/Statistics.cpp:829
+msgid "Downloads"
+msgstr ""
+
+#: src/amuleDlg.cpp:1738 src/muuli_wdr.cpp:3413
 msgid "Downloads Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1832 src/muuli_wdr.cpp:3443
+#: src/amuleDlg.cpp:1740 src/muuli_wdr.cpp:3287
+msgid "Shared files"
+msgstr ""
+
+#: src/amuleDlg.cpp:1744 src/muuli_wdr.cpp:3415
 msgid "Shared Files Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3444
+#: src/amuleDlg.cpp:1746 src/muuli_wdr.cpp:2919 src/muuli_wdr.cpp:3369
+#: src/muuli_wdr.cpp:3416
+msgid "Messages"
+msgstr ""
+
+#: src/amuleDlg.cpp:1750 src/muuli_wdr.cpp:3416
 msgid "Messages Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1844 src/muuli_wdr.cpp:3445
+#: src/amuleDlg.cpp:1752 src/muuli_wdr.cpp:3417 src/PrefsUnifiedDlg.cpp:312
+#: src/Statistics.cpp:779 src/Statistics.cpp:1235
+msgid "Statistics"
+msgstr ""
+
+#: src/amuleDlg.cpp:1756 src/muuli_wdr.cpp:3417
 msgid "Statistics Graph Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1851 src/muuli_wdr.cpp:3447
+#: src/amuleDlg.cpp:1759 src/muuli_wdr.cpp:3419 src/PrefsUnifiedDlg.cpp:328
+#: src/utils/wxCas/src/wxcasprefs.cpp:39
+msgid "Preferences"
+msgstr ""
+
+#: src/amuleDlg.cpp:1763 src/muuli_wdr.cpp:3419
 msgid "Preferences Settings Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1854 src/muuli_wdr.cpp:3448
+#: src/amuleDlg.cpp:1766 src/muuli_wdr.cpp:3420
 msgid "Import"
 msgstr ""
 
-#: src/amuleDlg.cpp:1858 src/muuli_wdr.cpp:3448
+#: src/amuleDlg.cpp:1770 src/muuli_wdr.cpp:3420
 msgid "The partfile importer tool"
 msgstr ""
 
-#: src/amuleDlg.cpp:1861 src/muuli_wdr.cpp:3449
+#: src/amuleDlg.cpp:1773 src/muuli_wdr.cpp:3421
 #: src/utils/aLinkCreator/src/alcframe.cpp:262
 msgid "About"
 msgstr ""
 
-#: src/amuleDlg.cpp:1861 src/muuli_wdr.cpp:3449
+#: src/amuleDlg.cpp:1773 src/muuli_wdr.cpp:3421
 msgid "About/Help"
 msgstr ""
 
-#: src/amuleDlg.cpp:2059
+#: src/amuleDlg.cpp:1971
 msgid "eD2k network"
 msgstr ""
 
-#: src/amuleDlg.cpp:2062
+#: src/amuleDlg.cpp:1974
 msgid "Kad network"
 msgstr ""
 
-#: src/amuleDlg.cpp:2062
+#: src/amuleDlg.cpp:1974
 msgid "No network"
 msgstr ""
 
@@ -918,7 +913,7 @@ msgstr ""
 msgid "The core rejected these shared folders:%s"
 msgstr ""
 
-#: src/amule-remote-gui.cpp:1336 src/ExternalConn.cpp:2346
+#: src/amule-remote-gui.cpp:1336 src/ExternalConn.cpp:2345
 msgid "Invalid link or already on list."
 msgstr ""
 
@@ -934,7 +929,7 @@ msgstr ""
 #: src/ClientDetailDialog.cpp:123 src/DataToText.cpp:61 src/DataToText.cpp:86
 #: src/DataToText.cpp:101 src/DataToText.cpp:136 src/DataToText.cpp:165
 #: src/DownloadListCtrl.cpp:1172 src/DownloadListCtrl.cpp:1185
-#: src/DownloadListCtrl.cpp:1196 src/ExternalConn.cpp:609
+#: src/DownloadListCtrl.cpp:1196 src/ExternalConn.cpp:608
 #: src/FileDetailDialog.cpp:203 src/FileDetailDialog.cpp:235
 #: src/FileDetailDialog.cpp:242 src/GenericClientListCtrl.cpp:1171
 #: src/GenericClientListCtrl.cpp:1182 src/GenericClientListCtrl.cpp:1192
@@ -1320,19 +1315,19 @@ msgstr ""
 msgid "Very low"
 msgstr ""
 
-#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:743 src/muuli_wdr.cpp:2303
+#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:743 src/muuli_wdr.cpp:2275
 #: src/ServerListCtrl.cpp:263 src/ServerListCtrl.cpp:456
 #: src/SharedFilesCtrl.cpp:145
 msgid "Low"
 msgstr ""
 
-#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:744 src/muuli_wdr.cpp:2304
+#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:744 src/muuli_wdr.cpp:2276
 #: src/ServerListCtrl.cpp:266 src/ServerListCtrl.cpp:457
 #: src/SharedFilesCtrl.cpp:146
 msgid "Normal"
 msgstr ""
 
-#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:745 src/muuli_wdr.cpp:2305
+#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:745 src/muuli_wdr.cpp:2277
 #: src/ServerListCtrl.cpp:269 src/ServerListCtrl.cpp:458
 #: src/SharedFilesCtrl.cpp:147
 msgid "High"
@@ -1424,8 +1419,8 @@ msgstr ""
 msgid "Remote Server"
 msgstr ""
 
-#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3202
-#: src/SearchDlg.cpp:119 src/TextClient.cpp:911
+#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3174
+#: src/SearchDlg.cpp:111 src/TextClient.cpp:911
 msgid "Kad"
 msgstr ""
 
@@ -1495,7 +1490,7 @@ msgstr ""
 msgid "Size"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3269
+#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3241
 msgid "Transferred"
 msgstr ""
 
@@ -1551,7 +1546,7 @@ msgid ""
 "\n"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:746 src/muuli_wdr.cpp:2306
+#: src/DownloadListCtrl.cpp:746 src/muuli_wdr.cpp:2278
 #: src/SharedFilesCtrl.cpp:150
 msgid "Auto"
 msgstr ""
@@ -1589,7 +1584,7 @@ msgid "Extended Options"
 msgstr ""
 
 #: src/DownloadListCtrl.cpp:770 src/DownloadListCtrl.cpp:822
-#: src/muuli_wdr.cpp:1790
+#: src/muuli_wdr.cpp:1789
 msgid "Preview"
 msgstr ""
 
@@ -1762,230 +1757,225 @@ msgstr[1] ""
 msgid "Invalid eD2k link! ERROR: %s"
 msgstr ""
 
-#: src/ExternalConn.cpp:380
+#: src/ExternalConn.cpp:379
 msgid "Client sent packet after authentication failed."
 msgstr ""
 
-#: src/ExternalConn.cpp:397
+#: src/ExternalConn.cpp:396
 msgid "External connection closed."
 msgstr ""
 
-#: src/ExternalConn.cpp:474
+#: src/ExternalConn.cpp:473
 msgid "External connections disabled due to empty password!"
 msgstr ""
 
-#: src/ExternalConn.cpp:495
+#: src/ExternalConn.cpp:494
 msgid "External connections disabled in config file"
 msgstr ""
 
-#: src/ExternalConn.cpp:576
+#: src/ExternalConn.cpp:575
 msgid "New external connection accepted"
 msgstr ""
 
-#: src/ExternalConn.cpp:579
+#: src/ExternalConn.cpp:578
 msgid "ERROR: couldn't accept a new external connection"
 msgstr ""
 
-#: src/ExternalConn.cpp:596
+#: src/ExternalConn.cpp:595
 msgid "External connection refused due to empty password in preferences!"
 msgstr ""
 
-#: src/ExternalConn.cpp:608
+#: src/ExternalConn.cpp:607
 #, c-format
 msgid "Connecting client: %s %s"
 msgstr ""
 
-#: src/ExternalConn.cpp:610
+#: src/ExternalConn.cpp:609
 msgid "Unknown version"
 msgstr ""
 
-#: src/ExternalConn.cpp:623
+#: src/ExternalConn.cpp:622
 msgid "Incorrect EC version ID, there might be binary incompatibility. Use core and remote from same snapshot."
 msgstr ""
 
-#: src/ExternalConn.cpp:631
+#: src/ExternalConn.cpp:630
 msgid "You cannot connect to a release version from an arbitrary development snapshot! *sigh* possible crash prevented"
 msgstr ""
 
-#: src/ExternalConn.cpp:714
+#: src/ExternalConn.cpp:713
 msgid "Invalid protocol version."
 msgstr ""
 
-#: src/ExternalConn.cpp:720
+#: src/ExternalConn.cpp:719
 msgid "Missing protocol version tag."
 msgstr ""
 
-#: src/ExternalConn.cpp:728
+#: src/ExternalConn.cpp:727
 msgid "Authentication failed: invalid hash specified as EC password."
 msgstr ""
 
-#: src/ExternalConn.cpp:776
+#: src/ExternalConn.cpp:775
 msgid "Authentication failed: wrong password."
 msgstr ""
 
-#: src/ExternalConn.cpp:778
+#: src/ExternalConn.cpp:777
 msgid "Authentication failed: missing password."
 msgstr ""
 
-#: src/ExternalConn.cpp:789
+#: src/ExternalConn.cpp:788
 msgid "Invalid request, please authenticate first."
 msgstr ""
 
-#: src/ExternalConn.cpp:794
+#: src/ExternalConn.cpp:793
 msgid "Access granted."
 msgstr ""
 
-#: src/ExternalConn.cpp:802
+#: src/ExternalConn.cpp:801
 #, c-format
 msgid "Sent error message \"%s\" to client."
 msgstr ""
 
-#: src/ExternalConn.cpp:807
+#: src/ExternalConn.cpp:806
 #, c-format
 msgid "Unauthorized access attempt from %s. Connection closed."
 msgstr ""
 
-#: src/ExternalConn.cpp:1420
+#: src/ExternalConn.cpp:1419
 #, c-format
 msgid "Remote PartFile command failed: FileHash not found: %s"
 msgstr ""
 
-#: src/ExternalConn.cpp:1424
+#: src/ExternalConn.cpp:1423
 #, c-format
 msgid "FileHash not found: %s"
 msgstr ""
 
-#: src/ExternalConn.cpp:1471 src/ExternalConn.cpp:1559
-#: src/ExternalConn.cpp:1680
+#: src/ExternalConn.cpp:1470 src/ExternalConn.cpp:1558
+#: src/ExternalConn.cpp:1679
 msgid "OOPS! OpCode processing error!"
 msgstr ""
 
-#: src/ExternalConn.cpp:1502
+#: src/ExternalConn.cpp:1501
 msgid "Server not added"
 msgstr ""
 
-#: src/ExternalConn.cpp:1521
+#: src/ExternalConn.cpp:1520
 #, c-format
 msgid "server not found: %s"
 msgstr ""
 
-#: src/ExternalConn.cpp:1538
+#: src/ExternalConn.cpp:1537
 msgid "need to define server to be removed"
 msgstr ""
 
-#: src/ExternalConn.cpp:1553
+#: src/ExternalConn.cpp:1552
 msgid "eD2k is disabled in preferences."
 msgstr ""
 
-#: src/ExternalConn.cpp:1658
+#: src/ExternalConn.cpp:1657
 msgid "Friend not found."
 msgstr ""
 
-#: src/ExternalConn.cpp:1668
+#: src/ExternalConn.cpp:1667
 msgid "Client not found."
 msgstr ""
 
-#: src/ExternalConn.cpp:1674
+#: src/ExternalConn.cpp:1673
 msgid "EC_TAG_FRIEND_SHARED requires EC_TAG_FRIEND or EC_TAG_CLIENT."
 msgstr ""
 
-#: src/ExternalConn.cpp:1992
+#: src/ExternalConn.cpp:1991
 msgid "WebSearch from remote interface makes no sense."
 msgstr ""
 
-#: src/ExternalConn.cpp:2027
+#: src/ExternalConn.cpp:2026
 msgid "Search in progress. Refetch results in a moment!"
 msgstr ""
 
-#: src/ExternalConn.cpp:2266
+#: src/ExternalConn.cpp:2265
 msgid "No points for graph."
 msgstr ""
 
-#: src/ExternalConn.cpp:2276
+#: src/ExternalConn.cpp:2275
 msgid "Your client is not configured for this detail level."
 msgstr ""
 
-#: src/ExternalConn.cpp:2303
+#: src/ExternalConn.cpp:2302
 msgid "External Connection: shutdown requested"
 msgstr ""
 
-#: src/ExternalConn.cpp:2315
+#: src/ExternalConn.cpp:2314
 msgid "Already shutting down."
 msgstr ""
 
-#: src/ExternalConn.cpp:2333
+#: src/ExternalConn.cpp:2332
 #, c-format
 msgid "ExternalConn: adding link '%s'."
 msgstr ""
 
-#: src/ExternalConn.cpp:2351
+#: src/ExternalConn.cpp:2350
 #, c-format
 msgid "%d of %d links failed (invalid or already on list)."
 msgstr ""
 
-#: src/ExternalConn.cpp:2374
+#: src/ExternalConn.cpp:2373
 msgid "Version check throttled; try again shortly."
 msgstr ""
 
-#: src/ExternalConn.cpp:2379
+#: src/ExternalConn.cpp:2378
 msgid "Version check is not available on this daemon."
 msgstr ""
 
-#: src/ExternalConn.cpp:2509
+#: src/ExternalConn.cpp:2508
 msgid "File not found."
 msgstr ""
 
-#: src/ExternalConn.cpp:2514
+#: src/ExternalConn.cpp:2513
 msgid "Invalid file name."
 msgstr ""
 
-#: src/ExternalConn.cpp:2522
+#: src/ExternalConn.cpp:2521
 msgid "Unable to rename file."
 msgstr ""
 
-#: src/ExternalConn.cpp:2839
-#, c-format
-msgid "Could not save the amuleapi password: %s"
-msgstr ""
-
-#: src/ExternalConn.cpp:3004 src/ExternalConn.cpp:3032
+#: src/ExternalConn.cpp:2992 src/ExternalConn.cpp:3020
 msgid "Kad is disabled in preferences."
 msgstr ""
 
-#: src/ExternalConn.cpp:3045
+#: src/ExternalConn.cpp:3033
 msgid "Already connected to eD2k."
 msgstr ""
 
-#: src/ExternalConn.cpp:3048
+#: src/ExternalConn.cpp:3036
 msgid "Connecting to eD2k..."
 msgstr ""
 
-#: src/ExternalConn.cpp:3057
+#: src/ExternalConn.cpp:3045
 msgid "Already connected to Kad."
 msgstr ""
 
-#: src/ExternalConn.cpp:3060
+#: src/ExternalConn.cpp:3048
 msgid "Connecting to Kad..."
 msgstr ""
 
-#: src/ExternalConn.cpp:3067
+#: src/ExternalConn.cpp:3055
 msgid "All networks are disabled."
 msgstr ""
 
-#: src/ExternalConn.cpp:3076
+#: src/ExternalConn.cpp:3064
 msgid "Disconnected from eD2k."
 msgstr ""
 
-#: src/ExternalConn.cpp:3081
+#: src/ExternalConn.cpp:3069
 msgid "Disconnected from Kad."
 msgstr ""
 
-#: src/ExternalConn.cpp:3090
+#: src/ExternalConn.cpp:3078
 #, c-format
 msgid "External Connection: invalid opcode received: %#x"
 msgstr ""
 
-#: src/ExternalConn.cpp:3095
+#: src/ExternalConn.cpp:3083
 msgid "Invalid opcode (wrong protocol version?)"
 msgstr ""
 
@@ -2272,19 +2262,19 @@ msgstr ""
 msgid "eD2k"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:349 src/muuli_wdr.cpp:1495
+#: src/FirstRunWizard.cpp:349 src/muuli_wdr.cpp:1488
 msgid "Kademlia"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:359 src/muuli_wdr.cpp:1423
+#: src/FirstRunWizard.cpp:359 src/muuli_wdr.cpp:1416
 msgid "Standard TCP Port "
 msgstr ""
 
-#: src/FirstRunWizard.cpp:365 src/muuli_wdr.cpp:1435
+#: src/FirstRunWizard.cpp:365 src/muuli_wdr.cpp:1428
 msgid "Extended UDP port (Kad / global search) "
 msgstr ""
 
-#: src/FirstRunWizard.cpp:377 src/muuli_wdr.cpp:1442
+#: src/FirstRunWizard.cpp:377 src/muuli_wdr.cpp:1435
 msgid "Enable UPnP for router port forwarding"
 msgstr ""
 
@@ -2309,7 +2299,7 @@ msgstr ""
 msgid "Your peer lists are already in place - nothing to download."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:434 src/muuli_wdr.cpp:1540
+#: src/FirstRunWizard.cpp:434 src/muuli_wdr.cpp:1533
 msgid "Auto-update server list at startup"
 msgstr ""
 
@@ -2355,23 +2345,23 @@ msgid ""
 "want downloads on a different (e.g. larger) disk."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:549 src/FirstRunWizard.cpp:611 src/muuli_wdr.cpp:1702
+#: src/FirstRunWizard.cpp:549 src/FirstRunWizard.cpp:611 src/muuli_wdr.cpp:1701
 msgid "Destination folder for downloads"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:553 src/FirstRunWizard.cpp:569 src/muuli_wdr.cpp:1349
-#: src/muuli_wdr.cpp:1366 src/muuli_wdr.cpp:1677 src/muuli_wdr.cpp:1708
-#: src/muuli_wdr.cpp:1720 src/muuli_wdr.cpp:2790
+#: src/FirstRunWizard.cpp:553 src/FirstRunWizard.cpp:569 src/muuli_wdr.cpp:1342
+#: src/muuli_wdr.cpp:1359 src/muuli_wdr.cpp:1676 src/muuli_wdr.cpp:1707
+#: src/muuli_wdr.cpp:1719 src/muuli_wdr.cpp:2762
 #: src/utils/aLinkCreator/src/alcframe.cpp:135
 #: src/utils/wxCas/src/wxcasprefs.cpp:52 src/utils/wxCas/src/wxcasprefs.cpp:118
 msgid "Browse"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:559 src/muuli_wdr.cpp:1713
+#: src/FirstRunWizard.cpp:559 src/muuli_wdr.cpp:1712
 msgid "(All files in this folder are shared with other peers)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:565 src/FirstRunWizard.cpp:624 src/muuli_wdr.cpp:1715
+#: src/FirstRunWizard.cpp:565 src/FirstRunWizard.cpp:624 src/muuli_wdr.cpp:1714
 msgid "Folder for temporary download files"
 msgstr ""
 
@@ -2402,7 +2392,7 @@ msgstr ""
 msgid "CRITICAL - no client on StartChatSession"
 msgstr ""
 
-#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2696 src/muuli_wdr.cpp:3373
+#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2668 src/muuli_wdr.cpp:3345
 msgid "Friends"
 msgstr ""
 
@@ -2508,8 +2498,8 @@ msgstr ""
 msgid "No"
 msgstr ""
 
-#: src/GenericClientListCtrl.cpp:1216 src/PrefsUnifiedDlg.cpp:2898
-#: src/PrefsUnifiedDlg.cpp:2948 src/ServerListCtrl.cpp:276
+#: src/GenericClientListCtrl.cpp:1216 src/PrefsUnifiedDlg.cpp:2818
+#: src/PrefsUnifiedDlg.cpp:2868 src/ServerListCtrl.cpp:276
 msgid "Yes"
 msgstr ""
 
@@ -2676,10 +2666,10 @@ msgstr ""
 msgid "Please fill all fields required"
 msgstr ""
 
-#: src/KadDlg.cpp:192 src/PartFile.cpp:1031 src/PrefsUnifiedDlg.cpp:1134
-#: src/PrefsUnifiedDlg.cpp:1204 src/PrefsUnifiedDlg.cpp:1405
-#: src/PrefsUnifiedDlg.cpp:1663 src/PrefsUnifiedDlg.cpp:1673
-#: src/PrefsUnifiedDlg.cpp:1690 src/PrefsUnifiedDlg.cpp:1738
+#: src/KadDlg.cpp:192 src/PartFile.cpp:1031 src/PrefsUnifiedDlg.cpp:1162
+#: src/PrefsUnifiedDlg.cpp:1331 src/PrefsUnifiedDlg.cpp:1589
+#: src/PrefsUnifiedDlg.cpp:1599 src/PrefsUnifiedDlg.cpp:1616
+#: src/PrefsUnifiedDlg.cpp:1658
 msgid "Message"
 msgstr ""
 
@@ -2780,7 +2770,7 @@ msgstr ""
 msgid "Uploaded"
 msgstr ""
 
-#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3253
+#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3225
 msgid "Requested"
 msgstr ""
 
@@ -2903,7 +2893,7 @@ msgid "WARNING: "
 msgstr ""
 
 #: src/MuleNotebook.cpp:179 src/muuli_wdr.cpp:817 src/muuli_wdr.cpp:1229
-#: src/muuli_wdr.cpp:3157 src/muuli_wdr.cpp:3413
+#: src/muuli_wdr.cpp:3129 src/muuli_wdr.cpp:3385
 msgid "Close"
 msgstr ""
 
@@ -2916,12 +2906,12 @@ msgstr ""
 msgid "Copy"
 msgstr ""
 
-#: src/MuleTextCtrl.cpp:88 src/SearchDlg.cpp:261
+#: src/MuleTextCtrl.cpp:88
 msgid "Paste"
 msgstr ""
 
 #: src/MuleTextCtrl.cpp:89 src/muuli_wdr.cpp:358 src/muuli_wdr.cpp:757
-#: src/muuli_wdr.cpp:2380 src/muuli_wdr.cpp:2399 src/muuli_wdr.cpp:2421
+#: src/muuli_wdr.cpp:2352 src/muuli_wdr.cpp:2371 src/muuli_wdr.cpp:2393
 #: src/utils/aLinkCreator/src/alcframe.cpp:142
 msgid "Clear"
 msgstr ""
@@ -3012,8 +3002,8 @@ msgid "Exit"
 msgstr ""
 
 #: src/MuleTrayIcon.cpp:579 src/MuleTrayIcon.cpp:945 src/MuleTrayIcon.cpp:965
-#: src/muuli_wdr.cpp:1398 src/muuli_wdr.cpp:1406 src/muuli_wdr.cpp:1413
-#: src/muuli_wdr.cpp:1836 src/muuli_wdr.cpp:1842 src/OtherFunctions.cpp:91
+#: src/muuli_wdr.cpp:1391 src/muuli_wdr.cpp:1399 src/muuli_wdr.cpp:1406
+#: src/muuli_wdr.cpp:1835 src/muuli_wdr.cpp:1841 src/OtherFunctions.cpp:91
 #: src/StatisticsDlg.cpp:93 src/StatisticsDlg.cpp:95
 msgid "kB/s"
 msgstr ""
@@ -3182,7 +3172,7 @@ msgstr ""
 msgid "Type"
 msgstr ""
 
-#: src/muuli_wdr.cpp:215 src/SearchDlg.cpp:118 src/SearchListCtrl.cpp:853
+#: src/muuli_wdr.cpp:215 src/SearchDlg.cpp:110 src/SearchListCtrl.cpp:853
 msgid "Local"
 msgstr ""
 
@@ -3253,7 +3243,7 @@ msgstr ""
 msgid "KB"
 msgstr ""
 
-#: src/muuli_wdr.cpp:274 src/muuli_wdr.cpp:293 src/muuli_wdr.cpp:1621
+#: src/muuli_wdr.cpp:274 src/muuli_wdr.cpp:293 src/muuli_wdr.cpp:1620
 #: src/OtherFunctions.cpp:64
 msgid "MB"
 msgstr ""
@@ -3270,7 +3260,7 @@ msgstr ""
 msgid "Availability"
 msgstr ""
 
-#: src/muuli_wdr.cpp:312 src/muuli_wdr.cpp:398 src/muuli_wdr.cpp:3318
+#: src/muuli_wdr.cpp:312 src/muuli_wdr.cpp:398 src/muuli_wdr.cpp:3290
 msgid "Filter:"
 msgstr ""
 
@@ -3302,7 +3292,7 @@ msgstr ""
 msgid "Stop"
 msgstr ""
 
-#: src/muuli_wdr.cpp:348 src/muuli_wdr.cpp:1392 src/SearchListCtrl.cpp:732
+#: src/muuli_wdr.cpp:348 src/muuli_wdr.cpp:1385 src/SearchListCtrl.cpp:732
 msgid "Download"
 msgstr ""
 
@@ -3333,12 +3323,12 @@ msgstr ""
 #: src/muuli_wdr.cpp:1160 src/muuli_wdr.cpp:1167 src/muuli_wdr.cpp:1172
 #: src/muuli_wdr.cpp:1179 src/muuli_wdr.cpp:1184 src/muuli_wdr.cpp:1191
 #: src/muuli_wdr.cpp:1205 src/muuli_wdr.cpp:1212 src/muuli_wdr.cpp:1217
-#: src/muuli_wdr.cpp:1224 src/muuli_wdr.cpp:3255 src/muuli_wdr.cpp:3263
-#: src/muuli_wdr.cpp:3271
+#: src/muuli_wdr.cpp:1224 src/muuli_wdr.cpp:3227 src/muuli_wdr.cpp:3235
+#: src/muuli_wdr.cpp:3243
 msgid "N/A"
 msgstr ""
 
-#: src/muuli_wdr.cpp:508 src/muuli_wdr.cpp:1065 src/PrefsUnifiedDlg.cpp:299
+#: src/muuli_wdr.cpp:508 src/muuli_wdr.cpp:1065 src/PrefsUnifiedDlg.cpp:297
 msgid "General"
 msgstr ""
 
@@ -3474,7 +3464,7 @@ msgstr ""
 msgid "Album :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:685 src/muuli_wdr.cpp:2275
+#: src/muuli_wdr.cpp:685 src/muuli_wdr.cpp:2247
 msgid "Title :"
 msgstr ""
 
@@ -3580,7 +3570,7 @@ msgstr ""
 msgid "Userhash :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:895 src/muuli_wdr.cpp:1742 src/muuli_wdr.cpp:2470
+#: src/muuli_wdr.cpp:895 src/muuli_wdr.cpp:1741 src/muuli_wdr.cpp:2442
 #: src/utils/aLinkCreator/src/alcframe.cpp:137
 msgid "Add"
 msgstr ""
@@ -3589,15 +3579,15 @@ msgstr ""
 msgid "Download-Speed"
 msgstr ""
 
-#: src/muuli_wdr.cpp:954 src/muuli_wdr.cpp:989 src/muuli_wdr.cpp:2574
+#: src/muuli_wdr.cpp:954 src/muuli_wdr.cpp:989 src/muuli_wdr.cpp:2546
 msgid "Current"
 msgstr ""
 
-#: src/muuli_wdr.cpp:962 src/muuli_wdr.cpp:997 src/muuli_wdr.cpp:2582
+#: src/muuli_wdr.cpp:962 src/muuli_wdr.cpp:997 src/muuli_wdr.cpp:2554
 msgid "Running average"
 msgstr ""
 
-#: src/muuli_wdr.cpp:970 src/muuli_wdr.cpp:1005 src/muuli_wdr.cpp:2590
+#: src/muuli_wdr.cpp:970 src/muuli_wdr.cpp:1005 src/muuli_wdr.cpp:2562
 msgid "Session average"
 msgstr ""
 
@@ -3609,7 +3599,7 @@ msgstr ""
 msgid "Connections"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1024 src/muuli_wdr.cpp:1861
+#: src/muuli_wdr.cpp:1024 src/muuli_wdr.cpp:1860
 msgid "Active downloads"
 msgstr ""
 
@@ -3617,7 +3607,7 @@ msgstr ""
 msgid "Active connections (1:1)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1040 src/muuli_wdr.cpp:1862
+#: src/muuli_wdr.cpp:1040 src/muuli_wdr.cpp:1861
 msgid "Active uploads"
 msgstr ""
 
@@ -3733,8 +3723,8 @@ msgstr ""
 msgid "Language: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1257 src/muuli_wdr.cpp:1330 src/muuli_wdr.cpp:1334
-#: src/muuli_wdr.cpp:1337
+#: src/muuli_wdr.cpp:1257 src/muuli_wdr.cpp:1323 src/muuli_wdr.cpp:1327
+#: src/muuli_wdr.cpp:1330
 msgid "The delay before showing tool-tips."
 msgstr ""
 
@@ -3810,943 +3800,923 @@ msgstr ""
 msgid "Enabling this will make aMule to show notifications when finished downloading."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1323
-msgid "Remember search history"
-msgstr ""
-
-#: src/muuli_wdr.cpp:1324
-msgid "Keeps a dropdown list of your past search terms in the Search tab's Name field. This remembers the queries you typed, not the results they returned."
-msgstr ""
-
-#: src/muuli_wdr.cpp:1329
+#: src/muuli_wdr.cpp:1322
 msgid "Tooltip delay time: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1336
+#: src/muuli_wdr.cpp:1329
 msgid "seconds"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1340
+#: src/muuli_wdr.cpp:1333
 msgid "Browser Selection"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1346
+#: src/muuli_wdr.cpp:1339
 msgid "Enter your browser name here. Leave this field empty to use the system default browser."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1353
+#: src/muuli_wdr.cpp:1346
 msgid "Open in new tab if possible"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1355
+#: src/muuli_wdr.cpp:1348
 msgid "Open the web page in a new tab instead of in a new window when possible"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1359
+#: src/muuli_wdr.cpp:1352
 msgid "Video Player"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1386
+#: src/muuli_wdr.cpp:1379
 msgid "Bandwidth limits"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1400
+#: src/muuli_wdr.cpp:1393
 msgid "Upload"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1408
+#: src/muuli_wdr.cpp:1401
 msgid "Slot Allocation"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1417
+#: src/muuli_wdr.cpp:1410
 msgid "Ports"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1427
+#: src/muuli_wdr.cpp:1420
 msgid "This is the standard eD2k port and cannot be disabled."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1430
+#: src/muuli_wdr.cpp:1423
 msgid "UDP port for server requests (TCP+3):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1432
+#: src/muuli_wdr.cpp:1425
 msgid "4665"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1439
+#: src/muuli_wdr.cpp:1432
 msgid "This UDP port is used for extended eD2k requests and Kad network"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1446
+#: src/muuli_wdr.cpp:1439
 msgid "UPnP TCP Port (Optional):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1456
+#: src/muuli_wdr.cpp:1449
 msgid "Bind local address to IP (empty for any):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1459
+#: src/muuli_wdr.cpp:1452
 msgid "Advanced users only: If you have multiple network interfaces, enter the address of the interface to which aMule should be bound."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1462 src/muuli_wdr.cpp:2055
+#: src/muuli_wdr.cpp:1455 src/muuli_wdr.cpp:2054
 msgid "Bind to network interface (empty for any):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1475
+#: src/muuli_wdr.cpp:1468
 msgid "Advanced users only: pin all of aMule's traffic to one network interface, chosen from the list or typed in by name (e.g. tun0, eth0, en0) or index. Unlike binding to an IP, this stops traffic leaking out via the default route - useful with a VPN. Requires no elevated privileges."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1481
+#: src/muuli_wdr.cpp:1474
 msgid "Max sources per downloading file:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1485
+#: src/muuli_wdr.cpp:1478
 msgid "Max simultaneous connections:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1498 src/muuli_wdr.cpp:3197
+#: src/muuli_wdr.cpp:1491 src/muuli_wdr.cpp:3169
 msgid "ED2K"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1505
+#: src/muuli_wdr.cpp:1498
 msgid "Autoconnect on startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1508
+#: src/muuli_wdr.cpp:1501
 msgid "Reconnect on loss"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1530
+#: src/muuli_wdr.cpp:1523
 msgid "Remove dead server after"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1531
+#: src/muuli_wdr.cpp:1524
 msgid "Static servers are never removed, even when unreachable."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1535
+#: src/muuli_wdr.cpp:1528
 msgid "retries"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1543
+#: src/muuli_wdr.cpp:1536
 msgid "List"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1546
+#: src/muuli_wdr.cpp:1539
 msgid "Update server list when connecting to a server"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1549
+#: src/muuli_wdr.cpp:1542
 msgid "Update server list when a client connects"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1552
+#: src/muuli_wdr.cpp:1545
 msgid "Use priority system"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1556
+#: src/muuli_wdr.cpp:1549
 msgid "Use smart LowID check on connect"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1560
+#: src/muuli_wdr.cpp:1553
 msgid "Safe connect"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1564
+#: src/muuli_wdr.cpp:1557
 msgid "Autoconnect to servers in static list only"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1567
+#: src/muuli_wdr.cpp:1560
 msgid "Set manually added servers to High Priority"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1588
+#: src/muuli_wdr.cpp:1581
 msgid "Add files to download in pause mode"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1590
+#: src/muuli_wdr.cpp:1583
 msgid "Add files to download with auto priority"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1593
+#: src/muuli_wdr.cpp:1586
 msgid "Try to download first and last chunks first"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1597
+#: src/muuli_wdr.cpp:1590
 msgid "Endgame mode: rotate to faster sources for the final blocks"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1600
+#: src/muuli_wdr.cpp:1593
 msgid "Start next paused file when a file completes"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1603
+#: src/muuli_wdr.cpp:1596
 msgid "From the same category"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1605
+#: src/muuli_wdr.cpp:1598
 msgid "In alphabetic order"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1607
+#: src/muuli_wdr.cpp:1600
 msgid "Preallocate disk space for new files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1608
+#: src/muuli_wdr.cpp:1601
 msgid "For new files preallocates disk space for the whole file, thus reduces fragmentation"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1613
+#: src/muuli_wdr.cpp:1606
+msgid "Create new files as sparse files"
+msgstr ""
+
+#: src/muuli_wdr.cpp:1607
+msgid "A sparse file reserves its full size on disk immediately without writing real data to it -- fast, but unsupported or slow on some filesystems, and free-space accounting stays optimistic while the download is in progress. Turn this off to grow the file only as data arrives."
+msgstr ""
+
+#: src/muuli_wdr.cpp:1612
 msgid "Stop downloads when free disk space reaches "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1614
+#: src/muuli_wdr.cpp:1613
 msgid "Select this if you want aMule to check your disk space"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1618
+#: src/muuli_wdr.cpp:1617
 msgid "Enter here the min disk space desired."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1624
+#: src/muuli_wdr.cpp:1623
 msgid "Save 10 sources on rare files (< 20 sources)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1628 src/Statistics.cpp:790
+#: src/muuli_wdr.cpp:1627 src/Statistics.cpp:790
 msgid "Uploads"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1631
+#: src/muuli_wdr.cpp:1630
 msgid "Add new shared files with auto priority"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1637
+#: src/muuli_wdr.cpp:1636
 msgid "Intelligent Corruption Handling (I.C.H.)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1640
+#: src/muuli_wdr.cpp:1639
 msgid "Enable"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1643
+#: src/muuli_wdr.cpp:1642
 msgid "Advanced I.C.H. trusts every hash (not recommended)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1655 src/PrefsUnifiedDlg.cpp:1990
+#: src/muuli_wdr.cpp:1654 src/PrefsUnifiedDlg.cpp:1910
 msgid "Media metadata extraction"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1659
+#: src/muuli_wdr.cpp:1658
 msgid "Extract length / bitrate / codec from shared audio and video files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1661
+#: src/muuli_wdr.cpp:1660
 msgid "When enabled, aMule runs ffprobe on each shared media file to fill in the Length / Bitrate / Codec columns other clients see when they find the file in a search. Requires ffmpeg (the ffprobe binary) to be installed."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1668
+#: src/muuli_wdr.cpp:1667
 msgid "Path to ffprobe:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1673
+#: src/muuli_wdr.cpp:1672
 msgid "Full path to the ffprobe binary. Leave empty to have aMule auto-detect it on startup."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1681
+#: src/muuli_wdr.cpp:1680
 msgid "Detect"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1682
+#: src/muuli_wdr.cpp:1681
 msgid "Search the standard install locations for an ffprobe binary and fill the path field."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1706
+#: src/muuli_wdr.cpp:1705
 msgid ""
 "Completed downloads are stored here. All files in this folder are automatically shared with other peers.\n"
 "If this folder also holds files you don't want to share, point it at an aMule-only sub-folder."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1709
+#: src/muuli_wdr.cpp:1708
 msgid "Pick the folder where completed downloads will be stored. All files in that folder will be shared with other peers."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1723
+#: src/muuli_wdr.cpp:1722
 msgid "Shared folders"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1729
+#: src/muuli_wdr.cpp:1728
 msgid "(Folders shared by the core. Enter a path to add one.)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1737
+#: src/muuli_wdr.cpp:1736
 msgid "Absolute path of a folder on the core's machine, e.g. /home/user/shared"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1739 src/PrefsUnifiedDlg.cpp:2874
+#: src/muuli_wdr.cpp:1738 src/PrefsUnifiedDlg.cpp:2794
 msgid "Recursive"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1740
+#: src/muuli_wdr.cpp:1739
 msgid "Share every sub-folder underneath this one, including ones created later."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1744 src/utils/aLinkCreator/src/alcframe.cpp:141
+#: src/muuli_wdr.cpp:1743 src/utils/aLinkCreator/src/alcframe.cpp:141
 msgid "Remove"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1748
+#: src/muuli_wdr.cpp:1747
 msgid "(Right click on folder icon for recursive share)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1755
+#: src/muuli_wdr.cpp:1754
 msgid "Share hidden files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1761
+#: src/muuli_wdr.cpp:1760
 msgid "Automatically rescan shared folders for changes"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1767
+#: src/muuli_wdr.cpp:1766
 msgid "Follow symbolic links in shared folders"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1773
+#: src/muuli_wdr.cpp:1772
 msgid "Exclude files matching:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1776
+#: src/muuli_wdr.cpp:1775
 msgid "Wildcard patterns separated by '|', e.g. .DS_Store|Thumbs.db|*.tmp. Files whose name matches are not shared. Matching is case-insensitive."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1780
+#: src/muuli_wdr.cpp:1779
 msgid "Patterns are regular expressions"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1781
+#: src/muuli_wdr.cpp:1780
 msgid "When set, the whole field is one regular expression ('|' is alternation). When unset, it is a list of '|'-separated wildcards."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1791
+#: src/muuli_wdr.cpp:1790
 msgid "Show how many shared files the current pattern would exclude."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1812
+#: src/muuli_wdr.cpp:1811
 msgid "Graphs"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1815 src/muuli_wdr.cpp:1877
+#: src/muuli_wdr.cpp:1814 src/muuli_wdr.cpp:1876
 msgid "Update delay : 5 secs"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1819
+#: src/muuli_wdr.cpp:1818
 msgid "Time for average graph: 100 mins"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1823
+#: src/muuli_wdr.cpp:1822
 msgid "Connections Graph Scale: 100 "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1830
+#: src/muuli_wdr.cpp:1829
 msgid "Download graph scale:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1838
+#: src/muuli_wdr.cpp:1837
 msgid "Upload graph scale:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1848
+#: src/muuli_wdr.cpp:1847
 msgid "Colors: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1852
+#: src/muuli_wdr.cpp:1851
 msgid "Background"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1853
+#: src/muuli_wdr.cpp:1852
 msgid "Grid"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1854
+#: src/muuli_wdr.cpp:1853
 msgid "Download current"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1855
+#: src/muuli_wdr.cpp:1854
 msgid "Download running average"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1856
+#: src/muuli_wdr.cpp:1855
 msgid "Download session average"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1857
+#: src/muuli_wdr.cpp:1856
 msgid "Upload current"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1858
+#: src/muuli_wdr.cpp:1857
 msgid "Upload running average"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1859
+#: src/muuli_wdr.cpp:1858
 msgid "Upload session average"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1860
+#: src/muuli_wdr.cpp:1859
 msgid "Active connections"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1863
+#: src/muuli_wdr.cpp:1862
 msgid "Systray Icon Speed Bar"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1864
+#: src/muuli_wdr.cpp:1863
 msgid "Kad-nodes current"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1865
+#: src/muuli_wdr.cpp:1864
 msgid "Kad-nodes running"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1866
+#: src/muuli_wdr.cpp:1865
 msgid "Kad-nodes session"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1870 src/muuli_wdr.cpp:2324
+#: src/muuli_wdr.cpp:1869 src/muuli_wdr.cpp:2296
 msgid "Select"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1874
+#: src/muuli_wdr.cpp:1873
 msgid "Tree"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1884
+#: src/muuli_wdr.cpp:1883
 msgid "Number of Client Versions shown (0=unlimited)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1909
+#: src/muuli_wdr.cpp:1908
 msgid "!!! WARNING !!!"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1924
+#: src/muuli_wdr.cpp:1923
 msgid "Max new connections / 5 secs"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1926
+#: src/muuli_wdr.cpp:1925
 msgid "Concurrent Kad source lookups"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1928
+#: src/muuli_wdr.cpp:1927
 msgid "Kad source re-search interval (minutes)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1930
+#: src/muuli_wdr.cpp:1929
 msgid "Source re-ask interval (minutes)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1934
+#: src/muuli_wdr.cpp:1933
 msgid "File Buffer Size: 240000 bytes"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1938
+#: src/muuli_wdr.cpp:1937
 msgid "Use MMAP: memory-mapped file access (lower memory use)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1939
+#: src/muuli_wdr.cpp:1938
 msgid "Maps part files into memory instead of buffering them on the heap, lowering the process memory footprint. May reduce download speed on some disks; best for memory-constrained or upload-heavy hosts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1941
+#: src/muuli_wdr.cpp:1940
 msgid "Upload Queue Size: 5000 clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1945
+#: src/muuli_wdr.cpp:1944
 msgid "Server connection refresh interval: Disable"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1949
+#: src/muuli_wdr.cpp:1948
 msgid "Disable computer's timed standby mode"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1968
+#: src/muuli_wdr.cpp:1967
 msgid "Skin to use: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1977
+#: src/muuli_wdr.cpp:1976
 msgid "Show \"Fast eD2k Links Handler\" in every window."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1980
+#: src/muuli_wdr.cpp:1979
 msgid "Show extended info on categories tabs"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1983
+#: src/muuli_wdr.cpp:1982
 msgid "Show application version on title"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1985
+#: src/muuli_wdr.cpp:1984
 msgid "Show transfer rates on title"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1987
+#: src/muuli_wdr.cpp:1986
 msgid "Before application name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1989
+#: src/muuli_wdr.cpp:1988
 msgid "After application name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1992
+#: src/muuli_wdr.cpp:1991
 msgid "Show overhead bandwidth"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1996
+#: src/muuli_wdr.cpp:1995
 msgid "Vertical toolbar orientation"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1998
+#: src/muuli_wdr.cpp:1997
 msgid "Live column sorting (auto-reorder rows as their values change)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2005
+#: src/muuli_wdr.cpp:2004
 msgid "Download Queue Files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2008
+#: src/muuli_wdr.cpp:2007
 msgid "Show progress percentage"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2014
+#: src/muuli_wdr.cpp:2013
 msgid "Show progress bar"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2017
+#: src/muuli_wdr.cpp:2016
 msgid "Flat"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2021
+#: src/muuli_wdr.cpp:2020
 msgid "Round"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2039
+#: src/muuli_wdr.cpp:2038
 msgid "External Connection Parameters"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2042
+#: src/muuli_wdr.cpp:2041
 msgid "Accept external connections"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2049 src/muuli_wdr.cpp:2108
+#: src/muuli_wdr.cpp:2048 src/muuli_wdr.cpp:2107
 msgid "IP of the listening interface:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2052
+#: src/muuli_wdr.cpp:2051
 msgid "Enter here a valid ip in the a.b.c.d format for the listening EC interface. An empty field or 0.0.0.0 will mean any interface."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2073 src/muuli_wdr.cpp:2184
+#: src/muuli_wdr.cpp:2072 src/muuli_wdr.cpp:2156
 msgid "TCP port:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2079
+#: src/muuli_wdr.cpp:2078
 msgid "Enable UPnP port forwarding on the EC port"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2083 src/muuli_wdr.cpp:3069
+#: src/muuli_wdr.cpp:2082 src/muuli_wdr.cpp:3041
 #: src/utils/wxCas/src/wxcasprefs.cpp:167
 msgid "Password"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2089
+#: src/muuli_wdr.cpp:2088
 msgid "aMule API server parameters"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2092
+#: src/muuli_wdr.cpp:2091
 msgid "Run amuleapi (REST API) on startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2097
+#: src/muuli_wdr.cpp:2096
 msgid "HTTP port:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2111
+#: src/muuli_wdr.cpp:2110
 msgid "The interface amuleapi's HTTP server listens on. 127.0.0.1 (default) accepts only local connections; use 0.0.0.0 or a specific IP to expose it to other hosts (set an admin password below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2116
-msgid "Type a password to set or change it. Stored passwords cannot be shown, so leaving this empty keeps the current one."
-msgstr ""
-
-#: src/muuli_wdr.cpp:2118
+#: src/muuli_wdr.cpp:2113
 msgid "Admin password"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2130 src/muuli_wdr.cpp:2147 src/PrefsUnifiedDlg.cpp:1103
-msgid "A password is set."
-msgstr ""
-
-#: src/muuli_wdr.cpp:2134
-msgid "Enable guest access"
-msgstr ""
-
-#: src/muuli_wdr.cpp:2135
-msgid "Guest sessions may read status and listings but cannot change anything. Turning this off clears the stored guest password."
-msgstr ""
-
-#: src/muuli_wdr.cpp:2139
-msgid "Guest password"
-msgstr ""
-
-#: src/muuli_wdr.cpp:2154
-msgid "Web server parameters"
-msgstr ""
-
-#: src/muuli_wdr.cpp:2157
-msgid "Run webserver on startup (deprecated)"
-msgstr ""
-
-#: src/muuli_wdr.cpp:2163
-msgid "Web template"
-msgstr ""
-
-#: src/muuli_wdr.cpp:2168
-msgid "Full rights password"
-msgstr ""
-
-#: src/muuli_wdr.cpp:2172
-msgid "Enable Low rights User"
-msgstr ""
-
-#: src/muuli_wdr.cpp:2177
+#: src/muuli_wdr.cpp:2118 src/muuli_wdr.cpp:2149
 msgid "Low rights password"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2191
+#: src/muuli_wdr.cpp:2126
+msgid "Web server parameters"
+msgstr ""
+
+#: src/muuli_wdr.cpp:2129
+msgid "Run webserver on startup (deprecated)"
+msgstr ""
+
+#: src/muuli_wdr.cpp:2135
+msgid "Web template"
+msgstr ""
+
+#: src/muuli_wdr.cpp:2140
+msgid "Full rights password"
+msgstr ""
+
+#: src/muuli_wdr.cpp:2144
+msgid "Enable Low rights User"
+msgstr ""
+
+#: src/muuli_wdr.cpp:2163
 msgid "Enable UPnP port forwarding of the web server port"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2196
+#: src/muuli_wdr.cpp:2168
 msgid "Web server UPnP TCP port (Optional)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2204
+#: src/muuli_wdr.cpp:2176
 msgid "Page Refresh Time (in secs)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2211
+#: src/muuli_wdr.cpp:2183
 msgid "Enable Gzip compression"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2245
+#: src/muuli_wdr.cpp:2217
 msgid "Reset page to defaults"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2246
+#: src/muuli_wdr.cpp:2218
 msgid "Reset the settings on the current page to their default values."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2248 src/muuli_wdr.cpp:2334 src/ServerWnd.cpp:274
+#: src/muuli_wdr.cpp:2220 src/muuli_wdr.cpp:2306 src/ServerWnd.cpp:274
 #: src/ServerWnd.cpp:282
 msgid "OK"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2250
+#: src/muuli_wdr.cpp:2222
 msgid "Click here to apply any changes made to the preferences."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2253
+#: src/muuli_wdr.cpp:2225
 msgid "Reset any changes made to the preferences."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2282
+#: src/muuli_wdr.cpp:2254
 msgid "Comment :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2289
+#: src/muuli_wdr.cpp:2261
 msgid "Incoming Dir :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2298
+#: src/muuli_wdr.cpp:2270
 msgid "Change priority for new assigned files :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2302
+#: src/muuli_wdr.cpp:2274
 msgid "Don't change"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2314
+#: src/muuli_wdr.cpp:2286
 msgid "Select color for this Category (currently selected) :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2381 src/muuli_wdr.cpp:2400 src/muuli_wdr.cpp:2422
+#: src/muuli_wdr.cpp:2353 src/muuli_wdr.cpp:2372 src/muuli_wdr.cpp:2394
 msgid "Click this button to reset the log."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2441
+#: src/muuli_wdr.cpp:2413
 msgid "Click on this button to update the servers list from URL ..."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2445
+#: src/muuli_wdr.cpp:2417
 msgid "Server list"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2449
+#: src/muuli_wdr.cpp:2421
 msgid "Enter the url to a server.met file here and press the button to the left to update the list of known servers."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2454
+#: src/muuli_wdr.cpp:2426
 msgid "Add server manually: Name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2457
+#: src/muuli_wdr.cpp:2429
 msgid "Enter the name of the new server here"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2459 src/ServerWnd.cpp:206
+#: src/muuli_wdr.cpp:2431 src/ServerWnd.cpp:206
 msgid "IP:Port"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2462
+#: src/muuli_wdr.cpp:2434
 msgid "Enter the IP of the server here, using the x.x.x.x format."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2468
+#: src/muuli_wdr.cpp:2440
 msgid "Enter the port of the server here."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2471
+#: src/muuli_wdr.cpp:2443
 msgid "Add manually a server (fill fields to the left before) ..."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2500
+#: src/muuli_wdr.cpp:2472
 msgid "aMule Log"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2508
+#: src/muuli_wdr.cpp:2480
 msgid "Server Info"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2512
+#: src/muuli_wdr.cpp:2484
 msgid "ED2K Info"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2516
+#: src/muuli_wdr.cpp:2488
 msgid "Kad Info"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2544
+#: src/muuli_wdr.cpp:2516
 msgid "Click on this button to update the nodes list from URL ..."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2548
+#: src/muuli_wdr.cpp:2520
 msgid "Nodes (0)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2552
+#: src/muuli_wdr.cpp:2524
 msgid "Enter the url to a nodes.dat file here and press the button to the left to update the list of known nodes."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2555
+#: src/muuli_wdr.cpp:2527
 msgid "Nodes stats"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2597
+#: src/muuli_wdr.cpp:2569
 msgid "Bootstrap"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2600
+#: src/muuli_wdr.cpp:2572
 msgid "New node"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2605
+#: src/muuli_wdr.cpp:2577
 msgid "IP:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2625
+#: src/muuli_wdr.cpp:2597
 msgid "Port:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2638
+#: src/muuli_wdr.cpp:2610
 msgid "Bootstrap from known clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2640
+#: src/muuli_wdr.cpp:2612
 msgid "Disconnect Kad"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2674
+#: src/muuli_wdr.cpp:2646
 msgid "Use Secure User Identification"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2676
+#: src/muuli_wdr.cpp:2648
 msgid "It is recommended to enable this option. You will not receive credits if SUI is not enabled."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2678
+#: src/muuli_wdr.cpp:2650
 msgid "Protocol Obfuscation"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2681
+#: src/muuli_wdr.cpp:2653
 msgid "Support Protocol Obfuscation"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2683
+#: src/muuli_wdr.cpp:2655
 msgid "This option enabled Protocol Obfuscation, and makes aMule accept obfuscated connections from other clients."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2685
+#: src/muuli_wdr.cpp:2657
 msgid "Use obfuscation for outgoing connections"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2687
+#: src/muuli_wdr.cpp:2659
 msgid "This option makes aMule use Protocol Obfuscation when connecting other clients/servers."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2689
+#: src/muuli_wdr.cpp:2661
 msgid "Accept only obfuscated connections"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2690
+#: src/muuli_wdr.cpp:2662
 msgid "This option makes aMule only accept obfuscated connections. You will have less sources, but all your traffic will be obfuscated"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2695
+#: src/muuli_wdr.cpp:2667
 msgid "Everybody"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2697
+#: src/muuli_wdr.cpp:2669
 msgid "No one"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2699
+#: src/muuli_wdr.cpp:2671
 msgid "Who can see my shared files:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2700
+#: src/muuli_wdr.cpp:2672
 msgid "Select who can request to view a list of your shared files."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2702
+#: src/muuli_wdr.cpp:2674
 msgid "IP-Filtering"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2709
+#: src/muuli_wdr.cpp:2681
 msgid "Filter clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2711
+#: src/muuli_wdr.cpp:2683
 msgid "Enable filtering of the client IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2713
+#: src/muuli_wdr.cpp:2685
 msgid "Filter servers"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2715
+#: src/muuli_wdr.cpp:2687
 msgid "Enable filtering of the server IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2719
+#: src/muuli_wdr.cpp:2691
 msgid "Reload List"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2720
+#: src/muuli_wdr.cpp:2692
 msgid "Reload the list of IPs to filter from the file ~/.aMule/ipfilter.dat"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2726
+#: src/muuli_wdr.cpp:2698
 msgid "URL:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2730 src/muuli_wdr.cpp:2923
+#: src/muuli_wdr.cpp:2702 src/muuli_wdr.cpp:2895
 msgid "Update now"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2733
+#: src/muuli_wdr.cpp:2705
 msgid "Auto-update ipfilter at startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2737
+#: src/muuli_wdr.cpp:2709
 msgid "Filtering Level:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2743
+#: src/muuli_wdr.cpp:2715
 msgid "Always filter LAN IPs"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2746
+#: src/muuli_wdr.cpp:2718
 msgid "Paranoid handling of non-matching IPs"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2748
+#: src/muuli_wdr.cpp:2720
 msgid "Rejects a packet when its source IP differs from the IP the client claims (an anti-spoofing check). Disable only if it causes connection problems."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2750
+#: src/muuli_wdr.cpp:2722
 msgid "Use system-wide ipfilter.dat if available"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2751
+#: src/muuli_wdr.cpp:2723
 msgid "If there's no local ipfilter.dat found, allow usage of a system-wide ipfilter file."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2768
+#: src/muuli_wdr.cpp:2740
 msgid "Enable Online-Signature"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2770
+#: src/muuli_wdr.cpp:2742
 msgid "Enables the writing of the OS file, which can be used by external apps to create signatures and the like."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2774
+#: src/muuli_wdr.cpp:2746
 msgid "Update Frequency (Secs):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2777
+#: src/muuli_wdr.cpp:2749
 msgid "Change the frequency (in seconds) of Online Signature updates."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2785
+#: src/muuli_wdr.cpp:2757
 msgid "Save online signature file in: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:2791
+#: src/muuli_wdr.cpp:2763
 msgid "Click here to select the directory containing the the Online Signature files."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2824
+#: src/muuli_wdr.cpp:2796
 msgid "Show country flags for clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2825
+#: src/muuli_wdr.cpp:2797
 msgid "Render the country flag column in the transfers, queue and search views. Requires a valid MMDB GeoIP database (see below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2830
+#: src/muuli_wdr.cpp:2802
 msgid "Database"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2846
+#: src/muuli_wdr.cpp:2818
 msgid "Source:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2849
+#: src/muuli_wdr.cpp:2821
 msgid "DB-IP (free, no account)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2850
+#: src/muuli_wdr.cpp:2822
 msgid "MaxMind GeoLite2 (free, account required)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2851
+#: src/muuli_wdr.cpp:2823
 msgid "Custom URL"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2854
+#: src/muuli_wdr.cpp:2826
 msgid "Choose which provider supplies the GeoIP MMDB database. DB-IP is the default - no account required. MaxMind requires a free account + license key. Use Custom URL to point at any other MMDB host (e.g. a local mirror)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2871
+#: src/muuli_wdr.cpp:2843
 msgid ""
 "No configuration required.\n"
 "\n"
@@ -4754,11 +4724,11 @@ msgid ""
 "License: Creative Commons BY 4.0 - https://creativecommons.org/licenses/by/4.0/"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2884
+#: src/muuli_wdr.cpp:2856
 msgid "License key:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2890
+#: src/muuli_wdr.cpp:2862
 msgid ""
 "Sign up for a free MaxMind account, then generate a License Key:\n"
 "https://www.maxmind.com/en/geolite2/signup\n"
@@ -4768,222 +4738,222 @@ msgid ""
 "Requires attribution and account registration; refresh at least every 30 days."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2905
+#: src/muuli_wdr.cpp:2877
 msgid "Download URL:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2911
+#: src/muuli_wdr.cpp:2883
 msgid ""
 "Must point to an .mmdb file or a .gz / .tar.gz containing one.\n"
 "URL may include credentials (https://user:pass@host/...).\n"
 "License and attribution terms are set by the upstream URL - you are responsible."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2924
+#: src/muuli_wdr.cpp:2896
 msgid "Download the GeoIP database from the selected source."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2926
+#: src/muuli_wdr.cpp:2898
 msgid "Auto-update on startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2927
+#: src/muuli_wdr.cpp:2899
 msgid "Re-download the GeoIP database from the selected source every time aMule starts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2950
+#: src/muuli_wdr.cpp:2922
 msgid "Filter incoming messages (except current chat):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2952
+#: src/muuli_wdr.cpp:2924
 msgid "Filter all messages"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2954
+#: src/muuli_wdr.cpp:2926
 msgid "Filter messages from people not on your friend list"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2956
+#: src/muuli_wdr.cpp:2928
 msgid "Filter messages from unknown clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2958
+#: src/muuli_wdr.cpp:2930
 msgid "Filter messages containing (use ',' as separator):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2961 src/muuli_wdr.cpp:2972
+#: src/muuli_wdr.cpp:2933 src/muuli_wdr.cpp:2944
 msgid "add here the words amule should filter and block messages including it"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2963
+#: src/muuli_wdr.cpp:2935
 msgid "Show received messages in the log"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2966
+#: src/muuli_wdr.cpp:2938
 msgid "Comments"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2969
+#: src/muuli_wdr.cpp:2941
 msgid "Filter comments containing (use ',' as separator):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2994
+#: src/muuli_wdr.cpp:2966
 msgid "Enable Proxy"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2995
+#: src/muuli_wdr.cpp:2967
 msgid "Enable/disable proxy support"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2998
+#: src/muuli_wdr.cpp:2970
 msgid "Proxy type:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3009
+#: src/muuli_wdr.cpp:2981
 msgid "Proxy host:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3012
+#: src/muuli_wdr.cpp:2984
 msgid "The proxy host name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3014
+#: src/muuli_wdr.cpp:2986
 msgid "Proxy port:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3017
+#: src/muuli_wdr.cpp:2989
 msgid "The proxy port"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3019
+#: src/muuli_wdr.cpp:2991
 msgid "Enable authentication"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3020
+#: src/muuli_wdr.cpp:2992
 msgid "Enable/disable username/password authentication"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3023
+#: src/muuli_wdr.cpp:2995
 msgid "Username: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:3026
+#: src/muuli_wdr.cpp:2998
 msgid "The username to use to connect to the proxy"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3028
+#: src/muuli_wdr.cpp:3000
 msgid "Password:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3031
+#: src/muuli_wdr.cpp:3003
 msgid "The password to use to connect to the proxy"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3050
+#: src/muuli_wdr.cpp:3022
 msgid "Connect to:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3059
+#: src/muuli_wdr.cpp:3031
 msgid "Login to remote amule"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3064
+#: src/muuli_wdr.cpp:3036
 msgid "User name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3075
+#: src/muuli_wdr.cpp:3047
 msgid "Remember those settings"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3078
+#: src/muuli_wdr.cpp:3050
 msgid "Force ZLIB compression"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3102
+#: src/muuli_wdr.cpp:3074
 msgid "Enable Verbose Debug-Logging."
 msgstr ""
 
-#: src/muuli_wdr.cpp:3104
+#: src/muuli_wdr.cpp:3076
 msgid "Only to Logfile"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3106
+#: src/muuli_wdr.cpp:3078
 msgid "Message Categories:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3130 src/PartFileConvertDlg.cpp:160
+#: src/muuli_wdr.cpp:3102 src/PartFileConvertDlg.cpp:160
 msgid "Waiting..."
 msgstr ""
 
-#: src/muuli_wdr.cpp:3150
+#: src/muuli_wdr.cpp:3122
 msgid "Add imports"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3153
+#: src/muuli_wdr.cpp:3125
 msgid "Retry selected"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3155
+#: src/muuli_wdr.cpp:3127
 msgid "Remove selected"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3218
+#: src/muuli_wdr.cpp:3190
 msgid "Event Types"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3237
+#: src/muuli_wdr.cpp:3209
 msgid "Statistics and queued clients for selected file(s) : Session / All time"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3261
+#: src/muuli_wdr.cpp:3233
 msgid "Active Uploads"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3275
+#: src/muuli_wdr.cpp:3247
 msgid "Percent of total files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3327
+#: src/muuli_wdr.cpp:3299
 msgid "Show Clients for"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3329
+#: src/muuli_wdr.cpp:3301
 msgid "All files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3332
+#: src/muuli_wdr.cpp:3304
 msgid "Selected files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3335
+#: src/muuli_wdr.cpp:3307
 msgid "Active uploads only"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3342
+#: src/muuli_wdr.cpp:3314
 msgid "Reload:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3346
+#: src/muuli_wdr.cpp:3318
 msgid "Reload your shared files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3409
+#: src/muuli_wdr.cpp:3381
 msgid "Send"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3410
+#: src/muuli_wdr.cpp:3382
 msgid "Sends the specified message."
 msgstr ""
 
-#: src/muuli_wdr.cpp:3414
+#: src/muuli_wdr.cpp:3386
 msgid "Close this chat-session."
 msgstr ""
 
-#: src/muuli_wdr.cpp:3437
+#: src/muuli_wdr.cpp:3409
 msgid "Connect to any server and/or Kad"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3443 src/SharedFilesCtrl.cpp:142 src/Statistics.cpp:941
+#: src/muuli_wdr.cpp:3415 src/SharedFilesCtrl.cpp:142 src/Statistics.cpp:941
 msgid "Shared Files"
 msgstr ""
 
@@ -5341,263 +5311,263 @@ msgstr ""
 msgid "ERROR: Failed to open partfile '%s'"
 msgstr ""
 
-#: src/Preferences.cpp:701
+#: src/Preferences.cpp:673
 msgid "System default"
 msgstr ""
 
-#: src/Preferences.cpp:702
+#: src/Preferences.cpp:674
 msgid "Albanian"
 msgstr ""
 
-#: src/Preferences.cpp:703
+#: src/Preferences.cpp:675
 msgid "Arabic"
 msgstr ""
 
-#: src/Preferences.cpp:704
+#: src/Preferences.cpp:676
 msgid "Asturian"
 msgstr ""
 
-#: src/Preferences.cpp:705
+#: src/Preferences.cpp:677
 msgid "Basque"
 msgstr ""
 
-#: src/Preferences.cpp:706
+#: src/Preferences.cpp:678
 msgid "Bulgarian"
 msgstr ""
 
-#: src/Preferences.cpp:707
+#: src/Preferences.cpp:679
 msgid "Catalan"
 msgstr ""
 
-#: src/Preferences.cpp:708
+#: src/Preferences.cpp:680
 msgid "Chinese (Simplified)"
 msgstr ""
 
-#: src/Preferences.cpp:709
+#: src/Preferences.cpp:681
 msgid "Chinese (Traditional)"
 msgstr ""
 
-#: src/Preferences.cpp:710
+#: src/Preferences.cpp:682
 msgid "Croatian"
 msgstr ""
 
-#: src/Preferences.cpp:711
+#: src/Preferences.cpp:683
 msgid "Czech"
 msgstr ""
 
-#: src/Preferences.cpp:712
+#: src/Preferences.cpp:684
 msgid "Danish"
 msgstr ""
 
-#: src/Preferences.cpp:713
+#: src/Preferences.cpp:685
 msgid "Dutch"
 msgstr ""
 
-#: src/Preferences.cpp:714
+#: src/Preferences.cpp:686
 msgid "English (U.K.)"
 msgstr ""
 
-#: src/Preferences.cpp:715
+#: src/Preferences.cpp:687
 msgid "English (U.S.)"
 msgstr ""
 
-#: src/Preferences.cpp:716
+#: src/Preferences.cpp:688
 msgid "Estonian"
 msgstr ""
 
-#: src/Preferences.cpp:717
+#: src/Preferences.cpp:689
 msgid "Finnish"
 msgstr ""
 
-#: src/Preferences.cpp:718
+#: src/Preferences.cpp:690
 msgid "French"
 msgstr ""
 
-#: src/Preferences.cpp:719
+#: src/Preferences.cpp:691
 msgid "Galician"
 msgstr ""
 
-#: src/Preferences.cpp:720
+#: src/Preferences.cpp:692
 msgid "German"
 msgstr ""
 
-#: src/Preferences.cpp:721
+#: src/Preferences.cpp:693
 msgid "Greek"
 msgstr ""
 
-#: src/Preferences.cpp:722
+#: src/Preferences.cpp:694
 msgid "Hebrew"
 msgstr ""
 
-#: src/Preferences.cpp:723
+#: src/Preferences.cpp:695
 msgid "Hungarian"
 msgstr ""
 
-#: src/Preferences.cpp:724
+#: src/Preferences.cpp:696
 msgid "Italian"
 msgstr ""
 
-#: src/Preferences.cpp:725
+#: src/Preferences.cpp:697
 msgid "Japanese"
 msgstr ""
 
-#: src/Preferences.cpp:726
+#: src/Preferences.cpp:698
 msgid "Korean"
 msgstr ""
 
-#: src/Preferences.cpp:727
+#: src/Preferences.cpp:699
 msgid "Latvian"
 msgstr ""
 
-#: src/Preferences.cpp:728
+#: src/Preferences.cpp:700
 msgid "Lithuanian"
 msgstr ""
 
-#: src/Preferences.cpp:729
+#: src/Preferences.cpp:701
 msgid "Norwegian (Nynorsk)"
 msgstr ""
 
-#: src/Preferences.cpp:730
+#: src/Preferences.cpp:702
 msgid "Polish"
 msgstr ""
 
-#: src/Preferences.cpp:731
+#: src/Preferences.cpp:703
 msgid "Portuguese"
 msgstr ""
 
-#: src/Preferences.cpp:732
+#: src/Preferences.cpp:704
 msgid "Portuguese (Brazilian)"
 msgstr ""
 
-#: src/Preferences.cpp:733
+#: src/Preferences.cpp:705
 msgid "Romanian"
 msgstr ""
 
-#: src/Preferences.cpp:734
+#: src/Preferences.cpp:706
 msgid "Russian"
 msgstr ""
 
-#: src/Preferences.cpp:735
+#: src/Preferences.cpp:707
 msgid "Slovenian"
 msgstr ""
 
-#: src/Preferences.cpp:736
+#: src/Preferences.cpp:708
 msgid "Spanish"
 msgstr ""
 
-#: src/Preferences.cpp:737
+#: src/Preferences.cpp:709
 msgid "Swedish"
 msgstr ""
 
-#: src/Preferences.cpp:738
+#: src/Preferences.cpp:710
 msgid "Turkish"
 msgstr ""
 
-#: src/Preferences.cpp:739
+#: src/Preferences.cpp:711
 msgid "Ukrainian"
 msgstr ""
 
-#: src/Preferences.cpp:842
+#: src/Preferences.cpp:814
 msgid "Change Language"
 msgstr ""
 
-#: src/Preferences.cpp:906
+#: src/Preferences.cpp:878
 msgid "There are no translations installed for aMule"
 msgstr ""
 
-#: src/Preferences.cpp:907
+#: src/Preferences.cpp:879
 msgid "No languages available"
 msgstr ""
 
-#: src/Preferences.cpp:1038
+#: src/Preferences.cpp:1010
 msgid "no options available"
 msgstr ""
 
-#: src/Preferences.cpp:2226
+#: src/Preferences.cpp:2179
 msgid "Invalid category found, skipping"
 msgstr ""
 
-#: src/Preferences.cpp:2395
+#: src/Preferences.cpp:2348
 msgid "TCP port can't be higher than 65532 due to server UDP socket being TCP+3"
 msgstr ""
 
-#: src/Preferences.cpp:2396
+#: src/Preferences.cpp:2349
 #, c-format
 msgid "Default port will be used (%d)"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:300 src/Statistics.cpp:866
+#: src/PrefsUnifiedDlg.cpp:298 src/Statistics.cpp:866
 msgid "Connection"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:301 src/SearchListCtrl.cpp:117
+#: src/PrefsUnifiedDlg.cpp:299 src/SearchListCtrl.cpp:117
 msgid "Directories"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:302 src/Statistics.cpp:917
+#: src/PrefsUnifiedDlg.cpp:300 src/Statistics.cpp:917
 msgid "Servers"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:303 src/ServerListCtrl.cpp:96
+#: src/PrefsUnifiedDlg.cpp:301 src/ServerListCtrl.cpp:96
 msgid "Files"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:304
+#: src/PrefsUnifiedDlg.cpp:302
 msgid "Security"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:305
+#: src/PrefsUnifiedDlg.cpp:303
 msgid "Interface"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:312
+#: src/PrefsUnifiedDlg.cpp:310
 msgid "IP2Country"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:315
+#: src/PrefsUnifiedDlg.cpp:313
 msgid "Proxy"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:316
+#: src/PrefsUnifiedDlg.cpp:314
 msgid "Filters"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:317
+#: src/PrefsUnifiedDlg.cpp:315
 msgid "Remote Controls"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:318
+#: src/PrefsUnifiedDlg.cpp:316
 msgid "Online Signature"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:319
+#: src/PrefsUnifiedDlg.cpp:317
 msgid "Advanced"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:320
+#: src/PrefsUnifiedDlg.cpp:318
 msgid "Events"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:323
+#: src/PrefsUnifiedDlg.cpp:321
 msgid "Debugging"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:453
+#: src/PrefsUnifiedDlg.cpp:451
 msgid ""
 "The following variables will be substituted:\n"
 "    %PARTFILE - full path to the file\n"
 "    %PARTNAME - file name only"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:474
+#: src/PrefsUnifiedDlg.cpp:472
 msgid "Tray icon support requires libayatana-appindicator3 at compile time."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:490
+#: src/PrefsUnifiedDlg.cpp:488
 msgid "Not available on Wayland: the protocol does not report when a window is minimized, so this option cannot intercept the system minimize button. Workaround: launch aMule with `GDK_BACKEND=x11` to use XWayland instead."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:536
+#: src/PrefsUnifiedDlg.cpp:534
 msgid ""
 "Do not change these setting unless you know\n"
 "what you are doing, otherwise you can easily\n"
@@ -5607,424 +5577,407 @@ msgid ""
 "these settings."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:647
+#: src/PrefsUnifiedDlg.cpp:645
 #, c-format
 msgid "Failed to connect Cfg to widget with the ID %d and key %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:695
+#: src/PrefsUnifiedDlg.cpp:693
 #, c-format
 msgid "Failed to transfer data from Cfg to Widget with the ID %d and key %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:801
+#: src/PrefsUnifiedDlg.cpp:799
 msgid "The type of proxy you are connecting to"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1020
+#: src/PrefsUnifiedDlg.cpp:1003
 #, c-format
 msgid "Failed to transfer data from Widget to Cfg with the ID %d and key %s"
 msgstr ""
 
 #: src/PrefsUnifiedDlg.cpp:1103
-msgid "No password set."
-msgstr ""
-
-#: src/PrefsUnifiedDlg.cpp:1132
-msgid "Guest access needs a password. Type one in the guest password field, or untick Enable guest access."
-msgstr ""
-
-#: src/PrefsUnifiedDlg.cpp:1144
 msgid ""
 "aMule must be restarted to enable these changes:\n"
 "\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1151
+#: src/PrefsUnifiedDlg.cpp:1110
 msgid "- TCP port changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1156
+#: src/PrefsUnifiedDlg.cpp:1115
 msgid "- UDP port changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1161
+#: src/PrefsUnifiedDlg.cpp:1120
 msgid "- Network interface binding changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1166
+#: src/PrefsUnifiedDlg.cpp:1125
 msgid "- External connect port changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1170
+#: src/PrefsUnifiedDlg.cpp:1129
 msgid "- External connect acceptance changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1174
+#: src/PrefsUnifiedDlg.cpp:1133
 msgid "- External connect interface changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1178
+#: src/PrefsUnifiedDlg.cpp:1137
 msgid "- Protocol obfuscation support changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1193
+#: src/PrefsUnifiedDlg.cpp:1151
 msgid "- amuleapi settings changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1202
+#: src/PrefsUnifiedDlg.cpp:1160
 msgid ""
 "Your Auto-update server list is empty.\n"
 "'Auto-update server list at startup' will be disabled."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1213
+#: src/PrefsUnifiedDlg.cpp:1171
 msgid ""
 "You have enabled external connections but have not specified a password.\n"
 "External connections cannot be enabled unless a valid password is specified."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1246
-#, c-format
-msgid "The amuleapi password could not be saved: %s"
-msgstr ""
-
-#: src/PrefsUnifiedDlg.cpp:1276
+#: src/PrefsUnifiedDlg.cpp:1202
 msgid "- Language changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1281
+#: src/PrefsUnifiedDlg.cpp:1207
 msgid "- Temp folder changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1286
+#: src/PrefsUnifiedDlg.cpp:1212
 msgid "- ED2K network enabled.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1319
+#: src/PrefsUnifiedDlg.cpp:1245
 msgid "The shared-file exclusion pattern is not a valid regular expression. The filter has been left disabled."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1321 src/PrefsUnifiedDlg.cpp:1921
+#: src/PrefsUnifiedDlg.cpp:1247 src/PrefsUnifiedDlg.cpp:1841
 msgid "Invalid regular expression"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1398
+#: src/PrefsUnifiedDlg.cpp:1324
 msgid ""
 "Both eD2k and Kad network are disabled.\n"
 "You won't be able to connect until you enable at least one of them."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1403
+#: src/PrefsUnifiedDlg.cpp:1329
 msgid ""
 "Kad will not start if your UDP port is disabled.\n"
 "Enable UDP port or disable Kad."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1459
+#: src/PrefsUnifiedDlg.cpp:1385
 msgid ""
 "\n"
 "You MUST restart aMule now.\n"
 "If you do not restart now, don't complain if anything bad happens.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1524
+#: src/PrefsUnifiedDlg.cpp:1450
 msgid "Could not register aMule for autostart at login. The autostart store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1526
+#: src/PrefsUnifiedDlg.cpp:1452
 msgid "Could not remove the autostart-at-login entry."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1527
+#: src/PrefsUnifiedDlg.cpp:1453
 msgid "Autostart"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1542
+#: src/PrefsUnifiedDlg.cpp:1468
 msgid "Register file type"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1542
+#: src/PrefsUnifiedDlg.cpp:1468
 msgid "Register URL handler"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1550
+#: src/PrefsUnifiedDlg.cpp:1476
 #, c-format
 msgid "aMule only handles eD2k-compatible magnets. If you replace the current magnet handler (%s), BitTorrent magnet links will stop working - aMule cannot download BitTorrent content. Continue?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1555
+#: src/PrefsUnifiedDlg.cpp:1481
 #, c-format
 msgid "Another application currently opens .emulecollection files (%s). Replace it with aMule?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1560
+#: src/PrefsUnifiedDlg.cpp:1486
 #, c-format
 msgid "Another application is currently the default handler for these links (%s). Replace it with aMule?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1585
+#: src/PrefsUnifiedDlg.cpp:1511
 msgid "Could not register aMule for .emulecollection files. The registration store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1587
+#: src/PrefsUnifiedDlg.cpp:1513
 msgid "Could not remove the file type registration."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1589
+#: src/PrefsUnifiedDlg.cpp:1515
 msgid "Could not register aMule as the URL handler. The registration store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1591
+#: src/PrefsUnifiedDlg.cpp:1517
 msgid "Could not remove the URL handler registration."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1661 src/PrefsUnifiedDlg.cpp:1688
+#: src/PrefsUnifiedDlg.cpp:1587 src/PrefsUnifiedDlg.cpp:1614
 msgid "The web server and aMule API require external connections to be enabled."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1671
+#: src/PrefsUnifiedDlg.cpp:1597
 msgid "The aMule web server is deprecated. Consider running the aMule API instead."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1735
+#: src/PrefsUnifiedDlg.cpp:1655
 msgid ""
 "Your Auto-update servers list is in blank.\n"
 "Please fill in at least one URL to point to a valid server.met file.\n"
 "Click on the button \"List\" by this checkbox to enter an URL."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1876
+#: src/PrefsUnifiedDlg.cpp:1796
 msgid "Temporary files"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1881
+#: src/PrefsUnifiedDlg.cpp:1801
 msgid "Incoming files"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1886
+#: src/PrefsUnifiedDlg.cpp:1806
 msgid "Online Signatures"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1899
+#: src/PrefsUnifiedDlg.cpp:1819
 #, c-format
 msgid "Choose a folder for %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1923
+#: src/PrefsUnifiedDlg.cpp:1843
 #, c-format
 msgid "Would exclude %u of %u shared file"
 msgid_plural "Would exclude %u of %u shared files"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/PrefsUnifiedDlg.cpp:1940
+#: src/PrefsUnifiedDlg.cpp:1860
 msgid "Browse for videoplayer"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1944
+#: src/PrefsUnifiedDlg.cpp:1864
 msgid "Select browser"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1948
+#: src/PrefsUnifiedDlg.cpp:1868
 msgid "Select ffprobe binary"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1954
+#: src/PrefsUnifiedDlg.cpp:1874
 #, c-format
 msgid "Executable%s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1988
+#: src/PrefsUnifiedDlg.cpp:1908
 msgid "ffprobe not found on PATH or in the standard install locations. Install ffmpeg (which ships ffprobe) or use Browse to pick a binary manually."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2000
+#: src/PrefsUnifiedDlg.cpp:1920
 msgid "Reset the settings on this page to their default values?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2001
+#: src/PrefsUnifiedDlg.cpp:1921
 msgid "Reset to defaults"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2028
+#: src/PrefsUnifiedDlg.cpp:1948
 msgid "Edit server list"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2029
+#: src/PrefsUnifiedDlg.cpp:1949
 msgid ""
 "Add here URL's to download server.met files.\n"
 "Only one url on each line."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2084
+#: src/PrefsUnifiedDlg.cpp:2004
 msgid "IP2Country update failed"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2229 src/PrefsUnifiedDlg.cpp:2260
+#: src/PrefsUnifiedDlg.cpp:2149 src/PrefsUnifiedDlg.cpp:2180
 msgid "Data by MaxMind GeoLite2"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2231 src/PrefsUnifiedDlg.cpp:2262
+#: src/PrefsUnifiedDlg.cpp:2151 src/PrefsUnifiedDlg.cpp:2182
 msgid "Custom source"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2233 src/PrefsUnifiedDlg.cpp:2264
+#: src/PrefsUnifiedDlg.cpp:2153 src/PrefsUnifiedDlg.cpp:2184
 msgid "Data by DB-IP.com"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2284
+#: src/PrefsUnifiedDlg.cpp:2204
 #, c-format
 msgid "Status: Loaded%s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2286
+#: src/PrefsUnifiedDlg.cpp:2206
 #, c-format
 msgid "Status: Loaded%s - %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2290
+#: src/PrefsUnifiedDlg.cpp:2210
 msgid "Status: Failed to load - click 'Update now' to refresh."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2292
+#: src/PrefsUnifiedDlg.cpp:2212
 msgid "Status: Not found - click 'Update now' to download."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2350 src/PrefsUnifiedDlg.cpp:2374
+#: src/PrefsUnifiedDlg.cpp:2270 src/PrefsUnifiedDlg.cpp:2294
 #, c-format
 msgid "Update delay: %d second"
 msgid_plural "Update delay: %d seconds"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/PrefsUnifiedDlg.cpp:2358
+#: src/PrefsUnifiedDlg.cpp:2278
 #, c-format
 msgid "Time for average graph: %d minute"
 msgid_plural "Time for average graph: %d minutes"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/PrefsUnifiedDlg.cpp:2367
+#: src/PrefsUnifiedDlg.cpp:2287
 #, c-format
 msgid "Connections Graph Scale: %d"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2382
+#: src/PrefsUnifiedDlg.cpp:2302
 #, c-format
 msgid "File Buffer Size: %d byte"
 msgid_plural "File Buffer Size: %d bytes"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/PrefsUnifiedDlg.cpp:2392
+#: src/PrefsUnifiedDlg.cpp:2312
 #, c-format
 msgid "Upload Queue Size: %d client"
 msgid_plural "Upload Queue Size: %d clients"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/PrefsUnifiedDlg.cpp:2402
+#: src/PrefsUnifiedDlg.cpp:2322
 #, c-format
 msgid "Server connection refresh interval: %d minute"
 msgid_plural "Server connection refresh interval: %d minutes"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/PrefsUnifiedDlg.cpp:2407
+#: src/PrefsUnifiedDlg.cpp:2327
 msgid "Server connection refresh interval: Disabled"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2451
+#: src/PrefsUnifiedDlg.cpp:2371
 msgid "disabled"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2477
+#: src/PrefsUnifiedDlg.cpp:2397
 #, c-format
 msgid "Execute command on '%s' event"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2484
+#: src/PrefsUnifiedDlg.cpp:2404
 msgid "Enable command execution on core"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2496
+#: src/PrefsUnifiedDlg.cpp:2416
 msgid "Core command:"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2512
+#: src/PrefsUnifiedDlg.cpp:2432
 msgid "Enable command execution on GUI"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2524
+#: src/PrefsUnifiedDlg.cpp:2444
 msgid "GUI command:"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2540
+#: src/PrefsUnifiedDlg.cpp:2460
 msgid "The following variables will be replaced:"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2708
+#: src/PrefsUnifiedDlg.cpp:2628
 msgid ""
 "The following folders look like system or sensitive locations:\n"
 "\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2713
+#: src/PrefsUnifiedDlg.cpp:2633
 msgid "Sharing them recursively will publish every file underneath on the eD2k/Kad networks. Do you really want to do this?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2716
+#: src/PrefsUnifiedDlg.cpp:2636
 msgid "Confirm shared folders"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2744
+#: src/PrefsUnifiedDlg.cpp:2664
 msgid "Reloading shared files..."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2745
+#: src/PrefsUnifiedDlg.cpp:2665
 msgid "Scanning for subdirectories..."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2746
+#: src/PrefsUnifiedDlg.cpp:2666
 msgid "Updating shared folders"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2773
+#: src/PrefsUnifiedDlg.cpp:2693
 #, c-format
 msgid "Scanned %u directories..."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2823
+#: src/PrefsUnifiedDlg.cpp:2743
 #, c-format
 msgid "Reloading shared files: %u files scanned"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2873
+#: src/PrefsUnifiedDlg.cpp:2793
 msgid "Shared folder"
 msgstr ""
 
-#: src/SearchDlg.cpp:280
-msgid "Clear search history"
-msgstr ""
-
-#: src/SearchDlg.cpp:584
+#: src/SearchDlg.cpp:425
 msgid "It's impossible to search when both eD2k and Kademlia are disabled."
 msgstr ""
 
-#: src/SearchDlg.cpp:585 src/SearchListCtrl.cpp:858
+#: src/SearchDlg.cpp:426 src/SearchListCtrl.cpp:858
 msgid "Search error"
 msgstr ""
 
-#: src/SearchDlg.cpp:929
+#: src/SearchDlg.cpp:768
 msgid "Min size must be smaller than max size. Max size ignored."
 msgstr ""
 
-#: src/SearchDlg.cpp:930 src/SearchDlg.cpp:1012
+#: src/SearchDlg.cpp:769 src/SearchDlg.cpp:851
 msgid "Search warning"
 msgstr ""
 
-#: src/SearchDlg.cpp:1092 src/SearchListCtrl.cpp:735
+#: src/SearchDlg.cpp:929 src/SearchListCtrl.cpp:735
 msgid "Main"
 msgstr ""
 

--- a/po/ar.po
+++ b/po/ar.po
@@ -9,8 +9,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-28 12:12+0200\n"
-"PO-Revision-Date: 2026-07-27 10:13+0000\n"
+"POT-Creation-Date: 2026-07-28 08:06+0200\n"
+"PO-Revision-Date: 2026-07-27 11:31+0000\n"
 "Last-Translator: saleh alhathal <hathalsal@hotmail.com>\n"
 "Language-Team: \n"
 "Language: ar\n"
@@ -135,7 +135,7 @@ msgstr ""
 msgid "Not now"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:422 src/amuleDlg.cpp:665
+#: src/AppImageIntegration.cpp:422 src/amuleDlg.cpp:600
 msgid "Don't ask again"
 msgstr ""
 
@@ -193,155 +193,155 @@ msgstr "فشل لفتح %s (%s)"
 msgid "WARNING: You can't add yourself as a source for an eD2k link while having a lowid."
 msgstr ""
 
-#: src/amule.cpp:301
+#: src/amule.cpp:300
 msgid "Now, exiting main app..."
 msgstr ""
 
-#: src/amule.cpp:331
+#: src/amule.cpp:330
 #, c-format
 msgid "Terminating amuleweb instance with pid '%d' ... "
 msgstr ""
 
-#: src/amule.cpp:335
+#: src/amule.cpp:334
 #, c-format
 msgid "Killing amuleweb instance with pid '%d' ... "
 msgstr ""
 
-#: src/amule.cpp:337 src/amule.cpp:350 src/ClientRef.cpp:180
-#: src/SearchDlg.cpp:1041 src/ServerListCtrl.cpp:98
+#: src/amule.cpp:336 src/amule.cpp:349 src/ClientRef.cpp:180
+#: src/SearchDlg.cpp:880 src/ServerListCtrl.cpp:98
 msgid "Failed"
 msgstr "فشل"
 
-#: src/amule.cpp:344
+#: src/amule.cpp:343
 #, c-format
 msgid "Terminating amuleapi instance with pid '%d' ... "
 msgstr ""
 
-#: src/amule.cpp:348
+#: src/amule.cpp:347
 #, c-format
 msgid "Killing amuleapi instance with pid '%d' ... "
 msgstr ""
 
-#: src/amule.cpp:356
+#: src/amule.cpp:355
 msgid "aMule OnExit: Terminating core."
 msgstr ""
 
-#: src/amule.cpp:467
+#: src/amule.cpp:466
 msgid "aMule shutdown completed."
 msgstr ""
 
-#: src/amule.cpp:471
+#: src/amule.cpp:470
 msgid "Memory debug results for aMule exit:"
 msgstr ""
 
-#: src/amule.cpp:652
+#: src/amule.cpp:651
 #, c-format
 msgid "Binding aMule's peer-to-peer traffic to interface: %s (HTTP updates use the default route)"
 msgstr ""
 
-#: src/amule.cpp:656
+#: src/amule.cpp:655
 #, c-format
 msgid "Binding all network traffic to interface: %s"
 msgstr ""
 
-#: src/amule.cpp:660
+#: src/amule.cpp:659
 #, c-format
 msgid "WARNING: configured network interface '%s' was not found - traffic is NOT bound to it and may leave via the default route. Check the interface name in Preferences."
 msgstr ""
 
-#: src/amule.cpp:666
+#: src/amule.cpp:665
 #, c-format
 msgid "WARNING: binding to network interface '%s' requires elevated privileges and was NOT applied - traffic may leave via the default route. Grant the capability (e.g. 'sudo setcap cap_net_raw+ep' on the aMule binary) or run with sufficient privileges."
 msgstr ""
 
-#: src/amule.cpp:674
+#: src/amule.cpp:673
 #, c-format
 msgid "WARNING: could not bind to network interface '%s' - traffic may leave via the default route."
 msgstr ""
 
-#: src/amule.cpp:733
+#: src/amule.cpp:732
 msgid "Your locale has been changed to System Default due to a configuration change. Sorry."
 msgstr ""
 
-#: src/amule.cpp:735 src/amule.cpp:1589 src/CatDialog.cpp:128
+#: src/amule.cpp:734 src/amule.cpp:1581 src/CatDialog.cpp:128
 #: src/CatDialog.cpp:136 src/CatDialog.cpp:149 src/ServerList.cpp:366
 #: src/ServerListCtrl.cpp:152
 msgid "Info"
 msgstr "معلومات"
 
-#: src/amule.cpp:742
+#: src/amule.cpp:741
 #, fuzzy
 msgid ""
 "\n"
 "EC configuration"
 msgstr "تاكيد الخروج"
 
-#: src/amule.cpp:745
+#: src/amule.cpp:744
 #, fuzzy
 msgid "Password set and external connections enabled."
 msgstr "قبل إتصال خارجي جديد\n"
 
-#: src/amule.cpp:755 src/KadDlg.cpp:176 src/KadDlg.cpp:185
-#: src/PrefsUnifiedDlg.cpp:1461 src/SharedFilesCtrl.cpp:476
+#: src/amule.cpp:754 src/KadDlg.cpp:176 src/KadDlg.cpp:185
+#: src/PrefsUnifiedDlg.cpp:1387 src/SharedFilesCtrl.cpp:476
 msgid "WARNING"
 msgstr ""
 
-#: src/amule.cpp:992
+#: src/amule.cpp:991
 msgid "Network bootstrap"
 msgstr ""
 
-#: src/amule.cpp:997
+#: src/amule.cpp:996
 msgid ""
 "aMule has detected missing network bootstrap files.\n"
 "Select which ones to download:"
 msgstr ""
 
-#: src/amule.cpp:1006 src/FirstRunWizard.cpp:411
+#: src/amule.cpp:1005 src/FirstRunWizard.cpp:411
 #, fuzzy
 msgid "eD2k server list (server.met)"
 msgstr "%i خادمات وجدت في server.met"
 
-#: src/amule.cpp:1013 src/FirstRunWizard.cpp:416
+#: src/amule.cpp:1012 src/FirstRunWizard.cpp:416
 msgid "Kad bootstrap nodes (nodes.dat)"
 msgstr ""
 
-#: src/amule.cpp:1103
+#: src/amule.cpp:1102
 #, c-format
 msgid "web server running on pid %d"
 msgstr ""
 
-#: src/amule.cpp:1116
+#: src/amule.cpp:1115
 msgid "You requested to run web server on startup, but the amuleweb binary cannot be run. Please install the package containing aMule web server, or build aMule from source with -DBUILD_WEBSERVER=YES and install it."
 msgstr ""
 
-#: src/amule.cpp:1121 src/amule.cpp:1185 src/amule.cpp:1299 src/amule.cpp:1601
+#: src/amule.cpp:1120 src/amule.cpp:1177 src/amule.cpp:1291 src/amule.cpp:1593
 #: src/amule-remote-gui.cpp:603 src/amule-remote-gui.cpp:671
 #: src/amule-remote-gui.cpp:709 src/amule-remote-gui.cpp:1282
 #: src/amule-remote-gui.cpp:1345 src/amule-remote-gui.cpp:1372
-#: src/DownloadQueue.cpp:1481 src/PrefsUnifiedDlg.cpp:1247
+#: src/DownloadQueue.cpp:1481
 msgid "ERROR"
 msgstr ""
 
-#: src/amule.cpp:1174
+#: src/amule.cpp:1166
 #, c-format
 msgid "amuleapi running on pid %d"
 msgstr ""
 
-#: src/amule.cpp:1180
+#: src/amule.cpp:1172
 msgid "You requested to run amuleapi on startup, but the amuleapi binary cannot be run. Please install the package containing aMule's REST API server, or build aMule from source with -DBUILD_AMULEAPI=YES and install it."
 msgstr ""
 
-#: src/amule.cpp:1267
+#: src/amule.cpp:1259
 #, c-format
 msgid "Could not bind ports to the specified address: %s"
 msgstr ""
 
-#: src/amule.cpp:1291
+#: src/amule.cpp:1283
 #, c-format
 msgid "Port %u is not available. You will be LOWID\n"
 msgstr ""
 
-#: src/amule.cpp:1296
+#: src/amule.cpp:1288
 #, c-format
 msgid ""
 "Port %u is not available!\n"
@@ -351,185 +351,185 @@ msgid ""
 "Check your network to make sure the port is open for output and input."
 msgstr ""
 
-#: src/amule.cpp:1393
+#: src/amule.cpp:1385
 msgid "Failed to create OnlineSig File"
 msgstr ""
 
-#: src/amule.cpp:1401
+#: src/amule.cpp:1393
 msgid "Failed to create aMule OnlineSig File"
 msgstr ""
 
-#: src/amule.cpp:1564
+#: src/amule.cpp:1556
 msgid "The selected locale seems not to be installed on your box. (Note: I'll try to set it anyway)"
 msgstr ""
 
-#: src/amule.cpp:1574
+#: src/amule.cpp:1566
 #, c-format
 msgid "This is the first time you run aMule %s"
 msgstr ""
 
-#: src/amule.cpp:1577
+#: src/amule.cpp:1569
 msgid "This version is a testing version, updated daily, and\n"
 msgstr ""
 
-#: src/amule.cpp:1578
+#: src/amule.cpp:1570
 msgid "we give no warranty it won't break anything, burn your house,\n"
 msgstr "ﻻ نضمن انه خالي من اﻻخطاء, قد يتسبب باعطال\n"
 
-#: src/amule.cpp:1579
+#: src/amule.cpp:1571
 msgid "or kill your dog. But it *should* be safe to use anyway.\n"
 msgstr ""
 
-#: src/amule.cpp:1584
+#: src/amule.cpp:1576
 msgid "More information, support and new releases can found at our homepage,\n"
 msgstr ""
 
-#: src/amule.cpp:1585
+#: src/amule.cpp:1577
 msgid "at https://amule-org.github.io, or in our IRC channel #aMule at irc.libera.chat.\n"
 msgstr ""
 
-#: src/amule.cpp:1587
+#: src/amule.cpp:1579
 msgid "Feel free to report any bugs to https://github.com/amule-org/amule/issues"
 msgstr ""
 
-#: src/amule.cpp:1599
+#: src/amule.cpp:1591
 msgid ""
 "The folder for Online Signature files you specified is INVALID!\n"
 " OnlineSignature will be DISABLED until you fix it on preferences."
 msgstr ""
 
-#: src/amule.cpp:1662
+#: src/amule.cpp:1654
 #, fuzzy
 msgid "Server hostname notified"
 msgstr "إسم الخادم"
 
-#: src/amule.cpp:2039
+#: src/amule.cpp:2031
 #, c-format
 msgid "Disk space preallocation for file '%s' failed: %s"
 msgstr ""
 
-#: src/amule.cpp:2168
+#: src/amule.cpp:2160
 msgid "ERROR: can't open logfile"
 msgstr ""
 
-#: src/amule.cpp:2172
+#: src/amule.cpp:2164
 msgid "WARNING: logfile is empty. Something is wrong."
 msgstr ""
 
-#: src/amule.cpp:2189
+#: src/amule.cpp:2181
 msgid "Log has been reset"
 msgstr ""
 
-#: src/amule.cpp:2213
+#: src/amule.cpp:2205
 #, c-format
 msgid "ServerMessage: %s"
 msgstr ""
 
-#: src/amule.cpp:2256 src/IP2Country.cpp:220 src/IPFilter.cpp:514
+#: src/amule.cpp:2248 src/IP2Country.cpp:220 src/IPFilter.cpp:514
 #: src/ServerList.cpp:875
 #, c-format
 msgid "Skipped download of %s, because requested file is not newer."
 msgstr ""
 
-#: src/amule.cpp:2259
+#: src/amule.cpp:2251
 msgid "Failed to download the nodes list."
 msgstr ""
 
-#: src/amule.cpp:2322
+#: src/amule.cpp:2314
 msgid "Failed to open the downloaded version check file"
 msgstr ""
 
-#: src/amule.cpp:2325 src/amule.cpp:2344
+#: src/amule.cpp:2317 src/amule.cpp:2336
 msgid "Corrupted version check file"
 msgstr ""
 
-#: src/amule.cpp:2367
+#: src/amule.cpp:2359
 msgid "You are using an outdated version of aMule!"
 msgstr ""
 
-#: src/amule.cpp:2369
+#: src/amule.cpp:2361
 #, c-format
 msgid "Your aMule version is %i.%i.%i and the latest version is %li.%li.%li"
 msgstr ""
 
-#: src/amule.cpp:2373
+#: src/amule.cpp:2365
 msgid "The latest version can always be found at https://github.com/amule-org/amule/releases/latest"
 msgstr ""
 
-#: src/amule.cpp:2376
+#: src/amule.cpp:2368
 #, c-format
 msgid "WARNING: Your aMuled version is outdated: %i.%i.%i < %li.%li.%li"
 msgstr ""
 
-#: src/amule.cpp:2382
+#: src/amule.cpp:2374
 msgid "Your copy of aMule is up to date."
 msgstr ""
 
-#: src/amule.cpp:2389
+#: src/amule.cpp:2381
 msgid "Failed to download the version check file"
 msgstr ""
 
-#: src/amule.cpp:2558 src/amule-remote-gui.cpp:1133
+#: src/amule.cpp:2550 src/amule-remote-gui.cpp:1133
 #, c-format
 msgid "Users: %s | Files: %s"
 msgstr ""
 
-#: src/amule.cpp:2559 src/amule-remote-gui.cpp:1134
+#: src/amule.cpp:2551 src/amule-remote-gui.cpp:1134
 #, c-format
 msgid "Users: E: %s K: %s | Files: E: %s K: %s"
 msgstr ""
 
-#: src/amule.cpp:2573 src/amule-remote-gui.cpp:1147
+#: src/amule.cpp:2565 src/amule-remote-gui.cpp:1147
 msgid "No networks selected"
 msgstr ""
 
-#: src/amule.cpp:2641 src/TextClient.cpp:903
+#: src/amule.cpp:2633 src/TextClient.cpp:903
 msgid "with LowID"
 msgstr ""
 
-#: src/amule.cpp:2641 src/TextClient.cpp:904
+#: src/amule.cpp:2633 src/TextClient.cpp:904
 msgid "with HighID"
 msgstr ""
 
-#: src/amule.cpp:2643
+#: src/amule.cpp:2635
 #, c-format
 msgid "Connected to %s %s"
 msgstr ""
 
-#: src/amule.cpp:2648
+#: src/amule.cpp:2640
 #, c-format
 msgid "Connecting to %s"
 msgstr ""
 
-#: src/amule.cpp:2650
+#: src/amule.cpp:2642
 msgid "Disconnected from eD2k"
 msgstr ""
 
-#: src/amule.cpp:2659
+#: src/amule.cpp:2651
 msgid "Kad started."
 msgstr ""
 
-#: src/amule.cpp:2661
+#: src/amule.cpp:2653
 msgid "Kad stopped."
 msgstr ""
 
-#: src/amule.cpp:2669
+#: src/amule.cpp:2661
 msgid "Connected to Kad (ok)"
 msgstr ""
 
-#: src/amule.cpp:2671
+#: src/amule.cpp:2663
 msgid "Connected to Kad (firewalled)"
 msgstr ""
 
-#: src/amule.cpp:2675
+#: src/amule.cpp:2667
 msgid "Disconnected from Kad"
 msgstr ""
 
-#: src/amule.cpp:2707
+#: src/amule.cpp:2699
 msgid "Kad network cannot be used if UDP port is disabled on preferences, not starting."
 msgstr ""
 
-#: src/amule.cpp:2711
+#: src/amule.cpp:2703
 msgid "Kad network disabled on preferences, not connecting."
 msgstr ""
 
@@ -554,68 +554,30 @@ msgstr ""
 msgid "ERROR: %s"
 msgstr ""
 
-#: src/amuleDlg.cpp:250
+#: src/amuleDlg.cpp:236
 #, c-format
 msgid "This is aMule %s based on eMule."
 msgstr ""
 
-#: src/amuleDlg.cpp:251
+#: src/amuleDlg.cpp:237
 #, c-format
 msgid "Running on %s"
 msgstr ""
 
-#: src/amuleDlg.cpp:253
+#: src/amuleDlg.cpp:239
 msgid "Visit https://github.com/amule-org/amule/releases/latest to check if a new version is available."
 msgstr ""
 
-#: src/amuleDlg.cpp:282
+#: src/amuleDlg.cpp:268
 msgid "FATAL ERROR: Failed to create Timer"
 msgstr ""
 
-#: src/amuleDlg.cpp:361 src/amuleDlg.cpp:1810 src/amuleDlg.cpp:2056
-#: src/muuli_wdr.cpp:1492 src/muuli_wdr.cpp:3439
-msgid "Networks"
-msgstr ""
-
-#: src/amuleDlg.cpp:362 src/amuleDlg.cpp:1816 src/muuli_wdr.cpp:3440
-msgid "Searches"
-msgstr "بحث"
-
-#: src/amuleDlg.cpp:363 src/amuleDlg.cpp:1822 src/DownloadListCtrl.cpp:740
-#: src/muuli_wdr.cpp:392 src/muuli_wdr.cpp:1585 src/muuli_wdr.cpp:3441
-#: src/Statistics.cpp:829
-msgid "Downloads"
-msgstr "تحميل"
-
-#: src/amuleDlg.cpp:364 src/amuleDlg.cpp:1828 src/muuli_wdr.cpp:3315
-msgid "Shared files"
-msgstr ""
-
-#: src/amuleDlg.cpp:365 src/amuleDlg.cpp:1834 src/muuli_wdr.cpp:2947
-#: src/muuli_wdr.cpp:3397 src/muuli_wdr.cpp:3444
-msgid "Messages"
-msgstr "رسائل"
-
-#: src/amuleDlg.cpp:366 src/amuleDlg.cpp:1840 src/muuli_wdr.cpp:3445
-#: src/PrefsUnifiedDlg.cpp:314 src/Statistics.cpp:779 src/Statistics.cpp:1235
-msgid "Statistics"
-msgstr "احصائات"
-
-#: src/amuleDlg.cpp:368 src/amuleDlg.cpp:1847 src/muuli_wdr.cpp:3447
-#: src/PrefsUnifiedDlg.cpp:330 src/utils/wxCas/src/wxcasprefs.cpp:39
-msgid "Preferences"
-msgstr "اعدادت"
-
-#: src/amuleDlg.cpp:371
-msgid "Navigate"
-msgstr ""
-
-#: src/amuleDlg.cpp:657
+#: src/amuleDlg.cpp:592
 #, fuzzy
 msgid "New version available"
 msgstr "غير متوفر"
 
-#: src/amuleDlg.cpp:661
+#: src/amuleDlg.cpp:596
 #, c-format
 msgid ""
 "A new version of aMule (%s) is available.\n"
@@ -625,189 +587,222 @@ msgid ""
 "Would you like to open the download page?"
 msgstr ""
 
-#: src/amuleDlg.cpp:743
+#: src/amuleDlg.cpp:678
 msgid "aMule dialog destroyed"
 msgstr ""
 
-#: src/amuleDlg.cpp:766 src/DataToText.cpp:68 src/IPFilter.cpp:547
+#: src/amuleDlg.cpp:701 src/DataToText.cpp:68 src/IPFilter.cpp:547
 msgid "Connecting"
 msgstr "يتم الإتصال"
 
-#: src/amuleDlg.cpp:958
+#: src/amuleDlg.cpp:893
 msgid "eD2k: Connecting"
 msgstr ""
 
-#: src/amuleDlg.cpp:962
+#: src/amuleDlg.cpp:897
 msgid "eD2k: Disconnected"
 msgstr ""
 
-#: src/amuleDlg.cpp:968
+#: src/amuleDlg.cpp:903
 msgid "Kad: Firewalled"
 msgstr ""
 
-#: src/amuleDlg.cpp:972
+#: src/amuleDlg.cpp:907
 #, fuzzy
 msgid "Kad: Connected"
 msgstr "متصل"
 
-#: src/amuleDlg.cpp:977
+#: src/amuleDlg.cpp:912
 #, fuzzy
 msgid "Kad: Connecting"
 msgstr "يتم الإتصال"
 
-#: src/amuleDlg.cpp:981
+#: src/amuleDlg.cpp:916
 msgid "Kad: Off"
 msgstr ""
 
-#: src/amuleDlg.cpp:1029 src/DownloadListCtrl.cpp:505
+#: src/amuleDlg.cpp:964 src/DownloadListCtrl.cpp:505
 #: src/DownloadListCtrl.cpp:749 src/FriendListCtrl.cpp:180
 #: src/muuli_wdr.cpp:731 src/muuli_wdr.cpp:782 src/muuli_wdr.cpp:846
-#: src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2252 src/muuli_wdr.cpp:2337
-#: src/muuli_wdr.cpp:3085 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
+#: src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2224 src/muuli_wdr.cpp:2309
+#: src/muuli_wdr.cpp:3057 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
 #: src/ServerListCtrl.cpp:606 src/TransferWnd.cpp:378
 #: src/utils/wxCas/src/wxcasprefs.cpp:235
 msgid "Cancel"
 msgstr "إلغاء"
 
-#: src/amuleDlg.cpp:1030
+#: src/amuleDlg.cpp:965
 #, fuzzy
 msgid "Stop the current connection attempts"
 msgstr "إيقاف محاولة اﻹتصال الحاليه"
 
-#: src/amuleDlg.cpp:1035 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976
-#: src/muuli_wdr.cpp:2475
+#: src/amuleDlg.cpp:970 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976
+#: src/muuli_wdr.cpp:2447
 msgid "Disconnect"
 msgstr "فصل"
 
-#: src/amuleDlg.cpp:1036
+#: src/amuleDlg.cpp:971
 #, fuzzy
 msgid "Disconnect from the currently connected networks"
 msgstr "فصل من المستضيف الحالي"
 
-#: src/amuleDlg.cpp:1041 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979
-#: src/muuli_wdr.cpp:2630 src/muuli_wdr.cpp:3082 src/muuli_wdr.cpp:3437
+#: src/amuleDlg.cpp:976 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979
+#: src/muuli_wdr.cpp:2602 src/muuli_wdr.cpp:3054 src/muuli_wdr.cpp:3409
 msgid "Connect"
 msgstr "إتصال"
 
-#: src/amuleDlg.cpp:1042
+#: src/amuleDlg.cpp:977
 msgid "Connect to the currently enabled networks"
 msgstr ""
 
-#: src/amuleDlg.cpp:1154
+#: src/amuleDlg.cpp:1089
 #, fuzzy, c-format
 msgid "Up: %.1f%s (%.1f) | Down: %.1f%s (%.1f)"
 msgstr "تحميل: %.1f(%.1f) | رفع: %.1f(%.1f)"
 
-#: src/amuleDlg.cpp:1156 src/amuleDlg.cpp:1158 src/amuleDlg.cpp:1162
-#: src/amuleDlg.cpp:1164 src/amuleDlg.cpp:1175 src/amuleDlg.cpp:1177
+#: src/amuleDlg.cpp:1091 src/amuleDlg.cpp:1093 src/amuleDlg.cpp:1097
+#: src/amuleDlg.cpp:1099 src/amuleDlg.cpp:1110 src/amuleDlg.cpp:1112
 #: src/MuleTrayIcon.cpp:796 src/MuleTrayIcon.cpp:799
 msgid " MB/s"
 msgstr ""
 
-#: src/amuleDlg.cpp:1156 src/amuleDlg.cpp:1158 src/amuleDlg.cpp:1162
-#: src/amuleDlg.cpp:1164 src/amuleDlg.cpp:1175 src/amuleDlg.cpp:1177
+#: src/amuleDlg.cpp:1091 src/amuleDlg.cpp:1093 src/amuleDlg.cpp:1097
+#: src/amuleDlg.cpp:1099 src/amuleDlg.cpp:1110 src/amuleDlg.cpp:1112
 #: src/MuleTrayIcon.cpp:796 src/MuleTrayIcon.cpp:799
 #: src/utils/wxCas/src/wxcasframe.cpp:1041
 msgid " kB/s"
 msgstr ""
 
-#: src/amuleDlg.cpp:1161
+#: src/amuleDlg.cpp:1096
 #, fuzzy, c-format
 msgid "Up: %.1f%s | Down: %.1f%s"
 msgstr "رفع : %.1f |تحميل : %.1f"
 
-#: src/amuleDlg.cpp:1193
+#: src/amuleDlg.cpp:1128
 #, c-format
 msgid "aMule (%s | Connected)"
 msgstr ""
 
-#: src/amuleDlg.cpp:1195
+#: src/amuleDlg.cpp:1130
 #, c-format
 msgid "aMule (%s | Disconnected)"
 msgstr ""
 
-#: src/amuleDlg.cpp:1248
+#: src/amuleDlg.cpp:1183
 #, fuzzy, c-format
 msgid "Do you really want to exit %s?"
 msgstr "هل تريد حقا الخروج من البرنامج؟"
 
-#: src/amuleDlg.cpp:1250
+#: src/amuleDlg.cpp:1185
 msgid "Exit confirmation"
 msgstr "تاكيد الخروج"
 
-#: src/amuleDlg.cpp:1613
+#: src/amuleDlg.cpp:1548
 msgid "Launch Command: "
 msgstr ""
 
-#: src/amuleDlg.cpp:1632 src/muuli_wdr.cpp:1972 src/Preferences.cpp:979
+#: src/amuleDlg.cpp:1567 src/muuli_wdr.cpp:1971 src/Preferences.cpp:951
 msgid "- default -"
 msgstr ""
 
-#: src/amuleDlg.cpp:1660
+#: src/amuleDlg.cpp:1595
 #, c-format
 msgid "Skin directory '%s' does not exist"
 msgstr ""
 
-#: src/amuleDlg.cpp:1663
+#: src/amuleDlg.cpp:1598
 #, c-format
 msgid "WARNING: Unable to open skin file '%s' for read"
 msgstr ""
 
-#: src/amuleDlg.cpp:1814 src/muuli_wdr.cpp:3439
+#: src/amuleDlg.cpp:1722 src/amuleDlg.cpp:1968 src/muuli_wdr.cpp:1485
+#: src/muuli_wdr.cpp:3411
+msgid "Networks"
+msgstr ""
+
+#: src/amuleDlg.cpp:1726 src/muuli_wdr.cpp:3411
 msgid "Networks Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1820 src/muuli_wdr.cpp:3440
+#: src/amuleDlg.cpp:1728 src/muuli_wdr.cpp:3412
+msgid "Searches"
+msgstr "بحث"
+
+#: src/amuleDlg.cpp:1732 src/muuli_wdr.cpp:3412
 msgid "Searches Window"
 msgstr "نافذة البحث"
 
-#: src/amuleDlg.cpp:1826 src/muuli_wdr.cpp:3441
+#: src/amuleDlg.cpp:1734 src/DownloadListCtrl.cpp:740 src/muuli_wdr.cpp:392
+#: src/muuli_wdr.cpp:1578 src/muuli_wdr.cpp:3413 src/Statistics.cpp:829
+msgid "Downloads"
+msgstr "تحميل"
+
+#: src/amuleDlg.cpp:1738 src/muuli_wdr.cpp:3413
 #, fuzzy
 msgid "Downloads Window"
 msgstr "تحميل"
 
-#: src/amuleDlg.cpp:1832 src/muuli_wdr.cpp:3443
+#: src/amuleDlg.cpp:1740 src/muuli_wdr.cpp:3287
+msgid "Shared files"
+msgstr ""
+
+#: src/amuleDlg.cpp:1744 src/muuli_wdr.cpp:3415
 msgid "Shared Files Window"
 msgstr "نافذة ملفات المشاركة"
 
-#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3444
+#: src/amuleDlg.cpp:1746 src/muuli_wdr.cpp:2919 src/muuli_wdr.cpp:3369
+#: src/muuli_wdr.cpp:3416
+msgid "Messages"
+msgstr "رسائل"
+
+#: src/amuleDlg.cpp:1750 src/muuli_wdr.cpp:3416
 msgid "Messages Window"
 msgstr "نافذة الرسائل"
 
-#: src/amuleDlg.cpp:1844 src/muuli_wdr.cpp:3445
+#: src/amuleDlg.cpp:1752 src/muuli_wdr.cpp:3417 src/PrefsUnifiedDlg.cpp:312
+#: src/Statistics.cpp:779 src/Statistics.cpp:1235
+msgid "Statistics"
+msgstr "احصائات"
+
+#: src/amuleDlg.cpp:1756 src/muuli_wdr.cpp:3417
 msgid "Statistics Graph Window"
 msgstr "نافذة اﻻحصائيات"
 
-#: src/amuleDlg.cpp:1851 src/muuli_wdr.cpp:3447
+#: src/amuleDlg.cpp:1759 src/muuli_wdr.cpp:3419 src/PrefsUnifiedDlg.cpp:328
+#: src/utils/wxCas/src/wxcasprefs.cpp:39
+msgid "Preferences"
+msgstr "اعدادت"
+
+#: src/amuleDlg.cpp:1763 src/muuli_wdr.cpp:3419
 msgid "Preferences Settings Window"
 msgstr "نافذة اﻹعدادات"
 
-#: src/amuleDlg.cpp:1854 src/muuli_wdr.cpp:3448
+#: src/amuleDlg.cpp:1766 src/muuli_wdr.cpp:3420
 msgid "Import"
 msgstr ""
 
-#: src/amuleDlg.cpp:1858 src/muuli_wdr.cpp:3448
+#: src/amuleDlg.cpp:1770 src/muuli_wdr.cpp:3420
 msgid "The partfile importer tool"
 msgstr ""
 
-#: src/amuleDlg.cpp:1861 src/muuli_wdr.cpp:3449
+#: src/amuleDlg.cpp:1773 src/muuli_wdr.cpp:3421
 #: src/utils/aLinkCreator/src/alcframe.cpp:262
 msgid "About"
 msgstr ""
 
-#: src/amuleDlg.cpp:1861 src/muuli_wdr.cpp:3449
+#: src/amuleDlg.cpp:1773 src/muuli_wdr.cpp:3421
 msgid "About/Help"
 msgstr ""
 
-#: src/amuleDlg.cpp:2059
+#: src/amuleDlg.cpp:1971
 msgid "eD2k network"
 msgstr ""
 
-#: src/amuleDlg.cpp:2062
+#: src/amuleDlg.cpp:1974
 msgid "Kad network"
 msgstr ""
 
-#: src/amuleDlg.cpp:2062
+#: src/amuleDlg.cpp:1974
 msgid "No network"
 msgstr ""
 
@@ -939,7 +934,7 @@ msgstr "ﻻ وجود ﻻجزاء الملفات"
 msgid "The core rejected these shared folders:%s"
 msgstr ""
 
-#: src/amule-remote-gui.cpp:1336 src/ExternalConn.cpp:2346
+#: src/amule-remote-gui.cpp:1336 src/ExternalConn.cpp:2345
 msgid "Invalid link or already on list."
 msgstr ""
 
@@ -955,7 +950,7 @@ msgstr ""
 #: src/ClientDetailDialog.cpp:123 src/DataToText.cpp:61 src/DataToText.cpp:86
 #: src/DataToText.cpp:101 src/DataToText.cpp:136 src/DataToText.cpp:165
 #: src/DownloadListCtrl.cpp:1172 src/DownloadListCtrl.cpp:1185
-#: src/DownloadListCtrl.cpp:1196 src/ExternalConn.cpp:609
+#: src/DownloadListCtrl.cpp:1196 src/ExternalConn.cpp:608
 #: src/FileDetailDialog.cpp:203 src/FileDetailDialog.cpp:235
 #: src/FileDetailDialog.cpp:242 src/GenericClientListCtrl.cpp:1171
 #: src/GenericClientListCtrl.cpp:1182 src/GenericClientListCtrl.cpp:1192
@@ -1343,19 +1338,19 @@ msgstr "ذاتي عالي"
 msgid "Very low"
 msgstr "متدني جدا"
 
-#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:743 src/muuli_wdr.cpp:2303
+#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:743 src/muuli_wdr.cpp:2275
 #: src/ServerListCtrl.cpp:263 src/ServerListCtrl.cpp:456
 #: src/SharedFilesCtrl.cpp:145
 msgid "Low"
 msgstr "متدني"
 
-#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:744 src/muuli_wdr.cpp:2304
+#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:744 src/muuli_wdr.cpp:2276
 #: src/ServerListCtrl.cpp:266 src/ServerListCtrl.cpp:457
 #: src/SharedFilesCtrl.cpp:146
 msgid "Normal"
 msgstr "عادي"
 
-#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:745 src/muuli_wdr.cpp:2305
+#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:745 src/muuli_wdr.cpp:2277
 #: src/ServerListCtrl.cpp:269 src/ServerListCtrl.cpp:458
 #: src/SharedFilesCtrl.cpp:147
 msgid "High"
@@ -1447,8 +1442,8 @@ msgstr ""
 msgid "Remote Server"
 msgstr ""
 
-#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3202
-#: src/SearchDlg.cpp:119 src/TextClient.cpp:911
+#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3174
+#: src/SearchDlg.cpp:111 src/TextClient.cpp:911
 msgid "Kad"
 msgstr ""
 
@@ -1518,7 +1513,7 @@ msgstr ""
 msgid "Size"
 msgstr "حجم"
 
-#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3269
+#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3241
 msgid "Transferred"
 msgstr "نقل"
 
@@ -1576,7 +1571,7 @@ msgid ""
 "\n"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:746 src/muuli_wdr.cpp:2306
+#: src/DownloadListCtrl.cpp:746 src/muuli_wdr.cpp:2278
 #: src/SharedFilesCtrl.cpp:150
 msgid "Auto"
 msgstr "ذاتي"
@@ -1614,7 +1609,7 @@ msgid "Extended Options"
 msgstr "خيرات اضافية"
 
 #: src/DownloadListCtrl.cpp:770 src/DownloadListCtrl.cpp:822
-#: src/muuli_wdr.cpp:1790
+#: src/muuli_wdr.cpp:1789
 msgid "Preview"
 msgstr "مشاهدة"
 
@@ -1787,230 +1782,225 @@ msgstr[1] ""
 msgid "Invalid eD2k link! ERROR: %s"
 msgstr ""
 
-#: src/ExternalConn.cpp:380
+#: src/ExternalConn.cpp:379
 msgid "Client sent packet after authentication failed."
 msgstr ""
 
-#: src/ExternalConn.cpp:397
+#: src/ExternalConn.cpp:396
 msgid "External connection closed."
 msgstr ""
 
-#: src/ExternalConn.cpp:474
+#: src/ExternalConn.cpp:473
 msgid "External connections disabled due to empty password!"
 msgstr ""
 
-#: src/ExternalConn.cpp:495
+#: src/ExternalConn.cpp:494
 msgid "External connections disabled in config file"
 msgstr ""
 
-#: src/ExternalConn.cpp:576
+#: src/ExternalConn.cpp:575
 msgid "New external connection accepted"
 msgstr ""
 
-#: src/ExternalConn.cpp:579
+#: src/ExternalConn.cpp:578
 msgid "ERROR: couldn't accept a new external connection"
 msgstr ""
 
-#: src/ExternalConn.cpp:596
+#: src/ExternalConn.cpp:595
 msgid "External connection refused due to empty password in preferences!"
 msgstr ""
 
-#: src/ExternalConn.cpp:608
+#: src/ExternalConn.cpp:607
 #, c-format
 msgid "Connecting client: %s %s"
 msgstr ""
 
-#: src/ExternalConn.cpp:610
+#: src/ExternalConn.cpp:609
 msgid "Unknown version"
 msgstr ""
 
-#: src/ExternalConn.cpp:623
+#: src/ExternalConn.cpp:622
 msgid "Incorrect EC version ID, there might be binary incompatibility. Use core and remote from same snapshot."
 msgstr ""
 
-#: src/ExternalConn.cpp:631
+#: src/ExternalConn.cpp:630
 msgid "You cannot connect to a release version from an arbitrary development snapshot! *sigh* possible crash prevented"
 msgstr ""
 
-#: src/ExternalConn.cpp:714
+#: src/ExternalConn.cpp:713
 msgid "Invalid protocol version."
 msgstr ""
 
-#: src/ExternalConn.cpp:720
+#: src/ExternalConn.cpp:719
 msgid "Missing protocol version tag."
 msgstr ""
 
-#: src/ExternalConn.cpp:728
+#: src/ExternalConn.cpp:727
 msgid "Authentication failed: invalid hash specified as EC password."
 msgstr ""
 
-#: src/ExternalConn.cpp:776
+#: src/ExternalConn.cpp:775
 msgid "Authentication failed: wrong password."
 msgstr ""
 
-#: src/ExternalConn.cpp:778
+#: src/ExternalConn.cpp:777
 msgid "Authentication failed: missing password."
 msgstr ""
 
-#: src/ExternalConn.cpp:789
+#: src/ExternalConn.cpp:788
 msgid "Invalid request, please authenticate first."
 msgstr ""
 
-#: src/ExternalConn.cpp:794
+#: src/ExternalConn.cpp:793
 msgid "Access granted."
 msgstr ""
 
-#: src/ExternalConn.cpp:802
+#: src/ExternalConn.cpp:801
 #, c-format
 msgid "Sent error message \"%s\" to client."
 msgstr ""
 
-#: src/ExternalConn.cpp:807
+#: src/ExternalConn.cpp:806
 #, c-format
 msgid "Unauthorized access attempt from %s. Connection closed."
 msgstr ""
 
-#: src/ExternalConn.cpp:1420
+#: src/ExternalConn.cpp:1419
 #, c-format
 msgid "Remote PartFile command failed: FileHash not found: %s"
 msgstr ""
 
-#: src/ExternalConn.cpp:1424
+#: src/ExternalConn.cpp:1423
 #, c-format
 msgid "FileHash not found: %s"
 msgstr ""
 
-#: src/ExternalConn.cpp:1471 src/ExternalConn.cpp:1559
-#: src/ExternalConn.cpp:1680
+#: src/ExternalConn.cpp:1470 src/ExternalConn.cpp:1558
+#: src/ExternalConn.cpp:1679
 msgid "OOPS! OpCode processing error!"
 msgstr ""
 
-#: src/ExternalConn.cpp:1502
+#: src/ExternalConn.cpp:1501
 msgid "Server not added"
 msgstr ""
 
-#: src/ExternalConn.cpp:1521
+#: src/ExternalConn.cpp:1520
 #, c-format
 msgid "server not found: %s"
 msgstr ""
 
-#: src/ExternalConn.cpp:1538
+#: src/ExternalConn.cpp:1537
 msgid "need to define server to be removed"
 msgstr ""
 
-#: src/ExternalConn.cpp:1553
+#: src/ExternalConn.cpp:1552
 msgid "eD2k is disabled in preferences."
 msgstr ""
 
-#: src/ExternalConn.cpp:1658
+#: src/ExternalConn.cpp:1657
 msgid "Friend not found."
 msgstr ""
 
-#: src/ExternalConn.cpp:1668
+#: src/ExternalConn.cpp:1667
 msgid "Client not found."
 msgstr ""
 
-#: src/ExternalConn.cpp:1674
+#: src/ExternalConn.cpp:1673
 msgid "EC_TAG_FRIEND_SHARED requires EC_TAG_FRIEND or EC_TAG_CLIENT."
 msgstr ""
 
-#: src/ExternalConn.cpp:1992
+#: src/ExternalConn.cpp:1991
 msgid "WebSearch from remote interface makes no sense."
 msgstr ""
 
-#: src/ExternalConn.cpp:2027
+#: src/ExternalConn.cpp:2026
 msgid "Search in progress. Refetch results in a moment!"
 msgstr "جاري البحث ستم جلب النتيجة في لحظة"
 
-#: src/ExternalConn.cpp:2266
+#: src/ExternalConn.cpp:2265
 msgid "No points for graph."
 msgstr ""
 
-#: src/ExternalConn.cpp:2276
+#: src/ExternalConn.cpp:2275
 msgid "Your client is not configured for this detail level."
 msgstr ""
 
-#: src/ExternalConn.cpp:2303
+#: src/ExternalConn.cpp:2302
 msgid "External Connection: shutdown requested"
 msgstr ""
 
-#: src/ExternalConn.cpp:2315
+#: src/ExternalConn.cpp:2314
 msgid "Already shutting down."
 msgstr ""
 
-#: src/ExternalConn.cpp:2333
+#: src/ExternalConn.cpp:2332
 #, c-format
 msgid "ExternalConn: adding link '%s'."
 msgstr ""
 
-#: src/ExternalConn.cpp:2351
+#: src/ExternalConn.cpp:2350
 #, c-format
 msgid "%d of %d links failed (invalid or already on list)."
 msgstr ""
 
-#: src/ExternalConn.cpp:2374
+#: src/ExternalConn.cpp:2373
 msgid "Version check throttled; try again shortly."
 msgstr ""
 
-#: src/ExternalConn.cpp:2379
+#: src/ExternalConn.cpp:2378
 msgid "Version check is not available on this daemon."
 msgstr ""
 
-#: src/ExternalConn.cpp:2509
+#: src/ExternalConn.cpp:2508
 msgid "File not found."
 msgstr ""
 
-#: src/ExternalConn.cpp:2514
+#: src/ExternalConn.cpp:2513
 msgid "Invalid file name."
 msgstr ""
 
-#: src/ExternalConn.cpp:2522
+#: src/ExternalConn.cpp:2521
 msgid "Unable to rename file."
 msgstr ""
 
-#: src/ExternalConn.cpp:2839
-#, c-format
-msgid "Could not save the amuleapi password: %s"
-msgstr ""
-
-#: src/ExternalConn.cpp:3004 src/ExternalConn.cpp:3032
+#: src/ExternalConn.cpp:2992 src/ExternalConn.cpp:3020
 msgid "Kad is disabled in preferences."
 msgstr ""
 
-#: src/ExternalConn.cpp:3045
+#: src/ExternalConn.cpp:3033
 msgid "Already connected to eD2k."
 msgstr ""
 
-#: src/ExternalConn.cpp:3048
+#: src/ExternalConn.cpp:3036
 msgid "Connecting to eD2k..."
 msgstr ""
 
-#: src/ExternalConn.cpp:3057
+#: src/ExternalConn.cpp:3045
 msgid "Already connected to Kad."
 msgstr ""
 
-#: src/ExternalConn.cpp:3060
+#: src/ExternalConn.cpp:3048
 msgid "Connecting to Kad..."
 msgstr ""
 
-#: src/ExternalConn.cpp:3067
+#: src/ExternalConn.cpp:3055
 msgid "All networks are disabled."
 msgstr ""
 
-#: src/ExternalConn.cpp:3076
+#: src/ExternalConn.cpp:3064
 msgid "Disconnected from eD2k."
 msgstr ""
 
-#: src/ExternalConn.cpp:3081
+#: src/ExternalConn.cpp:3069
 msgid "Disconnected from Kad."
 msgstr ""
 
-#: src/ExternalConn.cpp:3090
+#: src/ExternalConn.cpp:3078
 #, c-format
 msgid "External Connection: invalid opcode received: %#x"
 msgstr ""
 
-#: src/ExternalConn.cpp:3095
+#: src/ExternalConn.cpp:3083
 msgid "Invalid opcode (wrong protocol version?)"
 msgstr ""
 
@@ -2299,19 +2289,19 @@ msgstr ""
 msgid "eD2k"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:349 src/muuli_wdr.cpp:1495
+#: src/FirstRunWizard.cpp:349 src/muuli_wdr.cpp:1488
 msgid "Kademlia"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:359 src/muuli_wdr.cpp:1423
+#: src/FirstRunWizard.cpp:359 src/muuli_wdr.cpp:1416
 msgid "Standard TCP Port "
 msgstr ""
 
-#: src/FirstRunWizard.cpp:365 src/muuli_wdr.cpp:1435
+#: src/FirstRunWizard.cpp:365 src/muuli_wdr.cpp:1428
 msgid "Extended UDP port (Kad / global search) "
 msgstr ""
 
-#: src/FirstRunWizard.cpp:377 src/muuli_wdr.cpp:1442
+#: src/FirstRunWizard.cpp:377 src/muuli_wdr.cpp:1435
 msgid "Enable UPnP for router port forwarding"
 msgstr ""
 
@@ -2337,7 +2327,7 @@ msgstr ""
 msgid "Your peer lists are already in place - nothing to download."
 msgstr "قمت بمحاولت تحميل الملف مسبقا %s"
 
-#: src/FirstRunWizard.cpp:434 src/muuli_wdr.cpp:1540
+#: src/FirstRunWizard.cpp:434 src/muuli_wdr.cpp:1533
 msgid "Auto-update server list at startup"
 msgstr ""
 
@@ -2383,23 +2373,23 @@ msgid ""
 "want downloads on a different (e.g. larger) disk."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:549 src/FirstRunWizard.cpp:611 src/muuli_wdr.cpp:1702
+#: src/FirstRunWizard.cpp:549 src/FirstRunWizard.cpp:611 src/muuli_wdr.cpp:1701
 msgid "Destination folder for downloads"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:553 src/FirstRunWizard.cpp:569 src/muuli_wdr.cpp:1349
-#: src/muuli_wdr.cpp:1366 src/muuli_wdr.cpp:1677 src/muuli_wdr.cpp:1708
-#: src/muuli_wdr.cpp:1720 src/muuli_wdr.cpp:2790
+#: src/FirstRunWizard.cpp:553 src/FirstRunWizard.cpp:569 src/muuli_wdr.cpp:1342
+#: src/muuli_wdr.cpp:1359 src/muuli_wdr.cpp:1676 src/muuli_wdr.cpp:1707
+#: src/muuli_wdr.cpp:1719 src/muuli_wdr.cpp:2762
 #: src/utils/aLinkCreator/src/alcframe.cpp:135
 #: src/utils/wxCas/src/wxcasprefs.cpp:52 src/utils/wxCas/src/wxcasprefs.cpp:118
 msgid "Browse"
 msgstr "تصفح"
 
-#: src/FirstRunWizard.cpp:559 src/muuli_wdr.cpp:1713
+#: src/FirstRunWizard.cpp:559 src/muuli_wdr.cpp:1712
 msgid "(All files in this folder are shared with other peers)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:565 src/FirstRunWizard.cpp:624 src/muuli_wdr.cpp:1715
+#: src/FirstRunWizard.cpp:565 src/FirstRunWizard.cpp:624 src/muuli_wdr.cpp:1714
 msgid "Folder for temporary download files"
 msgstr ""
 
@@ -2430,7 +2420,7 @@ msgstr ""
 msgid "CRITICAL - no client on StartChatSession"
 msgstr ""
 
-#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2696 src/muuli_wdr.cpp:3373
+#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2668 src/muuli_wdr.cpp:3345
 msgid "Friends"
 msgstr "اصدقاء"
 
@@ -2541,8 +2531,8 @@ msgstr "ﻻ احد"
 msgid "No"
 msgstr "ﻻ"
 
-#: src/GenericClientListCtrl.cpp:1216 src/PrefsUnifiedDlg.cpp:2898
-#: src/PrefsUnifiedDlg.cpp:2948 src/ServerListCtrl.cpp:276
+#: src/GenericClientListCtrl.cpp:1216 src/PrefsUnifiedDlg.cpp:2818
+#: src/PrefsUnifiedDlg.cpp:2868 src/ServerListCtrl.cpp:276
 msgid "Yes"
 msgstr "نعم"
 
@@ -2710,10 +2700,10 @@ msgstr ""
 msgid "Please fill all fields required"
 msgstr ""
 
-#: src/KadDlg.cpp:192 src/PartFile.cpp:1031 src/PrefsUnifiedDlg.cpp:1134
-#: src/PrefsUnifiedDlg.cpp:1204 src/PrefsUnifiedDlg.cpp:1405
-#: src/PrefsUnifiedDlg.cpp:1663 src/PrefsUnifiedDlg.cpp:1673
-#: src/PrefsUnifiedDlg.cpp:1690 src/PrefsUnifiedDlg.cpp:1738
+#: src/KadDlg.cpp:192 src/PartFile.cpp:1031 src/PrefsUnifiedDlg.cpp:1162
+#: src/PrefsUnifiedDlg.cpp:1331 src/PrefsUnifiedDlg.cpp:1589
+#: src/PrefsUnifiedDlg.cpp:1599 src/PrefsUnifiedDlg.cpp:1616
+#: src/PrefsUnifiedDlg.cpp:1658
 msgid "Message"
 msgstr ""
 
@@ -2814,7 +2804,7 @@ msgstr ""
 msgid "Uploaded"
 msgstr ""
 
-#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3253
+#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3225
 msgid "Requested"
 msgstr ""
 
@@ -2939,7 +2929,7 @@ msgid "WARNING: "
 msgstr ""
 
 #: src/MuleNotebook.cpp:179 src/muuli_wdr.cpp:817 src/muuli_wdr.cpp:1229
-#: src/muuli_wdr.cpp:3157 src/muuli_wdr.cpp:3413
+#: src/muuli_wdr.cpp:3129 src/muuli_wdr.cpp:3385
 msgid "Close"
 msgstr "اغلق"
 
@@ -2952,12 +2942,12 @@ msgstr ""
 msgid "Copy"
 msgstr ""
 
-#: src/MuleTextCtrl.cpp:88 src/SearchDlg.cpp:261
+#: src/MuleTextCtrl.cpp:88
 msgid "Paste"
 msgstr ""
 
 #: src/MuleTextCtrl.cpp:89 src/muuli_wdr.cpp:358 src/muuli_wdr.cpp:757
-#: src/muuli_wdr.cpp:2380 src/muuli_wdr.cpp:2399 src/muuli_wdr.cpp:2421
+#: src/muuli_wdr.cpp:2352 src/muuli_wdr.cpp:2371 src/muuli_wdr.cpp:2393
 #: src/utils/aLinkCreator/src/alcframe.cpp:142
 msgid "Clear"
 msgstr "واضح"
@@ -3052,8 +3042,8 @@ msgid "Exit"
 msgstr "خروج"
 
 #: src/MuleTrayIcon.cpp:579 src/MuleTrayIcon.cpp:945 src/MuleTrayIcon.cpp:965
-#: src/muuli_wdr.cpp:1398 src/muuli_wdr.cpp:1406 src/muuli_wdr.cpp:1413
-#: src/muuli_wdr.cpp:1836 src/muuli_wdr.cpp:1842 src/OtherFunctions.cpp:91
+#: src/muuli_wdr.cpp:1391 src/muuli_wdr.cpp:1399 src/muuli_wdr.cpp:1406
+#: src/muuli_wdr.cpp:1835 src/muuli_wdr.cpp:1841 src/OtherFunctions.cpp:91
 #: src/StatisticsDlg.cpp:93 src/StatisticsDlg.cpp:95
 msgid "kB/s"
 msgstr ""
@@ -3223,7 +3213,7 @@ msgstr ""
 msgid "Type"
 msgstr "نوع"
 
-#: src/muuli_wdr.cpp:215 src/SearchDlg.cpp:118 src/SearchListCtrl.cpp:853
+#: src/muuli_wdr.cpp:215 src/SearchDlg.cpp:110 src/SearchListCtrl.cpp:853
 msgid "Local"
 msgstr ""
 
@@ -3294,7 +3284,7 @@ msgstr "بايت"
 msgid "KB"
 msgstr ""
 
-#: src/muuli_wdr.cpp:274 src/muuli_wdr.cpp:293 src/muuli_wdr.cpp:1621
+#: src/muuli_wdr.cpp:274 src/muuli_wdr.cpp:293 src/muuli_wdr.cpp:1620
 #: src/OtherFunctions.cpp:64
 msgid "MB"
 msgstr ""
@@ -3311,7 +3301,7 @@ msgstr "اكبر حجم"
 msgid "Availability"
 msgstr ""
 
-#: src/muuli_wdr.cpp:312 src/muuli_wdr.cpp:398 src/muuli_wdr.cpp:3318
+#: src/muuli_wdr.cpp:312 src/muuli_wdr.cpp:398 src/muuli_wdr.cpp:3290
 msgid "Filter:"
 msgstr ""
 
@@ -3343,7 +3333,7 @@ msgstr ""
 msgid "Stop"
 msgstr ""
 
-#: src/muuli_wdr.cpp:348 src/muuli_wdr.cpp:1392 src/SearchListCtrl.cpp:732
+#: src/muuli_wdr.cpp:348 src/muuli_wdr.cpp:1385 src/SearchListCtrl.cpp:732
 msgid "Download"
 msgstr "التحميل"
 
@@ -3375,12 +3365,12 @@ msgstr "ايجاد المصدر :"
 #: src/muuli_wdr.cpp:1160 src/muuli_wdr.cpp:1167 src/muuli_wdr.cpp:1172
 #: src/muuli_wdr.cpp:1179 src/muuli_wdr.cpp:1184 src/muuli_wdr.cpp:1191
 #: src/muuli_wdr.cpp:1205 src/muuli_wdr.cpp:1212 src/muuli_wdr.cpp:1217
-#: src/muuli_wdr.cpp:1224 src/muuli_wdr.cpp:3255 src/muuli_wdr.cpp:3263
-#: src/muuli_wdr.cpp:3271
+#: src/muuli_wdr.cpp:1224 src/muuli_wdr.cpp:3227 src/muuli_wdr.cpp:3235
+#: src/muuli_wdr.cpp:3243
 msgid "N/A"
 msgstr "غير متوفر"
 
-#: src/muuli_wdr.cpp:508 src/muuli_wdr.cpp:1065 src/PrefsUnifiedDlg.cpp:299
+#: src/muuli_wdr.cpp:508 src/muuli_wdr.cpp:1065 src/PrefsUnifiedDlg.cpp:297
 msgid "General"
 msgstr "عام"
 
@@ -3519,7 +3509,7 @@ msgstr ""
 msgid "Album :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:685 src/muuli_wdr.cpp:2275
+#: src/muuli_wdr.cpp:685 src/muuli_wdr.cpp:2247
 msgid "Title :"
 msgstr "عنوان :"
 
@@ -3625,7 +3615,7 @@ msgstr "اسم المستخدم :"
 msgid "Userhash :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:895 src/muuli_wdr.cpp:1742 src/muuli_wdr.cpp:2470
+#: src/muuli_wdr.cpp:895 src/muuli_wdr.cpp:1741 src/muuli_wdr.cpp:2442
 #: src/utils/aLinkCreator/src/alcframe.cpp:137
 msgid "Add"
 msgstr "اضف"
@@ -3634,15 +3624,15 @@ msgstr "اضف"
 msgid "Download-Speed"
 msgstr "سرعة-التحميل"
 
-#: src/muuli_wdr.cpp:954 src/muuli_wdr.cpp:989 src/muuli_wdr.cpp:2574
+#: src/muuli_wdr.cpp:954 src/muuli_wdr.cpp:989 src/muuli_wdr.cpp:2546
 msgid "Current"
 msgstr "الحالي"
 
-#: src/muuli_wdr.cpp:962 src/muuli_wdr.cpp:997 src/muuli_wdr.cpp:2582
+#: src/muuli_wdr.cpp:962 src/muuli_wdr.cpp:997 src/muuli_wdr.cpp:2554
 msgid "Running average"
 msgstr "معدل العمل"
 
-#: src/muuli_wdr.cpp:970 src/muuli_wdr.cpp:1005 src/muuli_wdr.cpp:2590
+#: src/muuli_wdr.cpp:970 src/muuli_wdr.cpp:1005 src/muuli_wdr.cpp:2562
 msgid "Session average"
 msgstr "معدل الجلسة"
 
@@ -3654,7 +3644,7 @@ msgstr "سرعة-الرفع"
 msgid "Connections"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1024 src/muuli_wdr.cpp:1861
+#: src/muuli_wdr.cpp:1024 src/muuli_wdr.cpp:1860
 msgid "Active downloads"
 msgstr "تحميل نشط"
 
@@ -3662,7 +3652,7 @@ msgstr "تحميل نشط"
 msgid "Active connections (1:1)"
 msgstr "إتصال نشط (1:1)"
 
-#: src/muuli_wdr.cpp:1040 src/muuli_wdr.cpp:1862
+#: src/muuli_wdr.cpp:1040 src/muuli_wdr.cpp:1861
 msgid "Active uploads"
 msgstr "رفع نشط"
 
@@ -3779,8 +3769,8 @@ msgstr ""
 msgid "Language: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1257 src/muuli_wdr.cpp:1330 src/muuli_wdr.cpp:1334
-#: src/muuli_wdr.cpp:1337
+#: src/muuli_wdr.cpp:1257 src/muuli_wdr.cpp:1323 src/muuli_wdr.cpp:1327
+#: src/muuli_wdr.cpp:1330
 msgid "The delay before showing tool-tips."
 msgstr ""
 
@@ -3856,949 +3846,929 @@ msgstr ""
 msgid "Enabling this will make aMule to show notifications when finished downloading."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1323
-msgid "Remember search history"
-msgstr ""
-
-#: src/muuli_wdr.cpp:1324
-msgid "Keeps a dropdown list of your past search terms in the Search tab's Name field. This remembers the queries you typed, not the results they returned."
-msgstr ""
-
-#: src/muuli_wdr.cpp:1329
+#: src/muuli_wdr.cpp:1322
 msgid "Tooltip delay time: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1336
+#: src/muuli_wdr.cpp:1329
 msgid "seconds"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1340
+#: src/muuli_wdr.cpp:1333
 msgid "Browser Selection"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1346
+#: src/muuli_wdr.cpp:1339
 msgid "Enter your browser name here. Leave this field empty to use the system default browser."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1353
+#: src/muuli_wdr.cpp:1346
 msgid "Open in new tab if possible"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1355
+#: src/muuli_wdr.cpp:1348
 msgid "Open the web page in a new tab instead of in a new window when possible"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1359
+#: src/muuli_wdr.cpp:1352
 msgid "Video Player"
 msgstr "مشغل الفيديو"
 
-#: src/muuli_wdr.cpp:1386
+#: src/muuli_wdr.cpp:1379
 msgid "Bandwidth limits"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1400
+#: src/muuli_wdr.cpp:1393
 msgid "Upload"
 msgstr "الرفع"
 
-#: src/muuli_wdr.cpp:1408
+#: src/muuli_wdr.cpp:1401
 msgid "Slot Allocation"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1417
+#: src/muuli_wdr.cpp:1410
 msgid "Ports"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1427
+#: src/muuli_wdr.cpp:1420
 msgid "This is the standard eD2k port and cannot be disabled."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1430
+#: src/muuli_wdr.cpp:1423
 msgid "UDP port for server requests (TCP+3):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1432
+#: src/muuli_wdr.cpp:1425
 msgid "4665"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1439
+#: src/muuli_wdr.cpp:1432
 msgid "This UDP port is used for extended eD2k requests and Kad network"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1446
+#: src/muuli_wdr.cpp:1439
 msgid "UPnP TCP Port (Optional):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1456
+#: src/muuli_wdr.cpp:1449
 msgid "Bind local address to IP (empty for any):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1459
+#: src/muuli_wdr.cpp:1452
 msgid "Advanced users only: If you have multiple network interfaces, enter the address of the interface to which aMule should be bound."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1462 src/muuli_wdr.cpp:2055
+#: src/muuli_wdr.cpp:1455 src/muuli_wdr.cpp:2054
 msgid "Bind to network interface (empty for any):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1475
+#: src/muuli_wdr.cpp:1468
 msgid "Advanced users only: pin all of aMule's traffic to one network interface, chosen from the list or typed in by name (e.g. tun0, eth0, en0) or index. Unlike binding to an IP, this stops traffic leaking out via the default route - useful with a VPN. Requires no elevated privileges."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1481
+#: src/muuli_wdr.cpp:1474
 msgid "Max sources per downloading file:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1485
+#: src/muuli_wdr.cpp:1478
 msgid "Max simultaneous connections:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1498 src/muuli_wdr.cpp:3197
+#: src/muuli_wdr.cpp:1491 src/muuli_wdr.cpp:3169
 msgid "ED2K"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1505
+#: src/muuli_wdr.cpp:1498
 msgid "Autoconnect on startup"
 msgstr "ربط تلقائي عند بدء التشغيل"
 
-#: src/muuli_wdr.cpp:1508
+#: src/muuli_wdr.cpp:1501
 msgid "Reconnect on loss"
 msgstr "إعادة اﻹتصال عند الفصل"
 
-#: src/muuli_wdr.cpp:1530
+#: src/muuli_wdr.cpp:1523
 msgid "Remove dead server after"
 msgstr "إحذ الخادمات التي ﻻ تعمل بعد"
 
-#: src/muuli_wdr.cpp:1531
+#: src/muuli_wdr.cpp:1524
 msgid "Static servers are never removed, even when unreachable."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1535
+#: src/muuli_wdr.cpp:1528
 msgid "retries"
 msgstr "أعد المحاولة"
 
-#: src/muuli_wdr.cpp:1543
+#: src/muuli_wdr.cpp:1536
 msgid "List"
 msgstr "قائمة"
 
-#: src/muuli_wdr.cpp:1546
+#: src/muuli_wdr.cpp:1539
 msgid "Update server list when connecting to a server"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1549
+#: src/muuli_wdr.cpp:1542
 msgid "Update server list when a client connects"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1552
+#: src/muuli_wdr.cpp:1545
 msgid "Use priority system"
 msgstr "إستخدم نظام اﻷولوية"
 
-#: src/muuli_wdr.cpp:1556
+#: src/muuli_wdr.cpp:1549
 msgid "Use smart LowID check on connect"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1560
+#: src/muuli_wdr.cpp:1553
 msgid "Safe connect"
 msgstr "إتصال أمن"
 
-#: src/muuli_wdr.cpp:1564
+#: src/muuli_wdr.cpp:1557
 msgid "Autoconnect to servers in static list only"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1567
+#: src/muuli_wdr.cpp:1560
 msgid "Set manually added servers to High Priority"
 msgstr "جعل الخادمات المضافة يدويا ذو اولوية عالية"
 
-#: src/muuli_wdr.cpp:1588
+#: src/muuli_wdr.cpp:1581
 msgid "Add files to download in pause mode"
 msgstr "أضف الملفات للتحميل بوضع متوقف"
 
-#: src/muuli_wdr.cpp:1590
+#: src/muuli_wdr.cpp:1583
 msgid "Add files to download with auto priority"
 msgstr "أضف الملفات للتحميل بوضع ذاتي"
 
-#: src/muuli_wdr.cpp:1593
+#: src/muuli_wdr.cpp:1586
 msgid "Try to download first and last chunks first"
 msgstr "حاول تحميل القطع اﻻولى واﻻخيرة اوﻻ"
 
-#: src/muuli_wdr.cpp:1597
+#: src/muuli_wdr.cpp:1590
 msgid "Endgame mode: rotate to faster sources for the final blocks"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1600
+#: src/muuli_wdr.cpp:1593
 msgid "Start next paused file when a file completes"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1603
+#: src/muuli_wdr.cpp:1596
 msgid "From the same category"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1605
+#: src/muuli_wdr.cpp:1598
 msgid "In alphabetic order"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1607
+#: src/muuli_wdr.cpp:1600
 msgid "Preallocate disk space for new files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1608
+#: src/muuli_wdr.cpp:1601
 msgid "For new files preallocates disk space for the whole file, thus reduces fragmentation"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1613
+#: src/muuli_wdr.cpp:1606
+msgid "Create new files as sparse files"
+msgstr ""
+
+#: src/muuli_wdr.cpp:1607
+msgid "A sparse file reserves its full size on disk immediately without writing real data to it -- fast, but unsupported or slow on some filesystems, and free-space accounting stays optimistic while the download is in progress. Turn this off to grow the file only as data arrives."
+msgstr ""
+
+#: src/muuli_wdr.cpp:1612
 msgid "Stop downloads when free disk space reaches "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1614
+#: src/muuli_wdr.cpp:1613
 msgid "Select this if you want aMule to check your disk space"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1618
+#: src/muuli_wdr.cpp:1617
 msgid "Enter here the min disk space desired."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1624
+#: src/muuli_wdr.cpp:1623
 msgid "Save 10 sources on rare files (< 20 sources)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1628 src/Statistics.cpp:790
+#: src/muuli_wdr.cpp:1627 src/Statistics.cpp:790
 msgid "Uploads"
 msgstr "ارفع"
 
-#: src/muuli_wdr.cpp:1631
+#: src/muuli_wdr.cpp:1630
 msgid "Add new shared files with auto priority"
 msgstr "أضف ملفات مشاركة جديدة بوضع ذاتي"
 
-#: src/muuli_wdr.cpp:1637
+#: src/muuli_wdr.cpp:1636
 msgid "Intelligent Corruption Handling (I.C.H.)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1640
+#: src/muuli_wdr.cpp:1639
 msgid "Enable"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1643
+#: src/muuli_wdr.cpp:1642
 msgid "Advanced I.C.H. trusts every hash (not recommended)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1655 src/PrefsUnifiedDlg.cpp:1990
+#: src/muuli_wdr.cpp:1654 src/PrefsUnifiedDlg.cpp:1910
 msgid "Media metadata extraction"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1659
+#: src/muuli_wdr.cpp:1658
 msgid "Extract length / bitrate / codec from shared audio and video files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1661
+#: src/muuli_wdr.cpp:1660
 msgid "When enabled, aMule runs ffprobe on each shared media file to fill in the Length / Bitrate / Codec columns other clients see when they find the file in a search. Requires ffmpeg (the ffprobe binary) to be installed."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1668
+#: src/muuli_wdr.cpp:1667
 msgid "Path to ffprobe:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1673
+#: src/muuli_wdr.cpp:1672
 msgid "Full path to the ffprobe binary. Leave empty to have aMule auto-detect it on startup."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1681
+#: src/muuli_wdr.cpp:1680
 msgid "Detect"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1682
+#: src/muuli_wdr.cpp:1681
 msgid "Search the standard install locations for an ffprobe binary and fill the path field."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1706
+#: src/muuli_wdr.cpp:1705
 msgid ""
 "Completed downloads are stored here. All files in this folder are automatically shared with other peers.\n"
 "If this folder also holds files you don't want to share, point it at an aMule-only sub-folder."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1709
+#: src/muuli_wdr.cpp:1708
 msgid "Pick the folder where completed downloads will be stored. All files in that folder will be shared with other peers."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1723
+#: src/muuli_wdr.cpp:1722
 msgid "Shared folders"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1729
+#: src/muuli_wdr.cpp:1728
 msgid "(Folders shared by the core. Enter a path to add one.)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1737
+#: src/muuli_wdr.cpp:1736
 msgid "Absolute path of a folder on the core's machine, e.g. /home/user/shared"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1739 src/PrefsUnifiedDlg.cpp:2874
+#: src/muuli_wdr.cpp:1738 src/PrefsUnifiedDlg.cpp:2794
 msgid "Recursive"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1740
+#: src/muuli_wdr.cpp:1739
 msgid "Share every sub-folder underneath this one, including ones created later."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1744 src/utils/aLinkCreator/src/alcframe.cpp:141
+#: src/muuli_wdr.cpp:1743 src/utils/aLinkCreator/src/alcframe.cpp:141
 msgid "Remove"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1748
+#: src/muuli_wdr.cpp:1747
 msgid "(Right click on folder icon for recursive share)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1755
+#: src/muuli_wdr.cpp:1754
 msgid "Share hidden files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1761
+#: src/muuli_wdr.cpp:1760
 msgid "Automatically rescan shared folders for changes"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1767
+#: src/muuli_wdr.cpp:1766
 msgid "Follow symbolic links in shared folders"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1773
+#: src/muuli_wdr.cpp:1772
 msgid "Exclude files matching:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1776
+#: src/muuli_wdr.cpp:1775
 msgid "Wildcard patterns separated by '|', e.g. .DS_Store|Thumbs.db|*.tmp. Files whose name matches are not shared. Matching is case-insensitive."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1780
+#: src/muuli_wdr.cpp:1779
 msgid "Patterns are regular expressions"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1781
+#: src/muuli_wdr.cpp:1780
 msgid "When set, the whole field is one regular expression ('|' is alternation). When unset, it is a list of '|'-separated wildcards."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1791
+#: src/muuli_wdr.cpp:1790
 msgid "Show how many shared files the current pattern would exclude."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1812
+#: src/muuli_wdr.cpp:1811
 msgid "Graphs"
 msgstr "رسم بياني"
 
-#: src/muuli_wdr.cpp:1815 src/muuli_wdr.cpp:1877
+#: src/muuli_wdr.cpp:1814 src/muuli_wdr.cpp:1876
 msgid "Update delay : 5 secs"
 msgstr "تحيدث كل:5 ثواني"
 
-#: src/muuli_wdr.cpp:1819
+#: src/muuli_wdr.cpp:1818
 msgid "Time for average graph: 100 mins"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1823
+#: src/muuli_wdr.cpp:1822
 msgid "Connections Graph Scale: 100 "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1830
+#: src/muuli_wdr.cpp:1829
 msgid "Download graph scale:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1838
+#: src/muuli_wdr.cpp:1837
 msgid "Upload graph scale:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1848
+#: src/muuli_wdr.cpp:1847
 msgid "Colors: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1852
+#: src/muuli_wdr.cpp:1851
 msgid "Background"
 msgstr "خلفية"
 
-#: src/muuli_wdr.cpp:1853
+#: src/muuli_wdr.cpp:1852
 msgid "Grid"
 msgstr "شبكة"
 
-#: src/muuli_wdr.cpp:1854
+#: src/muuli_wdr.cpp:1853
 msgid "Download current"
 msgstr "حمل الحالي"
 
-#: src/muuli_wdr.cpp:1855
+#: src/muuli_wdr.cpp:1854
 msgid "Download running average"
 msgstr "معدل تحميل الحالي"
 
-#: src/muuli_wdr.cpp:1856
+#: src/muuli_wdr.cpp:1855
 msgid "Download session average"
 msgstr "معدل تحميل الجلسة"
 
-#: src/muuli_wdr.cpp:1857
+#: src/muuli_wdr.cpp:1856
 msgid "Upload current"
 msgstr "ارفع الحالي"
 
-#: src/muuli_wdr.cpp:1858
+#: src/muuli_wdr.cpp:1857
 msgid "Upload running average"
 msgstr "معدل رفع الحالي"
 
-#: src/muuli_wdr.cpp:1859
+#: src/muuli_wdr.cpp:1858
 msgid "Upload session average"
 msgstr "معدل رفع الجلسة"
 
-#: src/muuli_wdr.cpp:1860
+#: src/muuli_wdr.cpp:1859
 msgid "Active connections"
 msgstr "اتصال نشط"
 
-#: src/muuli_wdr.cpp:1863
+#: src/muuli_wdr.cpp:1862
 msgid "Systray Icon Speed Bar"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1864
+#: src/muuli_wdr.cpp:1863
 msgid "Kad-nodes current"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1865
+#: src/muuli_wdr.cpp:1864
 msgid "Kad-nodes running"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1866
+#: src/muuli_wdr.cpp:1865
 msgid "Kad-nodes session"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1870 src/muuli_wdr.cpp:2324
+#: src/muuli_wdr.cpp:1869 src/muuli_wdr.cpp:2296
 msgid "Select"
 msgstr "اختر"
 
-#: src/muuli_wdr.cpp:1874
+#: src/muuli_wdr.cpp:1873
 msgid "Tree"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1884
+#: src/muuli_wdr.cpp:1883
 msgid "Number of Client Versions shown (0=unlimited)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1909
+#: src/muuli_wdr.cpp:1908
 msgid "!!! WARNING !!!"
 msgstr "!!!تحذير!!!"
 
-#: src/muuli_wdr.cpp:1924
+#: src/muuli_wdr.cpp:1923
 msgid "Max new connections / 5 secs"
 msgstr "الحد اﻷعلى للتصالات لكل 5 ثواني"
 
-#: src/muuli_wdr.cpp:1926
+#: src/muuli_wdr.cpp:1925
 msgid "Concurrent Kad source lookups"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1928
+#: src/muuli_wdr.cpp:1927
 msgid "Kad source re-search interval (minutes)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1930
+#: src/muuli_wdr.cpp:1929
 #, fuzzy
 msgid "Source re-ask interval (minutes)"
 msgstr "فترة تحديث الإتصال بالخادم %i دقيقة"
 
-#: src/muuli_wdr.cpp:1934
+#: src/muuli_wdr.cpp:1933
 msgid "File Buffer Size: 240000 bytes"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1938
+#: src/muuli_wdr.cpp:1937
 msgid "Use MMAP: memory-mapped file access (lower memory use)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1939
+#: src/muuli_wdr.cpp:1938
 msgid "Maps part files into memory instead of buffering them on the heap, lowering the process memory footprint. May reduce download speed on some disks; best for memory-constrained or upload-heavy hosts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1941
+#: src/muuli_wdr.cpp:1940
 msgid "Upload Queue Size: 5000 clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1945
+#: src/muuli_wdr.cpp:1944
 msgid "Server connection refresh interval: Disable"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1949
+#: src/muuli_wdr.cpp:1948
 msgid "Disable computer's timed standby mode"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1968
+#: src/muuli_wdr.cpp:1967
 msgid "Skin to use: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1977
+#: src/muuli_wdr.cpp:1976
 msgid "Show \"Fast eD2k Links Handler\" in every window."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1980
+#: src/muuli_wdr.cpp:1979
 msgid "Show extended info on categories tabs"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1983
+#: src/muuli_wdr.cpp:1982
 #, fuzzy
 msgid "Show application version on title"
 msgstr "اظهر معدل النقل علي العنوان"
 
-#: src/muuli_wdr.cpp:1985
+#: src/muuli_wdr.cpp:1984
 msgid "Show transfer rates on title"
 msgstr "اظهر معدل النقل علي العنوان"
 
-#: src/muuli_wdr.cpp:1987
+#: src/muuli_wdr.cpp:1986
 msgid "Before application name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1989
+#: src/muuli_wdr.cpp:1988
 msgid "After application name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1992
+#: src/muuli_wdr.cpp:1991
 msgid "Show overhead bandwidth"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1996
+#: src/muuli_wdr.cpp:1995
 msgid "Vertical toolbar orientation"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1998
+#: src/muuli_wdr.cpp:1997
 msgid "Live column sorting (auto-reorder rows as their values change)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2005
+#: src/muuli_wdr.cpp:2004
 msgid "Download Queue Files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2008
+#: src/muuli_wdr.cpp:2007
 msgid "Show progress percentage"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2014
+#: src/muuli_wdr.cpp:2013
 msgid "Show progress bar"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2017
+#: src/muuli_wdr.cpp:2016
 msgid "Flat"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2021
+#: src/muuli_wdr.cpp:2020
 msgid "Round"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2039
+#: src/muuli_wdr.cpp:2038
 msgid "External Connection Parameters"
 msgstr "عوامل اﻻتصال الخارجي"
 
-#: src/muuli_wdr.cpp:2042
+#: src/muuli_wdr.cpp:2041
 msgid "Accept external connections"
 msgstr "اقبل اتصال خارجي"
 
-#: src/muuli_wdr.cpp:2049 src/muuli_wdr.cpp:2108
+#: src/muuli_wdr.cpp:2048 src/muuli_wdr.cpp:2107
 msgid "IP of the listening interface:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2052
+#: src/muuli_wdr.cpp:2051
 msgid "Enter here a valid ip in the a.b.c.d format for the listening EC interface. An empty field or 0.0.0.0 will mean any interface."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2073 src/muuli_wdr.cpp:2184
+#: src/muuli_wdr.cpp:2072 src/muuli_wdr.cpp:2156
 msgid "TCP port:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2079
+#: src/muuli_wdr.cpp:2078
 msgid "Enable UPnP port forwarding on the EC port"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2083 src/muuli_wdr.cpp:3069
+#: src/muuli_wdr.cpp:2082 src/muuli_wdr.cpp:3041
 #: src/utils/wxCas/src/wxcasprefs.cpp:167
 msgid "Password"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2089
+#: src/muuli_wdr.cpp:2088
 msgid "aMule API server parameters"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2092
+#: src/muuli_wdr.cpp:2091
 msgid "Run amuleapi (REST API) on startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2097
+#: src/muuli_wdr.cpp:2096
 msgid "HTTP port:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2111
+#: src/muuli_wdr.cpp:2110
 msgid "The interface amuleapi's HTTP server listens on. 127.0.0.1 (default) accepts only local connections; use 0.0.0.0 or a specific IP to expose it to other hosts (set an admin password below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2116
-msgid "Type a password to set or change it. Stored passwords cannot be shown, so leaving this empty keeps the current one."
-msgstr ""
-
-#: src/muuli_wdr.cpp:2118
+#: src/muuli_wdr.cpp:2113
 msgid "Admin password"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2130 src/muuli_wdr.cpp:2147 src/PrefsUnifiedDlg.cpp:1103
-msgid "A password is set."
-msgstr ""
-
-#: src/muuli_wdr.cpp:2134
-msgid "Enable guest access"
-msgstr ""
-
-#: src/muuli_wdr.cpp:2135
-msgid "Guest sessions may read status and listings but cannot change anything. Turning this off clears the stored guest password."
-msgstr ""
-
-#: src/muuli_wdr.cpp:2139
-msgid "Guest password"
-msgstr ""
-
-#: src/muuli_wdr.cpp:2154
-msgid "Web server parameters"
-msgstr ""
-
-#: src/muuli_wdr.cpp:2157
-msgid "Run webserver on startup (deprecated)"
-msgstr ""
-
-#: src/muuli_wdr.cpp:2163
-msgid "Web template"
-msgstr ""
-
-#: src/muuli_wdr.cpp:2168
-msgid "Full rights password"
-msgstr ""
-
-#: src/muuli_wdr.cpp:2172
-msgid "Enable Low rights User"
-msgstr ""
-
-#: src/muuli_wdr.cpp:2177
+#: src/muuli_wdr.cpp:2118 src/muuli_wdr.cpp:2149
 msgid "Low rights password"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2191
+#: src/muuli_wdr.cpp:2126
+msgid "Web server parameters"
+msgstr ""
+
+#: src/muuli_wdr.cpp:2129
+msgid "Run webserver on startup (deprecated)"
+msgstr ""
+
+#: src/muuli_wdr.cpp:2135
+msgid "Web template"
+msgstr ""
+
+#: src/muuli_wdr.cpp:2140
+msgid "Full rights password"
+msgstr ""
+
+#: src/muuli_wdr.cpp:2144
+msgid "Enable Low rights User"
+msgstr ""
+
+#: src/muuli_wdr.cpp:2163
 msgid "Enable UPnP port forwarding of the web server port"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2196
+#: src/muuli_wdr.cpp:2168
 msgid "Web server UPnP TCP port (Optional)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2204
+#: src/muuli_wdr.cpp:2176
 msgid "Page Refresh Time (in secs)"
 msgstr "زمن تحديث الصفحة (بالثانية)"
 
-#: src/muuli_wdr.cpp:2211
+#: src/muuli_wdr.cpp:2183
 msgid "Enable Gzip compression"
 msgstr " Gzipتمكين ضغط نوع"
 
-#: src/muuli_wdr.cpp:2245
+#: src/muuli_wdr.cpp:2217
 #, fuzzy
 msgid "Reset page to defaults"
 msgstr "اﻹفتراضية بالنظام"
 
-#: src/muuli_wdr.cpp:2246
+#: src/muuli_wdr.cpp:2218
 msgid "Reset the settings on the current page to their default values."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2248 src/muuli_wdr.cpp:2334 src/ServerWnd.cpp:274
+#: src/muuli_wdr.cpp:2220 src/muuli_wdr.cpp:2306 src/ServerWnd.cpp:274
 #: src/ServerWnd.cpp:282
 msgid "OK"
 msgstr "موافق"
 
-#: src/muuli_wdr.cpp:2250
+#: src/muuli_wdr.cpp:2222
 msgid "Click here to apply any changes made to the preferences."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2253
+#: src/muuli_wdr.cpp:2225
 msgid "Reset any changes made to the preferences."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2282
+#: src/muuli_wdr.cpp:2254
 msgid "Comment :"
 msgstr "تعليق :"
 
-#: src/muuli_wdr.cpp:2289
+#: src/muuli_wdr.cpp:2261
 msgid "Incoming Dir :"
 msgstr "مجلد القادم"
 
-#: src/muuli_wdr.cpp:2298
+#: src/muuli_wdr.cpp:2270
 msgid "Change priority for new assigned files :"
 msgstr "تغير الأولوية للملفات الحديثة :"
 
-#: src/muuli_wdr.cpp:2302
+#: src/muuli_wdr.cpp:2274
 #, fuzzy
 msgid "Don't change"
 msgstr "ﻻ تغير"
 
-#: src/muuli_wdr.cpp:2314
+#: src/muuli_wdr.cpp:2286
 msgid "Select color for this Category (currently selected) :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2381 src/muuli_wdr.cpp:2400 src/muuli_wdr.cpp:2422
+#: src/muuli_wdr.cpp:2353 src/muuli_wdr.cpp:2372 src/muuli_wdr.cpp:2394
 msgid "Click this button to reset the log."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2441
+#: src/muuli_wdr.cpp:2413
 msgid "Click on this button to update the servers list from URL ..."
 msgstr "قم بالضغط على هذا الزر لتحديث قائمة الخادمات من العنوان ..."
 
-#: src/muuli_wdr.cpp:2445
+#: src/muuli_wdr.cpp:2417
 msgid "Server list"
 msgstr "قائمة الخادمات"
 
-#: src/muuli_wdr.cpp:2449
+#: src/muuli_wdr.cpp:2421
 msgid "Enter the url to a server.met file here and press the button to the left to update the list of known servers."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2454
+#: src/muuli_wdr.cpp:2426
 msgid "Add server manually: Name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2457
+#: src/muuli_wdr.cpp:2429
 msgid "Enter the name of the new server here"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2459 src/ServerWnd.cpp:206
+#: src/muuli_wdr.cpp:2431 src/ServerWnd.cpp:206
 msgid "IP:Port"
 msgstr "عنوان شبكي :منفذ"
 
-#: src/muuli_wdr.cpp:2462
+#: src/muuli_wdr.cpp:2434
 msgid "Enter the IP of the server here, using the x.x.x.x format."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2468
+#: src/muuli_wdr.cpp:2440
 msgid "Enter the port of the server here."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2471
+#: src/muuli_wdr.cpp:2443
 msgid "Add manually a server (fill fields to the left before) ..."
 msgstr "اضف خادم يدويا )قم بمل الخانة على اليسار اوﻻ)..."
 
-#: src/muuli_wdr.cpp:2500
+#: src/muuli_wdr.cpp:2472
 msgid "aMule Log"
 msgstr "سجل aMule"
 
-#: src/muuli_wdr.cpp:2508
+#: src/muuli_wdr.cpp:2480
 msgid "Server Info"
 msgstr "معلومات الخادم"
 
-#: src/muuli_wdr.cpp:2512
+#: src/muuli_wdr.cpp:2484
 msgid "ED2K Info"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2516
+#: src/muuli_wdr.cpp:2488
 msgid "Kad Info"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2544
+#: src/muuli_wdr.cpp:2516
 msgid "Click on this button to update the nodes list from URL ..."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2548
+#: src/muuli_wdr.cpp:2520
 msgid "Nodes (0)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2552
+#: src/muuli_wdr.cpp:2524
 msgid "Enter the url to a nodes.dat file here and press the button to the left to update the list of known nodes."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2555
+#: src/muuli_wdr.cpp:2527
 msgid "Nodes stats"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2597
+#: src/muuli_wdr.cpp:2569
 msgid "Bootstrap"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2600
+#: src/muuli_wdr.cpp:2572
 msgid "New node"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2605
+#: src/muuli_wdr.cpp:2577
 msgid "IP:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2625
+#: src/muuli_wdr.cpp:2597
 msgid "Port:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2638
+#: src/muuli_wdr.cpp:2610
 msgid "Bootstrap from known clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2640
+#: src/muuli_wdr.cpp:2612
 msgid "Disconnect Kad"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2674
+#: src/muuli_wdr.cpp:2646
 msgid "Use Secure User Identification"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2676
+#: src/muuli_wdr.cpp:2648
 msgid "It is recommended to enable this option. You will not receive credits if SUI is not enabled."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2678
+#: src/muuli_wdr.cpp:2650
 msgid "Protocol Obfuscation"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2681
+#: src/muuli_wdr.cpp:2653
 msgid "Support Protocol Obfuscation"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2683
+#: src/muuli_wdr.cpp:2655
 msgid "This option enabled Protocol Obfuscation, and makes aMule accept obfuscated connections from other clients."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2685
+#: src/muuli_wdr.cpp:2657
 msgid "Use obfuscation for outgoing connections"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2687
+#: src/muuli_wdr.cpp:2659
 msgid "This option makes aMule use Protocol Obfuscation when connecting other clients/servers."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2689
+#: src/muuli_wdr.cpp:2661
 msgid "Accept only obfuscated connections"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2690
+#: src/muuli_wdr.cpp:2662
 msgid "This option makes aMule only accept obfuscated connections. You will have less sources, but all your traffic will be obfuscated"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2695
+#: src/muuli_wdr.cpp:2667
 msgid "Everybody"
 msgstr "الكل"
 
-#: src/muuli_wdr.cpp:2697
+#: src/muuli_wdr.cpp:2669
 msgid "No one"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2699
+#: src/muuli_wdr.cpp:2671
 msgid "Who can see my shared files:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2700
+#: src/muuli_wdr.cpp:2672
 msgid "Select who can request to view a list of your shared files."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2702
+#: src/muuli_wdr.cpp:2674
 msgid "IP-Filtering"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2709
+#: src/muuli_wdr.cpp:2681
 msgid "Filter clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2711
+#: src/muuli_wdr.cpp:2683
 msgid "Enable filtering of the client IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2713
+#: src/muuli_wdr.cpp:2685
 msgid "Filter servers"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2715
+#: src/muuli_wdr.cpp:2687
 msgid "Enable filtering of the server IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2719
+#: src/muuli_wdr.cpp:2691
 msgid "Reload List"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2720
+#: src/muuli_wdr.cpp:2692
 msgid "Reload the list of IPs to filter from the file ~/.aMule/ipfilter.dat"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2726
+#: src/muuli_wdr.cpp:2698
 msgid "URL:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2730 src/muuli_wdr.cpp:2923
+#: src/muuli_wdr.cpp:2702 src/muuli_wdr.cpp:2895
 msgid "Update now"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2733
+#: src/muuli_wdr.cpp:2705
 msgid "Auto-update ipfilter at startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2737
+#: src/muuli_wdr.cpp:2709
 msgid "Filtering Level:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2743
+#: src/muuli_wdr.cpp:2715
 msgid "Always filter LAN IPs"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2746
+#: src/muuli_wdr.cpp:2718
 msgid "Paranoid handling of non-matching IPs"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2748
+#: src/muuli_wdr.cpp:2720
 msgid "Rejects a packet when its source IP differs from the IP the client claims (an anti-spoofing check). Disable only if it causes connection problems."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2750
+#: src/muuli_wdr.cpp:2722
 msgid "Use system-wide ipfilter.dat if available"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2751
+#: src/muuli_wdr.cpp:2723
 msgid "If there's no local ipfilter.dat found, allow usage of a system-wide ipfilter file."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2768
+#: src/muuli_wdr.cpp:2740
 msgid "Enable Online-Signature"
 msgstr "تمكين التوقيع الشبكي"
 
-#: src/muuli_wdr.cpp:2770
+#: src/muuli_wdr.cpp:2742
 msgid "Enables the writing of the OS file, which can be used by external apps to create signatures and the like."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2774
+#: src/muuli_wdr.cpp:2746
 msgid "Update Frequency (Secs):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2777
+#: src/muuli_wdr.cpp:2749
 msgid "Change the frequency (in seconds) of Online Signature updates."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2785
+#: src/muuli_wdr.cpp:2757
 msgid "Save online signature file in: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:2791
+#: src/muuli_wdr.cpp:2763
 msgid "Click here to select the directory containing the the Online Signature files."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2824
+#: src/muuli_wdr.cpp:2796
 msgid "Show country flags for clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2825
+#: src/muuli_wdr.cpp:2797
 msgid "Render the country flag column in the transfers, queue and search views. Requires a valid MMDB GeoIP database (see below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2830
+#: src/muuli_wdr.cpp:2802
 #, fuzzy
 msgid "Database"
 msgstr "نسبة المصادر :"
 
-#: src/muuli_wdr.cpp:2846
+#: src/muuli_wdr.cpp:2818
 #, fuzzy
 msgid "Source:"
 msgstr "مصدر"
 
-#: src/muuli_wdr.cpp:2849
+#: src/muuli_wdr.cpp:2821
 msgid "DB-IP (free, no account)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2850
+#: src/muuli_wdr.cpp:2822
 msgid "MaxMind GeoLite2 (free, account required)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2851
+#: src/muuli_wdr.cpp:2823
 msgid "Custom URL"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2854
+#: src/muuli_wdr.cpp:2826
 msgid "Choose which provider supplies the GeoIP MMDB database. DB-IP is the default - no account required. MaxMind requires a free account + license key. Use Custom URL to point at any other MMDB host (e.g. a local mirror)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2871
+#: src/muuli_wdr.cpp:2843
 msgid ""
 "No configuration required.\n"
 "\n"
@@ -4806,11 +4776,11 @@ msgid ""
 "License: Creative Commons BY 4.0 - https://creativecommons.org/licenses/by/4.0/"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2884
+#: src/muuli_wdr.cpp:2856
 msgid "License key:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2890
+#: src/muuli_wdr.cpp:2862
 msgid ""
 "Sign up for a free MaxMind account, then generate a License Key:\n"
 "https://www.maxmind.com/en/geolite2/signup\n"
@@ -4820,233 +4790,233 @@ msgid ""
 "Requires attribution and account registration; refresh at least every 30 days."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2905
+#: src/muuli_wdr.cpp:2877
 #, fuzzy
 msgid "Download URL:"
 msgstr "التحميل"
 
-#: src/muuli_wdr.cpp:2911
+#: src/muuli_wdr.cpp:2883
 msgid ""
 "Must point to an .mmdb file or a .gz / .tar.gz containing one.\n"
 "URL may include credentials (https://user:pass@host/...).\n"
 "License and attribution terms are set by the upstream URL - you are responsible."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2924
+#: src/muuli_wdr.cpp:2896
 msgid "Download the GeoIP database from the selected source."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2926
+#: src/muuli_wdr.cpp:2898
 #, fuzzy
 msgid "Auto-update on startup"
 msgstr "ربط تلقائي عند بدء التشغيل"
 
-#: src/muuli_wdr.cpp:2927
+#: src/muuli_wdr.cpp:2899
 msgid "Re-download the GeoIP database from the selected source every time aMule starts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2950
+#: src/muuli_wdr.cpp:2922
 msgid "Filter incoming messages (except current chat):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2952
+#: src/muuli_wdr.cpp:2924
 msgid "Filter all messages"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2954
+#: src/muuli_wdr.cpp:2926
 msgid "Filter messages from people not on your friend list"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2956
+#: src/muuli_wdr.cpp:2928
 msgid "Filter messages from unknown clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2958
+#: src/muuli_wdr.cpp:2930
 msgid "Filter messages containing (use ',' as separator):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2961 src/muuli_wdr.cpp:2972
+#: src/muuli_wdr.cpp:2933 src/muuli_wdr.cpp:2944
 msgid "add here the words amule should filter and block messages including it"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2963
+#: src/muuli_wdr.cpp:2935
 msgid "Show received messages in the log"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2966
+#: src/muuli_wdr.cpp:2938
 msgid "Comments"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2969
+#: src/muuli_wdr.cpp:2941
 msgid "Filter comments containing (use ',' as separator):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2994
+#: src/muuli_wdr.cpp:2966
 msgid "Enable Proxy"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2995
+#: src/muuli_wdr.cpp:2967
 msgid "Enable/disable proxy support"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2998
+#: src/muuli_wdr.cpp:2970
 msgid "Proxy type:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3009
+#: src/muuli_wdr.cpp:2981
 msgid "Proxy host:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3012
+#: src/muuli_wdr.cpp:2984
 msgid "The proxy host name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3014
+#: src/muuli_wdr.cpp:2986
 msgid "Proxy port:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3017
+#: src/muuli_wdr.cpp:2989
 msgid "The proxy port"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3019
+#: src/muuli_wdr.cpp:2991
 msgid "Enable authentication"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3020
+#: src/muuli_wdr.cpp:2992
 msgid "Enable/disable username/password authentication"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3023
+#: src/muuli_wdr.cpp:2995
 msgid "Username: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:3026
+#: src/muuli_wdr.cpp:2998
 msgid "The username to use to connect to the proxy"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3028
+#: src/muuli_wdr.cpp:3000
 msgid "Password:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3031
+#: src/muuli_wdr.cpp:3003
 msgid "The password to use to connect to the proxy"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3050
+#: src/muuli_wdr.cpp:3022
 msgid "Connect to:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3059
+#: src/muuli_wdr.cpp:3031
 msgid "Login to remote amule"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3064
+#: src/muuli_wdr.cpp:3036
 msgid "User name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3075
+#: src/muuli_wdr.cpp:3047
 msgid "Remember those settings"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3078
+#: src/muuli_wdr.cpp:3050
 #, fuzzy
 msgid "Force ZLIB compression"
 msgstr "أكتسب بواسطة الضغط :"
 
-#: src/muuli_wdr.cpp:3102
+#: src/muuli_wdr.cpp:3074
 msgid "Enable Verbose Debug-Logging."
 msgstr ""
 
-#: src/muuli_wdr.cpp:3104
+#: src/muuli_wdr.cpp:3076
 #, fuzzy
 msgid "Only to Logfile"
 msgstr "&فتح الملف"
 
-#: src/muuli_wdr.cpp:3106
+#: src/muuli_wdr.cpp:3078
 msgid "Message Categories:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3130 src/PartFileConvertDlg.cpp:160
+#: src/muuli_wdr.cpp:3102 src/PartFileConvertDlg.cpp:160
 msgid "Waiting..."
 msgstr "إنتظار..."
 
-#: src/muuli_wdr.cpp:3150
+#: src/muuli_wdr.cpp:3122
 msgid "Add imports"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3153
+#: src/muuli_wdr.cpp:3125
 msgid "Retry selected"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3155
+#: src/muuli_wdr.cpp:3127
 msgid "Remove selected"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3218
+#: src/muuli_wdr.cpp:3190
 msgid "Event Types"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3237
+#: src/muuli_wdr.cpp:3209
 msgid "Statistics and queued clients for selected file(s) : Session / All time"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3261
+#: src/muuli_wdr.cpp:3233
 #, fuzzy
 msgid "Active Uploads"
 msgstr "رفع نشط :"
 
-#: src/muuli_wdr.cpp:3275
+#: src/muuli_wdr.cpp:3247
 #, fuzzy
 msgid "Percent of total files"
 msgstr "مجموع الملفات"
 
-#: src/muuli_wdr.cpp:3327
+#: src/muuli_wdr.cpp:3299
 #, fuzzy
 msgid "Show Clients for"
 msgstr "منفذ العميل"
 
-#: src/muuli_wdr.cpp:3329
+#: src/muuli_wdr.cpp:3301
 #, fuzzy
 msgid "All files"
 msgstr "ملفات مشاركة"
 
-#: src/muuli_wdr.cpp:3332
+#: src/muuli_wdr.cpp:3304
 #, fuzzy
 msgid "Selected files"
 msgstr "إختر فلتر العرض"
 
-#: src/muuli_wdr.cpp:3335
+#: src/muuli_wdr.cpp:3307
 #, fuzzy
 msgid "Active uploads only"
 msgstr "رفع نشط"
 
-#: src/muuli_wdr.cpp:3342
+#: src/muuli_wdr.cpp:3314
 #, fuzzy
 msgid "Reload:"
 msgstr "اعد تحميل"
 
-#: src/muuli_wdr.cpp:3346
+#: src/muuli_wdr.cpp:3318
 msgid "Reload your shared files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3409
+#: src/muuli_wdr.cpp:3381
 msgid "Send"
 msgstr "ارسل"
 
-#: src/muuli_wdr.cpp:3410
+#: src/muuli_wdr.cpp:3382
 msgid "Sends the specified message."
 msgstr ""
 
-#: src/muuli_wdr.cpp:3414
+#: src/muuli_wdr.cpp:3386
 msgid "Close this chat-session."
 msgstr ""
 
-#: src/muuli_wdr.cpp:3437
+#: src/muuli_wdr.cpp:3409
 msgid "Connect to any server and/or Kad"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3443 src/SharedFilesCtrl.cpp:142 src/Statistics.cpp:941
+#: src/muuli_wdr.cpp:3415 src/SharedFilesCtrl.cpp:142 src/Statistics.cpp:941
 msgid "Shared Files"
 msgstr "ملفات مشاركة"
 
@@ -5408,267 +5378,267 @@ msgstr ""
 msgid "ERROR: Failed to open partfile '%s'"
 msgstr ""
 
-#: src/Preferences.cpp:701
+#: src/Preferences.cpp:673
 msgid "System default"
 msgstr "اﻹفتراضية بالنظام"
 
-#: src/Preferences.cpp:702
+#: src/Preferences.cpp:674
 msgid "Albanian"
 msgstr ""
 
-#: src/Preferences.cpp:703
+#: src/Preferences.cpp:675
 msgid "Arabic"
 msgstr "العربيه"
 
-#: src/Preferences.cpp:704
+#: src/Preferences.cpp:676
 #, fuzzy
 msgid "Asturian"
 msgstr "الأستونيه"
 
-#: src/Preferences.cpp:705
+#: src/Preferences.cpp:677
 msgid "Basque"
 msgstr ""
 
-#: src/Preferences.cpp:706
+#: src/Preferences.cpp:678
 msgid "Bulgarian"
 msgstr "البلغاريه"
 
-#: src/Preferences.cpp:707
+#: src/Preferences.cpp:679
 msgid "Catalan"
 msgstr ""
 
-#: src/Preferences.cpp:708
+#: src/Preferences.cpp:680
 msgid "Chinese (Simplified)"
 msgstr ""
 
-#: src/Preferences.cpp:709
+#: src/Preferences.cpp:681
 msgid "Chinese (Traditional)"
 msgstr ""
 
-#: src/Preferences.cpp:710
+#: src/Preferences.cpp:682
 msgid "Croatian"
 msgstr ""
 
-#: src/Preferences.cpp:711
+#: src/Preferences.cpp:683
 msgid "Czech"
 msgstr ""
 
-#: src/Preferences.cpp:712
+#: src/Preferences.cpp:684
 msgid "Danish"
 msgstr "الدانماركيه"
 
-#: src/Preferences.cpp:713
+#: src/Preferences.cpp:685
 msgid "Dutch"
 msgstr "الهولنديه"
 
-#: src/Preferences.cpp:714
+#: src/Preferences.cpp:686
 msgid "English (U.K.)"
 msgstr ""
 
-#: src/Preferences.cpp:715
+#: src/Preferences.cpp:687
 msgid "English (U.S.)"
 msgstr ""
 
-#: src/Preferences.cpp:716
+#: src/Preferences.cpp:688
 msgid "Estonian"
 msgstr "الأستونيه"
 
-#: src/Preferences.cpp:717
+#: src/Preferences.cpp:689
 msgid "Finnish"
 msgstr "الفلنديه"
 
-#: src/Preferences.cpp:718
+#: src/Preferences.cpp:690
 msgid "French"
 msgstr "الفرنسية"
 
-#: src/Preferences.cpp:719
+#: src/Preferences.cpp:691
 msgid "Galician"
 msgstr ""
 
-#: src/Preferences.cpp:720
+#: src/Preferences.cpp:692
 msgid "German"
 msgstr "الألمانيه"
 
-#: src/Preferences.cpp:721
+#: src/Preferences.cpp:693
 msgid "Greek"
 msgstr ""
 
-#: src/Preferences.cpp:722
+#: src/Preferences.cpp:694
 msgid "Hebrew"
 msgstr ""
 
-#: src/Preferences.cpp:723
+#: src/Preferences.cpp:695
 msgid "Hungarian"
 msgstr "الهنغاريه"
 
-#: src/Preferences.cpp:724
+#: src/Preferences.cpp:696
 msgid "Italian"
 msgstr "الايطاليه"
 
-#: src/Preferences.cpp:725
+#: src/Preferences.cpp:697
 msgid "Japanese"
 msgstr ""
 
-#: src/Preferences.cpp:726
+#: src/Preferences.cpp:698
 msgid "Korean"
 msgstr "الكوريه"
 
-#: src/Preferences.cpp:727
+#: src/Preferences.cpp:699
 msgid "Latvian"
 msgstr ""
 
-#: src/Preferences.cpp:728
+#: src/Preferences.cpp:700
 msgid "Lithuanian"
 msgstr "الليتوانيه"
 
-#: src/Preferences.cpp:729
+#: src/Preferences.cpp:701
 msgid "Norwegian (Nynorsk)"
 msgstr ""
 
-#: src/Preferences.cpp:730
+#: src/Preferences.cpp:702
 msgid "Polish"
 msgstr ""
 
-#: src/Preferences.cpp:731
+#: src/Preferences.cpp:703
 msgid "Portuguese"
 msgstr "البرتغاليه"
 
-#: src/Preferences.cpp:732
+#: src/Preferences.cpp:704
 msgid "Portuguese (Brazilian)"
 msgstr ""
 
-#: src/Preferences.cpp:733
+#: src/Preferences.cpp:705
 #, fuzzy
 msgid "Romanian"
 msgstr "الأستونيه"
 
-#: src/Preferences.cpp:734
+#: src/Preferences.cpp:706
 msgid "Russian"
 msgstr "الروسيه"
 
-#: src/Preferences.cpp:735
+#: src/Preferences.cpp:707
 msgid "Slovenian"
 msgstr ""
 
-#: src/Preferences.cpp:736
+#: src/Preferences.cpp:708
 msgid "Spanish"
 msgstr "الإسبانيه"
 
-#: src/Preferences.cpp:737
+#: src/Preferences.cpp:709
 msgid "Swedish"
 msgstr ""
 
-#: src/Preferences.cpp:738
+#: src/Preferences.cpp:710
 msgid "Turkish"
 msgstr ""
 
-#: src/Preferences.cpp:739
+#: src/Preferences.cpp:711
 msgid "Ukrainian"
 msgstr ""
 
-#: src/Preferences.cpp:842
+#: src/Preferences.cpp:814
 #, fuzzy
 msgid "Change Language"
 msgstr "الغة"
 
-#: src/Preferences.cpp:906
+#: src/Preferences.cpp:878
 msgid "There are no translations installed for aMule"
 msgstr ""
 
-#: src/Preferences.cpp:907
+#: src/Preferences.cpp:879
 #, fuzzy
 msgid "No languages available"
 msgstr "غير متوفر"
 
-#: src/Preferences.cpp:1038
+#: src/Preferences.cpp:1010
 msgid "no options available"
 msgstr ""
 
-#: src/Preferences.cpp:2226
+#: src/Preferences.cpp:2179
 msgid "Invalid category found, skipping"
 msgstr ""
 
-#: src/Preferences.cpp:2395
+#: src/Preferences.cpp:2348
 msgid "TCP port can't be higher than 65532 due to server UDP socket being TCP+3"
 msgstr ""
 
-#: src/Preferences.cpp:2396
+#: src/Preferences.cpp:2349
 #, c-format
 msgid "Default port will be used (%d)"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:300 src/Statistics.cpp:866
+#: src/PrefsUnifiedDlg.cpp:298 src/Statistics.cpp:866
 msgid "Connection"
 msgstr "اتصال"
 
-#: src/PrefsUnifiedDlg.cpp:301 src/SearchListCtrl.cpp:117
+#: src/PrefsUnifiedDlg.cpp:299 src/SearchListCtrl.cpp:117
 msgid "Directories"
 msgstr "مجلدات"
 
-#: src/PrefsUnifiedDlg.cpp:302 src/Statistics.cpp:917
+#: src/PrefsUnifiedDlg.cpp:300 src/Statistics.cpp:917
 msgid "Servers"
 msgstr "الخادمات"
 
-#: src/PrefsUnifiedDlg.cpp:303 src/ServerListCtrl.cpp:96
+#: src/PrefsUnifiedDlg.cpp:301 src/ServerListCtrl.cpp:96
 msgid "Files"
 msgstr "ملفات"
 
-#: src/PrefsUnifiedDlg.cpp:304
+#: src/PrefsUnifiedDlg.cpp:302
 msgid "Security"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:305
+#: src/PrefsUnifiedDlg.cpp:303
 msgid "Interface"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:312
+#: src/PrefsUnifiedDlg.cpp:310
 msgid "IP2Country"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:315
+#: src/PrefsUnifiedDlg.cpp:313
 msgid "Proxy"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:316
+#: src/PrefsUnifiedDlg.cpp:314
 msgid "Filters"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:317
+#: src/PrefsUnifiedDlg.cpp:315
 msgid "Remote Controls"
 msgstr "تحكم عن بعد"
 
-#: src/PrefsUnifiedDlg.cpp:318
+#: src/PrefsUnifiedDlg.cpp:316
 msgid "Online Signature"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:319
+#: src/PrefsUnifiedDlg.cpp:317
 msgid "Advanced"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:320
+#: src/PrefsUnifiedDlg.cpp:318
 msgid "Events"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:323
+#: src/PrefsUnifiedDlg.cpp:321
 msgid "Debugging"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:453
+#: src/PrefsUnifiedDlg.cpp:451
 msgid ""
 "The following variables will be substituted:\n"
 "    %PARTFILE - full path to the file\n"
 "    %PARTNAME - file name only"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:474
+#: src/PrefsUnifiedDlg.cpp:472
 msgid "Tray icon support requires libayatana-appindicator3 at compile time."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:490
+#: src/PrefsUnifiedDlg.cpp:488
 msgid "Not available on Wayland: the protocol does not report when a window is minimized, so this option cannot intercept the system minimize button. Workaround: launch aMule with `GDK_BACKEND=x11` to use XWayland instead."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:536
+#: src/PrefsUnifiedDlg.cpp:534
 msgid ""
 "Do not change these setting unless you know\n"
 "what you are doing, otherwise you can easily\n"
@@ -5678,260 +5648,247 @@ msgid ""
 "these settings."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:647
+#: src/PrefsUnifiedDlg.cpp:645
 #, c-format
 msgid "Failed to connect Cfg to widget with the ID %d and key %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:695
+#: src/PrefsUnifiedDlg.cpp:693
 #, c-format
 msgid "Failed to transfer data from Cfg to Widget with the ID %d and key %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:801
+#: src/PrefsUnifiedDlg.cpp:799
 msgid "The type of proxy you are connecting to"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1020
+#: src/PrefsUnifiedDlg.cpp:1003
 #, c-format
 msgid "Failed to transfer data from Widget to Cfg with the ID %d and key %s"
 msgstr ""
 
 #: src/PrefsUnifiedDlg.cpp:1103
-msgid "No password set."
-msgstr ""
-
-#: src/PrefsUnifiedDlg.cpp:1132
-msgid "Guest access needs a password. Type one in the guest password field, or untick Enable guest access."
-msgstr ""
-
-#: src/PrefsUnifiedDlg.cpp:1144
 msgid ""
 "aMule must be restarted to enable these changes:\n"
 "\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1151
+#: src/PrefsUnifiedDlg.cpp:1110
 msgid "- TCP port changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1156
+#: src/PrefsUnifiedDlg.cpp:1115
 msgid "- UDP port changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1161
+#: src/PrefsUnifiedDlg.cpp:1120
 #, fuzzy
 msgid "- Network interface binding changed.\n"
 msgstr "عوامل اﻻتصال الخارجي"
 
-#: src/PrefsUnifiedDlg.cpp:1166
+#: src/PrefsUnifiedDlg.cpp:1125
 #, fuzzy
 msgid "- External connect port changed.\n"
 msgstr "عوامل اﻻتصال الخارجي"
 
-#: src/PrefsUnifiedDlg.cpp:1170
+#: src/PrefsUnifiedDlg.cpp:1129
 #, fuzzy
 msgid "- External connect acceptance changed.\n"
 msgstr "عوامل اﻻتصال الخارجي"
 
-#: src/PrefsUnifiedDlg.cpp:1174
+#: src/PrefsUnifiedDlg.cpp:1133
 #, fuzzy
 msgid "- External connect interface changed.\n"
 msgstr "عوامل اﻻتصال الخارجي"
 
-#: src/PrefsUnifiedDlg.cpp:1178
+#: src/PrefsUnifiedDlg.cpp:1137
 #, fuzzy
 msgid "- Protocol obfuscation support changed.\n"
 msgstr "عوامل اﻻتصال الخارجي"
 
-#: src/PrefsUnifiedDlg.cpp:1193
+#: src/PrefsUnifiedDlg.cpp:1151
 msgid "- amuleapi settings changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1202
+#: src/PrefsUnifiedDlg.cpp:1160
 msgid ""
 "Your Auto-update server list is empty.\n"
 "'Auto-update server list at startup' will be disabled."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1213
+#: src/PrefsUnifiedDlg.cpp:1171
 msgid ""
 "You have enabled external connections but have not specified a password.\n"
 "External connections cannot be enabled unless a valid password is specified."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1246
-#, c-format
-msgid "The amuleapi password could not be saved: %s"
-msgstr ""
-
-#: src/PrefsUnifiedDlg.cpp:1276
+#: src/PrefsUnifiedDlg.cpp:1202
 msgid "- Language changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1281
+#: src/PrefsUnifiedDlg.cpp:1207
 msgid "- Temp folder changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1286
+#: src/PrefsUnifiedDlg.cpp:1212
 msgid "- ED2K network enabled.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1319
+#: src/PrefsUnifiedDlg.cpp:1245
 msgid "The shared-file exclusion pattern is not a valid regular expression. The filter has been left disabled."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1321 src/PrefsUnifiedDlg.cpp:1921
+#: src/PrefsUnifiedDlg.cpp:1247 src/PrefsUnifiedDlg.cpp:1841
 msgid "Invalid regular expression"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1398
+#: src/PrefsUnifiedDlg.cpp:1324
 msgid ""
 "Both eD2k and Kad network are disabled.\n"
 "You won't be able to connect until you enable at least one of them."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1403
+#: src/PrefsUnifiedDlg.cpp:1329
 msgid ""
 "Kad will not start if your UDP port is disabled.\n"
 "Enable UDP port or disable Kad."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1459
+#: src/PrefsUnifiedDlg.cpp:1385
 msgid ""
 "\n"
 "You MUST restart aMule now.\n"
 "If you do not restart now, don't complain if anything bad happens.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1524
+#: src/PrefsUnifiedDlg.cpp:1450
 msgid "Could not register aMule for autostart at login. The autostart store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1526
+#: src/PrefsUnifiedDlg.cpp:1452
 msgid "Could not remove the autostart-at-login entry."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1527
+#: src/PrefsUnifiedDlg.cpp:1453
 #, fuzzy
 msgid "Autostart"
 msgstr "ذاتي"
 
-#: src/PrefsUnifiedDlg.cpp:1542
+#: src/PrefsUnifiedDlg.cpp:1468
 msgid "Register file type"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1542
+#: src/PrefsUnifiedDlg.cpp:1468
 msgid "Register URL handler"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1550
+#: src/PrefsUnifiedDlg.cpp:1476
 #, c-format
 msgid "aMule only handles eD2k-compatible magnets. If you replace the current magnet handler (%s), BitTorrent magnet links will stop working - aMule cannot download BitTorrent content. Continue?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1555
+#: src/PrefsUnifiedDlg.cpp:1481
 #, c-format
 msgid "Another application currently opens .emulecollection files (%s). Replace it with aMule?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1560
+#: src/PrefsUnifiedDlg.cpp:1486
 #, c-format
 msgid "Another application is currently the default handler for these links (%s). Replace it with aMule?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1585
+#: src/PrefsUnifiedDlg.cpp:1511
 msgid "Could not register aMule for .emulecollection files. The registration store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1587
+#: src/PrefsUnifiedDlg.cpp:1513
 #, fuzzy
 msgid "Could not remove the file type registration."
 msgstr "قمت بمحاولت تحميل الملف مسبقا %s"
 
-#: src/PrefsUnifiedDlg.cpp:1589
+#: src/PrefsUnifiedDlg.cpp:1515
 msgid "Could not register aMule as the URL handler. The registration store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1591
+#: src/PrefsUnifiedDlg.cpp:1517
 msgid "Could not remove the URL handler registration."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1661 src/PrefsUnifiedDlg.cpp:1688
+#: src/PrefsUnifiedDlg.cpp:1587 src/PrefsUnifiedDlg.cpp:1614
 #, fuzzy
 msgid "The web server and aMule API require external connections to be enabled."
 msgstr "قبل إتصال خارجي جديد\n"
 
-#: src/PrefsUnifiedDlg.cpp:1671
+#: src/PrefsUnifiedDlg.cpp:1597
 msgid "The aMule web server is deprecated. Consider running the aMule API instead."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1735
+#: src/PrefsUnifiedDlg.cpp:1655
 msgid ""
 "Your Auto-update servers list is in blank.\n"
 "Please fill in at least one URL to point to a valid server.met file.\n"
 "Click on the button \"List\" by this checkbox to enter an URL."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1876
+#: src/PrefsUnifiedDlg.cpp:1796
 msgid "Temporary files"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1881
+#: src/PrefsUnifiedDlg.cpp:1801
 msgid "Incoming files"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1886
+#: src/PrefsUnifiedDlg.cpp:1806
 msgid "Online Signatures"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1899
+#: src/PrefsUnifiedDlg.cpp:1819
 #, c-format
 msgid "Choose a folder for %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1923
+#: src/PrefsUnifiedDlg.cpp:1843
 #, fuzzy, c-format
 msgid "Would exclude %u of %u shared file"
 msgid_plural "Would exclude %u of %u shared files"
 msgstr[0] "وجد %i ملف مشاركة معرف"
 msgstr[1] "وجد %i ملف مشاركة معرف"
 
-#: src/PrefsUnifiedDlg.cpp:1940
+#: src/PrefsUnifiedDlg.cpp:1860
 msgid "Browse for videoplayer"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1944
+#: src/PrefsUnifiedDlg.cpp:1864
 msgid "Select browser"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1948
+#: src/PrefsUnifiedDlg.cpp:1868
 msgid "Select ffprobe binary"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1954
+#: src/PrefsUnifiedDlg.cpp:1874
 #, c-format
 msgid "Executable%s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1988
+#: src/PrefsUnifiedDlg.cpp:1908
 msgid "ffprobe not found on PATH or in the standard install locations. Install ffmpeg (which ships ffprobe) or use Browse to pick a binary manually."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2000
+#: src/PrefsUnifiedDlg.cpp:1920
 msgid "Reset the settings on this page to their default values?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2001
+#: src/PrefsUnifiedDlg.cpp:1921
 #, fuzzy
 msgid "Reset to defaults"
 msgstr "اﻹفتراضية بالنظام"
 
-#: src/PrefsUnifiedDlg.cpp:2028
+#: src/PrefsUnifiedDlg.cpp:1948
 msgid "Edit server list"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2029
+#: src/PrefsUnifiedDlg.cpp:1949
 msgid ""
 "Add here URL's to download server.met files.\n"
 "Only one url on each line."
@@ -5939,178 +5896,174 @@ msgstr ""
 "أضف هنا عنوان لتحميل ملفات server.met \n"
 "عنوان واحد فقط لكل سطر"
 
-#: src/PrefsUnifiedDlg.cpp:2084
+#: src/PrefsUnifiedDlg.cpp:2004
 msgid "IP2Country update failed"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2229 src/PrefsUnifiedDlg.cpp:2260
+#: src/PrefsUnifiedDlg.cpp:2149 src/PrefsUnifiedDlg.cpp:2180
 msgid "Data by MaxMind GeoLite2"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2231 src/PrefsUnifiedDlg.cpp:2262
+#: src/PrefsUnifiedDlg.cpp:2151 src/PrefsUnifiedDlg.cpp:2182
 msgid "Custom source"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2233 src/PrefsUnifiedDlg.cpp:2264
+#: src/PrefsUnifiedDlg.cpp:2153 src/PrefsUnifiedDlg.cpp:2184
 msgid "Data by DB-IP.com"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2284
+#: src/PrefsUnifiedDlg.cpp:2204
 #, c-format
 msgid "Status: Loaded%s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2286
+#: src/PrefsUnifiedDlg.cpp:2206
 #, c-format
 msgid "Status: Loaded%s - %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2290
+#: src/PrefsUnifiedDlg.cpp:2210
 msgid "Status: Failed to load - click 'Update now' to refresh."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2292
+#: src/PrefsUnifiedDlg.cpp:2212
 msgid "Status: Not found - click 'Update now' to download."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2350 src/PrefsUnifiedDlg.cpp:2374
+#: src/PrefsUnifiedDlg.cpp:2270 src/PrefsUnifiedDlg.cpp:2294
 #, fuzzy, c-format
 msgid "Update delay: %d second"
 msgid_plural "Update delay: %d seconds"
 msgstr[0] "تحيدث كل:5 ثواني"
 msgstr[1] "تحيدث كل:5 ثواني"
 
-#: src/PrefsUnifiedDlg.cpp:2358
+#: src/PrefsUnifiedDlg.cpp:2278
 #, c-format
 msgid "Time for average graph: %d minute"
 msgid_plural "Time for average graph: %d minutes"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/PrefsUnifiedDlg.cpp:2367
+#: src/PrefsUnifiedDlg.cpp:2287
 #, c-format
 msgid "Connections Graph Scale: %d"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2382
+#: src/PrefsUnifiedDlg.cpp:2302
 #, c-format
 msgid "File Buffer Size: %d byte"
 msgid_plural "File Buffer Size: %d bytes"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/PrefsUnifiedDlg.cpp:2392
+#: src/PrefsUnifiedDlg.cpp:2312
 #, c-format
 msgid "Upload Queue Size: %d client"
 msgid_plural "Upload Queue Size: %d clients"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/PrefsUnifiedDlg.cpp:2402
+#: src/PrefsUnifiedDlg.cpp:2322
 #, fuzzy, c-format
 msgid "Server connection refresh interval: %d minute"
 msgid_plural "Server connection refresh interval: %d minutes"
 msgstr[0] "فترة تحديث الإتصال بالخادم %i دقيقة"
 msgstr[1] "فترة تحديث الإتصال بالخادم %i دقيقة"
 
-#: src/PrefsUnifiedDlg.cpp:2407
+#: src/PrefsUnifiedDlg.cpp:2327
 msgid "Server connection refresh interval: Disabled"
 msgstr "فترة تحديث الإتصال بالخادم :معطل"
 
-#: src/PrefsUnifiedDlg.cpp:2451
+#: src/PrefsUnifiedDlg.cpp:2371
 #, fuzzy
 msgid "disabled"
 msgstr "تعطيل"
 
-#: src/PrefsUnifiedDlg.cpp:2477
+#: src/PrefsUnifiedDlg.cpp:2397
 #, c-format
 msgid "Execute command on '%s' event"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2484
+#: src/PrefsUnifiedDlg.cpp:2404
 msgid "Enable command execution on core"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2496
+#: src/PrefsUnifiedDlg.cpp:2416
 msgid "Core command:"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2512
+#: src/PrefsUnifiedDlg.cpp:2432
 msgid "Enable command execution on GUI"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2524
+#: src/PrefsUnifiedDlg.cpp:2444
 msgid "GUI command:"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2540
+#: src/PrefsUnifiedDlg.cpp:2460
 msgid "The following variables will be replaced:"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2708
+#: src/PrefsUnifiedDlg.cpp:2628
 msgid ""
 "The following folders look like system or sensitive locations:\n"
 "\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2713
+#: src/PrefsUnifiedDlg.cpp:2633
 msgid "Sharing them recursively will publish every file underneath on the eD2k/Kad networks. Do you really want to do this?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2716
+#: src/PrefsUnifiedDlg.cpp:2636
 msgid "Confirm shared folders"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2744
+#: src/PrefsUnifiedDlg.cpp:2664
 #, fuzzy
 msgid "Reloading shared files..."
 msgstr "وجد %i ملف مشاركة معرف"
 
-#: src/PrefsUnifiedDlg.cpp:2745
+#: src/PrefsUnifiedDlg.cpp:2665
 msgid "Scanning for subdirectories..."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2746
+#: src/PrefsUnifiedDlg.cpp:2666
 msgid "Updating shared folders"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2773
+#: src/PrefsUnifiedDlg.cpp:2693
 #, c-format
 msgid "Scanned %u directories..."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2823
+#: src/PrefsUnifiedDlg.cpp:2743
 #, c-format
 msgid "Reloading shared files: %u files scanned"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2873
+#: src/PrefsUnifiedDlg.cpp:2793
 #, fuzzy
 msgid "Shared folder"
 msgstr "ملفات مشاركة"
 
-#: src/SearchDlg.cpp:280
-msgid "Clear search history"
-msgstr ""
-
-#: src/SearchDlg.cpp:584
+#: src/SearchDlg.cpp:425
 msgid "It's impossible to search when both eD2k and Kademlia are disabled."
 msgstr ""
 
-#: src/SearchDlg.cpp:585 src/SearchListCtrl.cpp:858
+#: src/SearchDlg.cpp:426 src/SearchListCtrl.cpp:858
 #, fuzzy
 msgid "Search error"
 msgstr "بحث"
 
-#: src/SearchDlg.cpp:929
+#: src/SearchDlg.cpp:768
 msgid "Min size must be smaller than max size. Max size ignored."
 msgstr ""
 
-#: src/SearchDlg.cpp:930 src/SearchDlg.cpp:1012
+#: src/SearchDlg.cpp:769 src/SearchDlg.cpp:851
 msgid "Search warning"
 msgstr ""
 
-#: src/SearchDlg.cpp:1092 src/SearchListCtrl.cpp:735
+#: src/SearchDlg.cpp:929 src/SearchListCtrl.cpp:735
 msgid "Main"
 msgstr ""
 

--- a/po/ar.po
+++ b/po/ar.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-28 10:19+0200\n"
+"POT-Creation-Date: 2026-07-28 12:17+0200\n"
 "PO-Revision-Date: 2026-07-27 11:31+0000\n"
 "Last-Translator: saleh alhathal <hathalsal@hotmail.com>\n"
 "Language-Team: \n"
@@ -193,155 +193,155 @@ msgstr "فشل لفتح %s (%s)"
 msgid "WARNING: You can't add yourself as a source for an eD2k link while having a lowid."
 msgstr ""
 
-#: src/amule.cpp:300
+#: src/amule.cpp:301
 msgid "Now, exiting main app..."
 msgstr ""
 
-#: src/amule.cpp:330
+#: src/amule.cpp:331
 #, c-format
 msgid "Terminating amuleweb instance with pid '%d' ... "
 msgstr ""
 
-#: src/amule.cpp:334
+#: src/amule.cpp:335
 #, c-format
 msgid "Killing amuleweb instance with pid '%d' ... "
 msgstr ""
 
-#: src/amule.cpp:336 src/amule.cpp:349 src/ClientRef.cpp:180
+#: src/amule.cpp:337 src/amule.cpp:350 src/ClientRef.cpp:180
 #: src/SearchDlg.cpp:1041 src/ServerListCtrl.cpp:98
 msgid "Failed"
 msgstr "فشل"
 
-#: src/amule.cpp:343
+#: src/amule.cpp:344
 #, c-format
 msgid "Terminating amuleapi instance with pid '%d' ... "
 msgstr ""
 
-#: src/amule.cpp:347
+#: src/amule.cpp:348
 #, c-format
 msgid "Killing amuleapi instance with pid '%d' ... "
 msgstr ""
 
-#: src/amule.cpp:355
+#: src/amule.cpp:356
 msgid "aMule OnExit: Terminating core."
 msgstr ""
 
-#: src/amule.cpp:466
+#: src/amule.cpp:467
 msgid "aMule shutdown completed."
 msgstr ""
 
-#: src/amule.cpp:470
+#: src/amule.cpp:471
 msgid "Memory debug results for aMule exit:"
 msgstr ""
 
-#: src/amule.cpp:651
+#: src/amule.cpp:652
 #, c-format
 msgid "Binding aMule's peer-to-peer traffic to interface: %s (HTTP updates use the default route)"
 msgstr ""
 
-#: src/amule.cpp:655
+#: src/amule.cpp:656
 #, c-format
 msgid "Binding all network traffic to interface: %s"
 msgstr ""
 
-#: src/amule.cpp:659
+#: src/amule.cpp:660
 #, c-format
 msgid "WARNING: configured network interface '%s' was not found - traffic is NOT bound to it and may leave via the default route. Check the interface name in Preferences."
 msgstr ""
 
-#: src/amule.cpp:665
+#: src/amule.cpp:666
 #, c-format
 msgid "WARNING: binding to network interface '%s' requires elevated privileges and was NOT applied - traffic may leave via the default route. Grant the capability (e.g. 'sudo setcap cap_net_raw+ep' on the aMule binary) or run with sufficient privileges."
 msgstr ""
 
-#: src/amule.cpp:673
+#: src/amule.cpp:674
 #, c-format
 msgid "WARNING: could not bind to network interface '%s' - traffic may leave via the default route."
 msgstr ""
 
-#: src/amule.cpp:732
+#: src/amule.cpp:733
 msgid "Your locale has been changed to System Default due to a configuration change. Sorry."
 msgstr ""
 
-#: src/amule.cpp:734 src/amule.cpp:1581 src/CatDialog.cpp:128
+#: src/amule.cpp:735 src/amule.cpp:1589 src/CatDialog.cpp:128
 #: src/CatDialog.cpp:136 src/CatDialog.cpp:149 src/ServerList.cpp:366
 #: src/ServerListCtrl.cpp:152
 msgid "Info"
 msgstr "معلومات"
 
-#: src/amule.cpp:741
+#: src/amule.cpp:742
 #, fuzzy
 msgid ""
 "\n"
 "EC configuration"
 msgstr "تاكيد الخروج"
 
-#: src/amule.cpp:744
+#: src/amule.cpp:745
 #, fuzzy
 msgid "Password set and external connections enabled."
 msgstr "قبل إتصال خارجي جديد\n"
 
-#: src/amule.cpp:754 src/KadDlg.cpp:176 src/KadDlg.cpp:185
-#: src/PrefsUnifiedDlg.cpp:1387 src/SharedFilesCtrl.cpp:476
+#: src/amule.cpp:755 src/KadDlg.cpp:176 src/KadDlg.cpp:185
+#: src/PrefsUnifiedDlg.cpp:1461 src/SharedFilesCtrl.cpp:476
 msgid "WARNING"
 msgstr ""
 
-#: src/amule.cpp:991
+#: src/amule.cpp:992
 msgid "Network bootstrap"
 msgstr ""
 
-#: src/amule.cpp:996
+#: src/amule.cpp:997
 msgid ""
 "aMule has detected missing network bootstrap files.\n"
 "Select which ones to download:"
 msgstr ""
 
-#: src/amule.cpp:1005 src/FirstRunWizard.cpp:411
+#: src/amule.cpp:1006 src/FirstRunWizard.cpp:411
 #, fuzzy
 msgid "eD2k server list (server.met)"
 msgstr "%i خادمات وجدت في server.met"
 
-#: src/amule.cpp:1012 src/FirstRunWizard.cpp:416
+#: src/amule.cpp:1013 src/FirstRunWizard.cpp:416
 msgid "Kad bootstrap nodes (nodes.dat)"
 msgstr ""
 
-#: src/amule.cpp:1102
+#: src/amule.cpp:1103
 #, c-format
 msgid "web server running on pid %d"
 msgstr ""
 
-#: src/amule.cpp:1115
+#: src/amule.cpp:1116
 msgid "You requested to run web server on startup, but the amuleweb binary cannot be run. Please install the package containing aMule web server, or build aMule from source with -DBUILD_WEBSERVER=YES and install it."
 msgstr ""
 
-#: src/amule.cpp:1120 src/amule.cpp:1177 src/amule.cpp:1291 src/amule.cpp:1593
+#: src/amule.cpp:1121 src/amule.cpp:1185 src/amule.cpp:1299 src/amule.cpp:1601
 #: src/amule-remote-gui.cpp:603 src/amule-remote-gui.cpp:671
 #: src/amule-remote-gui.cpp:709 src/amule-remote-gui.cpp:1282
 #: src/amule-remote-gui.cpp:1345 src/amule-remote-gui.cpp:1372
-#: src/DownloadQueue.cpp:1481
+#: src/DownloadQueue.cpp:1481 src/PrefsUnifiedDlg.cpp:1247
 msgid "ERROR"
 msgstr ""
 
-#: src/amule.cpp:1166
+#: src/amule.cpp:1174
 #, c-format
 msgid "amuleapi running on pid %d"
 msgstr ""
 
-#: src/amule.cpp:1172
+#: src/amule.cpp:1180
 msgid "You requested to run amuleapi on startup, but the amuleapi binary cannot be run. Please install the package containing aMule's REST API server, or build aMule from source with -DBUILD_AMULEAPI=YES and install it."
 msgstr ""
 
-#: src/amule.cpp:1259
+#: src/amule.cpp:1267
 #, c-format
 msgid "Could not bind ports to the specified address: %s"
 msgstr ""
 
-#: src/amule.cpp:1283
+#: src/amule.cpp:1291
 #, c-format
 msgid "Port %u is not available. You will be LOWID\n"
 msgstr ""
 
-#: src/amule.cpp:1288
+#: src/amule.cpp:1296
 #, c-format
 msgid ""
 "Port %u is not available!\n"
@@ -351,185 +351,185 @@ msgid ""
 "Check your network to make sure the port is open for output and input."
 msgstr ""
 
-#: src/amule.cpp:1385
+#: src/amule.cpp:1393
 msgid "Failed to create OnlineSig File"
 msgstr ""
 
-#: src/amule.cpp:1393
+#: src/amule.cpp:1401
 msgid "Failed to create aMule OnlineSig File"
 msgstr ""
 
-#: src/amule.cpp:1556
+#: src/amule.cpp:1564
 msgid "The selected locale seems not to be installed on your box. (Note: I'll try to set it anyway)"
 msgstr ""
 
-#: src/amule.cpp:1566
+#: src/amule.cpp:1574
 #, c-format
 msgid "This is the first time you run aMule %s"
 msgstr ""
 
-#: src/amule.cpp:1569
+#: src/amule.cpp:1577
 msgid "This version is a testing version, updated daily, and\n"
 msgstr ""
 
-#: src/amule.cpp:1570
+#: src/amule.cpp:1578
 msgid "we give no warranty it won't break anything, burn your house,\n"
 msgstr "ﻻ نضمن انه خالي من اﻻخطاء, قد يتسبب باعطال\n"
 
-#: src/amule.cpp:1571
+#: src/amule.cpp:1579
 msgid "or kill your dog. But it *should* be safe to use anyway.\n"
 msgstr ""
 
-#: src/amule.cpp:1576
+#: src/amule.cpp:1584
 msgid "More information, support and new releases can found at our homepage,\n"
 msgstr ""
 
-#: src/amule.cpp:1577
+#: src/amule.cpp:1585
 msgid "at https://amule-org.github.io, or in our IRC channel #aMule at irc.libera.chat.\n"
 msgstr ""
 
-#: src/amule.cpp:1579
+#: src/amule.cpp:1587
 msgid "Feel free to report any bugs to https://github.com/amule-org/amule/issues"
 msgstr ""
 
-#: src/amule.cpp:1591
+#: src/amule.cpp:1599
 msgid ""
 "The folder for Online Signature files you specified is INVALID!\n"
 " OnlineSignature will be DISABLED until you fix it on preferences."
 msgstr ""
 
-#: src/amule.cpp:1654
+#: src/amule.cpp:1662
 #, fuzzy
 msgid "Server hostname notified"
 msgstr "إسم الخادم"
 
-#: src/amule.cpp:2031
+#: src/amule.cpp:2039
 #, c-format
 msgid "Disk space preallocation for file '%s' failed: %s"
 msgstr ""
 
-#: src/amule.cpp:2160
+#: src/amule.cpp:2168
 msgid "ERROR: can't open logfile"
 msgstr ""
 
-#: src/amule.cpp:2164
+#: src/amule.cpp:2172
 msgid "WARNING: logfile is empty. Something is wrong."
 msgstr ""
 
-#: src/amule.cpp:2181
+#: src/amule.cpp:2189
 msgid "Log has been reset"
 msgstr ""
 
-#: src/amule.cpp:2205
+#: src/amule.cpp:2213
 #, c-format
 msgid "ServerMessage: %s"
 msgstr ""
 
-#: src/amule.cpp:2248 src/IP2Country.cpp:220 src/IPFilter.cpp:514
+#: src/amule.cpp:2256 src/IP2Country.cpp:220 src/IPFilter.cpp:514
 #: src/ServerList.cpp:875
 #, c-format
 msgid "Skipped download of %s, because requested file is not newer."
 msgstr ""
 
-#: src/amule.cpp:2251
+#: src/amule.cpp:2259
 msgid "Failed to download the nodes list."
 msgstr ""
 
-#: src/amule.cpp:2314
+#: src/amule.cpp:2322
 msgid "Failed to open the downloaded version check file"
 msgstr ""
 
-#: src/amule.cpp:2317 src/amule.cpp:2336
+#: src/amule.cpp:2325 src/amule.cpp:2344
 msgid "Corrupted version check file"
 msgstr ""
 
-#: src/amule.cpp:2359
+#: src/amule.cpp:2367
 msgid "You are using an outdated version of aMule!"
 msgstr ""
 
-#: src/amule.cpp:2361
+#: src/amule.cpp:2369
 #, c-format
 msgid "Your aMule version is %i.%i.%i and the latest version is %li.%li.%li"
 msgstr ""
 
-#: src/amule.cpp:2365
+#: src/amule.cpp:2373
 msgid "The latest version can always be found at https://github.com/amule-org/amule/releases/latest"
 msgstr ""
 
-#: src/amule.cpp:2368
+#: src/amule.cpp:2376
 #, c-format
 msgid "WARNING: Your aMuled version is outdated: %i.%i.%i < %li.%li.%li"
 msgstr ""
 
-#: src/amule.cpp:2374
+#: src/amule.cpp:2382
 msgid "Your copy of aMule is up to date."
 msgstr ""
 
-#: src/amule.cpp:2381
+#: src/amule.cpp:2389
 msgid "Failed to download the version check file"
 msgstr ""
 
-#: src/amule.cpp:2550 src/amule-remote-gui.cpp:1133
+#: src/amule.cpp:2558 src/amule-remote-gui.cpp:1133
 #, c-format
 msgid "Users: %s | Files: %s"
 msgstr ""
 
-#: src/amule.cpp:2551 src/amule-remote-gui.cpp:1134
+#: src/amule.cpp:2559 src/amule-remote-gui.cpp:1134
 #, c-format
 msgid "Users: E: %s K: %s | Files: E: %s K: %s"
 msgstr ""
 
-#: src/amule.cpp:2565 src/amule-remote-gui.cpp:1147
+#: src/amule.cpp:2573 src/amule-remote-gui.cpp:1147
 msgid "No networks selected"
 msgstr ""
 
-#: src/amule.cpp:2633 src/TextClient.cpp:903
+#: src/amule.cpp:2641 src/TextClient.cpp:903
 msgid "with LowID"
 msgstr ""
 
-#: src/amule.cpp:2633 src/TextClient.cpp:904
+#: src/amule.cpp:2641 src/TextClient.cpp:904
 msgid "with HighID"
 msgstr ""
 
-#: src/amule.cpp:2635
+#: src/amule.cpp:2643
 #, c-format
 msgid "Connected to %s %s"
 msgstr ""
 
-#: src/amule.cpp:2640
+#: src/amule.cpp:2648
 #, c-format
 msgid "Connecting to %s"
 msgstr ""
 
-#: src/amule.cpp:2642
+#: src/amule.cpp:2650
 msgid "Disconnected from eD2k"
 msgstr ""
 
-#: src/amule.cpp:2651
+#: src/amule.cpp:2659
 msgid "Kad started."
 msgstr ""
 
-#: src/amule.cpp:2653
+#: src/amule.cpp:2661
 msgid "Kad stopped."
 msgstr ""
 
-#: src/amule.cpp:2661
+#: src/amule.cpp:2669
 msgid "Connected to Kad (ok)"
 msgstr ""
 
-#: src/amule.cpp:2663
+#: src/amule.cpp:2671
 msgid "Connected to Kad (firewalled)"
 msgstr ""
 
-#: src/amule.cpp:2667
+#: src/amule.cpp:2675
 msgid "Disconnected from Kad"
 msgstr ""
 
-#: src/amule.cpp:2699
+#: src/amule.cpp:2707
 msgid "Kad network cannot be used if UDP port is disabled on preferences, not starting."
 msgstr ""
 
-#: src/amule.cpp:2703
+#: src/amule.cpp:2711
 msgid "Kad network disabled on preferences, not connecting."
 msgstr ""
 
@@ -573,36 +573,36 @@ msgid "FATAL ERROR: Failed to create Timer"
 msgstr ""
 
 #: src/amuleDlg.cpp:361 src/amuleDlg.cpp:1787 src/amuleDlg.cpp:2033
-#: src/muuli_wdr.cpp:1492 src/muuli_wdr.cpp:3418
+#: src/muuli_wdr.cpp:1492 src/muuli_wdr.cpp:3449
 msgid "Networks"
 msgstr ""
 
-#: src/amuleDlg.cpp:362 src/amuleDlg.cpp:1793 src/muuli_wdr.cpp:3419
+#: src/amuleDlg.cpp:362 src/amuleDlg.cpp:1793 src/muuli_wdr.cpp:3450
 msgid "Searches"
 msgstr "بحث"
 
 #: src/amuleDlg.cpp:363 src/amuleDlg.cpp:1799 src/DownloadListCtrl.cpp:740
-#: src/muuli_wdr.cpp:392 src/muuli_wdr.cpp:1585 src/muuli_wdr.cpp:3420
+#: src/muuli_wdr.cpp:392 src/muuli_wdr.cpp:1585 src/muuli_wdr.cpp:3451
 #: src/Statistics.cpp:829
 msgid "Downloads"
 msgstr "تحميل"
 
-#: src/amuleDlg.cpp:364 src/amuleDlg.cpp:1805 src/muuli_wdr.cpp:3294
+#: src/amuleDlg.cpp:364 src/amuleDlg.cpp:1805 src/muuli_wdr.cpp:3325
 msgid "Shared files"
 msgstr ""
 
-#: src/amuleDlg.cpp:365 src/amuleDlg.cpp:1811 src/muuli_wdr.cpp:2926
-#: src/muuli_wdr.cpp:3376 src/muuli_wdr.cpp:3423
+#: src/amuleDlg.cpp:365 src/amuleDlg.cpp:1811 src/muuli_wdr.cpp:2957
+#: src/muuli_wdr.cpp:3407 src/muuli_wdr.cpp:3454
 msgid "Messages"
 msgstr "رسائل"
 
-#: src/amuleDlg.cpp:366 src/amuleDlg.cpp:1817 src/muuli_wdr.cpp:3424
-#: src/PrefsUnifiedDlg.cpp:312 src/Statistics.cpp:779 src/Statistics.cpp:1235
+#: src/amuleDlg.cpp:366 src/amuleDlg.cpp:1817 src/muuli_wdr.cpp:3455
+#: src/PrefsUnifiedDlg.cpp:314 src/Statistics.cpp:779 src/Statistics.cpp:1235
 msgid "Statistics"
 msgstr "احصائات"
 
-#: src/amuleDlg.cpp:368 src/amuleDlg.cpp:1824 src/muuli_wdr.cpp:3426
-#: src/PrefsUnifiedDlg.cpp:328 src/utils/wxCas/src/wxcasprefs.cpp:39
+#: src/amuleDlg.cpp:368 src/amuleDlg.cpp:1824 src/muuli_wdr.cpp:3457
+#: src/PrefsUnifiedDlg.cpp:330 src/utils/wxCas/src/wxcasprefs.cpp:39
 msgid "Preferences"
 msgstr "اعدادت"
 
@@ -662,8 +662,8 @@ msgstr ""
 #: src/amuleDlg.cpp:1029 src/DownloadListCtrl.cpp:505
 #: src/DownloadListCtrl.cpp:749 src/FriendListCtrl.cpp:180
 #: src/muuli_wdr.cpp:731 src/muuli_wdr.cpp:782 src/muuli_wdr.cpp:846
-#: src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2231 src/muuli_wdr.cpp:2316
-#: src/muuli_wdr.cpp:3064 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
+#: src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2262 src/muuli_wdr.cpp:2347
+#: src/muuli_wdr.cpp:3095 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
 #: src/ServerListCtrl.cpp:606 src/TransferWnd.cpp:378
 #: src/utils/wxCas/src/wxcasprefs.cpp:235
 msgid "Cancel"
@@ -675,7 +675,7 @@ msgid "Stop the current connection attempts"
 msgstr "إيقاف محاولة اﻹتصال الحاليه"
 
 #: src/amuleDlg.cpp:1035 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976
-#: src/muuli_wdr.cpp:2454
+#: src/muuli_wdr.cpp:2485
 msgid "Disconnect"
 msgstr "فصل"
 
@@ -685,7 +685,7 @@ msgid "Disconnect from the currently connected networks"
 msgstr "فصل من المستضيف الحالي"
 
 #: src/amuleDlg.cpp:1041 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979
-#: src/muuli_wdr.cpp:2609 src/muuli_wdr.cpp:3061 src/muuli_wdr.cpp:3416
+#: src/muuli_wdr.cpp:2640 src/muuli_wdr.cpp:3092 src/muuli_wdr.cpp:3447
 msgid "Connect"
 msgstr "إتصال"
 
@@ -739,7 +739,7 @@ msgstr "تاكيد الخروج"
 msgid "Launch Command: "
 msgstr ""
 
-#: src/amuleDlg.cpp:1632 src/muuli_wdr.cpp:1978 src/Preferences.cpp:952
+#: src/amuleDlg.cpp:1632 src/muuli_wdr.cpp:1982 src/Preferences.cpp:979
 msgid "- default -"
 msgstr ""
 
@@ -753,49 +753,49 @@ msgstr ""
 msgid "WARNING: Unable to open skin file '%s' for read"
 msgstr ""
 
-#: src/amuleDlg.cpp:1791 src/muuli_wdr.cpp:3418
+#: src/amuleDlg.cpp:1791 src/muuli_wdr.cpp:3449
 msgid "Networks Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1797 src/muuli_wdr.cpp:3419
+#: src/amuleDlg.cpp:1797 src/muuli_wdr.cpp:3450
 msgid "Searches Window"
 msgstr "نافذة البحث"
 
-#: src/amuleDlg.cpp:1803 src/muuli_wdr.cpp:3420
+#: src/amuleDlg.cpp:1803 src/muuli_wdr.cpp:3451
 #, fuzzy
 msgid "Downloads Window"
 msgstr "تحميل"
 
-#: src/amuleDlg.cpp:1809 src/muuli_wdr.cpp:3422
+#: src/amuleDlg.cpp:1809 src/muuli_wdr.cpp:3453
 msgid "Shared Files Window"
 msgstr "نافذة ملفات المشاركة"
 
-#: src/amuleDlg.cpp:1815 src/muuli_wdr.cpp:3423
+#: src/amuleDlg.cpp:1815 src/muuli_wdr.cpp:3454
 msgid "Messages Window"
 msgstr "نافذة الرسائل"
 
-#: src/amuleDlg.cpp:1821 src/muuli_wdr.cpp:3424
+#: src/amuleDlg.cpp:1821 src/muuli_wdr.cpp:3455
 msgid "Statistics Graph Window"
 msgstr "نافذة اﻻحصائيات"
 
-#: src/amuleDlg.cpp:1828 src/muuli_wdr.cpp:3426
+#: src/amuleDlg.cpp:1828 src/muuli_wdr.cpp:3457
 msgid "Preferences Settings Window"
 msgstr "نافذة اﻹعدادات"
 
-#: src/amuleDlg.cpp:1831 src/muuli_wdr.cpp:3427
+#: src/amuleDlg.cpp:1831 src/muuli_wdr.cpp:3458
 msgid "Import"
 msgstr ""
 
-#: src/amuleDlg.cpp:1835 src/muuli_wdr.cpp:3427
+#: src/amuleDlg.cpp:1835 src/muuli_wdr.cpp:3458
 msgid "The partfile importer tool"
 msgstr ""
 
-#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3428
+#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3459
 #: src/utils/aLinkCreator/src/alcframe.cpp:262
 msgid "About"
 msgstr ""
 
-#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3428
+#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3459
 msgid "About/Help"
 msgstr ""
 
@@ -939,7 +939,7 @@ msgstr "ﻻ وجود ﻻجزاء الملفات"
 msgid "The core rejected these shared folders:%s"
 msgstr ""
 
-#: src/amule-remote-gui.cpp:1336 src/ExternalConn.cpp:2345
+#: src/amule-remote-gui.cpp:1336 src/ExternalConn.cpp:2346
 msgid "Invalid link or already on list."
 msgstr ""
 
@@ -955,7 +955,7 @@ msgstr ""
 #: src/ClientDetailDialog.cpp:123 src/DataToText.cpp:61 src/DataToText.cpp:86
 #: src/DataToText.cpp:101 src/DataToText.cpp:136 src/DataToText.cpp:165
 #: src/DownloadListCtrl.cpp:1172 src/DownloadListCtrl.cpp:1185
-#: src/DownloadListCtrl.cpp:1196 src/ExternalConn.cpp:608
+#: src/DownloadListCtrl.cpp:1196 src/ExternalConn.cpp:609
 #: src/FileDetailDialog.cpp:203 src/FileDetailDialog.cpp:235
 #: src/FileDetailDialog.cpp:242 src/GenericClientListCtrl.cpp:1171
 #: src/GenericClientListCtrl.cpp:1182 src/GenericClientListCtrl.cpp:1192
@@ -1343,19 +1343,19 @@ msgstr "ذاتي عالي"
 msgid "Very low"
 msgstr "متدني جدا"
 
-#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:743 src/muuli_wdr.cpp:2282
+#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:743 src/muuli_wdr.cpp:2313
 #: src/ServerListCtrl.cpp:263 src/ServerListCtrl.cpp:456
 #: src/SharedFilesCtrl.cpp:145
 msgid "Low"
 msgstr "متدني"
 
-#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:744 src/muuli_wdr.cpp:2283
+#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:744 src/muuli_wdr.cpp:2314
 #: src/ServerListCtrl.cpp:266 src/ServerListCtrl.cpp:457
 #: src/SharedFilesCtrl.cpp:146
 msgid "Normal"
 msgstr "عادي"
 
-#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:745 src/muuli_wdr.cpp:2284
+#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:745 src/muuli_wdr.cpp:2315
 #: src/ServerListCtrl.cpp:269 src/ServerListCtrl.cpp:458
 #: src/SharedFilesCtrl.cpp:147
 msgid "High"
@@ -1447,7 +1447,7 @@ msgstr ""
 msgid "Remote Server"
 msgstr ""
 
-#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3181
+#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3212
 #: src/SearchDlg.cpp:119 src/TextClient.cpp:911
 msgid "Kad"
 msgstr ""
@@ -1518,7 +1518,7 @@ msgstr ""
 msgid "Size"
 msgstr "حجم"
 
-#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3248
+#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3279
 msgid "Transferred"
 msgstr "نقل"
 
@@ -1576,7 +1576,7 @@ msgid ""
 "\n"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:746 src/muuli_wdr.cpp:2285
+#: src/DownloadListCtrl.cpp:746 src/muuli_wdr.cpp:2316
 #: src/SharedFilesCtrl.cpp:150
 msgid "Auto"
 msgstr "ذاتي"
@@ -1614,7 +1614,7 @@ msgid "Extended Options"
 msgstr "خيرات اضافية"
 
 #: src/DownloadListCtrl.cpp:770 src/DownloadListCtrl.cpp:822
-#: src/muuli_wdr.cpp:1796
+#: src/muuli_wdr.cpp:1800
 msgid "Preview"
 msgstr "مشاهدة"
 
@@ -1787,225 +1787,230 @@ msgstr[1] ""
 msgid "Invalid eD2k link! ERROR: %s"
 msgstr ""
 
-#: src/ExternalConn.cpp:379
+#: src/ExternalConn.cpp:380
 msgid "Client sent packet after authentication failed."
 msgstr ""
 
-#: src/ExternalConn.cpp:396
+#: src/ExternalConn.cpp:397
 msgid "External connection closed."
 msgstr ""
 
-#: src/ExternalConn.cpp:473
+#: src/ExternalConn.cpp:474
 msgid "External connections disabled due to empty password!"
 msgstr ""
 
-#: src/ExternalConn.cpp:494
+#: src/ExternalConn.cpp:495
 msgid "External connections disabled in config file"
 msgstr ""
 
-#: src/ExternalConn.cpp:575
+#: src/ExternalConn.cpp:576
 msgid "New external connection accepted"
 msgstr ""
 
-#: src/ExternalConn.cpp:578
+#: src/ExternalConn.cpp:579
 msgid "ERROR: couldn't accept a new external connection"
 msgstr ""
 
-#: src/ExternalConn.cpp:595
+#: src/ExternalConn.cpp:596
 msgid "External connection refused due to empty password in preferences!"
 msgstr ""
 
-#: src/ExternalConn.cpp:607
+#: src/ExternalConn.cpp:608
 #, c-format
 msgid "Connecting client: %s %s"
 msgstr ""
 
-#: src/ExternalConn.cpp:609
+#: src/ExternalConn.cpp:610
 msgid "Unknown version"
 msgstr ""
 
-#: src/ExternalConn.cpp:622
+#: src/ExternalConn.cpp:623
 msgid "Incorrect EC version ID, there might be binary incompatibility. Use core and remote from same snapshot."
 msgstr ""
 
-#: src/ExternalConn.cpp:630
+#: src/ExternalConn.cpp:631
 msgid "You cannot connect to a release version from an arbitrary development snapshot! *sigh* possible crash prevented"
 msgstr ""
 
-#: src/ExternalConn.cpp:713
+#: src/ExternalConn.cpp:714
 msgid "Invalid protocol version."
 msgstr ""
 
-#: src/ExternalConn.cpp:719
+#: src/ExternalConn.cpp:720
 msgid "Missing protocol version tag."
 msgstr ""
 
-#: src/ExternalConn.cpp:727
+#: src/ExternalConn.cpp:728
 msgid "Authentication failed: invalid hash specified as EC password."
 msgstr ""
 
-#: src/ExternalConn.cpp:775
+#: src/ExternalConn.cpp:776
 msgid "Authentication failed: wrong password."
 msgstr ""
 
-#: src/ExternalConn.cpp:777
+#: src/ExternalConn.cpp:778
 msgid "Authentication failed: missing password."
 msgstr ""
 
-#: src/ExternalConn.cpp:788
+#: src/ExternalConn.cpp:789
 msgid "Invalid request, please authenticate first."
 msgstr ""
 
-#: src/ExternalConn.cpp:793
+#: src/ExternalConn.cpp:794
 msgid "Access granted."
 msgstr ""
 
-#: src/ExternalConn.cpp:801
+#: src/ExternalConn.cpp:802
 #, c-format
 msgid "Sent error message \"%s\" to client."
 msgstr ""
 
-#: src/ExternalConn.cpp:806
+#: src/ExternalConn.cpp:807
 #, c-format
 msgid "Unauthorized access attempt from %s. Connection closed."
 msgstr ""
 
-#: src/ExternalConn.cpp:1419
+#: src/ExternalConn.cpp:1420
 #, c-format
 msgid "Remote PartFile command failed: FileHash not found: %s"
 msgstr ""
 
-#: src/ExternalConn.cpp:1423
+#: src/ExternalConn.cpp:1424
 #, c-format
 msgid "FileHash not found: %s"
 msgstr ""
 
-#: src/ExternalConn.cpp:1470 src/ExternalConn.cpp:1558
-#: src/ExternalConn.cpp:1679
+#: src/ExternalConn.cpp:1471 src/ExternalConn.cpp:1559
+#: src/ExternalConn.cpp:1680
 msgid "OOPS! OpCode processing error!"
 msgstr ""
 
-#: src/ExternalConn.cpp:1501
+#: src/ExternalConn.cpp:1502
 msgid "Server not added"
 msgstr ""
 
-#: src/ExternalConn.cpp:1520
+#: src/ExternalConn.cpp:1521
 #, c-format
 msgid "server not found: %s"
 msgstr ""
 
-#: src/ExternalConn.cpp:1537
+#: src/ExternalConn.cpp:1538
 msgid "need to define server to be removed"
 msgstr ""
 
-#: src/ExternalConn.cpp:1552
+#: src/ExternalConn.cpp:1553
 msgid "eD2k is disabled in preferences."
 msgstr ""
 
-#: src/ExternalConn.cpp:1657
+#: src/ExternalConn.cpp:1658
 msgid "Friend not found."
 msgstr ""
 
-#: src/ExternalConn.cpp:1667
+#: src/ExternalConn.cpp:1668
 msgid "Client not found."
 msgstr ""
 
-#: src/ExternalConn.cpp:1673
+#: src/ExternalConn.cpp:1674
 msgid "EC_TAG_FRIEND_SHARED requires EC_TAG_FRIEND or EC_TAG_CLIENT."
 msgstr ""
 
-#: src/ExternalConn.cpp:1991
+#: src/ExternalConn.cpp:1992
 msgid "WebSearch from remote interface makes no sense."
 msgstr ""
 
-#: src/ExternalConn.cpp:2026
+#: src/ExternalConn.cpp:2027
 msgid "Search in progress. Refetch results in a moment!"
 msgstr "جاري البحث ستم جلب النتيجة في لحظة"
 
-#: src/ExternalConn.cpp:2265
+#: src/ExternalConn.cpp:2266
 msgid "No points for graph."
 msgstr ""
 
-#: src/ExternalConn.cpp:2275
+#: src/ExternalConn.cpp:2276
 msgid "Your client is not configured for this detail level."
 msgstr ""
 
-#: src/ExternalConn.cpp:2302
+#: src/ExternalConn.cpp:2303
 msgid "External Connection: shutdown requested"
 msgstr ""
 
-#: src/ExternalConn.cpp:2314
+#: src/ExternalConn.cpp:2315
 msgid "Already shutting down."
 msgstr ""
 
-#: src/ExternalConn.cpp:2332
+#: src/ExternalConn.cpp:2333
 #, c-format
 msgid "ExternalConn: adding link '%s'."
 msgstr ""
 
-#: src/ExternalConn.cpp:2350
+#: src/ExternalConn.cpp:2351
 #, c-format
 msgid "%d of %d links failed (invalid or already on list)."
 msgstr ""
 
-#: src/ExternalConn.cpp:2373
+#: src/ExternalConn.cpp:2374
 msgid "Version check throttled; try again shortly."
 msgstr ""
 
-#: src/ExternalConn.cpp:2378
+#: src/ExternalConn.cpp:2379
 msgid "Version check is not available on this daemon."
 msgstr ""
 
-#: src/ExternalConn.cpp:2508
+#: src/ExternalConn.cpp:2509
 msgid "File not found."
 msgstr ""
 
-#: src/ExternalConn.cpp:2513
+#: src/ExternalConn.cpp:2514
 msgid "Invalid file name."
 msgstr ""
 
-#: src/ExternalConn.cpp:2521
+#: src/ExternalConn.cpp:2522
 msgid "Unable to rename file."
 msgstr ""
 
-#: src/ExternalConn.cpp:2992 src/ExternalConn.cpp:3020
+#: src/ExternalConn.cpp:2839
+#, c-format
+msgid "Could not save the amuleapi password: %s"
+msgstr ""
+
+#: src/ExternalConn.cpp:3004 src/ExternalConn.cpp:3032
 msgid "Kad is disabled in preferences."
 msgstr ""
 
-#: src/ExternalConn.cpp:3033
+#: src/ExternalConn.cpp:3045
 msgid "Already connected to eD2k."
 msgstr ""
 
-#: src/ExternalConn.cpp:3036
+#: src/ExternalConn.cpp:3048
 msgid "Connecting to eD2k..."
 msgstr ""
 
-#: src/ExternalConn.cpp:3045
+#: src/ExternalConn.cpp:3057
 msgid "Already connected to Kad."
 msgstr ""
 
-#: src/ExternalConn.cpp:3048
+#: src/ExternalConn.cpp:3060
 msgid "Connecting to Kad..."
 msgstr ""
 
-#: src/ExternalConn.cpp:3055
+#: src/ExternalConn.cpp:3067
 msgid "All networks are disabled."
 msgstr ""
 
-#: src/ExternalConn.cpp:3064
+#: src/ExternalConn.cpp:3076
 msgid "Disconnected from eD2k."
 msgstr ""
 
-#: src/ExternalConn.cpp:3069
+#: src/ExternalConn.cpp:3081
 msgid "Disconnected from Kad."
 msgstr ""
 
-#: src/ExternalConn.cpp:3078
+#: src/ExternalConn.cpp:3090
 #, c-format
 msgid "External Connection: invalid opcode received: %#x"
 msgstr ""
 
-#: src/ExternalConn.cpp:3083
+#: src/ExternalConn.cpp:3095
 msgid "Invalid opcode (wrong protocol version?)"
 msgstr ""
 
@@ -2378,23 +2383,23 @@ msgid ""
 "want downloads on a different (e.g. larger) disk."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:549 src/FirstRunWizard.cpp:611 src/muuli_wdr.cpp:1708
+#: src/FirstRunWizard.cpp:549 src/FirstRunWizard.cpp:611 src/muuli_wdr.cpp:1712
 msgid "Destination folder for downloads"
 msgstr ""
 
 #: src/FirstRunWizard.cpp:553 src/FirstRunWizard.cpp:569 src/muuli_wdr.cpp:1349
-#: src/muuli_wdr.cpp:1366 src/muuli_wdr.cpp:1683 src/muuli_wdr.cpp:1714
-#: src/muuli_wdr.cpp:1726 src/muuli_wdr.cpp:2769
+#: src/muuli_wdr.cpp:1366 src/muuli_wdr.cpp:1687 src/muuli_wdr.cpp:1718
+#: src/muuli_wdr.cpp:1730 src/muuli_wdr.cpp:2800
 #: src/utils/aLinkCreator/src/alcframe.cpp:135
 #: src/utils/wxCas/src/wxcasprefs.cpp:52 src/utils/wxCas/src/wxcasprefs.cpp:118
 msgid "Browse"
 msgstr "تصفح"
 
-#: src/FirstRunWizard.cpp:559 src/muuli_wdr.cpp:1719
+#: src/FirstRunWizard.cpp:559 src/muuli_wdr.cpp:1723
 msgid "(All files in this folder are shared with other peers)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:565 src/FirstRunWizard.cpp:624 src/muuli_wdr.cpp:1721
+#: src/FirstRunWizard.cpp:565 src/FirstRunWizard.cpp:624 src/muuli_wdr.cpp:1725
 msgid "Folder for temporary download files"
 msgstr ""
 
@@ -2425,7 +2430,7 @@ msgstr ""
 msgid "CRITICAL - no client on StartChatSession"
 msgstr ""
 
-#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2675 src/muuli_wdr.cpp:3352
+#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2706 src/muuli_wdr.cpp:3383
 msgid "Friends"
 msgstr "اصدقاء"
 
@@ -2536,8 +2541,8 @@ msgstr "ﻻ احد"
 msgid "No"
 msgstr "ﻻ"
 
-#: src/GenericClientListCtrl.cpp:1216 src/PrefsUnifiedDlg.cpp:2818
-#: src/PrefsUnifiedDlg.cpp:2868 src/ServerListCtrl.cpp:276
+#: src/GenericClientListCtrl.cpp:1216 src/PrefsUnifiedDlg.cpp:2898
+#: src/PrefsUnifiedDlg.cpp:2948 src/ServerListCtrl.cpp:276
 msgid "Yes"
 msgstr "نعم"
 
@@ -2705,10 +2710,10 @@ msgstr ""
 msgid "Please fill all fields required"
 msgstr ""
 
-#: src/KadDlg.cpp:192 src/PartFile.cpp:1031 src/PrefsUnifiedDlg.cpp:1162
-#: src/PrefsUnifiedDlg.cpp:1331 src/PrefsUnifiedDlg.cpp:1589
-#: src/PrefsUnifiedDlg.cpp:1599 src/PrefsUnifiedDlg.cpp:1616
-#: src/PrefsUnifiedDlg.cpp:1658
+#: src/KadDlg.cpp:192 src/PartFile.cpp:1031 src/PrefsUnifiedDlg.cpp:1134
+#: src/PrefsUnifiedDlg.cpp:1204 src/PrefsUnifiedDlg.cpp:1405
+#: src/PrefsUnifiedDlg.cpp:1663 src/PrefsUnifiedDlg.cpp:1673
+#: src/PrefsUnifiedDlg.cpp:1690 src/PrefsUnifiedDlg.cpp:1738
 msgid "Message"
 msgstr ""
 
@@ -2809,7 +2814,7 @@ msgstr ""
 msgid "Uploaded"
 msgstr ""
 
-#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3232
+#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3263
 msgid "Requested"
 msgstr ""
 
@@ -2934,7 +2939,7 @@ msgid "WARNING: "
 msgstr ""
 
 #: src/MuleNotebook.cpp:179 src/muuli_wdr.cpp:817 src/muuli_wdr.cpp:1229
-#: src/muuli_wdr.cpp:3136 src/muuli_wdr.cpp:3392
+#: src/muuli_wdr.cpp:3167 src/muuli_wdr.cpp:3423
 msgid "Close"
 msgstr "اغلق"
 
@@ -2952,7 +2957,7 @@ msgid "Paste"
 msgstr ""
 
 #: src/MuleTextCtrl.cpp:89 src/muuli_wdr.cpp:358 src/muuli_wdr.cpp:757
-#: src/muuli_wdr.cpp:2359 src/muuli_wdr.cpp:2378 src/muuli_wdr.cpp:2400
+#: src/muuli_wdr.cpp:2390 src/muuli_wdr.cpp:2409 src/muuli_wdr.cpp:2431
 #: src/utils/aLinkCreator/src/alcframe.cpp:142
 msgid "Clear"
 msgstr "واضح"
@@ -3048,7 +3053,7 @@ msgstr "خروج"
 
 #: src/MuleTrayIcon.cpp:579 src/MuleTrayIcon.cpp:945 src/MuleTrayIcon.cpp:965
 #: src/muuli_wdr.cpp:1398 src/muuli_wdr.cpp:1406 src/muuli_wdr.cpp:1413
-#: src/muuli_wdr.cpp:1842 src/muuli_wdr.cpp:1848 src/OtherFunctions.cpp:91
+#: src/muuli_wdr.cpp:1846 src/muuli_wdr.cpp:1852 src/OtherFunctions.cpp:91
 #: src/StatisticsDlg.cpp:93 src/StatisticsDlg.cpp:95
 msgid "kB/s"
 msgstr ""
@@ -3289,7 +3294,7 @@ msgstr "بايت"
 msgid "KB"
 msgstr ""
 
-#: src/muuli_wdr.cpp:274 src/muuli_wdr.cpp:293 src/muuli_wdr.cpp:1627
+#: src/muuli_wdr.cpp:274 src/muuli_wdr.cpp:293 src/muuli_wdr.cpp:1631
 #: src/OtherFunctions.cpp:64
 msgid "MB"
 msgstr ""
@@ -3306,7 +3311,7 @@ msgstr "اكبر حجم"
 msgid "Availability"
 msgstr ""
 
-#: src/muuli_wdr.cpp:312 src/muuli_wdr.cpp:398 src/muuli_wdr.cpp:3297
+#: src/muuli_wdr.cpp:312 src/muuli_wdr.cpp:398 src/muuli_wdr.cpp:3328
 msgid "Filter:"
 msgstr ""
 
@@ -3370,12 +3375,12 @@ msgstr "ايجاد المصدر :"
 #: src/muuli_wdr.cpp:1160 src/muuli_wdr.cpp:1167 src/muuli_wdr.cpp:1172
 #: src/muuli_wdr.cpp:1179 src/muuli_wdr.cpp:1184 src/muuli_wdr.cpp:1191
 #: src/muuli_wdr.cpp:1205 src/muuli_wdr.cpp:1212 src/muuli_wdr.cpp:1217
-#: src/muuli_wdr.cpp:1224 src/muuli_wdr.cpp:3234 src/muuli_wdr.cpp:3242
-#: src/muuli_wdr.cpp:3250
+#: src/muuli_wdr.cpp:1224 src/muuli_wdr.cpp:3265 src/muuli_wdr.cpp:3273
+#: src/muuli_wdr.cpp:3281
 msgid "N/A"
 msgstr "غير متوفر"
 
-#: src/muuli_wdr.cpp:508 src/muuli_wdr.cpp:1065 src/PrefsUnifiedDlg.cpp:297
+#: src/muuli_wdr.cpp:508 src/muuli_wdr.cpp:1065 src/PrefsUnifiedDlg.cpp:299
 msgid "General"
 msgstr "عام"
 
@@ -3514,7 +3519,7 @@ msgstr ""
 msgid "Album :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:685 src/muuli_wdr.cpp:2254
+#: src/muuli_wdr.cpp:685 src/muuli_wdr.cpp:2285
 msgid "Title :"
 msgstr "عنوان :"
 
@@ -3620,7 +3625,7 @@ msgstr "اسم المستخدم :"
 msgid "Userhash :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:895 src/muuli_wdr.cpp:1748 src/muuli_wdr.cpp:2449
+#: src/muuli_wdr.cpp:895 src/muuli_wdr.cpp:1752 src/muuli_wdr.cpp:2480
 #: src/utils/aLinkCreator/src/alcframe.cpp:137
 msgid "Add"
 msgstr "اضف"
@@ -3629,15 +3634,15 @@ msgstr "اضف"
 msgid "Download-Speed"
 msgstr "سرعة-التحميل"
 
-#: src/muuli_wdr.cpp:954 src/muuli_wdr.cpp:989 src/muuli_wdr.cpp:2553
+#: src/muuli_wdr.cpp:954 src/muuli_wdr.cpp:989 src/muuli_wdr.cpp:2584
 msgid "Current"
 msgstr "الحالي"
 
-#: src/muuli_wdr.cpp:962 src/muuli_wdr.cpp:997 src/muuli_wdr.cpp:2561
+#: src/muuli_wdr.cpp:962 src/muuli_wdr.cpp:997 src/muuli_wdr.cpp:2592
 msgid "Running average"
 msgstr "معدل العمل"
 
-#: src/muuli_wdr.cpp:970 src/muuli_wdr.cpp:1005 src/muuli_wdr.cpp:2569
+#: src/muuli_wdr.cpp:970 src/muuli_wdr.cpp:1005 src/muuli_wdr.cpp:2600
 msgid "Session average"
 msgstr "معدل الجلسة"
 
@@ -3649,7 +3654,7 @@ msgstr "سرعة-الرفع"
 msgid "Connections"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1024 src/muuli_wdr.cpp:1867
+#: src/muuli_wdr.cpp:1024 src/muuli_wdr.cpp:1871
 msgid "Active downloads"
 msgstr "تحميل نشط"
 
@@ -3657,7 +3662,7 @@ msgstr "تحميل نشط"
 msgid "Active connections (1:1)"
 msgstr "إتصال نشط (1:1)"
 
-#: src/muuli_wdr.cpp:1040 src/muuli_wdr.cpp:1868
+#: src/muuli_wdr.cpp:1040 src/muuli_wdr.cpp:1872
 msgid "Active uploads"
 msgstr "رفع نشط"
 
@@ -3931,7 +3936,7 @@ msgstr ""
 msgid "Advanced users only: If you have multiple network interfaces, enter the address of the interface to which aMule should be bound."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1462 src/muuli_wdr.cpp:2061
+#: src/muuli_wdr.cpp:1462 src/muuli_wdr.cpp:2065
 msgid "Bind to network interface (empty for any):"
 msgstr ""
 
@@ -3947,7 +3952,7 @@ msgstr ""
 msgid "Max simultaneous connections:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1498 src/muuli_wdr.cpp:3176
+#: src/muuli_wdr.cpp:1498 src/muuli_wdr.cpp:3207
 msgid "ED2K"
 msgstr ""
 
@@ -4039,749 +4044,769 @@ msgstr ""
 msgid "For new files preallocates disk space for the whole file, thus reduces fragmentation"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1613
+#: src/muuli_wdr.cpp:1617
 msgid "Create new files as sparse files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1614
-msgid "A sparse file reserves its full size on disk immediately without writing real data to it -- fast, but unsupported or slow on some filesystems, and free-space accounting stays optimistic while the download is in progress. Turn this off to grow the file only as data arrives."
+#: src/muuli_wdr.cpp:1618
+msgid "Sparse part files only occupy disk space for the parts already downloaded, so free space is used up gradually as the file fills in. Turn this off to use an ordinary file instead - useful where sparse files are unsupported or slow, or where backup/de-duplication tools handle them badly. Applies only when the core runs on Windows; on Linux and macOS part files are sparse anyway and this setting has no effect."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1619
+#: src/muuli_wdr.cpp:1623
 msgid "Stop downloads when free disk space reaches "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1620
+#: src/muuli_wdr.cpp:1624
 msgid "Select this if you want aMule to check your disk space"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1624
+#: src/muuli_wdr.cpp:1628
 msgid "Enter here the min disk space desired."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1630
+#: src/muuli_wdr.cpp:1634
 msgid "Save 10 sources on rare files (< 20 sources)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1634 src/Statistics.cpp:790
+#: src/muuli_wdr.cpp:1638 src/Statistics.cpp:790
 msgid "Uploads"
 msgstr "ارفع"
 
-#: src/muuli_wdr.cpp:1637
+#: src/muuli_wdr.cpp:1641
 msgid "Add new shared files with auto priority"
 msgstr "أضف ملفات مشاركة جديدة بوضع ذاتي"
 
-#: src/muuli_wdr.cpp:1643
+#: src/muuli_wdr.cpp:1647
 msgid "Intelligent Corruption Handling (I.C.H.)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1646
+#: src/muuli_wdr.cpp:1650
 msgid "Enable"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1649
+#: src/muuli_wdr.cpp:1653
 msgid "Advanced I.C.H. trusts every hash (not recommended)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1661 src/PrefsUnifiedDlg.cpp:1910
+#: src/muuli_wdr.cpp:1665 src/PrefsUnifiedDlg.cpp:1990
 msgid "Media metadata extraction"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1665
+#: src/muuli_wdr.cpp:1669
 msgid "Extract length / bitrate / codec from shared audio and video files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1667
+#: src/muuli_wdr.cpp:1671
 msgid "When enabled, aMule runs ffprobe on each shared media file to fill in the Length / Bitrate / Codec columns other clients see when they find the file in a search. Requires ffmpeg (the ffprobe binary) to be installed."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1674
+#: src/muuli_wdr.cpp:1678
 msgid "Path to ffprobe:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1679
+#: src/muuli_wdr.cpp:1683
 msgid "Full path to the ffprobe binary. Leave empty to have aMule auto-detect it on startup."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1687
+#: src/muuli_wdr.cpp:1691
 msgid "Detect"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1688
+#: src/muuli_wdr.cpp:1692
 msgid "Search the standard install locations for an ffprobe binary and fill the path field."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1712
+#: src/muuli_wdr.cpp:1716
 msgid ""
 "Completed downloads are stored here. All files in this folder are automatically shared with other peers.\n"
 "If this folder also holds files you don't want to share, point it at an aMule-only sub-folder."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1715
+#: src/muuli_wdr.cpp:1719
 msgid "Pick the folder where completed downloads will be stored. All files in that folder will be shared with other peers."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1729
+#: src/muuli_wdr.cpp:1733
 msgid "Shared folders"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1735
+#: src/muuli_wdr.cpp:1739
 msgid "(Folders shared by the core. Enter a path to add one.)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1743
+#: src/muuli_wdr.cpp:1747
 msgid "Absolute path of a folder on the core's machine, e.g. /home/user/shared"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1745 src/PrefsUnifiedDlg.cpp:2794
+#: src/muuli_wdr.cpp:1749 src/PrefsUnifiedDlg.cpp:2874
 msgid "Recursive"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1746
+#: src/muuli_wdr.cpp:1750
 msgid "Share every sub-folder underneath this one, including ones created later."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1750 src/utils/aLinkCreator/src/alcframe.cpp:141
+#: src/muuli_wdr.cpp:1754 src/utils/aLinkCreator/src/alcframe.cpp:141
 msgid "Remove"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1754
+#: src/muuli_wdr.cpp:1758
 msgid "(Right click on folder icon for recursive share)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1761
+#: src/muuli_wdr.cpp:1765
 msgid "Share hidden files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1767
+#: src/muuli_wdr.cpp:1771
 msgid "Automatically rescan shared folders for changes"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1773
+#: src/muuli_wdr.cpp:1777
 msgid "Follow symbolic links in shared folders"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1779
+#: src/muuli_wdr.cpp:1783
 msgid "Exclude files matching:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1782
+#: src/muuli_wdr.cpp:1786
 msgid "Wildcard patterns separated by '|', e.g. .DS_Store|Thumbs.db|*.tmp. Files whose name matches are not shared. Matching is case-insensitive."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1786
+#: src/muuli_wdr.cpp:1790
 msgid "Patterns are regular expressions"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1787
+#: src/muuli_wdr.cpp:1791
 msgid "When set, the whole field is one regular expression ('|' is alternation). When unset, it is a list of '|'-separated wildcards."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1797
+#: src/muuli_wdr.cpp:1801
 msgid "Show how many shared files the current pattern would exclude."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1818
+#: src/muuli_wdr.cpp:1822
 msgid "Graphs"
 msgstr "رسم بياني"
 
-#: src/muuli_wdr.cpp:1821 src/muuli_wdr.cpp:1883
+#: src/muuli_wdr.cpp:1825 src/muuli_wdr.cpp:1887
 msgid "Update delay : 5 secs"
 msgstr "تحيدث كل:5 ثواني"
 
-#: src/muuli_wdr.cpp:1825
+#: src/muuli_wdr.cpp:1829
 msgid "Time for average graph: 100 mins"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1829
+#: src/muuli_wdr.cpp:1833
 msgid "Connections Graph Scale: 100 "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1836
+#: src/muuli_wdr.cpp:1840
 msgid "Download graph scale:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1844
+#: src/muuli_wdr.cpp:1848
 msgid "Upload graph scale:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1854
+#: src/muuli_wdr.cpp:1858
 msgid "Colors: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1858
+#: src/muuli_wdr.cpp:1862
 msgid "Background"
 msgstr "خلفية"
 
-#: src/muuli_wdr.cpp:1859
+#: src/muuli_wdr.cpp:1863
 msgid "Grid"
 msgstr "شبكة"
 
-#: src/muuli_wdr.cpp:1860
+#: src/muuli_wdr.cpp:1864
 msgid "Download current"
 msgstr "حمل الحالي"
 
-#: src/muuli_wdr.cpp:1861
+#: src/muuli_wdr.cpp:1865
 msgid "Download running average"
 msgstr "معدل تحميل الحالي"
 
-#: src/muuli_wdr.cpp:1862
+#: src/muuli_wdr.cpp:1866
 msgid "Download session average"
 msgstr "معدل تحميل الجلسة"
 
-#: src/muuli_wdr.cpp:1863
+#: src/muuli_wdr.cpp:1867
 msgid "Upload current"
 msgstr "ارفع الحالي"
 
-#: src/muuli_wdr.cpp:1864
+#: src/muuli_wdr.cpp:1868
 msgid "Upload running average"
 msgstr "معدل رفع الحالي"
 
-#: src/muuli_wdr.cpp:1865
+#: src/muuli_wdr.cpp:1869
 msgid "Upload session average"
 msgstr "معدل رفع الجلسة"
 
-#: src/muuli_wdr.cpp:1866
+#: src/muuli_wdr.cpp:1870
 msgid "Active connections"
 msgstr "اتصال نشط"
 
-#: src/muuli_wdr.cpp:1869
+#: src/muuli_wdr.cpp:1873
 msgid "Systray Icon Speed Bar"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1870
+#: src/muuli_wdr.cpp:1874
 msgid "Kad-nodes current"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1871
+#: src/muuli_wdr.cpp:1875
 msgid "Kad-nodes running"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1872
+#: src/muuli_wdr.cpp:1876
 msgid "Kad-nodes session"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1876 src/muuli_wdr.cpp:2303
+#: src/muuli_wdr.cpp:1880 src/muuli_wdr.cpp:2334
 msgid "Select"
 msgstr "اختر"
 
-#: src/muuli_wdr.cpp:1880
+#: src/muuli_wdr.cpp:1884
 msgid "Tree"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1890
+#: src/muuli_wdr.cpp:1894
 msgid "Number of Client Versions shown (0=unlimited)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1915
+#: src/muuli_wdr.cpp:1919
 msgid "!!! WARNING !!!"
 msgstr "!!!تحذير!!!"
 
-#: src/muuli_wdr.cpp:1930
+#: src/muuli_wdr.cpp:1934
 msgid "Max new connections / 5 secs"
 msgstr "الحد اﻷعلى للتصالات لكل 5 ثواني"
 
-#: src/muuli_wdr.cpp:1932
+#: src/muuli_wdr.cpp:1936
 msgid "Concurrent Kad source lookups"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1934
+#: src/muuli_wdr.cpp:1938
 msgid "Kad source re-search interval (minutes)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1936
+#: src/muuli_wdr.cpp:1940
 #, fuzzy
 msgid "Source re-ask interval (minutes)"
 msgstr "فترة تحديث الإتصال بالخادم %i دقيقة"
 
-#: src/muuli_wdr.cpp:1940
+#: src/muuli_wdr.cpp:1944
 msgid "File Buffer Size: 240000 bytes"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1944
+#: src/muuli_wdr.cpp:1948
 msgid "Use MMAP: memory-mapped file access (lower memory use)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1945
+#: src/muuli_wdr.cpp:1949
 msgid "Maps part files into memory instead of buffering them on the heap, lowering the process memory footprint. May reduce download speed on some disks; best for memory-constrained or upload-heavy hosts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1947
+#: src/muuli_wdr.cpp:1951
 msgid "Upload Queue Size: 5000 clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1951
+#: src/muuli_wdr.cpp:1955
 msgid "Server connection refresh interval: Disable"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1955
+#: src/muuli_wdr.cpp:1959
 msgid "Disable computer's timed standby mode"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1974
+#: src/muuli_wdr.cpp:1978
 msgid "Skin to use: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1983
+#: src/muuli_wdr.cpp:1987
 msgid "Show \"Fast eD2k Links Handler\" in every window."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1986
+#: src/muuli_wdr.cpp:1990
 msgid "Show extended info on categories tabs"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1989
+#: src/muuli_wdr.cpp:1993
 #, fuzzy
 msgid "Show application version on title"
 msgstr "اظهر معدل النقل علي العنوان"
 
-#: src/muuli_wdr.cpp:1991
+#: src/muuli_wdr.cpp:1995
 msgid "Show transfer rates on title"
 msgstr "اظهر معدل النقل علي العنوان"
 
-#: src/muuli_wdr.cpp:1993
+#: src/muuli_wdr.cpp:1997
 msgid "Before application name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1995
+#: src/muuli_wdr.cpp:1999
 msgid "After application name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1998
+#: src/muuli_wdr.cpp:2002
 msgid "Show overhead bandwidth"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2002
+#: src/muuli_wdr.cpp:2006
 msgid "Vertical toolbar orientation"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2004
+#: src/muuli_wdr.cpp:2008
 msgid "Live column sorting (auto-reorder rows as their values change)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2011
+#: src/muuli_wdr.cpp:2015
 msgid "Download Queue Files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2014
+#: src/muuli_wdr.cpp:2018
 msgid "Show progress percentage"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2020
+#: src/muuli_wdr.cpp:2024
 msgid "Show progress bar"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2023
+#: src/muuli_wdr.cpp:2027
 msgid "Flat"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2027
+#: src/muuli_wdr.cpp:2031
 msgid "Round"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2045
+#: src/muuli_wdr.cpp:2049
 msgid "External Connection Parameters"
 msgstr "عوامل اﻻتصال الخارجي"
 
-#: src/muuli_wdr.cpp:2048
+#: src/muuli_wdr.cpp:2052
 msgid "Accept external connections"
 msgstr "اقبل اتصال خارجي"
 
-#: src/muuli_wdr.cpp:2055 src/muuli_wdr.cpp:2114
+#: src/muuli_wdr.cpp:2059 src/muuli_wdr.cpp:2118
 msgid "IP of the listening interface:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2058
+#: src/muuli_wdr.cpp:2062
 msgid "Enter here a valid ip in the a.b.c.d format for the listening EC interface. An empty field or 0.0.0.0 will mean any interface."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2079 src/muuli_wdr.cpp:2163
+#: src/muuli_wdr.cpp:2083 src/muuli_wdr.cpp:2194
 msgid "TCP port:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2085
+#: src/muuli_wdr.cpp:2089
 msgid "Enable UPnP port forwarding on the EC port"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2089 src/muuli_wdr.cpp:3048
+#: src/muuli_wdr.cpp:2093 src/muuli_wdr.cpp:3079
 #: src/utils/wxCas/src/wxcasprefs.cpp:167
 msgid "Password"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2095
+#: src/muuli_wdr.cpp:2099
 msgid "aMule API server parameters"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2098
+#: src/muuli_wdr.cpp:2102
 msgid "Run amuleapi (REST API) on startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2103
+#: src/muuli_wdr.cpp:2107
 msgid "HTTP port:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2117
+#: src/muuli_wdr.cpp:2121
 msgid "The interface amuleapi's HTTP server listens on. 127.0.0.1 (default) accepts only local connections; use 0.0.0.0 or a specific IP to expose it to other hosts (set an admin password below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2120
+#: src/muuli_wdr.cpp:2126
+msgid "Type a password to set or change it. Stored passwords cannot be shown, so leaving this empty keeps the current one."
+msgstr ""
+
+#: src/muuli_wdr.cpp:2128
 msgid "Admin password"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2125 src/muuli_wdr.cpp:2156
-msgid "Low rights password"
+#: src/muuli_wdr.cpp:2140 src/muuli_wdr.cpp:2157 src/PrefsUnifiedDlg.cpp:1103
+msgid "A password is set."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2133
+#: src/muuli_wdr.cpp:2144
+msgid "Enable guest access"
+msgstr ""
+
+#: src/muuli_wdr.cpp:2145
+msgid "Guest sessions may read status and listings but cannot change anything. Turning this off clears the stored guest password."
+msgstr ""
+
+#: src/muuli_wdr.cpp:2149
+msgid "Guest password"
+msgstr ""
+
+#: src/muuli_wdr.cpp:2164
 msgid "Web server parameters"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2136
+#: src/muuli_wdr.cpp:2167
 msgid "Run webserver on startup (deprecated)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2142
+#: src/muuli_wdr.cpp:2173
 msgid "Web template"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2147
+#: src/muuli_wdr.cpp:2178
 msgid "Full rights password"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2151
+#: src/muuli_wdr.cpp:2182
 msgid "Enable Low rights User"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2170
+#: src/muuli_wdr.cpp:2187
+msgid "Low rights password"
+msgstr ""
+
+#: src/muuli_wdr.cpp:2201
 msgid "Enable UPnP port forwarding of the web server port"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2175
+#: src/muuli_wdr.cpp:2206
 msgid "Web server UPnP TCP port (Optional)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2183
+#: src/muuli_wdr.cpp:2214
 msgid "Page Refresh Time (in secs)"
 msgstr "زمن تحديث الصفحة (بالثانية)"
 
-#: src/muuli_wdr.cpp:2190
+#: src/muuli_wdr.cpp:2221
 msgid "Enable Gzip compression"
 msgstr " Gzipتمكين ضغط نوع"
 
-#: src/muuli_wdr.cpp:2224
+#: src/muuli_wdr.cpp:2255
 #, fuzzy
 msgid "Reset page to defaults"
 msgstr "اﻹفتراضية بالنظام"
 
-#: src/muuli_wdr.cpp:2225
+#: src/muuli_wdr.cpp:2256
 msgid "Reset the settings on the current page to their default values."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2227 src/muuli_wdr.cpp:2313 src/ServerWnd.cpp:274
+#: src/muuli_wdr.cpp:2258 src/muuli_wdr.cpp:2344 src/ServerWnd.cpp:274
 #: src/ServerWnd.cpp:282
 msgid "OK"
 msgstr "موافق"
 
-#: src/muuli_wdr.cpp:2229
+#: src/muuli_wdr.cpp:2260
 msgid "Click here to apply any changes made to the preferences."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2232
+#: src/muuli_wdr.cpp:2263
 msgid "Reset any changes made to the preferences."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2261
+#: src/muuli_wdr.cpp:2292
 msgid "Comment :"
 msgstr "تعليق :"
 
-#: src/muuli_wdr.cpp:2268
+#: src/muuli_wdr.cpp:2299
 msgid "Incoming Dir :"
 msgstr "مجلد القادم"
 
-#: src/muuli_wdr.cpp:2277
+#: src/muuli_wdr.cpp:2308
 msgid "Change priority for new assigned files :"
 msgstr "تغير الأولوية للملفات الحديثة :"
 
-#: src/muuli_wdr.cpp:2281
+#: src/muuli_wdr.cpp:2312
 #, fuzzy
 msgid "Don't change"
 msgstr "ﻻ تغير"
 
-#: src/muuli_wdr.cpp:2293
+#: src/muuli_wdr.cpp:2324
 msgid "Select color for this Category (currently selected) :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2360 src/muuli_wdr.cpp:2379 src/muuli_wdr.cpp:2401
+#: src/muuli_wdr.cpp:2391 src/muuli_wdr.cpp:2410 src/muuli_wdr.cpp:2432
 msgid "Click this button to reset the log."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2420
+#: src/muuli_wdr.cpp:2451
 msgid "Click on this button to update the servers list from URL ..."
 msgstr "قم بالضغط على هذا الزر لتحديث قائمة الخادمات من العنوان ..."
 
-#: src/muuli_wdr.cpp:2424
+#: src/muuli_wdr.cpp:2455
 msgid "Server list"
 msgstr "قائمة الخادمات"
 
-#: src/muuli_wdr.cpp:2428
+#: src/muuli_wdr.cpp:2459
 msgid "Enter the url to a server.met file here and press the button to the left to update the list of known servers."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2433
+#: src/muuli_wdr.cpp:2464
 msgid "Add server manually: Name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2436
+#: src/muuli_wdr.cpp:2467
 msgid "Enter the name of the new server here"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2438 src/ServerWnd.cpp:206
+#: src/muuli_wdr.cpp:2469 src/ServerWnd.cpp:206
 msgid "IP:Port"
 msgstr "عنوان شبكي :منفذ"
 
-#: src/muuli_wdr.cpp:2441
+#: src/muuli_wdr.cpp:2472
 msgid "Enter the IP of the server here, using the x.x.x.x format."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2447
+#: src/muuli_wdr.cpp:2478
 msgid "Enter the port of the server here."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2450
+#: src/muuli_wdr.cpp:2481
 msgid "Add manually a server (fill fields to the left before) ..."
 msgstr "اضف خادم يدويا )قم بمل الخانة على اليسار اوﻻ)..."
 
-#: src/muuli_wdr.cpp:2479
+#: src/muuli_wdr.cpp:2510
 msgid "aMule Log"
 msgstr "سجل aMule"
 
-#: src/muuli_wdr.cpp:2487
+#: src/muuli_wdr.cpp:2518
 msgid "Server Info"
 msgstr "معلومات الخادم"
 
-#: src/muuli_wdr.cpp:2491
+#: src/muuli_wdr.cpp:2522
 msgid "ED2K Info"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2495
+#: src/muuli_wdr.cpp:2526
 msgid "Kad Info"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2523
+#: src/muuli_wdr.cpp:2554
 msgid "Click on this button to update the nodes list from URL ..."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2527
+#: src/muuli_wdr.cpp:2558
 msgid "Nodes (0)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2531
+#: src/muuli_wdr.cpp:2562
 msgid "Enter the url to a nodes.dat file here and press the button to the left to update the list of known nodes."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2534
+#: src/muuli_wdr.cpp:2565
 msgid "Nodes stats"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2576
+#: src/muuli_wdr.cpp:2607
 msgid "Bootstrap"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2579
+#: src/muuli_wdr.cpp:2610
 msgid "New node"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2584
+#: src/muuli_wdr.cpp:2615
 msgid "IP:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2604
+#: src/muuli_wdr.cpp:2635
 msgid "Port:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2617
+#: src/muuli_wdr.cpp:2648
 msgid "Bootstrap from known clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2619
+#: src/muuli_wdr.cpp:2650
 msgid "Disconnect Kad"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2653
+#: src/muuli_wdr.cpp:2684
 msgid "Use Secure User Identification"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2655
+#: src/muuli_wdr.cpp:2686
 msgid "It is recommended to enable this option. You will not receive credits if SUI is not enabled."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2657
+#: src/muuli_wdr.cpp:2688
 msgid "Protocol Obfuscation"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2660
+#: src/muuli_wdr.cpp:2691
 msgid "Support Protocol Obfuscation"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2662
+#: src/muuli_wdr.cpp:2693
 msgid "This option enabled Protocol Obfuscation, and makes aMule accept obfuscated connections from other clients."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2664
+#: src/muuli_wdr.cpp:2695
 msgid "Use obfuscation for outgoing connections"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2666
+#: src/muuli_wdr.cpp:2697
 msgid "This option makes aMule use Protocol Obfuscation when connecting other clients/servers."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2668
+#: src/muuli_wdr.cpp:2699
 msgid "Accept only obfuscated connections"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2669
+#: src/muuli_wdr.cpp:2700
 msgid "This option makes aMule only accept obfuscated connections. You will have less sources, but all your traffic will be obfuscated"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2674
+#: src/muuli_wdr.cpp:2705
 msgid "Everybody"
 msgstr "الكل"
 
-#: src/muuli_wdr.cpp:2676
+#: src/muuli_wdr.cpp:2707
 msgid "No one"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2678
+#: src/muuli_wdr.cpp:2709
 msgid "Who can see my shared files:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2679
+#: src/muuli_wdr.cpp:2710
 msgid "Select who can request to view a list of your shared files."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2681
+#: src/muuli_wdr.cpp:2712
 msgid "IP-Filtering"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2688
+#: src/muuli_wdr.cpp:2719
 msgid "Filter clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2690
+#: src/muuli_wdr.cpp:2721
 msgid "Enable filtering of the client IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2692
+#: src/muuli_wdr.cpp:2723
 msgid "Filter servers"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2694
+#: src/muuli_wdr.cpp:2725
 msgid "Enable filtering of the server IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2698
+#: src/muuli_wdr.cpp:2729
 msgid "Reload List"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2699
+#: src/muuli_wdr.cpp:2730
 msgid "Reload the list of IPs to filter from the file ~/.aMule/ipfilter.dat"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2705
+#: src/muuli_wdr.cpp:2736
 msgid "URL:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2709 src/muuli_wdr.cpp:2902
+#: src/muuli_wdr.cpp:2740 src/muuli_wdr.cpp:2933
 msgid "Update now"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2712
+#: src/muuli_wdr.cpp:2743
 msgid "Auto-update ipfilter at startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2716
+#: src/muuli_wdr.cpp:2747
 msgid "Filtering Level:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2722
+#: src/muuli_wdr.cpp:2753
 msgid "Always filter LAN IPs"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2725
+#: src/muuli_wdr.cpp:2756
 msgid "Paranoid handling of non-matching IPs"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2727
+#: src/muuli_wdr.cpp:2758
 msgid "Rejects a packet when its source IP differs from the IP the client claims (an anti-spoofing check). Disable only if it causes connection problems."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2729
+#: src/muuli_wdr.cpp:2760
 msgid "Use system-wide ipfilter.dat if available"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2730
+#: src/muuli_wdr.cpp:2761
 msgid "If there's no local ipfilter.dat found, allow usage of a system-wide ipfilter file."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2747
+#: src/muuli_wdr.cpp:2778
 msgid "Enable Online-Signature"
 msgstr "تمكين التوقيع الشبكي"
 
-#: src/muuli_wdr.cpp:2749
+#: src/muuli_wdr.cpp:2780
 msgid "Enables the writing of the OS file, which can be used by external apps to create signatures and the like."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2753
+#: src/muuli_wdr.cpp:2784
 msgid "Update Frequency (Secs):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2756
+#: src/muuli_wdr.cpp:2787
 msgid "Change the frequency (in seconds) of Online Signature updates."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2764
+#: src/muuli_wdr.cpp:2795
 msgid "Save online signature file in: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:2770
+#: src/muuli_wdr.cpp:2801
 msgid "Click here to select the directory containing the the Online Signature files."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2803
+#: src/muuli_wdr.cpp:2834
 msgid "Show country flags for clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2804
+#: src/muuli_wdr.cpp:2835
 msgid "Render the country flag column in the transfers, queue and search views. Requires a valid MMDB GeoIP database (see below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2809
+#: src/muuli_wdr.cpp:2840
 #, fuzzy
 msgid "Database"
 msgstr "نسبة المصادر :"
 
-#: src/muuli_wdr.cpp:2825
+#: src/muuli_wdr.cpp:2856
 #, fuzzy
 msgid "Source:"
 msgstr "مصدر"
 
-#: src/muuli_wdr.cpp:2828
+#: src/muuli_wdr.cpp:2859
 msgid "DB-IP (free, no account)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2829
+#: src/muuli_wdr.cpp:2860
 msgid "MaxMind GeoLite2 (free, account required)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2830
+#: src/muuli_wdr.cpp:2861
 msgid "Custom URL"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2833
+#: src/muuli_wdr.cpp:2864
 msgid "Choose which provider supplies the GeoIP MMDB database. DB-IP is the default - no account required. MaxMind requires a free account + license key. Use Custom URL to point at any other MMDB host (e.g. a local mirror)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2850
+#: src/muuli_wdr.cpp:2881
 msgid ""
 "No configuration required.\n"
 "\n"
@@ -4789,11 +4814,11 @@ msgid ""
 "License: Creative Commons BY 4.0 - https://creativecommons.org/licenses/by/4.0/"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2863
+#: src/muuli_wdr.cpp:2894
 msgid "License key:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2869
+#: src/muuli_wdr.cpp:2900
 msgid ""
 "Sign up for a free MaxMind account, then generate a License Key:\n"
 "https://www.maxmind.com/en/geolite2/signup\n"
@@ -4803,233 +4828,233 @@ msgid ""
 "Requires attribution and account registration; refresh at least every 30 days."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2884
+#: src/muuli_wdr.cpp:2915
 #, fuzzy
 msgid "Download URL:"
 msgstr "التحميل"
 
-#: src/muuli_wdr.cpp:2890
+#: src/muuli_wdr.cpp:2921
 msgid ""
 "Must point to an .mmdb file or a .gz / .tar.gz containing one.\n"
 "URL may include credentials (https://user:pass@host/...).\n"
 "License and attribution terms are set by the upstream URL - you are responsible."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2903
+#: src/muuli_wdr.cpp:2934
 msgid "Download the GeoIP database from the selected source."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2905
+#: src/muuli_wdr.cpp:2936
 #, fuzzy
 msgid "Auto-update on startup"
 msgstr "ربط تلقائي عند بدء التشغيل"
 
-#: src/muuli_wdr.cpp:2906
+#: src/muuli_wdr.cpp:2937
 msgid "Re-download the GeoIP database from the selected source every time aMule starts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2929
+#: src/muuli_wdr.cpp:2960
 msgid "Filter incoming messages (except current chat):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2931
+#: src/muuli_wdr.cpp:2962
 msgid "Filter all messages"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2933
+#: src/muuli_wdr.cpp:2964
 msgid "Filter messages from people not on your friend list"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2935
+#: src/muuli_wdr.cpp:2966
 msgid "Filter messages from unknown clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2937
+#: src/muuli_wdr.cpp:2968
 msgid "Filter messages containing (use ',' as separator):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2940 src/muuli_wdr.cpp:2951
+#: src/muuli_wdr.cpp:2971 src/muuli_wdr.cpp:2982
 msgid "add here the words amule should filter and block messages including it"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2942
+#: src/muuli_wdr.cpp:2973
 msgid "Show received messages in the log"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2945
+#: src/muuli_wdr.cpp:2976
 msgid "Comments"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2948
+#: src/muuli_wdr.cpp:2979
 msgid "Filter comments containing (use ',' as separator):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2973
+#: src/muuli_wdr.cpp:3004
 msgid "Enable Proxy"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2974
+#: src/muuli_wdr.cpp:3005
 msgid "Enable/disable proxy support"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2977
+#: src/muuli_wdr.cpp:3008
 msgid "Proxy type:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2988
+#: src/muuli_wdr.cpp:3019
 msgid "Proxy host:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2991
+#: src/muuli_wdr.cpp:3022
 msgid "The proxy host name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2993
+#: src/muuli_wdr.cpp:3024
 msgid "Proxy port:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2996
+#: src/muuli_wdr.cpp:3027
 msgid "The proxy port"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2998
+#: src/muuli_wdr.cpp:3029
 msgid "Enable authentication"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2999
+#: src/muuli_wdr.cpp:3030
 msgid "Enable/disable username/password authentication"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3002
+#: src/muuli_wdr.cpp:3033
 msgid "Username: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:3005
+#: src/muuli_wdr.cpp:3036
 msgid "The username to use to connect to the proxy"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3007
+#: src/muuli_wdr.cpp:3038
 msgid "Password:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3010
+#: src/muuli_wdr.cpp:3041
 msgid "The password to use to connect to the proxy"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3029
+#: src/muuli_wdr.cpp:3060
 msgid "Connect to:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3038
+#: src/muuli_wdr.cpp:3069
 msgid "Login to remote amule"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3043
+#: src/muuli_wdr.cpp:3074
 msgid "User name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3054
+#: src/muuli_wdr.cpp:3085
 msgid "Remember those settings"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3057
+#: src/muuli_wdr.cpp:3088
 #, fuzzy
 msgid "Force ZLIB compression"
 msgstr "أكتسب بواسطة الضغط :"
 
-#: src/muuli_wdr.cpp:3081
+#: src/muuli_wdr.cpp:3112
 msgid "Enable Verbose Debug-Logging."
 msgstr ""
 
-#: src/muuli_wdr.cpp:3083
+#: src/muuli_wdr.cpp:3114
 #, fuzzy
 msgid "Only to Logfile"
 msgstr "&فتح الملف"
 
-#: src/muuli_wdr.cpp:3085
+#: src/muuli_wdr.cpp:3116
 msgid "Message Categories:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3109 src/PartFileConvertDlg.cpp:160
+#: src/muuli_wdr.cpp:3140 src/PartFileConvertDlg.cpp:160
 msgid "Waiting..."
 msgstr "إنتظار..."
 
-#: src/muuli_wdr.cpp:3129
+#: src/muuli_wdr.cpp:3160
 msgid "Add imports"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3132
+#: src/muuli_wdr.cpp:3163
 msgid "Retry selected"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3134
+#: src/muuli_wdr.cpp:3165
 msgid "Remove selected"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3197
+#: src/muuli_wdr.cpp:3228
 msgid "Event Types"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3216
+#: src/muuli_wdr.cpp:3247
 msgid "Statistics and queued clients for selected file(s) : Session / All time"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3240
+#: src/muuli_wdr.cpp:3271
 #, fuzzy
 msgid "Active Uploads"
 msgstr "رفع نشط :"
 
-#: src/muuli_wdr.cpp:3254
+#: src/muuli_wdr.cpp:3285
 #, fuzzy
 msgid "Percent of total files"
 msgstr "مجموع الملفات"
 
-#: src/muuli_wdr.cpp:3306
+#: src/muuli_wdr.cpp:3337
 #, fuzzy
 msgid "Show Clients for"
 msgstr "منفذ العميل"
 
-#: src/muuli_wdr.cpp:3308
+#: src/muuli_wdr.cpp:3339
 #, fuzzy
 msgid "All files"
 msgstr "ملفات مشاركة"
 
-#: src/muuli_wdr.cpp:3311
+#: src/muuli_wdr.cpp:3342
 #, fuzzy
 msgid "Selected files"
 msgstr "إختر فلتر العرض"
 
-#: src/muuli_wdr.cpp:3314
+#: src/muuli_wdr.cpp:3345
 #, fuzzy
 msgid "Active uploads only"
 msgstr "رفع نشط"
 
-#: src/muuli_wdr.cpp:3321
+#: src/muuli_wdr.cpp:3352
 #, fuzzy
 msgid "Reload:"
 msgstr "اعد تحميل"
 
-#: src/muuli_wdr.cpp:3325
+#: src/muuli_wdr.cpp:3356
 msgid "Reload your shared files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3388
+#: src/muuli_wdr.cpp:3419
 msgid "Send"
 msgstr "ارسل"
 
-#: src/muuli_wdr.cpp:3389
+#: src/muuli_wdr.cpp:3420
 msgid "Sends the specified message."
 msgstr ""
 
-#: src/muuli_wdr.cpp:3393
+#: src/muuli_wdr.cpp:3424
 msgid "Close this chat-session."
 msgstr ""
 
-#: src/muuli_wdr.cpp:3416
+#: src/muuli_wdr.cpp:3447
 msgid "Connect to any server and/or Kad"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3422 src/SharedFilesCtrl.cpp:142 src/Statistics.cpp:941
+#: src/muuli_wdr.cpp:3453 src/SharedFilesCtrl.cpp:142 src/Statistics.cpp:941
 msgid "Shared Files"
 msgstr "ملفات مشاركة"
 
@@ -5391,267 +5416,267 @@ msgstr ""
 msgid "ERROR: Failed to open partfile '%s'"
 msgstr ""
 
-#: src/Preferences.cpp:674
+#: src/Preferences.cpp:701
 msgid "System default"
 msgstr "اﻹفتراضية بالنظام"
 
-#: src/Preferences.cpp:675
+#: src/Preferences.cpp:702
 msgid "Albanian"
 msgstr ""
 
-#: src/Preferences.cpp:676
+#: src/Preferences.cpp:703
 msgid "Arabic"
 msgstr "العربيه"
 
-#: src/Preferences.cpp:677
+#: src/Preferences.cpp:704
 #, fuzzy
 msgid "Asturian"
 msgstr "الأستونيه"
 
-#: src/Preferences.cpp:678
+#: src/Preferences.cpp:705
 msgid "Basque"
 msgstr ""
 
-#: src/Preferences.cpp:679
+#: src/Preferences.cpp:706
 msgid "Bulgarian"
 msgstr "البلغاريه"
 
-#: src/Preferences.cpp:680
+#: src/Preferences.cpp:707
 msgid "Catalan"
 msgstr ""
 
-#: src/Preferences.cpp:681
+#: src/Preferences.cpp:708
 msgid "Chinese (Simplified)"
 msgstr ""
 
-#: src/Preferences.cpp:682
+#: src/Preferences.cpp:709
 msgid "Chinese (Traditional)"
 msgstr ""
 
-#: src/Preferences.cpp:683
+#: src/Preferences.cpp:710
 msgid "Croatian"
 msgstr ""
 
-#: src/Preferences.cpp:684
+#: src/Preferences.cpp:711
 msgid "Czech"
 msgstr ""
 
-#: src/Preferences.cpp:685
+#: src/Preferences.cpp:712
 msgid "Danish"
 msgstr "الدانماركيه"
 
-#: src/Preferences.cpp:686
+#: src/Preferences.cpp:713
 msgid "Dutch"
 msgstr "الهولنديه"
 
-#: src/Preferences.cpp:687
+#: src/Preferences.cpp:714
 msgid "English (U.K.)"
 msgstr ""
 
-#: src/Preferences.cpp:688
+#: src/Preferences.cpp:715
 msgid "English (U.S.)"
 msgstr ""
 
-#: src/Preferences.cpp:689
+#: src/Preferences.cpp:716
 msgid "Estonian"
 msgstr "الأستونيه"
 
-#: src/Preferences.cpp:690
+#: src/Preferences.cpp:717
 msgid "Finnish"
 msgstr "الفلنديه"
 
-#: src/Preferences.cpp:691
+#: src/Preferences.cpp:718
 msgid "French"
 msgstr "الفرنسية"
 
-#: src/Preferences.cpp:692
+#: src/Preferences.cpp:719
 msgid "Galician"
 msgstr ""
 
-#: src/Preferences.cpp:693
+#: src/Preferences.cpp:720
 msgid "German"
 msgstr "الألمانيه"
 
-#: src/Preferences.cpp:694
+#: src/Preferences.cpp:721
 msgid "Greek"
 msgstr ""
 
-#: src/Preferences.cpp:695
+#: src/Preferences.cpp:722
 msgid "Hebrew"
 msgstr ""
 
-#: src/Preferences.cpp:696
+#: src/Preferences.cpp:723
 msgid "Hungarian"
 msgstr "الهنغاريه"
 
-#: src/Preferences.cpp:697
+#: src/Preferences.cpp:724
 msgid "Italian"
 msgstr "الايطاليه"
 
-#: src/Preferences.cpp:698
+#: src/Preferences.cpp:725
 msgid "Japanese"
 msgstr ""
 
-#: src/Preferences.cpp:699
+#: src/Preferences.cpp:726
 msgid "Korean"
 msgstr "الكوريه"
 
-#: src/Preferences.cpp:700
+#: src/Preferences.cpp:727
 msgid "Latvian"
 msgstr ""
 
-#: src/Preferences.cpp:701
+#: src/Preferences.cpp:728
 msgid "Lithuanian"
 msgstr "الليتوانيه"
 
-#: src/Preferences.cpp:702
+#: src/Preferences.cpp:729
 msgid "Norwegian (Nynorsk)"
 msgstr ""
 
-#: src/Preferences.cpp:703
+#: src/Preferences.cpp:730
 msgid "Polish"
 msgstr ""
 
-#: src/Preferences.cpp:704
+#: src/Preferences.cpp:731
 msgid "Portuguese"
 msgstr "البرتغاليه"
 
-#: src/Preferences.cpp:705
+#: src/Preferences.cpp:732
 msgid "Portuguese (Brazilian)"
 msgstr ""
 
-#: src/Preferences.cpp:706
+#: src/Preferences.cpp:733
 #, fuzzy
 msgid "Romanian"
 msgstr "الأستونيه"
 
-#: src/Preferences.cpp:707
+#: src/Preferences.cpp:734
 msgid "Russian"
 msgstr "الروسيه"
 
-#: src/Preferences.cpp:708
+#: src/Preferences.cpp:735
 msgid "Slovenian"
 msgstr ""
 
-#: src/Preferences.cpp:709
+#: src/Preferences.cpp:736
 msgid "Spanish"
 msgstr "الإسبانيه"
 
-#: src/Preferences.cpp:710
+#: src/Preferences.cpp:737
 msgid "Swedish"
 msgstr ""
 
-#: src/Preferences.cpp:711
+#: src/Preferences.cpp:738
 msgid "Turkish"
 msgstr ""
 
-#: src/Preferences.cpp:712
+#: src/Preferences.cpp:739
 msgid "Ukrainian"
 msgstr ""
 
-#: src/Preferences.cpp:815
+#: src/Preferences.cpp:842
 #, fuzzy
 msgid "Change Language"
 msgstr "الغة"
 
-#: src/Preferences.cpp:879
+#: src/Preferences.cpp:906
 msgid "There are no translations installed for aMule"
 msgstr ""
 
-#: src/Preferences.cpp:880
+#: src/Preferences.cpp:907
 #, fuzzy
 msgid "No languages available"
 msgstr "غير متوفر"
 
-#: src/Preferences.cpp:1011
+#: src/Preferences.cpp:1038
 msgid "no options available"
 msgstr ""
 
-#: src/Preferences.cpp:2182
+#: src/Preferences.cpp:2227
 msgid "Invalid category found, skipping"
 msgstr ""
 
-#: src/Preferences.cpp:2351
+#: src/Preferences.cpp:2396
 msgid "TCP port can't be higher than 65532 due to server UDP socket being TCP+3"
 msgstr ""
 
-#: src/Preferences.cpp:2352
+#: src/Preferences.cpp:2397
 #, c-format
 msgid "Default port will be used (%d)"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:298 src/Statistics.cpp:866
+#: src/PrefsUnifiedDlg.cpp:300 src/Statistics.cpp:866
 msgid "Connection"
 msgstr "اتصال"
 
-#: src/PrefsUnifiedDlg.cpp:299 src/SearchListCtrl.cpp:117
+#: src/PrefsUnifiedDlg.cpp:301 src/SearchListCtrl.cpp:117
 msgid "Directories"
 msgstr "مجلدات"
 
-#: src/PrefsUnifiedDlg.cpp:300 src/Statistics.cpp:917
+#: src/PrefsUnifiedDlg.cpp:302 src/Statistics.cpp:917
 msgid "Servers"
 msgstr "الخادمات"
 
-#: src/PrefsUnifiedDlg.cpp:301 src/ServerListCtrl.cpp:96
+#: src/PrefsUnifiedDlg.cpp:303 src/ServerListCtrl.cpp:96
 msgid "Files"
 msgstr "ملفات"
 
-#: src/PrefsUnifiedDlg.cpp:302
+#: src/PrefsUnifiedDlg.cpp:304
 msgid "Security"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:303
+#: src/PrefsUnifiedDlg.cpp:305
 msgid "Interface"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:310
+#: src/PrefsUnifiedDlg.cpp:312
 msgid "IP2Country"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:313
+#: src/PrefsUnifiedDlg.cpp:315
 msgid "Proxy"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:314
+#: src/PrefsUnifiedDlg.cpp:316
 msgid "Filters"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:315
+#: src/PrefsUnifiedDlg.cpp:317
 msgid "Remote Controls"
 msgstr "تحكم عن بعد"
 
-#: src/PrefsUnifiedDlg.cpp:316
+#: src/PrefsUnifiedDlg.cpp:318
 msgid "Online Signature"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:317
+#: src/PrefsUnifiedDlg.cpp:319
 msgid "Advanced"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:318
+#: src/PrefsUnifiedDlg.cpp:320
 msgid "Events"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:321
+#: src/PrefsUnifiedDlg.cpp:323
 msgid "Debugging"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:451
+#: src/PrefsUnifiedDlg.cpp:453
 msgid ""
 "The following variables will be substituted:\n"
 "    %PARTFILE - full path to the file\n"
 "    %PARTNAME - file name only"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:472
+#: src/PrefsUnifiedDlg.cpp:474
 msgid "Tray icon support requires libayatana-appindicator3 at compile time."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:488
+#: src/PrefsUnifiedDlg.cpp:490
 msgid "Not available on Wayland: the protocol does not report when a window is minimized, so this option cannot intercept the system minimize button. Workaround: launch aMule with `GDK_BACKEND=x11` to use XWayland instead."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:534
+#: src/PrefsUnifiedDlg.cpp:536
 msgid ""
 "Do not change these setting unless you know\n"
 "what you are doing, otherwise you can easily\n"
@@ -5661,247 +5686,260 @@ msgid ""
 "these settings."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:645
+#: src/PrefsUnifiedDlg.cpp:647
 #, c-format
 msgid "Failed to connect Cfg to widget with the ID %d and key %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:693
+#: src/PrefsUnifiedDlg.cpp:695
 #, c-format
 msgid "Failed to transfer data from Cfg to Widget with the ID %d and key %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:799
+#: src/PrefsUnifiedDlg.cpp:801
 msgid "The type of proxy you are connecting to"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1003
+#: src/PrefsUnifiedDlg.cpp:1020
 #, c-format
 msgid "Failed to transfer data from Widget to Cfg with the ID %d and key %s"
 msgstr ""
 
 #: src/PrefsUnifiedDlg.cpp:1103
+msgid "No password set."
+msgstr ""
+
+#: src/PrefsUnifiedDlg.cpp:1132
+msgid "Guest access needs a password. Type one in the guest password field, or untick Enable guest access."
+msgstr ""
+
+#: src/PrefsUnifiedDlg.cpp:1144
 msgid ""
 "aMule must be restarted to enable these changes:\n"
 "\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1110
+#: src/PrefsUnifiedDlg.cpp:1151
 msgid "- TCP port changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1115
+#: src/PrefsUnifiedDlg.cpp:1156
 msgid "- UDP port changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1120
+#: src/PrefsUnifiedDlg.cpp:1161
 #, fuzzy
 msgid "- Network interface binding changed.\n"
 msgstr "عوامل اﻻتصال الخارجي"
 
-#: src/PrefsUnifiedDlg.cpp:1125
+#: src/PrefsUnifiedDlg.cpp:1166
 #, fuzzy
 msgid "- External connect port changed.\n"
 msgstr "عوامل اﻻتصال الخارجي"
 
-#: src/PrefsUnifiedDlg.cpp:1129
+#: src/PrefsUnifiedDlg.cpp:1170
 #, fuzzy
 msgid "- External connect acceptance changed.\n"
 msgstr "عوامل اﻻتصال الخارجي"
 
-#: src/PrefsUnifiedDlg.cpp:1133
+#: src/PrefsUnifiedDlg.cpp:1174
 #, fuzzy
 msgid "- External connect interface changed.\n"
 msgstr "عوامل اﻻتصال الخارجي"
 
-#: src/PrefsUnifiedDlg.cpp:1137
+#: src/PrefsUnifiedDlg.cpp:1178
 #, fuzzy
 msgid "- Protocol obfuscation support changed.\n"
 msgstr "عوامل اﻻتصال الخارجي"
 
-#: src/PrefsUnifiedDlg.cpp:1151
+#: src/PrefsUnifiedDlg.cpp:1193
 msgid "- amuleapi settings changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1160
+#: src/PrefsUnifiedDlg.cpp:1202
 msgid ""
 "Your Auto-update server list is empty.\n"
 "'Auto-update server list at startup' will be disabled."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1171
+#: src/PrefsUnifiedDlg.cpp:1213
 msgid ""
 "You have enabled external connections but have not specified a password.\n"
 "External connections cannot be enabled unless a valid password is specified."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1202
+#: src/PrefsUnifiedDlg.cpp:1246
+#, c-format
+msgid "The amuleapi password could not be saved: %s"
+msgstr ""
+
+#: src/PrefsUnifiedDlg.cpp:1276
 msgid "- Language changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1207
+#: src/PrefsUnifiedDlg.cpp:1281
 msgid "- Temp folder changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1212
+#: src/PrefsUnifiedDlg.cpp:1286
 msgid "- ED2K network enabled.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1245
+#: src/PrefsUnifiedDlg.cpp:1319
 msgid "The shared-file exclusion pattern is not a valid regular expression. The filter has been left disabled."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1247 src/PrefsUnifiedDlg.cpp:1841
+#: src/PrefsUnifiedDlg.cpp:1321 src/PrefsUnifiedDlg.cpp:1921
 msgid "Invalid regular expression"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1324
+#: src/PrefsUnifiedDlg.cpp:1398
 msgid ""
 "Both eD2k and Kad network are disabled.\n"
 "You won't be able to connect until you enable at least one of them."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1329
+#: src/PrefsUnifiedDlg.cpp:1403
 msgid ""
 "Kad will not start if your UDP port is disabled.\n"
 "Enable UDP port or disable Kad."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1385
+#: src/PrefsUnifiedDlg.cpp:1459
 msgid ""
 "\n"
 "You MUST restart aMule now.\n"
 "If you do not restart now, don't complain if anything bad happens.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1450
+#: src/PrefsUnifiedDlg.cpp:1524
 msgid "Could not register aMule for autostart at login. The autostart store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1452
+#: src/PrefsUnifiedDlg.cpp:1526
 msgid "Could not remove the autostart-at-login entry."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1453
+#: src/PrefsUnifiedDlg.cpp:1527
 #, fuzzy
 msgid "Autostart"
 msgstr "ذاتي"
 
-#: src/PrefsUnifiedDlg.cpp:1468
+#: src/PrefsUnifiedDlg.cpp:1542
 msgid "Register file type"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1468
+#: src/PrefsUnifiedDlg.cpp:1542
 msgid "Register URL handler"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1476
+#: src/PrefsUnifiedDlg.cpp:1550
 #, c-format
 msgid "aMule only handles eD2k-compatible magnets. If you replace the current magnet handler (%s), BitTorrent magnet links will stop working - aMule cannot download BitTorrent content. Continue?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1481
+#: src/PrefsUnifiedDlg.cpp:1555
 #, c-format
 msgid "Another application currently opens .emulecollection files (%s). Replace it with aMule?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1486
+#: src/PrefsUnifiedDlg.cpp:1560
 #, c-format
 msgid "Another application is currently the default handler for these links (%s). Replace it with aMule?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1511
+#: src/PrefsUnifiedDlg.cpp:1585
 msgid "Could not register aMule for .emulecollection files. The registration store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1513
+#: src/PrefsUnifiedDlg.cpp:1587
 #, fuzzy
 msgid "Could not remove the file type registration."
 msgstr "قمت بمحاولت تحميل الملف مسبقا %s"
 
-#: src/PrefsUnifiedDlg.cpp:1515
+#: src/PrefsUnifiedDlg.cpp:1589
 msgid "Could not register aMule as the URL handler. The registration store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1517
+#: src/PrefsUnifiedDlg.cpp:1591
 msgid "Could not remove the URL handler registration."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1587 src/PrefsUnifiedDlg.cpp:1614
+#: src/PrefsUnifiedDlg.cpp:1661 src/PrefsUnifiedDlg.cpp:1688
 #, fuzzy
 msgid "The web server and aMule API require external connections to be enabled."
 msgstr "قبل إتصال خارجي جديد\n"
 
-#: src/PrefsUnifiedDlg.cpp:1597
+#: src/PrefsUnifiedDlg.cpp:1671
 msgid "The aMule web server is deprecated. Consider running the aMule API instead."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1655
+#: src/PrefsUnifiedDlg.cpp:1735
 msgid ""
 "Your Auto-update servers list is in blank.\n"
 "Please fill in at least one URL to point to a valid server.met file.\n"
 "Click on the button \"List\" by this checkbox to enter an URL."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1796
+#: src/PrefsUnifiedDlg.cpp:1876
 msgid "Temporary files"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1801
+#: src/PrefsUnifiedDlg.cpp:1881
 msgid "Incoming files"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1806
+#: src/PrefsUnifiedDlg.cpp:1886
 msgid "Online Signatures"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1819
+#: src/PrefsUnifiedDlg.cpp:1899
 #, c-format
 msgid "Choose a folder for %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1843
+#: src/PrefsUnifiedDlg.cpp:1923
 #, fuzzy, c-format
 msgid "Would exclude %u of %u shared file"
 msgid_plural "Would exclude %u of %u shared files"
 msgstr[0] "وجد %i ملف مشاركة معرف"
 msgstr[1] "وجد %i ملف مشاركة معرف"
 
-#: src/PrefsUnifiedDlg.cpp:1860
+#: src/PrefsUnifiedDlg.cpp:1940
 msgid "Browse for videoplayer"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1864
+#: src/PrefsUnifiedDlg.cpp:1944
 msgid "Select browser"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1868
+#: src/PrefsUnifiedDlg.cpp:1948
 msgid "Select ffprobe binary"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1874
+#: src/PrefsUnifiedDlg.cpp:1954
 #, c-format
 msgid "Executable%s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1908
+#: src/PrefsUnifiedDlg.cpp:1988
 msgid "ffprobe not found on PATH or in the standard install locations. Install ffmpeg (which ships ffprobe) or use Browse to pick a binary manually."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1920
+#: src/PrefsUnifiedDlg.cpp:2000
 msgid "Reset the settings on this page to their default values?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1921
+#: src/PrefsUnifiedDlg.cpp:2001
 #, fuzzy
 msgid "Reset to defaults"
 msgstr "اﻹفتراضية بالنظام"
 
-#: src/PrefsUnifiedDlg.cpp:1948
+#: src/PrefsUnifiedDlg.cpp:2028
 msgid "Edit server list"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1949
+#: src/PrefsUnifiedDlg.cpp:2029
 msgid ""
 "Add here URL's to download server.met files.\n"
 "Only one url on each line."
@@ -5909,152 +5947,152 @@ msgstr ""
 "أضف هنا عنوان لتحميل ملفات server.met \n"
 "عنوان واحد فقط لكل سطر"
 
-#: src/PrefsUnifiedDlg.cpp:2004
+#: src/PrefsUnifiedDlg.cpp:2084
 msgid "IP2Country update failed"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2149 src/PrefsUnifiedDlg.cpp:2180
+#: src/PrefsUnifiedDlg.cpp:2229 src/PrefsUnifiedDlg.cpp:2260
 msgid "Data by MaxMind GeoLite2"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2151 src/PrefsUnifiedDlg.cpp:2182
+#: src/PrefsUnifiedDlg.cpp:2231 src/PrefsUnifiedDlg.cpp:2262
 msgid "Custom source"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2153 src/PrefsUnifiedDlg.cpp:2184
+#: src/PrefsUnifiedDlg.cpp:2233 src/PrefsUnifiedDlg.cpp:2264
 msgid "Data by DB-IP.com"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2204
+#: src/PrefsUnifiedDlg.cpp:2284
 #, c-format
 msgid "Status: Loaded%s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2206
+#: src/PrefsUnifiedDlg.cpp:2286
 #, c-format
 msgid "Status: Loaded%s - %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2210
+#: src/PrefsUnifiedDlg.cpp:2290
 msgid "Status: Failed to load - click 'Update now' to refresh."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2212
+#: src/PrefsUnifiedDlg.cpp:2292
 msgid "Status: Not found - click 'Update now' to download."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2270 src/PrefsUnifiedDlg.cpp:2294
+#: src/PrefsUnifiedDlg.cpp:2350 src/PrefsUnifiedDlg.cpp:2374
 #, fuzzy, c-format
 msgid "Update delay: %d second"
 msgid_plural "Update delay: %d seconds"
 msgstr[0] "تحيدث كل:5 ثواني"
 msgstr[1] "تحيدث كل:5 ثواني"
 
-#: src/PrefsUnifiedDlg.cpp:2278
+#: src/PrefsUnifiedDlg.cpp:2358
 #, c-format
 msgid "Time for average graph: %d minute"
 msgid_plural "Time for average graph: %d minutes"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/PrefsUnifiedDlg.cpp:2287
+#: src/PrefsUnifiedDlg.cpp:2367
 #, c-format
 msgid "Connections Graph Scale: %d"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2302
+#: src/PrefsUnifiedDlg.cpp:2382
 #, c-format
 msgid "File Buffer Size: %d byte"
 msgid_plural "File Buffer Size: %d bytes"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/PrefsUnifiedDlg.cpp:2312
+#: src/PrefsUnifiedDlg.cpp:2392
 #, c-format
 msgid "Upload Queue Size: %d client"
 msgid_plural "Upload Queue Size: %d clients"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/PrefsUnifiedDlg.cpp:2322
+#: src/PrefsUnifiedDlg.cpp:2402
 #, fuzzy, c-format
 msgid "Server connection refresh interval: %d minute"
 msgid_plural "Server connection refresh interval: %d minutes"
 msgstr[0] "فترة تحديث الإتصال بالخادم %i دقيقة"
 msgstr[1] "فترة تحديث الإتصال بالخادم %i دقيقة"
 
-#: src/PrefsUnifiedDlg.cpp:2327
+#: src/PrefsUnifiedDlg.cpp:2407
 msgid "Server connection refresh interval: Disabled"
 msgstr "فترة تحديث الإتصال بالخادم :معطل"
 
-#: src/PrefsUnifiedDlg.cpp:2371
+#: src/PrefsUnifiedDlg.cpp:2451
 #, fuzzy
 msgid "disabled"
 msgstr "تعطيل"
 
-#: src/PrefsUnifiedDlg.cpp:2397
+#: src/PrefsUnifiedDlg.cpp:2477
 #, c-format
 msgid "Execute command on '%s' event"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2404
+#: src/PrefsUnifiedDlg.cpp:2484
 msgid "Enable command execution on core"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2416
+#: src/PrefsUnifiedDlg.cpp:2496
 msgid "Core command:"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2432
+#: src/PrefsUnifiedDlg.cpp:2512
 msgid "Enable command execution on GUI"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2444
+#: src/PrefsUnifiedDlg.cpp:2524
 msgid "GUI command:"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2460
+#: src/PrefsUnifiedDlg.cpp:2540
 msgid "The following variables will be replaced:"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2628
+#: src/PrefsUnifiedDlg.cpp:2708
 msgid ""
 "The following folders look like system or sensitive locations:\n"
 "\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2633
+#: src/PrefsUnifiedDlg.cpp:2713
 msgid "Sharing them recursively will publish every file underneath on the eD2k/Kad networks. Do you really want to do this?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2636
+#: src/PrefsUnifiedDlg.cpp:2716
 msgid "Confirm shared folders"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2664
+#: src/PrefsUnifiedDlg.cpp:2744
 #, fuzzy
 msgid "Reloading shared files..."
 msgstr "وجد %i ملف مشاركة معرف"
 
-#: src/PrefsUnifiedDlg.cpp:2665
+#: src/PrefsUnifiedDlg.cpp:2745
 msgid "Scanning for subdirectories..."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2666
+#: src/PrefsUnifiedDlg.cpp:2746
 msgid "Updating shared folders"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2693
+#: src/PrefsUnifiedDlg.cpp:2773
 #, c-format
 msgid "Scanned %u directories..."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2743
+#: src/PrefsUnifiedDlg.cpp:2823
 #, c-format
 msgid "Reloading shared files: %u files scanned"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2793
+#: src/PrefsUnifiedDlg.cpp:2873
 #, fuzzy
 msgid "Shared folder"
 msgstr "ملفات مشاركة"

--- a/po/ar.po
+++ b/po/ar.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-28 12:17+0200\n"
+"POT-Creation-Date: 2026-07-28 13:09+0200\n"
 "PO-Revision-Date: 2026-07-27 11:31+0000\n"
 "Last-Translator: saleh alhathal <hathalsal@hotmail.com>\n"
 "Language-Team: \n"
@@ -282,7 +282,7 @@ msgid "Password set and external connections enabled."
 msgstr "قبل إتصال خارجي جديد\n"
 
 #: src/amule.cpp:755 src/KadDlg.cpp:176 src/KadDlg.cpp:185
-#: src/PrefsUnifiedDlg.cpp:1461 src/SharedFilesCtrl.cpp:476
+#: src/PrefsUnifiedDlg.cpp:1470 src/SharedFilesCtrl.cpp:476
 msgid "WARNING"
 msgstr ""
 
@@ -318,7 +318,7 @@ msgstr ""
 #: src/amule-remote-gui.cpp:603 src/amule-remote-gui.cpp:671
 #: src/amule-remote-gui.cpp:709 src/amule-remote-gui.cpp:1282
 #: src/amule-remote-gui.cpp:1345 src/amule-remote-gui.cpp:1372
-#: src/DownloadQueue.cpp:1481 src/PrefsUnifiedDlg.cpp:1247
+#: src/DownloadQueue.cpp:1481 src/PrefsUnifiedDlg.cpp:1256
 msgid "ERROR"
 msgstr ""
 
@@ -572,36 +572,36 @@ msgstr ""
 msgid "FATAL ERROR: Failed to create Timer"
 msgstr ""
 
-#: src/amuleDlg.cpp:361 src/amuleDlg.cpp:1787 src/amuleDlg.cpp:2033
-#: src/muuli_wdr.cpp:1492 src/muuli_wdr.cpp:3449
+#: src/amuleDlg.cpp:361 src/amuleDlg.cpp:1810 src/amuleDlg.cpp:2056
+#: src/muuli_wdr.cpp:1492 src/muuli_wdr.cpp:3453
 msgid "Networks"
 msgstr ""
 
-#: src/amuleDlg.cpp:362 src/amuleDlg.cpp:1793 src/muuli_wdr.cpp:3450
+#: src/amuleDlg.cpp:362 src/amuleDlg.cpp:1816 src/muuli_wdr.cpp:3454
 msgid "Searches"
 msgstr "بحث"
 
-#: src/amuleDlg.cpp:363 src/amuleDlg.cpp:1799 src/DownloadListCtrl.cpp:740
-#: src/muuli_wdr.cpp:392 src/muuli_wdr.cpp:1585 src/muuli_wdr.cpp:3451
+#: src/amuleDlg.cpp:363 src/amuleDlg.cpp:1822 src/DownloadListCtrl.cpp:740
+#: src/muuli_wdr.cpp:392 src/muuli_wdr.cpp:1585 src/muuli_wdr.cpp:3455
 #: src/Statistics.cpp:829
 msgid "Downloads"
 msgstr "تحميل"
 
-#: src/amuleDlg.cpp:364 src/amuleDlg.cpp:1805 src/muuli_wdr.cpp:3325
+#: src/amuleDlg.cpp:364 src/amuleDlg.cpp:1828 src/muuli_wdr.cpp:3329
 msgid "Shared files"
 msgstr ""
 
-#: src/amuleDlg.cpp:365 src/amuleDlg.cpp:1811 src/muuli_wdr.cpp:2957
-#: src/muuli_wdr.cpp:3407 src/muuli_wdr.cpp:3454
+#: src/amuleDlg.cpp:365 src/amuleDlg.cpp:1834 src/muuli_wdr.cpp:2961
+#: src/muuli_wdr.cpp:3411 src/muuli_wdr.cpp:3458
 msgid "Messages"
 msgstr "رسائل"
 
-#: src/amuleDlg.cpp:366 src/amuleDlg.cpp:1817 src/muuli_wdr.cpp:3455
+#: src/amuleDlg.cpp:366 src/amuleDlg.cpp:1840 src/muuli_wdr.cpp:3459
 #: src/PrefsUnifiedDlg.cpp:314 src/Statistics.cpp:779 src/Statistics.cpp:1235
 msgid "Statistics"
 msgstr "احصائات"
 
-#: src/amuleDlg.cpp:368 src/amuleDlg.cpp:1824 src/muuli_wdr.cpp:3457
+#: src/amuleDlg.cpp:368 src/amuleDlg.cpp:1847 src/muuli_wdr.cpp:3461
 #: src/PrefsUnifiedDlg.cpp:330 src/utils/wxCas/src/wxcasprefs.cpp:39
 msgid "Preferences"
 msgstr "اعدادت"
@@ -662,8 +662,8 @@ msgstr ""
 #: src/amuleDlg.cpp:1029 src/DownloadListCtrl.cpp:505
 #: src/DownloadListCtrl.cpp:749 src/FriendListCtrl.cpp:180
 #: src/muuli_wdr.cpp:731 src/muuli_wdr.cpp:782 src/muuli_wdr.cpp:846
-#: src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2262 src/muuli_wdr.cpp:2347
-#: src/muuli_wdr.cpp:3095 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
+#: src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2266 src/muuli_wdr.cpp:2351
+#: src/muuli_wdr.cpp:3099 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
 #: src/ServerListCtrl.cpp:606 src/TransferWnd.cpp:378
 #: src/utils/wxCas/src/wxcasprefs.cpp:235
 msgid "Cancel"
@@ -675,7 +675,7 @@ msgid "Stop the current connection attempts"
 msgstr "إيقاف محاولة اﻹتصال الحاليه"
 
 #: src/amuleDlg.cpp:1035 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976
-#: src/muuli_wdr.cpp:2485
+#: src/muuli_wdr.cpp:2489
 msgid "Disconnect"
 msgstr "فصل"
 
@@ -685,7 +685,7 @@ msgid "Disconnect from the currently connected networks"
 msgstr "فصل من المستضيف الحالي"
 
 #: src/amuleDlg.cpp:1041 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979
-#: src/muuli_wdr.cpp:2640 src/muuli_wdr.cpp:3092 src/muuli_wdr.cpp:3447
+#: src/muuli_wdr.cpp:2644 src/muuli_wdr.cpp:3096 src/muuli_wdr.cpp:3451
 msgid "Connect"
 msgstr "إتصال"
 
@@ -739,7 +739,7 @@ msgstr "تاكيد الخروج"
 msgid "Launch Command: "
 msgstr ""
 
-#: src/amuleDlg.cpp:1632 src/muuli_wdr.cpp:1982 src/Preferences.cpp:979
+#: src/amuleDlg.cpp:1632 src/muuli_wdr.cpp:1986 src/Preferences.cpp:979
 msgid "- default -"
 msgstr ""
 
@@ -753,61 +753,61 @@ msgstr ""
 msgid "WARNING: Unable to open skin file '%s' for read"
 msgstr ""
 
-#: src/amuleDlg.cpp:1791 src/muuli_wdr.cpp:3449
+#: src/amuleDlg.cpp:1814 src/muuli_wdr.cpp:3453
 msgid "Networks Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1797 src/muuli_wdr.cpp:3450
+#: src/amuleDlg.cpp:1820 src/muuli_wdr.cpp:3454
 msgid "Searches Window"
 msgstr "نافذة البحث"
 
-#: src/amuleDlg.cpp:1803 src/muuli_wdr.cpp:3451
+#: src/amuleDlg.cpp:1826 src/muuli_wdr.cpp:3455
 #, fuzzy
 msgid "Downloads Window"
 msgstr "تحميل"
 
-#: src/amuleDlg.cpp:1809 src/muuli_wdr.cpp:3453
+#: src/amuleDlg.cpp:1832 src/muuli_wdr.cpp:3457
 msgid "Shared Files Window"
 msgstr "نافذة ملفات المشاركة"
 
-#: src/amuleDlg.cpp:1815 src/muuli_wdr.cpp:3454
+#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3458
 msgid "Messages Window"
 msgstr "نافذة الرسائل"
 
-#: src/amuleDlg.cpp:1821 src/muuli_wdr.cpp:3455
+#: src/amuleDlg.cpp:1844 src/muuli_wdr.cpp:3459
 msgid "Statistics Graph Window"
 msgstr "نافذة اﻻحصائيات"
 
-#: src/amuleDlg.cpp:1828 src/muuli_wdr.cpp:3457
+#: src/amuleDlg.cpp:1851 src/muuli_wdr.cpp:3461
 msgid "Preferences Settings Window"
 msgstr "نافذة اﻹعدادات"
 
-#: src/amuleDlg.cpp:1831 src/muuli_wdr.cpp:3458
+#: src/amuleDlg.cpp:1854 src/muuli_wdr.cpp:3462
 msgid "Import"
 msgstr ""
 
-#: src/amuleDlg.cpp:1835 src/muuli_wdr.cpp:3458
+#: src/amuleDlg.cpp:1858 src/muuli_wdr.cpp:3462
 msgid "The partfile importer tool"
 msgstr ""
 
-#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3459
+#: src/amuleDlg.cpp:1861 src/muuli_wdr.cpp:3463
 #: src/utils/aLinkCreator/src/alcframe.cpp:262
 msgid "About"
 msgstr ""
 
-#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3459
+#: src/amuleDlg.cpp:1861 src/muuli_wdr.cpp:3463
 msgid "About/Help"
 msgstr ""
 
-#: src/amuleDlg.cpp:2036
+#: src/amuleDlg.cpp:2059
 msgid "eD2k network"
 msgstr ""
 
-#: src/amuleDlg.cpp:2039
+#: src/amuleDlg.cpp:2062
 msgid "Kad network"
 msgstr ""
 
-#: src/amuleDlg.cpp:2039
+#: src/amuleDlg.cpp:2062
 msgid "No network"
 msgstr ""
 
@@ -1343,19 +1343,19 @@ msgstr "ذاتي عالي"
 msgid "Very low"
 msgstr "متدني جدا"
 
-#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:743 src/muuli_wdr.cpp:2313
+#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:743 src/muuli_wdr.cpp:2317
 #: src/ServerListCtrl.cpp:263 src/ServerListCtrl.cpp:456
 #: src/SharedFilesCtrl.cpp:145
 msgid "Low"
 msgstr "متدني"
 
-#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:744 src/muuli_wdr.cpp:2314
+#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:744 src/muuli_wdr.cpp:2318
 #: src/ServerListCtrl.cpp:266 src/ServerListCtrl.cpp:457
 #: src/SharedFilesCtrl.cpp:146
 msgid "Normal"
 msgstr "عادي"
 
-#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:745 src/muuli_wdr.cpp:2315
+#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:745 src/muuli_wdr.cpp:2319
 #: src/ServerListCtrl.cpp:269 src/ServerListCtrl.cpp:458
 #: src/SharedFilesCtrl.cpp:147
 msgid "High"
@@ -1447,7 +1447,7 @@ msgstr ""
 msgid "Remote Server"
 msgstr ""
 
-#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3212
+#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3216
 #: src/SearchDlg.cpp:119 src/TextClient.cpp:911
 msgid "Kad"
 msgstr ""
@@ -1518,7 +1518,7 @@ msgstr ""
 msgid "Size"
 msgstr "حجم"
 
-#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3279
+#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3283
 msgid "Transferred"
 msgstr "نقل"
 
@@ -1576,7 +1576,7 @@ msgid ""
 "\n"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:746 src/muuli_wdr.cpp:2316
+#: src/DownloadListCtrl.cpp:746 src/muuli_wdr.cpp:2320
 #: src/SharedFilesCtrl.cpp:150
 msgid "Auto"
 msgstr "ذاتي"
@@ -1614,7 +1614,7 @@ msgid "Extended Options"
 msgstr "خيرات اضافية"
 
 #: src/DownloadListCtrl.cpp:770 src/DownloadListCtrl.cpp:822
-#: src/muuli_wdr.cpp:1800
+#: src/muuli_wdr.cpp:1804
 msgid "Preview"
 msgstr "مشاهدة"
 
@@ -2383,23 +2383,23 @@ msgid ""
 "want downloads on a different (e.g. larger) disk."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:549 src/FirstRunWizard.cpp:611 src/muuli_wdr.cpp:1712
+#: src/FirstRunWizard.cpp:549 src/FirstRunWizard.cpp:611 src/muuli_wdr.cpp:1716
 msgid "Destination folder for downloads"
 msgstr ""
 
 #: src/FirstRunWizard.cpp:553 src/FirstRunWizard.cpp:569 src/muuli_wdr.cpp:1349
-#: src/muuli_wdr.cpp:1366 src/muuli_wdr.cpp:1687 src/muuli_wdr.cpp:1718
-#: src/muuli_wdr.cpp:1730 src/muuli_wdr.cpp:2800
+#: src/muuli_wdr.cpp:1366 src/muuli_wdr.cpp:1691 src/muuli_wdr.cpp:1722
+#: src/muuli_wdr.cpp:1734 src/muuli_wdr.cpp:2804
 #: src/utils/aLinkCreator/src/alcframe.cpp:135
 #: src/utils/wxCas/src/wxcasprefs.cpp:52 src/utils/wxCas/src/wxcasprefs.cpp:118
 msgid "Browse"
 msgstr "تصفح"
 
-#: src/FirstRunWizard.cpp:559 src/muuli_wdr.cpp:1723
+#: src/FirstRunWizard.cpp:559 src/muuli_wdr.cpp:1727
 msgid "(All files in this folder are shared with other peers)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:565 src/FirstRunWizard.cpp:624 src/muuli_wdr.cpp:1725
+#: src/FirstRunWizard.cpp:565 src/FirstRunWizard.cpp:624 src/muuli_wdr.cpp:1729
 msgid "Folder for temporary download files"
 msgstr ""
 
@@ -2430,7 +2430,7 @@ msgstr ""
 msgid "CRITICAL - no client on StartChatSession"
 msgstr ""
 
-#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2706 src/muuli_wdr.cpp:3383
+#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2710 src/muuli_wdr.cpp:3387
 msgid "Friends"
 msgstr "اصدقاء"
 
@@ -2541,8 +2541,8 @@ msgstr "ﻻ احد"
 msgid "No"
 msgstr "ﻻ"
 
-#: src/GenericClientListCtrl.cpp:1216 src/PrefsUnifiedDlg.cpp:2898
-#: src/PrefsUnifiedDlg.cpp:2948 src/ServerListCtrl.cpp:276
+#: src/GenericClientListCtrl.cpp:1216 src/PrefsUnifiedDlg.cpp:2907
+#: src/PrefsUnifiedDlg.cpp:2957 src/ServerListCtrl.cpp:276
 msgid "Yes"
 msgstr "نعم"
 
@@ -2710,10 +2710,10 @@ msgstr ""
 msgid "Please fill all fields required"
 msgstr ""
 
-#: src/KadDlg.cpp:192 src/PartFile.cpp:1031 src/PrefsUnifiedDlg.cpp:1134
-#: src/PrefsUnifiedDlg.cpp:1204 src/PrefsUnifiedDlg.cpp:1405
-#: src/PrefsUnifiedDlg.cpp:1663 src/PrefsUnifiedDlg.cpp:1673
-#: src/PrefsUnifiedDlg.cpp:1690 src/PrefsUnifiedDlg.cpp:1738
+#: src/KadDlg.cpp:192 src/PartFile.cpp:1031 src/PrefsUnifiedDlg.cpp:1143
+#: src/PrefsUnifiedDlg.cpp:1213 src/PrefsUnifiedDlg.cpp:1414
+#: src/PrefsUnifiedDlg.cpp:1672 src/PrefsUnifiedDlg.cpp:1682
+#: src/PrefsUnifiedDlg.cpp:1699 src/PrefsUnifiedDlg.cpp:1747
 msgid "Message"
 msgstr ""
 
@@ -2814,7 +2814,7 @@ msgstr ""
 msgid "Uploaded"
 msgstr ""
 
-#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3263
+#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3267
 msgid "Requested"
 msgstr ""
 
@@ -2939,7 +2939,7 @@ msgid "WARNING: "
 msgstr ""
 
 #: src/MuleNotebook.cpp:179 src/muuli_wdr.cpp:817 src/muuli_wdr.cpp:1229
-#: src/muuli_wdr.cpp:3167 src/muuli_wdr.cpp:3423
+#: src/muuli_wdr.cpp:3171 src/muuli_wdr.cpp:3427
 msgid "Close"
 msgstr "اغلق"
 
@@ -2957,7 +2957,7 @@ msgid "Paste"
 msgstr ""
 
 #: src/MuleTextCtrl.cpp:89 src/muuli_wdr.cpp:358 src/muuli_wdr.cpp:757
-#: src/muuli_wdr.cpp:2390 src/muuli_wdr.cpp:2409 src/muuli_wdr.cpp:2431
+#: src/muuli_wdr.cpp:2394 src/muuli_wdr.cpp:2413 src/muuli_wdr.cpp:2435
 #: src/utils/aLinkCreator/src/alcframe.cpp:142
 msgid "Clear"
 msgstr "واضح"
@@ -3053,7 +3053,7 @@ msgstr "خروج"
 
 #: src/MuleTrayIcon.cpp:579 src/MuleTrayIcon.cpp:945 src/MuleTrayIcon.cpp:965
 #: src/muuli_wdr.cpp:1398 src/muuli_wdr.cpp:1406 src/muuli_wdr.cpp:1413
-#: src/muuli_wdr.cpp:1846 src/muuli_wdr.cpp:1852 src/OtherFunctions.cpp:91
+#: src/muuli_wdr.cpp:1850 src/muuli_wdr.cpp:1856 src/OtherFunctions.cpp:91
 #: src/StatisticsDlg.cpp:93 src/StatisticsDlg.cpp:95
 msgid "kB/s"
 msgstr ""
@@ -3294,7 +3294,7 @@ msgstr "بايت"
 msgid "KB"
 msgstr ""
 
-#: src/muuli_wdr.cpp:274 src/muuli_wdr.cpp:293 src/muuli_wdr.cpp:1631
+#: src/muuli_wdr.cpp:274 src/muuli_wdr.cpp:293 src/muuli_wdr.cpp:1635
 #: src/OtherFunctions.cpp:64
 msgid "MB"
 msgstr ""
@@ -3311,7 +3311,7 @@ msgstr "اكبر حجم"
 msgid "Availability"
 msgstr ""
 
-#: src/muuli_wdr.cpp:312 src/muuli_wdr.cpp:398 src/muuli_wdr.cpp:3328
+#: src/muuli_wdr.cpp:312 src/muuli_wdr.cpp:398 src/muuli_wdr.cpp:3332
 msgid "Filter:"
 msgstr ""
 
@@ -3375,8 +3375,8 @@ msgstr "ايجاد المصدر :"
 #: src/muuli_wdr.cpp:1160 src/muuli_wdr.cpp:1167 src/muuli_wdr.cpp:1172
 #: src/muuli_wdr.cpp:1179 src/muuli_wdr.cpp:1184 src/muuli_wdr.cpp:1191
 #: src/muuli_wdr.cpp:1205 src/muuli_wdr.cpp:1212 src/muuli_wdr.cpp:1217
-#: src/muuli_wdr.cpp:1224 src/muuli_wdr.cpp:3265 src/muuli_wdr.cpp:3273
-#: src/muuli_wdr.cpp:3281
+#: src/muuli_wdr.cpp:1224 src/muuli_wdr.cpp:3269 src/muuli_wdr.cpp:3277
+#: src/muuli_wdr.cpp:3285
 msgid "N/A"
 msgstr "غير متوفر"
 
@@ -3519,7 +3519,7 @@ msgstr ""
 msgid "Album :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:685 src/muuli_wdr.cpp:2285
+#: src/muuli_wdr.cpp:685 src/muuli_wdr.cpp:2289
 msgid "Title :"
 msgstr "عنوان :"
 
@@ -3625,7 +3625,7 @@ msgstr "اسم المستخدم :"
 msgid "Userhash :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:895 src/muuli_wdr.cpp:1752 src/muuli_wdr.cpp:2480
+#: src/muuli_wdr.cpp:895 src/muuli_wdr.cpp:1756 src/muuli_wdr.cpp:2484
 #: src/utils/aLinkCreator/src/alcframe.cpp:137
 msgid "Add"
 msgstr "اضف"
@@ -3634,15 +3634,15 @@ msgstr "اضف"
 msgid "Download-Speed"
 msgstr "سرعة-التحميل"
 
-#: src/muuli_wdr.cpp:954 src/muuli_wdr.cpp:989 src/muuli_wdr.cpp:2584
+#: src/muuli_wdr.cpp:954 src/muuli_wdr.cpp:989 src/muuli_wdr.cpp:2588
 msgid "Current"
 msgstr "الحالي"
 
-#: src/muuli_wdr.cpp:962 src/muuli_wdr.cpp:997 src/muuli_wdr.cpp:2592
+#: src/muuli_wdr.cpp:962 src/muuli_wdr.cpp:997 src/muuli_wdr.cpp:2596
 msgid "Running average"
 msgstr "معدل العمل"
 
-#: src/muuli_wdr.cpp:970 src/muuli_wdr.cpp:1005 src/muuli_wdr.cpp:2600
+#: src/muuli_wdr.cpp:970 src/muuli_wdr.cpp:1005 src/muuli_wdr.cpp:2604
 msgid "Session average"
 msgstr "معدل الجلسة"
 
@@ -3654,7 +3654,7 @@ msgstr "سرعة-الرفع"
 msgid "Connections"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1024 src/muuli_wdr.cpp:1871
+#: src/muuli_wdr.cpp:1024 src/muuli_wdr.cpp:1875
 msgid "Active downloads"
 msgstr "تحميل نشط"
 
@@ -3662,7 +3662,7 @@ msgstr "تحميل نشط"
 msgid "Active connections (1:1)"
 msgstr "إتصال نشط (1:1)"
 
-#: src/muuli_wdr.cpp:1040 src/muuli_wdr.cpp:1872
+#: src/muuli_wdr.cpp:1040 src/muuli_wdr.cpp:1876
 msgid "Active uploads"
 msgstr "رفع نشط"
 
@@ -3936,7 +3936,7 @@ msgstr ""
 msgid "Advanced users only: If you have multiple network interfaces, enter the address of the interface to which aMule should be bound."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1462 src/muuli_wdr.cpp:2065
+#: src/muuli_wdr.cpp:1462 src/muuli_wdr.cpp:2069
 msgid "Bind to network interface (empty for any):"
 msgstr ""
 
@@ -3952,7 +3952,7 @@ msgstr ""
 msgid "Max simultaneous connections:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1498 src/muuli_wdr.cpp:3207
+#: src/muuli_wdr.cpp:1498 src/muuli_wdr.cpp:3211
 msgid "ED2K"
 msgstr ""
 
@@ -4044,769 +4044,769 @@ msgstr ""
 msgid "For new files preallocates disk space for the whole file, thus reduces fragmentation"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1617
+#: src/muuli_wdr.cpp:1621
 msgid "Create new files as sparse files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1618
+#: src/muuli_wdr.cpp:1622
 msgid "Sparse part files only occupy disk space for the parts already downloaded, so free space is used up gradually as the file fills in. Turn this off to use an ordinary file instead - useful where sparse files are unsupported or slow, or where backup/de-duplication tools handle them badly. Applies only when the core runs on Windows; on Linux and macOS part files are sparse anyway and this setting has no effect."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1623
+#: src/muuli_wdr.cpp:1627
 msgid "Stop downloads when free disk space reaches "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1624
+#: src/muuli_wdr.cpp:1628
 msgid "Select this if you want aMule to check your disk space"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1628
+#: src/muuli_wdr.cpp:1632
 msgid "Enter here the min disk space desired."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1634
+#: src/muuli_wdr.cpp:1638
 msgid "Save 10 sources on rare files (< 20 sources)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1638 src/Statistics.cpp:790
+#: src/muuli_wdr.cpp:1642 src/Statistics.cpp:790
 msgid "Uploads"
 msgstr "ارفع"
 
-#: src/muuli_wdr.cpp:1641
+#: src/muuli_wdr.cpp:1645
 msgid "Add new shared files with auto priority"
 msgstr "أضف ملفات مشاركة جديدة بوضع ذاتي"
 
-#: src/muuli_wdr.cpp:1647
+#: src/muuli_wdr.cpp:1651
 msgid "Intelligent Corruption Handling (I.C.H.)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1650
+#: src/muuli_wdr.cpp:1654
 msgid "Enable"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1653
+#: src/muuli_wdr.cpp:1657
 msgid "Advanced I.C.H. trusts every hash (not recommended)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1665 src/PrefsUnifiedDlg.cpp:1990
+#: src/muuli_wdr.cpp:1669 src/PrefsUnifiedDlg.cpp:1999
 msgid "Media metadata extraction"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1669
+#: src/muuli_wdr.cpp:1673
 msgid "Extract length / bitrate / codec from shared audio and video files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1671
+#: src/muuli_wdr.cpp:1675
 msgid "When enabled, aMule runs ffprobe on each shared media file to fill in the Length / Bitrate / Codec columns other clients see when they find the file in a search. Requires ffmpeg (the ffprobe binary) to be installed."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1678
+#: src/muuli_wdr.cpp:1682
 msgid "Path to ffprobe:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1683
+#: src/muuli_wdr.cpp:1687
 msgid "Full path to the ffprobe binary. Leave empty to have aMule auto-detect it on startup."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1691
+#: src/muuli_wdr.cpp:1695
 msgid "Detect"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1692
+#: src/muuli_wdr.cpp:1696
 msgid "Search the standard install locations for an ffprobe binary and fill the path field."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1716
+#: src/muuli_wdr.cpp:1720
 msgid ""
 "Completed downloads are stored here. All files in this folder are automatically shared with other peers.\n"
 "If this folder also holds files you don't want to share, point it at an aMule-only sub-folder."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1719
+#: src/muuli_wdr.cpp:1723
 msgid "Pick the folder where completed downloads will be stored. All files in that folder will be shared with other peers."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1733
+#: src/muuli_wdr.cpp:1737
 msgid "Shared folders"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1739
+#: src/muuli_wdr.cpp:1743
 msgid "(Folders shared by the core. Enter a path to add one.)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1747
+#: src/muuli_wdr.cpp:1751
 msgid "Absolute path of a folder on the core's machine, e.g. /home/user/shared"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1749 src/PrefsUnifiedDlg.cpp:2874
+#: src/muuli_wdr.cpp:1753 src/PrefsUnifiedDlg.cpp:2883
 msgid "Recursive"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1750
+#: src/muuli_wdr.cpp:1754
 msgid "Share every sub-folder underneath this one, including ones created later."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1754 src/utils/aLinkCreator/src/alcframe.cpp:141
+#: src/muuli_wdr.cpp:1758 src/utils/aLinkCreator/src/alcframe.cpp:141
 msgid "Remove"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1758
+#: src/muuli_wdr.cpp:1762
 msgid "(Right click on folder icon for recursive share)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1765
+#: src/muuli_wdr.cpp:1769
 msgid "Share hidden files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1771
+#: src/muuli_wdr.cpp:1775
 msgid "Automatically rescan shared folders for changes"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1777
+#: src/muuli_wdr.cpp:1781
 msgid "Follow symbolic links in shared folders"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1783
+#: src/muuli_wdr.cpp:1787
 msgid "Exclude files matching:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1786
+#: src/muuli_wdr.cpp:1790
 msgid "Wildcard patterns separated by '|', e.g. .DS_Store|Thumbs.db|*.tmp. Files whose name matches are not shared. Matching is case-insensitive."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1790
+#: src/muuli_wdr.cpp:1794
 msgid "Patterns are regular expressions"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1791
+#: src/muuli_wdr.cpp:1795
 msgid "When set, the whole field is one regular expression ('|' is alternation). When unset, it is a list of '|'-separated wildcards."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1801
+#: src/muuli_wdr.cpp:1805
 msgid "Show how many shared files the current pattern would exclude."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1822
+#: src/muuli_wdr.cpp:1826
 msgid "Graphs"
 msgstr "رسم بياني"
 
-#: src/muuli_wdr.cpp:1825 src/muuli_wdr.cpp:1887
+#: src/muuli_wdr.cpp:1829 src/muuli_wdr.cpp:1891
 msgid "Update delay : 5 secs"
 msgstr "تحيدث كل:5 ثواني"
 
-#: src/muuli_wdr.cpp:1829
+#: src/muuli_wdr.cpp:1833
 msgid "Time for average graph: 100 mins"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1833
+#: src/muuli_wdr.cpp:1837
 msgid "Connections Graph Scale: 100 "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1840
+#: src/muuli_wdr.cpp:1844
 msgid "Download graph scale:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1848
+#: src/muuli_wdr.cpp:1852
 msgid "Upload graph scale:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1858
+#: src/muuli_wdr.cpp:1862
 msgid "Colors: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1862
+#: src/muuli_wdr.cpp:1866
 msgid "Background"
 msgstr "خلفية"
 
-#: src/muuli_wdr.cpp:1863
+#: src/muuli_wdr.cpp:1867
 msgid "Grid"
 msgstr "شبكة"
 
-#: src/muuli_wdr.cpp:1864
+#: src/muuli_wdr.cpp:1868
 msgid "Download current"
 msgstr "حمل الحالي"
 
-#: src/muuli_wdr.cpp:1865
+#: src/muuli_wdr.cpp:1869
 msgid "Download running average"
 msgstr "معدل تحميل الحالي"
 
-#: src/muuli_wdr.cpp:1866
+#: src/muuli_wdr.cpp:1870
 msgid "Download session average"
 msgstr "معدل تحميل الجلسة"
 
-#: src/muuli_wdr.cpp:1867
+#: src/muuli_wdr.cpp:1871
 msgid "Upload current"
 msgstr "ارفع الحالي"
 
-#: src/muuli_wdr.cpp:1868
+#: src/muuli_wdr.cpp:1872
 msgid "Upload running average"
 msgstr "معدل رفع الحالي"
 
-#: src/muuli_wdr.cpp:1869
+#: src/muuli_wdr.cpp:1873
 msgid "Upload session average"
 msgstr "معدل رفع الجلسة"
 
-#: src/muuli_wdr.cpp:1870
+#: src/muuli_wdr.cpp:1874
 msgid "Active connections"
 msgstr "اتصال نشط"
 
-#: src/muuli_wdr.cpp:1873
+#: src/muuli_wdr.cpp:1877
 msgid "Systray Icon Speed Bar"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1874
+#: src/muuli_wdr.cpp:1878
 msgid "Kad-nodes current"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1875
+#: src/muuli_wdr.cpp:1879
 msgid "Kad-nodes running"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1876
+#: src/muuli_wdr.cpp:1880
 msgid "Kad-nodes session"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1880 src/muuli_wdr.cpp:2334
+#: src/muuli_wdr.cpp:1884 src/muuli_wdr.cpp:2338
 msgid "Select"
 msgstr "اختر"
 
-#: src/muuli_wdr.cpp:1884
+#: src/muuli_wdr.cpp:1888
 msgid "Tree"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1894
+#: src/muuli_wdr.cpp:1898
 msgid "Number of Client Versions shown (0=unlimited)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1919
+#: src/muuli_wdr.cpp:1923
 msgid "!!! WARNING !!!"
 msgstr "!!!تحذير!!!"
 
-#: src/muuli_wdr.cpp:1934
+#: src/muuli_wdr.cpp:1938
 msgid "Max new connections / 5 secs"
 msgstr "الحد اﻷعلى للتصالات لكل 5 ثواني"
 
-#: src/muuli_wdr.cpp:1936
+#: src/muuli_wdr.cpp:1940
 msgid "Concurrent Kad source lookups"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1938
+#: src/muuli_wdr.cpp:1942
 msgid "Kad source re-search interval (minutes)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1940
+#: src/muuli_wdr.cpp:1944
 #, fuzzy
 msgid "Source re-ask interval (minutes)"
 msgstr "فترة تحديث الإتصال بالخادم %i دقيقة"
 
-#: src/muuli_wdr.cpp:1944
+#: src/muuli_wdr.cpp:1948
 msgid "File Buffer Size: 240000 bytes"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1948
+#: src/muuli_wdr.cpp:1952
 msgid "Use MMAP: memory-mapped file access (lower memory use)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1949
+#: src/muuli_wdr.cpp:1953
 msgid "Maps part files into memory instead of buffering them on the heap, lowering the process memory footprint. May reduce download speed on some disks; best for memory-constrained or upload-heavy hosts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1951
+#: src/muuli_wdr.cpp:1955
 msgid "Upload Queue Size: 5000 clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1955
+#: src/muuli_wdr.cpp:1959
 msgid "Server connection refresh interval: Disable"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1959
+#: src/muuli_wdr.cpp:1963
 msgid "Disable computer's timed standby mode"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1978
+#: src/muuli_wdr.cpp:1982
 msgid "Skin to use: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1987
+#: src/muuli_wdr.cpp:1991
 msgid "Show \"Fast eD2k Links Handler\" in every window."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1990
+#: src/muuli_wdr.cpp:1994
 msgid "Show extended info on categories tabs"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1993
+#: src/muuli_wdr.cpp:1997
 #, fuzzy
 msgid "Show application version on title"
 msgstr "اظهر معدل النقل علي العنوان"
 
-#: src/muuli_wdr.cpp:1995
+#: src/muuli_wdr.cpp:1999
 msgid "Show transfer rates on title"
 msgstr "اظهر معدل النقل علي العنوان"
 
-#: src/muuli_wdr.cpp:1997
+#: src/muuli_wdr.cpp:2001
 msgid "Before application name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1999
+#: src/muuli_wdr.cpp:2003
 msgid "After application name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2002
+#: src/muuli_wdr.cpp:2006
 msgid "Show overhead bandwidth"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2006
+#: src/muuli_wdr.cpp:2010
 msgid "Vertical toolbar orientation"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2008
+#: src/muuli_wdr.cpp:2012
 msgid "Live column sorting (auto-reorder rows as their values change)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2015
+#: src/muuli_wdr.cpp:2019
 msgid "Download Queue Files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2018
+#: src/muuli_wdr.cpp:2022
 msgid "Show progress percentage"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2024
+#: src/muuli_wdr.cpp:2028
 msgid "Show progress bar"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2027
+#: src/muuli_wdr.cpp:2031
 msgid "Flat"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2031
+#: src/muuli_wdr.cpp:2035
 msgid "Round"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2049
+#: src/muuli_wdr.cpp:2053
 msgid "External Connection Parameters"
 msgstr "عوامل اﻻتصال الخارجي"
 
-#: src/muuli_wdr.cpp:2052
+#: src/muuli_wdr.cpp:2056
 msgid "Accept external connections"
 msgstr "اقبل اتصال خارجي"
 
-#: src/muuli_wdr.cpp:2059 src/muuli_wdr.cpp:2118
+#: src/muuli_wdr.cpp:2063 src/muuli_wdr.cpp:2122
 msgid "IP of the listening interface:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2062
+#: src/muuli_wdr.cpp:2066
 msgid "Enter here a valid ip in the a.b.c.d format for the listening EC interface. An empty field or 0.0.0.0 will mean any interface."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2083 src/muuli_wdr.cpp:2194
+#: src/muuli_wdr.cpp:2087 src/muuli_wdr.cpp:2198
 msgid "TCP port:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2089
+#: src/muuli_wdr.cpp:2093
 msgid "Enable UPnP port forwarding on the EC port"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2093 src/muuli_wdr.cpp:3079
+#: src/muuli_wdr.cpp:2097 src/muuli_wdr.cpp:3083
 #: src/utils/wxCas/src/wxcasprefs.cpp:167
 msgid "Password"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2099
+#: src/muuli_wdr.cpp:2103
 msgid "aMule API server parameters"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2102
+#: src/muuli_wdr.cpp:2106
 msgid "Run amuleapi (REST API) on startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2107
+#: src/muuli_wdr.cpp:2111
 msgid "HTTP port:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2121
+#: src/muuli_wdr.cpp:2125
 msgid "The interface amuleapi's HTTP server listens on. 127.0.0.1 (default) accepts only local connections; use 0.0.0.0 or a specific IP to expose it to other hosts (set an admin password below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2126
+#: src/muuli_wdr.cpp:2130
 msgid "Type a password to set or change it. Stored passwords cannot be shown, so leaving this empty keeps the current one."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2128
+#: src/muuli_wdr.cpp:2132
 msgid "Admin password"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2140 src/muuli_wdr.cpp:2157 src/PrefsUnifiedDlg.cpp:1103
+#: src/muuli_wdr.cpp:2144 src/muuli_wdr.cpp:2161 src/PrefsUnifiedDlg.cpp:1112
 msgid "A password is set."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2144
+#: src/muuli_wdr.cpp:2148
 msgid "Enable guest access"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2145
+#: src/muuli_wdr.cpp:2149
 msgid "Guest sessions may read status and listings but cannot change anything. Turning this off clears the stored guest password."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2149
+#: src/muuli_wdr.cpp:2153
 msgid "Guest password"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2164
+#: src/muuli_wdr.cpp:2168
 msgid "Web server parameters"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2167
+#: src/muuli_wdr.cpp:2171
 msgid "Run webserver on startup (deprecated)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2173
+#: src/muuli_wdr.cpp:2177
 msgid "Web template"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2178
+#: src/muuli_wdr.cpp:2182
 msgid "Full rights password"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2182
+#: src/muuli_wdr.cpp:2186
 msgid "Enable Low rights User"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2187
+#: src/muuli_wdr.cpp:2191
 msgid "Low rights password"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2201
+#: src/muuli_wdr.cpp:2205
 msgid "Enable UPnP port forwarding of the web server port"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2206
+#: src/muuli_wdr.cpp:2210
 msgid "Web server UPnP TCP port (Optional)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2214
+#: src/muuli_wdr.cpp:2218
 msgid "Page Refresh Time (in secs)"
 msgstr "زمن تحديث الصفحة (بالثانية)"
 
-#: src/muuli_wdr.cpp:2221
+#: src/muuli_wdr.cpp:2225
 msgid "Enable Gzip compression"
 msgstr " Gzipتمكين ضغط نوع"
 
-#: src/muuli_wdr.cpp:2255
+#: src/muuli_wdr.cpp:2259
 #, fuzzy
 msgid "Reset page to defaults"
 msgstr "اﻹفتراضية بالنظام"
 
-#: src/muuli_wdr.cpp:2256
+#: src/muuli_wdr.cpp:2260
 msgid "Reset the settings on the current page to their default values."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2258 src/muuli_wdr.cpp:2344 src/ServerWnd.cpp:274
+#: src/muuli_wdr.cpp:2262 src/muuli_wdr.cpp:2348 src/ServerWnd.cpp:274
 #: src/ServerWnd.cpp:282
 msgid "OK"
 msgstr "موافق"
 
-#: src/muuli_wdr.cpp:2260
+#: src/muuli_wdr.cpp:2264
 msgid "Click here to apply any changes made to the preferences."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2263
+#: src/muuli_wdr.cpp:2267
 msgid "Reset any changes made to the preferences."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2292
+#: src/muuli_wdr.cpp:2296
 msgid "Comment :"
 msgstr "تعليق :"
 
-#: src/muuli_wdr.cpp:2299
+#: src/muuli_wdr.cpp:2303
 msgid "Incoming Dir :"
 msgstr "مجلد القادم"
 
-#: src/muuli_wdr.cpp:2308
+#: src/muuli_wdr.cpp:2312
 msgid "Change priority for new assigned files :"
 msgstr "تغير الأولوية للملفات الحديثة :"
 
-#: src/muuli_wdr.cpp:2312
+#: src/muuli_wdr.cpp:2316
 #, fuzzy
 msgid "Don't change"
 msgstr "ﻻ تغير"
 
-#: src/muuli_wdr.cpp:2324
+#: src/muuli_wdr.cpp:2328
 msgid "Select color for this Category (currently selected) :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2391 src/muuli_wdr.cpp:2410 src/muuli_wdr.cpp:2432
+#: src/muuli_wdr.cpp:2395 src/muuli_wdr.cpp:2414 src/muuli_wdr.cpp:2436
 msgid "Click this button to reset the log."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2451
+#: src/muuli_wdr.cpp:2455
 msgid "Click on this button to update the servers list from URL ..."
 msgstr "قم بالضغط على هذا الزر لتحديث قائمة الخادمات من العنوان ..."
 
-#: src/muuli_wdr.cpp:2455
+#: src/muuli_wdr.cpp:2459
 msgid "Server list"
 msgstr "قائمة الخادمات"
 
-#: src/muuli_wdr.cpp:2459
+#: src/muuli_wdr.cpp:2463
 msgid "Enter the url to a server.met file here and press the button to the left to update the list of known servers."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2464
+#: src/muuli_wdr.cpp:2468
 msgid "Add server manually: Name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2467
+#: src/muuli_wdr.cpp:2471
 msgid "Enter the name of the new server here"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2469 src/ServerWnd.cpp:206
+#: src/muuli_wdr.cpp:2473 src/ServerWnd.cpp:206
 msgid "IP:Port"
 msgstr "عنوان شبكي :منفذ"
 
-#: src/muuli_wdr.cpp:2472
+#: src/muuli_wdr.cpp:2476
 msgid "Enter the IP of the server here, using the x.x.x.x format."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2478
+#: src/muuli_wdr.cpp:2482
 msgid "Enter the port of the server here."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2481
+#: src/muuli_wdr.cpp:2485
 msgid "Add manually a server (fill fields to the left before) ..."
 msgstr "اضف خادم يدويا )قم بمل الخانة على اليسار اوﻻ)..."
 
-#: src/muuli_wdr.cpp:2510
+#: src/muuli_wdr.cpp:2514
 msgid "aMule Log"
 msgstr "سجل aMule"
 
-#: src/muuli_wdr.cpp:2518
+#: src/muuli_wdr.cpp:2522
 msgid "Server Info"
 msgstr "معلومات الخادم"
 
-#: src/muuli_wdr.cpp:2522
+#: src/muuli_wdr.cpp:2526
 msgid "ED2K Info"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2526
+#: src/muuli_wdr.cpp:2530
 msgid "Kad Info"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2554
+#: src/muuli_wdr.cpp:2558
 msgid "Click on this button to update the nodes list from URL ..."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2558
+#: src/muuli_wdr.cpp:2562
 msgid "Nodes (0)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2562
+#: src/muuli_wdr.cpp:2566
 msgid "Enter the url to a nodes.dat file here and press the button to the left to update the list of known nodes."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2565
+#: src/muuli_wdr.cpp:2569
 msgid "Nodes stats"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2607
+#: src/muuli_wdr.cpp:2611
 msgid "Bootstrap"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2610
+#: src/muuli_wdr.cpp:2614
 msgid "New node"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2615
+#: src/muuli_wdr.cpp:2619
 msgid "IP:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2635
+#: src/muuli_wdr.cpp:2639
 msgid "Port:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2648
+#: src/muuli_wdr.cpp:2652
 msgid "Bootstrap from known clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2650
+#: src/muuli_wdr.cpp:2654
 msgid "Disconnect Kad"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2684
+#: src/muuli_wdr.cpp:2688
 msgid "Use Secure User Identification"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2686
+#: src/muuli_wdr.cpp:2690
 msgid "It is recommended to enable this option. You will not receive credits if SUI is not enabled."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2688
+#: src/muuli_wdr.cpp:2692
 msgid "Protocol Obfuscation"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2691
+#: src/muuli_wdr.cpp:2695
 msgid "Support Protocol Obfuscation"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2693
+#: src/muuli_wdr.cpp:2697
 msgid "This option enabled Protocol Obfuscation, and makes aMule accept obfuscated connections from other clients."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2695
+#: src/muuli_wdr.cpp:2699
 msgid "Use obfuscation for outgoing connections"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2697
+#: src/muuli_wdr.cpp:2701
 msgid "This option makes aMule use Protocol Obfuscation when connecting other clients/servers."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2699
+#: src/muuli_wdr.cpp:2703
 msgid "Accept only obfuscated connections"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2700
+#: src/muuli_wdr.cpp:2704
 msgid "This option makes aMule only accept obfuscated connections. You will have less sources, but all your traffic will be obfuscated"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2705
+#: src/muuli_wdr.cpp:2709
 msgid "Everybody"
 msgstr "الكل"
 
-#: src/muuli_wdr.cpp:2707
+#: src/muuli_wdr.cpp:2711
 msgid "No one"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2709
+#: src/muuli_wdr.cpp:2713
 msgid "Who can see my shared files:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2710
+#: src/muuli_wdr.cpp:2714
 msgid "Select who can request to view a list of your shared files."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2712
+#: src/muuli_wdr.cpp:2716
 msgid "IP-Filtering"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2719
+#: src/muuli_wdr.cpp:2723
 msgid "Filter clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2721
+#: src/muuli_wdr.cpp:2725
 msgid "Enable filtering of the client IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2723
+#: src/muuli_wdr.cpp:2727
 msgid "Filter servers"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2725
+#: src/muuli_wdr.cpp:2729
 msgid "Enable filtering of the server IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2729
+#: src/muuli_wdr.cpp:2733
 msgid "Reload List"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2730
+#: src/muuli_wdr.cpp:2734
 msgid "Reload the list of IPs to filter from the file ~/.aMule/ipfilter.dat"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2736
+#: src/muuli_wdr.cpp:2740
 msgid "URL:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2740 src/muuli_wdr.cpp:2933
+#: src/muuli_wdr.cpp:2744 src/muuli_wdr.cpp:2937
 msgid "Update now"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2743
+#: src/muuli_wdr.cpp:2747
 msgid "Auto-update ipfilter at startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2747
+#: src/muuli_wdr.cpp:2751
 msgid "Filtering Level:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2753
+#: src/muuli_wdr.cpp:2757
 msgid "Always filter LAN IPs"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2756
+#: src/muuli_wdr.cpp:2760
 msgid "Paranoid handling of non-matching IPs"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2758
+#: src/muuli_wdr.cpp:2762
 msgid "Rejects a packet when its source IP differs from the IP the client claims (an anti-spoofing check). Disable only if it causes connection problems."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2760
+#: src/muuli_wdr.cpp:2764
 msgid "Use system-wide ipfilter.dat if available"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2761
+#: src/muuli_wdr.cpp:2765
 msgid "If there's no local ipfilter.dat found, allow usage of a system-wide ipfilter file."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2778
+#: src/muuli_wdr.cpp:2782
 msgid "Enable Online-Signature"
 msgstr "تمكين التوقيع الشبكي"
 
-#: src/muuli_wdr.cpp:2780
+#: src/muuli_wdr.cpp:2784
 msgid "Enables the writing of the OS file, which can be used by external apps to create signatures and the like."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2784
+#: src/muuli_wdr.cpp:2788
 msgid "Update Frequency (Secs):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2787
+#: src/muuli_wdr.cpp:2791
 msgid "Change the frequency (in seconds) of Online Signature updates."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2795
+#: src/muuli_wdr.cpp:2799
 msgid "Save online signature file in: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:2801
+#: src/muuli_wdr.cpp:2805
 msgid "Click here to select the directory containing the the Online Signature files."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2834
+#: src/muuli_wdr.cpp:2838
 msgid "Show country flags for clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2835
+#: src/muuli_wdr.cpp:2839
 msgid "Render the country flag column in the transfers, queue and search views. Requires a valid MMDB GeoIP database (see below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2840
+#: src/muuli_wdr.cpp:2844
 #, fuzzy
 msgid "Database"
 msgstr "نسبة المصادر :"
 
-#: src/muuli_wdr.cpp:2856
+#: src/muuli_wdr.cpp:2860
 #, fuzzy
 msgid "Source:"
 msgstr "مصدر"
 
-#: src/muuli_wdr.cpp:2859
+#: src/muuli_wdr.cpp:2863
 msgid "DB-IP (free, no account)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2860
+#: src/muuli_wdr.cpp:2864
 msgid "MaxMind GeoLite2 (free, account required)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2861
+#: src/muuli_wdr.cpp:2865
 msgid "Custom URL"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2864
+#: src/muuli_wdr.cpp:2868
 msgid "Choose which provider supplies the GeoIP MMDB database. DB-IP is the default - no account required. MaxMind requires a free account + license key. Use Custom URL to point at any other MMDB host (e.g. a local mirror)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2881
+#: src/muuli_wdr.cpp:2885
 msgid ""
 "No configuration required.\n"
 "\n"
@@ -4814,11 +4814,11 @@ msgid ""
 "License: Creative Commons BY 4.0 - https://creativecommons.org/licenses/by/4.0/"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2894
+#: src/muuli_wdr.cpp:2898
 msgid "License key:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2900
+#: src/muuli_wdr.cpp:2904
 msgid ""
 "Sign up for a free MaxMind account, then generate a License Key:\n"
 "https://www.maxmind.com/en/geolite2/signup\n"
@@ -4828,233 +4828,233 @@ msgid ""
 "Requires attribution and account registration; refresh at least every 30 days."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2915
+#: src/muuli_wdr.cpp:2919
 #, fuzzy
 msgid "Download URL:"
 msgstr "التحميل"
 
-#: src/muuli_wdr.cpp:2921
+#: src/muuli_wdr.cpp:2925
 msgid ""
 "Must point to an .mmdb file or a .gz / .tar.gz containing one.\n"
 "URL may include credentials (https://user:pass@host/...).\n"
 "License and attribution terms are set by the upstream URL - you are responsible."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2934
+#: src/muuli_wdr.cpp:2938
 msgid "Download the GeoIP database from the selected source."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2936
+#: src/muuli_wdr.cpp:2940
 #, fuzzy
 msgid "Auto-update on startup"
 msgstr "ربط تلقائي عند بدء التشغيل"
 
-#: src/muuli_wdr.cpp:2937
+#: src/muuli_wdr.cpp:2941
 msgid "Re-download the GeoIP database from the selected source every time aMule starts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2960
+#: src/muuli_wdr.cpp:2964
 msgid "Filter incoming messages (except current chat):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2962
+#: src/muuli_wdr.cpp:2966
 msgid "Filter all messages"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2964
+#: src/muuli_wdr.cpp:2968
 msgid "Filter messages from people not on your friend list"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2966
+#: src/muuli_wdr.cpp:2970
 msgid "Filter messages from unknown clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2968
+#: src/muuli_wdr.cpp:2972
 msgid "Filter messages containing (use ',' as separator):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2971 src/muuli_wdr.cpp:2982
+#: src/muuli_wdr.cpp:2975 src/muuli_wdr.cpp:2986
 msgid "add here the words amule should filter and block messages including it"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2973
+#: src/muuli_wdr.cpp:2977
 msgid "Show received messages in the log"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2976
+#: src/muuli_wdr.cpp:2980
 msgid "Comments"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2979
+#: src/muuli_wdr.cpp:2983
 msgid "Filter comments containing (use ',' as separator):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3004
+#: src/muuli_wdr.cpp:3008
 msgid "Enable Proxy"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3005
+#: src/muuli_wdr.cpp:3009
 msgid "Enable/disable proxy support"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3008
+#: src/muuli_wdr.cpp:3012
 msgid "Proxy type:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3019
+#: src/muuli_wdr.cpp:3023
 msgid "Proxy host:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3022
+#: src/muuli_wdr.cpp:3026
 msgid "The proxy host name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3024
+#: src/muuli_wdr.cpp:3028
 msgid "Proxy port:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3027
+#: src/muuli_wdr.cpp:3031
 msgid "The proxy port"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3029
+#: src/muuli_wdr.cpp:3033
 msgid "Enable authentication"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3030
+#: src/muuli_wdr.cpp:3034
 msgid "Enable/disable username/password authentication"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3033
+#: src/muuli_wdr.cpp:3037
 msgid "Username: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:3036
+#: src/muuli_wdr.cpp:3040
 msgid "The username to use to connect to the proxy"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3038
+#: src/muuli_wdr.cpp:3042
 msgid "Password:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3041
+#: src/muuli_wdr.cpp:3045
 msgid "The password to use to connect to the proxy"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3060
+#: src/muuli_wdr.cpp:3064
 msgid "Connect to:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3069
+#: src/muuli_wdr.cpp:3073
 msgid "Login to remote amule"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3074
+#: src/muuli_wdr.cpp:3078
 msgid "User name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3085
+#: src/muuli_wdr.cpp:3089
 msgid "Remember those settings"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3088
+#: src/muuli_wdr.cpp:3092
 #, fuzzy
 msgid "Force ZLIB compression"
 msgstr "أكتسب بواسطة الضغط :"
 
-#: src/muuli_wdr.cpp:3112
+#: src/muuli_wdr.cpp:3116
 msgid "Enable Verbose Debug-Logging."
 msgstr ""
 
-#: src/muuli_wdr.cpp:3114
+#: src/muuli_wdr.cpp:3118
 #, fuzzy
 msgid "Only to Logfile"
 msgstr "&فتح الملف"
 
-#: src/muuli_wdr.cpp:3116
+#: src/muuli_wdr.cpp:3120
 msgid "Message Categories:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3140 src/PartFileConvertDlg.cpp:160
+#: src/muuli_wdr.cpp:3144 src/PartFileConvertDlg.cpp:160
 msgid "Waiting..."
 msgstr "إنتظار..."
 
-#: src/muuli_wdr.cpp:3160
+#: src/muuli_wdr.cpp:3164
 msgid "Add imports"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3163
+#: src/muuli_wdr.cpp:3167
 msgid "Retry selected"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3165
+#: src/muuli_wdr.cpp:3169
 msgid "Remove selected"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3228
+#: src/muuli_wdr.cpp:3232
 msgid "Event Types"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3247
+#: src/muuli_wdr.cpp:3251
 msgid "Statistics and queued clients for selected file(s) : Session / All time"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3271
+#: src/muuli_wdr.cpp:3275
 #, fuzzy
 msgid "Active Uploads"
 msgstr "رفع نشط :"
 
-#: src/muuli_wdr.cpp:3285
+#: src/muuli_wdr.cpp:3289
 #, fuzzy
 msgid "Percent of total files"
 msgstr "مجموع الملفات"
 
-#: src/muuli_wdr.cpp:3337
+#: src/muuli_wdr.cpp:3341
 #, fuzzy
 msgid "Show Clients for"
 msgstr "منفذ العميل"
 
-#: src/muuli_wdr.cpp:3339
+#: src/muuli_wdr.cpp:3343
 #, fuzzy
 msgid "All files"
 msgstr "ملفات مشاركة"
 
-#: src/muuli_wdr.cpp:3342
+#: src/muuli_wdr.cpp:3346
 #, fuzzy
 msgid "Selected files"
 msgstr "إختر فلتر العرض"
 
-#: src/muuli_wdr.cpp:3345
+#: src/muuli_wdr.cpp:3349
 #, fuzzy
 msgid "Active uploads only"
 msgstr "رفع نشط"
 
-#: src/muuli_wdr.cpp:3352
+#: src/muuli_wdr.cpp:3356
 #, fuzzy
 msgid "Reload:"
 msgstr "اعد تحميل"
 
-#: src/muuli_wdr.cpp:3356
+#: src/muuli_wdr.cpp:3360
 msgid "Reload your shared files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3419
+#: src/muuli_wdr.cpp:3423
 msgid "Send"
 msgstr "ارسل"
 
-#: src/muuli_wdr.cpp:3420
+#: src/muuli_wdr.cpp:3424
 msgid "Sends the specified message."
 msgstr ""
 
-#: src/muuli_wdr.cpp:3424
+#: src/muuli_wdr.cpp:3428
 msgid "Close this chat-session."
 msgstr ""
 
-#: src/muuli_wdr.cpp:3447
+#: src/muuli_wdr.cpp:3451
 msgid "Connect to any server and/or Kad"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3453 src/SharedFilesCtrl.cpp:142 src/Statistics.cpp:941
+#: src/muuli_wdr.cpp:3457 src/SharedFilesCtrl.cpp:142 src/Statistics.cpp:941
 msgid "Shared Files"
 msgstr "ملفات مشاركة"
 
@@ -5686,260 +5686,260 @@ msgid ""
 "these settings."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:647
+#: src/PrefsUnifiedDlg.cpp:656
 #, c-format
 msgid "Failed to connect Cfg to widget with the ID %d and key %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:695
+#: src/PrefsUnifiedDlg.cpp:704
 #, c-format
 msgid "Failed to transfer data from Cfg to Widget with the ID %d and key %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:801
+#: src/PrefsUnifiedDlg.cpp:810
 msgid "The type of proxy you are connecting to"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1020
+#: src/PrefsUnifiedDlg.cpp:1029
 #, c-format
 msgid "Failed to transfer data from Widget to Cfg with the ID %d and key %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1103
+#: src/PrefsUnifiedDlg.cpp:1112
 msgid "No password set."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1132
+#: src/PrefsUnifiedDlg.cpp:1141
 msgid "Guest access needs a password. Type one in the guest password field, or untick Enable guest access."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1144
+#: src/PrefsUnifiedDlg.cpp:1153
 msgid ""
 "aMule must be restarted to enable these changes:\n"
 "\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1151
+#: src/PrefsUnifiedDlg.cpp:1160
 msgid "- TCP port changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1156
+#: src/PrefsUnifiedDlg.cpp:1165
 msgid "- UDP port changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1161
+#: src/PrefsUnifiedDlg.cpp:1170
 #, fuzzy
 msgid "- Network interface binding changed.\n"
 msgstr "عوامل اﻻتصال الخارجي"
 
-#: src/PrefsUnifiedDlg.cpp:1166
+#: src/PrefsUnifiedDlg.cpp:1175
 #, fuzzy
 msgid "- External connect port changed.\n"
 msgstr "عوامل اﻻتصال الخارجي"
 
-#: src/PrefsUnifiedDlg.cpp:1170
+#: src/PrefsUnifiedDlg.cpp:1179
 #, fuzzy
 msgid "- External connect acceptance changed.\n"
 msgstr "عوامل اﻻتصال الخارجي"
 
-#: src/PrefsUnifiedDlg.cpp:1174
+#: src/PrefsUnifiedDlg.cpp:1183
 #, fuzzy
 msgid "- External connect interface changed.\n"
 msgstr "عوامل اﻻتصال الخارجي"
 
-#: src/PrefsUnifiedDlg.cpp:1178
+#: src/PrefsUnifiedDlg.cpp:1187
 #, fuzzy
 msgid "- Protocol obfuscation support changed.\n"
 msgstr "عوامل اﻻتصال الخارجي"
 
-#: src/PrefsUnifiedDlg.cpp:1193
+#: src/PrefsUnifiedDlg.cpp:1202
 msgid "- amuleapi settings changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1202
+#: src/PrefsUnifiedDlg.cpp:1211
 msgid ""
 "Your Auto-update server list is empty.\n"
 "'Auto-update server list at startup' will be disabled."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1213
+#: src/PrefsUnifiedDlg.cpp:1222
 msgid ""
 "You have enabled external connections but have not specified a password.\n"
 "External connections cannot be enabled unless a valid password is specified."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1246
+#: src/PrefsUnifiedDlg.cpp:1255
 #, c-format
 msgid "The amuleapi password could not be saved: %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1276
+#: src/PrefsUnifiedDlg.cpp:1285
 msgid "- Language changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1281
+#: src/PrefsUnifiedDlg.cpp:1290
 msgid "- Temp folder changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1286
+#: src/PrefsUnifiedDlg.cpp:1295
 msgid "- ED2K network enabled.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1319
+#: src/PrefsUnifiedDlg.cpp:1328
 msgid "The shared-file exclusion pattern is not a valid regular expression. The filter has been left disabled."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1321 src/PrefsUnifiedDlg.cpp:1921
+#: src/PrefsUnifiedDlg.cpp:1330 src/PrefsUnifiedDlg.cpp:1930
 msgid "Invalid regular expression"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1398
+#: src/PrefsUnifiedDlg.cpp:1407
 msgid ""
 "Both eD2k and Kad network are disabled.\n"
 "You won't be able to connect until you enable at least one of them."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1403
+#: src/PrefsUnifiedDlg.cpp:1412
 msgid ""
 "Kad will not start if your UDP port is disabled.\n"
 "Enable UDP port or disable Kad."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1459
+#: src/PrefsUnifiedDlg.cpp:1468
 msgid ""
 "\n"
 "You MUST restart aMule now.\n"
 "If you do not restart now, don't complain if anything bad happens.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1524
+#: src/PrefsUnifiedDlg.cpp:1533
 msgid "Could not register aMule for autostart at login. The autostart store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1526
+#: src/PrefsUnifiedDlg.cpp:1535
 msgid "Could not remove the autostart-at-login entry."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1527
+#: src/PrefsUnifiedDlg.cpp:1536
 #, fuzzy
 msgid "Autostart"
 msgstr "ذاتي"
 
-#: src/PrefsUnifiedDlg.cpp:1542
+#: src/PrefsUnifiedDlg.cpp:1551
 msgid "Register file type"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1542
+#: src/PrefsUnifiedDlg.cpp:1551
 msgid "Register URL handler"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1550
+#: src/PrefsUnifiedDlg.cpp:1559
 #, c-format
 msgid "aMule only handles eD2k-compatible magnets. If you replace the current magnet handler (%s), BitTorrent magnet links will stop working - aMule cannot download BitTorrent content. Continue?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1555
+#: src/PrefsUnifiedDlg.cpp:1564
 #, c-format
 msgid "Another application currently opens .emulecollection files (%s). Replace it with aMule?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1560
+#: src/PrefsUnifiedDlg.cpp:1569
 #, c-format
 msgid "Another application is currently the default handler for these links (%s). Replace it with aMule?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1585
+#: src/PrefsUnifiedDlg.cpp:1594
 msgid "Could not register aMule for .emulecollection files. The registration store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1587
+#: src/PrefsUnifiedDlg.cpp:1596
 #, fuzzy
 msgid "Could not remove the file type registration."
 msgstr "قمت بمحاولت تحميل الملف مسبقا %s"
 
-#: src/PrefsUnifiedDlg.cpp:1589
+#: src/PrefsUnifiedDlg.cpp:1598
 msgid "Could not register aMule as the URL handler. The registration store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1591
+#: src/PrefsUnifiedDlg.cpp:1600
 msgid "Could not remove the URL handler registration."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1661 src/PrefsUnifiedDlg.cpp:1688
+#: src/PrefsUnifiedDlg.cpp:1670 src/PrefsUnifiedDlg.cpp:1697
 #, fuzzy
 msgid "The web server and aMule API require external connections to be enabled."
 msgstr "قبل إتصال خارجي جديد\n"
 
-#: src/PrefsUnifiedDlg.cpp:1671
+#: src/PrefsUnifiedDlg.cpp:1680
 msgid "The aMule web server is deprecated. Consider running the aMule API instead."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1735
+#: src/PrefsUnifiedDlg.cpp:1744
 msgid ""
 "Your Auto-update servers list is in blank.\n"
 "Please fill in at least one URL to point to a valid server.met file.\n"
 "Click on the button \"List\" by this checkbox to enter an URL."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1876
+#: src/PrefsUnifiedDlg.cpp:1885
 msgid "Temporary files"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1881
+#: src/PrefsUnifiedDlg.cpp:1890
 msgid "Incoming files"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1886
+#: src/PrefsUnifiedDlg.cpp:1895
 msgid "Online Signatures"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1899
+#: src/PrefsUnifiedDlg.cpp:1908
 #, c-format
 msgid "Choose a folder for %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1923
+#: src/PrefsUnifiedDlg.cpp:1932
 #, fuzzy, c-format
 msgid "Would exclude %u of %u shared file"
 msgid_plural "Would exclude %u of %u shared files"
 msgstr[0] "وجد %i ملف مشاركة معرف"
 msgstr[1] "وجد %i ملف مشاركة معرف"
 
-#: src/PrefsUnifiedDlg.cpp:1940
+#: src/PrefsUnifiedDlg.cpp:1949
 msgid "Browse for videoplayer"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1944
+#: src/PrefsUnifiedDlg.cpp:1953
 msgid "Select browser"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1948
+#: src/PrefsUnifiedDlg.cpp:1957
 msgid "Select ffprobe binary"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1954
+#: src/PrefsUnifiedDlg.cpp:1963
 #, c-format
 msgid "Executable%s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1988
+#: src/PrefsUnifiedDlg.cpp:1997
 msgid "ffprobe not found on PATH or in the standard install locations. Install ffmpeg (which ships ffprobe) or use Browse to pick a binary manually."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2000
+#: src/PrefsUnifiedDlg.cpp:2009
 msgid "Reset the settings on this page to their default values?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2001
+#: src/PrefsUnifiedDlg.cpp:2010
 #, fuzzy
 msgid "Reset to defaults"
 msgstr "اﻹفتراضية بالنظام"
 
-#: src/PrefsUnifiedDlg.cpp:2028
+#: src/PrefsUnifiedDlg.cpp:2037
 msgid "Edit server list"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2029
+#: src/PrefsUnifiedDlg.cpp:2038
 msgid ""
 "Add here URL's to download server.met files.\n"
 "Only one url on each line."
@@ -5947,152 +5947,152 @@ msgstr ""
 "أضف هنا عنوان لتحميل ملفات server.met \n"
 "عنوان واحد فقط لكل سطر"
 
-#: src/PrefsUnifiedDlg.cpp:2084
+#: src/PrefsUnifiedDlg.cpp:2093
 msgid "IP2Country update failed"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2229 src/PrefsUnifiedDlg.cpp:2260
+#: src/PrefsUnifiedDlg.cpp:2238 src/PrefsUnifiedDlg.cpp:2269
 msgid "Data by MaxMind GeoLite2"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2231 src/PrefsUnifiedDlg.cpp:2262
+#: src/PrefsUnifiedDlg.cpp:2240 src/PrefsUnifiedDlg.cpp:2271
 msgid "Custom source"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2233 src/PrefsUnifiedDlg.cpp:2264
+#: src/PrefsUnifiedDlg.cpp:2242 src/PrefsUnifiedDlg.cpp:2273
 msgid "Data by DB-IP.com"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2284
+#: src/PrefsUnifiedDlg.cpp:2293
 #, c-format
 msgid "Status: Loaded%s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2286
+#: src/PrefsUnifiedDlg.cpp:2295
 #, c-format
 msgid "Status: Loaded%s - %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2290
+#: src/PrefsUnifiedDlg.cpp:2299
 msgid "Status: Failed to load - click 'Update now' to refresh."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2292
+#: src/PrefsUnifiedDlg.cpp:2301
 msgid "Status: Not found - click 'Update now' to download."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2350 src/PrefsUnifiedDlg.cpp:2374
+#: src/PrefsUnifiedDlg.cpp:2359 src/PrefsUnifiedDlg.cpp:2383
 #, fuzzy, c-format
 msgid "Update delay: %d second"
 msgid_plural "Update delay: %d seconds"
 msgstr[0] "تحيدث كل:5 ثواني"
 msgstr[1] "تحيدث كل:5 ثواني"
 
-#: src/PrefsUnifiedDlg.cpp:2358
+#: src/PrefsUnifiedDlg.cpp:2367
 #, c-format
 msgid "Time for average graph: %d minute"
 msgid_plural "Time for average graph: %d minutes"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/PrefsUnifiedDlg.cpp:2367
+#: src/PrefsUnifiedDlg.cpp:2376
 #, c-format
 msgid "Connections Graph Scale: %d"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2382
+#: src/PrefsUnifiedDlg.cpp:2391
 #, c-format
 msgid "File Buffer Size: %d byte"
 msgid_plural "File Buffer Size: %d bytes"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/PrefsUnifiedDlg.cpp:2392
+#: src/PrefsUnifiedDlg.cpp:2401
 #, c-format
 msgid "Upload Queue Size: %d client"
 msgid_plural "Upload Queue Size: %d clients"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/PrefsUnifiedDlg.cpp:2402
+#: src/PrefsUnifiedDlg.cpp:2411
 #, fuzzy, c-format
 msgid "Server connection refresh interval: %d minute"
 msgid_plural "Server connection refresh interval: %d minutes"
 msgstr[0] "فترة تحديث الإتصال بالخادم %i دقيقة"
 msgstr[1] "فترة تحديث الإتصال بالخادم %i دقيقة"
 
-#: src/PrefsUnifiedDlg.cpp:2407
+#: src/PrefsUnifiedDlg.cpp:2416
 msgid "Server connection refresh interval: Disabled"
 msgstr "فترة تحديث الإتصال بالخادم :معطل"
 
-#: src/PrefsUnifiedDlg.cpp:2451
+#: src/PrefsUnifiedDlg.cpp:2460
 #, fuzzy
 msgid "disabled"
 msgstr "تعطيل"
 
-#: src/PrefsUnifiedDlg.cpp:2477
+#: src/PrefsUnifiedDlg.cpp:2486
 #, c-format
 msgid "Execute command on '%s' event"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2484
+#: src/PrefsUnifiedDlg.cpp:2493
 msgid "Enable command execution on core"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2496
+#: src/PrefsUnifiedDlg.cpp:2505
 msgid "Core command:"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2512
+#: src/PrefsUnifiedDlg.cpp:2521
 msgid "Enable command execution on GUI"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2524
+#: src/PrefsUnifiedDlg.cpp:2533
 msgid "GUI command:"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2540
+#: src/PrefsUnifiedDlg.cpp:2549
 msgid "The following variables will be replaced:"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2708
+#: src/PrefsUnifiedDlg.cpp:2717
 msgid ""
 "The following folders look like system or sensitive locations:\n"
 "\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2713
+#: src/PrefsUnifiedDlg.cpp:2722
 msgid "Sharing them recursively will publish every file underneath on the eD2k/Kad networks. Do you really want to do this?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2716
+#: src/PrefsUnifiedDlg.cpp:2725
 msgid "Confirm shared folders"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2744
+#: src/PrefsUnifiedDlg.cpp:2753
 #, fuzzy
 msgid "Reloading shared files..."
 msgstr "وجد %i ملف مشاركة معرف"
 
-#: src/PrefsUnifiedDlg.cpp:2745
+#: src/PrefsUnifiedDlg.cpp:2754
 msgid "Scanning for subdirectories..."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2746
+#: src/PrefsUnifiedDlg.cpp:2755
 msgid "Updating shared folders"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2773
+#: src/PrefsUnifiedDlg.cpp:2782
 #, c-format
 msgid "Scanned %u directories..."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2823
+#: src/PrefsUnifiedDlg.cpp:2832
 #, c-format
 msgid "Reloading shared files: %u files scanned"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2873
+#: src/PrefsUnifiedDlg.cpp:2882
 #, fuzzy
 msgid "Shared folder"
 msgstr "ملفات مشاركة"
@@ -7753,12 +7753,12 @@ msgstr "الغاء المجموعة"
 msgid "Hashset requested for unknown file: %s"
 msgstr ""
 
-#: src/UploadQueue.cpp:618
+#: src/UploadQueue.cpp:627
 #, c-format
 msgid "Resuming uploads of file: %s"
 msgstr ""
 
-#: src/UploadQueue.cpp:634
+#: src/UploadQueue.cpp:643
 #, c-format
 msgid "Suspending upload of file: %s"
 msgstr ""

--- a/po/ar.po
+++ b/po/ar.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-28 08:06+0200\n"
+"POT-Creation-Date: 2026-07-28 10:19+0200\n"
 "PO-Revision-Date: 2026-07-27 11:31+0000\n"
 "Last-Translator: saleh alhathal <hathalsal@hotmail.com>\n"
 "Language-Team: \n"
@@ -135,7 +135,7 @@ msgstr ""
 msgid "Not now"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:422 src/amuleDlg.cpp:600
+#: src/AppImageIntegration.cpp:422 src/amuleDlg.cpp:665
 msgid "Don't ask again"
 msgstr ""
 
@@ -208,7 +208,7 @@ msgid "Killing amuleweb instance with pid '%d' ... "
 msgstr ""
 
 #: src/amule.cpp:336 src/amule.cpp:349 src/ClientRef.cpp:180
-#: src/SearchDlg.cpp:880 src/ServerListCtrl.cpp:98
+#: src/SearchDlg.cpp:1041 src/ServerListCtrl.cpp:98
 msgid "Failed"
 msgstr "فشل"
 
@@ -554,30 +554,68 @@ msgstr ""
 msgid "ERROR: %s"
 msgstr ""
 
-#: src/amuleDlg.cpp:236
+#: src/amuleDlg.cpp:250
 #, c-format
 msgid "This is aMule %s based on eMule."
 msgstr ""
 
-#: src/amuleDlg.cpp:237
+#: src/amuleDlg.cpp:251
 #, c-format
 msgid "Running on %s"
 msgstr ""
 
-#: src/amuleDlg.cpp:239
+#: src/amuleDlg.cpp:253
 msgid "Visit https://github.com/amule-org/amule/releases/latest to check if a new version is available."
 msgstr ""
 
-#: src/amuleDlg.cpp:268
+#: src/amuleDlg.cpp:282
 msgid "FATAL ERROR: Failed to create Timer"
 msgstr ""
 
-#: src/amuleDlg.cpp:592
+#: src/amuleDlg.cpp:361 src/amuleDlg.cpp:1787 src/amuleDlg.cpp:2033
+#: src/muuli_wdr.cpp:1492 src/muuli_wdr.cpp:3418
+msgid "Networks"
+msgstr ""
+
+#: src/amuleDlg.cpp:362 src/amuleDlg.cpp:1793 src/muuli_wdr.cpp:3419
+msgid "Searches"
+msgstr "بحث"
+
+#: src/amuleDlg.cpp:363 src/amuleDlg.cpp:1799 src/DownloadListCtrl.cpp:740
+#: src/muuli_wdr.cpp:392 src/muuli_wdr.cpp:1585 src/muuli_wdr.cpp:3420
+#: src/Statistics.cpp:829
+msgid "Downloads"
+msgstr "تحميل"
+
+#: src/amuleDlg.cpp:364 src/amuleDlg.cpp:1805 src/muuli_wdr.cpp:3294
+msgid "Shared files"
+msgstr ""
+
+#: src/amuleDlg.cpp:365 src/amuleDlg.cpp:1811 src/muuli_wdr.cpp:2926
+#: src/muuli_wdr.cpp:3376 src/muuli_wdr.cpp:3423
+msgid "Messages"
+msgstr "رسائل"
+
+#: src/amuleDlg.cpp:366 src/amuleDlg.cpp:1817 src/muuli_wdr.cpp:3424
+#: src/PrefsUnifiedDlg.cpp:312 src/Statistics.cpp:779 src/Statistics.cpp:1235
+msgid "Statistics"
+msgstr "احصائات"
+
+#: src/amuleDlg.cpp:368 src/amuleDlg.cpp:1824 src/muuli_wdr.cpp:3426
+#: src/PrefsUnifiedDlg.cpp:328 src/utils/wxCas/src/wxcasprefs.cpp:39
+msgid "Preferences"
+msgstr "اعدادت"
+
+#: src/amuleDlg.cpp:371
+msgid "Navigate"
+msgstr ""
+
+#: src/amuleDlg.cpp:657
 #, fuzzy
 msgid "New version available"
 msgstr "غير متوفر"
 
-#: src/amuleDlg.cpp:596
+#: src/amuleDlg.cpp:661
 #, c-format
 msgid ""
 "A new version of aMule (%s) is available.\n"
@@ -587,222 +625,189 @@ msgid ""
 "Would you like to open the download page?"
 msgstr ""
 
-#: src/amuleDlg.cpp:678
+#: src/amuleDlg.cpp:743
 msgid "aMule dialog destroyed"
 msgstr ""
 
-#: src/amuleDlg.cpp:701 src/DataToText.cpp:68 src/IPFilter.cpp:547
+#: src/amuleDlg.cpp:766 src/DataToText.cpp:68 src/IPFilter.cpp:547
 msgid "Connecting"
 msgstr "يتم الإتصال"
 
-#: src/amuleDlg.cpp:893
+#: src/amuleDlg.cpp:958
 msgid "eD2k: Connecting"
 msgstr ""
 
-#: src/amuleDlg.cpp:897
+#: src/amuleDlg.cpp:962
 msgid "eD2k: Disconnected"
 msgstr ""
 
-#: src/amuleDlg.cpp:903
+#: src/amuleDlg.cpp:968
 msgid "Kad: Firewalled"
 msgstr ""
 
-#: src/amuleDlg.cpp:907
+#: src/amuleDlg.cpp:972
 #, fuzzy
 msgid "Kad: Connected"
 msgstr "متصل"
 
-#: src/amuleDlg.cpp:912
+#: src/amuleDlg.cpp:977
 #, fuzzy
 msgid "Kad: Connecting"
 msgstr "يتم الإتصال"
 
-#: src/amuleDlg.cpp:916
+#: src/amuleDlg.cpp:981
 msgid "Kad: Off"
 msgstr ""
 
-#: src/amuleDlg.cpp:964 src/DownloadListCtrl.cpp:505
+#: src/amuleDlg.cpp:1029 src/DownloadListCtrl.cpp:505
 #: src/DownloadListCtrl.cpp:749 src/FriendListCtrl.cpp:180
 #: src/muuli_wdr.cpp:731 src/muuli_wdr.cpp:782 src/muuli_wdr.cpp:846
-#: src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2224 src/muuli_wdr.cpp:2309
-#: src/muuli_wdr.cpp:3057 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
+#: src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2231 src/muuli_wdr.cpp:2316
+#: src/muuli_wdr.cpp:3064 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
 #: src/ServerListCtrl.cpp:606 src/TransferWnd.cpp:378
 #: src/utils/wxCas/src/wxcasprefs.cpp:235
 msgid "Cancel"
 msgstr "إلغاء"
 
-#: src/amuleDlg.cpp:965
+#: src/amuleDlg.cpp:1030
 #, fuzzy
 msgid "Stop the current connection attempts"
 msgstr "إيقاف محاولة اﻹتصال الحاليه"
 
-#: src/amuleDlg.cpp:970 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976
-#: src/muuli_wdr.cpp:2447
+#: src/amuleDlg.cpp:1035 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976
+#: src/muuli_wdr.cpp:2454
 msgid "Disconnect"
 msgstr "فصل"
 
-#: src/amuleDlg.cpp:971
+#: src/amuleDlg.cpp:1036
 #, fuzzy
 msgid "Disconnect from the currently connected networks"
 msgstr "فصل من المستضيف الحالي"
 
-#: src/amuleDlg.cpp:976 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979
-#: src/muuli_wdr.cpp:2602 src/muuli_wdr.cpp:3054 src/muuli_wdr.cpp:3409
+#: src/amuleDlg.cpp:1041 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979
+#: src/muuli_wdr.cpp:2609 src/muuli_wdr.cpp:3061 src/muuli_wdr.cpp:3416
 msgid "Connect"
 msgstr "إتصال"
 
-#: src/amuleDlg.cpp:977
+#: src/amuleDlg.cpp:1042
 msgid "Connect to the currently enabled networks"
 msgstr ""
 
-#: src/amuleDlg.cpp:1089
+#: src/amuleDlg.cpp:1154
 #, fuzzy, c-format
 msgid "Up: %.1f%s (%.1f) | Down: %.1f%s (%.1f)"
 msgstr "تحميل: %.1f(%.1f) | رفع: %.1f(%.1f)"
 
-#: src/amuleDlg.cpp:1091 src/amuleDlg.cpp:1093 src/amuleDlg.cpp:1097
-#: src/amuleDlg.cpp:1099 src/amuleDlg.cpp:1110 src/amuleDlg.cpp:1112
+#: src/amuleDlg.cpp:1156 src/amuleDlg.cpp:1158 src/amuleDlg.cpp:1162
+#: src/amuleDlg.cpp:1164 src/amuleDlg.cpp:1175 src/amuleDlg.cpp:1177
 #: src/MuleTrayIcon.cpp:796 src/MuleTrayIcon.cpp:799
 msgid " MB/s"
 msgstr ""
 
-#: src/amuleDlg.cpp:1091 src/amuleDlg.cpp:1093 src/amuleDlg.cpp:1097
-#: src/amuleDlg.cpp:1099 src/amuleDlg.cpp:1110 src/amuleDlg.cpp:1112
+#: src/amuleDlg.cpp:1156 src/amuleDlg.cpp:1158 src/amuleDlg.cpp:1162
+#: src/amuleDlg.cpp:1164 src/amuleDlg.cpp:1175 src/amuleDlg.cpp:1177
 #: src/MuleTrayIcon.cpp:796 src/MuleTrayIcon.cpp:799
 #: src/utils/wxCas/src/wxcasframe.cpp:1041
 msgid " kB/s"
 msgstr ""
 
-#: src/amuleDlg.cpp:1096
+#: src/amuleDlg.cpp:1161
 #, fuzzy, c-format
 msgid "Up: %.1f%s | Down: %.1f%s"
 msgstr "رفع : %.1f |تحميل : %.1f"
 
-#: src/amuleDlg.cpp:1128
+#: src/amuleDlg.cpp:1193
 #, c-format
 msgid "aMule (%s | Connected)"
 msgstr ""
 
-#: src/amuleDlg.cpp:1130
+#: src/amuleDlg.cpp:1195
 #, c-format
 msgid "aMule (%s | Disconnected)"
 msgstr ""
 
-#: src/amuleDlg.cpp:1183
+#: src/amuleDlg.cpp:1248
 #, fuzzy, c-format
 msgid "Do you really want to exit %s?"
 msgstr "هل تريد حقا الخروج من البرنامج؟"
 
-#: src/amuleDlg.cpp:1185
+#: src/amuleDlg.cpp:1250
 msgid "Exit confirmation"
 msgstr "تاكيد الخروج"
 
-#: src/amuleDlg.cpp:1548
+#: src/amuleDlg.cpp:1613
 msgid "Launch Command: "
 msgstr ""
 
-#: src/amuleDlg.cpp:1567 src/muuli_wdr.cpp:1971 src/Preferences.cpp:951
+#: src/amuleDlg.cpp:1632 src/muuli_wdr.cpp:1978 src/Preferences.cpp:952
 msgid "- default -"
 msgstr ""
 
-#: src/amuleDlg.cpp:1595
+#: src/amuleDlg.cpp:1660
 #, c-format
 msgid "Skin directory '%s' does not exist"
 msgstr ""
 
-#: src/amuleDlg.cpp:1598
+#: src/amuleDlg.cpp:1663
 #, c-format
 msgid "WARNING: Unable to open skin file '%s' for read"
 msgstr ""
 
-#: src/amuleDlg.cpp:1722 src/amuleDlg.cpp:1968 src/muuli_wdr.cpp:1485
-#: src/muuli_wdr.cpp:3411
-msgid "Networks"
-msgstr ""
-
-#: src/amuleDlg.cpp:1726 src/muuli_wdr.cpp:3411
+#: src/amuleDlg.cpp:1791 src/muuli_wdr.cpp:3418
 msgid "Networks Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1728 src/muuli_wdr.cpp:3412
-msgid "Searches"
-msgstr "بحث"
-
-#: src/amuleDlg.cpp:1732 src/muuli_wdr.cpp:3412
+#: src/amuleDlg.cpp:1797 src/muuli_wdr.cpp:3419
 msgid "Searches Window"
 msgstr "نافذة البحث"
 
-#: src/amuleDlg.cpp:1734 src/DownloadListCtrl.cpp:740 src/muuli_wdr.cpp:392
-#: src/muuli_wdr.cpp:1578 src/muuli_wdr.cpp:3413 src/Statistics.cpp:829
-msgid "Downloads"
-msgstr "تحميل"
-
-#: src/amuleDlg.cpp:1738 src/muuli_wdr.cpp:3413
+#: src/amuleDlg.cpp:1803 src/muuli_wdr.cpp:3420
 #, fuzzy
 msgid "Downloads Window"
 msgstr "تحميل"
 
-#: src/amuleDlg.cpp:1740 src/muuli_wdr.cpp:3287
-msgid "Shared files"
-msgstr ""
-
-#: src/amuleDlg.cpp:1744 src/muuli_wdr.cpp:3415
+#: src/amuleDlg.cpp:1809 src/muuli_wdr.cpp:3422
 msgid "Shared Files Window"
 msgstr "نافذة ملفات المشاركة"
 
-#: src/amuleDlg.cpp:1746 src/muuli_wdr.cpp:2919 src/muuli_wdr.cpp:3369
-#: src/muuli_wdr.cpp:3416
-msgid "Messages"
-msgstr "رسائل"
-
-#: src/amuleDlg.cpp:1750 src/muuli_wdr.cpp:3416
+#: src/amuleDlg.cpp:1815 src/muuli_wdr.cpp:3423
 msgid "Messages Window"
 msgstr "نافذة الرسائل"
 
-#: src/amuleDlg.cpp:1752 src/muuli_wdr.cpp:3417 src/PrefsUnifiedDlg.cpp:312
-#: src/Statistics.cpp:779 src/Statistics.cpp:1235
-msgid "Statistics"
-msgstr "احصائات"
-
-#: src/amuleDlg.cpp:1756 src/muuli_wdr.cpp:3417
+#: src/amuleDlg.cpp:1821 src/muuli_wdr.cpp:3424
 msgid "Statistics Graph Window"
 msgstr "نافذة اﻻحصائيات"
 
-#: src/amuleDlg.cpp:1759 src/muuli_wdr.cpp:3419 src/PrefsUnifiedDlg.cpp:328
-#: src/utils/wxCas/src/wxcasprefs.cpp:39
-msgid "Preferences"
-msgstr "اعدادت"
-
-#: src/amuleDlg.cpp:1763 src/muuli_wdr.cpp:3419
+#: src/amuleDlg.cpp:1828 src/muuli_wdr.cpp:3426
 msgid "Preferences Settings Window"
 msgstr "نافذة اﻹعدادات"
 
-#: src/amuleDlg.cpp:1766 src/muuli_wdr.cpp:3420
+#: src/amuleDlg.cpp:1831 src/muuli_wdr.cpp:3427
 msgid "Import"
 msgstr ""
 
-#: src/amuleDlg.cpp:1770 src/muuli_wdr.cpp:3420
+#: src/amuleDlg.cpp:1835 src/muuli_wdr.cpp:3427
 msgid "The partfile importer tool"
 msgstr ""
 
-#: src/amuleDlg.cpp:1773 src/muuli_wdr.cpp:3421
+#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3428
 #: src/utils/aLinkCreator/src/alcframe.cpp:262
 msgid "About"
 msgstr ""
 
-#: src/amuleDlg.cpp:1773 src/muuli_wdr.cpp:3421
+#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3428
 msgid "About/Help"
 msgstr ""
 
-#: src/amuleDlg.cpp:1971
+#: src/amuleDlg.cpp:2036
 msgid "eD2k network"
 msgstr ""
 
-#: src/amuleDlg.cpp:1974
+#: src/amuleDlg.cpp:2039
 msgid "Kad network"
 msgstr ""
 
-#: src/amuleDlg.cpp:1974
+#: src/amuleDlg.cpp:2039
 msgid "No network"
 msgstr ""
 
@@ -1338,19 +1343,19 @@ msgstr "ذاتي عالي"
 msgid "Very low"
 msgstr "متدني جدا"
 
-#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:743 src/muuli_wdr.cpp:2275
+#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:743 src/muuli_wdr.cpp:2282
 #: src/ServerListCtrl.cpp:263 src/ServerListCtrl.cpp:456
 #: src/SharedFilesCtrl.cpp:145
 msgid "Low"
 msgstr "متدني"
 
-#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:744 src/muuli_wdr.cpp:2276
+#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:744 src/muuli_wdr.cpp:2283
 #: src/ServerListCtrl.cpp:266 src/ServerListCtrl.cpp:457
 #: src/SharedFilesCtrl.cpp:146
 msgid "Normal"
 msgstr "عادي"
 
-#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:745 src/muuli_wdr.cpp:2277
+#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:745 src/muuli_wdr.cpp:2284
 #: src/ServerListCtrl.cpp:269 src/ServerListCtrl.cpp:458
 #: src/SharedFilesCtrl.cpp:147
 msgid "High"
@@ -1442,8 +1447,8 @@ msgstr ""
 msgid "Remote Server"
 msgstr ""
 
-#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3174
-#: src/SearchDlg.cpp:111 src/TextClient.cpp:911
+#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3181
+#: src/SearchDlg.cpp:119 src/TextClient.cpp:911
 msgid "Kad"
 msgstr ""
 
@@ -1513,7 +1518,7 @@ msgstr ""
 msgid "Size"
 msgstr "حجم"
 
-#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3241
+#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3248
 msgid "Transferred"
 msgstr "نقل"
 
@@ -1571,7 +1576,7 @@ msgid ""
 "\n"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:746 src/muuli_wdr.cpp:2278
+#: src/DownloadListCtrl.cpp:746 src/muuli_wdr.cpp:2285
 #: src/SharedFilesCtrl.cpp:150
 msgid "Auto"
 msgstr "ذاتي"
@@ -1609,7 +1614,7 @@ msgid "Extended Options"
 msgstr "خيرات اضافية"
 
 #: src/DownloadListCtrl.cpp:770 src/DownloadListCtrl.cpp:822
-#: src/muuli_wdr.cpp:1789
+#: src/muuli_wdr.cpp:1796
 msgid "Preview"
 msgstr "مشاهدة"
 
@@ -2289,19 +2294,19 @@ msgstr ""
 msgid "eD2k"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:349 src/muuli_wdr.cpp:1488
+#: src/FirstRunWizard.cpp:349 src/muuli_wdr.cpp:1495
 msgid "Kademlia"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:359 src/muuli_wdr.cpp:1416
+#: src/FirstRunWizard.cpp:359 src/muuli_wdr.cpp:1423
 msgid "Standard TCP Port "
 msgstr ""
 
-#: src/FirstRunWizard.cpp:365 src/muuli_wdr.cpp:1428
+#: src/FirstRunWizard.cpp:365 src/muuli_wdr.cpp:1435
 msgid "Extended UDP port (Kad / global search) "
 msgstr ""
 
-#: src/FirstRunWizard.cpp:377 src/muuli_wdr.cpp:1435
+#: src/FirstRunWizard.cpp:377 src/muuli_wdr.cpp:1442
 msgid "Enable UPnP for router port forwarding"
 msgstr ""
 
@@ -2327,7 +2332,7 @@ msgstr ""
 msgid "Your peer lists are already in place - nothing to download."
 msgstr "قمت بمحاولت تحميل الملف مسبقا %s"
 
-#: src/FirstRunWizard.cpp:434 src/muuli_wdr.cpp:1533
+#: src/FirstRunWizard.cpp:434 src/muuli_wdr.cpp:1540
 msgid "Auto-update server list at startup"
 msgstr ""
 
@@ -2373,23 +2378,23 @@ msgid ""
 "want downloads on a different (e.g. larger) disk."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:549 src/FirstRunWizard.cpp:611 src/muuli_wdr.cpp:1701
+#: src/FirstRunWizard.cpp:549 src/FirstRunWizard.cpp:611 src/muuli_wdr.cpp:1708
 msgid "Destination folder for downloads"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:553 src/FirstRunWizard.cpp:569 src/muuli_wdr.cpp:1342
-#: src/muuli_wdr.cpp:1359 src/muuli_wdr.cpp:1676 src/muuli_wdr.cpp:1707
-#: src/muuli_wdr.cpp:1719 src/muuli_wdr.cpp:2762
+#: src/FirstRunWizard.cpp:553 src/FirstRunWizard.cpp:569 src/muuli_wdr.cpp:1349
+#: src/muuli_wdr.cpp:1366 src/muuli_wdr.cpp:1683 src/muuli_wdr.cpp:1714
+#: src/muuli_wdr.cpp:1726 src/muuli_wdr.cpp:2769
 #: src/utils/aLinkCreator/src/alcframe.cpp:135
 #: src/utils/wxCas/src/wxcasprefs.cpp:52 src/utils/wxCas/src/wxcasprefs.cpp:118
 msgid "Browse"
 msgstr "تصفح"
 
-#: src/FirstRunWizard.cpp:559 src/muuli_wdr.cpp:1712
+#: src/FirstRunWizard.cpp:559 src/muuli_wdr.cpp:1719
 msgid "(All files in this folder are shared with other peers)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:565 src/FirstRunWizard.cpp:624 src/muuli_wdr.cpp:1714
+#: src/FirstRunWizard.cpp:565 src/FirstRunWizard.cpp:624 src/muuli_wdr.cpp:1721
 msgid "Folder for temporary download files"
 msgstr ""
 
@@ -2420,7 +2425,7 @@ msgstr ""
 msgid "CRITICAL - no client on StartChatSession"
 msgstr ""
 
-#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2668 src/muuli_wdr.cpp:3345
+#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2675 src/muuli_wdr.cpp:3352
 msgid "Friends"
 msgstr "اصدقاء"
 
@@ -2804,7 +2809,7 @@ msgstr ""
 msgid "Uploaded"
 msgstr ""
 
-#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3225
+#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3232
 msgid "Requested"
 msgstr ""
 
@@ -2929,7 +2934,7 @@ msgid "WARNING: "
 msgstr ""
 
 #: src/MuleNotebook.cpp:179 src/muuli_wdr.cpp:817 src/muuli_wdr.cpp:1229
-#: src/muuli_wdr.cpp:3129 src/muuli_wdr.cpp:3385
+#: src/muuli_wdr.cpp:3136 src/muuli_wdr.cpp:3392
 msgid "Close"
 msgstr "اغلق"
 
@@ -2942,12 +2947,12 @@ msgstr ""
 msgid "Copy"
 msgstr ""
 
-#: src/MuleTextCtrl.cpp:88
+#: src/MuleTextCtrl.cpp:88 src/SearchDlg.cpp:261
 msgid "Paste"
 msgstr ""
 
 #: src/MuleTextCtrl.cpp:89 src/muuli_wdr.cpp:358 src/muuli_wdr.cpp:757
-#: src/muuli_wdr.cpp:2352 src/muuli_wdr.cpp:2371 src/muuli_wdr.cpp:2393
+#: src/muuli_wdr.cpp:2359 src/muuli_wdr.cpp:2378 src/muuli_wdr.cpp:2400
 #: src/utils/aLinkCreator/src/alcframe.cpp:142
 msgid "Clear"
 msgstr "واضح"
@@ -3042,8 +3047,8 @@ msgid "Exit"
 msgstr "خروج"
 
 #: src/MuleTrayIcon.cpp:579 src/MuleTrayIcon.cpp:945 src/MuleTrayIcon.cpp:965
-#: src/muuli_wdr.cpp:1391 src/muuli_wdr.cpp:1399 src/muuli_wdr.cpp:1406
-#: src/muuli_wdr.cpp:1835 src/muuli_wdr.cpp:1841 src/OtherFunctions.cpp:91
+#: src/muuli_wdr.cpp:1398 src/muuli_wdr.cpp:1406 src/muuli_wdr.cpp:1413
+#: src/muuli_wdr.cpp:1842 src/muuli_wdr.cpp:1848 src/OtherFunctions.cpp:91
 #: src/StatisticsDlg.cpp:93 src/StatisticsDlg.cpp:95
 msgid "kB/s"
 msgstr ""
@@ -3213,7 +3218,7 @@ msgstr ""
 msgid "Type"
 msgstr "نوع"
 
-#: src/muuli_wdr.cpp:215 src/SearchDlg.cpp:110 src/SearchListCtrl.cpp:853
+#: src/muuli_wdr.cpp:215 src/SearchDlg.cpp:118 src/SearchListCtrl.cpp:853
 msgid "Local"
 msgstr ""
 
@@ -3284,7 +3289,7 @@ msgstr "بايت"
 msgid "KB"
 msgstr ""
 
-#: src/muuli_wdr.cpp:274 src/muuli_wdr.cpp:293 src/muuli_wdr.cpp:1620
+#: src/muuli_wdr.cpp:274 src/muuli_wdr.cpp:293 src/muuli_wdr.cpp:1627
 #: src/OtherFunctions.cpp:64
 msgid "MB"
 msgstr ""
@@ -3301,7 +3306,7 @@ msgstr "اكبر حجم"
 msgid "Availability"
 msgstr ""
 
-#: src/muuli_wdr.cpp:312 src/muuli_wdr.cpp:398 src/muuli_wdr.cpp:3290
+#: src/muuli_wdr.cpp:312 src/muuli_wdr.cpp:398 src/muuli_wdr.cpp:3297
 msgid "Filter:"
 msgstr ""
 
@@ -3333,7 +3338,7 @@ msgstr ""
 msgid "Stop"
 msgstr ""
 
-#: src/muuli_wdr.cpp:348 src/muuli_wdr.cpp:1385 src/SearchListCtrl.cpp:732
+#: src/muuli_wdr.cpp:348 src/muuli_wdr.cpp:1392 src/SearchListCtrl.cpp:732
 msgid "Download"
 msgstr "التحميل"
 
@@ -3365,8 +3370,8 @@ msgstr "ايجاد المصدر :"
 #: src/muuli_wdr.cpp:1160 src/muuli_wdr.cpp:1167 src/muuli_wdr.cpp:1172
 #: src/muuli_wdr.cpp:1179 src/muuli_wdr.cpp:1184 src/muuli_wdr.cpp:1191
 #: src/muuli_wdr.cpp:1205 src/muuli_wdr.cpp:1212 src/muuli_wdr.cpp:1217
-#: src/muuli_wdr.cpp:1224 src/muuli_wdr.cpp:3227 src/muuli_wdr.cpp:3235
-#: src/muuli_wdr.cpp:3243
+#: src/muuli_wdr.cpp:1224 src/muuli_wdr.cpp:3234 src/muuli_wdr.cpp:3242
+#: src/muuli_wdr.cpp:3250
 msgid "N/A"
 msgstr "غير متوفر"
 
@@ -3509,7 +3514,7 @@ msgstr ""
 msgid "Album :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:685 src/muuli_wdr.cpp:2247
+#: src/muuli_wdr.cpp:685 src/muuli_wdr.cpp:2254
 msgid "Title :"
 msgstr "عنوان :"
 
@@ -3615,7 +3620,7 @@ msgstr "اسم المستخدم :"
 msgid "Userhash :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:895 src/muuli_wdr.cpp:1741 src/muuli_wdr.cpp:2442
+#: src/muuli_wdr.cpp:895 src/muuli_wdr.cpp:1748 src/muuli_wdr.cpp:2449
 #: src/utils/aLinkCreator/src/alcframe.cpp:137
 msgid "Add"
 msgstr "اضف"
@@ -3624,15 +3629,15 @@ msgstr "اضف"
 msgid "Download-Speed"
 msgstr "سرعة-التحميل"
 
-#: src/muuli_wdr.cpp:954 src/muuli_wdr.cpp:989 src/muuli_wdr.cpp:2546
+#: src/muuli_wdr.cpp:954 src/muuli_wdr.cpp:989 src/muuli_wdr.cpp:2553
 msgid "Current"
 msgstr "الحالي"
 
-#: src/muuli_wdr.cpp:962 src/muuli_wdr.cpp:997 src/muuli_wdr.cpp:2554
+#: src/muuli_wdr.cpp:962 src/muuli_wdr.cpp:997 src/muuli_wdr.cpp:2561
 msgid "Running average"
 msgstr "معدل العمل"
 
-#: src/muuli_wdr.cpp:970 src/muuli_wdr.cpp:1005 src/muuli_wdr.cpp:2562
+#: src/muuli_wdr.cpp:970 src/muuli_wdr.cpp:1005 src/muuli_wdr.cpp:2569
 msgid "Session average"
 msgstr "معدل الجلسة"
 
@@ -3644,7 +3649,7 @@ msgstr "سرعة-الرفع"
 msgid "Connections"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1024 src/muuli_wdr.cpp:1860
+#: src/muuli_wdr.cpp:1024 src/muuli_wdr.cpp:1867
 msgid "Active downloads"
 msgstr "تحميل نشط"
 
@@ -3652,7 +3657,7 @@ msgstr "تحميل نشط"
 msgid "Active connections (1:1)"
 msgstr "إتصال نشط (1:1)"
 
-#: src/muuli_wdr.cpp:1040 src/muuli_wdr.cpp:1861
+#: src/muuli_wdr.cpp:1040 src/muuli_wdr.cpp:1868
 msgid "Active uploads"
 msgstr "رفع نشط"
 
@@ -3769,8 +3774,8 @@ msgstr ""
 msgid "Language: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1257 src/muuli_wdr.cpp:1323 src/muuli_wdr.cpp:1327
-#: src/muuli_wdr.cpp:1330
+#: src/muuli_wdr.cpp:1257 src/muuli_wdr.cpp:1330 src/muuli_wdr.cpp:1334
+#: src/muuli_wdr.cpp:1337
 msgid "The delay before showing tool-tips."
 msgstr ""
 
@@ -3846,929 +3851,937 @@ msgstr ""
 msgid "Enabling this will make aMule to show notifications when finished downloading."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1322
-msgid "Tooltip delay time: "
+#: src/muuli_wdr.cpp:1323
+msgid "Remember search history"
+msgstr ""
+
+#: src/muuli_wdr.cpp:1324
+msgid "Keeps a dropdown list of your past search terms in the Search tab's Name field. This remembers the queries you typed, not the results they returned."
 msgstr ""
 
 #: src/muuli_wdr.cpp:1329
+msgid "Tooltip delay time: "
+msgstr ""
+
+#: src/muuli_wdr.cpp:1336
 msgid "seconds"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1333
+#: src/muuli_wdr.cpp:1340
 msgid "Browser Selection"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1339
+#: src/muuli_wdr.cpp:1346
 msgid "Enter your browser name here. Leave this field empty to use the system default browser."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1346
+#: src/muuli_wdr.cpp:1353
 msgid "Open in new tab if possible"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1348
+#: src/muuli_wdr.cpp:1355
 msgid "Open the web page in a new tab instead of in a new window when possible"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1352
+#: src/muuli_wdr.cpp:1359
 msgid "Video Player"
 msgstr "مشغل الفيديو"
 
-#: src/muuli_wdr.cpp:1379
+#: src/muuli_wdr.cpp:1386
 msgid "Bandwidth limits"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1393
+#: src/muuli_wdr.cpp:1400
 msgid "Upload"
 msgstr "الرفع"
 
-#: src/muuli_wdr.cpp:1401
+#: src/muuli_wdr.cpp:1408
 msgid "Slot Allocation"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1410
+#: src/muuli_wdr.cpp:1417
 msgid "Ports"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1420
+#: src/muuli_wdr.cpp:1427
 msgid "This is the standard eD2k port and cannot be disabled."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1423
+#: src/muuli_wdr.cpp:1430
 msgid "UDP port for server requests (TCP+3):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1425
+#: src/muuli_wdr.cpp:1432
 msgid "4665"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1432
+#: src/muuli_wdr.cpp:1439
 msgid "This UDP port is used for extended eD2k requests and Kad network"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1439
+#: src/muuli_wdr.cpp:1446
 msgid "UPnP TCP Port (Optional):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1449
+#: src/muuli_wdr.cpp:1456
 msgid "Bind local address to IP (empty for any):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1452
+#: src/muuli_wdr.cpp:1459
 msgid "Advanced users only: If you have multiple network interfaces, enter the address of the interface to which aMule should be bound."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1455 src/muuli_wdr.cpp:2054
+#: src/muuli_wdr.cpp:1462 src/muuli_wdr.cpp:2061
 msgid "Bind to network interface (empty for any):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1468
+#: src/muuli_wdr.cpp:1475
 msgid "Advanced users only: pin all of aMule's traffic to one network interface, chosen from the list or typed in by name (e.g. tun0, eth0, en0) or index. Unlike binding to an IP, this stops traffic leaking out via the default route - useful with a VPN. Requires no elevated privileges."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1474
+#: src/muuli_wdr.cpp:1481
 msgid "Max sources per downloading file:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1478
+#: src/muuli_wdr.cpp:1485
 msgid "Max simultaneous connections:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1491 src/muuli_wdr.cpp:3169
+#: src/muuli_wdr.cpp:1498 src/muuli_wdr.cpp:3176
 msgid "ED2K"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1498
+#: src/muuli_wdr.cpp:1505
 msgid "Autoconnect on startup"
 msgstr "ربط تلقائي عند بدء التشغيل"
 
-#: src/muuli_wdr.cpp:1501
+#: src/muuli_wdr.cpp:1508
 msgid "Reconnect on loss"
 msgstr "إعادة اﻹتصال عند الفصل"
 
-#: src/muuli_wdr.cpp:1523
+#: src/muuli_wdr.cpp:1530
 msgid "Remove dead server after"
 msgstr "إحذ الخادمات التي ﻻ تعمل بعد"
 
-#: src/muuli_wdr.cpp:1524
+#: src/muuli_wdr.cpp:1531
 msgid "Static servers are never removed, even when unreachable."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1528
+#: src/muuli_wdr.cpp:1535
 msgid "retries"
 msgstr "أعد المحاولة"
 
-#: src/muuli_wdr.cpp:1536
+#: src/muuli_wdr.cpp:1543
 msgid "List"
 msgstr "قائمة"
 
-#: src/muuli_wdr.cpp:1539
+#: src/muuli_wdr.cpp:1546
 msgid "Update server list when connecting to a server"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1542
+#: src/muuli_wdr.cpp:1549
 msgid "Update server list when a client connects"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1545
+#: src/muuli_wdr.cpp:1552
 msgid "Use priority system"
 msgstr "إستخدم نظام اﻷولوية"
 
-#: src/muuli_wdr.cpp:1549
+#: src/muuli_wdr.cpp:1556
 msgid "Use smart LowID check on connect"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1553
+#: src/muuli_wdr.cpp:1560
 msgid "Safe connect"
 msgstr "إتصال أمن"
 
-#: src/muuli_wdr.cpp:1557
+#: src/muuli_wdr.cpp:1564
 msgid "Autoconnect to servers in static list only"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1560
+#: src/muuli_wdr.cpp:1567
 msgid "Set manually added servers to High Priority"
 msgstr "جعل الخادمات المضافة يدويا ذو اولوية عالية"
 
-#: src/muuli_wdr.cpp:1581
+#: src/muuli_wdr.cpp:1588
 msgid "Add files to download in pause mode"
 msgstr "أضف الملفات للتحميل بوضع متوقف"
 
-#: src/muuli_wdr.cpp:1583
+#: src/muuli_wdr.cpp:1590
 msgid "Add files to download with auto priority"
 msgstr "أضف الملفات للتحميل بوضع ذاتي"
 
-#: src/muuli_wdr.cpp:1586
+#: src/muuli_wdr.cpp:1593
 msgid "Try to download first and last chunks first"
 msgstr "حاول تحميل القطع اﻻولى واﻻخيرة اوﻻ"
 
-#: src/muuli_wdr.cpp:1590
+#: src/muuli_wdr.cpp:1597
 msgid "Endgame mode: rotate to faster sources for the final blocks"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1593
+#: src/muuli_wdr.cpp:1600
 msgid "Start next paused file when a file completes"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1596
+#: src/muuli_wdr.cpp:1603
 msgid "From the same category"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1598
+#: src/muuli_wdr.cpp:1605
 msgid "In alphabetic order"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1600
+#: src/muuli_wdr.cpp:1607
 msgid "Preallocate disk space for new files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1601
+#: src/muuli_wdr.cpp:1608
 msgid "For new files preallocates disk space for the whole file, thus reduces fragmentation"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1606
+#: src/muuli_wdr.cpp:1613
 msgid "Create new files as sparse files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1607
+#: src/muuli_wdr.cpp:1614
 msgid "A sparse file reserves its full size on disk immediately without writing real data to it -- fast, but unsupported or slow on some filesystems, and free-space accounting stays optimistic while the download is in progress. Turn this off to grow the file only as data arrives."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1612
+#: src/muuli_wdr.cpp:1619
 msgid "Stop downloads when free disk space reaches "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1613
+#: src/muuli_wdr.cpp:1620
 msgid "Select this if you want aMule to check your disk space"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1617
+#: src/muuli_wdr.cpp:1624
 msgid "Enter here the min disk space desired."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1623
+#: src/muuli_wdr.cpp:1630
 msgid "Save 10 sources on rare files (< 20 sources)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1627 src/Statistics.cpp:790
+#: src/muuli_wdr.cpp:1634 src/Statistics.cpp:790
 msgid "Uploads"
 msgstr "ارفع"
 
-#: src/muuli_wdr.cpp:1630
+#: src/muuli_wdr.cpp:1637
 msgid "Add new shared files with auto priority"
 msgstr "أضف ملفات مشاركة جديدة بوضع ذاتي"
 
-#: src/muuli_wdr.cpp:1636
+#: src/muuli_wdr.cpp:1643
 msgid "Intelligent Corruption Handling (I.C.H.)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1639
+#: src/muuli_wdr.cpp:1646
 msgid "Enable"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1642
+#: src/muuli_wdr.cpp:1649
 msgid "Advanced I.C.H. trusts every hash (not recommended)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1654 src/PrefsUnifiedDlg.cpp:1910
+#: src/muuli_wdr.cpp:1661 src/PrefsUnifiedDlg.cpp:1910
 msgid "Media metadata extraction"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1658
+#: src/muuli_wdr.cpp:1665
 msgid "Extract length / bitrate / codec from shared audio and video files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1660
+#: src/muuli_wdr.cpp:1667
 msgid "When enabled, aMule runs ffprobe on each shared media file to fill in the Length / Bitrate / Codec columns other clients see when they find the file in a search. Requires ffmpeg (the ffprobe binary) to be installed."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1667
+#: src/muuli_wdr.cpp:1674
 msgid "Path to ffprobe:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1672
+#: src/muuli_wdr.cpp:1679
 msgid "Full path to the ffprobe binary. Leave empty to have aMule auto-detect it on startup."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1680
+#: src/muuli_wdr.cpp:1687
 msgid "Detect"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1681
+#: src/muuli_wdr.cpp:1688
 msgid "Search the standard install locations for an ffprobe binary and fill the path field."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1705
+#: src/muuli_wdr.cpp:1712
 msgid ""
 "Completed downloads are stored here. All files in this folder are automatically shared with other peers.\n"
 "If this folder also holds files you don't want to share, point it at an aMule-only sub-folder."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1708
+#: src/muuli_wdr.cpp:1715
 msgid "Pick the folder where completed downloads will be stored. All files in that folder will be shared with other peers."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1722
+#: src/muuli_wdr.cpp:1729
 msgid "Shared folders"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1728
+#: src/muuli_wdr.cpp:1735
 msgid "(Folders shared by the core. Enter a path to add one.)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1736
+#: src/muuli_wdr.cpp:1743
 msgid "Absolute path of a folder on the core's machine, e.g. /home/user/shared"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1738 src/PrefsUnifiedDlg.cpp:2794
+#: src/muuli_wdr.cpp:1745 src/PrefsUnifiedDlg.cpp:2794
 msgid "Recursive"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1739
+#: src/muuli_wdr.cpp:1746
 msgid "Share every sub-folder underneath this one, including ones created later."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1743 src/utils/aLinkCreator/src/alcframe.cpp:141
+#: src/muuli_wdr.cpp:1750 src/utils/aLinkCreator/src/alcframe.cpp:141
 msgid "Remove"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1747
+#: src/muuli_wdr.cpp:1754
 msgid "(Right click on folder icon for recursive share)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1754
+#: src/muuli_wdr.cpp:1761
 msgid "Share hidden files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1760
+#: src/muuli_wdr.cpp:1767
 msgid "Automatically rescan shared folders for changes"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1766
+#: src/muuli_wdr.cpp:1773
 msgid "Follow symbolic links in shared folders"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1772
+#: src/muuli_wdr.cpp:1779
 msgid "Exclude files matching:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1775
+#: src/muuli_wdr.cpp:1782
 msgid "Wildcard patterns separated by '|', e.g. .DS_Store|Thumbs.db|*.tmp. Files whose name matches are not shared. Matching is case-insensitive."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1779
+#: src/muuli_wdr.cpp:1786
 msgid "Patterns are regular expressions"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1780
+#: src/muuli_wdr.cpp:1787
 msgid "When set, the whole field is one regular expression ('|' is alternation). When unset, it is a list of '|'-separated wildcards."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1790
+#: src/muuli_wdr.cpp:1797
 msgid "Show how many shared files the current pattern would exclude."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1811
+#: src/muuli_wdr.cpp:1818
 msgid "Graphs"
 msgstr "رسم بياني"
 
-#: src/muuli_wdr.cpp:1814 src/muuli_wdr.cpp:1876
+#: src/muuli_wdr.cpp:1821 src/muuli_wdr.cpp:1883
 msgid "Update delay : 5 secs"
 msgstr "تحيدث كل:5 ثواني"
 
-#: src/muuli_wdr.cpp:1818
+#: src/muuli_wdr.cpp:1825
 msgid "Time for average graph: 100 mins"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1822
+#: src/muuli_wdr.cpp:1829
 msgid "Connections Graph Scale: 100 "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1829
+#: src/muuli_wdr.cpp:1836
 msgid "Download graph scale:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1837
+#: src/muuli_wdr.cpp:1844
 msgid "Upload graph scale:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1847
+#: src/muuli_wdr.cpp:1854
 msgid "Colors: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1851
+#: src/muuli_wdr.cpp:1858
 msgid "Background"
 msgstr "خلفية"
 
-#: src/muuli_wdr.cpp:1852
+#: src/muuli_wdr.cpp:1859
 msgid "Grid"
 msgstr "شبكة"
 
-#: src/muuli_wdr.cpp:1853
+#: src/muuli_wdr.cpp:1860
 msgid "Download current"
 msgstr "حمل الحالي"
 
-#: src/muuli_wdr.cpp:1854
+#: src/muuli_wdr.cpp:1861
 msgid "Download running average"
 msgstr "معدل تحميل الحالي"
 
-#: src/muuli_wdr.cpp:1855
+#: src/muuli_wdr.cpp:1862
 msgid "Download session average"
 msgstr "معدل تحميل الجلسة"
 
-#: src/muuli_wdr.cpp:1856
+#: src/muuli_wdr.cpp:1863
 msgid "Upload current"
 msgstr "ارفع الحالي"
 
-#: src/muuli_wdr.cpp:1857
+#: src/muuli_wdr.cpp:1864
 msgid "Upload running average"
 msgstr "معدل رفع الحالي"
 
-#: src/muuli_wdr.cpp:1858
+#: src/muuli_wdr.cpp:1865
 msgid "Upload session average"
 msgstr "معدل رفع الجلسة"
 
-#: src/muuli_wdr.cpp:1859
+#: src/muuli_wdr.cpp:1866
 msgid "Active connections"
 msgstr "اتصال نشط"
 
-#: src/muuli_wdr.cpp:1862
+#: src/muuli_wdr.cpp:1869
 msgid "Systray Icon Speed Bar"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1863
+#: src/muuli_wdr.cpp:1870
 msgid "Kad-nodes current"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1864
+#: src/muuli_wdr.cpp:1871
 msgid "Kad-nodes running"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1865
+#: src/muuli_wdr.cpp:1872
 msgid "Kad-nodes session"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1869 src/muuli_wdr.cpp:2296
+#: src/muuli_wdr.cpp:1876 src/muuli_wdr.cpp:2303
 msgid "Select"
 msgstr "اختر"
 
-#: src/muuli_wdr.cpp:1873
+#: src/muuli_wdr.cpp:1880
 msgid "Tree"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1883
+#: src/muuli_wdr.cpp:1890
 msgid "Number of Client Versions shown (0=unlimited)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1908
+#: src/muuli_wdr.cpp:1915
 msgid "!!! WARNING !!!"
 msgstr "!!!تحذير!!!"
 
-#: src/muuli_wdr.cpp:1923
+#: src/muuli_wdr.cpp:1930
 msgid "Max new connections / 5 secs"
 msgstr "الحد اﻷعلى للتصالات لكل 5 ثواني"
 
-#: src/muuli_wdr.cpp:1925
+#: src/muuli_wdr.cpp:1932
 msgid "Concurrent Kad source lookups"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1927
+#: src/muuli_wdr.cpp:1934
 msgid "Kad source re-search interval (minutes)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1929
+#: src/muuli_wdr.cpp:1936
 #, fuzzy
 msgid "Source re-ask interval (minutes)"
 msgstr "فترة تحديث الإتصال بالخادم %i دقيقة"
 
-#: src/muuli_wdr.cpp:1933
+#: src/muuli_wdr.cpp:1940
 msgid "File Buffer Size: 240000 bytes"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1937
+#: src/muuli_wdr.cpp:1944
 msgid "Use MMAP: memory-mapped file access (lower memory use)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1938
+#: src/muuli_wdr.cpp:1945
 msgid "Maps part files into memory instead of buffering them on the heap, lowering the process memory footprint. May reduce download speed on some disks; best for memory-constrained or upload-heavy hosts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1940
+#: src/muuli_wdr.cpp:1947
 msgid "Upload Queue Size: 5000 clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1944
+#: src/muuli_wdr.cpp:1951
 msgid "Server connection refresh interval: Disable"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1948
+#: src/muuli_wdr.cpp:1955
 msgid "Disable computer's timed standby mode"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1967
+#: src/muuli_wdr.cpp:1974
 msgid "Skin to use: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1976
+#: src/muuli_wdr.cpp:1983
 msgid "Show \"Fast eD2k Links Handler\" in every window."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1979
+#: src/muuli_wdr.cpp:1986
 msgid "Show extended info on categories tabs"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1982
+#: src/muuli_wdr.cpp:1989
 #, fuzzy
 msgid "Show application version on title"
 msgstr "اظهر معدل النقل علي العنوان"
 
-#: src/muuli_wdr.cpp:1984
+#: src/muuli_wdr.cpp:1991
 msgid "Show transfer rates on title"
 msgstr "اظهر معدل النقل علي العنوان"
 
-#: src/muuli_wdr.cpp:1986
+#: src/muuli_wdr.cpp:1993
 msgid "Before application name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1988
+#: src/muuli_wdr.cpp:1995
 msgid "After application name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1991
+#: src/muuli_wdr.cpp:1998
 msgid "Show overhead bandwidth"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1995
+#: src/muuli_wdr.cpp:2002
 msgid "Vertical toolbar orientation"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1997
+#: src/muuli_wdr.cpp:2004
 msgid "Live column sorting (auto-reorder rows as their values change)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2004
+#: src/muuli_wdr.cpp:2011
 msgid "Download Queue Files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2007
+#: src/muuli_wdr.cpp:2014
 msgid "Show progress percentage"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2013
+#: src/muuli_wdr.cpp:2020
 msgid "Show progress bar"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2016
+#: src/muuli_wdr.cpp:2023
 msgid "Flat"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2020
+#: src/muuli_wdr.cpp:2027
 msgid "Round"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2038
+#: src/muuli_wdr.cpp:2045
 msgid "External Connection Parameters"
 msgstr "عوامل اﻻتصال الخارجي"
 
-#: src/muuli_wdr.cpp:2041
+#: src/muuli_wdr.cpp:2048
 msgid "Accept external connections"
 msgstr "اقبل اتصال خارجي"
 
-#: src/muuli_wdr.cpp:2048 src/muuli_wdr.cpp:2107
+#: src/muuli_wdr.cpp:2055 src/muuli_wdr.cpp:2114
 msgid "IP of the listening interface:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2051
+#: src/muuli_wdr.cpp:2058
 msgid "Enter here a valid ip in the a.b.c.d format for the listening EC interface. An empty field or 0.0.0.0 will mean any interface."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2072 src/muuli_wdr.cpp:2156
+#: src/muuli_wdr.cpp:2079 src/muuli_wdr.cpp:2163
 msgid "TCP port:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2078
+#: src/muuli_wdr.cpp:2085
 msgid "Enable UPnP port forwarding on the EC port"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2082 src/muuli_wdr.cpp:3041
+#: src/muuli_wdr.cpp:2089 src/muuli_wdr.cpp:3048
 #: src/utils/wxCas/src/wxcasprefs.cpp:167
 msgid "Password"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2088
+#: src/muuli_wdr.cpp:2095
 msgid "aMule API server parameters"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2091
+#: src/muuli_wdr.cpp:2098
 msgid "Run amuleapi (REST API) on startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2096
+#: src/muuli_wdr.cpp:2103
 msgid "HTTP port:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2110
+#: src/muuli_wdr.cpp:2117
 msgid "The interface amuleapi's HTTP server listens on. 127.0.0.1 (default) accepts only local connections; use 0.0.0.0 or a specific IP to expose it to other hosts (set an admin password below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2113
+#: src/muuli_wdr.cpp:2120
 msgid "Admin password"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2118 src/muuli_wdr.cpp:2149
+#: src/muuli_wdr.cpp:2125 src/muuli_wdr.cpp:2156
 msgid "Low rights password"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2126
+#: src/muuli_wdr.cpp:2133
 msgid "Web server parameters"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2129
+#: src/muuli_wdr.cpp:2136
 msgid "Run webserver on startup (deprecated)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2135
+#: src/muuli_wdr.cpp:2142
 msgid "Web template"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2140
+#: src/muuli_wdr.cpp:2147
 msgid "Full rights password"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2144
+#: src/muuli_wdr.cpp:2151
 msgid "Enable Low rights User"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2163
+#: src/muuli_wdr.cpp:2170
 msgid "Enable UPnP port forwarding of the web server port"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2168
+#: src/muuli_wdr.cpp:2175
 msgid "Web server UPnP TCP port (Optional)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2176
+#: src/muuli_wdr.cpp:2183
 msgid "Page Refresh Time (in secs)"
 msgstr "زمن تحديث الصفحة (بالثانية)"
 
-#: src/muuli_wdr.cpp:2183
+#: src/muuli_wdr.cpp:2190
 msgid "Enable Gzip compression"
 msgstr " Gzipتمكين ضغط نوع"
 
-#: src/muuli_wdr.cpp:2217
+#: src/muuli_wdr.cpp:2224
 #, fuzzy
 msgid "Reset page to defaults"
 msgstr "اﻹفتراضية بالنظام"
 
-#: src/muuli_wdr.cpp:2218
+#: src/muuli_wdr.cpp:2225
 msgid "Reset the settings on the current page to their default values."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2220 src/muuli_wdr.cpp:2306 src/ServerWnd.cpp:274
+#: src/muuli_wdr.cpp:2227 src/muuli_wdr.cpp:2313 src/ServerWnd.cpp:274
 #: src/ServerWnd.cpp:282
 msgid "OK"
 msgstr "موافق"
 
-#: src/muuli_wdr.cpp:2222
+#: src/muuli_wdr.cpp:2229
 msgid "Click here to apply any changes made to the preferences."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2225
+#: src/muuli_wdr.cpp:2232
 msgid "Reset any changes made to the preferences."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2254
+#: src/muuli_wdr.cpp:2261
 msgid "Comment :"
 msgstr "تعليق :"
 
-#: src/muuli_wdr.cpp:2261
+#: src/muuli_wdr.cpp:2268
 msgid "Incoming Dir :"
 msgstr "مجلد القادم"
 
-#: src/muuli_wdr.cpp:2270
+#: src/muuli_wdr.cpp:2277
 msgid "Change priority for new assigned files :"
 msgstr "تغير الأولوية للملفات الحديثة :"
 
-#: src/muuli_wdr.cpp:2274
+#: src/muuli_wdr.cpp:2281
 #, fuzzy
 msgid "Don't change"
 msgstr "ﻻ تغير"
 
-#: src/muuli_wdr.cpp:2286
+#: src/muuli_wdr.cpp:2293
 msgid "Select color for this Category (currently selected) :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2353 src/muuli_wdr.cpp:2372 src/muuli_wdr.cpp:2394
+#: src/muuli_wdr.cpp:2360 src/muuli_wdr.cpp:2379 src/muuli_wdr.cpp:2401
 msgid "Click this button to reset the log."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2413
+#: src/muuli_wdr.cpp:2420
 msgid "Click on this button to update the servers list from URL ..."
 msgstr "قم بالضغط على هذا الزر لتحديث قائمة الخادمات من العنوان ..."
 
-#: src/muuli_wdr.cpp:2417
+#: src/muuli_wdr.cpp:2424
 msgid "Server list"
 msgstr "قائمة الخادمات"
 
-#: src/muuli_wdr.cpp:2421
+#: src/muuli_wdr.cpp:2428
 msgid "Enter the url to a server.met file here and press the button to the left to update the list of known servers."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2426
+#: src/muuli_wdr.cpp:2433
 msgid "Add server manually: Name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2429
+#: src/muuli_wdr.cpp:2436
 msgid "Enter the name of the new server here"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2431 src/ServerWnd.cpp:206
+#: src/muuli_wdr.cpp:2438 src/ServerWnd.cpp:206
 msgid "IP:Port"
 msgstr "عنوان شبكي :منفذ"
 
-#: src/muuli_wdr.cpp:2434
+#: src/muuli_wdr.cpp:2441
 msgid "Enter the IP of the server here, using the x.x.x.x format."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2440
+#: src/muuli_wdr.cpp:2447
 msgid "Enter the port of the server here."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2443
+#: src/muuli_wdr.cpp:2450
 msgid "Add manually a server (fill fields to the left before) ..."
 msgstr "اضف خادم يدويا )قم بمل الخانة على اليسار اوﻻ)..."
 
-#: src/muuli_wdr.cpp:2472
+#: src/muuli_wdr.cpp:2479
 msgid "aMule Log"
 msgstr "سجل aMule"
 
-#: src/muuli_wdr.cpp:2480
+#: src/muuli_wdr.cpp:2487
 msgid "Server Info"
 msgstr "معلومات الخادم"
 
-#: src/muuli_wdr.cpp:2484
+#: src/muuli_wdr.cpp:2491
 msgid "ED2K Info"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2488
+#: src/muuli_wdr.cpp:2495
 msgid "Kad Info"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2516
+#: src/muuli_wdr.cpp:2523
 msgid "Click on this button to update the nodes list from URL ..."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2520
+#: src/muuli_wdr.cpp:2527
 msgid "Nodes (0)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2524
+#: src/muuli_wdr.cpp:2531
 msgid "Enter the url to a nodes.dat file here and press the button to the left to update the list of known nodes."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2527
+#: src/muuli_wdr.cpp:2534
 msgid "Nodes stats"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2569
+#: src/muuli_wdr.cpp:2576
 msgid "Bootstrap"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2572
+#: src/muuli_wdr.cpp:2579
 msgid "New node"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2577
+#: src/muuli_wdr.cpp:2584
 msgid "IP:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2597
+#: src/muuli_wdr.cpp:2604
 msgid "Port:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2610
+#: src/muuli_wdr.cpp:2617
 msgid "Bootstrap from known clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2612
+#: src/muuli_wdr.cpp:2619
 msgid "Disconnect Kad"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2646
+#: src/muuli_wdr.cpp:2653
 msgid "Use Secure User Identification"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2648
+#: src/muuli_wdr.cpp:2655
 msgid "It is recommended to enable this option. You will not receive credits if SUI is not enabled."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2650
+#: src/muuli_wdr.cpp:2657
 msgid "Protocol Obfuscation"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2653
+#: src/muuli_wdr.cpp:2660
 msgid "Support Protocol Obfuscation"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2655
+#: src/muuli_wdr.cpp:2662
 msgid "This option enabled Protocol Obfuscation, and makes aMule accept obfuscated connections from other clients."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2657
+#: src/muuli_wdr.cpp:2664
 msgid "Use obfuscation for outgoing connections"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2659
+#: src/muuli_wdr.cpp:2666
 msgid "This option makes aMule use Protocol Obfuscation when connecting other clients/servers."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2661
+#: src/muuli_wdr.cpp:2668
 msgid "Accept only obfuscated connections"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2662
+#: src/muuli_wdr.cpp:2669
 msgid "This option makes aMule only accept obfuscated connections. You will have less sources, but all your traffic will be obfuscated"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2667
+#: src/muuli_wdr.cpp:2674
 msgid "Everybody"
 msgstr "الكل"
 
-#: src/muuli_wdr.cpp:2669
+#: src/muuli_wdr.cpp:2676
 msgid "No one"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2671
+#: src/muuli_wdr.cpp:2678
 msgid "Who can see my shared files:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2672
+#: src/muuli_wdr.cpp:2679
 msgid "Select who can request to view a list of your shared files."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2674
+#: src/muuli_wdr.cpp:2681
 msgid "IP-Filtering"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2681
+#: src/muuli_wdr.cpp:2688
 msgid "Filter clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2683
+#: src/muuli_wdr.cpp:2690
 msgid "Enable filtering of the client IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2685
+#: src/muuli_wdr.cpp:2692
 msgid "Filter servers"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2687
+#: src/muuli_wdr.cpp:2694
 msgid "Enable filtering of the server IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2691
+#: src/muuli_wdr.cpp:2698
 msgid "Reload List"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2692
+#: src/muuli_wdr.cpp:2699
 msgid "Reload the list of IPs to filter from the file ~/.aMule/ipfilter.dat"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2698
+#: src/muuli_wdr.cpp:2705
 msgid "URL:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2702 src/muuli_wdr.cpp:2895
+#: src/muuli_wdr.cpp:2709 src/muuli_wdr.cpp:2902
 msgid "Update now"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2705
+#: src/muuli_wdr.cpp:2712
 msgid "Auto-update ipfilter at startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2709
+#: src/muuli_wdr.cpp:2716
 msgid "Filtering Level:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2715
+#: src/muuli_wdr.cpp:2722
 msgid "Always filter LAN IPs"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2718
+#: src/muuli_wdr.cpp:2725
 msgid "Paranoid handling of non-matching IPs"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2720
+#: src/muuli_wdr.cpp:2727
 msgid "Rejects a packet when its source IP differs from the IP the client claims (an anti-spoofing check). Disable only if it causes connection problems."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2722
+#: src/muuli_wdr.cpp:2729
 msgid "Use system-wide ipfilter.dat if available"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2723
+#: src/muuli_wdr.cpp:2730
 msgid "If there's no local ipfilter.dat found, allow usage of a system-wide ipfilter file."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2740
+#: src/muuli_wdr.cpp:2747
 msgid "Enable Online-Signature"
 msgstr "تمكين التوقيع الشبكي"
 
-#: src/muuli_wdr.cpp:2742
+#: src/muuli_wdr.cpp:2749
 msgid "Enables the writing of the OS file, which can be used by external apps to create signatures and the like."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2746
+#: src/muuli_wdr.cpp:2753
 msgid "Update Frequency (Secs):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2749
+#: src/muuli_wdr.cpp:2756
 msgid "Change the frequency (in seconds) of Online Signature updates."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2757
+#: src/muuli_wdr.cpp:2764
 msgid "Save online signature file in: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:2763
+#: src/muuli_wdr.cpp:2770
 msgid "Click here to select the directory containing the the Online Signature files."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2796
+#: src/muuli_wdr.cpp:2803
 msgid "Show country flags for clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2797
+#: src/muuli_wdr.cpp:2804
 msgid "Render the country flag column in the transfers, queue and search views. Requires a valid MMDB GeoIP database (see below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2802
+#: src/muuli_wdr.cpp:2809
 #, fuzzy
 msgid "Database"
 msgstr "نسبة المصادر :"
 
-#: src/muuli_wdr.cpp:2818
+#: src/muuli_wdr.cpp:2825
 #, fuzzy
 msgid "Source:"
 msgstr "مصدر"
 
-#: src/muuli_wdr.cpp:2821
+#: src/muuli_wdr.cpp:2828
 msgid "DB-IP (free, no account)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2822
+#: src/muuli_wdr.cpp:2829
 msgid "MaxMind GeoLite2 (free, account required)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2823
+#: src/muuli_wdr.cpp:2830
 msgid "Custom URL"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2826
+#: src/muuli_wdr.cpp:2833
 msgid "Choose which provider supplies the GeoIP MMDB database. DB-IP is the default - no account required. MaxMind requires a free account + license key. Use Custom URL to point at any other MMDB host (e.g. a local mirror)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2843
+#: src/muuli_wdr.cpp:2850
 msgid ""
 "No configuration required.\n"
 "\n"
@@ -4776,11 +4789,11 @@ msgid ""
 "License: Creative Commons BY 4.0 - https://creativecommons.org/licenses/by/4.0/"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2856
+#: src/muuli_wdr.cpp:2863
 msgid "License key:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2862
+#: src/muuli_wdr.cpp:2869
 msgid ""
 "Sign up for a free MaxMind account, then generate a License Key:\n"
 "https://www.maxmind.com/en/geolite2/signup\n"
@@ -4790,233 +4803,233 @@ msgid ""
 "Requires attribution and account registration; refresh at least every 30 days."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2877
+#: src/muuli_wdr.cpp:2884
 #, fuzzy
 msgid "Download URL:"
 msgstr "التحميل"
 
-#: src/muuli_wdr.cpp:2883
+#: src/muuli_wdr.cpp:2890
 msgid ""
 "Must point to an .mmdb file or a .gz / .tar.gz containing one.\n"
 "URL may include credentials (https://user:pass@host/...).\n"
 "License and attribution terms are set by the upstream URL - you are responsible."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2896
+#: src/muuli_wdr.cpp:2903
 msgid "Download the GeoIP database from the selected source."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2898
+#: src/muuli_wdr.cpp:2905
 #, fuzzy
 msgid "Auto-update on startup"
 msgstr "ربط تلقائي عند بدء التشغيل"
 
-#: src/muuli_wdr.cpp:2899
+#: src/muuli_wdr.cpp:2906
 msgid "Re-download the GeoIP database from the selected source every time aMule starts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2922
+#: src/muuli_wdr.cpp:2929
 msgid "Filter incoming messages (except current chat):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2924
+#: src/muuli_wdr.cpp:2931
 msgid "Filter all messages"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2926
+#: src/muuli_wdr.cpp:2933
 msgid "Filter messages from people not on your friend list"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2928
+#: src/muuli_wdr.cpp:2935
 msgid "Filter messages from unknown clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2930
+#: src/muuli_wdr.cpp:2937
 msgid "Filter messages containing (use ',' as separator):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2933 src/muuli_wdr.cpp:2944
+#: src/muuli_wdr.cpp:2940 src/muuli_wdr.cpp:2951
 msgid "add here the words amule should filter and block messages including it"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2935
+#: src/muuli_wdr.cpp:2942
 msgid "Show received messages in the log"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2938
+#: src/muuli_wdr.cpp:2945
 msgid "Comments"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2941
+#: src/muuli_wdr.cpp:2948
 msgid "Filter comments containing (use ',' as separator):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2966
+#: src/muuli_wdr.cpp:2973
 msgid "Enable Proxy"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2967
+#: src/muuli_wdr.cpp:2974
 msgid "Enable/disable proxy support"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2970
+#: src/muuli_wdr.cpp:2977
 msgid "Proxy type:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2981
+#: src/muuli_wdr.cpp:2988
 msgid "Proxy host:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2984
+#: src/muuli_wdr.cpp:2991
 msgid "The proxy host name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2986
+#: src/muuli_wdr.cpp:2993
 msgid "Proxy port:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2989
+#: src/muuli_wdr.cpp:2996
 msgid "The proxy port"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2991
+#: src/muuli_wdr.cpp:2998
 msgid "Enable authentication"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2992
+#: src/muuli_wdr.cpp:2999
 msgid "Enable/disable username/password authentication"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2995
+#: src/muuli_wdr.cpp:3002
 msgid "Username: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:2998
+#: src/muuli_wdr.cpp:3005
 msgid "The username to use to connect to the proxy"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3000
+#: src/muuli_wdr.cpp:3007
 msgid "Password:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3003
+#: src/muuli_wdr.cpp:3010
 msgid "The password to use to connect to the proxy"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3022
+#: src/muuli_wdr.cpp:3029
 msgid "Connect to:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3031
+#: src/muuli_wdr.cpp:3038
 msgid "Login to remote amule"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3036
+#: src/muuli_wdr.cpp:3043
 msgid "User name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3047
+#: src/muuli_wdr.cpp:3054
 msgid "Remember those settings"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3050
+#: src/muuli_wdr.cpp:3057
 #, fuzzy
 msgid "Force ZLIB compression"
 msgstr "أكتسب بواسطة الضغط :"
 
-#: src/muuli_wdr.cpp:3074
+#: src/muuli_wdr.cpp:3081
 msgid "Enable Verbose Debug-Logging."
 msgstr ""
 
-#: src/muuli_wdr.cpp:3076
+#: src/muuli_wdr.cpp:3083
 #, fuzzy
 msgid "Only to Logfile"
 msgstr "&فتح الملف"
 
-#: src/muuli_wdr.cpp:3078
+#: src/muuli_wdr.cpp:3085
 msgid "Message Categories:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3102 src/PartFileConvertDlg.cpp:160
+#: src/muuli_wdr.cpp:3109 src/PartFileConvertDlg.cpp:160
 msgid "Waiting..."
 msgstr "إنتظار..."
 
-#: src/muuli_wdr.cpp:3122
+#: src/muuli_wdr.cpp:3129
 msgid "Add imports"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3125
+#: src/muuli_wdr.cpp:3132
 msgid "Retry selected"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3127
+#: src/muuli_wdr.cpp:3134
 msgid "Remove selected"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3190
+#: src/muuli_wdr.cpp:3197
 msgid "Event Types"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3209
+#: src/muuli_wdr.cpp:3216
 msgid "Statistics and queued clients for selected file(s) : Session / All time"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3233
+#: src/muuli_wdr.cpp:3240
 #, fuzzy
 msgid "Active Uploads"
 msgstr "رفع نشط :"
 
-#: src/muuli_wdr.cpp:3247
+#: src/muuli_wdr.cpp:3254
 #, fuzzy
 msgid "Percent of total files"
 msgstr "مجموع الملفات"
 
-#: src/muuli_wdr.cpp:3299
+#: src/muuli_wdr.cpp:3306
 #, fuzzy
 msgid "Show Clients for"
 msgstr "منفذ العميل"
 
-#: src/muuli_wdr.cpp:3301
+#: src/muuli_wdr.cpp:3308
 #, fuzzy
 msgid "All files"
 msgstr "ملفات مشاركة"
 
-#: src/muuli_wdr.cpp:3304
+#: src/muuli_wdr.cpp:3311
 #, fuzzy
 msgid "Selected files"
 msgstr "إختر فلتر العرض"
 
-#: src/muuli_wdr.cpp:3307
+#: src/muuli_wdr.cpp:3314
 #, fuzzy
 msgid "Active uploads only"
 msgstr "رفع نشط"
 
-#: src/muuli_wdr.cpp:3314
+#: src/muuli_wdr.cpp:3321
 #, fuzzy
 msgid "Reload:"
 msgstr "اعد تحميل"
 
-#: src/muuli_wdr.cpp:3318
+#: src/muuli_wdr.cpp:3325
 msgid "Reload your shared files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3381
+#: src/muuli_wdr.cpp:3388
 msgid "Send"
 msgstr "ارسل"
 
-#: src/muuli_wdr.cpp:3382
+#: src/muuli_wdr.cpp:3389
 msgid "Sends the specified message."
 msgstr ""
 
-#: src/muuli_wdr.cpp:3386
+#: src/muuli_wdr.cpp:3393
 msgid "Close this chat-session."
 msgstr ""
 
-#: src/muuli_wdr.cpp:3409
+#: src/muuli_wdr.cpp:3416
 msgid "Connect to any server and/or Kad"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3415 src/SharedFilesCtrl.cpp:142 src/Statistics.cpp:941
+#: src/muuli_wdr.cpp:3422 src/SharedFilesCtrl.cpp:142 src/Statistics.cpp:941
 msgid "Shared Files"
 msgstr "ملفات مشاركة"
 
@@ -5378,191 +5391,191 @@ msgstr ""
 msgid "ERROR: Failed to open partfile '%s'"
 msgstr ""
 
-#: src/Preferences.cpp:673
+#: src/Preferences.cpp:674
 msgid "System default"
 msgstr "اﻹفتراضية بالنظام"
 
-#: src/Preferences.cpp:674
+#: src/Preferences.cpp:675
 msgid "Albanian"
 msgstr ""
 
-#: src/Preferences.cpp:675
+#: src/Preferences.cpp:676
 msgid "Arabic"
 msgstr "العربيه"
 
-#: src/Preferences.cpp:676
+#: src/Preferences.cpp:677
 #, fuzzy
 msgid "Asturian"
 msgstr "الأستونيه"
 
-#: src/Preferences.cpp:677
+#: src/Preferences.cpp:678
 msgid "Basque"
 msgstr ""
 
-#: src/Preferences.cpp:678
+#: src/Preferences.cpp:679
 msgid "Bulgarian"
 msgstr "البلغاريه"
 
-#: src/Preferences.cpp:679
+#: src/Preferences.cpp:680
 msgid "Catalan"
 msgstr ""
 
-#: src/Preferences.cpp:680
+#: src/Preferences.cpp:681
 msgid "Chinese (Simplified)"
 msgstr ""
 
-#: src/Preferences.cpp:681
+#: src/Preferences.cpp:682
 msgid "Chinese (Traditional)"
 msgstr ""
 
-#: src/Preferences.cpp:682
+#: src/Preferences.cpp:683
 msgid "Croatian"
 msgstr ""
 
-#: src/Preferences.cpp:683
+#: src/Preferences.cpp:684
 msgid "Czech"
 msgstr ""
 
-#: src/Preferences.cpp:684
+#: src/Preferences.cpp:685
 msgid "Danish"
 msgstr "الدانماركيه"
 
-#: src/Preferences.cpp:685
+#: src/Preferences.cpp:686
 msgid "Dutch"
 msgstr "الهولنديه"
 
-#: src/Preferences.cpp:686
+#: src/Preferences.cpp:687
 msgid "English (U.K.)"
 msgstr ""
 
-#: src/Preferences.cpp:687
+#: src/Preferences.cpp:688
 msgid "English (U.S.)"
 msgstr ""
 
-#: src/Preferences.cpp:688
+#: src/Preferences.cpp:689
 msgid "Estonian"
 msgstr "الأستونيه"
 
-#: src/Preferences.cpp:689
+#: src/Preferences.cpp:690
 msgid "Finnish"
 msgstr "الفلنديه"
 
-#: src/Preferences.cpp:690
+#: src/Preferences.cpp:691
 msgid "French"
 msgstr "الفرنسية"
 
-#: src/Preferences.cpp:691
+#: src/Preferences.cpp:692
 msgid "Galician"
 msgstr ""
 
-#: src/Preferences.cpp:692
+#: src/Preferences.cpp:693
 msgid "German"
 msgstr "الألمانيه"
 
-#: src/Preferences.cpp:693
+#: src/Preferences.cpp:694
 msgid "Greek"
 msgstr ""
 
-#: src/Preferences.cpp:694
+#: src/Preferences.cpp:695
 msgid "Hebrew"
 msgstr ""
 
-#: src/Preferences.cpp:695
+#: src/Preferences.cpp:696
 msgid "Hungarian"
 msgstr "الهنغاريه"
 
-#: src/Preferences.cpp:696
+#: src/Preferences.cpp:697
 msgid "Italian"
 msgstr "الايطاليه"
 
-#: src/Preferences.cpp:697
+#: src/Preferences.cpp:698
 msgid "Japanese"
 msgstr ""
 
-#: src/Preferences.cpp:698
+#: src/Preferences.cpp:699
 msgid "Korean"
 msgstr "الكوريه"
 
-#: src/Preferences.cpp:699
+#: src/Preferences.cpp:700
 msgid "Latvian"
 msgstr ""
 
-#: src/Preferences.cpp:700
+#: src/Preferences.cpp:701
 msgid "Lithuanian"
 msgstr "الليتوانيه"
 
-#: src/Preferences.cpp:701
+#: src/Preferences.cpp:702
 msgid "Norwegian (Nynorsk)"
 msgstr ""
 
-#: src/Preferences.cpp:702
+#: src/Preferences.cpp:703
 msgid "Polish"
 msgstr ""
 
-#: src/Preferences.cpp:703
+#: src/Preferences.cpp:704
 msgid "Portuguese"
 msgstr "البرتغاليه"
 
-#: src/Preferences.cpp:704
+#: src/Preferences.cpp:705
 msgid "Portuguese (Brazilian)"
 msgstr ""
 
-#: src/Preferences.cpp:705
+#: src/Preferences.cpp:706
 #, fuzzy
 msgid "Romanian"
 msgstr "الأستونيه"
 
-#: src/Preferences.cpp:706
+#: src/Preferences.cpp:707
 msgid "Russian"
 msgstr "الروسيه"
 
-#: src/Preferences.cpp:707
+#: src/Preferences.cpp:708
 msgid "Slovenian"
 msgstr ""
 
-#: src/Preferences.cpp:708
+#: src/Preferences.cpp:709
 msgid "Spanish"
 msgstr "الإسبانيه"
 
-#: src/Preferences.cpp:709
+#: src/Preferences.cpp:710
 msgid "Swedish"
 msgstr ""
 
-#: src/Preferences.cpp:710
+#: src/Preferences.cpp:711
 msgid "Turkish"
 msgstr ""
 
-#: src/Preferences.cpp:711
+#: src/Preferences.cpp:712
 msgid "Ukrainian"
 msgstr ""
 
-#: src/Preferences.cpp:814
+#: src/Preferences.cpp:815
 #, fuzzy
 msgid "Change Language"
 msgstr "الغة"
 
-#: src/Preferences.cpp:878
+#: src/Preferences.cpp:879
 msgid "There are no translations installed for aMule"
 msgstr ""
 
-#: src/Preferences.cpp:879
+#: src/Preferences.cpp:880
 #, fuzzy
 msgid "No languages available"
 msgstr "غير متوفر"
 
-#: src/Preferences.cpp:1010
+#: src/Preferences.cpp:1011
 msgid "no options available"
 msgstr ""
 
-#: src/Preferences.cpp:2179
+#: src/Preferences.cpp:2182
 msgid "Invalid category found, skipping"
 msgstr ""
 
-#: src/Preferences.cpp:2348
+#: src/Preferences.cpp:2351
 msgid "TCP port can't be higher than 65532 due to server UDP socket being TCP+3"
 msgstr ""
 
-#: src/Preferences.cpp:2349
+#: src/Preferences.cpp:2352
 #, c-format
 msgid "Default port will be used (%d)"
 msgstr ""
@@ -6046,24 +6059,28 @@ msgstr ""
 msgid "Shared folder"
 msgstr "ملفات مشاركة"
 
-#: src/SearchDlg.cpp:425
+#: src/SearchDlg.cpp:280
+msgid "Clear search history"
+msgstr ""
+
+#: src/SearchDlg.cpp:584
 msgid "It's impossible to search when both eD2k and Kademlia are disabled."
 msgstr ""
 
-#: src/SearchDlg.cpp:426 src/SearchListCtrl.cpp:858
+#: src/SearchDlg.cpp:585 src/SearchListCtrl.cpp:858
 #, fuzzy
 msgid "Search error"
 msgstr "بحث"
 
-#: src/SearchDlg.cpp:768
+#: src/SearchDlg.cpp:929
 msgid "Min size must be smaller than max size. Max size ignored."
 msgstr ""
 
-#: src/SearchDlg.cpp:769 src/SearchDlg.cpp:851
+#: src/SearchDlg.cpp:930 src/SearchDlg.cpp:1012
 msgid "Search warning"
 msgstr ""
 
-#: src/SearchDlg.cpp:929 src/SearchListCtrl.cpp:735
+#: src/SearchDlg.cpp:1092 src/SearchListCtrl.cpp:735
 msgid "Main"
 msgstr ""
 

--- a/po/ast.po
+++ b/po/ast.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-28 10:19+0200\n"
+"POT-Creation-Date: 2026-07-28 12:17+0200\n"
 "PO-Revision-Date: 2026-07-27 11:32+0000\n"
 "Last-Translator: astur <malditoastur@gmail.com>\n"
 "Language-Team: Language ast <malditoastur@gmail.com>\n"
@@ -203,83 +203,83 @@ msgstr "Fallu al abrir ficheru ED2KLinks."
 msgid "WARNING: You can't add yourself as a source for an eD2k link while having a lowid."
 msgstr "AVISU: Nun pues amestate a tí mesmu como una fonte pa un enllaz eD2k teniendo ID baxa."
 
-#: src/amule.cpp:300
+#: src/amule.cpp:301
 msgid "Now, exiting main app..."
 msgstr "Agora, saliendo de l'aplicación principal..."
 
-#: src/amule.cpp:330
+#: src/amule.cpp:331
 #, c-format
 msgid "Terminating amuleweb instance with pid '%d' ... "
 msgstr "Matando instancia amuleweb con pid `%d' ... "
 
-#: src/amule.cpp:334
+#: src/amule.cpp:335
 #, c-format
 msgid "Killing amuleweb instance with pid '%d' ... "
 msgstr "Matando instancia amuleweb con pid `%d' ... "
 
-#: src/amule.cpp:336 src/amule.cpp:349 src/ClientRef.cpp:180
+#: src/amule.cpp:337 src/amule.cpp:350 src/ClientRef.cpp:180
 #: src/SearchDlg.cpp:1041 src/ServerListCtrl.cpp:98
 msgid "Failed"
 msgstr "Falló"
 
-#: src/amule.cpp:343
+#: src/amule.cpp:344
 #, fuzzy, c-format
 msgid "Terminating amuleapi instance with pid '%d' ... "
 msgstr "Matando instancia amuleweb con pid `%d' ... "
 
-#: src/amule.cpp:347
+#: src/amule.cpp:348
 #, fuzzy, c-format
 msgid "Killing amuleapi instance with pid '%d' ... "
 msgstr "Matando instancia amuleweb con pid `%d' ... "
 
-#: src/amule.cpp:355
+#: src/amule.cpp:356
 msgid "aMule OnExit: Terminating core."
 msgstr "aMule OnExit: Terminando núcleu."
 
-#: src/amule.cpp:466
+#: src/amule.cpp:467
 msgid "aMule shutdown completed."
 msgstr "Zarru d'aMule completáu."
 
-#: src/amule.cpp:470
+#: src/amule.cpp:471
 msgid "Memory debug results for aMule exit:"
 msgstr "Resultaos de depuración de memoria na salida d'aMule: "
 
-#: src/amule.cpp:651
+#: src/amule.cpp:652
 #, c-format
 msgid "Binding aMule's peer-to-peer traffic to interface: %s (HTTP updates use the default route)"
 msgstr ""
 
-#: src/amule.cpp:655
+#: src/amule.cpp:656
 #, c-format
 msgid "Binding all network traffic to interface: %s"
 msgstr ""
 
-#: src/amule.cpp:659
+#: src/amule.cpp:660
 #, c-format
 msgid "WARNING: configured network interface '%s' was not found - traffic is NOT bound to it and may leave via the default route. Check the interface name in Preferences."
 msgstr ""
 
-#: src/amule.cpp:665
+#: src/amule.cpp:666
 #, c-format
 msgid "WARNING: binding to network interface '%s' requires elevated privileges and was NOT applied - traffic may leave via the default route. Grant the capability (e.g. 'sudo setcap cap_net_raw+ep' on the aMule binary) or run with sufficient privileges."
 msgstr ""
 
-#: src/amule.cpp:673
+#: src/amule.cpp:674
 #, c-format
 msgid "WARNING: could not bind to network interface '%s' - traffic may leave via the default route."
 msgstr ""
 
-#: src/amule.cpp:732
+#: src/amule.cpp:733
 msgid "Your locale has been changed to System Default due to a configuration change. Sorry."
 msgstr "La to llingua foi camudada a la de por defeutu del sistema, darréu d'un cambéu de configuración. Siéntolo."
 
-#: src/amule.cpp:734 src/amule.cpp:1581 src/CatDialog.cpp:128
+#: src/amule.cpp:735 src/amule.cpp:1589 src/CatDialog.cpp:128
 #: src/CatDialog.cpp:136 src/CatDialog.cpp:149 src/ServerList.cpp:366
 #: src/ServerListCtrl.cpp:152
 msgid "Info"
 msgstr "Info"
 
-#: src/amule.cpp:741
+#: src/amule.cpp:742
 msgid ""
 "\n"
 "EC configuration"
@@ -287,74 +287,74 @@ msgstr ""
 "\n"
 "Configuración EC"
 
-#: src/amule.cpp:744
+#: src/amule.cpp:745
 msgid "Password set and external connections enabled."
 msgstr "Contraseña fixada y conexones esternes habilitaes."
 
-#: src/amule.cpp:754 src/KadDlg.cpp:176 src/KadDlg.cpp:185
-#: src/PrefsUnifiedDlg.cpp:1387 src/SharedFilesCtrl.cpp:476
+#: src/amule.cpp:755 src/KadDlg.cpp:176 src/KadDlg.cpp:185
+#: src/PrefsUnifiedDlg.cpp:1461 src/SharedFilesCtrl.cpp:476
 msgid "WARNING"
 msgstr "ALERTA"
 
-#: src/amule.cpp:991
+#: src/amule.cpp:992
 #, fuzzy
 msgid "Network bootstrap"
 msgstr "Redes"
 
-#: src/amule.cpp:996
+#: src/amule.cpp:997
 msgid ""
 "aMule has detected missing network bootstrap files.\n"
 "Select which ones to download:"
 msgstr ""
 
-#: src/amule.cpp:1005 src/FirstRunWizard.cpp:411
+#: src/amule.cpp:1006 src/FirstRunWizard.cpp:411
 #, fuzzy
 msgid "eD2k server list (server.met)"
 msgstr "%i sirvidor alcontráu en server.met"
 
-#: src/amule.cpp:1012 src/FirstRunWizard.cpp:416
+#: src/amule.cpp:1013 src/FirstRunWizard.cpp:416
 msgid "Kad bootstrap nodes (nodes.dat)"
 msgstr ""
 
-#: src/amule.cpp:1102
+#: src/amule.cpp:1103
 #, c-format
 msgid "web server running on pid %d"
 msgstr "sirvidor web corriendo con pid: %d"
 
-#: src/amule.cpp:1115
+#: src/amule.cpp:1116
 #, fuzzy
 msgid "You requested to run web server on startup, but the amuleweb binary cannot be run. Please install the package containing aMule web server, or build aMule from source with -DBUILD_WEBSERVER=YES and install it."
 msgstr "Solicitaste executar el sirvidor web al aniciu pero nun pudo correse'l binariu d'amuleweb. Por favor instala'l paquete que contenga'l sirvidor web d'aMule o compila aMule usando --enable-webserver y executa make install"
 
-#: src/amule.cpp:1120 src/amule.cpp:1177 src/amule.cpp:1291 src/amule.cpp:1593
+#: src/amule.cpp:1121 src/amule.cpp:1185 src/amule.cpp:1299 src/amule.cpp:1601
 #: src/amule-remote-gui.cpp:603 src/amule-remote-gui.cpp:671
 #: src/amule-remote-gui.cpp:709 src/amule-remote-gui.cpp:1282
 #: src/amule-remote-gui.cpp:1345 src/amule-remote-gui.cpp:1372
-#: src/DownloadQueue.cpp:1481
+#: src/DownloadQueue.cpp:1481 src/PrefsUnifiedDlg.cpp:1247
 msgid "ERROR"
 msgstr "FALLU"
 
-#: src/amule.cpp:1166
+#: src/amule.cpp:1174
 #, fuzzy, c-format
 msgid "amuleapi running on pid %d"
 msgstr "sirvidor web corriendo con pid: %d"
 
-#: src/amule.cpp:1172
+#: src/amule.cpp:1180
 #, fuzzy
 msgid "You requested to run amuleapi on startup, but the amuleapi binary cannot be run. Please install the package containing aMule's REST API server, or build aMule from source with -DBUILD_AMULEAPI=YES and install it."
 msgstr "Solicitaste executar el sirvidor web al aniciu pero nun pudo correse'l binariu d'amuleweb. Por favor instala'l paquete que contenga'l sirvidor web d'aMule o compila aMule usando --enable-webserver y executa make install"
 
-#: src/amule.cpp:1259
+#: src/amule.cpp:1267
 #, c-format
 msgid "Could not bind ports to the specified address: %s"
 msgstr "Nun ye dable direicionar los puertos a la direición especificada: %s"
 
-#: src/amule.cpp:1283
+#: src/amule.cpp:1291
 #, c-format
 msgid "Port %u is not available. You will be LOWID\n"
 msgstr "El puertu %u nun ta disponible. Tendrás IDBaxa\n"
 
-#: src/amule.cpp:1288
+#: src/amule.cpp:1296
 #, c-format
 msgid ""
 "Port %u is not available!\n"
@@ -369,48 +369,48 @@ msgstr ""
 "\n"
 "Comprueba la to rede y asegúrate de que'l puertu ta abiertu pa entrada y salida."
 
-#: src/amule.cpp:1385
+#: src/amule.cpp:1393
 msgid "Failed to create OnlineSig File"
 msgstr "Fallu al criar el ficheru de RoblaOnline"
 
-#: src/amule.cpp:1393
+#: src/amule.cpp:1401
 msgid "Failed to create aMule OnlineSig File"
 msgstr "Fallu al criar el ficheru de RoblaOnline aMule"
 
-#: src/amule.cpp:1556
+#: src/amule.cpp:1564
 msgid "The selected locale seems not to be installed on your box. (Note: I'll try to set it anyway)"
 msgstr "La llingua seleicionada nun paez tar instalada. (Nota: Tentará de ponese de toes formes)"
 
-#: src/amule.cpp:1566
+#: src/amule.cpp:1574
 #, c-format
 msgid "This is the first time you run aMule %s"
 msgstr "Ye la primer vegada qu'anicies aMule %s"
 
-#: src/amule.cpp:1569
+#: src/amule.cpp:1577
 msgid "This version is a testing version, updated daily, and\n"
 msgstr "Esto ye una versión de preba, actualízate diariamente, y \n"
 
-#: src/amule.cpp:1570
+#: src/amule.cpp:1578
 msgid "we give no warranty it won't break anything, burn your house,\n"
 msgstr "nun damos garantía si fraña daqué, ambura to casa,\n"
 
-#: src/amule.cpp:1571
+#: src/amule.cpp:1579
 msgid "or kill your dog. But it *should* be safe to use anyway.\n"
 msgstr "o fila la to sidra. Pero *tendría* de ser seguru de toes formes. \n"
 
-#: src/amule.cpp:1576
+#: src/amule.cpp:1584
 msgid "More information, support and new releases can found at our homepage,\n"
 msgstr "Podrás alcontrar na nuesa web, más información, sofitu y nueves versiones, \n"
 
-#: src/amule.cpp:1577
+#: src/amule.cpp:1585
 msgid "at https://amule-org.github.io, or in our IRC channel #aMule at irc.libera.chat.\n"
 msgstr "en https://amule-org.github.io, o nel nuesu canal de IRC #aMule en irc.libera.chat. \n"
 
-#: src/amule.cpp:1579
+#: src/amule.cpp:1587
 msgid "Feel free to report any bugs to https://github.com/amule-org/amule/issues"
 msgstr "Unvíanos cualesquier fallu a https://github.com/amule-org/amule/issues"
 
-#: src/amule.cpp:1591
+#: src/amule.cpp:1599
 msgid ""
 "The folder for Online Signature files you specified is INVALID!\n"
 " OnlineSignature will be DISABLED until you fix it on preferences."
@@ -418,137 +418,137 @@ msgstr ""
 "El direutoriu qu'especificaste de Robla Online nun ye válidu\n"
 "La Robla Online deshabilitóse hasta que lo igües nes opciones."
 
-#: src/amule.cpp:1654
+#: src/amule.cpp:1662
 msgid "Server hostname notified"
 msgstr "Nome sirvidor notificáu"
 
-#: src/amule.cpp:2031
+#: src/amule.cpp:2039
 #, c-format
 msgid "Disk space preallocation for file '%s' failed: %s"
 msgstr "La reserva del espaciu en discu pal ficheru '%s' falló: %s"
 
-#: src/amule.cpp:2160
+#: src/amule.cpp:2168
 msgid "ERROR: can't open logfile"
 msgstr "FALLU: nun puede abrise'l ficheru de rexistru"
 
-#: src/amule.cpp:2164
+#: src/amule.cpp:2172
 msgid "WARNING: logfile is empty. Something is wrong."
 msgstr "ALERTA: el ficheru de rexistru ta ermu. Hai daqué mal."
 
-#: src/amule.cpp:2181
+#: src/amule.cpp:2189
 msgid "Log has been reset"
 msgstr "El rexistru resetióse"
 
-#: src/amule.cpp:2205
+#: src/amule.cpp:2213
 #, c-format
 msgid "ServerMessage: %s"
 msgstr "Mensax del sirvidor: %s"
 
-#: src/amule.cpp:2248 src/IP2Country.cpp:220 src/IPFilter.cpp:514
+#: src/amule.cpp:2256 src/IP2Country.cpp:220 src/IPFilter.cpp:514
 #: src/ServerList.cpp:875
 #, c-format
 msgid "Skipped download of %s, because requested file is not newer."
 msgstr ""
 
-#: src/amule.cpp:2251
+#: src/amule.cpp:2259
 msgid "Failed to download the nodes list."
 msgstr "Fallu al descargar la llista de nodos."
 
-#: src/amule.cpp:2314
+#: src/amule.cpp:2322
 msgid "Failed to open the downloaded version check file"
 msgstr "Fallu al abrir el ficheru de comprobación de versión descargáu"
 
-#: src/amule.cpp:2317 src/amule.cpp:2336
+#: src/amule.cpp:2325 src/amule.cpp:2344
 msgid "Corrupted version check file"
 msgstr "Ficheru de comprobación de versión toyíu"
 
-#: src/amule.cpp:2359
+#: src/amule.cpp:2367
 msgid "You are using an outdated version of aMule!"
 msgstr "¡Tas usando una versión antigua de aMule!"
 
-#: src/amule.cpp:2361
+#: src/amule.cpp:2369
 #, c-format
 msgid "Your aMule version is %i.%i.%i and the latest version is %li.%li.%li"
 msgstr "La to versión de aMule ye %i.%i.%i y la cabera versión ye %li.%li.%li"
 
-#: src/amule.cpp:2365
+#: src/amule.cpp:2373
 msgid "The latest version can always be found at https://github.com/amule-org/amule/releases/latest"
 msgstr "La cabera versión pues alcontrala siempres en https://github.com/amule-org/amule/releases/latest"
 
-#: src/amule.cpp:2368
+#: src/amule.cpp:2376
 #, c-format
 msgid "WARNING: Your aMuled version is outdated: %i.%i.%i < %li.%li.%li"
 msgstr "ALERTA: La to versión de aMuled ye obsoleta: %i.%i.%i < %li.%li.%li"
 
-#: src/amule.cpp:2374
+#: src/amule.cpp:2382
 msgid "Your copy of aMule is up to date."
 msgstr "LA to copia de aMule ta actualizada."
 
-#: src/amule.cpp:2381
+#: src/amule.cpp:2389
 msgid "Failed to download the version check file"
 msgstr "Fallu al descargar el ficheru de comprobación de versión"
 
-#: src/amule.cpp:2550 src/amule-remote-gui.cpp:1133
+#: src/amule.cpp:2558 src/amule-remote-gui.cpp:1133
 #, c-format
 msgid "Users: %s | Files: %s"
 msgstr "Usuarios: %s | Ficheros: %s"
 
-#: src/amule.cpp:2551 src/amule-remote-gui.cpp:1134
+#: src/amule.cpp:2559 src/amule-remote-gui.cpp:1134
 #, c-format
 msgid "Users: E: %s K: %s | Files: E: %s K: %s"
 msgstr "Usuarios: E: %s K: %s | Ficheros: E: %s K: %s"
 
-#: src/amule.cpp:2565 src/amule-remote-gui.cpp:1147
+#: src/amule.cpp:2573 src/amule-remote-gui.cpp:1147
 msgid "No networks selected"
 msgstr "Ensin redes seleicionaes"
 
-#: src/amule.cpp:2633 src/TextClient.cpp:903
+#: src/amule.cpp:2641 src/TextClient.cpp:903
 msgid "with LowID"
 msgstr "con IDBaxa"
 
-#: src/amule.cpp:2633 src/TextClient.cpp:904
+#: src/amule.cpp:2641 src/TextClient.cpp:904
 msgid "with HighID"
 msgstr "con IDAlta"
 
-#: src/amule.cpp:2635
+#: src/amule.cpp:2643
 #, c-format
 msgid "Connected to %s %s"
 msgstr "Coneutáu a %s %s"
 
-#: src/amule.cpp:2640
+#: src/amule.cpp:2648
 #, c-format
 msgid "Connecting to %s"
 msgstr "Coneutando a %s"
 
-#: src/amule.cpp:2642
+#: src/amule.cpp:2650
 msgid "Disconnected from eD2k"
 msgstr "Desconeutáu de eD2k"
 
-#: src/amule.cpp:2651
+#: src/amule.cpp:2659
 msgid "Kad started."
 msgstr "Kad aniciáu."
 
-#: src/amule.cpp:2653
+#: src/amule.cpp:2661
 msgid "Kad stopped."
 msgstr "Kad deteníu."
 
-#: src/amule.cpp:2661
+#: src/amule.cpp:2669
 msgid "Connected to Kad (ok)"
 msgstr "Coneutáu a Kad (ok)"
 
-#: src/amule.cpp:2663
+#: src/amule.cpp:2671
 msgid "Connected to Kad (firewalled)"
 msgstr "Coneutáu a Kad (tres torgafueos)"
 
-#: src/amule.cpp:2667
+#: src/amule.cpp:2675
 msgid "Disconnected from Kad"
 msgstr "Desconeutáu de Kad"
 
-#: src/amule.cpp:2699
+#: src/amule.cpp:2707
 msgid "Kad network cannot be used if UDP port is disabled on preferences, not starting."
 msgstr "Red Kad nun pue usase si'l puertu UDP ta deshabilitáu n'opciones, non aniciando."
 
-#: src/amule.cpp:2703
+#: src/amule.cpp:2711
 msgid "Kad network disabled on preferences, not connecting."
 msgstr "Red Kad deshabilitada n'opciones, nun coneutará."
 
@@ -593,36 +593,36 @@ msgid "FATAL ERROR: Failed to create Timer"
 msgstr "FALLU GRAVE: Nun pudo criase'l temporizador"
 
 #: src/amuleDlg.cpp:361 src/amuleDlg.cpp:1787 src/amuleDlg.cpp:2033
-#: src/muuli_wdr.cpp:1492 src/muuli_wdr.cpp:3418
+#: src/muuli_wdr.cpp:1492 src/muuli_wdr.cpp:3449
 msgid "Networks"
 msgstr "Redes"
 
-#: src/amuleDlg.cpp:362 src/amuleDlg.cpp:1793 src/muuli_wdr.cpp:3419
+#: src/amuleDlg.cpp:362 src/amuleDlg.cpp:1793 src/muuli_wdr.cpp:3450
 msgid "Searches"
 msgstr "Guetar"
 
 #: src/amuleDlg.cpp:363 src/amuleDlg.cpp:1799 src/DownloadListCtrl.cpp:740
-#: src/muuli_wdr.cpp:392 src/muuli_wdr.cpp:1585 src/muuli_wdr.cpp:3420
+#: src/muuli_wdr.cpp:392 src/muuli_wdr.cpp:1585 src/muuli_wdr.cpp:3451
 #: src/Statistics.cpp:829
 msgid "Downloads"
 msgstr "Descargues"
 
-#: src/amuleDlg.cpp:364 src/amuleDlg.cpp:1805 src/muuli_wdr.cpp:3294
+#: src/amuleDlg.cpp:364 src/amuleDlg.cpp:1805 src/muuli_wdr.cpp:3325
 msgid "Shared files"
 msgstr "Ficheros compartíos"
 
-#: src/amuleDlg.cpp:365 src/amuleDlg.cpp:1811 src/muuli_wdr.cpp:2926
-#: src/muuli_wdr.cpp:3376 src/muuli_wdr.cpp:3423
+#: src/amuleDlg.cpp:365 src/amuleDlg.cpp:1811 src/muuli_wdr.cpp:2957
+#: src/muuli_wdr.cpp:3407 src/muuli_wdr.cpp:3454
 msgid "Messages"
 msgstr "Mensaxes"
 
-#: src/amuleDlg.cpp:366 src/amuleDlg.cpp:1817 src/muuli_wdr.cpp:3424
-#: src/PrefsUnifiedDlg.cpp:312 src/Statistics.cpp:779 src/Statistics.cpp:1235
+#: src/amuleDlg.cpp:366 src/amuleDlg.cpp:1817 src/muuli_wdr.cpp:3455
+#: src/PrefsUnifiedDlg.cpp:314 src/Statistics.cpp:779 src/Statistics.cpp:1235
 msgid "Statistics"
 msgstr "Estadístiques"
 
-#: src/amuleDlg.cpp:368 src/amuleDlg.cpp:1824 src/muuli_wdr.cpp:3426
-#: src/PrefsUnifiedDlg.cpp:328 src/utils/wxCas/src/wxcasprefs.cpp:39
+#: src/amuleDlg.cpp:368 src/amuleDlg.cpp:1824 src/muuli_wdr.cpp:3457
+#: src/PrefsUnifiedDlg.cpp:330 src/utils/wxCas/src/wxcasprefs.cpp:39
 msgid "Preferences"
 msgstr "Preferencies"
 
@@ -680,8 +680,8 @@ msgstr "Kad: Apagada"
 #: src/amuleDlg.cpp:1029 src/DownloadListCtrl.cpp:505
 #: src/DownloadListCtrl.cpp:749 src/FriendListCtrl.cpp:180
 #: src/muuli_wdr.cpp:731 src/muuli_wdr.cpp:782 src/muuli_wdr.cpp:846
-#: src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2231 src/muuli_wdr.cpp:2316
-#: src/muuli_wdr.cpp:3064 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
+#: src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2262 src/muuli_wdr.cpp:2347
+#: src/muuli_wdr.cpp:3095 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
 #: src/ServerListCtrl.cpp:606 src/TransferWnd.cpp:378
 #: src/utils/wxCas/src/wxcasprefs.cpp:235
 msgid "Cancel"
@@ -692,7 +692,7 @@ msgid "Stop the current connection attempts"
 msgstr "Detener los intentos de conexón actuales"
 
 #: src/amuleDlg.cpp:1035 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976
-#: src/muuli_wdr.cpp:2454
+#: src/muuli_wdr.cpp:2485
 msgid "Disconnect"
 msgstr "Desconeutar"
 
@@ -701,7 +701,7 @@ msgid "Disconnect from the currently connected networks"
 msgstr "Desconeutase de les redes coneutaes"
 
 #: src/amuleDlg.cpp:1041 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979
-#: src/muuli_wdr.cpp:2609 src/muuli_wdr.cpp:3061 src/muuli_wdr.cpp:3416
+#: src/muuli_wdr.cpp:2640 src/muuli_wdr.cpp:3092 src/muuli_wdr.cpp:3447
 msgid "Connect"
 msgstr "Coneutar"
 
@@ -756,7 +756,7 @@ msgstr "Confirmar colar."
 msgid "Launch Command: "
 msgstr "Llanzar comandu:"
 
-#: src/amuleDlg.cpp:1632 src/muuli_wdr.cpp:1978 src/Preferences.cpp:952
+#: src/amuleDlg.cpp:1632 src/muuli_wdr.cpp:1982 src/Preferences.cpp:979
 msgid "- default -"
 msgstr "- Por defeutu -"
 
@@ -770,49 +770,49 @@ msgstr "El direutorio de tema '%s' nun esiste"
 msgid "WARNING: Unable to open skin file '%s' for read"
 msgstr "ATENCIÓN: Nun pue abrise'l ficheru de temes '%s' pa llectura"
 
-#: src/amuleDlg.cpp:1791 src/muuli_wdr.cpp:3418
+#: src/amuleDlg.cpp:1791 src/muuli_wdr.cpp:3449
 msgid "Networks Window"
 msgstr "Ventana de redes"
 
-#: src/amuleDlg.cpp:1797 src/muuli_wdr.cpp:3419
+#: src/amuleDlg.cpp:1797 src/muuli_wdr.cpp:3450
 msgid "Searches Window"
 msgstr "Ventana de gueta"
 
-#: src/amuleDlg.cpp:1803 src/muuli_wdr.cpp:3420
+#: src/amuleDlg.cpp:1803 src/muuli_wdr.cpp:3451
 #, fuzzy
 msgid "Downloads Window"
 msgstr "Descargando"
 
-#: src/amuleDlg.cpp:1809 src/muuli_wdr.cpp:3422
+#: src/amuleDlg.cpp:1809 src/muuli_wdr.cpp:3453
 msgid "Shared Files Window"
 msgstr "Ventana de ficheros compartíos"
 
-#: src/amuleDlg.cpp:1815 src/muuli_wdr.cpp:3423
+#: src/amuleDlg.cpp:1815 src/muuli_wdr.cpp:3454
 msgid "Messages Window"
 msgstr "Ventana de mensaxes"
 
-#: src/amuleDlg.cpp:1821 src/muuli_wdr.cpp:3424
+#: src/amuleDlg.cpp:1821 src/muuli_wdr.cpp:3455
 msgid "Statistics Graph Window"
 msgstr "Ventana de gráficos d'estadístiques"
 
-#: src/amuleDlg.cpp:1828 src/muuli_wdr.cpp:3426
+#: src/amuleDlg.cpp:1828 src/muuli_wdr.cpp:3457
 msgid "Preferences Settings Window"
 msgstr "Ventana d'opciones"
 
-#: src/amuleDlg.cpp:1831 src/muuli_wdr.cpp:3427
+#: src/amuleDlg.cpp:1831 src/muuli_wdr.cpp:3458
 msgid "Import"
 msgstr "Importar"
 
-#: src/amuleDlg.cpp:1835 src/muuli_wdr.cpp:3427
+#: src/amuleDlg.cpp:1835 src/muuli_wdr.cpp:3458
 msgid "The partfile importer tool"
 msgstr "La ferramienta pa importar ficheros part"
 
-#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3428
+#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3459
 #: src/utils/aLinkCreator/src/alcframe.cpp:262
 msgid "About"
 msgstr "Tocante a"
 
-#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3428
+#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3459
 msgid "About/Help"
 msgstr "Tocante a/Aida"
 
@@ -954,7 +954,7 @@ msgstr "Ficheru non alcontráu"
 msgid "The core rejected these shared folders:%s"
 msgstr ""
 
-#: src/amule-remote-gui.cpp:1336 src/ExternalConn.cpp:2345
+#: src/amule-remote-gui.cpp:1336 src/ExternalConn.cpp:2346
 msgid "Invalid link or already on list."
 msgstr "Enllaz non válidu o yá ta na llista."
 
@@ -970,7 +970,7 @@ msgstr "Nun puede crease'l direutoriu '%s' pa la categoría '%s', calteniendo di
 #: src/ClientDetailDialog.cpp:123 src/DataToText.cpp:61 src/DataToText.cpp:86
 #: src/DataToText.cpp:101 src/DataToText.cpp:136 src/DataToText.cpp:165
 #: src/DownloadListCtrl.cpp:1172 src/DownloadListCtrl.cpp:1185
-#: src/DownloadListCtrl.cpp:1196 src/ExternalConn.cpp:608
+#: src/DownloadListCtrl.cpp:1196 src/ExternalConn.cpp:609
 #: src/FileDetailDialog.cpp:203 src/FileDetailDialog.cpp:235
 #: src/FileDetailDialog.cpp:242 src/GenericClientListCtrl.cpp:1171
 #: src/GenericClientListCtrl.cpp:1182 src/GenericClientListCtrl.cpp:1192
@@ -1358,19 +1358,19 @@ msgstr "Auto [Al]"
 msgid "Very low"
 msgstr "Mui baxa"
 
-#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:743 src/muuli_wdr.cpp:2282
+#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:743 src/muuli_wdr.cpp:2313
 #: src/ServerListCtrl.cpp:263 src/ServerListCtrl.cpp:456
 #: src/SharedFilesCtrl.cpp:145
 msgid "Low"
 msgstr "Baxa"
 
-#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:744 src/muuli_wdr.cpp:2283
+#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:744 src/muuli_wdr.cpp:2314
 #: src/ServerListCtrl.cpp:266 src/ServerListCtrl.cpp:457
 #: src/SharedFilesCtrl.cpp:146
 msgid "Normal"
 msgstr "Normal"
 
-#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:745 src/muuli_wdr.cpp:2284
+#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:745 src/muuli_wdr.cpp:2315
 #: src/ServerListCtrl.cpp:269 src/ServerListCtrl.cpp:458
 #: src/SharedFilesCtrl.cpp:147
 msgid "High"
@@ -1462,7 +1462,7 @@ msgstr "Sirvidor llocal"
 msgid "Remote Server"
 msgstr "Sirvidor remotu"
 
-#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3181
+#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3212
 #: src/SearchDlg.cpp:119 src/TextClient.cpp:911
 msgid "Kad"
 msgstr "Kad"
@@ -1534,7 +1534,7 @@ msgstr "Parte"
 msgid "Size"
 msgstr "Tamañu"
 
-#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3248
+#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3279
 msgid "Transferred"
 msgstr "Tresferío"
 
@@ -1592,7 +1592,7 @@ msgstr ""
 "Reaición dende: %s (%s)\n"
 "\n"
 
-#: src/DownloadListCtrl.cpp:746 src/muuli_wdr.cpp:2285
+#: src/DownloadListCtrl.cpp:746 src/muuli_wdr.cpp:2316
 #: src/SharedFilesCtrl.cpp:150
 msgid "Auto"
 msgstr "Auto"
@@ -1630,7 +1630,7 @@ msgid "Extended Options"
 msgstr "Opciones estendíes"
 
 #: src/DownloadListCtrl.cpp:770 src/DownloadListCtrl.cpp:822
-#: src/muuli_wdr.cpp:1796
+#: src/muuli_wdr.cpp:1800
 msgid "Preview"
 msgstr "Previsualizar"
 
@@ -1805,230 +1805,235 @@ msgstr[1] ""
 msgid "Invalid eD2k link! ERROR: %s"
 msgstr "Enllaz eD2k inválidu! FALLU: %s"
 
-#: src/ExternalConn.cpp:379
+#: src/ExternalConn.cpp:380
 msgid "Client sent packet after authentication failed."
 msgstr "El veceru unvió un paquete dempués que falló l'autenticación."
 
-#: src/ExternalConn.cpp:396
+#: src/ExternalConn.cpp:397
 msgid "External connection closed."
 msgstr "Conexón esterna zarrada."
 
-#: src/ExternalConn.cpp:473
+#: src/ExternalConn.cpp:474
 msgid "External connections disabled due to empty password!"
 msgstr "¡Conexones esternas deshabilitaes darréu d'una contraseña en blanco!"
 
-#: src/ExternalConn.cpp:494
+#: src/ExternalConn.cpp:495
 msgid "External connections disabled in config file"
 msgstr "Conexones esternas deshabilitaes nel ficheru de configuración"
 
-#: src/ExternalConn.cpp:575
+#: src/ExternalConn.cpp:576
 msgid "New external connection accepted"
 msgstr "Nueva conexón esterna, aceutada"
 
-#: src/ExternalConn.cpp:578
+#: src/ExternalConn.cpp:579
 msgid "ERROR: couldn't accept a new external connection"
 msgstr "FALLU: nun pudo aceutase una nueva conexón esterna"
 
-#: src/ExternalConn.cpp:595
+#: src/ExternalConn.cpp:596
 msgid "External connection refused due to empty password in preferences!"
 msgstr "¡Conexón esterna refugada darréu d'una contraseña en blanco nes opciones!"
 
-#: src/ExternalConn.cpp:607
+#: src/ExternalConn.cpp:608
 #, c-format
 msgid "Connecting client: %s %s"
 msgstr "Coneutando con veceru: %s %s"
 
-#: src/ExternalConn.cpp:609
+#: src/ExternalConn.cpp:610
 msgid "Unknown version"
 msgstr "Versión desconocía"
 
-#: src/ExternalConn.cpp:622
+#: src/ExternalConn.cpp:623
 msgid "Incorrect EC version ID, there might be binary incompatibility. Use core and remote from same snapshot."
 msgstr "EC Incorreutu na ID de versión, tien d'haber una incompatibilidá. Usa núcleu y remotu de la mesma versión."
 
-#: src/ExternalConn.cpp:630
+#: src/ExternalConn.cpp:631
 #, fuzzy
 msgid "You cannot connect to a release version from an arbitrary development snapshot! *sigh* possible crash prevented"
 msgstr "¡Nun pues coneutar a una versión final dende una versión SVN cualesquiera! *sigh* dable fallu evitáu"
 
-#: src/ExternalConn.cpp:713
+#: src/ExternalConn.cpp:714
 msgid "Invalid protocol version."
 msgstr "Versión de protocolu non válida"
 
-#: src/ExternalConn.cpp:719
+#: src/ExternalConn.cpp:720
 msgid "Missing protocol version tag."
 msgstr "Marcador de versión de protocolu inesistente"
 
-#: src/ExternalConn.cpp:727
+#: src/ExternalConn.cpp:728
 msgid "Authentication failed: invalid hash specified as EC password."
 msgstr ""
 
-#: src/ExternalConn.cpp:775
+#: src/ExternalConn.cpp:776
 #, fuzzy
 msgid "Authentication failed: wrong password."
 msgstr "Autenticación fallía"
 
-#: src/ExternalConn.cpp:777
+#: src/ExternalConn.cpp:778
 #, fuzzy
 msgid "Authentication failed: missing password."
 msgstr "Autenticación fallía"
 
-#: src/ExternalConn.cpp:788
+#: src/ExternalConn.cpp:789
 msgid "Invalid request, please authenticate first."
 msgstr "Solicitú non válida, tendríes d'autenticate primero."
 
-#: src/ExternalConn.cpp:793
+#: src/ExternalConn.cpp:794
 msgid "Access granted."
 msgstr "Accesu concedíu."
 
-#: src/ExternalConn.cpp:801
+#: src/ExternalConn.cpp:802
 #, fuzzy, c-format
 msgid "Sent error message \"%s\" to client."
 msgstr "Fieltrar mensaxes de veceros desconocíos"
 
-#: src/ExternalConn.cpp:806
+#: src/ExternalConn.cpp:807
 #, fuzzy, c-format
 msgid "Unauthorized access attempt from %s. Connection closed."
 msgstr "Intentu d'accesu non autorizáu. Conexón zarrada."
 
-#: src/ExternalConn.cpp:1419
+#: src/ExternalConn.cpp:1420
 #, c-format
 msgid "Remote PartFile command failed: FileHash not found: %s"
 msgstr "Fallu en comandu remotu del ficheru Part: Hash de ficheru non alcontráu: %s"
 
-#: src/ExternalConn.cpp:1423
+#: src/ExternalConn.cpp:1424
 #, c-format
 msgid "FileHash not found: %s"
 msgstr "Hash de ficheru non alcontráu: %s"
 
-#: src/ExternalConn.cpp:1470 src/ExternalConn.cpp:1558
-#: src/ExternalConn.cpp:1679
+#: src/ExternalConn.cpp:1471 src/ExternalConn.cpp:1559
+#: src/ExternalConn.cpp:1680
 msgid "OOPS! OpCode processing error!"
 msgstr "¡OOPS! ¡Fallu procesando OpCode!"
 
-#: src/ExternalConn.cpp:1501
+#: src/ExternalConn.cpp:1502
 msgid "Server not added"
 msgstr "Sirvidor non amestáu"
 
-#: src/ExternalConn.cpp:1520
+#: src/ExternalConn.cpp:1521
 #, c-format
 msgid "server not found: %s"
 msgstr "sirvidor non amestáu: %s"
 
-#: src/ExternalConn.cpp:1537
+#: src/ExternalConn.cpp:1538
 msgid "need to define server to be removed"
 msgstr "necesites definir un sirvidor pa desanicialu"
 
-#: src/ExternalConn.cpp:1552
+#: src/ExternalConn.cpp:1553
 msgid "eD2k is disabled in preferences."
 msgstr "eD2k ta desabilitáu nes preferencies"
 
-#: src/ExternalConn.cpp:1657
+#: src/ExternalConn.cpp:1658
 #, fuzzy
 msgid "Friend not found."
 msgstr "Ficheru non alcontráu"
 
-#: src/ExternalConn.cpp:1667
+#: src/ExternalConn.cpp:1668
 #, fuzzy
 msgid "Client not found."
 msgstr "Ficheru non alcontráu"
 
-#: src/ExternalConn.cpp:1673
+#: src/ExternalConn.cpp:1674
 msgid "EC_TAG_FRIEND_SHARED requires EC_TAG_FRIEND or EC_TAG_CLIENT."
 msgstr ""
 
-#: src/ExternalConn.cpp:1991
+#: src/ExternalConn.cpp:1992
 msgid "WebSearch from remote interface makes no sense."
 msgstr "Gueta web dende un interface remotu nun tien xacíu"
 
-#: src/ExternalConn.cpp:2026
+#: src/ExternalConn.cpp:2027
 msgid "Search in progress. Refetch results in a moment!"
 msgstr "Gueta en procesu. Resultaos obteníos aína! "
 
-#: src/ExternalConn.cpp:2265
+#: src/ExternalConn.cpp:2266
 msgid "No points for graph."
 msgstr "Ensin puntos pal gráficu."
 
-#: src/ExternalConn.cpp:2275
+#: src/ExternalConn.cpp:2276
 msgid "Your client is not configured for this detail level."
 msgstr "El to veceru nun ta configuráu pa esti nivel de detalle."
 
-#: src/ExternalConn.cpp:2302
+#: src/ExternalConn.cpp:2303
 msgid "External Connection: shutdown requested"
 msgstr "Conexón esterna: apagáu solicitáu"
 
-#: src/ExternalConn.cpp:2314
+#: src/ExternalConn.cpp:2315
 msgid "Already shutting down."
 msgstr "Yá tas zarrando."
 
-#: src/ExternalConn.cpp:2332
+#: src/ExternalConn.cpp:2333
 #, c-format
 msgid "ExternalConn: adding link '%s'."
 msgstr "Conexón esterna: amestando enllaz '%s'."
 
-#: src/ExternalConn.cpp:2350
+#: src/ExternalConn.cpp:2351
 #, fuzzy, c-format
 msgid "%d of %d links failed (invalid or already on list)."
 msgstr "Enllaz non válidu o yá ta na llista."
 
-#: src/ExternalConn.cpp:2373
+#: src/ExternalConn.cpp:2374
 msgid "Version check throttled; try again shortly."
 msgstr ""
 
-#: src/ExternalConn.cpp:2378
+#: src/ExternalConn.cpp:2379
 msgid "Version check is not available on this daemon."
 msgstr ""
 
-#: src/ExternalConn.cpp:2508
+#: src/ExternalConn.cpp:2509
 msgid "File not found."
 msgstr "Ficheru non alcontráu"
 
-#: src/ExternalConn.cpp:2513
+#: src/ExternalConn.cpp:2514
 msgid "Invalid file name."
 msgstr "Nome de ficheru incorreutu"
 
-#: src/ExternalConn.cpp:2521
+#: src/ExternalConn.cpp:2522
 msgid "Unable to rename file."
 msgstr "Nun ye dable renomar ficheru"
 
-#: src/ExternalConn.cpp:2992 src/ExternalConn.cpp:3020
+#: src/ExternalConn.cpp:2839
+#, c-format
+msgid "Could not save the amuleapi password: %s"
+msgstr ""
+
+#: src/ExternalConn.cpp:3004 src/ExternalConn.cpp:3032
 msgid "Kad is disabled in preferences."
 msgstr "Kad ta deshabilitáu n'opciones."
 
-#: src/ExternalConn.cpp:3033
+#: src/ExternalConn.cpp:3045
 msgid "Already connected to eD2k."
 msgstr "Yá tas coneutáu a eD2k."
 
-#: src/ExternalConn.cpp:3036
+#: src/ExternalConn.cpp:3048
 msgid "Connecting to eD2k..."
 msgstr "Coneutando a eD2k..."
 
-#: src/ExternalConn.cpp:3045
+#: src/ExternalConn.cpp:3057
 msgid "Already connected to Kad."
 msgstr "Yá tas coneutáu a Kad."
 
-#: src/ExternalConn.cpp:3048
+#: src/ExternalConn.cpp:3060
 msgid "Connecting to Kad..."
 msgstr "Coneutando a Kad..."
 
-#: src/ExternalConn.cpp:3055
+#: src/ExternalConn.cpp:3067
 msgid "All networks are disabled."
 msgstr "Toles redes tán deshabilitaes"
 
-#: src/ExternalConn.cpp:3064
+#: src/ExternalConn.cpp:3076
 msgid "Disconnected from eD2k."
 msgstr "Desconeutando de eD2k."
 
-#: src/ExternalConn.cpp:3069
+#: src/ExternalConn.cpp:3081
 msgid "Disconnected from Kad."
 msgstr "Desconeutando de Kad."
 
-#: src/ExternalConn.cpp:3078
+#: src/ExternalConn.cpp:3090
 #, c-format
 msgid "External Connection: invalid opcode received: %#x"
 msgstr "Conexón esterna: recibíu códigu d'operación inválidu: %#x"
 
-#: src/ExternalConn.cpp:3083
+#: src/ExternalConn.cpp:3095
 msgid "Invalid opcode (wrong protocol version?)"
 msgstr "opcode non válidu (¿versión de protocolu incorreuta?)"
 
@@ -2429,23 +2434,23 @@ msgid ""
 "want downloads on a different (e.g. larger) disk."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:549 src/FirstRunWizard.cpp:611 src/muuli_wdr.cpp:1708
+#: src/FirstRunWizard.cpp:549 src/FirstRunWizard.cpp:611 src/muuli_wdr.cpp:1712
 msgid "Destination folder for downloads"
 msgstr "Carpeta de destín pa les descargues"
 
 #: src/FirstRunWizard.cpp:553 src/FirstRunWizard.cpp:569 src/muuli_wdr.cpp:1349
-#: src/muuli_wdr.cpp:1366 src/muuli_wdr.cpp:1683 src/muuli_wdr.cpp:1714
-#: src/muuli_wdr.cpp:1726 src/muuli_wdr.cpp:2769
+#: src/muuli_wdr.cpp:1366 src/muuli_wdr.cpp:1687 src/muuli_wdr.cpp:1718
+#: src/muuli_wdr.cpp:1730 src/muuli_wdr.cpp:2800
 #: src/utils/aLinkCreator/src/alcframe.cpp:135
 #: src/utils/wxCas/src/wxcasprefs.cpp:52 src/utils/wxCas/src/wxcasprefs.cpp:118
 msgid "Browse"
 msgstr "Desaminar"
 
-#: src/FirstRunWizard.cpp:559 src/muuli_wdr.cpp:1719
+#: src/FirstRunWizard.cpp:559 src/muuli_wdr.cpp:1723
 msgid "(All files in this folder are shared with other peers)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:565 src/FirstRunWizard.cpp:624 src/muuli_wdr.cpp:1721
+#: src/FirstRunWizard.cpp:565 src/FirstRunWizard.cpp:624 src/muuli_wdr.cpp:1725
 msgid "Folder for temporary download files"
 msgstr "Carpeta pa los ficheros temporales de descargues"
 
@@ -2476,7 +2481,7 @@ msgstr "¡ Nun pudo abrise'l ficheru de collacios 'emfriends.met' pa la so escri
 msgid "CRITICAL - no client on StartChatSession"
 msgstr "CRITICU - ensin veceru en sesión charra d'aniciu"
 
-#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2675 src/muuli_wdr.cpp:3352
+#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2706 src/muuli_wdr.cpp:3383
 msgid "Friends"
 msgstr "Collacios"
 
@@ -2590,8 +2595,8 @@ msgstr "Dengún"
 msgid "No"
 msgstr "Non"
 
-#: src/GenericClientListCtrl.cpp:1216 src/PrefsUnifiedDlg.cpp:2818
-#: src/PrefsUnifiedDlg.cpp:2868 src/ServerListCtrl.cpp:276
+#: src/GenericClientListCtrl.cpp:1216 src/PrefsUnifiedDlg.cpp:2898
+#: src/PrefsUnifiedDlg.cpp:2948 src/ServerListCtrl.cpp:276
 msgid "Yes"
 msgstr "Sí"
 
@@ -2761,10 +2766,10 @@ msgstr "Puertu non válidu pa coneutar"
 msgid "Please fill all fields required"
 msgstr "Por favor enllene tolos campos requeríos"
 
-#: src/KadDlg.cpp:192 src/PartFile.cpp:1031 src/PrefsUnifiedDlg.cpp:1162
-#: src/PrefsUnifiedDlg.cpp:1331 src/PrefsUnifiedDlg.cpp:1589
-#: src/PrefsUnifiedDlg.cpp:1599 src/PrefsUnifiedDlg.cpp:1616
-#: src/PrefsUnifiedDlg.cpp:1658
+#: src/KadDlg.cpp:192 src/PartFile.cpp:1031 src/PrefsUnifiedDlg.cpp:1134
+#: src/PrefsUnifiedDlg.cpp:1204 src/PrefsUnifiedDlg.cpp:1405
+#: src/PrefsUnifiedDlg.cpp:1663 src/PrefsUnifiedDlg.cpp:1673
+#: src/PrefsUnifiedDlg.cpp:1690 src/PrefsUnifiedDlg.cpp:1738
 msgid "Message"
 msgstr "Mensax"
 
@@ -2866,7 +2871,7 @@ msgstr "Media compartío"
 msgid "Uploaded"
 msgstr "Xubío"
 
-#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3232
+#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3263
 msgid "Requested"
 msgstr "Pidío"
 
@@ -2990,7 +2995,7 @@ msgid "WARNING: "
 msgstr "AVISU:"
 
 #: src/MuleNotebook.cpp:179 src/muuli_wdr.cpp:817 src/muuli_wdr.cpp:1229
-#: src/muuli_wdr.cpp:3136 src/muuli_wdr.cpp:3392
+#: src/muuli_wdr.cpp:3167 src/muuli_wdr.cpp:3423
 msgid "Close"
 msgstr "Zarrar"
 
@@ -3008,7 +3013,7 @@ msgid "Paste"
 msgstr "Apegar"
 
 #: src/MuleTextCtrl.cpp:89 src/muuli_wdr.cpp:358 src/muuli_wdr.cpp:757
-#: src/muuli_wdr.cpp:2359 src/muuli_wdr.cpp:2378 src/muuli_wdr.cpp:2400
+#: src/muuli_wdr.cpp:2390 src/muuli_wdr.cpp:2409 src/muuli_wdr.cpp:2431
 #: src/utils/aLinkCreator/src/alcframe.cpp:142
 msgid "Clear"
 msgstr "Llimpiar"
@@ -3107,7 +3112,7 @@ msgstr "Colar"
 
 #: src/MuleTrayIcon.cpp:579 src/MuleTrayIcon.cpp:945 src/MuleTrayIcon.cpp:965
 #: src/muuli_wdr.cpp:1398 src/muuli_wdr.cpp:1406 src/muuli_wdr.cpp:1413
-#: src/muuli_wdr.cpp:1842 src/muuli_wdr.cpp:1848 src/OtherFunctions.cpp:91
+#: src/muuli_wdr.cpp:1846 src/muuli_wdr.cpp:1852 src/OtherFunctions.cpp:91
 #: src/StatisticsDlg.cpp:93 src/StatisticsDlg.cpp:95
 msgid "kB/s"
 msgstr "kB/s"
@@ -3349,7 +3354,7 @@ msgstr "Bytes"
 msgid "KB"
 msgstr "KB"
 
-#: src/muuli_wdr.cpp:274 src/muuli_wdr.cpp:293 src/muuli_wdr.cpp:1627
+#: src/muuli_wdr.cpp:274 src/muuli_wdr.cpp:293 src/muuli_wdr.cpp:1631
 #: src/OtherFunctions.cpp:64
 msgid "MB"
 msgstr "MB"
@@ -3366,7 +3371,7 @@ msgstr "Tamañu Máx"
 msgid "Availability"
 msgstr "Disponibilidá"
 
-#: src/muuli_wdr.cpp:312 src/muuli_wdr.cpp:398 src/muuli_wdr.cpp:3297
+#: src/muuli_wdr.cpp:312 src/muuli_wdr.cpp:398 src/muuli_wdr.cpp:3328
 msgid "Filter:"
 msgstr "Fieltru:"
 
@@ -3430,12 +3435,12 @@ msgstr "Fontes completes"
 #: src/muuli_wdr.cpp:1160 src/muuli_wdr.cpp:1167 src/muuli_wdr.cpp:1172
 #: src/muuli_wdr.cpp:1179 src/muuli_wdr.cpp:1184 src/muuli_wdr.cpp:1191
 #: src/muuli_wdr.cpp:1205 src/muuli_wdr.cpp:1212 src/muuli_wdr.cpp:1217
-#: src/muuli_wdr.cpp:1224 src/muuli_wdr.cpp:3234 src/muuli_wdr.cpp:3242
-#: src/muuli_wdr.cpp:3250
+#: src/muuli_wdr.cpp:1224 src/muuli_wdr.cpp:3265 src/muuli_wdr.cpp:3273
+#: src/muuli_wdr.cpp:3281
 msgid "N/A"
 msgstr "N/A"
 
-#: src/muuli_wdr.cpp:508 src/muuli_wdr.cpp:1065 src/PrefsUnifiedDlg.cpp:297
+#: src/muuli_wdr.cpp:508 src/muuli_wdr.cpp:1065 src/PrefsUnifiedDlg.cpp:299
 msgid "General"
 msgstr "Xeneral"
 
@@ -3576,7 +3581,7 @@ msgstr ""
 msgid "Album :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:685 src/muuli_wdr.cpp:2254
+#: src/muuli_wdr.cpp:685 src/muuli_wdr.cpp:2285
 msgid "Title :"
 msgstr "Títulu :"
 
@@ -3685,7 +3690,7 @@ msgstr "Nome d'usuariu :"
 msgid "Userhash :"
 msgstr "Hash del usuariu :"
 
-#: src/muuli_wdr.cpp:895 src/muuli_wdr.cpp:1748 src/muuli_wdr.cpp:2449
+#: src/muuli_wdr.cpp:895 src/muuli_wdr.cpp:1752 src/muuli_wdr.cpp:2480
 #: src/utils/aLinkCreator/src/alcframe.cpp:137
 msgid "Add"
 msgstr "Amestar"
@@ -3694,15 +3699,15 @@ msgstr "Amestar"
 msgid "Download-Speed"
 msgstr "Velocidá de descarga"
 
-#: src/muuli_wdr.cpp:954 src/muuli_wdr.cpp:989 src/muuli_wdr.cpp:2553
+#: src/muuli_wdr.cpp:954 src/muuli_wdr.cpp:989 src/muuli_wdr.cpp:2584
 msgid "Current"
 msgstr "Actual"
 
-#: src/muuli_wdr.cpp:962 src/muuli_wdr.cpp:997 src/muuli_wdr.cpp:2561
+#: src/muuli_wdr.cpp:962 src/muuli_wdr.cpp:997 src/muuli_wdr.cpp:2592
 msgid "Running average"
 msgstr "Media d'execución"
 
-#: src/muuli_wdr.cpp:970 src/muuli_wdr.cpp:1005 src/muuli_wdr.cpp:2569
+#: src/muuli_wdr.cpp:970 src/muuli_wdr.cpp:1005 src/muuli_wdr.cpp:2600
 msgid "Session average"
 msgstr "Media de la sesión"
 
@@ -3714,7 +3719,7 @@ msgstr "Velocidá de xuba"
 msgid "Connections"
 msgstr "Conexones"
 
-#: src/muuli_wdr.cpp:1024 src/muuli_wdr.cpp:1867
+#: src/muuli_wdr.cpp:1024 src/muuli_wdr.cpp:1871
 msgid "Active downloads"
 msgstr "Descargues actives"
 
@@ -3722,7 +3727,7 @@ msgstr "Descargues actives"
 msgid "Active connections (1:1)"
 msgstr "Conexones actives (1:1)"
 
-#: src/muuli_wdr.cpp:1040 src/muuli_wdr.cpp:1868
+#: src/muuli_wdr.cpp:1040 src/muuli_wdr.cpp:1872
 msgid "Active uploads"
 msgstr "Xubes actives"
 
@@ -3999,7 +4004,7 @@ msgstr "Señes IP llocal de enllaz: (erma pa cualesquiera):"
 msgid "Advanced users only: If you have multiple network interfaces, enter the address of the interface to which aMule should be bound."
 msgstr "Namái usuarios avanzaos: Si tu tienes múltiples tarxetes de rede, introduz la direición de la tarxeta, que aMule tendrá d'usar."
 
-#: src/muuli_wdr.cpp:1462 src/muuli_wdr.cpp:2061
+#: src/muuli_wdr.cpp:1462 src/muuli_wdr.cpp:2065
 #, fuzzy
 msgid "Bind to network interface (empty for any):"
 msgstr "Señes IP llocal de enllaz: (erma pa cualesquiera):"
@@ -4016,7 +4021,7 @@ msgstr "Max. fontes descargando un ficheru:"
 msgid "Max simultaneous connections:"
 msgstr "Máx. conexones al empar:"
 
-#: src/muuli_wdr.cpp:1498 src/muuli_wdr.cpp:3176
+#: src/muuli_wdr.cpp:1498 src/muuli_wdr.cpp:3207
 msgid "ED2K"
 msgstr "ED2K"
 
@@ -4108,760 +4113,783 @@ msgstr "Reservar espaciu en discu pa los nuevos ficheros"
 msgid "For new files preallocates disk space for the whole file, thus reduces fragmentation"
 msgstr "Pa los nuevos ficheros reservar tol espaciu del ficheru, esto amenorga la fragmentación"
 
-#: src/muuli_wdr.cpp:1613
+#: src/muuli_wdr.cpp:1617
 msgid "Create new files as sparse files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1614
-msgid "A sparse file reserves its full size on disk immediately without writing real data to it -- fast, but unsupported or slow on some filesystems, and free-space accounting stays optimistic while the download is in progress. Turn this off to grow the file only as data arrives."
+#: src/muuli_wdr.cpp:1618
+msgid "Sparse part files only occupy disk space for the parts already downloaded, so free space is used up gradually as the file fills in. Turn this off to use an ordinary file instead - useful where sparse files are unsupported or slow, or where backup/de-duplication tools handle them badly. Applies only when the core runs on Windows; on Linux and macOS part files are sparse anyway and this setting has no effect."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1619
+#: src/muuli_wdr.cpp:1623
 msgid "Stop downloads when free disk space reaches "
 msgstr "Detener descargues cuando s'algame l'espaciu llibre en discu"
 
-#: src/muuli_wdr.cpp:1620
+#: src/muuli_wdr.cpp:1624
 msgid "Select this if you want aMule to check your disk space"
 msgstr "Seleiciona esta opción si quies que aMule comprebe l'espaciu en discu"
 
-#: src/muuli_wdr.cpp:1624
+#: src/muuli_wdr.cpp:1628
 msgid "Enter here the min disk space desired."
 msgstr "Introduz l'espaciu mínimu de discu deseyáu."
 
-#: src/muuli_wdr.cpp:1630
+#: src/muuli_wdr.cpp:1634
 msgid "Save 10 sources on rare files (< 20 sources)"
 msgstr "Guardar 10 fontes en ficheros raros (< 20 fontes)"
 
-#: src/muuli_wdr.cpp:1634 src/Statistics.cpp:790
+#: src/muuli_wdr.cpp:1638 src/Statistics.cpp:790
 msgid "Uploads"
 msgstr "Xubíes"
 
-#: src/muuli_wdr.cpp:1637
+#: src/muuli_wdr.cpp:1641
 msgid "Add new shared files with auto priority"
 msgstr "Amestar nuevos ficheros compartíos con auto prioridá"
 
-#: src/muuli_wdr.cpp:1643
+#: src/muuli_wdr.cpp:1647
 msgid "Intelligent Corruption Handling (I.C.H.)"
 msgstr "Remanador Intelixente de Corrupciones (I.C.H)"
 
-#: src/muuli_wdr.cpp:1646
+#: src/muuli_wdr.cpp:1650
 msgid "Enable"
 msgstr "Habilitar"
 
-#: src/muuli_wdr.cpp:1649
+#: src/muuli_wdr.cpp:1653
 msgid "Advanced I.C.H. trusts every hash (not recommended)"
 msgstr "I.C.H. avanzáu, confiar en tolos hash (non recomendáu)"
 
-#: src/muuli_wdr.cpp:1661 src/PrefsUnifiedDlg.cpp:1910
+#: src/muuli_wdr.cpp:1665 src/PrefsUnifiedDlg.cpp:1990
 msgid "Media metadata extraction"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1665
+#: src/muuli_wdr.cpp:1669
 msgid "Extract length / bitrate / codec from shared audio and video files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1667
+#: src/muuli_wdr.cpp:1671
 msgid "When enabled, aMule runs ffprobe on each shared media file to fill in the Length / Bitrate / Codec columns other clients see when they find the file in a search. Requires ffmpeg (the ffprobe binary) to be installed."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1674
+#: src/muuli_wdr.cpp:1678
 msgid "Path to ffprobe:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1679
+#: src/muuli_wdr.cpp:1683
 msgid "Full path to the ffprobe binary. Leave empty to have aMule auto-detect it on startup."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1687
+#: src/muuli_wdr.cpp:1691
 msgid "Detect"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1688
+#: src/muuli_wdr.cpp:1692
 msgid "Search the standard install locations for an ffprobe binary and fill the path field."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1712
+#: src/muuli_wdr.cpp:1716
 msgid ""
 "Completed downloads are stored here. All files in this folder are automatically shared with other peers.\n"
 "If this folder also holds files you don't want to share, point it at an aMule-only sub-folder."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1715
+#: src/muuli_wdr.cpp:1719
 msgid "Pick the folder where completed downloads will be stored. All files in that folder will be shared with other peers."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1729
+#: src/muuli_wdr.cpp:1733
 msgid "Shared folders"
 msgstr "Carpetes compartíes"
 
-#: src/muuli_wdr.cpp:1735
+#: src/muuli_wdr.cpp:1739
 msgid "(Folders shared by the core. Enter a path to add one.)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1743
+#: src/muuli_wdr.cpp:1747
 msgid "Absolute path of a folder on the core's machine, e.g. /home/user/shared"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1745 src/PrefsUnifiedDlg.cpp:2794
+#: src/muuli_wdr.cpp:1749 src/PrefsUnifiedDlg.cpp:2874
 msgid "Recursive"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1746
+#: src/muuli_wdr.cpp:1750
 msgid "Share every sub-folder underneath this one, including ones created later."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1750 src/utils/aLinkCreator/src/alcframe.cpp:141
+#: src/muuli_wdr.cpp:1754 src/utils/aLinkCreator/src/alcframe.cpp:141
 msgid "Remove"
 msgstr "Desaniciar"
 
-#: src/muuli_wdr.cpp:1754
+#: src/muuli_wdr.cpp:1758
 msgid "(Right click on folder icon for recursive share)"
 msgstr "(Click drechu n'iconu de carpeta, pa compartición recursiva)"
 
-#: src/muuli_wdr.cpp:1761
+#: src/muuli_wdr.cpp:1765
 msgid "Share hidden files"
 msgstr "Compartir ficheros anubríos"
 
-#: src/muuli_wdr.cpp:1767
+#: src/muuli_wdr.cpp:1771
 msgid "Automatically rescan shared folders for changes"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1773
+#: src/muuli_wdr.cpp:1777
 msgid "Follow symbolic links in shared folders"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1779
+#: src/muuli_wdr.cpp:1783
 msgid "Exclude files matching:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1782
+#: src/muuli_wdr.cpp:1786
 msgid "Wildcard patterns separated by '|', e.g. .DS_Store|Thumbs.db|*.tmp. Files whose name matches are not shared. Matching is case-insensitive."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1786
+#: src/muuli_wdr.cpp:1790
 msgid "Patterns are regular expressions"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1787
+#: src/muuli_wdr.cpp:1791
 msgid "When set, the whole field is one regular expression ('|' is alternation). When unset, it is a list of '|'-separated wildcards."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1797
+#: src/muuli_wdr.cpp:1801
 msgid "Show how many shared files the current pattern would exclude."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1818
+#: src/muuli_wdr.cpp:1822
 msgid "Graphs"
 msgstr "Gráficos"
 
-#: src/muuli_wdr.cpp:1821 src/muuli_wdr.cpp:1883
+#: src/muuli_wdr.cpp:1825 src/muuli_wdr.cpp:1887
 msgid "Update delay : 5 secs"
 msgstr "Intervalu d'actualización : 5 segs"
 
-#: src/muuli_wdr.cpp:1825
+#: src/muuli_wdr.cpp:1829
 msgid "Time for average graph: 100 mins"
 msgstr "Tiempu de promediu del gráficu: 100 min"
 
-#: src/muuli_wdr.cpp:1829
+#: src/muuli_wdr.cpp:1833
 msgid "Connections Graph Scale: 100 "
 msgstr "Escala del gráficu de les conexones: 100"
 
-#: src/muuli_wdr.cpp:1836
+#: src/muuli_wdr.cpp:1840
 msgid "Download graph scale:"
 msgstr "Descargar escala gráfica:"
 
-#: src/muuli_wdr.cpp:1844
+#: src/muuli_wdr.cpp:1848
 msgid "Upload graph scale:"
 msgstr "Escala gráfica de descarga:"
 
-#: src/muuli_wdr.cpp:1854
+#: src/muuli_wdr.cpp:1858
 #, fuzzy
 msgid "Colors: "
 msgstr "Colores: "
 
-#: src/muuli_wdr.cpp:1858
+#: src/muuli_wdr.cpp:1862
 msgid "Background"
 msgstr "Fondu"
 
-#: src/muuli_wdr.cpp:1859
+#: src/muuli_wdr.cpp:1863
 msgid "Grid"
 msgstr "Rexella"
 
-#: src/muuli_wdr.cpp:1860
+#: src/muuli_wdr.cpp:1864
 msgid "Download current"
 msgstr "Descarga actual"
 
-#: src/muuli_wdr.cpp:1861
+#: src/muuli_wdr.cpp:1865
 msgid "Download running average"
 msgstr "Promediu descarga n'execución"
 
-#: src/muuli_wdr.cpp:1862
+#: src/muuli_wdr.cpp:1866
 msgid "Download session average"
 msgstr "Promediu Descarga/sesión"
 
-#: src/muuli_wdr.cpp:1863
+#: src/muuli_wdr.cpp:1867
 msgid "Upload current"
 msgstr "Xuba actual"
 
-#: src/muuli_wdr.cpp:1864
+#: src/muuli_wdr.cpp:1868
 msgid "Upload running average"
 msgstr "Promediu Xuba/tiempu"
 
-#: src/muuli_wdr.cpp:1865
+#: src/muuli_wdr.cpp:1869
 msgid "Upload session average"
 msgstr "Promediu xuba/sesión"
 
-#: src/muuli_wdr.cpp:1866
+#: src/muuli_wdr.cpp:1870
 msgid "Active connections"
 msgstr "Conexones actives"
 
-#: src/muuli_wdr.cpp:1869
+#: src/muuli_wdr.cpp:1873
 #, fuzzy
 msgid "Systray Icon Speed Bar"
 msgstr "Barra de velocidá del iconu de sistema"
 
-#: src/muuli_wdr.cpp:1870
+#: src/muuli_wdr.cpp:1874
 msgid "Kad-nodes current"
 msgstr "Kad-nodos actual"
 
-#: src/muuli_wdr.cpp:1871
+#: src/muuli_wdr.cpp:1875
 msgid "Kad-nodes running"
 msgstr "Kad-nodos executando"
 
-#: src/muuli_wdr.cpp:1872
+#: src/muuli_wdr.cpp:1876
 msgid "Kad-nodes session"
 msgstr "Kad-nodos sesión"
 
-#: src/muuli_wdr.cpp:1876 src/muuli_wdr.cpp:2303
+#: src/muuli_wdr.cpp:1880 src/muuli_wdr.cpp:2334
 msgid "Select"
 msgstr "Seleicionar"
 
-#: src/muuli_wdr.cpp:1880
+#: src/muuli_wdr.cpp:1884
 msgid "Tree"
 msgstr "Árbol"
 
-#: src/muuli_wdr.cpp:1890
+#: src/muuli_wdr.cpp:1894
 msgid "Number of Client Versions shown (0=unlimited)"
 msgstr "Númberu de versiones de veceros a amosar (0=ensin llímite)"
 
-#: src/muuli_wdr.cpp:1915
+#: src/muuli_wdr.cpp:1919
 msgid "!!! WARNING !!!"
 msgstr "¡¡¡ AVISU !!!"
 
-#: src/muuli_wdr.cpp:1930
+#: src/muuli_wdr.cpp:1934
 msgid "Max new connections / 5 secs"
 msgstr "Nueves conexones máx. / 5 segs"
 
-#: src/muuli_wdr.cpp:1932
+#: src/muuli_wdr.cpp:1936
 msgid "Concurrent Kad source lookups"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1934
+#: src/muuli_wdr.cpp:1938
 #, fuzzy
 msgid "Kad source re-search interval (minutes)"
 msgstr "Intervalu d'actualización de FTP en minutos"
 
-#: src/muuli_wdr.cpp:1936
+#: src/muuli_wdr.cpp:1940
 #, fuzzy
 msgid "Source re-ask interval (minutes)"
 msgstr "Intervalu d'actualización de FTP en minutos"
 
-#: src/muuli_wdr.cpp:1940
+#: src/muuli_wdr.cpp:1944
 msgid "File Buffer Size: 240000 bytes"
 msgstr "Tamañu del buffer de ficheru: 240000 bytes"
 
-#: src/muuli_wdr.cpp:1944
+#: src/muuli_wdr.cpp:1948
 msgid "Use MMAP: memory-mapped file access (lower memory use)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1945
+#: src/muuli_wdr.cpp:1949
 msgid "Maps part files into memory instead of buffering them on the heap, lowering the process memory footprint. May reduce download speed on some disks; best for memory-constrained or upload-heavy hosts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1947
+#: src/muuli_wdr.cpp:1951
 msgid "Upload Queue Size: 5000 clients"
 msgstr "Tamañu cola d'espera: 5000 veceros"
 
-#: src/muuli_wdr.cpp:1951
+#: src/muuli_wdr.cpp:1955
 msgid "Server connection refresh interval: Disable"
 msgstr "Intervalu d'actualización de conexón al sirvidor: Desactiváu"
 
-#: src/muuli_wdr.cpp:1955
+#: src/muuli_wdr.cpp:1959
 msgid "Disable computer's timed standby mode"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1974
+#: src/muuli_wdr.cpp:1978
 msgid "Skin to use: "
 msgstr "Tema a usar: "
 
-#: src/muuli_wdr.cpp:1983
+#: src/muuli_wdr.cpp:1987
 msgid "Show \"Fast eD2k Links Handler\" in every window."
 msgstr "Amosar \"Xestor rápidu d'enllaces eD2k\", en toles ventanes."
 
-#: src/muuli_wdr.cpp:1986
+#: src/muuli_wdr.cpp:1990
 msgid "Show extended info on categories tabs"
 msgstr "Amosar info estendía nes llingüetes de les categoríes"
 
-#: src/muuli_wdr.cpp:1989
+#: src/muuli_wdr.cpp:1993
 #, fuzzy
 msgid "Show application version on title"
 msgstr "Amosar índices de tresferencia nel títulu"
 
-#: src/muuli_wdr.cpp:1991
+#: src/muuli_wdr.cpp:1995
 msgid "Show transfer rates on title"
 msgstr "Amosar índices de tresferencia nel títulu"
 
-#: src/muuli_wdr.cpp:1993
+#: src/muuli_wdr.cpp:1997
 msgid "Before application name"
 msgstr "Enantes del nome de l'aplicación"
 
-#: src/muuli_wdr.cpp:1995
+#: src/muuli_wdr.cpp:1999
 msgid "After application name"
 msgstr "Dempués del nome de l'aplicación"
 
-#: src/muuli_wdr.cpp:1998
+#: src/muuli_wdr.cpp:2002
 msgid "Show overhead bandwidth"
 msgstr "Amosar anchor de banda escedente"
 
-#: src/muuli_wdr.cpp:2002
+#: src/muuli_wdr.cpp:2006
 msgid "Vertical toolbar orientation"
 msgstr "Orientación vertical de la barra de ferramientes"
 
-#: src/muuli_wdr.cpp:2004
+#: src/muuli_wdr.cpp:2008
 msgid "Live column sorting (auto-reorder rows as their values change)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2011
+#: src/muuli_wdr.cpp:2015
 msgid "Download Queue Files"
 msgstr "Ficheros de la cola de descarga"
 
-#: src/muuli_wdr.cpp:2014
+#: src/muuli_wdr.cpp:2018
 msgid "Show progress percentage"
 msgstr "Amosar porcentax de progresu"
 
-#: src/muuli_wdr.cpp:2020
+#: src/muuli_wdr.cpp:2024
 msgid "Show progress bar"
 msgstr "Amosar barra de progresu"
 
-#: src/muuli_wdr.cpp:2023
+#: src/muuli_wdr.cpp:2027
 msgid "Flat"
 msgstr "Planu"
 
-#: src/muuli_wdr.cpp:2027
+#: src/muuli_wdr.cpp:2031
 msgid "Round"
 msgstr "3D"
 
-#: src/muuli_wdr.cpp:2045
+#: src/muuli_wdr.cpp:2049
 msgid "External Connection Parameters"
 msgstr "Parámetros de conexón esterna"
 
-#: src/muuli_wdr.cpp:2048
+#: src/muuli_wdr.cpp:2052
 msgid "Accept external connections"
 msgstr "Aceutar conexones esternes"
 
-#: src/muuli_wdr.cpp:2055 src/muuli_wdr.cpp:2114
+#: src/muuli_wdr.cpp:2059 src/muuli_wdr.cpp:2118
 msgid "IP of the listening interface:"
 msgstr "IP de la interface que ta escuchando"
 
-#: src/muuli_wdr.cpp:2058
+#: src/muuli_wdr.cpp:2062
 msgid "Enter here a valid ip in the a.b.c.d format for the listening EC interface. An empty field or 0.0.0.0 will mean any interface."
 msgstr "Introduz una IP válida de la interface que ta escuchando. Un campu ermu o 0.0.0.0 significará cualesquier interface."
 
-#: src/muuli_wdr.cpp:2079 src/muuli_wdr.cpp:2163
+#: src/muuli_wdr.cpp:2083 src/muuli_wdr.cpp:2194
 msgid "TCP port:"
 msgstr "Puertu TCP:"
 
-#: src/muuli_wdr.cpp:2085
+#: src/muuli_wdr.cpp:2089
 msgid "Enable UPnP port forwarding on the EC port"
 msgstr "Habilitar UPnP port forwarding nel puertu EC"
 
-#: src/muuli_wdr.cpp:2089 src/muuli_wdr.cpp:3048
+#: src/muuli_wdr.cpp:2093 src/muuli_wdr.cpp:3079
 #: src/utils/wxCas/src/wxcasprefs.cpp:167
 msgid "Password"
 msgstr "Contraseña"
 
-#: src/muuli_wdr.cpp:2095
+#: src/muuli_wdr.cpp:2099
 #, fuzzy
 msgid "aMule API server parameters"
 msgstr "Parámetros del sirvidor web"
 
-#: src/muuli_wdr.cpp:2098
+#: src/muuli_wdr.cpp:2102
 msgid "Run amuleapi (REST API) on startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2103
+#: src/muuli_wdr.cpp:2107
 #, fuzzy
 msgid "HTTP port:"
 msgstr "Puertu TCP:"
 
-#: src/muuli_wdr.cpp:2117
+#: src/muuli_wdr.cpp:2121
 msgid "The interface amuleapi's HTTP server listens on. 127.0.0.1 (default) accepts only local connections; use 0.0.0.0 or a specific IP to expose it to other hosts (set an admin password below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2120
+#: src/muuli_wdr.cpp:2126
+msgid "Type a password to set or change it. Stored passwords cannot be shown, so leaving this empty keeps the current one."
+msgstr ""
+
+#: src/muuli_wdr.cpp:2128
 #, fuzzy
 msgid "Admin password"
 msgstr "Comprobando contraseña\n"
 
-#: src/muuli_wdr.cpp:2125 src/muuli_wdr.cpp:2156
-msgid "Low rights password"
-msgstr "Contraseña invitáu"
+#: src/muuli_wdr.cpp:2140 src/muuli_wdr.cpp:2157 src/PrefsUnifiedDlg.cpp:1103
+#, fuzzy
+msgid "A password is set."
+msgstr "Comprobando contraseña\n"
 
-#: src/muuli_wdr.cpp:2133
+#: src/muuli_wdr.cpp:2144
+#, fuzzy
+msgid "Enable guest access"
+msgstr "Denegar accesu a invitáu"
+
+#: src/muuli_wdr.cpp:2145
+msgid "Guest sessions may read status and listings but cannot change anything. Turning this off clears the stored guest password."
+msgstr ""
+
+#: src/muuli_wdr.cpp:2149
+#, fuzzy
+msgid "Guest password"
+msgstr "Contraseña d'invitáu pa sirvidor web"
+
+#: src/muuli_wdr.cpp:2164
 msgid "Web server parameters"
 msgstr "Parámetros del sirvidor web"
 
-#: src/muuli_wdr.cpp:2136
+#: src/muuli_wdr.cpp:2167
 #, fuzzy
 msgid "Run webserver on startup (deprecated)"
 msgstr "Aniciar sirvidor web al entamu"
 
-#: src/muuli_wdr.cpp:2142
+#: src/muuli_wdr.cpp:2173
 msgid "Web template"
 msgstr "Plantía Web"
 
-#: src/muuli_wdr.cpp:2147
+#: src/muuli_wdr.cpp:2178
 msgid "Full rights password"
 msgstr "Contraseña alministrador"
 
-#: src/muuli_wdr.cpp:2151
+#: src/muuli_wdr.cpp:2182
 msgid "Enable Low rights User"
 msgstr "Activar invitáu"
 
-#: src/muuli_wdr.cpp:2170
+#: src/muuli_wdr.cpp:2187
+msgid "Low rights password"
+msgstr "Contraseña invitáu"
+
+#: src/muuli_wdr.cpp:2201
 msgid "Enable UPnP port forwarding of the web server port"
 msgstr "Usar forwarding de puertos UPnP nel puertu del sirvidor web"
 
-#: src/muuli_wdr.cpp:2175
+#: src/muuli_wdr.cpp:2206
 msgid "Web server UPnP TCP port (Optional)"
 msgstr "Puertu HTTP del sirvidor web (Opcional)"
 
-#: src/muuli_wdr.cpp:2183
+#: src/muuli_wdr.cpp:2214
 msgid "Page Refresh Time (in secs)"
 msgstr "Tiempu d'actualización de páxina (en segs)"
 
-#: src/muuli_wdr.cpp:2190
+#: src/muuli_wdr.cpp:2221
 msgid "Enable Gzip compression"
 msgstr "Activar compresión gzip"
 
-#: src/muuli_wdr.cpp:2224
+#: src/muuli_wdr.cpp:2255
 #, fuzzy
 msgid "Reset page to defaults"
 msgstr "Por defeutu"
 
-#: src/muuli_wdr.cpp:2225
+#: src/muuli_wdr.cpp:2256
 msgid "Reset the settings on the current page to their default values."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2227 src/muuli_wdr.cpp:2313 src/ServerWnd.cpp:274
+#: src/muuli_wdr.cpp:2258 src/muuli_wdr.cpp:2344 src/ServerWnd.cpp:274
 #: src/ServerWnd.cpp:282
 msgid "OK"
 msgstr "Aceutar"
 
-#: src/muuli_wdr.cpp:2229
+#: src/muuli_wdr.cpp:2260
 msgid "Click here to apply any changes made to the preferences."
 msgstr "Aplicar cualesquier cambéu fechu nes opciones."
 
-#: src/muuli_wdr.cpp:2232
+#: src/muuli_wdr.cpp:2263
 msgid "Reset any changes made to the preferences."
 msgstr "Encaboxar cualesquier cambéu fechu nes opciones."
 
-#: src/muuli_wdr.cpp:2261
+#: src/muuli_wdr.cpp:2292
 msgid "Comment :"
 msgstr "Comentariu : "
 
-#: src/muuli_wdr.cpp:2268
+#: src/muuli_wdr.cpp:2299
 msgid "Incoming Dir :"
 msgstr "Direutoriu entrante :"
 
-#: src/muuli_wdr.cpp:2277
+#: src/muuli_wdr.cpp:2308
 msgid "Change priority for new assigned files :"
 msgstr "Cambiar prioridá a nuevos ficheros asignaos :"
 
-#: src/muuli_wdr.cpp:2281
+#: src/muuli_wdr.cpp:2312
 #, fuzzy
 msgid "Don't change"
 msgstr "Non cambiar"
 
-#: src/muuli_wdr.cpp:2293
+#: src/muuli_wdr.cpp:2324
 msgid "Select color for this Category (currently selected) :"
 msgstr "Seleiciona color pa esta categoría (seleicionada) :"
 
-#: src/muuli_wdr.cpp:2360 src/muuli_wdr.cpp:2379 src/muuli_wdr.cpp:2401
+#: src/muuli_wdr.cpp:2391 src/muuli_wdr.cpp:2410 src/muuli_wdr.cpp:2432
 msgid "Click this button to reset the log."
 msgstr "Calca esti botón pa llimpiar el registru."
 
-#: src/muuli_wdr.cpp:2420
+#: src/muuli_wdr.cpp:2451
 msgid "Click on this button to update the servers list from URL ..."
 msgstr "Click nesti botón p'actualizar la llista de sirvidores dende una URL ..."
 
-#: src/muuli_wdr.cpp:2424
+#: src/muuli_wdr.cpp:2455
 msgid "Server list"
 msgstr "Llista de sirvidores"
 
-#: src/muuli_wdr.cpp:2428
+#: src/muuli_wdr.cpp:2459
 msgid "Enter the url to a server.met file here and press the button to the left to update the list of known servers."
 msgstr "Introduz la url a un ficheru server.met y calca'l botón de la esquierda p'actualizar la llista de sirvidores conocíos."
 
-#: src/muuli_wdr.cpp:2433
+#: src/muuli_wdr.cpp:2464
 msgid "Add server manually: Name"
 msgstr "Amestar sirvidor manualmente: Nome"
 
-#: src/muuli_wdr.cpp:2436
+#: src/muuli_wdr.cpp:2467
 msgid "Enter the name of the new server here"
 msgstr "Introduz el nome del nuevu sirvidor"
 
-#: src/muuli_wdr.cpp:2438 src/ServerWnd.cpp:206
+#: src/muuli_wdr.cpp:2469 src/ServerWnd.cpp:206
 msgid "IP:Port"
 msgstr "IP:Puertu"
 
-#: src/muuli_wdr.cpp:2441
+#: src/muuli_wdr.cpp:2472
 msgid "Enter the IP of the server here, using the x.x.x.x format."
 msgstr "Introduz la IP del sirvidor, usando'l formatu X.X.X.X."
 
-#: src/muuli_wdr.cpp:2447
+#: src/muuli_wdr.cpp:2478
 msgid "Enter the port of the server here."
 msgstr "Introduz el puertu del sirvidor"
 
-#: src/muuli_wdr.cpp:2450
+#: src/muuli_wdr.cpp:2481
 msgid "Add manually a server (fill fields to the left before) ..."
 msgstr "Amestar manualmente un sirvidor (rellena los campos) ..."
 
-#: src/muuli_wdr.cpp:2479
+#: src/muuli_wdr.cpp:2510
 msgid "aMule Log"
 msgstr "Rexistru"
 
-#: src/muuli_wdr.cpp:2487
+#: src/muuli_wdr.cpp:2518
 msgid "Server Info"
 msgstr "Info. sirvidores"
 
-#: src/muuli_wdr.cpp:2491
+#: src/muuli_wdr.cpp:2522
 msgid "ED2K Info"
 msgstr "Info ED2K"
 
-#: src/muuli_wdr.cpp:2495
+#: src/muuli_wdr.cpp:2526
 msgid "Kad Info"
 msgstr "Info Kad"
 
-#: src/muuli_wdr.cpp:2523
+#: src/muuli_wdr.cpp:2554
 msgid "Click on this button to update the nodes list from URL ..."
 msgstr "Click nesti botón p'actualizar la llista de nodos dende la URL ..."
 
-#: src/muuli_wdr.cpp:2527
+#: src/muuli_wdr.cpp:2558
 msgid "Nodes (0)"
 msgstr "Nodos (0)"
 
-#: src/muuli_wdr.cpp:2531
+#: src/muuli_wdr.cpp:2562
 msgid "Enter the url to a nodes.dat file here and press the button to the left to update the list of known nodes."
 msgstr "Introduz equí la url al ficheru nodes.dat y calca'l botón de la esquierda, p'actualizar la llista de nodos conocíos."
 
-#: src/muuli_wdr.cpp:2534
+#: src/muuli_wdr.cpp:2565
 msgid "Nodes stats"
 msgstr "Estadístiques nodos"
 
-#: src/muuli_wdr.cpp:2576
+#: src/muuli_wdr.cpp:2607
 msgid "Bootstrap"
 msgstr "Coneutar"
 
-#: src/muuli_wdr.cpp:2579
+#: src/muuli_wdr.cpp:2610
 msgid "New node"
 msgstr "Nuevu nodu"
 
-#: src/muuli_wdr.cpp:2584
+#: src/muuli_wdr.cpp:2615
 msgid "IP:"
 msgstr "IP:"
 
-#: src/muuli_wdr.cpp:2604
+#: src/muuli_wdr.cpp:2635
 msgid "Port:"
 msgstr "Puertu:"
 
-#: src/muuli_wdr.cpp:2617
+#: src/muuli_wdr.cpp:2648
 #, fuzzy
 msgid "Bootstrap from known clients"
 msgstr ""
 "Coneutar dende \n"
 "veceros conocíos"
 
-#: src/muuli_wdr.cpp:2619
+#: src/muuli_wdr.cpp:2650
 msgid "Disconnect Kad"
 msgstr "Desconeutar Kad"
 
-#: src/muuli_wdr.cpp:2653
+#: src/muuli_wdr.cpp:2684
 msgid "Use Secure User Identification"
 msgstr "Usar Identificación Segura d'Usuariu"
 
-#: src/muuli_wdr.cpp:2655
+#: src/muuli_wdr.cpp:2686
 msgid "It is recommended to enable this option. You will not receive credits if SUI is not enabled."
 msgstr "Encamiéntase a activar esta opción. Nun recibirá créditos si la ISU (Identificación Segura d'Usuariu) nun ta habilitada."
 
-#: src/muuli_wdr.cpp:2657
+#: src/muuli_wdr.cpp:2688
 msgid "Protocol Obfuscation"
 msgstr "Ofuscación de protocolu"
 
-#: src/muuli_wdr.cpp:2660
+#: src/muuli_wdr.cpp:2691
 msgid "Support Protocol Obfuscation"
 msgstr "Sofitu d'ofuscación de protocolu"
 
-#: src/muuli_wdr.cpp:2662
+#: src/muuli_wdr.cpp:2693
 msgid "This option enabled Protocol Obfuscation, and makes aMule accept obfuscated connections from other clients."
 msgstr "Esta opción activa la ofuscación de protocolu, y fai que aMule aceute conexones ofuscaes de otros veceros."
 
-#: src/muuli_wdr.cpp:2664
+#: src/muuli_wdr.cpp:2695
 msgid "Use obfuscation for outgoing connections"
 msgstr "Usar ofuscación pa conexones salientes"
 
-#: src/muuli_wdr.cpp:2666
+#: src/muuli_wdr.cpp:2697
 msgid "This option makes aMule use Protocol Obfuscation when connecting other clients/servers."
 msgstr "Esta opción fai que aMule use ofuscación de protocolu cuando se coneuten otros veceros/sirvidores."
 
-#: src/muuli_wdr.cpp:2668
+#: src/muuli_wdr.cpp:2699
 msgid "Accept only obfuscated connections"
 msgstr "Aceutar namái conexones ofuscaes"
 
-#: src/muuli_wdr.cpp:2669
+#: src/muuli_wdr.cpp:2700
 msgid "This option makes aMule only accept obfuscated connections. You will have less sources, but all your traffic will be obfuscated"
 msgstr "Esa opción fai que aMule namái aceute conexones ofuscaes. Tendrá menos fontes, pero tol so tráficu sedrá ofuscáu."
 
-#: src/muuli_wdr.cpp:2674
+#: src/muuli_wdr.cpp:2705
 msgid "Everybody"
 msgstr "Toos"
 
-#: src/muuli_wdr.cpp:2676
+#: src/muuli_wdr.cpp:2707
 msgid "No one"
 msgstr "Dengún"
 
-#: src/muuli_wdr.cpp:2678
+#: src/muuli_wdr.cpp:2709
 msgid "Who can see my shared files:"
 msgstr "Quién pue adicar los mios ficheros compartíos:"
 
-#: src/muuli_wdr.cpp:2679
+#: src/muuli_wdr.cpp:2710
 msgid "Select who can request to view a list of your shared files."
 msgstr "Seleiciona quién pue solicitar adicar la nuesa llista de ficheros compartíos."
 
-#: src/muuli_wdr.cpp:2681
+#: src/muuli_wdr.cpp:2712
 msgid "IP-Filtering"
 msgstr "Fieltráu de IPs"
 
-#: src/muuli_wdr.cpp:2688
+#: src/muuli_wdr.cpp:2719
 msgid "Filter clients"
 msgstr "Fieltru veceros"
 
-#: src/muuli_wdr.cpp:2690
+#: src/muuli_wdr.cpp:2721
 msgid "Enable filtering of the client IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "Habilitar fieltráu de IPs de veceros definíu nel ficheru ~/.aMule/ipfilter.dat"
 
-#: src/muuli_wdr.cpp:2692
+#: src/muuli_wdr.cpp:2723
 msgid "Filter servers"
 msgstr "Fieltru sirvidores"
 
-#: src/muuli_wdr.cpp:2694
+#: src/muuli_wdr.cpp:2725
 msgid "Enable filtering of the server IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "Habilitar fieltráu de IPs de sirvidores definíu nel ficheru ~/.aMule/ipfilter.dat"
 
-#: src/muuli_wdr.cpp:2698
+#: src/muuli_wdr.cpp:2729
 msgid "Reload List"
 msgstr "Recargar llista"
 
-#: src/muuli_wdr.cpp:2699
+#: src/muuli_wdr.cpp:2730
 msgid "Reload the list of IPs to filter from the file ~/.aMule/ipfilter.dat"
 msgstr "Recargar llista de fieltráu de IPs dende ficheru ~/.aMule/ipfilter.dat"
 
-#: src/muuli_wdr.cpp:2705
+#: src/muuli_wdr.cpp:2736
 msgid "URL:"
 msgstr "URL:"
 
-#: src/muuli_wdr.cpp:2709 src/muuli_wdr.cpp:2902
+#: src/muuli_wdr.cpp:2740 src/muuli_wdr.cpp:2933
 msgid "Update now"
 msgstr "Actualizar agora"
 
-#: src/muuli_wdr.cpp:2712
+#: src/muuli_wdr.cpp:2743
 msgid "Auto-update ipfilter at startup"
 msgstr "Auto-actualizar el fieltráu de IPs al entamu"
 
-#: src/muuli_wdr.cpp:2716
+#: src/muuli_wdr.cpp:2747
 msgid "Filtering Level:"
 msgstr "Nivel de fieltráu:"
 
-#: src/muuli_wdr.cpp:2722
+#: src/muuli_wdr.cpp:2753
 msgid "Always filter LAN IPs"
 msgstr "Fieltrar siempres IP's de LAN"
 
-#: src/muuli_wdr.cpp:2725
+#: src/muuli_wdr.cpp:2756
 msgid "Paranoid handling of non-matching IPs"
 msgstr "Control paranoicu de IPs non comprobaes"
 
-#: src/muuli_wdr.cpp:2727
+#: src/muuli_wdr.cpp:2758
 msgid "Rejects a packet when its source IP differs from the IP the client claims (an anti-spoofing check). Disable only if it causes connection problems."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2729
+#: src/muuli_wdr.cpp:2760
 msgid "Use system-wide ipfilter.dat if available"
 msgstr "Usar el ipfilter.dat de sistema si ta disponible"
 
-#: src/muuli_wdr.cpp:2730
+#: src/muuli_wdr.cpp:2761
 #, fuzzy
 msgid "If there's no local ipfilter.dat found, allow usage of a system-wide ipfilter file."
 msgstr "Si nun s'alcuentra un ficheru ipfilter.dat llocal, permitir l'usu d'un ficheru ipfilter de sistema"
 
-#: src/muuli_wdr.cpp:2747
+#: src/muuli_wdr.cpp:2778
 msgid "Enable Online-Signature"
 msgstr "Activar Robla online"
 
-#: src/muuli_wdr.cpp:2749
+#: src/muuli_wdr.cpp:2780
 msgid "Enables the writing of the OS file, which can be used by external apps to create signatures and the like."
 msgstr "Habilitar la escritura de ficheros del SO, suel usase pa criar robles por aplicaciones esternes."
 
-#: src/muuli_wdr.cpp:2753
+#: src/muuli_wdr.cpp:2784
 msgid "Update Frequency (Secs):"
 msgstr "Frecuencia d'actualización (segs):"
 
-#: src/muuli_wdr.cpp:2756
+#: src/muuli_wdr.cpp:2787
 msgid "Change the frequency (in seconds) of Online Signature updates."
 msgstr "Cambiar la frecuencia (en segundos) de l'actualización de la robla-online"
 
-#: src/muuli_wdr.cpp:2764
+#: src/muuli_wdr.cpp:2795
 msgid "Save online signature file in: "
 msgstr "Guardar ficheru de robla online en: "
 
-#: src/muuli_wdr.cpp:2770
+#: src/muuli_wdr.cpp:2801
 msgid "Click here to select the directory containing the the Online Signature files."
 msgstr "Click equí pa seleicionar el direutoriu que contién los ficheros de robles-online."
 
-#: src/muuli_wdr.cpp:2803
+#: src/muuli_wdr.cpp:2834
 msgid "Show country flags for clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2804
+#: src/muuli_wdr.cpp:2835
 msgid "Render the country flag column in the transfers, queue and search views. Requires a valid MMDB GeoIP database (see below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2809
+#: src/muuli_wdr.cpp:2840
 #, fuzzy
 msgid "Database"
 msgstr "Fluxu de datos :"
 
-#: src/muuli_wdr.cpp:2825
+#: src/muuli_wdr.cpp:2856
 #, fuzzy
 msgid "Source:"
 msgstr "Fontes"
 
-#: src/muuli_wdr.cpp:2828
+#: src/muuli_wdr.cpp:2859
 msgid "DB-IP (free, no account)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2829
+#: src/muuli_wdr.cpp:2860
 msgid "MaxMind GeoLite2 (free, account required)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2830
+#: src/muuli_wdr.cpp:2861
 msgid "Custom URL"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2833
+#: src/muuli_wdr.cpp:2864
 msgid "Choose which provider supplies the GeoIP MMDB database. DB-IP is the default - no account required. MaxMind requires a free account + license key. Use Custom URL to point at any other MMDB host (e.g. a local mirror)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2850
+#: src/muuli_wdr.cpp:2881
 msgid ""
 "No configuration required.\n"
 "\n"
@@ -4869,11 +4897,11 @@ msgid ""
 "License: Creative Commons BY 4.0 - https://creativecommons.org/licenses/by/4.0/"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2863
+#: src/muuli_wdr.cpp:2894
 msgid "License key:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2869
+#: src/muuli_wdr.cpp:2900
 msgid ""
 "Sign up for a free MaxMind account, then generate a License Key:\n"
 "https://www.maxmind.com/en/geolite2/signup\n"
@@ -4883,232 +4911,232 @@ msgid ""
 "Requires attribution and account registration; refresh at least every 30 days."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2884
+#: src/muuli_wdr.cpp:2915
 #, fuzzy
 msgid "Download URL:"
 msgstr "Descargáu:"
 
-#: src/muuli_wdr.cpp:2890
+#: src/muuli_wdr.cpp:2921
 msgid ""
 "Must point to an .mmdb file or a .gz / .tar.gz containing one.\n"
 "URL may include credentials (https://user:pass@host/...).\n"
 "License and attribution terms are set by the upstream URL - you are responsible."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2903
+#: src/muuli_wdr.cpp:2934
 msgid "Download the GeoIP database from the selected source."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2905
+#: src/muuli_wdr.cpp:2936
 #, fuzzy
 msgid "Auto-update on startup"
 msgstr "Auto-actualizar el fieltráu de IPs al entamu"
 
-#: src/muuli_wdr.cpp:2906
+#: src/muuli_wdr.cpp:2937
 msgid "Re-download the GeoIP database from the selected source every time aMule starts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2929
+#: src/muuli_wdr.cpp:2960
 msgid "Filter incoming messages (except current chat):"
 msgstr "Fieltrar mensaxes entrantes (sacantes conversación actual):"
 
-#: src/muuli_wdr.cpp:2931
+#: src/muuli_wdr.cpp:2962
 msgid "Filter all messages"
 msgstr "Fieltrar tolos mensaxes"
 
-#: src/muuli_wdr.cpp:2933
+#: src/muuli_wdr.cpp:2964
 msgid "Filter messages from people not on your friend list"
 msgstr "Fieltrar mensaxes de xente que nun ta na to llista de collacios"
 
-#: src/muuli_wdr.cpp:2935
+#: src/muuli_wdr.cpp:2966
 msgid "Filter messages from unknown clients"
 msgstr "Fieltrar mensaxes de veceros desconocíos"
 
-#: src/muuli_wdr.cpp:2937
+#: src/muuli_wdr.cpp:2968
 msgid "Filter messages containing (use ',' as separator):"
 msgstr "Fieltrar mensaxes que contienen (usa ',' como separtador):"
 
-#: src/muuli_wdr.cpp:2940 src/muuli_wdr.cpp:2951
+#: src/muuli_wdr.cpp:2971 src/muuli_wdr.cpp:2982
 msgid "add here the words amule should filter and block messages including it"
 msgstr "amiesta equí les pallabres que amule tien de fieltrar y bloquiar mensaxes incluyíos"
 
-#: src/muuli_wdr.cpp:2942
+#: src/muuli_wdr.cpp:2973
 msgid "Show received messages in the log"
 msgstr "Amosar mensaxes recibíos nel rexistru"
 
-#: src/muuli_wdr.cpp:2945
+#: src/muuli_wdr.cpp:2976
 msgid "Comments"
 msgstr "Comentarios"
 
-#: src/muuli_wdr.cpp:2948
+#: src/muuli_wdr.cpp:2979
 msgid "Filter comments containing (use ',' as separator):"
 msgstr "Fieltrar comentarios que contengan (usar ',' como separtador):"
 
-#: src/muuli_wdr.cpp:2973
+#: src/muuli_wdr.cpp:3004
 msgid "Enable Proxy"
 msgstr "Habilitar Proxy"
 
-#: src/muuli_wdr.cpp:2974
+#: src/muuli_wdr.cpp:3005
 msgid "Enable/disable proxy support"
 msgstr "Habilitar/Deshabilitar soporte Proxy"
 
-#: src/muuli_wdr.cpp:2977
+#: src/muuli_wdr.cpp:3008
 msgid "Proxy type:"
 msgstr "Triba Proxy:"
 
-#: src/muuli_wdr.cpp:2988
+#: src/muuli_wdr.cpp:3019
 msgid "Proxy host:"
 msgstr "Sirvidor Proxy:"
 
-#: src/muuli_wdr.cpp:2991
+#: src/muuli_wdr.cpp:3022
 msgid "The proxy host name"
 msgstr "Nome del host del proxy"
 
-#: src/muuli_wdr.cpp:2993
+#: src/muuli_wdr.cpp:3024
 msgid "Proxy port:"
 msgstr "Puertu Proxy:"
 
-#: src/muuli_wdr.cpp:2996
+#: src/muuli_wdr.cpp:3027
 msgid "The proxy port"
 msgstr "El puertu del proxy"
 
-#: src/muuli_wdr.cpp:2998
+#: src/muuli_wdr.cpp:3029
 msgid "Enable authentication"
 msgstr "Habilitar autentificación"
 
-#: src/muuli_wdr.cpp:2999
+#: src/muuli_wdr.cpp:3030
 msgid "Enable/disable username/password authentication"
 msgstr "Habilita/deshabilita autentificación usuariu/contraseña"
 
-#: src/muuli_wdr.cpp:3002
+#: src/muuli_wdr.cpp:3033
 msgid "Username: "
 msgstr "Nome d'usuariu:"
 
-#: src/muuli_wdr.cpp:3005
+#: src/muuli_wdr.cpp:3036
 msgid "The username to use to connect to the proxy"
 msgstr "El nome d'usuariu a usar pa coneutar al proxy"
 
-#: src/muuli_wdr.cpp:3007
+#: src/muuli_wdr.cpp:3038
 msgid "Password:"
 msgstr "Contraseña:"
 
-#: src/muuli_wdr.cpp:3010
+#: src/muuli_wdr.cpp:3041
 msgid "The password to use to connect to the proxy"
 msgstr "La contraseña a usar pa coneutar al proxy"
 
-#: src/muuli_wdr.cpp:3029
+#: src/muuli_wdr.cpp:3060
 msgid "Connect to:"
 msgstr "Coneutar a:"
 
-#: src/muuli_wdr.cpp:3038
+#: src/muuli_wdr.cpp:3069
 msgid "Login to remote amule"
 msgstr "Conexón a aMule remotu"
 
-#: src/muuli_wdr.cpp:3043
+#: src/muuli_wdr.cpp:3074
 msgid "User name"
 msgstr "Nome usuariu:"
 
-#: src/muuli_wdr.cpp:3054
+#: src/muuli_wdr.cpp:3085
 msgid "Remember those settings"
 msgstr "Remembrar estes opciones"
 
-#: src/muuli_wdr.cpp:3057
+#: src/muuli_wdr.cpp:3088
 #, fuzzy
 msgid "Force ZLIB compression"
 msgstr "Usar compresión gzip"
 
-#: src/muuli_wdr.cpp:3081
+#: src/muuli_wdr.cpp:3112
 msgid "Enable Verbose Debug-Logging."
 msgstr "Habilita mou estendíu de depuración al aniciu"
 
-#: src/muuli_wdr.cpp:3083
+#: src/muuli_wdr.cpp:3114
 #, fuzzy
 msgid "Only to Logfile"
 msgstr "&Abrir el ficheru"
 
-#: src/muuli_wdr.cpp:3085
+#: src/muuli_wdr.cpp:3116
 msgid "Message Categories:"
 msgstr "Mensaxes de categoríes:"
 
-#: src/muuli_wdr.cpp:3109 src/PartFileConvertDlg.cpp:160
+#: src/muuli_wdr.cpp:3140 src/PartFileConvertDlg.cpp:160
 msgid "Waiting..."
 msgstr "Esperando..."
 
-#: src/muuli_wdr.cpp:3129
+#: src/muuli_wdr.cpp:3160
 msgid "Add imports"
 msgstr "Amestar imports"
 
-#: src/muuli_wdr.cpp:3132
+#: src/muuli_wdr.cpp:3163
 msgid "Retry selected"
 msgstr "Reintentar seleicionáu"
 
-#: src/muuli_wdr.cpp:3134
+#: src/muuli_wdr.cpp:3165
 msgid "Remove selected"
 msgstr "Desaniciar seleicionáu"
 
-#: src/muuli_wdr.cpp:3197
+#: src/muuli_wdr.cpp:3228
 msgid "Event Types"
 msgstr "Tipos Eventos"
 
-#: src/muuli_wdr.cpp:3216
+#: src/muuli_wdr.cpp:3247
 msgid "Statistics and queued clients for selected file(s) : Session / All time"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3240
+#: src/muuli_wdr.cpp:3271
 #, fuzzy
 msgid "Active Uploads"
 msgstr "Xubes aceutaes :"
 
-#: src/muuli_wdr.cpp:3254
+#: src/muuli_wdr.cpp:3285
 msgid "Percent of total files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3306
+#: src/muuli_wdr.cpp:3337
 #, fuzzy
 msgid "Show Clients for"
 msgstr "Amosar Veceros"
 
-#: src/muuli_wdr.cpp:3308
+#: src/muuli_wdr.cpp:3339
 #, fuzzy
 msgid "All files"
 msgstr "Anubre los ficheros compartíos"
 
-#: src/muuli_wdr.cpp:3311
+#: src/muuli_wdr.cpp:3342
 #, fuzzy
 msgid "Selected files"
 msgstr "Seleicionar fieltru de vistes"
 
-#: src/muuli_wdr.cpp:3314
+#: src/muuli_wdr.cpp:3345
 #, fuzzy
 msgid "Active uploads only"
 msgstr "Xubes actives"
 
-#: src/muuli_wdr.cpp:3321
+#: src/muuli_wdr.cpp:3352
 #, fuzzy
 msgid "Reload:"
 msgstr "Recargar llista"
 
-#: src/muuli_wdr.cpp:3325
+#: src/muuli_wdr.cpp:3356
 msgid "Reload your shared files"
 msgstr "Recargar los tos ficheros compartíos"
 
-#: src/muuli_wdr.cpp:3388
+#: src/muuli_wdr.cpp:3419
 msgid "Send"
 msgstr "Unviar"
 
-#: src/muuli_wdr.cpp:3389
+#: src/muuli_wdr.cpp:3420
 msgid "Sends the specified message."
 msgstr "Unviar un mensax específicu."
 
-#: src/muuli_wdr.cpp:3393
+#: src/muuli_wdr.cpp:3424
 msgid "Close this chat-session."
 msgstr "Zarrar esta sesión de charra"
 
-#: src/muuli_wdr.cpp:3416
+#: src/muuli_wdr.cpp:3447
 msgid "Connect to any server and/or Kad"
 msgstr "Coneutar a cualesquier sirvidor y/o Kad"
 
-#: src/muuli_wdr.cpp:3422 src/SharedFilesCtrl.cpp:142 src/Statistics.cpp:941
+#: src/muuli_wdr.cpp:3453 src/SharedFilesCtrl.cpp:142 src/Statistics.cpp:941
 msgid "Shared Files"
 msgstr "Fich compartíos"
 
@@ -5468,267 +5496,267 @@ msgstr "Descargáu"
 msgid "ERROR: Failed to open partfile '%s'"
 msgstr "ERROR: Fallu al abrir ficheru part '%s'"
 
-#: src/Preferences.cpp:674
+#: src/Preferences.cpp:701
 msgid "System default"
 msgstr "Por defeutu"
 
-#: src/Preferences.cpp:675
+#: src/Preferences.cpp:702
 msgid "Albanian"
 msgstr "Albanés"
 
-#: src/Preferences.cpp:676
+#: src/Preferences.cpp:703
 msgid "Arabic"
 msgstr "Árabe"
 
-#: src/Preferences.cpp:677
+#: src/Preferences.cpp:704
 msgid "Asturian"
 msgstr "Asturianu"
 
-#: src/Preferences.cpp:678
+#: src/Preferences.cpp:705
 msgid "Basque"
 msgstr "Euskera"
 
-#: src/Preferences.cpp:679
+#: src/Preferences.cpp:706
 msgid "Bulgarian"
 msgstr "Búlgaru"
 
-#: src/Preferences.cpp:680
+#: src/Preferences.cpp:707
 msgid "Catalan"
 msgstr "Catalán"
 
-#: src/Preferences.cpp:681
+#: src/Preferences.cpp:708
 msgid "Chinese (Simplified)"
 msgstr "Chinu (simplificáu)"
 
-#: src/Preferences.cpp:682
+#: src/Preferences.cpp:709
 msgid "Chinese (Traditional)"
 msgstr "Chinu (Tradicional)"
 
-#: src/Preferences.cpp:683
+#: src/Preferences.cpp:710
 msgid "Croatian"
 msgstr "Croata"
 
-#: src/Preferences.cpp:684
+#: src/Preferences.cpp:711
 msgid "Czech"
 msgstr "Checu"
 
-#: src/Preferences.cpp:685
+#: src/Preferences.cpp:712
 msgid "Danish"
 msgstr "Danés"
 
-#: src/Preferences.cpp:686
+#: src/Preferences.cpp:713
 msgid "Dutch"
 msgstr "Holandés"
 
-#: src/Preferences.cpp:687
+#: src/Preferences.cpp:714
 msgid "English (U.K.)"
 msgstr "Inglés (U.K.)"
 
-#: src/Preferences.cpp:688
+#: src/Preferences.cpp:715
 #, fuzzy
 msgid "English (U.S.)"
 msgstr "Inglés (U.K.)"
 
-#: src/Preferences.cpp:689
+#: src/Preferences.cpp:716
 msgid "Estonian"
 msgstr "Estoniu"
 
-#: src/Preferences.cpp:690
+#: src/Preferences.cpp:717
 msgid "Finnish"
 msgstr "Finlandés"
 
-#: src/Preferences.cpp:691
+#: src/Preferences.cpp:718
 msgid "French"
 msgstr "Francés"
 
-#: src/Preferences.cpp:692
+#: src/Preferences.cpp:719
 msgid "Galician"
 msgstr "Gallegu"
 
-#: src/Preferences.cpp:693
+#: src/Preferences.cpp:720
 msgid "German"
 msgstr "Alemán"
 
-#: src/Preferences.cpp:694
+#: src/Preferences.cpp:721
 msgid "Greek"
 msgstr "Griegu"
 
-#: src/Preferences.cpp:695
+#: src/Preferences.cpp:722
 msgid "Hebrew"
 msgstr "Hebréu"
 
-#: src/Preferences.cpp:696
+#: src/Preferences.cpp:723
 msgid "Hungarian"
 msgstr "Húngaru"
 
-#: src/Preferences.cpp:697
+#: src/Preferences.cpp:724
 msgid "Italian"
 msgstr "Italianu"
 
-#: src/Preferences.cpp:698
+#: src/Preferences.cpp:725
 msgid "Japanese"
 msgstr "Xaponés"
 
-#: src/Preferences.cpp:699
+#: src/Preferences.cpp:726
 msgid "Korean"
 msgstr "Coreanu"
 
-#: src/Preferences.cpp:700
+#: src/Preferences.cpp:727
 msgid "Latvian"
 msgstr ""
 
-#: src/Preferences.cpp:701
+#: src/Preferences.cpp:728
 msgid "Lithuanian"
 msgstr "Lituanu"
 
-#: src/Preferences.cpp:702
+#: src/Preferences.cpp:729
 msgid "Norwegian (Nynorsk)"
 msgstr "Noruegu"
 
-#: src/Preferences.cpp:703
+#: src/Preferences.cpp:730
 msgid "Polish"
 msgstr "Polacu"
 
-#: src/Preferences.cpp:704
+#: src/Preferences.cpp:731
 msgid "Portuguese"
 msgstr "Portugués"
 
-#: src/Preferences.cpp:705
+#: src/Preferences.cpp:732
 msgid "Portuguese (Brazilian)"
 msgstr "Portugués (Brasil)"
 
-#: src/Preferences.cpp:706
+#: src/Preferences.cpp:733
 #, fuzzy
 msgid "Romanian"
 msgstr "Albanés"
 
-#: src/Preferences.cpp:707
+#: src/Preferences.cpp:734
 msgid "Russian"
 msgstr "Rusu"
 
-#: src/Preferences.cpp:708
+#: src/Preferences.cpp:735
 msgid "Slovenian"
 msgstr "Eslovenu"
 
-#: src/Preferences.cpp:709
+#: src/Preferences.cpp:736
 msgid "Spanish"
 msgstr "Español"
 
-#: src/Preferences.cpp:710
+#: src/Preferences.cpp:737
 msgid "Swedish"
 msgstr "Suecu"
 
-#: src/Preferences.cpp:711
+#: src/Preferences.cpp:738
 msgid "Turkish"
 msgstr "Turcu"
 
-#: src/Preferences.cpp:712
+#: src/Preferences.cpp:739
 msgid "Ukrainian"
 msgstr "Ucranianu"
 
-#: src/Preferences.cpp:815
+#: src/Preferences.cpp:842
 #, fuzzy
 msgid "Change Language"
 msgstr "Llingua: "
 
-#: src/Preferences.cpp:879
+#: src/Preferences.cpp:906
 msgid "There are no translations installed for aMule"
 msgstr ""
 
-#: src/Preferences.cpp:880
+#: src/Preferences.cpp:907
 #, fuzzy
 msgid "No languages available"
 msgstr "Non disponible"
 
-#: src/Preferences.cpp:1011
+#: src/Preferences.cpp:1038
 msgid "no options available"
 msgstr "opciones non disponibles"
 
-#: src/Preferences.cpp:2182
+#: src/Preferences.cpp:2227
 msgid "Invalid category found, skipping"
 msgstr "Categoría inválida alcontrada, saltando"
 
-#: src/Preferences.cpp:2351
+#: src/Preferences.cpp:2396
 msgid "TCP port can't be higher than 65532 due to server UDP socket being TCP+3"
 msgstr "Puertu TCP nun pue ser más altu de 65532 darréu que'l socket del sirvidor UDP ye TCP+3"
 
-#: src/Preferences.cpp:2352
+#: src/Preferences.cpp:2397
 #, c-format
 msgid "Default port will be used (%d)"
 msgstr "Puertu por defeutu que s'usará (%d)"
 
-#: src/PrefsUnifiedDlg.cpp:298 src/Statistics.cpp:866
+#: src/PrefsUnifiedDlg.cpp:300 src/Statistics.cpp:866
 msgid "Connection"
 msgstr "Conexón"
 
-#: src/PrefsUnifiedDlg.cpp:299 src/SearchListCtrl.cpp:117
+#: src/PrefsUnifiedDlg.cpp:301 src/SearchListCtrl.cpp:117
 msgid "Directories"
 msgstr "Direutorios"
 
-#: src/PrefsUnifiedDlg.cpp:300 src/Statistics.cpp:917
+#: src/PrefsUnifiedDlg.cpp:302 src/Statistics.cpp:917
 msgid "Servers"
 msgstr "Sirvidores"
 
-#: src/PrefsUnifiedDlg.cpp:301 src/ServerListCtrl.cpp:96
+#: src/PrefsUnifiedDlg.cpp:303 src/ServerListCtrl.cpp:96
 msgid "Files"
 msgstr "Ficheros"
 
-#: src/PrefsUnifiedDlg.cpp:302
+#: src/PrefsUnifiedDlg.cpp:304
 msgid "Security"
 msgstr "Seguridá"
 
-#: src/PrefsUnifiedDlg.cpp:303
+#: src/PrefsUnifiedDlg.cpp:305
 msgid "Interface"
 msgstr "Interface"
 
-#: src/PrefsUnifiedDlg.cpp:310
+#: src/PrefsUnifiedDlg.cpp:312
 msgid "IP2Country"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:313
+#: src/PrefsUnifiedDlg.cpp:315
 msgid "Proxy"
 msgstr "Proxy"
 
-#: src/PrefsUnifiedDlg.cpp:314
+#: src/PrefsUnifiedDlg.cpp:316
 msgid "Filters"
 msgstr "Fieltros"
 
-#: src/PrefsUnifiedDlg.cpp:315
+#: src/PrefsUnifiedDlg.cpp:317
 msgid "Remote Controls"
 msgstr "Controles remotos"
 
-#: src/PrefsUnifiedDlg.cpp:316
+#: src/PrefsUnifiedDlg.cpp:318
 msgid "Online Signature"
 msgstr "Robla online"
 
-#: src/PrefsUnifiedDlg.cpp:317
+#: src/PrefsUnifiedDlg.cpp:319
 msgid "Advanced"
 msgstr "Avanzáu"
 
-#: src/PrefsUnifiedDlg.cpp:318
+#: src/PrefsUnifiedDlg.cpp:320
 msgid "Events"
 msgstr "Eventos"
 
-#: src/PrefsUnifiedDlg.cpp:321
+#: src/PrefsUnifiedDlg.cpp:323
 msgid "Debugging"
 msgstr "Debugging"
 
-#: src/PrefsUnifiedDlg.cpp:451
+#: src/PrefsUnifiedDlg.cpp:453
 msgid ""
 "The following variables will be substituted:\n"
 "    %PARTFILE - full path to the file\n"
 "    %PARTNAME - file name only"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:472
+#: src/PrefsUnifiedDlg.cpp:474
 msgid "Tray icon support requires libayatana-appindicator3 at compile time."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:488
+#: src/PrefsUnifiedDlg.cpp:490
 msgid "Not available on Wayland: the protocol does not report when a window is minimized, so this option cannot intercept the system minimize button. Workaround: launch aMule with `GDK_BACKEND=x11` to use XWayland instead."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:534
+#: src/PrefsUnifiedDlg.cpp:536
 msgid ""
 "Do not change these setting unless you know\n"
 "what you are doing, otherwise you can easily\n"
@@ -5744,26 +5772,35 @@ msgstr ""
 "aMule furrulará bien ensin que camudes dengún\n"
 "d'estos parámetros."
 
-#: src/PrefsUnifiedDlg.cpp:645
+#: src/PrefsUnifiedDlg.cpp:647
 #, c-format
 msgid "Failed to connect Cfg to widget with the ID %d and key %s"
 msgstr "Error al coneutar configuración con programa, col ID %d y clave %s"
 
-#: src/PrefsUnifiedDlg.cpp:693
+#: src/PrefsUnifiedDlg.cpp:695
 #, c-format
 msgid "Failed to transfer data from Cfg to Widget with the ID %d and key %s"
 msgstr "Error al tresferir datos dende la configuración al programa, col ID %d y la clave %s"
 
-#: src/PrefsUnifiedDlg.cpp:799
+#: src/PrefsUnifiedDlg.cpp:801
 msgid "The type of proxy you are connecting to"
 msgstr "La triba de proxy a la que tas coneutando"
 
-#: src/PrefsUnifiedDlg.cpp:1003
+#: src/PrefsUnifiedDlg.cpp:1020
 #, c-format
 msgid "Failed to transfer data from Widget to Cfg with the ID %d and key %s"
 msgstr "Error al tresferir datos dende'l programa a la configuración, col ID %d y la clave %s"
 
 #: src/PrefsUnifiedDlg.cpp:1103
+#, fuzzy
+msgid "No password set."
+msgstr "Comprobando contraseña\n"
+
+#: src/PrefsUnifiedDlg.cpp:1132
+msgid "Guest access needs a password. Type one in the guest password field, or untick Enable guest access."
+msgstr ""
+
+#: src/PrefsUnifiedDlg.cpp:1144
 msgid ""
 "aMule must be restarted to enable these changes:\n"
 "\n"
@@ -5771,45 +5808,45 @@ msgstr ""
 "aMule tien de reaniciase p'aplicar los cambeos:\n"
 "\n"
 
-#: src/PrefsUnifiedDlg.cpp:1110
+#: src/PrefsUnifiedDlg.cpp:1151
 msgid "- TCP port changed.\n"
 msgstr "- Puertu TCP camudáu.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1115
+#: src/PrefsUnifiedDlg.cpp:1156
 msgid "- UDP port changed.\n"
 msgstr "- Puertu UDP camudáu.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1120
+#: src/PrefsUnifiedDlg.cpp:1161
 #, fuzzy
 msgid "- Network interface binding changed.\n"
 msgstr "Conexón esterna zarrada."
 
-#: src/PrefsUnifiedDlg.cpp:1125
+#: src/PrefsUnifiedDlg.cpp:1166
 #, fuzzy
 msgid "- External connect port changed.\n"
 msgstr "Conexón esterna zarrada."
 
-#: src/PrefsUnifiedDlg.cpp:1129
+#: src/PrefsUnifiedDlg.cpp:1170
 #, fuzzy
 msgid "- External connect acceptance changed.\n"
 msgstr "Nueva conexón esterna, aceutada"
 
-#: src/PrefsUnifiedDlg.cpp:1133
+#: src/PrefsUnifiedDlg.cpp:1174
 #, fuzzy
 msgid "- External connect interface changed.\n"
 msgstr "Conexón esterna zarrada."
 
-#: src/PrefsUnifiedDlg.cpp:1137
+#: src/PrefsUnifiedDlg.cpp:1178
 #, fuzzy
 msgid "- Protocol obfuscation support changed.\n"
 msgstr "Ofuscación de protocolu"
 
-#: src/PrefsUnifiedDlg.cpp:1151
+#: src/PrefsUnifiedDlg.cpp:1193
 #, fuzzy
 msgid "- amuleapi settings changed.\n"
 msgstr "- Llingua camudada.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1160
+#: src/PrefsUnifiedDlg.cpp:1202
 msgid ""
 "Your Auto-update server list is empty.\n"
 "'Auto-update server list at startup' will be disabled."
@@ -5817,7 +5854,7 @@ msgstr ""
 "La to llista Auto-actualizable de sirvidores ta erma.\n"
 "La llista de sirvidores auto-actualizable al entamu desactivaráse."
 
-#: src/PrefsUnifiedDlg.cpp:1171
+#: src/PrefsUnifiedDlg.cpp:1213
 msgid ""
 "You have enabled external connections but have not specified a password.\n"
 "External connections cannot be enabled unless a valid password is specified."
@@ -5825,28 +5862,33 @@ msgstr ""
 "Tienes habilitao les conexones externes, pero nun tienes especificada una contraseña.\n"
 "Les conexones externes nun puen ser habilitaes sacante qu'especifiques una contraseña válida."
 
-#: src/PrefsUnifiedDlg.cpp:1202
+#: src/PrefsUnifiedDlg.cpp:1246
+#, c-format
+msgid "The amuleapi password could not be saved: %s"
+msgstr ""
+
+#: src/PrefsUnifiedDlg.cpp:1276
 msgid "- Language changed.\n"
 msgstr "- Llingua camudada.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1207
+#: src/PrefsUnifiedDlg.cpp:1281
 msgid "- Temp folder changed.\n"
 msgstr "- Direutoriu TEMP camudáu.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1212
+#: src/PrefsUnifiedDlg.cpp:1286
 msgid "- ED2K network enabled.\n"
 msgstr "- Rede ED2K activada.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1245
+#: src/PrefsUnifiedDlg.cpp:1319
 msgid "The shared-file exclusion pattern is not a valid regular expression. The filter has been left disabled."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1247 src/PrefsUnifiedDlg.cpp:1841
+#: src/PrefsUnifiedDlg.cpp:1321 src/PrefsUnifiedDlg.cpp:1921
 #, fuzzy
 msgid "Invalid regular expression"
 msgstr "Versión de protocolu non válida"
 
-#: src/PrefsUnifiedDlg.cpp:1324
+#: src/PrefsUnifiedDlg.cpp:1398
 msgid ""
 "Both eD2k and Kad network are disabled.\n"
 "You won't be able to connect until you enable at least one of them."
@@ -5854,7 +5896,7 @@ msgstr ""
 "eD2k y Kad tán desactivaos.\n"
 "Nun podrás coneutate hasta qu'actives a lo menos ún d'ellos."
 
-#: src/PrefsUnifiedDlg.cpp:1329
+#: src/PrefsUnifiedDlg.cpp:1403
 msgid ""
 "Kad will not start if your UDP port is disabled.\n"
 "Enable UDP port or disable Kad."
@@ -5862,7 +5904,7 @@ msgstr ""
 "Kad nun s'aniciará si'l to puertu UDP ta deshabilitáu.\n"
 "Habilita un puertu UDP o deshabilita Kad."
 
-#: src/PrefsUnifiedDlg.cpp:1385
+#: src/PrefsUnifiedDlg.cpp:1459
 msgid ""
 "\n"
 "You MUST restart aMule now.\n"
@@ -5872,69 +5914,69 @@ msgstr ""
 "Hai de reaniciar aMule agora.\n"
 "Si nun reanicies agora, nun sabemos si pasará daqué malo.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1450
+#: src/PrefsUnifiedDlg.cpp:1524
 msgid "Could not register aMule for autostart at login. The autostart store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1452
+#: src/PrefsUnifiedDlg.cpp:1526
 msgid "Could not remove the autostart-at-login entry."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1453
+#: src/PrefsUnifiedDlg.cpp:1527
 #, fuzzy
 msgid "Autostart"
 msgstr "Auto recargar, aniciáu"
 
-#: src/PrefsUnifiedDlg.cpp:1468
+#: src/PrefsUnifiedDlg.cpp:1542
 msgid "Register file type"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1468
+#: src/PrefsUnifiedDlg.cpp:1542
 msgid "Register URL handler"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1476
+#: src/PrefsUnifiedDlg.cpp:1550
 #, c-format
 msgid "aMule only handles eD2k-compatible magnets. If you replace the current magnet handler (%s), BitTorrent magnet links will stop working - aMule cannot download BitTorrent content. Continue?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1481
+#: src/PrefsUnifiedDlg.cpp:1555
 #, c-format
 msgid "Another application currently opens .emulecollection files (%s). Replace it with aMule?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1486
+#: src/PrefsUnifiedDlg.cpp:1560
 #, c-format
 msgid "Another application is currently the default handler for these links (%s). Replace it with aMule?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1511
+#: src/PrefsUnifiedDlg.cpp:1585
 msgid "Could not register aMule for .emulecollection files. The registration store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1513
+#: src/PrefsUnifiedDlg.cpp:1587
 #, fuzzy
 msgid "Could not remove the file type registration."
 msgstr "Carpeta pa los ficheros temporales de descargues"
 
-#: src/PrefsUnifiedDlg.cpp:1515
+#: src/PrefsUnifiedDlg.cpp:1589
 msgid "Could not register aMule as the URL handler. The registration store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1517
+#: src/PrefsUnifiedDlg.cpp:1591
 msgid "Could not remove the URL handler registration."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1587 src/PrefsUnifiedDlg.cpp:1614
+#: src/PrefsUnifiedDlg.cpp:1661 src/PrefsUnifiedDlg.cpp:1688
 #, fuzzy
 msgid "The web server and aMule API require external connections to be enabled."
 msgstr "Contraseña fixada y conexones esternes habilitaes."
 
-#: src/PrefsUnifiedDlg.cpp:1597
+#: src/PrefsUnifiedDlg.cpp:1671
 msgid "The aMule web server is deprecated. Consider running the aMule API instead."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1655
+#: src/PrefsUnifiedDlg.cpp:1735
 msgid ""
 "Your Auto-update servers list is in blank.\n"
 "Please fill in at least one URL to point to a valid server.met file.\n"
@@ -5944,66 +5986,66 @@ msgstr ""
 "Por favor introduz a lo menos una URL con un ficheru server.met válidu.\n"
 "Click nel botón \"Llista\" d'esta caxella  pa introducir una URL."
 
-#: src/PrefsUnifiedDlg.cpp:1796
+#: src/PrefsUnifiedDlg.cpp:1876
 msgid "Temporary files"
 msgstr "Ficheros temporales"
 
-#: src/PrefsUnifiedDlg.cpp:1801
+#: src/PrefsUnifiedDlg.cpp:1881
 msgid "Incoming files"
 msgstr "Ficheros entrantes"
 
-#: src/PrefsUnifiedDlg.cpp:1806
+#: src/PrefsUnifiedDlg.cpp:1886
 msgid "Online Signatures"
 msgstr "Robles online"
 
-#: src/PrefsUnifiedDlg.cpp:1819
+#: src/PrefsUnifiedDlg.cpp:1899
 #, c-format
 msgid "Choose a folder for %s"
 msgstr "Escueye una carpeta pa %s"
 
-#: src/PrefsUnifiedDlg.cpp:1843
+#: src/PrefsUnifiedDlg.cpp:1923
 #, fuzzy, c-format
 msgid "Would exclude %u of %u shared file"
 msgid_plural "Would exclude %u of %u shared files"
 msgstr[0] "Alcontróse %i ficheru compartíu"
 msgstr[1] "Alcontráronse %i ficheros compartíos"
 
-#: src/PrefsUnifiedDlg.cpp:1860
+#: src/PrefsUnifiedDlg.cpp:1940
 msgid "Browse for videoplayer"
 msgstr "Esplorar"
 
-#: src/PrefsUnifiedDlg.cpp:1864
+#: src/PrefsUnifiedDlg.cpp:1944
 msgid "Select browser"
 msgstr "Seleiciona restolador"
 
-#: src/PrefsUnifiedDlg.cpp:1868
+#: src/PrefsUnifiedDlg.cpp:1948
 #, fuzzy
 msgid "Select ffprobe binary"
 msgstr "Seleiciona restolador"
 
-#: src/PrefsUnifiedDlg.cpp:1874
+#: src/PrefsUnifiedDlg.cpp:1954
 #, c-format
 msgid "Executable%s"
 msgstr "Executable%s"
 
-#: src/PrefsUnifiedDlg.cpp:1908
+#: src/PrefsUnifiedDlg.cpp:1988
 msgid "ffprobe not found on PATH or in the standard install locations. Install ffmpeg (which ships ffprobe) or use Browse to pick a binary manually."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1920
+#: src/PrefsUnifiedDlg.cpp:2000
 msgid "Reset the settings on this page to their default values?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1921
+#: src/PrefsUnifiedDlg.cpp:2001
 #, fuzzy
 msgid "Reset to defaults"
 msgstr "Por defeutu"
 
-#: src/PrefsUnifiedDlg.cpp:1948
+#: src/PrefsUnifiedDlg.cpp:2028
 msgid "Edit server list"
 msgstr "Editar llista de sirvidores"
 
-#: src/PrefsUnifiedDlg.cpp:1949
+#: src/PrefsUnifiedDlg.cpp:2029
 msgid ""
 "Add here URL's to download server.met files.\n"
 "Only one url on each line."
@@ -6011,154 +6053,154 @@ msgstr ""
 "Amesta equí les URL's pa descargar los ficheros server.met.\n"
 "Namái una url per llinia."
 
-#: src/PrefsUnifiedDlg.cpp:2004
+#: src/PrefsUnifiedDlg.cpp:2084
 msgid "IP2Country update failed"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2149 src/PrefsUnifiedDlg.cpp:2180
+#: src/PrefsUnifiedDlg.cpp:2229 src/PrefsUnifiedDlg.cpp:2260
 msgid "Data by MaxMind GeoLite2"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2151 src/PrefsUnifiedDlg.cpp:2182
+#: src/PrefsUnifiedDlg.cpp:2231 src/PrefsUnifiedDlg.cpp:2262
 #, fuzzy
 msgid "Custom source"
 msgstr "Fontes completes"
 
-#: src/PrefsUnifiedDlg.cpp:2153 src/PrefsUnifiedDlg.cpp:2184
+#: src/PrefsUnifiedDlg.cpp:2233 src/PrefsUnifiedDlg.cpp:2264
 msgid "Data by DB-IP.com"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2204
+#: src/PrefsUnifiedDlg.cpp:2284
 #, fuzzy, c-format
 msgid "Status: Loaded%s"
 msgstr "Estáu:"
 
-#: src/PrefsUnifiedDlg.cpp:2206
+#: src/PrefsUnifiedDlg.cpp:2286
 #, fuzzy, c-format
 msgid "Status: Loaded%s - %s"
 msgstr "Estáu:"
 
-#: src/PrefsUnifiedDlg.cpp:2210
+#: src/PrefsUnifiedDlg.cpp:2290
 msgid "Status: Failed to load - click 'Update now' to refresh."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2212
+#: src/PrefsUnifiedDlg.cpp:2292
 msgid "Status: Not found - click 'Update now' to download."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2270 src/PrefsUnifiedDlg.cpp:2294
+#: src/PrefsUnifiedDlg.cpp:2350 src/PrefsUnifiedDlg.cpp:2374
 #, c-format
 msgid "Update delay: %d second"
 msgid_plural "Update delay: %d seconds"
 msgstr[0] "Intervalu d'actualización: %d seg"
 msgstr[1] "Intervalu d'actualización: %d segs"
 
-#: src/PrefsUnifiedDlg.cpp:2278
+#: src/PrefsUnifiedDlg.cpp:2358
 #, c-format
 msgid "Time for average graph: %d minute"
 msgid_plural "Time for average graph: %d minutes"
 msgstr[0] "Tiempu mediu del gráficu: %d min"
 msgstr[1] "Tiempu mediu del gráficu: %d mins"
 
-#: src/PrefsUnifiedDlg.cpp:2287
+#: src/PrefsUnifiedDlg.cpp:2367
 #, c-format
 msgid "Connections Graph Scale: %d"
 msgstr "Escala gráfica de conexones: %d"
 
-#: src/PrefsUnifiedDlg.cpp:2302
+#: src/PrefsUnifiedDlg.cpp:2382
 #, c-format
 msgid "File Buffer Size: %d byte"
 msgid_plural "File Buffer Size: %d bytes"
 msgstr[0] "Tamañu del buffer de ficheru: %d byte"
 msgstr[1] "Tamañu del buffer de ficheru: %d bytes"
 
-#: src/PrefsUnifiedDlg.cpp:2312
+#: src/PrefsUnifiedDlg.cpp:2392
 #, c-format
 msgid "Upload Queue Size: %d client"
 msgid_plural "Upload Queue Size: %d clients"
 msgstr[0] "Tamañu de la cola de xuba: %d veceru"
 msgstr[1] "Tamañu de la cola de xuba: %d veceros"
 
-#: src/PrefsUnifiedDlg.cpp:2322
+#: src/PrefsUnifiedDlg.cpp:2402
 #, c-format
 msgid "Server connection refresh interval: %d minute"
 msgid_plural "Server connection refresh interval: %d minutes"
 msgstr[0] "Intervalu de refrescu de la conexón al sirvidor: %d minutu"
 msgstr[1] "Intervalu de refrescu de la conexón al sirvidor: %d minutos"
 
-#: src/PrefsUnifiedDlg.cpp:2327
+#: src/PrefsUnifiedDlg.cpp:2407
 msgid "Server connection refresh interval: Disabled"
 msgstr "Intervalu de refrescu de la conexón al sirvidor: Deshabilitáu"
 
-#: src/PrefsUnifiedDlg.cpp:2371
+#: src/PrefsUnifiedDlg.cpp:2451
 msgid "disabled"
 msgstr "deshabilitáu"
 
-#: src/PrefsUnifiedDlg.cpp:2397
+#: src/PrefsUnifiedDlg.cpp:2477
 #, fuzzy, c-format
 msgid "Execute command on '%s' event"
 msgstr "Executar comandu nel eventu `%s'"
 
-#: src/PrefsUnifiedDlg.cpp:2404
+#: src/PrefsUnifiedDlg.cpp:2484
 msgid "Enable command execution on core"
 msgstr "Habilitar execución de comandu nel núcleu"
 
-#: src/PrefsUnifiedDlg.cpp:2416
+#: src/PrefsUnifiedDlg.cpp:2496
 msgid "Core command:"
 msgstr "Comandu del núcleu:"
 
-#: src/PrefsUnifiedDlg.cpp:2432
+#: src/PrefsUnifiedDlg.cpp:2512
 msgid "Enable command execution on GUI"
 msgstr "Habilitar execución de comandu na Interface"
 
-#: src/PrefsUnifiedDlg.cpp:2444
+#: src/PrefsUnifiedDlg.cpp:2524
 msgid "GUI command:"
 msgstr "Comandu de la Interface: "
 
-#: src/PrefsUnifiedDlg.cpp:2460
+#: src/PrefsUnifiedDlg.cpp:2540
 msgid "The following variables will be replaced:"
 msgstr "Les siguientes variables trocaránse:"
 
-#: src/PrefsUnifiedDlg.cpp:2628
+#: src/PrefsUnifiedDlg.cpp:2708
 msgid ""
 "The following folders look like system or sensitive locations:\n"
 "\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2633
+#: src/PrefsUnifiedDlg.cpp:2713
 msgid "Sharing them recursively will publish every file underneath on the eD2k/Kad networks. Do you really want to do this?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2636
+#: src/PrefsUnifiedDlg.cpp:2716
 #, fuzzy
 msgid "Confirm shared folders"
 msgstr "Carpetes compartíes"
 
-#: src/PrefsUnifiedDlg.cpp:2664
+#: src/PrefsUnifiedDlg.cpp:2744
 #, fuzzy
 msgid "Reloading shared files..."
 msgstr "Recargar los tos ficheros compartíos"
 
-#: src/PrefsUnifiedDlg.cpp:2665
+#: src/PrefsUnifiedDlg.cpp:2745
 msgid "Scanning for subdirectories..."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2666
+#: src/PrefsUnifiedDlg.cpp:2746
 #, fuzzy
 msgid "Updating shared folders"
 msgstr "Carpetes compartíes"
 
-#: src/PrefsUnifiedDlg.cpp:2693
+#: src/PrefsUnifiedDlg.cpp:2773
 #, c-format
 msgid "Scanned %u directories..."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2743
+#: src/PrefsUnifiedDlg.cpp:2823
 #, fuzzy, c-format
 msgid "Reloading shared files: %u files scanned"
 msgstr "Recargar llista de ficheros compartíos."
 
-#: src/PrefsUnifiedDlg.cpp:2793
+#: src/PrefsUnifiedDlg.cpp:2873
 #, fuzzy
 msgid "Shared folder"
 msgstr "Carpetes compartíes"

--- a/po/ast.po
+++ b/po/ast.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-28 12:17+0200\n"
+"POT-Creation-Date: 2026-07-28 13:09+0200\n"
 "PO-Revision-Date: 2026-07-27 11:32+0000\n"
 "Last-Translator: astur <malditoastur@gmail.com>\n"
 "Language-Team: Language ast <malditoastur@gmail.com>\n"
@@ -292,7 +292,7 @@ msgid "Password set and external connections enabled."
 msgstr "Contraseña fixada y conexones esternes habilitaes."
 
 #: src/amule.cpp:755 src/KadDlg.cpp:176 src/KadDlg.cpp:185
-#: src/PrefsUnifiedDlg.cpp:1461 src/SharedFilesCtrl.cpp:476
+#: src/PrefsUnifiedDlg.cpp:1470 src/SharedFilesCtrl.cpp:476
 msgid "WARNING"
 msgstr "ALERTA"
 
@@ -330,7 +330,7 @@ msgstr "Solicitaste executar el sirvidor web al aniciu pero nun pudo correse'l b
 #: src/amule-remote-gui.cpp:603 src/amule-remote-gui.cpp:671
 #: src/amule-remote-gui.cpp:709 src/amule-remote-gui.cpp:1282
 #: src/amule-remote-gui.cpp:1345 src/amule-remote-gui.cpp:1372
-#: src/DownloadQueue.cpp:1481 src/PrefsUnifiedDlg.cpp:1247
+#: src/DownloadQueue.cpp:1481 src/PrefsUnifiedDlg.cpp:1256
 msgid "ERROR"
 msgstr "FALLU"
 
@@ -592,36 +592,36 @@ msgstr "Visita https://github.com/amule-org/amule/releases/latest pa comprobar s
 msgid "FATAL ERROR: Failed to create Timer"
 msgstr "FALLU GRAVE: Nun pudo criase'l temporizador"
 
-#: src/amuleDlg.cpp:361 src/amuleDlg.cpp:1787 src/amuleDlg.cpp:2033
-#: src/muuli_wdr.cpp:1492 src/muuli_wdr.cpp:3449
+#: src/amuleDlg.cpp:361 src/amuleDlg.cpp:1810 src/amuleDlg.cpp:2056
+#: src/muuli_wdr.cpp:1492 src/muuli_wdr.cpp:3453
 msgid "Networks"
 msgstr "Redes"
 
-#: src/amuleDlg.cpp:362 src/amuleDlg.cpp:1793 src/muuli_wdr.cpp:3450
+#: src/amuleDlg.cpp:362 src/amuleDlg.cpp:1816 src/muuli_wdr.cpp:3454
 msgid "Searches"
 msgstr "Guetar"
 
-#: src/amuleDlg.cpp:363 src/amuleDlg.cpp:1799 src/DownloadListCtrl.cpp:740
-#: src/muuli_wdr.cpp:392 src/muuli_wdr.cpp:1585 src/muuli_wdr.cpp:3451
+#: src/amuleDlg.cpp:363 src/amuleDlg.cpp:1822 src/DownloadListCtrl.cpp:740
+#: src/muuli_wdr.cpp:392 src/muuli_wdr.cpp:1585 src/muuli_wdr.cpp:3455
 #: src/Statistics.cpp:829
 msgid "Downloads"
 msgstr "Descargues"
 
-#: src/amuleDlg.cpp:364 src/amuleDlg.cpp:1805 src/muuli_wdr.cpp:3325
+#: src/amuleDlg.cpp:364 src/amuleDlg.cpp:1828 src/muuli_wdr.cpp:3329
 msgid "Shared files"
 msgstr "Ficheros compartíos"
 
-#: src/amuleDlg.cpp:365 src/amuleDlg.cpp:1811 src/muuli_wdr.cpp:2957
-#: src/muuli_wdr.cpp:3407 src/muuli_wdr.cpp:3454
+#: src/amuleDlg.cpp:365 src/amuleDlg.cpp:1834 src/muuli_wdr.cpp:2961
+#: src/muuli_wdr.cpp:3411 src/muuli_wdr.cpp:3458
 msgid "Messages"
 msgstr "Mensaxes"
 
-#: src/amuleDlg.cpp:366 src/amuleDlg.cpp:1817 src/muuli_wdr.cpp:3455
+#: src/amuleDlg.cpp:366 src/amuleDlg.cpp:1840 src/muuli_wdr.cpp:3459
 #: src/PrefsUnifiedDlg.cpp:314 src/Statistics.cpp:779 src/Statistics.cpp:1235
 msgid "Statistics"
 msgstr "Estadístiques"
 
-#: src/amuleDlg.cpp:368 src/amuleDlg.cpp:1824 src/muuli_wdr.cpp:3457
+#: src/amuleDlg.cpp:368 src/amuleDlg.cpp:1847 src/muuli_wdr.cpp:3461
 #: src/PrefsUnifiedDlg.cpp:330 src/utils/wxCas/src/wxcasprefs.cpp:39
 msgid "Preferences"
 msgstr "Preferencies"
@@ -680,8 +680,8 @@ msgstr "Kad: Apagada"
 #: src/amuleDlg.cpp:1029 src/DownloadListCtrl.cpp:505
 #: src/DownloadListCtrl.cpp:749 src/FriendListCtrl.cpp:180
 #: src/muuli_wdr.cpp:731 src/muuli_wdr.cpp:782 src/muuli_wdr.cpp:846
-#: src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2262 src/muuli_wdr.cpp:2347
-#: src/muuli_wdr.cpp:3095 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
+#: src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2266 src/muuli_wdr.cpp:2351
+#: src/muuli_wdr.cpp:3099 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
 #: src/ServerListCtrl.cpp:606 src/TransferWnd.cpp:378
 #: src/utils/wxCas/src/wxcasprefs.cpp:235
 msgid "Cancel"
@@ -692,7 +692,7 @@ msgid "Stop the current connection attempts"
 msgstr "Detener los intentos de conexón actuales"
 
 #: src/amuleDlg.cpp:1035 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976
-#: src/muuli_wdr.cpp:2485
+#: src/muuli_wdr.cpp:2489
 msgid "Disconnect"
 msgstr "Desconeutar"
 
@@ -701,7 +701,7 @@ msgid "Disconnect from the currently connected networks"
 msgstr "Desconeutase de les redes coneutaes"
 
 #: src/amuleDlg.cpp:1041 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979
-#: src/muuli_wdr.cpp:2640 src/muuli_wdr.cpp:3092 src/muuli_wdr.cpp:3447
+#: src/muuli_wdr.cpp:2644 src/muuli_wdr.cpp:3096 src/muuli_wdr.cpp:3451
 msgid "Connect"
 msgstr "Coneutar"
 
@@ -756,7 +756,7 @@ msgstr "Confirmar colar."
 msgid "Launch Command: "
 msgstr "Llanzar comandu:"
 
-#: src/amuleDlg.cpp:1632 src/muuli_wdr.cpp:1982 src/Preferences.cpp:979
+#: src/amuleDlg.cpp:1632 src/muuli_wdr.cpp:1986 src/Preferences.cpp:979
 msgid "- default -"
 msgstr "- Por defeutu -"
 
@@ -770,61 +770,61 @@ msgstr "El direutorio de tema '%s' nun esiste"
 msgid "WARNING: Unable to open skin file '%s' for read"
 msgstr "ATENCIÓN: Nun pue abrise'l ficheru de temes '%s' pa llectura"
 
-#: src/amuleDlg.cpp:1791 src/muuli_wdr.cpp:3449
+#: src/amuleDlg.cpp:1814 src/muuli_wdr.cpp:3453
 msgid "Networks Window"
 msgstr "Ventana de redes"
 
-#: src/amuleDlg.cpp:1797 src/muuli_wdr.cpp:3450
+#: src/amuleDlg.cpp:1820 src/muuli_wdr.cpp:3454
 msgid "Searches Window"
 msgstr "Ventana de gueta"
 
-#: src/amuleDlg.cpp:1803 src/muuli_wdr.cpp:3451
+#: src/amuleDlg.cpp:1826 src/muuli_wdr.cpp:3455
 #, fuzzy
 msgid "Downloads Window"
 msgstr "Descargando"
 
-#: src/amuleDlg.cpp:1809 src/muuli_wdr.cpp:3453
+#: src/amuleDlg.cpp:1832 src/muuli_wdr.cpp:3457
 msgid "Shared Files Window"
 msgstr "Ventana de ficheros compartíos"
 
-#: src/amuleDlg.cpp:1815 src/muuli_wdr.cpp:3454
+#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3458
 msgid "Messages Window"
 msgstr "Ventana de mensaxes"
 
-#: src/amuleDlg.cpp:1821 src/muuli_wdr.cpp:3455
+#: src/amuleDlg.cpp:1844 src/muuli_wdr.cpp:3459
 msgid "Statistics Graph Window"
 msgstr "Ventana de gráficos d'estadístiques"
 
-#: src/amuleDlg.cpp:1828 src/muuli_wdr.cpp:3457
+#: src/amuleDlg.cpp:1851 src/muuli_wdr.cpp:3461
 msgid "Preferences Settings Window"
 msgstr "Ventana d'opciones"
 
-#: src/amuleDlg.cpp:1831 src/muuli_wdr.cpp:3458
+#: src/amuleDlg.cpp:1854 src/muuli_wdr.cpp:3462
 msgid "Import"
 msgstr "Importar"
 
-#: src/amuleDlg.cpp:1835 src/muuli_wdr.cpp:3458
+#: src/amuleDlg.cpp:1858 src/muuli_wdr.cpp:3462
 msgid "The partfile importer tool"
 msgstr "La ferramienta pa importar ficheros part"
 
-#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3459
+#: src/amuleDlg.cpp:1861 src/muuli_wdr.cpp:3463
 #: src/utils/aLinkCreator/src/alcframe.cpp:262
 msgid "About"
 msgstr "Tocante a"
 
-#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3459
+#: src/amuleDlg.cpp:1861 src/muuli_wdr.cpp:3463
 msgid "About/Help"
 msgstr "Tocante a/Aida"
 
-#: src/amuleDlg.cpp:2036
+#: src/amuleDlg.cpp:2059
 msgid "eD2k network"
 msgstr "Rede eD2k"
 
-#: src/amuleDlg.cpp:2039
+#: src/amuleDlg.cpp:2062
 msgid "Kad network"
 msgstr "Rede Kad"
 
-#: src/amuleDlg.cpp:2039
+#: src/amuleDlg.cpp:2062
 msgid "No network"
 msgstr "Ensin rede"
 
@@ -1358,19 +1358,19 @@ msgstr "Auto [Al]"
 msgid "Very low"
 msgstr "Mui baxa"
 
-#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:743 src/muuli_wdr.cpp:2313
+#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:743 src/muuli_wdr.cpp:2317
 #: src/ServerListCtrl.cpp:263 src/ServerListCtrl.cpp:456
 #: src/SharedFilesCtrl.cpp:145
 msgid "Low"
 msgstr "Baxa"
 
-#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:744 src/muuli_wdr.cpp:2314
+#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:744 src/muuli_wdr.cpp:2318
 #: src/ServerListCtrl.cpp:266 src/ServerListCtrl.cpp:457
 #: src/SharedFilesCtrl.cpp:146
 msgid "Normal"
 msgstr "Normal"
 
-#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:745 src/muuli_wdr.cpp:2315
+#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:745 src/muuli_wdr.cpp:2319
 #: src/ServerListCtrl.cpp:269 src/ServerListCtrl.cpp:458
 #: src/SharedFilesCtrl.cpp:147
 msgid "High"
@@ -1462,7 +1462,7 @@ msgstr "Sirvidor llocal"
 msgid "Remote Server"
 msgstr "Sirvidor remotu"
 
-#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3212
+#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3216
 #: src/SearchDlg.cpp:119 src/TextClient.cpp:911
 msgid "Kad"
 msgstr "Kad"
@@ -1534,7 +1534,7 @@ msgstr "Parte"
 msgid "Size"
 msgstr "Tamañu"
 
-#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3279
+#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3283
 msgid "Transferred"
 msgstr "Tresferío"
 
@@ -1592,7 +1592,7 @@ msgstr ""
 "Reaición dende: %s (%s)\n"
 "\n"
 
-#: src/DownloadListCtrl.cpp:746 src/muuli_wdr.cpp:2316
+#: src/DownloadListCtrl.cpp:746 src/muuli_wdr.cpp:2320
 #: src/SharedFilesCtrl.cpp:150
 msgid "Auto"
 msgstr "Auto"
@@ -1630,7 +1630,7 @@ msgid "Extended Options"
 msgstr "Opciones estendíes"
 
 #: src/DownloadListCtrl.cpp:770 src/DownloadListCtrl.cpp:822
-#: src/muuli_wdr.cpp:1800
+#: src/muuli_wdr.cpp:1804
 msgid "Preview"
 msgstr "Previsualizar"
 
@@ -2434,23 +2434,23 @@ msgid ""
 "want downloads on a different (e.g. larger) disk."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:549 src/FirstRunWizard.cpp:611 src/muuli_wdr.cpp:1712
+#: src/FirstRunWizard.cpp:549 src/FirstRunWizard.cpp:611 src/muuli_wdr.cpp:1716
 msgid "Destination folder for downloads"
 msgstr "Carpeta de destín pa les descargues"
 
 #: src/FirstRunWizard.cpp:553 src/FirstRunWizard.cpp:569 src/muuli_wdr.cpp:1349
-#: src/muuli_wdr.cpp:1366 src/muuli_wdr.cpp:1687 src/muuli_wdr.cpp:1718
-#: src/muuli_wdr.cpp:1730 src/muuli_wdr.cpp:2800
+#: src/muuli_wdr.cpp:1366 src/muuli_wdr.cpp:1691 src/muuli_wdr.cpp:1722
+#: src/muuli_wdr.cpp:1734 src/muuli_wdr.cpp:2804
 #: src/utils/aLinkCreator/src/alcframe.cpp:135
 #: src/utils/wxCas/src/wxcasprefs.cpp:52 src/utils/wxCas/src/wxcasprefs.cpp:118
 msgid "Browse"
 msgstr "Desaminar"
 
-#: src/FirstRunWizard.cpp:559 src/muuli_wdr.cpp:1723
+#: src/FirstRunWizard.cpp:559 src/muuli_wdr.cpp:1727
 msgid "(All files in this folder are shared with other peers)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:565 src/FirstRunWizard.cpp:624 src/muuli_wdr.cpp:1725
+#: src/FirstRunWizard.cpp:565 src/FirstRunWizard.cpp:624 src/muuli_wdr.cpp:1729
 msgid "Folder for temporary download files"
 msgstr "Carpeta pa los ficheros temporales de descargues"
 
@@ -2481,7 +2481,7 @@ msgstr "¡ Nun pudo abrise'l ficheru de collacios 'emfriends.met' pa la so escri
 msgid "CRITICAL - no client on StartChatSession"
 msgstr "CRITICU - ensin veceru en sesión charra d'aniciu"
 
-#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2706 src/muuli_wdr.cpp:3383
+#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2710 src/muuli_wdr.cpp:3387
 msgid "Friends"
 msgstr "Collacios"
 
@@ -2595,8 +2595,8 @@ msgstr "Dengún"
 msgid "No"
 msgstr "Non"
 
-#: src/GenericClientListCtrl.cpp:1216 src/PrefsUnifiedDlg.cpp:2898
-#: src/PrefsUnifiedDlg.cpp:2948 src/ServerListCtrl.cpp:276
+#: src/GenericClientListCtrl.cpp:1216 src/PrefsUnifiedDlg.cpp:2907
+#: src/PrefsUnifiedDlg.cpp:2957 src/ServerListCtrl.cpp:276
 msgid "Yes"
 msgstr "Sí"
 
@@ -2766,10 +2766,10 @@ msgstr "Puertu non válidu pa coneutar"
 msgid "Please fill all fields required"
 msgstr "Por favor enllene tolos campos requeríos"
 
-#: src/KadDlg.cpp:192 src/PartFile.cpp:1031 src/PrefsUnifiedDlg.cpp:1134
-#: src/PrefsUnifiedDlg.cpp:1204 src/PrefsUnifiedDlg.cpp:1405
-#: src/PrefsUnifiedDlg.cpp:1663 src/PrefsUnifiedDlg.cpp:1673
-#: src/PrefsUnifiedDlg.cpp:1690 src/PrefsUnifiedDlg.cpp:1738
+#: src/KadDlg.cpp:192 src/PartFile.cpp:1031 src/PrefsUnifiedDlg.cpp:1143
+#: src/PrefsUnifiedDlg.cpp:1213 src/PrefsUnifiedDlg.cpp:1414
+#: src/PrefsUnifiedDlg.cpp:1672 src/PrefsUnifiedDlg.cpp:1682
+#: src/PrefsUnifiedDlg.cpp:1699 src/PrefsUnifiedDlg.cpp:1747
 msgid "Message"
 msgstr "Mensax"
 
@@ -2871,7 +2871,7 @@ msgstr "Media compartío"
 msgid "Uploaded"
 msgstr "Xubío"
 
-#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3263
+#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3267
 msgid "Requested"
 msgstr "Pidío"
 
@@ -2995,7 +2995,7 @@ msgid "WARNING: "
 msgstr "AVISU:"
 
 #: src/MuleNotebook.cpp:179 src/muuli_wdr.cpp:817 src/muuli_wdr.cpp:1229
-#: src/muuli_wdr.cpp:3167 src/muuli_wdr.cpp:3423
+#: src/muuli_wdr.cpp:3171 src/muuli_wdr.cpp:3427
 msgid "Close"
 msgstr "Zarrar"
 
@@ -3013,7 +3013,7 @@ msgid "Paste"
 msgstr "Apegar"
 
 #: src/MuleTextCtrl.cpp:89 src/muuli_wdr.cpp:358 src/muuli_wdr.cpp:757
-#: src/muuli_wdr.cpp:2390 src/muuli_wdr.cpp:2409 src/muuli_wdr.cpp:2431
+#: src/muuli_wdr.cpp:2394 src/muuli_wdr.cpp:2413 src/muuli_wdr.cpp:2435
 #: src/utils/aLinkCreator/src/alcframe.cpp:142
 msgid "Clear"
 msgstr "Llimpiar"
@@ -3112,7 +3112,7 @@ msgstr "Colar"
 
 #: src/MuleTrayIcon.cpp:579 src/MuleTrayIcon.cpp:945 src/MuleTrayIcon.cpp:965
 #: src/muuli_wdr.cpp:1398 src/muuli_wdr.cpp:1406 src/muuli_wdr.cpp:1413
-#: src/muuli_wdr.cpp:1846 src/muuli_wdr.cpp:1852 src/OtherFunctions.cpp:91
+#: src/muuli_wdr.cpp:1850 src/muuli_wdr.cpp:1856 src/OtherFunctions.cpp:91
 #: src/StatisticsDlg.cpp:93 src/StatisticsDlg.cpp:95
 msgid "kB/s"
 msgstr "kB/s"
@@ -3354,7 +3354,7 @@ msgstr "Bytes"
 msgid "KB"
 msgstr "KB"
 
-#: src/muuli_wdr.cpp:274 src/muuli_wdr.cpp:293 src/muuli_wdr.cpp:1631
+#: src/muuli_wdr.cpp:274 src/muuli_wdr.cpp:293 src/muuli_wdr.cpp:1635
 #: src/OtherFunctions.cpp:64
 msgid "MB"
 msgstr "MB"
@@ -3371,7 +3371,7 @@ msgstr "Tamañu Máx"
 msgid "Availability"
 msgstr "Disponibilidá"
 
-#: src/muuli_wdr.cpp:312 src/muuli_wdr.cpp:398 src/muuli_wdr.cpp:3328
+#: src/muuli_wdr.cpp:312 src/muuli_wdr.cpp:398 src/muuli_wdr.cpp:3332
 msgid "Filter:"
 msgstr "Fieltru:"
 
@@ -3435,8 +3435,8 @@ msgstr "Fontes completes"
 #: src/muuli_wdr.cpp:1160 src/muuli_wdr.cpp:1167 src/muuli_wdr.cpp:1172
 #: src/muuli_wdr.cpp:1179 src/muuli_wdr.cpp:1184 src/muuli_wdr.cpp:1191
 #: src/muuli_wdr.cpp:1205 src/muuli_wdr.cpp:1212 src/muuli_wdr.cpp:1217
-#: src/muuli_wdr.cpp:1224 src/muuli_wdr.cpp:3265 src/muuli_wdr.cpp:3273
-#: src/muuli_wdr.cpp:3281
+#: src/muuli_wdr.cpp:1224 src/muuli_wdr.cpp:3269 src/muuli_wdr.cpp:3277
+#: src/muuli_wdr.cpp:3285
 msgid "N/A"
 msgstr "N/A"
 
@@ -3581,7 +3581,7 @@ msgstr ""
 msgid "Album :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:685 src/muuli_wdr.cpp:2285
+#: src/muuli_wdr.cpp:685 src/muuli_wdr.cpp:2289
 msgid "Title :"
 msgstr "Títulu :"
 
@@ -3690,7 +3690,7 @@ msgstr "Nome d'usuariu :"
 msgid "Userhash :"
 msgstr "Hash del usuariu :"
 
-#: src/muuli_wdr.cpp:895 src/muuli_wdr.cpp:1752 src/muuli_wdr.cpp:2480
+#: src/muuli_wdr.cpp:895 src/muuli_wdr.cpp:1756 src/muuli_wdr.cpp:2484
 #: src/utils/aLinkCreator/src/alcframe.cpp:137
 msgid "Add"
 msgstr "Amestar"
@@ -3699,15 +3699,15 @@ msgstr "Amestar"
 msgid "Download-Speed"
 msgstr "Velocidá de descarga"
 
-#: src/muuli_wdr.cpp:954 src/muuli_wdr.cpp:989 src/muuli_wdr.cpp:2584
+#: src/muuli_wdr.cpp:954 src/muuli_wdr.cpp:989 src/muuli_wdr.cpp:2588
 msgid "Current"
 msgstr "Actual"
 
-#: src/muuli_wdr.cpp:962 src/muuli_wdr.cpp:997 src/muuli_wdr.cpp:2592
+#: src/muuli_wdr.cpp:962 src/muuli_wdr.cpp:997 src/muuli_wdr.cpp:2596
 msgid "Running average"
 msgstr "Media d'execución"
 
-#: src/muuli_wdr.cpp:970 src/muuli_wdr.cpp:1005 src/muuli_wdr.cpp:2600
+#: src/muuli_wdr.cpp:970 src/muuli_wdr.cpp:1005 src/muuli_wdr.cpp:2604
 msgid "Session average"
 msgstr "Media de la sesión"
 
@@ -3719,7 +3719,7 @@ msgstr "Velocidá de xuba"
 msgid "Connections"
 msgstr "Conexones"
 
-#: src/muuli_wdr.cpp:1024 src/muuli_wdr.cpp:1871
+#: src/muuli_wdr.cpp:1024 src/muuli_wdr.cpp:1875
 msgid "Active downloads"
 msgstr "Descargues actives"
 
@@ -3727,7 +3727,7 @@ msgstr "Descargues actives"
 msgid "Active connections (1:1)"
 msgstr "Conexones actives (1:1)"
 
-#: src/muuli_wdr.cpp:1040 src/muuli_wdr.cpp:1872
+#: src/muuli_wdr.cpp:1040 src/muuli_wdr.cpp:1876
 msgid "Active uploads"
 msgstr "Xubes actives"
 
@@ -4004,7 +4004,7 @@ msgstr "Señes IP llocal de enllaz: (erma pa cualesquiera):"
 msgid "Advanced users only: If you have multiple network interfaces, enter the address of the interface to which aMule should be bound."
 msgstr "Namái usuarios avanzaos: Si tu tienes múltiples tarxetes de rede, introduz la direición de la tarxeta, que aMule tendrá d'usar."
 
-#: src/muuli_wdr.cpp:1462 src/muuli_wdr.cpp:2065
+#: src/muuli_wdr.cpp:1462 src/muuli_wdr.cpp:2069
 #, fuzzy
 msgid "Bind to network interface (empty for any):"
 msgstr "Señes IP llocal de enllaz: (erma pa cualesquiera):"
@@ -4021,7 +4021,7 @@ msgstr "Max. fontes descargando un ficheru:"
 msgid "Max simultaneous connections:"
 msgstr "Máx. conexones al empar:"
 
-#: src/muuli_wdr.cpp:1498 src/muuli_wdr.cpp:3207
+#: src/muuli_wdr.cpp:1498 src/muuli_wdr.cpp:3211
 msgid "ED2K"
 msgstr "ED2K"
 
@@ -4113,783 +4113,783 @@ msgstr "Reservar espaciu en discu pa los nuevos ficheros"
 msgid "For new files preallocates disk space for the whole file, thus reduces fragmentation"
 msgstr "Pa los nuevos ficheros reservar tol espaciu del ficheru, esto amenorga la fragmentación"
 
-#: src/muuli_wdr.cpp:1617
+#: src/muuli_wdr.cpp:1621
 msgid "Create new files as sparse files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1618
+#: src/muuli_wdr.cpp:1622
 msgid "Sparse part files only occupy disk space for the parts already downloaded, so free space is used up gradually as the file fills in. Turn this off to use an ordinary file instead - useful where sparse files are unsupported or slow, or where backup/de-duplication tools handle them badly. Applies only when the core runs on Windows; on Linux and macOS part files are sparse anyway and this setting has no effect."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1623
+#: src/muuli_wdr.cpp:1627
 msgid "Stop downloads when free disk space reaches "
 msgstr "Detener descargues cuando s'algame l'espaciu llibre en discu"
 
-#: src/muuli_wdr.cpp:1624
+#: src/muuli_wdr.cpp:1628
 msgid "Select this if you want aMule to check your disk space"
 msgstr "Seleiciona esta opción si quies que aMule comprebe l'espaciu en discu"
 
-#: src/muuli_wdr.cpp:1628
+#: src/muuli_wdr.cpp:1632
 msgid "Enter here the min disk space desired."
 msgstr "Introduz l'espaciu mínimu de discu deseyáu."
 
-#: src/muuli_wdr.cpp:1634
+#: src/muuli_wdr.cpp:1638
 msgid "Save 10 sources on rare files (< 20 sources)"
 msgstr "Guardar 10 fontes en ficheros raros (< 20 fontes)"
 
-#: src/muuli_wdr.cpp:1638 src/Statistics.cpp:790
+#: src/muuli_wdr.cpp:1642 src/Statistics.cpp:790
 msgid "Uploads"
 msgstr "Xubíes"
 
-#: src/muuli_wdr.cpp:1641
+#: src/muuli_wdr.cpp:1645
 msgid "Add new shared files with auto priority"
 msgstr "Amestar nuevos ficheros compartíos con auto prioridá"
 
-#: src/muuli_wdr.cpp:1647
+#: src/muuli_wdr.cpp:1651
 msgid "Intelligent Corruption Handling (I.C.H.)"
 msgstr "Remanador Intelixente de Corrupciones (I.C.H)"
 
-#: src/muuli_wdr.cpp:1650
+#: src/muuli_wdr.cpp:1654
 msgid "Enable"
 msgstr "Habilitar"
 
-#: src/muuli_wdr.cpp:1653
+#: src/muuli_wdr.cpp:1657
 msgid "Advanced I.C.H. trusts every hash (not recommended)"
 msgstr "I.C.H. avanzáu, confiar en tolos hash (non recomendáu)"
 
-#: src/muuli_wdr.cpp:1665 src/PrefsUnifiedDlg.cpp:1990
+#: src/muuli_wdr.cpp:1669 src/PrefsUnifiedDlg.cpp:1999
 msgid "Media metadata extraction"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1669
+#: src/muuli_wdr.cpp:1673
 msgid "Extract length / bitrate / codec from shared audio and video files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1671
+#: src/muuli_wdr.cpp:1675
 msgid "When enabled, aMule runs ffprobe on each shared media file to fill in the Length / Bitrate / Codec columns other clients see when they find the file in a search. Requires ffmpeg (the ffprobe binary) to be installed."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1678
+#: src/muuli_wdr.cpp:1682
 msgid "Path to ffprobe:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1683
+#: src/muuli_wdr.cpp:1687
 msgid "Full path to the ffprobe binary. Leave empty to have aMule auto-detect it on startup."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1691
+#: src/muuli_wdr.cpp:1695
 msgid "Detect"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1692
+#: src/muuli_wdr.cpp:1696
 msgid "Search the standard install locations for an ffprobe binary and fill the path field."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1716
+#: src/muuli_wdr.cpp:1720
 msgid ""
 "Completed downloads are stored here. All files in this folder are automatically shared with other peers.\n"
 "If this folder also holds files you don't want to share, point it at an aMule-only sub-folder."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1719
+#: src/muuli_wdr.cpp:1723
 msgid "Pick the folder where completed downloads will be stored. All files in that folder will be shared with other peers."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1733
+#: src/muuli_wdr.cpp:1737
 msgid "Shared folders"
 msgstr "Carpetes compartíes"
 
-#: src/muuli_wdr.cpp:1739
+#: src/muuli_wdr.cpp:1743
 msgid "(Folders shared by the core. Enter a path to add one.)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1747
+#: src/muuli_wdr.cpp:1751
 msgid "Absolute path of a folder on the core's machine, e.g. /home/user/shared"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1749 src/PrefsUnifiedDlg.cpp:2874
+#: src/muuli_wdr.cpp:1753 src/PrefsUnifiedDlg.cpp:2883
 msgid "Recursive"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1750
+#: src/muuli_wdr.cpp:1754
 msgid "Share every sub-folder underneath this one, including ones created later."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1754 src/utils/aLinkCreator/src/alcframe.cpp:141
+#: src/muuli_wdr.cpp:1758 src/utils/aLinkCreator/src/alcframe.cpp:141
 msgid "Remove"
 msgstr "Desaniciar"
 
-#: src/muuli_wdr.cpp:1758
+#: src/muuli_wdr.cpp:1762
 msgid "(Right click on folder icon for recursive share)"
 msgstr "(Click drechu n'iconu de carpeta, pa compartición recursiva)"
 
-#: src/muuli_wdr.cpp:1765
+#: src/muuli_wdr.cpp:1769
 msgid "Share hidden files"
 msgstr "Compartir ficheros anubríos"
 
-#: src/muuli_wdr.cpp:1771
+#: src/muuli_wdr.cpp:1775
 msgid "Automatically rescan shared folders for changes"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1777
+#: src/muuli_wdr.cpp:1781
 msgid "Follow symbolic links in shared folders"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1783
+#: src/muuli_wdr.cpp:1787
 msgid "Exclude files matching:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1786
+#: src/muuli_wdr.cpp:1790
 msgid "Wildcard patterns separated by '|', e.g. .DS_Store|Thumbs.db|*.tmp. Files whose name matches are not shared. Matching is case-insensitive."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1790
+#: src/muuli_wdr.cpp:1794
 msgid "Patterns are regular expressions"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1791
+#: src/muuli_wdr.cpp:1795
 msgid "When set, the whole field is one regular expression ('|' is alternation). When unset, it is a list of '|'-separated wildcards."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1801
+#: src/muuli_wdr.cpp:1805
 msgid "Show how many shared files the current pattern would exclude."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1822
+#: src/muuli_wdr.cpp:1826
 msgid "Graphs"
 msgstr "Gráficos"
 
-#: src/muuli_wdr.cpp:1825 src/muuli_wdr.cpp:1887
+#: src/muuli_wdr.cpp:1829 src/muuli_wdr.cpp:1891
 msgid "Update delay : 5 secs"
 msgstr "Intervalu d'actualización : 5 segs"
 
-#: src/muuli_wdr.cpp:1829
+#: src/muuli_wdr.cpp:1833
 msgid "Time for average graph: 100 mins"
 msgstr "Tiempu de promediu del gráficu: 100 min"
 
-#: src/muuli_wdr.cpp:1833
+#: src/muuli_wdr.cpp:1837
 msgid "Connections Graph Scale: 100 "
 msgstr "Escala del gráficu de les conexones: 100"
 
-#: src/muuli_wdr.cpp:1840
+#: src/muuli_wdr.cpp:1844
 msgid "Download graph scale:"
 msgstr "Descargar escala gráfica:"
 
-#: src/muuli_wdr.cpp:1848
+#: src/muuli_wdr.cpp:1852
 msgid "Upload graph scale:"
 msgstr "Escala gráfica de descarga:"
 
-#: src/muuli_wdr.cpp:1858
+#: src/muuli_wdr.cpp:1862
 #, fuzzy
 msgid "Colors: "
 msgstr "Colores: "
 
-#: src/muuli_wdr.cpp:1862
+#: src/muuli_wdr.cpp:1866
 msgid "Background"
 msgstr "Fondu"
 
-#: src/muuli_wdr.cpp:1863
+#: src/muuli_wdr.cpp:1867
 msgid "Grid"
 msgstr "Rexella"
 
-#: src/muuli_wdr.cpp:1864
+#: src/muuli_wdr.cpp:1868
 msgid "Download current"
 msgstr "Descarga actual"
 
-#: src/muuli_wdr.cpp:1865
+#: src/muuli_wdr.cpp:1869
 msgid "Download running average"
 msgstr "Promediu descarga n'execución"
 
-#: src/muuli_wdr.cpp:1866
+#: src/muuli_wdr.cpp:1870
 msgid "Download session average"
 msgstr "Promediu Descarga/sesión"
 
-#: src/muuli_wdr.cpp:1867
+#: src/muuli_wdr.cpp:1871
 msgid "Upload current"
 msgstr "Xuba actual"
 
-#: src/muuli_wdr.cpp:1868
+#: src/muuli_wdr.cpp:1872
 msgid "Upload running average"
 msgstr "Promediu Xuba/tiempu"
 
-#: src/muuli_wdr.cpp:1869
+#: src/muuli_wdr.cpp:1873
 msgid "Upload session average"
 msgstr "Promediu xuba/sesión"
 
-#: src/muuli_wdr.cpp:1870
+#: src/muuli_wdr.cpp:1874
 msgid "Active connections"
 msgstr "Conexones actives"
 
-#: src/muuli_wdr.cpp:1873
+#: src/muuli_wdr.cpp:1877
 #, fuzzy
 msgid "Systray Icon Speed Bar"
 msgstr "Barra de velocidá del iconu de sistema"
 
-#: src/muuli_wdr.cpp:1874
+#: src/muuli_wdr.cpp:1878
 msgid "Kad-nodes current"
 msgstr "Kad-nodos actual"
 
-#: src/muuli_wdr.cpp:1875
+#: src/muuli_wdr.cpp:1879
 msgid "Kad-nodes running"
 msgstr "Kad-nodos executando"
 
-#: src/muuli_wdr.cpp:1876
+#: src/muuli_wdr.cpp:1880
 msgid "Kad-nodes session"
 msgstr "Kad-nodos sesión"
 
-#: src/muuli_wdr.cpp:1880 src/muuli_wdr.cpp:2334
+#: src/muuli_wdr.cpp:1884 src/muuli_wdr.cpp:2338
 msgid "Select"
 msgstr "Seleicionar"
 
-#: src/muuli_wdr.cpp:1884
+#: src/muuli_wdr.cpp:1888
 msgid "Tree"
 msgstr "Árbol"
 
-#: src/muuli_wdr.cpp:1894
+#: src/muuli_wdr.cpp:1898
 msgid "Number of Client Versions shown (0=unlimited)"
 msgstr "Númberu de versiones de veceros a amosar (0=ensin llímite)"
 
-#: src/muuli_wdr.cpp:1919
+#: src/muuli_wdr.cpp:1923
 msgid "!!! WARNING !!!"
 msgstr "¡¡¡ AVISU !!!"
 
-#: src/muuli_wdr.cpp:1934
+#: src/muuli_wdr.cpp:1938
 msgid "Max new connections / 5 secs"
 msgstr "Nueves conexones máx. / 5 segs"
 
-#: src/muuli_wdr.cpp:1936
+#: src/muuli_wdr.cpp:1940
 msgid "Concurrent Kad source lookups"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1938
+#: src/muuli_wdr.cpp:1942
 #, fuzzy
 msgid "Kad source re-search interval (minutes)"
 msgstr "Intervalu d'actualización de FTP en minutos"
 
-#: src/muuli_wdr.cpp:1940
+#: src/muuli_wdr.cpp:1944
 #, fuzzy
 msgid "Source re-ask interval (minutes)"
 msgstr "Intervalu d'actualización de FTP en minutos"
 
-#: src/muuli_wdr.cpp:1944
+#: src/muuli_wdr.cpp:1948
 msgid "File Buffer Size: 240000 bytes"
 msgstr "Tamañu del buffer de ficheru: 240000 bytes"
 
-#: src/muuli_wdr.cpp:1948
+#: src/muuli_wdr.cpp:1952
 msgid "Use MMAP: memory-mapped file access (lower memory use)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1949
+#: src/muuli_wdr.cpp:1953
 msgid "Maps part files into memory instead of buffering them on the heap, lowering the process memory footprint. May reduce download speed on some disks; best for memory-constrained or upload-heavy hosts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1951
+#: src/muuli_wdr.cpp:1955
 msgid "Upload Queue Size: 5000 clients"
 msgstr "Tamañu cola d'espera: 5000 veceros"
 
-#: src/muuli_wdr.cpp:1955
+#: src/muuli_wdr.cpp:1959
 msgid "Server connection refresh interval: Disable"
 msgstr "Intervalu d'actualización de conexón al sirvidor: Desactiváu"
 
-#: src/muuli_wdr.cpp:1959
+#: src/muuli_wdr.cpp:1963
 msgid "Disable computer's timed standby mode"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1978
+#: src/muuli_wdr.cpp:1982
 msgid "Skin to use: "
 msgstr "Tema a usar: "
 
-#: src/muuli_wdr.cpp:1987
+#: src/muuli_wdr.cpp:1991
 msgid "Show \"Fast eD2k Links Handler\" in every window."
 msgstr "Amosar \"Xestor rápidu d'enllaces eD2k\", en toles ventanes."
 
-#: src/muuli_wdr.cpp:1990
+#: src/muuli_wdr.cpp:1994
 msgid "Show extended info on categories tabs"
 msgstr "Amosar info estendía nes llingüetes de les categoríes"
 
-#: src/muuli_wdr.cpp:1993
+#: src/muuli_wdr.cpp:1997
 #, fuzzy
 msgid "Show application version on title"
 msgstr "Amosar índices de tresferencia nel títulu"
 
-#: src/muuli_wdr.cpp:1995
+#: src/muuli_wdr.cpp:1999
 msgid "Show transfer rates on title"
 msgstr "Amosar índices de tresferencia nel títulu"
 
-#: src/muuli_wdr.cpp:1997
+#: src/muuli_wdr.cpp:2001
 msgid "Before application name"
 msgstr "Enantes del nome de l'aplicación"
 
-#: src/muuli_wdr.cpp:1999
+#: src/muuli_wdr.cpp:2003
 msgid "After application name"
 msgstr "Dempués del nome de l'aplicación"
 
-#: src/muuli_wdr.cpp:2002
+#: src/muuli_wdr.cpp:2006
 msgid "Show overhead bandwidth"
 msgstr "Amosar anchor de banda escedente"
 
-#: src/muuli_wdr.cpp:2006
+#: src/muuli_wdr.cpp:2010
 msgid "Vertical toolbar orientation"
 msgstr "Orientación vertical de la barra de ferramientes"
 
-#: src/muuli_wdr.cpp:2008
+#: src/muuli_wdr.cpp:2012
 msgid "Live column sorting (auto-reorder rows as their values change)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2015
+#: src/muuli_wdr.cpp:2019
 msgid "Download Queue Files"
 msgstr "Ficheros de la cola de descarga"
 
-#: src/muuli_wdr.cpp:2018
+#: src/muuli_wdr.cpp:2022
 msgid "Show progress percentage"
 msgstr "Amosar porcentax de progresu"
 
-#: src/muuli_wdr.cpp:2024
+#: src/muuli_wdr.cpp:2028
 msgid "Show progress bar"
 msgstr "Amosar barra de progresu"
 
-#: src/muuli_wdr.cpp:2027
+#: src/muuli_wdr.cpp:2031
 msgid "Flat"
 msgstr "Planu"
 
-#: src/muuli_wdr.cpp:2031
+#: src/muuli_wdr.cpp:2035
 msgid "Round"
 msgstr "3D"
 
-#: src/muuli_wdr.cpp:2049
+#: src/muuli_wdr.cpp:2053
 msgid "External Connection Parameters"
 msgstr "Parámetros de conexón esterna"
 
-#: src/muuli_wdr.cpp:2052
+#: src/muuli_wdr.cpp:2056
 msgid "Accept external connections"
 msgstr "Aceutar conexones esternes"
 
-#: src/muuli_wdr.cpp:2059 src/muuli_wdr.cpp:2118
+#: src/muuli_wdr.cpp:2063 src/muuli_wdr.cpp:2122
 msgid "IP of the listening interface:"
 msgstr "IP de la interface que ta escuchando"
 
-#: src/muuli_wdr.cpp:2062
+#: src/muuli_wdr.cpp:2066
 msgid "Enter here a valid ip in the a.b.c.d format for the listening EC interface. An empty field or 0.0.0.0 will mean any interface."
 msgstr "Introduz una IP válida de la interface que ta escuchando. Un campu ermu o 0.0.0.0 significará cualesquier interface."
 
-#: src/muuli_wdr.cpp:2083 src/muuli_wdr.cpp:2194
+#: src/muuli_wdr.cpp:2087 src/muuli_wdr.cpp:2198
 msgid "TCP port:"
 msgstr "Puertu TCP:"
 
-#: src/muuli_wdr.cpp:2089
+#: src/muuli_wdr.cpp:2093
 msgid "Enable UPnP port forwarding on the EC port"
 msgstr "Habilitar UPnP port forwarding nel puertu EC"
 
-#: src/muuli_wdr.cpp:2093 src/muuli_wdr.cpp:3079
+#: src/muuli_wdr.cpp:2097 src/muuli_wdr.cpp:3083
 #: src/utils/wxCas/src/wxcasprefs.cpp:167
 msgid "Password"
 msgstr "Contraseña"
 
-#: src/muuli_wdr.cpp:2099
+#: src/muuli_wdr.cpp:2103
 #, fuzzy
 msgid "aMule API server parameters"
 msgstr "Parámetros del sirvidor web"
 
-#: src/muuli_wdr.cpp:2102
+#: src/muuli_wdr.cpp:2106
 msgid "Run amuleapi (REST API) on startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2107
+#: src/muuli_wdr.cpp:2111
 #, fuzzy
 msgid "HTTP port:"
 msgstr "Puertu TCP:"
 
-#: src/muuli_wdr.cpp:2121
+#: src/muuli_wdr.cpp:2125
 msgid "The interface amuleapi's HTTP server listens on. 127.0.0.1 (default) accepts only local connections; use 0.0.0.0 or a specific IP to expose it to other hosts (set an admin password below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2126
+#: src/muuli_wdr.cpp:2130
 msgid "Type a password to set or change it. Stored passwords cannot be shown, so leaving this empty keeps the current one."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2128
+#: src/muuli_wdr.cpp:2132
 #, fuzzy
 msgid "Admin password"
 msgstr "Comprobando contraseña\n"
 
-#: src/muuli_wdr.cpp:2140 src/muuli_wdr.cpp:2157 src/PrefsUnifiedDlg.cpp:1103
+#: src/muuli_wdr.cpp:2144 src/muuli_wdr.cpp:2161 src/PrefsUnifiedDlg.cpp:1112
 #, fuzzy
 msgid "A password is set."
 msgstr "Comprobando contraseña\n"
 
-#: src/muuli_wdr.cpp:2144
+#: src/muuli_wdr.cpp:2148
 #, fuzzy
 msgid "Enable guest access"
 msgstr "Denegar accesu a invitáu"
 
-#: src/muuli_wdr.cpp:2145
+#: src/muuli_wdr.cpp:2149
 msgid "Guest sessions may read status and listings but cannot change anything. Turning this off clears the stored guest password."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2149
+#: src/muuli_wdr.cpp:2153
 #, fuzzy
 msgid "Guest password"
 msgstr "Contraseña d'invitáu pa sirvidor web"
 
-#: src/muuli_wdr.cpp:2164
+#: src/muuli_wdr.cpp:2168
 msgid "Web server parameters"
 msgstr "Parámetros del sirvidor web"
 
-#: src/muuli_wdr.cpp:2167
+#: src/muuli_wdr.cpp:2171
 #, fuzzy
 msgid "Run webserver on startup (deprecated)"
 msgstr "Aniciar sirvidor web al entamu"
 
-#: src/muuli_wdr.cpp:2173
+#: src/muuli_wdr.cpp:2177
 msgid "Web template"
 msgstr "Plantía Web"
 
-#: src/muuli_wdr.cpp:2178
+#: src/muuli_wdr.cpp:2182
 msgid "Full rights password"
 msgstr "Contraseña alministrador"
 
-#: src/muuli_wdr.cpp:2182
+#: src/muuli_wdr.cpp:2186
 msgid "Enable Low rights User"
 msgstr "Activar invitáu"
 
-#: src/muuli_wdr.cpp:2187
+#: src/muuli_wdr.cpp:2191
 msgid "Low rights password"
 msgstr "Contraseña invitáu"
 
-#: src/muuli_wdr.cpp:2201
+#: src/muuli_wdr.cpp:2205
 msgid "Enable UPnP port forwarding of the web server port"
 msgstr "Usar forwarding de puertos UPnP nel puertu del sirvidor web"
 
-#: src/muuli_wdr.cpp:2206
+#: src/muuli_wdr.cpp:2210
 msgid "Web server UPnP TCP port (Optional)"
 msgstr "Puertu HTTP del sirvidor web (Opcional)"
 
-#: src/muuli_wdr.cpp:2214
+#: src/muuli_wdr.cpp:2218
 msgid "Page Refresh Time (in secs)"
 msgstr "Tiempu d'actualización de páxina (en segs)"
 
-#: src/muuli_wdr.cpp:2221
+#: src/muuli_wdr.cpp:2225
 msgid "Enable Gzip compression"
 msgstr "Activar compresión gzip"
 
-#: src/muuli_wdr.cpp:2255
+#: src/muuli_wdr.cpp:2259
 #, fuzzy
 msgid "Reset page to defaults"
 msgstr "Por defeutu"
 
-#: src/muuli_wdr.cpp:2256
+#: src/muuli_wdr.cpp:2260
 msgid "Reset the settings on the current page to their default values."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2258 src/muuli_wdr.cpp:2344 src/ServerWnd.cpp:274
+#: src/muuli_wdr.cpp:2262 src/muuli_wdr.cpp:2348 src/ServerWnd.cpp:274
 #: src/ServerWnd.cpp:282
 msgid "OK"
 msgstr "Aceutar"
 
-#: src/muuli_wdr.cpp:2260
+#: src/muuli_wdr.cpp:2264
 msgid "Click here to apply any changes made to the preferences."
 msgstr "Aplicar cualesquier cambéu fechu nes opciones."
 
-#: src/muuli_wdr.cpp:2263
+#: src/muuli_wdr.cpp:2267
 msgid "Reset any changes made to the preferences."
 msgstr "Encaboxar cualesquier cambéu fechu nes opciones."
 
-#: src/muuli_wdr.cpp:2292
+#: src/muuli_wdr.cpp:2296
 msgid "Comment :"
 msgstr "Comentariu : "
 
-#: src/muuli_wdr.cpp:2299
+#: src/muuli_wdr.cpp:2303
 msgid "Incoming Dir :"
 msgstr "Direutoriu entrante :"
 
-#: src/muuli_wdr.cpp:2308
+#: src/muuli_wdr.cpp:2312
 msgid "Change priority for new assigned files :"
 msgstr "Cambiar prioridá a nuevos ficheros asignaos :"
 
-#: src/muuli_wdr.cpp:2312
+#: src/muuli_wdr.cpp:2316
 #, fuzzy
 msgid "Don't change"
 msgstr "Non cambiar"
 
-#: src/muuli_wdr.cpp:2324
+#: src/muuli_wdr.cpp:2328
 msgid "Select color for this Category (currently selected) :"
 msgstr "Seleiciona color pa esta categoría (seleicionada) :"
 
-#: src/muuli_wdr.cpp:2391 src/muuli_wdr.cpp:2410 src/muuli_wdr.cpp:2432
+#: src/muuli_wdr.cpp:2395 src/muuli_wdr.cpp:2414 src/muuli_wdr.cpp:2436
 msgid "Click this button to reset the log."
 msgstr "Calca esti botón pa llimpiar el registru."
 
-#: src/muuli_wdr.cpp:2451
+#: src/muuli_wdr.cpp:2455
 msgid "Click on this button to update the servers list from URL ..."
 msgstr "Click nesti botón p'actualizar la llista de sirvidores dende una URL ..."
 
-#: src/muuli_wdr.cpp:2455
+#: src/muuli_wdr.cpp:2459
 msgid "Server list"
 msgstr "Llista de sirvidores"
 
-#: src/muuli_wdr.cpp:2459
+#: src/muuli_wdr.cpp:2463
 msgid "Enter the url to a server.met file here and press the button to the left to update the list of known servers."
 msgstr "Introduz la url a un ficheru server.met y calca'l botón de la esquierda p'actualizar la llista de sirvidores conocíos."
 
-#: src/muuli_wdr.cpp:2464
+#: src/muuli_wdr.cpp:2468
 msgid "Add server manually: Name"
 msgstr "Amestar sirvidor manualmente: Nome"
 
-#: src/muuli_wdr.cpp:2467
+#: src/muuli_wdr.cpp:2471
 msgid "Enter the name of the new server here"
 msgstr "Introduz el nome del nuevu sirvidor"
 
-#: src/muuli_wdr.cpp:2469 src/ServerWnd.cpp:206
+#: src/muuli_wdr.cpp:2473 src/ServerWnd.cpp:206
 msgid "IP:Port"
 msgstr "IP:Puertu"
 
-#: src/muuli_wdr.cpp:2472
+#: src/muuli_wdr.cpp:2476
 msgid "Enter the IP of the server here, using the x.x.x.x format."
 msgstr "Introduz la IP del sirvidor, usando'l formatu X.X.X.X."
 
-#: src/muuli_wdr.cpp:2478
+#: src/muuli_wdr.cpp:2482
 msgid "Enter the port of the server here."
 msgstr "Introduz el puertu del sirvidor"
 
-#: src/muuli_wdr.cpp:2481
+#: src/muuli_wdr.cpp:2485
 msgid "Add manually a server (fill fields to the left before) ..."
 msgstr "Amestar manualmente un sirvidor (rellena los campos) ..."
 
-#: src/muuli_wdr.cpp:2510
+#: src/muuli_wdr.cpp:2514
 msgid "aMule Log"
 msgstr "Rexistru"
 
-#: src/muuli_wdr.cpp:2518
+#: src/muuli_wdr.cpp:2522
 msgid "Server Info"
 msgstr "Info. sirvidores"
 
-#: src/muuli_wdr.cpp:2522
+#: src/muuli_wdr.cpp:2526
 msgid "ED2K Info"
 msgstr "Info ED2K"
 
-#: src/muuli_wdr.cpp:2526
+#: src/muuli_wdr.cpp:2530
 msgid "Kad Info"
 msgstr "Info Kad"
 
-#: src/muuli_wdr.cpp:2554
+#: src/muuli_wdr.cpp:2558
 msgid "Click on this button to update the nodes list from URL ..."
 msgstr "Click nesti botón p'actualizar la llista de nodos dende la URL ..."
 
-#: src/muuli_wdr.cpp:2558
+#: src/muuli_wdr.cpp:2562
 msgid "Nodes (0)"
 msgstr "Nodos (0)"
 
-#: src/muuli_wdr.cpp:2562
+#: src/muuli_wdr.cpp:2566
 msgid "Enter the url to a nodes.dat file here and press the button to the left to update the list of known nodes."
 msgstr "Introduz equí la url al ficheru nodes.dat y calca'l botón de la esquierda, p'actualizar la llista de nodos conocíos."
 
-#: src/muuli_wdr.cpp:2565
+#: src/muuli_wdr.cpp:2569
 msgid "Nodes stats"
 msgstr "Estadístiques nodos"
 
-#: src/muuli_wdr.cpp:2607
+#: src/muuli_wdr.cpp:2611
 msgid "Bootstrap"
 msgstr "Coneutar"
 
-#: src/muuli_wdr.cpp:2610
+#: src/muuli_wdr.cpp:2614
 msgid "New node"
 msgstr "Nuevu nodu"
 
-#: src/muuli_wdr.cpp:2615
+#: src/muuli_wdr.cpp:2619
 msgid "IP:"
 msgstr "IP:"
 
-#: src/muuli_wdr.cpp:2635
+#: src/muuli_wdr.cpp:2639
 msgid "Port:"
 msgstr "Puertu:"
 
-#: src/muuli_wdr.cpp:2648
+#: src/muuli_wdr.cpp:2652
 #, fuzzy
 msgid "Bootstrap from known clients"
 msgstr ""
 "Coneutar dende \n"
 "veceros conocíos"
 
-#: src/muuli_wdr.cpp:2650
+#: src/muuli_wdr.cpp:2654
 msgid "Disconnect Kad"
 msgstr "Desconeutar Kad"
 
-#: src/muuli_wdr.cpp:2684
+#: src/muuli_wdr.cpp:2688
 msgid "Use Secure User Identification"
 msgstr "Usar Identificación Segura d'Usuariu"
 
-#: src/muuli_wdr.cpp:2686
+#: src/muuli_wdr.cpp:2690
 msgid "It is recommended to enable this option. You will not receive credits if SUI is not enabled."
 msgstr "Encamiéntase a activar esta opción. Nun recibirá créditos si la ISU (Identificación Segura d'Usuariu) nun ta habilitada."
 
-#: src/muuli_wdr.cpp:2688
+#: src/muuli_wdr.cpp:2692
 msgid "Protocol Obfuscation"
 msgstr "Ofuscación de protocolu"
 
-#: src/muuli_wdr.cpp:2691
+#: src/muuli_wdr.cpp:2695
 msgid "Support Protocol Obfuscation"
 msgstr "Sofitu d'ofuscación de protocolu"
 
-#: src/muuli_wdr.cpp:2693
+#: src/muuli_wdr.cpp:2697
 msgid "This option enabled Protocol Obfuscation, and makes aMule accept obfuscated connections from other clients."
 msgstr "Esta opción activa la ofuscación de protocolu, y fai que aMule aceute conexones ofuscaes de otros veceros."
 
-#: src/muuli_wdr.cpp:2695
+#: src/muuli_wdr.cpp:2699
 msgid "Use obfuscation for outgoing connections"
 msgstr "Usar ofuscación pa conexones salientes"
 
-#: src/muuli_wdr.cpp:2697
+#: src/muuli_wdr.cpp:2701
 msgid "This option makes aMule use Protocol Obfuscation when connecting other clients/servers."
 msgstr "Esta opción fai que aMule use ofuscación de protocolu cuando se coneuten otros veceros/sirvidores."
 
-#: src/muuli_wdr.cpp:2699
+#: src/muuli_wdr.cpp:2703
 msgid "Accept only obfuscated connections"
 msgstr "Aceutar namái conexones ofuscaes"
 
-#: src/muuli_wdr.cpp:2700
+#: src/muuli_wdr.cpp:2704
 msgid "This option makes aMule only accept obfuscated connections. You will have less sources, but all your traffic will be obfuscated"
 msgstr "Esa opción fai que aMule namái aceute conexones ofuscaes. Tendrá menos fontes, pero tol so tráficu sedrá ofuscáu."
 
-#: src/muuli_wdr.cpp:2705
+#: src/muuli_wdr.cpp:2709
 msgid "Everybody"
 msgstr "Toos"
 
-#: src/muuli_wdr.cpp:2707
+#: src/muuli_wdr.cpp:2711
 msgid "No one"
 msgstr "Dengún"
 
-#: src/muuli_wdr.cpp:2709
+#: src/muuli_wdr.cpp:2713
 msgid "Who can see my shared files:"
 msgstr "Quién pue adicar los mios ficheros compartíos:"
 
-#: src/muuli_wdr.cpp:2710
+#: src/muuli_wdr.cpp:2714
 msgid "Select who can request to view a list of your shared files."
 msgstr "Seleiciona quién pue solicitar adicar la nuesa llista de ficheros compartíos."
 
-#: src/muuli_wdr.cpp:2712
+#: src/muuli_wdr.cpp:2716
 msgid "IP-Filtering"
 msgstr "Fieltráu de IPs"
 
-#: src/muuli_wdr.cpp:2719
+#: src/muuli_wdr.cpp:2723
 msgid "Filter clients"
 msgstr "Fieltru veceros"
 
-#: src/muuli_wdr.cpp:2721
+#: src/muuli_wdr.cpp:2725
 msgid "Enable filtering of the client IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "Habilitar fieltráu de IPs de veceros definíu nel ficheru ~/.aMule/ipfilter.dat"
 
-#: src/muuli_wdr.cpp:2723
+#: src/muuli_wdr.cpp:2727
 msgid "Filter servers"
 msgstr "Fieltru sirvidores"
 
-#: src/muuli_wdr.cpp:2725
+#: src/muuli_wdr.cpp:2729
 msgid "Enable filtering of the server IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "Habilitar fieltráu de IPs de sirvidores definíu nel ficheru ~/.aMule/ipfilter.dat"
 
-#: src/muuli_wdr.cpp:2729
+#: src/muuli_wdr.cpp:2733
 msgid "Reload List"
 msgstr "Recargar llista"
 
-#: src/muuli_wdr.cpp:2730
+#: src/muuli_wdr.cpp:2734
 msgid "Reload the list of IPs to filter from the file ~/.aMule/ipfilter.dat"
 msgstr "Recargar llista de fieltráu de IPs dende ficheru ~/.aMule/ipfilter.dat"
 
-#: src/muuli_wdr.cpp:2736
+#: src/muuli_wdr.cpp:2740
 msgid "URL:"
 msgstr "URL:"
 
-#: src/muuli_wdr.cpp:2740 src/muuli_wdr.cpp:2933
+#: src/muuli_wdr.cpp:2744 src/muuli_wdr.cpp:2937
 msgid "Update now"
 msgstr "Actualizar agora"
 
-#: src/muuli_wdr.cpp:2743
+#: src/muuli_wdr.cpp:2747
 msgid "Auto-update ipfilter at startup"
 msgstr "Auto-actualizar el fieltráu de IPs al entamu"
 
-#: src/muuli_wdr.cpp:2747
+#: src/muuli_wdr.cpp:2751
 msgid "Filtering Level:"
 msgstr "Nivel de fieltráu:"
 
-#: src/muuli_wdr.cpp:2753
+#: src/muuli_wdr.cpp:2757
 msgid "Always filter LAN IPs"
 msgstr "Fieltrar siempres IP's de LAN"
 
-#: src/muuli_wdr.cpp:2756
+#: src/muuli_wdr.cpp:2760
 msgid "Paranoid handling of non-matching IPs"
 msgstr "Control paranoicu de IPs non comprobaes"
 
-#: src/muuli_wdr.cpp:2758
+#: src/muuli_wdr.cpp:2762
 msgid "Rejects a packet when its source IP differs from the IP the client claims (an anti-spoofing check). Disable only if it causes connection problems."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2760
+#: src/muuli_wdr.cpp:2764
 msgid "Use system-wide ipfilter.dat if available"
 msgstr "Usar el ipfilter.dat de sistema si ta disponible"
 
-#: src/muuli_wdr.cpp:2761
+#: src/muuli_wdr.cpp:2765
 #, fuzzy
 msgid "If there's no local ipfilter.dat found, allow usage of a system-wide ipfilter file."
 msgstr "Si nun s'alcuentra un ficheru ipfilter.dat llocal, permitir l'usu d'un ficheru ipfilter de sistema"
 
-#: src/muuli_wdr.cpp:2778
+#: src/muuli_wdr.cpp:2782
 msgid "Enable Online-Signature"
 msgstr "Activar Robla online"
 
-#: src/muuli_wdr.cpp:2780
+#: src/muuli_wdr.cpp:2784
 msgid "Enables the writing of the OS file, which can be used by external apps to create signatures and the like."
 msgstr "Habilitar la escritura de ficheros del SO, suel usase pa criar robles por aplicaciones esternes."
 
-#: src/muuli_wdr.cpp:2784
+#: src/muuli_wdr.cpp:2788
 msgid "Update Frequency (Secs):"
 msgstr "Frecuencia d'actualización (segs):"
 
-#: src/muuli_wdr.cpp:2787
+#: src/muuli_wdr.cpp:2791
 msgid "Change the frequency (in seconds) of Online Signature updates."
 msgstr "Cambiar la frecuencia (en segundos) de l'actualización de la robla-online"
 
-#: src/muuli_wdr.cpp:2795
+#: src/muuli_wdr.cpp:2799
 msgid "Save online signature file in: "
 msgstr "Guardar ficheru de robla online en: "
 
-#: src/muuli_wdr.cpp:2801
+#: src/muuli_wdr.cpp:2805
 msgid "Click here to select the directory containing the the Online Signature files."
 msgstr "Click equí pa seleicionar el direutoriu que contién los ficheros de robles-online."
 
-#: src/muuli_wdr.cpp:2834
+#: src/muuli_wdr.cpp:2838
 msgid "Show country flags for clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2835
+#: src/muuli_wdr.cpp:2839
 msgid "Render the country flag column in the transfers, queue and search views. Requires a valid MMDB GeoIP database (see below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2840
+#: src/muuli_wdr.cpp:2844
 #, fuzzy
 msgid "Database"
 msgstr "Fluxu de datos :"
 
-#: src/muuli_wdr.cpp:2856
+#: src/muuli_wdr.cpp:2860
 #, fuzzy
 msgid "Source:"
 msgstr "Fontes"
 
-#: src/muuli_wdr.cpp:2859
+#: src/muuli_wdr.cpp:2863
 msgid "DB-IP (free, no account)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2860
+#: src/muuli_wdr.cpp:2864
 msgid "MaxMind GeoLite2 (free, account required)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2861
+#: src/muuli_wdr.cpp:2865
 msgid "Custom URL"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2864
+#: src/muuli_wdr.cpp:2868
 msgid "Choose which provider supplies the GeoIP MMDB database. DB-IP is the default - no account required. MaxMind requires a free account + license key. Use Custom URL to point at any other MMDB host (e.g. a local mirror)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2881
+#: src/muuli_wdr.cpp:2885
 msgid ""
 "No configuration required.\n"
 "\n"
@@ -4897,11 +4897,11 @@ msgid ""
 "License: Creative Commons BY 4.0 - https://creativecommons.org/licenses/by/4.0/"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2894
+#: src/muuli_wdr.cpp:2898
 msgid "License key:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2900
+#: src/muuli_wdr.cpp:2904
 msgid ""
 "Sign up for a free MaxMind account, then generate a License Key:\n"
 "https://www.maxmind.com/en/geolite2/signup\n"
@@ -4911,232 +4911,232 @@ msgid ""
 "Requires attribution and account registration; refresh at least every 30 days."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2915
+#: src/muuli_wdr.cpp:2919
 #, fuzzy
 msgid "Download URL:"
 msgstr "Descargáu:"
 
-#: src/muuli_wdr.cpp:2921
+#: src/muuli_wdr.cpp:2925
 msgid ""
 "Must point to an .mmdb file or a .gz / .tar.gz containing one.\n"
 "URL may include credentials (https://user:pass@host/...).\n"
 "License and attribution terms are set by the upstream URL - you are responsible."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2934
+#: src/muuli_wdr.cpp:2938
 msgid "Download the GeoIP database from the selected source."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2936
+#: src/muuli_wdr.cpp:2940
 #, fuzzy
 msgid "Auto-update on startup"
 msgstr "Auto-actualizar el fieltráu de IPs al entamu"
 
-#: src/muuli_wdr.cpp:2937
+#: src/muuli_wdr.cpp:2941
 msgid "Re-download the GeoIP database from the selected source every time aMule starts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2960
+#: src/muuli_wdr.cpp:2964
 msgid "Filter incoming messages (except current chat):"
 msgstr "Fieltrar mensaxes entrantes (sacantes conversación actual):"
 
-#: src/muuli_wdr.cpp:2962
+#: src/muuli_wdr.cpp:2966
 msgid "Filter all messages"
 msgstr "Fieltrar tolos mensaxes"
 
-#: src/muuli_wdr.cpp:2964
+#: src/muuli_wdr.cpp:2968
 msgid "Filter messages from people not on your friend list"
 msgstr "Fieltrar mensaxes de xente que nun ta na to llista de collacios"
 
-#: src/muuli_wdr.cpp:2966
+#: src/muuli_wdr.cpp:2970
 msgid "Filter messages from unknown clients"
 msgstr "Fieltrar mensaxes de veceros desconocíos"
 
-#: src/muuli_wdr.cpp:2968
+#: src/muuli_wdr.cpp:2972
 msgid "Filter messages containing (use ',' as separator):"
 msgstr "Fieltrar mensaxes que contienen (usa ',' como separtador):"
 
-#: src/muuli_wdr.cpp:2971 src/muuli_wdr.cpp:2982
+#: src/muuli_wdr.cpp:2975 src/muuli_wdr.cpp:2986
 msgid "add here the words amule should filter and block messages including it"
 msgstr "amiesta equí les pallabres que amule tien de fieltrar y bloquiar mensaxes incluyíos"
 
-#: src/muuli_wdr.cpp:2973
+#: src/muuli_wdr.cpp:2977
 msgid "Show received messages in the log"
 msgstr "Amosar mensaxes recibíos nel rexistru"
 
-#: src/muuli_wdr.cpp:2976
+#: src/muuli_wdr.cpp:2980
 msgid "Comments"
 msgstr "Comentarios"
 
-#: src/muuli_wdr.cpp:2979
+#: src/muuli_wdr.cpp:2983
 msgid "Filter comments containing (use ',' as separator):"
 msgstr "Fieltrar comentarios que contengan (usar ',' como separtador):"
 
-#: src/muuli_wdr.cpp:3004
+#: src/muuli_wdr.cpp:3008
 msgid "Enable Proxy"
 msgstr "Habilitar Proxy"
 
-#: src/muuli_wdr.cpp:3005
+#: src/muuli_wdr.cpp:3009
 msgid "Enable/disable proxy support"
 msgstr "Habilitar/Deshabilitar soporte Proxy"
 
-#: src/muuli_wdr.cpp:3008
+#: src/muuli_wdr.cpp:3012
 msgid "Proxy type:"
 msgstr "Triba Proxy:"
 
-#: src/muuli_wdr.cpp:3019
+#: src/muuli_wdr.cpp:3023
 msgid "Proxy host:"
 msgstr "Sirvidor Proxy:"
 
-#: src/muuli_wdr.cpp:3022
+#: src/muuli_wdr.cpp:3026
 msgid "The proxy host name"
 msgstr "Nome del host del proxy"
 
-#: src/muuli_wdr.cpp:3024
+#: src/muuli_wdr.cpp:3028
 msgid "Proxy port:"
 msgstr "Puertu Proxy:"
 
-#: src/muuli_wdr.cpp:3027
+#: src/muuli_wdr.cpp:3031
 msgid "The proxy port"
 msgstr "El puertu del proxy"
 
-#: src/muuli_wdr.cpp:3029
+#: src/muuli_wdr.cpp:3033
 msgid "Enable authentication"
 msgstr "Habilitar autentificación"
 
-#: src/muuli_wdr.cpp:3030
+#: src/muuli_wdr.cpp:3034
 msgid "Enable/disable username/password authentication"
 msgstr "Habilita/deshabilita autentificación usuariu/contraseña"
 
-#: src/muuli_wdr.cpp:3033
+#: src/muuli_wdr.cpp:3037
 msgid "Username: "
 msgstr "Nome d'usuariu:"
 
-#: src/muuli_wdr.cpp:3036
+#: src/muuli_wdr.cpp:3040
 msgid "The username to use to connect to the proxy"
 msgstr "El nome d'usuariu a usar pa coneutar al proxy"
 
-#: src/muuli_wdr.cpp:3038
+#: src/muuli_wdr.cpp:3042
 msgid "Password:"
 msgstr "Contraseña:"
 
-#: src/muuli_wdr.cpp:3041
+#: src/muuli_wdr.cpp:3045
 msgid "The password to use to connect to the proxy"
 msgstr "La contraseña a usar pa coneutar al proxy"
 
-#: src/muuli_wdr.cpp:3060
+#: src/muuli_wdr.cpp:3064
 msgid "Connect to:"
 msgstr "Coneutar a:"
 
-#: src/muuli_wdr.cpp:3069
+#: src/muuli_wdr.cpp:3073
 msgid "Login to remote amule"
 msgstr "Conexón a aMule remotu"
 
-#: src/muuli_wdr.cpp:3074
+#: src/muuli_wdr.cpp:3078
 msgid "User name"
 msgstr "Nome usuariu:"
 
-#: src/muuli_wdr.cpp:3085
+#: src/muuli_wdr.cpp:3089
 msgid "Remember those settings"
 msgstr "Remembrar estes opciones"
 
-#: src/muuli_wdr.cpp:3088
+#: src/muuli_wdr.cpp:3092
 #, fuzzy
 msgid "Force ZLIB compression"
 msgstr "Usar compresión gzip"
 
-#: src/muuli_wdr.cpp:3112
+#: src/muuli_wdr.cpp:3116
 msgid "Enable Verbose Debug-Logging."
 msgstr "Habilita mou estendíu de depuración al aniciu"
 
-#: src/muuli_wdr.cpp:3114
+#: src/muuli_wdr.cpp:3118
 #, fuzzy
 msgid "Only to Logfile"
 msgstr "&Abrir el ficheru"
 
-#: src/muuli_wdr.cpp:3116
+#: src/muuli_wdr.cpp:3120
 msgid "Message Categories:"
 msgstr "Mensaxes de categoríes:"
 
-#: src/muuli_wdr.cpp:3140 src/PartFileConvertDlg.cpp:160
+#: src/muuli_wdr.cpp:3144 src/PartFileConvertDlg.cpp:160
 msgid "Waiting..."
 msgstr "Esperando..."
 
-#: src/muuli_wdr.cpp:3160
+#: src/muuli_wdr.cpp:3164
 msgid "Add imports"
 msgstr "Amestar imports"
 
-#: src/muuli_wdr.cpp:3163
+#: src/muuli_wdr.cpp:3167
 msgid "Retry selected"
 msgstr "Reintentar seleicionáu"
 
-#: src/muuli_wdr.cpp:3165
+#: src/muuli_wdr.cpp:3169
 msgid "Remove selected"
 msgstr "Desaniciar seleicionáu"
 
-#: src/muuli_wdr.cpp:3228
+#: src/muuli_wdr.cpp:3232
 msgid "Event Types"
 msgstr "Tipos Eventos"
 
-#: src/muuli_wdr.cpp:3247
+#: src/muuli_wdr.cpp:3251
 msgid "Statistics and queued clients for selected file(s) : Session / All time"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3271
+#: src/muuli_wdr.cpp:3275
 #, fuzzy
 msgid "Active Uploads"
 msgstr "Xubes aceutaes :"
 
-#: src/muuli_wdr.cpp:3285
+#: src/muuli_wdr.cpp:3289
 msgid "Percent of total files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3337
+#: src/muuli_wdr.cpp:3341
 #, fuzzy
 msgid "Show Clients for"
 msgstr "Amosar Veceros"
 
-#: src/muuli_wdr.cpp:3339
+#: src/muuli_wdr.cpp:3343
 #, fuzzy
 msgid "All files"
 msgstr "Anubre los ficheros compartíos"
 
-#: src/muuli_wdr.cpp:3342
+#: src/muuli_wdr.cpp:3346
 #, fuzzy
 msgid "Selected files"
 msgstr "Seleicionar fieltru de vistes"
 
-#: src/muuli_wdr.cpp:3345
+#: src/muuli_wdr.cpp:3349
 #, fuzzy
 msgid "Active uploads only"
 msgstr "Xubes actives"
 
-#: src/muuli_wdr.cpp:3352
+#: src/muuli_wdr.cpp:3356
 #, fuzzy
 msgid "Reload:"
 msgstr "Recargar llista"
 
-#: src/muuli_wdr.cpp:3356
+#: src/muuli_wdr.cpp:3360
 msgid "Reload your shared files"
 msgstr "Recargar los tos ficheros compartíos"
 
-#: src/muuli_wdr.cpp:3419
+#: src/muuli_wdr.cpp:3423
 msgid "Send"
 msgstr "Unviar"
 
-#: src/muuli_wdr.cpp:3420
+#: src/muuli_wdr.cpp:3424
 msgid "Sends the specified message."
 msgstr "Unviar un mensax específicu."
 
-#: src/muuli_wdr.cpp:3424
+#: src/muuli_wdr.cpp:3428
 msgid "Close this chat-session."
 msgstr "Zarrar esta sesión de charra"
 
-#: src/muuli_wdr.cpp:3447
+#: src/muuli_wdr.cpp:3451
 msgid "Connect to any server and/or Kad"
 msgstr "Coneutar a cualesquier sirvidor y/o Kad"
 
-#: src/muuli_wdr.cpp:3453 src/SharedFilesCtrl.cpp:142 src/Statistics.cpp:941
+#: src/muuli_wdr.cpp:3457 src/SharedFilesCtrl.cpp:142 src/Statistics.cpp:941
 msgid "Shared Files"
 msgstr "Fich compartíos"
 
@@ -5772,35 +5772,35 @@ msgstr ""
 "aMule furrulará bien ensin que camudes dengún\n"
 "d'estos parámetros."
 
-#: src/PrefsUnifiedDlg.cpp:647
+#: src/PrefsUnifiedDlg.cpp:656
 #, c-format
 msgid "Failed to connect Cfg to widget with the ID %d and key %s"
 msgstr "Error al coneutar configuración con programa, col ID %d y clave %s"
 
-#: src/PrefsUnifiedDlg.cpp:695
+#: src/PrefsUnifiedDlg.cpp:704
 #, c-format
 msgid "Failed to transfer data from Cfg to Widget with the ID %d and key %s"
 msgstr "Error al tresferir datos dende la configuración al programa, col ID %d y la clave %s"
 
-#: src/PrefsUnifiedDlg.cpp:801
+#: src/PrefsUnifiedDlg.cpp:810
 msgid "The type of proxy you are connecting to"
 msgstr "La triba de proxy a la que tas coneutando"
 
-#: src/PrefsUnifiedDlg.cpp:1020
+#: src/PrefsUnifiedDlg.cpp:1029
 #, c-format
 msgid "Failed to transfer data from Widget to Cfg with the ID %d and key %s"
 msgstr "Error al tresferir datos dende'l programa a la configuración, col ID %d y la clave %s"
 
-#: src/PrefsUnifiedDlg.cpp:1103
+#: src/PrefsUnifiedDlg.cpp:1112
 #, fuzzy
 msgid "No password set."
 msgstr "Comprobando contraseña\n"
 
-#: src/PrefsUnifiedDlg.cpp:1132
+#: src/PrefsUnifiedDlg.cpp:1141
 msgid "Guest access needs a password. Type one in the guest password field, or untick Enable guest access."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1144
+#: src/PrefsUnifiedDlg.cpp:1153
 msgid ""
 "aMule must be restarted to enable these changes:\n"
 "\n"
@@ -5808,45 +5808,45 @@ msgstr ""
 "aMule tien de reaniciase p'aplicar los cambeos:\n"
 "\n"
 
-#: src/PrefsUnifiedDlg.cpp:1151
+#: src/PrefsUnifiedDlg.cpp:1160
 msgid "- TCP port changed.\n"
 msgstr "- Puertu TCP camudáu.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1156
+#: src/PrefsUnifiedDlg.cpp:1165
 msgid "- UDP port changed.\n"
 msgstr "- Puertu UDP camudáu.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1161
+#: src/PrefsUnifiedDlg.cpp:1170
 #, fuzzy
 msgid "- Network interface binding changed.\n"
 msgstr "Conexón esterna zarrada."
 
-#: src/PrefsUnifiedDlg.cpp:1166
+#: src/PrefsUnifiedDlg.cpp:1175
 #, fuzzy
 msgid "- External connect port changed.\n"
 msgstr "Conexón esterna zarrada."
 
-#: src/PrefsUnifiedDlg.cpp:1170
+#: src/PrefsUnifiedDlg.cpp:1179
 #, fuzzy
 msgid "- External connect acceptance changed.\n"
 msgstr "Nueva conexón esterna, aceutada"
 
-#: src/PrefsUnifiedDlg.cpp:1174
+#: src/PrefsUnifiedDlg.cpp:1183
 #, fuzzy
 msgid "- External connect interface changed.\n"
 msgstr "Conexón esterna zarrada."
 
-#: src/PrefsUnifiedDlg.cpp:1178
+#: src/PrefsUnifiedDlg.cpp:1187
 #, fuzzy
 msgid "- Protocol obfuscation support changed.\n"
 msgstr "Ofuscación de protocolu"
 
-#: src/PrefsUnifiedDlg.cpp:1193
+#: src/PrefsUnifiedDlg.cpp:1202
 #, fuzzy
 msgid "- amuleapi settings changed.\n"
 msgstr "- Llingua camudada.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1202
+#: src/PrefsUnifiedDlg.cpp:1211
 msgid ""
 "Your Auto-update server list is empty.\n"
 "'Auto-update server list at startup' will be disabled."
@@ -5854,7 +5854,7 @@ msgstr ""
 "La to llista Auto-actualizable de sirvidores ta erma.\n"
 "La llista de sirvidores auto-actualizable al entamu desactivaráse."
 
-#: src/PrefsUnifiedDlg.cpp:1213
+#: src/PrefsUnifiedDlg.cpp:1222
 msgid ""
 "You have enabled external connections but have not specified a password.\n"
 "External connections cannot be enabled unless a valid password is specified."
@@ -5862,33 +5862,33 @@ msgstr ""
 "Tienes habilitao les conexones externes, pero nun tienes especificada una contraseña.\n"
 "Les conexones externes nun puen ser habilitaes sacante qu'especifiques una contraseña válida."
 
-#: src/PrefsUnifiedDlg.cpp:1246
+#: src/PrefsUnifiedDlg.cpp:1255
 #, c-format
 msgid "The amuleapi password could not be saved: %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1276
+#: src/PrefsUnifiedDlg.cpp:1285
 msgid "- Language changed.\n"
 msgstr "- Llingua camudada.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1281
+#: src/PrefsUnifiedDlg.cpp:1290
 msgid "- Temp folder changed.\n"
 msgstr "- Direutoriu TEMP camudáu.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1286
+#: src/PrefsUnifiedDlg.cpp:1295
 msgid "- ED2K network enabled.\n"
 msgstr "- Rede ED2K activada.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1319
+#: src/PrefsUnifiedDlg.cpp:1328
 msgid "The shared-file exclusion pattern is not a valid regular expression. The filter has been left disabled."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1321 src/PrefsUnifiedDlg.cpp:1921
+#: src/PrefsUnifiedDlg.cpp:1330 src/PrefsUnifiedDlg.cpp:1930
 #, fuzzy
 msgid "Invalid regular expression"
 msgstr "Versión de protocolu non válida"
 
-#: src/PrefsUnifiedDlg.cpp:1398
+#: src/PrefsUnifiedDlg.cpp:1407
 msgid ""
 "Both eD2k and Kad network are disabled.\n"
 "You won't be able to connect until you enable at least one of them."
@@ -5896,7 +5896,7 @@ msgstr ""
 "eD2k y Kad tán desactivaos.\n"
 "Nun podrás coneutate hasta qu'actives a lo menos ún d'ellos."
 
-#: src/PrefsUnifiedDlg.cpp:1403
+#: src/PrefsUnifiedDlg.cpp:1412
 msgid ""
 "Kad will not start if your UDP port is disabled.\n"
 "Enable UDP port or disable Kad."
@@ -5904,7 +5904,7 @@ msgstr ""
 "Kad nun s'aniciará si'l to puertu UDP ta deshabilitáu.\n"
 "Habilita un puertu UDP o deshabilita Kad."
 
-#: src/PrefsUnifiedDlg.cpp:1459
+#: src/PrefsUnifiedDlg.cpp:1468
 msgid ""
 "\n"
 "You MUST restart aMule now.\n"
@@ -5914,69 +5914,69 @@ msgstr ""
 "Hai de reaniciar aMule agora.\n"
 "Si nun reanicies agora, nun sabemos si pasará daqué malo.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1524
+#: src/PrefsUnifiedDlg.cpp:1533
 msgid "Could not register aMule for autostart at login. The autostart store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1526
+#: src/PrefsUnifiedDlg.cpp:1535
 msgid "Could not remove the autostart-at-login entry."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1527
+#: src/PrefsUnifiedDlg.cpp:1536
 #, fuzzy
 msgid "Autostart"
 msgstr "Auto recargar, aniciáu"
 
-#: src/PrefsUnifiedDlg.cpp:1542
+#: src/PrefsUnifiedDlg.cpp:1551
 msgid "Register file type"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1542
+#: src/PrefsUnifiedDlg.cpp:1551
 msgid "Register URL handler"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1550
+#: src/PrefsUnifiedDlg.cpp:1559
 #, c-format
 msgid "aMule only handles eD2k-compatible magnets. If you replace the current magnet handler (%s), BitTorrent magnet links will stop working - aMule cannot download BitTorrent content. Continue?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1555
+#: src/PrefsUnifiedDlg.cpp:1564
 #, c-format
 msgid "Another application currently opens .emulecollection files (%s). Replace it with aMule?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1560
+#: src/PrefsUnifiedDlg.cpp:1569
 #, c-format
 msgid "Another application is currently the default handler for these links (%s). Replace it with aMule?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1585
+#: src/PrefsUnifiedDlg.cpp:1594
 msgid "Could not register aMule for .emulecollection files. The registration store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1587
+#: src/PrefsUnifiedDlg.cpp:1596
 #, fuzzy
 msgid "Could not remove the file type registration."
 msgstr "Carpeta pa los ficheros temporales de descargues"
 
-#: src/PrefsUnifiedDlg.cpp:1589
+#: src/PrefsUnifiedDlg.cpp:1598
 msgid "Could not register aMule as the URL handler. The registration store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1591
+#: src/PrefsUnifiedDlg.cpp:1600
 msgid "Could not remove the URL handler registration."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1661 src/PrefsUnifiedDlg.cpp:1688
+#: src/PrefsUnifiedDlg.cpp:1670 src/PrefsUnifiedDlg.cpp:1697
 #, fuzzy
 msgid "The web server and aMule API require external connections to be enabled."
 msgstr "Contraseña fixada y conexones esternes habilitaes."
 
-#: src/PrefsUnifiedDlg.cpp:1671
+#: src/PrefsUnifiedDlg.cpp:1680
 msgid "The aMule web server is deprecated. Consider running the aMule API instead."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1735
+#: src/PrefsUnifiedDlg.cpp:1744
 msgid ""
 "Your Auto-update servers list is in blank.\n"
 "Please fill in at least one URL to point to a valid server.met file.\n"
@@ -5986,66 +5986,66 @@ msgstr ""
 "Por favor introduz a lo menos una URL con un ficheru server.met válidu.\n"
 "Click nel botón \"Llista\" d'esta caxella  pa introducir una URL."
 
-#: src/PrefsUnifiedDlg.cpp:1876
+#: src/PrefsUnifiedDlg.cpp:1885
 msgid "Temporary files"
 msgstr "Ficheros temporales"
 
-#: src/PrefsUnifiedDlg.cpp:1881
+#: src/PrefsUnifiedDlg.cpp:1890
 msgid "Incoming files"
 msgstr "Ficheros entrantes"
 
-#: src/PrefsUnifiedDlg.cpp:1886
+#: src/PrefsUnifiedDlg.cpp:1895
 msgid "Online Signatures"
 msgstr "Robles online"
 
-#: src/PrefsUnifiedDlg.cpp:1899
+#: src/PrefsUnifiedDlg.cpp:1908
 #, c-format
 msgid "Choose a folder for %s"
 msgstr "Escueye una carpeta pa %s"
 
-#: src/PrefsUnifiedDlg.cpp:1923
+#: src/PrefsUnifiedDlg.cpp:1932
 #, fuzzy, c-format
 msgid "Would exclude %u of %u shared file"
 msgid_plural "Would exclude %u of %u shared files"
 msgstr[0] "Alcontróse %i ficheru compartíu"
 msgstr[1] "Alcontráronse %i ficheros compartíos"
 
-#: src/PrefsUnifiedDlg.cpp:1940
+#: src/PrefsUnifiedDlg.cpp:1949
 msgid "Browse for videoplayer"
 msgstr "Esplorar"
 
-#: src/PrefsUnifiedDlg.cpp:1944
+#: src/PrefsUnifiedDlg.cpp:1953
 msgid "Select browser"
 msgstr "Seleiciona restolador"
 
-#: src/PrefsUnifiedDlg.cpp:1948
+#: src/PrefsUnifiedDlg.cpp:1957
 #, fuzzy
 msgid "Select ffprobe binary"
 msgstr "Seleiciona restolador"
 
-#: src/PrefsUnifiedDlg.cpp:1954
+#: src/PrefsUnifiedDlg.cpp:1963
 #, c-format
 msgid "Executable%s"
 msgstr "Executable%s"
 
-#: src/PrefsUnifiedDlg.cpp:1988
+#: src/PrefsUnifiedDlg.cpp:1997
 msgid "ffprobe not found on PATH or in the standard install locations. Install ffmpeg (which ships ffprobe) or use Browse to pick a binary manually."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2000
+#: src/PrefsUnifiedDlg.cpp:2009
 msgid "Reset the settings on this page to their default values?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2001
+#: src/PrefsUnifiedDlg.cpp:2010
 #, fuzzy
 msgid "Reset to defaults"
 msgstr "Por defeutu"
 
-#: src/PrefsUnifiedDlg.cpp:2028
+#: src/PrefsUnifiedDlg.cpp:2037
 msgid "Edit server list"
 msgstr "Editar llista de sirvidores"
 
-#: src/PrefsUnifiedDlg.cpp:2029
+#: src/PrefsUnifiedDlg.cpp:2038
 msgid ""
 "Add here URL's to download server.met files.\n"
 "Only one url on each line."
@@ -6053,154 +6053,154 @@ msgstr ""
 "Amesta equí les URL's pa descargar los ficheros server.met.\n"
 "Namái una url per llinia."
 
-#: src/PrefsUnifiedDlg.cpp:2084
+#: src/PrefsUnifiedDlg.cpp:2093
 msgid "IP2Country update failed"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2229 src/PrefsUnifiedDlg.cpp:2260
+#: src/PrefsUnifiedDlg.cpp:2238 src/PrefsUnifiedDlg.cpp:2269
 msgid "Data by MaxMind GeoLite2"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2231 src/PrefsUnifiedDlg.cpp:2262
+#: src/PrefsUnifiedDlg.cpp:2240 src/PrefsUnifiedDlg.cpp:2271
 #, fuzzy
 msgid "Custom source"
 msgstr "Fontes completes"
 
-#: src/PrefsUnifiedDlg.cpp:2233 src/PrefsUnifiedDlg.cpp:2264
+#: src/PrefsUnifiedDlg.cpp:2242 src/PrefsUnifiedDlg.cpp:2273
 msgid "Data by DB-IP.com"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2284
+#: src/PrefsUnifiedDlg.cpp:2293
 #, fuzzy, c-format
 msgid "Status: Loaded%s"
 msgstr "Estáu:"
 
-#: src/PrefsUnifiedDlg.cpp:2286
+#: src/PrefsUnifiedDlg.cpp:2295
 #, fuzzy, c-format
 msgid "Status: Loaded%s - %s"
 msgstr "Estáu:"
 
-#: src/PrefsUnifiedDlg.cpp:2290
+#: src/PrefsUnifiedDlg.cpp:2299
 msgid "Status: Failed to load - click 'Update now' to refresh."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2292
+#: src/PrefsUnifiedDlg.cpp:2301
 msgid "Status: Not found - click 'Update now' to download."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2350 src/PrefsUnifiedDlg.cpp:2374
+#: src/PrefsUnifiedDlg.cpp:2359 src/PrefsUnifiedDlg.cpp:2383
 #, c-format
 msgid "Update delay: %d second"
 msgid_plural "Update delay: %d seconds"
 msgstr[0] "Intervalu d'actualización: %d seg"
 msgstr[1] "Intervalu d'actualización: %d segs"
 
-#: src/PrefsUnifiedDlg.cpp:2358
+#: src/PrefsUnifiedDlg.cpp:2367
 #, c-format
 msgid "Time for average graph: %d minute"
 msgid_plural "Time for average graph: %d minutes"
 msgstr[0] "Tiempu mediu del gráficu: %d min"
 msgstr[1] "Tiempu mediu del gráficu: %d mins"
 
-#: src/PrefsUnifiedDlg.cpp:2367
+#: src/PrefsUnifiedDlg.cpp:2376
 #, c-format
 msgid "Connections Graph Scale: %d"
 msgstr "Escala gráfica de conexones: %d"
 
-#: src/PrefsUnifiedDlg.cpp:2382
+#: src/PrefsUnifiedDlg.cpp:2391
 #, c-format
 msgid "File Buffer Size: %d byte"
 msgid_plural "File Buffer Size: %d bytes"
 msgstr[0] "Tamañu del buffer de ficheru: %d byte"
 msgstr[1] "Tamañu del buffer de ficheru: %d bytes"
 
-#: src/PrefsUnifiedDlg.cpp:2392
+#: src/PrefsUnifiedDlg.cpp:2401
 #, c-format
 msgid "Upload Queue Size: %d client"
 msgid_plural "Upload Queue Size: %d clients"
 msgstr[0] "Tamañu de la cola de xuba: %d veceru"
 msgstr[1] "Tamañu de la cola de xuba: %d veceros"
 
-#: src/PrefsUnifiedDlg.cpp:2402
+#: src/PrefsUnifiedDlg.cpp:2411
 #, c-format
 msgid "Server connection refresh interval: %d minute"
 msgid_plural "Server connection refresh interval: %d minutes"
 msgstr[0] "Intervalu de refrescu de la conexón al sirvidor: %d minutu"
 msgstr[1] "Intervalu de refrescu de la conexón al sirvidor: %d minutos"
 
-#: src/PrefsUnifiedDlg.cpp:2407
+#: src/PrefsUnifiedDlg.cpp:2416
 msgid "Server connection refresh interval: Disabled"
 msgstr "Intervalu de refrescu de la conexón al sirvidor: Deshabilitáu"
 
-#: src/PrefsUnifiedDlg.cpp:2451
+#: src/PrefsUnifiedDlg.cpp:2460
 msgid "disabled"
 msgstr "deshabilitáu"
 
-#: src/PrefsUnifiedDlg.cpp:2477
+#: src/PrefsUnifiedDlg.cpp:2486
 #, fuzzy, c-format
 msgid "Execute command on '%s' event"
 msgstr "Executar comandu nel eventu `%s'"
 
-#: src/PrefsUnifiedDlg.cpp:2484
+#: src/PrefsUnifiedDlg.cpp:2493
 msgid "Enable command execution on core"
 msgstr "Habilitar execución de comandu nel núcleu"
 
-#: src/PrefsUnifiedDlg.cpp:2496
+#: src/PrefsUnifiedDlg.cpp:2505
 msgid "Core command:"
 msgstr "Comandu del núcleu:"
 
-#: src/PrefsUnifiedDlg.cpp:2512
+#: src/PrefsUnifiedDlg.cpp:2521
 msgid "Enable command execution on GUI"
 msgstr "Habilitar execución de comandu na Interface"
 
-#: src/PrefsUnifiedDlg.cpp:2524
+#: src/PrefsUnifiedDlg.cpp:2533
 msgid "GUI command:"
 msgstr "Comandu de la Interface: "
 
-#: src/PrefsUnifiedDlg.cpp:2540
+#: src/PrefsUnifiedDlg.cpp:2549
 msgid "The following variables will be replaced:"
 msgstr "Les siguientes variables trocaránse:"
 
-#: src/PrefsUnifiedDlg.cpp:2708
+#: src/PrefsUnifiedDlg.cpp:2717
 msgid ""
 "The following folders look like system or sensitive locations:\n"
 "\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2713
+#: src/PrefsUnifiedDlg.cpp:2722
 msgid "Sharing them recursively will publish every file underneath on the eD2k/Kad networks. Do you really want to do this?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2716
+#: src/PrefsUnifiedDlg.cpp:2725
 #, fuzzy
 msgid "Confirm shared folders"
 msgstr "Carpetes compartíes"
 
-#: src/PrefsUnifiedDlg.cpp:2744
+#: src/PrefsUnifiedDlg.cpp:2753
 #, fuzzy
 msgid "Reloading shared files..."
 msgstr "Recargar los tos ficheros compartíos"
 
-#: src/PrefsUnifiedDlg.cpp:2745
+#: src/PrefsUnifiedDlg.cpp:2754
 msgid "Scanning for subdirectories..."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2746
+#: src/PrefsUnifiedDlg.cpp:2755
 #, fuzzy
 msgid "Updating shared folders"
 msgstr "Carpetes compartíes"
 
-#: src/PrefsUnifiedDlg.cpp:2773
+#: src/PrefsUnifiedDlg.cpp:2782
 #, c-format
 msgid "Scanned %u directories..."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2823
+#: src/PrefsUnifiedDlg.cpp:2832
 #, fuzzy, c-format
 msgid "Reloading shared files: %u files scanned"
 msgstr "Recargar llista de ficheros compartíos."
 
-#: src/PrefsUnifiedDlg.cpp:2873
+#: src/PrefsUnifiedDlg.cpp:2882
 #, fuzzy
 msgid "Shared folder"
 msgstr "Carpetes compartíes"
@@ -7911,12 +7911,12 @@ msgstr "Desaniciar categoría"
 msgid "Hashset requested for unknown file: %s"
 msgstr "Hashset solicitáu de ficheru desconocíu: %s"
 
-#: src/UploadQueue.cpp:618
+#: src/UploadQueue.cpp:627
 #, c-format
 msgid "Resuming uploads of file: %s"
 msgstr "Resumiendo xubíes del ficheru: %s"
 
-#: src/UploadQueue.cpp:634
+#: src/UploadQueue.cpp:643
 #, c-format
 msgid "Suspending upload of file: %s"
 msgstr "Suspendiendo xuba del ficheru: %s"

--- a/po/ast.po
+++ b/po/ast.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-28 08:06+0200\n"
+"POT-Creation-Date: 2026-07-28 10:19+0200\n"
 "PO-Revision-Date: 2026-07-27 11:32+0000\n"
 "Last-Translator: astur <malditoastur@gmail.com>\n"
 "Language-Team: Language ast <malditoastur@gmail.com>\n"
@@ -145,7 +145,7 @@ msgstr ""
 msgid "Not now"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:422 src/amuleDlg.cpp:600
+#: src/AppImageIntegration.cpp:422 src/amuleDlg.cpp:665
 msgid "Don't ask again"
 msgstr ""
 
@@ -218,7 +218,7 @@ msgid "Killing amuleweb instance with pid '%d' ... "
 msgstr "Matando instancia amuleweb con pid `%d' ... "
 
 #: src/amule.cpp:336 src/amule.cpp:349 src/ClientRef.cpp:180
-#: src/SearchDlg.cpp:880 src/ServerListCtrl.cpp:98
+#: src/SearchDlg.cpp:1041 src/ServerListCtrl.cpp:98
 msgid "Failed"
 msgstr "Falló"
 
@@ -574,30 +574,68 @@ msgstr "Nun puede Crease un Ficheru Pid"
 msgid "ERROR: %s"
 msgstr "ERROR: %s"
 
-#: src/amuleDlg.cpp:236
+#: src/amuleDlg.cpp:250
 #, c-format
 msgid "This is aMule %s based on eMule."
 msgstr "Esto ye aMule %s basáu en eMule."
 
-#: src/amuleDlg.cpp:237
+#: src/amuleDlg.cpp:251
 #, c-format
 msgid "Running on %s"
 msgstr "Executándose en %s"
 
-#: src/amuleDlg.cpp:239
+#: src/amuleDlg.cpp:253
 msgid "Visit https://github.com/amule-org/amule/releases/latest to check if a new version is available."
 msgstr "Visita https://github.com/amule-org/amule/releases/latest pa comprobar si hai una nueva versión disponible"
 
-#: src/amuleDlg.cpp:268
+#: src/amuleDlg.cpp:282
 msgid "FATAL ERROR: Failed to create Timer"
 msgstr "FALLU GRAVE: Nun pudo criase'l temporizador"
 
-#: src/amuleDlg.cpp:592
+#: src/amuleDlg.cpp:361 src/amuleDlg.cpp:1787 src/amuleDlg.cpp:2033
+#: src/muuli_wdr.cpp:1492 src/muuli_wdr.cpp:3418
+msgid "Networks"
+msgstr "Redes"
+
+#: src/amuleDlg.cpp:362 src/amuleDlg.cpp:1793 src/muuli_wdr.cpp:3419
+msgid "Searches"
+msgstr "Guetar"
+
+#: src/amuleDlg.cpp:363 src/amuleDlg.cpp:1799 src/DownloadListCtrl.cpp:740
+#: src/muuli_wdr.cpp:392 src/muuli_wdr.cpp:1585 src/muuli_wdr.cpp:3420
+#: src/Statistics.cpp:829
+msgid "Downloads"
+msgstr "Descargues"
+
+#: src/amuleDlg.cpp:364 src/amuleDlg.cpp:1805 src/muuli_wdr.cpp:3294
+msgid "Shared files"
+msgstr "Ficheros compartíos"
+
+#: src/amuleDlg.cpp:365 src/amuleDlg.cpp:1811 src/muuli_wdr.cpp:2926
+#: src/muuli_wdr.cpp:3376 src/muuli_wdr.cpp:3423
+msgid "Messages"
+msgstr "Mensaxes"
+
+#: src/amuleDlg.cpp:366 src/amuleDlg.cpp:1817 src/muuli_wdr.cpp:3424
+#: src/PrefsUnifiedDlg.cpp:312 src/Statistics.cpp:779 src/Statistics.cpp:1235
+msgid "Statistics"
+msgstr "Estadístiques"
+
+#: src/amuleDlg.cpp:368 src/amuleDlg.cpp:1824 src/muuli_wdr.cpp:3426
+#: src/PrefsUnifiedDlg.cpp:328 src/utils/wxCas/src/wxcasprefs.cpp:39
+msgid "Preferences"
+msgstr "Preferencies"
+
+#: src/amuleDlg.cpp:371
+msgid "Navigate"
+msgstr ""
+
+#: src/amuleDlg.cpp:657
 #, fuzzy
 msgid "New version available"
 msgstr "Non disponible"
 
-#: src/amuleDlg.cpp:596
+#: src/amuleDlg.cpp:661
 #, fuzzy, c-format
 msgid ""
 "A new version of aMule (%s) is available.\n"
@@ -607,219 +645,186 @@ msgid ""
 "Would you like to open the download page?"
 msgstr "La cabera versión pues alcontrala siempres en https://github.com/amule-org/amule/releases/latest"
 
-#: src/amuleDlg.cpp:678
+#: src/amuleDlg.cpp:743
 msgid "aMule dialog destroyed"
 msgstr "Diálogu aMule afaráu"
 
-#: src/amuleDlg.cpp:701 src/DataToText.cpp:68 src/IPFilter.cpp:547
+#: src/amuleDlg.cpp:766 src/DataToText.cpp:68 src/IPFilter.cpp:547
 msgid "Connecting"
 msgstr "Coneutando"
 
-#: src/amuleDlg.cpp:893
+#: src/amuleDlg.cpp:958
 msgid "eD2k: Connecting"
 msgstr "eD2k: Coneutando"
 
-#: src/amuleDlg.cpp:897
+#: src/amuleDlg.cpp:962
 msgid "eD2k: Disconnected"
 msgstr "eD2k: Desconeutáu"
 
-#: src/amuleDlg.cpp:903
+#: src/amuleDlg.cpp:968
 msgid "Kad: Firewalled"
 msgstr "Kad: Tres Tornafueos"
 
-#: src/amuleDlg.cpp:907
+#: src/amuleDlg.cpp:972
 msgid "Kad: Connected"
 msgstr "Kad: Coneutáu"
 
-#: src/amuleDlg.cpp:912
+#: src/amuleDlg.cpp:977
 msgid "Kad: Connecting"
 msgstr "Kad: Coneutando"
 
-#: src/amuleDlg.cpp:916
+#: src/amuleDlg.cpp:981
 msgid "Kad: Off"
 msgstr "Kad: Apagada"
 
-#: src/amuleDlg.cpp:964 src/DownloadListCtrl.cpp:505
+#: src/amuleDlg.cpp:1029 src/DownloadListCtrl.cpp:505
 #: src/DownloadListCtrl.cpp:749 src/FriendListCtrl.cpp:180
 #: src/muuli_wdr.cpp:731 src/muuli_wdr.cpp:782 src/muuli_wdr.cpp:846
-#: src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2224 src/muuli_wdr.cpp:2309
-#: src/muuli_wdr.cpp:3057 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
+#: src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2231 src/muuli_wdr.cpp:2316
+#: src/muuli_wdr.cpp:3064 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
 #: src/ServerListCtrl.cpp:606 src/TransferWnd.cpp:378
 #: src/utils/wxCas/src/wxcasprefs.cpp:235
 msgid "Cancel"
 msgstr "Encaboxar"
 
-#: src/amuleDlg.cpp:965
+#: src/amuleDlg.cpp:1030
 msgid "Stop the current connection attempts"
 msgstr "Detener los intentos de conexón actuales"
 
-#: src/amuleDlg.cpp:970 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976
-#: src/muuli_wdr.cpp:2447
+#: src/amuleDlg.cpp:1035 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976
+#: src/muuli_wdr.cpp:2454
 msgid "Disconnect"
 msgstr "Desconeutar"
 
-#: src/amuleDlg.cpp:971
+#: src/amuleDlg.cpp:1036
 msgid "Disconnect from the currently connected networks"
 msgstr "Desconeutase de les redes coneutaes"
 
-#: src/amuleDlg.cpp:976 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979
-#: src/muuli_wdr.cpp:2602 src/muuli_wdr.cpp:3054 src/muuli_wdr.cpp:3409
+#: src/amuleDlg.cpp:1041 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979
+#: src/muuli_wdr.cpp:2609 src/muuli_wdr.cpp:3061 src/muuli_wdr.cpp:3416
 msgid "Connect"
 msgstr "Coneutar"
 
-#: src/amuleDlg.cpp:977
+#: src/amuleDlg.cpp:1042
 msgid "Connect to the currently enabled networks"
 msgstr "Coneutase a les redes disponibles"
 
-#: src/amuleDlg.cpp:1089
+#: src/amuleDlg.cpp:1154
 #, fuzzy, c-format
 msgid "Up: %.1f%s (%.1f) | Down: %.1f%s (%.1f)"
 msgstr "Xu: %.1f(%.1f) | Desc: %.1f(%.1f)"
 
-#: src/amuleDlg.cpp:1091 src/amuleDlg.cpp:1093 src/amuleDlg.cpp:1097
-#: src/amuleDlg.cpp:1099 src/amuleDlg.cpp:1110 src/amuleDlg.cpp:1112
+#: src/amuleDlg.cpp:1156 src/amuleDlg.cpp:1158 src/amuleDlg.cpp:1162
+#: src/amuleDlg.cpp:1164 src/amuleDlg.cpp:1175 src/amuleDlg.cpp:1177
 #: src/MuleTrayIcon.cpp:796 src/MuleTrayIcon.cpp:799
 #, fuzzy
 msgid " MB/s"
 msgstr "MB/s"
 
-#: src/amuleDlg.cpp:1091 src/amuleDlg.cpp:1093 src/amuleDlg.cpp:1097
-#: src/amuleDlg.cpp:1099 src/amuleDlg.cpp:1110 src/amuleDlg.cpp:1112
+#: src/amuleDlg.cpp:1156 src/amuleDlg.cpp:1158 src/amuleDlg.cpp:1162
+#: src/amuleDlg.cpp:1164 src/amuleDlg.cpp:1175 src/amuleDlg.cpp:1177
 #: src/MuleTrayIcon.cpp:796 src/MuleTrayIcon.cpp:799
 #: src/utils/wxCas/src/wxcasframe.cpp:1041
 msgid " kB/s"
 msgstr " kB/s"
 
-#: src/amuleDlg.cpp:1096
+#: src/amuleDlg.cpp:1161
 #, fuzzy, c-format
 msgid "Up: %.1f%s | Down: %.1f%s"
 msgstr "Xu: %.1f | Desc: %.1f"
 
-#: src/amuleDlg.cpp:1128
+#: src/amuleDlg.cpp:1193
 #, c-format
 msgid "aMule (%s | Connected)"
 msgstr "aMule (%s | Coneutáu)"
 
-#: src/amuleDlg.cpp:1130
+#: src/amuleDlg.cpp:1195
 #, c-format
 msgid "aMule (%s | Disconnected)"
 msgstr "aMule (%s | Desconeutáu)"
 
-#: src/amuleDlg.cpp:1183
+#: src/amuleDlg.cpp:1248
 #, fuzzy, c-format
 msgid "Do you really want to exit %s?"
 msgstr "Daveres quies colar de aMule?"
 
-#: src/amuleDlg.cpp:1185
+#: src/amuleDlg.cpp:1250
 msgid "Exit confirmation"
 msgstr "Confirmar colar."
 
-#: src/amuleDlg.cpp:1548
+#: src/amuleDlg.cpp:1613
 msgid "Launch Command: "
 msgstr "Llanzar comandu:"
 
-#: src/amuleDlg.cpp:1567 src/muuli_wdr.cpp:1971 src/Preferences.cpp:951
+#: src/amuleDlg.cpp:1632 src/muuli_wdr.cpp:1978 src/Preferences.cpp:952
 msgid "- default -"
 msgstr "- Por defeutu -"
 
-#: src/amuleDlg.cpp:1595
+#: src/amuleDlg.cpp:1660
 #, c-format
 msgid "Skin directory '%s' does not exist"
 msgstr "El direutorio de tema '%s' nun esiste"
 
-#: src/amuleDlg.cpp:1598
+#: src/amuleDlg.cpp:1663
 #, c-format
 msgid "WARNING: Unable to open skin file '%s' for read"
 msgstr "ATENCIÓN: Nun pue abrise'l ficheru de temes '%s' pa llectura"
 
-#: src/amuleDlg.cpp:1722 src/amuleDlg.cpp:1968 src/muuli_wdr.cpp:1485
-#: src/muuli_wdr.cpp:3411
-msgid "Networks"
-msgstr "Redes"
-
-#: src/amuleDlg.cpp:1726 src/muuli_wdr.cpp:3411
+#: src/amuleDlg.cpp:1791 src/muuli_wdr.cpp:3418
 msgid "Networks Window"
 msgstr "Ventana de redes"
 
-#: src/amuleDlg.cpp:1728 src/muuli_wdr.cpp:3412
-msgid "Searches"
-msgstr "Guetar"
-
-#: src/amuleDlg.cpp:1732 src/muuli_wdr.cpp:3412
+#: src/amuleDlg.cpp:1797 src/muuli_wdr.cpp:3419
 msgid "Searches Window"
 msgstr "Ventana de gueta"
 
-#: src/amuleDlg.cpp:1734 src/DownloadListCtrl.cpp:740 src/muuli_wdr.cpp:392
-#: src/muuli_wdr.cpp:1578 src/muuli_wdr.cpp:3413 src/Statistics.cpp:829
-msgid "Downloads"
-msgstr "Descargues"
-
-#: src/amuleDlg.cpp:1738 src/muuli_wdr.cpp:3413
+#: src/amuleDlg.cpp:1803 src/muuli_wdr.cpp:3420
 #, fuzzy
 msgid "Downloads Window"
 msgstr "Descargando"
 
-#: src/amuleDlg.cpp:1740 src/muuli_wdr.cpp:3287
-msgid "Shared files"
-msgstr "Ficheros compartíos"
-
-#: src/amuleDlg.cpp:1744 src/muuli_wdr.cpp:3415
+#: src/amuleDlg.cpp:1809 src/muuli_wdr.cpp:3422
 msgid "Shared Files Window"
 msgstr "Ventana de ficheros compartíos"
 
-#: src/amuleDlg.cpp:1746 src/muuli_wdr.cpp:2919 src/muuli_wdr.cpp:3369
-#: src/muuli_wdr.cpp:3416
-msgid "Messages"
-msgstr "Mensaxes"
-
-#: src/amuleDlg.cpp:1750 src/muuli_wdr.cpp:3416
+#: src/amuleDlg.cpp:1815 src/muuli_wdr.cpp:3423
 msgid "Messages Window"
 msgstr "Ventana de mensaxes"
 
-#: src/amuleDlg.cpp:1752 src/muuli_wdr.cpp:3417 src/PrefsUnifiedDlg.cpp:312
-#: src/Statistics.cpp:779 src/Statistics.cpp:1235
-msgid "Statistics"
-msgstr "Estadístiques"
-
-#: src/amuleDlg.cpp:1756 src/muuli_wdr.cpp:3417
+#: src/amuleDlg.cpp:1821 src/muuli_wdr.cpp:3424
 msgid "Statistics Graph Window"
 msgstr "Ventana de gráficos d'estadístiques"
 
-#: src/amuleDlg.cpp:1759 src/muuli_wdr.cpp:3419 src/PrefsUnifiedDlg.cpp:328
-#: src/utils/wxCas/src/wxcasprefs.cpp:39
-msgid "Preferences"
-msgstr "Preferencies"
-
-#: src/amuleDlg.cpp:1763 src/muuli_wdr.cpp:3419
+#: src/amuleDlg.cpp:1828 src/muuli_wdr.cpp:3426
 msgid "Preferences Settings Window"
 msgstr "Ventana d'opciones"
 
-#: src/amuleDlg.cpp:1766 src/muuli_wdr.cpp:3420
+#: src/amuleDlg.cpp:1831 src/muuli_wdr.cpp:3427
 msgid "Import"
 msgstr "Importar"
 
-#: src/amuleDlg.cpp:1770 src/muuli_wdr.cpp:3420
+#: src/amuleDlg.cpp:1835 src/muuli_wdr.cpp:3427
 msgid "The partfile importer tool"
 msgstr "La ferramienta pa importar ficheros part"
 
-#: src/amuleDlg.cpp:1773 src/muuli_wdr.cpp:3421
+#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3428
 #: src/utils/aLinkCreator/src/alcframe.cpp:262
 msgid "About"
 msgstr "Tocante a"
 
-#: src/amuleDlg.cpp:1773 src/muuli_wdr.cpp:3421
+#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3428
 msgid "About/Help"
 msgstr "Tocante a/Aida"
 
-#: src/amuleDlg.cpp:1971
+#: src/amuleDlg.cpp:2036
 msgid "eD2k network"
 msgstr "Rede eD2k"
 
-#: src/amuleDlg.cpp:1974
+#: src/amuleDlg.cpp:2039
 msgid "Kad network"
 msgstr "Rede Kad"
 
-#: src/amuleDlg.cpp:1974
+#: src/amuleDlg.cpp:2039
 msgid "No network"
 msgstr "Ensin rede"
 
@@ -1353,19 +1358,19 @@ msgstr "Auto [Al]"
 msgid "Very low"
 msgstr "Mui baxa"
 
-#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:743 src/muuli_wdr.cpp:2275
+#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:743 src/muuli_wdr.cpp:2282
 #: src/ServerListCtrl.cpp:263 src/ServerListCtrl.cpp:456
 #: src/SharedFilesCtrl.cpp:145
 msgid "Low"
 msgstr "Baxa"
 
-#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:744 src/muuli_wdr.cpp:2276
+#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:744 src/muuli_wdr.cpp:2283
 #: src/ServerListCtrl.cpp:266 src/ServerListCtrl.cpp:457
 #: src/SharedFilesCtrl.cpp:146
 msgid "Normal"
 msgstr "Normal"
 
-#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:745 src/muuli_wdr.cpp:2277
+#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:745 src/muuli_wdr.cpp:2284
 #: src/ServerListCtrl.cpp:269 src/ServerListCtrl.cpp:458
 #: src/SharedFilesCtrl.cpp:147
 msgid "High"
@@ -1457,8 +1462,8 @@ msgstr "Sirvidor llocal"
 msgid "Remote Server"
 msgstr "Sirvidor remotu"
 
-#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3174
-#: src/SearchDlg.cpp:111 src/TextClient.cpp:911
+#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3181
+#: src/SearchDlg.cpp:119 src/TextClient.cpp:911
 msgid "Kad"
 msgstr "Kad"
 
@@ -1529,7 +1534,7 @@ msgstr "Parte"
 msgid "Size"
 msgstr "Tamañu"
 
-#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3241
+#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3248
 msgid "Transferred"
 msgstr "Tresferío"
 
@@ -1587,7 +1592,7 @@ msgstr ""
 "Reaición dende: %s (%s)\n"
 "\n"
 
-#: src/DownloadListCtrl.cpp:746 src/muuli_wdr.cpp:2278
+#: src/DownloadListCtrl.cpp:746 src/muuli_wdr.cpp:2285
 #: src/SharedFilesCtrl.cpp:150
 msgid "Auto"
 msgstr "Auto"
@@ -1625,7 +1630,7 @@ msgid "Extended Options"
 msgstr "Opciones estendíes"
 
 #: src/DownloadListCtrl.cpp:770 src/DownloadListCtrl.cpp:822
-#: src/muuli_wdr.cpp:1789
+#: src/muuli_wdr.cpp:1796
 msgid "Preview"
 msgstr "Previsualizar"
 
@@ -2339,19 +2344,19 @@ msgstr ""
 msgid "eD2k"
 msgstr "eD2k"
 
-#: src/FirstRunWizard.cpp:349 src/muuli_wdr.cpp:1488
+#: src/FirstRunWizard.cpp:349 src/muuli_wdr.cpp:1495
 msgid "Kademlia"
 msgstr "Kademlia"
 
-#: src/FirstRunWizard.cpp:359 src/muuli_wdr.cpp:1416
+#: src/FirstRunWizard.cpp:359 src/muuli_wdr.cpp:1423
 msgid "Standard TCP Port "
 msgstr "Puertu TCP estándar "
 
-#: src/FirstRunWizard.cpp:365 src/muuli_wdr.cpp:1428
+#: src/FirstRunWizard.cpp:365 src/muuli_wdr.cpp:1435
 msgid "Extended UDP port (Kad / global search) "
 msgstr "Puertu UDP estándar (Kad / gueta global) "
 
-#: src/FirstRunWizard.cpp:377 src/muuli_wdr.cpp:1435
+#: src/FirstRunWizard.cpp:377 src/muuli_wdr.cpp:1442
 msgid "Enable UPnP for router port forwarding"
 msgstr "Habilitar UPnP pal reunvíu de puertu del router"
 
@@ -2378,7 +2383,7 @@ msgstr ""
 msgid "Your peer lists are already in place - nothing to download."
 msgstr "Yá tas descargando el ficheru %s"
 
-#: src/FirstRunWizard.cpp:434 src/muuli_wdr.cpp:1533
+#: src/FirstRunWizard.cpp:434 src/muuli_wdr.cpp:1540
 msgid "Auto-update server list at startup"
 msgstr "Auto-actualizar la llista de sirvidores al aniciu"
 
@@ -2424,23 +2429,23 @@ msgid ""
 "want downloads on a different (e.g. larger) disk."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:549 src/FirstRunWizard.cpp:611 src/muuli_wdr.cpp:1701
+#: src/FirstRunWizard.cpp:549 src/FirstRunWizard.cpp:611 src/muuli_wdr.cpp:1708
 msgid "Destination folder for downloads"
 msgstr "Carpeta de destín pa les descargues"
 
-#: src/FirstRunWizard.cpp:553 src/FirstRunWizard.cpp:569 src/muuli_wdr.cpp:1342
-#: src/muuli_wdr.cpp:1359 src/muuli_wdr.cpp:1676 src/muuli_wdr.cpp:1707
-#: src/muuli_wdr.cpp:1719 src/muuli_wdr.cpp:2762
+#: src/FirstRunWizard.cpp:553 src/FirstRunWizard.cpp:569 src/muuli_wdr.cpp:1349
+#: src/muuli_wdr.cpp:1366 src/muuli_wdr.cpp:1683 src/muuli_wdr.cpp:1714
+#: src/muuli_wdr.cpp:1726 src/muuli_wdr.cpp:2769
 #: src/utils/aLinkCreator/src/alcframe.cpp:135
 #: src/utils/wxCas/src/wxcasprefs.cpp:52 src/utils/wxCas/src/wxcasprefs.cpp:118
 msgid "Browse"
 msgstr "Desaminar"
 
-#: src/FirstRunWizard.cpp:559 src/muuli_wdr.cpp:1712
+#: src/FirstRunWizard.cpp:559 src/muuli_wdr.cpp:1719
 msgid "(All files in this folder are shared with other peers)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:565 src/FirstRunWizard.cpp:624 src/muuli_wdr.cpp:1714
+#: src/FirstRunWizard.cpp:565 src/FirstRunWizard.cpp:624 src/muuli_wdr.cpp:1721
 msgid "Folder for temporary download files"
 msgstr "Carpeta pa los ficheros temporales de descargues"
 
@@ -2471,7 +2476,7 @@ msgstr "¡ Nun pudo abrise'l ficheru de collacios 'emfriends.met' pa la so escri
 msgid "CRITICAL - no client on StartChatSession"
 msgstr "CRITICU - ensin veceru en sesión charra d'aniciu"
 
-#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2668 src/muuli_wdr.cpp:3345
+#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2675 src/muuli_wdr.cpp:3352
 msgid "Friends"
 msgstr "Collacios"
 
@@ -2861,7 +2866,7 @@ msgstr "Media compartío"
 msgid "Uploaded"
 msgstr "Xubío"
 
-#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3225
+#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3232
 msgid "Requested"
 msgstr "Pidío"
 
@@ -2985,7 +2990,7 @@ msgid "WARNING: "
 msgstr "AVISU:"
 
 #: src/MuleNotebook.cpp:179 src/muuli_wdr.cpp:817 src/muuli_wdr.cpp:1229
-#: src/muuli_wdr.cpp:3129 src/muuli_wdr.cpp:3385
+#: src/muuli_wdr.cpp:3136 src/muuli_wdr.cpp:3392
 msgid "Close"
 msgstr "Zarrar"
 
@@ -2998,12 +3003,12 @@ msgstr "Cortar"
 msgid "Copy"
 msgstr "Copiar"
 
-#: src/MuleTextCtrl.cpp:88
+#: src/MuleTextCtrl.cpp:88 src/SearchDlg.cpp:261
 msgid "Paste"
 msgstr "Apegar"
 
 #: src/MuleTextCtrl.cpp:89 src/muuli_wdr.cpp:358 src/muuli_wdr.cpp:757
-#: src/muuli_wdr.cpp:2352 src/muuli_wdr.cpp:2371 src/muuli_wdr.cpp:2393
+#: src/muuli_wdr.cpp:2359 src/muuli_wdr.cpp:2378 src/muuli_wdr.cpp:2400
 #: src/utils/aLinkCreator/src/alcframe.cpp:142
 msgid "Clear"
 msgstr "Llimpiar"
@@ -3101,8 +3106,8 @@ msgid "Exit"
 msgstr "Colar"
 
 #: src/MuleTrayIcon.cpp:579 src/MuleTrayIcon.cpp:945 src/MuleTrayIcon.cpp:965
-#: src/muuli_wdr.cpp:1391 src/muuli_wdr.cpp:1399 src/muuli_wdr.cpp:1406
-#: src/muuli_wdr.cpp:1835 src/muuli_wdr.cpp:1841 src/OtherFunctions.cpp:91
+#: src/muuli_wdr.cpp:1398 src/muuli_wdr.cpp:1406 src/muuli_wdr.cpp:1413
+#: src/muuli_wdr.cpp:1842 src/muuli_wdr.cpp:1848 src/OtherFunctions.cpp:91
 #: src/StatisticsDlg.cpp:93 src/StatisticsDlg.cpp:95
 msgid "kB/s"
 msgstr "kB/s"
@@ -3273,7 +3278,7 @@ msgstr "Nome:"
 msgid "Type"
 msgstr "Triba"
 
-#: src/muuli_wdr.cpp:215 src/SearchDlg.cpp:110 src/SearchListCtrl.cpp:853
+#: src/muuli_wdr.cpp:215 src/SearchDlg.cpp:118 src/SearchListCtrl.cpp:853
 msgid "Local"
 msgstr "Llocal"
 
@@ -3344,7 +3349,7 @@ msgstr "Bytes"
 msgid "KB"
 msgstr "KB"
 
-#: src/muuli_wdr.cpp:274 src/muuli_wdr.cpp:293 src/muuli_wdr.cpp:1620
+#: src/muuli_wdr.cpp:274 src/muuli_wdr.cpp:293 src/muuli_wdr.cpp:1627
 #: src/OtherFunctions.cpp:64
 msgid "MB"
 msgstr "MB"
@@ -3361,7 +3366,7 @@ msgstr "Tamañu Máx"
 msgid "Availability"
 msgstr "Disponibilidá"
 
-#: src/muuli_wdr.cpp:312 src/muuli_wdr.cpp:398 src/muuli_wdr.cpp:3290
+#: src/muuli_wdr.cpp:312 src/muuli_wdr.cpp:398 src/muuli_wdr.cpp:3297
 msgid "Filter:"
 msgstr "Fieltru:"
 
@@ -3393,7 +3398,7 @@ msgstr ""
 msgid "Stop"
 msgstr "Encaboxar"
 
-#: src/muuli_wdr.cpp:348 src/muuli_wdr.cpp:1385 src/SearchListCtrl.cpp:732
+#: src/muuli_wdr.cpp:348 src/muuli_wdr.cpp:1392 src/SearchListCtrl.cpp:732
 msgid "Download"
 msgstr "Descarga"
 
@@ -3425,8 +3430,8 @@ msgstr "Fontes completes"
 #: src/muuli_wdr.cpp:1160 src/muuli_wdr.cpp:1167 src/muuli_wdr.cpp:1172
 #: src/muuli_wdr.cpp:1179 src/muuli_wdr.cpp:1184 src/muuli_wdr.cpp:1191
 #: src/muuli_wdr.cpp:1205 src/muuli_wdr.cpp:1212 src/muuli_wdr.cpp:1217
-#: src/muuli_wdr.cpp:1224 src/muuli_wdr.cpp:3227 src/muuli_wdr.cpp:3235
-#: src/muuli_wdr.cpp:3243
+#: src/muuli_wdr.cpp:1224 src/muuli_wdr.cpp:3234 src/muuli_wdr.cpp:3242
+#: src/muuli_wdr.cpp:3250
 msgid "N/A"
 msgstr "N/A"
 
@@ -3571,7 +3576,7 @@ msgstr ""
 msgid "Album :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:685 src/muuli_wdr.cpp:2247
+#: src/muuli_wdr.cpp:685 src/muuli_wdr.cpp:2254
 msgid "Title :"
 msgstr "Títulu :"
 
@@ -3680,7 +3685,7 @@ msgstr "Nome d'usuariu :"
 msgid "Userhash :"
 msgstr "Hash del usuariu :"
 
-#: src/muuli_wdr.cpp:895 src/muuli_wdr.cpp:1741 src/muuli_wdr.cpp:2442
+#: src/muuli_wdr.cpp:895 src/muuli_wdr.cpp:1748 src/muuli_wdr.cpp:2449
 #: src/utils/aLinkCreator/src/alcframe.cpp:137
 msgid "Add"
 msgstr "Amestar"
@@ -3689,15 +3694,15 @@ msgstr "Amestar"
 msgid "Download-Speed"
 msgstr "Velocidá de descarga"
 
-#: src/muuli_wdr.cpp:954 src/muuli_wdr.cpp:989 src/muuli_wdr.cpp:2546
+#: src/muuli_wdr.cpp:954 src/muuli_wdr.cpp:989 src/muuli_wdr.cpp:2553
 msgid "Current"
 msgstr "Actual"
 
-#: src/muuli_wdr.cpp:962 src/muuli_wdr.cpp:997 src/muuli_wdr.cpp:2554
+#: src/muuli_wdr.cpp:962 src/muuli_wdr.cpp:997 src/muuli_wdr.cpp:2561
 msgid "Running average"
 msgstr "Media d'execución"
 
-#: src/muuli_wdr.cpp:970 src/muuli_wdr.cpp:1005 src/muuli_wdr.cpp:2562
+#: src/muuli_wdr.cpp:970 src/muuli_wdr.cpp:1005 src/muuli_wdr.cpp:2569
 msgid "Session average"
 msgstr "Media de la sesión"
 
@@ -3709,7 +3714,7 @@ msgstr "Velocidá de xuba"
 msgid "Connections"
 msgstr "Conexones"
 
-#: src/muuli_wdr.cpp:1024 src/muuli_wdr.cpp:1860
+#: src/muuli_wdr.cpp:1024 src/muuli_wdr.cpp:1867
 msgid "Active downloads"
 msgstr "Descargues actives"
 
@@ -3717,7 +3722,7 @@ msgstr "Descargues actives"
 msgid "Active connections (1:1)"
 msgstr "Conexones actives (1:1)"
 
-#: src/muuli_wdr.cpp:1040 src/muuli_wdr.cpp:1861
+#: src/muuli_wdr.cpp:1040 src/muuli_wdr.cpp:1868
 msgid "Active uploads"
 msgstr "Xubes actives"
 
@@ -3834,8 +3839,8 @@ msgstr "Esti ye'l nome que verán los otros usuarios verán cuando se coneuten a
 msgid "Language: "
 msgstr "Llingua: "
 
-#: src/muuli_wdr.cpp:1257 src/muuli_wdr.cpp:1323 src/muuli_wdr.cpp:1327
-#: src/muuli_wdr.cpp:1330
+#: src/muuli_wdr.cpp:1257 src/muuli_wdr.cpp:1330 src/muuli_wdr.cpp:1334
+#: src/muuli_wdr.cpp:1337
 msgid "The delay before showing tool-tips."
 msgstr "Allanciu enantes d'amosar los mensaxes emerxentes."
 
@@ -3913,941 +3918,950 @@ msgstr ""
 msgid "Enabling this will make aMule to show notifications when finished downloading."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1322
+#: src/muuli_wdr.cpp:1323
+#, fuzzy
+msgid "Remember search history"
+msgstr "Remembrar estes opciones"
+
+#: src/muuli_wdr.cpp:1324
+msgid "Keeps a dropdown list of your past search terms in the Search tab's Name field. This remembers the queries you typed, not the results they returned."
+msgstr ""
+
+#: src/muuli_wdr.cpp:1329
 msgid "Tooltip delay time: "
 msgstr "Tiempu d'allanciu de los mensaxes emerxentes: "
 
-#: src/muuli_wdr.cpp:1329
+#: src/muuli_wdr.cpp:1336
 msgid "seconds"
 msgstr "segundos"
 
-#: src/muuli_wdr.cpp:1333
+#: src/muuli_wdr.cpp:1340
 msgid "Browser Selection"
 msgstr "Seleición del restolador"
 
-#: src/muuli_wdr.cpp:1339
+#: src/muuli_wdr.cpp:1346
 msgid "Enter your browser name here. Leave this field empty to use the system default browser."
 msgstr "Introduz el nome del to restolador. Déxalo ermo si quies usar el que hai por defeutu."
 
-#: src/muuli_wdr.cpp:1346
+#: src/muuli_wdr.cpp:1353
 msgid "Open in new tab if possible"
 msgstr "Abrir en nueva llingüeta si ye dable"
 
-#: src/muuli_wdr.cpp:1348
+#: src/muuli_wdr.cpp:1355
 msgid "Open the web page in a new tab instead of in a new window when possible"
 msgstr "Abrir cuando seya dable, la páxina web nuna nueva llingüeta n'arroú de nuna nueva ventana"
 
-#: src/muuli_wdr.cpp:1352
+#: src/muuli_wdr.cpp:1359
 msgid "Video Player"
 msgstr "Reproductor de vídeu"
 
-#: src/muuli_wdr.cpp:1379
+#: src/muuli_wdr.cpp:1386
 msgid "Bandwidth limits"
 msgstr "Llímites del anchor de banda"
 
-#: src/muuli_wdr.cpp:1393
+#: src/muuli_wdr.cpp:1400
 msgid "Upload"
 msgstr "Xuba"
 
-#: src/muuli_wdr.cpp:1401
+#: src/muuli_wdr.cpp:1408
 msgid "Slot Allocation"
 msgstr "Asignación de puestu reserváu"
 
-#: src/muuli_wdr.cpp:1410
+#: src/muuli_wdr.cpp:1417
 msgid "Ports"
 msgstr "Puertos"
 
-#: src/muuli_wdr.cpp:1420
+#: src/muuli_wdr.cpp:1427
 msgid "This is the standard eD2k port and cannot be disabled."
 msgstr "Esti ye'l puertu eD2k estándar y nun pue deshabilitase"
 
-#: src/muuli_wdr.cpp:1423
+#: src/muuli_wdr.cpp:1430
 msgid "UDP port for server requests (TCP+3):"
 msgstr "Puertu UDP pa peticiones del sirvidor (TCP+3):"
 
-#: src/muuli_wdr.cpp:1425
+#: src/muuli_wdr.cpp:1432
 msgid "4665"
 msgstr "4665"
 
-#: src/muuli_wdr.cpp:1432
+#: src/muuli_wdr.cpp:1439
 msgid "This UDP port is used for extended eD2k requests and Kad network"
 msgstr "Esti puertu UDP úsase pa peticiones estendíes de eD2k y la rede Kad"
 
-#: src/muuli_wdr.cpp:1439
+#: src/muuli_wdr.cpp:1446
 msgid "UPnP TCP Port (Optional):"
 msgstr "Puertu UPnP TCP (Opcional):"
 
-#: src/muuli_wdr.cpp:1449
+#: src/muuli_wdr.cpp:1456
 msgid "Bind local address to IP (empty for any):"
 msgstr "Señes IP llocal de enllaz: (erma pa cualesquiera):"
 
-#: src/muuli_wdr.cpp:1452
+#: src/muuli_wdr.cpp:1459
 msgid "Advanced users only: If you have multiple network interfaces, enter the address of the interface to which aMule should be bound."
 msgstr "Namái usuarios avanzaos: Si tu tienes múltiples tarxetes de rede, introduz la direición de la tarxeta, que aMule tendrá d'usar."
 
-#: src/muuli_wdr.cpp:1455 src/muuli_wdr.cpp:2054
+#: src/muuli_wdr.cpp:1462 src/muuli_wdr.cpp:2061
 #, fuzzy
 msgid "Bind to network interface (empty for any):"
 msgstr "Señes IP llocal de enllaz: (erma pa cualesquiera):"
 
-#: src/muuli_wdr.cpp:1468
+#: src/muuli_wdr.cpp:1475
 msgid "Advanced users only: pin all of aMule's traffic to one network interface, chosen from the list or typed in by name (e.g. tun0, eth0, en0) or index. Unlike binding to an IP, this stops traffic leaking out via the default route - useful with a VPN. Requires no elevated privileges."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1474
+#: src/muuli_wdr.cpp:1481
 msgid "Max sources per downloading file:"
 msgstr "Max. fontes descargando un ficheru:"
 
-#: src/muuli_wdr.cpp:1478
+#: src/muuli_wdr.cpp:1485
 msgid "Max simultaneous connections:"
 msgstr "Máx. conexones al empar:"
 
-#: src/muuli_wdr.cpp:1491 src/muuli_wdr.cpp:3169
+#: src/muuli_wdr.cpp:1498 src/muuli_wdr.cpp:3176
 msgid "ED2K"
 msgstr "ED2K"
 
-#: src/muuli_wdr.cpp:1498
+#: src/muuli_wdr.cpp:1505
 msgid "Autoconnect on startup"
 msgstr "Autoconeutar al aniciar"
 
-#: src/muuli_wdr.cpp:1501
+#: src/muuli_wdr.cpp:1508
 msgid "Reconnect on loss"
 msgstr "Reconeutar al perder la conexón"
 
-#: src/muuli_wdr.cpp:1523
+#: src/muuli_wdr.cpp:1530
 msgid "Remove dead server after"
 msgstr "Desaniciar sirvidores cayíos tres"
 
-#: src/muuli_wdr.cpp:1524
+#: src/muuli_wdr.cpp:1531
 msgid "Static servers are never removed, even when unreachable."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1528
+#: src/muuli_wdr.cpp:1535
 msgid "retries"
 msgstr "reintentos"
 
-#: src/muuli_wdr.cpp:1536
+#: src/muuli_wdr.cpp:1543
 msgid "List"
 msgstr "Llista"
 
-#: src/muuli_wdr.cpp:1539
+#: src/muuli_wdr.cpp:1546
 msgid "Update server list when connecting to a server"
 msgstr "Actualizar la llista de sirvidores al coneutar a un sirvidor"
 
-#: src/muuli_wdr.cpp:1542
+#: src/muuli_wdr.cpp:1549
 msgid "Update server list when a client connects"
 msgstr "Actualizar la llista de sirvidores cuando un veceru se coneuta"
 
-#: src/muuli_wdr.cpp:1545
+#: src/muuli_wdr.cpp:1552
 msgid "Use priority system"
 msgstr "Usar sistema de prioridaes"
 
-#: src/muuli_wdr.cpp:1549
+#: src/muuli_wdr.cpp:1556
 msgid "Use smart LowID check on connect"
 msgstr "Control intelixente de IDBaxa al coneutar"
 
-#: src/muuli_wdr.cpp:1553
+#: src/muuli_wdr.cpp:1560
 msgid "Safe connect"
 msgstr "Conexón segura"
 
-#: src/muuli_wdr.cpp:1557
+#: src/muuli_wdr.cpp:1564
 msgid "Autoconnect to servers in static list only"
 msgstr "Autoconeutar namái a Sirvidores fixos"
 
-#: src/muuli_wdr.cpp:1560
+#: src/muuli_wdr.cpp:1567
 msgid "Set manually added servers to High Priority"
 msgstr "Asignar alta prioridá a los sirvidores amestaos manualmente"
 
-#: src/muuli_wdr.cpp:1581
+#: src/muuli_wdr.cpp:1588
 msgid "Add files to download in pause mode"
 msgstr "Amestar ficheros pa descargar en mou posáu"
 
-#: src/muuli_wdr.cpp:1583
+#: src/muuli_wdr.cpp:1590
 msgid "Add files to download with auto priority"
 msgstr "Amestar nueves descargues con auto prioridá"
 
-#: src/muuli_wdr.cpp:1586
+#: src/muuli_wdr.cpp:1593
 msgid "Try to download first and last chunks first"
 msgstr "Tentar descargar enantes la primer y cabera parte"
 
-#: src/muuli_wdr.cpp:1590
+#: src/muuli_wdr.cpp:1597
 msgid "Endgame mode: rotate to faster sources for the final blocks"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1593
+#: src/muuli_wdr.cpp:1600
 msgid "Start next paused file when a file completes"
 msgstr "Descargar siguiente ficheru posáu cuandu otru se complete"
 
-#: src/muuli_wdr.cpp:1596
+#: src/muuli_wdr.cpp:1603
 msgid "From the same category"
 msgstr "Namái na mesma categoría"
 
-#: src/muuli_wdr.cpp:1598
+#: src/muuli_wdr.cpp:1605
 msgid "In alphabetic order"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1600
+#: src/muuli_wdr.cpp:1607
 msgid "Preallocate disk space for new files"
 msgstr "Reservar espaciu en discu pa los nuevos ficheros"
 
-#: src/muuli_wdr.cpp:1601
+#: src/muuli_wdr.cpp:1608
 msgid "For new files preallocates disk space for the whole file, thus reduces fragmentation"
 msgstr "Pa los nuevos ficheros reservar tol espaciu del ficheru, esto amenorga la fragmentación"
 
-#: src/muuli_wdr.cpp:1606
+#: src/muuli_wdr.cpp:1613
 msgid "Create new files as sparse files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1607
+#: src/muuli_wdr.cpp:1614
 msgid "A sparse file reserves its full size on disk immediately without writing real data to it -- fast, but unsupported or slow on some filesystems, and free-space accounting stays optimistic while the download is in progress. Turn this off to grow the file only as data arrives."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1612
+#: src/muuli_wdr.cpp:1619
 msgid "Stop downloads when free disk space reaches "
 msgstr "Detener descargues cuando s'algame l'espaciu llibre en discu"
 
-#: src/muuli_wdr.cpp:1613
+#: src/muuli_wdr.cpp:1620
 msgid "Select this if you want aMule to check your disk space"
 msgstr "Seleiciona esta opción si quies que aMule comprebe l'espaciu en discu"
 
-#: src/muuli_wdr.cpp:1617
+#: src/muuli_wdr.cpp:1624
 msgid "Enter here the min disk space desired."
 msgstr "Introduz l'espaciu mínimu de discu deseyáu."
 
-#: src/muuli_wdr.cpp:1623
+#: src/muuli_wdr.cpp:1630
 msgid "Save 10 sources on rare files (< 20 sources)"
 msgstr "Guardar 10 fontes en ficheros raros (< 20 fontes)"
 
-#: src/muuli_wdr.cpp:1627 src/Statistics.cpp:790
+#: src/muuli_wdr.cpp:1634 src/Statistics.cpp:790
 msgid "Uploads"
 msgstr "Xubíes"
 
-#: src/muuli_wdr.cpp:1630
+#: src/muuli_wdr.cpp:1637
 msgid "Add new shared files with auto priority"
 msgstr "Amestar nuevos ficheros compartíos con auto prioridá"
 
-#: src/muuli_wdr.cpp:1636
+#: src/muuli_wdr.cpp:1643
 msgid "Intelligent Corruption Handling (I.C.H.)"
 msgstr "Remanador Intelixente de Corrupciones (I.C.H)"
 
-#: src/muuli_wdr.cpp:1639
+#: src/muuli_wdr.cpp:1646
 msgid "Enable"
 msgstr "Habilitar"
 
-#: src/muuli_wdr.cpp:1642
+#: src/muuli_wdr.cpp:1649
 msgid "Advanced I.C.H. trusts every hash (not recommended)"
 msgstr "I.C.H. avanzáu, confiar en tolos hash (non recomendáu)"
 
-#: src/muuli_wdr.cpp:1654 src/PrefsUnifiedDlg.cpp:1910
+#: src/muuli_wdr.cpp:1661 src/PrefsUnifiedDlg.cpp:1910
 msgid "Media metadata extraction"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1658
+#: src/muuli_wdr.cpp:1665
 msgid "Extract length / bitrate / codec from shared audio and video files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1660
+#: src/muuli_wdr.cpp:1667
 msgid "When enabled, aMule runs ffprobe on each shared media file to fill in the Length / Bitrate / Codec columns other clients see when they find the file in a search. Requires ffmpeg (the ffprobe binary) to be installed."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1667
+#: src/muuli_wdr.cpp:1674
 msgid "Path to ffprobe:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1672
+#: src/muuli_wdr.cpp:1679
 msgid "Full path to the ffprobe binary. Leave empty to have aMule auto-detect it on startup."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1680
+#: src/muuli_wdr.cpp:1687
 msgid "Detect"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1681
+#: src/muuli_wdr.cpp:1688
 msgid "Search the standard install locations for an ffprobe binary and fill the path field."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1705
+#: src/muuli_wdr.cpp:1712
 msgid ""
 "Completed downloads are stored here. All files in this folder are automatically shared with other peers.\n"
 "If this folder also holds files you don't want to share, point it at an aMule-only sub-folder."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1708
+#: src/muuli_wdr.cpp:1715
 msgid "Pick the folder where completed downloads will be stored. All files in that folder will be shared with other peers."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1722
+#: src/muuli_wdr.cpp:1729
 msgid "Shared folders"
 msgstr "Carpetes compartíes"
 
-#: src/muuli_wdr.cpp:1728
+#: src/muuli_wdr.cpp:1735
 msgid "(Folders shared by the core. Enter a path to add one.)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1736
+#: src/muuli_wdr.cpp:1743
 msgid "Absolute path of a folder on the core's machine, e.g. /home/user/shared"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1738 src/PrefsUnifiedDlg.cpp:2794
+#: src/muuli_wdr.cpp:1745 src/PrefsUnifiedDlg.cpp:2794
 msgid "Recursive"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1739
+#: src/muuli_wdr.cpp:1746
 msgid "Share every sub-folder underneath this one, including ones created later."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1743 src/utils/aLinkCreator/src/alcframe.cpp:141
+#: src/muuli_wdr.cpp:1750 src/utils/aLinkCreator/src/alcframe.cpp:141
 msgid "Remove"
 msgstr "Desaniciar"
 
-#: src/muuli_wdr.cpp:1747
+#: src/muuli_wdr.cpp:1754
 msgid "(Right click on folder icon for recursive share)"
 msgstr "(Click drechu n'iconu de carpeta, pa compartición recursiva)"
 
-#: src/muuli_wdr.cpp:1754
+#: src/muuli_wdr.cpp:1761
 msgid "Share hidden files"
 msgstr "Compartir ficheros anubríos"
 
-#: src/muuli_wdr.cpp:1760
+#: src/muuli_wdr.cpp:1767
 msgid "Automatically rescan shared folders for changes"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1766
+#: src/muuli_wdr.cpp:1773
 msgid "Follow symbolic links in shared folders"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1772
+#: src/muuli_wdr.cpp:1779
 msgid "Exclude files matching:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1775
+#: src/muuli_wdr.cpp:1782
 msgid "Wildcard patterns separated by '|', e.g. .DS_Store|Thumbs.db|*.tmp. Files whose name matches are not shared. Matching is case-insensitive."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1779
+#: src/muuli_wdr.cpp:1786
 msgid "Patterns are regular expressions"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1780
+#: src/muuli_wdr.cpp:1787
 msgid "When set, the whole field is one regular expression ('|' is alternation). When unset, it is a list of '|'-separated wildcards."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1790
+#: src/muuli_wdr.cpp:1797
 msgid "Show how many shared files the current pattern would exclude."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1811
+#: src/muuli_wdr.cpp:1818
 msgid "Graphs"
 msgstr "Gráficos"
 
-#: src/muuli_wdr.cpp:1814 src/muuli_wdr.cpp:1876
+#: src/muuli_wdr.cpp:1821 src/muuli_wdr.cpp:1883
 msgid "Update delay : 5 secs"
 msgstr "Intervalu d'actualización : 5 segs"
 
-#: src/muuli_wdr.cpp:1818
+#: src/muuli_wdr.cpp:1825
 msgid "Time for average graph: 100 mins"
 msgstr "Tiempu de promediu del gráficu: 100 min"
 
-#: src/muuli_wdr.cpp:1822
+#: src/muuli_wdr.cpp:1829
 msgid "Connections Graph Scale: 100 "
 msgstr "Escala del gráficu de les conexones: 100"
 
-#: src/muuli_wdr.cpp:1829
+#: src/muuli_wdr.cpp:1836
 msgid "Download graph scale:"
 msgstr "Descargar escala gráfica:"
 
-#: src/muuli_wdr.cpp:1837
+#: src/muuli_wdr.cpp:1844
 msgid "Upload graph scale:"
 msgstr "Escala gráfica de descarga:"
 
-#: src/muuli_wdr.cpp:1847
+#: src/muuli_wdr.cpp:1854
 #, fuzzy
 msgid "Colors: "
 msgstr "Colores: "
 
-#: src/muuli_wdr.cpp:1851
+#: src/muuli_wdr.cpp:1858
 msgid "Background"
 msgstr "Fondu"
 
-#: src/muuli_wdr.cpp:1852
+#: src/muuli_wdr.cpp:1859
 msgid "Grid"
 msgstr "Rexella"
 
-#: src/muuli_wdr.cpp:1853
+#: src/muuli_wdr.cpp:1860
 msgid "Download current"
 msgstr "Descarga actual"
 
-#: src/muuli_wdr.cpp:1854
+#: src/muuli_wdr.cpp:1861
 msgid "Download running average"
 msgstr "Promediu descarga n'execución"
 
-#: src/muuli_wdr.cpp:1855
+#: src/muuli_wdr.cpp:1862
 msgid "Download session average"
 msgstr "Promediu Descarga/sesión"
 
-#: src/muuli_wdr.cpp:1856
+#: src/muuli_wdr.cpp:1863
 msgid "Upload current"
 msgstr "Xuba actual"
 
-#: src/muuli_wdr.cpp:1857
+#: src/muuli_wdr.cpp:1864
 msgid "Upload running average"
 msgstr "Promediu Xuba/tiempu"
 
-#: src/muuli_wdr.cpp:1858
+#: src/muuli_wdr.cpp:1865
 msgid "Upload session average"
 msgstr "Promediu xuba/sesión"
 
-#: src/muuli_wdr.cpp:1859
+#: src/muuli_wdr.cpp:1866
 msgid "Active connections"
 msgstr "Conexones actives"
 
-#: src/muuli_wdr.cpp:1862
+#: src/muuli_wdr.cpp:1869
 #, fuzzy
 msgid "Systray Icon Speed Bar"
 msgstr "Barra de velocidá del iconu de sistema"
 
-#: src/muuli_wdr.cpp:1863
+#: src/muuli_wdr.cpp:1870
 msgid "Kad-nodes current"
 msgstr "Kad-nodos actual"
 
-#: src/muuli_wdr.cpp:1864
+#: src/muuli_wdr.cpp:1871
 msgid "Kad-nodes running"
 msgstr "Kad-nodos executando"
 
-#: src/muuli_wdr.cpp:1865
+#: src/muuli_wdr.cpp:1872
 msgid "Kad-nodes session"
 msgstr "Kad-nodos sesión"
 
-#: src/muuli_wdr.cpp:1869 src/muuli_wdr.cpp:2296
+#: src/muuli_wdr.cpp:1876 src/muuli_wdr.cpp:2303
 msgid "Select"
 msgstr "Seleicionar"
 
-#: src/muuli_wdr.cpp:1873
+#: src/muuli_wdr.cpp:1880
 msgid "Tree"
 msgstr "Árbol"
 
-#: src/muuli_wdr.cpp:1883
+#: src/muuli_wdr.cpp:1890
 msgid "Number of Client Versions shown (0=unlimited)"
 msgstr "Númberu de versiones de veceros a amosar (0=ensin llímite)"
 
-#: src/muuli_wdr.cpp:1908
+#: src/muuli_wdr.cpp:1915
 msgid "!!! WARNING !!!"
 msgstr "¡¡¡ AVISU !!!"
 
-#: src/muuli_wdr.cpp:1923
+#: src/muuli_wdr.cpp:1930
 msgid "Max new connections / 5 secs"
 msgstr "Nueves conexones máx. / 5 segs"
 
-#: src/muuli_wdr.cpp:1925
+#: src/muuli_wdr.cpp:1932
 msgid "Concurrent Kad source lookups"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1927
+#: src/muuli_wdr.cpp:1934
 #, fuzzy
 msgid "Kad source re-search interval (minutes)"
 msgstr "Intervalu d'actualización de FTP en minutos"
 
-#: src/muuli_wdr.cpp:1929
+#: src/muuli_wdr.cpp:1936
 #, fuzzy
 msgid "Source re-ask interval (minutes)"
 msgstr "Intervalu d'actualización de FTP en minutos"
 
-#: src/muuli_wdr.cpp:1933
+#: src/muuli_wdr.cpp:1940
 msgid "File Buffer Size: 240000 bytes"
 msgstr "Tamañu del buffer de ficheru: 240000 bytes"
 
-#: src/muuli_wdr.cpp:1937
+#: src/muuli_wdr.cpp:1944
 msgid "Use MMAP: memory-mapped file access (lower memory use)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1938
+#: src/muuli_wdr.cpp:1945
 msgid "Maps part files into memory instead of buffering them on the heap, lowering the process memory footprint. May reduce download speed on some disks; best for memory-constrained or upload-heavy hosts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1940
+#: src/muuli_wdr.cpp:1947
 msgid "Upload Queue Size: 5000 clients"
 msgstr "Tamañu cola d'espera: 5000 veceros"
 
-#: src/muuli_wdr.cpp:1944
+#: src/muuli_wdr.cpp:1951
 msgid "Server connection refresh interval: Disable"
 msgstr "Intervalu d'actualización de conexón al sirvidor: Desactiváu"
 
-#: src/muuli_wdr.cpp:1948
+#: src/muuli_wdr.cpp:1955
 msgid "Disable computer's timed standby mode"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1967
+#: src/muuli_wdr.cpp:1974
 msgid "Skin to use: "
 msgstr "Tema a usar: "
 
-#: src/muuli_wdr.cpp:1976
+#: src/muuli_wdr.cpp:1983
 msgid "Show \"Fast eD2k Links Handler\" in every window."
 msgstr "Amosar \"Xestor rápidu d'enllaces eD2k\", en toles ventanes."
 
-#: src/muuli_wdr.cpp:1979
+#: src/muuli_wdr.cpp:1986
 msgid "Show extended info on categories tabs"
 msgstr "Amosar info estendía nes llingüetes de les categoríes"
 
-#: src/muuli_wdr.cpp:1982
+#: src/muuli_wdr.cpp:1989
 #, fuzzy
 msgid "Show application version on title"
 msgstr "Amosar índices de tresferencia nel títulu"
 
-#: src/muuli_wdr.cpp:1984
+#: src/muuli_wdr.cpp:1991
 msgid "Show transfer rates on title"
 msgstr "Amosar índices de tresferencia nel títulu"
 
-#: src/muuli_wdr.cpp:1986
+#: src/muuli_wdr.cpp:1993
 msgid "Before application name"
 msgstr "Enantes del nome de l'aplicación"
 
-#: src/muuli_wdr.cpp:1988
+#: src/muuli_wdr.cpp:1995
 msgid "After application name"
 msgstr "Dempués del nome de l'aplicación"
 
-#: src/muuli_wdr.cpp:1991
+#: src/muuli_wdr.cpp:1998
 msgid "Show overhead bandwidth"
 msgstr "Amosar anchor de banda escedente"
 
-#: src/muuli_wdr.cpp:1995
+#: src/muuli_wdr.cpp:2002
 msgid "Vertical toolbar orientation"
 msgstr "Orientación vertical de la barra de ferramientes"
 
-#: src/muuli_wdr.cpp:1997
+#: src/muuli_wdr.cpp:2004
 msgid "Live column sorting (auto-reorder rows as their values change)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2004
+#: src/muuli_wdr.cpp:2011
 msgid "Download Queue Files"
 msgstr "Ficheros de la cola de descarga"
 
-#: src/muuli_wdr.cpp:2007
+#: src/muuli_wdr.cpp:2014
 msgid "Show progress percentage"
 msgstr "Amosar porcentax de progresu"
 
-#: src/muuli_wdr.cpp:2013
+#: src/muuli_wdr.cpp:2020
 msgid "Show progress bar"
 msgstr "Amosar barra de progresu"
 
-#: src/muuli_wdr.cpp:2016
+#: src/muuli_wdr.cpp:2023
 msgid "Flat"
 msgstr "Planu"
 
-#: src/muuli_wdr.cpp:2020
+#: src/muuli_wdr.cpp:2027
 msgid "Round"
 msgstr "3D"
 
-#: src/muuli_wdr.cpp:2038
+#: src/muuli_wdr.cpp:2045
 msgid "External Connection Parameters"
 msgstr "Parámetros de conexón esterna"
 
-#: src/muuli_wdr.cpp:2041
+#: src/muuli_wdr.cpp:2048
 msgid "Accept external connections"
 msgstr "Aceutar conexones esternes"
 
-#: src/muuli_wdr.cpp:2048 src/muuli_wdr.cpp:2107
+#: src/muuli_wdr.cpp:2055 src/muuli_wdr.cpp:2114
 msgid "IP of the listening interface:"
 msgstr "IP de la interface que ta escuchando"
 
-#: src/muuli_wdr.cpp:2051
+#: src/muuli_wdr.cpp:2058
 msgid "Enter here a valid ip in the a.b.c.d format for the listening EC interface. An empty field or 0.0.0.0 will mean any interface."
 msgstr "Introduz una IP válida de la interface que ta escuchando. Un campu ermu o 0.0.0.0 significará cualesquier interface."
 
-#: src/muuli_wdr.cpp:2072 src/muuli_wdr.cpp:2156
+#: src/muuli_wdr.cpp:2079 src/muuli_wdr.cpp:2163
 msgid "TCP port:"
 msgstr "Puertu TCP:"
 
-#: src/muuli_wdr.cpp:2078
+#: src/muuli_wdr.cpp:2085
 msgid "Enable UPnP port forwarding on the EC port"
 msgstr "Habilitar UPnP port forwarding nel puertu EC"
 
-#: src/muuli_wdr.cpp:2082 src/muuli_wdr.cpp:3041
+#: src/muuli_wdr.cpp:2089 src/muuli_wdr.cpp:3048
 #: src/utils/wxCas/src/wxcasprefs.cpp:167
 msgid "Password"
 msgstr "Contraseña"
 
-#: src/muuli_wdr.cpp:2088
+#: src/muuli_wdr.cpp:2095
 #, fuzzy
 msgid "aMule API server parameters"
 msgstr "Parámetros del sirvidor web"
 
-#: src/muuli_wdr.cpp:2091
+#: src/muuli_wdr.cpp:2098
 msgid "Run amuleapi (REST API) on startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2096
+#: src/muuli_wdr.cpp:2103
 #, fuzzy
 msgid "HTTP port:"
 msgstr "Puertu TCP:"
 
-#: src/muuli_wdr.cpp:2110
+#: src/muuli_wdr.cpp:2117
 msgid "The interface amuleapi's HTTP server listens on. 127.0.0.1 (default) accepts only local connections; use 0.0.0.0 or a specific IP to expose it to other hosts (set an admin password below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2113
+#: src/muuli_wdr.cpp:2120
 #, fuzzy
 msgid "Admin password"
 msgstr "Comprobando contraseña\n"
 
-#: src/muuli_wdr.cpp:2118 src/muuli_wdr.cpp:2149
+#: src/muuli_wdr.cpp:2125 src/muuli_wdr.cpp:2156
 msgid "Low rights password"
 msgstr "Contraseña invitáu"
 
-#: src/muuli_wdr.cpp:2126
+#: src/muuli_wdr.cpp:2133
 msgid "Web server parameters"
 msgstr "Parámetros del sirvidor web"
 
-#: src/muuli_wdr.cpp:2129
+#: src/muuli_wdr.cpp:2136
 #, fuzzy
 msgid "Run webserver on startup (deprecated)"
 msgstr "Aniciar sirvidor web al entamu"
 
-#: src/muuli_wdr.cpp:2135
+#: src/muuli_wdr.cpp:2142
 msgid "Web template"
 msgstr "Plantía Web"
 
-#: src/muuli_wdr.cpp:2140
+#: src/muuli_wdr.cpp:2147
 msgid "Full rights password"
 msgstr "Contraseña alministrador"
 
-#: src/muuli_wdr.cpp:2144
+#: src/muuli_wdr.cpp:2151
 msgid "Enable Low rights User"
 msgstr "Activar invitáu"
 
-#: src/muuli_wdr.cpp:2163
+#: src/muuli_wdr.cpp:2170
 msgid "Enable UPnP port forwarding of the web server port"
 msgstr "Usar forwarding de puertos UPnP nel puertu del sirvidor web"
 
-#: src/muuli_wdr.cpp:2168
+#: src/muuli_wdr.cpp:2175
 msgid "Web server UPnP TCP port (Optional)"
 msgstr "Puertu HTTP del sirvidor web (Opcional)"
 
-#: src/muuli_wdr.cpp:2176
+#: src/muuli_wdr.cpp:2183
 msgid "Page Refresh Time (in secs)"
 msgstr "Tiempu d'actualización de páxina (en segs)"
 
-#: src/muuli_wdr.cpp:2183
+#: src/muuli_wdr.cpp:2190
 msgid "Enable Gzip compression"
 msgstr "Activar compresión gzip"
 
-#: src/muuli_wdr.cpp:2217
+#: src/muuli_wdr.cpp:2224
 #, fuzzy
 msgid "Reset page to defaults"
 msgstr "Por defeutu"
 
-#: src/muuli_wdr.cpp:2218
+#: src/muuli_wdr.cpp:2225
 msgid "Reset the settings on the current page to their default values."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2220 src/muuli_wdr.cpp:2306 src/ServerWnd.cpp:274
+#: src/muuli_wdr.cpp:2227 src/muuli_wdr.cpp:2313 src/ServerWnd.cpp:274
 #: src/ServerWnd.cpp:282
 msgid "OK"
 msgstr "Aceutar"
 
-#: src/muuli_wdr.cpp:2222
+#: src/muuli_wdr.cpp:2229
 msgid "Click here to apply any changes made to the preferences."
 msgstr "Aplicar cualesquier cambéu fechu nes opciones."
 
-#: src/muuli_wdr.cpp:2225
+#: src/muuli_wdr.cpp:2232
 msgid "Reset any changes made to the preferences."
 msgstr "Encaboxar cualesquier cambéu fechu nes opciones."
 
-#: src/muuli_wdr.cpp:2254
+#: src/muuli_wdr.cpp:2261
 msgid "Comment :"
 msgstr "Comentariu : "
 
-#: src/muuli_wdr.cpp:2261
+#: src/muuli_wdr.cpp:2268
 msgid "Incoming Dir :"
 msgstr "Direutoriu entrante :"
 
-#: src/muuli_wdr.cpp:2270
+#: src/muuli_wdr.cpp:2277
 msgid "Change priority for new assigned files :"
 msgstr "Cambiar prioridá a nuevos ficheros asignaos :"
 
-#: src/muuli_wdr.cpp:2274
+#: src/muuli_wdr.cpp:2281
 #, fuzzy
 msgid "Don't change"
 msgstr "Non cambiar"
 
-#: src/muuli_wdr.cpp:2286
+#: src/muuli_wdr.cpp:2293
 msgid "Select color for this Category (currently selected) :"
 msgstr "Seleiciona color pa esta categoría (seleicionada) :"
 
-#: src/muuli_wdr.cpp:2353 src/muuli_wdr.cpp:2372 src/muuli_wdr.cpp:2394
+#: src/muuli_wdr.cpp:2360 src/muuli_wdr.cpp:2379 src/muuli_wdr.cpp:2401
 msgid "Click this button to reset the log."
 msgstr "Calca esti botón pa llimpiar el registru."
 
-#: src/muuli_wdr.cpp:2413
+#: src/muuli_wdr.cpp:2420
 msgid "Click on this button to update the servers list from URL ..."
 msgstr "Click nesti botón p'actualizar la llista de sirvidores dende una URL ..."
 
-#: src/muuli_wdr.cpp:2417
+#: src/muuli_wdr.cpp:2424
 msgid "Server list"
 msgstr "Llista de sirvidores"
 
-#: src/muuli_wdr.cpp:2421
+#: src/muuli_wdr.cpp:2428
 msgid "Enter the url to a server.met file here and press the button to the left to update the list of known servers."
 msgstr "Introduz la url a un ficheru server.met y calca'l botón de la esquierda p'actualizar la llista de sirvidores conocíos."
 
-#: src/muuli_wdr.cpp:2426
+#: src/muuli_wdr.cpp:2433
 msgid "Add server manually: Name"
 msgstr "Amestar sirvidor manualmente: Nome"
 
-#: src/muuli_wdr.cpp:2429
+#: src/muuli_wdr.cpp:2436
 msgid "Enter the name of the new server here"
 msgstr "Introduz el nome del nuevu sirvidor"
 
-#: src/muuli_wdr.cpp:2431 src/ServerWnd.cpp:206
+#: src/muuli_wdr.cpp:2438 src/ServerWnd.cpp:206
 msgid "IP:Port"
 msgstr "IP:Puertu"
 
-#: src/muuli_wdr.cpp:2434
+#: src/muuli_wdr.cpp:2441
 msgid "Enter the IP of the server here, using the x.x.x.x format."
 msgstr "Introduz la IP del sirvidor, usando'l formatu X.X.X.X."
 
-#: src/muuli_wdr.cpp:2440
+#: src/muuli_wdr.cpp:2447
 msgid "Enter the port of the server here."
 msgstr "Introduz el puertu del sirvidor"
 
-#: src/muuli_wdr.cpp:2443
+#: src/muuli_wdr.cpp:2450
 msgid "Add manually a server (fill fields to the left before) ..."
 msgstr "Amestar manualmente un sirvidor (rellena los campos) ..."
 
-#: src/muuli_wdr.cpp:2472
+#: src/muuli_wdr.cpp:2479
 msgid "aMule Log"
 msgstr "Rexistru"
 
-#: src/muuli_wdr.cpp:2480
+#: src/muuli_wdr.cpp:2487
 msgid "Server Info"
 msgstr "Info. sirvidores"
 
-#: src/muuli_wdr.cpp:2484
+#: src/muuli_wdr.cpp:2491
 msgid "ED2K Info"
 msgstr "Info ED2K"
 
-#: src/muuli_wdr.cpp:2488
+#: src/muuli_wdr.cpp:2495
 msgid "Kad Info"
 msgstr "Info Kad"
 
-#: src/muuli_wdr.cpp:2516
+#: src/muuli_wdr.cpp:2523
 msgid "Click on this button to update the nodes list from URL ..."
 msgstr "Click nesti botón p'actualizar la llista de nodos dende la URL ..."
 
-#: src/muuli_wdr.cpp:2520
+#: src/muuli_wdr.cpp:2527
 msgid "Nodes (0)"
 msgstr "Nodos (0)"
 
-#: src/muuli_wdr.cpp:2524
+#: src/muuli_wdr.cpp:2531
 msgid "Enter the url to a nodes.dat file here and press the button to the left to update the list of known nodes."
 msgstr "Introduz equí la url al ficheru nodes.dat y calca'l botón de la esquierda, p'actualizar la llista de nodos conocíos."
 
-#: src/muuli_wdr.cpp:2527
+#: src/muuli_wdr.cpp:2534
 msgid "Nodes stats"
 msgstr "Estadístiques nodos"
 
-#: src/muuli_wdr.cpp:2569
+#: src/muuli_wdr.cpp:2576
 msgid "Bootstrap"
 msgstr "Coneutar"
 
-#: src/muuli_wdr.cpp:2572
+#: src/muuli_wdr.cpp:2579
 msgid "New node"
 msgstr "Nuevu nodu"
 
-#: src/muuli_wdr.cpp:2577
+#: src/muuli_wdr.cpp:2584
 msgid "IP:"
 msgstr "IP:"
 
-#: src/muuli_wdr.cpp:2597
+#: src/muuli_wdr.cpp:2604
 msgid "Port:"
 msgstr "Puertu:"
 
-#: src/muuli_wdr.cpp:2610
+#: src/muuli_wdr.cpp:2617
 #, fuzzy
 msgid "Bootstrap from known clients"
 msgstr ""
 "Coneutar dende \n"
 "veceros conocíos"
 
-#: src/muuli_wdr.cpp:2612
+#: src/muuli_wdr.cpp:2619
 msgid "Disconnect Kad"
 msgstr "Desconeutar Kad"
 
-#: src/muuli_wdr.cpp:2646
+#: src/muuli_wdr.cpp:2653
 msgid "Use Secure User Identification"
 msgstr "Usar Identificación Segura d'Usuariu"
 
-#: src/muuli_wdr.cpp:2648
+#: src/muuli_wdr.cpp:2655
 msgid "It is recommended to enable this option. You will not receive credits if SUI is not enabled."
 msgstr "Encamiéntase a activar esta opción. Nun recibirá créditos si la ISU (Identificación Segura d'Usuariu) nun ta habilitada."
 
-#: src/muuli_wdr.cpp:2650
+#: src/muuli_wdr.cpp:2657
 msgid "Protocol Obfuscation"
 msgstr "Ofuscación de protocolu"
 
-#: src/muuli_wdr.cpp:2653
+#: src/muuli_wdr.cpp:2660
 msgid "Support Protocol Obfuscation"
 msgstr "Sofitu d'ofuscación de protocolu"
 
-#: src/muuli_wdr.cpp:2655
+#: src/muuli_wdr.cpp:2662
 msgid "This option enabled Protocol Obfuscation, and makes aMule accept obfuscated connections from other clients."
 msgstr "Esta opción activa la ofuscación de protocolu, y fai que aMule aceute conexones ofuscaes de otros veceros."
 
-#: src/muuli_wdr.cpp:2657
+#: src/muuli_wdr.cpp:2664
 msgid "Use obfuscation for outgoing connections"
 msgstr "Usar ofuscación pa conexones salientes"
 
-#: src/muuli_wdr.cpp:2659
+#: src/muuli_wdr.cpp:2666
 msgid "This option makes aMule use Protocol Obfuscation when connecting other clients/servers."
 msgstr "Esta opción fai que aMule use ofuscación de protocolu cuando se coneuten otros veceros/sirvidores."
 
-#: src/muuli_wdr.cpp:2661
+#: src/muuli_wdr.cpp:2668
 msgid "Accept only obfuscated connections"
 msgstr "Aceutar namái conexones ofuscaes"
 
-#: src/muuli_wdr.cpp:2662
+#: src/muuli_wdr.cpp:2669
 msgid "This option makes aMule only accept obfuscated connections. You will have less sources, but all your traffic will be obfuscated"
 msgstr "Esa opción fai que aMule namái aceute conexones ofuscaes. Tendrá menos fontes, pero tol so tráficu sedrá ofuscáu."
 
-#: src/muuli_wdr.cpp:2667
+#: src/muuli_wdr.cpp:2674
 msgid "Everybody"
 msgstr "Toos"
 
-#: src/muuli_wdr.cpp:2669
+#: src/muuli_wdr.cpp:2676
 msgid "No one"
 msgstr "Dengún"
 
-#: src/muuli_wdr.cpp:2671
+#: src/muuli_wdr.cpp:2678
 msgid "Who can see my shared files:"
 msgstr "Quién pue adicar los mios ficheros compartíos:"
 
-#: src/muuli_wdr.cpp:2672
+#: src/muuli_wdr.cpp:2679
 msgid "Select who can request to view a list of your shared files."
 msgstr "Seleiciona quién pue solicitar adicar la nuesa llista de ficheros compartíos."
 
-#: src/muuli_wdr.cpp:2674
+#: src/muuli_wdr.cpp:2681
 msgid "IP-Filtering"
 msgstr "Fieltráu de IPs"
 
-#: src/muuli_wdr.cpp:2681
+#: src/muuli_wdr.cpp:2688
 msgid "Filter clients"
 msgstr "Fieltru veceros"
 
-#: src/muuli_wdr.cpp:2683
+#: src/muuli_wdr.cpp:2690
 msgid "Enable filtering of the client IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "Habilitar fieltráu de IPs de veceros definíu nel ficheru ~/.aMule/ipfilter.dat"
 
-#: src/muuli_wdr.cpp:2685
+#: src/muuli_wdr.cpp:2692
 msgid "Filter servers"
 msgstr "Fieltru sirvidores"
 
-#: src/muuli_wdr.cpp:2687
+#: src/muuli_wdr.cpp:2694
 msgid "Enable filtering of the server IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "Habilitar fieltráu de IPs de sirvidores definíu nel ficheru ~/.aMule/ipfilter.dat"
 
-#: src/muuli_wdr.cpp:2691
+#: src/muuli_wdr.cpp:2698
 msgid "Reload List"
 msgstr "Recargar llista"
 
-#: src/muuli_wdr.cpp:2692
+#: src/muuli_wdr.cpp:2699
 msgid "Reload the list of IPs to filter from the file ~/.aMule/ipfilter.dat"
 msgstr "Recargar llista de fieltráu de IPs dende ficheru ~/.aMule/ipfilter.dat"
 
-#: src/muuli_wdr.cpp:2698
+#: src/muuli_wdr.cpp:2705
 msgid "URL:"
 msgstr "URL:"
 
-#: src/muuli_wdr.cpp:2702 src/muuli_wdr.cpp:2895
+#: src/muuli_wdr.cpp:2709 src/muuli_wdr.cpp:2902
 msgid "Update now"
 msgstr "Actualizar agora"
 
-#: src/muuli_wdr.cpp:2705
+#: src/muuli_wdr.cpp:2712
 msgid "Auto-update ipfilter at startup"
 msgstr "Auto-actualizar el fieltráu de IPs al entamu"
 
-#: src/muuli_wdr.cpp:2709
+#: src/muuli_wdr.cpp:2716
 msgid "Filtering Level:"
 msgstr "Nivel de fieltráu:"
 
-#: src/muuli_wdr.cpp:2715
+#: src/muuli_wdr.cpp:2722
 msgid "Always filter LAN IPs"
 msgstr "Fieltrar siempres IP's de LAN"
 
-#: src/muuli_wdr.cpp:2718
+#: src/muuli_wdr.cpp:2725
 msgid "Paranoid handling of non-matching IPs"
 msgstr "Control paranoicu de IPs non comprobaes"
 
-#: src/muuli_wdr.cpp:2720
+#: src/muuli_wdr.cpp:2727
 msgid "Rejects a packet when its source IP differs from the IP the client claims (an anti-spoofing check). Disable only if it causes connection problems."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2722
+#: src/muuli_wdr.cpp:2729
 msgid "Use system-wide ipfilter.dat if available"
 msgstr "Usar el ipfilter.dat de sistema si ta disponible"
 
-#: src/muuli_wdr.cpp:2723
+#: src/muuli_wdr.cpp:2730
 #, fuzzy
 msgid "If there's no local ipfilter.dat found, allow usage of a system-wide ipfilter file."
 msgstr "Si nun s'alcuentra un ficheru ipfilter.dat llocal, permitir l'usu d'un ficheru ipfilter de sistema"
 
-#: src/muuli_wdr.cpp:2740
+#: src/muuli_wdr.cpp:2747
 msgid "Enable Online-Signature"
 msgstr "Activar Robla online"
 
-#: src/muuli_wdr.cpp:2742
+#: src/muuli_wdr.cpp:2749
 msgid "Enables the writing of the OS file, which can be used by external apps to create signatures and the like."
 msgstr "Habilitar la escritura de ficheros del SO, suel usase pa criar robles por aplicaciones esternes."
 
-#: src/muuli_wdr.cpp:2746
+#: src/muuli_wdr.cpp:2753
 msgid "Update Frequency (Secs):"
 msgstr "Frecuencia d'actualización (segs):"
 
-#: src/muuli_wdr.cpp:2749
+#: src/muuli_wdr.cpp:2756
 msgid "Change the frequency (in seconds) of Online Signature updates."
 msgstr "Cambiar la frecuencia (en segundos) de l'actualización de la robla-online"
 
-#: src/muuli_wdr.cpp:2757
+#: src/muuli_wdr.cpp:2764
 msgid "Save online signature file in: "
 msgstr "Guardar ficheru de robla online en: "
 
-#: src/muuli_wdr.cpp:2763
+#: src/muuli_wdr.cpp:2770
 msgid "Click here to select the directory containing the the Online Signature files."
 msgstr "Click equí pa seleicionar el direutoriu que contién los ficheros de robles-online."
 
-#: src/muuli_wdr.cpp:2796
+#: src/muuli_wdr.cpp:2803
 msgid "Show country flags for clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2797
+#: src/muuli_wdr.cpp:2804
 msgid "Render the country flag column in the transfers, queue and search views. Requires a valid MMDB GeoIP database (see below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2802
+#: src/muuli_wdr.cpp:2809
 #, fuzzy
 msgid "Database"
 msgstr "Fluxu de datos :"
 
-#: src/muuli_wdr.cpp:2818
+#: src/muuli_wdr.cpp:2825
 #, fuzzy
 msgid "Source:"
 msgstr "Fontes"
 
-#: src/muuli_wdr.cpp:2821
+#: src/muuli_wdr.cpp:2828
 msgid "DB-IP (free, no account)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2822
+#: src/muuli_wdr.cpp:2829
 msgid "MaxMind GeoLite2 (free, account required)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2823
+#: src/muuli_wdr.cpp:2830
 msgid "Custom URL"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2826
+#: src/muuli_wdr.cpp:2833
 msgid "Choose which provider supplies the GeoIP MMDB database. DB-IP is the default - no account required. MaxMind requires a free account + license key. Use Custom URL to point at any other MMDB host (e.g. a local mirror)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2843
+#: src/muuli_wdr.cpp:2850
 msgid ""
 "No configuration required.\n"
 "\n"
@@ -4855,11 +4869,11 @@ msgid ""
 "License: Creative Commons BY 4.0 - https://creativecommons.org/licenses/by/4.0/"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2856
+#: src/muuli_wdr.cpp:2863
 msgid "License key:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2862
+#: src/muuli_wdr.cpp:2869
 msgid ""
 "Sign up for a free MaxMind account, then generate a License Key:\n"
 "https://www.maxmind.com/en/geolite2/signup\n"
@@ -4869,232 +4883,232 @@ msgid ""
 "Requires attribution and account registration; refresh at least every 30 days."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2877
+#: src/muuli_wdr.cpp:2884
 #, fuzzy
 msgid "Download URL:"
 msgstr "Descargáu:"
 
-#: src/muuli_wdr.cpp:2883
+#: src/muuli_wdr.cpp:2890
 msgid ""
 "Must point to an .mmdb file or a .gz / .tar.gz containing one.\n"
 "URL may include credentials (https://user:pass@host/...).\n"
 "License and attribution terms are set by the upstream URL - you are responsible."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2896
+#: src/muuli_wdr.cpp:2903
 msgid "Download the GeoIP database from the selected source."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2898
+#: src/muuli_wdr.cpp:2905
 #, fuzzy
 msgid "Auto-update on startup"
 msgstr "Auto-actualizar el fieltráu de IPs al entamu"
 
-#: src/muuli_wdr.cpp:2899
+#: src/muuli_wdr.cpp:2906
 msgid "Re-download the GeoIP database from the selected source every time aMule starts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2922
+#: src/muuli_wdr.cpp:2929
 msgid "Filter incoming messages (except current chat):"
 msgstr "Fieltrar mensaxes entrantes (sacantes conversación actual):"
 
-#: src/muuli_wdr.cpp:2924
+#: src/muuli_wdr.cpp:2931
 msgid "Filter all messages"
 msgstr "Fieltrar tolos mensaxes"
 
-#: src/muuli_wdr.cpp:2926
+#: src/muuli_wdr.cpp:2933
 msgid "Filter messages from people not on your friend list"
 msgstr "Fieltrar mensaxes de xente que nun ta na to llista de collacios"
 
-#: src/muuli_wdr.cpp:2928
+#: src/muuli_wdr.cpp:2935
 msgid "Filter messages from unknown clients"
 msgstr "Fieltrar mensaxes de veceros desconocíos"
 
-#: src/muuli_wdr.cpp:2930
+#: src/muuli_wdr.cpp:2937
 msgid "Filter messages containing (use ',' as separator):"
 msgstr "Fieltrar mensaxes que contienen (usa ',' como separtador):"
 
-#: src/muuli_wdr.cpp:2933 src/muuli_wdr.cpp:2944
+#: src/muuli_wdr.cpp:2940 src/muuli_wdr.cpp:2951
 msgid "add here the words amule should filter and block messages including it"
 msgstr "amiesta equí les pallabres que amule tien de fieltrar y bloquiar mensaxes incluyíos"
 
-#: src/muuli_wdr.cpp:2935
+#: src/muuli_wdr.cpp:2942
 msgid "Show received messages in the log"
 msgstr "Amosar mensaxes recibíos nel rexistru"
 
-#: src/muuli_wdr.cpp:2938
+#: src/muuli_wdr.cpp:2945
 msgid "Comments"
 msgstr "Comentarios"
 
-#: src/muuli_wdr.cpp:2941
+#: src/muuli_wdr.cpp:2948
 msgid "Filter comments containing (use ',' as separator):"
 msgstr "Fieltrar comentarios que contengan (usar ',' como separtador):"
 
-#: src/muuli_wdr.cpp:2966
+#: src/muuli_wdr.cpp:2973
 msgid "Enable Proxy"
 msgstr "Habilitar Proxy"
 
-#: src/muuli_wdr.cpp:2967
+#: src/muuli_wdr.cpp:2974
 msgid "Enable/disable proxy support"
 msgstr "Habilitar/Deshabilitar soporte Proxy"
 
-#: src/muuli_wdr.cpp:2970
+#: src/muuli_wdr.cpp:2977
 msgid "Proxy type:"
 msgstr "Triba Proxy:"
 
-#: src/muuli_wdr.cpp:2981
+#: src/muuli_wdr.cpp:2988
 msgid "Proxy host:"
 msgstr "Sirvidor Proxy:"
 
-#: src/muuli_wdr.cpp:2984
+#: src/muuli_wdr.cpp:2991
 msgid "The proxy host name"
 msgstr "Nome del host del proxy"
 
-#: src/muuli_wdr.cpp:2986
+#: src/muuli_wdr.cpp:2993
 msgid "Proxy port:"
 msgstr "Puertu Proxy:"
 
-#: src/muuli_wdr.cpp:2989
+#: src/muuli_wdr.cpp:2996
 msgid "The proxy port"
 msgstr "El puertu del proxy"
 
-#: src/muuli_wdr.cpp:2991
+#: src/muuli_wdr.cpp:2998
 msgid "Enable authentication"
 msgstr "Habilitar autentificación"
 
-#: src/muuli_wdr.cpp:2992
+#: src/muuli_wdr.cpp:2999
 msgid "Enable/disable username/password authentication"
 msgstr "Habilita/deshabilita autentificación usuariu/contraseña"
 
-#: src/muuli_wdr.cpp:2995
+#: src/muuli_wdr.cpp:3002
 msgid "Username: "
 msgstr "Nome d'usuariu:"
 
-#: src/muuli_wdr.cpp:2998
+#: src/muuli_wdr.cpp:3005
 msgid "The username to use to connect to the proxy"
 msgstr "El nome d'usuariu a usar pa coneutar al proxy"
 
-#: src/muuli_wdr.cpp:3000
+#: src/muuli_wdr.cpp:3007
 msgid "Password:"
 msgstr "Contraseña:"
 
-#: src/muuli_wdr.cpp:3003
+#: src/muuli_wdr.cpp:3010
 msgid "The password to use to connect to the proxy"
 msgstr "La contraseña a usar pa coneutar al proxy"
 
-#: src/muuli_wdr.cpp:3022
+#: src/muuli_wdr.cpp:3029
 msgid "Connect to:"
 msgstr "Coneutar a:"
 
-#: src/muuli_wdr.cpp:3031
+#: src/muuli_wdr.cpp:3038
 msgid "Login to remote amule"
 msgstr "Conexón a aMule remotu"
 
-#: src/muuli_wdr.cpp:3036
+#: src/muuli_wdr.cpp:3043
 msgid "User name"
 msgstr "Nome usuariu:"
 
-#: src/muuli_wdr.cpp:3047
+#: src/muuli_wdr.cpp:3054
 msgid "Remember those settings"
 msgstr "Remembrar estes opciones"
 
-#: src/muuli_wdr.cpp:3050
+#: src/muuli_wdr.cpp:3057
 #, fuzzy
 msgid "Force ZLIB compression"
 msgstr "Usar compresión gzip"
 
-#: src/muuli_wdr.cpp:3074
+#: src/muuli_wdr.cpp:3081
 msgid "Enable Verbose Debug-Logging."
 msgstr "Habilita mou estendíu de depuración al aniciu"
 
-#: src/muuli_wdr.cpp:3076
+#: src/muuli_wdr.cpp:3083
 #, fuzzy
 msgid "Only to Logfile"
 msgstr "&Abrir el ficheru"
 
-#: src/muuli_wdr.cpp:3078
+#: src/muuli_wdr.cpp:3085
 msgid "Message Categories:"
 msgstr "Mensaxes de categoríes:"
 
-#: src/muuli_wdr.cpp:3102 src/PartFileConvertDlg.cpp:160
+#: src/muuli_wdr.cpp:3109 src/PartFileConvertDlg.cpp:160
 msgid "Waiting..."
 msgstr "Esperando..."
 
-#: src/muuli_wdr.cpp:3122
+#: src/muuli_wdr.cpp:3129
 msgid "Add imports"
 msgstr "Amestar imports"
 
-#: src/muuli_wdr.cpp:3125
+#: src/muuli_wdr.cpp:3132
 msgid "Retry selected"
 msgstr "Reintentar seleicionáu"
 
-#: src/muuli_wdr.cpp:3127
+#: src/muuli_wdr.cpp:3134
 msgid "Remove selected"
 msgstr "Desaniciar seleicionáu"
 
-#: src/muuli_wdr.cpp:3190
+#: src/muuli_wdr.cpp:3197
 msgid "Event Types"
 msgstr "Tipos Eventos"
 
-#: src/muuli_wdr.cpp:3209
+#: src/muuli_wdr.cpp:3216
 msgid "Statistics and queued clients for selected file(s) : Session / All time"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3233
+#: src/muuli_wdr.cpp:3240
 #, fuzzy
 msgid "Active Uploads"
 msgstr "Xubes aceutaes :"
 
-#: src/muuli_wdr.cpp:3247
+#: src/muuli_wdr.cpp:3254
 msgid "Percent of total files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3299
+#: src/muuli_wdr.cpp:3306
 #, fuzzy
 msgid "Show Clients for"
 msgstr "Amosar Veceros"
 
-#: src/muuli_wdr.cpp:3301
+#: src/muuli_wdr.cpp:3308
 #, fuzzy
 msgid "All files"
 msgstr "Anubre los ficheros compartíos"
 
-#: src/muuli_wdr.cpp:3304
+#: src/muuli_wdr.cpp:3311
 #, fuzzy
 msgid "Selected files"
 msgstr "Seleicionar fieltru de vistes"
 
-#: src/muuli_wdr.cpp:3307
+#: src/muuli_wdr.cpp:3314
 #, fuzzy
 msgid "Active uploads only"
 msgstr "Xubes actives"
 
-#: src/muuli_wdr.cpp:3314
+#: src/muuli_wdr.cpp:3321
 #, fuzzy
 msgid "Reload:"
 msgstr "Recargar llista"
 
-#: src/muuli_wdr.cpp:3318
+#: src/muuli_wdr.cpp:3325
 msgid "Reload your shared files"
 msgstr "Recargar los tos ficheros compartíos"
 
-#: src/muuli_wdr.cpp:3381
+#: src/muuli_wdr.cpp:3388
 msgid "Send"
 msgstr "Unviar"
 
-#: src/muuli_wdr.cpp:3382
+#: src/muuli_wdr.cpp:3389
 msgid "Sends the specified message."
 msgstr "Unviar un mensax específicu."
 
-#: src/muuli_wdr.cpp:3386
+#: src/muuli_wdr.cpp:3393
 msgid "Close this chat-session."
 msgstr "Zarrar esta sesión de charra"
 
-#: src/muuli_wdr.cpp:3409
+#: src/muuli_wdr.cpp:3416
 msgid "Connect to any server and/or Kad"
 msgstr "Coneutar a cualesquier sirvidor y/o Kad"
 
-#: src/muuli_wdr.cpp:3415 src/SharedFilesCtrl.cpp:142 src/Statistics.cpp:941
+#: src/muuli_wdr.cpp:3422 src/SharedFilesCtrl.cpp:142 src/Statistics.cpp:941
 msgid "Shared Files"
 msgstr "Fich compartíos"
 
@@ -5454,191 +5468,191 @@ msgstr "Descargáu"
 msgid "ERROR: Failed to open partfile '%s'"
 msgstr "ERROR: Fallu al abrir ficheru part '%s'"
 
-#: src/Preferences.cpp:673
+#: src/Preferences.cpp:674
 msgid "System default"
 msgstr "Por defeutu"
 
-#: src/Preferences.cpp:674
+#: src/Preferences.cpp:675
 msgid "Albanian"
 msgstr "Albanés"
 
-#: src/Preferences.cpp:675
+#: src/Preferences.cpp:676
 msgid "Arabic"
 msgstr "Árabe"
 
-#: src/Preferences.cpp:676
+#: src/Preferences.cpp:677
 msgid "Asturian"
 msgstr "Asturianu"
 
-#: src/Preferences.cpp:677
+#: src/Preferences.cpp:678
 msgid "Basque"
 msgstr "Euskera"
 
-#: src/Preferences.cpp:678
+#: src/Preferences.cpp:679
 msgid "Bulgarian"
 msgstr "Búlgaru"
 
-#: src/Preferences.cpp:679
+#: src/Preferences.cpp:680
 msgid "Catalan"
 msgstr "Catalán"
 
-#: src/Preferences.cpp:680
+#: src/Preferences.cpp:681
 msgid "Chinese (Simplified)"
 msgstr "Chinu (simplificáu)"
 
-#: src/Preferences.cpp:681
+#: src/Preferences.cpp:682
 msgid "Chinese (Traditional)"
 msgstr "Chinu (Tradicional)"
 
-#: src/Preferences.cpp:682
+#: src/Preferences.cpp:683
 msgid "Croatian"
 msgstr "Croata"
 
-#: src/Preferences.cpp:683
+#: src/Preferences.cpp:684
 msgid "Czech"
 msgstr "Checu"
 
-#: src/Preferences.cpp:684
+#: src/Preferences.cpp:685
 msgid "Danish"
 msgstr "Danés"
 
-#: src/Preferences.cpp:685
+#: src/Preferences.cpp:686
 msgid "Dutch"
 msgstr "Holandés"
 
-#: src/Preferences.cpp:686
+#: src/Preferences.cpp:687
 msgid "English (U.K.)"
 msgstr "Inglés (U.K.)"
 
-#: src/Preferences.cpp:687
+#: src/Preferences.cpp:688
 #, fuzzy
 msgid "English (U.S.)"
 msgstr "Inglés (U.K.)"
 
-#: src/Preferences.cpp:688
+#: src/Preferences.cpp:689
 msgid "Estonian"
 msgstr "Estoniu"
 
-#: src/Preferences.cpp:689
+#: src/Preferences.cpp:690
 msgid "Finnish"
 msgstr "Finlandés"
 
-#: src/Preferences.cpp:690
+#: src/Preferences.cpp:691
 msgid "French"
 msgstr "Francés"
 
-#: src/Preferences.cpp:691
+#: src/Preferences.cpp:692
 msgid "Galician"
 msgstr "Gallegu"
 
-#: src/Preferences.cpp:692
+#: src/Preferences.cpp:693
 msgid "German"
 msgstr "Alemán"
 
-#: src/Preferences.cpp:693
+#: src/Preferences.cpp:694
 msgid "Greek"
 msgstr "Griegu"
 
-#: src/Preferences.cpp:694
+#: src/Preferences.cpp:695
 msgid "Hebrew"
 msgstr "Hebréu"
 
-#: src/Preferences.cpp:695
+#: src/Preferences.cpp:696
 msgid "Hungarian"
 msgstr "Húngaru"
 
-#: src/Preferences.cpp:696
+#: src/Preferences.cpp:697
 msgid "Italian"
 msgstr "Italianu"
 
-#: src/Preferences.cpp:697
+#: src/Preferences.cpp:698
 msgid "Japanese"
 msgstr "Xaponés"
 
-#: src/Preferences.cpp:698
+#: src/Preferences.cpp:699
 msgid "Korean"
 msgstr "Coreanu"
 
-#: src/Preferences.cpp:699
+#: src/Preferences.cpp:700
 msgid "Latvian"
 msgstr ""
 
-#: src/Preferences.cpp:700
+#: src/Preferences.cpp:701
 msgid "Lithuanian"
 msgstr "Lituanu"
 
-#: src/Preferences.cpp:701
+#: src/Preferences.cpp:702
 msgid "Norwegian (Nynorsk)"
 msgstr "Noruegu"
 
-#: src/Preferences.cpp:702
+#: src/Preferences.cpp:703
 msgid "Polish"
 msgstr "Polacu"
 
-#: src/Preferences.cpp:703
+#: src/Preferences.cpp:704
 msgid "Portuguese"
 msgstr "Portugués"
 
-#: src/Preferences.cpp:704
+#: src/Preferences.cpp:705
 msgid "Portuguese (Brazilian)"
 msgstr "Portugués (Brasil)"
 
-#: src/Preferences.cpp:705
+#: src/Preferences.cpp:706
 #, fuzzy
 msgid "Romanian"
 msgstr "Albanés"
 
-#: src/Preferences.cpp:706
+#: src/Preferences.cpp:707
 msgid "Russian"
 msgstr "Rusu"
 
-#: src/Preferences.cpp:707
+#: src/Preferences.cpp:708
 msgid "Slovenian"
 msgstr "Eslovenu"
 
-#: src/Preferences.cpp:708
+#: src/Preferences.cpp:709
 msgid "Spanish"
 msgstr "Español"
 
-#: src/Preferences.cpp:709
+#: src/Preferences.cpp:710
 msgid "Swedish"
 msgstr "Suecu"
 
-#: src/Preferences.cpp:710
+#: src/Preferences.cpp:711
 msgid "Turkish"
 msgstr "Turcu"
 
-#: src/Preferences.cpp:711
+#: src/Preferences.cpp:712
 msgid "Ukrainian"
 msgstr "Ucranianu"
 
-#: src/Preferences.cpp:814
+#: src/Preferences.cpp:815
 #, fuzzy
 msgid "Change Language"
 msgstr "Llingua: "
 
-#: src/Preferences.cpp:878
+#: src/Preferences.cpp:879
 msgid "There are no translations installed for aMule"
 msgstr ""
 
-#: src/Preferences.cpp:879
+#: src/Preferences.cpp:880
 #, fuzzy
 msgid "No languages available"
 msgstr "Non disponible"
 
-#: src/Preferences.cpp:1010
+#: src/Preferences.cpp:1011
 msgid "no options available"
 msgstr "opciones non disponibles"
 
-#: src/Preferences.cpp:2179
+#: src/Preferences.cpp:2182
 msgid "Invalid category found, skipping"
 msgstr "Categoría inválida alcontrada, saltando"
 
-#: src/Preferences.cpp:2348
+#: src/Preferences.cpp:2351
 msgid "TCP port can't be higher than 65532 due to server UDP socket being TCP+3"
 msgstr "Puertu TCP nun pue ser más altu de 65532 darréu que'l socket del sirvidor UDP ye TCP+3"
 
-#: src/Preferences.cpp:2349
+#: src/Preferences.cpp:2352
 #, c-format
 msgid "Default port will be used (%d)"
 msgstr "Puertu por defeutu que s'usará (%d)"
@@ -6149,24 +6163,28 @@ msgstr "Recargar llista de ficheros compartíos."
 msgid "Shared folder"
 msgstr "Carpetes compartíes"
 
-#: src/SearchDlg.cpp:425
+#: src/SearchDlg.cpp:280
+msgid "Clear search history"
+msgstr ""
+
+#: src/SearchDlg.cpp:584
 msgid "It's impossible to search when both eD2k and Kademlia are disabled."
 msgstr ""
 
-#: src/SearchDlg.cpp:426 src/SearchListCtrl.cpp:858
+#: src/SearchDlg.cpp:585 src/SearchListCtrl.cpp:858
 #, fuzzy
 msgid "Search error"
 msgstr "Guetar"
 
-#: src/SearchDlg.cpp:768
+#: src/SearchDlg.cpp:929
 msgid "Min size must be smaller than max size. Max size ignored."
 msgstr "El tamañu mínimu tien de ser menor al tamañu máximu. Tamañu máximu inoráu."
 
-#: src/SearchDlg.cpp:769 src/SearchDlg.cpp:851
+#: src/SearchDlg.cpp:930 src/SearchDlg.cpp:1012
 msgid "Search warning"
 msgstr "Alerta de gueta"
 
-#: src/SearchDlg.cpp:929 src/SearchListCtrl.cpp:735
+#: src/SearchDlg.cpp:1092 src/SearchListCtrl.cpp:735
 msgid "Main"
 msgstr "Principal"
 

--- a/po/ast.po
+++ b/po/ast.po
@@ -9,8 +9,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-28 12:12+0200\n"
-"PO-Revision-Date: 2026-07-27 10:14+0000\n"
+"POT-Creation-Date: 2026-07-28 08:06+0200\n"
+"PO-Revision-Date: 2026-07-27 11:32+0000\n"
 "Last-Translator: astur <malditoastur@gmail.com>\n"
 "Language-Team: Language ast <malditoastur@gmail.com>\n"
 "Language: ast\n"
@@ -145,7 +145,7 @@ msgstr ""
 msgid "Not now"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:422 src/amuleDlg.cpp:665
+#: src/AppImageIntegration.cpp:422 src/amuleDlg.cpp:600
 msgid "Don't ask again"
 msgstr ""
 
@@ -203,83 +203,83 @@ msgstr "Fallu al abrir ficheru ED2KLinks."
 msgid "WARNING: You can't add yourself as a source for an eD2k link while having a lowid."
 msgstr "AVISU: Nun pues amestate a tí mesmu como una fonte pa un enllaz eD2k teniendo ID baxa."
 
-#: src/amule.cpp:301
+#: src/amule.cpp:300
 msgid "Now, exiting main app..."
 msgstr "Agora, saliendo de l'aplicación principal..."
 
-#: src/amule.cpp:331
+#: src/amule.cpp:330
 #, c-format
 msgid "Terminating amuleweb instance with pid '%d' ... "
 msgstr "Matando instancia amuleweb con pid `%d' ... "
 
-#: src/amule.cpp:335
+#: src/amule.cpp:334
 #, c-format
 msgid "Killing amuleweb instance with pid '%d' ... "
 msgstr "Matando instancia amuleweb con pid `%d' ... "
 
-#: src/amule.cpp:337 src/amule.cpp:350 src/ClientRef.cpp:180
-#: src/SearchDlg.cpp:1041 src/ServerListCtrl.cpp:98
+#: src/amule.cpp:336 src/amule.cpp:349 src/ClientRef.cpp:180
+#: src/SearchDlg.cpp:880 src/ServerListCtrl.cpp:98
 msgid "Failed"
 msgstr "Falló"
 
-#: src/amule.cpp:344
+#: src/amule.cpp:343
 #, fuzzy, c-format
 msgid "Terminating amuleapi instance with pid '%d' ... "
 msgstr "Matando instancia amuleweb con pid `%d' ... "
 
-#: src/amule.cpp:348
+#: src/amule.cpp:347
 #, fuzzy, c-format
 msgid "Killing amuleapi instance with pid '%d' ... "
 msgstr "Matando instancia amuleweb con pid `%d' ... "
 
-#: src/amule.cpp:356
+#: src/amule.cpp:355
 msgid "aMule OnExit: Terminating core."
 msgstr "aMule OnExit: Terminando núcleu."
 
-#: src/amule.cpp:467
+#: src/amule.cpp:466
 msgid "aMule shutdown completed."
 msgstr "Zarru d'aMule completáu."
 
-#: src/amule.cpp:471
+#: src/amule.cpp:470
 msgid "Memory debug results for aMule exit:"
 msgstr "Resultaos de depuración de memoria na salida d'aMule: "
 
-#: src/amule.cpp:652
+#: src/amule.cpp:651
 #, c-format
 msgid "Binding aMule's peer-to-peer traffic to interface: %s (HTTP updates use the default route)"
 msgstr ""
 
-#: src/amule.cpp:656
+#: src/amule.cpp:655
 #, c-format
 msgid "Binding all network traffic to interface: %s"
 msgstr ""
 
-#: src/amule.cpp:660
+#: src/amule.cpp:659
 #, c-format
 msgid "WARNING: configured network interface '%s' was not found - traffic is NOT bound to it and may leave via the default route. Check the interface name in Preferences."
 msgstr ""
 
-#: src/amule.cpp:666
+#: src/amule.cpp:665
 #, c-format
 msgid "WARNING: binding to network interface '%s' requires elevated privileges and was NOT applied - traffic may leave via the default route. Grant the capability (e.g. 'sudo setcap cap_net_raw+ep' on the aMule binary) or run with sufficient privileges."
 msgstr ""
 
-#: src/amule.cpp:674
+#: src/amule.cpp:673
 #, c-format
 msgid "WARNING: could not bind to network interface '%s' - traffic may leave via the default route."
 msgstr ""
 
-#: src/amule.cpp:733
+#: src/amule.cpp:732
 msgid "Your locale has been changed to System Default due to a configuration change. Sorry."
 msgstr "La to llingua foi camudada a la de por defeutu del sistema, darréu d'un cambéu de configuración. Siéntolo."
 
-#: src/amule.cpp:735 src/amule.cpp:1589 src/CatDialog.cpp:128
+#: src/amule.cpp:734 src/amule.cpp:1581 src/CatDialog.cpp:128
 #: src/CatDialog.cpp:136 src/CatDialog.cpp:149 src/ServerList.cpp:366
 #: src/ServerListCtrl.cpp:152
 msgid "Info"
 msgstr "Info"
 
-#: src/amule.cpp:742
+#: src/amule.cpp:741
 msgid ""
 "\n"
 "EC configuration"
@@ -287,74 +287,74 @@ msgstr ""
 "\n"
 "Configuración EC"
 
-#: src/amule.cpp:745
+#: src/amule.cpp:744
 msgid "Password set and external connections enabled."
 msgstr "Contraseña fixada y conexones esternes habilitaes."
 
-#: src/amule.cpp:755 src/KadDlg.cpp:176 src/KadDlg.cpp:185
-#: src/PrefsUnifiedDlg.cpp:1461 src/SharedFilesCtrl.cpp:476
+#: src/amule.cpp:754 src/KadDlg.cpp:176 src/KadDlg.cpp:185
+#: src/PrefsUnifiedDlg.cpp:1387 src/SharedFilesCtrl.cpp:476
 msgid "WARNING"
 msgstr "ALERTA"
 
-#: src/amule.cpp:992
+#: src/amule.cpp:991
 #, fuzzy
 msgid "Network bootstrap"
 msgstr "Redes"
 
-#: src/amule.cpp:997
+#: src/amule.cpp:996
 msgid ""
 "aMule has detected missing network bootstrap files.\n"
 "Select which ones to download:"
 msgstr ""
 
-#: src/amule.cpp:1006 src/FirstRunWizard.cpp:411
+#: src/amule.cpp:1005 src/FirstRunWizard.cpp:411
 #, fuzzy
 msgid "eD2k server list (server.met)"
 msgstr "%i sirvidor alcontráu en server.met"
 
-#: src/amule.cpp:1013 src/FirstRunWizard.cpp:416
+#: src/amule.cpp:1012 src/FirstRunWizard.cpp:416
 msgid "Kad bootstrap nodes (nodes.dat)"
 msgstr ""
 
-#: src/amule.cpp:1103
+#: src/amule.cpp:1102
 #, c-format
 msgid "web server running on pid %d"
 msgstr "sirvidor web corriendo con pid: %d"
 
-#: src/amule.cpp:1116
+#: src/amule.cpp:1115
 #, fuzzy
 msgid "You requested to run web server on startup, but the amuleweb binary cannot be run. Please install the package containing aMule web server, or build aMule from source with -DBUILD_WEBSERVER=YES and install it."
 msgstr "Solicitaste executar el sirvidor web al aniciu pero nun pudo correse'l binariu d'amuleweb. Por favor instala'l paquete que contenga'l sirvidor web d'aMule o compila aMule usando --enable-webserver y executa make install"
 
-#: src/amule.cpp:1121 src/amule.cpp:1185 src/amule.cpp:1299 src/amule.cpp:1601
+#: src/amule.cpp:1120 src/amule.cpp:1177 src/amule.cpp:1291 src/amule.cpp:1593
 #: src/amule-remote-gui.cpp:603 src/amule-remote-gui.cpp:671
 #: src/amule-remote-gui.cpp:709 src/amule-remote-gui.cpp:1282
 #: src/amule-remote-gui.cpp:1345 src/amule-remote-gui.cpp:1372
-#: src/DownloadQueue.cpp:1481 src/PrefsUnifiedDlg.cpp:1247
+#: src/DownloadQueue.cpp:1481
 msgid "ERROR"
 msgstr "FALLU"
 
-#: src/amule.cpp:1174
+#: src/amule.cpp:1166
 #, fuzzy, c-format
 msgid "amuleapi running on pid %d"
 msgstr "sirvidor web corriendo con pid: %d"
 
-#: src/amule.cpp:1180
+#: src/amule.cpp:1172
 #, fuzzy
 msgid "You requested to run amuleapi on startup, but the amuleapi binary cannot be run. Please install the package containing aMule's REST API server, or build aMule from source with -DBUILD_AMULEAPI=YES and install it."
 msgstr "Solicitaste executar el sirvidor web al aniciu pero nun pudo correse'l binariu d'amuleweb. Por favor instala'l paquete que contenga'l sirvidor web d'aMule o compila aMule usando --enable-webserver y executa make install"
 
-#: src/amule.cpp:1267
+#: src/amule.cpp:1259
 #, c-format
 msgid "Could not bind ports to the specified address: %s"
 msgstr "Nun ye dable direicionar los puertos a la direición especificada: %s"
 
-#: src/amule.cpp:1291
+#: src/amule.cpp:1283
 #, c-format
 msgid "Port %u is not available. You will be LOWID\n"
 msgstr "El puertu %u nun ta disponible. Tendrás IDBaxa\n"
 
-#: src/amule.cpp:1296
+#: src/amule.cpp:1288
 #, c-format
 msgid ""
 "Port %u is not available!\n"
@@ -369,48 +369,48 @@ msgstr ""
 "\n"
 "Comprueba la to rede y asegúrate de que'l puertu ta abiertu pa entrada y salida."
 
-#: src/amule.cpp:1393
+#: src/amule.cpp:1385
 msgid "Failed to create OnlineSig File"
 msgstr "Fallu al criar el ficheru de RoblaOnline"
 
-#: src/amule.cpp:1401
+#: src/amule.cpp:1393
 msgid "Failed to create aMule OnlineSig File"
 msgstr "Fallu al criar el ficheru de RoblaOnline aMule"
 
-#: src/amule.cpp:1564
+#: src/amule.cpp:1556
 msgid "The selected locale seems not to be installed on your box. (Note: I'll try to set it anyway)"
 msgstr "La llingua seleicionada nun paez tar instalada. (Nota: Tentará de ponese de toes formes)"
 
-#: src/amule.cpp:1574
+#: src/amule.cpp:1566
 #, c-format
 msgid "This is the first time you run aMule %s"
 msgstr "Ye la primer vegada qu'anicies aMule %s"
 
-#: src/amule.cpp:1577
+#: src/amule.cpp:1569
 msgid "This version is a testing version, updated daily, and\n"
 msgstr "Esto ye una versión de preba, actualízate diariamente, y \n"
 
-#: src/amule.cpp:1578
+#: src/amule.cpp:1570
 msgid "we give no warranty it won't break anything, burn your house,\n"
 msgstr "nun damos garantía si fraña daqué, ambura to casa,\n"
 
-#: src/amule.cpp:1579
+#: src/amule.cpp:1571
 msgid "or kill your dog. But it *should* be safe to use anyway.\n"
 msgstr "o fila la to sidra. Pero *tendría* de ser seguru de toes formes. \n"
 
-#: src/amule.cpp:1584
+#: src/amule.cpp:1576
 msgid "More information, support and new releases can found at our homepage,\n"
 msgstr "Podrás alcontrar na nuesa web, más información, sofitu y nueves versiones, \n"
 
-#: src/amule.cpp:1585
+#: src/amule.cpp:1577
 msgid "at https://amule-org.github.io, or in our IRC channel #aMule at irc.libera.chat.\n"
 msgstr "en https://amule-org.github.io, o nel nuesu canal de IRC #aMule en irc.libera.chat. \n"
 
-#: src/amule.cpp:1587
+#: src/amule.cpp:1579
 msgid "Feel free to report any bugs to https://github.com/amule-org/amule/issues"
 msgstr "Unvíanos cualesquier fallu a https://github.com/amule-org/amule/issues"
 
-#: src/amule.cpp:1599
+#: src/amule.cpp:1591
 msgid ""
 "The folder for Online Signature files you specified is INVALID!\n"
 " OnlineSignature will be DISABLED until you fix it on preferences."
@@ -418,137 +418,137 @@ msgstr ""
 "El direutoriu qu'especificaste de Robla Online nun ye válidu\n"
 "La Robla Online deshabilitóse hasta que lo igües nes opciones."
 
-#: src/amule.cpp:1662
+#: src/amule.cpp:1654
 msgid "Server hostname notified"
 msgstr "Nome sirvidor notificáu"
 
-#: src/amule.cpp:2039
+#: src/amule.cpp:2031
 #, c-format
 msgid "Disk space preallocation for file '%s' failed: %s"
 msgstr "La reserva del espaciu en discu pal ficheru '%s' falló: %s"
 
-#: src/amule.cpp:2168
+#: src/amule.cpp:2160
 msgid "ERROR: can't open logfile"
 msgstr "FALLU: nun puede abrise'l ficheru de rexistru"
 
-#: src/amule.cpp:2172
+#: src/amule.cpp:2164
 msgid "WARNING: logfile is empty. Something is wrong."
 msgstr "ALERTA: el ficheru de rexistru ta ermu. Hai daqué mal."
 
-#: src/amule.cpp:2189
+#: src/amule.cpp:2181
 msgid "Log has been reset"
 msgstr "El rexistru resetióse"
 
-#: src/amule.cpp:2213
+#: src/amule.cpp:2205
 #, c-format
 msgid "ServerMessage: %s"
 msgstr "Mensax del sirvidor: %s"
 
-#: src/amule.cpp:2256 src/IP2Country.cpp:220 src/IPFilter.cpp:514
+#: src/amule.cpp:2248 src/IP2Country.cpp:220 src/IPFilter.cpp:514
 #: src/ServerList.cpp:875
 #, c-format
 msgid "Skipped download of %s, because requested file is not newer."
 msgstr ""
 
-#: src/amule.cpp:2259
+#: src/amule.cpp:2251
 msgid "Failed to download the nodes list."
 msgstr "Fallu al descargar la llista de nodos."
 
-#: src/amule.cpp:2322
+#: src/amule.cpp:2314
 msgid "Failed to open the downloaded version check file"
 msgstr "Fallu al abrir el ficheru de comprobación de versión descargáu"
 
-#: src/amule.cpp:2325 src/amule.cpp:2344
+#: src/amule.cpp:2317 src/amule.cpp:2336
 msgid "Corrupted version check file"
 msgstr "Ficheru de comprobación de versión toyíu"
 
-#: src/amule.cpp:2367
+#: src/amule.cpp:2359
 msgid "You are using an outdated version of aMule!"
 msgstr "¡Tas usando una versión antigua de aMule!"
 
-#: src/amule.cpp:2369
+#: src/amule.cpp:2361
 #, c-format
 msgid "Your aMule version is %i.%i.%i and the latest version is %li.%li.%li"
 msgstr "La to versión de aMule ye %i.%i.%i y la cabera versión ye %li.%li.%li"
 
-#: src/amule.cpp:2373
+#: src/amule.cpp:2365
 msgid "The latest version can always be found at https://github.com/amule-org/amule/releases/latest"
 msgstr "La cabera versión pues alcontrala siempres en https://github.com/amule-org/amule/releases/latest"
 
-#: src/amule.cpp:2376
+#: src/amule.cpp:2368
 #, c-format
 msgid "WARNING: Your aMuled version is outdated: %i.%i.%i < %li.%li.%li"
 msgstr "ALERTA: La to versión de aMuled ye obsoleta: %i.%i.%i < %li.%li.%li"
 
-#: src/amule.cpp:2382
+#: src/amule.cpp:2374
 msgid "Your copy of aMule is up to date."
 msgstr "LA to copia de aMule ta actualizada."
 
-#: src/amule.cpp:2389
+#: src/amule.cpp:2381
 msgid "Failed to download the version check file"
 msgstr "Fallu al descargar el ficheru de comprobación de versión"
 
-#: src/amule.cpp:2558 src/amule-remote-gui.cpp:1133
+#: src/amule.cpp:2550 src/amule-remote-gui.cpp:1133
 #, c-format
 msgid "Users: %s | Files: %s"
 msgstr "Usuarios: %s | Ficheros: %s"
 
-#: src/amule.cpp:2559 src/amule-remote-gui.cpp:1134
+#: src/amule.cpp:2551 src/amule-remote-gui.cpp:1134
 #, c-format
 msgid "Users: E: %s K: %s | Files: E: %s K: %s"
 msgstr "Usuarios: E: %s K: %s | Ficheros: E: %s K: %s"
 
-#: src/amule.cpp:2573 src/amule-remote-gui.cpp:1147
+#: src/amule.cpp:2565 src/amule-remote-gui.cpp:1147
 msgid "No networks selected"
 msgstr "Ensin redes seleicionaes"
 
-#: src/amule.cpp:2641 src/TextClient.cpp:903
+#: src/amule.cpp:2633 src/TextClient.cpp:903
 msgid "with LowID"
 msgstr "con IDBaxa"
 
-#: src/amule.cpp:2641 src/TextClient.cpp:904
+#: src/amule.cpp:2633 src/TextClient.cpp:904
 msgid "with HighID"
 msgstr "con IDAlta"
 
-#: src/amule.cpp:2643
+#: src/amule.cpp:2635
 #, c-format
 msgid "Connected to %s %s"
 msgstr "Coneutáu a %s %s"
 
-#: src/amule.cpp:2648
+#: src/amule.cpp:2640
 #, c-format
 msgid "Connecting to %s"
 msgstr "Coneutando a %s"
 
-#: src/amule.cpp:2650
+#: src/amule.cpp:2642
 msgid "Disconnected from eD2k"
 msgstr "Desconeutáu de eD2k"
 
-#: src/amule.cpp:2659
+#: src/amule.cpp:2651
 msgid "Kad started."
 msgstr "Kad aniciáu."
 
-#: src/amule.cpp:2661
+#: src/amule.cpp:2653
 msgid "Kad stopped."
 msgstr "Kad deteníu."
 
-#: src/amule.cpp:2669
+#: src/amule.cpp:2661
 msgid "Connected to Kad (ok)"
 msgstr "Coneutáu a Kad (ok)"
 
-#: src/amule.cpp:2671
+#: src/amule.cpp:2663
 msgid "Connected to Kad (firewalled)"
 msgstr "Coneutáu a Kad (tres torgafueos)"
 
-#: src/amule.cpp:2675
+#: src/amule.cpp:2667
 msgid "Disconnected from Kad"
 msgstr "Desconeutáu de Kad"
 
-#: src/amule.cpp:2707
+#: src/amule.cpp:2699
 msgid "Kad network cannot be used if UDP port is disabled on preferences, not starting."
 msgstr "Red Kad nun pue usase si'l puertu UDP ta deshabilitáu n'opciones, non aniciando."
 
-#: src/amule.cpp:2711
+#: src/amule.cpp:2703
 msgid "Kad network disabled on preferences, not connecting."
 msgstr "Red Kad deshabilitada n'opciones, nun coneutará."
 
@@ -574,68 +574,30 @@ msgstr "Nun puede Crease un Ficheru Pid"
 msgid "ERROR: %s"
 msgstr "ERROR: %s"
 
-#: src/amuleDlg.cpp:250
+#: src/amuleDlg.cpp:236
 #, c-format
 msgid "This is aMule %s based on eMule."
 msgstr "Esto ye aMule %s basáu en eMule."
 
-#: src/amuleDlg.cpp:251
+#: src/amuleDlg.cpp:237
 #, c-format
 msgid "Running on %s"
 msgstr "Executándose en %s"
 
-#: src/amuleDlg.cpp:253
+#: src/amuleDlg.cpp:239
 msgid "Visit https://github.com/amule-org/amule/releases/latest to check if a new version is available."
 msgstr "Visita https://github.com/amule-org/amule/releases/latest pa comprobar si hai una nueva versión disponible"
 
-#: src/amuleDlg.cpp:282
+#: src/amuleDlg.cpp:268
 msgid "FATAL ERROR: Failed to create Timer"
 msgstr "FALLU GRAVE: Nun pudo criase'l temporizador"
 
-#: src/amuleDlg.cpp:361 src/amuleDlg.cpp:1810 src/amuleDlg.cpp:2056
-#: src/muuli_wdr.cpp:1492 src/muuli_wdr.cpp:3439
-msgid "Networks"
-msgstr "Redes"
-
-#: src/amuleDlg.cpp:362 src/amuleDlg.cpp:1816 src/muuli_wdr.cpp:3440
-msgid "Searches"
-msgstr "Guetar"
-
-#: src/amuleDlg.cpp:363 src/amuleDlg.cpp:1822 src/DownloadListCtrl.cpp:740
-#: src/muuli_wdr.cpp:392 src/muuli_wdr.cpp:1585 src/muuli_wdr.cpp:3441
-#: src/Statistics.cpp:829
-msgid "Downloads"
-msgstr "Descargues"
-
-#: src/amuleDlg.cpp:364 src/amuleDlg.cpp:1828 src/muuli_wdr.cpp:3315
-msgid "Shared files"
-msgstr "Ficheros compartíos"
-
-#: src/amuleDlg.cpp:365 src/amuleDlg.cpp:1834 src/muuli_wdr.cpp:2947
-#: src/muuli_wdr.cpp:3397 src/muuli_wdr.cpp:3444
-msgid "Messages"
-msgstr "Mensaxes"
-
-#: src/amuleDlg.cpp:366 src/amuleDlg.cpp:1840 src/muuli_wdr.cpp:3445
-#: src/PrefsUnifiedDlg.cpp:314 src/Statistics.cpp:779 src/Statistics.cpp:1235
-msgid "Statistics"
-msgstr "Estadístiques"
-
-#: src/amuleDlg.cpp:368 src/amuleDlg.cpp:1847 src/muuli_wdr.cpp:3447
-#: src/PrefsUnifiedDlg.cpp:330 src/utils/wxCas/src/wxcasprefs.cpp:39
-msgid "Preferences"
-msgstr "Preferencies"
-
-#: src/amuleDlg.cpp:371
-msgid "Navigate"
-msgstr ""
-
-#: src/amuleDlg.cpp:657
+#: src/amuleDlg.cpp:592
 #, fuzzy
 msgid "New version available"
 msgstr "Non disponible"
 
-#: src/amuleDlg.cpp:661
+#: src/amuleDlg.cpp:596
 #, fuzzy, c-format
 msgid ""
 "A new version of aMule (%s) is available.\n"
@@ -645,186 +607,219 @@ msgid ""
 "Would you like to open the download page?"
 msgstr "La cabera versión pues alcontrala siempres en https://github.com/amule-org/amule/releases/latest"
 
-#: src/amuleDlg.cpp:743
+#: src/amuleDlg.cpp:678
 msgid "aMule dialog destroyed"
 msgstr "Diálogu aMule afaráu"
 
-#: src/amuleDlg.cpp:766 src/DataToText.cpp:68 src/IPFilter.cpp:547
+#: src/amuleDlg.cpp:701 src/DataToText.cpp:68 src/IPFilter.cpp:547
 msgid "Connecting"
 msgstr "Coneutando"
 
-#: src/amuleDlg.cpp:958
+#: src/amuleDlg.cpp:893
 msgid "eD2k: Connecting"
 msgstr "eD2k: Coneutando"
 
-#: src/amuleDlg.cpp:962
+#: src/amuleDlg.cpp:897
 msgid "eD2k: Disconnected"
 msgstr "eD2k: Desconeutáu"
 
-#: src/amuleDlg.cpp:968
+#: src/amuleDlg.cpp:903
 msgid "Kad: Firewalled"
 msgstr "Kad: Tres Tornafueos"
 
-#: src/amuleDlg.cpp:972
+#: src/amuleDlg.cpp:907
 msgid "Kad: Connected"
 msgstr "Kad: Coneutáu"
 
-#: src/amuleDlg.cpp:977
+#: src/amuleDlg.cpp:912
 msgid "Kad: Connecting"
 msgstr "Kad: Coneutando"
 
-#: src/amuleDlg.cpp:981
+#: src/amuleDlg.cpp:916
 msgid "Kad: Off"
 msgstr "Kad: Apagada"
 
-#: src/amuleDlg.cpp:1029 src/DownloadListCtrl.cpp:505
+#: src/amuleDlg.cpp:964 src/DownloadListCtrl.cpp:505
 #: src/DownloadListCtrl.cpp:749 src/FriendListCtrl.cpp:180
 #: src/muuli_wdr.cpp:731 src/muuli_wdr.cpp:782 src/muuli_wdr.cpp:846
-#: src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2252 src/muuli_wdr.cpp:2337
-#: src/muuli_wdr.cpp:3085 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
+#: src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2224 src/muuli_wdr.cpp:2309
+#: src/muuli_wdr.cpp:3057 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
 #: src/ServerListCtrl.cpp:606 src/TransferWnd.cpp:378
 #: src/utils/wxCas/src/wxcasprefs.cpp:235
 msgid "Cancel"
 msgstr "Encaboxar"
 
-#: src/amuleDlg.cpp:1030
+#: src/amuleDlg.cpp:965
 msgid "Stop the current connection attempts"
 msgstr "Detener los intentos de conexón actuales"
 
-#: src/amuleDlg.cpp:1035 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976
-#: src/muuli_wdr.cpp:2475
+#: src/amuleDlg.cpp:970 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976
+#: src/muuli_wdr.cpp:2447
 msgid "Disconnect"
 msgstr "Desconeutar"
 
-#: src/amuleDlg.cpp:1036
+#: src/amuleDlg.cpp:971
 msgid "Disconnect from the currently connected networks"
 msgstr "Desconeutase de les redes coneutaes"
 
-#: src/amuleDlg.cpp:1041 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979
-#: src/muuli_wdr.cpp:2630 src/muuli_wdr.cpp:3082 src/muuli_wdr.cpp:3437
+#: src/amuleDlg.cpp:976 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979
+#: src/muuli_wdr.cpp:2602 src/muuli_wdr.cpp:3054 src/muuli_wdr.cpp:3409
 msgid "Connect"
 msgstr "Coneutar"
 
-#: src/amuleDlg.cpp:1042
+#: src/amuleDlg.cpp:977
 msgid "Connect to the currently enabled networks"
 msgstr "Coneutase a les redes disponibles"
 
-#: src/amuleDlg.cpp:1154
+#: src/amuleDlg.cpp:1089
 #, fuzzy, c-format
 msgid "Up: %.1f%s (%.1f) | Down: %.1f%s (%.1f)"
 msgstr "Xu: %.1f(%.1f) | Desc: %.1f(%.1f)"
 
-#: src/amuleDlg.cpp:1156 src/amuleDlg.cpp:1158 src/amuleDlg.cpp:1162
-#: src/amuleDlg.cpp:1164 src/amuleDlg.cpp:1175 src/amuleDlg.cpp:1177
+#: src/amuleDlg.cpp:1091 src/amuleDlg.cpp:1093 src/amuleDlg.cpp:1097
+#: src/amuleDlg.cpp:1099 src/amuleDlg.cpp:1110 src/amuleDlg.cpp:1112
 #: src/MuleTrayIcon.cpp:796 src/MuleTrayIcon.cpp:799
 #, fuzzy
 msgid " MB/s"
 msgstr "MB/s"
 
-#: src/amuleDlg.cpp:1156 src/amuleDlg.cpp:1158 src/amuleDlg.cpp:1162
-#: src/amuleDlg.cpp:1164 src/amuleDlg.cpp:1175 src/amuleDlg.cpp:1177
+#: src/amuleDlg.cpp:1091 src/amuleDlg.cpp:1093 src/amuleDlg.cpp:1097
+#: src/amuleDlg.cpp:1099 src/amuleDlg.cpp:1110 src/amuleDlg.cpp:1112
 #: src/MuleTrayIcon.cpp:796 src/MuleTrayIcon.cpp:799
 #: src/utils/wxCas/src/wxcasframe.cpp:1041
 msgid " kB/s"
 msgstr " kB/s"
 
-#: src/amuleDlg.cpp:1161
+#: src/amuleDlg.cpp:1096
 #, fuzzy, c-format
 msgid "Up: %.1f%s | Down: %.1f%s"
 msgstr "Xu: %.1f | Desc: %.1f"
 
-#: src/amuleDlg.cpp:1193
+#: src/amuleDlg.cpp:1128
 #, c-format
 msgid "aMule (%s | Connected)"
 msgstr "aMule (%s | Coneutáu)"
 
-#: src/amuleDlg.cpp:1195
+#: src/amuleDlg.cpp:1130
 #, c-format
 msgid "aMule (%s | Disconnected)"
 msgstr "aMule (%s | Desconeutáu)"
 
-#: src/amuleDlg.cpp:1248
+#: src/amuleDlg.cpp:1183
 #, fuzzy, c-format
 msgid "Do you really want to exit %s?"
 msgstr "Daveres quies colar de aMule?"
 
-#: src/amuleDlg.cpp:1250
+#: src/amuleDlg.cpp:1185
 msgid "Exit confirmation"
 msgstr "Confirmar colar."
 
-#: src/amuleDlg.cpp:1613
+#: src/amuleDlg.cpp:1548
 msgid "Launch Command: "
 msgstr "Llanzar comandu:"
 
-#: src/amuleDlg.cpp:1632 src/muuli_wdr.cpp:1972 src/Preferences.cpp:979
+#: src/amuleDlg.cpp:1567 src/muuli_wdr.cpp:1971 src/Preferences.cpp:951
 msgid "- default -"
 msgstr "- Por defeutu -"
 
-#: src/amuleDlg.cpp:1660
+#: src/amuleDlg.cpp:1595
 #, c-format
 msgid "Skin directory '%s' does not exist"
 msgstr "El direutorio de tema '%s' nun esiste"
 
-#: src/amuleDlg.cpp:1663
+#: src/amuleDlg.cpp:1598
 #, c-format
 msgid "WARNING: Unable to open skin file '%s' for read"
 msgstr "ATENCIÓN: Nun pue abrise'l ficheru de temes '%s' pa llectura"
 
-#: src/amuleDlg.cpp:1814 src/muuli_wdr.cpp:3439
+#: src/amuleDlg.cpp:1722 src/amuleDlg.cpp:1968 src/muuli_wdr.cpp:1485
+#: src/muuli_wdr.cpp:3411
+msgid "Networks"
+msgstr "Redes"
+
+#: src/amuleDlg.cpp:1726 src/muuli_wdr.cpp:3411
 msgid "Networks Window"
 msgstr "Ventana de redes"
 
-#: src/amuleDlg.cpp:1820 src/muuli_wdr.cpp:3440
+#: src/amuleDlg.cpp:1728 src/muuli_wdr.cpp:3412
+msgid "Searches"
+msgstr "Guetar"
+
+#: src/amuleDlg.cpp:1732 src/muuli_wdr.cpp:3412
 msgid "Searches Window"
 msgstr "Ventana de gueta"
 
-#: src/amuleDlg.cpp:1826 src/muuli_wdr.cpp:3441
+#: src/amuleDlg.cpp:1734 src/DownloadListCtrl.cpp:740 src/muuli_wdr.cpp:392
+#: src/muuli_wdr.cpp:1578 src/muuli_wdr.cpp:3413 src/Statistics.cpp:829
+msgid "Downloads"
+msgstr "Descargues"
+
+#: src/amuleDlg.cpp:1738 src/muuli_wdr.cpp:3413
 #, fuzzy
 msgid "Downloads Window"
 msgstr "Descargando"
 
-#: src/amuleDlg.cpp:1832 src/muuli_wdr.cpp:3443
+#: src/amuleDlg.cpp:1740 src/muuli_wdr.cpp:3287
+msgid "Shared files"
+msgstr "Ficheros compartíos"
+
+#: src/amuleDlg.cpp:1744 src/muuli_wdr.cpp:3415
 msgid "Shared Files Window"
 msgstr "Ventana de ficheros compartíos"
 
-#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3444
+#: src/amuleDlg.cpp:1746 src/muuli_wdr.cpp:2919 src/muuli_wdr.cpp:3369
+#: src/muuli_wdr.cpp:3416
+msgid "Messages"
+msgstr "Mensaxes"
+
+#: src/amuleDlg.cpp:1750 src/muuli_wdr.cpp:3416
 msgid "Messages Window"
 msgstr "Ventana de mensaxes"
 
-#: src/amuleDlg.cpp:1844 src/muuli_wdr.cpp:3445
+#: src/amuleDlg.cpp:1752 src/muuli_wdr.cpp:3417 src/PrefsUnifiedDlg.cpp:312
+#: src/Statistics.cpp:779 src/Statistics.cpp:1235
+msgid "Statistics"
+msgstr "Estadístiques"
+
+#: src/amuleDlg.cpp:1756 src/muuli_wdr.cpp:3417
 msgid "Statistics Graph Window"
 msgstr "Ventana de gráficos d'estadístiques"
 
-#: src/amuleDlg.cpp:1851 src/muuli_wdr.cpp:3447
+#: src/amuleDlg.cpp:1759 src/muuli_wdr.cpp:3419 src/PrefsUnifiedDlg.cpp:328
+#: src/utils/wxCas/src/wxcasprefs.cpp:39
+msgid "Preferences"
+msgstr "Preferencies"
+
+#: src/amuleDlg.cpp:1763 src/muuli_wdr.cpp:3419
 msgid "Preferences Settings Window"
 msgstr "Ventana d'opciones"
 
-#: src/amuleDlg.cpp:1854 src/muuli_wdr.cpp:3448
+#: src/amuleDlg.cpp:1766 src/muuli_wdr.cpp:3420
 msgid "Import"
 msgstr "Importar"
 
-#: src/amuleDlg.cpp:1858 src/muuli_wdr.cpp:3448
+#: src/amuleDlg.cpp:1770 src/muuli_wdr.cpp:3420
 msgid "The partfile importer tool"
 msgstr "La ferramienta pa importar ficheros part"
 
-#: src/amuleDlg.cpp:1861 src/muuli_wdr.cpp:3449
+#: src/amuleDlg.cpp:1773 src/muuli_wdr.cpp:3421
 #: src/utils/aLinkCreator/src/alcframe.cpp:262
 msgid "About"
 msgstr "Tocante a"
 
-#: src/amuleDlg.cpp:1861 src/muuli_wdr.cpp:3449
+#: src/amuleDlg.cpp:1773 src/muuli_wdr.cpp:3421
 msgid "About/Help"
 msgstr "Tocante a/Aida"
 
-#: src/amuleDlg.cpp:2059
+#: src/amuleDlg.cpp:1971
 msgid "eD2k network"
 msgstr "Rede eD2k"
 
-#: src/amuleDlg.cpp:2062
+#: src/amuleDlg.cpp:1974
 msgid "Kad network"
 msgstr "Rede Kad"
 
-#: src/amuleDlg.cpp:2062
+#: src/amuleDlg.cpp:1974
 msgid "No network"
 msgstr "Ensin rede"
 
@@ -954,7 +949,7 @@ msgstr "Ficheru non alcontráu"
 msgid "The core rejected these shared folders:%s"
 msgstr ""
 
-#: src/amule-remote-gui.cpp:1336 src/ExternalConn.cpp:2346
+#: src/amule-remote-gui.cpp:1336 src/ExternalConn.cpp:2345
 msgid "Invalid link or already on list."
 msgstr "Enllaz non válidu o yá ta na llista."
 
@@ -970,7 +965,7 @@ msgstr "Nun puede crease'l direutoriu '%s' pa la categoría '%s', calteniendo di
 #: src/ClientDetailDialog.cpp:123 src/DataToText.cpp:61 src/DataToText.cpp:86
 #: src/DataToText.cpp:101 src/DataToText.cpp:136 src/DataToText.cpp:165
 #: src/DownloadListCtrl.cpp:1172 src/DownloadListCtrl.cpp:1185
-#: src/DownloadListCtrl.cpp:1196 src/ExternalConn.cpp:609
+#: src/DownloadListCtrl.cpp:1196 src/ExternalConn.cpp:608
 #: src/FileDetailDialog.cpp:203 src/FileDetailDialog.cpp:235
 #: src/FileDetailDialog.cpp:242 src/GenericClientListCtrl.cpp:1171
 #: src/GenericClientListCtrl.cpp:1182 src/GenericClientListCtrl.cpp:1192
@@ -1358,19 +1353,19 @@ msgstr "Auto [Al]"
 msgid "Very low"
 msgstr "Mui baxa"
 
-#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:743 src/muuli_wdr.cpp:2303
+#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:743 src/muuli_wdr.cpp:2275
 #: src/ServerListCtrl.cpp:263 src/ServerListCtrl.cpp:456
 #: src/SharedFilesCtrl.cpp:145
 msgid "Low"
 msgstr "Baxa"
 
-#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:744 src/muuli_wdr.cpp:2304
+#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:744 src/muuli_wdr.cpp:2276
 #: src/ServerListCtrl.cpp:266 src/ServerListCtrl.cpp:457
 #: src/SharedFilesCtrl.cpp:146
 msgid "Normal"
 msgstr "Normal"
 
-#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:745 src/muuli_wdr.cpp:2305
+#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:745 src/muuli_wdr.cpp:2277
 #: src/ServerListCtrl.cpp:269 src/ServerListCtrl.cpp:458
 #: src/SharedFilesCtrl.cpp:147
 msgid "High"
@@ -1462,8 +1457,8 @@ msgstr "Sirvidor llocal"
 msgid "Remote Server"
 msgstr "Sirvidor remotu"
 
-#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3202
-#: src/SearchDlg.cpp:119 src/TextClient.cpp:911
+#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3174
+#: src/SearchDlg.cpp:111 src/TextClient.cpp:911
 msgid "Kad"
 msgstr "Kad"
 
@@ -1534,7 +1529,7 @@ msgstr "Parte"
 msgid "Size"
 msgstr "Tamañu"
 
-#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3269
+#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3241
 msgid "Transferred"
 msgstr "Tresferío"
 
@@ -1592,7 +1587,7 @@ msgstr ""
 "Reaición dende: %s (%s)\n"
 "\n"
 
-#: src/DownloadListCtrl.cpp:746 src/muuli_wdr.cpp:2306
+#: src/DownloadListCtrl.cpp:746 src/muuli_wdr.cpp:2278
 #: src/SharedFilesCtrl.cpp:150
 msgid "Auto"
 msgstr "Auto"
@@ -1630,7 +1625,7 @@ msgid "Extended Options"
 msgstr "Opciones estendíes"
 
 #: src/DownloadListCtrl.cpp:770 src/DownloadListCtrl.cpp:822
-#: src/muuli_wdr.cpp:1790
+#: src/muuli_wdr.cpp:1789
 msgid "Preview"
 msgstr "Previsualizar"
 
@@ -1805,235 +1800,230 @@ msgstr[1] ""
 msgid "Invalid eD2k link! ERROR: %s"
 msgstr "Enllaz eD2k inválidu! FALLU: %s"
 
-#: src/ExternalConn.cpp:380
+#: src/ExternalConn.cpp:379
 msgid "Client sent packet after authentication failed."
 msgstr "El veceru unvió un paquete dempués que falló l'autenticación."
 
-#: src/ExternalConn.cpp:397
+#: src/ExternalConn.cpp:396
 msgid "External connection closed."
 msgstr "Conexón esterna zarrada."
 
-#: src/ExternalConn.cpp:474
+#: src/ExternalConn.cpp:473
 msgid "External connections disabled due to empty password!"
 msgstr "¡Conexones esternas deshabilitaes darréu d'una contraseña en blanco!"
 
-#: src/ExternalConn.cpp:495
+#: src/ExternalConn.cpp:494
 msgid "External connections disabled in config file"
 msgstr "Conexones esternas deshabilitaes nel ficheru de configuración"
 
-#: src/ExternalConn.cpp:576
+#: src/ExternalConn.cpp:575
 msgid "New external connection accepted"
 msgstr "Nueva conexón esterna, aceutada"
 
-#: src/ExternalConn.cpp:579
+#: src/ExternalConn.cpp:578
 msgid "ERROR: couldn't accept a new external connection"
 msgstr "FALLU: nun pudo aceutase una nueva conexón esterna"
 
-#: src/ExternalConn.cpp:596
+#: src/ExternalConn.cpp:595
 msgid "External connection refused due to empty password in preferences!"
 msgstr "¡Conexón esterna refugada darréu d'una contraseña en blanco nes opciones!"
 
-#: src/ExternalConn.cpp:608
+#: src/ExternalConn.cpp:607
 #, c-format
 msgid "Connecting client: %s %s"
 msgstr "Coneutando con veceru: %s %s"
 
-#: src/ExternalConn.cpp:610
+#: src/ExternalConn.cpp:609
 msgid "Unknown version"
 msgstr "Versión desconocía"
 
-#: src/ExternalConn.cpp:623
+#: src/ExternalConn.cpp:622
 msgid "Incorrect EC version ID, there might be binary incompatibility. Use core and remote from same snapshot."
 msgstr "EC Incorreutu na ID de versión, tien d'haber una incompatibilidá. Usa núcleu y remotu de la mesma versión."
 
-#: src/ExternalConn.cpp:631
+#: src/ExternalConn.cpp:630
 #, fuzzy
 msgid "You cannot connect to a release version from an arbitrary development snapshot! *sigh* possible crash prevented"
 msgstr "¡Nun pues coneutar a una versión final dende una versión SVN cualesquiera! *sigh* dable fallu evitáu"
 
-#: src/ExternalConn.cpp:714
+#: src/ExternalConn.cpp:713
 msgid "Invalid protocol version."
 msgstr "Versión de protocolu non válida"
 
-#: src/ExternalConn.cpp:720
+#: src/ExternalConn.cpp:719
 msgid "Missing protocol version tag."
 msgstr "Marcador de versión de protocolu inesistente"
 
-#: src/ExternalConn.cpp:728
+#: src/ExternalConn.cpp:727
 msgid "Authentication failed: invalid hash specified as EC password."
 msgstr ""
 
-#: src/ExternalConn.cpp:776
+#: src/ExternalConn.cpp:775
 #, fuzzy
 msgid "Authentication failed: wrong password."
 msgstr "Autenticación fallía"
 
-#: src/ExternalConn.cpp:778
+#: src/ExternalConn.cpp:777
 #, fuzzy
 msgid "Authentication failed: missing password."
 msgstr "Autenticación fallía"
 
-#: src/ExternalConn.cpp:789
+#: src/ExternalConn.cpp:788
 msgid "Invalid request, please authenticate first."
 msgstr "Solicitú non válida, tendríes d'autenticate primero."
 
-#: src/ExternalConn.cpp:794
+#: src/ExternalConn.cpp:793
 msgid "Access granted."
 msgstr "Accesu concedíu."
 
-#: src/ExternalConn.cpp:802
+#: src/ExternalConn.cpp:801
 #, fuzzy, c-format
 msgid "Sent error message \"%s\" to client."
 msgstr "Fieltrar mensaxes de veceros desconocíos"
 
-#: src/ExternalConn.cpp:807
+#: src/ExternalConn.cpp:806
 #, fuzzy, c-format
 msgid "Unauthorized access attempt from %s. Connection closed."
 msgstr "Intentu d'accesu non autorizáu. Conexón zarrada."
 
-#: src/ExternalConn.cpp:1420
+#: src/ExternalConn.cpp:1419
 #, c-format
 msgid "Remote PartFile command failed: FileHash not found: %s"
 msgstr "Fallu en comandu remotu del ficheru Part: Hash de ficheru non alcontráu: %s"
 
-#: src/ExternalConn.cpp:1424
+#: src/ExternalConn.cpp:1423
 #, c-format
 msgid "FileHash not found: %s"
 msgstr "Hash de ficheru non alcontráu: %s"
 
-#: src/ExternalConn.cpp:1471 src/ExternalConn.cpp:1559
-#: src/ExternalConn.cpp:1680
+#: src/ExternalConn.cpp:1470 src/ExternalConn.cpp:1558
+#: src/ExternalConn.cpp:1679
 msgid "OOPS! OpCode processing error!"
 msgstr "¡OOPS! ¡Fallu procesando OpCode!"
 
-#: src/ExternalConn.cpp:1502
+#: src/ExternalConn.cpp:1501
 msgid "Server not added"
 msgstr "Sirvidor non amestáu"
 
-#: src/ExternalConn.cpp:1521
+#: src/ExternalConn.cpp:1520
 #, c-format
 msgid "server not found: %s"
 msgstr "sirvidor non amestáu: %s"
 
-#: src/ExternalConn.cpp:1538
+#: src/ExternalConn.cpp:1537
 msgid "need to define server to be removed"
 msgstr "necesites definir un sirvidor pa desanicialu"
 
-#: src/ExternalConn.cpp:1553
+#: src/ExternalConn.cpp:1552
 msgid "eD2k is disabled in preferences."
 msgstr "eD2k ta desabilitáu nes preferencies"
 
-#: src/ExternalConn.cpp:1658
+#: src/ExternalConn.cpp:1657
 #, fuzzy
 msgid "Friend not found."
 msgstr "Ficheru non alcontráu"
 
-#: src/ExternalConn.cpp:1668
+#: src/ExternalConn.cpp:1667
 #, fuzzy
 msgid "Client not found."
 msgstr "Ficheru non alcontráu"
 
-#: src/ExternalConn.cpp:1674
+#: src/ExternalConn.cpp:1673
 msgid "EC_TAG_FRIEND_SHARED requires EC_TAG_FRIEND or EC_TAG_CLIENT."
 msgstr ""
 
-#: src/ExternalConn.cpp:1992
+#: src/ExternalConn.cpp:1991
 msgid "WebSearch from remote interface makes no sense."
 msgstr "Gueta web dende un interface remotu nun tien xacíu"
 
-#: src/ExternalConn.cpp:2027
+#: src/ExternalConn.cpp:2026
 msgid "Search in progress. Refetch results in a moment!"
 msgstr "Gueta en procesu. Resultaos obteníos aína! "
 
-#: src/ExternalConn.cpp:2266
+#: src/ExternalConn.cpp:2265
 msgid "No points for graph."
 msgstr "Ensin puntos pal gráficu."
 
-#: src/ExternalConn.cpp:2276
+#: src/ExternalConn.cpp:2275
 msgid "Your client is not configured for this detail level."
 msgstr "El to veceru nun ta configuráu pa esti nivel de detalle."
 
-#: src/ExternalConn.cpp:2303
+#: src/ExternalConn.cpp:2302
 msgid "External Connection: shutdown requested"
 msgstr "Conexón esterna: apagáu solicitáu"
 
-#: src/ExternalConn.cpp:2315
+#: src/ExternalConn.cpp:2314
 msgid "Already shutting down."
 msgstr "Yá tas zarrando."
 
-#: src/ExternalConn.cpp:2333
+#: src/ExternalConn.cpp:2332
 #, c-format
 msgid "ExternalConn: adding link '%s'."
 msgstr "Conexón esterna: amestando enllaz '%s'."
 
-#: src/ExternalConn.cpp:2351
+#: src/ExternalConn.cpp:2350
 #, fuzzy, c-format
 msgid "%d of %d links failed (invalid or already on list)."
 msgstr "Enllaz non válidu o yá ta na llista."
 
-#: src/ExternalConn.cpp:2374
+#: src/ExternalConn.cpp:2373
 msgid "Version check throttled; try again shortly."
 msgstr ""
 
-#: src/ExternalConn.cpp:2379
+#: src/ExternalConn.cpp:2378
 msgid "Version check is not available on this daemon."
 msgstr ""
 
-#: src/ExternalConn.cpp:2509
+#: src/ExternalConn.cpp:2508
 msgid "File not found."
 msgstr "Ficheru non alcontráu"
 
-#: src/ExternalConn.cpp:2514
+#: src/ExternalConn.cpp:2513
 msgid "Invalid file name."
 msgstr "Nome de ficheru incorreutu"
 
-#: src/ExternalConn.cpp:2522
+#: src/ExternalConn.cpp:2521
 msgid "Unable to rename file."
 msgstr "Nun ye dable renomar ficheru"
 
-#: src/ExternalConn.cpp:2839
-#, c-format
-msgid "Could not save the amuleapi password: %s"
-msgstr ""
-
-#: src/ExternalConn.cpp:3004 src/ExternalConn.cpp:3032
+#: src/ExternalConn.cpp:2992 src/ExternalConn.cpp:3020
 msgid "Kad is disabled in preferences."
 msgstr "Kad ta deshabilitáu n'opciones."
 
-#: src/ExternalConn.cpp:3045
+#: src/ExternalConn.cpp:3033
 msgid "Already connected to eD2k."
 msgstr "Yá tas coneutáu a eD2k."
 
-#: src/ExternalConn.cpp:3048
+#: src/ExternalConn.cpp:3036
 msgid "Connecting to eD2k..."
 msgstr "Coneutando a eD2k..."
 
-#: src/ExternalConn.cpp:3057
+#: src/ExternalConn.cpp:3045
 msgid "Already connected to Kad."
 msgstr "Yá tas coneutáu a Kad."
 
-#: src/ExternalConn.cpp:3060
+#: src/ExternalConn.cpp:3048
 msgid "Connecting to Kad..."
 msgstr "Coneutando a Kad..."
 
-#: src/ExternalConn.cpp:3067
+#: src/ExternalConn.cpp:3055
 msgid "All networks are disabled."
 msgstr "Toles redes tán deshabilitaes"
 
-#: src/ExternalConn.cpp:3076
+#: src/ExternalConn.cpp:3064
 msgid "Disconnected from eD2k."
 msgstr "Desconeutando de eD2k."
 
-#: src/ExternalConn.cpp:3081
+#: src/ExternalConn.cpp:3069
 msgid "Disconnected from Kad."
 msgstr "Desconeutando de Kad."
 
-#: src/ExternalConn.cpp:3090
+#: src/ExternalConn.cpp:3078
 #, c-format
 msgid "External Connection: invalid opcode received: %#x"
 msgstr "Conexón esterna: recibíu códigu d'operación inválidu: %#x"
 
-#: src/ExternalConn.cpp:3095
+#: src/ExternalConn.cpp:3083
 msgid "Invalid opcode (wrong protocol version?)"
 msgstr "opcode non válidu (¿versión de protocolu incorreuta?)"
 
@@ -2349,19 +2339,19 @@ msgstr ""
 msgid "eD2k"
 msgstr "eD2k"
 
-#: src/FirstRunWizard.cpp:349 src/muuli_wdr.cpp:1495
+#: src/FirstRunWizard.cpp:349 src/muuli_wdr.cpp:1488
 msgid "Kademlia"
 msgstr "Kademlia"
 
-#: src/FirstRunWizard.cpp:359 src/muuli_wdr.cpp:1423
+#: src/FirstRunWizard.cpp:359 src/muuli_wdr.cpp:1416
 msgid "Standard TCP Port "
 msgstr "Puertu TCP estándar "
 
-#: src/FirstRunWizard.cpp:365 src/muuli_wdr.cpp:1435
+#: src/FirstRunWizard.cpp:365 src/muuli_wdr.cpp:1428
 msgid "Extended UDP port (Kad / global search) "
 msgstr "Puertu UDP estándar (Kad / gueta global) "
 
-#: src/FirstRunWizard.cpp:377 src/muuli_wdr.cpp:1442
+#: src/FirstRunWizard.cpp:377 src/muuli_wdr.cpp:1435
 msgid "Enable UPnP for router port forwarding"
 msgstr "Habilitar UPnP pal reunvíu de puertu del router"
 
@@ -2388,7 +2378,7 @@ msgstr ""
 msgid "Your peer lists are already in place - nothing to download."
 msgstr "Yá tas descargando el ficheru %s"
 
-#: src/FirstRunWizard.cpp:434 src/muuli_wdr.cpp:1540
+#: src/FirstRunWizard.cpp:434 src/muuli_wdr.cpp:1533
 msgid "Auto-update server list at startup"
 msgstr "Auto-actualizar la llista de sirvidores al aniciu"
 
@@ -2434,23 +2424,23 @@ msgid ""
 "want downloads on a different (e.g. larger) disk."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:549 src/FirstRunWizard.cpp:611 src/muuli_wdr.cpp:1702
+#: src/FirstRunWizard.cpp:549 src/FirstRunWizard.cpp:611 src/muuli_wdr.cpp:1701
 msgid "Destination folder for downloads"
 msgstr "Carpeta de destín pa les descargues"
 
-#: src/FirstRunWizard.cpp:553 src/FirstRunWizard.cpp:569 src/muuli_wdr.cpp:1349
-#: src/muuli_wdr.cpp:1366 src/muuli_wdr.cpp:1677 src/muuli_wdr.cpp:1708
-#: src/muuli_wdr.cpp:1720 src/muuli_wdr.cpp:2790
+#: src/FirstRunWizard.cpp:553 src/FirstRunWizard.cpp:569 src/muuli_wdr.cpp:1342
+#: src/muuli_wdr.cpp:1359 src/muuli_wdr.cpp:1676 src/muuli_wdr.cpp:1707
+#: src/muuli_wdr.cpp:1719 src/muuli_wdr.cpp:2762
 #: src/utils/aLinkCreator/src/alcframe.cpp:135
 #: src/utils/wxCas/src/wxcasprefs.cpp:52 src/utils/wxCas/src/wxcasprefs.cpp:118
 msgid "Browse"
 msgstr "Desaminar"
 
-#: src/FirstRunWizard.cpp:559 src/muuli_wdr.cpp:1713
+#: src/FirstRunWizard.cpp:559 src/muuli_wdr.cpp:1712
 msgid "(All files in this folder are shared with other peers)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:565 src/FirstRunWizard.cpp:624 src/muuli_wdr.cpp:1715
+#: src/FirstRunWizard.cpp:565 src/FirstRunWizard.cpp:624 src/muuli_wdr.cpp:1714
 msgid "Folder for temporary download files"
 msgstr "Carpeta pa los ficheros temporales de descargues"
 
@@ -2481,7 +2471,7 @@ msgstr "¡ Nun pudo abrise'l ficheru de collacios 'emfriends.met' pa la so escri
 msgid "CRITICAL - no client on StartChatSession"
 msgstr "CRITICU - ensin veceru en sesión charra d'aniciu"
 
-#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2696 src/muuli_wdr.cpp:3373
+#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2668 src/muuli_wdr.cpp:3345
 msgid "Friends"
 msgstr "Collacios"
 
@@ -2595,8 +2585,8 @@ msgstr "Dengún"
 msgid "No"
 msgstr "Non"
 
-#: src/GenericClientListCtrl.cpp:1216 src/PrefsUnifiedDlg.cpp:2898
-#: src/PrefsUnifiedDlg.cpp:2948 src/ServerListCtrl.cpp:276
+#: src/GenericClientListCtrl.cpp:1216 src/PrefsUnifiedDlg.cpp:2818
+#: src/PrefsUnifiedDlg.cpp:2868 src/ServerListCtrl.cpp:276
 msgid "Yes"
 msgstr "Sí"
 
@@ -2766,10 +2756,10 @@ msgstr "Puertu non válidu pa coneutar"
 msgid "Please fill all fields required"
 msgstr "Por favor enllene tolos campos requeríos"
 
-#: src/KadDlg.cpp:192 src/PartFile.cpp:1031 src/PrefsUnifiedDlg.cpp:1134
-#: src/PrefsUnifiedDlg.cpp:1204 src/PrefsUnifiedDlg.cpp:1405
-#: src/PrefsUnifiedDlg.cpp:1663 src/PrefsUnifiedDlg.cpp:1673
-#: src/PrefsUnifiedDlg.cpp:1690 src/PrefsUnifiedDlg.cpp:1738
+#: src/KadDlg.cpp:192 src/PartFile.cpp:1031 src/PrefsUnifiedDlg.cpp:1162
+#: src/PrefsUnifiedDlg.cpp:1331 src/PrefsUnifiedDlg.cpp:1589
+#: src/PrefsUnifiedDlg.cpp:1599 src/PrefsUnifiedDlg.cpp:1616
+#: src/PrefsUnifiedDlg.cpp:1658
 msgid "Message"
 msgstr "Mensax"
 
@@ -2871,7 +2861,7 @@ msgstr "Media compartío"
 msgid "Uploaded"
 msgstr "Xubío"
 
-#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3253
+#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3225
 msgid "Requested"
 msgstr "Pidío"
 
@@ -2995,7 +2985,7 @@ msgid "WARNING: "
 msgstr "AVISU:"
 
 #: src/MuleNotebook.cpp:179 src/muuli_wdr.cpp:817 src/muuli_wdr.cpp:1229
-#: src/muuli_wdr.cpp:3157 src/muuli_wdr.cpp:3413
+#: src/muuli_wdr.cpp:3129 src/muuli_wdr.cpp:3385
 msgid "Close"
 msgstr "Zarrar"
 
@@ -3008,12 +2998,12 @@ msgstr "Cortar"
 msgid "Copy"
 msgstr "Copiar"
 
-#: src/MuleTextCtrl.cpp:88 src/SearchDlg.cpp:261
+#: src/MuleTextCtrl.cpp:88
 msgid "Paste"
 msgstr "Apegar"
 
 #: src/MuleTextCtrl.cpp:89 src/muuli_wdr.cpp:358 src/muuli_wdr.cpp:757
-#: src/muuli_wdr.cpp:2380 src/muuli_wdr.cpp:2399 src/muuli_wdr.cpp:2421
+#: src/muuli_wdr.cpp:2352 src/muuli_wdr.cpp:2371 src/muuli_wdr.cpp:2393
 #: src/utils/aLinkCreator/src/alcframe.cpp:142
 msgid "Clear"
 msgstr "Llimpiar"
@@ -3111,8 +3101,8 @@ msgid "Exit"
 msgstr "Colar"
 
 #: src/MuleTrayIcon.cpp:579 src/MuleTrayIcon.cpp:945 src/MuleTrayIcon.cpp:965
-#: src/muuli_wdr.cpp:1398 src/muuli_wdr.cpp:1406 src/muuli_wdr.cpp:1413
-#: src/muuli_wdr.cpp:1836 src/muuli_wdr.cpp:1842 src/OtherFunctions.cpp:91
+#: src/muuli_wdr.cpp:1391 src/muuli_wdr.cpp:1399 src/muuli_wdr.cpp:1406
+#: src/muuli_wdr.cpp:1835 src/muuli_wdr.cpp:1841 src/OtherFunctions.cpp:91
 #: src/StatisticsDlg.cpp:93 src/StatisticsDlg.cpp:95
 msgid "kB/s"
 msgstr "kB/s"
@@ -3283,7 +3273,7 @@ msgstr "Nome:"
 msgid "Type"
 msgstr "Triba"
 
-#: src/muuli_wdr.cpp:215 src/SearchDlg.cpp:118 src/SearchListCtrl.cpp:853
+#: src/muuli_wdr.cpp:215 src/SearchDlg.cpp:110 src/SearchListCtrl.cpp:853
 msgid "Local"
 msgstr "Llocal"
 
@@ -3354,7 +3344,7 @@ msgstr "Bytes"
 msgid "KB"
 msgstr "KB"
 
-#: src/muuli_wdr.cpp:274 src/muuli_wdr.cpp:293 src/muuli_wdr.cpp:1621
+#: src/muuli_wdr.cpp:274 src/muuli_wdr.cpp:293 src/muuli_wdr.cpp:1620
 #: src/OtherFunctions.cpp:64
 msgid "MB"
 msgstr "MB"
@@ -3371,7 +3361,7 @@ msgstr "Tamañu Máx"
 msgid "Availability"
 msgstr "Disponibilidá"
 
-#: src/muuli_wdr.cpp:312 src/muuli_wdr.cpp:398 src/muuli_wdr.cpp:3318
+#: src/muuli_wdr.cpp:312 src/muuli_wdr.cpp:398 src/muuli_wdr.cpp:3290
 msgid "Filter:"
 msgstr "Fieltru:"
 
@@ -3403,7 +3393,7 @@ msgstr ""
 msgid "Stop"
 msgstr "Encaboxar"
 
-#: src/muuli_wdr.cpp:348 src/muuli_wdr.cpp:1392 src/SearchListCtrl.cpp:732
+#: src/muuli_wdr.cpp:348 src/muuli_wdr.cpp:1385 src/SearchListCtrl.cpp:732
 msgid "Download"
 msgstr "Descarga"
 
@@ -3435,12 +3425,12 @@ msgstr "Fontes completes"
 #: src/muuli_wdr.cpp:1160 src/muuli_wdr.cpp:1167 src/muuli_wdr.cpp:1172
 #: src/muuli_wdr.cpp:1179 src/muuli_wdr.cpp:1184 src/muuli_wdr.cpp:1191
 #: src/muuli_wdr.cpp:1205 src/muuli_wdr.cpp:1212 src/muuli_wdr.cpp:1217
-#: src/muuli_wdr.cpp:1224 src/muuli_wdr.cpp:3255 src/muuli_wdr.cpp:3263
-#: src/muuli_wdr.cpp:3271
+#: src/muuli_wdr.cpp:1224 src/muuli_wdr.cpp:3227 src/muuli_wdr.cpp:3235
+#: src/muuli_wdr.cpp:3243
 msgid "N/A"
 msgstr "N/A"
 
-#: src/muuli_wdr.cpp:508 src/muuli_wdr.cpp:1065 src/PrefsUnifiedDlg.cpp:299
+#: src/muuli_wdr.cpp:508 src/muuli_wdr.cpp:1065 src/PrefsUnifiedDlg.cpp:297
 msgid "General"
 msgstr "Xeneral"
 
@@ -3581,7 +3571,7 @@ msgstr ""
 msgid "Album :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:685 src/muuli_wdr.cpp:2275
+#: src/muuli_wdr.cpp:685 src/muuli_wdr.cpp:2247
 msgid "Title :"
 msgstr "Títulu :"
 
@@ -3690,7 +3680,7 @@ msgstr "Nome d'usuariu :"
 msgid "Userhash :"
 msgstr "Hash del usuariu :"
 
-#: src/muuli_wdr.cpp:895 src/muuli_wdr.cpp:1742 src/muuli_wdr.cpp:2470
+#: src/muuli_wdr.cpp:895 src/muuli_wdr.cpp:1741 src/muuli_wdr.cpp:2442
 #: src/utils/aLinkCreator/src/alcframe.cpp:137
 msgid "Add"
 msgstr "Amestar"
@@ -3699,15 +3689,15 @@ msgstr "Amestar"
 msgid "Download-Speed"
 msgstr "Velocidá de descarga"
 
-#: src/muuli_wdr.cpp:954 src/muuli_wdr.cpp:989 src/muuli_wdr.cpp:2574
+#: src/muuli_wdr.cpp:954 src/muuli_wdr.cpp:989 src/muuli_wdr.cpp:2546
 msgid "Current"
 msgstr "Actual"
 
-#: src/muuli_wdr.cpp:962 src/muuli_wdr.cpp:997 src/muuli_wdr.cpp:2582
+#: src/muuli_wdr.cpp:962 src/muuli_wdr.cpp:997 src/muuli_wdr.cpp:2554
 msgid "Running average"
 msgstr "Media d'execución"
 
-#: src/muuli_wdr.cpp:970 src/muuli_wdr.cpp:1005 src/muuli_wdr.cpp:2590
+#: src/muuli_wdr.cpp:970 src/muuli_wdr.cpp:1005 src/muuli_wdr.cpp:2562
 msgid "Session average"
 msgstr "Media de la sesión"
 
@@ -3719,7 +3709,7 @@ msgstr "Velocidá de xuba"
 msgid "Connections"
 msgstr "Conexones"
 
-#: src/muuli_wdr.cpp:1024 src/muuli_wdr.cpp:1861
+#: src/muuli_wdr.cpp:1024 src/muuli_wdr.cpp:1860
 msgid "Active downloads"
 msgstr "Descargues actives"
 
@@ -3727,7 +3717,7 @@ msgstr "Descargues actives"
 msgid "Active connections (1:1)"
 msgstr "Conexones actives (1:1)"
 
-#: src/muuli_wdr.cpp:1040 src/muuli_wdr.cpp:1862
+#: src/muuli_wdr.cpp:1040 src/muuli_wdr.cpp:1861
 msgid "Active uploads"
 msgstr "Xubes actives"
 
@@ -3844,8 +3834,8 @@ msgstr "Esti ye'l nome que verán los otros usuarios verán cuando se coneuten a
 msgid "Language: "
 msgstr "Llingua: "
 
-#: src/muuli_wdr.cpp:1257 src/muuli_wdr.cpp:1330 src/muuli_wdr.cpp:1334
-#: src/muuli_wdr.cpp:1337
+#: src/muuli_wdr.cpp:1257 src/muuli_wdr.cpp:1323 src/muuli_wdr.cpp:1327
+#: src/muuli_wdr.cpp:1330
 msgid "The delay before showing tool-tips."
 msgstr "Allanciu enantes d'amosar los mensaxes emerxentes."
 
@@ -3923,965 +3913,941 @@ msgstr ""
 msgid "Enabling this will make aMule to show notifications when finished downloading."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1323
-#, fuzzy
-msgid "Remember search history"
-msgstr "Remembrar estes opciones"
-
-#: src/muuli_wdr.cpp:1324
-msgid "Keeps a dropdown list of your past search terms in the Search tab's Name field. This remembers the queries you typed, not the results they returned."
-msgstr ""
-
-#: src/muuli_wdr.cpp:1329
+#: src/muuli_wdr.cpp:1322
 msgid "Tooltip delay time: "
 msgstr "Tiempu d'allanciu de los mensaxes emerxentes: "
 
-#: src/muuli_wdr.cpp:1336
+#: src/muuli_wdr.cpp:1329
 msgid "seconds"
 msgstr "segundos"
 
-#: src/muuli_wdr.cpp:1340
+#: src/muuli_wdr.cpp:1333
 msgid "Browser Selection"
 msgstr "Seleición del restolador"
 
-#: src/muuli_wdr.cpp:1346
+#: src/muuli_wdr.cpp:1339
 msgid "Enter your browser name here. Leave this field empty to use the system default browser."
 msgstr "Introduz el nome del to restolador. Déxalo ermo si quies usar el que hai por defeutu."
 
-#: src/muuli_wdr.cpp:1353
+#: src/muuli_wdr.cpp:1346
 msgid "Open in new tab if possible"
 msgstr "Abrir en nueva llingüeta si ye dable"
 
-#: src/muuli_wdr.cpp:1355
+#: src/muuli_wdr.cpp:1348
 msgid "Open the web page in a new tab instead of in a new window when possible"
 msgstr "Abrir cuando seya dable, la páxina web nuna nueva llingüeta n'arroú de nuna nueva ventana"
 
-#: src/muuli_wdr.cpp:1359
+#: src/muuli_wdr.cpp:1352
 msgid "Video Player"
 msgstr "Reproductor de vídeu"
 
-#: src/muuli_wdr.cpp:1386
+#: src/muuli_wdr.cpp:1379
 msgid "Bandwidth limits"
 msgstr "Llímites del anchor de banda"
 
-#: src/muuli_wdr.cpp:1400
+#: src/muuli_wdr.cpp:1393
 msgid "Upload"
 msgstr "Xuba"
 
-#: src/muuli_wdr.cpp:1408
+#: src/muuli_wdr.cpp:1401
 msgid "Slot Allocation"
 msgstr "Asignación de puestu reserváu"
 
-#: src/muuli_wdr.cpp:1417
+#: src/muuli_wdr.cpp:1410
 msgid "Ports"
 msgstr "Puertos"
 
-#: src/muuli_wdr.cpp:1427
+#: src/muuli_wdr.cpp:1420
 msgid "This is the standard eD2k port and cannot be disabled."
 msgstr "Esti ye'l puertu eD2k estándar y nun pue deshabilitase"
 
-#: src/muuli_wdr.cpp:1430
+#: src/muuli_wdr.cpp:1423
 msgid "UDP port for server requests (TCP+3):"
 msgstr "Puertu UDP pa peticiones del sirvidor (TCP+3):"
 
-#: src/muuli_wdr.cpp:1432
+#: src/muuli_wdr.cpp:1425
 msgid "4665"
 msgstr "4665"
 
-#: src/muuli_wdr.cpp:1439
+#: src/muuli_wdr.cpp:1432
 msgid "This UDP port is used for extended eD2k requests and Kad network"
 msgstr "Esti puertu UDP úsase pa peticiones estendíes de eD2k y la rede Kad"
 
-#: src/muuli_wdr.cpp:1446
+#: src/muuli_wdr.cpp:1439
 msgid "UPnP TCP Port (Optional):"
 msgstr "Puertu UPnP TCP (Opcional):"
 
-#: src/muuli_wdr.cpp:1456
+#: src/muuli_wdr.cpp:1449
 msgid "Bind local address to IP (empty for any):"
 msgstr "Señes IP llocal de enllaz: (erma pa cualesquiera):"
 
-#: src/muuli_wdr.cpp:1459
+#: src/muuli_wdr.cpp:1452
 msgid "Advanced users only: If you have multiple network interfaces, enter the address of the interface to which aMule should be bound."
 msgstr "Namái usuarios avanzaos: Si tu tienes múltiples tarxetes de rede, introduz la direición de la tarxeta, que aMule tendrá d'usar."
 
-#: src/muuli_wdr.cpp:1462 src/muuli_wdr.cpp:2055
+#: src/muuli_wdr.cpp:1455 src/muuli_wdr.cpp:2054
 #, fuzzy
 msgid "Bind to network interface (empty for any):"
 msgstr "Señes IP llocal de enllaz: (erma pa cualesquiera):"
 
-#: src/muuli_wdr.cpp:1475
+#: src/muuli_wdr.cpp:1468
 msgid "Advanced users only: pin all of aMule's traffic to one network interface, chosen from the list or typed in by name (e.g. tun0, eth0, en0) or index. Unlike binding to an IP, this stops traffic leaking out via the default route - useful with a VPN. Requires no elevated privileges."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1481
+#: src/muuli_wdr.cpp:1474
 msgid "Max sources per downloading file:"
 msgstr "Max. fontes descargando un ficheru:"
 
-#: src/muuli_wdr.cpp:1485
+#: src/muuli_wdr.cpp:1478
 msgid "Max simultaneous connections:"
 msgstr "Máx. conexones al empar:"
 
-#: src/muuli_wdr.cpp:1498 src/muuli_wdr.cpp:3197
+#: src/muuli_wdr.cpp:1491 src/muuli_wdr.cpp:3169
 msgid "ED2K"
 msgstr "ED2K"
 
-#: src/muuli_wdr.cpp:1505
+#: src/muuli_wdr.cpp:1498
 msgid "Autoconnect on startup"
 msgstr "Autoconeutar al aniciar"
 
-#: src/muuli_wdr.cpp:1508
+#: src/muuli_wdr.cpp:1501
 msgid "Reconnect on loss"
 msgstr "Reconeutar al perder la conexón"
 
-#: src/muuli_wdr.cpp:1530
+#: src/muuli_wdr.cpp:1523
 msgid "Remove dead server after"
 msgstr "Desaniciar sirvidores cayíos tres"
 
-#: src/muuli_wdr.cpp:1531
+#: src/muuli_wdr.cpp:1524
 msgid "Static servers are never removed, even when unreachable."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1535
+#: src/muuli_wdr.cpp:1528
 msgid "retries"
 msgstr "reintentos"
 
-#: src/muuli_wdr.cpp:1543
+#: src/muuli_wdr.cpp:1536
 msgid "List"
 msgstr "Llista"
 
-#: src/muuli_wdr.cpp:1546
+#: src/muuli_wdr.cpp:1539
 msgid "Update server list when connecting to a server"
 msgstr "Actualizar la llista de sirvidores al coneutar a un sirvidor"
 
-#: src/muuli_wdr.cpp:1549
+#: src/muuli_wdr.cpp:1542
 msgid "Update server list when a client connects"
 msgstr "Actualizar la llista de sirvidores cuando un veceru se coneuta"
 
-#: src/muuli_wdr.cpp:1552
+#: src/muuli_wdr.cpp:1545
 msgid "Use priority system"
 msgstr "Usar sistema de prioridaes"
 
-#: src/muuli_wdr.cpp:1556
+#: src/muuli_wdr.cpp:1549
 msgid "Use smart LowID check on connect"
 msgstr "Control intelixente de IDBaxa al coneutar"
 
-#: src/muuli_wdr.cpp:1560
+#: src/muuli_wdr.cpp:1553
 msgid "Safe connect"
 msgstr "Conexón segura"
 
-#: src/muuli_wdr.cpp:1564
+#: src/muuli_wdr.cpp:1557
 msgid "Autoconnect to servers in static list only"
 msgstr "Autoconeutar namái a Sirvidores fixos"
 
-#: src/muuli_wdr.cpp:1567
+#: src/muuli_wdr.cpp:1560
 msgid "Set manually added servers to High Priority"
 msgstr "Asignar alta prioridá a los sirvidores amestaos manualmente"
 
-#: src/muuli_wdr.cpp:1588
+#: src/muuli_wdr.cpp:1581
 msgid "Add files to download in pause mode"
 msgstr "Amestar ficheros pa descargar en mou posáu"
 
-#: src/muuli_wdr.cpp:1590
+#: src/muuli_wdr.cpp:1583
 msgid "Add files to download with auto priority"
 msgstr "Amestar nueves descargues con auto prioridá"
 
-#: src/muuli_wdr.cpp:1593
+#: src/muuli_wdr.cpp:1586
 msgid "Try to download first and last chunks first"
 msgstr "Tentar descargar enantes la primer y cabera parte"
 
-#: src/muuli_wdr.cpp:1597
+#: src/muuli_wdr.cpp:1590
 msgid "Endgame mode: rotate to faster sources for the final blocks"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1600
+#: src/muuli_wdr.cpp:1593
 msgid "Start next paused file when a file completes"
 msgstr "Descargar siguiente ficheru posáu cuandu otru se complete"
 
-#: src/muuli_wdr.cpp:1603
+#: src/muuli_wdr.cpp:1596
 msgid "From the same category"
 msgstr "Namái na mesma categoría"
 
-#: src/muuli_wdr.cpp:1605
+#: src/muuli_wdr.cpp:1598
 msgid "In alphabetic order"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1607
+#: src/muuli_wdr.cpp:1600
 msgid "Preallocate disk space for new files"
 msgstr "Reservar espaciu en discu pa los nuevos ficheros"
 
-#: src/muuli_wdr.cpp:1608
+#: src/muuli_wdr.cpp:1601
 msgid "For new files preallocates disk space for the whole file, thus reduces fragmentation"
 msgstr "Pa los nuevos ficheros reservar tol espaciu del ficheru, esto amenorga la fragmentación"
 
-#: src/muuli_wdr.cpp:1613
+#: src/muuli_wdr.cpp:1606
+msgid "Create new files as sparse files"
+msgstr ""
+
+#: src/muuli_wdr.cpp:1607
+msgid "A sparse file reserves its full size on disk immediately without writing real data to it -- fast, but unsupported or slow on some filesystems, and free-space accounting stays optimistic while the download is in progress. Turn this off to grow the file only as data arrives."
+msgstr ""
+
+#: src/muuli_wdr.cpp:1612
 msgid "Stop downloads when free disk space reaches "
 msgstr "Detener descargues cuando s'algame l'espaciu llibre en discu"
 
-#: src/muuli_wdr.cpp:1614
+#: src/muuli_wdr.cpp:1613
 msgid "Select this if you want aMule to check your disk space"
 msgstr "Seleiciona esta opción si quies que aMule comprebe l'espaciu en discu"
 
-#: src/muuli_wdr.cpp:1618
+#: src/muuli_wdr.cpp:1617
 msgid "Enter here the min disk space desired."
 msgstr "Introduz l'espaciu mínimu de discu deseyáu."
 
-#: src/muuli_wdr.cpp:1624
+#: src/muuli_wdr.cpp:1623
 msgid "Save 10 sources on rare files (< 20 sources)"
 msgstr "Guardar 10 fontes en ficheros raros (< 20 fontes)"
 
-#: src/muuli_wdr.cpp:1628 src/Statistics.cpp:790
+#: src/muuli_wdr.cpp:1627 src/Statistics.cpp:790
 msgid "Uploads"
 msgstr "Xubíes"
 
-#: src/muuli_wdr.cpp:1631
+#: src/muuli_wdr.cpp:1630
 msgid "Add new shared files with auto priority"
 msgstr "Amestar nuevos ficheros compartíos con auto prioridá"
 
-#: src/muuli_wdr.cpp:1637
+#: src/muuli_wdr.cpp:1636
 msgid "Intelligent Corruption Handling (I.C.H.)"
 msgstr "Remanador Intelixente de Corrupciones (I.C.H)"
 
-#: src/muuli_wdr.cpp:1640
+#: src/muuli_wdr.cpp:1639
 msgid "Enable"
 msgstr "Habilitar"
 
-#: src/muuli_wdr.cpp:1643
+#: src/muuli_wdr.cpp:1642
 msgid "Advanced I.C.H. trusts every hash (not recommended)"
 msgstr "I.C.H. avanzáu, confiar en tolos hash (non recomendáu)"
 
-#: src/muuli_wdr.cpp:1655 src/PrefsUnifiedDlg.cpp:1990
+#: src/muuli_wdr.cpp:1654 src/PrefsUnifiedDlg.cpp:1910
 msgid "Media metadata extraction"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1659
+#: src/muuli_wdr.cpp:1658
 msgid "Extract length / bitrate / codec from shared audio and video files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1661
+#: src/muuli_wdr.cpp:1660
 msgid "When enabled, aMule runs ffprobe on each shared media file to fill in the Length / Bitrate / Codec columns other clients see when they find the file in a search. Requires ffmpeg (the ffprobe binary) to be installed."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1668
+#: src/muuli_wdr.cpp:1667
 msgid "Path to ffprobe:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1673
+#: src/muuli_wdr.cpp:1672
 msgid "Full path to the ffprobe binary. Leave empty to have aMule auto-detect it on startup."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1681
+#: src/muuli_wdr.cpp:1680
 msgid "Detect"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1682
+#: src/muuli_wdr.cpp:1681
 msgid "Search the standard install locations for an ffprobe binary and fill the path field."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1706
+#: src/muuli_wdr.cpp:1705
 msgid ""
 "Completed downloads are stored here. All files in this folder are automatically shared with other peers.\n"
 "If this folder also holds files you don't want to share, point it at an aMule-only sub-folder."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1709
+#: src/muuli_wdr.cpp:1708
 msgid "Pick the folder where completed downloads will be stored. All files in that folder will be shared with other peers."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1723
+#: src/muuli_wdr.cpp:1722
 msgid "Shared folders"
 msgstr "Carpetes compartíes"
 
-#: src/muuli_wdr.cpp:1729
+#: src/muuli_wdr.cpp:1728
 msgid "(Folders shared by the core. Enter a path to add one.)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1737
+#: src/muuli_wdr.cpp:1736
 msgid "Absolute path of a folder on the core's machine, e.g. /home/user/shared"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1739 src/PrefsUnifiedDlg.cpp:2874
+#: src/muuli_wdr.cpp:1738 src/PrefsUnifiedDlg.cpp:2794
 msgid "Recursive"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1740
+#: src/muuli_wdr.cpp:1739
 msgid "Share every sub-folder underneath this one, including ones created later."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1744 src/utils/aLinkCreator/src/alcframe.cpp:141
+#: src/muuli_wdr.cpp:1743 src/utils/aLinkCreator/src/alcframe.cpp:141
 msgid "Remove"
 msgstr "Desaniciar"
 
-#: src/muuli_wdr.cpp:1748
+#: src/muuli_wdr.cpp:1747
 msgid "(Right click on folder icon for recursive share)"
 msgstr "(Click drechu n'iconu de carpeta, pa compartición recursiva)"
 
-#: src/muuli_wdr.cpp:1755
+#: src/muuli_wdr.cpp:1754
 msgid "Share hidden files"
 msgstr "Compartir ficheros anubríos"
 
-#: src/muuli_wdr.cpp:1761
+#: src/muuli_wdr.cpp:1760
 msgid "Automatically rescan shared folders for changes"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1767
+#: src/muuli_wdr.cpp:1766
 msgid "Follow symbolic links in shared folders"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1773
+#: src/muuli_wdr.cpp:1772
 msgid "Exclude files matching:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1776
+#: src/muuli_wdr.cpp:1775
 msgid "Wildcard patterns separated by '|', e.g. .DS_Store|Thumbs.db|*.tmp. Files whose name matches are not shared. Matching is case-insensitive."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1780
+#: src/muuli_wdr.cpp:1779
 msgid "Patterns are regular expressions"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1781
+#: src/muuli_wdr.cpp:1780
 msgid "When set, the whole field is one regular expression ('|' is alternation). When unset, it is a list of '|'-separated wildcards."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1791
+#: src/muuli_wdr.cpp:1790
 msgid "Show how many shared files the current pattern would exclude."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1812
+#: src/muuli_wdr.cpp:1811
 msgid "Graphs"
 msgstr "Gráficos"
 
-#: src/muuli_wdr.cpp:1815 src/muuli_wdr.cpp:1877
+#: src/muuli_wdr.cpp:1814 src/muuli_wdr.cpp:1876
 msgid "Update delay : 5 secs"
 msgstr "Intervalu d'actualización : 5 segs"
 
-#: src/muuli_wdr.cpp:1819
+#: src/muuli_wdr.cpp:1818
 msgid "Time for average graph: 100 mins"
 msgstr "Tiempu de promediu del gráficu: 100 min"
 
-#: src/muuli_wdr.cpp:1823
+#: src/muuli_wdr.cpp:1822
 msgid "Connections Graph Scale: 100 "
 msgstr "Escala del gráficu de les conexones: 100"
 
-#: src/muuli_wdr.cpp:1830
+#: src/muuli_wdr.cpp:1829
 msgid "Download graph scale:"
 msgstr "Descargar escala gráfica:"
 
-#: src/muuli_wdr.cpp:1838
+#: src/muuli_wdr.cpp:1837
 msgid "Upload graph scale:"
 msgstr "Escala gráfica de descarga:"
 
-#: src/muuli_wdr.cpp:1848
+#: src/muuli_wdr.cpp:1847
 #, fuzzy
 msgid "Colors: "
 msgstr "Colores: "
 
-#: src/muuli_wdr.cpp:1852
+#: src/muuli_wdr.cpp:1851
 msgid "Background"
 msgstr "Fondu"
 
-#: src/muuli_wdr.cpp:1853
+#: src/muuli_wdr.cpp:1852
 msgid "Grid"
 msgstr "Rexella"
 
-#: src/muuli_wdr.cpp:1854
+#: src/muuli_wdr.cpp:1853
 msgid "Download current"
 msgstr "Descarga actual"
 
-#: src/muuli_wdr.cpp:1855
+#: src/muuli_wdr.cpp:1854
 msgid "Download running average"
 msgstr "Promediu descarga n'execución"
 
-#: src/muuli_wdr.cpp:1856
+#: src/muuli_wdr.cpp:1855
 msgid "Download session average"
 msgstr "Promediu Descarga/sesión"
 
-#: src/muuli_wdr.cpp:1857
+#: src/muuli_wdr.cpp:1856
 msgid "Upload current"
 msgstr "Xuba actual"
 
-#: src/muuli_wdr.cpp:1858
+#: src/muuli_wdr.cpp:1857
 msgid "Upload running average"
 msgstr "Promediu Xuba/tiempu"
 
-#: src/muuli_wdr.cpp:1859
+#: src/muuli_wdr.cpp:1858
 msgid "Upload session average"
 msgstr "Promediu xuba/sesión"
 
-#: src/muuli_wdr.cpp:1860
+#: src/muuli_wdr.cpp:1859
 msgid "Active connections"
 msgstr "Conexones actives"
 
-#: src/muuli_wdr.cpp:1863
+#: src/muuli_wdr.cpp:1862
 #, fuzzy
 msgid "Systray Icon Speed Bar"
 msgstr "Barra de velocidá del iconu de sistema"
 
-#: src/muuli_wdr.cpp:1864
+#: src/muuli_wdr.cpp:1863
 msgid "Kad-nodes current"
 msgstr "Kad-nodos actual"
 
-#: src/muuli_wdr.cpp:1865
+#: src/muuli_wdr.cpp:1864
 msgid "Kad-nodes running"
 msgstr "Kad-nodos executando"
 
-#: src/muuli_wdr.cpp:1866
+#: src/muuli_wdr.cpp:1865
 msgid "Kad-nodes session"
 msgstr "Kad-nodos sesión"
 
-#: src/muuli_wdr.cpp:1870 src/muuli_wdr.cpp:2324
+#: src/muuli_wdr.cpp:1869 src/muuli_wdr.cpp:2296
 msgid "Select"
 msgstr "Seleicionar"
 
-#: src/muuli_wdr.cpp:1874
+#: src/muuli_wdr.cpp:1873
 msgid "Tree"
 msgstr "Árbol"
 
-#: src/muuli_wdr.cpp:1884
+#: src/muuli_wdr.cpp:1883
 msgid "Number of Client Versions shown (0=unlimited)"
 msgstr "Númberu de versiones de veceros a amosar (0=ensin llímite)"
 
-#: src/muuli_wdr.cpp:1909
+#: src/muuli_wdr.cpp:1908
 msgid "!!! WARNING !!!"
 msgstr "¡¡¡ AVISU !!!"
 
-#: src/muuli_wdr.cpp:1924
+#: src/muuli_wdr.cpp:1923
 msgid "Max new connections / 5 secs"
 msgstr "Nueves conexones máx. / 5 segs"
 
-#: src/muuli_wdr.cpp:1926
+#: src/muuli_wdr.cpp:1925
 msgid "Concurrent Kad source lookups"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1928
+#: src/muuli_wdr.cpp:1927
 #, fuzzy
 msgid "Kad source re-search interval (minutes)"
 msgstr "Intervalu d'actualización de FTP en minutos"
 
-#: src/muuli_wdr.cpp:1930
+#: src/muuli_wdr.cpp:1929
 #, fuzzy
 msgid "Source re-ask interval (minutes)"
 msgstr "Intervalu d'actualización de FTP en minutos"
 
-#: src/muuli_wdr.cpp:1934
+#: src/muuli_wdr.cpp:1933
 msgid "File Buffer Size: 240000 bytes"
 msgstr "Tamañu del buffer de ficheru: 240000 bytes"
 
-#: src/muuli_wdr.cpp:1938
+#: src/muuli_wdr.cpp:1937
 msgid "Use MMAP: memory-mapped file access (lower memory use)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1939
+#: src/muuli_wdr.cpp:1938
 msgid "Maps part files into memory instead of buffering them on the heap, lowering the process memory footprint. May reduce download speed on some disks; best for memory-constrained or upload-heavy hosts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1941
+#: src/muuli_wdr.cpp:1940
 msgid "Upload Queue Size: 5000 clients"
 msgstr "Tamañu cola d'espera: 5000 veceros"
 
-#: src/muuli_wdr.cpp:1945
+#: src/muuli_wdr.cpp:1944
 msgid "Server connection refresh interval: Disable"
 msgstr "Intervalu d'actualización de conexón al sirvidor: Desactiváu"
 
-#: src/muuli_wdr.cpp:1949
+#: src/muuli_wdr.cpp:1948
 msgid "Disable computer's timed standby mode"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1968
+#: src/muuli_wdr.cpp:1967
 msgid "Skin to use: "
 msgstr "Tema a usar: "
 
-#: src/muuli_wdr.cpp:1977
+#: src/muuli_wdr.cpp:1976
 msgid "Show \"Fast eD2k Links Handler\" in every window."
 msgstr "Amosar \"Xestor rápidu d'enllaces eD2k\", en toles ventanes."
 
-#: src/muuli_wdr.cpp:1980
+#: src/muuli_wdr.cpp:1979
 msgid "Show extended info on categories tabs"
 msgstr "Amosar info estendía nes llingüetes de les categoríes"
 
-#: src/muuli_wdr.cpp:1983
+#: src/muuli_wdr.cpp:1982
 #, fuzzy
 msgid "Show application version on title"
 msgstr "Amosar índices de tresferencia nel títulu"
 
-#: src/muuli_wdr.cpp:1985
+#: src/muuli_wdr.cpp:1984
 msgid "Show transfer rates on title"
 msgstr "Amosar índices de tresferencia nel títulu"
 
-#: src/muuli_wdr.cpp:1987
+#: src/muuli_wdr.cpp:1986
 msgid "Before application name"
 msgstr "Enantes del nome de l'aplicación"
 
-#: src/muuli_wdr.cpp:1989
+#: src/muuli_wdr.cpp:1988
 msgid "After application name"
 msgstr "Dempués del nome de l'aplicación"
 
-#: src/muuli_wdr.cpp:1992
+#: src/muuli_wdr.cpp:1991
 msgid "Show overhead bandwidth"
 msgstr "Amosar anchor de banda escedente"
 
-#: src/muuli_wdr.cpp:1996
+#: src/muuli_wdr.cpp:1995
 msgid "Vertical toolbar orientation"
 msgstr "Orientación vertical de la barra de ferramientes"
 
-#: src/muuli_wdr.cpp:1998
+#: src/muuli_wdr.cpp:1997
 msgid "Live column sorting (auto-reorder rows as their values change)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2005
+#: src/muuli_wdr.cpp:2004
 msgid "Download Queue Files"
 msgstr "Ficheros de la cola de descarga"
 
-#: src/muuli_wdr.cpp:2008
+#: src/muuli_wdr.cpp:2007
 msgid "Show progress percentage"
 msgstr "Amosar porcentax de progresu"
 
-#: src/muuli_wdr.cpp:2014
+#: src/muuli_wdr.cpp:2013
 msgid "Show progress bar"
 msgstr "Amosar barra de progresu"
 
-#: src/muuli_wdr.cpp:2017
+#: src/muuli_wdr.cpp:2016
 msgid "Flat"
 msgstr "Planu"
 
-#: src/muuli_wdr.cpp:2021
+#: src/muuli_wdr.cpp:2020
 msgid "Round"
 msgstr "3D"
 
-#: src/muuli_wdr.cpp:2039
+#: src/muuli_wdr.cpp:2038
 msgid "External Connection Parameters"
 msgstr "Parámetros de conexón esterna"
 
-#: src/muuli_wdr.cpp:2042
+#: src/muuli_wdr.cpp:2041
 msgid "Accept external connections"
 msgstr "Aceutar conexones esternes"
 
-#: src/muuli_wdr.cpp:2049 src/muuli_wdr.cpp:2108
+#: src/muuli_wdr.cpp:2048 src/muuli_wdr.cpp:2107
 msgid "IP of the listening interface:"
 msgstr "IP de la interface que ta escuchando"
 
-#: src/muuli_wdr.cpp:2052
+#: src/muuli_wdr.cpp:2051
 msgid "Enter here a valid ip in the a.b.c.d format for the listening EC interface. An empty field or 0.0.0.0 will mean any interface."
 msgstr "Introduz una IP válida de la interface que ta escuchando. Un campu ermu o 0.0.0.0 significará cualesquier interface."
 
-#: src/muuli_wdr.cpp:2073 src/muuli_wdr.cpp:2184
+#: src/muuli_wdr.cpp:2072 src/muuli_wdr.cpp:2156
 msgid "TCP port:"
 msgstr "Puertu TCP:"
 
-#: src/muuli_wdr.cpp:2079
+#: src/muuli_wdr.cpp:2078
 msgid "Enable UPnP port forwarding on the EC port"
 msgstr "Habilitar UPnP port forwarding nel puertu EC"
 
-#: src/muuli_wdr.cpp:2083 src/muuli_wdr.cpp:3069
+#: src/muuli_wdr.cpp:2082 src/muuli_wdr.cpp:3041
 #: src/utils/wxCas/src/wxcasprefs.cpp:167
 msgid "Password"
 msgstr "Contraseña"
 
-#: src/muuli_wdr.cpp:2089
+#: src/muuli_wdr.cpp:2088
 #, fuzzy
 msgid "aMule API server parameters"
 msgstr "Parámetros del sirvidor web"
 
-#: src/muuli_wdr.cpp:2092
+#: src/muuli_wdr.cpp:2091
 msgid "Run amuleapi (REST API) on startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2097
+#: src/muuli_wdr.cpp:2096
 #, fuzzy
 msgid "HTTP port:"
 msgstr "Puertu TCP:"
 
-#: src/muuli_wdr.cpp:2111
+#: src/muuli_wdr.cpp:2110
 msgid "The interface amuleapi's HTTP server listens on. 127.0.0.1 (default) accepts only local connections; use 0.0.0.0 or a specific IP to expose it to other hosts (set an admin password below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2116
-msgid "Type a password to set or change it. Stored passwords cannot be shown, so leaving this empty keeps the current one."
-msgstr ""
-
-#: src/muuli_wdr.cpp:2118
+#: src/muuli_wdr.cpp:2113
 #, fuzzy
 msgid "Admin password"
 msgstr "Comprobando contraseña\n"
 
-#: src/muuli_wdr.cpp:2130 src/muuli_wdr.cpp:2147 src/PrefsUnifiedDlg.cpp:1103
-#, fuzzy
-msgid "A password is set."
-msgstr "Comprobando contraseña\n"
+#: src/muuli_wdr.cpp:2118 src/muuli_wdr.cpp:2149
+msgid "Low rights password"
+msgstr "Contraseña invitáu"
 
-#: src/muuli_wdr.cpp:2134
-#, fuzzy
-msgid "Enable guest access"
-msgstr "Denegar accesu a invitáu"
-
-#: src/muuli_wdr.cpp:2135
-msgid "Guest sessions may read status and listings but cannot change anything. Turning this off clears the stored guest password."
-msgstr ""
-
-#: src/muuli_wdr.cpp:2139
-#, fuzzy
-msgid "Guest password"
-msgstr "Contraseña d'invitáu pa sirvidor web"
-
-#: src/muuli_wdr.cpp:2154
+#: src/muuli_wdr.cpp:2126
 msgid "Web server parameters"
 msgstr "Parámetros del sirvidor web"
 
-#: src/muuli_wdr.cpp:2157
+#: src/muuli_wdr.cpp:2129
 #, fuzzy
 msgid "Run webserver on startup (deprecated)"
 msgstr "Aniciar sirvidor web al entamu"
 
-#: src/muuli_wdr.cpp:2163
+#: src/muuli_wdr.cpp:2135
 msgid "Web template"
 msgstr "Plantía Web"
 
-#: src/muuli_wdr.cpp:2168
+#: src/muuli_wdr.cpp:2140
 msgid "Full rights password"
 msgstr "Contraseña alministrador"
 
-#: src/muuli_wdr.cpp:2172
+#: src/muuli_wdr.cpp:2144
 msgid "Enable Low rights User"
 msgstr "Activar invitáu"
 
-#: src/muuli_wdr.cpp:2177
-msgid "Low rights password"
-msgstr "Contraseña invitáu"
-
-#: src/muuli_wdr.cpp:2191
+#: src/muuli_wdr.cpp:2163
 msgid "Enable UPnP port forwarding of the web server port"
 msgstr "Usar forwarding de puertos UPnP nel puertu del sirvidor web"
 
-#: src/muuli_wdr.cpp:2196
+#: src/muuli_wdr.cpp:2168
 msgid "Web server UPnP TCP port (Optional)"
 msgstr "Puertu HTTP del sirvidor web (Opcional)"
 
-#: src/muuli_wdr.cpp:2204
+#: src/muuli_wdr.cpp:2176
 msgid "Page Refresh Time (in secs)"
 msgstr "Tiempu d'actualización de páxina (en segs)"
 
-#: src/muuli_wdr.cpp:2211
+#: src/muuli_wdr.cpp:2183
 msgid "Enable Gzip compression"
 msgstr "Activar compresión gzip"
 
-#: src/muuli_wdr.cpp:2245
+#: src/muuli_wdr.cpp:2217
 #, fuzzy
 msgid "Reset page to defaults"
 msgstr "Por defeutu"
 
-#: src/muuli_wdr.cpp:2246
+#: src/muuli_wdr.cpp:2218
 msgid "Reset the settings on the current page to their default values."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2248 src/muuli_wdr.cpp:2334 src/ServerWnd.cpp:274
+#: src/muuli_wdr.cpp:2220 src/muuli_wdr.cpp:2306 src/ServerWnd.cpp:274
 #: src/ServerWnd.cpp:282
 msgid "OK"
 msgstr "Aceutar"
 
-#: src/muuli_wdr.cpp:2250
+#: src/muuli_wdr.cpp:2222
 msgid "Click here to apply any changes made to the preferences."
 msgstr "Aplicar cualesquier cambéu fechu nes opciones."
 
-#: src/muuli_wdr.cpp:2253
+#: src/muuli_wdr.cpp:2225
 msgid "Reset any changes made to the preferences."
 msgstr "Encaboxar cualesquier cambéu fechu nes opciones."
 
-#: src/muuli_wdr.cpp:2282
+#: src/muuli_wdr.cpp:2254
 msgid "Comment :"
 msgstr "Comentariu : "
 
-#: src/muuli_wdr.cpp:2289
+#: src/muuli_wdr.cpp:2261
 msgid "Incoming Dir :"
 msgstr "Direutoriu entrante :"
 
-#: src/muuli_wdr.cpp:2298
+#: src/muuli_wdr.cpp:2270
 msgid "Change priority for new assigned files :"
 msgstr "Cambiar prioridá a nuevos ficheros asignaos :"
 
-#: src/muuli_wdr.cpp:2302
+#: src/muuli_wdr.cpp:2274
 #, fuzzy
 msgid "Don't change"
 msgstr "Non cambiar"
 
-#: src/muuli_wdr.cpp:2314
+#: src/muuli_wdr.cpp:2286
 msgid "Select color for this Category (currently selected) :"
 msgstr "Seleiciona color pa esta categoría (seleicionada) :"
 
-#: src/muuli_wdr.cpp:2381 src/muuli_wdr.cpp:2400 src/muuli_wdr.cpp:2422
+#: src/muuli_wdr.cpp:2353 src/muuli_wdr.cpp:2372 src/muuli_wdr.cpp:2394
 msgid "Click this button to reset the log."
 msgstr "Calca esti botón pa llimpiar el registru."
 
-#: src/muuli_wdr.cpp:2441
+#: src/muuli_wdr.cpp:2413
 msgid "Click on this button to update the servers list from URL ..."
 msgstr "Click nesti botón p'actualizar la llista de sirvidores dende una URL ..."
 
-#: src/muuli_wdr.cpp:2445
+#: src/muuli_wdr.cpp:2417
 msgid "Server list"
 msgstr "Llista de sirvidores"
 
-#: src/muuli_wdr.cpp:2449
+#: src/muuli_wdr.cpp:2421
 msgid "Enter the url to a server.met file here and press the button to the left to update the list of known servers."
 msgstr "Introduz la url a un ficheru server.met y calca'l botón de la esquierda p'actualizar la llista de sirvidores conocíos."
 
-#: src/muuli_wdr.cpp:2454
+#: src/muuli_wdr.cpp:2426
 msgid "Add server manually: Name"
 msgstr "Amestar sirvidor manualmente: Nome"
 
-#: src/muuli_wdr.cpp:2457
+#: src/muuli_wdr.cpp:2429
 msgid "Enter the name of the new server here"
 msgstr "Introduz el nome del nuevu sirvidor"
 
-#: src/muuli_wdr.cpp:2459 src/ServerWnd.cpp:206
+#: src/muuli_wdr.cpp:2431 src/ServerWnd.cpp:206
 msgid "IP:Port"
 msgstr "IP:Puertu"
 
-#: src/muuli_wdr.cpp:2462
+#: src/muuli_wdr.cpp:2434
 msgid "Enter the IP of the server here, using the x.x.x.x format."
 msgstr "Introduz la IP del sirvidor, usando'l formatu X.X.X.X."
 
-#: src/muuli_wdr.cpp:2468
+#: src/muuli_wdr.cpp:2440
 msgid "Enter the port of the server here."
 msgstr "Introduz el puertu del sirvidor"
 
-#: src/muuli_wdr.cpp:2471
+#: src/muuli_wdr.cpp:2443
 msgid "Add manually a server (fill fields to the left before) ..."
 msgstr "Amestar manualmente un sirvidor (rellena los campos) ..."
 
-#: src/muuli_wdr.cpp:2500
+#: src/muuli_wdr.cpp:2472
 msgid "aMule Log"
 msgstr "Rexistru"
 
-#: src/muuli_wdr.cpp:2508
+#: src/muuli_wdr.cpp:2480
 msgid "Server Info"
 msgstr "Info. sirvidores"
 
-#: src/muuli_wdr.cpp:2512
+#: src/muuli_wdr.cpp:2484
 msgid "ED2K Info"
 msgstr "Info ED2K"
 
-#: src/muuli_wdr.cpp:2516
+#: src/muuli_wdr.cpp:2488
 msgid "Kad Info"
 msgstr "Info Kad"
 
-#: src/muuli_wdr.cpp:2544
+#: src/muuli_wdr.cpp:2516
 msgid "Click on this button to update the nodes list from URL ..."
 msgstr "Click nesti botón p'actualizar la llista de nodos dende la URL ..."
 
-#: src/muuli_wdr.cpp:2548
+#: src/muuli_wdr.cpp:2520
 msgid "Nodes (0)"
 msgstr "Nodos (0)"
 
-#: src/muuli_wdr.cpp:2552
+#: src/muuli_wdr.cpp:2524
 msgid "Enter the url to a nodes.dat file here and press the button to the left to update the list of known nodes."
 msgstr "Introduz equí la url al ficheru nodes.dat y calca'l botón de la esquierda, p'actualizar la llista de nodos conocíos."
 
-#: src/muuli_wdr.cpp:2555
+#: src/muuli_wdr.cpp:2527
 msgid "Nodes stats"
 msgstr "Estadístiques nodos"
 
-#: src/muuli_wdr.cpp:2597
+#: src/muuli_wdr.cpp:2569
 msgid "Bootstrap"
 msgstr "Coneutar"
 
-#: src/muuli_wdr.cpp:2600
+#: src/muuli_wdr.cpp:2572
 msgid "New node"
 msgstr "Nuevu nodu"
 
-#: src/muuli_wdr.cpp:2605
+#: src/muuli_wdr.cpp:2577
 msgid "IP:"
 msgstr "IP:"
 
-#: src/muuli_wdr.cpp:2625
+#: src/muuli_wdr.cpp:2597
 msgid "Port:"
 msgstr "Puertu:"
 
-#: src/muuli_wdr.cpp:2638
+#: src/muuli_wdr.cpp:2610
 #, fuzzy
 msgid "Bootstrap from known clients"
 msgstr ""
 "Coneutar dende \n"
 "veceros conocíos"
 
-#: src/muuli_wdr.cpp:2640
+#: src/muuli_wdr.cpp:2612
 msgid "Disconnect Kad"
 msgstr "Desconeutar Kad"
 
-#: src/muuli_wdr.cpp:2674
+#: src/muuli_wdr.cpp:2646
 msgid "Use Secure User Identification"
 msgstr "Usar Identificación Segura d'Usuariu"
 
-#: src/muuli_wdr.cpp:2676
+#: src/muuli_wdr.cpp:2648
 msgid "It is recommended to enable this option. You will not receive credits if SUI is not enabled."
 msgstr "Encamiéntase a activar esta opción. Nun recibirá créditos si la ISU (Identificación Segura d'Usuariu) nun ta habilitada."
 
-#: src/muuli_wdr.cpp:2678
+#: src/muuli_wdr.cpp:2650
 msgid "Protocol Obfuscation"
 msgstr "Ofuscación de protocolu"
 
-#: src/muuli_wdr.cpp:2681
+#: src/muuli_wdr.cpp:2653
 msgid "Support Protocol Obfuscation"
 msgstr "Sofitu d'ofuscación de protocolu"
 
-#: src/muuli_wdr.cpp:2683
+#: src/muuli_wdr.cpp:2655
 msgid "This option enabled Protocol Obfuscation, and makes aMule accept obfuscated connections from other clients."
 msgstr "Esta opción activa la ofuscación de protocolu, y fai que aMule aceute conexones ofuscaes de otros veceros."
 
-#: src/muuli_wdr.cpp:2685
+#: src/muuli_wdr.cpp:2657
 msgid "Use obfuscation for outgoing connections"
 msgstr "Usar ofuscación pa conexones salientes"
 
-#: src/muuli_wdr.cpp:2687
+#: src/muuli_wdr.cpp:2659
 msgid "This option makes aMule use Protocol Obfuscation when connecting other clients/servers."
 msgstr "Esta opción fai que aMule use ofuscación de protocolu cuando se coneuten otros veceros/sirvidores."
 
-#: src/muuli_wdr.cpp:2689
+#: src/muuli_wdr.cpp:2661
 msgid "Accept only obfuscated connections"
 msgstr "Aceutar namái conexones ofuscaes"
 
-#: src/muuli_wdr.cpp:2690
+#: src/muuli_wdr.cpp:2662
 msgid "This option makes aMule only accept obfuscated connections. You will have less sources, but all your traffic will be obfuscated"
 msgstr "Esa opción fai que aMule namái aceute conexones ofuscaes. Tendrá menos fontes, pero tol so tráficu sedrá ofuscáu."
 
-#: src/muuli_wdr.cpp:2695
+#: src/muuli_wdr.cpp:2667
 msgid "Everybody"
 msgstr "Toos"
 
-#: src/muuli_wdr.cpp:2697
+#: src/muuli_wdr.cpp:2669
 msgid "No one"
 msgstr "Dengún"
 
-#: src/muuli_wdr.cpp:2699
+#: src/muuli_wdr.cpp:2671
 msgid "Who can see my shared files:"
 msgstr "Quién pue adicar los mios ficheros compartíos:"
 
-#: src/muuli_wdr.cpp:2700
+#: src/muuli_wdr.cpp:2672
 msgid "Select who can request to view a list of your shared files."
 msgstr "Seleiciona quién pue solicitar adicar la nuesa llista de ficheros compartíos."
 
-#: src/muuli_wdr.cpp:2702
+#: src/muuli_wdr.cpp:2674
 msgid "IP-Filtering"
 msgstr "Fieltráu de IPs"
 
-#: src/muuli_wdr.cpp:2709
+#: src/muuli_wdr.cpp:2681
 msgid "Filter clients"
 msgstr "Fieltru veceros"
 
-#: src/muuli_wdr.cpp:2711
+#: src/muuli_wdr.cpp:2683
 msgid "Enable filtering of the client IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "Habilitar fieltráu de IPs de veceros definíu nel ficheru ~/.aMule/ipfilter.dat"
 
-#: src/muuli_wdr.cpp:2713
+#: src/muuli_wdr.cpp:2685
 msgid "Filter servers"
 msgstr "Fieltru sirvidores"
 
-#: src/muuli_wdr.cpp:2715
+#: src/muuli_wdr.cpp:2687
 msgid "Enable filtering of the server IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "Habilitar fieltráu de IPs de sirvidores definíu nel ficheru ~/.aMule/ipfilter.dat"
 
-#: src/muuli_wdr.cpp:2719
+#: src/muuli_wdr.cpp:2691
 msgid "Reload List"
 msgstr "Recargar llista"
 
-#: src/muuli_wdr.cpp:2720
+#: src/muuli_wdr.cpp:2692
 msgid "Reload the list of IPs to filter from the file ~/.aMule/ipfilter.dat"
 msgstr "Recargar llista de fieltráu de IPs dende ficheru ~/.aMule/ipfilter.dat"
 
-#: src/muuli_wdr.cpp:2726
+#: src/muuli_wdr.cpp:2698
 msgid "URL:"
 msgstr "URL:"
 
-#: src/muuli_wdr.cpp:2730 src/muuli_wdr.cpp:2923
+#: src/muuli_wdr.cpp:2702 src/muuli_wdr.cpp:2895
 msgid "Update now"
 msgstr "Actualizar agora"
 
-#: src/muuli_wdr.cpp:2733
+#: src/muuli_wdr.cpp:2705
 msgid "Auto-update ipfilter at startup"
 msgstr "Auto-actualizar el fieltráu de IPs al entamu"
 
-#: src/muuli_wdr.cpp:2737
+#: src/muuli_wdr.cpp:2709
 msgid "Filtering Level:"
 msgstr "Nivel de fieltráu:"
 
-#: src/muuli_wdr.cpp:2743
+#: src/muuli_wdr.cpp:2715
 msgid "Always filter LAN IPs"
 msgstr "Fieltrar siempres IP's de LAN"
 
-#: src/muuli_wdr.cpp:2746
+#: src/muuli_wdr.cpp:2718
 msgid "Paranoid handling of non-matching IPs"
 msgstr "Control paranoicu de IPs non comprobaes"
 
-#: src/muuli_wdr.cpp:2748
+#: src/muuli_wdr.cpp:2720
 msgid "Rejects a packet when its source IP differs from the IP the client claims (an anti-spoofing check). Disable only if it causes connection problems."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2750
+#: src/muuli_wdr.cpp:2722
 msgid "Use system-wide ipfilter.dat if available"
 msgstr "Usar el ipfilter.dat de sistema si ta disponible"
 
-#: src/muuli_wdr.cpp:2751
+#: src/muuli_wdr.cpp:2723
 #, fuzzy
 msgid "If there's no local ipfilter.dat found, allow usage of a system-wide ipfilter file."
 msgstr "Si nun s'alcuentra un ficheru ipfilter.dat llocal, permitir l'usu d'un ficheru ipfilter de sistema"
 
-#: src/muuli_wdr.cpp:2768
+#: src/muuli_wdr.cpp:2740
 msgid "Enable Online-Signature"
 msgstr "Activar Robla online"
 
-#: src/muuli_wdr.cpp:2770
+#: src/muuli_wdr.cpp:2742
 msgid "Enables the writing of the OS file, which can be used by external apps to create signatures and the like."
 msgstr "Habilitar la escritura de ficheros del SO, suel usase pa criar robles por aplicaciones esternes."
 
-#: src/muuli_wdr.cpp:2774
+#: src/muuli_wdr.cpp:2746
 msgid "Update Frequency (Secs):"
 msgstr "Frecuencia d'actualización (segs):"
 
-#: src/muuli_wdr.cpp:2777
+#: src/muuli_wdr.cpp:2749
 msgid "Change the frequency (in seconds) of Online Signature updates."
 msgstr "Cambiar la frecuencia (en segundos) de l'actualización de la robla-online"
 
-#: src/muuli_wdr.cpp:2785
+#: src/muuli_wdr.cpp:2757
 msgid "Save online signature file in: "
 msgstr "Guardar ficheru de robla online en: "
 
-#: src/muuli_wdr.cpp:2791
+#: src/muuli_wdr.cpp:2763
 msgid "Click here to select the directory containing the the Online Signature files."
 msgstr "Click equí pa seleicionar el direutoriu que contién los ficheros de robles-online."
 
-#: src/muuli_wdr.cpp:2824
+#: src/muuli_wdr.cpp:2796
 msgid "Show country flags for clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2825
+#: src/muuli_wdr.cpp:2797
 msgid "Render the country flag column in the transfers, queue and search views. Requires a valid MMDB GeoIP database (see below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2830
+#: src/muuli_wdr.cpp:2802
 #, fuzzy
 msgid "Database"
 msgstr "Fluxu de datos :"
 
-#: src/muuli_wdr.cpp:2846
+#: src/muuli_wdr.cpp:2818
 #, fuzzy
 msgid "Source:"
 msgstr "Fontes"
 
-#: src/muuli_wdr.cpp:2849
+#: src/muuli_wdr.cpp:2821
 msgid "DB-IP (free, no account)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2850
+#: src/muuli_wdr.cpp:2822
 msgid "MaxMind GeoLite2 (free, account required)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2851
+#: src/muuli_wdr.cpp:2823
 msgid "Custom URL"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2854
+#: src/muuli_wdr.cpp:2826
 msgid "Choose which provider supplies the GeoIP MMDB database. DB-IP is the default - no account required. MaxMind requires a free account + license key. Use Custom URL to point at any other MMDB host (e.g. a local mirror)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2871
+#: src/muuli_wdr.cpp:2843
 msgid ""
 "No configuration required.\n"
 "\n"
@@ -4889,11 +4855,11 @@ msgid ""
 "License: Creative Commons BY 4.0 - https://creativecommons.org/licenses/by/4.0/"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2884
+#: src/muuli_wdr.cpp:2856
 msgid "License key:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2890
+#: src/muuli_wdr.cpp:2862
 msgid ""
 "Sign up for a free MaxMind account, then generate a License Key:\n"
 "https://www.maxmind.com/en/geolite2/signup\n"
@@ -4903,232 +4869,232 @@ msgid ""
 "Requires attribution and account registration; refresh at least every 30 days."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2905
+#: src/muuli_wdr.cpp:2877
 #, fuzzy
 msgid "Download URL:"
 msgstr "Descargáu:"
 
-#: src/muuli_wdr.cpp:2911
+#: src/muuli_wdr.cpp:2883
 msgid ""
 "Must point to an .mmdb file or a .gz / .tar.gz containing one.\n"
 "URL may include credentials (https://user:pass@host/...).\n"
 "License and attribution terms are set by the upstream URL - you are responsible."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2924
+#: src/muuli_wdr.cpp:2896
 msgid "Download the GeoIP database from the selected source."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2926
+#: src/muuli_wdr.cpp:2898
 #, fuzzy
 msgid "Auto-update on startup"
 msgstr "Auto-actualizar el fieltráu de IPs al entamu"
 
-#: src/muuli_wdr.cpp:2927
+#: src/muuli_wdr.cpp:2899
 msgid "Re-download the GeoIP database from the selected source every time aMule starts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2950
+#: src/muuli_wdr.cpp:2922
 msgid "Filter incoming messages (except current chat):"
 msgstr "Fieltrar mensaxes entrantes (sacantes conversación actual):"
 
-#: src/muuli_wdr.cpp:2952
+#: src/muuli_wdr.cpp:2924
 msgid "Filter all messages"
 msgstr "Fieltrar tolos mensaxes"
 
-#: src/muuli_wdr.cpp:2954
+#: src/muuli_wdr.cpp:2926
 msgid "Filter messages from people not on your friend list"
 msgstr "Fieltrar mensaxes de xente que nun ta na to llista de collacios"
 
-#: src/muuli_wdr.cpp:2956
+#: src/muuli_wdr.cpp:2928
 msgid "Filter messages from unknown clients"
 msgstr "Fieltrar mensaxes de veceros desconocíos"
 
-#: src/muuli_wdr.cpp:2958
+#: src/muuli_wdr.cpp:2930
 msgid "Filter messages containing (use ',' as separator):"
 msgstr "Fieltrar mensaxes que contienen (usa ',' como separtador):"
 
-#: src/muuli_wdr.cpp:2961 src/muuli_wdr.cpp:2972
+#: src/muuli_wdr.cpp:2933 src/muuli_wdr.cpp:2944
 msgid "add here the words amule should filter and block messages including it"
 msgstr "amiesta equí les pallabres que amule tien de fieltrar y bloquiar mensaxes incluyíos"
 
-#: src/muuli_wdr.cpp:2963
+#: src/muuli_wdr.cpp:2935
 msgid "Show received messages in the log"
 msgstr "Amosar mensaxes recibíos nel rexistru"
 
-#: src/muuli_wdr.cpp:2966
+#: src/muuli_wdr.cpp:2938
 msgid "Comments"
 msgstr "Comentarios"
 
-#: src/muuli_wdr.cpp:2969
+#: src/muuli_wdr.cpp:2941
 msgid "Filter comments containing (use ',' as separator):"
 msgstr "Fieltrar comentarios que contengan (usar ',' como separtador):"
 
-#: src/muuli_wdr.cpp:2994
+#: src/muuli_wdr.cpp:2966
 msgid "Enable Proxy"
 msgstr "Habilitar Proxy"
 
-#: src/muuli_wdr.cpp:2995
+#: src/muuli_wdr.cpp:2967
 msgid "Enable/disable proxy support"
 msgstr "Habilitar/Deshabilitar soporte Proxy"
 
-#: src/muuli_wdr.cpp:2998
+#: src/muuli_wdr.cpp:2970
 msgid "Proxy type:"
 msgstr "Triba Proxy:"
 
-#: src/muuli_wdr.cpp:3009
+#: src/muuli_wdr.cpp:2981
 msgid "Proxy host:"
 msgstr "Sirvidor Proxy:"
 
-#: src/muuli_wdr.cpp:3012
+#: src/muuli_wdr.cpp:2984
 msgid "The proxy host name"
 msgstr "Nome del host del proxy"
 
-#: src/muuli_wdr.cpp:3014
+#: src/muuli_wdr.cpp:2986
 msgid "Proxy port:"
 msgstr "Puertu Proxy:"
 
-#: src/muuli_wdr.cpp:3017
+#: src/muuli_wdr.cpp:2989
 msgid "The proxy port"
 msgstr "El puertu del proxy"
 
-#: src/muuli_wdr.cpp:3019
+#: src/muuli_wdr.cpp:2991
 msgid "Enable authentication"
 msgstr "Habilitar autentificación"
 
-#: src/muuli_wdr.cpp:3020
+#: src/muuli_wdr.cpp:2992
 msgid "Enable/disable username/password authentication"
 msgstr "Habilita/deshabilita autentificación usuariu/contraseña"
 
-#: src/muuli_wdr.cpp:3023
+#: src/muuli_wdr.cpp:2995
 msgid "Username: "
 msgstr "Nome d'usuariu:"
 
-#: src/muuli_wdr.cpp:3026
+#: src/muuli_wdr.cpp:2998
 msgid "The username to use to connect to the proxy"
 msgstr "El nome d'usuariu a usar pa coneutar al proxy"
 
-#: src/muuli_wdr.cpp:3028
+#: src/muuli_wdr.cpp:3000
 msgid "Password:"
 msgstr "Contraseña:"
 
-#: src/muuli_wdr.cpp:3031
+#: src/muuli_wdr.cpp:3003
 msgid "The password to use to connect to the proxy"
 msgstr "La contraseña a usar pa coneutar al proxy"
 
-#: src/muuli_wdr.cpp:3050
+#: src/muuli_wdr.cpp:3022
 msgid "Connect to:"
 msgstr "Coneutar a:"
 
-#: src/muuli_wdr.cpp:3059
+#: src/muuli_wdr.cpp:3031
 msgid "Login to remote amule"
 msgstr "Conexón a aMule remotu"
 
-#: src/muuli_wdr.cpp:3064
+#: src/muuli_wdr.cpp:3036
 msgid "User name"
 msgstr "Nome usuariu:"
 
-#: src/muuli_wdr.cpp:3075
+#: src/muuli_wdr.cpp:3047
 msgid "Remember those settings"
 msgstr "Remembrar estes opciones"
 
-#: src/muuli_wdr.cpp:3078
+#: src/muuli_wdr.cpp:3050
 #, fuzzy
 msgid "Force ZLIB compression"
 msgstr "Usar compresión gzip"
 
-#: src/muuli_wdr.cpp:3102
+#: src/muuli_wdr.cpp:3074
 msgid "Enable Verbose Debug-Logging."
 msgstr "Habilita mou estendíu de depuración al aniciu"
 
-#: src/muuli_wdr.cpp:3104
+#: src/muuli_wdr.cpp:3076
 #, fuzzy
 msgid "Only to Logfile"
 msgstr "&Abrir el ficheru"
 
-#: src/muuli_wdr.cpp:3106
+#: src/muuli_wdr.cpp:3078
 msgid "Message Categories:"
 msgstr "Mensaxes de categoríes:"
 
-#: src/muuli_wdr.cpp:3130 src/PartFileConvertDlg.cpp:160
+#: src/muuli_wdr.cpp:3102 src/PartFileConvertDlg.cpp:160
 msgid "Waiting..."
 msgstr "Esperando..."
 
-#: src/muuli_wdr.cpp:3150
+#: src/muuli_wdr.cpp:3122
 msgid "Add imports"
 msgstr "Amestar imports"
 
-#: src/muuli_wdr.cpp:3153
+#: src/muuli_wdr.cpp:3125
 msgid "Retry selected"
 msgstr "Reintentar seleicionáu"
 
-#: src/muuli_wdr.cpp:3155
+#: src/muuli_wdr.cpp:3127
 msgid "Remove selected"
 msgstr "Desaniciar seleicionáu"
 
-#: src/muuli_wdr.cpp:3218
+#: src/muuli_wdr.cpp:3190
 msgid "Event Types"
 msgstr "Tipos Eventos"
 
-#: src/muuli_wdr.cpp:3237
+#: src/muuli_wdr.cpp:3209
 msgid "Statistics and queued clients for selected file(s) : Session / All time"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3261
+#: src/muuli_wdr.cpp:3233
 #, fuzzy
 msgid "Active Uploads"
 msgstr "Xubes aceutaes :"
 
-#: src/muuli_wdr.cpp:3275
+#: src/muuli_wdr.cpp:3247
 msgid "Percent of total files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3327
+#: src/muuli_wdr.cpp:3299
 #, fuzzy
 msgid "Show Clients for"
 msgstr "Amosar Veceros"
 
-#: src/muuli_wdr.cpp:3329
+#: src/muuli_wdr.cpp:3301
 #, fuzzy
 msgid "All files"
 msgstr "Anubre los ficheros compartíos"
 
-#: src/muuli_wdr.cpp:3332
+#: src/muuli_wdr.cpp:3304
 #, fuzzy
 msgid "Selected files"
 msgstr "Seleicionar fieltru de vistes"
 
-#: src/muuli_wdr.cpp:3335
+#: src/muuli_wdr.cpp:3307
 #, fuzzy
 msgid "Active uploads only"
 msgstr "Xubes actives"
 
-#: src/muuli_wdr.cpp:3342
+#: src/muuli_wdr.cpp:3314
 #, fuzzy
 msgid "Reload:"
 msgstr "Recargar llista"
 
-#: src/muuli_wdr.cpp:3346
+#: src/muuli_wdr.cpp:3318
 msgid "Reload your shared files"
 msgstr "Recargar los tos ficheros compartíos"
 
-#: src/muuli_wdr.cpp:3409
+#: src/muuli_wdr.cpp:3381
 msgid "Send"
 msgstr "Unviar"
 
-#: src/muuli_wdr.cpp:3410
+#: src/muuli_wdr.cpp:3382
 msgid "Sends the specified message."
 msgstr "Unviar un mensax específicu."
 
-#: src/muuli_wdr.cpp:3414
+#: src/muuli_wdr.cpp:3386
 msgid "Close this chat-session."
 msgstr "Zarrar esta sesión de charra"
 
-#: src/muuli_wdr.cpp:3437
+#: src/muuli_wdr.cpp:3409
 msgid "Connect to any server and/or Kad"
 msgstr "Coneutar a cualesquier sirvidor y/o Kad"
 
-#: src/muuli_wdr.cpp:3443 src/SharedFilesCtrl.cpp:142 src/Statistics.cpp:941
+#: src/muuli_wdr.cpp:3415 src/SharedFilesCtrl.cpp:142 src/Statistics.cpp:941
 msgid "Shared Files"
 msgstr "Fich compartíos"
 
@@ -5488,267 +5454,267 @@ msgstr "Descargáu"
 msgid "ERROR: Failed to open partfile '%s'"
 msgstr "ERROR: Fallu al abrir ficheru part '%s'"
 
-#: src/Preferences.cpp:701
+#: src/Preferences.cpp:673
 msgid "System default"
 msgstr "Por defeutu"
 
-#: src/Preferences.cpp:702
+#: src/Preferences.cpp:674
 msgid "Albanian"
 msgstr "Albanés"
 
-#: src/Preferences.cpp:703
+#: src/Preferences.cpp:675
 msgid "Arabic"
 msgstr "Árabe"
 
-#: src/Preferences.cpp:704
+#: src/Preferences.cpp:676
 msgid "Asturian"
 msgstr "Asturianu"
 
-#: src/Preferences.cpp:705
+#: src/Preferences.cpp:677
 msgid "Basque"
 msgstr "Euskera"
 
-#: src/Preferences.cpp:706
+#: src/Preferences.cpp:678
 msgid "Bulgarian"
 msgstr "Búlgaru"
 
-#: src/Preferences.cpp:707
+#: src/Preferences.cpp:679
 msgid "Catalan"
 msgstr "Catalán"
 
-#: src/Preferences.cpp:708
+#: src/Preferences.cpp:680
 msgid "Chinese (Simplified)"
 msgstr "Chinu (simplificáu)"
 
-#: src/Preferences.cpp:709
+#: src/Preferences.cpp:681
 msgid "Chinese (Traditional)"
 msgstr "Chinu (Tradicional)"
 
-#: src/Preferences.cpp:710
+#: src/Preferences.cpp:682
 msgid "Croatian"
 msgstr "Croata"
 
-#: src/Preferences.cpp:711
+#: src/Preferences.cpp:683
 msgid "Czech"
 msgstr "Checu"
 
-#: src/Preferences.cpp:712
+#: src/Preferences.cpp:684
 msgid "Danish"
 msgstr "Danés"
 
-#: src/Preferences.cpp:713
+#: src/Preferences.cpp:685
 msgid "Dutch"
 msgstr "Holandés"
 
-#: src/Preferences.cpp:714
+#: src/Preferences.cpp:686
 msgid "English (U.K.)"
 msgstr "Inglés (U.K.)"
 
-#: src/Preferences.cpp:715
+#: src/Preferences.cpp:687
 #, fuzzy
 msgid "English (U.S.)"
 msgstr "Inglés (U.K.)"
 
-#: src/Preferences.cpp:716
+#: src/Preferences.cpp:688
 msgid "Estonian"
 msgstr "Estoniu"
 
-#: src/Preferences.cpp:717
+#: src/Preferences.cpp:689
 msgid "Finnish"
 msgstr "Finlandés"
 
-#: src/Preferences.cpp:718
+#: src/Preferences.cpp:690
 msgid "French"
 msgstr "Francés"
 
-#: src/Preferences.cpp:719
+#: src/Preferences.cpp:691
 msgid "Galician"
 msgstr "Gallegu"
 
-#: src/Preferences.cpp:720
+#: src/Preferences.cpp:692
 msgid "German"
 msgstr "Alemán"
 
-#: src/Preferences.cpp:721
+#: src/Preferences.cpp:693
 msgid "Greek"
 msgstr "Griegu"
 
-#: src/Preferences.cpp:722
+#: src/Preferences.cpp:694
 msgid "Hebrew"
 msgstr "Hebréu"
 
-#: src/Preferences.cpp:723
+#: src/Preferences.cpp:695
 msgid "Hungarian"
 msgstr "Húngaru"
 
-#: src/Preferences.cpp:724
+#: src/Preferences.cpp:696
 msgid "Italian"
 msgstr "Italianu"
 
-#: src/Preferences.cpp:725
+#: src/Preferences.cpp:697
 msgid "Japanese"
 msgstr "Xaponés"
 
-#: src/Preferences.cpp:726
+#: src/Preferences.cpp:698
 msgid "Korean"
 msgstr "Coreanu"
 
-#: src/Preferences.cpp:727
+#: src/Preferences.cpp:699
 msgid "Latvian"
 msgstr ""
 
-#: src/Preferences.cpp:728
+#: src/Preferences.cpp:700
 msgid "Lithuanian"
 msgstr "Lituanu"
 
-#: src/Preferences.cpp:729
+#: src/Preferences.cpp:701
 msgid "Norwegian (Nynorsk)"
 msgstr "Noruegu"
 
-#: src/Preferences.cpp:730
+#: src/Preferences.cpp:702
 msgid "Polish"
 msgstr "Polacu"
 
-#: src/Preferences.cpp:731
+#: src/Preferences.cpp:703
 msgid "Portuguese"
 msgstr "Portugués"
 
-#: src/Preferences.cpp:732
+#: src/Preferences.cpp:704
 msgid "Portuguese (Brazilian)"
 msgstr "Portugués (Brasil)"
 
-#: src/Preferences.cpp:733
+#: src/Preferences.cpp:705
 #, fuzzy
 msgid "Romanian"
 msgstr "Albanés"
 
-#: src/Preferences.cpp:734
+#: src/Preferences.cpp:706
 msgid "Russian"
 msgstr "Rusu"
 
-#: src/Preferences.cpp:735
+#: src/Preferences.cpp:707
 msgid "Slovenian"
 msgstr "Eslovenu"
 
-#: src/Preferences.cpp:736
+#: src/Preferences.cpp:708
 msgid "Spanish"
 msgstr "Español"
 
-#: src/Preferences.cpp:737
+#: src/Preferences.cpp:709
 msgid "Swedish"
 msgstr "Suecu"
 
-#: src/Preferences.cpp:738
+#: src/Preferences.cpp:710
 msgid "Turkish"
 msgstr "Turcu"
 
-#: src/Preferences.cpp:739
+#: src/Preferences.cpp:711
 msgid "Ukrainian"
 msgstr "Ucranianu"
 
-#: src/Preferences.cpp:842
+#: src/Preferences.cpp:814
 #, fuzzy
 msgid "Change Language"
 msgstr "Llingua: "
 
-#: src/Preferences.cpp:906
+#: src/Preferences.cpp:878
 msgid "There are no translations installed for aMule"
 msgstr ""
 
-#: src/Preferences.cpp:907
+#: src/Preferences.cpp:879
 #, fuzzy
 msgid "No languages available"
 msgstr "Non disponible"
 
-#: src/Preferences.cpp:1038
+#: src/Preferences.cpp:1010
 msgid "no options available"
 msgstr "opciones non disponibles"
 
-#: src/Preferences.cpp:2226
+#: src/Preferences.cpp:2179
 msgid "Invalid category found, skipping"
 msgstr "Categoría inválida alcontrada, saltando"
 
-#: src/Preferences.cpp:2395
+#: src/Preferences.cpp:2348
 msgid "TCP port can't be higher than 65532 due to server UDP socket being TCP+3"
 msgstr "Puertu TCP nun pue ser más altu de 65532 darréu que'l socket del sirvidor UDP ye TCP+3"
 
-#: src/Preferences.cpp:2396
+#: src/Preferences.cpp:2349
 #, c-format
 msgid "Default port will be used (%d)"
 msgstr "Puertu por defeutu que s'usará (%d)"
 
-#: src/PrefsUnifiedDlg.cpp:300 src/Statistics.cpp:866
+#: src/PrefsUnifiedDlg.cpp:298 src/Statistics.cpp:866
 msgid "Connection"
 msgstr "Conexón"
 
-#: src/PrefsUnifiedDlg.cpp:301 src/SearchListCtrl.cpp:117
+#: src/PrefsUnifiedDlg.cpp:299 src/SearchListCtrl.cpp:117
 msgid "Directories"
 msgstr "Direutorios"
 
-#: src/PrefsUnifiedDlg.cpp:302 src/Statistics.cpp:917
+#: src/PrefsUnifiedDlg.cpp:300 src/Statistics.cpp:917
 msgid "Servers"
 msgstr "Sirvidores"
 
-#: src/PrefsUnifiedDlg.cpp:303 src/ServerListCtrl.cpp:96
+#: src/PrefsUnifiedDlg.cpp:301 src/ServerListCtrl.cpp:96
 msgid "Files"
 msgstr "Ficheros"
 
-#: src/PrefsUnifiedDlg.cpp:304
+#: src/PrefsUnifiedDlg.cpp:302
 msgid "Security"
 msgstr "Seguridá"
 
-#: src/PrefsUnifiedDlg.cpp:305
+#: src/PrefsUnifiedDlg.cpp:303
 msgid "Interface"
 msgstr "Interface"
 
-#: src/PrefsUnifiedDlg.cpp:312
+#: src/PrefsUnifiedDlg.cpp:310
 msgid "IP2Country"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:315
+#: src/PrefsUnifiedDlg.cpp:313
 msgid "Proxy"
 msgstr "Proxy"
 
-#: src/PrefsUnifiedDlg.cpp:316
+#: src/PrefsUnifiedDlg.cpp:314
 msgid "Filters"
 msgstr "Fieltros"
 
-#: src/PrefsUnifiedDlg.cpp:317
+#: src/PrefsUnifiedDlg.cpp:315
 msgid "Remote Controls"
 msgstr "Controles remotos"
 
-#: src/PrefsUnifiedDlg.cpp:318
+#: src/PrefsUnifiedDlg.cpp:316
 msgid "Online Signature"
 msgstr "Robla online"
 
-#: src/PrefsUnifiedDlg.cpp:319
+#: src/PrefsUnifiedDlg.cpp:317
 msgid "Advanced"
 msgstr "Avanzáu"
 
-#: src/PrefsUnifiedDlg.cpp:320
+#: src/PrefsUnifiedDlg.cpp:318
 msgid "Events"
 msgstr "Eventos"
 
-#: src/PrefsUnifiedDlg.cpp:323
+#: src/PrefsUnifiedDlg.cpp:321
 msgid "Debugging"
 msgstr "Debugging"
 
-#: src/PrefsUnifiedDlg.cpp:453
+#: src/PrefsUnifiedDlg.cpp:451
 msgid ""
 "The following variables will be substituted:\n"
 "    %PARTFILE - full path to the file\n"
 "    %PARTNAME - file name only"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:474
+#: src/PrefsUnifiedDlg.cpp:472
 msgid "Tray icon support requires libayatana-appindicator3 at compile time."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:490
+#: src/PrefsUnifiedDlg.cpp:488
 msgid "Not available on Wayland: the protocol does not report when a window is minimized, so this option cannot intercept the system minimize button. Workaround: launch aMule with `GDK_BACKEND=x11` to use XWayland instead."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:536
+#: src/PrefsUnifiedDlg.cpp:534
 msgid ""
 "Do not change these setting unless you know\n"
 "what you are doing, otherwise you can easily\n"
@@ -5764,35 +5730,26 @@ msgstr ""
 "aMule furrulará bien ensin que camudes dengún\n"
 "d'estos parámetros."
 
-#: src/PrefsUnifiedDlg.cpp:647
+#: src/PrefsUnifiedDlg.cpp:645
 #, c-format
 msgid "Failed to connect Cfg to widget with the ID %d and key %s"
 msgstr "Error al coneutar configuración con programa, col ID %d y clave %s"
 
-#: src/PrefsUnifiedDlg.cpp:695
+#: src/PrefsUnifiedDlg.cpp:693
 #, c-format
 msgid "Failed to transfer data from Cfg to Widget with the ID %d and key %s"
 msgstr "Error al tresferir datos dende la configuración al programa, col ID %d y la clave %s"
 
-#: src/PrefsUnifiedDlg.cpp:801
+#: src/PrefsUnifiedDlg.cpp:799
 msgid "The type of proxy you are connecting to"
 msgstr "La triba de proxy a la que tas coneutando"
 
-#: src/PrefsUnifiedDlg.cpp:1020
+#: src/PrefsUnifiedDlg.cpp:1003
 #, c-format
 msgid "Failed to transfer data from Widget to Cfg with the ID %d and key %s"
 msgstr "Error al tresferir datos dende'l programa a la configuración, col ID %d y la clave %s"
 
 #: src/PrefsUnifiedDlg.cpp:1103
-#, fuzzy
-msgid "No password set."
-msgstr "Comprobando contraseña\n"
-
-#: src/PrefsUnifiedDlg.cpp:1132
-msgid "Guest access needs a password. Type one in the guest password field, or untick Enable guest access."
-msgstr ""
-
-#: src/PrefsUnifiedDlg.cpp:1144
 msgid ""
 "aMule must be restarted to enable these changes:\n"
 "\n"
@@ -5800,45 +5757,45 @@ msgstr ""
 "aMule tien de reaniciase p'aplicar los cambeos:\n"
 "\n"
 
-#: src/PrefsUnifiedDlg.cpp:1151
+#: src/PrefsUnifiedDlg.cpp:1110
 msgid "- TCP port changed.\n"
 msgstr "- Puertu TCP camudáu.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1156
+#: src/PrefsUnifiedDlg.cpp:1115
 msgid "- UDP port changed.\n"
 msgstr "- Puertu UDP camudáu.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1161
+#: src/PrefsUnifiedDlg.cpp:1120
 #, fuzzy
 msgid "- Network interface binding changed.\n"
 msgstr "Conexón esterna zarrada."
 
-#: src/PrefsUnifiedDlg.cpp:1166
+#: src/PrefsUnifiedDlg.cpp:1125
 #, fuzzy
 msgid "- External connect port changed.\n"
 msgstr "Conexón esterna zarrada."
 
-#: src/PrefsUnifiedDlg.cpp:1170
+#: src/PrefsUnifiedDlg.cpp:1129
 #, fuzzy
 msgid "- External connect acceptance changed.\n"
 msgstr "Nueva conexón esterna, aceutada"
 
-#: src/PrefsUnifiedDlg.cpp:1174
+#: src/PrefsUnifiedDlg.cpp:1133
 #, fuzzy
 msgid "- External connect interface changed.\n"
 msgstr "Conexón esterna zarrada."
 
-#: src/PrefsUnifiedDlg.cpp:1178
+#: src/PrefsUnifiedDlg.cpp:1137
 #, fuzzy
 msgid "- Protocol obfuscation support changed.\n"
 msgstr "Ofuscación de protocolu"
 
-#: src/PrefsUnifiedDlg.cpp:1193
+#: src/PrefsUnifiedDlg.cpp:1151
 #, fuzzy
 msgid "- amuleapi settings changed.\n"
 msgstr "- Llingua camudada.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1202
+#: src/PrefsUnifiedDlg.cpp:1160
 msgid ""
 "Your Auto-update server list is empty.\n"
 "'Auto-update server list at startup' will be disabled."
@@ -5846,7 +5803,7 @@ msgstr ""
 "La to llista Auto-actualizable de sirvidores ta erma.\n"
 "La llista de sirvidores auto-actualizable al entamu desactivaráse."
 
-#: src/PrefsUnifiedDlg.cpp:1213
+#: src/PrefsUnifiedDlg.cpp:1171
 msgid ""
 "You have enabled external connections but have not specified a password.\n"
 "External connections cannot be enabled unless a valid password is specified."
@@ -5854,33 +5811,28 @@ msgstr ""
 "Tienes habilitao les conexones externes, pero nun tienes especificada una contraseña.\n"
 "Les conexones externes nun puen ser habilitaes sacante qu'especifiques una contraseña válida."
 
-#: src/PrefsUnifiedDlg.cpp:1246
-#, c-format
-msgid "The amuleapi password could not be saved: %s"
-msgstr ""
-
-#: src/PrefsUnifiedDlg.cpp:1276
+#: src/PrefsUnifiedDlg.cpp:1202
 msgid "- Language changed.\n"
 msgstr "- Llingua camudada.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1281
+#: src/PrefsUnifiedDlg.cpp:1207
 msgid "- Temp folder changed.\n"
 msgstr "- Direutoriu TEMP camudáu.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1286
+#: src/PrefsUnifiedDlg.cpp:1212
 msgid "- ED2K network enabled.\n"
 msgstr "- Rede ED2K activada.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1319
+#: src/PrefsUnifiedDlg.cpp:1245
 msgid "The shared-file exclusion pattern is not a valid regular expression. The filter has been left disabled."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1321 src/PrefsUnifiedDlg.cpp:1921
+#: src/PrefsUnifiedDlg.cpp:1247 src/PrefsUnifiedDlg.cpp:1841
 #, fuzzy
 msgid "Invalid regular expression"
 msgstr "Versión de protocolu non válida"
 
-#: src/PrefsUnifiedDlg.cpp:1398
+#: src/PrefsUnifiedDlg.cpp:1324
 msgid ""
 "Both eD2k and Kad network are disabled.\n"
 "You won't be able to connect until you enable at least one of them."
@@ -5888,7 +5840,7 @@ msgstr ""
 "eD2k y Kad tán desactivaos.\n"
 "Nun podrás coneutate hasta qu'actives a lo menos ún d'ellos."
 
-#: src/PrefsUnifiedDlg.cpp:1403
+#: src/PrefsUnifiedDlg.cpp:1329
 msgid ""
 "Kad will not start if your UDP port is disabled.\n"
 "Enable UDP port or disable Kad."
@@ -5896,7 +5848,7 @@ msgstr ""
 "Kad nun s'aniciará si'l to puertu UDP ta deshabilitáu.\n"
 "Habilita un puertu UDP o deshabilita Kad."
 
-#: src/PrefsUnifiedDlg.cpp:1459
+#: src/PrefsUnifiedDlg.cpp:1385
 msgid ""
 "\n"
 "You MUST restart aMule now.\n"
@@ -5906,69 +5858,69 @@ msgstr ""
 "Hai de reaniciar aMule agora.\n"
 "Si nun reanicies agora, nun sabemos si pasará daqué malo.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1524
+#: src/PrefsUnifiedDlg.cpp:1450
 msgid "Could not register aMule for autostart at login. The autostart store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1526
+#: src/PrefsUnifiedDlg.cpp:1452
 msgid "Could not remove the autostart-at-login entry."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1527
+#: src/PrefsUnifiedDlg.cpp:1453
 #, fuzzy
 msgid "Autostart"
 msgstr "Auto recargar, aniciáu"
 
-#: src/PrefsUnifiedDlg.cpp:1542
+#: src/PrefsUnifiedDlg.cpp:1468
 msgid "Register file type"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1542
+#: src/PrefsUnifiedDlg.cpp:1468
 msgid "Register URL handler"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1550
+#: src/PrefsUnifiedDlg.cpp:1476
 #, c-format
 msgid "aMule only handles eD2k-compatible magnets. If you replace the current magnet handler (%s), BitTorrent magnet links will stop working - aMule cannot download BitTorrent content. Continue?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1555
+#: src/PrefsUnifiedDlg.cpp:1481
 #, c-format
 msgid "Another application currently opens .emulecollection files (%s). Replace it with aMule?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1560
+#: src/PrefsUnifiedDlg.cpp:1486
 #, c-format
 msgid "Another application is currently the default handler for these links (%s). Replace it with aMule?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1585
+#: src/PrefsUnifiedDlg.cpp:1511
 msgid "Could not register aMule for .emulecollection files. The registration store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1587
+#: src/PrefsUnifiedDlg.cpp:1513
 #, fuzzy
 msgid "Could not remove the file type registration."
 msgstr "Carpeta pa los ficheros temporales de descargues"
 
-#: src/PrefsUnifiedDlg.cpp:1589
+#: src/PrefsUnifiedDlg.cpp:1515
 msgid "Could not register aMule as the URL handler. The registration store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1591
+#: src/PrefsUnifiedDlg.cpp:1517
 msgid "Could not remove the URL handler registration."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1661 src/PrefsUnifiedDlg.cpp:1688
+#: src/PrefsUnifiedDlg.cpp:1587 src/PrefsUnifiedDlg.cpp:1614
 #, fuzzy
 msgid "The web server and aMule API require external connections to be enabled."
 msgstr "Contraseña fixada y conexones esternes habilitaes."
 
-#: src/PrefsUnifiedDlg.cpp:1671
+#: src/PrefsUnifiedDlg.cpp:1597
 msgid "The aMule web server is deprecated. Consider running the aMule API instead."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1735
+#: src/PrefsUnifiedDlg.cpp:1655
 msgid ""
 "Your Auto-update servers list is in blank.\n"
 "Please fill in at least one URL to point to a valid server.met file.\n"
@@ -5978,66 +5930,66 @@ msgstr ""
 "Por favor introduz a lo menos una URL con un ficheru server.met válidu.\n"
 "Click nel botón \"Llista\" d'esta caxella  pa introducir una URL."
 
-#: src/PrefsUnifiedDlg.cpp:1876
+#: src/PrefsUnifiedDlg.cpp:1796
 msgid "Temporary files"
 msgstr "Ficheros temporales"
 
-#: src/PrefsUnifiedDlg.cpp:1881
+#: src/PrefsUnifiedDlg.cpp:1801
 msgid "Incoming files"
 msgstr "Ficheros entrantes"
 
-#: src/PrefsUnifiedDlg.cpp:1886
+#: src/PrefsUnifiedDlg.cpp:1806
 msgid "Online Signatures"
 msgstr "Robles online"
 
-#: src/PrefsUnifiedDlg.cpp:1899
+#: src/PrefsUnifiedDlg.cpp:1819
 #, c-format
 msgid "Choose a folder for %s"
 msgstr "Escueye una carpeta pa %s"
 
-#: src/PrefsUnifiedDlg.cpp:1923
+#: src/PrefsUnifiedDlg.cpp:1843
 #, fuzzy, c-format
 msgid "Would exclude %u of %u shared file"
 msgid_plural "Would exclude %u of %u shared files"
 msgstr[0] "Alcontróse %i ficheru compartíu"
 msgstr[1] "Alcontráronse %i ficheros compartíos"
 
-#: src/PrefsUnifiedDlg.cpp:1940
+#: src/PrefsUnifiedDlg.cpp:1860
 msgid "Browse for videoplayer"
 msgstr "Esplorar"
 
-#: src/PrefsUnifiedDlg.cpp:1944
+#: src/PrefsUnifiedDlg.cpp:1864
 msgid "Select browser"
 msgstr "Seleiciona restolador"
 
-#: src/PrefsUnifiedDlg.cpp:1948
+#: src/PrefsUnifiedDlg.cpp:1868
 #, fuzzy
 msgid "Select ffprobe binary"
 msgstr "Seleiciona restolador"
 
-#: src/PrefsUnifiedDlg.cpp:1954
+#: src/PrefsUnifiedDlg.cpp:1874
 #, c-format
 msgid "Executable%s"
 msgstr "Executable%s"
 
-#: src/PrefsUnifiedDlg.cpp:1988
+#: src/PrefsUnifiedDlg.cpp:1908
 msgid "ffprobe not found on PATH or in the standard install locations. Install ffmpeg (which ships ffprobe) or use Browse to pick a binary manually."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2000
+#: src/PrefsUnifiedDlg.cpp:1920
 msgid "Reset the settings on this page to their default values?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2001
+#: src/PrefsUnifiedDlg.cpp:1921
 #, fuzzy
 msgid "Reset to defaults"
 msgstr "Por defeutu"
 
-#: src/PrefsUnifiedDlg.cpp:2028
+#: src/PrefsUnifiedDlg.cpp:1948
 msgid "Edit server list"
 msgstr "Editar llista de sirvidores"
 
-#: src/PrefsUnifiedDlg.cpp:2029
+#: src/PrefsUnifiedDlg.cpp:1949
 msgid ""
 "Add here URL's to download server.met files.\n"
 "Only one url on each line."
@@ -6045,180 +5997,176 @@ msgstr ""
 "Amesta equí les URL's pa descargar los ficheros server.met.\n"
 "Namái una url per llinia."
 
-#: src/PrefsUnifiedDlg.cpp:2084
+#: src/PrefsUnifiedDlg.cpp:2004
 msgid "IP2Country update failed"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2229 src/PrefsUnifiedDlg.cpp:2260
+#: src/PrefsUnifiedDlg.cpp:2149 src/PrefsUnifiedDlg.cpp:2180
 msgid "Data by MaxMind GeoLite2"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2231 src/PrefsUnifiedDlg.cpp:2262
+#: src/PrefsUnifiedDlg.cpp:2151 src/PrefsUnifiedDlg.cpp:2182
 #, fuzzy
 msgid "Custom source"
 msgstr "Fontes completes"
 
-#: src/PrefsUnifiedDlg.cpp:2233 src/PrefsUnifiedDlg.cpp:2264
+#: src/PrefsUnifiedDlg.cpp:2153 src/PrefsUnifiedDlg.cpp:2184
 msgid "Data by DB-IP.com"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2284
+#: src/PrefsUnifiedDlg.cpp:2204
 #, fuzzy, c-format
 msgid "Status: Loaded%s"
 msgstr "Estáu:"
 
-#: src/PrefsUnifiedDlg.cpp:2286
+#: src/PrefsUnifiedDlg.cpp:2206
 #, fuzzy, c-format
 msgid "Status: Loaded%s - %s"
 msgstr "Estáu:"
 
-#: src/PrefsUnifiedDlg.cpp:2290
+#: src/PrefsUnifiedDlg.cpp:2210
 msgid "Status: Failed to load - click 'Update now' to refresh."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2292
+#: src/PrefsUnifiedDlg.cpp:2212
 msgid "Status: Not found - click 'Update now' to download."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2350 src/PrefsUnifiedDlg.cpp:2374
+#: src/PrefsUnifiedDlg.cpp:2270 src/PrefsUnifiedDlg.cpp:2294
 #, c-format
 msgid "Update delay: %d second"
 msgid_plural "Update delay: %d seconds"
 msgstr[0] "Intervalu d'actualización: %d seg"
 msgstr[1] "Intervalu d'actualización: %d segs"
 
-#: src/PrefsUnifiedDlg.cpp:2358
+#: src/PrefsUnifiedDlg.cpp:2278
 #, c-format
 msgid "Time for average graph: %d minute"
 msgid_plural "Time for average graph: %d minutes"
 msgstr[0] "Tiempu mediu del gráficu: %d min"
 msgstr[1] "Tiempu mediu del gráficu: %d mins"
 
-#: src/PrefsUnifiedDlg.cpp:2367
+#: src/PrefsUnifiedDlg.cpp:2287
 #, c-format
 msgid "Connections Graph Scale: %d"
 msgstr "Escala gráfica de conexones: %d"
 
-#: src/PrefsUnifiedDlg.cpp:2382
+#: src/PrefsUnifiedDlg.cpp:2302
 #, c-format
 msgid "File Buffer Size: %d byte"
 msgid_plural "File Buffer Size: %d bytes"
 msgstr[0] "Tamañu del buffer de ficheru: %d byte"
 msgstr[1] "Tamañu del buffer de ficheru: %d bytes"
 
-#: src/PrefsUnifiedDlg.cpp:2392
+#: src/PrefsUnifiedDlg.cpp:2312
 #, c-format
 msgid "Upload Queue Size: %d client"
 msgid_plural "Upload Queue Size: %d clients"
 msgstr[0] "Tamañu de la cola de xuba: %d veceru"
 msgstr[1] "Tamañu de la cola de xuba: %d veceros"
 
-#: src/PrefsUnifiedDlg.cpp:2402
+#: src/PrefsUnifiedDlg.cpp:2322
 #, c-format
 msgid "Server connection refresh interval: %d minute"
 msgid_plural "Server connection refresh interval: %d minutes"
 msgstr[0] "Intervalu de refrescu de la conexón al sirvidor: %d minutu"
 msgstr[1] "Intervalu de refrescu de la conexón al sirvidor: %d minutos"
 
-#: src/PrefsUnifiedDlg.cpp:2407
+#: src/PrefsUnifiedDlg.cpp:2327
 msgid "Server connection refresh interval: Disabled"
 msgstr "Intervalu de refrescu de la conexón al sirvidor: Deshabilitáu"
 
-#: src/PrefsUnifiedDlg.cpp:2451
+#: src/PrefsUnifiedDlg.cpp:2371
 msgid "disabled"
 msgstr "deshabilitáu"
 
-#: src/PrefsUnifiedDlg.cpp:2477
+#: src/PrefsUnifiedDlg.cpp:2397
 #, fuzzy, c-format
 msgid "Execute command on '%s' event"
 msgstr "Executar comandu nel eventu `%s'"
 
-#: src/PrefsUnifiedDlg.cpp:2484
+#: src/PrefsUnifiedDlg.cpp:2404
 msgid "Enable command execution on core"
 msgstr "Habilitar execución de comandu nel núcleu"
 
-#: src/PrefsUnifiedDlg.cpp:2496
+#: src/PrefsUnifiedDlg.cpp:2416
 msgid "Core command:"
 msgstr "Comandu del núcleu:"
 
-#: src/PrefsUnifiedDlg.cpp:2512
+#: src/PrefsUnifiedDlg.cpp:2432
 msgid "Enable command execution on GUI"
 msgstr "Habilitar execución de comandu na Interface"
 
-#: src/PrefsUnifiedDlg.cpp:2524
+#: src/PrefsUnifiedDlg.cpp:2444
 msgid "GUI command:"
 msgstr "Comandu de la Interface: "
 
-#: src/PrefsUnifiedDlg.cpp:2540
+#: src/PrefsUnifiedDlg.cpp:2460
 msgid "The following variables will be replaced:"
 msgstr "Les siguientes variables trocaránse:"
 
-#: src/PrefsUnifiedDlg.cpp:2708
+#: src/PrefsUnifiedDlg.cpp:2628
 msgid ""
 "The following folders look like system or sensitive locations:\n"
 "\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2713
+#: src/PrefsUnifiedDlg.cpp:2633
 msgid "Sharing them recursively will publish every file underneath on the eD2k/Kad networks. Do you really want to do this?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2716
+#: src/PrefsUnifiedDlg.cpp:2636
 #, fuzzy
 msgid "Confirm shared folders"
 msgstr "Carpetes compartíes"
 
-#: src/PrefsUnifiedDlg.cpp:2744
+#: src/PrefsUnifiedDlg.cpp:2664
 #, fuzzy
 msgid "Reloading shared files..."
 msgstr "Recargar los tos ficheros compartíos"
 
-#: src/PrefsUnifiedDlg.cpp:2745
+#: src/PrefsUnifiedDlg.cpp:2665
 msgid "Scanning for subdirectories..."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2746
+#: src/PrefsUnifiedDlg.cpp:2666
 #, fuzzy
 msgid "Updating shared folders"
 msgstr "Carpetes compartíes"
 
-#: src/PrefsUnifiedDlg.cpp:2773
+#: src/PrefsUnifiedDlg.cpp:2693
 #, c-format
 msgid "Scanned %u directories..."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2823
+#: src/PrefsUnifiedDlg.cpp:2743
 #, fuzzy, c-format
 msgid "Reloading shared files: %u files scanned"
 msgstr "Recargar llista de ficheros compartíos."
 
-#: src/PrefsUnifiedDlg.cpp:2873
+#: src/PrefsUnifiedDlg.cpp:2793
 #, fuzzy
 msgid "Shared folder"
 msgstr "Carpetes compartíes"
 
-#: src/SearchDlg.cpp:280
-msgid "Clear search history"
-msgstr ""
-
-#: src/SearchDlg.cpp:584
+#: src/SearchDlg.cpp:425
 msgid "It's impossible to search when both eD2k and Kademlia are disabled."
 msgstr ""
 
-#: src/SearchDlg.cpp:585 src/SearchListCtrl.cpp:858
+#: src/SearchDlg.cpp:426 src/SearchListCtrl.cpp:858
 #, fuzzy
 msgid "Search error"
 msgstr "Guetar"
 
-#: src/SearchDlg.cpp:929
+#: src/SearchDlg.cpp:768
 msgid "Min size must be smaller than max size. Max size ignored."
 msgstr "El tamañu mínimu tien de ser menor al tamañu máximu. Tamañu máximu inoráu."
 
-#: src/SearchDlg.cpp:930 src/SearchDlg.cpp:1012
+#: src/SearchDlg.cpp:769 src/SearchDlg.cpp:851
 msgid "Search warning"
 msgstr "Alerta de gueta"
 
-#: src/SearchDlg.cpp:1092 src/SearchListCtrl.cpp:735
+#: src/SearchDlg.cpp:929 src/SearchListCtrl.cpp:735
 msgid "Main"
 msgstr "Principal"
 

--- a/po/bg.po
+++ b/po/bg.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-28 12:17+0200\n"
+"POT-Creation-Date: 2026-07-28 13:09+0200\n"
 "PO-Revision-Date: 2026-07-27 11:32+0000\n"
 "Last-Translator: Sebastiano Pistore <SebastianoPistore.info@protonmail.ch>\n"
 "Language-Team: Bulgarian <dict@linux.zonebg.com>\n"
@@ -282,7 +282,7 @@ msgid "Password set and external connections enabled."
 msgstr ""
 
 #: src/amule.cpp:755 src/KadDlg.cpp:176 src/KadDlg.cpp:185
-#: src/PrefsUnifiedDlg.cpp:1461 src/SharedFilesCtrl.cpp:476
+#: src/PrefsUnifiedDlg.cpp:1470 src/SharedFilesCtrl.cpp:476
 msgid "WARNING"
 msgstr ""
 
@@ -318,7 +318,7 @@ msgstr ""
 #: src/amule-remote-gui.cpp:603 src/amule-remote-gui.cpp:671
 #: src/amule-remote-gui.cpp:709 src/amule-remote-gui.cpp:1282
 #: src/amule-remote-gui.cpp:1345 src/amule-remote-gui.cpp:1372
-#: src/DownloadQueue.cpp:1481 src/PrefsUnifiedDlg.cpp:1247
+#: src/DownloadQueue.cpp:1481 src/PrefsUnifiedDlg.cpp:1256
 msgid "ERROR"
 msgstr ""
 
@@ -571,36 +571,36 @@ msgstr ""
 msgid "FATAL ERROR: Failed to create Timer"
 msgstr ""
 
-#: src/amuleDlg.cpp:361 src/amuleDlg.cpp:1787 src/amuleDlg.cpp:2033
-#: src/muuli_wdr.cpp:1492 src/muuli_wdr.cpp:3449
+#: src/amuleDlg.cpp:361 src/amuleDlg.cpp:1810 src/amuleDlg.cpp:2056
+#: src/muuli_wdr.cpp:1492 src/muuli_wdr.cpp:3453
 msgid "Networks"
 msgstr ""
 
-#: src/amuleDlg.cpp:362 src/amuleDlg.cpp:1793 src/muuli_wdr.cpp:3450
+#: src/amuleDlg.cpp:362 src/amuleDlg.cpp:1816 src/muuli_wdr.cpp:3454
 msgid "Searches"
 msgstr ""
 
-#: src/amuleDlg.cpp:363 src/amuleDlg.cpp:1799 src/DownloadListCtrl.cpp:740
-#: src/muuli_wdr.cpp:392 src/muuli_wdr.cpp:1585 src/muuli_wdr.cpp:3451
+#: src/amuleDlg.cpp:363 src/amuleDlg.cpp:1822 src/DownloadListCtrl.cpp:740
+#: src/muuli_wdr.cpp:392 src/muuli_wdr.cpp:1585 src/muuli_wdr.cpp:3455
 #: src/Statistics.cpp:829
 msgid "Downloads"
 msgstr ""
 
-#: src/amuleDlg.cpp:364 src/amuleDlg.cpp:1805 src/muuli_wdr.cpp:3325
+#: src/amuleDlg.cpp:364 src/amuleDlg.cpp:1828 src/muuli_wdr.cpp:3329
 msgid "Shared files"
 msgstr ""
 
-#: src/amuleDlg.cpp:365 src/amuleDlg.cpp:1811 src/muuli_wdr.cpp:2957
-#: src/muuli_wdr.cpp:3407 src/muuli_wdr.cpp:3454
+#: src/amuleDlg.cpp:365 src/amuleDlg.cpp:1834 src/muuli_wdr.cpp:2961
+#: src/muuli_wdr.cpp:3411 src/muuli_wdr.cpp:3458
 msgid "Messages"
 msgstr "Съобщения"
 
-#: src/amuleDlg.cpp:366 src/amuleDlg.cpp:1817 src/muuli_wdr.cpp:3455
+#: src/amuleDlg.cpp:366 src/amuleDlg.cpp:1840 src/muuli_wdr.cpp:3459
 #: src/PrefsUnifiedDlg.cpp:314 src/Statistics.cpp:779 src/Statistics.cpp:1235
 msgid "Statistics"
 msgstr "Статистика"
 
-#: src/amuleDlg.cpp:368 src/amuleDlg.cpp:1824 src/muuli_wdr.cpp:3457
+#: src/amuleDlg.cpp:368 src/amuleDlg.cpp:1847 src/muuli_wdr.cpp:3461
 #: src/PrefsUnifiedDlg.cpp:330 src/utils/wxCas/src/wxcasprefs.cpp:39
 msgid "Preferences"
 msgstr "Настройки"
@@ -660,8 +660,8 @@ msgstr ""
 #: src/amuleDlg.cpp:1029 src/DownloadListCtrl.cpp:505
 #: src/DownloadListCtrl.cpp:749 src/FriendListCtrl.cpp:180
 #: src/muuli_wdr.cpp:731 src/muuli_wdr.cpp:782 src/muuli_wdr.cpp:846
-#: src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2262 src/muuli_wdr.cpp:2347
-#: src/muuli_wdr.cpp:3095 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
+#: src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2266 src/muuli_wdr.cpp:2351
+#: src/muuli_wdr.cpp:3099 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
 #: src/ServerListCtrl.cpp:606 src/TransferWnd.cpp:378
 #: src/utils/wxCas/src/wxcasprefs.cpp:235
 msgid "Cancel"
@@ -673,7 +673,7 @@ msgid "Stop the current connection attempts"
 msgstr "Спира текущите опити за свързване"
 
 #: src/amuleDlg.cpp:1035 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976
-#: src/muuli_wdr.cpp:2485
+#: src/muuli_wdr.cpp:2489
 msgid "Disconnect"
 msgstr "Разкачи"
 
@@ -683,7 +683,7 @@ msgid "Disconnect from the currently connected networks"
 msgstr "Изключване от текущия сървър"
 
 #: src/amuleDlg.cpp:1041 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979
-#: src/muuli_wdr.cpp:2640 src/muuli_wdr.cpp:3092 src/muuli_wdr.cpp:3447
+#: src/muuli_wdr.cpp:2644 src/muuli_wdr.cpp:3096 src/muuli_wdr.cpp:3451
 msgid "Connect"
 msgstr "Връзка"
 
@@ -737,7 +737,7 @@ msgstr "Потвърждение за изход"
 msgid "Launch Command: "
 msgstr ""
 
-#: src/amuleDlg.cpp:1632 src/muuli_wdr.cpp:1982 src/Preferences.cpp:979
+#: src/amuleDlg.cpp:1632 src/muuli_wdr.cpp:1986 src/Preferences.cpp:979
 msgid "- default -"
 msgstr "- по подразбиране -"
 
@@ -751,61 +751,61 @@ msgstr ""
 msgid "WARNING: Unable to open skin file '%s' for read"
 msgstr ""
 
-#: src/amuleDlg.cpp:1791 src/muuli_wdr.cpp:3449
+#: src/amuleDlg.cpp:1814 src/muuli_wdr.cpp:3453
 msgid "Networks Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1797 src/muuli_wdr.cpp:3450
+#: src/amuleDlg.cpp:1820 src/muuli_wdr.cpp:3454
 msgid "Searches Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1803 src/muuli_wdr.cpp:3451
+#: src/amuleDlg.cpp:1826 src/muuli_wdr.cpp:3455
 #, fuzzy
 msgid "Downloads Window"
 msgstr "Изтегляне"
 
-#: src/amuleDlg.cpp:1809 src/muuli_wdr.cpp:3453
+#: src/amuleDlg.cpp:1832 src/muuli_wdr.cpp:3457
 msgid "Shared Files Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1815 src/muuli_wdr.cpp:3454
+#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3458
 msgid "Messages Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1821 src/muuli_wdr.cpp:3455
+#: src/amuleDlg.cpp:1844 src/muuli_wdr.cpp:3459
 msgid "Statistics Graph Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1828 src/muuli_wdr.cpp:3457
+#: src/amuleDlg.cpp:1851 src/muuli_wdr.cpp:3461
 msgid "Preferences Settings Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1831 src/muuli_wdr.cpp:3458
+#: src/amuleDlg.cpp:1854 src/muuli_wdr.cpp:3462
 msgid "Import"
 msgstr ""
 
-#: src/amuleDlg.cpp:1835 src/muuli_wdr.cpp:3458
+#: src/amuleDlg.cpp:1858 src/muuli_wdr.cpp:3462
 msgid "The partfile importer tool"
 msgstr ""
 
-#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3459
+#: src/amuleDlg.cpp:1861 src/muuli_wdr.cpp:3463
 #: src/utils/aLinkCreator/src/alcframe.cpp:262
 msgid "About"
 msgstr ""
 
-#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3459
+#: src/amuleDlg.cpp:1861 src/muuli_wdr.cpp:3463
 msgid "About/Help"
 msgstr ""
 
-#: src/amuleDlg.cpp:2036
+#: src/amuleDlg.cpp:2059
 msgid "eD2k network"
 msgstr ""
 
-#: src/amuleDlg.cpp:2039
+#: src/amuleDlg.cpp:2062
 msgid "Kad network"
 msgstr ""
 
-#: src/amuleDlg.cpp:2039
+#: src/amuleDlg.cpp:2062
 msgid "No network"
 msgstr "Няма мрежа"
 
@@ -1338,19 +1338,19 @@ msgstr "Автоматичен [Hi]"
 msgid "Very low"
 msgstr ""
 
-#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:743 src/muuli_wdr.cpp:2313
+#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:743 src/muuli_wdr.cpp:2317
 #: src/ServerListCtrl.cpp:263 src/ServerListCtrl.cpp:456
 #: src/SharedFilesCtrl.cpp:145
 msgid "Low"
 msgstr "Ниско"
 
-#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:744 src/muuli_wdr.cpp:2314
+#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:744 src/muuli_wdr.cpp:2318
 #: src/ServerListCtrl.cpp:266 src/ServerListCtrl.cpp:457
 #: src/SharedFilesCtrl.cpp:146
 msgid "Normal"
 msgstr "Нормален"
 
-#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:745 src/muuli_wdr.cpp:2315
+#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:745 src/muuli_wdr.cpp:2319
 #: src/ServerListCtrl.cpp:269 src/ServerListCtrl.cpp:458
 #: src/SharedFilesCtrl.cpp:147
 msgid "High"
@@ -1442,7 +1442,7 @@ msgstr ""
 msgid "Remote Server"
 msgstr ""
 
-#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3212
+#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3216
 #: src/SearchDlg.cpp:119 src/TextClient.cpp:911
 msgid "Kad"
 msgstr ""
@@ -1513,7 +1513,7 @@ msgstr ""
 msgid "Size"
 msgstr "Размер"
 
-#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3279
+#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3283
 msgid "Transferred"
 msgstr "Пренесен"
 
@@ -1571,7 +1571,7 @@ msgid ""
 "\n"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:746 src/muuli_wdr.cpp:2316
+#: src/DownloadListCtrl.cpp:746 src/muuli_wdr.cpp:2320
 #: src/SharedFilesCtrl.cpp:150
 msgid "Auto"
 msgstr "Автоматично"
@@ -1609,7 +1609,7 @@ msgid "Extended Options"
 msgstr ""
 
 #: src/DownloadListCtrl.cpp:770 src/DownloadListCtrl.cpp:822
-#: src/muuli_wdr.cpp:1800
+#: src/muuli_wdr.cpp:1804
 msgid "Preview"
 msgstr "Преглед"
 
@@ -2381,23 +2381,23 @@ msgid ""
 "want downloads on a different (e.g. larger) disk."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:549 src/FirstRunWizard.cpp:611 src/muuli_wdr.cpp:1712
+#: src/FirstRunWizard.cpp:549 src/FirstRunWizard.cpp:611 src/muuli_wdr.cpp:1716
 msgid "Destination folder for downloads"
 msgstr ""
 
 #: src/FirstRunWizard.cpp:553 src/FirstRunWizard.cpp:569 src/muuli_wdr.cpp:1349
-#: src/muuli_wdr.cpp:1366 src/muuli_wdr.cpp:1687 src/muuli_wdr.cpp:1718
-#: src/muuli_wdr.cpp:1730 src/muuli_wdr.cpp:2800
+#: src/muuli_wdr.cpp:1366 src/muuli_wdr.cpp:1691 src/muuli_wdr.cpp:1722
+#: src/muuli_wdr.cpp:1734 src/muuli_wdr.cpp:2804
 #: src/utils/aLinkCreator/src/alcframe.cpp:135
 #: src/utils/wxCas/src/wxcasprefs.cpp:52 src/utils/wxCas/src/wxcasprefs.cpp:118
 msgid "Browse"
 msgstr "Избери"
 
-#: src/FirstRunWizard.cpp:559 src/muuli_wdr.cpp:1723
+#: src/FirstRunWizard.cpp:559 src/muuli_wdr.cpp:1727
 msgid "(All files in this folder are shared with other peers)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:565 src/FirstRunWizard.cpp:624 src/muuli_wdr.cpp:1725
+#: src/FirstRunWizard.cpp:565 src/FirstRunWizard.cpp:624 src/muuli_wdr.cpp:1729
 msgid "Folder for temporary download files"
 msgstr ""
 
@@ -2428,7 +2428,7 @@ msgstr ""
 msgid "CRITICAL - no client on StartChatSession"
 msgstr ""
 
-#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2706 src/muuli_wdr.cpp:3383
+#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2710 src/muuli_wdr.cpp:3387
 msgid "Friends"
 msgstr "Приятели"
 
@@ -2537,8 +2537,8 @@ msgstr "никой"
 msgid "No"
 msgstr "Не"
 
-#: src/GenericClientListCtrl.cpp:1216 src/PrefsUnifiedDlg.cpp:2898
-#: src/PrefsUnifiedDlg.cpp:2948 src/ServerListCtrl.cpp:276
+#: src/GenericClientListCtrl.cpp:1216 src/PrefsUnifiedDlg.cpp:2907
+#: src/PrefsUnifiedDlg.cpp:2957 src/ServerListCtrl.cpp:276
 msgid "Yes"
 msgstr "Да"
 
@@ -2705,10 +2705,10 @@ msgstr ""
 msgid "Please fill all fields required"
 msgstr ""
 
-#: src/KadDlg.cpp:192 src/PartFile.cpp:1031 src/PrefsUnifiedDlg.cpp:1134
-#: src/PrefsUnifiedDlg.cpp:1204 src/PrefsUnifiedDlg.cpp:1405
-#: src/PrefsUnifiedDlg.cpp:1663 src/PrefsUnifiedDlg.cpp:1673
-#: src/PrefsUnifiedDlg.cpp:1690 src/PrefsUnifiedDlg.cpp:1738
+#: src/KadDlg.cpp:192 src/PartFile.cpp:1031 src/PrefsUnifiedDlg.cpp:1143
+#: src/PrefsUnifiedDlg.cpp:1213 src/PrefsUnifiedDlg.cpp:1414
+#: src/PrefsUnifiedDlg.cpp:1672 src/PrefsUnifiedDlg.cpp:1682
+#: src/PrefsUnifiedDlg.cpp:1699 src/PrefsUnifiedDlg.cpp:1747
 msgid "Message"
 msgstr ""
 
@@ -2809,7 +2809,7 @@ msgstr ""
 msgid "Uploaded"
 msgstr ""
 
-#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3263
+#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3267
 msgid "Requested"
 msgstr ""
 
@@ -2933,7 +2933,7 @@ msgid "WARNING: "
 msgstr ""
 
 #: src/MuleNotebook.cpp:179 src/muuli_wdr.cpp:817 src/muuli_wdr.cpp:1229
-#: src/muuli_wdr.cpp:3167 src/muuli_wdr.cpp:3423
+#: src/muuli_wdr.cpp:3171 src/muuli_wdr.cpp:3427
 msgid "Close"
 msgstr "Затвори"
 
@@ -2951,7 +2951,7 @@ msgid "Paste"
 msgstr ""
 
 #: src/MuleTextCtrl.cpp:89 src/muuli_wdr.cpp:358 src/muuli_wdr.cpp:757
-#: src/muuli_wdr.cpp:2390 src/muuli_wdr.cpp:2409 src/muuli_wdr.cpp:2431
+#: src/muuli_wdr.cpp:2394 src/muuli_wdr.cpp:2413 src/muuli_wdr.cpp:2435
 #: src/utils/aLinkCreator/src/alcframe.cpp:142
 msgid "Clear"
 msgstr "Изчисти"
@@ -3047,7 +3047,7 @@ msgstr "Изход"
 
 #: src/MuleTrayIcon.cpp:579 src/MuleTrayIcon.cpp:945 src/MuleTrayIcon.cpp:965
 #: src/muuli_wdr.cpp:1398 src/muuli_wdr.cpp:1406 src/muuli_wdr.cpp:1413
-#: src/muuli_wdr.cpp:1846 src/muuli_wdr.cpp:1852 src/OtherFunctions.cpp:91
+#: src/muuli_wdr.cpp:1850 src/muuli_wdr.cpp:1856 src/OtherFunctions.cpp:91
 #: src/StatisticsDlg.cpp:93 src/StatisticsDlg.cpp:95
 msgid "kB/s"
 msgstr "кБ/с"
@@ -3287,7 +3287,7 @@ msgstr "Байта"
 msgid "KB"
 msgstr "KB"
 
-#: src/muuli_wdr.cpp:274 src/muuli_wdr.cpp:293 src/muuli_wdr.cpp:1631
+#: src/muuli_wdr.cpp:274 src/muuli_wdr.cpp:293 src/muuli_wdr.cpp:1635
 #: src/OtherFunctions.cpp:64
 msgid "MB"
 msgstr "MB"
@@ -3304,7 +3304,7 @@ msgstr "Максимален размер"
 msgid "Availability"
 msgstr ""
 
-#: src/muuli_wdr.cpp:312 src/muuli_wdr.cpp:398 src/muuli_wdr.cpp:3328
+#: src/muuli_wdr.cpp:312 src/muuli_wdr.cpp:398 src/muuli_wdr.cpp:3332
 msgid "Filter:"
 msgstr ""
 
@@ -3368,8 +3368,8 @@ msgstr "Намерени източници: %i"
 #: src/muuli_wdr.cpp:1160 src/muuli_wdr.cpp:1167 src/muuli_wdr.cpp:1172
 #: src/muuli_wdr.cpp:1179 src/muuli_wdr.cpp:1184 src/muuli_wdr.cpp:1191
 #: src/muuli_wdr.cpp:1205 src/muuli_wdr.cpp:1212 src/muuli_wdr.cpp:1217
-#: src/muuli_wdr.cpp:1224 src/muuli_wdr.cpp:3265 src/muuli_wdr.cpp:3273
-#: src/muuli_wdr.cpp:3281
+#: src/muuli_wdr.cpp:1224 src/muuli_wdr.cpp:3269 src/muuli_wdr.cpp:3277
+#: src/muuli_wdr.cpp:3285
 msgid "N/A"
 msgstr "Няма"
 
@@ -3511,7 +3511,7 @@ msgstr ""
 msgid "Album :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:685 src/muuli_wdr.cpp:2285
+#: src/muuli_wdr.cpp:685 src/muuli_wdr.cpp:2289
 msgid "Title :"
 msgstr "Заглавие :"
 
@@ -3617,7 +3617,7 @@ msgstr ""
 msgid "Userhash :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:895 src/muuli_wdr.cpp:1752 src/muuli_wdr.cpp:2480
+#: src/muuli_wdr.cpp:895 src/muuli_wdr.cpp:1756 src/muuli_wdr.cpp:2484
 #: src/utils/aLinkCreator/src/alcframe.cpp:137
 msgid "Add"
 msgstr "Добавяне"
@@ -3626,15 +3626,15 @@ msgstr "Добавяне"
 msgid "Download-Speed"
 msgstr ""
 
-#: src/muuli_wdr.cpp:954 src/muuli_wdr.cpp:989 src/muuli_wdr.cpp:2584
+#: src/muuli_wdr.cpp:954 src/muuli_wdr.cpp:989 src/muuli_wdr.cpp:2588
 msgid "Current"
 msgstr "Текущ"
 
-#: src/muuli_wdr.cpp:962 src/muuli_wdr.cpp:997 src/muuli_wdr.cpp:2592
+#: src/muuli_wdr.cpp:962 src/muuli_wdr.cpp:997 src/muuli_wdr.cpp:2596
 msgid "Running average"
 msgstr ""
 
-#: src/muuli_wdr.cpp:970 src/muuli_wdr.cpp:1005 src/muuli_wdr.cpp:2600
+#: src/muuli_wdr.cpp:970 src/muuli_wdr.cpp:1005 src/muuli_wdr.cpp:2604
 msgid "Session average"
 msgstr ""
 
@@ -3646,7 +3646,7 @@ msgstr ""
 msgid "Connections"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1024 src/muuli_wdr.cpp:1871
+#: src/muuli_wdr.cpp:1024 src/muuli_wdr.cpp:1875
 msgid "Active downloads"
 msgstr ""
 
@@ -3654,7 +3654,7 @@ msgstr ""
 msgid "Active connections (1:1)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1040 src/muuli_wdr.cpp:1872
+#: src/muuli_wdr.cpp:1040 src/muuli_wdr.cpp:1876
 msgid "Active uploads"
 msgstr ""
 
@@ -3928,7 +3928,7 @@ msgstr ""
 msgid "Advanced users only: If you have multiple network interfaces, enter the address of the interface to which aMule should be bound."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1462 src/muuli_wdr.cpp:2065
+#: src/muuli_wdr.cpp:1462 src/muuli_wdr.cpp:2069
 msgid "Bind to network interface (empty for any):"
 msgstr ""
 
@@ -3944,7 +3944,7 @@ msgstr ""
 msgid "Max simultaneous connections:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1498 src/muuli_wdr.cpp:3207
+#: src/muuli_wdr.cpp:1498 src/muuli_wdr.cpp:3211
 msgid "ED2K"
 msgstr ""
 
@@ -4036,768 +4036,768 @@ msgstr ""
 msgid "For new files preallocates disk space for the whole file, thus reduces fragmentation"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1617
+#: src/muuli_wdr.cpp:1621
 msgid "Create new files as sparse files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1618
+#: src/muuli_wdr.cpp:1622
 msgid "Sparse part files only occupy disk space for the parts already downloaded, so free space is used up gradually as the file fills in. Turn this off to use an ordinary file instead - useful where sparse files are unsupported or slow, or where backup/de-duplication tools handle them badly. Applies only when the core runs on Windows; on Linux and macOS part files are sparse anyway and this setting has no effect."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1623
+#: src/muuli_wdr.cpp:1627
 msgid "Stop downloads when free disk space reaches "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1624
+#: src/muuli_wdr.cpp:1628
 msgid "Select this if you want aMule to check your disk space"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1628
+#: src/muuli_wdr.cpp:1632
 msgid "Enter here the min disk space desired."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1634
+#: src/muuli_wdr.cpp:1638
 msgid "Save 10 sources on rare files (< 20 sources)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1638 src/Statistics.cpp:790
+#: src/muuli_wdr.cpp:1642 src/Statistics.cpp:790
 msgid "Uploads"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1641
+#: src/muuli_wdr.cpp:1645
 msgid "Add new shared files with auto priority"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1647
+#: src/muuli_wdr.cpp:1651
 msgid "Intelligent Corruption Handling (I.C.H.)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1650
+#: src/muuli_wdr.cpp:1654
 msgid "Enable"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1653
+#: src/muuli_wdr.cpp:1657
 msgid "Advanced I.C.H. trusts every hash (not recommended)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1665 src/PrefsUnifiedDlg.cpp:1990
+#: src/muuli_wdr.cpp:1669 src/PrefsUnifiedDlg.cpp:1999
 msgid "Media metadata extraction"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1669
+#: src/muuli_wdr.cpp:1673
 msgid "Extract length / bitrate / codec from shared audio and video files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1671
+#: src/muuli_wdr.cpp:1675
 msgid "When enabled, aMule runs ffprobe on each shared media file to fill in the Length / Bitrate / Codec columns other clients see when they find the file in a search. Requires ffmpeg (the ffprobe binary) to be installed."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1678
+#: src/muuli_wdr.cpp:1682
 msgid "Path to ffprobe:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1683
+#: src/muuli_wdr.cpp:1687
 msgid "Full path to the ffprobe binary. Leave empty to have aMule auto-detect it on startup."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1691
+#: src/muuli_wdr.cpp:1695
 msgid "Detect"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1692
+#: src/muuli_wdr.cpp:1696
 msgid "Search the standard install locations for an ffprobe binary and fill the path field."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1716
+#: src/muuli_wdr.cpp:1720
 msgid ""
 "Completed downloads are stored here. All files in this folder are automatically shared with other peers.\n"
 "If this folder also holds files you don't want to share, point it at an aMule-only sub-folder."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1719
+#: src/muuli_wdr.cpp:1723
 msgid "Pick the folder where completed downloads will be stored. All files in that folder will be shared with other peers."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1733
+#: src/muuli_wdr.cpp:1737
 msgid "Shared folders"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1739
+#: src/muuli_wdr.cpp:1743
 msgid "(Folders shared by the core. Enter a path to add one.)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1747
+#: src/muuli_wdr.cpp:1751
 msgid "Absolute path of a folder on the core's machine, e.g. /home/user/shared"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1749 src/PrefsUnifiedDlg.cpp:2874
+#: src/muuli_wdr.cpp:1753 src/PrefsUnifiedDlg.cpp:2883
 msgid "Recursive"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1750
+#: src/muuli_wdr.cpp:1754
 msgid "Share every sub-folder underneath this one, including ones created later."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1754 src/utils/aLinkCreator/src/alcframe.cpp:141
+#: src/muuli_wdr.cpp:1758 src/utils/aLinkCreator/src/alcframe.cpp:141
 msgid "Remove"
 msgstr "Премахване"
 
-#: src/muuli_wdr.cpp:1758
+#: src/muuli_wdr.cpp:1762
 msgid "(Right click on folder icon for recursive share)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1765
+#: src/muuli_wdr.cpp:1769
 msgid "Share hidden files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1771
+#: src/muuli_wdr.cpp:1775
 msgid "Automatically rescan shared folders for changes"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1777
+#: src/muuli_wdr.cpp:1781
 msgid "Follow symbolic links in shared folders"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1783
+#: src/muuli_wdr.cpp:1787
 msgid "Exclude files matching:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1786
+#: src/muuli_wdr.cpp:1790
 msgid "Wildcard patterns separated by '|', e.g. .DS_Store|Thumbs.db|*.tmp. Files whose name matches are not shared. Matching is case-insensitive."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1790
+#: src/muuli_wdr.cpp:1794
 msgid "Patterns are regular expressions"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1791
+#: src/muuli_wdr.cpp:1795
 msgid "When set, the whole field is one regular expression ('|' is alternation). When unset, it is a list of '|'-separated wildcards."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1801
+#: src/muuli_wdr.cpp:1805
 msgid "Show how many shared files the current pattern would exclude."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1822
+#: src/muuli_wdr.cpp:1826
 msgid "Graphs"
 msgstr "Диаграми"
 
-#: src/muuli_wdr.cpp:1825 src/muuli_wdr.cpp:1887
+#: src/muuli_wdr.cpp:1829 src/muuli_wdr.cpp:1891
 msgid "Update delay : 5 secs"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1829
+#: src/muuli_wdr.cpp:1833
 msgid "Time for average graph: 100 mins"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1833
+#: src/muuli_wdr.cpp:1837
 msgid "Connections Graph Scale: 100 "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1840
+#: src/muuli_wdr.cpp:1844
 msgid "Download graph scale:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1848
+#: src/muuli_wdr.cpp:1852
 msgid "Upload graph scale:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1858
+#: src/muuli_wdr.cpp:1862
 #, fuzzy
 msgid "Colors: "
 msgstr "Цветове: "
 
-#: src/muuli_wdr.cpp:1862
+#: src/muuli_wdr.cpp:1866
 msgid "Background"
 msgstr "Фон"
 
-#: src/muuli_wdr.cpp:1863
+#: src/muuli_wdr.cpp:1867
 msgid "Grid"
 msgstr "Мрежа"
 
-#: src/muuli_wdr.cpp:1864
+#: src/muuli_wdr.cpp:1868
 msgid "Download current"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1865
+#: src/muuli_wdr.cpp:1869
 msgid "Download running average"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1866
+#: src/muuli_wdr.cpp:1870
 msgid "Download session average"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1867
+#: src/muuli_wdr.cpp:1871
 msgid "Upload current"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1868
+#: src/muuli_wdr.cpp:1872
 msgid "Upload running average"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1869
+#: src/muuli_wdr.cpp:1873
 msgid "Upload session average"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1870
+#: src/muuli_wdr.cpp:1874
 msgid "Active connections"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1873
+#: src/muuli_wdr.cpp:1877
 msgid "Systray Icon Speed Bar"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1874
+#: src/muuli_wdr.cpp:1878
 msgid "Kad-nodes current"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1875
+#: src/muuli_wdr.cpp:1879
 msgid "Kad-nodes running"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1876
+#: src/muuli_wdr.cpp:1880
 msgid "Kad-nodes session"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1880 src/muuli_wdr.cpp:2334
+#: src/muuli_wdr.cpp:1884 src/muuli_wdr.cpp:2338
 msgid "Select"
 msgstr "Избор"
 
-#: src/muuli_wdr.cpp:1884
+#: src/muuli_wdr.cpp:1888
 msgid "Tree"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1894
+#: src/muuli_wdr.cpp:1898
 msgid "Number of Client Versions shown (0=unlimited)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1919
+#: src/muuli_wdr.cpp:1923
 msgid "!!! WARNING !!!"
 msgstr "!!! ВНИМАНИЕ !!!"
 
-#: src/muuli_wdr.cpp:1934
+#: src/muuli_wdr.cpp:1938
 msgid "Max new connections / 5 secs"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1936
+#: src/muuli_wdr.cpp:1940
 msgid "Concurrent Kad source lookups"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1938
+#: src/muuli_wdr.cpp:1942
 msgid "Kad source re-search interval (minutes)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1940
+#: src/muuli_wdr.cpp:1944
 msgid "Source re-ask interval (minutes)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1944
+#: src/muuli_wdr.cpp:1948
 msgid "File Buffer Size: 240000 bytes"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1948
+#: src/muuli_wdr.cpp:1952
 msgid "Use MMAP: memory-mapped file access (lower memory use)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1949
+#: src/muuli_wdr.cpp:1953
 msgid "Maps part files into memory instead of buffering them on the heap, lowering the process memory footprint. May reduce download speed on some disks; best for memory-constrained or upload-heavy hosts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1951
+#: src/muuli_wdr.cpp:1955
 msgid "Upload Queue Size: 5000 clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1955
+#: src/muuli_wdr.cpp:1959
 msgid "Server connection refresh interval: Disable"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1959
+#: src/muuli_wdr.cpp:1963
 msgid "Disable computer's timed standby mode"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1978
+#: src/muuli_wdr.cpp:1982
 msgid "Skin to use: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1987
+#: src/muuli_wdr.cpp:1991
 msgid "Show \"Fast eD2k Links Handler\" in every window."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1990
+#: src/muuli_wdr.cpp:1994
 msgid "Show extended info on categories tabs"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1993
+#: src/muuli_wdr.cpp:1997
 msgid "Show application version on title"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1995
+#: src/muuli_wdr.cpp:1999
 msgid "Show transfer rates on title"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1997
+#: src/muuli_wdr.cpp:2001
 msgid "Before application name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1999
+#: src/muuli_wdr.cpp:2003
 msgid "After application name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2002
+#: src/muuli_wdr.cpp:2006
 msgid "Show overhead bandwidth"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2006
+#: src/muuli_wdr.cpp:2010
 msgid "Vertical toolbar orientation"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2008
+#: src/muuli_wdr.cpp:2012
 msgid "Live column sorting (auto-reorder rows as their values change)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2015
+#: src/muuli_wdr.cpp:2019
 msgid "Download Queue Files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2018
+#: src/muuli_wdr.cpp:2022
 msgid "Show progress percentage"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2024
+#: src/muuli_wdr.cpp:2028
 msgid "Show progress bar"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2027
+#: src/muuli_wdr.cpp:2031
 msgid "Flat"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2031
+#: src/muuli_wdr.cpp:2035
 msgid "Round"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2049
+#: src/muuli_wdr.cpp:2053
 msgid "External Connection Parameters"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2052
+#: src/muuli_wdr.cpp:2056
 msgid "Accept external connections"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2059 src/muuli_wdr.cpp:2118
+#: src/muuli_wdr.cpp:2063 src/muuli_wdr.cpp:2122
 msgid "IP of the listening interface:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2062
+#: src/muuli_wdr.cpp:2066
 msgid "Enter here a valid ip in the a.b.c.d format for the listening EC interface. An empty field or 0.0.0.0 will mean any interface."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2083 src/muuli_wdr.cpp:2194
+#: src/muuli_wdr.cpp:2087 src/muuli_wdr.cpp:2198
 msgid "TCP port:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2089
+#: src/muuli_wdr.cpp:2093
 msgid "Enable UPnP port forwarding on the EC port"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2093 src/muuli_wdr.cpp:3079
+#: src/muuli_wdr.cpp:2097 src/muuli_wdr.cpp:3083
 #: src/utils/wxCas/src/wxcasprefs.cpp:167
 msgid "Password"
 msgstr "парола"
 
-#: src/muuli_wdr.cpp:2099
+#: src/muuli_wdr.cpp:2103
 msgid "aMule API server parameters"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2102
+#: src/muuli_wdr.cpp:2106
 msgid "Run amuleapi (REST API) on startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2107
+#: src/muuli_wdr.cpp:2111
 msgid "HTTP port:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2121
+#: src/muuli_wdr.cpp:2125
 msgid "The interface amuleapi's HTTP server listens on. 127.0.0.1 (default) accepts only local connections; use 0.0.0.0 or a specific IP to expose it to other hosts (set an admin password below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2126
+#: src/muuli_wdr.cpp:2130
 msgid "Type a password to set or change it. Stored passwords cannot be shown, so leaving this empty keeps the current one."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2128
+#: src/muuli_wdr.cpp:2132
 #, fuzzy
 msgid "Admin password"
 msgstr "парола"
 
-#: src/muuli_wdr.cpp:2140 src/muuli_wdr.cpp:2157 src/PrefsUnifiedDlg.cpp:1103
+#: src/muuli_wdr.cpp:2144 src/muuli_wdr.cpp:2161 src/PrefsUnifiedDlg.cpp:1112
 #, fuzzy
 msgid "A password is set."
 msgstr "парола"
 
-#: src/muuli_wdr.cpp:2144
+#: src/muuli_wdr.cpp:2148
 msgid "Enable guest access"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2145
+#: src/muuli_wdr.cpp:2149
 msgid "Guest sessions may read status and listings but cannot change anything. Turning this off clears the stored guest password."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2149
+#: src/muuli_wdr.cpp:2153
 #, fuzzy
 msgid "Guest password"
 msgstr "парола"
 
-#: src/muuli_wdr.cpp:2164
+#: src/muuli_wdr.cpp:2168
 msgid "Web server parameters"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2167
+#: src/muuli_wdr.cpp:2171
 msgid "Run webserver on startup (deprecated)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2173
+#: src/muuli_wdr.cpp:2177
 msgid "Web template"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2178
+#: src/muuli_wdr.cpp:2182
 msgid "Full rights password"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2182
+#: src/muuli_wdr.cpp:2186
 msgid "Enable Low rights User"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2187
+#: src/muuli_wdr.cpp:2191
 msgid "Low rights password"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2201
+#: src/muuli_wdr.cpp:2205
 msgid "Enable UPnP port forwarding of the web server port"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2206
+#: src/muuli_wdr.cpp:2210
 msgid "Web server UPnP TCP port (Optional)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2214
+#: src/muuli_wdr.cpp:2218
 msgid "Page Refresh Time (in secs)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2221
+#: src/muuli_wdr.cpp:2225
 msgid "Enable Gzip compression"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2255
+#: src/muuli_wdr.cpp:2259
 msgid "Reset page to defaults"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2256
+#: src/muuli_wdr.cpp:2260
 msgid "Reset the settings on the current page to their default values."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2258 src/muuli_wdr.cpp:2344 src/ServerWnd.cpp:274
+#: src/muuli_wdr.cpp:2262 src/muuli_wdr.cpp:2348 src/ServerWnd.cpp:274
 #: src/ServerWnd.cpp:282
 msgid "OK"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2260
+#: src/muuli_wdr.cpp:2264
 msgid "Click here to apply any changes made to the preferences."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2263
+#: src/muuli_wdr.cpp:2267
 msgid "Reset any changes made to the preferences."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2292
+#: src/muuli_wdr.cpp:2296
 msgid "Comment :"
 msgstr "Коментар:"
 
-#: src/muuli_wdr.cpp:2299
+#: src/muuli_wdr.cpp:2303
 msgid "Incoming Dir :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2308
+#: src/muuli_wdr.cpp:2312
 msgid "Change priority for new assigned files :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2312
+#: src/muuli_wdr.cpp:2316
 msgid "Don't change"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2324
+#: src/muuli_wdr.cpp:2328
 msgid "Select color for this Category (currently selected) :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2391 src/muuli_wdr.cpp:2410 src/muuli_wdr.cpp:2432
+#: src/muuli_wdr.cpp:2395 src/muuli_wdr.cpp:2414 src/muuli_wdr.cpp:2436
 msgid "Click this button to reset the log."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2451
+#: src/muuli_wdr.cpp:2455
 msgid "Click on this button to update the servers list from URL ..."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2455
+#: src/muuli_wdr.cpp:2459
 msgid "Server list"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2459
+#: src/muuli_wdr.cpp:2463
 msgid "Enter the url to a server.met file here and press the button to the left to update the list of known servers."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2464
+#: src/muuli_wdr.cpp:2468
 msgid "Add server manually: Name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2467
+#: src/muuli_wdr.cpp:2471
 msgid "Enter the name of the new server here"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2469 src/ServerWnd.cpp:206
+#: src/muuli_wdr.cpp:2473 src/ServerWnd.cpp:206
 msgid "IP:Port"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2472
+#: src/muuli_wdr.cpp:2476
 msgid "Enter the IP of the server here, using the x.x.x.x format."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2478
+#: src/muuli_wdr.cpp:2482
 msgid "Enter the port of the server here."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2481
+#: src/muuli_wdr.cpp:2485
 msgid "Add manually a server (fill fields to the left before) ..."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2510
+#: src/muuli_wdr.cpp:2514
 msgid "aMule Log"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2518
+#: src/muuli_wdr.cpp:2522
 msgid "Server Info"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2522
+#: src/muuli_wdr.cpp:2526
 msgid "ED2K Info"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2526
+#: src/muuli_wdr.cpp:2530
 msgid "Kad Info"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2554
+#: src/muuli_wdr.cpp:2558
 msgid "Click on this button to update the nodes list from URL ..."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2558
+#: src/muuli_wdr.cpp:2562
 msgid "Nodes (0)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2562
+#: src/muuli_wdr.cpp:2566
 msgid "Enter the url to a nodes.dat file here and press the button to the left to update the list of known nodes."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2565
+#: src/muuli_wdr.cpp:2569
 msgid "Nodes stats"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2607
+#: src/muuli_wdr.cpp:2611
 msgid "Bootstrap"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2610
+#: src/muuli_wdr.cpp:2614
 msgid "New node"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2615
+#: src/muuli_wdr.cpp:2619
 msgid "IP:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2635
+#: src/muuli_wdr.cpp:2639
 msgid "Port:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2648
+#: src/muuli_wdr.cpp:2652
 msgid "Bootstrap from known clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2650
+#: src/muuli_wdr.cpp:2654
 msgid "Disconnect Kad"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2684
+#: src/muuli_wdr.cpp:2688
 msgid "Use Secure User Identification"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2686
+#: src/muuli_wdr.cpp:2690
 msgid "It is recommended to enable this option. You will not receive credits if SUI is not enabled."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2688
+#: src/muuli_wdr.cpp:2692
 msgid "Protocol Obfuscation"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2691
+#: src/muuli_wdr.cpp:2695
 msgid "Support Protocol Obfuscation"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2693
+#: src/muuli_wdr.cpp:2697
 msgid "This option enabled Protocol Obfuscation, and makes aMule accept obfuscated connections from other clients."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2695
+#: src/muuli_wdr.cpp:2699
 msgid "Use obfuscation for outgoing connections"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2697
+#: src/muuli_wdr.cpp:2701
 msgid "This option makes aMule use Protocol Obfuscation when connecting other clients/servers."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2699
+#: src/muuli_wdr.cpp:2703
 msgid "Accept only obfuscated connections"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2700
+#: src/muuli_wdr.cpp:2704
 msgid "This option makes aMule only accept obfuscated connections. You will have less sources, but all your traffic will be obfuscated"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2705
+#: src/muuli_wdr.cpp:2709
 msgid "Everybody"
 msgstr "Всеки"
 
-#: src/muuli_wdr.cpp:2707
+#: src/muuli_wdr.cpp:2711
 msgid "No one"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2709
+#: src/muuli_wdr.cpp:2713
 msgid "Who can see my shared files:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2710
+#: src/muuli_wdr.cpp:2714
 msgid "Select who can request to view a list of your shared files."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2712
+#: src/muuli_wdr.cpp:2716
 msgid "IP-Filtering"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2719
+#: src/muuli_wdr.cpp:2723
 msgid "Filter clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2721
+#: src/muuli_wdr.cpp:2725
 msgid "Enable filtering of the client IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2723
+#: src/muuli_wdr.cpp:2727
 msgid "Filter servers"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2725
+#: src/muuli_wdr.cpp:2729
 msgid "Enable filtering of the server IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2729
+#: src/muuli_wdr.cpp:2733
 msgid "Reload List"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2730
+#: src/muuli_wdr.cpp:2734
 msgid "Reload the list of IPs to filter from the file ~/.aMule/ipfilter.dat"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2736
+#: src/muuli_wdr.cpp:2740
 msgid "URL:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2740 src/muuli_wdr.cpp:2933
+#: src/muuli_wdr.cpp:2744 src/muuli_wdr.cpp:2937
 msgid "Update now"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2743
+#: src/muuli_wdr.cpp:2747
 msgid "Auto-update ipfilter at startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2747
+#: src/muuli_wdr.cpp:2751
 msgid "Filtering Level:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2753
+#: src/muuli_wdr.cpp:2757
 msgid "Always filter LAN IPs"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2756
+#: src/muuli_wdr.cpp:2760
 msgid "Paranoid handling of non-matching IPs"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2758
+#: src/muuli_wdr.cpp:2762
 msgid "Rejects a packet when its source IP differs from the IP the client claims (an anti-spoofing check). Disable only if it causes connection problems."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2760
+#: src/muuli_wdr.cpp:2764
 msgid "Use system-wide ipfilter.dat if available"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2761
+#: src/muuli_wdr.cpp:2765
 msgid "If there's no local ipfilter.dat found, allow usage of a system-wide ipfilter file."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2778
+#: src/muuli_wdr.cpp:2782
 msgid "Enable Online-Signature"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2780
+#: src/muuli_wdr.cpp:2784
 msgid "Enables the writing of the OS file, which can be used by external apps to create signatures and the like."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2784
+#: src/muuli_wdr.cpp:2788
 msgid "Update Frequency (Secs):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2787
+#: src/muuli_wdr.cpp:2791
 msgid "Change the frequency (in seconds) of Online Signature updates."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2795
+#: src/muuli_wdr.cpp:2799
 msgid "Save online signature file in: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:2801
+#: src/muuli_wdr.cpp:2805
 msgid "Click here to select the directory containing the the Online Signature files."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2834
+#: src/muuli_wdr.cpp:2838
 msgid "Show country flags for clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2835
+#: src/muuli_wdr.cpp:2839
 msgid "Render the country flag column in the transfers, queue and search views. Requires a valid MMDB GeoIP database (see below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2840
+#: src/muuli_wdr.cpp:2844
 msgid "Database"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2856
+#: src/muuli_wdr.cpp:2860
 #, fuzzy
 msgid "Source:"
 msgstr "Източници"
 
-#: src/muuli_wdr.cpp:2859
+#: src/muuli_wdr.cpp:2863
 msgid "DB-IP (free, no account)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2860
+#: src/muuli_wdr.cpp:2864
 msgid "MaxMind GeoLite2 (free, account required)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2861
+#: src/muuli_wdr.cpp:2865
 msgid "Custom URL"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2864
+#: src/muuli_wdr.cpp:2868
 msgid "Choose which provider supplies the GeoIP MMDB database. DB-IP is the default - no account required. MaxMind requires a free account + license key. Use Custom URL to point at any other MMDB host (e.g. a local mirror)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2881
+#: src/muuli_wdr.cpp:2885
 msgid ""
 "No configuration required.\n"
 "\n"
@@ -4805,11 +4805,11 @@ msgid ""
 "License: Creative Commons BY 4.0 - https://creativecommons.org/licenses/by/4.0/"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2894
+#: src/muuli_wdr.cpp:2898
 msgid "License key:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2900
+#: src/muuli_wdr.cpp:2904
 msgid ""
 "Sign up for a free MaxMind account, then generate a License Key:\n"
 "https://www.maxmind.com/en/geolite2/signup\n"
@@ -4819,229 +4819,229 @@ msgid ""
 "Requires attribution and account registration; refresh at least every 30 days."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2915
+#: src/muuli_wdr.cpp:2919
 #, fuzzy
 msgid "Download URL:"
 msgstr "Изтегляне"
 
-#: src/muuli_wdr.cpp:2921
+#: src/muuli_wdr.cpp:2925
 msgid ""
 "Must point to an .mmdb file or a .gz / .tar.gz containing one.\n"
 "URL may include credentials (https://user:pass@host/...).\n"
 "License and attribution terms are set by the upstream URL - you are responsible."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2934
+#: src/muuli_wdr.cpp:2938
 msgid "Download the GeoIP database from the selected source."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2936
+#: src/muuli_wdr.cpp:2940
 msgid "Auto-update on startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2937
+#: src/muuli_wdr.cpp:2941
 msgid "Re-download the GeoIP database from the selected source every time aMule starts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2960
+#: src/muuli_wdr.cpp:2964
 msgid "Filter incoming messages (except current chat):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2962
+#: src/muuli_wdr.cpp:2966
 msgid "Filter all messages"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2964
+#: src/muuli_wdr.cpp:2968
 msgid "Filter messages from people not on your friend list"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2966
+#: src/muuli_wdr.cpp:2970
 msgid "Filter messages from unknown clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2968
+#: src/muuli_wdr.cpp:2972
 msgid "Filter messages containing (use ',' as separator):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2971 src/muuli_wdr.cpp:2982
+#: src/muuli_wdr.cpp:2975 src/muuli_wdr.cpp:2986
 msgid "add here the words amule should filter and block messages including it"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2973
+#: src/muuli_wdr.cpp:2977
 msgid "Show received messages in the log"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2976
+#: src/muuli_wdr.cpp:2980
 msgid "Comments"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2979
+#: src/muuli_wdr.cpp:2983
 msgid "Filter comments containing (use ',' as separator):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3004
+#: src/muuli_wdr.cpp:3008
 msgid "Enable Proxy"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3005
+#: src/muuli_wdr.cpp:3009
 msgid "Enable/disable proxy support"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3008
+#: src/muuli_wdr.cpp:3012
 msgid "Proxy type:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3019
+#: src/muuli_wdr.cpp:3023
 msgid "Proxy host:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3022
+#: src/muuli_wdr.cpp:3026
 msgid "The proxy host name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3024
+#: src/muuli_wdr.cpp:3028
 msgid "Proxy port:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3027
+#: src/muuli_wdr.cpp:3031
 msgid "The proxy port"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3029
+#: src/muuli_wdr.cpp:3033
 msgid "Enable authentication"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3030
+#: src/muuli_wdr.cpp:3034
 msgid "Enable/disable username/password authentication"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3033
+#: src/muuli_wdr.cpp:3037
 msgid "Username: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:3036
+#: src/muuli_wdr.cpp:3040
 msgid "The username to use to connect to the proxy"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3038
+#: src/muuli_wdr.cpp:3042
 msgid "Password:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3041
+#: src/muuli_wdr.cpp:3045
 msgid "The password to use to connect to the proxy"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3060
+#: src/muuli_wdr.cpp:3064
 msgid "Connect to:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3069
+#: src/muuli_wdr.cpp:3073
 msgid "Login to remote amule"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3074
+#: src/muuli_wdr.cpp:3078
 msgid "User name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3085
+#: src/muuli_wdr.cpp:3089
 msgid "Remember those settings"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3088
+#: src/muuli_wdr.cpp:3092
 msgid "Force ZLIB compression"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3112
+#: src/muuli_wdr.cpp:3116
 msgid "Enable Verbose Debug-Logging."
 msgstr ""
 
-#: src/muuli_wdr.cpp:3114
+#: src/muuli_wdr.cpp:3118
 msgid "Only to Logfile"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3116
+#: src/muuli_wdr.cpp:3120
 msgid "Message Categories:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3140 src/PartFileConvertDlg.cpp:160
+#: src/muuli_wdr.cpp:3144 src/PartFileConvertDlg.cpp:160
 msgid "Waiting..."
 msgstr "Изчакване"
 
-#: src/muuli_wdr.cpp:3160
+#: src/muuli_wdr.cpp:3164
 msgid "Add imports"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3163
+#: src/muuli_wdr.cpp:3167
 msgid "Retry selected"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3165
+#: src/muuli_wdr.cpp:3169
 msgid "Remove selected"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3228
+#: src/muuli_wdr.cpp:3232
 msgid "Event Types"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3247
+#: src/muuli_wdr.cpp:3251
 msgid "Statistics and queued clients for selected file(s) : Session / All time"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3271
+#: src/muuli_wdr.cpp:3275
 #, fuzzy
 msgid "Active Uploads"
 msgstr "Активни качвания: %i"
 
-#: src/muuli_wdr.cpp:3285
+#: src/muuli_wdr.cpp:3289
 #, fuzzy
 msgid "Percent of total files"
 msgstr "Общо файлове"
 
-#: src/muuli_wdr.cpp:3337
+#: src/muuli_wdr.cpp:3341
 #, fuzzy
 msgid "Show Clients for"
 msgstr "Клиенти"
 
-#: src/muuli_wdr.cpp:3339
+#: src/muuli_wdr.cpp:3343
 msgid "All files"
 msgstr "Всички файлове"
 
-#: src/muuli_wdr.cpp:3342
+#: src/muuli_wdr.cpp:3346
 #, fuzzy
 msgid "Selected files"
 msgstr "Избор на филтър"
 
-#: src/muuli_wdr.cpp:3345
+#: src/muuli_wdr.cpp:3349
 #, fuzzy
 msgid "Active uploads only"
 msgstr "Активни качвания: %i"
 
-#: src/muuli_wdr.cpp:3352
+#: src/muuli_wdr.cpp:3356
 #, fuzzy
 msgid "Reload:"
 msgstr "Качване"
 
-#: src/muuli_wdr.cpp:3356
+#: src/muuli_wdr.cpp:3360
 msgid "Reload your shared files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3419
+#: src/muuli_wdr.cpp:3423
 msgid "Send"
 msgstr "Изпраща"
 
-#: src/muuli_wdr.cpp:3420
+#: src/muuli_wdr.cpp:3424
 msgid "Sends the specified message."
 msgstr ""
 
-#: src/muuli_wdr.cpp:3424
+#: src/muuli_wdr.cpp:3428
 msgid "Close this chat-session."
 msgstr ""
 
-#: src/muuli_wdr.cpp:3447
+#: src/muuli_wdr.cpp:3451
 msgid "Connect to any server and/or Kad"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3453 src/SharedFilesCtrl.cpp:142 src/Statistics.cpp:941
+#: src/muuli_wdr.cpp:3457 src/SharedFilesCtrl.cpp:142 src/Statistics.cpp:941
 msgid "Shared Files"
 msgstr ""
 
@@ -5667,255 +5667,255 @@ msgid ""
 "these settings."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:647
+#: src/PrefsUnifiedDlg.cpp:656
 #, c-format
 msgid "Failed to connect Cfg to widget with the ID %d and key %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:695
+#: src/PrefsUnifiedDlg.cpp:704
 #, c-format
 msgid "Failed to transfer data from Cfg to Widget with the ID %d and key %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:801
+#: src/PrefsUnifiedDlg.cpp:810
 msgid "The type of proxy you are connecting to"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1020
+#: src/PrefsUnifiedDlg.cpp:1029
 #, c-format
 msgid "Failed to transfer data from Widget to Cfg with the ID %d and key %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1103
+#: src/PrefsUnifiedDlg.cpp:1112
 #, fuzzy
 msgid "No password set."
 msgstr "парола"
 
-#: src/PrefsUnifiedDlg.cpp:1132
+#: src/PrefsUnifiedDlg.cpp:1141
 msgid "Guest access needs a password. Type one in the guest password field, or untick Enable guest access."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1144
+#: src/PrefsUnifiedDlg.cpp:1153
 msgid ""
 "aMule must be restarted to enable these changes:\n"
 "\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1151
+#: src/PrefsUnifiedDlg.cpp:1160
 msgid "- TCP port changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1156
+#: src/PrefsUnifiedDlg.cpp:1165
 msgid "- UDP port changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1161
+#: src/PrefsUnifiedDlg.cpp:1170
 msgid "- Network interface binding changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1166
+#: src/PrefsUnifiedDlg.cpp:1175
 msgid "- External connect port changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1170
+#: src/PrefsUnifiedDlg.cpp:1179
 msgid "- External connect acceptance changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1174
+#: src/PrefsUnifiedDlg.cpp:1183
 msgid "- External connect interface changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1178
+#: src/PrefsUnifiedDlg.cpp:1187
 msgid "- Protocol obfuscation support changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1193
+#: src/PrefsUnifiedDlg.cpp:1202
 #, fuzzy
 msgid "- amuleapi settings changed.\n"
 msgstr "- Език променило.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1202
+#: src/PrefsUnifiedDlg.cpp:1211
 msgid ""
 "Your Auto-update server list is empty.\n"
 "'Auto-update server list at startup' will be disabled."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1213
+#: src/PrefsUnifiedDlg.cpp:1222
 msgid ""
 "You have enabled external connections but have not specified a password.\n"
 "External connections cannot be enabled unless a valid password is specified."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1246
+#: src/PrefsUnifiedDlg.cpp:1255
 #, c-format
 msgid "The amuleapi password could not be saved: %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1276
+#: src/PrefsUnifiedDlg.cpp:1285
 msgid "- Language changed.\n"
 msgstr "- Език променило.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1281
+#: src/PrefsUnifiedDlg.cpp:1290
 msgid "- Temp folder changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1286
+#: src/PrefsUnifiedDlg.cpp:1295
 msgid "- ED2K network enabled.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1319
+#: src/PrefsUnifiedDlg.cpp:1328
 msgid "The shared-file exclusion pattern is not a valid regular expression. The filter has been left disabled."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1321 src/PrefsUnifiedDlg.cpp:1921
+#: src/PrefsUnifiedDlg.cpp:1330 src/PrefsUnifiedDlg.cpp:1930
 msgid "Invalid regular expression"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1398
+#: src/PrefsUnifiedDlg.cpp:1407
 msgid ""
 "Both eD2k and Kad network are disabled.\n"
 "You won't be able to connect until you enable at least one of them."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1403
+#: src/PrefsUnifiedDlg.cpp:1412
 msgid ""
 "Kad will not start if your UDP port is disabled.\n"
 "Enable UDP port or disable Kad."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1459
+#: src/PrefsUnifiedDlg.cpp:1468
 msgid ""
 "\n"
 "You MUST restart aMule now.\n"
 "If you do not restart now, don't complain if anything bad happens.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1524
+#: src/PrefsUnifiedDlg.cpp:1533
 msgid "Could not register aMule for autostart at login. The autostart store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1526
+#: src/PrefsUnifiedDlg.cpp:1535
 msgid "Could not remove the autostart-at-login entry."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1527
+#: src/PrefsUnifiedDlg.cpp:1536
 #, fuzzy
 msgid "Autostart"
 msgstr "Автоматично"
 
-#: src/PrefsUnifiedDlg.cpp:1542
+#: src/PrefsUnifiedDlg.cpp:1551
 msgid "Register file type"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1542
+#: src/PrefsUnifiedDlg.cpp:1551
 msgid "Register URL handler"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1550
+#: src/PrefsUnifiedDlg.cpp:1559
 #, c-format
 msgid "aMule only handles eD2k-compatible magnets. If you replace the current magnet handler (%s), BitTorrent magnet links will stop working - aMule cannot download BitTorrent content. Continue?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1555
+#: src/PrefsUnifiedDlg.cpp:1564
 #, c-format
 msgid "Another application currently opens .emulecollection files (%s). Replace it with aMule?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1560
+#: src/PrefsUnifiedDlg.cpp:1569
 #, c-format
 msgid "Another application is currently the default handler for these links (%s). Replace it with aMule?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1585
+#: src/PrefsUnifiedDlg.cpp:1594
 msgid "Could not register aMule for .emulecollection files. The registration store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1587
+#: src/PrefsUnifiedDlg.cpp:1596
 #, fuzzy
 msgid "Could not remove the file type registration."
 msgstr "Вие вече опитвате да свалите файла %s"
 
-#: src/PrefsUnifiedDlg.cpp:1589
+#: src/PrefsUnifiedDlg.cpp:1598
 msgid "Could not register aMule as the URL handler. The registration store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1591
+#: src/PrefsUnifiedDlg.cpp:1600
 msgid "Could not remove the URL handler registration."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1661 src/PrefsUnifiedDlg.cpp:1688
+#: src/PrefsUnifiedDlg.cpp:1670 src/PrefsUnifiedDlg.cpp:1697
 msgid "The web server and aMule API require external connections to be enabled."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1671
+#: src/PrefsUnifiedDlg.cpp:1680
 msgid "The aMule web server is deprecated. Consider running the aMule API instead."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1735
+#: src/PrefsUnifiedDlg.cpp:1744
 msgid ""
 "Your Auto-update servers list is in blank.\n"
 "Please fill in at least one URL to point to a valid server.met file.\n"
 "Click on the button \"List\" by this checkbox to enter an URL."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1876
+#: src/PrefsUnifiedDlg.cpp:1885
 msgid "Temporary files"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1881
+#: src/PrefsUnifiedDlg.cpp:1890
 msgid "Incoming files"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1886
+#: src/PrefsUnifiedDlg.cpp:1895
 msgid "Online Signatures"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1899
+#: src/PrefsUnifiedDlg.cpp:1908
 #, c-format
 msgid "Choose a folder for %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1923
+#: src/PrefsUnifiedDlg.cpp:1932
 #, fuzzy, c-format
 msgid "Would exclude %u of %u shared file"
 msgid_plural "Would exclude %u of %u shared files"
 msgstr[0] "Известни са %i споделени файлове"
 msgstr[1] "Известни са %i споделени файлове"
 
-#: src/PrefsUnifiedDlg.cpp:1940
+#: src/PrefsUnifiedDlg.cpp:1949
 msgid "Browse for videoplayer"
 msgstr "Търсене на видео плеър"
 
-#: src/PrefsUnifiedDlg.cpp:1944
+#: src/PrefsUnifiedDlg.cpp:1953
 msgid "Select browser"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1948
+#: src/PrefsUnifiedDlg.cpp:1957
 msgid "Select ffprobe binary"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1954
+#: src/PrefsUnifiedDlg.cpp:1963
 #, c-format
 msgid "Executable%s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1988
+#: src/PrefsUnifiedDlg.cpp:1997
 msgid "ffprobe not found on PATH or in the standard install locations. Install ffmpeg (which ships ffprobe) or use Browse to pick a binary manually."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2000
+#: src/PrefsUnifiedDlg.cpp:2009
 msgid "Reset the settings on this page to their default values?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2001
+#: src/PrefsUnifiedDlg.cpp:2010
 msgid "Reset to defaults"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2028
+#: src/PrefsUnifiedDlg.cpp:2037
 msgid "Edit server list"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2029
+#: src/PrefsUnifiedDlg.cpp:2038
 msgid ""
 "Add here URL's to download server.met files.\n"
 "Only one url on each line."
@@ -5923,152 +5923,152 @@ msgstr ""
 "Тук добавете линкове за сваляне на .met файлове.\n"
 "Само по един URL на ред."
 
-#: src/PrefsUnifiedDlg.cpp:2084
+#: src/PrefsUnifiedDlg.cpp:2093
 msgid "IP2Country update failed"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2229 src/PrefsUnifiedDlg.cpp:2260
+#: src/PrefsUnifiedDlg.cpp:2238 src/PrefsUnifiedDlg.cpp:2269
 msgid "Data by MaxMind GeoLite2"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2231 src/PrefsUnifiedDlg.cpp:2262
+#: src/PrefsUnifiedDlg.cpp:2240 src/PrefsUnifiedDlg.cpp:2271
 msgid "Custom source"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2233 src/PrefsUnifiedDlg.cpp:2264
+#: src/PrefsUnifiedDlg.cpp:2242 src/PrefsUnifiedDlg.cpp:2273
 msgid "Data by DB-IP.com"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2284
+#: src/PrefsUnifiedDlg.cpp:2293
 #, c-format
 msgid "Status: Loaded%s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2286
+#: src/PrefsUnifiedDlg.cpp:2295
 #, c-format
 msgid "Status: Loaded%s - %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2290
+#: src/PrefsUnifiedDlg.cpp:2299
 msgid "Status: Failed to load - click 'Update now' to refresh."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2292
+#: src/PrefsUnifiedDlg.cpp:2301
 msgid "Status: Not found - click 'Update now' to download."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2350 src/PrefsUnifiedDlg.cpp:2374
+#: src/PrefsUnifiedDlg.cpp:2359 src/PrefsUnifiedDlg.cpp:2383
 #, c-format
 msgid "Update delay: %d second"
 msgid_plural "Update delay: %d seconds"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/PrefsUnifiedDlg.cpp:2358
+#: src/PrefsUnifiedDlg.cpp:2367
 #, c-format
 msgid "Time for average graph: %d minute"
 msgid_plural "Time for average graph: %d minutes"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/PrefsUnifiedDlg.cpp:2367
+#: src/PrefsUnifiedDlg.cpp:2376
 #, c-format
 msgid "Connections Graph Scale: %d"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2382
+#: src/PrefsUnifiedDlg.cpp:2391
 #, c-format
 msgid "File Buffer Size: %d byte"
 msgid_plural "File Buffer Size: %d bytes"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/PrefsUnifiedDlg.cpp:2392
+#: src/PrefsUnifiedDlg.cpp:2401
 #, c-format
 msgid "Upload Queue Size: %d client"
 msgid_plural "Upload Queue Size: %d clients"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/PrefsUnifiedDlg.cpp:2402
+#: src/PrefsUnifiedDlg.cpp:2411
 #, c-format
 msgid "Server connection refresh interval: %d minute"
 msgid_plural "Server connection refresh interval: %d minutes"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/PrefsUnifiedDlg.cpp:2407
+#: src/PrefsUnifiedDlg.cpp:2416
 msgid "Server connection refresh interval: Disabled"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2451
+#: src/PrefsUnifiedDlg.cpp:2460
 #, fuzzy
 msgid "disabled"
 msgstr "деактивиране"
 
-#: src/PrefsUnifiedDlg.cpp:2477
+#: src/PrefsUnifiedDlg.cpp:2486
 #, c-format
 msgid "Execute command on '%s' event"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2484
+#: src/PrefsUnifiedDlg.cpp:2493
 msgid "Enable command execution on core"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2496
+#: src/PrefsUnifiedDlg.cpp:2505
 msgid "Core command:"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2512
+#: src/PrefsUnifiedDlg.cpp:2521
 msgid "Enable command execution on GUI"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2524
+#: src/PrefsUnifiedDlg.cpp:2533
 msgid "GUI command:"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2540
+#: src/PrefsUnifiedDlg.cpp:2549
 msgid "The following variables will be replaced:"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2708
+#: src/PrefsUnifiedDlg.cpp:2717
 msgid ""
 "The following folders look like system or sensitive locations:\n"
 "\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2713
+#: src/PrefsUnifiedDlg.cpp:2722
 msgid "Sharing them recursively will publish every file underneath on the eD2k/Kad networks. Do you really want to do this?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2716
+#: src/PrefsUnifiedDlg.cpp:2725
 msgid "Confirm shared folders"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2744
+#: src/PrefsUnifiedDlg.cpp:2753
 #, fuzzy
 msgid "Reloading shared files..."
 msgstr "Известни са %i споделени файлове"
 
-#: src/PrefsUnifiedDlg.cpp:2745
+#: src/PrefsUnifiedDlg.cpp:2754
 msgid "Scanning for subdirectories..."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2746
+#: src/PrefsUnifiedDlg.cpp:2755
 msgid "Updating shared folders"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2773
+#: src/PrefsUnifiedDlg.cpp:2782
 #, c-format
 msgid "Scanned %u directories..."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2823
+#: src/PrefsUnifiedDlg.cpp:2832
 #, c-format
 msgid "Reloading shared files: %u files scanned"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2873
+#: src/PrefsUnifiedDlg.cpp:2882
 #, fuzzy
 msgid "Shared folder"
 msgstr "Споделени файлове (%i)"
@@ -7725,12 +7725,12 @@ msgstr "Премахване на категория"
 msgid "Hashset requested for unknown file: %s"
 msgstr ""
 
-#: src/UploadQueue.cpp:618
+#: src/UploadQueue.cpp:627
 #, c-format
 msgid "Resuming uploads of file: %s"
 msgstr ""
 
-#: src/UploadQueue.cpp:634
+#: src/UploadQueue.cpp:643
 #, c-format
 msgid "Suspending upload of file: %s"
 msgstr ""

--- a/po/bg.po
+++ b/po/bg.po
@@ -11,8 +11,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-28 12:12+0200\n"
-"PO-Revision-Date: 2026-07-27 10:15+0000\n"
+"POT-Creation-Date: 2026-07-28 08:06+0200\n"
+"PO-Revision-Date: 2026-07-27 11:32+0000\n"
 "Last-Translator: Sebastiano Pistore <SebastianoPistore.info@protonmail.ch>\n"
 "Language-Team: Bulgarian <dict@linux.zonebg.com>\n"
 "Language: bg\n"
@@ -136,7 +136,7 @@ msgstr ""
 msgid "Not now"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:422 src/amuleDlg.cpp:665
+#: src/AppImageIntegration.cpp:422 src/amuleDlg.cpp:600
 msgid "Don't ask again"
 msgstr ""
 
@@ -194,154 +194,154 @@ msgstr "Грешка при запис на файла с кредити"
 msgid "WARNING: You can't add yourself as a source for an eD2k link while having a lowid."
 msgstr ""
 
-#: src/amule.cpp:301
+#: src/amule.cpp:300
 msgid "Now, exiting main app..."
 msgstr ""
 
-#: src/amule.cpp:331
+#: src/amule.cpp:330
 #, c-format
 msgid "Terminating amuleweb instance with pid '%d' ... "
 msgstr ""
 
-#: src/amule.cpp:335
+#: src/amule.cpp:334
 #, c-format
 msgid "Killing amuleweb instance with pid '%d' ... "
 msgstr ""
 
-#: src/amule.cpp:337 src/amule.cpp:350 src/ClientRef.cpp:180
-#: src/SearchDlg.cpp:1041 src/ServerListCtrl.cpp:98
+#: src/amule.cpp:336 src/amule.cpp:349 src/ClientRef.cpp:180
+#: src/SearchDlg.cpp:880 src/ServerListCtrl.cpp:98
 msgid "Failed"
 msgstr "Грешка"
 
-#: src/amule.cpp:344
+#: src/amule.cpp:343
 #, c-format
 msgid "Terminating amuleapi instance with pid '%d' ... "
 msgstr ""
 
-#: src/amule.cpp:348
+#: src/amule.cpp:347
 #, c-format
 msgid "Killing amuleapi instance with pid '%d' ... "
 msgstr ""
 
-#: src/amule.cpp:356
+#: src/amule.cpp:355
 msgid "aMule OnExit: Terminating core."
 msgstr ""
 
-#: src/amule.cpp:467
+#: src/amule.cpp:466
 msgid "aMule shutdown completed."
 msgstr ""
 
-#: src/amule.cpp:471
+#: src/amule.cpp:470
 msgid "Memory debug results for aMule exit:"
 msgstr ""
 
-#: src/amule.cpp:652
+#: src/amule.cpp:651
 #, c-format
 msgid "Binding aMule's peer-to-peer traffic to interface: %s (HTTP updates use the default route)"
 msgstr ""
 
-#: src/amule.cpp:656
+#: src/amule.cpp:655
 #, c-format
 msgid "Binding all network traffic to interface: %s"
 msgstr ""
 
-#: src/amule.cpp:660
+#: src/amule.cpp:659
 #, c-format
 msgid "WARNING: configured network interface '%s' was not found - traffic is NOT bound to it and may leave via the default route. Check the interface name in Preferences."
 msgstr ""
 
-#: src/amule.cpp:666
+#: src/amule.cpp:665
 #, c-format
 msgid "WARNING: binding to network interface '%s' requires elevated privileges and was NOT applied - traffic may leave via the default route. Grant the capability (e.g. 'sudo setcap cap_net_raw+ep' on the aMule binary) or run with sufficient privileges."
 msgstr ""
 
-#: src/amule.cpp:674
+#: src/amule.cpp:673
 #, c-format
 msgid "WARNING: could not bind to network interface '%s' - traffic may leave via the default route."
 msgstr ""
 
-#: src/amule.cpp:733
+#: src/amule.cpp:732
 msgid "Your locale has been changed to System Default due to a configuration change. Sorry."
 msgstr ""
 
-#: src/amule.cpp:735 src/amule.cpp:1589 src/CatDialog.cpp:128
+#: src/amule.cpp:734 src/amule.cpp:1581 src/CatDialog.cpp:128
 #: src/CatDialog.cpp:136 src/CatDialog.cpp:149 src/ServerList.cpp:366
 #: src/ServerListCtrl.cpp:152
 msgid "Info"
 msgstr ""
 
-#: src/amule.cpp:742
+#: src/amule.cpp:741
 #, fuzzy
 msgid ""
 "\n"
 "EC configuration"
 msgstr "Потвърждение за изход"
 
-#: src/amule.cpp:745
+#: src/amule.cpp:744
 msgid "Password set and external connections enabled."
 msgstr ""
 
-#: src/amule.cpp:755 src/KadDlg.cpp:176 src/KadDlg.cpp:185
-#: src/PrefsUnifiedDlg.cpp:1461 src/SharedFilesCtrl.cpp:476
+#: src/amule.cpp:754 src/KadDlg.cpp:176 src/KadDlg.cpp:185
+#: src/PrefsUnifiedDlg.cpp:1387 src/SharedFilesCtrl.cpp:476
 msgid "WARNING"
 msgstr ""
 
-#: src/amule.cpp:992
+#: src/amule.cpp:991
 msgid "Network bootstrap"
 msgstr ""
 
-#: src/amule.cpp:997
+#: src/amule.cpp:996
 msgid ""
 "aMule has detected missing network bootstrap files.\n"
 "Select which ones to download:"
 msgstr ""
 
-#: src/amule.cpp:1006 src/FirstRunWizard.cpp:411
+#: src/amule.cpp:1005 src/FirstRunWizard.cpp:411
 #, fuzzy
 msgid "eD2k server list (server.met)"
 msgstr "%i сървъра бяха намерени в server.met"
 
-#: src/amule.cpp:1013 src/FirstRunWizard.cpp:416
+#: src/amule.cpp:1012 src/FirstRunWizard.cpp:416
 msgid "Kad bootstrap nodes (nodes.dat)"
 msgstr ""
 
-#: src/amule.cpp:1103
+#: src/amule.cpp:1102
 #, c-format
 msgid "web server running on pid %d"
 msgstr ""
 
-#: src/amule.cpp:1116
+#: src/amule.cpp:1115
 msgid "You requested to run web server on startup, but the amuleweb binary cannot be run. Please install the package containing aMule web server, or build aMule from source with -DBUILD_WEBSERVER=YES and install it."
 msgstr ""
 
-#: src/amule.cpp:1121 src/amule.cpp:1185 src/amule.cpp:1299 src/amule.cpp:1601
+#: src/amule.cpp:1120 src/amule.cpp:1177 src/amule.cpp:1291 src/amule.cpp:1593
 #: src/amule-remote-gui.cpp:603 src/amule-remote-gui.cpp:671
 #: src/amule-remote-gui.cpp:709 src/amule-remote-gui.cpp:1282
 #: src/amule-remote-gui.cpp:1345 src/amule-remote-gui.cpp:1372
-#: src/DownloadQueue.cpp:1481 src/PrefsUnifiedDlg.cpp:1247
+#: src/DownloadQueue.cpp:1481
 msgid "ERROR"
 msgstr ""
 
-#: src/amule.cpp:1174
+#: src/amule.cpp:1166
 #, c-format
 msgid "amuleapi running on pid %d"
 msgstr ""
 
-#: src/amule.cpp:1180
+#: src/amule.cpp:1172
 msgid "You requested to run amuleapi on startup, but the amuleapi binary cannot be run. Please install the package containing aMule's REST API server, or build aMule from source with -DBUILD_AMULEAPI=YES and install it."
 msgstr ""
 
-#: src/amule.cpp:1267
+#: src/amule.cpp:1259
 #, c-format
 msgid "Could not bind ports to the specified address: %s"
 msgstr ""
 
-#: src/amule.cpp:1291
+#: src/amule.cpp:1283
 #, c-format
 msgid "Port %u is not available. You will be LOWID\n"
 msgstr ""
 
-#: src/amule.cpp:1296
+#: src/amule.cpp:1288
 #, c-format
 msgid ""
 "Port %u is not available!\n"
@@ -351,184 +351,184 @@ msgid ""
 "Check your network to make sure the port is open for output and input."
 msgstr ""
 
-#: src/amule.cpp:1393
+#: src/amule.cpp:1385
 msgid "Failed to create OnlineSig File"
 msgstr ""
 
-#: src/amule.cpp:1401
+#: src/amule.cpp:1393
 msgid "Failed to create aMule OnlineSig File"
 msgstr ""
 
-#: src/amule.cpp:1564
+#: src/amule.cpp:1556
 msgid "The selected locale seems not to be installed on your box. (Note: I'll try to set it anyway)"
 msgstr ""
 
-#: src/amule.cpp:1574
+#: src/amule.cpp:1566
 #, c-format
 msgid "This is the first time you run aMule %s"
 msgstr ""
 
-#: src/amule.cpp:1577
+#: src/amule.cpp:1569
 msgid "This version is a testing version, updated daily, and\n"
 msgstr ""
 
-#: src/amule.cpp:1578
+#: src/amule.cpp:1570
 msgid "we give no warranty it won't break anything, burn your house,\n"
 msgstr ""
 
-#: src/amule.cpp:1579
+#: src/amule.cpp:1571
 msgid "or kill your dog. But it *should* be safe to use anyway.\n"
 msgstr ""
 
-#: src/amule.cpp:1584
+#: src/amule.cpp:1576
 msgid "More information, support and new releases can found at our homepage,\n"
 msgstr ""
 
-#: src/amule.cpp:1585
+#: src/amule.cpp:1577
 msgid "at https://amule-org.github.io, or in our IRC channel #aMule at irc.libera.chat.\n"
 msgstr ""
 
-#: src/amule.cpp:1587
+#: src/amule.cpp:1579
 msgid "Feel free to report any bugs to https://github.com/amule-org/amule/issues"
 msgstr ""
 
-#: src/amule.cpp:1599
+#: src/amule.cpp:1591
 msgid ""
 "The folder for Online Signature files you specified is INVALID!\n"
 " OnlineSignature will be DISABLED until you fix it on preferences."
 msgstr ""
 
-#: src/amule.cpp:1662
+#: src/amule.cpp:1654
 msgid "Server hostname notified"
 msgstr ""
 
-#: src/amule.cpp:2039
+#: src/amule.cpp:2031
 #, c-format
 msgid "Disk space preallocation for file '%s' failed: %s"
 msgstr ""
 
-#: src/amule.cpp:2168
+#: src/amule.cpp:2160
 msgid "ERROR: can't open logfile"
 msgstr ""
 
-#: src/amule.cpp:2172
+#: src/amule.cpp:2164
 msgid "WARNING: logfile is empty. Something is wrong."
 msgstr ""
 
-#: src/amule.cpp:2189
+#: src/amule.cpp:2181
 msgid "Log has been reset"
 msgstr ""
 
-#: src/amule.cpp:2213
+#: src/amule.cpp:2205
 #, c-format
 msgid "ServerMessage: %s"
 msgstr ""
 
-#: src/amule.cpp:2256 src/IP2Country.cpp:220 src/IPFilter.cpp:514
+#: src/amule.cpp:2248 src/IP2Country.cpp:220 src/IPFilter.cpp:514
 #: src/ServerList.cpp:875
 #, c-format
 msgid "Skipped download of %s, because requested file is not newer."
 msgstr ""
 
-#: src/amule.cpp:2259
+#: src/amule.cpp:2251
 msgid "Failed to download the nodes list."
 msgstr ""
 
-#: src/amule.cpp:2322
+#: src/amule.cpp:2314
 msgid "Failed to open the downloaded version check file"
 msgstr ""
 
-#: src/amule.cpp:2325 src/amule.cpp:2344
+#: src/amule.cpp:2317 src/amule.cpp:2336
 msgid "Corrupted version check file"
 msgstr ""
 
-#: src/amule.cpp:2367
+#: src/amule.cpp:2359
 msgid "You are using an outdated version of aMule!"
 msgstr ""
 
-#: src/amule.cpp:2369
+#: src/amule.cpp:2361
 #, c-format
 msgid "Your aMule version is %i.%i.%i and the latest version is %li.%li.%li"
 msgstr ""
 
-#: src/amule.cpp:2373
+#: src/amule.cpp:2365
 msgid "The latest version can always be found at https://github.com/amule-org/amule/releases/latest"
 msgstr ""
 
-#: src/amule.cpp:2376
+#: src/amule.cpp:2368
 #, c-format
 msgid "WARNING: Your aMuled version is outdated: %i.%i.%i < %li.%li.%li"
 msgstr ""
 
-#: src/amule.cpp:2382
+#: src/amule.cpp:2374
 msgid "Your copy of aMule is up to date."
 msgstr ""
 
-#: src/amule.cpp:2389
+#: src/amule.cpp:2381
 msgid "Failed to download the version check file"
 msgstr ""
 
-#: src/amule.cpp:2558 src/amule-remote-gui.cpp:1133
+#: src/amule.cpp:2550 src/amule-remote-gui.cpp:1133
 #, c-format
 msgid "Users: %s | Files: %s"
 msgstr ""
 
-#: src/amule.cpp:2559 src/amule-remote-gui.cpp:1134
+#: src/amule.cpp:2551 src/amule-remote-gui.cpp:1134
 #, c-format
 msgid "Users: E: %s K: %s | Files: E: %s K: %s"
 msgstr ""
 
-#: src/amule.cpp:2573 src/amule-remote-gui.cpp:1147
+#: src/amule.cpp:2565 src/amule-remote-gui.cpp:1147
 msgid "No networks selected"
 msgstr ""
 
-#: src/amule.cpp:2641 src/TextClient.cpp:903
+#: src/amule.cpp:2633 src/TextClient.cpp:903
 msgid "with LowID"
 msgstr ""
 
-#: src/amule.cpp:2641 src/TextClient.cpp:904
+#: src/amule.cpp:2633 src/TextClient.cpp:904
 msgid "with HighID"
 msgstr ""
 
-#: src/amule.cpp:2643
+#: src/amule.cpp:2635
 #, c-format
 msgid "Connected to %s %s"
 msgstr ""
 
-#: src/amule.cpp:2648
+#: src/amule.cpp:2640
 #, c-format
 msgid "Connecting to %s"
 msgstr ""
 
-#: src/amule.cpp:2650
+#: src/amule.cpp:2642
 msgid "Disconnected from eD2k"
 msgstr ""
 
-#: src/amule.cpp:2659
+#: src/amule.cpp:2651
 msgid "Kad started."
 msgstr ""
 
-#: src/amule.cpp:2661
+#: src/amule.cpp:2653
 msgid "Kad stopped."
 msgstr ""
 
-#: src/amule.cpp:2669
+#: src/amule.cpp:2661
 msgid "Connected to Kad (ok)"
 msgstr ""
 
-#: src/amule.cpp:2671
+#: src/amule.cpp:2663
 msgid "Connected to Kad (firewalled)"
 msgstr ""
 
-#: src/amule.cpp:2675
+#: src/amule.cpp:2667
 msgid "Disconnected from Kad"
 msgstr ""
 
-#: src/amule.cpp:2707
+#: src/amule.cpp:2699
 msgid "Kad network cannot be used if UDP port is disabled on preferences, not starting."
 msgstr ""
 
-#: src/amule.cpp:2711
+#: src/amule.cpp:2703
 msgid "Kad network disabled on preferences, not connecting."
 msgstr ""
 
@@ -553,67 +553,29 @@ msgstr ""
 msgid "ERROR: %s"
 msgstr ""
 
-#: src/amuleDlg.cpp:250
+#: src/amuleDlg.cpp:236
 #, c-format
 msgid "This is aMule %s based on eMule."
 msgstr ""
 
-#: src/amuleDlg.cpp:251
+#: src/amuleDlg.cpp:237
 #, c-format
 msgid "Running on %s"
 msgstr ""
 
-#: src/amuleDlg.cpp:253
+#: src/amuleDlg.cpp:239
 msgid "Visit https://github.com/amule-org/amule/releases/latest to check if a new version is available."
 msgstr ""
 
-#: src/amuleDlg.cpp:282
+#: src/amuleDlg.cpp:268
 msgid "FATAL ERROR: Failed to create Timer"
 msgstr ""
 
-#: src/amuleDlg.cpp:361 src/amuleDlg.cpp:1810 src/amuleDlg.cpp:2056
-#: src/muuli_wdr.cpp:1492 src/muuli_wdr.cpp:3439
-msgid "Networks"
-msgstr ""
-
-#: src/amuleDlg.cpp:362 src/amuleDlg.cpp:1816 src/muuli_wdr.cpp:3440
-msgid "Searches"
-msgstr ""
-
-#: src/amuleDlg.cpp:363 src/amuleDlg.cpp:1822 src/DownloadListCtrl.cpp:740
-#: src/muuli_wdr.cpp:392 src/muuli_wdr.cpp:1585 src/muuli_wdr.cpp:3441
-#: src/Statistics.cpp:829
-msgid "Downloads"
-msgstr ""
-
-#: src/amuleDlg.cpp:364 src/amuleDlg.cpp:1828 src/muuli_wdr.cpp:3315
-msgid "Shared files"
-msgstr ""
-
-#: src/amuleDlg.cpp:365 src/amuleDlg.cpp:1834 src/muuli_wdr.cpp:2947
-#: src/muuli_wdr.cpp:3397 src/muuli_wdr.cpp:3444
-msgid "Messages"
-msgstr "Съобщения"
-
-#: src/amuleDlg.cpp:366 src/amuleDlg.cpp:1840 src/muuli_wdr.cpp:3445
-#: src/PrefsUnifiedDlg.cpp:314 src/Statistics.cpp:779 src/Statistics.cpp:1235
-msgid "Statistics"
-msgstr "Статистика"
-
-#: src/amuleDlg.cpp:368 src/amuleDlg.cpp:1847 src/muuli_wdr.cpp:3447
-#: src/PrefsUnifiedDlg.cpp:330 src/utils/wxCas/src/wxcasprefs.cpp:39
-msgid "Preferences"
-msgstr "Настройки"
-
-#: src/amuleDlg.cpp:371
-msgid "Navigate"
-msgstr ""
-
-#: src/amuleDlg.cpp:657
+#: src/amuleDlg.cpp:592
 msgid "New version available"
 msgstr ""
 
-#: src/amuleDlg.cpp:661
+#: src/amuleDlg.cpp:596
 #, c-format
 msgid ""
 "A new version of aMule (%s) is available.\n"
@@ -623,189 +585,222 @@ msgid ""
 "Would you like to open the download page?"
 msgstr ""
 
-#: src/amuleDlg.cpp:743
+#: src/amuleDlg.cpp:678
 msgid "aMule dialog destroyed"
 msgstr ""
 
-#: src/amuleDlg.cpp:766 src/DataToText.cpp:68 src/IPFilter.cpp:547
+#: src/amuleDlg.cpp:701 src/DataToText.cpp:68 src/IPFilter.cpp:547
 msgid "Connecting"
 msgstr "Свързва"
 
-#: src/amuleDlg.cpp:958
+#: src/amuleDlg.cpp:893
 msgid "eD2k: Connecting"
 msgstr ""
 
-#: src/amuleDlg.cpp:962
+#: src/amuleDlg.cpp:897
 msgid "eD2k: Disconnected"
 msgstr ""
 
-#: src/amuleDlg.cpp:968
+#: src/amuleDlg.cpp:903
 msgid "Kad: Firewalled"
 msgstr ""
 
-#: src/amuleDlg.cpp:972
+#: src/amuleDlg.cpp:907
 #, fuzzy
 msgid "Kad: Connected"
 msgstr "Връзкате е установена"
 
-#: src/amuleDlg.cpp:977
+#: src/amuleDlg.cpp:912
 #, fuzzy
 msgid "Kad: Connecting"
 msgstr "Свързва"
 
-#: src/amuleDlg.cpp:981
+#: src/amuleDlg.cpp:916
 msgid "Kad: Off"
 msgstr ""
 
-#: src/amuleDlg.cpp:1029 src/DownloadListCtrl.cpp:505
+#: src/amuleDlg.cpp:964 src/DownloadListCtrl.cpp:505
 #: src/DownloadListCtrl.cpp:749 src/FriendListCtrl.cpp:180
 #: src/muuli_wdr.cpp:731 src/muuli_wdr.cpp:782 src/muuli_wdr.cpp:846
-#: src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2252 src/muuli_wdr.cpp:2337
-#: src/muuli_wdr.cpp:3085 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
+#: src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2224 src/muuli_wdr.cpp:2309
+#: src/muuli_wdr.cpp:3057 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
 #: src/ServerListCtrl.cpp:606 src/TransferWnd.cpp:378
 #: src/utils/wxCas/src/wxcasprefs.cpp:235
 msgid "Cancel"
 msgstr "Отказ"
 
-#: src/amuleDlg.cpp:1030
+#: src/amuleDlg.cpp:965
 #, fuzzy
 msgid "Stop the current connection attempts"
 msgstr "Спира текущите опити за свързване"
 
-#: src/amuleDlg.cpp:1035 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976
-#: src/muuli_wdr.cpp:2475
+#: src/amuleDlg.cpp:970 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976
+#: src/muuli_wdr.cpp:2447
 msgid "Disconnect"
 msgstr "Разкачи"
 
-#: src/amuleDlg.cpp:1036
+#: src/amuleDlg.cpp:971
 #, fuzzy
 msgid "Disconnect from the currently connected networks"
 msgstr "Изключване от текущия сървър"
 
-#: src/amuleDlg.cpp:1041 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979
-#: src/muuli_wdr.cpp:2630 src/muuli_wdr.cpp:3082 src/muuli_wdr.cpp:3437
+#: src/amuleDlg.cpp:976 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979
+#: src/muuli_wdr.cpp:2602 src/muuli_wdr.cpp:3054 src/muuli_wdr.cpp:3409
 msgid "Connect"
 msgstr "Връзка"
 
-#: src/amuleDlg.cpp:1042
+#: src/amuleDlg.cpp:977
 msgid "Connect to the currently enabled networks"
 msgstr ""
 
-#: src/amuleDlg.cpp:1154
+#: src/amuleDlg.cpp:1089
 #, fuzzy, c-format
 msgid "Up: %.1f%s (%.1f) | Down: %.1f%s (%.1f)"
 msgstr "Кач.: %.1f(%.1f) | Свал.: %.1f(%.1f)"
 
-#: src/amuleDlg.cpp:1156 src/amuleDlg.cpp:1158 src/amuleDlg.cpp:1162
-#: src/amuleDlg.cpp:1164 src/amuleDlg.cpp:1175 src/amuleDlg.cpp:1177
+#: src/amuleDlg.cpp:1091 src/amuleDlg.cpp:1093 src/amuleDlg.cpp:1097
+#: src/amuleDlg.cpp:1099 src/amuleDlg.cpp:1110 src/amuleDlg.cpp:1112
 #: src/MuleTrayIcon.cpp:796 src/MuleTrayIcon.cpp:799
 msgid " MB/s"
 msgstr ""
 
-#: src/amuleDlg.cpp:1156 src/amuleDlg.cpp:1158 src/amuleDlg.cpp:1162
-#: src/amuleDlg.cpp:1164 src/amuleDlg.cpp:1175 src/amuleDlg.cpp:1177
+#: src/amuleDlg.cpp:1091 src/amuleDlg.cpp:1093 src/amuleDlg.cpp:1097
+#: src/amuleDlg.cpp:1099 src/amuleDlg.cpp:1110 src/amuleDlg.cpp:1112
 #: src/MuleTrayIcon.cpp:796 src/MuleTrayIcon.cpp:799
 #: src/utils/wxCas/src/wxcasframe.cpp:1041
 msgid " kB/s"
 msgstr " кБ/с"
 
-#: src/amuleDlg.cpp:1161
+#: src/amuleDlg.cpp:1096
 #, fuzzy, c-format
 msgid "Up: %.1f%s | Down: %.1f%s"
 msgstr "Кач.: %.1f | Свал.: %.1f"
 
-#: src/amuleDlg.cpp:1193
+#: src/amuleDlg.cpp:1128
 #, c-format
 msgid "aMule (%s | Connected)"
 msgstr ""
 
-#: src/amuleDlg.cpp:1195
+#: src/amuleDlg.cpp:1130
 #, c-format
 msgid "aMule (%s | Disconnected)"
 msgstr ""
 
-#: src/amuleDlg.cpp:1248
+#: src/amuleDlg.cpp:1183
 #, fuzzy, c-format
 msgid "Do you really want to exit %s?"
 msgstr "Наистина ли желаете да изключите aМуле?"
 
-#: src/amuleDlg.cpp:1250
+#: src/amuleDlg.cpp:1185
 msgid "Exit confirmation"
 msgstr "Потвърждение за изход"
 
-#: src/amuleDlg.cpp:1613
+#: src/amuleDlg.cpp:1548
 msgid "Launch Command: "
 msgstr ""
 
-#: src/amuleDlg.cpp:1632 src/muuli_wdr.cpp:1972 src/Preferences.cpp:979
+#: src/amuleDlg.cpp:1567 src/muuli_wdr.cpp:1971 src/Preferences.cpp:951
 msgid "- default -"
 msgstr "- по подразбиране -"
 
-#: src/amuleDlg.cpp:1660
+#: src/amuleDlg.cpp:1595
 #, c-format
 msgid "Skin directory '%s' does not exist"
 msgstr ""
 
-#: src/amuleDlg.cpp:1663
+#: src/amuleDlg.cpp:1598
 #, c-format
 msgid "WARNING: Unable to open skin file '%s' for read"
 msgstr ""
 
-#: src/amuleDlg.cpp:1814 src/muuli_wdr.cpp:3439
+#: src/amuleDlg.cpp:1722 src/amuleDlg.cpp:1968 src/muuli_wdr.cpp:1485
+#: src/muuli_wdr.cpp:3411
+msgid "Networks"
+msgstr ""
+
+#: src/amuleDlg.cpp:1726 src/muuli_wdr.cpp:3411
 msgid "Networks Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1820 src/muuli_wdr.cpp:3440
+#: src/amuleDlg.cpp:1728 src/muuli_wdr.cpp:3412
+msgid "Searches"
+msgstr ""
+
+#: src/amuleDlg.cpp:1732 src/muuli_wdr.cpp:3412
 msgid "Searches Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1826 src/muuli_wdr.cpp:3441
+#: src/amuleDlg.cpp:1734 src/DownloadListCtrl.cpp:740 src/muuli_wdr.cpp:392
+#: src/muuli_wdr.cpp:1578 src/muuli_wdr.cpp:3413 src/Statistics.cpp:829
+msgid "Downloads"
+msgstr ""
+
+#: src/amuleDlg.cpp:1738 src/muuli_wdr.cpp:3413
 #, fuzzy
 msgid "Downloads Window"
 msgstr "Изтегляне"
 
-#: src/amuleDlg.cpp:1832 src/muuli_wdr.cpp:3443
+#: src/amuleDlg.cpp:1740 src/muuli_wdr.cpp:3287
+msgid "Shared files"
+msgstr ""
+
+#: src/amuleDlg.cpp:1744 src/muuli_wdr.cpp:3415
 msgid "Shared Files Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3444
+#: src/amuleDlg.cpp:1746 src/muuli_wdr.cpp:2919 src/muuli_wdr.cpp:3369
+#: src/muuli_wdr.cpp:3416
+msgid "Messages"
+msgstr "Съобщения"
+
+#: src/amuleDlg.cpp:1750 src/muuli_wdr.cpp:3416
 msgid "Messages Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1844 src/muuli_wdr.cpp:3445
+#: src/amuleDlg.cpp:1752 src/muuli_wdr.cpp:3417 src/PrefsUnifiedDlg.cpp:312
+#: src/Statistics.cpp:779 src/Statistics.cpp:1235
+msgid "Statistics"
+msgstr "Статистика"
+
+#: src/amuleDlg.cpp:1756 src/muuli_wdr.cpp:3417
 msgid "Statistics Graph Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1851 src/muuli_wdr.cpp:3447
+#: src/amuleDlg.cpp:1759 src/muuli_wdr.cpp:3419 src/PrefsUnifiedDlg.cpp:328
+#: src/utils/wxCas/src/wxcasprefs.cpp:39
+msgid "Preferences"
+msgstr "Настройки"
+
+#: src/amuleDlg.cpp:1763 src/muuli_wdr.cpp:3419
 msgid "Preferences Settings Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1854 src/muuli_wdr.cpp:3448
+#: src/amuleDlg.cpp:1766 src/muuli_wdr.cpp:3420
 msgid "Import"
 msgstr ""
 
-#: src/amuleDlg.cpp:1858 src/muuli_wdr.cpp:3448
+#: src/amuleDlg.cpp:1770 src/muuli_wdr.cpp:3420
 msgid "The partfile importer tool"
 msgstr ""
 
-#: src/amuleDlg.cpp:1861 src/muuli_wdr.cpp:3449
+#: src/amuleDlg.cpp:1773 src/muuli_wdr.cpp:3421
 #: src/utils/aLinkCreator/src/alcframe.cpp:262
 msgid "About"
 msgstr ""
 
-#: src/amuleDlg.cpp:1861 src/muuli_wdr.cpp:3449
+#: src/amuleDlg.cpp:1773 src/muuli_wdr.cpp:3421
 msgid "About/Help"
 msgstr ""
 
-#: src/amuleDlg.cpp:2059
+#: src/amuleDlg.cpp:1971
 msgid "eD2k network"
 msgstr ""
 
-#: src/amuleDlg.cpp:2062
+#: src/amuleDlg.cpp:1974
 msgid "Kad network"
 msgstr ""
 
-#: src/amuleDlg.cpp:2062
+#: src/amuleDlg.cpp:1974
 msgid "No network"
 msgstr "Няма мрежа"
 
@@ -934,7 +929,7 @@ msgstr "Не са открити части от файлове"
 msgid "The core rejected these shared folders:%s"
 msgstr ""
 
-#: src/amule-remote-gui.cpp:1336 src/ExternalConn.cpp:2346
+#: src/amule-remote-gui.cpp:1336 src/ExternalConn.cpp:2345
 msgid "Invalid link or already on list."
 msgstr ""
 
@@ -950,7 +945,7 @@ msgstr ""
 #: src/ClientDetailDialog.cpp:123 src/DataToText.cpp:61 src/DataToText.cpp:86
 #: src/DataToText.cpp:101 src/DataToText.cpp:136 src/DataToText.cpp:165
 #: src/DownloadListCtrl.cpp:1172 src/DownloadListCtrl.cpp:1185
-#: src/DownloadListCtrl.cpp:1196 src/ExternalConn.cpp:609
+#: src/DownloadListCtrl.cpp:1196 src/ExternalConn.cpp:608
 #: src/FileDetailDialog.cpp:203 src/FileDetailDialog.cpp:235
 #: src/FileDetailDialog.cpp:242 src/GenericClientListCtrl.cpp:1171
 #: src/GenericClientListCtrl.cpp:1182 src/GenericClientListCtrl.cpp:1192
@@ -1338,19 +1333,19 @@ msgstr "Автоматичен [Hi]"
 msgid "Very low"
 msgstr ""
 
-#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:743 src/muuli_wdr.cpp:2303
+#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:743 src/muuli_wdr.cpp:2275
 #: src/ServerListCtrl.cpp:263 src/ServerListCtrl.cpp:456
 #: src/SharedFilesCtrl.cpp:145
 msgid "Low"
 msgstr "Ниско"
 
-#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:744 src/muuli_wdr.cpp:2304
+#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:744 src/muuli_wdr.cpp:2276
 #: src/ServerListCtrl.cpp:266 src/ServerListCtrl.cpp:457
 #: src/SharedFilesCtrl.cpp:146
 msgid "Normal"
 msgstr "Нормален"
 
-#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:745 src/muuli_wdr.cpp:2305
+#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:745 src/muuli_wdr.cpp:2277
 #: src/ServerListCtrl.cpp:269 src/ServerListCtrl.cpp:458
 #: src/SharedFilesCtrl.cpp:147
 msgid "High"
@@ -1442,8 +1437,8 @@ msgstr ""
 msgid "Remote Server"
 msgstr ""
 
-#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3202
-#: src/SearchDlg.cpp:119 src/TextClient.cpp:911
+#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3174
+#: src/SearchDlg.cpp:111 src/TextClient.cpp:911
 msgid "Kad"
 msgstr ""
 
@@ -1513,7 +1508,7 @@ msgstr ""
 msgid "Size"
 msgstr "Размер"
 
-#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3269
+#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3241
 msgid "Transferred"
 msgstr "Пренесен"
 
@@ -1571,7 +1566,7 @@ msgid ""
 "\n"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:746 src/muuli_wdr.cpp:2306
+#: src/DownloadListCtrl.cpp:746 src/muuli_wdr.cpp:2278
 #: src/SharedFilesCtrl.cpp:150
 msgid "Auto"
 msgstr "Автоматично"
@@ -1609,7 +1604,7 @@ msgid "Extended Options"
 msgstr ""
 
 #: src/DownloadListCtrl.cpp:770 src/DownloadListCtrl.cpp:822
-#: src/muuli_wdr.cpp:1790
+#: src/muuli_wdr.cpp:1789
 msgid "Preview"
 msgstr "Преглед"
 
@@ -1782,230 +1777,225 @@ msgstr[1] ""
 msgid "Invalid eD2k link! ERROR: %s"
 msgstr ""
 
-#: src/ExternalConn.cpp:380
+#: src/ExternalConn.cpp:379
 msgid "Client sent packet after authentication failed."
 msgstr ""
 
-#: src/ExternalConn.cpp:397
+#: src/ExternalConn.cpp:396
 msgid "External connection closed."
 msgstr ""
 
-#: src/ExternalConn.cpp:474
+#: src/ExternalConn.cpp:473
 msgid "External connections disabled due to empty password!"
 msgstr ""
 
-#: src/ExternalConn.cpp:495
+#: src/ExternalConn.cpp:494
 msgid "External connections disabled in config file"
 msgstr ""
 
-#: src/ExternalConn.cpp:576
+#: src/ExternalConn.cpp:575
 msgid "New external connection accepted"
 msgstr ""
 
-#: src/ExternalConn.cpp:579
+#: src/ExternalConn.cpp:578
 msgid "ERROR: couldn't accept a new external connection"
 msgstr ""
 
-#: src/ExternalConn.cpp:596
+#: src/ExternalConn.cpp:595
 msgid "External connection refused due to empty password in preferences!"
 msgstr ""
 
-#: src/ExternalConn.cpp:608
+#: src/ExternalConn.cpp:607
 #, c-format
 msgid "Connecting client: %s %s"
 msgstr ""
 
-#: src/ExternalConn.cpp:610
+#: src/ExternalConn.cpp:609
 msgid "Unknown version"
 msgstr ""
 
-#: src/ExternalConn.cpp:623
+#: src/ExternalConn.cpp:622
 msgid "Incorrect EC version ID, there might be binary incompatibility. Use core and remote from same snapshot."
 msgstr ""
 
-#: src/ExternalConn.cpp:631
+#: src/ExternalConn.cpp:630
 msgid "You cannot connect to a release version from an arbitrary development snapshot! *sigh* possible crash prevented"
 msgstr ""
 
-#: src/ExternalConn.cpp:714
+#: src/ExternalConn.cpp:713
 msgid "Invalid protocol version."
 msgstr ""
 
-#: src/ExternalConn.cpp:720
+#: src/ExternalConn.cpp:719
 msgid "Missing protocol version tag."
 msgstr ""
 
-#: src/ExternalConn.cpp:728
+#: src/ExternalConn.cpp:727
 msgid "Authentication failed: invalid hash specified as EC password."
 msgstr ""
 
-#: src/ExternalConn.cpp:776
+#: src/ExternalConn.cpp:775
 msgid "Authentication failed: wrong password."
 msgstr ""
 
-#: src/ExternalConn.cpp:778
+#: src/ExternalConn.cpp:777
 msgid "Authentication failed: missing password."
 msgstr ""
 
-#: src/ExternalConn.cpp:789
+#: src/ExternalConn.cpp:788
 msgid "Invalid request, please authenticate first."
 msgstr ""
 
-#: src/ExternalConn.cpp:794
+#: src/ExternalConn.cpp:793
 msgid "Access granted."
 msgstr ""
 
-#: src/ExternalConn.cpp:802
+#: src/ExternalConn.cpp:801
 #, c-format
 msgid "Sent error message \"%s\" to client."
 msgstr ""
 
-#: src/ExternalConn.cpp:807
+#: src/ExternalConn.cpp:806
 #, c-format
 msgid "Unauthorized access attempt from %s. Connection closed."
 msgstr ""
 
-#: src/ExternalConn.cpp:1420
+#: src/ExternalConn.cpp:1419
 #, c-format
 msgid "Remote PartFile command failed: FileHash not found: %s"
 msgstr ""
 
-#: src/ExternalConn.cpp:1424
+#: src/ExternalConn.cpp:1423
 #, c-format
 msgid "FileHash not found: %s"
 msgstr ""
 
-#: src/ExternalConn.cpp:1471 src/ExternalConn.cpp:1559
-#: src/ExternalConn.cpp:1680
+#: src/ExternalConn.cpp:1470 src/ExternalConn.cpp:1558
+#: src/ExternalConn.cpp:1679
 msgid "OOPS! OpCode processing error!"
 msgstr ""
 
-#: src/ExternalConn.cpp:1502
+#: src/ExternalConn.cpp:1501
 msgid "Server not added"
 msgstr ""
 
-#: src/ExternalConn.cpp:1521
+#: src/ExternalConn.cpp:1520
 #, c-format
 msgid "server not found: %s"
 msgstr ""
 
-#: src/ExternalConn.cpp:1538
+#: src/ExternalConn.cpp:1537
 msgid "need to define server to be removed"
 msgstr ""
 
-#: src/ExternalConn.cpp:1553
+#: src/ExternalConn.cpp:1552
 msgid "eD2k is disabled in preferences."
 msgstr ""
 
-#: src/ExternalConn.cpp:1658
+#: src/ExternalConn.cpp:1657
 msgid "Friend not found."
 msgstr ""
 
-#: src/ExternalConn.cpp:1668
+#: src/ExternalConn.cpp:1667
 msgid "Client not found."
 msgstr ""
 
-#: src/ExternalConn.cpp:1674
+#: src/ExternalConn.cpp:1673
 msgid "EC_TAG_FRIEND_SHARED requires EC_TAG_FRIEND or EC_TAG_CLIENT."
 msgstr ""
 
-#: src/ExternalConn.cpp:1992
+#: src/ExternalConn.cpp:1991
 msgid "WebSearch from remote interface makes no sense."
 msgstr ""
 
-#: src/ExternalConn.cpp:2027
+#: src/ExternalConn.cpp:2026
 msgid "Search in progress. Refetch results in a moment!"
 msgstr ""
 
-#: src/ExternalConn.cpp:2266
+#: src/ExternalConn.cpp:2265
 msgid "No points for graph."
 msgstr ""
 
-#: src/ExternalConn.cpp:2276
+#: src/ExternalConn.cpp:2275
 msgid "Your client is not configured for this detail level."
 msgstr ""
 
-#: src/ExternalConn.cpp:2303
+#: src/ExternalConn.cpp:2302
 msgid "External Connection: shutdown requested"
 msgstr ""
 
-#: src/ExternalConn.cpp:2315
+#: src/ExternalConn.cpp:2314
 msgid "Already shutting down."
 msgstr ""
 
-#: src/ExternalConn.cpp:2333
+#: src/ExternalConn.cpp:2332
 #, c-format
 msgid "ExternalConn: adding link '%s'."
 msgstr ""
 
-#: src/ExternalConn.cpp:2351
+#: src/ExternalConn.cpp:2350
 #, c-format
 msgid "%d of %d links failed (invalid or already on list)."
 msgstr ""
 
-#: src/ExternalConn.cpp:2374
+#: src/ExternalConn.cpp:2373
 msgid "Version check throttled; try again shortly."
 msgstr ""
 
-#: src/ExternalConn.cpp:2379
+#: src/ExternalConn.cpp:2378
 msgid "Version check is not available on this daemon."
 msgstr ""
 
-#: src/ExternalConn.cpp:2509
+#: src/ExternalConn.cpp:2508
 msgid "File not found."
 msgstr ""
 
-#: src/ExternalConn.cpp:2514
+#: src/ExternalConn.cpp:2513
 msgid "Invalid file name."
 msgstr ""
 
-#: src/ExternalConn.cpp:2522
+#: src/ExternalConn.cpp:2521
 msgid "Unable to rename file."
 msgstr ""
 
-#: src/ExternalConn.cpp:2839
-#, c-format
-msgid "Could not save the amuleapi password: %s"
-msgstr ""
-
-#: src/ExternalConn.cpp:3004 src/ExternalConn.cpp:3032
+#: src/ExternalConn.cpp:2992 src/ExternalConn.cpp:3020
 msgid "Kad is disabled in preferences."
 msgstr ""
 
-#: src/ExternalConn.cpp:3045
+#: src/ExternalConn.cpp:3033
 msgid "Already connected to eD2k."
 msgstr ""
 
-#: src/ExternalConn.cpp:3048
+#: src/ExternalConn.cpp:3036
 msgid "Connecting to eD2k..."
 msgstr ""
 
-#: src/ExternalConn.cpp:3057
+#: src/ExternalConn.cpp:3045
 msgid "Already connected to Kad."
 msgstr ""
 
-#: src/ExternalConn.cpp:3060
+#: src/ExternalConn.cpp:3048
 msgid "Connecting to Kad..."
 msgstr ""
 
-#: src/ExternalConn.cpp:3067
+#: src/ExternalConn.cpp:3055
 msgid "All networks are disabled."
 msgstr ""
 
-#: src/ExternalConn.cpp:3076
+#: src/ExternalConn.cpp:3064
 msgid "Disconnected from eD2k."
 msgstr ""
 
-#: src/ExternalConn.cpp:3081
+#: src/ExternalConn.cpp:3069
 msgid "Disconnected from Kad."
 msgstr ""
 
-#: src/ExternalConn.cpp:3090
+#: src/ExternalConn.cpp:3078
 #, c-format
 msgid "External Connection: invalid opcode received: %#x"
 msgstr ""
 
-#: src/ExternalConn.cpp:3095
+#: src/ExternalConn.cpp:3083
 msgid "Invalid opcode (wrong protocol version?)"
 msgstr ""
 
@@ -2297,19 +2287,19 @@ msgstr ""
 msgid "eD2k"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:349 src/muuli_wdr.cpp:1495
+#: src/FirstRunWizard.cpp:349 src/muuli_wdr.cpp:1488
 msgid "Kademlia"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:359 src/muuli_wdr.cpp:1423
+#: src/FirstRunWizard.cpp:359 src/muuli_wdr.cpp:1416
 msgid "Standard TCP Port "
 msgstr ""
 
-#: src/FirstRunWizard.cpp:365 src/muuli_wdr.cpp:1435
+#: src/FirstRunWizard.cpp:365 src/muuli_wdr.cpp:1428
 msgid "Extended UDP port (Kad / global search) "
 msgstr ""
 
-#: src/FirstRunWizard.cpp:377 src/muuli_wdr.cpp:1442
+#: src/FirstRunWizard.cpp:377 src/muuli_wdr.cpp:1435
 msgid "Enable UPnP for router port forwarding"
 msgstr ""
 
@@ -2335,7 +2325,7 @@ msgstr ""
 msgid "Your peer lists are already in place - nothing to download."
 msgstr "Вие вече опитвате да свалите файла %s"
 
-#: src/FirstRunWizard.cpp:434 src/muuli_wdr.cpp:1540
+#: src/FirstRunWizard.cpp:434 src/muuli_wdr.cpp:1533
 msgid "Auto-update server list at startup"
 msgstr ""
 
@@ -2381,23 +2371,23 @@ msgid ""
 "want downloads on a different (e.g. larger) disk."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:549 src/FirstRunWizard.cpp:611 src/muuli_wdr.cpp:1702
+#: src/FirstRunWizard.cpp:549 src/FirstRunWizard.cpp:611 src/muuli_wdr.cpp:1701
 msgid "Destination folder for downloads"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:553 src/FirstRunWizard.cpp:569 src/muuli_wdr.cpp:1349
-#: src/muuli_wdr.cpp:1366 src/muuli_wdr.cpp:1677 src/muuli_wdr.cpp:1708
-#: src/muuli_wdr.cpp:1720 src/muuli_wdr.cpp:2790
+#: src/FirstRunWizard.cpp:553 src/FirstRunWizard.cpp:569 src/muuli_wdr.cpp:1342
+#: src/muuli_wdr.cpp:1359 src/muuli_wdr.cpp:1676 src/muuli_wdr.cpp:1707
+#: src/muuli_wdr.cpp:1719 src/muuli_wdr.cpp:2762
 #: src/utils/aLinkCreator/src/alcframe.cpp:135
 #: src/utils/wxCas/src/wxcasprefs.cpp:52 src/utils/wxCas/src/wxcasprefs.cpp:118
 msgid "Browse"
 msgstr "Избери"
 
-#: src/FirstRunWizard.cpp:559 src/muuli_wdr.cpp:1713
+#: src/FirstRunWizard.cpp:559 src/muuli_wdr.cpp:1712
 msgid "(All files in this folder are shared with other peers)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:565 src/FirstRunWizard.cpp:624 src/muuli_wdr.cpp:1715
+#: src/FirstRunWizard.cpp:565 src/FirstRunWizard.cpp:624 src/muuli_wdr.cpp:1714
 msgid "Folder for temporary download files"
 msgstr ""
 
@@ -2428,7 +2418,7 @@ msgstr ""
 msgid "CRITICAL - no client on StartChatSession"
 msgstr ""
 
-#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2696 src/muuli_wdr.cpp:3373
+#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2668 src/muuli_wdr.cpp:3345
 msgid "Friends"
 msgstr "Приятели"
 
@@ -2537,8 +2527,8 @@ msgstr "никой"
 msgid "No"
 msgstr "Не"
 
-#: src/GenericClientListCtrl.cpp:1216 src/PrefsUnifiedDlg.cpp:2898
-#: src/PrefsUnifiedDlg.cpp:2948 src/ServerListCtrl.cpp:276
+#: src/GenericClientListCtrl.cpp:1216 src/PrefsUnifiedDlg.cpp:2818
+#: src/PrefsUnifiedDlg.cpp:2868 src/ServerListCtrl.cpp:276
 msgid "Yes"
 msgstr "Да"
 
@@ -2705,10 +2695,10 @@ msgstr ""
 msgid "Please fill all fields required"
 msgstr ""
 
-#: src/KadDlg.cpp:192 src/PartFile.cpp:1031 src/PrefsUnifiedDlg.cpp:1134
-#: src/PrefsUnifiedDlg.cpp:1204 src/PrefsUnifiedDlg.cpp:1405
-#: src/PrefsUnifiedDlg.cpp:1663 src/PrefsUnifiedDlg.cpp:1673
-#: src/PrefsUnifiedDlg.cpp:1690 src/PrefsUnifiedDlg.cpp:1738
+#: src/KadDlg.cpp:192 src/PartFile.cpp:1031 src/PrefsUnifiedDlg.cpp:1162
+#: src/PrefsUnifiedDlg.cpp:1331 src/PrefsUnifiedDlg.cpp:1589
+#: src/PrefsUnifiedDlg.cpp:1599 src/PrefsUnifiedDlg.cpp:1616
+#: src/PrefsUnifiedDlg.cpp:1658
 msgid "Message"
 msgstr ""
 
@@ -2809,7 +2799,7 @@ msgstr ""
 msgid "Uploaded"
 msgstr ""
 
-#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3253
+#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3225
 msgid "Requested"
 msgstr ""
 
@@ -2933,7 +2923,7 @@ msgid "WARNING: "
 msgstr ""
 
 #: src/MuleNotebook.cpp:179 src/muuli_wdr.cpp:817 src/muuli_wdr.cpp:1229
-#: src/muuli_wdr.cpp:3157 src/muuli_wdr.cpp:3413
+#: src/muuli_wdr.cpp:3129 src/muuli_wdr.cpp:3385
 msgid "Close"
 msgstr "Затвори"
 
@@ -2946,12 +2936,12 @@ msgstr ""
 msgid "Copy"
 msgstr "копие"
 
-#: src/MuleTextCtrl.cpp:88 src/SearchDlg.cpp:261
+#: src/MuleTextCtrl.cpp:88
 msgid "Paste"
 msgstr ""
 
 #: src/MuleTextCtrl.cpp:89 src/muuli_wdr.cpp:358 src/muuli_wdr.cpp:757
-#: src/muuli_wdr.cpp:2380 src/muuli_wdr.cpp:2399 src/muuli_wdr.cpp:2421
+#: src/muuli_wdr.cpp:2352 src/muuli_wdr.cpp:2371 src/muuli_wdr.cpp:2393
 #: src/utils/aLinkCreator/src/alcframe.cpp:142
 msgid "Clear"
 msgstr "Изчисти"
@@ -3046,8 +3036,8 @@ msgid "Exit"
 msgstr "Изход"
 
 #: src/MuleTrayIcon.cpp:579 src/MuleTrayIcon.cpp:945 src/MuleTrayIcon.cpp:965
-#: src/muuli_wdr.cpp:1398 src/muuli_wdr.cpp:1406 src/muuli_wdr.cpp:1413
-#: src/muuli_wdr.cpp:1836 src/muuli_wdr.cpp:1842 src/OtherFunctions.cpp:91
+#: src/muuli_wdr.cpp:1391 src/muuli_wdr.cpp:1399 src/muuli_wdr.cpp:1406
+#: src/muuli_wdr.cpp:1835 src/muuli_wdr.cpp:1841 src/OtherFunctions.cpp:91
 #: src/StatisticsDlg.cpp:93 src/StatisticsDlg.cpp:95
 msgid "kB/s"
 msgstr "кБ/с"
@@ -3216,7 +3206,7 @@ msgstr "Име:"
 msgid "Type"
 msgstr "Тип"
 
-#: src/muuli_wdr.cpp:215 src/SearchDlg.cpp:118 src/SearchListCtrl.cpp:853
+#: src/muuli_wdr.cpp:215 src/SearchDlg.cpp:110 src/SearchListCtrl.cpp:853
 msgid "Local"
 msgstr ""
 
@@ -3287,7 +3277,7 @@ msgstr "Байта"
 msgid "KB"
 msgstr "KB"
 
-#: src/muuli_wdr.cpp:274 src/muuli_wdr.cpp:293 src/muuli_wdr.cpp:1621
+#: src/muuli_wdr.cpp:274 src/muuli_wdr.cpp:293 src/muuli_wdr.cpp:1620
 #: src/OtherFunctions.cpp:64
 msgid "MB"
 msgstr "MB"
@@ -3304,7 +3294,7 @@ msgstr "Максимален размер"
 msgid "Availability"
 msgstr ""
 
-#: src/muuli_wdr.cpp:312 src/muuli_wdr.cpp:398 src/muuli_wdr.cpp:3318
+#: src/muuli_wdr.cpp:312 src/muuli_wdr.cpp:398 src/muuli_wdr.cpp:3290
 msgid "Filter:"
 msgstr ""
 
@@ -3336,7 +3326,7 @@ msgstr ""
 msgid "Stop"
 msgstr ""
 
-#: src/muuli_wdr.cpp:348 src/muuli_wdr.cpp:1392 src/SearchListCtrl.cpp:732
+#: src/muuli_wdr.cpp:348 src/muuli_wdr.cpp:1385 src/SearchListCtrl.cpp:732
 msgid "Download"
 msgstr "Изтегляне"
 
@@ -3368,12 +3358,12 @@ msgstr "Намерени източници: %i"
 #: src/muuli_wdr.cpp:1160 src/muuli_wdr.cpp:1167 src/muuli_wdr.cpp:1172
 #: src/muuli_wdr.cpp:1179 src/muuli_wdr.cpp:1184 src/muuli_wdr.cpp:1191
 #: src/muuli_wdr.cpp:1205 src/muuli_wdr.cpp:1212 src/muuli_wdr.cpp:1217
-#: src/muuli_wdr.cpp:1224 src/muuli_wdr.cpp:3255 src/muuli_wdr.cpp:3263
-#: src/muuli_wdr.cpp:3271
+#: src/muuli_wdr.cpp:1224 src/muuli_wdr.cpp:3227 src/muuli_wdr.cpp:3235
+#: src/muuli_wdr.cpp:3243
 msgid "N/A"
 msgstr "Няма"
 
-#: src/muuli_wdr.cpp:508 src/muuli_wdr.cpp:1065 src/PrefsUnifiedDlg.cpp:299
+#: src/muuli_wdr.cpp:508 src/muuli_wdr.cpp:1065 src/PrefsUnifiedDlg.cpp:297
 msgid "General"
 msgstr "Общи"
 
@@ -3511,7 +3501,7 @@ msgstr ""
 msgid "Album :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:685 src/muuli_wdr.cpp:2275
+#: src/muuli_wdr.cpp:685 src/muuli_wdr.cpp:2247
 msgid "Title :"
 msgstr "Заглавие :"
 
@@ -3617,7 +3607,7 @@ msgstr ""
 msgid "Userhash :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:895 src/muuli_wdr.cpp:1742 src/muuli_wdr.cpp:2470
+#: src/muuli_wdr.cpp:895 src/muuli_wdr.cpp:1741 src/muuli_wdr.cpp:2442
 #: src/utils/aLinkCreator/src/alcframe.cpp:137
 msgid "Add"
 msgstr "Добавяне"
@@ -3626,15 +3616,15 @@ msgstr "Добавяне"
 msgid "Download-Speed"
 msgstr ""
 
-#: src/muuli_wdr.cpp:954 src/muuli_wdr.cpp:989 src/muuli_wdr.cpp:2574
+#: src/muuli_wdr.cpp:954 src/muuli_wdr.cpp:989 src/muuli_wdr.cpp:2546
 msgid "Current"
 msgstr "Текущ"
 
-#: src/muuli_wdr.cpp:962 src/muuli_wdr.cpp:997 src/muuli_wdr.cpp:2582
+#: src/muuli_wdr.cpp:962 src/muuli_wdr.cpp:997 src/muuli_wdr.cpp:2554
 msgid "Running average"
 msgstr ""
 
-#: src/muuli_wdr.cpp:970 src/muuli_wdr.cpp:1005 src/muuli_wdr.cpp:2590
+#: src/muuli_wdr.cpp:970 src/muuli_wdr.cpp:1005 src/muuli_wdr.cpp:2562
 msgid "Session average"
 msgstr ""
 
@@ -3646,7 +3636,7 @@ msgstr ""
 msgid "Connections"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1024 src/muuli_wdr.cpp:1861
+#: src/muuli_wdr.cpp:1024 src/muuli_wdr.cpp:1860
 msgid "Active downloads"
 msgstr ""
 
@@ -3654,7 +3644,7 @@ msgstr ""
 msgid "Active connections (1:1)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1040 src/muuli_wdr.cpp:1862
+#: src/muuli_wdr.cpp:1040 src/muuli_wdr.cpp:1861
 msgid "Active uploads"
 msgstr ""
 
@@ -3771,8 +3761,8 @@ msgstr ""
 msgid "Language: "
 msgstr "език: "
 
-#: src/muuli_wdr.cpp:1257 src/muuli_wdr.cpp:1330 src/muuli_wdr.cpp:1334
-#: src/muuli_wdr.cpp:1337
+#: src/muuli_wdr.cpp:1257 src/muuli_wdr.cpp:1323 src/muuli_wdr.cpp:1327
+#: src/muuli_wdr.cpp:1330
 msgid "The delay before showing tool-tips."
 msgstr ""
 
@@ -3848,948 +3838,926 @@ msgstr ""
 msgid "Enabling this will make aMule to show notifications when finished downloading."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1323
-msgid "Remember search history"
-msgstr ""
-
-#: src/muuli_wdr.cpp:1324
-msgid "Keeps a dropdown list of your past search terms in the Search tab's Name field. This remembers the queries you typed, not the results they returned."
-msgstr ""
-
-#: src/muuli_wdr.cpp:1329
+#: src/muuli_wdr.cpp:1322
 msgid "Tooltip delay time: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1336
+#: src/muuli_wdr.cpp:1329
 msgid "seconds"
 msgstr "секунди"
 
-#: src/muuli_wdr.cpp:1340
+#: src/muuli_wdr.cpp:1333
 msgid "Browser Selection"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1346
+#: src/muuli_wdr.cpp:1339
 msgid "Enter your browser name here. Leave this field empty to use the system default browser."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1353
+#: src/muuli_wdr.cpp:1346
 msgid "Open in new tab if possible"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1355
+#: src/muuli_wdr.cpp:1348
 msgid "Open the web page in a new tab instead of in a new window when possible"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1359
+#: src/muuli_wdr.cpp:1352
 msgid "Video Player"
 msgstr "Видео плеър"
 
-#: src/muuli_wdr.cpp:1386
+#: src/muuli_wdr.cpp:1379
 msgid "Bandwidth limits"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1400
+#: src/muuli_wdr.cpp:1393
 msgid "Upload"
 msgstr "Качване"
 
-#: src/muuli_wdr.cpp:1408
+#: src/muuli_wdr.cpp:1401
 msgid "Slot Allocation"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1417
+#: src/muuli_wdr.cpp:1410
 msgid "Ports"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1427
+#: src/muuli_wdr.cpp:1420
 msgid "This is the standard eD2k port and cannot be disabled."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1430
+#: src/muuli_wdr.cpp:1423
 msgid "UDP port for server requests (TCP+3):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1432
+#: src/muuli_wdr.cpp:1425
 msgid "4665"
 msgstr "4665"
 
-#: src/muuli_wdr.cpp:1439
+#: src/muuli_wdr.cpp:1432
 msgid "This UDP port is used for extended eD2k requests and Kad network"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1446
+#: src/muuli_wdr.cpp:1439
 msgid "UPnP TCP Port (Optional):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1456
+#: src/muuli_wdr.cpp:1449
 msgid "Bind local address to IP (empty for any):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1459
+#: src/muuli_wdr.cpp:1452
 msgid "Advanced users only: If you have multiple network interfaces, enter the address of the interface to which aMule should be bound."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1462 src/muuli_wdr.cpp:2055
+#: src/muuli_wdr.cpp:1455 src/muuli_wdr.cpp:2054
 msgid "Bind to network interface (empty for any):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1475
+#: src/muuli_wdr.cpp:1468
 msgid "Advanced users only: pin all of aMule's traffic to one network interface, chosen from the list or typed in by name (e.g. tun0, eth0, en0) or index. Unlike binding to an IP, this stops traffic leaking out via the default route - useful with a VPN. Requires no elevated privileges."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1481
+#: src/muuli_wdr.cpp:1474
 msgid "Max sources per downloading file:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1485
+#: src/muuli_wdr.cpp:1478
 msgid "Max simultaneous connections:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1498 src/muuli_wdr.cpp:3197
+#: src/muuli_wdr.cpp:1491 src/muuli_wdr.cpp:3169
 msgid "ED2K"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1505
+#: src/muuli_wdr.cpp:1498
 msgid "Autoconnect on startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1508
+#: src/muuli_wdr.cpp:1501
 msgid "Reconnect on loss"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1530
+#: src/muuli_wdr.cpp:1523
 msgid "Remove dead server after"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1531
+#: src/muuli_wdr.cpp:1524
 msgid "Static servers are never removed, even when unreachable."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1535
+#: src/muuli_wdr.cpp:1528
 msgid "retries"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1543
+#: src/muuli_wdr.cpp:1536
 msgid "List"
 msgstr "Списък"
 
-#: src/muuli_wdr.cpp:1546
+#: src/muuli_wdr.cpp:1539
 msgid "Update server list when connecting to a server"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1549
+#: src/muuli_wdr.cpp:1542
 msgid "Update server list when a client connects"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1552
+#: src/muuli_wdr.cpp:1545
 msgid "Use priority system"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1556
+#: src/muuli_wdr.cpp:1549
 msgid "Use smart LowID check on connect"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1560
+#: src/muuli_wdr.cpp:1553
 msgid "Safe connect"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1564
+#: src/muuli_wdr.cpp:1557
 msgid "Autoconnect to servers in static list only"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1567
+#: src/muuli_wdr.cpp:1560
 msgid "Set manually added servers to High Priority"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1588
+#: src/muuli_wdr.cpp:1581
 msgid "Add files to download in pause mode"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1590
+#: src/muuli_wdr.cpp:1583
 msgid "Add files to download with auto priority"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1593
+#: src/muuli_wdr.cpp:1586
 msgid "Try to download first and last chunks first"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1597
+#: src/muuli_wdr.cpp:1590
 msgid "Endgame mode: rotate to faster sources for the final blocks"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1600
+#: src/muuli_wdr.cpp:1593
 msgid "Start next paused file when a file completes"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1603
+#: src/muuli_wdr.cpp:1596
 msgid "From the same category"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1605
+#: src/muuli_wdr.cpp:1598
 msgid "In alphabetic order"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1607
+#: src/muuli_wdr.cpp:1600
 msgid "Preallocate disk space for new files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1608
+#: src/muuli_wdr.cpp:1601
 msgid "For new files preallocates disk space for the whole file, thus reduces fragmentation"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1613
+#: src/muuli_wdr.cpp:1606
+msgid "Create new files as sparse files"
+msgstr ""
+
+#: src/muuli_wdr.cpp:1607
+msgid "A sparse file reserves its full size on disk immediately without writing real data to it -- fast, but unsupported or slow on some filesystems, and free-space accounting stays optimistic while the download is in progress. Turn this off to grow the file only as data arrives."
+msgstr ""
+
+#: src/muuli_wdr.cpp:1612
 msgid "Stop downloads when free disk space reaches "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1614
+#: src/muuli_wdr.cpp:1613
 msgid "Select this if you want aMule to check your disk space"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1618
+#: src/muuli_wdr.cpp:1617
 msgid "Enter here the min disk space desired."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1624
+#: src/muuli_wdr.cpp:1623
 msgid "Save 10 sources on rare files (< 20 sources)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1628 src/Statistics.cpp:790
+#: src/muuli_wdr.cpp:1627 src/Statistics.cpp:790
 msgid "Uploads"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1631
+#: src/muuli_wdr.cpp:1630
 msgid "Add new shared files with auto priority"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1637
+#: src/muuli_wdr.cpp:1636
 msgid "Intelligent Corruption Handling (I.C.H.)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1640
+#: src/muuli_wdr.cpp:1639
 msgid "Enable"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1643
+#: src/muuli_wdr.cpp:1642
 msgid "Advanced I.C.H. trusts every hash (not recommended)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1655 src/PrefsUnifiedDlg.cpp:1990
+#: src/muuli_wdr.cpp:1654 src/PrefsUnifiedDlg.cpp:1910
 msgid "Media metadata extraction"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1659
+#: src/muuli_wdr.cpp:1658
 msgid "Extract length / bitrate / codec from shared audio and video files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1661
+#: src/muuli_wdr.cpp:1660
 msgid "When enabled, aMule runs ffprobe on each shared media file to fill in the Length / Bitrate / Codec columns other clients see when they find the file in a search. Requires ffmpeg (the ffprobe binary) to be installed."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1668
+#: src/muuli_wdr.cpp:1667
 msgid "Path to ffprobe:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1673
+#: src/muuli_wdr.cpp:1672
 msgid "Full path to the ffprobe binary. Leave empty to have aMule auto-detect it on startup."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1681
+#: src/muuli_wdr.cpp:1680
 msgid "Detect"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1682
+#: src/muuli_wdr.cpp:1681
 msgid "Search the standard install locations for an ffprobe binary and fill the path field."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1706
+#: src/muuli_wdr.cpp:1705
 msgid ""
 "Completed downloads are stored here. All files in this folder are automatically shared with other peers.\n"
 "If this folder also holds files you don't want to share, point it at an aMule-only sub-folder."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1709
+#: src/muuli_wdr.cpp:1708
 msgid "Pick the folder where completed downloads will be stored. All files in that folder will be shared with other peers."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1723
+#: src/muuli_wdr.cpp:1722
 msgid "Shared folders"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1729
+#: src/muuli_wdr.cpp:1728
 msgid "(Folders shared by the core. Enter a path to add one.)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1737
+#: src/muuli_wdr.cpp:1736
 msgid "Absolute path of a folder on the core's machine, e.g. /home/user/shared"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1739 src/PrefsUnifiedDlg.cpp:2874
+#: src/muuli_wdr.cpp:1738 src/PrefsUnifiedDlg.cpp:2794
 msgid "Recursive"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1740
+#: src/muuli_wdr.cpp:1739
 msgid "Share every sub-folder underneath this one, including ones created later."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1744 src/utils/aLinkCreator/src/alcframe.cpp:141
+#: src/muuli_wdr.cpp:1743 src/utils/aLinkCreator/src/alcframe.cpp:141
 msgid "Remove"
 msgstr "Премахване"
 
-#: src/muuli_wdr.cpp:1748
+#: src/muuli_wdr.cpp:1747
 msgid "(Right click on folder icon for recursive share)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1755
+#: src/muuli_wdr.cpp:1754
 msgid "Share hidden files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1761
+#: src/muuli_wdr.cpp:1760
 msgid "Automatically rescan shared folders for changes"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1767
+#: src/muuli_wdr.cpp:1766
 msgid "Follow symbolic links in shared folders"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1773
+#: src/muuli_wdr.cpp:1772
 msgid "Exclude files matching:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1776
+#: src/muuli_wdr.cpp:1775
 msgid "Wildcard patterns separated by '|', e.g. .DS_Store|Thumbs.db|*.tmp. Files whose name matches are not shared. Matching is case-insensitive."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1780
+#: src/muuli_wdr.cpp:1779
 msgid "Patterns are regular expressions"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1781
+#: src/muuli_wdr.cpp:1780
 msgid "When set, the whole field is one regular expression ('|' is alternation). When unset, it is a list of '|'-separated wildcards."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1791
+#: src/muuli_wdr.cpp:1790
 msgid "Show how many shared files the current pattern would exclude."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1812
+#: src/muuli_wdr.cpp:1811
 msgid "Graphs"
 msgstr "Диаграми"
 
-#: src/muuli_wdr.cpp:1815 src/muuli_wdr.cpp:1877
+#: src/muuli_wdr.cpp:1814 src/muuli_wdr.cpp:1876
 msgid "Update delay : 5 secs"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1819
+#: src/muuli_wdr.cpp:1818
 msgid "Time for average graph: 100 mins"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1823
+#: src/muuli_wdr.cpp:1822
 msgid "Connections Graph Scale: 100 "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1830
+#: src/muuli_wdr.cpp:1829
 msgid "Download graph scale:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1838
+#: src/muuli_wdr.cpp:1837
 msgid "Upload graph scale:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1848
+#: src/muuli_wdr.cpp:1847
 #, fuzzy
 msgid "Colors: "
 msgstr "Цветове: "
 
-#: src/muuli_wdr.cpp:1852
+#: src/muuli_wdr.cpp:1851
 msgid "Background"
 msgstr "Фон"
 
-#: src/muuli_wdr.cpp:1853
+#: src/muuli_wdr.cpp:1852
 msgid "Grid"
 msgstr "Мрежа"
 
-#: src/muuli_wdr.cpp:1854
+#: src/muuli_wdr.cpp:1853
 msgid "Download current"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1855
+#: src/muuli_wdr.cpp:1854
 msgid "Download running average"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1856
+#: src/muuli_wdr.cpp:1855
 msgid "Download session average"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1857
+#: src/muuli_wdr.cpp:1856
 msgid "Upload current"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1858
+#: src/muuli_wdr.cpp:1857
 msgid "Upload running average"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1859
+#: src/muuli_wdr.cpp:1858
 msgid "Upload session average"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1860
+#: src/muuli_wdr.cpp:1859
 msgid "Active connections"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1863
+#: src/muuli_wdr.cpp:1862
 msgid "Systray Icon Speed Bar"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1864
+#: src/muuli_wdr.cpp:1863
 msgid "Kad-nodes current"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1865
+#: src/muuli_wdr.cpp:1864
 msgid "Kad-nodes running"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1866
+#: src/muuli_wdr.cpp:1865
 msgid "Kad-nodes session"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1870 src/muuli_wdr.cpp:2324
+#: src/muuli_wdr.cpp:1869 src/muuli_wdr.cpp:2296
 msgid "Select"
 msgstr "Избор"
 
-#: src/muuli_wdr.cpp:1874
+#: src/muuli_wdr.cpp:1873
 msgid "Tree"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1884
+#: src/muuli_wdr.cpp:1883
 msgid "Number of Client Versions shown (0=unlimited)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1909
+#: src/muuli_wdr.cpp:1908
 msgid "!!! WARNING !!!"
 msgstr "!!! ВНИМАНИЕ !!!"
 
-#: src/muuli_wdr.cpp:1924
+#: src/muuli_wdr.cpp:1923
 msgid "Max new connections / 5 secs"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1926
+#: src/muuli_wdr.cpp:1925
 msgid "Concurrent Kad source lookups"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1928
+#: src/muuli_wdr.cpp:1927
 msgid "Kad source re-search interval (minutes)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1930
+#: src/muuli_wdr.cpp:1929
 msgid "Source re-ask interval (minutes)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1934
+#: src/muuli_wdr.cpp:1933
 msgid "File Buffer Size: 240000 bytes"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1938
+#: src/muuli_wdr.cpp:1937
 msgid "Use MMAP: memory-mapped file access (lower memory use)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1939
+#: src/muuli_wdr.cpp:1938
 msgid "Maps part files into memory instead of buffering them on the heap, lowering the process memory footprint. May reduce download speed on some disks; best for memory-constrained or upload-heavy hosts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1941
+#: src/muuli_wdr.cpp:1940
 msgid "Upload Queue Size: 5000 clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1945
+#: src/muuli_wdr.cpp:1944
 msgid "Server connection refresh interval: Disable"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1949
+#: src/muuli_wdr.cpp:1948
 msgid "Disable computer's timed standby mode"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1968
+#: src/muuli_wdr.cpp:1967
 msgid "Skin to use: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1977
+#: src/muuli_wdr.cpp:1976
 msgid "Show \"Fast eD2k Links Handler\" in every window."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1980
+#: src/muuli_wdr.cpp:1979
 msgid "Show extended info on categories tabs"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1983
+#: src/muuli_wdr.cpp:1982
 msgid "Show application version on title"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1985
+#: src/muuli_wdr.cpp:1984
 msgid "Show transfer rates on title"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1987
+#: src/muuli_wdr.cpp:1986
 msgid "Before application name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1989
+#: src/muuli_wdr.cpp:1988
 msgid "After application name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1992
+#: src/muuli_wdr.cpp:1991
 msgid "Show overhead bandwidth"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1996
+#: src/muuli_wdr.cpp:1995
 msgid "Vertical toolbar orientation"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1998
+#: src/muuli_wdr.cpp:1997
 msgid "Live column sorting (auto-reorder rows as their values change)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2005
+#: src/muuli_wdr.cpp:2004
 msgid "Download Queue Files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2008
+#: src/muuli_wdr.cpp:2007
 msgid "Show progress percentage"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2014
+#: src/muuli_wdr.cpp:2013
 msgid "Show progress bar"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2017
+#: src/muuli_wdr.cpp:2016
 msgid "Flat"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2021
+#: src/muuli_wdr.cpp:2020
 msgid "Round"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2039
+#: src/muuli_wdr.cpp:2038
 msgid "External Connection Parameters"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2042
+#: src/muuli_wdr.cpp:2041
 msgid "Accept external connections"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2049 src/muuli_wdr.cpp:2108
+#: src/muuli_wdr.cpp:2048 src/muuli_wdr.cpp:2107
 msgid "IP of the listening interface:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2052
+#: src/muuli_wdr.cpp:2051
 msgid "Enter here a valid ip in the a.b.c.d format for the listening EC interface. An empty field or 0.0.0.0 will mean any interface."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2073 src/muuli_wdr.cpp:2184
+#: src/muuli_wdr.cpp:2072 src/muuli_wdr.cpp:2156
 msgid "TCP port:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2079
+#: src/muuli_wdr.cpp:2078
 msgid "Enable UPnP port forwarding on the EC port"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2083 src/muuli_wdr.cpp:3069
+#: src/muuli_wdr.cpp:2082 src/muuli_wdr.cpp:3041
 #: src/utils/wxCas/src/wxcasprefs.cpp:167
 msgid "Password"
 msgstr "парола"
 
-#: src/muuli_wdr.cpp:2089
+#: src/muuli_wdr.cpp:2088
 msgid "aMule API server parameters"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2092
+#: src/muuli_wdr.cpp:2091
 msgid "Run amuleapi (REST API) on startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2097
+#: src/muuli_wdr.cpp:2096
 msgid "HTTP port:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2111
+#: src/muuli_wdr.cpp:2110
 msgid "The interface amuleapi's HTTP server listens on. 127.0.0.1 (default) accepts only local connections; use 0.0.0.0 or a specific IP to expose it to other hosts (set an admin password below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2116
-msgid "Type a password to set or change it. Stored passwords cannot be shown, so leaving this empty keeps the current one."
-msgstr ""
-
-#: src/muuli_wdr.cpp:2118
+#: src/muuli_wdr.cpp:2113
 #, fuzzy
 msgid "Admin password"
 msgstr "парола"
 
-#: src/muuli_wdr.cpp:2130 src/muuli_wdr.cpp:2147 src/PrefsUnifiedDlg.cpp:1103
-#, fuzzy
-msgid "A password is set."
-msgstr "парола"
-
-#: src/muuli_wdr.cpp:2134
-msgid "Enable guest access"
-msgstr ""
-
-#: src/muuli_wdr.cpp:2135
-msgid "Guest sessions may read status and listings but cannot change anything. Turning this off clears the stored guest password."
-msgstr ""
-
-#: src/muuli_wdr.cpp:2139
-#, fuzzy
-msgid "Guest password"
-msgstr "парола"
-
-#: src/muuli_wdr.cpp:2154
-msgid "Web server parameters"
-msgstr ""
-
-#: src/muuli_wdr.cpp:2157
-msgid "Run webserver on startup (deprecated)"
-msgstr ""
-
-#: src/muuli_wdr.cpp:2163
-msgid "Web template"
-msgstr ""
-
-#: src/muuli_wdr.cpp:2168
-msgid "Full rights password"
-msgstr ""
-
-#: src/muuli_wdr.cpp:2172
-msgid "Enable Low rights User"
-msgstr ""
-
-#: src/muuli_wdr.cpp:2177
+#: src/muuli_wdr.cpp:2118 src/muuli_wdr.cpp:2149
 msgid "Low rights password"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2191
+#: src/muuli_wdr.cpp:2126
+msgid "Web server parameters"
+msgstr ""
+
+#: src/muuli_wdr.cpp:2129
+msgid "Run webserver on startup (deprecated)"
+msgstr ""
+
+#: src/muuli_wdr.cpp:2135
+msgid "Web template"
+msgstr ""
+
+#: src/muuli_wdr.cpp:2140
+msgid "Full rights password"
+msgstr ""
+
+#: src/muuli_wdr.cpp:2144
+msgid "Enable Low rights User"
+msgstr ""
+
+#: src/muuli_wdr.cpp:2163
 msgid "Enable UPnP port forwarding of the web server port"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2196
+#: src/muuli_wdr.cpp:2168
 msgid "Web server UPnP TCP port (Optional)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2204
+#: src/muuli_wdr.cpp:2176
 msgid "Page Refresh Time (in secs)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2211
+#: src/muuli_wdr.cpp:2183
 msgid "Enable Gzip compression"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2245
+#: src/muuli_wdr.cpp:2217
 msgid "Reset page to defaults"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2246
+#: src/muuli_wdr.cpp:2218
 msgid "Reset the settings on the current page to their default values."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2248 src/muuli_wdr.cpp:2334 src/ServerWnd.cpp:274
+#: src/muuli_wdr.cpp:2220 src/muuli_wdr.cpp:2306 src/ServerWnd.cpp:274
 #: src/ServerWnd.cpp:282
 msgid "OK"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2250
+#: src/muuli_wdr.cpp:2222
 msgid "Click here to apply any changes made to the preferences."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2253
+#: src/muuli_wdr.cpp:2225
 msgid "Reset any changes made to the preferences."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2282
+#: src/muuli_wdr.cpp:2254
 msgid "Comment :"
 msgstr "Коментар:"
 
-#: src/muuli_wdr.cpp:2289
+#: src/muuli_wdr.cpp:2261
 msgid "Incoming Dir :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2298
+#: src/muuli_wdr.cpp:2270
 msgid "Change priority for new assigned files :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2302
+#: src/muuli_wdr.cpp:2274
 msgid "Don't change"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2314
+#: src/muuli_wdr.cpp:2286
 msgid "Select color for this Category (currently selected) :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2381 src/muuli_wdr.cpp:2400 src/muuli_wdr.cpp:2422
+#: src/muuli_wdr.cpp:2353 src/muuli_wdr.cpp:2372 src/muuli_wdr.cpp:2394
 msgid "Click this button to reset the log."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2441
+#: src/muuli_wdr.cpp:2413
 msgid "Click on this button to update the servers list from URL ..."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2445
+#: src/muuli_wdr.cpp:2417
 msgid "Server list"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2449
+#: src/muuli_wdr.cpp:2421
 msgid "Enter the url to a server.met file here and press the button to the left to update the list of known servers."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2454
+#: src/muuli_wdr.cpp:2426
 msgid "Add server manually: Name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2457
+#: src/muuli_wdr.cpp:2429
 msgid "Enter the name of the new server here"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2459 src/ServerWnd.cpp:206
+#: src/muuli_wdr.cpp:2431 src/ServerWnd.cpp:206
 msgid "IP:Port"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2462
+#: src/muuli_wdr.cpp:2434
 msgid "Enter the IP of the server here, using the x.x.x.x format."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2468
+#: src/muuli_wdr.cpp:2440
 msgid "Enter the port of the server here."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2471
+#: src/muuli_wdr.cpp:2443
 msgid "Add manually a server (fill fields to the left before) ..."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2500
+#: src/muuli_wdr.cpp:2472
 msgid "aMule Log"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2508
+#: src/muuli_wdr.cpp:2480
 msgid "Server Info"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2512
+#: src/muuli_wdr.cpp:2484
 msgid "ED2K Info"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2516
+#: src/muuli_wdr.cpp:2488
 msgid "Kad Info"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2544
+#: src/muuli_wdr.cpp:2516
 msgid "Click on this button to update the nodes list from URL ..."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2548
+#: src/muuli_wdr.cpp:2520
 msgid "Nodes (0)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2552
+#: src/muuli_wdr.cpp:2524
 msgid "Enter the url to a nodes.dat file here and press the button to the left to update the list of known nodes."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2555
+#: src/muuli_wdr.cpp:2527
 msgid "Nodes stats"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2597
+#: src/muuli_wdr.cpp:2569
 msgid "Bootstrap"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2600
+#: src/muuli_wdr.cpp:2572
 msgid "New node"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2605
+#: src/muuli_wdr.cpp:2577
 msgid "IP:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2625
+#: src/muuli_wdr.cpp:2597
 msgid "Port:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2638
+#: src/muuli_wdr.cpp:2610
 msgid "Bootstrap from known clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2640
+#: src/muuli_wdr.cpp:2612
 msgid "Disconnect Kad"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2674
+#: src/muuli_wdr.cpp:2646
 msgid "Use Secure User Identification"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2676
+#: src/muuli_wdr.cpp:2648
 msgid "It is recommended to enable this option. You will not receive credits if SUI is not enabled."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2678
+#: src/muuli_wdr.cpp:2650
 msgid "Protocol Obfuscation"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2681
+#: src/muuli_wdr.cpp:2653
 msgid "Support Protocol Obfuscation"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2683
+#: src/muuli_wdr.cpp:2655
 msgid "This option enabled Protocol Obfuscation, and makes aMule accept obfuscated connections from other clients."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2685
+#: src/muuli_wdr.cpp:2657
 msgid "Use obfuscation for outgoing connections"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2687
+#: src/muuli_wdr.cpp:2659
 msgid "This option makes aMule use Protocol Obfuscation when connecting other clients/servers."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2689
+#: src/muuli_wdr.cpp:2661
 msgid "Accept only obfuscated connections"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2690
+#: src/muuli_wdr.cpp:2662
 msgid "This option makes aMule only accept obfuscated connections. You will have less sources, but all your traffic will be obfuscated"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2695
+#: src/muuli_wdr.cpp:2667
 msgid "Everybody"
 msgstr "Всеки"
 
-#: src/muuli_wdr.cpp:2697
+#: src/muuli_wdr.cpp:2669
 msgid "No one"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2699
+#: src/muuli_wdr.cpp:2671
 msgid "Who can see my shared files:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2700
+#: src/muuli_wdr.cpp:2672
 msgid "Select who can request to view a list of your shared files."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2702
+#: src/muuli_wdr.cpp:2674
 msgid "IP-Filtering"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2709
+#: src/muuli_wdr.cpp:2681
 msgid "Filter clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2711
+#: src/muuli_wdr.cpp:2683
 msgid "Enable filtering of the client IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2713
+#: src/muuli_wdr.cpp:2685
 msgid "Filter servers"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2715
+#: src/muuli_wdr.cpp:2687
 msgid "Enable filtering of the server IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2719
+#: src/muuli_wdr.cpp:2691
 msgid "Reload List"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2720
+#: src/muuli_wdr.cpp:2692
 msgid "Reload the list of IPs to filter from the file ~/.aMule/ipfilter.dat"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2726
+#: src/muuli_wdr.cpp:2698
 msgid "URL:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2730 src/muuli_wdr.cpp:2923
+#: src/muuli_wdr.cpp:2702 src/muuli_wdr.cpp:2895
 msgid "Update now"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2733
+#: src/muuli_wdr.cpp:2705
 msgid "Auto-update ipfilter at startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2737
+#: src/muuli_wdr.cpp:2709
 msgid "Filtering Level:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2743
+#: src/muuli_wdr.cpp:2715
 msgid "Always filter LAN IPs"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2746
+#: src/muuli_wdr.cpp:2718
 msgid "Paranoid handling of non-matching IPs"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2748
+#: src/muuli_wdr.cpp:2720
 msgid "Rejects a packet when its source IP differs from the IP the client claims (an anti-spoofing check). Disable only if it causes connection problems."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2750
+#: src/muuli_wdr.cpp:2722
 msgid "Use system-wide ipfilter.dat if available"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2751
+#: src/muuli_wdr.cpp:2723
 msgid "If there's no local ipfilter.dat found, allow usage of a system-wide ipfilter file."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2768
+#: src/muuli_wdr.cpp:2740
 msgid "Enable Online-Signature"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2770
+#: src/muuli_wdr.cpp:2742
 msgid "Enables the writing of the OS file, which can be used by external apps to create signatures and the like."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2774
+#: src/muuli_wdr.cpp:2746
 msgid "Update Frequency (Secs):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2777
+#: src/muuli_wdr.cpp:2749
 msgid "Change the frequency (in seconds) of Online Signature updates."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2785
+#: src/muuli_wdr.cpp:2757
 msgid "Save online signature file in: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:2791
+#: src/muuli_wdr.cpp:2763
 msgid "Click here to select the directory containing the the Online Signature files."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2824
+#: src/muuli_wdr.cpp:2796
 msgid "Show country flags for clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2825
+#: src/muuli_wdr.cpp:2797
 msgid "Render the country flag column in the transfers, queue and search views. Requires a valid MMDB GeoIP database (see below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2830
+#: src/muuli_wdr.cpp:2802
 msgid "Database"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2846
+#: src/muuli_wdr.cpp:2818
 #, fuzzy
 msgid "Source:"
 msgstr "Източници"
 
-#: src/muuli_wdr.cpp:2849
+#: src/muuli_wdr.cpp:2821
 msgid "DB-IP (free, no account)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2850
+#: src/muuli_wdr.cpp:2822
 msgid "MaxMind GeoLite2 (free, account required)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2851
+#: src/muuli_wdr.cpp:2823
 msgid "Custom URL"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2854
+#: src/muuli_wdr.cpp:2826
 msgid "Choose which provider supplies the GeoIP MMDB database. DB-IP is the default - no account required. MaxMind requires a free account + license key. Use Custom URL to point at any other MMDB host (e.g. a local mirror)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2871
+#: src/muuli_wdr.cpp:2843
 msgid ""
 "No configuration required.\n"
 "\n"
@@ -4797,11 +4765,11 @@ msgid ""
 "License: Creative Commons BY 4.0 - https://creativecommons.org/licenses/by/4.0/"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2884
+#: src/muuli_wdr.cpp:2856
 msgid "License key:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2890
+#: src/muuli_wdr.cpp:2862
 msgid ""
 "Sign up for a free MaxMind account, then generate a License Key:\n"
 "https://www.maxmind.com/en/geolite2/signup\n"
@@ -4811,229 +4779,229 @@ msgid ""
 "Requires attribution and account registration; refresh at least every 30 days."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2905
+#: src/muuli_wdr.cpp:2877
 #, fuzzy
 msgid "Download URL:"
 msgstr "Изтегляне"
 
-#: src/muuli_wdr.cpp:2911
+#: src/muuli_wdr.cpp:2883
 msgid ""
 "Must point to an .mmdb file or a .gz / .tar.gz containing one.\n"
 "URL may include credentials (https://user:pass@host/...).\n"
 "License and attribution terms are set by the upstream URL - you are responsible."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2924
+#: src/muuli_wdr.cpp:2896
 msgid "Download the GeoIP database from the selected source."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2926
+#: src/muuli_wdr.cpp:2898
 msgid "Auto-update on startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2927
+#: src/muuli_wdr.cpp:2899
 msgid "Re-download the GeoIP database from the selected source every time aMule starts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2950
+#: src/muuli_wdr.cpp:2922
 msgid "Filter incoming messages (except current chat):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2952
+#: src/muuli_wdr.cpp:2924
 msgid "Filter all messages"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2954
+#: src/muuli_wdr.cpp:2926
 msgid "Filter messages from people not on your friend list"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2956
+#: src/muuli_wdr.cpp:2928
 msgid "Filter messages from unknown clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2958
+#: src/muuli_wdr.cpp:2930
 msgid "Filter messages containing (use ',' as separator):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2961 src/muuli_wdr.cpp:2972
+#: src/muuli_wdr.cpp:2933 src/muuli_wdr.cpp:2944
 msgid "add here the words amule should filter and block messages including it"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2963
+#: src/muuli_wdr.cpp:2935
 msgid "Show received messages in the log"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2966
+#: src/muuli_wdr.cpp:2938
 msgid "Comments"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2969
+#: src/muuli_wdr.cpp:2941
 msgid "Filter comments containing (use ',' as separator):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2994
+#: src/muuli_wdr.cpp:2966
 msgid "Enable Proxy"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2995
+#: src/muuli_wdr.cpp:2967
 msgid "Enable/disable proxy support"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2998
+#: src/muuli_wdr.cpp:2970
 msgid "Proxy type:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3009
+#: src/muuli_wdr.cpp:2981
 msgid "Proxy host:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3012
+#: src/muuli_wdr.cpp:2984
 msgid "The proxy host name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3014
+#: src/muuli_wdr.cpp:2986
 msgid "Proxy port:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3017
+#: src/muuli_wdr.cpp:2989
 msgid "The proxy port"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3019
+#: src/muuli_wdr.cpp:2991
 msgid "Enable authentication"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3020
+#: src/muuli_wdr.cpp:2992
 msgid "Enable/disable username/password authentication"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3023
+#: src/muuli_wdr.cpp:2995
 msgid "Username: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:3026
+#: src/muuli_wdr.cpp:2998
 msgid "The username to use to connect to the proxy"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3028
+#: src/muuli_wdr.cpp:3000
 msgid "Password:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3031
+#: src/muuli_wdr.cpp:3003
 msgid "The password to use to connect to the proxy"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3050
+#: src/muuli_wdr.cpp:3022
 msgid "Connect to:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3059
+#: src/muuli_wdr.cpp:3031
 msgid "Login to remote amule"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3064
+#: src/muuli_wdr.cpp:3036
 msgid "User name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3075
+#: src/muuli_wdr.cpp:3047
 msgid "Remember those settings"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3078
+#: src/muuli_wdr.cpp:3050
 msgid "Force ZLIB compression"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3102
+#: src/muuli_wdr.cpp:3074
 msgid "Enable Verbose Debug-Logging."
 msgstr ""
 
-#: src/muuli_wdr.cpp:3104
+#: src/muuli_wdr.cpp:3076
 msgid "Only to Logfile"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3106
+#: src/muuli_wdr.cpp:3078
 msgid "Message Categories:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3130 src/PartFileConvertDlg.cpp:160
+#: src/muuli_wdr.cpp:3102 src/PartFileConvertDlg.cpp:160
 msgid "Waiting..."
 msgstr "Изчакване"
 
-#: src/muuli_wdr.cpp:3150
+#: src/muuli_wdr.cpp:3122
 msgid "Add imports"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3153
+#: src/muuli_wdr.cpp:3125
 msgid "Retry selected"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3155
+#: src/muuli_wdr.cpp:3127
 msgid "Remove selected"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3218
+#: src/muuli_wdr.cpp:3190
 msgid "Event Types"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3237
+#: src/muuli_wdr.cpp:3209
 msgid "Statistics and queued clients for selected file(s) : Session / All time"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3261
+#: src/muuli_wdr.cpp:3233
 #, fuzzy
 msgid "Active Uploads"
 msgstr "Активни качвания: %i"
 
-#: src/muuli_wdr.cpp:3275
+#: src/muuli_wdr.cpp:3247
 #, fuzzy
 msgid "Percent of total files"
 msgstr "Общо файлове"
 
-#: src/muuli_wdr.cpp:3327
+#: src/muuli_wdr.cpp:3299
 #, fuzzy
 msgid "Show Clients for"
 msgstr "Клиенти"
 
-#: src/muuli_wdr.cpp:3329
+#: src/muuli_wdr.cpp:3301
 msgid "All files"
 msgstr "Всички файлове"
 
-#: src/muuli_wdr.cpp:3332
+#: src/muuli_wdr.cpp:3304
 #, fuzzy
 msgid "Selected files"
 msgstr "Избор на филтър"
 
-#: src/muuli_wdr.cpp:3335
+#: src/muuli_wdr.cpp:3307
 #, fuzzy
 msgid "Active uploads only"
 msgstr "Активни качвания: %i"
 
-#: src/muuli_wdr.cpp:3342
+#: src/muuli_wdr.cpp:3314
 #, fuzzy
 msgid "Reload:"
 msgstr "Качване"
 
-#: src/muuli_wdr.cpp:3346
+#: src/muuli_wdr.cpp:3318
 msgid "Reload your shared files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3409
+#: src/muuli_wdr.cpp:3381
 msgid "Send"
 msgstr "Изпраща"
 
-#: src/muuli_wdr.cpp:3410
+#: src/muuli_wdr.cpp:3382
 msgid "Sends the specified message."
 msgstr ""
 
-#: src/muuli_wdr.cpp:3414
+#: src/muuli_wdr.cpp:3386
 msgid "Close this chat-session."
 msgstr ""
 
-#: src/muuli_wdr.cpp:3437
+#: src/muuli_wdr.cpp:3409
 msgid "Connect to any server and/or Kad"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3443 src/SharedFilesCtrl.cpp:142 src/Statistics.cpp:941
+#: src/muuli_wdr.cpp:3415 src/SharedFilesCtrl.cpp:142 src/Statistics.cpp:941
 msgid "Shared Files"
 msgstr ""
 
@@ -5393,263 +5361,263 @@ msgstr ""
 msgid "ERROR: Failed to open partfile '%s'"
 msgstr ""
 
-#: src/Preferences.cpp:701
+#: src/Preferences.cpp:673
 msgid "System default"
 msgstr ""
 
-#: src/Preferences.cpp:702
+#: src/Preferences.cpp:674
 msgid "Albanian"
 msgstr "албанец"
 
-#: src/Preferences.cpp:703
+#: src/Preferences.cpp:675
 msgid "Arabic"
 msgstr "арабски"
 
-#: src/Preferences.cpp:704
+#: src/Preferences.cpp:676
 msgid "Asturian"
 msgstr "Астурия"
 
-#: src/Preferences.cpp:705
+#: src/Preferences.cpp:677
 msgid "Basque"
 msgstr "баска"
 
-#: src/Preferences.cpp:706
+#: src/Preferences.cpp:678
 msgid "Bulgarian"
 msgstr "български"
 
-#: src/Preferences.cpp:707
+#: src/Preferences.cpp:679
 msgid "Catalan"
 msgstr "Каталунски"
 
-#: src/Preferences.cpp:708
+#: src/Preferences.cpp:680
 msgid "Chinese (Simplified)"
 msgstr "Китайски (опростен)"
 
-#: src/Preferences.cpp:709
+#: src/Preferences.cpp:681
 msgid "Chinese (Traditional)"
 msgstr "Китайски (традиционен)"
 
-#: src/Preferences.cpp:710
+#: src/Preferences.cpp:682
 msgid "Croatian"
 msgstr "хърватски"
 
-#: src/Preferences.cpp:711
+#: src/Preferences.cpp:683
 msgid "Czech"
 msgstr "чешки"
 
-#: src/Preferences.cpp:712
+#: src/Preferences.cpp:684
 msgid "Danish"
 msgstr "датски"
 
-#: src/Preferences.cpp:713
+#: src/Preferences.cpp:685
 msgid "Dutch"
 msgstr "холандски"
 
-#: src/Preferences.cpp:714
+#: src/Preferences.cpp:686
 msgid "English (U.K.)"
 msgstr ""
 
-#: src/Preferences.cpp:715
+#: src/Preferences.cpp:687
 msgid "English (U.S.)"
 msgstr ""
 
-#: src/Preferences.cpp:716
+#: src/Preferences.cpp:688
 msgid "Estonian"
 msgstr "естонски"
 
-#: src/Preferences.cpp:717
+#: src/Preferences.cpp:689
 msgid "Finnish"
 msgstr "фински"
 
-#: src/Preferences.cpp:718
+#: src/Preferences.cpp:690
 msgid "French"
 msgstr "Френски"
 
-#: src/Preferences.cpp:719
+#: src/Preferences.cpp:691
 msgid "Galician"
 msgstr "галисийски"
 
-#: src/Preferences.cpp:720
+#: src/Preferences.cpp:692
 msgid "German"
 msgstr "Немски"
 
-#: src/Preferences.cpp:721
+#: src/Preferences.cpp:693
 msgid "Greek"
 msgstr "Гръцки"
 
-#: src/Preferences.cpp:722
+#: src/Preferences.cpp:694
 msgid "Hebrew"
 msgstr "иврит"
 
-#: src/Preferences.cpp:723
+#: src/Preferences.cpp:695
 msgid "Hungarian"
 msgstr "унгарски"
 
-#: src/Preferences.cpp:724
+#: src/Preferences.cpp:696
 msgid "Italian"
 msgstr "Италиански"
 
-#: src/Preferences.cpp:725
+#: src/Preferences.cpp:697
 msgid "Japanese"
 msgstr "японски"
 
-#: src/Preferences.cpp:726
+#: src/Preferences.cpp:698
 msgid "Korean"
 msgstr "корейски"
 
-#: src/Preferences.cpp:727
+#: src/Preferences.cpp:699
 msgid "Latvian"
 msgstr ""
 
-#: src/Preferences.cpp:728
+#: src/Preferences.cpp:700
 msgid "Lithuanian"
 msgstr "литовски"
 
-#: src/Preferences.cpp:729
+#: src/Preferences.cpp:701
 msgid "Norwegian (Nynorsk)"
 msgstr "норвежки (Съвременен)"
 
-#: src/Preferences.cpp:730
+#: src/Preferences.cpp:702
 msgid "Polish"
 msgstr "полски"
 
-#: src/Preferences.cpp:731
+#: src/Preferences.cpp:703
 msgid "Portuguese"
 msgstr "португалски"
 
-#: src/Preferences.cpp:732
+#: src/Preferences.cpp:704
 msgid "Portuguese (Brazilian)"
 msgstr "португалски (бразилски)"
 
-#: src/Preferences.cpp:733
+#: src/Preferences.cpp:705
 msgid "Romanian"
 msgstr "румънски"
 
-#: src/Preferences.cpp:734
+#: src/Preferences.cpp:706
 msgid "Russian"
 msgstr "Руски"
 
-#: src/Preferences.cpp:735
+#: src/Preferences.cpp:707
 msgid "Slovenian"
 msgstr "словенски"
 
-#: src/Preferences.cpp:736
+#: src/Preferences.cpp:708
 msgid "Spanish"
 msgstr "Spanish"
 
-#: src/Preferences.cpp:737
+#: src/Preferences.cpp:709
 msgid "Swedish"
 msgstr "шведски"
 
-#: src/Preferences.cpp:738
+#: src/Preferences.cpp:710
 msgid "Turkish"
 msgstr "Турски"
 
-#: src/Preferences.cpp:739
+#: src/Preferences.cpp:711
 msgid "Ukrainian"
 msgstr "украински"
 
-#: src/Preferences.cpp:842
+#: src/Preferences.cpp:814
 msgid "Change Language"
 msgstr "Смени езика"
 
-#: src/Preferences.cpp:906
+#: src/Preferences.cpp:878
 msgid "There are no translations installed for aMule"
 msgstr ""
 
-#: src/Preferences.cpp:907
+#: src/Preferences.cpp:879
 msgid "No languages available"
 msgstr ""
 
-#: src/Preferences.cpp:1038
+#: src/Preferences.cpp:1010
 msgid "no options available"
 msgstr ""
 
-#: src/Preferences.cpp:2226
+#: src/Preferences.cpp:2179
 msgid "Invalid category found, skipping"
 msgstr ""
 
-#: src/Preferences.cpp:2395
+#: src/Preferences.cpp:2348
 msgid "TCP port can't be higher than 65532 due to server UDP socket being TCP+3"
 msgstr ""
 
-#: src/Preferences.cpp:2396
+#: src/Preferences.cpp:2349
 #, c-format
 msgid "Default port will be used (%d)"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:300 src/Statistics.cpp:866
+#: src/PrefsUnifiedDlg.cpp:298 src/Statistics.cpp:866
 msgid "Connection"
 msgstr "Връзка"
 
-#: src/PrefsUnifiedDlg.cpp:301 src/SearchListCtrl.cpp:117
+#: src/PrefsUnifiedDlg.cpp:299 src/SearchListCtrl.cpp:117
 msgid "Directories"
 msgstr "Директории"
 
-#: src/PrefsUnifiedDlg.cpp:302 src/Statistics.cpp:917
+#: src/PrefsUnifiedDlg.cpp:300 src/Statistics.cpp:917
 msgid "Servers"
 msgstr "Сървъри"
 
-#: src/PrefsUnifiedDlg.cpp:303 src/ServerListCtrl.cpp:96
+#: src/PrefsUnifiedDlg.cpp:301 src/ServerListCtrl.cpp:96
 msgid "Files"
 msgstr "Файлове"
 
-#: src/PrefsUnifiedDlg.cpp:304
+#: src/PrefsUnifiedDlg.cpp:302
 msgid "Security"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:305
+#: src/PrefsUnifiedDlg.cpp:303
 msgid "Interface"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:312
+#: src/PrefsUnifiedDlg.cpp:310
 msgid "IP2Country"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:315
+#: src/PrefsUnifiedDlg.cpp:313
 msgid "Proxy"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:316
+#: src/PrefsUnifiedDlg.cpp:314
 msgid "Filters"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:317
+#: src/PrefsUnifiedDlg.cpp:315
 msgid "Remote Controls"
 msgstr "Дистанционни управления"
 
-#: src/PrefsUnifiedDlg.cpp:318
+#: src/PrefsUnifiedDlg.cpp:316
 msgid "Online Signature"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:319
+#: src/PrefsUnifiedDlg.cpp:317
 msgid "Advanced"
 msgstr "напреднал"
 
-#: src/PrefsUnifiedDlg.cpp:320
+#: src/PrefsUnifiedDlg.cpp:318
 msgid "Events"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:323
+#: src/PrefsUnifiedDlg.cpp:321
 msgid "Debugging"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:453
+#: src/PrefsUnifiedDlg.cpp:451
 msgid ""
 "The following variables will be substituted:\n"
 "    %PARTFILE - full path to the file\n"
 "    %PARTNAME - file name only"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:474
+#: src/PrefsUnifiedDlg.cpp:472
 msgid "Tray icon support requires libayatana-appindicator3 at compile time."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:490
+#: src/PrefsUnifiedDlg.cpp:488
 msgid "Not available on Wayland: the protocol does not report when a window is minimized, so this option cannot intercept the system minimize button. Workaround: launch aMule with `GDK_BACKEND=x11` to use XWayland instead."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:536
+#: src/PrefsUnifiedDlg.cpp:534
 msgid ""
 "Do not change these setting unless you know\n"
 "what you are doing, otherwise you can easily\n"
@@ -5659,255 +5627,241 @@ msgid ""
 "these settings."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:647
+#: src/PrefsUnifiedDlg.cpp:645
 #, c-format
 msgid "Failed to connect Cfg to widget with the ID %d and key %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:695
+#: src/PrefsUnifiedDlg.cpp:693
 #, c-format
 msgid "Failed to transfer data from Cfg to Widget with the ID %d and key %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:801
+#: src/PrefsUnifiedDlg.cpp:799
 msgid "The type of proxy you are connecting to"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1020
+#: src/PrefsUnifiedDlg.cpp:1003
 #, c-format
 msgid "Failed to transfer data from Widget to Cfg with the ID %d and key %s"
 msgstr ""
 
 #: src/PrefsUnifiedDlg.cpp:1103
-#, fuzzy
-msgid "No password set."
-msgstr "парола"
-
-#: src/PrefsUnifiedDlg.cpp:1132
-msgid "Guest access needs a password. Type one in the guest password field, or untick Enable guest access."
-msgstr ""
-
-#: src/PrefsUnifiedDlg.cpp:1144
 msgid ""
 "aMule must be restarted to enable these changes:\n"
 "\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1151
+#: src/PrefsUnifiedDlg.cpp:1110
 msgid "- TCP port changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1156
+#: src/PrefsUnifiedDlg.cpp:1115
 msgid "- UDP port changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1161
+#: src/PrefsUnifiedDlg.cpp:1120
 msgid "- Network interface binding changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1166
+#: src/PrefsUnifiedDlg.cpp:1125
 msgid "- External connect port changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1170
+#: src/PrefsUnifiedDlg.cpp:1129
 msgid "- External connect acceptance changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1174
+#: src/PrefsUnifiedDlg.cpp:1133
 msgid "- External connect interface changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1178
+#: src/PrefsUnifiedDlg.cpp:1137
 msgid "- Protocol obfuscation support changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1193
+#: src/PrefsUnifiedDlg.cpp:1151
 #, fuzzy
 msgid "- amuleapi settings changed.\n"
 msgstr "- Език променило.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1202
+#: src/PrefsUnifiedDlg.cpp:1160
 msgid ""
 "Your Auto-update server list is empty.\n"
 "'Auto-update server list at startup' will be disabled."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1213
+#: src/PrefsUnifiedDlg.cpp:1171
 msgid ""
 "You have enabled external connections but have not specified a password.\n"
 "External connections cannot be enabled unless a valid password is specified."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1246
-#, c-format
-msgid "The amuleapi password could not be saved: %s"
-msgstr ""
-
-#: src/PrefsUnifiedDlg.cpp:1276
+#: src/PrefsUnifiedDlg.cpp:1202
 msgid "- Language changed.\n"
 msgstr "- Език променило.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1281
+#: src/PrefsUnifiedDlg.cpp:1207
 msgid "- Temp folder changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1286
+#: src/PrefsUnifiedDlg.cpp:1212
 msgid "- ED2K network enabled.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1319
+#: src/PrefsUnifiedDlg.cpp:1245
 msgid "The shared-file exclusion pattern is not a valid regular expression. The filter has been left disabled."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1321 src/PrefsUnifiedDlg.cpp:1921
+#: src/PrefsUnifiedDlg.cpp:1247 src/PrefsUnifiedDlg.cpp:1841
 msgid "Invalid regular expression"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1398
+#: src/PrefsUnifiedDlg.cpp:1324
 msgid ""
 "Both eD2k and Kad network are disabled.\n"
 "You won't be able to connect until you enable at least one of them."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1403
+#: src/PrefsUnifiedDlg.cpp:1329
 msgid ""
 "Kad will not start if your UDP port is disabled.\n"
 "Enable UDP port or disable Kad."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1459
+#: src/PrefsUnifiedDlg.cpp:1385
 msgid ""
 "\n"
 "You MUST restart aMule now.\n"
 "If you do not restart now, don't complain if anything bad happens.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1524
+#: src/PrefsUnifiedDlg.cpp:1450
 msgid "Could not register aMule for autostart at login. The autostart store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1526
+#: src/PrefsUnifiedDlg.cpp:1452
 msgid "Could not remove the autostart-at-login entry."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1527
+#: src/PrefsUnifiedDlg.cpp:1453
 #, fuzzy
 msgid "Autostart"
 msgstr "Автоматично"
 
-#: src/PrefsUnifiedDlg.cpp:1542
+#: src/PrefsUnifiedDlg.cpp:1468
 msgid "Register file type"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1542
+#: src/PrefsUnifiedDlg.cpp:1468
 msgid "Register URL handler"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1550
+#: src/PrefsUnifiedDlg.cpp:1476
 #, c-format
 msgid "aMule only handles eD2k-compatible magnets. If you replace the current magnet handler (%s), BitTorrent magnet links will stop working - aMule cannot download BitTorrent content. Continue?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1555
+#: src/PrefsUnifiedDlg.cpp:1481
 #, c-format
 msgid "Another application currently opens .emulecollection files (%s). Replace it with aMule?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1560
+#: src/PrefsUnifiedDlg.cpp:1486
 #, c-format
 msgid "Another application is currently the default handler for these links (%s). Replace it with aMule?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1585
+#: src/PrefsUnifiedDlg.cpp:1511
 msgid "Could not register aMule for .emulecollection files. The registration store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1587
+#: src/PrefsUnifiedDlg.cpp:1513
 #, fuzzy
 msgid "Could not remove the file type registration."
 msgstr "Вие вече опитвате да свалите файла %s"
 
-#: src/PrefsUnifiedDlg.cpp:1589
+#: src/PrefsUnifiedDlg.cpp:1515
 msgid "Could not register aMule as the URL handler. The registration store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1591
+#: src/PrefsUnifiedDlg.cpp:1517
 msgid "Could not remove the URL handler registration."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1661 src/PrefsUnifiedDlg.cpp:1688
+#: src/PrefsUnifiedDlg.cpp:1587 src/PrefsUnifiedDlg.cpp:1614
 msgid "The web server and aMule API require external connections to be enabled."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1671
+#: src/PrefsUnifiedDlg.cpp:1597
 msgid "The aMule web server is deprecated. Consider running the aMule API instead."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1735
+#: src/PrefsUnifiedDlg.cpp:1655
 msgid ""
 "Your Auto-update servers list is in blank.\n"
 "Please fill in at least one URL to point to a valid server.met file.\n"
 "Click on the button \"List\" by this checkbox to enter an URL."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1876
+#: src/PrefsUnifiedDlg.cpp:1796
 msgid "Temporary files"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1881
+#: src/PrefsUnifiedDlg.cpp:1801
 msgid "Incoming files"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1886
+#: src/PrefsUnifiedDlg.cpp:1806
 msgid "Online Signatures"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1899
+#: src/PrefsUnifiedDlg.cpp:1819
 #, c-format
 msgid "Choose a folder for %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1923
+#: src/PrefsUnifiedDlg.cpp:1843
 #, fuzzy, c-format
 msgid "Would exclude %u of %u shared file"
 msgid_plural "Would exclude %u of %u shared files"
 msgstr[0] "Известни са %i споделени файлове"
 msgstr[1] "Известни са %i споделени файлове"
 
-#: src/PrefsUnifiedDlg.cpp:1940
+#: src/PrefsUnifiedDlg.cpp:1860
 msgid "Browse for videoplayer"
 msgstr "Търсене на видео плеър"
 
-#: src/PrefsUnifiedDlg.cpp:1944
+#: src/PrefsUnifiedDlg.cpp:1864
 msgid "Select browser"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1948
+#: src/PrefsUnifiedDlg.cpp:1868
 msgid "Select ffprobe binary"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1954
+#: src/PrefsUnifiedDlg.cpp:1874
 #, c-format
 msgid "Executable%s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1988
+#: src/PrefsUnifiedDlg.cpp:1908
 msgid "ffprobe not found on PATH or in the standard install locations. Install ffmpeg (which ships ffprobe) or use Browse to pick a binary manually."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2000
+#: src/PrefsUnifiedDlg.cpp:1920
 msgid "Reset the settings on this page to their default values?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2001
+#: src/PrefsUnifiedDlg.cpp:1921
 msgid "Reset to defaults"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2028
+#: src/PrefsUnifiedDlg.cpp:1948
 msgid "Edit server list"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2029
+#: src/PrefsUnifiedDlg.cpp:1949
 msgid ""
 "Add here URL's to download server.met files.\n"
 "Only one url on each line."
@@ -5915,178 +5869,174 @@ msgstr ""
 "Тук добавете линкове за сваляне на .met файлове.\n"
 "Само по един URL на ред."
 
-#: src/PrefsUnifiedDlg.cpp:2084
+#: src/PrefsUnifiedDlg.cpp:2004
 msgid "IP2Country update failed"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2229 src/PrefsUnifiedDlg.cpp:2260
+#: src/PrefsUnifiedDlg.cpp:2149 src/PrefsUnifiedDlg.cpp:2180
 msgid "Data by MaxMind GeoLite2"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2231 src/PrefsUnifiedDlg.cpp:2262
+#: src/PrefsUnifiedDlg.cpp:2151 src/PrefsUnifiedDlg.cpp:2182
 msgid "Custom source"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2233 src/PrefsUnifiedDlg.cpp:2264
+#: src/PrefsUnifiedDlg.cpp:2153 src/PrefsUnifiedDlg.cpp:2184
 msgid "Data by DB-IP.com"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2284
+#: src/PrefsUnifiedDlg.cpp:2204
 #, c-format
 msgid "Status: Loaded%s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2286
+#: src/PrefsUnifiedDlg.cpp:2206
 #, c-format
 msgid "Status: Loaded%s - %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2290
+#: src/PrefsUnifiedDlg.cpp:2210
 msgid "Status: Failed to load - click 'Update now' to refresh."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2292
+#: src/PrefsUnifiedDlg.cpp:2212
 msgid "Status: Not found - click 'Update now' to download."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2350 src/PrefsUnifiedDlg.cpp:2374
+#: src/PrefsUnifiedDlg.cpp:2270 src/PrefsUnifiedDlg.cpp:2294
 #, c-format
 msgid "Update delay: %d second"
 msgid_plural "Update delay: %d seconds"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/PrefsUnifiedDlg.cpp:2358
+#: src/PrefsUnifiedDlg.cpp:2278
 #, c-format
 msgid "Time for average graph: %d minute"
 msgid_plural "Time for average graph: %d minutes"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/PrefsUnifiedDlg.cpp:2367
+#: src/PrefsUnifiedDlg.cpp:2287
 #, c-format
 msgid "Connections Graph Scale: %d"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2382
+#: src/PrefsUnifiedDlg.cpp:2302
 #, c-format
 msgid "File Buffer Size: %d byte"
 msgid_plural "File Buffer Size: %d bytes"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/PrefsUnifiedDlg.cpp:2392
+#: src/PrefsUnifiedDlg.cpp:2312
 #, c-format
 msgid "Upload Queue Size: %d client"
 msgid_plural "Upload Queue Size: %d clients"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/PrefsUnifiedDlg.cpp:2402
+#: src/PrefsUnifiedDlg.cpp:2322
 #, c-format
 msgid "Server connection refresh interval: %d minute"
 msgid_plural "Server connection refresh interval: %d minutes"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/PrefsUnifiedDlg.cpp:2407
+#: src/PrefsUnifiedDlg.cpp:2327
 msgid "Server connection refresh interval: Disabled"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2451
+#: src/PrefsUnifiedDlg.cpp:2371
 #, fuzzy
 msgid "disabled"
 msgstr "деактивиране"
 
-#: src/PrefsUnifiedDlg.cpp:2477
+#: src/PrefsUnifiedDlg.cpp:2397
 #, c-format
 msgid "Execute command on '%s' event"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2484
+#: src/PrefsUnifiedDlg.cpp:2404
 msgid "Enable command execution on core"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2496
+#: src/PrefsUnifiedDlg.cpp:2416
 msgid "Core command:"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2512
+#: src/PrefsUnifiedDlg.cpp:2432
 msgid "Enable command execution on GUI"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2524
+#: src/PrefsUnifiedDlg.cpp:2444
 msgid "GUI command:"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2540
+#: src/PrefsUnifiedDlg.cpp:2460
 msgid "The following variables will be replaced:"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2708
+#: src/PrefsUnifiedDlg.cpp:2628
 msgid ""
 "The following folders look like system or sensitive locations:\n"
 "\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2713
+#: src/PrefsUnifiedDlg.cpp:2633
 msgid "Sharing them recursively will publish every file underneath on the eD2k/Kad networks. Do you really want to do this?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2716
+#: src/PrefsUnifiedDlg.cpp:2636
 msgid "Confirm shared folders"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2744
+#: src/PrefsUnifiedDlg.cpp:2664
 #, fuzzy
 msgid "Reloading shared files..."
 msgstr "Известни са %i споделени файлове"
 
-#: src/PrefsUnifiedDlg.cpp:2745
+#: src/PrefsUnifiedDlg.cpp:2665
 msgid "Scanning for subdirectories..."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2746
+#: src/PrefsUnifiedDlg.cpp:2666
 msgid "Updating shared folders"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2773
+#: src/PrefsUnifiedDlg.cpp:2693
 #, c-format
 msgid "Scanned %u directories..."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2823
+#: src/PrefsUnifiedDlg.cpp:2743
 #, c-format
 msgid "Reloading shared files: %u files scanned"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2873
+#: src/PrefsUnifiedDlg.cpp:2793
 #, fuzzy
 msgid "Shared folder"
 msgstr "Споделени файлове (%i)"
 
-#: src/SearchDlg.cpp:280
-msgid "Clear search history"
-msgstr ""
-
-#: src/SearchDlg.cpp:584
+#: src/SearchDlg.cpp:425
 msgid "It's impossible to search when both eD2k and Kademlia are disabled."
 msgstr ""
 
-#: src/SearchDlg.cpp:585 src/SearchListCtrl.cpp:858
+#: src/SearchDlg.cpp:426 src/SearchListCtrl.cpp:858
 #, fuzzy
 msgid "Search error"
 msgstr "Търсене"
 
-#: src/SearchDlg.cpp:929
+#: src/SearchDlg.cpp:768
 msgid "Min size must be smaller than max size. Max size ignored."
 msgstr ""
 
-#: src/SearchDlg.cpp:930 src/SearchDlg.cpp:1012
+#: src/SearchDlg.cpp:769 src/SearchDlg.cpp:851
 msgid "Search warning"
 msgstr ""
 
-#: src/SearchDlg.cpp:1092 src/SearchListCtrl.cpp:735
+#: src/SearchDlg.cpp:929 src/SearchListCtrl.cpp:735
 msgid "Main"
 msgstr ""
 

--- a/po/bg.po
+++ b/po/bg.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-28 08:06+0200\n"
+"POT-Creation-Date: 2026-07-28 10:19+0200\n"
 "PO-Revision-Date: 2026-07-27 11:32+0000\n"
 "Last-Translator: Sebastiano Pistore <SebastianoPistore.info@protonmail.ch>\n"
 "Language-Team: Bulgarian <dict@linux.zonebg.com>\n"
@@ -136,7 +136,7 @@ msgstr ""
 msgid "Not now"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:422 src/amuleDlg.cpp:600
+#: src/AppImageIntegration.cpp:422 src/amuleDlg.cpp:665
 msgid "Don't ask again"
 msgstr ""
 
@@ -209,7 +209,7 @@ msgid "Killing amuleweb instance with pid '%d' ... "
 msgstr ""
 
 #: src/amule.cpp:336 src/amule.cpp:349 src/ClientRef.cpp:180
-#: src/SearchDlg.cpp:880 src/ServerListCtrl.cpp:98
+#: src/SearchDlg.cpp:1041 src/ServerListCtrl.cpp:98
 msgid "Failed"
 msgstr "Грешка"
 
@@ -553,29 +553,67 @@ msgstr ""
 msgid "ERROR: %s"
 msgstr ""
 
-#: src/amuleDlg.cpp:236
+#: src/amuleDlg.cpp:250
 #, c-format
 msgid "This is aMule %s based on eMule."
 msgstr ""
 
-#: src/amuleDlg.cpp:237
+#: src/amuleDlg.cpp:251
 #, c-format
 msgid "Running on %s"
 msgstr ""
 
-#: src/amuleDlg.cpp:239
+#: src/amuleDlg.cpp:253
 msgid "Visit https://github.com/amule-org/amule/releases/latest to check if a new version is available."
 msgstr ""
 
-#: src/amuleDlg.cpp:268
+#: src/amuleDlg.cpp:282
 msgid "FATAL ERROR: Failed to create Timer"
 msgstr ""
 
-#: src/amuleDlg.cpp:592
+#: src/amuleDlg.cpp:361 src/amuleDlg.cpp:1787 src/amuleDlg.cpp:2033
+#: src/muuli_wdr.cpp:1492 src/muuli_wdr.cpp:3418
+msgid "Networks"
+msgstr ""
+
+#: src/amuleDlg.cpp:362 src/amuleDlg.cpp:1793 src/muuli_wdr.cpp:3419
+msgid "Searches"
+msgstr ""
+
+#: src/amuleDlg.cpp:363 src/amuleDlg.cpp:1799 src/DownloadListCtrl.cpp:740
+#: src/muuli_wdr.cpp:392 src/muuli_wdr.cpp:1585 src/muuli_wdr.cpp:3420
+#: src/Statistics.cpp:829
+msgid "Downloads"
+msgstr ""
+
+#: src/amuleDlg.cpp:364 src/amuleDlg.cpp:1805 src/muuli_wdr.cpp:3294
+msgid "Shared files"
+msgstr ""
+
+#: src/amuleDlg.cpp:365 src/amuleDlg.cpp:1811 src/muuli_wdr.cpp:2926
+#: src/muuli_wdr.cpp:3376 src/muuli_wdr.cpp:3423
+msgid "Messages"
+msgstr "Съобщения"
+
+#: src/amuleDlg.cpp:366 src/amuleDlg.cpp:1817 src/muuli_wdr.cpp:3424
+#: src/PrefsUnifiedDlg.cpp:312 src/Statistics.cpp:779 src/Statistics.cpp:1235
+msgid "Statistics"
+msgstr "Статистика"
+
+#: src/amuleDlg.cpp:368 src/amuleDlg.cpp:1824 src/muuli_wdr.cpp:3426
+#: src/PrefsUnifiedDlg.cpp:328 src/utils/wxCas/src/wxcasprefs.cpp:39
+msgid "Preferences"
+msgstr "Настройки"
+
+#: src/amuleDlg.cpp:371
+msgid "Navigate"
+msgstr ""
+
+#: src/amuleDlg.cpp:657
 msgid "New version available"
 msgstr ""
 
-#: src/amuleDlg.cpp:596
+#: src/amuleDlg.cpp:661
 #, c-format
 msgid ""
 "A new version of aMule (%s) is available.\n"
@@ -585,222 +623,189 @@ msgid ""
 "Would you like to open the download page?"
 msgstr ""
 
-#: src/amuleDlg.cpp:678
+#: src/amuleDlg.cpp:743
 msgid "aMule dialog destroyed"
 msgstr ""
 
-#: src/amuleDlg.cpp:701 src/DataToText.cpp:68 src/IPFilter.cpp:547
+#: src/amuleDlg.cpp:766 src/DataToText.cpp:68 src/IPFilter.cpp:547
 msgid "Connecting"
 msgstr "Свързва"
 
-#: src/amuleDlg.cpp:893
+#: src/amuleDlg.cpp:958
 msgid "eD2k: Connecting"
 msgstr ""
 
-#: src/amuleDlg.cpp:897
+#: src/amuleDlg.cpp:962
 msgid "eD2k: Disconnected"
 msgstr ""
 
-#: src/amuleDlg.cpp:903
+#: src/amuleDlg.cpp:968
 msgid "Kad: Firewalled"
 msgstr ""
 
-#: src/amuleDlg.cpp:907
+#: src/amuleDlg.cpp:972
 #, fuzzy
 msgid "Kad: Connected"
 msgstr "Връзкате е установена"
 
-#: src/amuleDlg.cpp:912
+#: src/amuleDlg.cpp:977
 #, fuzzy
 msgid "Kad: Connecting"
 msgstr "Свързва"
 
-#: src/amuleDlg.cpp:916
+#: src/amuleDlg.cpp:981
 msgid "Kad: Off"
 msgstr ""
 
-#: src/amuleDlg.cpp:964 src/DownloadListCtrl.cpp:505
+#: src/amuleDlg.cpp:1029 src/DownloadListCtrl.cpp:505
 #: src/DownloadListCtrl.cpp:749 src/FriendListCtrl.cpp:180
 #: src/muuli_wdr.cpp:731 src/muuli_wdr.cpp:782 src/muuli_wdr.cpp:846
-#: src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2224 src/muuli_wdr.cpp:2309
-#: src/muuli_wdr.cpp:3057 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
+#: src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2231 src/muuli_wdr.cpp:2316
+#: src/muuli_wdr.cpp:3064 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
 #: src/ServerListCtrl.cpp:606 src/TransferWnd.cpp:378
 #: src/utils/wxCas/src/wxcasprefs.cpp:235
 msgid "Cancel"
 msgstr "Отказ"
 
-#: src/amuleDlg.cpp:965
+#: src/amuleDlg.cpp:1030
 #, fuzzy
 msgid "Stop the current connection attempts"
 msgstr "Спира текущите опити за свързване"
 
-#: src/amuleDlg.cpp:970 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976
-#: src/muuli_wdr.cpp:2447
+#: src/amuleDlg.cpp:1035 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976
+#: src/muuli_wdr.cpp:2454
 msgid "Disconnect"
 msgstr "Разкачи"
 
-#: src/amuleDlg.cpp:971
+#: src/amuleDlg.cpp:1036
 #, fuzzy
 msgid "Disconnect from the currently connected networks"
 msgstr "Изключване от текущия сървър"
 
-#: src/amuleDlg.cpp:976 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979
-#: src/muuli_wdr.cpp:2602 src/muuli_wdr.cpp:3054 src/muuli_wdr.cpp:3409
+#: src/amuleDlg.cpp:1041 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979
+#: src/muuli_wdr.cpp:2609 src/muuli_wdr.cpp:3061 src/muuli_wdr.cpp:3416
 msgid "Connect"
 msgstr "Връзка"
 
-#: src/amuleDlg.cpp:977
+#: src/amuleDlg.cpp:1042
 msgid "Connect to the currently enabled networks"
 msgstr ""
 
-#: src/amuleDlg.cpp:1089
+#: src/amuleDlg.cpp:1154
 #, fuzzy, c-format
 msgid "Up: %.1f%s (%.1f) | Down: %.1f%s (%.1f)"
 msgstr "Кач.: %.1f(%.1f) | Свал.: %.1f(%.1f)"
 
-#: src/amuleDlg.cpp:1091 src/amuleDlg.cpp:1093 src/amuleDlg.cpp:1097
-#: src/amuleDlg.cpp:1099 src/amuleDlg.cpp:1110 src/amuleDlg.cpp:1112
+#: src/amuleDlg.cpp:1156 src/amuleDlg.cpp:1158 src/amuleDlg.cpp:1162
+#: src/amuleDlg.cpp:1164 src/amuleDlg.cpp:1175 src/amuleDlg.cpp:1177
 #: src/MuleTrayIcon.cpp:796 src/MuleTrayIcon.cpp:799
 msgid " MB/s"
 msgstr ""
 
-#: src/amuleDlg.cpp:1091 src/amuleDlg.cpp:1093 src/amuleDlg.cpp:1097
-#: src/amuleDlg.cpp:1099 src/amuleDlg.cpp:1110 src/amuleDlg.cpp:1112
+#: src/amuleDlg.cpp:1156 src/amuleDlg.cpp:1158 src/amuleDlg.cpp:1162
+#: src/amuleDlg.cpp:1164 src/amuleDlg.cpp:1175 src/amuleDlg.cpp:1177
 #: src/MuleTrayIcon.cpp:796 src/MuleTrayIcon.cpp:799
 #: src/utils/wxCas/src/wxcasframe.cpp:1041
 msgid " kB/s"
 msgstr " кБ/с"
 
-#: src/amuleDlg.cpp:1096
+#: src/amuleDlg.cpp:1161
 #, fuzzy, c-format
 msgid "Up: %.1f%s | Down: %.1f%s"
 msgstr "Кач.: %.1f | Свал.: %.1f"
 
-#: src/amuleDlg.cpp:1128
+#: src/amuleDlg.cpp:1193
 #, c-format
 msgid "aMule (%s | Connected)"
 msgstr ""
 
-#: src/amuleDlg.cpp:1130
+#: src/amuleDlg.cpp:1195
 #, c-format
 msgid "aMule (%s | Disconnected)"
 msgstr ""
 
-#: src/amuleDlg.cpp:1183
+#: src/amuleDlg.cpp:1248
 #, fuzzy, c-format
 msgid "Do you really want to exit %s?"
 msgstr "Наистина ли желаете да изключите aМуле?"
 
-#: src/amuleDlg.cpp:1185
+#: src/amuleDlg.cpp:1250
 msgid "Exit confirmation"
 msgstr "Потвърждение за изход"
 
-#: src/amuleDlg.cpp:1548
+#: src/amuleDlg.cpp:1613
 msgid "Launch Command: "
 msgstr ""
 
-#: src/amuleDlg.cpp:1567 src/muuli_wdr.cpp:1971 src/Preferences.cpp:951
+#: src/amuleDlg.cpp:1632 src/muuli_wdr.cpp:1978 src/Preferences.cpp:952
 msgid "- default -"
 msgstr "- по подразбиране -"
 
-#: src/amuleDlg.cpp:1595
+#: src/amuleDlg.cpp:1660
 #, c-format
 msgid "Skin directory '%s' does not exist"
 msgstr ""
 
-#: src/amuleDlg.cpp:1598
+#: src/amuleDlg.cpp:1663
 #, c-format
 msgid "WARNING: Unable to open skin file '%s' for read"
 msgstr ""
 
-#: src/amuleDlg.cpp:1722 src/amuleDlg.cpp:1968 src/muuli_wdr.cpp:1485
-#: src/muuli_wdr.cpp:3411
-msgid "Networks"
-msgstr ""
-
-#: src/amuleDlg.cpp:1726 src/muuli_wdr.cpp:3411
+#: src/amuleDlg.cpp:1791 src/muuli_wdr.cpp:3418
 msgid "Networks Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1728 src/muuli_wdr.cpp:3412
-msgid "Searches"
-msgstr ""
-
-#: src/amuleDlg.cpp:1732 src/muuli_wdr.cpp:3412
+#: src/amuleDlg.cpp:1797 src/muuli_wdr.cpp:3419
 msgid "Searches Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1734 src/DownloadListCtrl.cpp:740 src/muuli_wdr.cpp:392
-#: src/muuli_wdr.cpp:1578 src/muuli_wdr.cpp:3413 src/Statistics.cpp:829
-msgid "Downloads"
-msgstr ""
-
-#: src/amuleDlg.cpp:1738 src/muuli_wdr.cpp:3413
+#: src/amuleDlg.cpp:1803 src/muuli_wdr.cpp:3420
 #, fuzzy
 msgid "Downloads Window"
 msgstr "Изтегляне"
 
-#: src/amuleDlg.cpp:1740 src/muuli_wdr.cpp:3287
-msgid "Shared files"
-msgstr ""
-
-#: src/amuleDlg.cpp:1744 src/muuli_wdr.cpp:3415
+#: src/amuleDlg.cpp:1809 src/muuli_wdr.cpp:3422
 msgid "Shared Files Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1746 src/muuli_wdr.cpp:2919 src/muuli_wdr.cpp:3369
-#: src/muuli_wdr.cpp:3416
-msgid "Messages"
-msgstr "Съобщения"
-
-#: src/amuleDlg.cpp:1750 src/muuli_wdr.cpp:3416
+#: src/amuleDlg.cpp:1815 src/muuli_wdr.cpp:3423
 msgid "Messages Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1752 src/muuli_wdr.cpp:3417 src/PrefsUnifiedDlg.cpp:312
-#: src/Statistics.cpp:779 src/Statistics.cpp:1235
-msgid "Statistics"
-msgstr "Статистика"
-
-#: src/amuleDlg.cpp:1756 src/muuli_wdr.cpp:3417
+#: src/amuleDlg.cpp:1821 src/muuli_wdr.cpp:3424
 msgid "Statistics Graph Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1759 src/muuli_wdr.cpp:3419 src/PrefsUnifiedDlg.cpp:328
-#: src/utils/wxCas/src/wxcasprefs.cpp:39
-msgid "Preferences"
-msgstr "Настройки"
-
-#: src/amuleDlg.cpp:1763 src/muuli_wdr.cpp:3419
+#: src/amuleDlg.cpp:1828 src/muuli_wdr.cpp:3426
 msgid "Preferences Settings Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1766 src/muuli_wdr.cpp:3420
+#: src/amuleDlg.cpp:1831 src/muuli_wdr.cpp:3427
 msgid "Import"
 msgstr ""
 
-#: src/amuleDlg.cpp:1770 src/muuli_wdr.cpp:3420
+#: src/amuleDlg.cpp:1835 src/muuli_wdr.cpp:3427
 msgid "The partfile importer tool"
 msgstr ""
 
-#: src/amuleDlg.cpp:1773 src/muuli_wdr.cpp:3421
+#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3428
 #: src/utils/aLinkCreator/src/alcframe.cpp:262
 msgid "About"
 msgstr ""
 
-#: src/amuleDlg.cpp:1773 src/muuli_wdr.cpp:3421
+#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3428
 msgid "About/Help"
 msgstr ""
 
-#: src/amuleDlg.cpp:1971
+#: src/amuleDlg.cpp:2036
 msgid "eD2k network"
 msgstr ""
 
-#: src/amuleDlg.cpp:1974
+#: src/amuleDlg.cpp:2039
 msgid "Kad network"
 msgstr ""
 
-#: src/amuleDlg.cpp:1974
+#: src/amuleDlg.cpp:2039
 msgid "No network"
 msgstr "Няма мрежа"
 
@@ -1333,19 +1338,19 @@ msgstr "Автоматичен [Hi]"
 msgid "Very low"
 msgstr ""
 
-#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:743 src/muuli_wdr.cpp:2275
+#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:743 src/muuli_wdr.cpp:2282
 #: src/ServerListCtrl.cpp:263 src/ServerListCtrl.cpp:456
 #: src/SharedFilesCtrl.cpp:145
 msgid "Low"
 msgstr "Ниско"
 
-#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:744 src/muuli_wdr.cpp:2276
+#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:744 src/muuli_wdr.cpp:2283
 #: src/ServerListCtrl.cpp:266 src/ServerListCtrl.cpp:457
 #: src/SharedFilesCtrl.cpp:146
 msgid "Normal"
 msgstr "Нормален"
 
-#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:745 src/muuli_wdr.cpp:2277
+#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:745 src/muuli_wdr.cpp:2284
 #: src/ServerListCtrl.cpp:269 src/ServerListCtrl.cpp:458
 #: src/SharedFilesCtrl.cpp:147
 msgid "High"
@@ -1437,8 +1442,8 @@ msgstr ""
 msgid "Remote Server"
 msgstr ""
 
-#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3174
-#: src/SearchDlg.cpp:111 src/TextClient.cpp:911
+#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3181
+#: src/SearchDlg.cpp:119 src/TextClient.cpp:911
 msgid "Kad"
 msgstr ""
 
@@ -1508,7 +1513,7 @@ msgstr ""
 msgid "Size"
 msgstr "Размер"
 
-#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3241
+#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3248
 msgid "Transferred"
 msgstr "Пренесен"
 
@@ -1566,7 +1571,7 @@ msgid ""
 "\n"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:746 src/muuli_wdr.cpp:2278
+#: src/DownloadListCtrl.cpp:746 src/muuli_wdr.cpp:2285
 #: src/SharedFilesCtrl.cpp:150
 msgid "Auto"
 msgstr "Автоматично"
@@ -1604,7 +1609,7 @@ msgid "Extended Options"
 msgstr ""
 
 #: src/DownloadListCtrl.cpp:770 src/DownloadListCtrl.cpp:822
-#: src/muuli_wdr.cpp:1789
+#: src/muuli_wdr.cpp:1796
 msgid "Preview"
 msgstr "Преглед"
 
@@ -2287,19 +2292,19 @@ msgstr ""
 msgid "eD2k"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:349 src/muuli_wdr.cpp:1488
+#: src/FirstRunWizard.cpp:349 src/muuli_wdr.cpp:1495
 msgid "Kademlia"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:359 src/muuli_wdr.cpp:1416
+#: src/FirstRunWizard.cpp:359 src/muuli_wdr.cpp:1423
 msgid "Standard TCP Port "
 msgstr ""
 
-#: src/FirstRunWizard.cpp:365 src/muuli_wdr.cpp:1428
+#: src/FirstRunWizard.cpp:365 src/muuli_wdr.cpp:1435
 msgid "Extended UDP port (Kad / global search) "
 msgstr ""
 
-#: src/FirstRunWizard.cpp:377 src/muuli_wdr.cpp:1435
+#: src/FirstRunWizard.cpp:377 src/muuli_wdr.cpp:1442
 msgid "Enable UPnP for router port forwarding"
 msgstr ""
 
@@ -2325,7 +2330,7 @@ msgstr ""
 msgid "Your peer lists are already in place - nothing to download."
 msgstr "Вие вече опитвате да свалите файла %s"
 
-#: src/FirstRunWizard.cpp:434 src/muuli_wdr.cpp:1533
+#: src/FirstRunWizard.cpp:434 src/muuli_wdr.cpp:1540
 msgid "Auto-update server list at startup"
 msgstr ""
 
@@ -2371,23 +2376,23 @@ msgid ""
 "want downloads on a different (e.g. larger) disk."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:549 src/FirstRunWizard.cpp:611 src/muuli_wdr.cpp:1701
+#: src/FirstRunWizard.cpp:549 src/FirstRunWizard.cpp:611 src/muuli_wdr.cpp:1708
 msgid "Destination folder for downloads"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:553 src/FirstRunWizard.cpp:569 src/muuli_wdr.cpp:1342
-#: src/muuli_wdr.cpp:1359 src/muuli_wdr.cpp:1676 src/muuli_wdr.cpp:1707
-#: src/muuli_wdr.cpp:1719 src/muuli_wdr.cpp:2762
+#: src/FirstRunWizard.cpp:553 src/FirstRunWizard.cpp:569 src/muuli_wdr.cpp:1349
+#: src/muuli_wdr.cpp:1366 src/muuli_wdr.cpp:1683 src/muuli_wdr.cpp:1714
+#: src/muuli_wdr.cpp:1726 src/muuli_wdr.cpp:2769
 #: src/utils/aLinkCreator/src/alcframe.cpp:135
 #: src/utils/wxCas/src/wxcasprefs.cpp:52 src/utils/wxCas/src/wxcasprefs.cpp:118
 msgid "Browse"
 msgstr "Избери"
 
-#: src/FirstRunWizard.cpp:559 src/muuli_wdr.cpp:1712
+#: src/FirstRunWizard.cpp:559 src/muuli_wdr.cpp:1719
 msgid "(All files in this folder are shared with other peers)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:565 src/FirstRunWizard.cpp:624 src/muuli_wdr.cpp:1714
+#: src/FirstRunWizard.cpp:565 src/FirstRunWizard.cpp:624 src/muuli_wdr.cpp:1721
 msgid "Folder for temporary download files"
 msgstr ""
 
@@ -2418,7 +2423,7 @@ msgstr ""
 msgid "CRITICAL - no client on StartChatSession"
 msgstr ""
 
-#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2668 src/muuli_wdr.cpp:3345
+#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2675 src/muuli_wdr.cpp:3352
 msgid "Friends"
 msgstr "Приятели"
 
@@ -2799,7 +2804,7 @@ msgstr ""
 msgid "Uploaded"
 msgstr ""
 
-#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3225
+#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3232
 msgid "Requested"
 msgstr ""
 
@@ -2923,7 +2928,7 @@ msgid "WARNING: "
 msgstr ""
 
 #: src/MuleNotebook.cpp:179 src/muuli_wdr.cpp:817 src/muuli_wdr.cpp:1229
-#: src/muuli_wdr.cpp:3129 src/muuli_wdr.cpp:3385
+#: src/muuli_wdr.cpp:3136 src/muuli_wdr.cpp:3392
 msgid "Close"
 msgstr "Затвори"
 
@@ -2936,12 +2941,12 @@ msgstr ""
 msgid "Copy"
 msgstr "копие"
 
-#: src/MuleTextCtrl.cpp:88
+#: src/MuleTextCtrl.cpp:88 src/SearchDlg.cpp:261
 msgid "Paste"
 msgstr ""
 
 #: src/MuleTextCtrl.cpp:89 src/muuli_wdr.cpp:358 src/muuli_wdr.cpp:757
-#: src/muuli_wdr.cpp:2352 src/muuli_wdr.cpp:2371 src/muuli_wdr.cpp:2393
+#: src/muuli_wdr.cpp:2359 src/muuli_wdr.cpp:2378 src/muuli_wdr.cpp:2400
 #: src/utils/aLinkCreator/src/alcframe.cpp:142
 msgid "Clear"
 msgstr "Изчисти"
@@ -3036,8 +3041,8 @@ msgid "Exit"
 msgstr "Изход"
 
 #: src/MuleTrayIcon.cpp:579 src/MuleTrayIcon.cpp:945 src/MuleTrayIcon.cpp:965
-#: src/muuli_wdr.cpp:1391 src/muuli_wdr.cpp:1399 src/muuli_wdr.cpp:1406
-#: src/muuli_wdr.cpp:1835 src/muuli_wdr.cpp:1841 src/OtherFunctions.cpp:91
+#: src/muuli_wdr.cpp:1398 src/muuli_wdr.cpp:1406 src/muuli_wdr.cpp:1413
+#: src/muuli_wdr.cpp:1842 src/muuli_wdr.cpp:1848 src/OtherFunctions.cpp:91
 #: src/StatisticsDlg.cpp:93 src/StatisticsDlg.cpp:95
 msgid "kB/s"
 msgstr "кБ/с"
@@ -3206,7 +3211,7 @@ msgstr "Име:"
 msgid "Type"
 msgstr "Тип"
 
-#: src/muuli_wdr.cpp:215 src/SearchDlg.cpp:110 src/SearchListCtrl.cpp:853
+#: src/muuli_wdr.cpp:215 src/SearchDlg.cpp:118 src/SearchListCtrl.cpp:853
 msgid "Local"
 msgstr ""
 
@@ -3277,7 +3282,7 @@ msgstr "Байта"
 msgid "KB"
 msgstr "KB"
 
-#: src/muuli_wdr.cpp:274 src/muuli_wdr.cpp:293 src/muuli_wdr.cpp:1620
+#: src/muuli_wdr.cpp:274 src/muuli_wdr.cpp:293 src/muuli_wdr.cpp:1627
 #: src/OtherFunctions.cpp:64
 msgid "MB"
 msgstr "MB"
@@ -3294,7 +3299,7 @@ msgstr "Максимален размер"
 msgid "Availability"
 msgstr ""
 
-#: src/muuli_wdr.cpp:312 src/muuli_wdr.cpp:398 src/muuli_wdr.cpp:3290
+#: src/muuli_wdr.cpp:312 src/muuli_wdr.cpp:398 src/muuli_wdr.cpp:3297
 msgid "Filter:"
 msgstr ""
 
@@ -3326,7 +3331,7 @@ msgstr ""
 msgid "Stop"
 msgstr ""
 
-#: src/muuli_wdr.cpp:348 src/muuli_wdr.cpp:1385 src/SearchListCtrl.cpp:732
+#: src/muuli_wdr.cpp:348 src/muuli_wdr.cpp:1392 src/SearchListCtrl.cpp:732
 msgid "Download"
 msgstr "Изтегляне"
 
@@ -3358,8 +3363,8 @@ msgstr "Намерени източници: %i"
 #: src/muuli_wdr.cpp:1160 src/muuli_wdr.cpp:1167 src/muuli_wdr.cpp:1172
 #: src/muuli_wdr.cpp:1179 src/muuli_wdr.cpp:1184 src/muuli_wdr.cpp:1191
 #: src/muuli_wdr.cpp:1205 src/muuli_wdr.cpp:1212 src/muuli_wdr.cpp:1217
-#: src/muuli_wdr.cpp:1224 src/muuli_wdr.cpp:3227 src/muuli_wdr.cpp:3235
-#: src/muuli_wdr.cpp:3243
+#: src/muuli_wdr.cpp:1224 src/muuli_wdr.cpp:3234 src/muuli_wdr.cpp:3242
+#: src/muuli_wdr.cpp:3250
 msgid "N/A"
 msgstr "Няма"
 
@@ -3501,7 +3506,7 @@ msgstr ""
 msgid "Album :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:685 src/muuli_wdr.cpp:2247
+#: src/muuli_wdr.cpp:685 src/muuli_wdr.cpp:2254
 msgid "Title :"
 msgstr "Заглавие :"
 
@@ -3607,7 +3612,7 @@ msgstr ""
 msgid "Userhash :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:895 src/muuli_wdr.cpp:1741 src/muuli_wdr.cpp:2442
+#: src/muuli_wdr.cpp:895 src/muuli_wdr.cpp:1748 src/muuli_wdr.cpp:2449
 #: src/utils/aLinkCreator/src/alcframe.cpp:137
 msgid "Add"
 msgstr "Добавяне"
@@ -3616,15 +3621,15 @@ msgstr "Добавяне"
 msgid "Download-Speed"
 msgstr ""
 
-#: src/muuli_wdr.cpp:954 src/muuli_wdr.cpp:989 src/muuli_wdr.cpp:2546
+#: src/muuli_wdr.cpp:954 src/muuli_wdr.cpp:989 src/muuli_wdr.cpp:2553
 msgid "Current"
 msgstr "Текущ"
 
-#: src/muuli_wdr.cpp:962 src/muuli_wdr.cpp:997 src/muuli_wdr.cpp:2554
+#: src/muuli_wdr.cpp:962 src/muuli_wdr.cpp:997 src/muuli_wdr.cpp:2561
 msgid "Running average"
 msgstr ""
 
-#: src/muuli_wdr.cpp:970 src/muuli_wdr.cpp:1005 src/muuli_wdr.cpp:2562
+#: src/muuli_wdr.cpp:970 src/muuli_wdr.cpp:1005 src/muuli_wdr.cpp:2569
 msgid "Session average"
 msgstr ""
 
@@ -3636,7 +3641,7 @@ msgstr ""
 msgid "Connections"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1024 src/muuli_wdr.cpp:1860
+#: src/muuli_wdr.cpp:1024 src/muuli_wdr.cpp:1867
 msgid "Active downloads"
 msgstr ""
 
@@ -3644,7 +3649,7 @@ msgstr ""
 msgid "Active connections (1:1)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1040 src/muuli_wdr.cpp:1861
+#: src/muuli_wdr.cpp:1040 src/muuli_wdr.cpp:1868
 msgid "Active uploads"
 msgstr ""
 
@@ -3761,8 +3766,8 @@ msgstr ""
 msgid "Language: "
 msgstr "език: "
 
-#: src/muuli_wdr.cpp:1257 src/muuli_wdr.cpp:1323 src/muuli_wdr.cpp:1327
-#: src/muuli_wdr.cpp:1330
+#: src/muuli_wdr.cpp:1257 src/muuli_wdr.cpp:1330 src/muuli_wdr.cpp:1334
+#: src/muuli_wdr.cpp:1337
 msgid "The delay before showing tool-tips."
 msgstr ""
 
@@ -3838,926 +3843,934 @@ msgstr ""
 msgid "Enabling this will make aMule to show notifications when finished downloading."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1322
-msgid "Tooltip delay time: "
+#: src/muuli_wdr.cpp:1323
+msgid "Remember search history"
+msgstr ""
+
+#: src/muuli_wdr.cpp:1324
+msgid "Keeps a dropdown list of your past search terms in the Search tab's Name field. This remembers the queries you typed, not the results they returned."
 msgstr ""
 
 #: src/muuli_wdr.cpp:1329
+msgid "Tooltip delay time: "
+msgstr ""
+
+#: src/muuli_wdr.cpp:1336
 msgid "seconds"
 msgstr "секунди"
 
-#: src/muuli_wdr.cpp:1333
+#: src/muuli_wdr.cpp:1340
 msgid "Browser Selection"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1339
+#: src/muuli_wdr.cpp:1346
 msgid "Enter your browser name here. Leave this field empty to use the system default browser."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1346
+#: src/muuli_wdr.cpp:1353
 msgid "Open in new tab if possible"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1348
+#: src/muuli_wdr.cpp:1355
 msgid "Open the web page in a new tab instead of in a new window when possible"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1352
+#: src/muuli_wdr.cpp:1359
 msgid "Video Player"
 msgstr "Видео плеър"
 
-#: src/muuli_wdr.cpp:1379
+#: src/muuli_wdr.cpp:1386
 msgid "Bandwidth limits"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1393
+#: src/muuli_wdr.cpp:1400
 msgid "Upload"
 msgstr "Качване"
 
-#: src/muuli_wdr.cpp:1401
+#: src/muuli_wdr.cpp:1408
 msgid "Slot Allocation"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1410
+#: src/muuli_wdr.cpp:1417
 msgid "Ports"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1420
+#: src/muuli_wdr.cpp:1427
 msgid "This is the standard eD2k port and cannot be disabled."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1423
+#: src/muuli_wdr.cpp:1430
 msgid "UDP port for server requests (TCP+3):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1425
+#: src/muuli_wdr.cpp:1432
 msgid "4665"
 msgstr "4665"
 
-#: src/muuli_wdr.cpp:1432
+#: src/muuli_wdr.cpp:1439
 msgid "This UDP port is used for extended eD2k requests and Kad network"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1439
+#: src/muuli_wdr.cpp:1446
 msgid "UPnP TCP Port (Optional):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1449
+#: src/muuli_wdr.cpp:1456
 msgid "Bind local address to IP (empty for any):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1452
+#: src/muuli_wdr.cpp:1459
 msgid "Advanced users only: If you have multiple network interfaces, enter the address of the interface to which aMule should be bound."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1455 src/muuli_wdr.cpp:2054
+#: src/muuli_wdr.cpp:1462 src/muuli_wdr.cpp:2061
 msgid "Bind to network interface (empty for any):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1468
+#: src/muuli_wdr.cpp:1475
 msgid "Advanced users only: pin all of aMule's traffic to one network interface, chosen from the list or typed in by name (e.g. tun0, eth0, en0) or index. Unlike binding to an IP, this stops traffic leaking out via the default route - useful with a VPN. Requires no elevated privileges."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1474
+#: src/muuli_wdr.cpp:1481
 msgid "Max sources per downloading file:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1478
+#: src/muuli_wdr.cpp:1485
 msgid "Max simultaneous connections:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1491 src/muuli_wdr.cpp:3169
+#: src/muuli_wdr.cpp:1498 src/muuli_wdr.cpp:3176
 msgid "ED2K"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1498
+#: src/muuli_wdr.cpp:1505
 msgid "Autoconnect on startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1501
+#: src/muuli_wdr.cpp:1508
 msgid "Reconnect on loss"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1523
+#: src/muuli_wdr.cpp:1530
 msgid "Remove dead server after"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1524
+#: src/muuli_wdr.cpp:1531
 msgid "Static servers are never removed, even when unreachable."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1528
+#: src/muuli_wdr.cpp:1535
 msgid "retries"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1536
+#: src/muuli_wdr.cpp:1543
 msgid "List"
 msgstr "Списък"
 
-#: src/muuli_wdr.cpp:1539
+#: src/muuli_wdr.cpp:1546
 msgid "Update server list when connecting to a server"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1542
+#: src/muuli_wdr.cpp:1549
 msgid "Update server list when a client connects"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1545
+#: src/muuli_wdr.cpp:1552
 msgid "Use priority system"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1549
+#: src/muuli_wdr.cpp:1556
 msgid "Use smart LowID check on connect"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1553
+#: src/muuli_wdr.cpp:1560
 msgid "Safe connect"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1557
+#: src/muuli_wdr.cpp:1564
 msgid "Autoconnect to servers in static list only"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1560
+#: src/muuli_wdr.cpp:1567
 msgid "Set manually added servers to High Priority"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1581
+#: src/muuli_wdr.cpp:1588
 msgid "Add files to download in pause mode"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1583
+#: src/muuli_wdr.cpp:1590
 msgid "Add files to download with auto priority"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1586
+#: src/muuli_wdr.cpp:1593
 msgid "Try to download first and last chunks first"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1590
+#: src/muuli_wdr.cpp:1597
 msgid "Endgame mode: rotate to faster sources for the final blocks"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1593
+#: src/muuli_wdr.cpp:1600
 msgid "Start next paused file when a file completes"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1596
+#: src/muuli_wdr.cpp:1603
 msgid "From the same category"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1598
+#: src/muuli_wdr.cpp:1605
 msgid "In alphabetic order"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1600
+#: src/muuli_wdr.cpp:1607
 msgid "Preallocate disk space for new files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1601
+#: src/muuli_wdr.cpp:1608
 msgid "For new files preallocates disk space for the whole file, thus reduces fragmentation"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1606
+#: src/muuli_wdr.cpp:1613
 msgid "Create new files as sparse files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1607
+#: src/muuli_wdr.cpp:1614
 msgid "A sparse file reserves its full size on disk immediately without writing real data to it -- fast, but unsupported or slow on some filesystems, and free-space accounting stays optimistic while the download is in progress. Turn this off to grow the file only as data arrives."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1612
+#: src/muuli_wdr.cpp:1619
 msgid "Stop downloads when free disk space reaches "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1613
+#: src/muuli_wdr.cpp:1620
 msgid "Select this if you want aMule to check your disk space"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1617
+#: src/muuli_wdr.cpp:1624
 msgid "Enter here the min disk space desired."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1623
+#: src/muuli_wdr.cpp:1630
 msgid "Save 10 sources on rare files (< 20 sources)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1627 src/Statistics.cpp:790
+#: src/muuli_wdr.cpp:1634 src/Statistics.cpp:790
 msgid "Uploads"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1630
+#: src/muuli_wdr.cpp:1637
 msgid "Add new shared files with auto priority"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1636
+#: src/muuli_wdr.cpp:1643
 msgid "Intelligent Corruption Handling (I.C.H.)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1639
+#: src/muuli_wdr.cpp:1646
 msgid "Enable"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1642
+#: src/muuli_wdr.cpp:1649
 msgid "Advanced I.C.H. trusts every hash (not recommended)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1654 src/PrefsUnifiedDlg.cpp:1910
+#: src/muuli_wdr.cpp:1661 src/PrefsUnifiedDlg.cpp:1910
 msgid "Media metadata extraction"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1658
+#: src/muuli_wdr.cpp:1665
 msgid "Extract length / bitrate / codec from shared audio and video files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1660
+#: src/muuli_wdr.cpp:1667
 msgid "When enabled, aMule runs ffprobe on each shared media file to fill in the Length / Bitrate / Codec columns other clients see when they find the file in a search. Requires ffmpeg (the ffprobe binary) to be installed."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1667
+#: src/muuli_wdr.cpp:1674
 msgid "Path to ffprobe:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1672
+#: src/muuli_wdr.cpp:1679
 msgid "Full path to the ffprobe binary. Leave empty to have aMule auto-detect it on startup."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1680
+#: src/muuli_wdr.cpp:1687
 msgid "Detect"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1681
+#: src/muuli_wdr.cpp:1688
 msgid "Search the standard install locations for an ffprobe binary and fill the path field."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1705
+#: src/muuli_wdr.cpp:1712
 msgid ""
 "Completed downloads are stored here. All files in this folder are automatically shared with other peers.\n"
 "If this folder also holds files you don't want to share, point it at an aMule-only sub-folder."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1708
+#: src/muuli_wdr.cpp:1715
 msgid "Pick the folder where completed downloads will be stored. All files in that folder will be shared with other peers."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1722
+#: src/muuli_wdr.cpp:1729
 msgid "Shared folders"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1728
+#: src/muuli_wdr.cpp:1735
 msgid "(Folders shared by the core. Enter a path to add one.)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1736
+#: src/muuli_wdr.cpp:1743
 msgid "Absolute path of a folder on the core's machine, e.g. /home/user/shared"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1738 src/PrefsUnifiedDlg.cpp:2794
+#: src/muuli_wdr.cpp:1745 src/PrefsUnifiedDlg.cpp:2794
 msgid "Recursive"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1739
+#: src/muuli_wdr.cpp:1746
 msgid "Share every sub-folder underneath this one, including ones created later."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1743 src/utils/aLinkCreator/src/alcframe.cpp:141
+#: src/muuli_wdr.cpp:1750 src/utils/aLinkCreator/src/alcframe.cpp:141
 msgid "Remove"
 msgstr "Премахване"
 
-#: src/muuli_wdr.cpp:1747
+#: src/muuli_wdr.cpp:1754
 msgid "(Right click on folder icon for recursive share)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1754
+#: src/muuli_wdr.cpp:1761
 msgid "Share hidden files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1760
+#: src/muuli_wdr.cpp:1767
 msgid "Automatically rescan shared folders for changes"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1766
+#: src/muuli_wdr.cpp:1773
 msgid "Follow symbolic links in shared folders"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1772
+#: src/muuli_wdr.cpp:1779
 msgid "Exclude files matching:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1775
+#: src/muuli_wdr.cpp:1782
 msgid "Wildcard patterns separated by '|', e.g. .DS_Store|Thumbs.db|*.tmp. Files whose name matches are not shared. Matching is case-insensitive."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1779
+#: src/muuli_wdr.cpp:1786
 msgid "Patterns are regular expressions"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1780
+#: src/muuli_wdr.cpp:1787
 msgid "When set, the whole field is one regular expression ('|' is alternation). When unset, it is a list of '|'-separated wildcards."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1790
+#: src/muuli_wdr.cpp:1797
 msgid "Show how many shared files the current pattern would exclude."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1811
+#: src/muuli_wdr.cpp:1818
 msgid "Graphs"
 msgstr "Диаграми"
 
-#: src/muuli_wdr.cpp:1814 src/muuli_wdr.cpp:1876
+#: src/muuli_wdr.cpp:1821 src/muuli_wdr.cpp:1883
 msgid "Update delay : 5 secs"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1818
+#: src/muuli_wdr.cpp:1825
 msgid "Time for average graph: 100 mins"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1822
+#: src/muuli_wdr.cpp:1829
 msgid "Connections Graph Scale: 100 "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1829
+#: src/muuli_wdr.cpp:1836
 msgid "Download graph scale:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1837
+#: src/muuli_wdr.cpp:1844
 msgid "Upload graph scale:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1847
+#: src/muuli_wdr.cpp:1854
 #, fuzzy
 msgid "Colors: "
 msgstr "Цветове: "
 
-#: src/muuli_wdr.cpp:1851
+#: src/muuli_wdr.cpp:1858
 msgid "Background"
 msgstr "Фон"
 
-#: src/muuli_wdr.cpp:1852
+#: src/muuli_wdr.cpp:1859
 msgid "Grid"
 msgstr "Мрежа"
 
-#: src/muuli_wdr.cpp:1853
+#: src/muuli_wdr.cpp:1860
 msgid "Download current"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1854
+#: src/muuli_wdr.cpp:1861
 msgid "Download running average"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1855
+#: src/muuli_wdr.cpp:1862
 msgid "Download session average"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1856
+#: src/muuli_wdr.cpp:1863
 msgid "Upload current"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1857
+#: src/muuli_wdr.cpp:1864
 msgid "Upload running average"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1858
+#: src/muuli_wdr.cpp:1865
 msgid "Upload session average"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1859
+#: src/muuli_wdr.cpp:1866
 msgid "Active connections"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1862
+#: src/muuli_wdr.cpp:1869
 msgid "Systray Icon Speed Bar"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1863
+#: src/muuli_wdr.cpp:1870
 msgid "Kad-nodes current"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1864
+#: src/muuli_wdr.cpp:1871
 msgid "Kad-nodes running"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1865
+#: src/muuli_wdr.cpp:1872
 msgid "Kad-nodes session"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1869 src/muuli_wdr.cpp:2296
+#: src/muuli_wdr.cpp:1876 src/muuli_wdr.cpp:2303
 msgid "Select"
 msgstr "Избор"
 
-#: src/muuli_wdr.cpp:1873
+#: src/muuli_wdr.cpp:1880
 msgid "Tree"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1883
+#: src/muuli_wdr.cpp:1890
 msgid "Number of Client Versions shown (0=unlimited)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1908
+#: src/muuli_wdr.cpp:1915
 msgid "!!! WARNING !!!"
 msgstr "!!! ВНИМАНИЕ !!!"
 
-#: src/muuli_wdr.cpp:1923
+#: src/muuli_wdr.cpp:1930
 msgid "Max new connections / 5 secs"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1925
+#: src/muuli_wdr.cpp:1932
 msgid "Concurrent Kad source lookups"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1927
+#: src/muuli_wdr.cpp:1934
 msgid "Kad source re-search interval (minutes)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1929
+#: src/muuli_wdr.cpp:1936
 msgid "Source re-ask interval (minutes)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1933
+#: src/muuli_wdr.cpp:1940
 msgid "File Buffer Size: 240000 bytes"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1937
+#: src/muuli_wdr.cpp:1944
 msgid "Use MMAP: memory-mapped file access (lower memory use)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1938
+#: src/muuli_wdr.cpp:1945
 msgid "Maps part files into memory instead of buffering them on the heap, lowering the process memory footprint. May reduce download speed on some disks; best for memory-constrained or upload-heavy hosts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1940
+#: src/muuli_wdr.cpp:1947
 msgid "Upload Queue Size: 5000 clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1944
+#: src/muuli_wdr.cpp:1951
 msgid "Server connection refresh interval: Disable"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1948
+#: src/muuli_wdr.cpp:1955
 msgid "Disable computer's timed standby mode"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1967
+#: src/muuli_wdr.cpp:1974
 msgid "Skin to use: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1976
+#: src/muuli_wdr.cpp:1983
 msgid "Show \"Fast eD2k Links Handler\" in every window."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1979
+#: src/muuli_wdr.cpp:1986
 msgid "Show extended info on categories tabs"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1982
+#: src/muuli_wdr.cpp:1989
 msgid "Show application version on title"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1984
+#: src/muuli_wdr.cpp:1991
 msgid "Show transfer rates on title"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1986
+#: src/muuli_wdr.cpp:1993
 msgid "Before application name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1988
+#: src/muuli_wdr.cpp:1995
 msgid "After application name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1991
+#: src/muuli_wdr.cpp:1998
 msgid "Show overhead bandwidth"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1995
+#: src/muuli_wdr.cpp:2002
 msgid "Vertical toolbar orientation"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1997
+#: src/muuli_wdr.cpp:2004
 msgid "Live column sorting (auto-reorder rows as their values change)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2004
+#: src/muuli_wdr.cpp:2011
 msgid "Download Queue Files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2007
+#: src/muuli_wdr.cpp:2014
 msgid "Show progress percentage"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2013
+#: src/muuli_wdr.cpp:2020
 msgid "Show progress bar"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2016
+#: src/muuli_wdr.cpp:2023
 msgid "Flat"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2020
+#: src/muuli_wdr.cpp:2027
 msgid "Round"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2038
+#: src/muuli_wdr.cpp:2045
 msgid "External Connection Parameters"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2041
+#: src/muuli_wdr.cpp:2048
 msgid "Accept external connections"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2048 src/muuli_wdr.cpp:2107
+#: src/muuli_wdr.cpp:2055 src/muuli_wdr.cpp:2114
 msgid "IP of the listening interface:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2051
+#: src/muuli_wdr.cpp:2058
 msgid "Enter here a valid ip in the a.b.c.d format for the listening EC interface. An empty field or 0.0.0.0 will mean any interface."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2072 src/muuli_wdr.cpp:2156
+#: src/muuli_wdr.cpp:2079 src/muuli_wdr.cpp:2163
 msgid "TCP port:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2078
+#: src/muuli_wdr.cpp:2085
 msgid "Enable UPnP port forwarding on the EC port"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2082 src/muuli_wdr.cpp:3041
+#: src/muuli_wdr.cpp:2089 src/muuli_wdr.cpp:3048
 #: src/utils/wxCas/src/wxcasprefs.cpp:167
 msgid "Password"
 msgstr "парола"
 
-#: src/muuli_wdr.cpp:2088
+#: src/muuli_wdr.cpp:2095
 msgid "aMule API server parameters"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2091
+#: src/muuli_wdr.cpp:2098
 msgid "Run amuleapi (REST API) on startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2096
+#: src/muuli_wdr.cpp:2103
 msgid "HTTP port:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2110
+#: src/muuli_wdr.cpp:2117
 msgid "The interface amuleapi's HTTP server listens on. 127.0.0.1 (default) accepts only local connections; use 0.0.0.0 or a specific IP to expose it to other hosts (set an admin password below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2113
+#: src/muuli_wdr.cpp:2120
 #, fuzzy
 msgid "Admin password"
 msgstr "парола"
 
-#: src/muuli_wdr.cpp:2118 src/muuli_wdr.cpp:2149
+#: src/muuli_wdr.cpp:2125 src/muuli_wdr.cpp:2156
 msgid "Low rights password"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2126
+#: src/muuli_wdr.cpp:2133
 msgid "Web server parameters"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2129
+#: src/muuli_wdr.cpp:2136
 msgid "Run webserver on startup (deprecated)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2135
+#: src/muuli_wdr.cpp:2142
 msgid "Web template"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2140
+#: src/muuli_wdr.cpp:2147
 msgid "Full rights password"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2144
+#: src/muuli_wdr.cpp:2151
 msgid "Enable Low rights User"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2163
+#: src/muuli_wdr.cpp:2170
 msgid "Enable UPnP port forwarding of the web server port"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2168
+#: src/muuli_wdr.cpp:2175
 msgid "Web server UPnP TCP port (Optional)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2176
+#: src/muuli_wdr.cpp:2183
 msgid "Page Refresh Time (in secs)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2183
+#: src/muuli_wdr.cpp:2190
 msgid "Enable Gzip compression"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2217
+#: src/muuli_wdr.cpp:2224
 msgid "Reset page to defaults"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2218
+#: src/muuli_wdr.cpp:2225
 msgid "Reset the settings on the current page to their default values."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2220 src/muuli_wdr.cpp:2306 src/ServerWnd.cpp:274
+#: src/muuli_wdr.cpp:2227 src/muuli_wdr.cpp:2313 src/ServerWnd.cpp:274
 #: src/ServerWnd.cpp:282
 msgid "OK"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2222
+#: src/muuli_wdr.cpp:2229
 msgid "Click here to apply any changes made to the preferences."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2225
+#: src/muuli_wdr.cpp:2232
 msgid "Reset any changes made to the preferences."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2254
+#: src/muuli_wdr.cpp:2261
 msgid "Comment :"
 msgstr "Коментар:"
 
-#: src/muuli_wdr.cpp:2261
+#: src/muuli_wdr.cpp:2268
 msgid "Incoming Dir :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2270
+#: src/muuli_wdr.cpp:2277
 msgid "Change priority for new assigned files :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2274
+#: src/muuli_wdr.cpp:2281
 msgid "Don't change"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2286
+#: src/muuli_wdr.cpp:2293
 msgid "Select color for this Category (currently selected) :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2353 src/muuli_wdr.cpp:2372 src/muuli_wdr.cpp:2394
+#: src/muuli_wdr.cpp:2360 src/muuli_wdr.cpp:2379 src/muuli_wdr.cpp:2401
 msgid "Click this button to reset the log."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2413
+#: src/muuli_wdr.cpp:2420
 msgid "Click on this button to update the servers list from URL ..."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2417
+#: src/muuli_wdr.cpp:2424
 msgid "Server list"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2421
+#: src/muuli_wdr.cpp:2428
 msgid "Enter the url to a server.met file here and press the button to the left to update the list of known servers."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2426
+#: src/muuli_wdr.cpp:2433
 msgid "Add server manually: Name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2429
+#: src/muuli_wdr.cpp:2436
 msgid "Enter the name of the new server here"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2431 src/ServerWnd.cpp:206
+#: src/muuli_wdr.cpp:2438 src/ServerWnd.cpp:206
 msgid "IP:Port"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2434
+#: src/muuli_wdr.cpp:2441
 msgid "Enter the IP of the server here, using the x.x.x.x format."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2440
+#: src/muuli_wdr.cpp:2447
 msgid "Enter the port of the server here."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2443
+#: src/muuli_wdr.cpp:2450
 msgid "Add manually a server (fill fields to the left before) ..."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2472
+#: src/muuli_wdr.cpp:2479
 msgid "aMule Log"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2480
+#: src/muuli_wdr.cpp:2487
 msgid "Server Info"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2484
+#: src/muuli_wdr.cpp:2491
 msgid "ED2K Info"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2488
+#: src/muuli_wdr.cpp:2495
 msgid "Kad Info"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2516
+#: src/muuli_wdr.cpp:2523
 msgid "Click on this button to update the nodes list from URL ..."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2520
+#: src/muuli_wdr.cpp:2527
 msgid "Nodes (0)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2524
+#: src/muuli_wdr.cpp:2531
 msgid "Enter the url to a nodes.dat file here and press the button to the left to update the list of known nodes."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2527
+#: src/muuli_wdr.cpp:2534
 msgid "Nodes stats"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2569
+#: src/muuli_wdr.cpp:2576
 msgid "Bootstrap"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2572
+#: src/muuli_wdr.cpp:2579
 msgid "New node"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2577
+#: src/muuli_wdr.cpp:2584
 msgid "IP:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2597
+#: src/muuli_wdr.cpp:2604
 msgid "Port:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2610
+#: src/muuli_wdr.cpp:2617
 msgid "Bootstrap from known clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2612
+#: src/muuli_wdr.cpp:2619
 msgid "Disconnect Kad"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2646
+#: src/muuli_wdr.cpp:2653
 msgid "Use Secure User Identification"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2648
+#: src/muuli_wdr.cpp:2655
 msgid "It is recommended to enable this option. You will not receive credits if SUI is not enabled."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2650
+#: src/muuli_wdr.cpp:2657
 msgid "Protocol Obfuscation"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2653
+#: src/muuli_wdr.cpp:2660
 msgid "Support Protocol Obfuscation"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2655
+#: src/muuli_wdr.cpp:2662
 msgid "This option enabled Protocol Obfuscation, and makes aMule accept obfuscated connections from other clients."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2657
+#: src/muuli_wdr.cpp:2664
 msgid "Use obfuscation for outgoing connections"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2659
+#: src/muuli_wdr.cpp:2666
 msgid "This option makes aMule use Protocol Obfuscation when connecting other clients/servers."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2661
+#: src/muuli_wdr.cpp:2668
 msgid "Accept only obfuscated connections"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2662
+#: src/muuli_wdr.cpp:2669
 msgid "This option makes aMule only accept obfuscated connections. You will have less sources, but all your traffic will be obfuscated"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2667
+#: src/muuli_wdr.cpp:2674
 msgid "Everybody"
 msgstr "Всеки"
 
-#: src/muuli_wdr.cpp:2669
+#: src/muuli_wdr.cpp:2676
 msgid "No one"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2671
+#: src/muuli_wdr.cpp:2678
 msgid "Who can see my shared files:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2672
+#: src/muuli_wdr.cpp:2679
 msgid "Select who can request to view a list of your shared files."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2674
+#: src/muuli_wdr.cpp:2681
 msgid "IP-Filtering"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2681
+#: src/muuli_wdr.cpp:2688
 msgid "Filter clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2683
+#: src/muuli_wdr.cpp:2690
 msgid "Enable filtering of the client IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2685
+#: src/muuli_wdr.cpp:2692
 msgid "Filter servers"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2687
+#: src/muuli_wdr.cpp:2694
 msgid "Enable filtering of the server IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2691
+#: src/muuli_wdr.cpp:2698
 msgid "Reload List"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2692
+#: src/muuli_wdr.cpp:2699
 msgid "Reload the list of IPs to filter from the file ~/.aMule/ipfilter.dat"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2698
+#: src/muuli_wdr.cpp:2705
 msgid "URL:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2702 src/muuli_wdr.cpp:2895
+#: src/muuli_wdr.cpp:2709 src/muuli_wdr.cpp:2902
 msgid "Update now"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2705
+#: src/muuli_wdr.cpp:2712
 msgid "Auto-update ipfilter at startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2709
+#: src/muuli_wdr.cpp:2716
 msgid "Filtering Level:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2715
+#: src/muuli_wdr.cpp:2722
 msgid "Always filter LAN IPs"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2718
+#: src/muuli_wdr.cpp:2725
 msgid "Paranoid handling of non-matching IPs"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2720
+#: src/muuli_wdr.cpp:2727
 msgid "Rejects a packet when its source IP differs from the IP the client claims (an anti-spoofing check). Disable only if it causes connection problems."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2722
+#: src/muuli_wdr.cpp:2729
 msgid "Use system-wide ipfilter.dat if available"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2723
+#: src/muuli_wdr.cpp:2730
 msgid "If there's no local ipfilter.dat found, allow usage of a system-wide ipfilter file."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2740
+#: src/muuli_wdr.cpp:2747
 msgid "Enable Online-Signature"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2742
+#: src/muuli_wdr.cpp:2749
 msgid "Enables the writing of the OS file, which can be used by external apps to create signatures and the like."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2746
+#: src/muuli_wdr.cpp:2753
 msgid "Update Frequency (Secs):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2749
+#: src/muuli_wdr.cpp:2756
 msgid "Change the frequency (in seconds) of Online Signature updates."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2757
+#: src/muuli_wdr.cpp:2764
 msgid "Save online signature file in: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:2763
+#: src/muuli_wdr.cpp:2770
 msgid "Click here to select the directory containing the the Online Signature files."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2796
+#: src/muuli_wdr.cpp:2803
 msgid "Show country flags for clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2797
+#: src/muuli_wdr.cpp:2804
 msgid "Render the country flag column in the transfers, queue and search views. Requires a valid MMDB GeoIP database (see below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2802
+#: src/muuli_wdr.cpp:2809
 msgid "Database"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2818
+#: src/muuli_wdr.cpp:2825
 #, fuzzy
 msgid "Source:"
 msgstr "Източници"
 
-#: src/muuli_wdr.cpp:2821
+#: src/muuli_wdr.cpp:2828
 msgid "DB-IP (free, no account)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2822
+#: src/muuli_wdr.cpp:2829
 msgid "MaxMind GeoLite2 (free, account required)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2823
+#: src/muuli_wdr.cpp:2830
 msgid "Custom URL"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2826
+#: src/muuli_wdr.cpp:2833
 msgid "Choose which provider supplies the GeoIP MMDB database. DB-IP is the default - no account required. MaxMind requires a free account + license key. Use Custom URL to point at any other MMDB host (e.g. a local mirror)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2843
+#: src/muuli_wdr.cpp:2850
 msgid ""
 "No configuration required.\n"
 "\n"
@@ -4765,11 +4778,11 @@ msgid ""
 "License: Creative Commons BY 4.0 - https://creativecommons.org/licenses/by/4.0/"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2856
+#: src/muuli_wdr.cpp:2863
 msgid "License key:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2862
+#: src/muuli_wdr.cpp:2869
 msgid ""
 "Sign up for a free MaxMind account, then generate a License Key:\n"
 "https://www.maxmind.com/en/geolite2/signup\n"
@@ -4779,229 +4792,229 @@ msgid ""
 "Requires attribution and account registration; refresh at least every 30 days."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2877
+#: src/muuli_wdr.cpp:2884
 #, fuzzy
 msgid "Download URL:"
 msgstr "Изтегляне"
 
-#: src/muuli_wdr.cpp:2883
+#: src/muuli_wdr.cpp:2890
 msgid ""
 "Must point to an .mmdb file or a .gz / .tar.gz containing one.\n"
 "URL may include credentials (https://user:pass@host/...).\n"
 "License and attribution terms are set by the upstream URL - you are responsible."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2896
+#: src/muuli_wdr.cpp:2903
 msgid "Download the GeoIP database from the selected source."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2898
+#: src/muuli_wdr.cpp:2905
 msgid "Auto-update on startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2899
+#: src/muuli_wdr.cpp:2906
 msgid "Re-download the GeoIP database from the selected source every time aMule starts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2922
+#: src/muuli_wdr.cpp:2929
 msgid "Filter incoming messages (except current chat):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2924
+#: src/muuli_wdr.cpp:2931
 msgid "Filter all messages"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2926
+#: src/muuli_wdr.cpp:2933
 msgid "Filter messages from people not on your friend list"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2928
+#: src/muuli_wdr.cpp:2935
 msgid "Filter messages from unknown clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2930
+#: src/muuli_wdr.cpp:2937
 msgid "Filter messages containing (use ',' as separator):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2933 src/muuli_wdr.cpp:2944
+#: src/muuli_wdr.cpp:2940 src/muuli_wdr.cpp:2951
 msgid "add here the words amule should filter and block messages including it"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2935
+#: src/muuli_wdr.cpp:2942
 msgid "Show received messages in the log"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2938
+#: src/muuli_wdr.cpp:2945
 msgid "Comments"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2941
+#: src/muuli_wdr.cpp:2948
 msgid "Filter comments containing (use ',' as separator):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2966
+#: src/muuli_wdr.cpp:2973
 msgid "Enable Proxy"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2967
+#: src/muuli_wdr.cpp:2974
 msgid "Enable/disable proxy support"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2970
+#: src/muuli_wdr.cpp:2977
 msgid "Proxy type:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2981
+#: src/muuli_wdr.cpp:2988
 msgid "Proxy host:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2984
+#: src/muuli_wdr.cpp:2991
 msgid "The proxy host name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2986
+#: src/muuli_wdr.cpp:2993
 msgid "Proxy port:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2989
+#: src/muuli_wdr.cpp:2996
 msgid "The proxy port"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2991
+#: src/muuli_wdr.cpp:2998
 msgid "Enable authentication"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2992
+#: src/muuli_wdr.cpp:2999
 msgid "Enable/disable username/password authentication"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2995
+#: src/muuli_wdr.cpp:3002
 msgid "Username: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:2998
+#: src/muuli_wdr.cpp:3005
 msgid "The username to use to connect to the proxy"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3000
+#: src/muuli_wdr.cpp:3007
 msgid "Password:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3003
+#: src/muuli_wdr.cpp:3010
 msgid "The password to use to connect to the proxy"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3022
+#: src/muuli_wdr.cpp:3029
 msgid "Connect to:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3031
+#: src/muuli_wdr.cpp:3038
 msgid "Login to remote amule"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3036
+#: src/muuli_wdr.cpp:3043
 msgid "User name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3047
+#: src/muuli_wdr.cpp:3054
 msgid "Remember those settings"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3050
+#: src/muuli_wdr.cpp:3057
 msgid "Force ZLIB compression"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3074
+#: src/muuli_wdr.cpp:3081
 msgid "Enable Verbose Debug-Logging."
 msgstr ""
 
-#: src/muuli_wdr.cpp:3076
+#: src/muuli_wdr.cpp:3083
 msgid "Only to Logfile"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3078
+#: src/muuli_wdr.cpp:3085
 msgid "Message Categories:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3102 src/PartFileConvertDlg.cpp:160
+#: src/muuli_wdr.cpp:3109 src/PartFileConvertDlg.cpp:160
 msgid "Waiting..."
 msgstr "Изчакване"
 
-#: src/muuli_wdr.cpp:3122
+#: src/muuli_wdr.cpp:3129
 msgid "Add imports"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3125
+#: src/muuli_wdr.cpp:3132
 msgid "Retry selected"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3127
+#: src/muuli_wdr.cpp:3134
 msgid "Remove selected"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3190
+#: src/muuli_wdr.cpp:3197
 msgid "Event Types"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3209
+#: src/muuli_wdr.cpp:3216
 msgid "Statistics and queued clients for selected file(s) : Session / All time"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3233
+#: src/muuli_wdr.cpp:3240
 #, fuzzy
 msgid "Active Uploads"
 msgstr "Активни качвания: %i"
 
-#: src/muuli_wdr.cpp:3247
+#: src/muuli_wdr.cpp:3254
 #, fuzzy
 msgid "Percent of total files"
 msgstr "Общо файлове"
 
-#: src/muuli_wdr.cpp:3299
+#: src/muuli_wdr.cpp:3306
 #, fuzzy
 msgid "Show Clients for"
 msgstr "Клиенти"
 
-#: src/muuli_wdr.cpp:3301
+#: src/muuli_wdr.cpp:3308
 msgid "All files"
 msgstr "Всички файлове"
 
-#: src/muuli_wdr.cpp:3304
+#: src/muuli_wdr.cpp:3311
 #, fuzzy
 msgid "Selected files"
 msgstr "Избор на филтър"
 
-#: src/muuli_wdr.cpp:3307
+#: src/muuli_wdr.cpp:3314
 #, fuzzy
 msgid "Active uploads only"
 msgstr "Активни качвания: %i"
 
-#: src/muuli_wdr.cpp:3314
+#: src/muuli_wdr.cpp:3321
 #, fuzzy
 msgid "Reload:"
 msgstr "Качване"
 
-#: src/muuli_wdr.cpp:3318
+#: src/muuli_wdr.cpp:3325
 msgid "Reload your shared files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3381
+#: src/muuli_wdr.cpp:3388
 msgid "Send"
 msgstr "Изпраща"
 
-#: src/muuli_wdr.cpp:3382
+#: src/muuli_wdr.cpp:3389
 msgid "Sends the specified message."
 msgstr ""
 
-#: src/muuli_wdr.cpp:3386
+#: src/muuli_wdr.cpp:3393
 msgid "Close this chat-session."
 msgstr ""
 
-#: src/muuli_wdr.cpp:3409
+#: src/muuli_wdr.cpp:3416
 msgid "Connect to any server and/or Kad"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3415 src/SharedFilesCtrl.cpp:142 src/Statistics.cpp:941
+#: src/muuli_wdr.cpp:3422 src/SharedFilesCtrl.cpp:142 src/Statistics.cpp:941
 msgid "Shared Files"
 msgstr ""
 
@@ -5361,187 +5374,187 @@ msgstr ""
 msgid "ERROR: Failed to open partfile '%s'"
 msgstr ""
 
-#: src/Preferences.cpp:673
+#: src/Preferences.cpp:674
 msgid "System default"
 msgstr ""
 
-#: src/Preferences.cpp:674
+#: src/Preferences.cpp:675
 msgid "Albanian"
 msgstr "албанец"
 
-#: src/Preferences.cpp:675
+#: src/Preferences.cpp:676
 msgid "Arabic"
 msgstr "арабски"
 
-#: src/Preferences.cpp:676
+#: src/Preferences.cpp:677
 msgid "Asturian"
 msgstr "Астурия"
 
-#: src/Preferences.cpp:677
+#: src/Preferences.cpp:678
 msgid "Basque"
 msgstr "баска"
 
-#: src/Preferences.cpp:678
+#: src/Preferences.cpp:679
 msgid "Bulgarian"
 msgstr "български"
 
-#: src/Preferences.cpp:679
+#: src/Preferences.cpp:680
 msgid "Catalan"
 msgstr "Каталунски"
 
-#: src/Preferences.cpp:680
+#: src/Preferences.cpp:681
 msgid "Chinese (Simplified)"
 msgstr "Китайски (опростен)"
 
-#: src/Preferences.cpp:681
+#: src/Preferences.cpp:682
 msgid "Chinese (Traditional)"
 msgstr "Китайски (традиционен)"
 
-#: src/Preferences.cpp:682
+#: src/Preferences.cpp:683
 msgid "Croatian"
 msgstr "хърватски"
 
-#: src/Preferences.cpp:683
+#: src/Preferences.cpp:684
 msgid "Czech"
 msgstr "чешки"
 
-#: src/Preferences.cpp:684
+#: src/Preferences.cpp:685
 msgid "Danish"
 msgstr "датски"
 
-#: src/Preferences.cpp:685
+#: src/Preferences.cpp:686
 msgid "Dutch"
 msgstr "холандски"
 
-#: src/Preferences.cpp:686
+#: src/Preferences.cpp:687
 msgid "English (U.K.)"
 msgstr ""
 
-#: src/Preferences.cpp:687
+#: src/Preferences.cpp:688
 msgid "English (U.S.)"
 msgstr ""
 
-#: src/Preferences.cpp:688
+#: src/Preferences.cpp:689
 msgid "Estonian"
 msgstr "естонски"
 
-#: src/Preferences.cpp:689
+#: src/Preferences.cpp:690
 msgid "Finnish"
 msgstr "фински"
 
-#: src/Preferences.cpp:690
+#: src/Preferences.cpp:691
 msgid "French"
 msgstr "Френски"
 
-#: src/Preferences.cpp:691
+#: src/Preferences.cpp:692
 msgid "Galician"
 msgstr "галисийски"
 
-#: src/Preferences.cpp:692
+#: src/Preferences.cpp:693
 msgid "German"
 msgstr "Немски"
 
-#: src/Preferences.cpp:693
+#: src/Preferences.cpp:694
 msgid "Greek"
 msgstr "Гръцки"
 
-#: src/Preferences.cpp:694
+#: src/Preferences.cpp:695
 msgid "Hebrew"
 msgstr "иврит"
 
-#: src/Preferences.cpp:695
+#: src/Preferences.cpp:696
 msgid "Hungarian"
 msgstr "унгарски"
 
-#: src/Preferences.cpp:696
+#: src/Preferences.cpp:697
 msgid "Italian"
 msgstr "Италиански"
 
-#: src/Preferences.cpp:697
+#: src/Preferences.cpp:698
 msgid "Japanese"
 msgstr "японски"
 
-#: src/Preferences.cpp:698
+#: src/Preferences.cpp:699
 msgid "Korean"
 msgstr "корейски"
 
-#: src/Preferences.cpp:699
+#: src/Preferences.cpp:700
 msgid "Latvian"
 msgstr ""
 
-#: src/Preferences.cpp:700
+#: src/Preferences.cpp:701
 msgid "Lithuanian"
 msgstr "литовски"
 
-#: src/Preferences.cpp:701
+#: src/Preferences.cpp:702
 msgid "Norwegian (Nynorsk)"
 msgstr "норвежки (Съвременен)"
 
-#: src/Preferences.cpp:702
+#: src/Preferences.cpp:703
 msgid "Polish"
 msgstr "полски"
 
-#: src/Preferences.cpp:703
+#: src/Preferences.cpp:704
 msgid "Portuguese"
 msgstr "португалски"
 
-#: src/Preferences.cpp:704
+#: src/Preferences.cpp:705
 msgid "Portuguese (Brazilian)"
 msgstr "португалски (бразилски)"
 
-#: src/Preferences.cpp:705
+#: src/Preferences.cpp:706
 msgid "Romanian"
 msgstr "румънски"
 
-#: src/Preferences.cpp:706
+#: src/Preferences.cpp:707
 msgid "Russian"
 msgstr "Руски"
 
-#: src/Preferences.cpp:707
+#: src/Preferences.cpp:708
 msgid "Slovenian"
 msgstr "словенски"
 
-#: src/Preferences.cpp:708
+#: src/Preferences.cpp:709
 msgid "Spanish"
 msgstr "Spanish"
 
-#: src/Preferences.cpp:709
+#: src/Preferences.cpp:710
 msgid "Swedish"
 msgstr "шведски"
 
-#: src/Preferences.cpp:710
+#: src/Preferences.cpp:711
 msgid "Turkish"
 msgstr "Турски"
 
-#: src/Preferences.cpp:711
+#: src/Preferences.cpp:712
 msgid "Ukrainian"
 msgstr "украински"
 
-#: src/Preferences.cpp:814
+#: src/Preferences.cpp:815
 msgid "Change Language"
 msgstr "Смени езика"
 
-#: src/Preferences.cpp:878
+#: src/Preferences.cpp:879
 msgid "There are no translations installed for aMule"
 msgstr ""
 
-#: src/Preferences.cpp:879
+#: src/Preferences.cpp:880
 msgid "No languages available"
 msgstr ""
 
-#: src/Preferences.cpp:1010
+#: src/Preferences.cpp:1011
 msgid "no options available"
 msgstr ""
 
-#: src/Preferences.cpp:2179
+#: src/Preferences.cpp:2182
 msgid "Invalid category found, skipping"
 msgstr ""
 
-#: src/Preferences.cpp:2348
+#: src/Preferences.cpp:2351
 msgid "TCP port can't be higher than 65532 due to server UDP socket being TCP+3"
 msgstr ""
 
-#: src/Preferences.cpp:2349
+#: src/Preferences.cpp:2352
 #, c-format
 msgid "Default port will be used (%d)"
 msgstr ""
@@ -6019,24 +6032,28 @@ msgstr ""
 msgid "Shared folder"
 msgstr "Споделени файлове (%i)"
 
-#: src/SearchDlg.cpp:425
+#: src/SearchDlg.cpp:280
+msgid "Clear search history"
+msgstr ""
+
+#: src/SearchDlg.cpp:584
 msgid "It's impossible to search when both eD2k and Kademlia are disabled."
 msgstr ""
 
-#: src/SearchDlg.cpp:426 src/SearchListCtrl.cpp:858
+#: src/SearchDlg.cpp:585 src/SearchListCtrl.cpp:858
 #, fuzzy
 msgid "Search error"
 msgstr "Търсене"
 
-#: src/SearchDlg.cpp:768
+#: src/SearchDlg.cpp:929
 msgid "Min size must be smaller than max size. Max size ignored."
 msgstr ""
 
-#: src/SearchDlg.cpp:769 src/SearchDlg.cpp:851
+#: src/SearchDlg.cpp:930 src/SearchDlg.cpp:1012
 msgid "Search warning"
 msgstr ""
 
-#: src/SearchDlg.cpp:929 src/SearchListCtrl.cpp:735
+#: src/SearchDlg.cpp:1092 src/SearchListCtrl.cpp:735
 msgid "Main"
 msgstr ""
 

--- a/po/bg.po
+++ b/po/bg.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-28 10:19+0200\n"
+"POT-Creation-Date: 2026-07-28 12:17+0200\n"
 "PO-Revision-Date: 2026-07-27 11:32+0000\n"
 "Last-Translator: Sebastiano Pistore <SebastianoPistore.info@protonmail.ch>\n"
 "Language-Team: Bulgarian <dict@linux.zonebg.com>\n"
@@ -194,154 +194,154 @@ msgstr "Грешка при запис на файла с кредити"
 msgid "WARNING: You can't add yourself as a source for an eD2k link while having a lowid."
 msgstr ""
 
-#: src/amule.cpp:300
+#: src/amule.cpp:301
 msgid "Now, exiting main app..."
 msgstr ""
 
-#: src/amule.cpp:330
+#: src/amule.cpp:331
 #, c-format
 msgid "Terminating amuleweb instance with pid '%d' ... "
 msgstr ""
 
-#: src/amule.cpp:334
+#: src/amule.cpp:335
 #, c-format
 msgid "Killing amuleweb instance with pid '%d' ... "
 msgstr ""
 
-#: src/amule.cpp:336 src/amule.cpp:349 src/ClientRef.cpp:180
+#: src/amule.cpp:337 src/amule.cpp:350 src/ClientRef.cpp:180
 #: src/SearchDlg.cpp:1041 src/ServerListCtrl.cpp:98
 msgid "Failed"
 msgstr "Грешка"
 
-#: src/amule.cpp:343
+#: src/amule.cpp:344
 #, c-format
 msgid "Terminating amuleapi instance with pid '%d' ... "
 msgstr ""
 
-#: src/amule.cpp:347
+#: src/amule.cpp:348
 #, c-format
 msgid "Killing amuleapi instance with pid '%d' ... "
 msgstr ""
 
-#: src/amule.cpp:355
+#: src/amule.cpp:356
 msgid "aMule OnExit: Terminating core."
 msgstr ""
 
-#: src/amule.cpp:466
+#: src/amule.cpp:467
 msgid "aMule shutdown completed."
 msgstr ""
 
-#: src/amule.cpp:470
+#: src/amule.cpp:471
 msgid "Memory debug results for aMule exit:"
 msgstr ""
 
-#: src/amule.cpp:651
+#: src/amule.cpp:652
 #, c-format
 msgid "Binding aMule's peer-to-peer traffic to interface: %s (HTTP updates use the default route)"
 msgstr ""
 
-#: src/amule.cpp:655
+#: src/amule.cpp:656
 #, c-format
 msgid "Binding all network traffic to interface: %s"
 msgstr ""
 
-#: src/amule.cpp:659
+#: src/amule.cpp:660
 #, c-format
 msgid "WARNING: configured network interface '%s' was not found - traffic is NOT bound to it and may leave via the default route. Check the interface name in Preferences."
 msgstr ""
 
-#: src/amule.cpp:665
+#: src/amule.cpp:666
 #, c-format
 msgid "WARNING: binding to network interface '%s' requires elevated privileges and was NOT applied - traffic may leave via the default route. Grant the capability (e.g. 'sudo setcap cap_net_raw+ep' on the aMule binary) or run with sufficient privileges."
 msgstr ""
 
-#: src/amule.cpp:673
+#: src/amule.cpp:674
 #, c-format
 msgid "WARNING: could not bind to network interface '%s' - traffic may leave via the default route."
 msgstr ""
 
-#: src/amule.cpp:732
+#: src/amule.cpp:733
 msgid "Your locale has been changed to System Default due to a configuration change. Sorry."
 msgstr ""
 
-#: src/amule.cpp:734 src/amule.cpp:1581 src/CatDialog.cpp:128
+#: src/amule.cpp:735 src/amule.cpp:1589 src/CatDialog.cpp:128
 #: src/CatDialog.cpp:136 src/CatDialog.cpp:149 src/ServerList.cpp:366
 #: src/ServerListCtrl.cpp:152
 msgid "Info"
 msgstr ""
 
-#: src/amule.cpp:741
+#: src/amule.cpp:742
 #, fuzzy
 msgid ""
 "\n"
 "EC configuration"
 msgstr "Потвърждение за изход"
 
-#: src/amule.cpp:744
+#: src/amule.cpp:745
 msgid "Password set and external connections enabled."
 msgstr ""
 
-#: src/amule.cpp:754 src/KadDlg.cpp:176 src/KadDlg.cpp:185
-#: src/PrefsUnifiedDlg.cpp:1387 src/SharedFilesCtrl.cpp:476
+#: src/amule.cpp:755 src/KadDlg.cpp:176 src/KadDlg.cpp:185
+#: src/PrefsUnifiedDlg.cpp:1461 src/SharedFilesCtrl.cpp:476
 msgid "WARNING"
 msgstr ""
 
-#: src/amule.cpp:991
+#: src/amule.cpp:992
 msgid "Network bootstrap"
 msgstr ""
 
-#: src/amule.cpp:996
+#: src/amule.cpp:997
 msgid ""
 "aMule has detected missing network bootstrap files.\n"
 "Select which ones to download:"
 msgstr ""
 
-#: src/amule.cpp:1005 src/FirstRunWizard.cpp:411
+#: src/amule.cpp:1006 src/FirstRunWizard.cpp:411
 #, fuzzy
 msgid "eD2k server list (server.met)"
 msgstr "%i сървъра бяха намерени в server.met"
 
-#: src/amule.cpp:1012 src/FirstRunWizard.cpp:416
+#: src/amule.cpp:1013 src/FirstRunWizard.cpp:416
 msgid "Kad bootstrap nodes (nodes.dat)"
 msgstr ""
 
-#: src/amule.cpp:1102
+#: src/amule.cpp:1103
 #, c-format
 msgid "web server running on pid %d"
 msgstr ""
 
-#: src/amule.cpp:1115
+#: src/amule.cpp:1116
 msgid "You requested to run web server on startup, but the amuleweb binary cannot be run. Please install the package containing aMule web server, or build aMule from source with -DBUILD_WEBSERVER=YES and install it."
 msgstr ""
 
-#: src/amule.cpp:1120 src/amule.cpp:1177 src/amule.cpp:1291 src/amule.cpp:1593
+#: src/amule.cpp:1121 src/amule.cpp:1185 src/amule.cpp:1299 src/amule.cpp:1601
 #: src/amule-remote-gui.cpp:603 src/amule-remote-gui.cpp:671
 #: src/amule-remote-gui.cpp:709 src/amule-remote-gui.cpp:1282
 #: src/amule-remote-gui.cpp:1345 src/amule-remote-gui.cpp:1372
-#: src/DownloadQueue.cpp:1481
+#: src/DownloadQueue.cpp:1481 src/PrefsUnifiedDlg.cpp:1247
 msgid "ERROR"
 msgstr ""
 
-#: src/amule.cpp:1166
+#: src/amule.cpp:1174
 #, c-format
 msgid "amuleapi running on pid %d"
 msgstr ""
 
-#: src/amule.cpp:1172
+#: src/amule.cpp:1180
 msgid "You requested to run amuleapi on startup, but the amuleapi binary cannot be run. Please install the package containing aMule's REST API server, or build aMule from source with -DBUILD_AMULEAPI=YES and install it."
 msgstr ""
 
-#: src/amule.cpp:1259
+#: src/amule.cpp:1267
 #, c-format
 msgid "Could not bind ports to the specified address: %s"
 msgstr ""
 
-#: src/amule.cpp:1283
+#: src/amule.cpp:1291
 #, c-format
 msgid "Port %u is not available. You will be LOWID\n"
 msgstr ""
 
-#: src/amule.cpp:1288
+#: src/amule.cpp:1296
 #, c-format
 msgid ""
 "Port %u is not available!\n"
@@ -351,184 +351,184 @@ msgid ""
 "Check your network to make sure the port is open for output and input."
 msgstr ""
 
-#: src/amule.cpp:1385
+#: src/amule.cpp:1393
 msgid "Failed to create OnlineSig File"
 msgstr ""
 
-#: src/amule.cpp:1393
+#: src/amule.cpp:1401
 msgid "Failed to create aMule OnlineSig File"
 msgstr ""
 
-#: src/amule.cpp:1556
+#: src/amule.cpp:1564
 msgid "The selected locale seems not to be installed on your box. (Note: I'll try to set it anyway)"
 msgstr ""
 
-#: src/amule.cpp:1566
+#: src/amule.cpp:1574
 #, c-format
 msgid "This is the first time you run aMule %s"
 msgstr ""
 
-#: src/amule.cpp:1569
+#: src/amule.cpp:1577
 msgid "This version is a testing version, updated daily, and\n"
 msgstr ""
 
-#: src/amule.cpp:1570
+#: src/amule.cpp:1578
 msgid "we give no warranty it won't break anything, burn your house,\n"
 msgstr ""
 
-#: src/amule.cpp:1571
+#: src/amule.cpp:1579
 msgid "or kill your dog. But it *should* be safe to use anyway.\n"
 msgstr ""
 
-#: src/amule.cpp:1576
+#: src/amule.cpp:1584
 msgid "More information, support and new releases can found at our homepage,\n"
 msgstr ""
 
-#: src/amule.cpp:1577
+#: src/amule.cpp:1585
 msgid "at https://amule-org.github.io, or in our IRC channel #aMule at irc.libera.chat.\n"
 msgstr ""
 
-#: src/amule.cpp:1579
+#: src/amule.cpp:1587
 msgid "Feel free to report any bugs to https://github.com/amule-org/amule/issues"
 msgstr ""
 
-#: src/amule.cpp:1591
+#: src/amule.cpp:1599
 msgid ""
 "The folder for Online Signature files you specified is INVALID!\n"
 " OnlineSignature will be DISABLED until you fix it on preferences."
 msgstr ""
 
-#: src/amule.cpp:1654
+#: src/amule.cpp:1662
 msgid "Server hostname notified"
 msgstr ""
 
-#: src/amule.cpp:2031
+#: src/amule.cpp:2039
 #, c-format
 msgid "Disk space preallocation for file '%s' failed: %s"
 msgstr ""
 
-#: src/amule.cpp:2160
+#: src/amule.cpp:2168
 msgid "ERROR: can't open logfile"
 msgstr ""
 
-#: src/amule.cpp:2164
+#: src/amule.cpp:2172
 msgid "WARNING: logfile is empty. Something is wrong."
 msgstr ""
 
-#: src/amule.cpp:2181
+#: src/amule.cpp:2189
 msgid "Log has been reset"
 msgstr ""
 
-#: src/amule.cpp:2205
+#: src/amule.cpp:2213
 #, c-format
 msgid "ServerMessage: %s"
 msgstr ""
 
-#: src/amule.cpp:2248 src/IP2Country.cpp:220 src/IPFilter.cpp:514
+#: src/amule.cpp:2256 src/IP2Country.cpp:220 src/IPFilter.cpp:514
 #: src/ServerList.cpp:875
 #, c-format
 msgid "Skipped download of %s, because requested file is not newer."
 msgstr ""
 
-#: src/amule.cpp:2251
+#: src/amule.cpp:2259
 msgid "Failed to download the nodes list."
 msgstr ""
 
-#: src/amule.cpp:2314
+#: src/amule.cpp:2322
 msgid "Failed to open the downloaded version check file"
 msgstr ""
 
-#: src/amule.cpp:2317 src/amule.cpp:2336
+#: src/amule.cpp:2325 src/amule.cpp:2344
 msgid "Corrupted version check file"
 msgstr ""
 
-#: src/amule.cpp:2359
+#: src/amule.cpp:2367
 msgid "You are using an outdated version of aMule!"
 msgstr ""
 
-#: src/amule.cpp:2361
+#: src/amule.cpp:2369
 #, c-format
 msgid "Your aMule version is %i.%i.%i and the latest version is %li.%li.%li"
 msgstr ""
 
-#: src/amule.cpp:2365
+#: src/amule.cpp:2373
 msgid "The latest version can always be found at https://github.com/amule-org/amule/releases/latest"
 msgstr ""
 
-#: src/amule.cpp:2368
+#: src/amule.cpp:2376
 #, c-format
 msgid "WARNING: Your aMuled version is outdated: %i.%i.%i < %li.%li.%li"
 msgstr ""
 
-#: src/amule.cpp:2374
+#: src/amule.cpp:2382
 msgid "Your copy of aMule is up to date."
 msgstr ""
 
-#: src/amule.cpp:2381
+#: src/amule.cpp:2389
 msgid "Failed to download the version check file"
 msgstr ""
 
-#: src/amule.cpp:2550 src/amule-remote-gui.cpp:1133
+#: src/amule.cpp:2558 src/amule-remote-gui.cpp:1133
 #, c-format
 msgid "Users: %s | Files: %s"
 msgstr ""
 
-#: src/amule.cpp:2551 src/amule-remote-gui.cpp:1134
+#: src/amule.cpp:2559 src/amule-remote-gui.cpp:1134
 #, c-format
 msgid "Users: E: %s K: %s | Files: E: %s K: %s"
 msgstr ""
 
-#: src/amule.cpp:2565 src/amule-remote-gui.cpp:1147
+#: src/amule.cpp:2573 src/amule-remote-gui.cpp:1147
 msgid "No networks selected"
 msgstr ""
 
-#: src/amule.cpp:2633 src/TextClient.cpp:903
+#: src/amule.cpp:2641 src/TextClient.cpp:903
 msgid "with LowID"
 msgstr ""
 
-#: src/amule.cpp:2633 src/TextClient.cpp:904
+#: src/amule.cpp:2641 src/TextClient.cpp:904
 msgid "with HighID"
 msgstr ""
 
-#: src/amule.cpp:2635
+#: src/amule.cpp:2643
 #, c-format
 msgid "Connected to %s %s"
 msgstr ""
 
-#: src/amule.cpp:2640
+#: src/amule.cpp:2648
 #, c-format
 msgid "Connecting to %s"
 msgstr ""
 
-#: src/amule.cpp:2642
+#: src/amule.cpp:2650
 msgid "Disconnected from eD2k"
 msgstr ""
 
-#: src/amule.cpp:2651
+#: src/amule.cpp:2659
 msgid "Kad started."
 msgstr ""
 
-#: src/amule.cpp:2653
+#: src/amule.cpp:2661
 msgid "Kad stopped."
 msgstr ""
 
-#: src/amule.cpp:2661
+#: src/amule.cpp:2669
 msgid "Connected to Kad (ok)"
 msgstr ""
 
-#: src/amule.cpp:2663
+#: src/amule.cpp:2671
 msgid "Connected to Kad (firewalled)"
 msgstr ""
 
-#: src/amule.cpp:2667
+#: src/amule.cpp:2675
 msgid "Disconnected from Kad"
 msgstr ""
 
-#: src/amule.cpp:2699
+#: src/amule.cpp:2707
 msgid "Kad network cannot be used if UDP port is disabled on preferences, not starting."
 msgstr ""
 
-#: src/amule.cpp:2703
+#: src/amule.cpp:2711
 msgid "Kad network disabled on preferences, not connecting."
 msgstr ""
 
@@ -572,36 +572,36 @@ msgid "FATAL ERROR: Failed to create Timer"
 msgstr ""
 
 #: src/amuleDlg.cpp:361 src/amuleDlg.cpp:1787 src/amuleDlg.cpp:2033
-#: src/muuli_wdr.cpp:1492 src/muuli_wdr.cpp:3418
+#: src/muuli_wdr.cpp:1492 src/muuli_wdr.cpp:3449
 msgid "Networks"
 msgstr ""
 
-#: src/amuleDlg.cpp:362 src/amuleDlg.cpp:1793 src/muuli_wdr.cpp:3419
+#: src/amuleDlg.cpp:362 src/amuleDlg.cpp:1793 src/muuli_wdr.cpp:3450
 msgid "Searches"
 msgstr ""
 
 #: src/amuleDlg.cpp:363 src/amuleDlg.cpp:1799 src/DownloadListCtrl.cpp:740
-#: src/muuli_wdr.cpp:392 src/muuli_wdr.cpp:1585 src/muuli_wdr.cpp:3420
+#: src/muuli_wdr.cpp:392 src/muuli_wdr.cpp:1585 src/muuli_wdr.cpp:3451
 #: src/Statistics.cpp:829
 msgid "Downloads"
 msgstr ""
 
-#: src/amuleDlg.cpp:364 src/amuleDlg.cpp:1805 src/muuli_wdr.cpp:3294
+#: src/amuleDlg.cpp:364 src/amuleDlg.cpp:1805 src/muuli_wdr.cpp:3325
 msgid "Shared files"
 msgstr ""
 
-#: src/amuleDlg.cpp:365 src/amuleDlg.cpp:1811 src/muuli_wdr.cpp:2926
-#: src/muuli_wdr.cpp:3376 src/muuli_wdr.cpp:3423
+#: src/amuleDlg.cpp:365 src/amuleDlg.cpp:1811 src/muuli_wdr.cpp:2957
+#: src/muuli_wdr.cpp:3407 src/muuli_wdr.cpp:3454
 msgid "Messages"
 msgstr "Съобщения"
 
-#: src/amuleDlg.cpp:366 src/amuleDlg.cpp:1817 src/muuli_wdr.cpp:3424
-#: src/PrefsUnifiedDlg.cpp:312 src/Statistics.cpp:779 src/Statistics.cpp:1235
+#: src/amuleDlg.cpp:366 src/amuleDlg.cpp:1817 src/muuli_wdr.cpp:3455
+#: src/PrefsUnifiedDlg.cpp:314 src/Statistics.cpp:779 src/Statistics.cpp:1235
 msgid "Statistics"
 msgstr "Статистика"
 
-#: src/amuleDlg.cpp:368 src/amuleDlg.cpp:1824 src/muuli_wdr.cpp:3426
-#: src/PrefsUnifiedDlg.cpp:328 src/utils/wxCas/src/wxcasprefs.cpp:39
+#: src/amuleDlg.cpp:368 src/amuleDlg.cpp:1824 src/muuli_wdr.cpp:3457
+#: src/PrefsUnifiedDlg.cpp:330 src/utils/wxCas/src/wxcasprefs.cpp:39
 msgid "Preferences"
 msgstr "Настройки"
 
@@ -660,8 +660,8 @@ msgstr ""
 #: src/amuleDlg.cpp:1029 src/DownloadListCtrl.cpp:505
 #: src/DownloadListCtrl.cpp:749 src/FriendListCtrl.cpp:180
 #: src/muuli_wdr.cpp:731 src/muuli_wdr.cpp:782 src/muuli_wdr.cpp:846
-#: src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2231 src/muuli_wdr.cpp:2316
-#: src/muuli_wdr.cpp:3064 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
+#: src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2262 src/muuli_wdr.cpp:2347
+#: src/muuli_wdr.cpp:3095 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
 #: src/ServerListCtrl.cpp:606 src/TransferWnd.cpp:378
 #: src/utils/wxCas/src/wxcasprefs.cpp:235
 msgid "Cancel"
@@ -673,7 +673,7 @@ msgid "Stop the current connection attempts"
 msgstr "Спира текущите опити за свързване"
 
 #: src/amuleDlg.cpp:1035 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976
-#: src/muuli_wdr.cpp:2454
+#: src/muuli_wdr.cpp:2485
 msgid "Disconnect"
 msgstr "Разкачи"
 
@@ -683,7 +683,7 @@ msgid "Disconnect from the currently connected networks"
 msgstr "Изключване от текущия сървър"
 
 #: src/amuleDlg.cpp:1041 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979
-#: src/muuli_wdr.cpp:2609 src/muuli_wdr.cpp:3061 src/muuli_wdr.cpp:3416
+#: src/muuli_wdr.cpp:2640 src/muuli_wdr.cpp:3092 src/muuli_wdr.cpp:3447
 msgid "Connect"
 msgstr "Връзка"
 
@@ -737,7 +737,7 @@ msgstr "Потвърждение за изход"
 msgid "Launch Command: "
 msgstr ""
 
-#: src/amuleDlg.cpp:1632 src/muuli_wdr.cpp:1978 src/Preferences.cpp:952
+#: src/amuleDlg.cpp:1632 src/muuli_wdr.cpp:1982 src/Preferences.cpp:979
 msgid "- default -"
 msgstr "- по подразбиране -"
 
@@ -751,49 +751,49 @@ msgstr ""
 msgid "WARNING: Unable to open skin file '%s' for read"
 msgstr ""
 
-#: src/amuleDlg.cpp:1791 src/muuli_wdr.cpp:3418
+#: src/amuleDlg.cpp:1791 src/muuli_wdr.cpp:3449
 msgid "Networks Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1797 src/muuli_wdr.cpp:3419
+#: src/amuleDlg.cpp:1797 src/muuli_wdr.cpp:3450
 msgid "Searches Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1803 src/muuli_wdr.cpp:3420
+#: src/amuleDlg.cpp:1803 src/muuli_wdr.cpp:3451
 #, fuzzy
 msgid "Downloads Window"
 msgstr "Изтегляне"
 
-#: src/amuleDlg.cpp:1809 src/muuli_wdr.cpp:3422
+#: src/amuleDlg.cpp:1809 src/muuli_wdr.cpp:3453
 msgid "Shared Files Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1815 src/muuli_wdr.cpp:3423
+#: src/amuleDlg.cpp:1815 src/muuli_wdr.cpp:3454
 msgid "Messages Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1821 src/muuli_wdr.cpp:3424
+#: src/amuleDlg.cpp:1821 src/muuli_wdr.cpp:3455
 msgid "Statistics Graph Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1828 src/muuli_wdr.cpp:3426
+#: src/amuleDlg.cpp:1828 src/muuli_wdr.cpp:3457
 msgid "Preferences Settings Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1831 src/muuli_wdr.cpp:3427
+#: src/amuleDlg.cpp:1831 src/muuli_wdr.cpp:3458
 msgid "Import"
 msgstr ""
 
-#: src/amuleDlg.cpp:1835 src/muuli_wdr.cpp:3427
+#: src/amuleDlg.cpp:1835 src/muuli_wdr.cpp:3458
 msgid "The partfile importer tool"
 msgstr ""
 
-#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3428
+#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3459
 #: src/utils/aLinkCreator/src/alcframe.cpp:262
 msgid "About"
 msgstr ""
 
-#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3428
+#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3459
 msgid "About/Help"
 msgstr ""
 
@@ -934,7 +934,7 @@ msgstr "Не са открити части от файлове"
 msgid "The core rejected these shared folders:%s"
 msgstr ""
 
-#: src/amule-remote-gui.cpp:1336 src/ExternalConn.cpp:2345
+#: src/amule-remote-gui.cpp:1336 src/ExternalConn.cpp:2346
 msgid "Invalid link or already on list."
 msgstr ""
 
@@ -950,7 +950,7 @@ msgstr ""
 #: src/ClientDetailDialog.cpp:123 src/DataToText.cpp:61 src/DataToText.cpp:86
 #: src/DataToText.cpp:101 src/DataToText.cpp:136 src/DataToText.cpp:165
 #: src/DownloadListCtrl.cpp:1172 src/DownloadListCtrl.cpp:1185
-#: src/DownloadListCtrl.cpp:1196 src/ExternalConn.cpp:608
+#: src/DownloadListCtrl.cpp:1196 src/ExternalConn.cpp:609
 #: src/FileDetailDialog.cpp:203 src/FileDetailDialog.cpp:235
 #: src/FileDetailDialog.cpp:242 src/GenericClientListCtrl.cpp:1171
 #: src/GenericClientListCtrl.cpp:1182 src/GenericClientListCtrl.cpp:1192
@@ -1338,19 +1338,19 @@ msgstr "Автоматичен [Hi]"
 msgid "Very low"
 msgstr ""
 
-#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:743 src/muuli_wdr.cpp:2282
+#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:743 src/muuli_wdr.cpp:2313
 #: src/ServerListCtrl.cpp:263 src/ServerListCtrl.cpp:456
 #: src/SharedFilesCtrl.cpp:145
 msgid "Low"
 msgstr "Ниско"
 
-#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:744 src/muuli_wdr.cpp:2283
+#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:744 src/muuli_wdr.cpp:2314
 #: src/ServerListCtrl.cpp:266 src/ServerListCtrl.cpp:457
 #: src/SharedFilesCtrl.cpp:146
 msgid "Normal"
 msgstr "Нормален"
 
-#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:745 src/muuli_wdr.cpp:2284
+#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:745 src/muuli_wdr.cpp:2315
 #: src/ServerListCtrl.cpp:269 src/ServerListCtrl.cpp:458
 #: src/SharedFilesCtrl.cpp:147
 msgid "High"
@@ -1442,7 +1442,7 @@ msgstr ""
 msgid "Remote Server"
 msgstr ""
 
-#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3181
+#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3212
 #: src/SearchDlg.cpp:119 src/TextClient.cpp:911
 msgid "Kad"
 msgstr ""
@@ -1513,7 +1513,7 @@ msgstr ""
 msgid "Size"
 msgstr "Размер"
 
-#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3248
+#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3279
 msgid "Transferred"
 msgstr "Пренесен"
 
@@ -1571,7 +1571,7 @@ msgid ""
 "\n"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:746 src/muuli_wdr.cpp:2285
+#: src/DownloadListCtrl.cpp:746 src/muuli_wdr.cpp:2316
 #: src/SharedFilesCtrl.cpp:150
 msgid "Auto"
 msgstr "Автоматично"
@@ -1609,7 +1609,7 @@ msgid "Extended Options"
 msgstr ""
 
 #: src/DownloadListCtrl.cpp:770 src/DownloadListCtrl.cpp:822
-#: src/muuli_wdr.cpp:1796
+#: src/muuli_wdr.cpp:1800
 msgid "Preview"
 msgstr "Преглед"
 
@@ -1782,225 +1782,230 @@ msgstr[1] ""
 msgid "Invalid eD2k link! ERROR: %s"
 msgstr ""
 
-#: src/ExternalConn.cpp:379
+#: src/ExternalConn.cpp:380
 msgid "Client sent packet after authentication failed."
 msgstr ""
 
-#: src/ExternalConn.cpp:396
+#: src/ExternalConn.cpp:397
 msgid "External connection closed."
 msgstr ""
 
-#: src/ExternalConn.cpp:473
+#: src/ExternalConn.cpp:474
 msgid "External connections disabled due to empty password!"
 msgstr ""
 
-#: src/ExternalConn.cpp:494
+#: src/ExternalConn.cpp:495
 msgid "External connections disabled in config file"
 msgstr ""
 
-#: src/ExternalConn.cpp:575
+#: src/ExternalConn.cpp:576
 msgid "New external connection accepted"
 msgstr ""
 
-#: src/ExternalConn.cpp:578
+#: src/ExternalConn.cpp:579
 msgid "ERROR: couldn't accept a new external connection"
 msgstr ""
 
-#: src/ExternalConn.cpp:595
+#: src/ExternalConn.cpp:596
 msgid "External connection refused due to empty password in preferences!"
 msgstr ""
 
-#: src/ExternalConn.cpp:607
+#: src/ExternalConn.cpp:608
 #, c-format
 msgid "Connecting client: %s %s"
 msgstr ""
 
-#: src/ExternalConn.cpp:609
+#: src/ExternalConn.cpp:610
 msgid "Unknown version"
 msgstr ""
 
-#: src/ExternalConn.cpp:622
+#: src/ExternalConn.cpp:623
 msgid "Incorrect EC version ID, there might be binary incompatibility. Use core and remote from same snapshot."
 msgstr ""
 
-#: src/ExternalConn.cpp:630
+#: src/ExternalConn.cpp:631
 msgid "You cannot connect to a release version from an arbitrary development snapshot! *sigh* possible crash prevented"
 msgstr ""
 
-#: src/ExternalConn.cpp:713
+#: src/ExternalConn.cpp:714
 msgid "Invalid protocol version."
 msgstr ""
 
-#: src/ExternalConn.cpp:719
+#: src/ExternalConn.cpp:720
 msgid "Missing protocol version tag."
 msgstr ""
 
-#: src/ExternalConn.cpp:727
+#: src/ExternalConn.cpp:728
 msgid "Authentication failed: invalid hash specified as EC password."
 msgstr ""
 
-#: src/ExternalConn.cpp:775
+#: src/ExternalConn.cpp:776
 msgid "Authentication failed: wrong password."
 msgstr ""
 
-#: src/ExternalConn.cpp:777
+#: src/ExternalConn.cpp:778
 msgid "Authentication failed: missing password."
 msgstr ""
 
-#: src/ExternalConn.cpp:788
+#: src/ExternalConn.cpp:789
 msgid "Invalid request, please authenticate first."
 msgstr ""
 
-#: src/ExternalConn.cpp:793
+#: src/ExternalConn.cpp:794
 msgid "Access granted."
 msgstr ""
 
-#: src/ExternalConn.cpp:801
+#: src/ExternalConn.cpp:802
 #, c-format
 msgid "Sent error message \"%s\" to client."
 msgstr ""
 
-#: src/ExternalConn.cpp:806
+#: src/ExternalConn.cpp:807
 #, c-format
 msgid "Unauthorized access attempt from %s. Connection closed."
 msgstr ""
 
-#: src/ExternalConn.cpp:1419
+#: src/ExternalConn.cpp:1420
 #, c-format
 msgid "Remote PartFile command failed: FileHash not found: %s"
 msgstr ""
 
-#: src/ExternalConn.cpp:1423
+#: src/ExternalConn.cpp:1424
 #, c-format
 msgid "FileHash not found: %s"
 msgstr ""
 
-#: src/ExternalConn.cpp:1470 src/ExternalConn.cpp:1558
-#: src/ExternalConn.cpp:1679
+#: src/ExternalConn.cpp:1471 src/ExternalConn.cpp:1559
+#: src/ExternalConn.cpp:1680
 msgid "OOPS! OpCode processing error!"
 msgstr ""
 
-#: src/ExternalConn.cpp:1501
+#: src/ExternalConn.cpp:1502
 msgid "Server not added"
 msgstr ""
 
-#: src/ExternalConn.cpp:1520
+#: src/ExternalConn.cpp:1521
 #, c-format
 msgid "server not found: %s"
 msgstr ""
 
-#: src/ExternalConn.cpp:1537
+#: src/ExternalConn.cpp:1538
 msgid "need to define server to be removed"
 msgstr ""
 
-#: src/ExternalConn.cpp:1552
+#: src/ExternalConn.cpp:1553
 msgid "eD2k is disabled in preferences."
 msgstr ""
 
-#: src/ExternalConn.cpp:1657
+#: src/ExternalConn.cpp:1658
 msgid "Friend not found."
 msgstr ""
 
-#: src/ExternalConn.cpp:1667
+#: src/ExternalConn.cpp:1668
 msgid "Client not found."
 msgstr ""
 
-#: src/ExternalConn.cpp:1673
+#: src/ExternalConn.cpp:1674
 msgid "EC_TAG_FRIEND_SHARED requires EC_TAG_FRIEND or EC_TAG_CLIENT."
 msgstr ""
 
-#: src/ExternalConn.cpp:1991
+#: src/ExternalConn.cpp:1992
 msgid "WebSearch from remote interface makes no sense."
 msgstr ""
 
-#: src/ExternalConn.cpp:2026
+#: src/ExternalConn.cpp:2027
 msgid "Search in progress. Refetch results in a moment!"
 msgstr ""
 
-#: src/ExternalConn.cpp:2265
+#: src/ExternalConn.cpp:2266
 msgid "No points for graph."
 msgstr ""
 
-#: src/ExternalConn.cpp:2275
+#: src/ExternalConn.cpp:2276
 msgid "Your client is not configured for this detail level."
 msgstr ""
 
-#: src/ExternalConn.cpp:2302
+#: src/ExternalConn.cpp:2303
 msgid "External Connection: shutdown requested"
 msgstr ""
 
-#: src/ExternalConn.cpp:2314
+#: src/ExternalConn.cpp:2315
 msgid "Already shutting down."
 msgstr ""
 
-#: src/ExternalConn.cpp:2332
+#: src/ExternalConn.cpp:2333
 #, c-format
 msgid "ExternalConn: adding link '%s'."
 msgstr ""
 
-#: src/ExternalConn.cpp:2350
+#: src/ExternalConn.cpp:2351
 #, c-format
 msgid "%d of %d links failed (invalid or already on list)."
 msgstr ""
 
-#: src/ExternalConn.cpp:2373
+#: src/ExternalConn.cpp:2374
 msgid "Version check throttled; try again shortly."
 msgstr ""
 
-#: src/ExternalConn.cpp:2378
+#: src/ExternalConn.cpp:2379
 msgid "Version check is not available on this daemon."
 msgstr ""
 
-#: src/ExternalConn.cpp:2508
+#: src/ExternalConn.cpp:2509
 msgid "File not found."
 msgstr ""
 
-#: src/ExternalConn.cpp:2513
+#: src/ExternalConn.cpp:2514
 msgid "Invalid file name."
 msgstr ""
 
-#: src/ExternalConn.cpp:2521
+#: src/ExternalConn.cpp:2522
 msgid "Unable to rename file."
 msgstr ""
 
-#: src/ExternalConn.cpp:2992 src/ExternalConn.cpp:3020
+#: src/ExternalConn.cpp:2839
+#, c-format
+msgid "Could not save the amuleapi password: %s"
+msgstr ""
+
+#: src/ExternalConn.cpp:3004 src/ExternalConn.cpp:3032
 msgid "Kad is disabled in preferences."
 msgstr ""
 
-#: src/ExternalConn.cpp:3033
+#: src/ExternalConn.cpp:3045
 msgid "Already connected to eD2k."
 msgstr ""
 
-#: src/ExternalConn.cpp:3036
+#: src/ExternalConn.cpp:3048
 msgid "Connecting to eD2k..."
 msgstr ""
 
-#: src/ExternalConn.cpp:3045
+#: src/ExternalConn.cpp:3057
 msgid "Already connected to Kad."
 msgstr ""
 
-#: src/ExternalConn.cpp:3048
+#: src/ExternalConn.cpp:3060
 msgid "Connecting to Kad..."
 msgstr ""
 
-#: src/ExternalConn.cpp:3055
+#: src/ExternalConn.cpp:3067
 msgid "All networks are disabled."
 msgstr ""
 
-#: src/ExternalConn.cpp:3064
+#: src/ExternalConn.cpp:3076
 msgid "Disconnected from eD2k."
 msgstr ""
 
-#: src/ExternalConn.cpp:3069
+#: src/ExternalConn.cpp:3081
 msgid "Disconnected from Kad."
 msgstr ""
 
-#: src/ExternalConn.cpp:3078
+#: src/ExternalConn.cpp:3090
 #, c-format
 msgid "External Connection: invalid opcode received: %#x"
 msgstr ""
 
-#: src/ExternalConn.cpp:3083
+#: src/ExternalConn.cpp:3095
 msgid "Invalid opcode (wrong protocol version?)"
 msgstr ""
 
@@ -2376,23 +2381,23 @@ msgid ""
 "want downloads on a different (e.g. larger) disk."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:549 src/FirstRunWizard.cpp:611 src/muuli_wdr.cpp:1708
+#: src/FirstRunWizard.cpp:549 src/FirstRunWizard.cpp:611 src/muuli_wdr.cpp:1712
 msgid "Destination folder for downloads"
 msgstr ""
 
 #: src/FirstRunWizard.cpp:553 src/FirstRunWizard.cpp:569 src/muuli_wdr.cpp:1349
-#: src/muuli_wdr.cpp:1366 src/muuli_wdr.cpp:1683 src/muuli_wdr.cpp:1714
-#: src/muuli_wdr.cpp:1726 src/muuli_wdr.cpp:2769
+#: src/muuli_wdr.cpp:1366 src/muuli_wdr.cpp:1687 src/muuli_wdr.cpp:1718
+#: src/muuli_wdr.cpp:1730 src/muuli_wdr.cpp:2800
 #: src/utils/aLinkCreator/src/alcframe.cpp:135
 #: src/utils/wxCas/src/wxcasprefs.cpp:52 src/utils/wxCas/src/wxcasprefs.cpp:118
 msgid "Browse"
 msgstr "Избери"
 
-#: src/FirstRunWizard.cpp:559 src/muuli_wdr.cpp:1719
+#: src/FirstRunWizard.cpp:559 src/muuli_wdr.cpp:1723
 msgid "(All files in this folder are shared with other peers)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:565 src/FirstRunWizard.cpp:624 src/muuli_wdr.cpp:1721
+#: src/FirstRunWizard.cpp:565 src/FirstRunWizard.cpp:624 src/muuli_wdr.cpp:1725
 msgid "Folder for temporary download files"
 msgstr ""
 
@@ -2423,7 +2428,7 @@ msgstr ""
 msgid "CRITICAL - no client on StartChatSession"
 msgstr ""
 
-#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2675 src/muuli_wdr.cpp:3352
+#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2706 src/muuli_wdr.cpp:3383
 msgid "Friends"
 msgstr "Приятели"
 
@@ -2532,8 +2537,8 @@ msgstr "никой"
 msgid "No"
 msgstr "Не"
 
-#: src/GenericClientListCtrl.cpp:1216 src/PrefsUnifiedDlg.cpp:2818
-#: src/PrefsUnifiedDlg.cpp:2868 src/ServerListCtrl.cpp:276
+#: src/GenericClientListCtrl.cpp:1216 src/PrefsUnifiedDlg.cpp:2898
+#: src/PrefsUnifiedDlg.cpp:2948 src/ServerListCtrl.cpp:276
 msgid "Yes"
 msgstr "Да"
 
@@ -2700,10 +2705,10 @@ msgstr ""
 msgid "Please fill all fields required"
 msgstr ""
 
-#: src/KadDlg.cpp:192 src/PartFile.cpp:1031 src/PrefsUnifiedDlg.cpp:1162
-#: src/PrefsUnifiedDlg.cpp:1331 src/PrefsUnifiedDlg.cpp:1589
-#: src/PrefsUnifiedDlg.cpp:1599 src/PrefsUnifiedDlg.cpp:1616
-#: src/PrefsUnifiedDlg.cpp:1658
+#: src/KadDlg.cpp:192 src/PartFile.cpp:1031 src/PrefsUnifiedDlg.cpp:1134
+#: src/PrefsUnifiedDlg.cpp:1204 src/PrefsUnifiedDlg.cpp:1405
+#: src/PrefsUnifiedDlg.cpp:1663 src/PrefsUnifiedDlg.cpp:1673
+#: src/PrefsUnifiedDlg.cpp:1690 src/PrefsUnifiedDlg.cpp:1738
 msgid "Message"
 msgstr ""
 
@@ -2804,7 +2809,7 @@ msgstr ""
 msgid "Uploaded"
 msgstr ""
 
-#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3232
+#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3263
 msgid "Requested"
 msgstr ""
 
@@ -2928,7 +2933,7 @@ msgid "WARNING: "
 msgstr ""
 
 #: src/MuleNotebook.cpp:179 src/muuli_wdr.cpp:817 src/muuli_wdr.cpp:1229
-#: src/muuli_wdr.cpp:3136 src/muuli_wdr.cpp:3392
+#: src/muuli_wdr.cpp:3167 src/muuli_wdr.cpp:3423
 msgid "Close"
 msgstr "Затвори"
 
@@ -2946,7 +2951,7 @@ msgid "Paste"
 msgstr ""
 
 #: src/MuleTextCtrl.cpp:89 src/muuli_wdr.cpp:358 src/muuli_wdr.cpp:757
-#: src/muuli_wdr.cpp:2359 src/muuli_wdr.cpp:2378 src/muuli_wdr.cpp:2400
+#: src/muuli_wdr.cpp:2390 src/muuli_wdr.cpp:2409 src/muuli_wdr.cpp:2431
 #: src/utils/aLinkCreator/src/alcframe.cpp:142
 msgid "Clear"
 msgstr "Изчисти"
@@ -3042,7 +3047,7 @@ msgstr "Изход"
 
 #: src/MuleTrayIcon.cpp:579 src/MuleTrayIcon.cpp:945 src/MuleTrayIcon.cpp:965
 #: src/muuli_wdr.cpp:1398 src/muuli_wdr.cpp:1406 src/muuli_wdr.cpp:1413
-#: src/muuli_wdr.cpp:1842 src/muuli_wdr.cpp:1848 src/OtherFunctions.cpp:91
+#: src/muuli_wdr.cpp:1846 src/muuli_wdr.cpp:1852 src/OtherFunctions.cpp:91
 #: src/StatisticsDlg.cpp:93 src/StatisticsDlg.cpp:95
 msgid "kB/s"
 msgstr "кБ/с"
@@ -3282,7 +3287,7 @@ msgstr "Байта"
 msgid "KB"
 msgstr "KB"
 
-#: src/muuli_wdr.cpp:274 src/muuli_wdr.cpp:293 src/muuli_wdr.cpp:1627
+#: src/muuli_wdr.cpp:274 src/muuli_wdr.cpp:293 src/muuli_wdr.cpp:1631
 #: src/OtherFunctions.cpp:64
 msgid "MB"
 msgstr "MB"
@@ -3299,7 +3304,7 @@ msgstr "Максимален размер"
 msgid "Availability"
 msgstr ""
 
-#: src/muuli_wdr.cpp:312 src/muuli_wdr.cpp:398 src/muuli_wdr.cpp:3297
+#: src/muuli_wdr.cpp:312 src/muuli_wdr.cpp:398 src/muuli_wdr.cpp:3328
 msgid "Filter:"
 msgstr ""
 
@@ -3363,12 +3368,12 @@ msgstr "Намерени източници: %i"
 #: src/muuli_wdr.cpp:1160 src/muuli_wdr.cpp:1167 src/muuli_wdr.cpp:1172
 #: src/muuli_wdr.cpp:1179 src/muuli_wdr.cpp:1184 src/muuli_wdr.cpp:1191
 #: src/muuli_wdr.cpp:1205 src/muuli_wdr.cpp:1212 src/muuli_wdr.cpp:1217
-#: src/muuli_wdr.cpp:1224 src/muuli_wdr.cpp:3234 src/muuli_wdr.cpp:3242
-#: src/muuli_wdr.cpp:3250
+#: src/muuli_wdr.cpp:1224 src/muuli_wdr.cpp:3265 src/muuli_wdr.cpp:3273
+#: src/muuli_wdr.cpp:3281
 msgid "N/A"
 msgstr "Няма"
 
-#: src/muuli_wdr.cpp:508 src/muuli_wdr.cpp:1065 src/PrefsUnifiedDlg.cpp:297
+#: src/muuli_wdr.cpp:508 src/muuli_wdr.cpp:1065 src/PrefsUnifiedDlg.cpp:299
 msgid "General"
 msgstr "Общи"
 
@@ -3506,7 +3511,7 @@ msgstr ""
 msgid "Album :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:685 src/muuli_wdr.cpp:2254
+#: src/muuli_wdr.cpp:685 src/muuli_wdr.cpp:2285
 msgid "Title :"
 msgstr "Заглавие :"
 
@@ -3612,7 +3617,7 @@ msgstr ""
 msgid "Userhash :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:895 src/muuli_wdr.cpp:1748 src/muuli_wdr.cpp:2449
+#: src/muuli_wdr.cpp:895 src/muuli_wdr.cpp:1752 src/muuli_wdr.cpp:2480
 #: src/utils/aLinkCreator/src/alcframe.cpp:137
 msgid "Add"
 msgstr "Добавяне"
@@ -3621,15 +3626,15 @@ msgstr "Добавяне"
 msgid "Download-Speed"
 msgstr ""
 
-#: src/muuli_wdr.cpp:954 src/muuli_wdr.cpp:989 src/muuli_wdr.cpp:2553
+#: src/muuli_wdr.cpp:954 src/muuli_wdr.cpp:989 src/muuli_wdr.cpp:2584
 msgid "Current"
 msgstr "Текущ"
 
-#: src/muuli_wdr.cpp:962 src/muuli_wdr.cpp:997 src/muuli_wdr.cpp:2561
+#: src/muuli_wdr.cpp:962 src/muuli_wdr.cpp:997 src/muuli_wdr.cpp:2592
 msgid "Running average"
 msgstr ""
 
-#: src/muuli_wdr.cpp:970 src/muuli_wdr.cpp:1005 src/muuli_wdr.cpp:2569
+#: src/muuli_wdr.cpp:970 src/muuli_wdr.cpp:1005 src/muuli_wdr.cpp:2600
 msgid "Session average"
 msgstr ""
 
@@ -3641,7 +3646,7 @@ msgstr ""
 msgid "Connections"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1024 src/muuli_wdr.cpp:1867
+#: src/muuli_wdr.cpp:1024 src/muuli_wdr.cpp:1871
 msgid "Active downloads"
 msgstr ""
 
@@ -3649,7 +3654,7 @@ msgstr ""
 msgid "Active connections (1:1)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1040 src/muuli_wdr.cpp:1868
+#: src/muuli_wdr.cpp:1040 src/muuli_wdr.cpp:1872
 msgid "Active uploads"
 msgstr ""
 
@@ -3923,7 +3928,7 @@ msgstr ""
 msgid "Advanced users only: If you have multiple network interfaces, enter the address of the interface to which aMule should be bound."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1462 src/muuli_wdr.cpp:2061
+#: src/muuli_wdr.cpp:1462 src/muuli_wdr.cpp:2065
 msgid "Bind to network interface (empty for any):"
 msgstr ""
 
@@ -3939,7 +3944,7 @@ msgstr ""
 msgid "Max simultaneous connections:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1498 src/muuli_wdr.cpp:3176
+#: src/muuli_wdr.cpp:1498 src/muuli_wdr.cpp:3207
 msgid "ED2K"
 msgstr ""
 
@@ -4031,746 +4036,768 @@ msgstr ""
 msgid "For new files preallocates disk space for the whole file, thus reduces fragmentation"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1613
+#: src/muuli_wdr.cpp:1617
 msgid "Create new files as sparse files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1614
-msgid "A sparse file reserves its full size on disk immediately without writing real data to it -- fast, but unsupported or slow on some filesystems, and free-space accounting stays optimistic while the download is in progress. Turn this off to grow the file only as data arrives."
+#: src/muuli_wdr.cpp:1618
+msgid "Sparse part files only occupy disk space for the parts already downloaded, so free space is used up gradually as the file fills in. Turn this off to use an ordinary file instead - useful where sparse files are unsupported or slow, or where backup/de-duplication tools handle them badly. Applies only when the core runs on Windows; on Linux and macOS part files are sparse anyway and this setting has no effect."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1619
+#: src/muuli_wdr.cpp:1623
 msgid "Stop downloads when free disk space reaches "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1620
+#: src/muuli_wdr.cpp:1624
 msgid "Select this if you want aMule to check your disk space"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1624
+#: src/muuli_wdr.cpp:1628
 msgid "Enter here the min disk space desired."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1630
+#: src/muuli_wdr.cpp:1634
 msgid "Save 10 sources on rare files (< 20 sources)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1634 src/Statistics.cpp:790
+#: src/muuli_wdr.cpp:1638 src/Statistics.cpp:790
 msgid "Uploads"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1637
+#: src/muuli_wdr.cpp:1641
 msgid "Add new shared files with auto priority"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1643
+#: src/muuli_wdr.cpp:1647
 msgid "Intelligent Corruption Handling (I.C.H.)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1646
+#: src/muuli_wdr.cpp:1650
 msgid "Enable"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1649
+#: src/muuli_wdr.cpp:1653
 msgid "Advanced I.C.H. trusts every hash (not recommended)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1661 src/PrefsUnifiedDlg.cpp:1910
+#: src/muuli_wdr.cpp:1665 src/PrefsUnifiedDlg.cpp:1990
 msgid "Media metadata extraction"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1665
+#: src/muuli_wdr.cpp:1669
 msgid "Extract length / bitrate / codec from shared audio and video files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1667
+#: src/muuli_wdr.cpp:1671
 msgid "When enabled, aMule runs ffprobe on each shared media file to fill in the Length / Bitrate / Codec columns other clients see when they find the file in a search. Requires ffmpeg (the ffprobe binary) to be installed."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1674
+#: src/muuli_wdr.cpp:1678
 msgid "Path to ffprobe:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1679
+#: src/muuli_wdr.cpp:1683
 msgid "Full path to the ffprobe binary. Leave empty to have aMule auto-detect it on startup."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1687
+#: src/muuli_wdr.cpp:1691
 msgid "Detect"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1688
+#: src/muuli_wdr.cpp:1692
 msgid "Search the standard install locations for an ffprobe binary and fill the path field."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1712
+#: src/muuli_wdr.cpp:1716
 msgid ""
 "Completed downloads are stored here. All files in this folder are automatically shared with other peers.\n"
 "If this folder also holds files you don't want to share, point it at an aMule-only sub-folder."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1715
+#: src/muuli_wdr.cpp:1719
 msgid "Pick the folder where completed downloads will be stored. All files in that folder will be shared with other peers."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1729
+#: src/muuli_wdr.cpp:1733
 msgid "Shared folders"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1735
+#: src/muuli_wdr.cpp:1739
 msgid "(Folders shared by the core. Enter a path to add one.)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1743
+#: src/muuli_wdr.cpp:1747
 msgid "Absolute path of a folder on the core's machine, e.g. /home/user/shared"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1745 src/PrefsUnifiedDlg.cpp:2794
+#: src/muuli_wdr.cpp:1749 src/PrefsUnifiedDlg.cpp:2874
 msgid "Recursive"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1746
+#: src/muuli_wdr.cpp:1750
 msgid "Share every sub-folder underneath this one, including ones created later."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1750 src/utils/aLinkCreator/src/alcframe.cpp:141
+#: src/muuli_wdr.cpp:1754 src/utils/aLinkCreator/src/alcframe.cpp:141
 msgid "Remove"
 msgstr "Премахване"
 
-#: src/muuli_wdr.cpp:1754
+#: src/muuli_wdr.cpp:1758
 msgid "(Right click on folder icon for recursive share)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1761
+#: src/muuli_wdr.cpp:1765
 msgid "Share hidden files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1767
+#: src/muuli_wdr.cpp:1771
 msgid "Automatically rescan shared folders for changes"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1773
+#: src/muuli_wdr.cpp:1777
 msgid "Follow symbolic links in shared folders"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1779
+#: src/muuli_wdr.cpp:1783
 msgid "Exclude files matching:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1782
+#: src/muuli_wdr.cpp:1786
 msgid "Wildcard patterns separated by '|', e.g. .DS_Store|Thumbs.db|*.tmp. Files whose name matches are not shared. Matching is case-insensitive."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1786
+#: src/muuli_wdr.cpp:1790
 msgid "Patterns are regular expressions"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1787
+#: src/muuli_wdr.cpp:1791
 msgid "When set, the whole field is one regular expression ('|' is alternation). When unset, it is a list of '|'-separated wildcards."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1797
+#: src/muuli_wdr.cpp:1801
 msgid "Show how many shared files the current pattern would exclude."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1818
+#: src/muuli_wdr.cpp:1822
 msgid "Graphs"
 msgstr "Диаграми"
 
-#: src/muuli_wdr.cpp:1821 src/muuli_wdr.cpp:1883
+#: src/muuli_wdr.cpp:1825 src/muuli_wdr.cpp:1887
 msgid "Update delay : 5 secs"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1825
+#: src/muuli_wdr.cpp:1829
 msgid "Time for average graph: 100 mins"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1829
+#: src/muuli_wdr.cpp:1833
 msgid "Connections Graph Scale: 100 "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1836
+#: src/muuli_wdr.cpp:1840
 msgid "Download graph scale:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1844
+#: src/muuli_wdr.cpp:1848
 msgid "Upload graph scale:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1854
+#: src/muuli_wdr.cpp:1858
 #, fuzzy
 msgid "Colors: "
 msgstr "Цветове: "
 
-#: src/muuli_wdr.cpp:1858
+#: src/muuli_wdr.cpp:1862
 msgid "Background"
 msgstr "Фон"
 
-#: src/muuli_wdr.cpp:1859
+#: src/muuli_wdr.cpp:1863
 msgid "Grid"
 msgstr "Мрежа"
 
-#: src/muuli_wdr.cpp:1860
+#: src/muuli_wdr.cpp:1864
 msgid "Download current"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1861
+#: src/muuli_wdr.cpp:1865
 msgid "Download running average"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1862
+#: src/muuli_wdr.cpp:1866
 msgid "Download session average"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1863
+#: src/muuli_wdr.cpp:1867
 msgid "Upload current"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1864
+#: src/muuli_wdr.cpp:1868
 msgid "Upload running average"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1865
+#: src/muuli_wdr.cpp:1869
 msgid "Upload session average"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1866
+#: src/muuli_wdr.cpp:1870
 msgid "Active connections"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1869
+#: src/muuli_wdr.cpp:1873
 msgid "Systray Icon Speed Bar"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1870
+#: src/muuli_wdr.cpp:1874
 msgid "Kad-nodes current"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1871
+#: src/muuli_wdr.cpp:1875
 msgid "Kad-nodes running"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1872
+#: src/muuli_wdr.cpp:1876
 msgid "Kad-nodes session"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1876 src/muuli_wdr.cpp:2303
+#: src/muuli_wdr.cpp:1880 src/muuli_wdr.cpp:2334
 msgid "Select"
 msgstr "Избор"
 
-#: src/muuli_wdr.cpp:1880
+#: src/muuli_wdr.cpp:1884
 msgid "Tree"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1890
+#: src/muuli_wdr.cpp:1894
 msgid "Number of Client Versions shown (0=unlimited)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1915
+#: src/muuli_wdr.cpp:1919
 msgid "!!! WARNING !!!"
 msgstr "!!! ВНИМАНИЕ !!!"
 
-#: src/muuli_wdr.cpp:1930
+#: src/muuli_wdr.cpp:1934
 msgid "Max new connections / 5 secs"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1932
+#: src/muuli_wdr.cpp:1936
 msgid "Concurrent Kad source lookups"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1934
+#: src/muuli_wdr.cpp:1938
 msgid "Kad source re-search interval (minutes)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1936
+#: src/muuli_wdr.cpp:1940
 msgid "Source re-ask interval (minutes)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1940
+#: src/muuli_wdr.cpp:1944
 msgid "File Buffer Size: 240000 bytes"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1944
+#: src/muuli_wdr.cpp:1948
 msgid "Use MMAP: memory-mapped file access (lower memory use)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1945
+#: src/muuli_wdr.cpp:1949
 msgid "Maps part files into memory instead of buffering them on the heap, lowering the process memory footprint. May reduce download speed on some disks; best for memory-constrained or upload-heavy hosts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1947
+#: src/muuli_wdr.cpp:1951
 msgid "Upload Queue Size: 5000 clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1951
+#: src/muuli_wdr.cpp:1955
 msgid "Server connection refresh interval: Disable"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1955
+#: src/muuli_wdr.cpp:1959
 msgid "Disable computer's timed standby mode"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1974
+#: src/muuli_wdr.cpp:1978
 msgid "Skin to use: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1983
+#: src/muuli_wdr.cpp:1987
 msgid "Show \"Fast eD2k Links Handler\" in every window."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1986
+#: src/muuli_wdr.cpp:1990
 msgid "Show extended info on categories tabs"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1989
+#: src/muuli_wdr.cpp:1993
 msgid "Show application version on title"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1991
+#: src/muuli_wdr.cpp:1995
 msgid "Show transfer rates on title"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1993
+#: src/muuli_wdr.cpp:1997
 msgid "Before application name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1995
+#: src/muuli_wdr.cpp:1999
 msgid "After application name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1998
+#: src/muuli_wdr.cpp:2002
 msgid "Show overhead bandwidth"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2002
+#: src/muuli_wdr.cpp:2006
 msgid "Vertical toolbar orientation"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2004
+#: src/muuli_wdr.cpp:2008
 msgid "Live column sorting (auto-reorder rows as their values change)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2011
+#: src/muuli_wdr.cpp:2015
 msgid "Download Queue Files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2014
+#: src/muuli_wdr.cpp:2018
 msgid "Show progress percentage"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2020
+#: src/muuli_wdr.cpp:2024
 msgid "Show progress bar"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2023
+#: src/muuli_wdr.cpp:2027
 msgid "Flat"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2027
+#: src/muuli_wdr.cpp:2031
 msgid "Round"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2045
+#: src/muuli_wdr.cpp:2049
 msgid "External Connection Parameters"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2048
+#: src/muuli_wdr.cpp:2052
 msgid "Accept external connections"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2055 src/muuli_wdr.cpp:2114
+#: src/muuli_wdr.cpp:2059 src/muuli_wdr.cpp:2118
 msgid "IP of the listening interface:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2058
+#: src/muuli_wdr.cpp:2062
 msgid "Enter here a valid ip in the a.b.c.d format for the listening EC interface. An empty field or 0.0.0.0 will mean any interface."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2079 src/muuli_wdr.cpp:2163
+#: src/muuli_wdr.cpp:2083 src/muuli_wdr.cpp:2194
 msgid "TCP port:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2085
+#: src/muuli_wdr.cpp:2089
 msgid "Enable UPnP port forwarding on the EC port"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2089 src/muuli_wdr.cpp:3048
+#: src/muuli_wdr.cpp:2093 src/muuli_wdr.cpp:3079
 #: src/utils/wxCas/src/wxcasprefs.cpp:167
 msgid "Password"
 msgstr "парола"
 
-#: src/muuli_wdr.cpp:2095
+#: src/muuli_wdr.cpp:2099
 msgid "aMule API server parameters"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2098
+#: src/muuli_wdr.cpp:2102
 msgid "Run amuleapi (REST API) on startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2103
+#: src/muuli_wdr.cpp:2107
 msgid "HTTP port:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2117
+#: src/muuli_wdr.cpp:2121
 msgid "The interface amuleapi's HTTP server listens on. 127.0.0.1 (default) accepts only local connections; use 0.0.0.0 or a specific IP to expose it to other hosts (set an admin password below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2120
+#: src/muuli_wdr.cpp:2126
+msgid "Type a password to set or change it. Stored passwords cannot be shown, so leaving this empty keeps the current one."
+msgstr ""
+
+#: src/muuli_wdr.cpp:2128
 #, fuzzy
 msgid "Admin password"
 msgstr "парола"
 
-#: src/muuli_wdr.cpp:2125 src/muuli_wdr.cpp:2156
-msgid "Low rights password"
+#: src/muuli_wdr.cpp:2140 src/muuli_wdr.cpp:2157 src/PrefsUnifiedDlg.cpp:1103
+#, fuzzy
+msgid "A password is set."
+msgstr "парола"
+
+#: src/muuli_wdr.cpp:2144
+msgid "Enable guest access"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2133
+#: src/muuli_wdr.cpp:2145
+msgid "Guest sessions may read status and listings but cannot change anything. Turning this off clears the stored guest password."
+msgstr ""
+
+#: src/muuli_wdr.cpp:2149
+#, fuzzy
+msgid "Guest password"
+msgstr "парола"
+
+#: src/muuli_wdr.cpp:2164
 msgid "Web server parameters"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2136
+#: src/muuli_wdr.cpp:2167
 msgid "Run webserver on startup (deprecated)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2142
+#: src/muuli_wdr.cpp:2173
 msgid "Web template"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2147
+#: src/muuli_wdr.cpp:2178
 msgid "Full rights password"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2151
+#: src/muuli_wdr.cpp:2182
 msgid "Enable Low rights User"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2170
+#: src/muuli_wdr.cpp:2187
+msgid "Low rights password"
+msgstr ""
+
+#: src/muuli_wdr.cpp:2201
 msgid "Enable UPnP port forwarding of the web server port"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2175
+#: src/muuli_wdr.cpp:2206
 msgid "Web server UPnP TCP port (Optional)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2183
+#: src/muuli_wdr.cpp:2214
 msgid "Page Refresh Time (in secs)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2190
+#: src/muuli_wdr.cpp:2221
 msgid "Enable Gzip compression"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2224
+#: src/muuli_wdr.cpp:2255
 msgid "Reset page to defaults"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2225
+#: src/muuli_wdr.cpp:2256
 msgid "Reset the settings on the current page to their default values."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2227 src/muuli_wdr.cpp:2313 src/ServerWnd.cpp:274
+#: src/muuli_wdr.cpp:2258 src/muuli_wdr.cpp:2344 src/ServerWnd.cpp:274
 #: src/ServerWnd.cpp:282
 msgid "OK"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2229
+#: src/muuli_wdr.cpp:2260
 msgid "Click here to apply any changes made to the preferences."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2232
+#: src/muuli_wdr.cpp:2263
 msgid "Reset any changes made to the preferences."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2261
+#: src/muuli_wdr.cpp:2292
 msgid "Comment :"
 msgstr "Коментар:"
 
-#: src/muuli_wdr.cpp:2268
+#: src/muuli_wdr.cpp:2299
 msgid "Incoming Dir :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2277
+#: src/muuli_wdr.cpp:2308
 msgid "Change priority for new assigned files :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2281
+#: src/muuli_wdr.cpp:2312
 msgid "Don't change"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2293
+#: src/muuli_wdr.cpp:2324
 msgid "Select color for this Category (currently selected) :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2360 src/muuli_wdr.cpp:2379 src/muuli_wdr.cpp:2401
+#: src/muuli_wdr.cpp:2391 src/muuli_wdr.cpp:2410 src/muuli_wdr.cpp:2432
 msgid "Click this button to reset the log."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2420
+#: src/muuli_wdr.cpp:2451
 msgid "Click on this button to update the servers list from URL ..."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2424
+#: src/muuli_wdr.cpp:2455
 msgid "Server list"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2428
+#: src/muuli_wdr.cpp:2459
 msgid "Enter the url to a server.met file here and press the button to the left to update the list of known servers."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2433
+#: src/muuli_wdr.cpp:2464
 msgid "Add server manually: Name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2436
+#: src/muuli_wdr.cpp:2467
 msgid "Enter the name of the new server here"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2438 src/ServerWnd.cpp:206
+#: src/muuli_wdr.cpp:2469 src/ServerWnd.cpp:206
 msgid "IP:Port"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2441
+#: src/muuli_wdr.cpp:2472
 msgid "Enter the IP of the server here, using the x.x.x.x format."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2447
+#: src/muuli_wdr.cpp:2478
 msgid "Enter the port of the server here."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2450
+#: src/muuli_wdr.cpp:2481
 msgid "Add manually a server (fill fields to the left before) ..."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2479
+#: src/muuli_wdr.cpp:2510
 msgid "aMule Log"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2487
+#: src/muuli_wdr.cpp:2518
 msgid "Server Info"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2491
+#: src/muuli_wdr.cpp:2522
 msgid "ED2K Info"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2495
+#: src/muuli_wdr.cpp:2526
 msgid "Kad Info"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2523
+#: src/muuli_wdr.cpp:2554
 msgid "Click on this button to update the nodes list from URL ..."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2527
+#: src/muuli_wdr.cpp:2558
 msgid "Nodes (0)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2531
+#: src/muuli_wdr.cpp:2562
 msgid "Enter the url to a nodes.dat file here and press the button to the left to update the list of known nodes."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2534
+#: src/muuli_wdr.cpp:2565
 msgid "Nodes stats"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2576
+#: src/muuli_wdr.cpp:2607
 msgid "Bootstrap"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2579
+#: src/muuli_wdr.cpp:2610
 msgid "New node"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2584
+#: src/muuli_wdr.cpp:2615
 msgid "IP:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2604
+#: src/muuli_wdr.cpp:2635
 msgid "Port:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2617
+#: src/muuli_wdr.cpp:2648
 msgid "Bootstrap from known clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2619
+#: src/muuli_wdr.cpp:2650
 msgid "Disconnect Kad"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2653
+#: src/muuli_wdr.cpp:2684
 msgid "Use Secure User Identification"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2655
+#: src/muuli_wdr.cpp:2686
 msgid "It is recommended to enable this option. You will not receive credits if SUI is not enabled."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2657
+#: src/muuli_wdr.cpp:2688
 msgid "Protocol Obfuscation"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2660
+#: src/muuli_wdr.cpp:2691
 msgid "Support Protocol Obfuscation"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2662
+#: src/muuli_wdr.cpp:2693
 msgid "This option enabled Protocol Obfuscation, and makes aMule accept obfuscated connections from other clients."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2664
+#: src/muuli_wdr.cpp:2695
 msgid "Use obfuscation for outgoing connections"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2666
+#: src/muuli_wdr.cpp:2697
 msgid "This option makes aMule use Protocol Obfuscation when connecting other clients/servers."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2668
+#: src/muuli_wdr.cpp:2699
 msgid "Accept only obfuscated connections"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2669
+#: src/muuli_wdr.cpp:2700
 msgid "This option makes aMule only accept obfuscated connections. You will have less sources, but all your traffic will be obfuscated"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2674
+#: src/muuli_wdr.cpp:2705
 msgid "Everybody"
 msgstr "Всеки"
 
-#: src/muuli_wdr.cpp:2676
+#: src/muuli_wdr.cpp:2707
 msgid "No one"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2678
+#: src/muuli_wdr.cpp:2709
 msgid "Who can see my shared files:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2679
+#: src/muuli_wdr.cpp:2710
 msgid "Select who can request to view a list of your shared files."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2681
+#: src/muuli_wdr.cpp:2712
 msgid "IP-Filtering"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2688
+#: src/muuli_wdr.cpp:2719
 msgid "Filter clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2690
+#: src/muuli_wdr.cpp:2721
 msgid "Enable filtering of the client IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2692
+#: src/muuli_wdr.cpp:2723
 msgid "Filter servers"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2694
+#: src/muuli_wdr.cpp:2725
 msgid "Enable filtering of the server IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2698
+#: src/muuli_wdr.cpp:2729
 msgid "Reload List"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2699
+#: src/muuli_wdr.cpp:2730
 msgid "Reload the list of IPs to filter from the file ~/.aMule/ipfilter.dat"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2705
+#: src/muuli_wdr.cpp:2736
 msgid "URL:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2709 src/muuli_wdr.cpp:2902
+#: src/muuli_wdr.cpp:2740 src/muuli_wdr.cpp:2933
 msgid "Update now"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2712
+#: src/muuli_wdr.cpp:2743
 msgid "Auto-update ipfilter at startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2716
+#: src/muuli_wdr.cpp:2747
 msgid "Filtering Level:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2722
+#: src/muuli_wdr.cpp:2753
 msgid "Always filter LAN IPs"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2725
+#: src/muuli_wdr.cpp:2756
 msgid "Paranoid handling of non-matching IPs"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2727
+#: src/muuli_wdr.cpp:2758
 msgid "Rejects a packet when its source IP differs from the IP the client claims (an anti-spoofing check). Disable only if it causes connection problems."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2729
+#: src/muuli_wdr.cpp:2760
 msgid "Use system-wide ipfilter.dat if available"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2730
+#: src/muuli_wdr.cpp:2761
 msgid "If there's no local ipfilter.dat found, allow usage of a system-wide ipfilter file."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2747
+#: src/muuli_wdr.cpp:2778
 msgid "Enable Online-Signature"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2749
+#: src/muuli_wdr.cpp:2780
 msgid "Enables the writing of the OS file, which can be used by external apps to create signatures and the like."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2753
+#: src/muuli_wdr.cpp:2784
 msgid "Update Frequency (Secs):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2756
+#: src/muuli_wdr.cpp:2787
 msgid "Change the frequency (in seconds) of Online Signature updates."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2764
+#: src/muuli_wdr.cpp:2795
 msgid "Save online signature file in: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:2770
+#: src/muuli_wdr.cpp:2801
 msgid "Click here to select the directory containing the the Online Signature files."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2803
+#: src/muuli_wdr.cpp:2834
 msgid "Show country flags for clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2804
+#: src/muuli_wdr.cpp:2835
 msgid "Render the country flag column in the transfers, queue and search views. Requires a valid MMDB GeoIP database (see below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2809
+#: src/muuli_wdr.cpp:2840
 msgid "Database"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2825
+#: src/muuli_wdr.cpp:2856
 #, fuzzy
 msgid "Source:"
 msgstr "Източници"
 
-#: src/muuli_wdr.cpp:2828
+#: src/muuli_wdr.cpp:2859
 msgid "DB-IP (free, no account)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2829
+#: src/muuli_wdr.cpp:2860
 msgid "MaxMind GeoLite2 (free, account required)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2830
+#: src/muuli_wdr.cpp:2861
 msgid "Custom URL"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2833
+#: src/muuli_wdr.cpp:2864
 msgid "Choose which provider supplies the GeoIP MMDB database. DB-IP is the default - no account required. MaxMind requires a free account + license key. Use Custom URL to point at any other MMDB host (e.g. a local mirror)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2850
+#: src/muuli_wdr.cpp:2881
 msgid ""
 "No configuration required.\n"
 "\n"
@@ -4778,11 +4805,11 @@ msgid ""
 "License: Creative Commons BY 4.0 - https://creativecommons.org/licenses/by/4.0/"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2863
+#: src/muuli_wdr.cpp:2894
 msgid "License key:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2869
+#: src/muuli_wdr.cpp:2900
 msgid ""
 "Sign up for a free MaxMind account, then generate a License Key:\n"
 "https://www.maxmind.com/en/geolite2/signup\n"
@@ -4792,229 +4819,229 @@ msgid ""
 "Requires attribution and account registration; refresh at least every 30 days."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2884
+#: src/muuli_wdr.cpp:2915
 #, fuzzy
 msgid "Download URL:"
 msgstr "Изтегляне"
 
-#: src/muuli_wdr.cpp:2890
+#: src/muuli_wdr.cpp:2921
 msgid ""
 "Must point to an .mmdb file or a .gz / .tar.gz containing one.\n"
 "URL may include credentials (https://user:pass@host/...).\n"
 "License and attribution terms are set by the upstream URL - you are responsible."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2903
+#: src/muuli_wdr.cpp:2934
 msgid "Download the GeoIP database from the selected source."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2905
+#: src/muuli_wdr.cpp:2936
 msgid "Auto-update on startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2906
+#: src/muuli_wdr.cpp:2937
 msgid "Re-download the GeoIP database from the selected source every time aMule starts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2929
+#: src/muuli_wdr.cpp:2960
 msgid "Filter incoming messages (except current chat):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2931
+#: src/muuli_wdr.cpp:2962
 msgid "Filter all messages"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2933
+#: src/muuli_wdr.cpp:2964
 msgid "Filter messages from people not on your friend list"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2935
+#: src/muuli_wdr.cpp:2966
 msgid "Filter messages from unknown clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2937
+#: src/muuli_wdr.cpp:2968
 msgid "Filter messages containing (use ',' as separator):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2940 src/muuli_wdr.cpp:2951
+#: src/muuli_wdr.cpp:2971 src/muuli_wdr.cpp:2982
 msgid "add here the words amule should filter and block messages including it"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2942
+#: src/muuli_wdr.cpp:2973
 msgid "Show received messages in the log"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2945
+#: src/muuli_wdr.cpp:2976
 msgid "Comments"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2948
+#: src/muuli_wdr.cpp:2979
 msgid "Filter comments containing (use ',' as separator):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2973
+#: src/muuli_wdr.cpp:3004
 msgid "Enable Proxy"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2974
+#: src/muuli_wdr.cpp:3005
 msgid "Enable/disable proxy support"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2977
+#: src/muuli_wdr.cpp:3008
 msgid "Proxy type:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2988
+#: src/muuli_wdr.cpp:3019
 msgid "Proxy host:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2991
+#: src/muuli_wdr.cpp:3022
 msgid "The proxy host name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2993
+#: src/muuli_wdr.cpp:3024
 msgid "Proxy port:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2996
+#: src/muuli_wdr.cpp:3027
 msgid "The proxy port"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2998
+#: src/muuli_wdr.cpp:3029
 msgid "Enable authentication"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2999
+#: src/muuli_wdr.cpp:3030
 msgid "Enable/disable username/password authentication"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3002
+#: src/muuli_wdr.cpp:3033
 msgid "Username: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:3005
+#: src/muuli_wdr.cpp:3036
 msgid "The username to use to connect to the proxy"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3007
+#: src/muuli_wdr.cpp:3038
 msgid "Password:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3010
+#: src/muuli_wdr.cpp:3041
 msgid "The password to use to connect to the proxy"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3029
+#: src/muuli_wdr.cpp:3060
 msgid "Connect to:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3038
+#: src/muuli_wdr.cpp:3069
 msgid "Login to remote amule"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3043
+#: src/muuli_wdr.cpp:3074
 msgid "User name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3054
+#: src/muuli_wdr.cpp:3085
 msgid "Remember those settings"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3057
+#: src/muuli_wdr.cpp:3088
 msgid "Force ZLIB compression"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3081
+#: src/muuli_wdr.cpp:3112
 msgid "Enable Verbose Debug-Logging."
 msgstr ""
 
-#: src/muuli_wdr.cpp:3083
+#: src/muuli_wdr.cpp:3114
 msgid "Only to Logfile"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3085
+#: src/muuli_wdr.cpp:3116
 msgid "Message Categories:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3109 src/PartFileConvertDlg.cpp:160
+#: src/muuli_wdr.cpp:3140 src/PartFileConvertDlg.cpp:160
 msgid "Waiting..."
 msgstr "Изчакване"
 
-#: src/muuli_wdr.cpp:3129
+#: src/muuli_wdr.cpp:3160
 msgid "Add imports"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3132
+#: src/muuli_wdr.cpp:3163
 msgid "Retry selected"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3134
+#: src/muuli_wdr.cpp:3165
 msgid "Remove selected"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3197
+#: src/muuli_wdr.cpp:3228
 msgid "Event Types"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3216
+#: src/muuli_wdr.cpp:3247
 msgid "Statistics and queued clients for selected file(s) : Session / All time"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3240
+#: src/muuli_wdr.cpp:3271
 #, fuzzy
 msgid "Active Uploads"
 msgstr "Активни качвания: %i"
 
-#: src/muuli_wdr.cpp:3254
+#: src/muuli_wdr.cpp:3285
 #, fuzzy
 msgid "Percent of total files"
 msgstr "Общо файлове"
 
-#: src/muuli_wdr.cpp:3306
+#: src/muuli_wdr.cpp:3337
 #, fuzzy
 msgid "Show Clients for"
 msgstr "Клиенти"
 
-#: src/muuli_wdr.cpp:3308
+#: src/muuli_wdr.cpp:3339
 msgid "All files"
 msgstr "Всички файлове"
 
-#: src/muuli_wdr.cpp:3311
+#: src/muuli_wdr.cpp:3342
 #, fuzzy
 msgid "Selected files"
 msgstr "Избор на филтър"
 
-#: src/muuli_wdr.cpp:3314
+#: src/muuli_wdr.cpp:3345
 #, fuzzy
 msgid "Active uploads only"
 msgstr "Активни качвания: %i"
 
-#: src/muuli_wdr.cpp:3321
+#: src/muuli_wdr.cpp:3352
 #, fuzzy
 msgid "Reload:"
 msgstr "Качване"
 
-#: src/muuli_wdr.cpp:3325
+#: src/muuli_wdr.cpp:3356
 msgid "Reload your shared files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3388
+#: src/muuli_wdr.cpp:3419
 msgid "Send"
 msgstr "Изпраща"
 
-#: src/muuli_wdr.cpp:3389
+#: src/muuli_wdr.cpp:3420
 msgid "Sends the specified message."
 msgstr ""
 
-#: src/muuli_wdr.cpp:3393
+#: src/muuli_wdr.cpp:3424
 msgid "Close this chat-session."
 msgstr ""
 
-#: src/muuli_wdr.cpp:3416
+#: src/muuli_wdr.cpp:3447
 msgid "Connect to any server and/or Kad"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3422 src/SharedFilesCtrl.cpp:142 src/Statistics.cpp:941
+#: src/muuli_wdr.cpp:3453 src/SharedFilesCtrl.cpp:142 src/Statistics.cpp:941
 msgid "Shared Files"
 msgstr ""
 
@@ -5374,263 +5401,263 @@ msgstr ""
 msgid "ERROR: Failed to open partfile '%s'"
 msgstr ""
 
-#: src/Preferences.cpp:674
+#: src/Preferences.cpp:701
 msgid "System default"
 msgstr ""
 
-#: src/Preferences.cpp:675
+#: src/Preferences.cpp:702
 msgid "Albanian"
 msgstr "албанец"
 
-#: src/Preferences.cpp:676
+#: src/Preferences.cpp:703
 msgid "Arabic"
 msgstr "арабски"
 
-#: src/Preferences.cpp:677
+#: src/Preferences.cpp:704
 msgid "Asturian"
 msgstr "Астурия"
 
-#: src/Preferences.cpp:678
+#: src/Preferences.cpp:705
 msgid "Basque"
 msgstr "баска"
 
-#: src/Preferences.cpp:679
+#: src/Preferences.cpp:706
 msgid "Bulgarian"
 msgstr "български"
 
-#: src/Preferences.cpp:680
+#: src/Preferences.cpp:707
 msgid "Catalan"
 msgstr "Каталунски"
 
-#: src/Preferences.cpp:681
+#: src/Preferences.cpp:708
 msgid "Chinese (Simplified)"
 msgstr "Китайски (опростен)"
 
-#: src/Preferences.cpp:682
+#: src/Preferences.cpp:709
 msgid "Chinese (Traditional)"
 msgstr "Китайски (традиционен)"
 
-#: src/Preferences.cpp:683
+#: src/Preferences.cpp:710
 msgid "Croatian"
 msgstr "хърватски"
 
-#: src/Preferences.cpp:684
+#: src/Preferences.cpp:711
 msgid "Czech"
 msgstr "чешки"
 
-#: src/Preferences.cpp:685
+#: src/Preferences.cpp:712
 msgid "Danish"
 msgstr "датски"
 
-#: src/Preferences.cpp:686
+#: src/Preferences.cpp:713
 msgid "Dutch"
 msgstr "холандски"
 
-#: src/Preferences.cpp:687
+#: src/Preferences.cpp:714
 msgid "English (U.K.)"
 msgstr ""
 
-#: src/Preferences.cpp:688
+#: src/Preferences.cpp:715
 msgid "English (U.S.)"
 msgstr ""
 
-#: src/Preferences.cpp:689
+#: src/Preferences.cpp:716
 msgid "Estonian"
 msgstr "естонски"
 
-#: src/Preferences.cpp:690
+#: src/Preferences.cpp:717
 msgid "Finnish"
 msgstr "фински"
 
-#: src/Preferences.cpp:691
+#: src/Preferences.cpp:718
 msgid "French"
 msgstr "Френски"
 
-#: src/Preferences.cpp:692
+#: src/Preferences.cpp:719
 msgid "Galician"
 msgstr "галисийски"
 
-#: src/Preferences.cpp:693
+#: src/Preferences.cpp:720
 msgid "German"
 msgstr "Немски"
 
-#: src/Preferences.cpp:694
+#: src/Preferences.cpp:721
 msgid "Greek"
 msgstr "Гръцки"
 
-#: src/Preferences.cpp:695
+#: src/Preferences.cpp:722
 msgid "Hebrew"
 msgstr "иврит"
 
-#: src/Preferences.cpp:696
+#: src/Preferences.cpp:723
 msgid "Hungarian"
 msgstr "унгарски"
 
-#: src/Preferences.cpp:697
+#: src/Preferences.cpp:724
 msgid "Italian"
 msgstr "Италиански"
 
-#: src/Preferences.cpp:698
+#: src/Preferences.cpp:725
 msgid "Japanese"
 msgstr "японски"
 
-#: src/Preferences.cpp:699
+#: src/Preferences.cpp:726
 msgid "Korean"
 msgstr "корейски"
 
-#: src/Preferences.cpp:700
+#: src/Preferences.cpp:727
 msgid "Latvian"
 msgstr ""
 
-#: src/Preferences.cpp:701
+#: src/Preferences.cpp:728
 msgid "Lithuanian"
 msgstr "литовски"
 
-#: src/Preferences.cpp:702
+#: src/Preferences.cpp:729
 msgid "Norwegian (Nynorsk)"
 msgstr "норвежки (Съвременен)"
 
-#: src/Preferences.cpp:703
+#: src/Preferences.cpp:730
 msgid "Polish"
 msgstr "полски"
 
-#: src/Preferences.cpp:704
+#: src/Preferences.cpp:731
 msgid "Portuguese"
 msgstr "португалски"
 
-#: src/Preferences.cpp:705
+#: src/Preferences.cpp:732
 msgid "Portuguese (Brazilian)"
 msgstr "португалски (бразилски)"
 
-#: src/Preferences.cpp:706
+#: src/Preferences.cpp:733
 msgid "Romanian"
 msgstr "румънски"
 
-#: src/Preferences.cpp:707
+#: src/Preferences.cpp:734
 msgid "Russian"
 msgstr "Руски"
 
-#: src/Preferences.cpp:708
+#: src/Preferences.cpp:735
 msgid "Slovenian"
 msgstr "словенски"
 
-#: src/Preferences.cpp:709
+#: src/Preferences.cpp:736
 msgid "Spanish"
 msgstr "Spanish"
 
-#: src/Preferences.cpp:710
+#: src/Preferences.cpp:737
 msgid "Swedish"
 msgstr "шведски"
 
-#: src/Preferences.cpp:711
+#: src/Preferences.cpp:738
 msgid "Turkish"
 msgstr "Турски"
 
-#: src/Preferences.cpp:712
+#: src/Preferences.cpp:739
 msgid "Ukrainian"
 msgstr "украински"
 
-#: src/Preferences.cpp:815
+#: src/Preferences.cpp:842
 msgid "Change Language"
 msgstr "Смени езика"
 
-#: src/Preferences.cpp:879
+#: src/Preferences.cpp:906
 msgid "There are no translations installed for aMule"
 msgstr ""
 
-#: src/Preferences.cpp:880
+#: src/Preferences.cpp:907
 msgid "No languages available"
 msgstr ""
 
-#: src/Preferences.cpp:1011
+#: src/Preferences.cpp:1038
 msgid "no options available"
 msgstr ""
 
-#: src/Preferences.cpp:2182
+#: src/Preferences.cpp:2227
 msgid "Invalid category found, skipping"
 msgstr ""
 
-#: src/Preferences.cpp:2351
+#: src/Preferences.cpp:2396
 msgid "TCP port can't be higher than 65532 due to server UDP socket being TCP+3"
 msgstr ""
 
-#: src/Preferences.cpp:2352
+#: src/Preferences.cpp:2397
 #, c-format
 msgid "Default port will be used (%d)"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:298 src/Statistics.cpp:866
+#: src/PrefsUnifiedDlg.cpp:300 src/Statistics.cpp:866
 msgid "Connection"
 msgstr "Връзка"
 
-#: src/PrefsUnifiedDlg.cpp:299 src/SearchListCtrl.cpp:117
+#: src/PrefsUnifiedDlg.cpp:301 src/SearchListCtrl.cpp:117
 msgid "Directories"
 msgstr "Директории"
 
-#: src/PrefsUnifiedDlg.cpp:300 src/Statistics.cpp:917
+#: src/PrefsUnifiedDlg.cpp:302 src/Statistics.cpp:917
 msgid "Servers"
 msgstr "Сървъри"
 
-#: src/PrefsUnifiedDlg.cpp:301 src/ServerListCtrl.cpp:96
+#: src/PrefsUnifiedDlg.cpp:303 src/ServerListCtrl.cpp:96
 msgid "Files"
 msgstr "Файлове"
 
-#: src/PrefsUnifiedDlg.cpp:302
+#: src/PrefsUnifiedDlg.cpp:304
 msgid "Security"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:303
+#: src/PrefsUnifiedDlg.cpp:305
 msgid "Interface"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:310
+#: src/PrefsUnifiedDlg.cpp:312
 msgid "IP2Country"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:313
+#: src/PrefsUnifiedDlg.cpp:315
 msgid "Proxy"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:314
+#: src/PrefsUnifiedDlg.cpp:316
 msgid "Filters"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:315
+#: src/PrefsUnifiedDlg.cpp:317
 msgid "Remote Controls"
 msgstr "Дистанционни управления"
 
-#: src/PrefsUnifiedDlg.cpp:316
+#: src/PrefsUnifiedDlg.cpp:318
 msgid "Online Signature"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:317
+#: src/PrefsUnifiedDlg.cpp:319
 msgid "Advanced"
 msgstr "напреднал"
 
-#: src/PrefsUnifiedDlg.cpp:318
+#: src/PrefsUnifiedDlg.cpp:320
 msgid "Events"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:321
+#: src/PrefsUnifiedDlg.cpp:323
 msgid "Debugging"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:451
+#: src/PrefsUnifiedDlg.cpp:453
 msgid ""
 "The following variables will be substituted:\n"
 "    %PARTFILE - full path to the file\n"
 "    %PARTNAME - file name only"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:472
+#: src/PrefsUnifiedDlg.cpp:474
 msgid "Tray icon support requires libayatana-appindicator3 at compile time."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:488
+#: src/PrefsUnifiedDlg.cpp:490
 msgid "Not available on Wayland: the protocol does not report when a window is minimized, so this option cannot intercept the system minimize button. Workaround: launch aMule with `GDK_BACKEND=x11` to use XWayland instead."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:534
+#: src/PrefsUnifiedDlg.cpp:536
 msgid ""
 "Do not change these setting unless you know\n"
 "what you are doing, otherwise you can easily\n"
@@ -5640,241 +5667,255 @@ msgid ""
 "these settings."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:645
+#: src/PrefsUnifiedDlg.cpp:647
 #, c-format
 msgid "Failed to connect Cfg to widget with the ID %d and key %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:693
+#: src/PrefsUnifiedDlg.cpp:695
 #, c-format
 msgid "Failed to transfer data from Cfg to Widget with the ID %d and key %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:799
+#: src/PrefsUnifiedDlg.cpp:801
 msgid "The type of proxy you are connecting to"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1003
+#: src/PrefsUnifiedDlg.cpp:1020
 #, c-format
 msgid "Failed to transfer data from Widget to Cfg with the ID %d and key %s"
 msgstr ""
 
 #: src/PrefsUnifiedDlg.cpp:1103
+#, fuzzy
+msgid "No password set."
+msgstr "парола"
+
+#: src/PrefsUnifiedDlg.cpp:1132
+msgid "Guest access needs a password. Type one in the guest password field, or untick Enable guest access."
+msgstr ""
+
+#: src/PrefsUnifiedDlg.cpp:1144
 msgid ""
 "aMule must be restarted to enable these changes:\n"
 "\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1110
+#: src/PrefsUnifiedDlg.cpp:1151
 msgid "- TCP port changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1115
+#: src/PrefsUnifiedDlg.cpp:1156
 msgid "- UDP port changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1120
+#: src/PrefsUnifiedDlg.cpp:1161
 msgid "- Network interface binding changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1125
+#: src/PrefsUnifiedDlg.cpp:1166
 msgid "- External connect port changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1129
+#: src/PrefsUnifiedDlg.cpp:1170
 msgid "- External connect acceptance changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1133
+#: src/PrefsUnifiedDlg.cpp:1174
 msgid "- External connect interface changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1137
+#: src/PrefsUnifiedDlg.cpp:1178
 msgid "- Protocol obfuscation support changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1151
+#: src/PrefsUnifiedDlg.cpp:1193
 #, fuzzy
 msgid "- amuleapi settings changed.\n"
 msgstr "- Език променило.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1160
+#: src/PrefsUnifiedDlg.cpp:1202
 msgid ""
 "Your Auto-update server list is empty.\n"
 "'Auto-update server list at startup' will be disabled."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1171
+#: src/PrefsUnifiedDlg.cpp:1213
 msgid ""
 "You have enabled external connections but have not specified a password.\n"
 "External connections cannot be enabled unless a valid password is specified."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1202
+#: src/PrefsUnifiedDlg.cpp:1246
+#, c-format
+msgid "The amuleapi password could not be saved: %s"
+msgstr ""
+
+#: src/PrefsUnifiedDlg.cpp:1276
 msgid "- Language changed.\n"
 msgstr "- Език променило.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1207
+#: src/PrefsUnifiedDlg.cpp:1281
 msgid "- Temp folder changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1212
+#: src/PrefsUnifiedDlg.cpp:1286
 msgid "- ED2K network enabled.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1245
+#: src/PrefsUnifiedDlg.cpp:1319
 msgid "The shared-file exclusion pattern is not a valid regular expression. The filter has been left disabled."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1247 src/PrefsUnifiedDlg.cpp:1841
+#: src/PrefsUnifiedDlg.cpp:1321 src/PrefsUnifiedDlg.cpp:1921
 msgid "Invalid regular expression"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1324
+#: src/PrefsUnifiedDlg.cpp:1398
 msgid ""
 "Both eD2k and Kad network are disabled.\n"
 "You won't be able to connect until you enable at least one of them."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1329
+#: src/PrefsUnifiedDlg.cpp:1403
 msgid ""
 "Kad will not start if your UDP port is disabled.\n"
 "Enable UDP port or disable Kad."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1385
+#: src/PrefsUnifiedDlg.cpp:1459
 msgid ""
 "\n"
 "You MUST restart aMule now.\n"
 "If you do not restart now, don't complain if anything bad happens.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1450
+#: src/PrefsUnifiedDlg.cpp:1524
 msgid "Could not register aMule for autostart at login. The autostart store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1452
+#: src/PrefsUnifiedDlg.cpp:1526
 msgid "Could not remove the autostart-at-login entry."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1453
+#: src/PrefsUnifiedDlg.cpp:1527
 #, fuzzy
 msgid "Autostart"
 msgstr "Автоматично"
 
-#: src/PrefsUnifiedDlg.cpp:1468
+#: src/PrefsUnifiedDlg.cpp:1542
 msgid "Register file type"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1468
+#: src/PrefsUnifiedDlg.cpp:1542
 msgid "Register URL handler"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1476
+#: src/PrefsUnifiedDlg.cpp:1550
 #, c-format
 msgid "aMule only handles eD2k-compatible magnets. If you replace the current magnet handler (%s), BitTorrent magnet links will stop working - aMule cannot download BitTorrent content. Continue?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1481
+#: src/PrefsUnifiedDlg.cpp:1555
 #, c-format
 msgid "Another application currently opens .emulecollection files (%s). Replace it with aMule?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1486
+#: src/PrefsUnifiedDlg.cpp:1560
 #, c-format
 msgid "Another application is currently the default handler for these links (%s). Replace it with aMule?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1511
+#: src/PrefsUnifiedDlg.cpp:1585
 msgid "Could not register aMule for .emulecollection files. The registration store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1513
+#: src/PrefsUnifiedDlg.cpp:1587
 #, fuzzy
 msgid "Could not remove the file type registration."
 msgstr "Вие вече опитвате да свалите файла %s"
 
-#: src/PrefsUnifiedDlg.cpp:1515
+#: src/PrefsUnifiedDlg.cpp:1589
 msgid "Could not register aMule as the URL handler. The registration store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1517
+#: src/PrefsUnifiedDlg.cpp:1591
 msgid "Could not remove the URL handler registration."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1587 src/PrefsUnifiedDlg.cpp:1614
+#: src/PrefsUnifiedDlg.cpp:1661 src/PrefsUnifiedDlg.cpp:1688
 msgid "The web server and aMule API require external connections to be enabled."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1597
+#: src/PrefsUnifiedDlg.cpp:1671
 msgid "The aMule web server is deprecated. Consider running the aMule API instead."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1655
+#: src/PrefsUnifiedDlg.cpp:1735
 msgid ""
 "Your Auto-update servers list is in blank.\n"
 "Please fill in at least one URL to point to a valid server.met file.\n"
 "Click on the button \"List\" by this checkbox to enter an URL."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1796
+#: src/PrefsUnifiedDlg.cpp:1876
 msgid "Temporary files"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1801
+#: src/PrefsUnifiedDlg.cpp:1881
 msgid "Incoming files"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1806
+#: src/PrefsUnifiedDlg.cpp:1886
 msgid "Online Signatures"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1819
+#: src/PrefsUnifiedDlg.cpp:1899
 #, c-format
 msgid "Choose a folder for %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1843
+#: src/PrefsUnifiedDlg.cpp:1923
 #, fuzzy, c-format
 msgid "Would exclude %u of %u shared file"
 msgid_plural "Would exclude %u of %u shared files"
 msgstr[0] "Известни са %i споделени файлове"
 msgstr[1] "Известни са %i споделени файлове"
 
-#: src/PrefsUnifiedDlg.cpp:1860
+#: src/PrefsUnifiedDlg.cpp:1940
 msgid "Browse for videoplayer"
 msgstr "Търсене на видео плеър"
 
-#: src/PrefsUnifiedDlg.cpp:1864
+#: src/PrefsUnifiedDlg.cpp:1944
 msgid "Select browser"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1868
+#: src/PrefsUnifiedDlg.cpp:1948
 msgid "Select ffprobe binary"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1874
+#: src/PrefsUnifiedDlg.cpp:1954
 #, c-format
 msgid "Executable%s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1908
+#: src/PrefsUnifiedDlg.cpp:1988
 msgid "ffprobe not found on PATH or in the standard install locations. Install ffmpeg (which ships ffprobe) or use Browse to pick a binary manually."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1920
+#: src/PrefsUnifiedDlg.cpp:2000
 msgid "Reset the settings on this page to their default values?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1921
+#: src/PrefsUnifiedDlg.cpp:2001
 msgid "Reset to defaults"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1948
+#: src/PrefsUnifiedDlg.cpp:2028
 msgid "Edit server list"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1949
+#: src/PrefsUnifiedDlg.cpp:2029
 msgid ""
 "Add here URL's to download server.met files.\n"
 "Only one url on each line."
@@ -5882,152 +5923,152 @@ msgstr ""
 "Тук добавете линкове за сваляне на .met файлове.\n"
 "Само по един URL на ред."
 
-#: src/PrefsUnifiedDlg.cpp:2004
+#: src/PrefsUnifiedDlg.cpp:2084
 msgid "IP2Country update failed"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2149 src/PrefsUnifiedDlg.cpp:2180
+#: src/PrefsUnifiedDlg.cpp:2229 src/PrefsUnifiedDlg.cpp:2260
 msgid "Data by MaxMind GeoLite2"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2151 src/PrefsUnifiedDlg.cpp:2182
+#: src/PrefsUnifiedDlg.cpp:2231 src/PrefsUnifiedDlg.cpp:2262
 msgid "Custom source"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2153 src/PrefsUnifiedDlg.cpp:2184
+#: src/PrefsUnifiedDlg.cpp:2233 src/PrefsUnifiedDlg.cpp:2264
 msgid "Data by DB-IP.com"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2204
+#: src/PrefsUnifiedDlg.cpp:2284
 #, c-format
 msgid "Status: Loaded%s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2206
+#: src/PrefsUnifiedDlg.cpp:2286
 #, c-format
 msgid "Status: Loaded%s - %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2210
+#: src/PrefsUnifiedDlg.cpp:2290
 msgid "Status: Failed to load - click 'Update now' to refresh."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2212
+#: src/PrefsUnifiedDlg.cpp:2292
 msgid "Status: Not found - click 'Update now' to download."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2270 src/PrefsUnifiedDlg.cpp:2294
+#: src/PrefsUnifiedDlg.cpp:2350 src/PrefsUnifiedDlg.cpp:2374
 #, c-format
 msgid "Update delay: %d second"
 msgid_plural "Update delay: %d seconds"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/PrefsUnifiedDlg.cpp:2278
+#: src/PrefsUnifiedDlg.cpp:2358
 #, c-format
 msgid "Time for average graph: %d minute"
 msgid_plural "Time for average graph: %d minutes"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/PrefsUnifiedDlg.cpp:2287
+#: src/PrefsUnifiedDlg.cpp:2367
 #, c-format
 msgid "Connections Graph Scale: %d"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2302
+#: src/PrefsUnifiedDlg.cpp:2382
 #, c-format
 msgid "File Buffer Size: %d byte"
 msgid_plural "File Buffer Size: %d bytes"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/PrefsUnifiedDlg.cpp:2312
+#: src/PrefsUnifiedDlg.cpp:2392
 #, c-format
 msgid "Upload Queue Size: %d client"
 msgid_plural "Upload Queue Size: %d clients"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/PrefsUnifiedDlg.cpp:2322
+#: src/PrefsUnifiedDlg.cpp:2402
 #, c-format
 msgid "Server connection refresh interval: %d minute"
 msgid_plural "Server connection refresh interval: %d minutes"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/PrefsUnifiedDlg.cpp:2327
+#: src/PrefsUnifiedDlg.cpp:2407
 msgid "Server connection refresh interval: Disabled"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2371
+#: src/PrefsUnifiedDlg.cpp:2451
 #, fuzzy
 msgid "disabled"
 msgstr "деактивиране"
 
-#: src/PrefsUnifiedDlg.cpp:2397
+#: src/PrefsUnifiedDlg.cpp:2477
 #, c-format
 msgid "Execute command on '%s' event"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2404
+#: src/PrefsUnifiedDlg.cpp:2484
 msgid "Enable command execution on core"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2416
+#: src/PrefsUnifiedDlg.cpp:2496
 msgid "Core command:"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2432
+#: src/PrefsUnifiedDlg.cpp:2512
 msgid "Enable command execution on GUI"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2444
+#: src/PrefsUnifiedDlg.cpp:2524
 msgid "GUI command:"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2460
+#: src/PrefsUnifiedDlg.cpp:2540
 msgid "The following variables will be replaced:"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2628
+#: src/PrefsUnifiedDlg.cpp:2708
 msgid ""
 "The following folders look like system or sensitive locations:\n"
 "\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2633
+#: src/PrefsUnifiedDlg.cpp:2713
 msgid "Sharing them recursively will publish every file underneath on the eD2k/Kad networks. Do you really want to do this?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2636
+#: src/PrefsUnifiedDlg.cpp:2716
 msgid "Confirm shared folders"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2664
+#: src/PrefsUnifiedDlg.cpp:2744
 #, fuzzy
 msgid "Reloading shared files..."
 msgstr "Известни са %i споделени файлове"
 
-#: src/PrefsUnifiedDlg.cpp:2665
+#: src/PrefsUnifiedDlg.cpp:2745
 msgid "Scanning for subdirectories..."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2666
+#: src/PrefsUnifiedDlg.cpp:2746
 msgid "Updating shared folders"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2693
+#: src/PrefsUnifiedDlg.cpp:2773
 #, c-format
 msgid "Scanned %u directories..."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2743
+#: src/PrefsUnifiedDlg.cpp:2823
 #, c-format
 msgid "Reloading shared files: %u files scanned"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2793
+#: src/PrefsUnifiedDlg.cpp:2873
 #, fuzzy
 msgid "Shared folder"
 msgstr "Споделени файлове (%i)"

--- a/po/bn.po
+++ b/po/bn.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-28 10:19+0200\n"
+"POT-Creation-Date: 2026-07-28 12:17+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: none\n"
@@ -188,152 +188,152 @@ msgstr ""
 msgid "WARNING: You can't add yourself as a source for an eD2k link while having a lowid."
 msgstr ""
 
-#: src/amule.cpp:300
+#: src/amule.cpp:301
 msgid "Now, exiting main app..."
 msgstr ""
 
-#: src/amule.cpp:330
+#: src/amule.cpp:331
 #, c-format
 msgid "Terminating amuleweb instance with pid '%d' ... "
 msgstr ""
 
-#: src/amule.cpp:334
+#: src/amule.cpp:335
 #, c-format
 msgid "Killing amuleweb instance with pid '%d' ... "
 msgstr ""
 
-#: src/amule.cpp:336 src/amule.cpp:349 src/ClientRef.cpp:180
+#: src/amule.cpp:337 src/amule.cpp:350 src/ClientRef.cpp:180
 #: src/SearchDlg.cpp:1041 src/ServerListCtrl.cpp:98
 msgid "Failed"
 msgstr ""
 
-#: src/amule.cpp:343
+#: src/amule.cpp:344
 #, c-format
 msgid "Terminating amuleapi instance with pid '%d' ... "
 msgstr ""
 
-#: src/amule.cpp:347
+#: src/amule.cpp:348
 #, c-format
 msgid "Killing amuleapi instance with pid '%d' ... "
 msgstr ""
 
-#: src/amule.cpp:355
+#: src/amule.cpp:356
 msgid "aMule OnExit: Terminating core."
 msgstr ""
 
-#: src/amule.cpp:466
+#: src/amule.cpp:467
 msgid "aMule shutdown completed."
 msgstr ""
 
-#: src/amule.cpp:470
+#: src/amule.cpp:471
 msgid "Memory debug results for aMule exit:"
 msgstr ""
 
-#: src/amule.cpp:651
+#: src/amule.cpp:652
 #, c-format
 msgid "Binding aMule's peer-to-peer traffic to interface: %s (HTTP updates use the default route)"
 msgstr ""
 
-#: src/amule.cpp:655
+#: src/amule.cpp:656
 #, c-format
 msgid "Binding all network traffic to interface: %s"
 msgstr ""
 
-#: src/amule.cpp:659
+#: src/amule.cpp:660
 #, c-format
 msgid "WARNING: configured network interface '%s' was not found - traffic is NOT bound to it and may leave via the default route. Check the interface name in Preferences."
 msgstr ""
 
-#: src/amule.cpp:665
+#: src/amule.cpp:666
 #, c-format
 msgid "WARNING: binding to network interface '%s' requires elevated privileges and was NOT applied - traffic may leave via the default route. Grant the capability (e.g. 'sudo setcap cap_net_raw+ep' on the aMule binary) or run with sufficient privileges."
 msgstr ""
 
-#: src/amule.cpp:673
+#: src/amule.cpp:674
 #, c-format
 msgid "WARNING: could not bind to network interface '%s' - traffic may leave via the default route."
 msgstr ""
 
-#: src/amule.cpp:732
+#: src/amule.cpp:733
 msgid "Your locale has been changed to System Default due to a configuration change. Sorry."
 msgstr ""
 
-#: src/amule.cpp:734 src/amule.cpp:1581 src/CatDialog.cpp:128
+#: src/amule.cpp:735 src/amule.cpp:1589 src/CatDialog.cpp:128
 #: src/CatDialog.cpp:136 src/CatDialog.cpp:149 src/ServerList.cpp:366
 #: src/ServerListCtrl.cpp:152
 msgid "Info"
 msgstr ""
 
-#: src/amule.cpp:741
+#: src/amule.cpp:742
 msgid ""
 "\n"
 "EC configuration"
 msgstr ""
 
-#: src/amule.cpp:744
+#: src/amule.cpp:745
 msgid "Password set and external connections enabled."
 msgstr ""
 
-#: src/amule.cpp:754 src/KadDlg.cpp:176 src/KadDlg.cpp:185
-#: src/PrefsUnifiedDlg.cpp:1387 src/SharedFilesCtrl.cpp:476
+#: src/amule.cpp:755 src/KadDlg.cpp:176 src/KadDlg.cpp:185
+#: src/PrefsUnifiedDlg.cpp:1461 src/SharedFilesCtrl.cpp:476
 msgid "WARNING"
 msgstr ""
 
-#: src/amule.cpp:991
+#: src/amule.cpp:992
 msgid "Network bootstrap"
 msgstr ""
 
-#: src/amule.cpp:996
+#: src/amule.cpp:997
 msgid ""
 "aMule has detected missing network bootstrap files.\n"
 "Select which ones to download:"
 msgstr ""
 
-#: src/amule.cpp:1005 src/FirstRunWizard.cpp:411
+#: src/amule.cpp:1006 src/FirstRunWizard.cpp:411
 msgid "eD2k server list (server.met)"
 msgstr ""
 
-#: src/amule.cpp:1012 src/FirstRunWizard.cpp:416
+#: src/amule.cpp:1013 src/FirstRunWizard.cpp:416
 msgid "Kad bootstrap nodes (nodes.dat)"
 msgstr ""
 
-#: src/amule.cpp:1102
+#: src/amule.cpp:1103
 #, c-format
 msgid "web server running on pid %d"
 msgstr ""
 
-#: src/amule.cpp:1115
+#: src/amule.cpp:1116
 msgid "You requested to run web server on startup, but the amuleweb binary cannot be run. Please install the package containing aMule web server, or build aMule from source with -DBUILD_WEBSERVER=YES and install it."
 msgstr ""
 
-#: src/amule.cpp:1120 src/amule.cpp:1177 src/amule.cpp:1291 src/amule.cpp:1593
+#: src/amule.cpp:1121 src/amule.cpp:1185 src/amule.cpp:1299 src/amule.cpp:1601
 #: src/amule-remote-gui.cpp:603 src/amule-remote-gui.cpp:671
 #: src/amule-remote-gui.cpp:709 src/amule-remote-gui.cpp:1282
 #: src/amule-remote-gui.cpp:1345 src/amule-remote-gui.cpp:1372
-#: src/DownloadQueue.cpp:1481
+#: src/DownloadQueue.cpp:1481 src/PrefsUnifiedDlg.cpp:1247
 msgid "ERROR"
 msgstr ""
 
-#: src/amule.cpp:1166
+#: src/amule.cpp:1174
 #, c-format
 msgid "amuleapi running on pid %d"
 msgstr ""
 
-#: src/amule.cpp:1172
+#: src/amule.cpp:1180
 msgid "You requested to run amuleapi on startup, but the amuleapi binary cannot be run. Please install the package containing aMule's REST API server, or build aMule from source with -DBUILD_AMULEAPI=YES and install it."
 msgstr ""
 
-#: src/amule.cpp:1259
+#: src/amule.cpp:1267
 #, c-format
 msgid "Could not bind ports to the specified address: %s"
 msgstr ""
 
-#: src/amule.cpp:1283
+#: src/amule.cpp:1291
 #, c-format
 msgid "Port %u is not available. You will be LOWID\n"
 msgstr ""
 
-#: src/amule.cpp:1288
+#: src/amule.cpp:1296
 #, c-format
 msgid ""
 "Port %u is not available!\n"
@@ -343,184 +343,184 @@ msgid ""
 "Check your network to make sure the port is open for output and input."
 msgstr ""
 
-#: src/amule.cpp:1385
+#: src/amule.cpp:1393
 msgid "Failed to create OnlineSig File"
 msgstr ""
 
-#: src/amule.cpp:1393
+#: src/amule.cpp:1401
 msgid "Failed to create aMule OnlineSig File"
 msgstr ""
 
-#: src/amule.cpp:1556
+#: src/amule.cpp:1564
 msgid "The selected locale seems not to be installed on your box. (Note: I'll try to set it anyway)"
 msgstr ""
 
-#: src/amule.cpp:1566
+#: src/amule.cpp:1574
 #, c-format
 msgid "This is the first time you run aMule %s"
 msgstr ""
 
-#: src/amule.cpp:1569
+#: src/amule.cpp:1577
 msgid "This version is a testing version, updated daily, and\n"
 msgstr ""
 
-#: src/amule.cpp:1570
+#: src/amule.cpp:1578
 msgid "we give no warranty it won't break anything, burn your house,\n"
 msgstr ""
 
-#: src/amule.cpp:1571
+#: src/amule.cpp:1579
 msgid "or kill your dog. But it *should* be safe to use anyway.\n"
 msgstr ""
 
-#: src/amule.cpp:1576
+#: src/amule.cpp:1584
 msgid "More information, support and new releases can found at our homepage,\n"
 msgstr ""
 
-#: src/amule.cpp:1577
+#: src/amule.cpp:1585
 msgid "at https://amule-org.github.io, or in our IRC channel #aMule at irc.libera.chat.\n"
 msgstr ""
 
-#: src/amule.cpp:1579
+#: src/amule.cpp:1587
 msgid "Feel free to report any bugs to https://github.com/amule-org/amule/issues"
 msgstr ""
 
-#: src/amule.cpp:1591
+#: src/amule.cpp:1599
 msgid ""
 "The folder for Online Signature files you specified is INVALID!\n"
 " OnlineSignature will be DISABLED until you fix it on preferences."
 msgstr ""
 
-#: src/amule.cpp:1654
+#: src/amule.cpp:1662
 msgid "Server hostname notified"
 msgstr ""
 
-#: src/amule.cpp:2031
+#: src/amule.cpp:2039
 #, c-format
 msgid "Disk space preallocation for file '%s' failed: %s"
 msgstr ""
 
-#: src/amule.cpp:2160
+#: src/amule.cpp:2168
 msgid "ERROR: can't open logfile"
 msgstr ""
 
-#: src/amule.cpp:2164
+#: src/amule.cpp:2172
 msgid "WARNING: logfile is empty. Something is wrong."
 msgstr ""
 
-#: src/amule.cpp:2181
+#: src/amule.cpp:2189
 msgid "Log has been reset"
 msgstr ""
 
-#: src/amule.cpp:2205
+#: src/amule.cpp:2213
 #, c-format
 msgid "ServerMessage: %s"
 msgstr ""
 
-#: src/amule.cpp:2248 src/IP2Country.cpp:220 src/IPFilter.cpp:514
+#: src/amule.cpp:2256 src/IP2Country.cpp:220 src/IPFilter.cpp:514
 #: src/ServerList.cpp:875
 #, c-format
 msgid "Skipped download of %s, because requested file is not newer."
 msgstr ""
 
-#: src/amule.cpp:2251
+#: src/amule.cpp:2259
 msgid "Failed to download the nodes list."
 msgstr ""
 
-#: src/amule.cpp:2314
+#: src/amule.cpp:2322
 msgid "Failed to open the downloaded version check file"
 msgstr ""
 
-#: src/amule.cpp:2317 src/amule.cpp:2336
+#: src/amule.cpp:2325 src/amule.cpp:2344
 msgid "Corrupted version check file"
 msgstr ""
 
-#: src/amule.cpp:2359
+#: src/amule.cpp:2367
 msgid "You are using an outdated version of aMule!"
 msgstr ""
 
-#: src/amule.cpp:2361
+#: src/amule.cpp:2369
 #, c-format
 msgid "Your aMule version is %i.%i.%i and the latest version is %li.%li.%li"
 msgstr ""
 
-#: src/amule.cpp:2365
+#: src/amule.cpp:2373
 msgid "The latest version can always be found at https://github.com/amule-org/amule/releases/latest"
 msgstr ""
 
-#: src/amule.cpp:2368
+#: src/amule.cpp:2376
 #, c-format
 msgid "WARNING: Your aMuled version is outdated: %i.%i.%i < %li.%li.%li"
 msgstr ""
 
-#: src/amule.cpp:2374
+#: src/amule.cpp:2382
 msgid "Your copy of aMule is up to date."
 msgstr ""
 
-#: src/amule.cpp:2381
+#: src/amule.cpp:2389
 msgid "Failed to download the version check file"
 msgstr ""
 
-#: src/amule.cpp:2550 src/amule-remote-gui.cpp:1133
+#: src/amule.cpp:2558 src/amule-remote-gui.cpp:1133
 #, c-format
 msgid "Users: %s | Files: %s"
 msgstr ""
 
-#: src/amule.cpp:2551 src/amule-remote-gui.cpp:1134
+#: src/amule.cpp:2559 src/amule-remote-gui.cpp:1134
 #, c-format
 msgid "Users: E: %s K: %s | Files: E: %s K: %s"
 msgstr ""
 
-#: src/amule.cpp:2565 src/amule-remote-gui.cpp:1147
+#: src/amule.cpp:2573 src/amule-remote-gui.cpp:1147
 msgid "No networks selected"
 msgstr ""
 
-#: src/amule.cpp:2633 src/TextClient.cpp:903
+#: src/amule.cpp:2641 src/TextClient.cpp:903
 msgid "with LowID"
 msgstr ""
 
-#: src/amule.cpp:2633 src/TextClient.cpp:904
+#: src/amule.cpp:2641 src/TextClient.cpp:904
 msgid "with HighID"
 msgstr ""
 
-#: src/amule.cpp:2635
+#: src/amule.cpp:2643
 #, c-format
 msgid "Connected to %s %s"
 msgstr ""
 
-#: src/amule.cpp:2640
+#: src/amule.cpp:2648
 #, c-format
 msgid "Connecting to %s"
 msgstr ""
 
-#: src/amule.cpp:2642
+#: src/amule.cpp:2650
 msgid "Disconnected from eD2k"
 msgstr ""
 
-#: src/amule.cpp:2651
+#: src/amule.cpp:2659
 msgid "Kad started."
 msgstr ""
 
-#: src/amule.cpp:2653
+#: src/amule.cpp:2661
 msgid "Kad stopped."
 msgstr ""
 
-#: src/amule.cpp:2661
+#: src/amule.cpp:2669
 msgid "Connected to Kad (ok)"
 msgstr ""
 
-#: src/amule.cpp:2663
+#: src/amule.cpp:2671
 msgid "Connected to Kad (firewalled)"
 msgstr ""
 
-#: src/amule.cpp:2667
+#: src/amule.cpp:2675
 msgid "Disconnected from Kad"
 msgstr ""
 
-#: src/amule.cpp:2699
+#: src/amule.cpp:2707
 msgid "Kad network cannot be used if UDP port is disabled on preferences, not starting."
 msgstr ""
 
-#: src/amule.cpp:2703
+#: src/amule.cpp:2711
 msgid "Kad network disabled on preferences, not connecting."
 msgstr ""
 
@@ -564,36 +564,36 @@ msgid "FATAL ERROR: Failed to create Timer"
 msgstr ""
 
 #: src/amuleDlg.cpp:361 src/amuleDlg.cpp:1787 src/amuleDlg.cpp:2033
-#: src/muuli_wdr.cpp:1492 src/muuli_wdr.cpp:3418
+#: src/muuli_wdr.cpp:1492 src/muuli_wdr.cpp:3449
 msgid "Networks"
 msgstr ""
 
-#: src/amuleDlg.cpp:362 src/amuleDlg.cpp:1793 src/muuli_wdr.cpp:3419
+#: src/amuleDlg.cpp:362 src/amuleDlg.cpp:1793 src/muuli_wdr.cpp:3450
 msgid "Searches"
 msgstr ""
 
 #: src/amuleDlg.cpp:363 src/amuleDlg.cpp:1799 src/DownloadListCtrl.cpp:740
-#: src/muuli_wdr.cpp:392 src/muuli_wdr.cpp:1585 src/muuli_wdr.cpp:3420
+#: src/muuli_wdr.cpp:392 src/muuli_wdr.cpp:1585 src/muuli_wdr.cpp:3451
 #: src/Statistics.cpp:829
 msgid "Downloads"
 msgstr ""
 
-#: src/amuleDlg.cpp:364 src/amuleDlg.cpp:1805 src/muuli_wdr.cpp:3294
+#: src/amuleDlg.cpp:364 src/amuleDlg.cpp:1805 src/muuli_wdr.cpp:3325
 msgid "Shared files"
 msgstr ""
 
-#: src/amuleDlg.cpp:365 src/amuleDlg.cpp:1811 src/muuli_wdr.cpp:2926
-#: src/muuli_wdr.cpp:3376 src/muuli_wdr.cpp:3423
+#: src/amuleDlg.cpp:365 src/amuleDlg.cpp:1811 src/muuli_wdr.cpp:2957
+#: src/muuli_wdr.cpp:3407 src/muuli_wdr.cpp:3454
 msgid "Messages"
 msgstr ""
 
-#: src/amuleDlg.cpp:366 src/amuleDlg.cpp:1817 src/muuli_wdr.cpp:3424
-#: src/PrefsUnifiedDlg.cpp:312 src/Statistics.cpp:779 src/Statistics.cpp:1235
+#: src/amuleDlg.cpp:366 src/amuleDlg.cpp:1817 src/muuli_wdr.cpp:3455
+#: src/PrefsUnifiedDlg.cpp:314 src/Statistics.cpp:779 src/Statistics.cpp:1235
 msgid "Statistics"
 msgstr ""
 
-#: src/amuleDlg.cpp:368 src/amuleDlg.cpp:1824 src/muuli_wdr.cpp:3426
-#: src/PrefsUnifiedDlg.cpp:328 src/utils/wxCas/src/wxcasprefs.cpp:39
+#: src/amuleDlg.cpp:368 src/amuleDlg.cpp:1824 src/muuli_wdr.cpp:3457
+#: src/PrefsUnifiedDlg.cpp:330 src/utils/wxCas/src/wxcasprefs.cpp:39
 msgid "Preferences"
 msgstr ""
 
@@ -650,8 +650,8 @@ msgstr ""
 #: src/amuleDlg.cpp:1029 src/DownloadListCtrl.cpp:505
 #: src/DownloadListCtrl.cpp:749 src/FriendListCtrl.cpp:180
 #: src/muuli_wdr.cpp:731 src/muuli_wdr.cpp:782 src/muuli_wdr.cpp:846
-#: src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2231 src/muuli_wdr.cpp:2316
-#: src/muuli_wdr.cpp:3064 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
+#: src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2262 src/muuli_wdr.cpp:2347
+#: src/muuli_wdr.cpp:3095 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
 #: src/ServerListCtrl.cpp:606 src/TransferWnd.cpp:378
 #: src/utils/wxCas/src/wxcasprefs.cpp:235
 msgid "Cancel"
@@ -662,7 +662,7 @@ msgid "Stop the current connection attempts"
 msgstr ""
 
 #: src/amuleDlg.cpp:1035 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976
-#: src/muuli_wdr.cpp:2454
+#: src/muuli_wdr.cpp:2485
 msgid "Disconnect"
 msgstr ""
 
@@ -671,7 +671,7 @@ msgid "Disconnect from the currently connected networks"
 msgstr ""
 
 #: src/amuleDlg.cpp:1041 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979
-#: src/muuli_wdr.cpp:2609 src/muuli_wdr.cpp:3061 src/muuli_wdr.cpp:3416
+#: src/muuli_wdr.cpp:2640 src/muuli_wdr.cpp:3092 src/muuli_wdr.cpp:3447
 msgid "Connect"
 msgstr ""
 
@@ -725,7 +725,7 @@ msgstr ""
 msgid "Launch Command: "
 msgstr ""
 
-#: src/amuleDlg.cpp:1632 src/muuli_wdr.cpp:1978 src/Preferences.cpp:952
+#: src/amuleDlg.cpp:1632 src/muuli_wdr.cpp:1982 src/Preferences.cpp:979
 msgid "- default -"
 msgstr ""
 
@@ -739,48 +739,48 @@ msgstr ""
 msgid "WARNING: Unable to open skin file '%s' for read"
 msgstr ""
 
-#: src/amuleDlg.cpp:1791 src/muuli_wdr.cpp:3418
+#: src/amuleDlg.cpp:1791 src/muuli_wdr.cpp:3449
 msgid "Networks Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1797 src/muuli_wdr.cpp:3419
+#: src/amuleDlg.cpp:1797 src/muuli_wdr.cpp:3450
 msgid "Searches Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1803 src/muuli_wdr.cpp:3420
+#: src/amuleDlg.cpp:1803 src/muuli_wdr.cpp:3451
 msgid "Downloads Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1809 src/muuli_wdr.cpp:3422
+#: src/amuleDlg.cpp:1809 src/muuli_wdr.cpp:3453
 msgid "Shared Files Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1815 src/muuli_wdr.cpp:3423
+#: src/amuleDlg.cpp:1815 src/muuli_wdr.cpp:3454
 msgid "Messages Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1821 src/muuli_wdr.cpp:3424
+#: src/amuleDlg.cpp:1821 src/muuli_wdr.cpp:3455
 msgid "Statistics Graph Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1828 src/muuli_wdr.cpp:3426
+#: src/amuleDlg.cpp:1828 src/muuli_wdr.cpp:3457
 msgid "Preferences Settings Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1831 src/muuli_wdr.cpp:3427
+#: src/amuleDlg.cpp:1831 src/muuli_wdr.cpp:3458
 msgid "Import"
 msgstr ""
 
-#: src/amuleDlg.cpp:1835 src/muuli_wdr.cpp:3427
+#: src/amuleDlg.cpp:1835 src/muuli_wdr.cpp:3458
 msgid "The partfile importer tool"
 msgstr ""
 
-#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3428
+#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3459
 #: src/utils/aLinkCreator/src/alcframe.cpp:262
 msgid "About"
 msgstr ""
 
-#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3428
+#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3459
 msgid "About/Help"
 msgstr ""
 
@@ -917,7 +917,7 @@ msgstr ""
 msgid "The core rejected these shared folders:%s"
 msgstr ""
 
-#: src/amule-remote-gui.cpp:1336 src/ExternalConn.cpp:2345
+#: src/amule-remote-gui.cpp:1336 src/ExternalConn.cpp:2346
 msgid "Invalid link or already on list."
 msgstr ""
 
@@ -933,7 +933,7 @@ msgstr ""
 #: src/ClientDetailDialog.cpp:123 src/DataToText.cpp:61 src/DataToText.cpp:86
 #: src/DataToText.cpp:101 src/DataToText.cpp:136 src/DataToText.cpp:165
 #: src/DownloadListCtrl.cpp:1172 src/DownloadListCtrl.cpp:1185
-#: src/DownloadListCtrl.cpp:1196 src/ExternalConn.cpp:608
+#: src/DownloadListCtrl.cpp:1196 src/ExternalConn.cpp:609
 #: src/FileDetailDialog.cpp:203 src/FileDetailDialog.cpp:235
 #: src/FileDetailDialog.cpp:242 src/GenericClientListCtrl.cpp:1171
 #: src/GenericClientListCtrl.cpp:1182 src/GenericClientListCtrl.cpp:1192
@@ -1319,19 +1319,19 @@ msgstr ""
 msgid "Very low"
 msgstr ""
 
-#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:743 src/muuli_wdr.cpp:2282
+#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:743 src/muuli_wdr.cpp:2313
 #: src/ServerListCtrl.cpp:263 src/ServerListCtrl.cpp:456
 #: src/SharedFilesCtrl.cpp:145
 msgid "Low"
 msgstr ""
 
-#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:744 src/muuli_wdr.cpp:2283
+#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:744 src/muuli_wdr.cpp:2314
 #: src/ServerListCtrl.cpp:266 src/ServerListCtrl.cpp:457
 #: src/SharedFilesCtrl.cpp:146
 msgid "Normal"
 msgstr ""
 
-#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:745 src/muuli_wdr.cpp:2284
+#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:745 src/muuli_wdr.cpp:2315
 #: src/ServerListCtrl.cpp:269 src/ServerListCtrl.cpp:458
 #: src/SharedFilesCtrl.cpp:147
 msgid "High"
@@ -1423,7 +1423,7 @@ msgstr ""
 msgid "Remote Server"
 msgstr ""
 
-#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3181
+#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3212
 #: src/SearchDlg.cpp:119 src/TextClient.cpp:911
 msgid "Kad"
 msgstr ""
@@ -1494,7 +1494,7 @@ msgstr ""
 msgid "Size"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3248
+#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3279
 msgid "Transferred"
 msgstr ""
 
@@ -1550,7 +1550,7 @@ msgid ""
 "\n"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:746 src/muuli_wdr.cpp:2285
+#: src/DownloadListCtrl.cpp:746 src/muuli_wdr.cpp:2316
 #: src/SharedFilesCtrl.cpp:150
 msgid "Auto"
 msgstr ""
@@ -1588,7 +1588,7 @@ msgid "Extended Options"
 msgstr ""
 
 #: src/DownloadListCtrl.cpp:770 src/DownloadListCtrl.cpp:822
-#: src/muuli_wdr.cpp:1796
+#: src/muuli_wdr.cpp:1800
 msgid "Preview"
 msgstr ""
 
@@ -1761,225 +1761,230 @@ msgstr[1] ""
 msgid "Invalid eD2k link! ERROR: %s"
 msgstr ""
 
-#: src/ExternalConn.cpp:379
+#: src/ExternalConn.cpp:380
 msgid "Client sent packet after authentication failed."
 msgstr ""
 
-#: src/ExternalConn.cpp:396
+#: src/ExternalConn.cpp:397
 msgid "External connection closed."
 msgstr ""
 
-#: src/ExternalConn.cpp:473
+#: src/ExternalConn.cpp:474
 msgid "External connections disabled due to empty password!"
 msgstr ""
 
-#: src/ExternalConn.cpp:494
+#: src/ExternalConn.cpp:495
 msgid "External connections disabled in config file"
 msgstr ""
 
-#: src/ExternalConn.cpp:575
+#: src/ExternalConn.cpp:576
 msgid "New external connection accepted"
 msgstr ""
 
-#: src/ExternalConn.cpp:578
+#: src/ExternalConn.cpp:579
 msgid "ERROR: couldn't accept a new external connection"
 msgstr ""
 
-#: src/ExternalConn.cpp:595
+#: src/ExternalConn.cpp:596
 msgid "External connection refused due to empty password in preferences!"
 msgstr ""
 
-#: src/ExternalConn.cpp:607
+#: src/ExternalConn.cpp:608
 #, c-format
 msgid "Connecting client: %s %s"
 msgstr ""
 
-#: src/ExternalConn.cpp:609
+#: src/ExternalConn.cpp:610
 msgid "Unknown version"
 msgstr ""
 
-#: src/ExternalConn.cpp:622
+#: src/ExternalConn.cpp:623
 msgid "Incorrect EC version ID, there might be binary incompatibility. Use core and remote from same snapshot."
 msgstr ""
 
-#: src/ExternalConn.cpp:630
+#: src/ExternalConn.cpp:631
 msgid "You cannot connect to a release version from an arbitrary development snapshot! *sigh* possible crash prevented"
 msgstr ""
 
-#: src/ExternalConn.cpp:713
+#: src/ExternalConn.cpp:714
 msgid "Invalid protocol version."
 msgstr ""
 
-#: src/ExternalConn.cpp:719
+#: src/ExternalConn.cpp:720
 msgid "Missing protocol version tag."
 msgstr ""
 
-#: src/ExternalConn.cpp:727
+#: src/ExternalConn.cpp:728
 msgid "Authentication failed: invalid hash specified as EC password."
 msgstr ""
 
-#: src/ExternalConn.cpp:775
+#: src/ExternalConn.cpp:776
 msgid "Authentication failed: wrong password."
 msgstr ""
 
-#: src/ExternalConn.cpp:777
+#: src/ExternalConn.cpp:778
 msgid "Authentication failed: missing password."
 msgstr ""
 
-#: src/ExternalConn.cpp:788
+#: src/ExternalConn.cpp:789
 msgid "Invalid request, please authenticate first."
 msgstr ""
 
-#: src/ExternalConn.cpp:793
+#: src/ExternalConn.cpp:794
 msgid "Access granted."
 msgstr ""
 
-#: src/ExternalConn.cpp:801
+#: src/ExternalConn.cpp:802
 #, c-format
 msgid "Sent error message \"%s\" to client."
 msgstr ""
 
-#: src/ExternalConn.cpp:806
+#: src/ExternalConn.cpp:807
 #, c-format
 msgid "Unauthorized access attempt from %s. Connection closed."
 msgstr ""
 
-#: src/ExternalConn.cpp:1419
+#: src/ExternalConn.cpp:1420
 #, c-format
 msgid "Remote PartFile command failed: FileHash not found: %s"
 msgstr ""
 
-#: src/ExternalConn.cpp:1423
+#: src/ExternalConn.cpp:1424
 #, c-format
 msgid "FileHash not found: %s"
 msgstr ""
 
-#: src/ExternalConn.cpp:1470 src/ExternalConn.cpp:1558
-#: src/ExternalConn.cpp:1679
+#: src/ExternalConn.cpp:1471 src/ExternalConn.cpp:1559
+#: src/ExternalConn.cpp:1680
 msgid "OOPS! OpCode processing error!"
 msgstr ""
 
-#: src/ExternalConn.cpp:1501
+#: src/ExternalConn.cpp:1502
 msgid "Server not added"
 msgstr ""
 
-#: src/ExternalConn.cpp:1520
+#: src/ExternalConn.cpp:1521
 #, c-format
 msgid "server not found: %s"
 msgstr ""
 
-#: src/ExternalConn.cpp:1537
+#: src/ExternalConn.cpp:1538
 msgid "need to define server to be removed"
 msgstr ""
 
-#: src/ExternalConn.cpp:1552
+#: src/ExternalConn.cpp:1553
 msgid "eD2k is disabled in preferences."
 msgstr ""
 
-#: src/ExternalConn.cpp:1657
+#: src/ExternalConn.cpp:1658
 msgid "Friend not found."
 msgstr ""
 
-#: src/ExternalConn.cpp:1667
+#: src/ExternalConn.cpp:1668
 msgid "Client not found."
 msgstr ""
 
-#: src/ExternalConn.cpp:1673
+#: src/ExternalConn.cpp:1674
 msgid "EC_TAG_FRIEND_SHARED requires EC_TAG_FRIEND or EC_TAG_CLIENT."
 msgstr ""
 
-#: src/ExternalConn.cpp:1991
+#: src/ExternalConn.cpp:1992
 msgid "WebSearch from remote interface makes no sense."
 msgstr ""
 
-#: src/ExternalConn.cpp:2026
+#: src/ExternalConn.cpp:2027
 msgid "Search in progress. Refetch results in a moment!"
 msgstr ""
 
-#: src/ExternalConn.cpp:2265
+#: src/ExternalConn.cpp:2266
 msgid "No points for graph."
 msgstr ""
 
-#: src/ExternalConn.cpp:2275
+#: src/ExternalConn.cpp:2276
 msgid "Your client is not configured for this detail level."
 msgstr ""
 
-#: src/ExternalConn.cpp:2302
+#: src/ExternalConn.cpp:2303
 msgid "External Connection: shutdown requested"
 msgstr ""
 
-#: src/ExternalConn.cpp:2314
+#: src/ExternalConn.cpp:2315
 msgid "Already shutting down."
 msgstr ""
 
-#: src/ExternalConn.cpp:2332
+#: src/ExternalConn.cpp:2333
 #, c-format
 msgid "ExternalConn: adding link '%s'."
 msgstr ""
 
-#: src/ExternalConn.cpp:2350
+#: src/ExternalConn.cpp:2351
 #, c-format
 msgid "%d of %d links failed (invalid or already on list)."
 msgstr ""
 
-#: src/ExternalConn.cpp:2373
+#: src/ExternalConn.cpp:2374
 msgid "Version check throttled; try again shortly."
 msgstr ""
 
-#: src/ExternalConn.cpp:2378
+#: src/ExternalConn.cpp:2379
 msgid "Version check is not available on this daemon."
 msgstr ""
 
-#: src/ExternalConn.cpp:2508
+#: src/ExternalConn.cpp:2509
 msgid "File not found."
 msgstr ""
 
-#: src/ExternalConn.cpp:2513
+#: src/ExternalConn.cpp:2514
 msgid "Invalid file name."
 msgstr ""
 
-#: src/ExternalConn.cpp:2521
+#: src/ExternalConn.cpp:2522
 msgid "Unable to rename file."
 msgstr ""
 
-#: src/ExternalConn.cpp:2992 src/ExternalConn.cpp:3020
+#: src/ExternalConn.cpp:2839
+#, c-format
+msgid "Could not save the amuleapi password: %s"
+msgstr ""
+
+#: src/ExternalConn.cpp:3004 src/ExternalConn.cpp:3032
 msgid "Kad is disabled in preferences."
 msgstr ""
 
-#: src/ExternalConn.cpp:3033
+#: src/ExternalConn.cpp:3045
 msgid "Already connected to eD2k."
 msgstr ""
 
-#: src/ExternalConn.cpp:3036
+#: src/ExternalConn.cpp:3048
 msgid "Connecting to eD2k..."
 msgstr ""
 
-#: src/ExternalConn.cpp:3045
+#: src/ExternalConn.cpp:3057
 msgid "Already connected to Kad."
 msgstr ""
 
-#: src/ExternalConn.cpp:3048
+#: src/ExternalConn.cpp:3060
 msgid "Connecting to Kad..."
 msgstr ""
 
-#: src/ExternalConn.cpp:3055
+#: src/ExternalConn.cpp:3067
 msgid "All networks are disabled."
 msgstr ""
 
-#: src/ExternalConn.cpp:3064
+#: src/ExternalConn.cpp:3076
 msgid "Disconnected from eD2k."
 msgstr ""
 
-#: src/ExternalConn.cpp:3069
+#: src/ExternalConn.cpp:3081
 msgid "Disconnected from Kad."
 msgstr ""
 
-#: src/ExternalConn.cpp:3078
+#: src/ExternalConn.cpp:3090
 #, c-format
 msgid "External Connection: invalid opcode received: %#x"
 msgstr ""
 
-#: src/ExternalConn.cpp:3083
+#: src/ExternalConn.cpp:3095
 msgid "Invalid opcode (wrong protocol version?)"
 msgstr ""
 
@@ -2349,23 +2354,23 @@ msgid ""
 "want downloads on a different (e.g. larger) disk."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:549 src/FirstRunWizard.cpp:611 src/muuli_wdr.cpp:1708
+#: src/FirstRunWizard.cpp:549 src/FirstRunWizard.cpp:611 src/muuli_wdr.cpp:1712
 msgid "Destination folder for downloads"
 msgstr ""
 
 #: src/FirstRunWizard.cpp:553 src/FirstRunWizard.cpp:569 src/muuli_wdr.cpp:1349
-#: src/muuli_wdr.cpp:1366 src/muuli_wdr.cpp:1683 src/muuli_wdr.cpp:1714
-#: src/muuli_wdr.cpp:1726 src/muuli_wdr.cpp:2769
+#: src/muuli_wdr.cpp:1366 src/muuli_wdr.cpp:1687 src/muuli_wdr.cpp:1718
+#: src/muuli_wdr.cpp:1730 src/muuli_wdr.cpp:2800
 #: src/utils/aLinkCreator/src/alcframe.cpp:135
 #: src/utils/wxCas/src/wxcasprefs.cpp:52 src/utils/wxCas/src/wxcasprefs.cpp:118
 msgid "Browse"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:559 src/muuli_wdr.cpp:1719
+#: src/FirstRunWizard.cpp:559 src/muuli_wdr.cpp:1723
 msgid "(All files in this folder are shared with other peers)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:565 src/FirstRunWizard.cpp:624 src/muuli_wdr.cpp:1721
+#: src/FirstRunWizard.cpp:565 src/FirstRunWizard.cpp:624 src/muuli_wdr.cpp:1725
 msgid "Folder for temporary download files"
 msgstr ""
 
@@ -2396,7 +2401,7 @@ msgstr ""
 msgid "CRITICAL - no client on StartChatSession"
 msgstr ""
 
-#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2675 src/muuli_wdr.cpp:3352
+#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2706 src/muuli_wdr.cpp:3383
 msgid "Friends"
 msgstr ""
 
@@ -2502,8 +2507,8 @@ msgstr ""
 msgid "No"
 msgstr ""
 
-#: src/GenericClientListCtrl.cpp:1216 src/PrefsUnifiedDlg.cpp:2818
-#: src/PrefsUnifiedDlg.cpp:2868 src/ServerListCtrl.cpp:276
+#: src/GenericClientListCtrl.cpp:1216 src/PrefsUnifiedDlg.cpp:2898
+#: src/PrefsUnifiedDlg.cpp:2948 src/ServerListCtrl.cpp:276
 msgid "Yes"
 msgstr ""
 
@@ -2670,10 +2675,10 @@ msgstr ""
 msgid "Please fill all fields required"
 msgstr ""
 
-#: src/KadDlg.cpp:192 src/PartFile.cpp:1031 src/PrefsUnifiedDlg.cpp:1162
-#: src/PrefsUnifiedDlg.cpp:1331 src/PrefsUnifiedDlg.cpp:1589
-#: src/PrefsUnifiedDlg.cpp:1599 src/PrefsUnifiedDlg.cpp:1616
-#: src/PrefsUnifiedDlg.cpp:1658
+#: src/KadDlg.cpp:192 src/PartFile.cpp:1031 src/PrefsUnifiedDlg.cpp:1134
+#: src/PrefsUnifiedDlg.cpp:1204 src/PrefsUnifiedDlg.cpp:1405
+#: src/PrefsUnifiedDlg.cpp:1663 src/PrefsUnifiedDlg.cpp:1673
+#: src/PrefsUnifiedDlg.cpp:1690 src/PrefsUnifiedDlg.cpp:1738
 msgid "Message"
 msgstr ""
 
@@ -2774,7 +2779,7 @@ msgstr ""
 msgid "Uploaded"
 msgstr ""
 
-#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3232
+#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3263
 msgid "Requested"
 msgstr ""
 
@@ -2897,7 +2902,7 @@ msgid "WARNING: "
 msgstr ""
 
 #: src/MuleNotebook.cpp:179 src/muuli_wdr.cpp:817 src/muuli_wdr.cpp:1229
-#: src/muuli_wdr.cpp:3136 src/muuli_wdr.cpp:3392
+#: src/muuli_wdr.cpp:3167 src/muuli_wdr.cpp:3423
 msgid "Close"
 msgstr ""
 
@@ -2915,7 +2920,7 @@ msgid "Paste"
 msgstr ""
 
 #: src/MuleTextCtrl.cpp:89 src/muuli_wdr.cpp:358 src/muuli_wdr.cpp:757
-#: src/muuli_wdr.cpp:2359 src/muuli_wdr.cpp:2378 src/muuli_wdr.cpp:2400
+#: src/muuli_wdr.cpp:2390 src/muuli_wdr.cpp:2409 src/muuli_wdr.cpp:2431
 #: src/utils/aLinkCreator/src/alcframe.cpp:142
 msgid "Clear"
 msgstr ""
@@ -3007,7 +3012,7 @@ msgstr ""
 
 #: src/MuleTrayIcon.cpp:579 src/MuleTrayIcon.cpp:945 src/MuleTrayIcon.cpp:965
 #: src/muuli_wdr.cpp:1398 src/muuli_wdr.cpp:1406 src/muuli_wdr.cpp:1413
-#: src/muuli_wdr.cpp:1842 src/muuli_wdr.cpp:1848 src/OtherFunctions.cpp:91
+#: src/muuli_wdr.cpp:1846 src/muuli_wdr.cpp:1852 src/OtherFunctions.cpp:91
 #: src/StatisticsDlg.cpp:93 src/StatisticsDlg.cpp:95
 msgid "kB/s"
 msgstr ""
@@ -3247,7 +3252,7 @@ msgstr ""
 msgid "KB"
 msgstr ""
 
-#: src/muuli_wdr.cpp:274 src/muuli_wdr.cpp:293 src/muuli_wdr.cpp:1627
+#: src/muuli_wdr.cpp:274 src/muuli_wdr.cpp:293 src/muuli_wdr.cpp:1631
 #: src/OtherFunctions.cpp:64
 msgid "MB"
 msgstr ""
@@ -3264,7 +3269,7 @@ msgstr ""
 msgid "Availability"
 msgstr ""
 
-#: src/muuli_wdr.cpp:312 src/muuli_wdr.cpp:398 src/muuli_wdr.cpp:3297
+#: src/muuli_wdr.cpp:312 src/muuli_wdr.cpp:398 src/muuli_wdr.cpp:3328
 msgid "Filter:"
 msgstr ""
 
@@ -3327,12 +3332,12 @@ msgstr ""
 #: src/muuli_wdr.cpp:1160 src/muuli_wdr.cpp:1167 src/muuli_wdr.cpp:1172
 #: src/muuli_wdr.cpp:1179 src/muuli_wdr.cpp:1184 src/muuli_wdr.cpp:1191
 #: src/muuli_wdr.cpp:1205 src/muuli_wdr.cpp:1212 src/muuli_wdr.cpp:1217
-#: src/muuli_wdr.cpp:1224 src/muuli_wdr.cpp:3234 src/muuli_wdr.cpp:3242
-#: src/muuli_wdr.cpp:3250
+#: src/muuli_wdr.cpp:1224 src/muuli_wdr.cpp:3265 src/muuli_wdr.cpp:3273
+#: src/muuli_wdr.cpp:3281
 msgid "N/A"
 msgstr ""
 
-#: src/muuli_wdr.cpp:508 src/muuli_wdr.cpp:1065 src/PrefsUnifiedDlg.cpp:297
+#: src/muuli_wdr.cpp:508 src/muuli_wdr.cpp:1065 src/PrefsUnifiedDlg.cpp:299
 msgid "General"
 msgstr ""
 
@@ -3468,7 +3473,7 @@ msgstr ""
 msgid "Album :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:685 src/muuli_wdr.cpp:2254
+#: src/muuli_wdr.cpp:685 src/muuli_wdr.cpp:2285
 msgid "Title :"
 msgstr ""
 
@@ -3574,7 +3579,7 @@ msgstr ""
 msgid "Userhash :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:895 src/muuli_wdr.cpp:1748 src/muuli_wdr.cpp:2449
+#: src/muuli_wdr.cpp:895 src/muuli_wdr.cpp:1752 src/muuli_wdr.cpp:2480
 #: src/utils/aLinkCreator/src/alcframe.cpp:137
 msgid "Add"
 msgstr ""
@@ -3583,15 +3588,15 @@ msgstr ""
 msgid "Download-Speed"
 msgstr ""
 
-#: src/muuli_wdr.cpp:954 src/muuli_wdr.cpp:989 src/muuli_wdr.cpp:2553
+#: src/muuli_wdr.cpp:954 src/muuli_wdr.cpp:989 src/muuli_wdr.cpp:2584
 msgid "Current"
 msgstr ""
 
-#: src/muuli_wdr.cpp:962 src/muuli_wdr.cpp:997 src/muuli_wdr.cpp:2561
+#: src/muuli_wdr.cpp:962 src/muuli_wdr.cpp:997 src/muuli_wdr.cpp:2592
 msgid "Running average"
 msgstr ""
 
-#: src/muuli_wdr.cpp:970 src/muuli_wdr.cpp:1005 src/muuli_wdr.cpp:2569
+#: src/muuli_wdr.cpp:970 src/muuli_wdr.cpp:1005 src/muuli_wdr.cpp:2600
 msgid "Session average"
 msgstr ""
 
@@ -3603,7 +3608,7 @@ msgstr ""
 msgid "Connections"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1024 src/muuli_wdr.cpp:1867
+#: src/muuli_wdr.cpp:1024 src/muuli_wdr.cpp:1871
 msgid "Active downloads"
 msgstr ""
 
@@ -3611,7 +3616,7 @@ msgstr ""
 msgid "Active connections (1:1)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1040 src/muuli_wdr.cpp:1868
+#: src/muuli_wdr.cpp:1040 src/muuli_wdr.cpp:1872
 msgid "Active uploads"
 msgstr ""
 
@@ -3884,7 +3889,7 @@ msgstr ""
 msgid "Advanced users only: If you have multiple network interfaces, enter the address of the interface to which aMule should be bound."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1462 src/muuli_wdr.cpp:2061
+#: src/muuli_wdr.cpp:1462 src/muuli_wdr.cpp:2065
 msgid "Bind to network interface (empty for any):"
 msgstr ""
 
@@ -3900,7 +3905,7 @@ msgstr ""
 msgid "Max simultaneous connections:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1498 src/muuli_wdr.cpp:3176
+#: src/muuli_wdr.cpp:1498 src/muuli_wdr.cpp:3207
 msgid "ED2K"
 msgstr ""
 
@@ -3992,743 +3997,763 @@ msgstr ""
 msgid "For new files preallocates disk space for the whole file, thus reduces fragmentation"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1613
+#: src/muuli_wdr.cpp:1617
 msgid "Create new files as sparse files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1614
-msgid "A sparse file reserves its full size on disk immediately without writing real data to it -- fast, but unsupported or slow on some filesystems, and free-space accounting stays optimistic while the download is in progress. Turn this off to grow the file only as data arrives."
+#: src/muuli_wdr.cpp:1618
+msgid "Sparse part files only occupy disk space for the parts already downloaded, so free space is used up gradually as the file fills in. Turn this off to use an ordinary file instead - useful where sparse files are unsupported or slow, or where backup/de-duplication tools handle them badly. Applies only when the core runs on Windows; on Linux and macOS part files are sparse anyway and this setting has no effect."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1619
+#: src/muuli_wdr.cpp:1623
 msgid "Stop downloads when free disk space reaches "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1620
+#: src/muuli_wdr.cpp:1624
 msgid "Select this if you want aMule to check your disk space"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1624
+#: src/muuli_wdr.cpp:1628
 msgid "Enter here the min disk space desired."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1630
+#: src/muuli_wdr.cpp:1634
 msgid "Save 10 sources on rare files (< 20 sources)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1634 src/Statistics.cpp:790
+#: src/muuli_wdr.cpp:1638 src/Statistics.cpp:790
 msgid "Uploads"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1637
+#: src/muuli_wdr.cpp:1641
 msgid "Add new shared files with auto priority"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1643
+#: src/muuli_wdr.cpp:1647
 msgid "Intelligent Corruption Handling (I.C.H.)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1646
+#: src/muuli_wdr.cpp:1650
 msgid "Enable"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1649
+#: src/muuli_wdr.cpp:1653
 msgid "Advanced I.C.H. trusts every hash (not recommended)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1661 src/PrefsUnifiedDlg.cpp:1910
+#: src/muuli_wdr.cpp:1665 src/PrefsUnifiedDlg.cpp:1990
 msgid "Media metadata extraction"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1665
+#: src/muuli_wdr.cpp:1669
 msgid "Extract length / bitrate / codec from shared audio and video files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1667
+#: src/muuli_wdr.cpp:1671
 msgid "When enabled, aMule runs ffprobe on each shared media file to fill in the Length / Bitrate / Codec columns other clients see when they find the file in a search. Requires ffmpeg (the ffprobe binary) to be installed."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1674
+#: src/muuli_wdr.cpp:1678
 msgid "Path to ffprobe:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1679
+#: src/muuli_wdr.cpp:1683
 msgid "Full path to the ffprobe binary. Leave empty to have aMule auto-detect it on startup."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1687
+#: src/muuli_wdr.cpp:1691
 msgid "Detect"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1688
+#: src/muuli_wdr.cpp:1692
 msgid "Search the standard install locations for an ffprobe binary and fill the path field."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1712
+#: src/muuli_wdr.cpp:1716
 msgid ""
 "Completed downloads are stored here. All files in this folder are automatically shared with other peers.\n"
 "If this folder also holds files you don't want to share, point it at an aMule-only sub-folder."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1715
+#: src/muuli_wdr.cpp:1719
 msgid "Pick the folder where completed downloads will be stored. All files in that folder will be shared with other peers."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1729
+#: src/muuli_wdr.cpp:1733
 msgid "Shared folders"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1735
+#: src/muuli_wdr.cpp:1739
 msgid "(Folders shared by the core. Enter a path to add one.)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1743
+#: src/muuli_wdr.cpp:1747
 msgid "Absolute path of a folder on the core's machine, e.g. /home/user/shared"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1745 src/PrefsUnifiedDlg.cpp:2794
+#: src/muuli_wdr.cpp:1749 src/PrefsUnifiedDlg.cpp:2874
 msgid "Recursive"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1746
+#: src/muuli_wdr.cpp:1750
 msgid "Share every sub-folder underneath this one, including ones created later."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1750 src/utils/aLinkCreator/src/alcframe.cpp:141
+#: src/muuli_wdr.cpp:1754 src/utils/aLinkCreator/src/alcframe.cpp:141
 msgid "Remove"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1754
+#: src/muuli_wdr.cpp:1758
 msgid "(Right click on folder icon for recursive share)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1761
+#: src/muuli_wdr.cpp:1765
 msgid "Share hidden files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1767
+#: src/muuli_wdr.cpp:1771
 msgid "Automatically rescan shared folders for changes"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1773
+#: src/muuli_wdr.cpp:1777
 msgid "Follow symbolic links in shared folders"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1779
+#: src/muuli_wdr.cpp:1783
 msgid "Exclude files matching:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1782
+#: src/muuli_wdr.cpp:1786
 msgid "Wildcard patterns separated by '|', e.g. .DS_Store|Thumbs.db|*.tmp. Files whose name matches are not shared. Matching is case-insensitive."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1786
+#: src/muuli_wdr.cpp:1790
 msgid "Patterns are regular expressions"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1787
+#: src/muuli_wdr.cpp:1791
 msgid "When set, the whole field is one regular expression ('|' is alternation). When unset, it is a list of '|'-separated wildcards."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1797
+#: src/muuli_wdr.cpp:1801
 msgid "Show how many shared files the current pattern would exclude."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1818
+#: src/muuli_wdr.cpp:1822
 msgid "Graphs"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1821 src/muuli_wdr.cpp:1883
+#: src/muuli_wdr.cpp:1825 src/muuli_wdr.cpp:1887
 msgid "Update delay : 5 secs"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1825
+#: src/muuli_wdr.cpp:1829
 msgid "Time for average graph: 100 mins"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1829
+#: src/muuli_wdr.cpp:1833
 msgid "Connections Graph Scale: 100 "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1836
+#: src/muuli_wdr.cpp:1840
 msgid "Download graph scale:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1844
+#: src/muuli_wdr.cpp:1848
 msgid "Upload graph scale:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1854
+#: src/muuli_wdr.cpp:1858
 msgid "Colors: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1858
+#: src/muuli_wdr.cpp:1862
 msgid "Background"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1859
+#: src/muuli_wdr.cpp:1863
 msgid "Grid"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1860
+#: src/muuli_wdr.cpp:1864
 msgid "Download current"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1861
+#: src/muuli_wdr.cpp:1865
 msgid "Download running average"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1862
+#: src/muuli_wdr.cpp:1866
 msgid "Download session average"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1863
+#: src/muuli_wdr.cpp:1867
 msgid "Upload current"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1864
+#: src/muuli_wdr.cpp:1868
 msgid "Upload running average"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1865
+#: src/muuli_wdr.cpp:1869
 msgid "Upload session average"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1866
+#: src/muuli_wdr.cpp:1870
 msgid "Active connections"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1869
+#: src/muuli_wdr.cpp:1873
 msgid "Systray Icon Speed Bar"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1870
+#: src/muuli_wdr.cpp:1874
 msgid "Kad-nodes current"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1871
+#: src/muuli_wdr.cpp:1875
 msgid "Kad-nodes running"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1872
+#: src/muuli_wdr.cpp:1876
 msgid "Kad-nodes session"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1876 src/muuli_wdr.cpp:2303
+#: src/muuli_wdr.cpp:1880 src/muuli_wdr.cpp:2334
 msgid "Select"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1880
+#: src/muuli_wdr.cpp:1884
 msgid "Tree"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1890
+#: src/muuli_wdr.cpp:1894
 msgid "Number of Client Versions shown (0=unlimited)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1915
+#: src/muuli_wdr.cpp:1919
 msgid "!!! WARNING !!!"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1930
+#: src/muuli_wdr.cpp:1934
 msgid "Max new connections / 5 secs"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1932
+#: src/muuli_wdr.cpp:1936
 msgid "Concurrent Kad source lookups"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1934
+#: src/muuli_wdr.cpp:1938
 msgid "Kad source re-search interval (minutes)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1936
+#: src/muuli_wdr.cpp:1940
 msgid "Source re-ask interval (minutes)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1940
+#: src/muuli_wdr.cpp:1944
 msgid "File Buffer Size: 240000 bytes"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1944
+#: src/muuli_wdr.cpp:1948
 msgid "Use MMAP: memory-mapped file access (lower memory use)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1945
+#: src/muuli_wdr.cpp:1949
 msgid "Maps part files into memory instead of buffering them on the heap, lowering the process memory footprint. May reduce download speed on some disks; best for memory-constrained or upload-heavy hosts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1947
+#: src/muuli_wdr.cpp:1951
 msgid "Upload Queue Size: 5000 clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1951
+#: src/muuli_wdr.cpp:1955
 msgid "Server connection refresh interval: Disable"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1955
+#: src/muuli_wdr.cpp:1959
 msgid "Disable computer's timed standby mode"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1974
+#: src/muuli_wdr.cpp:1978
 msgid "Skin to use: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1983
+#: src/muuli_wdr.cpp:1987
 msgid "Show \"Fast eD2k Links Handler\" in every window."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1986
+#: src/muuli_wdr.cpp:1990
 msgid "Show extended info on categories tabs"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1989
+#: src/muuli_wdr.cpp:1993
 msgid "Show application version on title"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1991
+#: src/muuli_wdr.cpp:1995
 msgid "Show transfer rates on title"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1993
+#: src/muuli_wdr.cpp:1997
 msgid "Before application name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1995
+#: src/muuli_wdr.cpp:1999
 msgid "After application name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1998
+#: src/muuli_wdr.cpp:2002
 msgid "Show overhead bandwidth"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2002
+#: src/muuli_wdr.cpp:2006
 msgid "Vertical toolbar orientation"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2004
+#: src/muuli_wdr.cpp:2008
 msgid "Live column sorting (auto-reorder rows as their values change)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2011
+#: src/muuli_wdr.cpp:2015
 msgid "Download Queue Files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2014
+#: src/muuli_wdr.cpp:2018
 msgid "Show progress percentage"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2020
+#: src/muuli_wdr.cpp:2024
 msgid "Show progress bar"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2023
+#: src/muuli_wdr.cpp:2027
 msgid "Flat"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2027
+#: src/muuli_wdr.cpp:2031
 msgid "Round"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2045
+#: src/muuli_wdr.cpp:2049
 msgid "External Connection Parameters"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2048
+#: src/muuli_wdr.cpp:2052
 msgid "Accept external connections"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2055 src/muuli_wdr.cpp:2114
+#: src/muuli_wdr.cpp:2059 src/muuli_wdr.cpp:2118
 msgid "IP of the listening interface:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2058
+#: src/muuli_wdr.cpp:2062
 msgid "Enter here a valid ip in the a.b.c.d format for the listening EC interface. An empty field or 0.0.0.0 will mean any interface."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2079 src/muuli_wdr.cpp:2163
+#: src/muuli_wdr.cpp:2083 src/muuli_wdr.cpp:2194
 msgid "TCP port:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2085
+#: src/muuli_wdr.cpp:2089
 msgid "Enable UPnP port forwarding on the EC port"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2089 src/muuli_wdr.cpp:3048
+#: src/muuli_wdr.cpp:2093 src/muuli_wdr.cpp:3079
 #: src/utils/wxCas/src/wxcasprefs.cpp:167
 msgid "Password"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2095
+#: src/muuli_wdr.cpp:2099
 msgid "aMule API server parameters"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2098
+#: src/muuli_wdr.cpp:2102
 msgid "Run amuleapi (REST API) on startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2103
+#: src/muuli_wdr.cpp:2107
 msgid "HTTP port:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2117
+#: src/muuli_wdr.cpp:2121
 msgid "The interface amuleapi's HTTP server listens on. 127.0.0.1 (default) accepts only local connections; use 0.0.0.0 or a specific IP to expose it to other hosts (set an admin password below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2120
+#: src/muuli_wdr.cpp:2126
+msgid "Type a password to set or change it. Stored passwords cannot be shown, so leaving this empty keeps the current one."
+msgstr ""
+
+#: src/muuli_wdr.cpp:2128
 msgid "Admin password"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2125 src/muuli_wdr.cpp:2156
-msgid "Low rights password"
+#: src/muuli_wdr.cpp:2140 src/muuli_wdr.cpp:2157 src/PrefsUnifiedDlg.cpp:1103
+msgid "A password is set."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2133
+#: src/muuli_wdr.cpp:2144
+msgid "Enable guest access"
+msgstr ""
+
+#: src/muuli_wdr.cpp:2145
+msgid "Guest sessions may read status and listings but cannot change anything. Turning this off clears the stored guest password."
+msgstr ""
+
+#: src/muuli_wdr.cpp:2149
+msgid "Guest password"
+msgstr ""
+
+#: src/muuli_wdr.cpp:2164
 msgid "Web server parameters"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2136
+#: src/muuli_wdr.cpp:2167
 msgid "Run webserver on startup (deprecated)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2142
+#: src/muuli_wdr.cpp:2173
 msgid "Web template"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2147
+#: src/muuli_wdr.cpp:2178
 msgid "Full rights password"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2151
+#: src/muuli_wdr.cpp:2182
 msgid "Enable Low rights User"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2170
+#: src/muuli_wdr.cpp:2187
+msgid "Low rights password"
+msgstr ""
+
+#: src/muuli_wdr.cpp:2201
 msgid "Enable UPnP port forwarding of the web server port"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2175
+#: src/muuli_wdr.cpp:2206
 msgid "Web server UPnP TCP port (Optional)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2183
+#: src/muuli_wdr.cpp:2214
 msgid "Page Refresh Time (in secs)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2190
+#: src/muuli_wdr.cpp:2221
 msgid "Enable Gzip compression"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2224
+#: src/muuli_wdr.cpp:2255
 msgid "Reset page to defaults"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2225
+#: src/muuli_wdr.cpp:2256
 msgid "Reset the settings on the current page to their default values."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2227 src/muuli_wdr.cpp:2313 src/ServerWnd.cpp:274
+#: src/muuli_wdr.cpp:2258 src/muuli_wdr.cpp:2344 src/ServerWnd.cpp:274
 #: src/ServerWnd.cpp:282
 msgid "OK"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2229
+#: src/muuli_wdr.cpp:2260
 msgid "Click here to apply any changes made to the preferences."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2232
+#: src/muuli_wdr.cpp:2263
 msgid "Reset any changes made to the preferences."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2261
+#: src/muuli_wdr.cpp:2292
 msgid "Comment :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2268
+#: src/muuli_wdr.cpp:2299
 msgid "Incoming Dir :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2277
+#: src/muuli_wdr.cpp:2308
 msgid "Change priority for new assigned files :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2281
+#: src/muuli_wdr.cpp:2312
 msgid "Don't change"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2293
+#: src/muuli_wdr.cpp:2324
 msgid "Select color for this Category (currently selected) :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2360 src/muuli_wdr.cpp:2379 src/muuli_wdr.cpp:2401
+#: src/muuli_wdr.cpp:2391 src/muuli_wdr.cpp:2410 src/muuli_wdr.cpp:2432
 msgid "Click this button to reset the log."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2420
+#: src/muuli_wdr.cpp:2451
 msgid "Click on this button to update the servers list from URL ..."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2424
+#: src/muuli_wdr.cpp:2455
 msgid "Server list"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2428
+#: src/muuli_wdr.cpp:2459
 msgid "Enter the url to a server.met file here and press the button to the left to update the list of known servers."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2433
+#: src/muuli_wdr.cpp:2464
 msgid "Add server manually: Name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2436
+#: src/muuli_wdr.cpp:2467
 msgid "Enter the name of the new server here"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2438 src/ServerWnd.cpp:206
+#: src/muuli_wdr.cpp:2469 src/ServerWnd.cpp:206
 msgid "IP:Port"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2441
+#: src/muuli_wdr.cpp:2472
 msgid "Enter the IP of the server here, using the x.x.x.x format."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2447
+#: src/muuli_wdr.cpp:2478
 msgid "Enter the port of the server here."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2450
+#: src/muuli_wdr.cpp:2481
 msgid "Add manually a server (fill fields to the left before) ..."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2479
+#: src/muuli_wdr.cpp:2510
 msgid "aMule Log"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2487
+#: src/muuli_wdr.cpp:2518
 msgid "Server Info"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2491
+#: src/muuli_wdr.cpp:2522
 msgid "ED2K Info"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2495
+#: src/muuli_wdr.cpp:2526
 msgid "Kad Info"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2523
+#: src/muuli_wdr.cpp:2554
 msgid "Click on this button to update the nodes list from URL ..."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2527
+#: src/muuli_wdr.cpp:2558
 msgid "Nodes (0)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2531
+#: src/muuli_wdr.cpp:2562
 msgid "Enter the url to a nodes.dat file here and press the button to the left to update the list of known nodes."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2534
+#: src/muuli_wdr.cpp:2565
 msgid "Nodes stats"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2576
+#: src/muuli_wdr.cpp:2607
 msgid "Bootstrap"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2579
+#: src/muuli_wdr.cpp:2610
 msgid "New node"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2584
+#: src/muuli_wdr.cpp:2615
 msgid "IP:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2604
+#: src/muuli_wdr.cpp:2635
 msgid "Port:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2617
+#: src/muuli_wdr.cpp:2648
 msgid "Bootstrap from known clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2619
+#: src/muuli_wdr.cpp:2650
 msgid "Disconnect Kad"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2653
+#: src/muuli_wdr.cpp:2684
 msgid "Use Secure User Identification"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2655
+#: src/muuli_wdr.cpp:2686
 msgid "It is recommended to enable this option. You will not receive credits if SUI is not enabled."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2657
+#: src/muuli_wdr.cpp:2688
 msgid "Protocol Obfuscation"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2660
+#: src/muuli_wdr.cpp:2691
 msgid "Support Protocol Obfuscation"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2662
+#: src/muuli_wdr.cpp:2693
 msgid "This option enabled Protocol Obfuscation, and makes aMule accept obfuscated connections from other clients."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2664
+#: src/muuli_wdr.cpp:2695
 msgid "Use obfuscation for outgoing connections"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2666
+#: src/muuli_wdr.cpp:2697
 msgid "This option makes aMule use Protocol Obfuscation when connecting other clients/servers."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2668
+#: src/muuli_wdr.cpp:2699
 msgid "Accept only obfuscated connections"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2669
+#: src/muuli_wdr.cpp:2700
 msgid "This option makes aMule only accept obfuscated connections. You will have less sources, but all your traffic will be obfuscated"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2674
+#: src/muuli_wdr.cpp:2705
 msgid "Everybody"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2676
+#: src/muuli_wdr.cpp:2707
 msgid "No one"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2678
+#: src/muuli_wdr.cpp:2709
 msgid "Who can see my shared files:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2679
+#: src/muuli_wdr.cpp:2710
 msgid "Select who can request to view a list of your shared files."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2681
+#: src/muuli_wdr.cpp:2712
 msgid "IP-Filtering"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2688
+#: src/muuli_wdr.cpp:2719
 msgid "Filter clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2690
+#: src/muuli_wdr.cpp:2721
 msgid "Enable filtering of the client IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2692
+#: src/muuli_wdr.cpp:2723
 msgid "Filter servers"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2694
+#: src/muuli_wdr.cpp:2725
 msgid "Enable filtering of the server IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2698
+#: src/muuli_wdr.cpp:2729
 msgid "Reload List"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2699
+#: src/muuli_wdr.cpp:2730
 msgid "Reload the list of IPs to filter from the file ~/.aMule/ipfilter.dat"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2705
+#: src/muuli_wdr.cpp:2736
 msgid "URL:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2709 src/muuli_wdr.cpp:2902
+#: src/muuli_wdr.cpp:2740 src/muuli_wdr.cpp:2933
 msgid "Update now"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2712
+#: src/muuli_wdr.cpp:2743
 msgid "Auto-update ipfilter at startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2716
+#: src/muuli_wdr.cpp:2747
 msgid "Filtering Level:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2722
+#: src/muuli_wdr.cpp:2753
 msgid "Always filter LAN IPs"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2725
+#: src/muuli_wdr.cpp:2756
 msgid "Paranoid handling of non-matching IPs"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2727
+#: src/muuli_wdr.cpp:2758
 msgid "Rejects a packet when its source IP differs from the IP the client claims (an anti-spoofing check). Disable only if it causes connection problems."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2729
+#: src/muuli_wdr.cpp:2760
 msgid "Use system-wide ipfilter.dat if available"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2730
+#: src/muuli_wdr.cpp:2761
 msgid "If there's no local ipfilter.dat found, allow usage of a system-wide ipfilter file."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2747
+#: src/muuli_wdr.cpp:2778
 msgid "Enable Online-Signature"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2749
+#: src/muuli_wdr.cpp:2780
 msgid "Enables the writing of the OS file, which can be used by external apps to create signatures and the like."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2753
+#: src/muuli_wdr.cpp:2784
 msgid "Update Frequency (Secs):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2756
+#: src/muuli_wdr.cpp:2787
 msgid "Change the frequency (in seconds) of Online Signature updates."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2764
+#: src/muuli_wdr.cpp:2795
 msgid "Save online signature file in: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:2770
+#: src/muuli_wdr.cpp:2801
 msgid "Click here to select the directory containing the the Online Signature files."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2803
+#: src/muuli_wdr.cpp:2834
 msgid "Show country flags for clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2804
+#: src/muuli_wdr.cpp:2835
 msgid "Render the country flag column in the transfers, queue and search views. Requires a valid MMDB GeoIP database (see below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2809
+#: src/muuli_wdr.cpp:2840
 msgid "Database"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2825
+#: src/muuli_wdr.cpp:2856
 msgid "Source:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2828
+#: src/muuli_wdr.cpp:2859
 msgid "DB-IP (free, no account)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2829
+#: src/muuli_wdr.cpp:2860
 msgid "MaxMind GeoLite2 (free, account required)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2830
+#: src/muuli_wdr.cpp:2861
 msgid "Custom URL"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2833
+#: src/muuli_wdr.cpp:2864
 msgid "Choose which provider supplies the GeoIP MMDB database. DB-IP is the default - no account required. MaxMind requires a free account + license key. Use Custom URL to point at any other MMDB host (e.g. a local mirror)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2850
+#: src/muuli_wdr.cpp:2881
 msgid ""
 "No configuration required.\n"
 "\n"
@@ -4736,11 +4761,11 @@ msgid ""
 "License: Creative Commons BY 4.0 - https://creativecommons.org/licenses/by/4.0/"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2863
+#: src/muuli_wdr.cpp:2894
 msgid "License key:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2869
+#: src/muuli_wdr.cpp:2900
 msgid ""
 "Sign up for a free MaxMind account, then generate a License Key:\n"
 "https://www.maxmind.com/en/geolite2/signup\n"
@@ -4750,222 +4775,222 @@ msgid ""
 "Requires attribution and account registration; refresh at least every 30 days."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2884
+#: src/muuli_wdr.cpp:2915
 msgid "Download URL:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2890
+#: src/muuli_wdr.cpp:2921
 msgid ""
 "Must point to an .mmdb file or a .gz / .tar.gz containing one.\n"
 "URL may include credentials (https://user:pass@host/...).\n"
 "License and attribution terms are set by the upstream URL - you are responsible."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2903
+#: src/muuli_wdr.cpp:2934
 msgid "Download the GeoIP database from the selected source."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2905
+#: src/muuli_wdr.cpp:2936
 msgid "Auto-update on startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2906
+#: src/muuli_wdr.cpp:2937
 msgid "Re-download the GeoIP database from the selected source every time aMule starts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2929
+#: src/muuli_wdr.cpp:2960
 msgid "Filter incoming messages (except current chat):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2931
+#: src/muuli_wdr.cpp:2962
 msgid "Filter all messages"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2933
+#: src/muuli_wdr.cpp:2964
 msgid "Filter messages from people not on your friend list"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2935
+#: src/muuli_wdr.cpp:2966
 msgid "Filter messages from unknown clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2937
+#: src/muuli_wdr.cpp:2968
 msgid "Filter messages containing (use ',' as separator):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2940 src/muuli_wdr.cpp:2951
+#: src/muuli_wdr.cpp:2971 src/muuli_wdr.cpp:2982
 msgid "add here the words amule should filter and block messages including it"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2942
+#: src/muuli_wdr.cpp:2973
 msgid "Show received messages in the log"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2945
+#: src/muuli_wdr.cpp:2976
 msgid "Comments"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2948
+#: src/muuli_wdr.cpp:2979
 msgid "Filter comments containing (use ',' as separator):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2973
+#: src/muuli_wdr.cpp:3004
 msgid "Enable Proxy"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2974
+#: src/muuli_wdr.cpp:3005
 msgid "Enable/disable proxy support"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2977
+#: src/muuli_wdr.cpp:3008
 msgid "Proxy type:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2988
+#: src/muuli_wdr.cpp:3019
 msgid "Proxy host:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2991
+#: src/muuli_wdr.cpp:3022
 msgid "The proxy host name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2993
+#: src/muuli_wdr.cpp:3024
 msgid "Proxy port:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2996
+#: src/muuli_wdr.cpp:3027
 msgid "The proxy port"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2998
+#: src/muuli_wdr.cpp:3029
 msgid "Enable authentication"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2999
+#: src/muuli_wdr.cpp:3030
 msgid "Enable/disable username/password authentication"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3002
+#: src/muuli_wdr.cpp:3033
 msgid "Username: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:3005
+#: src/muuli_wdr.cpp:3036
 msgid "The username to use to connect to the proxy"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3007
+#: src/muuli_wdr.cpp:3038
 msgid "Password:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3010
+#: src/muuli_wdr.cpp:3041
 msgid "The password to use to connect to the proxy"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3029
+#: src/muuli_wdr.cpp:3060
 msgid "Connect to:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3038
+#: src/muuli_wdr.cpp:3069
 msgid "Login to remote amule"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3043
+#: src/muuli_wdr.cpp:3074
 msgid "User name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3054
+#: src/muuli_wdr.cpp:3085
 msgid "Remember those settings"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3057
+#: src/muuli_wdr.cpp:3088
 msgid "Force ZLIB compression"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3081
+#: src/muuli_wdr.cpp:3112
 msgid "Enable Verbose Debug-Logging."
 msgstr ""
 
-#: src/muuli_wdr.cpp:3083
+#: src/muuli_wdr.cpp:3114
 msgid "Only to Logfile"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3085
+#: src/muuli_wdr.cpp:3116
 msgid "Message Categories:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3109 src/PartFileConvertDlg.cpp:160
+#: src/muuli_wdr.cpp:3140 src/PartFileConvertDlg.cpp:160
 msgid "Waiting..."
 msgstr ""
 
-#: src/muuli_wdr.cpp:3129
+#: src/muuli_wdr.cpp:3160
 msgid "Add imports"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3132
+#: src/muuli_wdr.cpp:3163
 msgid "Retry selected"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3134
+#: src/muuli_wdr.cpp:3165
 msgid "Remove selected"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3197
+#: src/muuli_wdr.cpp:3228
 msgid "Event Types"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3216
+#: src/muuli_wdr.cpp:3247
 msgid "Statistics and queued clients for selected file(s) : Session / All time"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3240
+#: src/muuli_wdr.cpp:3271
 msgid "Active Uploads"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3254
+#: src/muuli_wdr.cpp:3285
 msgid "Percent of total files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3306
+#: src/muuli_wdr.cpp:3337
 msgid "Show Clients for"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3308
+#: src/muuli_wdr.cpp:3339
 msgid "All files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3311
+#: src/muuli_wdr.cpp:3342
 msgid "Selected files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3314
+#: src/muuli_wdr.cpp:3345
 msgid "Active uploads only"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3321
+#: src/muuli_wdr.cpp:3352
 msgid "Reload:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3325
+#: src/muuli_wdr.cpp:3356
 msgid "Reload your shared files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3388
+#: src/muuli_wdr.cpp:3419
 msgid "Send"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3389
+#: src/muuli_wdr.cpp:3420
 msgid "Sends the specified message."
 msgstr ""
 
-#: src/muuli_wdr.cpp:3393
+#: src/muuli_wdr.cpp:3424
 msgid "Close this chat-session."
 msgstr ""
 
-#: src/muuli_wdr.cpp:3416
+#: src/muuli_wdr.cpp:3447
 msgid "Connect to any server and/or Kad"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3422 src/SharedFilesCtrl.cpp:142 src/Statistics.cpp:941
+#: src/muuli_wdr.cpp:3453 src/SharedFilesCtrl.cpp:142 src/Statistics.cpp:941
 msgid "Shared Files"
 msgstr ""
 
@@ -5323,263 +5348,263 @@ msgstr ""
 msgid "ERROR: Failed to open partfile '%s'"
 msgstr ""
 
-#: src/Preferences.cpp:674
+#: src/Preferences.cpp:701
 msgid "System default"
 msgstr ""
 
-#: src/Preferences.cpp:675
+#: src/Preferences.cpp:702
 msgid "Albanian"
 msgstr ""
 
-#: src/Preferences.cpp:676
+#: src/Preferences.cpp:703
 msgid "Arabic"
 msgstr ""
 
-#: src/Preferences.cpp:677
+#: src/Preferences.cpp:704
 msgid "Asturian"
 msgstr ""
 
-#: src/Preferences.cpp:678
+#: src/Preferences.cpp:705
 msgid "Basque"
 msgstr ""
 
-#: src/Preferences.cpp:679
+#: src/Preferences.cpp:706
 msgid "Bulgarian"
 msgstr ""
 
-#: src/Preferences.cpp:680
+#: src/Preferences.cpp:707
 msgid "Catalan"
 msgstr ""
 
-#: src/Preferences.cpp:681
+#: src/Preferences.cpp:708
 msgid "Chinese (Simplified)"
 msgstr ""
 
-#: src/Preferences.cpp:682
+#: src/Preferences.cpp:709
 msgid "Chinese (Traditional)"
 msgstr ""
 
-#: src/Preferences.cpp:683
+#: src/Preferences.cpp:710
 msgid "Croatian"
 msgstr ""
 
-#: src/Preferences.cpp:684
+#: src/Preferences.cpp:711
 msgid "Czech"
 msgstr ""
 
-#: src/Preferences.cpp:685
+#: src/Preferences.cpp:712
 msgid "Danish"
 msgstr ""
 
-#: src/Preferences.cpp:686
+#: src/Preferences.cpp:713
 msgid "Dutch"
 msgstr ""
 
-#: src/Preferences.cpp:687
+#: src/Preferences.cpp:714
 msgid "English (U.K.)"
 msgstr ""
 
-#: src/Preferences.cpp:688
+#: src/Preferences.cpp:715
 msgid "English (U.S.)"
 msgstr ""
 
-#: src/Preferences.cpp:689
+#: src/Preferences.cpp:716
 msgid "Estonian"
 msgstr ""
 
-#: src/Preferences.cpp:690
+#: src/Preferences.cpp:717
 msgid "Finnish"
 msgstr ""
 
-#: src/Preferences.cpp:691
+#: src/Preferences.cpp:718
 msgid "French"
 msgstr ""
 
-#: src/Preferences.cpp:692
+#: src/Preferences.cpp:719
 msgid "Galician"
 msgstr ""
 
-#: src/Preferences.cpp:693
+#: src/Preferences.cpp:720
 msgid "German"
 msgstr ""
 
-#: src/Preferences.cpp:694
+#: src/Preferences.cpp:721
 msgid "Greek"
 msgstr ""
 
-#: src/Preferences.cpp:695
+#: src/Preferences.cpp:722
 msgid "Hebrew"
 msgstr ""
 
-#: src/Preferences.cpp:696
+#: src/Preferences.cpp:723
 msgid "Hungarian"
 msgstr ""
 
-#: src/Preferences.cpp:697
+#: src/Preferences.cpp:724
 msgid "Italian"
 msgstr ""
 
-#: src/Preferences.cpp:698
+#: src/Preferences.cpp:725
 msgid "Japanese"
 msgstr ""
 
-#: src/Preferences.cpp:699
+#: src/Preferences.cpp:726
 msgid "Korean"
 msgstr ""
 
-#: src/Preferences.cpp:700
+#: src/Preferences.cpp:727
 msgid "Latvian"
 msgstr ""
 
-#: src/Preferences.cpp:701
+#: src/Preferences.cpp:728
 msgid "Lithuanian"
 msgstr ""
 
-#: src/Preferences.cpp:702
+#: src/Preferences.cpp:729
 msgid "Norwegian (Nynorsk)"
 msgstr ""
 
-#: src/Preferences.cpp:703
+#: src/Preferences.cpp:730
 msgid "Polish"
 msgstr ""
 
-#: src/Preferences.cpp:704
+#: src/Preferences.cpp:731
 msgid "Portuguese"
 msgstr ""
 
-#: src/Preferences.cpp:705
+#: src/Preferences.cpp:732
 msgid "Portuguese (Brazilian)"
 msgstr ""
 
-#: src/Preferences.cpp:706
+#: src/Preferences.cpp:733
 msgid "Romanian"
 msgstr ""
 
-#: src/Preferences.cpp:707
+#: src/Preferences.cpp:734
 msgid "Russian"
 msgstr ""
 
-#: src/Preferences.cpp:708
+#: src/Preferences.cpp:735
 msgid "Slovenian"
 msgstr ""
 
-#: src/Preferences.cpp:709
+#: src/Preferences.cpp:736
 msgid "Spanish"
 msgstr ""
 
-#: src/Preferences.cpp:710
+#: src/Preferences.cpp:737
 msgid "Swedish"
 msgstr ""
 
-#: src/Preferences.cpp:711
+#: src/Preferences.cpp:738
 msgid "Turkish"
 msgstr ""
 
-#: src/Preferences.cpp:712
+#: src/Preferences.cpp:739
 msgid "Ukrainian"
 msgstr ""
 
-#: src/Preferences.cpp:815
+#: src/Preferences.cpp:842
 msgid "Change Language"
 msgstr ""
 
-#: src/Preferences.cpp:879
+#: src/Preferences.cpp:906
 msgid "There are no translations installed for aMule"
 msgstr ""
 
-#: src/Preferences.cpp:880
+#: src/Preferences.cpp:907
 msgid "No languages available"
 msgstr ""
 
-#: src/Preferences.cpp:1011
+#: src/Preferences.cpp:1038
 msgid "no options available"
 msgstr ""
 
-#: src/Preferences.cpp:2182
+#: src/Preferences.cpp:2227
 msgid "Invalid category found, skipping"
 msgstr ""
 
-#: src/Preferences.cpp:2351
+#: src/Preferences.cpp:2396
 msgid "TCP port can't be higher than 65532 due to server UDP socket being TCP+3"
 msgstr ""
 
-#: src/Preferences.cpp:2352
+#: src/Preferences.cpp:2397
 #, c-format
 msgid "Default port will be used (%d)"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:298 src/Statistics.cpp:866
+#: src/PrefsUnifiedDlg.cpp:300 src/Statistics.cpp:866
 msgid "Connection"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:299 src/SearchListCtrl.cpp:117
+#: src/PrefsUnifiedDlg.cpp:301 src/SearchListCtrl.cpp:117
 msgid "Directories"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:300 src/Statistics.cpp:917
+#: src/PrefsUnifiedDlg.cpp:302 src/Statistics.cpp:917
 msgid "Servers"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:301 src/ServerListCtrl.cpp:96
+#: src/PrefsUnifiedDlg.cpp:303 src/ServerListCtrl.cpp:96
 msgid "Files"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:302
+#: src/PrefsUnifiedDlg.cpp:304
 msgid "Security"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:303
+#: src/PrefsUnifiedDlg.cpp:305
 msgid "Interface"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:310
+#: src/PrefsUnifiedDlg.cpp:312
 msgid "IP2Country"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:313
+#: src/PrefsUnifiedDlg.cpp:315
 msgid "Proxy"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:314
+#: src/PrefsUnifiedDlg.cpp:316
 msgid "Filters"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:315
+#: src/PrefsUnifiedDlg.cpp:317
 msgid "Remote Controls"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:316
+#: src/PrefsUnifiedDlg.cpp:318
 msgid "Online Signature"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:317
+#: src/PrefsUnifiedDlg.cpp:319
 msgid "Advanced"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:318
+#: src/PrefsUnifiedDlg.cpp:320
 msgid "Events"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:321
+#: src/PrefsUnifiedDlg.cpp:323
 msgid "Debugging"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:451
+#: src/PrefsUnifiedDlg.cpp:453
 msgid ""
 "The following variables will be substituted:\n"
 "    %PARTFILE - full path to the file\n"
 "    %PARTNAME - file name only"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:472
+#: src/PrefsUnifiedDlg.cpp:474
 msgid "Tray icon support requires libayatana-appindicator3 at compile time."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:488
+#: src/PrefsUnifiedDlg.cpp:490
 msgid "Not available on Wayland: the protocol does not report when a window is minimized, so this option cannot intercept the system minimize button. Workaround: launch aMule with `GDK_BACKEND=x11` to use XWayland instead."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:534
+#: src/PrefsUnifiedDlg.cpp:536
 msgid ""
 "Do not change these setting unless you know\n"
 "what you are doing, otherwise you can easily\n"
@@ -5589,387 +5614,400 @@ msgid ""
 "these settings."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:645
+#: src/PrefsUnifiedDlg.cpp:647
 #, c-format
 msgid "Failed to connect Cfg to widget with the ID %d and key %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:693
+#: src/PrefsUnifiedDlg.cpp:695
 #, c-format
 msgid "Failed to transfer data from Cfg to Widget with the ID %d and key %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:799
+#: src/PrefsUnifiedDlg.cpp:801
 msgid "The type of proxy you are connecting to"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1003
+#: src/PrefsUnifiedDlg.cpp:1020
 #, c-format
 msgid "Failed to transfer data from Widget to Cfg with the ID %d and key %s"
 msgstr ""
 
 #: src/PrefsUnifiedDlg.cpp:1103
+msgid "No password set."
+msgstr ""
+
+#: src/PrefsUnifiedDlg.cpp:1132
+msgid "Guest access needs a password. Type one in the guest password field, or untick Enable guest access."
+msgstr ""
+
+#: src/PrefsUnifiedDlg.cpp:1144
 msgid ""
 "aMule must be restarted to enable these changes:\n"
 "\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1110
+#: src/PrefsUnifiedDlg.cpp:1151
 msgid "- TCP port changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1115
+#: src/PrefsUnifiedDlg.cpp:1156
 msgid "- UDP port changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1120
+#: src/PrefsUnifiedDlg.cpp:1161
 msgid "- Network interface binding changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1125
+#: src/PrefsUnifiedDlg.cpp:1166
 msgid "- External connect port changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1129
+#: src/PrefsUnifiedDlg.cpp:1170
 msgid "- External connect acceptance changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1133
+#: src/PrefsUnifiedDlg.cpp:1174
 msgid "- External connect interface changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1137
+#: src/PrefsUnifiedDlg.cpp:1178
 msgid "- Protocol obfuscation support changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1151
+#: src/PrefsUnifiedDlg.cpp:1193
 msgid "- amuleapi settings changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1160
+#: src/PrefsUnifiedDlg.cpp:1202
 msgid ""
 "Your Auto-update server list is empty.\n"
 "'Auto-update server list at startup' will be disabled."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1171
+#: src/PrefsUnifiedDlg.cpp:1213
 msgid ""
 "You have enabled external connections but have not specified a password.\n"
 "External connections cannot be enabled unless a valid password is specified."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1202
+#: src/PrefsUnifiedDlg.cpp:1246
+#, c-format
+msgid "The amuleapi password could not be saved: %s"
+msgstr ""
+
+#: src/PrefsUnifiedDlg.cpp:1276
 msgid "- Language changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1207
+#: src/PrefsUnifiedDlg.cpp:1281
 msgid "- Temp folder changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1212
+#: src/PrefsUnifiedDlg.cpp:1286
 msgid "- ED2K network enabled.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1245
+#: src/PrefsUnifiedDlg.cpp:1319
 msgid "The shared-file exclusion pattern is not a valid regular expression. The filter has been left disabled."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1247 src/PrefsUnifiedDlg.cpp:1841
+#: src/PrefsUnifiedDlg.cpp:1321 src/PrefsUnifiedDlg.cpp:1921
 msgid "Invalid regular expression"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1324
+#: src/PrefsUnifiedDlg.cpp:1398
 msgid ""
 "Both eD2k and Kad network are disabled.\n"
 "You won't be able to connect until you enable at least one of them."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1329
+#: src/PrefsUnifiedDlg.cpp:1403
 msgid ""
 "Kad will not start if your UDP port is disabled.\n"
 "Enable UDP port or disable Kad."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1385
+#: src/PrefsUnifiedDlg.cpp:1459
 msgid ""
 "\n"
 "You MUST restart aMule now.\n"
 "If you do not restart now, don't complain if anything bad happens.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1450
+#: src/PrefsUnifiedDlg.cpp:1524
 msgid "Could not register aMule for autostart at login. The autostart store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1452
+#: src/PrefsUnifiedDlg.cpp:1526
 msgid "Could not remove the autostart-at-login entry."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1453
+#: src/PrefsUnifiedDlg.cpp:1527
 msgid "Autostart"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1468
+#: src/PrefsUnifiedDlg.cpp:1542
 msgid "Register file type"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1468
+#: src/PrefsUnifiedDlg.cpp:1542
 msgid "Register URL handler"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1476
+#: src/PrefsUnifiedDlg.cpp:1550
 #, c-format
 msgid "aMule only handles eD2k-compatible magnets. If you replace the current magnet handler (%s), BitTorrent magnet links will stop working - aMule cannot download BitTorrent content. Continue?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1481
+#: src/PrefsUnifiedDlg.cpp:1555
 #, c-format
 msgid "Another application currently opens .emulecollection files (%s). Replace it with aMule?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1486
+#: src/PrefsUnifiedDlg.cpp:1560
 #, c-format
 msgid "Another application is currently the default handler for these links (%s). Replace it with aMule?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1511
+#: src/PrefsUnifiedDlg.cpp:1585
 msgid "Could not register aMule for .emulecollection files. The registration store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1513
+#: src/PrefsUnifiedDlg.cpp:1587
 msgid "Could not remove the file type registration."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1515
+#: src/PrefsUnifiedDlg.cpp:1589
 msgid "Could not register aMule as the URL handler. The registration store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1517
+#: src/PrefsUnifiedDlg.cpp:1591
 msgid "Could not remove the URL handler registration."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1587 src/PrefsUnifiedDlg.cpp:1614
+#: src/PrefsUnifiedDlg.cpp:1661 src/PrefsUnifiedDlg.cpp:1688
 msgid "The web server and aMule API require external connections to be enabled."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1597
+#: src/PrefsUnifiedDlg.cpp:1671
 msgid "The aMule web server is deprecated. Consider running the aMule API instead."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1655
+#: src/PrefsUnifiedDlg.cpp:1735
 msgid ""
 "Your Auto-update servers list is in blank.\n"
 "Please fill in at least one URL to point to a valid server.met file.\n"
 "Click on the button \"List\" by this checkbox to enter an URL."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1796
+#: src/PrefsUnifiedDlg.cpp:1876
 msgid "Temporary files"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1801
+#: src/PrefsUnifiedDlg.cpp:1881
 msgid "Incoming files"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1806
+#: src/PrefsUnifiedDlg.cpp:1886
 msgid "Online Signatures"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1819
+#: src/PrefsUnifiedDlg.cpp:1899
 #, c-format
 msgid "Choose a folder for %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1843
+#: src/PrefsUnifiedDlg.cpp:1923
 #, c-format
 msgid "Would exclude %u of %u shared file"
 msgid_plural "Would exclude %u of %u shared files"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/PrefsUnifiedDlg.cpp:1860
+#: src/PrefsUnifiedDlg.cpp:1940
 msgid "Browse for videoplayer"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1864
+#: src/PrefsUnifiedDlg.cpp:1944
 msgid "Select browser"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1868
+#: src/PrefsUnifiedDlg.cpp:1948
 msgid "Select ffprobe binary"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1874
+#: src/PrefsUnifiedDlg.cpp:1954
 #, c-format
 msgid "Executable%s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1908
+#: src/PrefsUnifiedDlg.cpp:1988
 msgid "ffprobe not found on PATH or in the standard install locations. Install ffmpeg (which ships ffprobe) or use Browse to pick a binary manually."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1920
+#: src/PrefsUnifiedDlg.cpp:2000
 msgid "Reset the settings on this page to their default values?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1921
+#: src/PrefsUnifiedDlg.cpp:2001
 msgid "Reset to defaults"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1948
+#: src/PrefsUnifiedDlg.cpp:2028
 msgid "Edit server list"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1949
+#: src/PrefsUnifiedDlg.cpp:2029
 msgid ""
 "Add here URL's to download server.met files.\n"
 "Only one url on each line."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2004
+#: src/PrefsUnifiedDlg.cpp:2084
 msgid "IP2Country update failed"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2149 src/PrefsUnifiedDlg.cpp:2180
+#: src/PrefsUnifiedDlg.cpp:2229 src/PrefsUnifiedDlg.cpp:2260
 msgid "Data by MaxMind GeoLite2"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2151 src/PrefsUnifiedDlg.cpp:2182
+#: src/PrefsUnifiedDlg.cpp:2231 src/PrefsUnifiedDlg.cpp:2262
 msgid "Custom source"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2153 src/PrefsUnifiedDlg.cpp:2184
+#: src/PrefsUnifiedDlg.cpp:2233 src/PrefsUnifiedDlg.cpp:2264
 msgid "Data by DB-IP.com"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2204
+#: src/PrefsUnifiedDlg.cpp:2284
 #, c-format
 msgid "Status: Loaded%s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2206
+#: src/PrefsUnifiedDlg.cpp:2286
 #, c-format
 msgid "Status: Loaded%s - %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2210
+#: src/PrefsUnifiedDlg.cpp:2290
 msgid "Status: Failed to load - click 'Update now' to refresh."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2212
+#: src/PrefsUnifiedDlg.cpp:2292
 msgid "Status: Not found - click 'Update now' to download."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2270 src/PrefsUnifiedDlg.cpp:2294
+#: src/PrefsUnifiedDlg.cpp:2350 src/PrefsUnifiedDlg.cpp:2374
 #, c-format
 msgid "Update delay: %d second"
 msgid_plural "Update delay: %d seconds"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/PrefsUnifiedDlg.cpp:2278
+#: src/PrefsUnifiedDlg.cpp:2358
 #, c-format
 msgid "Time for average graph: %d minute"
 msgid_plural "Time for average graph: %d minutes"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/PrefsUnifiedDlg.cpp:2287
+#: src/PrefsUnifiedDlg.cpp:2367
 #, c-format
 msgid "Connections Graph Scale: %d"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2302
+#: src/PrefsUnifiedDlg.cpp:2382
 #, c-format
 msgid "File Buffer Size: %d byte"
 msgid_plural "File Buffer Size: %d bytes"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/PrefsUnifiedDlg.cpp:2312
+#: src/PrefsUnifiedDlg.cpp:2392
 #, c-format
 msgid "Upload Queue Size: %d client"
 msgid_plural "Upload Queue Size: %d clients"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/PrefsUnifiedDlg.cpp:2322
+#: src/PrefsUnifiedDlg.cpp:2402
 #, c-format
 msgid "Server connection refresh interval: %d minute"
 msgid_plural "Server connection refresh interval: %d minutes"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/PrefsUnifiedDlg.cpp:2327
+#: src/PrefsUnifiedDlg.cpp:2407
 msgid "Server connection refresh interval: Disabled"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2371
+#: src/PrefsUnifiedDlg.cpp:2451
 msgid "disabled"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2397
+#: src/PrefsUnifiedDlg.cpp:2477
 #, c-format
 msgid "Execute command on '%s' event"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2404
+#: src/PrefsUnifiedDlg.cpp:2484
 msgid "Enable command execution on core"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2416
+#: src/PrefsUnifiedDlg.cpp:2496
 msgid "Core command:"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2432
+#: src/PrefsUnifiedDlg.cpp:2512
 msgid "Enable command execution on GUI"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2444
+#: src/PrefsUnifiedDlg.cpp:2524
 msgid "GUI command:"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2460
+#: src/PrefsUnifiedDlg.cpp:2540
 msgid "The following variables will be replaced:"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2628
+#: src/PrefsUnifiedDlg.cpp:2708
 msgid ""
 "The following folders look like system or sensitive locations:\n"
 "\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2633
+#: src/PrefsUnifiedDlg.cpp:2713
 msgid "Sharing them recursively will publish every file underneath on the eD2k/Kad networks. Do you really want to do this?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2636
+#: src/PrefsUnifiedDlg.cpp:2716
 msgid "Confirm shared folders"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2664
+#: src/PrefsUnifiedDlg.cpp:2744
 msgid "Reloading shared files..."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2665
+#: src/PrefsUnifiedDlg.cpp:2745
 msgid "Scanning for subdirectories..."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2666
+#: src/PrefsUnifiedDlg.cpp:2746
 msgid "Updating shared folders"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2693
+#: src/PrefsUnifiedDlg.cpp:2773
 #, c-format
 msgid "Scanned %u directories..."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2743
+#: src/PrefsUnifiedDlg.cpp:2823
 #, c-format
 msgid "Reloading shared files: %u files scanned"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2793
+#: src/PrefsUnifiedDlg.cpp:2873
 msgid "Shared folder"
 msgstr ""
 

--- a/po/bn.po
+++ b/po/bn.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-28 12:17+0200\n"
+"POT-Creation-Date: 2026-07-28 13:09+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: none\n"
@@ -275,7 +275,7 @@ msgid "Password set and external connections enabled."
 msgstr ""
 
 #: src/amule.cpp:755 src/KadDlg.cpp:176 src/KadDlg.cpp:185
-#: src/PrefsUnifiedDlg.cpp:1461 src/SharedFilesCtrl.cpp:476
+#: src/PrefsUnifiedDlg.cpp:1470 src/SharedFilesCtrl.cpp:476
 msgid "WARNING"
 msgstr ""
 
@@ -310,7 +310,7 @@ msgstr ""
 #: src/amule-remote-gui.cpp:603 src/amule-remote-gui.cpp:671
 #: src/amule-remote-gui.cpp:709 src/amule-remote-gui.cpp:1282
 #: src/amule-remote-gui.cpp:1345 src/amule-remote-gui.cpp:1372
-#: src/DownloadQueue.cpp:1481 src/PrefsUnifiedDlg.cpp:1247
+#: src/DownloadQueue.cpp:1481 src/PrefsUnifiedDlg.cpp:1256
 msgid "ERROR"
 msgstr ""
 
@@ -563,36 +563,36 @@ msgstr ""
 msgid "FATAL ERROR: Failed to create Timer"
 msgstr ""
 
-#: src/amuleDlg.cpp:361 src/amuleDlg.cpp:1787 src/amuleDlg.cpp:2033
-#: src/muuli_wdr.cpp:1492 src/muuli_wdr.cpp:3449
+#: src/amuleDlg.cpp:361 src/amuleDlg.cpp:1810 src/amuleDlg.cpp:2056
+#: src/muuli_wdr.cpp:1492 src/muuli_wdr.cpp:3453
 msgid "Networks"
 msgstr ""
 
-#: src/amuleDlg.cpp:362 src/amuleDlg.cpp:1793 src/muuli_wdr.cpp:3450
+#: src/amuleDlg.cpp:362 src/amuleDlg.cpp:1816 src/muuli_wdr.cpp:3454
 msgid "Searches"
 msgstr ""
 
-#: src/amuleDlg.cpp:363 src/amuleDlg.cpp:1799 src/DownloadListCtrl.cpp:740
-#: src/muuli_wdr.cpp:392 src/muuli_wdr.cpp:1585 src/muuli_wdr.cpp:3451
+#: src/amuleDlg.cpp:363 src/amuleDlg.cpp:1822 src/DownloadListCtrl.cpp:740
+#: src/muuli_wdr.cpp:392 src/muuli_wdr.cpp:1585 src/muuli_wdr.cpp:3455
 #: src/Statistics.cpp:829
 msgid "Downloads"
 msgstr ""
 
-#: src/amuleDlg.cpp:364 src/amuleDlg.cpp:1805 src/muuli_wdr.cpp:3325
+#: src/amuleDlg.cpp:364 src/amuleDlg.cpp:1828 src/muuli_wdr.cpp:3329
 msgid "Shared files"
 msgstr ""
 
-#: src/amuleDlg.cpp:365 src/amuleDlg.cpp:1811 src/muuli_wdr.cpp:2957
-#: src/muuli_wdr.cpp:3407 src/muuli_wdr.cpp:3454
+#: src/amuleDlg.cpp:365 src/amuleDlg.cpp:1834 src/muuli_wdr.cpp:2961
+#: src/muuli_wdr.cpp:3411 src/muuli_wdr.cpp:3458
 msgid "Messages"
 msgstr ""
 
-#: src/amuleDlg.cpp:366 src/amuleDlg.cpp:1817 src/muuli_wdr.cpp:3455
+#: src/amuleDlg.cpp:366 src/amuleDlg.cpp:1840 src/muuli_wdr.cpp:3459
 #: src/PrefsUnifiedDlg.cpp:314 src/Statistics.cpp:779 src/Statistics.cpp:1235
 msgid "Statistics"
 msgstr ""
 
-#: src/amuleDlg.cpp:368 src/amuleDlg.cpp:1824 src/muuli_wdr.cpp:3457
+#: src/amuleDlg.cpp:368 src/amuleDlg.cpp:1847 src/muuli_wdr.cpp:3461
 #: src/PrefsUnifiedDlg.cpp:330 src/utils/wxCas/src/wxcasprefs.cpp:39
 msgid "Preferences"
 msgstr ""
@@ -650,8 +650,8 @@ msgstr ""
 #: src/amuleDlg.cpp:1029 src/DownloadListCtrl.cpp:505
 #: src/DownloadListCtrl.cpp:749 src/FriendListCtrl.cpp:180
 #: src/muuli_wdr.cpp:731 src/muuli_wdr.cpp:782 src/muuli_wdr.cpp:846
-#: src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2262 src/muuli_wdr.cpp:2347
-#: src/muuli_wdr.cpp:3095 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
+#: src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2266 src/muuli_wdr.cpp:2351
+#: src/muuli_wdr.cpp:3099 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
 #: src/ServerListCtrl.cpp:606 src/TransferWnd.cpp:378
 #: src/utils/wxCas/src/wxcasprefs.cpp:235
 msgid "Cancel"
@@ -662,7 +662,7 @@ msgid "Stop the current connection attempts"
 msgstr ""
 
 #: src/amuleDlg.cpp:1035 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976
-#: src/muuli_wdr.cpp:2485
+#: src/muuli_wdr.cpp:2489
 msgid "Disconnect"
 msgstr ""
 
@@ -671,7 +671,7 @@ msgid "Disconnect from the currently connected networks"
 msgstr ""
 
 #: src/amuleDlg.cpp:1041 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979
-#: src/muuli_wdr.cpp:2640 src/muuli_wdr.cpp:3092 src/muuli_wdr.cpp:3447
+#: src/muuli_wdr.cpp:2644 src/muuli_wdr.cpp:3096 src/muuli_wdr.cpp:3451
 msgid "Connect"
 msgstr ""
 
@@ -725,7 +725,7 @@ msgstr ""
 msgid "Launch Command: "
 msgstr ""
 
-#: src/amuleDlg.cpp:1632 src/muuli_wdr.cpp:1982 src/Preferences.cpp:979
+#: src/amuleDlg.cpp:1632 src/muuli_wdr.cpp:1986 src/Preferences.cpp:979
 msgid "- default -"
 msgstr ""
 
@@ -739,60 +739,60 @@ msgstr ""
 msgid "WARNING: Unable to open skin file '%s' for read"
 msgstr ""
 
-#: src/amuleDlg.cpp:1791 src/muuli_wdr.cpp:3449
+#: src/amuleDlg.cpp:1814 src/muuli_wdr.cpp:3453
 msgid "Networks Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1797 src/muuli_wdr.cpp:3450
+#: src/amuleDlg.cpp:1820 src/muuli_wdr.cpp:3454
 msgid "Searches Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1803 src/muuli_wdr.cpp:3451
+#: src/amuleDlg.cpp:1826 src/muuli_wdr.cpp:3455
 msgid "Downloads Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1809 src/muuli_wdr.cpp:3453
+#: src/amuleDlg.cpp:1832 src/muuli_wdr.cpp:3457
 msgid "Shared Files Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1815 src/muuli_wdr.cpp:3454
+#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3458
 msgid "Messages Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1821 src/muuli_wdr.cpp:3455
+#: src/amuleDlg.cpp:1844 src/muuli_wdr.cpp:3459
 msgid "Statistics Graph Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1828 src/muuli_wdr.cpp:3457
+#: src/amuleDlg.cpp:1851 src/muuli_wdr.cpp:3461
 msgid "Preferences Settings Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1831 src/muuli_wdr.cpp:3458
+#: src/amuleDlg.cpp:1854 src/muuli_wdr.cpp:3462
 msgid "Import"
 msgstr ""
 
-#: src/amuleDlg.cpp:1835 src/muuli_wdr.cpp:3458
+#: src/amuleDlg.cpp:1858 src/muuli_wdr.cpp:3462
 msgid "The partfile importer tool"
 msgstr ""
 
-#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3459
+#: src/amuleDlg.cpp:1861 src/muuli_wdr.cpp:3463
 #: src/utils/aLinkCreator/src/alcframe.cpp:262
 msgid "About"
 msgstr ""
 
-#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3459
+#: src/amuleDlg.cpp:1861 src/muuli_wdr.cpp:3463
 msgid "About/Help"
 msgstr ""
 
-#: src/amuleDlg.cpp:2036
+#: src/amuleDlg.cpp:2059
 msgid "eD2k network"
 msgstr ""
 
-#: src/amuleDlg.cpp:2039
+#: src/amuleDlg.cpp:2062
 msgid "Kad network"
 msgstr ""
 
-#: src/amuleDlg.cpp:2039
+#: src/amuleDlg.cpp:2062
 msgid "No network"
 msgstr ""
 
@@ -1319,19 +1319,19 @@ msgstr ""
 msgid "Very low"
 msgstr ""
 
-#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:743 src/muuli_wdr.cpp:2313
+#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:743 src/muuli_wdr.cpp:2317
 #: src/ServerListCtrl.cpp:263 src/ServerListCtrl.cpp:456
 #: src/SharedFilesCtrl.cpp:145
 msgid "Low"
 msgstr ""
 
-#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:744 src/muuli_wdr.cpp:2314
+#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:744 src/muuli_wdr.cpp:2318
 #: src/ServerListCtrl.cpp:266 src/ServerListCtrl.cpp:457
 #: src/SharedFilesCtrl.cpp:146
 msgid "Normal"
 msgstr ""
 
-#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:745 src/muuli_wdr.cpp:2315
+#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:745 src/muuli_wdr.cpp:2319
 #: src/ServerListCtrl.cpp:269 src/ServerListCtrl.cpp:458
 #: src/SharedFilesCtrl.cpp:147
 msgid "High"
@@ -1423,7 +1423,7 @@ msgstr ""
 msgid "Remote Server"
 msgstr ""
 
-#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3212
+#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3216
 #: src/SearchDlg.cpp:119 src/TextClient.cpp:911
 msgid "Kad"
 msgstr ""
@@ -1494,7 +1494,7 @@ msgstr ""
 msgid "Size"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3279
+#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3283
 msgid "Transferred"
 msgstr ""
 
@@ -1550,7 +1550,7 @@ msgid ""
 "\n"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:746 src/muuli_wdr.cpp:2316
+#: src/DownloadListCtrl.cpp:746 src/muuli_wdr.cpp:2320
 #: src/SharedFilesCtrl.cpp:150
 msgid "Auto"
 msgstr ""
@@ -1588,7 +1588,7 @@ msgid "Extended Options"
 msgstr ""
 
 #: src/DownloadListCtrl.cpp:770 src/DownloadListCtrl.cpp:822
-#: src/muuli_wdr.cpp:1800
+#: src/muuli_wdr.cpp:1804
 msgid "Preview"
 msgstr ""
 
@@ -2354,23 +2354,23 @@ msgid ""
 "want downloads on a different (e.g. larger) disk."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:549 src/FirstRunWizard.cpp:611 src/muuli_wdr.cpp:1712
+#: src/FirstRunWizard.cpp:549 src/FirstRunWizard.cpp:611 src/muuli_wdr.cpp:1716
 msgid "Destination folder for downloads"
 msgstr ""
 
 #: src/FirstRunWizard.cpp:553 src/FirstRunWizard.cpp:569 src/muuli_wdr.cpp:1349
-#: src/muuli_wdr.cpp:1366 src/muuli_wdr.cpp:1687 src/muuli_wdr.cpp:1718
-#: src/muuli_wdr.cpp:1730 src/muuli_wdr.cpp:2800
+#: src/muuli_wdr.cpp:1366 src/muuli_wdr.cpp:1691 src/muuli_wdr.cpp:1722
+#: src/muuli_wdr.cpp:1734 src/muuli_wdr.cpp:2804
 #: src/utils/aLinkCreator/src/alcframe.cpp:135
 #: src/utils/wxCas/src/wxcasprefs.cpp:52 src/utils/wxCas/src/wxcasprefs.cpp:118
 msgid "Browse"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:559 src/muuli_wdr.cpp:1723
+#: src/FirstRunWizard.cpp:559 src/muuli_wdr.cpp:1727
 msgid "(All files in this folder are shared with other peers)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:565 src/FirstRunWizard.cpp:624 src/muuli_wdr.cpp:1725
+#: src/FirstRunWizard.cpp:565 src/FirstRunWizard.cpp:624 src/muuli_wdr.cpp:1729
 msgid "Folder for temporary download files"
 msgstr ""
 
@@ -2401,7 +2401,7 @@ msgstr ""
 msgid "CRITICAL - no client on StartChatSession"
 msgstr ""
 
-#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2706 src/muuli_wdr.cpp:3383
+#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2710 src/muuli_wdr.cpp:3387
 msgid "Friends"
 msgstr ""
 
@@ -2507,8 +2507,8 @@ msgstr ""
 msgid "No"
 msgstr ""
 
-#: src/GenericClientListCtrl.cpp:1216 src/PrefsUnifiedDlg.cpp:2898
-#: src/PrefsUnifiedDlg.cpp:2948 src/ServerListCtrl.cpp:276
+#: src/GenericClientListCtrl.cpp:1216 src/PrefsUnifiedDlg.cpp:2907
+#: src/PrefsUnifiedDlg.cpp:2957 src/ServerListCtrl.cpp:276
 msgid "Yes"
 msgstr ""
 
@@ -2675,10 +2675,10 @@ msgstr ""
 msgid "Please fill all fields required"
 msgstr ""
 
-#: src/KadDlg.cpp:192 src/PartFile.cpp:1031 src/PrefsUnifiedDlg.cpp:1134
-#: src/PrefsUnifiedDlg.cpp:1204 src/PrefsUnifiedDlg.cpp:1405
-#: src/PrefsUnifiedDlg.cpp:1663 src/PrefsUnifiedDlg.cpp:1673
-#: src/PrefsUnifiedDlg.cpp:1690 src/PrefsUnifiedDlg.cpp:1738
+#: src/KadDlg.cpp:192 src/PartFile.cpp:1031 src/PrefsUnifiedDlg.cpp:1143
+#: src/PrefsUnifiedDlg.cpp:1213 src/PrefsUnifiedDlg.cpp:1414
+#: src/PrefsUnifiedDlg.cpp:1672 src/PrefsUnifiedDlg.cpp:1682
+#: src/PrefsUnifiedDlg.cpp:1699 src/PrefsUnifiedDlg.cpp:1747
 msgid "Message"
 msgstr ""
 
@@ -2779,7 +2779,7 @@ msgstr ""
 msgid "Uploaded"
 msgstr ""
 
-#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3263
+#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3267
 msgid "Requested"
 msgstr ""
 
@@ -2902,7 +2902,7 @@ msgid "WARNING: "
 msgstr ""
 
 #: src/MuleNotebook.cpp:179 src/muuli_wdr.cpp:817 src/muuli_wdr.cpp:1229
-#: src/muuli_wdr.cpp:3167 src/muuli_wdr.cpp:3423
+#: src/muuli_wdr.cpp:3171 src/muuli_wdr.cpp:3427
 msgid "Close"
 msgstr ""
 
@@ -2920,7 +2920,7 @@ msgid "Paste"
 msgstr ""
 
 #: src/MuleTextCtrl.cpp:89 src/muuli_wdr.cpp:358 src/muuli_wdr.cpp:757
-#: src/muuli_wdr.cpp:2390 src/muuli_wdr.cpp:2409 src/muuli_wdr.cpp:2431
+#: src/muuli_wdr.cpp:2394 src/muuli_wdr.cpp:2413 src/muuli_wdr.cpp:2435
 #: src/utils/aLinkCreator/src/alcframe.cpp:142
 msgid "Clear"
 msgstr ""
@@ -3012,7 +3012,7 @@ msgstr ""
 
 #: src/MuleTrayIcon.cpp:579 src/MuleTrayIcon.cpp:945 src/MuleTrayIcon.cpp:965
 #: src/muuli_wdr.cpp:1398 src/muuli_wdr.cpp:1406 src/muuli_wdr.cpp:1413
-#: src/muuli_wdr.cpp:1846 src/muuli_wdr.cpp:1852 src/OtherFunctions.cpp:91
+#: src/muuli_wdr.cpp:1850 src/muuli_wdr.cpp:1856 src/OtherFunctions.cpp:91
 #: src/StatisticsDlg.cpp:93 src/StatisticsDlg.cpp:95
 msgid "kB/s"
 msgstr ""
@@ -3252,7 +3252,7 @@ msgstr ""
 msgid "KB"
 msgstr ""
 
-#: src/muuli_wdr.cpp:274 src/muuli_wdr.cpp:293 src/muuli_wdr.cpp:1631
+#: src/muuli_wdr.cpp:274 src/muuli_wdr.cpp:293 src/muuli_wdr.cpp:1635
 #: src/OtherFunctions.cpp:64
 msgid "MB"
 msgstr ""
@@ -3269,7 +3269,7 @@ msgstr ""
 msgid "Availability"
 msgstr ""
 
-#: src/muuli_wdr.cpp:312 src/muuli_wdr.cpp:398 src/muuli_wdr.cpp:3328
+#: src/muuli_wdr.cpp:312 src/muuli_wdr.cpp:398 src/muuli_wdr.cpp:3332
 msgid "Filter:"
 msgstr ""
 
@@ -3332,8 +3332,8 @@ msgstr ""
 #: src/muuli_wdr.cpp:1160 src/muuli_wdr.cpp:1167 src/muuli_wdr.cpp:1172
 #: src/muuli_wdr.cpp:1179 src/muuli_wdr.cpp:1184 src/muuli_wdr.cpp:1191
 #: src/muuli_wdr.cpp:1205 src/muuli_wdr.cpp:1212 src/muuli_wdr.cpp:1217
-#: src/muuli_wdr.cpp:1224 src/muuli_wdr.cpp:3265 src/muuli_wdr.cpp:3273
-#: src/muuli_wdr.cpp:3281
+#: src/muuli_wdr.cpp:1224 src/muuli_wdr.cpp:3269 src/muuli_wdr.cpp:3277
+#: src/muuli_wdr.cpp:3285
 msgid "N/A"
 msgstr ""
 
@@ -3473,7 +3473,7 @@ msgstr ""
 msgid "Album :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:685 src/muuli_wdr.cpp:2285
+#: src/muuli_wdr.cpp:685 src/muuli_wdr.cpp:2289
 msgid "Title :"
 msgstr ""
 
@@ -3579,7 +3579,7 @@ msgstr ""
 msgid "Userhash :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:895 src/muuli_wdr.cpp:1752 src/muuli_wdr.cpp:2480
+#: src/muuli_wdr.cpp:895 src/muuli_wdr.cpp:1756 src/muuli_wdr.cpp:2484
 #: src/utils/aLinkCreator/src/alcframe.cpp:137
 msgid "Add"
 msgstr ""
@@ -3588,15 +3588,15 @@ msgstr ""
 msgid "Download-Speed"
 msgstr ""
 
-#: src/muuli_wdr.cpp:954 src/muuli_wdr.cpp:989 src/muuli_wdr.cpp:2584
+#: src/muuli_wdr.cpp:954 src/muuli_wdr.cpp:989 src/muuli_wdr.cpp:2588
 msgid "Current"
 msgstr ""
 
-#: src/muuli_wdr.cpp:962 src/muuli_wdr.cpp:997 src/muuli_wdr.cpp:2592
+#: src/muuli_wdr.cpp:962 src/muuli_wdr.cpp:997 src/muuli_wdr.cpp:2596
 msgid "Running average"
 msgstr ""
 
-#: src/muuli_wdr.cpp:970 src/muuli_wdr.cpp:1005 src/muuli_wdr.cpp:2600
+#: src/muuli_wdr.cpp:970 src/muuli_wdr.cpp:1005 src/muuli_wdr.cpp:2604
 msgid "Session average"
 msgstr ""
 
@@ -3608,7 +3608,7 @@ msgstr ""
 msgid "Connections"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1024 src/muuli_wdr.cpp:1871
+#: src/muuli_wdr.cpp:1024 src/muuli_wdr.cpp:1875
 msgid "Active downloads"
 msgstr ""
 
@@ -3616,7 +3616,7 @@ msgstr ""
 msgid "Active connections (1:1)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1040 src/muuli_wdr.cpp:1872
+#: src/muuli_wdr.cpp:1040 src/muuli_wdr.cpp:1876
 msgid "Active uploads"
 msgstr ""
 
@@ -3889,7 +3889,7 @@ msgstr ""
 msgid "Advanced users only: If you have multiple network interfaces, enter the address of the interface to which aMule should be bound."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1462 src/muuli_wdr.cpp:2065
+#: src/muuli_wdr.cpp:1462 src/muuli_wdr.cpp:2069
 msgid "Bind to network interface (empty for any):"
 msgstr ""
 
@@ -3905,7 +3905,7 @@ msgstr ""
 msgid "Max simultaneous connections:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1498 src/muuli_wdr.cpp:3207
+#: src/muuli_wdr.cpp:1498 src/muuli_wdr.cpp:3211
 msgid "ED2K"
 msgstr ""
 
@@ -3997,763 +3997,763 @@ msgstr ""
 msgid "For new files preallocates disk space for the whole file, thus reduces fragmentation"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1617
+#: src/muuli_wdr.cpp:1621
 msgid "Create new files as sparse files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1618
+#: src/muuli_wdr.cpp:1622
 msgid "Sparse part files only occupy disk space for the parts already downloaded, so free space is used up gradually as the file fills in. Turn this off to use an ordinary file instead - useful where sparse files are unsupported or slow, or where backup/de-duplication tools handle them badly. Applies only when the core runs on Windows; on Linux and macOS part files are sparse anyway and this setting has no effect."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1623
+#: src/muuli_wdr.cpp:1627
 msgid "Stop downloads when free disk space reaches "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1624
+#: src/muuli_wdr.cpp:1628
 msgid "Select this if you want aMule to check your disk space"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1628
+#: src/muuli_wdr.cpp:1632
 msgid "Enter here the min disk space desired."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1634
+#: src/muuli_wdr.cpp:1638
 msgid "Save 10 sources on rare files (< 20 sources)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1638 src/Statistics.cpp:790
+#: src/muuli_wdr.cpp:1642 src/Statistics.cpp:790
 msgid "Uploads"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1641
+#: src/muuli_wdr.cpp:1645
 msgid "Add new shared files with auto priority"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1647
+#: src/muuli_wdr.cpp:1651
 msgid "Intelligent Corruption Handling (I.C.H.)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1650
+#: src/muuli_wdr.cpp:1654
 msgid "Enable"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1653
+#: src/muuli_wdr.cpp:1657
 msgid "Advanced I.C.H. trusts every hash (not recommended)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1665 src/PrefsUnifiedDlg.cpp:1990
+#: src/muuli_wdr.cpp:1669 src/PrefsUnifiedDlg.cpp:1999
 msgid "Media metadata extraction"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1669
+#: src/muuli_wdr.cpp:1673
 msgid "Extract length / bitrate / codec from shared audio and video files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1671
+#: src/muuli_wdr.cpp:1675
 msgid "When enabled, aMule runs ffprobe on each shared media file to fill in the Length / Bitrate / Codec columns other clients see when they find the file in a search. Requires ffmpeg (the ffprobe binary) to be installed."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1678
+#: src/muuli_wdr.cpp:1682
 msgid "Path to ffprobe:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1683
+#: src/muuli_wdr.cpp:1687
 msgid "Full path to the ffprobe binary. Leave empty to have aMule auto-detect it on startup."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1691
+#: src/muuli_wdr.cpp:1695
 msgid "Detect"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1692
+#: src/muuli_wdr.cpp:1696
 msgid "Search the standard install locations for an ffprobe binary and fill the path field."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1716
+#: src/muuli_wdr.cpp:1720
 msgid ""
 "Completed downloads are stored here. All files in this folder are automatically shared with other peers.\n"
 "If this folder also holds files you don't want to share, point it at an aMule-only sub-folder."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1719
+#: src/muuli_wdr.cpp:1723
 msgid "Pick the folder where completed downloads will be stored. All files in that folder will be shared with other peers."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1733
+#: src/muuli_wdr.cpp:1737
 msgid "Shared folders"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1739
+#: src/muuli_wdr.cpp:1743
 msgid "(Folders shared by the core. Enter a path to add one.)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1747
+#: src/muuli_wdr.cpp:1751
 msgid "Absolute path of a folder on the core's machine, e.g. /home/user/shared"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1749 src/PrefsUnifiedDlg.cpp:2874
+#: src/muuli_wdr.cpp:1753 src/PrefsUnifiedDlg.cpp:2883
 msgid "Recursive"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1750
+#: src/muuli_wdr.cpp:1754
 msgid "Share every sub-folder underneath this one, including ones created later."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1754 src/utils/aLinkCreator/src/alcframe.cpp:141
+#: src/muuli_wdr.cpp:1758 src/utils/aLinkCreator/src/alcframe.cpp:141
 msgid "Remove"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1758
+#: src/muuli_wdr.cpp:1762
 msgid "(Right click on folder icon for recursive share)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1765
+#: src/muuli_wdr.cpp:1769
 msgid "Share hidden files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1771
+#: src/muuli_wdr.cpp:1775
 msgid "Automatically rescan shared folders for changes"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1777
+#: src/muuli_wdr.cpp:1781
 msgid "Follow symbolic links in shared folders"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1783
+#: src/muuli_wdr.cpp:1787
 msgid "Exclude files matching:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1786
+#: src/muuli_wdr.cpp:1790
 msgid "Wildcard patterns separated by '|', e.g. .DS_Store|Thumbs.db|*.tmp. Files whose name matches are not shared. Matching is case-insensitive."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1790
+#: src/muuli_wdr.cpp:1794
 msgid "Patterns are regular expressions"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1791
+#: src/muuli_wdr.cpp:1795
 msgid "When set, the whole field is one regular expression ('|' is alternation). When unset, it is a list of '|'-separated wildcards."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1801
+#: src/muuli_wdr.cpp:1805
 msgid "Show how many shared files the current pattern would exclude."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1822
+#: src/muuli_wdr.cpp:1826
 msgid "Graphs"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1825 src/muuli_wdr.cpp:1887
+#: src/muuli_wdr.cpp:1829 src/muuli_wdr.cpp:1891
 msgid "Update delay : 5 secs"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1829
+#: src/muuli_wdr.cpp:1833
 msgid "Time for average graph: 100 mins"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1833
+#: src/muuli_wdr.cpp:1837
 msgid "Connections Graph Scale: 100 "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1840
+#: src/muuli_wdr.cpp:1844
 msgid "Download graph scale:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1848
+#: src/muuli_wdr.cpp:1852
 msgid "Upload graph scale:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1858
+#: src/muuli_wdr.cpp:1862
 msgid "Colors: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1862
+#: src/muuli_wdr.cpp:1866
 msgid "Background"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1863
+#: src/muuli_wdr.cpp:1867
 msgid "Grid"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1864
+#: src/muuli_wdr.cpp:1868
 msgid "Download current"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1865
+#: src/muuli_wdr.cpp:1869
 msgid "Download running average"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1866
+#: src/muuli_wdr.cpp:1870
 msgid "Download session average"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1867
+#: src/muuli_wdr.cpp:1871
 msgid "Upload current"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1868
+#: src/muuli_wdr.cpp:1872
 msgid "Upload running average"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1869
+#: src/muuli_wdr.cpp:1873
 msgid "Upload session average"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1870
+#: src/muuli_wdr.cpp:1874
 msgid "Active connections"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1873
+#: src/muuli_wdr.cpp:1877
 msgid "Systray Icon Speed Bar"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1874
+#: src/muuli_wdr.cpp:1878
 msgid "Kad-nodes current"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1875
+#: src/muuli_wdr.cpp:1879
 msgid "Kad-nodes running"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1876
+#: src/muuli_wdr.cpp:1880
 msgid "Kad-nodes session"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1880 src/muuli_wdr.cpp:2334
+#: src/muuli_wdr.cpp:1884 src/muuli_wdr.cpp:2338
 msgid "Select"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1884
+#: src/muuli_wdr.cpp:1888
 msgid "Tree"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1894
+#: src/muuli_wdr.cpp:1898
 msgid "Number of Client Versions shown (0=unlimited)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1919
+#: src/muuli_wdr.cpp:1923
 msgid "!!! WARNING !!!"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1934
+#: src/muuli_wdr.cpp:1938
 msgid "Max new connections / 5 secs"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1936
+#: src/muuli_wdr.cpp:1940
 msgid "Concurrent Kad source lookups"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1938
+#: src/muuli_wdr.cpp:1942
 msgid "Kad source re-search interval (minutes)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1940
+#: src/muuli_wdr.cpp:1944
 msgid "Source re-ask interval (minutes)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1944
+#: src/muuli_wdr.cpp:1948
 msgid "File Buffer Size: 240000 bytes"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1948
+#: src/muuli_wdr.cpp:1952
 msgid "Use MMAP: memory-mapped file access (lower memory use)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1949
+#: src/muuli_wdr.cpp:1953
 msgid "Maps part files into memory instead of buffering them on the heap, lowering the process memory footprint. May reduce download speed on some disks; best for memory-constrained or upload-heavy hosts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1951
+#: src/muuli_wdr.cpp:1955
 msgid "Upload Queue Size: 5000 clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1955
+#: src/muuli_wdr.cpp:1959
 msgid "Server connection refresh interval: Disable"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1959
+#: src/muuli_wdr.cpp:1963
 msgid "Disable computer's timed standby mode"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1978
+#: src/muuli_wdr.cpp:1982
 msgid "Skin to use: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1987
+#: src/muuli_wdr.cpp:1991
 msgid "Show \"Fast eD2k Links Handler\" in every window."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1990
+#: src/muuli_wdr.cpp:1994
 msgid "Show extended info on categories tabs"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1993
+#: src/muuli_wdr.cpp:1997
 msgid "Show application version on title"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1995
+#: src/muuli_wdr.cpp:1999
 msgid "Show transfer rates on title"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1997
+#: src/muuli_wdr.cpp:2001
 msgid "Before application name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1999
+#: src/muuli_wdr.cpp:2003
 msgid "After application name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2002
+#: src/muuli_wdr.cpp:2006
 msgid "Show overhead bandwidth"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2006
+#: src/muuli_wdr.cpp:2010
 msgid "Vertical toolbar orientation"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2008
+#: src/muuli_wdr.cpp:2012
 msgid "Live column sorting (auto-reorder rows as their values change)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2015
+#: src/muuli_wdr.cpp:2019
 msgid "Download Queue Files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2018
+#: src/muuli_wdr.cpp:2022
 msgid "Show progress percentage"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2024
+#: src/muuli_wdr.cpp:2028
 msgid "Show progress bar"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2027
+#: src/muuli_wdr.cpp:2031
 msgid "Flat"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2031
+#: src/muuli_wdr.cpp:2035
 msgid "Round"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2049
+#: src/muuli_wdr.cpp:2053
 msgid "External Connection Parameters"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2052
+#: src/muuli_wdr.cpp:2056
 msgid "Accept external connections"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2059 src/muuli_wdr.cpp:2118
+#: src/muuli_wdr.cpp:2063 src/muuli_wdr.cpp:2122
 msgid "IP of the listening interface:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2062
+#: src/muuli_wdr.cpp:2066
 msgid "Enter here a valid ip in the a.b.c.d format for the listening EC interface. An empty field or 0.0.0.0 will mean any interface."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2083 src/muuli_wdr.cpp:2194
+#: src/muuli_wdr.cpp:2087 src/muuli_wdr.cpp:2198
 msgid "TCP port:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2089
+#: src/muuli_wdr.cpp:2093
 msgid "Enable UPnP port forwarding on the EC port"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2093 src/muuli_wdr.cpp:3079
+#: src/muuli_wdr.cpp:2097 src/muuli_wdr.cpp:3083
 #: src/utils/wxCas/src/wxcasprefs.cpp:167
 msgid "Password"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2099
+#: src/muuli_wdr.cpp:2103
 msgid "aMule API server parameters"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2102
+#: src/muuli_wdr.cpp:2106
 msgid "Run amuleapi (REST API) on startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2107
+#: src/muuli_wdr.cpp:2111
 msgid "HTTP port:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2121
+#: src/muuli_wdr.cpp:2125
 msgid "The interface amuleapi's HTTP server listens on. 127.0.0.1 (default) accepts only local connections; use 0.0.0.0 or a specific IP to expose it to other hosts (set an admin password below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2126
+#: src/muuli_wdr.cpp:2130
 msgid "Type a password to set or change it. Stored passwords cannot be shown, so leaving this empty keeps the current one."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2128
+#: src/muuli_wdr.cpp:2132
 msgid "Admin password"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2140 src/muuli_wdr.cpp:2157 src/PrefsUnifiedDlg.cpp:1103
+#: src/muuli_wdr.cpp:2144 src/muuli_wdr.cpp:2161 src/PrefsUnifiedDlg.cpp:1112
 msgid "A password is set."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2144
+#: src/muuli_wdr.cpp:2148
 msgid "Enable guest access"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2145
+#: src/muuli_wdr.cpp:2149
 msgid "Guest sessions may read status and listings but cannot change anything. Turning this off clears the stored guest password."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2149
+#: src/muuli_wdr.cpp:2153
 msgid "Guest password"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2164
+#: src/muuli_wdr.cpp:2168
 msgid "Web server parameters"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2167
+#: src/muuli_wdr.cpp:2171
 msgid "Run webserver on startup (deprecated)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2173
+#: src/muuli_wdr.cpp:2177
 msgid "Web template"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2178
+#: src/muuli_wdr.cpp:2182
 msgid "Full rights password"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2182
+#: src/muuli_wdr.cpp:2186
 msgid "Enable Low rights User"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2187
+#: src/muuli_wdr.cpp:2191
 msgid "Low rights password"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2201
+#: src/muuli_wdr.cpp:2205
 msgid "Enable UPnP port forwarding of the web server port"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2206
+#: src/muuli_wdr.cpp:2210
 msgid "Web server UPnP TCP port (Optional)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2214
+#: src/muuli_wdr.cpp:2218
 msgid "Page Refresh Time (in secs)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2221
+#: src/muuli_wdr.cpp:2225
 msgid "Enable Gzip compression"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2255
+#: src/muuli_wdr.cpp:2259
 msgid "Reset page to defaults"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2256
+#: src/muuli_wdr.cpp:2260
 msgid "Reset the settings on the current page to their default values."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2258 src/muuli_wdr.cpp:2344 src/ServerWnd.cpp:274
+#: src/muuli_wdr.cpp:2262 src/muuli_wdr.cpp:2348 src/ServerWnd.cpp:274
 #: src/ServerWnd.cpp:282
 msgid "OK"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2260
+#: src/muuli_wdr.cpp:2264
 msgid "Click here to apply any changes made to the preferences."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2263
+#: src/muuli_wdr.cpp:2267
 msgid "Reset any changes made to the preferences."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2292
+#: src/muuli_wdr.cpp:2296
 msgid "Comment :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2299
+#: src/muuli_wdr.cpp:2303
 msgid "Incoming Dir :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2308
+#: src/muuli_wdr.cpp:2312
 msgid "Change priority for new assigned files :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2312
+#: src/muuli_wdr.cpp:2316
 msgid "Don't change"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2324
+#: src/muuli_wdr.cpp:2328
 msgid "Select color for this Category (currently selected) :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2391 src/muuli_wdr.cpp:2410 src/muuli_wdr.cpp:2432
+#: src/muuli_wdr.cpp:2395 src/muuli_wdr.cpp:2414 src/muuli_wdr.cpp:2436
 msgid "Click this button to reset the log."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2451
+#: src/muuli_wdr.cpp:2455
 msgid "Click on this button to update the servers list from URL ..."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2455
+#: src/muuli_wdr.cpp:2459
 msgid "Server list"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2459
+#: src/muuli_wdr.cpp:2463
 msgid "Enter the url to a server.met file here and press the button to the left to update the list of known servers."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2464
+#: src/muuli_wdr.cpp:2468
 msgid "Add server manually: Name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2467
+#: src/muuli_wdr.cpp:2471
 msgid "Enter the name of the new server here"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2469 src/ServerWnd.cpp:206
+#: src/muuli_wdr.cpp:2473 src/ServerWnd.cpp:206
 msgid "IP:Port"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2472
+#: src/muuli_wdr.cpp:2476
 msgid "Enter the IP of the server here, using the x.x.x.x format."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2478
+#: src/muuli_wdr.cpp:2482
 msgid "Enter the port of the server here."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2481
+#: src/muuli_wdr.cpp:2485
 msgid "Add manually a server (fill fields to the left before) ..."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2510
+#: src/muuli_wdr.cpp:2514
 msgid "aMule Log"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2518
+#: src/muuli_wdr.cpp:2522
 msgid "Server Info"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2522
+#: src/muuli_wdr.cpp:2526
 msgid "ED2K Info"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2526
+#: src/muuli_wdr.cpp:2530
 msgid "Kad Info"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2554
+#: src/muuli_wdr.cpp:2558
 msgid "Click on this button to update the nodes list from URL ..."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2558
+#: src/muuli_wdr.cpp:2562
 msgid "Nodes (0)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2562
+#: src/muuli_wdr.cpp:2566
 msgid "Enter the url to a nodes.dat file here and press the button to the left to update the list of known nodes."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2565
+#: src/muuli_wdr.cpp:2569
 msgid "Nodes stats"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2607
+#: src/muuli_wdr.cpp:2611
 msgid "Bootstrap"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2610
+#: src/muuli_wdr.cpp:2614
 msgid "New node"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2615
+#: src/muuli_wdr.cpp:2619
 msgid "IP:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2635
+#: src/muuli_wdr.cpp:2639
 msgid "Port:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2648
+#: src/muuli_wdr.cpp:2652
 msgid "Bootstrap from known clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2650
+#: src/muuli_wdr.cpp:2654
 msgid "Disconnect Kad"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2684
+#: src/muuli_wdr.cpp:2688
 msgid "Use Secure User Identification"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2686
+#: src/muuli_wdr.cpp:2690
 msgid "It is recommended to enable this option. You will not receive credits if SUI is not enabled."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2688
+#: src/muuli_wdr.cpp:2692
 msgid "Protocol Obfuscation"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2691
+#: src/muuli_wdr.cpp:2695
 msgid "Support Protocol Obfuscation"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2693
+#: src/muuli_wdr.cpp:2697
 msgid "This option enabled Protocol Obfuscation, and makes aMule accept obfuscated connections from other clients."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2695
+#: src/muuli_wdr.cpp:2699
 msgid "Use obfuscation for outgoing connections"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2697
+#: src/muuli_wdr.cpp:2701
 msgid "This option makes aMule use Protocol Obfuscation when connecting other clients/servers."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2699
+#: src/muuli_wdr.cpp:2703
 msgid "Accept only obfuscated connections"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2700
+#: src/muuli_wdr.cpp:2704
 msgid "This option makes aMule only accept obfuscated connections. You will have less sources, but all your traffic will be obfuscated"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2705
+#: src/muuli_wdr.cpp:2709
 msgid "Everybody"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2707
+#: src/muuli_wdr.cpp:2711
 msgid "No one"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2709
+#: src/muuli_wdr.cpp:2713
 msgid "Who can see my shared files:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2710
+#: src/muuli_wdr.cpp:2714
 msgid "Select who can request to view a list of your shared files."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2712
+#: src/muuli_wdr.cpp:2716
 msgid "IP-Filtering"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2719
+#: src/muuli_wdr.cpp:2723
 msgid "Filter clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2721
+#: src/muuli_wdr.cpp:2725
 msgid "Enable filtering of the client IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2723
+#: src/muuli_wdr.cpp:2727
 msgid "Filter servers"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2725
+#: src/muuli_wdr.cpp:2729
 msgid "Enable filtering of the server IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2729
+#: src/muuli_wdr.cpp:2733
 msgid "Reload List"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2730
+#: src/muuli_wdr.cpp:2734
 msgid "Reload the list of IPs to filter from the file ~/.aMule/ipfilter.dat"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2736
+#: src/muuli_wdr.cpp:2740
 msgid "URL:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2740 src/muuli_wdr.cpp:2933
+#: src/muuli_wdr.cpp:2744 src/muuli_wdr.cpp:2937
 msgid "Update now"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2743
+#: src/muuli_wdr.cpp:2747
 msgid "Auto-update ipfilter at startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2747
+#: src/muuli_wdr.cpp:2751
 msgid "Filtering Level:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2753
+#: src/muuli_wdr.cpp:2757
 msgid "Always filter LAN IPs"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2756
+#: src/muuli_wdr.cpp:2760
 msgid "Paranoid handling of non-matching IPs"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2758
+#: src/muuli_wdr.cpp:2762
 msgid "Rejects a packet when its source IP differs from the IP the client claims (an anti-spoofing check). Disable only if it causes connection problems."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2760
+#: src/muuli_wdr.cpp:2764
 msgid "Use system-wide ipfilter.dat if available"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2761
+#: src/muuli_wdr.cpp:2765
 msgid "If there's no local ipfilter.dat found, allow usage of a system-wide ipfilter file."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2778
+#: src/muuli_wdr.cpp:2782
 msgid "Enable Online-Signature"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2780
+#: src/muuli_wdr.cpp:2784
 msgid "Enables the writing of the OS file, which can be used by external apps to create signatures and the like."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2784
+#: src/muuli_wdr.cpp:2788
 msgid "Update Frequency (Secs):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2787
+#: src/muuli_wdr.cpp:2791
 msgid "Change the frequency (in seconds) of Online Signature updates."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2795
+#: src/muuli_wdr.cpp:2799
 msgid "Save online signature file in: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:2801
+#: src/muuli_wdr.cpp:2805
 msgid "Click here to select the directory containing the the Online Signature files."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2834
+#: src/muuli_wdr.cpp:2838
 msgid "Show country flags for clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2835
+#: src/muuli_wdr.cpp:2839
 msgid "Render the country flag column in the transfers, queue and search views. Requires a valid MMDB GeoIP database (see below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2840
+#: src/muuli_wdr.cpp:2844
 msgid "Database"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2856
+#: src/muuli_wdr.cpp:2860
 msgid "Source:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2859
+#: src/muuli_wdr.cpp:2863
 msgid "DB-IP (free, no account)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2860
+#: src/muuli_wdr.cpp:2864
 msgid "MaxMind GeoLite2 (free, account required)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2861
+#: src/muuli_wdr.cpp:2865
 msgid "Custom URL"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2864
+#: src/muuli_wdr.cpp:2868
 msgid "Choose which provider supplies the GeoIP MMDB database. DB-IP is the default - no account required. MaxMind requires a free account + license key. Use Custom URL to point at any other MMDB host (e.g. a local mirror)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2881
+#: src/muuli_wdr.cpp:2885
 msgid ""
 "No configuration required.\n"
 "\n"
@@ -4761,11 +4761,11 @@ msgid ""
 "License: Creative Commons BY 4.0 - https://creativecommons.org/licenses/by/4.0/"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2894
+#: src/muuli_wdr.cpp:2898
 msgid "License key:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2900
+#: src/muuli_wdr.cpp:2904
 msgid ""
 "Sign up for a free MaxMind account, then generate a License Key:\n"
 "https://www.maxmind.com/en/geolite2/signup\n"
@@ -4775,222 +4775,222 @@ msgid ""
 "Requires attribution and account registration; refresh at least every 30 days."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2915
+#: src/muuli_wdr.cpp:2919
 msgid "Download URL:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2921
+#: src/muuli_wdr.cpp:2925
 msgid ""
 "Must point to an .mmdb file or a .gz / .tar.gz containing one.\n"
 "URL may include credentials (https://user:pass@host/...).\n"
 "License and attribution terms are set by the upstream URL - you are responsible."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2934
+#: src/muuli_wdr.cpp:2938
 msgid "Download the GeoIP database from the selected source."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2936
+#: src/muuli_wdr.cpp:2940
 msgid "Auto-update on startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2937
+#: src/muuli_wdr.cpp:2941
 msgid "Re-download the GeoIP database from the selected source every time aMule starts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2960
+#: src/muuli_wdr.cpp:2964
 msgid "Filter incoming messages (except current chat):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2962
+#: src/muuli_wdr.cpp:2966
 msgid "Filter all messages"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2964
+#: src/muuli_wdr.cpp:2968
 msgid "Filter messages from people not on your friend list"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2966
+#: src/muuli_wdr.cpp:2970
 msgid "Filter messages from unknown clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2968
+#: src/muuli_wdr.cpp:2972
 msgid "Filter messages containing (use ',' as separator):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2971 src/muuli_wdr.cpp:2982
+#: src/muuli_wdr.cpp:2975 src/muuli_wdr.cpp:2986
 msgid "add here the words amule should filter and block messages including it"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2973
+#: src/muuli_wdr.cpp:2977
 msgid "Show received messages in the log"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2976
+#: src/muuli_wdr.cpp:2980
 msgid "Comments"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2979
+#: src/muuli_wdr.cpp:2983
 msgid "Filter comments containing (use ',' as separator):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3004
+#: src/muuli_wdr.cpp:3008
 msgid "Enable Proxy"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3005
+#: src/muuli_wdr.cpp:3009
 msgid "Enable/disable proxy support"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3008
+#: src/muuli_wdr.cpp:3012
 msgid "Proxy type:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3019
+#: src/muuli_wdr.cpp:3023
 msgid "Proxy host:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3022
+#: src/muuli_wdr.cpp:3026
 msgid "The proxy host name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3024
+#: src/muuli_wdr.cpp:3028
 msgid "Proxy port:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3027
+#: src/muuli_wdr.cpp:3031
 msgid "The proxy port"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3029
+#: src/muuli_wdr.cpp:3033
 msgid "Enable authentication"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3030
+#: src/muuli_wdr.cpp:3034
 msgid "Enable/disable username/password authentication"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3033
+#: src/muuli_wdr.cpp:3037
 msgid "Username: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:3036
+#: src/muuli_wdr.cpp:3040
 msgid "The username to use to connect to the proxy"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3038
+#: src/muuli_wdr.cpp:3042
 msgid "Password:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3041
+#: src/muuli_wdr.cpp:3045
 msgid "The password to use to connect to the proxy"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3060
+#: src/muuli_wdr.cpp:3064
 msgid "Connect to:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3069
+#: src/muuli_wdr.cpp:3073
 msgid "Login to remote amule"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3074
+#: src/muuli_wdr.cpp:3078
 msgid "User name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3085
+#: src/muuli_wdr.cpp:3089
 msgid "Remember those settings"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3088
+#: src/muuli_wdr.cpp:3092
 msgid "Force ZLIB compression"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3112
+#: src/muuli_wdr.cpp:3116
 msgid "Enable Verbose Debug-Logging."
 msgstr ""
 
-#: src/muuli_wdr.cpp:3114
+#: src/muuli_wdr.cpp:3118
 msgid "Only to Logfile"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3116
+#: src/muuli_wdr.cpp:3120
 msgid "Message Categories:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3140 src/PartFileConvertDlg.cpp:160
+#: src/muuli_wdr.cpp:3144 src/PartFileConvertDlg.cpp:160
 msgid "Waiting..."
 msgstr ""
 
-#: src/muuli_wdr.cpp:3160
+#: src/muuli_wdr.cpp:3164
 msgid "Add imports"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3163
+#: src/muuli_wdr.cpp:3167
 msgid "Retry selected"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3165
+#: src/muuli_wdr.cpp:3169
 msgid "Remove selected"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3228
+#: src/muuli_wdr.cpp:3232
 msgid "Event Types"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3247
+#: src/muuli_wdr.cpp:3251
 msgid "Statistics and queued clients for selected file(s) : Session / All time"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3271
+#: src/muuli_wdr.cpp:3275
 msgid "Active Uploads"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3285
+#: src/muuli_wdr.cpp:3289
 msgid "Percent of total files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3337
+#: src/muuli_wdr.cpp:3341
 msgid "Show Clients for"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3339
+#: src/muuli_wdr.cpp:3343
 msgid "All files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3342
+#: src/muuli_wdr.cpp:3346
 msgid "Selected files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3345
+#: src/muuli_wdr.cpp:3349
 msgid "Active uploads only"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3352
+#: src/muuli_wdr.cpp:3356
 msgid "Reload:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3356
+#: src/muuli_wdr.cpp:3360
 msgid "Reload your shared files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3419
+#: src/muuli_wdr.cpp:3423
 msgid "Send"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3420
+#: src/muuli_wdr.cpp:3424
 msgid "Sends the specified message."
 msgstr ""
 
-#: src/muuli_wdr.cpp:3424
+#: src/muuli_wdr.cpp:3428
 msgid "Close this chat-session."
 msgstr ""
 
-#: src/muuli_wdr.cpp:3447
+#: src/muuli_wdr.cpp:3451
 msgid "Connect to any server and/or Kad"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3453 src/SharedFilesCtrl.cpp:142 src/Statistics.cpp:941
+#: src/muuli_wdr.cpp:3457 src/SharedFilesCtrl.cpp:142 src/Statistics.cpp:941
 msgid "Shared Files"
 msgstr ""
 
@@ -5614,400 +5614,400 @@ msgid ""
 "these settings."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:647
+#: src/PrefsUnifiedDlg.cpp:656
 #, c-format
 msgid "Failed to connect Cfg to widget with the ID %d and key %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:695
+#: src/PrefsUnifiedDlg.cpp:704
 #, c-format
 msgid "Failed to transfer data from Cfg to Widget with the ID %d and key %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:801
+#: src/PrefsUnifiedDlg.cpp:810
 msgid "The type of proxy you are connecting to"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1020
+#: src/PrefsUnifiedDlg.cpp:1029
 #, c-format
 msgid "Failed to transfer data from Widget to Cfg with the ID %d and key %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1103
+#: src/PrefsUnifiedDlg.cpp:1112
 msgid "No password set."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1132
+#: src/PrefsUnifiedDlg.cpp:1141
 msgid "Guest access needs a password. Type one in the guest password field, or untick Enable guest access."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1144
+#: src/PrefsUnifiedDlg.cpp:1153
 msgid ""
 "aMule must be restarted to enable these changes:\n"
 "\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1151
+#: src/PrefsUnifiedDlg.cpp:1160
 msgid "- TCP port changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1156
+#: src/PrefsUnifiedDlg.cpp:1165
 msgid "- UDP port changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1161
+#: src/PrefsUnifiedDlg.cpp:1170
 msgid "- Network interface binding changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1166
+#: src/PrefsUnifiedDlg.cpp:1175
 msgid "- External connect port changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1170
+#: src/PrefsUnifiedDlg.cpp:1179
 msgid "- External connect acceptance changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1174
+#: src/PrefsUnifiedDlg.cpp:1183
 msgid "- External connect interface changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1178
+#: src/PrefsUnifiedDlg.cpp:1187
 msgid "- Protocol obfuscation support changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1193
+#: src/PrefsUnifiedDlg.cpp:1202
 msgid "- amuleapi settings changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1202
+#: src/PrefsUnifiedDlg.cpp:1211
 msgid ""
 "Your Auto-update server list is empty.\n"
 "'Auto-update server list at startup' will be disabled."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1213
+#: src/PrefsUnifiedDlg.cpp:1222
 msgid ""
 "You have enabled external connections but have not specified a password.\n"
 "External connections cannot be enabled unless a valid password is specified."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1246
+#: src/PrefsUnifiedDlg.cpp:1255
 #, c-format
 msgid "The amuleapi password could not be saved: %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1276
+#: src/PrefsUnifiedDlg.cpp:1285
 msgid "- Language changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1281
+#: src/PrefsUnifiedDlg.cpp:1290
 msgid "- Temp folder changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1286
+#: src/PrefsUnifiedDlg.cpp:1295
 msgid "- ED2K network enabled.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1319
+#: src/PrefsUnifiedDlg.cpp:1328
 msgid "The shared-file exclusion pattern is not a valid regular expression. The filter has been left disabled."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1321 src/PrefsUnifiedDlg.cpp:1921
+#: src/PrefsUnifiedDlg.cpp:1330 src/PrefsUnifiedDlg.cpp:1930
 msgid "Invalid regular expression"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1398
+#: src/PrefsUnifiedDlg.cpp:1407
 msgid ""
 "Both eD2k and Kad network are disabled.\n"
 "You won't be able to connect until you enable at least one of them."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1403
+#: src/PrefsUnifiedDlg.cpp:1412
 msgid ""
 "Kad will not start if your UDP port is disabled.\n"
 "Enable UDP port or disable Kad."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1459
+#: src/PrefsUnifiedDlg.cpp:1468
 msgid ""
 "\n"
 "You MUST restart aMule now.\n"
 "If you do not restart now, don't complain if anything bad happens.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1524
+#: src/PrefsUnifiedDlg.cpp:1533
 msgid "Could not register aMule for autostart at login. The autostart store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1526
+#: src/PrefsUnifiedDlg.cpp:1535
 msgid "Could not remove the autostart-at-login entry."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1527
+#: src/PrefsUnifiedDlg.cpp:1536
 msgid "Autostart"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1542
+#: src/PrefsUnifiedDlg.cpp:1551
 msgid "Register file type"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1542
+#: src/PrefsUnifiedDlg.cpp:1551
 msgid "Register URL handler"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1550
+#: src/PrefsUnifiedDlg.cpp:1559
 #, c-format
 msgid "aMule only handles eD2k-compatible magnets. If you replace the current magnet handler (%s), BitTorrent magnet links will stop working - aMule cannot download BitTorrent content. Continue?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1555
+#: src/PrefsUnifiedDlg.cpp:1564
 #, c-format
 msgid "Another application currently opens .emulecollection files (%s). Replace it with aMule?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1560
+#: src/PrefsUnifiedDlg.cpp:1569
 #, c-format
 msgid "Another application is currently the default handler for these links (%s). Replace it with aMule?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1585
+#: src/PrefsUnifiedDlg.cpp:1594
 msgid "Could not register aMule for .emulecollection files. The registration store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1587
+#: src/PrefsUnifiedDlg.cpp:1596
 msgid "Could not remove the file type registration."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1589
+#: src/PrefsUnifiedDlg.cpp:1598
 msgid "Could not register aMule as the URL handler. The registration store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1591
+#: src/PrefsUnifiedDlg.cpp:1600
 msgid "Could not remove the URL handler registration."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1661 src/PrefsUnifiedDlg.cpp:1688
+#: src/PrefsUnifiedDlg.cpp:1670 src/PrefsUnifiedDlg.cpp:1697
 msgid "The web server and aMule API require external connections to be enabled."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1671
+#: src/PrefsUnifiedDlg.cpp:1680
 msgid "The aMule web server is deprecated. Consider running the aMule API instead."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1735
+#: src/PrefsUnifiedDlg.cpp:1744
 msgid ""
 "Your Auto-update servers list is in blank.\n"
 "Please fill in at least one URL to point to a valid server.met file.\n"
 "Click on the button \"List\" by this checkbox to enter an URL."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1876
+#: src/PrefsUnifiedDlg.cpp:1885
 msgid "Temporary files"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1881
+#: src/PrefsUnifiedDlg.cpp:1890
 msgid "Incoming files"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1886
+#: src/PrefsUnifiedDlg.cpp:1895
 msgid "Online Signatures"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1899
+#: src/PrefsUnifiedDlg.cpp:1908
 #, c-format
 msgid "Choose a folder for %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1923
+#: src/PrefsUnifiedDlg.cpp:1932
 #, c-format
 msgid "Would exclude %u of %u shared file"
 msgid_plural "Would exclude %u of %u shared files"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/PrefsUnifiedDlg.cpp:1940
+#: src/PrefsUnifiedDlg.cpp:1949
 msgid "Browse for videoplayer"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1944
+#: src/PrefsUnifiedDlg.cpp:1953
 msgid "Select browser"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1948
+#: src/PrefsUnifiedDlg.cpp:1957
 msgid "Select ffprobe binary"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1954
+#: src/PrefsUnifiedDlg.cpp:1963
 #, c-format
 msgid "Executable%s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1988
+#: src/PrefsUnifiedDlg.cpp:1997
 msgid "ffprobe not found on PATH or in the standard install locations. Install ffmpeg (which ships ffprobe) or use Browse to pick a binary manually."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2000
+#: src/PrefsUnifiedDlg.cpp:2009
 msgid "Reset the settings on this page to their default values?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2001
+#: src/PrefsUnifiedDlg.cpp:2010
 msgid "Reset to defaults"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2028
+#: src/PrefsUnifiedDlg.cpp:2037
 msgid "Edit server list"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2029
+#: src/PrefsUnifiedDlg.cpp:2038
 msgid ""
 "Add here URL's to download server.met files.\n"
 "Only one url on each line."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2084
+#: src/PrefsUnifiedDlg.cpp:2093
 msgid "IP2Country update failed"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2229 src/PrefsUnifiedDlg.cpp:2260
+#: src/PrefsUnifiedDlg.cpp:2238 src/PrefsUnifiedDlg.cpp:2269
 msgid "Data by MaxMind GeoLite2"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2231 src/PrefsUnifiedDlg.cpp:2262
+#: src/PrefsUnifiedDlg.cpp:2240 src/PrefsUnifiedDlg.cpp:2271
 msgid "Custom source"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2233 src/PrefsUnifiedDlg.cpp:2264
+#: src/PrefsUnifiedDlg.cpp:2242 src/PrefsUnifiedDlg.cpp:2273
 msgid "Data by DB-IP.com"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2284
+#: src/PrefsUnifiedDlg.cpp:2293
 #, c-format
 msgid "Status: Loaded%s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2286
+#: src/PrefsUnifiedDlg.cpp:2295
 #, c-format
 msgid "Status: Loaded%s - %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2290
+#: src/PrefsUnifiedDlg.cpp:2299
 msgid "Status: Failed to load - click 'Update now' to refresh."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2292
+#: src/PrefsUnifiedDlg.cpp:2301
 msgid "Status: Not found - click 'Update now' to download."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2350 src/PrefsUnifiedDlg.cpp:2374
+#: src/PrefsUnifiedDlg.cpp:2359 src/PrefsUnifiedDlg.cpp:2383
 #, c-format
 msgid "Update delay: %d second"
 msgid_plural "Update delay: %d seconds"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/PrefsUnifiedDlg.cpp:2358
+#: src/PrefsUnifiedDlg.cpp:2367
 #, c-format
 msgid "Time for average graph: %d minute"
 msgid_plural "Time for average graph: %d minutes"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/PrefsUnifiedDlg.cpp:2367
+#: src/PrefsUnifiedDlg.cpp:2376
 #, c-format
 msgid "Connections Graph Scale: %d"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2382
+#: src/PrefsUnifiedDlg.cpp:2391
 #, c-format
 msgid "File Buffer Size: %d byte"
 msgid_plural "File Buffer Size: %d bytes"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/PrefsUnifiedDlg.cpp:2392
+#: src/PrefsUnifiedDlg.cpp:2401
 #, c-format
 msgid "Upload Queue Size: %d client"
 msgid_plural "Upload Queue Size: %d clients"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/PrefsUnifiedDlg.cpp:2402
+#: src/PrefsUnifiedDlg.cpp:2411
 #, c-format
 msgid "Server connection refresh interval: %d minute"
 msgid_plural "Server connection refresh interval: %d minutes"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/PrefsUnifiedDlg.cpp:2407
+#: src/PrefsUnifiedDlg.cpp:2416
 msgid "Server connection refresh interval: Disabled"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2451
+#: src/PrefsUnifiedDlg.cpp:2460
 msgid "disabled"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2477
+#: src/PrefsUnifiedDlg.cpp:2486
 #, c-format
 msgid "Execute command on '%s' event"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2484
+#: src/PrefsUnifiedDlg.cpp:2493
 msgid "Enable command execution on core"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2496
+#: src/PrefsUnifiedDlg.cpp:2505
 msgid "Core command:"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2512
+#: src/PrefsUnifiedDlg.cpp:2521
 msgid "Enable command execution on GUI"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2524
+#: src/PrefsUnifiedDlg.cpp:2533
 msgid "GUI command:"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2540
+#: src/PrefsUnifiedDlg.cpp:2549
 msgid "The following variables will be replaced:"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2708
+#: src/PrefsUnifiedDlg.cpp:2717
 msgid ""
 "The following folders look like system or sensitive locations:\n"
 "\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2713
+#: src/PrefsUnifiedDlg.cpp:2722
 msgid "Sharing them recursively will publish every file underneath on the eD2k/Kad networks. Do you really want to do this?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2716
+#: src/PrefsUnifiedDlg.cpp:2725
 msgid "Confirm shared folders"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2744
+#: src/PrefsUnifiedDlg.cpp:2753
 msgid "Reloading shared files..."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2745
+#: src/PrefsUnifiedDlg.cpp:2754
 msgid "Scanning for subdirectories..."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2746
+#: src/PrefsUnifiedDlg.cpp:2755
 msgid "Updating shared folders"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2773
+#: src/PrefsUnifiedDlg.cpp:2782
 #, c-format
 msgid "Scanned %u directories..."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2823
+#: src/PrefsUnifiedDlg.cpp:2832
 #, c-format
 msgid "Reloading shared files: %u files scanned"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2873
+#: src/PrefsUnifiedDlg.cpp:2882
 msgid "Shared folder"
 msgstr ""
 
@@ -7635,12 +7635,12 @@ msgstr ""
 msgid "Hashset requested for unknown file: %s"
 msgstr ""
 
-#: src/UploadQueue.cpp:618
+#: src/UploadQueue.cpp:627
 #, c-format
 msgid "Resuming uploads of file: %s"
 msgstr ""
 
-#: src/UploadQueue.cpp:634
+#: src/UploadQueue.cpp:643
 #, c-format
 msgid "Suspending upload of file: %s"
 msgstr ""

--- a/po/bn.po
+++ b/po/bn.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-28 08:06+0200\n"
+"POT-Creation-Date: 2026-07-28 10:19+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: none\n"
@@ -131,7 +131,7 @@ msgstr ""
 msgid "Not now"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:422 src/amuleDlg.cpp:600
+#: src/AppImageIntegration.cpp:422 src/amuleDlg.cpp:665
 msgid "Don't ask again"
 msgstr ""
 
@@ -203,7 +203,7 @@ msgid "Killing amuleweb instance with pid '%d' ... "
 msgstr ""
 
 #: src/amule.cpp:336 src/amule.cpp:349 src/ClientRef.cpp:180
-#: src/SearchDlg.cpp:880 src/ServerListCtrl.cpp:98
+#: src/SearchDlg.cpp:1041 src/ServerListCtrl.cpp:98
 msgid "Failed"
 msgstr ""
 
@@ -545,29 +545,67 @@ msgstr ""
 msgid "ERROR: %s"
 msgstr ""
 
-#: src/amuleDlg.cpp:236
+#: src/amuleDlg.cpp:250
 #, c-format
 msgid "This is aMule %s based on eMule."
 msgstr ""
 
-#: src/amuleDlg.cpp:237
+#: src/amuleDlg.cpp:251
 #, c-format
 msgid "Running on %s"
 msgstr ""
 
-#: src/amuleDlg.cpp:239
+#: src/amuleDlg.cpp:253
 msgid "Visit https://github.com/amule-org/amule/releases/latest to check if a new version is available."
 msgstr ""
 
-#: src/amuleDlg.cpp:268
+#: src/amuleDlg.cpp:282
 msgid "FATAL ERROR: Failed to create Timer"
 msgstr ""
 
-#: src/amuleDlg.cpp:592
+#: src/amuleDlg.cpp:361 src/amuleDlg.cpp:1787 src/amuleDlg.cpp:2033
+#: src/muuli_wdr.cpp:1492 src/muuli_wdr.cpp:3418
+msgid "Networks"
+msgstr ""
+
+#: src/amuleDlg.cpp:362 src/amuleDlg.cpp:1793 src/muuli_wdr.cpp:3419
+msgid "Searches"
+msgstr ""
+
+#: src/amuleDlg.cpp:363 src/amuleDlg.cpp:1799 src/DownloadListCtrl.cpp:740
+#: src/muuli_wdr.cpp:392 src/muuli_wdr.cpp:1585 src/muuli_wdr.cpp:3420
+#: src/Statistics.cpp:829
+msgid "Downloads"
+msgstr ""
+
+#: src/amuleDlg.cpp:364 src/amuleDlg.cpp:1805 src/muuli_wdr.cpp:3294
+msgid "Shared files"
+msgstr ""
+
+#: src/amuleDlg.cpp:365 src/amuleDlg.cpp:1811 src/muuli_wdr.cpp:2926
+#: src/muuli_wdr.cpp:3376 src/muuli_wdr.cpp:3423
+msgid "Messages"
+msgstr ""
+
+#: src/amuleDlg.cpp:366 src/amuleDlg.cpp:1817 src/muuli_wdr.cpp:3424
+#: src/PrefsUnifiedDlg.cpp:312 src/Statistics.cpp:779 src/Statistics.cpp:1235
+msgid "Statistics"
+msgstr ""
+
+#: src/amuleDlg.cpp:368 src/amuleDlg.cpp:1824 src/muuli_wdr.cpp:3426
+#: src/PrefsUnifiedDlg.cpp:328 src/utils/wxCas/src/wxcasprefs.cpp:39
+msgid "Preferences"
+msgstr ""
+
+#: src/amuleDlg.cpp:371
+msgid "Navigate"
+msgstr ""
+
+#: src/amuleDlg.cpp:657
 msgid "New version available"
 msgstr ""
 
-#: src/amuleDlg.cpp:596
+#: src/amuleDlg.cpp:661
 #, c-format
 msgid ""
 "A new version of aMule (%s) is available.\n"
@@ -577,217 +615,184 @@ msgid ""
 "Would you like to open the download page?"
 msgstr ""
 
-#: src/amuleDlg.cpp:678
+#: src/amuleDlg.cpp:743
 msgid "aMule dialog destroyed"
 msgstr ""
 
-#: src/amuleDlg.cpp:701 src/DataToText.cpp:68 src/IPFilter.cpp:547
+#: src/amuleDlg.cpp:766 src/DataToText.cpp:68 src/IPFilter.cpp:547
 msgid "Connecting"
 msgstr ""
 
-#: src/amuleDlg.cpp:893
+#: src/amuleDlg.cpp:958
 msgid "eD2k: Connecting"
 msgstr ""
 
-#: src/amuleDlg.cpp:897
+#: src/amuleDlg.cpp:962
 msgid "eD2k: Disconnected"
 msgstr ""
 
-#: src/amuleDlg.cpp:903
+#: src/amuleDlg.cpp:968
 msgid "Kad: Firewalled"
 msgstr ""
 
-#: src/amuleDlg.cpp:907
+#: src/amuleDlg.cpp:972
 msgid "Kad: Connected"
 msgstr ""
 
-#: src/amuleDlg.cpp:912
+#: src/amuleDlg.cpp:977
 msgid "Kad: Connecting"
 msgstr ""
 
-#: src/amuleDlg.cpp:916
+#: src/amuleDlg.cpp:981
 msgid "Kad: Off"
 msgstr ""
 
-#: src/amuleDlg.cpp:964 src/DownloadListCtrl.cpp:505
+#: src/amuleDlg.cpp:1029 src/DownloadListCtrl.cpp:505
 #: src/DownloadListCtrl.cpp:749 src/FriendListCtrl.cpp:180
 #: src/muuli_wdr.cpp:731 src/muuli_wdr.cpp:782 src/muuli_wdr.cpp:846
-#: src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2224 src/muuli_wdr.cpp:2309
-#: src/muuli_wdr.cpp:3057 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
+#: src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2231 src/muuli_wdr.cpp:2316
+#: src/muuli_wdr.cpp:3064 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
 #: src/ServerListCtrl.cpp:606 src/TransferWnd.cpp:378
 #: src/utils/wxCas/src/wxcasprefs.cpp:235
 msgid "Cancel"
 msgstr ""
 
-#: src/amuleDlg.cpp:965
+#: src/amuleDlg.cpp:1030
 msgid "Stop the current connection attempts"
 msgstr ""
 
-#: src/amuleDlg.cpp:970 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976
-#: src/muuli_wdr.cpp:2447
+#: src/amuleDlg.cpp:1035 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976
+#: src/muuli_wdr.cpp:2454
 msgid "Disconnect"
 msgstr ""
 
-#: src/amuleDlg.cpp:971
+#: src/amuleDlg.cpp:1036
 msgid "Disconnect from the currently connected networks"
 msgstr ""
 
-#: src/amuleDlg.cpp:976 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979
-#: src/muuli_wdr.cpp:2602 src/muuli_wdr.cpp:3054 src/muuli_wdr.cpp:3409
+#: src/amuleDlg.cpp:1041 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979
+#: src/muuli_wdr.cpp:2609 src/muuli_wdr.cpp:3061 src/muuli_wdr.cpp:3416
 msgid "Connect"
 msgstr ""
 
-#: src/amuleDlg.cpp:977
+#: src/amuleDlg.cpp:1042
 msgid "Connect to the currently enabled networks"
 msgstr ""
 
-#: src/amuleDlg.cpp:1089
+#: src/amuleDlg.cpp:1154
 #, c-format
 msgid "Up: %.1f%s (%.1f) | Down: %.1f%s (%.1f)"
 msgstr ""
 
-#: src/amuleDlg.cpp:1091 src/amuleDlg.cpp:1093 src/amuleDlg.cpp:1097
-#: src/amuleDlg.cpp:1099 src/amuleDlg.cpp:1110 src/amuleDlg.cpp:1112
+#: src/amuleDlg.cpp:1156 src/amuleDlg.cpp:1158 src/amuleDlg.cpp:1162
+#: src/amuleDlg.cpp:1164 src/amuleDlg.cpp:1175 src/amuleDlg.cpp:1177
 #: src/MuleTrayIcon.cpp:796 src/MuleTrayIcon.cpp:799
 msgid " MB/s"
 msgstr ""
 
-#: src/amuleDlg.cpp:1091 src/amuleDlg.cpp:1093 src/amuleDlg.cpp:1097
-#: src/amuleDlg.cpp:1099 src/amuleDlg.cpp:1110 src/amuleDlg.cpp:1112
+#: src/amuleDlg.cpp:1156 src/amuleDlg.cpp:1158 src/amuleDlg.cpp:1162
+#: src/amuleDlg.cpp:1164 src/amuleDlg.cpp:1175 src/amuleDlg.cpp:1177
 #: src/MuleTrayIcon.cpp:796 src/MuleTrayIcon.cpp:799
 #: src/utils/wxCas/src/wxcasframe.cpp:1041
 msgid " kB/s"
 msgstr ""
 
-#: src/amuleDlg.cpp:1096
+#: src/amuleDlg.cpp:1161
 #, c-format
 msgid "Up: %.1f%s | Down: %.1f%s"
 msgstr ""
 
-#: src/amuleDlg.cpp:1128
+#: src/amuleDlg.cpp:1193
 #, c-format
 msgid "aMule (%s | Connected)"
 msgstr ""
 
-#: src/amuleDlg.cpp:1130
+#: src/amuleDlg.cpp:1195
 #, c-format
 msgid "aMule (%s | Disconnected)"
 msgstr ""
 
-#: src/amuleDlg.cpp:1183
+#: src/amuleDlg.cpp:1248
 #, c-format
 msgid "Do you really want to exit %s?"
 msgstr ""
 
-#: src/amuleDlg.cpp:1185
+#: src/amuleDlg.cpp:1250
 msgid "Exit confirmation"
 msgstr ""
 
-#: src/amuleDlg.cpp:1548
+#: src/amuleDlg.cpp:1613
 msgid "Launch Command: "
 msgstr ""
 
-#: src/amuleDlg.cpp:1567 src/muuli_wdr.cpp:1971 src/Preferences.cpp:951
+#: src/amuleDlg.cpp:1632 src/muuli_wdr.cpp:1978 src/Preferences.cpp:952
 msgid "- default -"
 msgstr ""
 
-#: src/amuleDlg.cpp:1595
+#: src/amuleDlg.cpp:1660
 #, c-format
 msgid "Skin directory '%s' does not exist"
 msgstr ""
 
-#: src/amuleDlg.cpp:1598
+#: src/amuleDlg.cpp:1663
 #, c-format
 msgid "WARNING: Unable to open skin file '%s' for read"
 msgstr ""
 
-#: src/amuleDlg.cpp:1722 src/amuleDlg.cpp:1968 src/muuli_wdr.cpp:1485
-#: src/muuli_wdr.cpp:3411
-msgid "Networks"
-msgstr ""
-
-#: src/amuleDlg.cpp:1726 src/muuli_wdr.cpp:3411
+#: src/amuleDlg.cpp:1791 src/muuli_wdr.cpp:3418
 msgid "Networks Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1728 src/muuli_wdr.cpp:3412
-msgid "Searches"
-msgstr ""
-
-#: src/amuleDlg.cpp:1732 src/muuli_wdr.cpp:3412
+#: src/amuleDlg.cpp:1797 src/muuli_wdr.cpp:3419
 msgid "Searches Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1734 src/DownloadListCtrl.cpp:740 src/muuli_wdr.cpp:392
-#: src/muuli_wdr.cpp:1578 src/muuli_wdr.cpp:3413 src/Statistics.cpp:829
-msgid "Downloads"
-msgstr ""
-
-#: src/amuleDlg.cpp:1738 src/muuli_wdr.cpp:3413
+#: src/amuleDlg.cpp:1803 src/muuli_wdr.cpp:3420
 msgid "Downloads Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1740 src/muuli_wdr.cpp:3287
-msgid "Shared files"
-msgstr ""
-
-#: src/amuleDlg.cpp:1744 src/muuli_wdr.cpp:3415
+#: src/amuleDlg.cpp:1809 src/muuli_wdr.cpp:3422
 msgid "Shared Files Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1746 src/muuli_wdr.cpp:2919 src/muuli_wdr.cpp:3369
-#: src/muuli_wdr.cpp:3416
-msgid "Messages"
-msgstr ""
-
-#: src/amuleDlg.cpp:1750 src/muuli_wdr.cpp:3416
+#: src/amuleDlg.cpp:1815 src/muuli_wdr.cpp:3423
 msgid "Messages Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1752 src/muuli_wdr.cpp:3417 src/PrefsUnifiedDlg.cpp:312
-#: src/Statistics.cpp:779 src/Statistics.cpp:1235
-msgid "Statistics"
-msgstr ""
-
-#: src/amuleDlg.cpp:1756 src/muuli_wdr.cpp:3417
+#: src/amuleDlg.cpp:1821 src/muuli_wdr.cpp:3424
 msgid "Statistics Graph Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1759 src/muuli_wdr.cpp:3419 src/PrefsUnifiedDlg.cpp:328
-#: src/utils/wxCas/src/wxcasprefs.cpp:39
-msgid "Preferences"
-msgstr ""
-
-#: src/amuleDlg.cpp:1763 src/muuli_wdr.cpp:3419
+#: src/amuleDlg.cpp:1828 src/muuli_wdr.cpp:3426
 msgid "Preferences Settings Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1766 src/muuli_wdr.cpp:3420
+#: src/amuleDlg.cpp:1831 src/muuli_wdr.cpp:3427
 msgid "Import"
 msgstr ""
 
-#: src/amuleDlg.cpp:1770 src/muuli_wdr.cpp:3420
+#: src/amuleDlg.cpp:1835 src/muuli_wdr.cpp:3427
 msgid "The partfile importer tool"
 msgstr ""
 
-#: src/amuleDlg.cpp:1773 src/muuli_wdr.cpp:3421
+#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3428
 #: src/utils/aLinkCreator/src/alcframe.cpp:262
 msgid "About"
 msgstr ""
 
-#: src/amuleDlg.cpp:1773 src/muuli_wdr.cpp:3421
+#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3428
 msgid "About/Help"
 msgstr ""
 
-#: src/amuleDlg.cpp:1971
+#: src/amuleDlg.cpp:2036
 msgid "eD2k network"
 msgstr ""
 
-#: src/amuleDlg.cpp:1974
+#: src/amuleDlg.cpp:2039
 msgid "Kad network"
 msgstr ""
 
-#: src/amuleDlg.cpp:1974
+#: src/amuleDlg.cpp:2039
 msgid "No network"
 msgstr ""
 
@@ -1314,19 +1319,19 @@ msgstr ""
 msgid "Very low"
 msgstr ""
 
-#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:743 src/muuli_wdr.cpp:2275
+#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:743 src/muuli_wdr.cpp:2282
 #: src/ServerListCtrl.cpp:263 src/ServerListCtrl.cpp:456
 #: src/SharedFilesCtrl.cpp:145
 msgid "Low"
 msgstr ""
 
-#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:744 src/muuli_wdr.cpp:2276
+#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:744 src/muuli_wdr.cpp:2283
 #: src/ServerListCtrl.cpp:266 src/ServerListCtrl.cpp:457
 #: src/SharedFilesCtrl.cpp:146
 msgid "Normal"
 msgstr ""
 
-#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:745 src/muuli_wdr.cpp:2277
+#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:745 src/muuli_wdr.cpp:2284
 #: src/ServerListCtrl.cpp:269 src/ServerListCtrl.cpp:458
 #: src/SharedFilesCtrl.cpp:147
 msgid "High"
@@ -1418,8 +1423,8 @@ msgstr ""
 msgid "Remote Server"
 msgstr ""
 
-#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3174
-#: src/SearchDlg.cpp:111 src/TextClient.cpp:911
+#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3181
+#: src/SearchDlg.cpp:119 src/TextClient.cpp:911
 msgid "Kad"
 msgstr ""
 
@@ -1489,7 +1494,7 @@ msgstr ""
 msgid "Size"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3241
+#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3248
 msgid "Transferred"
 msgstr ""
 
@@ -1545,7 +1550,7 @@ msgid ""
 "\n"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:746 src/muuli_wdr.cpp:2278
+#: src/DownloadListCtrl.cpp:746 src/muuli_wdr.cpp:2285
 #: src/SharedFilesCtrl.cpp:150
 msgid "Auto"
 msgstr ""
@@ -1583,7 +1588,7 @@ msgid "Extended Options"
 msgstr ""
 
 #: src/DownloadListCtrl.cpp:770 src/DownloadListCtrl.cpp:822
-#: src/muuli_wdr.cpp:1789
+#: src/muuli_wdr.cpp:1796
 msgid "Preview"
 msgstr ""
 
@@ -2261,19 +2266,19 @@ msgstr ""
 msgid "eD2k"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:349 src/muuli_wdr.cpp:1488
+#: src/FirstRunWizard.cpp:349 src/muuli_wdr.cpp:1495
 msgid "Kademlia"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:359 src/muuli_wdr.cpp:1416
+#: src/FirstRunWizard.cpp:359 src/muuli_wdr.cpp:1423
 msgid "Standard TCP Port "
 msgstr ""
 
-#: src/FirstRunWizard.cpp:365 src/muuli_wdr.cpp:1428
+#: src/FirstRunWizard.cpp:365 src/muuli_wdr.cpp:1435
 msgid "Extended UDP port (Kad / global search) "
 msgstr ""
 
-#: src/FirstRunWizard.cpp:377 src/muuli_wdr.cpp:1435
+#: src/FirstRunWizard.cpp:377 src/muuli_wdr.cpp:1442
 msgid "Enable UPnP for router port forwarding"
 msgstr ""
 
@@ -2298,7 +2303,7 @@ msgstr ""
 msgid "Your peer lists are already in place - nothing to download."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:434 src/muuli_wdr.cpp:1533
+#: src/FirstRunWizard.cpp:434 src/muuli_wdr.cpp:1540
 msgid "Auto-update server list at startup"
 msgstr ""
 
@@ -2344,23 +2349,23 @@ msgid ""
 "want downloads on a different (e.g. larger) disk."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:549 src/FirstRunWizard.cpp:611 src/muuli_wdr.cpp:1701
+#: src/FirstRunWizard.cpp:549 src/FirstRunWizard.cpp:611 src/muuli_wdr.cpp:1708
 msgid "Destination folder for downloads"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:553 src/FirstRunWizard.cpp:569 src/muuli_wdr.cpp:1342
-#: src/muuli_wdr.cpp:1359 src/muuli_wdr.cpp:1676 src/muuli_wdr.cpp:1707
-#: src/muuli_wdr.cpp:1719 src/muuli_wdr.cpp:2762
+#: src/FirstRunWizard.cpp:553 src/FirstRunWizard.cpp:569 src/muuli_wdr.cpp:1349
+#: src/muuli_wdr.cpp:1366 src/muuli_wdr.cpp:1683 src/muuli_wdr.cpp:1714
+#: src/muuli_wdr.cpp:1726 src/muuli_wdr.cpp:2769
 #: src/utils/aLinkCreator/src/alcframe.cpp:135
 #: src/utils/wxCas/src/wxcasprefs.cpp:52 src/utils/wxCas/src/wxcasprefs.cpp:118
 msgid "Browse"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:559 src/muuli_wdr.cpp:1712
+#: src/FirstRunWizard.cpp:559 src/muuli_wdr.cpp:1719
 msgid "(All files in this folder are shared with other peers)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:565 src/FirstRunWizard.cpp:624 src/muuli_wdr.cpp:1714
+#: src/FirstRunWizard.cpp:565 src/FirstRunWizard.cpp:624 src/muuli_wdr.cpp:1721
 msgid "Folder for temporary download files"
 msgstr ""
 
@@ -2391,7 +2396,7 @@ msgstr ""
 msgid "CRITICAL - no client on StartChatSession"
 msgstr ""
 
-#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2668 src/muuli_wdr.cpp:3345
+#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2675 src/muuli_wdr.cpp:3352
 msgid "Friends"
 msgstr ""
 
@@ -2769,7 +2774,7 @@ msgstr ""
 msgid "Uploaded"
 msgstr ""
 
-#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3225
+#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3232
 msgid "Requested"
 msgstr ""
 
@@ -2892,7 +2897,7 @@ msgid "WARNING: "
 msgstr ""
 
 #: src/MuleNotebook.cpp:179 src/muuli_wdr.cpp:817 src/muuli_wdr.cpp:1229
-#: src/muuli_wdr.cpp:3129 src/muuli_wdr.cpp:3385
+#: src/muuli_wdr.cpp:3136 src/muuli_wdr.cpp:3392
 msgid "Close"
 msgstr ""
 
@@ -2905,12 +2910,12 @@ msgstr ""
 msgid "Copy"
 msgstr ""
 
-#: src/MuleTextCtrl.cpp:88
+#: src/MuleTextCtrl.cpp:88 src/SearchDlg.cpp:261
 msgid "Paste"
 msgstr ""
 
 #: src/MuleTextCtrl.cpp:89 src/muuli_wdr.cpp:358 src/muuli_wdr.cpp:757
-#: src/muuli_wdr.cpp:2352 src/muuli_wdr.cpp:2371 src/muuli_wdr.cpp:2393
+#: src/muuli_wdr.cpp:2359 src/muuli_wdr.cpp:2378 src/muuli_wdr.cpp:2400
 #: src/utils/aLinkCreator/src/alcframe.cpp:142
 msgid "Clear"
 msgstr ""
@@ -3001,8 +3006,8 @@ msgid "Exit"
 msgstr ""
 
 #: src/MuleTrayIcon.cpp:579 src/MuleTrayIcon.cpp:945 src/MuleTrayIcon.cpp:965
-#: src/muuli_wdr.cpp:1391 src/muuli_wdr.cpp:1399 src/muuli_wdr.cpp:1406
-#: src/muuli_wdr.cpp:1835 src/muuli_wdr.cpp:1841 src/OtherFunctions.cpp:91
+#: src/muuli_wdr.cpp:1398 src/muuli_wdr.cpp:1406 src/muuli_wdr.cpp:1413
+#: src/muuli_wdr.cpp:1842 src/muuli_wdr.cpp:1848 src/OtherFunctions.cpp:91
 #: src/StatisticsDlg.cpp:93 src/StatisticsDlg.cpp:95
 msgid "kB/s"
 msgstr ""
@@ -3171,7 +3176,7 @@ msgstr ""
 msgid "Type"
 msgstr ""
 
-#: src/muuli_wdr.cpp:215 src/SearchDlg.cpp:110 src/SearchListCtrl.cpp:853
+#: src/muuli_wdr.cpp:215 src/SearchDlg.cpp:118 src/SearchListCtrl.cpp:853
 msgid "Local"
 msgstr ""
 
@@ -3242,7 +3247,7 @@ msgstr ""
 msgid "KB"
 msgstr ""
 
-#: src/muuli_wdr.cpp:274 src/muuli_wdr.cpp:293 src/muuli_wdr.cpp:1620
+#: src/muuli_wdr.cpp:274 src/muuli_wdr.cpp:293 src/muuli_wdr.cpp:1627
 #: src/OtherFunctions.cpp:64
 msgid "MB"
 msgstr ""
@@ -3259,7 +3264,7 @@ msgstr ""
 msgid "Availability"
 msgstr ""
 
-#: src/muuli_wdr.cpp:312 src/muuli_wdr.cpp:398 src/muuli_wdr.cpp:3290
+#: src/muuli_wdr.cpp:312 src/muuli_wdr.cpp:398 src/muuli_wdr.cpp:3297
 msgid "Filter:"
 msgstr ""
 
@@ -3291,7 +3296,7 @@ msgstr ""
 msgid "Stop"
 msgstr ""
 
-#: src/muuli_wdr.cpp:348 src/muuli_wdr.cpp:1385 src/SearchListCtrl.cpp:732
+#: src/muuli_wdr.cpp:348 src/muuli_wdr.cpp:1392 src/SearchListCtrl.cpp:732
 msgid "Download"
 msgstr ""
 
@@ -3322,8 +3327,8 @@ msgstr ""
 #: src/muuli_wdr.cpp:1160 src/muuli_wdr.cpp:1167 src/muuli_wdr.cpp:1172
 #: src/muuli_wdr.cpp:1179 src/muuli_wdr.cpp:1184 src/muuli_wdr.cpp:1191
 #: src/muuli_wdr.cpp:1205 src/muuli_wdr.cpp:1212 src/muuli_wdr.cpp:1217
-#: src/muuli_wdr.cpp:1224 src/muuli_wdr.cpp:3227 src/muuli_wdr.cpp:3235
-#: src/muuli_wdr.cpp:3243
+#: src/muuli_wdr.cpp:1224 src/muuli_wdr.cpp:3234 src/muuli_wdr.cpp:3242
+#: src/muuli_wdr.cpp:3250
 msgid "N/A"
 msgstr ""
 
@@ -3463,7 +3468,7 @@ msgstr ""
 msgid "Album :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:685 src/muuli_wdr.cpp:2247
+#: src/muuli_wdr.cpp:685 src/muuli_wdr.cpp:2254
 msgid "Title :"
 msgstr ""
 
@@ -3569,7 +3574,7 @@ msgstr ""
 msgid "Userhash :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:895 src/muuli_wdr.cpp:1741 src/muuli_wdr.cpp:2442
+#: src/muuli_wdr.cpp:895 src/muuli_wdr.cpp:1748 src/muuli_wdr.cpp:2449
 #: src/utils/aLinkCreator/src/alcframe.cpp:137
 msgid "Add"
 msgstr ""
@@ -3578,15 +3583,15 @@ msgstr ""
 msgid "Download-Speed"
 msgstr ""
 
-#: src/muuli_wdr.cpp:954 src/muuli_wdr.cpp:989 src/muuli_wdr.cpp:2546
+#: src/muuli_wdr.cpp:954 src/muuli_wdr.cpp:989 src/muuli_wdr.cpp:2553
 msgid "Current"
 msgstr ""
 
-#: src/muuli_wdr.cpp:962 src/muuli_wdr.cpp:997 src/muuli_wdr.cpp:2554
+#: src/muuli_wdr.cpp:962 src/muuli_wdr.cpp:997 src/muuli_wdr.cpp:2561
 msgid "Running average"
 msgstr ""
 
-#: src/muuli_wdr.cpp:970 src/muuli_wdr.cpp:1005 src/muuli_wdr.cpp:2562
+#: src/muuli_wdr.cpp:970 src/muuli_wdr.cpp:1005 src/muuli_wdr.cpp:2569
 msgid "Session average"
 msgstr ""
 
@@ -3598,7 +3603,7 @@ msgstr ""
 msgid "Connections"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1024 src/muuli_wdr.cpp:1860
+#: src/muuli_wdr.cpp:1024 src/muuli_wdr.cpp:1867
 msgid "Active downloads"
 msgstr ""
 
@@ -3606,7 +3611,7 @@ msgstr ""
 msgid "Active connections (1:1)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1040 src/muuli_wdr.cpp:1861
+#: src/muuli_wdr.cpp:1040 src/muuli_wdr.cpp:1868
 msgid "Active uploads"
 msgstr ""
 
@@ -3722,8 +3727,8 @@ msgstr ""
 msgid "Language: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1257 src/muuli_wdr.cpp:1323 src/muuli_wdr.cpp:1327
-#: src/muuli_wdr.cpp:1330
+#: src/muuli_wdr.cpp:1257 src/muuli_wdr.cpp:1330 src/muuli_wdr.cpp:1334
+#: src/muuli_wdr.cpp:1337
 msgid "The delay before showing tool-tips."
 msgstr ""
 
@@ -3799,923 +3804,931 @@ msgstr ""
 msgid "Enabling this will make aMule to show notifications when finished downloading."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1322
-msgid "Tooltip delay time: "
+#: src/muuli_wdr.cpp:1323
+msgid "Remember search history"
+msgstr ""
+
+#: src/muuli_wdr.cpp:1324
+msgid "Keeps a dropdown list of your past search terms in the Search tab's Name field. This remembers the queries you typed, not the results they returned."
 msgstr ""
 
 #: src/muuli_wdr.cpp:1329
+msgid "Tooltip delay time: "
+msgstr ""
+
+#: src/muuli_wdr.cpp:1336
 msgid "seconds"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1333
+#: src/muuli_wdr.cpp:1340
 msgid "Browser Selection"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1339
+#: src/muuli_wdr.cpp:1346
 msgid "Enter your browser name here. Leave this field empty to use the system default browser."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1346
+#: src/muuli_wdr.cpp:1353
 msgid "Open in new tab if possible"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1348
+#: src/muuli_wdr.cpp:1355
 msgid "Open the web page in a new tab instead of in a new window when possible"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1352
+#: src/muuli_wdr.cpp:1359
 msgid "Video Player"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1379
+#: src/muuli_wdr.cpp:1386
 msgid "Bandwidth limits"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1393
+#: src/muuli_wdr.cpp:1400
 msgid "Upload"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1401
+#: src/muuli_wdr.cpp:1408
 msgid "Slot Allocation"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1410
+#: src/muuli_wdr.cpp:1417
 msgid "Ports"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1420
+#: src/muuli_wdr.cpp:1427
 msgid "This is the standard eD2k port and cannot be disabled."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1423
+#: src/muuli_wdr.cpp:1430
 msgid "UDP port for server requests (TCP+3):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1425
+#: src/muuli_wdr.cpp:1432
 msgid "4665"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1432
+#: src/muuli_wdr.cpp:1439
 msgid "This UDP port is used for extended eD2k requests and Kad network"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1439
+#: src/muuli_wdr.cpp:1446
 msgid "UPnP TCP Port (Optional):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1449
+#: src/muuli_wdr.cpp:1456
 msgid "Bind local address to IP (empty for any):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1452
+#: src/muuli_wdr.cpp:1459
 msgid "Advanced users only: If you have multiple network interfaces, enter the address of the interface to which aMule should be bound."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1455 src/muuli_wdr.cpp:2054
+#: src/muuli_wdr.cpp:1462 src/muuli_wdr.cpp:2061
 msgid "Bind to network interface (empty for any):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1468
+#: src/muuli_wdr.cpp:1475
 msgid "Advanced users only: pin all of aMule's traffic to one network interface, chosen from the list or typed in by name (e.g. tun0, eth0, en0) or index. Unlike binding to an IP, this stops traffic leaking out via the default route - useful with a VPN. Requires no elevated privileges."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1474
+#: src/muuli_wdr.cpp:1481
 msgid "Max sources per downloading file:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1478
+#: src/muuli_wdr.cpp:1485
 msgid "Max simultaneous connections:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1491 src/muuli_wdr.cpp:3169
+#: src/muuli_wdr.cpp:1498 src/muuli_wdr.cpp:3176
 msgid "ED2K"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1498
+#: src/muuli_wdr.cpp:1505
 msgid "Autoconnect on startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1501
+#: src/muuli_wdr.cpp:1508
 msgid "Reconnect on loss"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1523
+#: src/muuli_wdr.cpp:1530
 msgid "Remove dead server after"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1524
+#: src/muuli_wdr.cpp:1531
 msgid "Static servers are never removed, even when unreachable."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1528
+#: src/muuli_wdr.cpp:1535
 msgid "retries"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1536
+#: src/muuli_wdr.cpp:1543
 msgid "List"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1539
+#: src/muuli_wdr.cpp:1546
 msgid "Update server list when connecting to a server"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1542
+#: src/muuli_wdr.cpp:1549
 msgid "Update server list when a client connects"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1545
+#: src/muuli_wdr.cpp:1552
 msgid "Use priority system"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1549
+#: src/muuli_wdr.cpp:1556
 msgid "Use smart LowID check on connect"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1553
+#: src/muuli_wdr.cpp:1560
 msgid "Safe connect"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1557
+#: src/muuli_wdr.cpp:1564
 msgid "Autoconnect to servers in static list only"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1560
+#: src/muuli_wdr.cpp:1567
 msgid "Set manually added servers to High Priority"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1581
+#: src/muuli_wdr.cpp:1588
 msgid "Add files to download in pause mode"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1583
+#: src/muuli_wdr.cpp:1590
 msgid "Add files to download with auto priority"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1586
+#: src/muuli_wdr.cpp:1593
 msgid "Try to download first and last chunks first"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1590
+#: src/muuli_wdr.cpp:1597
 msgid "Endgame mode: rotate to faster sources for the final blocks"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1593
+#: src/muuli_wdr.cpp:1600
 msgid "Start next paused file when a file completes"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1596
+#: src/muuli_wdr.cpp:1603
 msgid "From the same category"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1598
+#: src/muuli_wdr.cpp:1605
 msgid "In alphabetic order"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1600
+#: src/muuli_wdr.cpp:1607
 msgid "Preallocate disk space for new files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1601
+#: src/muuli_wdr.cpp:1608
 msgid "For new files preallocates disk space for the whole file, thus reduces fragmentation"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1606
+#: src/muuli_wdr.cpp:1613
 msgid "Create new files as sparse files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1607
+#: src/muuli_wdr.cpp:1614
 msgid "A sparse file reserves its full size on disk immediately without writing real data to it -- fast, but unsupported or slow on some filesystems, and free-space accounting stays optimistic while the download is in progress. Turn this off to grow the file only as data arrives."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1612
+#: src/muuli_wdr.cpp:1619
 msgid "Stop downloads when free disk space reaches "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1613
+#: src/muuli_wdr.cpp:1620
 msgid "Select this if you want aMule to check your disk space"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1617
+#: src/muuli_wdr.cpp:1624
 msgid "Enter here the min disk space desired."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1623
+#: src/muuli_wdr.cpp:1630
 msgid "Save 10 sources on rare files (< 20 sources)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1627 src/Statistics.cpp:790
+#: src/muuli_wdr.cpp:1634 src/Statistics.cpp:790
 msgid "Uploads"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1630
+#: src/muuli_wdr.cpp:1637
 msgid "Add new shared files with auto priority"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1636
+#: src/muuli_wdr.cpp:1643
 msgid "Intelligent Corruption Handling (I.C.H.)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1639
+#: src/muuli_wdr.cpp:1646
 msgid "Enable"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1642
+#: src/muuli_wdr.cpp:1649
 msgid "Advanced I.C.H. trusts every hash (not recommended)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1654 src/PrefsUnifiedDlg.cpp:1910
+#: src/muuli_wdr.cpp:1661 src/PrefsUnifiedDlg.cpp:1910
 msgid "Media metadata extraction"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1658
+#: src/muuli_wdr.cpp:1665
 msgid "Extract length / bitrate / codec from shared audio and video files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1660
+#: src/muuli_wdr.cpp:1667
 msgid "When enabled, aMule runs ffprobe on each shared media file to fill in the Length / Bitrate / Codec columns other clients see when they find the file in a search. Requires ffmpeg (the ffprobe binary) to be installed."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1667
+#: src/muuli_wdr.cpp:1674
 msgid "Path to ffprobe:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1672
+#: src/muuli_wdr.cpp:1679
 msgid "Full path to the ffprobe binary. Leave empty to have aMule auto-detect it on startup."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1680
+#: src/muuli_wdr.cpp:1687
 msgid "Detect"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1681
+#: src/muuli_wdr.cpp:1688
 msgid "Search the standard install locations for an ffprobe binary and fill the path field."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1705
+#: src/muuli_wdr.cpp:1712
 msgid ""
 "Completed downloads are stored here. All files in this folder are automatically shared with other peers.\n"
 "If this folder also holds files you don't want to share, point it at an aMule-only sub-folder."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1708
+#: src/muuli_wdr.cpp:1715
 msgid "Pick the folder where completed downloads will be stored. All files in that folder will be shared with other peers."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1722
+#: src/muuli_wdr.cpp:1729
 msgid "Shared folders"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1728
+#: src/muuli_wdr.cpp:1735
 msgid "(Folders shared by the core. Enter a path to add one.)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1736
+#: src/muuli_wdr.cpp:1743
 msgid "Absolute path of a folder on the core's machine, e.g. /home/user/shared"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1738 src/PrefsUnifiedDlg.cpp:2794
+#: src/muuli_wdr.cpp:1745 src/PrefsUnifiedDlg.cpp:2794
 msgid "Recursive"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1739
+#: src/muuli_wdr.cpp:1746
 msgid "Share every sub-folder underneath this one, including ones created later."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1743 src/utils/aLinkCreator/src/alcframe.cpp:141
+#: src/muuli_wdr.cpp:1750 src/utils/aLinkCreator/src/alcframe.cpp:141
 msgid "Remove"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1747
+#: src/muuli_wdr.cpp:1754
 msgid "(Right click on folder icon for recursive share)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1754
+#: src/muuli_wdr.cpp:1761
 msgid "Share hidden files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1760
+#: src/muuli_wdr.cpp:1767
 msgid "Automatically rescan shared folders for changes"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1766
+#: src/muuli_wdr.cpp:1773
 msgid "Follow symbolic links in shared folders"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1772
+#: src/muuli_wdr.cpp:1779
 msgid "Exclude files matching:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1775
+#: src/muuli_wdr.cpp:1782
 msgid "Wildcard patterns separated by '|', e.g. .DS_Store|Thumbs.db|*.tmp. Files whose name matches are not shared. Matching is case-insensitive."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1779
+#: src/muuli_wdr.cpp:1786
 msgid "Patterns are regular expressions"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1780
+#: src/muuli_wdr.cpp:1787
 msgid "When set, the whole field is one regular expression ('|' is alternation). When unset, it is a list of '|'-separated wildcards."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1790
+#: src/muuli_wdr.cpp:1797
 msgid "Show how many shared files the current pattern would exclude."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1811
+#: src/muuli_wdr.cpp:1818
 msgid "Graphs"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1814 src/muuli_wdr.cpp:1876
+#: src/muuli_wdr.cpp:1821 src/muuli_wdr.cpp:1883
 msgid "Update delay : 5 secs"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1818
+#: src/muuli_wdr.cpp:1825
 msgid "Time for average graph: 100 mins"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1822
+#: src/muuli_wdr.cpp:1829
 msgid "Connections Graph Scale: 100 "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1829
+#: src/muuli_wdr.cpp:1836
 msgid "Download graph scale:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1837
+#: src/muuli_wdr.cpp:1844
 msgid "Upload graph scale:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1847
+#: src/muuli_wdr.cpp:1854
 msgid "Colors: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1851
+#: src/muuli_wdr.cpp:1858
 msgid "Background"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1852
+#: src/muuli_wdr.cpp:1859
 msgid "Grid"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1853
+#: src/muuli_wdr.cpp:1860
 msgid "Download current"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1854
+#: src/muuli_wdr.cpp:1861
 msgid "Download running average"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1855
+#: src/muuli_wdr.cpp:1862
 msgid "Download session average"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1856
+#: src/muuli_wdr.cpp:1863
 msgid "Upload current"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1857
+#: src/muuli_wdr.cpp:1864
 msgid "Upload running average"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1858
+#: src/muuli_wdr.cpp:1865
 msgid "Upload session average"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1859
+#: src/muuli_wdr.cpp:1866
 msgid "Active connections"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1862
+#: src/muuli_wdr.cpp:1869
 msgid "Systray Icon Speed Bar"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1863
+#: src/muuli_wdr.cpp:1870
 msgid "Kad-nodes current"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1864
+#: src/muuli_wdr.cpp:1871
 msgid "Kad-nodes running"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1865
+#: src/muuli_wdr.cpp:1872
 msgid "Kad-nodes session"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1869 src/muuli_wdr.cpp:2296
+#: src/muuli_wdr.cpp:1876 src/muuli_wdr.cpp:2303
 msgid "Select"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1873
+#: src/muuli_wdr.cpp:1880
 msgid "Tree"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1883
+#: src/muuli_wdr.cpp:1890
 msgid "Number of Client Versions shown (0=unlimited)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1908
+#: src/muuli_wdr.cpp:1915
 msgid "!!! WARNING !!!"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1923
+#: src/muuli_wdr.cpp:1930
 msgid "Max new connections / 5 secs"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1925
+#: src/muuli_wdr.cpp:1932
 msgid "Concurrent Kad source lookups"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1927
+#: src/muuli_wdr.cpp:1934
 msgid "Kad source re-search interval (minutes)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1929
+#: src/muuli_wdr.cpp:1936
 msgid "Source re-ask interval (minutes)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1933
+#: src/muuli_wdr.cpp:1940
 msgid "File Buffer Size: 240000 bytes"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1937
+#: src/muuli_wdr.cpp:1944
 msgid "Use MMAP: memory-mapped file access (lower memory use)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1938
+#: src/muuli_wdr.cpp:1945
 msgid "Maps part files into memory instead of buffering them on the heap, lowering the process memory footprint. May reduce download speed on some disks; best for memory-constrained or upload-heavy hosts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1940
+#: src/muuli_wdr.cpp:1947
 msgid "Upload Queue Size: 5000 clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1944
+#: src/muuli_wdr.cpp:1951
 msgid "Server connection refresh interval: Disable"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1948
+#: src/muuli_wdr.cpp:1955
 msgid "Disable computer's timed standby mode"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1967
+#: src/muuli_wdr.cpp:1974
 msgid "Skin to use: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1976
+#: src/muuli_wdr.cpp:1983
 msgid "Show \"Fast eD2k Links Handler\" in every window."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1979
+#: src/muuli_wdr.cpp:1986
 msgid "Show extended info on categories tabs"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1982
+#: src/muuli_wdr.cpp:1989
 msgid "Show application version on title"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1984
+#: src/muuli_wdr.cpp:1991
 msgid "Show transfer rates on title"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1986
+#: src/muuli_wdr.cpp:1993
 msgid "Before application name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1988
+#: src/muuli_wdr.cpp:1995
 msgid "After application name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1991
+#: src/muuli_wdr.cpp:1998
 msgid "Show overhead bandwidth"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1995
+#: src/muuli_wdr.cpp:2002
 msgid "Vertical toolbar orientation"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1997
+#: src/muuli_wdr.cpp:2004
 msgid "Live column sorting (auto-reorder rows as their values change)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2004
+#: src/muuli_wdr.cpp:2011
 msgid "Download Queue Files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2007
+#: src/muuli_wdr.cpp:2014
 msgid "Show progress percentage"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2013
+#: src/muuli_wdr.cpp:2020
 msgid "Show progress bar"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2016
+#: src/muuli_wdr.cpp:2023
 msgid "Flat"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2020
+#: src/muuli_wdr.cpp:2027
 msgid "Round"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2038
+#: src/muuli_wdr.cpp:2045
 msgid "External Connection Parameters"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2041
+#: src/muuli_wdr.cpp:2048
 msgid "Accept external connections"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2048 src/muuli_wdr.cpp:2107
+#: src/muuli_wdr.cpp:2055 src/muuli_wdr.cpp:2114
 msgid "IP of the listening interface:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2051
+#: src/muuli_wdr.cpp:2058
 msgid "Enter here a valid ip in the a.b.c.d format for the listening EC interface. An empty field or 0.0.0.0 will mean any interface."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2072 src/muuli_wdr.cpp:2156
+#: src/muuli_wdr.cpp:2079 src/muuli_wdr.cpp:2163
 msgid "TCP port:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2078
+#: src/muuli_wdr.cpp:2085
 msgid "Enable UPnP port forwarding on the EC port"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2082 src/muuli_wdr.cpp:3041
+#: src/muuli_wdr.cpp:2089 src/muuli_wdr.cpp:3048
 #: src/utils/wxCas/src/wxcasprefs.cpp:167
 msgid "Password"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2088
+#: src/muuli_wdr.cpp:2095
 msgid "aMule API server parameters"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2091
+#: src/muuli_wdr.cpp:2098
 msgid "Run amuleapi (REST API) on startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2096
+#: src/muuli_wdr.cpp:2103
 msgid "HTTP port:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2110
+#: src/muuli_wdr.cpp:2117
 msgid "The interface amuleapi's HTTP server listens on. 127.0.0.1 (default) accepts only local connections; use 0.0.0.0 or a specific IP to expose it to other hosts (set an admin password below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2113
+#: src/muuli_wdr.cpp:2120
 msgid "Admin password"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2118 src/muuli_wdr.cpp:2149
+#: src/muuli_wdr.cpp:2125 src/muuli_wdr.cpp:2156
 msgid "Low rights password"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2126
+#: src/muuli_wdr.cpp:2133
 msgid "Web server parameters"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2129
+#: src/muuli_wdr.cpp:2136
 msgid "Run webserver on startup (deprecated)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2135
+#: src/muuli_wdr.cpp:2142
 msgid "Web template"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2140
+#: src/muuli_wdr.cpp:2147
 msgid "Full rights password"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2144
+#: src/muuli_wdr.cpp:2151
 msgid "Enable Low rights User"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2163
+#: src/muuli_wdr.cpp:2170
 msgid "Enable UPnP port forwarding of the web server port"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2168
+#: src/muuli_wdr.cpp:2175
 msgid "Web server UPnP TCP port (Optional)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2176
+#: src/muuli_wdr.cpp:2183
 msgid "Page Refresh Time (in secs)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2183
+#: src/muuli_wdr.cpp:2190
 msgid "Enable Gzip compression"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2217
+#: src/muuli_wdr.cpp:2224
 msgid "Reset page to defaults"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2218
+#: src/muuli_wdr.cpp:2225
 msgid "Reset the settings on the current page to their default values."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2220 src/muuli_wdr.cpp:2306 src/ServerWnd.cpp:274
+#: src/muuli_wdr.cpp:2227 src/muuli_wdr.cpp:2313 src/ServerWnd.cpp:274
 #: src/ServerWnd.cpp:282
 msgid "OK"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2222
+#: src/muuli_wdr.cpp:2229
 msgid "Click here to apply any changes made to the preferences."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2225
+#: src/muuli_wdr.cpp:2232
 msgid "Reset any changes made to the preferences."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2254
+#: src/muuli_wdr.cpp:2261
 msgid "Comment :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2261
+#: src/muuli_wdr.cpp:2268
 msgid "Incoming Dir :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2270
+#: src/muuli_wdr.cpp:2277
 msgid "Change priority for new assigned files :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2274
+#: src/muuli_wdr.cpp:2281
 msgid "Don't change"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2286
+#: src/muuli_wdr.cpp:2293
 msgid "Select color for this Category (currently selected) :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2353 src/muuli_wdr.cpp:2372 src/muuli_wdr.cpp:2394
+#: src/muuli_wdr.cpp:2360 src/muuli_wdr.cpp:2379 src/muuli_wdr.cpp:2401
 msgid "Click this button to reset the log."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2413
+#: src/muuli_wdr.cpp:2420
 msgid "Click on this button to update the servers list from URL ..."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2417
+#: src/muuli_wdr.cpp:2424
 msgid "Server list"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2421
+#: src/muuli_wdr.cpp:2428
 msgid "Enter the url to a server.met file here and press the button to the left to update the list of known servers."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2426
+#: src/muuli_wdr.cpp:2433
 msgid "Add server manually: Name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2429
+#: src/muuli_wdr.cpp:2436
 msgid "Enter the name of the new server here"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2431 src/ServerWnd.cpp:206
+#: src/muuli_wdr.cpp:2438 src/ServerWnd.cpp:206
 msgid "IP:Port"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2434
+#: src/muuli_wdr.cpp:2441
 msgid "Enter the IP of the server here, using the x.x.x.x format."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2440
+#: src/muuli_wdr.cpp:2447
 msgid "Enter the port of the server here."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2443
+#: src/muuli_wdr.cpp:2450
 msgid "Add manually a server (fill fields to the left before) ..."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2472
+#: src/muuli_wdr.cpp:2479
 msgid "aMule Log"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2480
+#: src/muuli_wdr.cpp:2487
 msgid "Server Info"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2484
+#: src/muuli_wdr.cpp:2491
 msgid "ED2K Info"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2488
+#: src/muuli_wdr.cpp:2495
 msgid "Kad Info"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2516
+#: src/muuli_wdr.cpp:2523
 msgid "Click on this button to update the nodes list from URL ..."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2520
+#: src/muuli_wdr.cpp:2527
 msgid "Nodes (0)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2524
+#: src/muuli_wdr.cpp:2531
 msgid "Enter the url to a nodes.dat file here and press the button to the left to update the list of known nodes."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2527
+#: src/muuli_wdr.cpp:2534
 msgid "Nodes stats"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2569
+#: src/muuli_wdr.cpp:2576
 msgid "Bootstrap"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2572
+#: src/muuli_wdr.cpp:2579
 msgid "New node"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2577
+#: src/muuli_wdr.cpp:2584
 msgid "IP:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2597
+#: src/muuli_wdr.cpp:2604
 msgid "Port:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2610
+#: src/muuli_wdr.cpp:2617
 msgid "Bootstrap from known clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2612
+#: src/muuli_wdr.cpp:2619
 msgid "Disconnect Kad"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2646
+#: src/muuli_wdr.cpp:2653
 msgid "Use Secure User Identification"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2648
+#: src/muuli_wdr.cpp:2655
 msgid "It is recommended to enable this option. You will not receive credits if SUI is not enabled."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2650
+#: src/muuli_wdr.cpp:2657
 msgid "Protocol Obfuscation"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2653
+#: src/muuli_wdr.cpp:2660
 msgid "Support Protocol Obfuscation"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2655
+#: src/muuli_wdr.cpp:2662
 msgid "This option enabled Protocol Obfuscation, and makes aMule accept obfuscated connections from other clients."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2657
+#: src/muuli_wdr.cpp:2664
 msgid "Use obfuscation for outgoing connections"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2659
+#: src/muuli_wdr.cpp:2666
 msgid "This option makes aMule use Protocol Obfuscation when connecting other clients/servers."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2661
+#: src/muuli_wdr.cpp:2668
 msgid "Accept only obfuscated connections"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2662
+#: src/muuli_wdr.cpp:2669
 msgid "This option makes aMule only accept obfuscated connections. You will have less sources, but all your traffic will be obfuscated"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2667
+#: src/muuli_wdr.cpp:2674
 msgid "Everybody"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2669
+#: src/muuli_wdr.cpp:2676
 msgid "No one"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2671
+#: src/muuli_wdr.cpp:2678
 msgid "Who can see my shared files:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2672
+#: src/muuli_wdr.cpp:2679
 msgid "Select who can request to view a list of your shared files."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2674
+#: src/muuli_wdr.cpp:2681
 msgid "IP-Filtering"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2681
+#: src/muuli_wdr.cpp:2688
 msgid "Filter clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2683
+#: src/muuli_wdr.cpp:2690
 msgid "Enable filtering of the client IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2685
+#: src/muuli_wdr.cpp:2692
 msgid "Filter servers"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2687
+#: src/muuli_wdr.cpp:2694
 msgid "Enable filtering of the server IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2691
+#: src/muuli_wdr.cpp:2698
 msgid "Reload List"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2692
+#: src/muuli_wdr.cpp:2699
 msgid "Reload the list of IPs to filter from the file ~/.aMule/ipfilter.dat"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2698
+#: src/muuli_wdr.cpp:2705
 msgid "URL:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2702 src/muuli_wdr.cpp:2895
+#: src/muuli_wdr.cpp:2709 src/muuli_wdr.cpp:2902
 msgid "Update now"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2705
+#: src/muuli_wdr.cpp:2712
 msgid "Auto-update ipfilter at startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2709
+#: src/muuli_wdr.cpp:2716
 msgid "Filtering Level:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2715
+#: src/muuli_wdr.cpp:2722
 msgid "Always filter LAN IPs"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2718
+#: src/muuli_wdr.cpp:2725
 msgid "Paranoid handling of non-matching IPs"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2720
+#: src/muuli_wdr.cpp:2727
 msgid "Rejects a packet when its source IP differs from the IP the client claims (an anti-spoofing check). Disable only if it causes connection problems."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2722
+#: src/muuli_wdr.cpp:2729
 msgid "Use system-wide ipfilter.dat if available"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2723
+#: src/muuli_wdr.cpp:2730
 msgid "If there's no local ipfilter.dat found, allow usage of a system-wide ipfilter file."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2740
+#: src/muuli_wdr.cpp:2747
 msgid "Enable Online-Signature"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2742
+#: src/muuli_wdr.cpp:2749
 msgid "Enables the writing of the OS file, which can be used by external apps to create signatures and the like."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2746
+#: src/muuli_wdr.cpp:2753
 msgid "Update Frequency (Secs):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2749
+#: src/muuli_wdr.cpp:2756
 msgid "Change the frequency (in seconds) of Online Signature updates."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2757
+#: src/muuli_wdr.cpp:2764
 msgid "Save online signature file in: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:2763
+#: src/muuli_wdr.cpp:2770
 msgid "Click here to select the directory containing the the Online Signature files."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2796
+#: src/muuli_wdr.cpp:2803
 msgid "Show country flags for clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2797
+#: src/muuli_wdr.cpp:2804
 msgid "Render the country flag column in the transfers, queue and search views. Requires a valid MMDB GeoIP database (see below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2802
+#: src/muuli_wdr.cpp:2809
 msgid "Database"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2818
+#: src/muuli_wdr.cpp:2825
 msgid "Source:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2821
+#: src/muuli_wdr.cpp:2828
 msgid "DB-IP (free, no account)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2822
+#: src/muuli_wdr.cpp:2829
 msgid "MaxMind GeoLite2 (free, account required)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2823
+#: src/muuli_wdr.cpp:2830
 msgid "Custom URL"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2826
+#: src/muuli_wdr.cpp:2833
 msgid "Choose which provider supplies the GeoIP MMDB database. DB-IP is the default - no account required. MaxMind requires a free account + license key. Use Custom URL to point at any other MMDB host (e.g. a local mirror)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2843
+#: src/muuli_wdr.cpp:2850
 msgid ""
 "No configuration required.\n"
 "\n"
@@ -4723,11 +4736,11 @@ msgid ""
 "License: Creative Commons BY 4.0 - https://creativecommons.org/licenses/by/4.0/"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2856
+#: src/muuli_wdr.cpp:2863
 msgid "License key:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2862
+#: src/muuli_wdr.cpp:2869
 msgid ""
 "Sign up for a free MaxMind account, then generate a License Key:\n"
 "https://www.maxmind.com/en/geolite2/signup\n"
@@ -4737,222 +4750,222 @@ msgid ""
 "Requires attribution and account registration; refresh at least every 30 days."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2877
+#: src/muuli_wdr.cpp:2884
 msgid "Download URL:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2883
+#: src/muuli_wdr.cpp:2890
 msgid ""
 "Must point to an .mmdb file or a .gz / .tar.gz containing one.\n"
 "URL may include credentials (https://user:pass@host/...).\n"
 "License and attribution terms are set by the upstream URL - you are responsible."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2896
+#: src/muuli_wdr.cpp:2903
 msgid "Download the GeoIP database from the selected source."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2898
+#: src/muuli_wdr.cpp:2905
 msgid "Auto-update on startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2899
+#: src/muuli_wdr.cpp:2906
 msgid "Re-download the GeoIP database from the selected source every time aMule starts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2922
+#: src/muuli_wdr.cpp:2929
 msgid "Filter incoming messages (except current chat):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2924
+#: src/muuli_wdr.cpp:2931
 msgid "Filter all messages"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2926
+#: src/muuli_wdr.cpp:2933
 msgid "Filter messages from people not on your friend list"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2928
+#: src/muuli_wdr.cpp:2935
 msgid "Filter messages from unknown clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2930
+#: src/muuli_wdr.cpp:2937
 msgid "Filter messages containing (use ',' as separator):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2933 src/muuli_wdr.cpp:2944
+#: src/muuli_wdr.cpp:2940 src/muuli_wdr.cpp:2951
 msgid "add here the words amule should filter and block messages including it"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2935
+#: src/muuli_wdr.cpp:2942
 msgid "Show received messages in the log"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2938
+#: src/muuli_wdr.cpp:2945
 msgid "Comments"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2941
+#: src/muuli_wdr.cpp:2948
 msgid "Filter comments containing (use ',' as separator):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2966
+#: src/muuli_wdr.cpp:2973
 msgid "Enable Proxy"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2967
+#: src/muuli_wdr.cpp:2974
 msgid "Enable/disable proxy support"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2970
+#: src/muuli_wdr.cpp:2977
 msgid "Proxy type:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2981
+#: src/muuli_wdr.cpp:2988
 msgid "Proxy host:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2984
+#: src/muuli_wdr.cpp:2991
 msgid "The proxy host name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2986
+#: src/muuli_wdr.cpp:2993
 msgid "Proxy port:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2989
+#: src/muuli_wdr.cpp:2996
 msgid "The proxy port"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2991
+#: src/muuli_wdr.cpp:2998
 msgid "Enable authentication"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2992
+#: src/muuli_wdr.cpp:2999
 msgid "Enable/disable username/password authentication"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2995
+#: src/muuli_wdr.cpp:3002
 msgid "Username: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:2998
+#: src/muuli_wdr.cpp:3005
 msgid "The username to use to connect to the proxy"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3000
+#: src/muuli_wdr.cpp:3007
 msgid "Password:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3003
+#: src/muuli_wdr.cpp:3010
 msgid "The password to use to connect to the proxy"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3022
+#: src/muuli_wdr.cpp:3029
 msgid "Connect to:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3031
+#: src/muuli_wdr.cpp:3038
 msgid "Login to remote amule"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3036
+#: src/muuli_wdr.cpp:3043
 msgid "User name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3047
+#: src/muuli_wdr.cpp:3054
 msgid "Remember those settings"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3050
+#: src/muuli_wdr.cpp:3057
 msgid "Force ZLIB compression"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3074
+#: src/muuli_wdr.cpp:3081
 msgid "Enable Verbose Debug-Logging."
 msgstr ""
 
-#: src/muuli_wdr.cpp:3076
+#: src/muuli_wdr.cpp:3083
 msgid "Only to Logfile"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3078
+#: src/muuli_wdr.cpp:3085
 msgid "Message Categories:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3102 src/PartFileConvertDlg.cpp:160
+#: src/muuli_wdr.cpp:3109 src/PartFileConvertDlg.cpp:160
 msgid "Waiting..."
 msgstr ""
 
-#: src/muuli_wdr.cpp:3122
+#: src/muuli_wdr.cpp:3129
 msgid "Add imports"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3125
+#: src/muuli_wdr.cpp:3132
 msgid "Retry selected"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3127
+#: src/muuli_wdr.cpp:3134
 msgid "Remove selected"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3190
+#: src/muuli_wdr.cpp:3197
 msgid "Event Types"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3209
+#: src/muuli_wdr.cpp:3216
 msgid "Statistics and queued clients for selected file(s) : Session / All time"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3233
+#: src/muuli_wdr.cpp:3240
 msgid "Active Uploads"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3247
+#: src/muuli_wdr.cpp:3254
 msgid "Percent of total files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3299
+#: src/muuli_wdr.cpp:3306
 msgid "Show Clients for"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3301
+#: src/muuli_wdr.cpp:3308
 msgid "All files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3304
+#: src/muuli_wdr.cpp:3311
 msgid "Selected files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3307
+#: src/muuli_wdr.cpp:3314
 msgid "Active uploads only"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3314
+#: src/muuli_wdr.cpp:3321
 msgid "Reload:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3318
+#: src/muuli_wdr.cpp:3325
 msgid "Reload your shared files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3381
+#: src/muuli_wdr.cpp:3388
 msgid "Send"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3382
+#: src/muuli_wdr.cpp:3389
 msgid "Sends the specified message."
 msgstr ""
 
-#: src/muuli_wdr.cpp:3386
+#: src/muuli_wdr.cpp:3393
 msgid "Close this chat-session."
 msgstr ""
 
-#: src/muuli_wdr.cpp:3409
+#: src/muuli_wdr.cpp:3416
 msgid "Connect to any server and/or Kad"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3415 src/SharedFilesCtrl.cpp:142 src/Statistics.cpp:941
+#: src/muuli_wdr.cpp:3422 src/SharedFilesCtrl.cpp:142 src/Statistics.cpp:941
 msgid "Shared Files"
 msgstr ""
 
@@ -5310,187 +5323,187 @@ msgstr ""
 msgid "ERROR: Failed to open partfile '%s'"
 msgstr ""
 
-#: src/Preferences.cpp:673
+#: src/Preferences.cpp:674
 msgid "System default"
 msgstr ""
 
-#: src/Preferences.cpp:674
+#: src/Preferences.cpp:675
 msgid "Albanian"
 msgstr ""
 
-#: src/Preferences.cpp:675
+#: src/Preferences.cpp:676
 msgid "Arabic"
 msgstr ""
 
-#: src/Preferences.cpp:676
+#: src/Preferences.cpp:677
 msgid "Asturian"
 msgstr ""
 
-#: src/Preferences.cpp:677
+#: src/Preferences.cpp:678
 msgid "Basque"
 msgstr ""
 
-#: src/Preferences.cpp:678
+#: src/Preferences.cpp:679
 msgid "Bulgarian"
 msgstr ""
 
-#: src/Preferences.cpp:679
+#: src/Preferences.cpp:680
 msgid "Catalan"
 msgstr ""
 
-#: src/Preferences.cpp:680
+#: src/Preferences.cpp:681
 msgid "Chinese (Simplified)"
 msgstr ""
 
-#: src/Preferences.cpp:681
+#: src/Preferences.cpp:682
 msgid "Chinese (Traditional)"
 msgstr ""
 
-#: src/Preferences.cpp:682
+#: src/Preferences.cpp:683
 msgid "Croatian"
 msgstr ""
 
-#: src/Preferences.cpp:683
+#: src/Preferences.cpp:684
 msgid "Czech"
 msgstr ""
 
-#: src/Preferences.cpp:684
+#: src/Preferences.cpp:685
 msgid "Danish"
 msgstr ""
 
-#: src/Preferences.cpp:685
+#: src/Preferences.cpp:686
 msgid "Dutch"
 msgstr ""
 
-#: src/Preferences.cpp:686
+#: src/Preferences.cpp:687
 msgid "English (U.K.)"
 msgstr ""
 
-#: src/Preferences.cpp:687
+#: src/Preferences.cpp:688
 msgid "English (U.S.)"
 msgstr ""
 
-#: src/Preferences.cpp:688
+#: src/Preferences.cpp:689
 msgid "Estonian"
 msgstr ""
 
-#: src/Preferences.cpp:689
+#: src/Preferences.cpp:690
 msgid "Finnish"
 msgstr ""
 
-#: src/Preferences.cpp:690
+#: src/Preferences.cpp:691
 msgid "French"
 msgstr ""
 
-#: src/Preferences.cpp:691
+#: src/Preferences.cpp:692
 msgid "Galician"
 msgstr ""
 
-#: src/Preferences.cpp:692
+#: src/Preferences.cpp:693
 msgid "German"
 msgstr ""
 
-#: src/Preferences.cpp:693
+#: src/Preferences.cpp:694
 msgid "Greek"
 msgstr ""
 
-#: src/Preferences.cpp:694
+#: src/Preferences.cpp:695
 msgid "Hebrew"
 msgstr ""
 
-#: src/Preferences.cpp:695
+#: src/Preferences.cpp:696
 msgid "Hungarian"
 msgstr ""
 
-#: src/Preferences.cpp:696
+#: src/Preferences.cpp:697
 msgid "Italian"
 msgstr ""
 
-#: src/Preferences.cpp:697
+#: src/Preferences.cpp:698
 msgid "Japanese"
 msgstr ""
 
-#: src/Preferences.cpp:698
+#: src/Preferences.cpp:699
 msgid "Korean"
 msgstr ""
 
-#: src/Preferences.cpp:699
+#: src/Preferences.cpp:700
 msgid "Latvian"
 msgstr ""
 
-#: src/Preferences.cpp:700
+#: src/Preferences.cpp:701
 msgid "Lithuanian"
 msgstr ""
 
-#: src/Preferences.cpp:701
+#: src/Preferences.cpp:702
 msgid "Norwegian (Nynorsk)"
 msgstr ""
 
-#: src/Preferences.cpp:702
+#: src/Preferences.cpp:703
 msgid "Polish"
 msgstr ""
 
-#: src/Preferences.cpp:703
+#: src/Preferences.cpp:704
 msgid "Portuguese"
 msgstr ""
 
-#: src/Preferences.cpp:704
+#: src/Preferences.cpp:705
 msgid "Portuguese (Brazilian)"
 msgstr ""
 
-#: src/Preferences.cpp:705
+#: src/Preferences.cpp:706
 msgid "Romanian"
 msgstr ""
 
-#: src/Preferences.cpp:706
+#: src/Preferences.cpp:707
 msgid "Russian"
 msgstr ""
 
-#: src/Preferences.cpp:707
+#: src/Preferences.cpp:708
 msgid "Slovenian"
 msgstr ""
 
-#: src/Preferences.cpp:708
+#: src/Preferences.cpp:709
 msgid "Spanish"
 msgstr ""
 
-#: src/Preferences.cpp:709
+#: src/Preferences.cpp:710
 msgid "Swedish"
 msgstr ""
 
-#: src/Preferences.cpp:710
+#: src/Preferences.cpp:711
 msgid "Turkish"
 msgstr ""
 
-#: src/Preferences.cpp:711
+#: src/Preferences.cpp:712
 msgid "Ukrainian"
 msgstr ""
 
-#: src/Preferences.cpp:814
+#: src/Preferences.cpp:815
 msgid "Change Language"
 msgstr ""
 
-#: src/Preferences.cpp:878
+#: src/Preferences.cpp:879
 msgid "There are no translations installed for aMule"
 msgstr ""
 
-#: src/Preferences.cpp:879
+#: src/Preferences.cpp:880
 msgid "No languages available"
 msgstr ""
 
-#: src/Preferences.cpp:1010
+#: src/Preferences.cpp:1011
 msgid "no options available"
 msgstr ""
 
-#: src/Preferences.cpp:2179
+#: src/Preferences.cpp:2182
 msgid "Invalid category found, skipping"
 msgstr ""
 
-#: src/Preferences.cpp:2348
+#: src/Preferences.cpp:2351
 msgid "TCP port can't be higher than 65532 due to server UDP socket being TCP+3"
 msgstr ""
 
-#: src/Preferences.cpp:2349
+#: src/Preferences.cpp:2352
 #, c-format
 msgid "Default port will be used (%d)"
 msgstr ""
@@ -5960,23 +5973,27 @@ msgstr ""
 msgid "Shared folder"
 msgstr ""
 
-#: src/SearchDlg.cpp:425
+#: src/SearchDlg.cpp:280
+msgid "Clear search history"
+msgstr ""
+
+#: src/SearchDlg.cpp:584
 msgid "It's impossible to search when both eD2k and Kademlia are disabled."
 msgstr ""
 
-#: src/SearchDlg.cpp:426 src/SearchListCtrl.cpp:858
+#: src/SearchDlg.cpp:585 src/SearchListCtrl.cpp:858
 msgid "Search error"
 msgstr ""
 
-#: src/SearchDlg.cpp:768
+#: src/SearchDlg.cpp:929
 msgid "Min size must be smaller than max size. Max size ignored."
 msgstr ""
 
-#: src/SearchDlg.cpp:769 src/SearchDlg.cpp:851
+#: src/SearchDlg.cpp:930 src/SearchDlg.cpp:1012
 msgid "Search warning"
 msgstr ""
 
-#: src/SearchDlg.cpp:929 src/SearchListCtrl.cpp:735
+#: src/SearchDlg.cpp:1092 src/SearchListCtrl.cpp:735
 msgid "Main"
 msgstr ""
 

--- a/po/bn.po
+++ b/po/bn.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-28 12:12+0200\n"
+"POT-Creation-Date: 2026-07-28 08:06+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: none\n"
@@ -131,7 +131,7 @@ msgstr ""
 msgid "Not now"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:422 src/amuleDlg.cpp:665
+#: src/AppImageIntegration.cpp:422 src/amuleDlg.cpp:600
 msgid "Don't ask again"
 msgstr ""
 
@@ -188,152 +188,152 @@ msgstr ""
 msgid "WARNING: You can't add yourself as a source for an eD2k link while having a lowid."
 msgstr ""
 
-#: src/amule.cpp:301
+#: src/amule.cpp:300
 msgid "Now, exiting main app..."
 msgstr ""
 
-#: src/amule.cpp:331
+#: src/amule.cpp:330
 #, c-format
 msgid "Terminating amuleweb instance with pid '%d' ... "
 msgstr ""
 
-#: src/amule.cpp:335
+#: src/amule.cpp:334
 #, c-format
 msgid "Killing amuleweb instance with pid '%d' ... "
 msgstr ""
 
-#: src/amule.cpp:337 src/amule.cpp:350 src/ClientRef.cpp:180
-#: src/SearchDlg.cpp:1041 src/ServerListCtrl.cpp:98
+#: src/amule.cpp:336 src/amule.cpp:349 src/ClientRef.cpp:180
+#: src/SearchDlg.cpp:880 src/ServerListCtrl.cpp:98
 msgid "Failed"
 msgstr ""
 
-#: src/amule.cpp:344
+#: src/amule.cpp:343
 #, c-format
 msgid "Terminating amuleapi instance with pid '%d' ... "
 msgstr ""
 
-#: src/amule.cpp:348
+#: src/amule.cpp:347
 #, c-format
 msgid "Killing amuleapi instance with pid '%d' ... "
 msgstr ""
 
-#: src/amule.cpp:356
+#: src/amule.cpp:355
 msgid "aMule OnExit: Terminating core."
 msgstr ""
 
-#: src/amule.cpp:467
+#: src/amule.cpp:466
 msgid "aMule shutdown completed."
 msgstr ""
 
-#: src/amule.cpp:471
+#: src/amule.cpp:470
 msgid "Memory debug results for aMule exit:"
 msgstr ""
 
-#: src/amule.cpp:652
+#: src/amule.cpp:651
 #, c-format
 msgid "Binding aMule's peer-to-peer traffic to interface: %s (HTTP updates use the default route)"
 msgstr ""
 
-#: src/amule.cpp:656
+#: src/amule.cpp:655
 #, c-format
 msgid "Binding all network traffic to interface: %s"
 msgstr ""
 
-#: src/amule.cpp:660
+#: src/amule.cpp:659
 #, c-format
 msgid "WARNING: configured network interface '%s' was not found - traffic is NOT bound to it and may leave via the default route. Check the interface name in Preferences."
 msgstr ""
 
-#: src/amule.cpp:666
+#: src/amule.cpp:665
 #, c-format
 msgid "WARNING: binding to network interface '%s' requires elevated privileges and was NOT applied - traffic may leave via the default route. Grant the capability (e.g. 'sudo setcap cap_net_raw+ep' on the aMule binary) or run with sufficient privileges."
 msgstr ""
 
-#: src/amule.cpp:674
+#: src/amule.cpp:673
 #, c-format
 msgid "WARNING: could not bind to network interface '%s' - traffic may leave via the default route."
 msgstr ""
 
-#: src/amule.cpp:733
+#: src/amule.cpp:732
 msgid "Your locale has been changed to System Default due to a configuration change. Sorry."
 msgstr ""
 
-#: src/amule.cpp:735 src/amule.cpp:1589 src/CatDialog.cpp:128
+#: src/amule.cpp:734 src/amule.cpp:1581 src/CatDialog.cpp:128
 #: src/CatDialog.cpp:136 src/CatDialog.cpp:149 src/ServerList.cpp:366
 #: src/ServerListCtrl.cpp:152
 msgid "Info"
 msgstr ""
 
-#: src/amule.cpp:742
+#: src/amule.cpp:741
 msgid ""
 "\n"
 "EC configuration"
 msgstr ""
 
-#: src/amule.cpp:745
+#: src/amule.cpp:744
 msgid "Password set and external connections enabled."
 msgstr ""
 
-#: src/amule.cpp:755 src/KadDlg.cpp:176 src/KadDlg.cpp:185
-#: src/PrefsUnifiedDlg.cpp:1461 src/SharedFilesCtrl.cpp:476
+#: src/amule.cpp:754 src/KadDlg.cpp:176 src/KadDlg.cpp:185
+#: src/PrefsUnifiedDlg.cpp:1387 src/SharedFilesCtrl.cpp:476
 msgid "WARNING"
 msgstr ""
 
-#: src/amule.cpp:992
+#: src/amule.cpp:991
 msgid "Network bootstrap"
 msgstr ""
 
-#: src/amule.cpp:997
+#: src/amule.cpp:996
 msgid ""
 "aMule has detected missing network bootstrap files.\n"
 "Select which ones to download:"
 msgstr ""
 
-#: src/amule.cpp:1006 src/FirstRunWizard.cpp:411
+#: src/amule.cpp:1005 src/FirstRunWizard.cpp:411
 msgid "eD2k server list (server.met)"
 msgstr ""
 
-#: src/amule.cpp:1013 src/FirstRunWizard.cpp:416
+#: src/amule.cpp:1012 src/FirstRunWizard.cpp:416
 msgid "Kad bootstrap nodes (nodes.dat)"
 msgstr ""
 
-#: src/amule.cpp:1103
+#: src/amule.cpp:1102
 #, c-format
 msgid "web server running on pid %d"
 msgstr ""
 
-#: src/amule.cpp:1116
+#: src/amule.cpp:1115
 msgid "You requested to run web server on startup, but the amuleweb binary cannot be run. Please install the package containing aMule web server, or build aMule from source with -DBUILD_WEBSERVER=YES and install it."
 msgstr ""
 
-#: src/amule.cpp:1121 src/amule.cpp:1185 src/amule.cpp:1299 src/amule.cpp:1601
+#: src/amule.cpp:1120 src/amule.cpp:1177 src/amule.cpp:1291 src/amule.cpp:1593
 #: src/amule-remote-gui.cpp:603 src/amule-remote-gui.cpp:671
 #: src/amule-remote-gui.cpp:709 src/amule-remote-gui.cpp:1282
 #: src/amule-remote-gui.cpp:1345 src/amule-remote-gui.cpp:1372
-#: src/DownloadQueue.cpp:1481 src/PrefsUnifiedDlg.cpp:1247
+#: src/DownloadQueue.cpp:1481
 msgid "ERROR"
 msgstr ""
 
-#: src/amule.cpp:1174
+#: src/amule.cpp:1166
 #, c-format
 msgid "amuleapi running on pid %d"
 msgstr ""
 
-#: src/amule.cpp:1180
+#: src/amule.cpp:1172
 msgid "You requested to run amuleapi on startup, but the amuleapi binary cannot be run. Please install the package containing aMule's REST API server, or build aMule from source with -DBUILD_AMULEAPI=YES and install it."
 msgstr ""
 
-#: src/amule.cpp:1267
+#: src/amule.cpp:1259
 #, c-format
 msgid "Could not bind ports to the specified address: %s"
 msgstr ""
 
-#: src/amule.cpp:1291
+#: src/amule.cpp:1283
 #, c-format
 msgid "Port %u is not available. You will be LOWID\n"
 msgstr ""
 
-#: src/amule.cpp:1296
+#: src/amule.cpp:1288
 #, c-format
 msgid ""
 "Port %u is not available!\n"
@@ -343,184 +343,184 @@ msgid ""
 "Check your network to make sure the port is open for output and input."
 msgstr ""
 
-#: src/amule.cpp:1393
+#: src/amule.cpp:1385
 msgid "Failed to create OnlineSig File"
 msgstr ""
 
-#: src/amule.cpp:1401
+#: src/amule.cpp:1393
 msgid "Failed to create aMule OnlineSig File"
 msgstr ""
 
-#: src/amule.cpp:1564
+#: src/amule.cpp:1556
 msgid "The selected locale seems not to be installed on your box. (Note: I'll try to set it anyway)"
 msgstr ""
 
-#: src/amule.cpp:1574
+#: src/amule.cpp:1566
 #, c-format
 msgid "This is the first time you run aMule %s"
 msgstr ""
 
-#: src/amule.cpp:1577
+#: src/amule.cpp:1569
 msgid "This version is a testing version, updated daily, and\n"
 msgstr ""
 
-#: src/amule.cpp:1578
+#: src/amule.cpp:1570
 msgid "we give no warranty it won't break anything, burn your house,\n"
 msgstr ""
 
-#: src/amule.cpp:1579
+#: src/amule.cpp:1571
 msgid "or kill your dog. But it *should* be safe to use anyway.\n"
 msgstr ""
 
-#: src/amule.cpp:1584
+#: src/amule.cpp:1576
 msgid "More information, support and new releases can found at our homepage,\n"
 msgstr ""
 
-#: src/amule.cpp:1585
+#: src/amule.cpp:1577
 msgid "at https://amule-org.github.io, or in our IRC channel #aMule at irc.libera.chat.\n"
 msgstr ""
 
-#: src/amule.cpp:1587
+#: src/amule.cpp:1579
 msgid "Feel free to report any bugs to https://github.com/amule-org/amule/issues"
 msgstr ""
 
-#: src/amule.cpp:1599
+#: src/amule.cpp:1591
 msgid ""
 "The folder for Online Signature files you specified is INVALID!\n"
 " OnlineSignature will be DISABLED until you fix it on preferences."
 msgstr ""
 
-#: src/amule.cpp:1662
+#: src/amule.cpp:1654
 msgid "Server hostname notified"
 msgstr ""
 
-#: src/amule.cpp:2039
+#: src/amule.cpp:2031
 #, c-format
 msgid "Disk space preallocation for file '%s' failed: %s"
 msgstr ""
 
-#: src/amule.cpp:2168
+#: src/amule.cpp:2160
 msgid "ERROR: can't open logfile"
 msgstr ""
 
-#: src/amule.cpp:2172
+#: src/amule.cpp:2164
 msgid "WARNING: logfile is empty. Something is wrong."
 msgstr ""
 
-#: src/amule.cpp:2189
+#: src/amule.cpp:2181
 msgid "Log has been reset"
 msgstr ""
 
-#: src/amule.cpp:2213
+#: src/amule.cpp:2205
 #, c-format
 msgid "ServerMessage: %s"
 msgstr ""
 
-#: src/amule.cpp:2256 src/IP2Country.cpp:220 src/IPFilter.cpp:514
+#: src/amule.cpp:2248 src/IP2Country.cpp:220 src/IPFilter.cpp:514
 #: src/ServerList.cpp:875
 #, c-format
 msgid "Skipped download of %s, because requested file is not newer."
 msgstr ""
 
-#: src/amule.cpp:2259
+#: src/amule.cpp:2251
 msgid "Failed to download the nodes list."
 msgstr ""
 
-#: src/amule.cpp:2322
+#: src/amule.cpp:2314
 msgid "Failed to open the downloaded version check file"
 msgstr ""
 
-#: src/amule.cpp:2325 src/amule.cpp:2344
+#: src/amule.cpp:2317 src/amule.cpp:2336
 msgid "Corrupted version check file"
 msgstr ""
 
-#: src/amule.cpp:2367
+#: src/amule.cpp:2359
 msgid "You are using an outdated version of aMule!"
 msgstr ""
 
-#: src/amule.cpp:2369
+#: src/amule.cpp:2361
 #, c-format
 msgid "Your aMule version is %i.%i.%i and the latest version is %li.%li.%li"
 msgstr ""
 
-#: src/amule.cpp:2373
+#: src/amule.cpp:2365
 msgid "The latest version can always be found at https://github.com/amule-org/amule/releases/latest"
 msgstr ""
 
-#: src/amule.cpp:2376
+#: src/amule.cpp:2368
 #, c-format
 msgid "WARNING: Your aMuled version is outdated: %i.%i.%i < %li.%li.%li"
 msgstr ""
 
-#: src/amule.cpp:2382
+#: src/amule.cpp:2374
 msgid "Your copy of aMule is up to date."
 msgstr ""
 
-#: src/amule.cpp:2389
+#: src/amule.cpp:2381
 msgid "Failed to download the version check file"
 msgstr ""
 
-#: src/amule.cpp:2558 src/amule-remote-gui.cpp:1133
+#: src/amule.cpp:2550 src/amule-remote-gui.cpp:1133
 #, c-format
 msgid "Users: %s | Files: %s"
 msgstr ""
 
-#: src/amule.cpp:2559 src/amule-remote-gui.cpp:1134
+#: src/amule.cpp:2551 src/amule-remote-gui.cpp:1134
 #, c-format
 msgid "Users: E: %s K: %s | Files: E: %s K: %s"
 msgstr ""
 
-#: src/amule.cpp:2573 src/amule-remote-gui.cpp:1147
+#: src/amule.cpp:2565 src/amule-remote-gui.cpp:1147
 msgid "No networks selected"
 msgstr ""
 
-#: src/amule.cpp:2641 src/TextClient.cpp:903
+#: src/amule.cpp:2633 src/TextClient.cpp:903
 msgid "with LowID"
 msgstr ""
 
-#: src/amule.cpp:2641 src/TextClient.cpp:904
+#: src/amule.cpp:2633 src/TextClient.cpp:904
 msgid "with HighID"
 msgstr ""
 
-#: src/amule.cpp:2643
+#: src/amule.cpp:2635
 #, c-format
 msgid "Connected to %s %s"
 msgstr ""
 
-#: src/amule.cpp:2648
+#: src/amule.cpp:2640
 #, c-format
 msgid "Connecting to %s"
 msgstr ""
 
-#: src/amule.cpp:2650
+#: src/amule.cpp:2642
 msgid "Disconnected from eD2k"
 msgstr ""
 
-#: src/amule.cpp:2659
+#: src/amule.cpp:2651
 msgid "Kad started."
 msgstr ""
 
-#: src/amule.cpp:2661
+#: src/amule.cpp:2653
 msgid "Kad stopped."
 msgstr ""
 
-#: src/amule.cpp:2669
+#: src/amule.cpp:2661
 msgid "Connected to Kad (ok)"
 msgstr ""
 
-#: src/amule.cpp:2671
+#: src/amule.cpp:2663
 msgid "Connected to Kad (firewalled)"
 msgstr ""
 
-#: src/amule.cpp:2675
+#: src/amule.cpp:2667
 msgid "Disconnected from Kad"
 msgstr ""
 
-#: src/amule.cpp:2707
+#: src/amule.cpp:2699
 msgid "Kad network cannot be used if UDP port is disabled on preferences, not starting."
 msgstr ""
 
-#: src/amule.cpp:2711
+#: src/amule.cpp:2703
 msgid "Kad network disabled on preferences, not connecting."
 msgstr ""
 
@@ -545,67 +545,29 @@ msgstr ""
 msgid "ERROR: %s"
 msgstr ""
 
-#: src/amuleDlg.cpp:250
+#: src/amuleDlg.cpp:236
 #, c-format
 msgid "This is aMule %s based on eMule."
 msgstr ""
 
-#: src/amuleDlg.cpp:251
+#: src/amuleDlg.cpp:237
 #, c-format
 msgid "Running on %s"
 msgstr ""
 
-#: src/amuleDlg.cpp:253
+#: src/amuleDlg.cpp:239
 msgid "Visit https://github.com/amule-org/amule/releases/latest to check if a new version is available."
 msgstr ""
 
-#: src/amuleDlg.cpp:282
+#: src/amuleDlg.cpp:268
 msgid "FATAL ERROR: Failed to create Timer"
 msgstr ""
 
-#: src/amuleDlg.cpp:361 src/amuleDlg.cpp:1810 src/amuleDlg.cpp:2056
-#: src/muuli_wdr.cpp:1492 src/muuli_wdr.cpp:3439
-msgid "Networks"
-msgstr ""
-
-#: src/amuleDlg.cpp:362 src/amuleDlg.cpp:1816 src/muuli_wdr.cpp:3440
-msgid "Searches"
-msgstr ""
-
-#: src/amuleDlg.cpp:363 src/amuleDlg.cpp:1822 src/DownloadListCtrl.cpp:740
-#: src/muuli_wdr.cpp:392 src/muuli_wdr.cpp:1585 src/muuli_wdr.cpp:3441
-#: src/Statistics.cpp:829
-msgid "Downloads"
-msgstr ""
-
-#: src/amuleDlg.cpp:364 src/amuleDlg.cpp:1828 src/muuli_wdr.cpp:3315
-msgid "Shared files"
-msgstr ""
-
-#: src/amuleDlg.cpp:365 src/amuleDlg.cpp:1834 src/muuli_wdr.cpp:2947
-#: src/muuli_wdr.cpp:3397 src/muuli_wdr.cpp:3444
-msgid "Messages"
-msgstr ""
-
-#: src/amuleDlg.cpp:366 src/amuleDlg.cpp:1840 src/muuli_wdr.cpp:3445
-#: src/PrefsUnifiedDlg.cpp:314 src/Statistics.cpp:779 src/Statistics.cpp:1235
-msgid "Statistics"
-msgstr ""
-
-#: src/amuleDlg.cpp:368 src/amuleDlg.cpp:1847 src/muuli_wdr.cpp:3447
-#: src/PrefsUnifiedDlg.cpp:330 src/utils/wxCas/src/wxcasprefs.cpp:39
-msgid "Preferences"
-msgstr ""
-
-#: src/amuleDlg.cpp:371
-msgid "Navigate"
-msgstr ""
-
-#: src/amuleDlg.cpp:657
+#: src/amuleDlg.cpp:592
 msgid "New version available"
 msgstr ""
 
-#: src/amuleDlg.cpp:661
+#: src/amuleDlg.cpp:596
 #, c-format
 msgid ""
 "A new version of aMule (%s) is available.\n"
@@ -615,184 +577,217 @@ msgid ""
 "Would you like to open the download page?"
 msgstr ""
 
-#: src/amuleDlg.cpp:743
+#: src/amuleDlg.cpp:678
 msgid "aMule dialog destroyed"
 msgstr ""
 
-#: src/amuleDlg.cpp:766 src/DataToText.cpp:68 src/IPFilter.cpp:547
+#: src/amuleDlg.cpp:701 src/DataToText.cpp:68 src/IPFilter.cpp:547
 msgid "Connecting"
 msgstr ""
 
-#: src/amuleDlg.cpp:958
+#: src/amuleDlg.cpp:893
 msgid "eD2k: Connecting"
 msgstr ""
 
-#: src/amuleDlg.cpp:962
+#: src/amuleDlg.cpp:897
 msgid "eD2k: Disconnected"
 msgstr ""
 
-#: src/amuleDlg.cpp:968
+#: src/amuleDlg.cpp:903
 msgid "Kad: Firewalled"
 msgstr ""
 
-#: src/amuleDlg.cpp:972
+#: src/amuleDlg.cpp:907
 msgid "Kad: Connected"
 msgstr ""
 
-#: src/amuleDlg.cpp:977
+#: src/amuleDlg.cpp:912
 msgid "Kad: Connecting"
 msgstr ""
 
-#: src/amuleDlg.cpp:981
+#: src/amuleDlg.cpp:916
 msgid "Kad: Off"
 msgstr ""
 
-#: src/amuleDlg.cpp:1029 src/DownloadListCtrl.cpp:505
+#: src/amuleDlg.cpp:964 src/DownloadListCtrl.cpp:505
 #: src/DownloadListCtrl.cpp:749 src/FriendListCtrl.cpp:180
 #: src/muuli_wdr.cpp:731 src/muuli_wdr.cpp:782 src/muuli_wdr.cpp:846
-#: src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2252 src/muuli_wdr.cpp:2337
-#: src/muuli_wdr.cpp:3085 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
+#: src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2224 src/muuli_wdr.cpp:2309
+#: src/muuli_wdr.cpp:3057 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
 #: src/ServerListCtrl.cpp:606 src/TransferWnd.cpp:378
 #: src/utils/wxCas/src/wxcasprefs.cpp:235
 msgid "Cancel"
 msgstr ""
 
-#: src/amuleDlg.cpp:1030
+#: src/amuleDlg.cpp:965
 msgid "Stop the current connection attempts"
 msgstr ""
 
-#: src/amuleDlg.cpp:1035 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976
-#: src/muuli_wdr.cpp:2475
+#: src/amuleDlg.cpp:970 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976
+#: src/muuli_wdr.cpp:2447
 msgid "Disconnect"
 msgstr ""
 
-#: src/amuleDlg.cpp:1036
+#: src/amuleDlg.cpp:971
 msgid "Disconnect from the currently connected networks"
 msgstr ""
 
-#: src/amuleDlg.cpp:1041 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979
-#: src/muuli_wdr.cpp:2630 src/muuli_wdr.cpp:3082 src/muuli_wdr.cpp:3437
+#: src/amuleDlg.cpp:976 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979
+#: src/muuli_wdr.cpp:2602 src/muuli_wdr.cpp:3054 src/muuli_wdr.cpp:3409
 msgid "Connect"
 msgstr ""
 
-#: src/amuleDlg.cpp:1042
+#: src/amuleDlg.cpp:977
 msgid "Connect to the currently enabled networks"
 msgstr ""
 
-#: src/amuleDlg.cpp:1154
+#: src/amuleDlg.cpp:1089
 #, c-format
 msgid "Up: %.1f%s (%.1f) | Down: %.1f%s (%.1f)"
 msgstr ""
 
-#: src/amuleDlg.cpp:1156 src/amuleDlg.cpp:1158 src/amuleDlg.cpp:1162
-#: src/amuleDlg.cpp:1164 src/amuleDlg.cpp:1175 src/amuleDlg.cpp:1177
+#: src/amuleDlg.cpp:1091 src/amuleDlg.cpp:1093 src/amuleDlg.cpp:1097
+#: src/amuleDlg.cpp:1099 src/amuleDlg.cpp:1110 src/amuleDlg.cpp:1112
 #: src/MuleTrayIcon.cpp:796 src/MuleTrayIcon.cpp:799
 msgid " MB/s"
 msgstr ""
 
-#: src/amuleDlg.cpp:1156 src/amuleDlg.cpp:1158 src/amuleDlg.cpp:1162
-#: src/amuleDlg.cpp:1164 src/amuleDlg.cpp:1175 src/amuleDlg.cpp:1177
+#: src/amuleDlg.cpp:1091 src/amuleDlg.cpp:1093 src/amuleDlg.cpp:1097
+#: src/amuleDlg.cpp:1099 src/amuleDlg.cpp:1110 src/amuleDlg.cpp:1112
 #: src/MuleTrayIcon.cpp:796 src/MuleTrayIcon.cpp:799
 #: src/utils/wxCas/src/wxcasframe.cpp:1041
 msgid " kB/s"
 msgstr ""
 
-#: src/amuleDlg.cpp:1161
+#: src/amuleDlg.cpp:1096
 #, c-format
 msgid "Up: %.1f%s | Down: %.1f%s"
 msgstr ""
 
-#: src/amuleDlg.cpp:1193
+#: src/amuleDlg.cpp:1128
 #, c-format
 msgid "aMule (%s | Connected)"
 msgstr ""
 
-#: src/amuleDlg.cpp:1195
+#: src/amuleDlg.cpp:1130
 #, c-format
 msgid "aMule (%s | Disconnected)"
 msgstr ""
 
-#: src/amuleDlg.cpp:1248
+#: src/amuleDlg.cpp:1183
 #, c-format
 msgid "Do you really want to exit %s?"
 msgstr ""
 
-#: src/amuleDlg.cpp:1250
+#: src/amuleDlg.cpp:1185
 msgid "Exit confirmation"
 msgstr ""
 
-#: src/amuleDlg.cpp:1613
+#: src/amuleDlg.cpp:1548
 msgid "Launch Command: "
 msgstr ""
 
-#: src/amuleDlg.cpp:1632 src/muuli_wdr.cpp:1972 src/Preferences.cpp:979
+#: src/amuleDlg.cpp:1567 src/muuli_wdr.cpp:1971 src/Preferences.cpp:951
 msgid "- default -"
 msgstr ""
 
-#: src/amuleDlg.cpp:1660
+#: src/amuleDlg.cpp:1595
 #, c-format
 msgid "Skin directory '%s' does not exist"
 msgstr ""
 
-#: src/amuleDlg.cpp:1663
+#: src/amuleDlg.cpp:1598
 #, c-format
 msgid "WARNING: Unable to open skin file '%s' for read"
 msgstr ""
 
-#: src/amuleDlg.cpp:1814 src/muuli_wdr.cpp:3439
+#: src/amuleDlg.cpp:1722 src/amuleDlg.cpp:1968 src/muuli_wdr.cpp:1485
+#: src/muuli_wdr.cpp:3411
+msgid "Networks"
+msgstr ""
+
+#: src/amuleDlg.cpp:1726 src/muuli_wdr.cpp:3411
 msgid "Networks Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1820 src/muuli_wdr.cpp:3440
+#: src/amuleDlg.cpp:1728 src/muuli_wdr.cpp:3412
+msgid "Searches"
+msgstr ""
+
+#: src/amuleDlg.cpp:1732 src/muuli_wdr.cpp:3412
 msgid "Searches Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1826 src/muuli_wdr.cpp:3441
+#: src/amuleDlg.cpp:1734 src/DownloadListCtrl.cpp:740 src/muuli_wdr.cpp:392
+#: src/muuli_wdr.cpp:1578 src/muuli_wdr.cpp:3413 src/Statistics.cpp:829
+msgid "Downloads"
+msgstr ""
+
+#: src/amuleDlg.cpp:1738 src/muuli_wdr.cpp:3413
 msgid "Downloads Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1832 src/muuli_wdr.cpp:3443
+#: src/amuleDlg.cpp:1740 src/muuli_wdr.cpp:3287
+msgid "Shared files"
+msgstr ""
+
+#: src/amuleDlg.cpp:1744 src/muuli_wdr.cpp:3415
 msgid "Shared Files Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3444
+#: src/amuleDlg.cpp:1746 src/muuli_wdr.cpp:2919 src/muuli_wdr.cpp:3369
+#: src/muuli_wdr.cpp:3416
+msgid "Messages"
+msgstr ""
+
+#: src/amuleDlg.cpp:1750 src/muuli_wdr.cpp:3416
 msgid "Messages Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1844 src/muuli_wdr.cpp:3445
+#: src/amuleDlg.cpp:1752 src/muuli_wdr.cpp:3417 src/PrefsUnifiedDlg.cpp:312
+#: src/Statistics.cpp:779 src/Statistics.cpp:1235
+msgid "Statistics"
+msgstr ""
+
+#: src/amuleDlg.cpp:1756 src/muuli_wdr.cpp:3417
 msgid "Statistics Graph Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1851 src/muuli_wdr.cpp:3447
+#: src/amuleDlg.cpp:1759 src/muuli_wdr.cpp:3419 src/PrefsUnifiedDlg.cpp:328
+#: src/utils/wxCas/src/wxcasprefs.cpp:39
+msgid "Preferences"
+msgstr ""
+
+#: src/amuleDlg.cpp:1763 src/muuli_wdr.cpp:3419
 msgid "Preferences Settings Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1854 src/muuli_wdr.cpp:3448
+#: src/amuleDlg.cpp:1766 src/muuli_wdr.cpp:3420
 msgid "Import"
 msgstr ""
 
-#: src/amuleDlg.cpp:1858 src/muuli_wdr.cpp:3448
+#: src/amuleDlg.cpp:1770 src/muuli_wdr.cpp:3420
 msgid "The partfile importer tool"
 msgstr ""
 
-#: src/amuleDlg.cpp:1861 src/muuli_wdr.cpp:3449
+#: src/amuleDlg.cpp:1773 src/muuli_wdr.cpp:3421
 #: src/utils/aLinkCreator/src/alcframe.cpp:262
 msgid "About"
 msgstr ""
 
-#: src/amuleDlg.cpp:1861 src/muuli_wdr.cpp:3449
+#: src/amuleDlg.cpp:1773 src/muuli_wdr.cpp:3421
 msgid "About/Help"
 msgstr ""
 
-#: src/amuleDlg.cpp:2059
+#: src/amuleDlg.cpp:1971
 msgid "eD2k network"
 msgstr ""
 
-#: src/amuleDlg.cpp:2062
+#: src/amuleDlg.cpp:1974
 msgid "Kad network"
 msgstr ""
 
-#: src/amuleDlg.cpp:2062
+#: src/amuleDlg.cpp:1974
 msgid "No network"
 msgstr ""
 
@@ -917,7 +912,7 @@ msgstr ""
 msgid "The core rejected these shared folders:%s"
 msgstr ""
 
-#: src/amule-remote-gui.cpp:1336 src/ExternalConn.cpp:2346
+#: src/amule-remote-gui.cpp:1336 src/ExternalConn.cpp:2345
 msgid "Invalid link or already on list."
 msgstr ""
 
@@ -933,7 +928,7 @@ msgstr ""
 #: src/ClientDetailDialog.cpp:123 src/DataToText.cpp:61 src/DataToText.cpp:86
 #: src/DataToText.cpp:101 src/DataToText.cpp:136 src/DataToText.cpp:165
 #: src/DownloadListCtrl.cpp:1172 src/DownloadListCtrl.cpp:1185
-#: src/DownloadListCtrl.cpp:1196 src/ExternalConn.cpp:609
+#: src/DownloadListCtrl.cpp:1196 src/ExternalConn.cpp:608
 #: src/FileDetailDialog.cpp:203 src/FileDetailDialog.cpp:235
 #: src/FileDetailDialog.cpp:242 src/GenericClientListCtrl.cpp:1171
 #: src/GenericClientListCtrl.cpp:1182 src/GenericClientListCtrl.cpp:1192
@@ -1319,19 +1314,19 @@ msgstr ""
 msgid "Very low"
 msgstr ""
 
-#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:743 src/muuli_wdr.cpp:2303
+#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:743 src/muuli_wdr.cpp:2275
 #: src/ServerListCtrl.cpp:263 src/ServerListCtrl.cpp:456
 #: src/SharedFilesCtrl.cpp:145
 msgid "Low"
 msgstr ""
 
-#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:744 src/muuli_wdr.cpp:2304
+#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:744 src/muuli_wdr.cpp:2276
 #: src/ServerListCtrl.cpp:266 src/ServerListCtrl.cpp:457
 #: src/SharedFilesCtrl.cpp:146
 msgid "Normal"
 msgstr ""
 
-#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:745 src/muuli_wdr.cpp:2305
+#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:745 src/muuli_wdr.cpp:2277
 #: src/ServerListCtrl.cpp:269 src/ServerListCtrl.cpp:458
 #: src/SharedFilesCtrl.cpp:147
 msgid "High"
@@ -1423,8 +1418,8 @@ msgstr ""
 msgid "Remote Server"
 msgstr ""
 
-#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3202
-#: src/SearchDlg.cpp:119 src/TextClient.cpp:911
+#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3174
+#: src/SearchDlg.cpp:111 src/TextClient.cpp:911
 msgid "Kad"
 msgstr ""
 
@@ -1494,7 +1489,7 @@ msgstr ""
 msgid "Size"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3269
+#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3241
 msgid "Transferred"
 msgstr ""
 
@@ -1550,7 +1545,7 @@ msgid ""
 "\n"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:746 src/muuli_wdr.cpp:2306
+#: src/DownloadListCtrl.cpp:746 src/muuli_wdr.cpp:2278
 #: src/SharedFilesCtrl.cpp:150
 msgid "Auto"
 msgstr ""
@@ -1588,7 +1583,7 @@ msgid "Extended Options"
 msgstr ""
 
 #: src/DownloadListCtrl.cpp:770 src/DownloadListCtrl.cpp:822
-#: src/muuli_wdr.cpp:1790
+#: src/muuli_wdr.cpp:1789
 msgid "Preview"
 msgstr ""
 
@@ -1761,230 +1756,225 @@ msgstr[1] ""
 msgid "Invalid eD2k link! ERROR: %s"
 msgstr ""
 
-#: src/ExternalConn.cpp:380
+#: src/ExternalConn.cpp:379
 msgid "Client sent packet after authentication failed."
 msgstr ""
 
-#: src/ExternalConn.cpp:397
+#: src/ExternalConn.cpp:396
 msgid "External connection closed."
 msgstr ""
 
-#: src/ExternalConn.cpp:474
+#: src/ExternalConn.cpp:473
 msgid "External connections disabled due to empty password!"
 msgstr ""
 
-#: src/ExternalConn.cpp:495
+#: src/ExternalConn.cpp:494
 msgid "External connections disabled in config file"
 msgstr ""
 
-#: src/ExternalConn.cpp:576
+#: src/ExternalConn.cpp:575
 msgid "New external connection accepted"
 msgstr ""
 
-#: src/ExternalConn.cpp:579
+#: src/ExternalConn.cpp:578
 msgid "ERROR: couldn't accept a new external connection"
 msgstr ""
 
-#: src/ExternalConn.cpp:596
+#: src/ExternalConn.cpp:595
 msgid "External connection refused due to empty password in preferences!"
 msgstr ""
 
-#: src/ExternalConn.cpp:608
+#: src/ExternalConn.cpp:607
 #, c-format
 msgid "Connecting client: %s %s"
 msgstr ""
 
-#: src/ExternalConn.cpp:610
+#: src/ExternalConn.cpp:609
 msgid "Unknown version"
 msgstr ""
 
-#: src/ExternalConn.cpp:623
+#: src/ExternalConn.cpp:622
 msgid "Incorrect EC version ID, there might be binary incompatibility. Use core and remote from same snapshot."
 msgstr ""
 
-#: src/ExternalConn.cpp:631
+#: src/ExternalConn.cpp:630
 msgid "You cannot connect to a release version from an arbitrary development snapshot! *sigh* possible crash prevented"
 msgstr ""
 
-#: src/ExternalConn.cpp:714
+#: src/ExternalConn.cpp:713
 msgid "Invalid protocol version."
 msgstr ""
 
-#: src/ExternalConn.cpp:720
+#: src/ExternalConn.cpp:719
 msgid "Missing protocol version tag."
 msgstr ""
 
-#: src/ExternalConn.cpp:728
+#: src/ExternalConn.cpp:727
 msgid "Authentication failed: invalid hash specified as EC password."
 msgstr ""
 
-#: src/ExternalConn.cpp:776
+#: src/ExternalConn.cpp:775
 msgid "Authentication failed: wrong password."
 msgstr ""
 
-#: src/ExternalConn.cpp:778
+#: src/ExternalConn.cpp:777
 msgid "Authentication failed: missing password."
 msgstr ""
 
-#: src/ExternalConn.cpp:789
+#: src/ExternalConn.cpp:788
 msgid "Invalid request, please authenticate first."
 msgstr ""
 
-#: src/ExternalConn.cpp:794
+#: src/ExternalConn.cpp:793
 msgid "Access granted."
 msgstr ""
 
-#: src/ExternalConn.cpp:802
+#: src/ExternalConn.cpp:801
 #, c-format
 msgid "Sent error message \"%s\" to client."
 msgstr ""
 
-#: src/ExternalConn.cpp:807
+#: src/ExternalConn.cpp:806
 #, c-format
 msgid "Unauthorized access attempt from %s. Connection closed."
 msgstr ""
 
-#: src/ExternalConn.cpp:1420
+#: src/ExternalConn.cpp:1419
 #, c-format
 msgid "Remote PartFile command failed: FileHash not found: %s"
 msgstr ""
 
-#: src/ExternalConn.cpp:1424
+#: src/ExternalConn.cpp:1423
 #, c-format
 msgid "FileHash not found: %s"
 msgstr ""
 
-#: src/ExternalConn.cpp:1471 src/ExternalConn.cpp:1559
-#: src/ExternalConn.cpp:1680
+#: src/ExternalConn.cpp:1470 src/ExternalConn.cpp:1558
+#: src/ExternalConn.cpp:1679
 msgid "OOPS! OpCode processing error!"
 msgstr ""
 
-#: src/ExternalConn.cpp:1502
+#: src/ExternalConn.cpp:1501
 msgid "Server not added"
 msgstr ""
 
-#: src/ExternalConn.cpp:1521
+#: src/ExternalConn.cpp:1520
 #, c-format
 msgid "server not found: %s"
 msgstr ""
 
-#: src/ExternalConn.cpp:1538
+#: src/ExternalConn.cpp:1537
 msgid "need to define server to be removed"
 msgstr ""
 
-#: src/ExternalConn.cpp:1553
+#: src/ExternalConn.cpp:1552
 msgid "eD2k is disabled in preferences."
 msgstr ""
 
-#: src/ExternalConn.cpp:1658
+#: src/ExternalConn.cpp:1657
 msgid "Friend not found."
 msgstr ""
 
-#: src/ExternalConn.cpp:1668
+#: src/ExternalConn.cpp:1667
 msgid "Client not found."
 msgstr ""
 
-#: src/ExternalConn.cpp:1674
+#: src/ExternalConn.cpp:1673
 msgid "EC_TAG_FRIEND_SHARED requires EC_TAG_FRIEND or EC_TAG_CLIENT."
 msgstr ""
 
-#: src/ExternalConn.cpp:1992
+#: src/ExternalConn.cpp:1991
 msgid "WebSearch from remote interface makes no sense."
 msgstr ""
 
-#: src/ExternalConn.cpp:2027
+#: src/ExternalConn.cpp:2026
 msgid "Search in progress. Refetch results in a moment!"
 msgstr ""
 
-#: src/ExternalConn.cpp:2266
+#: src/ExternalConn.cpp:2265
 msgid "No points for graph."
 msgstr ""
 
-#: src/ExternalConn.cpp:2276
+#: src/ExternalConn.cpp:2275
 msgid "Your client is not configured for this detail level."
 msgstr ""
 
-#: src/ExternalConn.cpp:2303
+#: src/ExternalConn.cpp:2302
 msgid "External Connection: shutdown requested"
 msgstr ""
 
-#: src/ExternalConn.cpp:2315
+#: src/ExternalConn.cpp:2314
 msgid "Already shutting down."
 msgstr ""
 
-#: src/ExternalConn.cpp:2333
+#: src/ExternalConn.cpp:2332
 #, c-format
 msgid "ExternalConn: adding link '%s'."
 msgstr ""
 
-#: src/ExternalConn.cpp:2351
+#: src/ExternalConn.cpp:2350
 #, c-format
 msgid "%d of %d links failed (invalid or already on list)."
 msgstr ""
 
-#: src/ExternalConn.cpp:2374
+#: src/ExternalConn.cpp:2373
 msgid "Version check throttled; try again shortly."
 msgstr ""
 
-#: src/ExternalConn.cpp:2379
+#: src/ExternalConn.cpp:2378
 msgid "Version check is not available on this daemon."
 msgstr ""
 
-#: src/ExternalConn.cpp:2509
+#: src/ExternalConn.cpp:2508
 msgid "File not found."
 msgstr ""
 
-#: src/ExternalConn.cpp:2514
+#: src/ExternalConn.cpp:2513
 msgid "Invalid file name."
 msgstr ""
 
-#: src/ExternalConn.cpp:2522
+#: src/ExternalConn.cpp:2521
 msgid "Unable to rename file."
 msgstr ""
 
-#: src/ExternalConn.cpp:2839
-#, c-format
-msgid "Could not save the amuleapi password: %s"
-msgstr ""
-
-#: src/ExternalConn.cpp:3004 src/ExternalConn.cpp:3032
+#: src/ExternalConn.cpp:2992 src/ExternalConn.cpp:3020
 msgid "Kad is disabled in preferences."
 msgstr ""
 
-#: src/ExternalConn.cpp:3045
+#: src/ExternalConn.cpp:3033
 msgid "Already connected to eD2k."
 msgstr ""
 
-#: src/ExternalConn.cpp:3048
+#: src/ExternalConn.cpp:3036
 msgid "Connecting to eD2k..."
 msgstr ""
 
-#: src/ExternalConn.cpp:3057
+#: src/ExternalConn.cpp:3045
 msgid "Already connected to Kad."
 msgstr ""
 
-#: src/ExternalConn.cpp:3060
+#: src/ExternalConn.cpp:3048
 msgid "Connecting to Kad..."
 msgstr ""
 
-#: src/ExternalConn.cpp:3067
+#: src/ExternalConn.cpp:3055
 msgid "All networks are disabled."
 msgstr ""
 
-#: src/ExternalConn.cpp:3076
+#: src/ExternalConn.cpp:3064
 msgid "Disconnected from eD2k."
 msgstr ""
 
-#: src/ExternalConn.cpp:3081
+#: src/ExternalConn.cpp:3069
 msgid "Disconnected from Kad."
 msgstr ""
 
-#: src/ExternalConn.cpp:3090
+#: src/ExternalConn.cpp:3078
 #, c-format
 msgid "External Connection: invalid opcode received: %#x"
 msgstr ""
 
-#: src/ExternalConn.cpp:3095
+#: src/ExternalConn.cpp:3083
 msgid "Invalid opcode (wrong protocol version?)"
 msgstr ""
 
@@ -2271,19 +2261,19 @@ msgstr ""
 msgid "eD2k"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:349 src/muuli_wdr.cpp:1495
+#: src/FirstRunWizard.cpp:349 src/muuli_wdr.cpp:1488
 msgid "Kademlia"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:359 src/muuli_wdr.cpp:1423
+#: src/FirstRunWizard.cpp:359 src/muuli_wdr.cpp:1416
 msgid "Standard TCP Port "
 msgstr ""
 
-#: src/FirstRunWizard.cpp:365 src/muuli_wdr.cpp:1435
+#: src/FirstRunWizard.cpp:365 src/muuli_wdr.cpp:1428
 msgid "Extended UDP port (Kad / global search) "
 msgstr ""
 
-#: src/FirstRunWizard.cpp:377 src/muuli_wdr.cpp:1442
+#: src/FirstRunWizard.cpp:377 src/muuli_wdr.cpp:1435
 msgid "Enable UPnP for router port forwarding"
 msgstr ""
 
@@ -2308,7 +2298,7 @@ msgstr ""
 msgid "Your peer lists are already in place - nothing to download."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:434 src/muuli_wdr.cpp:1540
+#: src/FirstRunWizard.cpp:434 src/muuli_wdr.cpp:1533
 msgid "Auto-update server list at startup"
 msgstr ""
 
@@ -2354,23 +2344,23 @@ msgid ""
 "want downloads on a different (e.g. larger) disk."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:549 src/FirstRunWizard.cpp:611 src/muuli_wdr.cpp:1702
+#: src/FirstRunWizard.cpp:549 src/FirstRunWizard.cpp:611 src/muuli_wdr.cpp:1701
 msgid "Destination folder for downloads"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:553 src/FirstRunWizard.cpp:569 src/muuli_wdr.cpp:1349
-#: src/muuli_wdr.cpp:1366 src/muuli_wdr.cpp:1677 src/muuli_wdr.cpp:1708
-#: src/muuli_wdr.cpp:1720 src/muuli_wdr.cpp:2790
+#: src/FirstRunWizard.cpp:553 src/FirstRunWizard.cpp:569 src/muuli_wdr.cpp:1342
+#: src/muuli_wdr.cpp:1359 src/muuli_wdr.cpp:1676 src/muuli_wdr.cpp:1707
+#: src/muuli_wdr.cpp:1719 src/muuli_wdr.cpp:2762
 #: src/utils/aLinkCreator/src/alcframe.cpp:135
 #: src/utils/wxCas/src/wxcasprefs.cpp:52 src/utils/wxCas/src/wxcasprefs.cpp:118
 msgid "Browse"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:559 src/muuli_wdr.cpp:1713
+#: src/FirstRunWizard.cpp:559 src/muuli_wdr.cpp:1712
 msgid "(All files in this folder are shared with other peers)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:565 src/FirstRunWizard.cpp:624 src/muuli_wdr.cpp:1715
+#: src/FirstRunWizard.cpp:565 src/FirstRunWizard.cpp:624 src/muuli_wdr.cpp:1714
 msgid "Folder for temporary download files"
 msgstr ""
 
@@ -2401,7 +2391,7 @@ msgstr ""
 msgid "CRITICAL - no client on StartChatSession"
 msgstr ""
 
-#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2696 src/muuli_wdr.cpp:3373
+#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2668 src/muuli_wdr.cpp:3345
 msgid "Friends"
 msgstr ""
 
@@ -2507,8 +2497,8 @@ msgstr ""
 msgid "No"
 msgstr ""
 
-#: src/GenericClientListCtrl.cpp:1216 src/PrefsUnifiedDlg.cpp:2898
-#: src/PrefsUnifiedDlg.cpp:2948 src/ServerListCtrl.cpp:276
+#: src/GenericClientListCtrl.cpp:1216 src/PrefsUnifiedDlg.cpp:2818
+#: src/PrefsUnifiedDlg.cpp:2868 src/ServerListCtrl.cpp:276
 msgid "Yes"
 msgstr ""
 
@@ -2675,10 +2665,10 @@ msgstr ""
 msgid "Please fill all fields required"
 msgstr ""
 
-#: src/KadDlg.cpp:192 src/PartFile.cpp:1031 src/PrefsUnifiedDlg.cpp:1134
-#: src/PrefsUnifiedDlg.cpp:1204 src/PrefsUnifiedDlg.cpp:1405
-#: src/PrefsUnifiedDlg.cpp:1663 src/PrefsUnifiedDlg.cpp:1673
-#: src/PrefsUnifiedDlg.cpp:1690 src/PrefsUnifiedDlg.cpp:1738
+#: src/KadDlg.cpp:192 src/PartFile.cpp:1031 src/PrefsUnifiedDlg.cpp:1162
+#: src/PrefsUnifiedDlg.cpp:1331 src/PrefsUnifiedDlg.cpp:1589
+#: src/PrefsUnifiedDlg.cpp:1599 src/PrefsUnifiedDlg.cpp:1616
+#: src/PrefsUnifiedDlg.cpp:1658
 msgid "Message"
 msgstr ""
 
@@ -2779,7 +2769,7 @@ msgstr ""
 msgid "Uploaded"
 msgstr ""
 
-#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3253
+#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3225
 msgid "Requested"
 msgstr ""
 
@@ -2902,7 +2892,7 @@ msgid "WARNING: "
 msgstr ""
 
 #: src/MuleNotebook.cpp:179 src/muuli_wdr.cpp:817 src/muuli_wdr.cpp:1229
-#: src/muuli_wdr.cpp:3157 src/muuli_wdr.cpp:3413
+#: src/muuli_wdr.cpp:3129 src/muuli_wdr.cpp:3385
 msgid "Close"
 msgstr ""
 
@@ -2915,12 +2905,12 @@ msgstr ""
 msgid "Copy"
 msgstr ""
 
-#: src/MuleTextCtrl.cpp:88 src/SearchDlg.cpp:261
+#: src/MuleTextCtrl.cpp:88
 msgid "Paste"
 msgstr ""
 
 #: src/MuleTextCtrl.cpp:89 src/muuli_wdr.cpp:358 src/muuli_wdr.cpp:757
-#: src/muuli_wdr.cpp:2380 src/muuli_wdr.cpp:2399 src/muuli_wdr.cpp:2421
+#: src/muuli_wdr.cpp:2352 src/muuli_wdr.cpp:2371 src/muuli_wdr.cpp:2393
 #: src/utils/aLinkCreator/src/alcframe.cpp:142
 msgid "Clear"
 msgstr ""
@@ -3011,8 +3001,8 @@ msgid "Exit"
 msgstr ""
 
 #: src/MuleTrayIcon.cpp:579 src/MuleTrayIcon.cpp:945 src/MuleTrayIcon.cpp:965
-#: src/muuli_wdr.cpp:1398 src/muuli_wdr.cpp:1406 src/muuli_wdr.cpp:1413
-#: src/muuli_wdr.cpp:1836 src/muuli_wdr.cpp:1842 src/OtherFunctions.cpp:91
+#: src/muuli_wdr.cpp:1391 src/muuli_wdr.cpp:1399 src/muuli_wdr.cpp:1406
+#: src/muuli_wdr.cpp:1835 src/muuli_wdr.cpp:1841 src/OtherFunctions.cpp:91
 #: src/StatisticsDlg.cpp:93 src/StatisticsDlg.cpp:95
 msgid "kB/s"
 msgstr ""
@@ -3181,7 +3171,7 @@ msgstr ""
 msgid "Type"
 msgstr ""
 
-#: src/muuli_wdr.cpp:215 src/SearchDlg.cpp:118 src/SearchListCtrl.cpp:853
+#: src/muuli_wdr.cpp:215 src/SearchDlg.cpp:110 src/SearchListCtrl.cpp:853
 msgid "Local"
 msgstr ""
 
@@ -3252,7 +3242,7 @@ msgstr ""
 msgid "KB"
 msgstr ""
 
-#: src/muuli_wdr.cpp:274 src/muuli_wdr.cpp:293 src/muuli_wdr.cpp:1621
+#: src/muuli_wdr.cpp:274 src/muuli_wdr.cpp:293 src/muuli_wdr.cpp:1620
 #: src/OtherFunctions.cpp:64
 msgid "MB"
 msgstr ""
@@ -3269,7 +3259,7 @@ msgstr ""
 msgid "Availability"
 msgstr ""
 
-#: src/muuli_wdr.cpp:312 src/muuli_wdr.cpp:398 src/muuli_wdr.cpp:3318
+#: src/muuli_wdr.cpp:312 src/muuli_wdr.cpp:398 src/muuli_wdr.cpp:3290
 msgid "Filter:"
 msgstr ""
 
@@ -3301,7 +3291,7 @@ msgstr ""
 msgid "Stop"
 msgstr ""
 
-#: src/muuli_wdr.cpp:348 src/muuli_wdr.cpp:1392 src/SearchListCtrl.cpp:732
+#: src/muuli_wdr.cpp:348 src/muuli_wdr.cpp:1385 src/SearchListCtrl.cpp:732
 msgid "Download"
 msgstr ""
 
@@ -3332,12 +3322,12 @@ msgstr ""
 #: src/muuli_wdr.cpp:1160 src/muuli_wdr.cpp:1167 src/muuli_wdr.cpp:1172
 #: src/muuli_wdr.cpp:1179 src/muuli_wdr.cpp:1184 src/muuli_wdr.cpp:1191
 #: src/muuli_wdr.cpp:1205 src/muuli_wdr.cpp:1212 src/muuli_wdr.cpp:1217
-#: src/muuli_wdr.cpp:1224 src/muuli_wdr.cpp:3255 src/muuli_wdr.cpp:3263
-#: src/muuli_wdr.cpp:3271
+#: src/muuli_wdr.cpp:1224 src/muuli_wdr.cpp:3227 src/muuli_wdr.cpp:3235
+#: src/muuli_wdr.cpp:3243
 msgid "N/A"
 msgstr ""
 
-#: src/muuli_wdr.cpp:508 src/muuli_wdr.cpp:1065 src/PrefsUnifiedDlg.cpp:299
+#: src/muuli_wdr.cpp:508 src/muuli_wdr.cpp:1065 src/PrefsUnifiedDlg.cpp:297
 msgid "General"
 msgstr ""
 
@@ -3473,7 +3463,7 @@ msgstr ""
 msgid "Album :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:685 src/muuli_wdr.cpp:2275
+#: src/muuli_wdr.cpp:685 src/muuli_wdr.cpp:2247
 msgid "Title :"
 msgstr ""
 
@@ -3579,7 +3569,7 @@ msgstr ""
 msgid "Userhash :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:895 src/muuli_wdr.cpp:1742 src/muuli_wdr.cpp:2470
+#: src/muuli_wdr.cpp:895 src/muuli_wdr.cpp:1741 src/muuli_wdr.cpp:2442
 #: src/utils/aLinkCreator/src/alcframe.cpp:137
 msgid "Add"
 msgstr ""
@@ -3588,15 +3578,15 @@ msgstr ""
 msgid "Download-Speed"
 msgstr ""
 
-#: src/muuli_wdr.cpp:954 src/muuli_wdr.cpp:989 src/muuli_wdr.cpp:2574
+#: src/muuli_wdr.cpp:954 src/muuli_wdr.cpp:989 src/muuli_wdr.cpp:2546
 msgid "Current"
 msgstr ""
 
-#: src/muuli_wdr.cpp:962 src/muuli_wdr.cpp:997 src/muuli_wdr.cpp:2582
+#: src/muuli_wdr.cpp:962 src/muuli_wdr.cpp:997 src/muuli_wdr.cpp:2554
 msgid "Running average"
 msgstr ""
 
-#: src/muuli_wdr.cpp:970 src/muuli_wdr.cpp:1005 src/muuli_wdr.cpp:2590
+#: src/muuli_wdr.cpp:970 src/muuli_wdr.cpp:1005 src/muuli_wdr.cpp:2562
 msgid "Session average"
 msgstr ""
 
@@ -3608,7 +3598,7 @@ msgstr ""
 msgid "Connections"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1024 src/muuli_wdr.cpp:1861
+#: src/muuli_wdr.cpp:1024 src/muuli_wdr.cpp:1860
 msgid "Active downloads"
 msgstr ""
 
@@ -3616,7 +3606,7 @@ msgstr ""
 msgid "Active connections (1:1)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1040 src/muuli_wdr.cpp:1862
+#: src/muuli_wdr.cpp:1040 src/muuli_wdr.cpp:1861
 msgid "Active uploads"
 msgstr ""
 
@@ -3732,8 +3722,8 @@ msgstr ""
 msgid "Language: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1257 src/muuli_wdr.cpp:1330 src/muuli_wdr.cpp:1334
-#: src/muuli_wdr.cpp:1337
+#: src/muuli_wdr.cpp:1257 src/muuli_wdr.cpp:1323 src/muuli_wdr.cpp:1327
+#: src/muuli_wdr.cpp:1330
 msgid "The delay before showing tool-tips."
 msgstr ""
 
@@ -3809,943 +3799,923 @@ msgstr ""
 msgid "Enabling this will make aMule to show notifications when finished downloading."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1323
-msgid "Remember search history"
-msgstr ""
-
-#: src/muuli_wdr.cpp:1324
-msgid "Keeps a dropdown list of your past search terms in the Search tab's Name field. This remembers the queries you typed, not the results they returned."
-msgstr ""
-
-#: src/muuli_wdr.cpp:1329
+#: src/muuli_wdr.cpp:1322
 msgid "Tooltip delay time: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1336
+#: src/muuli_wdr.cpp:1329
 msgid "seconds"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1340
+#: src/muuli_wdr.cpp:1333
 msgid "Browser Selection"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1346
+#: src/muuli_wdr.cpp:1339
 msgid "Enter your browser name here. Leave this field empty to use the system default browser."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1353
+#: src/muuli_wdr.cpp:1346
 msgid "Open in new tab if possible"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1355
+#: src/muuli_wdr.cpp:1348
 msgid "Open the web page in a new tab instead of in a new window when possible"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1359
+#: src/muuli_wdr.cpp:1352
 msgid "Video Player"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1386
+#: src/muuli_wdr.cpp:1379
 msgid "Bandwidth limits"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1400
+#: src/muuli_wdr.cpp:1393
 msgid "Upload"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1408
+#: src/muuli_wdr.cpp:1401
 msgid "Slot Allocation"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1417
+#: src/muuli_wdr.cpp:1410
 msgid "Ports"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1427
+#: src/muuli_wdr.cpp:1420
 msgid "This is the standard eD2k port and cannot be disabled."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1430
+#: src/muuli_wdr.cpp:1423
 msgid "UDP port for server requests (TCP+3):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1432
+#: src/muuli_wdr.cpp:1425
 msgid "4665"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1439
+#: src/muuli_wdr.cpp:1432
 msgid "This UDP port is used for extended eD2k requests and Kad network"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1446
+#: src/muuli_wdr.cpp:1439
 msgid "UPnP TCP Port (Optional):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1456
+#: src/muuli_wdr.cpp:1449
 msgid "Bind local address to IP (empty for any):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1459
+#: src/muuli_wdr.cpp:1452
 msgid "Advanced users only: If you have multiple network interfaces, enter the address of the interface to which aMule should be bound."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1462 src/muuli_wdr.cpp:2055
+#: src/muuli_wdr.cpp:1455 src/muuli_wdr.cpp:2054
 msgid "Bind to network interface (empty for any):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1475
+#: src/muuli_wdr.cpp:1468
 msgid "Advanced users only: pin all of aMule's traffic to one network interface, chosen from the list or typed in by name (e.g. tun0, eth0, en0) or index. Unlike binding to an IP, this stops traffic leaking out via the default route - useful with a VPN. Requires no elevated privileges."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1481
+#: src/muuli_wdr.cpp:1474
 msgid "Max sources per downloading file:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1485
+#: src/muuli_wdr.cpp:1478
 msgid "Max simultaneous connections:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1498 src/muuli_wdr.cpp:3197
+#: src/muuli_wdr.cpp:1491 src/muuli_wdr.cpp:3169
 msgid "ED2K"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1505
+#: src/muuli_wdr.cpp:1498
 msgid "Autoconnect on startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1508
+#: src/muuli_wdr.cpp:1501
 msgid "Reconnect on loss"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1530
+#: src/muuli_wdr.cpp:1523
 msgid "Remove dead server after"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1531
+#: src/muuli_wdr.cpp:1524
 msgid "Static servers are never removed, even when unreachable."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1535
+#: src/muuli_wdr.cpp:1528
 msgid "retries"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1543
+#: src/muuli_wdr.cpp:1536
 msgid "List"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1546
+#: src/muuli_wdr.cpp:1539
 msgid "Update server list when connecting to a server"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1549
+#: src/muuli_wdr.cpp:1542
 msgid "Update server list when a client connects"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1552
+#: src/muuli_wdr.cpp:1545
 msgid "Use priority system"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1556
+#: src/muuli_wdr.cpp:1549
 msgid "Use smart LowID check on connect"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1560
+#: src/muuli_wdr.cpp:1553
 msgid "Safe connect"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1564
+#: src/muuli_wdr.cpp:1557
 msgid "Autoconnect to servers in static list only"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1567
+#: src/muuli_wdr.cpp:1560
 msgid "Set manually added servers to High Priority"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1588
+#: src/muuli_wdr.cpp:1581
 msgid "Add files to download in pause mode"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1590
+#: src/muuli_wdr.cpp:1583
 msgid "Add files to download with auto priority"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1593
+#: src/muuli_wdr.cpp:1586
 msgid "Try to download first and last chunks first"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1597
+#: src/muuli_wdr.cpp:1590
 msgid "Endgame mode: rotate to faster sources for the final blocks"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1600
+#: src/muuli_wdr.cpp:1593
 msgid "Start next paused file when a file completes"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1603
+#: src/muuli_wdr.cpp:1596
 msgid "From the same category"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1605
+#: src/muuli_wdr.cpp:1598
 msgid "In alphabetic order"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1607
+#: src/muuli_wdr.cpp:1600
 msgid "Preallocate disk space for new files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1608
+#: src/muuli_wdr.cpp:1601
 msgid "For new files preallocates disk space for the whole file, thus reduces fragmentation"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1613
+#: src/muuli_wdr.cpp:1606
+msgid "Create new files as sparse files"
+msgstr ""
+
+#: src/muuli_wdr.cpp:1607
+msgid "A sparse file reserves its full size on disk immediately without writing real data to it -- fast, but unsupported or slow on some filesystems, and free-space accounting stays optimistic while the download is in progress. Turn this off to grow the file only as data arrives."
+msgstr ""
+
+#: src/muuli_wdr.cpp:1612
 msgid "Stop downloads when free disk space reaches "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1614
+#: src/muuli_wdr.cpp:1613
 msgid "Select this if you want aMule to check your disk space"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1618
+#: src/muuli_wdr.cpp:1617
 msgid "Enter here the min disk space desired."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1624
+#: src/muuli_wdr.cpp:1623
 msgid "Save 10 sources on rare files (< 20 sources)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1628 src/Statistics.cpp:790
+#: src/muuli_wdr.cpp:1627 src/Statistics.cpp:790
 msgid "Uploads"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1631
+#: src/muuli_wdr.cpp:1630
 msgid "Add new shared files with auto priority"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1637
+#: src/muuli_wdr.cpp:1636
 msgid "Intelligent Corruption Handling (I.C.H.)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1640
+#: src/muuli_wdr.cpp:1639
 msgid "Enable"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1643
+#: src/muuli_wdr.cpp:1642
 msgid "Advanced I.C.H. trusts every hash (not recommended)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1655 src/PrefsUnifiedDlg.cpp:1990
+#: src/muuli_wdr.cpp:1654 src/PrefsUnifiedDlg.cpp:1910
 msgid "Media metadata extraction"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1659
+#: src/muuli_wdr.cpp:1658
 msgid "Extract length / bitrate / codec from shared audio and video files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1661
+#: src/muuli_wdr.cpp:1660
 msgid "When enabled, aMule runs ffprobe on each shared media file to fill in the Length / Bitrate / Codec columns other clients see when they find the file in a search. Requires ffmpeg (the ffprobe binary) to be installed."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1668
+#: src/muuli_wdr.cpp:1667
 msgid "Path to ffprobe:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1673
+#: src/muuli_wdr.cpp:1672
 msgid "Full path to the ffprobe binary. Leave empty to have aMule auto-detect it on startup."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1681
+#: src/muuli_wdr.cpp:1680
 msgid "Detect"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1682
+#: src/muuli_wdr.cpp:1681
 msgid "Search the standard install locations for an ffprobe binary and fill the path field."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1706
+#: src/muuli_wdr.cpp:1705
 msgid ""
 "Completed downloads are stored here. All files in this folder are automatically shared with other peers.\n"
 "If this folder also holds files you don't want to share, point it at an aMule-only sub-folder."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1709
+#: src/muuli_wdr.cpp:1708
 msgid "Pick the folder where completed downloads will be stored. All files in that folder will be shared with other peers."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1723
+#: src/muuli_wdr.cpp:1722
 msgid "Shared folders"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1729
+#: src/muuli_wdr.cpp:1728
 msgid "(Folders shared by the core. Enter a path to add one.)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1737
+#: src/muuli_wdr.cpp:1736
 msgid "Absolute path of a folder on the core's machine, e.g. /home/user/shared"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1739 src/PrefsUnifiedDlg.cpp:2874
+#: src/muuli_wdr.cpp:1738 src/PrefsUnifiedDlg.cpp:2794
 msgid "Recursive"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1740
+#: src/muuli_wdr.cpp:1739
 msgid "Share every sub-folder underneath this one, including ones created later."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1744 src/utils/aLinkCreator/src/alcframe.cpp:141
+#: src/muuli_wdr.cpp:1743 src/utils/aLinkCreator/src/alcframe.cpp:141
 msgid "Remove"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1748
+#: src/muuli_wdr.cpp:1747
 msgid "(Right click on folder icon for recursive share)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1755
+#: src/muuli_wdr.cpp:1754
 msgid "Share hidden files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1761
+#: src/muuli_wdr.cpp:1760
 msgid "Automatically rescan shared folders for changes"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1767
+#: src/muuli_wdr.cpp:1766
 msgid "Follow symbolic links in shared folders"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1773
+#: src/muuli_wdr.cpp:1772
 msgid "Exclude files matching:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1776
+#: src/muuli_wdr.cpp:1775
 msgid "Wildcard patterns separated by '|', e.g. .DS_Store|Thumbs.db|*.tmp. Files whose name matches are not shared. Matching is case-insensitive."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1780
+#: src/muuli_wdr.cpp:1779
 msgid "Patterns are regular expressions"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1781
+#: src/muuli_wdr.cpp:1780
 msgid "When set, the whole field is one regular expression ('|' is alternation). When unset, it is a list of '|'-separated wildcards."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1791
+#: src/muuli_wdr.cpp:1790
 msgid "Show how many shared files the current pattern would exclude."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1812
+#: src/muuli_wdr.cpp:1811
 msgid "Graphs"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1815 src/muuli_wdr.cpp:1877
+#: src/muuli_wdr.cpp:1814 src/muuli_wdr.cpp:1876
 msgid "Update delay : 5 secs"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1819
+#: src/muuli_wdr.cpp:1818
 msgid "Time for average graph: 100 mins"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1823
+#: src/muuli_wdr.cpp:1822
 msgid "Connections Graph Scale: 100 "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1830
+#: src/muuli_wdr.cpp:1829
 msgid "Download graph scale:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1838
+#: src/muuli_wdr.cpp:1837
 msgid "Upload graph scale:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1848
+#: src/muuli_wdr.cpp:1847
 msgid "Colors: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1852
+#: src/muuli_wdr.cpp:1851
 msgid "Background"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1853
+#: src/muuli_wdr.cpp:1852
 msgid "Grid"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1854
+#: src/muuli_wdr.cpp:1853
 msgid "Download current"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1855
+#: src/muuli_wdr.cpp:1854
 msgid "Download running average"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1856
+#: src/muuli_wdr.cpp:1855
 msgid "Download session average"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1857
+#: src/muuli_wdr.cpp:1856
 msgid "Upload current"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1858
+#: src/muuli_wdr.cpp:1857
 msgid "Upload running average"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1859
+#: src/muuli_wdr.cpp:1858
 msgid "Upload session average"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1860
+#: src/muuli_wdr.cpp:1859
 msgid "Active connections"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1863
+#: src/muuli_wdr.cpp:1862
 msgid "Systray Icon Speed Bar"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1864
+#: src/muuli_wdr.cpp:1863
 msgid "Kad-nodes current"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1865
+#: src/muuli_wdr.cpp:1864
 msgid "Kad-nodes running"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1866
+#: src/muuli_wdr.cpp:1865
 msgid "Kad-nodes session"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1870 src/muuli_wdr.cpp:2324
+#: src/muuli_wdr.cpp:1869 src/muuli_wdr.cpp:2296
 msgid "Select"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1874
+#: src/muuli_wdr.cpp:1873
 msgid "Tree"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1884
+#: src/muuli_wdr.cpp:1883
 msgid "Number of Client Versions shown (0=unlimited)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1909
+#: src/muuli_wdr.cpp:1908
 msgid "!!! WARNING !!!"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1924
+#: src/muuli_wdr.cpp:1923
 msgid "Max new connections / 5 secs"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1926
+#: src/muuli_wdr.cpp:1925
 msgid "Concurrent Kad source lookups"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1928
+#: src/muuli_wdr.cpp:1927
 msgid "Kad source re-search interval (minutes)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1930
+#: src/muuli_wdr.cpp:1929
 msgid "Source re-ask interval (minutes)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1934
+#: src/muuli_wdr.cpp:1933
 msgid "File Buffer Size: 240000 bytes"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1938
+#: src/muuli_wdr.cpp:1937
 msgid "Use MMAP: memory-mapped file access (lower memory use)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1939
+#: src/muuli_wdr.cpp:1938
 msgid "Maps part files into memory instead of buffering them on the heap, lowering the process memory footprint. May reduce download speed on some disks; best for memory-constrained or upload-heavy hosts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1941
+#: src/muuli_wdr.cpp:1940
 msgid "Upload Queue Size: 5000 clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1945
+#: src/muuli_wdr.cpp:1944
 msgid "Server connection refresh interval: Disable"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1949
+#: src/muuli_wdr.cpp:1948
 msgid "Disable computer's timed standby mode"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1968
+#: src/muuli_wdr.cpp:1967
 msgid "Skin to use: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1977
+#: src/muuli_wdr.cpp:1976
 msgid "Show \"Fast eD2k Links Handler\" in every window."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1980
+#: src/muuli_wdr.cpp:1979
 msgid "Show extended info on categories tabs"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1983
+#: src/muuli_wdr.cpp:1982
 msgid "Show application version on title"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1985
+#: src/muuli_wdr.cpp:1984
 msgid "Show transfer rates on title"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1987
+#: src/muuli_wdr.cpp:1986
 msgid "Before application name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1989
+#: src/muuli_wdr.cpp:1988
 msgid "After application name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1992
+#: src/muuli_wdr.cpp:1991
 msgid "Show overhead bandwidth"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1996
+#: src/muuli_wdr.cpp:1995
 msgid "Vertical toolbar orientation"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1998
+#: src/muuli_wdr.cpp:1997
 msgid "Live column sorting (auto-reorder rows as their values change)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2005
+#: src/muuli_wdr.cpp:2004
 msgid "Download Queue Files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2008
+#: src/muuli_wdr.cpp:2007
 msgid "Show progress percentage"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2014
+#: src/muuli_wdr.cpp:2013
 msgid "Show progress bar"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2017
+#: src/muuli_wdr.cpp:2016
 msgid "Flat"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2021
+#: src/muuli_wdr.cpp:2020
 msgid "Round"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2039
+#: src/muuli_wdr.cpp:2038
 msgid "External Connection Parameters"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2042
+#: src/muuli_wdr.cpp:2041
 msgid "Accept external connections"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2049 src/muuli_wdr.cpp:2108
+#: src/muuli_wdr.cpp:2048 src/muuli_wdr.cpp:2107
 msgid "IP of the listening interface:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2052
+#: src/muuli_wdr.cpp:2051
 msgid "Enter here a valid ip in the a.b.c.d format for the listening EC interface. An empty field or 0.0.0.0 will mean any interface."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2073 src/muuli_wdr.cpp:2184
+#: src/muuli_wdr.cpp:2072 src/muuli_wdr.cpp:2156
 msgid "TCP port:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2079
+#: src/muuli_wdr.cpp:2078
 msgid "Enable UPnP port forwarding on the EC port"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2083 src/muuli_wdr.cpp:3069
+#: src/muuli_wdr.cpp:2082 src/muuli_wdr.cpp:3041
 #: src/utils/wxCas/src/wxcasprefs.cpp:167
 msgid "Password"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2089
+#: src/muuli_wdr.cpp:2088
 msgid "aMule API server parameters"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2092
+#: src/muuli_wdr.cpp:2091
 msgid "Run amuleapi (REST API) on startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2097
+#: src/muuli_wdr.cpp:2096
 msgid "HTTP port:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2111
+#: src/muuli_wdr.cpp:2110
 msgid "The interface amuleapi's HTTP server listens on. 127.0.0.1 (default) accepts only local connections; use 0.0.0.0 or a specific IP to expose it to other hosts (set an admin password below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2116
-msgid "Type a password to set or change it. Stored passwords cannot be shown, so leaving this empty keeps the current one."
-msgstr ""
-
-#: src/muuli_wdr.cpp:2118
+#: src/muuli_wdr.cpp:2113
 msgid "Admin password"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2130 src/muuli_wdr.cpp:2147 src/PrefsUnifiedDlg.cpp:1103
-msgid "A password is set."
-msgstr ""
-
-#: src/muuli_wdr.cpp:2134
-msgid "Enable guest access"
-msgstr ""
-
-#: src/muuli_wdr.cpp:2135
-msgid "Guest sessions may read status and listings but cannot change anything. Turning this off clears the stored guest password."
-msgstr ""
-
-#: src/muuli_wdr.cpp:2139
-msgid "Guest password"
-msgstr ""
-
-#: src/muuli_wdr.cpp:2154
-msgid "Web server parameters"
-msgstr ""
-
-#: src/muuli_wdr.cpp:2157
-msgid "Run webserver on startup (deprecated)"
-msgstr ""
-
-#: src/muuli_wdr.cpp:2163
-msgid "Web template"
-msgstr ""
-
-#: src/muuli_wdr.cpp:2168
-msgid "Full rights password"
-msgstr ""
-
-#: src/muuli_wdr.cpp:2172
-msgid "Enable Low rights User"
-msgstr ""
-
-#: src/muuli_wdr.cpp:2177
+#: src/muuli_wdr.cpp:2118 src/muuli_wdr.cpp:2149
 msgid "Low rights password"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2191
+#: src/muuli_wdr.cpp:2126
+msgid "Web server parameters"
+msgstr ""
+
+#: src/muuli_wdr.cpp:2129
+msgid "Run webserver on startup (deprecated)"
+msgstr ""
+
+#: src/muuli_wdr.cpp:2135
+msgid "Web template"
+msgstr ""
+
+#: src/muuli_wdr.cpp:2140
+msgid "Full rights password"
+msgstr ""
+
+#: src/muuli_wdr.cpp:2144
+msgid "Enable Low rights User"
+msgstr ""
+
+#: src/muuli_wdr.cpp:2163
 msgid "Enable UPnP port forwarding of the web server port"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2196
+#: src/muuli_wdr.cpp:2168
 msgid "Web server UPnP TCP port (Optional)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2204
+#: src/muuli_wdr.cpp:2176
 msgid "Page Refresh Time (in secs)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2211
+#: src/muuli_wdr.cpp:2183
 msgid "Enable Gzip compression"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2245
+#: src/muuli_wdr.cpp:2217
 msgid "Reset page to defaults"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2246
+#: src/muuli_wdr.cpp:2218
 msgid "Reset the settings on the current page to their default values."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2248 src/muuli_wdr.cpp:2334 src/ServerWnd.cpp:274
+#: src/muuli_wdr.cpp:2220 src/muuli_wdr.cpp:2306 src/ServerWnd.cpp:274
 #: src/ServerWnd.cpp:282
 msgid "OK"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2250
+#: src/muuli_wdr.cpp:2222
 msgid "Click here to apply any changes made to the preferences."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2253
+#: src/muuli_wdr.cpp:2225
 msgid "Reset any changes made to the preferences."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2282
+#: src/muuli_wdr.cpp:2254
 msgid "Comment :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2289
+#: src/muuli_wdr.cpp:2261
 msgid "Incoming Dir :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2298
+#: src/muuli_wdr.cpp:2270
 msgid "Change priority for new assigned files :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2302
+#: src/muuli_wdr.cpp:2274
 msgid "Don't change"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2314
+#: src/muuli_wdr.cpp:2286
 msgid "Select color for this Category (currently selected) :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2381 src/muuli_wdr.cpp:2400 src/muuli_wdr.cpp:2422
+#: src/muuli_wdr.cpp:2353 src/muuli_wdr.cpp:2372 src/muuli_wdr.cpp:2394
 msgid "Click this button to reset the log."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2441
+#: src/muuli_wdr.cpp:2413
 msgid "Click on this button to update the servers list from URL ..."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2445
+#: src/muuli_wdr.cpp:2417
 msgid "Server list"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2449
+#: src/muuli_wdr.cpp:2421
 msgid "Enter the url to a server.met file here and press the button to the left to update the list of known servers."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2454
+#: src/muuli_wdr.cpp:2426
 msgid "Add server manually: Name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2457
+#: src/muuli_wdr.cpp:2429
 msgid "Enter the name of the new server here"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2459 src/ServerWnd.cpp:206
+#: src/muuli_wdr.cpp:2431 src/ServerWnd.cpp:206
 msgid "IP:Port"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2462
+#: src/muuli_wdr.cpp:2434
 msgid "Enter the IP of the server here, using the x.x.x.x format."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2468
+#: src/muuli_wdr.cpp:2440
 msgid "Enter the port of the server here."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2471
+#: src/muuli_wdr.cpp:2443
 msgid "Add manually a server (fill fields to the left before) ..."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2500
+#: src/muuli_wdr.cpp:2472
 msgid "aMule Log"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2508
+#: src/muuli_wdr.cpp:2480
 msgid "Server Info"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2512
+#: src/muuli_wdr.cpp:2484
 msgid "ED2K Info"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2516
+#: src/muuli_wdr.cpp:2488
 msgid "Kad Info"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2544
+#: src/muuli_wdr.cpp:2516
 msgid "Click on this button to update the nodes list from URL ..."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2548
+#: src/muuli_wdr.cpp:2520
 msgid "Nodes (0)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2552
+#: src/muuli_wdr.cpp:2524
 msgid "Enter the url to a nodes.dat file here and press the button to the left to update the list of known nodes."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2555
+#: src/muuli_wdr.cpp:2527
 msgid "Nodes stats"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2597
+#: src/muuli_wdr.cpp:2569
 msgid "Bootstrap"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2600
+#: src/muuli_wdr.cpp:2572
 msgid "New node"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2605
+#: src/muuli_wdr.cpp:2577
 msgid "IP:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2625
+#: src/muuli_wdr.cpp:2597
 msgid "Port:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2638
+#: src/muuli_wdr.cpp:2610
 msgid "Bootstrap from known clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2640
+#: src/muuli_wdr.cpp:2612
 msgid "Disconnect Kad"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2674
+#: src/muuli_wdr.cpp:2646
 msgid "Use Secure User Identification"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2676
+#: src/muuli_wdr.cpp:2648
 msgid "It is recommended to enable this option. You will not receive credits if SUI is not enabled."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2678
+#: src/muuli_wdr.cpp:2650
 msgid "Protocol Obfuscation"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2681
+#: src/muuli_wdr.cpp:2653
 msgid "Support Protocol Obfuscation"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2683
+#: src/muuli_wdr.cpp:2655
 msgid "This option enabled Protocol Obfuscation, and makes aMule accept obfuscated connections from other clients."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2685
+#: src/muuli_wdr.cpp:2657
 msgid "Use obfuscation for outgoing connections"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2687
+#: src/muuli_wdr.cpp:2659
 msgid "This option makes aMule use Protocol Obfuscation when connecting other clients/servers."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2689
+#: src/muuli_wdr.cpp:2661
 msgid "Accept only obfuscated connections"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2690
+#: src/muuli_wdr.cpp:2662
 msgid "This option makes aMule only accept obfuscated connections. You will have less sources, but all your traffic will be obfuscated"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2695
+#: src/muuli_wdr.cpp:2667
 msgid "Everybody"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2697
+#: src/muuli_wdr.cpp:2669
 msgid "No one"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2699
+#: src/muuli_wdr.cpp:2671
 msgid "Who can see my shared files:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2700
+#: src/muuli_wdr.cpp:2672
 msgid "Select who can request to view a list of your shared files."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2702
+#: src/muuli_wdr.cpp:2674
 msgid "IP-Filtering"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2709
+#: src/muuli_wdr.cpp:2681
 msgid "Filter clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2711
+#: src/muuli_wdr.cpp:2683
 msgid "Enable filtering of the client IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2713
+#: src/muuli_wdr.cpp:2685
 msgid "Filter servers"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2715
+#: src/muuli_wdr.cpp:2687
 msgid "Enable filtering of the server IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2719
+#: src/muuli_wdr.cpp:2691
 msgid "Reload List"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2720
+#: src/muuli_wdr.cpp:2692
 msgid "Reload the list of IPs to filter from the file ~/.aMule/ipfilter.dat"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2726
+#: src/muuli_wdr.cpp:2698
 msgid "URL:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2730 src/muuli_wdr.cpp:2923
+#: src/muuli_wdr.cpp:2702 src/muuli_wdr.cpp:2895
 msgid "Update now"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2733
+#: src/muuli_wdr.cpp:2705
 msgid "Auto-update ipfilter at startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2737
+#: src/muuli_wdr.cpp:2709
 msgid "Filtering Level:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2743
+#: src/muuli_wdr.cpp:2715
 msgid "Always filter LAN IPs"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2746
+#: src/muuli_wdr.cpp:2718
 msgid "Paranoid handling of non-matching IPs"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2748
+#: src/muuli_wdr.cpp:2720
 msgid "Rejects a packet when its source IP differs from the IP the client claims (an anti-spoofing check). Disable only if it causes connection problems."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2750
+#: src/muuli_wdr.cpp:2722
 msgid "Use system-wide ipfilter.dat if available"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2751
+#: src/muuli_wdr.cpp:2723
 msgid "If there's no local ipfilter.dat found, allow usage of a system-wide ipfilter file."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2768
+#: src/muuli_wdr.cpp:2740
 msgid "Enable Online-Signature"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2770
+#: src/muuli_wdr.cpp:2742
 msgid "Enables the writing of the OS file, which can be used by external apps to create signatures and the like."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2774
+#: src/muuli_wdr.cpp:2746
 msgid "Update Frequency (Secs):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2777
+#: src/muuli_wdr.cpp:2749
 msgid "Change the frequency (in seconds) of Online Signature updates."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2785
+#: src/muuli_wdr.cpp:2757
 msgid "Save online signature file in: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:2791
+#: src/muuli_wdr.cpp:2763
 msgid "Click here to select the directory containing the the Online Signature files."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2824
+#: src/muuli_wdr.cpp:2796
 msgid "Show country flags for clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2825
+#: src/muuli_wdr.cpp:2797
 msgid "Render the country flag column in the transfers, queue and search views. Requires a valid MMDB GeoIP database (see below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2830
+#: src/muuli_wdr.cpp:2802
 msgid "Database"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2846
+#: src/muuli_wdr.cpp:2818
 msgid "Source:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2849
+#: src/muuli_wdr.cpp:2821
 msgid "DB-IP (free, no account)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2850
+#: src/muuli_wdr.cpp:2822
 msgid "MaxMind GeoLite2 (free, account required)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2851
+#: src/muuli_wdr.cpp:2823
 msgid "Custom URL"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2854
+#: src/muuli_wdr.cpp:2826
 msgid "Choose which provider supplies the GeoIP MMDB database. DB-IP is the default - no account required. MaxMind requires a free account + license key. Use Custom URL to point at any other MMDB host (e.g. a local mirror)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2871
+#: src/muuli_wdr.cpp:2843
 msgid ""
 "No configuration required.\n"
 "\n"
@@ -4753,11 +4723,11 @@ msgid ""
 "License: Creative Commons BY 4.0 - https://creativecommons.org/licenses/by/4.0/"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2884
+#: src/muuli_wdr.cpp:2856
 msgid "License key:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2890
+#: src/muuli_wdr.cpp:2862
 msgid ""
 "Sign up for a free MaxMind account, then generate a License Key:\n"
 "https://www.maxmind.com/en/geolite2/signup\n"
@@ -4767,222 +4737,222 @@ msgid ""
 "Requires attribution and account registration; refresh at least every 30 days."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2905
+#: src/muuli_wdr.cpp:2877
 msgid "Download URL:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2911
+#: src/muuli_wdr.cpp:2883
 msgid ""
 "Must point to an .mmdb file or a .gz / .tar.gz containing one.\n"
 "URL may include credentials (https://user:pass@host/...).\n"
 "License and attribution terms are set by the upstream URL - you are responsible."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2924
+#: src/muuli_wdr.cpp:2896
 msgid "Download the GeoIP database from the selected source."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2926
+#: src/muuli_wdr.cpp:2898
 msgid "Auto-update on startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2927
+#: src/muuli_wdr.cpp:2899
 msgid "Re-download the GeoIP database from the selected source every time aMule starts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2950
+#: src/muuli_wdr.cpp:2922
 msgid "Filter incoming messages (except current chat):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2952
+#: src/muuli_wdr.cpp:2924
 msgid "Filter all messages"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2954
+#: src/muuli_wdr.cpp:2926
 msgid "Filter messages from people not on your friend list"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2956
+#: src/muuli_wdr.cpp:2928
 msgid "Filter messages from unknown clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2958
+#: src/muuli_wdr.cpp:2930
 msgid "Filter messages containing (use ',' as separator):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2961 src/muuli_wdr.cpp:2972
+#: src/muuli_wdr.cpp:2933 src/muuli_wdr.cpp:2944
 msgid "add here the words amule should filter and block messages including it"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2963
+#: src/muuli_wdr.cpp:2935
 msgid "Show received messages in the log"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2966
+#: src/muuli_wdr.cpp:2938
 msgid "Comments"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2969
+#: src/muuli_wdr.cpp:2941
 msgid "Filter comments containing (use ',' as separator):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2994
+#: src/muuli_wdr.cpp:2966
 msgid "Enable Proxy"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2995
+#: src/muuli_wdr.cpp:2967
 msgid "Enable/disable proxy support"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2998
+#: src/muuli_wdr.cpp:2970
 msgid "Proxy type:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3009
+#: src/muuli_wdr.cpp:2981
 msgid "Proxy host:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3012
+#: src/muuli_wdr.cpp:2984
 msgid "The proxy host name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3014
+#: src/muuli_wdr.cpp:2986
 msgid "Proxy port:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3017
+#: src/muuli_wdr.cpp:2989
 msgid "The proxy port"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3019
+#: src/muuli_wdr.cpp:2991
 msgid "Enable authentication"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3020
+#: src/muuli_wdr.cpp:2992
 msgid "Enable/disable username/password authentication"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3023
+#: src/muuli_wdr.cpp:2995
 msgid "Username: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:3026
+#: src/muuli_wdr.cpp:2998
 msgid "The username to use to connect to the proxy"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3028
+#: src/muuli_wdr.cpp:3000
 msgid "Password:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3031
+#: src/muuli_wdr.cpp:3003
 msgid "The password to use to connect to the proxy"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3050
+#: src/muuli_wdr.cpp:3022
 msgid "Connect to:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3059
+#: src/muuli_wdr.cpp:3031
 msgid "Login to remote amule"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3064
+#: src/muuli_wdr.cpp:3036
 msgid "User name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3075
+#: src/muuli_wdr.cpp:3047
 msgid "Remember those settings"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3078
+#: src/muuli_wdr.cpp:3050
 msgid "Force ZLIB compression"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3102
+#: src/muuli_wdr.cpp:3074
 msgid "Enable Verbose Debug-Logging."
 msgstr ""
 
-#: src/muuli_wdr.cpp:3104
+#: src/muuli_wdr.cpp:3076
 msgid "Only to Logfile"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3106
+#: src/muuli_wdr.cpp:3078
 msgid "Message Categories:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3130 src/PartFileConvertDlg.cpp:160
+#: src/muuli_wdr.cpp:3102 src/PartFileConvertDlg.cpp:160
 msgid "Waiting..."
 msgstr ""
 
-#: src/muuli_wdr.cpp:3150
+#: src/muuli_wdr.cpp:3122
 msgid "Add imports"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3153
+#: src/muuli_wdr.cpp:3125
 msgid "Retry selected"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3155
+#: src/muuli_wdr.cpp:3127
 msgid "Remove selected"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3218
+#: src/muuli_wdr.cpp:3190
 msgid "Event Types"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3237
+#: src/muuli_wdr.cpp:3209
 msgid "Statistics and queued clients for selected file(s) : Session / All time"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3261
+#: src/muuli_wdr.cpp:3233
 msgid "Active Uploads"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3275
+#: src/muuli_wdr.cpp:3247
 msgid "Percent of total files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3327
+#: src/muuli_wdr.cpp:3299
 msgid "Show Clients for"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3329
+#: src/muuli_wdr.cpp:3301
 msgid "All files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3332
+#: src/muuli_wdr.cpp:3304
 msgid "Selected files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3335
+#: src/muuli_wdr.cpp:3307
 msgid "Active uploads only"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3342
+#: src/muuli_wdr.cpp:3314
 msgid "Reload:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3346
+#: src/muuli_wdr.cpp:3318
 msgid "Reload your shared files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3409
+#: src/muuli_wdr.cpp:3381
 msgid "Send"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3410
+#: src/muuli_wdr.cpp:3382
 msgid "Sends the specified message."
 msgstr ""
 
-#: src/muuli_wdr.cpp:3414
+#: src/muuli_wdr.cpp:3386
 msgid "Close this chat-session."
 msgstr ""
 
-#: src/muuli_wdr.cpp:3437
+#: src/muuli_wdr.cpp:3409
 msgid "Connect to any server and/or Kad"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3443 src/SharedFilesCtrl.cpp:142 src/Statistics.cpp:941
+#: src/muuli_wdr.cpp:3415 src/SharedFilesCtrl.cpp:142 src/Statistics.cpp:941
 msgid "Shared Files"
 msgstr ""
 
@@ -5340,263 +5310,263 @@ msgstr ""
 msgid "ERROR: Failed to open partfile '%s'"
 msgstr ""
 
-#: src/Preferences.cpp:701
+#: src/Preferences.cpp:673
 msgid "System default"
 msgstr ""
 
-#: src/Preferences.cpp:702
+#: src/Preferences.cpp:674
 msgid "Albanian"
 msgstr ""
 
-#: src/Preferences.cpp:703
+#: src/Preferences.cpp:675
 msgid "Arabic"
 msgstr ""
 
-#: src/Preferences.cpp:704
+#: src/Preferences.cpp:676
 msgid "Asturian"
 msgstr ""
 
-#: src/Preferences.cpp:705
+#: src/Preferences.cpp:677
 msgid "Basque"
 msgstr ""
 
-#: src/Preferences.cpp:706
+#: src/Preferences.cpp:678
 msgid "Bulgarian"
 msgstr ""
 
-#: src/Preferences.cpp:707
+#: src/Preferences.cpp:679
 msgid "Catalan"
 msgstr ""
 
-#: src/Preferences.cpp:708
+#: src/Preferences.cpp:680
 msgid "Chinese (Simplified)"
 msgstr ""
 
-#: src/Preferences.cpp:709
+#: src/Preferences.cpp:681
 msgid "Chinese (Traditional)"
 msgstr ""
 
-#: src/Preferences.cpp:710
+#: src/Preferences.cpp:682
 msgid "Croatian"
 msgstr ""
 
-#: src/Preferences.cpp:711
+#: src/Preferences.cpp:683
 msgid "Czech"
 msgstr ""
 
-#: src/Preferences.cpp:712
+#: src/Preferences.cpp:684
 msgid "Danish"
 msgstr ""
 
-#: src/Preferences.cpp:713
+#: src/Preferences.cpp:685
 msgid "Dutch"
 msgstr ""
 
-#: src/Preferences.cpp:714
+#: src/Preferences.cpp:686
 msgid "English (U.K.)"
 msgstr ""
 
-#: src/Preferences.cpp:715
+#: src/Preferences.cpp:687
 msgid "English (U.S.)"
 msgstr ""
 
-#: src/Preferences.cpp:716
+#: src/Preferences.cpp:688
 msgid "Estonian"
 msgstr ""
 
-#: src/Preferences.cpp:717
+#: src/Preferences.cpp:689
 msgid "Finnish"
 msgstr ""
 
-#: src/Preferences.cpp:718
+#: src/Preferences.cpp:690
 msgid "French"
 msgstr ""
 
-#: src/Preferences.cpp:719
+#: src/Preferences.cpp:691
 msgid "Galician"
 msgstr ""
 
-#: src/Preferences.cpp:720
+#: src/Preferences.cpp:692
 msgid "German"
 msgstr ""
 
-#: src/Preferences.cpp:721
+#: src/Preferences.cpp:693
 msgid "Greek"
 msgstr ""
 
-#: src/Preferences.cpp:722
+#: src/Preferences.cpp:694
 msgid "Hebrew"
 msgstr ""
 
-#: src/Preferences.cpp:723
+#: src/Preferences.cpp:695
 msgid "Hungarian"
 msgstr ""
 
-#: src/Preferences.cpp:724
+#: src/Preferences.cpp:696
 msgid "Italian"
 msgstr ""
 
-#: src/Preferences.cpp:725
+#: src/Preferences.cpp:697
 msgid "Japanese"
 msgstr ""
 
-#: src/Preferences.cpp:726
+#: src/Preferences.cpp:698
 msgid "Korean"
 msgstr ""
 
-#: src/Preferences.cpp:727
+#: src/Preferences.cpp:699
 msgid "Latvian"
 msgstr ""
 
-#: src/Preferences.cpp:728
+#: src/Preferences.cpp:700
 msgid "Lithuanian"
 msgstr ""
 
-#: src/Preferences.cpp:729
+#: src/Preferences.cpp:701
 msgid "Norwegian (Nynorsk)"
 msgstr ""
 
-#: src/Preferences.cpp:730
+#: src/Preferences.cpp:702
 msgid "Polish"
 msgstr ""
 
-#: src/Preferences.cpp:731
+#: src/Preferences.cpp:703
 msgid "Portuguese"
 msgstr ""
 
-#: src/Preferences.cpp:732
+#: src/Preferences.cpp:704
 msgid "Portuguese (Brazilian)"
 msgstr ""
 
-#: src/Preferences.cpp:733
+#: src/Preferences.cpp:705
 msgid "Romanian"
 msgstr ""
 
-#: src/Preferences.cpp:734
+#: src/Preferences.cpp:706
 msgid "Russian"
 msgstr ""
 
-#: src/Preferences.cpp:735
+#: src/Preferences.cpp:707
 msgid "Slovenian"
 msgstr ""
 
-#: src/Preferences.cpp:736
+#: src/Preferences.cpp:708
 msgid "Spanish"
 msgstr ""
 
-#: src/Preferences.cpp:737
+#: src/Preferences.cpp:709
 msgid "Swedish"
 msgstr ""
 
-#: src/Preferences.cpp:738
+#: src/Preferences.cpp:710
 msgid "Turkish"
 msgstr ""
 
-#: src/Preferences.cpp:739
+#: src/Preferences.cpp:711
 msgid "Ukrainian"
 msgstr ""
 
-#: src/Preferences.cpp:842
+#: src/Preferences.cpp:814
 msgid "Change Language"
 msgstr ""
 
-#: src/Preferences.cpp:906
+#: src/Preferences.cpp:878
 msgid "There are no translations installed for aMule"
 msgstr ""
 
-#: src/Preferences.cpp:907
+#: src/Preferences.cpp:879
 msgid "No languages available"
 msgstr ""
 
-#: src/Preferences.cpp:1038
+#: src/Preferences.cpp:1010
 msgid "no options available"
 msgstr ""
 
-#: src/Preferences.cpp:2226
+#: src/Preferences.cpp:2179
 msgid "Invalid category found, skipping"
 msgstr ""
 
-#: src/Preferences.cpp:2395
+#: src/Preferences.cpp:2348
 msgid "TCP port can't be higher than 65532 due to server UDP socket being TCP+3"
 msgstr ""
 
-#: src/Preferences.cpp:2396
+#: src/Preferences.cpp:2349
 #, c-format
 msgid "Default port will be used (%d)"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:300 src/Statistics.cpp:866
+#: src/PrefsUnifiedDlg.cpp:298 src/Statistics.cpp:866
 msgid "Connection"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:301 src/SearchListCtrl.cpp:117
+#: src/PrefsUnifiedDlg.cpp:299 src/SearchListCtrl.cpp:117
 msgid "Directories"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:302 src/Statistics.cpp:917
+#: src/PrefsUnifiedDlg.cpp:300 src/Statistics.cpp:917
 msgid "Servers"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:303 src/ServerListCtrl.cpp:96
+#: src/PrefsUnifiedDlg.cpp:301 src/ServerListCtrl.cpp:96
 msgid "Files"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:304
+#: src/PrefsUnifiedDlg.cpp:302
 msgid "Security"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:305
+#: src/PrefsUnifiedDlg.cpp:303
 msgid "Interface"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:312
+#: src/PrefsUnifiedDlg.cpp:310
 msgid "IP2Country"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:315
+#: src/PrefsUnifiedDlg.cpp:313
 msgid "Proxy"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:316
+#: src/PrefsUnifiedDlg.cpp:314
 msgid "Filters"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:317
+#: src/PrefsUnifiedDlg.cpp:315
 msgid "Remote Controls"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:318
+#: src/PrefsUnifiedDlg.cpp:316
 msgid "Online Signature"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:319
+#: src/PrefsUnifiedDlg.cpp:317
 msgid "Advanced"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:320
+#: src/PrefsUnifiedDlg.cpp:318
 msgid "Events"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:323
+#: src/PrefsUnifiedDlg.cpp:321
 msgid "Debugging"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:453
+#: src/PrefsUnifiedDlg.cpp:451
 msgid ""
 "The following variables will be substituted:\n"
 "    %PARTFILE - full path to the file\n"
 "    %PARTNAME - file name only"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:474
+#: src/PrefsUnifiedDlg.cpp:472
 msgid "Tray icon support requires libayatana-appindicator3 at compile time."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:490
+#: src/PrefsUnifiedDlg.cpp:488
 msgid "Not available on Wayland: the protocol does not report when a window is minimized, so this option cannot intercept the system minimize button. Workaround: launch aMule with `GDK_BACKEND=x11` to use XWayland instead."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:536
+#: src/PrefsUnifiedDlg.cpp:534
 msgid ""
 "Do not change these setting unless you know\n"
 "what you are doing, otherwise you can easily\n"
@@ -5606,424 +5576,407 @@ msgid ""
 "these settings."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:647
+#: src/PrefsUnifiedDlg.cpp:645
 #, c-format
 msgid "Failed to connect Cfg to widget with the ID %d and key %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:695
+#: src/PrefsUnifiedDlg.cpp:693
 #, c-format
 msgid "Failed to transfer data from Cfg to Widget with the ID %d and key %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:801
+#: src/PrefsUnifiedDlg.cpp:799
 msgid "The type of proxy you are connecting to"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1020
+#: src/PrefsUnifiedDlg.cpp:1003
 #, c-format
 msgid "Failed to transfer data from Widget to Cfg with the ID %d and key %s"
 msgstr ""
 
 #: src/PrefsUnifiedDlg.cpp:1103
-msgid "No password set."
-msgstr ""
-
-#: src/PrefsUnifiedDlg.cpp:1132
-msgid "Guest access needs a password. Type one in the guest password field, or untick Enable guest access."
-msgstr ""
-
-#: src/PrefsUnifiedDlg.cpp:1144
 msgid ""
 "aMule must be restarted to enable these changes:\n"
 "\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1151
+#: src/PrefsUnifiedDlg.cpp:1110
 msgid "- TCP port changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1156
+#: src/PrefsUnifiedDlg.cpp:1115
 msgid "- UDP port changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1161
+#: src/PrefsUnifiedDlg.cpp:1120
 msgid "- Network interface binding changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1166
+#: src/PrefsUnifiedDlg.cpp:1125
 msgid "- External connect port changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1170
+#: src/PrefsUnifiedDlg.cpp:1129
 msgid "- External connect acceptance changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1174
+#: src/PrefsUnifiedDlg.cpp:1133
 msgid "- External connect interface changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1178
+#: src/PrefsUnifiedDlg.cpp:1137
 msgid "- Protocol obfuscation support changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1193
+#: src/PrefsUnifiedDlg.cpp:1151
 msgid "- amuleapi settings changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1202
+#: src/PrefsUnifiedDlg.cpp:1160
 msgid ""
 "Your Auto-update server list is empty.\n"
 "'Auto-update server list at startup' will be disabled."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1213
+#: src/PrefsUnifiedDlg.cpp:1171
 msgid ""
 "You have enabled external connections but have not specified a password.\n"
 "External connections cannot be enabled unless a valid password is specified."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1246
-#, c-format
-msgid "The amuleapi password could not be saved: %s"
-msgstr ""
-
-#: src/PrefsUnifiedDlg.cpp:1276
+#: src/PrefsUnifiedDlg.cpp:1202
 msgid "- Language changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1281
+#: src/PrefsUnifiedDlg.cpp:1207
 msgid "- Temp folder changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1286
+#: src/PrefsUnifiedDlg.cpp:1212
 msgid "- ED2K network enabled.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1319
+#: src/PrefsUnifiedDlg.cpp:1245
 msgid "The shared-file exclusion pattern is not a valid regular expression. The filter has been left disabled."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1321 src/PrefsUnifiedDlg.cpp:1921
+#: src/PrefsUnifiedDlg.cpp:1247 src/PrefsUnifiedDlg.cpp:1841
 msgid "Invalid regular expression"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1398
+#: src/PrefsUnifiedDlg.cpp:1324
 msgid ""
 "Both eD2k and Kad network are disabled.\n"
 "You won't be able to connect until you enable at least one of them."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1403
+#: src/PrefsUnifiedDlg.cpp:1329
 msgid ""
 "Kad will not start if your UDP port is disabled.\n"
 "Enable UDP port or disable Kad."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1459
+#: src/PrefsUnifiedDlg.cpp:1385
 msgid ""
 "\n"
 "You MUST restart aMule now.\n"
 "If you do not restart now, don't complain if anything bad happens.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1524
+#: src/PrefsUnifiedDlg.cpp:1450
 msgid "Could not register aMule for autostart at login. The autostart store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1526
+#: src/PrefsUnifiedDlg.cpp:1452
 msgid "Could not remove the autostart-at-login entry."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1527
+#: src/PrefsUnifiedDlg.cpp:1453
 msgid "Autostart"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1542
+#: src/PrefsUnifiedDlg.cpp:1468
 msgid "Register file type"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1542
+#: src/PrefsUnifiedDlg.cpp:1468
 msgid "Register URL handler"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1550
+#: src/PrefsUnifiedDlg.cpp:1476
 #, c-format
 msgid "aMule only handles eD2k-compatible magnets. If you replace the current magnet handler (%s), BitTorrent magnet links will stop working - aMule cannot download BitTorrent content. Continue?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1555
+#: src/PrefsUnifiedDlg.cpp:1481
 #, c-format
 msgid "Another application currently opens .emulecollection files (%s). Replace it with aMule?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1560
+#: src/PrefsUnifiedDlg.cpp:1486
 #, c-format
 msgid "Another application is currently the default handler for these links (%s). Replace it with aMule?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1585
+#: src/PrefsUnifiedDlg.cpp:1511
 msgid "Could not register aMule for .emulecollection files. The registration store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1587
+#: src/PrefsUnifiedDlg.cpp:1513
 msgid "Could not remove the file type registration."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1589
+#: src/PrefsUnifiedDlg.cpp:1515
 msgid "Could not register aMule as the URL handler. The registration store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1591
+#: src/PrefsUnifiedDlg.cpp:1517
 msgid "Could not remove the URL handler registration."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1661 src/PrefsUnifiedDlg.cpp:1688
+#: src/PrefsUnifiedDlg.cpp:1587 src/PrefsUnifiedDlg.cpp:1614
 msgid "The web server and aMule API require external connections to be enabled."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1671
+#: src/PrefsUnifiedDlg.cpp:1597
 msgid "The aMule web server is deprecated. Consider running the aMule API instead."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1735
+#: src/PrefsUnifiedDlg.cpp:1655
 msgid ""
 "Your Auto-update servers list is in blank.\n"
 "Please fill in at least one URL to point to a valid server.met file.\n"
 "Click on the button \"List\" by this checkbox to enter an URL."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1876
+#: src/PrefsUnifiedDlg.cpp:1796
 msgid "Temporary files"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1881
+#: src/PrefsUnifiedDlg.cpp:1801
 msgid "Incoming files"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1886
+#: src/PrefsUnifiedDlg.cpp:1806
 msgid "Online Signatures"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1899
+#: src/PrefsUnifiedDlg.cpp:1819
 #, c-format
 msgid "Choose a folder for %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1923
+#: src/PrefsUnifiedDlg.cpp:1843
 #, c-format
 msgid "Would exclude %u of %u shared file"
 msgid_plural "Would exclude %u of %u shared files"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/PrefsUnifiedDlg.cpp:1940
+#: src/PrefsUnifiedDlg.cpp:1860
 msgid "Browse for videoplayer"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1944
+#: src/PrefsUnifiedDlg.cpp:1864
 msgid "Select browser"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1948
+#: src/PrefsUnifiedDlg.cpp:1868
 msgid "Select ffprobe binary"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1954
+#: src/PrefsUnifiedDlg.cpp:1874
 #, c-format
 msgid "Executable%s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1988
+#: src/PrefsUnifiedDlg.cpp:1908
 msgid "ffprobe not found on PATH or in the standard install locations. Install ffmpeg (which ships ffprobe) or use Browse to pick a binary manually."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2000
+#: src/PrefsUnifiedDlg.cpp:1920
 msgid "Reset the settings on this page to their default values?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2001
+#: src/PrefsUnifiedDlg.cpp:1921
 msgid "Reset to defaults"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2028
+#: src/PrefsUnifiedDlg.cpp:1948
 msgid "Edit server list"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2029
+#: src/PrefsUnifiedDlg.cpp:1949
 msgid ""
 "Add here URL's to download server.met files.\n"
 "Only one url on each line."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2084
+#: src/PrefsUnifiedDlg.cpp:2004
 msgid "IP2Country update failed"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2229 src/PrefsUnifiedDlg.cpp:2260
+#: src/PrefsUnifiedDlg.cpp:2149 src/PrefsUnifiedDlg.cpp:2180
 msgid "Data by MaxMind GeoLite2"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2231 src/PrefsUnifiedDlg.cpp:2262
+#: src/PrefsUnifiedDlg.cpp:2151 src/PrefsUnifiedDlg.cpp:2182
 msgid "Custom source"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2233 src/PrefsUnifiedDlg.cpp:2264
+#: src/PrefsUnifiedDlg.cpp:2153 src/PrefsUnifiedDlg.cpp:2184
 msgid "Data by DB-IP.com"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2284
+#: src/PrefsUnifiedDlg.cpp:2204
 #, c-format
 msgid "Status: Loaded%s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2286
+#: src/PrefsUnifiedDlg.cpp:2206
 #, c-format
 msgid "Status: Loaded%s - %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2290
+#: src/PrefsUnifiedDlg.cpp:2210
 msgid "Status: Failed to load - click 'Update now' to refresh."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2292
+#: src/PrefsUnifiedDlg.cpp:2212
 msgid "Status: Not found - click 'Update now' to download."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2350 src/PrefsUnifiedDlg.cpp:2374
+#: src/PrefsUnifiedDlg.cpp:2270 src/PrefsUnifiedDlg.cpp:2294
 #, c-format
 msgid "Update delay: %d second"
 msgid_plural "Update delay: %d seconds"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/PrefsUnifiedDlg.cpp:2358
+#: src/PrefsUnifiedDlg.cpp:2278
 #, c-format
 msgid "Time for average graph: %d minute"
 msgid_plural "Time for average graph: %d minutes"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/PrefsUnifiedDlg.cpp:2367
+#: src/PrefsUnifiedDlg.cpp:2287
 #, c-format
 msgid "Connections Graph Scale: %d"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2382
+#: src/PrefsUnifiedDlg.cpp:2302
 #, c-format
 msgid "File Buffer Size: %d byte"
 msgid_plural "File Buffer Size: %d bytes"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/PrefsUnifiedDlg.cpp:2392
+#: src/PrefsUnifiedDlg.cpp:2312
 #, c-format
 msgid "Upload Queue Size: %d client"
 msgid_plural "Upload Queue Size: %d clients"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/PrefsUnifiedDlg.cpp:2402
+#: src/PrefsUnifiedDlg.cpp:2322
 #, c-format
 msgid "Server connection refresh interval: %d minute"
 msgid_plural "Server connection refresh interval: %d minutes"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/PrefsUnifiedDlg.cpp:2407
+#: src/PrefsUnifiedDlg.cpp:2327
 msgid "Server connection refresh interval: Disabled"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2451
+#: src/PrefsUnifiedDlg.cpp:2371
 msgid "disabled"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2477
+#: src/PrefsUnifiedDlg.cpp:2397
 #, c-format
 msgid "Execute command on '%s' event"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2484
+#: src/PrefsUnifiedDlg.cpp:2404
 msgid "Enable command execution on core"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2496
+#: src/PrefsUnifiedDlg.cpp:2416
 msgid "Core command:"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2512
+#: src/PrefsUnifiedDlg.cpp:2432
 msgid "Enable command execution on GUI"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2524
+#: src/PrefsUnifiedDlg.cpp:2444
 msgid "GUI command:"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2540
+#: src/PrefsUnifiedDlg.cpp:2460
 msgid "The following variables will be replaced:"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2708
+#: src/PrefsUnifiedDlg.cpp:2628
 msgid ""
 "The following folders look like system or sensitive locations:\n"
 "\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2713
+#: src/PrefsUnifiedDlg.cpp:2633
 msgid "Sharing them recursively will publish every file underneath on the eD2k/Kad networks. Do you really want to do this?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2716
+#: src/PrefsUnifiedDlg.cpp:2636
 msgid "Confirm shared folders"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2744
+#: src/PrefsUnifiedDlg.cpp:2664
 msgid "Reloading shared files..."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2745
+#: src/PrefsUnifiedDlg.cpp:2665
 msgid "Scanning for subdirectories..."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2746
+#: src/PrefsUnifiedDlg.cpp:2666
 msgid "Updating shared folders"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2773
+#: src/PrefsUnifiedDlg.cpp:2693
 #, c-format
 msgid "Scanned %u directories..."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2823
+#: src/PrefsUnifiedDlg.cpp:2743
 #, c-format
 msgid "Reloading shared files: %u files scanned"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2873
+#: src/PrefsUnifiedDlg.cpp:2793
 msgid "Shared folder"
 msgstr ""
 
-#: src/SearchDlg.cpp:280
-msgid "Clear search history"
-msgstr ""
-
-#: src/SearchDlg.cpp:584
+#: src/SearchDlg.cpp:425
 msgid "It's impossible to search when both eD2k and Kademlia are disabled."
 msgstr ""
 
-#: src/SearchDlg.cpp:585 src/SearchListCtrl.cpp:858
+#: src/SearchDlg.cpp:426 src/SearchListCtrl.cpp:858
 msgid "Search error"
 msgstr ""
 
-#: src/SearchDlg.cpp:929
+#: src/SearchDlg.cpp:768
 msgid "Min size must be smaller than max size. Max size ignored."
 msgstr ""
 
-#: src/SearchDlg.cpp:930 src/SearchDlg.cpp:1012
+#: src/SearchDlg.cpp:769 src/SearchDlg.cpp:851
 msgid "Search warning"
 msgstr ""
 
-#: src/SearchDlg.cpp:1092 src/SearchListCtrl.cpp:735
+#: src/SearchDlg.cpp:929 src/SearchListCtrl.cpp:735
 msgid "Main"
 msgstr ""
 

--- a/po/ca.po
+++ b/po/ca.po
@@ -14,7 +14,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-28 10:19+0200\n"
+"POT-Creation-Date: 2026-07-28 12:17+0200\n"
 "PO-Revision-Date: 2026-07-27 11:33+0000\n"
 "Last-Translator: minterior <minterior@gmail.com>\n"
 "Language-Team: Català\n"
@@ -203,83 +203,83 @@ msgstr "No s'ha pogut obrir el fitxer de enllaços ED2K."
 msgid "WARNING: You can't add yourself as a source for an eD2k link while having a lowid."
 msgstr "AVÍS: No us podeu afegir com a font per a un enllaç eD2k mentre teniu ID Baixa."
 
-#: src/amule.cpp:300
+#: src/amule.cpp:301
 msgid "Now, exiting main app..."
 msgstr "Sortint del programa..."
 
-#: src/amule.cpp:330
+#: src/amule.cpp:331
 #, c-format
 msgid "Terminating amuleweb instance with pid '%d' ... "
 msgstr "S'està aturant el procés amuleweb amb pid '%d' ... "
 
-#: src/amule.cpp:334
+#: src/amule.cpp:335
 #, c-format
 msgid "Killing amuleweb instance with pid '%d' ... "
 msgstr "Aturant el procés amuleweb amb pid '%d' ... "
 
-#: src/amule.cpp:336 src/amule.cpp:349 src/ClientRef.cpp:180
+#: src/amule.cpp:337 src/amule.cpp:350 src/ClientRef.cpp:180
 #: src/SearchDlg.cpp:1041 src/ServerListCtrl.cpp:98
 msgid "Failed"
 msgstr "Fallades"
 
-#: src/amule.cpp:343
+#: src/amule.cpp:344
 #, fuzzy, c-format
 msgid "Terminating amuleapi instance with pid '%d' ... "
 msgstr "S'està aturant el procés amuleweb amb pid '%d' ... "
 
-#: src/amule.cpp:347
+#: src/amule.cpp:348
 #, fuzzy, c-format
 msgid "Killing amuleapi instance with pid '%d' ... "
 msgstr "Aturant el procés amuleweb amb pid '%d' ... "
 
-#: src/amule.cpp:355
+#: src/amule.cpp:356
 msgid "aMule OnExit: Terminating core."
 msgstr "aMule Sortida: Finalitzant nucli."
 
-#: src/amule.cpp:466
+#: src/amule.cpp:467
 msgid "aMule shutdown completed."
 msgstr "Aturada aMule completada."
 
-#: src/amule.cpp:470
+#: src/amule.cpp:471
 msgid "Memory debug results for aMule exit:"
 msgstr "Resultat de la depuració de la memòria a la sortida de l'aMule:"
 
-#: src/amule.cpp:651
+#: src/amule.cpp:652
 #, c-format
 msgid "Binding aMule's peer-to-peer traffic to interface: %s (HTTP updates use the default route)"
 msgstr ""
 
-#: src/amule.cpp:655
+#: src/amule.cpp:656
 #, c-format
 msgid "Binding all network traffic to interface: %s"
 msgstr ""
 
-#: src/amule.cpp:659
+#: src/amule.cpp:660
 #, c-format
 msgid "WARNING: configured network interface '%s' was not found - traffic is NOT bound to it and may leave via the default route. Check the interface name in Preferences."
 msgstr ""
 
-#: src/amule.cpp:665
+#: src/amule.cpp:666
 #, c-format
 msgid "WARNING: binding to network interface '%s' requires elevated privileges and was NOT applied - traffic may leave via the default route. Grant the capability (e.g. 'sudo setcap cap_net_raw+ep' on the aMule binary) or run with sufficient privileges."
 msgstr ""
 
-#: src/amule.cpp:673
+#: src/amule.cpp:674
 #, c-format
 msgid "WARNING: could not bind to network interface '%s' - traffic may leave via the default route."
 msgstr ""
 
-#: src/amule.cpp:732
+#: src/amule.cpp:733
 msgid "Your locale has been changed to System Default due to a configuration change. Sorry."
 msgstr "S'ha establert l'idioma Predeterminat del Sistema a causa d'un canvi de configuració. Disculpeu."
 
-#: src/amule.cpp:734 src/amule.cpp:1581 src/CatDialog.cpp:128
+#: src/amule.cpp:735 src/amule.cpp:1589 src/CatDialog.cpp:128
 #: src/CatDialog.cpp:136 src/CatDialog.cpp:149 src/ServerList.cpp:366
 #: src/ServerListCtrl.cpp:152
 msgid "Info"
 msgstr "Informació"
 
-#: src/amule.cpp:741
+#: src/amule.cpp:742
 msgid ""
 "\n"
 "EC configuration"
@@ -287,74 +287,74 @@ msgstr ""
 "\n"
 "Configuració EC"
 
-#: src/amule.cpp:744
+#: src/amule.cpp:745
 msgid "Password set and external connections enabled."
 msgstr "Contrassenya definida i connexions externes activades."
 
-#: src/amule.cpp:754 src/KadDlg.cpp:176 src/KadDlg.cpp:185
-#: src/PrefsUnifiedDlg.cpp:1387 src/SharedFilesCtrl.cpp:476
+#: src/amule.cpp:755 src/KadDlg.cpp:176 src/KadDlg.cpp:185
+#: src/PrefsUnifiedDlg.cpp:1461 src/SharedFilesCtrl.cpp:476
 msgid "WARNING"
 msgstr "AVÍS"
 
-#: src/amule.cpp:991
+#: src/amule.cpp:992
 #, fuzzy
 msgid "Network bootstrap"
 msgstr "Xarxes"
 
-#: src/amule.cpp:996
+#: src/amule.cpp:997
 msgid ""
 "aMule has detected missing network bootstrap files.\n"
 "Select which ones to download:"
 msgstr ""
 
-#: src/amule.cpp:1005 src/FirstRunWizard.cpp:411
+#: src/amule.cpp:1006 src/FirstRunWizard.cpp:411
 #, fuzzy
 msgid "eD2k server list (server.met)"
 msgstr "S'ha trobat %i servidor al server.met"
 
-#: src/amule.cpp:1012 src/FirstRunWizard.cpp:416
+#: src/amule.cpp:1013 src/FirstRunWizard.cpp:416
 msgid "Kad bootstrap nodes (nodes.dat)"
 msgstr ""
 
-#: src/amule.cpp:1102
+#: src/amule.cpp:1103
 #, c-format
 msgid "web server running on pid %d"
 msgstr "servidor web executant-se al pid %d"
 
-#: src/amule.cpp:1115
+#: src/amule.cpp:1116
 #, fuzzy
 msgid "You requested to run web server on startup, but the amuleweb binary cannot be run. Please install the package containing aMule web server, or build aMule from source with -DBUILD_WEBSERVER=YES and install it."
 msgstr "Heu demanat que s'executi el servidor web a l'inici, però no s'ha trobat el fitxer binari de l'amuleweb. Si us plau instal·leu el paquet que conté el servidor web de l'aMule, o compileu l'aMule usant la opció --enable-webserver i executeu make install"
 
-#: src/amule.cpp:1120 src/amule.cpp:1177 src/amule.cpp:1291 src/amule.cpp:1593
+#: src/amule.cpp:1121 src/amule.cpp:1185 src/amule.cpp:1299 src/amule.cpp:1601
 #: src/amule-remote-gui.cpp:603 src/amule-remote-gui.cpp:671
 #: src/amule-remote-gui.cpp:709 src/amule-remote-gui.cpp:1282
 #: src/amule-remote-gui.cpp:1345 src/amule-remote-gui.cpp:1372
-#: src/DownloadQueue.cpp:1481
+#: src/DownloadQueue.cpp:1481 src/PrefsUnifiedDlg.cpp:1247
 msgid "ERROR"
 msgstr "ERROR"
 
-#: src/amule.cpp:1166
+#: src/amule.cpp:1174
 #, fuzzy, c-format
 msgid "amuleapi running on pid %d"
 msgstr "servidor web executant-se al pid %d"
 
-#: src/amule.cpp:1172
+#: src/amule.cpp:1180
 #, fuzzy
 msgid "You requested to run amuleapi on startup, but the amuleapi binary cannot be run. Please install the package containing aMule's REST API server, or build aMule from source with -DBUILD_AMULEAPI=YES and install it."
 msgstr "Heu demanat que s'executi el servidor web a l'inici, però no s'ha trobat el fitxer binari de l'amuleweb. Si us plau instal·leu el paquet que conté el servidor web de l'aMule, o compileu l'aMule usant la opció --enable-webserver i executeu make install"
 
-#: src/amule.cpp:1259
+#: src/amule.cpp:1267
 #, c-format
 msgid "Could not bind ports to the specified address: %s"
 msgstr "No s'han pogut vincular els ports a l'adreça especificada: %s"
 
-#: src/amule.cpp:1283
+#: src/amule.cpp:1291
 #, c-format
 msgid "Port %u is not available. You will be LOWID\n"
 msgstr "El port %u no està disponible. Tindreu ID BAIXA\n"
 
-#: src/amule.cpp:1288
+#: src/amule.cpp:1296
 #, c-format
 msgid ""
 "Port %u is not available!\n"
@@ -369,48 +369,48 @@ msgstr ""
 "\n"
 "Comproveu la configuració de la xarxa per a assegurar-vos que el port està obert."
 
-#: src/amule.cpp:1385
+#: src/amule.cpp:1393
 msgid "Failed to create OnlineSig File"
 msgstr "No s'ha pogut crear el fitxer de la signatura en línia"
 
-#: src/amule.cpp:1393
+#: src/amule.cpp:1401
 msgid "Failed to create aMule OnlineSig File"
 msgstr "No s'ha pogut crear el fitxer de la signatura en línia de l'aMule"
 
-#: src/amule.cpp:1556
+#: src/amule.cpp:1564
 msgid "The selected locale seems not to be installed on your box. (Note: I'll try to set it anyway)"
 msgstr "L'idioma seleccionat no està instal·lat al PC. (Nota: s'intentarà establir igualment)"
 
-#: src/amule.cpp:1566
+#: src/amule.cpp:1574
 #, c-format
 msgid "This is the first time you run aMule %s"
 msgstr "És la primera vegada que executeu l'aMule %s"
 
-#: src/amule.cpp:1569
+#: src/amule.cpp:1577
 msgid "This version is a testing version, updated daily, and\n"
 msgstr "Aquesta és una versió de prova, actualitzada diàriament, i\n"
 
-#: src/amule.cpp:1570
+#: src/amule.cpp:1578
 msgid "we give no warranty it won't break anything, burn your house,\n"
 msgstr "no podem garantir que no trenqui res, cremi casa vostra,\n"
 
-#: src/amule.cpp:1571
+#: src/amule.cpp:1579
 msgid "or kill your dog. But it *should* be safe to use anyway.\n"
 msgstr "o mati al gos. Tanmateix el seu ús *hauria* de ser segur.\n"
 
-#: src/amule.cpp:1576
+#: src/amule.cpp:1584
 msgid "More information, support and new releases can found at our homepage,\n"
 msgstr "Podeu trobar més informació, ajuda i noves versions a la nostra pàgina web,\n"
 
-#: src/amule.cpp:1577
+#: src/amule.cpp:1585
 msgid "at https://amule-org.github.io, or in our IRC channel #aMule at irc.libera.chat.\n"
 msgstr "https://amule-org.github.io, o al nostre canal IRC #aMule de irc.libera.chat.\n"
 
-#: src/amule.cpp:1579
+#: src/amule.cpp:1587
 msgid "Feel free to report any bugs to https://github.com/amule-org/amule/issues"
 msgstr "Podeu informar de qualsevol error a https://github.com/amule-org/amule/issues"
 
-#: src/amule.cpp:1591
+#: src/amule.cpp:1599
 msgid ""
 "The folder for Online Signature files you specified is INVALID!\n"
 " OnlineSignature will be DISABLED until you fix it on preferences."
@@ -418,137 +418,137 @@ msgstr ""
 "La carpeta especificada per als fitxers de la signatura en línia és INVÀLIDA!\n"
 " S'INHABILITARÀ la signatura en línia fins que ho resolgueu a les preferències."
 
-#: src/amule.cpp:1654
+#: src/amule.cpp:1662
 msgid "Server hostname notified"
 msgstr "Nom del servidor notificat"
 
-#: src/amule.cpp:2031
+#: src/amule.cpp:2039
 #, c-format
 msgid "Disk space preallocation for file '%s' failed: %s"
 msgstr "La preassignació d'espai per al fitxer '%s' ha fallat: %s"
 
-#: src/amule.cpp:2160
+#: src/amule.cpp:2168
 msgid "ERROR: can't open logfile"
 msgstr "ERROR: no es pot obrir el fitxer de registre"
 
-#: src/amule.cpp:2164
+#: src/amule.cpp:2172
 msgid "WARNING: logfile is empty. Something is wrong."
 msgstr "AVÍS: el fitxer de registre està buit. Alguna cosa no va bé."
 
-#: src/amule.cpp:2181
+#: src/amule.cpp:2189
 msgid "Log has been reset"
 msgstr "S'ha reiniciat el registre"
 
-#: src/amule.cpp:2205
+#: src/amule.cpp:2213
 #, c-format
 msgid "ServerMessage: %s"
 msgstr "Missatge del servidor: %s"
 
-#: src/amule.cpp:2248 src/IP2Country.cpp:220 src/IPFilter.cpp:514
+#: src/amule.cpp:2256 src/IP2Country.cpp:220 src/IPFilter.cpp:514
 #: src/ServerList.cpp:875
 #, c-format
 msgid "Skipped download of %s, because requested file is not newer."
 msgstr "S'ha omès la baixada de %s perquè el fitxer sol·licitat no és més recent."
 
-#: src/amule.cpp:2251
+#: src/amule.cpp:2259
 msgid "Failed to download the nodes list."
 msgstr "No s'ha pogut baixar la llista de nodes."
 
-#: src/amule.cpp:2314
+#: src/amule.cpp:2322
 msgid "Failed to open the downloaded version check file"
 msgstr "No s'ha pogut obrir el fitxer de comprovació de versió"
 
-#: src/amule.cpp:2317 src/amule.cpp:2336
+#: src/amule.cpp:2325 src/amule.cpp:2344
 msgid "Corrupted version check file"
 msgstr "Fitxer de comprovació de versió corrupte"
 
-#: src/amule.cpp:2359
+#: src/amule.cpp:2367
 msgid "You are using an outdated version of aMule!"
 msgstr "Esteu usant una versió antiga de l'aMule!"
 
-#: src/amule.cpp:2361
+#: src/amule.cpp:2369
 #, c-format
 msgid "Your aMule version is %i.%i.%i and the latest version is %li.%li.%li"
 msgstr "La vostra versió de l'aMule és %i.%i.%i i l'última versió és %li.%li.%li"
 
-#: src/amule.cpp:2365
+#: src/amule.cpp:2373
 msgid "The latest version can always be found at https://github.com/amule-org/amule/releases/latest"
 msgstr "Sempre podeu trobar l'última versió a https://github.com/amule-org/amule/releases/latest"
 
-#: src/amule.cpp:2368
+#: src/amule.cpp:2376
 #, c-format
 msgid "WARNING: Your aMuled version is outdated: %i.%i.%i < %li.%li.%li"
 msgstr "AVÍS: La vostra versió d'aMuled és antiga: %i.%i.%i < %li.%li.%li"
 
-#: src/amule.cpp:2374
+#: src/amule.cpp:2382
 msgid "Your copy of aMule is up to date."
 msgstr "La vostra versió de l'aMule és l'última."
 
-#: src/amule.cpp:2381
+#: src/amule.cpp:2389
 msgid "Failed to download the version check file"
 msgstr "No s'ha pogut baixar el fitxer de comprovació de versió"
 
-#: src/amule.cpp:2550 src/amule-remote-gui.cpp:1133
+#: src/amule.cpp:2558 src/amule-remote-gui.cpp:1133
 #, c-format
 msgid "Users: %s | Files: %s"
 msgstr "Usuaris: %s | Fitxers: %s"
 
-#: src/amule.cpp:2551 src/amule-remote-gui.cpp:1134
+#: src/amule.cpp:2559 src/amule-remote-gui.cpp:1134
 #, c-format
 msgid "Users: E: %s K: %s | Files: E: %s K: %s"
 msgstr "Usuaris: E: %s K: %s | Fitxers: E: %s K: %s"
 
-#: src/amule.cpp:2565 src/amule-remote-gui.cpp:1147
+#: src/amule.cpp:2573 src/amule-remote-gui.cpp:1147
 msgid "No networks selected"
 msgstr "No s'han seleccionat xarxes"
 
-#: src/amule.cpp:2633 src/TextClient.cpp:903
+#: src/amule.cpp:2641 src/TextClient.cpp:903
 msgid "with LowID"
 msgstr "amb ID Baixa"
 
-#: src/amule.cpp:2633 src/TextClient.cpp:904
+#: src/amule.cpp:2641 src/TextClient.cpp:904
 msgid "with HighID"
 msgstr "amb ID Alta"
 
-#: src/amule.cpp:2635
+#: src/amule.cpp:2643
 #, c-format
 msgid "Connected to %s %s"
 msgstr "Connectat a %s %s"
 
-#: src/amule.cpp:2640
+#: src/amule.cpp:2648
 #, c-format
 msgid "Connecting to %s"
 msgstr "S'està connectant a %s"
 
-#: src/amule.cpp:2642
+#: src/amule.cpp:2650
 msgid "Disconnected from eD2k"
 msgstr "Desconnectat de eD2k"
 
-#: src/amule.cpp:2651
+#: src/amule.cpp:2659
 msgid "Kad started."
 msgstr "S'ha engegat la xarxa Kad."
 
-#: src/amule.cpp:2653
+#: src/amule.cpp:2661
 msgid "Kad stopped."
 msgstr "S'ha aturat la xarxa Kad."
 
-#: src/amule.cpp:2661
+#: src/amule.cpp:2669
 msgid "Connected to Kad (ok)"
 msgstr "Connectat a Kad (ok)"
 
-#: src/amule.cpp:2663
+#: src/amule.cpp:2671
 msgid "Connected to Kad (firewalled)"
 msgstr "Connectat a Kad (tallafocs)"
 
-#: src/amule.cpp:2667
+#: src/amule.cpp:2675
 msgid "Disconnected from Kad"
 msgstr "Desconnectat de Kad"
 
-#: src/amule.cpp:2699
+#: src/amule.cpp:2707
 msgid "Kad network cannot be used if UDP port is disabled on preferences, not starting."
 msgstr "No es pot usar la xarxa Kad si el port UDP està inhabilitat a les preferències, no s'engegarà."
 
-#: src/amule.cpp:2703
+#: src/amule.cpp:2711
 msgid "Kad network disabled on preferences, not connecting."
 msgstr "La xarxa Kad està inhabilitada a les preferències, no es connectarà."
 
@@ -593,36 +593,36 @@ msgid "FATAL ERROR: Failed to create Timer"
 msgstr "ERROR GREU: No s'ha pogut crear el temporitzador"
 
 #: src/amuleDlg.cpp:361 src/amuleDlg.cpp:1787 src/amuleDlg.cpp:2033
-#: src/muuli_wdr.cpp:1492 src/muuli_wdr.cpp:3418
+#: src/muuli_wdr.cpp:1492 src/muuli_wdr.cpp:3449
 msgid "Networks"
 msgstr "Xarxes"
 
-#: src/amuleDlg.cpp:362 src/amuleDlg.cpp:1793 src/muuli_wdr.cpp:3419
+#: src/amuleDlg.cpp:362 src/amuleDlg.cpp:1793 src/muuli_wdr.cpp:3450
 msgid "Searches"
 msgstr "Cerques"
 
 #: src/amuleDlg.cpp:363 src/amuleDlg.cpp:1799 src/DownloadListCtrl.cpp:740
-#: src/muuli_wdr.cpp:392 src/muuli_wdr.cpp:1585 src/muuli_wdr.cpp:3420
+#: src/muuli_wdr.cpp:392 src/muuli_wdr.cpp:1585 src/muuli_wdr.cpp:3451
 #: src/Statistics.cpp:829
 msgid "Downloads"
 msgstr "Baixades"
 
-#: src/amuleDlg.cpp:364 src/amuleDlg.cpp:1805 src/muuli_wdr.cpp:3294
+#: src/amuleDlg.cpp:364 src/amuleDlg.cpp:1805 src/muuli_wdr.cpp:3325
 msgid "Shared files"
 msgstr "Compartits"
 
-#: src/amuleDlg.cpp:365 src/amuleDlg.cpp:1811 src/muuli_wdr.cpp:2926
-#: src/muuli_wdr.cpp:3376 src/muuli_wdr.cpp:3423
+#: src/amuleDlg.cpp:365 src/amuleDlg.cpp:1811 src/muuli_wdr.cpp:2957
+#: src/muuli_wdr.cpp:3407 src/muuli_wdr.cpp:3454
 msgid "Messages"
 msgstr "Missatges"
 
-#: src/amuleDlg.cpp:366 src/amuleDlg.cpp:1817 src/muuli_wdr.cpp:3424
-#: src/PrefsUnifiedDlg.cpp:312 src/Statistics.cpp:779 src/Statistics.cpp:1235
+#: src/amuleDlg.cpp:366 src/amuleDlg.cpp:1817 src/muuli_wdr.cpp:3455
+#: src/PrefsUnifiedDlg.cpp:314 src/Statistics.cpp:779 src/Statistics.cpp:1235
 msgid "Statistics"
 msgstr "Estadístiques"
 
-#: src/amuleDlg.cpp:368 src/amuleDlg.cpp:1824 src/muuli_wdr.cpp:3426
-#: src/PrefsUnifiedDlg.cpp:328 src/utils/wxCas/src/wxcasprefs.cpp:39
+#: src/amuleDlg.cpp:368 src/amuleDlg.cpp:1824 src/muuli_wdr.cpp:3457
+#: src/PrefsUnifiedDlg.cpp:330 src/utils/wxCas/src/wxcasprefs.cpp:39
 msgid "Preferences"
 msgstr "Preferències"
 
@@ -680,8 +680,8 @@ msgstr "Kad: Inativa"
 #: src/amuleDlg.cpp:1029 src/DownloadListCtrl.cpp:505
 #: src/DownloadListCtrl.cpp:749 src/FriendListCtrl.cpp:180
 #: src/muuli_wdr.cpp:731 src/muuli_wdr.cpp:782 src/muuli_wdr.cpp:846
-#: src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2231 src/muuli_wdr.cpp:2316
-#: src/muuli_wdr.cpp:3064 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
+#: src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2262 src/muuli_wdr.cpp:2347
+#: src/muuli_wdr.cpp:3095 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
 #: src/ServerListCtrl.cpp:606 src/TransferWnd.cpp:378
 #: src/utils/wxCas/src/wxcasprefs.cpp:235
 msgid "Cancel"
@@ -692,7 +692,7 @@ msgid "Stop the current connection attempts"
 msgstr "Atura els intents de connexió actuals"
 
 #: src/amuleDlg.cpp:1035 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976
-#: src/muuli_wdr.cpp:2454
+#: src/muuli_wdr.cpp:2485
 msgid "Disconnect"
 msgstr "Desconnecta"
 
@@ -701,7 +701,7 @@ msgid "Disconnect from the currently connected networks"
 msgstr "Desconnecta de les xarxes on s'està connectat actualment"
 
 #: src/amuleDlg.cpp:1041 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979
-#: src/muuli_wdr.cpp:2609 src/muuli_wdr.cpp:3061 src/muuli_wdr.cpp:3416
+#: src/muuli_wdr.cpp:2640 src/muuli_wdr.cpp:3092 src/muuli_wdr.cpp:3447
 msgid "Connect"
 msgstr "Connecta"
 
@@ -755,7 +755,7 @@ msgstr "Confirmació de sortida"
 msgid "Launch Command: "
 msgstr "Ordre: "
 
-#: src/amuleDlg.cpp:1632 src/muuli_wdr.cpp:1978 src/Preferences.cpp:952
+#: src/amuleDlg.cpp:1632 src/muuli_wdr.cpp:1982 src/Preferences.cpp:979
 msgid "- default -"
 msgstr "- defecte -"
 
@@ -769,48 +769,48 @@ msgstr "El directori del tema '%s' no existeix"
 msgid "WARNING: Unable to open skin file '%s' for read"
 msgstr "AVÍS: No ha estat possible obrir el fitxer d'aparença '%s' per a lectura"
 
-#: src/amuleDlg.cpp:1791 src/muuli_wdr.cpp:3418
+#: src/amuleDlg.cpp:1791 src/muuli_wdr.cpp:3449
 msgid "Networks Window"
 msgstr "Finestra de les Xarxes"
 
-#: src/amuleDlg.cpp:1797 src/muuli_wdr.cpp:3419
+#: src/amuleDlg.cpp:1797 src/muuli_wdr.cpp:3450
 msgid "Searches Window"
 msgstr "Finestra de cerques"
 
-#: src/amuleDlg.cpp:1803 src/muuli_wdr.cpp:3420
+#: src/amuleDlg.cpp:1803 src/muuli_wdr.cpp:3451
 msgid "Downloads Window"
 msgstr "Finestra de baixades"
 
-#: src/amuleDlg.cpp:1809 src/muuli_wdr.cpp:3422
+#: src/amuleDlg.cpp:1809 src/muuli_wdr.cpp:3453
 msgid "Shared Files Window"
 msgstr "Finestra de fitxers compartits"
 
-#: src/amuleDlg.cpp:1815 src/muuli_wdr.cpp:3423
+#: src/amuleDlg.cpp:1815 src/muuli_wdr.cpp:3454
 msgid "Messages Window"
 msgstr "Finestra de Missatges"
 
-#: src/amuleDlg.cpp:1821 src/muuli_wdr.cpp:3424
+#: src/amuleDlg.cpp:1821 src/muuli_wdr.cpp:3455
 msgid "Statistics Graph Window"
 msgstr "Finestra del gràfic d'estadístiques"
 
-#: src/amuleDlg.cpp:1828 src/muuli_wdr.cpp:3426
+#: src/amuleDlg.cpp:1828 src/muuli_wdr.cpp:3457
 msgid "Preferences Settings Window"
 msgstr "Finestra de la configuració de preferències"
 
-#: src/amuleDlg.cpp:1831 src/muuli_wdr.cpp:3427
+#: src/amuleDlg.cpp:1831 src/muuli_wdr.cpp:3458
 msgid "Import"
 msgstr "Importa"
 
-#: src/amuleDlg.cpp:1835 src/muuli_wdr.cpp:3427
+#: src/amuleDlg.cpp:1835 src/muuli_wdr.cpp:3458
 msgid "The partfile importer tool"
 msgstr "Eina d'importació de fitxers de parts"
 
-#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3428
+#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3459
 #: src/utils/aLinkCreator/src/alcframe.cpp:262
 msgid "About"
 msgstr "Quant a"
 
-#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3428
+#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3459
 msgid "About/Help"
 msgstr "Quant a / Ajuda"
 
@@ -952,7 +952,7 @@ msgstr "No s'ha trobat el fitxer."
 msgid "The core rejected these shared folders:%s"
 msgstr ""
 
-#: src/amule-remote-gui.cpp:1336 src/ExternalConn.cpp:2345
+#: src/amule-remote-gui.cpp:1336 src/ExternalConn.cpp:2346
 msgid "Invalid link or already on list."
 msgstr "L'enllaç és invàlid o ja és present a la llista."
 
@@ -968,7 +968,7 @@ msgstr "No s'ha pogut crear el directori '%s' per a la categoria '%s', es mantin
 #: src/ClientDetailDialog.cpp:123 src/DataToText.cpp:61 src/DataToText.cpp:86
 #: src/DataToText.cpp:101 src/DataToText.cpp:136 src/DataToText.cpp:165
 #: src/DownloadListCtrl.cpp:1172 src/DownloadListCtrl.cpp:1185
-#: src/DownloadListCtrl.cpp:1196 src/ExternalConn.cpp:608
+#: src/DownloadListCtrl.cpp:1196 src/ExternalConn.cpp:609
 #: src/FileDetailDialog.cpp:203 src/FileDetailDialog.cpp:235
 #: src/FileDetailDialog.cpp:242 src/GenericClientListCtrl.cpp:1171
 #: src/GenericClientListCtrl.cpp:1182 src/GenericClientListCtrl.cpp:1192
@@ -1355,19 +1355,19 @@ msgstr "Auto [Al]"
 msgid "Very low"
 msgstr "Molt baixa"
 
-#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:743 src/muuli_wdr.cpp:2282
+#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:743 src/muuli_wdr.cpp:2313
 #: src/ServerListCtrl.cpp:263 src/ServerListCtrl.cpp:456
 #: src/SharedFilesCtrl.cpp:145
 msgid "Low"
 msgstr "Baixa"
 
-#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:744 src/muuli_wdr.cpp:2283
+#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:744 src/muuli_wdr.cpp:2314
 #: src/ServerListCtrl.cpp:266 src/ServerListCtrl.cpp:457
 #: src/SharedFilesCtrl.cpp:146
 msgid "Normal"
 msgstr "Normal"
 
-#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:745 src/muuli_wdr.cpp:2284
+#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:745 src/muuli_wdr.cpp:2315
 #: src/ServerListCtrl.cpp:269 src/ServerListCtrl.cpp:458
 #: src/SharedFilesCtrl.cpp:147
 msgid "High"
@@ -1459,7 +1459,7 @@ msgstr "Servidor local"
 msgid "Remote Server"
 msgstr "Servidor remot"
 
-#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3181
+#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3212
 #: src/SearchDlg.cpp:119 src/TextClient.cpp:911
 msgid "Kad"
 msgstr "Kad"
@@ -1531,7 +1531,7 @@ msgstr "Part"
 msgid "Size"
 msgstr "Mida"
 
-#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3248
+#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3279
 msgid "Transferred"
 msgstr "Transferit"
 
@@ -1589,7 +1589,7 @@ msgstr ""
 "Retroacció des de: %s (%s)\n"
 "\n"
 
-#: src/DownloadListCtrl.cpp:746 src/muuli_wdr.cpp:2285
+#: src/DownloadListCtrl.cpp:746 src/muuli_wdr.cpp:2316
 #: src/SharedFilesCtrl.cpp:150
 msgid "Auto"
 msgstr "Auto"
@@ -1627,7 +1627,7 @@ msgid "Extended Options"
 msgstr "Opcions avançades"
 
 #: src/DownloadListCtrl.cpp:770 src/DownloadListCtrl.cpp:822
-#: src/muuli_wdr.cpp:1796
+#: src/muuli_wdr.cpp:1800
 msgid "Preview"
 msgstr "Previsualitza"
 
@@ -1802,227 +1802,232 @@ msgstr[1] ""
 msgid "Invalid eD2k link! ERROR: %s"
 msgstr "Enllaç eD2k invàlid! ERROR: %s"
 
-#: src/ExternalConn.cpp:379
+#: src/ExternalConn.cpp:380
 msgid "Client sent packet after authentication failed."
 msgstr "El client ha enviat un paquet després d'una autenticació fallida."
 
-#: src/ExternalConn.cpp:396
+#: src/ExternalConn.cpp:397
 msgid "External connection closed."
 msgstr "Connexió externa tancada."
 
-#: src/ExternalConn.cpp:473
+#: src/ExternalConn.cpp:474
 msgid "External connections disabled due to empty password!"
 msgstr "Les connexions externes han estat inhabilitades per manca d'una contrasenya!"
 
-#: src/ExternalConn.cpp:494
+#: src/ExternalConn.cpp:495
 msgid "External connections disabled in config file"
 msgstr "Les connexions externes estan inhabilitades al fitxer de configuració"
 
-#: src/ExternalConn.cpp:575
+#: src/ExternalConn.cpp:576
 msgid "New external connection accepted"
 msgstr "Nova connexió externa acceptada"
 
-#: src/ExternalConn.cpp:578
+#: src/ExternalConn.cpp:579
 msgid "ERROR: couldn't accept a new external connection"
 msgstr "ERROR: no s'ha pogut acceptar una nova connexió externa"
 
-#: src/ExternalConn.cpp:595
+#: src/ExternalConn.cpp:596
 msgid "External connection refused due to empty password in preferences!"
 msgstr "S'ha rebutjat la connexió externa per manca d'una contrasenya a les preferències!"
 
-#: src/ExternalConn.cpp:607
+#: src/ExternalConn.cpp:608
 #, c-format
 msgid "Connecting client: %s %s"
 msgstr "S'està connectant al client: %s %s"
 
-#: src/ExternalConn.cpp:609
+#: src/ExternalConn.cpp:610
 msgid "Unknown version"
 msgstr "Versió desconeguda"
 
-#: src/ExternalConn.cpp:622
+#: src/ExternalConn.cpp:623
 msgid "Incorrect EC version ID, there might be binary incompatibility. Use core and remote from same snapshot."
 msgstr "ID de versió EC incorrecta, pot haver-hi incompatibilitat binaria. Useu un nucli i un client remot del mateix llançament (versió)."
 
-#: src/ExternalConn.cpp:630
+#: src/ExternalConn.cpp:631
 msgid "You cannot connect to a release version from an arbitrary development snapshot! *sigh* possible crash prevented"
 msgstr "No us podeu connectar a una versió final des d'una versió de desenvolupament arbitrària! *buf* s'ha evitat una possible fallada"
 
-#: src/ExternalConn.cpp:713
+#: src/ExternalConn.cpp:714
 msgid "Invalid protocol version."
 msgstr "Versió del protocol invàlida."
 
-#: src/ExternalConn.cpp:719
+#: src/ExternalConn.cpp:720
 msgid "Missing protocol version tag."
 msgstr "Marcador de la versió del protocol inexistent."
 
-#: src/ExternalConn.cpp:727
+#: src/ExternalConn.cpp:728
 msgid "Authentication failed: invalid hash specified as EC password."
 msgstr "L'autenticació ha fallat: el resum especificat com a contrasenya d'EC no és vàlid."
 
-#: src/ExternalConn.cpp:775
+#: src/ExternalConn.cpp:776
 msgid "Authentication failed: wrong password."
 msgstr "Ha fallat l'autenticació: contrasenya incorrecta"
 
-#: src/ExternalConn.cpp:777
+#: src/ExternalConn.cpp:778
 msgid "Authentication failed: missing password."
 msgstr "Ha fallat l'autenticació: falta la contrasenya"
 
-#: src/ExternalConn.cpp:788
+#: src/ExternalConn.cpp:789
 msgid "Invalid request, please authenticate first."
 msgstr "Petició invàlida, primer heu d'autenticar-vos."
 
-#: src/ExternalConn.cpp:793
+#: src/ExternalConn.cpp:794
 msgid "Access granted."
 msgstr "Accés concedit."
 
-#: src/ExternalConn.cpp:801
+#: src/ExternalConn.cpp:802
 #, c-format
 msgid "Sent error message \"%s\" to client."
 msgstr "S'ha enviat el missatge d'error \"%s\" al client."
 
-#: src/ExternalConn.cpp:806
+#: src/ExternalConn.cpp:807
 #, c-format
 msgid "Unauthorized access attempt from %s. Connection closed."
 msgstr "Intent d'accés no autoritzat de %s. Connexió tancada."
 
-#: src/ExternalConn.cpp:1419
+#: src/ExternalConn.cpp:1420
 #, c-format
 msgid "Remote PartFile command failed: FileHash not found: %s"
 msgstr "Ha fallat una ordre remota de fitxer de parts: No s'ha trobat el resum del fitxer: %s"
 
-#: src/ExternalConn.cpp:1423
+#: src/ExternalConn.cpp:1424
 #, c-format
 msgid "FileHash not found: %s"
 msgstr "No s'ha trobat el resum del fitxer: %s"
 
-#: src/ExternalConn.cpp:1470 src/ExternalConn.cpp:1558
-#: src/ExternalConn.cpp:1679
+#: src/ExternalConn.cpp:1471 src/ExternalConn.cpp:1559
+#: src/ExternalConn.cpp:1680
 msgid "OOPS! OpCode processing error!"
 msgstr "Error en processar el codi d'opció!"
 
-#: src/ExternalConn.cpp:1501
+#: src/ExternalConn.cpp:1502
 msgid "Server not added"
 msgstr "No s'ha afegit el servidor"
 
-#: src/ExternalConn.cpp:1520
+#: src/ExternalConn.cpp:1521
 #, c-format
 msgid "server not found: %s"
 msgstr "no s'ha trobat el servidor: %s"
 
-#: src/ExternalConn.cpp:1537
+#: src/ExternalConn.cpp:1538
 msgid "need to define server to be removed"
 msgstr "és necessari definir el servidor a esborrar"
 
-#: src/ExternalConn.cpp:1552
+#: src/ExternalConn.cpp:1553
 msgid "eD2k is disabled in preferences."
 msgstr "eD2k és inhabilitada a les preferències."
 
-#: src/ExternalConn.cpp:1657
+#: src/ExternalConn.cpp:1658
 #, fuzzy
 msgid "Friend not found."
 msgstr "No s'ha trobat el fitxer."
 
-#: src/ExternalConn.cpp:1667
+#: src/ExternalConn.cpp:1668
 #, fuzzy
 msgid "Client not found."
 msgstr "No s'ha trobat el fitxer."
 
-#: src/ExternalConn.cpp:1673
+#: src/ExternalConn.cpp:1674
 msgid "EC_TAG_FRIEND_SHARED requires EC_TAG_FRIEND or EC_TAG_CLIENT."
 msgstr ""
 
-#: src/ExternalConn.cpp:1991
+#: src/ExternalConn.cpp:1992
 msgid "WebSearch from remote interface makes no sense."
 msgstr "La recerca web des de la interfície remota no té sentit."
 
-#: src/ExternalConn.cpp:2026
+#: src/ExternalConn.cpp:2027
 msgid "Search in progress. Refetch results in a moment!"
 msgstr "Cerca en procés. S'obtindran resultats en un moment!"
 
-#: src/ExternalConn.cpp:2265
+#: src/ExternalConn.cpp:2266
 msgid "No points for graph."
 msgstr "Cap punt per al gràfic."
 
-#: src/ExternalConn.cpp:2275
+#: src/ExternalConn.cpp:2276
 msgid "Your client is not configured for this detail level."
 msgstr "El vostre client no està configurat per a aquest nivell de detall."
 
-#: src/ExternalConn.cpp:2302
+#: src/ExternalConn.cpp:2303
 msgid "External Connection: shutdown requested"
 msgstr "Connexió externa: s'ha demanat l'aturada"
 
-#: src/ExternalConn.cpp:2314
+#: src/ExternalConn.cpp:2315
 msgid "Already shutting down."
 msgstr "Ja s'està aturant."
 
-#: src/ExternalConn.cpp:2332
+#: src/ExternalConn.cpp:2333
 #, c-format
 msgid "ExternalConn: adding link '%s'."
 msgstr "ExternalConn: afegint l'enllaç '%s'."
 
-#: src/ExternalConn.cpp:2350
+#: src/ExternalConn.cpp:2351
 #, fuzzy, c-format
 msgid "%d of %d links failed (invalid or already on list)."
 msgstr "L'enllaç és invàlid o ja és present a la llista."
 
-#: src/ExternalConn.cpp:2373
+#: src/ExternalConn.cpp:2374
 msgid "Version check throttled; try again shortly."
 msgstr ""
 
-#: src/ExternalConn.cpp:2378
+#: src/ExternalConn.cpp:2379
 msgid "Version check is not available on this daemon."
 msgstr ""
 
-#: src/ExternalConn.cpp:2508
+#: src/ExternalConn.cpp:2509
 msgid "File not found."
 msgstr "No s'ha trobat el fitxer."
 
-#: src/ExternalConn.cpp:2513
+#: src/ExternalConn.cpp:2514
 msgid "Invalid file name."
 msgstr "Nom de fitxer invàlid."
 
-#: src/ExternalConn.cpp:2521
+#: src/ExternalConn.cpp:2522
 msgid "Unable to rename file."
 msgstr "No s'ha pogut canviar el nom del fitxer."
 
-#: src/ExternalConn.cpp:2992 src/ExternalConn.cpp:3020
+#: src/ExternalConn.cpp:2839
+#, c-format
+msgid "Could not save the amuleapi password: %s"
+msgstr ""
+
+#: src/ExternalConn.cpp:3004 src/ExternalConn.cpp:3032
 msgid "Kad is disabled in preferences."
 msgstr "Kad està inhabilitada a les preferències."
 
-#: src/ExternalConn.cpp:3033
+#: src/ExternalConn.cpp:3045
 msgid "Already connected to eD2k."
 msgstr "Ja esteu connectat a eD2k."
 
-#: src/ExternalConn.cpp:3036
+#: src/ExternalConn.cpp:3048
 msgid "Connecting to eD2k..."
 msgstr "Connectant a eD2k..."
 
-#: src/ExternalConn.cpp:3045
+#: src/ExternalConn.cpp:3057
 msgid "Already connected to Kad."
 msgstr "Ja esteu connectat a Kad."
 
-#: src/ExternalConn.cpp:3048
+#: src/ExternalConn.cpp:3060
 msgid "Connecting to Kad..."
 msgstr "S'està connectant a Kad..."
 
-#: src/ExternalConn.cpp:3055
+#: src/ExternalConn.cpp:3067
 msgid "All networks are disabled."
 msgstr "Totes les xarxes estan inhabilitades."
 
-#: src/ExternalConn.cpp:3064
+#: src/ExternalConn.cpp:3076
 msgid "Disconnected from eD2k."
 msgstr "Desconnectat de eD2k."
 
-#: src/ExternalConn.cpp:3069
+#: src/ExternalConn.cpp:3081
 msgid "Disconnected from Kad."
 msgstr "Desconnectat de Kad."
 
-#: src/ExternalConn.cpp:3078
+#: src/ExternalConn.cpp:3090
 #, c-format
 msgid "External Connection: invalid opcode received: %#x"
 msgstr "Connexió externa: s'ha rebut un codi d'opció invàlid: %#x"
 
-#: src/ExternalConn.cpp:3083
+#: src/ExternalConn.cpp:3095
 msgid "Invalid opcode (wrong protocol version?)"
 msgstr "Codi d'opció invàlid (versió de protocol errònia?)"
 
@@ -2423,23 +2428,23 @@ msgid ""
 "want downloads on a different (e.g. larger) disk."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:549 src/FirstRunWizard.cpp:611 src/muuli_wdr.cpp:1708
+#: src/FirstRunWizard.cpp:549 src/FirstRunWizard.cpp:611 src/muuli_wdr.cpp:1712
 msgid "Destination folder for downloads"
 msgstr "Carpeta on desar les descàrregues"
 
 #: src/FirstRunWizard.cpp:553 src/FirstRunWizard.cpp:569 src/muuli_wdr.cpp:1349
-#: src/muuli_wdr.cpp:1366 src/muuli_wdr.cpp:1683 src/muuli_wdr.cpp:1714
-#: src/muuli_wdr.cpp:1726 src/muuli_wdr.cpp:2769
+#: src/muuli_wdr.cpp:1366 src/muuli_wdr.cpp:1687 src/muuli_wdr.cpp:1718
+#: src/muuli_wdr.cpp:1730 src/muuli_wdr.cpp:2800
 #: src/utils/aLinkCreator/src/alcframe.cpp:135
 #: src/utils/wxCas/src/wxcasprefs.cpp:52 src/utils/wxCas/src/wxcasprefs.cpp:118
 msgid "Browse"
 msgstr "Explora"
 
-#: src/FirstRunWizard.cpp:559 src/muuli_wdr.cpp:1719
+#: src/FirstRunWizard.cpp:559 src/muuli_wdr.cpp:1723
 msgid "(All files in this folder are shared with other peers)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:565 src/FirstRunWizard.cpp:624 src/muuli_wdr.cpp:1721
+#: src/FirstRunWizard.cpp:565 src/FirstRunWizard.cpp:624 src/muuli_wdr.cpp:1725
 msgid "Folder for temporary download files"
 msgstr "Carpeta on desar les descàrregues temporals"
 
@@ -2470,7 +2475,7 @@ msgstr "No s'ha pogut obrir el fitxer amb la llista d'amics 'emfriends.met' per 
 msgid "CRITICAL - no client on StartChatSession"
 msgstr "CRITIC - no hi ha client a l'Inici de Sessió del Xat"
 
-#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2675 src/muuli_wdr.cpp:3352
+#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2706 src/muuli_wdr.cpp:3383
 msgid "Friends"
 msgstr "Amics"
 
@@ -2581,8 +2586,8 @@ msgstr "Cap"
 msgid "No"
 msgstr "No"
 
-#: src/GenericClientListCtrl.cpp:1216 src/PrefsUnifiedDlg.cpp:2818
-#: src/PrefsUnifiedDlg.cpp:2868 src/ServerListCtrl.cpp:276
+#: src/GenericClientListCtrl.cpp:1216 src/PrefsUnifiedDlg.cpp:2898
+#: src/PrefsUnifiedDlg.cpp:2948 src/ServerListCtrl.cpp:276
 msgid "Yes"
 msgstr "Sí"
 
@@ -2751,10 +2756,10 @@ msgstr "Port invàlid per a l'arrancada"
 msgid "Please fill all fields required"
 msgstr "Si us plau empleneu tots els camps requerits"
 
-#: src/KadDlg.cpp:192 src/PartFile.cpp:1031 src/PrefsUnifiedDlg.cpp:1162
-#: src/PrefsUnifiedDlg.cpp:1331 src/PrefsUnifiedDlg.cpp:1589
-#: src/PrefsUnifiedDlg.cpp:1599 src/PrefsUnifiedDlg.cpp:1616
-#: src/PrefsUnifiedDlg.cpp:1658
+#: src/KadDlg.cpp:192 src/PartFile.cpp:1031 src/PrefsUnifiedDlg.cpp:1134
+#: src/PrefsUnifiedDlg.cpp:1204 src/PrefsUnifiedDlg.cpp:1405
+#: src/PrefsUnifiedDlg.cpp:1663 src/PrefsUnifiedDlg.cpp:1673
+#: src/PrefsUnifiedDlg.cpp:1690 src/PrefsUnifiedDlg.cpp:1738
 msgid "Message"
 msgstr "Missatge"
 
@@ -2856,7 +2861,7 @@ msgstr "Ràtio"
 msgid "Uploaded"
 msgstr "Transferit"
 
-#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3232
+#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3263
 msgid "Requested"
 msgstr "Peticions"
 
@@ -2980,7 +2985,7 @@ msgid "WARNING: "
 msgstr "AVÍS: "
 
 #: src/MuleNotebook.cpp:179 src/muuli_wdr.cpp:817 src/muuli_wdr.cpp:1229
-#: src/muuli_wdr.cpp:3136 src/muuli_wdr.cpp:3392
+#: src/muuli_wdr.cpp:3167 src/muuli_wdr.cpp:3423
 msgid "Close"
 msgstr "Tanca"
 
@@ -2998,7 +3003,7 @@ msgid "Paste"
 msgstr "Enganxa"
 
 #: src/MuleTextCtrl.cpp:89 src/muuli_wdr.cpp:358 src/muuli_wdr.cpp:757
-#: src/muuli_wdr.cpp:2359 src/muuli_wdr.cpp:2378 src/muuli_wdr.cpp:2400
+#: src/muuli_wdr.cpp:2390 src/muuli_wdr.cpp:2409 src/muuli_wdr.cpp:2431
 #: src/utils/aLinkCreator/src/alcframe.cpp:142
 msgid "Clear"
 msgstr "Neteja"
@@ -3097,7 +3102,7 @@ msgstr "Surt"
 
 #: src/MuleTrayIcon.cpp:579 src/MuleTrayIcon.cpp:945 src/MuleTrayIcon.cpp:965
 #: src/muuli_wdr.cpp:1398 src/muuli_wdr.cpp:1406 src/muuli_wdr.cpp:1413
-#: src/muuli_wdr.cpp:1842 src/muuli_wdr.cpp:1848 src/OtherFunctions.cpp:91
+#: src/muuli_wdr.cpp:1846 src/muuli_wdr.cpp:1852 src/OtherFunctions.cpp:91
 #: src/StatisticsDlg.cpp:93 src/StatisticsDlg.cpp:95
 msgid "kB/s"
 msgstr "kB/s"
@@ -3339,7 +3344,7 @@ msgstr "Bytes"
 msgid "KB"
 msgstr "KB"
 
-#: src/muuli_wdr.cpp:274 src/muuli_wdr.cpp:293 src/muuli_wdr.cpp:1627
+#: src/muuli_wdr.cpp:274 src/muuli_wdr.cpp:293 src/muuli_wdr.cpp:1631
 #: src/OtherFunctions.cpp:64
 msgid "MB"
 msgstr "MB"
@@ -3356,7 +3361,7 @@ msgstr "Mida Màx."
 msgid "Availability"
 msgstr "Disponibilitat"
 
-#: src/muuli_wdr.cpp:312 src/muuli_wdr.cpp:398 src/muuli_wdr.cpp:3297
+#: src/muuli_wdr.cpp:312 src/muuli_wdr.cpp:398 src/muuli_wdr.cpp:3328
 msgid "Filter:"
 msgstr "Filtre:"
 
@@ -3419,12 +3424,12 @@ msgstr "Fonts del fitxer:"
 #: src/muuli_wdr.cpp:1160 src/muuli_wdr.cpp:1167 src/muuli_wdr.cpp:1172
 #: src/muuli_wdr.cpp:1179 src/muuli_wdr.cpp:1184 src/muuli_wdr.cpp:1191
 #: src/muuli_wdr.cpp:1205 src/muuli_wdr.cpp:1212 src/muuli_wdr.cpp:1217
-#: src/muuli_wdr.cpp:1224 src/muuli_wdr.cpp:3234 src/muuli_wdr.cpp:3242
-#: src/muuli_wdr.cpp:3250
+#: src/muuli_wdr.cpp:1224 src/muuli_wdr.cpp:3265 src/muuli_wdr.cpp:3273
+#: src/muuli_wdr.cpp:3281
 msgid "N/A"
 msgstr "N/D"
 
-#: src/muuli_wdr.cpp:508 src/muuli_wdr.cpp:1065 src/PrefsUnifiedDlg.cpp:297
+#: src/muuli_wdr.cpp:508 src/muuli_wdr.cpp:1065 src/PrefsUnifiedDlg.cpp:299
 msgid "General"
 msgstr "General "
 
@@ -3565,7 +3570,7 @@ msgstr ""
 msgid "Album :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:685 src/muuli_wdr.cpp:2254
+#: src/muuli_wdr.cpp:685 src/muuli_wdr.cpp:2285
 msgid "Title :"
 msgstr "Títol:"
 
@@ -3674,7 +3679,7 @@ msgstr "Usuari:"
 msgid "Userhash :"
 msgstr "Resum de l'usuari:"
 
-#: src/muuli_wdr.cpp:895 src/muuli_wdr.cpp:1748 src/muuli_wdr.cpp:2449
+#: src/muuli_wdr.cpp:895 src/muuli_wdr.cpp:1752 src/muuli_wdr.cpp:2480
 #: src/utils/aLinkCreator/src/alcframe.cpp:137
 msgid "Add"
 msgstr "Afegeix"
@@ -3683,15 +3688,15 @@ msgstr "Afegeix"
 msgid "Download-Speed"
 msgstr "Velocitat de baixada"
 
-#: src/muuli_wdr.cpp:954 src/muuli_wdr.cpp:989 src/muuli_wdr.cpp:2553
+#: src/muuli_wdr.cpp:954 src/muuli_wdr.cpp:989 src/muuli_wdr.cpp:2584
 msgid "Current"
 msgstr "Actual"
 
-#: src/muuli_wdr.cpp:962 src/muuli_wdr.cpp:997 src/muuli_wdr.cpp:2561
+#: src/muuli_wdr.cpp:962 src/muuli_wdr.cpp:997 src/muuli_wdr.cpp:2592
 msgid "Running average"
 msgstr "Mitjana total"
 
-#: src/muuli_wdr.cpp:970 src/muuli_wdr.cpp:1005 src/muuli_wdr.cpp:2569
+#: src/muuli_wdr.cpp:970 src/muuli_wdr.cpp:1005 src/muuli_wdr.cpp:2600
 msgid "Session average"
 msgstr "Mitjana de la sessió"
 
@@ -3703,7 +3708,7 @@ msgstr "Velocitat de pujada"
 msgid "Connections"
 msgstr "Connexions"
 
-#: src/muuli_wdr.cpp:1024 src/muuli_wdr.cpp:1867
+#: src/muuli_wdr.cpp:1024 src/muuli_wdr.cpp:1871
 msgid "Active downloads"
 msgstr "Baixades actives"
 
@@ -3711,7 +3716,7 @@ msgstr "Baixades actives"
 msgid "Active connections (1:1)"
 msgstr "Connexions actives (1:1)"
 
-#: src/muuli_wdr.cpp:1040 src/muuli_wdr.cpp:1868
+#: src/muuli_wdr.cpp:1040 src/muuli_wdr.cpp:1872
 msgid "Active uploads"
 msgstr "Pujades actives"
 
@@ -3987,7 +3992,7 @@ msgstr "Vincula l'adreça local a l'IP (buit per qualsevol):"
 msgid "Advanced users only: If you have multiple network interfaces, enter the address of the interface to which aMule should be bound."
 msgstr "Només usuaris avançats: Si disposeu de multiples interfícies de xarxa, entreu l'adreça de la interfície a la que l'aMule hauria d'estar vinculada."
 
-#: src/muuli_wdr.cpp:1462 src/muuli_wdr.cpp:2061
+#: src/muuli_wdr.cpp:1462 src/muuli_wdr.cpp:2065
 #, fuzzy
 msgid "Bind to network interface (empty for any):"
 msgstr "Vincula l'adreça local a l'IP (buit per qualsevol):"
@@ -4004,7 +4009,7 @@ msgstr "Nombre màxim de fonts per descàrrega:"
 msgid "Max simultaneous connections:"
 msgstr "Nombre màxim de connexions simultànies:"
 
-#: src/muuli_wdr.cpp:1498 src/muuli_wdr.cpp:3176
+#: src/muuli_wdr.cpp:1498 src/muuli_wdr.cpp:3207
 msgid "ED2K"
 msgstr "ED2K"
 
@@ -4096,755 +4101,778 @@ msgstr "Preassigna l'espai al disc per als fitxers nous"
 msgid "For new files preallocates disk space for the whole file, thus reduces fragmentation"
 msgstr "Per a fitxers nous reserva l'espai que ocuparà el fitxer complet. Açò redueix la fragmentació"
 
-#: src/muuli_wdr.cpp:1613
+#: src/muuli_wdr.cpp:1617
 msgid "Create new files as sparse files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1614
-msgid "A sparse file reserves its full size on disk immediately without writing real data to it -- fast, but unsupported or slow on some filesystems, and free-space accounting stays optimistic while the download is in progress. Turn this off to grow the file only as data arrives."
+#: src/muuli_wdr.cpp:1618
+msgid "Sparse part files only occupy disk space for the parts already downloaded, so free space is used up gradually as the file fills in. Turn this off to use an ordinary file instead - useful where sparse files are unsupported or slow, or where backup/de-duplication tools handle them badly. Applies only when the core runs on Windows; on Linux and macOS part files are sparse anyway and this setting has no effect."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1619
+#: src/muuli_wdr.cpp:1623
 msgid "Stop downloads when free disk space reaches "
 msgstr "Atura les descàrregues quan l'espai buit al disc arribi a "
 
-#: src/muuli_wdr.cpp:1620
+#: src/muuli_wdr.cpp:1624
 msgid "Select this if you want aMule to check your disk space"
 msgstr "Seleccioneu-ho si voleu que l'aMule comprovi l'espai del disc"
 
-#: src/muuli_wdr.cpp:1624
+#: src/muuli_wdr.cpp:1628
 msgid "Enter here the min disk space desired."
 msgstr "Poseu l'espai mínim de disc desitjat."
 
-#: src/muuli_wdr.cpp:1630
+#: src/muuli_wdr.cpp:1634
 msgid "Save 10 sources on rare files (< 20 sources)"
 msgstr "Recorda 10 fonts dels fitxers rars (amb < 20 fonts)"
 
-#: src/muuli_wdr.cpp:1634 src/Statistics.cpp:790
+#: src/muuli_wdr.cpp:1638 src/Statistics.cpp:790
 msgid "Uploads"
 msgstr "Pujades"
 
-#: src/muuli_wdr.cpp:1637
+#: src/muuli_wdr.cpp:1641
 msgid "Add new shared files with auto priority"
 msgstr "Afegeix els nous fitxer compartits amb prioritat automàtica"
 
-#: src/muuli_wdr.cpp:1643
+#: src/muuli_wdr.cpp:1647
 msgid "Intelligent Corruption Handling (I.C.H.)"
 msgstr "Gestió d'Errors Inteligent (I.C.H.)"
 
-#: src/muuli_wdr.cpp:1646
+#: src/muuli_wdr.cpp:1650
 msgid "Enable"
 msgstr "Activa"
 
-#: src/muuli_wdr.cpp:1649
+#: src/muuli_wdr.cpp:1653
 msgid "Advanced I.C.H. trusts every hash (not recommended)"
 msgstr "I.C.H. avançat confia en totes les comprovacions (no recomanat)"
 
-#: src/muuli_wdr.cpp:1661 src/PrefsUnifiedDlg.cpp:1910
+#: src/muuli_wdr.cpp:1665 src/PrefsUnifiedDlg.cpp:1990
 msgid "Media metadata extraction"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1665
+#: src/muuli_wdr.cpp:1669
 msgid "Extract length / bitrate / codec from shared audio and video files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1667
+#: src/muuli_wdr.cpp:1671
 msgid "When enabled, aMule runs ffprobe on each shared media file to fill in the Length / Bitrate / Codec columns other clients see when they find the file in a search. Requires ffmpeg (the ffprobe binary) to be installed."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1674
+#: src/muuli_wdr.cpp:1678
 msgid "Path to ffprobe:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1679
+#: src/muuli_wdr.cpp:1683
 msgid "Full path to the ffprobe binary. Leave empty to have aMule auto-detect it on startup."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1687
+#: src/muuli_wdr.cpp:1691
 msgid "Detect"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1688
+#: src/muuli_wdr.cpp:1692
 msgid "Search the standard install locations for an ffprobe binary and fill the path field."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1712
+#: src/muuli_wdr.cpp:1716
 msgid ""
 "Completed downloads are stored here. All files in this folder are automatically shared with other peers.\n"
 "If this folder also holds files you don't want to share, point it at an aMule-only sub-folder."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1715
+#: src/muuli_wdr.cpp:1719
 msgid "Pick the folder where completed downloads will be stored. All files in that folder will be shared with other peers."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1729
+#: src/muuli_wdr.cpp:1733
 msgid "Shared folders"
 msgstr "Carpetes compartides"
 
-#: src/muuli_wdr.cpp:1735
+#: src/muuli_wdr.cpp:1739
 msgid "(Folders shared by the core. Enter a path to add one.)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1743
+#: src/muuli_wdr.cpp:1747
 msgid "Absolute path of a folder on the core's machine, e.g. /home/user/shared"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1745 src/PrefsUnifiedDlg.cpp:2794
+#: src/muuli_wdr.cpp:1749 src/PrefsUnifiedDlg.cpp:2874
 msgid "Recursive"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1746
+#: src/muuli_wdr.cpp:1750
 msgid "Share every sub-folder underneath this one, including ones created later."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1750 src/utils/aLinkCreator/src/alcframe.cpp:141
+#: src/muuli_wdr.cpp:1754 src/utils/aLinkCreator/src/alcframe.cpp:141
 msgid "Remove"
 msgstr "Esborra"
 
-#: src/muuli_wdr.cpp:1754
+#: src/muuli_wdr.cpp:1758
 msgid "(Right click on folder icon for recursive share)"
 msgstr "(Per a compartir recursivament feu clic dret sobre el directori)"
 
-#: src/muuli_wdr.cpp:1761
+#: src/muuli_wdr.cpp:1765
 msgid "Share hidden files"
 msgstr "Comparteix els fitxers ocults"
 
-#: src/muuli_wdr.cpp:1767
+#: src/muuli_wdr.cpp:1771
 msgid "Automatically rescan shared folders for changes"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1773
+#: src/muuli_wdr.cpp:1777
 msgid "Follow symbolic links in shared folders"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1779
+#: src/muuli_wdr.cpp:1783
 msgid "Exclude files matching:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1782
+#: src/muuli_wdr.cpp:1786
 msgid "Wildcard patterns separated by '|', e.g. .DS_Store|Thumbs.db|*.tmp. Files whose name matches are not shared. Matching is case-insensitive."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1786
+#: src/muuli_wdr.cpp:1790
 msgid "Patterns are regular expressions"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1787
+#: src/muuli_wdr.cpp:1791
 msgid "When set, the whole field is one regular expression ('|' is alternation). When unset, it is a list of '|'-separated wildcards."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1797
+#: src/muuli_wdr.cpp:1801
 msgid "Show how many shared files the current pattern would exclude."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1818
+#: src/muuli_wdr.cpp:1822
 msgid "Graphs"
 msgstr "Gràfics"
 
-#: src/muuli_wdr.cpp:1821 src/muuli_wdr.cpp:1883
+#: src/muuli_wdr.cpp:1825 src/muuli_wdr.cpp:1887
 msgid "Update delay : 5 secs"
 msgstr "Actualitza cada: 5 segs"
 
-#: src/muuli_wdr.cpp:1825
+#: src/muuli_wdr.cpp:1829
 msgid "Time for average graph: 100 mins"
 msgstr "Temps per al gràfic de mitjana: 100 mins"
 
-#: src/muuli_wdr.cpp:1829
+#: src/muuli_wdr.cpp:1833
 msgid "Connections Graph Scale: 100 "
 msgstr "Escala del Gràfic de Connexions: 100 "
 
-#: src/muuli_wdr.cpp:1836
+#: src/muuli_wdr.cpp:1840
 msgid "Download graph scale:"
 msgstr "Escala del gràfic de descàrrega:"
 
-#: src/muuli_wdr.cpp:1844
+#: src/muuli_wdr.cpp:1848
 msgid "Upload graph scale:"
 msgstr "Escala del gràfic de pujada:"
 
-#: src/muuli_wdr.cpp:1854
+#: src/muuli_wdr.cpp:1858
 #, fuzzy
 msgid "Colors: "
 msgstr "Colors: "
 
-#: src/muuli_wdr.cpp:1858
+#: src/muuli_wdr.cpp:1862
 msgid "Background"
 msgstr "Fons"
 
-#: src/muuli_wdr.cpp:1859
+#: src/muuli_wdr.cpp:1863
 msgid "Grid"
 msgstr "Graella"
 
-#: src/muuli_wdr.cpp:1860
+#: src/muuli_wdr.cpp:1864
 msgid "Download current"
 msgstr "Baixada actual"
 
-#: src/muuli_wdr.cpp:1861
+#: src/muuli_wdr.cpp:1865
 msgid "Download running average"
 msgstr "Mitjana de baixada total"
 
-#: src/muuli_wdr.cpp:1862
+#: src/muuli_wdr.cpp:1866
 msgid "Download session average"
 msgstr "Mitjana de baixada de la sessió"
 
-#: src/muuli_wdr.cpp:1863
+#: src/muuli_wdr.cpp:1867
 msgid "Upload current"
 msgstr "Pujada actual"
 
-#: src/muuli_wdr.cpp:1864
+#: src/muuli_wdr.cpp:1868
 msgid "Upload running average"
 msgstr "Mitjana de pujada total"
 
-#: src/muuli_wdr.cpp:1865
+#: src/muuli_wdr.cpp:1869
 msgid "Upload session average"
 msgstr "Mitjana de pujada de la sessió"
 
-#: src/muuli_wdr.cpp:1866
+#: src/muuli_wdr.cpp:1870
 msgid "Active connections"
 msgstr "Connexions actives"
 
-#: src/muuli_wdr.cpp:1869
+#: src/muuli_wdr.cpp:1873
 #, fuzzy
 msgid "Systray Icon Speed Bar"
 msgstr "Barra de velocitat de la icona d'estat"
 
-#: src/muuli_wdr.cpp:1870
+#: src/muuli_wdr.cpp:1874
 msgid "Kad-nodes current"
 msgstr "Nodes-Kad actuals"
 
-#: src/muuli_wdr.cpp:1871
+#: src/muuli_wdr.cpp:1875
 msgid "Kad-nodes running"
 msgstr "Nodes-Kad funcionant"
 
-#: src/muuli_wdr.cpp:1872
+#: src/muuli_wdr.cpp:1876
 msgid "Kad-nodes session"
 msgstr "Nodes-Kad de la sessió"
 
-#: src/muuli_wdr.cpp:1876 src/muuli_wdr.cpp:2303
+#: src/muuli_wdr.cpp:1880 src/muuli_wdr.cpp:2334
 msgid "Select"
 msgstr "Selecciona"
 
-#: src/muuli_wdr.cpp:1880
+#: src/muuli_wdr.cpp:1884
 msgid "Tree"
 msgstr "Arbre"
 
-#: src/muuli_wdr.cpp:1890
+#: src/muuli_wdr.cpp:1894
 msgid "Number of Client Versions shown (0=unlimited)"
 msgstr "Nombre de versions de client a mostrar (0=il·limitat)"
 
-#: src/muuli_wdr.cpp:1915
+#: src/muuli_wdr.cpp:1919
 msgid "!!! WARNING !!!"
 msgstr "!!! AVÍS !!!"
 
-#: src/muuli_wdr.cpp:1930
+#: src/muuli_wdr.cpp:1934
 msgid "Max new connections / 5 secs"
 msgstr "Connexions noves màx. / 5 segs"
 
-#: src/muuli_wdr.cpp:1932
+#: src/muuli_wdr.cpp:1936
 msgid "Concurrent Kad source lookups"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1934
+#: src/muuli_wdr.cpp:1938
 #, fuzzy
 msgid "Kad source re-search interval (minutes)"
 msgstr "Interval d'actualització de l'FTP en minuts"
 
-#: src/muuli_wdr.cpp:1936
+#: src/muuli_wdr.cpp:1940
 #, fuzzy
 msgid "Source re-ask interval (minutes)"
 msgstr "Interval d'actualització de l'FTP en minuts"
 
-#: src/muuli_wdr.cpp:1940
+#: src/muuli_wdr.cpp:1944
 msgid "File Buffer Size: 240000 bytes"
 msgstr "Mida del buffer de fitxer: 240000 bytes"
 
-#: src/muuli_wdr.cpp:1944
+#: src/muuli_wdr.cpp:1948
 msgid "Use MMAP: memory-mapped file access (lower memory use)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1945
+#: src/muuli_wdr.cpp:1949
 msgid "Maps part files into memory instead of buffering them on the heap, lowering the process memory footprint. May reduce download speed on some disks; best for memory-constrained or upload-heavy hosts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1947
+#: src/muuli_wdr.cpp:1951
 msgid "Upload Queue Size: 5000 clients"
 msgstr "Mida de la cua de pujades: 5000 clients"
 
-#: src/muuli_wdr.cpp:1951
+#: src/muuli_wdr.cpp:1955
 msgid "Server connection refresh interval: Disable"
 msgstr "Interval de refresc de la connexió amb el servidor: Inhabilitat"
 
-#: src/muuli_wdr.cpp:1955
+#: src/muuli_wdr.cpp:1959
 msgid "Disable computer's timed standby mode"
 msgstr "Inhabilita el mode d'espera programat de l'ordinador"
 
-#: src/muuli_wdr.cpp:1974
+#: src/muuli_wdr.cpp:1978
 msgid "Skin to use: "
 msgstr "Aparença a usar: "
 
-#: src/muuli_wdr.cpp:1983
+#: src/muuli_wdr.cpp:1987
 msgid "Show \"Fast eD2k Links Handler\" in every window."
 msgstr "Mostra \"Gestor ràpid de links eD2k\" en totes les finestres."
 
-#: src/muuli_wdr.cpp:1986
+#: src/muuli_wdr.cpp:1990
 msgid "Show extended info on categories tabs"
 msgstr "Mostra informació estesa a les pestanyes de les categories"
 
-#: src/muuli_wdr.cpp:1989
+#: src/muuli_wdr.cpp:1993
 msgid "Show application version on title"
 msgstr "Mostra la versió de l'aplicació al títol"
 
-#: src/muuli_wdr.cpp:1991
+#: src/muuli_wdr.cpp:1995
 msgid "Show transfer rates on title"
 msgstr "Mostra les velocitats de transferència al títol"
 
-#: src/muuli_wdr.cpp:1993
+#: src/muuli_wdr.cpp:1997
 msgid "Before application name"
 msgstr "Abans del nom de l'aplicació"
 
-#: src/muuli_wdr.cpp:1995
+#: src/muuli_wdr.cpp:1999
 msgid "After application name"
 msgstr "Després del nom de l'aplicació"
 
-#: src/muuli_wdr.cpp:1998
+#: src/muuli_wdr.cpp:2002
 msgid "Show overhead bandwidth"
 msgstr "Mostra ample de banda sobrecarregat"
 
-#: src/muuli_wdr.cpp:2002
+#: src/muuli_wdr.cpp:2006
 msgid "Vertical toolbar orientation"
 msgstr "Orientació vertical de la barra d'eines"
 
-#: src/muuli_wdr.cpp:2004
+#: src/muuli_wdr.cpp:2008
 msgid "Live column sorting (auto-reorder rows as their values change)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2011
+#: src/muuli_wdr.cpp:2015
 msgid "Download Queue Files"
 msgstr "Cua de descàrregues"
 
-#: src/muuli_wdr.cpp:2014
+#: src/muuli_wdr.cpp:2018
 msgid "Show progress percentage"
 msgstr "Mostra el percentatge de descàrrega"
 
-#: src/muuli_wdr.cpp:2020
+#: src/muuli_wdr.cpp:2024
 msgid "Show progress bar"
 msgstr "Mostra barra de descàrrega"
 
-#: src/muuli_wdr.cpp:2023
+#: src/muuli_wdr.cpp:2027
 msgid "Flat"
 msgstr "Plana"
 
-#: src/muuli_wdr.cpp:2027
+#: src/muuli_wdr.cpp:2031
 msgid "Round"
 msgstr "Arrodonida"
 
-#: src/muuli_wdr.cpp:2045
+#: src/muuli_wdr.cpp:2049
 msgid "External Connection Parameters"
 msgstr "Paràmetres de la connexió externa "
 
-#: src/muuli_wdr.cpp:2048
+#: src/muuli_wdr.cpp:2052
 msgid "Accept external connections"
 msgstr "Accepta connexions externes"
 
-#: src/muuli_wdr.cpp:2055 src/muuli_wdr.cpp:2114
+#: src/muuli_wdr.cpp:2059 src/muuli_wdr.cpp:2118
 msgid "IP of the listening interface:"
 msgstr "IP de la interfície que rep connexions:"
 
-#: src/muuli_wdr.cpp:2058
+#: src/muuli_wdr.cpp:2062
 msgid "Enter here a valid ip in the a.b.c.d format for the listening EC interface. An empty field or 0.0.0.0 will mean any interface."
 msgstr "Introduïu una IP vàlida amb format a.b.c.d per a la interfície EC que escolta. Un camp buit o 0.0.0.0 significarà qualsevol interfície."
 
-#: src/muuli_wdr.cpp:2079 src/muuli_wdr.cpp:2163
+#: src/muuli_wdr.cpp:2083 src/muuli_wdr.cpp:2194
 msgid "TCP port:"
 msgstr "Port TCP:"
 
-#: src/muuli_wdr.cpp:2085
+#: src/muuli_wdr.cpp:2089
 msgid "Enable UPnP port forwarding on the EC port"
 msgstr "Activa l'encaminament UPnP al port de connexions externes"
 
-#: src/muuli_wdr.cpp:2089 src/muuli_wdr.cpp:3048
+#: src/muuli_wdr.cpp:2093 src/muuli_wdr.cpp:3079
 #: src/utils/wxCas/src/wxcasprefs.cpp:167
 msgid "Password"
 msgstr "Contrasenya"
 
-#: src/muuli_wdr.cpp:2095
+#: src/muuli_wdr.cpp:2099
 #, fuzzy
 msgid "aMule API server parameters"
 msgstr "Paràmetres del servidor web "
 
-#: src/muuli_wdr.cpp:2098
+#: src/muuli_wdr.cpp:2102
 msgid "Run amuleapi (REST API) on startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2103
+#: src/muuli_wdr.cpp:2107
 #, fuzzy
 msgid "HTTP port:"
 msgstr "Port TCP:"
 
-#: src/muuli_wdr.cpp:2117
+#: src/muuli_wdr.cpp:2121
 msgid "The interface amuleapi's HTTP server listens on. 127.0.0.1 (default) accepts only local connections; use 0.0.0.0 or a specific IP to expose it to other hosts (set an admin password below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2120
+#: src/muuli_wdr.cpp:2126
+msgid "Type a password to set or change it. Stored passwords cannot be shown, so leaving this empty keeps the current one."
+msgstr ""
+
+#: src/muuli_wdr.cpp:2128
 #, fuzzy
 msgid "Admin password"
 msgstr "S'està comprovant la contrasenya\n"
 
-#: src/muuli_wdr.cpp:2125 src/muuli_wdr.cpp:2156
-msgid "Low rights password"
-msgstr "Contrasenya del convidat:"
+#: src/muuli_wdr.cpp:2140 src/muuli_wdr.cpp:2157 src/PrefsUnifiedDlg.cpp:1103
+#, fuzzy
+msgid "A password is set."
+msgstr "S'està comprovant la contrasenya\n"
 
-#: src/muuli_wdr.cpp:2133
+#: src/muuli_wdr.cpp:2144
+#, fuzzy
+msgid "Enable guest access"
+msgstr "Denega l'accés de convidats"
+
+#: src/muuli_wdr.cpp:2145
+msgid "Guest sessions may read status and listings but cannot change anything. Turning this off clears the stored guest password."
+msgstr ""
+
+#: src/muuli_wdr.cpp:2149
+#, fuzzy
+msgid "Guest password"
+msgstr "Contrasenya de convidat per al servidor web"
+
+#: src/muuli_wdr.cpp:2164
 msgid "Web server parameters"
 msgstr "Paràmetres del servidor web "
 
-#: src/muuli_wdr.cpp:2136
+#: src/muuli_wdr.cpp:2167
 #, fuzzy
 msgid "Run webserver on startup (deprecated)"
 msgstr "Executa el servidor web a l'inici"
 
-#: src/muuli_wdr.cpp:2142
+#: src/muuli_wdr.cpp:2173
 msgid "Web template"
 msgstr "Plantilla web"
 
-#: src/muuli_wdr.cpp:2147
+#: src/muuli_wdr.cpp:2178
 msgid "Full rights password"
 msgstr "Contrasenya de l'administrador:"
 
-#: src/muuli_wdr.cpp:2151
+#: src/muuli_wdr.cpp:2182
 msgid "Enable Low rights User"
 msgstr "Habilita l'usuari convidat"
 
-#: src/muuli_wdr.cpp:2170
+#: src/muuli_wdr.cpp:2187
+msgid "Low rights password"
+msgstr "Contrasenya del convidat:"
+
+#: src/muuli_wdr.cpp:2201
 msgid "Enable UPnP port forwarding of the web server port"
 msgstr "Activa redirecció de ports UPnP en el port del servidor web"
 
-#: src/muuli_wdr.cpp:2175
+#: src/muuli_wdr.cpp:2206
 msgid "Web server UPnP TCP port (Optional)"
 msgstr "Port TCP del servidor web (Opcional):"
 
-#: src/muuli_wdr.cpp:2183
+#: src/muuli_wdr.cpp:2214
 msgid "Page Refresh Time (in secs)"
 msgstr "Temps de refresc de la pàgina (en segons):"
 
-#: src/muuli_wdr.cpp:2190
+#: src/muuli_wdr.cpp:2221
 msgid "Enable Gzip compression"
 msgstr "Habilita la compressió Gzip"
 
-#: src/muuli_wdr.cpp:2224
+#: src/muuli_wdr.cpp:2255
 #, fuzzy
 msgid "Reset page to defaults"
 msgstr "Predeterminat"
 
-#: src/muuli_wdr.cpp:2225
+#: src/muuli_wdr.cpp:2256
 msgid "Reset the settings on the current page to their default values."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2227 src/muuli_wdr.cpp:2313 src/ServerWnd.cpp:274
+#: src/muuli_wdr.cpp:2258 src/muuli_wdr.cpp:2344 src/ServerWnd.cpp:274
 #: src/ServerWnd.cpp:282
 msgid "OK"
 msgstr "OK"
 
-#: src/muuli_wdr.cpp:2229
+#: src/muuli_wdr.cpp:2260
 msgid "Click here to apply any changes made to the preferences."
 msgstr "Feu clic per a aplicar qualsevol canvi fet a les preferències."
 
-#: src/muuli_wdr.cpp:2232
+#: src/muuli_wdr.cpp:2263
 msgid "Reset any changes made to the preferences."
 msgstr "Reinicia qualsevol canvi fet a les preferències."
 
-#: src/muuli_wdr.cpp:2261
+#: src/muuli_wdr.cpp:2292
 msgid "Comment :"
 msgstr "Comentari:"
 
-#: src/muuli_wdr.cpp:2268
+#: src/muuli_wdr.cpp:2299
 msgid "Incoming Dir :"
 msgstr "Dir. d'entrada:"
 
-#: src/muuli_wdr.cpp:2277
+#: src/muuli_wdr.cpp:2308
 msgid "Change priority for new assigned files :"
 msgstr "Canvia la prioritat per als nous fitxers assignats:"
 
-#: src/muuli_wdr.cpp:2281
+#: src/muuli_wdr.cpp:2312
 msgid "Don't change"
 msgstr "No canviar"
 
-#: src/muuli_wdr.cpp:2293
+#: src/muuli_wdr.cpp:2324
 msgid "Select color for this Category (currently selected) :"
 msgstr "Seleccioneu un color per a la Categoria (actualment seleccionat):"
 
-#: src/muuli_wdr.cpp:2360 src/muuli_wdr.cpp:2379 src/muuli_wdr.cpp:2401
+#: src/muuli_wdr.cpp:2391 src/muuli_wdr.cpp:2410 src/muuli_wdr.cpp:2432
 msgid "Click this button to reset the log."
 msgstr "Feu clic per a reiniciar el registre."
 
-#: src/muuli_wdr.cpp:2420
+#: src/muuli_wdr.cpp:2451
 msgid "Click on this button to update the servers list from URL ..."
 msgstr "Feu clic en aquest botó per a actualitzar la llista de servidors des d'una URL ... "
 
-#: src/muuli_wdr.cpp:2424
+#: src/muuli_wdr.cpp:2455
 msgid "Server list"
 msgstr "Llista de servidors"
 
-#: src/muuli_wdr.cpp:2428
+#: src/muuli_wdr.cpp:2459
 msgid "Enter the url to a server.met file here and press the button to the left to update the list of known servers."
 msgstr "Introduïu l'adreça d'un fitxer server.met i premeu el botó de l'esquerra per a actualitzar la llista de servidors coneguts."
 
-#: src/muuli_wdr.cpp:2433
+#: src/muuli_wdr.cpp:2464
 msgid "Add server manually: Name"
 msgstr "Afegeix un servidor manualment: Nom"
 
-#: src/muuli_wdr.cpp:2436
+#: src/muuli_wdr.cpp:2467
 msgid "Enter the name of the new server here"
 msgstr "Introduïu el nom del nou servidor"
 
-#: src/muuli_wdr.cpp:2438 src/ServerWnd.cpp:206
+#: src/muuli_wdr.cpp:2469 src/ServerWnd.cpp:206
 msgid "IP:Port"
 msgstr "IP:Port"
 
-#: src/muuli_wdr.cpp:2441
+#: src/muuli_wdr.cpp:2472
 msgid "Enter the IP of the server here, using the x.x.x.x format."
 msgstr "Introduïu la IP del servidor, fent servir el format x.x.x.x."
 
-#: src/muuli_wdr.cpp:2447
+#: src/muuli_wdr.cpp:2478
 msgid "Enter the port of the server here."
 msgstr "Introduïu el port del servidor."
 
-#: src/muuli_wdr.cpp:2450
+#: src/muuli_wdr.cpp:2481
 msgid "Add manually a server (fill fields to the left before) ..."
 msgstr "Afegeix un servidor manualment (abans omple els camps de l'esquerra) ..."
 
-#: src/muuli_wdr.cpp:2479
+#: src/muuli_wdr.cpp:2510
 msgid "aMule Log"
 msgstr "Registre de l'aMule"
 
-#: src/muuli_wdr.cpp:2487
+#: src/muuli_wdr.cpp:2518
 msgid "Server Info"
 msgstr "Informació del servidor"
 
-#: src/muuli_wdr.cpp:2491
+#: src/muuli_wdr.cpp:2522
 msgid "ED2K Info"
 msgstr "Info. ED2K"
 
-#: src/muuli_wdr.cpp:2495
+#: src/muuli_wdr.cpp:2526
 msgid "Kad Info"
 msgstr "Info. Kad"
 
-#: src/muuli_wdr.cpp:2523
+#: src/muuli_wdr.cpp:2554
 msgid "Click on this button to update the nodes list from URL ..."
 msgstr "Feu clic en aquest botó per a actualitzar la llista de nodes des d'una URL ..."
 
-#: src/muuli_wdr.cpp:2527
+#: src/muuli_wdr.cpp:2558
 msgid "Nodes (0)"
 msgstr "Nodes (0)"
 
-#: src/muuli_wdr.cpp:2531
+#: src/muuli_wdr.cpp:2562
 msgid "Enter the url to a nodes.dat file here and press the button to the left to update the list of known nodes."
 msgstr "Introduïu la URL d'un fitxer nodes.dat i premeu el botó de l'esquerra per a actualitzar la llista de nodes coneguts."
 
-#: src/muuli_wdr.cpp:2534
+#: src/muuli_wdr.cpp:2565
 msgid "Nodes stats"
 msgstr "Estadístiques de nodes"
 
-#: src/muuli_wdr.cpp:2576
+#: src/muuli_wdr.cpp:2607
 msgid "Bootstrap"
 msgstr "Arrancada"
 
-#: src/muuli_wdr.cpp:2579
+#: src/muuli_wdr.cpp:2610
 msgid "New node"
 msgstr "Nou node"
 
-#: src/muuli_wdr.cpp:2584
+#: src/muuli_wdr.cpp:2615
 msgid "IP:"
 msgstr "IP:"
 
-#: src/muuli_wdr.cpp:2604
+#: src/muuli_wdr.cpp:2635
 msgid "Port:"
 msgstr "Port:"
 
-#: src/muuli_wdr.cpp:2617
+#: src/muuli_wdr.cpp:2648
 msgid "Bootstrap from known clients"
 msgstr "Inicia des dels clients coneguts"
 
-#: src/muuli_wdr.cpp:2619
+#: src/muuli_wdr.cpp:2650
 msgid "Disconnect Kad"
 msgstr "Desconnecta Kad"
 
-#: src/muuli_wdr.cpp:2653
+#: src/muuli_wdr.cpp:2684
 msgid "Use Secure User Identification"
 msgstr "Usa la Identificació Segura d'Usuari"
 
-#: src/muuli_wdr.cpp:2655
+#: src/muuli_wdr.cpp:2686
 msgid "It is recommended to enable this option. You will not receive credits if SUI is not enabled."
 msgstr "Es recomana activar aquesta opció. No rebreu crèdits (punts) si la Identificació Segura d'Usuari no és habilitada."
 
-#: src/muuli_wdr.cpp:2657
+#: src/muuli_wdr.cpp:2688
 msgid "Protocol Obfuscation"
 msgstr "Ofuscació de protocol"
 
-#: src/muuli_wdr.cpp:2660
+#: src/muuli_wdr.cpp:2691
 msgid "Support Protocol Obfuscation"
 msgstr "Suport per a l'ofuscació de protocol"
 
-#: src/muuli_wdr.cpp:2662
+#: src/muuli_wdr.cpp:2693
 msgid "This option enabled Protocol Obfuscation, and makes aMule accept obfuscated connections from other clients."
 msgstr "Habilita l'ofuscació de protocol, i permet a l'aMule acceptar connexions ofuscades d'altres clients."
 
-#: src/muuli_wdr.cpp:2664
+#: src/muuli_wdr.cpp:2695
 msgid "Use obfuscation for outgoing connections"
 msgstr "Usa l'ofuscació per a les connexions sortints"
 
-#: src/muuli_wdr.cpp:2666
+#: src/muuli_wdr.cpp:2697
 msgid "This option makes aMule use Protocol Obfuscation when connecting other clients/servers."
 msgstr "L'aMule usarà l'ofuscació de protocol en connectar amb altres clients/servidors."
 
-#: src/muuli_wdr.cpp:2668
+#: src/muuli_wdr.cpp:2699
 msgid "Accept only obfuscated connections"
 msgstr "Accepta únicament les connexions ofuscades"
 
-#: src/muuli_wdr.cpp:2669
+#: src/muuli_wdr.cpp:2700
 msgid "This option makes aMule only accept obfuscated connections. You will have less sources, but all your traffic will be obfuscated"
 msgstr "L'aMule només acceptarà les connexions ofuscades. Tindreu menys fonts, però tot el tràfic serà ofuscat"
 
-#: src/muuli_wdr.cpp:2674
+#: src/muuli_wdr.cpp:2705
 msgid "Everybody"
 msgstr "Tothom"
 
-#: src/muuli_wdr.cpp:2676
+#: src/muuli_wdr.cpp:2707
 msgid "No one"
 msgstr "Ningú"
 
-#: src/muuli_wdr.cpp:2678
+#: src/muuli_wdr.cpp:2709
 msgid "Who can see my shared files:"
 msgstr "Qui pot veure els meus fitxers compartits:"
 
-#: src/muuli_wdr.cpp:2679
+#: src/muuli_wdr.cpp:2710
 msgid "Select who can request to view a list of your shared files."
 msgstr "Selecciona qui pot veure la llista de fitxers compartits."
 
-#: src/muuli_wdr.cpp:2681
+#: src/muuli_wdr.cpp:2712
 msgid "IP-Filtering"
 msgstr "Filtratge IP"
 
-#: src/muuli_wdr.cpp:2688
+#: src/muuli_wdr.cpp:2719
 msgid "Filter clients"
 msgstr "Filtra els clients"
 
-#: src/muuli_wdr.cpp:2690
+#: src/muuli_wdr.cpp:2721
 msgid "Enable filtering of the client IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "Habilita el filtratge de les IP de clients especificades al fitxer ~/.aMule/ipfilter.dat."
 
-#: src/muuli_wdr.cpp:2692
+#: src/muuli_wdr.cpp:2723
 msgid "Filter servers"
 msgstr "Filtra els servidors"
 
-#: src/muuli_wdr.cpp:2694
+#: src/muuli_wdr.cpp:2725
 msgid "Enable filtering of the server IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "Habilita el filtratge de les IP de servidors especificades al fitxer ~/.aMule/ipfilter.dat."
 
-#: src/muuli_wdr.cpp:2698
+#: src/muuli_wdr.cpp:2729
 msgid "Reload List"
 msgstr "Recarrega la llista"
 
-#: src/muuli_wdr.cpp:2699
+#: src/muuli_wdr.cpp:2730
 msgid "Reload the list of IPs to filter from the file ~/.aMule/ipfilter.dat"
 msgstr "Recarrega la llista d'IPs a filtrar des del fitxer ~/.aMule/ipfilter.dat"
 
-#: src/muuli_wdr.cpp:2705
+#: src/muuli_wdr.cpp:2736
 msgid "URL:"
 msgstr "Adreça:"
 
-#: src/muuli_wdr.cpp:2709 src/muuli_wdr.cpp:2902
+#: src/muuli_wdr.cpp:2740 src/muuli_wdr.cpp:2933
 msgid "Update now"
 msgstr "Actualitza ara"
 
-#: src/muuli_wdr.cpp:2712
+#: src/muuli_wdr.cpp:2743
 msgid "Auto-update ipfilter at startup"
 msgstr "Actualitza automàticament a l'inici"
 
-#: src/muuli_wdr.cpp:2716
+#: src/muuli_wdr.cpp:2747
 msgid "Filtering Level:"
 msgstr "Nivell de filtratge:"
 
-#: src/muuli_wdr.cpp:2722
+#: src/muuli_wdr.cpp:2753
 msgid "Always filter LAN IPs"
 msgstr "Filtra sempre les IP LAN"
 
-#: src/muuli_wdr.cpp:2725
+#: src/muuli_wdr.cpp:2756
 msgid "Paranoid handling of non-matching IPs"
 msgstr "Gestió paranoica de les IP no corresponents"
 
-#: src/muuli_wdr.cpp:2727
+#: src/muuli_wdr.cpp:2758
 msgid "Rejects a packet when its source IP differs from the IP the client claims (an anti-spoofing check). Disable only if it causes connection problems."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2729
+#: src/muuli_wdr.cpp:2760
 msgid "Use system-wide ipfilter.dat if available"
 msgstr "Usa l'ipfilter.dat del sistema si està disponible"
 
-#: src/muuli_wdr.cpp:2730
+#: src/muuli_wdr.cpp:2761
 #, fuzzy
 msgid "If there's no local ipfilter.dat found, allow usage of a system-wide ipfilter file."
 msgstr "Si no es troba l'ipfilter.dat local, permet l'ús del fitxer ipfilter del sistema."
 
-#: src/muuli_wdr.cpp:2747
+#: src/muuli_wdr.cpp:2778
 msgid "Enable Online-Signature"
 msgstr "Habilita la signatura en línia"
 
-#: src/muuli_wdr.cpp:2749
+#: src/muuli_wdr.cpp:2780
 msgid "Enables the writing of the OS file, which can be used by external apps to create signatures and the like."
 msgstr "Habilita l'escriptura del fitxer de signatura, que altres aplicacions externes poden usar per a crear signatures i similars."
 
-#: src/muuli_wdr.cpp:2753
+#: src/muuli_wdr.cpp:2784
 msgid "Update Frequency (Secs):"
 msgstr "Freqüència d'actualització (segs):"
 
-#: src/muuli_wdr.cpp:2756
+#: src/muuli_wdr.cpp:2787
 msgid "Change the frequency (in seconds) of Online Signature updates."
 msgstr "Canvia la freqüència d'actualització (en segons) de la signatura en línia."
 
-#: src/muuli_wdr.cpp:2764
+#: src/muuli_wdr.cpp:2795
 msgid "Save online signature file in: "
 msgstr "Desa el fitxer de signatura en línia a: "
 
-#: src/muuli_wdr.cpp:2770
+#: src/muuli_wdr.cpp:2801
 msgid "Click here to select the directory containing the the Online Signature files."
 msgstr "Feu clic per a seleccionar el directori que conté els fitxers de signatura en línia."
 
-#: src/muuli_wdr.cpp:2803
+#: src/muuli_wdr.cpp:2834
 msgid "Show country flags for clients"
 msgstr "Mostra les banderes dels països per als clients"
 
-#: src/muuli_wdr.cpp:2804
+#: src/muuli_wdr.cpp:2835
 msgid "Render the country flag column in the transfers, queue and search views. Requires a valid MMDB GeoIP database (see below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2809
+#: src/muuli_wdr.cpp:2840
 #, fuzzy
 msgid "Database"
 msgstr "Velocitat:"
 
-#: src/muuli_wdr.cpp:2825
+#: src/muuli_wdr.cpp:2856
 #, fuzzy
 msgid "Source:"
 msgstr "Fonts"
 
-#: src/muuli_wdr.cpp:2828
+#: src/muuli_wdr.cpp:2859
 msgid "DB-IP (free, no account)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2829
+#: src/muuli_wdr.cpp:2860
 msgid "MaxMind GeoLite2 (free, account required)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2830
+#: src/muuli_wdr.cpp:2861
 msgid "Custom URL"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2833
+#: src/muuli_wdr.cpp:2864
 msgid "Choose which provider supplies the GeoIP MMDB database. DB-IP is the default - no account required. MaxMind requires a free account + license key. Use Custom URL to point at any other MMDB host (e.g. a local mirror)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2850
+#: src/muuli_wdr.cpp:2881
 msgid ""
 "No configuration required.\n"
 "\n"
@@ -4852,11 +4880,11 @@ msgid ""
 "License: Creative Commons BY 4.0 - https://creativecommons.org/licenses/by/4.0/"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2863
+#: src/muuli_wdr.cpp:2894
 msgid "License key:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2869
+#: src/muuli_wdr.cpp:2900
 msgid ""
 "Sign up for a free MaxMind account, then generate a License Key:\n"
 "https://www.maxmind.com/en/geolite2/signup\n"
@@ -4866,225 +4894,225 @@ msgid ""
 "Requires attribution and account registration; refresh at least every 30 days."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2884
+#: src/muuli_wdr.cpp:2915
 #, fuzzy
 msgid "Download URL:"
 msgstr "Baixant: "
 
-#: src/muuli_wdr.cpp:2890
+#: src/muuli_wdr.cpp:2921
 msgid ""
 "Must point to an .mmdb file or a .gz / .tar.gz containing one.\n"
 "URL may include credentials (https://user:pass@host/...).\n"
 "License and attribution terms are set by the upstream URL - you are responsible."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2903
+#: src/muuli_wdr.cpp:2934
 msgid "Download the GeoIP database from the selected source."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2905
+#: src/muuli_wdr.cpp:2936
 #, fuzzy
 msgid "Auto-update on startup"
 msgstr "Actualitza automàticament a l'inici"
 
-#: src/muuli_wdr.cpp:2906
+#: src/muuli_wdr.cpp:2937
 msgid "Re-download the GeoIP database from the selected source every time aMule starts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2929
+#: src/muuli_wdr.cpp:2960
 msgid "Filter incoming messages (except current chat):"
 msgstr "Filtra els missatges entrants (excepte el xat actual):"
 
-#: src/muuli_wdr.cpp:2931
+#: src/muuli_wdr.cpp:2962
 msgid "Filter all messages"
 msgstr "Filtra tots els missatges"
 
-#: src/muuli_wdr.cpp:2933
+#: src/muuli_wdr.cpp:2964
 msgid "Filter messages from people not on your friend list"
 msgstr "Filtra els missatges de la gent que no és a la llista d'amics"
 
-#: src/muuli_wdr.cpp:2935
+#: src/muuli_wdr.cpp:2966
 msgid "Filter messages from unknown clients"
 msgstr "Filtra els missatges dels clients desconeguts"
 
-#: src/muuli_wdr.cpp:2937
+#: src/muuli_wdr.cpp:2968
 msgid "Filter messages containing (use ',' as separator):"
 msgstr "Filtra els missatges que continguin (useu ',' per a separar):"
 
-#: src/muuli_wdr.cpp:2940 src/muuli_wdr.cpp:2951
+#: src/muuli_wdr.cpp:2971 src/muuli_wdr.cpp:2982
 msgid "add here the words amule should filter and block messages including it"
 msgstr "Els missatges que continguin aquestes paraules seran filtrats i bloquejats per l'aMule"
 
-#: src/muuli_wdr.cpp:2942
+#: src/muuli_wdr.cpp:2973
 msgid "Show received messages in the log"
 msgstr "Mostra els missatges rebuts en el registre"
 
-#: src/muuli_wdr.cpp:2945
+#: src/muuli_wdr.cpp:2976
 msgid "Comments"
 msgstr "Comentaris"
 
-#: src/muuli_wdr.cpp:2948
+#: src/muuli_wdr.cpp:2979
 msgid "Filter comments containing (use ',' as separator):"
 msgstr "Filtra els comentaris que continguin (useu ',' per a separar):"
 
-#: src/muuli_wdr.cpp:2973
+#: src/muuli_wdr.cpp:3004
 msgid "Enable Proxy"
 msgstr "Habilita el servidor intermediari"
 
-#: src/muuli_wdr.cpp:2974
+#: src/muuli_wdr.cpp:3005
 msgid "Enable/disable proxy support"
 msgstr "Habilita/inhabilita el suport per a servidor intermediari"
 
-#: src/muuli_wdr.cpp:2977
+#: src/muuli_wdr.cpp:3008
 msgid "Proxy type:"
 msgstr "Tipus de servidor:"
 
-#: src/muuli_wdr.cpp:2988
+#: src/muuli_wdr.cpp:3019
 msgid "Proxy host:"
 msgstr "Servidor intermediari:"
 
-#: src/muuli_wdr.cpp:2991
+#: src/muuli_wdr.cpp:3022
 msgid "The proxy host name"
 msgstr "El nom del servidor intermediari"
 
-#: src/muuli_wdr.cpp:2993
+#: src/muuli_wdr.cpp:3024
 msgid "Proxy port:"
 msgstr "Port del servidor:"
 
-#: src/muuli_wdr.cpp:2996
+#: src/muuli_wdr.cpp:3027
 msgid "The proxy port"
 msgstr "El port del servidor intermediari"
 
-#: src/muuli_wdr.cpp:2998
+#: src/muuli_wdr.cpp:3029
 msgid "Enable authentication"
 msgstr "Habilita l'autenticació"
 
-#: src/muuli_wdr.cpp:2999
+#: src/muuli_wdr.cpp:3030
 msgid "Enable/disable username/password authentication"
 msgstr "Habilita/inhabilita l'autenticació amb usuari/contrasenya"
 
-#: src/muuli_wdr.cpp:3002
+#: src/muuli_wdr.cpp:3033
 msgid "Username: "
 msgstr "Nom d'usuari:"
 
-#: src/muuli_wdr.cpp:3005
+#: src/muuli_wdr.cpp:3036
 msgid "The username to use to connect to the proxy"
 msgstr "El nom d'usuari per a connectar al servidor intermediari"
 
-#: src/muuli_wdr.cpp:3007
+#: src/muuli_wdr.cpp:3038
 msgid "Password:"
 msgstr "Contrasenya:"
 
-#: src/muuli_wdr.cpp:3010
+#: src/muuli_wdr.cpp:3041
 msgid "The password to use to connect to the proxy"
 msgstr "La contrasenya per a connectar al servidor intermediari"
 
-#: src/muuli_wdr.cpp:3029
+#: src/muuli_wdr.cpp:3060
 msgid "Connect to:"
 msgstr "Connecta a:"
 
-#: src/muuli_wdr.cpp:3038
+#: src/muuli_wdr.cpp:3069
 msgid "Login to remote amule"
 msgstr "Entra a l'aMule remot"
 
-#: src/muuli_wdr.cpp:3043
+#: src/muuli_wdr.cpp:3074
 msgid "User name"
 msgstr "Nom d'usuari"
 
-#: src/muuli_wdr.cpp:3054
+#: src/muuli_wdr.cpp:3085
 msgid "Remember those settings"
 msgstr "Recorda la configuració"
 
-#: src/muuli_wdr.cpp:3057
+#: src/muuli_wdr.cpp:3088
 #, fuzzy
 msgid "Force ZLIB compression"
 msgstr "Usa la compressió gzip"
 
-#: src/muuli_wdr.cpp:3081
+#: src/muuli_wdr.cpp:3112
 msgid "Enable Verbose Debug-Logging."
 msgstr "Habilita la depuració-registre detallats."
 
-#: src/muuli_wdr.cpp:3083
+#: src/muuli_wdr.cpp:3114
 msgid "Only to Logfile"
 msgstr "Només al fitxer de registre"
 
-#: src/muuli_wdr.cpp:3085
+#: src/muuli_wdr.cpp:3116
 msgid "Message Categories:"
 msgstr "Categories de missatge:"
 
-#: src/muuli_wdr.cpp:3109 src/PartFileConvertDlg.cpp:160
+#: src/muuli_wdr.cpp:3140 src/PartFileConvertDlg.cpp:160
 msgid "Waiting..."
 msgstr "Esperant..."
 
-#: src/muuli_wdr.cpp:3129
+#: src/muuli_wdr.cpp:3160
 msgid "Add imports"
 msgstr "Afegeix"
 
-#: src/muuli_wdr.cpp:3132
+#: src/muuli_wdr.cpp:3163
 msgid "Retry selected"
 msgstr "Reintenta"
 
-#: src/muuli_wdr.cpp:3134
+#: src/muuli_wdr.cpp:3165
 msgid "Remove selected"
 msgstr "Esborra"
 
-#: src/muuli_wdr.cpp:3197
+#: src/muuli_wdr.cpp:3228
 msgid "Event Types"
 msgstr "Tipus d'esdeveniments"
 
-#: src/muuli_wdr.cpp:3216
+#: src/muuli_wdr.cpp:3247
 msgid "Statistics and queued clients for selected file(s) : Session / All time"
 msgstr "Estadístiques i clients en cua per als fitxers seleccionats: Sessió / Total"
 
-#: src/muuli_wdr.cpp:3240
+#: src/muuli_wdr.cpp:3271
 msgid "Active Uploads"
 msgstr "Pujades actives"
 
-#: src/muuli_wdr.cpp:3254
+#: src/muuli_wdr.cpp:3285
 msgid "Percent of total files"
 msgstr "Percentatge del total de fitxers"
 
-#: src/muuli_wdr.cpp:3306
+#: src/muuli_wdr.cpp:3337
 msgid "Show Clients for"
 msgstr "Mostra els clients per"
 
-#: src/muuli_wdr.cpp:3308
+#: src/muuli_wdr.cpp:3339
 msgid "All files"
 msgstr "Tots els fitxers"
 
-#: src/muuli_wdr.cpp:3311
+#: src/muuli_wdr.cpp:3342
 msgid "Selected files"
 msgstr "Fitxers seleccionats"
 
-#: src/muuli_wdr.cpp:3314
+#: src/muuli_wdr.cpp:3345
 msgid "Active uploads only"
 msgstr "Només pujades actives"
 
-#: src/muuli_wdr.cpp:3321
+#: src/muuli_wdr.cpp:3352
 msgid "Reload:"
 msgstr "Recarrega:"
 
-#: src/muuli_wdr.cpp:3325
+#: src/muuli_wdr.cpp:3356
 msgid "Reload your shared files"
 msgstr "Recarrega els compartits"
 
-#: src/muuli_wdr.cpp:3388
+#: src/muuli_wdr.cpp:3419
 msgid "Send"
 msgstr "Envia"
 
-#: src/muuli_wdr.cpp:3389
+#: src/muuli_wdr.cpp:3420
 msgid "Sends the specified message."
 msgstr "Envia el missatge especificat."
 
-#: src/muuli_wdr.cpp:3393
+#: src/muuli_wdr.cpp:3424
 msgid "Close this chat-session."
 msgstr "Tanca aquesta sessió de xat."
 
-#: src/muuli_wdr.cpp:3416
+#: src/muuli_wdr.cpp:3447
 msgid "Connect to any server and/or Kad"
 msgstr "Connecta amb qualsevol servidor i/o Kad"
 
-#: src/muuli_wdr.cpp:3422 src/SharedFilesCtrl.cpp:142 src/Statistics.cpp:941
+#: src/muuli_wdr.cpp:3453 src/SharedFilesCtrl.cpp:142 src/Statistics.cpp:941
 msgid "Shared Files"
 msgstr "Compartits"
 
@@ -5445,249 +5473,249 @@ msgstr "Baixat"
 msgid "ERROR: Failed to open partfile '%s'"
 msgstr "ERROR: No s'ha pogut obrir el fitxer part '%s'"
 
-#: src/Preferences.cpp:674
+#: src/Preferences.cpp:701
 msgid "System default"
 msgstr "Predeterminat"
 
-#: src/Preferences.cpp:675
+#: src/Preferences.cpp:702
 msgid "Albanian"
 msgstr "Albanès"
 
-#: src/Preferences.cpp:676
+#: src/Preferences.cpp:703
 msgid "Arabic"
 msgstr "Àrab"
 
-#: src/Preferences.cpp:677
+#: src/Preferences.cpp:704
 msgid "Asturian"
 msgstr "Asturià"
 
-#: src/Preferences.cpp:678
+#: src/Preferences.cpp:705
 msgid "Basque"
 msgstr "Basc"
 
-#: src/Preferences.cpp:679
+#: src/Preferences.cpp:706
 msgid "Bulgarian"
 msgstr "Búlgar"
 
-#: src/Preferences.cpp:680
+#: src/Preferences.cpp:707
 msgid "Catalan"
 msgstr "Català; Valencià"
 
-#: src/Preferences.cpp:681
+#: src/Preferences.cpp:708
 msgid "Chinese (Simplified)"
 msgstr "Xinès (Simplificat)"
 
-#: src/Preferences.cpp:682
+#: src/Preferences.cpp:709
 msgid "Chinese (Traditional)"
 msgstr "Xinès (Tradicional)"
 
-#: src/Preferences.cpp:683
+#: src/Preferences.cpp:710
 msgid "Croatian"
 msgstr "Croat"
 
-#: src/Preferences.cpp:684
+#: src/Preferences.cpp:711
 msgid "Czech"
 msgstr "Txec"
 
-#: src/Preferences.cpp:685
+#: src/Preferences.cpp:712
 msgid "Danish"
 msgstr "Danès"
 
-#: src/Preferences.cpp:686
+#: src/Preferences.cpp:713
 msgid "Dutch"
 msgstr "Holandès"
 
-#: src/Preferences.cpp:687
+#: src/Preferences.cpp:714
 msgid "English (U.K.)"
 msgstr "Anglès (R.U.)"
 
-#: src/Preferences.cpp:688
+#: src/Preferences.cpp:715
 #, fuzzy
 msgid "English (U.S.)"
 msgstr "Anglès (R.U.)"
 
-#: src/Preferences.cpp:689
+#: src/Preferences.cpp:716
 msgid "Estonian"
 msgstr "Estonià"
 
-#: src/Preferences.cpp:690
+#: src/Preferences.cpp:717
 msgid "Finnish"
 msgstr "Finès"
 
-#: src/Preferences.cpp:691
+#: src/Preferences.cpp:718
 msgid "French"
 msgstr "Francès"
 
-#: src/Preferences.cpp:692
+#: src/Preferences.cpp:719
 msgid "Galician"
 msgstr "Gallec"
 
-#: src/Preferences.cpp:693
+#: src/Preferences.cpp:720
 msgid "German"
 msgstr "Alemany"
 
-#: src/Preferences.cpp:694
+#: src/Preferences.cpp:721
 msgid "Greek"
 msgstr "Grec"
 
-#: src/Preferences.cpp:695
+#: src/Preferences.cpp:722
 msgid "Hebrew"
 msgstr "Hebreu"
 
-#: src/Preferences.cpp:696
+#: src/Preferences.cpp:723
 msgid "Hungarian"
 msgstr "Hongarès"
 
-#: src/Preferences.cpp:697
+#: src/Preferences.cpp:724
 msgid "Italian"
 msgstr "Italià"
 
-#: src/Preferences.cpp:698
+#: src/Preferences.cpp:725
 msgid "Japanese"
 msgstr "Japonès"
 
-#: src/Preferences.cpp:699
+#: src/Preferences.cpp:726
 msgid "Korean"
 msgstr "Coreà"
 
-#: src/Preferences.cpp:700
+#: src/Preferences.cpp:727
 msgid "Latvian"
 msgstr ""
 
-#: src/Preferences.cpp:701
+#: src/Preferences.cpp:728
 msgid "Lithuanian"
 msgstr "Lituà"
 
-#: src/Preferences.cpp:702
+#: src/Preferences.cpp:729
 msgid "Norwegian (Nynorsk)"
 msgstr "Noruec"
 
-#: src/Preferences.cpp:703
+#: src/Preferences.cpp:730
 msgid "Polish"
 msgstr "Polonès"
 
-#: src/Preferences.cpp:704
+#: src/Preferences.cpp:731
 msgid "Portuguese"
 msgstr "Portuguès"
 
-#: src/Preferences.cpp:705
+#: src/Preferences.cpp:732
 msgid "Portuguese (Brazilian)"
 msgstr "Portuguès (Brasil)"
 
-#: src/Preferences.cpp:706
+#: src/Preferences.cpp:733
 msgid "Romanian"
 msgstr "Romanès"
 
-#: src/Preferences.cpp:707
+#: src/Preferences.cpp:734
 msgid "Russian"
 msgstr "Rus"
 
-#: src/Preferences.cpp:708
+#: src/Preferences.cpp:735
 msgid "Slovenian"
 msgstr "Eslovè"
 
-#: src/Preferences.cpp:709
+#: src/Preferences.cpp:736
 msgid "Spanish"
 msgstr "Espanyol; Castellà"
 
-#: src/Preferences.cpp:710
+#: src/Preferences.cpp:737
 msgid "Swedish"
 msgstr "Suec"
 
-#: src/Preferences.cpp:711
+#: src/Preferences.cpp:738
 msgid "Turkish"
 msgstr "Turc"
 
-#: src/Preferences.cpp:712
+#: src/Preferences.cpp:739
 msgid "Ukrainian"
 msgstr "Ucranià"
 
-#: src/Preferences.cpp:815
+#: src/Preferences.cpp:842
 msgid "Change Language"
 msgstr "Canvi d'idioma"
 
-#: src/Preferences.cpp:879
+#: src/Preferences.cpp:906
 msgid "There are no translations installed for aMule"
 msgstr "No hi ha traduccions instal·lades per a l'aMule"
 
-#: src/Preferences.cpp:880
+#: src/Preferences.cpp:907
 msgid "No languages available"
 msgstr "Sense idiomes disponibles"
 
-#: src/Preferences.cpp:1011
+#: src/Preferences.cpp:1038
 msgid "no options available"
 msgstr "No hi ha opcions disponibles"
 
-#: src/Preferences.cpp:2182
+#: src/Preferences.cpp:2227
 msgid "Invalid category found, skipping"
 msgstr "Categoria invàlida trobada, omitint"
 
-#: src/Preferences.cpp:2351
+#: src/Preferences.cpp:2396
 msgid "TCP port can't be higher than 65532 due to server UDP socket being TCP+3"
 msgstr "El port TCP no pot ser més gran que 65532 puix el sòcol UDP del servidor és TCP+3"
 
-#: src/Preferences.cpp:2352
+#: src/Preferences.cpp:2397
 #, c-format
 msgid "Default port will be used (%d)"
 msgstr "S'usarà el port per defecte (%d)"
 
-#: src/PrefsUnifiedDlg.cpp:298 src/Statistics.cpp:866
+#: src/PrefsUnifiedDlg.cpp:300 src/Statistics.cpp:866
 msgid "Connection"
 msgstr "Connexió"
 
-#: src/PrefsUnifiedDlg.cpp:299 src/SearchListCtrl.cpp:117
+#: src/PrefsUnifiedDlg.cpp:301 src/SearchListCtrl.cpp:117
 msgid "Directories"
 msgstr "Directoris"
 
-#: src/PrefsUnifiedDlg.cpp:300 src/Statistics.cpp:917
+#: src/PrefsUnifiedDlg.cpp:302 src/Statistics.cpp:917
 msgid "Servers"
 msgstr "Servidors"
 
-#: src/PrefsUnifiedDlg.cpp:301 src/ServerListCtrl.cpp:96
+#: src/PrefsUnifiedDlg.cpp:303 src/ServerListCtrl.cpp:96
 msgid "Files"
 msgstr "Fitxers"
 
-#: src/PrefsUnifiedDlg.cpp:302
+#: src/PrefsUnifiedDlg.cpp:304
 msgid "Security"
 msgstr "Seguretat"
 
-#: src/PrefsUnifiedDlg.cpp:303
+#: src/PrefsUnifiedDlg.cpp:305
 msgid "Interface"
 msgstr "Interfície"
 
-#: src/PrefsUnifiedDlg.cpp:310
+#: src/PrefsUnifiedDlg.cpp:312
 msgid "IP2Country"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:313
+#: src/PrefsUnifiedDlg.cpp:315
 msgid "Proxy"
 msgstr "Servidor intermediari"
 
-#: src/PrefsUnifiedDlg.cpp:314
+#: src/PrefsUnifiedDlg.cpp:316
 msgid "Filters"
 msgstr "Filtres"
 
-#: src/PrefsUnifiedDlg.cpp:315
+#: src/PrefsUnifiedDlg.cpp:317
 msgid "Remote Controls"
 msgstr "Control remot"
 
-#: src/PrefsUnifiedDlg.cpp:316
+#: src/PrefsUnifiedDlg.cpp:318
 msgid "Online Signature"
 msgstr "Signatura en línia"
 
-#: src/PrefsUnifiedDlg.cpp:317
+#: src/PrefsUnifiedDlg.cpp:319
 msgid "Advanced"
 msgstr "Avançat"
 
-#: src/PrefsUnifiedDlg.cpp:318
+#: src/PrefsUnifiedDlg.cpp:320
 msgid "Events"
 msgstr "Esdeveniments"
 
-#: src/PrefsUnifiedDlg.cpp:321
+#: src/PrefsUnifiedDlg.cpp:323
 msgid "Debugging"
 msgstr "Depuració"
 
-#: src/PrefsUnifiedDlg.cpp:451
+#: src/PrefsUnifiedDlg.cpp:453
 msgid ""
 "The following variables will be substituted:\n"
 "    %PARTFILE - full path to the file\n"
@@ -5697,15 +5725,15 @@ msgstr ""
 "    %PARTFILE - camí complet al fitxer\n"
 "    %PARTNAME - només el nom del fitxer"
 
-#: src/PrefsUnifiedDlg.cpp:472
+#: src/PrefsUnifiedDlg.cpp:474
 msgid "Tray icon support requires libayatana-appindicator3 at compile time."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:488
+#: src/PrefsUnifiedDlg.cpp:490
 msgid "Not available on Wayland: the protocol does not report when a window is minimized, so this option cannot intercept the system minimize button. Workaround: launch aMule with `GDK_BACKEND=x11` to use XWayland instead."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:534
+#: src/PrefsUnifiedDlg.cpp:536
 msgid ""
 "Do not change these setting unless you know\n"
 "what you are doing, otherwise you can easily\n"
@@ -5721,26 +5749,35 @@ msgstr ""
 "L'aMule anirà bé sense canviar cap\n"
 "d'aquests paràmetres."
 
-#: src/PrefsUnifiedDlg.cpp:645
+#: src/PrefsUnifiedDlg.cpp:647
 #, c-format
 msgid "Failed to connect Cfg to widget with the ID %d and key %s"
 msgstr "Connexió fallida entre Cfg i el giny amb ID %d i clau %s"
 
-#: src/PrefsUnifiedDlg.cpp:693
+#: src/PrefsUnifiedDlg.cpp:695
 #, c-format
 msgid "Failed to transfer data from Cfg to Widget with the ID %d and key %s"
 msgstr "Fallida en l'enviament de dades de Cfg al giny amb ID %d i clau %s"
 
-#: src/PrefsUnifiedDlg.cpp:799
+#: src/PrefsUnifiedDlg.cpp:801
 msgid "The type of proxy you are connecting to"
 msgstr "El tipus de servidor intermediari al que connecteu"
 
-#: src/PrefsUnifiedDlg.cpp:1003
+#: src/PrefsUnifiedDlg.cpp:1020
 #, c-format
 msgid "Failed to transfer data from Widget to Cfg with the ID %d and key %s"
 msgstr "Fallida en l'enviament de dades del giny al Cfg amb ID %d i clau %s"
 
 #: src/PrefsUnifiedDlg.cpp:1103
+#, fuzzy
+msgid "No password set."
+msgstr "S'està comprovant la contrasenya\n"
+
+#: src/PrefsUnifiedDlg.cpp:1132
+msgid "Guest access needs a password. Type one in the guest password field, or untick Enable guest access."
+msgstr ""
+
+#: src/PrefsUnifiedDlg.cpp:1144
 msgid ""
 "aMule must be restarted to enable these changes:\n"
 "\n"
@@ -5748,41 +5785,41 @@ msgstr ""
 "S'ha de reiniciar l'aMule per a habilitar aquests canvis:\n"
 "\n"
 
-#: src/PrefsUnifiedDlg.cpp:1110
+#: src/PrefsUnifiedDlg.cpp:1151
 msgid "- TCP port changed.\n"
 msgstr "- El port TCP ha canviat.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1115
+#: src/PrefsUnifiedDlg.cpp:1156
 msgid "- UDP port changed.\n"
 msgstr "- El port UDP ha canviat.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1120
+#: src/PrefsUnifiedDlg.cpp:1161
 #, fuzzy
 msgid "- Network interface binding changed.\n"
 msgstr "- S'ha canviat la interfície de connexió externa.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1125
+#: src/PrefsUnifiedDlg.cpp:1166
 msgid "- External connect port changed.\n"
 msgstr "- S'ha canviat el port de connexió externa.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1129
+#: src/PrefsUnifiedDlg.cpp:1170
 msgid "- External connect acceptance changed.\n"
 msgstr "- S'ha canviat l'acceptació de la connexió externa.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1133
+#: src/PrefsUnifiedDlg.cpp:1174
 msgid "- External connect interface changed.\n"
 msgstr "- S'ha canviat la interfície de connexió externa.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1137
+#: src/PrefsUnifiedDlg.cpp:1178
 msgid "- Protocol obfuscation support changed.\n"
 msgstr "- S'ha canviat el suport d'ofuscació de protocol.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1151
+#: src/PrefsUnifiedDlg.cpp:1193
 #, fuzzy
 msgid "- amuleapi settings changed.\n"
 msgstr "- L'idioma ha canviat.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1160
+#: src/PrefsUnifiedDlg.cpp:1202
 msgid ""
 "Your Auto-update server list is empty.\n"
 "'Auto-update server list at startup' will be disabled."
@@ -5790,7 +5827,7 @@ msgstr ""
 "La llista d'actualització de servidors és buida.\n"
 "L'actualització de servidors a l'inici serà desactivada."
 
-#: src/PrefsUnifiedDlg.cpp:1171
+#: src/PrefsUnifiedDlg.cpp:1213
 msgid ""
 "You have enabled external connections but have not specified a password.\n"
 "External connections cannot be enabled unless a valid password is specified."
@@ -5798,28 +5835,33 @@ msgstr ""
 "Heu habilitat les connexions externes però no heu especificat una contrasenya.\n"
 "Les connexions externes no poden ser habilitades a menys que s'hagi especificat una contrasenya externa vàlida."
 
-#: src/PrefsUnifiedDlg.cpp:1202
+#: src/PrefsUnifiedDlg.cpp:1246
+#, c-format
+msgid "The amuleapi password could not be saved: %s"
+msgstr ""
+
+#: src/PrefsUnifiedDlg.cpp:1276
 msgid "- Language changed.\n"
 msgstr "- L'idioma ha canviat.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1207
+#: src/PrefsUnifiedDlg.cpp:1281
 msgid "- Temp folder changed.\n"
 msgstr "- El directori temporal ha canviat.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1212
+#: src/PrefsUnifiedDlg.cpp:1286
 msgid "- ED2K network enabled.\n"
 msgstr "- Xarxa ED2K habilitada.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1245
+#: src/PrefsUnifiedDlg.cpp:1319
 msgid "The shared-file exclusion pattern is not a valid regular expression. The filter has been left disabled."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1247 src/PrefsUnifiedDlg.cpp:1841
+#: src/PrefsUnifiedDlg.cpp:1321 src/PrefsUnifiedDlg.cpp:1921
 #, fuzzy
 msgid "Invalid regular expression"
 msgstr "Versió del protocol invàlida."
 
-#: src/PrefsUnifiedDlg.cpp:1324
+#: src/PrefsUnifiedDlg.cpp:1398
 msgid ""
 "Both eD2k and Kad network are disabled.\n"
 "You won't be able to connect until you enable at least one of them."
@@ -5827,7 +5869,7 @@ msgstr ""
 "Les xarxes eD2k i Kad estan inhabilitades.\n"
 "No podreu connectar fins que n'habiliteu almenys una."
 
-#: src/PrefsUnifiedDlg.cpp:1329
+#: src/PrefsUnifiedDlg.cpp:1403
 msgid ""
 "Kad will not start if your UDP port is disabled.\n"
 "Enable UDP port or disable Kad."
@@ -5835,7 +5877,7 @@ msgstr ""
 "La xarxa Kad no s'engegarà si el port UDP està inhabilitat.\n"
 "Habiliteu el port UDP o inhabiliteu la xarxa Kad."
 
-#: src/PrefsUnifiedDlg.cpp:1385
+#: src/PrefsUnifiedDlg.cpp:1459
 msgid ""
 "\n"
 "You MUST restart aMule now.\n"
@@ -5845,69 +5887,69 @@ msgstr ""
 "HEU de reiniciar l'aMule ara mateix.\n"
 "Si no reinicieu ara, no vos queixeu dels possibles problemes.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1450
+#: src/PrefsUnifiedDlg.cpp:1524
 msgid "Could not register aMule for autostart at login. The autostart store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1452
+#: src/PrefsUnifiedDlg.cpp:1526
 msgid "Could not remove the autostart-at-login entry."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1453
+#: src/PrefsUnifiedDlg.cpp:1527
 #, fuzzy
 msgid "Autostart"
 msgstr "Autorefresc iniciat"
 
-#: src/PrefsUnifiedDlg.cpp:1468
+#: src/PrefsUnifiedDlg.cpp:1542
 msgid "Register file type"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1468
+#: src/PrefsUnifiedDlg.cpp:1542
 msgid "Register URL handler"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1476
+#: src/PrefsUnifiedDlg.cpp:1550
 #, c-format
 msgid "aMule only handles eD2k-compatible magnets. If you replace the current magnet handler (%s), BitTorrent magnet links will stop working - aMule cannot download BitTorrent content. Continue?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1481
+#: src/PrefsUnifiedDlg.cpp:1555
 #, c-format
 msgid "Another application currently opens .emulecollection files (%s). Replace it with aMule?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1486
+#: src/PrefsUnifiedDlg.cpp:1560
 #, c-format
 msgid "Another application is currently the default handler for these links (%s). Replace it with aMule?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1511
+#: src/PrefsUnifiedDlg.cpp:1585
 msgid "Could not register aMule for .emulecollection files. The registration store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1513
+#: src/PrefsUnifiedDlg.cpp:1587
 #, fuzzy
 msgid "Could not remove the file type registration."
 msgstr "Carpeta on desar les descàrregues temporals"
 
-#: src/PrefsUnifiedDlg.cpp:1515
+#: src/PrefsUnifiedDlg.cpp:1589
 msgid "Could not register aMule as the URL handler. The registration store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1517
+#: src/PrefsUnifiedDlg.cpp:1591
 msgid "Could not remove the URL handler registration."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1587 src/PrefsUnifiedDlg.cpp:1614
+#: src/PrefsUnifiedDlg.cpp:1661 src/PrefsUnifiedDlg.cpp:1688
 #, fuzzy
 msgid "The web server and aMule API require external connections to be enabled."
 msgstr "Contrassenya definida i connexions externes activades."
 
-#: src/PrefsUnifiedDlg.cpp:1597
+#: src/PrefsUnifiedDlg.cpp:1671
 msgid "The aMule web server is deprecated. Consider running the aMule API instead."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1655
+#: src/PrefsUnifiedDlg.cpp:1735
 msgid ""
 "Your Auto-update servers list is in blank.\n"
 "Please fill in at least one URL to point to a valid server.met file.\n"
@@ -5917,66 +5959,66 @@ msgstr ""
 "Si us plau, ompliu-la amb una URL que apunti a un fitxer server.met vàlid.\n"
 "Feu clic sobre el botó \"Llista\" d'aquest quadre de verificació per afegir una adreça."
 
-#: src/PrefsUnifiedDlg.cpp:1796
+#: src/PrefsUnifiedDlg.cpp:1876
 msgid "Temporary files"
 msgstr "Fitxers temporals"
 
-#: src/PrefsUnifiedDlg.cpp:1801
+#: src/PrefsUnifiedDlg.cpp:1881
 msgid "Incoming files"
 msgstr "Fitxers entrants"
 
-#: src/PrefsUnifiedDlg.cpp:1806
+#: src/PrefsUnifiedDlg.cpp:1886
 msgid "Online Signatures"
 msgstr "Signatures en línia"
 
-#: src/PrefsUnifiedDlg.cpp:1819
+#: src/PrefsUnifiedDlg.cpp:1899
 #, c-format
 msgid "Choose a folder for %s"
 msgstr "Carpeta per a %s"
 
-#: src/PrefsUnifiedDlg.cpp:1843
+#: src/PrefsUnifiedDlg.cpp:1923
 #, fuzzy, c-format
 msgid "Would exclude %u of %u shared file"
 msgid_plural "Would exclude %u of %u shared files"
 msgstr[0] "S'ha trobat %i fitxer compartit"
 msgstr[1] "S'han trobat %i fitxers compartits"
 
-#: src/PrefsUnifiedDlg.cpp:1860
+#: src/PrefsUnifiedDlg.cpp:1940
 msgid "Browse for videoplayer"
 msgstr "Explora per a trobar un reproductor de vídeo"
 
-#: src/PrefsUnifiedDlg.cpp:1864
+#: src/PrefsUnifiedDlg.cpp:1944
 msgid "Select browser"
 msgstr "Selecciona navegador"
 
-#: src/PrefsUnifiedDlg.cpp:1868
+#: src/PrefsUnifiedDlg.cpp:1948
 #, fuzzy
 msgid "Select ffprobe binary"
 msgstr "Selecciona navegador"
 
-#: src/PrefsUnifiedDlg.cpp:1874
+#: src/PrefsUnifiedDlg.cpp:1954
 #, c-format
 msgid "Executable%s"
 msgstr "Executable%s"
 
-#: src/PrefsUnifiedDlg.cpp:1908
+#: src/PrefsUnifiedDlg.cpp:1988
 msgid "ffprobe not found on PATH or in the standard install locations. Install ffmpeg (which ships ffprobe) or use Browse to pick a binary manually."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1920
+#: src/PrefsUnifiedDlg.cpp:2000
 msgid "Reset the settings on this page to their default values?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1921
+#: src/PrefsUnifiedDlg.cpp:2001
 #, fuzzy
 msgid "Reset to defaults"
 msgstr "Predeterminat"
 
-#: src/PrefsUnifiedDlg.cpp:1948
+#: src/PrefsUnifiedDlg.cpp:2028
 msgid "Edit server list"
 msgstr "Edita la llista de servidors"
 
-#: src/PrefsUnifiedDlg.cpp:1949
+#: src/PrefsUnifiedDlg.cpp:2029
 msgid ""
 "Add here URL's to download server.met files.\n"
 "Only one url on each line."
@@ -5984,154 +6026,154 @@ msgstr ""
 "Afegiu adreces URL d'on baixar el fitxer server.met.\n"
 "Només una adreça a cada línia."
 
-#: src/PrefsUnifiedDlg.cpp:2004
+#: src/PrefsUnifiedDlg.cpp:2084
 msgid "IP2Country update failed"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2149 src/PrefsUnifiedDlg.cpp:2180
+#: src/PrefsUnifiedDlg.cpp:2229 src/PrefsUnifiedDlg.cpp:2260
 msgid "Data by MaxMind GeoLite2"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2151 src/PrefsUnifiedDlg.cpp:2182
+#: src/PrefsUnifiedDlg.cpp:2231 src/PrefsUnifiedDlg.cpp:2262
 #, fuzzy
 msgid "Custom source"
 msgstr "Fonts completes"
 
-#: src/PrefsUnifiedDlg.cpp:2153 src/PrefsUnifiedDlg.cpp:2184
+#: src/PrefsUnifiedDlg.cpp:2233 src/PrefsUnifiedDlg.cpp:2264
 msgid "Data by DB-IP.com"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2204
+#: src/PrefsUnifiedDlg.cpp:2284
 #, fuzzy, c-format
 msgid "Status: Loaded%s"
 msgstr "Estat:"
 
-#: src/PrefsUnifiedDlg.cpp:2206
+#: src/PrefsUnifiedDlg.cpp:2286
 #, fuzzy, c-format
 msgid "Status: Loaded%s - %s"
 msgstr "Estat:"
 
-#: src/PrefsUnifiedDlg.cpp:2210
+#: src/PrefsUnifiedDlg.cpp:2290
 msgid "Status: Failed to load - click 'Update now' to refresh."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2212
+#: src/PrefsUnifiedDlg.cpp:2292
 msgid "Status: Not found - click 'Update now' to download."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2270 src/PrefsUnifiedDlg.cpp:2294
+#: src/PrefsUnifiedDlg.cpp:2350 src/PrefsUnifiedDlg.cpp:2374
 #, c-format
 msgid "Update delay: %d second"
 msgid_plural "Update delay: %d seconds"
 msgstr[0] "Retard de l'actualització: %d seg"
 msgstr[1] "Retard de l'actualització: %d segs"
 
-#: src/PrefsUnifiedDlg.cpp:2278
+#: src/PrefsUnifiedDlg.cpp:2358
 #, c-format
 msgid "Time for average graph: %d minute"
 msgid_plural "Time for average graph: %d minutes"
 msgstr[0] "Temps per al gràfic de mitjanes: %d min"
 msgstr[1] "Temps per al gràfic de mitjanes: %d mins"
 
-#: src/PrefsUnifiedDlg.cpp:2287
+#: src/PrefsUnifiedDlg.cpp:2367
 #, c-format
 msgid "Connections Graph Scale: %d"
 msgstr "Escala del gràfic de connexions: %d"
 
-#: src/PrefsUnifiedDlg.cpp:2302
+#: src/PrefsUnifiedDlg.cpp:2382
 #, c-format
 msgid "File Buffer Size: %d byte"
 msgid_plural "File Buffer Size: %d bytes"
 msgstr[0] "Mida de la memòria intermèdia de fitxer: %d byte"
 msgstr[1] "Mida de la memòria intermèdia de fitxer: %d bytes"
 
-#: src/PrefsUnifiedDlg.cpp:2312
+#: src/PrefsUnifiedDlg.cpp:2392
 #, c-format
 msgid "Upload Queue Size: %d client"
 msgid_plural "Upload Queue Size: %d clients"
 msgstr[0] "Mida de la cua de pujada: %d client"
 msgstr[1] "Mida de la cua de pujada: %d clients"
 
-#: src/PrefsUnifiedDlg.cpp:2322
+#: src/PrefsUnifiedDlg.cpp:2402
 #, c-format
 msgid "Server connection refresh interval: %d minute"
 msgid_plural "Server connection refresh interval: %d minutes"
 msgstr[0] "Interval de refresc de la connexió amb el servidor: %d minut"
 msgstr[1] "Interval de refresc de la connexió amb el servidor: %d minuts"
 
-#: src/PrefsUnifiedDlg.cpp:2327
+#: src/PrefsUnifiedDlg.cpp:2407
 msgid "Server connection refresh interval: Disabled"
 msgstr "Interval de refresc de la connexió amb el servidor: Inhabilitat"
 
-#: src/PrefsUnifiedDlg.cpp:2371
+#: src/PrefsUnifiedDlg.cpp:2451
 msgid "disabled"
 msgstr "inhabilitat"
 
-#: src/PrefsUnifiedDlg.cpp:2397
+#: src/PrefsUnifiedDlg.cpp:2477
 #, c-format
 msgid "Execute command on '%s' event"
 msgstr "Executa una ordre per a l'esdeveniment '%s'"
 
-#: src/PrefsUnifiedDlg.cpp:2404
+#: src/PrefsUnifiedDlg.cpp:2484
 msgid "Enable command execution on core"
 msgstr "Activa l'execució d'ordres al nucli"
 
-#: src/PrefsUnifiedDlg.cpp:2416
+#: src/PrefsUnifiedDlg.cpp:2496
 msgid "Core command:"
 msgstr "Odre del nucli:"
 
-#: src/PrefsUnifiedDlg.cpp:2432
+#: src/PrefsUnifiedDlg.cpp:2512
 msgid "Enable command execution on GUI"
 msgstr "Activa l'execució d'ordres a la interfície gràfica"
 
-#: src/PrefsUnifiedDlg.cpp:2444
+#: src/PrefsUnifiedDlg.cpp:2524
 msgid "GUI command:"
 msgstr "Ordre de la IGU:"
 
-#: src/PrefsUnifiedDlg.cpp:2460
+#: src/PrefsUnifiedDlg.cpp:2540
 msgid "The following variables will be replaced:"
 msgstr "Les següents variables seran reemplaçades:"
 
-#: src/PrefsUnifiedDlg.cpp:2628
+#: src/PrefsUnifiedDlg.cpp:2708
 msgid ""
 "The following folders look like system or sensitive locations:\n"
 "\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2633
+#: src/PrefsUnifiedDlg.cpp:2713
 msgid "Sharing them recursively will publish every file underneath on the eD2k/Kad networks. Do you really want to do this?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2636
+#: src/PrefsUnifiedDlg.cpp:2716
 #, fuzzy
 msgid "Confirm shared folders"
 msgstr "Carpetes compartides"
 
-#: src/PrefsUnifiedDlg.cpp:2664
+#: src/PrefsUnifiedDlg.cpp:2744
 #, fuzzy
 msgid "Reloading shared files..."
 msgstr "Recarrega els compartits"
 
-#: src/PrefsUnifiedDlg.cpp:2665
+#: src/PrefsUnifiedDlg.cpp:2745
 msgid "Scanning for subdirectories..."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2666
+#: src/PrefsUnifiedDlg.cpp:2746
 #, fuzzy
 msgid "Updating shared folders"
 msgstr "Carpetes compartides"
 
-#: src/PrefsUnifiedDlg.cpp:2693
+#: src/PrefsUnifiedDlg.cpp:2773
 #, c-format
 msgid "Scanned %u directories..."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2743
+#: src/PrefsUnifiedDlg.cpp:2823
 #, fuzzy, c-format
 msgid "Reloading shared files: %u files scanned"
 msgstr "Recarrega la llista de fitxers compartits."
 
-#: src/PrefsUnifiedDlg.cpp:2793
+#: src/PrefsUnifiedDlg.cpp:2873
 #, fuzzy
 msgid "Shared folder"
 msgstr "Carpetes compartides"

--- a/po/ca.po
+++ b/po/ca.po
@@ -14,8 +14,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-28 12:12+0200\n"
-"PO-Revision-Date: 2026-07-27 10:16+0000\n"
+"POT-Creation-Date: 2026-07-28 08:06+0200\n"
+"PO-Revision-Date: 2026-07-27 11:33+0000\n"
 "Last-Translator: minterior <minterior@gmail.com>\n"
 "Language-Team: Català\n"
 "Language: ca\n"
@@ -145,7 +145,7 @@ msgstr ""
 msgid "Not now"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:422 src/amuleDlg.cpp:665
+#: src/AppImageIntegration.cpp:422 src/amuleDlg.cpp:600
 msgid "Don't ask again"
 msgstr ""
 
@@ -203,83 +203,83 @@ msgstr "No s'ha pogut obrir el fitxer de enllaços ED2K."
 msgid "WARNING: You can't add yourself as a source for an eD2k link while having a lowid."
 msgstr "AVÍS: No us podeu afegir com a font per a un enllaç eD2k mentre teniu ID Baixa."
 
-#: src/amule.cpp:301
+#: src/amule.cpp:300
 msgid "Now, exiting main app..."
 msgstr "Sortint del programa..."
 
-#: src/amule.cpp:331
+#: src/amule.cpp:330
 #, c-format
 msgid "Terminating amuleweb instance with pid '%d' ... "
 msgstr "S'està aturant el procés amuleweb amb pid '%d' ... "
 
-#: src/amule.cpp:335
+#: src/amule.cpp:334
 #, c-format
 msgid "Killing amuleweb instance with pid '%d' ... "
 msgstr "Aturant el procés amuleweb amb pid '%d' ... "
 
-#: src/amule.cpp:337 src/amule.cpp:350 src/ClientRef.cpp:180
-#: src/SearchDlg.cpp:1041 src/ServerListCtrl.cpp:98
+#: src/amule.cpp:336 src/amule.cpp:349 src/ClientRef.cpp:180
+#: src/SearchDlg.cpp:880 src/ServerListCtrl.cpp:98
 msgid "Failed"
 msgstr "Fallades"
 
-#: src/amule.cpp:344
+#: src/amule.cpp:343
 #, fuzzy, c-format
 msgid "Terminating amuleapi instance with pid '%d' ... "
 msgstr "S'està aturant el procés amuleweb amb pid '%d' ... "
 
-#: src/amule.cpp:348
+#: src/amule.cpp:347
 #, fuzzy, c-format
 msgid "Killing amuleapi instance with pid '%d' ... "
 msgstr "Aturant el procés amuleweb amb pid '%d' ... "
 
-#: src/amule.cpp:356
+#: src/amule.cpp:355
 msgid "aMule OnExit: Terminating core."
 msgstr "aMule Sortida: Finalitzant nucli."
 
-#: src/amule.cpp:467
+#: src/amule.cpp:466
 msgid "aMule shutdown completed."
 msgstr "Aturada aMule completada."
 
-#: src/amule.cpp:471
+#: src/amule.cpp:470
 msgid "Memory debug results for aMule exit:"
 msgstr "Resultat de la depuració de la memòria a la sortida de l'aMule:"
 
-#: src/amule.cpp:652
+#: src/amule.cpp:651
 #, c-format
 msgid "Binding aMule's peer-to-peer traffic to interface: %s (HTTP updates use the default route)"
 msgstr ""
 
-#: src/amule.cpp:656
+#: src/amule.cpp:655
 #, c-format
 msgid "Binding all network traffic to interface: %s"
 msgstr ""
 
-#: src/amule.cpp:660
+#: src/amule.cpp:659
 #, c-format
 msgid "WARNING: configured network interface '%s' was not found - traffic is NOT bound to it and may leave via the default route. Check the interface name in Preferences."
 msgstr ""
 
-#: src/amule.cpp:666
+#: src/amule.cpp:665
 #, c-format
 msgid "WARNING: binding to network interface '%s' requires elevated privileges and was NOT applied - traffic may leave via the default route. Grant the capability (e.g. 'sudo setcap cap_net_raw+ep' on the aMule binary) or run with sufficient privileges."
 msgstr ""
 
-#: src/amule.cpp:674
+#: src/amule.cpp:673
 #, c-format
 msgid "WARNING: could not bind to network interface '%s' - traffic may leave via the default route."
 msgstr ""
 
-#: src/amule.cpp:733
+#: src/amule.cpp:732
 msgid "Your locale has been changed to System Default due to a configuration change. Sorry."
 msgstr "S'ha establert l'idioma Predeterminat del Sistema a causa d'un canvi de configuració. Disculpeu."
 
-#: src/amule.cpp:735 src/amule.cpp:1589 src/CatDialog.cpp:128
+#: src/amule.cpp:734 src/amule.cpp:1581 src/CatDialog.cpp:128
 #: src/CatDialog.cpp:136 src/CatDialog.cpp:149 src/ServerList.cpp:366
 #: src/ServerListCtrl.cpp:152
 msgid "Info"
 msgstr "Informació"
 
-#: src/amule.cpp:742
+#: src/amule.cpp:741
 msgid ""
 "\n"
 "EC configuration"
@@ -287,74 +287,74 @@ msgstr ""
 "\n"
 "Configuració EC"
 
-#: src/amule.cpp:745
+#: src/amule.cpp:744
 msgid "Password set and external connections enabled."
 msgstr "Contrassenya definida i connexions externes activades."
 
-#: src/amule.cpp:755 src/KadDlg.cpp:176 src/KadDlg.cpp:185
-#: src/PrefsUnifiedDlg.cpp:1461 src/SharedFilesCtrl.cpp:476
+#: src/amule.cpp:754 src/KadDlg.cpp:176 src/KadDlg.cpp:185
+#: src/PrefsUnifiedDlg.cpp:1387 src/SharedFilesCtrl.cpp:476
 msgid "WARNING"
 msgstr "AVÍS"
 
-#: src/amule.cpp:992
+#: src/amule.cpp:991
 #, fuzzy
 msgid "Network bootstrap"
 msgstr "Xarxes"
 
-#: src/amule.cpp:997
+#: src/amule.cpp:996
 msgid ""
 "aMule has detected missing network bootstrap files.\n"
 "Select which ones to download:"
 msgstr ""
 
-#: src/amule.cpp:1006 src/FirstRunWizard.cpp:411
+#: src/amule.cpp:1005 src/FirstRunWizard.cpp:411
 #, fuzzy
 msgid "eD2k server list (server.met)"
 msgstr "S'ha trobat %i servidor al server.met"
 
-#: src/amule.cpp:1013 src/FirstRunWizard.cpp:416
+#: src/amule.cpp:1012 src/FirstRunWizard.cpp:416
 msgid "Kad bootstrap nodes (nodes.dat)"
 msgstr ""
 
-#: src/amule.cpp:1103
+#: src/amule.cpp:1102
 #, c-format
 msgid "web server running on pid %d"
 msgstr "servidor web executant-se al pid %d"
 
-#: src/amule.cpp:1116
+#: src/amule.cpp:1115
 #, fuzzy
 msgid "You requested to run web server on startup, but the amuleweb binary cannot be run. Please install the package containing aMule web server, or build aMule from source with -DBUILD_WEBSERVER=YES and install it."
 msgstr "Heu demanat que s'executi el servidor web a l'inici, però no s'ha trobat el fitxer binari de l'amuleweb. Si us plau instal·leu el paquet que conté el servidor web de l'aMule, o compileu l'aMule usant la opció --enable-webserver i executeu make install"
 
-#: src/amule.cpp:1121 src/amule.cpp:1185 src/amule.cpp:1299 src/amule.cpp:1601
+#: src/amule.cpp:1120 src/amule.cpp:1177 src/amule.cpp:1291 src/amule.cpp:1593
 #: src/amule-remote-gui.cpp:603 src/amule-remote-gui.cpp:671
 #: src/amule-remote-gui.cpp:709 src/amule-remote-gui.cpp:1282
 #: src/amule-remote-gui.cpp:1345 src/amule-remote-gui.cpp:1372
-#: src/DownloadQueue.cpp:1481 src/PrefsUnifiedDlg.cpp:1247
+#: src/DownloadQueue.cpp:1481
 msgid "ERROR"
 msgstr "ERROR"
 
-#: src/amule.cpp:1174
+#: src/amule.cpp:1166
 #, fuzzy, c-format
 msgid "amuleapi running on pid %d"
 msgstr "servidor web executant-se al pid %d"
 
-#: src/amule.cpp:1180
+#: src/amule.cpp:1172
 #, fuzzy
 msgid "You requested to run amuleapi on startup, but the amuleapi binary cannot be run. Please install the package containing aMule's REST API server, or build aMule from source with -DBUILD_AMULEAPI=YES and install it."
 msgstr "Heu demanat que s'executi el servidor web a l'inici, però no s'ha trobat el fitxer binari de l'amuleweb. Si us plau instal·leu el paquet que conté el servidor web de l'aMule, o compileu l'aMule usant la opció --enable-webserver i executeu make install"
 
-#: src/amule.cpp:1267
+#: src/amule.cpp:1259
 #, c-format
 msgid "Could not bind ports to the specified address: %s"
 msgstr "No s'han pogut vincular els ports a l'adreça especificada: %s"
 
-#: src/amule.cpp:1291
+#: src/amule.cpp:1283
 #, c-format
 msgid "Port %u is not available. You will be LOWID\n"
 msgstr "El port %u no està disponible. Tindreu ID BAIXA\n"
 
-#: src/amule.cpp:1296
+#: src/amule.cpp:1288
 #, c-format
 msgid ""
 "Port %u is not available!\n"
@@ -369,48 +369,48 @@ msgstr ""
 "\n"
 "Comproveu la configuració de la xarxa per a assegurar-vos que el port està obert."
 
-#: src/amule.cpp:1393
+#: src/amule.cpp:1385
 msgid "Failed to create OnlineSig File"
 msgstr "No s'ha pogut crear el fitxer de la signatura en línia"
 
-#: src/amule.cpp:1401
+#: src/amule.cpp:1393
 msgid "Failed to create aMule OnlineSig File"
 msgstr "No s'ha pogut crear el fitxer de la signatura en línia de l'aMule"
 
-#: src/amule.cpp:1564
+#: src/amule.cpp:1556
 msgid "The selected locale seems not to be installed on your box. (Note: I'll try to set it anyway)"
 msgstr "L'idioma seleccionat no està instal·lat al PC. (Nota: s'intentarà establir igualment)"
 
-#: src/amule.cpp:1574
+#: src/amule.cpp:1566
 #, c-format
 msgid "This is the first time you run aMule %s"
 msgstr "És la primera vegada que executeu l'aMule %s"
 
-#: src/amule.cpp:1577
+#: src/amule.cpp:1569
 msgid "This version is a testing version, updated daily, and\n"
 msgstr "Aquesta és una versió de prova, actualitzada diàriament, i\n"
 
-#: src/amule.cpp:1578
+#: src/amule.cpp:1570
 msgid "we give no warranty it won't break anything, burn your house,\n"
 msgstr "no podem garantir que no trenqui res, cremi casa vostra,\n"
 
-#: src/amule.cpp:1579
+#: src/amule.cpp:1571
 msgid "or kill your dog. But it *should* be safe to use anyway.\n"
 msgstr "o mati al gos. Tanmateix el seu ús *hauria* de ser segur.\n"
 
-#: src/amule.cpp:1584
+#: src/amule.cpp:1576
 msgid "More information, support and new releases can found at our homepage,\n"
 msgstr "Podeu trobar més informació, ajuda i noves versions a la nostra pàgina web,\n"
 
-#: src/amule.cpp:1585
+#: src/amule.cpp:1577
 msgid "at https://amule-org.github.io, or in our IRC channel #aMule at irc.libera.chat.\n"
 msgstr "https://amule-org.github.io, o al nostre canal IRC #aMule de irc.libera.chat.\n"
 
-#: src/amule.cpp:1587
+#: src/amule.cpp:1579
 msgid "Feel free to report any bugs to https://github.com/amule-org/amule/issues"
 msgstr "Podeu informar de qualsevol error a https://github.com/amule-org/amule/issues"
 
-#: src/amule.cpp:1599
+#: src/amule.cpp:1591
 msgid ""
 "The folder for Online Signature files you specified is INVALID!\n"
 " OnlineSignature will be DISABLED until you fix it on preferences."
@@ -418,137 +418,137 @@ msgstr ""
 "La carpeta especificada per als fitxers de la signatura en línia és INVÀLIDA!\n"
 " S'INHABILITARÀ la signatura en línia fins que ho resolgueu a les preferències."
 
-#: src/amule.cpp:1662
+#: src/amule.cpp:1654
 msgid "Server hostname notified"
 msgstr "Nom del servidor notificat"
 
-#: src/amule.cpp:2039
+#: src/amule.cpp:2031
 #, c-format
 msgid "Disk space preallocation for file '%s' failed: %s"
 msgstr "La preassignació d'espai per al fitxer '%s' ha fallat: %s"
 
-#: src/amule.cpp:2168
+#: src/amule.cpp:2160
 msgid "ERROR: can't open logfile"
 msgstr "ERROR: no es pot obrir el fitxer de registre"
 
-#: src/amule.cpp:2172
+#: src/amule.cpp:2164
 msgid "WARNING: logfile is empty. Something is wrong."
 msgstr "AVÍS: el fitxer de registre està buit. Alguna cosa no va bé."
 
-#: src/amule.cpp:2189
+#: src/amule.cpp:2181
 msgid "Log has been reset"
 msgstr "S'ha reiniciat el registre"
 
-#: src/amule.cpp:2213
+#: src/amule.cpp:2205
 #, c-format
 msgid "ServerMessage: %s"
 msgstr "Missatge del servidor: %s"
 
-#: src/amule.cpp:2256 src/IP2Country.cpp:220 src/IPFilter.cpp:514
+#: src/amule.cpp:2248 src/IP2Country.cpp:220 src/IPFilter.cpp:514
 #: src/ServerList.cpp:875
 #, c-format
 msgid "Skipped download of %s, because requested file is not newer."
 msgstr "S'ha omès la baixada de %s perquè el fitxer sol·licitat no és més recent."
 
-#: src/amule.cpp:2259
+#: src/amule.cpp:2251
 msgid "Failed to download the nodes list."
 msgstr "No s'ha pogut baixar la llista de nodes."
 
-#: src/amule.cpp:2322
+#: src/amule.cpp:2314
 msgid "Failed to open the downloaded version check file"
 msgstr "No s'ha pogut obrir el fitxer de comprovació de versió"
 
-#: src/amule.cpp:2325 src/amule.cpp:2344
+#: src/amule.cpp:2317 src/amule.cpp:2336
 msgid "Corrupted version check file"
 msgstr "Fitxer de comprovació de versió corrupte"
 
-#: src/amule.cpp:2367
+#: src/amule.cpp:2359
 msgid "You are using an outdated version of aMule!"
 msgstr "Esteu usant una versió antiga de l'aMule!"
 
-#: src/amule.cpp:2369
+#: src/amule.cpp:2361
 #, c-format
 msgid "Your aMule version is %i.%i.%i and the latest version is %li.%li.%li"
 msgstr "La vostra versió de l'aMule és %i.%i.%i i l'última versió és %li.%li.%li"
 
-#: src/amule.cpp:2373
+#: src/amule.cpp:2365
 msgid "The latest version can always be found at https://github.com/amule-org/amule/releases/latest"
 msgstr "Sempre podeu trobar l'última versió a https://github.com/amule-org/amule/releases/latest"
 
-#: src/amule.cpp:2376
+#: src/amule.cpp:2368
 #, c-format
 msgid "WARNING: Your aMuled version is outdated: %i.%i.%i < %li.%li.%li"
 msgstr "AVÍS: La vostra versió d'aMuled és antiga: %i.%i.%i < %li.%li.%li"
 
-#: src/amule.cpp:2382
+#: src/amule.cpp:2374
 msgid "Your copy of aMule is up to date."
 msgstr "La vostra versió de l'aMule és l'última."
 
-#: src/amule.cpp:2389
+#: src/amule.cpp:2381
 msgid "Failed to download the version check file"
 msgstr "No s'ha pogut baixar el fitxer de comprovació de versió"
 
-#: src/amule.cpp:2558 src/amule-remote-gui.cpp:1133
+#: src/amule.cpp:2550 src/amule-remote-gui.cpp:1133
 #, c-format
 msgid "Users: %s | Files: %s"
 msgstr "Usuaris: %s | Fitxers: %s"
 
-#: src/amule.cpp:2559 src/amule-remote-gui.cpp:1134
+#: src/amule.cpp:2551 src/amule-remote-gui.cpp:1134
 #, c-format
 msgid "Users: E: %s K: %s | Files: E: %s K: %s"
 msgstr "Usuaris: E: %s K: %s | Fitxers: E: %s K: %s"
 
-#: src/amule.cpp:2573 src/amule-remote-gui.cpp:1147
+#: src/amule.cpp:2565 src/amule-remote-gui.cpp:1147
 msgid "No networks selected"
 msgstr "No s'han seleccionat xarxes"
 
-#: src/amule.cpp:2641 src/TextClient.cpp:903
+#: src/amule.cpp:2633 src/TextClient.cpp:903
 msgid "with LowID"
 msgstr "amb ID Baixa"
 
-#: src/amule.cpp:2641 src/TextClient.cpp:904
+#: src/amule.cpp:2633 src/TextClient.cpp:904
 msgid "with HighID"
 msgstr "amb ID Alta"
 
-#: src/amule.cpp:2643
+#: src/amule.cpp:2635
 #, c-format
 msgid "Connected to %s %s"
 msgstr "Connectat a %s %s"
 
-#: src/amule.cpp:2648
+#: src/amule.cpp:2640
 #, c-format
 msgid "Connecting to %s"
 msgstr "S'està connectant a %s"
 
-#: src/amule.cpp:2650
+#: src/amule.cpp:2642
 msgid "Disconnected from eD2k"
 msgstr "Desconnectat de eD2k"
 
-#: src/amule.cpp:2659
+#: src/amule.cpp:2651
 msgid "Kad started."
 msgstr "S'ha engegat la xarxa Kad."
 
-#: src/amule.cpp:2661
+#: src/amule.cpp:2653
 msgid "Kad stopped."
 msgstr "S'ha aturat la xarxa Kad."
 
-#: src/amule.cpp:2669
+#: src/amule.cpp:2661
 msgid "Connected to Kad (ok)"
 msgstr "Connectat a Kad (ok)"
 
-#: src/amule.cpp:2671
+#: src/amule.cpp:2663
 msgid "Connected to Kad (firewalled)"
 msgstr "Connectat a Kad (tallafocs)"
 
-#: src/amule.cpp:2675
+#: src/amule.cpp:2667
 msgid "Disconnected from Kad"
 msgstr "Desconnectat de Kad"
 
-#: src/amule.cpp:2707
+#: src/amule.cpp:2699
 msgid "Kad network cannot be used if UDP port is disabled on preferences, not starting."
 msgstr "No es pot usar la xarxa Kad si el port UDP està inhabilitat a les preferències, no s'engegarà."
 
-#: src/amule.cpp:2711
+#: src/amule.cpp:2703
 msgid "Kad network disabled on preferences, not connecting."
 msgstr "La xarxa Kad està inhabilitada a les preferències, no es connectarà."
 
@@ -574,68 +574,30 @@ msgstr "No s'ha pogut crear el fitxer Pid"
 msgid "ERROR: %s"
 msgstr "ERROR: %s"
 
-#: src/amuleDlg.cpp:250
+#: src/amuleDlg.cpp:236
 #, c-format
 msgid "This is aMule %s based on eMule."
 msgstr "aMule %s basat en eMule."
 
-#: src/amuleDlg.cpp:251
+#: src/amuleDlg.cpp:237
 #, c-format
 msgid "Running on %s"
 msgstr "S'està executant sobre %s"
 
-#: src/amuleDlg.cpp:253
+#: src/amuleDlg.cpp:239
 msgid "Visit https://github.com/amule-org/amule/releases/latest to check if a new version is available."
 msgstr "Visiteu https://github.com/amule-org/amule/releases/latest per a comprovar si hi ha disponible una versió nova."
 
-#: src/amuleDlg.cpp:282
+#: src/amuleDlg.cpp:268
 msgid "FATAL ERROR: Failed to create Timer"
 msgstr "ERROR GREU: No s'ha pogut crear el temporitzador"
 
-#: src/amuleDlg.cpp:361 src/amuleDlg.cpp:1810 src/amuleDlg.cpp:2056
-#: src/muuli_wdr.cpp:1492 src/muuli_wdr.cpp:3439
-msgid "Networks"
-msgstr "Xarxes"
-
-#: src/amuleDlg.cpp:362 src/amuleDlg.cpp:1816 src/muuli_wdr.cpp:3440
-msgid "Searches"
-msgstr "Cerques"
-
-#: src/amuleDlg.cpp:363 src/amuleDlg.cpp:1822 src/DownloadListCtrl.cpp:740
-#: src/muuli_wdr.cpp:392 src/muuli_wdr.cpp:1585 src/muuli_wdr.cpp:3441
-#: src/Statistics.cpp:829
-msgid "Downloads"
-msgstr "Baixades"
-
-#: src/amuleDlg.cpp:364 src/amuleDlg.cpp:1828 src/muuli_wdr.cpp:3315
-msgid "Shared files"
-msgstr "Compartits"
-
-#: src/amuleDlg.cpp:365 src/amuleDlg.cpp:1834 src/muuli_wdr.cpp:2947
-#: src/muuli_wdr.cpp:3397 src/muuli_wdr.cpp:3444
-msgid "Messages"
-msgstr "Missatges"
-
-#: src/amuleDlg.cpp:366 src/amuleDlg.cpp:1840 src/muuli_wdr.cpp:3445
-#: src/PrefsUnifiedDlg.cpp:314 src/Statistics.cpp:779 src/Statistics.cpp:1235
-msgid "Statistics"
-msgstr "Estadístiques"
-
-#: src/amuleDlg.cpp:368 src/amuleDlg.cpp:1847 src/muuli_wdr.cpp:3447
-#: src/PrefsUnifiedDlg.cpp:330 src/utils/wxCas/src/wxcasprefs.cpp:39
-msgid "Preferences"
-msgstr "Preferències"
-
-#: src/amuleDlg.cpp:371
-msgid "Navigate"
-msgstr ""
-
-#: src/amuleDlg.cpp:657
+#: src/amuleDlg.cpp:592
 #, fuzzy
 msgid "New version available"
 msgstr "No disponible"
 
-#: src/amuleDlg.cpp:661
+#: src/amuleDlg.cpp:596
 #, fuzzy, c-format
 msgid ""
 "A new version of aMule (%s) is available.\n"
@@ -645,184 +607,217 @@ msgid ""
 "Would you like to open the download page?"
 msgstr "Sempre podeu trobar l'última versió a https://github.com/amule-org/amule/releases/latest"
 
-#: src/amuleDlg.cpp:743
+#: src/amuleDlg.cpp:678
 msgid "aMule dialog destroyed"
 msgstr "Diàleg de l'aMule tancat"
 
-#: src/amuleDlg.cpp:766 src/DataToText.cpp:68 src/IPFilter.cpp:547
+#: src/amuleDlg.cpp:701 src/DataToText.cpp:68 src/IPFilter.cpp:547
 msgid "Connecting"
 msgstr "Connectant"
 
-#: src/amuleDlg.cpp:958
+#: src/amuleDlg.cpp:893
 msgid "eD2k: Connecting"
 msgstr "eD2k: S'està connectant"
 
-#: src/amuleDlg.cpp:962
+#: src/amuleDlg.cpp:897
 msgid "eD2k: Disconnected"
 msgstr "eD2k: Desconnectat"
 
-#: src/amuleDlg.cpp:968
+#: src/amuleDlg.cpp:903
 msgid "Kad: Firewalled"
 msgstr "Kad: Bloquejat"
 
-#: src/amuleDlg.cpp:972
+#: src/amuleDlg.cpp:907
 msgid "Kad: Connected"
 msgstr "Kad: Connectat"
 
-#: src/amuleDlg.cpp:977
+#: src/amuleDlg.cpp:912
 msgid "Kad: Connecting"
 msgstr "Kad: Connectant"
 
-#: src/amuleDlg.cpp:981
+#: src/amuleDlg.cpp:916
 msgid "Kad: Off"
 msgstr "Kad: Inativa"
 
-#: src/amuleDlg.cpp:1029 src/DownloadListCtrl.cpp:505
+#: src/amuleDlg.cpp:964 src/DownloadListCtrl.cpp:505
 #: src/DownloadListCtrl.cpp:749 src/FriendListCtrl.cpp:180
 #: src/muuli_wdr.cpp:731 src/muuli_wdr.cpp:782 src/muuli_wdr.cpp:846
-#: src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2252 src/muuli_wdr.cpp:2337
-#: src/muuli_wdr.cpp:3085 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
+#: src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2224 src/muuli_wdr.cpp:2309
+#: src/muuli_wdr.cpp:3057 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
 #: src/ServerListCtrl.cpp:606 src/TransferWnd.cpp:378
 #: src/utils/wxCas/src/wxcasprefs.cpp:235
 msgid "Cancel"
 msgstr "Cancel·la"
 
-#: src/amuleDlg.cpp:1030
+#: src/amuleDlg.cpp:965
 msgid "Stop the current connection attempts"
 msgstr "Atura els intents de connexió actuals"
 
-#: src/amuleDlg.cpp:1035 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976
-#: src/muuli_wdr.cpp:2475
+#: src/amuleDlg.cpp:970 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976
+#: src/muuli_wdr.cpp:2447
 msgid "Disconnect"
 msgstr "Desconnecta"
 
-#: src/amuleDlg.cpp:1036
+#: src/amuleDlg.cpp:971
 msgid "Disconnect from the currently connected networks"
 msgstr "Desconnecta de les xarxes on s'està connectat actualment"
 
-#: src/amuleDlg.cpp:1041 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979
-#: src/muuli_wdr.cpp:2630 src/muuli_wdr.cpp:3082 src/muuli_wdr.cpp:3437
+#: src/amuleDlg.cpp:976 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979
+#: src/muuli_wdr.cpp:2602 src/muuli_wdr.cpp:3054 src/muuli_wdr.cpp:3409
 msgid "Connect"
 msgstr "Connecta"
 
-#: src/amuleDlg.cpp:1042
+#: src/amuleDlg.cpp:977
 msgid "Connect to the currently enabled networks"
 msgstr "Connecta a les xarxes habilitades actualment"
 
-#: src/amuleDlg.cpp:1154
+#: src/amuleDlg.cpp:1089
 #, c-format
 msgid "Up: %.1f%s (%.1f) | Down: %.1f%s (%.1f)"
 msgstr "PU: %.1f%s (%.1f) | BA: %.1f%s (%.1f)"
 
-#: src/amuleDlg.cpp:1156 src/amuleDlg.cpp:1158 src/amuleDlg.cpp:1162
-#: src/amuleDlg.cpp:1164 src/amuleDlg.cpp:1175 src/amuleDlg.cpp:1177
+#: src/amuleDlg.cpp:1091 src/amuleDlg.cpp:1093 src/amuleDlg.cpp:1097
+#: src/amuleDlg.cpp:1099 src/amuleDlg.cpp:1110 src/amuleDlg.cpp:1112
 #: src/MuleTrayIcon.cpp:796 src/MuleTrayIcon.cpp:799
 msgid " MB/s"
 msgstr " MB/s"
 
-#: src/amuleDlg.cpp:1156 src/amuleDlg.cpp:1158 src/amuleDlg.cpp:1162
-#: src/amuleDlg.cpp:1164 src/amuleDlg.cpp:1175 src/amuleDlg.cpp:1177
+#: src/amuleDlg.cpp:1091 src/amuleDlg.cpp:1093 src/amuleDlg.cpp:1097
+#: src/amuleDlg.cpp:1099 src/amuleDlg.cpp:1110 src/amuleDlg.cpp:1112
 #: src/MuleTrayIcon.cpp:796 src/MuleTrayIcon.cpp:799
 #: src/utils/wxCas/src/wxcasframe.cpp:1041
 msgid " kB/s"
 msgstr " kB/s"
 
-#: src/amuleDlg.cpp:1161
+#: src/amuleDlg.cpp:1096
 #, c-format
 msgid "Up: %.1f%s | Down: %.1f%s"
 msgstr "PU: %.1f%s | BA: %.1f%s"
 
-#: src/amuleDlg.cpp:1193
+#: src/amuleDlg.cpp:1128
 #, c-format
 msgid "aMule (%s | Connected)"
 msgstr "aMule (%s | Connectat)"
 
-#: src/amuleDlg.cpp:1195
+#: src/amuleDlg.cpp:1130
 #, c-format
 msgid "aMule (%s | Disconnected)"
 msgstr "aMule (%s | Desconnectat)"
 
-#: src/amuleDlg.cpp:1248
+#: src/amuleDlg.cpp:1183
 #, c-format
 msgid "Do you really want to exit %s?"
 msgstr "Esteu segur que voleu eixir de %s?"
 
-#: src/amuleDlg.cpp:1250
+#: src/amuleDlg.cpp:1185
 msgid "Exit confirmation"
 msgstr "Confirmació de sortida"
 
-#: src/amuleDlg.cpp:1613
+#: src/amuleDlg.cpp:1548
 msgid "Launch Command: "
 msgstr "Ordre: "
 
-#: src/amuleDlg.cpp:1632 src/muuli_wdr.cpp:1972 src/Preferences.cpp:979
+#: src/amuleDlg.cpp:1567 src/muuli_wdr.cpp:1971 src/Preferences.cpp:951
 msgid "- default -"
 msgstr "- defecte -"
 
-#: src/amuleDlg.cpp:1660
+#: src/amuleDlg.cpp:1595
 #, c-format
 msgid "Skin directory '%s' does not exist"
 msgstr "El directori del tema '%s' no existeix"
 
-#: src/amuleDlg.cpp:1663
+#: src/amuleDlg.cpp:1598
 #, c-format
 msgid "WARNING: Unable to open skin file '%s' for read"
 msgstr "AVÍS: No ha estat possible obrir el fitxer d'aparença '%s' per a lectura"
 
-#: src/amuleDlg.cpp:1814 src/muuli_wdr.cpp:3439
+#: src/amuleDlg.cpp:1722 src/amuleDlg.cpp:1968 src/muuli_wdr.cpp:1485
+#: src/muuli_wdr.cpp:3411
+msgid "Networks"
+msgstr "Xarxes"
+
+#: src/amuleDlg.cpp:1726 src/muuli_wdr.cpp:3411
 msgid "Networks Window"
 msgstr "Finestra de les Xarxes"
 
-#: src/amuleDlg.cpp:1820 src/muuli_wdr.cpp:3440
+#: src/amuleDlg.cpp:1728 src/muuli_wdr.cpp:3412
+msgid "Searches"
+msgstr "Cerques"
+
+#: src/amuleDlg.cpp:1732 src/muuli_wdr.cpp:3412
 msgid "Searches Window"
 msgstr "Finestra de cerques"
 
-#: src/amuleDlg.cpp:1826 src/muuli_wdr.cpp:3441
+#: src/amuleDlg.cpp:1734 src/DownloadListCtrl.cpp:740 src/muuli_wdr.cpp:392
+#: src/muuli_wdr.cpp:1578 src/muuli_wdr.cpp:3413 src/Statistics.cpp:829
+msgid "Downloads"
+msgstr "Baixades"
+
+#: src/amuleDlg.cpp:1738 src/muuli_wdr.cpp:3413
 msgid "Downloads Window"
 msgstr "Finestra de baixades"
 
-#: src/amuleDlg.cpp:1832 src/muuli_wdr.cpp:3443
+#: src/amuleDlg.cpp:1740 src/muuli_wdr.cpp:3287
+msgid "Shared files"
+msgstr "Compartits"
+
+#: src/amuleDlg.cpp:1744 src/muuli_wdr.cpp:3415
 msgid "Shared Files Window"
 msgstr "Finestra de fitxers compartits"
 
-#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3444
+#: src/amuleDlg.cpp:1746 src/muuli_wdr.cpp:2919 src/muuli_wdr.cpp:3369
+#: src/muuli_wdr.cpp:3416
+msgid "Messages"
+msgstr "Missatges"
+
+#: src/amuleDlg.cpp:1750 src/muuli_wdr.cpp:3416
 msgid "Messages Window"
 msgstr "Finestra de Missatges"
 
-#: src/amuleDlg.cpp:1844 src/muuli_wdr.cpp:3445
+#: src/amuleDlg.cpp:1752 src/muuli_wdr.cpp:3417 src/PrefsUnifiedDlg.cpp:312
+#: src/Statistics.cpp:779 src/Statistics.cpp:1235
+msgid "Statistics"
+msgstr "Estadístiques"
+
+#: src/amuleDlg.cpp:1756 src/muuli_wdr.cpp:3417
 msgid "Statistics Graph Window"
 msgstr "Finestra del gràfic d'estadístiques"
 
-#: src/amuleDlg.cpp:1851 src/muuli_wdr.cpp:3447
+#: src/amuleDlg.cpp:1759 src/muuli_wdr.cpp:3419 src/PrefsUnifiedDlg.cpp:328
+#: src/utils/wxCas/src/wxcasprefs.cpp:39
+msgid "Preferences"
+msgstr "Preferències"
+
+#: src/amuleDlg.cpp:1763 src/muuli_wdr.cpp:3419
 msgid "Preferences Settings Window"
 msgstr "Finestra de la configuració de preferències"
 
-#: src/amuleDlg.cpp:1854 src/muuli_wdr.cpp:3448
+#: src/amuleDlg.cpp:1766 src/muuli_wdr.cpp:3420
 msgid "Import"
 msgstr "Importa"
 
-#: src/amuleDlg.cpp:1858 src/muuli_wdr.cpp:3448
+#: src/amuleDlg.cpp:1770 src/muuli_wdr.cpp:3420
 msgid "The partfile importer tool"
 msgstr "Eina d'importació de fitxers de parts"
 
-#: src/amuleDlg.cpp:1861 src/muuli_wdr.cpp:3449
+#: src/amuleDlg.cpp:1773 src/muuli_wdr.cpp:3421
 #: src/utils/aLinkCreator/src/alcframe.cpp:262
 msgid "About"
 msgstr "Quant a"
 
-#: src/amuleDlg.cpp:1861 src/muuli_wdr.cpp:3449
+#: src/amuleDlg.cpp:1773 src/muuli_wdr.cpp:3421
 msgid "About/Help"
 msgstr "Quant a / Ajuda"
 
-#: src/amuleDlg.cpp:2059
+#: src/amuleDlg.cpp:1971
 msgid "eD2k network"
 msgstr "Xarxa eD2k"
 
-#: src/amuleDlg.cpp:2062
+#: src/amuleDlg.cpp:1974
 msgid "Kad network"
 msgstr "Xarxa Kad"
 
-#: src/amuleDlg.cpp:2062
+#: src/amuleDlg.cpp:1974
 msgid "No network"
 msgstr "Cap xarxa"
 
@@ -952,7 +947,7 @@ msgstr "No s'ha trobat el fitxer."
 msgid "The core rejected these shared folders:%s"
 msgstr ""
 
-#: src/amule-remote-gui.cpp:1336 src/ExternalConn.cpp:2346
+#: src/amule-remote-gui.cpp:1336 src/ExternalConn.cpp:2345
 msgid "Invalid link or already on list."
 msgstr "L'enllaç és invàlid o ja és present a la llista."
 
@@ -968,7 +963,7 @@ msgstr "No s'ha pogut crear el directori '%s' per a la categoria '%s', es mantin
 #: src/ClientDetailDialog.cpp:123 src/DataToText.cpp:61 src/DataToText.cpp:86
 #: src/DataToText.cpp:101 src/DataToText.cpp:136 src/DataToText.cpp:165
 #: src/DownloadListCtrl.cpp:1172 src/DownloadListCtrl.cpp:1185
-#: src/DownloadListCtrl.cpp:1196 src/ExternalConn.cpp:609
+#: src/DownloadListCtrl.cpp:1196 src/ExternalConn.cpp:608
 #: src/FileDetailDialog.cpp:203 src/FileDetailDialog.cpp:235
 #: src/FileDetailDialog.cpp:242 src/GenericClientListCtrl.cpp:1171
 #: src/GenericClientListCtrl.cpp:1182 src/GenericClientListCtrl.cpp:1192
@@ -1355,19 +1350,19 @@ msgstr "Auto [Al]"
 msgid "Very low"
 msgstr "Molt baixa"
 
-#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:743 src/muuli_wdr.cpp:2303
+#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:743 src/muuli_wdr.cpp:2275
 #: src/ServerListCtrl.cpp:263 src/ServerListCtrl.cpp:456
 #: src/SharedFilesCtrl.cpp:145
 msgid "Low"
 msgstr "Baixa"
 
-#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:744 src/muuli_wdr.cpp:2304
+#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:744 src/muuli_wdr.cpp:2276
 #: src/ServerListCtrl.cpp:266 src/ServerListCtrl.cpp:457
 #: src/SharedFilesCtrl.cpp:146
 msgid "Normal"
 msgstr "Normal"
 
-#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:745 src/muuli_wdr.cpp:2305
+#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:745 src/muuli_wdr.cpp:2277
 #: src/ServerListCtrl.cpp:269 src/ServerListCtrl.cpp:458
 #: src/SharedFilesCtrl.cpp:147
 msgid "High"
@@ -1459,8 +1454,8 @@ msgstr "Servidor local"
 msgid "Remote Server"
 msgstr "Servidor remot"
 
-#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3202
-#: src/SearchDlg.cpp:119 src/TextClient.cpp:911
+#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3174
+#: src/SearchDlg.cpp:111 src/TextClient.cpp:911
 msgid "Kad"
 msgstr "Kad"
 
@@ -1531,7 +1526,7 @@ msgstr "Part"
 msgid "Size"
 msgstr "Mida"
 
-#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3269
+#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3241
 msgid "Transferred"
 msgstr "Transferit"
 
@@ -1589,7 +1584,7 @@ msgstr ""
 "Retroacció des de: %s (%s)\n"
 "\n"
 
-#: src/DownloadListCtrl.cpp:746 src/muuli_wdr.cpp:2306
+#: src/DownloadListCtrl.cpp:746 src/muuli_wdr.cpp:2278
 #: src/SharedFilesCtrl.cpp:150
 msgid "Auto"
 msgstr "Auto"
@@ -1627,7 +1622,7 @@ msgid "Extended Options"
 msgstr "Opcions avançades"
 
 #: src/DownloadListCtrl.cpp:770 src/DownloadListCtrl.cpp:822
-#: src/muuli_wdr.cpp:1790
+#: src/muuli_wdr.cpp:1789
 msgid "Preview"
 msgstr "Previsualitza"
 
@@ -1802,232 +1797,227 @@ msgstr[1] ""
 msgid "Invalid eD2k link! ERROR: %s"
 msgstr "Enllaç eD2k invàlid! ERROR: %s"
 
-#: src/ExternalConn.cpp:380
+#: src/ExternalConn.cpp:379
 msgid "Client sent packet after authentication failed."
 msgstr "El client ha enviat un paquet després d'una autenticació fallida."
 
-#: src/ExternalConn.cpp:397
+#: src/ExternalConn.cpp:396
 msgid "External connection closed."
 msgstr "Connexió externa tancada."
 
-#: src/ExternalConn.cpp:474
+#: src/ExternalConn.cpp:473
 msgid "External connections disabled due to empty password!"
 msgstr "Les connexions externes han estat inhabilitades per manca d'una contrasenya!"
 
-#: src/ExternalConn.cpp:495
+#: src/ExternalConn.cpp:494
 msgid "External connections disabled in config file"
 msgstr "Les connexions externes estan inhabilitades al fitxer de configuració"
 
-#: src/ExternalConn.cpp:576
+#: src/ExternalConn.cpp:575
 msgid "New external connection accepted"
 msgstr "Nova connexió externa acceptada"
 
-#: src/ExternalConn.cpp:579
+#: src/ExternalConn.cpp:578
 msgid "ERROR: couldn't accept a new external connection"
 msgstr "ERROR: no s'ha pogut acceptar una nova connexió externa"
 
-#: src/ExternalConn.cpp:596
+#: src/ExternalConn.cpp:595
 msgid "External connection refused due to empty password in preferences!"
 msgstr "S'ha rebutjat la connexió externa per manca d'una contrasenya a les preferències!"
 
-#: src/ExternalConn.cpp:608
+#: src/ExternalConn.cpp:607
 #, c-format
 msgid "Connecting client: %s %s"
 msgstr "S'està connectant al client: %s %s"
 
-#: src/ExternalConn.cpp:610
+#: src/ExternalConn.cpp:609
 msgid "Unknown version"
 msgstr "Versió desconeguda"
 
-#: src/ExternalConn.cpp:623
+#: src/ExternalConn.cpp:622
 msgid "Incorrect EC version ID, there might be binary incompatibility. Use core and remote from same snapshot."
 msgstr "ID de versió EC incorrecta, pot haver-hi incompatibilitat binaria. Useu un nucli i un client remot del mateix llançament (versió)."
 
-#: src/ExternalConn.cpp:631
+#: src/ExternalConn.cpp:630
 msgid "You cannot connect to a release version from an arbitrary development snapshot! *sigh* possible crash prevented"
 msgstr "No us podeu connectar a una versió final des d'una versió de desenvolupament arbitrària! *buf* s'ha evitat una possible fallada"
 
-#: src/ExternalConn.cpp:714
+#: src/ExternalConn.cpp:713
 msgid "Invalid protocol version."
 msgstr "Versió del protocol invàlida."
 
-#: src/ExternalConn.cpp:720
+#: src/ExternalConn.cpp:719
 msgid "Missing protocol version tag."
 msgstr "Marcador de la versió del protocol inexistent."
 
-#: src/ExternalConn.cpp:728
+#: src/ExternalConn.cpp:727
 msgid "Authentication failed: invalid hash specified as EC password."
 msgstr "L'autenticació ha fallat: el resum especificat com a contrasenya d'EC no és vàlid."
 
-#: src/ExternalConn.cpp:776
+#: src/ExternalConn.cpp:775
 msgid "Authentication failed: wrong password."
 msgstr "Ha fallat l'autenticació: contrasenya incorrecta"
 
-#: src/ExternalConn.cpp:778
+#: src/ExternalConn.cpp:777
 msgid "Authentication failed: missing password."
 msgstr "Ha fallat l'autenticació: falta la contrasenya"
 
-#: src/ExternalConn.cpp:789
+#: src/ExternalConn.cpp:788
 msgid "Invalid request, please authenticate first."
 msgstr "Petició invàlida, primer heu d'autenticar-vos."
 
-#: src/ExternalConn.cpp:794
+#: src/ExternalConn.cpp:793
 msgid "Access granted."
 msgstr "Accés concedit."
 
-#: src/ExternalConn.cpp:802
+#: src/ExternalConn.cpp:801
 #, c-format
 msgid "Sent error message \"%s\" to client."
 msgstr "S'ha enviat el missatge d'error \"%s\" al client."
 
-#: src/ExternalConn.cpp:807
+#: src/ExternalConn.cpp:806
 #, c-format
 msgid "Unauthorized access attempt from %s. Connection closed."
 msgstr "Intent d'accés no autoritzat de %s. Connexió tancada."
 
-#: src/ExternalConn.cpp:1420
+#: src/ExternalConn.cpp:1419
 #, c-format
 msgid "Remote PartFile command failed: FileHash not found: %s"
 msgstr "Ha fallat una ordre remota de fitxer de parts: No s'ha trobat el resum del fitxer: %s"
 
-#: src/ExternalConn.cpp:1424
+#: src/ExternalConn.cpp:1423
 #, c-format
 msgid "FileHash not found: %s"
 msgstr "No s'ha trobat el resum del fitxer: %s"
 
-#: src/ExternalConn.cpp:1471 src/ExternalConn.cpp:1559
-#: src/ExternalConn.cpp:1680
+#: src/ExternalConn.cpp:1470 src/ExternalConn.cpp:1558
+#: src/ExternalConn.cpp:1679
 msgid "OOPS! OpCode processing error!"
 msgstr "Error en processar el codi d'opció!"
 
-#: src/ExternalConn.cpp:1502
+#: src/ExternalConn.cpp:1501
 msgid "Server not added"
 msgstr "No s'ha afegit el servidor"
 
-#: src/ExternalConn.cpp:1521
+#: src/ExternalConn.cpp:1520
 #, c-format
 msgid "server not found: %s"
 msgstr "no s'ha trobat el servidor: %s"
 
-#: src/ExternalConn.cpp:1538
+#: src/ExternalConn.cpp:1537
 msgid "need to define server to be removed"
 msgstr "és necessari definir el servidor a esborrar"
 
-#: src/ExternalConn.cpp:1553
+#: src/ExternalConn.cpp:1552
 msgid "eD2k is disabled in preferences."
 msgstr "eD2k és inhabilitada a les preferències."
 
-#: src/ExternalConn.cpp:1658
+#: src/ExternalConn.cpp:1657
 #, fuzzy
 msgid "Friend not found."
 msgstr "No s'ha trobat el fitxer."
 
-#: src/ExternalConn.cpp:1668
+#: src/ExternalConn.cpp:1667
 #, fuzzy
 msgid "Client not found."
 msgstr "No s'ha trobat el fitxer."
 
-#: src/ExternalConn.cpp:1674
+#: src/ExternalConn.cpp:1673
 msgid "EC_TAG_FRIEND_SHARED requires EC_TAG_FRIEND or EC_TAG_CLIENT."
 msgstr ""
 
-#: src/ExternalConn.cpp:1992
+#: src/ExternalConn.cpp:1991
 msgid "WebSearch from remote interface makes no sense."
 msgstr "La recerca web des de la interfície remota no té sentit."
 
-#: src/ExternalConn.cpp:2027
+#: src/ExternalConn.cpp:2026
 msgid "Search in progress. Refetch results in a moment!"
 msgstr "Cerca en procés. S'obtindran resultats en un moment!"
 
-#: src/ExternalConn.cpp:2266
+#: src/ExternalConn.cpp:2265
 msgid "No points for graph."
 msgstr "Cap punt per al gràfic."
 
-#: src/ExternalConn.cpp:2276
+#: src/ExternalConn.cpp:2275
 msgid "Your client is not configured for this detail level."
 msgstr "El vostre client no està configurat per a aquest nivell de detall."
 
-#: src/ExternalConn.cpp:2303
+#: src/ExternalConn.cpp:2302
 msgid "External Connection: shutdown requested"
 msgstr "Connexió externa: s'ha demanat l'aturada"
 
-#: src/ExternalConn.cpp:2315
+#: src/ExternalConn.cpp:2314
 msgid "Already shutting down."
 msgstr "Ja s'està aturant."
 
-#: src/ExternalConn.cpp:2333
+#: src/ExternalConn.cpp:2332
 #, c-format
 msgid "ExternalConn: adding link '%s'."
 msgstr "ExternalConn: afegint l'enllaç '%s'."
 
-#: src/ExternalConn.cpp:2351
+#: src/ExternalConn.cpp:2350
 #, fuzzy, c-format
 msgid "%d of %d links failed (invalid or already on list)."
 msgstr "L'enllaç és invàlid o ja és present a la llista."
 
-#: src/ExternalConn.cpp:2374
+#: src/ExternalConn.cpp:2373
 msgid "Version check throttled; try again shortly."
 msgstr ""
 
-#: src/ExternalConn.cpp:2379
+#: src/ExternalConn.cpp:2378
 msgid "Version check is not available on this daemon."
 msgstr ""
 
-#: src/ExternalConn.cpp:2509
+#: src/ExternalConn.cpp:2508
 msgid "File not found."
 msgstr "No s'ha trobat el fitxer."
 
-#: src/ExternalConn.cpp:2514
+#: src/ExternalConn.cpp:2513
 msgid "Invalid file name."
 msgstr "Nom de fitxer invàlid."
 
-#: src/ExternalConn.cpp:2522
+#: src/ExternalConn.cpp:2521
 msgid "Unable to rename file."
 msgstr "No s'ha pogut canviar el nom del fitxer."
 
-#: src/ExternalConn.cpp:2839
-#, c-format
-msgid "Could not save the amuleapi password: %s"
-msgstr ""
-
-#: src/ExternalConn.cpp:3004 src/ExternalConn.cpp:3032
+#: src/ExternalConn.cpp:2992 src/ExternalConn.cpp:3020
 msgid "Kad is disabled in preferences."
 msgstr "Kad està inhabilitada a les preferències."
 
-#: src/ExternalConn.cpp:3045
+#: src/ExternalConn.cpp:3033
 msgid "Already connected to eD2k."
 msgstr "Ja esteu connectat a eD2k."
 
-#: src/ExternalConn.cpp:3048
+#: src/ExternalConn.cpp:3036
 msgid "Connecting to eD2k..."
 msgstr "Connectant a eD2k..."
 
-#: src/ExternalConn.cpp:3057
+#: src/ExternalConn.cpp:3045
 msgid "Already connected to Kad."
 msgstr "Ja esteu connectat a Kad."
 
-#: src/ExternalConn.cpp:3060
+#: src/ExternalConn.cpp:3048
 msgid "Connecting to Kad..."
 msgstr "S'està connectant a Kad..."
 
-#: src/ExternalConn.cpp:3067
+#: src/ExternalConn.cpp:3055
 msgid "All networks are disabled."
 msgstr "Totes les xarxes estan inhabilitades."
 
-#: src/ExternalConn.cpp:3076
+#: src/ExternalConn.cpp:3064
 msgid "Disconnected from eD2k."
 msgstr "Desconnectat de eD2k."
 
-#: src/ExternalConn.cpp:3081
+#: src/ExternalConn.cpp:3069
 msgid "Disconnected from Kad."
 msgstr "Desconnectat de Kad."
 
-#: src/ExternalConn.cpp:3090
+#: src/ExternalConn.cpp:3078
 #, c-format
 msgid "External Connection: invalid opcode received: %#x"
 msgstr "Connexió externa: s'ha rebut un codi d'opció invàlid: %#x"
 
-#: src/ExternalConn.cpp:3095
+#: src/ExternalConn.cpp:3083
 msgid "Invalid opcode (wrong protocol version?)"
 msgstr "Codi d'opció invàlid (versió de protocol errònia?)"
 
@@ -2343,19 +2333,19 @@ msgstr ""
 msgid "eD2k"
 msgstr "eD2k"
 
-#: src/FirstRunWizard.cpp:349 src/muuli_wdr.cpp:1495
+#: src/FirstRunWizard.cpp:349 src/muuli_wdr.cpp:1488
 msgid "Kademlia"
 msgstr "Kademlia"
 
-#: src/FirstRunWizard.cpp:359 src/muuli_wdr.cpp:1423
+#: src/FirstRunWizard.cpp:359 src/muuli_wdr.cpp:1416
 msgid "Standard TCP Port "
 msgstr "Port TCP per defecte:"
 
-#: src/FirstRunWizard.cpp:365 src/muuli_wdr.cpp:1435
+#: src/FirstRunWizard.cpp:365 src/muuli_wdr.cpp:1428
 msgid "Extended UDP port (Kad / global search) "
 msgstr "Port UDP extès (Kad / cerca global) "
 
-#: src/FirstRunWizard.cpp:377 src/muuli_wdr.cpp:1442
+#: src/FirstRunWizard.cpp:377 src/muuli_wdr.cpp:1435
 msgid "Enable UPnP for router port forwarding"
 msgstr "Activa UPnP per redirecció de ports"
 
@@ -2382,7 +2372,7 @@ msgstr ""
 msgid "Your peer lists are already in place - nothing to download."
 msgstr "Ja esteu intentant baixar el fitxer %s"
 
-#: src/FirstRunWizard.cpp:434 src/muuli_wdr.cpp:1540
+#: src/FirstRunWizard.cpp:434 src/muuli_wdr.cpp:1533
 msgid "Auto-update server list at startup"
 msgstr "Actualitza automàticament la llista de servidors a l'inici"
 
@@ -2428,23 +2418,23 @@ msgid ""
 "want downloads on a different (e.g. larger) disk."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:549 src/FirstRunWizard.cpp:611 src/muuli_wdr.cpp:1702
+#: src/FirstRunWizard.cpp:549 src/FirstRunWizard.cpp:611 src/muuli_wdr.cpp:1701
 msgid "Destination folder for downloads"
 msgstr "Carpeta on desar les descàrregues"
 
-#: src/FirstRunWizard.cpp:553 src/FirstRunWizard.cpp:569 src/muuli_wdr.cpp:1349
-#: src/muuli_wdr.cpp:1366 src/muuli_wdr.cpp:1677 src/muuli_wdr.cpp:1708
-#: src/muuli_wdr.cpp:1720 src/muuli_wdr.cpp:2790
+#: src/FirstRunWizard.cpp:553 src/FirstRunWizard.cpp:569 src/muuli_wdr.cpp:1342
+#: src/muuli_wdr.cpp:1359 src/muuli_wdr.cpp:1676 src/muuli_wdr.cpp:1707
+#: src/muuli_wdr.cpp:1719 src/muuli_wdr.cpp:2762
 #: src/utils/aLinkCreator/src/alcframe.cpp:135
 #: src/utils/wxCas/src/wxcasprefs.cpp:52 src/utils/wxCas/src/wxcasprefs.cpp:118
 msgid "Browse"
 msgstr "Explora"
 
-#: src/FirstRunWizard.cpp:559 src/muuli_wdr.cpp:1713
+#: src/FirstRunWizard.cpp:559 src/muuli_wdr.cpp:1712
 msgid "(All files in this folder are shared with other peers)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:565 src/FirstRunWizard.cpp:624 src/muuli_wdr.cpp:1715
+#: src/FirstRunWizard.cpp:565 src/FirstRunWizard.cpp:624 src/muuli_wdr.cpp:1714
 msgid "Folder for temporary download files"
 msgstr "Carpeta on desar les descàrregues temporals"
 
@@ -2475,7 +2465,7 @@ msgstr "No s'ha pogut obrir el fitxer amb la llista d'amics 'emfriends.met' per 
 msgid "CRITICAL - no client on StartChatSession"
 msgstr "CRITIC - no hi ha client a l'Inici de Sessió del Xat"
 
-#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2696 src/muuli_wdr.cpp:3373
+#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2668 src/muuli_wdr.cpp:3345
 msgid "Friends"
 msgstr "Amics"
 
@@ -2586,8 +2576,8 @@ msgstr "Cap"
 msgid "No"
 msgstr "No"
 
-#: src/GenericClientListCtrl.cpp:1216 src/PrefsUnifiedDlg.cpp:2898
-#: src/PrefsUnifiedDlg.cpp:2948 src/ServerListCtrl.cpp:276
+#: src/GenericClientListCtrl.cpp:1216 src/PrefsUnifiedDlg.cpp:2818
+#: src/PrefsUnifiedDlg.cpp:2868 src/ServerListCtrl.cpp:276
 msgid "Yes"
 msgstr "Sí"
 
@@ -2756,10 +2746,10 @@ msgstr "Port invàlid per a l'arrancada"
 msgid "Please fill all fields required"
 msgstr "Si us plau empleneu tots els camps requerits"
 
-#: src/KadDlg.cpp:192 src/PartFile.cpp:1031 src/PrefsUnifiedDlg.cpp:1134
-#: src/PrefsUnifiedDlg.cpp:1204 src/PrefsUnifiedDlg.cpp:1405
-#: src/PrefsUnifiedDlg.cpp:1663 src/PrefsUnifiedDlg.cpp:1673
-#: src/PrefsUnifiedDlg.cpp:1690 src/PrefsUnifiedDlg.cpp:1738
+#: src/KadDlg.cpp:192 src/PartFile.cpp:1031 src/PrefsUnifiedDlg.cpp:1162
+#: src/PrefsUnifiedDlg.cpp:1331 src/PrefsUnifiedDlg.cpp:1589
+#: src/PrefsUnifiedDlg.cpp:1599 src/PrefsUnifiedDlg.cpp:1616
+#: src/PrefsUnifiedDlg.cpp:1658
 msgid "Message"
 msgstr "Missatge"
 
@@ -2861,7 +2851,7 @@ msgstr "Ràtio"
 msgid "Uploaded"
 msgstr "Transferit"
 
-#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3253
+#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3225
 msgid "Requested"
 msgstr "Peticions"
 
@@ -2985,7 +2975,7 @@ msgid "WARNING: "
 msgstr "AVÍS: "
 
 #: src/MuleNotebook.cpp:179 src/muuli_wdr.cpp:817 src/muuli_wdr.cpp:1229
-#: src/muuli_wdr.cpp:3157 src/muuli_wdr.cpp:3413
+#: src/muuli_wdr.cpp:3129 src/muuli_wdr.cpp:3385
 msgid "Close"
 msgstr "Tanca"
 
@@ -2998,12 +2988,12 @@ msgstr "Retalla"
 msgid "Copy"
 msgstr "Copia"
 
-#: src/MuleTextCtrl.cpp:88 src/SearchDlg.cpp:261
+#: src/MuleTextCtrl.cpp:88
 msgid "Paste"
 msgstr "Enganxa"
 
 #: src/MuleTextCtrl.cpp:89 src/muuli_wdr.cpp:358 src/muuli_wdr.cpp:757
-#: src/muuli_wdr.cpp:2380 src/muuli_wdr.cpp:2399 src/muuli_wdr.cpp:2421
+#: src/muuli_wdr.cpp:2352 src/muuli_wdr.cpp:2371 src/muuli_wdr.cpp:2393
 #: src/utils/aLinkCreator/src/alcframe.cpp:142
 msgid "Clear"
 msgstr "Neteja"
@@ -3101,8 +3091,8 @@ msgid "Exit"
 msgstr "Surt"
 
 #: src/MuleTrayIcon.cpp:579 src/MuleTrayIcon.cpp:945 src/MuleTrayIcon.cpp:965
-#: src/muuli_wdr.cpp:1398 src/muuli_wdr.cpp:1406 src/muuli_wdr.cpp:1413
-#: src/muuli_wdr.cpp:1836 src/muuli_wdr.cpp:1842 src/OtherFunctions.cpp:91
+#: src/muuli_wdr.cpp:1391 src/muuli_wdr.cpp:1399 src/muuli_wdr.cpp:1406
+#: src/muuli_wdr.cpp:1835 src/muuli_wdr.cpp:1841 src/OtherFunctions.cpp:91
 #: src/StatisticsDlg.cpp:93 src/StatisticsDlg.cpp:95
 msgid "kB/s"
 msgstr "kB/s"
@@ -3273,7 +3263,7 @@ msgstr "Nom:"
 msgid "Type"
 msgstr "Tipus"
 
-#: src/muuli_wdr.cpp:215 src/SearchDlg.cpp:118 src/SearchListCtrl.cpp:853
+#: src/muuli_wdr.cpp:215 src/SearchDlg.cpp:110 src/SearchListCtrl.cpp:853
 msgid "Local"
 msgstr "Local"
 
@@ -3344,7 +3334,7 @@ msgstr "Bytes"
 msgid "KB"
 msgstr "KB"
 
-#: src/muuli_wdr.cpp:274 src/muuli_wdr.cpp:293 src/muuli_wdr.cpp:1621
+#: src/muuli_wdr.cpp:274 src/muuli_wdr.cpp:293 src/muuli_wdr.cpp:1620
 #: src/OtherFunctions.cpp:64
 msgid "MB"
 msgstr "MB"
@@ -3361,7 +3351,7 @@ msgstr "Mida Màx."
 msgid "Availability"
 msgstr "Disponibilitat"
 
-#: src/muuli_wdr.cpp:312 src/muuli_wdr.cpp:398 src/muuli_wdr.cpp:3318
+#: src/muuli_wdr.cpp:312 src/muuli_wdr.cpp:398 src/muuli_wdr.cpp:3290
 msgid "Filter:"
 msgstr "Filtre:"
 
@@ -3393,7 +3383,7 @@ msgstr ""
 msgid "Stop"
 msgstr "Atura"
 
-#: src/muuli_wdr.cpp:348 src/muuli_wdr.cpp:1392 src/SearchListCtrl.cpp:732
+#: src/muuli_wdr.cpp:348 src/muuli_wdr.cpp:1385 src/SearchListCtrl.cpp:732
 msgid "Download"
 msgstr "Baixada"
 
@@ -3424,12 +3414,12 @@ msgstr "Fonts del fitxer:"
 #: src/muuli_wdr.cpp:1160 src/muuli_wdr.cpp:1167 src/muuli_wdr.cpp:1172
 #: src/muuli_wdr.cpp:1179 src/muuli_wdr.cpp:1184 src/muuli_wdr.cpp:1191
 #: src/muuli_wdr.cpp:1205 src/muuli_wdr.cpp:1212 src/muuli_wdr.cpp:1217
-#: src/muuli_wdr.cpp:1224 src/muuli_wdr.cpp:3255 src/muuli_wdr.cpp:3263
-#: src/muuli_wdr.cpp:3271
+#: src/muuli_wdr.cpp:1224 src/muuli_wdr.cpp:3227 src/muuli_wdr.cpp:3235
+#: src/muuli_wdr.cpp:3243
 msgid "N/A"
 msgstr "N/D"
 
-#: src/muuli_wdr.cpp:508 src/muuli_wdr.cpp:1065 src/PrefsUnifiedDlg.cpp:299
+#: src/muuli_wdr.cpp:508 src/muuli_wdr.cpp:1065 src/PrefsUnifiedDlg.cpp:297
 msgid "General"
 msgstr "General "
 
@@ -3570,7 +3560,7 @@ msgstr ""
 msgid "Album :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:685 src/muuli_wdr.cpp:2275
+#: src/muuli_wdr.cpp:685 src/muuli_wdr.cpp:2247
 msgid "Title :"
 msgstr "Títol:"
 
@@ -3679,7 +3669,7 @@ msgstr "Usuari:"
 msgid "Userhash :"
 msgstr "Resum de l'usuari:"
 
-#: src/muuli_wdr.cpp:895 src/muuli_wdr.cpp:1742 src/muuli_wdr.cpp:2470
+#: src/muuli_wdr.cpp:895 src/muuli_wdr.cpp:1741 src/muuli_wdr.cpp:2442
 #: src/utils/aLinkCreator/src/alcframe.cpp:137
 msgid "Add"
 msgstr "Afegeix"
@@ -3688,15 +3678,15 @@ msgstr "Afegeix"
 msgid "Download-Speed"
 msgstr "Velocitat de baixada"
 
-#: src/muuli_wdr.cpp:954 src/muuli_wdr.cpp:989 src/muuli_wdr.cpp:2574
+#: src/muuli_wdr.cpp:954 src/muuli_wdr.cpp:989 src/muuli_wdr.cpp:2546
 msgid "Current"
 msgstr "Actual"
 
-#: src/muuli_wdr.cpp:962 src/muuli_wdr.cpp:997 src/muuli_wdr.cpp:2582
+#: src/muuli_wdr.cpp:962 src/muuli_wdr.cpp:997 src/muuli_wdr.cpp:2554
 msgid "Running average"
 msgstr "Mitjana total"
 
-#: src/muuli_wdr.cpp:970 src/muuli_wdr.cpp:1005 src/muuli_wdr.cpp:2590
+#: src/muuli_wdr.cpp:970 src/muuli_wdr.cpp:1005 src/muuli_wdr.cpp:2562
 msgid "Session average"
 msgstr "Mitjana de la sessió"
 
@@ -3708,7 +3698,7 @@ msgstr "Velocitat de pujada"
 msgid "Connections"
 msgstr "Connexions"
 
-#: src/muuli_wdr.cpp:1024 src/muuli_wdr.cpp:1861
+#: src/muuli_wdr.cpp:1024 src/muuli_wdr.cpp:1860
 msgid "Active downloads"
 msgstr "Baixades actives"
 
@@ -3716,7 +3706,7 @@ msgstr "Baixades actives"
 msgid "Active connections (1:1)"
 msgstr "Connexions actives (1:1)"
 
-#: src/muuli_wdr.cpp:1040 src/muuli_wdr.cpp:1862
+#: src/muuli_wdr.cpp:1040 src/muuli_wdr.cpp:1861
 msgid "Active uploads"
 msgstr "Pujades actives"
 
@@ -3832,8 +3822,8 @@ msgstr "Aquest és el (vostre) nom que els altres usuaris veuran en connectar-se
 msgid "Language: "
 msgstr "Idioma: "
 
-#: src/muuli_wdr.cpp:1257 src/muuli_wdr.cpp:1330 src/muuli_wdr.cpp:1334
-#: src/muuli_wdr.cpp:1337
+#: src/muuli_wdr.cpp:1257 src/muuli_wdr.cpp:1323 src/muuli_wdr.cpp:1327
+#: src/muuli_wdr.cpp:1330
 msgid "The delay before showing tool-tips."
 msgstr "El retard abans de mostrar els consells (notes emergents)."
 
@@ -3911,960 +3901,936 @@ msgstr "Mostra notificacions en finalitzar les baixades"
 msgid "Enabling this will make aMule to show notifications when finished downloading."
 msgstr "Si s'habilita, l'aMule mostrarà notificacions quan hagin finalitzat les baixades."
 
-#: src/muuli_wdr.cpp:1323
-#, fuzzy
-msgid "Remember search history"
-msgstr "Recorda la configuració"
-
-#: src/muuli_wdr.cpp:1324
-msgid "Keeps a dropdown list of your past search terms in the Search tab's Name field. This remembers the queries you typed, not the results they returned."
-msgstr ""
-
-#: src/muuli_wdr.cpp:1329
+#: src/muuli_wdr.cpp:1322
 msgid "Tooltip delay time: "
 msgstr "Temps de retard de l'indicador de funció:"
 
-#: src/muuli_wdr.cpp:1336
+#: src/muuli_wdr.cpp:1329
 msgid "seconds"
 msgstr "segons"
 
-#: src/muuli_wdr.cpp:1340
+#: src/muuli_wdr.cpp:1333
 msgid "Browser Selection"
 msgstr "Selecció del navegador"
 
-#: src/muuli_wdr.cpp:1346
+#: src/muuli_wdr.cpp:1339
 msgid "Enter your browser name here. Leave this field empty to use the system default browser."
 msgstr "Introdueix el nom del teu navegador. Deixa el camp buit per usar el navegador per defecte del sistema."
 
-#: src/muuli_wdr.cpp:1353
+#: src/muuli_wdr.cpp:1346
 msgid "Open in new tab if possible"
 msgstr "Obre en una nova pestanya si és possible"
 
-#: src/muuli_wdr.cpp:1355
+#: src/muuli_wdr.cpp:1348
 msgid "Open the web page in a new tab instead of in a new window when possible"
 msgstr "Obre la pàgina web en una nova pestanya en comptes de obrir una nova finestra si és possible"
 
-#: src/muuli_wdr.cpp:1359
+#: src/muuli_wdr.cpp:1352
 msgid "Video Player"
 msgstr "Reproductor de vídeo"
 
-#: src/muuli_wdr.cpp:1386
+#: src/muuli_wdr.cpp:1379
 msgid "Bandwidth limits"
 msgstr "Límits d'ample de banda "
 
-#: src/muuli_wdr.cpp:1400
+#: src/muuli_wdr.cpp:1393
 msgid "Upload"
 msgstr "Pujada"
 
-#: src/muuli_wdr.cpp:1408
+#: src/muuli_wdr.cpp:1401
 msgid "Slot Allocation"
 msgstr "Per posició (slot)"
 
-#: src/muuli_wdr.cpp:1417
+#: src/muuli_wdr.cpp:1410
 msgid "Ports"
 msgstr "Ports "
 
-#: src/muuli_wdr.cpp:1427
+#: src/muuli_wdr.cpp:1420
 msgid "This is the standard eD2k port and cannot be disabled."
 msgstr "Aquest és el port eD2k estàndard i no es pot inhabilitar."
 
-#: src/muuli_wdr.cpp:1430
+#: src/muuli_wdr.cpp:1423
 msgid "UDP port for server requests (TCP+3):"
 msgstr "Port UDP per sol·licituds del servidor (TCP+3):"
 
-#: src/muuli_wdr.cpp:1432
+#: src/muuli_wdr.cpp:1425
 msgid "4665"
 msgstr "4665"
 
-#: src/muuli_wdr.cpp:1439
+#: src/muuli_wdr.cpp:1432
 msgid "This UDP port is used for extended eD2k requests and Kad network"
 msgstr "Aquest port UDP és utilitzat per sol·licituds eD2k i Kad exteses"
 
-#: src/muuli_wdr.cpp:1446
+#: src/muuli_wdr.cpp:1439
 msgid "UPnP TCP Port (Optional):"
 msgstr "UPnP Port TCP (Opcional):"
 
-#: src/muuli_wdr.cpp:1456
+#: src/muuli_wdr.cpp:1449
 msgid "Bind local address to IP (empty for any):"
 msgstr "Vincula l'adreça local a l'IP (buit per qualsevol):"
 
-#: src/muuli_wdr.cpp:1459
+#: src/muuli_wdr.cpp:1452
 msgid "Advanced users only: If you have multiple network interfaces, enter the address of the interface to which aMule should be bound."
 msgstr "Només usuaris avançats: Si disposeu de multiples interfícies de xarxa, entreu l'adreça de la interfície a la que l'aMule hauria d'estar vinculada."
 
-#: src/muuli_wdr.cpp:1462 src/muuli_wdr.cpp:2055
+#: src/muuli_wdr.cpp:1455 src/muuli_wdr.cpp:2054
 #, fuzzy
 msgid "Bind to network interface (empty for any):"
 msgstr "Vincula l'adreça local a l'IP (buit per qualsevol):"
 
-#: src/muuli_wdr.cpp:1475
+#: src/muuli_wdr.cpp:1468
 msgid "Advanced users only: pin all of aMule's traffic to one network interface, chosen from the list or typed in by name (e.g. tun0, eth0, en0) or index. Unlike binding to an IP, this stops traffic leaking out via the default route - useful with a VPN. Requires no elevated privileges."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1481
+#: src/muuli_wdr.cpp:1474
 msgid "Max sources per downloading file:"
 msgstr "Nombre màxim de fonts per descàrrega:"
 
-#: src/muuli_wdr.cpp:1485
+#: src/muuli_wdr.cpp:1478
 msgid "Max simultaneous connections:"
 msgstr "Nombre màxim de connexions simultànies:"
 
-#: src/muuli_wdr.cpp:1498 src/muuli_wdr.cpp:3197
+#: src/muuli_wdr.cpp:1491 src/muuli_wdr.cpp:3169
 msgid "ED2K"
 msgstr "ED2K"
 
-#: src/muuli_wdr.cpp:1505
+#: src/muuli_wdr.cpp:1498
 msgid "Autoconnect on startup"
 msgstr "Autoconnecta a l'inici"
 
-#: src/muuli_wdr.cpp:1508
+#: src/muuli_wdr.cpp:1501
 msgid "Reconnect on loss"
 msgstr "Reconnecta en perdre la connexió"
 
-#: src/muuli_wdr.cpp:1530
+#: src/muuli_wdr.cpp:1523
 msgid "Remove dead server after"
 msgstr "Elimina els servidors morts després de"
 
-#: src/muuli_wdr.cpp:1531
+#: src/muuli_wdr.cpp:1524
 msgid "Static servers are never removed, even when unreachable."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1535
+#: src/muuli_wdr.cpp:1528
 msgid "retries"
 msgstr "intents"
 
-#: src/muuli_wdr.cpp:1543
+#: src/muuli_wdr.cpp:1536
 msgid "List"
 msgstr "Llista"
 
-#: src/muuli_wdr.cpp:1546
+#: src/muuli_wdr.cpp:1539
 msgid "Update server list when connecting to a server"
 msgstr "Actualitza la llista de servidors quan es connecti amb un servidor"
 
-#: src/muuli_wdr.cpp:1549
+#: src/muuli_wdr.cpp:1542
 msgid "Update server list when a client connects"
 msgstr "Actualitza la llista de servidors quan es connecta un client"
 
-#: src/muuli_wdr.cpp:1552
+#: src/muuli_wdr.cpp:1545
 msgid "Use priority system"
 msgstr "Usa el sistema de prioritats"
 
-#: src/muuli_wdr.cpp:1556
+#: src/muuli_wdr.cpp:1549
 msgid "Use smart LowID check on connect"
 msgstr "Usa la comprovació intel·ligent d'ID Baixa en connectar"
 
-#: src/muuli_wdr.cpp:1560
+#: src/muuli_wdr.cpp:1553
 msgid "Safe connect"
 msgstr "Connexió segura"
 
-#: src/muuli_wdr.cpp:1564
+#: src/muuli_wdr.cpp:1557
 msgid "Autoconnect to servers in static list only"
 msgstr "Autoconnecta només a servidors de la llista estàtica"
 
-#: src/muuli_wdr.cpp:1567
+#: src/muuli_wdr.cpp:1560
 msgid "Set manually added servers to High Priority"
 msgstr "Estableix prioritat Alta per als servidors afegits manualment"
 
-#: src/muuli_wdr.cpp:1588
+#: src/muuli_wdr.cpp:1581
 msgid "Add files to download in pause mode"
 msgstr "Afegeix les noves baixades en mode pausat"
 
-#: src/muuli_wdr.cpp:1590
+#: src/muuli_wdr.cpp:1583
 msgid "Add files to download with auto priority"
 msgstr "Afegeix les noves baixades amb prioritat automàtica"
 
-#: src/muuli_wdr.cpp:1593
+#: src/muuli_wdr.cpp:1586
 msgid "Try to download first and last chunks first"
 msgstr "Intenta baixar abans les parts inicials i finals"
 
-#: src/muuli_wdr.cpp:1597
+#: src/muuli_wdr.cpp:1590
 msgid "Endgame mode: rotate to faster sources for the final blocks"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1600
+#: src/muuli_wdr.cpp:1593
 msgid "Start next paused file when a file completes"
 msgstr "Inicia el següent fitxer pausat quan s'acabi una descàrrega"
 
-#: src/muuli_wdr.cpp:1603
+#: src/muuli_wdr.cpp:1596
 msgid "From the same category"
 msgstr "De la mateixa categoria"
 
-#: src/muuli_wdr.cpp:1605
+#: src/muuli_wdr.cpp:1598
 msgid "In alphabetic order"
 msgstr "En ordre alfabètic"
 
-#: src/muuli_wdr.cpp:1607
+#: src/muuli_wdr.cpp:1600
 msgid "Preallocate disk space for new files"
 msgstr "Preassigna l'espai al disc per als fitxers nous"
 
-#: src/muuli_wdr.cpp:1608
+#: src/muuli_wdr.cpp:1601
 msgid "For new files preallocates disk space for the whole file, thus reduces fragmentation"
 msgstr "Per a fitxers nous reserva l'espai que ocuparà el fitxer complet. Açò redueix la fragmentació"
 
-#: src/muuli_wdr.cpp:1613
+#: src/muuli_wdr.cpp:1606
+msgid "Create new files as sparse files"
+msgstr ""
+
+#: src/muuli_wdr.cpp:1607
+msgid "A sparse file reserves its full size on disk immediately without writing real data to it -- fast, but unsupported or slow on some filesystems, and free-space accounting stays optimistic while the download is in progress. Turn this off to grow the file only as data arrives."
+msgstr ""
+
+#: src/muuli_wdr.cpp:1612
 msgid "Stop downloads when free disk space reaches "
 msgstr "Atura les descàrregues quan l'espai buit al disc arribi a "
 
-#: src/muuli_wdr.cpp:1614
+#: src/muuli_wdr.cpp:1613
 msgid "Select this if you want aMule to check your disk space"
 msgstr "Seleccioneu-ho si voleu que l'aMule comprovi l'espai del disc"
 
-#: src/muuli_wdr.cpp:1618
+#: src/muuli_wdr.cpp:1617
 msgid "Enter here the min disk space desired."
 msgstr "Poseu l'espai mínim de disc desitjat."
 
-#: src/muuli_wdr.cpp:1624
+#: src/muuli_wdr.cpp:1623
 msgid "Save 10 sources on rare files (< 20 sources)"
 msgstr "Recorda 10 fonts dels fitxers rars (amb < 20 fonts)"
 
-#: src/muuli_wdr.cpp:1628 src/Statistics.cpp:790
+#: src/muuli_wdr.cpp:1627 src/Statistics.cpp:790
 msgid "Uploads"
 msgstr "Pujades"
 
-#: src/muuli_wdr.cpp:1631
+#: src/muuli_wdr.cpp:1630
 msgid "Add new shared files with auto priority"
 msgstr "Afegeix els nous fitxer compartits amb prioritat automàtica"
 
-#: src/muuli_wdr.cpp:1637
+#: src/muuli_wdr.cpp:1636
 msgid "Intelligent Corruption Handling (I.C.H.)"
 msgstr "Gestió d'Errors Inteligent (I.C.H.)"
 
-#: src/muuli_wdr.cpp:1640
+#: src/muuli_wdr.cpp:1639
 msgid "Enable"
 msgstr "Activa"
 
-#: src/muuli_wdr.cpp:1643
+#: src/muuli_wdr.cpp:1642
 msgid "Advanced I.C.H. trusts every hash (not recommended)"
 msgstr "I.C.H. avançat confia en totes les comprovacions (no recomanat)"
 
-#: src/muuli_wdr.cpp:1655 src/PrefsUnifiedDlg.cpp:1990
+#: src/muuli_wdr.cpp:1654 src/PrefsUnifiedDlg.cpp:1910
 msgid "Media metadata extraction"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1659
+#: src/muuli_wdr.cpp:1658
 msgid "Extract length / bitrate / codec from shared audio and video files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1661
+#: src/muuli_wdr.cpp:1660
 msgid "When enabled, aMule runs ffprobe on each shared media file to fill in the Length / Bitrate / Codec columns other clients see when they find the file in a search. Requires ffmpeg (the ffprobe binary) to be installed."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1668
+#: src/muuli_wdr.cpp:1667
 msgid "Path to ffprobe:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1673
+#: src/muuli_wdr.cpp:1672
 msgid "Full path to the ffprobe binary. Leave empty to have aMule auto-detect it on startup."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1681
+#: src/muuli_wdr.cpp:1680
 msgid "Detect"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1682
+#: src/muuli_wdr.cpp:1681
 msgid "Search the standard install locations for an ffprobe binary and fill the path field."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1706
+#: src/muuli_wdr.cpp:1705
 msgid ""
 "Completed downloads are stored here. All files in this folder are automatically shared with other peers.\n"
 "If this folder also holds files you don't want to share, point it at an aMule-only sub-folder."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1709
+#: src/muuli_wdr.cpp:1708
 msgid "Pick the folder where completed downloads will be stored. All files in that folder will be shared with other peers."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1723
+#: src/muuli_wdr.cpp:1722
 msgid "Shared folders"
 msgstr "Carpetes compartides"
 
-#: src/muuli_wdr.cpp:1729
+#: src/muuli_wdr.cpp:1728
 msgid "(Folders shared by the core. Enter a path to add one.)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1737
+#: src/muuli_wdr.cpp:1736
 msgid "Absolute path of a folder on the core's machine, e.g. /home/user/shared"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1739 src/PrefsUnifiedDlg.cpp:2874
+#: src/muuli_wdr.cpp:1738 src/PrefsUnifiedDlg.cpp:2794
 msgid "Recursive"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1740
+#: src/muuli_wdr.cpp:1739
 msgid "Share every sub-folder underneath this one, including ones created later."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1744 src/utils/aLinkCreator/src/alcframe.cpp:141
+#: src/muuli_wdr.cpp:1743 src/utils/aLinkCreator/src/alcframe.cpp:141
 msgid "Remove"
 msgstr "Esborra"
 
-#: src/muuli_wdr.cpp:1748
+#: src/muuli_wdr.cpp:1747
 msgid "(Right click on folder icon for recursive share)"
 msgstr "(Per a compartir recursivament feu clic dret sobre el directori)"
 
-#: src/muuli_wdr.cpp:1755
+#: src/muuli_wdr.cpp:1754
 msgid "Share hidden files"
 msgstr "Comparteix els fitxers ocults"
 
-#: src/muuli_wdr.cpp:1761
+#: src/muuli_wdr.cpp:1760
 msgid "Automatically rescan shared folders for changes"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1767
+#: src/muuli_wdr.cpp:1766
 msgid "Follow symbolic links in shared folders"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1773
+#: src/muuli_wdr.cpp:1772
 msgid "Exclude files matching:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1776
+#: src/muuli_wdr.cpp:1775
 msgid "Wildcard patterns separated by '|', e.g. .DS_Store|Thumbs.db|*.tmp. Files whose name matches are not shared. Matching is case-insensitive."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1780
+#: src/muuli_wdr.cpp:1779
 msgid "Patterns are regular expressions"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1781
+#: src/muuli_wdr.cpp:1780
 msgid "When set, the whole field is one regular expression ('|' is alternation). When unset, it is a list of '|'-separated wildcards."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1791
+#: src/muuli_wdr.cpp:1790
 msgid "Show how many shared files the current pattern would exclude."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1812
+#: src/muuli_wdr.cpp:1811
 msgid "Graphs"
 msgstr "Gràfics"
 
-#: src/muuli_wdr.cpp:1815 src/muuli_wdr.cpp:1877
+#: src/muuli_wdr.cpp:1814 src/muuli_wdr.cpp:1876
 msgid "Update delay : 5 secs"
 msgstr "Actualitza cada: 5 segs"
 
-#: src/muuli_wdr.cpp:1819
+#: src/muuli_wdr.cpp:1818
 msgid "Time for average graph: 100 mins"
 msgstr "Temps per al gràfic de mitjana: 100 mins"
 
-#: src/muuli_wdr.cpp:1823
+#: src/muuli_wdr.cpp:1822
 msgid "Connections Graph Scale: 100 "
 msgstr "Escala del Gràfic de Connexions: 100 "
 
-#: src/muuli_wdr.cpp:1830
+#: src/muuli_wdr.cpp:1829
 msgid "Download graph scale:"
 msgstr "Escala del gràfic de descàrrega:"
 
-#: src/muuli_wdr.cpp:1838
+#: src/muuli_wdr.cpp:1837
 msgid "Upload graph scale:"
 msgstr "Escala del gràfic de pujada:"
 
-#: src/muuli_wdr.cpp:1848
+#: src/muuli_wdr.cpp:1847
 #, fuzzy
 msgid "Colors: "
 msgstr "Colors: "
 
-#: src/muuli_wdr.cpp:1852
+#: src/muuli_wdr.cpp:1851
 msgid "Background"
 msgstr "Fons"
 
-#: src/muuli_wdr.cpp:1853
+#: src/muuli_wdr.cpp:1852
 msgid "Grid"
 msgstr "Graella"
 
-#: src/muuli_wdr.cpp:1854
+#: src/muuli_wdr.cpp:1853
 msgid "Download current"
 msgstr "Baixada actual"
 
-#: src/muuli_wdr.cpp:1855
+#: src/muuli_wdr.cpp:1854
 msgid "Download running average"
 msgstr "Mitjana de baixada total"
 
-#: src/muuli_wdr.cpp:1856
+#: src/muuli_wdr.cpp:1855
 msgid "Download session average"
 msgstr "Mitjana de baixada de la sessió"
 
-#: src/muuli_wdr.cpp:1857
+#: src/muuli_wdr.cpp:1856
 msgid "Upload current"
 msgstr "Pujada actual"
 
-#: src/muuli_wdr.cpp:1858
+#: src/muuli_wdr.cpp:1857
 msgid "Upload running average"
 msgstr "Mitjana de pujada total"
 
-#: src/muuli_wdr.cpp:1859
+#: src/muuli_wdr.cpp:1858
 msgid "Upload session average"
 msgstr "Mitjana de pujada de la sessió"
 
-#: src/muuli_wdr.cpp:1860
+#: src/muuli_wdr.cpp:1859
 msgid "Active connections"
 msgstr "Connexions actives"
 
-#: src/muuli_wdr.cpp:1863
+#: src/muuli_wdr.cpp:1862
 #, fuzzy
 msgid "Systray Icon Speed Bar"
 msgstr "Barra de velocitat de la icona d'estat"
 
-#: src/muuli_wdr.cpp:1864
+#: src/muuli_wdr.cpp:1863
 msgid "Kad-nodes current"
 msgstr "Nodes-Kad actuals"
 
-#: src/muuli_wdr.cpp:1865
+#: src/muuli_wdr.cpp:1864
 msgid "Kad-nodes running"
 msgstr "Nodes-Kad funcionant"
 
-#: src/muuli_wdr.cpp:1866
+#: src/muuli_wdr.cpp:1865
 msgid "Kad-nodes session"
 msgstr "Nodes-Kad de la sessió"
 
-#: src/muuli_wdr.cpp:1870 src/muuli_wdr.cpp:2324
+#: src/muuli_wdr.cpp:1869 src/muuli_wdr.cpp:2296
 msgid "Select"
 msgstr "Selecciona"
 
-#: src/muuli_wdr.cpp:1874
+#: src/muuli_wdr.cpp:1873
 msgid "Tree"
 msgstr "Arbre"
 
-#: src/muuli_wdr.cpp:1884
+#: src/muuli_wdr.cpp:1883
 msgid "Number of Client Versions shown (0=unlimited)"
 msgstr "Nombre de versions de client a mostrar (0=il·limitat)"
 
-#: src/muuli_wdr.cpp:1909
+#: src/muuli_wdr.cpp:1908
 msgid "!!! WARNING !!!"
 msgstr "!!! AVÍS !!!"
 
-#: src/muuli_wdr.cpp:1924
+#: src/muuli_wdr.cpp:1923
 msgid "Max new connections / 5 secs"
 msgstr "Connexions noves màx. / 5 segs"
 
-#: src/muuli_wdr.cpp:1926
+#: src/muuli_wdr.cpp:1925
 msgid "Concurrent Kad source lookups"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1928
+#: src/muuli_wdr.cpp:1927
 #, fuzzy
 msgid "Kad source re-search interval (minutes)"
 msgstr "Interval d'actualització de l'FTP en minuts"
 
-#: src/muuli_wdr.cpp:1930
+#: src/muuli_wdr.cpp:1929
 #, fuzzy
 msgid "Source re-ask interval (minutes)"
 msgstr "Interval d'actualització de l'FTP en minuts"
 
-#: src/muuli_wdr.cpp:1934
+#: src/muuli_wdr.cpp:1933
 msgid "File Buffer Size: 240000 bytes"
 msgstr "Mida del buffer de fitxer: 240000 bytes"
 
-#: src/muuli_wdr.cpp:1938
+#: src/muuli_wdr.cpp:1937
 msgid "Use MMAP: memory-mapped file access (lower memory use)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1939
+#: src/muuli_wdr.cpp:1938
 msgid "Maps part files into memory instead of buffering them on the heap, lowering the process memory footprint. May reduce download speed on some disks; best for memory-constrained or upload-heavy hosts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1941
+#: src/muuli_wdr.cpp:1940
 msgid "Upload Queue Size: 5000 clients"
 msgstr "Mida de la cua de pujades: 5000 clients"
 
-#: src/muuli_wdr.cpp:1945
+#: src/muuli_wdr.cpp:1944
 msgid "Server connection refresh interval: Disable"
 msgstr "Interval de refresc de la connexió amb el servidor: Inhabilitat"
 
-#: src/muuli_wdr.cpp:1949
+#: src/muuli_wdr.cpp:1948
 msgid "Disable computer's timed standby mode"
 msgstr "Inhabilita el mode d'espera programat de l'ordinador"
 
-#: src/muuli_wdr.cpp:1968
+#: src/muuli_wdr.cpp:1967
 msgid "Skin to use: "
 msgstr "Aparença a usar: "
 
-#: src/muuli_wdr.cpp:1977
+#: src/muuli_wdr.cpp:1976
 msgid "Show \"Fast eD2k Links Handler\" in every window."
 msgstr "Mostra \"Gestor ràpid de links eD2k\" en totes les finestres."
 
-#: src/muuli_wdr.cpp:1980
+#: src/muuli_wdr.cpp:1979
 msgid "Show extended info on categories tabs"
 msgstr "Mostra informació estesa a les pestanyes de les categories"
 
-#: src/muuli_wdr.cpp:1983
+#: src/muuli_wdr.cpp:1982
 msgid "Show application version on title"
 msgstr "Mostra la versió de l'aplicació al títol"
 
-#: src/muuli_wdr.cpp:1985
+#: src/muuli_wdr.cpp:1984
 msgid "Show transfer rates on title"
 msgstr "Mostra les velocitats de transferència al títol"
 
-#: src/muuli_wdr.cpp:1987
+#: src/muuli_wdr.cpp:1986
 msgid "Before application name"
 msgstr "Abans del nom de l'aplicació"
 
-#: src/muuli_wdr.cpp:1989
+#: src/muuli_wdr.cpp:1988
 msgid "After application name"
 msgstr "Després del nom de l'aplicació"
 
-#: src/muuli_wdr.cpp:1992
+#: src/muuli_wdr.cpp:1991
 msgid "Show overhead bandwidth"
 msgstr "Mostra ample de banda sobrecarregat"
 
-#: src/muuli_wdr.cpp:1996
+#: src/muuli_wdr.cpp:1995
 msgid "Vertical toolbar orientation"
 msgstr "Orientació vertical de la barra d'eines"
 
-#: src/muuli_wdr.cpp:1998
+#: src/muuli_wdr.cpp:1997
 msgid "Live column sorting (auto-reorder rows as their values change)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2005
+#: src/muuli_wdr.cpp:2004
 msgid "Download Queue Files"
 msgstr "Cua de descàrregues"
 
-#: src/muuli_wdr.cpp:2008
+#: src/muuli_wdr.cpp:2007
 msgid "Show progress percentage"
 msgstr "Mostra el percentatge de descàrrega"
 
-#: src/muuli_wdr.cpp:2014
+#: src/muuli_wdr.cpp:2013
 msgid "Show progress bar"
 msgstr "Mostra barra de descàrrega"
 
-#: src/muuli_wdr.cpp:2017
+#: src/muuli_wdr.cpp:2016
 msgid "Flat"
 msgstr "Plana"
 
-#: src/muuli_wdr.cpp:2021
+#: src/muuli_wdr.cpp:2020
 msgid "Round"
 msgstr "Arrodonida"
 
-#: src/muuli_wdr.cpp:2039
+#: src/muuli_wdr.cpp:2038
 msgid "External Connection Parameters"
 msgstr "Paràmetres de la connexió externa "
 
-#: src/muuli_wdr.cpp:2042
+#: src/muuli_wdr.cpp:2041
 msgid "Accept external connections"
 msgstr "Accepta connexions externes"
 
-#: src/muuli_wdr.cpp:2049 src/muuli_wdr.cpp:2108
+#: src/muuli_wdr.cpp:2048 src/muuli_wdr.cpp:2107
 msgid "IP of the listening interface:"
 msgstr "IP de la interfície que rep connexions:"
 
-#: src/muuli_wdr.cpp:2052
+#: src/muuli_wdr.cpp:2051
 msgid "Enter here a valid ip in the a.b.c.d format for the listening EC interface. An empty field or 0.0.0.0 will mean any interface."
 msgstr "Introduïu una IP vàlida amb format a.b.c.d per a la interfície EC que escolta. Un camp buit o 0.0.0.0 significarà qualsevol interfície."
 
-#: src/muuli_wdr.cpp:2073 src/muuli_wdr.cpp:2184
+#: src/muuli_wdr.cpp:2072 src/muuli_wdr.cpp:2156
 msgid "TCP port:"
 msgstr "Port TCP:"
 
-#: src/muuli_wdr.cpp:2079
+#: src/muuli_wdr.cpp:2078
 msgid "Enable UPnP port forwarding on the EC port"
 msgstr "Activa l'encaminament UPnP al port de connexions externes"
 
-#: src/muuli_wdr.cpp:2083 src/muuli_wdr.cpp:3069
+#: src/muuli_wdr.cpp:2082 src/muuli_wdr.cpp:3041
 #: src/utils/wxCas/src/wxcasprefs.cpp:167
 msgid "Password"
 msgstr "Contrasenya"
 
-#: src/muuli_wdr.cpp:2089
+#: src/muuli_wdr.cpp:2088
 #, fuzzy
 msgid "aMule API server parameters"
 msgstr "Paràmetres del servidor web "
 
-#: src/muuli_wdr.cpp:2092
+#: src/muuli_wdr.cpp:2091
 msgid "Run amuleapi (REST API) on startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2097
+#: src/muuli_wdr.cpp:2096
 #, fuzzy
 msgid "HTTP port:"
 msgstr "Port TCP:"
 
-#: src/muuli_wdr.cpp:2111
+#: src/muuli_wdr.cpp:2110
 msgid "The interface amuleapi's HTTP server listens on. 127.0.0.1 (default) accepts only local connections; use 0.0.0.0 or a specific IP to expose it to other hosts (set an admin password below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2116
-msgid "Type a password to set or change it. Stored passwords cannot be shown, so leaving this empty keeps the current one."
-msgstr ""
-
-#: src/muuli_wdr.cpp:2118
+#: src/muuli_wdr.cpp:2113
 #, fuzzy
 msgid "Admin password"
 msgstr "S'està comprovant la contrasenya\n"
 
-#: src/muuli_wdr.cpp:2130 src/muuli_wdr.cpp:2147 src/PrefsUnifiedDlg.cpp:1103
-#, fuzzy
-msgid "A password is set."
-msgstr "S'està comprovant la contrasenya\n"
+#: src/muuli_wdr.cpp:2118 src/muuli_wdr.cpp:2149
+msgid "Low rights password"
+msgstr "Contrasenya del convidat:"
 
-#: src/muuli_wdr.cpp:2134
-#, fuzzy
-msgid "Enable guest access"
-msgstr "Denega l'accés de convidats"
-
-#: src/muuli_wdr.cpp:2135
-msgid "Guest sessions may read status and listings but cannot change anything. Turning this off clears the stored guest password."
-msgstr ""
-
-#: src/muuli_wdr.cpp:2139
-#, fuzzy
-msgid "Guest password"
-msgstr "Contrasenya de convidat per al servidor web"
-
-#: src/muuli_wdr.cpp:2154
+#: src/muuli_wdr.cpp:2126
 msgid "Web server parameters"
 msgstr "Paràmetres del servidor web "
 
-#: src/muuli_wdr.cpp:2157
+#: src/muuli_wdr.cpp:2129
 #, fuzzy
 msgid "Run webserver on startup (deprecated)"
 msgstr "Executa el servidor web a l'inici"
 
-#: src/muuli_wdr.cpp:2163
+#: src/muuli_wdr.cpp:2135
 msgid "Web template"
 msgstr "Plantilla web"
 
-#: src/muuli_wdr.cpp:2168
+#: src/muuli_wdr.cpp:2140
 msgid "Full rights password"
 msgstr "Contrasenya de l'administrador:"
 
-#: src/muuli_wdr.cpp:2172
+#: src/muuli_wdr.cpp:2144
 msgid "Enable Low rights User"
 msgstr "Habilita l'usuari convidat"
 
-#: src/muuli_wdr.cpp:2177
-msgid "Low rights password"
-msgstr "Contrasenya del convidat:"
-
-#: src/muuli_wdr.cpp:2191
+#: src/muuli_wdr.cpp:2163
 msgid "Enable UPnP port forwarding of the web server port"
 msgstr "Activa redirecció de ports UPnP en el port del servidor web"
 
-#: src/muuli_wdr.cpp:2196
+#: src/muuli_wdr.cpp:2168
 msgid "Web server UPnP TCP port (Optional)"
 msgstr "Port TCP del servidor web (Opcional):"
 
-#: src/muuli_wdr.cpp:2204
+#: src/muuli_wdr.cpp:2176
 msgid "Page Refresh Time (in secs)"
 msgstr "Temps de refresc de la pàgina (en segons):"
 
-#: src/muuli_wdr.cpp:2211
+#: src/muuli_wdr.cpp:2183
 msgid "Enable Gzip compression"
 msgstr "Habilita la compressió Gzip"
 
-#: src/muuli_wdr.cpp:2245
+#: src/muuli_wdr.cpp:2217
 #, fuzzy
 msgid "Reset page to defaults"
 msgstr "Predeterminat"
 
-#: src/muuli_wdr.cpp:2246
+#: src/muuli_wdr.cpp:2218
 msgid "Reset the settings on the current page to their default values."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2248 src/muuli_wdr.cpp:2334 src/ServerWnd.cpp:274
+#: src/muuli_wdr.cpp:2220 src/muuli_wdr.cpp:2306 src/ServerWnd.cpp:274
 #: src/ServerWnd.cpp:282
 msgid "OK"
 msgstr "OK"
 
-#: src/muuli_wdr.cpp:2250
+#: src/muuli_wdr.cpp:2222
 msgid "Click here to apply any changes made to the preferences."
 msgstr "Feu clic per a aplicar qualsevol canvi fet a les preferències."
 
-#: src/muuli_wdr.cpp:2253
+#: src/muuli_wdr.cpp:2225
 msgid "Reset any changes made to the preferences."
 msgstr "Reinicia qualsevol canvi fet a les preferències."
 
-#: src/muuli_wdr.cpp:2282
+#: src/muuli_wdr.cpp:2254
 msgid "Comment :"
 msgstr "Comentari:"
 
-#: src/muuli_wdr.cpp:2289
+#: src/muuli_wdr.cpp:2261
 msgid "Incoming Dir :"
 msgstr "Dir. d'entrada:"
 
-#: src/muuli_wdr.cpp:2298
+#: src/muuli_wdr.cpp:2270
 msgid "Change priority for new assigned files :"
 msgstr "Canvia la prioritat per als nous fitxers assignats:"
 
-#: src/muuli_wdr.cpp:2302
+#: src/muuli_wdr.cpp:2274
 msgid "Don't change"
 msgstr "No canviar"
 
-#: src/muuli_wdr.cpp:2314
+#: src/muuli_wdr.cpp:2286
 msgid "Select color for this Category (currently selected) :"
 msgstr "Seleccioneu un color per a la Categoria (actualment seleccionat):"
 
-#: src/muuli_wdr.cpp:2381 src/muuli_wdr.cpp:2400 src/muuli_wdr.cpp:2422
+#: src/muuli_wdr.cpp:2353 src/muuli_wdr.cpp:2372 src/muuli_wdr.cpp:2394
 msgid "Click this button to reset the log."
 msgstr "Feu clic per a reiniciar el registre."
 
-#: src/muuli_wdr.cpp:2441
+#: src/muuli_wdr.cpp:2413
 msgid "Click on this button to update the servers list from URL ..."
 msgstr "Feu clic en aquest botó per a actualitzar la llista de servidors des d'una URL ... "
 
-#: src/muuli_wdr.cpp:2445
+#: src/muuli_wdr.cpp:2417
 msgid "Server list"
 msgstr "Llista de servidors"
 
-#: src/muuli_wdr.cpp:2449
+#: src/muuli_wdr.cpp:2421
 msgid "Enter the url to a server.met file here and press the button to the left to update the list of known servers."
 msgstr "Introduïu l'adreça d'un fitxer server.met i premeu el botó de l'esquerra per a actualitzar la llista de servidors coneguts."
 
-#: src/muuli_wdr.cpp:2454
+#: src/muuli_wdr.cpp:2426
 msgid "Add server manually: Name"
 msgstr "Afegeix un servidor manualment: Nom"
 
-#: src/muuli_wdr.cpp:2457
+#: src/muuli_wdr.cpp:2429
 msgid "Enter the name of the new server here"
 msgstr "Introduïu el nom del nou servidor"
 
-#: src/muuli_wdr.cpp:2459 src/ServerWnd.cpp:206
+#: src/muuli_wdr.cpp:2431 src/ServerWnd.cpp:206
 msgid "IP:Port"
 msgstr "IP:Port"
 
-#: src/muuli_wdr.cpp:2462
+#: src/muuli_wdr.cpp:2434
 msgid "Enter the IP of the server here, using the x.x.x.x format."
 msgstr "Introduïu la IP del servidor, fent servir el format x.x.x.x."
 
-#: src/muuli_wdr.cpp:2468
+#: src/muuli_wdr.cpp:2440
 msgid "Enter the port of the server here."
 msgstr "Introduïu el port del servidor."
 
-#: src/muuli_wdr.cpp:2471
+#: src/muuli_wdr.cpp:2443
 msgid "Add manually a server (fill fields to the left before) ..."
 msgstr "Afegeix un servidor manualment (abans omple els camps de l'esquerra) ..."
 
-#: src/muuli_wdr.cpp:2500
+#: src/muuli_wdr.cpp:2472
 msgid "aMule Log"
 msgstr "Registre de l'aMule"
 
-#: src/muuli_wdr.cpp:2508
+#: src/muuli_wdr.cpp:2480
 msgid "Server Info"
 msgstr "Informació del servidor"
 
-#: src/muuli_wdr.cpp:2512
+#: src/muuli_wdr.cpp:2484
 msgid "ED2K Info"
 msgstr "Info. ED2K"
 
-#: src/muuli_wdr.cpp:2516
+#: src/muuli_wdr.cpp:2488
 msgid "Kad Info"
 msgstr "Info. Kad"
 
-#: src/muuli_wdr.cpp:2544
+#: src/muuli_wdr.cpp:2516
 msgid "Click on this button to update the nodes list from URL ..."
 msgstr "Feu clic en aquest botó per a actualitzar la llista de nodes des d'una URL ..."
 
-#: src/muuli_wdr.cpp:2548
+#: src/muuli_wdr.cpp:2520
 msgid "Nodes (0)"
 msgstr "Nodes (0)"
 
-#: src/muuli_wdr.cpp:2552
+#: src/muuli_wdr.cpp:2524
 msgid "Enter the url to a nodes.dat file here and press the button to the left to update the list of known nodes."
 msgstr "Introduïu la URL d'un fitxer nodes.dat i premeu el botó de l'esquerra per a actualitzar la llista de nodes coneguts."
 
-#: src/muuli_wdr.cpp:2555
+#: src/muuli_wdr.cpp:2527
 msgid "Nodes stats"
 msgstr "Estadístiques de nodes"
 
-#: src/muuli_wdr.cpp:2597
+#: src/muuli_wdr.cpp:2569
 msgid "Bootstrap"
 msgstr "Arrancada"
 
-#: src/muuli_wdr.cpp:2600
+#: src/muuli_wdr.cpp:2572
 msgid "New node"
 msgstr "Nou node"
 
-#: src/muuli_wdr.cpp:2605
+#: src/muuli_wdr.cpp:2577
 msgid "IP:"
 msgstr "IP:"
 
-#: src/muuli_wdr.cpp:2625
+#: src/muuli_wdr.cpp:2597
 msgid "Port:"
 msgstr "Port:"
 
-#: src/muuli_wdr.cpp:2638
+#: src/muuli_wdr.cpp:2610
 msgid "Bootstrap from known clients"
 msgstr "Inicia des dels clients coneguts"
 
-#: src/muuli_wdr.cpp:2640
+#: src/muuli_wdr.cpp:2612
 msgid "Disconnect Kad"
 msgstr "Desconnecta Kad"
 
-#: src/muuli_wdr.cpp:2674
+#: src/muuli_wdr.cpp:2646
 msgid "Use Secure User Identification"
 msgstr "Usa la Identificació Segura d'Usuari"
 
-#: src/muuli_wdr.cpp:2676
+#: src/muuli_wdr.cpp:2648
 msgid "It is recommended to enable this option. You will not receive credits if SUI is not enabled."
 msgstr "Es recomana activar aquesta opció. No rebreu crèdits (punts) si la Identificació Segura d'Usuari no és habilitada."
 
-#: src/muuli_wdr.cpp:2678
+#: src/muuli_wdr.cpp:2650
 msgid "Protocol Obfuscation"
 msgstr "Ofuscació de protocol"
 
-#: src/muuli_wdr.cpp:2681
+#: src/muuli_wdr.cpp:2653
 msgid "Support Protocol Obfuscation"
 msgstr "Suport per a l'ofuscació de protocol"
 
-#: src/muuli_wdr.cpp:2683
+#: src/muuli_wdr.cpp:2655
 msgid "This option enabled Protocol Obfuscation, and makes aMule accept obfuscated connections from other clients."
 msgstr "Habilita l'ofuscació de protocol, i permet a l'aMule acceptar connexions ofuscades d'altres clients."
 
-#: src/muuli_wdr.cpp:2685
+#: src/muuli_wdr.cpp:2657
 msgid "Use obfuscation for outgoing connections"
 msgstr "Usa l'ofuscació per a les connexions sortints"
 
-#: src/muuli_wdr.cpp:2687
+#: src/muuli_wdr.cpp:2659
 msgid "This option makes aMule use Protocol Obfuscation when connecting other clients/servers."
 msgstr "L'aMule usarà l'ofuscació de protocol en connectar amb altres clients/servidors."
 
-#: src/muuli_wdr.cpp:2689
+#: src/muuli_wdr.cpp:2661
 msgid "Accept only obfuscated connections"
 msgstr "Accepta únicament les connexions ofuscades"
 
-#: src/muuli_wdr.cpp:2690
+#: src/muuli_wdr.cpp:2662
 msgid "This option makes aMule only accept obfuscated connections. You will have less sources, but all your traffic will be obfuscated"
 msgstr "L'aMule només acceptarà les connexions ofuscades. Tindreu menys fonts, però tot el tràfic serà ofuscat"
 
-#: src/muuli_wdr.cpp:2695
+#: src/muuli_wdr.cpp:2667
 msgid "Everybody"
 msgstr "Tothom"
 
-#: src/muuli_wdr.cpp:2697
+#: src/muuli_wdr.cpp:2669
 msgid "No one"
 msgstr "Ningú"
 
-#: src/muuli_wdr.cpp:2699
+#: src/muuli_wdr.cpp:2671
 msgid "Who can see my shared files:"
 msgstr "Qui pot veure els meus fitxers compartits:"
 
-#: src/muuli_wdr.cpp:2700
+#: src/muuli_wdr.cpp:2672
 msgid "Select who can request to view a list of your shared files."
 msgstr "Selecciona qui pot veure la llista de fitxers compartits."
 
-#: src/muuli_wdr.cpp:2702
+#: src/muuli_wdr.cpp:2674
 msgid "IP-Filtering"
 msgstr "Filtratge IP"
 
-#: src/muuli_wdr.cpp:2709
+#: src/muuli_wdr.cpp:2681
 msgid "Filter clients"
 msgstr "Filtra els clients"
 
-#: src/muuli_wdr.cpp:2711
+#: src/muuli_wdr.cpp:2683
 msgid "Enable filtering of the client IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "Habilita el filtratge de les IP de clients especificades al fitxer ~/.aMule/ipfilter.dat."
 
-#: src/muuli_wdr.cpp:2713
+#: src/muuli_wdr.cpp:2685
 msgid "Filter servers"
 msgstr "Filtra els servidors"
 
-#: src/muuli_wdr.cpp:2715
+#: src/muuli_wdr.cpp:2687
 msgid "Enable filtering of the server IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "Habilita el filtratge de les IP de servidors especificades al fitxer ~/.aMule/ipfilter.dat."
 
-#: src/muuli_wdr.cpp:2719
+#: src/muuli_wdr.cpp:2691
 msgid "Reload List"
 msgstr "Recarrega la llista"
 
-#: src/muuli_wdr.cpp:2720
+#: src/muuli_wdr.cpp:2692
 msgid "Reload the list of IPs to filter from the file ~/.aMule/ipfilter.dat"
 msgstr "Recarrega la llista d'IPs a filtrar des del fitxer ~/.aMule/ipfilter.dat"
 
-#: src/muuli_wdr.cpp:2726
+#: src/muuli_wdr.cpp:2698
 msgid "URL:"
 msgstr "Adreça:"
 
-#: src/muuli_wdr.cpp:2730 src/muuli_wdr.cpp:2923
+#: src/muuli_wdr.cpp:2702 src/muuli_wdr.cpp:2895
 msgid "Update now"
 msgstr "Actualitza ara"
 
-#: src/muuli_wdr.cpp:2733
+#: src/muuli_wdr.cpp:2705
 msgid "Auto-update ipfilter at startup"
 msgstr "Actualitza automàticament a l'inici"
 
-#: src/muuli_wdr.cpp:2737
+#: src/muuli_wdr.cpp:2709
 msgid "Filtering Level:"
 msgstr "Nivell de filtratge:"
 
-#: src/muuli_wdr.cpp:2743
+#: src/muuli_wdr.cpp:2715
 msgid "Always filter LAN IPs"
 msgstr "Filtra sempre les IP LAN"
 
-#: src/muuli_wdr.cpp:2746
+#: src/muuli_wdr.cpp:2718
 msgid "Paranoid handling of non-matching IPs"
 msgstr "Gestió paranoica de les IP no corresponents"
 
-#: src/muuli_wdr.cpp:2748
+#: src/muuli_wdr.cpp:2720
 msgid "Rejects a packet when its source IP differs from the IP the client claims (an anti-spoofing check). Disable only if it causes connection problems."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2750
+#: src/muuli_wdr.cpp:2722
 msgid "Use system-wide ipfilter.dat if available"
 msgstr "Usa l'ipfilter.dat del sistema si està disponible"
 
-#: src/muuli_wdr.cpp:2751
+#: src/muuli_wdr.cpp:2723
 #, fuzzy
 msgid "If there's no local ipfilter.dat found, allow usage of a system-wide ipfilter file."
 msgstr "Si no es troba l'ipfilter.dat local, permet l'ús del fitxer ipfilter del sistema."
 
-#: src/muuli_wdr.cpp:2768
+#: src/muuli_wdr.cpp:2740
 msgid "Enable Online-Signature"
 msgstr "Habilita la signatura en línia"
 
-#: src/muuli_wdr.cpp:2770
+#: src/muuli_wdr.cpp:2742
 msgid "Enables the writing of the OS file, which can be used by external apps to create signatures and the like."
 msgstr "Habilita l'escriptura del fitxer de signatura, que altres aplicacions externes poden usar per a crear signatures i similars."
 
-#: src/muuli_wdr.cpp:2774
+#: src/muuli_wdr.cpp:2746
 msgid "Update Frequency (Secs):"
 msgstr "Freqüència d'actualització (segs):"
 
-#: src/muuli_wdr.cpp:2777
+#: src/muuli_wdr.cpp:2749
 msgid "Change the frequency (in seconds) of Online Signature updates."
 msgstr "Canvia la freqüència d'actualització (en segons) de la signatura en línia."
 
-#: src/muuli_wdr.cpp:2785
+#: src/muuli_wdr.cpp:2757
 msgid "Save online signature file in: "
 msgstr "Desa el fitxer de signatura en línia a: "
 
-#: src/muuli_wdr.cpp:2791
+#: src/muuli_wdr.cpp:2763
 msgid "Click here to select the directory containing the the Online Signature files."
 msgstr "Feu clic per a seleccionar el directori que conté els fitxers de signatura en línia."
 
-#: src/muuli_wdr.cpp:2824
+#: src/muuli_wdr.cpp:2796
 msgid "Show country flags for clients"
 msgstr "Mostra les banderes dels països per als clients"
 
-#: src/muuli_wdr.cpp:2825
+#: src/muuli_wdr.cpp:2797
 msgid "Render the country flag column in the transfers, queue and search views. Requires a valid MMDB GeoIP database (see below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2830
+#: src/muuli_wdr.cpp:2802
 #, fuzzy
 msgid "Database"
 msgstr "Velocitat:"
 
-#: src/muuli_wdr.cpp:2846
+#: src/muuli_wdr.cpp:2818
 #, fuzzy
 msgid "Source:"
 msgstr "Fonts"
 
-#: src/muuli_wdr.cpp:2849
+#: src/muuli_wdr.cpp:2821
 msgid "DB-IP (free, no account)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2850
+#: src/muuli_wdr.cpp:2822
 msgid "MaxMind GeoLite2 (free, account required)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2851
+#: src/muuli_wdr.cpp:2823
 msgid "Custom URL"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2854
+#: src/muuli_wdr.cpp:2826
 msgid "Choose which provider supplies the GeoIP MMDB database. DB-IP is the default - no account required. MaxMind requires a free account + license key. Use Custom URL to point at any other MMDB host (e.g. a local mirror)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2871
+#: src/muuli_wdr.cpp:2843
 msgid ""
 "No configuration required.\n"
 "\n"
@@ -4872,11 +4838,11 @@ msgid ""
 "License: Creative Commons BY 4.0 - https://creativecommons.org/licenses/by/4.0/"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2884
+#: src/muuli_wdr.cpp:2856
 msgid "License key:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2890
+#: src/muuli_wdr.cpp:2862
 msgid ""
 "Sign up for a free MaxMind account, then generate a License Key:\n"
 "https://www.maxmind.com/en/geolite2/signup\n"
@@ -4886,225 +4852,225 @@ msgid ""
 "Requires attribution and account registration; refresh at least every 30 days."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2905
+#: src/muuli_wdr.cpp:2877
 #, fuzzy
 msgid "Download URL:"
 msgstr "Baixant: "
 
-#: src/muuli_wdr.cpp:2911
+#: src/muuli_wdr.cpp:2883
 msgid ""
 "Must point to an .mmdb file or a .gz / .tar.gz containing one.\n"
 "URL may include credentials (https://user:pass@host/...).\n"
 "License and attribution terms are set by the upstream URL - you are responsible."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2924
+#: src/muuli_wdr.cpp:2896
 msgid "Download the GeoIP database from the selected source."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2926
+#: src/muuli_wdr.cpp:2898
 #, fuzzy
 msgid "Auto-update on startup"
 msgstr "Actualitza automàticament a l'inici"
 
-#: src/muuli_wdr.cpp:2927
+#: src/muuli_wdr.cpp:2899
 msgid "Re-download the GeoIP database from the selected source every time aMule starts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2950
+#: src/muuli_wdr.cpp:2922
 msgid "Filter incoming messages (except current chat):"
 msgstr "Filtra els missatges entrants (excepte el xat actual):"
 
-#: src/muuli_wdr.cpp:2952
+#: src/muuli_wdr.cpp:2924
 msgid "Filter all messages"
 msgstr "Filtra tots els missatges"
 
-#: src/muuli_wdr.cpp:2954
+#: src/muuli_wdr.cpp:2926
 msgid "Filter messages from people not on your friend list"
 msgstr "Filtra els missatges de la gent que no és a la llista d'amics"
 
-#: src/muuli_wdr.cpp:2956
+#: src/muuli_wdr.cpp:2928
 msgid "Filter messages from unknown clients"
 msgstr "Filtra els missatges dels clients desconeguts"
 
-#: src/muuli_wdr.cpp:2958
+#: src/muuli_wdr.cpp:2930
 msgid "Filter messages containing (use ',' as separator):"
 msgstr "Filtra els missatges que continguin (useu ',' per a separar):"
 
-#: src/muuli_wdr.cpp:2961 src/muuli_wdr.cpp:2972
+#: src/muuli_wdr.cpp:2933 src/muuli_wdr.cpp:2944
 msgid "add here the words amule should filter and block messages including it"
 msgstr "Els missatges que continguin aquestes paraules seran filtrats i bloquejats per l'aMule"
 
-#: src/muuli_wdr.cpp:2963
+#: src/muuli_wdr.cpp:2935
 msgid "Show received messages in the log"
 msgstr "Mostra els missatges rebuts en el registre"
 
-#: src/muuli_wdr.cpp:2966
+#: src/muuli_wdr.cpp:2938
 msgid "Comments"
 msgstr "Comentaris"
 
-#: src/muuli_wdr.cpp:2969
+#: src/muuli_wdr.cpp:2941
 msgid "Filter comments containing (use ',' as separator):"
 msgstr "Filtra els comentaris que continguin (useu ',' per a separar):"
 
-#: src/muuli_wdr.cpp:2994
+#: src/muuli_wdr.cpp:2966
 msgid "Enable Proxy"
 msgstr "Habilita el servidor intermediari"
 
-#: src/muuli_wdr.cpp:2995
+#: src/muuli_wdr.cpp:2967
 msgid "Enable/disable proxy support"
 msgstr "Habilita/inhabilita el suport per a servidor intermediari"
 
-#: src/muuli_wdr.cpp:2998
+#: src/muuli_wdr.cpp:2970
 msgid "Proxy type:"
 msgstr "Tipus de servidor:"
 
-#: src/muuli_wdr.cpp:3009
+#: src/muuli_wdr.cpp:2981
 msgid "Proxy host:"
 msgstr "Servidor intermediari:"
 
-#: src/muuli_wdr.cpp:3012
+#: src/muuli_wdr.cpp:2984
 msgid "The proxy host name"
 msgstr "El nom del servidor intermediari"
 
-#: src/muuli_wdr.cpp:3014
+#: src/muuli_wdr.cpp:2986
 msgid "Proxy port:"
 msgstr "Port del servidor:"
 
-#: src/muuli_wdr.cpp:3017
+#: src/muuli_wdr.cpp:2989
 msgid "The proxy port"
 msgstr "El port del servidor intermediari"
 
-#: src/muuli_wdr.cpp:3019
+#: src/muuli_wdr.cpp:2991
 msgid "Enable authentication"
 msgstr "Habilita l'autenticació"
 
-#: src/muuli_wdr.cpp:3020
+#: src/muuli_wdr.cpp:2992
 msgid "Enable/disable username/password authentication"
 msgstr "Habilita/inhabilita l'autenticació amb usuari/contrasenya"
 
-#: src/muuli_wdr.cpp:3023
+#: src/muuli_wdr.cpp:2995
 msgid "Username: "
 msgstr "Nom d'usuari:"
 
-#: src/muuli_wdr.cpp:3026
+#: src/muuli_wdr.cpp:2998
 msgid "The username to use to connect to the proxy"
 msgstr "El nom d'usuari per a connectar al servidor intermediari"
 
-#: src/muuli_wdr.cpp:3028
+#: src/muuli_wdr.cpp:3000
 msgid "Password:"
 msgstr "Contrasenya:"
 
-#: src/muuli_wdr.cpp:3031
+#: src/muuli_wdr.cpp:3003
 msgid "The password to use to connect to the proxy"
 msgstr "La contrasenya per a connectar al servidor intermediari"
 
-#: src/muuli_wdr.cpp:3050
+#: src/muuli_wdr.cpp:3022
 msgid "Connect to:"
 msgstr "Connecta a:"
 
-#: src/muuli_wdr.cpp:3059
+#: src/muuli_wdr.cpp:3031
 msgid "Login to remote amule"
 msgstr "Entra a l'aMule remot"
 
-#: src/muuli_wdr.cpp:3064
+#: src/muuli_wdr.cpp:3036
 msgid "User name"
 msgstr "Nom d'usuari"
 
-#: src/muuli_wdr.cpp:3075
+#: src/muuli_wdr.cpp:3047
 msgid "Remember those settings"
 msgstr "Recorda la configuració"
 
-#: src/muuli_wdr.cpp:3078
+#: src/muuli_wdr.cpp:3050
 #, fuzzy
 msgid "Force ZLIB compression"
 msgstr "Usa la compressió gzip"
 
-#: src/muuli_wdr.cpp:3102
+#: src/muuli_wdr.cpp:3074
 msgid "Enable Verbose Debug-Logging."
 msgstr "Habilita la depuració-registre detallats."
 
-#: src/muuli_wdr.cpp:3104
+#: src/muuli_wdr.cpp:3076
 msgid "Only to Logfile"
 msgstr "Només al fitxer de registre"
 
-#: src/muuli_wdr.cpp:3106
+#: src/muuli_wdr.cpp:3078
 msgid "Message Categories:"
 msgstr "Categories de missatge:"
 
-#: src/muuli_wdr.cpp:3130 src/PartFileConvertDlg.cpp:160
+#: src/muuli_wdr.cpp:3102 src/PartFileConvertDlg.cpp:160
 msgid "Waiting..."
 msgstr "Esperant..."
 
-#: src/muuli_wdr.cpp:3150
+#: src/muuli_wdr.cpp:3122
 msgid "Add imports"
 msgstr "Afegeix"
 
-#: src/muuli_wdr.cpp:3153
+#: src/muuli_wdr.cpp:3125
 msgid "Retry selected"
 msgstr "Reintenta"
 
-#: src/muuli_wdr.cpp:3155
+#: src/muuli_wdr.cpp:3127
 msgid "Remove selected"
 msgstr "Esborra"
 
-#: src/muuli_wdr.cpp:3218
+#: src/muuli_wdr.cpp:3190
 msgid "Event Types"
 msgstr "Tipus d'esdeveniments"
 
-#: src/muuli_wdr.cpp:3237
+#: src/muuli_wdr.cpp:3209
 msgid "Statistics and queued clients for selected file(s) : Session / All time"
 msgstr "Estadístiques i clients en cua per als fitxers seleccionats: Sessió / Total"
 
-#: src/muuli_wdr.cpp:3261
+#: src/muuli_wdr.cpp:3233
 msgid "Active Uploads"
 msgstr "Pujades actives"
 
-#: src/muuli_wdr.cpp:3275
+#: src/muuli_wdr.cpp:3247
 msgid "Percent of total files"
 msgstr "Percentatge del total de fitxers"
 
-#: src/muuli_wdr.cpp:3327
+#: src/muuli_wdr.cpp:3299
 msgid "Show Clients for"
 msgstr "Mostra els clients per"
 
-#: src/muuli_wdr.cpp:3329
+#: src/muuli_wdr.cpp:3301
 msgid "All files"
 msgstr "Tots els fitxers"
 
-#: src/muuli_wdr.cpp:3332
+#: src/muuli_wdr.cpp:3304
 msgid "Selected files"
 msgstr "Fitxers seleccionats"
 
-#: src/muuli_wdr.cpp:3335
+#: src/muuli_wdr.cpp:3307
 msgid "Active uploads only"
 msgstr "Només pujades actives"
 
-#: src/muuli_wdr.cpp:3342
+#: src/muuli_wdr.cpp:3314
 msgid "Reload:"
 msgstr "Recarrega:"
 
-#: src/muuli_wdr.cpp:3346
+#: src/muuli_wdr.cpp:3318
 msgid "Reload your shared files"
 msgstr "Recarrega els compartits"
 
-#: src/muuli_wdr.cpp:3409
+#: src/muuli_wdr.cpp:3381
 msgid "Send"
 msgstr "Envia"
 
-#: src/muuli_wdr.cpp:3410
+#: src/muuli_wdr.cpp:3382
 msgid "Sends the specified message."
 msgstr "Envia el missatge especificat."
 
-#: src/muuli_wdr.cpp:3414
+#: src/muuli_wdr.cpp:3386
 msgid "Close this chat-session."
 msgstr "Tanca aquesta sessió de xat."
 
-#: src/muuli_wdr.cpp:3437
+#: src/muuli_wdr.cpp:3409
 msgid "Connect to any server and/or Kad"
 msgstr "Connecta amb qualsevol servidor i/o Kad"
 
-#: src/muuli_wdr.cpp:3443 src/SharedFilesCtrl.cpp:142 src/Statistics.cpp:941
+#: src/muuli_wdr.cpp:3415 src/SharedFilesCtrl.cpp:142 src/Statistics.cpp:941
 msgid "Shared Files"
 msgstr "Compartits"
 
@@ -5465,249 +5431,249 @@ msgstr "Baixat"
 msgid "ERROR: Failed to open partfile '%s'"
 msgstr "ERROR: No s'ha pogut obrir el fitxer part '%s'"
 
-#: src/Preferences.cpp:701
+#: src/Preferences.cpp:673
 msgid "System default"
 msgstr "Predeterminat"
 
-#: src/Preferences.cpp:702
+#: src/Preferences.cpp:674
 msgid "Albanian"
 msgstr "Albanès"
 
-#: src/Preferences.cpp:703
+#: src/Preferences.cpp:675
 msgid "Arabic"
 msgstr "Àrab"
 
-#: src/Preferences.cpp:704
+#: src/Preferences.cpp:676
 msgid "Asturian"
 msgstr "Asturià"
 
-#: src/Preferences.cpp:705
+#: src/Preferences.cpp:677
 msgid "Basque"
 msgstr "Basc"
 
-#: src/Preferences.cpp:706
+#: src/Preferences.cpp:678
 msgid "Bulgarian"
 msgstr "Búlgar"
 
-#: src/Preferences.cpp:707
+#: src/Preferences.cpp:679
 msgid "Catalan"
 msgstr "Català; Valencià"
 
-#: src/Preferences.cpp:708
+#: src/Preferences.cpp:680
 msgid "Chinese (Simplified)"
 msgstr "Xinès (Simplificat)"
 
-#: src/Preferences.cpp:709
+#: src/Preferences.cpp:681
 msgid "Chinese (Traditional)"
 msgstr "Xinès (Tradicional)"
 
-#: src/Preferences.cpp:710
+#: src/Preferences.cpp:682
 msgid "Croatian"
 msgstr "Croat"
 
-#: src/Preferences.cpp:711
+#: src/Preferences.cpp:683
 msgid "Czech"
 msgstr "Txec"
 
-#: src/Preferences.cpp:712
+#: src/Preferences.cpp:684
 msgid "Danish"
 msgstr "Danès"
 
-#: src/Preferences.cpp:713
+#: src/Preferences.cpp:685
 msgid "Dutch"
 msgstr "Holandès"
 
-#: src/Preferences.cpp:714
+#: src/Preferences.cpp:686
 msgid "English (U.K.)"
 msgstr "Anglès (R.U.)"
 
-#: src/Preferences.cpp:715
+#: src/Preferences.cpp:687
 #, fuzzy
 msgid "English (U.S.)"
 msgstr "Anglès (R.U.)"
 
-#: src/Preferences.cpp:716
+#: src/Preferences.cpp:688
 msgid "Estonian"
 msgstr "Estonià"
 
-#: src/Preferences.cpp:717
+#: src/Preferences.cpp:689
 msgid "Finnish"
 msgstr "Finès"
 
-#: src/Preferences.cpp:718
+#: src/Preferences.cpp:690
 msgid "French"
 msgstr "Francès"
 
-#: src/Preferences.cpp:719
+#: src/Preferences.cpp:691
 msgid "Galician"
 msgstr "Gallec"
 
-#: src/Preferences.cpp:720
+#: src/Preferences.cpp:692
 msgid "German"
 msgstr "Alemany"
 
-#: src/Preferences.cpp:721
+#: src/Preferences.cpp:693
 msgid "Greek"
 msgstr "Grec"
 
-#: src/Preferences.cpp:722
+#: src/Preferences.cpp:694
 msgid "Hebrew"
 msgstr "Hebreu"
 
-#: src/Preferences.cpp:723
+#: src/Preferences.cpp:695
 msgid "Hungarian"
 msgstr "Hongarès"
 
-#: src/Preferences.cpp:724
+#: src/Preferences.cpp:696
 msgid "Italian"
 msgstr "Italià"
 
-#: src/Preferences.cpp:725
+#: src/Preferences.cpp:697
 msgid "Japanese"
 msgstr "Japonès"
 
-#: src/Preferences.cpp:726
+#: src/Preferences.cpp:698
 msgid "Korean"
 msgstr "Coreà"
 
-#: src/Preferences.cpp:727
+#: src/Preferences.cpp:699
 msgid "Latvian"
 msgstr ""
 
-#: src/Preferences.cpp:728
+#: src/Preferences.cpp:700
 msgid "Lithuanian"
 msgstr "Lituà"
 
-#: src/Preferences.cpp:729
+#: src/Preferences.cpp:701
 msgid "Norwegian (Nynorsk)"
 msgstr "Noruec"
 
-#: src/Preferences.cpp:730
+#: src/Preferences.cpp:702
 msgid "Polish"
 msgstr "Polonès"
 
-#: src/Preferences.cpp:731
+#: src/Preferences.cpp:703
 msgid "Portuguese"
 msgstr "Portuguès"
 
-#: src/Preferences.cpp:732
+#: src/Preferences.cpp:704
 msgid "Portuguese (Brazilian)"
 msgstr "Portuguès (Brasil)"
 
-#: src/Preferences.cpp:733
+#: src/Preferences.cpp:705
 msgid "Romanian"
 msgstr "Romanès"
 
-#: src/Preferences.cpp:734
+#: src/Preferences.cpp:706
 msgid "Russian"
 msgstr "Rus"
 
-#: src/Preferences.cpp:735
+#: src/Preferences.cpp:707
 msgid "Slovenian"
 msgstr "Eslovè"
 
-#: src/Preferences.cpp:736
+#: src/Preferences.cpp:708
 msgid "Spanish"
 msgstr "Espanyol; Castellà"
 
-#: src/Preferences.cpp:737
+#: src/Preferences.cpp:709
 msgid "Swedish"
 msgstr "Suec"
 
-#: src/Preferences.cpp:738
+#: src/Preferences.cpp:710
 msgid "Turkish"
 msgstr "Turc"
 
-#: src/Preferences.cpp:739
+#: src/Preferences.cpp:711
 msgid "Ukrainian"
 msgstr "Ucranià"
 
-#: src/Preferences.cpp:842
+#: src/Preferences.cpp:814
 msgid "Change Language"
 msgstr "Canvi d'idioma"
 
-#: src/Preferences.cpp:906
+#: src/Preferences.cpp:878
 msgid "There are no translations installed for aMule"
 msgstr "No hi ha traduccions instal·lades per a l'aMule"
 
-#: src/Preferences.cpp:907
+#: src/Preferences.cpp:879
 msgid "No languages available"
 msgstr "Sense idiomes disponibles"
 
-#: src/Preferences.cpp:1038
+#: src/Preferences.cpp:1010
 msgid "no options available"
 msgstr "No hi ha opcions disponibles"
 
-#: src/Preferences.cpp:2226
+#: src/Preferences.cpp:2179
 msgid "Invalid category found, skipping"
 msgstr "Categoria invàlida trobada, omitint"
 
-#: src/Preferences.cpp:2395
+#: src/Preferences.cpp:2348
 msgid "TCP port can't be higher than 65532 due to server UDP socket being TCP+3"
 msgstr "El port TCP no pot ser més gran que 65532 puix el sòcol UDP del servidor és TCP+3"
 
-#: src/Preferences.cpp:2396
+#: src/Preferences.cpp:2349
 #, c-format
 msgid "Default port will be used (%d)"
 msgstr "S'usarà el port per defecte (%d)"
 
-#: src/PrefsUnifiedDlg.cpp:300 src/Statistics.cpp:866
+#: src/PrefsUnifiedDlg.cpp:298 src/Statistics.cpp:866
 msgid "Connection"
 msgstr "Connexió"
 
-#: src/PrefsUnifiedDlg.cpp:301 src/SearchListCtrl.cpp:117
+#: src/PrefsUnifiedDlg.cpp:299 src/SearchListCtrl.cpp:117
 msgid "Directories"
 msgstr "Directoris"
 
-#: src/PrefsUnifiedDlg.cpp:302 src/Statistics.cpp:917
+#: src/PrefsUnifiedDlg.cpp:300 src/Statistics.cpp:917
 msgid "Servers"
 msgstr "Servidors"
 
-#: src/PrefsUnifiedDlg.cpp:303 src/ServerListCtrl.cpp:96
+#: src/PrefsUnifiedDlg.cpp:301 src/ServerListCtrl.cpp:96
 msgid "Files"
 msgstr "Fitxers"
 
-#: src/PrefsUnifiedDlg.cpp:304
+#: src/PrefsUnifiedDlg.cpp:302
 msgid "Security"
 msgstr "Seguretat"
 
-#: src/PrefsUnifiedDlg.cpp:305
+#: src/PrefsUnifiedDlg.cpp:303
 msgid "Interface"
 msgstr "Interfície"
 
-#: src/PrefsUnifiedDlg.cpp:312
+#: src/PrefsUnifiedDlg.cpp:310
 msgid "IP2Country"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:315
+#: src/PrefsUnifiedDlg.cpp:313
 msgid "Proxy"
 msgstr "Servidor intermediari"
 
-#: src/PrefsUnifiedDlg.cpp:316
+#: src/PrefsUnifiedDlg.cpp:314
 msgid "Filters"
 msgstr "Filtres"
 
-#: src/PrefsUnifiedDlg.cpp:317
+#: src/PrefsUnifiedDlg.cpp:315
 msgid "Remote Controls"
 msgstr "Control remot"
 
-#: src/PrefsUnifiedDlg.cpp:318
+#: src/PrefsUnifiedDlg.cpp:316
 msgid "Online Signature"
 msgstr "Signatura en línia"
 
-#: src/PrefsUnifiedDlg.cpp:319
+#: src/PrefsUnifiedDlg.cpp:317
 msgid "Advanced"
 msgstr "Avançat"
 
-#: src/PrefsUnifiedDlg.cpp:320
+#: src/PrefsUnifiedDlg.cpp:318
 msgid "Events"
 msgstr "Esdeveniments"
 
-#: src/PrefsUnifiedDlg.cpp:323
+#: src/PrefsUnifiedDlg.cpp:321
 msgid "Debugging"
 msgstr "Depuració"
 
-#: src/PrefsUnifiedDlg.cpp:453
+#: src/PrefsUnifiedDlg.cpp:451
 msgid ""
 "The following variables will be substituted:\n"
 "    %PARTFILE - full path to the file\n"
@@ -5717,15 +5683,15 @@ msgstr ""
 "    %PARTFILE - camí complet al fitxer\n"
 "    %PARTNAME - només el nom del fitxer"
 
-#: src/PrefsUnifiedDlg.cpp:474
+#: src/PrefsUnifiedDlg.cpp:472
 msgid "Tray icon support requires libayatana-appindicator3 at compile time."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:490
+#: src/PrefsUnifiedDlg.cpp:488
 msgid "Not available on Wayland: the protocol does not report when a window is minimized, so this option cannot intercept the system minimize button. Workaround: launch aMule with `GDK_BACKEND=x11` to use XWayland instead."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:536
+#: src/PrefsUnifiedDlg.cpp:534
 msgid ""
 "Do not change these setting unless you know\n"
 "what you are doing, otherwise you can easily\n"
@@ -5741,35 +5707,26 @@ msgstr ""
 "L'aMule anirà bé sense canviar cap\n"
 "d'aquests paràmetres."
 
-#: src/PrefsUnifiedDlg.cpp:647
+#: src/PrefsUnifiedDlg.cpp:645
 #, c-format
 msgid "Failed to connect Cfg to widget with the ID %d and key %s"
 msgstr "Connexió fallida entre Cfg i el giny amb ID %d i clau %s"
 
-#: src/PrefsUnifiedDlg.cpp:695
+#: src/PrefsUnifiedDlg.cpp:693
 #, c-format
 msgid "Failed to transfer data from Cfg to Widget with the ID %d and key %s"
 msgstr "Fallida en l'enviament de dades de Cfg al giny amb ID %d i clau %s"
 
-#: src/PrefsUnifiedDlg.cpp:801
+#: src/PrefsUnifiedDlg.cpp:799
 msgid "The type of proxy you are connecting to"
 msgstr "El tipus de servidor intermediari al que connecteu"
 
-#: src/PrefsUnifiedDlg.cpp:1020
+#: src/PrefsUnifiedDlg.cpp:1003
 #, c-format
 msgid "Failed to transfer data from Widget to Cfg with the ID %d and key %s"
 msgstr "Fallida en l'enviament de dades del giny al Cfg amb ID %d i clau %s"
 
 #: src/PrefsUnifiedDlg.cpp:1103
-#, fuzzy
-msgid "No password set."
-msgstr "S'està comprovant la contrasenya\n"
-
-#: src/PrefsUnifiedDlg.cpp:1132
-msgid "Guest access needs a password. Type one in the guest password field, or untick Enable guest access."
-msgstr ""
-
-#: src/PrefsUnifiedDlg.cpp:1144
 msgid ""
 "aMule must be restarted to enable these changes:\n"
 "\n"
@@ -5777,41 +5734,41 @@ msgstr ""
 "S'ha de reiniciar l'aMule per a habilitar aquests canvis:\n"
 "\n"
 
-#: src/PrefsUnifiedDlg.cpp:1151
+#: src/PrefsUnifiedDlg.cpp:1110
 msgid "- TCP port changed.\n"
 msgstr "- El port TCP ha canviat.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1156
+#: src/PrefsUnifiedDlg.cpp:1115
 msgid "- UDP port changed.\n"
 msgstr "- El port UDP ha canviat.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1161
+#: src/PrefsUnifiedDlg.cpp:1120
 #, fuzzy
 msgid "- Network interface binding changed.\n"
 msgstr "- S'ha canviat la interfície de connexió externa.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1166
+#: src/PrefsUnifiedDlg.cpp:1125
 msgid "- External connect port changed.\n"
 msgstr "- S'ha canviat el port de connexió externa.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1170
+#: src/PrefsUnifiedDlg.cpp:1129
 msgid "- External connect acceptance changed.\n"
 msgstr "- S'ha canviat l'acceptació de la connexió externa.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1174
+#: src/PrefsUnifiedDlg.cpp:1133
 msgid "- External connect interface changed.\n"
 msgstr "- S'ha canviat la interfície de connexió externa.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1178
+#: src/PrefsUnifiedDlg.cpp:1137
 msgid "- Protocol obfuscation support changed.\n"
 msgstr "- S'ha canviat el suport d'ofuscació de protocol.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1193
+#: src/PrefsUnifiedDlg.cpp:1151
 #, fuzzy
 msgid "- amuleapi settings changed.\n"
 msgstr "- L'idioma ha canviat.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1202
+#: src/PrefsUnifiedDlg.cpp:1160
 msgid ""
 "Your Auto-update server list is empty.\n"
 "'Auto-update server list at startup' will be disabled."
@@ -5819,7 +5776,7 @@ msgstr ""
 "La llista d'actualització de servidors és buida.\n"
 "L'actualització de servidors a l'inici serà desactivada."
 
-#: src/PrefsUnifiedDlg.cpp:1213
+#: src/PrefsUnifiedDlg.cpp:1171
 msgid ""
 "You have enabled external connections but have not specified a password.\n"
 "External connections cannot be enabled unless a valid password is specified."
@@ -5827,33 +5784,28 @@ msgstr ""
 "Heu habilitat les connexions externes però no heu especificat una contrasenya.\n"
 "Les connexions externes no poden ser habilitades a menys que s'hagi especificat una contrasenya externa vàlida."
 
-#: src/PrefsUnifiedDlg.cpp:1246
-#, c-format
-msgid "The amuleapi password could not be saved: %s"
-msgstr ""
-
-#: src/PrefsUnifiedDlg.cpp:1276
+#: src/PrefsUnifiedDlg.cpp:1202
 msgid "- Language changed.\n"
 msgstr "- L'idioma ha canviat.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1281
+#: src/PrefsUnifiedDlg.cpp:1207
 msgid "- Temp folder changed.\n"
 msgstr "- El directori temporal ha canviat.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1286
+#: src/PrefsUnifiedDlg.cpp:1212
 msgid "- ED2K network enabled.\n"
 msgstr "- Xarxa ED2K habilitada.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1319
+#: src/PrefsUnifiedDlg.cpp:1245
 msgid "The shared-file exclusion pattern is not a valid regular expression. The filter has been left disabled."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1321 src/PrefsUnifiedDlg.cpp:1921
+#: src/PrefsUnifiedDlg.cpp:1247 src/PrefsUnifiedDlg.cpp:1841
 #, fuzzy
 msgid "Invalid regular expression"
 msgstr "Versió del protocol invàlida."
 
-#: src/PrefsUnifiedDlg.cpp:1398
+#: src/PrefsUnifiedDlg.cpp:1324
 msgid ""
 "Both eD2k and Kad network are disabled.\n"
 "You won't be able to connect until you enable at least one of them."
@@ -5861,7 +5813,7 @@ msgstr ""
 "Les xarxes eD2k i Kad estan inhabilitades.\n"
 "No podreu connectar fins que n'habiliteu almenys una."
 
-#: src/PrefsUnifiedDlg.cpp:1403
+#: src/PrefsUnifiedDlg.cpp:1329
 msgid ""
 "Kad will not start if your UDP port is disabled.\n"
 "Enable UDP port or disable Kad."
@@ -5869,7 +5821,7 @@ msgstr ""
 "La xarxa Kad no s'engegarà si el port UDP està inhabilitat.\n"
 "Habiliteu el port UDP o inhabiliteu la xarxa Kad."
 
-#: src/PrefsUnifiedDlg.cpp:1459
+#: src/PrefsUnifiedDlg.cpp:1385
 msgid ""
 "\n"
 "You MUST restart aMule now.\n"
@@ -5879,69 +5831,69 @@ msgstr ""
 "HEU de reiniciar l'aMule ara mateix.\n"
 "Si no reinicieu ara, no vos queixeu dels possibles problemes.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1524
+#: src/PrefsUnifiedDlg.cpp:1450
 msgid "Could not register aMule for autostart at login. The autostart store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1526
+#: src/PrefsUnifiedDlg.cpp:1452
 msgid "Could not remove the autostart-at-login entry."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1527
+#: src/PrefsUnifiedDlg.cpp:1453
 #, fuzzy
 msgid "Autostart"
 msgstr "Autorefresc iniciat"
 
-#: src/PrefsUnifiedDlg.cpp:1542
+#: src/PrefsUnifiedDlg.cpp:1468
 msgid "Register file type"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1542
+#: src/PrefsUnifiedDlg.cpp:1468
 msgid "Register URL handler"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1550
+#: src/PrefsUnifiedDlg.cpp:1476
 #, c-format
 msgid "aMule only handles eD2k-compatible magnets. If you replace the current magnet handler (%s), BitTorrent magnet links will stop working - aMule cannot download BitTorrent content. Continue?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1555
+#: src/PrefsUnifiedDlg.cpp:1481
 #, c-format
 msgid "Another application currently opens .emulecollection files (%s). Replace it with aMule?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1560
+#: src/PrefsUnifiedDlg.cpp:1486
 #, c-format
 msgid "Another application is currently the default handler for these links (%s). Replace it with aMule?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1585
+#: src/PrefsUnifiedDlg.cpp:1511
 msgid "Could not register aMule for .emulecollection files. The registration store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1587
+#: src/PrefsUnifiedDlg.cpp:1513
 #, fuzzy
 msgid "Could not remove the file type registration."
 msgstr "Carpeta on desar les descàrregues temporals"
 
-#: src/PrefsUnifiedDlg.cpp:1589
+#: src/PrefsUnifiedDlg.cpp:1515
 msgid "Could not register aMule as the URL handler. The registration store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1591
+#: src/PrefsUnifiedDlg.cpp:1517
 msgid "Could not remove the URL handler registration."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1661 src/PrefsUnifiedDlg.cpp:1688
+#: src/PrefsUnifiedDlg.cpp:1587 src/PrefsUnifiedDlg.cpp:1614
 #, fuzzy
 msgid "The web server and aMule API require external connections to be enabled."
 msgstr "Contrassenya definida i connexions externes activades."
 
-#: src/PrefsUnifiedDlg.cpp:1671
+#: src/PrefsUnifiedDlg.cpp:1597
 msgid "The aMule web server is deprecated. Consider running the aMule API instead."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1735
+#: src/PrefsUnifiedDlg.cpp:1655
 msgid ""
 "Your Auto-update servers list is in blank.\n"
 "Please fill in at least one URL to point to a valid server.met file.\n"
@@ -5951,66 +5903,66 @@ msgstr ""
 "Si us plau, ompliu-la amb una URL que apunti a un fitxer server.met vàlid.\n"
 "Feu clic sobre el botó \"Llista\" d'aquest quadre de verificació per afegir una adreça."
 
-#: src/PrefsUnifiedDlg.cpp:1876
+#: src/PrefsUnifiedDlg.cpp:1796
 msgid "Temporary files"
 msgstr "Fitxers temporals"
 
-#: src/PrefsUnifiedDlg.cpp:1881
+#: src/PrefsUnifiedDlg.cpp:1801
 msgid "Incoming files"
 msgstr "Fitxers entrants"
 
-#: src/PrefsUnifiedDlg.cpp:1886
+#: src/PrefsUnifiedDlg.cpp:1806
 msgid "Online Signatures"
 msgstr "Signatures en línia"
 
-#: src/PrefsUnifiedDlg.cpp:1899
+#: src/PrefsUnifiedDlg.cpp:1819
 #, c-format
 msgid "Choose a folder for %s"
 msgstr "Carpeta per a %s"
 
-#: src/PrefsUnifiedDlg.cpp:1923
+#: src/PrefsUnifiedDlg.cpp:1843
 #, fuzzy, c-format
 msgid "Would exclude %u of %u shared file"
 msgid_plural "Would exclude %u of %u shared files"
 msgstr[0] "S'ha trobat %i fitxer compartit"
 msgstr[1] "S'han trobat %i fitxers compartits"
 
-#: src/PrefsUnifiedDlg.cpp:1940
+#: src/PrefsUnifiedDlg.cpp:1860
 msgid "Browse for videoplayer"
 msgstr "Explora per a trobar un reproductor de vídeo"
 
-#: src/PrefsUnifiedDlg.cpp:1944
+#: src/PrefsUnifiedDlg.cpp:1864
 msgid "Select browser"
 msgstr "Selecciona navegador"
 
-#: src/PrefsUnifiedDlg.cpp:1948
+#: src/PrefsUnifiedDlg.cpp:1868
 #, fuzzy
 msgid "Select ffprobe binary"
 msgstr "Selecciona navegador"
 
-#: src/PrefsUnifiedDlg.cpp:1954
+#: src/PrefsUnifiedDlg.cpp:1874
 #, c-format
 msgid "Executable%s"
 msgstr "Executable%s"
 
-#: src/PrefsUnifiedDlg.cpp:1988
+#: src/PrefsUnifiedDlg.cpp:1908
 msgid "ffprobe not found on PATH or in the standard install locations. Install ffmpeg (which ships ffprobe) or use Browse to pick a binary manually."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2000
+#: src/PrefsUnifiedDlg.cpp:1920
 msgid "Reset the settings on this page to their default values?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2001
+#: src/PrefsUnifiedDlg.cpp:1921
 #, fuzzy
 msgid "Reset to defaults"
 msgstr "Predeterminat"
 
-#: src/PrefsUnifiedDlg.cpp:2028
+#: src/PrefsUnifiedDlg.cpp:1948
 msgid "Edit server list"
 msgstr "Edita la llista de servidors"
 
-#: src/PrefsUnifiedDlg.cpp:2029
+#: src/PrefsUnifiedDlg.cpp:1949
 msgid ""
 "Add here URL's to download server.met files.\n"
 "Only one url on each line."
@@ -6018,179 +5970,175 @@ msgstr ""
 "Afegiu adreces URL d'on baixar el fitxer server.met.\n"
 "Només una adreça a cada línia."
 
-#: src/PrefsUnifiedDlg.cpp:2084
+#: src/PrefsUnifiedDlg.cpp:2004
 msgid "IP2Country update failed"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2229 src/PrefsUnifiedDlg.cpp:2260
+#: src/PrefsUnifiedDlg.cpp:2149 src/PrefsUnifiedDlg.cpp:2180
 msgid "Data by MaxMind GeoLite2"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2231 src/PrefsUnifiedDlg.cpp:2262
+#: src/PrefsUnifiedDlg.cpp:2151 src/PrefsUnifiedDlg.cpp:2182
 #, fuzzy
 msgid "Custom source"
 msgstr "Fonts completes"
 
-#: src/PrefsUnifiedDlg.cpp:2233 src/PrefsUnifiedDlg.cpp:2264
+#: src/PrefsUnifiedDlg.cpp:2153 src/PrefsUnifiedDlg.cpp:2184
 msgid "Data by DB-IP.com"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2284
+#: src/PrefsUnifiedDlg.cpp:2204
 #, fuzzy, c-format
 msgid "Status: Loaded%s"
 msgstr "Estat:"
 
-#: src/PrefsUnifiedDlg.cpp:2286
+#: src/PrefsUnifiedDlg.cpp:2206
 #, fuzzy, c-format
 msgid "Status: Loaded%s - %s"
 msgstr "Estat:"
 
-#: src/PrefsUnifiedDlg.cpp:2290
+#: src/PrefsUnifiedDlg.cpp:2210
 msgid "Status: Failed to load - click 'Update now' to refresh."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2292
+#: src/PrefsUnifiedDlg.cpp:2212
 msgid "Status: Not found - click 'Update now' to download."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2350 src/PrefsUnifiedDlg.cpp:2374
+#: src/PrefsUnifiedDlg.cpp:2270 src/PrefsUnifiedDlg.cpp:2294
 #, c-format
 msgid "Update delay: %d second"
 msgid_plural "Update delay: %d seconds"
 msgstr[0] "Retard de l'actualització: %d seg"
 msgstr[1] "Retard de l'actualització: %d segs"
 
-#: src/PrefsUnifiedDlg.cpp:2358
+#: src/PrefsUnifiedDlg.cpp:2278
 #, c-format
 msgid "Time for average graph: %d minute"
 msgid_plural "Time for average graph: %d minutes"
 msgstr[0] "Temps per al gràfic de mitjanes: %d min"
 msgstr[1] "Temps per al gràfic de mitjanes: %d mins"
 
-#: src/PrefsUnifiedDlg.cpp:2367
+#: src/PrefsUnifiedDlg.cpp:2287
 #, c-format
 msgid "Connections Graph Scale: %d"
 msgstr "Escala del gràfic de connexions: %d"
 
-#: src/PrefsUnifiedDlg.cpp:2382
+#: src/PrefsUnifiedDlg.cpp:2302
 #, c-format
 msgid "File Buffer Size: %d byte"
 msgid_plural "File Buffer Size: %d bytes"
 msgstr[0] "Mida de la memòria intermèdia de fitxer: %d byte"
 msgstr[1] "Mida de la memòria intermèdia de fitxer: %d bytes"
 
-#: src/PrefsUnifiedDlg.cpp:2392
+#: src/PrefsUnifiedDlg.cpp:2312
 #, c-format
 msgid "Upload Queue Size: %d client"
 msgid_plural "Upload Queue Size: %d clients"
 msgstr[0] "Mida de la cua de pujada: %d client"
 msgstr[1] "Mida de la cua de pujada: %d clients"
 
-#: src/PrefsUnifiedDlg.cpp:2402
+#: src/PrefsUnifiedDlg.cpp:2322
 #, c-format
 msgid "Server connection refresh interval: %d minute"
 msgid_plural "Server connection refresh interval: %d minutes"
 msgstr[0] "Interval de refresc de la connexió amb el servidor: %d minut"
 msgstr[1] "Interval de refresc de la connexió amb el servidor: %d minuts"
 
-#: src/PrefsUnifiedDlg.cpp:2407
+#: src/PrefsUnifiedDlg.cpp:2327
 msgid "Server connection refresh interval: Disabled"
 msgstr "Interval de refresc de la connexió amb el servidor: Inhabilitat"
 
-#: src/PrefsUnifiedDlg.cpp:2451
+#: src/PrefsUnifiedDlg.cpp:2371
 msgid "disabled"
 msgstr "inhabilitat"
 
-#: src/PrefsUnifiedDlg.cpp:2477
+#: src/PrefsUnifiedDlg.cpp:2397
 #, c-format
 msgid "Execute command on '%s' event"
 msgstr "Executa una ordre per a l'esdeveniment '%s'"
 
-#: src/PrefsUnifiedDlg.cpp:2484
+#: src/PrefsUnifiedDlg.cpp:2404
 msgid "Enable command execution on core"
 msgstr "Activa l'execució d'ordres al nucli"
 
-#: src/PrefsUnifiedDlg.cpp:2496
+#: src/PrefsUnifiedDlg.cpp:2416
 msgid "Core command:"
 msgstr "Odre del nucli:"
 
-#: src/PrefsUnifiedDlg.cpp:2512
+#: src/PrefsUnifiedDlg.cpp:2432
 msgid "Enable command execution on GUI"
 msgstr "Activa l'execució d'ordres a la interfície gràfica"
 
-#: src/PrefsUnifiedDlg.cpp:2524
+#: src/PrefsUnifiedDlg.cpp:2444
 msgid "GUI command:"
 msgstr "Ordre de la IGU:"
 
-#: src/PrefsUnifiedDlg.cpp:2540
+#: src/PrefsUnifiedDlg.cpp:2460
 msgid "The following variables will be replaced:"
 msgstr "Les següents variables seran reemplaçades:"
 
-#: src/PrefsUnifiedDlg.cpp:2708
+#: src/PrefsUnifiedDlg.cpp:2628
 msgid ""
 "The following folders look like system or sensitive locations:\n"
 "\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2713
+#: src/PrefsUnifiedDlg.cpp:2633
 msgid "Sharing them recursively will publish every file underneath on the eD2k/Kad networks. Do you really want to do this?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2716
+#: src/PrefsUnifiedDlg.cpp:2636
 #, fuzzy
 msgid "Confirm shared folders"
 msgstr "Carpetes compartides"
 
-#: src/PrefsUnifiedDlg.cpp:2744
+#: src/PrefsUnifiedDlg.cpp:2664
 #, fuzzy
 msgid "Reloading shared files..."
 msgstr "Recarrega els compartits"
 
-#: src/PrefsUnifiedDlg.cpp:2745
+#: src/PrefsUnifiedDlg.cpp:2665
 msgid "Scanning for subdirectories..."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2746
+#: src/PrefsUnifiedDlg.cpp:2666
 #, fuzzy
 msgid "Updating shared folders"
 msgstr "Carpetes compartides"
 
-#: src/PrefsUnifiedDlg.cpp:2773
+#: src/PrefsUnifiedDlg.cpp:2693
 #, c-format
 msgid "Scanned %u directories..."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2823
+#: src/PrefsUnifiedDlg.cpp:2743
 #, fuzzy, c-format
 msgid "Reloading shared files: %u files scanned"
 msgstr "Recarrega la llista de fitxers compartits."
 
-#: src/PrefsUnifiedDlg.cpp:2873
+#: src/PrefsUnifiedDlg.cpp:2793
 #, fuzzy
 msgid "Shared folder"
 msgstr "Carpetes compartides"
 
-#: src/SearchDlg.cpp:280
-msgid "Clear search history"
-msgstr ""
-
-#: src/SearchDlg.cpp:584
+#: src/SearchDlg.cpp:425
 msgid "It's impossible to search when both eD2k and Kademlia are disabled."
 msgstr "És impossible cercar quan l'eD2k i el Kademlia estan inhabilitats."
 
-#: src/SearchDlg.cpp:585 src/SearchListCtrl.cpp:858
+#: src/SearchDlg.cpp:426 src/SearchListCtrl.cpp:858
 msgid "Search error"
 msgstr "Error en la cerca"
 
-#: src/SearchDlg.cpp:929
+#: src/SearchDlg.cpp:768
 msgid "Min size must be smaller than max size. Max size ignored."
 msgstr "La mida mínima ha de ser menor que la màxima. S'ignorarà la mida màxima."
 
-#: src/SearchDlg.cpp:930 src/SearchDlg.cpp:1012
+#: src/SearchDlg.cpp:769 src/SearchDlg.cpp:851
 msgid "Search warning"
 msgstr "Avís de cerca"
 
-#: src/SearchDlg.cpp:1092 src/SearchListCtrl.cpp:735
+#: src/SearchDlg.cpp:929 src/SearchListCtrl.cpp:735
 msgid "Main"
 msgstr "Principal"
 

--- a/po/ca.po
+++ b/po/ca.po
@@ -14,7 +14,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-28 08:06+0200\n"
+"POT-Creation-Date: 2026-07-28 10:19+0200\n"
 "PO-Revision-Date: 2026-07-27 11:33+0000\n"
 "Last-Translator: minterior <minterior@gmail.com>\n"
 "Language-Team: Català\n"
@@ -145,7 +145,7 @@ msgstr ""
 msgid "Not now"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:422 src/amuleDlg.cpp:600
+#: src/AppImageIntegration.cpp:422 src/amuleDlg.cpp:665
 msgid "Don't ask again"
 msgstr ""
 
@@ -218,7 +218,7 @@ msgid "Killing amuleweb instance with pid '%d' ... "
 msgstr "Aturant el procés amuleweb amb pid '%d' ... "
 
 #: src/amule.cpp:336 src/amule.cpp:349 src/ClientRef.cpp:180
-#: src/SearchDlg.cpp:880 src/ServerListCtrl.cpp:98
+#: src/SearchDlg.cpp:1041 src/ServerListCtrl.cpp:98
 msgid "Failed"
 msgstr "Fallades"
 
@@ -574,30 +574,68 @@ msgstr "No s'ha pogut crear el fitxer Pid"
 msgid "ERROR: %s"
 msgstr "ERROR: %s"
 
-#: src/amuleDlg.cpp:236
+#: src/amuleDlg.cpp:250
 #, c-format
 msgid "This is aMule %s based on eMule."
 msgstr "aMule %s basat en eMule."
 
-#: src/amuleDlg.cpp:237
+#: src/amuleDlg.cpp:251
 #, c-format
 msgid "Running on %s"
 msgstr "S'està executant sobre %s"
 
-#: src/amuleDlg.cpp:239
+#: src/amuleDlg.cpp:253
 msgid "Visit https://github.com/amule-org/amule/releases/latest to check if a new version is available."
 msgstr "Visiteu https://github.com/amule-org/amule/releases/latest per a comprovar si hi ha disponible una versió nova."
 
-#: src/amuleDlg.cpp:268
+#: src/amuleDlg.cpp:282
 msgid "FATAL ERROR: Failed to create Timer"
 msgstr "ERROR GREU: No s'ha pogut crear el temporitzador"
 
-#: src/amuleDlg.cpp:592
+#: src/amuleDlg.cpp:361 src/amuleDlg.cpp:1787 src/amuleDlg.cpp:2033
+#: src/muuli_wdr.cpp:1492 src/muuli_wdr.cpp:3418
+msgid "Networks"
+msgstr "Xarxes"
+
+#: src/amuleDlg.cpp:362 src/amuleDlg.cpp:1793 src/muuli_wdr.cpp:3419
+msgid "Searches"
+msgstr "Cerques"
+
+#: src/amuleDlg.cpp:363 src/amuleDlg.cpp:1799 src/DownloadListCtrl.cpp:740
+#: src/muuli_wdr.cpp:392 src/muuli_wdr.cpp:1585 src/muuli_wdr.cpp:3420
+#: src/Statistics.cpp:829
+msgid "Downloads"
+msgstr "Baixades"
+
+#: src/amuleDlg.cpp:364 src/amuleDlg.cpp:1805 src/muuli_wdr.cpp:3294
+msgid "Shared files"
+msgstr "Compartits"
+
+#: src/amuleDlg.cpp:365 src/amuleDlg.cpp:1811 src/muuli_wdr.cpp:2926
+#: src/muuli_wdr.cpp:3376 src/muuli_wdr.cpp:3423
+msgid "Messages"
+msgstr "Missatges"
+
+#: src/amuleDlg.cpp:366 src/amuleDlg.cpp:1817 src/muuli_wdr.cpp:3424
+#: src/PrefsUnifiedDlg.cpp:312 src/Statistics.cpp:779 src/Statistics.cpp:1235
+msgid "Statistics"
+msgstr "Estadístiques"
+
+#: src/amuleDlg.cpp:368 src/amuleDlg.cpp:1824 src/muuli_wdr.cpp:3426
+#: src/PrefsUnifiedDlg.cpp:328 src/utils/wxCas/src/wxcasprefs.cpp:39
+msgid "Preferences"
+msgstr "Preferències"
+
+#: src/amuleDlg.cpp:371
+msgid "Navigate"
+msgstr ""
+
+#: src/amuleDlg.cpp:657
 #, fuzzy
 msgid "New version available"
 msgstr "No disponible"
 
-#: src/amuleDlg.cpp:596
+#: src/amuleDlg.cpp:661
 #, fuzzy, c-format
 msgid ""
 "A new version of aMule (%s) is available.\n"
@@ -607,217 +645,184 @@ msgid ""
 "Would you like to open the download page?"
 msgstr "Sempre podeu trobar l'última versió a https://github.com/amule-org/amule/releases/latest"
 
-#: src/amuleDlg.cpp:678
+#: src/amuleDlg.cpp:743
 msgid "aMule dialog destroyed"
 msgstr "Diàleg de l'aMule tancat"
 
-#: src/amuleDlg.cpp:701 src/DataToText.cpp:68 src/IPFilter.cpp:547
+#: src/amuleDlg.cpp:766 src/DataToText.cpp:68 src/IPFilter.cpp:547
 msgid "Connecting"
 msgstr "Connectant"
 
-#: src/amuleDlg.cpp:893
+#: src/amuleDlg.cpp:958
 msgid "eD2k: Connecting"
 msgstr "eD2k: S'està connectant"
 
-#: src/amuleDlg.cpp:897
+#: src/amuleDlg.cpp:962
 msgid "eD2k: Disconnected"
 msgstr "eD2k: Desconnectat"
 
-#: src/amuleDlg.cpp:903
+#: src/amuleDlg.cpp:968
 msgid "Kad: Firewalled"
 msgstr "Kad: Bloquejat"
 
-#: src/amuleDlg.cpp:907
+#: src/amuleDlg.cpp:972
 msgid "Kad: Connected"
 msgstr "Kad: Connectat"
 
-#: src/amuleDlg.cpp:912
+#: src/amuleDlg.cpp:977
 msgid "Kad: Connecting"
 msgstr "Kad: Connectant"
 
-#: src/amuleDlg.cpp:916
+#: src/amuleDlg.cpp:981
 msgid "Kad: Off"
 msgstr "Kad: Inativa"
 
-#: src/amuleDlg.cpp:964 src/DownloadListCtrl.cpp:505
+#: src/amuleDlg.cpp:1029 src/DownloadListCtrl.cpp:505
 #: src/DownloadListCtrl.cpp:749 src/FriendListCtrl.cpp:180
 #: src/muuli_wdr.cpp:731 src/muuli_wdr.cpp:782 src/muuli_wdr.cpp:846
-#: src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2224 src/muuli_wdr.cpp:2309
-#: src/muuli_wdr.cpp:3057 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
+#: src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2231 src/muuli_wdr.cpp:2316
+#: src/muuli_wdr.cpp:3064 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
 #: src/ServerListCtrl.cpp:606 src/TransferWnd.cpp:378
 #: src/utils/wxCas/src/wxcasprefs.cpp:235
 msgid "Cancel"
 msgstr "Cancel·la"
 
-#: src/amuleDlg.cpp:965
+#: src/amuleDlg.cpp:1030
 msgid "Stop the current connection attempts"
 msgstr "Atura els intents de connexió actuals"
 
-#: src/amuleDlg.cpp:970 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976
-#: src/muuli_wdr.cpp:2447
+#: src/amuleDlg.cpp:1035 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976
+#: src/muuli_wdr.cpp:2454
 msgid "Disconnect"
 msgstr "Desconnecta"
 
-#: src/amuleDlg.cpp:971
+#: src/amuleDlg.cpp:1036
 msgid "Disconnect from the currently connected networks"
 msgstr "Desconnecta de les xarxes on s'està connectat actualment"
 
-#: src/amuleDlg.cpp:976 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979
-#: src/muuli_wdr.cpp:2602 src/muuli_wdr.cpp:3054 src/muuli_wdr.cpp:3409
+#: src/amuleDlg.cpp:1041 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979
+#: src/muuli_wdr.cpp:2609 src/muuli_wdr.cpp:3061 src/muuli_wdr.cpp:3416
 msgid "Connect"
 msgstr "Connecta"
 
-#: src/amuleDlg.cpp:977
+#: src/amuleDlg.cpp:1042
 msgid "Connect to the currently enabled networks"
 msgstr "Connecta a les xarxes habilitades actualment"
 
-#: src/amuleDlg.cpp:1089
+#: src/amuleDlg.cpp:1154
 #, c-format
 msgid "Up: %.1f%s (%.1f) | Down: %.1f%s (%.1f)"
 msgstr "PU: %.1f%s (%.1f) | BA: %.1f%s (%.1f)"
 
-#: src/amuleDlg.cpp:1091 src/amuleDlg.cpp:1093 src/amuleDlg.cpp:1097
-#: src/amuleDlg.cpp:1099 src/amuleDlg.cpp:1110 src/amuleDlg.cpp:1112
+#: src/amuleDlg.cpp:1156 src/amuleDlg.cpp:1158 src/amuleDlg.cpp:1162
+#: src/amuleDlg.cpp:1164 src/amuleDlg.cpp:1175 src/amuleDlg.cpp:1177
 #: src/MuleTrayIcon.cpp:796 src/MuleTrayIcon.cpp:799
 msgid " MB/s"
 msgstr " MB/s"
 
-#: src/amuleDlg.cpp:1091 src/amuleDlg.cpp:1093 src/amuleDlg.cpp:1097
-#: src/amuleDlg.cpp:1099 src/amuleDlg.cpp:1110 src/amuleDlg.cpp:1112
+#: src/amuleDlg.cpp:1156 src/amuleDlg.cpp:1158 src/amuleDlg.cpp:1162
+#: src/amuleDlg.cpp:1164 src/amuleDlg.cpp:1175 src/amuleDlg.cpp:1177
 #: src/MuleTrayIcon.cpp:796 src/MuleTrayIcon.cpp:799
 #: src/utils/wxCas/src/wxcasframe.cpp:1041
 msgid " kB/s"
 msgstr " kB/s"
 
-#: src/amuleDlg.cpp:1096
+#: src/amuleDlg.cpp:1161
 #, c-format
 msgid "Up: %.1f%s | Down: %.1f%s"
 msgstr "PU: %.1f%s | BA: %.1f%s"
 
-#: src/amuleDlg.cpp:1128
+#: src/amuleDlg.cpp:1193
 #, c-format
 msgid "aMule (%s | Connected)"
 msgstr "aMule (%s | Connectat)"
 
-#: src/amuleDlg.cpp:1130
+#: src/amuleDlg.cpp:1195
 #, c-format
 msgid "aMule (%s | Disconnected)"
 msgstr "aMule (%s | Desconnectat)"
 
-#: src/amuleDlg.cpp:1183
+#: src/amuleDlg.cpp:1248
 #, c-format
 msgid "Do you really want to exit %s?"
 msgstr "Esteu segur que voleu eixir de %s?"
 
-#: src/amuleDlg.cpp:1185
+#: src/amuleDlg.cpp:1250
 msgid "Exit confirmation"
 msgstr "Confirmació de sortida"
 
-#: src/amuleDlg.cpp:1548
+#: src/amuleDlg.cpp:1613
 msgid "Launch Command: "
 msgstr "Ordre: "
 
-#: src/amuleDlg.cpp:1567 src/muuli_wdr.cpp:1971 src/Preferences.cpp:951
+#: src/amuleDlg.cpp:1632 src/muuli_wdr.cpp:1978 src/Preferences.cpp:952
 msgid "- default -"
 msgstr "- defecte -"
 
-#: src/amuleDlg.cpp:1595
+#: src/amuleDlg.cpp:1660
 #, c-format
 msgid "Skin directory '%s' does not exist"
 msgstr "El directori del tema '%s' no existeix"
 
-#: src/amuleDlg.cpp:1598
+#: src/amuleDlg.cpp:1663
 #, c-format
 msgid "WARNING: Unable to open skin file '%s' for read"
 msgstr "AVÍS: No ha estat possible obrir el fitxer d'aparença '%s' per a lectura"
 
-#: src/amuleDlg.cpp:1722 src/amuleDlg.cpp:1968 src/muuli_wdr.cpp:1485
-#: src/muuli_wdr.cpp:3411
-msgid "Networks"
-msgstr "Xarxes"
-
-#: src/amuleDlg.cpp:1726 src/muuli_wdr.cpp:3411
+#: src/amuleDlg.cpp:1791 src/muuli_wdr.cpp:3418
 msgid "Networks Window"
 msgstr "Finestra de les Xarxes"
 
-#: src/amuleDlg.cpp:1728 src/muuli_wdr.cpp:3412
-msgid "Searches"
-msgstr "Cerques"
-
-#: src/amuleDlg.cpp:1732 src/muuli_wdr.cpp:3412
+#: src/amuleDlg.cpp:1797 src/muuli_wdr.cpp:3419
 msgid "Searches Window"
 msgstr "Finestra de cerques"
 
-#: src/amuleDlg.cpp:1734 src/DownloadListCtrl.cpp:740 src/muuli_wdr.cpp:392
-#: src/muuli_wdr.cpp:1578 src/muuli_wdr.cpp:3413 src/Statistics.cpp:829
-msgid "Downloads"
-msgstr "Baixades"
-
-#: src/amuleDlg.cpp:1738 src/muuli_wdr.cpp:3413
+#: src/amuleDlg.cpp:1803 src/muuli_wdr.cpp:3420
 msgid "Downloads Window"
 msgstr "Finestra de baixades"
 
-#: src/amuleDlg.cpp:1740 src/muuli_wdr.cpp:3287
-msgid "Shared files"
-msgstr "Compartits"
-
-#: src/amuleDlg.cpp:1744 src/muuli_wdr.cpp:3415
+#: src/amuleDlg.cpp:1809 src/muuli_wdr.cpp:3422
 msgid "Shared Files Window"
 msgstr "Finestra de fitxers compartits"
 
-#: src/amuleDlg.cpp:1746 src/muuli_wdr.cpp:2919 src/muuli_wdr.cpp:3369
-#: src/muuli_wdr.cpp:3416
-msgid "Messages"
-msgstr "Missatges"
-
-#: src/amuleDlg.cpp:1750 src/muuli_wdr.cpp:3416
+#: src/amuleDlg.cpp:1815 src/muuli_wdr.cpp:3423
 msgid "Messages Window"
 msgstr "Finestra de Missatges"
 
-#: src/amuleDlg.cpp:1752 src/muuli_wdr.cpp:3417 src/PrefsUnifiedDlg.cpp:312
-#: src/Statistics.cpp:779 src/Statistics.cpp:1235
-msgid "Statistics"
-msgstr "Estadístiques"
-
-#: src/amuleDlg.cpp:1756 src/muuli_wdr.cpp:3417
+#: src/amuleDlg.cpp:1821 src/muuli_wdr.cpp:3424
 msgid "Statistics Graph Window"
 msgstr "Finestra del gràfic d'estadístiques"
 
-#: src/amuleDlg.cpp:1759 src/muuli_wdr.cpp:3419 src/PrefsUnifiedDlg.cpp:328
-#: src/utils/wxCas/src/wxcasprefs.cpp:39
-msgid "Preferences"
-msgstr "Preferències"
-
-#: src/amuleDlg.cpp:1763 src/muuli_wdr.cpp:3419
+#: src/amuleDlg.cpp:1828 src/muuli_wdr.cpp:3426
 msgid "Preferences Settings Window"
 msgstr "Finestra de la configuració de preferències"
 
-#: src/amuleDlg.cpp:1766 src/muuli_wdr.cpp:3420
+#: src/amuleDlg.cpp:1831 src/muuli_wdr.cpp:3427
 msgid "Import"
 msgstr "Importa"
 
-#: src/amuleDlg.cpp:1770 src/muuli_wdr.cpp:3420
+#: src/amuleDlg.cpp:1835 src/muuli_wdr.cpp:3427
 msgid "The partfile importer tool"
 msgstr "Eina d'importació de fitxers de parts"
 
-#: src/amuleDlg.cpp:1773 src/muuli_wdr.cpp:3421
+#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3428
 #: src/utils/aLinkCreator/src/alcframe.cpp:262
 msgid "About"
 msgstr "Quant a"
 
-#: src/amuleDlg.cpp:1773 src/muuli_wdr.cpp:3421
+#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3428
 msgid "About/Help"
 msgstr "Quant a / Ajuda"
 
-#: src/amuleDlg.cpp:1971
+#: src/amuleDlg.cpp:2036
 msgid "eD2k network"
 msgstr "Xarxa eD2k"
 
-#: src/amuleDlg.cpp:1974
+#: src/amuleDlg.cpp:2039
 msgid "Kad network"
 msgstr "Xarxa Kad"
 
-#: src/amuleDlg.cpp:1974
+#: src/amuleDlg.cpp:2039
 msgid "No network"
 msgstr "Cap xarxa"
 
@@ -1350,19 +1355,19 @@ msgstr "Auto [Al]"
 msgid "Very low"
 msgstr "Molt baixa"
 
-#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:743 src/muuli_wdr.cpp:2275
+#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:743 src/muuli_wdr.cpp:2282
 #: src/ServerListCtrl.cpp:263 src/ServerListCtrl.cpp:456
 #: src/SharedFilesCtrl.cpp:145
 msgid "Low"
 msgstr "Baixa"
 
-#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:744 src/muuli_wdr.cpp:2276
+#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:744 src/muuli_wdr.cpp:2283
 #: src/ServerListCtrl.cpp:266 src/ServerListCtrl.cpp:457
 #: src/SharedFilesCtrl.cpp:146
 msgid "Normal"
 msgstr "Normal"
 
-#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:745 src/muuli_wdr.cpp:2277
+#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:745 src/muuli_wdr.cpp:2284
 #: src/ServerListCtrl.cpp:269 src/ServerListCtrl.cpp:458
 #: src/SharedFilesCtrl.cpp:147
 msgid "High"
@@ -1454,8 +1459,8 @@ msgstr "Servidor local"
 msgid "Remote Server"
 msgstr "Servidor remot"
 
-#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3174
-#: src/SearchDlg.cpp:111 src/TextClient.cpp:911
+#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3181
+#: src/SearchDlg.cpp:119 src/TextClient.cpp:911
 msgid "Kad"
 msgstr "Kad"
 
@@ -1526,7 +1531,7 @@ msgstr "Part"
 msgid "Size"
 msgstr "Mida"
 
-#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3241
+#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3248
 msgid "Transferred"
 msgstr "Transferit"
 
@@ -1584,7 +1589,7 @@ msgstr ""
 "Retroacció des de: %s (%s)\n"
 "\n"
 
-#: src/DownloadListCtrl.cpp:746 src/muuli_wdr.cpp:2278
+#: src/DownloadListCtrl.cpp:746 src/muuli_wdr.cpp:2285
 #: src/SharedFilesCtrl.cpp:150
 msgid "Auto"
 msgstr "Auto"
@@ -1622,7 +1627,7 @@ msgid "Extended Options"
 msgstr "Opcions avançades"
 
 #: src/DownloadListCtrl.cpp:770 src/DownloadListCtrl.cpp:822
-#: src/muuli_wdr.cpp:1789
+#: src/muuli_wdr.cpp:1796
 msgid "Preview"
 msgstr "Previsualitza"
 
@@ -2333,19 +2338,19 @@ msgstr ""
 msgid "eD2k"
 msgstr "eD2k"
 
-#: src/FirstRunWizard.cpp:349 src/muuli_wdr.cpp:1488
+#: src/FirstRunWizard.cpp:349 src/muuli_wdr.cpp:1495
 msgid "Kademlia"
 msgstr "Kademlia"
 
-#: src/FirstRunWizard.cpp:359 src/muuli_wdr.cpp:1416
+#: src/FirstRunWizard.cpp:359 src/muuli_wdr.cpp:1423
 msgid "Standard TCP Port "
 msgstr "Port TCP per defecte:"
 
-#: src/FirstRunWizard.cpp:365 src/muuli_wdr.cpp:1428
+#: src/FirstRunWizard.cpp:365 src/muuli_wdr.cpp:1435
 msgid "Extended UDP port (Kad / global search) "
 msgstr "Port UDP extès (Kad / cerca global) "
 
-#: src/FirstRunWizard.cpp:377 src/muuli_wdr.cpp:1435
+#: src/FirstRunWizard.cpp:377 src/muuli_wdr.cpp:1442
 msgid "Enable UPnP for router port forwarding"
 msgstr "Activa UPnP per redirecció de ports"
 
@@ -2372,7 +2377,7 @@ msgstr ""
 msgid "Your peer lists are already in place - nothing to download."
 msgstr "Ja esteu intentant baixar el fitxer %s"
 
-#: src/FirstRunWizard.cpp:434 src/muuli_wdr.cpp:1533
+#: src/FirstRunWizard.cpp:434 src/muuli_wdr.cpp:1540
 msgid "Auto-update server list at startup"
 msgstr "Actualitza automàticament la llista de servidors a l'inici"
 
@@ -2418,23 +2423,23 @@ msgid ""
 "want downloads on a different (e.g. larger) disk."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:549 src/FirstRunWizard.cpp:611 src/muuli_wdr.cpp:1701
+#: src/FirstRunWizard.cpp:549 src/FirstRunWizard.cpp:611 src/muuli_wdr.cpp:1708
 msgid "Destination folder for downloads"
 msgstr "Carpeta on desar les descàrregues"
 
-#: src/FirstRunWizard.cpp:553 src/FirstRunWizard.cpp:569 src/muuli_wdr.cpp:1342
-#: src/muuli_wdr.cpp:1359 src/muuli_wdr.cpp:1676 src/muuli_wdr.cpp:1707
-#: src/muuli_wdr.cpp:1719 src/muuli_wdr.cpp:2762
+#: src/FirstRunWizard.cpp:553 src/FirstRunWizard.cpp:569 src/muuli_wdr.cpp:1349
+#: src/muuli_wdr.cpp:1366 src/muuli_wdr.cpp:1683 src/muuli_wdr.cpp:1714
+#: src/muuli_wdr.cpp:1726 src/muuli_wdr.cpp:2769
 #: src/utils/aLinkCreator/src/alcframe.cpp:135
 #: src/utils/wxCas/src/wxcasprefs.cpp:52 src/utils/wxCas/src/wxcasprefs.cpp:118
 msgid "Browse"
 msgstr "Explora"
 
-#: src/FirstRunWizard.cpp:559 src/muuli_wdr.cpp:1712
+#: src/FirstRunWizard.cpp:559 src/muuli_wdr.cpp:1719
 msgid "(All files in this folder are shared with other peers)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:565 src/FirstRunWizard.cpp:624 src/muuli_wdr.cpp:1714
+#: src/FirstRunWizard.cpp:565 src/FirstRunWizard.cpp:624 src/muuli_wdr.cpp:1721
 msgid "Folder for temporary download files"
 msgstr "Carpeta on desar les descàrregues temporals"
 
@@ -2465,7 +2470,7 @@ msgstr "No s'ha pogut obrir el fitxer amb la llista d'amics 'emfriends.met' per 
 msgid "CRITICAL - no client on StartChatSession"
 msgstr "CRITIC - no hi ha client a l'Inici de Sessió del Xat"
 
-#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2668 src/muuli_wdr.cpp:3345
+#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2675 src/muuli_wdr.cpp:3352
 msgid "Friends"
 msgstr "Amics"
 
@@ -2851,7 +2856,7 @@ msgstr "Ràtio"
 msgid "Uploaded"
 msgstr "Transferit"
 
-#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3225
+#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3232
 msgid "Requested"
 msgstr "Peticions"
 
@@ -2975,7 +2980,7 @@ msgid "WARNING: "
 msgstr "AVÍS: "
 
 #: src/MuleNotebook.cpp:179 src/muuli_wdr.cpp:817 src/muuli_wdr.cpp:1229
-#: src/muuli_wdr.cpp:3129 src/muuli_wdr.cpp:3385
+#: src/muuli_wdr.cpp:3136 src/muuli_wdr.cpp:3392
 msgid "Close"
 msgstr "Tanca"
 
@@ -2988,12 +2993,12 @@ msgstr "Retalla"
 msgid "Copy"
 msgstr "Copia"
 
-#: src/MuleTextCtrl.cpp:88
+#: src/MuleTextCtrl.cpp:88 src/SearchDlg.cpp:261
 msgid "Paste"
 msgstr "Enganxa"
 
 #: src/MuleTextCtrl.cpp:89 src/muuli_wdr.cpp:358 src/muuli_wdr.cpp:757
-#: src/muuli_wdr.cpp:2352 src/muuli_wdr.cpp:2371 src/muuli_wdr.cpp:2393
+#: src/muuli_wdr.cpp:2359 src/muuli_wdr.cpp:2378 src/muuli_wdr.cpp:2400
 #: src/utils/aLinkCreator/src/alcframe.cpp:142
 msgid "Clear"
 msgstr "Neteja"
@@ -3091,8 +3096,8 @@ msgid "Exit"
 msgstr "Surt"
 
 #: src/MuleTrayIcon.cpp:579 src/MuleTrayIcon.cpp:945 src/MuleTrayIcon.cpp:965
-#: src/muuli_wdr.cpp:1391 src/muuli_wdr.cpp:1399 src/muuli_wdr.cpp:1406
-#: src/muuli_wdr.cpp:1835 src/muuli_wdr.cpp:1841 src/OtherFunctions.cpp:91
+#: src/muuli_wdr.cpp:1398 src/muuli_wdr.cpp:1406 src/muuli_wdr.cpp:1413
+#: src/muuli_wdr.cpp:1842 src/muuli_wdr.cpp:1848 src/OtherFunctions.cpp:91
 #: src/StatisticsDlg.cpp:93 src/StatisticsDlg.cpp:95
 msgid "kB/s"
 msgstr "kB/s"
@@ -3263,7 +3268,7 @@ msgstr "Nom:"
 msgid "Type"
 msgstr "Tipus"
 
-#: src/muuli_wdr.cpp:215 src/SearchDlg.cpp:110 src/SearchListCtrl.cpp:853
+#: src/muuli_wdr.cpp:215 src/SearchDlg.cpp:118 src/SearchListCtrl.cpp:853
 msgid "Local"
 msgstr "Local"
 
@@ -3334,7 +3339,7 @@ msgstr "Bytes"
 msgid "KB"
 msgstr "KB"
 
-#: src/muuli_wdr.cpp:274 src/muuli_wdr.cpp:293 src/muuli_wdr.cpp:1620
+#: src/muuli_wdr.cpp:274 src/muuli_wdr.cpp:293 src/muuli_wdr.cpp:1627
 #: src/OtherFunctions.cpp:64
 msgid "MB"
 msgstr "MB"
@@ -3351,7 +3356,7 @@ msgstr "Mida Màx."
 msgid "Availability"
 msgstr "Disponibilitat"
 
-#: src/muuli_wdr.cpp:312 src/muuli_wdr.cpp:398 src/muuli_wdr.cpp:3290
+#: src/muuli_wdr.cpp:312 src/muuli_wdr.cpp:398 src/muuli_wdr.cpp:3297
 msgid "Filter:"
 msgstr "Filtre:"
 
@@ -3383,7 +3388,7 @@ msgstr ""
 msgid "Stop"
 msgstr "Atura"
 
-#: src/muuli_wdr.cpp:348 src/muuli_wdr.cpp:1385 src/SearchListCtrl.cpp:732
+#: src/muuli_wdr.cpp:348 src/muuli_wdr.cpp:1392 src/SearchListCtrl.cpp:732
 msgid "Download"
 msgstr "Baixada"
 
@@ -3414,8 +3419,8 @@ msgstr "Fonts del fitxer:"
 #: src/muuli_wdr.cpp:1160 src/muuli_wdr.cpp:1167 src/muuli_wdr.cpp:1172
 #: src/muuli_wdr.cpp:1179 src/muuli_wdr.cpp:1184 src/muuli_wdr.cpp:1191
 #: src/muuli_wdr.cpp:1205 src/muuli_wdr.cpp:1212 src/muuli_wdr.cpp:1217
-#: src/muuli_wdr.cpp:1224 src/muuli_wdr.cpp:3227 src/muuli_wdr.cpp:3235
-#: src/muuli_wdr.cpp:3243
+#: src/muuli_wdr.cpp:1224 src/muuli_wdr.cpp:3234 src/muuli_wdr.cpp:3242
+#: src/muuli_wdr.cpp:3250
 msgid "N/A"
 msgstr "N/D"
 
@@ -3560,7 +3565,7 @@ msgstr ""
 msgid "Album :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:685 src/muuli_wdr.cpp:2247
+#: src/muuli_wdr.cpp:685 src/muuli_wdr.cpp:2254
 msgid "Title :"
 msgstr "Títol:"
 
@@ -3669,7 +3674,7 @@ msgstr "Usuari:"
 msgid "Userhash :"
 msgstr "Resum de l'usuari:"
 
-#: src/muuli_wdr.cpp:895 src/muuli_wdr.cpp:1741 src/muuli_wdr.cpp:2442
+#: src/muuli_wdr.cpp:895 src/muuli_wdr.cpp:1748 src/muuli_wdr.cpp:2449
 #: src/utils/aLinkCreator/src/alcframe.cpp:137
 msgid "Add"
 msgstr "Afegeix"
@@ -3678,15 +3683,15 @@ msgstr "Afegeix"
 msgid "Download-Speed"
 msgstr "Velocitat de baixada"
 
-#: src/muuli_wdr.cpp:954 src/muuli_wdr.cpp:989 src/muuli_wdr.cpp:2546
+#: src/muuli_wdr.cpp:954 src/muuli_wdr.cpp:989 src/muuli_wdr.cpp:2553
 msgid "Current"
 msgstr "Actual"
 
-#: src/muuli_wdr.cpp:962 src/muuli_wdr.cpp:997 src/muuli_wdr.cpp:2554
+#: src/muuli_wdr.cpp:962 src/muuli_wdr.cpp:997 src/muuli_wdr.cpp:2561
 msgid "Running average"
 msgstr "Mitjana total"
 
-#: src/muuli_wdr.cpp:970 src/muuli_wdr.cpp:1005 src/muuli_wdr.cpp:2562
+#: src/muuli_wdr.cpp:970 src/muuli_wdr.cpp:1005 src/muuli_wdr.cpp:2569
 msgid "Session average"
 msgstr "Mitjana de la sessió"
 
@@ -3698,7 +3703,7 @@ msgstr "Velocitat de pujada"
 msgid "Connections"
 msgstr "Connexions"
 
-#: src/muuli_wdr.cpp:1024 src/muuli_wdr.cpp:1860
+#: src/muuli_wdr.cpp:1024 src/muuli_wdr.cpp:1867
 msgid "Active downloads"
 msgstr "Baixades actives"
 
@@ -3706,7 +3711,7 @@ msgstr "Baixades actives"
 msgid "Active connections (1:1)"
 msgstr "Connexions actives (1:1)"
 
-#: src/muuli_wdr.cpp:1040 src/muuli_wdr.cpp:1861
+#: src/muuli_wdr.cpp:1040 src/muuli_wdr.cpp:1868
 msgid "Active uploads"
 msgstr "Pujades actives"
 
@@ -3822,8 +3827,8 @@ msgstr "Aquest és el (vostre) nom que els altres usuaris veuran en connectar-se
 msgid "Language: "
 msgstr "Idioma: "
 
-#: src/muuli_wdr.cpp:1257 src/muuli_wdr.cpp:1323 src/muuli_wdr.cpp:1327
-#: src/muuli_wdr.cpp:1330
+#: src/muuli_wdr.cpp:1257 src/muuli_wdr.cpp:1330 src/muuli_wdr.cpp:1334
+#: src/muuli_wdr.cpp:1337
 msgid "The delay before showing tool-tips."
 msgstr "El retard abans de mostrar els consells (notes emergents)."
 
@@ -3901,936 +3906,945 @@ msgstr "Mostra notificacions en finalitzar les baixades"
 msgid "Enabling this will make aMule to show notifications when finished downloading."
 msgstr "Si s'habilita, l'aMule mostrarà notificacions quan hagin finalitzat les baixades."
 
-#: src/muuli_wdr.cpp:1322
+#: src/muuli_wdr.cpp:1323
+#, fuzzy
+msgid "Remember search history"
+msgstr "Recorda la configuració"
+
+#: src/muuli_wdr.cpp:1324
+msgid "Keeps a dropdown list of your past search terms in the Search tab's Name field. This remembers the queries you typed, not the results they returned."
+msgstr ""
+
+#: src/muuli_wdr.cpp:1329
 msgid "Tooltip delay time: "
 msgstr "Temps de retard de l'indicador de funció:"
 
-#: src/muuli_wdr.cpp:1329
+#: src/muuli_wdr.cpp:1336
 msgid "seconds"
 msgstr "segons"
 
-#: src/muuli_wdr.cpp:1333
+#: src/muuli_wdr.cpp:1340
 msgid "Browser Selection"
 msgstr "Selecció del navegador"
 
-#: src/muuli_wdr.cpp:1339
+#: src/muuli_wdr.cpp:1346
 msgid "Enter your browser name here. Leave this field empty to use the system default browser."
 msgstr "Introdueix el nom del teu navegador. Deixa el camp buit per usar el navegador per defecte del sistema."
 
-#: src/muuli_wdr.cpp:1346
+#: src/muuli_wdr.cpp:1353
 msgid "Open in new tab if possible"
 msgstr "Obre en una nova pestanya si és possible"
 
-#: src/muuli_wdr.cpp:1348
+#: src/muuli_wdr.cpp:1355
 msgid "Open the web page in a new tab instead of in a new window when possible"
 msgstr "Obre la pàgina web en una nova pestanya en comptes de obrir una nova finestra si és possible"
 
-#: src/muuli_wdr.cpp:1352
+#: src/muuli_wdr.cpp:1359
 msgid "Video Player"
 msgstr "Reproductor de vídeo"
 
-#: src/muuli_wdr.cpp:1379
+#: src/muuli_wdr.cpp:1386
 msgid "Bandwidth limits"
 msgstr "Límits d'ample de banda "
 
-#: src/muuli_wdr.cpp:1393
+#: src/muuli_wdr.cpp:1400
 msgid "Upload"
 msgstr "Pujada"
 
-#: src/muuli_wdr.cpp:1401
+#: src/muuli_wdr.cpp:1408
 msgid "Slot Allocation"
 msgstr "Per posició (slot)"
 
-#: src/muuli_wdr.cpp:1410
+#: src/muuli_wdr.cpp:1417
 msgid "Ports"
 msgstr "Ports "
 
-#: src/muuli_wdr.cpp:1420
+#: src/muuli_wdr.cpp:1427
 msgid "This is the standard eD2k port and cannot be disabled."
 msgstr "Aquest és el port eD2k estàndard i no es pot inhabilitar."
 
-#: src/muuli_wdr.cpp:1423
+#: src/muuli_wdr.cpp:1430
 msgid "UDP port for server requests (TCP+3):"
 msgstr "Port UDP per sol·licituds del servidor (TCP+3):"
 
-#: src/muuli_wdr.cpp:1425
+#: src/muuli_wdr.cpp:1432
 msgid "4665"
 msgstr "4665"
 
-#: src/muuli_wdr.cpp:1432
+#: src/muuli_wdr.cpp:1439
 msgid "This UDP port is used for extended eD2k requests and Kad network"
 msgstr "Aquest port UDP és utilitzat per sol·licituds eD2k i Kad exteses"
 
-#: src/muuli_wdr.cpp:1439
+#: src/muuli_wdr.cpp:1446
 msgid "UPnP TCP Port (Optional):"
 msgstr "UPnP Port TCP (Opcional):"
 
-#: src/muuli_wdr.cpp:1449
+#: src/muuli_wdr.cpp:1456
 msgid "Bind local address to IP (empty for any):"
 msgstr "Vincula l'adreça local a l'IP (buit per qualsevol):"
 
-#: src/muuli_wdr.cpp:1452
+#: src/muuli_wdr.cpp:1459
 msgid "Advanced users only: If you have multiple network interfaces, enter the address of the interface to which aMule should be bound."
 msgstr "Només usuaris avançats: Si disposeu de multiples interfícies de xarxa, entreu l'adreça de la interfície a la que l'aMule hauria d'estar vinculada."
 
-#: src/muuli_wdr.cpp:1455 src/muuli_wdr.cpp:2054
+#: src/muuli_wdr.cpp:1462 src/muuli_wdr.cpp:2061
 #, fuzzy
 msgid "Bind to network interface (empty for any):"
 msgstr "Vincula l'adreça local a l'IP (buit per qualsevol):"
 
-#: src/muuli_wdr.cpp:1468
+#: src/muuli_wdr.cpp:1475
 msgid "Advanced users only: pin all of aMule's traffic to one network interface, chosen from the list or typed in by name (e.g. tun0, eth0, en0) or index. Unlike binding to an IP, this stops traffic leaking out via the default route - useful with a VPN. Requires no elevated privileges."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1474
+#: src/muuli_wdr.cpp:1481
 msgid "Max sources per downloading file:"
 msgstr "Nombre màxim de fonts per descàrrega:"
 
-#: src/muuli_wdr.cpp:1478
+#: src/muuli_wdr.cpp:1485
 msgid "Max simultaneous connections:"
 msgstr "Nombre màxim de connexions simultànies:"
 
-#: src/muuli_wdr.cpp:1491 src/muuli_wdr.cpp:3169
+#: src/muuli_wdr.cpp:1498 src/muuli_wdr.cpp:3176
 msgid "ED2K"
 msgstr "ED2K"
 
-#: src/muuli_wdr.cpp:1498
+#: src/muuli_wdr.cpp:1505
 msgid "Autoconnect on startup"
 msgstr "Autoconnecta a l'inici"
 
-#: src/muuli_wdr.cpp:1501
+#: src/muuli_wdr.cpp:1508
 msgid "Reconnect on loss"
 msgstr "Reconnecta en perdre la connexió"
 
-#: src/muuli_wdr.cpp:1523
+#: src/muuli_wdr.cpp:1530
 msgid "Remove dead server after"
 msgstr "Elimina els servidors morts després de"
 
-#: src/muuli_wdr.cpp:1524
+#: src/muuli_wdr.cpp:1531
 msgid "Static servers are never removed, even when unreachable."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1528
+#: src/muuli_wdr.cpp:1535
 msgid "retries"
 msgstr "intents"
 
-#: src/muuli_wdr.cpp:1536
+#: src/muuli_wdr.cpp:1543
 msgid "List"
 msgstr "Llista"
 
-#: src/muuli_wdr.cpp:1539
+#: src/muuli_wdr.cpp:1546
 msgid "Update server list when connecting to a server"
 msgstr "Actualitza la llista de servidors quan es connecti amb un servidor"
 
-#: src/muuli_wdr.cpp:1542
+#: src/muuli_wdr.cpp:1549
 msgid "Update server list when a client connects"
 msgstr "Actualitza la llista de servidors quan es connecta un client"
 
-#: src/muuli_wdr.cpp:1545
+#: src/muuli_wdr.cpp:1552
 msgid "Use priority system"
 msgstr "Usa el sistema de prioritats"
 
-#: src/muuli_wdr.cpp:1549
+#: src/muuli_wdr.cpp:1556
 msgid "Use smart LowID check on connect"
 msgstr "Usa la comprovació intel·ligent d'ID Baixa en connectar"
 
-#: src/muuli_wdr.cpp:1553
+#: src/muuli_wdr.cpp:1560
 msgid "Safe connect"
 msgstr "Connexió segura"
 
-#: src/muuli_wdr.cpp:1557
+#: src/muuli_wdr.cpp:1564
 msgid "Autoconnect to servers in static list only"
 msgstr "Autoconnecta només a servidors de la llista estàtica"
 
-#: src/muuli_wdr.cpp:1560
+#: src/muuli_wdr.cpp:1567
 msgid "Set manually added servers to High Priority"
 msgstr "Estableix prioritat Alta per als servidors afegits manualment"
 
-#: src/muuli_wdr.cpp:1581
+#: src/muuli_wdr.cpp:1588
 msgid "Add files to download in pause mode"
 msgstr "Afegeix les noves baixades en mode pausat"
 
-#: src/muuli_wdr.cpp:1583
+#: src/muuli_wdr.cpp:1590
 msgid "Add files to download with auto priority"
 msgstr "Afegeix les noves baixades amb prioritat automàtica"
 
-#: src/muuli_wdr.cpp:1586
+#: src/muuli_wdr.cpp:1593
 msgid "Try to download first and last chunks first"
 msgstr "Intenta baixar abans les parts inicials i finals"
 
-#: src/muuli_wdr.cpp:1590
+#: src/muuli_wdr.cpp:1597
 msgid "Endgame mode: rotate to faster sources for the final blocks"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1593
+#: src/muuli_wdr.cpp:1600
 msgid "Start next paused file when a file completes"
 msgstr "Inicia el següent fitxer pausat quan s'acabi una descàrrega"
 
-#: src/muuli_wdr.cpp:1596
+#: src/muuli_wdr.cpp:1603
 msgid "From the same category"
 msgstr "De la mateixa categoria"
 
-#: src/muuli_wdr.cpp:1598
+#: src/muuli_wdr.cpp:1605
 msgid "In alphabetic order"
 msgstr "En ordre alfabètic"
 
-#: src/muuli_wdr.cpp:1600
+#: src/muuli_wdr.cpp:1607
 msgid "Preallocate disk space for new files"
 msgstr "Preassigna l'espai al disc per als fitxers nous"
 
-#: src/muuli_wdr.cpp:1601
+#: src/muuli_wdr.cpp:1608
 msgid "For new files preallocates disk space for the whole file, thus reduces fragmentation"
 msgstr "Per a fitxers nous reserva l'espai que ocuparà el fitxer complet. Açò redueix la fragmentació"
 
-#: src/muuli_wdr.cpp:1606
+#: src/muuli_wdr.cpp:1613
 msgid "Create new files as sparse files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1607
+#: src/muuli_wdr.cpp:1614
 msgid "A sparse file reserves its full size on disk immediately without writing real data to it -- fast, but unsupported or slow on some filesystems, and free-space accounting stays optimistic while the download is in progress. Turn this off to grow the file only as data arrives."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1612
+#: src/muuli_wdr.cpp:1619
 msgid "Stop downloads when free disk space reaches "
 msgstr "Atura les descàrregues quan l'espai buit al disc arribi a "
 
-#: src/muuli_wdr.cpp:1613
+#: src/muuli_wdr.cpp:1620
 msgid "Select this if you want aMule to check your disk space"
 msgstr "Seleccioneu-ho si voleu que l'aMule comprovi l'espai del disc"
 
-#: src/muuli_wdr.cpp:1617
+#: src/muuli_wdr.cpp:1624
 msgid "Enter here the min disk space desired."
 msgstr "Poseu l'espai mínim de disc desitjat."
 
-#: src/muuli_wdr.cpp:1623
+#: src/muuli_wdr.cpp:1630
 msgid "Save 10 sources on rare files (< 20 sources)"
 msgstr "Recorda 10 fonts dels fitxers rars (amb < 20 fonts)"
 
-#: src/muuli_wdr.cpp:1627 src/Statistics.cpp:790
+#: src/muuli_wdr.cpp:1634 src/Statistics.cpp:790
 msgid "Uploads"
 msgstr "Pujades"
 
-#: src/muuli_wdr.cpp:1630
+#: src/muuli_wdr.cpp:1637
 msgid "Add new shared files with auto priority"
 msgstr "Afegeix els nous fitxer compartits amb prioritat automàtica"
 
-#: src/muuli_wdr.cpp:1636
+#: src/muuli_wdr.cpp:1643
 msgid "Intelligent Corruption Handling (I.C.H.)"
 msgstr "Gestió d'Errors Inteligent (I.C.H.)"
 
-#: src/muuli_wdr.cpp:1639
+#: src/muuli_wdr.cpp:1646
 msgid "Enable"
 msgstr "Activa"
 
-#: src/muuli_wdr.cpp:1642
+#: src/muuli_wdr.cpp:1649
 msgid "Advanced I.C.H. trusts every hash (not recommended)"
 msgstr "I.C.H. avançat confia en totes les comprovacions (no recomanat)"
 
-#: src/muuli_wdr.cpp:1654 src/PrefsUnifiedDlg.cpp:1910
+#: src/muuli_wdr.cpp:1661 src/PrefsUnifiedDlg.cpp:1910
 msgid "Media metadata extraction"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1658
+#: src/muuli_wdr.cpp:1665
 msgid "Extract length / bitrate / codec from shared audio and video files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1660
+#: src/muuli_wdr.cpp:1667
 msgid "When enabled, aMule runs ffprobe on each shared media file to fill in the Length / Bitrate / Codec columns other clients see when they find the file in a search. Requires ffmpeg (the ffprobe binary) to be installed."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1667
+#: src/muuli_wdr.cpp:1674
 msgid "Path to ffprobe:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1672
+#: src/muuli_wdr.cpp:1679
 msgid "Full path to the ffprobe binary. Leave empty to have aMule auto-detect it on startup."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1680
+#: src/muuli_wdr.cpp:1687
 msgid "Detect"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1681
+#: src/muuli_wdr.cpp:1688
 msgid "Search the standard install locations for an ffprobe binary and fill the path field."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1705
+#: src/muuli_wdr.cpp:1712
 msgid ""
 "Completed downloads are stored here. All files in this folder are automatically shared with other peers.\n"
 "If this folder also holds files you don't want to share, point it at an aMule-only sub-folder."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1708
+#: src/muuli_wdr.cpp:1715
 msgid "Pick the folder where completed downloads will be stored. All files in that folder will be shared with other peers."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1722
+#: src/muuli_wdr.cpp:1729
 msgid "Shared folders"
 msgstr "Carpetes compartides"
 
-#: src/muuli_wdr.cpp:1728
+#: src/muuli_wdr.cpp:1735
 msgid "(Folders shared by the core. Enter a path to add one.)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1736
+#: src/muuli_wdr.cpp:1743
 msgid "Absolute path of a folder on the core's machine, e.g. /home/user/shared"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1738 src/PrefsUnifiedDlg.cpp:2794
+#: src/muuli_wdr.cpp:1745 src/PrefsUnifiedDlg.cpp:2794
 msgid "Recursive"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1739
+#: src/muuli_wdr.cpp:1746
 msgid "Share every sub-folder underneath this one, including ones created later."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1743 src/utils/aLinkCreator/src/alcframe.cpp:141
+#: src/muuli_wdr.cpp:1750 src/utils/aLinkCreator/src/alcframe.cpp:141
 msgid "Remove"
 msgstr "Esborra"
 
-#: src/muuli_wdr.cpp:1747
+#: src/muuli_wdr.cpp:1754
 msgid "(Right click on folder icon for recursive share)"
 msgstr "(Per a compartir recursivament feu clic dret sobre el directori)"
 
-#: src/muuli_wdr.cpp:1754
+#: src/muuli_wdr.cpp:1761
 msgid "Share hidden files"
 msgstr "Comparteix els fitxers ocults"
 
-#: src/muuli_wdr.cpp:1760
+#: src/muuli_wdr.cpp:1767
 msgid "Automatically rescan shared folders for changes"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1766
+#: src/muuli_wdr.cpp:1773
 msgid "Follow symbolic links in shared folders"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1772
+#: src/muuli_wdr.cpp:1779
 msgid "Exclude files matching:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1775
+#: src/muuli_wdr.cpp:1782
 msgid "Wildcard patterns separated by '|', e.g. .DS_Store|Thumbs.db|*.tmp. Files whose name matches are not shared. Matching is case-insensitive."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1779
+#: src/muuli_wdr.cpp:1786
 msgid "Patterns are regular expressions"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1780
+#: src/muuli_wdr.cpp:1787
 msgid "When set, the whole field is one regular expression ('|' is alternation). When unset, it is a list of '|'-separated wildcards."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1790
+#: src/muuli_wdr.cpp:1797
 msgid "Show how many shared files the current pattern would exclude."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1811
+#: src/muuli_wdr.cpp:1818
 msgid "Graphs"
 msgstr "Gràfics"
 
-#: src/muuli_wdr.cpp:1814 src/muuli_wdr.cpp:1876
+#: src/muuli_wdr.cpp:1821 src/muuli_wdr.cpp:1883
 msgid "Update delay : 5 secs"
 msgstr "Actualitza cada: 5 segs"
 
-#: src/muuli_wdr.cpp:1818
+#: src/muuli_wdr.cpp:1825
 msgid "Time for average graph: 100 mins"
 msgstr "Temps per al gràfic de mitjana: 100 mins"
 
-#: src/muuli_wdr.cpp:1822
+#: src/muuli_wdr.cpp:1829
 msgid "Connections Graph Scale: 100 "
 msgstr "Escala del Gràfic de Connexions: 100 "
 
-#: src/muuli_wdr.cpp:1829
+#: src/muuli_wdr.cpp:1836
 msgid "Download graph scale:"
 msgstr "Escala del gràfic de descàrrega:"
 
-#: src/muuli_wdr.cpp:1837
+#: src/muuli_wdr.cpp:1844
 msgid "Upload graph scale:"
 msgstr "Escala del gràfic de pujada:"
 
-#: src/muuli_wdr.cpp:1847
+#: src/muuli_wdr.cpp:1854
 #, fuzzy
 msgid "Colors: "
 msgstr "Colors: "
 
-#: src/muuli_wdr.cpp:1851
+#: src/muuli_wdr.cpp:1858
 msgid "Background"
 msgstr "Fons"
 
-#: src/muuli_wdr.cpp:1852
+#: src/muuli_wdr.cpp:1859
 msgid "Grid"
 msgstr "Graella"
 
-#: src/muuli_wdr.cpp:1853
+#: src/muuli_wdr.cpp:1860
 msgid "Download current"
 msgstr "Baixada actual"
 
-#: src/muuli_wdr.cpp:1854
+#: src/muuli_wdr.cpp:1861
 msgid "Download running average"
 msgstr "Mitjana de baixada total"
 
-#: src/muuli_wdr.cpp:1855
+#: src/muuli_wdr.cpp:1862
 msgid "Download session average"
 msgstr "Mitjana de baixada de la sessió"
 
-#: src/muuli_wdr.cpp:1856
+#: src/muuli_wdr.cpp:1863
 msgid "Upload current"
 msgstr "Pujada actual"
 
-#: src/muuli_wdr.cpp:1857
+#: src/muuli_wdr.cpp:1864
 msgid "Upload running average"
 msgstr "Mitjana de pujada total"
 
-#: src/muuli_wdr.cpp:1858
+#: src/muuli_wdr.cpp:1865
 msgid "Upload session average"
 msgstr "Mitjana de pujada de la sessió"
 
-#: src/muuli_wdr.cpp:1859
+#: src/muuli_wdr.cpp:1866
 msgid "Active connections"
 msgstr "Connexions actives"
 
-#: src/muuli_wdr.cpp:1862
+#: src/muuli_wdr.cpp:1869
 #, fuzzy
 msgid "Systray Icon Speed Bar"
 msgstr "Barra de velocitat de la icona d'estat"
 
-#: src/muuli_wdr.cpp:1863
+#: src/muuli_wdr.cpp:1870
 msgid "Kad-nodes current"
 msgstr "Nodes-Kad actuals"
 
-#: src/muuli_wdr.cpp:1864
+#: src/muuli_wdr.cpp:1871
 msgid "Kad-nodes running"
 msgstr "Nodes-Kad funcionant"
 
-#: src/muuli_wdr.cpp:1865
+#: src/muuli_wdr.cpp:1872
 msgid "Kad-nodes session"
 msgstr "Nodes-Kad de la sessió"
 
-#: src/muuli_wdr.cpp:1869 src/muuli_wdr.cpp:2296
+#: src/muuli_wdr.cpp:1876 src/muuli_wdr.cpp:2303
 msgid "Select"
 msgstr "Selecciona"
 
-#: src/muuli_wdr.cpp:1873
+#: src/muuli_wdr.cpp:1880
 msgid "Tree"
 msgstr "Arbre"
 
-#: src/muuli_wdr.cpp:1883
+#: src/muuli_wdr.cpp:1890
 msgid "Number of Client Versions shown (0=unlimited)"
 msgstr "Nombre de versions de client a mostrar (0=il·limitat)"
 
-#: src/muuli_wdr.cpp:1908
+#: src/muuli_wdr.cpp:1915
 msgid "!!! WARNING !!!"
 msgstr "!!! AVÍS !!!"
 
-#: src/muuli_wdr.cpp:1923
+#: src/muuli_wdr.cpp:1930
 msgid "Max new connections / 5 secs"
 msgstr "Connexions noves màx. / 5 segs"
 
-#: src/muuli_wdr.cpp:1925
+#: src/muuli_wdr.cpp:1932
 msgid "Concurrent Kad source lookups"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1927
+#: src/muuli_wdr.cpp:1934
 #, fuzzy
 msgid "Kad source re-search interval (minutes)"
 msgstr "Interval d'actualització de l'FTP en minuts"
 
-#: src/muuli_wdr.cpp:1929
+#: src/muuli_wdr.cpp:1936
 #, fuzzy
 msgid "Source re-ask interval (minutes)"
 msgstr "Interval d'actualització de l'FTP en minuts"
 
-#: src/muuli_wdr.cpp:1933
+#: src/muuli_wdr.cpp:1940
 msgid "File Buffer Size: 240000 bytes"
 msgstr "Mida del buffer de fitxer: 240000 bytes"
 
-#: src/muuli_wdr.cpp:1937
+#: src/muuli_wdr.cpp:1944
 msgid "Use MMAP: memory-mapped file access (lower memory use)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1938
+#: src/muuli_wdr.cpp:1945
 msgid "Maps part files into memory instead of buffering them on the heap, lowering the process memory footprint. May reduce download speed on some disks; best for memory-constrained or upload-heavy hosts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1940
+#: src/muuli_wdr.cpp:1947
 msgid "Upload Queue Size: 5000 clients"
 msgstr "Mida de la cua de pujades: 5000 clients"
 
-#: src/muuli_wdr.cpp:1944
+#: src/muuli_wdr.cpp:1951
 msgid "Server connection refresh interval: Disable"
 msgstr "Interval de refresc de la connexió amb el servidor: Inhabilitat"
 
-#: src/muuli_wdr.cpp:1948
+#: src/muuli_wdr.cpp:1955
 msgid "Disable computer's timed standby mode"
 msgstr "Inhabilita el mode d'espera programat de l'ordinador"
 
-#: src/muuli_wdr.cpp:1967
+#: src/muuli_wdr.cpp:1974
 msgid "Skin to use: "
 msgstr "Aparença a usar: "
 
-#: src/muuli_wdr.cpp:1976
+#: src/muuli_wdr.cpp:1983
 msgid "Show \"Fast eD2k Links Handler\" in every window."
 msgstr "Mostra \"Gestor ràpid de links eD2k\" en totes les finestres."
 
-#: src/muuli_wdr.cpp:1979
+#: src/muuli_wdr.cpp:1986
 msgid "Show extended info on categories tabs"
 msgstr "Mostra informació estesa a les pestanyes de les categories"
 
-#: src/muuli_wdr.cpp:1982
+#: src/muuli_wdr.cpp:1989
 msgid "Show application version on title"
 msgstr "Mostra la versió de l'aplicació al títol"
 
-#: src/muuli_wdr.cpp:1984
+#: src/muuli_wdr.cpp:1991
 msgid "Show transfer rates on title"
 msgstr "Mostra les velocitats de transferència al títol"
 
-#: src/muuli_wdr.cpp:1986
+#: src/muuli_wdr.cpp:1993
 msgid "Before application name"
 msgstr "Abans del nom de l'aplicació"
 
-#: src/muuli_wdr.cpp:1988
+#: src/muuli_wdr.cpp:1995
 msgid "After application name"
 msgstr "Després del nom de l'aplicació"
 
-#: src/muuli_wdr.cpp:1991
+#: src/muuli_wdr.cpp:1998
 msgid "Show overhead bandwidth"
 msgstr "Mostra ample de banda sobrecarregat"
 
-#: src/muuli_wdr.cpp:1995
+#: src/muuli_wdr.cpp:2002
 msgid "Vertical toolbar orientation"
 msgstr "Orientació vertical de la barra d'eines"
 
-#: src/muuli_wdr.cpp:1997
+#: src/muuli_wdr.cpp:2004
 msgid "Live column sorting (auto-reorder rows as their values change)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2004
+#: src/muuli_wdr.cpp:2011
 msgid "Download Queue Files"
 msgstr "Cua de descàrregues"
 
-#: src/muuli_wdr.cpp:2007
+#: src/muuli_wdr.cpp:2014
 msgid "Show progress percentage"
 msgstr "Mostra el percentatge de descàrrega"
 
-#: src/muuli_wdr.cpp:2013
+#: src/muuli_wdr.cpp:2020
 msgid "Show progress bar"
 msgstr "Mostra barra de descàrrega"
 
-#: src/muuli_wdr.cpp:2016
+#: src/muuli_wdr.cpp:2023
 msgid "Flat"
 msgstr "Plana"
 
-#: src/muuli_wdr.cpp:2020
+#: src/muuli_wdr.cpp:2027
 msgid "Round"
 msgstr "Arrodonida"
 
-#: src/muuli_wdr.cpp:2038
+#: src/muuli_wdr.cpp:2045
 msgid "External Connection Parameters"
 msgstr "Paràmetres de la connexió externa "
 
-#: src/muuli_wdr.cpp:2041
+#: src/muuli_wdr.cpp:2048
 msgid "Accept external connections"
 msgstr "Accepta connexions externes"
 
-#: src/muuli_wdr.cpp:2048 src/muuli_wdr.cpp:2107
+#: src/muuli_wdr.cpp:2055 src/muuli_wdr.cpp:2114
 msgid "IP of the listening interface:"
 msgstr "IP de la interfície que rep connexions:"
 
-#: src/muuli_wdr.cpp:2051
+#: src/muuli_wdr.cpp:2058
 msgid "Enter here a valid ip in the a.b.c.d format for the listening EC interface. An empty field or 0.0.0.0 will mean any interface."
 msgstr "Introduïu una IP vàlida amb format a.b.c.d per a la interfície EC que escolta. Un camp buit o 0.0.0.0 significarà qualsevol interfície."
 
-#: src/muuli_wdr.cpp:2072 src/muuli_wdr.cpp:2156
+#: src/muuli_wdr.cpp:2079 src/muuli_wdr.cpp:2163
 msgid "TCP port:"
 msgstr "Port TCP:"
 
-#: src/muuli_wdr.cpp:2078
+#: src/muuli_wdr.cpp:2085
 msgid "Enable UPnP port forwarding on the EC port"
 msgstr "Activa l'encaminament UPnP al port de connexions externes"
 
-#: src/muuli_wdr.cpp:2082 src/muuli_wdr.cpp:3041
+#: src/muuli_wdr.cpp:2089 src/muuli_wdr.cpp:3048
 #: src/utils/wxCas/src/wxcasprefs.cpp:167
 msgid "Password"
 msgstr "Contrasenya"
 
-#: src/muuli_wdr.cpp:2088
+#: src/muuli_wdr.cpp:2095
 #, fuzzy
 msgid "aMule API server parameters"
 msgstr "Paràmetres del servidor web "
 
-#: src/muuli_wdr.cpp:2091
+#: src/muuli_wdr.cpp:2098
 msgid "Run amuleapi (REST API) on startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2096
+#: src/muuli_wdr.cpp:2103
 #, fuzzy
 msgid "HTTP port:"
 msgstr "Port TCP:"
 
-#: src/muuli_wdr.cpp:2110
+#: src/muuli_wdr.cpp:2117
 msgid "The interface amuleapi's HTTP server listens on. 127.0.0.1 (default) accepts only local connections; use 0.0.0.0 or a specific IP to expose it to other hosts (set an admin password below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2113
+#: src/muuli_wdr.cpp:2120
 #, fuzzy
 msgid "Admin password"
 msgstr "S'està comprovant la contrasenya\n"
 
-#: src/muuli_wdr.cpp:2118 src/muuli_wdr.cpp:2149
+#: src/muuli_wdr.cpp:2125 src/muuli_wdr.cpp:2156
 msgid "Low rights password"
 msgstr "Contrasenya del convidat:"
 
-#: src/muuli_wdr.cpp:2126
+#: src/muuli_wdr.cpp:2133
 msgid "Web server parameters"
 msgstr "Paràmetres del servidor web "
 
-#: src/muuli_wdr.cpp:2129
+#: src/muuli_wdr.cpp:2136
 #, fuzzy
 msgid "Run webserver on startup (deprecated)"
 msgstr "Executa el servidor web a l'inici"
 
-#: src/muuli_wdr.cpp:2135
+#: src/muuli_wdr.cpp:2142
 msgid "Web template"
 msgstr "Plantilla web"
 
-#: src/muuli_wdr.cpp:2140
+#: src/muuli_wdr.cpp:2147
 msgid "Full rights password"
 msgstr "Contrasenya de l'administrador:"
 
-#: src/muuli_wdr.cpp:2144
+#: src/muuli_wdr.cpp:2151
 msgid "Enable Low rights User"
 msgstr "Habilita l'usuari convidat"
 
-#: src/muuli_wdr.cpp:2163
+#: src/muuli_wdr.cpp:2170
 msgid "Enable UPnP port forwarding of the web server port"
 msgstr "Activa redirecció de ports UPnP en el port del servidor web"
 
-#: src/muuli_wdr.cpp:2168
+#: src/muuli_wdr.cpp:2175
 msgid "Web server UPnP TCP port (Optional)"
 msgstr "Port TCP del servidor web (Opcional):"
 
-#: src/muuli_wdr.cpp:2176
+#: src/muuli_wdr.cpp:2183
 msgid "Page Refresh Time (in secs)"
 msgstr "Temps de refresc de la pàgina (en segons):"
 
-#: src/muuli_wdr.cpp:2183
+#: src/muuli_wdr.cpp:2190
 msgid "Enable Gzip compression"
 msgstr "Habilita la compressió Gzip"
 
-#: src/muuli_wdr.cpp:2217
+#: src/muuli_wdr.cpp:2224
 #, fuzzy
 msgid "Reset page to defaults"
 msgstr "Predeterminat"
 
-#: src/muuli_wdr.cpp:2218
+#: src/muuli_wdr.cpp:2225
 msgid "Reset the settings on the current page to their default values."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2220 src/muuli_wdr.cpp:2306 src/ServerWnd.cpp:274
+#: src/muuli_wdr.cpp:2227 src/muuli_wdr.cpp:2313 src/ServerWnd.cpp:274
 #: src/ServerWnd.cpp:282
 msgid "OK"
 msgstr "OK"
 
-#: src/muuli_wdr.cpp:2222
+#: src/muuli_wdr.cpp:2229
 msgid "Click here to apply any changes made to the preferences."
 msgstr "Feu clic per a aplicar qualsevol canvi fet a les preferències."
 
-#: src/muuli_wdr.cpp:2225
+#: src/muuli_wdr.cpp:2232
 msgid "Reset any changes made to the preferences."
 msgstr "Reinicia qualsevol canvi fet a les preferències."
 
-#: src/muuli_wdr.cpp:2254
+#: src/muuli_wdr.cpp:2261
 msgid "Comment :"
 msgstr "Comentari:"
 
-#: src/muuli_wdr.cpp:2261
+#: src/muuli_wdr.cpp:2268
 msgid "Incoming Dir :"
 msgstr "Dir. d'entrada:"
 
-#: src/muuli_wdr.cpp:2270
+#: src/muuli_wdr.cpp:2277
 msgid "Change priority for new assigned files :"
 msgstr "Canvia la prioritat per als nous fitxers assignats:"
 
-#: src/muuli_wdr.cpp:2274
+#: src/muuli_wdr.cpp:2281
 msgid "Don't change"
 msgstr "No canviar"
 
-#: src/muuli_wdr.cpp:2286
+#: src/muuli_wdr.cpp:2293
 msgid "Select color for this Category (currently selected) :"
 msgstr "Seleccioneu un color per a la Categoria (actualment seleccionat):"
 
-#: src/muuli_wdr.cpp:2353 src/muuli_wdr.cpp:2372 src/muuli_wdr.cpp:2394
+#: src/muuli_wdr.cpp:2360 src/muuli_wdr.cpp:2379 src/muuli_wdr.cpp:2401
 msgid "Click this button to reset the log."
 msgstr "Feu clic per a reiniciar el registre."
 
-#: src/muuli_wdr.cpp:2413
+#: src/muuli_wdr.cpp:2420
 msgid "Click on this button to update the servers list from URL ..."
 msgstr "Feu clic en aquest botó per a actualitzar la llista de servidors des d'una URL ... "
 
-#: src/muuli_wdr.cpp:2417
+#: src/muuli_wdr.cpp:2424
 msgid "Server list"
 msgstr "Llista de servidors"
 
-#: src/muuli_wdr.cpp:2421
+#: src/muuli_wdr.cpp:2428
 msgid "Enter the url to a server.met file here and press the button to the left to update the list of known servers."
 msgstr "Introduïu l'adreça d'un fitxer server.met i premeu el botó de l'esquerra per a actualitzar la llista de servidors coneguts."
 
-#: src/muuli_wdr.cpp:2426
+#: src/muuli_wdr.cpp:2433
 msgid "Add server manually: Name"
 msgstr "Afegeix un servidor manualment: Nom"
 
-#: src/muuli_wdr.cpp:2429
+#: src/muuli_wdr.cpp:2436
 msgid "Enter the name of the new server here"
 msgstr "Introduïu el nom del nou servidor"
 
-#: src/muuli_wdr.cpp:2431 src/ServerWnd.cpp:206
+#: src/muuli_wdr.cpp:2438 src/ServerWnd.cpp:206
 msgid "IP:Port"
 msgstr "IP:Port"
 
-#: src/muuli_wdr.cpp:2434
+#: src/muuli_wdr.cpp:2441
 msgid "Enter the IP of the server here, using the x.x.x.x format."
 msgstr "Introduïu la IP del servidor, fent servir el format x.x.x.x."
 
-#: src/muuli_wdr.cpp:2440
+#: src/muuli_wdr.cpp:2447
 msgid "Enter the port of the server here."
 msgstr "Introduïu el port del servidor."
 
-#: src/muuli_wdr.cpp:2443
+#: src/muuli_wdr.cpp:2450
 msgid "Add manually a server (fill fields to the left before) ..."
 msgstr "Afegeix un servidor manualment (abans omple els camps de l'esquerra) ..."
 
-#: src/muuli_wdr.cpp:2472
+#: src/muuli_wdr.cpp:2479
 msgid "aMule Log"
 msgstr "Registre de l'aMule"
 
-#: src/muuli_wdr.cpp:2480
+#: src/muuli_wdr.cpp:2487
 msgid "Server Info"
 msgstr "Informació del servidor"
 
-#: src/muuli_wdr.cpp:2484
+#: src/muuli_wdr.cpp:2491
 msgid "ED2K Info"
 msgstr "Info. ED2K"
 
-#: src/muuli_wdr.cpp:2488
+#: src/muuli_wdr.cpp:2495
 msgid "Kad Info"
 msgstr "Info. Kad"
 
-#: src/muuli_wdr.cpp:2516
+#: src/muuli_wdr.cpp:2523
 msgid "Click on this button to update the nodes list from URL ..."
 msgstr "Feu clic en aquest botó per a actualitzar la llista de nodes des d'una URL ..."
 
-#: src/muuli_wdr.cpp:2520
+#: src/muuli_wdr.cpp:2527
 msgid "Nodes (0)"
 msgstr "Nodes (0)"
 
-#: src/muuli_wdr.cpp:2524
+#: src/muuli_wdr.cpp:2531
 msgid "Enter the url to a nodes.dat file here and press the button to the left to update the list of known nodes."
 msgstr "Introduïu la URL d'un fitxer nodes.dat i premeu el botó de l'esquerra per a actualitzar la llista de nodes coneguts."
 
-#: src/muuli_wdr.cpp:2527
+#: src/muuli_wdr.cpp:2534
 msgid "Nodes stats"
 msgstr "Estadístiques de nodes"
 
-#: src/muuli_wdr.cpp:2569
+#: src/muuli_wdr.cpp:2576
 msgid "Bootstrap"
 msgstr "Arrancada"
 
-#: src/muuli_wdr.cpp:2572
+#: src/muuli_wdr.cpp:2579
 msgid "New node"
 msgstr "Nou node"
 
-#: src/muuli_wdr.cpp:2577
+#: src/muuli_wdr.cpp:2584
 msgid "IP:"
 msgstr "IP:"
 
-#: src/muuli_wdr.cpp:2597
+#: src/muuli_wdr.cpp:2604
 msgid "Port:"
 msgstr "Port:"
 
-#: src/muuli_wdr.cpp:2610
+#: src/muuli_wdr.cpp:2617
 msgid "Bootstrap from known clients"
 msgstr "Inicia des dels clients coneguts"
 
-#: src/muuli_wdr.cpp:2612
+#: src/muuli_wdr.cpp:2619
 msgid "Disconnect Kad"
 msgstr "Desconnecta Kad"
 
-#: src/muuli_wdr.cpp:2646
+#: src/muuli_wdr.cpp:2653
 msgid "Use Secure User Identification"
 msgstr "Usa la Identificació Segura d'Usuari"
 
-#: src/muuli_wdr.cpp:2648
+#: src/muuli_wdr.cpp:2655
 msgid "It is recommended to enable this option. You will not receive credits if SUI is not enabled."
 msgstr "Es recomana activar aquesta opció. No rebreu crèdits (punts) si la Identificació Segura d'Usuari no és habilitada."
 
-#: src/muuli_wdr.cpp:2650
+#: src/muuli_wdr.cpp:2657
 msgid "Protocol Obfuscation"
 msgstr "Ofuscació de protocol"
 
-#: src/muuli_wdr.cpp:2653
+#: src/muuli_wdr.cpp:2660
 msgid "Support Protocol Obfuscation"
 msgstr "Suport per a l'ofuscació de protocol"
 
-#: src/muuli_wdr.cpp:2655
+#: src/muuli_wdr.cpp:2662
 msgid "This option enabled Protocol Obfuscation, and makes aMule accept obfuscated connections from other clients."
 msgstr "Habilita l'ofuscació de protocol, i permet a l'aMule acceptar connexions ofuscades d'altres clients."
 
-#: src/muuli_wdr.cpp:2657
+#: src/muuli_wdr.cpp:2664
 msgid "Use obfuscation for outgoing connections"
 msgstr "Usa l'ofuscació per a les connexions sortints"
 
-#: src/muuli_wdr.cpp:2659
+#: src/muuli_wdr.cpp:2666
 msgid "This option makes aMule use Protocol Obfuscation when connecting other clients/servers."
 msgstr "L'aMule usarà l'ofuscació de protocol en connectar amb altres clients/servidors."
 
-#: src/muuli_wdr.cpp:2661
+#: src/muuli_wdr.cpp:2668
 msgid "Accept only obfuscated connections"
 msgstr "Accepta únicament les connexions ofuscades"
 
-#: src/muuli_wdr.cpp:2662
+#: src/muuli_wdr.cpp:2669
 msgid "This option makes aMule only accept obfuscated connections. You will have less sources, but all your traffic will be obfuscated"
 msgstr "L'aMule només acceptarà les connexions ofuscades. Tindreu menys fonts, però tot el tràfic serà ofuscat"
 
-#: src/muuli_wdr.cpp:2667
+#: src/muuli_wdr.cpp:2674
 msgid "Everybody"
 msgstr "Tothom"
 
-#: src/muuli_wdr.cpp:2669
+#: src/muuli_wdr.cpp:2676
 msgid "No one"
 msgstr "Ningú"
 
-#: src/muuli_wdr.cpp:2671
+#: src/muuli_wdr.cpp:2678
 msgid "Who can see my shared files:"
 msgstr "Qui pot veure els meus fitxers compartits:"
 
-#: src/muuli_wdr.cpp:2672
+#: src/muuli_wdr.cpp:2679
 msgid "Select who can request to view a list of your shared files."
 msgstr "Selecciona qui pot veure la llista de fitxers compartits."
 
-#: src/muuli_wdr.cpp:2674
+#: src/muuli_wdr.cpp:2681
 msgid "IP-Filtering"
 msgstr "Filtratge IP"
 
-#: src/muuli_wdr.cpp:2681
+#: src/muuli_wdr.cpp:2688
 msgid "Filter clients"
 msgstr "Filtra els clients"
 
-#: src/muuli_wdr.cpp:2683
+#: src/muuli_wdr.cpp:2690
 msgid "Enable filtering of the client IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "Habilita el filtratge de les IP de clients especificades al fitxer ~/.aMule/ipfilter.dat."
 
-#: src/muuli_wdr.cpp:2685
+#: src/muuli_wdr.cpp:2692
 msgid "Filter servers"
 msgstr "Filtra els servidors"
 
-#: src/muuli_wdr.cpp:2687
+#: src/muuli_wdr.cpp:2694
 msgid "Enable filtering of the server IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "Habilita el filtratge de les IP de servidors especificades al fitxer ~/.aMule/ipfilter.dat."
 
-#: src/muuli_wdr.cpp:2691
+#: src/muuli_wdr.cpp:2698
 msgid "Reload List"
 msgstr "Recarrega la llista"
 
-#: src/muuli_wdr.cpp:2692
+#: src/muuli_wdr.cpp:2699
 msgid "Reload the list of IPs to filter from the file ~/.aMule/ipfilter.dat"
 msgstr "Recarrega la llista d'IPs a filtrar des del fitxer ~/.aMule/ipfilter.dat"
 
-#: src/muuli_wdr.cpp:2698
+#: src/muuli_wdr.cpp:2705
 msgid "URL:"
 msgstr "Adreça:"
 
-#: src/muuli_wdr.cpp:2702 src/muuli_wdr.cpp:2895
+#: src/muuli_wdr.cpp:2709 src/muuli_wdr.cpp:2902
 msgid "Update now"
 msgstr "Actualitza ara"
 
-#: src/muuli_wdr.cpp:2705
+#: src/muuli_wdr.cpp:2712
 msgid "Auto-update ipfilter at startup"
 msgstr "Actualitza automàticament a l'inici"
 
-#: src/muuli_wdr.cpp:2709
+#: src/muuli_wdr.cpp:2716
 msgid "Filtering Level:"
 msgstr "Nivell de filtratge:"
 
-#: src/muuli_wdr.cpp:2715
+#: src/muuli_wdr.cpp:2722
 msgid "Always filter LAN IPs"
 msgstr "Filtra sempre les IP LAN"
 
-#: src/muuli_wdr.cpp:2718
+#: src/muuli_wdr.cpp:2725
 msgid "Paranoid handling of non-matching IPs"
 msgstr "Gestió paranoica de les IP no corresponents"
 
-#: src/muuli_wdr.cpp:2720
+#: src/muuli_wdr.cpp:2727
 msgid "Rejects a packet when its source IP differs from the IP the client claims (an anti-spoofing check). Disable only if it causes connection problems."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2722
+#: src/muuli_wdr.cpp:2729
 msgid "Use system-wide ipfilter.dat if available"
 msgstr "Usa l'ipfilter.dat del sistema si està disponible"
 
-#: src/muuli_wdr.cpp:2723
+#: src/muuli_wdr.cpp:2730
 #, fuzzy
 msgid "If there's no local ipfilter.dat found, allow usage of a system-wide ipfilter file."
 msgstr "Si no es troba l'ipfilter.dat local, permet l'ús del fitxer ipfilter del sistema."
 
-#: src/muuli_wdr.cpp:2740
+#: src/muuli_wdr.cpp:2747
 msgid "Enable Online-Signature"
 msgstr "Habilita la signatura en línia"
 
-#: src/muuli_wdr.cpp:2742
+#: src/muuli_wdr.cpp:2749
 msgid "Enables the writing of the OS file, which can be used by external apps to create signatures and the like."
 msgstr "Habilita l'escriptura del fitxer de signatura, que altres aplicacions externes poden usar per a crear signatures i similars."
 
-#: src/muuli_wdr.cpp:2746
+#: src/muuli_wdr.cpp:2753
 msgid "Update Frequency (Secs):"
 msgstr "Freqüència d'actualització (segs):"
 
-#: src/muuli_wdr.cpp:2749
+#: src/muuli_wdr.cpp:2756
 msgid "Change the frequency (in seconds) of Online Signature updates."
 msgstr "Canvia la freqüència d'actualització (en segons) de la signatura en línia."
 
-#: src/muuli_wdr.cpp:2757
+#: src/muuli_wdr.cpp:2764
 msgid "Save online signature file in: "
 msgstr "Desa el fitxer de signatura en línia a: "
 
-#: src/muuli_wdr.cpp:2763
+#: src/muuli_wdr.cpp:2770
 msgid "Click here to select the directory containing the the Online Signature files."
 msgstr "Feu clic per a seleccionar el directori que conté els fitxers de signatura en línia."
 
-#: src/muuli_wdr.cpp:2796
+#: src/muuli_wdr.cpp:2803
 msgid "Show country flags for clients"
 msgstr "Mostra les banderes dels països per als clients"
 
-#: src/muuli_wdr.cpp:2797
+#: src/muuli_wdr.cpp:2804
 msgid "Render the country flag column in the transfers, queue and search views. Requires a valid MMDB GeoIP database (see below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2802
+#: src/muuli_wdr.cpp:2809
 #, fuzzy
 msgid "Database"
 msgstr "Velocitat:"
 
-#: src/muuli_wdr.cpp:2818
+#: src/muuli_wdr.cpp:2825
 #, fuzzy
 msgid "Source:"
 msgstr "Fonts"
 
-#: src/muuli_wdr.cpp:2821
+#: src/muuli_wdr.cpp:2828
 msgid "DB-IP (free, no account)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2822
+#: src/muuli_wdr.cpp:2829
 msgid "MaxMind GeoLite2 (free, account required)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2823
+#: src/muuli_wdr.cpp:2830
 msgid "Custom URL"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2826
+#: src/muuli_wdr.cpp:2833
 msgid "Choose which provider supplies the GeoIP MMDB database. DB-IP is the default - no account required. MaxMind requires a free account + license key. Use Custom URL to point at any other MMDB host (e.g. a local mirror)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2843
+#: src/muuli_wdr.cpp:2850
 msgid ""
 "No configuration required.\n"
 "\n"
@@ -4838,11 +4852,11 @@ msgid ""
 "License: Creative Commons BY 4.0 - https://creativecommons.org/licenses/by/4.0/"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2856
+#: src/muuli_wdr.cpp:2863
 msgid "License key:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2862
+#: src/muuli_wdr.cpp:2869
 msgid ""
 "Sign up for a free MaxMind account, then generate a License Key:\n"
 "https://www.maxmind.com/en/geolite2/signup\n"
@@ -4852,225 +4866,225 @@ msgid ""
 "Requires attribution and account registration; refresh at least every 30 days."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2877
+#: src/muuli_wdr.cpp:2884
 #, fuzzy
 msgid "Download URL:"
 msgstr "Baixant: "
 
-#: src/muuli_wdr.cpp:2883
+#: src/muuli_wdr.cpp:2890
 msgid ""
 "Must point to an .mmdb file or a .gz / .tar.gz containing one.\n"
 "URL may include credentials (https://user:pass@host/...).\n"
 "License and attribution terms are set by the upstream URL - you are responsible."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2896
+#: src/muuli_wdr.cpp:2903
 msgid "Download the GeoIP database from the selected source."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2898
+#: src/muuli_wdr.cpp:2905
 #, fuzzy
 msgid "Auto-update on startup"
 msgstr "Actualitza automàticament a l'inici"
 
-#: src/muuli_wdr.cpp:2899
+#: src/muuli_wdr.cpp:2906
 msgid "Re-download the GeoIP database from the selected source every time aMule starts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2922
+#: src/muuli_wdr.cpp:2929
 msgid "Filter incoming messages (except current chat):"
 msgstr "Filtra els missatges entrants (excepte el xat actual):"
 
-#: src/muuli_wdr.cpp:2924
+#: src/muuli_wdr.cpp:2931
 msgid "Filter all messages"
 msgstr "Filtra tots els missatges"
 
-#: src/muuli_wdr.cpp:2926
+#: src/muuli_wdr.cpp:2933
 msgid "Filter messages from people not on your friend list"
 msgstr "Filtra els missatges de la gent que no és a la llista d'amics"
 
-#: src/muuli_wdr.cpp:2928
+#: src/muuli_wdr.cpp:2935
 msgid "Filter messages from unknown clients"
 msgstr "Filtra els missatges dels clients desconeguts"
 
-#: src/muuli_wdr.cpp:2930
+#: src/muuli_wdr.cpp:2937
 msgid "Filter messages containing (use ',' as separator):"
 msgstr "Filtra els missatges que continguin (useu ',' per a separar):"
 
-#: src/muuli_wdr.cpp:2933 src/muuli_wdr.cpp:2944
+#: src/muuli_wdr.cpp:2940 src/muuli_wdr.cpp:2951
 msgid "add here the words amule should filter and block messages including it"
 msgstr "Els missatges que continguin aquestes paraules seran filtrats i bloquejats per l'aMule"
 
-#: src/muuli_wdr.cpp:2935
+#: src/muuli_wdr.cpp:2942
 msgid "Show received messages in the log"
 msgstr "Mostra els missatges rebuts en el registre"
 
-#: src/muuli_wdr.cpp:2938
+#: src/muuli_wdr.cpp:2945
 msgid "Comments"
 msgstr "Comentaris"
 
-#: src/muuli_wdr.cpp:2941
+#: src/muuli_wdr.cpp:2948
 msgid "Filter comments containing (use ',' as separator):"
 msgstr "Filtra els comentaris que continguin (useu ',' per a separar):"
 
-#: src/muuli_wdr.cpp:2966
+#: src/muuli_wdr.cpp:2973
 msgid "Enable Proxy"
 msgstr "Habilita el servidor intermediari"
 
-#: src/muuli_wdr.cpp:2967
+#: src/muuli_wdr.cpp:2974
 msgid "Enable/disable proxy support"
 msgstr "Habilita/inhabilita el suport per a servidor intermediari"
 
-#: src/muuli_wdr.cpp:2970
+#: src/muuli_wdr.cpp:2977
 msgid "Proxy type:"
 msgstr "Tipus de servidor:"
 
-#: src/muuli_wdr.cpp:2981
+#: src/muuli_wdr.cpp:2988
 msgid "Proxy host:"
 msgstr "Servidor intermediari:"
 
-#: src/muuli_wdr.cpp:2984
+#: src/muuli_wdr.cpp:2991
 msgid "The proxy host name"
 msgstr "El nom del servidor intermediari"
 
-#: src/muuli_wdr.cpp:2986
+#: src/muuli_wdr.cpp:2993
 msgid "Proxy port:"
 msgstr "Port del servidor:"
 
-#: src/muuli_wdr.cpp:2989
+#: src/muuli_wdr.cpp:2996
 msgid "The proxy port"
 msgstr "El port del servidor intermediari"
 
-#: src/muuli_wdr.cpp:2991
+#: src/muuli_wdr.cpp:2998
 msgid "Enable authentication"
 msgstr "Habilita l'autenticació"
 
-#: src/muuli_wdr.cpp:2992
+#: src/muuli_wdr.cpp:2999
 msgid "Enable/disable username/password authentication"
 msgstr "Habilita/inhabilita l'autenticació amb usuari/contrasenya"
 
-#: src/muuli_wdr.cpp:2995
+#: src/muuli_wdr.cpp:3002
 msgid "Username: "
 msgstr "Nom d'usuari:"
 
-#: src/muuli_wdr.cpp:2998
+#: src/muuli_wdr.cpp:3005
 msgid "The username to use to connect to the proxy"
 msgstr "El nom d'usuari per a connectar al servidor intermediari"
 
-#: src/muuli_wdr.cpp:3000
+#: src/muuli_wdr.cpp:3007
 msgid "Password:"
 msgstr "Contrasenya:"
 
-#: src/muuli_wdr.cpp:3003
+#: src/muuli_wdr.cpp:3010
 msgid "The password to use to connect to the proxy"
 msgstr "La contrasenya per a connectar al servidor intermediari"
 
-#: src/muuli_wdr.cpp:3022
+#: src/muuli_wdr.cpp:3029
 msgid "Connect to:"
 msgstr "Connecta a:"
 
-#: src/muuli_wdr.cpp:3031
+#: src/muuli_wdr.cpp:3038
 msgid "Login to remote amule"
 msgstr "Entra a l'aMule remot"
 
-#: src/muuli_wdr.cpp:3036
+#: src/muuli_wdr.cpp:3043
 msgid "User name"
 msgstr "Nom d'usuari"
 
-#: src/muuli_wdr.cpp:3047
+#: src/muuli_wdr.cpp:3054
 msgid "Remember those settings"
 msgstr "Recorda la configuració"
 
-#: src/muuli_wdr.cpp:3050
+#: src/muuli_wdr.cpp:3057
 #, fuzzy
 msgid "Force ZLIB compression"
 msgstr "Usa la compressió gzip"
 
-#: src/muuli_wdr.cpp:3074
+#: src/muuli_wdr.cpp:3081
 msgid "Enable Verbose Debug-Logging."
 msgstr "Habilita la depuració-registre detallats."
 
-#: src/muuli_wdr.cpp:3076
+#: src/muuli_wdr.cpp:3083
 msgid "Only to Logfile"
 msgstr "Només al fitxer de registre"
 
-#: src/muuli_wdr.cpp:3078
+#: src/muuli_wdr.cpp:3085
 msgid "Message Categories:"
 msgstr "Categories de missatge:"
 
-#: src/muuli_wdr.cpp:3102 src/PartFileConvertDlg.cpp:160
+#: src/muuli_wdr.cpp:3109 src/PartFileConvertDlg.cpp:160
 msgid "Waiting..."
 msgstr "Esperant..."
 
-#: src/muuli_wdr.cpp:3122
+#: src/muuli_wdr.cpp:3129
 msgid "Add imports"
 msgstr "Afegeix"
 
-#: src/muuli_wdr.cpp:3125
+#: src/muuli_wdr.cpp:3132
 msgid "Retry selected"
 msgstr "Reintenta"
 
-#: src/muuli_wdr.cpp:3127
+#: src/muuli_wdr.cpp:3134
 msgid "Remove selected"
 msgstr "Esborra"
 
-#: src/muuli_wdr.cpp:3190
+#: src/muuli_wdr.cpp:3197
 msgid "Event Types"
 msgstr "Tipus d'esdeveniments"
 
-#: src/muuli_wdr.cpp:3209
+#: src/muuli_wdr.cpp:3216
 msgid "Statistics and queued clients for selected file(s) : Session / All time"
 msgstr "Estadístiques i clients en cua per als fitxers seleccionats: Sessió / Total"
 
-#: src/muuli_wdr.cpp:3233
+#: src/muuli_wdr.cpp:3240
 msgid "Active Uploads"
 msgstr "Pujades actives"
 
-#: src/muuli_wdr.cpp:3247
+#: src/muuli_wdr.cpp:3254
 msgid "Percent of total files"
 msgstr "Percentatge del total de fitxers"
 
-#: src/muuli_wdr.cpp:3299
+#: src/muuli_wdr.cpp:3306
 msgid "Show Clients for"
 msgstr "Mostra els clients per"
 
-#: src/muuli_wdr.cpp:3301
+#: src/muuli_wdr.cpp:3308
 msgid "All files"
 msgstr "Tots els fitxers"
 
-#: src/muuli_wdr.cpp:3304
+#: src/muuli_wdr.cpp:3311
 msgid "Selected files"
 msgstr "Fitxers seleccionats"
 
-#: src/muuli_wdr.cpp:3307
+#: src/muuli_wdr.cpp:3314
 msgid "Active uploads only"
 msgstr "Només pujades actives"
 
-#: src/muuli_wdr.cpp:3314
+#: src/muuli_wdr.cpp:3321
 msgid "Reload:"
 msgstr "Recarrega:"
 
-#: src/muuli_wdr.cpp:3318
+#: src/muuli_wdr.cpp:3325
 msgid "Reload your shared files"
 msgstr "Recarrega els compartits"
 
-#: src/muuli_wdr.cpp:3381
+#: src/muuli_wdr.cpp:3388
 msgid "Send"
 msgstr "Envia"
 
-#: src/muuli_wdr.cpp:3382
+#: src/muuli_wdr.cpp:3389
 msgid "Sends the specified message."
 msgstr "Envia el missatge especificat."
 
-#: src/muuli_wdr.cpp:3386
+#: src/muuli_wdr.cpp:3393
 msgid "Close this chat-session."
 msgstr "Tanca aquesta sessió de xat."
 
-#: src/muuli_wdr.cpp:3409
+#: src/muuli_wdr.cpp:3416
 msgid "Connect to any server and/or Kad"
 msgstr "Connecta amb qualsevol servidor i/o Kad"
 
-#: src/muuli_wdr.cpp:3415 src/SharedFilesCtrl.cpp:142 src/Statistics.cpp:941
+#: src/muuli_wdr.cpp:3422 src/SharedFilesCtrl.cpp:142 src/Statistics.cpp:941
 msgid "Shared Files"
 msgstr "Compartits"
 
@@ -5431,188 +5445,188 @@ msgstr "Baixat"
 msgid "ERROR: Failed to open partfile '%s'"
 msgstr "ERROR: No s'ha pogut obrir el fitxer part '%s'"
 
-#: src/Preferences.cpp:673
+#: src/Preferences.cpp:674
 msgid "System default"
 msgstr "Predeterminat"
 
-#: src/Preferences.cpp:674
+#: src/Preferences.cpp:675
 msgid "Albanian"
 msgstr "Albanès"
 
-#: src/Preferences.cpp:675
+#: src/Preferences.cpp:676
 msgid "Arabic"
 msgstr "Àrab"
 
-#: src/Preferences.cpp:676
+#: src/Preferences.cpp:677
 msgid "Asturian"
 msgstr "Asturià"
 
-#: src/Preferences.cpp:677
+#: src/Preferences.cpp:678
 msgid "Basque"
 msgstr "Basc"
 
-#: src/Preferences.cpp:678
+#: src/Preferences.cpp:679
 msgid "Bulgarian"
 msgstr "Búlgar"
 
-#: src/Preferences.cpp:679
+#: src/Preferences.cpp:680
 msgid "Catalan"
 msgstr "Català; Valencià"
 
-#: src/Preferences.cpp:680
+#: src/Preferences.cpp:681
 msgid "Chinese (Simplified)"
 msgstr "Xinès (Simplificat)"
 
-#: src/Preferences.cpp:681
+#: src/Preferences.cpp:682
 msgid "Chinese (Traditional)"
 msgstr "Xinès (Tradicional)"
 
-#: src/Preferences.cpp:682
+#: src/Preferences.cpp:683
 msgid "Croatian"
 msgstr "Croat"
 
-#: src/Preferences.cpp:683
+#: src/Preferences.cpp:684
 msgid "Czech"
 msgstr "Txec"
 
-#: src/Preferences.cpp:684
+#: src/Preferences.cpp:685
 msgid "Danish"
 msgstr "Danès"
 
-#: src/Preferences.cpp:685
+#: src/Preferences.cpp:686
 msgid "Dutch"
 msgstr "Holandès"
 
-#: src/Preferences.cpp:686
+#: src/Preferences.cpp:687
 msgid "English (U.K.)"
 msgstr "Anglès (R.U.)"
 
-#: src/Preferences.cpp:687
+#: src/Preferences.cpp:688
 #, fuzzy
 msgid "English (U.S.)"
 msgstr "Anglès (R.U.)"
 
-#: src/Preferences.cpp:688
+#: src/Preferences.cpp:689
 msgid "Estonian"
 msgstr "Estonià"
 
-#: src/Preferences.cpp:689
+#: src/Preferences.cpp:690
 msgid "Finnish"
 msgstr "Finès"
 
-#: src/Preferences.cpp:690
+#: src/Preferences.cpp:691
 msgid "French"
 msgstr "Francès"
 
-#: src/Preferences.cpp:691
+#: src/Preferences.cpp:692
 msgid "Galician"
 msgstr "Gallec"
 
-#: src/Preferences.cpp:692
+#: src/Preferences.cpp:693
 msgid "German"
 msgstr "Alemany"
 
-#: src/Preferences.cpp:693
+#: src/Preferences.cpp:694
 msgid "Greek"
 msgstr "Grec"
 
-#: src/Preferences.cpp:694
+#: src/Preferences.cpp:695
 msgid "Hebrew"
 msgstr "Hebreu"
 
-#: src/Preferences.cpp:695
+#: src/Preferences.cpp:696
 msgid "Hungarian"
 msgstr "Hongarès"
 
-#: src/Preferences.cpp:696
+#: src/Preferences.cpp:697
 msgid "Italian"
 msgstr "Italià"
 
-#: src/Preferences.cpp:697
+#: src/Preferences.cpp:698
 msgid "Japanese"
 msgstr "Japonès"
 
-#: src/Preferences.cpp:698
+#: src/Preferences.cpp:699
 msgid "Korean"
 msgstr "Coreà"
 
-#: src/Preferences.cpp:699
+#: src/Preferences.cpp:700
 msgid "Latvian"
 msgstr ""
 
-#: src/Preferences.cpp:700
+#: src/Preferences.cpp:701
 msgid "Lithuanian"
 msgstr "Lituà"
 
-#: src/Preferences.cpp:701
+#: src/Preferences.cpp:702
 msgid "Norwegian (Nynorsk)"
 msgstr "Noruec"
 
-#: src/Preferences.cpp:702
+#: src/Preferences.cpp:703
 msgid "Polish"
 msgstr "Polonès"
 
-#: src/Preferences.cpp:703
+#: src/Preferences.cpp:704
 msgid "Portuguese"
 msgstr "Portuguès"
 
-#: src/Preferences.cpp:704
+#: src/Preferences.cpp:705
 msgid "Portuguese (Brazilian)"
 msgstr "Portuguès (Brasil)"
 
-#: src/Preferences.cpp:705
+#: src/Preferences.cpp:706
 msgid "Romanian"
 msgstr "Romanès"
 
-#: src/Preferences.cpp:706
+#: src/Preferences.cpp:707
 msgid "Russian"
 msgstr "Rus"
 
-#: src/Preferences.cpp:707
+#: src/Preferences.cpp:708
 msgid "Slovenian"
 msgstr "Eslovè"
 
-#: src/Preferences.cpp:708
+#: src/Preferences.cpp:709
 msgid "Spanish"
 msgstr "Espanyol; Castellà"
 
-#: src/Preferences.cpp:709
+#: src/Preferences.cpp:710
 msgid "Swedish"
 msgstr "Suec"
 
-#: src/Preferences.cpp:710
+#: src/Preferences.cpp:711
 msgid "Turkish"
 msgstr "Turc"
 
-#: src/Preferences.cpp:711
+#: src/Preferences.cpp:712
 msgid "Ukrainian"
 msgstr "Ucranià"
 
-#: src/Preferences.cpp:814
+#: src/Preferences.cpp:815
 msgid "Change Language"
 msgstr "Canvi d'idioma"
 
-#: src/Preferences.cpp:878
+#: src/Preferences.cpp:879
 msgid "There are no translations installed for aMule"
 msgstr "No hi ha traduccions instal·lades per a l'aMule"
 
-#: src/Preferences.cpp:879
+#: src/Preferences.cpp:880
 msgid "No languages available"
 msgstr "Sense idiomes disponibles"
 
-#: src/Preferences.cpp:1010
+#: src/Preferences.cpp:1011
 msgid "no options available"
 msgstr "No hi ha opcions disponibles"
 
-#: src/Preferences.cpp:2179
+#: src/Preferences.cpp:2182
 msgid "Invalid category found, skipping"
 msgstr "Categoria invàlida trobada, omitint"
 
-#: src/Preferences.cpp:2348
+#: src/Preferences.cpp:2351
 msgid "TCP port can't be higher than 65532 due to server UDP socket being TCP+3"
 msgstr "El port TCP no pot ser més gran que 65532 puix el sòcol UDP del servidor és TCP+3"
 
-#: src/Preferences.cpp:2349
+#: src/Preferences.cpp:2352
 #, c-format
 msgid "Default port will be used (%d)"
 msgstr "S'usarà el port per defecte (%d)"
@@ -6122,23 +6136,27 @@ msgstr "Recarrega la llista de fitxers compartits."
 msgid "Shared folder"
 msgstr "Carpetes compartides"
 
-#: src/SearchDlg.cpp:425
+#: src/SearchDlg.cpp:280
+msgid "Clear search history"
+msgstr ""
+
+#: src/SearchDlg.cpp:584
 msgid "It's impossible to search when both eD2k and Kademlia are disabled."
 msgstr "És impossible cercar quan l'eD2k i el Kademlia estan inhabilitats."
 
-#: src/SearchDlg.cpp:426 src/SearchListCtrl.cpp:858
+#: src/SearchDlg.cpp:585 src/SearchListCtrl.cpp:858
 msgid "Search error"
 msgstr "Error en la cerca"
 
-#: src/SearchDlg.cpp:768
+#: src/SearchDlg.cpp:929
 msgid "Min size must be smaller than max size. Max size ignored."
 msgstr "La mida mínima ha de ser menor que la màxima. S'ignorarà la mida màxima."
 
-#: src/SearchDlg.cpp:769 src/SearchDlg.cpp:851
+#: src/SearchDlg.cpp:930 src/SearchDlg.cpp:1012
 msgid "Search warning"
 msgstr "Avís de cerca"
 
-#: src/SearchDlg.cpp:929 src/SearchListCtrl.cpp:735
+#: src/SearchDlg.cpp:1092 src/SearchListCtrl.cpp:735
 msgid "Main"
 msgstr "Principal"
 

--- a/po/ca.po
+++ b/po/ca.po
@@ -14,7 +14,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-28 12:17+0200\n"
+"POT-Creation-Date: 2026-07-28 13:09+0200\n"
 "PO-Revision-Date: 2026-07-27 11:33+0000\n"
 "Last-Translator: minterior <minterior@gmail.com>\n"
 "Language-Team: Català\n"
@@ -292,7 +292,7 @@ msgid "Password set and external connections enabled."
 msgstr "Contrassenya definida i connexions externes activades."
 
 #: src/amule.cpp:755 src/KadDlg.cpp:176 src/KadDlg.cpp:185
-#: src/PrefsUnifiedDlg.cpp:1461 src/SharedFilesCtrl.cpp:476
+#: src/PrefsUnifiedDlg.cpp:1470 src/SharedFilesCtrl.cpp:476
 msgid "WARNING"
 msgstr "AVÍS"
 
@@ -330,7 +330,7 @@ msgstr "Heu demanat que s'executi el servidor web a l'inici, però no s'ha troba
 #: src/amule-remote-gui.cpp:603 src/amule-remote-gui.cpp:671
 #: src/amule-remote-gui.cpp:709 src/amule-remote-gui.cpp:1282
 #: src/amule-remote-gui.cpp:1345 src/amule-remote-gui.cpp:1372
-#: src/DownloadQueue.cpp:1481 src/PrefsUnifiedDlg.cpp:1247
+#: src/DownloadQueue.cpp:1481 src/PrefsUnifiedDlg.cpp:1256
 msgid "ERROR"
 msgstr "ERROR"
 
@@ -592,36 +592,36 @@ msgstr "Visiteu https://github.com/amule-org/amule/releases/latest per a comprov
 msgid "FATAL ERROR: Failed to create Timer"
 msgstr "ERROR GREU: No s'ha pogut crear el temporitzador"
 
-#: src/amuleDlg.cpp:361 src/amuleDlg.cpp:1787 src/amuleDlg.cpp:2033
-#: src/muuli_wdr.cpp:1492 src/muuli_wdr.cpp:3449
+#: src/amuleDlg.cpp:361 src/amuleDlg.cpp:1810 src/amuleDlg.cpp:2056
+#: src/muuli_wdr.cpp:1492 src/muuli_wdr.cpp:3453
 msgid "Networks"
 msgstr "Xarxes"
 
-#: src/amuleDlg.cpp:362 src/amuleDlg.cpp:1793 src/muuli_wdr.cpp:3450
+#: src/amuleDlg.cpp:362 src/amuleDlg.cpp:1816 src/muuli_wdr.cpp:3454
 msgid "Searches"
 msgstr "Cerques"
 
-#: src/amuleDlg.cpp:363 src/amuleDlg.cpp:1799 src/DownloadListCtrl.cpp:740
-#: src/muuli_wdr.cpp:392 src/muuli_wdr.cpp:1585 src/muuli_wdr.cpp:3451
+#: src/amuleDlg.cpp:363 src/amuleDlg.cpp:1822 src/DownloadListCtrl.cpp:740
+#: src/muuli_wdr.cpp:392 src/muuli_wdr.cpp:1585 src/muuli_wdr.cpp:3455
 #: src/Statistics.cpp:829
 msgid "Downloads"
 msgstr "Baixades"
 
-#: src/amuleDlg.cpp:364 src/amuleDlg.cpp:1805 src/muuli_wdr.cpp:3325
+#: src/amuleDlg.cpp:364 src/amuleDlg.cpp:1828 src/muuli_wdr.cpp:3329
 msgid "Shared files"
 msgstr "Compartits"
 
-#: src/amuleDlg.cpp:365 src/amuleDlg.cpp:1811 src/muuli_wdr.cpp:2957
-#: src/muuli_wdr.cpp:3407 src/muuli_wdr.cpp:3454
+#: src/amuleDlg.cpp:365 src/amuleDlg.cpp:1834 src/muuli_wdr.cpp:2961
+#: src/muuli_wdr.cpp:3411 src/muuli_wdr.cpp:3458
 msgid "Messages"
 msgstr "Missatges"
 
-#: src/amuleDlg.cpp:366 src/amuleDlg.cpp:1817 src/muuli_wdr.cpp:3455
+#: src/amuleDlg.cpp:366 src/amuleDlg.cpp:1840 src/muuli_wdr.cpp:3459
 #: src/PrefsUnifiedDlg.cpp:314 src/Statistics.cpp:779 src/Statistics.cpp:1235
 msgid "Statistics"
 msgstr "Estadístiques"
 
-#: src/amuleDlg.cpp:368 src/amuleDlg.cpp:1824 src/muuli_wdr.cpp:3457
+#: src/amuleDlg.cpp:368 src/amuleDlg.cpp:1847 src/muuli_wdr.cpp:3461
 #: src/PrefsUnifiedDlg.cpp:330 src/utils/wxCas/src/wxcasprefs.cpp:39
 msgid "Preferences"
 msgstr "Preferències"
@@ -680,8 +680,8 @@ msgstr "Kad: Inativa"
 #: src/amuleDlg.cpp:1029 src/DownloadListCtrl.cpp:505
 #: src/DownloadListCtrl.cpp:749 src/FriendListCtrl.cpp:180
 #: src/muuli_wdr.cpp:731 src/muuli_wdr.cpp:782 src/muuli_wdr.cpp:846
-#: src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2262 src/muuli_wdr.cpp:2347
-#: src/muuli_wdr.cpp:3095 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
+#: src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2266 src/muuli_wdr.cpp:2351
+#: src/muuli_wdr.cpp:3099 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
 #: src/ServerListCtrl.cpp:606 src/TransferWnd.cpp:378
 #: src/utils/wxCas/src/wxcasprefs.cpp:235
 msgid "Cancel"
@@ -692,7 +692,7 @@ msgid "Stop the current connection attempts"
 msgstr "Atura els intents de connexió actuals"
 
 #: src/amuleDlg.cpp:1035 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976
-#: src/muuli_wdr.cpp:2485
+#: src/muuli_wdr.cpp:2489
 msgid "Disconnect"
 msgstr "Desconnecta"
 
@@ -701,7 +701,7 @@ msgid "Disconnect from the currently connected networks"
 msgstr "Desconnecta de les xarxes on s'està connectat actualment"
 
 #: src/amuleDlg.cpp:1041 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979
-#: src/muuli_wdr.cpp:2640 src/muuli_wdr.cpp:3092 src/muuli_wdr.cpp:3447
+#: src/muuli_wdr.cpp:2644 src/muuli_wdr.cpp:3096 src/muuli_wdr.cpp:3451
 msgid "Connect"
 msgstr "Connecta"
 
@@ -755,7 +755,7 @@ msgstr "Confirmació de sortida"
 msgid "Launch Command: "
 msgstr "Ordre: "
 
-#: src/amuleDlg.cpp:1632 src/muuli_wdr.cpp:1982 src/Preferences.cpp:979
+#: src/amuleDlg.cpp:1632 src/muuli_wdr.cpp:1986 src/Preferences.cpp:979
 msgid "- default -"
 msgstr "- defecte -"
 
@@ -769,60 +769,60 @@ msgstr "El directori del tema '%s' no existeix"
 msgid "WARNING: Unable to open skin file '%s' for read"
 msgstr "AVÍS: No ha estat possible obrir el fitxer d'aparença '%s' per a lectura"
 
-#: src/amuleDlg.cpp:1791 src/muuli_wdr.cpp:3449
+#: src/amuleDlg.cpp:1814 src/muuli_wdr.cpp:3453
 msgid "Networks Window"
 msgstr "Finestra de les Xarxes"
 
-#: src/amuleDlg.cpp:1797 src/muuli_wdr.cpp:3450
+#: src/amuleDlg.cpp:1820 src/muuli_wdr.cpp:3454
 msgid "Searches Window"
 msgstr "Finestra de cerques"
 
-#: src/amuleDlg.cpp:1803 src/muuli_wdr.cpp:3451
+#: src/amuleDlg.cpp:1826 src/muuli_wdr.cpp:3455
 msgid "Downloads Window"
 msgstr "Finestra de baixades"
 
-#: src/amuleDlg.cpp:1809 src/muuli_wdr.cpp:3453
+#: src/amuleDlg.cpp:1832 src/muuli_wdr.cpp:3457
 msgid "Shared Files Window"
 msgstr "Finestra de fitxers compartits"
 
-#: src/amuleDlg.cpp:1815 src/muuli_wdr.cpp:3454
+#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3458
 msgid "Messages Window"
 msgstr "Finestra de Missatges"
 
-#: src/amuleDlg.cpp:1821 src/muuli_wdr.cpp:3455
+#: src/amuleDlg.cpp:1844 src/muuli_wdr.cpp:3459
 msgid "Statistics Graph Window"
 msgstr "Finestra del gràfic d'estadístiques"
 
-#: src/amuleDlg.cpp:1828 src/muuli_wdr.cpp:3457
+#: src/amuleDlg.cpp:1851 src/muuli_wdr.cpp:3461
 msgid "Preferences Settings Window"
 msgstr "Finestra de la configuració de preferències"
 
-#: src/amuleDlg.cpp:1831 src/muuli_wdr.cpp:3458
+#: src/amuleDlg.cpp:1854 src/muuli_wdr.cpp:3462
 msgid "Import"
 msgstr "Importa"
 
-#: src/amuleDlg.cpp:1835 src/muuli_wdr.cpp:3458
+#: src/amuleDlg.cpp:1858 src/muuli_wdr.cpp:3462
 msgid "The partfile importer tool"
 msgstr "Eina d'importació de fitxers de parts"
 
-#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3459
+#: src/amuleDlg.cpp:1861 src/muuli_wdr.cpp:3463
 #: src/utils/aLinkCreator/src/alcframe.cpp:262
 msgid "About"
 msgstr "Quant a"
 
-#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3459
+#: src/amuleDlg.cpp:1861 src/muuli_wdr.cpp:3463
 msgid "About/Help"
 msgstr "Quant a / Ajuda"
 
-#: src/amuleDlg.cpp:2036
+#: src/amuleDlg.cpp:2059
 msgid "eD2k network"
 msgstr "Xarxa eD2k"
 
-#: src/amuleDlg.cpp:2039
+#: src/amuleDlg.cpp:2062
 msgid "Kad network"
 msgstr "Xarxa Kad"
 
-#: src/amuleDlg.cpp:2039
+#: src/amuleDlg.cpp:2062
 msgid "No network"
 msgstr "Cap xarxa"
 
@@ -1355,19 +1355,19 @@ msgstr "Auto [Al]"
 msgid "Very low"
 msgstr "Molt baixa"
 
-#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:743 src/muuli_wdr.cpp:2313
+#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:743 src/muuli_wdr.cpp:2317
 #: src/ServerListCtrl.cpp:263 src/ServerListCtrl.cpp:456
 #: src/SharedFilesCtrl.cpp:145
 msgid "Low"
 msgstr "Baixa"
 
-#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:744 src/muuli_wdr.cpp:2314
+#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:744 src/muuli_wdr.cpp:2318
 #: src/ServerListCtrl.cpp:266 src/ServerListCtrl.cpp:457
 #: src/SharedFilesCtrl.cpp:146
 msgid "Normal"
 msgstr "Normal"
 
-#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:745 src/muuli_wdr.cpp:2315
+#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:745 src/muuli_wdr.cpp:2319
 #: src/ServerListCtrl.cpp:269 src/ServerListCtrl.cpp:458
 #: src/SharedFilesCtrl.cpp:147
 msgid "High"
@@ -1459,7 +1459,7 @@ msgstr "Servidor local"
 msgid "Remote Server"
 msgstr "Servidor remot"
 
-#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3212
+#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3216
 #: src/SearchDlg.cpp:119 src/TextClient.cpp:911
 msgid "Kad"
 msgstr "Kad"
@@ -1531,7 +1531,7 @@ msgstr "Part"
 msgid "Size"
 msgstr "Mida"
 
-#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3279
+#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3283
 msgid "Transferred"
 msgstr "Transferit"
 
@@ -1589,7 +1589,7 @@ msgstr ""
 "Retroacció des de: %s (%s)\n"
 "\n"
 
-#: src/DownloadListCtrl.cpp:746 src/muuli_wdr.cpp:2316
+#: src/DownloadListCtrl.cpp:746 src/muuli_wdr.cpp:2320
 #: src/SharedFilesCtrl.cpp:150
 msgid "Auto"
 msgstr "Auto"
@@ -1627,7 +1627,7 @@ msgid "Extended Options"
 msgstr "Opcions avançades"
 
 #: src/DownloadListCtrl.cpp:770 src/DownloadListCtrl.cpp:822
-#: src/muuli_wdr.cpp:1800
+#: src/muuli_wdr.cpp:1804
 msgid "Preview"
 msgstr "Previsualitza"
 
@@ -2428,23 +2428,23 @@ msgid ""
 "want downloads on a different (e.g. larger) disk."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:549 src/FirstRunWizard.cpp:611 src/muuli_wdr.cpp:1712
+#: src/FirstRunWizard.cpp:549 src/FirstRunWizard.cpp:611 src/muuli_wdr.cpp:1716
 msgid "Destination folder for downloads"
 msgstr "Carpeta on desar les descàrregues"
 
 #: src/FirstRunWizard.cpp:553 src/FirstRunWizard.cpp:569 src/muuli_wdr.cpp:1349
-#: src/muuli_wdr.cpp:1366 src/muuli_wdr.cpp:1687 src/muuli_wdr.cpp:1718
-#: src/muuli_wdr.cpp:1730 src/muuli_wdr.cpp:2800
+#: src/muuli_wdr.cpp:1366 src/muuli_wdr.cpp:1691 src/muuli_wdr.cpp:1722
+#: src/muuli_wdr.cpp:1734 src/muuli_wdr.cpp:2804
 #: src/utils/aLinkCreator/src/alcframe.cpp:135
 #: src/utils/wxCas/src/wxcasprefs.cpp:52 src/utils/wxCas/src/wxcasprefs.cpp:118
 msgid "Browse"
 msgstr "Explora"
 
-#: src/FirstRunWizard.cpp:559 src/muuli_wdr.cpp:1723
+#: src/FirstRunWizard.cpp:559 src/muuli_wdr.cpp:1727
 msgid "(All files in this folder are shared with other peers)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:565 src/FirstRunWizard.cpp:624 src/muuli_wdr.cpp:1725
+#: src/FirstRunWizard.cpp:565 src/FirstRunWizard.cpp:624 src/muuli_wdr.cpp:1729
 msgid "Folder for temporary download files"
 msgstr "Carpeta on desar les descàrregues temporals"
 
@@ -2475,7 +2475,7 @@ msgstr "No s'ha pogut obrir el fitxer amb la llista d'amics 'emfriends.met' per 
 msgid "CRITICAL - no client on StartChatSession"
 msgstr "CRITIC - no hi ha client a l'Inici de Sessió del Xat"
 
-#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2706 src/muuli_wdr.cpp:3383
+#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2710 src/muuli_wdr.cpp:3387
 msgid "Friends"
 msgstr "Amics"
 
@@ -2586,8 +2586,8 @@ msgstr "Cap"
 msgid "No"
 msgstr "No"
 
-#: src/GenericClientListCtrl.cpp:1216 src/PrefsUnifiedDlg.cpp:2898
-#: src/PrefsUnifiedDlg.cpp:2948 src/ServerListCtrl.cpp:276
+#: src/GenericClientListCtrl.cpp:1216 src/PrefsUnifiedDlg.cpp:2907
+#: src/PrefsUnifiedDlg.cpp:2957 src/ServerListCtrl.cpp:276
 msgid "Yes"
 msgstr "Sí"
 
@@ -2756,10 +2756,10 @@ msgstr "Port invàlid per a l'arrancada"
 msgid "Please fill all fields required"
 msgstr "Si us plau empleneu tots els camps requerits"
 
-#: src/KadDlg.cpp:192 src/PartFile.cpp:1031 src/PrefsUnifiedDlg.cpp:1134
-#: src/PrefsUnifiedDlg.cpp:1204 src/PrefsUnifiedDlg.cpp:1405
-#: src/PrefsUnifiedDlg.cpp:1663 src/PrefsUnifiedDlg.cpp:1673
-#: src/PrefsUnifiedDlg.cpp:1690 src/PrefsUnifiedDlg.cpp:1738
+#: src/KadDlg.cpp:192 src/PartFile.cpp:1031 src/PrefsUnifiedDlg.cpp:1143
+#: src/PrefsUnifiedDlg.cpp:1213 src/PrefsUnifiedDlg.cpp:1414
+#: src/PrefsUnifiedDlg.cpp:1672 src/PrefsUnifiedDlg.cpp:1682
+#: src/PrefsUnifiedDlg.cpp:1699 src/PrefsUnifiedDlg.cpp:1747
 msgid "Message"
 msgstr "Missatge"
 
@@ -2861,7 +2861,7 @@ msgstr "Ràtio"
 msgid "Uploaded"
 msgstr "Transferit"
 
-#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3263
+#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3267
 msgid "Requested"
 msgstr "Peticions"
 
@@ -2985,7 +2985,7 @@ msgid "WARNING: "
 msgstr "AVÍS: "
 
 #: src/MuleNotebook.cpp:179 src/muuli_wdr.cpp:817 src/muuli_wdr.cpp:1229
-#: src/muuli_wdr.cpp:3167 src/muuli_wdr.cpp:3423
+#: src/muuli_wdr.cpp:3171 src/muuli_wdr.cpp:3427
 msgid "Close"
 msgstr "Tanca"
 
@@ -3003,7 +3003,7 @@ msgid "Paste"
 msgstr "Enganxa"
 
 #: src/MuleTextCtrl.cpp:89 src/muuli_wdr.cpp:358 src/muuli_wdr.cpp:757
-#: src/muuli_wdr.cpp:2390 src/muuli_wdr.cpp:2409 src/muuli_wdr.cpp:2431
+#: src/muuli_wdr.cpp:2394 src/muuli_wdr.cpp:2413 src/muuli_wdr.cpp:2435
 #: src/utils/aLinkCreator/src/alcframe.cpp:142
 msgid "Clear"
 msgstr "Neteja"
@@ -3102,7 +3102,7 @@ msgstr "Surt"
 
 #: src/MuleTrayIcon.cpp:579 src/MuleTrayIcon.cpp:945 src/MuleTrayIcon.cpp:965
 #: src/muuli_wdr.cpp:1398 src/muuli_wdr.cpp:1406 src/muuli_wdr.cpp:1413
-#: src/muuli_wdr.cpp:1846 src/muuli_wdr.cpp:1852 src/OtherFunctions.cpp:91
+#: src/muuli_wdr.cpp:1850 src/muuli_wdr.cpp:1856 src/OtherFunctions.cpp:91
 #: src/StatisticsDlg.cpp:93 src/StatisticsDlg.cpp:95
 msgid "kB/s"
 msgstr "kB/s"
@@ -3344,7 +3344,7 @@ msgstr "Bytes"
 msgid "KB"
 msgstr "KB"
 
-#: src/muuli_wdr.cpp:274 src/muuli_wdr.cpp:293 src/muuli_wdr.cpp:1631
+#: src/muuli_wdr.cpp:274 src/muuli_wdr.cpp:293 src/muuli_wdr.cpp:1635
 #: src/OtherFunctions.cpp:64
 msgid "MB"
 msgstr "MB"
@@ -3361,7 +3361,7 @@ msgstr "Mida Màx."
 msgid "Availability"
 msgstr "Disponibilitat"
 
-#: src/muuli_wdr.cpp:312 src/muuli_wdr.cpp:398 src/muuli_wdr.cpp:3328
+#: src/muuli_wdr.cpp:312 src/muuli_wdr.cpp:398 src/muuli_wdr.cpp:3332
 msgid "Filter:"
 msgstr "Filtre:"
 
@@ -3424,8 +3424,8 @@ msgstr "Fonts del fitxer:"
 #: src/muuli_wdr.cpp:1160 src/muuli_wdr.cpp:1167 src/muuli_wdr.cpp:1172
 #: src/muuli_wdr.cpp:1179 src/muuli_wdr.cpp:1184 src/muuli_wdr.cpp:1191
 #: src/muuli_wdr.cpp:1205 src/muuli_wdr.cpp:1212 src/muuli_wdr.cpp:1217
-#: src/muuli_wdr.cpp:1224 src/muuli_wdr.cpp:3265 src/muuli_wdr.cpp:3273
-#: src/muuli_wdr.cpp:3281
+#: src/muuli_wdr.cpp:1224 src/muuli_wdr.cpp:3269 src/muuli_wdr.cpp:3277
+#: src/muuli_wdr.cpp:3285
 msgid "N/A"
 msgstr "N/D"
 
@@ -3570,7 +3570,7 @@ msgstr ""
 msgid "Album :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:685 src/muuli_wdr.cpp:2285
+#: src/muuli_wdr.cpp:685 src/muuli_wdr.cpp:2289
 msgid "Title :"
 msgstr "Títol:"
 
@@ -3679,7 +3679,7 @@ msgstr "Usuari:"
 msgid "Userhash :"
 msgstr "Resum de l'usuari:"
 
-#: src/muuli_wdr.cpp:895 src/muuli_wdr.cpp:1752 src/muuli_wdr.cpp:2480
+#: src/muuli_wdr.cpp:895 src/muuli_wdr.cpp:1756 src/muuli_wdr.cpp:2484
 #: src/utils/aLinkCreator/src/alcframe.cpp:137
 msgid "Add"
 msgstr "Afegeix"
@@ -3688,15 +3688,15 @@ msgstr "Afegeix"
 msgid "Download-Speed"
 msgstr "Velocitat de baixada"
 
-#: src/muuli_wdr.cpp:954 src/muuli_wdr.cpp:989 src/muuli_wdr.cpp:2584
+#: src/muuli_wdr.cpp:954 src/muuli_wdr.cpp:989 src/muuli_wdr.cpp:2588
 msgid "Current"
 msgstr "Actual"
 
-#: src/muuli_wdr.cpp:962 src/muuli_wdr.cpp:997 src/muuli_wdr.cpp:2592
+#: src/muuli_wdr.cpp:962 src/muuli_wdr.cpp:997 src/muuli_wdr.cpp:2596
 msgid "Running average"
 msgstr "Mitjana total"
 
-#: src/muuli_wdr.cpp:970 src/muuli_wdr.cpp:1005 src/muuli_wdr.cpp:2600
+#: src/muuli_wdr.cpp:970 src/muuli_wdr.cpp:1005 src/muuli_wdr.cpp:2604
 msgid "Session average"
 msgstr "Mitjana de la sessió"
 
@@ -3708,7 +3708,7 @@ msgstr "Velocitat de pujada"
 msgid "Connections"
 msgstr "Connexions"
 
-#: src/muuli_wdr.cpp:1024 src/muuli_wdr.cpp:1871
+#: src/muuli_wdr.cpp:1024 src/muuli_wdr.cpp:1875
 msgid "Active downloads"
 msgstr "Baixades actives"
 
@@ -3716,7 +3716,7 @@ msgstr "Baixades actives"
 msgid "Active connections (1:1)"
 msgstr "Connexions actives (1:1)"
 
-#: src/muuli_wdr.cpp:1040 src/muuli_wdr.cpp:1872
+#: src/muuli_wdr.cpp:1040 src/muuli_wdr.cpp:1876
 msgid "Active uploads"
 msgstr "Pujades actives"
 
@@ -3992,7 +3992,7 @@ msgstr "Vincula l'adreça local a l'IP (buit per qualsevol):"
 msgid "Advanced users only: If you have multiple network interfaces, enter the address of the interface to which aMule should be bound."
 msgstr "Només usuaris avançats: Si disposeu de multiples interfícies de xarxa, entreu l'adreça de la interfície a la que l'aMule hauria d'estar vinculada."
 
-#: src/muuli_wdr.cpp:1462 src/muuli_wdr.cpp:2065
+#: src/muuli_wdr.cpp:1462 src/muuli_wdr.cpp:2069
 #, fuzzy
 msgid "Bind to network interface (empty for any):"
 msgstr "Vincula l'adreça local a l'IP (buit per qualsevol):"
@@ -4009,7 +4009,7 @@ msgstr "Nombre màxim de fonts per descàrrega:"
 msgid "Max simultaneous connections:"
 msgstr "Nombre màxim de connexions simultànies:"
 
-#: src/muuli_wdr.cpp:1498 src/muuli_wdr.cpp:3207
+#: src/muuli_wdr.cpp:1498 src/muuli_wdr.cpp:3211
 msgid "ED2K"
 msgstr "ED2K"
 
@@ -4101,778 +4101,778 @@ msgstr "Preassigna l'espai al disc per als fitxers nous"
 msgid "For new files preallocates disk space for the whole file, thus reduces fragmentation"
 msgstr "Per a fitxers nous reserva l'espai que ocuparà el fitxer complet. Açò redueix la fragmentació"
 
-#: src/muuli_wdr.cpp:1617
+#: src/muuli_wdr.cpp:1621
 msgid "Create new files as sparse files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1618
+#: src/muuli_wdr.cpp:1622
 msgid "Sparse part files only occupy disk space for the parts already downloaded, so free space is used up gradually as the file fills in. Turn this off to use an ordinary file instead - useful where sparse files are unsupported or slow, or where backup/de-duplication tools handle them badly. Applies only when the core runs on Windows; on Linux and macOS part files are sparse anyway and this setting has no effect."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1623
+#: src/muuli_wdr.cpp:1627
 msgid "Stop downloads when free disk space reaches "
 msgstr "Atura les descàrregues quan l'espai buit al disc arribi a "
 
-#: src/muuli_wdr.cpp:1624
+#: src/muuli_wdr.cpp:1628
 msgid "Select this if you want aMule to check your disk space"
 msgstr "Seleccioneu-ho si voleu que l'aMule comprovi l'espai del disc"
 
-#: src/muuli_wdr.cpp:1628
+#: src/muuli_wdr.cpp:1632
 msgid "Enter here the min disk space desired."
 msgstr "Poseu l'espai mínim de disc desitjat."
 
-#: src/muuli_wdr.cpp:1634
+#: src/muuli_wdr.cpp:1638
 msgid "Save 10 sources on rare files (< 20 sources)"
 msgstr "Recorda 10 fonts dels fitxers rars (amb < 20 fonts)"
 
-#: src/muuli_wdr.cpp:1638 src/Statistics.cpp:790
+#: src/muuli_wdr.cpp:1642 src/Statistics.cpp:790
 msgid "Uploads"
 msgstr "Pujades"
 
-#: src/muuli_wdr.cpp:1641
+#: src/muuli_wdr.cpp:1645
 msgid "Add new shared files with auto priority"
 msgstr "Afegeix els nous fitxer compartits amb prioritat automàtica"
 
-#: src/muuli_wdr.cpp:1647
+#: src/muuli_wdr.cpp:1651
 msgid "Intelligent Corruption Handling (I.C.H.)"
 msgstr "Gestió d'Errors Inteligent (I.C.H.)"
 
-#: src/muuli_wdr.cpp:1650
+#: src/muuli_wdr.cpp:1654
 msgid "Enable"
 msgstr "Activa"
 
-#: src/muuli_wdr.cpp:1653
+#: src/muuli_wdr.cpp:1657
 msgid "Advanced I.C.H. trusts every hash (not recommended)"
 msgstr "I.C.H. avançat confia en totes les comprovacions (no recomanat)"
 
-#: src/muuli_wdr.cpp:1665 src/PrefsUnifiedDlg.cpp:1990
+#: src/muuli_wdr.cpp:1669 src/PrefsUnifiedDlg.cpp:1999
 msgid "Media metadata extraction"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1669
+#: src/muuli_wdr.cpp:1673
 msgid "Extract length / bitrate / codec from shared audio and video files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1671
+#: src/muuli_wdr.cpp:1675
 msgid "When enabled, aMule runs ffprobe on each shared media file to fill in the Length / Bitrate / Codec columns other clients see when they find the file in a search. Requires ffmpeg (the ffprobe binary) to be installed."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1678
+#: src/muuli_wdr.cpp:1682
 msgid "Path to ffprobe:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1683
+#: src/muuli_wdr.cpp:1687
 msgid "Full path to the ffprobe binary. Leave empty to have aMule auto-detect it on startup."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1691
+#: src/muuli_wdr.cpp:1695
 msgid "Detect"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1692
+#: src/muuli_wdr.cpp:1696
 msgid "Search the standard install locations for an ffprobe binary and fill the path field."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1716
+#: src/muuli_wdr.cpp:1720
 msgid ""
 "Completed downloads are stored here. All files in this folder are automatically shared with other peers.\n"
 "If this folder also holds files you don't want to share, point it at an aMule-only sub-folder."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1719
+#: src/muuli_wdr.cpp:1723
 msgid "Pick the folder where completed downloads will be stored. All files in that folder will be shared with other peers."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1733
+#: src/muuli_wdr.cpp:1737
 msgid "Shared folders"
 msgstr "Carpetes compartides"
 
-#: src/muuli_wdr.cpp:1739
+#: src/muuli_wdr.cpp:1743
 msgid "(Folders shared by the core. Enter a path to add one.)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1747
+#: src/muuli_wdr.cpp:1751
 msgid "Absolute path of a folder on the core's machine, e.g. /home/user/shared"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1749 src/PrefsUnifiedDlg.cpp:2874
+#: src/muuli_wdr.cpp:1753 src/PrefsUnifiedDlg.cpp:2883
 msgid "Recursive"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1750
+#: src/muuli_wdr.cpp:1754
 msgid "Share every sub-folder underneath this one, including ones created later."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1754 src/utils/aLinkCreator/src/alcframe.cpp:141
+#: src/muuli_wdr.cpp:1758 src/utils/aLinkCreator/src/alcframe.cpp:141
 msgid "Remove"
 msgstr "Esborra"
 
-#: src/muuli_wdr.cpp:1758
+#: src/muuli_wdr.cpp:1762
 msgid "(Right click on folder icon for recursive share)"
 msgstr "(Per a compartir recursivament feu clic dret sobre el directori)"
 
-#: src/muuli_wdr.cpp:1765
+#: src/muuli_wdr.cpp:1769
 msgid "Share hidden files"
 msgstr "Comparteix els fitxers ocults"
 
-#: src/muuli_wdr.cpp:1771
+#: src/muuli_wdr.cpp:1775
 msgid "Automatically rescan shared folders for changes"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1777
+#: src/muuli_wdr.cpp:1781
 msgid "Follow symbolic links in shared folders"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1783
+#: src/muuli_wdr.cpp:1787
 msgid "Exclude files matching:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1786
+#: src/muuli_wdr.cpp:1790
 msgid "Wildcard patterns separated by '|', e.g. .DS_Store|Thumbs.db|*.tmp. Files whose name matches are not shared. Matching is case-insensitive."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1790
+#: src/muuli_wdr.cpp:1794
 msgid "Patterns are regular expressions"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1791
+#: src/muuli_wdr.cpp:1795
 msgid "When set, the whole field is one regular expression ('|' is alternation). When unset, it is a list of '|'-separated wildcards."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1801
+#: src/muuli_wdr.cpp:1805
 msgid "Show how many shared files the current pattern would exclude."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1822
+#: src/muuli_wdr.cpp:1826
 msgid "Graphs"
 msgstr "Gràfics"
 
-#: src/muuli_wdr.cpp:1825 src/muuli_wdr.cpp:1887
+#: src/muuli_wdr.cpp:1829 src/muuli_wdr.cpp:1891
 msgid "Update delay : 5 secs"
 msgstr "Actualitza cada: 5 segs"
 
-#: src/muuli_wdr.cpp:1829
+#: src/muuli_wdr.cpp:1833
 msgid "Time for average graph: 100 mins"
 msgstr "Temps per al gràfic de mitjana: 100 mins"
 
-#: src/muuli_wdr.cpp:1833
+#: src/muuli_wdr.cpp:1837
 msgid "Connections Graph Scale: 100 "
 msgstr "Escala del Gràfic de Connexions: 100 "
 
-#: src/muuli_wdr.cpp:1840
+#: src/muuli_wdr.cpp:1844
 msgid "Download graph scale:"
 msgstr "Escala del gràfic de descàrrega:"
 
-#: src/muuli_wdr.cpp:1848
+#: src/muuli_wdr.cpp:1852
 msgid "Upload graph scale:"
 msgstr "Escala del gràfic de pujada:"
 
-#: src/muuli_wdr.cpp:1858
+#: src/muuli_wdr.cpp:1862
 #, fuzzy
 msgid "Colors: "
 msgstr "Colors: "
 
-#: src/muuli_wdr.cpp:1862
+#: src/muuli_wdr.cpp:1866
 msgid "Background"
 msgstr "Fons"
 
-#: src/muuli_wdr.cpp:1863
+#: src/muuli_wdr.cpp:1867
 msgid "Grid"
 msgstr "Graella"
 
-#: src/muuli_wdr.cpp:1864
+#: src/muuli_wdr.cpp:1868
 msgid "Download current"
 msgstr "Baixada actual"
 
-#: src/muuli_wdr.cpp:1865
+#: src/muuli_wdr.cpp:1869
 msgid "Download running average"
 msgstr "Mitjana de baixada total"
 
-#: src/muuli_wdr.cpp:1866
+#: src/muuli_wdr.cpp:1870
 msgid "Download session average"
 msgstr "Mitjana de baixada de la sessió"
 
-#: src/muuli_wdr.cpp:1867
+#: src/muuli_wdr.cpp:1871
 msgid "Upload current"
 msgstr "Pujada actual"
 
-#: src/muuli_wdr.cpp:1868
+#: src/muuli_wdr.cpp:1872
 msgid "Upload running average"
 msgstr "Mitjana de pujada total"
 
-#: src/muuli_wdr.cpp:1869
+#: src/muuli_wdr.cpp:1873
 msgid "Upload session average"
 msgstr "Mitjana de pujada de la sessió"
 
-#: src/muuli_wdr.cpp:1870
+#: src/muuli_wdr.cpp:1874
 msgid "Active connections"
 msgstr "Connexions actives"
 
-#: src/muuli_wdr.cpp:1873
+#: src/muuli_wdr.cpp:1877
 #, fuzzy
 msgid "Systray Icon Speed Bar"
 msgstr "Barra de velocitat de la icona d'estat"
 
-#: src/muuli_wdr.cpp:1874
+#: src/muuli_wdr.cpp:1878
 msgid "Kad-nodes current"
 msgstr "Nodes-Kad actuals"
 
-#: src/muuli_wdr.cpp:1875
+#: src/muuli_wdr.cpp:1879
 msgid "Kad-nodes running"
 msgstr "Nodes-Kad funcionant"
 
-#: src/muuli_wdr.cpp:1876
+#: src/muuli_wdr.cpp:1880
 msgid "Kad-nodes session"
 msgstr "Nodes-Kad de la sessió"
 
-#: src/muuli_wdr.cpp:1880 src/muuli_wdr.cpp:2334
+#: src/muuli_wdr.cpp:1884 src/muuli_wdr.cpp:2338
 msgid "Select"
 msgstr "Selecciona"
 
-#: src/muuli_wdr.cpp:1884
+#: src/muuli_wdr.cpp:1888
 msgid "Tree"
 msgstr "Arbre"
 
-#: src/muuli_wdr.cpp:1894
+#: src/muuli_wdr.cpp:1898
 msgid "Number of Client Versions shown (0=unlimited)"
 msgstr "Nombre de versions de client a mostrar (0=il·limitat)"
 
-#: src/muuli_wdr.cpp:1919
+#: src/muuli_wdr.cpp:1923
 msgid "!!! WARNING !!!"
 msgstr "!!! AVÍS !!!"
 
-#: src/muuli_wdr.cpp:1934
+#: src/muuli_wdr.cpp:1938
 msgid "Max new connections / 5 secs"
 msgstr "Connexions noves màx. / 5 segs"
 
-#: src/muuli_wdr.cpp:1936
+#: src/muuli_wdr.cpp:1940
 msgid "Concurrent Kad source lookups"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1938
+#: src/muuli_wdr.cpp:1942
 #, fuzzy
 msgid "Kad source re-search interval (minutes)"
 msgstr "Interval d'actualització de l'FTP en minuts"
 
-#: src/muuli_wdr.cpp:1940
+#: src/muuli_wdr.cpp:1944
 #, fuzzy
 msgid "Source re-ask interval (minutes)"
 msgstr "Interval d'actualització de l'FTP en minuts"
 
-#: src/muuli_wdr.cpp:1944
+#: src/muuli_wdr.cpp:1948
 msgid "File Buffer Size: 240000 bytes"
 msgstr "Mida del buffer de fitxer: 240000 bytes"
 
-#: src/muuli_wdr.cpp:1948
+#: src/muuli_wdr.cpp:1952
 msgid "Use MMAP: memory-mapped file access (lower memory use)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1949
+#: src/muuli_wdr.cpp:1953
 msgid "Maps part files into memory instead of buffering them on the heap, lowering the process memory footprint. May reduce download speed on some disks; best for memory-constrained or upload-heavy hosts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1951
+#: src/muuli_wdr.cpp:1955
 msgid "Upload Queue Size: 5000 clients"
 msgstr "Mida de la cua de pujades: 5000 clients"
 
-#: src/muuli_wdr.cpp:1955
+#: src/muuli_wdr.cpp:1959
 msgid "Server connection refresh interval: Disable"
 msgstr "Interval de refresc de la connexió amb el servidor: Inhabilitat"
 
-#: src/muuli_wdr.cpp:1959
+#: src/muuli_wdr.cpp:1963
 msgid "Disable computer's timed standby mode"
 msgstr "Inhabilita el mode d'espera programat de l'ordinador"
 
-#: src/muuli_wdr.cpp:1978
+#: src/muuli_wdr.cpp:1982
 msgid "Skin to use: "
 msgstr "Aparença a usar: "
 
-#: src/muuli_wdr.cpp:1987
+#: src/muuli_wdr.cpp:1991
 msgid "Show \"Fast eD2k Links Handler\" in every window."
 msgstr "Mostra \"Gestor ràpid de links eD2k\" en totes les finestres."
 
-#: src/muuli_wdr.cpp:1990
+#: src/muuli_wdr.cpp:1994
 msgid "Show extended info on categories tabs"
 msgstr "Mostra informació estesa a les pestanyes de les categories"
 
-#: src/muuli_wdr.cpp:1993
+#: src/muuli_wdr.cpp:1997
 msgid "Show application version on title"
 msgstr "Mostra la versió de l'aplicació al títol"
 
-#: src/muuli_wdr.cpp:1995
+#: src/muuli_wdr.cpp:1999
 msgid "Show transfer rates on title"
 msgstr "Mostra les velocitats de transferència al títol"
 
-#: src/muuli_wdr.cpp:1997
+#: src/muuli_wdr.cpp:2001
 msgid "Before application name"
 msgstr "Abans del nom de l'aplicació"
 
-#: src/muuli_wdr.cpp:1999
+#: src/muuli_wdr.cpp:2003
 msgid "After application name"
 msgstr "Després del nom de l'aplicació"
 
-#: src/muuli_wdr.cpp:2002
+#: src/muuli_wdr.cpp:2006
 msgid "Show overhead bandwidth"
 msgstr "Mostra ample de banda sobrecarregat"
 
-#: src/muuli_wdr.cpp:2006
+#: src/muuli_wdr.cpp:2010
 msgid "Vertical toolbar orientation"
 msgstr "Orientació vertical de la barra d'eines"
 
-#: src/muuli_wdr.cpp:2008
+#: src/muuli_wdr.cpp:2012
 msgid "Live column sorting (auto-reorder rows as their values change)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2015
+#: src/muuli_wdr.cpp:2019
 msgid "Download Queue Files"
 msgstr "Cua de descàrregues"
 
-#: src/muuli_wdr.cpp:2018
+#: src/muuli_wdr.cpp:2022
 msgid "Show progress percentage"
 msgstr "Mostra el percentatge de descàrrega"
 
-#: src/muuli_wdr.cpp:2024
+#: src/muuli_wdr.cpp:2028
 msgid "Show progress bar"
 msgstr "Mostra barra de descàrrega"
 
-#: src/muuli_wdr.cpp:2027
+#: src/muuli_wdr.cpp:2031
 msgid "Flat"
 msgstr "Plana"
 
-#: src/muuli_wdr.cpp:2031
+#: src/muuli_wdr.cpp:2035
 msgid "Round"
 msgstr "Arrodonida"
 
-#: src/muuli_wdr.cpp:2049
+#: src/muuli_wdr.cpp:2053
 msgid "External Connection Parameters"
 msgstr "Paràmetres de la connexió externa "
 
-#: src/muuli_wdr.cpp:2052
+#: src/muuli_wdr.cpp:2056
 msgid "Accept external connections"
 msgstr "Accepta connexions externes"
 
-#: src/muuli_wdr.cpp:2059 src/muuli_wdr.cpp:2118
+#: src/muuli_wdr.cpp:2063 src/muuli_wdr.cpp:2122
 msgid "IP of the listening interface:"
 msgstr "IP de la interfície que rep connexions:"
 
-#: src/muuli_wdr.cpp:2062
+#: src/muuli_wdr.cpp:2066
 msgid "Enter here a valid ip in the a.b.c.d format for the listening EC interface. An empty field or 0.0.0.0 will mean any interface."
 msgstr "Introduïu una IP vàlida amb format a.b.c.d per a la interfície EC que escolta. Un camp buit o 0.0.0.0 significarà qualsevol interfície."
 
-#: src/muuli_wdr.cpp:2083 src/muuli_wdr.cpp:2194
+#: src/muuli_wdr.cpp:2087 src/muuli_wdr.cpp:2198
 msgid "TCP port:"
 msgstr "Port TCP:"
 
-#: src/muuli_wdr.cpp:2089
+#: src/muuli_wdr.cpp:2093
 msgid "Enable UPnP port forwarding on the EC port"
 msgstr "Activa l'encaminament UPnP al port de connexions externes"
 
-#: src/muuli_wdr.cpp:2093 src/muuli_wdr.cpp:3079
+#: src/muuli_wdr.cpp:2097 src/muuli_wdr.cpp:3083
 #: src/utils/wxCas/src/wxcasprefs.cpp:167
 msgid "Password"
 msgstr "Contrasenya"
 
-#: src/muuli_wdr.cpp:2099
+#: src/muuli_wdr.cpp:2103
 #, fuzzy
 msgid "aMule API server parameters"
 msgstr "Paràmetres del servidor web "
 
-#: src/muuli_wdr.cpp:2102
+#: src/muuli_wdr.cpp:2106
 msgid "Run amuleapi (REST API) on startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2107
+#: src/muuli_wdr.cpp:2111
 #, fuzzy
 msgid "HTTP port:"
 msgstr "Port TCP:"
 
-#: src/muuli_wdr.cpp:2121
+#: src/muuli_wdr.cpp:2125
 msgid "The interface amuleapi's HTTP server listens on. 127.0.0.1 (default) accepts only local connections; use 0.0.0.0 or a specific IP to expose it to other hosts (set an admin password below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2126
+#: src/muuli_wdr.cpp:2130
 msgid "Type a password to set or change it. Stored passwords cannot be shown, so leaving this empty keeps the current one."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2128
+#: src/muuli_wdr.cpp:2132
 #, fuzzy
 msgid "Admin password"
 msgstr "S'està comprovant la contrasenya\n"
 
-#: src/muuli_wdr.cpp:2140 src/muuli_wdr.cpp:2157 src/PrefsUnifiedDlg.cpp:1103
+#: src/muuli_wdr.cpp:2144 src/muuli_wdr.cpp:2161 src/PrefsUnifiedDlg.cpp:1112
 #, fuzzy
 msgid "A password is set."
 msgstr "S'està comprovant la contrasenya\n"
 
-#: src/muuli_wdr.cpp:2144
+#: src/muuli_wdr.cpp:2148
 #, fuzzy
 msgid "Enable guest access"
 msgstr "Denega l'accés de convidats"
 
-#: src/muuli_wdr.cpp:2145
+#: src/muuli_wdr.cpp:2149
 msgid "Guest sessions may read status and listings but cannot change anything. Turning this off clears the stored guest password."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2149
+#: src/muuli_wdr.cpp:2153
 #, fuzzy
 msgid "Guest password"
 msgstr "Contrasenya de convidat per al servidor web"
 
-#: src/muuli_wdr.cpp:2164
+#: src/muuli_wdr.cpp:2168
 msgid "Web server parameters"
 msgstr "Paràmetres del servidor web "
 
-#: src/muuli_wdr.cpp:2167
+#: src/muuli_wdr.cpp:2171
 #, fuzzy
 msgid "Run webserver on startup (deprecated)"
 msgstr "Executa el servidor web a l'inici"
 
-#: src/muuli_wdr.cpp:2173
+#: src/muuli_wdr.cpp:2177
 msgid "Web template"
 msgstr "Plantilla web"
 
-#: src/muuli_wdr.cpp:2178
+#: src/muuli_wdr.cpp:2182
 msgid "Full rights password"
 msgstr "Contrasenya de l'administrador:"
 
-#: src/muuli_wdr.cpp:2182
+#: src/muuli_wdr.cpp:2186
 msgid "Enable Low rights User"
 msgstr "Habilita l'usuari convidat"
 
-#: src/muuli_wdr.cpp:2187
+#: src/muuli_wdr.cpp:2191
 msgid "Low rights password"
 msgstr "Contrasenya del convidat:"
 
-#: src/muuli_wdr.cpp:2201
+#: src/muuli_wdr.cpp:2205
 msgid "Enable UPnP port forwarding of the web server port"
 msgstr "Activa redirecció de ports UPnP en el port del servidor web"
 
-#: src/muuli_wdr.cpp:2206
+#: src/muuli_wdr.cpp:2210
 msgid "Web server UPnP TCP port (Optional)"
 msgstr "Port TCP del servidor web (Opcional):"
 
-#: src/muuli_wdr.cpp:2214
+#: src/muuli_wdr.cpp:2218
 msgid "Page Refresh Time (in secs)"
 msgstr "Temps de refresc de la pàgina (en segons):"
 
-#: src/muuli_wdr.cpp:2221
+#: src/muuli_wdr.cpp:2225
 msgid "Enable Gzip compression"
 msgstr "Habilita la compressió Gzip"
 
-#: src/muuli_wdr.cpp:2255
+#: src/muuli_wdr.cpp:2259
 #, fuzzy
 msgid "Reset page to defaults"
 msgstr "Predeterminat"
 
-#: src/muuli_wdr.cpp:2256
+#: src/muuli_wdr.cpp:2260
 msgid "Reset the settings on the current page to their default values."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2258 src/muuli_wdr.cpp:2344 src/ServerWnd.cpp:274
+#: src/muuli_wdr.cpp:2262 src/muuli_wdr.cpp:2348 src/ServerWnd.cpp:274
 #: src/ServerWnd.cpp:282
 msgid "OK"
 msgstr "OK"
 
-#: src/muuli_wdr.cpp:2260
+#: src/muuli_wdr.cpp:2264
 msgid "Click here to apply any changes made to the preferences."
 msgstr "Feu clic per a aplicar qualsevol canvi fet a les preferències."
 
-#: src/muuli_wdr.cpp:2263
+#: src/muuli_wdr.cpp:2267
 msgid "Reset any changes made to the preferences."
 msgstr "Reinicia qualsevol canvi fet a les preferències."
 
-#: src/muuli_wdr.cpp:2292
+#: src/muuli_wdr.cpp:2296
 msgid "Comment :"
 msgstr "Comentari:"
 
-#: src/muuli_wdr.cpp:2299
+#: src/muuli_wdr.cpp:2303
 msgid "Incoming Dir :"
 msgstr "Dir. d'entrada:"
 
-#: src/muuli_wdr.cpp:2308
+#: src/muuli_wdr.cpp:2312
 msgid "Change priority for new assigned files :"
 msgstr "Canvia la prioritat per als nous fitxers assignats:"
 
-#: src/muuli_wdr.cpp:2312
+#: src/muuli_wdr.cpp:2316
 msgid "Don't change"
 msgstr "No canviar"
 
-#: src/muuli_wdr.cpp:2324
+#: src/muuli_wdr.cpp:2328
 msgid "Select color for this Category (currently selected) :"
 msgstr "Seleccioneu un color per a la Categoria (actualment seleccionat):"
 
-#: src/muuli_wdr.cpp:2391 src/muuli_wdr.cpp:2410 src/muuli_wdr.cpp:2432
+#: src/muuli_wdr.cpp:2395 src/muuli_wdr.cpp:2414 src/muuli_wdr.cpp:2436
 msgid "Click this button to reset the log."
 msgstr "Feu clic per a reiniciar el registre."
 
-#: src/muuli_wdr.cpp:2451
+#: src/muuli_wdr.cpp:2455
 msgid "Click on this button to update the servers list from URL ..."
 msgstr "Feu clic en aquest botó per a actualitzar la llista de servidors des d'una URL ... "
 
-#: src/muuli_wdr.cpp:2455
+#: src/muuli_wdr.cpp:2459
 msgid "Server list"
 msgstr "Llista de servidors"
 
-#: src/muuli_wdr.cpp:2459
+#: src/muuli_wdr.cpp:2463
 msgid "Enter the url to a server.met file here and press the button to the left to update the list of known servers."
 msgstr "Introduïu l'adreça d'un fitxer server.met i premeu el botó de l'esquerra per a actualitzar la llista de servidors coneguts."
 
-#: src/muuli_wdr.cpp:2464
+#: src/muuli_wdr.cpp:2468
 msgid "Add server manually: Name"
 msgstr "Afegeix un servidor manualment: Nom"
 
-#: src/muuli_wdr.cpp:2467
+#: src/muuli_wdr.cpp:2471
 msgid "Enter the name of the new server here"
 msgstr "Introduïu el nom del nou servidor"
 
-#: src/muuli_wdr.cpp:2469 src/ServerWnd.cpp:206
+#: src/muuli_wdr.cpp:2473 src/ServerWnd.cpp:206
 msgid "IP:Port"
 msgstr "IP:Port"
 
-#: src/muuli_wdr.cpp:2472
+#: src/muuli_wdr.cpp:2476
 msgid "Enter the IP of the server here, using the x.x.x.x format."
 msgstr "Introduïu la IP del servidor, fent servir el format x.x.x.x."
 
-#: src/muuli_wdr.cpp:2478
+#: src/muuli_wdr.cpp:2482
 msgid "Enter the port of the server here."
 msgstr "Introduïu el port del servidor."
 
-#: src/muuli_wdr.cpp:2481
+#: src/muuli_wdr.cpp:2485
 msgid "Add manually a server (fill fields to the left before) ..."
 msgstr "Afegeix un servidor manualment (abans omple els camps de l'esquerra) ..."
 
-#: src/muuli_wdr.cpp:2510
+#: src/muuli_wdr.cpp:2514
 msgid "aMule Log"
 msgstr "Registre de l'aMule"
 
-#: src/muuli_wdr.cpp:2518
+#: src/muuli_wdr.cpp:2522
 msgid "Server Info"
 msgstr "Informació del servidor"
 
-#: src/muuli_wdr.cpp:2522
+#: src/muuli_wdr.cpp:2526
 msgid "ED2K Info"
 msgstr "Info. ED2K"
 
-#: src/muuli_wdr.cpp:2526
+#: src/muuli_wdr.cpp:2530
 msgid "Kad Info"
 msgstr "Info. Kad"
 
-#: src/muuli_wdr.cpp:2554
+#: src/muuli_wdr.cpp:2558
 msgid "Click on this button to update the nodes list from URL ..."
 msgstr "Feu clic en aquest botó per a actualitzar la llista de nodes des d'una URL ..."
 
-#: src/muuli_wdr.cpp:2558
+#: src/muuli_wdr.cpp:2562
 msgid "Nodes (0)"
 msgstr "Nodes (0)"
 
-#: src/muuli_wdr.cpp:2562
+#: src/muuli_wdr.cpp:2566
 msgid "Enter the url to a nodes.dat file here and press the button to the left to update the list of known nodes."
 msgstr "Introduïu la URL d'un fitxer nodes.dat i premeu el botó de l'esquerra per a actualitzar la llista de nodes coneguts."
 
-#: src/muuli_wdr.cpp:2565
+#: src/muuli_wdr.cpp:2569
 msgid "Nodes stats"
 msgstr "Estadístiques de nodes"
 
-#: src/muuli_wdr.cpp:2607
+#: src/muuli_wdr.cpp:2611
 msgid "Bootstrap"
 msgstr "Arrancada"
 
-#: src/muuli_wdr.cpp:2610
+#: src/muuli_wdr.cpp:2614
 msgid "New node"
 msgstr "Nou node"
 
-#: src/muuli_wdr.cpp:2615
+#: src/muuli_wdr.cpp:2619
 msgid "IP:"
 msgstr "IP:"
 
-#: src/muuli_wdr.cpp:2635
+#: src/muuli_wdr.cpp:2639
 msgid "Port:"
 msgstr "Port:"
 
-#: src/muuli_wdr.cpp:2648
+#: src/muuli_wdr.cpp:2652
 msgid "Bootstrap from known clients"
 msgstr "Inicia des dels clients coneguts"
 
-#: src/muuli_wdr.cpp:2650
+#: src/muuli_wdr.cpp:2654
 msgid "Disconnect Kad"
 msgstr "Desconnecta Kad"
 
-#: src/muuli_wdr.cpp:2684
+#: src/muuli_wdr.cpp:2688
 msgid "Use Secure User Identification"
 msgstr "Usa la Identificació Segura d'Usuari"
 
-#: src/muuli_wdr.cpp:2686
+#: src/muuli_wdr.cpp:2690
 msgid "It is recommended to enable this option. You will not receive credits if SUI is not enabled."
 msgstr "Es recomana activar aquesta opció. No rebreu crèdits (punts) si la Identificació Segura d'Usuari no és habilitada."
 
-#: src/muuli_wdr.cpp:2688
+#: src/muuli_wdr.cpp:2692
 msgid "Protocol Obfuscation"
 msgstr "Ofuscació de protocol"
 
-#: src/muuli_wdr.cpp:2691
+#: src/muuli_wdr.cpp:2695
 msgid "Support Protocol Obfuscation"
 msgstr "Suport per a l'ofuscació de protocol"
 
-#: src/muuli_wdr.cpp:2693
+#: src/muuli_wdr.cpp:2697
 msgid "This option enabled Protocol Obfuscation, and makes aMule accept obfuscated connections from other clients."
 msgstr "Habilita l'ofuscació de protocol, i permet a l'aMule acceptar connexions ofuscades d'altres clients."
 
-#: src/muuli_wdr.cpp:2695
+#: src/muuli_wdr.cpp:2699
 msgid "Use obfuscation for outgoing connections"
 msgstr "Usa l'ofuscació per a les connexions sortints"
 
-#: src/muuli_wdr.cpp:2697
+#: src/muuli_wdr.cpp:2701
 msgid "This option makes aMule use Protocol Obfuscation when connecting other clients/servers."
 msgstr "L'aMule usarà l'ofuscació de protocol en connectar amb altres clients/servidors."
 
-#: src/muuli_wdr.cpp:2699
+#: src/muuli_wdr.cpp:2703
 msgid "Accept only obfuscated connections"
 msgstr "Accepta únicament les connexions ofuscades"
 
-#: src/muuli_wdr.cpp:2700
+#: src/muuli_wdr.cpp:2704
 msgid "This option makes aMule only accept obfuscated connections. You will have less sources, but all your traffic will be obfuscated"
 msgstr "L'aMule només acceptarà les connexions ofuscades. Tindreu menys fonts, però tot el tràfic serà ofuscat"
 
-#: src/muuli_wdr.cpp:2705
+#: src/muuli_wdr.cpp:2709
 msgid "Everybody"
 msgstr "Tothom"
 
-#: src/muuli_wdr.cpp:2707
+#: src/muuli_wdr.cpp:2711
 msgid "No one"
 msgstr "Ningú"
 
-#: src/muuli_wdr.cpp:2709
+#: src/muuli_wdr.cpp:2713
 msgid "Who can see my shared files:"
 msgstr "Qui pot veure els meus fitxers compartits:"
 
-#: src/muuli_wdr.cpp:2710
+#: src/muuli_wdr.cpp:2714
 msgid "Select who can request to view a list of your shared files."
 msgstr "Selecciona qui pot veure la llista de fitxers compartits."
 
-#: src/muuli_wdr.cpp:2712
+#: src/muuli_wdr.cpp:2716
 msgid "IP-Filtering"
 msgstr "Filtratge IP"
 
-#: src/muuli_wdr.cpp:2719
+#: src/muuli_wdr.cpp:2723
 msgid "Filter clients"
 msgstr "Filtra els clients"
 
-#: src/muuli_wdr.cpp:2721
+#: src/muuli_wdr.cpp:2725
 msgid "Enable filtering of the client IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "Habilita el filtratge de les IP de clients especificades al fitxer ~/.aMule/ipfilter.dat."
 
-#: src/muuli_wdr.cpp:2723
+#: src/muuli_wdr.cpp:2727
 msgid "Filter servers"
 msgstr "Filtra els servidors"
 
-#: src/muuli_wdr.cpp:2725
+#: src/muuli_wdr.cpp:2729
 msgid "Enable filtering of the server IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "Habilita el filtratge de les IP de servidors especificades al fitxer ~/.aMule/ipfilter.dat."
 
-#: src/muuli_wdr.cpp:2729
+#: src/muuli_wdr.cpp:2733
 msgid "Reload List"
 msgstr "Recarrega la llista"
 
-#: src/muuli_wdr.cpp:2730
+#: src/muuli_wdr.cpp:2734
 msgid "Reload the list of IPs to filter from the file ~/.aMule/ipfilter.dat"
 msgstr "Recarrega la llista d'IPs a filtrar des del fitxer ~/.aMule/ipfilter.dat"
 
-#: src/muuli_wdr.cpp:2736
+#: src/muuli_wdr.cpp:2740
 msgid "URL:"
 msgstr "Adreça:"
 
-#: src/muuli_wdr.cpp:2740 src/muuli_wdr.cpp:2933
+#: src/muuli_wdr.cpp:2744 src/muuli_wdr.cpp:2937
 msgid "Update now"
 msgstr "Actualitza ara"
 
-#: src/muuli_wdr.cpp:2743
+#: src/muuli_wdr.cpp:2747
 msgid "Auto-update ipfilter at startup"
 msgstr "Actualitza automàticament a l'inici"
 
-#: src/muuli_wdr.cpp:2747
+#: src/muuli_wdr.cpp:2751
 msgid "Filtering Level:"
 msgstr "Nivell de filtratge:"
 
-#: src/muuli_wdr.cpp:2753
+#: src/muuli_wdr.cpp:2757
 msgid "Always filter LAN IPs"
 msgstr "Filtra sempre les IP LAN"
 
-#: src/muuli_wdr.cpp:2756
+#: src/muuli_wdr.cpp:2760
 msgid "Paranoid handling of non-matching IPs"
 msgstr "Gestió paranoica de les IP no corresponents"
 
-#: src/muuli_wdr.cpp:2758
+#: src/muuli_wdr.cpp:2762
 msgid "Rejects a packet when its source IP differs from the IP the client claims (an anti-spoofing check). Disable only if it causes connection problems."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2760
+#: src/muuli_wdr.cpp:2764
 msgid "Use system-wide ipfilter.dat if available"
 msgstr "Usa l'ipfilter.dat del sistema si està disponible"
 
-#: src/muuli_wdr.cpp:2761
+#: src/muuli_wdr.cpp:2765
 #, fuzzy
 msgid "If there's no local ipfilter.dat found, allow usage of a system-wide ipfilter file."
 msgstr "Si no es troba l'ipfilter.dat local, permet l'ús del fitxer ipfilter del sistema."
 
-#: src/muuli_wdr.cpp:2778
+#: src/muuli_wdr.cpp:2782
 msgid "Enable Online-Signature"
 msgstr "Habilita la signatura en línia"
 
-#: src/muuli_wdr.cpp:2780
+#: src/muuli_wdr.cpp:2784
 msgid "Enables the writing of the OS file, which can be used by external apps to create signatures and the like."
 msgstr "Habilita l'escriptura del fitxer de signatura, que altres aplicacions externes poden usar per a crear signatures i similars."
 
-#: src/muuli_wdr.cpp:2784
+#: src/muuli_wdr.cpp:2788
 msgid "Update Frequency (Secs):"
 msgstr "Freqüència d'actualització (segs):"
 
-#: src/muuli_wdr.cpp:2787
+#: src/muuli_wdr.cpp:2791
 msgid "Change the frequency (in seconds) of Online Signature updates."
 msgstr "Canvia la freqüència d'actualització (en segons) de la signatura en línia."
 
-#: src/muuli_wdr.cpp:2795
+#: src/muuli_wdr.cpp:2799
 msgid "Save online signature file in: "
 msgstr "Desa el fitxer de signatura en línia a: "
 
-#: src/muuli_wdr.cpp:2801
+#: src/muuli_wdr.cpp:2805
 msgid "Click here to select the directory containing the the Online Signature files."
 msgstr "Feu clic per a seleccionar el directori que conté els fitxers de signatura en línia."
 
-#: src/muuli_wdr.cpp:2834
+#: src/muuli_wdr.cpp:2838
 msgid "Show country flags for clients"
 msgstr "Mostra les banderes dels països per als clients"
 
-#: src/muuli_wdr.cpp:2835
+#: src/muuli_wdr.cpp:2839
 msgid "Render the country flag column in the transfers, queue and search views. Requires a valid MMDB GeoIP database (see below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2840
+#: src/muuli_wdr.cpp:2844
 #, fuzzy
 msgid "Database"
 msgstr "Velocitat:"
 
-#: src/muuli_wdr.cpp:2856
+#: src/muuli_wdr.cpp:2860
 #, fuzzy
 msgid "Source:"
 msgstr "Fonts"
 
-#: src/muuli_wdr.cpp:2859
+#: src/muuli_wdr.cpp:2863
 msgid "DB-IP (free, no account)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2860
+#: src/muuli_wdr.cpp:2864
 msgid "MaxMind GeoLite2 (free, account required)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2861
+#: src/muuli_wdr.cpp:2865
 msgid "Custom URL"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2864
+#: src/muuli_wdr.cpp:2868
 msgid "Choose which provider supplies the GeoIP MMDB database. DB-IP is the default - no account required. MaxMind requires a free account + license key. Use Custom URL to point at any other MMDB host (e.g. a local mirror)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2881
+#: src/muuli_wdr.cpp:2885
 msgid ""
 "No configuration required.\n"
 "\n"
@@ -4880,11 +4880,11 @@ msgid ""
 "License: Creative Commons BY 4.0 - https://creativecommons.org/licenses/by/4.0/"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2894
+#: src/muuli_wdr.cpp:2898
 msgid "License key:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2900
+#: src/muuli_wdr.cpp:2904
 msgid ""
 "Sign up for a free MaxMind account, then generate a License Key:\n"
 "https://www.maxmind.com/en/geolite2/signup\n"
@@ -4894,225 +4894,225 @@ msgid ""
 "Requires attribution and account registration; refresh at least every 30 days."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2915
+#: src/muuli_wdr.cpp:2919
 #, fuzzy
 msgid "Download URL:"
 msgstr "Baixant: "
 
-#: src/muuli_wdr.cpp:2921
+#: src/muuli_wdr.cpp:2925
 msgid ""
 "Must point to an .mmdb file or a .gz / .tar.gz containing one.\n"
 "URL may include credentials (https://user:pass@host/...).\n"
 "License and attribution terms are set by the upstream URL - you are responsible."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2934
+#: src/muuli_wdr.cpp:2938
 msgid "Download the GeoIP database from the selected source."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2936
+#: src/muuli_wdr.cpp:2940
 #, fuzzy
 msgid "Auto-update on startup"
 msgstr "Actualitza automàticament a l'inici"
 
-#: src/muuli_wdr.cpp:2937
+#: src/muuli_wdr.cpp:2941
 msgid "Re-download the GeoIP database from the selected source every time aMule starts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2960
+#: src/muuli_wdr.cpp:2964
 msgid "Filter incoming messages (except current chat):"
 msgstr "Filtra els missatges entrants (excepte el xat actual):"
 
-#: src/muuli_wdr.cpp:2962
+#: src/muuli_wdr.cpp:2966
 msgid "Filter all messages"
 msgstr "Filtra tots els missatges"
 
-#: src/muuli_wdr.cpp:2964
+#: src/muuli_wdr.cpp:2968
 msgid "Filter messages from people not on your friend list"
 msgstr "Filtra els missatges de la gent que no és a la llista d'amics"
 
-#: src/muuli_wdr.cpp:2966
+#: src/muuli_wdr.cpp:2970
 msgid "Filter messages from unknown clients"
 msgstr "Filtra els missatges dels clients desconeguts"
 
-#: src/muuli_wdr.cpp:2968
+#: src/muuli_wdr.cpp:2972
 msgid "Filter messages containing (use ',' as separator):"
 msgstr "Filtra els missatges que continguin (useu ',' per a separar):"
 
-#: src/muuli_wdr.cpp:2971 src/muuli_wdr.cpp:2982
+#: src/muuli_wdr.cpp:2975 src/muuli_wdr.cpp:2986
 msgid "add here the words amule should filter and block messages including it"
 msgstr "Els missatges que continguin aquestes paraules seran filtrats i bloquejats per l'aMule"
 
-#: src/muuli_wdr.cpp:2973
+#: src/muuli_wdr.cpp:2977
 msgid "Show received messages in the log"
 msgstr "Mostra els missatges rebuts en el registre"
 
-#: src/muuli_wdr.cpp:2976
+#: src/muuli_wdr.cpp:2980
 msgid "Comments"
 msgstr "Comentaris"
 
-#: src/muuli_wdr.cpp:2979
+#: src/muuli_wdr.cpp:2983
 msgid "Filter comments containing (use ',' as separator):"
 msgstr "Filtra els comentaris que continguin (useu ',' per a separar):"
 
-#: src/muuli_wdr.cpp:3004
+#: src/muuli_wdr.cpp:3008
 msgid "Enable Proxy"
 msgstr "Habilita el servidor intermediari"
 
-#: src/muuli_wdr.cpp:3005
+#: src/muuli_wdr.cpp:3009
 msgid "Enable/disable proxy support"
 msgstr "Habilita/inhabilita el suport per a servidor intermediari"
 
-#: src/muuli_wdr.cpp:3008
+#: src/muuli_wdr.cpp:3012
 msgid "Proxy type:"
 msgstr "Tipus de servidor:"
 
-#: src/muuli_wdr.cpp:3019
+#: src/muuli_wdr.cpp:3023
 msgid "Proxy host:"
 msgstr "Servidor intermediari:"
 
-#: src/muuli_wdr.cpp:3022
+#: src/muuli_wdr.cpp:3026
 msgid "The proxy host name"
 msgstr "El nom del servidor intermediari"
 
-#: src/muuli_wdr.cpp:3024
+#: src/muuli_wdr.cpp:3028
 msgid "Proxy port:"
 msgstr "Port del servidor:"
 
-#: src/muuli_wdr.cpp:3027
+#: src/muuli_wdr.cpp:3031
 msgid "The proxy port"
 msgstr "El port del servidor intermediari"
 
-#: src/muuli_wdr.cpp:3029
+#: src/muuli_wdr.cpp:3033
 msgid "Enable authentication"
 msgstr "Habilita l'autenticació"
 
-#: src/muuli_wdr.cpp:3030
+#: src/muuli_wdr.cpp:3034
 msgid "Enable/disable username/password authentication"
 msgstr "Habilita/inhabilita l'autenticació amb usuari/contrasenya"
 
-#: src/muuli_wdr.cpp:3033
+#: src/muuli_wdr.cpp:3037
 msgid "Username: "
 msgstr "Nom d'usuari:"
 
-#: src/muuli_wdr.cpp:3036
+#: src/muuli_wdr.cpp:3040
 msgid "The username to use to connect to the proxy"
 msgstr "El nom d'usuari per a connectar al servidor intermediari"
 
-#: src/muuli_wdr.cpp:3038
+#: src/muuli_wdr.cpp:3042
 msgid "Password:"
 msgstr "Contrasenya:"
 
-#: src/muuli_wdr.cpp:3041
+#: src/muuli_wdr.cpp:3045
 msgid "The password to use to connect to the proxy"
 msgstr "La contrasenya per a connectar al servidor intermediari"
 
-#: src/muuli_wdr.cpp:3060
+#: src/muuli_wdr.cpp:3064
 msgid "Connect to:"
 msgstr "Connecta a:"
 
-#: src/muuli_wdr.cpp:3069
+#: src/muuli_wdr.cpp:3073
 msgid "Login to remote amule"
 msgstr "Entra a l'aMule remot"
 
-#: src/muuli_wdr.cpp:3074
+#: src/muuli_wdr.cpp:3078
 msgid "User name"
 msgstr "Nom d'usuari"
 
-#: src/muuli_wdr.cpp:3085
+#: src/muuli_wdr.cpp:3089
 msgid "Remember those settings"
 msgstr "Recorda la configuració"
 
-#: src/muuli_wdr.cpp:3088
+#: src/muuli_wdr.cpp:3092
 #, fuzzy
 msgid "Force ZLIB compression"
 msgstr "Usa la compressió gzip"
 
-#: src/muuli_wdr.cpp:3112
+#: src/muuli_wdr.cpp:3116
 msgid "Enable Verbose Debug-Logging."
 msgstr "Habilita la depuració-registre detallats."
 
-#: src/muuli_wdr.cpp:3114
+#: src/muuli_wdr.cpp:3118
 msgid "Only to Logfile"
 msgstr "Només al fitxer de registre"
 
-#: src/muuli_wdr.cpp:3116
+#: src/muuli_wdr.cpp:3120
 msgid "Message Categories:"
 msgstr "Categories de missatge:"
 
-#: src/muuli_wdr.cpp:3140 src/PartFileConvertDlg.cpp:160
+#: src/muuli_wdr.cpp:3144 src/PartFileConvertDlg.cpp:160
 msgid "Waiting..."
 msgstr "Esperant..."
 
-#: src/muuli_wdr.cpp:3160
+#: src/muuli_wdr.cpp:3164
 msgid "Add imports"
 msgstr "Afegeix"
 
-#: src/muuli_wdr.cpp:3163
+#: src/muuli_wdr.cpp:3167
 msgid "Retry selected"
 msgstr "Reintenta"
 
-#: src/muuli_wdr.cpp:3165
+#: src/muuli_wdr.cpp:3169
 msgid "Remove selected"
 msgstr "Esborra"
 
-#: src/muuli_wdr.cpp:3228
+#: src/muuli_wdr.cpp:3232
 msgid "Event Types"
 msgstr "Tipus d'esdeveniments"
 
-#: src/muuli_wdr.cpp:3247
+#: src/muuli_wdr.cpp:3251
 msgid "Statistics and queued clients for selected file(s) : Session / All time"
 msgstr "Estadístiques i clients en cua per als fitxers seleccionats: Sessió / Total"
 
-#: src/muuli_wdr.cpp:3271
+#: src/muuli_wdr.cpp:3275
 msgid "Active Uploads"
 msgstr "Pujades actives"
 
-#: src/muuli_wdr.cpp:3285
+#: src/muuli_wdr.cpp:3289
 msgid "Percent of total files"
 msgstr "Percentatge del total de fitxers"
 
-#: src/muuli_wdr.cpp:3337
+#: src/muuli_wdr.cpp:3341
 msgid "Show Clients for"
 msgstr "Mostra els clients per"
 
-#: src/muuli_wdr.cpp:3339
+#: src/muuli_wdr.cpp:3343
 msgid "All files"
 msgstr "Tots els fitxers"
 
-#: src/muuli_wdr.cpp:3342
+#: src/muuli_wdr.cpp:3346
 msgid "Selected files"
 msgstr "Fitxers seleccionats"
 
-#: src/muuli_wdr.cpp:3345
+#: src/muuli_wdr.cpp:3349
 msgid "Active uploads only"
 msgstr "Només pujades actives"
 
-#: src/muuli_wdr.cpp:3352
+#: src/muuli_wdr.cpp:3356
 msgid "Reload:"
 msgstr "Recarrega:"
 
-#: src/muuli_wdr.cpp:3356
+#: src/muuli_wdr.cpp:3360
 msgid "Reload your shared files"
 msgstr "Recarrega els compartits"
 
-#: src/muuli_wdr.cpp:3419
+#: src/muuli_wdr.cpp:3423
 msgid "Send"
 msgstr "Envia"
 
-#: src/muuli_wdr.cpp:3420
+#: src/muuli_wdr.cpp:3424
 msgid "Sends the specified message."
 msgstr "Envia el missatge especificat."
 
-#: src/muuli_wdr.cpp:3424
+#: src/muuli_wdr.cpp:3428
 msgid "Close this chat-session."
 msgstr "Tanca aquesta sessió de xat."
 
-#: src/muuli_wdr.cpp:3447
+#: src/muuli_wdr.cpp:3451
 msgid "Connect to any server and/or Kad"
 msgstr "Connecta amb qualsevol servidor i/o Kad"
 
-#: src/muuli_wdr.cpp:3453 src/SharedFilesCtrl.cpp:142 src/Statistics.cpp:941
+#: src/muuli_wdr.cpp:3457 src/SharedFilesCtrl.cpp:142 src/Statistics.cpp:941
 msgid "Shared Files"
 msgstr "Compartits"
 
@@ -5749,35 +5749,35 @@ msgstr ""
 "L'aMule anirà bé sense canviar cap\n"
 "d'aquests paràmetres."
 
-#: src/PrefsUnifiedDlg.cpp:647
+#: src/PrefsUnifiedDlg.cpp:656
 #, c-format
 msgid "Failed to connect Cfg to widget with the ID %d and key %s"
 msgstr "Connexió fallida entre Cfg i el giny amb ID %d i clau %s"
 
-#: src/PrefsUnifiedDlg.cpp:695
+#: src/PrefsUnifiedDlg.cpp:704
 #, c-format
 msgid "Failed to transfer data from Cfg to Widget with the ID %d and key %s"
 msgstr "Fallida en l'enviament de dades de Cfg al giny amb ID %d i clau %s"
 
-#: src/PrefsUnifiedDlg.cpp:801
+#: src/PrefsUnifiedDlg.cpp:810
 msgid "The type of proxy you are connecting to"
 msgstr "El tipus de servidor intermediari al que connecteu"
 
-#: src/PrefsUnifiedDlg.cpp:1020
+#: src/PrefsUnifiedDlg.cpp:1029
 #, c-format
 msgid "Failed to transfer data from Widget to Cfg with the ID %d and key %s"
 msgstr "Fallida en l'enviament de dades del giny al Cfg amb ID %d i clau %s"
 
-#: src/PrefsUnifiedDlg.cpp:1103
+#: src/PrefsUnifiedDlg.cpp:1112
 #, fuzzy
 msgid "No password set."
 msgstr "S'està comprovant la contrasenya\n"
 
-#: src/PrefsUnifiedDlg.cpp:1132
+#: src/PrefsUnifiedDlg.cpp:1141
 msgid "Guest access needs a password. Type one in the guest password field, or untick Enable guest access."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1144
+#: src/PrefsUnifiedDlg.cpp:1153
 msgid ""
 "aMule must be restarted to enable these changes:\n"
 "\n"
@@ -5785,41 +5785,41 @@ msgstr ""
 "S'ha de reiniciar l'aMule per a habilitar aquests canvis:\n"
 "\n"
 
-#: src/PrefsUnifiedDlg.cpp:1151
+#: src/PrefsUnifiedDlg.cpp:1160
 msgid "- TCP port changed.\n"
 msgstr "- El port TCP ha canviat.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1156
+#: src/PrefsUnifiedDlg.cpp:1165
 msgid "- UDP port changed.\n"
 msgstr "- El port UDP ha canviat.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1161
+#: src/PrefsUnifiedDlg.cpp:1170
 #, fuzzy
 msgid "- Network interface binding changed.\n"
 msgstr "- S'ha canviat la interfície de connexió externa.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1166
+#: src/PrefsUnifiedDlg.cpp:1175
 msgid "- External connect port changed.\n"
 msgstr "- S'ha canviat el port de connexió externa.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1170
+#: src/PrefsUnifiedDlg.cpp:1179
 msgid "- External connect acceptance changed.\n"
 msgstr "- S'ha canviat l'acceptació de la connexió externa.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1174
+#: src/PrefsUnifiedDlg.cpp:1183
 msgid "- External connect interface changed.\n"
 msgstr "- S'ha canviat la interfície de connexió externa.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1178
+#: src/PrefsUnifiedDlg.cpp:1187
 msgid "- Protocol obfuscation support changed.\n"
 msgstr "- S'ha canviat el suport d'ofuscació de protocol.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1193
+#: src/PrefsUnifiedDlg.cpp:1202
 #, fuzzy
 msgid "- amuleapi settings changed.\n"
 msgstr "- L'idioma ha canviat.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1202
+#: src/PrefsUnifiedDlg.cpp:1211
 msgid ""
 "Your Auto-update server list is empty.\n"
 "'Auto-update server list at startup' will be disabled."
@@ -5827,7 +5827,7 @@ msgstr ""
 "La llista d'actualització de servidors és buida.\n"
 "L'actualització de servidors a l'inici serà desactivada."
 
-#: src/PrefsUnifiedDlg.cpp:1213
+#: src/PrefsUnifiedDlg.cpp:1222
 msgid ""
 "You have enabled external connections but have not specified a password.\n"
 "External connections cannot be enabled unless a valid password is specified."
@@ -5835,33 +5835,33 @@ msgstr ""
 "Heu habilitat les connexions externes però no heu especificat una contrasenya.\n"
 "Les connexions externes no poden ser habilitades a menys que s'hagi especificat una contrasenya externa vàlida."
 
-#: src/PrefsUnifiedDlg.cpp:1246
+#: src/PrefsUnifiedDlg.cpp:1255
 #, c-format
 msgid "The amuleapi password could not be saved: %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1276
+#: src/PrefsUnifiedDlg.cpp:1285
 msgid "- Language changed.\n"
 msgstr "- L'idioma ha canviat.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1281
+#: src/PrefsUnifiedDlg.cpp:1290
 msgid "- Temp folder changed.\n"
 msgstr "- El directori temporal ha canviat.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1286
+#: src/PrefsUnifiedDlg.cpp:1295
 msgid "- ED2K network enabled.\n"
 msgstr "- Xarxa ED2K habilitada.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1319
+#: src/PrefsUnifiedDlg.cpp:1328
 msgid "The shared-file exclusion pattern is not a valid regular expression. The filter has been left disabled."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1321 src/PrefsUnifiedDlg.cpp:1921
+#: src/PrefsUnifiedDlg.cpp:1330 src/PrefsUnifiedDlg.cpp:1930
 #, fuzzy
 msgid "Invalid regular expression"
 msgstr "Versió del protocol invàlida."
 
-#: src/PrefsUnifiedDlg.cpp:1398
+#: src/PrefsUnifiedDlg.cpp:1407
 msgid ""
 "Both eD2k and Kad network are disabled.\n"
 "You won't be able to connect until you enable at least one of them."
@@ -5869,7 +5869,7 @@ msgstr ""
 "Les xarxes eD2k i Kad estan inhabilitades.\n"
 "No podreu connectar fins que n'habiliteu almenys una."
 
-#: src/PrefsUnifiedDlg.cpp:1403
+#: src/PrefsUnifiedDlg.cpp:1412
 msgid ""
 "Kad will not start if your UDP port is disabled.\n"
 "Enable UDP port or disable Kad."
@@ -5877,7 +5877,7 @@ msgstr ""
 "La xarxa Kad no s'engegarà si el port UDP està inhabilitat.\n"
 "Habiliteu el port UDP o inhabiliteu la xarxa Kad."
 
-#: src/PrefsUnifiedDlg.cpp:1459
+#: src/PrefsUnifiedDlg.cpp:1468
 msgid ""
 "\n"
 "You MUST restart aMule now.\n"
@@ -5887,69 +5887,69 @@ msgstr ""
 "HEU de reiniciar l'aMule ara mateix.\n"
 "Si no reinicieu ara, no vos queixeu dels possibles problemes.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1524
+#: src/PrefsUnifiedDlg.cpp:1533
 msgid "Could not register aMule for autostart at login. The autostart store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1526
+#: src/PrefsUnifiedDlg.cpp:1535
 msgid "Could not remove the autostart-at-login entry."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1527
+#: src/PrefsUnifiedDlg.cpp:1536
 #, fuzzy
 msgid "Autostart"
 msgstr "Autorefresc iniciat"
 
-#: src/PrefsUnifiedDlg.cpp:1542
+#: src/PrefsUnifiedDlg.cpp:1551
 msgid "Register file type"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1542
+#: src/PrefsUnifiedDlg.cpp:1551
 msgid "Register URL handler"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1550
+#: src/PrefsUnifiedDlg.cpp:1559
 #, c-format
 msgid "aMule only handles eD2k-compatible magnets. If you replace the current magnet handler (%s), BitTorrent magnet links will stop working - aMule cannot download BitTorrent content. Continue?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1555
+#: src/PrefsUnifiedDlg.cpp:1564
 #, c-format
 msgid "Another application currently opens .emulecollection files (%s). Replace it with aMule?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1560
+#: src/PrefsUnifiedDlg.cpp:1569
 #, c-format
 msgid "Another application is currently the default handler for these links (%s). Replace it with aMule?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1585
+#: src/PrefsUnifiedDlg.cpp:1594
 msgid "Could not register aMule for .emulecollection files. The registration store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1587
+#: src/PrefsUnifiedDlg.cpp:1596
 #, fuzzy
 msgid "Could not remove the file type registration."
 msgstr "Carpeta on desar les descàrregues temporals"
 
-#: src/PrefsUnifiedDlg.cpp:1589
+#: src/PrefsUnifiedDlg.cpp:1598
 msgid "Could not register aMule as the URL handler. The registration store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1591
+#: src/PrefsUnifiedDlg.cpp:1600
 msgid "Could not remove the URL handler registration."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1661 src/PrefsUnifiedDlg.cpp:1688
+#: src/PrefsUnifiedDlg.cpp:1670 src/PrefsUnifiedDlg.cpp:1697
 #, fuzzy
 msgid "The web server and aMule API require external connections to be enabled."
 msgstr "Contrassenya definida i connexions externes activades."
 
-#: src/PrefsUnifiedDlg.cpp:1671
+#: src/PrefsUnifiedDlg.cpp:1680
 msgid "The aMule web server is deprecated. Consider running the aMule API instead."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1735
+#: src/PrefsUnifiedDlg.cpp:1744
 msgid ""
 "Your Auto-update servers list is in blank.\n"
 "Please fill in at least one URL to point to a valid server.met file.\n"
@@ -5959,66 +5959,66 @@ msgstr ""
 "Si us plau, ompliu-la amb una URL que apunti a un fitxer server.met vàlid.\n"
 "Feu clic sobre el botó \"Llista\" d'aquest quadre de verificació per afegir una adreça."
 
-#: src/PrefsUnifiedDlg.cpp:1876
+#: src/PrefsUnifiedDlg.cpp:1885
 msgid "Temporary files"
 msgstr "Fitxers temporals"
 
-#: src/PrefsUnifiedDlg.cpp:1881
+#: src/PrefsUnifiedDlg.cpp:1890
 msgid "Incoming files"
 msgstr "Fitxers entrants"
 
-#: src/PrefsUnifiedDlg.cpp:1886
+#: src/PrefsUnifiedDlg.cpp:1895
 msgid "Online Signatures"
 msgstr "Signatures en línia"
 
-#: src/PrefsUnifiedDlg.cpp:1899
+#: src/PrefsUnifiedDlg.cpp:1908
 #, c-format
 msgid "Choose a folder for %s"
 msgstr "Carpeta per a %s"
 
-#: src/PrefsUnifiedDlg.cpp:1923
+#: src/PrefsUnifiedDlg.cpp:1932
 #, fuzzy, c-format
 msgid "Would exclude %u of %u shared file"
 msgid_plural "Would exclude %u of %u shared files"
 msgstr[0] "S'ha trobat %i fitxer compartit"
 msgstr[1] "S'han trobat %i fitxers compartits"
 
-#: src/PrefsUnifiedDlg.cpp:1940
+#: src/PrefsUnifiedDlg.cpp:1949
 msgid "Browse for videoplayer"
 msgstr "Explora per a trobar un reproductor de vídeo"
 
-#: src/PrefsUnifiedDlg.cpp:1944
+#: src/PrefsUnifiedDlg.cpp:1953
 msgid "Select browser"
 msgstr "Selecciona navegador"
 
-#: src/PrefsUnifiedDlg.cpp:1948
+#: src/PrefsUnifiedDlg.cpp:1957
 #, fuzzy
 msgid "Select ffprobe binary"
 msgstr "Selecciona navegador"
 
-#: src/PrefsUnifiedDlg.cpp:1954
+#: src/PrefsUnifiedDlg.cpp:1963
 #, c-format
 msgid "Executable%s"
 msgstr "Executable%s"
 
-#: src/PrefsUnifiedDlg.cpp:1988
+#: src/PrefsUnifiedDlg.cpp:1997
 msgid "ffprobe not found on PATH or in the standard install locations. Install ffmpeg (which ships ffprobe) or use Browse to pick a binary manually."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2000
+#: src/PrefsUnifiedDlg.cpp:2009
 msgid "Reset the settings on this page to their default values?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2001
+#: src/PrefsUnifiedDlg.cpp:2010
 #, fuzzy
 msgid "Reset to defaults"
 msgstr "Predeterminat"
 
-#: src/PrefsUnifiedDlg.cpp:2028
+#: src/PrefsUnifiedDlg.cpp:2037
 msgid "Edit server list"
 msgstr "Edita la llista de servidors"
 
-#: src/PrefsUnifiedDlg.cpp:2029
+#: src/PrefsUnifiedDlg.cpp:2038
 msgid ""
 "Add here URL's to download server.met files.\n"
 "Only one url on each line."
@@ -6026,154 +6026,154 @@ msgstr ""
 "Afegiu adreces URL d'on baixar el fitxer server.met.\n"
 "Només una adreça a cada línia."
 
-#: src/PrefsUnifiedDlg.cpp:2084
+#: src/PrefsUnifiedDlg.cpp:2093
 msgid "IP2Country update failed"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2229 src/PrefsUnifiedDlg.cpp:2260
+#: src/PrefsUnifiedDlg.cpp:2238 src/PrefsUnifiedDlg.cpp:2269
 msgid "Data by MaxMind GeoLite2"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2231 src/PrefsUnifiedDlg.cpp:2262
+#: src/PrefsUnifiedDlg.cpp:2240 src/PrefsUnifiedDlg.cpp:2271
 #, fuzzy
 msgid "Custom source"
 msgstr "Fonts completes"
 
-#: src/PrefsUnifiedDlg.cpp:2233 src/PrefsUnifiedDlg.cpp:2264
+#: src/PrefsUnifiedDlg.cpp:2242 src/PrefsUnifiedDlg.cpp:2273
 msgid "Data by DB-IP.com"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2284
+#: src/PrefsUnifiedDlg.cpp:2293
 #, fuzzy, c-format
 msgid "Status: Loaded%s"
 msgstr "Estat:"
 
-#: src/PrefsUnifiedDlg.cpp:2286
+#: src/PrefsUnifiedDlg.cpp:2295
 #, fuzzy, c-format
 msgid "Status: Loaded%s - %s"
 msgstr "Estat:"
 
-#: src/PrefsUnifiedDlg.cpp:2290
+#: src/PrefsUnifiedDlg.cpp:2299
 msgid "Status: Failed to load - click 'Update now' to refresh."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2292
+#: src/PrefsUnifiedDlg.cpp:2301
 msgid "Status: Not found - click 'Update now' to download."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2350 src/PrefsUnifiedDlg.cpp:2374
+#: src/PrefsUnifiedDlg.cpp:2359 src/PrefsUnifiedDlg.cpp:2383
 #, c-format
 msgid "Update delay: %d second"
 msgid_plural "Update delay: %d seconds"
 msgstr[0] "Retard de l'actualització: %d seg"
 msgstr[1] "Retard de l'actualització: %d segs"
 
-#: src/PrefsUnifiedDlg.cpp:2358
+#: src/PrefsUnifiedDlg.cpp:2367
 #, c-format
 msgid "Time for average graph: %d minute"
 msgid_plural "Time for average graph: %d minutes"
 msgstr[0] "Temps per al gràfic de mitjanes: %d min"
 msgstr[1] "Temps per al gràfic de mitjanes: %d mins"
 
-#: src/PrefsUnifiedDlg.cpp:2367
+#: src/PrefsUnifiedDlg.cpp:2376
 #, c-format
 msgid "Connections Graph Scale: %d"
 msgstr "Escala del gràfic de connexions: %d"
 
-#: src/PrefsUnifiedDlg.cpp:2382
+#: src/PrefsUnifiedDlg.cpp:2391
 #, c-format
 msgid "File Buffer Size: %d byte"
 msgid_plural "File Buffer Size: %d bytes"
 msgstr[0] "Mida de la memòria intermèdia de fitxer: %d byte"
 msgstr[1] "Mida de la memòria intermèdia de fitxer: %d bytes"
 
-#: src/PrefsUnifiedDlg.cpp:2392
+#: src/PrefsUnifiedDlg.cpp:2401
 #, c-format
 msgid "Upload Queue Size: %d client"
 msgid_plural "Upload Queue Size: %d clients"
 msgstr[0] "Mida de la cua de pujada: %d client"
 msgstr[1] "Mida de la cua de pujada: %d clients"
 
-#: src/PrefsUnifiedDlg.cpp:2402
+#: src/PrefsUnifiedDlg.cpp:2411
 #, c-format
 msgid "Server connection refresh interval: %d minute"
 msgid_plural "Server connection refresh interval: %d minutes"
 msgstr[0] "Interval de refresc de la connexió amb el servidor: %d minut"
 msgstr[1] "Interval de refresc de la connexió amb el servidor: %d minuts"
 
-#: src/PrefsUnifiedDlg.cpp:2407
+#: src/PrefsUnifiedDlg.cpp:2416
 msgid "Server connection refresh interval: Disabled"
 msgstr "Interval de refresc de la connexió amb el servidor: Inhabilitat"
 
-#: src/PrefsUnifiedDlg.cpp:2451
+#: src/PrefsUnifiedDlg.cpp:2460
 msgid "disabled"
 msgstr "inhabilitat"
 
-#: src/PrefsUnifiedDlg.cpp:2477
+#: src/PrefsUnifiedDlg.cpp:2486
 #, c-format
 msgid "Execute command on '%s' event"
 msgstr "Executa una ordre per a l'esdeveniment '%s'"
 
-#: src/PrefsUnifiedDlg.cpp:2484
+#: src/PrefsUnifiedDlg.cpp:2493
 msgid "Enable command execution on core"
 msgstr "Activa l'execució d'ordres al nucli"
 
-#: src/PrefsUnifiedDlg.cpp:2496
+#: src/PrefsUnifiedDlg.cpp:2505
 msgid "Core command:"
 msgstr "Odre del nucli:"
 
-#: src/PrefsUnifiedDlg.cpp:2512
+#: src/PrefsUnifiedDlg.cpp:2521
 msgid "Enable command execution on GUI"
 msgstr "Activa l'execució d'ordres a la interfície gràfica"
 
-#: src/PrefsUnifiedDlg.cpp:2524
+#: src/PrefsUnifiedDlg.cpp:2533
 msgid "GUI command:"
 msgstr "Ordre de la IGU:"
 
-#: src/PrefsUnifiedDlg.cpp:2540
+#: src/PrefsUnifiedDlg.cpp:2549
 msgid "The following variables will be replaced:"
 msgstr "Les següents variables seran reemplaçades:"
 
-#: src/PrefsUnifiedDlg.cpp:2708
+#: src/PrefsUnifiedDlg.cpp:2717
 msgid ""
 "The following folders look like system or sensitive locations:\n"
 "\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2713
+#: src/PrefsUnifiedDlg.cpp:2722
 msgid "Sharing them recursively will publish every file underneath on the eD2k/Kad networks. Do you really want to do this?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2716
+#: src/PrefsUnifiedDlg.cpp:2725
 #, fuzzy
 msgid "Confirm shared folders"
 msgstr "Carpetes compartides"
 
-#: src/PrefsUnifiedDlg.cpp:2744
+#: src/PrefsUnifiedDlg.cpp:2753
 #, fuzzy
 msgid "Reloading shared files..."
 msgstr "Recarrega els compartits"
 
-#: src/PrefsUnifiedDlg.cpp:2745
+#: src/PrefsUnifiedDlg.cpp:2754
 msgid "Scanning for subdirectories..."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2746
+#: src/PrefsUnifiedDlg.cpp:2755
 #, fuzzy
 msgid "Updating shared folders"
 msgstr "Carpetes compartides"
 
-#: src/PrefsUnifiedDlg.cpp:2773
+#: src/PrefsUnifiedDlg.cpp:2782
 #, c-format
 msgid "Scanned %u directories..."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2823
+#: src/PrefsUnifiedDlg.cpp:2832
 #, fuzzy, c-format
 msgid "Reloading shared files: %u files scanned"
 msgstr "Recarrega la llista de fitxers compartits."
 
-#: src/PrefsUnifiedDlg.cpp:2873
+#: src/PrefsUnifiedDlg.cpp:2882
 #, fuzzy
 msgid "Shared folder"
 msgstr "Carpetes compartides"
@@ -7853,12 +7853,12 @@ msgstr "Elimina la categoria"
 msgid "Hashset requested for unknown file: %s"
 msgstr "S'ha demanat un conjunt de resums d'un fitxer desconegut: %s"
 
-#: src/UploadQueue.cpp:618
+#: src/UploadQueue.cpp:627
 #, c-format
 msgid "Resuming uploads of file: %s"
 msgstr "S'està reprenent la pujada del fitxer: %s"
 
-#: src/UploadQueue.cpp:634
+#: src/UploadQueue.cpp:643
 #, c-format
 msgid "Suspending upload of file: %s"
 msgstr "S'està suspenent la pujada del fitxer: %s"

--- a/po/cs.po
+++ b/po/cs.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-28 08:06+0200\n"
+"POT-Creation-Date: 2026-07-28 10:19+0200\n"
 "PO-Revision-Date: 2026-07-27 11:34+0000\n"
 "Last-Translator: David Watzke <david@watzke.cz>\n"
 "Language-Team: cs <cs@li.org>\n"
@@ -143,7 +143,7 @@ msgstr ""
 msgid "Not now"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:422 src/amuleDlg.cpp:600
+#: src/AppImageIntegration.cpp:422 src/amuleDlg.cpp:665
 msgid "Don't ask again"
 msgstr ""
 
@@ -216,7 +216,7 @@ msgid "Killing amuleweb instance with pid '%d' ... "
 msgstr "Zabíjím instanci amuleweb s PID `%d'..."
 
 #: src/amule.cpp:336 src/amule.cpp:349 src/ClientRef.cpp:180
-#: src/SearchDlg.cpp:880 src/ServerListCtrl.cpp:98
+#: src/SearchDlg.cpp:1041 src/ServerListCtrl.cpp:98
 msgid "Failed"
 msgstr "Selhal"
 
@@ -567,30 +567,68 @@ msgstr "Nelze vytvořit soubor s PID"
 msgid "ERROR: %s"
 msgstr "CHYBA: %s"
 
-#: src/amuleDlg.cpp:236
+#: src/amuleDlg.cpp:250
 #, c-format
 msgid "This is aMule %s based on eMule."
 msgstr "Toto je aMule %s založená na eMule."
 
-#: src/amuleDlg.cpp:237
+#: src/amuleDlg.cpp:251
 #, c-format
 msgid "Running on %s"
 msgstr "Běží na %s"
 
-#: src/amuleDlg.cpp:239
+#: src/amuleDlg.cpp:253
 msgid "Visit https://github.com/amule-org/amule/releases/latest to check if a new version is available."
 msgstr "Navštivte https://github.com/amule-org/amule/releases/latest  pro kontrolu, jestli není dostupná nová verze."
 
-#: src/amuleDlg.cpp:268
+#: src/amuleDlg.cpp:282
 msgid "FATAL ERROR: Failed to create Timer"
 msgstr "KRITICKÁ CHYBA: Vytváření časovače selhalo"
 
-#: src/amuleDlg.cpp:592
+#: src/amuleDlg.cpp:361 src/amuleDlg.cpp:1787 src/amuleDlg.cpp:2033
+#: src/muuli_wdr.cpp:1492 src/muuli_wdr.cpp:3418
+msgid "Networks"
+msgstr "Sítě"
+
+#: src/amuleDlg.cpp:362 src/amuleDlg.cpp:1793 src/muuli_wdr.cpp:3419
+msgid "Searches"
+msgstr "Vyhledávání"
+
+#: src/amuleDlg.cpp:363 src/amuleDlg.cpp:1799 src/DownloadListCtrl.cpp:740
+#: src/muuli_wdr.cpp:392 src/muuli_wdr.cpp:1585 src/muuli_wdr.cpp:3420
+#: src/Statistics.cpp:829
+msgid "Downloads"
+msgstr "Stahování"
+
+#: src/amuleDlg.cpp:364 src/amuleDlg.cpp:1805 src/muuli_wdr.cpp:3294
+msgid "Shared files"
+msgstr "Sdílené soubory"
+
+#: src/amuleDlg.cpp:365 src/amuleDlg.cpp:1811 src/muuli_wdr.cpp:2926
+#: src/muuli_wdr.cpp:3376 src/muuli_wdr.cpp:3423
+msgid "Messages"
+msgstr "Zprávy"
+
+#: src/amuleDlg.cpp:366 src/amuleDlg.cpp:1817 src/muuli_wdr.cpp:3424
+#: src/PrefsUnifiedDlg.cpp:312 src/Statistics.cpp:779 src/Statistics.cpp:1235
+msgid "Statistics"
+msgstr "Statistiky"
+
+#: src/amuleDlg.cpp:368 src/amuleDlg.cpp:1824 src/muuli_wdr.cpp:3426
+#: src/PrefsUnifiedDlg.cpp:328 src/utils/wxCas/src/wxcasprefs.cpp:39
+msgid "Preferences"
+msgstr "Nastavení"
+
+#: src/amuleDlg.cpp:371
+msgid "Navigate"
+msgstr ""
+
+#: src/amuleDlg.cpp:657
 #, fuzzy
 msgid "New version available"
 msgstr "Nedostupný"
 
-#: src/amuleDlg.cpp:596
+#: src/amuleDlg.cpp:661
 #, fuzzy, c-format
 msgid ""
 "A new version of aMule (%s) is available.\n"
@@ -600,218 +638,185 @@ msgid ""
 "Would you like to open the download page?"
 msgstr "Poslední verze jsou vždy k nalezení na https://github.com/amule-org/amule/releases/latest "
 
-#: src/amuleDlg.cpp:678
+#: src/amuleDlg.cpp:743
 msgid "aMule dialog destroyed"
 msgstr "Dialog aMule zničen"
 
-#: src/amuleDlg.cpp:701 src/DataToText.cpp:68 src/IPFilter.cpp:547
+#: src/amuleDlg.cpp:766 src/DataToText.cpp:68 src/IPFilter.cpp:547
 msgid "Connecting"
 msgstr "Připojuji"
 
-#: src/amuleDlg.cpp:893
+#: src/amuleDlg.cpp:958
 msgid "eD2k: Connecting"
 msgstr "eD2k: připojuji"
 
-#: src/amuleDlg.cpp:897
+#: src/amuleDlg.cpp:962
 msgid "eD2k: Disconnected"
 msgstr "eD2k: odpojeno"
 
-#: src/amuleDlg.cpp:903
+#: src/amuleDlg.cpp:968
 msgid "Kad: Firewalled"
 msgstr "Kad: Za firewallem"
 
-#: src/amuleDlg.cpp:907
+#: src/amuleDlg.cpp:972
 msgid "Kad: Connected"
 msgstr "Kad: Připojen"
 
-#: src/amuleDlg.cpp:912
+#: src/amuleDlg.cpp:977
 msgid "Kad: Connecting"
 msgstr "Kad: Připojuji"
 
-#: src/amuleDlg.cpp:916
+#: src/amuleDlg.cpp:981
 msgid "Kad: Off"
 msgstr "Kad: vypnut"
 
-#: src/amuleDlg.cpp:964 src/DownloadListCtrl.cpp:505
+#: src/amuleDlg.cpp:1029 src/DownloadListCtrl.cpp:505
 #: src/DownloadListCtrl.cpp:749 src/FriendListCtrl.cpp:180
 #: src/muuli_wdr.cpp:731 src/muuli_wdr.cpp:782 src/muuli_wdr.cpp:846
-#: src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2224 src/muuli_wdr.cpp:2309
-#: src/muuli_wdr.cpp:3057 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
+#: src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2231 src/muuli_wdr.cpp:2316
+#: src/muuli_wdr.cpp:3064 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
 #: src/ServerListCtrl.cpp:606 src/TransferWnd.cpp:378
 #: src/utils/wxCas/src/wxcasprefs.cpp:235
 msgid "Cancel"
 msgstr "Zrušit"
 
-#: src/amuleDlg.cpp:965
+#: src/amuleDlg.cpp:1030
 msgid "Stop the current connection attempts"
 msgstr "Zastaví aktuální pokusy o připojení"
 
-#: src/amuleDlg.cpp:970 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976
-#: src/muuli_wdr.cpp:2447
+#: src/amuleDlg.cpp:1035 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976
+#: src/muuli_wdr.cpp:2454
 msgid "Disconnect"
 msgstr "Odpojit"
 
-#: src/amuleDlg.cpp:971
+#: src/amuleDlg.cpp:1036
 msgid "Disconnect from the currently connected networks"
 msgstr "Odpojit se od aktuálně připojených sítí"
 
-#: src/amuleDlg.cpp:976 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979
-#: src/muuli_wdr.cpp:2602 src/muuli_wdr.cpp:3054 src/muuli_wdr.cpp:3409
+#: src/amuleDlg.cpp:1041 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979
+#: src/muuli_wdr.cpp:2609 src/muuli_wdr.cpp:3061 src/muuli_wdr.cpp:3416
 msgid "Connect"
 msgstr "Připojit"
 
-#: src/amuleDlg.cpp:977
+#: src/amuleDlg.cpp:1042
 msgid "Connect to the currently enabled networks"
 msgstr "Připojit se k povoleným sítím"
 
-#: src/amuleDlg.cpp:1089
+#: src/amuleDlg.cpp:1154
 #, fuzzy, c-format
 msgid "Up: %.1f%s (%.1f) | Down: %.1f%s (%.1f)"
 msgstr "Od: %.1f(%.1f) | St: %.1f(%.1f)"
 
-#: src/amuleDlg.cpp:1091 src/amuleDlg.cpp:1093 src/amuleDlg.cpp:1097
-#: src/amuleDlg.cpp:1099 src/amuleDlg.cpp:1110 src/amuleDlg.cpp:1112
+#: src/amuleDlg.cpp:1156 src/amuleDlg.cpp:1158 src/amuleDlg.cpp:1162
+#: src/amuleDlg.cpp:1164 src/amuleDlg.cpp:1175 src/amuleDlg.cpp:1177
 #: src/MuleTrayIcon.cpp:796 src/MuleTrayIcon.cpp:799
 #, fuzzy
 msgid " MB/s"
 msgstr "MB/s"
 
-#: src/amuleDlg.cpp:1091 src/amuleDlg.cpp:1093 src/amuleDlg.cpp:1097
-#: src/amuleDlg.cpp:1099 src/amuleDlg.cpp:1110 src/amuleDlg.cpp:1112
+#: src/amuleDlg.cpp:1156 src/amuleDlg.cpp:1158 src/amuleDlg.cpp:1162
+#: src/amuleDlg.cpp:1164 src/amuleDlg.cpp:1175 src/amuleDlg.cpp:1177
 #: src/MuleTrayIcon.cpp:796 src/MuleTrayIcon.cpp:799
 #: src/utils/wxCas/src/wxcasframe.cpp:1041
 msgid " kB/s"
 msgstr " kB/s"
 
-#: src/amuleDlg.cpp:1096
+#: src/amuleDlg.cpp:1161
 #, fuzzy, c-format
 msgid "Up: %.1f%s | Down: %.1f%s"
 msgstr "Od: %.1f | St: %.1f"
 
-#: src/amuleDlg.cpp:1128
+#: src/amuleDlg.cpp:1193
 #, c-format
 msgid "aMule (%s | Connected)"
 msgstr "aMule (%s | připojen)"
 
-#: src/amuleDlg.cpp:1130
+#: src/amuleDlg.cpp:1195
 #, c-format
 msgid "aMule (%s | Disconnected)"
 msgstr "aMule (%s | odpojen)"
 
-#: src/amuleDlg.cpp:1183
+#: src/amuleDlg.cpp:1248
 #, c-format
 msgid "Do you really want to exit %s?"
 msgstr "Opravdu si přejete ukončit %s?"
 
-#: src/amuleDlg.cpp:1185
+#: src/amuleDlg.cpp:1250
 msgid "Exit confirmation"
 msgstr "Potvrzení ukončení"
 
-#: src/amuleDlg.cpp:1548
+#: src/amuleDlg.cpp:1613
 msgid "Launch Command: "
 msgstr "Spustit příkaz: "
 
-#: src/amuleDlg.cpp:1567 src/muuli_wdr.cpp:1971 src/Preferences.cpp:951
+#: src/amuleDlg.cpp:1632 src/muuli_wdr.cpp:1978 src/Preferences.cpp:952
 msgid "- default -"
 msgstr "- výchozí -"
 
-#: src/amuleDlg.cpp:1595
+#: src/amuleDlg.cpp:1660
 #, c-format
 msgid "Skin directory '%s' does not exist"
 msgstr "Adresář se skiny '%s' neexistuje"
 
-#: src/amuleDlg.cpp:1598
+#: src/amuleDlg.cpp:1663
 #, c-format
 msgid "WARNING: Unable to open skin file '%s' for read"
 msgstr "VAROVÁNÍ: Nelze otevřít soubor se vzhledem '%s' pro čtení"
 
-#: src/amuleDlg.cpp:1722 src/amuleDlg.cpp:1968 src/muuli_wdr.cpp:1485
-#: src/muuli_wdr.cpp:3411
-msgid "Networks"
-msgstr "Sítě"
-
-#: src/amuleDlg.cpp:1726 src/muuli_wdr.cpp:3411
+#: src/amuleDlg.cpp:1791 src/muuli_wdr.cpp:3418
 msgid "Networks Window"
 msgstr "Okno sítí"
 
-#: src/amuleDlg.cpp:1728 src/muuli_wdr.cpp:3412
-msgid "Searches"
-msgstr "Vyhledávání"
-
-#: src/amuleDlg.cpp:1732 src/muuli_wdr.cpp:3412
+#: src/amuleDlg.cpp:1797 src/muuli_wdr.cpp:3419
 msgid "Searches Window"
 msgstr "Vyhledávací okno"
 
-#: src/amuleDlg.cpp:1734 src/DownloadListCtrl.cpp:740 src/muuli_wdr.cpp:392
-#: src/muuli_wdr.cpp:1578 src/muuli_wdr.cpp:3413 src/Statistics.cpp:829
-msgid "Downloads"
-msgstr "Stahování"
-
-#: src/amuleDlg.cpp:1738 src/muuli_wdr.cpp:3413
+#: src/amuleDlg.cpp:1803 src/muuli_wdr.cpp:3420
 msgid "Downloads Window"
 msgstr "Stahování"
 
-#: src/amuleDlg.cpp:1740 src/muuli_wdr.cpp:3287
-msgid "Shared files"
-msgstr "Sdílené soubory"
-
-#: src/amuleDlg.cpp:1744 src/muuli_wdr.cpp:3415
+#: src/amuleDlg.cpp:1809 src/muuli_wdr.cpp:3422
 msgid "Shared Files Window"
 msgstr "Okno se sdílenými soubory"
 
-#: src/amuleDlg.cpp:1746 src/muuli_wdr.cpp:2919 src/muuli_wdr.cpp:3369
-#: src/muuli_wdr.cpp:3416
-msgid "Messages"
-msgstr "Zprávy"
-
-#: src/amuleDlg.cpp:1750 src/muuli_wdr.cpp:3416
+#: src/amuleDlg.cpp:1815 src/muuli_wdr.cpp:3423
 msgid "Messages Window"
 msgstr "Okno zpráv"
 
-#: src/amuleDlg.cpp:1752 src/muuli_wdr.cpp:3417 src/PrefsUnifiedDlg.cpp:312
-#: src/Statistics.cpp:779 src/Statistics.cpp:1235
-msgid "Statistics"
-msgstr "Statistiky"
-
-#: src/amuleDlg.cpp:1756 src/muuli_wdr.cpp:3417
+#: src/amuleDlg.cpp:1821 src/muuli_wdr.cpp:3424
 msgid "Statistics Graph Window"
 msgstr "Okno se statistikami"
 
-#: src/amuleDlg.cpp:1759 src/muuli_wdr.cpp:3419 src/PrefsUnifiedDlg.cpp:328
-#: src/utils/wxCas/src/wxcasprefs.cpp:39
-msgid "Preferences"
-msgstr "Nastavení"
-
-#: src/amuleDlg.cpp:1763 src/muuli_wdr.cpp:3419
+#: src/amuleDlg.cpp:1828 src/muuli_wdr.cpp:3426
 msgid "Preferences Settings Window"
 msgstr "Okno s nastavením"
 
-#: src/amuleDlg.cpp:1766 src/muuli_wdr.cpp:3420
+#: src/amuleDlg.cpp:1831 src/muuli_wdr.cpp:3427
 msgid "Import"
 msgstr "Import"
 
-#: src/amuleDlg.cpp:1770 src/muuli_wdr.cpp:3420
+#: src/amuleDlg.cpp:1835 src/muuli_wdr.cpp:3427
 msgid "The partfile importer tool"
 msgstr "Nástroj pro import částečných souborů"
 
-#: src/amuleDlg.cpp:1773 src/muuli_wdr.cpp:3421
+#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3428
 #: src/utils/aLinkCreator/src/alcframe.cpp:262
 msgid "About"
 msgstr "O programu"
 
-#: src/amuleDlg.cpp:1773 src/muuli_wdr.cpp:3421
+#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3428
 msgid "About/Help"
 msgstr "O programu/Nápověda"
 
-#: src/amuleDlg.cpp:1971
+#: src/amuleDlg.cpp:2036
 msgid "eD2k network"
 msgstr "Síť eD2k"
 
-#: src/amuleDlg.cpp:1974
+#: src/amuleDlg.cpp:2039
 msgid "Kad network"
 msgstr "Síť Kad"
 
-#: src/amuleDlg.cpp:1974
+#: src/amuleDlg.cpp:2039
 msgid "No network"
 msgstr "Žádná síť"
 
@@ -1349,19 +1354,19 @@ msgstr "Auto [Vy]"
 msgid "Very low"
 msgstr "Velmi nízká"
 
-#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:743 src/muuli_wdr.cpp:2275
+#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:743 src/muuli_wdr.cpp:2282
 #: src/ServerListCtrl.cpp:263 src/ServerListCtrl.cpp:456
 #: src/SharedFilesCtrl.cpp:145
 msgid "Low"
 msgstr "Nízká"
 
-#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:744 src/muuli_wdr.cpp:2276
+#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:744 src/muuli_wdr.cpp:2283
 #: src/ServerListCtrl.cpp:266 src/ServerListCtrl.cpp:457
 #: src/SharedFilesCtrl.cpp:146
 msgid "Normal"
 msgstr "Normální"
 
-#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:745 src/muuli_wdr.cpp:2277
+#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:745 src/muuli_wdr.cpp:2284
 #: src/ServerListCtrl.cpp:269 src/ServerListCtrl.cpp:458
 #: src/SharedFilesCtrl.cpp:147
 msgid "High"
@@ -1453,8 +1458,8 @@ msgstr "Lokální server"
 msgid "Remote Server"
 msgstr "Vzdálený server"
 
-#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3174
-#: src/SearchDlg.cpp:111 src/TextClient.cpp:911
+#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3181
+#: src/SearchDlg.cpp:119 src/TextClient.cpp:911
 msgid "Kad"
 msgstr "Kad"
 
@@ -1525,7 +1530,7 @@ msgstr "Část"
 msgid "Size"
 msgstr "Velikost"
 
-#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3241
+#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3248
 msgid "Transferred"
 msgstr "Přeneseno"
 
@@ -1583,7 +1588,7 @@ msgstr ""
 "Odezva od: %s (%s)\n"
 "\n"
 
-#: src/DownloadListCtrl.cpp:746 src/muuli_wdr.cpp:2278
+#: src/DownloadListCtrl.cpp:746 src/muuli_wdr.cpp:2285
 #: src/SharedFilesCtrl.cpp:150
 msgid "Auto"
 msgstr "Auto"
@@ -1621,7 +1626,7 @@ msgid "Extended Options"
 msgstr "Rozšířené nastavení"
 
 #: src/DownloadListCtrl.cpp:770 src/DownloadListCtrl.cpp:822
-#: src/muuli_wdr.cpp:1789
+#: src/muuli_wdr.cpp:1796
 msgid "Preview"
 msgstr "Náhled"
 
@@ -2317,19 +2322,19 @@ msgstr ""
 msgid "eD2k"
 msgstr "eD2k"
 
-#: src/FirstRunWizard.cpp:349 src/muuli_wdr.cpp:1488
+#: src/FirstRunWizard.cpp:349 src/muuli_wdr.cpp:1495
 msgid "Kademlia"
 msgstr "Kademlia"
 
-#: src/FirstRunWizard.cpp:359 src/muuli_wdr.cpp:1416
+#: src/FirstRunWizard.cpp:359 src/muuli_wdr.cpp:1423
 msgid "Standard TCP Port "
 msgstr "Standardní TCP port"
 
-#: src/FirstRunWizard.cpp:365 src/muuli_wdr.cpp:1428
+#: src/FirstRunWizard.cpp:365 src/muuli_wdr.cpp:1435
 msgid "Extended UDP port (Kad / global search) "
 msgstr "Rozšířený UDP port (Kad / globální vyhledávání)"
 
-#: src/FirstRunWizard.cpp:377 src/muuli_wdr.cpp:1435
+#: src/FirstRunWizard.cpp:377 src/muuli_wdr.cpp:1442
 msgid "Enable UPnP for router port forwarding"
 msgstr "Povolit UPnP port forwarding"
 
@@ -2356,7 +2361,7 @@ msgstr ""
 msgid "Your peer lists are already in place - nothing to download."
 msgstr "Soubor %s se již pokoušíte stáhnout"
 
-#: src/FirstRunWizard.cpp:434 src/muuli_wdr.cpp:1533
+#: src/FirstRunWizard.cpp:434 src/muuli_wdr.cpp:1540
 msgid "Auto-update server list at startup"
 msgstr "Automaticky aktualizovat seznam serverů po spuštění"
 
@@ -2402,23 +2407,23 @@ msgid ""
 "want downloads on a different (e.g. larger) disk."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:549 src/FirstRunWizard.cpp:611 src/muuli_wdr.cpp:1701
+#: src/FirstRunWizard.cpp:549 src/FirstRunWizard.cpp:611 src/muuli_wdr.cpp:1708
 msgid "Destination folder for downloads"
 msgstr "Cílový adresář pro stahování"
 
-#: src/FirstRunWizard.cpp:553 src/FirstRunWizard.cpp:569 src/muuli_wdr.cpp:1342
-#: src/muuli_wdr.cpp:1359 src/muuli_wdr.cpp:1676 src/muuli_wdr.cpp:1707
-#: src/muuli_wdr.cpp:1719 src/muuli_wdr.cpp:2762
+#: src/FirstRunWizard.cpp:553 src/FirstRunWizard.cpp:569 src/muuli_wdr.cpp:1349
+#: src/muuli_wdr.cpp:1366 src/muuli_wdr.cpp:1683 src/muuli_wdr.cpp:1714
+#: src/muuli_wdr.cpp:1726 src/muuli_wdr.cpp:2769
 #: src/utils/aLinkCreator/src/alcframe.cpp:135
 #: src/utils/wxCas/src/wxcasprefs.cpp:52 src/utils/wxCas/src/wxcasprefs.cpp:118
 msgid "Browse"
 msgstr "Procházet"
 
-#: src/FirstRunWizard.cpp:559 src/muuli_wdr.cpp:1712
+#: src/FirstRunWizard.cpp:559 src/muuli_wdr.cpp:1719
 msgid "(All files in this folder are shared with other peers)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:565 src/FirstRunWizard.cpp:624 src/muuli_wdr.cpp:1714
+#: src/FirstRunWizard.cpp:565 src/FirstRunWizard.cpp:624 src/muuli_wdr.cpp:1721
 msgid "Folder for temporary download files"
 msgstr ""
 
@@ -2449,7 +2454,7 @@ msgstr ""
 msgid "CRITICAL - no client on StartChatSession"
 msgstr ""
 
-#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2668 src/muuli_wdr.cpp:3345
+#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2675 src/muuli_wdr.cpp:3352
 msgid "Friends"
 msgstr "Kamarádi"
 
@@ -2841,7 +2846,7 @@ msgstr "Poměr sdílení"
 msgid "Uploaded"
 msgstr "Odesláno"
 
-#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3225
+#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3232
 msgid "Requested"
 msgstr "Vyžádáno"
 
@@ -2967,7 +2972,7 @@ msgid "WARNING: "
 msgstr "VAROVÁNÍ: "
 
 #: src/MuleNotebook.cpp:179 src/muuli_wdr.cpp:817 src/muuli_wdr.cpp:1229
-#: src/muuli_wdr.cpp:3129 src/muuli_wdr.cpp:3385
+#: src/muuli_wdr.cpp:3136 src/muuli_wdr.cpp:3392
 msgid "Close"
 msgstr "Zavřít"
 
@@ -2980,12 +2985,12 @@ msgstr "Vyjmout"
 msgid "Copy"
 msgstr "Kopírovat"
 
-#: src/MuleTextCtrl.cpp:88
+#: src/MuleTextCtrl.cpp:88 src/SearchDlg.cpp:261
 msgid "Paste"
 msgstr "Vložit"
 
 #: src/MuleTextCtrl.cpp:89 src/muuli_wdr.cpp:358 src/muuli_wdr.cpp:757
-#: src/muuli_wdr.cpp:2352 src/muuli_wdr.cpp:2371 src/muuli_wdr.cpp:2393
+#: src/muuli_wdr.cpp:2359 src/muuli_wdr.cpp:2378 src/muuli_wdr.cpp:2400
 #: src/utils/aLinkCreator/src/alcframe.cpp:142
 msgid "Clear"
 msgstr "Vyprázdnit"
@@ -3083,8 +3088,8 @@ msgid "Exit"
 msgstr "Ukončit"
 
 #: src/MuleTrayIcon.cpp:579 src/MuleTrayIcon.cpp:945 src/MuleTrayIcon.cpp:965
-#: src/muuli_wdr.cpp:1391 src/muuli_wdr.cpp:1399 src/muuli_wdr.cpp:1406
-#: src/muuli_wdr.cpp:1835 src/muuli_wdr.cpp:1841 src/OtherFunctions.cpp:91
+#: src/muuli_wdr.cpp:1398 src/muuli_wdr.cpp:1406 src/muuli_wdr.cpp:1413
+#: src/muuli_wdr.cpp:1842 src/muuli_wdr.cpp:1848 src/OtherFunctions.cpp:91
 #: src/StatisticsDlg.cpp:93 src/StatisticsDlg.cpp:95
 msgid "kB/s"
 msgstr "kB/s"
@@ -3255,7 +3260,7 @@ msgstr "Název:"
 msgid "Type"
 msgstr "Typ"
 
-#: src/muuli_wdr.cpp:215 src/SearchDlg.cpp:110 src/SearchListCtrl.cpp:853
+#: src/muuli_wdr.cpp:215 src/SearchDlg.cpp:118 src/SearchListCtrl.cpp:853
 msgid "Local"
 msgstr "Lokální"
 
@@ -3326,7 +3331,7 @@ msgstr "bajtů"
 msgid "KB"
 msgstr "KB"
 
-#: src/muuli_wdr.cpp:274 src/muuli_wdr.cpp:293 src/muuli_wdr.cpp:1620
+#: src/muuli_wdr.cpp:274 src/muuli_wdr.cpp:293 src/muuli_wdr.cpp:1627
 #: src/OtherFunctions.cpp:64
 msgid "MB"
 msgstr "MB"
@@ -3343,7 +3348,7 @@ msgstr "Max. velikost"
 msgid "Availability"
 msgstr "Dostupnost"
 
-#: src/muuli_wdr.cpp:312 src/muuli_wdr.cpp:398 src/muuli_wdr.cpp:3290
+#: src/muuli_wdr.cpp:312 src/muuli_wdr.cpp:398 src/muuli_wdr.cpp:3297
 msgid "Filter:"
 msgstr "Filtr:"
 
@@ -3375,7 +3380,7 @@ msgstr ""
 msgid "Stop"
 msgstr "Zastavit"
 
-#: src/muuli_wdr.cpp:348 src/muuli_wdr.cpp:1385 src/SearchListCtrl.cpp:732
+#: src/muuli_wdr.cpp:348 src/muuli_wdr.cpp:1392 src/SearchListCtrl.cpp:732
 msgid "Download"
 msgstr "Stahování"
 
@@ -3406,8 +3411,8 @@ msgstr "Zdroje souboru:"
 #: src/muuli_wdr.cpp:1160 src/muuli_wdr.cpp:1167 src/muuli_wdr.cpp:1172
 #: src/muuli_wdr.cpp:1179 src/muuli_wdr.cpp:1184 src/muuli_wdr.cpp:1191
 #: src/muuli_wdr.cpp:1205 src/muuli_wdr.cpp:1212 src/muuli_wdr.cpp:1217
-#: src/muuli_wdr.cpp:1224 src/muuli_wdr.cpp:3227 src/muuli_wdr.cpp:3235
-#: src/muuli_wdr.cpp:3243
+#: src/muuli_wdr.cpp:1224 src/muuli_wdr.cpp:3234 src/muuli_wdr.cpp:3242
+#: src/muuli_wdr.cpp:3250
 msgid "N/A"
 msgstr "N/A"
 
@@ -3552,7 +3557,7 @@ msgstr ""
 msgid "Album :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:685 src/muuli_wdr.cpp:2247
+#: src/muuli_wdr.cpp:685 src/muuli_wdr.cpp:2254
 msgid "Title :"
 msgstr "Titulek:"
 
@@ -3659,7 +3664,7 @@ msgstr "Uživatelské jméno:"
 msgid "Userhash :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:895 src/muuli_wdr.cpp:1741 src/muuli_wdr.cpp:2442
+#: src/muuli_wdr.cpp:895 src/muuli_wdr.cpp:1748 src/muuli_wdr.cpp:2449
 #: src/utils/aLinkCreator/src/alcframe.cpp:137
 msgid "Add"
 msgstr "Přidat"
@@ -3668,15 +3673,15 @@ msgstr "Přidat"
 msgid "Download-Speed"
 msgstr "Rychlost stahování"
 
-#: src/muuli_wdr.cpp:954 src/muuli_wdr.cpp:989 src/muuli_wdr.cpp:2546
+#: src/muuli_wdr.cpp:954 src/muuli_wdr.cpp:989 src/muuli_wdr.cpp:2553
 msgid "Current"
 msgstr ""
 
-#: src/muuli_wdr.cpp:962 src/muuli_wdr.cpp:997 src/muuli_wdr.cpp:2554
+#: src/muuli_wdr.cpp:962 src/muuli_wdr.cpp:997 src/muuli_wdr.cpp:2561
 msgid "Running average"
 msgstr ""
 
-#: src/muuli_wdr.cpp:970 src/muuli_wdr.cpp:1005 src/muuli_wdr.cpp:2562
+#: src/muuli_wdr.cpp:970 src/muuli_wdr.cpp:1005 src/muuli_wdr.cpp:2569
 msgid "Session average"
 msgstr "Průměr sezení"
 
@@ -3688,7 +3693,7 @@ msgstr "Rychlost odesílání"
 msgid "Connections"
 msgstr "Připojení"
 
-#: src/muuli_wdr.cpp:1024 src/muuli_wdr.cpp:1860
+#: src/muuli_wdr.cpp:1024 src/muuli_wdr.cpp:1867
 msgid "Active downloads"
 msgstr "Aktivní stahování"
 
@@ -3696,7 +3701,7 @@ msgstr "Aktivní stahování"
 msgid "Active connections (1:1)"
 msgstr "Aktivní připojení (1:1)"
 
-#: src/muuli_wdr.cpp:1040 src/muuli_wdr.cpp:1861
+#: src/muuli_wdr.cpp:1040 src/muuli_wdr.cpp:1868
 msgid "Active uploads"
 msgstr "Aktivní odesílání"
 
@@ -3813,8 +3818,8 @@ msgstr "Toto jméno uvidí ostatní uživatelé, kteří se k vám připojí."
 msgid "Language: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1257 src/muuli_wdr.cpp:1323 src/muuli_wdr.cpp:1327
-#: src/muuli_wdr.cpp:1330
+#: src/muuli_wdr.cpp:1257 src/muuli_wdr.cpp:1330 src/muuli_wdr.cpp:1334
+#: src/muuli_wdr.cpp:1337
 msgid "The delay before showing tool-tips."
 msgstr "Prodleva před zobrazením tooltipů."
 
@@ -3892,936 +3897,945 @@ msgstr ""
 msgid "Enabling this will make aMule to show notifications when finished downloading."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1322
-msgid "Tooltip delay time: "
+#: src/muuli_wdr.cpp:1323
+#, fuzzy
+msgid "Remember search history"
+msgstr "Zapamatovat si toto nastavení"
+
+#: src/muuli_wdr.cpp:1324
+msgid "Keeps a dropdown list of your past search terms in the Search tab's Name field. This remembers the queries you typed, not the results they returned."
 msgstr ""
 
 #: src/muuli_wdr.cpp:1329
+msgid "Tooltip delay time: "
+msgstr ""
+
+#: src/muuli_wdr.cpp:1336
 msgid "seconds"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1333
+#: src/muuli_wdr.cpp:1340
 msgid "Browser Selection"
 msgstr "Výběr prohlížeče"
 
-#: src/muuli_wdr.cpp:1339
+#: src/muuli_wdr.cpp:1346
 msgid "Enter your browser name here. Leave this field empty to use the system default browser."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1346
+#: src/muuli_wdr.cpp:1353
 msgid "Open in new tab if possible"
 msgstr "Otevřít pokud možno v novém tabu"
 
-#: src/muuli_wdr.cpp:1348
+#: src/muuli_wdr.cpp:1355
 msgid "Open the web page in a new tab instead of in a new window when possible"
 msgstr "Otevřít webovou stránku v novém tabu místo otvírání nového okna, pokud je to možné"
 
-#: src/muuli_wdr.cpp:1352
+#: src/muuli_wdr.cpp:1359
 msgid "Video Player"
 msgstr "Video přehrávač"
 
-#: src/muuli_wdr.cpp:1379
+#: src/muuli_wdr.cpp:1386
 msgid "Bandwidth limits"
 msgstr "Limity šířky pásma"
 
-#: src/muuli_wdr.cpp:1393
+#: src/muuli_wdr.cpp:1400
 msgid "Upload"
 msgstr "Odesílání"
 
-#: src/muuli_wdr.cpp:1401
+#: src/muuli_wdr.cpp:1408
 msgid "Slot Allocation"
 msgstr "Přidělování slotů"
 
-#: src/muuli_wdr.cpp:1410
+#: src/muuli_wdr.cpp:1417
 msgid "Ports"
 msgstr "Porty"
 
-#: src/muuli_wdr.cpp:1420
+#: src/muuli_wdr.cpp:1427
 msgid "This is the standard eD2k port and cannot be disabled."
 msgstr "Tohle je standardní eD2k port a nelze jej zakázat."
 
-#: src/muuli_wdr.cpp:1423
+#: src/muuli_wdr.cpp:1430
 msgid "UDP port for server requests (TCP+3):"
 msgstr "UDP port pro požadavky serveru (TCP+3):"
 
-#: src/muuli_wdr.cpp:1425
+#: src/muuli_wdr.cpp:1432
 msgid "4665"
 msgstr "4665"
 
-#: src/muuli_wdr.cpp:1432
+#: src/muuli_wdr.cpp:1439
 msgid "This UDP port is used for extended eD2k requests and Kad network"
 msgstr "Tento UDP port je použit pro rozšířené požadavky eD2k a pro síť Kad"
 
-#: src/muuli_wdr.cpp:1439
+#: src/muuli_wdr.cpp:1446
 msgid "UPnP TCP Port (Optional):"
 msgstr "UPnP TCP port (volitelné):"
 
-#: src/muuli_wdr.cpp:1449
+#: src/muuli_wdr.cpp:1456
 msgid "Bind local address to IP (empty for any):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1452
+#: src/muuli_wdr.cpp:1459
 msgid "Advanced users only: If you have multiple network interfaces, enter the address of the interface to which aMule should be bound."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1455 src/muuli_wdr.cpp:2054
+#: src/muuli_wdr.cpp:1462 src/muuli_wdr.cpp:2061
 msgid "Bind to network interface (empty for any):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1468
+#: src/muuli_wdr.cpp:1475
 msgid "Advanced users only: pin all of aMule's traffic to one network interface, chosen from the list or typed in by name (e.g. tun0, eth0, en0) or index. Unlike binding to an IP, this stops traffic leaking out via the default route - useful with a VPN. Requires no elevated privileges."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1474
+#: src/muuli_wdr.cpp:1481
 msgid "Max sources per downloading file:"
 msgstr "Max. zdrojů na stahovaný soubor:"
 
-#: src/muuli_wdr.cpp:1478
+#: src/muuli_wdr.cpp:1485
 msgid "Max simultaneous connections:"
 msgstr "Maximum připojení naráz:"
 
-#: src/muuli_wdr.cpp:1491 src/muuli_wdr.cpp:3169
+#: src/muuli_wdr.cpp:1498 src/muuli_wdr.cpp:3176
 msgid "ED2K"
 msgstr "ED2K"
 
-#: src/muuli_wdr.cpp:1498
+#: src/muuli_wdr.cpp:1505
 msgid "Autoconnect on startup"
 msgstr "Automatické připojení po spuštění"
 
-#: src/muuli_wdr.cpp:1501
+#: src/muuli_wdr.cpp:1508
 msgid "Reconnect on loss"
 msgstr "Po odpojení znovu připojit"
 
-#: src/muuli_wdr.cpp:1523
+#: src/muuli_wdr.cpp:1530
 msgid "Remove dead server after"
 msgstr "Odstranit mrtvý server po"
 
-#: src/muuli_wdr.cpp:1524
+#: src/muuli_wdr.cpp:1531
 msgid "Static servers are never removed, even when unreachable."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1528
+#: src/muuli_wdr.cpp:1535
 msgid "retries"
 msgstr "pokusech"
 
-#: src/muuli_wdr.cpp:1536
+#: src/muuli_wdr.cpp:1543
 msgid "List"
 msgstr "Seznam"
 
-#: src/muuli_wdr.cpp:1539
+#: src/muuli_wdr.cpp:1546
 msgid "Update server list when connecting to a server"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1542
+#: src/muuli_wdr.cpp:1549
 msgid "Update server list when a client connects"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1545
+#: src/muuli_wdr.cpp:1552
 msgid "Use priority system"
 msgstr "Použít systém priorit"
 
-#: src/muuli_wdr.cpp:1549
+#: src/muuli_wdr.cpp:1556
 msgid "Use smart LowID check on connect"
 msgstr "Použít po připojení chytrou kontrolu LowID"
 
-#: src/muuli_wdr.cpp:1553
+#: src/muuli_wdr.cpp:1560
 msgid "Safe connect"
 msgstr "Bezpečné připojení"
 
-#: src/muuli_wdr.cpp:1557
+#: src/muuli_wdr.cpp:1564
 msgid "Autoconnect to servers in static list only"
 msgstr "Automaticky se připojit jen ke stálým serverům"
 
-#: src/muuli_wdr.cpp:1560
+#: src/muuli_wdr.cpp:1567
 msgid "Set manually added servers to High Priority"
 msgstr "Přidělit ručně přidaným serverům vysokou prioritu"
 
-#: src/muuli_wdr.cpp:1581
+#: src/muuli_wdr.cpp:1588
 msgid "Add files to download in pause mode"
 msgstr "Přidávat soubory ke stažení do fronty pozastavené"
 
-#: src/muuli_wdr.cpp:1583
+#: src/muuli_wdr.cpp:1590
 msgid "Add files to download with auto priority"
 msgstr "Přidávat soubory ke stažení do fronty s \"auto\" prioritou"
 
-#: src/muuli_wdr.cpp:1586
+#: src/muuli_wdr.cpp:1593
 msgid "Try to download first and last chunks first"
 msgstr "Pokusit se nejprve stáhnout první a poslední části"
 
-#: src/muuli_wdr.cpp:1590
+#: src/muuli_wdr.cpp:1597
 msgid "Endgame mode: rotate to faster sources for the final blocks"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1593
+#: src/muuli_wdr.cpp:1600
 msgid "Start next paused file when a file completes"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1596
+#: src/muuli_wdr.cpp:1603
 msgid "From the same category"
 msgstr "Ze stejné kategorie"
 
-#: src/muuli_wdr.cpp:1598
+#: src/muuli_wdr.cpp:1605
 msgid "In alphabetic order"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1600
+#: src/muuli_wdr.cpp:1607
 msgid "Preallocate disk space for new files"
 msgstr "Předalokovat místo na disku pro nové soubory"
 
-#: src/muuli_wdr.cpp:1601
+#: src/muuli_wdr.cpp:1608
 msgid "For new files preallocates disk space for the whole file, thus reduces fragmentation"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1606
+#: src/muuli_wdr.cpp:1613
 msgid "Create new files as sparse files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1607
+#: src/muuli_wdr.cpp:1614
 msgid "A sparse file reserves its full size on disk immediately without writing real data to it -- fast, but unsupported or slow on some filesystems, and free-space accounting stays optimistic while the download is in progress. Turn this off to grow the file only as data arrives."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1612
+#: src/muuli_wdr.cpp:1619
 msgid "Stop downloads when free disk space reaches "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1613
+#: src/muuli_wdr.cpp:1620
 msgid "Select this if you want aMule to check your disk space"
 msgstr "Toto zvolte chcete-li, aby aMule kontrolovala místo na disku"
 
-#: src/muuli_wdr.cpp:1617
+#: src/muuli_wdr.cpp:1624
 msgid "Enter here the min disk space desired."
 msgstr "Zadejte minimum místa na disku."
 
-#: src/muuli_wdr.cpp:1623
+#: src/muuli_wdr.cpp:1630
 msgid "Save 10 sources on rare files (< 20 sources)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1627 src/Statistics.cpp:790
+#: src/muuli_wdr.cpp:1634 src/Statistics.cpp:790
 msgid "Uploads"
 msgstr "Odesílání"
 
-#: src/muuli_wdr.cpp:1630
+#: src/muuli_wdr.cpp:1637
 msgid "Add new shared files with auto priority"
 msgstr "Přidat nově sdílené soubory s \"auto\" prioritou"
 
-#: src/muuli_wdr.cpp:1636
+#: src/muuli_wdr.cpp:1643
 msgid "Intelligent Corruption Handling (I.C.H.)"
 msgstr "Inteligentní zpracování poškození (I.C.H.)"
 
-#: src/muuli_wdr.cpp:1639
+#: src/muuli_wdr.cpp:1646
 msgid "Enable"
 msgstr "Povolit"
 
-#: src/muuli_wdr.cpp:1642
+#: src/muuli_wdr.cpp:1649
 msgid "Advanced I.C.H. trusts every hash (not recommended)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1654 src/PrefsUnifiedDlg.cpp:1910
+#: src/muuli_wdr.cpp:1661 src/PrefsUnifiedDlg.cpp:1910
 msgid "Media metadata extraction"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1658
+#: src/muuli_wdr.cpp:1665
 msgid "Extract length / bitrate / codec from shared audio and video files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1660
+#: src/muuli_wdr.cpp:1667
 msgid "When enabled, aMule runs ffprobe on each shared media file to fill in the Length / Bitrate / Codec columns other clients see when they find the file in a search. Requires ffmpeg (the ffprobe binary) to be installed."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1667
+#: src/muuli_wdr.cpp:1674
 msgid "Path to ffprobe:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1672
+#: src/muuli_wdr.cpp:1679
 msgid "Full path to the ffprobe binary. Leave empty to have aMule auto-detect it on startup."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1680
+#: src/muuli_wdr.cpp:1687
 msgid "Detect"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1681
+#: src/muuli_wdr.cpp:1688
 msgid "Search the standard install locations for an ffprobe binary and fill the path field."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1705
+#: src/muuli_wdr.cpp:1712
 msgid ""
 "Completed downloads are stored here. All files in this folder are automatically shared with other peers.\n"
 "If this folder also holds files you don't want to share, point it at an aMule-only sub-folder."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1708
+#: src/muuli_wdr.cpp:1715
 msgid "Pick the folder where completed downloads will be stored. All files in that folder will be shared with other peers."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1722
+#: src/muuli_wdr.cpp:1729
 msgid "Shared folders"
 msgstr "Sdílené adresáře"
 
-#: src/muuli_wdr.cpp:1728
+#: src/muuli_wdr.cpp:1735
 msgid "(Folders shared by the core. Enter a path to add one.)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1736
+#: src/muuli_wdr.cpp:1743
 msgid "Absolute path of a folder on the core's machine, e.g. /home/user/shared"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1738 src/PrefsUnifiedDlg.cpp:2794
+#: src/muuli_wdr.cpp:1745 src/PrefsUnifiedDlg.cpp:2794
 msgid "Recursive"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1739
+#: src/muuli_wdr.cpp:1746
 msgid "Share every sub-folder underneath this one, including ones created later."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1743 src/utils/aLinkCreator/src/alcframe.cpp:141
+#: src/muuli_wdr.cpp:1750 src/utils/aLinkCreator/src/alcframe.cpp:141
 msgid "Remove"
 msgstr "Odebrat"
 
-#: src/muuli_wdr.cpp:1747
+#: src/muuli_wdr.cpp:1754
 msgid "(Right click on folder icon for recursive share)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1754
+#: src/muuli_wdr.cpp:1761
 msgid "Share hidden files"
 msgstr "Sdílet skryté soubory"
 
-#: src/muuli_wdr.cpp:1760
+#: src/muuli_wdr.cpp:1767
 msgid "Automatically rescan shared folders for changes"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1766
+#: src/muuli_wdr.cpp:1773
 msgid "Follow symbolic links in shared folders"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1772
+#: src/muuli_wdr.cpp:1779
 msgid "Exclude files matching:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1775
+#: src/muuli_wdr.cpp:1782
 msgid "Wildcard patterns separated by '|', e.g. .DS_Store|Thumbs.db|*.tmp. Files whose name matches are not shared. Matching is case-insensitive."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1779
+#: src/muuli_wdr.cpp:1786
 msgid "Patterns are regular expressions"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1780
+#: src/muuli_wdr.cpp:1787
 msgid "When set, the whole field is one regular expression ('|' is alternation). When unset, it is a list of '|'-separated wildcards."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1790
+#: src/muuli_wdr.cpp:1797
 msgid "Show how many shared files the current pattern would exclude."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1811
+#: src/muuli_wdr.cpp:1818
 msgid "Graphs"
 msgstr "Grafy"
 
-#: src/muuli_wdr.cpp:1814 src/muuli_wdr.cpp:1876
+#: src/muuli_wdr.cpp:1821 src/muuli_wdr.cpp:1883
 msgid "Update delay : 5 secs"
 msgstr "Prodleva aktualizace: 5 sekund"
 
-#: src/muuli_wdr.cpp:1818
+#: src/muuli_wdr.cpp:1825
 msgid "Time for average graph: 100 mins"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1822
+#: src/muuli_wdr.cpp:1829
 msgid "Connections Graph Scale: 100 "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1829
+#: src/muuli_wdr.cpp:1836
 msgid "Download graph scale:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1837
+#: src/muuli_wdr.cpp:1844
 msgid "Upload graph scale:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1847
+#: src/muuli_wdr.cpp:1854
 #, fuzzy
 msgid "Colors: "
 msgstr "Barvy: "
 
-#: src/muuli_wdr.cpp:1851
+#: src/muuli_wdr.cpp:1858
 msgid "Background"
 msgstr "Na pozadí"
 
-#: src/muuli_wdr.cpp:1852
+#: src/muuli_wdr.cpp:1859
 msgid "Grid"
 msgstr "Mřížka"
 
-#: src/muuli_wdr.cpp:1853
+#: src/muuli_wdr.cpp:1860
 msgid "Download current"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1854
+#: src/muuli_wdr.cpp:1861
 msgid "Download running average"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1855
+#: src/muuli_wdr.cpp:1862
 msgid "Download session average"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1856
+#: src/muuli_wdr.cpp:1863
 msgid "Upload current"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1857
+#: src/muuli_wdr.cpp:1864
 msgid "Upload running average"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1858
+#: src/muuli_wdr.cpp:1865
 msgid "Upload session average"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1859
+#: src/muuli_wdr.cpp:1866
 msgid "Active connections"
 msgstr "Aktivní připojení"
 
-#: src/muuli_wdr.cpp:1862
+#: src/muuli_wdr.cpp:1869
 #, fuzzy
 msgid "Systray Icon Speed Bar"
 msgstr "Ukazatel rychlosti v tray ikoně"
 
-#: src/muuli_wdr.cpp:1863
+#: src/muuli_wdr.cpp:1870
 msgid "Kad-nodes current"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1864
+#: src/muuli_wdr.cpp:1871
 msgid "Kad-nodes running"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1865
+#: src/muuli_wdr.cpp:1872
 msgid "Kad-nodes session"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1869 src/muuli_wdr.cpp:2296
+#: src/muuli_wdr.cpp:1876 src/muuli_wdr.cpp:2303
 msgid "Select"
 msgstr "Vyberte"
 
-#: src/muuli_wdr.cpp:1873
+#: src/muuli_wdr.cpp:1880
 msgid "Tree"
 msgstr "Strom"
 
-#: src/muuli_wdr.cpp:1883
+#: src/muuli_wdr.cpp:1890
 msgid "Number of Client Versions shown (0=unlimited)"
 msgstr "Počet verzí klientů k zobrazení (0=neomezeně)"
 
-#: src/muuli_wdr.cpp:1908
+#: src/muuli_wdr.cpp:1915
 msgid "!!! WARNING !!!"
 msgstr "!!! VAROVÁNÍ !!!"
 
-#: src/muuli_wdr.cpp:1923
+#: src/muuli_wdr.cpp:1930
 msgid "Max new connections / 5 secs"
 msgstr "Max. nových připojení za 5 sek."
 
-#: src/muuli_wdr.cpp:1925
+#: src/muuli_wdr.cpp:1932
 msgid "Concurrent Kad source lookups"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1927
+#: src/muuli_wdr.cpp:1934
 #, fuzzy
 msgid "Kad source re-search interval (minutes)"
 msgstr "Interval aktualizace FTP v minutách"
 
-#: src/muuli_wdr.cpp:1929
+#: src/muuli_wdr.cpp:1936
 #, fuzzy
 msgid "Source re-ask interval (minutes)"
 msgstr "Interval aktualizace FTP v minutách"
 
-#: src/muuli_wdr.cpp:1933
+#: src/muuli_wdr.cpp:1940
 msgid "File Buffer Size: 240000 bytes"
 msgstr "Velikost zásobníku pro soubory: 240000 bytů"
 
-#: src/muuli_wdr.cpp:1937
+#: src/muuli_wdr.cpp:1944
 msgid "Use MMAP: memory-mapped file access (lower memory use)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1938
+#: src/muuli_wdr.cpp:1945
 msgid "Maps part files into memory instead of buffering them on the heap, lowering the process memory footprint. May reduce download speed on some disks; best for memory-constrained or upload-heavy hosts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1940
+#: src/muuli_wdr.cpp:1947
 msgid "Upload Queue Size: 5000 clients"
 msgstr "Velikost fronty odesílání: 5000 klientů"
 
-#: src/muuli_wdr.cpp:1944
+#: src/muuli_wdr.cpp:1951
 msgid "Server connection refresh interval: Disable"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1948
+#: src/muuli_wdr.cpp:1955
 msgid "Disable computer's timed standby mode"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1967
+#: src/muuli_wdr.cpp:1974
 msgid "Skin to use: "
 msgstr "Vzhled: "
 
-#: src/muuli_wdr.cpp:1976
+#: src/muuli_wdr.cpp:1983
 msgid "Show \"Fast eD2k Links Handler\" in every window."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1979
+#: src/muuli_wdr.cpp:1986
 msgid "Show extended info on categories tabs"
 msgstr "Zobrazit rozšířené informace na tabech kategorií"
 
-#: src/muuli_wdr.cpp:1982
+#: src/muuli_wdr.cpp:1989
 #, fuzzy
 msgid "Show application version on title"
 msgstr "Zobrazit rychlosti přenosu v titulku okna"
 
-#: src/muuli_wdr.cpp:1984
+#: src/muuli_wdr.cpp:1991
 msgid "Show transfer rates on title"
 msgstr "Zobrazit rychlosti přenosu v titulku okna"
 
-#: src/muuli_wdr.cpp:1986
+#: src/muuli_wdr.cpp:1993
 msgid "Before application name"
 msgstr "Před názvem programu"
 
-#: src/muuli_wdr.cpp:1988
+#: src/muuli_wdr.cpp:1995
 msgid "After application name"
 msgstr "Za názvem programu"
 
-#: src/muuli_wdr.cpp:1991
+#: src/muuli_wdr.cpp:1998
 msgid "Show overhead bandwidth"
 msgstr "Zobrazit šířku pásma režie"
 
-#: src/muuli_wdr.cpp:1995
+#: src/muuli_wdr.cpp:2002
 msgid "Vertical toolbar orientation"
 msgstr "Vertikální umístění nástrojové lišty"
 
-#: src/muuli_wdr.cpp:1997
+#: src/muuli_wdr.cpp:2004
 msgid "Live column sorting (auto-reorder rows as their values change)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2004
+#: src/muuli_wdr.cpp:2011
 msgid "Download Queue Files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2007
+#: src/muuli_wdr.cpp:2014
 msgid "Show progress percentage"
 msgstr "Zobrazit procenta průběhu"
 
-#: src/muuli_wdr.cpp:2013
+#: src/muuli_wdr.cpp:2020
 msgid "Show progress bar"
 msgstr "Zobrazit ukazatel průběhu"
 
-#: src/muuli_wdr.cpp:2016
+#: src/muuli_wdr.cpp:2023
 msgid "Flat"
 msgstr "Plochý"
 
-#: src/muuli_wdr.cpp:2020
+#: src/muuli_wdr.cpp:2027
 msgid "Round"
 msgstr "Kulatý"
 
-#: src/muuli_wdr.cpp:2038
+#: src/muuli_wdr.cpp:2045
 msgid "External Connection Parameters"
 msgstr "Nastavení externího připojení"
 
-#: src/muuli_wdr.cpp:2041
+#: src/muuli_wdr.cpp:2048
 msgid "Accept external connections"
 msgstr "Přijímat externí připojení"
 
-#: src/muuli_wdr.cpp:2048 src/muuli_wdr.cpp:2107
+#: src/muuli_wdr.cpp:2055 src/muuli_wdr.cpp:2114
 msgid "IP of the listening interface:"
 msgstr "IP naslouchajícího zařízení:"
 
-#: src/muuli_wdr.cpp:2051
+#: src/muuli_wdr.cpp:2058
 msgid "Enter here a valid ip in the a.b.c.d format for the listening EC interface. An empty field or 0.0.0.0 will mean any interface."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2072 src/muuli_wdr.cpp:2156
+#: src/muuli_wdr.cpp:2079 src/muuli_wdr.cpp:2163
 msgid "TCP port:"
 msgstr "TCP port:"
 
-#: src/muuli_wdr.cpp:2078
+#: src/muuli_wdr.cpp:2085
 msgid "Enable UPnP port forwarding on the EC port"
 msgstr "Povolit UPnP port forwarding na EC portu"
 
-#: src/muuli_wdr.cpp:2082 src/muuli_wdr.cpp:3041
+#: src/muuli_wdr.cpp:2089 src/muuli_wdr.cpp:3048
 #: src/utils/wxCas/src/wxcasprefs.cpp:167
 msgid "Password"
 msgstr "Heslo"
 
-#: src/muuli_wdr.cpp:2088
+#: src/muuli_wdr.cpp:2095
 #, fuzzy
 msgid "aMule API server parameters"
 msgstr "Parametry webserveru"
 
-#: src/muuli_wdr.cpp:2091
+#: src/muuli_wdr.cpp:2098
 msgid "Run amuleapi (REST API) on startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2096
+#: src/muuli_wdr.cpp:2103
 #, fuzzy
 msgid "HTTP port:"
 msgstr "TCP port:"
 
-#: src/muuli_wdr.cpp:2110
+#: src/muuli_wdr.cpp:2117
 msgid "The interface amuleapi's HTTP server listens on. 127.0.0.1 (default) accepts only local connections; use 0.0.0.0 or a specific IP to expose it to other hosts (set an admin password below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2113
+#: src/muuli_wdr.cpp:2120
 #, fuzzy
 msgid "Admin password"
 msgstr "Kontrola hesla\n"
 
-#: src/muuli_wdr.cpp:2118 src/muuli_wdr.cpp:2149
+#: src/muuli_wdr.cpp:2125 src/muuli_wdr.cpp:2156
 msgid "Low rights password"
 msgstr "Heslo pro omezená práva"
 
-#: src/muuli_wdr.cpp:2126
+#: src/muuli_wdr.cpp:2133
 msgid "Web server parameters"
 msgstr "Parametry webserveru"
 
-#: src/muuli_wdr.cpp:2129
+#: src/muuli_wdr.cpp:2136
 #, fuzzy
 msgid "Run webserver on startup (deprecated)"
 msgstr "Spustit webserver při spuštění aMule"
 
-#: src/muuli_wdr.cpp:2135
+#: src/muuli_wdr.cpp:2142
 msgid "Web template"
 msgstr "Šablona webu"
 
-#: src/muuli_wdr.cpp:2140
+#: src/muuli_wdr.cpp:2147
 msgid "Full rights password"
 msgstr "Heslo pro plná práva"
 
-#: src/muuli_wdr.cpp:2144
+#: src/muuli_wdr.cpp:2151
 msgid "Enable Low rights User"
 msgstr "Povolit uživatele s omezenými právy"
 
-#: src/muuli_wdr.cpp:2163
+#: src/muuli_wdr.cpp:2170
 msgid "Enable UPnP port forwarding of the web server port"
 msgstr "Povolit UPnP port forwarding portu webserveru"
 
-#: src/muuli_wdr.cpp:2168
+#: src/muuli_wdr.cpp:2175
 msgid "Web server UPnP TCP port (Optional)"
 msgstr "UPnP TCP port webserveru (volitelné)"
 
-#: src/muuli_wdr.cpp:2176
+#: src/muuli_wdr.cpp:2183
 msgid "Page Refresh Time (in secs)"
 msgstr "Obnovování stránky (v sek.)"
 
-#: src/muuli_wdr.cpp:2183
+#: src/muuli_wdr.cpp:2190
 msgid "Enable Gzip compression"
 msgstr "Povoliz Gzip kompresi"
 
-#: src/muuli_wdr.cpp:2217
+#: src/muuli_wdr.cpp:2224
 #, fuzzy
 msgid "Reset page to defaults"
 msgstr "Výchozí pro systém"
 
-#: src/muuli_wdr.cpp:2218
+#: src/muuli_wdr.cpp:2225
 msgid "Reset the settings on the current page to their default values."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2220 src/muuli_wdr.cpp:2306 src/ServerWnd.cpp:274
+#: src/muuli_wdr.cpp:2227 src/muuli_wdr.cpp:2313 src/ServerWnd.cpp:274
 #: src/ServerWnd.cpp:282
 msgid "OK"
 msgstr "Budiž"
 
-#: src/muuli_wdr.cpp:2222
+#: src/muuli_wdr.cpp:2229
 msgid "Click here to apply any changes made to the preferences."
 msgstr "Klikněte zde pro aplikování změn nastavení."
 
-#: src/muuli_wdr.cpp:2225
+#: src/muuli_wdr.cpp:2232
 msgid "Reset any changes made to the preferences."
 msgstr "Zahodí všechny změny v nastavení."
 
-#: src/muuli_wdr.cpp:2254
+#: src/muuli_wdr.cpp:2261
 msgid "Comment :"
 msgstr "Komentář:"
 
-#: src/muuli_wdr.cpp:2261
+#: src/muuli_wdr.cpp:2268
 msgid "Incoming Dir :"
 msgstr "Příchozí adresář:"
 
-#: src/muuli_wdr.cpp:2270
+#: src/muuli_wdr.cpp:2277
 msgid "Change priority for new assigned files :"
 msgstr "Změnit prioritu pro nově přiřazené soubory:"
 
-#: src/muuli_wdr.cpp:2274
+#: src/muuli_wdr.cpp:2281
 #, fuzzy
 msgid "Don't change"
 msgstr "Neměnit"
 
-#: src/muuli_wdr.cpp:2286
+#: src/muuli_wdr.cpp:2293
 msgid "Select color for this Category (currently selected) :"
 msgstr "Barva pro tuto kategorii:"
 
-#: src/muuli_wdr.cpp:2353 src/muuli_wdr.cpp:2372 src/muuli_wdr.cpp:2394
+#: src/muuli_wdr.cpp:2360 src/muuli_wdr.cpp:2379 src/muuli_wdr.cpp:2401
 msgid "Click this button to reset the log."
 msgstr "Klikněte na toto tlačítko pro vynulování logu."
 
-#: src/muuli_wdr.cpp:2413
+#: src/muuli_wdr.cpp:2420
 msgid "Click on this button to update the servers list from URL ..."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2417
+#: src/muuli_wdr.cpp:2424
 msgid "Server list"
 msgstr "Seznam serverů"
 
-#: src/muuli_wdr.cpp:2421
+#: src/muuli_wdr.cpp:2428
 msgid "Enter the url to a server.met file here and press the button to the left to update the list of known servers."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2426
+#: src/muuli_wdr.cpp:2433
 msgid "Add server manually: Name"
 msgstr "Přidat server ručně: Název"
 
-#: src/muuli_wdr.cpp:2429
+#: src/muuli_wdr.cpp:2436
 msgid "Enter the name of the new server here"
 msgstr "Zadejte název serveru"
 
-#: src/muuli_wdr.cpp:2431 src/ServerWnd.cpp:206
+#: src/muuli_wdr.cpp:2438 src/ServerWnd.cpp:206
 msgid "IP:Port"
 msgstr "IP:Port"
 
-#: src/muuli_wdr.cpp:2434
+#: src/muuli_wdr.cpp:2441
 msgid "Enter the IP of the server here, using the x.x.x.x format."
 msgstr "Zadejte IP serveru ve tvaru x.x.x.x."
 
-#: src/muuli_wdr.cpp:2440
+#: src/muuli_wdr.cpp:2447
 msgid "Enter the port of the server here."
 msgstr "Zadejte port serveru."
 
-#: src/muuli_wdr.cpp:2443
+#: src/muuli_wdr.cpp:2450
 msgid "Add manually a server (fill fields to the left before) ..."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2472
+#: src/muuli_wdr.cpp:2479
 msgid "aMule Log"
 msgstr "Log aMule"
 
-#: src/muuli_wdr.cpp:2480
+#: src/muuli_wdr.cpp:2487
 msgid "Server Info"
 msgstr "Info o serveru"
 
-#: src/muuli_wdr.cpp:2484
+#: src/muuli_wdr.cpp:2491
 msgid "ED2K Info"
 msgstr "ED2K Info"
 
-#: src/muuli_wdr.cpp:2488
+#: src/muuli_wdr.cpp:2495
 msgid "Kad Info"
 msgstr "Kad Info"
 
-#: src/muuli_wdr.cpp:2516
+#: src/muuli_wdr.cpp:2523
 msgid "Click on this button to update the nodes list from URL ..."
 msgstr "Aktualizuje seznam uzlů z dané URL..."
 
-#: src/muuli_wdr.cpp:2520
+#: src/muuli_wdr.cpp:2527
 msgid "Nodes (0)"
 msgstr "Uzly (0)"
 
-#: src/muuli_wdr.cpp:2524
+#: src/muuli_wdr.cpp:2531
 msgid "Enter the url to a nodes.dat file here and press the button to the left to update the list of known nodes."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2527
+#: src/muuli_wdr.cpp:2534
 msgid "Nodes stats"
 msgstr "Statistiky uzlů"
 
-#: src/muuli_wdr.cpp:2569
+#: src/muuli_wdr.cpp:2576
 msgid "Bootstrap"
 msgstr "Bootstrap"
 
-#: src/muuli_wdr.cpp:2572
+#: src/muuli_wdr.cpp:2579
 msgid "New node"
 msgstr "Nový uzel"
 
-#: src/muuli_wdr.cpp:2577
+#: src/muuli_wdr.cpp:2584
 msgid "IP:"
 msgstr "IP:"
 
-#: src/muuli_wdr.cpp:2597
+#: src/muuli_wdr.cpp:2604
 msgid "Port:"
 msgstr "Port:"
 
-#: src/muuli_wdr.cpp:2610
+#: src/muuli_wdr.cpp:2617
 msgid "Bootstrap from known clients"
 msgstr "Bootstrap od známých klientů"
 
-#: src/muuli_wdr.cpp:2612
+#: src/muuli_wdr.cpp:2619
 msgid "Disconnect Kad"
 msgstr "Odpojit Kad"
 
-#: src/muuli_wdr.cpp:2646
+#: src/muuli_wdr.cpp:2653
 msgid "Use Secure User Identification"
 msgstr "Použít bezpečnou uživatelskou identifikaci"
 
-#: src/muuli_wdr.cpp:2648
+#: src/muuli_wdr.cpp:2655
 msgid "It is recommended to enable this option. You will not receive credits if SUI is not enabled."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2650
+#: src/muuli_wdr.cpp:2657
 msgid "Protocol Obfuscation"
 msgstr "Zatemnění protokolu"
 
-#: src/muuli_wdr.cpp:2653
+#: src/muuli_wdr.cpp:2660
 msgid "Support Protocol Obfuscation"
 msgstr "Podporuje zatemnění protokolu"
 
-#: src/muuli_wdr.cpp:2655
+#: src/muuli_wdr.cpp:2662
 msgid "This option enabled Protocol Obfuscation, and makes aMule accept obfuscated connections from other clients."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2657
+#: src/muuli_wdr.cpp:2664
 msgid "Use obfuscation for outgoing connections"
 msgstr "Použít zatemnění protokolu pro odchozí spojení"
 
-#: src/muuli_wdr.cpp:2659
+#: src/muuli_wdr.cpp:2666
 msgid "This option makes aMule use Protocol Obfuscation when connecting other clients/servers."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2661
+#: src/muuli_wdr.cpp:2668
 msgid "Accept only obfuscated connections"
 msgstr "Přijímat pouze zatemněná spojení"
 
-#: src/muuli_wdr.cpp:2662
+#: src/muuli_wdr.cpp:2669
 msgid "This option makes aMule only accept obfuscated connections. You will have less sources, but all your traffic will be obfuscated"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2667
+#: src/muuli_wdr.cpp:2674
 msgid "Everybody"
 msgstr "Všichni"
 
-#: src/muuli_wdr.cpp:2669
+#: src/muuli_wdr.cpp:2676
 msgid "No one"
 msgstr "Nikdo"
 
-#: src/muuli_wdr.cpp:2671
+#: src/muuli_wdr.cpp:2678
 msgid "Who can see my shared files:"
 msgstr "Kdo může prohlížet moje sdílené soubory:"
 
-#: src/muuli_wdr.cpp:2672
+#: src/muuli_wdr.cpp:2679
 msgid "Select who can request to view a list of your shared files."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2674
+#: src/muuli_wdr.cpp:2681
 msgid "IP-Filtering"
 msgstr "IP filtrování"
 
-#: src/muuli_wdr.cpp:2681
+#: src/muuli_wdr.cpp:2688
 msgid "Filter clients"
 msgstr "Filtrovat klienty"
 
-#: src/muuli_wdr.cpp:2683
+#: src/muuli_wdr.cpp:2690
 msgid "Enable filtering of the client IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2685
+#: src/muuli_wdr.cpp:2692
 msgid "Filter servers"
 msgstr "Filtrovat servery"
 
-#: src/muuli_wdr.cpp:2687
+#: src/muuli_wdr.cpp:2694
 msgid "Enable filtering of the server IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2691
+#: src/muuli_wdr.cpp:2698
 msgid "Reload List"
 msgstr "Obnovit seznam"
 
-#: src/muuli_wdr.cpp:2692
+#: src/muuli_wdr.cpp:2699
 msgid "Reload the list of IPs to filter from the file ~/.aMule/ipfilter.dat"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2698
+#: src/muuli_wdr.cpp:2705
 msgid "URL:"
 msgstr "URL:"
 
-#: src/muuli_wdr.cpp:2702 src/muuli_wdr.cpp:2895
+#: src/muuli_wdr.cpp:2709 src/muuli_wdr.cpp:2902
 msgid "Update now"
 msgstr "Obnovit"
 
-#: src/muuli_wdr.cpp:2705
+#: src/muuli_wdr.cpp:2712
 msgid "Auto-update ipfilter at startup"
 msgstr "Automaticky aktualizovat IP filtr po spuštění"
 
-#: src/muuli_wdr.cpp:2709
+#: src/muuli_wdr.cpp:2716
 msgid "Filtering Level:"
 msgstr "Úroveň filtrování:"
 
-#: src/muuli_wdr.cpp:2715
+#: src/muuli_wdr.cpp:2722
 msgid "Always filter LAN IPs"
 msgstr "Vždy filtrovat LAN IP"
 
-#: src/muuli_wdr.cpp:2718
+#: src/muuli_wdr.cpp:2725
 msgid "Paranoid handling of non-matching IPs"
 msgstr "Paranoidní nakládání s nesouhlasícími IP"
 
-#: src/muuli_wdr.cpp:2720
+#: src/muuli_wdr.cpp:2727
 msgid "Rejects a packet when its source IP differs from the IP the client claims (an anti-spoofing check). Disable only if it causes connection problems."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2722
+#: src/muuli_wdr.cpp:2729
 msgid "Use system-wide ipfilter.dat if available"
 msgstr "Použít systémový ipfilter.dat, je-li dostupný"
 
-#: src/muuli_wdr.cpp:2723
+#: src/muuli_wdr.cpp:2730
 #, fuzzy
 msgid "If there's no local ipfilter.dat found, allow usage of a system-wide ipfilter file."
 msgstr "Neexistuje-li místní ipfilter.dat, umožní použití systémového."
 
-#: src/muuli_wdr.cpp:2740
+#: src/muuli_wdr.cpp:2747
 msgid "Enable Online-Signature"
 msgstr "Povolit online podpis"
 
-#: src/muuli_wdr.cpp:2742
+#: src/muuli_wdr.cpp:2749
 msgid "Enables the writing of the OS file, which can be used by external apps to create signatures and the like."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2746
+#: src/muuli_wdr.cpp:2753
 msgid "Update Frequency (Secs):"
 msgstr "Prodleva aktualizace (sek.):"
 
-#: src/muuli_wdr.cpp:2749
+#: src/muuli_wdr.cpp:2756
 msgid "Change the frequency (in seconds) of Online Signature updates."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2757
+#: src/muuli_wdr.cpp:2764
 msgid "Save online signature file in: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:2763
+#: src/muuli_wdr.cpp:2770
 msgid "Click here to select the directory containing the the Online Signature files."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2796
+#: src/muuli_wdr.cpp:2803
 msgid "Show country flags for clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2797
+#: src/muuli_wdr.cpp:2804
 msgid "Render the country flag column in the transfers, queue and search views. Requires a valid MMDB GeoIP database (see below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2802
+#: src/muuli_wdr.cpp:2809
 msgid "Database"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2818
+#: src/muuli_wdr.cpp:2825
 #, fuzzy
 msgid "Source:"
 msgstr "Zdroje"
 
-#: src/muuli_wdr.cpp:2821
+#: src/muuli_wdr.cpp:2828
 msgid "DB-IP (free, no account)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2822
+#: src/muuli_wdr.cpp:2829
 msgid "MaxMind GeoLite2 (free, account required)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2823
+#: src/muuli_wdr.cpp:2830
 msgid "Custom URL"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2826
+#: src/muuli_wdr.cpp:2833
 msgid "Choose which provider supplies the GeoIP MMDB database. DB-IP is the default - no account required. MaxMind requires a free account + license key. Use Custom URL to point at any other MMDB host (e.g. a local mirror)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2843
+#: src/muuli_wdr.cpp:2850
 msgid ""
 "No configuration required.\n"
 "\n"
@@ -4829,11 +4843,11 @@ msgid ""
 "License: Creative Commons BY 4.0 - https://creativecommons.org/licenses/by/4.0/"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2856
+#: src/muuli_wdr.cpp:2863
 msgid "License key:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2862
+#: src/muuli_wdr.cpp:2869
 msgid ""
 "Sign up for a free MaxMind account, then generate a License Key:\n"
 "https://www.maxmind.com/en/geolite2/signup\n"
@@ -4843,230 +4857,230 @@ msgid ""
 "Requires attribution and account registration; refresh at least every 30 days."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2877
+#: src/muuli_wdr.cpp:2884
 #, fuzzy
 msgid "Download URL:"
 msgstr "Stahování: "
 
-#: src/muuli_wdr.cpp:2883
+#: src/muuli_wdr.cpp:2890
 msgid ""
 "Must point to an .mmdb file or a .gz / .tar.gz containing one.\n"
 "URL may include credentials (https://user:pass@host/...).\n"
 "License and attribution terms are set by the upstream URL - you are responsible."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2896
+#: src/muuli_wdr.cpp:2903
 msgid "Download the GeoIP database from the selected source."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2898
+#: src/muuli_wdr.cpp:2905
 #, fuzzy
 msgid "Auto-update on startup"
 msgstr "Automaticky aktualizovat IP filtr po spuštění"
 
-#: src/muuli_wdr.cpp:2899
+#: src/muuli_wdr.cpp:2906
 msgid "Re-download the GeoIP database from the selected source every time aMule starts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2922
+#: src/muuli_wdr.cpp:2929
 msgid "Filter incoming messages (except current chat):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2924
+#: src/muuli_wdr.cpp:2931
 msgid "Filter all messages"
 msgstr "Filtrovat všechny zprávy"
 
-#: src/muuli_wdr.cpp:2926
+#: src/muuli_wdr.cpp:2933
 msgid "Filter messages from people not on your friend list"
 msgstr "Filtrovat zprávy, které nejsou od přátel"
 
-#: src/muuli_wdr.cpp:2928
+#: src/muuli_wdr.cpp:2935
 msgid "Filter messages from unknown clients"
 msgstr "Filtrovat zprávy od neznámých klientů"
 
-#: src/muuli_wdr.cpp:2930
+#: src/muuli_wdr.cpp:2937
 msgid "Filter messages containing (use ',' as separator):"
 msgstr "Filtrovat zprávy obsahující (použijte ',' jako oddělovač):"
 
-#: src/muuli_wdr.cpp:2933 src/muuli_wdr.cpp:2944
+#: src/muuli_wdr.cpp:2940 src/muuli_wdr.cpp:2951
 msgid "add here the words amule should filter and block messages including it"
 msgstr "zadejte slova, která by měla amule filtrovat a blokovat zprávy obsahující je"
 
-#: src/muuli_wdr.cpp:2935
+#: src/muuli_wdr.cpp:2942
 msgid "Show received messages in the log"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2938
+#: src/muuli_wdr.cpp:2945
 msgid "Comments"
 msgstr "Komentáře"
 
-#: src/muuli_wdr.cpp:2941
+#: src/muuli_wdr.cpp:2948
 msgid "Filter comments containing (use ',' as separator):"
 msgstr "Filtrovat komentáře obsahující (použijte ',' jako oddělovač):"
 
-#: src/muuli_wdr.cpp:2966
+#: src/muuli_wdr.cpp:2973
 msgid "Enable Proxy"
 msgstr "Povolit proxy"
 
-#: src/muuli_wdr.cpp:2967
+#: src/muuli_wdr.cpp:2974
 msgid "Enable/disable proxy support"
 msgstr "Povolí/zakáže proxy"
 
-#: src/muuli_wdr.cpp:2970
+#: src/muuli_wdr.cpp:2977
 msgid "Proxy type:"
 msgstr "Typ proxy:"
 
-#: src/muuli_wdr.cpp:2981
+#: src/muuli_wdr.cpp:2988
 msgid "Proxy host:"
 msgstr "Hostitel proxy:"
 
-#: src/muuli_wdr.cpp:2984
+#: src/muuli_wdr.cpp:2991
 msgid "The proxy host name"
 msgstr "Název hostitele proxy"
 
-#: src/muuli_wdr.cpp:2986
+#: src/muuli_wdr.cpp:2993
 msgid "Proxy port:"
 msgstr "Port proxy:"
 
-#: src/muuli_wdr.cpp:2989
+#: src/muuli_wdr.cpp:2996
 msgid "The proxy port"
 msgstr "Port proxy"
 
-#: src/muuli_wdr.cpp:2991
+#: src/muuli_wdr.cpp:2998
 msgid "Enable authentication"
 msgstr "Povolit autentizaci"
 
-#: src/muuli_wdr.cpp:2992
+#: src/muuli_wdr.cpp:2999
 msgid "Enable/disable username/password authentication"
 msgstr "Povolí/zakáže autentizaci (uživatelské jméno a heslo)"
 
-#: src/muuli_wdr.cpp:2995
+#: src/muuli_wdr.cpp:3002
 msgid "Username: "
 msgstr "Uživatelské jméno: "
 
-#: src/muuli_wdr.cpp:2998
+#: src/muuli_wdr.cpp:3005
 msgid "The username to use to connect to the proxy"
 msgstr "Uživatelské jméno, které se použije pro přihlášení k proxy"
 
-#: src/muuli_wdr.cpp:3000
+#: src/muuli_wdr.cpp:3007
 msgid "Password:"
 msgstr "Heslo:"
 
-#: src/muuli_wdr.cpp:3003
+#: src/muuli_wdr.cpp:3010
 msgid "The password to use to connect to the proxy"
 msgstr "Heslo, které se použije pro přihlášení k proxy"
 
-#: src/muuli_wdr.cpp:3022
+#: src/muuli_wdr.cpp:3029
 msgid "Connect to:"
 msgstr "Připojit se k:"
 
-#: src/muuli_wdr.cpp:3031
+#: src/muuli_wdr.cpp:3038
 msgid "Login to remote amule"
 msgstr "Připojit k vzdálené aMuli"
 
-#: src/muuli_wdr.cpp:3036
+#: src/muuli_wdr.cpp:3043
 msgid "User name"
 msgstr "Uživatelské jméno"
 
-#: src/muuli_wdr.cpp:3047
+#: src/muuli_wdr.cpp:3054
 msgid "Remember those settings"
 msgstr "Zapamatovat si toto nastavení"
 
-#: src/muuli_wdr.cpp:3050
+#: src/muuli_wdr.cpp:3057
 #, fuzzy
 msgid "Force ZLIB compression"
 msgstr "Použít gzip kompresi"
 
-#: src/muuli_wdr.cpp:3074
+#: src/muuli_wdr.cpp:3081
 msgid "Enable Verbose Debug-Logging."
 msgstr ""
 
-#: src/muuli_wdr.cpp:3076
+#: src/muuli_wdr.cpp:3083
 #, fuzzy
 msgid "Only to Logfile"
 msgstr "&Otevřít tento soubor"
 
-#: src/muuli_wdr.cpp:3078
+#: src/muuli_wdr.cpp:3085
 msgid "Message Categories:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3102 src/PartFileConvertDlg.cpp:160
+#: src/muuli_wdr.cpp:3109 src/PartFileConvertDlg.cpp:160
 msgid "Waiting..."
 msgstr "Čekání..."
 
-#: src/muuli_wdr.cpp:3122
+#: src/muuli_wdr.cpp:3129
 msgid "Add imports"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3125
+#: src/muuli_wdr.cpp:3132
 msgid "Retry selected"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3127
+#: src/muuli_wdr.cpp:3134
 msgid "Remove selected"
 msgstr "Odstranit vybrané"
 
-#: src/muuli_wdr.cpp:3190
+#: src/muuli_wdr.cpp:3197
 msgid "Event Types"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3209
+#: src/muuli_wdr.cpp:3216
 msgid "Statistics and queued clients for selected file(s) : Session / All time"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3233
+#: src/muuli_wdr.cpp:3240
 msgid "Active Uploads"
 msgstr "Aktivní odesílání"
 
-#: src/muuli_wdr.cpp:3247
+#: src/muuli_wdr.cpp:3254
 msgid "Percent of total files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3299
+#: src/muuli_wdr.cpp:3306
 #, fuzzy
 msgid "Show Clients for"
 msgstr "Zobrazit klienty"
 
-#: src/muuli_wdr.cpp:3301
+#: src/muuli_wdr.cpp:3308
 #, fuzzy
 msgid "All files"
 msgstr "Všechny sdílené soubory"
 
-#: src/muuli_wdr.cpp:3304
+#: src/muuli_wdr.cpp:3311
 #, fuzzy
 msgid "Selected files"
 msgstr "Sdílené soubory"
 
-#: src/muuli_wdr.cpp:3307
+#: src/muuli_wdr.cpp:3314
 #, fuzzy
 msgid "Active uploads only"
 msgstr "Aktivní odesílání"
 
-#: src/muuli_wdr.cpp:3314
+#: src/muuli_wdr.cpp:3321
 msgid "Reload:"
 msgstr "Obnovit:"
 
-#: src/muuli_wdr.cpp:3318
+#: src/muuli_wdr.cpp:3325
 msgid "Reload your shared files"
 msgstr "Znovu načíst vaše sdílené soubory"
 
-#: src/muuli_wdr.cpp:3381
+#: src/muuli_wdr.cpp:3388
 msgid "Send"
 msgstr "Odeslat"
 
-#: src/muuli_wdr.cpp:3382
+#: src/muuli_wdr.cpp:3389
 msgid "Sends the specified message."
 msgstr "Odešle zadanou zprávu."
 
-#: src/muuli_wdr.cpp:3386
+#: src/muuli_wdr.cpp:3393
 msgid "Close this chat-session."
 msgstr "Zavře tento chat."
 
-#: src/muuli_wdr.cpp:3409
+#: src/muuli_wdr.cpp:3416
 msgid "Connect to any server and/or Kad"
 msgstr "Připojit k nějakému serveru a/nebo Kadu"
 
-#: src/muuli_wdr.cpp:3415 src/SharedFilesCtrl.cpp:142 src/Statistics.cpp:941
+#: src/muuli_wdr.cpp:3422 src/SharedFilesCtrl.cpp:142 src/Statistics.cpp:941
 msgid "Shared Files"
 msgstr "Sdílené soubory"
 
@@ -5430,189 +5444,189 @@ msgstr "Staženo"
 msgid "ERROR: Failed to open partfile '%s'"
 msgstr ""
 
-#: src/Preferences.cpp:673
+#: src/Preferences.cpp:674
 msgid "System default"
 msgstr "Výchozí pro systém"
 
-#: src/Preferences.cpp:674
+#: src/Preferences.cpp:675
 msgid "Albanian"
 msgstr "Albánština"
 
-#: src/Preferences.cpp:675
+#: src/Preferences.cpp:676
 msgid "Arabic"
 msgstr "Arabský"
 
-#: src/Preferences.cpp:676
+#: src/Preferences.cpp:677
 msgid "Asturian"
 msgstr ""
 
-#: src/Preferences.cpp:677
+#: src/Preferences.cpp:678
 msgid "Basque"
 msgstr "Baskičtina"
 
-#: src/Preferences.cpp:678
+#: src/Preferences.cpp:679
 msgid "Bulgarian"
 msgstr "Bulharský"
 
-#: src/Preferences.cpp:679
+#: src/Preferences.cpp:680
 msgid "Catalan"
 msgstr "Katalánština"
 
-#: src/Preferences.cpp:680
+#: src/Preferences.cpp:681
 msgid "Chinese (Simplified)"
 msgstr "Čínština (zjednodušená)"
 
-#: src/Preferences.cpp:681
+#: src/Preferences.cpp:682
 msgid "Chinese (Traditional)"
 msgstr "Čínština (tradiční)"
 
-#: src/Preferences.cpp:682
+#: src/Preferences.cpp:683
 msgid "Croatian"
 msgstr "Chorvatština"
 
-#: src/Preferences.cpp:683
+#: src/Preferences.cpp:684
 msgid "Czech"
 msgstr "Česky"
 
-#: src/Preferences.cpp:684
+#: src/Preferences.cpp:685
 msgid "Danish"
 msgstr "Dánština"
 
-#: src/Preferences.cpp:685
+#: src/Preferences.cpp:686
 msgid "Dutch"
 msgstr "Nizozemština"
 
-#: src/Preferences.cpp:686
+#: src/Preferences.cpp:687
 msgid "English (U.K.)"
 msgstr "Angličtina (britská)"
 
-#: src/Preferences.cpp:687
+#: src/Preferences.cpp:688
 #, fuzzy
 msgid "English (U.S.)"
 msgstr "Angličtina (britská)"
 
-#: src/Preferences.cpp:688
+#: src/Preferences.cpp:689
 msgid "Estonian"
 msgstr "Estonština"
 
-#: src/Preferences.cpp:689
+#: src/Preferences.cpp:690
 msgid "Finnish"
 msgstr "Finština"
 
-#: src/Preferences.cpp:690
+#: src/Preferences.cpp:691
 msgid "French"
 msgstr "Francouzština"
 
-#: src/Preferences.cpp:691
+#: src/Preferences.cpp:692
 msgid "Galician"
 msgstr "Galicijština"
 
-#: src/Preferences.cpp:692
+#: src/Preferences.cpp:693
 msgid "German"
 msgstr "Němčina"
 
-#: src/Preferences.cpp:693
+#: src/Preferences.cpp:694
 msgid "Greek"
 msgstr "Řečtina"
 
-#: src/Preferences.cpp:694
+#: src/Preferences.cpp:695
 msgid "Hebrew"
 msgstr "Hebrejština"
 
-#: src/Preferences.cpp:695
+#: src/Preferences.cpp:696
 msgid "Hungarian"
 msgstr "Maďarština"
 
-#: src/Preferences.cpp:696
+#: src/Preferences.cpp:697
 msgid "Italian"
 msgstr "Italština"
 
-#: src/Preferences.cpp:697
+#: src/Preferences.cpp:698
 msgid "Japanese"
 msgstr "Japonština"
 
-#: src/Preferences.cpp:698
+#: src/Preferences.cpp:699
 msgid "Korean"
 msgstr "Korejština"
 
-#: src/Preferences.cpp:699
+#: src/Preferences.cpp:700
 msgid "Latvian"
 msgstr ""
 
-#: src/Preferences.cpp:700
+#: src/Preferences.cpp:701
 msgid "Lithuanian"
 msgstr "Litevština"
 
-#: src/Preferences.cpp:701
+#: src/Preferences.cpp:702
 msgid "Norwegian (Nynorsk)"
 msgstr "Norština"
 
-#: src/Preferences.cpp:702
+#: src/Preferences.cpp:703
 msgid "Polish"
 msgstr "Polština"
 
-#: src/Preferences.cpp:703
+#: src/Preferences.cpp:704
 msgid "Portuguese"
 msgstr "Portugalština"
 
-#: src/Preferences.cpp:704
+#: src/Preferences.cpp:705
 msgid "Portuguese (Brazilian)"
 msgstr "Portugalština (brazilská)"
 
-#: src/Preferences.cpp:705
+#: src/Preferences.cpp:706
 msgid "Romanian"
 msgstr "Rumunština"
 
-#: src/Preferences.cpp:706
+#: src/Preferences.cpp:707
 msgid "Russian"
 msgstr "Ruština"
 
-#: src/Preferences.cpp:707
+#: src/Preferences.cpp:708
 msgid "Slovenian"
 msgstr "Slovinština"
 
-#: src/Preferences.cpp:708
+#: src/Preferences.cpp:709
 msgid "Spanish"
 msgstr "Španělština"
 
-#: src/Preferences.cpp:709
+#: src/Preferences.cpp:710
 msgid "Swedish"
 msgstr "Švédština"
 
-#: src/Preferences.cpp:710
+#: src/Preferences.cpp:711
 msgid "Turkish"
 msgstr "Turečtina"
 
-#: src/Preferences.cpp:711
+#: src/Preferences.cpp:712
 msgid "Ukrainian"
 msgstr "Ukrajinština"
 
-#: src/Preferences.cpp:814
+#: src/Preferences.cpp:815
 msgid "Change Language"
 msgstr "Změnit jazyk"
 
-#: src/Preferences.cpp:878
+#: src/Preferences.cpp:879
 msgid "There are no translations installed for aMule"
 msgstr ""
 
-#: src/Preferences.cpp:879
+#: src/Preferences.cpp:880
 #, fuzzy
 msgid "No languages available"
 msgstr "Nedostupný"
 
-#: src/Preferences.cpp:1010
+#: src/Preferences.cpp:1011
 msgid "no options available"
 msgstr "není dostupné žádné nastavení"
 
-#: src/Preferences.cpp:2179
+#: src/Preferences.cpp:2182
 msgid "Invalid category found, skipping"
 msgstr "Nalezena neplatná kategorie, přeskakuji"
 
-#: src/Preferences.cpp:2348
+#: src/Preferences.cpp:2351
 msgid "TCP port can't be higher than 65532 due to server UDP socket being TCP+3"
 msgstr "TCP port nemůže být vyšší než 65532, protože UDP port je TCP+3"
 
-#: src/Preferences.cpp:2349
+#: src/Preferences.cpp:2352
 #, c-format
 msgid "Default port will be used (%d)"
 msgstr "Bude použit výchozí port (%d)"
@@ -6120,24 +6134,28 @@ msgstr "Znovu načte seznam sdílených souborů."
 msgid "Shared folder"
 msgstr "Sdílené adresáře"
 
-#: src/SearchDlg.cpp:425
+#: src/SearchDlg.cpp:280
+msgid "Clear search history"
+msgstr ""
+
+#: src/SearchDlg.cpp:584
 msgid "It's impossible to search when both eD2k and Kademlia are disabled."
 msgstr ""
 
-#: src/SearchDlg.cpp:426 src/SearchListCtrl.cpp:858
+#: src/SearchDlg.cpp:585 src/SearchListCtrl.cpp:858
 #, fuzzy
 msgid "Search error"
 msgstr "Vyhledávání"
 
-#: src/SearchDlg.cpp:768
+#: src/SearchDlg.cpp:929
 msgid "Min size must be smaller than max size. Max size ignored."
 msgstr "Min. velikost musí být menší než max. velikost. Ignoruji max. velikost."
 
-#: src/SearchDlg.cpp:769 src/SearchDlg.cpp:851
+#: src/SearchDlg.cpp:930 src/SearchDlg.cpp:1012
 msgid "Search warning"
 msgstr "Varování při vyhledávání"
 
-#: src/SearchDlg.cpp:929 src/SearchListCtrl.cpp:735
+#: src/SearchDlg.cpp:1092 src/SearchListCtrl.cpp:735
 msgid "Main"
 msgstr "Hlavní"
 

--- a/po/cs.po
+++ b/po/cs.po
@@ -9,8 +9,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-28 12:12+0200\n"
-"PO-Revision-Date: 2026-07-27 10:16+0000\n"
+"POT-Creation-Date: 2026-07-28 08:06+0200\n"
+"PO-Revision-Date: 2026-07-27 11:34+0000\n"
 "Last-Translator: David Watzke <david@watzke.cz>\n"
 "Language-Team: cs <cs@li.org>\n"
 "Language: cs\n"
@@ -143,7 +143,7 @@ msgstr ""
 msgid "Not now"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:422 src/amuleDlg.cpp:665
+#: src/AppImageIntegration.cpp:422 src/amuleDlg.cpp:600
 msgid "Don't ask again"
 msgstr ""
 
@@ -201,83 +201,83 @@ msgstr "Selhalo otvírání souboru ED2KLinks."
 msgid "WARNING: You can't add yourself as a source for an eD2k link while having a lowid."
 msgstr "VAROVÁNÍ: Nemůžete přidat sebe jako zdroj pro eD2k odkaz, když máte LowID."
 
-#: src/amule.cpp:301
+#: src/amule.cpp:300
 msgid "Now, exiting main app..."
 msgstr "Ukončuji hlavní aplikaci..."
 
-#: src/amule.cpp:331
+#: src/amule.cpp:330
 #, c-format
 msgid "Terminating amuleweb instance with pid '%d' ... "
 msgstr "Ukončuji instanci amuleweb s PID `%d'..."
 
-#: src/amule.cpp:335
+#: src/amule.cpp:334
 #, c-format
 msgid "Killing amuleweb instance with pid '%d' ... "
 msgstr "Zabíjím instanci amuleweb s PID `%d'..."
 
-#: src/amule.cpp:337 src/amule.cpp:350 src/ClientRef.cpp:180
-#: src/SearchDlg.cpp:1041 src/ServerListCtrl.cpp:98
+#: src/amule.cpp:336 src/amule.cpp:349 src/ClientRef.cpp:180
+#: src/SearchDlg.cpp:880 src/ServerListCtrl.cpp:98
 msgid "Failed"
 msgstr "Selhal"
 
-#: src/amule.cpp:344
+#: src/amule.cpp:343
 #, fuzzy, c-format
 msgid "Terminating amuleapi instance with pid '%d' ... "
 msgstr "Ukončuji instanci amuleweb s PID `%d'..."
 
-#: src/amule.cpp:348
+#: src/amule.cpp:347
 #, fuzzy, c-format
 msgid "Killing amuleapi instance with pid '%d' ... "
 msgstr "Zabíjím instanci amuleweb s PID `%d'..."
 
-#: src/amule.cpp:356
+#: src/amule.cpp:355
 msgid "aMule OnExit: Terminating core."
 msgstr "aMule OnExit: Ukončuji jádro."
 
-#: src/amule.cpp:467
+#: src/amule.cpp:466
 msgid "aMule shutdown completed."
 msgstr "Ukončení aMule dokončeno."
 
-#: src/amule.cpp:471
+#: src/amule.cpp:470
 msgid "Memory debug results for aMule exit:"
 msgstr ""
 
-#: src/amule.cpp:652
+#: src/amule.cpp:651
 #, c-format
 msgid "Binding aMule's peer-to-peer traffic to interface: %s (HTTP updates use the default route)"
 msgstr ""
 
-#: src/amule.cpp:656
+#: src/amule.cpp:655
 #, c-format
 msgid "Binding all network traffic to interface: %s"
 msgstr ""
 
-#: src/amule.cpp:660
+#: src/amule.cpp:659
 #, c-format
 msgid "WARNING: configured network interface '%s' was not found - traffic is NOT bound to it and may leave via the default route. Check the interface name in Preferences."
 msgstr ""
 
-#: src/amule.cpp:666
+#: src/amule.cpp:665
 #, c-format
 msgid "WARNING: binding to network interface '%s' requires elevated privileges and was NOT applied - traffic may leave via the default route. Grant the capability (e.g. 'sudo setcap cap_net_raw+ep' on the aMule binary) or run with sufficient privileges."
 msgstr ""
 
-#: src/amule.cpp:674
+#: src/amule.cpp:673
 #, c-format
 msgid "WARNING: could not bind to network interface '%s' - traffic may leave via the default route."
 msgstr ""
 
-#: src/amule.cpp:733
+#: src/amule.cpp:732
 msgid "Your locale has been changed to System Default due to a configuration change. Sorry."
 msgstr "Vaše nastavení locale bylo změněno na výchozí systémové nastavení kvůli změně v konfiguraci. Pardon."
 
-#: src/amule.cpp:735 src/amule.cpp:1589 src/CatDialog.cpp:128
+#: src/amule.cpp:734 src/amule.cpp:1581 src/CatDialog.cpp:128
 #: src/CatDialog.cpp:136 src/CatDialog.cpp:149 src/ServerList.cpp:366
 #: src/ServerListCtrl.cpp:152
 msgid "Info"
 msgstr "Info"
 
-#: src/amule.cpp:742
+#: src/amule.cpp:741
 msgid ""
 "\n"
 "EC configuration"
@@ -285,71 +285,71 @@ msgstr ""
 "\n"
 "Konfigurace EC"
 
-#: src/amule.cpp:745
+#: src/amule.cpp:744
 msgid "Password set and external connections enabled."
 msgstr "Heslo nastaveno a externí připojení povoleno."
 
-#: src/amule.cpp:755 src/KadDlg.cpp:176 src/KadDlg.cpp:185
-#: src/PrefsUnifiedDlg.cpp:1461 src/SharedFilesCtrl.cpp:476
+#: src/amule.cpp:754 src/KadDlg.cpp:176 src/KadDlg.cpp:185
+#: src/PrefsUnifiedDlg.cpp:1387 src/SharedFilesCtrl.cpp:476
 msgid "WARNING"
 msgstr "VAROVÁNÍ"
 
-#: src/amule.cpp:992
+#: src/amule.cpp:991
 #, fuzzy
 msgid "Network bootstrap"
 msgstr "Sítě"
 
-#: src/amule.cpp:997
+#: src/amule.cpp:996
 msgid ""
 "aMule has detected missing network bootstrap files.\n"
 "Select which ones to download:"
 msgstr ""
 
-#: src/amule.cpp:1006 src/FirstRunWizard.cpp:411
+#: src/amule.cpp:1005 src/FirstRunWizard.cpp:411
 msgid "eD2k server list (server.met)"
 msgstr ""
 
-#: src/amule.cpp:1013 src/FirstRunWizard.cpp:416
+#: src/amule.cpp:1012 src/FirstRunWizard.cpp:416
 msgid "Kad bootstrap nodes (nodes.dat)"
 msgstr ""
 
-#: src/amule.cpp:1103
+#: src/amule.cpp:1102
 #, c-format
 msgid "web server running on pid %d"
 msgstr "webserver běží s PID %d"
 
-#: src/amule.cpp:1116
+#: src/amule.cpp:1115
 msgid "You requested to run web server on startup, but the amuleweb binary cannot be run. Please install the package containing aMule web server, or build aMule from source with -DBUILD_WEBSERVER=YES and install it."
 msgstr ""
 
-#: src/amule.cpp:1121 src/amule.cpp:1185 src/amule.cpp:1299 src/amule.cpp:1601
+#: src/amule.cpp:1120 src/amule.cpp:1177 src/amule.cpp:1291 src/amule.cpp:1593
 #: src/amule-remote-gui.cpp:603 src/amule-remote-gui.cpp:671
 #: src/amule-remote-gui.cpp:709 src/amule-remote-gui.cpp:1282
 #: src/amule-remote-gui.cpp:1345 src/amule-remote-gui.cpp:1372
-#: src/DownloadQueue.cpp:1481 src/PrefsUnifiedDlg.cpp:1247
+#: src/DownloadQueue.cpp:1481
 msgid "ERROR"
 msgstr "CHYBA"
 
-#: src/amule.cpp:1174
+#: src/amule.cpp:1166
 #, fuzzy, c-format
 msgid "amuleapi running on pid %d"
 msgstr "webserver běží s PID %d"
 
-#: src/amule.cpp:1180
+#: src/amule.cpp:1172
 msgid "You requested to run amuleapi on startup, but the amuleapi binary cannot be run. Please install the package containing aMule's REST API server, or build aMule from source with -DBUILD_AMULEAPI=YES and install it."
 msgstr ""
 
-#: src/amule.cpp:1267
+#: src/amule.cpp:1259
 #, c-format
 msgid "Could not bind ports to the specified address: %s"
 msgstr ""
 
-#: src/amule.cpp:1291
+#: src/amule.cpp:1283
 #, c-format
 msgid "Port %u is not available. You will be LOWID\n"
 msgstr "Port %u je nedostupný. Budete mít LowID\n"
 
-#: src/amule.cpp:1296
+#: src/amule.cpp:1288
 #, c-format
 msgid ""
 "Port %u is not available!\n"
@@ -364,184 +364,184 @@ msgstr ""
 "\n"
 "Zkontrolujte nastavení vaší sítě a ujistěte se, že je port v obou směrech otevřený."
 
-#: src/amule.cpp:1393
+#: src/amule.cpp:1385
 msgid "Failed to create OnlineSig File"
 msgstr "Selhalo vytvoření OnlineSig souboru"
 
-#: src/amule.cpp:1401
+#: src/amule.cpp:1393
 msgid "Failed to create aMule OnlineSig File"
 msgstr "Selhalo vytvoření aMule OnlineSig souboru"
 
-#: src/amule.cpp:1564
+#: src/amule.cpp:1556
 msgid "The selected locale seems not to be installed on your box. (Note: I'll try to set it anyway)"
 msgstr ""
 
-#: src/amule.cpp:1574
+#: src/amule.cpp:1566
 #, c-format
 msgid "This is the first time you run aMule %s"
 msgstr "Toto je vaše první spuštění aMule %s"
 
-#: src/amule.cpp:1577
+#: src/amule.cpp:1569
 msgid "This version is a testing version, updated daily, and\n"
 msgstr "Toto je testovací verze, která je denně aktualizovaná a\n"
 
-#: src/amule.cpp:1578
+#: src/amule.cpp:1570
 msgid "we give no warranty it won't break anything, burn your house,\n"
 msgstr "my nezaručujeme, že nemůže nic pokazit, zapálit váš dům,\n"
 
-#: src/amule.cpp:1579
+#: src/amule.cpp:1571
 msgid "or kill your dog. But it *should* be safe to use anyway.\n"
 msgstr "nebo zabít vašeho psa. Nicméně i tak by *mělo* být její používání bezpečné.\n"
 
-#: src/amule.cpp:1584
+#: src/amule.cpp:1576
 msgid "More information, support and new releases can found at our homepage,\n"
 msgstr "Více informací, podporu a nová vydání naleznete na naší domovské stránce,\n"
 
-#: src/amule.cpp:1585
+#: src/amule.cpp:1577
 msgid "at https://amule-org.github.io, or in our IRC channel #aMule at irc.libera.chat.\n"
 msgstr "na https://amule-org.github.io, nebo na našem IRC kanálu #aMule na irc.libera.chat.\n"
 
-#: src/amule.cpp:1587
+#: src/amule.cpp:1579
 msgid "Feel free to report any bugs to https://github.com/amule-org/amule/issues"
 msgstr "Hlašte chyby na adrese https://github.com/amule-org/amule/issues"
 
-#: src/amule.cpp:1599
+#: src/amule.cpp:1591
 msgid ""
 "The folder for Online Signature files you specified is INVALID!\n"
 " OnlineSignature will be DISABLED until you fix it on preferences."
 msgstr ""
 
-#: src/amule.cpp:1662
+#: src/amule.cpp:1654
 msgid "Server hostname notified"
 msgstr ""
 
-#: src/amule.cpp:2039
+#: src/amule.cpp:2031
 #, c-format
 msgid "Disk space preallocation for file '%s' failed: %s"
 msgstr "Předalokace místa na disku pro soubor '%s' selhala: %s"
 
-#: src/amule.cpp:2168
+#: src/amule.cpp:2160
 msgid "ERROR: can't open logfile"
 msgstr "CHYBA: nelze otevřít logovací soubor"
 
-#: src/amule.cpp:2172
+#: src/amule.cpp:2164
 msgid "WARNING: logfile is empty. Something is wrong."
 msgstr "VAROVÁNÍ: log je prázdný. Něco je špatně."
 
-#: src/amule.cpp:2189
+#: src/amule.cpp:2181
 msgid "Log has been reset"
 msgstr "Log byl vymazán"
 
-#: src/amule.cpp:2213
+#: src/amule.cpp:2205
 #, c-format
 msgid "ServerMessage: %s"
 msgstr "Zpráva od serveru: %s"
 
-#: src/amule.cpp:2256 src/IP2Country.cpp:220 src/IPFilter.cpp:514
+#: src/amule.cpp:2248 src/IP2Country.cpp:220 src/IPFilter.cpp:514
 #: src/ServerList.cpp:875
 #, c-format
 msgid "Skipped download of %s, because requested file is not newer."
 msgstr ""
 
-#: src/amule.cpp:2259
+#: src/amule.cpp:2251
 msgid "Failed to download the nodes list."
 msgstr "Selhalo stahování seznamu uzlů."
 
-#: src/amule.cpp:2322
+#: src/amule.cpp:2314
 msgid "Failed to open the downloaded version check file"
 msgstr "Selhalo otvírání staženého kontrolního souboru s verzí"
 
-#: src/amule.cpp:2325 src/amule.cpp:2344
+#: src/amule.cpp:2317 src/amule.cpp:2336
 msgid "Corrupted version check file"
 msgstr "Porušený soubor pro kontrolu verze"
 
-#: src/amule.cpp:2367
+#: src/amule.cpp:2359
 msgid "You are using an outdated version of aMule!"
 msgstr "Používáte zastaralou verzi aMule!"
 
-#: src/amule.cpp:2369
+#: src/amule.cpp:2361
 #, c-format
 msgid "Your aMule version is %i.%i.%i and the latest version is %li.%li.%li"
 msgstr "Vaše verze aMule je %i.%i.%i a poslední verze je %li.%li.%li"
 
-#: src/amule.cpp:2373
+#: src/amule.cpp:2365
 msgid "The latest version can always be found at https://github.com/amule-org/amule/releases/latest"
 msgstr "Poslední verze jsou vždy k nalezení na https://github.com/amule-org/amule/releases/latest "
 
-#: src/amule.cpp:2376
+#: src/amule.cpp:2368
 #, c-format
 msgid "WARNING: Your aMuled version is outdated: %i.%i.%i < %li.%li.%li"
 msgstr "VAROVÁNÍ: Vaše verze aMuled je zastaralá: %i.%i.%i < %li.%li.%li"
 
-#: src/amule.cpp:2382
+#: src/amule.cpp:2374
 msgid "Your copy of aMule is up to date."
 msgstr "Vaše verze aMule je aktuální."
 
-#: src/amule.cpp:2389
+#: src/amule.cpp:2381
 msgid "Failed to download the version check file"
 msgstr "Selhalo stahování kontrolního souboru s verzí"
 
-#: src/amule.cpp:2558 src/amule-remote-gui.cpp:1133
+#: src/amule.cpp:2550 src/amule-remote-gui.cpp:1133
 #, c-format
 msgid "Users: %s | Files: %s"
 msgstr "Uživatelů: %s | Souborů: %s"
 
-#: src/amule.cpp:2559 src/amule-remote-gui.cpp:1134
+#: src/amule.cpp:2551 src/amule-remote-gui.cpp:1134
 #, c-format
 msgid "Users: E: %s K: %s | Files: E: %s K: %s"
 msgstr "Uživatelů: E: %s K: %s | Souborů: E: %s K: %s"
 
-#: src/amule.cpp:2573 src/amule-remote-gui.cpp:1147
+#: src/amule.cpp:2565 src/amule-remote-gui.cpp:1147
 msgid "No networks selected"
 msgstr "Nezvoleny žádné sítě"
 
-#: src/amule.cpp:2641 src/TextClient.cpp:903
+#: src/amule.cpp:2633 src/TextClient.cpp:903
 msgid "with LowID"
 msgstr "s LowID"
 
-#: src/amule.cpp:2641 src/TextClient.cpp:904
+#: src/amule.cpp:2633 src/TextClient.cpp:904
 msgid "with HighID"
 msgstr "s HighID"
 
-#: src/amule.cpp:2643
+#: src/amule.cpp:2635
 #, c-format
 msgid "Connected to %s %s"
 msgstr "Připojen k %s %s"
 
-#: src/amule.cpp:2648
+#: src/amule.cpp:2640
 #, c-format
 msgid "Connecting to %s"
 msgstr "Připojování k %s"
 
-#: src/amule.cpp:2650
+#: src/amule.cpp:2642
 msgid "Disconnected from eD2k"
 msgstr "Odpojen od eD2k"
 
-#: src/amule.cpp:2659
+#: src/amule.cpp:2651
 msgid "Kad started."
 msgstr "Kad spuštěn."
 
-#: src/amule.cpp:2661
+#: src/amule.cpp:2653
 msgid "Kad stopped."
 msgstr "Kad zastaven."
 
-#: src/amule.cpp:2669
+#: src/amule.cpp:2661
 msgid "Connected to Kad (ok)"
 msgstr "Připojen ke Kad (ok)"
 
-#: src/amule.cpp:2671
+#: src/amule.cpp:2663
 msgid "Connected to Kad (firewalled)"
 msgstr "Připojen ke kad (za firewallem)"
 
-#: src/amule.cpp:2675
+#: src/amule.cpp:2667
 msgid "Disconnected from Kad"
 msgstr "Odpojen od Kad"
 
-#: src/amule.cpp:2707
+#: src/amule.cpp:2699
 msgid "Kad network cannot be used if UDP port is disabled on preferences, not starting."
 msgstr "Síť Kad nelze použít, když je v nastavení zakázán UDP port."
 
-#: src/amule.cpp:2711
+#: src/amule.cpp:2703
 msgid "Kad network disabled on preferences, not connecting."
 msgstr "Síť Kad je zakázána v nastavení, nepřipojuji se."
 
@@ -567,68 +567,30 @@ msgstr "Nelze vytvořit soubor s PID"
 msgid "ERROR: %s"
 msgstr "CHYBA: %s"
 
-#: src/amuleDlg.cpp:250
+#: src/amuleDlg.cpp:236
 #, c-format
 msgid "This is aMule %s based on eMule."
 msgstr "Toto je aMule %s založená na eMule."
 
-#: src/amuleDlg.cpp:251
+#: src/amuleDlg.cpp:237
 #, c-format
 msgid "Running on %s"
 msgstr "Běží na %s"
 
-#: src/amuleDlg.cpp:253
+#: src/amuleDlg.cpp:239
 msgid "Visit https://github.com/amule-org/amule/releases/latest to check if a new version is available."
 msgstr "Navštivte https://github.com/amule-org/amule/releases/latest  pro kontrolu, jestli není dostupná nová verze."
 
-#: src/amuleDlg.cpp:282
+#: src/amuleDlg.cpp:268
 msgid "FATAL ERROR: Failed to create Timer"
 msgstr "KRITICKÁ CHYBA: Vytváření časovače selhalo"
 
-#: src/amuleDlg.cpp:361 src/amuleDlg.cpp:1810 src/amuleDlg.cpp:2056
-#: src/muuli_wdr.cpp:1492 src/muuli_wdr.cpp:3439
-msgid "Networks"
-msgstr "Sítě"
-
-#: src/amuleDlg.cpp:362 src/amuleDlg.cpp:1816 src/muuli_wdr.cpp:3440
-msgid "Searches"
-msgstr "Vyhledávání"
-
-#: src/amuleDlg.cpp:363 src/amuleDlg.cpp:1822 src/DownloadListCtrl.cpp:740
-#: src/muuli_wdr.cpp:392 src/muuli_wdr.cpp:1585 src/muuli_wdr.cpp:3441
-#: src/Statistics.cpp:829
-msgid "Downloads"
-msgstr "Stahování"
-
-#: src/amuleDlg.cpp:364 src/amuleDlg.cpp:1828 src/muuli_wdr.cpp:3315
-msgid "Shared files"
-msgstr "Sdílené soubory"
-
-#: src/amuleDlg.cpp:365 src/amuleDlg.cpp:1834 src/muuli_wdr.cpp:2947
-#: src/muuli_wdr.cpp:3397 src/muuli_wdr.cpp:3444
-msgid "Messages"
-msgstr "Zprávy"
-
-#: src/amuleDlg.cpp:366 src/amuleDlg.cpp:1840 src/muuli_wdr.cpp:3445
-#: src/PrefsUnifiedDlg.cpp:314 src/Statistics.cpp:779 src/Statistics.cpp:1235
-msgid "Statistics"
-msgstr "Statistiky"
-
-#: src/amuleDlg.cpp:368 src/amuleDlg.cpp:1847 src/muuli_wdr.cpp:3447
-#: src/PrefsUnifiedDlg.cpp:330 src/utils/wxCas/src/wxcasprefs.cpp:39
-msgid "Preferences"
-msgstr "Nastavení"
-
-#: src/amuleDlg.cpp:371
-msgid "Navigate"
-msgstr ""
-
-#: src/amuleDlg.cpp:657
+#: src/amuleDlg.cpp:592
 #, fuzzy
 msgid "New version available"
 msgstr "Nedostupný"
 
-#: src/amuleDlg.cpp:661
+#: src/amuleDlg.cpp:596
 #, fuzzy, c-format
 msgid ""
 "A new version of aMule (%s) is available.\n"
@@ -638,185 +600,218 @@ msgid ""
 "Would you like to open the download page?"
 msgstr "Poslední verze jsou vždy k nalezení na https://github.com/amule-org/amule/releases/latest "
 
-#: src/amuleDlg.cpp:743
+#: src/amuleDlg.cpp:678
 msgid "aMule dialog destroyed"
 msgstr "Dialog aMule zničen"
 
-#: src/amuleDlg.cpp:766 src/DataToText.cpp:68 src/IPFilter.cpp:547
+#: src/amuleDlg.cpp:701 src/DataToText.cpp:68 src/IPFilter.cpp:547
 msgid "Connecting"
 msgstr "Připojuji"
 
-#: src/amuleDlg.cpp:958
+#: src/amuleDlg.cpp:893
 msgid "eD2k: Connecting"
 msgstr "eD2k: připojuji"
 
-#: src/amuleDlg.cpp:962
+#: src/amuleDlg.cpp:897
 msgid "eD2k: Disconnected"
 msgstr "eD2k: odpojeno"
 
-#: src/amuleDlg.cpp:968
+#: src/amuleDlg.cpp:903
 msgid "Kad: Firewalled"
 msgstr "Kad: Za firewallem"
 
-#: src/amuleDlg.cpp:972
+#: src/amuleDlg.cpp:907
 msgid "Kad: Connected"
 msgstr "Kad: Připojen"
 
-#: src/amuleDlg.cpp:977
+#: src/amuleDlg.cpp:912
 msgid "Kad: Connecting"
 msgstr "Kad: Připojuji"
 
-#: src/amuleDlg.cpp:981
+#: src/amuleDlg.cpp:916
 msgid "Kad: Off"
 msgstr "Kad: vypnut"
 
-#: src/amuleDlg.cpp:1029 src/DownloadListCtrl.cpp:505
+#: src/amuleDlg.cpp:964 src/DownloadListCtrl.cpp:505
 #: src/DownloadListCtrl.cpp:749 src/FriendListCtrl.cpp:180
 #: src/muuli_wdr.cpp:731 src/muuli_wdr.cpp:782 src/muuli_wdr.cpp:846
-#: src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2252 src/muuli_wdr.cpp:2337
-#: src/muuli_wdr.cpp:3085 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
+#: src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2224 src/muuli_wdr.cpp:2309
+#: src/muuli_wdr.cpp:3057 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
 #: src/ServerListCtrl.cpp:606 src/TransferWnd.cpp:378
 #: src/utils/wxCas/src/wxcasprefs.cpp:235
 msgid "Cancel"
 msgstr "Zrušit"
 
-#: src/amuleDlg.cpp:1030
+#: src/amuleDlg.cpp:965
 msgid "Stop the current connection attempts"
 msgstr "Zastaví aktuální pokusy o připojení"
 
-#: src/amuleDlg.cpp:1035 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976
-#: src/muuli_wdr.cpp:2475
+#: src/amuleDlg.cpp:970 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976
+#: src/muuli_wdr.cpp:2447
 msgid "Disconnect"
 msgstr "Odpojit"
 
-#: src/amuleDlg.cpp:1036
+#: src/amuleDlg.cpp:971
 msgid "Disconnect from the currently connected networks"
 msgstr "Odpojit se od aktuálně připojených sítí"
 
-#: src/amuleDlg.cpp:1041 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979
-#: src/muuli_wdr.cpp:2630 src/muuli_wdr.cpp:3082 src/muuli_wdr.cpp:3437
+#: src/amuleDlg.cpp:976 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979
+#: src/muuli_wdr.cpp:2602 src/muuli_wdr.cpp:3054 src/muuli_wdr.cpp:3409
 msgid "Connect"
 msgstr "Připojit"
 
-#: src/amuleDlg.cpp:1042
+#: src/amuleDlg.cpp:977
 msgid "Connect to the currently enabled networks"
 msgstr "Připojit se k povoleným sítím"
 
-#: src/amuleDlg.cpp:1154
+#: src/amuleDlg.cpp:1089
 #, fuzzy, c-format
 msgid "Up: %.1f%s (%.1f) | Down: %.1f%s (%.1f)"
 msgstr "Od: %.1f(%.1f) | St: %.1f(%.1f)"
 
-#: src/amuleDlg.cpp:1156 src/amuleDlg.cpp:1158 src/amuleDlg.cpp:1162
-#: src/amuleDlg.cpp:1164 src/amuleDlg.cpp:1175 src/amuleDlg.cpp:1177
+#: src/amuleDlg.cpp:1091 src/amuleDlg.cpp:1093 src/amuleDlg.cpp:1097
+#: src/amuleDlg.cpp:1099 src/amuleDlg.cpp:1110 src/amuleDlg.cpp:1112
 #: src/MuleTrayIcon.cpp:796 src/MuleTrayIcon.cpp:799
 #, fuzzy
 msgid " MB/s"
 msgstr "MB/s"
 
-#: src/amuleDlg.cpp:1156 src/amuleDlg.cpp:1158 src/amuleDlg.cpp:1162
-#: src/amuleDlg.cpp:1164 src/amuleDlg.cpp:1175 src/amuleDlg.cpp:1177
+#: src/amuleDlg.cpp:1091 src/amuleDlg.cpp:1093 src/amuleDlg.cpp:1097
+#: src/amuleDlg.cpp:1099 src/amuleDlg.cpp:1110 src/amuleDlg.cpp:1112
 #: src/MuleTrayIcon.cpp:796 src/MuleTrayIcon.cpp:799
 #: src/utils/wxCas/src/wxcasframe.cpp:1041
 msgid " kB/s"
 msgstr " kB/s"
 
-#: src/amuleDlg.cpp:1161
+#: src/amuleDlg.cpp:1096
 #, fuzzy, c-format
 msgid "Up: %.1f%s | Down: %.1f%s"
 msgstr "Od: %.1f | St: %.1f"
 
-#: src/amuleDlg.cpp:1193
+#: src/amuleDlg.cpp:1128
 #, c-format
 msgid "aMule (%s | Connected)"
 msgstr "aMule (%s | připojen)"
 
-#: src/amuleDlg.cpp:1195
+#: src/amuleDlg.cpp:1130
 #, c-format
 msgid "aMule (%s | Disconnected)"
 msgstr "aMule (%s | odpojen)"
 
-#: src/amuleDlg.cpp:1248
+#: src/amuleDlg.cpp:1183
 #, c-format
 msgid "Do you really want to exit %s?"
 msgstr "Opravdu si přejete ukončit %s?"
 
-#: src/amuleDlg.cpp:1250
+#: src/amuleDlg.cpp:1185
 msgid "Exit confirmation"
 msgstr "Potvrzení ukončení"
 
-#: src/amuleDlg.cpp:1613
+#: src/amuleDlg.cpp:1548
 msgid "Launch Command: "
 msgstr "Spustit příkaz: "
 
-#: src/amuleDlg.cpp:1632 src/muuli_wdr.cpp:1972 src/Preferences.cpp:979
+#: src/amuleDlg.cpp:1567 src/muuli_wdr.cpp:1971 src/Preferences.cpp:951
 msgid "- default -"
 msgstr "- výchozí -"
 
-#: src/amuleDlg.cpp:1660
+#: src/amuleDlg.cpp:1595
 #, c-format
 msgid "Skin directory '%s' does not exist"
 msgstr "Adresář se skiny '%s' neexistuje"
 
-#: src/amuleDlg.cpp:1663
+#: src/amuleDlg.cpp:1598
 #, c-format
 msgid "WARNING: Unable to open skin file '%s' for read"
 msgstr "VAROVÁNÍ: Nelze otevřít soubor se vzhledem '%s' pro čtení"
 
-#: src/amuleDlg.cpp:1814 src/muuli_wdr.cpp:3439
+#: src/amuleDlg.cpp:1722 src/amuleDlg.cpp:1968 src/muuli_wdr.cpp:1485
+#: src/muuli_wdr.cpp:3411
+msgid "Networks"
+msgstr "Sítě"
+
+#: src/amuleDlg.cpp:1726 src/muuli_wdr.cpp:3411
 msgid "Networks Window"
 msgstr "Okno sítí"
 
-#: src/amuleDlg.cpp:1820 src/muuli_wdr.cpp:3440
+#: src/amuleDlg.cpp:1728 src/muuli_wdr.cpp:3412
+msgid "Searches"
+msgstr "Vyhledávání"
+
+#: src/amuleDlg.cpp:1732 src/muuli_wdr.cpp:3412
 msgid "Searches Window"
 msgstr "Vyhledávací okno"
 
-#: src/amuleDlg.cpp:1826 src/muuli_wdr.cpp:3441
+#: src/amuleDlg.cpp:1734 src/DownloadListCtrl.cpp:740 src/muuli_wdr.cpp:392
+#: src/muuli_wdr.cpp:1578 src/muuli_wdr.cpp:3413 src/Statistics.cpp:829
+msgid "Downloads"
+msgstr "Stahování"
+
+#: src/amuleDlg.cpp:1738 src/muuli_wdr.cpp:3413
 msgid "Downloads Window"
 msgstr "Stahování"
 
-#: src/amuleDlg.cpp:1832 src/muuli_wdr.cpp:3443
+#: src/amuleDlg.cpp:1740 src/muuli_wdr.cpp:3287
+msgid "Shared files"
+msgstr "Sdílené soubory"
+
+#: src/amuleDlg.cpp:1744 src/muuli_wdr.cpp:3415
 msgid "Shared Files Window"
 msgstr "Okno se sdílenými soubory"
 
-#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3444
+#: src/amuleDlg.cpp:1746 src/muuli_wdr.cpp:2919 src/muuli_wdr.cpp:3369
+#: src/muuli_wdr.cpp:3416
+msgid "Messages"
+msgstr "Zprávy"
+
+#: src/amuleDlg.cpp:1750 src/muuli_wdr.cpp:3416
 msgid "Messages Window"
 msgstr "Okno zpráv"
 
-#: src/amuleDlg.cpp:1844 src/muuli_wdr.cpp:3445
+#: src/amuleDlg.cpp:1752 src/muuli_wdr.cpp:3417 src/PrefsUnifiedDlg.cpp:312
+#: src/Statistics.cpp:779 src/Statistics.cpp:1235
+msgid "Statistics"
+msgstr "Statistiky"
+
+#: src/amuleDlg.cpp:1756 src/muuli_wdr.cpp:3417
 msgid "Statistics Graph Window"
 msgstr "Okno se statistikami"
 
-#: src/amuleDlg.cpp:1851 src/muuli_wdr.cpp:3447
+#: src/amuleDlg.cpp:1759 src/muuli_wdr.cpp:3419 src/PrefsUnifiedDlg.cpp:328
+#: src/utils/wxCas/src/wxcasprefs.cpp:39
+msgid "Preferences"
+msgstr "Nastavení"
+
+#: src/amuleDlg.cpp:1763 src/muuli_wdr.cpp:3419
 msgid "Preferences Settings Window"
 msgstr "Okno s nastavením"
 
-#: src/amuleDlg.cpp:1854 src/muuli_wdr.cpp:3448
+#: src/amuleDlg.cpp:1766 src/muuli_wdr.cpp:3420
 msgid "Import"
 msgstr "Import"
 
-#: src/amuleDlg.cpp:1858 src/muuli_wdr.cpp:3448
+#: src/amuleDlg.cpp:1770 src/muuli_wdr.cpp:3420
 msgid "The partfile importer tool"
 msgstr "Nástroj pro import částečných souborů"
 
-#: src/amuleDlg.cpp:1861 src/muuli_wdr.cpp:3449
+#: src/amuleDlg.cpp:1773 src/muuli_wdr.cpp:3421
 #: src/utils/aLinkCreator/src/alcframe.cpp:262
 msgid "About"
 msgstr "O programu"
 
-#: src/amuleDlg.cpp:1861 src/muuli_wdr.cpp:3449
+#: src/amuleDlg.cpp:1773 src/muuli_wdr.cpp:3421
 msgid "About/Help"
 msgstr "O programu/Nápověda"
 
-#: src/amuleDlg.cpp:2059
+#: src/amuleDlg.cpp:1971
 msgid "eD2k network"
 msgstr "Síť eD2k"
 
-#: src/amuleDlg.cpp:2062
+#: src/amuleDlg.cpp:1974
 msgid "Kad network"
 msgstr "Síť Kad"
 
-#: src/amuleDlg.cpp:2062
+#: src/amuleDlg.cpp:1974
 msgid "No network"
 msgstr "Žádná síť"
 
@@ -946,7 +941,7 @@ msgstr "Soubor nenalezen."
 msgid "The core rejected these shared folders:%s"
 msgstr ""
 
-#: src/amule-remote-gui.cpp:1336 src/ExternalConn.cpp:2346
+#: src/amule-remote-gui.cpp:1336 src/ExternalConn.cpp:2345
 msgid "Invalid link or already on list."
 msgstr "Neplatný odkaz, nebo je již v seznamu."
 
@@ -962,7 +957,7 @@ msgstr ""
 #: src/ClientDetailDialog.cpp:123 src/DataToText.cpp:61 src/DataToText.cpp:86
 #: src/DataToText.cpp:101 src/DataToText.cpp:136 src/DataToText.cpp:165
 #: src/DownloadListCtrl.cpp:1172 src/DownloadListCtrl.cpp:1185
-#: src/DownloadListCtrl.cpp:1196 src/ExternalConn.cpp:609
+#: src/DownloadListCtrl.cpp:1196 src/ExternalConn.cpp:608
 #: src/FileDetailDialog.cpp:203 src/FileDetailDialog.cpp:235
 #: src/FileDetailDialog.cpp:242 src/GenericClientListCtrl.cpp:1171
 #: src/GenericClientListCtrl.cpp:1182 src/GenericClientListCtrl.cpp:1192
@@ -1354,19 +1349,19 @@ msgstr "Auto [Vy]"
 msgid "Very low"
 msgstr "Velmi nízká"
 
-#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:743 src/muuli_wdr.cpp:2303
+#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:743 src/muuli_wdr.cpp:2275
 #: src/ServerListCtrl.cpp:263 src/ServerListCtrl.cpp:456
 #: src/SharedFilesCtrl.cpp:145
 msgid "Low"
 msgstr "Nízká"
 
-#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:744 src/muuli_wdr.cpp:2304
+#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:744 src/muuli_wdr.cpp:2276
 #: src/ServerListCtrl.cpp:266 src/ServerListCtrl.cpp:457
 #: src/SharedFilesCtrl.cpp:146
 msgid "Normal"
 msgstr "Normální"
 
-#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:745 src/muuli_wdr.cpp:2305
+#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:745 src/muuli_wdr.cpp:2277
 #: src/ServerListCtrl.cpp:269 src/ServerListCtrl.cpp:458
 #: src/SharedFilesCtrl.cpp:147
 msgid "High"
@@ -1458,8 +1453,8 @@ msgstr "Lokální server"
 msgid "Remote Server"
 msgstr "Vzdálený server"
 
-#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3202
-#: src/SearchDlg.cpp:119 src/TextClient.cpp:911
+#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3174
+#: src/SearchDlg.cpp:111 src/TextClient.cpp:911
 msgid "Kad"
 msgstr "Kad"
 
@@ -1530,7 +1525,7 @@ msgstr "Část"
 msgid "Size"
 msgstr "Velikost"
 
-#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3269
+#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3241
 msgid "Transferred"
 msgstr "Přeneseno"
 
@@ -1588,7 +1583,7 @@ msgstr ""
 "Odezva od: %s (%s)\n"
 "\n"
 
-#: src/DownloadListCtrl.cpp:746 src/muuli_wdr.cpp:2306
+#: src/DownloadListCtrl.cpp:746 src/muuli_wdr.cpp:2278
 #: src/SharedFilesCtrl.cpp:150
 msgid "Auto"
 msgstr "Auto"
@@ -1626,7 +1621,7 @@ msgid "Extended Options"
 msgstr "Rozšířené nastavení"
 
 #: src/DownloadListCtrl.cpp:770 src/DownloadListCtrl.cpp:822
-#: src/muuli_wdr.cpp:1790
+#: src/muuli_wdr.cpp:1789
 msgid "Preview"
 msgstr "Náhled"
 
@@ -1801,232 +1796,227 @@ msgstr[2] ""
 msgid "Invalid eD2k link! ERROR: %s"
 msgstr "Neplatný eD2k odkaz! CHYBA: %s"
 
-#: src/ExternalConn.cpp:380
+#: src/ExternalConn.cpp:379
 msgid "Client sent packet after authentication failed."
 msgstr "Klient odeslal paket poté, co selhala autentizace."
 
-#: src/ExternalConn.cpp:397
+#: src/ExternalConn.cpp:396
 msgid "External connection closed."
 msgstr "Externí připojení uzavřeno."
 
-#: src/ExternalConn.cpp:474
+#: src/ExternalConn.cpp:473
 msgid "External connections disabled due to empty password!"
 msgstr "Externí připojení jsou zakázány kvůli prázdnému heslu!"
 
-#: src/ExternalConn.cpp:495
+#: src/ExternalConn.cpp:494
 msgid "External connections disabled in config file"
 msgstr "Externí připojení jsou zakázány v konfiguračním souboru"
 
-#: src/ExternalConn.cpp:576
+#: src/ExternalConn.cpp:575
 msgid "New external connection accepted"
 msgstr "Nové externí připojení přijato"
 
-#: src/ExternalConn.cpp:579
+#: src/ExternalConn.cpp:578
 msgid "ERROR: couldn't accept a new external connection"
 msgstr ""
 
-#: src/ExternalConn.cpp:596
+#: src/ExternalConn.cpp:595
 msgid "External connection refused due to empty password in preferences!"
 msgstr "Externí připojení odmítnuto kvůli prázdnému heslu v nastavení!"
 
-#: src/ExternalConn.cpp:608
+#: src/ExternalConn.cpp:607
 #, c-format
 msgid "Connecting client: %s %s"
 msgstr "Připojuji klienta: %s %s"
 
-#: src/ExternalConn.cpp:610
+#: src/ExternalConn.cpp:609
 msgid "Unknown version"
 msgstr "Neznámá verze"
 
-#: src/ExternalConn.cpp:623
+#: src/ExternalConn.cpp:622
 msgid "Incorrect EC version ID, there might be binary incompatibility. Use core and remote from same snapshot."
 msgstr ""
 
-#: src/ExternalConn.cpp:631
+#: src/ExternalConn.cpp:630
 msgid "You cannot connect to a release version from an arbitrary development snapshot! *sigh* possible crash prevented"
 msgstr ""
 
-#: src/ExternalConn.cpp:714
+#: src/ExternalConn.cpp:713
 msgid "Invalid protocol version."
 msgstr "Neplatná verze protokolu."
 
-#: src/ExternalConn.cpp:720
+#: src/ExternalConn.cpp:719
 msgid "Missing protocol version tag."
 msgstr ""
 
-#: src/ExternalConn.cpp:728
+#: src/ExternalConn.cpp:727
 msgid "Authentication failed: invalid hash specified as EC password."
 msgstr ""
 
-#: src/ExternalConn.cpp:776
+#: src/ExternalConn.cpp:775
 msgid "Authentication failed: wrong password."
 msgstr "Autentizace selhala: nesprávné heslo."
 
-#: src/ExternalConn.cpp:778
+#: src/ExternalConn.cpp:777
 msgid "Authentication failed: missing password."
 msgstr "Autentizace selhala: chybějící heslo."
 
-#: src/ExternalConn.cpp:789
+#: src/ExternalConn.cpp:788
 msgid "Invalid request, please authenticate first."
 msgstr "Neplatný požadavek, nejdřív se prosím autentizujte."
 
-#: src/ExternalConn.cpp:794
+#: src/ExternalConn.cpp:793
 msgid "Access granted."
 msgstr "Přistup povolen."
 
-#: src/ExternalConn.cpp:802
+#: src/ExternalConn.cpp:801
 #, c-format
 msgid "Sent error message \"%s\" to client."
 msgstr "Odeslána chybová hláška \"%s\" pro klienta."
 
-#: src/ExternalConn.cpp:807
+#: src/ExternalConn.cpp:806
 #, c-format
 msgid "Unauthorized access attempt from %s. Connection closed."
 msgstr "Neautorizovaný pokus o přístup z %s. Připojení uzavřeno."
 
-#: src/ExternalConn.cpp:1420
+#: src/ExternalConn.cpp:1419
 #, c-format
 msgid "Remote PartFile command failed: FileHash not found: %s"
 msgstr ""
 
-#: src/ExternalConn.cpp:1424
+#: src/ExternalConn.cpp:1423
 #, c-format
 msgid "FileHash not found: %s"
 msgstr "FileHash nenalezen: %s"
 
-#: src/ExternalConn.cpp:1471 src/ExternalConn.cpp:1559
-#: src/ExternalConn.cpp:1680
+#: src/ExternalConn.cpp:1470 src/ExternalConn.cpp:1558
+#: src/ExternalConn.cpp:1679
 msgid "OOPS! OpCode processing error!"
 msgstr ""
 
-#: src/ExternalConn.cpp:1502
+#: src/ExternalConn.cpp:1501
 msgid "Server not added"
 msgstr "Server nepřidán"
 
-#: src/ExternalConn.cpp:1521
+#: src/ExternalConn.cpp:1520
 #, c-format
 msgid "server not found: %s"
 msgstr "server nenalezen: %s"
 
-#: src/ExternalConn.cpp:1538
+#: src/ExternalConn.cpp:1537
 msgid "need to define server to be removed"
 msgstr ""
 
-#: src/ExternalConn.cpp:1553
+#: src/ExternalConn.cpp:1552
 msgid "eD2k is disabled in preferences."
 msgstr "eD2k je zakázané v nastavení."
 
-#: src/ExternalConn.cpp:1658
+#: src/ExternalConn.cpp:1657
 #, fuzzy
 msgid "Friend not found."
 msgstr "Soubor nenalezen."
 
-#: src/ExternalConn.cpp:1668
+#: src/ExternalConn.cpp:1667
 #, fuzzy
 msgid "Client not found."
 msgstr "Soubor nenalezen."
 
-#: src/ExternalConn.cpp:1674
+#: src/ExternalConn.cpp:1673
 msgid "EC_TAG_FRIEND_SHARED requires EC_TAG_FRIEND or EC_TAG_CLIENT."
 msgstr ""
 
-#: src/ExternalConn.cpp:1992
+#: src/ExternalConn.cpp:1991
 msgid "WebSearch from remote interface makes no sense."
 msgstr ""
 
-#: src/ExternalConn.cpp:2027
+#: src/ExternalConn.cpp:2026
 msgid "Search in progress. Refetch results in a moment!"
 msgstr ""
 
-#: src/ExternalConn.cpp:2266
+#: src/ExternalConn.cpp:2265
 msgid "No points for graph."
 msgstr "Žádné údaje pro graf."
 
-#: src/ExternalConn.cpp:2276
+#: src/ExternalConn.cpp:2275
 msgid "Your client is not configured for this detail level."
 msgstr "Vás klient není nakonfigurován pro tuto úroveň detailů."
 
-#: src/ExternalConn.cpp:2303
+#: src/ExternalConn.cpp:2302
 msgid "External Connection: shutdown requested"
 msgstr ""
 
-#: src/ExternalConn.cpp:2315
+#: src/ExternalConn.cpp:2314
 msgid "Already shutting down."
 msgstr "Již se ukončuji."
 
-#: src/ExternalConn.cpp:2333
+#: src/ExternalConn.cpp:2332
 #, c-format
 msgid "ExternalConn: adding link '%s'."
 msgstr ""
 
-#: src/ExternalConn.cpp:2351
+#: src/ExternalConn.cpp:2350
 #, fuzzy, c-format
 msgid "%d of %d links failed (invalid or already on list)."
 msgstr "Neplatný odkaz, nebo je již v seznamu."
 
-#: src/ExternalConn.cpp:2374
+#: src/ExternalConn.cpp:2373
 msgid "Version check throttled; try again shortly."
 msgstr ""
 
-#: src/ExternalConn.cpp:2379
+#: src/ExternalConn.cpp:2378
 msgid "Version check is not available on this daemon."
 msgstr ""
 
-#: src/ExternalConn.cpp:2509
+#: src/ExternalConn.cpp:2508
 msgid "File not found."
 msgstr "Soubor nenalezen."
 
-#: src/ExternalConn.cpp:2514
+#: src/ExternalConn.cpp:2513
 msgid "Invalid file name."
 msgstr "Neplatný název souboru."
 
-#: src/ExternalConn.cpp:2522
+#: src/ExternalConn.cpp:2521
 msgid "Unable to rename file."
 msgstr "Nelze přejmenovat soubor."
 
-#: src/ExternalConn.cpp:2839
-#, c-format
-msgid "Could not save the amuleapi password: %s"
-msgstr ""
-
-#: src/ExternalConn.cpp:3004 src/ExternalConn.cpp:3032
+#: src/ExternalConn.cpp:2992 src/ExternalConn.cpp:3020
 msgid "Kad is disabled in preferences."
 msgstr "Kad je zakázaný v nastavení."
 
-#: src/ExternalConn.cpp:3045
+#: src/ExternalConn.cpp:3033
 msgid "Already connected to eD2k."
 msgstr "Již připojen k eD2k."
 
-#: src/ExternalConn.cpp:3048
+#: src/ExternalConn.cpp:3036
 msgid "Connecting to eD2k..."
 msgstr "Připojuji se k eD2k..."
 
-#: src/ExternalConn.cpp:3057
+#: src/ExternalConn.cpp:3045
 msgid "Already connected to Kad."
 msgstr "Již jste připojen k síti Kad."
 
-#: src/ExternalConn.cpp:3060
+#: src/ExternalConn.cpp:3048
 msgid "Connecting to Kad..."
 msgstr "Připojuji se k síti Kad..."
 
-#: src/ExternalConn.cpp:3067
+#: src/ExternalConn.cpp:3055
 msgid "All networks are disabled."
 msgstr "Všechny sítě jsou zakázány."
 
-#: src/ExternalConn.cpp:3076
+#: src/ExternalConn.cpp:3064
 msgid "Disconnected from eD2k."
 msgstr "Odpojen od eD2k."
 
-#: src/ExternalConn.cpp:3081
+#: src/ExternalConn.cpp:3069
 msgid "Disconnected from Kad."
 msgstr "Odpojen od Kademlia."
 
-#: src/ExternalConn.cpp:3090
+#: src/ExternalConn.cpp:3078
 #, c-format
 msgid "External Connection: invalid opcode received: %#x"
 msgstr ""
 
-#: src/ExternalConn.cpp:3095
+#: src/ExternalConn.cpp:3083
 msgid "Invalid opcode (wrong protocol version?)"
 msgstr ""
 
@@ -2327,19 +2317,19 @@ msgstr ""
 msgid "eD2k"
 msgstr "eD2k"
 
-#: src/FirstRunWizard.cpp:349 src/muuli_wdr.cpp:1495
+#: src/FirstRunWizard.cpp:349 src/muuli_wdr.cpp:1488
 msgid "Kademlia"
 msgstr "Kademlia"
 
-#: src/FirstRunWizard.cpp:359 src/muuli_wdr.cpp:1423
+#: src/FirstRunWizard.cpp:359 src/muuli_wdr.cpp:1416
 msgid "Standard TCP Port "
 msgstr "Standardní TCP port"
 
-#: src/FirstRunWizard.cpp:365 src/muuli_wdr.cpp:1435
+#: src/FirstRunWizard.cpp:365 src/muuli_wdr.cpp:1428
 msgid "Extended UDP port (Kad / global search) "
 msgstr "Rozšířený UDP port (Kad / globální vyhledávání)"
 
-#: src/FirstRunWizard.cpp:377 src/muuli_wdr.cpp:1442
+#: src/FirstRunWizard.cpp:377 src/muuli_wdr.cpp:1435
 msgid "Enable UPnP for router port forwarding"
 msgstr "Povolit UPnP port forwarding"
 
@@ -2366,7 +2356,7 @@ msgstr ""
 msgid "Your peer lists are already in place - nothing to download."
 msgstr "Soubor %s se již pokoušíte stáhnout"
 
-#: src/FirstRunWizard.cpp:434 src/muuli_wdr.cpp:1540
+#: src/FirstRunWizard.cpp:434 src/muuli_wdr.cpp:1533
 msgid "Auto-update server list at startup"
 msgstr "Automaticky aktualizovat seznam serverů po spuštění"
 
@@ -2412,23 +2402,23 @@ msgid ""
 "want downloads on a different (e.g. larger) disk."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:549 src/FirstRunWizard.cpp:611 src/muuli_wdr.cpp:1702
+#: src/FirstRunWizard.cpp:549 src/FirstRunWizard.cpp:611 src/muuli_wdr.cpp:1701
 msgid "Destination folder for downloads"
 msgstr "Cílový adresář pro stahování"
 
-#: src/FirstRunWizard.cpp:553 src/FirstRunWizard.cpp:569 src/muuli_wdr.cpp:1349
-#: src/muuli_wdr.cpp:1366 src/muuli_wdr.cpp:1677 src/muuli_wdr.cpp:1708
-#: src/muuli_wdr.cpp:1720 src/muuli_wdr.cpp:2790
+#: src/FirstRunWizard.cpp:553 src/FirstRunWizard.cpp:569 src/muuli_wdr.cpp:1342
+#: src/muuli_wdr.cpp:1359 src/muuli_wdr.cpp:1676 src/muuli_wdr.cpp:1707
+#: src/muuli_wdr.cpp:1719 src/muuli_wdr.cpp:2762
 #: src/utils/aLinkCreator/src/alcframe.cpp:135
 #: src/utils/wxCas/src/wxcasprefs.cpp:52 src/utils/wxCas/src/wxcasprefs.cpp:118
 msgid "Browse"
 msgstr "Procházet"
 
-#: src/FirstRunWizard.cpp:559 src/muuli_wdr.cpp:1713
+#: src/FirstRunWizard.cpp:559 src/muuli_wdr.cpp:1712
 msgid "(All files in this folder are shared with other peers)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:565 src/FirstRunWizard.cpp:624 src/muuli_wdr.cpp:1715
+#: src/FirstRunWizard.cpp:565 src/FirstRunWizard.cpp:624 src/muuli_wdr.cpp:1714
 msgid "Folder for temporary download files"
 msgstr ""
 
@@ -2459,7 +2449,7 @@ msgstr ""
 msgid "CRITICAL - no client on StartChatSession"
 msgstr ""
 
-#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2696 src/muuli_wdr.cpp:3373
+#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2668 src/muuli_wdr.cpp:3345
 msgid "Friends"
 msgstr "Kamarádi"
 
@@ -2570,8 +2560,8 @@ msgstr "Nic"
 msgid "No"
 msgstr "Ne"
 
-#: src/GenericClientListCtrl.cpp:1216 src/PrefsUnifiedDlg.cpp:2898
-#: src/PrefsUnifiedDlg.cpp:2948 src/ServerListCtrl.cpp:276
+#: src/GenericClientListCtrl.cpp:1216 src/PrefsUnifiedDlg.cpp:2818
+#: src/PrefsUnifiedDlg.cpp:2868 src/ServerListCtrl.cpp:276
 msgid "Yes"
 msgstr "Ano"
 
@@ -2743,10 +2733,10 @@ msgstr "Neplatný port pro bootstrap"
 msgid "Please fill all fields required"
 msgstr "Prosím vyplňte všechna potřebná pole"
 
-#: src/KadDlg.cpp:192 src/PartFile.cpp:1031 src/PrefsUnifiedDlg.cpp:1134
-#: src/PrefsUnifiedDlg.cpp:1204 src/PrefsUnifiedDlg.cpp:1405
-#: src/PrefsUnifiedDlg.cpp:1663 src/PrefsUnifiedDlg.cpp:1673
-#: src/PrefsUnifiedDlg.cpp:1690 src/PrefsUnifiedDlg.cpp:1738
+#: src/KadDlg.cpp:192 src/PartFile.cpp:1031 src/PrefsUnifiedDlg.cpp:1162
+#: src/PrefsUnifiedDlg.cpp:1331 src/PrefsUnifiedDlg.cpp:1589
+#: src/PrefsUnifiedDlg.cpp:1599 src/PrefsUnifiedDlg.cpp:1616
+#: src/PrefsUnifiedDlg.cpp:1658
 msgid "Message"
 msgstr "Zpráva"
 
@@ -2851,7 +2841,7 @@ msgstr "Poměr sdílení"
 msgid "Uploaded"
 msgstr "Odesláno"
 
-#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3253
+#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3225
 msgid "Requested"
 msgstr "Vyžádáno"
 
@@ -2977,7 +2967,7 @@ msgid "WARNING: "
 msgstr "VAROVÁNÍ: "
 
 #: src/MuleNotebook.cpp:179 src/muuli_wdr.cpp:817 src/muuli_wdr.cpp:1229
-#: src/muuli_wdr.cpp:3157 src/muuli_wdr.cpp:3413
+#: src/muuli_wdr.cpp:3129 src/muuli_wdr.cpp:3385
 msgid "Close"
 msgstr "Zavřít"
 
@@ -2990,12 +2980,12 @@ msgstr "Vyjmout"
 msgid "Copy"
 msgstr "Kopírovat"
 
-#: src/MuleTextCtrl.cpp:88 src/SearchDlg.cpp:261
+#: src/MuleTextCtrl.cpp:88
 msgid "Paste"
 msgstr "Vložit"
 
 #: src/MuleTextCtrl.cpp:89 src/muuli_wdr.cpp:358 src/muuli_wdr.cpp:757
-#: src/muuli_wdr.cpp:2380 src/muuli_wdr.cpp:2399 src/muuli_wdr.cpp:2421
+#: src/muuli_wdr.cpp:2352 src/muuli_wdr.cpp:2371 src/muuli_wdr.cpp:2393
 #: src/utils/aLinkCreator/src/alcframe.cpp:142
 msgid "Clear"
 msgstr "Vyprázdnit"
@@ -3093,8 +3083,8 @@ msgid "Exit"
 msgstr "Ukončit"
 
 #: src/MuleTrayIcon.cpp:579 src/MuleTrayIcon.cpp:945 src/MuleTrayIcon.cpp:965
-#: src/muuli_wdr.cpp:1398 src/muuli_wdr.cpp:1406 src/muuli_wdr.cpp:1413
-#: src/muuli_wdr.cpp:1836 src/muuli_wdr.cpp:1842 src/OtherFunctions.cpp:91
+#: src/muuli_wdr.cpp:1391 src/muuli_wdr.cpp:1399 src/muuli_wdr.cpp:1406
+#: src/muuli_wdr.cpp:1835 src/muuli_wdr.cpp:1841 src/OtherFunctions.cpp:91
 #: src/StatisticsDlg.cpp:93 src/StatisticsDlg.cpp:95
 msgid "kB/s"
 msgstr "kB/s"
@@ -3265,7 +3255,7 @@ msgstr "Název:"
 msgid "Type"
 msgstr "Typ"
 
-#: src/muuli_wdr.cpp:215 src/SearchDlg.cpp:118 src/SearchListCtrl.cpp:853
+#: src/muuli_wdr.cpp:215 src/SearchDlg.cpp:110 src/SearchListCtrl.cpp:853
 msgid "Local"
 msgstr "Lokální"
 
@@ -3336,7 +3326,7 @@ msgstr "bajtů"
 msgid "KB"
 msgstr "KB"
 
-#: src/muuli_wdr.cpp:274 src/muuli_wdr.cpp:293 src/muuli_wdr.cpp:1621
+#: src/muuli_wdr.cpp:274 src/muuli_wdr.cpp:293 src/muuli_wdr.cpp:1620
 #: src/OtherFunctions.cpp:64
 msgid "MB"
 msgstr "MB"
@@ -3353,7 +3343,7 @@ msgstr "Max. velikost"
 msgid "Availability"
 msgstr "Dostupnost"
 
-#: src/muuli_wdr.cpp:312 src/muuli_wdr.cpp:398 src/muuli_wdr.cpp:3318
+#: src/muuli_wdr.cpp:312 src/muuli_wdr.cpp:398 src/muuli_wdr.cpp:3290
 msgid "Filter:"
 msgstr "Filtr:"
 
@@ -3385,7 +3375,7 @@ msgstr ""
 msgid "Stop"
 msgstr "Zastavit"
 
-#: src/muuli_wdr.cpp:348 src/muuli_wdr.cpp:1392 src/SearchListCtrl.cpp:732
+#: src/muuli_wdr.cpp:348 src/muuli_wdr.cpp:1385 src/SearchListCtrl.cpp:732
 msgid "Download"
 msgstr "Stahování"
 
@@ -3416,12 +3406,12 @@ msgstr "Zdroje souboru:"
 #: src/muuli_wdr.cpp:1160 src/muuli_wdr.cpp:1167 src/muuli_wdr.cpp:1172
 #: src/muuli_wdr.cpp:1179 src/muuli_wdr.cpp:1184 src/muuli_wdr.cpp:1191
 #: src/muuli_wdr.cpp:1205 src/muuli_wdr.cpp:1212 src/muuli_wdr.cpp:1217
-#: src/muuli_wdr.cpp:1224 src/muuli_wdr.cpp:3255 src/muuli_wdr.cpp:3263
-#: src/muuli_wdr.cpp:3271
+#: src/muuli_wdr.cpp:1224 src/muuli_wdr.cpp:3227 src/muuli_wdr.cpp:3235
+#: src/muuli_wdr.cpp:3243
 msgid "N/A"
 msgstr "N/A"
 
-#: src/muuli_wdr.cpp:508 src/muuli_wdr.cpp:1065 src/PrefsUnifiedDlg.cpp:299
+#: src/muuli_wdr.cpp:508 src/muuli_wdr.cpp:1065 src/PrefsUnifiedDlg.cpp:297
 msgid "General"
 msgstr "Hlavní"
 
@@ -3562,7 +3552,7 @@ msgstr ""
 msgid "Album :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:685 src/muuli_wdr.cpp:2275
+#: src/muuli_wdr.cpp:685 src/muuli_wdr.cpp:2247
 msgid "Title :"
 msgstr "Titulek:"
 
@@ -3669,7 +3659,7 @@ msgstr "Uživatelské jméno:"
 msgid "Userhash :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:895 src/muuli_wdr.cpp:1742 src/muuli_wdr.cpp:2470
+#: src/muuli_wdr.cpp:895 src/muuli_wdr.cpp:1741 src/muuli_wdr.cpp:2442
 #: src/utils/aLinkCreator/src/alcframe.cpp:137
 msgid "Add"
 msgstr "Přidat"
@@ -3678,15 +3668,15 @@ msgstr "Přidat"
 msgid "Download-Speed"
 msgstr "Rychlost stahování"
 
-#: src/muuli_wdr.cpp:954 src/muuli_wdr.cpp:989 src/muuli_wdr.cpp:2574
+#: src/muuli_wdr.cpp:954 src/muuli_wdr.cpp:989 src/muuli_wdr.cpp:2546
 msgid "Current"
 msgstr ""
 
-#: src/muuli_wdr.cpp:962 src/muuli_wdr.cpp:997 src/muuli_wdr.cpp:2582
+#: src/muuli_wdr.cpp:962 src/muuli_wdr.cpp:997 src/muuli_wdr.cpp:2554
 msgid "Running average"
 msgstr ""
 
-#: src/muuli_wdr.cpp:970 src/muuli_wdr.cpp:1005 src/muuli_wdr.cpp:2590
+#: src/muuli_wdr.cpp:970 src/muuli_wdr.cpp:1005 src/muuli_wdr.cpp:2562
 msgid "Session average"
 msgstr "Průměr sezení"
 
@@ -3698,7 +3688,7 @@ msgstr "Rychlost odesílání"
 msgid "Connections"
 msgstr "Připojení"
 
-#: src/muuli_wdr.cpp:1024 src/muuli_wdr.cpp:1861
+#: src/muuli_wdr.cpp:1024 src/muuli_wdr.cpp:1860
 msgid "Active downloads"
 msgstr "Aktivní stahování"
 
@@ -3706,7 +3696,7 @@ msgstr "Aktivní stahování"
 msgid "Active connections (1:1)"
 msgstr "Aktivní připojení (1:1)"
 
-#: src/muuli_wdr.cpp:1040 src/muuli_wdr.cpp:1862
+#: src/muuli_wdr.cpp:1040 src/muuli_wdr.cpp:1861
 msgid "Active uploads"
 msgstr "Aktivní odesílání"
 
@@ -3823,8 +3813,8 @@ msgstr "Toto jméno uvidí ostatní uživatelé, kteří se k vám připojí."
 msgid "Language: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1257 src/muuli_wdr.cpp:1330 src/muuli_wdr.cpp:1334
-#: src/muuli_wdr.cpp:1337
+#: src/muuli_wdr.cpp:1257 src/muuli_wdr.cpp:1323 src/muuli_wdr.cpp:1327
+#: src/muuli_wdr.cpp:1330
 msgid "The delay before showing tool-tips."
 msgstr "Prodleva před zobrazením tooltipů."
 
@@ -3902,960 +3892,936 @@ msgstr ""
 msgid "Enabling this will make aMule to show notifications when finished downloading."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1323
-#, fuzzy
-msgid "Remember search history"
-msgstr "Zapamatovat si toto nastavení"
-
-#: src/muuli_wdr.cpp:1324
-msgid "Keeps a dropdown list of your past search terms in the Search tab's Name field. This remembers the queries you typed, not the results they returned."
-msgstr ""
-
-#: src/muuli_wdr.cpp:1329
+#: src/muuli_wdr.cpp:1322
 msgid "Tooltip delay time: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1336
+#: src/muuli_wdr.cpp:1329
 msgid "seconds"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1340
+#: src/muuli_wdr.cpp:1333
 msgid "Browser Selection"
 msgstr "Výběr prohlížeče"
 
-#: src/muuli_wdr.cpp:1346
+#: src/muuli_wdr.cpp:1339
 msgid "Enter your browser name here. Leave this field empty to use the system default browser."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1353
+#: src/muuli_wdr.cpp:1346
 msgid "Open in new tab if possible"
 msgstr "Otevřít pokud možno v novém tabu"
 
-#: src/muuli_wdr.cpp:1355
+#: src/muuli_wdr.cpp:1348
 msgid "Open the web page in a new tab instead of in a new window when possible"
 msgstr "Otevřít webovou stránku v novém tabu místo otvírání nového okna, pokud je to možné"
 
-#: src/muuli_wdr.cpp:1359
+#: src/muuli_wdr.cpp:1352
 msgid "Video Player"
 msgstr "Video přehrávač"
 
-#: src/muuli_wdr.cpp:1386
+#: src/muuli_wdr.cpp:1379
 msgid "Bandwidth limits"
 msgstr "Limity šířky pásma"
 
-#: src/muuli_wdr.cpp:1400
+#: src/muuli_wdr.cpp:1393
 msgid "Upload"
 msgstr "Odesílání"
 
-#: src/muuli_wdr.cpp:1408
+#: src/muuli_wdr.cpp:1401
 msgid "Slot Allocation"
 msgstr "Přidělování slotů"
 
-#: src/muuli_wdr.cpp:1417
+#: src/muuli_wdr.cpp:1410
 msgid "Ports"
 msgstr "Porty"
 
-#: src/muuli_wdr.cpp:1427
+#: src/muuli_wdr.cpp:1420
 msgid "This is the standard eD2k port and cannot be disabled."
 msgstr "Tohle je standardní eD2k port a nelze jej zakázat."
 
-#: src/muuli_wdr.cpp:1430
+#: src/muuli_wdr.cpp:1423
 msgid "UDP port for server requests (TCP+3):"
 msgstr "UDP port pro požadavky serveru (TCP+3):"
 
-#: src/muuli_wdr.cpp:1432
+#: src/muuli_wdr.cpp:1425
 msgid "4665"
 msgstr "4665"
 
-#: src/muuli_wdr.cpp:1439
+#: src/muuli_wdr.cpp:1432
 msgid "This UDP port is used for extended eD2k requests and Kad network"
 msgstr "Tento UDP port je použit pro rozšířené požadavky eD2k a pro síť Kad"
 
-#: src/muuli_wdr.cpp:1446
+#: src/muuli_wdr.cpp:1439
 msgid "UPnP TCP Port (Optional):"
 msgstr "UPnP TCP port (volitelné):"
 
-#: src/muuli_wdr.cpp:1456
+#: src/muuli_wdr.cpp:1449
 msgid "Bind local address to IP (empty for any):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1459
+#: src/muuli_wdr.cpp:1452
 msgid "Advanced users only: If you have multiple network interfaces, enter the address of the interface to which aMule should be bound."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1462 src/muuli_wdr.cpp:2055
+#: src/muuli_wdr.cpp:1455 src/muuli_wdr.cpp:2054
 msgid "Bind to network interface (empty for any):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1475
+#: src/muuli_wdr.cpp:1468
 msgid "Advanced users only: pin all of aMule's traffic to one network interface, chosen from the list or typed in by name (e.g. tun0, eth0, en0) or index. Unlike binding to an IP, this stops traffic leaking out via the default route - useful with a VPN. Requires no elevated privileges."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1481
+#: src/muuli_wdr.cpp:1474
 msgid "Max sources per downloading file:"
 msgstr "Max. zdrojů na stahovaný soubor:"
 
-#: src/muuli_wdr.cpp:1485
+#: src/muuli_wdr.cpp:1478
 msgid "Max simultaneous connections:"
 msgstr "Maximum připojení naráz:"
 
-#: src/muuli_wdr.cpp:1498 src/muuli_wdr.cpp:3197
+#: src/muuli_wdr.cpp:1491 src/muuli_wdr.cpp:3169
 msgid "ED2K"
 msgstr "ED2K"
 
-#: src/muuli_wdr.cpp:1505
+#: src/muuli_wdr.cpp:1498
 msgid "Autoconnect on startup"
 msgstr "Automatické připojení po spuštění"
 
-#: src/muuli_wdr.cpp:1508
+#: src/muuli_wdr.cpp:1501
 msgid "Reconnect on loss"
 msgstr "Po odpojení znovu připojit"
 
-#: src/muuli_wdr.cpp:1530
+#: src/muuli_wdr.cpp:1523
 msgid "Remove dead server after"
 msgstr "Odstranit mrtvý server po"
 
-#: src/muuli_wdr.cpp:1531
+#: src/muuli_wdr.cpp:1524
 msgid "Static servers are never removed, even when unreachable."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1535
+#: src/muuli_wdr.cpp:1528
 msgid "retries"
 msgstr "pokusech"
 
-#: src/muuli_wdr.cpp:1543
+#: src/muuli_wdr.cpp:1536
 msgid "List"
 msgstr "Seznam"
 
-#: src/muuli_wdr.cpp:1546
+#: src/muuli_wdr.cpp:1539
 msgid "Update server list when connecting to a server"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1549
+#: src/muuli_wdr.cpp:1542
 msgid "Update server list when a client connects"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1552
+#: src/muuli_wdr.cpp:1545
 msgid "Use priority system"
 msgstr "Použít systém priorit"
 
-#: src/muuli_wdr.cpp:1556
+#: src/muuli_wdr.cpp:1549
 msgid "Use smart LowID check on connect"
 msgstr "Použít po připojení chytrou kontrolu LowID"
 
-#: src/muuli_wdr.cpp:1560
+#: src/muuli_wdr.cpp:1553
 msgid "Safe connect"
 msgstr "Bezpečné připojení"
 
-#: src/muuli_wdr.cpp:1564
+#: src/muuli_wdr.cpp:1557
 msgid "Autoconnect to servers in static list only"
 msgstr "Automaticky se připojit jen ke stálým serverům"
 
-#: src/muuli_wdr.cpp:1567
+#: src/muuli_wdr.cpp:1560
 msgid "Set manually added servers to High Priority"
 msgstr "Přidělit ručně přidaným serverům vysokou prioritu"
 
-#: src/muuli_wdr.cpp:1588
+#: src/muuli_wdr.cpp:1581
 msgid "Add files to download in pause mode"
 msgstr "Přidávat soubory ke stažení do fronty pozastavené"
 
-#: src/muuli_wdr.cpp:1590
+#: src/muuli_wdr.cpp:1583
 msgid "Add files to download with auto priority"
 msgstr "Přidávat soubory ke stažení do fronty s \"auto\" prioritou"
 
-#: src/muuli_wdr.cpp:1593
+#: src/muuli_wdr.cpp:1586
 msgid "Try to download first and last chunks first"
 msgstr "Pokusit se nejprve stáhnout první a poslední části"
 
-#: src/muuli_wdr.cpp:1597
+#: src/muuli_wdr.cpp:1590
 msgid "Endgame mode: rotate to faster sources for the final blocks"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1600
+#: src/muuli_wdr.cpp:1593
 msgid "Start next paused file when a file completes"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1603
+#: src/muuli_wdr.cpp:1596
 msgid "From the same category"
 msgstr "Ze stejné kategorie"
 
-#: src/muuli_wdr.cpp:1605
+#: src/muuli_wdr.cpp:1598
 msgid "In alphabetic order"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1607
+#: src/muuli_wdr.cpp:1600
 msgid "Preallocate disk space for new files"
 msgstr "Předalokovat místo na disku pro nové soubory"
 
-#: src/muuli_wdr.cpp:1608
+#: src/muuli_wdr.cpp:1601
 msgid "For new files preallocates disk space for the whole file, thus reduces fragmentation"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1613
+#: src/muuli_wdr.cpp:1606
+msgid "Create new files as sparse files"
+msgstr ""
+
+#: src/muuli_wdr.cpp:1607
+msgid "A sparse file reserves its full size on disk immediately without writing real data to it -- fast, but unsupported or slow on some filesystems, and free-space accounting stays optimistic while the download is in progress. Turn this off to grow the file only as data arrives."
+msgstr ""
+
+#: src/muuli_wdr.cpp:1612
 msgid "Stop downloads when free disk space reaches "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1614
+#: src/muuli_wdr.cpp:1613
 msgid "Select this if you want aMule to check your disk space"
 msgstr "Toto zvolte chcete-li, aby aMule kontrolovala místo na disku"
 
-#: src/muuli_wdr.cpp:1618
+#: src/muuli_wdr.cpp:1617
 msgid "Enter here the min disk space desired."
 msgstr "Zadejte minimum místa na disku."
 
-#: src/muuli_wdr.cpp:1624
+#: src/muuli_wdr.cpp:1623
 msgid "Save 10 sources on rare files (< 20 sources)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1628 src/Statistics.cpp:790
+#: src/muuli_wdr.cpp:1627 src/Statistics.cpp:790
 msgid "Uploads"
 msgstr "Odesílání"
 
-#: src/muuli_wdr.cpp:1631
+#: src/muuli_wdr.cpp:1630
 msgid "Add new shared files with auto priority"
 msgstr "Přidat nově sdílené soubory s \"auto\" prioritou"
 
-#: src/muuli_wdr.cpp:1637
+#: src/muuli_wdr.cpp:1636
 msgid "Intelligent Corruption Handling (I.C.H.)"
 msgstr "Inteligentní zpracování poškození (I.C.H.)"
 
-#: src/muuli_wdr.cpp:1640
+#: src/muuli_wdr.cpp:1639
 msgid "Enable"
 msgstr "Povolit"
 
-#: src/muuli_wdr.cpp:1643
+#: src/muuli_wdr.cpp:1642
 msgid "Advanced I.C.H. trusts every hash (not recommended)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1655 src/PrefsUnifiedDlg.cpp:1990
+#: src/muuli_wdr.cpp:1654 src/PrefsUnifiedDlg.cpp:1910
 msgid "Media metadata extraction"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1659
+#: src/muuli_wdr.cpp:1658
 msgid "Extract length / bitrate / codec from shared audio and video files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1661
+#: src/muuli_wdr.cpp:1660
 msgid "When enabled, aMule runs ffprobe on each shared media file to fill in the Length / Bitrate / Codec columns other clients see when they find the file in a search. Requires ffmpeg (the ffprobe binary) to be installed."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1668
+#: src/muuli_wdr.cpp:1667
 msgid "Path to ffprobe:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1673
+#: src/muuli_wdr.cpp:1672
 msgid "Full path to the ffprobe binary. Leave empty to have aMule auto-detect it on startup."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1681
+#: src/muuli_wdr.cpp:1680
 msgid "Detect"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1682
+#: src/muuli_wdr.cpp:1681
 msgid "Search the standard install locations for an ffprobe binary and fill the path field."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1706
+#: src/muuli_wdr.cpp:1705
 msgid ""
 "Completed downloads are stored here. All files in this folder are automatically shared with other peers.\n"
 "If this folder also holds files you don't want to share, point it at an aMule-only sub-folder."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1709
+#: src/muuli_wdr.cpp:1708
 msgid "Pick the folder where completed downloads will be stored. All files in that folder will be shared with other peers."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1723
+#: src/muuli_wdr.cpp:1722
 msgid "Shared folders"
 msgstr "Sdílené adresáře"
 
-#: src/muuli_wdr.cpp:1729
+#: src/muuli_wdr.cpp:1728
 msgid "(Folders shared by the core. Enter a path to add one.)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1737
+#: src/muuli_wdr.cpp:1736
 msgid "Absolute path of a folder on the core's machine, e.g. /home/user/shared"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1739 src/PrefsUnifiedDlg.cpp:2874
+#: src/muuli_wdr.cpp:1738 src/PrefsUnifiedDlg.cpp:2794
 msgid "Recursive"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1740
+#: src/muuli_wdr.cpp:1739
 msgid "Share every sub-folder underneath this one, including ones created later."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1744 src/utils/aLinkCreator/src/alcframe.cpp:141
+#: src/muuli_wdr.cpp:1743 src/utils/aLinkCreator/src/alcframe.cpp:141
 msgid "Remove"
 msgstr "Odebrat"
 
-#: src/muuli_wdr.cpp:1748
+#: src/muuli_wdr.cpp:1747
 msgid "(Right click on folder icon for recursive share)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1755
+#: src/muuli_wdr.cpp:1754
 msgid "Share hidden files"
 msgstr "Sdílet skryté soubory"
 
-#: src/muuli_wdr.cpp:1761
+#: src/muuli_wdr.cpp:1760
 msgid "Automatically rescan shared folders for changes"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1767
+#: src/muuli_wdr.cpp:1766
 msgid "Follow symbolic links in shared folders"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1773
+#: src/muuli_wdr.cpp:1772
 msgid "Exclude files matching:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1776
+#: src/muuli_wdr.cpp:1775
 msgid "Wildcard patterns separated by '|', e.g. .DS_Store|Thumbs.db|*.tmp. Files whose name matches are not shared. Matching is case-insensitive."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1780
+#: src/muuli_wdr.cpp:1779
 msgid "Patterns are regular expressions"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1781
+#: src/muuli_wdr.cpp:1780
 msgid "When set, the whole field is one regular expression ('|' is alternation). When unset, it is a list of '|'-separated wildcards."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1791
+#: src/muuli_wdr.cpp:1790
 msgid "Show how many shared files the current pattern would exclude."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1812
+#: src/muuli_wdr.cpp:1811
 msgid "Graphs"
 msgstr "Grafy"
 
-#: src/muuli_wdr.cpp:1815 src/muuli_wdr.cpp:1877
+#: src/muuli_wdr.cpp:1814 src/muuli_wdr.cpp:1876
 msgid "Update delay : 5 secs"
 msgstr "Prodleva aktualizace: 5 sekund"
 
-#: src/muuli_wdr.cpp:1819
+#: src/muuli_wdr.cpp:1818
 msgid "Time for average graph: 100 mins"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1823
+#: src/muuli_wdr.cpp:1822
 msgid "Connections Graph Scale: 100 "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1830
+#: src/muuli_wdr.cpp:1829
 msgid "Download graph scale:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1838
+#: src/muuli_wdr.cpp:1837
 msgid "Upload graph scale:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1848
+#: src/muuli_wdr.cpp:1847
 #, fuzzy
 msgid "Colors: "
 msgstr "Barvy: "
 
-#: src/muuli_wdr.cpp:1852
+#: src/muuli_wdr.cpp:1851
 msgid "Background"
 msgstr "Na pozadí"
 
-#: src/muuli_wdr.cpp:1853
+#: src/muuli_wdr.cpp:1852
 msgid "Grid"
 msgstr "Mřížka"
 
-#: src/muuli_wdr.cpp:1854
+#: src/muuli_wdr.cpp:1853
 msgid "Download current"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1855
+#: src/muuli_wdr.cpp:1854
 msgid "Download running average"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1856
+#: src/muuli_wdr.cpp:1855
 msgid "Download session average"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1857
+#: src/muuli_wdr.cpp:1856
 msgid "Upload current"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1858
+#: src/muuli_wdr.cpp:1857
 msgid "Upload running average"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1859
+#: src/muuli_wdr.cpp:1858
 msgid "Upload session average"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1860
+#: src/muuli_wdr.cpp:1859
 msgid "Active connections"
 msgstr "Aktivní připojení"
 
-#: src/muuli_wdr.cpp:1863
+#: src/muuli_wdr.cpp:1862
 #, fuzzy
 msgid "Systray Icon Speed Bar"
 msgstr "Ukazatel rychlosti v tray ikoně"
 
-#: src/muuli_wdr.cpp:1864
+#: src/muuli_wdr.cpp:1863
 msgid "Kad-nodes current"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1865
+#: src/muuli_wdr.cpp:1864
 msgid "Kad-nodes running"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1866
+#: src/muuli_wdr.cpp:1865
 msgid "Kad-nodes session"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1870 src/muuli_wdr.cpp:2324
+#: src/muuli_wdr.cpp:1869 src/muuli_wdr.cpp:2296
 msgid "Select"
 msgstr "Vyberte"
 
-#: src/muuli_wdr.cpp:1874
+#: src/muuli_wdr.cpp:1873
 msgid "Tree"
 msgstr "Strom"
 
-#: src/muuli_wdr.cpp:1884
+#: src/muuli_wdr.cpp:1883
 msgid "Number of Client Versions shown (0=unlimited)"
 msgstr "Počet verzí klientů k zobrazení (0=neomezeně)"
 
-#: src/muuli_wdr.cpp:1909
+#: src/muuli_wdr.cpp:1908
 msgid "!!! WARNING !!!"
 msgstr "!!! VAROVÁNÍ !!!"
 
-#: src/muuli_wdr.cpp:1924
+#: src/muuli_wdr.cpp:1923
 msgid "Max new connections / 5 secs"
 msgstr "Max. nových připojení za 5 sek."
 
-#: src/muuli_wdr.cpp:1926
+#: src/muuli_wdr.cpp:1925
 msgid "Concurrent Kad source lookups"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1928
+#: src/muuli_wdr.cpp:1927
 #, fuzzy
 msgid "Kad source re-search interval (minutes)"
 msgstr "Interval aktualizace FTP v minutách"
 
-#: src/muuli_wdr.cpp:1930
+#: src/muuli_wdr.cpp:1929
 #, fuzzy
 msgid "Source re-ask interval (minutes)"
 msgstr "Interval aktualizace FTP v minutách"
 
-#: src/muuli_wdr.cpp:1934
+#: src/muuli_wdr.cpp:1933
 msgid "File Buffer Size: 240000 bytes"
 msgstr "Velikost zásobníku pro soubory: 240000 bytů"
 
-#: src/muuli_wdr.cpp:1938
+#: src/muuli_wdr.cpp:1937
 msgid "Use MMAP: memory-mapped file access (lower memory use)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1939
+#: src/muuli_wdr.cpp:1938
 msgid "Maps part files into memory instead of buffering them on the heap, lowering the process memory footprint. May reduce download speed on some disks; best for memory-constrained or upload-heavy hosts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1941
+#: src/muuli_wdr.cpp:1940
 msgid "Upload Queue Size: 5000 clients"
 msgstr "Velikost fronty odesílání: 5000 klientů"
 
-#: src/muuli_wdr.cpp:1945
+#: src/muuli_wdr.cpp:1944
 msgid "Server connection refresh interval: Disable"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1949
+#: src/muuli_wdr.cpp:1948
 msgid "Disable computer's timed standby mode"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1968
+#: src/muuli_wdr.cpp:1967
 msgid "Skin to use: "
 msgstr "Vzhled: "
 
-#: src/muuli_wdr.cpp:1977
+#: src/muuli_wdr.cpp:1976
 msgid "Show \"Fast eD2k Links Handler\" in every window."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1980
+#: src/muuli_wdr.cpp:1979
 msgid "Show extended info on categories tabs"
 msgstr "Zobrazit rozšířené informace na tabech kategorií"
 
-#: src/muuli_wdr.cpp:1983
+#: src/muuli_wdr.cpp:1982
 #, fuzzy
 msgid "Show application version on title"
 msgstr "Zobrazit rychlosti přenosu v titulku okna"
 
-#: src/muuli_wdr.cpp:1985
+#: src/muuli_wdr.cpp:1984
 msgid "Show transfer rates on title"
 msgstr "Zobrazit rychlosti přenosu v titulku okna"
 
-#: src/muuli_wdr.cpp:1987
+#: src/muuli_wdr.cpp:1986
 msgid "Before application name"
 msgstr "Před názvem programu"
 
-#: src/muuli_wdr.cpp:1989
+#: src/muuli_wdr.cpp:1988
 msgid "After application name"
 msgstr "Za názvem programu"
 
-#: src/muuli_wdr.cpp:1992
+#: src/muuli_wdr.cpp:1991
 msgid "Show overhead bandwidth"
 msgstr "Zobrazit šířku pásma režie"
 
-#: src/muuli_wdr.cpp:1996
+#: src/muuli_wdr.cpp:1995
 msgid "Vertical toolbar orientation"
 msgstr "Vertikální umístění nástrojové lišty"
 
-#: src/muuli_wdr.cpp:1998
+#: src/muuli_wdr.cpp:1997
 msgid "Live column sorting (auto-reorder rows as their values change)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2005
+#: src/muuli_wdr.cpp:2004
 msgid "Download Queue Files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2008
+#: src/muuli_wdr.cpp:2007
 msgid "Show progress percentage"
 msgstr "Zobrazit procenta průběhu"
 
-#: src/muuli_wdr.cpp:2014
+#: src/muuli_wdr.cpp:2013
 msgid "Show progress bar"
 msgstr "Zobrazit ukazatel průběhu"
 
-#: src/muuli_wdr.cpp:2017
+#: src/muuli_wdr.cpp:2016
 msgid "Flat"
 msgstr "Plochý"
 
-#: src/muuli_wdr.cpp:2021
+#: src/muuli_wdr.cpp:2020
 msgid "Round"
 msgstr "Kulatý"
 
-#: src/muuli_wdr.cpp:2039
+#: src/muuli_wdr.cpp:2038
 msgid "External Connection Parameters"
 msgstr "Nastavení externího připojení"
 
-#: src/muuli_wdr.cpp:2042
+#: src/muuli_wdr.cpp:2041
 msgid "Accept external connections"
 msgstr "Přijímat externí připojení"
 
-#: src/muuli_wdr.cpp:2049 src/muuli_wdr.cpp:2108
+#: src/muuli_wdr.cpp:2048 src/muuli_wdr.cpp:2107
 msgid "IP of the listening interface:"
 msgstr "IP naslouchajícího zařízení:"
 
-#: src/muuli_wdr.cpp:2052
+#: src/muuli_wdr.cpp:2051
 msgid "Enter here a valid ip in the a.b.c.d format for the listening EC interface. An empty field or 0.0.0.0 will mean any interface."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2073 src/muuli_wdr.cpp:2184
+#: src/muuli_wdr.cpp:2072 src/muuli_wdr.cpp:2156
 msgid "TCP port:"
 msgstr "TCP port:"
 
-#: src/muuli_wdr.cpp:2079
+#: src/muuli_wdr.cpp:2078
 msgid "Enable UPnP port forwarding on the EC port"
 msgstr "Povolit UPnP port forwarding na EC portu"
 
-#: src/muuli_wdr.cpp:2083 src/muuli_wdr.cpp:3069
+#: src/muuli_wdr.cpp:2082 src/muuli_wdr.cpp:3041
 #: src/utils/wxCas/src/wxcasprefs.cpp:167
 msgid "Password"
 msgstr "Heslo"
 
-#: src/muuli_wdr.cpp:2089
+#: src/muuli_wdr.cpp:2088
 #, fuzzy
 msgid "aMule API server parameters"
 msgstr "Parametry webserveru"
 
-#: src/muuli_wdr.cpp:2092
+#: src/muuli_wdr.cpp:2091
 msgid "Run amuleapi (REST API) on startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2097
+#: src/muuli_wdr.cpp:2096
 #, fuzzy
 msgid "HTTP port:"
 msgstr "TCP port:"
 
-#: src/muuli_wdr.cpp:2111
+#: src/muuli_wdr.cpp:2110
 msgid "The interface amuleapi's HTTP server listens on. 127.0.0.1 (default) accepts only local connections; use 0.0.0.0 or a specific IP to expose it to other hosts (set an admin password below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2116
-msgid "Type a password to set or change it. Stored passwords cannot be shown, so leaving this empty keeps the current one."
-msgstr ""
-
-#: src/muuli_wdr.cpp:2118
+#: src/muuli_wdr.cpp:2113
 #, fuzzy
 msgid "Admin password"
 msgstr "Kontrola hesla\n"
 
-#: src/muuli_wdr.cpp:2130 src/muuli_wdr.cpp:2147 src/PrefsUnifiedDlg.cpp:1103
-#, fuzzy
-msgid "A password is set."
-msgstr "Kontrola hesla\n"
+#: src/muuli_wdr.cpp:2118 src/muuli_wdr.cpp:2149
+msgid "Low rights password"
+msgstr "Heslo pro omezená práva"
 
-#: src/muuli_wdr.cpp:2134
-#, fuzzy
-msgid "Enable guest access"
-msgstr "Zakázat přístup hostům"
-
-#: src/muuli_wdr.cpp:2135
-msgid "Guest sessions may read status and listings but cannot change anything. Turning this off clears the stored guest password."
-msgstr ""
-
-#: src/muuli_wdr.cpp:2139
-#, fuzzy
-msgid "Guest password"
-msgstr "Heslo pro omezený přístup k webserveru"
-
-#: src/muuli_wdr.cpp:2154
+#: src/muuli_wdr.cpp:2126
 msgid "Web server parameters"
 msgstr "Parametry webserveru"
 
-#: src/muuli_wdr.cpp:2157
+#: src/muuli_wdr.cpp:2129
 #, fuzzy
 msgid "Run webserver on startup (deprecated)"
 msgstr "Spustit webserver při spuštění aMule"
 
-#: src/muuli_wdr.cpp:2163
+#: src/muuli_wdr.cpp:2135
 msgid "Web template"
 msgstr "Šablona webu"
 
-#: src/muuli_wdr.cpp:2168
+#: src/muuli_wdr.cpp:2140
 msgid "Full rights password"
 msgstr "Heslo pro plná práva"
 
-#: src/muuli_wdr.cpp:2172
+#: src/muuli_wdr.cpp:2144
 msgid "Enable Low rights User"
 msgstr "Povolit uživatele s omezenými právy"
 
-#: src/muuli_wdr.cpp:2177
-msgid "Low rights password"
-msgstr "Heslo pro omezená práva"
-
-#: src/muuli_wdr.cpp:2191
+#: src/muuli_wdr.cpp:2163
 msgid "Enable UPnP port forwarding of the web server port"
 msgstr "Povolit UPnP port forwarding portu webserveru"
 
-#: src/muuli_wdr.cpp:2196
+#: src/muuli_wdr.cpp:2168
 msgid "Web server UPnP TCP port (Optional)"
 msgstr "UPnP TCP port webserveru (volitelné)"
 
-#: src/muuli_wdr.cpp:2204
+#: src/muuli_wdr.cpp:2176
 msgid "Page Refresh Time (in secs)"
 msgstr "Obnovování stránky (v sek.)"
 
-#: src/muuli_wdr.cpp:2211
+#: src/muuli_wdr.cpp:2183
 msgid "Enable Gzip compression"
 msgstr "Povoliz Gzip kompresi"
 
-#: src/muuli_wdr.cpp:2245
+#: src/muuli_wdr.cpp:2217
 #, fuzzy
 msgid "Reset page to defaults"
 msgstr "Výchozí pro systém"
 
-#: src/muuli_wdr.cpp:2246
+#: src/muuli_wdr.cpp:2218
 msgid "Reset the settings on the current page to their default values."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2248 src/muuli_wdr.cpp:2334 src/ServerWnd.cpp:274
+#: src/muuli_wdr.cpp:2220 src/muuli_wdr.cpp:2306 src/ServerWnd.cpp:274
 #: src/ServerWnd.cpp:282
 msgid "OK"
 msgstr "Budiž"
 
-#: src/muuli_wdr.cpp:2250
+#: src/muuli_wdr.cpp:2222
 msgid "Click here to apply any changes made to the preferences."
 msgstr "Klikněte zde pro aplikování změn nastavení."
 
-#: src/muuli_wdr.cpp:2253
+#: src/muuli_wdr.cpp:2225
 msgid "Reset any changes made to the preferences."
 msgstr "Zahodí všechny změny v nastavení."
 
-#: src/muuli_wdr.cpp:2282
+#: src/muuli_wdr.cpp:2254
 msgid "Comment :"
 msgstr "Komentář:"
 
-#: src/muuli_wdr.cpp:2289
+#: src/muuli_wdr.cpp:2261
 msgid "Incoming Dir :"
 msgstr "Příchozí adresář:"
 
-#: src/muuli_wdr.cpp:2298
+#: src/muuli_wdr.cpp:2270
 msgid "Change priority for new assigned files :"
 msgstr "Změnit prioritu pro nově přiřazené soubory:"
 
-#: src/muuli_wdr.cpp:2302
+#: src/muuli_wdr.cpp:2274
 #, fuzzy
 msgid "Don't change"
 msgstr "Neměnit"
 
-#: src/muuli_wdr.cpp:2314
+#: src/muuli_wdr.cpp:2286
 msgid "Select color for this Category (currently selected) :"
 msgstr "Barva pro tuto kategorii:"
 
-#: src/muuli_wdr.cpp:2381 src/muuli_wdr.cpp:2400 src/muuli_wdr.cpp:2422
+#: src/muuli_wdr.cpp:2353 src/muuli_wdr.cpp:2372 src/muuli_wdr.cpp:2394
 msgid "Click this button to reset the log."
 msgstr "Klikněte na toto tlačítko pro vynulování logu."
 
-#: src/muuli_wdr.cpp:2441
+#: src/muuli_wdr.cpp:2413
 msgid "Click on this button to update the servers list from URL ..."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2445
+#: src/muuli_wdr.cpp:2417
 msgid "Server list"
 msgstr "Seznam serverů"
 
-#: src/muuli_wdr.cpp:2449
+#: src/muuli_wdr.cpp:2421
 msgid "Enter the url to a server.met file here and press the button to the left to update the list of known servers."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2454
+#: src/muuli_wdr.cpp:2426
 msgid "Add server manually: Name"
 msgstr "Přidat server ručně: Název"
 
-#: src/muuli_wdr.cpp:2457
+#: src/muuli_wdr.cpp:2429
 msgid "Enter the name of the new server here"
 msgstr "Zadejte název serveru"
 
-#: src/muuli_wdr.cpp:2459 src/ServerWnd.cpp:206
+#: src/muuli_wdr.cpp:2431 src/ServerWnd.cpp:206
 msgid "IP:Port"
 msgstr "IP:Port"
 
-#: src/muuli_wdr.cpp:2462
+#: src/muuli_wdr.cpp:2434
 msgid "Enter the IP of the server here, using the x.x.x.x format."
 msgstr "Zadejte IP serveru ve tvaru x.x.x.x."
 
-#: src/muuli_wdr.cpp:2468
+#: src/muuli_wdr.cpp:2440
 msgid "Enter the port of the server here."
 msgstr "Zadejte port serveru."
 
-#: src/muuli_wdr.cpp:2471
+#: src/muuli_wdr.cpp:2443
 msgid "Add manually a server (fill fields to the left before) ..."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2500
+#: src/muuli_wdr.cpp:2472
 msgid "aMule Log"
 msgstr "Log aMule"
 
-#: src/muuli_wdr.cpp:2508
+#: src/muuli_wdr.cpp:2480
 msgid "Server Info"
 msgstr "Info o serveru"
 
-#: src/muuli_wdr.cpp:2512
+#: src/muuli_wdr.cpp:2484
 msgid "ED2K Info"
 msgstr "ED2K Info"
 
-#: src/muuli_wdr.cpp:2516
+#: src/muuli_wdr.cpp:2488
 msgid "Kad Info"
 msgstr "Kad Info"
 
-#: src/muuli_wdr.cpp:2544
+#: src/muuli_wdr.cpp:2516
 msgid "Click on this button to update the nodes list from URL ..."
 msgstr "Aktualizuje seznam uzlů z dané URL..."
 
-#: src/muuli_wdr.cpp:2548
+#: src/muuli_wdr.cpp:2520
 msgid "Nodes (0)"
 msgstr "Uzly (0)"
 
-#: src/muuli_wdr.cpp:2552
+#: src/muuli_wdr.cpp:2524
 msgid "Enter the url to a nodes.dat file here and press the button to the left to update the list of known nodes."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2555
+#: src/muuli_wdr.cpp:2527
 msgid "Nodes stats"
 msgstr "Statistiky uzlů"
 
-#: src/muuli_wdr.cpp:2597
+#: src/muuli_wdr.cpp:2569
 msgid "Bootstrap"
 msgstr "Bootstrap"
 
-#: src/muuli_wdr.cpp:2600
+#: src/muuli_wdr.cpp:2572
 msgid "New node"
 msgstr "Nový uzel"
 
-#: src/muuli_wdr.cpp:2605
+#: src/muuli_wdr.cpp:2577
 msgid "IP:"
 msgstr "IP:"
 
-#: src/muuli_wdr.cpp:2625
+#: src/muuli_wdr.cpp:2597
 msgid "Port:"
 msgstr "Port:"
 
-#: src/muuli_wdr.cpp:2638
+#: src/muuli_wdr.cpp:2610
 msgid "Bootstrap from known clients"
 msgstr "Bootstrap od známých klientů"
 
-#: src/muuli_wdr.cpp:2640
+#: src/muuli_wdr.cpp:2612
 msgid "Disconnect Kad"
 msgstr "Odpojit Kad"
 
-#: src/muuli_wdr.cpp:2674
+#: src/muuli_wdr.cpp:2646
 msgid "Use Secure User Identification"
 msgstr "Použít bezpečnou uživatelskou identifikaci"
 
-#: src/muuli_wdr.cpp:2676
+#: src/muuli_wdr.cpp:2648
 msgid "It is recommended to enable this option. You will not receive credits if SUI is not enabled."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2678
+#: src/muuli_wdr.cpp:2650
 msgid "Protocol Obfuscation"
 msgstr "Zatemnění protokolu"
 
-#: src/muuli_wdr.cpp:2681
+#: src/muuli_wdr.cpp:2653
 msgid "Support Protocol Obfuscation"
 msgstr "Podporuje zatemnění protokolu"
 
-#: src/muuli_wdr.cpp:2683
+#: src/muuli_wdr.cpp:2655
 msgid "This option enabled Protocol Obfuscation, and makes aMule accept obfuscated connections from other clients."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2685
+#: src/muuli_wdr.cpp:2657
 msgid "Use obfuscation for outgoing connections"
 msgstr "Použít zatemnění protokolu pro odchozí spojení"
 
-#: src/muuli_wdr.cpp:2687
+#: src/muuli_wdr.cpp:2659
 msgid "This option makes aMule use Protocol Obfuscation when connecting other clients/servers."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2689
+#: src/muuli_wdr.cpp:2661
 msgid "Accept only obfuscated connections"
 msgstr "Přijímat pouze zatemněná spojení"
 
-#: src/muuli_wdr.cpp:2690
+#: src/muuli_wdr.cpp:2662
 msgid "This option makes aMule only accept obfuscated connections. You will have less sources, but all your traffic will be obfuscated"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2695
+#: src/muuli_wdr.cpp:2667
 msgid "Everybody"
 msgstr "Všichni"
 
-#: src/muuli_wdr.cpp:2697
+#: src/muuli_wdr.cpp:2669
 msgid "No one"
 msgstr "Nikdo"
 
-#: src/muuli_wdr.cpp:2699
+#: src/muuli_wdr.cpp:2671
 msgid "Who can see my shared files:"
 msgstr "Kdo může prohlížet moje sdílené soubory:"
 
-#: src/muuli_wdr.cpp:2700
+#: src/muuli_wdr.cpp:2672
 msgid "Select who can request to view a list of your shared files."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2702
+#: src/muuli_wdr.cpp:2674
 msgid "IP-Filtering"
 msgstr "IP filtrování"
 
-#: src/muuli_wdr.cpp:2709
+#: src/muuli_wdr.cpp:2681
 msgid "Filter clients"
 msgstr "Filtrovat klienty"
 
-#: src/muuli_wdr.cpp:2711
+#: src/muuli_wdr.cpp:2683
 msgid "Enable filtering of the client IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2713
+#: src/muuli_wdr.cpp:2685
 msgid "Filter servers"
 msgstr "Filtrovat servery"
 
-#: src/muuli_wdr.cpp:2715
+#: src/muuli_wdr.cpp:2687
 msgid "Enable filtering of the server IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2719
+#: src/muuli_wdr.cpp:2691
 msgid "Reload List"
 msgstr "Obnovit seznam"
 
-#: src/muuli_wdr.cpp:2720
+#: src/muuli_wdr.cpp:2692
 msgid "Reload the list of IPs to filter from the file ~/.aMule/ipfilter.dat"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2726
+#: src/muuli_wdr.cpp:2698
 msgid "URL:"
 msgstr "URL:"
 
-#: src/muuli_wdr.cpp:2730 src/muuli_wdr.cpp:2923
+#: src/muuli_wdr.cpp:2702 src/muuli_wdr.cpp:2895
 msgid "Update now"
 msgstr "Obnovit"
 
-#: src/muuli_wdr.cpp:2733
+#: src/muuli_wdr.cpp:2705
 msgid "Auto-update ipfilter at startup"
 msgstr "Automaticky aktualizovat IP filtr po spuštění"
 
-#: src/muuli_wdr.cpp:2737
+#: src/muuli_wdr.cpp:2709
 msgid "Filtering Level:"
 msgstr "Úroveň filtrování:"
 
-#: src/muuli_wdr.cpp:2743
+#: src/muuli_wdr.cpp:2715
 msgid "Always filter LAN IPs"
 msgstr "Vždy filtrovat LAN IP"
 
-#: src/muuli_wdr.cpp:2746
+#: src/muuli_wdr.cpp:2718
 msgid "Paranoid handling of non-matching IPs"
 msgstr "Paranoidní nakládání s nesouhlasícími IP"
 
-#: src/muuli_wdr.cpp:2748
+#: src/muuli_wdr.cpp:2720
 msgid "Rejects a packet when its source IP differs from the IP the client claims (an anti-spoofing check). Disable only if it causes connection problems."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2750
+#: src/muuli_wdr.cpp:2722
 msgid "Use system-wide ipfilter.dat if available"
 msgstr "Použít systémový ipfilter.dat, je-li dostupný"
 
-#: src/muuli_wdr.cpp:2751
+#: src/muuli_wdr.cpp:2723
 #, fuzzy
 msgid "If there's no local ipfilter.dat found, allow usage of a system-wide ipfilter file."
 msgstr "Neexistuje-li místní ipfilter.dat, umožní použití systémového."
 
-#: src/muuli_wdr.cpp:2768
+#: src/muuli_wdr.cpp:2740
 msgid "Enable Online-Signature"
 msgstr "Povolit online podpis"
 
-#: src/muuli_wdr.cpp:2770
+#: src/muuli_wdr.cpp:2742
 msgid "Enables the writing of the OS file, which can be used by external apps to create signatures and the like."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2774
+#: src/muuli_wdr.cpp:2746
 msgid "Update Frequency (Secs):"
 msgstr "Prodleva aktualizace (sek.):"
 
-#: src/muuli_wdr.cpp:2777
+#: src/muuli_wdr.cpp:2749
 msgid "Change the frequency (in seconds) of Online Signature updates."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2785
+#: src/muuli_wdr.cpp:2757
 msgid "Save online signature file in: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:2791
+#: src/muuli_wdr.cpp:2763
 msgid "Click here to select the directory containing the the Online Signature files."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2824
+#: src/muuli_wdr.cpp:2796
 msgid "Show country flags for clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2825
+#: src/muuli_wdr.cpp:2797
 msgid "Render the country flag column in the transfers, queue and search views. Requires a valid MMDB GeoIP database (see below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2830
+#: src/muuli_wdr.cpp:2802
 msgid "Database"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2846
+#: src/muuli_wdr.cpp:2818
 #, fuzzy
 msgid "Source:"
 msgstr "Zdroje"
 
-#: src/muuli_wdr.cpp:2849
+#: src/muuli_wdr.cpp:2821
 msgid "DB-IP (free, no account)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2850
+#: src/muuli_wdr.cpp:2822
 msgid "MaxMind GeoLite2 (free, account required)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2851
+#: src/muuli_wdr.cpp:2823
 msgid "Custom URL"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2854
+#: src/muuli_wdr.cpp:2826
 msgid "Choose which provider supplies the GeoIP MMDB database. DB-IP is the default - no account required. MaxMind requires a free account + license key. Use Custom URL to point at any other MMDB host (e.g. a local mirror)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2871
+#: src/muuli_wdr.cpp:2843
 msgid ""
 "No configuration required.\n"
 "\n"
@@ -4863,11 +4829,11 @@ msgid ""
 "License: Creative Commons BY 4.0 - https://creativecommons.org/licenses/by/4.0/"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2884
+#: src/muuli_wdr.cpp:2856
 msgid "License key:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2890
+#: src/muuli_wdr.cpp:2862
 msgid ""
 "Sign up for a free MaxMind account, then generate a License Key:\n"
 "https://www.maxmind.com/en/geolite2/signup\n"
@@ -4877,230 +4843,230 @@ msgid ""
 "Requires attribution and account registration; refresh at least every 30 days."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2905
+#: src/muuli_wdr.cpp:2877
 #, fuzzy
 msgid "Download URL:"
 msgstr "Stahování: "
 
-#: src/muuli_wdr.cpp:2911
+#: src/muuli_wdr.cpp:2883
 msgid ""
 "Must point to an .mmdb file or a .gz / .tar.gz containing one.\n"
 "URL may include credentials (https://user:pass@host/...).\n"
 "License and attribution terms are set by the upstream URL - you are responsible."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2924
+#: src/muuli_wdr.cpp:2896
 msgid "Download the GeoIP database from the selected source."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2926
+#: src/muuli_wdr.cpp:2898
 #, fuzzy
 msgid "Auto-update on startup"
 msgstr "Automaticky aktualizovat IP filtr po spuštění"
 
-#: src/muuli_wdr.cpp:2927
+#: src/muuli_wdr.cpp:2899
 msgid "Re-download the GeoIP database from the selected source every time aMule starts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2950
+#: src/muuli_wdr.cpp:2922
 msgid "Filter incoming messages (except current chat):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2952
+#: src/muuli_wdr.cpp:2924
 msgid "Filter all messages"
 msgstr "Filtrovat všechny zprávy"
 
-#: src/muuli_wdr.cpp:2954
+#: src/muuli_wdr.cpp:2926
 msgid "Filter messages from people not on your friend list"
 msgstr "Filtrovat zprávy, které nejsou od přátel"
 
-#: src/muuli_wdr.cpp:2956
+#: src/muuli_wdr.cpp:2928
 msgid "Filter messages from unknown clients"
 msgstr "Filtrovat zprávy od neznámých klientů"
 
-#: src/muuli_wdr.cpp:2958
+#: src/muuli_wdr.cpp:2930
 msgid "Filter messages containing (use ',' as separator):"
 msgstr "Filtrovat zprávy obsahující (použijte ',' jako oddělovač):"
 
-#: src/muuli_wdr.cpp:2961 src/muuli_wdr.cpp:2972
+#: src/muuli_wdr.cpp:2933 src/muuli_wdr.cpp:2944
 msgid "add here the words amule should filter and block messages including it"
 msgstr "zadejte slova, která by měla amule filtrovat a blokovat zprávy obsahující je"
 
-#: src/muuli_wdr.cpp:2963
+#: src/muuli_wdr.cpp:2935
 msgid "Show received messages in the log"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2966
+#: src/muuli_wdr.cpp:2938
 msgid "Comments"
 msgstr "Komentáře"
 
-#: src/muuli_wdr.cpp:2969
+#: src/muuli_wdr.cpp:2941
 msgid "Filter comments containing (use ',' as separator):"
 msgstr "Filtrovat komentáře obsahující (použijte ',' jako oddělovač):"
 
-#: src/muuli_wdr.cpp:2994
+#: src/muuli_wdr.cpp:2966
 msgid "Enable Proxy"
 msgstr "Povolit proxy"
 
-#: src/muuli_wdr.cpp:2995
+#: src/muuli_wdr.cpp:2967
 msgid "Enable/disable proxy support"
 msgstr "Povolí/zakáže proxy"
 
-#: src/muuli_wdr.cpp:2998
+#: src/muuli_wdr.cpp:2970
 msgid "Proxy type:"
 msgstr "Typ proxy:"
 
-#: src/muuli_wdr.cpp:3009
+#: src/muuli_wdr.cpp:2981
 msgid "Proxy host:"
 msgstr "Hostitel proxy:"
 
-#: src/muuli_wdr.cpp:3012
+#: src/muuli_wdr.cpp:2984
 msgid "The proxy host name"
 msgstr "Název hostitele proxy"
 
-#: src/muuli_wdr.cpp:3014
+#: src/muuli_wdr.cpp:2986
 msgid "Proxy port:"
 msgstr "Port proxy:"
 
-#: src/muuli_wdr.cpp:3017
+#: src/muuli_wdr.cpp:2989
 msgid "The proxy port"
 msgstr "Port proxy"
 
-#: src/muuli_wdr.cpp:3019
+#: src/muuli_wdr.cpp:2991
 msgid "Enable authentication"
 msgstr "Povolit autentizaci"
 
-#: src/muuli_wdr.cpp:3020
+#: src/muuli_wdr.cpp:2992
 msgid "Enable/disable username/password authentication"
 msgstr "Povolí/zakáže autentizaci (uživatelské jméno a heslo)"
 
-#: src/muuli_wdr.cpp:3023
+#: src/muuli_wdr.cpp:2995
 msgid "Username: "
 msgstr "Uživatelské jméno: "
 
-#: src/muuli_wdr.cpp:3026
+#: src/muuli_wdr.cpp:2998
 msgid "The username to use to connect to the proxy"
 msgstr "Uživatelské jméno, které se použije pro přihlášení k proxy"
 
-#: src/muuli_wdr.cpp:3028
+#: src/muuli_wdr.cpp:3000
 msgid "Password:"
 msgstr "Heslo:"
 
-#: src/muuli_wdr.cpp:3031
+#: src/muuli_wdr.cpp:3003
 msgid "The password to use to connect to the proxy"
 msgstr "Heslo, které se použije pro přihlášení k proxy"
 
-#: src/muuli_wdr.cpp:3050
+#: src/muuli_wdr.cpp:3022
 msgid "Connect to:"
 msgstr "Připojit se k:"
 
-#: src/muuli_wdr.cpp:3059
+#: src/muuli_wdr.cpp:3031
 msgid "Login to remote amule"
 msgstr "Připojit k vzdálené aMuli"
 
-#: src/muuli_wdr.cpp:3064
+#: src/muuli_wdr.cpp:3036
 msgid "User name"
 msgstr "Uživatelské jméno"
 
-#: src/muuli_wdr.cpp:3075
+#: src/muuli_wdr.cpp:3047
 msgid "Remember those settings"
 msgstr "Zapamatovat si toto nastavení"
 
-#: src/muuli_wdr.cpp:3078
+#: src/muuli_wdr.cpp:3050
 #, fuzzy
 msgid "Force ZLIB compression"
 msgstr "Použít gzip kompresi"
 
-#: src/muuli_wdr.cpp:3102
+#: src/muuli_wdr.cpp:3074
 msgid "Enable Verbose Debug-Logging."
 msgstr ""
 
-#: src/muuli_wdr.cpp:3104
+#: src/muuli_wdr.cpp:3076
 #, fuzzy
 msgid "Only to Logfile"
 msgstr "&Otevřít tento soubor"
 
-#: src/muuli_wdr.cpp:3106
+#: src/muuli_wdr.cpp:3078
 msgid "Message Categories:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3130 src/PartFileConvertDlg.cpp:160
+#: src/muuli_wdr.cpp:3102 src/PartFileConvertDlg.cpp:160
 msgid "Waiting..."
 msgstr "Čekání..."
 
-#: src/muuli_wdr.cpp:3150
+#: src/muuli_wdr.cpp:3122
 msgid "Add imports"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3153
+#: src/muuli_wdr.cpp:3125
 msgid "Retry selected"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3155
+#: src/muuli_wdr.cpp:3127
 msgid "Remove selected"
 msgstr "Odstranit vybrané"
 
-#: src/muuli_wdr.cpp:3218
+#: src/muuli_wdr.cpp:3190
 msgid "Event Types"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3237
+#: src/muuli_wdr.cpp:3209
 msgid "Statistics and queued clients for selected file(s) : Session / All time"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3261
+#: src/muuli_wdr.cpp:3233
 msgid "Active Uploads"
 msgstr "Aktivní odesílání"
 
-#: src/muuli_wdr.cpp:3275
+#: src/muuli_wdr.cpp:3247
 msgid "Percent of total files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3327
+#: src/muuli_wdr.cpp:3299
 #, fuzzy
 msgid "Show Clients for"
 msgstr "Zobrazit klienty"
 
-#: src/muuli_wdr.cpp:3329
+#: src/muuli_wdr.cpp:3301
 #, fuzzy
 msgid "All files"
 msgstr "Všechny sdílené soubory"
 
-#: src/muuli_wdr.cpp:3332
+#: src/muuli_wdr.cpp:3304
 #, fuzzy
 msgid "Selected files"
 msgstr "Sdílené soubory"
 
-#: src/muuli_wdr.cpp:3335
+#: src/muuli_wdr.cpp:3307
 #, fuzzy
 msgid "Active uploads only"
 msgstr "Aktivní odesílání"
 
-#: src/muuli_wdr.cpp:3342
+#: src/muuli_wdr.cpp:3314
 msgid "Reload:"
 msgstr "Obnovit:"
 
-#: src/muuli_wdr.cpp:3346
+#: src/muuli_wdr.cpp:3318
 msgid "Reload your shared files"
 msgstr "Znovu načíst vaše sdílené soubory"
 
-#: src/muuli_wdr.cpp:3409
+#: src/muuli_wdr.cpp:3381
 msgid "Send"
 msgstr "Odeslat"
 
-#: src/muuli_wdr.cpp:3410
+#: src/muuli_wdr.cpp:3382
 msgid "Sends the specified message."
 msgstr "Odešle zadanou zprávu."
 
-#: src/muuli_wdr.cpp:3414
+#: src/muuli_wdr.cpp:3386
 msgid "Close this chat-session."
 msgstr "Zavře tento chat."
 
-#: src/muuli_wdr.cpp:3437
+#: src/muuli_wdr.cpp:3409
 msgid "Connect to any server and/or Kad"
 msgstr "Připojit k nějakému serveru a/nebo Kadu"
 
-#: src/muuli_wdr.cpp:3443 src/SharedFilesCtrl.cpp:142 src/Statistics.cpp:941
+#: src/muuli_wdr.cpp:3415 src/SharedFilesCtrl.cpp:142 src/Statistics.cpp:941
 msgid "Shared Files"
 msgstr "Sdílené soubory"
 
@@ -5464,265 +5430,265 @@ msgstr "Staženo"
 msgid "ERROR: Failed to open partfile '%s'"
 msgstr ""
 
-#: src/Preferences.cpp:701
+#: src/Preferences.cpp:673
 msgid "System default"
 msgstr "Výchozí pro systém"
 
-#: src/Preferences.cpp:702
+#: src/Preferences.cpp:674
 msgid "Albanian"
 msgstr "Albánština"
 
-#: src/Preferences.cpp:703
+#: src/Preferences.cpp:675
 msgid "Arabic"
 msgstr "Arabský"
 
-#: src/Preferences.cpp:704
+#: src/Preferences.cpp:676
 msgid "Asturian"
 msgstr ""
 
-#: src/Preferences.cpp:705
+#: src/Preferences.cpp:677
 msgid "Basque"
 msgstr "Baskičtina"
 
-#: src/Preferences.cpp:706
+#: src/Preferences.cpp:678
 msgid "Bulgarian"
 msgstr "Bulharský"
 
-#: src/Preferences.cpp:707
+#: src/Preferences.cpp:679
 msgid "Catalan"
 msgstr "Katalánština"
 
-#: src/Preferences.cpp:708
+#: src/Preferences.cpp:680
 msgid "Chinese (Simplified)"
 msgstr "Čínština (zjednodušená)"
 
-#: src/Preferences.cpp:709
+#: src/Preferences.cpp:681
 msgid "Chinese (Traditional)"
 msgstr "Čínština (tradiční)"
 
-#: src/Preferences.cpp:710
+#: src/Preferences.cpp:682
 msgid "Croatian"
 msgstr "Chorvatština"
 
-#: src/Preferences.cpp:711
+#: src/Preferences.cpp:683
 msgid "Czech"
 msgstr "Česky"
 
-#: src/Preferences.cpp:712
+#: src/Preferences.cpp:684
 msgid "Danish"
 msgstr "Dánština"
 
-#: src/Preferences.cpp:713
+#: src/Preferences.cpp:685
 msgid "Dutch"
 msgstr "Nizozemština"
 
-#: src/Preferences.cpp:714
+#: src/Preferences.cpp:686
 msgid "English (U.K.)"
 msgstr "Angličtina (britská)"
 
-#: src/Preferences.cpp:715
+#: src/Preferences.cpp:687
 #, fuzzy
 msgid "English (U.S.)"
 msgstr "Angličtina (britská)"
 
-#: src/Preferences.cpp:716
+#: src/Preferences.cpp:688
 msgid "Estonian"
 msgstr "Estonština"
 
-#: src/Preferences.cpp:717
+#: src/Preferences.cpp:689
 msgid "Finnish"
 msgstr "Finština"
 
-#: src/Preferences.cpp:718
+#: src/Preferences.cpp:690
 msgid "French"
 msgstr "Francouzština"
 
-#: src/Preferences.cpp:719
+#: src/Preferences.cpp:691
 msgid "Galician"
 msgstr "Galicijština"
 
-#: src/Preferences.cpp:720
+#: src/Preferences.cpp:692
 msgid "German"
 msgstr "Němčina"
 
-#: src/Preferences.cpp:721
+#: src/Preferences.cpp:693
 msgid "Greek"
 msgstr "Řečtina"
 
-#: src/Preferences.cpp:722
+#: src/Preferences.cpp:694
 msgid "Hebrew"
 msgstr "Hebrejština"
 
-#: src/Preferences.cpp:723
+#: src/Preferences.cpp:695
 msgid "Hungarian"
 msgstr "Maďarština"
 
-#: src/Preferences.cpp:724
+#: src/Preferences.cpp:696
 msgid "Italian"
 msgstr "Italština"
 
-#: src/Preferences.cpp:725
+#: src/Preferences.cpp:697
 msgid "Japanese"
 msgstr "Japonština"
 
-#: src/Preferences.cpp:726
+#: src/Preferences.cpp:698
 msgid "Korean"
 msgstr "Korejština"
 
-#: src/Preferences.cpp:727
+#: src/Preferences.cpp:699
 msgid "Latvian"
 msgstr ""
 
-#: src/Preferences.cpp:728
+#: src/Preferences.cpp:700
 msgid "Lithuanian"
 msgstr "Litevština"
 
-#: src/Preferences.cpp:729
+#: src/Preferences.cpp:701
 msgid "Norwegian (Nynorsk)"
 msgstr "Norština"
 
-#: src/Preferences.cpp:730
+#: src/Preferences.cpp:702
 msgid "Polish"
 msgstr "Polština"
 
-#: src/Preferences.cpp:731
+#: src/Preferences.cpp:703
 msgid "Portuguese"
 msgstr "Portugalština"
 
-#: src/Preferences.cpp:732
+#: src/Preferences.cpp:704
 msgid "Portuguese (Brazilian)"
 msgstr "Portugalština (brazilská)"
 
-#: src/Preferences.cpp:733
+#: src/Preferences.cpp:705
 msgid "Romanian"
 msgstr "Rumunština"
 
-#: src/Preferences.cpp:734
+#: src/Preferences.cpp:706
 msgid "Russian"
 msgstr "Ruština"
 
-#: src/Preferences.cpp:735
+#: src/Preferences.cpp:707
 msgid "Slovenian"
 msgstr "Slovinština"
 
-#: src/Preferences.cpp:736
+#: src/Preferences.cpp:708
 msgid "Spanish"
 msgstr "Španělština"
 
-#: src/Preferences.cpp:737
+#: src/Preferences.cpp:709
 msgid "Swedish"
 msgstr "Švédština"
 
-#: src/Preferences.cpp:738
+#: src/Preferences.cpp:710
 msgid "Turkish"
 msgstr "Turečtina"
 
-#: src/Preferences.cpp:739
+#: src/Preferences.cpp:711
 msgid "Ukrainian"
 msgstr "Ukrajinština"
 
-#: src/Preferences.cpp:842
+#: src/Preferences.cpp:814
 msgid "Change Language"
 msgstr "Změnit jazyk"
 
-#: src/Preferences.cpp:906
+#: src/Preferences.cpp:878
 msgid "There are no translations installed for aMule"
 msgstr ""
 
-#: src/Preferences.cpp:907
+#: src/Preferences.cpp:879
 #, fuzzy
 msgid "No languages available"
 msgstr "Nedostupný"
 
-#: src/Preferences.cpp:1038
+#: src/Preferences.cpp:1010
 msgid "no options available"
 msgstr "není dostupné žádné nastavení"
 
-#: src/Preferences.cpp:2226
+#: src/Preferences.cpp:2179
 msgid "Invalid category found, skipping"
 msgstr "Nalezena neplatná kategorie, přeskakuji"
 
-#: src/Preferences.cpp:2395
+#: src/Preferences.cpp:2348
 msgid "TCP port can't be higher than 65532 due to server UDP socket being TCP+3"
 msgstr "TCP port nemůže být vyšší než 65532, protože UDP port je TCP+3"
 
-#: src/Preferences.cpp:2396
+#: src/Preferences.cpp:2349
 #, c-format
 msgid "Default port will be used (%d)"
 msgstr "Bude použit výchozí port (%d)"
 
-#: src/PrefsUnifiedDlg.cpp:300 src/Statistics.cpp:866
+#: src/PrefsUnifiedDlg.cpp:298 src/Statistics.cpp:866
 msgid "Connection"
 msgstr "Připojení"
 
-#: src/PrefsUnifiedDlg.cpp:301 src/SearchListCtrl.cpp:117
+#: src/PrefsUnifiedDlg.cpp:299 src/SearchListCtrl.cpp:117
 msgid "Directories"
 msgstr "Adresáře"
 
-#: src/PrefsUnifiedDlg.cpp:302 src/Statistics.cpp:917
+#: src/PrefsUnifiedDlg.cpp:300 src/Statistics.cpp:917
 msgid "Servers"
 msgstr "Servery"
 
-#: src/PrefsUnifiedDlg.cpp:303 src/ServerListCtrl.cpp:96
+#: src/PrefsUnifiedDlg.cpp:301 src/ServerListCtrl.cpp:96
 msgid "Files"
 msgstr "Soubory"
 
-#: src/PrefsUnifiedDlg.cpp:304
+#: src/PrefsUnifiedDlg.cpp:302
 msgid "Security"
 msgstr "Bezpečnost"
 
-#: src/PrefsUnifiedDlg.cpp:305
+#: src/PrefsUnifiedDlg.cpp:303
 msgid "Interface"
 msgstr "Rozhraní"
 
-#: src/PrefsUnifiedDlg.cpp:312
+#: src/PrefsUnifiedDlg.cpp:310
 msgid "IP2Country"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:315
+#: src/PrefsUnifiedDlg.cpp:313
 msgid "Proxy"
 msgstr "Proxy"
 
-#: src/PrefsUnifiedDlg.cpp:316
+#: src/PrefsUnifiedDlg.cpp:314
 msgid "Filters"
 msgstr "Filtry"
 
-#: src/PrefsUnifiedDlg.cpp:317
+#: src/PrefsUnifiedDlg.cpp:315
 msgid "Remote Controls"
 msgstr "Vzdálené ovládání"
 
-#: src/PrefsUnifiedDlg.cpp:318
+#: src/PrefsUnifiedDlg.cpp:316
 msgid "Online Signature"
 msgstr "Online podpis"
 
-#: src/PrefsUnifiedDlg.cpp:319
+#: src/PrefsUnifiedDlg.cpp:317
 msgid "Advanced"
 msgstr "Pokročilé"
 
-#: src/PrefsUnifiedDlg.cpp:320
+#: src/PrefsUnifiedDlg.cpp:318
 msgid "Events"
 msgstr "Události"
 
-#: src/PrefsUnifiedDlg.cpp:323
+#: src/PrefsUnifiedDlg.cpp:321
 msgid "Debugging"
 msgstr "Debugování"
 
-#: src/PrefsUnifiedDlg.cpp:453
+#: src/PrefsUnifiedDlg.cpp:451
 msgid ""
 "The following variables will be substituted:\n"
 "    %PARTFILE - full path to the file\n"
 "    %PARTNAME - file name only"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:474
+#: src/PrefsUnifiedDlg.cpp:472
 msgid "Tray icon support requires libayatana-appindicator3 at compile time."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:490
+#: src/PrefsUnifiedDlg.cpp:488
 msgid "Not available on Wayland: the protocol does not report when a window is minimized, so this option cannot intercept the system minimize button. Workaround: launch aMule with `GDK_BACKEND=x11` to use XWayland instead."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:536
+#: src/PrefsUnifiedDlg.cpp:534
 msgid ""
 "Do not change these setting unless you know\n"
 "what you are doing, otherwise you can easily\n"
@@ -5738,35 +5704,26 @@ msgstr ""
 "aMule poběží v pohodě bez změny\n"
 "nastavení na tomto tabu."
 
-#: src/PrefsUnifiedDlg.cpp:647
+#: src/PrefsUnifiedDlg.cpp:645
 #, c-format
 msgid "Failed to connect Cfg to widget with the ID %d and key %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:695
+#: src/PrefsUnifiedDlg.cpp:693
 #, c-format
 msgid "Failed to transfer data from Cfg to Widget with the ID %d and key %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:801
+#: src/PrefsUnifiedDlg.cpp:799
 msgid "The type of proxy you are connecting to"
 msgstr "Typ proxy, ke které se připojujete"
 
-#: src/PrefsUnifiedDlg.cpp:1020
+#: src/PrefsUnifiedDlg.cpp:1003
 #, c-format
 msgid "Failed to transfer data from Widget to Cfg with the ID %d and key %s"
 msgstr ""
 
 #: src/PrefsUnifiedDlg.cpp:1103
-#, fuzzy
-msgid "No password set."
-msgstr "Kontrola hesla\n"
-
-#: src/PrefsUnifiedDlg.cpp:1132
-msgid "Guest access needs a password. Type one in the guest password field, or untick Enable guest access."
-msgstr ""
-
-#: src/PrefsUnifiedDlg.cpp:1144
 msgid ""
 "aMule must be restarted to enable these changes:\n"
 "\n"
@@ -5774,89 +5731,84 @@ msgstr ""
 "Restartujte aMule, aby se projevily následující změny:\n"
 "\n"
 
-#: src/PrefsUnifiedDlg.cpp:1151
+#: src/PrefsUnifiedDlg.cpp:1110
 msgid "- TCP port changed.\n"
 msgstr "- TCP port změněn.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1156
+#: src/PrefsUnifiedDlg.cpp:1115
 msgid "- UDP port changed.\n"
 msgstr "- UDP port změněn.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1161
+#: src/PrefsUnifiedDlg.cpp:1120
 #, fuzzy
 msgid "- Network interface binding changed.\n"
 msgstr "Externí připojení uzavřeno."
 
-#: src/PrefsUnifiedDlg.cpp:1166
+#: src/PrefsUnifiedDlg.cpp:1125
 #, fuzzy
 msgid "- External connect port changed.\n"
 msgstr "Externí připojení uzavřeno."
 
-#: src/PrefsUnifiedDlg.cpp:1170
+#: src/PrefsUnifiedDlg.cpp:1129
 #, fuzzy
 msgid "- External connect acceptance changed.\n"
 msgstr "Nové externí připojení přijato"
 
-#: src/PrefsUnifiedDlg.cpp:1174
+#: src/PrefsUnifiedDlg.cpp:1133
 #, fuzzy
 msgid "- External connect interface changed.\n"
 msgstr "Externí připojení uzavřeno."
 
-#: src/PrefsUnifiedDlg.cpp:1178
+#: src/PrefsUnifiedDlg.cpp:1137
 #, fuzzy
 msgid "- Protocol obfuscation support changed.\n"
 msgstr "Zatemnění protokolu"
 
-#: src/PrefsUnifiedDlg.cpp:1193
+#: src/PrefsUnifiedDlg.cpp:1151
 #, fuzzy
 msgid "- amuleapi settings changed.\n"
 msgstr "- Jazyk byl změněn.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1202
+#: src/PrefsUnifiedDlg.cpp:1160
 msgid ""
 "Your Auto-update server list is empty.\n"
 "'Auto-update server list at startup' will be disabled."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1213
+#: src/PrefsUnifiedDlg.cpp:1171
 msgid ""
 "You have enabled external connections but have not specified a password.\n"
 "External connections cannot be enabled unless a valid password is specified."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1246
-#, c-format
-msgid "The amuleapi password could not be saved: %s"
-msgstr ""
-
-#: src/PrefsUnifiedDlg.cpp:1276
+#: src/PrefsUnifiedDlg.cpp:1202
 msgid "- Language changed.\n"
 msgstr "- Jazyk byl změněn.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1281
+#: src/PrefsUnifiedDlg.cpp:1207
 msgid "- Temp folder changed.\n"
 msgstr "- Dočasný adresář byl změněn.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1286
+#: src/PrefsUnifiedDlg.cpp:1212
 msgid "- ED2K network enabled.\n"
 msgstr "- Síť eD2k povolena.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1319
+#: src/PrefsUnifiedDlg.cpp:1245
 msgid "The shared-file exclusion pattern is not a valid regular expression. The filter has been left disabled."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1321 src/PrefsUnifiedDlg.cpp:1921
+#: src/PrefsUnifiedDlg.cpp:1247 src/PrefsUnifiedDlg.cpp:1841
 #, fuzzy
 msgid "Invalid regular expression"
 msgstr "Neplatná verze protokolu."
 
-#: src/PrefsUnifiedDlg.cpp:1398
+#: src/PrefsUnifiedDlg.cpp:1324
 msgid ""
 "Both eD2k and Kad network are disabled.\n"
 "You won't be able to connect until you enable at least one of them."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1403
+#: src/PrefsUnifiedDlg.cpp:1329
 msgid ""
 "Kad will not start if your UDP port is disabled.\n"
 "Enable UDP port or disable Kad."
@@ -5864,7 +5816,7 @@ msgstr ""
 "Kad se nespustí, když máte zakázaný UDP port.\n"
 "Povolte UDP port, nebo zakažte připojování na Kad."
 
-#: src/PrefsUnifiedDlg.cpp:1459
+#: src/PrefsUnifiedDlg.cpp:1385
 msgid ""
 "\n"
 "You MUST restart aMule now.\n"
@@ -5874,93 +5826,93 @@ msgstr ""
 "Nyní MUSÍTE restartovat aMule.\n"
 "Pokud to neuděláte, tak si pak nestěžujte, když se přihodí něco špatného.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1524
+#: src/PrefsUnifiedDlg.cpp:1450
 msgid "Could not register aMule for autostart at login. The autostart store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1526
+#: src/PrefsUnifiedDlg.cpp:1452
 msgid "Could not remove the autostart-at-login entry."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1527
+#: src/PrefsUnifiedDlg.cpp:1453
 #, fuzzy
 msgid "Autostart"
 msgstr "Automatické obnovování spuštěno"
 
-#: src/PrefsUnifiedDlg.cpp:1542
+#: src/PrefsUnifiedDlg.cpp:1468
 msgid "Register file type"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1542
+#: src/PrefsUnifiedDlg.cpp:1468
 msgid "Register URL handler"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1550
+#: src/PrefsUnifiedDlg.cpp:1476
 #, c-format
 msgid "aMule only handles eD2k-compatible magnets. If you replace the current magnet handler (%s), BitTorrent magnet links will stop working - aMule cannot download BitTorrent content. Continue?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1555
+#: src/PrefsUnifiedDlg.cpp:1481
 #, c-format
 msgid "Another application currently opens .emulecollection files (%s). Replace it with aMule?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1560
+#: src/PrefsUnifiedDlg.cpp:1486
 #, c-format
 msgid "Another application is currently the default handler for these links (%s). Replace it with aMule?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1585
+#: src/PrefsUnifiedDlg.cpp:1511
 msgid "Could not register aMule for .emulecollection files. The registration store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1587
+#: src/PrefsUnifiedDlg.cpp:1513
 #, fuzzy
 msgid "Could not remove the file type registration."
 msgstr "Soubor %s se již pokoušíte stáhnout"
 
-#: src/PrefsUnifiedDlg.cpp:1589
+#: src/PrefsUnifiedDlg.cpp:1515
 msgid "Could not register aMule as the URL handler. The registration store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1591
+#: src/PrefsUnifiedDlg.cpp:1517
 msgid "Could not remove the URL handler registration."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1661 src/PrefsUnifiedDlg.cpp:1688
+#: src/PrefsUnifiedDlg.cpp:1587 src/PrefsUnifiedDlg.cpp:1614
 #, fuzzy
 msgid "The web server and aMule API require external connections to be enabled."
 msgstr "Heslo nastaveno a externí připojení povoleno."
 
-#: src/PrefsUnifiedDlg.cpp:1671
+#: src/PrefsUnifiedDlg.cpp:1597
 msgid "The aMule web server is deprecated. Consider running the aMule API instead."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1735
+#: src/PrefsUnifiedDlg.cpp:1655
 msgid ""
 "Your Auto-update servers list is in blank.\n"
 "Please fill in at least one URL to point to a valid server.met file.\n"
 "Click on the button \"List\" by this checkbox to enter an URL."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1876
+#: src/PrefsUnifiedDlg.cpp:1796
 msgid "Temporary files"
 msgstr "Dočasné soubory"
 
-#: src/PrefsUnifiedDlg.cpp:1881
+#: src/PrefsUnifiedDlg.cpp:1801
 msgid "Incoming files"
 msgstr "Příchozí soubory"
 
-#: src/PrefsUnifiedDlg.cpp:1886
+#: src/PrefsUnifiedDlg.cpp:1806
 msgid "Online Signatures"
 msgstr "Online podpisy"
 
-#: src/PrefsUnifiedDlg.cpp:1899
+#: src/PrefsUnifiedDlg.cpp:1819
 #, c-format
 msgid "Choose a folder for %s"
 msgstr "Zvolte adresář pro %s"
 
-#: src/PrefsUnifiedDlg.cpp:1923
+#: src/PrefsUnifiedDlg.cpp:1843
 #, fuzzy, c-format
 msgid "Would exclude %u of %u shared file"
 msgid_plural "Would exclude %u of %u shared files"
@@ -5968,42 +5920,42 @@ msgstr[0] "Znovu načíst vaše sdílené soubory"
 msgstr[1] "Znovu načíst vaše sdílené soubory"
 msgstr[2] "Znovu načíst vaše sdílené soubory"
 
-#: src/PrefsUnifiedDlg.cpp:1940
+#: src/PrefsUnifiedDlg.cpp:1860
 msgid "Browse for videoplayer"
 msgstr "Zvolit přehrávač videa"
 
-#: src/PrefsUnifiedDlg.cpp:1944
+#: src/PrefsUnifiedDlg.cpp:1864
 msgid "Select browser"
 msgstr "Výběr prohlížeče"
 
-#: src/PrefsUnifiedDlg.cpp:1948
+#: src/PrefsUnifiedDlg.cpp:1868
 #, fuzzy
 msgid "Select ffprobe binary"
 msgstr "Výběr prohlížeče"
 
-#: src/PrefsUnifiedDlg.cpp:1954
+#: src/PrefsUnifiedDlg.cpp:1874
 #, c-format
 msgid "Executable%s"
 msgstr "Spustitelný soubor %s"
 
-#: src/PrefsUnifiedDlg.cpp:1988
+#: src/PrefsUnifiedDlg.cpp:1908
 msgid "ffprobe not found on PATH or in the standard install locations. Install ffmpeg (which ships ffprobe) or use Browse to pick a binary manually."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2000
+#: src/PrefsUnifiedDlg.cpp:1920
 msgid "Reset the settings on this page to their default values?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2001
+#: src/PrefsUnifiedDlg.cpp:1921
 #, fuzzy
 msgid "Reset to defaults"
 msgstr "Výchozí pro systém"
 
-#: src/PrefsUnifiedDlg.cpp:2028
+#: src/PrefsUnifiedDlg.cpp:1948
 msgid "Edit server list"
 msgstr "Upravit seznam serverů"
 
-#: src/PrefsUnifiedDlg.cpp:2029
+#: src/PrefsUnifiedDlg.cpp:1949
 msgid ""
 "Add here URL's to download server.met files.\n"
 "Only one url on each line."
@@ -6011,42 +5963,42 @@ msgstr ""
 "Sem přidejte URL pro stažení server.met souborů.\n"
 "Pouze jedno URL na každý řádek."
 
-#: src/PrefsUnifiedDlg.cpp:2084
+#: src/PrefsUnifiedDlg.cpp:2004
 msgid "IP2Country update failed"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2229 src/PrefsUnifiedDlg.cpp:2260
+#: src/PrefsUnifiedDlg.cpp:2149 src/PrefsUnifiedDlg.cpp:2180
 msgid "Data by MaxMind GeoLite2"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2231 src/PrefsUnifiedDlg.cpp:2262
+#: src/PrefsUnifiedDlg.cpp:2151 src/PrefsUnifiedDlg.cpp:2182
 #, fuzzy
 msgid "Custom source"
 msgstr "Kompletní zdroje"
 
-#: src/PrefsUnifiedDlg.cpp:2233 src/PrefsUnifiedDlg.cpp:2264
+#: src/PrefsUnifiedDlg.cpp:2153 src/PrefsUnifiedDlg.cpp:2184
 msgid "Data by DB-IP.com"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2284
+#: src/PrefsUnifiedDlg.cpp:2204
 #, fuzzy, c-format
 msgid "Status: Loaded%s"
 msgstr "Stav:"
 
-#: src/PrefsUnifiedDlg.cpp:2286
+#: src/PrefsUnifiedDlg.cpp:2206
 #, fuzzy, c-format
 msgid "Status: Loaded%s - %s"
 msgstr "Stav:"
 
-#: src/PrefsUnifiedDlg.cpp:2290
+#: src/PrefsUnifiedDlg.cpp:2210
 msgid "Status: Failed to load - click 'Update now' to refresh."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2292
+#: src/PrefsUnifiedDlg.cpp:2212
 msgid "Status: Not found - click 'Update now' to download."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2350 src/PrefsUnifiedDlg.cpp:2374
+#: src/PrefsUnifiedDlg.cpp:2270 src/PrefsUnifiedDlg.cpp:2294
 #, c-format
 msgid "Update delay: %d second"
 msgid_plural "Update delay: %d seconds"
@@ -6054,7 +6006,7 @@ msgstr[0] ""
 msgstr[1] ""
 msgstr[2] ""
 
-#: src/PrefsUnifiedDlg.cpp:2358
+#: src/PrefsUnifiedDlg.cpp:2278
 #, fuzzy, c-format
 msgid "Time for average graph: %d minute"
 msgid_plural "Time for average graph: %d minutes"
@@ -6062,12 +6014,12 @@ msgstr[0] "Čas pro průměrný graf: %d minut"
 msgstr[1] "Čas pro průměrný graf: %d minut"
 msgstr[2] ""
 
-#: src/PrefsUnifiedDlg.cpp:2367
+#: src/PrefsUnifiedDlg.cpp:2287
 #, c-format
 msgid "Connections Graph Scale: %d"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2382
+#: src/PrefsUnifiedDlg.cpp:2302
 #, fuzzy, c-format
 msgid "File Buffer Size: %d byte"
 msgid_plural "File Buffer Size: %d bytes"
@@ -6075,7 +6027,7 @@ msgstr[0] "Velikost zásobníku pro soubory: %d bajtů"
 msgstr[1] "Velikost zásobníku pro soubory: %d bajtů"
 msgstr[2] ""
 
-#: src/PrefsUnifiedDlg.cpp:2392
+#: src/PrefsUnifiedDlg.cpp:2312
 #, fuzzy, c-format
 msgid "Upload Queue Size: %d client"
 msgid_plural "Upload Queue Size: %d clients"
@@ -6083,7 +6035,7 @@ msgstr[0] "Velikost fronty pro odesílání: %d klientů"
 msgstr[1] "Velikost fronty pro odesílání: %d klientů"
 msgstr[2] ""
 
-#: src/PrefsUnifiedDlg.cpp:2402
+#: src/PrefsUnifiedDlg.cpp:2322
 #, fuzzy, c-format
 msgid "Server connection refresh interval: %d minute"
 msgid_plural "Server connection refresh interval: %d minutes"
@@ -6091,105 +6043,101 @@ msgstr[0] "Interval pro obnovení připojení k serveru: %d minut"
 msgstr[1] "Interval pro obnovení připojení k serveru: %d minut"
 msgstr[2] ""
 
-#: src/PrefsUnifiedDlg.cpp:2407
+#: src/PrefsUnifiedDlg.cpp:2327
 msgid "Server connection refresh interval: Disabled"
 msgstr "Interval pro obnovení připojení k serveru: Zakázáno"
 
-#: src/PrefsUnifiedDlg.cpp:2451
+#: src/PrefsUnifiedDlg.cpp:2371
 msgid "disabled"
 msgstr "zakázáno"
 
-#: src/PrefsUnifiedDlg.cpp:2477
+#: src/PrefsUnifiedDlg.cpp:2397
 #, fuzzy, c-format
 msgid "Execute command on '%s' event"
 msgstr "Spustí příkaz při událost `%s'"
 
-#: src/PrefsUnifiedDlg.cpp:2484
+#: src/PrefsUnifiedDlg.cpp:2404
 msgid "Enable command execution on core"
 msgstr "Povolit jaderné příkazy"
 
-#: src/PrefsUnifiedDlg.cpp:2496
+#: src/PrefsUnifiedDlg.cpp:2416
 msgid "Core command:"
 msgstr "Příkaz jádra:"
 
-#: src/PrefsUnifiedDlg.cpp:2512
+#: src/PrefsUnifiedDlg.cpp:2432
 msgid "Enable command execution on GUI"
 msgstr "Povolit GUI příkazy"
 
-#: src/PrefsUnifiedDlg.cpp:2524
+#: src/PrefsUnifiedDlg.cpp:2444
 msgid "GUI command:"
 msgstr "Příkaz GUI:"
 
-#: src/PrefsUnifiedDlg.cpp:2540
+#: src/PrefsUnifiedDlg.cpp:2460
 msgid "The following variables will be replaced:"
 msgstr "Následující proměnné budou nahrazeny:"
 
-#: src/PrefsUnifiedDlg.cpp:2708
+#: src/PrefsUnifiedDlg.cpp:2628
 msgid ""
 "The following folders look like system or sensitive locations:\n"
 "\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2713
+#: src/PrefsUnifiedDlg.cpp:2633
 msgid "Sharing them recursively will publish every file underneath on the eD2k/Kad networks. Do you really want to do this?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2716
+#: src/PrefsUnifiedDlg.cpp:2636
 #, fuzzy
 msgid "Confirm shared folders"
 msgstr "Sdílené adresáře"
 
-#: src/PrefsUnifiedDlg.cpp:2744
+#: src/PrefsUnifiedDlg.cpp:2664
 #, fuzzy
 msgid "Reloading shared files..."
 msgstr "Znovu načíst vaše sdílené soubory"
 
-#: src/PrefsUnifiedDlg.cpp:2745
+#: src/PrefsUnifiedDlg.cpp:2665
 msgid "Scanning for subdirectories..."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2746
+#: src/PrefsUnifiedDlg.cpp:2666
 #, fuzzy
 msgid "Updating shared folders"
 msgstr "Sdílené adresáře"
 
-#: src/PrefsUnifiedDlg.cpp:2773
+#: src/PrefsUnifiedDlg.cpp:2693
 #, c-format
 msgid "Scanned %u directories..."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2823
+#: src/PrefsUnifiedDlg.cpp:2743
 #, fuzzy, c-format
 msgid "Reloading shared files: %u files scanned"
 msgstr "Znovu načte seznam sdílených souborů."
 
-#: src/PrefsUnifiedDlg.cpp:2873
+#: src/PrefsUnifiedDlg.cpp:2793
 #, fuzzy
 msgid "Shared folder"
 msgstr "Sdílené adresáře"
 
-#: src/SearchDlg.cpp:280
-msgid "Clear search history"
-msgstr ""
-
-#: src/SearchDlg.cpp:584
+#: src/SearchDlg.cpp:425
 msgid "It's impossible to search when both eD2k and Kademlia are disabled."
 msgstr ""
 
-#: src/SearchDlg.cpp:585 src/SearchListCtrl.cpp:858
+#: src/SearchDlg.cpp:426 src/SearchListCtrl.cpp:858
 #, fuzzy
 msgid "Search error"
 msgstr "Vyhledávání"
 
-#: src/SearchDlg.cpp:929
+#: src/SearchDlg.cpp:768
 msgid "Min size must be smaller than max size. Max size ignored."
 msgstr "Min. velikost musí být menší než max. velikost. Ignoruji max. velikost."
 
-#: src/SearchDlg.cpp:930 src/SearchDlg.cpp:1012
+#: src/SearchDlg.cpp:769 src/SearchDlg.cpp:851
 msgid "Search warning"
 msgstr "Varování při vyhledávání"
 
-#: src/SearchDlg.cpp:1092 src/SearchListCtrl.cpp:735
+#: src/SearchDlg.cpp:929 src/SearchListCtrl.cpp:735
 msgid "Main"
 msgstr "Hlavní"
 

--- a/po/cs.po
+++ b/po/cs.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-28 10:19+0200\n"
+"POT-Creation-Date: 2026-07-28 12:17+0200\n"
 "PO-Revision-Date: 2026-07-27 11:34+0000\n"
 "Last-Translator: David Watzke <david@watzke.cz>\n"
 "Language-Team: cs <cs@li.org>\n"
@@ -201,83 +201,83 @@ msgstr "Selhalo otvírání souboru ED2KLinks."
 msgid "WARNING: You can't add yourself as a source for an eD2k link while having a lowid."
 msgstr "VAROVÁNÍ: Nemůžete přidat sebe jako zdroj pro eD2k odkaz, když máte LowID."
 
-#: src/amule.cpp:300
+#: src/amule.cpp:301
 msgid "Now, exiting main app..."
 msgstr "Ukončuji hlavní aplikaci..."
 
-#: src/amule.cpp:330
+#: src/amule.cpp:331
 #, c-format
 msgid "Terminating amuleweb instance with pid '%d' ... "
 msgstr "Ukončuji instanci amuleweb s PID `%d'..."
 
-#: src/amule.cpp:334
+#: src/amule.cpp:335
 #, c-format
 msgid "Killing amuleweb instance with pid '%d' ... "
 msgstr "Zabíjím instanci amuleweb s PID `%d'..."
 
-#: src/amule.cpp:336 src/amule.cpp:349 src/ClientRef.cpp:180
+#: src/amule.cpp:337 src/amule.cpp:350 src/ClientRef.cpp:180
 #: src/SearchDlg.cpp:1041 src/ServerListCtrl.cpp:98
 msgid "Failed"
 msgstr "Selhal"
 
-#: src/amule.cpp:343
+#: src/amule.cpp:344
 #, fuzzy, c-format
 msgid "Terminating amuleapi instance with pid '%d' ... "
 msgstr "Ukončuji instanci amuleweb s PID `%d'..."
 
-#: src/amule.cpp:347
+#: src/amule.cpp:348
 #, fuzzy, c-format
 msgid "Killing amuleapi instance with pid '%d' ... "
 msgstr "Zabíjím instanci amuleweb s PID `%d'..."
 
-#: src/amule.cpp:355
+#: src/amule.cpp:356
 msgid "aMule OnExit: Terminating core."
 msgstr "aMule OnExit: Ukončuji jádro."
 
-#: src/amule.cpp:466
+#: src/amule.cpp:467
 msgid "aMule shutdown completed."
 msgstr "Ukončení aMule dokončeno."
 
-#: src/amule.cpp:470
+#: src/amule.cpp:471
 msgid "Memory debug results for aMule exit:"
 msgstr ""
 
-#: src/amule.cpp:651
+#: src/amule.cpp:652
 #, c-format
 msgid "Binding aMule's peer-to-peer traffic to interface: %s (HTTP updates use the default route)"
 msgstr ""
 
-#: src/amule.cpp:655
+#: src/amule.cpp:656
 #, c-format
 msgid "Binding all network traffic to interface: %s"
 msgstr ""
 
-#: src/amule.cpp:659
+#: src/amule.cpp:660
 #, c-format
 msgid "WARNING: configured network interface '%s' was not found - traffic is NOT bound to it and may leave via the default route. Check the interface name in Preferences."
 msgstr ""
 
-#: src/amule.cpp:665
+#: src/amule.cpp:666
 #, c-format
 msgid "WARNING: binding to network interface '%s' requires elevated privileges and was NOT applied - traffic may leave via the default route. Grant the capability (e.g. 'sudo setcap cap_net_raw+ep' on the aMule binary) or run with sufficient privileges."
 msgstr ""
 
-#: src/amule.cpp:673
+#: src/amule.cpp:674
 #, c-format
 msgid "WARNING: could not bind to network interface '%s' - traffic may leave via the default route."
 msgstr ""
 
-#: src/amule.cpp:732
+#: src/amule.cpp:733
 msgid "Your locale has been changed to System Default due to a configuration change. Sorry."
 msgstr "Vaše nastavení locale bylo změněno na výchozí systémové nastavení kvůli změně v konfiguraci. Pardon."
 
-#: src/amule.cpp:734 src/amule.cpp:1581 src/CatDialog.cpp:128
+#: src/amule.cpp:735 src/amule.cpp:1589 src/CatDialog.cpp:128
 #: src/CatDialog.cpp:136 src/CatDialog.cpp:149 src/ServerList.cpp:366
 #: src/ServerListCtrl.cpp:152
 msgid "Info"
 msgstr "Info"
 
-#: src/amule.cpp:741
+#: src/amule.cpp:742
 msgid ""
 "\n"
 "EC configuration"
@@ -285,71 +285,71 @@ msgstr ""
 "\n"
 "Konfigurace EC"
 
-#: src/amule.cpp:744
+#: src/amule.cpp:745
 msgid "Password set and external connections enabled."
 msgstr "Heslo nastaveno a externí připojení povoleno."
 
-#: src/amule.cpp:754 src/KadDlg.cpp:176 src/KadDlg.cpp:185
-#: src/PrefsUnifiedDlg.cpp:1387 src/SharedFilesCtrl.cpp:476
+#: src/amule.cpp:755 src/KadDlg.cpp:176 src/KadDlg.cpp:185
+#: src/PrefsUnifiedDlg.cpp:1461 src/SharedFilesCtrl.cpp:476
 msgid "WARNING"
 msgstr "VAROVÁNÍ"
 
-#: src/amule.cpp:991
+#: src/amule.cpp:992
 #, fuzzy
 msgid "Network bootstrap"
 msgstr "Sítě"
 
-#: src/amule.cpp:996
+#: src/amule.cpp:997
 msgid ""
 "aMule has detected missing network bootstrap files.\n"
 "Select which ones to download:"
 msgstr ""
 
-#: src/amule.cpp:1005 src/FirstRunWizard.cpp:411
+#: src/amule.cpp:1006 src/FirstRunWizard.cpp:411
 msgid "eD2k server list (server.met)"
 msgstr ""
 
-#: src/amule.cpp:1012 src/FirstRunWizard.cpp:416
+#: src/amule.cpp:1013 src/FirstRunWizard.cpp:416
 msgid "Kad bootstrap nodes (nodes.dat)"
 msgstr ""
 
-#: src/amule.cpp:1102
+#: src/amule.cpp:1103
 #, c-format
 msgid "web server running on pid %d"
 msgstr "webserver běží s PID %d"
 
-#: src/amule.cpp:1115
+#: src/amule.cpp:1116
 msgid "You requested to run web server on startup, but the amuleweb binary cannot be run. Please install the package containing aMule web server, or build aMule from source with -DBUILD_WEBSERVER=YES and install it."
 msgstr ""
 
-#: src/amule.cpp:1120 src/amule.cpp:1177 src/amule.cpp:1291 src/amule.cpp:1593
+#: src/amule.cpp:1121 src/amule.cpp:1185 src/amule.cpp:1299 src/amule.cpp:1601
 #: src/amule-remote-gui.cpp:603 src/amule-remote-gui.cpp:671
 #: src/amule-remote-gui.cpp:709 src/amule-remote-gui.cpp:1282
 #: src/amule-remote-gui.cpp:1345 src/amule-remote-gui.cpp:1372
-#: src/DownloadQueue.cpp:1481
+#: src/DownloadQueue.cpp:1481 src/PrefsUnifiedDlg.cpp:1247
 msgid "ERROR"
 msgstr "CHYBA"
 
-#: src/amule.cpp:1166
+#: src/amule.cpp:1174
 #, fuzzy, c-format
 msgid "amuleapi running on pid %d"
 msgstr "webserver běží s PID %d"
 
-#: src/amule.cpp:1172
+#: src/amule.cpp:1180
 msgid "You requested to run amuleapi on startup, but the amuleapi binary cannot be run. Please install the package containing aMule's REST API server, or build aMule from source with -DBUILD_AMULEAPI=YES and install it."
 msgstr ""
 
-#: src/amule.cpp:1259
+#: src/amule.cpp:1267
 #, c-format
 msgid "Could not bind ports to the specified address: %s"
 msgstr ""
 
-#: src/amule.cpp:1283
+#: src/amule.cpp:1291
 #, c-format
 msgid "Port %u is not available. You will be LOWID\n"
 msgstr "Port %u je nedostupný. Budete mít LowID\n"
 
-#: src/amule.cpp:1288
+#: src/amule.cpp:1296
 #, c-format
 msgid ""
 "Port %u is not available!\n"
@@ -364,184 +364,184 @@ msgstr ""
 "\n"
 "Zkontrolujte nastavení vaší sítě a ujistěte se, že je port v obou směrech otevřený."
 
-#: src/amule.cpp:1385
+#: src/amule.cpp:1393
 msgid "Failed to create OnlineSig File"
 msgstr "Selhalo vytvoření OnlineSig souboru"
 
-#: src/amule.cpp:1393
+#: src/amule.cpp:1401
 msgid "Failed to create aMule OnlineSig File"
 msgstr "Selhalo vytvoření aMule OnlineSig souboru"
 
-#: src/amule.cpp:1556
+#: src/amule.cpp:1564
 msgid "The selected locale seems not to be installed on your box. (Note: I'll try to set it anyway)"
 msgstr ""
 
-#: src/amule.cpp:1566
+#: src/amule.cpp:1574
 #, c-format
 msgid "This is the first time you run aMule %s"
 msgstr "Toto je vaše první spuštění aMule %s"
 
-#: src/amule.cpp:1569
+#: src/amule.cpp:1577
 msgid "This version is a testing version, updated daily, and\n"
 msgstr "Toto je testovací verze, která je denně aktualizovaná a\n"
 
-#: src/amule.cpp:1570
+#: src/amule.cpp:1578
 msgid "we give no warranty it won't break anything, burn your house,\n"
 msgstr "my nezaručujeme, že nemůže nic pokazit, zapálit váš dům,\n"
 
-#: src/amule.cpp:1571
+#: src/amule.cpp:1579
 msgid "or kill your dog. But it *should* be safe to use anyway.\n"
 msgstr "nebo zabít vašeho psa. Nicméně i tak by *mělo* být její používání bezpečné.\n"
 
-#: src/amule.cpp:1576
+#: src/amule.cpp:1584
 msgid "More information, support and new releases can found at our homepage,\n"
 msgstr "Více informací, podporu a nová vydání naleznete na naší domovské stránce,\n"
 
-#: src/amule.cpp:1577
+#: src/amule.cpp:1585
 msgid "at https://amule-org.github.io, or in our IRC channel #aMule at irc.libera.chat.\n"
 msgstr "na https://amule-org.github.io, nebo na našem IRC kanálu #aMule na irc.libera.chat.\n"
 
-#: src/amule.cpp:1579
+#: src/amule.cpp:1587
 msgid "Feel free to report any bugs to https://github.com/amule-org/amule/issues"
 msgstr "Hlašte chyby na adrese https://github.com/amule-org/amule/issues"
 
-#: src/amule.cpp:1591
+#: src/amule.cpp:1599
 msgid ""
 "The folder for Online Signature files you specified is INVALID!\n"
 " OnlineSignature will be DISABLED until you fix it on preferences."
 msgstr ""
 
-#: src/amule.cpp:1654
+#: src/amule.cpp:1662
 msgid "Server hostname notified"
 msgstr ""
 
-#: src/amule.cpp:2031
+#: src/amule.cpp:2039
 #, c-format
 msgid "Disk space preallocation for file '%s' failed: %s"
 msgstr "Předalokace místa na disku pro soubor '%s' selhala: %s"
 
-#: src/amule.cpp:2160
+#: src/amule.cpp:2168
 msgid "ERROR: can't open logfile"
 msgstr "CHYBA: nelze otevřít logovací soubor"
 
-#: src/amule.cpp:2164
+#: src/amule.cpp:2172
 msgid "WARNING: logfile is empty. Something is wrong."
 msgstr "VAROVÁNÍ: log je prázdný. Něco je špatně."
 
-#: src/amule.cpp:2181
+#: src/amule.cpp:2189
 msgid "Log has been reset"
 msgstr "Log byl vymazán"
 
-#: src/amule.cpp:2205
+#: src/amule.cpp:2213
 #, c-format
 msgid "ServerMessage: %s"
 msgstr "Zpráva od serveru: %s"
 
-#: src/amule.cpp:2248 src/IP2Country.cpp:220 src/IPFilter.cpp:514
+#: src/amule.cpp:2256 src/IP2Country.cpp:220 src/IPFilter.cpp:514
 #: src/ServerList.cpp:875
 #, c-format
 msgid "Skipped download of %s, because requested file is not newer."
 msgstr ""
 
-#: src/amule.cpp:2251
+#: src/amule.cpp:2259
 msgid "Failed to download the nodes list."
 msgstr "Selhalo stahování seznamu uzlů."
 
-#: src/amule.cpp:2314
+#: src/amule.cpp:2322
 msgid "Failed to open the downloaded version check file"
 msgstr "Selhalo otvírání staženého kontrolního souboru s verzí"
 
-#: src/amule.cpp:2317 src/amule.cpp:2336
+#: src/amule.cpp:2325 src/amule.cpp:2344
 msgid "Corrupted version check file"
 msgstr "Porušený soubor pro kontrolu verze"
 
-#: src/amule.cpp:2359
+#: src/amule.cpp:2367
 msgid "You are using an outdated version of aMule!"
 msgstr "Používáte zastaralou verzi aMule!"
 
-#: src/amule.cpp:2361
+#: src/amule.cpp:2369
 #, c-format
 msgid "Your aMule version is %i.%i.%i and the latest version is %li.%li.%li"
 msgstr "Vaše verze aMule je %i.%i.%i a poslední verze je %li.%li.%li"
 
-#: src/amule.cpp:2365
+#: src/amule.cpp:2373
 msgid "The latest version can always be found at https://github.com/amule-org/amule/releases/latest"
 msgstr "Poslední verze jsou vždy k nalezení na https://github.com/amule-org/amule/releases/latest "
 
-#: src/amule.cpp:2368
+#: src/amule.cpp:2376
 #, c-format
 msgid "WARNING: Your aMuled version is outdated: %i.%i.%i < %li.%li.%li"
 msgstr "VAROVÁNÍ: Vaše verze aMuled je zastaralá: %i.%i.%i < %li.%li.%li"
 
-#: src/amule.cpp:2374
+#: src/amule.cpp:2382
 msgid "Your copy of aMule is up to date."
 msgstr "Vaše verze aMule je aktuální."
 
-#: src/amule.cpp:2381
+#: src/amule.cpp:2389
 msgid "Failed to download the version check file"
 msgstr "Selhalo stahování kontrolního souboru s verzí"
 
-#: src/amule.cpp:2550 src/amule-remote-gui.cpp:1133
+#: src/amule.cpp:2558 src/amule-remote-gui.cpp:1133
 #, c-format
 msgid "Users: %s | Files: %s"
 msgstr "Uživatelů: %s | Souborů: %s"
 
-#: src/amule.cpp:2551 src/amule-remote-gui.cpp:1134
+#: src/amule.cpp:2559 src/amule-remote-gui.cpp:1134
 #, c-format
 msgid "Users: E: %s K: %s | Files: E: %s K: %s"
 msgstr "Uživatelů: E: %s K: %s | Souborů: E: %s K: %s"
 
-#: src/amule.cpp:2565 src/amule-remote-gui.cpp:1147
+#: src/amule.cpp:2573 src/amule-remote-gui.cpp:1147
 msgid "No networks selected"
 msgstr "Nezvoleny žádné sítě"
 
-#: src/amule.cpp:2633 src/TextClient.cpp:903
+#: src/amule.cpp:2641 src/TextClient.cpp:903
 msgid "with LowID"
 msgstr "s LowID"
 
-#: src/amule.cpp:2633 src/TextClient.cpp:904
+#: src/amule.cpp:2641 src/TextClient.cpp:904
 msgid "with HighID"
 msgstr "s HighID"
 
-#: src/amule.cpp:2635
+#: src/amule.cpp:2643
 #, c-format
 msgid "Connected to %s %s"
 msgstr "Připojen k %s %s"
 
-#: src/amule.cpp:2640
+#: src/amule.cpp:2648
 #, c-format
 msgid "Connecting to %s"
 msgstr "Připojování k %s"
 
-#: src/amule.cpp:2642
+#: src/amule.cpp:2650
 msgid "Disconnected from eD2k"
 msgstr "Odpojen od eD2k"
 
-#: src/amule.cpp:2651
+#: src/amule.cpp:2659
 msgid "Kad started."
 msgstr "Kad spuštěn."
 
-#: src/amule.cpp:2653
+#: src/amule.cpp:2661
 msgid "Kad stopped."
 msgstr "Kad zastaven."
 
-#: src/amule.cpp:2661
+#: src/amule.cpp:2669
 msgid "Connected to Kad (ok)"
 msgstr "Připojen ke Kad (ok)"
 
-#: src/amule.cpp:2663
+#: src/amule.cpp:2671
 msgid "Connected to Kad (firewalled)"
 msgstr "Připojen ke kad (za firewallem)"
 
-#: src/amule.cpp:2667
+#: src/amule.cpp:2675
 msgid "Disconnected from Kad"
 msgstr "Odpojen od Kad"
 
-#: src/amule.cpp:2699
+#: src/amule.cpp:2707
 msgid "Kad network cannot be used if UDP port is disabled on preferences, not starting."
 msgstr "Síť Kad nelze použít, když je v nastavení zakázán UDP port."
 
-#: src/amule.cpp:2703
+#: src/amule.cpp:2711
 msgid "Kad network disabled on preferences, not connecting."
 msgstr "Síť Kad je zakázána v nastavení, nepřipojuji se."
 
@@ -586,36 +586,36 @@ msgid "FATAL ERROR: Failed to create Timer"
 msgstr "KRITICKÁ CHYBA: Vytváření časovače selhalo"
 
 #: src/amuleDlg.cpp:361 src/amuleDlg.cpp:1787 src/amuleDlg.cpp:2033
-#: src/muuli_wdr.cpp:1492 src/muuli_wdr.cpp:3418
+#: src/muuli_wdr.cpp:1492 src/muuli_wdr.cpp:3449
 msgid "Networks"
 msgstr "Sítě"
 
-#: src/amuleDlg.cpp:362 src/amuleDlg.cpp:1793 src/muuli_wdr.cpp:3419
+#: src/amuleDlg.cpp:362 src/amuleDlg.cpp:1793 src/muuli_wdr.cpp:3450
 msgid "Searches"
 msgstr "Vyhledávání"
 
 #: src/amuleDlg.cpp:363 src/amuleDlg.cpp:1799 src/DownloadListCtrl.cpp:740
-#: src/muuli_wdr.cpp:392 src/muuli_wdr.cpp:1585 src/muuli_wdr.cpp:3420
+#: src/muuli_wdr.cpp:392 src/muuli_wdr.cpp:1585 src/muuli_wdr.cpp:3451
 #: src/Statistics.cpp:829
 msgid "Downloads"
 msgstr "Stahování"
 
-#: src/amuleDlg.cpp:364 src/amuleDlg.cpp:1805 src/muuli_wdr.cpp:3294
+#: src/amuleDlg.cpp:364 src/amuleDlg.cpp:1805 src/muuli_wdr.cpp:3325
 msgid "Shared files"
 msgstr "Sdílené soubory"
 
-#: src/amuleDlg.cpp:365 src/amuleDlg.cpp:1811 src/muuli_wdr.cpp:2926
-#: src/muuli_wdr.cpp:3376 src/muuli_wdr.cpp:3423
+#: src/amuleDlg.cpp:365 src/amuleDlg.cpp:1811 src/muuli_wdr.cpp:2957
+#: src/muuli_wdr.cpp:3407 src/muuli_wdr.cpp:3454
 msgid "Messages"
 msgstr "Zprávy"
 
-#: src/amuleDlg.cpp:366 src/amuleDlg.cpp:1817 src/muuli_wdr.cpp:3424
-#: src/PrefsUnifiedDlg.cpp:312 src/Statistics.cpp:779 src/Statistics.cpp:1235
+#: src/amuleDlg.cpp:366 src/amuleDlg.cpp:1817 src/muuli_wdr.cpp:3455
+#: src/PrefsUnifiedDlg.cpp:314 src/Statistics.cpp:779 src/Statistics.cpp:1235
 msgid "Statistics"
 msgstr "Statistiky"
 
-#: src/amuleDlg.cpp:368 src/amuleDlg.cpp:1824 src/muuli_wdr.cpp:3426
-#: src/PrefsUnifiedDlg.cpp:328 src/utils/wxCas/src/wxcasprefs.cpp:39
+#: src/amuleDlg.cpp:368 src/amuleDlg.cpp:1824 src/muuli_wdr.cpp:3457
+#: src/PrefsUnifiedDlg.cpp:330 src/utils/wxCas/src/wxcasprefs.cpp:39
 msgid "Preferences"
 msgstr "Nastavení"
 
@@ -673,8 +673,8 @@ msgstr "Kad: vypnut"
 #: src/amuleDlg.cpp:1029 src/DownloadListCtrl.cpp:505
 #: src/DownloadListCtrl.cpp:749 src/FriendListCtrl.cpp:180
 #: src/muuli_wdr.cpp:731 src/muuli_wdr.cpp:782 src/muuli_wdr.cpp:846
-#: src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2231 src/muuli_wdr.cpp:2316
-#: src/muuli_wdr.cpp:3064 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
+#: src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2262 src/muuli_wdr.cpp:2347
+#: src/muuli_wdr.cpp:3095 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
 #: src/ServerListCtrl.cpp:606 src/TransferWnd.cpp:378
 #: src/utils/wxCas/src/wxcasprefs.cpp:235
 msgid "Cancel"
@@ -685,7 +685,7 @@ msgid "Stop the current connection attempts"
 msgstr "Zastaví aktuální pokusy o připojení"
 
 #: src/amuleDlg.cpp:1035 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976
-#: src/muuli_wdr.cpp:2454
+#: src/muuli_wdr.cpp:2485
 msgid "Disconnect"
 msgstr "Odpojit"
 
@@ -694,7 +694,7 @@ msgid "Disconnect from the currently connected networks"
 msgstr "Odpojit se od aktuálně připojených sítí"
 
 #: src/amuleDlg.cpp:1041 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979
-#: src/muuli_wdr.cpp:2609 src/muuli_wdr.cpp:3061 src/muuli_wdr.cpp:3416
+#: src/muuli_wdr.cpp:2640 src/muuli_wdr.cpp:3092 src/muuli_wdr.cpp:3447
 msgid "Connect"
 msgstr "Připojit"
 
@@ -749,7 +749,7 @@ msgstr "Potvrzení ukončení"
 msgid "Launch Command: "
 msgstr "Spustit příkaz: "
 
-#: src/amuleDlg.cpp:1632 src/muuli_wdr.cpp:1978 src/Preferences.cpp:952
+#: src/amuleDlg.cpp:1632 src/muuli_wdr.cpp:1982 src/Preferences.cpp:979
 msgid "- default -"
 msgstr "- výchozí -"
 
@@ -763,48 +763,48 @@ msgstr "Adresář se skiny '%s' neexistuje"
 msgid "WARNING: Unable to open skin file '%s' for read"
 msgstr "VAROVÁNÍ: Nelze otevřít soubor se vzhledem '%s' pro čtení"
 
-#: src/amuleDlg.cpp:1791 src/muuli_wdr.cpp:3418
+#: src/amuleDlg.cpp:1791 src/muuli_wdr.cpp:3449
 msgid "Networks Window"
 msgstr "Okno sítí"
 
-#: src/amuleDlg.cpp:1797 src/muuli_wdr.cpp:3419
+#: src/amuleDlg.cpp:1797 src/muuli_wdr.cpp:3450
 msgid "Searches Window"
 msgstr "Vyhledávací okno"
 
-#: src/amuleDlg.cpp:1803 src/muuli_wdr.cpp:3420
+#: src/amuleDlg.cpp:1803 src/muuli_wdr.cpp:3451
 msgid "Downloads Window"
 msgstr "Stahování"
 
-#: src/amuleDlg.cpp:1809 src/muuli_wdr.cpp:3422
+#: src/amuleDlg.cpp:1809 src/muuli_wdr.cpp:3453
 msgid "Shared Files Window"
 msgstr "Okno se sdílenými soubory"
 
-#: src/amuleDlg.cpp:1815 src/muuli_wdr.cpp:3423
+#: src/amuleDlg.cpp:1815 src/muuli_wdr.cpp:3454
 msgid "Messages Window"
 msgstr "Okno zpráv"
 
-#: src/amuleDlg.cpp:1821 src/muuli_wdr.cpp:3424
+#: src/amuleDlg.cpp:1821 src/muuli_wdr.cpp:3455
 msgid "Statistics Graph Window"
 msgstr "Okno se statistikami"
 
-#: src/amuleDlg.cpp:1828 src/muuli_wdr.cpp:3426
+#: src/amuleDlg.cpp:1828 src/muuli_wdr.cpp:3457
 msgid "Preferences Settings Window"
 msgstr "Okno s nastavením"
 
-#: src/amuleDlg.cpp:1831 src/muuli_wdr.cpp:3427
+#: src/amuleDlg.cpp:1831 src/muuli_wdr.cpp:3458
 msgid "Import"
 msgstr "Import"
 
-#: src/amuleDlg.cpp:1835 src/muuli_wdr.cpp:3427
+#: src/amuleDlg.cpp:1835 src/muuli_wdr.cpp:3458
 msgid "The partfile importer tool"
 msgstr "Nástroj pro import částečných souborů"
 
-#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3428
+#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3459
 #: src/utils/aLinkCreator/src/alcframe.cpp:262
 msgid "About"
 msgstr "O programu"
 
-#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3428
+#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3459
 msgid "About/Help"
 msgstr "O programu/Nápověda"
 
@@ -946,7 +946,7 @@ msgstr "Soubor nenalezen."
 msgid "The core rejected these shared folders:%s"
 msgstr ""
 
-#: src/amule-remote-gui.cpp:1336 src/ExternalConn.cpp:2345
+#: src/amule-remote-gui.cpp:1336 src/ExternalConn.cpp:2346
 msgid "Invalid link or already on list."
 msgstr "Neplatný odkaz, nebo je již v seznamu."
 
@@ -962,7 +962,7 @@ msgstr ""
 #: src/ClientDetailDialog.cpp:123 src/DataToText.cpp:61 src/DataToText.cpp:86
 #: src/DataToText.cpp:101 src/DataToText.cpp:136 src/DataToText.cpp:165
 #: src/DownloadListCtrl.cpp:1172 src/DownloadListCtrl.cpp:1185
-#: src/DownloadListCtrl.cpp:1196 src/ExternalConn.cpp:608
+#: src/DownloadListCtrl.cpp:1196 src/ExternalConn.cpp:609
 #: src/FileDetailDialog.cpp:203 src/FileDetailDialog.cpp:235
 #: src/FileDetailDialog.cpp:242 src/GenericClientListCtrl.cpp:1171
 #: src/GenericClientListCtrl.cpp:1182 src/GenericClientListCtrl.cpp:1192
@@ -1354,19 +1354,19 @@ msgstr "Auto [Vy]"
 msgid "Very low"
 msgstr "Velmi nízká"
 
-#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:743 src/muuli_wdr.cpp:2282
+#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:743 src/muuli_wdr.cpp:2313
 #: src/ServerListCtrl.cpp:263 src/ServerListCtrl.cpp:456
 #: src/SharedFilesCtrl.cpp:145
 msgid "Low"
 msgstr "Nízká"
 
-#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:744 src/muuli_wdr.cpp:2283
+#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:744 src/muuli_wdr.cpp:2314
 #: src/ServerListCtrl.cpp:266 src/ServerListCtrl.cpp:457
 #: src/SharedFilesCtrl.cpp:146
 msgid "Normal"
 msgstr "Normální"
 
-#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:745 src/muuli_wdr.cpp:2284
+#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:745 src/muuli_wdr.cpp:2315
 #: src/ServerListCtrl.cpp:269 src/ServerListCtrl.cpp:458
 #: src/SharedFilesCtrl.cpp:147
 msgid "High"
@@ -1458,7 +1458,7 @@ msgstr "Lokální server"
 msgid "Remote Server"
 msgstr "Vzdálený server"
 
-#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3181
+#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3212
 #: src/SearchDlg.cpp:119 src/TextClient.cpp:911
 msgid "Kad"
 msgstr "Kad"
@@ -1530,7 +1530,7 @@ msgstr "Část"
 msgid "Size"
 msgstr "Velikost"
 
-#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3248
+#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3279
 msgid "Transferred"
 msgstr "Přeneseno"
 
@@ -1588,7 +1588,7 @@ msgstr ""
 "Odezva od: %s (%s)\n"
 "\n"
 
-#: src/DownloadListCtrl.cpp:746 src/muuli_wdr.cpp:2285
+#: src/DownloadListCtrl.cpp:746 src/muuli_wdr.cpp:2316
 #: src/SharedFilesCtrl.cpp:150
 msgid "Auto"
 msgstr "Auto"
@@ -1626,7 +1626,7 @@ msgid "Extended Options"
 msgstr "Rozšířené nastavení"
 
 #: src/DownloadListCtrl.cpp:770 src/DownloadListCtrl.cpp:822
-#: src/muuli_wdr.cpp:1796
+#: src/muuli_wdr.cpp:1800
 msgid "Preview"
 msgstr "Náhled"
 
@@ -1801,227 +1801,232 @@ msgstr[2] ""
 msgid "Invalid eD2k link! ERROR: %s"
 msgstr "Neplatný eD2k odkaz! CHYBA: %s"
 
-#: src/ExternalConn.cpp:379
+#: src/ExternalConn.cpp:380
 msgid "Client sent packet after authentication failed."
 msgstr "Klient odeslal paket poté, co selhala autentizace."
 
-#: src/ExternalConn.cpp:396
+#: src/ExternalConn.cpp:397
 msgid "External connection closed."
 msgstr "Externí připojení uzavřeno."
 
-#: src/ExternalConn.cpp:473
+#: src/ExternalConn.cpp:474
 msgid "External connections disabled due to empty password!"
 msgstr "Externí připojení jsou zakázány kvůli prázdnému heslu!"
 
-#: src/ExternalConn.cpp:494
+#: src/ExternalConn.cpp:495
 msgid "External connections disabled in config file"
 msgstr "Externí připojení jsou zakázány v konfiguračním souboru"
 
-#: src/ExternalConn.cpp:575
+#: src/ExternalConn.cpp:576
 msgid "New external connection accepted"
 msgstr "Nové externí připojení přijato"
 
-#: src/ExternalConn.cpp:578
+#: src/ExternalConn.cpp:579
 msgid "ERROR: couldn't accept a new external connection"
 msgstr ""
 
-#: src/ExternalConn.cpp:595
+#: src/ExternalConn.cpp:596
 msgid "External connection refused due to empty password in preferences!"
 msgstr "Externí připojení odmítnuto kvůli prázdnému heslu v nastavení!"
 
-#: src/ExternalConn.cpp:607
+#: src/ExternalConn.cpp:608
 #, c-format
 msgid "Connecting client: %s %s"
 msgstr "Připojuji klienta: %s %s"
 
-#: src/ExternalConn.cpp:609
+#: src/ExternalConn.cpp:610
 msgid "Unknown version"
 msgstr "Neznámá verze"
 
-#: src/ExternalConn.cpp:622
+#: src/ExternalConn.cpp:623
 msgid "Incorrect EC version ID, there might be binary incompatibility. Use core and remote from same snapshot."
 msgstr ""
 
-#: src/ExternalConn.cpp:630
+#: src/ExternalConn.cpp:631
 msgid "You cannot connect to a release version from an arbitrary development snapshot! *sigh* possible crash prevented"
 msgstr ""
 
-#: src/ExternalConn.cpp:713
+#: src/ExternalConn.cpp:714
 msgid "Invalid protocol version."
 msgstr "Neplatná verze protokolu."
 
-#: src/ExternalConn.cpp:719
+#: src/ExternalConn.cpp:720
 msgid "Missing protocol version tag."
 msgstr ""
 
-#: src/ExternalConn.cpp:727
+#: src/ExternalConn.cpp:728
 msgid "Authentication failed: invalid hash specified as EC password."
 msgstr ""
 
-#: src/ExternalConn.cpp:775
+#: src/ExternalConn.cpp:776
 msgid "Authentication failed: wrong password."
 msgstr "Autentizace selhala: nesprávné heslo."
 
-#: src/ExternalConn.cpp:777
+#: src/ExternalConn.cpp:778
 msgid "Authentication failed: missing password."
 msgstr "Autentizace selhala: chybějící heslo."
 
-#: src/ExternalConn.cpp:788
+#: src/ExternalConn.cpp:789
 msgid "Invalid request, please authenticate first."
 msgstr "Neplatný požadavek, nejdřív se prosím autentizujte."
 
-#: src/ExternalConn.cpp:793
+#: src/ExternalConn.cpp:794
 msgid "Access granted."
 msgstr "Přistup povolen."
 
-#: src/ExternalConn.cpp:801
+#: src/ExternalConn.cpp:802
 #, c-format
 msgid "Sent error message \"%s\" to client."
 msgstr "Odeslána chybová hláška \"%s\" pro klienta."
 
-#: src/ExternalConn.cpp:806
+#: src/ExternalConn.cpp:807
 #, c-format
 msgid "Unauthorized access attempt from %s. Connection closed."
 msgstr "Neautorizovaný pokus o přístup z %s. Připojení uzavřeno."
 
-#: src/ExternalConn.cpp:1419
+#: src/ExternalConn.cpp:1420
 #, c-format
 msgid "Remote PartFile command failed: FileHash not found: %s"
 msgstr ""
 
-#: src/ExternalConn.cpp:1423
+#: src/ExternalConn.cpp:1424
 #, c-format
 msgid "FileHash not found: %s"
 msgstr "FileHash nenalezen: %s"
 
-#: src/ExternalConn.cpp:1470 src/ExternalConn.cpp:1558
-#: src/ExternalConn.cpp:1679
+#: src/ExternalConn.cpp:1471 src/ExternalConn.cpp:1559
+#: src/ExternalConn.cpp:1680
 msgid "OOPS! OpCode processing error!"
 msgstr ""
 
-#: src/ExternalConn.cpp:1501
+#: src/ExternalConn.cpp:1502
 msgid "Server not added"
 msgstr "Server nepřidán"
 
-#: src/ExternalConn.cpp:1520
+#: src/ExternalConn.cpp:1521
 #, c-format
 msgid "server not found: %s"
 msgstr "server nenalezen: %s"
 
-#: src/ExternalConn.cpp:1537
+#: src/ExternalConn.cpp:1538
 msgid "need to define server to be removed"
 msgstr ""
 
-#: src/ExternalConn.cpp:1552
+#: src/ExternalConn.cpp:1553
 msgid "eD2k is disabled in preferences."
 msgstr "eD2k je zakázané v nastavení."
 
-#: src/ExternalConn.cpp:1657
+#: src/ExternalConn.cpp:1658
 #, fuzzy
 msgid "Friend not found."
 msgstr "Soubor nenalezen."
 
-#: src/ExternalConn.cpp:1667
+#: src/ExternalConn.cpp:1668
 #, fuzzy
 msgid "Client not found."
 msgstr "Soubor nenalezen."
 
-#: src/ExternalConn.cpp:1673
+#: src/ExternalConn.cpp:1674
 msgid "EC_TAG_FRIEND_SHARED requires EC_TAG_FRIEND or EC_TAG_CLIENT."
 msgstr ""
 
-#: src/ExternalConn.cpp:1991
+#: src/ExternalConn.cpp:1992
 msgid "WebSearch from remote interface makes no sense."
 msgstr ""
 
-#: src/ExternalConn.cpp:2026
+#: src/ExternalConn.cpp:2027
 msgid "Search in progress. Refetch results in a moment!"
 msgstr ""
 
-#: src/ExternalConn.cpp:2265
+#: src/ExternalConn.cpp:2266
 msgid "No points for graph."
 msgstr "Žádné údaje pro graf."
 
-#: src/ExternalConn.cpp:2275
+#: src/ExternalConn.cpp:2276
 msgid "Your client is not configured for this detail level."
 msgstr "Vás klient není nakonfigurován pro tuto úroveň detailů."
 
-#: src/ExternalConn.cpp:2302
+#: src/ExternalConn.cpp:2303
 msgid "External Connection: shutdown requested"
 msgstr ""
 
-#: src/ExternalConn.cpp:2314
+#: src/ExternalConn.cpp:2315
 msgid "Already shutting down."
 msgstr "Již se ukončuji."
 
-#: src/ExternalConn.cpp:2332
+#: src/ExternalConn.cpp:2333
 #, c-format
 msgid "ExternalConn: adding link '%s'."
 msgstr ""
 
-#: src/ExternalConn.cpp:2350
+#: src/ExternalConn.cpp:2351
 #, fuzzy, c-format
 msgid "%d of %d links failed (invalid or already on list)."
 msgstr "Neplatný odkaz, nebo je již v seznamu."
 
-#: src/ExternalConn.cpp:2373
+#: src/ExternalConn.cpp:2374
 msgid "Version check throttled; try again shortly."
 msgstr ""
 
-#: src/ExternalConn.cpp:2378
+#: src/ExternalConn.cpp:2379
 msgid "Version check is not available on this daemon."
 msgstr ""
 
-#: src/ExternalConn.cpp:2508
+#: src/ExternalConn.cpp:2509
 msgid "File not found."
 msgstr "Soubor nenalezen."
 
-#: src/ExternalConn.cpp:2513
+#: src/ExternalConn.cpp:2514
 msgid "Invalid file name."
 msgstr "Neplatný název souboru."
 
-#: src/ExternalConn.cpp:2521
+#: src/ExternalConn.cpp:2522
 msgid "Unable to rename file."
 msgstr "Nelze přejmenovat soubor."
 
-#: src/ExternalConn.cpp:2992 src/ExternalConn.cpp:3020
+#: src/ExternalConn.cpp:2839
+#, c-format
+msgid "Could not save the amuleapi password: %s"
+msgstr ""
+
+#: src/ExternalConn.cpp:3004 src/ExternalConn.cpp:3032
 msgid "Kad is disabled in preferences."
 msgstr "Kad je zakázaný v nastavení."
 
-#: src/ExternalConn.cpp:3033
+#: src/ExternalConn.cpp:3045
 msgid "Already connected to eD2k."
 msgstr "Již připojen k eD2k."
 
-#: src/ExternalConn.cpp:3036
+#: src/ExternalConn.cpp:3048
 msgid "Connecting to eD2k..."
 msgstr "Připojuji se k eD2k..."
 
-#: src/ExternalConn.cpp:3045
+#: src/ExternalConn.cpp:3057
 msgid "Already connected to Kad."
 msgstr "Již jste připojen k síti Kad."
 
-#: src/ExternalConn.cpp:3048
+#: src/ExternalConn.cpp:3060
 msgid "Connecting to Kad..."
 msgstr "Připojuji se k síti Kad..."
 
-#: src/ExternalConn.cpp:3055
+#: src/ExternalConn.cpp:3067
 msgid "All networks are disabled."
 msgstr "Všechny sítě jsou zakázány."
 
-#: src/ExternalConn.cpp:3064
+#: src/ExternalConn.cpp:3076
 msgid "Disconnected from eD2k."
 msgstr "Odpojen od eD2k."
 
-#: src/ExternalConn.cpp:3069
+#: src/ExternalConn.cpp:3081
 msgid "Disconnected from Kad."
 msgstr "Odpojen od Kademlia."
 
-#: src/ExternalConn.cpp:3078
+#: src/ExternalConn.cpp:3090
 #, c-format
 msgid "External Connection: invalid opcode received: %#x"
 msgstr ""
 
-#: src/ExternalConn.cpp:3083
+#: src/ExternalConn.cpp:3095
 msgid "Invalid opcode (wrong protocol version?)"
 msgstr ""
 
@@ -2407,23 +2412,23 @@ msgid ""
 "want downloads on a different (e.g. larger) disk."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:549 src/FirstRunWizard.cpp:611 src/muuli_wdr.cpp:1708
+#: src/FirstRunWizard.cpp:549 src/FirstRunWizard.cpp:611 src/muuli_wdr.cpp:1712
 msgid "Destination folder for downloads"
 msgstr "Cílový adresář pro stahování"
 
 #: src/FirstRunWizard.cpp:553 src/FirstRunWizard.cpp:569 src/muuli_wdr.cpp:1349
-#: src/muuli_wdr.cpp:1366 src/muuli_wdr.cpp:1683 src/muuli_wdr.cpp:1714
-#: src/muuli_wdr.cpp:1726 src/muuli_wdr.cpp:2769
+#: src/muuli_wdr.cpp:1366 src/muuli_wdr.cpp:1687 src/muuli_wdr.cpp:1718
+#: src/muuli_wdr.cpp:1730 src/muuli_wdr.cpp:2800
 #: src/utils/aLinkCreator/src/alcframe.cpp:135
 #: src/utils/wxCas/src/wxcasprefs.cpp:52 src/utils/wxCas/src/wxcasprefs.cpp:118
 msgid "Browse"
 msgstr "Procházet"
 
-#: src/FirstRunWizard.cpp:559 src/muuli_wdr.cpp:1719
+#: src/FirstRunWizard.cpp:559 src/muuli_wdr.cpp:1723
 msgid "(All files in this folder are shared with other peers)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:565 src/FirstRunWizard.cpp:624 src/muuli_wdr.cpp:1721
+#: src/FirstRunWizard.cpp:565 src/FirstRunWizard.cpp:624 src/muuli_wdr.cpp:1725
 msgid "Folder for temporary download files"
 msgstr ""
 
@@ -2454,7 +2459,7 @@ msgstr ""
 msgid "CRITICAL - no client on StartChatSession"
 msgstr ""
 
-#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2675 src/muuli_wdr.cpp:3352
+#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2706 src/muuli_wdr.cpp:3383
 msgid "Friends"
 msgstr "Kamarádi"
 
@@ -2565,8 +2570,8 @@ msgstr "Nic"
 msgid "No"
 msgstr "Ne"
 
-#: src/GenericClientListCtrl.cpp:1216 src/PrefsUnifiedDlg.cpp:2818
-#: src/PrefsUnifiedDlg.cpp:2868 src/ServerListCtrl.cpp:276
+#: src/GenericClientListCtrl.cpp:1216 src/PrefsUnifiedDlg.cpp:2898
+#: src/PrefsUnifiedDlg.cpp:2948 src/ServerListCtrl.cpp:276
 msgid "Yes"
 msgstr "Ano"
 
@@ -2738,10 +2743,10 @@ msgstr "Neplatný port pro bootstrap"
 msgid "Please fill all fields required"
 msgstr "Prosím vyplňte všechna potřebná pole"
 
-#: src/KadDlg.cpp:192 src/PartFile.cpp:1031 src/PrefsUnifiedDlg.cpp:1162
-#: src/PrefsUnifiedDlg.cpp:1331 src/PrefsUnifiedDlg.cpp:1589
-#: src/PrefsUnifiedDlg.cpp:1599 src/PrefsUnifiedDlg.cpp:1616
-#: src/PrefsUnifiedDlg.cpp:1658
+#: src/KadDlg.cpp:192 src/PartFile.cpp:1031 src/PrefsUnifiedDlg.cpp:1134
+#: src/PrefsUnifiedDlg.cpp:1204 src/PrefsUnifiedDlg.cpp:1405
+#: src/PrefsUnifiedDlg.cpp:1663 src/PrefsUnifiedDlg.cpp:1673
+#: src/PrefsUnifiedDlg.cpp:1690 src/PrefsUnifiedDlg.cpp:1738
 msgid "Message"
 msgstr "Zpráva"
 
@@ -2846,7 +2851,7 @@ msgstr "Poměr sdílení"
 msgid "Uploaded"
 msgstr "Odesláno"
 
-#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3232
+#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3263
 msgid "Requested"
 msgstr "Vyžádáno"
 
@@ -2972,7 +2977,7 @@ msgid "WARNING: "
 msgstr "VAROVÁNÍ: "
 
 #: src/MuleNotebook.cpp:179 src/muuli_wdr.cpp:817 src/muuli_wdr.cpp:1229
-#: src/muuli_wdr.cpp:3136 src/muuli_wdr.cpp:3392
+#: src/muuli_wdr.cpp:3167 src/muuli_wdr.cpp:3423
 msgid "Close"
 msgstr "Zavřít"
 
@@ -2990,7 +2995,7 @@ msgid "Paste"
 msgstr "Vložit"
 
 #: src/MuleTextCtrl.cpp:89 src/muuli_wdr.cpp:358 src/muuli_wdr.cpp:757
-#: src/muuli_wdr.cpp:2359 src/muuli_wdr.cpp:2378 src/muuli_wdr.cpp:2400
+#: src/muuli_wdr.cpp:2390 src/muuli_wdr.cpp:2409 src/muuli_wdr.cpp:2431
 #: src/utils/aLinkCreator/src/alcframe.cpp:142
 msgid "Clear"
 msgstr "Vyprázdnit"
@@ -3089,7 +3094,7 @@ msgstr "Ukončit"
 
 #: src/MuleTrayIcon.cpp:579 src/MuleTrayIcon.cpp:945 src/MuleTrayIcon.cpp:965
 #: src/muuli_wdr.cpp:1398 src/muuli_wdr.cpp:1406 src/muuli_wdr.cpp:1413
-#: src/muuli_wdr.cpp:1842 src/muuli_wdr.cpp:1848 src/OtherFunctions.cpp:91
+#: src/muuli_wdr.cpp:1846 src/muuli_wdr.cpp:1852 src/OtherFunctions.cpp:91
 #: src/StatisticsDlg.cpp:93 src/StatisticsDlg.cpp:95
 msgid "kB/s"
 msgstr "kB/s"
@@ -3331,7 +3336,7 @@ msgstr "bajtů"
 msgid "KB"
 msgstr "KB"
 
-#: src/muuli_wdr.cpp:274 src/muuli_wdr.cpp:293 src/muuli_wdr.cpp:1627
+#: src/muuli_wdr.cpp:274 src/muuli_wdr.cpp:293 src/muuli_wdr.cpp:1631
 #: src/OtherFunctions.cpp:64
 msgid "MB"
 msgstr "MB"
@@ -3348,7 +3353,7 @@ msgstr "Max. velikost"
 msgid "Availability"
 msgstr "Dostupnost"
 
-#: src/muuli_wdr.cpp:312 src/muuli_wdr.cpp:398 src/muuli_wdr.cpp:3297
+#: src/muuli_wdr.cpp:312 src/muuli_wdr.cpp:398 src/muuli_wdr.cpp:3328
 msgid "Filter:"
 msgstr "Filtr:"
 
@@ -3411,12 +3416,12 @@ msgstr "Zdroje souboru:"
 #: src/muuli_wdr.cpp:1160 src/muuli_wdr.cpp:1167 src/muuli_wdr.cpp:1172
 #: src/muuli_wdr.cpp:1179 src/muuli_wdr.cpp:1184 src/muuli_wdr.cpp:1191
 #: src/muuli_wdr.cpp:1205 src/muuli_wdr.cpp:1212 src/muuli_wdr.cpp:1217
-#: src/muuli_wdr.cpp:1224 src/muuli_wdr.cpp:3234 src/muuli_wdr.cpp:3242
-#: src/muuli_wdr.cpp:3250
+#: src/muuli_wdr.cpp:1224 src/muuli_wdr.cpp:3265 src/muuli_wdr.cpp:3273
+#: src/muuli_wdr.cpp:3281
 msgid "N/A"
 msgstr "N/A"
 
-#: src/muuli_wdr.cpp:508 src/muuli_wdr.cpp:1065 src/PrefsUnifiedDlg.cpp:297
+#: src/muuli_wdr.cpp:508 src/muuli_wdr.cpp:1065 src/PrefsUnifiedDlg.cpp:299
 msgid "General"
 msgstr "Hlavní"
 
@@ -3557,7 +3562,7 @@ msgstr ""
 msgid "Album :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:685 src/muuli_wdr.cpp:2254
+#: src/muuli_wdr.cpp:685 src/muuli_wdr.cpp:2285
 msgid "Title :"
 msgstr "Titulek:"
 
@@ -3664,7 +3669,7 @@ msgstr "Uživatelské jméno:"
 msgid "Userhash :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:895 src/muuli_wdr.cpp:1748 src/muuli_wdr.cpp:2449
+#: src/muuli_wdr.cpp:895 src/muuli_wdr.cpp:1752 src/muuli_wdr.cpp:2480
 #: src/utils/aLinkCreator/src/alcframe.cpp:137
 msgid "Add"
 msgstr "Přidat"
@@ -3673,15 +3678,15 @@ msgstr "Přidat"
 msgid "Download-Speed"
 msgstr "Rychlost stahování"
 
-#: src/muuli_wdr.cpp:954 src/muuli_wdr.cpp:989 src/muuli_wdr.cpp:2553
+#: src/muuli_wdr.cpp:954 src/muuli_wdr.cpp:989 src/muuli_wdr.cpp:2584
 msgid "Current"
 msgstr ""
 
-#: src/muuli_wdr.cpp:962 src/muuli_wdr.cpp:997 src/muuli_wdr.cpp:2561
+#: src/muuli_wdr.cpp:962 src/muuli_wdr.cpp:997 src/muuli_wdr.cpp:2592
 msgid "Running average"
 msgstr ""
 
-#: src/muuli_wdr.cpp:970 src/muuli_wdr.cpp:1005 src/muuli_wdr.cpp:2569
+#: src/muuli_wdr.cpp:970 src/muuli_wdr.cpp:1005 src/muuli_wdr.cpp:2600
 msgid "Session average"
 msgstr "Průměr sezení"
 
@@ -3693,7 +3698,7 @@ msgstr "Rychlost odesílání"
 msgid "Connections"
 msgstr "Připojení"
 
-#: src/muuli_wdr.cpp:1024 src/muuli_wdr.cpp:1867
+#: src/muuli_wdr.cpp:1024 src/muuli_wdr.cpp:1871
 msgid "Active downloads"
 msgstr "Aktivní stahování"
 
@@ -3701,7 +3706,7 @@ msgstr "Aktivní stahování"
 msgid "Active connections (1:1)"
 msgstr "Aktivní připojení (1:1)"
 
-#: src/muuli_wdr.cpp:1040 src/muuli_wdr.cpp:1868
+#: src/muuli_wdr.cpp:1040 src/muuli_wdr.cpp:1872
 msgid "Active uploads"
 msgstr "Aktivní odesílání"
 
@@ -3978,7 +3983,7 @@ msgstr ""
 msgid "Advanced users only: If you have multiple network interfaces, enter the address of the interface to which aMule should be bound."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1462 src/muuli_wdr.cpp:2061
+#: src/muuli_wdr.cpp:1462 src/muuli_wdr.cpp:2065
 msgid "Bind to network interface (empty for any):"
 msgstr ""
 
@@ -3994,7 +3999,7 @@ msgstr "Max. zdrojů na stahovaný soubor:"
 msgid "Max simultaneous connections:"
 msgstr "Maximum připojení naráz:"
 
-#: src/muuli_wdr.cpp:1498 src/muuli_wdr.cpp:3176
+#: src/muuli_wdr.cpp:1498 src/muuli_wdr.cpp:3207
 msgid "ED2K"
 msgstr "ED2K"
 
@@ -4086,756 +4091,779 @@ msgstr "Předalokovat místo na disku pro nové soubory"
 msgid "For new files preallocates disk space for the whole file, thus reduces fragmentation"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1613
+#: src/muuli_wdr.cpp:1617
 msgid "Create new files as sparse files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1614
-msgid "A sparse file reserves its full size on disk immediately without writing real data to it -- fast, but unsupported or slow on some filesystems, and free-space accounting stays optimistic while the download is in progress. Turn this off to grow the file only as data arrives."
+#: src/muuli_wdr.cpp:1618
+msgid "Sparse part files only occupy disk space for the parts already downloaded, so free space is used up gradually as the file fills in. Turn this off to use an ordinary file instead - useful where sparse files are unsupported or slow, or where backup/de-duplication tools handle them badly. Applies only when the core runs on Windows; on Linux and macOS part files are sparse anyway and this setting has no effect."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1619
+#: src/muuli_wdr.cpp:1623
 msgid "Stop downloads when free disk space reaches "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1620
+#: src/muuli_wdr.cpp:1624
 msgid "Select this if you want aMule to check your disk space"
 msgstr "Toto zvolte chcete-li, aby aMule kontrolovala místo na disku"
 
-#: src/muuli_wdr.cpp:1624
+#: src/muuli_wdr.cpp:1628
 msgid "Enter here the min disk space desired."
 msgstr "Zadejte minimum místa na disku."
 
-#: src/muuli_wdr.cpp:1630
+#: src/muuli_wdr.cpp:1634
 msgid "Save 10 sources on rare files (< 20 sources)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1634 src/Statistics.cpp:790
+#: src/muuli_wdr.cpp:1638 src/Statistics.cpp:790
 msgid "Uploads"
 msgstr "Odesílání"
 
-#: src/muuli_wdr.cpp:1637
+#: src/muuli_wdr.cpp:1641
 msgid "Add new shared files with auto priority"
 msgstr "Přidat nově sdílené soubory s \"auto\" prioritou"
 
-#: src/muuli_wdr.cpp:1643
+#: src/muuli_wdr.cpp:1647
 msgid "Intelligent Corruption Handling (I.C.H.)"
 msgstr "Inteligentní zpracování poškození (I.C.H.)"
 
-#: src/muuli_wdr.cpp:1646
+#: src/muuli_wdr.cpp:1650
 msgid "Enable"
 msgstr "Povolit"
 
-#: src/muuli_wdr.cpp:1649
+#: src/muuli_wdr.cpp:1653
 msgid "Advanced I.C.H. trusts every hash (not recommended)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1661 src/PrefsUnifiedDlg.cpp:1910
+#: src/muuli_wdr.cpp:1665 src/PrefsUnifiedDlg.cpp:1990
 msgid "Media metadata extraction"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1665
+#: src/muuli_wdr.cpp:1669
 msgid "Extract length / bitrate / codec from shared audio and video files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1667
+#: src/muuli_wdr.cpp:1671
 msgid "When enabled, aMule runs ffprobe on each shared media file to fill in the Length / Bitrate / Codec columns other clients see when they find the file in a search. Requires ffmpeg (the ffprobe binary) to be installed."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1674
+#: src/muuli_wdr.cpp:1678
 msgid "Path to ffprobe:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1679
+#: src/muuli_wdr.cpp:1683
 msgid "Full path to the ffprobe binary. Leave empty to have aMule auto-detect it on startup."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1687
+#: src/muuli_wdr.cpp:1691
 msgid "Detect"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1688
+#: src/muuli_wdr.cpp:1692
 msgid "Search the standard install locations for an ffprobe binary and fill the path field."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1712
+#: src/muuli_wdr.cpp:1716
 msgid ""
 "Completed downloads are stored here. All files in this folder are automatically shared with other peers.\n"
 "If this folder also holds files you don't want to share, point it at an aMule-only sub-folder."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1715
+#: src/muuli_wdr.cpp:1719
 msgid "Pick the folder where completed downloads will be stored. All files in that folder will be shared with other peers."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1729
+#: src/muuli_wdr.cpp:1733
 msgid "Shared folders"
 msgstr "Sdílené adresáře"
 
-#: src/muuli_wdr.cpp:1735
+#: src/muuli_wdr.cpp:1739
 msgid "(Folders shared by the core. Enter a path to add one.)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1743
+#: src/muuli_wdr.cpp:1747
 msgid "Absolute path of a folder on the core's machine, e.g. /home/user/shared"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1745 src/PrefsUnifiedDlg.cpp:2794
+#: src/muuli_wdr.cpp:1749 src/PrefsUnifiedDlg.cpp:2874
 msgid "Recursive"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1746
+#: src/muuli_wdr.cpp:1750
 msgid "Share every sub-folder underneath this one, including ones created later."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1750 src/utils/aLinkCreator/src/alcframe.cpp:141
+#: src/muuli_wdr.cpp:1754 src/utils/aLinkCreator/src/alcframe.cpp:141
 msgid "Remove"
 msgstr "Odebrat"
 
-#: src/muuli_wdr.cpp:1754
+#: src/muuli_wdr.cpp:1758
 msgid "(Right click on folder icon for recursive share)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1761
+#: src/muuli_wdr.cpp:1765
 msgid "Share hidden files"
 msgstr "Sdílet skryté soubory"
 
-#: src/muuli_wdr.cpp:1767
+#: src/muuli_wdr.cpp:1771
 msgid "Automatically rescan shared folders for changes"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1773
+#: src/muuli_wdr.cpp:1777
 msgid "Follow symbolic links in shared folders"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1779
+#: src/muuli_wdr.cpp:1783
 msgid "Exclude files matching:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1782
+#: src/muuli_wdr.cpp:1786
 msgid "Wildcard patterns separated by '|', e.g. .DS_Store|Thumbs.db|*.tmp. Files whose name matches are not shared. Matching is case-insensitive."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1786
+#: src/muuli_wdr.cpp:1790
 msgid "Patterns are regular expressions"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1787
+#: src/muuli_wdr.cpp:1791
 msgid "When set, the whole field is one regular expression ('|' is alternation). When unset, it is a list of '|'-separated wildcards."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1797
+#: src/muuli_wdr.cpp:1801
 msgid "Show how many shared files the current pattern would exclude."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1818
+#: src/muuli_wdr.cpp:1822
 msgid "Graphs"
 msgstr "Grafy"
 
-#: src/muuli_wdr.cpp:1821 src/muuli_wdr.cpp:1883
+#: src/muuli_wdr.cpp:1825 src/muuli_wdr.cpp:1887
 msgid "Update delay : 5 secs"
 msgstr "Prodleva aktualizace: 5 sekund"
 
-#: src/muuli_wdr.cpp:1825
+#: src/muuli_wdr.cpp:1829
 msgid "Time for average graph: 100 mins"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1829
+#: src/muuli_wdr.cpp:1833
 msgid "Connections Graph Scale: 100 "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1836
+#: src/muuli_wdr.cpp:1840
 msgid "Download graph scale:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1844
+#: src/muuli_wdr.cpp:1848
 msgid "Upload graph scale:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1854
+#: src/muuli_wdr.cpp:1858
 #, fuzzy
 msgid "Colors: "
 msgstr "Barvy: "
 
-#: src/muuli_wdr.cpp:1858
+#: src/muuli_wdr.cpp:1862
 msgid "Background"
 msgstr "Na pozadí"
 
-#: src/muuli_wdr.cpp:1859
+#: src/muuli_wdr.cpp:1863
 msgid "Grid"
 msgstr "Mřížka"
 
-#: src/muuli_wdr.cpp:1860
+#: src/muuli_wdr.cpp:1864
 msgid "Download current"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1861
+#: src/muuli_wdr.cpp:1865
 msgid "Download running average"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1862
+#: src/muuli_wdr.cpp:1866
 msgid "Download session average"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1863
+#: src/muuli_wdr.cpp:1867
 msgid "Upload current"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1864
+#: src/muuli_wdr.cpp:1868
 msgid "Upload running average"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1865
+#: src/muuli_wdr.cpp:1869
 msgid "Upload session average"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1866
+#: src/muuli_wdr.cpp:1870
 msgid "Active connections"
 msgstr "Aktivní připojení"
 
-#: src/muuli_wdr.cpp:1869
+#: src/muuli_wdr.cpp:1873
 #, fuzzy
 msgid "Systray Icon Speed Bar"
 msgstr "Ukazatel rychlosti v tray ikoně"
 
-#: src/muuli_wdr.cpp:1870
+#: src/muuli_wdr.cpp:1874
 msgid "Kad-nodes current"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1871
+#: src/muuli_wdr.cpp:1875
 msgid "Kad-nodes running"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1872
+#: src/muuli_wdr.cpp:1876
 msgid "Kad-nodes session"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1876 src/muuli_wdr.cpp:2303
+#: src/muuli_wdr.cpp:1880 src/muuli_wdr.cpp:2334
 msgid "Select"
 msgstr "Vyberte"
 
-#: src/muuli_wdr.cpp:1880
+#: src/muuli_wdr.cpp:1884
 msgid "Tree"
 msgstr "Strom"
 
-#: src/muuli_wdr.cpp:1890
+#: src/muuli_wdr.cpp:1894
 msgid "Number of Client Versions shown (0=unlimited)"
 msgstr "Počet verzí klientů k zobrazení (0=neomezeně)"
 
-#: src/muuli_wdr.cpp:1915
+#: src/muuli_wdr.cpp:1919
 msgid "!!! WARNING !!!"
 msgstr "!!! VAROVÁNÍ !!!"
 
-#: src/muuli_wdr.cpp:1930
+#: src/muuli_wdr.cpp:1934
 msgid "Max new connections / 5 secs"
 msgstr "Max. nových připojení za 5 sek."
 
-#: src/muuli_wdr.cpp:1932
+#: src/muuli_wdr.cpp:1936
 msgid "Concurrent Kad source lookups"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1934
+#: src/muuli_wdr.cpp:1938
 #, fuzzy
 msgid "Kad source re-search interval (minutes)"
 msgstr "Interval aktualizace FTP v minutách"
 
-#: src/muuli_wdr.cpp:1936
+#: src/muuli_wdr.cpp:1940
 #, fuzzy
 msgid "Source re-ask interval (minutes)"
 msgstr "Interval aktualizace FTP v minutách"
 
-#: src/muuli_wdr.cpp:1940
+#: src/muuli_wdr.cpp:1944
 msgid "File Buffer Size: 240000 bytes"
 msgstr "Velikost zásobníku pro soubory: 240000 bytů"
 
-#: src/muuli_wdr.cpp:1944
+#: src/muuli_wdr.cpp:1948
 msgid "Use MMAP: memory-mapped file access (lower memory use)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1945
+#: src/muuli_wdr.cpp:1949
 msgid "Maps part files into memory instead of buffering them on the heap, lowering the process memory footprint. May reduce download speed on some disks; best for memory-constrained or upload-heavy hosts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1947
+#: src/muuli_wdr.cpp:1951
 msgid "Upload Queue Size: 5000 clients"
 msgstr "Velikost fronty odesílání: 5000 klientů"
 
-#: src/muuli_wdr.cpp:1951
+#: src/muuli_wdr.cpp:1955
 msgid "Server connection refresh interval: Disable"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1955
+#: src/muuli_wdr.cpp:1959
 msgid "Disable computer's timed standby mode"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1974
+#: src/muuli_wdr.cpp:1978
 msgid "Skin to use: "
 msgstr "Vzhled: "
 
-#: src/muuli_wdr.cpp:1983
+#: src/muuli_wdr.cpp:1987
 msgid "Show \"Fast eD2k Links Handler\" in every window."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1986
+#: src/muuli_wdr.cpp:1990
 msgid "Show extended info on categories tabs"
 msgstr "Zobrazit rozšířené informace na tabech kategorií"
 
-#: src/muuli_wdr.cpp:1989
+#: src/muuli_wdr.cpp:1993
 #, fuzzy
 msgid "Show application version on title"
 msgstr "Zobrazit rychlosti přenosu v titulku okna"
 
-#: src/muuli_wdr.cpp:1991
+#: src/muuli_wdr.cpp:1995
 msgid "Show transfer rates on title"
 msgstr "Zobrazit rychlosti přenosu v titulku okna"
 
-#: src/muuli_wdr.cpp:1993
+#: src/muuli_wdr.cpp:1997
 msgid "Before application name"
 msgstr "Před názvem programu"
 
-#: src/muuli_wdr.cpp:1995
+#: src/muuli_wdr.cpp:1999
 msgid "After application name"
 msgstr "Za názvem programu"
 
-#: src/muuli_wdr.cpp:1998
+#: src/muuli_wdr.cpp:2002
 msgid "Show overhead bandwidth"
 msgstr "Zobrazit šířku pásma režie"
 
-#: src/muuli_wdr.cpp:2002
+#: src/muuli_wdr.cpp:2006
 msgid "Vertical toolbar orientation"
 msgstr "Vertikální umístění nástrojové lišty"
 
-#: src/muuli_wdr.cpp:2004
+#: src/muuli_wdr.cpp:2008
 msgid "Live column sorting (auto-reorder rows as their values change)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2011
+#: src/muuli_wdr.cpp:2015
 msgid "Download Queue Files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2014
+#: src/muuli_wdr.cpp:2018
 msgid "Show progress percentage"
 msgstr "Zobrazit procenta průběhu"
 
-#: src/muuli_wdr.cpp:2020
+#: src/muuli_wdr.cpp:2024
 msgid "Show progress bar"
 msgstr "Zobrazit ukazatel průběhu"
 
-#: src/muuli_wdr.cpp:2023
+#: src/muuli_wdr.cpp:2027
 msgid "Flat"
 msgstr "Plochý"
 
-#: src/muuli_wdr.cpp:2027
+#: src/muuli_wdr.cpp:2031
 msgid "Round"
 msgstr "Kulatý"
 
-#: src/muuli_wdr.cpp:2045
+#: src/muuli_wdr.cpp:2049
 msgid "External Connection Parameters"
 msgstr "Nastavení externího připojení"
 
-#: src/muuli_wdr.cpp:2048
+#: src/muuli_wdr.cpp:2052
 msgid "Accept external connections"
 msgstr "Přijímat externí připojení"
 
-#: src/muuli_wdr.cpp:2055 src/muuli_wdr.cpp:2114
+#: src/muuli_wdr.cpp:2059 src/muuli_wdr.cpp:2118
 msgid "IP of the listening interface:"
 msgstr "IP naslouchajícího zařízení:"
 
-#: src/muuli_wdr.cpp:2058
+#: src/muuli_wdr.cpp:2062
 msgid "Enter here a valid ip in the a.b.c.d format for the listening EC interface. An empty field or 0.0.0.0 will mean any interface."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2079 src/muuli_wdr.cpp:2163
+#: src/muuli_wdr.cpp:2083 src/muuli_wdr.cpp:2194
 msgid "TCP port:"
 msgstr "TCP port:"
 
-#: src/muuli_wdr.cpp:2085
+#: src/muuli_wdr.cpp:2089
 msgid "Enable UPnP port forwarding on the EC port"
 msgstr "Povolit UPnP port forwarding na EC portu"
 
-#: src/muuli_wdr.cpp:2089 src/muuli_wdr.cpp:3048
+#: src/muuli_wdr.cpp:2093 src/muuli_wdr.cpp:3079
 #: src/utils/wxCas/src/wxcasprefs.cpp:167
 msgid "Password"
 msgstr "Heslo"
 
-#: src/muuli_wdr.cpp:2095
+#: src/muuli_wdr.cpp:2099
 #, fuzzy
 msgid "aMule API server parameters"
 msgstr "Parametry webserveru"
 
-#: src/muuli_wdr.cpp:2098
+#: src/muuli_wdr.cpp:2102
 msgid "Run amuleapi (REST API) on startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2103
+#: src/muuli_wdr.cpp:2107
 #, fuzzy
 msgid "HTTP port:"
 msgstr "TCP port:"
 
-#: src/muuli_wdr.cpp:2117
+#: src/muuli_wdr.cpp:2121
 msgid "The interface amuleapi's HTTP server listens on. 127.0.0.1 (default) accepts only local connections; use 0.0.0.0 or a specific IP to expose it to other hosts (set an admin password below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2120
+#: src/muuli_wdr.cpp:2126
+msgid "Type a password to set or change it. Stored passwords cannot be shown, so leaving this empty keeps the current one."
+msgstr ""
+
+#: src/muuli_wdr.cpp:2128
 #, fuzzy
 msgid "Admin password"
 msgstr "Kontrola hesla\n"
 
-#: src/muuli_wdr.cpp:2125 src/muuli_wdr.cpp:2156
-msgid "Low rights password"
-msgstr "Heslo pro omezená práva"
+#: src/muuli_wdr.cpp:2140 src/muuli_wdr.cpp:2157 src/PrefsUnifiedDlg.cpp:1103
+#, fuzzy
+msgid "A password is set."
+msgstr "Kontrola hesla\n"
 
-#: src/muuli_wdr.cpp:2133
+#: src/muuli_wdr.cpp:2144
+#, fuzzy
+msgid "Enable guest access"
+msgstr "Zakázat přístup hostům"
+
+#: src/muuli_wdr.cpp:2145
+msgid "Guest sessions may read status and listings but cannot change anything. Turning this off clears the stored guest password."
+msgstr ""
+
+#: src/muuli_wdr.cpp:2149
+#, fuzzy
+msgid "Guest password"
+msgstr "Heslo pro omezený přístup k webserveru"
+
+#: src/muuli_wdr.cpp:2164
 msgid "Web server parameters"
 msgstr "Parametry webserveru"
 
-#: src/muuli_wdr.cpp:2136
+#: src/muuli_wdr.cpp:2167
 #, fuzzy
 msgid "Run webserver on startup (deprecated)"
 msgstr "Spustit webserver při spuštění aMule"
 
-#: src/muuli_wdr.cpp:2142
+#: src/muuli_wdr.cpp:2173
 msgid "Web template"
 msgstr "Šablona webu"
 
-#: src/muuli_wdr.cpp:2147
+#: src/muuli_wdr.cpp:2178
 msgid "Full rights password"
 msgstr "Heslo pro plná práva"
 
-#: src/muuli_wdr.cpp:2151
+#: src/muuli_wdr.cpp:2182
 msgid "Enable Low rights User"
 msgstr "Povolit uživatele s omezenými právy"
 
-#: src/muuli_wdr.cpp:2170
+#: src/muuli_wdr.cpp:2187
+msgid "Low rights password"
+msgstr "Heslo pro omezená práva"
+
+#: src/muuli_wdr.cpp:2201
 msgid "Enable UPnP port forwarding of the web server port"
 msgstr "Povolit UPnP port forwarding portu webserveru"
 
-#: src/muuli_wdr.cpp:2175
+#: src/muuli_wdr.cpp:2206
 msgid "Web server UPnP TCP port (Optional)"
 msgstr "UPnP TCP port webserveru (volitelné)"
 
-#: src/muuli_wdr.cpp:2183
+#: src/muuli_wdr.cpp:2214
 msgid "Page Refresh Time (in secs)"
 msgstr "Obnovování stránky (v sek.)"
 
-#: src/muuli_wdr.cpp:2190
+#: src/muuli_wdr.cpp:2221
 msgid "Enable Gzip compression"
 msgstr "Povoliz Gzip kompresi"
 
-#: src/muuli_wdr.cpp:2224
+#: src/muuli_wdr.cpp:2255
 #, fuzzy
 msgid "Reset page to defaults"
 msgstr "Výchozí pro systém"
 
-#: src/muuli_wdr.cpp:2225
+#: src/muuli_wdr.cpp:2256
 msgid "Reset the settings on the current page to their default values."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2227 src/muuli_wdr.cpp:2313 src/ServerWnd.cpp:274
+#: src/muuli_wdr.cpp:2258 src/muuli_wdr.cpp:2344 src/ServerWnd.cpp:274
 #: src/ServerWnd.cpp:282
 msgid "OK"
 msgstr "Budiž"
 
-#: src/muuli_wdr.cpp:2229
+#: src/muuli_wdr.cpp:2260
 msgid "Click here to apply any changes made to the preferences."
 msgstr "Klikněte zde pro aplikování změn nastavení."
 
-#: src/muuli_wdr.cpp:2232
+#: src/muuli_wdr.cpp:2263
 msgid "Reset any changes made to the preferences."
 msgstr "Zahodí všechny změny v nastavení."
 
-#: src/muuli_wdr.cpp:2261
+#: src/muuli_wdr.cpp:2292
 msgid "Comment :"
 msgstr "Komentář:"
 
-#: src/muuli_wdr.cpp:2268
+#: src/muuli_wdr.cpp:2299
 msgid "Incoming Dir :"
 msgstr "Příchozí adresář:"
 
-#: src/muuli_wdr.cpp:2277
+#: src/muuli_wdr.cpp:2308
 msgid "Change priority for new assigned files :"
 msgstr "Změnit prioritu pro nově přiřazené soubory:"
 
-#: src/muuli_wdr.cpp:2281
+#: src/muuli_wdr.cpp:2312
 #, fuzzy
 msgid "Don't change"
 msgstr "Neměnit"
 
-#: src/muuli_wdr.cpp:2293
+#: src/muuli_wdr.cpp:2324
 msgid "Select color for this Category (currently selected) :"
 msgstr "Barva pro tuto kategorii:"
 
-#: src/muuli_wdr.cpp:2360 src/muuli_wdr.cpp:2379 src/muuli_wdr.cpp:2401
+#: src/muuli_wdr.cpp:2391 src/muuli_wdr.cpp:2410 src/muuli_wdr.cpp:2432
 msgid "Click this button to reset the log."
 msgstr "Klikněte na toto tlačítko pro vynulování logu."
 
-#: src/muuli_wdr.cpp:2420
+#: src/muuli_wdr.cpp:2451
 msgid "Click on this button to update the servers list from URL ..."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2424
+#: src/muuli_wdr.cpp:2455
 msgid "Server list"
 msgstr "Seznam serverů"
 
-#: src/muuli_wdr.cpp:2428
+#: src/muuli_wdr.cpp:2459
 msgid "Enter the url to a server.met file here and press the button to the left to update the list of known servers."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2433
+#: src/muuli_wdr.cpp:2464
 msgid "Add server manually: Name"
 msgstr "Přidat server ručně: Název"
 
-#: src/muuli_wdr.cpp:2436
+#: src/muuli_wdr.cpp:2467
 msgid "Enter the name of the new server here"
 msgstr "Zadejte název serveru"
 
-#: src/muuli_wdr.cpp:2438 src/ServerWnd.cpp:206
+#: src/muuli_wdr.cpp:2469 src/ServerWnd.cpp:206
 msgid "IP:Port"
 msgstr "IP:Port"
 
-#: src/muuli_wdr.cpp:2441
+#: src/muuli_wdr.cpp:2472
 msgid "Enter the IP of the server here, using the x.x.x.x format."
 msgstr "Zadejte IP serveru ve tvaru x.x.x.x."
 
-#: src/muuli_wdr.cpp:2447
+#: src/muuli_wdr.cpp:2478
 msgid "Enter the port of the server here."
 msgstr "Zadejte port serveru."
 
-#: src/muuli_wdr.cpp:2450
+#: src/muuli_wdr.cpp:2481
 msgid "Add manually a server (fill fields to the left before) ..."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2479
+#: src/muuli_wdr.cpp:2510
 msgid "aMule Log"
 msgstr "Log aMule"
 
-#: src/muuli_wdr.cpp:2487
+#: src/muuli_wdr.cpp:2518
 msgid "Server Info"
 msgstr "Info o serveru"
 
-#: src/muuli_wdr.cpp:2491
+#: src/muuli_wdr.cpp:2522
 msgid "ED2K Info"
 msgstr "ED2K Info"
 
-#: src/muuli_wdr.cpp:2495
+#: src/muuli_wdr.cpp:2526
 msgid "Kad Info"
 msgstr "Kad Info"
 
-#: src/muuli_wdr.cpp:2523
+#: src/muuli_wdr.cpp:2554
 msgid "Click on this button to update the nodes list from URL ..."
 msgstr "Aktualizuje seznam uzlů z dané URL..."
 
-#: src/muuli_wdr.cpp:2527
+#: src/muuli_wdr.cpp:2558
 msgid "Nodes (0)"
 msgstr "Uzly (0)"
 
-#: src/muuli_wdr.cpp:2531
+#: src/muuli_wdr.cpp:2562
 msgid "Enter the url to a nodes.dat file here and press the button to the left to update the list of known nodes."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2534
+#: src/muuli_wdr.cpp:2565
 msgid "Nodes stats"
 msgstr "Statistiky uzlů"
 
-#: src/muuli_wdr.cpp:2576
+#: src/muuli_wdr.cpp:2607
 msgid "Bootstrap"
 msgstr "Bootstrap"
 
-#: src/muuli_wdr.cpp:2579
+#: src/muuli_wdr.cpp:2610
 msgid "New node"
 msgstr "Nový uzel"
 
-#: src/muuli_wdr.cpp:2584
+#: src/muuli_wdr.cpp:2615
 msgid "IP:"
 msgstr "IP:"
 
-#: src/muuli_wdr.cpp:2604
+#: src/muuli_wdr.cpp:2635
 msgid "Port:"
 msgstr "Port:"
 
-#: src/muuli_wdr.cpp:2617
+#: src/muuli_wdr.cpp:2648
 msgid "Bootstrap from known clients"
 msgstr "Bootstrap od známých klientů"
 
-#: src/muuli_wdr.cpp:2619
+#: src/muuli_wdr.cpp:2650
 msgid "Disconnect Kad"
 msgstr "Odpojit Kad"
 
-#: src/muuli_wdr.cpp:2653
+#: src/muuli_wdr.cpp:2684
 msgid "Use Secure User Identification"
 msgstr "Použít bezpečnou uživatelskou identifikaci"
 
-#: src/muuli_wdr.cpp:2655
+#: src/muuli_wdr.cpp:2686
 msgid "It is recommended to enable this option. You will not receive credits if SUI is not enabled."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2657
+#: src/muuli_wdr.cpp:2688
 msgid "Protocol Obfuscation"
 msgstr "Zatemnění protokolu"
 
-#: src/muuli_wdr.cpp:2660
+#: src/muuli_wdr.cpp:2691
 msgid "Support Protocol Obfuscation"
 msgstr "Podporuje zatemnění protokolu"
 
-#: src/muuli_wdr.cpp:2662
+#: src/muuli_wdr.cpp:2693
 msgid "This option enabled Protocol Obfuscation, and makes aMule accept obfuscated connections from other clients."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2664
+#: src/muuli_wdr.cpp:2695
 msgid "Use obfuscation for outgoing connections"
 msgstr "Použít zatemnění protokolu pro odchozí spojení"
 
-#: src/muuli_wdr.cpp:2666
+#: src/muuli_wdr.cpp:2697
 msgid "This option makes aMule use Protocol Obfuscation when connecting other clients/servers."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2668
+#: src/muuli_wdr.cpp:2699
 msgid "Accept only obfuscated connections"
 msgstr "Přijímat pouze zatemněná spojení"
 
-#: src/muuli_wdr.cpp:2669
+#: src/muuli_wdr.cpp:2700
 msgid "This option makes aMule only accept obfuscated connections. You will have less sources, but all your traffic will be obfuscated"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2674
+#: src/muuli_wdr.cpp:2705
 msgid "Everybody"
 msgstr "Všichni"
 
-#: src/muuli_wdr.cpp:2676
+#: src/muuli_wdr.cpp:2707
 msgid "No one"
 msgstr "Nikdo"
 
-#: src/muuli_wdr.cpp:2678
+#: src/muuli_wdr.cpp:2709
 msgid "Who can see my shared files:"
 msgstr "Kdo může prohlížet moje sdílené soubory:"
 
-#: src/muuli_wdr.cpp:2679
+#: src/muuli_wdr.cpp:2710
 msgid "Select who can request to view a list of your shared files."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2681
+#: src/muuli_wdr.cpp:2712
 msgid "IP-Filtering"
 msgstr "IP filtrování"
 
-#: src/muuli_wdr.cpp:2688
+#: src/muuli_wdr.cpp:2719
 msgid "Filter clients"
 msgstr "Filtrovat klienty"
 
-#: src/muuli_wdr.cpp:2690
+#: src/muuli_wdr.cpp:2721
 msgid "Enable filtering of the client IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2692
+#: src/muuli_wdr.cpp:2723
 msgid "Filter servers"
 msgstr "Filtrovat servery"
 
-#: src/muuli_wdr.cpp:2694
+#: src/muuli_wdr.cpp:2725
 msgid "Enable filtering of the server IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2698
+#: src/muuli_wdr.cpp:2729
 msgid "Reload List"
 msgstr "Obnovit seznam"
 
-#: src/muuli_wdr.cpp:2699
+#: src/muuli_wdr.cpp:2730
 msgid "Reload the list of IPs to filter from the file ~/.aMule/ipfilter.dat"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2705
+#: src/muuli_wdr.cpp:2736
 msgid "URL:"
 msgstr "URL:"
 
-#: src/muuli_wdr.cpp:2709 src/muuli_wdr.cpp:2902
+#: src/muuli_wdr.cpp:2740 src/muuli_wdr.cpp:2933
 msgid "Update now"
 msgstr "Obnovit"
 
-#: src/muuli_wdr.cpp:2712
+#: src/muuli_wdr.cpp:2743
 msgid "Auto-update ipfilter at startup"
 msgstr "Automaticky aktualizovat IP filtr po spuštění"
 
-#: src/muuli_wdr.cpp:2716
+#: src/muuli_wdr.cpp:2747
 msgid "Filtering Level:"
 msgstr "Úroveň filtrování:"
 
-#: src/muuli_wdr.cpp:2722
+#: src/muuli_wdr.cpp:2753
 msgid "Always filter LAN IPs"
 msgstr "Vždy filtrovat LAN IP"
 
-#: src/muuli_wdr.cpp:2725
+#: src/muuli_wdr.cpp:2756
 msgid "Paranoid handling of non-matching IPs"
 msgstr "Paranoidní nakládání s nesouhlasícími IP"
 
-#: src/muuli_wdr.cpp:2727
+#: src/muuli_wdr.cpp:2758
 msgid "Rejects a packet when its source IP differs from the IP the client claims (an anti-spoofing check). Disable only if it causes connection problems."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2729
+#: src/muuli_wdr.cpp:2760
 msgid "Use system-wide ipfilter.dat if available"
 msgstr "Použít systémový ipfilter.dat, je-li dostupný"
 
-#: src/muuli_wdr.cpp:2730
+#: src/muuli_wdr.cpp:2761
 #, fuzzy
 msgid "If there's no local ipfilter.dat found, allow usage of a system-wide ipfilter file."
 msgstr "Neexistuje-li místní ipfilter.dat, umožní použití systémového."
 
-#: src/muuli_wdr.cpp:2747
+#: src/muuli_wdr.cpp:2778
 msgid "Enable Online-Signature"
 msgstr "Povolit online podpis"
 
-#: src/muuli_wdr.cpp:2749
+#: src/muuli_wdr.cpp:2780
 msgid "Enables the writing of the OS file, which can be used by external apps to create signatures and the like."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2753
+#: src/muuli_wdr.cpp:2784
 msgid "Update Frequency (Secs):"
 msgstr "Prodleva aktualizace (sek.):"
 
-#: src/muuli_wdr.cpp:2756
+#: src/muuli_wdr.cpp:2787
 msgid "Change the frequency (in seconds) of Online Signature updates."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2764
+#: src/muuli_wdr.cpp:2795
 msgid "Save online signature file in: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:2770
+#: src/muuli_wdr.cpp:2801
 msgid "Click here to select the directory containing the the Online Signature files."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2803
+#: src/muuli_wdr.cpp:2834
 msgid "Show country flags for clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2804
+#: src/muuli_wdr.cpp:2835
 msgid "Render the country flag column in the transfers, queue and search views. Requires a valid MMDB GeoIP database (see below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2809
+#: src/muuli_wdr.cpp:2840
 msgid "Database"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2825
+#: src/muuli_wdr.cpp:2856
 #, fuzzy
 msgid "Source:"
 msgstr "Zdroje"
 
-#: src/muuli_wdr.cpp:2828
+#: src/muuli_wdr.cpp:2859
 msgid "DB-IP (free, no account)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2829
+#: src/muuli_wdr.cpp:2860
 msgid "MaxMind GeoLite2 (free, account required)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2830
+#: src/muuli_wdr.cpp:2861
 msgid "Custom URL"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2833
+#: src/muuli_wdr.cpp:2864
 msgid "Choose which provider supplies the GeoIP MMDB database. DB-IP is the default - no account required. MaxMind requires a free account + license key. Use Custom URL to point at any other MMDB host (e.g. a local mirror)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2850
+#: src/muuli_wdr.cpp:2881
 msgid ""
 "No configuration required.\n"
 "\n"
@@ -4843,11 +4871,11 @@ msgid ""
 "License: Creative Commons BY 4.0 - https://creativecommons.org/licenses/by/4.0/"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2863
+#: src/muuli_wdr.cpp:2894
 msgid "License key:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2869
+#: src/muuli_wdr.cpp:2900
 msgid ""
 "Sign up for a free MaxMind account, then generate a License Key:\n"
 "https://www.maxmind.com/en/geolite2/signup\n"
@@ -4857,230 +4885,230 @@ msgid ""
 "Requires attribution and account registration; refresh at least every 30 days."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2884
+#: src/muuli_wdr.cpp:2915
 #, fuzzy
 msgid "Download URL:"
 msgstr "Stahování: "
 
-#: src/muuli_wdr.cpp:2890
+#: src/muuli_wdr.cpp:2921
 msgid ""
 "Must point to an .mmdb file or a .gz / .tar.gz containing one.\n"
 "URL may include credentials (https://user:pass@host/...).\n"
 "License and attribution terms are set by the upstream URL - you are responsible."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2903
+#: src/muuli_wdr.cpp:2934
 msgid "Download the GeoIP database from the selected source."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2905
+#: src/muuli_wdr.cpp:2936
 #, fuzzy
 msgid "Auto-update on startup"
 msgstr "Automaticky aktualizovat IP filtr po spuštění"
 
-#: src/muuli_wdr.cpp:2906
+#: src/muuli_wdr.cpp:2937
 msgid "Re-download the GeoIP database from the selected source every time aMule starts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2929
+#: src/muuli_wdr.cpp:2960
 msgid "Filter incoming messages (except current chat):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2931
+#: src/muuli_wdr.cpp:2962
 msgid "Filter all messages"
 msgstr "Filtrovat všechny zprávy"
 
-#: src/muuli_wdr.cpp:2933
+#: src/muuli_wdr.cpp:2964
 msgid "Filter messages from people not on your friend list"
 msgstr "Filtrovat zprávy, které nejsou od přátel"
 
-#: src/muuli_wdr.cpp:2935
+#: src/muuli_wdr.cpp:2966
 msgid "Filter messages from unknown clients"
 msgstr "Filtrovat zprávy od neznámých klientů"
 
-#: src/muuli_wdr.cpp:2937
+#: src/muuli_wdr.cpp:2968
 msgid "Filter messages containing (use ',' as separator):"
 msgstr "Filtrovat zprávy obsahující (použijte ',' jako oddělovač):"
 
-#: src/muuli_wdr.cpp:2940 src/muuli_wdr.cpp:2951
+#: src/muuli_wdr.cpp:2971 src/muuli_wdr.cpp:2982
 msgid "add here the words amule should filter and block messages including it"
 msgstr "zadejte slova, která by měla amule filtrovat a blokovat zprávy obsahující je"
 
-#: src/muuli_wdr.cpp:2942
+#: src/muuli_wdr.cpp:2973
 msgid "Show received messages in the log"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2945
+#: src/muuli_wdr.cpp:2976
 msgid "Comments"
 msgstr "Komentáře"
 
-#: src/muuli_wdr.cpp:2948
+#: src/muuli_wdr.cpp:2979
 msgid "Filter comments containing (use ',' as separator):"
 msgstr "Filtrovat komentáře obsahující (použijte ',' jako oddělovač):"
 
-#: src/muuli_wdr.cpp:2973
+#: src/muuli_wdr.cpp:3004
 msgid "Enable Proxy"
 msgstr "Povolit proxy"
 
-#: src/muuli_wdr.cpp:2974
+#: src/muuli_wdr.cpp:3005
 msgid "Enable/disable proxy support"
 msgstr "Povolí/zakáže proxy"
 
-#: src/muuli_wdr.cpp:2977
+#: src/muuli_wdr.cpp:3008
 msgid "Proxy type:"
 msgstr "Typ proxy:"
 
-#: src/muuli_wdr.cpp:2988
+#: src/muuli_wdr.cpp:3019
 msgid "Proxy host:"
 msgstr "Hostitel proxy:"
 
-#: src/muuli_wdr.cpp:2991
+#: src/muuli_wdr.cpp:3022
 msgid "The proxy host name"
 msgstr "Název hostitele proxy"
 
-#: src/muuli_wdr.cpp:2993
+#: src/muuli_wdr.cpp:3024
 msgid "Proxy port:"
 msgstr "Port proxy:"
 
-#: src/muuli_wdr.cpp:2996
+#: src/muuli_wdr.cpp:3027
 msgid "The proxy port"
 msgstr "Port proxy"
 
-#: src/muuli_wdr.cpp:2998
+#: src/muuli_wdr.cpp:3029
 msgid "Enable authentication"
 msgstr "Povolit autentizaci"
 
-#: src/muuli_wdr.cpp:2999
+#: src/muuli_wdr.cpp:3030
 msgid "Enable/disable username/password authentication"
 msgstr "Povolí/zakáže autentizaci (uživatelské jméno a heslo)"
 
-#: src/muuli_wdr.cpp:3002
+#: src/muuli_wdr.cpp:3033
 msgid "Username: "
 msgstr "Uživatelské jméno: "
 
-#: src/muuli_wdr.cpp:3005
+#: src/muuli_wdr.cpp:3036
 msgid "The username to use to connect to the proxy"
 msgstr "Uživatelské jméno, které se použije pro přihlášení k proxy"
 
-#: src/muuli_wdr.cpp:3007
+#: src/muuli_wdr.cpp:3038
 msgid "Password:"
 msgstr "Heslo:"
 
-#: src/muuli_wdr.cpp:3010
+#: src/muuli_wdr.cpp:3041
 msgid "The password to use to connect to the proxy"
 msgstr "Heslo, které se použije pro přihlášení k proxy"
 
-#: src/muuli_wdr.cpp:3029
+#: src/muuli_wdr.cpp:3060
 msgid "Connect to:"
 msgstr "Připojit se k:"
 
-#: src/muuli_wdr.cpp:3038
+#: src/muuli_wdr.cpp:3069
 msgid "Login to remote amule"
 msgstr "Připojit k vzdálené aMuli"
 
-#: src/muuli_wdr.cpp:3043
+#: src/muuli_wdr.cpp:3074
 msgid "User name"
 msgstr "Uživatelské jméno"
 
-#: src/muuli_wdr.cpp:3054
+#: src/muuli_wdr.cpp:3085
 msgid "Remember those settings"
 msgstr "Zapamatovat si toto nastavení"
 
-#: src/muuli_wdr.cpp:3057
+#: src/muuli_wdr.cpp:3088
 #, fuzzy
 msgid "Force ZLIB compression"
 msgstr "Použít gzip kompresi"
 
-#: src/muuli_wdr.cpp:3081
+#: src/muuli_wdr.cpp:3112
 msgid "Enable Verbose Debug-Logging."
 msgstr ""
 
-#: src/muuli_wdr.cpp:3083
+#: src/muuli_wdr.cpp:3114
 #, fuzzy
 msgid "Only to Logfile"
 msgstr "&Otevřít tento soubor"
 
-#: src/muuli_wdr.cpp:3085
+#: src/muuli_wdr.cpp:3116
 msgid "Message Categories:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3109 src/PartFileConvertDlg.cpp:160
+#: src/muuli_wdr.cpp:3140 src/PartFileConvertDlg.cpp:160
 msgid "Waiting..."
 msgstr "Čekání..."
 
-#: src/muuli_wdr.cpp:3129
+#: src/muuli_wdr.cpp:3160
 msgid "Add imports"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3132
+#: src/muuli_wdr.cpp:3163
 msgid "Retry selected"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3134
+#: src/muuli_wdr.cpp:3165
 msgid "Remove selected"
 msgstr "Odstranit vybrané"
 
-#: src/muuli_wdr.cpp:3197
+#: src/muuli_wdr.cpp:3228
 msgid "Event Types"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3216
+#: src/muuli_wdr.cpp:3247
 msgid "Statistics and queued clients for selected file(s) : Session / All time"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3240
+#: src/muuli_wdr.cpp:3271
 msgid "Active Uploads"
 msgstr "Aktivní odesílání"
 
-#: src/muuli_wdr.cpp:3254
+#: src/muuli_wdr.cpp:3285
 msgid "Percent of total files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3306
+#: src/muuli_wdr.cpp:3337
 #, fuzzy
 msgid "Show Clients for"
 msgstr "Zobrazit klienty"
 
-#: src/muuli_wdr.cpp:3308
+#: src/muuli_wdr.cpp:3339
 #, fuzzy
 msgid "All files"
 msgstr "Všechny sdílené soubory"
 
-#: src/muuli_wdr.cpp:3311
+#: src/muuli_wdr.cpp:3342
 #, fuzzy
 msgid "Selected files"
 msgstr "Sdílené soubory"
 
-#: src/muuli_wdr.cpp:3314
+#: src/muuli_wdr.cpp:3345
 #, fuzzy
 msgid "Active uploads only"
 msgstr "Aktivní odesílání"
 
-#: src/muuli_wdr.cpp:3321
+#: src/muuli_wdr.cpp:3352
 msgid "Reload:"
 msgstr "Obnovit:"
 
-#: src/muuli_wdr.cpp:3325
+#: src/muuli_wdr.cpp:3356
 msgid "Reload your shared files"
 msgstr "Znovu načíst vaše sdílené soubory"
 
-#: src/muuli_wdr.cpp:3388
+#: src/muuli_wdr.cpp:3419
 msgid "Send"
 msgstr "Odeslat"
 
-#: src/muuli_wdr.cpp:3389
+#: src/muuli_wdr.cpp:3420
 msgid "Sends the specified message."
 msgstr "Odešle zadanou zprávu."
 
-#: src/muuli_wdr.cpp:3393
+#: src/muuli_wdr.cpp:3424
 msgid "Close this chat-session."
 msgstr "Zavře tento chat."
 
-#: src/muuli_wdr.cpp:3416
+#: src/muuli_wdr.cpp:3447
 msgid "Connect to any server and/or Kad"
 msgstr "Připojit k nějakému serveru a/nebo Kadu"
 
-#: src/muuli_wdr.cpp:3422 src/SharedFilesCtrl.cpp:142 src/Statistics.cpp:941
+#: src/muuli_wdr.cpp:3453 src/SharedFilesCtrl.cpp:142 src/Statistics.cpp:941
 msgid "Shared Files"
 msgstr "Sdílené soubory"
 
@@ -5444,265 +5472,265 @@ msgstr "Staženo"
 msgid "ERROR: Failed to open partfile '%s'"
 msgstr ""
 
-#: src/Preferences.cpp:674
+#: src/Preferences.cpp:701
 msgid "System default"
 msgstr "Výchozí pro systém"
 
-#: src/Preferences.cpp:675
+#: src/Preferences.cpp:702
 msgid "Albanian"
 msgstr "Albánština"
 
-#: src/Preferences.cpp:676
+#: src/Preferences.cpp:703
 msgid "Arabic"
 msgstr "Arabský"
 
-#: src/Preferences.cpp:677
+#: src/Preferences.cpp:704
 msgid "Asturian"
 msgstr ""
 
-#: src/Preferences.cpp:678
+#: src/Preferences.cpp:705
 msgid "Basque"
 msgstr "Baskičtina"
 
-#: src/Preferences.cpp:679
+#: src/Preferences.cpp:706
 msgid "Bulgarian"
 msgstr "Bulharský"
 
-#: src/Preferences.cpp:680
+#: src/Preferences.cpp:707
 msgid "Catalan"
 msgstr "Katalánština"
 
-#: src/Preferences.cpp:681
+#: src/Preferences.cpp:708
 msgid "Chinese (Simplified)"
 msgstr "Čínština (zjednodušená)"
 
-#: src/Preferences.cpp:682
+#: src/Preferences.cpp:709
 msgid "Chinese (Traditional)"
 msgstr "Čínština (tradiční)"
 
-#: src/Preferences.cpp:683
+#: src/Preferences.cpp:710
 msgid "Croatian"
 msgstr "Chorvatština"
 
-#: src/Preferences.cpp:684
+#: src/Preferences.cpp:711
 msgid "Czech"
 msgstr "Česky"
 
-#: src/Preferences.cpp:685
+#: src/Preferences.cpp:712
 msgid "Danish"
 msgstr "Dánština"
 
-#: src/Preferences.cpp:686
+#: src/Preferences.cpp:713
 msgid "Dutch"
 msgstr "Nizozemština"
 
-#: src/Preferences.cpp:687
+#: src/Preferences.cpp:714
 msgid "English (U.K.)"
 msgstr "Angličtina (britská)"
 
-#: src/Preferences.cpp:688
+#: src/Preferences.cpp:715
 #, fuzzy
 msgid "English (U.S.)"
 msgstr "Angličtina (britská)"
 
-#: src/Preferences.cpp:689
+#: src/Preferences.cpp:716
 msgid "Estonian"
 msgstr "Estonština"
 
-#: src/Preferences.cpp:690
+#: src/Preferences.cpp:717
 msgid "Finnish"
 msgstr "Finština"
 
-#: src/Preferences.cpp:691
+#: src/Preferences.cpp:718
 msgid "French"
 msgstr "Francouzština"
 
-#: src/Preferences.cpp:692
+#: src/Preferences.cpp:719
 msgid "Galician"
 msgstr "Galicijština"
 
-#: src/Preferences.cpp:693
+#: src/Preferences.cpp:720
 msgid "German"
 msgstr "Němčina"
 
-#: src/Preferences.cpp:694
+#: src/Preferences.cpp:721
 msgid "Greek"
 msgstr "Řečtina"
 
-#: src/Preferences.cpp:695
+#: src/Preferences.cpp:722
 msgid "Hebrew"
 msgstr "Hebrejština"
 
-#: src/Preferences.cpp:696
+#: src/Preferences.cpp:723
 msgid "Hungarian"
 msgstr "Maďarština"
 
-#: src/Preferences.cpp:697
+#: src/Preferences.cpp:724
 msgid "Italian"
 msgstr "Italština"
 
-#: src/Preferences.cpp:698
+#: src/Preferences.cpp:725
 msgid "Japanese"
 msgstr "Japonština"
 
-#: src/Preferences.cpp:699
+#: src/Preferences.cpp:726
 msgid "Korean"
 msgstr "Korejština"
 
-#: src/Preferences.cpp:700
+#: src/Preferences.cpp:727
 msgid "Latvian"
 msgstr ""
 
-#: src/Preferences.cpp:701
+#: src/Preferences.cpp:728
 msgid "Lithuanian"
 msgstr "Litevština"
 
-#: src/Preferences.cpp:702
+#: src/Preferences.cpp:729
 msgid "Norwegian (Nynorsk)"
 msgstr "Norština"
 
-#: src/Preferences.cpp:703
+#: src/Preferences.cpp:730
 msgid "Polish"
 msgstr "Polština"
 
-#: src/Preferences.cpp:704
+#: src/Preferences.cpp:731
 msgid "Portuguese"
 msgstr "Portugalština"
 
-#: src/Preferences.cpp:705
+#: src/Preferences.cpp:732
 msgid "Portuguese (Brazilian)"
 msgstr "Portugalština (brazilská)"
 
-#: src/Preferences.cpp:706
+#: src/Preferences.cpp:733
 msgid "Romanian"
 msgstr "Rumunština"
 
-#: src/Preferences.cpp:707
+#: src/Preferences.cpp:734
 msgid "Russian"
 msgstr "Ruština"
 
-#: src/Preferences.cpp:708
+#: src/Preferences.cpp:735
 msgid "Slovenian"
 msgstr "Slovinština"
 
-#: src/Preferences.cpp:709
+#: src/Preferences.cpp:736
 msgid "Spanish"
 msgstr "Španělština"
 
-#: src/Preferences.cpp:710
+#: src/Preferences.cpp:737
 msgid "Swedish"
 msgstr "Švédština"
 
-#: src/Preferences.cpp:711
+#: src/Preferences.cpp:738
 msgid "Turkish"
 msgstr "Turečtina"
 
-#: src/Preferences.cpp:712
+#: src/Preferences.cpp:739
 msgid "Ukrainian"
 msgstr "Ukrajinština"
 
-#: src/Preferences.cpp:815
+#: src/Preferences.cpp:842
 msgid "Change Language"
 msgstr "Změnit jazyk"
 
-#: src/Preferences.cpp:879
+#: src/Preferences.cpp:906
 msgid "There are no translations installed for aMule"
 msgstr ""
 
-#: src/Preferences.cpp:880
+#: src/Preferences.cpp:907
 #, fuzzy
 msgid "No languages available"
 msgstr "Nedostupný"
 
-#: src/Preferences.cpp:1011
+#: src/Preferences.cpp:1038
 msgid "no options available"
 msgstr "není dostupné žádné nastavení"
 
-#: src/Preferences.cpp:2182
+#: src/Preferences.cpp:2227
 msgid "Invalid category found, skipping"
 msgstr "Nalezena neplatná kategorie, přeskakuji"
 
-#: src/Preferences.cpp:2351
+#: src/Preferences.cpp:2396
 msgid "TCP port can't be higher than 65532 due to server UDP socket being TCP+3"
 msgstr "TCP port nemůže být vyšší než 65532, protože UDP port je TCP+3"
 
-#: src/Preferences.cpp:2352
+#: src/Preferences.cpp:2397
 #, c-format
 msgid "Default port will be used (%d)"
 msgstr "Bude použit výchozí port (%d)"
 
-#: src/PrefsUnifiedDlg.cpp:298 src/Statistics.cpp:866
+#: src/PrefsUnifiedDlg.cpp:300 src/Statistics.cpp:866
 msgid "Connection"
 msgstr "Připojení"
 
-#: src/PrefsUnifiedDlg.cpp:299 src/SearchListCtrl.cpp:117
+#: src/PrefsUnifiedDlg.cpp:301 src/SearchListCtrl.cpp:117
 msgid "Directories"
 msgstr "Adresáře"
 
-#: src/PrefsUnifiedDlg.cpp:300 src/Statistics.cpp:917
+#: src/PrefsUnifiedDlg.cpp:302 src/Statistics.cpp:917
 msgid "Servers"
 msgstr "Servery"
 
-#: src/PrefsUnifiedDlg.cpp:301 src/ServerListCtrl.cpp:96
+#: src/PrefsUnifiedDlg.cpp:303 src/ServerListCtrl.cpp:96
 msgid "Files"
 msgstr "Soubory"
 
-#: src/PrefsUnifiedDlg.cpp:302
+#: src/PrefsUnifiedDlg.cpp:304
 msgid "Security"
 msgstr "Bezpečnost"
 
-#: src/PrefsUnifiedDlg.cpp:303
+#: src/PrefsUnifiedDlg.cpp:305
 msgid "Interface"
 msgstr "Rozhraní"
 
-#: src/PrefsUnifiedDlg.cpp:310
+#: src/PrefsUnifiedDlg.cpp:312
 msgid "IP2Country"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:313
+#: src/PrefsUnifiedDlg.cpp:315
 msgid "Proxy"
 msgstr "Proxy"
 
-#: src/PrefsUnifiedDlg.cpp:314
+#: src/PrefsUnifiedDlg.cpp:316
 msgid "Filters"
 msgstr "Filtry"
 
-#: src/PrefsUnifiedDlg.cpp:315
+#: src/PrefsUnifiedDlg.cpp:317
 msgid "Remote Controls"
 msgstr "Vzdálené ovládání"
 
-#: src/PrefsUnifiedDlg.cpp:316
+#: src/PrefsUnifiedDlg.cpp:318
 msgid "Online Signature"
 msgstr "Online podpis"
 
-#: src/PrefsUnifiedDlg.cpp:317
+#: src/PrefsUnifiedDlg.cpp:319
 msgid "Advanced"
 msgstr "Pokročilé"
 
-#: src/PrefsUnifiedDlg.cpp:318
+#: src/PrefsUnifiedDlg.cpp:320
 msgid "Events"
 msgstr "Události"
 
-#: src/PrefsUnifiedDlg.cpp:321
+#: src/PrefsUnifiedDlg.cpp:323
 msgid "Debugging"
 msgstr "Debugování"
 
-#: src/PrefsUnifiedDlg.cpp:451
+#: src/PrefsUnifiedDlg.cpp:453
 msgid ""
 "The following variables will be substituted:\n"
 "    %PARTFILE - full path to the file\n"
 "    %PARTNAME - file name only"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:472
+#: src/PrefsUnifiedDlg.cpp:474
 msgid "Tray icon support requires libayatana-appindicator3 at compile time."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:488
+#: src/PrefsUnifiedDlg.cpp:490
 msgid "Not available on Wayland: the protocol does not report when a window is minimized, so this option cannot intercept the system minimize button. Workaround: launch aMule with `GDK_BACKEND=x11` to use XWayland instead."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:534
+#: src/PrefsUnifiedDlg.cpp:536
 msgid ""
 "Do not change these setting unless you know\n"
 "what you are doing, otherwise you can easily\n"
@@ -5718,26 +5746,35 @@ msgstr ""
 "aMule poběží v pohodě bez změny\n"
 "nastavení na tomto tabu."
 
-#: src/PrefsUnifiedDlg.cpp:645
+#: src/PrefsUnifiedDlg.cpp:647
 #, c-format
 msgid "Failed to connect Cfg to widget with the ID %d and key %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:693
+#: src/PrefsUnifiedDlg.cpp:695
 #, c-format
 msgid "Failed to transfer data from Cfg to Widget with the ID %d and key %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:799
+#: src/PrefsUnifiedDlg.cpp:801
 msgid "The type of proxy you are connecting to"
 msgstr "Typ proxy, ke které se připojujete"
 
-#: src/PrefsUnifiedDlg.cpp:1003
+#: src/PrefsUnifiedDlg.cpp:1020
 #, c-format
 msgid "Failed to transfer data from Widget to Cfg with the ID %d and key %s"
 msgstr ""
 
 #: src/PrefsUnifiedDlg.cpp:1103
+#, fuzzy
+msgid "No password set."
+msgstr "Kontrola hesla\n"
+
+#: src/PrefsUnifiedDlg.cpp:1132
+msgid "Guest access needs a password. Type one in the guest password field, or untick Enable guest access."
+msgstr ""
+
+#: src/PrefsUnifiedDlg.cpp:1144
 msgid ""
 "aMule must be restarted to enable these changes:\n"
 "\n"
@@ -5745,84 +5782,89 @@ msgstr ""
 "Restartujte aMule, aby se projevily následující změny:\n"
 "\n"
 
-#: src/PrefsUnifiedDlg.cpp:1110
+#: src/PrefsUnifiedDlg.cpp:1151
 msgid "- TCP port changed.\n"
 msgstr "- TCP port změněn.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1115
+#: src/PrefsUnifiedDlg.cpp:1156
 msgid "- UDP port changed.\n"
 msgstr "- UDP port změněn.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1120
+#: src/PrefsUnifiedDlg.cpp:1161
 #, fuzzy
 msgid "- Network interface binding changed.\n"
 msgstr "Externí připojení uzavřeno."
 
-#: src/PrefsUnifiedDlg.cpp:1125
+#: src/PrefsUnifiedDlg.cpp:1166
 #, fuzzy
 msgid "- External connect port changed.\n"
 msgstr "Externí připojení uzavřeno."
 
-#: src/PrefsUnifiedDlg.cpp:1129
+#: src/PrefsUnifiedDlg.cpp:1170
 #, fuzzy
 msgid "- External connect acceptance changed.\n"
 msgstr "Nové externí připojení přijato"
 
-#: src/PrefsUnifiedDlg.cpp:1133
+#: src/PrefsUnifiedDlg.cpp:1174
 #, fuzzy
 msgid "- External connect interface changed.\n"
 msgstr "Externí připojení uzavřeno."
 
-#: src/PrefsUnifiedDlg.cpp:1137
+#: src/PrefsUnifiedDlg.cpp:1178
 #, fuzzy
 msgid "- Protocol obfuscation support changed.\n"
 msgstr "Zatemnění protokolu"
 
-#: src/PrefsUnifiedDlg.cpp:1151
+#: src/PrefsUnifiedDlg.cpp:1193
 #, fuzzy
 msgid "- amuleapi settings changed.\n"
 msgstr "- Jazyk byl změněn.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1160
+#: src/PrefsUnifiedDlg.cpp:1202
 msgid ""
 "Your Auto-update server list is empty.\n"
 "'Auto-update server list at startup' will be disabled."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1171
+#: src/PrefsUnifiedDlg.cpp:1213
 msgid ""
 "You have enabled external connections but have not specified a password.\n"
 "External connections cannot be enabled unless a valid password is specified."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1202
+#: src/PrefsUnifiedDlg.cpp:1246
+#, c-format
+msgid "The amuleapi password could not be saved: %s"
+msgstr ""
+
+#: src/PrefsUnifiedDlg.cpp:1276
 msgid "- Language changed.\n"
 msgstr "- Jazyk byl změněn.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1207
+#: src/PrefsUnifiedDlg.cpp:1281
 msgid "- Temp folder changed.\n"
 msgstr "- Dočasný adresář byl změněn.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1212
+#: src/PrefsUnifiedDlg.cpp:1286
 msgid "- ED2K network enabled.\n"
 msgstr "- Síť eD2k povolena.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1245
+#: src/PrefsUnifiedDlg.cpp:1319
 msgid "The shared-file exclusion pattern is not a valid regular expression. The filter has been left disabled."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1247 src/PrefsUnifiedDlg.cpp:1841
+#: src/PrefsUnifiedDlg.cpp:1321 src/PrefsUnifiedDlg.cpp:1921
 #, fuzzy
 msgid "Invalid regular expression"
 msgstr "Neplatná verze protokolu."
 
-#: src/PrefsUnifiedDlg.cpp:1324
+#: src/PrefsUnifiedDlg.cpp:1398
 msgid ""
 "Both eD2k and Kad network are disabled.\n"
 "You won't be able to connect until you enable at least one of them."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1329
+#: src/PrefsUnifiedDlg.cpp:1403
 msgid ""
 "Kad will not start if your UDP port is disabled.\n"
 "Enable UDP port or disable Kad."
@@ -5830,7 +5872,7 @@ msgstr ""
 "Kad se nespustí, když máte zakázaný UDP port.\n"
 "Povolte UDP port, nebo zakažte připojování na Kad."
 
-#: src/PrefsUnifiedDlg.cpp:1385
+#: src/PrefsUnifiedDlg.cpp:1459
 msgid ""
 "\n"
 "You MUST restart aMule now.\n"
@@ -5840,93 +5882,93 @@ msgstr ""
 "Nyní MUSÍTE restartovat aMule.\n"
 "Pokud to neuděláte, tak si pak nestěžujte, když se přihodí něco špatného.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1450
+#: src/PrefsUnifiedDlg.cpp:1524
 msgid "Could not register aMule for autostart at login. The autostart store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1452
+#: src/PrefsUnifiedDlg.cpp:1526
 msgid "Could not remove the autostart-at-login entry."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1453
+#: src/PrefsUnifiedDlg.cpp:1527
 #, fuzzy
 msgid "Autostart"
 msgstr "Automatické obnovování spuštěno"
 
-#: src/PrefsUnifiedDlg.cpp:1468
+#: src/PrefsUnifiedDlg.cpp:1542
 msgid "Register file type"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1468
+#: src/PrefsUnifiedDlg.cpp:1542
 msgid "Register URL handler"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1476
+#: src/PrefsUnifiedDlg.cpp:1550
 #, c-format
 msgid "aMule only handles eD2k-compatible magnets. If you replace the current magnet handler (%s), BitTorrent magnet links will stop working - aMule cannot download BitTorrent content. Continue?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1481
+#: src/PrefsUnifiedDlg.cpp:1555
 #, c-format
 msgid "Another application currently opens .emulecollection files (%s). Replace it with aMule?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1486
+#: src/PrefsUnifiedDlg.cpp:1560
 #, c-format
 msgid "Another application is currently the default handler for these links (%s). Replace it with aMule?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1511
+#: src/PrefsUnifiedDlg.cpp:1585
 msgid "Could not register aMule for .emulecollection files. The registration store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1513
+#: src/PrefsUnifiedDlg.cpp:1587
 #, fuzzy
 msgid "Could not remove the file type registration."
 msgstr "Soubor %s se již pokoušíte stáhnout"
 
-#: src/PrefsUnifiedDlg.cpp:1515
+#: src/PrefsUnifiedDlg.cpp:1589
 msgid "Could not register aMule as the URL handler. The registration store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1517
+#: src/PrefsUnifiedDlg.cpp:1591
 msgid "Could not remove the URL handler registration."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1587 src/PrefsUnifiedDlg.cpp:1614
+#: src/PrefsUnifiedDlg.cpp:1661 src/PrefsUnifiedDlg.cpp:1688
 #, fuzzy
 msgid "The web server and aMule API require external connections to be enabled."
 msgstr "Heslo nastaveno a externí připojení povoleno."
 
-#: src/PrefsUnifiedDlg.cpp:1597
+#: src/PrefsUnifiedDlg.cpp:1671
 msgid "The aMule web server is deprecated. Consider running the aMule API instead."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1655
+#: src/PrefsUnifiedDlg.cpp:1735
 msgid ""
 "Your Auto-update servers list is in blank.\n"
 "Please fill in at least one URL to point to a valid server.met file.\n"
 "Click on the button \"List\" by this checkbox to enter an URL."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1796
+#: src/PrefsUnifiedDlg.cpp:1876
 msgid "Temporary files"
 msgstr "Dočasné soubory"
 
-#: src/PrefsUnifiedDlg.cpp:1801
+#: src/PrefsUnifiedDlg.cpp:1881
 msgid "Incoming files"
 msgstr "Příchozí soubory"
 
-#: src/PrefsUnifiedDlg.cpp:1806
+#: src/PrefsUnifiedDlg.cpp:1886
 msgid "Online Signatures"
 msgstr "Online podpisy"
 
-#: src/PrefsUnifiedDlg.cpp:1819
+#: src/PrefsUnifiedDlg.cpp:1899
 #, c-format
 msgid "Choose a folder for %s"
 msgstr "Zvolte adresář pro %s"
 
-#: src/PrefsUnifiedDlg.cpp:1843
+#: src/PrefsUnifiedDlg.cpp:1923
 #, fuzzy, c-format
 msgid "Would exclude %u of %u shared file"
 msgid_plural "Would exclude %u of %u shared files"
@@ -5934,42 +5976,42 @@ msgstr[0] "Znovu načíst vaše sdílené soubory"
 msgstr[1] "Znovu načíst vaše sdílené soubory"
 msgstr[2] "Znovu načíst vaše sdílené soubory"
 
-#: src/PrefsUnifiedDlg.cpp:1860
+#: src/PrefsUnifiedDlg.cpp:1940
 msgid "Browse for videoplayer"
 msgstr "Zvolit přehrávač videa"
 
-#: src/PrefsUnifiedDlg.cpp:1864
+#: src/PrefsUnifiedDlg.cpp:1944
 msgid "Select browser"
 msgstr "Výběr prohlížeče"
 
-#: src/PrefsUnifiedDlg.cpp:1868
+#: src/PrefsUnifiedDlg.cpp:1948
 #, fuzzy
 msgid "Select ffprobe binary"
 msgstr "Výběr prohlížeče"
 
-#: src/PrefsUnifiedDlg.cpp:1874
+#: src/PrefsUnifiedDlg.cpp:1954
 #, c-format
 msgid "Executable%s"
 msgstr "Spustitelný soubor %s"
 
-#: src/PrefsUnifiedDlg.cpp:1908
+#: src/PrefsUnifiedDlg.cpp:1988
 msgid "ffprobe not found on PATH or in the standard install locations. Install ffmpeg (which ships ffprobe) or use Browse to pick a binary manually."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1920
+#: src/PrefsUnifiedDlg.cpp:2000
 msgid "Reset the settings on this page to their default values?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1921
+#: src/PrefsUnifiedDlg.cpp:2001
 #, fuzzy
 msgid "Reset to defaults"
 msgstr "Výchozí pro systém"
 
-#: src/PrefsUnifiedDlg.cpp:1948
+#: src/PrefsUnifiedDlg.cpp:2028
 msgid "Edit server list"
 msgstr "Upravit seznam serverů"
 
-#: src/PrefsUnifiedDlg.cpp:1949
+#: src/PrefsUnifiedDlg.cpp:2029
 msgid ""
 "Add here URL's to download server.met files.\n"
 "Only one url on each line."
@@ -5977,42 +6019,42 @@ msgstr ""
 "Sem přidejte URL pro stažení server.met souborů.\n"
 "Pouze jedno URL na každý řádek."
 
-#: src/PrefsUnifiedDlg.cpp:2004
+#: src/PrefsUnifiedDlg.cpp:2084
 msgid "IP2Country update failed"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2149 src/PrefsUnifiedDlg.cpp:2180
+#: src/PrefsUnifiedDlg.cpp:2229 src/PrefsUnifiedDlg.cpp:2260
 msgid "Data by MaxMind GeoLite2"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2151 src/PrefsUnifiedDlg.cpp:2182
+#: src/PrefsUnifiedDlg.cpp:2231 src/PrefsUnifiedDlg.cpp:2262
 #, fuzzy
 msgid "Custom source"
 msgstr "Kompletní zdroje"
 
-#: src/PrefsUnifiedDlg.cpp:2153 src/PrefsUnifiedDlg.cpp:2184
+#: src/PrefsUnifiedDlg.cpp:2233 src/PrefsUnifiedDlg.cpp:2264
 msgid "Data by DB-IP.com"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2204
+#: src/PrefsUnifiedDlg.cpp:2284
 #, fuzzy, c-format
 msgid "Status: Loaded%s"
 msgstr "Stav:"
 
-#: src/PrefsUnifiedDlg.cpp:2206
+#: src/PrefsUnifiedDlg.cpp:2286
 #, fuzzy, c-format
 msgid "Status: Loaded%s - %s"
 msgstr "Stav:"
 
-#: src/PrefsUnifiedDlg.cpp:2210
+#: src/PrefsUnifiedDlg.cpp:2290
 msgid "Status: Failed to load - click 'Update now' to refresh."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2212
+#: src/PrefsUnifiedDlg.cpp:2292
 msgid "Status: Not found - click 'Update now' to download."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2270 src/PrefsUnifiedDlg.cpp:2294
+#: src/PrefsUnifiedDlg.cpp:2350 src/PrefsUnifiedDlg.cpp:2374
 #, c-format
 msgid "Update delay: %d second"
 msgid_plural "Update delay: %d seconds"
@@ -6020,7 +6062,7 @@ msgstr[0] ""
 msgstr[1] ""
 msgstr[2] ""
 
-#: src/PrefsUnifiedDlg.cpp:2278
+#: src/PrefsUnifiedDlg.cpp:2358
 #, fuzzy, c-format
 msgid "Time for average graph: %d minute"
 msgid_plural "Time for average graph: %d minutes"
@@ -6028,12 +6070,12 @@ msgstr[0] "Čas pro průměrný graf: %d minut"
 msgstr[1] "Čas pro průměrný graf: %d minut"
 msgstr[2] ""
 
-#: src/PrefsUnifiedDlg.cpp:2287
+#: src/PrefsUnifiedDlg.cpp:2367
 #, c-format
 msgid "Connections Graph Scale: %d"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2302
+#: src/PrefsUnifiedDlg.cpp:2382
 #, fuzzy, c-format
 msgid "File Buffer Size: %d byte"
 msgid_plural "File Buffer Size: %d bytes"
@@ -6041,7 +6083,7 @@ msgstr[0] "Velikost zásobníku pro soubory: %d bajtů"
 msgstr[1] "Velikost zásobníku pro soubory: %d bajtů"
 msgstr[2] ""
 
-#: src/PrefsUnifiedDlg.cpp:2312
+#: src/PrefsUnifiedDlg.cpp:2392
 #, fuzzy, c-format
 msgid "Upload Queue Size: %d client"
 msgid_plural "Upload Queue Size: %d clients"
@@ -6049,7 +6091,7 @@ msgstr[0] "Velikost fronty pro odesílání: %d klientů"
 msgstr[1] "Velikost fronty pro odesílání: %d klientů"
 msgstr[2] ""
 
-#: src/PrefsUnifiedDlg.cpp:2322
+#: src/PrefsUnifiedDlg.cpp:2402
 #, fuzzy, c-format
 msgid "Server connection refresh interval: %d minute"
 msgid_plural "Server connection refresh interval: %d minutes"
@@ -6057,79 +6099,79 @@ msgstr[0] "Interval pro obnovení připojení k serveru: %d minut"
 msgstr[1] "Interval pro obnovení připojení k serveru: %d minut"
 msgstr[2] ""
 
-#: src/PrefsUnifiedDlg.cpp:2327
+#: src/PrefsUnifiedDlg.cpp:2407
 msgid "Server connection refresh interval: Disabled"
 msgstr "Interval pro obnovení připojení k serveru: Zakázáno"
 
-#: src/PrefsUnifiedDlg.cpp:2371
+#: src/PrefsUnifiedDlg.cpp:2451
 msgid "disabled"
 msgstr "zakázáno"
 
-#: src/PrefsUnifiedDlg.cpp:2397
+#: src/PrefsUnifiedDlg.cpp:2477
 #, fuzzy, c-format
 msgid "Execute command on '%s' event"
 msgstr "Spustí příkaz při událost `%s'"
 
-#: src/PrefsUnifiedDlg.cpp:2404
+#: src/PrefsUnifiedDlg.cpp:2484
 msgid "Enable command execution on core"
 msgstr "Povolit jaderné příkazy"
 
-#: src/PrefsUnifiedDlg.cpp:2416
+#: src/PrefsUnifiedDlg.cpp:2496
 msgid "Core command:"
 msgstr "Příkaz jádra:"
 
-#: src/PrefsUnifiedDlg.cpp:2432
+#: src/PrefsUnifiedDlg.cpp:2512
 msgid "Enable command execution on GUI"
 msgstr "Povolit GUI příkazy"
 
-#: src/PrefsUnifiedDlg.cpp:2444
+#: src/PrefsUnifiedDlg.cpp:2524
 msgid "GUI command:"
 msgstr "Příkaz GUI:"
 
-#: src/PrefsUnifiedDlg.cpp:2460
+#: src/PrefsUnifiedDlg.cpp:2540
 msgid "The following variables will be replaced:"
 msgstr "Následující proměnné budou nahrazeny:"
 
-#: src/PrefsUnifiedDlg.cpp:2628
+#: src/PrefsUnifiedDlg.cpp:2708
 msgid ""
 "The following folders look like system or sensitive locations:\n"
 "\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2633
+#: src/PrefsUnifiedDlg.cpp:2713
 msgid "Sharing them recursively will publish every file underneath on the eD2k/Kad networks. Do you really want to do this?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2636
+#: src/PrefsUnifiedDlg.cpp:2716
 #, fuzzy
 msgid "Confirm shared folders"
 msgstr "Sdílené adresáře"
 
-#: src/PrefsUnifiedDlg.cpp:2664
+#: src/PrefsUnifiedDlg.cpp:2744
 #, fuzzy
 msgid "Reloading shared files..."
 msgstr "Znovu načíst vaše sdílené soubory"
 
-#: src/PrefsUnifiedDlg.cpp:2665
+#: src/PrefsUnifiedDlg.cpp:2745
 msgid "Scanning for subdirectories..."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2666
+#: src/PrefsUnifiedDlg.cpp:2746
 #, fuzzy
 msgid "Updating shared folders"
 msgstr "Sdílené adresáře"
 
-#: src/PrefsUnifiedDlg.cpp:2693
+#: src/PrefsUnifiedDlg.cpp:2773
 #, c-format
 msgid "Scanned %u directories..."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2743
+#: src/PrefsUnifiedDlg.cpp:2823
 #, fuzzy, c-format
 msgid "Reloading shared files: %u files scanned"
 msgstr "Znovu načte seznam sdílených souborů."
 
-#: src/PrefsUnifiedDlg.cpp:2793
+#: src/PrefsUnifiedDlg.cpp:2873
 #, fuzzy
 msgid "Shared folder"
 msgstr "Sdílené adresáře"

--- a/po/cs.po
+++ b/po/cs.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-28 12:17+0200\n"
+"POT-Creation-Date: 2026-07-28 13:09+0200\n"
 "PO-Revision-Date: 2026-07-27 11:34+0000\n"
 "Last-Translator: David Watzke <david@watzke.cz>\n"
 "Language-Team: cs <cs@li.org>\n"
@@ -290,7 +290,7 @@ msgid "Password set and external connections enabled."
 msgstr "Heslo nastaveno a externí připojení povoleno."
 
 #: src/amule.cpp:755 src/KadDlg.cpp:176 src/KadDlg.cpp:185
-#: src/PrefsUnifiedDlg.cpp:1461 src/SharedFilesCtrl.cpp:476
+#: src/PrefsUnifiedDlg.cpp:1470 src/SharedFilesCtrl.cpp:476
 msgid "WARNING"
 msgstr "VAROVÁNÍ"
 
@@ -326,7 +326,7 @@ msgstr ""
 #: src/amule-remote-gui.cpp:603 src/amule-remote-gui.cpp:671
 #: src/amule-remote-gui.cpp:709 src/amule-remote-gui.cpp:1282
 #: src/amule-remote-gui.cpp:1345 src/amule-remote-gui.cpp:1372
-#: src/DownloadQueue.cpp:1481 src/PrefsUnifiedDlg.cpp:1247
+#: src/DownloadQueue.cpp:1481 src/PrefsUnifiedDlg.cpp:1256
 msgid "ERROR"
 msgstr "CHYBA"
 
@@ -585,36 +585,36 @@ msgstr "Navštivte https://github.com/amule-org/amule/releases/latest  pro kontr
 msgid "FATAL ERROR: Failed to create Timer"
 msgstr "KRITICKÁ CHYBA: Vytváření časovače selhalo"
 
-#: src/amuleDlg.cpp:361 src/amuleDlg.cpp:1787 src/amuleDlg.cpp:2033
-#: src/muuli_wdr.cpp:1492 src/muuli_wdr.cpp:3449
+#: src/amuleDlg.cpp:361 src/amuleDlg.cpp:1810 src/amuleDlg.cpp:2056
+#: src/muuli_wdr.cpp:1492 src/muuli_wdr.cpp:3453
 msgid "Networks"
 msgstr "Sítě"
 
-#: src/amuleDlg.cpp:362 src/amuleDlg.cpp:1793 src/muuli_wdr.cpp:3450
+#: src/amuleDlg.cpp:362 src/amuleDlg.cpp:1816 src/muuli_wdr.cpp:3454
 msgid "Searches"
 msgstr "Vyhledávání"
 
-#: src/amuleDlg.cpp:363 src/amuleDlg.cpp:1799 src/DownloadListCtrl.cpp:740
-#: src/muuli_wdr.cpp:392 src/muuli_wdr.cpp:1585 src/muuli_wdr.cpp:3451
+#: src/amuleDlg.cpp:363 src/amuleDlg.cpp:1822 src/DownloadListCtrl.cpp:740
+#: src/muuli_wdr.cpp:392 src/muuli_wdr.cpp:1585 src/muuli_wdr.cpp:3455
 #: src/Statistics.cpp:829
 msgid "Downloads"
 msgstr "Stahování"
 
-#: src/amuleDlg.cpp:364 src/amuleDlg.cpp:1805 src/muuli_wdr.cpp:3325
+#: src/amuleDlg.cpp:364 src/amuleDlg.cpp:1828 src/muuli_wdr.cpp:3329
 msgid "Shared files"
 msgstr "Sdílené soubory"
 
-#: src/amuleDlg.cpp:365 src/amuleDlg.cpp:1811 src/muuli_wdr.cpp:2957
-#: src/muuli_wdr.cpp:3407 src/muuli_wdr.cpp:3454
+#: src/amuleDlg.cpp:365 src/amuleDlg.cpp:1834 src/muuli_wdr.cpp:2961
+#: src/muuli_wdr.cpp:3411 src/muuli_wdr.cpp:3458
 msgid "Messages"
 msgstr "Zprávy"
 
-#: src/amuleDlg.cpp:366 src/amuleDlg.cpp:1817 src/muuli_wdr.cpp:3455
+#: src/amuleDlg.cpp:366 src/amuleDlg.cpp:1840 src/muuli_wdr.cpp:3459
 #: src/PrefsUnifiedDlg.cpp:314 src/Statistics.cpp:779 src/Statistics.cpp:1235
 msgid "Statistics"
 msgstr "Statistiky"
 
-#: src/amuleDlg.cpp:368 src/amuleDlg.cpp:1824 src/muuli_wdr.cpp:3457
+#: src/amuleDlg.cpp:368 src/amuleDlg.cpp:1847 src/muuli_wdr.cpp:3461
 #: src/PrefsUnifiedDlg.cpp:330 src/utils/wxCas/src/wxcasprefs.cpp:39
 msgid "Preferences"
 msgstr "Nastavení"
@@ -673,8 +673,8 @@ msgstr "Kad: vypnut"
 #: src/amuleDlg.cpp:1029 src/DownloadListCtrl.cpp:505
 #: src/DownloadListCtrl.cpp:749 src/FriendListCtrl.cpp:180
 #: src/muuli_wdr.cpp:731 src/muuli_wdr.cpp:782 src/muuli_wdr.cpp:846
-#: src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2262 src/muuli_wdr.cpp:2347
-#: src/muuli_wdr.cpp:3095 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
+#: src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2266 src/muuli_wdr.cpp:2351
+#: src/muuli_wdr.cpp:3099 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
 #: src/ServerListCtrl.cpp:606 src/TransferWnd.cpp:378
 #: src/utils/wxCas/src/wxcasprefs.cpp:235
 msgid "Cancel"
@@ -685,7 +685,7 @@ msgid "Stop the current connection attempts"
 msgstr "Zastaví aktuální pokusy o připojení"
 
 #: src/amuleDlg.cpp:1035 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976
-#: src/muuli_wdr.cpp:2485
+#: src/muuli_wdr.cpp:2489
 msgid "Disconnect"
 msgstr "Odpojit"
 
@@ -694,7 +694,7 @@ msgid "Disconnect from the currently connected networks"
 msgstr "Odpojit se od aktuálně připojených sítí"
 
 #: src/amuleDlg.cpp:1041 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979
-#: src/muuli_wdr.cpp:2640 src/muuli_wdr.cpp:3092 src/muuli_wdr.cpp:3447
+#: src/muuli_wdr.cpp:2644 src/muuli_wdr.cpp:3096 src/muuli_wdr.cpp:3451
 msgid "Connect"
 msgstr "Připojit"
 
@@ -749,7 +749,7 @@ msgstr "Potvrzení ukončení"
 msgid "Launch Command: "
 msgstr "Spustit příkaz: "
 
-#: src/amuleDlg.cpp:1632 src/muuli_wdr.cpp:1982 src/Preferences.cpp:979
+#: src/amuleDlg.cpp:1632 src/muuli_wdr.cpp:1986 src/Preferences.cpp:979
 msgid "- default -"
 msgstr "- výchozí -"
 
@@ -763,60 +763,60 @@ msgstr "Adresář se skiny '%s' neexistuje"
 msgid "WARNING: Unable to open skin file '%s' for read"
 msgstr "VAROVÁNÍ: Nelze otevřít soubor se vzhledem '%s' pro čtení"
 
-#: src/amuleDlg.cpp:1791 src/muuli_wdr.cpp:3449
+#: src/amuleDlg.cpp:1814 src/muuli_wdr.cpp:3453
 msgid "Networks Window"
 msgstr "Okno sítí"
 
-#: src/amuleDlg.cpp:1797 src/muuli_wdr.cpp:3450
+#: src/amuleDlg.cpp:1820 src/muuli_wdr.cpp:3454
 msgid "Searches Window"
 msgstr "Vyhledávací okno"
 
-#: src/amuleDlg.cpp:1803 src/muuli_wdr.cpp:3451
+#: src/amuleDlg.cpp:1826 src/muuli_wdr.cpp:3455
 msgid "Downloads Window"
 msgstr "Stahování"
 
-#: src/amuleDlg.cpp:1809 src/muuli_wdr.cpp:3453
+#: src/amuleDlg.cpp:1832 src/muuli_wdr.cpp:3457
 msgid "Shared Files Window"
 msgstr "Okno se sdílenými soubory"
 
-#: src/amuleDlg.cpp:1815 src/muuli_wdr.cpp:3454
+#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3458
 msgid "Messages Window"
 msgstr "Okno zpráv"
 
-#: src/amuleDlg.cpp:1821 src/muuli_wdr.cpp:3455
+#: src/amuleDlg.cpp:1844 src/muuli_wdr.cpp:3459
 msgid "Statistics Graph Window"
 msgstr "Okno se statistikami"
 
-#: src/amuleDlg.cpp:1828 src/muuli_wdr.cpp:3457
+#: src/amuleDlg.cpp:1851 src/muuli_wdr.cpp:3461
 msgid "Preferences Settings Window"
 msgstr "Okno s nastavením"
 
-#: src/amuleDlg.cpp:1831 src/muuli_wdr.cpp:3458
+#: src/amuleDlg.cpp:1854 src/muuli_wdr.cpp:3462
 msgid "Import"
 msgstr "Import"
 
-#: src/amuleDlg.cpp:1835 src/muuli_wdr.cpp:3458
+#: src/amuleDlg.cpp:1858 src/muuli_wdr.cpp:3462
 msgid "The partfile importer tool"
 msgstr "Nástroj pro import částečných souborů"
 
-#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3459
+#: src/amuleDlg.cpp:1861 src/muuli_wdr.cpp:3463
 #: src/utils/aLinkCreator/src/alcframe.cpp:262
 msgid "About"
 msgstr "O programu"
 
-#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3459
+#: src/amuleDlg.cpp:1861 src/muuli_wdr.cpp:3463
 msgid "About/Help"
 msgstr "O programu/Nápověda"
 
-#: src/amuleDlg.cpp:2036
+#: src/amuleDlg.cpp:2059
 msgid "eD2k network"
 msgstr "Síť eD2k"
 
-#: src/amuleDlg.cpp:2039
+#: src/amuleDlg.cpp:2062
 msgid "Kad network"
 msgstr "Síť Kad"
 
-#: src/amuleDlg.cpp:2039
+#: src/amuleDlg.cpp:2062
 msgid "No network"
 msgstr "Žádná síť"
 
@@ -1354,19 +1354,19 @@ msgstr "Auto [Vy]"
 msgid "Very low"
 msgstr "Velmi nízká"
 
-#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:743 src/muuli_wdr.cpp:2313
+#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:743 src/muuli_wdr.cpp:2317
 #: src/ServerListCtrl.cpp:263 src/ServerListCtrl.cpp:456
 #: src/SharedFilesCtrl.cpp:145
 msgid "Low"
 msgstr "Nízká"
 
-#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:744 src/muuli_wdr.cpp:2314
+#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:744 src/muuli_wdr.cpp:2318
 #: src/ServerListCtrl.cpp:266 src/ServerListCtrl.cpp:457
 #: src/SharedFilesCtrl.cpp:146
 msgid "Normal"
 msgstr "Normální"
 
-#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:745 src/muuli_wdr.cpp:2315
+#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:745 src/muuli_wdr.cpp:2319
 #: src/ServerListCtrl.cpp:269 src/ServerListCtrl.cpp:458
 #: src/SharedFilesCtrl.cpp:147
 msgid "High"
@@ -1458,7 +1458,7 @@ msgstr "Lokální server"
 msgid "Remote Server"
 msgstr "Vzdálený server"
 
-#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3212
+#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3216
 #: src/SearchDlg.cpp:119 src/TextClient.cpp:911
 msgid "Kad"
 msgstr "Kad"
@@ -1530,7 +1530,7 @@ msgstr "Část"
 msgid "Size"
 msgstr "Velikost"
 
-#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3279
+#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3283
 msgid "Transferred"
 msgstr "Přeneseno"
 
@@ -1588,7 +1588,7 @@ msgstr ""
 "Odezva od: %s (%s)\n"
 "\n"
 
-#: src/DownloadListCtrl.cpp:746 src/muuli_wdr.cpp:2316
+#: src/DownloadListCtrl.cpp:746 src/muuli_wdr.cpp:2320
 #: src/SharedFilesCtrl.cpp:150
 msgid "Auto"
 msgstr "Auto"
@@ -1626,7 +1626,7 @@ msgid "Extended Options"
 msgstr "Rozšířené nastavení"
 
 #: src/DownloadListCtrl.cpp:770 src/DownloadListCtrl.cpp:822
-#: src/muuli_wdr.cpp:1800
+#: src/muuli_wdr.cpp:1804
 msgid "Preview"
 msgstr "Náhled"
 
@@ -2412,23 +2412,23 @@ msgid ""
 "want downloads on a different (e.g. larger) disk."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:549 src/FirstRunWizard.cpp:611 src/muuli_wdr.cpp:1712
+#: src/FirstRunWizard.cpp:549 src/FirstRunWizard.cpp:611 src/muuli_wdr.cpp:1716
 msgid "Destination folder for downloads"
 msgstr "Cílový adresář pro stahování"
 
 #: src/FirstRunWizard.cpp:553 src/FirstRunWizard.cpp:569 src/muuli_wdr.cpp:1349
-#: src/muuli_wdr.cpp:1366 src/muuli_wdr.cpp:1687 src/muuli_wdr.cpp:1718
-#: src/muuli_wdr.cpp:1730 src/muuli_wdr.cpp:2800
+#: src/muuli_wdr.cpp:1366 src/muuli_wdr.cpp:1691 src/muuli_wdr.cpp:1722
+#: src/muuli_wdr.cpp:1734 src/muuli_wdr.cpp:2804
 #: src/utils/aLinkCreator/src/alcframe.cpp:135
 #: src/utils/wxCas/src/wxcasprefs.cpp:52 src/utils/wxCas/src/wxcasprefs.cpp:118
 msgid "Browse"
 msgstr "Procházet"
 
-#: src/FirstRunWizard.cpp:559 src/muuli_wdr.cpp:1723
+#: src/FirstRunWizard.cpp:559 src/muuli_wdr.cpp:1727
 msgid "(All files in this folder are shared with other peers)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:565 src/FirstRunWizard.cpp:624 src/muuli_wdr.cpp:1725
+#: src/FirstRunWizard.cpp:565 src/FirstRunWizard.cpp:624 src/muuli_wdr.cpp:1729
 msgid "Folder for temporary download files"
 msgstr ""
 
@@ -2459,7 +2459,7 @@ msgstr ""
 msgid "CRITICAL - no client on StartChatSession"
 msgstr ""
 
-#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2706 src/muuli_wdr.cpp:3383
+#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2710 src/muuli_wdr.cpp:3387
 msgid "Friends"
 msgstr "Kamarádi"
 
@@ -2570,8 +2570,8 @@ msgstr "Nic"
 msgid "No"
 msgstr "Ne"
 
-#: src/GenericClientListCtrl.cpp:1216 src/PrefsUnifiedDlg.cpp:2898
-#: src/PrefsUnifiedDlg.cpp:2948 src/ServerListCtrl.cpp:276
+#: src/GenericClientListCtrl.cpp:1216 src/PrefsUnifiedDlg.cpp:2907
+#: src/PrefsUnifiedDlg.cpp:2957 src/ServerListCtrl.cpp:276
 msgid "Yes"
 msgstr "Ano"
 
@@ -2743,10 +2743,10 @@ msgstr "Neplatný port pro bootstrap"
 msgid "Please fill all fields required"
 msgstr "Prosím vyplňte všechna potřebná pole"
 
-#: src/KadDlg.cpp:192 src/PartFile.cpp:1031 src/PrefsUnifiedDlg.cpp:1134
-#: src/PrefsUnifiedDlg.cpp:1204 src/PrefsUnifiedDlg.cpp:1405
-#: src/PrefsUnifiedDlg.cpp:1663 src/PrefsUnifiedDlg.cpp:1673
-#: src/PrefsUnifiedDlg.cpp:1690 src/PrefsUnifiedDlg.cpp:1738
+#: src/KadDlg.cpp:192 src/PartFile.cpp:1031 src/PrefsUnifiedDlg.cpp:1143
+#: src/PrefsUnifiedDlg.cpp:1213 src/PrefsUnifiedDlg.cpp:1414
+#: src/PrefsUnifiedDlg.cpp:1672 src/PrefsUnifiedDlg.cpp:1682
+#: src/PrefsUnifiedDlg.cpp:1699 src/PrefsUnifiedDlg.cpp:1747
 msgid "Message"
 msgstr "Zpráva"
 
@@ -2851,7 +2851,7 @@ msgstr "Poměr sdílení"
 msgid "Uploaded"
 msgstr "Odesláno"
 
-#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3263
+#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3267
 msgid "Requested"
 msgstr "Vyžádáno"
 
@@ -2977,7 +2977,7 @@ msgid "WARNING: "
 msgstr "VAROVÁNÍ: "
 
 #: src/MuleNotebook.cpp:179 src/muuli_wdr.cpp:817 src/muuli_wdr.cpp:1229
-#: src/muuli_wdr.cpp:3167 src/muuli_wdr.cpp:3423
+#: src/muuli_wdr.cpp:3171 src/muuli_wdr.cpp:3427
 msgid "Close"
 msgstr "Zavřít"
 
@@ -2995,7 +2995,7 @@ msgid "Paste"
 msgstr "Vložit"
 
 #: src/MuleTextCtrl.cpp:89 src/muuli_wdr.cpp:358 src/muuli_wdr.cpp:757
-#: src/muuli_wdr.cpp:2390 src/muuli_wdr.cpp:2409 src/muuli_wdr.cpp:2431
+#: src/muuli_wdr.cpp:2394 src/muuli_wdr.cpp:2413 src/muuli_wdr.cpp:2435
 #: src/utils/aLinkCreator/src/alcframe.cpp:142
 msgid "Clear"
 msgstr "Vyprázdnit"
@@ -3094,7 +3094,7 @@ msgstr "Ukončit"
 
 #: src/MuleTrayIcon.cpp:579 src/MuleTrayIcon.cpp:945 src/MuleTrayIcon.cpp:965
 #: src/muuli_wdr.cpp:1398 src/muuli_wdr.cpp:1406 src/muuli_wdr.cpp:1413
-#: src/muuli_wdr.cpp:1846 src/muuli_wdr.cpp:1852 src/OtherFunctions.cpp:91
+#: src/muuli_wdr.cpp:1850 src/muuli_wdr.cpp:1856 src/OtherFunctions.cpp:91
 #: src/StatisticsDlg.cpp:93 src/StatisticsDlg.cpp:95
 msgid "kB/s"
 msgstr "kB/s"
@@ -3336,7 +3336,7 @@ msgstr "bajtů"
 msgid "KB"
 msgstr "KB"
 
-#: src/muuli_wdr.cpp:274 src/muuli_wdr.cpp:293 src/muuli_wdr.cpp:1631
+#: src/muuli_wdr.cpp:274 src/muuli_wdr.cpp:293 src/muuli_wdr.cpp:1635
 #: src/OtherFunctions.cpp:64
 msgid "MB"
 msgstr "MB"
@@ -3353,7 +3353,7 @@ msgstr "Max. velikost"
 msgid "Availability"
 msgstr "Dostupnost"
 
-#: src/muuli_wdr.cpp:312 src/muuli_wdr.cpp:398 src/muuli_wdr.cpp:3328
+#: src/muuli_wdr.cpp:312 src/muuli_wdr.cpp:398 src/muuli_wdr.cpp:3332
 msgid "Filter:"
 msgstr "Filtr:"
 
@@ -3416,8 +3416,8 @@ msgstr "Zdroje souboru:"
 #: src/muuli_wdr.cpp:1160 src/muuli_wdr.cpp:1167 src/muuli_wdr.cpp:1172
 #: src/muuli_wdr.cpp:1179 src/muuli_wdr.cpp:1184 src/muuli_wdr.cpp:1191
 #: src/muuli_wdr.cpp:1205 src/muuli_wdr.cpp:1212 src/muuli_wdr.cpp:1217
-#: src/muuli_wdr.cpp:1224 src/muuli_wdr.cpp:3265 src/muuli_wdr.cpp:3273
-#: src/muuli_wdr.cpp:3281
+#: src/muuli_wdr.cpp:1224 src/muuli_wdr.cpp:3269 src/muuli_wdr.cpp:3277
+#: src/muuli_wdr.cpp:3285
 msgid "N/A"
 msgstr "N/A"
 
@@ -3562,7 +3562,7 @@ msgstr ""
 msgid "Album :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:685 src/muuli_wdr.cpp:2285
+#: src/muuli_wdr.cpp:685 src/muuli_wdr.cpp:2289
 msgid "Title :"
 msgstr "Titulek:"
 
@@ -3669,7 +3669,7 @@ msgstr "Uživatelské jméno:"
 msgid "Userhash :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:895 src/muuli_wdr.cpp:1752 src/muuli_wdr.cpp:2480
+#: src/muuli_wdr.cpp:895 src/muuli_wdr.cpp:1756 src/muuli_wdr.cpp:2484
 #: src/utils/aLinkCreator/src/alcframe.cpp:137
 msgid "Add"
 msgstr "Přidat"
@@ -3678,15 +3678,15 @@ msgstr "Přidat"
 msgid "Download-Speed"
 msgstr "Rychlost stahování"
 
-#: src/muuli_wdr.cpp:954 src/muuli_wdr.cpp:989 src/muuli_wdr.cpp:2584
+#: src/muuli_wdr.cpp:954 src/muuli_wdr.cpp:989 src/muuli_wdr.cpp:2588
 msgid "Current"
 msgstr ""
 
-#: src/muuli_wdr.cpp:962 src/muuli_wdr.cpp:997 src/muuli_wdr.cpp:2592
+#: src/muuli_wdr.cpp:962 src/muuli_wdr.cpp:997 src/muuli_wdr.cpp:2596
 msgid "Running average"
 msgstr ""
 
-#: src/muuli_wdr.cpp:970 src/muuli_wdr.cpp:1005 src/muuli_wdr.cpp:2600
+#: src/muuli_wdr.cpp:970 src/muuli_wdr.cpp:1005 src/muuli_wdr.cpp:2604
 msgid "Session average"
 msgstr "Průměr sezení"
 
@@ -3698,7 +3698,7 @@ msgstr "Rychlost odesílání"
 msgid "Connections"
 msgstr "Připojení"
 
-#: src/muuli_wdr.cpp:1024 src/muuli_wdr.cpp:1871
+#: src/muuli_wdr.cpp:1024 src/muuli_wdr.cpp:1875
 msgid "Active downloads"
 msgstr "Aktivní stahování"
 
@@ -3706,7 +3706,7 @@ msgstr "Aktivní stahování"
 msgid "Active connections (1:1)"
 msgstr "Aktivní připojení (1:1)"
 
-#: src/muuli_wdr.cpp:1040 src/muuli_wdr.cpp:1872
+#: src/muuli_wdr.cpp:1040 src/muuli_wdr.cpp:1876
 msgid "Active uploads"
 msgstr "Aktivní odesílání"
 
@@ -3983,7 +3983,7 @@ msgstr ""
 msgid "Advanced users only: If you have multiple network interfaces, enter the address of the interface to which aMule should be bound."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1462 src/muuli_wdr.cpp:2065
+#: src/muuli_wdr.cpp:1462 src/muuli_wdr.cpp:2069
 msgid "Bind to network interface (empty for any):"
 msgstr ""
 
@@ -3999,7 +3999,7 @@ msgstr "Max. zdrojů na stahovaný soubor:"
 msgid "Max simultaneous connections:"
 msgstr "Maximum připojení naráz:"
 
-#: src/muuli_wdr.cpp:1498 src/muuli_wdr.cpp:3207
+#: src/muuli_wdr.cpp:1498 src/muuli_wdr.cpp:3211
 msgid "ED2K"
 msgstr "ED2K"
 
@@ -4091,779 +4091,779 @@ msgstr "Předalokovat místo na disku pro nové soubory"
 msgid "For new files preallocates disk space for the whole file, thus reduces fragmentation"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1617
+#: src/muuli_wdr.cpp:1621
 msgid "Create new files as sparse files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1618
+#: src/muuli_wdr.cpp:1622
 msgid "Sparse part files only occupy disk space for the parts already downloaded, so free space is used up gradually as the file fills in. Turn this off to use an ordinary file instead - useful where sparse files are unsupported or slow, or where backup/de-duplication tools handle them badly. Applies only when the core runs on Windows; on Linux and macOS part files are sparse anyway and this setting has no effect."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1623
+#: src/muuli_wdr.cpp:1627
 msgid "Stop downloads when free disk space reaches "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1624
+#: src/muuli_wdr.cpp:1628
 msgid "Select this if you want aMule to check your disk space"
 msgstr "Toto zvolte chcete-li, aby aMule kontrolovala místo na disku"
 
-#: src/muuli_wdr.cpp:1628
+#: src/muuli_wdr.cpp:1632
 msgid "Enter here the min disk space desired."
 msgstr "Zadejte minimum místa na disku."
 
-#: src/muuli_wdr.cpp:1634
+#: src/muuli_wdr.cpp:1638
 msgid "Save 10 sources on rare files (< 20 sources)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1638 src/Statistics.cpp:790
+#: src/muuli_wdr.cpp:1642 src/Statistics.cpp:790
 msgid "Uploads"
 msgstr "Odesílání"
 
-#: src/muuli_wdr.cpp:1641
+#: src/muuli_wdr.cpp:1645
 msgid "Add new shared files with auto priority"
 msgstr "Přidat nově sdílené soubory s \"auto\" prioritou"
 
-#: src/muuli_wdr.cpp:1647
+#: src/muuli_wdr.cpp:1651
 msgid "Intelligent Corruption Handling (I.C.H.)"
 msgstr "Inteligentní zpracování poškození (I.C.H.)"
 
-#: src/muuli_wdr.cpp:1650
+#: src/muuli_wdr.cpp:1654
 msgid "Enable"
 msgstr "Povolit"
 
-#: src/muuli_wdr.cpp:1653
+#: src/muuli_wdr.cpp:1657
 msgid "Advanced I.C.H. trusts every hash (not recommended)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1665 src/PrefsUnifiedDlg.cpp:1990
+#: src/muuli_wdr.cpp:1669 src/PrefsUnifiedDlg.cpp:1999
 msgid "Media metadata extraction"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1669
+#: src/muuli_wdr.cpp:1673
 msgid "Extract length / bitrate / codec from shared audio and video files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1671
+#: src/muuli_wdr.cpp:1675
 msgid "When enabled, aMule runs ffprobe on each shared media file to fill in the Length / Bitrate / Codec columns other clients see when they find the file in a search. Requires ffmpeg (the ffprobe binary) to be installed."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1678
+#: src/muuli_wdr.cpp:1682
 msgid "Path to ffprobe:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1683
+#: src/muuli_wdr.cpp:1687
 msgid "Full path to the ffprobe binary. Leave empty to have aMule auto-detect it on startup."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1691
+#: src/muuli_wdr.cpp:1695
 msgid "Detect"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1692
+#: src/muuli_wdr.cpp:1696
 msgid "Search the standard install locations for an ffprobe binary and fill the path field."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1716
+#: src/muuli_wdr.cpp:1720
 msgid ""
 "Completed downloads are stored here. All files in this folder are automatically shared with other peers.\n"
 "If this folder also holds files you don't want to share, point it at an aMule-only sub-folder."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1719
+#: src/muuli_wdr.cpp:1723
 msgid "Pick the folder where completed downloads will be stored. All files in that folder will be shared with other peers."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1733
+#: src/muuli_wdr.cpp:1737
 msgid "Shared folders"
 msgstr "Sdílené adresáře"
 
-#: src/muuli_wdr.cpp:1739
+#: src/muuli_wdr.cpp:1743
 msgid "(Folders shared by the core. Enter a path to add one.)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1747
+#: src/muuli_wdr.cpp:1751
 msgid "Absolute path of a folder on the core's machine, e.g. /home/user/shared"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1749 src/PrefsUnifiedDlg.cpp:2874
+#: src/muuli_wdr.cpp:1753 src/PrefsUnifiedDlg.cpp:2883
 msgid "Recursive"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1750
+#: src/muuli_wdr.cpp:1754
 msgid "Share every sub-folder underneath this one, including ones created later."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1754 src/utils/aLinkCreator/src/alcframe.cpp:141
+#: src/muuli_wdr.cpp:1758 src/utils/aLinkCreator/src/alcframe.cpp:141
 msgid "Remove"
 msgstr "Odebrat"
 
-#: src/muuli_wdr.cpp:1758
+#: src/muuli_wdr.cpp:1762
 msgid "(Right click on folder icon for recursive share)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1765
+#: src/muuli_wdr.cpp:1769
 msgid "Share hidden files"
 msgstr "Sdílet skryté soubory"
 
-#: src/muuli_wdr.cpp:1771
+#: src/muuli_wdr.cpp:1775
 msgid "Automatically rescan shared folders for changes"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1777
+#: src/muuli_wdr.cpp:1781
 msgid "Follow symbolic links in shared folders"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1783
+#: src/muuli_wdr.cpp:1787
 msgid "Exclude files matching:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1786
+#: src/muuli_wdr.cpp:1790
 msgid "Wildcard patterns separated by '|', e.g. .DS_Store|Thumbs.db|*.tmp. Files whose name matches are not shared. Matching is case-insensitive."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1790
+#: src/muuli_wdr.cpp:1794
 msgid "Patterns are regular expressions"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1791
+#: src/muuli_wdr.cpp:1795
 msgid "When set, the whole field is one regular expression ('|' is alternation). When unset, it is a list of '|'-separated wildcards."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1801
+#: src/muuli_wdr.cpp:1805
 msgid "Show how many shared files the current pattern would exclude."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1822
+#: src/muuli_wdr.cpp:1826
 msgid "Graphs"
 msgstr "Grafy"
 
-#: src/muuli_wdr.cpp:1825 src/muuli_wdr.cpp:1887
+#: src/muuli_wdr.cpp:1829 src/muuli_wdr.cpp:1891
 msgid "Update delay : 5 secs"
 msgstr "Prodleva aktualizace: 5 sekund"
 
-#: src/muuli_wdr.cpp:1829
+#: src/muuli_wdr.cpp:1833
 msgid "Time for average graph: 100 mins"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1833
+#: src/muuli_wdr.cpp:1837
 msgid "Connections Graph Scale: 100 "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1840
+#: src/muuli_wdr.cpp:1844
 msgid "Download graph scale:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1848
+#: src/muuli_wdr.cpp:1852
 msgid "Upload graph scale:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1858
+#: src/muuli_wdr.cpp:1862
 #, fuzzy
 msgid "Colors: "
 msgstr "Barvy: "
 
-#: src/muuli_wdr.cpp:1862
+#: src/muuli_wdr.cpp:1866
 msgid "Background"
 msgstr "Na pozadí"
 
-#: src/muuli_wdr.cpp:1863
+#: src/muuli_wdr.cpp:1867
 msgid "Grid"
 msgstr "Mřížka"
 
-#: src/muuli_wdr.cpp:1864
+#: src/muuli_wdr.cpp:1868
 msgid "Download current"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1865
+#: src/muuli_wdr.cpp:1869
 msgid "Download running average"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1866
+#: src/muuli_wdr.cpp:1870
 msgid "Download session average"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1867
+#: src/muuli_wdr.cpp:1871
 msgid "Upload current"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1868
+#: src/muuli_wdr.cpp:1872
 msgid "Upload running average"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1869
+#: src/muuli_wdr.cpp:1873
 msgid "Upload session average"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1870
+#: src/muuli_wdr.cpp:1874
 msgid "Active connections"
 msgstr "Aktivní připojení"
 
-#: src/muuli_wdr.cpp:1873
+#: src/muuli_wdr.cpp:1877
 #, fuzzy
 msgid "Systray Icon Speed Bar"
 msgstr "Ukazatel rychlosti v tray ikoně"
 
-#: src/muuli_wdr.cpp:1874
+#: src/muuli_wdr.cpp:1878
 msgid "Kad-nodes current"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1875
+#: src/muuli_wdr.cpp:1879
 msgid "Kad-nodes running"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1876
+#: src/muuli_wdr.cpp:1880
 msgid "Kad-nodes session"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1880 src/muuli_wdr.cpp:2334
+#: src/muuli_wdr.cpp:1884 src/muuli_wdr.cpp:2338
 msgid "Select"
 msgstr "Vyberte"
 
-#: src/muuli_wdr.cpp:1884
+#: src/muuli_wdr.cpp:1888
 msgid "Tree"
 msgstr "Strom"
 
-#: src/muuli_wdr.cpp:1894
+#: src/muuli_wdr.cpp:1898
 msgid "Number of Client Versions shown (0=unlimited)"
 msgstr "Počet verzí klientů k zobrazení (0=neomezeně)"
 
-#: src/muuli_wdr.cpp:1919
+#: src/muuli_wdr.cpp:1923
 msgid "!!! WARNING !!!"
 msgstr "!!! VAROVÁNÍ !!!"
 
-#: src/muuli_wdr.cpp:1934
+#: src/muuli_wdr.cpp:1938
 msgid "Max new connections / 5 secs"
 msgstr "Max. nových připojení za 5 sek."
 
-#: src/muuli_wdr.cpp:1936
+#: src/muuli_wdr.cpp:1940
 msgid "Concurrent Kad source lookups"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1938
+#: src/muuli_wdr.cpp:1942
 #, fuzzy
 msgid "Kad source re-search interval (minutes)"
 msgstr "Interval aktualizace FTP v minutách"
 
-#: src/muuli_wdr.cpp:1940
+#: src/muuli_wdr.cpp:1944
 #, fuzzy
 msgid "Source re-ask interval (minutes)"
 msgstr "Interval aktualizace FTP v minutách"
 
-#: src/muuli_wdr.cpp:1944
+#: src/muuli_wdr.cpp:1948
 msgid "File Buffer Size: 240000 bytes"
 msgstr "Velikost zásobníku pro soubory: 240000 bytů"
 
-#: src/muuli_wdr.cpp:1948
+#: src/muuli_wdr.cpp:1952
 msgid "Use MMAP: memory-mapped file access (lower memory use)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1949
+#: src/muuli_wdr.cpp:1953
 msgid "Maps part files into memory instead of buffering them on the heap, lowering the process memory footprint. May reduce download speed on some disks; best for memory-constrained or upload-heavy hosts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1951
+#: src/muuli_wdr.cpp:1955
 msgid "Upload Queue Size: 5000 clients"
 msgstr "Velikost fronty odesílání: 5000 klientů"
 
-#: src/muuli_wdr.cpp:1955
+#: src/muuli_wdr.cpp:1959
 msgid "Server connection refresh interval: Disable"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1959
+#: src/muuli_wdr.cpp:1963
 msgid "Disable computer's timed standby mode"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1978
+#: src/muuli_wdr.cpp:1982
 msgid "Skin to use: "
 msgstr "Vzhled: "
 
-#: src/muuli_wdr.cpp:1987
+#: src/muuli_wdr.cpp:1991
 msgid "Show \"Fast eD2k Links Handler\" in every window."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1990
+#: src/muuli_wdr.cpp:1994
 msgid "Show extended info on categories tabs"
 msgstr "Zobrazit rozšířené informace na tabech kategorií"
 
-#: src/muuli_wdr.cpp:1993
+#: src/muuli_wdr.cpp:1997
 #, fuzzy
 msgid "Show application version on title"
 msgstr "Zobrazit rychlosti přenosu v titulku okna"
 
-#: src/muuli_wdr.cpp:1995
+#: src/muuli_wdr.cpp:1999
 msgid "Show transfer rates on title"
 msgstr "Zobrazit rychlosti přenosu v titulku okna"
 
-#: src/muuli_wdr.cpp:1997
+#: src/muuli_wdr.cpp:2001
 msgid "Before application name"
 msgstr "Před názvem programu"
 
-#: src/muuli_wdr.cpp:1999
+#: src/muuli_wdr.cpp:2003
 msgid "After application name"
 msgstr "Za názvem programu"
 
-#: src/muuli_wdr.cpp:2002
+#: src/muuli_wdr.cpp:2006
 msgid "Show overhead bandwidth"
 msgstr "Zobrazit šířku pásma režie"
 
-#: src/muuli_wdr.cpp:2006
+#: src/muuli_wdr.cpp:2010
 msgid "Vertical toolbar orientation"
 msgstr "Vertikální umístění nástrojové lišty"
 
-#: src/muuli_wdr.cpp:2008
+#: src/muuli_wdr.cpp:2012
 msgid "Live column sorting (auto-reorder rows as their values change)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2015
+#: src/muuli_wdr.cpp:2019
 msgid "Download Queue Files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2018
+#: src/muuli_wdr.cpp:2022
 msgid "Show progress percentage"
 msgstr "Zobrazit procenta průběhu"
 
-#: src/muuli_wdr.cpp:2024
+#: src/muuli_wdr.cpp:2028
 msgid "Show progress bar"
 msgstr "Zobrazit ukazatel průběhu"
 
-#: src/muuli_wdr.cpp:2027
+#: src/muuli_wdr.cpp:2031
 msgid "Flat"
 msgstr "Plochý"
 
-#: src/muuli_wdr.cpp:2031
+#: src/muuli_wdr.cpp:2035
 msgid "Round"
 msgstr "Kulatý"
 
-#: src/muuli_wdr.cpp:2049
+#: src/muuli_wdr.cpp:2053
 msgid "External Connection Parameters"
 msgstr "Nastavení externího připojení"
 
-#: src/muuli_wdr.cpp:2052
+#: src/muuli_wdr.cpp:2056
 msgid "Accept external connections"
 msgstr "Přijímat externí připojení"
 
-#: src/muuli_wdr.cpp:2059 src/muuli_wdr.cpp:2118
+#: src/muuli_wdr.cpp:2063 src/muuli_wdr.cpp:2122
 msgid "IP of the listening interface:"
 msgstr "IP naslouchajícího zařízení:"
 
-#: src/muuli_wdr.cpp:2062
+#: src/muuli_wdr.cpp:2066
 msgid "Enter here a valid ip in the a.b.c.d format for the listening EC interface. An empty field or 0.0.0.0 will mean any interface."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2083 src/muuli_wdr.cpp:2194
+#: src/muuli_wdr.cpp:2087 src/muuli_wdr.cpp:2198
 msgid "TCP port:"
 msgstr "TCP port:"
 
-#: src/muuli_wdr.cpp:2089
+#: src/muuli_wdr.cpp:2093
 msgid "Enable UPnP port forwarding on the EC port"
 msgstr "Povolit UPnP port forwarding na EC portu"
 
-#: src/muuli_wdr.cpp:2093 src/muuli_wdr.cpp:3079
+#: src/muuli_wdr.cpp:2097 src/muuli_wdr.cpp:3083
 #: src/utils/wxCas/src/wxcasprefs.cpp:167
 msgid "Password"
 msgstr "Heslo"
 
-#: src/muuli_wdr.cpp:2099
+#: src/muuli_wdr.cpp:2103
 #, fuzzy
 msgid "aMule API server parameters"
 msgstr "Parametry webserveru"
 
-#: src/muuli_wdr.cpp:2102
+#: src/muuli_wdr.cpp:2106
 msgid "Run amuleapi (REST API) on startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2107
+#: src/muuli_wdr.cpp:2111
 #, fuzzy
 msgid "HTTP port:"
 msgstr "TCP port:"
 
-#: src/muuli_wdr.cpp:2121
+#: src/muuli_wdr.cpp:2125
 msgid "The interface amuleapi's HTTP server listens on. 127.0.0.1 (default) accepts only local connections; use 0.0.0.0 or a specific IP to expose it to other hosts (set an admin password below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2126
+#: src/muuli_wdr.cpp:2130
 msgid "Type a password to set or change it. Stored passwords cannot be shown, so leaving this empty keeps the current one."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2128
+#: src/muuli_wdr.cpp:2132
 #, fuzzy
 msgid "Admin password"
 msgstr "Kontrola hesla\n"
 
-#: src/muuli_wdr.cpp:2140 src/muuli_wdr.cpp:2157 src/PrefsUnifiedDlg.cpp:1103
+#: src/muuli_wdr.cpp:2144 src/muuli_wdr.cpp:2161 src/PrefsUnifiedDlg.cpp:1112
 #, fuzzy
 msgid "A password is set."
 msgstr "Kontrola hesla\n"
 
-#: src/muuli_wdr.cpp:2144
+#: src/muuli_wdr.cpp:2148
 #, fuzzy
 msgid "Enable guest access"
 msgstr "Zakázat přístup hostům"
 
-#: src/muuli_wdr.cpp:2145
+#: src/muuli_wdr.cpp:2149
 msgid "Guest sessions may read status and listings but cannot change anything. Turning this off clears the stored guest password."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2149
+#: src/muuli_wdr.cpp:2153
 #, fuzzy
 msgid "Guest password"
 msgstr "Heslo pro omezený přístup k webserveru"
 
-#: src/muuli_wdr.cpp:2164
+#: src/muuli_wdr.cpp:2168
 msgid "Web server parameters"
 msgstr "Parametry webserveru"
 
-#: src/muuli_wdr.cpp:2167
+#: src/muuli_wdr.cpp:2171
 #, fuzzy
 msgid "Run webserver on startup (deprecated)"
 msgstr "Spustit webserver při spuštění aMule"
 
-#: src/muuli_wdr.cpp:2173
+#: src/muuli_wdr.cpp:2177
 msgid "Web template"
 msgstr "Šablona webu"
 
-#: src/muuli_wdr.cpp:2178
+#: src/muuli_wdr.cpp:2182
 msgid "Full rights password"
 msgstr "Heslo pro plná práva"
 
-#: src/muuli_wdr.cpp:2182
+#: src/muuli_wdr.cpp:2186
 msgid "Enable Low rights User"
 msgstr "Povolit uživatele s omezenými právy"
 
-#: src/muuli_wdr.cpp:2187
+#: src/muuli_wdr.cpp:2191
 msgid "Low rights password"
 msgstr "Heslo pro omezená práva"
 
-#: src/muuli_wdr.cpp:2201
+#: src/muuli_wdr.cpp:2205
 msgid "Enable UPnP port forwarding of the web server port"
 msgstr "Povolit UPnP port forwarding portu webserveru"
 
-#: src/muuli_wdr.cpp:2206
+#: src/muuli_wdr.cpp:2210
 msgid "Web server UPnP TCP port (Optional)"
 msgstr "UPnP TCP port webserveru (volitelné)"
 
-#: src/muuli_wdr.cpp:2214
+#: src/muuli_wdr.cpp:2218
 msgid "Page Refresh Time (in secs)"
 msgstr "Obnovování stránky (v sek.)"
 
-#: src/muuli_wdr.cpp:2221
+#: src/muuli_wdr.cpp:2225
 msgid "Enable Gzip compression"
 msgstr "Povoliz Gzip kompresi"
 
-#: src/muuli_wdr.cpp:2255
+#: src/muuli_wdr.cpp:2259
 #, fuzzy
 msgid "Reset page to defaults"
 msgstr "Výchozí pro systém"
 
-#: src/muuli_wdr.cpp:2256
+#: src/muuli_wdr.cpp:2260
 msgid "Reset the settings on the current page to their default values."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2258 src/muuli_wdr.cpp:2344 src/ServerWnd.cpp:274
+#: src/muuli_wdr.cpp:2262 src/muuli_wdr.cpp:2348 src/ServerWnd.cpp:274
 #: src/ServerWnd.cpp:282
 msgid "OK"
 msgstr "Budiž"
 
-#: src/muuli_wdr.cpp:2260
+#: src/muuli_wdr.cpp:2264
 msgid "Click here to apply any changes made to the preferences."
 msgstr "Klikněte zde pro aplikování změn nastavení."
 
-#: src/muuli_wdr.cpp:2263
+#: src/muuli_wdr.cpp:2267
 msgid "Reset any changes made to the preferences."
 msgstr "Zahodí všechny změny v nastavení."
 
-#: src/muuli_wdr.cpp:2292
+#: src/muuli_wdr.cpp:2296
 msgid "Comment :"
 msgstr "Komentář:"
 
-#: src/muuli_wdr.cpp:2299
+#: src/muuli_wdr.cpp:2303
 msgid "Incoming Dir :"
 msgstr "Příchozí adresář:"
 
-#: src/muuli_wdr.cpp:2308
+#: src/muuli_wdr.cpp:2312
 msgid "Change priority for new assigned files :"
 msgstr "Změnit prioritu pro nově přiřazené soubory:"
 
-#: src/muuli_wdr.cpp:2312
+#: src/muuli_wdr.cpp:2316
 #, fuzzy
 msgid "Don't change"
 msgstr "Neměnit"
 
-#: src/muuli_wdr.cpp:2324
+#: src/muuli_wdr.cpp:2328
 msgid "Select color for this Category (currently selected) :"
 msgstr "Barva pro tuto kategorii:"
 
-#: src/muuli_wdr.cpp:2391 src/muuli_wdr.cpp:2410 src/muuli_wdr.cpp:2432
+#: src/muuli_wdr.cpp:2395 src/muuli_wdr.cpp:2414 src/muuli_wdr.cpp:2436
 msgid "Click this button to reset the log."
 msgstr "Klikněte na toto tlačítko pro vynulování logu."
 
-#: src/muuli_wdr.cpp:2451
+#: src/muuli_wdr.cpp:2455
 msgid "Click on this button to update the servers list from URL ..."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2455
+#: src/muuli_wdr.cpp:2459
 msgid "Server list"
 msgstr "Seznam serverů"
 
-#: src/muuli_wdr.cpp:2459
+#: src/muuli_wdr.cpp:2463
 msgid "Enter the url to a server.met file here and press the button to the left to update the list of known servers."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2464
+#: src/muuli_wdr.cpp:2468
 msgid "Add server manually: Name"
 msgstr "Přidat server ručně: Název"
 
-#: src/muuli_wdr.cpp:2467
+#: src/muuli_wdr.cpp:2471
 msgid "Enter the name of the new server here"
 msgstr "Zadejte název serveru"
 
-#: src/muuli_wdr.cpp:2469 src/ServerWnd.cpp:206
+#: src/muuli_wdr.cpp:2473 src/ServerWnd.cpp:206
 msgid "IP:Port"
 msgstr "IP:Port"
 
-#: src/muuli_wdr.cpp:2472
+#: src/muuli_wdr.cpp:2476
 msgid "Enter the IP of the server here, using the x.x.x.x format."
 msgstr "Zadejte IP serveru ve tvaru x.x.x.x."
 
-#: src/muuli_wdr.cpp:2478
+#: src/muuli_wdr.cpp:2482
 msgid "Enter the port of the server here."
 msgstr "Zadejte port serveru."
 
-#: src/muuli_wdr.cpp:2481
+#: src/muuli_wdr.cpp:2485
 msgid "Add manually a server (fill fields to the left before) ..."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2510
+#: src/muuli_wdr.cpp:2514
 msgid "aMule Log"
 msgstr "Log aMule"
 
-#: src/muuli_wdr.cpp:2518
+#: src/muuli_wdr.cpp:2522
 msgid "Server Info"
 msgstr "Info o serveru"
 
-#: src/muuli_wdr.cpp:2522
+#: src/muuli_wdr.cpp:2526
 msgid "ED2K Info"
 msgstr "ED2K Info"
 
-#: src/muuli_wdr.cpp:2526
+#: src/muuli_wdr.cpp:2530
 msgid "Kad Info"
 msgstr "Kad Info"
 
-#: src/muuli_wdr.cpp:2554
+#: src/muuli_wdr.cpp:2558
 msgid "Click on this button to update the nodes list from URL ..."
 msgstr "Aktualizuje seznam uzlů z dané URL..."
 
-#: src/muuli_wdr.cpp:2558
+#: src/muuli_wdr.cpp:2562
 msgid "Nodes (0)"
 msgstr "Uzly (0)"
 
-#: src/muuli_wdr.cpp:2562
+#: src/muuli_wdr.cpp:2566
 msgid "Enter the url to a nodes.dat file here and press the button to the left to update the list of known nodes."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2565
+#: src/muuli_wdr.cpp:2569
 msgid "Nodes stats"
 msgstr "Statistiky uzlů"
 
-#: src/muuli_wdr.cpp:2607
+#: src/muuli_wdr.cpp:2611
 msgid "Bootstrap"
 msgstr "Bootstrap"
 
-#: src/muuli_wdr.cpp:2610
+#: src/muuli_wdr.cpp:2614
 msgid "New node"
 msgstr "Nový uzel"
 
-#: src/muuli_wdr.cpp:2615
+#: src/muuli_wdr.cpp:2619
 msgid "IP:"
 msgstr "IP:"
 
-#: src/muuli_wdr.cpp:2635
+#: src/muuli_wdr.cpp:2639
 msgid "Port:"
 msgstr "Port:"
 
-#: src/muuli_wdr.cpp:2648
+#: src/muuli_wdr.cpp:2652
 msgid "Bootstrap from known clients"
 msgstr "Bootstrap od známých klientů"
 
-#: src/muuli_wdr.cpp:2650
+#: src/muuli_wdr.cpp:2654
 msgid "Disconnect Kad"
 msgstr "Odpojit Kad"
 
-#: src/muuli_wdr.cpp:2684
+#: src/muuli_wdr.cpp:2688
 msgid "Use Secure User Identification"
 msgstr "Použít bezpečnou uživatelskou identifikaci"
 
-#: src/muuli_wdr.cpp:2686
+#: src/muuli_wdr.cpp:2690
 msgid "It is recommended to enable this option. You will not receive credits if SUI is not enabled."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2688
+#: src/muuli_wdr.cpp:2692
 msgid "Protocol Obfuscation"
 msgstr "Zatemnění protokolu"
 
-#: src/muuli_wdr.cpp:2691
+#: src/muuli_wdr.cpp:2695
 msgid "Support Protocol Obfuscation"
 msgstr "Podporuje zatemnění protokolu"
 
-#: src/muuli_wdr.cpp:2693
+#: src/muuli_wdr.cpp:2697
 msgid "This option enabled Protocol Obfuscation, and makes aMule accept obfuscated connections from other clients."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2695
+#: src/muuli_wdr.cpp:2699
 msgid "Use obfuscation for outgoing connections"
 msgstr "Použít zatemnění protokolu pro odchozí spojení"
 
-#: src/muuli_wdr.cpp:2697
+#: src/muuli_wdr.cpp:2701
 msgid "This option makes aMule use Protocol Obfuscation when connecting other clients/servers."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2699
+#: src/muuli_wdr.cpp:2703
 msgid "Accept only obfuscated connections"
 msgstr "Přijímat pouze zatemněná spojení"
 
-#: src/muuli_wdr.cpp:2700
+#: src/muuli_wdr.cpp:2704
 msgid "This option makes aMule only accept obfuscated connections. You will have less sources, but all your traffic will be obfuscated"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2705
+#: src/muuli_wdr.cpp:2709
 msgid "Everybody"
 msgstr "Všichni"
 
-#: src/muuli_wdr.cpp:2707
+#: src/muuli_wdr.cpp:2711
 msgid "No one"
 msgstr "Nikdo"
 
-#: src/muuli_wdr.cpp:2709
+#: src/muuli_wdr.cpp:2713
 msgid "Who can see my shared files:"
 msgstr "Kdo může prohlížet moje sdílené soubory:"
 
-#: src/muuli_wdr.cpp:2710
+#: src/muuli_wdr.cpp:2714
 msgid "Select who can request to view a list of your shared files."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2712
+#: src/muuli_wdr.cpp:2716
 msgid "IP-Filtering"
 msgstr "IP filtrování"
 
-#: src/muuli_wdr.cpp:2719
+#: src/muuli_wdr.cpp:2723
 msgid "Filter clients"
 msgstr "Filtrovat klienty"
 
-#: src/muuli_wdr.cpp:2721
+#: src/muuli_wdr.cpp:2725
 msgid "Enable filtering of the client IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2723
+#: src/muuli_wdr.cpp:2727
 msgid "Filter servers"
 msgstr "Filtrovat servery"
 
-#: src/muuli_wdr.cpp:2725
+#: src/muuli_wdr.cpp:2729
 msgid "Enable filtering of the server IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2729
+#: src/muuli_wdr.cpp:2733
 msgid "Reload List"
 msgstr "Obnovit seznam"
 
-#: src/muuli_wdr.cpp:2730
+#: src/muuli_wdr.cpp:2734
 msgid "Reload the list of IPs to filter from the file ~/.aMule/ipfilter.dat"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2736
+#: src/muuli_wdr.cpp:2740
 msgid "URL:"
 msgstr "URL:"
 
-#: src/muuli_wdr.cpp:2740 src/muuli_wdr.cpp:2933
+#: src/muuli_wdr.cpp:2744 src/muuli_wdr.cpp:2937
 msgid "Update now"
 msgstr "Obnovit"
 
-#: src/muuli_wdr.cpp:2743
+#: src/muuli_wdr.cpp:2747
 msgid "Auto-update ipfilter at startup"
 msgstr "Automaticky aktualizovat IP filtr po spuštění"
 
-#: src/muuli_wdr.cpp:2747
+#: src/muuli_wdr.cpp:2751
 msgid "Filtering Level:"
 msgstr "Úroveň filtrování:"
 
-#: src/muuli_wdr.cpp:2753
+#: src/muuli_wdr.cpp:2757
 msgid "Always filter LAN IPs"
 msgstr "Vždy filtrovat LAN IP"
 
-#: src/muuli_wdr.cpp:2756
+#: src/muuli_wdr.cpp:2760
 msgid "Paranoid handling of non-matching IPs"
 msgstr "Paranoidní nakládání s nesouhlasícími IP"
 
-#: src/muuli_wdr.cpp:2758
+#: src/muuli_wdr.cpp:2762
 msgid "Rejects a packet when its source IP differs from the IP the client claims (an anti-spoofing check). Disable only if it causes connection problems."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2760
+#: src/muuli_wdr.cpp:2764
 msgid "Use system-wide ipfilter.dat if available"
 msgstr "Použít systémový ipfilter.dat, je-li dostupný"
 
-#: src/muuli_wdr.cpp:2761
+#: src/muuli_wdr.cpp:2765
 #, fuzzy
 msgid "If there's no local ipfilter.dat found, allow usage of a system-wide ipfilter file."
 msgstr "Neexistuje-li místní ipfilter.dat, umožní použití systémového."
 
-#: src/muuli_wdr.cpp:2778
+#: src/muuli_wdr.cpp:2782
 msgid "Enable Online-Signature"
 msgstr "Povolit online podpis"
 
-#: src/muuli_wdr.cpp:2780
+#: src/muuli_wdr.cpp:2784
 msgid "Enables the writing of the OS file, which can be used by external apps to create signatures and the like."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2784
+#: src/muuli_wdr.cpp:2788
 msgid "Update Frequency (Secs):"
 msgstr "Prodleva aktualizace (sek.):"
 
-#: src/muuli_wdr.cpp:2787
+#: src/muuli_wdr.cpp:2791
 msgid "Change the frequency (in seconds) of Online Signature updates."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2795
+#: src/muuli_wdr.cpp:2799
 msgid "Save online signature file in: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:2801
+#: src/muuli_wdr.cpp:2805
 msgid "Click here to select the directory containing the the Online Signature files."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2834
+#: src/muuli_wdr.cpp:2838
 msgid "Show country flags for clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2835
+#: src/muuli_wdr.cpp:2839
 msgid "Render the country flag column in the transfers, queue and search views. Requires a valid MMDB GeoIP database (see below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2840
+#: src/muuli_wdr.cpp:2844
 msgid "Database"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2856
+#: src/muuli_wdr.cpp:2860
 #, fuzzy
 msgid "Source:"
 msgstr "Zdroje"
 
-#: src/muuli_wdr.cpp:2859
+#: src/muuli_wdr.cpp:2863
 msgid "DB-IP (free, no account)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2860
+#: src/muuli_wdr.cpp:2864
 msgid "MaxMind GeoLite2 (free, account required)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2861
+#: src/muuli_wdr.cpp:2865
 msgid "Custom URL"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2864
+#: src/muuli_wdr.cpp:2868
 msgid "Choose which provider supplies the GeoIP MMDB database. DB-IP is the default - no account required. MaxMind requires a free account + license key. Use Custom URL to point at any other MMDB host (e.g. a local mirror)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2881
+#: src/muuli_wdr.cpp:2885
 msgid ""
 "No configuration required.\n"
 "\n"
@@ -4871,11 +4871,11 @@ msgid ""
 "License: Creative Commons BY 4.0 - https://creativecommons.org/licenses/by/4.0/"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2894
+#: src/muuli_wdr.cpp:2898
 msgid "License key:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2900
+#: src/muuli_wdr.cpp:2904
 msgid ""
 "Sign up for a free MaxMind account, then generate a License Key:\n"
 "https://www.maxmind.com/en/geolite2/signup\n"
@@ -4885,230 +4885,230 @@ msgid ""
 "Requires attribution and account registration; refresh at least every 30 days."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2915
+#: src/muuli_wdr.cpp:2919
 #, fuzzy
 msgid "Download URL:"
 msgstr "Stahování: "
 
-#: src/muuli_wdr.cpp:2921
+#: src/muuli_wdr.cpp:2925
 msgid ""
 "Must point to an .mmdb file or a .gz / .tar.gz containing one.\n"
 "URL may include credentials (https://user:pass@host/...).\n"
 "License and attribution terms are set by the upstream URL - you are responsible."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2934
+#: src/muuli_wdr.cpp:2938
 msgid "Download the GeoIP database from the selected source."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2936
+#: src/muuli_wdr.cpp:2940
 #, fuzzy
 msgid "Auto-update on startup"
 msgstr "Automaticky aktualizovat IP filtr po spuštění"
 
-#: src/muuli_wdr.cpp:2937
+#: src/muuli_wdr.cpp:2941
 msgid "Re-download the GeoIP database from the selected source every time aMule starts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2960
+#: src/muuli_wdr.cpp:2964
 msgid "Filter incoming messages (except current chat):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2962
+#: src/muuli_wdr.cpp:2966
 msgid "Filter all messages"
 msgstr "Filtrovat všechny zprávy"
 
-#: src/muuli_wdr.cpp:2964
+#: src/muuli_wdr.cpp:2968
 msgid "Filter messages from people not on your friend list"
 msgstr "Filtrovat zprávy, které nejsou od přátel"
 
-#: src/muuli_wdr.cpp:2966
+#: src/muuli_wdr.cpp:2970
 msgid "Filter messages from unknown clients"
 msgstr "Filtrovat zprávy od neznámých klientů"
 
-#: src/muuli_wdr.cpp:2968
+#: src/muuli_wdr.cpp:2972
 msgid "Filter messages containing (use ',' as separator):"
 msgstr "Filtrovat zprávy obsahující (použijte ',' jako oddělovač):"
 
-#: src/muuli_wdr.cpp:2971 src/muuli_wdr.cpp:2982
+#: src/muuli_wdr.cpp:2975 src/muuli_wdr.cpp:2986
 msgid "add here the words amule should filter and block messages including it"
 msgstr "zadejte slova, která by měla amule filtrovat a blokovat zprávy obsahující je"
 
-#: src/muuli_wdr.cpp:2973
+#: src/muuli_wdr.cpp:2977
 msgid "Show received messages in the log"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2976
+#: src/muuli_wdr.cpp:2980
 msgid "Comments"
 msgstr "Komentáře"
 
-#: src/muuli_wdr.cpp:2979
+#: src/muuli_wdr.cpp:2983
 msgid "Filter comments containing (use ',' as separator):"
 msgstr "Filtrovat komentáře obsahující (použijte ',' jako oddělovač):"
 
-#: src/muuli_wdr.cpp:3004
+#: src/muuli_wdr.cpp:3008
 msgid "Enable Proxy"
 msgstr "Povolit proxy"
 
-#: src/muuli_wdr.cpp:3005
+#: src/muuli_wdr.cpp:3009
 msgid "Enable/disable proxy support"
 msgstr "Povolí/zakáže proxy"
 
-#: src/muuli_wdr.cpp:3008
+#: src/muuli_wdr.cpp:3012
 msgid "Proxy type:"
 msgstr "Typ proxy:"
 
-#: src/muuli_wdr.cpp:3019
+#: src/muuli_wdr.cpp:3023
 msgid "Proxy host:"
 msgstr "Hostitel proxy:"
 
-#: src/muuli_wdr.cpp:3022
+#: src/muuli_wdr.cpp:3026
 msgid "The proxy host name"
 msgstr "Název hostitele proxy"
 
-#: src/muuli_wdr.cpp:3024
+#: src/muuli_wdr.cpp:3028
 msgid "Proxy port:"
 msgstr "Port proxy:"
 
-#: src/muuli_wdr.cpp:3027
+#: src/muuli_wdr.cpp:3031
 msgid "The proxy port"
 msgstr "Port proxy"
 
-#: src/muuli_wdr.cpp:3029
+#: src/muuli_wdr.cpp:3033
 msgid "Enable authentication"
 msgstr "Povolit autentizaci"
 
-#: src/muuli_wdr.cpp:3030
+#: src/muuli_wdr.cpp:3034
 msgid "Enable/disable username/password authentication"
 msgstr "Povolí/zakáže autentizaci (uživatelské jméno a heslo)"
 
-#: src/muuli_wdr.cpp:3033
+#: src/muuli_wdr.cpp:3037
 msgid "Username: "
 msgstr "Uživatelské jméno: "
 
-#: src/muuli_wdr.cpp:3036
+#: src/muuli_wdr.cpp:3040
 msgid "The username to use to connect to the proxy"
 msgstr "Uživatelské jméno, které se použije pro přihlášení k proxy"
 
-#: src/muuli_wdr.cpp:3038
+#: src/muuli_wdr.cpp:3042
 msgid "Password:"
 msgstr "Heslo:"
 
-#: src/muuli_wdr.cpp:3041
+#: src/muuli_wdr.cpp:3045
 msgid "The password to use to connect to the proxy"
 msgstr "Heslo, které se použije pro přihlášení k proxy"
 
-#: src/muuli_wdr.cpp:3060
+#: src/muuli_wdr.cpp:3064
 msgid "Connect to:"
 msgstr "Připojit se k:"
 
-#: src/muuli_wdr.cpp:3069
+#: src/muuli_wdr.cpp:3073
 msgid "Login to remote amule"
 msgstr "Připojit k vzdálené aMuli"
 
-#: src/muuli_wdr.cpp:3074
+#: src/muuli_wdr.cpp:3078
 msgid "User name"
 msgstr "Uživatelské jméno"
 
-#: src/muuli_wdr.cpp:3085
+#: src/muuli_wdr.cpp:3089
 msgid "Remember those settings"
 msgstr "Zapamatovat si toto nastavení"
 
-#: src/muuli_wdr.cpp:3088
+#: src/muuli_wdr.cpp:3092
 #, fuzzy
 msgid "Force ZLIB compression"
 msgstr "Použít gzip kompresi"
 
-#: src/muuli_wdr.cpp:3112
+#: src/muuli_wdr.cpp:3116
 msgid "Enable Verbose Debug-Logging."
 msgstr ""
 
-#: src/muuli_wdr.cpp:3114
+#: src/muuli_wdr.cpp:3118
 #, fuzzy
 msgid "Only to Logfile"
 msgstr "&Otevřít tento soubor"
 
-#: src/muuli_wdr.cpp:3116
+#: src/muuli_wdr.cpp:3120
 msgid "Message Categories:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3140 src/PartFileConvertDlg.cpp:160
+#: src/muuli_wdr.cpp:3144 src/PartFileConvertDlg.cpp:160
 msgid "Waiting..."
 msgstr "Čekání..."
 
-#: src/muuli_wdr.cpp:3160
+#: src/muuli_wdr.cpp:3164
 msgid "Add imports"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3163
+#: src/muuli_wdr.cpp:3167
 msgid "Retry selected"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3165
+#: src/muuli_wdr.cpp:3169
 msgid "Remove selected"
 msgstr "Odstranit vybrané"
 
-#: src/muuli_wdr.cpp:3228
+#: src/muuli_wdr.cpp:3232
 msgid "Event Types"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3247
+#: src/muuli_wdr.cpp:3251
 msgid "Statistics and queued clients for selected file(s) : Session / All time"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3271
+#: src/muuli_wdr.cpp:3275
 msgid "Active Uploads"
 msgstr "Aktivní odesílání"
 
-#: src/muuli_wdr.cpp:3285
+#: src/muuli_wdr.cpp:3289
 msgid "Percent of total files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3337
+#: src/muuli_wdr.cpp:3341
 #, fuzzy
 msgid "Show Clients for"
 msgstr "Zobrazit klienty"
 
-#: src/muuli_wdr.cpp:3339
+#: src/muuli_wdr.cpp:3343
 #, fuzzy
 msgid "All files"
 msgstr "Všechny sdílené soubory"
 
-#: src/muuli_wdr.cpp:3342
+#: src/muuli_wdr.cpp:3346
 #, fuzzy
 msgid "Selected files"
 msgstr "Sdílené soubory"
 
-#: src/muuli_wdr.cpp:3345
+#: src/muuli_wdr.cpp:3349
 #, fuzzy
 msgid "Active uploads only"
 msgstr "Aktivní odesílání"
 
-#: src/muuli_wdr.cpp:3352
+#: src/muuli_wdr.cpp:3356
 msgid "Reload:"
 msgstr "Obnovit:"
 
-#: src/muuli_wdr.cpp:3356
+#: src/muuli_wdr.cpp:3360
 msgid "Reload your shared files"
 msgstr "Znovu načíst vaše sdílené soubory"
 
-#: src/muuli_wdr.cpp:3419
+#: src/muuli_wdr.cpp:3423
 msgid "Send"
 msgstr "Odeslat"
 
-#: src/muuli_wdr.cpp:3420
+#: src/muuli_wdr.cpp:3424
 msgid "Sends the specified message."
 msgstr "Odešle zadanou zprávu."
 
-#: src/muuli_wdr.cpp:3424
+#: src/muuli_wdr.cpp:3428
 msgid "Close this chat-session."
 msgstr "Zavře tento chat."
 
-#: src/muuli_wdr.cpp:3447
+#: src/muuli_wdr.cpp:3451
 msgid "Connect to any server and/or Kad"
 msgstr "Připojit k nějakému serveru a/nebo Kadu"
 
-#: src/muuli_wdr.cpp:3453 src/SharedFilesCtrl.cpp:142 src/Statistics.cpp:941
+#: src/muuli_wdr.cpp:3457 src/SharedFilesCtrl.cpp:142 src/Statistics.cpp:941
 msgid "Shared Files"
 msgstr "Sdílené soubory"
 
@@ -5746,35 +5746,35 @@ msgstr ""
 "aMule poběží v pohodě bez změny\n"
 "nastavení na tomto tabu."
 
-#: src/PrefsUnifiedDlg.cpp:647
+#: src/PrefsUnifiedDlg.cpp:656
 #, c-format
 msgid "Failed to connect Cfg to widget with the ID %d and key %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:695
+#: src/PrefsUnifiedDlg.cpp:704
 #, c-format
 msgid "Failed to transfer data from Cfg to Widget with the ID %d and key %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:801
+#: src/PrefsUnifiedDlg.cpp:810
 msgid "The type of proxy you are connecting to"
 msgstr "Typ proxy, ke které se připojujete"
 
-#: src/PrefsUnifiedDlg.cpp:1020
+#: src/PrefsUnifiedDlg.cpp:1029
 #, c-format
 msgid "Failed to transfer data from Widget to Cfg with the ID %d and key %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1103
+#: src/PrefsUnifiedDlg.cpp:1112
 #, fuzzy
 msgid "No password set."
 msgstr "Kontrola hesla\n"
 
-#: src/PrefsUnifiedDlg.cpp:1132
+#: src/PrefsUnifiedDlg.cpp:1141
 msgid "Guest access needs a password. Type one in the guest password field, or untick Enable guest access."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1144
+#: src/PrefsUnifiedDlg.cpp:1153
 msgid ""
 "aMule must be restarted to enable these changes:\n"
 "\n"
@@ -5782,89 +5782,89 @@ msgstr ""
 "Restartujte aMule, aby se projevily následující změny:\n"
 "\n"
 
-#: src/PrefsUnifiedDlg.cpp:1151
+#: src/PrefsUnifiedDlg.cpp:1160
 msgid "- TCP port changed.\n"
 msgstr "- TCP port změněn.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1156
+#: src/PrefsUnifiedDlg.cpp:1165
 msgid "- UDP port changed.\n"
 msgstr "- UDP port změněn.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1161
+#: src/PrefsUnifiedDlg.cpp:1170
 #, fuzzy
 msgid "- Network interface binding changed.\n"
 msgstr "Externí připojení uzavřeno."
 
-#: src/PrefsUnifiedDlg.cpp:1166
+#: src/PrefsUnifiedDlg.cpp:1175
 #, fuzzy
 msgid "- External connect port changed.\n"
 msgstr "Externí připojení uzavřeno."
 
-#: src/PrefsUnifiedDlg.cpp:1170
+#: src/PrefsUnifiedDlg.cpp:1179
 #, fuzzy
 msgid "- External connect acceptance changed.\n"
 msgstr "Nové externí připojení přijato"
 
-#: src/PrefsUnifiedDlg.cpp:1174
+#: src/PrefsUnifiedDlg.cpp:1183
 #, fuzzy
 msgid "- External connect interface changed.\n"
 msgstr "Externí připojení uzavřeno."
 
-#: src/PrefsUnifiedDlg.cpp:1178
+#: src/PrefsUnifiedDlg.cpp:1187
 #, fuzzy
 msgid "- Protocol obfuscation support changed.\n"
 msgstr "Zatemnění protokolu"
 
-#: src/PrefsUnifiedDlg.cpp:1193
+#: src/PrefsUnifiedDlg.cpp:1202
 #, fuzzy
 msgid "- amuleapi settings changed.\n"
 msgstr "- Jazyk byl změněn.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1202
+#: src/PrefsUnifiedDlg.cpp:1211
 msgid ""
 "Your Auto-update server list is empty.\n"
 "'Auto-update server list at startup' will be disabled."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1213
+#: src/PrefsUnifiedDlg.cpp:1222
 msgid ""
 "You have enabled external connections but have not specified a password.\n"
 "External connections cannot be enabled unless a valid password is specified."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1246
+#: src/PrefsUnifiedDlg.cpp:1255
 #, c-format
 msgid "The amuleapi password could not be saved: %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1276
+#: src/PrefsUnifiedDlg.cpp:1285
 msgid "- Language changed.\n"
 msgstr "- Jazyk byl změněn.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1281
+#: src/PrefsUnifiedDlg.cpp:1290
 msgid "- Temp folder changed.\n"
 msgstr "- Dočasný adresář byl změněn.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1286
+#: src/PrefsUnifiedDlg.cpp:1295
 msgid "- ED2K network enabled.\n"
 msgstr "- Síť eD2k povolena.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1319
+#: src/PrefsUnifiedDlg.cpp:1328
 msgid "The shared-file exclusion pattern is not a valid regular expression. The filter has been left disabled."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1321 src/PrefsUnifiedDlg.cpp:1921
+#: src/PrefsUnifiedDlg.cpp:1330 src/PrefsUnifiedDlg.cpp:1930
 #, fuzzy
 msgid "Invalid regular expression"
 msgstr "Neplatná verze protokolu."
 
-#: src/PrefsUnifiedDlg.cpp:1398
+#: src/PrefsUnifiedDlg.cpp:1407
 msgid ""
 "Both eD2k and Kad network are disabled.\n"
 "You won't be able to connect until you enable at least one of them."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1403
+#: src/PrefsUnifiedDlg.cpp:1412
 msgid ""
 "Kad will not start if your UDP port is disabled.\n"
 "Enable UDP port or disable Kad."
@@ -5872,7 +5872,7 @@ msgstr ""
 "Kad se nespustí, když máte zakázaný UDP port.\n"
 "Povolte UDP port, nebo zakažte připojování na Kad."
 
-#: src/PrefsUnifiedDlg.cpp:1459
+#: src/PrefsUnifiedDlg.cpp:1468
 msgid ""
 "\n"
 "You MUST restart aMule now.\n"
@@ -5882,93 +5882,93 @@ msgstr ""
 "Nyní MUSÍTE restartovat aMule.\n"
 "Pokud to neuděláte, tak si pak nestěžujte, když se přihodí něco špatného.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1524
+#: src/PrefsUnifiedDlg.cpp:1533
 msgid "Could not register aMule for autostart at login. The autostart store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1526
+#: src/PrefsUnifiedDlg.cpp:1535
 msgid "Could not remove the autostart-at-login entry."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1527
+#: src/PrefsUnifiedDlg.cpp:1536
 #, fuzzy
 msgid "Autostart"
 msgstr "Automatické obnovování spuštěno"
 
-#: src/PrefsUnifiedDlg.cpp:1542
+#: src/PrefsUnifiedDlg.cpp:1551
 msgid "Register file type"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1542
+#: src/PrefsUnifiedDlg.cpp:1551
 msgid "Register URL handler"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1550
+#: src/PrefsUnifiedDlg.cpp:1559
 #, c-format
 msgid "aMule only handles eD2k-compatible magnets. If you replace the current magnet handler (%s), BitTorrent magnet links will stop working - aMule cannot download BitTorrent content. Continue?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1555
+#: src/PrefsUnifiedDlg.cpp:1564
 #, c-format
 msgid "Another application currently opens .emulecollection files (%s). Replace it with aMule?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1560
+#: src/PrefsUnifiedDlg.cpp:1569
 #, c-format
 msgid "Another application is currently the default handler for these links (%s). Replace it with aMule?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1585
+#: src/PrefsUnifiedDlg.cpp:1594
 msgid "Could not register aMule for .emulecollection files. The registration store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1587
+#: src/PrefsUnifiedDlg.cpp:1596
 #, fuzzy
 msgid "Could not remove the file type registration."
 msgstr "Soubor %s se již pokoušíte stáhnout"
 
-#: src/PrefsUnifiedDlg.cpp:1589
+#: src/PrefsUnifiedDlg.cpp:1598
 msgid "Could not register aMule as the URL handler. The registration store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1591
+#: src/PrefsUnifiedDlg.cpp:1600
 msgid "Could not remove the URL handler registration."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1661 src/PrefsUnifiedDlg.cpp:1688
+#: src/PrefsUnifiedDlg.cpp:1670 src/PrefsUnifiedDlg.cpp:1697
 #, fuzzy
 msgid "The web server and aMule API require external connections to be enabled."
 msgstr "Heslo nastaveno a externí připojení povoleno."
 
-#: src/PrefsUnifiedDlg.cpp:1671
+#: src/PrefsUnifiedDlg.cpp:1680
 msgid "The aMule web server is deprecated. Consider running the aMule API instead."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1735
+#: src/PrefsUnifiedDlg.cpp:1744
 msgid ""
 "Your Auto-update servers list is in blank.\n"
 "Please fill in at least one URL to point to a valid server.met file.\n"
 "Click on the button \"List\" by this checkbox to enter an URL."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1876
+#: src/PrefsUnifiedDlg.cpp:1885
 msgid "Temporary files"
 msgstr "Dočasné soubory"
 
-#: src/PrefsUnifiedDlg.cpp:1881
+#: src/PrefsUnifiedDlg.cpp:1890
 msgid "Incoming files"
 msgstr "Příchozí soubory"
 
-#: src/PrefsUnifiedDlg.cpp:1886
+#: src/PrefsUnifiedDlg.cpp:1895
 msgid "Online Signatures"
 msgstr "Online podpisy"
 
-#: src/PrefsUnifiedDlg.cpp:1899
+#: src/PrefsUnifiedDlg.cpp:1908
 #, c-format
 msgid "Choose a folder for %s"
 msgstr "Zvolte adresář pro %s"
 
-#: src/PrefsUnifiedDlg.cpp:1923
+#: src/PrefsUnifiedDlg.cpp:1932
 #, fuzzy, c-format
 msgid "Would exclude %u of %u shared file"
 msgid_plural "Would exclude %u of %u shared files"
@@ -5976,42 +5976,42 @@ msgstr[0] "Znovu načíst vaše sdílené soubory"
 msgstr[1] "Znovu načíst vaše sdílené soubory"
 msgstr[2] "Znovu načíst vaše sdílené soubory"
 
-#: src/PrefsUnifiedDlg.cpp:1940
+#: src/PrefsUnifiedDlg.cpp:1949
 msgid "Browse for videoplayer"
 msgstr "Zvolit přehrávač videa"
 
-#: src/PrefsUnifiedDlg.cpp:1944
+#: src/PrefsUnifiedDlg.cpp:1953
 msgid "Select browser"
 msgstr "Výběr prohlížeče"
 
-#: src/PrefsUnifiedDlg.cpp:1948
+#: src/PrefsUnifiedDlg.cpp:1957
 #, fuzzy
 msgid "Select ffprobe binary"
 msgstr "Výběr prohlížeče"
 
-#: src/PrefsUnifiedDlg.cpp:1954
+#: src/PrefsUnifiedDlg.cpp:1963
 #, c-format
 msgid "Executable%s"
 msgstr "Spustitelný soubor %s"
 
-#: src/PrefsUnifiedDlg.cpp:1988
+#: src/PrefsUnifiedDlg.cpp:1997
 msgid "ffprobe not found on PATH or in the standard install locations. Install ffmpeg (which ships ffprobe) or use Browse to pick a binary manually."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2000
+#: src/PrefsUnifiedDlg.cpp:2009
 msgid "Reset the settings on this page to their default values?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2001
+#: src/PrefsUnifiedDlg.cpp:2010
 #, fuzzy
 msgid "Reset to defaults"
 msgstr "Výchozí pro systém"
 
-#: src/PrefsUnifiedDlg.cpp:2028
+#: src/PrefsUnifiedDlg.cpp:2037
 msgid "Edit server list"
 msgstr "Upravit seznam serverů"
 
-#: src/PrefsUnifiedDlg.cpp:2029
+#: src/PrefsUnifiedDlg.cpp:2038
 msgid ""
 "Add here URL's to download server.met files.\n"
 "Only one url on each line."
@@ -6019,42 +6019,42 @@ msgstr ""
 "Sem přidejte URL pro stažení server.met souborů.\n"
 "Pouze jedno URL na každý řádek."
 
-#: src/PrefsUnifiedDlg.cpp:2084
+#: src/PrefsUnifiedDlg.cpp:2093
 msgid "IP2Country update failed"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2229 src/PrefsUnifiedDlg.cpp:2260
+#: src/PrefsUnifiedDlg.cpp:2238 src/PrefsUnifiedDlg.cpp:2269
 msgid "Data by MaxMind GeoLite2"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2231 src/PrefsUnifiedDlg.cpp:2262
+#: src/PrefsUnifiedDlg.cpp:2240 src/PrefsUnifiedDlg.cpp:2271
 #, fuzzy
 msgid "Custom source"
 msgstr "Kompletní zdroje"
 
-#: src/PrefsUnifiedDlg.cpp:2233 src/PrefsUnifiedDlg.cpp:2264
+#: src/PrefsUnifiedDlg.cpp:2242 src/PrefsUnifiedDlg.cpp:2273
 msgid "Data by DB-IP.com"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2284
+#: src/PrefsUnifiedDlg.cpp:2293
 #, fuzzy, c-format
 msgid "Status: Loaded%s"
 msgstr "Stav:"
 
-#: src/PrefsUnifiedDlg.cpp:2286
+#: src/PrefsUnifiedDlg.cpp:2295
 #, fuzzy, c-format
 msgid "Status: Loaded%s - %s"
 msgstr "Stav:"
 
-#: src/PrefsUnifiedDlg.cpp:2290
+#: src/PrefsUnifiedDlg.cpp:2299
 msgid "Status: Failed to load - click 'Update now' to refresh."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2292
+#: src/PrefsUnifiedDlg.cpp:2301
 msgid "Status: Not found - click 'Update now' to download."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2350 src/PrefsUnifiedDlg.cpp:2374
+#: src/PrefsUnifiedDlg.cpp:2359 src/PrefsUnifiedDlg.cpp:2383
 #, c-format
 msgid "Update delay: %d second"
 msgid_plural "Update delay: %d seconds"
@@ -6062,7 +6062,7 @@ msgstr[0] ""
 msgstr[1] ""
 msgstr[2] ""
 
-#: src/PrefsUnifiedDlg.cpp:2358
+#: src/PrefsUnifiedDlg.cpp:2367
 #, fuzzy, c-format
 msgid "Time for average graph: %d minute"
 msgid_plural "Time for average graph: %d minutes"
@@ -6070,12 +6070,12 @@ msgstr[0] "Čas pro průměrný graf: %d minut"
 msgstr[1] "Čas pro průměrný graf: %d minut"
 msgstr[2] ""
 
-#: src/PrefsUnifiedDlg.cpp:2367
+#: src/PrefsUnifiedDlg.cpp:2376
 #, c-format
 msgid "Connections Graph Scale: %d"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2382
+#: src/PrefsUnifiedDlg.cpp:2391
 #, fuzzy, c-format
 msgid "File Buffer Size: %d byte"
 msgid_plural "File Buffer Size: %d bytes"
@@ -6083,7 +6083,7 @@ msgstr[0] "Velikost zásobníku pro soubory: %d bajtů"
 msgstr[1] "Velikost zásobníku pro soubory: %d bajtů"
 msgstr[2] ""
 
-#: src/PrefsUnifiedDlg.cpp:2392
+#: src/PrefsUnifiedDlg.cpp:2401
 #, fuzzy, c-format
 msgid "Upload Queue Size: %d client"
 msgid_plural "Upload Queue Size: %d clients"
@@ -6091,7 +6091,7 @@ msgstr[0] "Velikost fronty pro odesílání: %d klientů"
 msgstr[1] "Velikost fronty pro odesílání: %d klientů"
 msgstr[2] ""
 
-#: src/PrefsUnifiedDlg.cpp:2402
+#: src/PrefsUnifiedDlg.cpp:2411
 #, fuzzy, c-format
 msgid "Server connection refresh interval: %d minute"
 msgid_plural "Server connection refresh interval: %d minutes"
@@ -6099,79 +6099,79 @@ msgstr[0] "Interval pro obnovení připojení k serveru: %d minut"
 msgstr[1] "Interval pro obnovení připojení k serveru: %d minut"
 msgstr[2] ""
 
-#: src/PrefsUnifiedDlg.cpp:2407
+#: src/PrefsUnifiedDlg.cpp:2416
 msgid "Server connection refresh interval: Disabled"
 msgstr "Interval pro obnovení připojení k serveru: Zakázáno"
 
-#: src/PrefsUnifiedDlg.cpp:2451
+#: src/PrefsUnifiedDlg.cpp:2460
 msgid "disabled"
 msgstr "zakázáno"
 
-#: src/PrefsUnifiedDlg.cpp:2477
+#: src/PrefsUnifiedDlg.cpp:2486
 #, fuzzy, c-format
 msgid "Execute command on '%s' event"
 msgstr "Spustí příkaz při událost `%s'"
 
-#: src/PrefsUnifiedDlg.cpp:2484
+#: src/PrefsUnifiedDlg.cpp:2493
 msgid "Enable command execution on core"
 msgstr "Povolit jaderné příkazy"
 
-#: src/PrefsUnifiedDlg.cpp:2496
+#: src/PrefsUnifiedDlg.cpp:2505
 msgid "Core command:"
 msgstr "Příkaz jádra:"
 
-#: src/PrefsUnifiedDlg.cpp:2512
+#: src/PrefsUnifiedDlg.cpp:2521
 msgid "Enable command execution on GUI"
 msgstr "Povolit GUI příkazy"
 
-#: src/PrefsUnifiedDlg.cpp:2524
+#: src/PrefsUnifiedDlg.cpp:2533
 msgid "GUI command:"
 msgstr "Příkaz GUI:"
 
-#: src/PrefsUnifiedDlg.cpp:2540
+#: src/PrefsUnifiedDlg.cpp:2549
 msgid "The following variables will be replaced:"
 msgstr "Následující proměnné budou nahrazeny:"
 
-#: src/PrefsUnifiedDlg.cpp:2708
+#: src/PrefsUnifiedDlg.cpp:2717
 msgid ""
 "The following folders look like system or sensitive locations:\n"
 "\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2713
+#: src/PrefsUnifiedDlg.cpp:2722
 msgid "Sharing them recursively will publish every file underneath on the eD2k/Kad networks. Do you really want to do this?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2716
+#: src/PrefsUnifiedDlg.cpp:2725
 #, fuzzy
 msgid "Confirm shared folders"
 msgstr "Sdílené adresáře"
 
-#: src/PrefsUnifiedDlg.cpp:2744
+#: src/PrefsUnifiedDlg.cpp:2753
 #, fuzzy
 msgid "Reloading shared files..."
 msgstr "Znovu načíst vaše sdílené soubory"
 
-#: src/PrefsUnifiedDlg.cpp:2745
+#: src/PrefsUnifiedDlg.cpp:2754
 msgid "Scanning for subdirectories..."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2746
+#: src/PrefsUnifiedDlg.cpp:2755
 #, fuzzy
 msgid "Updating shared folders"
 msgstr "Sdílené adresáře"
 
-#: src/PrefsUnifiedDlg.cpp:2773
+#: src/PrefsUnifiedDlg.cpp:2782
 #, c-format
 msgid "Scanned %u directories..."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2823
+#: src/PrefsUnifiedDlg.cpp:2832
 #, fuzzy, c-format
 msgid "Reloading shared files: %u files scanned"
 msgstr "Znovu načte seznam sdílených souborů."
 
-#: src/PrefsUnifiedDlg.cpp:2873
+#: src/PrefsUnifiedDlg.cpp:2882
 #, fuzzy
 msgid "Shared folder"
 msgstr "Sdílené adresáře"
@@ -7843,12 +7843,12 @@ msgstr "Odstranit kategorii"
 msgid "Hashset requested for unknown file: %s"
 msgstr ""
 
-#: src/UploadQueue.cpp:618
+#: src/UploadQueue.cpp:627
 #, c-format
 msgid "Resuming uploads of file: %s"
 msgstr "Obnovuji odesílání souboru %s"
 
-#: src/UploadQueue.cpp:634
+#: src/UploadQueue.cpp:643
 #, c-format
 msgid "Suspending upload of file: %s"
 msgstr "Zastavuji odesílání souboru %s"

--- a/po/da.po
+++ b/po/da.po
@@ -9,8 +9,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-28 12:12+0200\n"
-"PO-Revision-Date: 2026-07-27 10:17+0000\n"
+"POT-Creation-Date: 2026-07-28 08:06+0200\n"
+"PO-Revision-Date: 2026-07-27 11:34+0000\n"
 "Last-Translator: Alex Thomsen Leth <alexl@stofanet.dk>\n"
 "Language-Team: aMule Team <https://github.com/amule-org/amule>\n"
 "Language: da\n"
@@ -136,7 +136,7 @@ msgstr ""
 msgid "Not now"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:422 src/amuleDlg.cpp:665
+#: src/AppImageIntegration.cpp:422 src/amuleDlg.cpp:600
 msgid "Don't ask again"
 msgstr ""
 
@@ -194,155 +194,155 @@ msgstr "Kunne ikke åbne %s (%s)"
 msgid "WARNING: You can't add yourself as a source for an eD2k link while having a lowid."
 msgstr ""
 
-#: src/amule.cpp:301
+#: src/amule.cpp:300
 msgid "Now, exiting main app..."
 msgstr ""
 
-#: src/amule.cpp:331
+#: src/amule.cpp:330
 #, c-format
 msgid "Terminating amuleweb instance with pid '%d' ... "
 msgstr ""
 
-#: src/amule.cpp:335
+#: src/amule.cpp:334
 #, c-format
 msgid "Killing amuleweb instance with pid '%d' ... "
 msgstr ""
 
-#: src/amule.cpp:337 src/amule.cpp:350 src/ClientRef.cpp:180
-#: src/SearchDlg.cpp:1041 src/ServerListCtrl.cpp:98
+#: src/amule.cpp:336 src/amule.cpp:349 src/ClientRef.cpp:180
+#: src/SearchDlg.cpp:880 src/ServerListCtrl.cpp:98
 msgid "Failed"
 msgstr "Fejlede"
 
-#: src/amule.cpp:344
+#: src/amule.cpp:343
 #, c-format
 msgid "Terminating amuleapi instance with pid '%d' ... "
 msgstr ""
 
-#: src/amule.cpp:348
+#: src/amule.cpp:347
 #, c-format
 msgid "Killing amuleapi instance with pid '%d' ... "
 msgstr ""
 
-#: src/amule.cpp:356
+#: src/amule.cpp:355
 msgid "aMule OnExit: Terminating core."
 msgstr ""
 
-#: src/amule.cpp:467
+#: src/amule.cpp:466
 msgid "aMule shutdown completed."
 msgstr ""
 
-#: src/amule.cpp:471
+#: src/amule.cpp:470
 msgid "Memory debug results for aMule exit:"
 msgstr ""
 
-#: src/amule.cpp:652
+#: src/amule.cpp:651
 #, c-format
 msgid "Binding aMule's peer-to-peer traffic to interface: %s (HTTP updates use the default route)"
 msgstr ""
 
-#: src/amule.cpp:656
+#: src/amule.cpp:655
 #, c-format
 msgid "Binding all network traffic to interface: %s"
 msgstr ""
 
-#: src/amule.cpp:660
+#: src/amule.cpp:659
 #, c-format
 msgid "WARNING: configured network interface '%s' was not found - traffic is NOT bound to it and may leave via the default route. Check the interface name in Preferences."
 msgstr ""
 
-#: src/amule.cpp:666
+#: src/amule.cpp:665
 #, c-format
 msgid "WARNING: binding to network interface '%s' requires elevated privileges and was NOT applied - traffic may leave via the default route. Grant the capability (e.g. 'sudo setcap cap_net_raw+ep' on the aMule binary) or run with sufficient privileges."
 msgstr ""
 
-#: src/amule.cpp:674
+#: src/amule.cpp:673
 #, c-format
 msgid "WARNING: could not bind to network interface '%s' - traffic may leave via the default route."
 msgstr ""
 
-#: src/amule.cpp:733
+#: src/amule.cpp:732
 msgid "Your locale has been changed to System Default due to a configuration change. Sorry."
 msgstr ""
 
-#: src/amule.cpp:735 src/amule.cpp:1589 src/CatDialog.cpp:128
+#: src/amule.cpp:734 src/amule.cpp:1581 src/CatDialog.cpp:128
 #: src/CatDialog.cpp:136 src/CatDialog.cpp:149 src/ServerList.cpp:366
 #: src/ServerListCtrl.cpp:152
 msgid "Info"
 msgstr "Info"
 
-#: src/amule.cpp:742
+#: src/amule.cpp:741
 #, fuzzy
 msgid ""
 "\n"
 "EC configuration"
 msgstr "Bekræft afslut"
 
-#: src/amule.cpp:745
+#: src/amule.cpp:744
 #, fuzzy
 msgid "Password set and external connections enabled."
 msgstr "Accepter ydre forbindelser"
 
-#: src/amule.cpp:755 src/KadDlg.cpp:176 src/KadDlg.cpp:185
-#: src/PrefsUnifiedDlg.cpp:1461 src/SharedFilesCtrl.cpp:476
+#: src/amule.cpp:754 src/KadDlg.cpp:176 src/KadDlg.cpp:185
+#: src/PrefsUnifiedDlg.cpp:1387 src/SharedFilesCtrl.cpp:476
 msgid "WARNING"
 msgstr ""
 
-#: src/amule.cpp:992
+#: src/amule.cpp:991
 msgid "Network bootstrap"
 msgstr ""
 
-#: src/amule.cpp:997
+#: src/amule.cpp:996
 msgid ""
 "aMule has detected missing network bootstrap files.\n"
 "Select which ones to download:"
 msgstr ""
 
-#: src/amule.cpp:1006 src/FirstRunWizard.cpp:411
+#: src/amule.cpp:1005 src/FirstRunWizard.cpp:411
 #, fuzzy
 msgid "eD2k server list (server.met)"
 msgstr "%i Serverer fundet i server.met"
 
-#: src/amule.cpp:1013 src/FirstRunWizard.cpp:416
+#: src/amule.cpp:1012 src/FirstRunWizard.cpp:416
 msgid "Kad bootstrap nodes (nodes.dat)"
 msgstr ""
 
-#: src/amule.cpp:1103
+#: src/amule.cpp:1102
 #, c-format
 msgid "web server running on pid %d"
 msgstr ""
 
-#: src/amule.cpp:1116
+#: src/amule.cpp:1115
 msgid "You requested to run web server on startup, but the amuleweb binary cannot be run. Please install the package containing aMule web server, or build aMule from source with -DBUILD_WEBSERVER=YES and install it."
 msgstr ""
 
-#: src/amule.cpp:1121 src/amule.cpp:1185 src/amule.cpp:1299 src/amule.cpp:1601
+#: src/amule.cpp:1120 src/amule.cpp:1177 src/amule.cpp:1291 src/amule.cpp:1593
 #: src/amule-remote-gui.cpp:603 src/amule-remote-gui.cpp:671
 #: src/amule-remote-gui.cpp:709 src/amule-remote-gui.cpp:1282
 #: src/amule-remote-gui.cpp:1345 src/amule-remote-gui.cpp:1372
-#: src/DownloadQueue.cpp:1481 src/PrefsUnifiedDlg.cpp:1247
+#: src/DownloadQueue.cpp:1481
 msgid "ERROR"
 msgstr ""
 
-#: src/amule.cpp:1174
+#: src/amule.cpp:1166
 #, fuzzy, c-format
 msgid "amuleapi running on pid %d"
 msgstr "aMule kører"
 
-#: src/amule.cpp:1180
+#: src/amule.cpp:1172
 msgid "You requested to run amuleapi on startup, but the amuleapi binary cannot be run. Please install the package containing aMule's REST API server, or build aMule from source with -DBUILD_AMULEAPI=YES and install it."
 msgstr ""
 
-#: src/amule.cpp:1267
+#: src/amule.cpp:1259
 #, c-format
 msgid "Could not bind ports to the specified address: %s"
 msgstr ""
 
-#: src/amule.cpp:1291
+#: src/amule.cpp:1283
 #, c-format
 msgid "Port %u is not available. You will be LOWID\n"
 msgstr ""
 
-#: src/amule.cpp:1296
+#: src/amule.cpp:1288
 #, c-format
 msgid ""
 "Port %u is not available!\n"
@@ -352,185 +352,185 @@ msgid ""
 "Check your network to make sure the port is open for output and input."
 msgstr ""
 
-#: src/amule.cpp:1393
+#: src/amule.cpp:1385
 msgid "Failed to create OnlineSig File"
 msgstr ""
 
-#: src/amule.cpp:1401
+#: src/amule.cpp:1393
 msgid "Failed to create aMule OnlineSig File"
 msgstr ""
 
-#: src/amule.cpp:1564
+#: src/amule.cpp:1556
 msgid "The selected locale seems not to be installed on your box. (Note: I'll try to set it anyway)"
 msgstr ""
 
-#: src/amule.cpp:1574
+#: src/amule.cpp:1566
 #, c-format
 msgid "This is the first time you run aMule %s"
 msgstr ""
 
-#: src/amule.cpp:1577
+#: src/amule.cpp:1569
 msgid "This version is a testing version, updated daily, and\n"
 msgstr ""
 
-#: src/amule.cpp:1578
+#: src/amule.cpp:1570
 msgid "we give no warranty it won't break anything, burn your house,\n"
 msgstr "Vi giver ikke garanti for at det ikke vil ødelægge noget, brænde dit hus,\n"
 
-#: src/amule.cpp:1579
+#: src/amule.cpp:1571
 msgid "or kill your dog. But it *should* be safe to use anyway.\n"
 msgstr ""
 
-#: src/amule.cpp:1584
+#: src/amule.cpp:1576
 msgid "More information, support and new releases can found at our homepage,\n"
 msgstr ""
 
-#: src/amule.cpp:1585
+#: src/amule.cpp:1577
 msgid "at https://amule-org.github.io, or in our IRC channel #aMule at irc.libera.chat.\n"
 msgstr ""
 
-#: src/amule.cpp:1587
+#: src/amule.cpp:1579
 msgid "Feel free to report any bugs to https://github.com/amule-org/amule/issues"
 msgstr ""
 
-#: src/amule.cpp:1599
+#: src/amule.cpp:1591
 msgid ""
 "The folder for Online Signature files you specified is INVALID!\n"
 " OnlineSignature will be DISABLED until you fix it on preferences."
 msgstr ""
 
-#: src/amule.cpp:1662
+#: src/amule.cpp:1654
 #, fuzzy
 msgid "Server hostname notified"
 msgstr "Servernavn :"
 
-#: src/amule.cpp:2039
+#: src/amule.cpp:2031
 #, c-format
 msgid "Disk space preallocation for file '%s' failed: %s"
 msgstr ""
 
-#: src/amule.cpp:2168
+#: src/amule.cpp:2160
 msgid "ERROR: can't open logfile"
 msgstr "FEJL: Kan ikke åbne logfil"
 
-#: src/amule.cpp:2172
+#: src/amule.cpp:2164
 msgid "WARNING: logfile is empty. Something is wrong."
 msgstr "FARE: logfilen er tom. Noget er galt"
 
-#: src/amule.cpp:2189
+#: src/amule.cpp:2181
 msgid "Log has been reset"
 msgstr "Log nulstillet"
 
-#: src/amule.cpp:2213
+#: src/amule.cpp:2205
 #, c-format
 msgid "ServerMessage: %s"
 msgstr "ServerBesked: %s"
 
-#: src/amule.cpp:2256 src/IP2Country.cpp:220 src/IPFilter.cpp:514
+#: src/amule.cpp:2248 src/IP2Country.cpp:220 src/IPFilter.cpp:514
 #: src/ServerList.cpp:875
 #, c-format
 msgid "Skipped download of %s, because requested file is not newer."
 msgstr ""
 
-#: src/amule.cpp:2259
+#: src/amule.cpp:2251
 msgid "Failed to download the nodes list."
 msgstr "Fejl ved hentning af node listen"
 
-#: src/amule.cpp:2322
+#: src/amule.cpp:2314
 msgid "Failed to open the downloaded version check file"
 msgstr "Fejl ved åbning af den hentet version check filen"
 
-#: src/amule.cpp:2325 src/amule.cpp:2344
+#: src/amule.cpp:2317 src/amule.cpp:2336
 msgid "Corrupted version check file"
 msgstr "Korrupt version check fil"
 
-#: src/amule.cpp:2367
+#: src/amule.cpp:2359
 msgid "You are using an outdated version of aMule!"
 msgstr "Du bruger en forældet version af aMule"
 
-#: src/amule.cpp:2369
+#: src/amule.cpp:2361
 #, c-format
 msgid "Your aMule version is %i.%i.%i and the latest version is %li.%li.%li"
 msgstr "Din aMule version er %i.%i.%i og den sisdte nye version er %li.%li.%li"
 
-#: src/amule.cpp:2373
+#: src/amule.cpp:2365
 msgid "The latest version can always be found at https://github.com/amule-org/amule/releases/latest"
 msgstr "Den sidste nye version kan altid findes hos https://github.com/amule-org/amule/releases/latest"
 
-#: src/amule.cpp:2376
+#: src/amule.cpp:2368
 #, c-format
 msgid "WARNING: Your aMuled version is outdated: %i.%i.%i < %li.%li.%li"
 msgstr "FARE: Din aMule version er forældet: %i.%i.%i < %li.%li.%li"
 
-#: src/amule.cpp:2382
+#: src/amule.cpp:2374
 msgid "Your copy of aMule is up to date."
 msgstr "Din kopi af aMule er op til dato"
 
-#: src/amule.cpp:2389
+#: src/amule.cpp:2381
 msgid "Failed to download the version check file"
 msgstr "Fejl ved hentning af version check filen"
 
-#: src/amule.cpp:2558 src/amule-remote-gui.cpp:1133
+#: src/amule.cpp:2550 src/amule-remote-gui.cpp:1133
 #, c-format
 msgid "Users: %s | Files: %s"
 msgstr ""
 
-#: src/amule.cpp:2559 src/amule-remote-gui.cpp:1134
+#: src/amule.cpp:2551 src/amule-remote-gui.cpp:1134
 #, c-format
 msgid "Users: E: %s K: %s | Files: E: %s K: %s"
 msgstr ""
 
-#: src/amule.cpp:2573 src/amule-remote-gui.cpp:1147
+#: src/amule.cpp:2565 src/amule-remote-gui.cpp:1147
 msgid "No networks selected"
 msgstr ""
 
-#: src/amule.cpp:2641 src/TextClient.cpp:903
+#: src/amule.cpp:2633 src/TextClient.cpp:903
 msgid "with LowID"
 msgstr ""
 
-#: src/amule.cpp:2641 src/TextClient.cpp:904
+#: src/amule.cpp:2633 src/TextClient.cpp:904
 msgid "with HighID"
 msgstr ""
 
-#: src/amule.cpp:2643
+#: src/amule.cpp:2635
 #, c-format
 msgid "Connected to %s %s"
 msgstr "Forbundet til %s %s"
 
-#: src/amule.cpp:2648
+#: src/amule.cpp:2640
 #, c-format
 msgid "Connecting to %s"
 msgstr "Forbundet til %s"
 
-#: src/amule.cpp:2650
+#: src/amule.cpp:2642
 msgid "Disconnected from eD2k"
 msgstr ""
 
-#: src/amule.cpp:2659
+#: src/amule.cpp:2651
 msgid "Kad started."
 msgstr "Kad startet."
 
-#: src/amule.cpp:2661
+#: src/amule.cpp:2653
 msgid "Kad stopped."
 msgstr "Kad stoppet."
 
-#: src/amule.cpp:2669
+#: src/amule.cpp:2661
 msgid "Connected to Kad (ok)"
 msgstr "Forbundet til Kad (ok)"
 
-#: src/amule.cpp:2671
+#: src/amule.cpp:2663
 msgid "Connected to Kad (firewalled)"
 msgstr "Forbundet til Kad (med firewall)"
 
-#: src/amule.cpp:2675
+#: src/amule.cpp:2667
 msgid "Disconnected from Kad"
 msgstr "Afbrudt fra Kad"
 
-#: src/amule.cpp:2707
+#: src/amule.cpp:2699
 msgid "Kad network cannot be used if UDP port is disabled on preferences, not starting."
 msgstr "Kad netværk kan ikke bruges hvis UDP port er fravalgt i instillinger, starter ikke."
 
-#: src/amule.cpp:2711
+#: src/amule.cpp:2703
 msgid "Kad network disabled on preferences, not connecting."
 msgstr "Kad netværk fravalgt i instillinger, forbinder ikke."
 
@@ -555,68 +555,30 @@ msgstr ""
 msgid "ERROR: %s"
 msgstr ""
 
-#: src/amuleDlg.cpp:250
+#: src/amuleDlg.cpp:236
 #, c-format
 msgid "This is aMule %s based on eMule."
 msgstr ""
 
-#: src/amuleDlg.cpp:251
+#: src/amuleDlg.cpp:237
 #, c-format
 msgid "Running on %s"
 msgstr ""
 
-#: src/amuleDlg.cpp:253
+#: src/amuleDlg.cpp:239
 msgid "Visit https://github.com/amule-org/amule/releases/latest to check if a new version is available."
 msgstr ""
 
-#: src/amuleDlg.cpp:282
+#: src/amuleDlg.cpp:268
 msgid "FATAL ERROR: Failed to create Timer"
 msgstr ""
 
-#: src/amuleDlg.cpp:361 src/amuleDlg.cpp:1810 src/amuleDlg.cpp:2056
-#: src/muuli_wdr.cpp:1492 src/muuli_wdr.cpp:3439
-msgid "Networks"
-msgstr ""
-
-#: src/amuleDlg.cpp:362 src/amuleDlg.cpp:1816 src/muuli_wdr.cpp:3440
-msgid "Searches"
-msgstr "Søg"
-
-#: src/amuleDlg.cpp:363 src/amuleDlg.cpp:1822 src/DownloadListCtrl.cpp:740
-#: src/muuli_wdr.cpp:392 src/muuli_wdr.cpp:1585 src/muuli_wdr.cpp:3441
-#: src/Statistics.cpp:829
-msgid "Downloads"
-msgstr "Downloads"
-
-#: src/amuleDlg.cpp:364 src/amuleDlg.cpp:1828 src/muuli_wdr.cpp:3315
-msgid "Shared files"
-msgstr ""
-
-#: src/amuleDlg.cpp:365 src/amuleDlg.cpp:1834 src/muuli_wdr.cpp:2947
-#: src/muuli_wdr.cpp:3397 src/muuli_wdr.cpp:3444
-msgid "Messages"
-msgstr "Beskeder"
-
-#: src/amuleDlg.cpp:366 src/amuleDlg.cpp:1840 src/muuli_wdr.cpp:3445
-#: src/PrefsUnifiedDlg.cpp:314 src/Statistics.cpp:779 src/Statistics.cpp:1235
-msgid "Statistics"
-msgstr "Statistik"
-
-#: src/amuleDlg.cpp:368 src/amuleDlg.cpp:1847 src/muuli_wdr.cpp:3447
-#: src/PrefsUnifiedDlg.cpp:330 src/utils/wxCas/src/wxcasprefs.cpp:39
-msgid "Preferences"
-msgstr "Indstillinger"
-
-#: src/amuleDlg.cpp:371
-msgid "Navigate"
-msgstr ""
-
-#: src/amuleDlg.cpp:657
+#: src/amuleDlg.cpp:592
 #, fuzzy
 msgid "New version available"
 msgstr "Ikke tilgængelig"
 
-#: src/amuleDlg.cpp:661
+#: src/amuleDlg.cpp:596
 #, fuzzy, c-format
 msgid ""
 "A new version of aMule (%s) is available.\n"
@@ -626,191 +588,224 @@ msgid ""
 "Would you like to open the download page?"
 msgstr "Den sidste nye version kan altid findes hos https://github.com/amule-org/amule/releases/latest"
 
-#: src/amuleDlg.cpp:743
+#: src/amuleDlg.cpp:678
 msgid "aMule dialog destroyed"
 msgstr ""
 
-#: src/amuleDlg.cpp:766 src/DataToText.cpp:68 src/IPFilter.cpp:547
+#: src/amuleDlg.cpp:701 src/DataToText.cpp:68 src/IPFilter.cpp:547
 msgid "Connecting"
 msgstr "Forbinder"
 
-#: src/amuleDlg.cpp:958
+#: src/amuleDlg.cpp:893
 msgid "eD2k: Connecting"
 msgstr ""
 
-#: src/amuleDlg.cpp:962
+#: src/amuleDlg.cpp:897
 msgid "eD2k: Disconnected"
 msgstr ""
 
-#: src/amuleDlg.cpp:968
+#: src/amuleDlg.cpp:903
 #, fuzzy
 msgid "Kad: Firewalled"
 msgstr "firewalled"
 
-#: src/amuleDlg.cpp:972
+#: src/amuleDlg.cpp:907
 #, fuzzy
 msgid "Kad: Connected"
 msgstr "Forbundet"
 
-#: src/amuleDlg.cpp:977
+#: src/amuleDlg.cpp:912
 #, fuzzy
 msgid "Kad: Connecting"
 msgstr "Forbinder"
 
-#: src/amuleDlg.cpp:981
+#: src/amuleDlg.cpp:916
 #, fuzzy
 msgid "Kad: Off"
 msgstr " Kad: "
 
-#: src/amuleDlg.cpp:1029 src/DownloadListCtrl.cpp:505
+#: src/amuleDlg.cpp:964 src/DownloadListCtrl.cpp:505
 #: src/DownloadListCtrl.cpp:749 src/FriendListCtrl.cpp:180
 #: src/muuli_wdr.cpp:731 src/muuli_wdr.cpp:782 src/muuli_wdr.cpp:846
-#: src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2252 src/muuli_wdr.cpp:2337
-#: src/muuli_wdr.cpp:3085 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
+#: src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2224 src/muuli_wdr.cpp:2309
+#: src/muuli_wdr.cpp:3057 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
 #: src/ServerListCtrl.cpp:606 src/TransferWnd.cpp:378
 #: src/utils/wxCas/src/wxcasprefs.cpp:235
 msgid "Cancel"
 msgstr "Afbryd"
 
-#: src/amuleDlg.cpp:1030
+#: src/amuleDlg.cpp:965
 #, fuzzy
 msgid "Stop the current connection attempts"
 msgstr "Stop de nuværende forbindelses forsøg"
 
-#: src/amuleDlg.cpp:1035 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976
-#: src/muuli_wdr.cpp:2475
+#: src/amuleDlg.cpp:970 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976
+#: src/muuli_wdr.cpp:2447
 msgid "Disconnect"
 msgstr "Afbryd"
 
-#: src/amuleDlg.cpp:1036
+#: src/amuleDlg.cpp:971
 #, fuzzy
 msgid "Disconnect from the currently connected networks"
 msgstr "Afbryd fra nuvÃŠrende server"
 
-#: src/amuleDlg.cpp:1041 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979
-#: src/muuli_wdr.cpp:2630 src/muuli_wdr.cpp:3082 src/muuli_wdr.cpp:3437
+#: src/amuleDlg.cpp:976 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979
+#: src/muuli_wdr.cpp:2602 src/muuli_wdr.cpp:3054 src/muuli_wdr.cpp:3409
 msgid "Connect"
 msgstr "Forbind"
 
-#: src/amuleDlg.cpp:1042
+#: src/amuleDlg.cpp:977
 msgid "Connect to the currently enabled networks"
 msgstr ""
 
-#: src/amuleDlg.cpp:1154
+#: src/amuleDlg.cpp:1089
 #, fuzzy, c-format
 msgid "Up: %.1f%s (%.1f) | Down: %.1f%s (%.1f)"
 msgstr "Up: %.1f(%.1f) | Down: %.1f(%.1f)"
 
-#: src/amuleDlg.cpp:1156 src/amuleDlg.cpp:1158 src/amuleDlg.cpp:1162
-#: src/amuleDlg.cpp:1164 src/amuleDlg.cpp:1175 src/amuleDlg.cpp:1177
+#: src/amuleDlg.cpp:1091 src/amuleDlg.cpp:1093 src/amuleDlg.cpp:1097
+#: src/amuleDlg.cpp:1099 src/amuleDlg.cpp:1110 src/amuleDlg.cpp:1112
 #: src/MuleTrayIcon.cpp:796 src/MuleTrayIcon.cpp:799
 msgid " MB/s"
 msgstr ""
 
-#: src/amuleDlg.cpp:1156 src/amuleDlg.cpp:1158 src/amuleDlg.cpp:1162
-#: src/amuleDlg.cpp:1164 src/amuleDlg.cpp:1175 src/amuleDlg.cpp:1177
+#: src/amuleDlg.cpp:1091 src/amuleDlg.cpp:1093 src/amuleDlg.cpp:1097
+#: src/amuleDlg.cpp:1099 src/amuleDlg.cpp:1110 src/amuleDlg.cpp:1112
 #: src/MuleTrayIcon.cpp:796 src/MuleTrayIcon.cpp:799
 #: src/utils/wxCas/src/wxcasframe.cpp:1041
 msgid " kB/s"
 msgstr " kB/s"
 
-#: src/amuleDlg.cpp:1161
+#: src/amuleDlg.cpp:1096
 #, fuzzy, c-format
 msgid "Up: %.1f%s | Down: %.1f%s"
 msgstr "Op: %.1f | Ned: %.1f"
 
-#: src/amuleDlg.cpp:1193
+#: src/amuleDlg.cpp:1128
 #, c-format
 msgid "aMule (%s | Connected)"
 msgstr ""
 
-#: src/amuleDlg.cpp:1195
+#: src/amuleDlg.cpp:1130
 #, c-format
 msgid "aMule (%s | Disconnected)"
 msgstr ""
 
-#: src/amuleDlg.cpp:1248
+#: src/amuleDlg.cpp:1183
 #, fuzzy, c-format
 msgid "Do you really want to exit %s?"
 msgstr "Vil du virkelig afslutte aMule?"
 
-#: src/amuleDlg.cpp:1250
+#: src/amuleDlg.cpp:1185
 msgid "Exit confirmation"
 msgstr "Bekræft afslut"
 
-#: src/amuleDlg.cpp:1613
+#: src/amuleDlg.cpp:1548
 msgid "Launch Command: "
 msgstr ""
 
-#: src/amuleDlg.cpp:1632 src/muuli_wdr.cpp:1972 src/Preferences.cpp:979
+#: src/amuleDlg.cpp:1567 src/muuli_wdr.cpp:1971 src/Preferences.cpp:951
 msgid "- default -"
 msgstr ""
 
-#: src/amuleDlg.cpp:1660
+#: src/amuleDlg.cpp:1595
 #, c-format
 msgid "Skin directory '%s' does not exist"
 msgstr ""
 
-#: src/amuleDlg.cpp:1663
+#: src/amuleDlg.cpp:1598
 #, c-format
 msgid "WARNING: Unable to open skin file '%s' for read"
 msgstr ""
 
-#: src/amuleDlg.cpp:1814 src/muuli_wdr.cpp:3439
+#: src/amuleDlg.cpp:1722 src/amuleDlg.cpp:1968 src/muuli_wdr.cpp:1485
+#: src/muuli_wdr.cpp:3411
+msgid "Networks"
+msgstr ""
+
+#: src/amuleDlg.cpp:1726 src/muuli_wdr.cpp:3411
 msgid "Networks Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1820 src/muuli_wdr.cpp:3440
+#: src/amuleDlg.cpp:1728 src/muuli_wdr.cpp:3412
+msgid "Searches"
+msgstr "Søg"
+
+#: src/amuleDlg.cpp:1732 src/muuli_wdr.cpp:3412
 msgid "Searches Window"
 msgstr "Søge Vindue"
 
-#: src/amuleDlg.cpp:1826 src/muuli_wdr.cpp:3441
+#: src/amuleDlg.cpp:1734 src/DownloadListCtrl.cpp:740 src/muuli_wdr.cpp:392
+#: src/muuli_wdr.cpp:1578 src/muuli_wdr.cpp:3413 src/Statistics.cpp:829
+msgid "Downloads"
+msgstr "Downloads"
+
+#: src/amuleDlg.cpp:1738 src/muuli_wdr.cpp:3413
 #, fuzzy
 msgid "Downloads Window"
 msgstr "Henter"
 
-#: src/amuleDlg.cpp:1832 src/muuli_wdr.cpp:3443
+#: src/amuleDlg.cpp:1740 src/muuli_wdr.cpp:3287
+msgid "Shared files"
+msgstr ""
+
+#: src/amuleDlg.cpp:1744 src/muuli_wdr.cpp:3415
 msgid "Shared Files Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3444
+#: src/amuleDlg.cpp:1746 src/muuli_wdr.cpp:2919 src/muuli_wdr.cpp:3369
+#: src/muuli_wdr.cpp:3416
+msgid "Messages"
+msgstr "Beskeder"
+
+#: src/amuleDlg.cpp:1750 src/muuli_wdr.cpp:3416
 msgid "Messages Window"
 msgstr "Besked Vindue"
 
-#: src/amuleDlg.cpp:1844 src/muuli_wdr.cpp:3445
+#: src/amuleDlg.cpp:1752 src/muuli_wdr.cpp:3417 src/PrefsUnifiedDlg.cpp:312
+#: src/Statistics.cpp:779 src/Statistics.cpp:1235
+msgid "Statistics"
+msgstr "Statistik"
+
+#: src/amuleDlg.cpp:1756 src/muuli_wdr.cpp:3417
 msgid "Statistics Graph Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1851 src/muuli_wdr.cpp:3447
+#: src/amuleDlg.cpp:1759 src/muuli_wdr.cpp:3419 src/PrefsUnifiedDlg.cpp:328
+#: src/utils/wxCas/src/wxcasprefs.cpp:39
+msgid "Preferences"
+msgstr "Indstillinger"
+
+#: src/amuleDlg.cpp:1763 src/muuli_wdr.cpp:3419
 msgid "Preferences Settings Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1854 src/muuli_wdr.cpp:3448
+#: src/amuleDlg.cpp:1766 src/muuli_wdr.cpp:3420
 msgid "Import"
 msgstr ""
 
-#: src/amuleDlg.cpp:1858 src/muuli_wdr.cpp:3448
+#: src/amuleDlg.cpp:1770 src/muuli_wdr.cpp:3420
 msgid "The partfile importer tool"
 msgstr ""
 
-#: src/amuleDlg.cpp:1861 src/muuli_wdr.cpp:3449
+#: src/amuleDlg.cpp:1773 src/muuli_wdr.cpp:3421
 #: src/utils/aLinkCreator/src/alcframe.cpp:262
 msgid "About"
 msgstr ""
 
-#: src/amuleDlg.cpp:1861 src/muuli_wdr.cpp:3449
+#: src/amuleDlg.cpp:1773 src/muuli_wdr.cpp:3421
 msgid "About/Help"
 msgstr ""
 
-#: src/amuleDlg.cpp:2059
+#: src/amuleDlg.cpp:1971
 msgid "eD2k network"
 msgstr ""
 
-#: src/amuleDlg.cpp:2062
+#: src/amuleDlg.cpp:1974
 msgid "Kad network"
 msgstr ""
 
-#: src/amuleDlg.cpp:2062
+#: src/amuleDlg.cpp:1974
 msgid "No network"
 msgstr ""
 
@@ -942,7 +937,7 @@ msgstr "Ingen part filer fundet"
 msgid "The core rejected these shared folders:%s"
 msgstr ""
 
-#: src/amule-remote-gui.cpp:1336 src/ExternalConn.cpp:2346
+#: src/amule-remote-gui.cpp:1336 src/ExternalConn.cpp:2345
 msgid "Invalid link or already on list."
 msgstr ""
 
@@ -958,7 +953,7 @@ msgstr ""
 #: src/ClientDetailDialog.cpp:123 src/DataToText.cpp:61 src/DataToText.cpp:86
 #: src/DataToText.cpp:101 src/DataToText.cpp:136 src/DataToText.cpp:165
 #: src/DownloadListCtrl.cpp:1172 src/DownloadListCtrl.cpp:1185
-#: src/DownloadListCtrl.cpp:1196 src/ExternalConn.cpp:609
+#: src/DownloadListCtrl.cpp:1196 src/ExternalConn.cpp:608
 #: src/FileDetailDialog.cpp:203 src/FileDetailDialog.cpp:235
 #: src/FileDetailDialog.cpp:242 src/GenericClientListCtrl.cpp:1171
 #: src/GenericClientListCtrl.cpp:1182 src/GenericClientListCtrl.cpp:1192
@@ -1346,19 +1341,19 @@ msgstr "Auto [Hø]"
 msgid "Very low"
 msgstr "Meget lav"
 
-#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:743 src/muuli_wdr.cpp:2303
+#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:743 src/muuli_wdr.cpp:2275
 #: src/ServerListCtrl.cpp:263 src/ServerListCtrl.cpp:456
 #: src/SharedFilesCtrl.cpp:145
 msgid "Low"
 msgstr "Lav"
 
-#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:744 src/muuli_wdr.cpp:2304
+#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:744 src/muuli_wdr.cpp:2276
 #: src/ServerListCtrl.cpp:266 src/ServerListCtrl.cpp:457
 #: src/SharedFilesCtrl.cpp:146
 msgid "Normal"
 msgstr "Normal"
 
-#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:745 src/muuli_wdr.cpp:2305
+#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:745 src/muuli_wdr.cpp:2277
 #: src/ServerListCtrl.cpp:269 src/ServerListCtrl.cpp:458
 #: src/SharedFilesCtrl.cpp:147
 msgid "High"
@@ -1450,8 +1445,8 @@ msgstr ""
 msgid "Remote Server"
 msgstr ""
 
-#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3202
-#: src/SearchDlg.cpp:119 src/TextClient.cpp:911
+#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3174
+#: src/SearchDlg.cpp:111 src/TextClient.cpp:911
 msgid "Kad"
 msgstr ""
 
@@ -1521,7 +1516,7 @@ msgstr ""
 msgid "Size"
 msgstr "Størrelse"
 
-#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3269
+#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3241
 msgid "Transferred"
 msgstr "Overført"
 
@@ -1579,7 +1574,7 @@ msgid ""
 "\n"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:746 src/muuli_wdr.cpp:2306
+#: src/DownloadListCtrl.cpp:746 src/muuli_wdr.cpp:2278
 #: src/SharedFilesCtrl.cpp:150
 msgid "Auto"
 msgstr "Auto"
@@ -1617,7 +1612,7 @@ msgid "Extended Options"
 msgstr "Udvidet Muligheder"
 
 #: src/DownloadListCtrl.cpp:770 src/DownloadListCtrl.cpp:822
-#: src/muuli_wdr.cpp:1790
+#: src/muuli_wdr.cpp:1789
 msgid "Preview"
 msgstr "Smug Kig"
 
@@ -1790,232 +1785,227 @@ msgstr[1] ""
 msgid "Invalid eD2k link! ERROR: %s"
 msgstr ""
 
-#: src/ExternalConn.cpp:380
+#: src/ExternalConn.cpp:379
 msgid "Client sent packet after authentication failed."
 msgstr ""
 
-#: src/ExternalConn.cpp:397
+#: src/ExternalConn.cpp:396
 msgid "External connection closed."
 msgstr ""
 
-#: src/ExternalConn.cpp:474
+#: src/ExternalConn.cpp:473
 msgid "External connections disabled due to empty password!"
 msgstr ""
 
-#: src/ExternalConn.cpp:495
+#: src/ExternalConn.cpp:494
 msgid "External connections disabled in config file"
 msgstr ""
 
-#: src/ExternalConn.cpp:576
+#: src/ExternalConn.cpp:575
 msgid "New external connection accepted"
 msgstr ""
 
-#: src/ExternalConn.cpp:579
+#: src/ExternalConn.cpp:578
 msgid "ERROR: couldn't accept a new external connection"
 msgstr ""
 
-#: src/ExternalConn.cpp:596
+#: src/ExternalConn.cpp:595
 msgid "External connection refused due to empty password in preferences!"
 msgstr ""
 
-#: src/ExternalConn.cpp:608
+#: src/ExternalConn.cpp:607
 #, c-format
 msgid "Connecting client: %s %s"
 msgstr ""
 
-#: src/ExternalConn.cpp:610
+#: src/ExternalConn.cpp:609
 msgid "Unknown version"
 msgstr ""
 
-#: src/ExternalConn.cpp:623
+#: src/ExternalConn.cpp:622
 msgid "Incorrect EC version ID, there might be binary incompatibility. Use core and remote from same snapshot."
 msgstr ""
 
-#: src/ExternalConn.cpp:631
+#: src/ExternalConn.cpp:630
 msgid "You cannot connect to a release version from an arbitrary development snapshot! *sigh* possible crash prevented"
 msgstr ""
 
-#: src/ExternalConn.cpp:714
+#: src/ExternalConn.cpp:713
 msgid "Invalid protocol version."
 msgstr ""
 
-#: src/ExternalConn.cpp:720
+#: src/ExternalConn.cpp:719
 msgid "Missing protocol version tag."
 msgstr ""
 
-#: src/ExternalConn.cpp:728
+#: src/ExternalConn.cpp:727
 msgid "Authentication failed: invalid hash specified as EC password."
 msgstr ""
 
-#: src/ExternalConn.cpp:776
+#: src/ExternalConn.cpp:775
 msgid "Authentication failed: wrong password."
 msgstr ""
 
-#: src/ExternalConn.cpp:778
+#: src/ExternalConn.cpp:777
 msgid "Authentication failed: missing password."
 msgstr ""
 
-#: src/ExternalConn.cpp:789
+#: src/ExternalConn.cpp:788
 msgid "Invalid request, please authenticate first."
 msgstr ""
 
-#: src/ExternalConn.cpp:794
+#: src/ExternalConn.cpp:793
 msgid "Access granted."
 msgstr ""
 
-#: src/ExternalConn.cpp:802
+#: src/ExternalConn.cpp:801
 #, c-format
 msgid "Sent error message \"%s\" to client."
 msgstr ""
 
-#: src/ExternalConn.cpp:807
+#: src/ExternalConn.cpp:806
 #, c-format
 msgid "Unauthorized access attempt from %s. Connection closed."
 msgstr ""
 
-#: src/ExternalConn.cpp:1420
+#: src/ExternalConn.cpp:1419
 #, c-format
 msgid "Remote PartFile command failed: FileHash not found: %s"
 msgstr ""
 
-#: src/ExternalConn.cpp:1424
+#: src/ExternalConn.cpp:1423
 #, c-format
 msgid "FileHash not found: %s"
 msgstr ""
 
-#: src/ExternalConn.cpp:1471 src/ExternalConn.cpp:1559
-#: src/ExternalConn.cpp:1680
+#: src/ExternalConn.cpp:1470 src/ExternalConn.cpp:1558
+#: src/ExternalConn.cpp:1679
 msgid "OOPS! OpCode processing error!"
 msgstr ""
 
-#: src/ExternalConn.cpp:1502
+#: src/ExternalConn.cpp:1501
 msgid "Server not added"
 msgstr ""
 
-#: src/ExternalConn.cpp:1521
+#: src/ExternalConn.cpp:1520
 #, c-format
 msgid "server not found: %s"
 msgstr ""
 
-#: src/ExternalConn.cpp:1538
+#: src/ExternalConn.cpp:1537
 msgid "need to define server to be removed"
 msgstr ""
 
-#: src/ExternalConn.cpp:1553
+#: src/ExternalConn.cpp:1552
 msgid "eD2k is disabled in preferences."
 msgstr ""
 
-#: src/ExternalConn.cpp:1658
+#: src/ExternalConn.cpp:1657
 #, fuzzy
 msgid "Friend not found."
 msgstr "Index fil ikke fundet: "
 
-#: src/ExternalConn.cpp:1668
+#: src/ExternalConn.cpp:1667
 #, fuzzy
 msgid "Client not found."
 msgstr "Index fil ikke fundet: "
 
-#: src/ExternalConn.cpp:1674
+#: src/ExternalConn.cpp:1673
 msgid "EC_TAG_FRIEND_SHARED requires EC_TAG_FRIEND or EC_TAG_CLIENT."
 msgstr ""
 
-#: src/ExternalConn.cpp:1992
+#: src/ExternalConn.cpp:1991
 msgid "WebSearch from remote interface makes no sense."
 msgstr ""
 
-#: src/ExternalConn.cpp:2027
+#: src/ExternalConn.cpp:2026
 msgid "Search in progress. Refetch results in a moment!"
 msgstr ""
 
-#: src/ExternalConn.cpp:2266
+#: src/ExternalConn.cpp:2265
 msgid "No points for graph."
 msgstr ""
 
-#: src/ExternalConn.cpp:2276
+#: src/ExternalConn.cpp:2275
 msgid "Your client is not configured for this detail level."
 msgstr ""
 
-#: src/ExternalConn.cpp:2303
+#: src/ExternalConn.cpp:2302
 msgid "External Connection: shutdown requested"
 msgstr ""
 
-#: src/ExternalConn.cpp:2315
+#: src/ExternalConn.cpp:2314
 msgid "Already shutting down."
 msgstr ""
 
-#: src/ExternalConn.cpp:2333
+#: src/ExternalConn.cpp:2332
 #, c-format
 msgid "ExternalConn: adding link '%s'."
 msgstr ""
 
-#: src/ExternalConn.cpp:2351
+#: src/ExternalConn.cpp:2350
 #, c-format
 msgid "%d of %d links failed (invalid or already on list)."
 msgstr ""
 
-#: src/ExternalConn.cpp:2374
+#: src/ExternalConn.cpp:2373
 msgid "Version check throttled; try again shortly."
 msgstr ""
 
-#: src/ExternalConn.cpp:2379
+#: src/ExternalConn.cpp:2378
 msgid "Version check is not available on this daemon."
 msgstr ""
 
-#: src/ExternalConn.cpp:2509
+#: src/ExternalConn.cpp:2508
 msgid "File not found."
 msgstr ""
 
-#: src/ExternalConn.cpp:2514
+#: src/ExternalConn.cpp:2513
 msgid "Invalid file name."
 msgstr ""
 
-#: src/ExternalConn.cpp:2522
+#: src/ExternalConn.cpp:2521
 msgid "Unable to rename file."
 msgstr ""
 
-#: src/ExternalConn.cpp:2839
-#, c-format
-msgid "Could not save the amuleapi password: %s"
-msgstr ""
-
-#: src/ExternalConn.cpp:3004 src/ExternalConn.cpp:3032
+#: src/ExternalConn.cpp:2992 src/ExternalConn.cpp:3020
 msgid "Kad is disabled in preferences."
 msgstr ""
 
-#: src/ExternalConn.cpp:3045
+#: src/ExternalConn.cpp:3033
 msgid "Already connected to eD2k."
 msgstr ""
 
-#: src/ExternalConn.cpp:3048
+#: src/ExternalConn.cpp:3036
 msgid "Connecting to eD2k..."
 msgstr ""
 
-#: src/ExternalConn.cpp:3057
+#: src/ExternalConn.cpp:3045
 msgid "Already connected to Kad."
 msgstr ""
 
-#: src/ExternalConn.cpp:3060
+#: src/ExternalConn.cpp:3048
 msgid "Connecting to Kad..."
 msgstr ""
 
-#: src/ExternalConn.cpp:3067
+#: src/ExternalConn.cpp:3055
 msgid "All networks are disabled."
 msgstr ""
 
-#: src/ExternalConn.cpp:3076
+#: src/ExternalConn.cpp:3064
 msgid "Disconnected from eD2k."
 msgstr ""
 
-#: src/ExternalConn.cpp:3081
+#: src/ExternalConn.cpp:3069
 msgid "Disconnected from Kad."
 msgstr ""
 
-#: src/ExternalConn.cpp:3090
+#: src/ExternalConn.cpp:3078
 #, c-format
 msgid "External Connection: invalid opcode received: %#x"
 msgstr ""
 
-#: src/ExternalConn.cpp:3095
+#: src/ExternalConn.cpp:3083
 msgid "Invalid opcode (wrong protocol version?)"
 msgstr ""
 
@@ -2305,19 +2295,19 @@ msgstr ""
 msgid "eD2k"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:349 src/muuli_wdr.cpp:1495
+#: src/FirstRunWizard.cpp:349 src/muuli_wdr.cpp:1488
 msgid "Kademlia"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:359 src/muuli_wdr.cpp:1423
+#: src/FirstRunWizard.cpp:359 src/muuli_wdr.cpp:1416
 msgid "Standard TCP Port "
 msgstr ""
 
-#: src/FirstRunWizard.cpp:365 src/muuli_wdr.cpp:1435
+#: src/FirstRunWizard.cpp:365 src/muuli_wdr.cpp:1428
 msgid "Extended UDP port (Kad / global search) "
 msgstr ""
 
-#: src/FirstRunWizard.cpp:377 src/muuli_wdr.cpp:1442
+#: src/FirstRunWizard.cpp:377 src/muuli_wdr.cpp:1435
 msgid "Enable UPnP for router port forwarding"
 msgstr ""
 
@@ -2343,7 +2333,7 @@ msgstr ""
 msgid "Your peer lists are already in place - nothing to download."
 msgstr "Du prøver allerede at downloade denne fil %s"
 
-#: src/FirstRunWizard.cpp:434 src/muuli_wdr.cpp:1540
+#: src/FirstRunWizard.cpp:434 src/muuli_wdr.cpp:1533
 msgid "Auto-update server list at startup"
 msgstr ""
 
@@ -2389,23 +2379,23 @@ msgid ""
 "want downloads on a different (e.g. larger) disk."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:549 src/FirstRunWizard.cpp:611 src/muuli_wdr.cpp:1702
+#: src/FirstRunWizard.cpp:549 src/FirstRunWizard.cpp:611 src/muuli_wdr.cpp:1701
 msgid "Destination folder for downloads"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:553 src/FirstRunWizard.cpp:569 src/muuli_wdr.cpp:1349
-#: src/muuli_wdr.cpp:1366 src/muuli_wdr.cpp:1677 src/muuli_wdr.cpp:1708
-#: src/muuli_wdr.cpp:1720 src/muuli_wdr.cpp:2790
+#: src/FirstRunWizard.cpp:553 src/FirstRunWizard.cpp:569 src/muuli_wdr.cpp:1342
+#: src/muuli_wdr.cpp:1359 src/muuli_wdr.cpp:1676 src/muuli_wdr.cpp:1707
+#: src/muuli_wdr.cpp:1719 src/muuli_wdr.cpp:2762
 #: src/utils/aLinkCreator/src/alcframe.cpp:135
 #: src/utils/wxCas/src/wxcasprefs.cpp:52 src/utils/wxCas/src/wxcasprefs.cpp:118
 msgid "Browse"
 msgstr "Gennemse"
 
-#: src/FirstRunWizard.cpp:559 src/muuli_wdr.cpp:1713
+#: src/FirstRunWizard.cpp:559 src/muuli_wdr.cpp:1712
 msgid "(All files in this folder are shared with other peers)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:565 src/FirstRunWizard.cpp:624 src/muuli_wdr.cpp:1715
+#: src/FirstRunWizard.cpp:565 src/FirstRunWizard.cpp:624 src/muuli_wdr.cpp:1714
 msgid "Folder for temporary download files"
 msgstr ""
 
@@ -2436,7 +2426,7 @@ msgstr ""
 msgid "CRITICAL - no client on StartChatSession"
 msgstr ""
 
-#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2696 src/muuli_wdr.cpp:3373
+#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2668 src/muuli_wdr.cpp:3345
 msgid "Friends"
 msgstr "Venner"
 
@@ -2547,8 +2537,8 @@ msgstr "Ingen"
 msgid "No"
 msgstr "Nej"
 
-#: src/GenericClientListCtrl.cpp:1216 src/PrefsUnifiedDlg.cpp:2898
-#: src/PrefsUnifiedDlg.cpp:2948 src/ServerListCtrl.cpp:276
+#: src/GenericClientListCtrl.cpp:1216 src/PrefsUnifiedDlg.cpp:2818
+#: src/PrefsUnifiedDlg.cpp:2868 src/ServerListCtrl.cpp:276
 msgid "Yes"
 msgstr "Ja"
 
@@ -2716,10 +2706,10 @@ msgstr ""
 msgid "Please fill all fields required"
 msgstr ""
 
-#: src/KadDlg.cpp:192 src/PartFile.cpp:1031 src/PrefsUnifiedDlg.cpp:1134
-#: src/PrefsUnifiedDlg.cpp:1204 src/PrefsUnifiedDlg.cpp:1405
-#: src/PrefsUnifiedDlg.cpp:1663 src/PrefsUnifiedDlg.cpp:1673
-#: src/PrefsUnifiedDlg.cpp:1690 src/PrefsUnifiedDlg.cpp:1738
+#: src/KadDlg.cpp:192 src/PartFile.cpp:1031 src/PrefsUnifiedDlg.cpp:1162
+#: src/PrefsUnifiedDlg.cpp:1331 src/PrefsUnifiedDlg.cpp:1589
+#: src/PrefsUnifiedDlg.cpp:1599 src/PrefsUnifiedDlg.cpp:1616
+#: src/PrefsUnifiedDlg.cpp:1658
 msgid "Message"
 msgstr ""
 
@@ -2821,7 +2811,7 @@ msgstr ""
 msgid "Uploaded"
 msgstr ""
 
-#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3253
+#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3225
 msgid "Requested"
 msgstr ""
 
@@ -2947,7 +2937,7 @@ msgid "WARNING: "
 msgstr ""
 
 #: src/MuleNotebook.cpp:179 src/muuli_wdr.cpp:817 src/muuli_wdr.cpp:1229
-#: src/muuli_wdr.cpp:3157 src/muuli_wdr.cpp:3413
+#: src/muuli_wdr.cpp:3129 src/muuli_wdr.cpp:3385
 msgid "Close"
 msgstr "Luk"
 
@@ -2960,12 +2950,12 @@ msgstr ""
 msgid "Copy"
 msgstr ""
 
-#: src/MuleTextCtrl.cpp:88 src/SearchDlg.cpp:261
+#: src/MuleTextCtrl.cpp:88
 msgid "Paste"
 msgstr ""
 
 #: src/MuleTextCtrl.cpp:89 src/muuli_wdr.cpp:358 src/muuli_wdr.cpp:757
-#: src/muuli_wdr.cpp:2380 src/muuli_wdr.cpp:2399 src/muuli_wdr.cpp:2421
+#: src/muuli_wdr.cpp:2352 src/muuli_wdr.cpp:2371 src/muuli_wdr.cpp:2393
 #: src/utils/aLinkCreator/src/alcframe.cpp:142
 msgid "Clear"
 msgstr "Ryd"
@@ -3062,8 +3052,8 @@ msgid "Exit"
 msgstr "Afslut"
 
 #: src/MuleTrayIcon.cpp:579 src/MuleTrayIcon.cpp:945 src/MuleTrayIcon.cpp:965
-#: src/muuli_wdr.cpp:1398 src/muuli_wdr.cpp:1406 src/muuli_wdr.cpp:1413
-#: src/muuli_wdr.cpp:1836 src/muuli_wdr.cpp:1842 src/OtherFunctions.cpp:91
+#: src/muuli_wdr.cpp:1391 src/muuli_wdr.cpp:1399 src/muuli_wdr.cpp:1406
+#: src/muuli_wdr.cpp:1835 src/muuli_wdr.cpp:1841 src/OtherFunctions.cpp:91
 #: src/StatisticsDlg.cpp:93 src/StatisticsDlg.cpp:95
 msgid "kB/s"
 msgstr "kB/s"
@@ -3233,7 +3223,7 @@ msgstr ""
 msgid "Type"
 msgstr "Type"
 
-#: src/muuli_wdr.cpp:215 src/SearchDlg.cpp:118 src/SearchListCtrl.cpp:853
+#: src/muuli_wdr.cpp:215 src/SearchDlg.cpp:110 src/SearchListCtrl.cpp:853
 msgid "Local"
 msgstr ""
 
@@ -3304,7 +3294,7 @@ msgstr "Bytes"
 msgid "KB"
 msgstr "KB"
 
-#: src/muuli_wdr.cpp:274 src/muuli_wdr.cpp:293 src/muuli_wdr.cpp:1621
+#: src/muuli_wdr.cpp:274 src/muuli_wdr.cpp:293 src/muuli_wdr.cpp:1620
 #: src/OtherFunctions.cpp:64
 msgid "MB"
 msgstr "MB"
@@ -3321,7 +3311,7 @@ msgstr "Max Størrelse"
 msgid "Availability"
 msgstr ""
 
-#: src/muuli_wdr.cpp:312 src/muuli_wdr.cpp:398 src/muuli_wdr.cpp:3318
+#: src/muuli_wdr.cpp:312 src/muuli_wdr.cpp:398 src/muuli_wdr.cpp:3290
 msgid "Filter:"
 msgstr ""
 
@@ -3353,7 +3343,7 @@ msgstr ""
 msgid "Stop"
 msgstr ""
 
-#: src/muuli_wdr.cpp:348 src/muuli_wdr.cpp:1392 src/SearchListCtrl.cpp:732
+#: src/muuli_wdr.cpp:348 src/muuli_wdr.cpp:1385 src/SearchListCtrl.cpp:732
 msgid "Download"
 msgstr "Download"
 
@@ -3385,12 +3375,12 @@ msgstr "Fundne Kilder :"
 #: src/muuli_wdr.cpp:1160 src/muuli_wdr.cpp:1167 src/muuli_wdr.cpp:1172
 #: src/muuli_wdr.cpp:1179 src/muuli_wdr.cpp:1184 src/muuli_wdr.cpp:1191
 #: src/muuli_wdr.cpp:1205 src/muuli_wdr.cpp:1212 src/muuli_wdr.cpp:1217
-#: src/muuli_wdr.cpp:1224 src/muuli_wdr.cpp:3255 src/muuli_wdr.cpp:3263
-#: src/muuli_wdr.cpp:3271
+#: src/muuli_wdr.cpp:1224 src/muuli_wdr.cpp:3227 src/muuli_wdr.cpp:3235
+#: src/muuli_wdr.cpp:3243
 msgid "N/A"
 msgstr "N/A"
 
-#: src/muuli_wdr.cpp:508 src/muuli_wdr.cpp:1065 src/PrefsUnifiedDlg.cpp:299
+#: src/muuli_wdr.cpp:508 src/muuli_wdr.cpp:1065 src/PrefsUnifiedDlg.cpp:297
 msgid "General"
 msgstr "General"
 
@@ -3530,7 +3520,7 @@ msgstr ""
 msgid "Album :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:685 src/muuli_wdr.cpp:2275
+#: src/muuli_wdr.cpp:685 src/muuli_wdr.cpp:2247
 msgid "Title :"
 msgstr "Titel :"
 
@@ -3637,7 +3627,7 @@ msgstr "Brugernavn :"
 msgid "Userhash :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:895 src/muuli_wdr.cpp:1742 src/muuli_wdr.cpp:2470
+#: src/muuli_wdr.cpp:895 src/muuli_wdr.cpp:1741 src/muuli_wdr.cpp:2442
 #: src/utils/aLinkCreator/src/alcframe.cpp:137
 msgid "Add"
 msgstr "Tilføj"
@@ -3646,15 +3636,15 @@ msgstr "Tilføj"
 msgid "Download-Speed"
 msgstr "Download-Hastighed"
 
-#: src/muuli_wdr.cpp:954 src/muuli_wdr.cpp:989 src/muuli_wdr.cpp:2574
+#: src/muuli_wdr.cpp:954 src/muuli_wdr.cpp:989 src/muuli_wdr.cpp:2546
 msgid "Current"
 msgstr "Nuværende"
 
-#: src/muuli_wdr.cpp:962 src/muuli_wdr.cpp:997 src/muuli_wdr.cpp:2582
+#: src/muuli_wdr.cpp:962 src/muuli_wdr.cpp:997 src/muuli_wdr.cpp:2554
 msgid "Running average"
 msgstr "Nuværende Gennemsnit"
 
-#: src/muuli_wdr.cpp:970 src/muuli_wdr.cpp:1005 src/muuli_wdr.cpp:2590
+#: src/muuli_wdr.cpp:970 src/muuli_wdr.cpp:1005 src/muuli_wdr.cpp:2562
 msgid "Session average"
 msgstr "Sessions Gennemsnit"
 
@@ -3666,7 +3656,7 @@ msgstr "Upload-Hastighed"
 msgid "Connections"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1024 src/muuli_wdr.cpp:1861
+#: src/muuli_wdr.cpp:1024 src/muuli_wdr.cpp:1860
 msgid "Active downloads"
 msgstr "Aktive Downloads"
 
@@ -3674,7 +3664,7 @@ msgstr "Aktive Downloads"
 msgid "Active connections (1:1)"
 msgstr "Aktive Forbindelser (1:1)"
 
-#: src/muuli_wdr.cpp:1040 src/muuli_wdr.cpp:1862
+#: src/muuli_wdr.cpp:1040 src/muuli_wdr.cpp:1861
 msgid "Active uploads"
 msgstr "Aktive Uploads"
 
@@ -3791,8 +3781,8 @@ msgstr ""
 msgid "Language: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1257 src/muuli_wdr.cpp:1330 src/muuli_wdr.cpp:1334
-#: src/muuli_wdr.cpp:1337
+#: src/muuli_wdr.cpp:1257 src/muuli_wdr.cpp:1323 src/muuli_wdr.cpp:1327
+#: src/muuli_wdr.cpp:1330
 msgid "The delay before showing tool-tips."
 msgstr ""
 
@@ -3868,953 +3858,930 @@ msgstr ""
 msgid "Enabling this will make aMule to show notifications when finished downloading."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1323
-msgid "Remember search history"
-msgstr ""
-
-#: src/muuli_wdr.cpp:1324
-msgid "Keeps a dropdown list of your past search terms in the Search tab's Name field. This remembers the queries you typed, not the results they returned."
-msgstr ""
-
-#: src/muuli_wdr.cpp:1329
+#: src/muuli_wdr.cpp:1322
 msgid "Tooltip delay time: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1336
+#: src/muuli_wdr.cpp:1329
 msgid "seconds"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1340
+#: src/muuli_wdr.cpp:1333
 msgid "Browser Selection"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1346
+#: src/muuli_wdr.cpp:1339
 msgid "Enter your browser name here. Leave this field empty to use the system default browser."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1353
+#: src/muuli_wdr.cpp:1346
 msgid "Open in new tab if possible"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1355
+#: src/muuli_wdr.cpp:1348
 msgid "Open the web page in a new tab instead of in a new window when possible"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1359
+#: src/muuli_wdr.cpp:1352
 msgid "Video Player"
 msgstr "Video Afspiller"
 
-#: src/muuli_wdr.cpp:1386
+#: src/muuli_wdr.cpp:1379
 msgid "Bandwidth limits"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1400
+#: src/muuli_wdr.cpp:1393
 msgid "Upload"
 msgstr "Upload"
 
-#: src/muuli_wdr.cpp:1408
+#: src/muuli_wdr.cpp:1401
 msgid "Slot Allocation"
 msgstr "Slot Tildeling"
 
-#: src/muuli_wdr.cpp:1417
+#: src/muuli_wdr.cpp:1410
 msgid "Ports"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1427
+#: src/muuli_wdr.cpp:1420
 msgid "This is the standard eD2k port and cannot be disabled."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1430
+#: src/muuli_wdr.cpp:1423
 msgid "UDP port for server requests (TCP+3):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1432
+#: src/muuli_wdr.cpp:1425
 msgid "4665"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1439
+#: src/muuli_wdr.cpp:1432
 msgid "This UDP port is used for extended eD2k requests and Kad network"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1446
+#: src/muuli_wdr.cpp:1439
 msgid "UPnP TCP Port (Optional):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1456
+#: src/muuli_wdr.cpp:1449
 msgid "Bind local address to IP (empty for any):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1459
+#: src/muuli_wdr.cpp:1452
 msgid "Advanced users only: If you have multiple network interfaces, enter the address of the interface to which aMule should be bound."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1462 src/muuli_wdr.cpp:2055
+#: src/muuli_wdr.cpp:1455 src/muuli_wdr.cpp:2054
 msgid "Bind to network interface (empty for any):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1475
+#: src/muuli_wdr.cpp:1468
 msgid "Advanced users only: pin all of aMule's traffic to one network interface, chosen from the list or typed in by name (e.g. tun0, eth0, en0) or index. Unlike binding to an IP, this stops traffic leaking out via the default route - useful with a VPN. Requires no elevated privileges."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1481
+#: src/muuli_wdr.cpp:1474
 msgid "Max sources per downloading file:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1485
+#: src/muuli_wdr.cpp:1478
 msgid "Max simultaneous connections:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1498 src/muuli_wdr.cpp:3197
+#: src/muuli_wdr.cpp:1491 src/muuli_wdr.cpp:3169
 msgid "ED2K"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1505
+#: src/muuli_wdr.cpp:1498
 msgid "Autoconnect on startup"
 msgstr "Auto forbind ved start"
 
-#: src/muuli_wdr.cpp:1508
+#: src/muuli_wdr.cpp:1501
 msgid "Reconnect on loss"
 msgstr "Genforbind ved fejl"
 
-#: src/muuli_wdr.cpp:1530
+#: src/muuli_wdr.cpp:1523
 msgid "Remove dead server after"
 msgstr "Fjern ikke tilgængelige servere, efter"
 
-#: src/muuli_wdr.cpp:1531
+#: src/muuli_wdr.cpp:1524
 msgid "Static servers are never removed, even when unreachable."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1535
+#: src/muuli_wdr.cpp:1528
 msgid "retries"
 msgstr "forsøg"
 
-#: src/muuli_wdr.cpp:1543
+#: src/muuli_wdr.cpp:1536
 msgid "List"
 msgstr "Liste"
 
-#: src/muuli_wdr.cpp:1546
+#: src/muuli_wdr.cpp:1539
 msgid "Update server list when connecting to a server"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1549
+#: src/muuli_wdr.cpp:1542
 msgid "Update server list when a client connects"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1552
+#: src/muuli_wdr.cpp:1545
 msgid "Use priority system"
 msgstr "Brug prioterings system"
 
-#: src/muuli_wdr.cpp:1556
+#: src/muuli_wdr.cpp:1549
 msgid "Use smart LowID check on connect"
 msgstr "Brug smart LavID tjek ved forbindelse"
 
-#: src/muuli_wdr.cpp:1560
+#: src/muuli_wdr.cpp:1553
 msgid "Safe connect"
 msgstr "Sikker forbindelse"
 
-#: src/muuli_wdr.cpp:1564
+#: src/muuli_wdr.cpp:1557
 msgid "Autoconnect to servers in static list only"
 msgstr "Autoforbind kun til servere i statik liste"
 
-#: src/muuli_wdr.cpp:1567
+#: src/muuli_wdr.cpp:1560
 msgid "Set manually added servers to High Priority"
 msgstr "Sæt manuelt tilføjede servere til Høj Priotet"
 
-#: src/muuli_wdr.cpp:1588
+#: src/muuli_wdr.cpp:1581
 msgid "Add files to download in pause mode"
 msgstr "Tilføj filer til download i pause tilstand"
 
-#: src/muuli_wdr.cpp:1590
+#: src/muuli_wdr.cpp:1583
 msgid "Add files to download with auto priority"
 msgstr "Tilføj filer til download med auto priotet"
 
-#: src/muuli_wdr.cpp:1593
+#: src/muuli_wdr.cpp:1586
 msgid "Try to download first and last chunks first"
 msgstr "Prøv at download første og sidste del først"
 
-#: src/muuli_wdr.cpp:1597
+#: src/muuli_wdr.cpp:1590
 msgid "Endgame mode: rotate to faster sources for the final blocks"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1600
+#: src/muuli_wdr.cpp:1593
 msgid "Start next paused file when a file completes"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1603
+#: src/muuli_wdr.cpp:1596
 msgid "From the same category"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1605
+#: src/muuli_wdr.cpp:1598
 msgid "In alphabetic order"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1607
+#: src/muuli_wdr.cpp:1600
 msgid "Preallocate disk space for new files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1608
+#: src/muuli_wdr.cpp:1601
 msgid "For new files preallocates disk space for the whole file, thus reduces fragmentation"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1613
+#: src/muuli_wdr.cpp:1606
+msgid "Create new files as sparse files"
+msgstr ""
+
+#: src/muuli_wdr.cpp:1607
+msgid "A sparse file reserves its full size on disk immediately without writing real data to it -- fast, but unsupported or slow on some filesystems, and free-space accounting stays optimistic while the download is in progress. Turn this off to grow the file only as data arrives."
+msgstr ""
+
+#: src/muuli_wdr.cpp:1612
 msgid "Stop downloads when free disk space reaches "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1614
+#: src/muuli_wdr.cpp:1613
 msgid "Select this if you want aMule to check your disk space"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1618
+#: src/muuli_wdr.cpp:1617
 msgid "Enter here the min disk space desired."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1624
+#: src/muuli_wdr.cpp:1623
 msgid "Save 10 sources on rare files (< 20 sources)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1628 src/Statistics.cpp:790
+#: src/muuli_wdr.cpp:1627 src/Statistics.cpp:790
 msgid "Uploads"
 msgstr "Uploads"
 
-#: src/muuli_wdr.cpp:1631
+#: src/muuli_wdr.cpp:1630
 msgid "Add new shared files with auto priority"
 msgstr "Tilføj nye delte filer med auto priotet"
 
-#: src/muuli_wdr.cpp:1637
+#: src/muuli_wdr.cpp:1636
 msgid "Intelligent Corruption Handling (I.C.H.)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1640
+#: src/muuli_wdr.cpp:1639
 msgid "Enable"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1643
+#: src/muuli_wdr.cpp:1642
 msgid "Advanced I.C.H. trusts every hash (not recommended)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1655 src/PrefsUnifiedDlg.cpp:1990
+#: src/muuli_wdr.cpp:1654 src/PrefsUnifiedDlg.cpp:1910
 msgid "Media metadata extraction"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1659
+#: src/muuli_wdr.cpp:1658
 msgid "Extract length / bitrate / codec from shared audio and video files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1661
+#: src/muuli_wdr.cpp:1660
 msgid "When enabled, aMule runs ffprobe on each shared media file to fill in the Length / Bitrate / Codec columns other clients see when they find the file in a search. Requires ffmpeg (the ffprobe binary) to be installed."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1668
+#: src/muuli_wdr.cpp:1667
 msgid "Path to ffprobe:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1673
+#: src/muuli_wdr.cpp:1672
 msgid "Full path to the ffprobe binary. Leave empty to have aMule auto-detect it on startup."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1681
+#: src/muuli_wdr.cpp:1680
 msgid "Detect"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1682
+#: src/muuli_wdr.cpp:1681
 msgid "Search the standard install locations for an ffprobe binary and fill the path field."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1706
+#: src/muuli_wdr.cpp:1705
 msgid ""
 "Completed downloads are stored here. All files in this folder are automatically shared with other peers.\n"
 "If this folder also holds files you don't want to share, point it at an aMule-only sub-folder."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1709
+#: src/muuli_wdr.cpp:1708
 msgid "Pick the folder where completed downloads will be stored. All files in that folder will be shared with other peers."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1723
+#: src/muuli_wdr.cpp:1722
 msgid "Shared folders"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1729
+#: src/muuli_wdr.cpp:1728
 msgid "(Folders shared by the core. Enter a path to add one.)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1737
+#: src/muuli_wdr.cpp:1736
 msgid "Absolute path of a folder on the core's machine, e.g. /home/user/shared"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1739 src/PrefsUnifiedDlg.cpp:2874
+#: src/muuli_wdr.cpp:1738 src/PrefsUnifiedDlg.cpp:2794
 msgid "Recursive"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1740
+#: src/muuli_wdr.cpp:1739
 msgid "Share every sub-folder underneath this one, including ones created later."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1744 src/utils/aLinkCreator/src/alcframe.cpp:141
+#: src/muuli_wdr.cpp:1743 src/utils/aLinkCreator/src/alcframe.cpp:141
 msgid "Remove"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1748
+#: src/muuli_wdr.cpp:1747
 msgid "(Right click on folder icon for recursive share)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1755
+#: src/muuli_wdr.cpp:1754
 msgid "Share hidden files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1761
+#: src/muuli_wdr.cpp:1760
 msgid "Automatically rescan shared folders for changes"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1767
+#: src/muuli_wdr.cpp:1766
 msgid "Follow symbolic links in shared folders"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1773
+#: src/muuli_wdr.cpp:1772
 msgid "Exclude files matching:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1776
+#: src/muuli_wdr.cpp:1775
 msgid "Wildcard patterns separated by '|', e.g. .DS_Store|Thumbs.db|*.tmp. Files whose name matches are not shared. Matching is case-insensitive."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1780
+#: src/muuli_wdr.cpp:1779
 msgid "Patterns are regular expressions"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1781
+#: src/muuli_wdr.cpp:1780
 msgid "When set, the whole field is one regular expression ('|' is alternation). When unset, it is a list of '|'-separated wildcards."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1791
+#: src/muuli_wdr.cpp:1790
 msgid "Show how many shared files the current pattern would exclude."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1812
+#: src/muuli_wdr.cpp:1811
 msgid "Graphs"
 msgstr "Grafer"
 
-#: src/muuli_wdr.cpp:1815 src/muuli_wdr.cpp:1877
+#: src/muuli_wdr.cpp:1814 src/muuli_wdr.cpp:1876
 msgid "Update delay : 5 secs"
 msgstr "Opdaterings interval : 5 sek"
 
-#: src/muuli_wdr.cpp:1819
+#: src/muuli_wdr.cpp:1818
 msgid "Time for average graph: 100 mins"
 msgstr "Tid for gennemsnitlig graf: 100 min"
 
-#: src/muuli_wdr.cpp:1823
+#: src/muuli_wdr.cpp:1822
 msgid "Connections Graph Scale: 100 "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1830
+#: src/muuli_wdr.cpp:1829
 msgid "Download graph scale:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1838
+#: src/muuli_wdr.cpp:1837
 msgid "Upload graph scale:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1848
+#: src/muuli_wdr.cpp:1847
 msgid "Colors: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1852
+#: src/muuli_wdr.cpp:1851
 msgid "Background"
 msgstr "Baggrund"
 
-#: src/muuli_wdr.cpp:1853
+#: src/muuli_wdr.cpp:1852
 msgid "Grid"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1854
+#: src/muuli_wdr.cpp:1853
 msgid "Download current"
 msgstr "Download nu"
 
-#: src/muuli_wdr.cpp:1855
+#: src/muuli_wdr.cpp:1854
 msgid "Download running average"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1856
+#: src/muuli_wdr.cpp:1855
 msgid "Download session average"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1857
+#: src/muuli_wdr.cpp:1856
 msgid "Upload current"
 msgstr "Upload nu"
 
-#: src/muuli_wdr.cpp:1858
+#: src/muuli_wdr.cpp:1857
 msgid "Upload running average"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1859
+#: src/muuli_wdr.cpp:1858
 msgid "Upload session average"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1860
+#: src/muuli_wdr.cpp:1859
 msgid "Active connections"
 msgstr "Aktive Forbindelser"
 
-#: src/muuli_wdr.cpp:1863
+#: src/muuli_wdr.cpp:1862
 msgid "Systray Icon Speed Bar"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1864
+#: src/muuli_wdr.cpp:1863
 msgid "Kad-nodes current"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1865
+#: src/muuli_wdr.cpp:1864
 msgid "Kad-nodes running"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1866
+#: src/muuli_wdr.cpp:1865
 msgid "Kad-nodes session"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1870 src/muuli_wdr.cpp:2324
+#: src/muuli_wdr.cpp:1869 src/muuli_wdr.cpp:2296
 msgid "Select"
 msgstr "Vælg"
 
-#: src/muuli_wdr.cpp:1874
+#: src/muuli_wdr.cpp:1873
 msgid "Tree"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1884
+#: src/muuli_wdr.cpp:1883
 msgid "Number of Client Versions shown (0=unlimited)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1909
+#: src/muuli_wdr.cpp:1908
 msgid "!!! WARNING !!!"
 msgstr "!!! Advarsel !!!"
 
-#: src/muuli_wdr.cpp:1924
+#: src/muuli_wdr.cpp:1923
 msgid "Max new connections / 5 secs"
 msgstr "Max nye forbindelser / 5 sekunder"
 
-#: src/muuli_wdr.cpp:1926
+#: src/muuli_wdr.cpp:1925
 msgid "Concurrent Kad source lookups"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1928
+#: src/muuli_wdr.cpp:1927
 #, fuzzy
 msgid "Kad source re-search interval (minutes)"
 msgstr "FTP opdaterings interval i minutter"
 
-#: src/muuli_wdr.cpp:1930
+#: src/muuli_wdr.cpp:1929
 #, fuzzy
 msgid "Source re-ask interval (minutes)"
 msgstr "FTP opdaterings interval i minutter"
 
-#: src/muuli_wdr.cpp:1934
+#: src/muuli_wdr.cpp:1933
 msgid "File Buffer Size: 240000 bytes"
 msgstr "Fil Buffer Størrelse"
 
-#: src/muuli_wdr.cpp:1938
+#: src/muuli_wdr.cpp:1937
 msgid "Use MMAP: memory-mapped file access (lower memory use)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1939
+#: src/muuli_wdr.cpp:1938
 msgid "Maps part files into memory instead of buffering them on the heap, lowering the process memory footprint. May reduce download speed on some disks; best for memory-constrained or upload-heavy hosts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1941
+#: src/muuli_wdr.cpp:1940
 msgid "Upload Queue Size: 5000 clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1945
+#: src/muuli_wdr.cpp:1944
 msgid "Server connection refresh interval: Disable"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1949
+#: src/muuli_wdr.cpp:1948
 msgid "Disable computer's timed standby mode"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1968
+#: src/muuli_wdr.cpp:1967
 msgid "Skin to use: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1977
+#: src/muuli_wdr.cpp:1976
 msgid "Show \"Fast eD2k Links Handler\" in every window."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1980
+#: src/muuli_wdr.cpp:1979
 msgid "Show extended info on categories tabs"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1983
+#: src/muuli_wdr.cpp:1982
 #, fuzzy
 msgid "Show application version on title"
 msgstr "Vis overførsels hastighed i titel"
 
-#: src/muuli_wdr.cpp:1985
+#: src/muuli_wdr.cpp:1984
 msgid "Show transfer rates on title"
 msgstr "Vis overførsels hastighed i titel"
 
-#: src/muuli_wdr.cpp:1987
+#: src/muuli_wdr.cpp:1986
 msgid "Before application name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1989
+#: src/muuli_wdr.cpp:1988
 msgid "After application name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1992
+#: src/muuli_wdr.cpp:1991
 msgid "Show overhead bandwidth"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1996
+#: src/muuli_wdr.cpp:1995
 msgid "Vertical toolbar orientation"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1998
+#: src/muuli_wdr.cpp:1997
 msgid "Live column sorting (auto-reorder rows as their values change)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2005
+#: src/muuli_wdr.cpp:2004
 msgid "Download Queue Files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2008
+#: src/muuli_wdr.cpp:2007
 msgid "Show progress percentage"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2014
+#: src/muuli_wdr.cpp:2013
 msgid "Show progress bar"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2017
+#: src/muuli_wdr.cpp:2016
 msgid "Flat"
 msgstr "Flad"
 
-#: src/muuli_wdr.cpp:2021
+#: src/muuli_wdr.cpp:2020
 msgid "Round"
 msgstr "Rund"
 
-#: src/muuli_wdr.cpp:2039
+#: src/muuli_wdr.cpp:2038
 msgid "External Connection Parameters"
 msgstr "Ydre Forbindelses Parametre"
 
-#: src/muuli_wdr.cpp:2042
+#: src/muuli_wdr.cpp:2041
 msgid "Accept external connections"
 msgstr "Accepter ydre forbindelser"
 
-#: src/muuli_wdr.cpp:2049 src/muuli_wdr.cpp:2108
+#: src/muuli_wdr.cpp:2048 src/muuli_wdr.cpp:2107
 msgid "IP of the listening interface:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2052
+#: src/muuli_wdr.cpp:2051
 msgid "Enter here a valid ip in the a.b.c.d format for the listening EC interface. An empty field or 0.0.0.0 will mean any interface."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2073 src/muuli_wdr.cpp:2184
+#: src/muuli_wdr.cpp:2072 src/muuli_wdr.cpp:2156
 msgid "TCP port:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2079
+#: src/muuli_wdr.cpp:2078
 msgid "Enable UPnP port forwarding on the EC port"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2083 src/muuli_wdr.cpp:3069
+#: src/muuli_wdr.cpp:2082 src/muuli_wdr.cpp:3041
 #: src/utils/wxCas/src/wxcasprefs.cpp:167
 msgid "Password"
 msgstr "Password"
 
-#: src/muuli_wdr.cpp:2089
+#: src/muuli_wdr.cpp:2088
 msgid "aMule API server parameters"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2092
+#: src/muuli_wdr.cpp:2091
 msgid "Run amuleapi (REST API) on startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2097
+#: src/muuli_wdr.cpp:2096
 #, fuzzy
 msgid "HTTP port:"
 msgstr "UPnP port"
 
-#: src/muuli_wdr.cpp:2111
+#: src/muuli_wdr.cpp:2110
 msgid "The interface amuleapi's HTTP server listens on. 127.0.0.1 (default) accepts only local connections; use 0.0.0.0 or a specific IP to expose it to other hosts (set an admin password below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2116
-msgid "Type a password to set or change it. Stored passwords cannot be shown, so leaving this empty keeps the current one."
-msgstr ""
-
-#: src/muuli_wdr.cpp:2118
+#: src/muuli_wdr.cpp:2113
 #, fuzzy
 msgid "Admin password"
 msgstr "Undersøger password\n"
 
-#: src/muuli_wdr.cpp:2130 src/muuli_wdr.cpp:2147 src/PrefsUnifiedDlg.cpp:1103
-#, fuzzy
-msgid "A password is set."
-msgstr "Undersøger password\n"
-
-#: src/muuli_wdr.cpp:2134
-#, fuzzy
-msgid "Enable guest access"
-msgstr "Tillad bruger adgang"
-
-#: src/muuli_wdr.cpp:2135
-msgid "Guest sessions may read status and listings but cannot change anything. Turning this off clears the stored guest password."
-msgstr ""
-
-#: src/muuli_wdr.cpp:2139
-#, fuzzy
-msgid "Guest password"
-msgstr "Fuld rettigheds kodeord"
-
-#: src/muuli_wdr.cpp:2154
-msgid "Web server parameters"
-msgstr ""
-
-#: src/muuli_wdr.cpp:2157
-msgid "Run webserver on startup (deprecated)"
-msgstr ""
-
-#: src/muuli_wdr.cpp:2163
-msgid "Web template"
-msgstr ""
-
-#: src/muuli_wdr.cpp:2168
-msgid "Full rights password"
-msgstr "Fuld rettigheds kodeord"
-
-#: src/muuli_wdr.cpp:2172
-msgid "Enable Low rights User"
-msgstr "Aktiver lav rettigheds brugere"
-
-#: src/muuli_wdr.cpp:2177
+#: src/muuli_wdr.cpp:2118 src/muuli_wdr.cpp:2149
 msgid "Low rights password"
 msgstr "Lav rettigheds kodeord"
 
-#: src/muuli_wdr.cpp:2191
+#: src/muuli_wdr.cpp:2126
+msgid "Web server parameters"
+msgstr ""
+
+#: src/muuli_wdr.cpp:2129
+msgid "Run webserver on startup (deprecated)"
+msgstr ""
+
+#: src/muuli_wdr.cpp:2135
+msgid "Web template"
+msgstr ""
+
+#: src/muuli_wdr.cpp:2140
+msgid "Full rights password"
+msgstr "Fuld rettigheds kodeord"
+
+#: src/muuli_wdr.cpp:2144
+msgid "Enable Low rights User"
+msgstr "Aktiver lav rettigheds brugere"
+
+#: src/muuli_wdr.cpp:2163
 msgid "Enable UPnP port forwarding of the web server port"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2196
+#: src/muuli_wdr.cpp:2168
 msgid "Web server UPnP TCP port (Optional)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2204
+#: src/muuli_wdr.cpp:2176
 msgid "Page Refresh Time (in secs)"
 msgstr "Side Opdaterings Tid (i sek)"
 
-#: src/muuli_wdr.cpp:2211
+#: src/muuli_wdr.cpp:2183
 msgid "Enable Gzip compression"
 msgstr "Aktiver Gzip komprimering"
 
-#: src/muuli_wdr.cpp:2245
+#: src/muuli_wdr.cpp:2217
 #, fuzzy
 msgid "Reset page to defaults"
 msgstr "System standard"
 
-#: src/muuli_wdr.cpp:2246
+#: src/muuli_wdr.cpp:2218
 msgid "Reset the settings on the current page to their default values."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2248 src/muuli_wdr.cpp:2334 src/ServerWnd.cpp:274
+#: src/muuli_wdr.cpp:2220 src/muuli_wdr.cpp:2306 src/ServerWnd.cpp:274
 #: src/ServerWnd.cpp:282
 msgid "OK"
 msgstr "OK"
 
-#: src/muuli_wdr.cpp:2250
+#: src/muuli_wdr.cpp:2222
 msgid "Click here to apply any changes made to the preferences."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2253
+#: src/muuli_wdr.cpp:2225
 msgid "Reset any changes made to the preferences."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2282
+#: src/muuli_wdr.cpp:2254
 msgid "Comment :"
 msgstr "Kommentar :"
 
-#: src/muuli_wdr.cpp:2289
+#: src/muuli_wdr.cpp:2261
 msgid "Incoming Dir :"
 msgstr "Indkommende Mappe :"
 
-#: src/muuli_wdr.cpp:2298
+#: src/muuli_wdr.cpp:2270
 msgid "Change priority for new assigned files :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2302
+#: src/muuli_wdr.cpp:2274
 msgid "Don't change"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2314
+#: src/muuli_wdr.cpp:2286
 msgid "Select color for this Category (currently selected) :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2381 src/muuli_wdr.cpp:2400 src/muuli_wdr.cpp:2422
+#: src/muuli_wdr.cpp:2353 src/muuli_wdr.cpp:2372 src/muuli_wdr.cpp:2394
 msgid "Click this button to reset the log."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2441
+#: src/muuli_wdr.cpp:2413
 msgid "Click on this button to update the servers list from URL ..."
 msgstr "Tryk på denne knap for at opdatere serverlisten fra URL ..."
 
-#: src/muuli_wdr.cpp:2445
+#: src/muuli_wdr.cpp:2417
 msgid "Server list"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2449
+#: src/muuli_wdr.cpp:2421
 msgid "Enter the url to a server.met file here and press the button to the left to update the list of known servers."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2454
+#: src/muuli_wdr.cpp:2426
 msgid "Add server manually: Name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2457
+#: src/muuli_wdr.cpp:2429
 msgid "Enter the name of the new server here"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2459 src/ServerWnd.cpp:206
+#: src/muuli_wdr.cpp:2431 src/ServerWnd.cpp:206
 msgid "IP:Port"
 msgstr "IP:Port"
 
-#: src/muuli_wdr.cpp:2462
+#: src/muuli_wdr.cpp:2434
 msgid "Enter the IP of the server here, using the x.x.x.x format."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2468
+#: src/muuli_wdr.cpp:2440
 msgid "Enter the port of the server here."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2471
+#: src/muuli_wdr.cpp:2443
 msgid "Add manually a server (fill fields to the left before) ..."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2500
+#: src/muuli_wdr.cpp:2472
 msgid "aMule Log"
 msgstr "aMule Log"
 
-#: src/muuli_wdr.cpp:2508
+#: src/muuli_wdr.cpp:2480
 msgid "Server Info"
 msgstr "Server Info"
 
-#: src/muuli_wdr.cpp:2512
+#: src/muuli_wdr.cpp:2484
 msgid "ED2K Info"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2516
+#: src/muuli_wdr.cpp:2488
 msgid "Kad Info"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2544
+#: src/muuli_wdr.cpp:2516
 msgid "Click on this button to update the nodes list from URL ..."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2548
+#: src/muuli_wdr.cpp:2520
 msgid "Nodes (0)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2552
+#: src/muuli_wdr.cpp:2524
 msgid "Enter the url to a nodes.dat file here and press the button to the left to update the list of known nodes."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2555
+#: src/muuli_wdr.cpp:2527
 msgid "Nodes stats"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2597
+#: src/muuli_wdr.cpp:2569
 msgid "Bootstrap"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2600
+#: src/muuli_wdr.cpp:2572
 msgid "New node"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2605
+#: src/muuli_wdr.cpp:2577
 msgid "IP:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2625
+#: src/muuli_wdr.cpp:2597
 msgid "Port:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2638
+#: src/muuli_wdr.cpp:2610
 msgid "Bootstrap from known clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2640
+#: src/muuli_wdr.cpp:2612
 msgid "Disconnect Kad"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2674
+#: src/muuli_wdr.cpp:2646
 msgid "Use Secure User Identification"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2676
+#: src/muuli_wdr.cpp:2648
 msgid "It is recommended to enable this option. You will not receive credits if SUI is not enabled."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2678
+#: src/muuli_wdr.cpp:2650
 msgid "Protocol Obfuscation"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2681
+#: src/muuli_wdr.cpp:2653
 msgid "Support Protocol Obfuscation"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2683
+#: src/muuli_wdr.cpp:2655
 msgid "This option enabled Protocol Obfuscation, and makes aMule accept obfuscated connections from other clients."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2685
+#: src/muuli_wdr.cpp:2657
 msgid "Use obfuscation for outgoing connections"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2687
+#: src/muuli_wdr.cpp:2659
 msgid "This option makes aMule use Protocol Obfuscation when connecting other clients/servers."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2689
+#: src/muuli_wdr.cpp:2661
 msgid "Accept only obfuscated connections"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2690
+#: src/muuli_wdr.cpp:2662
 msgid "This option makes aMule only accept obfuscated connections. You will have less sources, but all your traffic will be obfuscated"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2695
+#: src/muuli_wdr.cpp:2667
 msgid "Everybody"
 msgstr "Alle"
 
-#: src/muuli_wdr.cpp:2697
+#: src/muuli_wdr.cpp:2669
 msgid "No one"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2699
+#: src/muuli_wdr.cpp:2671
 msgid "Who can see my shared files:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2700
+#: src/muuli_wdr.cpp:2672
 msgid "Select who can request to view a list of your shared files."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2702
+#: src/muuli_wdr.cpp:2674
 msgid "IP-Filtering"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2709
+#: src/muuli_wdr.cpp:2681
 msgid "Filter clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2711
+#: src/muuli_wdr.cpp:2683
 msgid "Enable filtering of the client IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2713
+#: src/muuli_wdr.cpp:2685
 msgid "Filter servers"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2715
+#: src/muuli_wdr.cpp:2687
 msgid "Enable filtering of the server IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2719
+#: src/muuli_wdr.cpp:2691
 msgid "Reload List"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2720
+#: src/muuli_wdr.cpp:2692
 msgid "Reload the list of IPs to filter from the file ~/.aMule/ipfilter.dat"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2726
+#: src/muuli_wdr.cpp:2698
 msgid "URL:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2730 src/muuli_wdr.cpp:2923
+#: src/muuli_wdr.cpp:2702 src/muuli_wdr.cpp:2895
 msgid "Update now"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2733
+#: src/muuli_wdr.cpp:2705
 msgid "Auto-update ipfilter at startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2737
+#: src/muuli_wdr.cpp:2709
 msgid "Filtering Level:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2743
+#: src/muuli_wdr.cpp:2715
 msgid "Always filter LAN IPs"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2746
+#: src/muuli_wdr.cpp:2718
 msgid "Paranoid handling of non-matching IPs"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2748
+#: src/muuli_wdr.cpp:2720
 msgid "Rejects a packet when its source IP differs from the IP the client claims (an anti-spoofing check). Disable only if it causes connection problems."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2750
+#: src/muuli_wdr.cpp:2722
 msgid "Use system-wide ipfilter.dat if available"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2751
+#: src/muuli_wdr.cpp:2723
 msgid "If there's no local ipfilter.dat found, allow usage of a system-wide ipfilter file."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2768
+#: src/muuli_wdr.cpp:2740
 msgid "Enable Online-Signature"
 msgstr "Aktiver online-signatur"
 
-#: src/muuli_wdr.cpp:2770
+#: src/muuli_wdr.cpp:2742
 msgid "Enables the writing of the OS file, which can be used by external apps to create signatures and the like."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2774
+#: src/muuli_wdr.cpp:2746
 msgid "Update Frequency (Secs):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2777
+#: src/muuli_wdr.cpp:2749
 msgid "Change the frequency (in seconds) of Online Signature updates."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2785
+#: src/muuli_wdr.cpp:2757
 msgid "Save online signature file in: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:2791
+#: src/muuli_wdr.cpp:2763
 msgid "Click here to select the directory containing the the Online Signature files."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2824
+#: src/muuli_wdr.cpp:2796
 msgid "Show country flags for clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2825
+#: src/muuli_wdr.cpp:2797
 msgid "Render the country flag column in the transfers, queue and search views. Requires a valid MMDB GeoIP database (see below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2830
+#: src/muuli_wdr.cpp:2802
 msgid "Database"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2846
+#: src/muuli_wdr.cpp:2818
 #, fuzzy
 msgid "Source:"
 msgstr "Kilder"
 
-#: src/muuli_wdr.cpp:2849
+#: src/muuli_wdr.cpp:2821
 msgid "DB-IP (free, no account)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2850
+#: src/muuli_wdr.cpp:2822
 msgid "MaxMind GeoLite2 (free, account required)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2851
+#: src/muuli_wdr.cpp:2823
 msgid "Custom URL"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2854
+#: src/muuli_wdr.cpp:2826
 msgid "Choose which provider supplies the GeoIP MMDB database. DB-IP is the default - no account required. MaxMind requires a free account + license key. Use Custom URL to point at any other MMDB host (e.g. a local mirror)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2871
+#: src/muuli_wdr.cpp:2843
 msgid ""
 "No configuration required.\n"
 "\n"
@@ -4822,11 +4789,11 @@ msgid ""
 "License: Creative Commons BY 4.0 - https://creativecommons.org/licenses/by/4.0/"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2884
+#: src/muuli_wdr.cpp:2856
 msgid "License key:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2890
+#: src/muuli_wdr.cpp:2862
 msgid ""
 "Sign up for a free MaxMind account, then generate a License Key:\n"
 "https://www.maxmind.com/en/geolite2/signup\n"
@@ -4836,232 +4803,232 @@ msgid ""
 "Requires attribution and account registration; refresh at least every 30 days."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2905
+#: src/muuli_wdr.cpp:2877
 #, fuzzy
 msgid "Download URL:"
 msgstr "Download: "
 
-#: src/muuli_wdr.cpp:2911
+#: src/muuli_wdr.cpp:2883
 msgid ""
 "Must point to an .mmdb file or a .gz / .tar.gz containing one.\n"
 "URL may include credentials (https://user:pass@host/...).\n"
 "License and attribution terms are set by the upstream URL - you are responsible."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2924
+#: src/muuli_wdr.cpp:2896
 msgid "Download the GeoIP database from the selected source."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2926
+#: src/muuli_wdr.cpp:2898
 #, fuzzy
 msgid "Auto-update on startup"
 msgstr "Auto forbind ved start"
 
-#: src/muuli_wdr.cpp:2927
+#: src/muuli_wdr.cpp:2899
 msgid "Re-download the GeoIP database from the selected source every time aMule starts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2950
+#: src/muuli_wdr.cpp:2922
 msgid "Filter incoming messages (except current chat):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2952
+#: src/muuli_wdr.cpp:2924
 msgid "Filter all messages"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2954
+#: src/muuli_wdr.cpp:2926
 msgid "Filter messages from people not on your friend list"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2956
+#: src/muuli_wdr.cpp:2928
 msgid "Filter messages from unknown clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2958
+#: src/muuli_wdr.cpp:2930
 msgid "Filter messages containing (use ',' as separator):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2961 src/muuli_wdr.cpp:2972
+#: src/muuli_wdr.cpp:2933 src/muuli_wdr.cpp:2944
 msgid "add here the words amule should filter and block messages including it"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2963
+#: src/muuli_wdr.cpp:2935
 msgid "Show received messages in the log"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2966
+#: src/muuli_wdr.cpp:2938
 msgid "Comments"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2969
+#: src/muuli_wdr.cpp:2941
 msgid "Filter comments containing (use ',' as separator):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2994
+#: src/muuli_wdr.cpp:2966
 msgid "Enable Proxy"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2995
+#: src/muuli_wdr.cpp:2967
 msgid "Enable/disable proxy support"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2998
+#: src/muuli_wdr.cpp:2970
 msgid "Proxy type:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3009
+#: src/muuli_wdr.cpp:2981
 msgid "Proxy host:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3012
+#: src/muuli_wdr.cpp:2984
 msgid "The proxy host name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3014
+#: src/muuli_wdr.cpp:2986
 msgid "Proxy port:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3017
+#: src/muuli_wdr.cpp:2989
 msgid "The proxy port"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3019
+#: src/muuli_wdr.cpp:2991
 msgid "Enable authentication"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3020
+#: src/muuli_wdr.cpp:2992
 msgid "Enable/disable username/password authentication"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3023
+#: src/muuli_wdr.cpp:2995
 msgid "Username: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:3026
+#: src/muuli_wdr.cpp:2998
 msgid "The username to use to connect to the proxy"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3028
+#: src/muuli_wdr.cpp:3000
 msgid "Password:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3031
+#: src/muuli_wdr.cpp:3003
 msgid "The password to use to connect to the proxy"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3050
+#: src/muuli_wdr.cpp:3022
 msgid "Connect to:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3059
+#: src/muuli_wdr.cpp:3031
 msgid "Login to remote amule"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3064
+#: src/muuli_wdr.cpp:3036
 msgid "User name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3075
+#: src/muuli_wdr.cpp:3047
 msgid "Remember those settings"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3078
+#: src/muuli_wdr.cpp:3050
 #, fuzzy
 msgid "Force ZLIB compression"
 msgstr "Brug gzip komprimering"
 
-#: src/muuli_wdr.cpp:3102
+#: src/muuli_wdr.cpp:3074
 msgid "Enable Verbose Debug-Logging."
 msgstr ""
 
-#: src/muuli_wdr.cpp:3104
+#: src/muuli_wdr.cpp:3076
 #, fuzzy
 msgid "Only to Logfile"
 msgstr "&Åben filen"
 
-#: src/muuli_wdr.cpp:3106
+#: src/muuli_wdr.cpp:3078
 msgid "Message Categories:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3130 src/PartFileConvertDlg.cpp:160
+#: src/muuli_wdr.cpp:3102 src/PartFileConvertDlg.cpp:160
 msgid "Waiting..."
 msgstr "Venter..."
 
-#: src/muuli_wdr.cpp:3150
+#: src/muuli_wdr.cpp:3122
 msgid "Add imports"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3153
+#: src/muuli_wdr.cpp:3125
 msgid "Retry selected"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3155
+#: src/muuli_wdr.cpp:3127
 msgid "Remove selected"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3218
+#: src/muuli_wdr.cpp:3190
 msgid "Event Types"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3237
+#: src/muuli_wdr.cpp:3209
 msgid "Statistics and queued clients for selected file(s) : Session / All time"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3261
+#: src/muuli_wdr.cpp:3233
 msgid "Active Uploads"
 msgstr "Aktive Uploads"
 
-#: src/muuli_wdr.cpp:3275
+#: src/muuli_wdr.cpp:3247
 #, fuzzy
 msgid "Percent of total files"
 msgstr "Antal Filer Total"
 
-#: src/muuli_wdr.cpp:3327
+#: src/muuli_wdr.cpp:3299
 #, fuzzy
 msgid "Show Clients for"
 msgstr "Vis Liste"
 
-#: src/muuli_wdr.cpp:3329
+#: src/muuli_wdr.cpp:3301
 #, fuzzy
 msgid "All files"
 msgstr "Delte Filer"
 
-#: src/muuli_wdr.cpp:3332
+#: src/muuli_wdr.cpp:3304
 #, fuzzy
 msgid "Selected files"
 msgstr "Slettede Servere"
 
-#: src/muuli_wdr.cpp:3335
+#: src/muuli_wdr.cpp:3307
 #, fuzzy
 msgid "Active uploads only"
 msgstr "Aktive Uploads"
 
-#: src/muuli_wdr.cpp:3342
+#: src/muuli_wdr.cpp:3314
 #, fuzzy
 msgid "Reload:"
 msgstr "Opdater"
 
-#: src/muuli_wdr.cpp:3346
+#: src/muuli_wdr.cpp:3318
 msgid "Reload your shared files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3409
+#: src/muuli_wdr.cpp:3381
 msgid "Send"
 msgstr "Send"
 
-#: src/muuli_wdr.cpp:3410
+#: src/muuli_wdr.cpp:3382
 msgid "Sends the specified message."
 msgstr ""
 
-#: src/muuli_wdr.cpp:3414
+#: src/muuli_wdr.cpp:3386
 msgid "Close this chat-session."
 msgstr ""
 
-#: src/muuli_wdr.cpp:3437
+#: src/muuli_wdr.cpp:3409
 msgid "Connect to any server and/or Kad"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3443 src/SharedFilesCtrl.cpp:142 src/Statistics.cpp:941
+#: src/muuli_wdr.cpp:3415 src/SharedFilesCtrl.cpp:142 src/Statistics.cpp:941
 msgid "Shared Files"
 msgstr "Delte Filer"
 
@@ -5423,267 +5390,267 @@ msgstr ""
 msgid "ERROR: Failed to open partfile '%s'"
 msgstr ""
 
-#: src/Preferences.cpp:701
+#: src/Preferences.cpp:673
 msgid "System default"
 msgstr "System standard"
 
-#: src/Preferences.cpp:702
+#: src/Preferences.cpp:674
 msgid "Albanian"
 msgstr ""
 
-#: src/Preferences.cpp:703
+#: src/Preferences.cpp:675
 msgid "Arabic"
 msgstr "Arabic"
 
-#: src/Preferences.cpp:704
+#: src/Preferences.cpp:676
 #, fuzzy
 msgid "Asturian"
 msgstr "Estonian"
 
-#: src/Preferences.cpp:705
+#: src/Preferences.cpp:677
 msgid "Basque"
 msgstr "Basque"
 
-#: src/Preferences.cpp:706
+#: src/Preferences.cpp:678
 msgid "Bulgarian"
 msgstr "Bulgarian"
 
-#: src/Preferences.cpp:707
+#: src/Preferences.cpp:679
 msgid "Catalan"
 msgstr "Catalan"
 
-#: src/Preferences.cpp:708
+#: src/Preferences.cpp:680
 msgid "Chinese (Simplified)"
 msgstr ""
 
-#: src/Preferences.cpp:709
+#: src/Preferences.cpp:681
 msgid "Chinese (Traditional)"
 msgstr ""
 
-#: src/Preferences.cpp:710
+#: src/Preferences.cpp:682
 msgid "Croatian"
 msgstr ""
 
-#: src/Preferences.cpp:711
+#: src/Preferences.cpp:683
 msgid "Czech"
 msgstr ""
 
-#: src/Preferences.cpp:712
+#: src/Preferences.cpp:684
 msgid "Danish"
 msgstr "Danish"
 
-#: src/Preferences.cpp:713
+#: src/Preferences.cpp:685
 msgid "Dutch"
 msgstr "Dutch"
 
-#: src/Preferences.cpp:714
+#: src/Preferences.cpp:686
 msgid "English (U.K.)"
 msgstr ""
 
-#: src/Preferences.cpp:715
+#: src/Preferences.cpp:687
 msgid "English (U.S.)"
 msgstr ""
 
-#: src/Preferences.cpp:716
+#: src/Preferences.cpp:688
 msgid "Estonian"
 msgstr "Estonian"
 
-#: src/Preferences.cpp:717
+#: src/Preferences.cpp:689
 msgid "Finnish"
 msgstr "Finnish"
 
-#: src/Preferences.cpp:718
+#: src/Preferences.cpp:690
 msgid "French"
 msgstr "French"
 
-#: src/Preferences.cpp:719
+#: src/Preferences.cpp:691
 msgid "Galician"
 msgstr ""
 
-#: src/Preferences.cpp:720
+#: src/Preferences.cpp:692
 msgid "German"
 msgstr "German"
 
-#: src/Preferences.cpp:721
+#: src/Preferences.cpp:693
 msgid "Greek"
 msgstr ""
 
-#: src/Preferences.cpp:722
+#: src/Preferences.cpp:694
 msgid "Hebrew"
 msgstr ""
 
-#: src/Preferences.cpp:723
+#: src/Preferences.cpp:695
 msgid "Hungarian"
 msgstr ""
 
-#: src/Preferences.cpp:724
+#: src/Preferences.cpp:696
 msgid "Italian"
 msgstr "Italian"
 
-#: src/Preferences.cpp:725
+#: src/Preferences.cpp:697
 msgid "Japanese"
 msgstr ""
 
-#: src/Preferences.cpp:726
+#: src/Preferences.cpp:698
 msgid "Korean"
 msgstr "Korean"
 
-#: src/Preferences.cpp:727
+#: src/Preferences.cpp:699
 msgid "Latvian"
 msgstr ""
 
-#: src/Preferences.cpp:728
+#: src/Preferences.cpp:700
 msgid "Lithuanian"
 msgstr "Lithuanian"
 
-#: src/Preferences.cpp:729
+#: src/Preferences.cpp:701
 msgid "Norwegian (Nynorsk)"
 msgstr ""
 
-#: src/Preferences.cpp:730
+#: src/Preferences.cpp:702
 msgid "Polish"
 msgstr "Polish"
 
-#: src/Preferences.cpp:731
+#: src/Preferences.cpp:703
 msgid "Portuguese"
 msgstr "Portuguese"
 
-#: src/Preferences.cpp:732
+#: src/Preferences.cpp:704
 msgid "Portuguese (Brazilian)"
 msgstr ""
 
-#: src/Preferences.cpp:733
+#: src/Preferences.cpp:705
 #, fuzzy
 msgid "Romanian"
 msgstr "Estonian"
 
-#: src/Preferences.cpp:734
+#: src/Preferences.cpp:706
 msgid "Russian"
 msgstr "Russian"
 
-#: src/Preferences.cpp:735
+#: src/Preferences.cpp:707
 msgid "Slovenian"
 msgstr ""
 
-#: src/Preferences.cpp:736
+#: src/Preferences.cpp:708
 msgid "Spanish"
 msgstr "Spanish"
 
-#: src/Preferences.cpp:737
+#: src/Preferences.cpp:709
 msgid "Swedish"
 msgstr ""
 
-#: src/Preferences.cpp:738
+#: src/Preferences.cpp:710
 msgid "Turkish"
 msgstr ""
 
-#: src/Preferences.cpp:739
+#: src/Preferences.cpp:711
 msgid "Ukrainian"
 msgstr ""
 
-#: src/Preferences.cpp:842
+#: src/Preferences.cpp:814
 #, fuzzy
 msgid "Change Language"
 msgstr "Sprog"
 
-#: src/Preferences.cpp:906
+#: src/Preferences.cpp:878
 msgid "There are no translations installed for aMule"
 msgstr ""
 
-#: src/Preferences.cpp:907
+#: src/Preferences.cpp:879
 #, fuzzy
 msgid "No languages available"
 msgstr "Ikke tilgængelig"
 
-#: src/Preferences.cpp:1038
+#: src/Preferences.cpp:1010
 msgid "no options available"
 msgstr ""
 
-#: src/Preferences.cpp:2226
+#: src/Preferences.cpp:2179
 msgid "Invalid category found, skipping"
 msgstr ""
 
-#: src/Preferences.cpp:2395
+#: src/Preferences.cpp:2348
 msgid "TCP port can't be higher than 65532 due to server UDP socket being TCP+3"
 msgstr ""
 
-#: src/Preferences.cpp:2396
+#: src/Preferences.cpp:2349
 #, c-format
 msgid "Default port will be used (%d)"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:300 src/Statistics.cpp:866
+#: src/PrefsUnifiedDlg.cpp:298 src/Statistics.cpp:866
 msgid "Connection"
 msgstr "Forbindelse"
 
-#: src/PrefsUnifiedDlg.cpp:301 src/SearchListCtrl.cpp:117
+#: src/PrefsUnifiedDlg.cpp:299 src/SearchListCtrl.cpp:117
 msgid "Directories"
 msgstr "Mapper"
 
-#: src/PrefsUnifiedDlg.cpp:302 src/Statistics.cpp:917
+#: src/PrefsUnifiedDlg.cpp:300 src/Statistics.cpp:917
 msgid "Servers"
 msgstr "Servere"
 
-#: src/PrefsUnifiedDlg.cpp:303 src/ServerListCtrl.cpp:96
+#: src/PrefsUnifiedDlg.cpp:301 src/ServerListCtrl.cpp:96
 msgid "Files"
 msgstr "Filer"
 
-#: src/PrefsUnifiedDlg.cpp:304
+#: src/PrefsUnifiedDlg.cpp:302
 msgid "Security"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:305
+#: src/PrefsUnifiedDlg.cpp:303
 msgid "Interface"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:312
+#: src/PrefsUnifiedDlg.cpp:310
 msgid "IP2Country"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:315
+#: src/PrefsUnifiedDlg.cpp:313
 msgid "Proxy"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:316
+#: src/PrefsUnifiedDlg.cpp:314
 msgid "Filters"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:317
+#: src/PrefsUnifiedDlg.cpp:315
 msgid "Remote Controls"
 msgstr "Fjern Kontrol"
 
-#: src/PrefsUnifiedDlg.cpp:318
+#: src/PrefsUnifiedDlg.cpp:316
 msgid "Online Signature"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:319
+#: src/PrefsUnifiedDlg.cpp:317
 msgid "Advanced"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:320
+#: src/PrefsUnifiedDlg.cpp:318
 msgid "Events"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:323
+#: src/PrefsUnifiedDlg.cpp:321
 msgid "Debugging"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:453
+#: src/PrefsUnifiedDlg.cpp:451
 msgid ""
 "The following variables will be substituted:\n"
 "    %PARTFILE - full path to the file\n"
 "    %PARTNAME - file name only"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:474
+#: src/PrefsUnifiedDlg.cpp:472
 msgid "Tray icon support requires libayatana-appindicator3 at compile time."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:490
+#: src/PrefsUnifiedDlg.cpp:488
 msgid "Not available on Wayland: the protocol does not report when a window is minimized, so this option cannot intercept the system minimize button. Workaround: launch aMule with `GDK_BACKEND=x11` to use XWayland instead."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:536
+#: src/PrefsUnifiedDlg.cpp:534
 msgid ""
 "Do not change these setting unless you know\n"
 "what you are doing, otherwise you can easily\n"
@@ -5693,261 +5660,247 @@ msgid ""
 "these settings."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:647
+#: src/PrefsUnifiedDlg.cpp:645
 #, c-format
 msgid "Failed to connect Cfg to widget with the ID %d and key %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:695
+#: src/PrefsUnifiedDlg.cpp:693
 #, c-format
 msgid "Failed to transfer data from Cfg to Widget with the ID %d and key %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:801
+#: src/PrefsUnifiedDlg.cpp:799
 msgid "The type of proxy you are connecting to"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1020
+#: src/PrefsUnifiedDlg.cpp:1003
 #, c-format
 msgid "Failed to transfer data from Widget to Cfg with the ID %d and key %s"
 msgstr ""
 
 #: src/PrefsUnifiedDlg.cpp:1103
-#, fuzzy
-msgid "No password set."
-msgstr "Undersøger password\n"
-
-#: src/PrefsUnifiedDlg.cpp:1132
-msgid "Guest access needs a password. Type one in the guest password field, or untick Enable guest access."
-msgstr ""
-
-#: src/PrefsUnifiedDlg.cpp:1144
 msgid ""
 "aMule must be restarted to enable these changes:\n"
 "\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1151
+#: src/PrefsUnifiedDlg.cpp:1110
 msgid "- TCP port changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1156
+#: src/PrefsUnifiedDlg.cpp:1115
 msgid "- UDP port changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1161
+#: src/PrefsUnifiedDlg.cpp:1120
 #, fuzzy
 msgid "- Network interface binding changed.\n"
 msgstr "Ydre Forbindelses Parametre"
 
-#: src/PrefsUnifiedDlg.cpp:1166
+#: src/PrefsUnifiedDlg.cpp:1125
 #, fuzzy
 msgid "- External connect port changed.\n"
 msgstr "Ydre Forbindelses Parametre"
 
-#: src/PrefsUnifiedDlg.cpp:1170
+#: src/PrefsUnifiedDlg.cpp:1129
 #, fuzzy
 msgid "- External connect acceptance changed.\n"
 msgstr "Ydre Forbindelses Parametre"
 
-#: src/PrefsUnifiedDlg.cpp:1174
+#: src/PrefsUnifiedDlg.cpp:1133
 #, fuzzy
 msgid "- External connect interface changed.\n"
 msgstr "Ydre Forbindelses Parametre"
 
-#: src/PrefsUnifiedDlg.cpp:1178
+#: src/PrefsUnifiedDlg.cpp:1137
 #, fuzzy
 msgid "- Protocol obfuscation support changed.\n"
 msgstr "Ydre Forbindelses Parametre"
 
-#: src/PrefsUnifiedDlg.cpp:1193
+#: src/PrefsUnifiedDlg.cpp:1151
 msgid "- amuleapi settings changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1202
+#: src/PrefsUnifiedDlg.cpp:1160
 msgid ""
 "Your Auto-update server list is empty.\n"
 "'Auto-update server list at startup' will be disabled."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1213
+#: src/PrefsUnifiedDlg.cpp:1171
 msgid ""
 "You have enabled external connections but have not specified a password.\n"
 "External connections cannot be enabled unless a valid password is specified."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1246
-#, c-format
-msgid "The amuleapi password could not be saved: %s"
-msgstr ""
-
-#: src/PrefsUnifiedDlg.cpp:1276
+#: src/PrefsUnifiedDlg.cpp:1202
 msgid "- Language changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1281
+#: src/PrefsUnifiedDlg.cpp:1207
 msgid "- Temp folder changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1286
+#: src/PrefsUnifiedDlg.cpp:1212
 msgid "- ED2K network enabled.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1319
+#: src/PrefsUnifiedDlg.cpp:1245
 msgid "The shared-file exclusion pattern is not a valid regular expression. The filter has been left disabled."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1321 src/PrefsUnifiedDlg.cpp:1921
+#: src/PrefsUnifiedDlg.cpp:1247 src/PrefsUnifiedDlg.cpp:1841
 msgid "Invalid regular expression"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1398
+#: src/PrefsUnifiedDlg.cpp:1324
 msgid ""
 "Both eD2k and Kad network are disabled.\n"
 "You won't be able to connect until you enable at least one of them."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1403
+#: src/PrefsUnifiedDlg.cpp:1329
 msgid ""
 "Kad will not start if your UDP port is disabled.\n"
 "Enable UDP port or disable Kad."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1459
+#: src/PrefsUnifiedDlg.cpp:1385
 msgid ""
 "\n"
 "You MUST restart aMule now.\n"
 "If you do not restart now, don't complain if anything bad happens.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1524
+#: src/PrefsUnifiedDlg.cpp:1450
 msgid "Could not register aMule for autostart at login. The autostart store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1526
+#: src/PrefsUnifiedDlg.cpp:1452
 msgid "Could not remove the autostart-at-login entry."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1527
+#: src/PrefsUnifiedDlg.cpp:1453
 #, fuzzy
 msgid "Autostart"
 msgstr "Auto Opdatering startet"
 
-#: src/PrefsUnifiedDlg.cpp:1542
+#: src/PrefsUnifiedDlg.cpp:1468
 msgid "Register file type"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1542
+#: src/PrefsUnifiedDlg.cpp:1468
 msgid "Register URL handler"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1550
+#: src/PrefsUnifiedDlg.cpp:1476
 #, c-format
 msgid "aMule only handles eD2k-compatible magnets. If you replace the current magnet handler (%s), BitTorrent magnet links will stop working - aMule cannot download BitTorrent content. Continue?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1555
+#: src/PrefsUnifiedDlg.cpp:1481
 #, c-format
 msgid "Another application currently opens .emulecollection files (%s). Replace it with aMule?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1560
+#: src/PrefsUnifiedDlg.cpp:1486
 #, c-format
 msgid "Another application is currently the default handler for these links (%s). Replace it with aMule?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1585
+#: src/PrefsUnifiedDlg.cpp:1511
 msgid "Could not register aMule for .emulecollection files. The registration store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1587
+#: src/PrefsUnifiedDlg.cpp:1513
 #, fuzzy
 msgid "Could not remove the file type registration."
 msgstr "Du prøver allerede at downloade denne fil %s"
 
-#: src/PrefsUnifiedDlg.cpp:1589
+#: src/PrefsUnifiedDlg.cpp:1515
 msgid "Could not register aMule as the URL handler. The registration store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1591
+#: src/PrefsUnifiedDlg.cpp:1517
 msgid "Could not remove the URL handler registration."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1661 src/PrefsUnifiedDlg.cpp:1688
+#: src/PrefsUnifiedDlg.cpp:1587 src/PrefsUnifiedDlg.cpp:1614
 #, fuzzy
 msgid "The web server and aMule API require external connections to be enabled."
 msgstr "Accepter ydre forbindelser"
 
-#: src/PrefsUnifiedDlg.cpp:1671
+#: src/PrefsUnifiedDlg.cpp:1597
 msgid "The aMule web server is deprecated. Consider running the aMule API instead."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1735
+#: src/PrefsUnifiedDlg.cpp:1655
 msgid ""
 "Your Auto-update servers list is in blank.\n"
 "Please fill in at least one URL to point to a valid server.met file.\n"
 "Click on the button \"List\" by this checkbox to enter an URL."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1876
+#: src/PrefsUnifiedDlg.cpp:1796
 msgid "Temporary files"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1881
+#: src/PrefsUnifiedDlg.cpp:1801
 msgid "Incoming files"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1886
+#: src/PrefsUnifiedDlg.cpp:1806
 msgid "Online Signatures"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1899
+#: src/PrefsUnifiedDlg.cpp:1819
 #, c-format
 msgid "Choose a folder for %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1923
+#: src/PrefsUnifiedDlg.cpp:1843
 #, fuzzy, c-format
 msgid "Would exclude %u of %u shared file"
 msgid_plural "Would exclude %u of %u shared files"
 msgstr[0] "Fandt %i kendte delte filer"
 msgstr[1] "Fandt %i kendte delte filer"
 
-#: src/PrefsUnifiedDlg.cpp:1940
+#: src/PrefsUnifiedDlg.cpp:1860
 msgid "Browse for videoplayer"
 msgstr "Gennemse efter Video Afspiller"
 
-#: src/PrefsUnifiedDlg.cpp:1944
+#: src/PrefsUnifiedDlg.cpp:1864
 msgid "Select browser"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1948
+#: src/PrefsUnifiedDlg.cpp:1868
 msgid "Select ffprobe binary"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1954
+#: src/PrefsUnifiedDlg.cpp:1874
 #, c-format
 msgid "Executable%s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1988
+#: src/PrefsUnifiedDlg.cpp:1908
 msgid "ffprobe not found on PATH or in the standard install locations. Install ffmpeg (which ships ffprobe) or use Browse to pick a binary manually."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2000
+#: src/PrefsUnifiedDlg.cpp:1920
 msgid "Reset the settings on this page to their default values?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2001
+#: src/PrefsUnifiedDlg.cpp:1921
 #, fuzzy
 msgid "Reset to defaults"
 msgstr "System standard"
 
-#: src/PrefsUnifiedDlg.cpp:2028
+#: src/PrefsUnifiedDlg.cpp:1948
 msgid "Edit server list"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2029
+#: src/PrefsUnifiedDlg.cpp:1949
 msgid ""
 "Add here URL's to download server.met files.\n"
 "Only one url on each line."
@@ -5955,179 +5908,175 @@ msgstr ""
 "Tilføj URLer hvor der kan hentes server.met filer.\n"
 "Kun en URL på hver linje."
 
-#: src/PrefsUnifiedDlg.cpp:2084
+#: src/PrefsUnifiedDlg.cpp:2004
 msgid "IP2Country update failed"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2229 src/PrefsUnifiedDlg.cpp:2260
+#: src/PrefsUnifiedDlg.cpp:2149 src/PrefsUnifiedDlg.cpp:2180
 msgid "Data by MaxMind GeoLite2"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2231 src/PrefsUnifiedDlg.cpp:2262
+#: src/PrefsUnifiedDlg.cpp:2151 src/PrefsUnifiedDlg.cpp:2182
 #, fuzzy
 msgid "Custom source"
 msgstr "Hele kilder"
 
-#: src/PrefsUnifiedDlg.cpp:2233 src/PrefsUnifiedDlg.cpp:2264
+#: src/PrefsUnifiedDlg.cpp:2153 src/PrefsUnifiedDlg.cpp:2184
 msgid "Data by DB-IP.com"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2284
+#: src/PrefsUnifiedDlg.cpp:2204
 #, c-format
 msgid "Status: Loaded%s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2286
+#: src/PrefsUnifiedDlg.cpp:2206
 #, c-format
 msgid "Status: Loaded%s - %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2290
+#: src/PrefsUnifiedDlg.cpp:2210
 msgid "Status: Failed to load - click 'Update now' to refresh."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2292
+#: src/PrefsUnifiedDlg.cpp:2212
 msgid "Status: Not found - click 'Update now' to download."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2350 src/PrefsUnifiedDlg.cpp:2374
+#: src/PrefsUnifiedDlg.cpp:2270 src/PrefsUnifiedDlg.cpp:2294
 #, fuzzy, c-format
 msgid "Update delay: %d second"
 msgid_plural "Update delay: %d seconds"
 msgstr[0] "Opdaterings interval : 5 sek"
 msgstr[1] "Opdaterings interval : 5 sek"
 
-#: src/PrefsUnifiedDlg.cpp:2358
+#: src/PrefsUnifiedDlg.cpp:2278
 #, fuzzy, c-format
 msgid "Time for average graph: %d minute"
 msgid_plural "Time for average graph: %d minutes"
 msgstr[0] "Tid for gennemsnitlig graf: 100 min"
 msgstr[1] "Tid for gennemsnitlig graf: 100 min"
 
-#: src/PrefsUnifiedDlg.cpp:2367
+#: src/PrefsUnifiedDlg.cpp:2287
 #, c-format
 msgid "Connections Graph Scale: %d"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2382
+#: src/PrefsUnifiedDlg.cpp:2302
 #, fuzzy, c-format
 msgid "File Buffer Size: %d byte"
 msgid_plural "File Buffer Size: %d bytes"
 msgstr[0] "Fil Buffer StÃžrrelse %i bytes"
 msgstr[1] "Fil Buffer StÃžrrelse %i bytes"
 
-#: src/PrefsUnifiedDlg.cpp:2392
+#: src/PrefsUnifiedDlg.cpp:2312
 #, c-format
 msgid "Upload Queue Size: %d client"
 msgid_plural "Upload Queue Size: %d clients"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/PrefsUnifiedDlg.cpp:2402
+#: src/PrefsUnifiedDlg.cpp:2322
 #, fuzzy, c-format
 msgid "Server connection refresh interval: %d minute"
 msgid_plural "Server connection refresh interval: %d minutes"
 msgstr[0] "Server forbindelses opdaterings interval %i min"
 msgstr[1] "Server forbindelses opdaterings interval %i min"
 
-#: src/PrefsUnifiedDlg.cpp:2407
+#: src/PrefsUnifiedDlg.cpp:2327
 msgid "Server connection refresh interval: Disabled"
 msgstr "Server forbindelses opdaterings interval: Inaktiv"
 
-#: src/PrefsUnifiedDlg.cpp:2451
+#: src/PrefsUnifiedDlg.cpp:2371
 #, fuzzy
 msgid "disabled"
 msgstr "deaktiver"
 
-#: src/PrefsUnifiedDlg.cpp:2477
+#: src/PrefsUnifiedDlg.cpp:2397
 #, c-format
 msgid "Execute command on '%s' event"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2484
+#: src/PrefsUnifiedDlg.cpp:2404
 msgid "Enable command execution on core"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2496
+#: src/PrefsUnifiedDlg.cpp:2416
 msgid "Core command:"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2512
+#: src/PrefsUnifiedDlg.cpp:2432
 msgid "Enable command execution on GUI"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2524
+#: src/PrefsUnifiedDlg.cpp:2444
 msgid "GUI command:"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2540
+#: src/PrefsUnifiedDlg.cpp:2460
 msgid "The following variables will be replaced:"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2708
+#: src/PrefsUnifiedDlg.cpp:2628
 msgid ""
 "The following folders look like system or sensitive locations:\n"
 "\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2713
+#: src/PrefsUnifiedDlg.cpp:2633
 msgid "Sharing them recursively will publish every file underneath on the eD2k/Kad networks. Do you really want to do this?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2716
+#: src/PrefsUnifiedDlg.cpp:2636
 msgid "Confirm shared folders"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2744
+#: src/PrefsUnifiedDlg.cpp:2664
 #, fuzzy
 msgid "Reloading shared files..."
 msgstr "Fandt %i kendte delte filer"
 
-#: src/PrefsUnifiedDlg.cpp:2745
+#: src/PrefsUnifiedDlg.cpp:2665
 msgid "Scanning for subdirectories..."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2746
+#: src/PrefsUnifiedDlg.cpp:2666
 msgid "Updating shared folders"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2773
+#: src/PrefsUnifiedDlg.cpp:2693
 #, c-format
 msgid "Scanned %u directories..."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2823
+#: src/PrefsUnifiedDlg.cpp:2743
 #, c-format
 msgid "Reloading shared files: %u files scanned"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2873
+#: src/PrefsUnifiedDlg.cpp:2793
 #, fuzzy
 msgid "Shared folder"
 msgstr "Delte Filer"
 
-#: src/SearchDlg.cpp:280
-msgid "Clear search history"
-msgstr ""
-
-#: src/SearchDlg.cpp:584
+#: src/SearchDlg.cpp:425
 msgid "It's impossible to search when both eD2k and Kademlia are disabled."
 msgstr ""
 
-#: src/SearchDlg.cpp:585 src/SearchListCtrl.cpp:858
+#: src/SearchDlg.cpp:426 src/SearchListCtrl.cpp:858
 #, fuzzy
 msgid "Search error"
 msgstr "Søg"
 
-#: src/SearchDlg.cpp:929
+#: src/SearchDlg.cpp:768
 msgid "Min size must be smaller than max size. Max size ignored."
 msgstr ""
 
-#: src/SearchDlg.cpp:930 src/SearchDlg.cpp:1012
+#: src/SearchDlg.cpp:769 src/SearchDlg.cpp:851
 msgid "Search warning"
 msgstr ""
 
-#: src/SearchDlg.cpp:1092 src/SearchListCtrl.cpp:735
+#: src/SearchDlg.cpp:929 src/SearchListCtrl.cpp:735
 msgid "Main"
 msgstr ""
 

--- a/po/da.po
+++ b/po/da.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-28 08:06+0200\n"
+"POT-Creation-Date: 2026-07-28 10:19+0200\n"
 "PO-Revision-Date: 2026-07-27 11:34+0000\n"
 "Last-Translator: Alex Thomsen Leth <alexl@stofanet.dk>\n"
 "Language-Team: aMule Team <https://github.com/amule-org/amule>\n"
@@ -136,7 +136,7 @@ msgstr ""
 msgid "Not now"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:422 src/amuleDlg.cpp:600
+#: src/AppImageIntegration.cpp:422 src/amuleDlg.cpp:665
 msgid "Don't ask again"
 msgstr ""
 
@@ -209,7 +209,7 @@ msgid "Killing amuleweb instance with pid '%d' ... "
 msgstr ""
 
 #: src/amule.cpp:336 src/amule.cpp:349 src/ClientRef.cpp:180
-#: src/SearchDlg.cpp:880 src/ServerListCtrl.cpp:98
+#: src/SearchDlg.cpp:1041 src/ServerListCtrl.cpp:98
 msgid "Failed"
 msgstr "Fejlede"
 
@@ -555,30 +555,68 @@ msgstr ""
 msgid "ERROR: %s"
 msgstr ""
 
-#: src/amuleDlg.cpp:236
+#: src/amuleDlg.cpp:250
 #, c-format
 msgid "This is aMule %s based on eMule."
 msgstr ""
 
-#: src/amuleDlg.cpp:237
+#: src/amuleDlg.cpp:251
 #, c-format
 msgid "Running on %s"
 msgstr ""
 
-#: src/amuleDlg.cpp:239
+#: src/amuleDlg.cpp:253
 msgid "Visit https://github.com/amule-org/amule/releases/latest to check if a new version is available."
 msgstr ""
 
-#: src/amuleDlg.cpp:268
+#: src/amuleDlg.cpp:282
 msgid "FATAL ERROR: Failed to create Timer"
 msgstr ""
 
-#: src/amuleDlg.cpp:592
+#: src/amuleDlg.cpp:361 src/amuleDlg.cpp:1787 src/amuleDlg.cpp:2033
+#: src/muuli_wdr.cpp:1492 src/muuli_wdr.cpp:3418
+msgid "Networks"
+msgstr ""
+
+#: src/amuleDlg.cpp:362 src/amuleDlg.cpp:1793 src/muuli_wdr.cpp:3419
+msgid "Searches"
+msgstr "Søg"
+
+#: src/amuleDlg.cpp:363 src/amuleDlg.cpp:1799 src/DownloadListCtrl.cpp:740
+#: src/muuli_wdr.cpp:392 src/muuli_wdr.cpp:1585 src/muuli_wdr.cpp:3420
+#: src/Statistics.cpp:829
+msgid "Downloads"
+msgstr "Downloads"
+
+#: src/amuleDlg.cpp:364 src/amuleDlg.cpp:1805 src/muuli_wdr.cpp:3294
+msgid "Shared files"
+msgstr ""
+
+#: src/amuleDlg.cpp:365 src/amuleDlg.cpp:1811 src/muuli_wdr.cpp:2926
+#: src/muuli_wdr.cpp:3376 src/muuli_wdr.cpp:3423
+msgid "Messages"
+msgstr "Beskeder"
+
+#: src/amuleDlg.cpp:366 src/amuleDlg.cpp:1817 src/muuli_wdr.cpp:3424
+#: src/PrefsUnifiedDlg.cpp:312 src/Statistics.cpp:779 src/Statistics.cpp:1235
+msgid "Statistics"
+msgstr "Statistik"
+
+#: src/amuleDlg.cpp:368 src/amuleDlg.cpp:1824 src/muuli_wdr.cpp:3426
+#: src/PrefsUnifiedDlg.cpp:328 src/utils/wxCas/src/wxcasprefs.cpp:39
+msgid "Preferences"
+msgstr "Indstillinger"
+
+#: src/amuleDlg.cpp:371
+msgid "Navigate"
+msgstr ""
+
+#: src/amuleDlg.cpp:657
 #, fuzzy
 msgid "New version available"
 msgstr "Ikke tilgængelig"
 
-#: src/amuleDlg.cpp:596
+#: src/amuleDlg.cpp:661
 #, fuzzy, c-format
 msgid ""
 "A new version of aMule (%s) is available.\n"
@@ -588,224 +626,191 @@ msgid ""
 "Would you like to open the download page?"
 msgstr "Den sidste nye version kan altid findes hos https://github.com/amule-org/amule/releases/latest"
 
-#: src/amuleDlg.cpp:678
+#: src/amuleDlg.cpp:743
 msgid "aMule dialog destroyed"
 msgstr ""
 
-#: src/amuleDlg.cpp:701 src/DataToText.cpp:68 src/IPFilter.cpp:547
+#: src/amuleDlg.cpp:766 src/DataToText.cpp:68 src/IPFilter.cpp:547
 msgid "Connecting"
 msgstr "Forbinder"
 
-#: src/amuleDlg.cpp:893
+#: src/amuleDlg.cpp:958
 msgid "eD2k: Connecting"
 msgstr ""
 
-#: src/amuleDlg.cpp:897
+#: src/amuleDlg.cpp:962
 msgid "eD2k: Disconnected"
 msgstr ""
 
-#: src/amuleDlg.cpp:903
+#: src/amuleDlg.cpp:968
 #, fuzzy
 msgid "Kad: Firewalled"
 msgstr "firewalled"
 
-#: src/amuleDlg.cpp:907
+#: src/amuleDlg.cpp:972
 #, fuzzy
 msgid "Kad: Connected"
 msgstr "Forbundet"
 
-#: src/amuleDlg.cpp:912
+#: src/amuleDlg.cpp:977
 #, fuzzy
 msgid "Kad: Connecting"
 msgstr "Forbinder"
 
-#: src/amuleDlg.cpp:916
+#: src/amuleDlg.cpp:981
 #, fuzzy
 msgid "Kad: Off"
 msgstr " Kad: "
 
-#: src/amuleDlg.cpp:964 src/DownloadListCtrl.cpp:505
+#: src/amuleDlg.cpp:1029 src/DownloadListCtrl.cpp:505
 #: src/DownloadListCtrl.cpp:749 src/FriendListCtrl.cpp:180
 #: src/muuli_wdr.cpp:731 src/muuli_wdr.cpp:782 src/muuli_wdr.cpp:846
-#: src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2224 src/muuli_wdr.cpp:2309
-#: src/muuli_wdr.cpp:3057 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
+#: src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2231 src/muuli_wdr.cpp:2316
+#: src/muuli_wdr.cpp:3064 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
 #: src/ServerListCtrl.cpp:606 src/TransferWnd.cpp:378
 #: src/utils/wxCas/src/wxcasprefs.cpp:235
 msgid "Cancel"
 msgstr "Afbryd"
 
-#: src/amuleDlg.cpp:965
+#: src/amuleDlg.cpp:1030
 #, fuzzy
 msgid "Stop the current connection attempts"
 msgstr "Stop de nuværende forbindelses forsøg"
 
-#: src/amuleDlg.cpp:970 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976
-#: src/muuli_wdr.cpp:2447
+#: src/amuleDlg.cpp:1035 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976
+#: src/muuli_wdr.cpp:2454
 msgid "Disconnect"
 msgstr "Afbryd"
 
-#: src/amuleDlg.cpp:971
+#: src/amuleDlg.cpp:1036
 #, fuzzy
 msgid "Disconnect from the currently connected networks"
 msgstr "Afbryd fra nuvÃŠrende server"
 
-#: src/amuleDlg.cpp:976 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979
-#: src/muuli_wdr.cpp:2602 src/muuli_wdr.cpp:3054 src/muuli_wdr.cpp:3409
+#: src/amuleDlg.cpp:1041 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979
+#: src/muuli_wdr.cpp:2609 src/muuli_wdr.cpp:3061 src/muuli_wdr.cpp:3416
 msgid "Connect"
 msgstr "Forbind"
 
-#: src/amuleDlg.cpp:977
+#: src/amuleDlg.cpp:1042
 msgid "Connect to the currently enabled networks"
 msgstr ""
 
-#: src/amuleDlg.cpp:1089
+#: src/amuleDlg.cpp:1154
 #, fuzzy, c-format
 msgid "Up: %.1f%s (%.1f) | Down: %.1f%s (%.1f)"
 msgstr "Up: %.1f(%.1f) | Down: %.1f(%.1f)"
 
-#: src/amuleDlg.cpp:1091 src/amuleDlg.cpp:1093 src/amuleDlg.cpp:1097
-#: src/amuleDlg.cpp:1099 src/amuleDlg.cpp:1110 src/amuleDlg.cpp:1112
+#: src/amuleDlg.cpp:1156 src/amuleDlg.cpp:1158 src/amuleDlg.cpp:1162
+#: src/amuleDlg.cpp:1164 src/amuleDlg.cpp:1175 src/amuleDlg.cpp:1177
 #: src/MuleTrayIcon.cpp:796 src/MuleTrayIcon.cpp:799
 msgid " MB/s"
 msgstr ""
 
-#: src/amuleDlg.cpp:1091 src/amuleDlg.cpp:1093 src/amuleDlg.cpp:1097
-#: src/amuleDlg.cpp:1099 src/amuleDlg.cpp:1110 src/amuleDlg.cpp:1112
+#: src/amuleDlg.cpp:1156 src/amuleDlg.cpp:1158 src/amuleDlg.cpp:1162
+#: src/amuleDlg.cpp:1164 src/amuleDlg.cpp:1175 src/amuleDlg.cpp:1177
 #: src/MuleTrayIcon.cpp:796 src/MuleTrayIcon.cpp:799
 #: src/utils/wxCas/src/wxcasframe.cpp:1041
 msgid " kB/s"
 msgstr " kB/s"
 
-#: src/amuleDlg.cpp:1096
+#: src/amuleDlg.cpp:1161
 #, fuzzy, c-format
 msgid "Up: %.1f%s | Down: %.1f%s"
 msgstr "Op: %.1f | Ned: %.1f"
 
-#: src/amuleDlg.cpp:1128
+#: src/amuleDlg.cpp:1193
 #, c-format
 msgid "aMule (%s | Connected)"
 msgstr ""
 
-#: src/amuleDlg.cpp:1130
+#: src/amuleDlg.cpp:1195
 #, c-format
 msgid "aMule (%s | Disconnected)"
 msgstr ""
 
-#: src/amuleDlg.cpp:1183
+#: src/amuleDlg.cpp:1248
 #, fuzzy, c-format
 msgid "Do you really want to exit %s?"
 msgstr "Vil du virkelig afslutte aMule?"
 
-#: src/amuleDlg.cpp:1185
+#: src/amuleDlg.cpp:1250
 msgid "Exit confirmation"
 msgstr "Bekræft afslut"
 
-#: src/amuleDlg.cpp:1548
+#: src/amuleDlg.cpp:1613
 msgid "Launch Command: "
 msgstr ""
 
-#: src/amuleDlg.cpp:1567 src/muuli_wdr.cpp:1971 src/Preferences.cpp:951
+#: src/amuleDlg.cpp:1632 src/muuli_wdr.cpp:1978 src/Preferences.cpp:952
 msgid "- default -"
 msgstr ""
 
-#: src/amuleDlg.cpp:1595
+#: src/amuleDlg.cpp:1660
 #, c-format
 msgid "Skin directory '%s' does not exist"
 msgstr ""
 
-#: src/amuleDlg.cpp:1598
+#: src/amuleDlg.cpp:1663
 #, c-format
 msgid "WARNING: Unable to open skin file '%s' for read"
 msgstr ""
 
-#: src/amuleDlg.cpp:1722 src/amuleDlg.cpp:1968 src/muuli_wdr.cpp:1485
-#: src/muuli_wdr.cpp:3411
-msgid "Networks"
-msgstr ""
-
-#: src/amuleDlg.cpp:1726 src/muuli_wdr.cpp:3411
+#: src/amuleDlg.cpp:1791 src/muuli_wdr.cpp:3418
 msgid "Networks Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1728 src/muuli_wdr.cpp:3412
-msgid "Searches"
-msgstr "Søg"
-
-#: src/amuleDlg.cpp:1732 src/muuli_wdr.cpp:3412
+#: src/amuleDlg.cpp:1797 src/muuli_wdr.cpp:3419
 msgid "Searches Window"
 msgstr "Søge Vindue"
 
-#: src/amuleDlg.cpp:1734 src/DownloadListCtrl.cpp:740 src/muuli_wdr.cpp:392
-#: src/muuli_wdr.cpp:1578 src/muuli_wdr.cpp:3413 src/Statistics.cpp:829
-msgid "Downloads"
-msgstr "Downloads"
-
-#: src/amuleDlg.cpp:1738 src/muuli_wdr.cpp:3413
+#: src/amuleDlg.cpp:1803 src/muuli_wdr.cpp:3420
 #, fuzzy
 msgid "Downloads Window"
 msgstr "Henter"
 
-#: src/amuleDlg.cpp:1740 src/muuli_wdr.cpp:3287
-msgid "Shared files"
-msgstr ""
-
-#: src/amuleDlg.cpp:1744 src/muuli_wdr.cpp:3415
+#: src/amuleDlg.cpp:1809 src/muuli_wdr.cpp:3422
 msgid "Shared Files Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1746 src/muuli_wdr.cpp:2919 src/muuli_wdr.cpp:3369
-#: src/muuli_wdr.cpp:3416
-msgid "Messages"
-msgstr "Beskeder"
-
-#: src/amuleDlg.cpp:1750 src/muuli_wdr.cpp:3416
+#: src/amuleDlg.cpp:1815 src/muuli_wdr.cpp:3423
 msgid "Messages Window"
 msgstr "Besked Vindue"
 
-#: src/amuleDlg.cpp:1752 src/muuli_wdr.cpp:3417 src/PrefsUnifiedDlg.cpp:312
-#: src/Statistics.cpp:779 src/Statistics.cpp:1235
-msgid "Statistics"
-msgstr "Statistik"
-
-#: src/amuleDlg.cpp:1756 src/muuli_wdr.cpp:3417
+#: src/amuleDlg.cpp:1821 src/muuli_wdr.cpp:3424
 msgid "Statistics Graph Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1759 src/muuli_wdr.cpp:3419 src/PrefsUnifiedDlg.cpp:328
-#: src/utils/wxCas/src/wxcasprefs.cpp:39
-msgid "Preferences"
-msgstr "Indstillinger"
-
-#: src/amuleDlg.cpp:1763 src/muuli_wdr.cpp:3419
+#: src/amuleDlg.cpp:1828 src/muuli_wdr.cpp:3426
 msgid "Preferences Settings Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1766 src/muuli_wdr.cpp:3420
+#: src/amuleDlg.cpp:1831 src/muuli_wdr.cpp:3427
 msgid "Import"
 msgstr ""
 
-#: src/amuleDlg.cpp:1770 src/muuli_wdr.cpp:3420
+#: src/amuleDlg.cpp:1835 src/muuli_wdr.cpp:3427
 msgid "The partfile importer tool"
 msgstr ""
 
-#: src/amuleDlg.cpp:1773 src/muuli_wdr.cpp:3421
+#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3428
 #: src/utils/aLinkCreator/src/alcframe.cpp:262
 msgid "About"
 msgstr ""
 
-#: src/amuleDlg.cpp:1773 src/muuli_wdr.cpp:3421
+#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3428
 msgid "About/Help"
 msgstr ""
 
-#: src/amuleDlg.cpp:1971
+#: src/amuleDlg.cpp:2036
 msgid "eD2k network"
 msgstr ""
 
-#: src/amuleDlg.cpp:1974
+#: src/amuleDlg.cpp:2039
 msgid "Kad network"
 msgstr ""
 
-#: src/amuleDlg.cpp:1974
+#: src/amuleDlg.cpp:2039
 msgid "No network"
 msgstr ""
 
@@ -1341,19 +1346,19 @@ msgstr "Auto [Hø]"
 msgid "Very low"
 msgstr "Meget lav"
 
-#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:743 src/muuli_wdr.cpp:2275
+#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:743 src/muuli_wdr.cpp:2282
 #: src/ServerListCtrl.cpp:263 src/ServerListCtrl.cpp:456
 #: src/SharedFilesCtrl.cpp:145
 msgid "Low"
 msgstr "Lav"
 
-#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:744 src/muuli_wdr.cpp:2276
+#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:744 src/muuli_wdr.cpp:2283
 #: src/ServerListCtrl.cpp:266 src/ServerListCtrl.cpp:457
 #: src/SharedFilesCtrl.cpp:146
 msgid "Normal"
 msgstr "Normal"
 
-#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:745 src/muuli_wdr.cpp:2277
+#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:745 src/muuli_wdr.cpp:2284
 #: src/ServerListCtrl.cpp:269 src/ServerListCtrl.cpp:458
 #: src/SharedFilesCtrl.cpp:147
 msgid "High"
@@ -1445,8 +1450,8 @@ msgstr ""
 msgid "Remote Server"
 msgstr ""
 
-#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3174
-#: src/SearchDlg.cpp:111 src/TextClient.cpp:911
+#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3181
+#: src/SearchDlg.cpp:119 src/TextClient.cpp:911
 msgid "Kad"
 msgstr ""
 
@@ -1516,7 +1521,7 @@ msgstr ""
 msgid "Size"
 msgstr "Størrelse"
 
-#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3241
+#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3248
 msgid "Transferred"
 msgstr "Overført"
 
@@ -1574,7 +1579,7 @@ msgid ""
 "\n"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:746 src/muuli_wdr.cpp:2278
+#: src/DownloadListCtrl.cpp:746 src/muuli_wdr.cpp:2285
 #: src/SharedFilesCtrl.cpp:150
 msgid "Auto"
 msgstr "Auto"
@@ -1612,7 +1617,7 @@ msgid "Extended Options"
 msgstr "Udvidet Muligheder"
 
 #: src/DownloadListCtrl.cpp:770 src/DownloadListCtrl.cpp:822
-#: src/muuli_wdr.cpp:1789
+#: src/muuli_wdr.cpp:1796
 msgid "Preview"
 msgstr "Smug Kig"
 
@@ -2295,19 +2300,19 @@ msgstr ""
 msgid "eD2k"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:349 src/muuli_wdr.cpp:1488
+#: src/FirstRunWizard.cpp:349 src/muuli_wdr.cpp:1495
 msgid "Kademlia"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:359 src/muuli_wdr.cpp:1416
+#: src/FirstRunWizard.cpp:359 src/muuli_wdr.cpp:1423
 msgid "Standard TCP Port "
 msgstr ""
 
-#: src/FirstRunWizard.cpp:365 src/muuli_wdr.cpp:1428
+#: src/FirstRunWizard.cpp:365 src/muuli_wdr.cpp:1435
 msgid "Extended UDP port (Kad / global search) "
 msgstr ""
 
-#: src/FirstRunWizard.cpp:377 src/muuli_wdr.cpp:1435
+#: src/FirstRunWizard.cpp:377 src/muuli_wdr.cpp:1442
 msgid "Enable UPnP for router port forwarding"
 msgstr ""
 
@@ -2333,7 +2338,7 @@ msgstr ""
 msgid "Your peer lists are already in place - nothing to download."
 msgstr "Du prøver allerede at downloade denne fil %s"
 
-#: src/FirstRunWizard.cpp:434 src/muuli_wdr.cpp:1533
+#: src/FirstRunWizard.cpp:434 src/muuli_wdr.cpp:1540
 msgid "Auto-update server list at startup"
 msgstr ""
 
@@ -2379,23 +2384,23 @@ msgid ""
 "want downloads on a different (e.g. larger) disk."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:549 src/FirstRunWizard.cpp:611 src/muuli_wdr.cpp:1701
+#: src/FirstRunWizard.cpp:549 src/FirstRunWizard.cpp:611 src/muuli_wdr.cpp:1708
 msgid "Destination folder for downloads"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:553 src/FirstRunWizard.cpp:569 src/muuli_wdr.cpp:1342
-#: src/muuli_wdr.cpp:1359 src/muuli_wdr.cpp:1676 src/muuli_wdr.cpp:1707
-#: src/muuli_wdr.cpp:1719 src/muuli_wdr.cpp:2762
+#: src/FirstRunWizard.cpp:553 src/FirstRunWizard.cpp:569 src/muuli_wdr.cpp:1349
+#: src/muuli_wdr.cpp:1366 src/muuli_wdr.cpp:1683 src/muuli_wdr.cpp:1714
+#: src/muuli_wdr.cpp:1726 src/muuli_wdr.cpp:2769
 #: src/utils/aLinkCreator/src/alcframe.cpp:135
 #: src/utils/wxCas/src/wxcasprefs.cpp:52 src/utils/wxCas/src/wxcasprefs.cpp:118
 msgid "Browse"
 msgstr "Gennemse"
 
-#: src/FirstRunWizard.cpp:559 src/muuli_wdr.cpp:1712
+#: src/FirstRunWizard.cpp:559 src/muuli_wdr.cpp:1719
 msgid "(All files in this folder are shared with other peers)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:565 src/FirstRunWizard.cpp:624 src/muuli_wdr.cpp:1714
+#: src/FirstRunWizard.cpp:565 src/FirstRunWizard.cpp:624 src/muuli_wdr.cpp:1721
 msgid "Folder for temporary download files"
 msgstr ""
 
@@ -2426,7 +2431,7 @@ msgstr ""
 msgid "CRITICAL - no client on StartChatSession"
 msgstr ""
 
-#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2668 src/muuli_wdr.cpp:3345
+#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2675 src/muuli_wdr.cpp:3352
 msgid "Friends"
 msgstr "Venner"
 
@@ -2811,7 +2816,7 @@ msgstr ""
 msgid "Uploaded"
 msgstr ""
 
-#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3225
+#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3232
 msgid "Requested"
 msgstr ""
 
@@ -2937,7 +2942,7 @@ msgid "WARNING: "
 msgstr ""
 
 #: src/MuleNotebook.cpp:179 src/muuli_wdr.cpp:817 src/muuli_wdr.cpp:1229
-#: src/muuli_wdr.cpp:3129 src/muuli_wdr.cpp:3385
+#: src/muuli_wdr.cpp:3136 src/muuli_wdr.cpp:3392
 msgid "Close"
 msgstr "Luk"
 
@@ -2950,12 +2955,12 @@ msgstr ""
 msgid "Copy"
 msgstr ""
 
-#: src/MuleTextCtrl.cpp:88
+#: src/MuleTextCtrl.cpp:88 src/SearchDlg.cpp:261
 msgid "Paste"
 msgstr ""
 
 #: src/MuleTextCtrl.cpp:89 src/muuli_wdr.cpp:358 src/muuli_wdr.cpp:757
-#: src/muuli_wdr.cpp:2352 src/muuli_wdr.cpp:2371 src/muuli_wdr.cpp:2393
+#: src/muuli_wdr.cpp:2359 src/muuli_wdr.cpp:2378 src/muuli_wdr.cpp:2400
 #: src/utils/aLinkCreator/src/alcframe.cpp:142
 msgid "Clear"
 msgstr "Ryd"
@@ -3052,8 +3057,8 @@ msgid "Exit"
 msgstr "Afslut"
 
 #: src/MuleTrayIcon.cpp:579 src/MuleTrayIcon.cpp:945 src/MuleTrayIcon.cpp:965
-#: src/muuli_wdr.cpp:1391 src/muuli_wdr.cpp:1399 src/muuli_wdr.cpp:1406
-#: src/muuli_wdr.cpp:1835 src/muuli_wdr.cpp:1841 src/OtherFunctions.cpp:91
+#: src/muuli_wdr.cpp:1398 src/muuli_wdr.cpp:1406 src/muuli_wdr.cpp:1413
+#: src/muuli_wdr.cpp:1842 src/muuli_wdr.cpp:1848 src/OtherFunctions.cpp:91
 #: src/StatisticsDlg.cpp:93 src/StatisticsDlg.cpp:95
 msgid "kB/s"
 msgstr "kB/s"
@@ -3223,7 +3228,7 @@ msgstr ""
 msgid "Type"
 msgstr "Type"
 
-#: src/muuli_wdr.cpp:215 src/SearchDlg.cpp:110 src/SearchListCtrl.cpp:853
+#: src/muuli_wdr.cpp:215 src/SearchDlg.cpp:118 src/SearchListCtrl.cpp:853
 msgid "Local"
 msgstr ""
 
@@ -3294,7 +3299,7 @@ msgstr "Bytes"
 msgid "KB"
 msgstr "KB"
 
-#: src/muuli_wdr.cpp:274 src/muuli_wdr.cpp:293 src/muuli_wdr.cpp:1620
+#: src/muuli_wdr.cpp:274 src/muuli_wdr.cpp:293 src/muuli_wdr.cpp:1627
 #: src/OtherFunctions.cpp:64
 msgid "MB"
 msgstr "MB"
@@ -3311,7 +3316,7 @@ msgstr "Max Størrelse"
 msgid "Availability"
 msgstr ""
 
-#: src/muuli_wdr.cpp:312 src/muuli_wdr.cpp:398 src/muuli_wdr.cpp:3290
+#: src/muuli_wdr.cpp:312 src/muuli_wdr.cpp:398 src/muuli_wdr.cpp:3297
 msgid "Filter:"
 msgstr ""
 
@@ -3343,7 +3348,7 @@ msgstr ""
 msgid "Stop"
 msgstr ""
 
-#: src/muuli_wdr.cpp:348 src/muuli_wdr.cpp:1385 src/SearchListCtrl.cpp:732
+#: src/muuli_wdr.cpp:348 src/muuli_wdr.cpp:1392 src/SearchListCtrl.cpp:732
 msgid "Download"
 msgstr "Download"
 
@@ -3375,8 +3380,8 @@ msgstr "Fundne Kilder :"
 #: src/muuli_wdr.cpp:1160 src/muuli_wdr.cpp:1167 src/muuli_wdr.cpp:1172
 #: src/muuli_wdr.cpp:1179 src/muuli_wdr.cpp:1184 src/muuli_wdr.cpp:1191
 #: src/muuli_wdr.cpp:1205 src/muuli_wdr.cpp:1212 src/muuli_wdr.cpp:1217
-#: src/muuli_wdr.cpp:1224 src/muuli_wdr.cpp:3227 src/muuli_wdr.cpp:3235
-#: src/muuli_wdr.cpp:3243
+#: src/muuli_wdr.cpp:1224 src/muuli_wdr.cpp:3234 src/muuli_wdr.cpp:3242
+#: src/muuli_wdr.cpp:3250
 msgid "N/A"
 msgstr "N/A"
 
@@ -3520,7 +3525,7 @@ msgstr ""
 msgid "Album :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:685 src/muuli_wdr.cpp:2247
+#: src/muuli_wdr.cpp:685 src/muuli_wdr.cpp:2254
 msgid "Title :"
 msgstr "Titel :"
 
@@ -3627,7 +3632,7 @@ msgstr "Brugernavn :"
 msgid "Userhash :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:895 src/muuli_wdr.cpp:1741 src/muuli_wdr.cpp:2442
+#: src/muuli_wdr.cpp:895 src/muuli_wdr.cpp:1748 src/muuli_wdr.cpp:2449
 #: src/utils/aLinkCreator/src/alcframe.cpp:137
 msgid "Add"
 msgstr "Tilføj"
@@ -3636,15 +3641,15 @@ msgstr "Tilføj"
 msgid "Download-Speed"
 msgstr "Download-Hastighed"
 
-#: src/muuli_wdr.cpp:954 src/muuli_wdr.cpp:989 src/muuli_wdr.cpp:2546
+#: src/muuli_wdr.cpp:954 src/muuli_wdr.cpp:989 src/muuli_wdr.cpp:2553
 msgid "Current"
 msgstr "Nuværende"
 
-#: src/muuli_wdr.cpp:962 src/muuli_wdr.cpp:997 src/muuli_wdr.cpp:2554
+#: src/muuli_wdr.cpp:962 src/muuli_wdr.cpp:997 src/muuli_wdr.cpp:2561
 msgid "Running average"
 msgstr "Nuværende Gennemsnit"
 
-#: src/muuli_wdr.cpp:970 src/muuli_wdr.cpp:1005 src/muuli_wdr.cpp:2562
+#: src/muuli_wdr.cpp:970 src/muuli_wdr.cpp:1005 src/muuli_wdr.cpp:2569
 msgid "Session average"
 msgstr "Sessions Gennemsnit"
 
@@ -3656,7 +3661,7 @@ msgstr "Upload-Hastighed"
 msgid "Connections"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1024 src/muuli_wdr.cpp:1860
+#: src/muuli_wdr.cpp:1024 src/muuli_wdr.cpp:1867
 msgid "Active downloads"
 msgstr "Aktive Downloads"
 
@@ -3664,7 +3669,7 @@ msgstr "Aktive Downloads"
 msgid "Active connections (1:1)"
 msgstr "Aktive Forbindelser (1:1)"
 
-#: src/muuli_wdr.cpp:1040 src/muuli_wdr.cpp:1861
+#: src/muuli_wdr.cpp:1040 src/muuli_wdr.cpp:1868
 msgid "Active uploads"
 msgstr "Aktive Uploads"
 
@@ -3781,8 +3786,8 @@ msgstr ""
 msgid "Language: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1257 src/muuli_wdr.cpp:1323 src/muuli_wdr.cpp:1327
-#: src/muuli_wdr.cpp:1330
+#: src/muuli_wdr.cpp:1257 src/muuli_wdr.cpp:1330 src/muuli_wdr.cpp:1334
+#: src/muuli_wdr.cpp:1337
 msgid "The delay before showing tool-tips."
 msgstr ""
 
@@ -3858,930 +3863,938 @@ msgstr ""
 msgid "Enabling this will make aMule to show notifications when finished downloading."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1322
-msgid "Tooltip delay time: "
+#: src/muuli_wdr.cpp:1323
+msgid "Remember search history"
+msgstr ""
+
+#: src/muuli_wdr.cpp:1324
+msgid "Keeps a dropdown list of your past search terms in the Search tab's Name field. This remembers the queries you typed, not the results they returned."
 msgstr ""
 
 #: src/muuli_wdr.cpp:1329
+msgid "Tooltip delay time: "
+msgstr ""
+
+#: src/muuli_wdr.cpp:1336
 msgid "seconds"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1333
+#: src/muuli_wdr.cpp:1340
 msgid "Browser Selection"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1339
+#: src/muuli_wdr.cpp:1346
 msgid "Enter your browser name here. Leave this field empty to use the system default browser."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1346
+#: src/muuli_wdr.cpp:1353
 msgid "Open in new tab if possible"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1348
+#: src/muuli_wdr.cpp:1355
 msgid "Open the web page in a new tab instead of in a new window when possible"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1352
+#: src/muuli_wdr.cpp:1359
 msgid "Video Player"
 msgstr "Video Afspiller"
 
-#: src/muuli_wdr.cpp:1379
+#: src/muuli_wdr.cpp:1386
 msgid "Bandwidth limits"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1393
+#: src/muuli_wdr.cpp:1400
 msgid "Upload"
 msgstr "Upload"
 
-#: src/muuli_wdr.cpp:1401
+#: src/muuli_wdr.cpp:1408
 msgid "Slot Allocation"
 msgstr "Slot Tildeling"
 
-#: src/muuli_wdr.cpp:1410
+#: src/muuli_wdr.cpp:1417
 msgid "Ports"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1420
+#: src/muuli_wdr.cpp:1427
 msgid "This is the standard eD2k port and cannot be disabled."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1423
+#: src/muuli_wdr.cpp:1430
 msgid "UDP port for server requests (TCP+3):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1425
+#: src/muuli_wdr.cpp:1432
 msgid "4665"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1432
+#: src/muuli_wdr.cpp:1439
 msgid "This UDP port is used for extended eD2k requests and Kad network"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1439
+#: src/muuli_wdr.cpp:1446
 msgid "UPnP TCP Port (Optional):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1449
+#: src/muuli_wdr.cpp:1456
 msgid "Bind local address to IP (empty for any):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1452
+#: src/muuli_wdr.cpp:1459
 msgid "Advanced users only: If you have multiple network interfaces, enter the address of the interface to which aMule should be bound."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1455 src/muuli_wdr.cpp:2054
+#: src/muuli_wdr.cpp:1462 src/muuli_wdr.cpp:2061
 msgid "Bind to network interface (empty for any):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1468
+#: src/muuli_wdr.cpp:1475
 msgid "Advanced users only: pin all of aMule's traffic to one network interface, chosen from the list or typed in by name (e.g. tun0, eth0, en0) or index. Unlike binding to an IP, this stops traffic leaking out via the default route - useful with a VPN. Requires no elevated privileges."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1474
+#: src/muuli_wdr.cpp:1481
 msgid "Max sources per downloading file:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1478
+#: src/muuli_wdr.cpp:1485
 msgid "Max simultaneous connections:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1491 src/muuli_wdr.cpp:3169
+#: src/muuli_wdr.cpp:1498 src/muuli_wdr.cpp:3176
 msgid "ED2K"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1498
+#: src/muuli_wdr.cpp:1505
 msgid "Autoconnect on startup"
 msgstr "Auto forbind ved start"
 
-#: src/muuli_wdr.cpp:1501
+#: src/muuli_wdr.cpp:1508
 msgid "Reconnect on loss"
 msgstr "Genforbind ved fejl"
 
-#: src/muuli_wdr.cpp:1523
+#: src/muuli_wdr.cpp:1530
 msgid "Remove dead server after"
 msgstr "Fjern ikke tilgængelige servere, efter"
 
-#: src/muuli_wdr.cpp:1524
+#: src/muuli_wdr.cpp:1531
 msgid "Static servers are never removed, even when unreachable."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1528
+#: src/muuli_wdr.cpp:1535
 msgid "retries"
 msgstr "forsøg"
 
-#: src/muuli_wdr.cpp:1536
+#: src/muuli_wdr.cpp:1543
 msgid "List"
 msgstr "Liste"
 
-#: src/muuli_wdr.cpp:1539
+#: src/muuli_wdr.cpp:1546
 msgid "Update server list when connecting to a server"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1542
+#: src/muuli_wdr.cpp:1549
 msgid "Update server list when a client connects"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1545
+#: src/muuli_wdr.cpp:1552
 msgid "Use priority system"
 msgstr "Brug prioterings system"
 
-#: src/muuli_wdr.cpp:1549
+#: src/muuli_wdr.cpp:1556
 msgid "Use smart LowID check on connect"
 msgstr "Brug smart LavID tjek ved forbindelse"
 
-#: src/muuli_wdr.cpp:1553
+#: src/muuli_wdr.cpp:1560
 msgid "Safe connect"
 msgstr "Sikker forbindelse"
 
-#: src/muuli_wdr.cpp:1557
+#: src/muuli_wdr.cpp:1564
 msgid "Autoconnect to servers in static list only"
 msgstr "Autoforbind kun til servere i statik liste"
 
-#: src/muuli_wdr.cpp:1560
+#: src/muuli_wdr.cpp:1567
 msgid "Set manually added servers to High Priority"
 msgstr "Sæt manuelt tilføjede servere til Høj Priotet"
 
-#: src/muuli_wdr.cpp:1581
+#: src/muuli_wdr.cpp:1588
 msgid "Add files to download in pause mode"
 msgstr "Tilføj filer til download i pause tilstand"
 
-#: src/muuli_wdr.cpp:1583
+#: src/muuli_wdr.cpp:1590
 msgid "Add files to download with auto priority"
 msgstr "Tilføj filer til download med auto priotet"
 
-#: src/muuli_wdr.cpp:1586
+#: src/muuli_wdr.cpp:1593
 msgid "Try to download first and last chunks first"
 msgstr "Prøv at download første og sidste del først"
 
-#: src/muuli_wdr.cpp:1590
+#: src/muuli_wdr.cpp:1597
 msgid "Endgame mode: rotate to faster sources for the final blocks"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1593
+#: src/muuli_wdr.cpp:1600
 msgid "Start next paused file when a file completes"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1596
+#: src/muuli_wdr.cpp:1603
 msgid "From the same category"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1598
+#: src/muuli_wdr.cpp:1605
 msgid "In alphabetic order"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1600
+#: src/muuli_wdr.cpp:1607
 msgid "Preallocate disk space for new files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1601
+#: src/muuli_wdr.cpp:1608
 msgid "For new files preallocates disk space for the whole file, thus reduces fragmentation"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1606
+#: src/muuli_wdr.cpp:1613
 msgid "Create new files as sparse files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1607
+#: src/muuli_wdr.cpp:1614
 msgid "A sparse file reserves its full size on disk immediately without writing real data to it -- fast, but unsupported or slow on some filesystems, and free-space accounting stays optimistic while the download is in progress. Turn this off to grow the file only as data arrives."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1612
+#: src/muuli_wdr.cpp:1619
 msgid "Stop downloads when free disk space reaches "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1613
+#: src/muuli_wdr.cpp:1620
 msgid "Select this if you want aMule to check your disk space"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1617
+#: src/muuli_wdr.cpp:1624
 msgid "Enter here the min disk space desired."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1623
+#: src/muuli_wdr.cpp:1630
 msgid "Save 10 sources on rare files (< 20 sources)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1627 src/Statistics.cpp:790
+#: src/muuli_wdr.cpp:1634 src/Statistics.cpp:790
 msgid "Uploads"
 msgstr "Uploads"
 
-#: src/muuli_wdr.cpp:1630
+#: src/muuli_wdr.cpp:1637
 msgid "Add new shared files with auto priority"
 msgstr "Tilføj nye delte filer med auto priotet"
 
-#: src/muuli_wdr.cpp:1636
+#: src/muuli_wdr.cpp:1643
 msgid "Intelligent Corruption Handling (I.C.H.)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1639
+#: src/muuli_wdr.cpp:1646
 msgid "Enable"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1642
+#: src/muuli_wdr.cpp:1649
 msgid "Advanced I.C.H. trusts every hash (not recommended)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1654 src/PrefsUnifiedDlg.cpp:1910
+#: src/muuli_wdr.cpp:1661 src/PrefsUnifiedDlg.cpp:1910
 msgid "Media metadata extraction"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1658
+#: src/muuli_wdr.cpp:1665
 msgid "Extract length / bitrate / codec from shared audio and video files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1660
+#: src/muuli_wdr.cpp:1667
 msgid "When enabled, aMule runs ffprobe on each shared media file to fill in the Length / Bitrate / Codec columns other clients see when they find the file in a search. Requires ffmpeg (the ffprobe binary) to be installed."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1667
+#: src/muuli_wdr.cpp:1674
 msgid "Path to ffprobe:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1672
+#: src/muuli_wdr.cpp:1679
 msgid "Full path to the ffprobe binary. Leave empty to have aMule auto-detect it on startup."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1680
+#: src/muuli_wdr.cpp:1687
 msgid "Detect"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1681
+#: src/muuli_wdr.cpp:1688
 msgid "Search the standard install locations for an ffprobe binary and fill the path field."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1705
+#: src/muuli_wdr.cpp:1712
 msgid ""
 "Completed downloads are stored here. All files in this folder are automatically shared with other peers.\n"
 "If this folder also holds files you don't want to share, point it at an aMule-only sub-folder."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1708
+#: src/muuli_wdr.cpp:1715
 msgid "Pick the folder where completed downloads will be stored. All files in that folder will be shared with other peers."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1722
+#: src/muuli_wdr.cpp:1729
 msgid "Shared folders"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1728
+#: src/muuli_wdr.cpp:1735
 msgid "(Folders shared by the core. Enter a path to add one.)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1736
+#: src/muuli_wdr.cpp:1743
 msgid "Absolute path of a folder on the core's machine, e.g. /home/user/shared"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1738 src/PrefsUnifiedDlg.cpp:2794
+#: src/muuli_wdr.cpp:1745 src/PrefsUnifiedDlg.cpp:2794
 msgid "Recursive"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1739
+#: src/muuli_wdr.cpp:1746
 msgid "Share every sub-folder underneath this one, including ones created later."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1743 src/utils/aLinkCreator/src/alcframe.cpp:141
+#: src/muuli_wdr.cpp:1750 src/utils/aLinkCreator/src/alcframe.cpp:141
 msgid "Remove"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1747
+#: src/muuli_wdr.cpp:1754
 msgid "(Right click on folder icon for recursive share)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1754
+#: src/muuli_wdr.cpp:1761
 msgid "Share hidden files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1760
+#: src/muuli_wdr.cpp:1767
 msgid "Automatically rescan shared folders for changes"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1766
+#: src/muuli_wdr.cpp:1773
 msgid "Follow symbolic links in shared folders"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1772
+#: src/muuli_wdr.cpp:1779
 msgid "Exclude files matching:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1775
+#: src/muuli_wdr.cpp:1782
 msgid "Wildcard patterns separated by '|', e.g. .DS_Store|Thumbs.db|*.tmp. Files whose name matches are not shared. Matching is case-insensitive."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1779
+#: src/muuli_wdr.cpp:1786
 msgid "Patterns are regular expressions"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1780
+#: src/muuli_wdr.cpp:1787
 msgid "When set, the whole field is one regular expression ('|' is alternation). When unset, it is a list of '|'-separated wildcards."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1790
+#: src/muuli_wdr.cpp:1797
 msgid "Show how many shared files the current pattern would exclude."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1811
+#: src/muuli_wdr.cpp:1818
 msgid "Graphs"
 msgstr "Grafer"
 
-#: src/muuli_wdr.cpp:1814 src/muuli_wdr.cpp:1876
+#: src/muuli_wdr.cpp:1821 src/muuli_wdr.cpp:1883
 msgid "Update delay : 5 secs"
 msgstr "Opdaterings interval : 5 sek"
 
-#: src/muuli_wdr.cpp:1818
+#: src/muuli_wdr.cpp:1825
 msgid "Time for average graph: 100 mins"
 msgstr "Tid for gennemsnitlig graf: 100 min"
 
-#: src/muuli_wdr.cpp:1822
+#: src/muuli_wdr.cpp:1829
 msgid "Connections Graph Scale: 100 "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1829
+#: src/muuli_wdr.cpp:1836
 msgid "Download graph scale:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1837
+#: src/muuli_wdr.cpp:1844
 msgid "Upload graph scale:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1847
+#: src/muuli_wdr.cpp:1854
 msgid "Colors: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1851
+#: src/muuli_wdr.cpp:1858
 msgid "Background"
 msgstr "Baggrund"
 
-#: src/muuli_wdr.cpp:1852
+#: src/muuli_wdr.cpp:1859
 msgid "Grid"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1853
+#: src/muuli_wdr.cpp:1860
 msgid "Download current"
 msgstr "Download nu"
 
-#: src/muuli_wdr.cpp:1854
+#: src/muuli_wdr.cpp:1861
 msgid "Download running average"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1855
+#: src/muuli_wdr.cpp:1862
 msgid "Download session average"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1856
+#: src/muuli_wdr.cpp:1863
 msgid "Upload current"
 msgstr "Upload nu"
 
-#: src/muuli_wdr.cpp:1857
+#: src/muuli_wdr.cpp:1864
 msgid "Upload running average"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1858
+#: src/muuli_wdr.cpp:1865
 msgid "Upload session average"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1859
+#: src/muuli_wdr.cpp:1866
 msgid "Active connections"
 msgstr "Aktive Forbindelser"
 
-#: src/muuli_wdr.cpp:1862
+#: src/muuli_wdr.cpp:1869
 msgid "Systray Icon Speed Bar"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1863
+#: src/muuli_wdr.cpp:1870
 msgid "Kad-nodes current"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1864
+#: src/muuli_wdr.cpp:1871
 msgid "Kad-nodes running"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1865
+#: src/muuli_wdr.cpp:1872
 msgid "Kad-nodes session"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1869 src/muuli_wdr.cpp:2296
+#: src/muuli_wdr.cpp:1876 src/muuli_wdr.cpp:2303
 msgid "Select"
 msgstr "Vælg"
 
-#: src/muuli_wdr.cpp:1873
+#: src/muuli_wdr.cpp:1880
 msgid "Tree"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1883
+#: src/muuli_wdr.cpp:1890
 msgid "Number of Client Versions shown (0=unlimited)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1908
+#: src/muuli_wdr.cpp:1915
 msgid "!!! WARNING !!!"
 msgstr "!!! Advarsel !!!"
 
-#: src/muuli_wdr.cpp:1923
+#: src/muuli_wdr.cpp:1930
 msgid "Max new connections / 5 secs"
 msgstr "Max nye forbindelser / 5 sekunder"
 
-#: src/muuli_wdr.cpp:1925
+#: src/muuli_wdr.cpp:1932
 msgid "Concurrent Kad source lookups"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1927
+#: src/muuli_wdr.cpp:1934
 #, fuzzy
 msgid "Kad source re-search interval (minutes)"
 msgstr "FTP opdaterings interval i minutter"
 
-#: src/muuli_wdr.cpp:1929
+#: src/muuli_wdr.cpp:1936
 #, fuzzy
 msgid "Source re-ask interval (minutes)"
 msgstr "FTP opdaterings interval i minutter"
 
-#: src/muuli_wdr.cpp:1933
+#: src/muuli_wdr.cpp:1940
 msgid "File Buffer Size: 240000 bytes"
 msgstr "Fil Buffer Størrelse"
 
-#: src/muuli_wdr.cpp:1937
+#: src/muuli_wdr.cpp:1944
 msgid "Use MMAP: memory-mapped file access (lower memory use)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1938
+#: src/muuli_wdr.cpp:1945
 msgid "Maps part files into memory instead of buffering them on the heap, lowering the process memory footprint. May reduce download speed on some disks; best for memory-constrained or upload-heavy hosts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1940
+#: src/muuli_wdr.cpp:1947
 msgid "Upload Queue Size: 5000 clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1944
+#: src/muuli_wdr.cpp:1951
 msgid "Server connection refresh interval: Disable"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1948
+#: src/muuli_wdr.cpp:1955
 msgid "Disable computer's timed standby mode"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1967
+#: src/muuli_wdr.cpp:1974
 msgid "Skin to use: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1976
+#: src/muuli_wdr.cpp:1983
 msgid "Show \"Fast eD2k Links Handler\" in every window."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1979
+#: src/muuli_wdr.cpp:1986
 msgid "Show extended info on categories tabs"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1982
+#: src/muuli_wdr.cpp:1989
 #, fuzzy
 msgid "Show application version on title"
 msgstr "Vis overførsels hastighed i titel"
 
-#: src/muuli_wdr.cpp:1984
+#: src/muuli_wdr.cpp:1991
 msgid "Show transfer rates on title"
 msgstr "Vis overførsels hastighed i titel"
 
-#: src/muuli_wdr.cpp:1986
+#: src/muuli_wdr.cpp:1993
 msgid "Before application name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1988
+#: src/muuli_wdr.cpp:1995
 msgid "After application name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1991
+#: src/muuli_wdr.cpp:1998
 msgid "Show overhead bandwidth"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1995
+#: src/muuli_wdr.cpp:2002
 msgid "Vertical toolbar orientation"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1997
+#: src/muuli_wdr.cpp:2004
 msgid "Live column sorting (auto-reorder rows as their values change)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2004
+#: src/muuli_wdr.cpp:2011
 msgid "Download Queue Files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2007
+#: src/muuli_wdr.cpp:2014
 msgid "Show progress percentage"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2013
+#: src/muuli_wdr.cpp:2020
 msgid "Show progress bar"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2016
+#: src/muuli_wdr.cpp:2023
 msgid "Flat"
 msgstr "Flad"
 
-#: src/muuli_wdr.cpp:2020
+#: src/muuli_wdr.cpp:2027
 msgid "Round"
 msgstr "Rund"
 
-#: src/muuli_wdr.cpp:2038
+#: src/muuli_wdr.cpp:2045
 msgid "External Connection Parameters"
 msgstr "Ydre Forbindelses Parametre"
 
-#: src/muuli_wdr.cpp:2041
+#: src/muuli_wdr.cpp:2048
 msgid "Accept external connections"
 msgstr "Accepter ydre forbindelser"
 
-#: src/muuli_wdr.cpp:2048 src/muuli_wdr.cpp:2107
+#: src/muuli_wdr.cpp:2055 src/muuli_wdr.cpp:2114
 msgid "IP of the listening interface:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2051
+#: src/muuli_wdr.cpp:2058
 msgid "Enter here a valid ip in the a.b.c.d format for the listening EC interface. An empty field or 0.0.0.0 will mean any interface."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2072 src/muuli_wdr.cpp:2156
+#: src/muuli_wdr.cpp:2079 src/muuli_wdr.cpp:2163
 msgid "TCP port:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2078
+#: src/muuli_wdr.cpp:2085
 msgid "Enable UPnP port forwarding on the EC port"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2082 src/muuli_wdr.cpp:3041
+#: src/muuli_wdr.cpp:2089 src/muuli_wdr.cpp:3048
 #: src/utils/wxCas/src/wxcasprefs.cpp:167
 msgid "Password"
 msgstr "Password"
 
-#: src/muuli_wdr.cpp:2088
+#: src/muuli_wdr.cpp:2095
 msgid "aMule API server parameters"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2091
+#: src/muuli_wdr.cpp:2098
 msgid "Run amuleapi (REST API) on startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2096
+#: src/muuli_wdr.cpp:2103
 #, fuzzy
 msgid "HTTP port:"
 msgstr "UPnP port"
 
-#: src/muuli_wdr.cpp:2110
+#: src/muuli_wdr.cpp:2117
 msgid "The interface amuleapi's HTTP server listens on. 127.0.0.1 (default) accepts only local connections; use 0.0.0.0 or a specific IP to expose it to other hosts (set an admin password below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2113
+#: src/muuli_wdr.cpp:2120
 #, fuzzy
 msgid "Admin password"
 msgstr "Undersøger password\n"
 
-#: src/muuli_wdr.cpp:2118 src/muuli_wdr.cpp:2149
+#: src/muuli_wdr.cpp:2125 src/muuli_wdr.cpp:2156
 msgid "Low rights password"
 msgstr "Lav rettigheds kodeord"
 
-#: src/muuli_wdr.cpp:2126
+#: src/muuli_wdr.cpp:2133
 msgid "Web server parameters"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2129
+#: src/muuli_wdr.cpp:2136
 msgid "Run webserver on startup (deprecated)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2135
+#: src/muuli_wdr.cpp:2142
 msgid "Web template"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2140
+#: src/muuli_wdr.cpp:2147
 msgid "Full rights password"
 msgstr "Fuld rettigheds kodeord"
 
-#: src/muuli_wdr.cpp:2144
+#: src/muuli_wdr.cpp:2151
 msgid "Enable Low rights User"
 msgstr "Aktiver lav rettigheds brugere"
 
-#: src/muuli_wdr.cpp:2163
+#: src/muuli_wdr.cpp:2170
 msgid "Enable UPnP port forwarding of the web server port"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2168
+#: src/muuli_wdr.cpp:2175
 msgid "Web server UPnP TCP port (Optional)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2176
+#: src/muuli_wdr.cpp:2183
 msgid "Page Refresh Time (in secs)"
 msgstr "Side Opdaterings Tid (i sek)"
 
-#: src/muuli_wdr.cpp:2183
+#: src/muuli_wdr.cpp:2190
 msgid "Enable Gzip compression"
 msgstr "Aktiver Gzip komprimering"
 
-#: src/muuli_wdr.cpp:2217
+#: src/muuli_wdr.cpp:2224
 #, fuzzy
 msgid "Reset page to defaults"
 msgstr "System standard"
 
-#: src/muuli_wdr.cpp:2218
+#: src/muuli_wdr.cpp:2225
 msgid "Reset the settings on the current page to their default values."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2220 src/muuli_wdr.cpp:2306 src/ServerWnd.cpp:274
+#: src/muuli_wdr.cpp:2227 src/muuli_wdr.cpp:2313 src/ServerWnd.cpp:274
 #: src/ServerWnd.cpp:282
 msgid "OK"
 msgstr "OK"
 
-#: src/muuli_wdr.cpp:2222
+#: src/muuli_wdr.cpp:2229
 msgid "Click here to apply any changes made to the preferences."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2225
+#: src/muuli_wdr.cpp:2232
 msgid "Reset any changes made to the preferences."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2254
+#: src/muuli_wdr.cpp:2261
 msgid "Comment :"
 msgstr "Kommentar :"
 
-#: src/muuli_wdr.cpp:2261
+#: src/muuli_wdr.cpp:2268
 msgid "Incoming Dir :"
 msgstr "Indkommende Mappe :"
 
-#: src/muuli_wdr.cpp:2270
+#: src/muuli_wdr.cpp:2277
 msgid "Change priority for new assigned files :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2274
+#: src/muuli_wdr.cpp:2281
 msgid "Don't change"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2286
+#: src/muuli_wdr.cpp:2293
 msgid "Select color for this Category (currently selected) :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2353 src/muuli_wdr.cpp:2372 src/muuli_wdr.cpp:2394
+#: src/muuli_wdr.cpp:2360 src/muuli_wdr.cpp:2379 src/muuli_wdr.cpp:2401
 msgid "Click this button to reset the log."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2413
+#: src/muuli_wdr.cpp:2420
 msgid "Click on this button to update the servers list from URL ..."
 msgstr "Tryk på denne knap for at opdatere serverlisten fra URL ..."
 
-#: src/muuli_wdr.cpp:2417
+#: src/muuli_wdr.cpp:2424
 msgid "Server list"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2421
+#: src/muuli_wdr.cpp:2428
 msgid "Enter the url to a server.met file here and press the button to the left to update the list of known servers."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2426
+#: src/muuli_wdr.cpp:2433
 msgid "Add server manually: Name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2429
+#: src/muuli_wdr.cpp:2436
 msgid "Enter the name of the new server here"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2431 src/ServerWnd.cpp:206
+#: src/muuli_wdr.cpp:2438 src/ServerWnd.cpp:206
 msgid "IP:Port"
 msgstr "IP:Port"
 
-#: src/muuli_wdr.cpp:2434
+#: src/muuli_wdr.cpp:2441
 msgid "Enter the IP of the server here, using the x.x.x.x format."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2440
+#: src/muuli_wdr.cpp:2447
 msgid "Enter the port of the server here."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2443
+#: src/muuli_wdr.cpp:2450
 msgid "Add manually a server (fill fields to the left before) ..."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2472
+#: src/muuli_wdr.cpp:2479
 msgid "aMule Log"
 msgstr "aMule Log"
 
-#: src/muuli_wdr.cpp:2480
+#: src/muuli_wdr.cpp:2487
 msgid "Server Info"
 msgstr "Server Info"
 
-#: src/muuli_wdr.cpp:2484
+#: src/muuli_wdr.cpp:2491
 msgid "ED2K Info"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2488
+#: src/muuli_wdr.cpp:2495
 msgid "Kad Info"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2516
+#: src/muuli_wdr.cpp:2523
 msgid "Click on this button to update the nodes list from URL ..."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2520
+#: src/muuli_wdr.cpp:2527
 msgid "Nodes (0)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2524
+#: src/muuli_wdr.cpp:2531
 msgid "Enter the url to a nodes.dat file here and press the button to the left to update the list of known nodes."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2527
+#: src/muuli_wdr.cpp:2534
 msgid "Nodes stats"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2569
+#: src/muuli_wdr.cpp:2576
 msgid "Bootstrap"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2572
+#: src/muuli_wdr.cpp:2579
 msgid "New node"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2577
+#: src/muuli_wdr.cpp:2584
 msgid "IP:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2597
+#: src/muuli_wdr.cpp:2604
 msgid "Port:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2610
+#: src/muuli_wdr.cpp:2617
 msgid "Bootstrap from known clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2612
+#: src/muuli_wdr.cpp:2619
 msgid "Disconnect Kad"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2646
+#: src/muuli_wdr.cpp:2653
 msgid "Use Secure User Identification"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2648
+#: src/muuli_wdr.cpp:2655
 msgid "It is recommended to enable this option. You will not receive credits if SUI is not enabled."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2650
+#: src/muuli_wdr.cpp:2657
 msgid "Protocol Obfuscation"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2653
+#: src/muuli_wdr.cpp:2660
 msgid "Support Protocol Obfuscation"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2655
+#: src/muuli_wdr.cpp:2662
 msgid "This option enabled Protocol Obfuscation, and makes aMule accept obfuscated connections from other clients."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2657
+#: src/muuli_wdr.cpp:2664
 msgid "Use obfuscation for outgoing connections"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2659
+#: src/muuli_wdr.cpp:2666
 msgid "This option makes aMule use Protocol Obfuscation when connecting other clients/servers."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2661
+#: src/muuli_wdr.cpp:2668
 msgid "Accept only obfuscated connections"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2662
+#: src/muuli_wdr.cpp:2669
 msgid "This option makes aMule only accept obfuscated connections. You will have less sources, but all your traffic will be obfuscated"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2667
+#: src/muuli_wdr.cpp:2674
 msgid "Everybody"
 msgstr "Alle"
 
-#: src/muuli_wdr.cpp:2669
+#: src/muuli_wdr.cpp:2676
 msgid "No one"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2671
+#: src/muuli_wdr.cpp:2678
 msgid "Who can see my shared files:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2672
+#: src/muuli_wdr.cpp:2679
 msgid "Select who can request to view a list of your shared files."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2674
+#: src/muuli_wdr.cpp:2681
 msgid "IP-Filtering"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2681
+#: src/muuli_wdr.cpp:2688
 msgid "Filter clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2683
+#: src/muuli_wdr.cpp:2690
 msgid "Enable filtering of the client IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2685
+#: src/muuli_wdr.cpp:2692
 msgid "Filter servers"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2687
+#: src/muuli_wdr.cpp:2694
 msgid "Enable filtering of the server IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2691
+#: src/muuli_wdr.cpp:2698
 msgid "Reload List"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2692
+#: src/muuli_wdr.cpp:2699
 msgid "Reload the list of IPs to filter from the file ~/.aMule/ipfilter.dat"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2698
+#: src/muuli_wdr.cpp:2705
 msgid "URL:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2702 src/muuli_wdr.cpp:2895
+#: src/muuli_wdr.cpp:2709 src/muuli_wdr.cpp:2902
 msgid "Update now"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2705
+#: src/muuli_wdr.cpp:2712
 msgid "Auto-update ipfilter at startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2709
+#: src/muuli_wdr.cpp:2716
 msgid "Filtering Level:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2715
+#: src/muuli_wdr.cpp:2722
 msgid "Always filter LAN IPs"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2718
+#: src/muuli_wdr.cpp:2725
 msgid "Paranoid handling of non-matching IPs"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2720
+#: src/muuli_wdr.cpp:2727
 msgid "Rejects a packet when its source IP differs from the IP the client claims (an anti-spoofing check). Disable only if it causes connection problems."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2722
+#: src/muuli_wdr.cpp:2729
 msgid "Use system-wide ipfilter.dat if available"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2723
+#: src/muuli_wdr.cpp:2730
 msgid "If there's no local ipfilter.dat found, allow usage of a system-wide ipfilter file."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2740
+#: src/muuli_wdr.cpp:2747
 msgid "Enable Online-Signature"
 msgstr "Aktiver online-signatur"
 
-#: src/muuli_wdr.cpp:2742
+#: src/muuli_wdr.cpp:2749
 msgid "Enables the writing of the OS file, which can be used by external apps to create signatures and the like."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2746
+#: src/muuli_wdr.cpp:2753
 msgid "Update Frequency (Secs):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2749
+#: src/muuli_wdr.cpp:2756
 msgid "Change the frequency (in seconds) of Online Signature updates."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2757
+#: src/muuli_wdr.cpp:2764
 msgid "Save online signature file in: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:2763
+#: src/muuli_wdr.cpp:2770
 msgid "Click here to select the directory containing the the Online Signature files."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2796
+#: src/muuli_wdr.cpp:2803
 msgid "Show country flags for clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2797
+#: src/muuli_wdr.cpp:2804
 msgid "Render the country flag column in the transfers, queue and search views. Requires a valid MMDB GeoIP database (see below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2802
+#: src/muuli_wdr.cpp:2809
 msgid "Database"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2818
+#: src/muuli_wdr.cpp:2825
 #, fuzzy
 msgid "Source:"
 msgstr "Kilder"
 
-#: src/muuli_wdr.cpp:2821
+#: src/muuli_wdr.cpp:2828
 msgid "DB-IP (free, no account)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2822
+#: src/muuli_wdr.cpp:2829
 msgid "MaxMind GeoLite2 (free, account required)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2823
+#: src/muuli_wdr.cpp:2830
 msgid "Custom URL"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2826
+#: src/muuli_wdr.cpp:2833
 msgid "Choose which provider supplies the GeoIP MMDB database. DB-IP is the default - no account required. MaxMind requires a free account + license key. Use Custom URL to point at any other MMDB host (e.g. a local mirror)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2843
+#: src/muuli_wdr.cpp:2850
 msgid ""
 "No configuration required.\n"
 "\n"
@@ -4789,11 +4802,11 @@ msgid ""
 "License: Creative Commons BY 4.0 - https://creativecommons.org/licenses/by/4.0/"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2856
+#: src/muuli_wdr.cpp:2863
 msgid "License key:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2862
+#: src/muuli_wdr.cpp:2869
 msgid ""
 "Sign up for a free MaxMind account, then generate a License Key:\n"
 "https://www.maxmind.com/en/geolite2/signup\n"
@@ -4803,232 +4816,232 @@ msgid ""
 "Requires attribution and account registration; refresh at least every 30 days."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2877
+#: src/muuli_wdr.cpp:2884
 #, fuzzy
 msgid "Download URL:"
 msgstr "Download: "
 
-#: src/muuli_wdr.cpp:2883
+#: src/muuli_wdr.cpp:2890
 msgid ""
 "Must point to an .mmdb file or a .gz / .tar.gz containing one.\n"
 "URL may include credentials (https://user:pass@host/...).\n"
 "License and attribution terms are set by the upstream URL - you are responsible."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2896
+#: src/muuli_wdr.cpp:2903
 msgid "Download the GeoIP database from the selected source."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2898
+#: src/muuli_wdr.cpp:2905
 #, fuzzy
 msgid "Auto-update on startup"
 msgstr "Auto forbind ved start"
 
-#: src/muuli_wdr.cpp:2899
+#: src/muuli_wdr.cpp:2906
 msgid "Re-download the GeoIP database from the selected source every time aMule starts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2922
+#: src/muuli_wdr.cpp:2929
 msgid "Filter incoming messages (except current chat):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2924
+#: src/muuli_wdr.cpp:2931
 msgid "Filter all messages"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2926
+#: src/muuli_wdr.cpp:2933
 msgid "Filter messages from people not on your friend list"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2928
+#: src/muuli_wdr.cpp:2935
 msgid "Filter messages from unknown clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2930
+#: src/muuli_wdr.cpp:2937
 msgid "Filter messages containing (use ',' as separator):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2933 src/muuli_wdr.cpp:2944
+#: src/muuli_wdr.cpp:2940 src/muuli_wdr.cpp:2951
 msgid "add here the words amule should filter and block messages including it"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2935
+#: src/muuli_wdr.cpp:2942
 msgid "Show received messages in the log"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2938
+#: src/muuli_wdr.cpp:2945
 msgid "Comments"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2941
+#: src/muuli_wdr.cpp:2948
 msgid "Filter comments containing (use ',' as separator):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2966
+#: src/muuli_wdr.cpp:2973
 msgid "Enable Proxy"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2967
+#: src/muuli_wdr.cpp:2974
 msgid "Enable/disable proxy support"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2970
+#: src/muuli_wdr.cpp:2977
 msgid "Proxy type:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2981
+#: src/muuli_wdr.cpp:2988
 msgid "Proxy host:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2984
+#: src/muuli_wdr.cpp:2991
 msgid "The proxy host name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2986
+#: src/muuli_wdr.cpp:2993
 msgid "Proxy port:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2989
+#: src/muuli_wdr.cpp:2996
 msgid "The proxy port"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2991
+#: src/muuli_wdr.cpp:2998
 msgid "Enable authentication"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2992
+#: src/muuli_wdr.cpp:2999
 msgid "Enable/disable username/password authentication"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2995
+#: src/muuli_wdr.cpp:3002
 msgid "Username: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:2998
+#: src/muuli_wdr.cpp:3005
 msgid "The username to use to connect to the proxy"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3000
+#: src/muuli_wdr.cpp:3007
 msgid "Password:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3003
+#: src/muuli_wdr.cpp:3010
 msgid "The password to use to connect to the proxy"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3022
+#: src/muuli_wdr.cpp:3029
 msgid "Connect to:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3031
+#: src/muuli_wdr.cpp:3038
 msgid "Login to remote amule"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3036
+#: src/muuli_wdr.cpp:3043
 msgid "User name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3047
+#: src/muuli_wdr.cpp:3054
 msgid "Remember those settings"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3050
+#: src/muuli_wdr.cpp:3057
 #, fuzzy
 msgid "Force ZLIB compression"
 msgstr "Brug gzip komprimering"
 
-#: src/muuli_wdr.cpp:3074
+#: src/muuli_wdr.cpp:3081
 msgid "Enable Verbose Debug-Logging."
 msgstr ""
 
-#: src/muuli_wdr.cpp:3076
+#: src/muuli_wdr.cpp:3083
 #, fuzzy
 msgid "Only to Logfile"
 msgstr "&Åben filen"
 
-#: src/muuli_wdr.cpp:3078
+#: src/muuli_wdr.cpp:3085
 msgid "Message Categories:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3102 src/PartFileConvertDlg.cpp:160
+#: src/muuli_wdr.cpp:3109 src/PartFileConvertDlg.cpp:160
 msgid "Waiting..."
 msgstr "Venter..."
 
-#: src/muuli_wdr.cpp:3122
+#: src/muuli_wdr.cpp:3129
 msgid "Add imports"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3125
+#: src/muuli_wdr.cpp:3132
 msgid "Retry selected"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3127
+#: src/muuli_wdr.cpp:3134
 msgid "Remove selected"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3190
+#: src/muuli_wdr.cpp:3197
 msgid "Event Types"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3209
+#: src/muuli_wdr.cpp:3216
 msgid "Statistics and queued clients for selected file(s) : Session / All time"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3233
+#: src/muuli_wdr.cpp:3240
 msgid "Active Uploads"
 msgstr "Aktive Uploads"
 
-#: src/muuli_wdr.cpp:3247
+#: src/muuli_wdr.cpp:3254
 #, fuzzy
 msgid "Percent of total files"
 msgstr "Antal Filer Total"
 
-#: src/muuli_wdr.cpp:3299
+#: src/muuli_wdr.cpp:3306
 #, fuzzy
 msgid "Show Clients for"
 msgstr "Vis Liste"
 
-#: src/muuli_wdr.cpp:3301
+#: src/muuli_wdr.cpp:3308
 #, fuzzy
 msgid "All files"
 msgstr "Delte Filer"
 
-#: src/muuli_wdr.cpp:3304
+#: src/muuli_wdr.cpp:3311
 #, fuzzy
 msgid "Selected files"
 msgstr "Slettede Servere"
 
-#: src/muuli_wdr.cpp:3307
+#: src/muuli_wdr.cpp:3314
 #, fuzzy
 msgid "Active uploads only"
 msgstr "Aktive Uploads"
 
-#: src/muuli_wdr.cpp:3314
+#: src/muuli_wdr.cpp:3321
 #, fuzzy
 msgid "Reload:"
 msgstr "Opdater"
 
-#: src/muuli_wdr.cpp:3318
+#: src/muuli_wdr.cpp:3325
 msgid "Reload your shared files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3381
+#: src/muuli_wdr.cpp:3388
 msgid "Send"
 msgstr "Send"
 
-#: src/muuli_wdr.cpp:3382
+#: src/muuli_wdr.cpp:3389
 msgid "Sends the specified message."
 msgstr ""
 
-#: src/muuli_wdr.cpp:3386
+#: src/muuli_wdr.cpp:3393
 msgid "Close this chat-session."
 msgstr ""
 
-#: src/muuli_wdr.cpp:3409
+#: src/muuli_wdr.cpp:3416
 msgid "Connect to any server and/or Kad"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3415 src/SharedFilesCtrl.cpp:142 src/Statistics.cpp:941
+#: src/muuli_wdr.cpp:3422 src/SharedFilesCtrl.cpp:142 src/Statistics.cpp:941
 msgid "Shared Files"
 msgstr "Delte Filer"
 
@@ -5390,191 +5403,191 @@ msgstr ""
 msgid "ERROR: Failed to open partfile '%s'"
 msgstr ""
 
-#: src/Preferences.cpp:673
+#: src/Preferences.cpp:674
 msgid "System default"
 msgstr "System standard"
 
-#: src/Preferences.cpp:674
+#: src/Preferences.cpp:675
 msgid "Albanian"
 msgstr ""
 
-#: src/Preferences.cpp:675
+#: src/Preferences.cpp:676
 msgid "Arabic"
 msgstr "Arabic"
 
-#: src/Preferences.cpp:676
+#: src/Preferences.cpp:677
 #, fuzzy
 msgid "Asturian"
 msgstr "Estonian"
 
-#: src/Preferences.cpp:677
+#: src/Preferences.cpp:678
 msgid "Basque"
 msgstr "Basque"
 
-#: src/Preferences.cpp:678
+#: src/Preferences.cpp:679
 msgid "Bulgarian"
 msgstr "Bulgarian"
 
-#: src/Preferences.cpp:679
+#: src/Preferences.cpp:680
 msgid "Catalan"
 msgstr "Catalan"
 
-#: src/Preferences.cpp:680
+#: src/Preferences.cpp:681
 msgid "Chinese (Simplified)"
 msgstr ""
 
-#: src/Preferences.cpp:681
+#: src/Preferences.cpp:682
 msgid "Chinese (Traditional)"
 msgstr ""
 
-#: src/Preferences.cpp:682
+#: src/Preferences.cpp:683
 msgid "Croatian"
 msgstr ""
 
-#: src/Preferences.cpp:683
+#: src/Preferences.cpp:684
 msgid "Czech"
 msgstr ""
 
-#: src/Preferences.cpp:684
+#: src/Preferences.cpp:685
 msgid "Danish"
 msgstr "Danish"
 
-#: src/Preferences.cpp:685
+#: src/Preferences.cpp:686
 msgid "Dutch"
 msgstr "Dutch"
 
-#: src/Preferences.cpp:686
+#: src/Preferences.cpp:687
 msgid "English (U.K.)"
 msgstr ""
 
-#: src/Preferences.cpp:687
+#: src/Preferences.cpp:688
 msgid "English (U.S.)"
 msgstr ""
 
-#: src/Preferences.cpp:688
+#: src/Preferences.cpp:689
 msgid "Estonian"
 msgstr "Estonian"
 
-#: src/Preferences.cpp:689
+#: src/Preferences.cpp:690
 msgid "Finnish"
 msgstr "Finnish"
 
-#: src/Preferences.cpp:690
+#: src/Preferences.cpp:691
 msgid "French"
 msgstr "French"
 
-#: src/Preferences.cpp:691
+#: src/Preferences.cpp:692
 msgid "Galician"
 msgstr ""
 
-#: src/Preferences.cpp:692
+#: src/Preferences.cpp:693
 msgid "German"
 msgstr "German"
 
-#: src/Preferences.cpp:693
+#: src/Preferences.cpp:694
 msgid "Greek"
 msgstr ""
 
-#: src/Preferences.cpp:694
+#: src/Preferences.cpp:695
 msgid "Hebrew"
 msgstr ""
 
-#: src/Preferences.cpp:695
+#: src/Preferences.cpp:696
 msgid "Hungarian"
 msgstr ""
 
-#: src/Preferences.cpp:696
+#: src/Preferences.cpp:697
 msgid "Italian"
 msgstr "Italian"
 
-#: src/Preferences.cpp:697
+#: src/Preferences.cpp:698
 msgid "Japanese"
 msgstr ""
 
-#: src/Preferences.cpp:698
+#: src/Preferences.cpp:699
 msgid "Korean"
 msgstr "Korean"
 
-#: src/Preferences.cpp:699
+#: src/Preferences.cpp:700
 msgid "Latvian"
 msgstr ""
 
-#: src/Preferences.cpp:700
+#: src/Preferences.cpp:701
 msgid "Lithuanian"
 msgstr "Lithuanian"
 
-#: src/Preferences.cpp:701
+#: src/Preferences.cpp:702
 msgid "Norwegian (Nynorsk)"
 msgstr ""
 
-#: src/Preferences.cpp:702
+#: src/Preferences.cpp:703
 msgid "Polish"
 msgstr "Polish"
 
-#: src/Preferences.cpp:703
+#: src/Preferences.cpp:704
 msgid "Portuguese"
 msgstr "Portuguese"
 
-#: src/Preferences.cpp:704
+#: src/Preferences.cpp:705
 msgid "Portuguese (Brazilian)"
 msgstr ""
 
-#: src/Preferences.cpp:705
+#: src/Preferences.cpp:706
 #, fuzzy
 msgid "Romanian"
 msgstr "Estonian"
 
-#: src/Preferences.cpp:706
+#: src/Preferences.cpp:707
 msgid "Russian"
 msgstr "Russian"
 
-#: src/Preferences.cpp:707
+#: src/Preferences.cpp:708
 msgid "Slovenian"
 msgstr ""
 
-#: src/Preferences.cpp:708
+#: src/Preferences.cpp:709
 msgid "Spanish"
 msgstr "Spanish"
 
-#: src/Preferences.cpp:709
+#: src/Preferences.cpp:710
 msgid "Swedish"
 msgstr ""
 
-#: src/Preferences.cpp:710
+#: src/Preferences.cpp:711
 msgid "Turkish"
 msgstr ""
 
-#: src/Preferences.cpp:711
+#: src/Preferences.cpp:712
 msgid "Ukrainian"
 msgstr ""
 
-#: src/Preferences.cpp:814
+#: src/Preferences.cpp:815
 #, fuzzy
 msgid "Change Language"
 msgstr "Sprog"
 
-#: src/Preferences.cpp:878
+#: src/Preferences.cpp:879
 msgid "There are no translations installed for aMule"
 msgstr ""
 
-#: src/Preferences.cpp:879
+#: src/Preferences.cpp:880
 #, fuzzy
 msgid "No languages available"
 msgstr "Ikke tilgængelig"
 
-#: src/Preferences.cpp:1010
+#: src/Preferences.cpp:1011
 msgid "no options available"
 msgstr ""
 
-#: src/Preferences.cpp:2179
+#: src/Preferences.cpp:2182
 msgid "Invalid category found, skipping"
 msgstr ""
 
-#: src/Preferences.cpp:2348
+#: src/Preferences.cpp:2351
 msgid "TCP port can't be higher than 65532 due to server UDP socket being TCP+3"
 msgstr ""
 
-#: src/Preferences.cpp:2349
+#: src/Preferences.cpp:2352
 #, c-format
 msgid "Default port will be used (%d)"
 msgstr ""
@@ -6059,24 +6072,28 @@ msgstr ""
 msgid "Shared folder"
 msgstr "Delte Filer"
 
-#: src/SearchDlg.cpp:425
+#: src/SearchDlg.cpp:280
+msgid "Clear search history"
+msgstr ""
+
+#: src/SearchDlg.cpp:584
 msgid "It's impossible to search when both eD2k and Kademlia are disabled."
 msgstr ""
 
-#: src/SearchDlg.cpp:426 src/SearchListCtrl.cpp:858
+#: src/SearchDlg.cpp:585 src/SearchListCtrl.cpp:858
 #, fuzzy
 msgid "Search error"
 msgstr "Søg"
 
-#: src/SearchDlg.cpp:768
+#: src/SearchDlg.cpp:929
 msgid "Min size must be smaller than max size. Max size ignored."
 msgstr ""
 
-#: src/SearchDlg.cpp:769 src/SearchDlg.cpp:851
+#: src/SearchDlg.cpp:930 src/SearchDlg.cpp:1012
 msgid "Search warning"
 msgstr ""
 
-#: src/SearchDlg.cpp:929 src/SearchListCtrl.cpp:735
+#: src/SearchDlg.cpp:1092 src/SearchListCtrl.cpp:735
 msgid "Main"
 msgstr ""
 

--- a/po/da.po
+++ b/po/da.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-28 12:17+0200\n"
+"POT-Creation-Date: 2026-07-28 13:09+0200\n"
 "PO-Revision-Date: 2026-07-27 11:34+0000\n"
 "Last-Translator: Alex Thomsen Leth <alexl@stofanet.dk>\n"
 "Language-Team: aMule Team <https://github.com/amule-org/amule>\n"
@@ -283,7 +283,7 @@ msgid "Password set and external connections enabled."
 msgstr "Accepter ydre forbindelser"
 
 #: src/amule.cpp:755 src/KadDlg.cpp:176 src/KadDlg.cpp:185
-#: src/PrefsUnifiedDlg.cpp:1461 src/SharedFilesCtrl.cpp:476
+#: src/PrefsUnifiedDlg.cpp:1470 src/SharedFilesCtrl.cpp:476
 msgid "WARNING"
 msgstr ""
 
@@ -319,7 +319,7 @@ msgstr ""
 #: src/amule-remote-gui.cpp:603 src/amule-remote-gui.cpp:671
 #: src/amule-remote-gui.cpp:709 src/amule-remote-gui.cpp:1282
 #: src/amule-remote-gui.cpp:1345 src/amule-remote-gui.cpp:1372
-#: src/DownloadQueue.cpp:1481 src/PrefsUnifiedDlg.cpp:1247
+#: src/DownloadQueue.cpp:1481 src/PrefsUnifiedDlg.cpp:1256
 msgid "ERROR"
 msgstr ""
 
@@ -573,36 +573,36 @@ msgstr ""
 msgid "FATAL ERROR: Failed to create Timer"
 msgstr ""
 
-#: src/amuleDlg.cpp:361 src/amuleDlg.cpp:1787 src/amuleDlg.cpp:2033
-#: src/muuli_wdr.cpp:1492 src/muuli_wdr.cpp:3449
+#: src/amuleDlg.cpp:361 src/amuleDlg.cpp:1810 src/amuleDlg.cpp:2056
+#: src/muuli_wdr.cpp:1492 src/muuli_wdr.cpp:3453
 msgid "Networks"
 msgstr ""
 
-#: src/amuleDlg.cpp:362 src/amuleDlg.cpp:1793 src/muuli_wdr.cpp:3450
+#: src/amuleDlg.cpp:362 src/amuleDlg.cpp:1816 src/muuli_wdr.cpp:3454
 msgid "Searches"
 msgstr "Søg"
 
-#: src/amuleDlg.cpp:363 src/amuleDlg.cpp:1799 src/DownloadListCtrl.cpp:740
-#: src/muuli_wdr.cpp:392 src/muuli_wdr.cpp:1585 src/muuli_wdr.cpp:3451
+#: src/amuleDlg.cpp:363 src/amuleDlg.cpp:1822 src/DownloadListCtrl.cpp:740
+#: src/muuli_wdr.cpp:392 src/muuli_wdr.cpp:1585 src/muuli_wdr.cpp:3455
 #: src/Statistics.cpp:829
 msgid "Downloads"
 msgstr "Downloads"
 
-#: src/amuleDlg.cpp:364 src/amuleDlg.cpp:1805 src/muuli_wdr.cpp:3325
+#: src/amuleDlg.cpp:364 src/amuleDlg.cpp:1828 src/muuli_wdr.cpp:3329
 msgid "Shared files"
 msgstr ""
 
-#: src/amuleDlg.cpp:365 src/amuleDlg.cpp:1811 src/muuli_wdr.cpp:2957
-#: src/muuli_wdr.cpp:3407 src/muuli_wdr.cpp:3454
+#: src/amuleDlg.cpp:365 src/amuleDlg.cpp:1834 src/muuli_wdr.cpp:2961
+#: src/muuli_wdr.cpp:3411 src/muuli_wdr.cpp:3458
 msgid "Messages"
 msgstr "Beskeder"
 
-#: src/amuleDlg.cpp:366 src/amuleDlg.cpp:1817 src/muuli_wdr.cpp:3455
+#: src/amuleDlg.cpp:366 src/amuleDlg.cpp:1840 src/muuli_wdr.cpp:3459
 #: src/PrefsUnifiedDlg.cpp:314 src/Statistics.cpp:779 src/Statistics.cpp:1235
 msgid "Statistics"
 msgstr "Statistik"
 
-#: src/amuleDlg.cpp:368 src/amuleDlg.cpp:1824 src/muuli_wdr.cpp:3457
+#: src/amuleDlg.cpp:368 src/amuleDlg.cpp:1847 src/muuli_wdr.cpp:3461
 #: src/PrefsUnifiedDlg.cpp:330 src/utils/wxCas/src/wxcasprefs.cpp:39
 msgid "Preferences"
 msgstr "Indstillinger"
@@ -665,8 +665,8 @@ msgstr " Kad: "
 #: src/amuleDlg.cpp:1029 src/DownloadListCtrl.cpp:505
 #: src/DownloadListCtrl.cpp:749 src/FriendListCtrl.cpp:180
 #: src/muuli_wdr.cpp:731 src/muuli_wdr.cpp:782 src/muuli_wdr.cpp:846
-#: src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2262 src/muuli_wdr.cpp:2347
-#: src/muuli_wdr.cpp:3095 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
+#: src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2266 src/muuli_wdr.cpp:2351
+#: src/muuli_wdr.cpp:3099 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
 #: src/ServerListCtrl.cpp:606 src/TransferWnd.cpp:378
 #: src/utils/wxCas/src/wxcasprefs.cpp:235
 msgid "Cancel"
@@ -678,7 +678,7 @@ msgid "Stop the current connection attempts"
 msgstr "Stop de nuværende forbindelses forsøg"
 
 #: src/amuleDlg.cpp:1035 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976
-#: src/muuli_wdr.cpp:2485
+#: src/muuli_wdr.cpp:2489
 msgid "Disconnect"
 msgstr "Afbryd"
 
@@ -688,7 +688,7 @@ msgid "Disconnect from the currently connected networks"
 msgstr "Afbryd fra nuvÃŠrende server"
 
 #: src/amuleDlg.cpp:1041 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979
-#: src/muuli_wdr.cpp:2640 src/muuli_wdr.cpp:3092 src/muuli_wdr.cpp:3447
+#: src/muuli_wdr.cpp:2644 src/muuli_wdr.cpp:3096 src/muuli_wdr.cpp:3451
 msgid "Connect"
 msgstr "Forbind"
 
@@ -742,7 +742,7 @@ msgstr "Bekræft afslut"
 msgid "Launch Command: "
 msgstr ""
 
-#: src/amuleDlg.cpp:1632 src/muuli_wdr.cpp:1982 src/Preferences.cpp:979
+#: src/amuleDlg.cpp:1632 src/muuli_wdr.cpp:1986 src/Preferences.cpp:979
 msgid "- default -"
 msgstr ""
 
@@ -756,61 +756,61 @@ msgstr ""
 msgid "WARNING: Unable to open skin file '%s' for read"
 msgstr ""
 
-#: src/amuleDlg.cpp:1791 src/muuli_wdr.cpp:3449
+#: src/amuleDlg.cpp:1814 src/muuli_wdr.cpp:3453
 msgid "Networks Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1797 src/muuli_wdr.cpp:3450
+#: src/amuleDlg.cpp:1820 src/muuli_wdr.cpp:3454
 msgid "Searches Window"
 msgstr "Søge Vindue"
 
-#: src/amuleDlg.cpp:1803 src/muuli_wdr.cpp:3451
+#: src/amuleDlg.cpp:1826 src/muuli_wdr.cpp:3455
 #, fuzzy
 msgid "Downloads Window"
 msgstr "Henter"
 
-#: src/amuleDlg.cpp:1809 src/muuli_wdr.cpp:3453
+#: src/amuleDlg.cpp:1832 src/muuli_wdr.cpp:3457
 msgid "Shared Files Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1815 src/muuli_wdr.cpp:3454
+#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3458
 msgid "Messages Window"
 msgstr "Besked Vindue"
 
-#: src/amuleDlg.cpp:1821 src/muuli_wdr.cpp:3455
+#: src/amuleDlg.cpp:1844 src/muuli_wdr.cpp:3459
 msgid "Statistics Graph Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1828 src/muuli_wdr.cpp:3457
+#: src/amuleDlg.cpp:1851 src/muuli_wdr.cpp:3461
 msgid "Preferences Settings Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1831 src/muuli_wdr.cpp:3458
+#: src/amuleDlg.cpp:1854 src/muuli_wdr.cpp:3462
 msgid "Import"
 msgstr ""
 
-#: src/amuleDlg.cpp:1835 src/muuli_wdr.cpp:3458
+#: src/amuleDlg.cpp:1858 src/muuli_wdr.cpp:3462
 msgid "The partfile importer tool"
 msgstr ""
 
-#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3459
+#: src/amuleDlg.cpp:1861 src/muuli_wdr.cpp:3463
 #: src/utils/aLinkCreator/src/alcframe.cpp:262
 msgid "About"
 msgstr ""
 
-#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3459
+#: src/amuleDlg.cpp:1861 src/muuli_wdr.cpp:3463
 msgid "About/Help"
 msgstr ""
 
-#: src/amuleDlg.cpp:2036
+#: src/amuleDlg.cpp:2059
 msgid "eD2k network"
 msgstr ""
 
-#: src/amuleDlg.cpp:2039
+#: src/amuleDlg.cpp:2062
 msgid "Kad network"
 msgstr ""
 
-#: src/amuleDlg.cpp:2039
+#: src/amuleDlg.cpp:2062
 msgid "No network"
 msgstr ""
 
@@ -1346,19 +1346,19 @@ msgstr "Auto [Hø]"
 msgid "Very low"
 msgstr "Meget lav"
 
-#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:743 src/muuli_wdr.cpp:2313
+#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:743 src/muuli_wdr.cpp:2317
 #: src/ServerListCtrl.cpp:263 src/ServerListCtrl.cpp:456
 #: src/SharedFilesCtrl.cpp:145
 msgid "Low"
 msgstr "Lav"
 
-#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:744 src/muuli_wdr.cpp:2314
+#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:744 src/muuli_wdr.cpp:2318
 #: src/ServerListCtrl.cpp:266 src/ServerListCtrl.cpp:457
 #: src/SharedFilesCtrl.cpp:146
 msgid "Normal"
 msgstr "Normal"
 
-#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:745 src/muuli_wdr.cpp:2315
+#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:745 src/muuli_wdr.cpp:2319
 #: src/ServerListCtrl.cpp:269 src/ServerListCtrl.cpp:458
 #: src/SharedFilesCtrl.cpp:147
 msgid "High"
@@ -1450,7 +1450,7 @@ msgstr ""
 msgid "Remote Server"
 msgstr ""
 
-#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3212
+#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3216
 #: src/SearchDlg.cpp:119 src/TextClient.cpp:911
 msgid "Kad"
 msgstr ""
@@ -1521,7 +1521,7 @@ msgstr ""
 msgid "Size"
 msgstr "Størrelse"
 
-#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3279
+#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3283
 msgid "Transferred"
 msgstr "Overført"
 
@@ -1579,7 +1579,7 @@ msgid ""
 "\n"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:746 src/muuli_wdr.cpp:2316
+#: src/DownloadListCtrl.cpp:746 src/muuli_wdr.cpp:2320
 #: src/SharedFilesCtrl.cpp:150
 msgid "Auto"
 msgstr "Auto"
@@ -1617,7 +1617,7 @@ msgid "Extended Options"
 msgstr "Udvidet Muligheder"
 
 #: src/DownloadListCtrl.cpp:770 src/DownloadListCtrl.cpp:822
-#: src/muuli_wdr.cpp:1800
+#: src/muuli_wdr.cpp:1804
 msgid "Preview"
 msgstr "Smug Kig"
 
@@ -2389,23 +2389,23 @@ msgid ""
 "want downloads on a different (e.g. larger) disk."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:549 src/FirstRunWizard.cpp:611 src/muuli_wdr.cpp:1712
+#: src/FirstRunWizard.cpp:549 src/FirstRunWizard.cpp:611 src/muuli_wdr.cpp:1716
 msgid "Destination folder for downloads"
 msgstr ""
 
 #: src/FirstRunWizard.cpp:553 src/FirstRunWizard.cpp:569 src/muuli_wdr.cpp:1349
-#: src/muuli_wdr.cpp:1366 src/muuli_wdr.cpp:1687 src/muuli_wdr.cpp:1718
-#: src/muuli_wdr.cpp:1730 src/muuli_wdr.cpp:2800
+#: src/muuli_wdr.cpp:1366 src/muuli_wdr.cpp:1691 src/muuli_wdr.cpp:1722
+#: src/muuli_wdr.cpp:1734 src/muuli_wdr.cpp:2804
 #: src/utils/aLinkCreator/src/alcframe.cpp:135
 #: src/utils/wxCas/src/wxcasprefs.cpp:52 src/utils/wxCas/src/wxcasprefs.cpp:118
 msgid "Browse"
 msgstr "Gennemse"
 
-#: src/FirstRunWizard.cpp:559 src/muuli_wdr.cpp:1723
+#: src/FirstRunWizard.cpp:559 src/muuli_wdr.cpp:1727
 msgid "(All files in this folder are shared with other peers)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:565 src/FirstRunWizard.cpp:624 src/muuli_wdr.cpp:1725
+#: src/FirstRunWizard.cpp:565 src/FirstRunWizard.cpp:624 src/muuli_wdr.cpp:1729
 msgid "Folder for temporary download files"
 msgstr ""
 
@@ -2436,7 +2436,7 @@ msgstr ""
 msgid "CRITICAL - no client on StartChatSession"
 msgstr ""
 
-#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2706 src/muuli_wdr.cpp:3383
+#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2710 src/muuli_wdr.cpp:3387
 msgid "Friends"
 msgstr "Venner"
 
@@ -2547,8 +2547,8 @@ msgstr "Ingen"
 msgid "No"
 msgstr "Nej"
 
-#: src/GenericClientListCtrl.cpp:1216 src/PrefsUnifiedDlg.cpp:2898
-#: src/PrefsUnifiedDlg.cpp:2948 src/ServerListCtrl.cpp:276
+#: src/GenericClientListCtrl.cpp:1216 src/PrefsUnifiedDlg.cpp:2907
+#: src/PrefsUnifiedDlg.cpp:2957 src/ServerListCtrl.cpp:276
 msgid "Yes"
 msgstr "Ja"
 
@@ -2716,10 +2716,10 @@ msgstr ""
 msgid "Please fill all fields required"
 msgstr ""
 
-#: src/KadDlg.cpp:192 src/PartFile.cpp:1031 src/PrefsUnifiedDlg.cpp:1134
-#: src/PrefsUnifiedDlg.cpp:1204 src/PrefsUnifiedDlg.cpp:1405
-#: src/PrefsUnifiedDlg.cpp:1663 src/PrefsUnifiedDlg.cpp:1673
-#: src/PrefsUnifiedDlg.cpp:1690 src/PrefsUnifiedDlg.cpp:1738
+#: src/KadDlg.cpp:192 src/PartFile.cpp:1031 src/PrefsUnifiedDlg.cpp:1143
+#: src/PrefsUnifiedDlg.cpp:1213 src/PrefsUnifiedDlg.cpp:1414
+#: src/PrefsUnifiedDlg.cpp:1672 src/PrefsUnifiedDlg.cpp:1682
+#: src/PrefsUnifiedDlg.cpp:1699 src/PrefsUnifiedDlg.cpp:1747
 msgid "Message"
 msgstr ""
 
@@ -2821,7 +2821,7 @@ msgstr ""
 msgid "Uploaded"
 msgstr ""
 
-#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3263
+#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3267
 msgid "Requested"
 msgstr ""
 
@@ -2947,7 +2947,7 @@ msgid "WARNING: "
 msgstr ""
 
 #: src/MuleNotebook.cpp:179 src/muuli_wdr.cpp:817 src/muuli_wdr.cpp:1229
-#: src/muuli_wdr.cpp:3167 src/muuli_wdr.cpp:3423
+#: src/muuli_wdr.cpp:3171 src/muuli_wdr.cpp:3427
 msgid "Close"
 msgstr "Luk"
 
@@ -2965,7 +2965,7 @@ msgid "Paste"
 msgstr ""
 
 #: src/MuleTextCtrl.cpp:89 src/muuli_wdr.cpp:358 src/muuli_wdr.cpp:757
-#: src/muuli_wdr.cpp:2390 src/muuli_wdr.cpp:2409 src/muuli_wdr.cpp:2431
+#: src/muuli_wdr.cpp:2394 src/muuli_wdr.cpp:2413 src/muuli_wdr.cpp:2435
 #: src/utils/aLinkCreator/src/alcframe.cpp:142
 msgid "Clear"
 msgstr "Ryd"
@@ -3063,7 +3063,7 @@ msgstr "Afslut"
 
 #: src/MuleTrayIcon.cpp:579 src/MuleTrayIcon.cpp:945 src/MuleTrayIcon.cpp:965
 #: src/muuli_wdr.cpp:1398 src/muuli_wdr.cpp:1406 src/muuli_wdr.cpp:1413
-#: src/muuli_wdr.cpp:1846 src/muuli_wdr.cpp:1852 src/OtherFunctions.cpp:91
+#: src/muuli_wdr.cpp:1850 src/muuli_wdr.cpp:1856 src/OtherFunctions.cpp:91
 #: src/StatisticsDlg.cpp:93 src/StatisticsDlg.cpp:95
 msgid "kB/s"
 msgstr "kB/s"
@@ -3304,7 +3304,7 @@ msgstr "Bytes"
 msgid "KB"
 msgstr "KB"
 
-#: src/muuli_wdr.cpp:274 src/muuli_wdr.cpp:293 src/muuli_wdr.cpp:1631
+#: src/muuli_wdr.cpp:274 src/muuli_wdr.cpp:293 src/muuli_wdr.cpp:1635
 #: src/OtherFunctions.cpp:64
 msgid "MB"
 msgstr "MB"
@@ -3321,7 +3321,7 @@ msgstr "Max Størrelse"
 msgid "Availability"
 msgstr ""
 
-#: src/muuli_wdr.cpp:312 src/muuli_wdr.cpp:398 src/muuli_wdr.cpp:3328
+#: src/muuli_wdr.cpp:312 src/muuli_wdr.cpp:398 src/muuli_wdr.cpp:3332
 msgid "Filter:"
 msgstr ""
 
@@ -3385,8 +3385,8 @@ msgstr "Fundne Kilder :"
 #: src/muuli_wdr.cpp:1160 src/muuli_wdr.cpp:1167 src/muuli_wdr.cpp:1172
 #: src/muuli_wdr.cpp:1179 src/muuli_wdr.cpp:1184 src/muuli_wdr.cpp:1191
 #: src/muuli_wdr.cpp:1205 src/muuli_wdr.cpp:1212 src/muuli_wdr.cpp:1217
-#: src/muuli_wdr.cpp:1224 src/muuli_wdr.cpp:3265 src/muuli_wdr.cpp:3273
-#: src/muuli_wdr.cpp:3281
+#: src/muuli_wdr.cpp:1224 src/muuli_wdr.cpp:3269 src/muuli_wdr.cpp:3277
+#: src/muuli_wdr.cpp:3285
 msgid "N/A"
 msgstr "N/A"
 
@@ -3530,7 +3530,7 @@ msgstr ""
 msgid "Album :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:685 src/muuli_wdr.cpp:2285
+#: src/muuli_wdr.cpp:685 src/muuli_wdr.cpp:2289
 msgid "Title :"
 msgstr "Titel :"
 
@@ -3637,7 +3637,7 @@ msgstr "Brugernavn :"
 msgid "Userhash :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:895 src/muuli_wdr.cpp:1752 src/muuli_wdr.cpp:2480
+#: src/muuli_wdr.cpp:895 src/muuli_wdr.cpp:1756 src/muuli_wdr.cpp:2484
 #: src/utils/aLinkCreator/src/alcframe.cpp:137
 msgid "Add"
 msgstr "Tilføj"
@@ -3646,15 +3646,15 @@ msgstr "Tilføj"
 msgid "Download-Speed"
 msgstr "Download-Hastighed"
 
-#: src/muuli_wdr.cpp:954 src/muuli_wdr.cpp:989 src/muuli_wdr.cpp:2584
+#: src/muuli_wdr.cpp:954 src/muuli_wdr.cpp:989 src/muuli_wdr.cpp:2588
 msgid "Current"
 msgstr "Nuværende"
 
-#: src/muuli_wdr.cpp:962 src/muuli_wdr.cpp:997 src/muuli_wdr.cpp:2592
+#: src/muuli_wdr.cpp:962 src/muuli_wdr.cpp:997 src/muuli_wdr.cpp:2596
 msgid "Running average"
 msgstr "Nuværende Gennemsnit"
 
-#: src/muuli_wdr.cpp:970 src/muuli_wdr.cpp:1005 src/muuli_wdr.cpp:2600
+#: src/muuli_wdr.cpp:970 src/muuli_wdr.cpp:1005 src/muuli_wdr.cpp:2604
 msgid "Session average"
 msgstr "Sessions Gennemsnit"
 
@@ -3666,7 +3666,7 @@ msgstr "Upload-Hastighed"
 msgid "Connections"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1024 src/muuli_wdr.cpp:1871
+#: src/muuli_wdr.cpp:1024 src/muuli_wdr.cpp:1875
 msgid "Active downloads"
 msgstr "Aktive Downloads"
 
@@ -3674,7 +3674,7 @@ msgstr "Aktive Downloads"
 msgid "Active connections (1:1)"
 msgstr "Aktive Forbindelser (1:1)"
 
-#: src/muuli_wdr.cpp:1040 src/muuli_wdr.cpp:1872
+#: src/muuli_wdr.cpp:1040 src/muuli_wdr.cpp:1876
 msgid "Active uploads"
 msgstr "Aktive Uploads"
 
@@ -3948,7 +3948,7 @@ msgstr ""
 msgid "Advanced users only: If you have multiple network interfaces, enter the address of the interface to which aMule should be bound."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1462 src/muuli_wdr.cpp:2065
+#: src/muuli_wdr.cpp:1462 src/muuli_wdr.cpp:2069
 msgid "Bind to network interface (empty for any):"
 msgstr ""
 
@@ -3964,7 +3964,7 @@ msgstr ""
 msgid "Max simultaneous connections:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1498 src/muuli_wdr.cpp:3207
+#: src/muuli_wdr.cpp:1498 src/muuli_wdr.cpp:3211
 msgid "ED2K"
 msgstr ""
 
@@ -4056,773 +4056,773 @@ msgstr ""
 msgid "For new files preallocates disk space for the whole file, thus reduces fragmentation"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1617
+#: src/muuli_wdr.cpp:1621
 msgid "Create new files as sparse files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1618
+#: src/muuli_wdr.cpp:1622
 msgid "Sparse part files only occupy disk space for the parts already downloaded, so free space is used up gradually as the file fills in. Turn this off to use an ordinary file instead - useful where sparse files are unsupported or slow, or where backup/de-duplication tools handle them badly. Applies only when the core runs on Windows; on Linux and macOS part files are sparse anyway and this setting has no effect."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1623
+#: src/muuli_wdr.cpp:1627
 msgid "Stop downloads when free disk space reaches "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1624
+#: src/muuli_wdr.cpp:1628
 msgid "Select this if you want aMule to check your disk space"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1628
+#: src/muuli_wdr.cpp:1632
 msgid "Enter here the min disk space desired."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1634
+#: src/muuli_wdr.cpp:1638
 msgid "Save 10 sources on rare files (< 20 sources)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1638 src/Statistics.cpp:790
+#: src/muuli_wdr.cpp:1642 src/Statistics.cpp:790
 msgid "Uploads"
 msgstr "Uploads"
 
-#: src/muuli_wdr.cpp:1641
+#: src/muuli_wdr.cpp:1645
 msgid "Add new shared files with auto priority"
 msgstr "Tilføj nye delte filer med auto priotet"
 
-#: src/muuli_wdr.cpp:1647
+#: src/muuli_wdr.cpp:1651
 msgid "Intelligent Corruption Handling (I.C.H.)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1650
+#: src/muuli_wdr.cpp:1654
 msgid "Enable"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1653
+#: src/muuli_wdr.cpp:1657
 msgid "Advanced I.C.H. trusts every hash (not recommended)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1665 src/PrefsUnifiedDlg.cpp:1990
+#: src/muuli_wdr.cpp:1669 src/PrefsUnifiedDlg.cpp:1999
 msgid "Media metadata extraction"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1669
+#: src/muuli_wdr.cpp:1673
 msgid "Extract length / bitrate / codec from shared audio and video files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1671
+#: src/muuli_wdr.cpp:1675
 msgid "When enabled, aMule runs ffprobe on each shared media file to fill in the Length / Bitrate / Codec columns other clients see when they find the file in a search. Requires ffmpeg (the ffprobe binary) to be installed."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1678
+#: src/muuli_wdr.cpp:1682
 msgid "Path to ffprobe:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1683
+#: src/muuli_wdr.cpp:1687
 msgid "Full path to the ffprobe binary. Leave empty to have aMule auto-detect it on startup."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1691
+#: src/muuli_wdr.cpp:1695
 msgid "Detect"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1692
+#: src/muuli_wdr.cpp:1696
 msgid "Search the standard install locations for an ffprobe binary and fill the path field."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1716
+#: src/muuli_wdr.cpp:1720
 msgid ""
 "Completed downloads are stored here. All files in this folder are automatically shared with other peers.\n"
 "If this folder also holds files you don't want to share, point it at an aMule-only sub-folder."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1719
+#: src/muuli_wdr.cpp:1723
 msgid "Pick the folder where completed downloads will be stored. All files in that folder will be shared with other peers."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1733
+#: src/muuli_wdr.cpp:1737
 msgid "Shared folders"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1739
+#: src/muuli_wdr.cpp:1743
 msgid "(Folders shared by the core. Enter a path to add one.)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1747
+#: src/muuli_wdr.cpp:1751
 msgid "Absolute path of a folder on the core's machine, e.g. /home/user/shared"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1749 src/PrefsUnifiedDlg.cpp:2874
+#: src/muuli_wdr.cpp:1753 src/PrefsUnifiedDlg.cpp:2883
 msgid "Recursive"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1750
+#: src/muuli_wdr.cpp:1754
 msgid "Share every sub-folder underneath this one, including ones created later."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1754 src/utils/aLinkCreator/src/alcframe.cpp:141
+#: src/muuli_wdr.cpp:1758 src/utils/aLinkCreator/src/alcframe.cpp:141
 msgid "Remove"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1758
+#: src/muuli_wdr.cpp:1762
 msgid "(Right click on folder icon for recursive share)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1765
+#: src/muuli_wdr.cpp:1769
 msgid "Share hidden files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1771
+#: src/muuli_wdr.cpp:1775
 msgid "Automatically rescan shared folders for changes"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1777
+#: src/muuli_wdr.cpp:1781
 msgid "Follow symbolic links in shared folders"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1783
+#: src/muuli_wdr.cpp:1787
 msgid "Exclude files matching:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1786
+#: src/muuli_wdr.cpp:1790
 msgid "Wildcard patterns separated by '|', e.g. .DS_Store|Thumbs.db|*.tmp. Files whose name matches are not shared. Matching is case-insensitive."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1790
+#: src/muuli_wdr.cpp:1794
 msgid "Patterns are regular expressions"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1791
+#: src/muuli_wdr.cpp:1795
 msgid "When set, the whole field is one regular expression ('|' is alternation). When unset, it is a list of '|'-separated wildcards."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1801
+#: src/muuli_wdr.cpp:1805
 msgid "Show how many shared files the current pattern would exclude."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1822
+#: src/muuli_wdr.cpp:1826
 msgid "Graphs"
 msgstr "Grafer"
 
-#: src/muuli_wdr.cpp:1825 src/muuli_wdr.cpp:1887
+#: src/muuli_wdr.cpp:1829 src/muuli_wdr.cpp:1891
 msgid "Update delay : 5 secs"
 msgstr "Opdaterings interval : 5 sek"
 
-#: src/muuli_wdr.cpp:1829
+#: src/muuli_wdr.cpp:1833
 msgid "Time for average graph: 100 mins"
 msgstr "Tid for gennemsnitlig graf: 100 min"
 
-#: src/muuli_wdr.cpp:1833
+#: src/muuli_wdr.cpp:1837
 msgid "Connections Graph Scale: 100 "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1840
+#: src/muuli_wdr.cpp:1844
 msgid "Download graph scale:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1848
+#: src/muuli_wdr.cpp:1852
 msgid "Upload graph scale:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1858
+#: src/muuli_wdr.cpp:1862
 msgid "Colors: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1862
+#: src/muuli_wdr.cpp:1866
 msgid "Background"
 msgstr "Baggrund"
 
-#: src/muuli_wdr.cpp:1863
+#: src/muuli_wdr.cpp:1867
 msgid "Grid"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1864
+#: src/muuli_wdr.cpp:1868
 msgid "Download current"
 msgstr "Download nu"
 
-#: src/muuli_wdr.cpp:1865
+#: src/muuli_wdr.cpp:1869
 msgid "Download running average"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1866
+#: src/muuli_wdr.cpp:1870
 msgid "Download session average"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1867
+#: src/muuli_wdr.cpp:1871
 msgid "Upload current"
 msgstr "Upload nu"
 
-#: src/muuli_wdr.cpp:1868
+#: src/muuli_wdr.cpp:1872
 msgid "Upload running average"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1869
+#: src/muuli_wdr.cpp:1873
 msgid "Upload session average"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1870
+#: src/muuli_wdr.cpp:1874
 msgid "Active connections"
 msgstr "Aktive Forbindelser"
 
-#: src/muuli_wdr.cpp:1873
+#: src/muuli_wdr.cpp:1877
 msgid "Systray Icon Speed Bar"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1874
+#: src/muuli_wdr.cpp:1878
 msgid "Kad-nodes current"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1875
+#: src/muuli_wdr.cpp:1879
 msgid "Kad-nodes running"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1876
+#: src/muuli_wdr.cpp:1880
 msgid "Kad-nodes session"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1880 src/muuli_wdr.cpp:2334
+#: src/muuli_wdr.cpp:1884 src/muuli_wdr.cpp:2338
 msgid "Select"
 msgstr "Vælg"
 
-#: src/muuli_wdr.cpp:1884
+#: src/muuli_wdr.cpp:1888
 msgid "Tree"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1894
+#: src/muuli_wdr.cpp:1898
 msgid "Number of Client Versions shown (0=unlimited)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1919
+#: src/muuli_wdr.cpp:1923
 msgid "!!! WARNING !!!"
 msgstr "!!! Advarsel !!!"
 
-#: src/muuli_wdr.cpp:1934
+#: src/muuli_wdr.cpp:1938
 msgid "Max new connections / 5 secs"
 msgstr "Max nye forbindelser / 5 sekunder"
 
-#: src/muuli_wdr.cpp:1936
+#: src/muuli_wdr.cpp:1940
 msgid "Concurrent Kad source lookups"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1938
+#: src/muuli_wdr.cpp:1942
 #, fuzzy
 msgid "Kad source re-search interval (minutes)"
 msgstr "FTP opdaterings interval i minutter"
 
-#: src/muuli_wdr.cpp:1940
+#: src/muuli_wdr.cpp:1944
 #, fuzzy
 msgid "Source re-ask interval (minutes)"
 msgstr "FTP opdaterings interval i minutter"
 
-#: src/muuli_wdr.cpp:1944
+#: src/muuli_wdr.cpp:1948
 msgid "File Buffer Size: 240000 bytes"
 msgstr "Fil Buffer Størrelse"
 
-#: src/muuli_wdr.cpp:1948
+#: src/muuli_wdr.cpp:1952
 msgid "Use MMAP: memory-mapped file access (lower memory use)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1949
+#: src/muuli_wdr.cpp:1953
 msgid "Maps part files into memory instead of buffering them on the heap, lowering the process memory footprint. May reduce download speed on some disks; best for memory-constrained or upload-heavy hosts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1951
+#: src/muuli_wdr.cpp:1955
 msgid "Upload Queue Size: 5000 clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1955
+#: src/muuli_wdr.cpp:1959
 msgid "Server connection refresh interval: Disable"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1959
+#: src/muuli_wdr.cpp:1963
 msgid "Disable computer's timed standby mode"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1978
+#: src/muuli_wdr.cpp:1982
 msgid "Skin to use: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1987
+#: src/muuli_wdr.cpp:1991
 msgid "Show \"Fast eD2k Links Handler\" in every window."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1990
+#: src/muuli_wdr.cpp:1994
 msgid "Show extended info on categories tabs"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1993
+#: src/muuli_wdr.cpp:1997
 #, fuzzy
 msgid "Show application version on title"
 msgstr "Vis overførsels hastighed i titel"
 
-#: src/muuli_wdr.cpp:1995
+#: src/muuli_wdr.cpp:1999
 msgid "Show transfer rates on title"
 msgstr "Vis overførsels hastighed i titel"
 
-#: src/muuli_wdr.cpp:1997
+#: src/muuli_wdr.cpp:2001
 msgid "Before application name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1999
+#: src/muuli_wdr.cpp:2003
 msgid "After application name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2002
+#: src/muuli_wdr.cpp:2006
 msgid "Show overhead bandwidth"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2006
+#: src/muuli_wdr.cpp:2010
 msgid "Vertical toolbar orientation"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2008
+#: src/muuli_wdr.cpp:2012
 msgid "Live column sorting (auto-reorder rows as their values change)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2015
+#: src/muuli_wdr.cpp:2019
 msgid "Download Queue Files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2018
+#: src/muuli_wdr.cpp:2022
 msgid "Show progress percentage"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2024
+#: src/muuli_wdr.cpp:2028
 msgid "Show progress bar"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2027
+#: src/muuli_wdr.cpp:2031
 msgid "Flat"
 msgstr "Flad"
 
-#: src/muuli_wdr.cpp:2031
+#: src/muuli_wdr.cpp:2035
 msgid "Round"
 msgstr "Rund"
 
-#: src/muuli_wdr.cpp:2049
+#: src/muuli_wdr.cpp:2053
 msgid "External Connection Parameters"
 msgstr "Ydre Forbindelses Parametre"
 
-#: src/muuli_wdr.cpp:2052
+#: src/muuli_wdr.cpp:2056
 msgid "Accept external connections"
 msgstr "Accepter ydre forbindelser"
 
-#: src/muuli_wdr.cpp:2059 src/muuli_wdr.cpp:2118
+#: src/muuli_wdr.cpp:2063 src/muuli_wdr.cpp:2122
 msgid "IP of the listening interface:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2062
+#: src/muuli_wdr.cpp:2066
 msgid "Enter here a valid ip in the a.b.c.d format for the listening EC interface. An empty field or 0.0.0.0 will mean any interface."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2083 src/muuli_wdr.cpp:2194
+#: src/muuli_wdr.cpp:2087 src/muuli_wdr.cpp:2198
 msgid "TCP port:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2089
+#: src/muuli_wdr.cpp:2093
 msgid "Enable UPnP port forwarding on the EC port"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2093 src/muuli_wdr.cpp:3079
+#: src/muuli_wdr.cpp:2097 src/muuli_wdr.cpp:3083
 #: src/utils/wxCas/src/wxcasprefs.cpp:167
 msgid "Password"
 msgstr "Password"
 
-#: src/muuli_wdr.cpp:2099
+#: src/muuli_wdr.cpp:2103
 msgid "aMule API server parameters"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2102
+#: src/muuli_wdr.cpp:2106
 msgid "Run amuleapi (REST API) on startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2107
+#: src/muuli_wdr.cpp:2111
 #, fuzzy
 msgid "HTTP port:"
 msgstr "UPnP port"
 
-#: src/muuli_wdr.cpp:2121
+#: src/muuli_wdr.cpp:2125
 msgid "The interface amuleapi's HTTP server listens on. 127.0.0.1 (default) accepts only local connections; use 0.0.0.0 or a specific IP to expose it to other hosts (set an admin password below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2126
+#: src/muuli_wdr.cpp:2130
 msgid "Type a password to set or change it. Stored passwords cannot be shown, so leaving this empty keeps the current one."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2128
+#: src/muuli_wdr.cpp:2132
 #, fuzzy
 msgid "Admin password"
 msgstr "Undersøger password\n"
 
-#: src/muuli_wdr.cpp:2140 src/muuli_wdr.cpp:2157 src/PrefsUnifiedDlg.cpp:1103
+#: src/muuli_wdr.cpp:2144 src/muuli_wdr.cpp:2161 src/PrefsUnifiedDlg.cpp:1112
 #, fuzzy
 msgid "A password is set."
 msgstr "Undersøger password\n"
 
-#: src/muuli_wdr.cpp:2144
+#: src/muuli_wdr.cpp:2148
 #, fuzzy
 msgid "Enable guest access"
 msgstr "Tillad bruger adgang"
 
-#: src/muuli_wdr.cpp:2145
+#: src/muuli_wdr.cpp:2149
 msgid "Guest sessions may read status and listings but cannot change anything. Turning this off clears the stored guest password."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2149
+#: src/muuli_wdr.cpp:2153
 #, fuzzy
 msgid "Guest password"
 msgstr "Fuld rettigheds kodeord"
 
-#: src/muuli_wdr.cpp:2164
+#: src/muuli_wdr.cpp:2168
 msgid "Web server parameters"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2167
+#: src/muuli_wdr.cpp:2171
 msgid "Run webserver on startup (deprecated)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2173
+#: src/muuli_wdr.cpp:2177
 msgid "Web template"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2178
+#: src/muuli_wdr.cpp:2182
 msgid "Full rights password"
 msgstr "Fuld rettigheds kodeord"
 
-#: src/muuli_wdr.cpp:2182
+#: src/muuli_wdr.cpp:2186
 msgid "Enable Low rights User"
 msgstr "Aktiver lav rettigheds brugere"
 
-#: src/muuli_wdr.cpp:2187
+#: src/muuli_wdr.cpp:2191
 msgid "Low rights password"
 msgstr "Lav rettigheds kodeord"
 
-#: src/muuli_wdr.cpp:2201
+#: src/muuli_wdr.cpp:2205
 msgid "Enable UPnP port forwarding of the web server port"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2206
+#: src/muuli_wdr.cpp:2210
 msgid "Web server UPnP TCP port (Optional)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2214
+#: src/muuli_wdr.cpp:2218
 msgid "Page Refresh Time (in secs)"
 msgstr "Side Opdaterings Tid (i sek)"
 
-#: src/muuli_wdr.cpp:2221
+#: src/muuli_wdr.cpp:2225
 msgid "Enable Gzip compression"
 msgstr "Aktiver Gzip komprimering"
 
-#: src/muuli_wdr.cpp:2255
+#: src/muuli_wdr.cpp:2259
 #, fuzzy
 msgid "Reset page to defaults"
 msgstr "System standard"
 
-#: src/muuli_wdr.cpp:2256
+#: src/muuli_wdr.cpp:2260
 msgid "Reset the settings on the current page to their default values."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2258 src/muuli_wdr.cpp:2344 src/ServerWnd.cpp:274
+#: src/muuli_wdr.cpp:2262 src/muuli_wdr.cpp:2348 src/ServerWnd.cpp:274
 #: src/ServerWnd.cpp:282
 msgid "OK"
 msgstr "OK"
 
-#: src/muuli_wdr.cpp:2260
+#: src/muuli_wdr.cpp:2264
 msgid "Click here to apply any changes made to the preferences."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2263
+#: src/muuli_wdr.cpp:2267
 msgid "Reset any changes made to the preferences."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2292
+#: src/muuli_wdr.cpp:2296
 msgid "Comment :"
 msgstr "Kommentar :"
 
-#: src/muuli_wdr.cpp:2299
+#: src/muuli_wdr.cpp:2303
 msgid "Incoming Dir :"
 msgstr "Indkommende Mappe :"
 
-#: src/muuli_wdr.cpp:2308
+#: src/muuli_wdr.cpp:2312
 msgid "Change priority for new assigned files :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2312
+#: src/muuli_wdr.cpp:2316
 msgid "Don't change"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2324
+#: src/muuli_wdr.cpp:2328
 msgid "Select color for this Category (currently selected) :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2391 src/muuli_wdr.cpp:2410 src/muuli_wdr.cpp:2432
+#: src/muuli_wdr.cpp:2395 src/muuli_wdr.cpp:2414 src/muuli_wdr.cpp:2436
 msgid "Click this button to reset the log."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2451
+#: src/muuli_wdr.cpp:2455
 msgid "Click on this button to update the servers list from URL ..."
 msgstr "Tryk på denne knap for at opdatere serverlisten fra URL ..."
 
-#: src/muuli_wdr.cpp:2455
+#: src/muuli_wdr.cpp:2459
 msgid "Server list"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2459
+#: src/muuli_wdr.cpp:2463
 msgid "Enter the url to a server.met file here and press the button to the left to update the list of known servers."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2464
+#: src/muuli_wdr.cpp:2468
 msgid "Add server manually: Name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2467
+#: src/muuli_wdr.cpp:2471
 msgid "Enter the name of the new server here"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2469 src/ServerWnd.cpp:206
+#: src/muuli_wdr.cpp:2473 src/ServerWnd.cpp:206
 msgid "IP:Port"
 msgstr "IP:Port"
 
-#: src/muuli_wdr.cpp:2472
+#: src/muuli_wdr.cpp:2476
 msgid "Enter the IP of the server here, using the x.x.x.x format."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2478
+#: src/muuli_wdr.cpp:2482
 msgid "Enter the port of the server here."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2481
+#: src/muuli_wdr.cpp:2485
 msgid "Add manually a server (fill fields to the left before) ..."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2510
+#: src/muuli_wdr.cpp:2514
 msgid "aMule Log"
 msgstr "aMule Log"
 
-#: src/muuli_wdr.cpp:2518
+#: src/muuli_wdr.cpp:2522
 msgid "Server Info"
 msgstr "Server Info"
 
-#: src/muuli_wdr.cpp:2522
+#: src/muuli_wdr.cpp:2526
 msgid "ED2K Info"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2526
+#: src/muuli_wdr.cpp:2530
 msgid "Kad Info"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2554
+#: src/muuli_wdr.cpp:2558
 msgid "Click on this button to update the nodes list from URL ..."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2558
+#: src/muuli_wdr.cpp:2562
 msgid "Nodes (0)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2562
+#: src/muuli_wdr.cpp:2566
 msgid "Enter the url to a nodes.dat file here and press the button to the left to update the list of known nodes."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2565
+#: src/muuli_wdr.cpp:2569
 msgid "Nodes stats"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2607
+#: src/muuli_wdr.cpp:2611
 msgid "Bootstrap"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2610
+#: src/muuli_wdr.cpp:2614
 msgid "New node"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2615
+#: src/muuli_wdr.cpp:2619
 msgid "IP:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2635
+#: src/muuli_wdr.cpp:2639
 msgid "Port:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2648
+#: src/muuli_wdr.cpp:2652
 msgid "Bootstrap from known clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2650
+#: src/muuli_wdr.cpp:2654
 msgid "Disconnect Kad"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2684
+#: src/muuli_wdr.cpp:2688
 msgid "Use Secure User Identification"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2686
+#: src/muuli_wdr.cpp:2690
 msgid "It is recommended to enable this option. You will not receive credits if SUI is not enabled."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2688
+#: src/muuli_wdr.cpp:2692
 msgid "Protocol Obfuscation"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2691
+#: src/muuli_wdr.cpp:2695
 msgid "Support Protocol Obfuscation"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2693
+#: src/muuli_wdr.cpp:2697
 msgid "This option enabled Protocol Obfuscation, and makes aMule accept obfuscated connections from other clients."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2695
+#: src/muuli_wdr.cpp:2699
 msgid "Use obfuscation for outgoing connections"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2697
+#: src/muuli_wdr.cpp:2701
 msgid "This option makes aMule use Protocol Obfuscation when connecting other clients/servers."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2699
+#: src/muuli_wdr.cpp:2703
 msgid "Accept only obfuscated connections"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2700
+#: src/muuli_wdr.cpp:2704
 msgid "This option makes aMule only accept obfuscated connections. You will have less sources, but all your traffic will be obfuscated"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2705
+#: src/muuli_wdr.cpp:2709
 msgid "Everybody"
 msgstr "Alle"
 
-#: src/muuli_wdr.cpp:2707
+#: src/muuli_wdr.cpp:2711
 msgid "No one"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2709
+#: src/muuli_wdr.cpp:2713
 msgid "Who can see my shared files:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2710
+#: src/muuli_wdr.cpp:2714
 msgid "Select who can request to view a list of your shared files."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2712
+#: src/muuli_wdr.cpp:2716
 msgid "IP-Filtering"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2719
+#: src/muuli_wdr.cpp:2723
 msgid "Filter clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2721
+#: src/muuli_wdr.cpp:2725
 msgid "Enable filtering of the client IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2723
+#: src/muuli_wdr.cpp:2727
 msgid "Filter servers"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2725
+#: src/muuli_wdr.cpp:2729
 msgid "Enable filtering of the server IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2729
+#: src/muuli_wdr.cpp:2733
 msgid "Reload List"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2730
+#: src/muuli_wdr.cpp:2734
 msgid "Reload the list of IPs to filter from the file ~/.aMule/ipfilter.dat"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2736
+#: src/muuli_wdr.cpp:2740
 msgid "URL:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2740 src/muuli_wdr.cpp:2933
+#: src/muuli_wdr.cpp:2744 src/muuli_wdr.cpp:2937
 msgid "Update now"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2743
+#: src/muuli_wdr.cpp:2747
 msgid "Auto-update ipfilter at startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2747
+#: src/muuli_wdr.cpp:2751
 msgid "Filtering Level:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2753
+#: src/muuli_wdr.cpp:2757
 msgid "Always filter LAN IPs"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2756
+#: src/muuli_wdr.cpp:2760
 msgid "Paranoid handling of non-matching IPs"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2758
+#: src/muuli_wdr.cpp:2762
 msgid "Rejects a packet when its source IP differs from the IP the client claims (an anti-spoofing check). Disable only if it causes connection problems."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2760
+#: src/muuli_wdr.cpp:2764
 msgid "Use system-wide ipfilter.dat if available"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2761
+#: src/muuli_wdr.cpp:2765
 msgid "If there's no local ipfilter.dat found, allow usage of a system-wide ipfilter file."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2778
+#: src/muuli_wdr.cpp:2782
 msgid "Enable Online-Signature"
 msgstr "Aktiver online-signatur"
 
-#: src/muuli_wdr.cpp:2780
+#: src/muuli_wdr.cpp:2784
 msgid "Enables the writing of the OS file, which can be used by external apps to create signatures and the like."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2784
+#: src/muuli_wdr.cpp:2788
 msgid "Update Frequency (Secs):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2787
+#: src/muuli_wdr.cpp:2791
 msgid "Change the frequency (in seconds) of Online Signature updates."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2795
+#: src/muuli_wdr.cpp:2799
 msgid "Save online signature file in: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:2801
+#: src/muuli_wdr.cpp:2805
 msgid "Click here to select the directory containing the the Online Signature files."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2834
+#: src/muuli_wdr.cpp:2838
 msgid "Show country flags for clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2835
+#: src/muuli_wdr.cpp:2839
 msgid "Render the country flag column in the transfers, queue and search views. Requires a valid MMDB GeoIP database (see below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2840
+#: src/muuli_wdr.cpp:2844
 msgid "Database"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2856
+#: src/muuli_wdr.cpp:2860
 #, fuzzy
 msgid "Source:"
 msgstr "Kilder"
 
-#: src/muuli_wdr.cpp:2859
+#: src/muuli_wdr.cpp:2863
 msgid "DB-IP (free, no account)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2860
+#: src/muuli_wdr.cpp:2864
 msgid "MaxMind GeoLite2 (free, account required)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2861
+#: src/muuli_wdr.cpp:2865
 msgid "Custom URL"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2864
+#: src/muuli_wdr.cpp:2868
 msgid "Choose which provider supplies the GeoIP MMDB database. DB-IP is the default - no account required. MaxMind requires a free account + license key. Use Custom URL to point at any other MMDB host (e.g. a local mirror)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2881
+#: src/muuli_wdr.cpp:2885
 msgid ""
 "No configuration required.\n"
 "\n"
@@ -4830,11 +4830,11 @@ msgid ""
 "License: Creative Commons BY 4.0 - https://creativecommons.org/licenses/by/4.0/"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2894
+#: src/muuli_wdr.cpp:2898
 msgid "License key:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2900
+#: src/muuli_wdr.cpp:2904
 msgid ""
 "Sign up for a free MaxMind account, then generate a License Key:\n"
 "https://www.maxmind.com/en/geolite2/signup\n"
@@ -4844,232 +4844,232 @@ msgid ""
 "Requires attribution and account registration; refresh at least every 30 days."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2915
+#: src/muuli_wdr.cpp:2919
 #, fuzzy
 msgid "Download URL:"
 msgstr "Download: "
 
-#: src/muuli_wdr.cpp:2921
+#: src/muuli_wdr.cpp:2925
 msgid ""
 "Must point to an .mmdb file or a .gz / .tar.gz containing one.\n"
 "URL may include credentials (https://user:pass@host/...).\n"
 "License and attribution terms are set by the upstream URL - you are responsible."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2934
+#: src/muuli_wdr.cpp:2938
 msgid "Download the GeoIP database from the selected source."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2936
+#: src/muuli_wdr.cpp:2940
 #, fuzzy
 msgid "Auto-update on startup"
 msgstr "Auto forbind ved start"
 
-#: src/muuli_wdr.cpp:2937
+#: src/muuli_wdr.cpp:2941
 msgid "Re-download the GeoIP database from the selected source every time aMule starts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2960
+#: src/muuli_wdr.cpp:2964
 msgid "Filter incoming messages (except current chat):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2962
+#: src/muuli_wdr.cpp:2966
 msgid "Filter all messages"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2964
+#: src/muuli_wdr.cpp:2968
 msgid "Filter messages from people not on your friend list"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2966
+#: src/muuli_wdr.cpp:2970
 msgid "Filter messages from unknown clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2968
+#: src/muuli_wdr.cpp:2972
 msgid "Filter messages containing (use ',' as separator):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2971 src/muuli_wdr.cpp:2982
+#: src/muuli_wdr.cpp:2975 src/muuli_wdr.cpp:2986
 msgid "add here the words amule should filter and block messages including it"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2973
+#: src/muuli_wdr.cpp:2977
 msgid "Show received messages in the log"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2976
+#: src/muuli_wdr.cpp:2980
 msgid "Comments"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2979
+#: src/muuli_wdr.cpp:2983
 msgid "Filter comments containing (use ',' as separator):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3004
+#: src/muuli_wdr.cpp:3008
 msgid "Enable Proxy"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3005
+#: src/muuli_wdr.cpp:3009
 msgid "Enable/disable proxy support"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3008
+#: src/muuli_wdr.cpp:3012
 msgid "Proxy type:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3019
+#: src/muuli_wdr.cpp:3023
 msgid "Proxy host:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3022
+#: src/muuli_wdr.cpp:3026
 msgid "The proxy host name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3024
+#: src/muuli_wdr.cpp:3028
 msgid "Proxy port:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3027
+#: src/muuli_wdr.cpp:3031
 msgid "The proxy port"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3029
+#: src/muuli_wdr.cpp:3033
 msgid "Enable authentication"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3030
+#: src/muuli_wdr.cpp:3034
 msgid "Enable/disable username/password authentication"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3033
+#: src/muuli_wdr.cpp:3037
 msgid "Username: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:3036
+#: src/muuli_wdr.cpp:3040
 msgid "The username to use to connect to the proxy"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3038
+#: src/muuli_wdr.cpp:3042
 msgid "Password:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3041
+#: src/muuli_wdr.cpp:3045
 msgid "The password to use to connect to the proxy"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3060
+#: src/muuli_wdr.cpp:3064
 msgid "Connect to:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3069
+#: src/muuli_wdr.cpp:3073
 msgid "Login to remote amule"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3074
+#: src/muuli_wdr.cpp:3078
 msgid "User name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3085
+#: src/muuli_wdr.cpp:3089
 msgid "Remember those settings"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3088
+#: src/muuli_wdr.cpp:3092
 #, fuzzy
 msgid "Force ZLIB compression"
 msgstr "Brug gzip komprimering"
 
-#: src/muuli_wdr.cpp:3112
+#: src/muuli_wdr.cpp:3116
 msgid "Enable Verbose Debug-Logging."
 msgstr ""
 
-#: src/muuli_wdr.cpp:3114
+#: src/muuli_wdr.cpp:3118
 #, fuzzy
 msgid "Only to Logfile"
 msgstr "&Åben filen"
 
-#: src/muuli_wdr.cpp:3116
+#: src/muuli_wdr.cpp:3120
 msgid "Message Categories:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3140 src/PartFileConvertDlg.cpp:160
+#: src/muuli_wdr.cpp:3144 src/PartFileConvertDlg.cpp:160
 msgid "Waiting..."
 msgstr "Venter..."
 
-#: src/muuli_wdr.cpp:3160
+#: src/muuli_wdr.cpp:3164
 msgid "Add imports"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3163
+#: src/muuli_wdr.cpp:3167
 msgid "Retry selected"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3165
+#: src/muuli_wdr.cpp:3169
 msgid "Remove selected"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3228
+#: src/muuli_wdr.cpp:3232
 msgid "Event Types"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3247
+#: src/muuli_wdr.cpp:3251
 msgid "Statistics and queued clients for selected file(s) : Session / All time"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3271
+#: src/muuli_wdr.cpp:3275
 msgid "Active Uploads"
 msgstr "Aktive Uploads"
 
-#: src/muuli_wdr.cpp:3285
+#: src/muuli_wdr.cpp:3289
 #, fuzzy
 msgid "Percent of total files"
 msgstr "Antal Filer Total"
 
-#: src/muuli_wdr.cpp:3337
+#: src/muuli_wdr.cpp:3341
 #, fuzzy
 msgid "Show Clients for"
 msgstr "Vis Liste"
 
-#: src/muuli_wdr.cpp:3339
+#: src/muuli_wdr.cpp:3343
 #, fuzzy
 msgid "All files"
 msgstr "Delte Filer"
 
-#: src/muuli_wdr.cpp:3342
+#: src/muuli_wdr.cpp:3346
 #, fuzzy
 msgid "Selected files"
 msgstr "Slettede Servere"
 
-#: src/muuli_wdr.cpp:3345
+#: src/muuli_wdr.cpp:3349
 #, fuzzy
 msgid "Active uploads only"
 msgstr "Aktive Uploads"
 
-#: src/muuli_wdr.cpp:3352
+#: src/muuli_wdr.cpp:3356
 #, fuzzy
 msgid "Reload:"
 msgstr "Opdater"
 
-#: src/muuli_wdr.cpp:3356
+#: src/muuli_wdr.cpp:3360
 msgid "Reload your shared files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3419
+#: src/muuli_wdr.cpp:3423
 msgid "Send"
 msgstr "Send"
 
-#: src/muuli_wdr.cpp:3420
+#: src/muuli_wdr.cpp:3424
 msgid "Sends the specified message."
 msgstr ""
 
-#: src/muuli_wdr.cpp:3424
+#: src/muuli_wdr.cpp:3428
 msgid "Close this chat-session."
 msgstr ""
 
-#: src/muuli_wdr.cpp:3447
+#: src/muuli_wdr.cpp:3451
 msgid "Connect to any server and/or Kad"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3453 src/SharedFilesCtrl.cpp:142 src/Statistics.cpp:941
+#: src/muuli_wdr.cpp:3457 src/SharedFilesCtrl.cpp:142 src/Statistics.cpp:941
 msgid "Shared Files"
 msgstr "Delte Filer"
 
@@ -5701,261 +5701,261 @@ msgid ""
 "these settings."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:647
+#: src/PrefsUnifiedDlg.cpp:656
 #, c-format
 msgid "Failed to connect Cfg to widget with the ID %d and key %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:695
+#: src/PrefsUnifiedDlg.cpp:704
 #, c-format
 msgid "Failed to transfer data from Cfg to Widget with the ID %d and key %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:801
+#: src/PrefsUnifiedDlg.cpp:810
 msgid "The type of proxy you are connecting to"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1020
+#: src/PrefsUnifiedDlg.cpp:1029
 #, c-format
 msgid "Failed to transfer data from Widget to Cfg with the ID %d and key %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1103
+#: src/PrefsUnifiedDlg.cpp:1112
 #, fuzzy
 msgid "No password set."
 msgstr "Undersøger password\n"
 
-#: src/PrefsUnifiedDlg.cpp:1132
+#: src/PrefsUnifiedDlg.cpp:1141
 msgid "Guest access needs a password. Type one in the guest password field, or untick Enable guest access."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1144
+#: src/PrefsUnifiedDlg.cpp:1153
 msgid ""
 "aMule must be restarted to enable these changes:\n"
 "\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1151
+#: src/PrefsUnifiedDlg.cpp:1160
 msgid "- TCP port changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1156
+#: src/PrefsUnifiedDlg.cpp:1165
 msgid "- UDP port changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1161
+#: src/PrefsUnifiedDlg.cpp:1170
 #, fuzzy
 msgid "- Network interface binding changed.\n"
 msgstr "Ydre Forbindelses Parametre"
 
-#: src/PrefsUnifiedDlg.cpp:1166
+#: src/PrefsUnifiedDlg.cpp:1175
 #, fuzzy
 msgid "- External connect port changed.\n"
 msgstr "Ydre Forbindelses Parametre"
 
-#: src/PrefsUnifiedDlg.cpp:1170
+#: src/PrefsUnifiedDlg.cpp:1179
 #, fuzzy
 msgid "- External connect acceptance changed.\n"
 msgstr "Ydre Forbindelses Parametre"
 
-#: src/PrefsUnifiedDlg.cpp:1174
+#: src/PrefsUnifiedDlg.cpp:1183
 #, fuzzy
 msgid "- External connect interface changed.\n"
 msgstr "Ydre Forbindelses Parametre"
 
-#: src/PrefsUnifiedDlg.cpp:1178
+#: src/PrefsUnifiedDlg.cpp:1187
 #, fuzzy
 msgid "- Protocol obfuscation support changed.\n"
 msgstr "Ydre Forbindelses Parametre"
 
-#: src/PrefsUnifiedDlg.cpp:1193
+#: src/PrefsUnifiedDlg.cpp:1202
 msgid "- amuleapi settings changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1202
+#: src/PrefsUnifiedDlg.cpp:1211
 msgid ""
 "Your Auto-update server list is empty.\n"
 "'Auto-update server list at startup' will be disabled."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1213
+#: src/PrefsUnifiedDlg.cpp:1222
 msgid ""
 "You have enabled external connections but have not specified a password.\n"
 "External connections cannot be enabled unless a valid password is specified."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1246
+#: src/PrefsUnifiedDlg.cpp:1255
 #, c-format
 msgid "The amuleapi password could not be saved: %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1276
+#: src/PrefsUnifiedDlg.cpp:1285
 msgid "- Language changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1281
+#: src/PrefsUnifiedDlg.cpp:1290
 msgid "- Temp folder changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1286
+#: src/PrefsUnifiedDlg.cpp:1295
 msgid "- ED2K network enabled.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1319
+#: src/PrefsUnifiedDlg.cpp:1328
 msgid "The shared-file exclusion pattern is not a valid regular expression. The filter has been left disabled."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1321 src/PrefsUnifiedDlg.cpp:1921
+#: src/PrefsUnifiedDlg.cpp:1330 src/PrefsUnifiedDlg.cpp:1930
 msgid "Invalid regular expression"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1398
+#: src/PrefsUnifiedDlg.cpp:1407
 msgid ""
 "Both eD2k and Kad network are disabled.\n"
 "You won't be able to connect until you enable at least one of them."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1403
+#: src/PrefsUnifiedDlg.cpp:1412
 msgid ""
 "Kad will not start if your UDP port is disabled.\n"
 "Enable UDP port or disable Kad."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1459
+#: src/PrefsUnifiedDlg.cpp:1468
 msgid ""
 "\n"
 "You MUST restart aMule now.\n"
 "If you do not restart now, don't complain if anything bad happens.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1524
+#: src/PrefsUnifiedDlg.cpp:1533
 msgid "Could not register aMule for autostart at login. The autostart store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1526
+#: src/PrefsUnifiedDlg.cpp:1535
 msgid "Could not remove the autostart-at-login entry."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1527
+#: src/PrefsUnifiedDlg.cpp:1536
 #, fuzzy
 msgid "Autostart"
 msgstr "Auto Opdatering startet"
 
-#: src/PrefsUnifiedDlg.cpp:1542
+#: src/PrefsUnifiedDlg.cpp:1551
 msgid "Register file type"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1542
+#: src/PrefsUnifiedDlg.cpp:1551
 msgid "Register URL handler"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1550
+#: src/PrefsUnifiedDlg.cpp:1559
 #, c-format
 msgid "aMule only handles eD2k-compatible magnets. If you replace the current magnet handler (%s), BitTorrent magnet links will stop working - aMule cannot download BitTorrent content. Continue?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1555
+#: src/PrefsUnifiedDlg.cpp:1564
 #, c-format
 msgid "Another application currently opens .emulecollection files (%s). Replace it with aMule?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1560
+#: src/PrefsUnifiedDlg.cpp:1569
 #, c-format
 msgid "Another application is currently the default handler for these links (%s). Replace it with aMule?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1585
+#: src/PrefsUnifiedDlg.cpp:1594
 msgid "Could not register aMule for .emulecollection files. The registration store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1587
+#: src/PrefsUnifiedDlg.cpp:1596
 #, fuzzy
 msgid "Could not remove the file type registration."
 msgstr "Du prøver allerede at downloade denne fil %s"
 
-#: src/PrefsUnifiedDlg.cpp:1589
+#: src/PrefsUnifiedDlg.cpp:1598
 msgid "Could not register aMule as the URL handler. The registration store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1591
+#: src/PrefsUnifiedDlg.cpp:1600
 msgid "Could not remove the URL handler registration."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1661 src/PrefsUnifiedDlg.cpp:1688
+#: src/PrefsUnifiedDlg.cpp:1670 src/PrefsUnifiedDlg.cpp:1697
 #, fuzzy
 msgid "The web server and aMule API require external connections to be enabled."
 msgstr "Accepter ydre forbindelser"
 
-#: src/PrefsUnifiedDlg.cpp:1671
+#: src/PrefsUnifiedDlg.cpp:1680
 msgid "The aMule web server is deprecated. Consider running the aMule API instead."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1735
+#: src/PrefsUnifiedDlg.cpp:1744
 msgid ""
 "Your Auto-update servers list is in blank.\n"
 "Please fill in at least one URL to point to a valid server.met file.\n"
 "Click on the button \"List\" by this checkbox to enter an URL."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1876
+#: src/PrefsUnifiedDlg.cpp:1885
 msgid "Temporary files"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1881
+#: src/PrefsUnifiedDlg.cpp:1890
 msgid "Incoming files"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1886
+#: src/PrefsUnifiedDlg.cpp:1895
 msgid "Online Signatures"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1899
+#: src/PrefsUnifiedDlg.cpp:1908
 #, c-format
 msgid "Choose a folder for %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1923
+#: src/PrefsUnifiedDlg.cpp:1932
 #, fuzzy, c-format
 msgid "Would exclude %u of %u shared file"
 msgid_plural "Would exclude %u of %u shared files"
 msgstr[0] "Fandt %i kendte delte filer"
 msgstr[1] "Fandt %i kendte delte filer"
 
-#: src/PrefsUnifiedDlg.cpp:1940
+#: src/PrefsUnifiedDlg.cpp:1949
 msgid "Browse for videoplayer"
 msgstr "Gennemse efter Video Afspiller"
 
-#: src/PrefsUnifiedDlg.cpp:1944
+#: src/PrefsUnifiedDlg.cpp:1953
 msgid "Select browser"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1948
+#: src/PrefsUnifiedDlg.cpp:1957
 msgid "Select ffprobe binary"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1954
+#: src/PrefsUnifiedDlg.cpp:1963
 #, c-format
 msgid "Executable%s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1988
+#: src/PrefsUnifiedDlg.cpp:1997
 msgid "ffprobe not found on PATH or in the standard install locations. Install ffmpeg (which ships ffprobe) or use Browse to pick a binary manually."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2000
+#: src/PrefsUnifiedDlg.cpp:2009
 msgid "Reset the settings on this page to their default values?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2001
+#: src/PrefsUnifiedDlg.cpp:2010
 #, fuzzy
 msgid "Reset to defaults"
 msgstr "System standard"
 
-#: src/PrefsUnifiedDlg.cpp:2028
+#: src/PrefsUnifiedDlg.cpp:2037
 msgid "Edit server list"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2029
+#: src/PrefsUnifiedDlg.cpp:2038
 msgid ""
 "Add here URL's to download server.met files.\n"
 "Only one url on each line."
@@ -5963,153 +5963,153 @@ msgstr ""
 "Tilføj URLer hvor der kan hentes server.met filer.\n"
 "Kun en URL på hver linje."
 
-#: src/PrefsUnifiedDlg.cpp:2084
+#: src/PrefsUnifiedDlg.cpp:2093
 msgid "IP2Country update failed"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2229 src/PrefsUnifiedDlg.cpp:2260
+#: src/PrefsUnifiedDlg.cpp:2238 src/PrefsUnifiedDlg.cpp:2269
 msgid "Data by MaxMind GeoLite2"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2231 src/PrefsUnifiedDlg.cpp:2262
+#: src/PrefsUnifiedDlg.cpp:2240 src/PrefsUnifiedDlg.cpp:2271
 #, fuzzy
 msgid "Custom source"
 msgstr "Hele kilder"
 
-#: src/PrefsUnifiedDlg.cpp:2233 src/PrefsUnifiedDlg.cpp:2264
+#: src/PrefsUnifiedDlg.cpp:2242 src/PrefsUnifiedDlg.cpp:2273
 msgid "Data by DB-IP.com"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2284
+#: src/PrefsUnifiedDlg.cpp:2293
 #, c-format
 msgid "Status: Loaded%s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2286
+#: src/PrefsUnifiedDlg.cpp:2295
 #, c-format
 msgid "Status: Loaded%s - %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2290
+#: src/PrefsUnifiedDlg.cpp:2299
 msgid "Status: Failed to load - click 'Update now' to refresh."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2292
+#: src/PrefsUnifiedDlg.cpp:2301
 msgid "Status: Not found - click 'Update now' to download."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2350 src/PrefsUnifiedDlg.cpp:2374
+#: src/PrefsUnifiedDlg.cpp:2359 src/PrefsUnifiedDlg.cpp:2383
 #, fuzzy, c-format
 msgid "Update delay: %d second"
 msgid_plural "Update delay: %d seconds"
 msgstr[0] "Opdaterings interval : 5 sek"
 msgstr[1] "Opdaterings interval : 5 sek"
 
-#: src/PrefsUnifiedDlg.cpp:2358
+#: src/PrefsUnifiedDlg.cpp:2367
 #, fuzzy, c-format
 msgid "Time for average graph: %d minute"
 msgid_plural "Time for average graph: %d minutes"
 msgstr[0] "Tid for gennemsnitlig graf: 100 min"
 msgstr[1] "Tid for gennemsnitlig graf: 100 min"
 
-#: src/PrefsUnifiedDlg.cpp:2367
+#: src/PrefsUnifiedDlg.cpp:2376
 #, c-format
 msgid "Connections Graph Scale: %d"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2382
+#: src/PrefsUnifiedDlg.cpp:2391
 #, fuzzy, c-format
 msgid "File Buffer Size: %d byte"
 msgid_plural "File Buffer Size: %d bytes"
 msgstr[0] "Fil Buffer StÃžrrelse %i bytes"
 msgstr[1] "Fil Buffer StÃžrrelse %i bytes"
 
-#: src/PrefsUnifiedDlg.cpp:2392
+#: src/PrefsUnifiedDlg.cpp:2401
 #, c-format
 msgid "Upload Queue Size: %d client"
 msgid_plural "Upload Queue Size: %d clients"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/PrefsUnifiedDlg.cpp:2402
+#: src/PrefsUnifiedDlg.cpp:2411
 #, fuzzy, c-format
 msgid "Server connection refresh interval: %d minute"
 msgid_plural "Server connection refresh interval: %d minutes"
 msgstr[0] "Server forbindelses opdaterings interval %i min"
 msgstr[1] "Server forbindelses opdaterings interval %i min"
 
-#: src/PrefsUnifiedDlg.cpp:2407
+#: src/PrefsUnifiedDlg.cpp:2416
 msgid "Server connection refresh interval: Disabled"
 msgstr "Server forbindelses opdaterings interval: Inaktiv"
 
-#: src/PrefsUnifiedDlg.cpp:2451
+#: src/PrefsUnifiedDlg.cpp:2460
 #, fuzzy
 msgid "disabled"
 msgstr "deaktiver"
 
-#: src/PrefsUnifiedDlg.cpp:2477
+#: src/PrefsUnifiedDlg.cpp:2486
 #, c-format
 msgid "Execute command on '%s' event"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2484
+#: src/PrefsUnifiedDlg.cpp:2493
 msgid "Enable command execution on core"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2496
+#: src/PrefsUnifiedDlg.cpp:2505
 msgid "Core command:"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2512
+#: src/PrefsUnifiedDlg.cpp:2521
 msgid "Enable command execution on GUI"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2524
+#: src/PrefsUnifiedDlg.cpp:2533
 msgid "GUI command:"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2540
+#: src/PrefsUnifiedDlg.cpp:2549
 msgid "The following variables will be replaced:"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2708
+#: src/PrefsUnifiedDlg.cpp:2717
 msgid ""
 "The following folders look like system or sensitive locations:\n"
 "\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2713
+#: src/PrefsUnifiedDlg.cpp:2722
 msgid "Sharing them recursively will publish every file underneath on the eD2k/Kad networks. Do you really want to do this?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2716
+#: src/PrefsUnifiedDlg.cpp:2725
 msgid "Confirm shared folders"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2744
+#: src/PrefsUnifiedDlg.cpp:2753
 #, fuzzy
 msgid "Reloading shared files..."
 msgstr "Fandt %i kendte delte filer"
 
-#: src/PrefsUnifiedDlg.cpp:2745
+#: src/PrefsUnifiedDlg.cpp:2754
 msgid "Scanning for subdirectories..."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2746
+#: src/PrefsUnifiedDlg.cpp:2755
 msgid "Updating shared folders"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2773
+#: src/PrefsUnifiedDlg.cpp:2782
 #, c-format
 msgid "Scanned %u directories..."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2823
+#: src/PrefsUnifiedDlg.cpp:2832
 #, c-format
 msgid "Reloading shared files: %u files scanned"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2873
+#: src/PrefsUnifiedDlg.cpp:2882
 #, fuzzy
 msgid "Shared folder"
 msgstr "Delte Filer"
@@ -7770,12 +7770,12 @@ msgstr "Fjern kategori"
 msgid "Hashset requested for unknown file: %s"
 msgstr ""
 
-#: src/UploadQueue.cpp:618
+#: src/UploadQueue.cpp:627
 #, c-format
 msgid "Resuming uploads of file: %s"
 msgstr "Genoptager uploads af fil: %s"
 
-#: src/UploadQueue.cpp:634
+#: src/UploadQueue.cpp:643
 #, fuzzy, c-format
 msgid "Suspending upload of file: %s"
 msgstr "Suspender upload af fil: %s"

--- a/po/da.po
+++ b/po/da.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-28 10:19+0200\n"
+"POT-Creation-Date: 2026-07-28 12:17+0200\n"
 "PO-Revision-Date: 2026-07-27 11:34+0000\n"
 "Last-Translator: Alex Thomsen Leth <alexl@stofanet.dk>\n"
 "Language-Team: aMule Team <https://github.com/amule-org/amule>\n"
@@ -194,155 +194,155 @@ msgstr "Kunne ikke åbne %s (%s)"
 msgid "WARNING: You can't add yourself as a source for an eD2k link while having a lowid."
 msgstr ""
 
-#: src/amule.cpp:300
+#: src/amule.cpp:301
 msgid "Now, exiting main app..."
 msgstr ""
 
-#: src/amule.cpp:330
+#: src/amule.cpp:331
 #, c-format
 msgid "Terminating amuleweb instance with pid '%d' ... "
 msgstr ""
 
-#: src/amule.cpp:334
+#: src/amule.cpp:335
 #, c-format
 msgid "Killing amuleweb instance with pid '%d' ... "
 msgstr ""
 
-#: src/amule.cpp:336 src/amule.cpp:349 src/ClientRef.cpp:180
+#: src/amule.cpp:337 src/amule.cpp:350 src/ClientRef.cpp:180
 #: src/SearchDlg.cpp:1041 src/ServerListCtrl.cpp:98
 msgid "Failed"
 msgstr "Fejlede"
 
-#: src/amule.cpp:343
+#: src/amule.cpp:344
 #, c-format
 msgid "Terminating amuleapi instance with pid '%d' ... "
 msgstr ""
 
-#: src/amule.cpp:347
+#: src/amule.cpp:348
 #, c-format
 msgid "Killing amuleapi instance with pid '%d' ... "
 msgstr ""
 
-#: src/amule.cpp:355
+#: src/amule.cpp:356
 msgid "aMule OnExit: Terminating core."
 msgstr ""
 
-#: src/amule.cpp:466
+#: src/amule.cpp:467
 msgid "aMule shutdown completed."
 msgstr ""
 
-#: src/amule.cpp:470
+#: src/amule.cpp:471
 msgid "Memory debug results for aMule exit:"
 msgstr ""
 
-#: src/amule.cpp:651
+#: src/amule.cpp:652
 #, c-format
 msgid "Binding aMule's peer-to-peer traffic to interface: %s (HTTP updates use the default route)"
 msgstr ""
 
-#: src/amule.cpp:655
+#: src/amule.cpp:656
 #, c-format
 msgid "Binding all network traffic to interface: %s"
 msgstr ""
 
-#: src/amule.cpp:659
+#: src/amule.cpp:660
 #, c-format
 msgid "WARNING: configured network interface '%s' was not found - traffic is NOT bound to it and may leave via the default route. Check the interface name in Preferences."
 msgstr ""
 
-#: src/amule.cpp:665
+#: src/amule.cpp:666
 #, c-format
 msgid "WARNING: binding to network interface '%s' requires elevated privileges and was NOT applied - traffic may leave via the default route. Grant the capability (e.g. 'sudo setcap cap_net_raw+ep' on the aMule binary) or run with sufficient privileges."
 msgstr ""
 
-#: src/amule.cpp:673
+#: src/amule.cpp:674
 #, c-format
 msgid "WARNING: could not bind to network interface '%s' - traffic may leave via the default route."
 msgstr ""
 
-#: src/amule.cpp:732
+#: src/amule.cpp:733
 msgid "Your locale has been changed to System Default due to a configuration change. Sorry."
 msgstr ""
 
-#: src/amule.cpp:734 src/amule.cpp:1581 src/CatDialog.cpp:128
+#: src/amule.cpp:735 src/amule.cpp:1589 src/CatDialog.cpp:128
 #: src/CatDialog.cpp:136 src/CatDialog.cpp:149 src/ServerList.cpp:366
 #: src/ServerListCtrl.cpp:152
 msgid "Info"
 msgstr "Info"
 
-#: src/amule.cpp:741
+#: src/amule.cpp:742
 #, fuzzy
 msgid ""
 "\n"
 "EC configuration"
 msgstr "Bekræft afslut"
 
-#: src/amule.cpp:744
+#: src/amule.cpp:745
 #, fuzzy
 msgid "Password set and external connections enabled."
 msgstr "Accepter ydre forbindelser"
 
-#: src/amule.cpp:754 src/KadDlg.cpp:176 src/KadDlg.cpp:185
-#: src/PrefsUnifiedDlg.cpp:1387 src/SharedFilesCtrl.cpp:476
+#: src/amule.cpp:755 src/KadDlg.cpp:176 src/KadDlg.cpp:185
+#: src/PrefsUnifiedDlg.cpp:1461 src/SharedFilesCtrl.cpp:476
 msgid "WARNING"
 msgstr ""
 
-#: src/amule.cpp:991
+#: src/amule.cpp:992
 msgid "Network bootstrap"
 msgstr ""
 
-#: src/amule.cpp:996
+#: src/amule.cpp:997
 msgid ""
 "aMule has detected missing network bootstrap files.\n"
 "Select which ones to download:"
 msgstr ""
 
-#: src/amule.cpp:1005 src/FirstRunWizard.cpp:411
+#: src/amule.cpp:1006 src/FirstRunWizard.cpp:411
 #, fuzzy
 msgid "eD2k server list (server.met)"
 msgstr "%i Serverer fundet i server.met"
 
-#: src/amule.cpp:1012 src/FirstRunWizard.cpp:416
+#: src/amule.cpp:1013 src/FirstRunWizard.cpp:416
 msgid "Kad bootstrap nodes (nodes.dat)"
 msgstr ""
 
-#: src/amule.cpp:1102
+#: src/amule.cpp:1103
 #, c-format
 msgid "web server running on pid %d"
 msgstr ""
 
-#: src/amule.cpp:1115
+#: src/amule.cpp:1116
 msgid "You requested to run web server on startup, but the amuleweb binary cannot be run. Please install the package containing aMule web server, or build aMule from source with -DBUILD_WEBSERVER=YES and install it."
 msgstr ""
 
-#: src/amule.cpp:1120 src/amule.cpp:1177 src/amule.cpp:1291 src/amule.cpp:1593
+#: src/amule.cpp:1121 src/amule.cpp:1185 src/amule.cpp:1299 src/amule.cpp:1601
 #: src/amule-remote-gui.cpp:603 src/amule-remote-gui.cpp:671
 #: src/amule-remote-gui.cpp:709 src/amule-remote-gui.cpp:1282
 #: src/amule-remote-gui.cpp:1345 src/amule-remote-gui.cpp:1372
-#: src/DownloadQueue.cpp:1481
+#: src/DownloadQueue.cpp:1481 src/PrefsUnifiedDlg.cpp:1247
 msgid "ERROR"
 msgstr ""
 
-#: src/amule.cpp:1166
+#: src/amule.cpp:1174
 #, fuzzy, c-format
 msgid "amuleapi running on pid %d"
 msgstr "aMule kører"
 
-#: src/amule.cpp:1172
+#: src/amule.cpp:1180
 msgid "You requested to run amuleapi on startup, but the amuleapi binary cannot be run. Please install the package containing aMule's REST API server, or build aMule from source with -DBUILD_AMULEAPI=YES and install it."
 msgstr ""
 
-#: src/amule.cpp:1259
+#: src/amule.cpp:1267
 #, c-format
 msgid "Could not bind ports to the specified address: %s"
 msgstr ""
 
-#: src/amule.cpp:1283
+#: src/amule.cpp:1291
 #, c-format
 msgid "Port %u is not available. You will be LOWID\n"
 msgstr ""
 
-#: src/amule.cpp:1288
+#: src/amule.cpp:1296
 #, c-format
 msgid ""
 "Port %u is not available!\n"
@@ -352,185 +352,185 @@ msgid ""
 "Check your network to make sure the port is open for output and input."
 msgstr ""
 
-#: src/amule.cpp:1385
+#: src/amule.cpp:1393
 msgid "Failed to create OnlineSig File"
 msgstr ""
 
-#: src/amule.cpp:1393
+#: src/amule.cpp:1401
 msgid "Failed to create aMule OnlineSig File"
 msgstr ""
 
-#: src/amule.cpp:1556
+#: src/amule.cpp:1564
 msgid "The selected locale seems not to be installed on your box. (Note: I'll try to set it anyway)"
 msgstr ""
 
-#: src/amule.cpp:1566
+#: src/amule.cpp:1574
 #, c-format
 msgid "This is the first time you run aMule %s"
 msgstr ""
 
-#: src/amule.cpp:1569
+#: src/amule.cpp:1577
 msgid "This version is a testing version, updated daily, and\n"
 msgstr ""
 
-#: src/amule.cpp:1570
+#: src/amule.cpp:1578
 msgid "we give no warranty it won't break anything, burn your house,\n"
 msgstr "Vi giver ikke garanti for at det ikke vil ødelægge noget, brænde dit hus,\n"
 
-#: src/amule.cpp:1571
+#: src/amule.cpp:1579
 msgid "or kill your dog. But it *should* be safe to use anyway.\n"
 msgstr ""
 
-#: src/amule.cpp:1576
+#: src/amule.cpp:1584
 msgid "More information, support and new releases can found at our homepage,\n"
 msgstr ""
 
-#: src/amule.cpp:1577
+#: src/amule.cpp:1585
 msgid "at https://amule-org.github.io, or in our IRC channel #aMule at irc.libera.chat.\n"
 msgstr ""
 
-#: src/amule.cpp:1579
+#: src/amule.cpp:1587
 msgid "Feel free to report any bugs to https://github.com/amule-org/amule/issues"
 msgstr ""
 
-#: src/amule.cpp:1591
+#: src/amule.cpp:1599
 msgid ""
 "The folder for Online Signature files you specified is INVALID!\n"
 " OnlineSignature will be DISABLED until you fix it on preferences."
 msgstr ""
 
-#: src/amule.cpp:1654
+#: src/amule.cpp:1662
 #, fuzzy
 msgid "Server hostname notified"
 msgstr "Servernavn :"
 
-#: src/amule.cpp:2031
+#: src/amule.cpp:2039
 #, c-format
 msgid "Disk space preallocation for file '%s' failed: %s"
 msgstr ""
 
-#: src/amule.cpp:2160
+#: src/amule.cpp:2168
 msgid "ERROR: can't open logfile"
 msgstr "FEJL: Kan ikke åbne logfil"
 
-#: src/amule.cpp:2164
+#: src/amule.cpp:2172
 msgid "WARNING: logfile is empty. Something is wrong."
 msgstr "FARE: logfilen er tom. Noget er galt"
 
-#: src/amule.cpp:2181
+#: src/amule.cpp:2189
 msgid "Log has been reset"
 msgstr "Log nulstillet"
 
-#: src/amule.cpp:2205
+#: src/amule.cpp:2213
 #, c-format
 msgid "ServerMessage: %s"
 msgstr "ServerBesked: %s"
 
-#: src/amule.cpp:2248 src/IP2Country.cpp:220 src/IPFilter.cpp:514
+#: src/amule.cpp:2256 src/IP2Country.cpp:220 src/IPFilter.cpp:514
 #: src/ServerList.cpp:875
 #, c-format
 msgid "Skipped download of %s, because requested file is not newer."
 msgstr ""
 
-#: src/amule.cpp:2251
+#: src/amule.cpp:2259
 msgid "Failed to download the nodes list."
 msgstr "Fejl ved hentning af node listen"
 
-#: src/amule.cpp:2314
+#: src/amule.cpp:2322
 msgid "Failed to open the downloaded version check file"
 msgstr "Fejl ved åbning af den hentet version check filen"
 
-#: src/amule.cpp:2317 src/amule.cpp:2336
+#: src/amule.cpp:2325 src/amule.cpp:2344
 msgid "Corrupted version check file"
 msgstr "Korrupt version check fil"
 
-#: src/amule.cpp:2359
+#: src/amule.cpp:2367
 msgid "You are using an outdated version of aMule!"
 msgstr "Du bruger en forældet version af aMule"
 
-#: src/amule.cpp:2361
+#: src/amule.cpp:2369
 #, c-format
 msgid "Your aMule version is %i.%i.%i and the latest version is %li.%li.%li"
 msgstr "Din aMule version er %i.%i.%i og den sisdte nye version er %li.%li.%li"
 
-#: src/amule.cpp:2365
+#: src/amule.cpp:2373
 msgid "The latest version can always be found at https://github.com/amule-org/amule/releases/latest"
 msgstr "Den sidste nye version kan altid findes hos https://github.com/amule-org/amule/releases/latest"
 
-#: src/amule.cpp:2368
+#: src/amule.cpp:2376
 #, c-format
 msgid "WARNING: Your aMuled version is outdated: %i.%i.%i < %li.%li.%li"
 msgstr "FARE: Din aMule version er forældet: %i.%i.%i < %li.%li.%li"
 
-#: src/amule.cpp:2374
+#: src/amule.cpp:2382
 msgid "Your copy of aMule is up to date."
 msgstr "Din kopi af aMule er op til dato"
 
-#: src/amule.cpp:2381
+#: src/amule.cpp:2389
 msgid "Failed to download the version check file"
 msgstr "Fejl ved hentning af version check filen"
 
-#: src/amule.cpp:2550 src/amule-remote-gui.cpp:1133
+#: src/amule.cpp:2558 src/amule-remote-gui.cpp:1133
 #, c-format
 msgid "Users: %s | Files: %s"
 msgstr ""
 
-#: src/amule.cpp:2551 src/amule-remote-gui.cpp:1134
+#: src/amule.cpp:2559 src/amule-remote-gui.cpp:1134
 #, c-format
 msgid "Users: E: %s K: %s | Files: E: %s K: %s"
 msgstr ""
 
-#: src/amule.cpp:2565 src/amule-remote-gui.cpp:1147
+#: src/amule.cpp:2573 src/amule-remote-gui.cpp:1147
 msgid "No networks selected"
 msgstr ""
 
-#: src/amule.cpp:2633 src/TextClient.cpp:903
+#: src/amule.cpp:2641 src/TextClient.cpp:903
 msgid "with LowID"
 msgstr ""
 
-#: src/amule.cpp:2633 src/TextClient.cpp:904
+#: src/amule.cpp:2641 src/TextClient.cpp:904
 msgid "with HighID"
 msgstr ""
 
-#: src/amule.cpp:2635
+#: src/amule.cpp:2643
 #, c-format
 msgid "Connected to %s %s"
 msgstr "Forbundet til %s %s"
 
-#: src/amule.cpp:2640
+#: src/amule.cpp:2648
 #, c-format
 msgid "Connecting to %s"
 msgstr "Forbundet til %s"
 
-#: src/amule.cpp:2642
+#: src/amule.cpp:2650
 msgid "Disconnected from eD2k"
 msgstr ""
 
-#: src/amule.cpp:2651
+#: src/amule.cpp:2659
 msgid "Kad started."
 msgstr "Kad startet."
 
-#: src/amule.cpp:2653
+#: src/amule.cpp:2661
 msgid "Kad stopped."
 msgstr "Kad stoppet."
 
-#: src/amule.cpp:2661
+#: src/amule.cpp:2669
 msgid "Connected to Kad (ok)"
 msgstr "Forbundet til Kad (ok)"
 
-#: src/amule.cpp:2663
+#: src/amule.cpp:2671
 msgid "Connected to Kad (firewalled)"
 msgstr "Forbundet til Kad (med firewall)"
 
-#: src/amule.cpp:2667
+#: src/amule.cpp:2675
 msgid "Disconnected from Kad"
 msgstr "Afbrudt fra Kad"
 
-#: src/amule.cpp:2699
+#: src/amule.cpp:2707
 msgid "Kad network cannot be used if UDP port is disabled on preferences, not starting."
 msgstr "Kad netværk kan ikke bruges hvis UDP port er fravalgt i instillinger, starter ikke."
 
-#: src/amule.cpp:2703
+#: src/amule.cpp:2711
 msgid "Kad network disabled on preferences, not connecting."
 msgstr "Kad netværk fravalgt i instillinger, forbinder ikke."
 
@@ -574,36 +574,36 @@ msgid "FATAL ERROR: Failed to create Timer"
 msgstr ""
 
 #: src/amuleDlg.cpp:361 src/amuleDlg.cpp:1787 src/amuleDlg.cpp:2033
-#: src/muuli_wdr.cpp:1492 src/muuli_wdr.cpp:3418
+#: src/muuli_wdr.cpp:1492 src/muuli_wdr.cpp:3449
 msgid "Networks"
 msgstr ""
 
-#: src/amuleDlg.cpp:362 src/amuleDlg.cpp:1793 src/muuli_wdr.cpp:3419
+#: src/amuleDlg.cpp:362 src/amuleDlg.cpp:1793 src/muuli_wdr.cpp:3450
 msgid "Searches"
 msgstr "Søg"
 
 #: src/amuleDlg.cpp:363 src/amuleDlg.cpp:1799 src/DownloadListCtrl.cpp:740
-#: src/muuli_wdr.cpp:392 src/muuli_wdr.cpp:1585 src/muuli_wdr.cpp:3420
+#: src/muuli_wdr.cpp:392 src/muuli_wdr.cpp:1585 src/muuli_wdr.cpp:3451
 #: src/Statistics.cpp:829
 msgid "Downloads"
 msgstr "Downloads"
 
-#: src/amuleDlg.cpp:364 src/amuleDlg.cpp:1805 src/muuli_wdr.cpp:3294
+#: src/amuleDlg.cpp:364 src/amuleDlg.cpp:1805 src/muuli_wdr.cpp:3325
 msgid "Shared files"
 msgstr ""
 
-#: src/amuleDlg.cpp:365 src/amuleDlg.cpp:1811 src/muuli_wdr.cpp:2926
-#: src/muuli_wdr.cpp:3376 src/muuli_wdr.cpp:3423
+#: src/amuleDlg.cpp:365 src/amuleDlg.cpp:1811 src/muuli_wdr.cpp:2957
+#: src/muuli_wdr.cpp:3407 src/muuli_wdr.cpp:3454
 msgid "Messages"
 msgstr "Beskeder"
 
-#: src/amuleDlg.cpp:366 src/amuleDlg.cpp:1817 src/muuli_wdr.cpp:3424
-#: src/PrefsUnifiedDlg.cpp:312 src/Statistics.cpp:779 src/Statistics.cpp:1235
+#: src/amuleDlg.cpp:366 src/amuleDlg.cpp:1817 src/muuli_wdr.cpp:3455
+#: src/PrefsUnifiedDlg.cpp:314 src/Statistics.cpp:779 src/Statistics.cpp:1235
 msgid "Statistics"
 msgstr "Statistik"
 
-#: src/amuleDlg.cpp:368 src/amuleDlg.cpp:1824 src/muuli_wdr.cpp:3426
-#: src/PrefsUnifiedDlg.cpp:328 src/utils/wxCas/src/wxcasprefs.cpp:39
+#: src/amuleDlg.cpp:368 src/amuleDlg.cpp:1824 src/muuli_wdr.cpp:3457
+#: src/PrefsUnifiedDlg.cpp:330 src/utils/wxCas/src/wxcasprefs.cpp:39
 msgid "Preferences"
 msgstr "Indstillinger"
 
@@ -665,8 +665,8 @@ msgstr " Kad: "
 #: src/amuleDlg.cpp:1029 src/DownloadListCtrl.cpp:505
 #: src/DownloadListCtrl.cpp:749 src/FriendListCtrl.cpp:180
 #: src/muuli_wdr.cpp:731 src/muuli_wdr.cpp:782 src/muuli_wdr.cpp:846
-#: src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2231 src/muuli_wdr.cpp:2316
-#: src/muuli_wdr.cpp:3064 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
+#: src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2262 src/muuli_wdr.cpp:2347
+#: src/muuli_wdr.cpp:3095 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
 #: src/ServerListCtrl.cpp:606 src/TransferWnd.cpp:378
 #: src/utils/wxCas/src/wxcasprefs.cpp:235
 msgid "Cancel"
@@ -678,7 +678,7 @@ msgid "Stop the current connection attempts"
 msgstr "Stop de nuværende forbindelses forsøg"
 
 #: src/amuleDlg.cpp:1035 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976
-#: src/muuli_wdr.cpp:2454
+#: src/muuli_wdr.cpp:2485
 msgid "Disconnect"
 msgstr "Afbryd"
 
@@ -688,7 +688,7 @@ msgid "Disconnect from the currently connected networks"
 msgstr "Afbryd fra nuvÃŠrende server"
 
 #: src/amuleDlg.cpp:1041 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979
-#: src/muuli_wdr.cpp:2609 src/muuli_wdr.cpp:3061 src/muuli_wdr.cpp:3416
+#: src/muuli_wdr.cpp:2640 src/muuli_wdr.cpp:3092 src/muuli_wdr.cpp:3447
 msgid "Connect"
 msgstr "Forbind"
 
@@ -742,7 +742,7 @@ msgstr "Bekræft afslut"
 msgid "Launch Command: "
 msgstr ""
 
-#: src/amuleDlg.cpp:1632 src/muuli_wdr.cpp:1978 src/Preferences.cpp:952
+#: src/amuleDlg.cpp:1632 src/muuli_wdr.cpp:1982 src/Preferences.cpp:979
 msgid "- default -"
 msgstr ""
 
@@ -756,49 +756,49 @@ msgstr ""
 msgid "WARNING: Unable to open skin file '%s' for read"
 msgstr ""
 
-#: src/amuleDlg.cpp:1791 src/muuli_wdr.cpp:3418
+#: src/amuleDlg.cpp:1791 src/muuli_wdr.cpp:3449
 msgid "Networks Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1797 src/muuli_wdr.cpp:3419
+#: src/amuleDlg.cpp:1797 src/muuli_wdr.cpp:3450
 msgid "Searches Window"
 msgstr "Søge Vindue"
 
-#: src/amuleDlg.cpp:1803 src/muuli_wdr.cpp:3420
+#: src/amuleDlg.cpp:1803 src/muuli_wdr.cpp:3451
 #, fuzzy
 msgid "Downloads Window"
 msgstr "Henter"
 
-#: src/amuleDlg.cpp:1809 src/muuli_wdr.cpp:3422
+#: src/amuleDlg.cpp:1809 src/muuli_wdr.cpp:3453
 msgid "Shared Files Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1815 src/muuli_wdr.cpp:3423
+#: src/amuleDlg.cpp:1815 src/muuli_wdr.cpp:3454
 msgid "Messages Window"
 msgstr "Besked Vindue"
 
-#: src/amuleDlg.cpp:1821 src/muuli_wdr.cpp:3424
+#: src/amuleDlg.cpp:1821 src/muuli_wdr.cpp:3455
 msgid "Statistics Graph Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1828 src/muuli_wdr.cpp:3426
+#: src/amuleDlg.cpp:1828 src/muuli_wdr.cpp:3457
 msgid "Preferences Settings Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1831 src/muuli_wdr.cpp:3427
+#: src/amuleDlg.cpp:1831 src/muuli_wdr.cpp:3458
 msgid "Import"
 msgstr ""
 
-#: src/amuleDlg.cpp:1835 src/muuli_wdr.cpp:3427
+#: src/amuleDlg.cpp:1835 src/muuli_wdr.cpp:3458
 msgid "The partfile importer tool"
 msgstr ""
 
-#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3428
+#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3459
 #: src/utils/aLinkCreator/src/alcframe.cpp:262
 msgid "About"
 msgstr ""
 
-#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3428
+#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3459
 msgid "About/Help"
 msgstr ""
 
@@ -942,7 +942,7 @@ msgstr "Ingen part filer fundet"
 msgid "The core rejected these shared folders:%s"
 msgstr ""
 
-#: src/amule-remote-gui.cpp:1336 src/ExternalConn.cpp:2345
+#: src/amule-remote-gui.cpp:1336 src/ExternalConn.cpp:2346
 msgid "Invalid link or already on list."
 msgstr ""
 
@@ -958,7 +958,7 @@ msgstr ""
 #: src/ClientDetailDialog.cpp:123 src/DataToText.cpp:61 src/DataToText.cpp:86
 #: src/DataToText.cpp:101 src/DataToText.cpp:136 src/DataToText.cpp:165
 #: src/DownloadListCtrl.cpp:1172 src/DownloadListCtrl.cpp:1185
-#: src/DownloadListCtrl.cpp:1196 src/ExternalConn.cpp:608
+#: src/DownloadListCtrl.cpp:1196 src/ExternalConn.cpp:609
 #: src/FileDetailDialog.cpp:203 src/FileDetailDialog.cpp:235
 #: src/FileDetailDialog.cpp:242 src/GenericClientListCtrl.cpp:1171
 #: src/GenericClientListCtrl.cpp:1182 src/GenericClientListCtrl.cpp:1192
@@ -1346,19 +1346,19 @@ msgstr "Auto [Hø]"
 msgid "Very low"
 msgstr "Meget lav"
 
-#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:743 src/muuli_wdr.cpp:2282
+#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:743 src/muuli_wdr.cpp:2313
 #: src/ServerListCtrl.cpp:263 src/ServerListCtrl.cpp:456
 #: src/SharedFilesCtrl.cpp:145
 msgid "Low"
 msgstr "Lav"
 
-#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:744 src/muuli_wdr.cpp:2283
+#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:744 src/muuli_wdr.cpp:2314
 #: src/ServerListCtrl.cpp:266 src/ServerListCtrl.cpp:457
 #: src/SharedFilesCtrl.cpp:146
 msgid "Normal"
 msgstr "Normal"
 
-#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:745 src/muuli_wdr.cpp:2284
+#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:745 src/muuli_wdr.cpp:2315
 #: src/ServerListCtrl.cpp:269 src/ServerListCtrl.cpp:458
 #: src/SharedFilesCtrl.cpp:147
 msgid "High"
@@ -1450,7 +1450,7 @@ msgstr ""
 msgid "Remote Server"
 msgstr ""
 
-#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3181
+#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3212
 #: src/SearchDlg.cpp:119 src/TextClient.cpp:911
 msgid "Kad"
 msgstr ""
@@ -1521,7 +1521,7 @@ msgstr ""
 msgid "Size"
 msgstr "Størrelse"
 
-#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3248
+#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3279
 msgid "Transferred"
 msgstr "Overført"
 
@@ -1579,7 +1579,7 @@ msgid ""
 "\n"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:746 src/muuli_wdr.cpp:2285
+#: src/DownloadListCtrl.cpp:746 src/muuli_wdr.cpp:2316
 #: src/SharedFilesCtrl.cpp:150
 msgid "Auto"
 msgstr "Auto"
@@ -1617,7 +1617,7 @@ msgid "Extended Options"
 msgstr "Udvidet Muligheder"
 
 #: src/DownloadListCtrl.cpp:770 src/DownloadListCtrl.cpp:822
-#: src/muuli_wdr.cpp:1796
+#: src/muuli_wdr.cpp:1800
 msgid "Preview"
 msgstr "Smug Kig"
 
@@ -1790,227 +1790,232 @@ msgstr[1] ""
 msgid "Invalid eD2k link! ERROR: %s"
 msgstr ""
 
-#: src/ExternalConn.cpp:379
+#: src/ExternalConn.cpp:380
 msgid "Client sent packet after authentication failed."
 msgstr ""
 
-#: src/ExternalConn.cpp:396
+#: src/ExternalConn.cpp:397
 msgid "External connection closed."
 msgstr ""
 
-#: src/ExternalConn.cpp:473
+#: src/ExternalConn.cpp:474
 msgid "External connections disabled due to empty password!"
 msgstr ""
 
-#: src/ExternalConn.cpp:494
+#: src/ExternalConn.cpp:495
 msgid "External connections disabled in config file"
 msgstr ""
 
-#: src/ExternalConn.cpp:575
+#: src/ExternalConn.cpp:576
 msgid "New external connection accepted"
 msgstr ""
 
-#: src/ExternalConn.cpp:578
+#: src/ExternalConn.cpp:579
 msgid "ERROR: couldn't accept a new external connection"
 msgstr ""
 
-#: src/ExternalConn.cpp:595
+#: src/ExternalConn.cpp:596
 msgid "External connection refused due to empty password in preferences!"
 msgstr ""
 
-#: src/ExternalConn.cpp:607
+#: src/ExternalConn.cpp:608
 #, c-format
 msgid "Connecting client: %s %s"
 msgstr ""
 
-#: src/ExternalConn.cpp:609
+#: src/ExternalConn.cpp:610
 msgid "Unknown version"
 msgstr ""
 
-#: src/ExternalConn.cpp:622
+#: src/ExternalConn.cpp:623
 msgid "Incorrect EC version ID, there might be binary incompatibility. Use core and remote from same snapshot."
 msgstr ""
 
-#: src/ExternalConn.cpp:630
+#: src/ExternalConn.cpp:631
 msgid "You cannot connect to a release version from an arbitrary development snapshot! *sigh* possible crash prevented"
 msgstr ""
 
-#: src/ExternalConn.cpp:713
+#: src/ExternalConn.cpp:714
 msgid "Invalid protocol version."
 msgstr ""
 
-#: src/ExternalConn.cpp:719
+#: src/ExternalConn.cpp:720
 msgid "Missing protocol version tag."
 msgstr ""
 
-#: src/ExternalConn.cpp:727
+#: src/ExternalConn.cpp:728
 msgid "Authentication failed: invalid hash specified as EC password."
 msgstr ""
 
-#: src/ExternalConn.cpp:775
+#: src/ExternalConn.cpp:776
 msgid "Authentication failed: wrong password."
 msgstr ""
 
-#: src/ExternalConn.cpp:777
+#: src/ExternalConn.cpp:778
 msgid "Authentication failed: missing password."
 msgstr ""
 
-#: src/ExternalConn.cpp:788
+#: src/ExternalConn.cpp:789
 msgid "Invalid request, please authenticate first."
 msgstr ""
 
-#: src/ExternalConn.cpp:793
+#: src/ExternalConn.cpp:794
 msgid "Access granted."
 msgstr ""
 
-#: src/ExternalConn.cpp:801
+#: src/ExternalConn.cpp:802
 #, c-format
 msgid "Sent error message \"%s\" to client."
 msgstr ""
 
-#: src/ExternalConn.cpp:806
+#: src/ExternalConn.cpp:807
 #, c-format
 msgid "Unauthorized access attempt from %s. Connection closed."
 msgstr ""
 
-#: src/ExternalConn.cpp:1419
+#: src/ExternalConn.cpp:1420
 #, c-format
 msgid "Remote PartFile command failed: FileHash not found: %s"
 msgstr ""
 
-#: src/ExternalConn.cpp:1423
+#: src/ExternalConn.cpp:1424
 #, c-format
 msgid "FileHash not found: %s"
 msgstr ""
 
-#: src/ExternalConn.cpp:1470 src/ExternalConn.cpp:1558
-#: src/ExternalConn.cpp:1679
+#: src/ExternalConn.cpp:1471 src/ExternalConn.cpp:1559
+#: src/ExternalConn.cpp:1680
 msgid "OOPS! OpCode processing error!"
 msgstr ""
 
-#: src/ExternalConn.cpp:1501
+#: src/ExternalConn.cpp:1502
 msgid "Server not added"
 msgstr ""
 
-#: src/ExternalConn.cpp:1520
+#: src/ExternalConn.cpp:1521
 #, c-format
 msgid "server not found: %s"
 msgstr ""
 
-#: src/ExternalConn.cpp:1537
+#: src/ExternalConn.cpp:1538
 msgid "need to define server to be removed"
 msgstr ""
 
-#: src/ExternalConn.cpp:1552
+#: src/ExternalConn.cpp:1553
 msgid "eD2k is disabled in preferences."
 msgstr ""
 
-#: src/ExternalConn.cpp:1657
+#: src/ExternalConn.cpp:1658
 #, fuzzy
 msgid "Friend not found."
 msgstr "Index fil ikke fundet: "
 
-#: src/ExternalConn.cpp:1667
+#: src/ExternalConn.cpp:1668
 #, fuzzy
 msgid "Client not found."
 msgstr "Index fil ikke fundet: "
 
-#: src/ExternalConn.cpp:1673
+#: src/ExternalConn.cpp:1674
 msgid "EC_TAG_FRIEND_SHARED requires EC_TAG_FRIEND or EC_TAG_CLIENT."
 msgstr ""
 
-#: src/ExternalConn.cpp:1991
+#: src/ExternalConn.cpp:1992
 msgid "WebSearch from remote interface makes no sense."
 msgstr ""
 
-#: src/ExternalConn.cpp:2026
+#: src/ExternalConn.cpp:2027
 msgid "Search in progress. Refetch results in a moment!"
 msgstr ""
 
-#: src/ExternalConn.cpp:2265
+#: src/ExternalConn.cpp:2266
 msgid "No points for graph."
 msgstr ""
 
-#: src/ExternalConn.cpp:2275
+#: src/ExternalConn.cpp:2276
 msgid "Your client is not configured for this detail level."
 msgstr ""
 
-#: src/ExternalConn.cpp:2302
+#: src/ExternalConn.cpp:2303
 msgid "External Connection: shutdown requested"
 msgstr ""
 
-#: src/ExternalConn.cpp:2314
+#: src/ExternalConn.cpp:2315
 msgid "Already shutting down."
 msgstr ""
 
-#: src/ExternalConn.cpp:2332
+#: src/ExternalConn.cpp:2333
 #, c-format
 msgid "ExternalConn: adding link '%s'."
 msgstr ""
 
-#: src/ExternalConn.cpp:2350
+#: src/ExternalConn.cpp:2351
 #, c-format
 msgid "%d of %d links failed (invalid or already on list)."
 msgstr ""
 
-#: src/ExternalConn.cpp:2373
+#: src/ExternalConn.cpp:2374
 msgid "Version check throttled; try again shortly."
 msgstr ""
 
-#: src/ExternalConn.cpp:2378
+#: src/ExternalConn.cpp:2379
 msgid "Version check is not available on this daemon."
 msgstr ""
 
-#: src/ExternalConn.cpp:2508
+#: src/ExternalConn.cpp:2509
 msgid "File not found."
 msgstr ""
 
-#: src/ExternalConn.cpp:2513
+#: src/ExternalConn.cpp:2514
 msgid "Invalid file name."
 msgstr ""
 
-#: src/ExternalConn.cpp:2521
+#: src/ExternalConn.cpp:2522
 msgid "Unable to rename file."
 msgstr ""
 
-#: src/ExternalConn.cpp:2992 src/ExternalConn.cpp:3020
+#: src/ExternalConn.cpp:2839
+#, c-format
+msgid "Could not save the amuleapi password: %s"
+msgstr ""
+
+#: src/ExternalConn.cpp:3004 src/ExternalConn.cpp:3032
 msgid "Kad is disabled in preferences."
 msgstr ""
 
-#: src/ExternalConn.cpp:3033
+#: src/ExternalConn.cpp:3045
 msgid "Already connected to eD2k."
 msgstr ""
 
-#: src/ExternalConn.cpp:3036
+#: src/ExternalConn.cpp:3048
 msgid "Connecting to eD2k..."
 msgstr ""
 
-#: src/ExternalConn.cpp:3045
+#: src/ExternalConn.cpp:3057
 msgid "Already connected to Kad."
 msgstr ""
 
-#: src/ExternalConn.cpp:3048
+#: src/ExternalConn.cpp:3060
 msgid "Connecting to Kad..."
 msgstr ""
 
-#: src/ExternalConn.cpp:3055
+#: src/ExternalConn.cpp:3067
 msgid "All networks are disabled."
 msgstr ""
 
-#: src/ExternalConn.cpp:3064
+#: src/ExternalConn.cpp:3076
 msgid "Disconnected from eD2k."
 msgstr ""
 
-#: src/ExternalConn.cpp:3069
+#: src/ExternalConn.cpp:3081
 msgid "Disconnected from Kad."
 msgstr ""
 
-#: src/ExternalConn.cpp:3078
+#: src/ExternalConn.cpp:3090
 #, c-format
 msgid "External Connection: invalid opcode received: %#x"
 msgstr ""
 
-#: src/ExternalConn.cpp:3083
+#: src/ExternalConn.cpp:3095
 msgid "Invalid opcode (wrong protocol version?)"
 msgstr ""
 
@@ -2384,23 +2389,23 @@ msgid ""
 "want downloads on a different (e.g. larger) disk."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:549 src/FirstRunWizard.cpp:611 src/muuli_wdr.cpp:1708
+#: src/FirstRunWizard.cpp:549 src/FirstRunWizard.cpp:611 src/muuli_wdr.cpp:1712
 msgid "Destination folder for downloads"
 msgstr ""
 
 #: src/FirstRunWizard.cpp:553 src/FirstRunWizard.cpp:569 src/muuli_wdr.cpp:1349
-#: src/muuli_wdr.cpp:1366 src/muuli_wdr.cpp:1683 src/muuli_wdr.cpp:1714
-#: src/muuli_wdr.cpp:1726 src/muuli_wdr.cpp:2769
+#: src/muuli_wdr.cpp:1366 src/muuli_wdr.cpp:1687 src/muuli_wdr.cpp:1718
+#: src/muuli_wdr.cpp:1730 src/muuli_wdr.cpp:2800
 #: src/utils/aLinkCreator/src/alcframe.cpp:135
 #: src/utils/wxCas/src/wxcasprefs.cpp:52 src/utils/wxCas/src/wxcasprefs.cpp:118
 msgid "Browse"
 msgstr "Gennemse"
 
-#: src/FirstRunWizard.cpp:559 src/muuli_wdr.cpp:1719
+#: src/FirstRunWizard.cpp:559 src/muuli_wdr.cpp:1723
 msgid "(All files in this folder are shared with other peers)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:565 src/FirstRunWizard.cpp:624 src/muuli_wdr.cpp:1721
+#: src/FirstRunWizard.cpp:565 src/FirstRunWizard.cpp:624 src/muuli_wdr.cpp:1725
 msgid "Folder for temporary download files"
 msgstr ""
 
@@ -2431,7 +2436,7 @@ msgstr ""
 msgid "CRITICAL - no client on StartChatSession"
 msgstr ""
 
-#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2675 src/muuli_wdr.cpp:3352
+#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2706 src/muuli_wdr.cpp:3383
 msgid "Friends"
 msgstr "Venner"
 
@@ -2542,8 +2547,8 @@ msgstr "Ingen"
 msgid "No"
 msgstr "Nej"
 
-#: src/GenericClientListCtrl.cpp:1216 src/PrefsUnifiedDlg.cpp:2818
-#: src/PrefsUnifiedDlg.cpp:2868 src/ServerListCtrl.cpp:276
+#: src/GenericClientListCtrl.cpp:1216 src/PrefsUnifiedDlg.cpp:2898
+#: src/PrefsUnifiedDlg.cpp:2948 src/ServerListCtrl.cpp:276
 msgid "Yes"
 msgstr "Ja"
 
@@ -2711,10 +2716,10 @@ msgstr ""
 msgid "Please fill all fields required"
 msgstr ""
 
-#: src/KadDlg.cpp:192 src/PartFile.cpp:1031 src/PrefsUnifiedDlg.cpp:1162
-#: src/PrefsUnifiedDlg.cpp:1331 src/PrefsUnifiedDlg.cpp:1589
-#: src/PrefsUnifiedDlg.cpp:1599 src/PrefsUnifiedDlg.cpp:1616
-#: src/PrefsUnifiedDlg.cpp:1658
+#: src/KadDlg.cpp:192 src/PartFile.cpp:1031 src/PrefsUnifiedDlg.cpp:1134
+#: src/PrefsUnifiedDlg.cpp:1204 src/PrefsUnifiedDlg.cpp:1405
+#: src/PrefsUnifiedDlg.cpp:1663 src/PrefsUnifiedDlg.cpp:1673
+#: src/PrefsUnifiedDlg.cpp:1690 src/PrefsUnifiedDlg.cpp:1738
 msgid "Message"
 msgstr ""
 
@@ -2816,7 +2821,7 @@ msgstr ""
 msgid "Uploaded"
 msgstr ""
 
-#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3232
+#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3263
 msgid "Requested"
 msgstr ""
 
@@ -2942,7 +2947,7 @@ msgid "WARNING: "
 msgstr ""
 
 #: src/MuleNotebook.cpp:179 src/muuli_wdr.cpp:817 src/muuli_wdr.cpp:1229
-#: src/muuli_wdr.cpp:3136 src/muuli_wdr.cpp:3392
+#: src/muuli_wdr.cpp:3167 src/muuli_wdr.cpp:3423
 msgid "Close"
 msgstr "Luk"
 
@@ -2960,7 +2965,7 @@ msgid "Paste"
 msgstr ""
 
 #: src/MuleTextCtrl.cpp:89 src/muuli_wdr.cpp:358 src/muuli_wdr.cpp:757
-#: src/muuli_wdr.cpp:2359 src/muuli_wdr.cpp:2378 src/muuli_wdr.cpp:2400
+#: src/muuli_wdr.cpp:2390 src/muuli_wdr.cpp:2409 src/muuli_wdr.cpp:2431
 #: src/utils/aLinkCreator/src/alcframe.cpp:142
 msgid "Clear"
 msgstr "Ryd"
@@ -3058,7 +3063,7 @@ msgstr "Afslut"
 
 #: src/MuleTrayIcon.cpp:579 src/MuleTrayIcon.cpp:945 src/MuleTrayIcon.cpp:965
 #: src/muuli_wdr.cpp:1398 src/muuli_wdr.cpp:1406 src/muuli_wdr.cpp:1413
-#: src/muuli_wdr.cpp:1842 src/muuli_wdr.cpp:1848 src/OtherFunctions.cpp:91
+#: src/muuli_wdr.cpp:1846 src/muuli_wdr.cpp:1852 src/OtherFunctions.cpp:91
 #: src/StatisticsDlg.cpp:93 src/StatisticsDlg.cpp:95
 msgid "kB/s"
 msgstr "kB/s"
@@ -3299,7 +3304,7 @@ msgstr "Bytes"
 msgid "KB"
 msgstr "KB"
 
-#: src/muuli_wdr.cpp:274 src/muuli_wdr.cpp:293 src/muuli_wdr.cpp:1627
+#: src/muuli_wdr.cpp:274 src/muuli_wdr.cpp:293 src/muuli_wdr.cpp:1631
 #: src/OtherFunctions.cpp:64
 msgid "MB"
 msgstr "MB"
@@ -3316,7 +3321,7 @@ msgstr "Max Størrelse"
 msgid "Availability"
 msgstr ""
 
-#: src/muuli_wdr.cpp:312 src/muuli_wdr.cpp:398 src/muuli_wdr.cpp:3297
+#: src/muuli_wdr.cpp:312 src/muuli_wdr.cpp:398 src/muuli_wdr.cpp:3328
 msgid "Filter:"
 msgstr ""
 
@@ -3380,12 +3385,12 @@ msgstr "Fundne Kilder :"
 #: src/muuli_wdr.cpp:1160 src/muuli_wdr.cpp:1167 src/muuli_wdr.cpp:1172
 #: src/muuli_wdr.cpp:1179 src/muuli_wdr.cpp:1184 src/muuli_wdr.cpp:1191
 #: src/muuli_wdr.cpp:1205 src/muuli_wdr.cpp:1212 src/muuli_wdr.cpp:1217
-#: src/muuli_wdr.cpp:1224 src/muuli_wdr.cpp:3234 src/muuli_wdr.cpp:3242
-#: src/muuli_wdr.cpp:3250
+#: src/muuli_wdr.cpp:1224 src/muuli_wdr.cpp:3265 src/muuli_wdr.cpp:3273
+#: src/muuli_wdr.cpp:3281
 msgid "N/A"
 msgstr "N/A"
 
-#: src/muuli_wdr.cpp:508 src/muuli_wdr.cpp:1065 src/PrefsUnifiedDlg.cpp:297
+#: src/muuli_wdr.cpp:508 src/muuli_wdr.cpp:1065 src/PrefsUnifiedDlg.cpp:299
 msgid "General"
 msgstr "General"
 
@@ -3525,7 +3530,7 @@ msgstr ""
 msgid "Album :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:685 src/muuli_wdr.cpp:2254
+#: src/muuli_wdr.cpp:685 src/muuli_wdr.cpp:2285
 msgid "Title :"
 msgstr "Titel :"
 
@@ -3632,7 +3637,7 @@ msgstr "Brugernavn :"
 msgid "Userhash :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:895 src/muuli_wdr.cpp:1748 src/muuli_wdr.cpp:2449
+#: src/muuli_wdr.cpp:895 src/muuli_wdr.cpp:1752 src/muuli_wdr.cpp:2480
 #: src/utils/aLinkCreator/src/alcframe.cpp:137
 msgid "Add"
 msgstr "Tilføj"
@@ -3641,15 +3646,15 @@ msgstr "Tilføj"
 msgid "Download-Speed"
 msgstr "Download-Hastighed"
 
-#: src/muuli_wdr.cpp:954 src/muuli_wdr.cpp:989 src/muuli_wdr.cpp:2553
+#: src/muuli_wdr.cpp:954 src/muuli_wdr.cpp:989 src/muuli_wdr.cpp:2584
 msgid "Current"
 msgstr "Nuværende"
 
-#: src/muuli_wdr.cpp:962 src/muuli_wdr.cpp:997 src/muuli_wdr.cpp:2561
+#: src/muuli_wdr.cpp:962 src/muuli_wdr.cpp:997 src/muuli_wdr.cpp:2592
 msgid "Running average"
 msgstr "Nuværende Gennemsnit"
 
-#: src/muuli_wdr.cpp:970 src/muuli_wdr.cpp:1005 src/muuli_wdr.cpp:2569
+#: src/muuli_wdr.cpp:970 src/muuli_wdr.cpp:1005 src/muuli_wdr.cpp:2600
 msgid "Session average"
 msgstr "Sessions Gennemsnit"
 
@@ -3661,7 +3666,7 @@ msgstr "Upload-Hastighed"
 msgid "Connections"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1024 src/muuli_wdr.cpp:1867
+#: src/muuli_wdr.cpp:1024 src/muuli_wdr.cpp:1871
 msgid "Active downloads"
 msgstr "Aktive Downloads"
 
@@ -3669,7 +3674,7 @@ msgstr "Aktive Downloads"
 msgid "Active connections (1:1)"
 msgstr "Aktive Forbindelser (1:1)"
 
-#: src/muuli_wdr.cpp:1040 src/muuli_wdr.cpp:1868
+#: src/muuli_wdr.cpp:1040 src/muuli_wdr.cpp:1872
 msgid "Active uploads"
 msgstr "Aktive Uploads"
 
@@ -3943,7 +3948,7 @@ msgstr ""
 msgid "Advanced users only: If you have multiple network interfaces, enter the address of the interface to which aMule should be bound."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1462 src/muuli_wdr.cpp:2061
+#: src/muuli_wdr.cpp:1462 src/muuli_wdr.cpp:2065
 msgid "Bind to network interface (empty for any):"
 msgstr ""
 
@@ -3959,7 +3964,7 @@ msgstr ""
 msgid "Max simultaneous connections:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1498 src/muuli_wdr.cpp:3176
+#: src/muuli_wdr.cpp:1498 src/muuli_wdr.cpp:3207
 msgid "ED2K"
 msgstr ""
 
@@ -4051,750 +4056,773 @@ msgstr ""
 msgid "For new files preallocates disk space for the whole file, thus reduces fragmentation"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1613
+#: src/muuli_wdr.cpp:1617
 msgid "Create new files as sparse files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1614
-msgid "A sparse file reserves its full size on disk immediately without writing real data to it -- fast, but unsupported or slow on some filesystems, and free-space accounting stays optimistic while the download is in progress. Turn this off to grow the file only as data arrives."
+#: src/muuli_wdr.cpp:1618
+msgid "Sparse part files only occupy disk space for the parts already downloaded, so free space is used up gradually as the file fills in. Turn this off to use an ordinary file instead - useful where sparse files are unsupported or slow, or where backup/de-duplication tools handle them badly. Applies only when the core runs on Windows; on Linux and macOS part files are sparse anyway and this setting has no effect."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1619
+#: src/muuli_wdr.cpp:1623
 msgid "Stop downloads when free disk space reaches "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1620
+#: src/muuli_wdr.cpp:1624
 msgid "Select this if you want aMule to check your disk space"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1624
+#: src/muuli_wdr.cpp:1628
 msgid "Enter here the min disk space desired."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1630
+#: src/muuli_wdr.cpp:1634
 msgid "Save 10 sources on rare files (< 20 sources)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1634 src/Statistics.cpp:790
+#: src/muuli_wdr.cpp:1638 src/Statistics.cpp:790
 msgid "Uploads"
 msgstr "Uploads"
 
-#: src/muuli_wdr.cpp:1637
+#: src/muuli_wdr.cpp:1641
 msgid "Add new shared files with auto priority"
 msgstr "Tilføj nye delte filer med auto priotet"
 
-#: src/muuli_wdr.cpp:1643
+#: src/muuli_wdr.cpp:1647
 msgid "Intelligent Corruption Handling (I.C.H.)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1646
+#: src/muuli_wdr.cpp:1650
 msgid "Enable"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1649
+#: src/muuli_wdr.cpp:1653
 msgid "Advanced I.C.H. trusts every hash (not recommended)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1661 src/PrefsUnifiedDlg.cpp:1910
+#: src/muuli_wdr.cpp:1665 src/PrefsUnifiedDlg.cpp:1990
 msgid "Media metadata extraction"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1665
+#: src/muuli_wdr.cpp:1669
 msgid "Extract length / bitrate / codec from shared audio and video files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1667
+#: src/muuli_wdr.cpp:1671
 msgid "When enabled, aMule runs ffprobe on each shared media file to fill in the Length / Bitrate / Codec columns other clients see when they find the file in a search. Requires ffmpeg (the ffprobe binary) to be installed."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1674
+#: src/muuli_wdr.cpp:1678
 msgid "Path to ffprobe:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1679
+#: src/muuli_wdr.cpp:1683
 msgid "Full path to the ffprobe binary. Leave empty to have aMule auto-detect it on startup."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1687
+#: src/muuli_wdr.cpp:1691
 msgid "Detect"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1688
+#: src/muuli_wdr.cpp:1692
 msgid "Search the standard install locations for an ffprobe binary and fill the path field."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1712
+#: src/muuli_wdr.cpp:1716
 msgid ""
 "Completed downloads are stored here. All files in this folder are automatically shared with other peers.\n"
 "If this folder also holds files you don't want to share, point it at an aMule-only sub-folder."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1715
+#: src/muuli_wdr.cpp:1719
 msgid "Pick the folder where completed downloads will be stored. All files in that folder will be shared with other peers."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1729
+#: src/muuli_wdr.cpp:1733
 msgid "Shared folders"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1735
+#: src/muuli_wdr.cpp:1739
 msgid "(Folders shared by the core. Enter a path to add one.)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1743
+#: src/muuli_wdr.cpp:1747
 msgid "Absolute path of a folder on the core's machine, e.g. /home/user/shared"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1745 src/PrefsUnifiedDlg.cpp:2794
+#: src/muuli_wdr.cpp:1749 src/PrefsUnifiedDlg.cpp:2874
 msgid "Recursive"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1746
+#: src/muuli_wdr.cpp:1750
 msgid "Share every sub-folder underneath this one, including ones created later."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1750 src/utils/aLinkCreator/src/alcframe.cpp:141
+#: src/muuli_wdr.cpp:1754 src/utils/aLinkCreator/src/alcframe.cpp:141
 msgid "Remove"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1754
+#: src/muuli_wdr.cpp:1758
 msgid "(Right click on folder icon for recursive share)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1761
+#: src/muuli_wdr.cpp:1765
 msgid "Share hidden files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1767
+#: src/muuli_wdr.cpp:1771
 msgid "Automatically rescan shared folders for changes"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1773
+#: src/muuli_wdr.cpp:1777
 msgid "Follow symbolic links in shared folders"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1779
+#: src/muuli_wdr.cpp:1783
 msgid "Exclude files matching:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1782
+#: src/muuli_wdr.cpp:1786
 msgid "Wildcard patterns separated by '|', e.g. .DS_Store|Thumbs.db|*.tmp. Files whose name matches are not shared. Matching is case-insensitive."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1786
+#: src/muuli_wdr.cpp:1790
 msgid "Patterns are regular expressions"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1787
+#: src/muuli_wdr.cpp:1791
 msgid "When set, the whole field is one regular expression ('|' is alternation). When unset, it is a list of '|'-separated wildcards."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1797
+#: src/muuli_wdr.cpp:1801
 msgid "Show how many shared files the current pattern would exclude."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1818
+#: src/muuli_wdr.cpp:1822
 msgid "Graphs"
 msgstr "Grafer"
 
-#: src/muuli_wdr.cpp:1821 src/muuli_wdr.cpp:1883
+#: src/muuli_wdr.cpp:1825 src/muuli_wdr.cpp:1887
 msgid "Update delay : 5 secs"
 msgstr "Opdaterings interval : 5 sek"
 
-#: src/muuli_wdr.cpp:1825
+#: src/muuli_wdr.cpp:1829
 msgid "Time for average graph: 100 mins"
 msgstr "Tid for gennemsnitlig graf: 100 min"
 
-#: src/muuli_wdr.cpp:1829
+#: src/muuli_wdr.cpp:1833
 msgid "Connections Graph Scale: 100 "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1836
+#: src/muuli_wdr.cpp:1840
 msgid "Download graph scale:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1844
+#: src/muuli_wdr.cpp:1848
 msgid "Upload graph scale:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1854
+#: src/muuli_wdr.cpp:1858
 msgid "Colors: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1858
+#: src/muuli_wdr.cpp:1862
 msgid "Background"
 msgstr "Baggrund"
 
-#: src/muuli_wdr.cpp:1859
+#: src/muuli_wdr.cpp:1863
 msgid "Grid"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1860
+#: src/muuli_wdr.cpp:1864
 msgid "Download current"
 msgstr "Download nu"
 
-#: src/muuli_wdr.cpp:1861
+#: src/muuli_wdr.cpp:1865
 msgid "Download running average"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1862
+#: src/muuli_wdr.cpp:1866
 msgid "Download session average"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1863
+#: src/muuli_wdr.cpp:1867
 msgid "Upload current"
 msgstr "Upload nu"
 
-#: src/muuli_wdr.cpp:1864
+#: src/muuli_wdr.cpp:1868
 msgid "Upload running average"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1865
+#: src/muuli_wdr.cpp:1869
 msgid "Upload session average"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1866
+#: src/muuli_wdr.cpp:1870
 msgid "Active connections"
 msgstr "Aktive Forbindelser"
 
-#: src/muuli_wdr.cpp:1869
+#: src/muuli_wdr.cpp:1873
 msgid "Systray Icon Speed Bar"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1870
+#: src/muuli_wdr.cpp:1874
 msgid "Kad-nodes current"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1871
+#: src/muuli_wdr.cpp:1875
 msgid "Kad-nodes running"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1872
+#: src/muuli_wdr.cpp:1876
 msgid "Kad-nodes session"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1876 src/muuli_wdr.cpp:2303
+#: src/muuli_wdr.cpp:1880 src/muuli_wdr.cpp:2334
 msgid "Select"
 msgstr "Vælg"
 
-#: src/muuli_wdr.cpp:1880
+#: src/muuli_wdr.cpp:1884
 msgid "Tree"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1890
+#: src/muuli_wdr.cpp:1894
 msgid "Number of Client Versions shown (0=unlimited)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1915
+#: src/muuli_wdr.cpp:1919
 msgid "!!! WARNING !!!"
 msgstr "!!! Advarsel !!!"
 
-#: src/muuli_wdr.cpp:1930
+#: src/muuli_wdr.cpp:1934
 msgid "Max new connections / 5 secs"
 msgstr "Max nye forbindelser / 5 sekunder"
 
-#: src/muuli_wdr.cpp:1932
+#: src/muuli_wdr.cpp:1936
 msgid "Concurrent Kad source lookups"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1934
+#: src/muuli_wdr.cpp:1938
 #, fuzzy
 msgid "Kad source re-search interval (minutes)"
 msgstr "FTP opdaterings interval i minutter"
 
-#: src/muuli_wdr.cpp:1936
+#: src/muuli_wdr.cpp:1940
 #, fuzzy
 msgid "Source re-ask interval (minutes)"
 msgstr "FTP opdaterings interval i minutter"
 
-#: src/muuli_wdr.cpp:1940
+#: src/muuli_wdr.cpp:1944
 msgid "File Buffer Size: 240000 bytes"
 msgstr "Fil Buffer Størrelse"
 
-#: src/muuli_wdr.cpp:1944
+#: src/muuli_wdr.cpp:1948
 msgid "Use MMAP: memory-mapped file access (lower memory use)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1945
+#: src/muuli_wdr.cpp:1949
 msgid "Maps part files into memory instead of buffering them on the heap, lowering the process memory footprint. May reduce download speed on some disks; best for memory-constrained or upload-heavy hosts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1947
+#: src/muuli_wdr.cpp:1951
 msgid "Upload Queue Size: 5000 clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1951
+#: src/muuli_wdr.cpp:1955
 msgid "Server connection refresh interval: Disable"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1955
+#: src/muuli_wdr.cpp:1959
 msgid "Disable computer's timed standby mode"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1974
+#: src/muuli_wdr.cpp:1978
 msgid "Skin to use: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1983
+#: src/muuli_wdr.cpp:1987
 msgid "Show \"Fast eD2k Links Handler\" in every window."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1986
+#: src/muuli_wdr.cpp:1990
 msgid "Show extended info on categories tabs"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1989
+#: src/muuli_wdr.cpp:1993
 #, fuzzy
 msgid "Show application version on title"
 msgstr "Vis overførsels hastighed i titel"
 
-#: src/muuli_wdr.cpp:1991
+#: src/muuli_wdr.cpp:1995
 msgid "Show transfer rates on title"
 msgstr "Vis overførsels hastighed i titel"
 
-#: src/muuli_wdr.cpp:1993
+#: src/muuli_wdr.cpp:1997
 msgid "Before application name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1995
+#: src/muuli_wdr.cpp:1999
 msgid "After application name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1998
+#: src/muuli_wdr.cpp:2002
 msgid "Show overhead bandwidth"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2002
+#: src/muuli_wdr.cpp:2006
 msgid "Vertical toolbar orientation"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2004
+#: src/muuli_wdr.cpp:2008
 msgid "Live column sorting (auto-reorder rows as their values change)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2011
+#: src/muuli_wdr.cpp:2015
 msgid "Download Queue Files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2014
+#: src/muuli_wdr.cpp:2018
 msgid "Show progress percentage"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2020
+#: src/muuli_wdr.cpp:2024
 msgid "Show progress bar"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2023
+#: src/muuli_wdr.cpp:2027
 msgid "Flat"
 msgstr "Flad"
 
-#: src/muuli_wdr.cpp:2027
+#: src/muuli_wdr.cpp:2031
 msgid "Round"
 msgstr "Rund"
 
-#: src/muuli_wdr.cpp:2045
+#: src/muuli_wdr.cpp:2049
 msgid "External Connection Parameters"
 msgstr "Ydre Forbindelses Parametre"
 
-#: src/muuli_wdr.cpp:2048
+#: src/muuli_wdr.cpp:2052
 msgid "Accept external connections"
 msgstr "Accepter ydre forbindelser"
 
-#: src/muuli_wdr.cpp:2055 src/muuli_wdr.cpp:2114
+#: src/muuli_wdr.cpp:2059 src/muuli_wdr.cpp:2118
 msgid "IP of the listening interface:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2058
+#: src/muuli_wdr.cpp:2062
 msgid "Enter here a valid ip in the a.b.c.d format for the listening EC interface. An empty field or 0.0.0.0 will mean any interface."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2079 src/muuli_wdr.cpp:2163
+#: src/muuli_wdr.cpp:2083 src/muuli_wdr.cpp:2194
 msgid "TCP port:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2085
+#: src/muuli_wdr.cpp:2089
 msgid "Enable UPnP port forwarding on the EC port"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2089 src/muuli_wdr.cpp:3048
+#: src/muuli_wdr.cpp:2093 src/muuli_wdr.cpp:3079
 #: src/utils/wxCas/src/wxcasprefs.cpp:167
 msgid "Password"
 msgstr "Password"
 
-#: src/muuli_wdr.cpp:2095
+#: src/muuli_wdr.cpp:2099
 msgid "aMule API server parameters"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2098
+#: src/muuli_wdr.cpp:2102
 msgid "Run amuleapi (REST API) on startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2103
+#: src/muuli_wdr.cpp:2107
 #, fuzzy
 msgid "HTTP port:"
 msgstr "UPnP port"
 
-#: src/muuli_wdr.cpp:2117
+#: src/muuli_wdr.cpp:2121
 msgid "The interface amuleapi's HTTP server listens on. 127.0.0.1 (default) accepts only local connections; use 0.0.0.0 or a specific IP to expose it to other hosts (set an admin password below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2120
+#: src/muuli_wdr.cpp:2126
+msgid "Type a password to set or change it. Stored passwords cannot be shown, so leaving this empty keeps the current one."
+msgstr ""
+
+#: src/muuli_wdr.cpp:2128
 #, fuzzy
 msgid "Admin password"
 msgstr "Undersøger password\n"
 
-#: src/muuli_wdr.cpp:2125 src/muuli_wdr.cpp:2156
-msgid "Low rights password"
-msgstr "Lav rettigheds kodeord"
+#: src/muuli_wdr.cpp:2140 src/muuli_wdr.cpp:2157 src/PrefsUnifiedDlg.cpp:1103
+#, fuzzy
+msgid "A password is set."
+msgstr "Undersøger password\n"
 
-#: src/muuli_wdr.cpp:2133
+#: src/muuli_wdr.cpp:2144
+#, fuzzy
+msgid "Enable guest access"
+msgstr "Tillad bruger adgang"
+
+#: src/muuli_wdr.cpp:2145
+msgid "Guest sessions may read status and listings but cannot change anything. Turning this off clears the stored guest password."
+msgstr ""
+
+#: src/muuli_wdr.cpp:2149
+#, fuzzy
+msgid "Guest password"
+msgstr "Fuld rettigheds kodeord"
+
+#: src/muuli_wdr.cpp:2164
 msgid "Web server parameters"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2136
+#: src/muuli_wdr.cpp:2167
 msgid "Run webserver on startup (deprecated)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2142
+#: src/muuli_wdr.cpp:2173
 msgid "Web template"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2147
+#: src/muuli_wdr.cpp:2178
 msgid "Full rights password"
 msgstr "Fuld rettigheds kodeord"
 
-#: src/muuli_wdr.cpp:2151
+#: src/muuli_wdr.cpp:2182
 msgid "Enable Low rights User"
 msgstr "Aktiver lav rettigheds brugere"
 
-#: src/muuli_wdr.cpp:2170
+#: src/muuli_wdr.cpp:2187
+msgid "Low rights password"
+msgstr "Lav rettigheds kodeord"
+
+#: src/muuli_wdr.cpp:2201
 msgid "Enable UPnP port forwarding of the web server port"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2175
+#: src/muuli_wdr.cpp:2206
 msgid "Web server UPnP TCP port (Optional)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2183
+#: src/muuli_wdr.cpp:2214
 msgid "Page Refresh Time (in secs)"
 msgstr "Side Opdaterings Tid (i sek)"
 
-#: src/muuli_wdr.cpp:2190
+#: src/muuli_wdr.cpp:2221
 msgid "Enable Gzip compression"
 msgstr "Aktiver Gzip komprimering"
 
-#: src/muuli_wdr.cpp:2224
+#: src/muuli_wdr.cpp:2255
 #, fuzzy
 msgid "Reset page to defaults"
 msgstr "System standard"
 
-#: src/muuli_wdr.cpp:2225
+#: src/muuli_wdr.cpp:2256
 msgid "Reset the settings on the current page to their default values."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2227 src/muuli_wdr.cpp:2313 src/ServerWnd.cpp:274
+#: src/muuli_wdr.cpp:2258 src/muuli_wdr.cpp:2344 src/ServerWnd.cpp:274
 #: src/ServerWnd.cpp:282
 msgid "OK"
 msgstr "OK"
 
-#: src/muuli_wdr.cpp:2229
+#: src/muuli_wdr.cpp:2260
 msgid "Click here to apply any changes made to the preferences."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2232
+#: src/muuli_wdr.cpp:2263
 msgid "Reset any changes made to the preferences."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2261
+#: src/muuli_wdr.cpp:2292
 msgid "Comment :"
 msgstr "Kommentar :"
 
-#: src/muuli_wdr.cpp:2268
+#: src/muuli_wdr.cpp:2299
 msgid "Incoming Dir :"
 msgstr "Indkommende Mappe :"
 
-#: src/muuli_wdr.cpp:2277
+#: src/muuli_wdr.cpp:2308
 msgid "Change priority for new assigned files :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2281
+#: src/muuli_wdr.cpp:2312
 msgid "Don't change"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2293
+#: src/muuli_wdr.cpp:2324
 msgid "Select color for this Category (currently selected) :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2360 src/muuli_wdr.cpp:2379 src/muuli_wdr.cpp:2401
+#: src/muuli_wdr.cpp:2391 src/muuli_wdr.cpp:2410 src/muuli_wdr.cpp:2432
 msgid "Click this button to reset the log."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2420
+#: src/muuli_wdr.cpp:2451
 msgid "Click on this button to update the servers list from URL ..."
 msgstr "Tryk på denne knap for at opdatere serverlisten fra URL ..."
 
-#: src/muuli_wdr.cpp:2424
+#: src/muuli_wdr.cpp:2455
 msgid "Server list"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2428
+#: src/muuli_wdr.cpp:2459
 msgid "Enter the url to a server.met file here and press the button to the left to update the list of known servers."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2433
+#: src/muuli_wdr.cpp:2464
 msgid "Add server manually: Name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2436
+#: src/muuli_wdr.cpp:2467
 msgid "Enter the name of the new server here"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2438 src/ServerWnd.cpp:206
+#: src/muuli_wdr.cpp:2469 src/ServerWnd.cpp:206
 msgid "IP:Port"
 msgstr "IP:Port"
 
-#: src/muuli_wdr.cpp:2441
+#: src/muuli_wdr.cpp:2472
 msgid "Enter the IP of the server here, using the x.x.x.x format."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2447
+#: src/muuli_wdr.cpp:2478
 msgid "Enter the port of the server here."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2450
+#: src/muuli_wdr.cpp:2481
 msgid "Add manually a server (fill fields to the left before) ..."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2479
+#: src/muuli_wdr.cpp:2510
 msgid "aMule Log"
 msgstr "aMule Log"
 
-#: src/muuli_wdr.cpp:2487
+#: src/muuli_wdr.cpp:2518
 msgid "Server Info"
 msgstr "Server Info"
 
-#: src/muuli_wdr.cpp:2491
+#: src/muuli_wdr.cpp:2522
 msgid "ED2K Info"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2495
+#: src/muuli_wdr.cpp:2526
 msgid "Kad Info"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2523
+#: src/muuli_wdr.cpp:2554
 msgid "Click on this button to update the nodes list from URL ..."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2527
+#: src/muuli_wdr.cpp:2558
 msgid "Nodes (0)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2531
+#: src/muuli_wdr.cpp:2562
 msgid "Enter the url to a nodes.dat file here and press the button to the left to update the list of known nodes."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2534
+#: src/muuli_wdr.cpp:2565
 msgid "Nodes stats"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2576
+#: src/muuli_wdr.cpp:2607
 msgid "Bootstrap"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2579
+#: src/muuli_wdr.cpp:2610
 msgid "New node"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2584
+#: src/muuli_wdr.cpp:2615
 msgid "IP:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2604
+#: src/muuli_wdr.cpp:2635
 msgid "Port:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2617
+#: src/muuli_wdr.cpp:2648
 msgid "Bootstrap from known clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2619
+#: src/muuli_wdr.cpp:2650
 msgid "Disconnect Kad"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2653
+#: src/muuli_wdr.cpp:2684
 msgid "Use Secure User Identification"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2655
+#: src/muuli_wdr.cpp:2686
 msgid "It is recommended to enable this option. You will not receive credits if SUI is not enabled."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2657
+#: src/muuli_wdr.cpp:2688
 msgid "Protocol Obfuscation"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2660
+#: src/muuli_wdr.cpp:2691
 msgid "Support Protocol Obfuscation"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2662
+#: src/muuli_wdr.cpp:2693
 msgid "This option enabled Protocol Obfuscation, and makes aMule accept obfuscated connections from other clients."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2664
+#: src/muuli_wdr.cpp:2695
 msgid "Use obfuscation for outgoing connections"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2666
+#: src/muuli_wdr.cpp:2697
 msgid "This option makes aMule use Protocol Obfuscation when connecting other clients/servers."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2668
+#: src/muuli_wdr.cpp:2699
 msgid "Accept only obfuscated connections"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2669
+#: src/muuli_wdr.cpp:2700
 msgid "This option makes aMule only accept obfuscated connections. You will have less sources, but all your traffic will be obfuscated"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2674
+#: src/muuli_wdr.cpp:2705
 msgid "Everybody"
 msgstr "Alle"
 
-#: src/muuli_wdr.cpp:2676
+#: src/muuli_wdr.cpp:2707
 msgid "No one"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2678
+#: src/muuli_wdr.cpp:2709
 msgid "Who can see my shared files:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2679
+#: src/muuli_wdr.cpp:2710
 msgid "Select who can request to view a list of your shared files."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2681
+#: src/muuli_wdr.cpp:2712
 msgid "IP-Filtering"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2688
+#: src/muuli_wdr.cpp:2719
 msgid "Filter clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2690
+#: src/muuli_wdr.cpp:2721
 msgid "Enable filtering of the client IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2692
+#: src/muuli_wdr.cpp:2723
 msgid "Filter servers"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2694
+#: src/muuli_wdr.cpp:2725
 msgid "Enable filtering of the server IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2698
+#: src/muuli_wdr.cpp:2729
 msgid "Reload List"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2699
+#: src/muuli_wdr.cpp:2730
 msgid "Reload the list of IPs to filter from the file ~/.aMule/ipfilter.dat"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2705
+#: src/muuli_wdr.cpp:2736
 msgid "URL:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2709 src/muuli_wdr.cpp:2902
+#: src/muuli_wdr.cpp:2740 src/muuli_wdr.cpp:2933
 msgid "Update now"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2712
+#: src/muuli_wdr.cpp:2743
 msgid "Auto-update ipfilter at startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2716
+#: src/muuli_wdr.cpp:2747
 msgid "Filtering Level:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2722
+#: src/muuli_wdr.cpp:2753
 msgid "Always filter LAN IPs"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2725
+#: src/muuli_wdr.cpp:2756
 msgid "Paranoid handling of non-matching IPs"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2727
+#: src/muuli_wdr.cpp:2758
 msgid "Rejects a packet when its source IP differs from the IP the client claims (an anti-spoofing check). Disable only if it causes connection problems."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2729
+#: src/muuli_wdr.cpp:2760
 msgid "Use system-wide ipfilter.dat if available"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2730
+#: src/muuli_wdr.cpp:2761
 msgid "If there's no local ipfilter.dat found, allow usage of a system-wide ipfilter file."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2747
+#: src/muuli_wdr.cpp:2778
 msgid "Enable Online-Signature"
 msgstr "Aktiver online-signatur"
 
-#: src/muuli_wdr.cpp:2749
+#: src/muuli_wdr.cpp:2780
 msgid "Enables the writing of the OS file, which can be used by external apps to create signatures and the like."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2753
+#: src/muuli_wdr.cpp:2784
 msgid "Update Frequency (Secs):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2756
+#: src/muuli_wdr.cpp:2787
 msgid "Change the frequency (in seconds) of Online Signature updates."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2764
+#: src/muuli_wdr.cpp:2795
 msgid "Save online signature file in: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:2770
+#: src/muuli_wdr.cpp:2801
 msgid "Click here to select the directory containing the the Online Signature files."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2803
+#: src/muuli_wdr.cpp:2834
 msgid "Show country flags for clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2804
+#: src/muuli_wdr.cpp:2835
 msgid "Render the country flag column in the transfers, queue and search views. Requires a valid MMDB GeoIP database (see below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2809
+#: src/muuli_wdr.cpp:2840
 msgid "Database"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2825
+#: src/muuli_wdr.cpp:2856
 #, fuzzy
 msgid "Source:"
 msgstr "Kilder"
 
-#: src/muuli_wdr.cpp:2828
+#: src/muuli_wdr.cpp:2859
 msgid "DB-IP (free, no account)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2829
+#: src/muuli_wdr.cpp:2860
 msgid "MaxMind GeoLite2 (free, account required)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2830
+#: src/muuli_wdr.cpp:2861
 msgid "Custom URL"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2833
+#: src/muuli_wdr.cpp:2864
 msgid "Choose which provider supplies the GeoIP MMDB database. DB-IP is the default - no account required. MaxMind requires a free account + license key. Use Custom URL to point at any other MMDB host (e.g. a local mirror)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2850
+#: src/muuli_wdr.cpp:2881
 msgid ""
 "No configuration required.\n"
 "\n"
@@ -4802,11 +4830,11 @@ msgid ""
 "License: Creative Commons BY 4.0 - https://creativecommons.org/licenses/by/4.0/"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2863
+#: src/muuli_wdr.cpp:2894
 msgid "License key:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2869
+#: src/muuli_wdr.cpp:2900
 msgid ""
 "Sign up for a free MaxMind account, then generate a License Key:\n"
 "https://www.maxmind.com/en/geolite2/signup\n"
@@ -4816,232 +4844,232 @@ msgid ""
 "Requires attribution and account registration; refresh at least every 30 days."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2884
+#: src/muuli_wdr.cpp:2915
 #, fuzzy
 msgid "Download URL:"
 msgstr "Download: "
 
-#: src/muuli_wdr.cpp:2890
+#: src/muuli_wdr.cpp:2921
 msgid ""
 "Must point to an .mmdb file or a .gz / .tar.gz containing one.\n"
 "URL may include credentials (https://user:pass@host/...).\n"
 "License and attribution terms are set by the upstream URL - you are responsible."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2903
+#: src/muuli_wdr.cpp:2934
 msgid "Download the GeoIP database from the selected source."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2905
+#: src/muuli_wdr.cpp:2936
 #, fuzzy
 msgid "Auto-update on startup"
 msgstr "Auto forbind ved start"
 
-#: src/muuli_wdr.cpp:2906
+#: src/muuli_wdr.cpp:2937
 msgid "Re-download the GeoIP database from the selected source every time aMule starts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2929
+#: src/muuli_wdr.cpp:2960
 msgid "Filter incoming messages (except current chat):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2931
+#: src/muuli_wdr.cpp:2962
 msgid "Filter all messages"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2933
+#: src/muuli_wdr.cpp:2964
 msgid "Filter messages from people not on your friend list"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2935
+#: src/muuli_wdr.cpp:2966
 msgid "Filter messages from unknown clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2937
+#: src/muuli_wdr.cpp:2968
 msgid "Filter messages containing (use ',' as separator):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2940 src/muuli_wdr.cpp:2951
+#: src/muuli_wdr.cpp:2971 src/muuli_wdr.cpp:2982
 msgid "add here the words amule should filter and block messages including it"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2942
+#: src/muuli_wdr.cpp:2973
 msgid "Show received messages in the log"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2945
+#: src/muuli_wdr.cpp:2976
 msgid "Comments"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2948
+#: src/muuli_wdr.cpp:2979
 msgid "Filter comments containing (use ',' as separator):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2973
+#: src/muuli_wdr.cpp:3004
 msgid "Enable Proxy"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2974
+#: src/muuli_wdr.cpp:3005
 msgid "Enable/disable proxy support"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2977
+#: src/muuli_wdr.cpp:3008
 msgid "Proxy type:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2988
+#: src/muuli_wdr.cpp:3019
 msgid "Proxy host:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2991
+#: src/muuli_wdr.cpp:3022
 msgid "The proxy host name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2993
+#: src/muuli_wdr.cpp:3024
 msgid "Proxy port:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2996
+#: src/muuli_wdr.cpp:3027
 msgid "The proxy port"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2998
+#: src/muuli_wdr.cpp:3029
 msgid "Enable authentication"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2999
+#: src/muuli_wdr.cpp:3030
 msgid "Enable/disable username/password authentication"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3002
+#: src/muuli_wdr.cpp:3033
 msgid "Username: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:3005
+#: src/muuli_wdr.cpp:3036
 msgid "The username to use to connect to the proxy"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3007
+#: src/muuli_wdr.cpp:3038
 msgid "Password:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3010
+#: src/muuli_wdr.cpp:3041
 msgid "The password to use to connect to the proxy"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3029
+#: src/muuli_wdr.cpp:3060
 msgid "Connect to:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3038
+#: src/muuli_wdr.cpp:3069
 msgid "Login to remote amule"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3043
+#: src/muuli_wdr.cpp:3074
 msgid "User name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3054
+#: src/muuli_wdr.cpp:3085
 msgid "Remember those settings"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3057
+#: src/muuli_wdr.cpp:3088
 #, fuzzy
 msgid "Force ZLIB compression"
 msgstr "Brug gzip komprimering"
 
-#: src/muuli_wdr.cpp:3081
+#: src/muuli_wdr.cpp:3112
 msgid "Enable Verbose Debug-Logging."
 msgstr ""
 
-#: src/muuli_wdr.cpp:3083
+#: src/muuli_wdr.cpp:3114
 #, fuzzy
 msgid "Only to Logfile"
 msgstr "&Åben filen"
 
-#: src/muuli_wdr.cpp:3085
+#: src/muuli_wdr.cpp:3116
 msgid "Message Categories:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3109 src/PartFileConvertDlg.cpp:160
+#: src/muuli_wdr.cpp:3140 src/PartFileConvertDlg.cpp:160
 msgid "Waiting..."
 msgstr "Venter..."
 
-#: src/muuli_wdr.cpp:3129
+#: src/muuli_wdr.cpp:3160
 msgid "Add imports"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3132
+#: src/muuli_wdr.cpp:3163
 msgid "Retry selected"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3134
+#: src/muuli_wdr.cpp:3165
 msgid "Remove selected"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3197
+#: src/muuli_wdr.cpp:3228
 msgid "Event Types"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3216
+#: src/muuli_wdr.cpp:3247
 msgid "Statistics and queued clients for selected file(s) : Session / All time"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3240
+#: src/muuli_wdr.cpp:3271
 msgid "Active Uploads"
 msgstr "Aktive Uploads"
 
-#: src/muuli_wdr.cpp:3254
+#: src/muuli_wdr.cpp:3285
 #, fuzzy
 msgid "Percent of total files"
 msgstr "Antal Filer Total"
 
-#: src/muuli_wdr.cpp:3306
+#: src/muuli_wdr.cpp:3337
 #, fuzzy
 msgid "Show Clients for"
 msgstr "Vis Liste"
 
-#: src/muuli_wdr.cpp:3308
+#: src/muuli_wdr.cpp:3339
 #, fuzzy
 msgid "All files"
 msgstr "Delte Filer"
 
-#: src/muuli_wdr.cpp:3311
+#: src/muuli_wdr.cpp:3342
 #, fuzzy
 msgid "Selected files"
 msgstr "Slettede Servere"
 
-#: src/muuli_wdr.cpp:3314
+#: src/muuli_wdr.cpp:3345
 #, fuzzy
 msgid "Active uploads only"
 msgstr "Aktive Uploads"
 
-#: src/muuli_wdr.cpp:3321
+#: src/muuli_wdr.cpp:3352
 #, fuzzy
 msgid "Reload:"
 msgstr "Opdater"
 
-#: src/muuli_wdr.cpp:3325
+#: src/muuli_wdr.cpp:3356
 msgid "Reload your shared files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3388
+#: src/muuli_wdr.cpp:3419
 msgid "Send"
 msgstr "Send"
 
-#: src/muuli_wdr.cpp:3389
+#: src/muuli_wdr.cpp:3420
 msgid "Sends the specified message."
 msgstr ""
 
-#: src/muuli_wdr.cpp:3393
+#: src/muuli_wdr.cpp:3424
 msgid "Close this chat-session."
 msgstr ""
 
-#: src/muuli_wdr.cpp:3416
+#: src/muuli_wdr.cpp:3447
 msgid "Connect to any server and/or Kad"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3422 src/SharedFilesCtrl.cpp:142 src/Statistics.cpp:941
+#: src/muuli_wdr.cpp:3453 src/SharedFilesCtrl.cpp:142 src/Statistics.cpp:941
 msgid "Shared Files"
 msgstr "Delte Filer"
 
@@ -5403,267 +5431,267 @@ msgstr ""
 msgid "ERROR: Failed to open partfile '%s'"
 msgstr ""
 
-#: src/Preferences.cpp:674
+#: src/Preferences.cpp:701
 msgid "System default"
 msgstr "System standard"
 
-#: src/Preferences.cpp:675
+#: src/Preferences.cpp:702
 msgid "Albanian"
 msgstr ""
 
-#: src/Preferences.cpp:676
+#: src/Preferences.cpp:703
 msgid "Arabic"
 msgstr "Arabic"
 
-#: src/Preferences.cpp:677
+#: src/Preferences.cpp:704
 #, fuzzy
 msgid "Asturian"
 msgstr "Estonian"
 
-#: src/Preferences.cpp:678
+#: src/Preferences.cpp:705
 msgid "Basque"
 msgstr "Basque"
 
-#: src/Preferences.cpp:679
+#: src/Preferences.cpp:706
 msgid "Bulgarian"
 msgstr "Bulgarian"
 
-#: src/Preferences.cpp:680
+#: src/Preferences.cpp:707
 msgid "Catalan"
 msgstr "Catalan"
 
-#: src/Preferences.cpp:681
+#: src/Preferences.cpp:708
 msgid "Chinese (Simplified)"
 msgstr ""
 
-#: src/Preferences.cpp:682
+#: src/Preferences.cpp:709
 msgid "Chinese (Traditional)"
 msgstr ""
 
-#: src/Preferences.cpp:683
+#: src/Preferences.cpp:710
 msgid "Croatian"
 msgstr ""
 
-#: src/Preferences.cpp:684
+#: src/Preferences.cpp:711
 msgid "Czech"
 msgstr ""
 
-#: src/Preferences.cpp:685
+#: src/Preferences.cpp:712
 msgid "Danish"
 msgstr "Danish"
 
-#: src/Preferences.cpp:686
+#: src/Preferences.cpp:713
 msgid "Dutch"
 msgstr "Dutch"
 
-#: src/Preferences.cpp:687
+#: src/Preferences.cpp:714
 msgid "English (U.K.)"
 msgstr ""
 
-#: src/Preferences.cpp:688
+#: src/Preferences.cpp:715
 msgid "English (U.S.)"
 msgstr ""
 
-#: src/Preferences.cpp:689
+#: src/Preferences.cpp:716
 msgid "Estonian"
 msgstr "Estonian"
 
-#: src/Preferences.cpp:690
+#: src/Preferences.cpp:717
 msgid "Finnish"
 msgstr "Finnish"
 
-#: src/Preferences.cpp:691
+#: src/Preferences.cpp:718
 msgid "French"
 msgstr "French"
 
-#: src/Preferences.cpp:692
+#: src/Preferences.cpp:719
 msgid "Galician"
 msgstr ""
 
-#: src/Preferences.cpp:693
+#: src/Preferences.cpp:720
 msgid "German"
 msgstr "German"
 
-#: src/Preferences.cpp:694
+#: src/Preferences.cpp:721
 msgid "Greek"
 msgstr ""
 
-#: src/Preferences.cpp:695
+#: src/Preferences.cpp:722
 msgid "Hebrew"
 msgstr ""
 
-#: src/Preferences.cpp:696
+#: src/Preferences.cpp:723
 msgid "Hungarian"
 msgstr ""
 
-#: src/Preferences.cpp:697
+#: src/Preferences.cpp:724
 msgid "Italian"
 msgstr "Italian"
 
-#: src/Preferences.cpp:698
+#: src/Preferences.cpp:725
 msgid "Japanese"
 msgstr ""
 
-#: src/Preferences.cpp:699
+#: src/Preferences.cpp:726
 msgid "Korean"
 msgstr "Korean"
 
-#: src/Preferences.cpp:700
+#: src/Preferences.cpp:727
 msgid "Latvian"
 msgstr ""
 
-#: src/Preferences.cpp:701
+#: src/Preferences.cpp:728
 msgid "Lithuanian"
 msgstr "Lithuanian"
 
-#: src/Preferences.cpp:702
+#: src/Preferences.cpp:729
 msgid "Norwegian (Nynorsk)"
 msgstr ""
 
-#: src/Preferences.cpp:703
+#: src/Preferences.cpp:730
 msgid "Polish"
 msgstr "Polish"
 
-#: src/Preferences.cpp:704
+#: src/Preferences.cpp:731
 msgid "Portuguese"
 msgstr "Portuguese"
 
-#: src/Preferences.cpp:705
+#: src/Preferences.cpp:732
 msgid "Portuguese (Brazilian)"
 msgstr ""
 
-#: src/Preferences.cpp:706
+#: src/Preferences.cpp:733
 #, fuzzy
 msgid "Romanian"
 msgstr "Estonian"
 
-#: src/Preferences.cpp:707
+#: src/Preferences.cpp:734
 msgid "Russian"
 msgstr "Russian"
 
-#: src/Preferences.cpp:708
+#: src/Preferences.cpp:735
 msgid "Slovenian"
 msgstr ""
 
-#: src/Preferences.cpp:709
+#: src/Preferences.cpp:736
 msgid "Spanish"
 msgstr "Spanish"
 
-#: src/Preferences.cpp:710
+#: src/Preferences.cpp:737
 msgid "Swedish"
 msgstr ""
 
-#: src/Preferences.cpp:711
+#: src/Preferences.cpp:738
 msgid "Turkish"
 msgstr ""
 
-#: src/Preferences.cpp:712
+#: src/Preferences.cpp:739
 msgid "Ukrainian"
 msgstr ""
 
-#: src/Preferences.cpp:815
+#: src/Preferences.cpp:842
 #, fuzzy
 msgid "Change Language"
 msgstr "Sprog"
 
-#: src/Preferences.cpp:879
+#: src/Preferences.cpp:906
 msgid "There are no translations installed for aMule"
 msgstr ""
 
-#: src/Preferences.cpp:880
+#: src/Preferences.cpp:907
 #, fuzzy
 msgid "No languages available"
 msgstr "Ikke tilgængelig"
 
-#: src/Preferences.cpp:1011
+#: src/Preferences.cpp:1038
 msgid "no options available"
 msgstr ""
 
-#: src/Preferences.cpp:2182
+#: src/Preferences.cpp:2227
 msgid "Invalid category found, skipping"
 msgstr ""
 
-#: src/Preferences.cpp:2351
+#: src/Preferences.cpp:2396
 msgid "TCP port can't be higher than 65532 due to server UDP socket being TCP+3"
 msgstr ""
 
-#: src/Preferences.cpp:2352
+#: src/Preferences.cpp:2397
 #, c-format
 msgid "Default port will be used (%d)"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:298 src/Statistics.cpp:866
+#: src/PrefsUnifiedDlg.cpp:300 src/Statistics.cpp:866
 msgid "Connection"
 msgstr "Forbindelse"
 
-#: src/PrefsUnifiedDlg.cpp:299 src/SearchListCtrl.cpp:117
+#: src/PrefsUnifiedDlg.cpp:301 src/SearchListCtrl.cpp:117
 msgid "Directories"
 msgstr "Mapper"
 
-#: src/PrefsUnifiedDlg.cpp:300 src/Statistics.cpp:917
+#: src/PrefsUnifiedDlg.cpp:302 src/Statistics.cpp:917
 msgid "Servers"
 msgstr "Servere"
 
-#: src/PrefsUnifiedDlg.cpp:301 src/ServerListCtrl.cpp:96
+#: src/PrefsUnifiedDlg.cpp:303 src/ServerListCtrl.cpp:96
 msgid "Files"
 msgstr "Filer"
 
-#: src/PrefsUnifiedDlg.cpp:302
+#: src/PrefsUnifiedDlg.cpp:304
 msgid "Security"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:303
+#: src/PrefsUnifiedDlg.cpp:305
 msgid "Interface"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:310
+#: src/PrefsUnifiedDlg.cpp:312
 msgid "IP2Country"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:313
+#: src/PrefsUnifiedDlg.cpp:315
 msgid "Proxy"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:314
+#: src/PrefsUnifiedDlg.cpp:316
 msgid "Filters"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:315
+#: src/PrefsUnifiedDlg.cpp:317
 msgid "Remote Controls"
 msgstr "Fjern Kontrol"
 
-#: src/PrefsUnifiedDlg.cpp:316
+#: src/PrefsUnifiedDlg.cpp:318
 msgid "Online Signature"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:317
+#: src/PrefsUnifiedDlg.cpp:319
 msgid "Advanced"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:318
+#: src/PrefsUnifiedDlg.cpp:320
 msgid "Events"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:321
+#: src/PrefsUnifiedDlg.cpp:323
 msgid "Debugging"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:451
+#: src/PrefsUnifiedDlg.cpp:453
 msgid ""
 "The following variables will be substituted:\n"
 "    %PARTFILE - full path to the file\n"
 "    %PARTNAME - file name only"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:472
+#: src/PrefsUnifiedDlg.cpp:474
 msgid "Tray icon support requires libayatana-appindicator3 at compile time."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:488
+#: src/PrefsUnifiedDlg.cpp:490
 msgid "Not available on Wayland: the protocol does not report when a window is minimized, so this option cannot intercept the system minimize button. Workaround: launch aMule with `GDK_BACKEND=x11` to use XWayland instead."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:534
+#: src/PrefsUnifiedDlg.cpp:536
 msgid ""
 "Do not change these setting unless you know\n"
 "what you are doing, otherwise you can easily\n"
@@ -5673,247 +5701,261 @@ msgid ""
 "these settings."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:645
+#: src/PrefsUnifiedDlg.cpp:647
 #, c-format
 msgid "Failed to connect Cfg to widget with the ID %d and key %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:693
+#: src/PrefsUnifiedDlg.cpp:695
 #, c-format
 msgid "Failed to transfer data from Cfg to Widget with the ID %d and key %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:799
+#: src/PrefsUnifiedDlg.cpp:801
 msgid "The type of proxy you are connecting to"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1003
+#: src/PrefsUnifiedDlg.cpp:1020
 #, c-format
 msgid "Failed to transfer data from Widget to Cfg with the ID %d and key %s"
 msgstr ""
 
 #: src/PrefsUnifiedDlg.cpp:1103
+#, fuzzy
+msgid "No password set."
+msgstr "Undersøger password\n"
+
+#: src/PrefsUnifiedDlg.cpp:1132
+msgid "Guest access needs a password. Type one in the guest password field, or untick Enable guest access."
+msgstr ""
+
+#: src/PrefsUnifiedDlg.cpp:1144
 msgid ""
 "aMule must be restarted to enable these changes:\n"
 "\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1110
+#: src/PrefsUnifiedDlg.cpp:1151
 msgid "- TCP port changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1115
+#: src/PrefsUnifiedDlg.cpp:1156
 msgid "- UDP port changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1120
+#: src/PrefsUnifiedDlg.cpp:1161
 #, fuzzy
 msgid "- Network interface binding changed.\n"
 msgstr "Ydre Forbindelses Parametre"
 
-#: src/PrefsUnifiedDlg.cpp:1125
+#: src/PrefsUnifiedDlg.cpp:1166
 #, fuzzy
 msgid "- External connect port changed.\n"
 msgstr "Ydre Forbindelses Parametre"
 
-#: src/PrefsUnifiedDlg.cpp:1129
+#: src/PrefsUnifiedDlg.cpp:1170
 #, fuzzy
 msgid "- External connect acceptance changed.\n"
 msgstr "Ydre Forbindelses Parametre"
 
-#: src/PrefsUnifiedDlg.cpp:1133
+#: src/PrefsUnifiedDlg.cpp:1174
 #, fuzzy
 msgid "- External connect interface changed.\n"
 msgstr "Ydre Forbindelses Parametre"
 
-#: src/PrefsUnifiedDlg.cpp:1137
+#: src/PrefsUnifiedDlg.cpp:1178
 #, fuzzy
 msgid "- Protocol obfuscation support changed.\n"
 msgstr "Ydre Forbindelses Parametre"
 
-#: src/PrefsUnifiedDlg.cpp:1151
+#: src/PrefsUnifiedDlg.cpp:1193
 msgid "- amuleapi settings changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1160
+#: src/PrefsUnifiedDlg.cpp:1202
 msgid ""
 "Your Auto-update server list is empty.\n"
 "'Auto-update server list at startup' will be disabled."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1171
+#: src/PrefsUnifiedDlg.cpp:1213
 msgid ""
 "You have enabled external connections but have not specified a password.\n"
 "External connections cannot be enabled unless a valid password is specified."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1202
+#: src/PrefsUnifiedDlg.cpp:1246
+#, c-format
+msgid "The amuleapi password could not be saved: %s"
+msgstr ""
+
+#: src/PrefsUnifiedDlg.cpp:1276
 msgid "- Language changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1207
+#: src/PrefsUnifiedDlg.cpp:1281
 msgid "- Temp folder changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1212
+#: src/PrefsUnifiedDlg.cpp:1286
 msgid "- ED2K network enabled.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1245
+#: src/PrefsUnifiedDlg.cpp:1319
 msgid "The shared-file exclusion pattern is not a valid regular expression. The filter has been left disabled."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1247 src/PrefsUnifiedDlg.cpp:1841
+#: src/PrefsUnifiedDlg.cpp:1321 src/PrefsUnifiedDlg.cpp:1921
 msgid "Invalid regular expression"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1324
+#: src/PrefsUnifiedDlg.cpp:1398
 msgid ""
 "Both eD2k and Kad network are disabled.\n"
 "You won't be able to connect until you enable at least one of them."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1329
+#: src/PrefsUnifiedDlg.cpp:1403
 msgid ""
 "Kad will not start if your UDP port is disabled.\n"
 "Enable UDP port or disable Kad."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1385
+#: src/PrefsUnifiedDlg.cpp:1459
 msgid ""
 "\n"
 "You MUST restart aMule now.\n"
 "If you do not restart now, don't complain if anything bad happens.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1450
+#: src/PrefsUnifiedDlg.cpp:1524
 msgid "Could not register aMule for autostart at login. The autostart store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1452
+#: src/PrefsUnifiedDlg.cpp:1526
 msgid "Could not remove the autostart-at-login entry."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1453
+#: src/PrefsUnifiedDlg.cpp:1527
 #, fuzzy
 msgid "Autostart"
 msgstr "Auto Opdatering startet"
 
-#: src/PrefsUnifiedDlg.cpp:1468
+#: src/PrefsUnifiedDlg.cpp:1542
 msgid "Register file type"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1468
+#: src/PrefsUnifiedDlg.cpp:1542
 msgid "Register URL handler"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1476
+#: src/PrefsUnifiedDlg.cpp:1550
 #, c-format
 msgid "aMule only handles eD2k-compatible magnets. If you replace the current magnet handler (%s), BitTorrent magnet links will stop working - aMule cannot download BitTorrent content. Continue?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1481
+#: src/PrefsUnifiedDlg.cpp:1555
 #, c-format
 msgid "Another application currently opens .emulecollection files (%s). Replace it with aMule?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1486
+#: src/PrefsUnifiedDlg.cpp:1560
 #, c-format
 msgid "Another application is currently the default handler for these links (%s). Replace it with aMule?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1511
+#: src/PrefsUnifiedDlg.cpp:1585
 msgid "Could not register aMule for .emulecollection files. The registration store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1513
+#: src/PrefsUnifiedDlg.cpp:1587
 #, fuzzy
 msgid "Could not remove the file type registration."
 msgstr "Du prøver allerede at downloade denne fil %s"
 
-#: src/PrefsUnifiedDlg.cpp:1515
+#: src/PrefsUnifiedDlg.cpp:1589
 msgid "Could not register aMule as the URL handler. The registration store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1517
+#: src/PrefsUnifiedDlg.cpp:1591
 msgid "Could not remove the URL handler registration."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1587 src/PrefsUnifiedDlg.cpp:1614
+#: src/PrefsUnifiedDlg.cpp:1661 src/PrefsUnifiedDlg.cpp:1688
 #, fuzzy
 msgid "The web server and aMule API require external connections to be enabled."
 msgstr "Accepter ydre forbindelser"
 
-#: src/PrefsUnifiedDlg.cpp:1597
+#: src/PrefsUnifiedDlg.cpp:1671
 msgid "The aMule web server is deprecated. Consider running the aMule API instead."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1655
+#: src/PrefsUnifiedDlg.cpp:1735
 msgid ""
 "Your Auto-update servers list is in blank.\n"
 "Please fill in at least one URL to point to a valid server.met file.\n"
 "Click on the button \"List\" by this checkbox to enter an URL."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1796
+#: src/PrefsUnifiedDlg.cpp:1876
 msgid "Temporary files"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1801
+#: src/PrefsUnifiedDlg.cpp:1881
 msgid "Incoming files"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1806
+#: src/PrefsUnifiedDlg.cpp:1886
 msgid "Online Signatures"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1819
+#: src/PrefsUnifiedDlg.cpp:1899
 #, c-format
 msgid "Choose a folder for %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1843
+#: src/PrefsUnifiedDlg.cpp:1923
 #, fuzzy, c-format
 msgid "Would exclude %u of %u shared file"
 msgid_plural "Would exclude %u of %u shared files"
 msgstr[0] "Fandt %i kendte delte filer"
 msgstr[1] "Fandt %i kendte delte filer"
 
-#: src/PrefsUnifiedDlg.cpp:1860
+#: src/PrefsUnifiedDlg.cpp:1940
 msgid "Browse for videoplayer"
 msgstr "Gennemse efter Video Afspiller"
 
-#: src/PrefsUnifiedDlg.cpp:1864
+#: src/PrefsUnifiedDlg.cpp:1944
 msgid "Select browser"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1868
+#: src/PrefsUnifiedDlg.cpp:1948
 msgid "Select ffprobe binary"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1874
+#: src/PrefsUnifiedDlg.cpp:1954
 #, c-format
 msgid "Executable%s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1908
+#: src/PrefsUnifiedDlg.cpp:1988
 msgid "ffprobe not found on PATH or in the standard install locations. Install ffmpeg (which ships ffprobe) or use Browse to pick a binary manually."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1920
+#: src/PrefsUnifiedDlg.cpp:2000
 msgid "Reset the settings on this page to their default values?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1921
+#: src/PrefsUnifiedDlg.cpp:2001
 #, fuzzy
 msgid "Reset to defaults"
 msgstr "System standard"
 
-#: src/PrefsUnifiedDlg.cpp:1948
+#: src/PrefsUnifiedDlg.cpp:2028
 msgid "Edit server list"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1949
+#: src/PrefsUnifiedDlg.cpp:2029
 msgid ""
 "Add here URL's to download server.met files.\n"
 "Only one url on each line."
@@ -5921,153 +5963,153 @@ msgstr ""
 "Tilføj URLer hvor der kan hentes server.met filer.\n"
 "Kun en URL på hver linje."
 
-#: src/PrefsUnifiedDlg.cpp:2004
+#: src/PrefsUnifiedDlg.cpp:2084
 msgid "IP2Country update failed"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2149 src/PrefsUnifiedDlg.cpp:2180
+#: src/PrefsUnifiedDlg.cpp:2229 src/PrefsUnifiedDlg.cpp:2260
 msgid "Data by MaxMind GeoLite2"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2151 src/PrefsUnifiedDlg.cpp:2182
+#: src/PrefsUnifiedDlg.cpp:2231 src/PrefsUnifiedDlg.cpp:2262
 #, fuzzy
 msgid "Custom source"
 msgstr "Hele kilder"
 
-#: src/PrefsUnifiedDlg.cpp:2153 src/PrefsUnifiedDlg.cpp:2184
+#: src/PrefsUnifiedDlg.cpp:2233 src/PrefsUnifiedDlg.cpp:2264
 msgid "Data by DB-IP.com"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2204
+#: src/PrefsUnifiedDlg.cpp:2284
 #, c-format
 msgid "Status: Loaded%s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2206
+#: src/PrefsUnifiedDlg.cpp:2286
 #, c-format
 msgid "Status: Loaded%s - %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2210
+#: src/PrefsUnifiedDlg.cpp:2290
 msgid "Status: Failed to load - click 'Update now' to refresh."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2212
+#: src/PrefsUnifiedDlg.cpp:2292
 msgid "Status: Not found - click 'Update now' to download."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2270 src/PrefsUnifiedDlg.cpp:2294
+#: src/PrefsUnifiedDlg.cpp:2350 src/PrefsUnifiedDlg.cpp:2374
 #, fuzzy, c-format
 msgid "Update delay: %d second"
 msgid_plural "Update delay: %d seconds"
 msgstr[0] "Opdaterings interval : 5 sek"
 msgstr[1] "Opdaterings interval : 5 sek"
 
-#: src/PrefsUnifiedDlg.cpp:2278
+#: src/PrefsUnifiedDlg.cpp:2358
 #, fuzzy, c-format
 msgid "Time for average graph: %d minute"
 msgid_plural "Time for average graph: %d minutes"
 msgstr[0] "Tid for gennemsnitlig graf: 100 min"
 msgstr[1] "Tid for gennemsnitlig graf: 100 min"
 
-#: src/PrefsUnifiedDlg.cpp:2287
+#: src/PrefsUnifiedDlg.cpp:2367
 #, c-format
 msgid "Connections Graph Scale: %d"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2302
+#: src/PrefsUnifiedDlg.cpp:2382
 #, fuzzy, c-format
 msgid "File Buffer Size: %d byte"
 msgid_plural "File Buffer Size: %d bytes"
 msgstr[0] "Fil Buffer StÃžrrelse %i bytes"
 msgstr[1] "Fil Buffer StÃžrrelse %i bytes"
 
-#: src/PrefsUnifiedDlg.cpp:2312
+#: src/PrefsUnifiedDlg.cpp:2392
 #, c-format
 msgid "Upload Queue Size: %d client"
 msgid_plural "Upload Queue Size: %d clients"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/PrefsUnifiedDlg.cpp:2322
+#: src/PrefsUnifiedDlg.cpp:2402
 #, fuzzy, c-format
 msgid "Server connection refresh interval: %d minute"
 msgid_plural "Server connection refresh interval: %d minutes"
 msgstr[0] "Server forbindelses opdaterings interval %i min"
 msgstr[1] "Server forbindelses opdaterings interval %i min"
 
-#: src/PrefsUnifiedDlg.cpp:2327
+#: src/PrefsUnifiedDlg.cpp:2407
 msgid "Server connection refresh interval: Disabled"
 msgstr "Server forbindelses opdaterings interval: Inaktiv"
 
-#: src/PrefsUnifiedDlg.cpp:2371
+#: src/PrefsUnifiedDlg.cpp:2451
 #, fuzzy
 msgid "disabled"
 msgstr "deaktiver"
 
-#: src/PrefsUnifiedDlg.cpp:2397
+#: src/PrefsUnifiedDlg.cpp:2477
 #, c-format
 msgid "Execute command on '%s' event"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2404
+#: src/PrefsUnifiedDlg.cpp:2484
 msgid "Enable command execution on core"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2416
+#: src/PrefsUnifiedDlg.cpp:2496
 msgid "Core command:"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2432
+#: src/PrefsUnifiedDlg.cpp:2512
 msgid "Enable command execution on GUI"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2444
+#: src/PrefsUnifiedDlg.cpp:2524
 msgid "GUI command:"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2460
+#: src/PrefsUnifiedDlg.cpp:2540
 msgid "The following variables will be replaced:"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2628
+#: src/PrefsUnifiedDlg.cpp:2708
 msgid ""
 "The following folders look like system or sensitive locations:\n"
 "\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2633
+#: src/PrefsUnifiedDlg.cpp:2713
 msgid "Sharing them recursively will publish every file underneath on the eD2k/Kad networks. Do you really want to do this?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2636
+#: src/PrefsUnifiedDlg.cpp:2716
 msgid "Confirm shared folders"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2664
+#: src/PrefsUnifiedDlg.cpp:2744
 #, fuzzy
 msgid "Reloading shared files..."
 msgstr "Fandt %i kendte delte filer"
 
-#: src/PrefsUnifiedDlg.cpp:2665
+#: src/PrefsUnifiedDlg.cpp:2745
 msgid "Scanning for subdirectories..."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2666
+#: src/PrefsUnifiedDlg.cpp:2746
 msgid "Updating shared folders"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2693
+#: src/PrefsUnifiedDlg.cpp:2773
 #, c-format
 msgid "Scanned %u directories..."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2743
+#: src/PrefsUnifiedDlg.cpp:2823
 #, c-format
 msgid "Reloading shared files: %u files scanned"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2793
+#: src/PrefsUnifiedDlg.cpp:2873
 #, fuzzy
 msgid "Shared folder"
 msgstr "Delte Filer"

--- a/po/de.po
+++ b/po/de.po
@@ -13,8 +13,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-28 12:12+0200\n"
-"PO-Revision-Date: 2026-07-27 10:18+0000\n"
+"POT-Creation-Date: 2026-07-28 08:06+0200\n"
+"PO-Revision-Date: 2026-07-27 11:34+0000\n"
 "Last-Translator: Werner Mahr <werner@vollstreckernet.de>\n"
 "Language-Team: German <>\n"
 "Language: de\n"
@@ -150,7 +150,7 @@ msgstr "Installieren"
 msgid "Not now"
 msgstr "Nicht jetzt"
 
-#: src/AppImageIntegration.cpp:422 src/amuleDlg.cpp:665
+#: src/AppImageIntegration.cpp:422 src/amuleDlg.cpp:600
 msgid "Don't ask again"
 msgstr "Nicht erneut fragen"
 
@@ -212,83 +212,83 @@ msgstr "Fehler beim Öffnen der ED2KLinks-Datei."
 msgid "WARNING: You can't add yourself as a source for an eD2k link while having a lowid."
 msgstr "WARNUNG: Man kann sich nicht als Quelle für einen eD2k-Verweis hinzufügen während man eine niedrige ID hat."
 
-#: src/amule.cpp:301
+#: src/amule.cpp:300
 msgid "Now, exiting main app..."
 msgstr "Beende nun Hauptanwendung ..."
 
-#: src/amule.cpp:331
+#: src/amule.cpp:330
 #, c-format
 msgid "Terminating amuleweb instance with pid '%d' ... "
 msgstr "Beende amuleweb-Instanz mit pid '%d' ... "
 
-#: src/amule.cpp:335
+#: src/amule.cpp:334
 #, c-format
 msgid "Killing amuleweb instance with pid '%d' ... "
 msgstr "Erzwinge Beenden der amuleweb-Instanz mit pid '%d' ... "
 
-#: src/amule.cpp:337 src/amule.cpp:350 src/ClientRef.cpp:180
-#: src/SearchDlg.cpp:1041 src/ServerListCtrl.cpp:98
+#: src/amule.cpp:336 src/amule.cpp:349 src/ClientRef.cpp:180
+#: src/SearchDlg.cpp:880 src/ServerListCtrl.cpp:98
 msgid "Failed"
 msgstr "Fehlgeschlagen"
 
-#: src/amule.cpp:344
+#: src/amule.cpp:343
 #, fuzzy, c-format
 msgid "Terminating amuleapi instance with pid '%d' ... "
 msgstr "Beende amuleweb-Instanz mit pid '%d' ... "
 
-#: src/amule.cpp:348
+#: src/amule.cpp:347
 #, fuzzy, c-format
 msgid "Killing amuleapi instance with pid '%d' ... "
 msgstr "Erzwinge Beenden der amuleweb-Instanz mit pid '%d' ... "
 
-#: src/amule.cpp:356
+#: src/amule.cpp:355
 msgid "aMule OnExit: Terminating core."
 msgstr "aMule OnExit: Beende Programmkern."
 
-#: src/amule.cpp:467
+#: src/amule.cpp:466
 msgid "aMule shutdown completed."
 msgstr "aMule-Herunterfahren abgeschlossen."
 
-#: src/amule.cpp:471
+#: src/amule.cpp:470
 msgid "Memory debug results for aMule exit:"
 msgstr "Speicherfehlerbehebungsresultate für aMule-Beendung:"
 
-#: src/amule.cpp:652
+#: src/amule.cpp:651
 #, c-format
 msgid "Binding aMule's peer-to-peer traffic to interface: %s (HTTP updates use the default route)"
 msgstr ""
 
-#: src/amule.cpp:656
+#: src/amule.cpp:655
 #, c-format
 msgid "Binding all network traffic to interface: %s"
 msgstr ""
 
-#: src/amule.cpp:660
+#: src/amule.cpp:659
 #, c-format
 msgid "WARNING: configured network interface '%s' was not found - traffic is NOT bound to it and may leave via the default route. Check the interface name in Preferences."
 msgstr ""
 
-#: src/amule.cpp:666
+#: src/amule.cpp:665
 #, c-format
 msgid "WARNING: binding to network interface '%s' requires elevated privileges and was NOT applied - traffic may leave via the default route. Grant the capability (e.g. 'sudo setcap cap_net_raw+ep' on the aMule binary) or run with sufficient privileges."
 msgstr ""
 
-#: src/amule.cpp:674
+#: src/amule.cpp:673
 #, c-format
 msgid "WARNING: could not bind to network interface '%s' - traffic may leave via the default route."
 msgstr ""
 
-#: src/amule.cpp:733
+#: src/amule.cpp:732
 msgid "Your locale has been changed to System Default due to a configuration change. Sorry."
 msgstr "Deine Locale wurde wegen einer Konfigurationsänderung auf Systemstandard geändert. Sorry."
 
-#: src/amule.cpp:735 src/amule.cpp:1589 src/CatDialog.cpp:128
+#: src/amule.cpp:734 src/amule.cpp:1581 src/CatDialog.cpp:128
 #: src/CatDialog.cpp:136 src/CatDialog.cpp:149 src/ServerList.cpp:366
 #: src/ServerListCtrl.cpp:152
 msgid "Info"
 msgstr "Info"
 
-#: src/amule.cpp:742
+#: src/amule.cpp:741
 msgid ""
 "\n"
 "EC configuration"
@@ -296,20 +296,20 @@ msgstr ""
 "\n"
 "EC-Konfiguration"
 
-#: src/amule.cpp:745
+#: src/amule.cpp:744
 msgid "Password set and external connections enabled."
 msgstr "Passwort eingestellt und externe Verbindungen aktiviert."
 
-#: src/amule.cpp:755 src/KadDlg.cpp:176 src/KadDlg.cpp:185
-#: src/PrefsUnifiedDlg.cpp:1461 src/SharedFilesCtrl.cpp:476
+#: src/amule.cpp:754 src/KadDlg.cpp:176 src/KadDlg.cpp:185
+#: src/PrefsUnifiedDlg.cpp:1387 src/SharedFilesCtrl.cpp:476
 msgid "WARNING"
 msgstr "WARNUNG"
 
-#: src/amule.cpp:992
+#: src/amule.cpp:991
 msgid "Network bootstrap"
 msgstr "Netzwerk-Bootstrap"
 
-#: src/amule.cpp:997
+#: src/amule.cpp:996
 msgid ""
 "aMule has detected missing network bootstrap files.\n"
 "Select which ones to download:"
@@ -317,52 +317,52 @@ msgstr ""
 "aMule hat fehlende Netzwerk-Bootstrap-Dateien erkannt.\n"
 "Wählen Sie aus, welche heruntergeladen werden sollen:"
 
-#: src/amule.cpp:1006 src/FirstRunWizard.cpp:411
+#: src/amule.cpp:1005 src/FirstRunWizard.cpp:411
 msgid "eD2k server list (server.met)"
 msgstr "eD2k-Serverliste (server.met)"
 
-#: src/amule.cpp:1013 src/FirstRunWizard.cpp:416
+#: src/amule.cpp:1012 src/FirstRunWizard.cpp:416
 msgid "Kad bootstrap nodes (nodes.dat)"
 msgstr "Kad-Bootstrap-Knoten (nodes.dat)"
 
-#: src/amule.cpp:1103
+#: src/amule.cpp:1102
 #, c-format
 msgid "web server running on pid %d"
 msgstr "Webserver läuft mit pid %d"
 
-#: src/amule.cpp:1116
+#: src/amule.cpp:1115
 msgid "You requested to run web server on startup, but the amuleweb binary cannot be run. Please install the package containing aMule web server, or build aMule from source with -DBUILD_WEBSERVER=YES and install it."
 msgstr "Du hast \"amuleweb zusammen mit aMule starten\" aktiviert, allerdings kann die amuleweb-Programmdatei nicht gestartet werden. Bitte installiere das Paket, das amuleweb enthält, oder kompiliere aMule mit -DBUILD_WEBSERVER=YES  neu und installiere dies."
 
-#: src/amule.cpp:1121 src/amule.cpp:1185 src/amule.cpp:1299 src/amule.cpp:1601
+#: src/amule.cpp:1120 src/amule.cpp:1177 src/amule.cpp:1291 src/amule.cpp:1593
 #: src/amule-remote-gui.cpp:603 src/amule-remote-gui.cpp:671
 #: src/amule-remote-gui.cpp:709 src/amule-remote-gui.cpp:1282
 #: src/amule-remote-gui.cpp:1345 src/amule-remote-gui.cpp:1372
-#: src/DownloadQueue.cpp:1481 src/PrefsUnifiedDlg.cpp:1247
+#: src/DownloadQueue.cpp:1481
 msgid "ERROR"
 msgstr "FEHLER"
 
-#: src/amule.cpp:1174
+#: src/amule.cpp:1166
 #, fuzzy, c-format
 msgid "amuleapi running on pid %d"
 msgstr "Webserver läuft mit pid %d"
 
-#: src/amule.cpp:1180
+#: src/amule.cpp:1172
 #, fuzzy
 msgid "You requested to run amuleapi on startup, but the amuleapi binary cannot be run. Please install the package containing aMule's REST API server, or build aMule from source with -DBUILD_AMULEAPI=YES and install it."
 msgstr "Du hast \"amuleweb zusammen mit aMule starten\" aktiviert, allerdings kann die amuleweb-Programmdatei nicht gestartet werden. Bitte installiere das Paket, das amuleweb enthält, oder kompiliere aMule mit -DBUILD_WEBSERVER=YES  neu und installiere dies."
 
-#: src/amule.cpp:1267
+#: src/amule.cpp:1259
 #, c-format
 msgid "Could not bind ports to the specified address: %s"
 msgstr "Kann Ports nicht mit der festgelegten Adresse verbinden: %s"
 
-#: src/amule.cpp:1291
+#: src/amule.cpp:1283
 #, c-format
 msgid "Port %u is not available. You will be LOWID\n"
 msgstr "Port %u ist nicht erreichbar. Du wirst eine niedrige ID erhalten\n"
 
-#: src/amule.cpp:1296
+#: src/amule.cpp:1288
 #, c-format
 msgid ""
 "Port %u is not available!\n"
@@ -377,48 +377,48 @@ msgstr ""
 "\n"
 "Bitte überprüfe deine Netzwerkeinstellungen, um sicherzugehen, dass der Port für ein- und ausgehenden Traffic geöffnet ist."
 
-#: src/amule.cpp:1393
+#: src/amule.cpp:1385
 msgid "Failed to create OnlineSig File"
 msgstr "Erstellen der OnlineSig-Datei gescheitert"
 
-#: src/amule.cpp:1401
+#: src/amule.cpp:1393
 msgid "Failed to create aMule OnlineSig File"
 msgstr "Erstellen der aMule OnlineSig-Datei gescheitert"
 
-#: src/amule.cpp:1564
+#: src/amule.cpp:1556
 msgid "The selected locale seems not to be installed on your box. (Note: I'll try to set it anyway)"
 msgstr "Die ausgewählte Locale scheint nicht auf dem System installiert zu sein.(INFO: Ich werde trotzdem versuchen, sie zu setzen)"
 
-#: src/amule.cpp:1574
+#: src/amule.cpp:1566
 #, c-format
 msgid "This is the first time you run aMule %s"
 msgstr "Dies ist das erste Mal, dass du aMule %s startest"
 
-#: src/amule.cpp:1577
+#: src/amule.cpp:1569
 msgid "This version is a testing version, updated daily, and\n"
 msgstr "Dies ist eine Testversion, täglich aktualisiert, und\n"
 
-#: src/amule.cpp:1578
+#: src/amule.cpp:1570
 msgid "we give no warranty it won't break anything, burn your house,\n"
 msgstr "wir garantieren nicht, dass sie keine Daten zerstört, dein Haus anzündet\n"
 
-#: src/amule.cpp:1579
+#: src/amule.cpp:1571
 msgid "or kill your dog. But it *should* be safe to use anyway.\n"
 msgstr "oder deinen Hund tötet. Aber es *sollte* sicher sein, sie zu benutzen.\n"
 
-#: src/amule.cpp:1584
+#: src/amule.cpp:1576
 msgid "More information, support and new releases can found at our homepage,\n"
 msgstr "Mehr Informationen und neue Releases können auf unserer Homepage gefunden werden\n"
 
-#: src/amule.cpp:1585
+#: src/amule.cpp:1577
 msgid "at https://amule-org.github.io, or in our IRC channel #aMule at irc.libera.chat.\n"
 msgstr "unter https://amule-org.github.io, oder in unserem IRC-Channel #amule auf irc.libera.chat.\n"
 
-#: src/amule.cpp:1587
+#: src/amule.cpp:1579
 msgid "Feel free to report any bugs to https://github.com/amule-org/amule/issues"
 msgstr "Bitte melde Fehler unter https://github.com/amule-org/amule/issues"
 
-#: src/amule.cpp:1599
+#: src/amule.cpp:1591
 msgid ""
 "The folder for Online Signature files you specified is INVALID!\n"
 " OnlineSignature will be DISABLED until you fix it on preferences."
@@ -426,137 +426,137 @@ msgstr ""
 "Das angegebene Verzeichnis für die Online-Signaturdateien ist UNGÜLTIG!\n"
 "Online-Signatur wird bis zur Fehlerbehebung in den Einstellungen DEAKTIVIERT."
 
-#: src/amule.cpp:1662
+#: src/amule.cpp:1654
 msgid "Server hostname notified"
 msgstr "Server Hostname benachrichtigt"
 
-#: src/amule.cpp:2039
+#: src/amule.cpp:2031
 #, c-format
 msgid "Disk space preallocation for file '%s' failed: %s"
 msgstr "Speicherplatzvorbelegung für Datei '%s' fehlgeschlagen: %s"
 
-#: src/amule.cpp:2168
+#: src/amule.cpp:2160
 msgid "ERROR: can't open logfile"
 msgstr "FEHLER: kann Logdatei nicht öffnen"
 
-#: src/amule.cpp:2172
+#: src/amule.cpp:2164
 msgid "WARNING: logfile is empty. Something is wrong."
 msgstr "WARNUNG: Logdatei ist leer. Etwas ist falsch."
 
-#: src/amule.cpp:2189
+#: src/amule.cpp:2181
 msgid "Log has been reset"
 msgstr "Das Log wurde zurückgesetzt"
 
-#: src/amule.cpp:2213
+#: src/amule.cpp:2205
 #, c-format
 msgid "ServerMessage: %s"
 msgstr "Servernachricht: %s"
 
-#: src/amule.cpp:2256 src/IP2Country.cpp:220 src/IPFilter.cpp:514
+#: src/amule.cpp:2248 src/IP2Country.cpp:220 src/IPFilter.cpp:514
 #: src/ServerList.cpp:875
 #, c-format
 msgid "Skipped download of %s, because requested file is not newer."
 msgstr "Lade %s nicht herunter, weil die angeforderte Datei nicht neuer ist."
 
-#: src/amule.cpp:2259
+#: src/amule.cpp:2251
 msgid "Failed to download the nodes list."
 msgstr "Knotenliste kann nicht geholt werden."
 
-#: src/amule.cpp:2322
+#: src/amule.cpp:2314
 msgid "Failed to open the downloaded version check file"
 msgstr "Konnte heruntergeladene Datei zur Versionsprüfung nicht öffnen"
 
-#: src/amule.cpp:2325 src/amule.cpp:2344
+#: src/amule.cpp:2317 src/amule.cpp:2336
 msgid "Corrupted version check file"
 msgstr "Fehlerhafte Versionsprüfungsdatei"
 
-#: src/amule.cpp:2367
+#: src/amule.cpp:2359
 msgid "You are using an outdated version of aMule!"
 msgstr "Du benutzt eine veraltete aMule-Version!"
 
-#: src/amule.cpp:2369
+#: src/amule.cpp:2361
 #, c-format
 msgid "Your aMule version is %i.%i.%i and the latest version is %li.%li.%li"
 msgstr "Diese Version von aMule ist %i.%i.%i und die aktuelle Version ist %li.%li.%li"
 
-#: src/amule.cpp:2373
+#: src/amule.cpp:2365
 msgid "The latest version can always be found at https://github.com/amule-org/amule/releases/latest"
 msgstr "Die neueste Version kann man immer auf https://github.com/amule-org/amule/releases/latest finden."
 
-#: src/amule.cpp:2376
+#: src/amule.cpp:2368
 #, c-format
 msgid "WARNING: Your aMuled version is outdated: %i.%i.%i < %li.%li.%li"
 msgstr "WARNUNG: Diese Version von aMuled ist veraltet: %i.%i.%i < %li.%li.%li"
 
-#: src/amule.cpp:2382
+#: src/amule.cpp:2374
 msgid "Your copy of aMule is up to date."
 msgstr "Deine Kopie von aMule ist aktuell."
 
-#: src/amule.cpp:2389
+#: src/amule.cpp:2381
 msgid "Failed to download the version check file"
 msgstr "Konnte die Versionsprüfungsdatei nicht herunterladen"
 
-#: src/amule.cpp:2558 src/amule-remote-gui.cpp:1133
+#: src/amule.cpp:2550 src/amule-remote-gui.cpp:1133
 #, c-format
 msgid "Users: %s | Files: %s"
 msgstr "Benutzer: %s | Dateien: %s"
 
-#: src/amule.cpp:2559 src/amule-remote-gui.cpp:1134
+#: src/amule.cpp:2551 src/amule-remote-gui.cpp:1134
 #, c-format
 msgid "Users: E: %s K: %s | Files: E: %s K: %s"
 msgstr "Benutzer: E: %s K: %s | Dateien: E: %s K: %s"
 
-#: src/amule.cpp:2573 src/amule-remote-gui.cpp:1147
+#: src/amule.cpp:2565 src/amule-remote-gui.cpp:1147
 msgid "No networks selected"
 msgstr "Keine Netzwerke ausgewählt"
 
-#: src/amule.cpp:2641 src/TextClient.cpp:903
+#: src/amule.cpp:2633 src/TextClient.cpp:903
 msgid "with LowID"
 msgstr "mit niedriger ID"
 
-#: src/amule.cpp:2641 src/TextClient.cpp:904
+#: src/amule.cpp:2633 src/TextClient.cpp:904
 msgid "with HighID"
 msgstr "mit hoher ID"
 
-#: src/amule.cpp:2643
+#: src/amule.cpp:2635
 #, c-format
 msgid "Connected to %s %s"
 msgstr "Verbunden zu %s %s"
 
-#: src/amule.cpp:2648
+#: src/amule.cpp:2640
 #, c-format
 msgid "Connecting to %s"
 msgstr "Verbinde zu %s"
 
-#: src/amule.cpp:2650
+#: src/amule.cpp:2642
 msgid "Disconnected from eD2k"
 msgstr "eD2k getrennt"
 
-#: src/amule.cpp:2659
+#: src/amule.cpp:2651
 msgid "Kad started."
 msgstr "Kad gestartet."
 
-#: src/amule.cpp:2661
+#: src/amule.cpp:2653
 msgid "Kad stopped."
 msgstr "Kad beendet."
 
-#: src/amule.cpp:2669
+#: src/amule.cpp:2661
 msgid "Connected to Kad (ok)"
 msgstr "Kad verbunden (ok)"
 
-#: src/amule.cpp:2671
+#: src/amule.cpp:2663
 msgid "Connected to Kad (firewalled)"
 msgstr "Kad verbunden (firewalled)"
 
-#: src/amule.cpp:2675
+#: src/amule.cpp:2667
 msgid "Disconnected from Kad"
 msgstr "Kad getrennt"
 
-#: src/amule.cpp:2707
+#: src/amule.cpp:2699
 msgid "Kad network cannot be used if UDP port is disabled on preferences, not starting."
 msgstr "Kad-Netzwerk kann mit deaktiviertem UDP-Port nicht benutzt werden, nicht gestartet."
 
-#: src/amule.cpp:2711
+#: src/amule.cpp:2703
 msgid "Kad network disabled on preferences, not connecting."
 msgstr "Kad-Netzwerk ist in den Voreinstellungen deaktiviert, kein Verbindungsversuch."
 
@@ -581,68 +581,30 @@ msgstr "Kann keine Pid-Datei erstellen"
 msgid "ERROR: %s"
 msgstr "FEHLER: %s"
 
-#: src/amuleDlg.cpp:250
+#: src/amuleDlg.cpp:236
 #, c-format
 msgid "This is aMule %s based on eMule."
 msgstr "Dies ist aMule %s, basierend auf eMule."
 
-#: src/amuleDlg.cpp:251
+#: src/amuleDlg.cpp:237
 #, c-format
 msgid "Running on %s"
 msgstr "Läuft auf %s"
 
-#: src/amuleDlg.cpp:253
+#: src/amuleDlg.cpp:239
 msgid "Visit https://github.com/amule-org/amule/releases/latest to check if a new version is available."
 msgstr "Besuche https://github.com/amule-org/amule/releases/latest um zu sehen, ob eine neue Version verfügbar ist."
 
-#: src/amuleDlg.cpp:282
+#: src/amuleDlg.cpp:268
 msgid "FATAL ERROR: Failed to create Timer"
 msgstr "UNBEHEBBARER FEHLER: Es konnte kein Zeitgeber erstellt werden."
 
-#: src/amuleDlg.cpp:361 src/amuleDlg.cpp:1810 src/amuleDlg.cpp:2056
-#: src/muuli_wdr.cpp:1492 src/muuli_wdr.cpp:3439
-msgid "Networks"
-msgstr "Netzwerke"
-
-#: src/amuleDlg.cpp:362 src/amuleDlg.cpp:1816 src/muuli_wdr.cpp:3440
-msgid "Searches"
-msgstr "Suchen"
-
-#: src/amuleDlg.cpp:363 src/amuleDlg.cpp:1822 src/DownloadListCtrl.cpp:740
-#: src/muuli_wdr.cpp:392 src/muuli_wdr.cpp:1585 src/muuli_wdr.cpp:3441
-#: src/Statistics.cpp:829
-msgid "Downloads"
-msgstr "Downloads"
-
-#: src/amuleDlg.cpp:364 src/amuleDlg.cpp:1828 src/muuli_wdr.cpp:3315
-msgid "Shared files"
-msgstr "Freigegebene Dateien"
-
-#: src/amuleDlg.cpp:365 src/amuleDlg.cpp:1834 src/muuli_wdr.cpp:2947
-#: src/muuli_wdr.cpp:3397 src/muuli_wdr.cpp:3444
-msgid "Messages"
-msgstr "Nachrichten"
-
-#: src/amuleDlg.cpp:366 src/amuleDlg.cpp:1840 src/muuli_wdr.cpp:3445
-#: src/PrefsUnifiedDlg.cpp:314 src/Statistics.cpp:779 src/Statistics.cpp:1235
-msgid "Statistics"
-msgstr "Statistiken"
-
-#: src/amuleDlg.cpp:368 src/amuleDlg.cpp:1847 src/muuli_wdr.cpp:3447
-#: src/PrefsUnifiedDlg.cpp:330 src/utils/wxCas/src/wxcasprefs.cpp:39
-msgid "Preferences"
-msgstr "Einstellungen"
-
-#: src/amuleDlg.cpp:371
-msgid "Navigate"
-msgstr ""
-
-#: src/amuleDlg.cpp:657
+#: src/amuleDlg.cpp:592
 #, fuzzy
 msgid "New version available"
 msgstr "Nicht verfügbar"
 
-#: src/amuleDlg.cpp:661
+#: src/amuleDlg.cpp:596
 #, fuzzy, c-format
 msgid ""
 "A new version of aMule (%s) is available.\n"
@@ -652,184 +614,217 @@ msgid ""
 "Would you like to open the download page?"
 msgstr "Die neueste Version kann man immer auf https://github.com/amule-org/amule/releases/latest finden."
 
-#: src/amuleDlg.cpp:743
+#: src/amuleDlg.cpp:678
 msgid "aMule dialog destroyed"
 msgstr "aMule Dialog zerstört."
 
-#: src/amuleDlg.cpp:766 src/DataToText.cpp:68 src/IPFilter.cpp:547
+#: src/amuleDlg.cpp:701 src/DataToText.cpp:68 src/IPFilter.cpp:547
 msgid "Connecting"
 msgstr "Verbinden"
 
-#: src/amuleDlg.cpp:958
+#: src/amuleDlg.cpp:893
 msgid "eD2k: Connecting"
 msgstr "eD2k: Baue Verbindung auf"
 
-#: src/amuleDlg.cpp:962
+#: src/amuleDlg.cpp:897
 msgid "eD2k: Disconnected"
 msgstr "eD2k: Verbindung getrennt"
 
-#: src/amuleDlg.cpp:968
+#: src/amuleDlg.cpp:903
 msgid "Kad: Firewalled"
 msgstr "Kad: Firewalled"
 
-#: src/amuleDlg.cpp:972
+#: src/amuleDlg.cpp:907
 msgid "Kad: Connected"
 msgstr "Kad: Verbunden"
 
-#: src/amuleDlg.cpp:977
+#: src/amuleDlg.cpp:912
 msgid "Kad: Connecting"
 msgstr "Kad: Baue Verbindung auf"
 
-#: src/amuleDlg.cpp:981
+#: src/amuleDlg.cpp:916
 msgid "Kad: Off"
 msgstr "Kad: aus"
 
-#: src/amuleDlg.cpp:1029 src/DownloadListCtrl.cpp:505
+#: src/amuleDlg.cpp:964 src/DownloadListCtrl.cpp:505
 #: src/DownloadListCtrl.cpp:749 src/FriendListCtrl.cpp:180
 #: src/muuli_wdr.cpp:731 src/muuli_wdr.cpp:782 src/muuli_wdr.cpp:846
-#: src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2252 src/muuli_wdr.cpp:2337
-#: src/muuli_wdr.cpp:3085 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
+#: src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2224 src/muuli_wdr.cpp:2309
+#: src/muuli_wdr.cpp:3057 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
 #: src/ServerListCtrl.cpp:606 src/TransferWnd.cpp:378
 #: src/utils/wxCas/src/wxcasprefs.cpp:235
 msgid "Cancel"
 msgstr "Abbruch"
 
-#: src/amuleDlg.cpp:1030
+#: src/amuleDlg.cpp:965
 msgid "Stop the current connection attempts"
 msgstr "Beendet die derzeitigen Verbindungsversuche"
 
-#: src/amuleDlg.cpp:1035 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976
-#: src/muuli_wdr.cpp:2475
+#: src/amuleDlg.cpp:970 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976
+#: src/muuli_wdr.cpp:2447
 msgid "Disconnect"
 msgstr "Trennen"
 
-#: src/amuleDlg.cpp:1036
+#: src/amuleDlg.cpp:971
 msgid "Disconnect from the currently connected networks"
 msgstr "Von den momentan verbundenen Netzwerken trennen."
 
-#: src/amuleDlg.cpp:1041 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979
-#: src/muuli_wdr.cpp:2630 src/muuli_wdr.cpp:3082 src/muuli_wdr.cpp:3437
+#: src/amuleDlg.cpp:976 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979
+#: src/muuli_wdr.cpp:2602 src/muuli_wdr.cpp:3054 src/muuli_wdr.cpp:3409
 msgid "Connect"
 msgstr "Verbinden"
 
-#: src/amuleDlg.cpp:1042
+#: src/amuleDlg.cpp:977
 msgid "Connect to the currently enabled networks"
 msgstr "Mit den aktuell aktivierten Netzwerken verbinden."
 
-#: src/amuleDlg.cpp:1154
+#: src/amuleDlg.cpp:1089
 #, c-format
 msgid "Up: %.1f%s (%.1f) | Down: %.1f%s (%.1f)"
 msgstr "Up: %.1f%s (%.1f) | Down: %.1f%s (%.1f)"
 
-#: src/amuleDlg.cpp:1156 src/amuleDlg.cpp:1158 src/amuleDlg.cpp:1162
-#: src/amuleDlg.cpp:1164 src/amuleDlg.cpp:1175 src/amuleDlg.cpp:1177
+#: src/amuleDlg.cpp:1091 src/amuleDlg.cpp:1093 src/amuleDlg.cpp:1097
+#: src/amuleDlg.cpp:1099 src/amuleDlg.cpp:1110 src/amuleDlg.cpp:1112
 #: src/MuleTrayIcon.cpp:796 src/MuleTrayIcon.cpp:799
 msgid " MB/s"
 msgstr " MB/s"
 
-#: src/amuleDlg.cpp:1156 src/amuleDlg.cpp:1158 src/amuleDlg.cpp:1162
-#: src/amuleDlg.cpp:1164 src/amuleDlg.cpp:1175 src/amuleDlg.cpp:1177
+#: src/amuleDlg.cpp:1091 src/amuleDlg.cpp:1093 src/amuleDlg.cpp:1097
+#: src/amuleDlg.cpp:1099 src/amuleDlg.cpp:1110 src/amuleDlg.cpp:1112
 #: src/MuleTrayIcon.cpp:796 src/MuleTrayIcon.cpp:799
 #: src/utils/wxCas/src/wxcasframe.cpp:1041
 msgid " kB/s"
 msgstr " kB/s"
 
-#: src/amuleDlg.cpp:1161
+#: src/amuleDlg.cpp:1096
 #, c-format
 msgid "Up: %.1f%s | Down: %.1f%s"
 msgstr "Up: %.1f%s | Down: %.1f%s"
 
-#: src/amuleDlg.cpp:1193
+#: src/amuleDlg.cpp:1128
 #, c-format
 msgid "aMule (%s | Connected)"
 msgstr "aMule (%s | Verbunden)"
 
-#: src/amuleDlg.cpp:1195
+#: src/amuleDlg.cpp:1130
 #, c-format
 msgid "aMule (%s | Disconnected)"
 msgstr "aMule (%s | Getrennt)"
 
-#: src/amuleDlg.cpp:1248
+#: src/amuleDlg.cpp:1183
 #, c-format
 msgid "Do you really want to exit %s?"
 msgstr "%s wirklich beenden?"
 
-#: src/amuleDlg.cpp:1250
+#: src/amuleDlg.cpp:1185
 msgid "Exit confirmation"
 msgstr "Beenden bestätigen"
 
-#: src/amuleDlg.cpp:1613
+#: src/amuleDlg.cpp:1548
 msgid "Launch Command: "
 msgstr "Startbefehl: "
 
-#: src/amuleDlg.cpp:1632 src/muuli_wdr.cpp:1972 src/Preferences.cpp:979
+#: src/amuleDlg.cpp:1567 src/muuli_wdr.cpp:1971 src/Preferences.cpp:951
 msgid "- default -"
 msgstr "- Voreinstellung -"
 
-#: src/amuleDlg.cpp:1660
+#: src/amuleDlg.cpp:1595
 #, c-format
 msgid "Skin directory '%s' does not exist"
 msgstr "Skin-Verzeichnis '%s' existiert nicht"
 
-#: src/amuleDlg.cpp:1663
+#: src/amuleDlg.cpp:1598
 #, c-format
 msgid "WARNING: Unable to open skin file '%s' for read"
 msgstr "WARNUNG: Öffnen der Skin-Datei '%s' zum Lesen nicht möglich"
 
-#: src/amuleDlg.cpp:1814 src/muuli_wdr.cpp:3439
+#: src/amuleDlg.cpp:1722 src/amuleDlg.cpp:1968 src/muuli_wdr.cpp:1485
+#: src/muuli_wdr.cpp:3411
+msgid "Networks"
+msgstr "Netzwerke"
+
+#: src/amuleDlg.cpp:1726 src/muuli_wdr.cpp:3411
 msgid "Networks Window"
 msgstr "Übersicht der verwendeten Netzwerke"
 
-#: src/amuleDlg.cpp:1820 src/muuli_wdr.cpp:3440
+#: src/amuleDlg.cpp:1728 src/muuli_wdr.cpp:3412
+msgid "Searches"
+msgstr "Suchen"
+
+#: src/amuleDlg.cpp:1732 src/muuli_wdr.cpp:3412
 msgid "Searches Window"
 msgstr "Dateisuche in den verbundenen Netzwerken"
 
-#: src/amuleDlg.cpp:1826 src/muuli_wdr.cpp:3441
+#: src/amuleDlg.cpp:1734 src/DownloadListCtrl.cpp:740 src/muuli_wdr.cpp:392
+#: src/muuli_wdr.cpp:1578 src/muuli_wdr.cpp:3413 src/Statistics.cpp:829
+msgid "Downloads"
+msgstr "Downloads"
+
+#: src/amuleDlg.cpp:1738 src/muuli_wdr.cpp:3413
 msgid "Downloads Window"
 msgstr "Download-Fenster"
 
-#: src/amuleDlg.cpp:1832 src/muuli_wdr.cpp:3443
+#: src/amuleDlg.cpp:1740 src/muuli_wdr.cpp:3287
+msgid "Shared files"
+msgstr "Freigegebene Dateien"
+
+#: src/amuleDlg.cpp:1744 src/muuli_wdr.cpp:3415
 msgid "Shared Files Window"
 msgstr "Übersicht der freigegebenen Dateien"
 
-#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3444
+#: src/amuleDlg.cpp:1746 src/muuli_wdr.cpp:2919 src/muuli_wdr.cpp:3369
+#: src/muuli_wdr.cpp:3416
+msgid "Messages"
+msgstr "Nachrichten"
+
+#: src/amuleDlg.cpp:1750 src/muuli_wdr.cpp:3416
 msgid "Messages Window"
 msgstr "Nachrichten, Chat, Freundesliste"
 
-#: src/amuleDlg.cpp:1844 src/muuli_wdr.cpp:3445
+#: src/amuleDlg.cpp:1752 src/muuli_wdr.cpp:3417 src/PrefsUnifiedDlg.cpp:312
+#: src/Statistics.cpp:779 src/Statistics.cpp:1235
+msgid "Statistics"
+msgstr "Statistiken"
+
+#: src/amuleDlg.cpp:1756 src/muuli_wdr.cpp:3417
 msgid "Statistics Graph Window"
 msgstr "Diverse Statistiken über Up- und Download, Verbindungen, Clients usw."
 
-#: src/amuleDlg.cpp:1851 src/muuli_wdr.cpp:3447
+#: src/amuleDlg.cpp:1759 src/muuli_wdr.cpp:3419 src/PrefsUnifiedDlg.cpp:328
+#: src/utils/wxCas/src/wxcasprefs.cpp:39
+msgid "Preferences"
+msgstr "Einstellungen"
+
+#: src/amuleDlg.cpp:1763 src/muuli_wdr.cpp:3419
 msgid "Preferences Settings Window"
 msgstr "Fenster für Einstellungen"
 
-#: src/amuleDlg.cpp:1854 src/muuli_wdr.cpp:3448
+#: src/amuleDlg.cpp:1766 src/muuli_wdr.cpp:3420
 msgid "Import"
 msgstr "Importiere"
 
-#: src/amuleDlg.cpp:1858 src/muuli_wdr.cpp:3448
+#: src/amuleDlg.cpp:1770 src/muuli_wdr.cpp:3420
 msgid "The partfile importer tool"
 msgstr "Das Importierwerkzeug für Part-Dateien"
 
-#: src/amuleDlg.cpp:1861 src/muuli_wdr.cpp:3449
+#: src/amuleDlg.cpp:1773 src/muuli_wdr.cpp:3421
 #: src/utils/aLinkCreator/src/alcframe.cpp:262
 msgid "About"
 msgstr "Über"
 
-#: src/amuleDlg.cpp:1861 src/muuli_wdr.cpp:3449
+#: src/amuleDlg.cpp:1773 src/muuli_wdr.cpp:3421
 msgid "About/Help"
 msgstr "Über/Hilfe - Hinweise zur Version usw."
 
-#: src/amuleDlg.cpp:2059
+#: src/amuleDlg.cpp:1971
 msgid "eD2k network"
 msgstr "eD2k-Netzwerk"
 
-#: src/amuleDlg.cpp:2062
+#: src/amuleDlg.cpp:1974
 msgid "Kad network"
 msgstr "Kad-Netzwerk"
 
-#: src/amuleDlg.cpp:2062
+#: src/amuleDlg.cpp:1974
 msgid "No network"
 msgstr "Kein Netzwerk"
 
@@ -961,7 +956,7 @@ msgstr "Datei nicht gefunden."
 msgid "The core rejected these shared folders:%s"
 msgstr ""
 
-#: src/amule-remote-gui.cpp:1336 src/ExternalConn.cpp:2346
+#: src/amule-remote-gui.cpp:1336 src/ExternalConn.cpp:2345
 msgid "Invalid link or already on list."
 msgstr "Ungültiger Verweis oder schon auf der Liste"
 
@@ -977,7 +972,7 @@ msgstr "Konnte das Verzeichnis '%s' für die Kategorie '%s' nicht erstellen, nut
 #: src/ClientDetailDialog.cpp:123 src/DataToText.cpp:61 src/DataToText.cpp:86
 #: src/DataToText.cpp:101 src/DataToText.cpp:136 src/DataToText.cpp:165
 #: src/DownloadListCtrl.cpp:1172 src/DownloadListCtrl.cpp:1185
-#: src/DownloadListCtrl.cpp:1196 src/ExternalConn.cpp:609
+#: src/DownloadListCtrl.cpp:1196 src/ExternalConn.cpp:608
 #: src/FileDetailDialog.cpp:203 src/FileDetailDialog.cpp:235
 #: src/FileDetailDialog.cpp:242 src/GenericClientListCtrl.cpp:1171
 #: src/GenericClientListCtrl.cpp:1182 src/GenericClientListCtrl.cpp:1192
@@ -1364,19 +1359,19 @@ msgstr "Auto [Ho]"
 msgid "Very low"
 msgstr "Sehr niedrig"
 
-#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:743 src/muuli_wdr.cpp:2303
+#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:743 src/muuli_wdr.cpp:2275
 #: src/ServerListCtrl.cpp:263 src/ServerListCtrl.cpp:456
 #: src/SharedFilesCtrl.cpp:145
 msgid "Low"
 msgstr "Niedrig"
 
-#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:744 src/muuli_wdr.cpp:2304
+#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:744 src/muuli_wdr.cpp:2276
 #: src/ServerListCtrl.cpp:266 src/ServerListCtrl.cpp:457
 #: src/SharedFilesCtrl.cpp:146
 msgid "Normal"
 msgstr "Normal"
 
-#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:745 src/muuli_wdr.cpp:2305
+#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:745 src/muuli_wdr.cpp:2277
 #: src/ServerListCtrl.cpp:269 src/ServerListCtrl.cpp:458
 #: src/SharedFilesCtrl.cpp:147
 msgid "High"
@@ -1468,8 +1463,8 @@ msgstr "Lokaler Server"
 msgid "Remote Server"
 msgstr "Entfernter Server"
 
-#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3202
-#: src/SearchDlg.cpp:119 src/TextClient.cpp:911
+#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3174
+#: src/SearchDlg.cpp:111 src/TextClient.cpp:911
 msgid "Kad"
 msgstr "Kad"
 
@@ -1539,7 +1534,7 @@ msgstr "Teil"
 msgid "Size"
 msgstr "Größe"
 
-#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3269
+#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3241
 msgid "Transferred"
 msgstr "Übertragen"
 
@@ -1597,7 +1592,7 @@ msgstr ""
 "Rückmeldung von: %s (%s)\n"
 "\n"
 
-#: src/DownloadListCtrl.cpp:746 src/muuli_wdr.cpp:2306
+#: src/DownloadListCtrl.cpp:746 src/muuli_wdr.cpp:2278
 #: src/SharedFilesCtrl.cpp:150
 msgid "Auto"
 msgstr "Automatisch"
@@ -1635,7 +1630,7 @@ msgid "Extended Options"
 msgstr "Erweiterte Optionen"
 
 #: src/DownloadListCtrl.cpp:770 src/DownloadListCtrl.cpp:822
-#: src/muuli_wdr.cpp:1790
+#: src/muuli_wdr.cpp:1789
 msgid "Preview"
 msgstr "Vorschau"
 
@@ -1810,230 +1805,225 @@ msgstr[1] "Konnte %u Links nicht hinzufügen (Details: siehe Log)"
 msgid "Invalid eD2k link! ERROR: %s"
 msgstr "Ungültiger eD2k-Link! Fehler: %s"
 
-#: src/ExternalConn.cpp:380
+#: src/ExternalConn.cpp:379
 msgid "Client sent packet after authentication failed."
 msgstr "Client sendete Paket nach fehlgeschlagener Authentifizierung."
 
-#: src/ExternalConn.cpp:397
+#: src/ExternalConn.cpp:396
 msgid "External connection closed."
 msgstr "Externe Verbindung getrennt."
 
-#: src/ExternalConn.cpp:474
+#: src/ExternalConn.cpp:473
 msgid "External connections disabled due to empty password!"
 msgstr "Externe Verbindungen deaktiviert. Leeres Passwort!"
 
-#: src/ExternalConn.cpp:495
+#: src/ExternalConn.cpp:494
 msgid "External connections disabled in config file"
 msgstr "Externe Verbindungen in der Konfigurationsdatei deaktiviert"
 
-#: src/ExternalConn.cpp:576
+#: src/ExternalConn.cpp:575
 msgid "New external connection accepted"
 msgstr "Neue externe Verbindung akzeptiert"
 
-#: src/ExternalConn.cpp:579
+#: src/ExternalConn.cpp:578
 msgid "ERROR: couldn't accept a new external connection"
 msgstr "FEHLER: Konnte keine neue externe Verbindung akzeptieren"
 
-#: src/ExternalConn.cpp:596
+#: src/ExternalConn.cpp:595
 msgid "External connection refused due to empty password in preferences!"
 msgstr "Externe Verbindung verweigert. Kein Passwort in den Einstellungen angegeben!"
 
-#: src/ExternalConn.cpp:608
+#: src/ExternalConn.cpp:607
 #, c-format
 msgid "Connecting client: %s %s"
 msgstr "Verbinde mit Client: %s %s"
 
-#: src/ExternalConn.cpp:610
+#: src/ExternalConn.cpp:609
 msgid "Unknown version"
 msgstr "Unbekannte Version"
 
-#: src/ExternalConn.cpp:623
+#: src/ExternalConn.cpp:622
 msgid "Incorrect EC version ID, there might be binary incompatibility. Use core and remote from same snapshot."
 msgstr "Unkorrekte EC-Versions-ID; es könnte eine binär-Inkompatibilität vorliegen. Benutze Kern und Fernsteuerung desselben Schnappschusses."
 
-#: src/ExternalConn.cpp:631
+#: src/ExternalConn.cpp:630
 msgid "You cannot connect to a release version from an arbitrary development snapshot! *sigh* possible crash prevented"
 msgstr "Du kannst nicht zu einer Release-Version von einer beliebigen Entwicklungs-Version verbinden! *seufz* möglicher Absturz verhindert"
 
-#: src/ExternalConn.cpp:714
+#: src/ExternalConn.cpp:713
 msgid "Invalid protocol version."
 msgstr "Ungültige Protokollversion."
 
-#: src/ExternalConn.cpp:720
+#: src/ExternalConn.cpp:719
 msgid "Missing protocol version tag."
 msgstr "Fehlende Protokollversionsmarke."
 
-#: src/ExternalConn.cpp:728
+#: src/ExternalConn.cpp:727
 msgid "Authentication failed: invalid hash specified as EC password."
 msgstr "Authentifizierung fehlgeschlagen: ungültiger Hash als EC-Passwort angegeben."
 
-#: src/ExternalConn.cpp:776
+#: src/ExternalConn.cpp:775
 msgid "Authentication failed: wrong password."
 msgstr "Authentifizierung fehlgeschlagen: falsches Passwort."
 
-#: src/ExternalConn.cpp:778
+#: src/ExternalConn.cpp:777
 msgid "Authentication failed: missing password."
 msgstr "Authentifizierung fehlgeschlagen: fehlendes Passwort."
 
-#: src/ExternalConn.cpp:789
+#: src/ExternalConn.cpp:788
 msgid "Invalid request, please authenticate first."
 msgstr "Ungültige Anfrage, bitte zuerst authentifizieren."
 
-#: src/ExternalConn.cpp:794
+#: src/ExternalConn.cpp:793
 msgid "Access granted."
 msgstr "Zugang gewährt."
 
-#: src/ExternalConn.cpp:802
+#: src/ExternalConn.cpp:801
 #, c-format
 msgid "Sent error message \"%s\" to client."
 msgstr "Fehlermeldung \"%s\" zu Client gesendet."
 
-#: src/ExternalConn.cpp:807
+#: src/ExternalConn.cpp:806
 #, c-format
 msgid "Unauthorized access attempt from %s. Connection closed."
 msgstr "Unerlaubter Verbindungsversuch von %s. Verbindung getrennt."
 
-#: src/ExternalConn.cpp:1420
+#: src/ExternalConn.cpp:1419
 #, c-format
 msgid "Remote PartFile command failed: FileHash not found: %s"
 msgstr "Fernsteuerungs-Part-Datei-Kommando gescheitert: Dateiprüfsumme nicht gefunden: %s"
 
-#: src/ExternalConn.cpp:1424
+#: src/ExternalConn.cpp:1423
 #, c-format
 msgid "FileHash not found: %s"
 msgstr "Dateiprüfsumme nicht gefunden: %s"
 
-#: src/ExternalConn.cpp:1471 src/ExternalConn.cpp:1559
-#: src/ExternalConn.cpp:1680
+#: src/ExternalConn.cpp:1470 src/ExternalConn.cpp:1558
+#: src/ExternalConn.cpp:1679
 msgid "OOPS! OpCode processing error!"
 msgstr "OOPS! OpCode-Verarbeitungsfehler!"
 
-#: src/ExternalConn.cpp:1502
+#: src/ExternalConn.cpp:1501
 msgid "Server not added"
 msgstr "Server nicht hinzugefügt"
 
-#: src/ExternalConn.cpp:1521
+#: src/ExternalConn.cpp:1520
 #, c-format
 msgid "server not found: %s"
 msgstr "Server nicht gefunden: %s"
 
-#: src/ExternalConn.cpp:1538
+#: src/ExternalConn.cpp:1537
 msgid "need to define server to be removed"
 msgstr "Der zu entfernende Server muss angegeben sein"
 
-#: src/ExternalConn.cpp:1553
+#: src/ExternalConn.cpp:1552
 msgid "eD2k is disabled in preferences."
 msgstr "eD2k ist in den Einstellungen deaktiviert."
 
-#: src/ExternalConn.cpp:1658
+#: src/ExternalConn.cpp:1657
 msgid "Friend not found."
 msgstr "Freund nicht gefunden."
 
-#: src/ExternalConn.cpp:1668
+#: src/ExternalConn.cpp:1667
 msgid "Client not found."
 msgstr "Client nicht gefunden."
 
-#: src/ExternalConn.cpp:1674
+#: src/ExternalConn.cpp:1673
 msgid "EC_TAG_FRIEND_SHARED requires EC_TAG_FRIEND or EC_TAG_CLIENT."
 msgstr "EC_TAG_FRIEND_SHARED erfordert EC_TAG_FRIEND oder EC_TAG_CLIENT."
 
-#: src/ExternalConn.cpp:1992
+#: src/ExternalConn.cpp:1991
 msgid "WebSearch from remote interface makes no sense."
 msgstr "Websuche mit der Fernsteuerungsschnittstelle macht keinen Sinn."
 
-#: src/ExternalConn.cpp:2027
+#: src/ExternalConn.cpp:2026
 msgid "Search in progress. Refetch results in a moment!"
 msgstr "Suche läuft gerade. Aktualisiere gleich die Ergebnisse!"
 
-#: src/ExternalConn.cpp:2266
+#: src/ExternalConn.cpp:2265
 msgid "No points for graph."
 msgstr "Keine Punkte für Graphen."
 
-#: src/ExternalConn.cpp:2276
+#: src/ExternalConn.cpp:2275
 msgid "Your client is not configured for this detail level."
 msgstr "Der Client ist nicht nicht für diese Detailstufe eingestellt."
 
-#: src/ExternalConn.cpp:2303
+#: src/ExternalConn.cpp:2302
 msgid "External Connection: shutdown requested"
 msgstr "Externe Verbindungen: Herunterfahren gefordert"
 
-#: src/ExternalConn.cpp:2315
+#: src/ExternalConn.cpp:2314
 msgid "Already shutting down."
 msgstr "Wird bereits heruntergefahren."
 
-#: src/ExternalConn.cpp:2333
+#: src/ExternalConn.cpp:2332
 #, c-format
 msgid "ExternalConn: adding link '%s'."
 msgstr "Externe Verbindungen: Füge hinzu Verweis '%s'."
 
-#: src/ExternalConn.cpp:2351
+#: src/ExternalConn.cpp:2350
 #, c-format
 msgid "%d of %d links failed (invalid or already on list)."
 msgstr "%d von %d Links fehlgeschlagen. Ungültiger Verweis oder schon auf der Liste"
 
-#: src/ExternalConn.cpp:2374
+#: src/ExternalConn.cpp:2373
 msgid "Version check throttled; try again shortly."
 msgstr ""
 
-#: src/ExternalConn.cpp:2379
+#: src/ExternalConn.cpp:2378
 msgid "Version check is not available on this daemon."
 msgstr ""
 
-#: src/ExternalConn.cpp:2509
+#: src/ExternalConn.cpp:2508
 msgid "File not found."
 msgstr "Datei nicht gefunden."
 
-#: src/ExternalConn.cpp:2514
+#: src/ExternalConn.cpp:2513
 msgid "Invalid file name."
 msgstr "Ungültiger Dateiname."
 
-#: src/ExternalConn.cpp:2522
+#: src/ExternalConn.cpp:2521
 msgid "Unable to rename file."
 msgstr "Datei kann nicht umbenannt werden."
 
-#: src/ExternalConn.cpp:2839
-#, c-format
-msgid "Could not save the amuleapi password: %s"
-msgstr ""
-
-#: src/ExternalConn.cpp:3004 src/ExternalConn.cpp:3032
+#: src/ExternalConn.cpp:2992 src/ExternalConn.cpp:3020
 msgid "Kad is disabled in preferences."
 msgstr "Kad ist in den Einstellungen deaktiviert."
 
-#: src/ExternalConn.cpp:3045
+#: src/ExternalConn.cpp:3033
 msgid "Already connected to eD2k."
 msgstr "Bereits mit eD2k verbunden."
 
-#: src/ExternalConn.cpp:3048
+#: src/ExternalConn.cpp:3036
 msgid "Connecting to eD2k..."
 msgstr "Verbinde mit eD2k..."
 
-#: src/ExternalConn.cpp:3057
+#: src/ExternalConn.cpp:3045
 msgid "Already connected to Kad."
 msgstr "Bereits mit Kad verbunden."
 
-#: src/ExternalConn.cpp:3060
+#: src/ExternalConn.cpp:3048
 msgid "Connecting to Kad..."
 msgstr "Verbinde mit Kad..."
 
-#: src/ExternalConn.cpp:3067
+#: src/ExternalConn.cpp:3055
 msgid "All networks are disabled."
 msgstr "Alle Netzwerke sind deaktiviert."
 
-#: src/ExternalConn.cpp:3076
+#: src/ExternalConn.cpp:3064
 msgid "Disconnected from eD2k."
 msgstr "Von eD2k getrennt."
 
-#: src/ExternalConn.cpp:3081
+#: src/ExternalConn.cpp:3069
 msgid "Disconnected from Kad."
 msgstr "Von Kad getrennt."
 
-#: src/ExternalConn.cpp:3090
+#: src/ExternalConn.cpp:3078
 #, c-format
 msgid "External Connection: invalid opcode received: %#x"
 msgstr "Externe Verbindungen: ungültigen Opcode empfangen: %#x"
 
-#: src/ExternalConn.cpp:3095
+#: src/ExternalConn.cpp:3083
 msgid "Invalid opcode (wrong protocol version?)"
 msgstr "Ungültiger OpCode (falsche Protokollversion?)"
 
@@ -2349,19 +2339,19 @@ msgstr ""
 msgid "eD2k"
 msgstr "eD2k"
 
-#: src/FirstRunWizard.cpp:349 src/muuli_wdr.cpp:1495
+#: src/FirstRunWizard.cpp:349 src/muuli_wdr.cpp:1488
 msgid "Kademlia"
 msgstr "Kademlia"
 
-#: src/FirstRunWizard.cpp:359 src/muuli_wdr.cpp:1423
+#: src/FirstRunWizard.cpp:359 src/muuli_wdr.cpp:1416
 msgid "Standard TCP Port "
 msgstr "Standard-TCP-Port"
 
-#: src/FirstRunWizard.cpp:365 src/muuli_wdr.cpp:1435
+#: src/FirstRunWizard.cpp:365 src/muuli_wdr.cpp:1428
 msgid "Extended UDP port (Kad / global search) "
 msgstr "Erweiterter UDP-Port (Kad / globale Suche)"
 
-#: src/FirstRunWizard.cpp:377 src/muuli_wdr.cpp:1442
+#: src/FirstRunWizard.cpp:377 src/muuli_wdr.cpp:1435
 msgid "Enable UPnP for router port forwarding"
 msgstr "Aktiviere UPnP für Router-Port-Weiterleitung"
 
@@ -2388,7 +2378,7 @@ msgstr ""
 msgid "Your peer lists are already in place - nothing to download."
 msgstr "Die Datei %s wird bereits heruntergeladen"
 
-#: src/FirstRunWizard.cpp:434 src/muuli_wdr.cpp:1540
+#: src/FirstRunWizard.cpp:434 src/muuli_wdr.cpp:1533
 msgid "Auto-update server list at startup"
 msgstr "Serverliste beim Programmstart aktualisieren"
 
@@ -2434,23 +2424,23 @@ msgid ""
 "want downloads on a different (e.g. larger) disk."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:549 src/FirstRunWizard.cpp:611 src/muuli_wdr.cpp:1702
+#: src/FirstRunWizard.cpp:549 src/FirstRunWizard.cpp:611 src/muuli_wdr.cpp:1701
 msgid "Destination folder for downloads"
 msgstr "Zielverzeichnis für Downloads."
 
-#: src/FirstRunWizard.cpp:553 src/FirstRunWizard.cpp:569 src/muuli_wdr.cpp:1349
-#: src/muuli_wdr.cpp:1366 src/muuli_wdr.cpp:1677 src/muuli_wdr.cpp:1708
-#: src/muuli_wdr.cpp:1720 src/muuli_wdr.cpp:2790
+#: src/FirstRunWizard.cpp:553 src/FirstRunWizard.cpp:569 src/muuli_wdr.cpp:1342
+#: src/muuli_wdr.cpp:1359 src/muuli_wdr.cpp:1676 src/muuli_wdr.cpp:1707
+#: src/muuli_wdr.cpp:1719 src/muuli_wdr.cpp:2762
 #: src/utils/aLinkCreator/src/alcframe.cpp:135
 #: src/utils/wxCas/src/wxcasprefs.cpp:52 src/utils/wxCas/src/wxcasprefs.cpp:118
 msgid "Browse"
 msgstr "Durchsuchen"
 
-#: src/FirstRunWizard.cpp:559 src/muuli_wdr.cpp:1713
+#: src/FirstRunWizard.cpp:559 src/muuli_wdr.cpp:1712
 msgid "(All files in this folder are shared with other peers)"
 msgstr "(Alle Dateien in diesem Ordner werden mit anderen Nutzern geteilt)"
 
-#: src/FirstRunWizard.cpp:565 src/FirstRunWizard.cpp:624 src/muuli_wdr.cpp:1715
+#: src/FirstRunWizard.cpp:565 src/FirstRunWizard.cpp:624 src/muuli_wdr.cpp:1714
 msgid "Folder for temporary download files"
 msgstr "Verzeichnis für temporäre Downloaddateien"
 
@@ -2481,7 +2471,7 @@ msgstr "Konnte Freundes-Liste 'emfriends.met' nicht schreiben!"
 msgid "CRITICAL - no client on StartChatSession"
 msgstr "KRITISCH - kein Client bei StartChatSession"
 
-#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2696 src/muuli_wdr.cpp:3373
+#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2668 src/muuli_wdr.cpp:3345
 msgid "Friends"
 msgstr "Freunde"
 
@@ -2591,8 +2581,8 @@ msgstr "Keine"
 msgid "No"
 msgstr "Nein"
 
-#: src/GenericClientListCtrl.cpp:1216 src/PrefsUnifiedDlg.cpp:2898
-#: src/PrefsUnifiedDlg.cpp:2948 src/ServerListCtrl.cpp:276
+#: src/GenericClientListCtrl.cpp:1216 src/PrefsUnifiedDlg.cpp:2818
+#: src/PrefsUnifiedDlg.cpp:2868 src/ServerListCtrl.cpp:276
 msgid "Yes"
 msgstr "Ja"
 
@@ -2761,10 +2751,10 @@ msgstr "Ungültiger Bootstrap-Port"
 msgid "Please fill all fields required"
 msgstr "Bitte alle erforderlichen Felder ausfüllen"
 
-#: src/KadDlg.cpp:192 src/PartFile.cpp:1031 src/PrefsUnifiedDlg.cpp:1134
-#: src/PrefsUnifiedDlg.cpp:1204 src/PrefsUnifiedDlg.cpp:1405
-#: src/PrefsUnifiedDlg.cpp:1663 src/PrefsUnifiedDlg.cpp:1673
-#: src/PrefsUnifiedDlg.cpp:1690 src/PrefsUnifiedDlg.cpp:1738
+#: src/KadDlg.cpp:192 src/PartFile.cpp:1031 src/PrefsUnifiedDlg.cpp:1162
+#: src/PrefsUnifiedDlg.cpp:1331 src/PrefsUnifiedDlg.cpp:1589
+#: src/PrefsUnifiedDlg.cpp:1599 src/PrefsUnifiedDlg.cpp:1616
+#: src/PrefsUnifiedDlg.cpp:1658
 msgid "Message"
 msgstr "Nachricht"
 
@@ -2866,7 +2856,7 @@ msgstr "Tauschverhältnis"
 msgid "Uploaded"
 msgstr "Hochgeladen"
 
-#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3253
+#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3225
 msgid "Requested"
 msgstr "Angefordert"
 
@@ -2990,7 +2980,7 @@ msgid "WARNING: "
 msgstr "WARNUNG: "
 
 #: src/MuleNotebook.cpp:179 src/muuli_wdr.cpp:817 src/muuli_wdr.cpp:1229
-#: src/muuli_wdr.cpp:3157 src/muuli_wdr.cpp:3413
+#: src/muuli_wdr.cpp:3129 src/muuli_wdr.cpp:3385
 msgid "Close"
 msgstr "Schließen"
 
@@ -3003,12 +2993,12 @@ msgstr "Ausschneiden"
 msgid "Copy"
 msgstr "Kopieren"
 
-#: src/MuleTextCtrl.cpp:88 src/SearchDlg.cpp:261
+#: src/MuleTextCtrl.cpp:88
 msgid "Paste"
 msgstr "Einfügen"
 
 #: src/MuleTextCtrl.cpp:89 src/muuli_wdr.cpp:358 src/muuli_wdr.cpp:757
-#: src/muuli_wdr.cpp:2380 src/muuli_wdr.cpp:2399 src/muuli_wdr.cpp:2421
+#: src/muuli_wdr.cpp:2352 src/muuli_wdr.cpp:2371 src/muuli_wdr.cpp:2393
 #: src/utils/aLinkCreator/src/alcframe.cpp:142
 msgid "Clear"
 msgstr "Leeren"
@@ -3099,8 +3089,8 @@ msgid "Exit"
 msgstr "Schließen"
 
 #: src/MuleTrayIcon.cpp:579 src/MuleTrayIcon.cpp:945 src/MuleTrayIcon.cpp:965
-#: src/muuli_wdr.cpp:1398 src/muuli_wdr.cpp:1406 src/muuli_wdr.cpp:1413
-#: src/muuli_wdr.cpp:1836 src/muuli_wdr.cpp:1842 src/OtherFunctions.cpp:91
+#: src/muuli_wdr.cpp:1391 src/muuli_wdr.cpp:1399 src/muuli_wdr.cpp:1406
+#: src/muuli_wdr.cpp:1835 src/muuli_wdr.cpp:1841 src/OtherFunctions.cpp:91
 #: src/StatisticsDlg.cpp:93 src/StatisticsDlg.cpp:95
 msgid "kB/s"
 msgstr "kB/s"
@@ -3271,7 +3261,7 @@ msgstr "Name:"
 msgid "Type"
 msgstr "Suchtyp"
 
-#: src/muuli_wdr.cpp:215 src/SearchDlg.cpp:118 src/SearchListCtrl.cpp:853
+#: src/muuli_wdr.cpp:215 src/SearchDlg.cpp:110 src/SearchListCtrl.cpp:853
 msgid "Local"
 msgstr "Lokal"
 
@@ -3342,7 +3332,7 @@ msgstr "Bytes"
 msgid "KB"
 msgstr "KB"
 
-#: src/muuli_wdr.cpp:274 src/muuli_wdr.cpp:293 src/muuli_wdr.cpp:1621
+#: src/muuli_wdr.cpp:274 src/muuli_wdr.cpp:293 src/muuli_wdr.cpp:1620
 #: src/OtherFunctions.cpp:64
 msgid "MB"
 msgstr "MB"
@@ -3359,7 +3349,7 @@ msgstr "Höchstgröße"
 msgid "Availability"
 msgstr "Verfügbarkeit"
 
-#: src/muuli_wdr.cpp:312 src/muuli_wdr.cpp:398 src/muuli_wdr.cpp:3318
+#: src/muuli_wdr.cpp:312 src/muuli_wdr.cpp:398 src/muuli_wdr.cpp:3290
 msgid "Filter:"
 msgstr "Filter:"
 
@@ -3391,7 +3381,7 @@ msgstr "Bittet Kad-Peers, die bereits geantwortet haben, die Suche zu erweitern.
 msgid "Stop"
 msgstr "Stopp"
 
-#: src/muuli_wdr.cpp:348 src/muuli_wdr.cpp:1392 src/SearchListCtrl.cpp:732
+#: src/muuli_wdr.cpp:348 src/muuli_wdr.cpp:1385 src/SearchListCtrl.cpp:732
 msgid "Download"
 msgstr "Download"
 
@@ -3422,12 +3412,12 @@ msgstr "Dateiquellen:"
 #: src/muuli_wdr.cpp:1160 src/muuli_wdr.cpp:1167 src/muuli_wdr.cpp:1172
 #: src/muuli_wdr.cpp:1179 src/muuli_wdr.cpp:1184 src/muuli_wdr.cpp:1191
 #: src/muuli_wdr.cpp:1205 src/muuli_wdr.cpp:1212 src/muuli_wdr.cpp:1217
-#: src/muuli_wdr.cpp:1224 src/muuli_wdr.cpp:3255 src/muuli_wdr.cpp:3263
-#: src/muuli_wdr.cpp:3271
+#: src/muuli_wdr.cpp:1224 src/muuli_wdr.cpp:3227 src/muuli_wdr.cpp:3235
+#: src/muuli_wdr.cpp:3243
 msgid "N/A"
 msgstr "Nicht verfügbar"
 
-#: src/muuli_wdr.cpp:508 src/muuli_wdr.cpp:1065 src/PrefsUnifiedDlg.cpp:299
+#: src/muuli_wdr.cpp:508 src/muuli_wdr.cpp:1065 src/PrefsUnifiedDlg.cpp:297
 msgid "General"
 msgstr "Allgemein"
 
@@ -3568,7 +3558,7 @@ msgstr ""
 msgid "Album :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:685 src/muuli_wdr.cpp:2275
+#: src/muuli_wdr.cpp:685 src/muuli_wdr.cpp:2247
 msgid "Title :"
 msgstr "Titel:"
 
@@ -3677,7 +3667,7 @@ msgstr "Benutzername:"
 msgid "Userhash :"
 msgstr "Benutzerprüfsumme:"
 
-#: src/muuli_wdr.cpp:895 src/muuli_wdr.cpp:1742 src/muuli_wdr.cpp:2470
+#: src/muuli_wdr.cpp:895 src/muuli_wdr.cpp:1741 src/muuli_wdr.cpp:2442
 #: src/utils/aLinkCreator/src/alcframe.cpp:137
 msgid "Add"
 msgstr "Hinzufügen"
@@ -3686,15 +3676,15 @@ msgstr "Hinzufügen"
 msgid "Download-Speed"
 msgstr "Download-Geschwindigkeit"
 
-#: src/muuli_wdr.cpp:954 src/muuli_wdr.cpp:989 src/muuli_wdr.cpp:2574
+#: src/muuli_wdr.cpp:954 src/muuli_wdr.cpp:989 src/muuli_wdr.cpp:2546
 msgid "Current"
 msgstr "Aktuell"
 
-#: src/muuli_wdr.cpp:962 src/muuli_wdr.cpp:997 src/muuli_wdr.cpp:2582
+#: src/muuli_wdr.cpp:962 src/muuli_wdr.cpp:997 src/muuli_wdr.cpp:2554
 msgid "Running average"
 msgstr "gleitender Mittelwert"
 
-#: src/muuli_wdr.cpp:970 src/muuli_wdr.cpp:1005 src/muuli_wdr.cpp:2590
+#: src/muuli_wdr.cpp:970 src/muuli_wdr.cpp:1005 src/muuli_wdr.cpp:2562
 msgid "Session average"
 msgstr "Sitzungsdurchschnitt"
 
@@ -3706,7 +3696,7 @@ msgstr "Upload-Geschwindigkeit"
 msgid "Connections"
 msgstr "Verbindungen"
 
-#: src/muuli_wdr.cpp:1024 src/muuli_wdr.cpp:1861
+#: src/muuli_wdr.cpp:1024 src/muuli_wdr.cpp:1860
 msgid "Active downloads"
 msgstr "Aktive Downloads"
 
@@ -3714,7 +3704,7 @@ msgstr "Aktive Downloads"
 msgid "Active connections (1:1)"
 msgstr "Aktive Verbindungen (1:1)"
 
-#: src/muuli_wdr.cpp:1040 src/muuli_wdr.cpp:1862
+#: src/muuli_wdr.cpp:1040 src/muuli_wdr.cpp:1861
 msgid "Active uploads"
 msgstr "Aktive Uploads"
 
@@ -3830,8 +3820,8 @@ msgstr "Dies ist der Name, den andere Benutzer sehen, wenn sie mit dir verbunden
 msgid "Language: "
 msgstr "Sprache:"
 
-#: src/muuli_wdr.cpp:1257 src/muuli_wdr.cpp:1330 src/muuli_wdr.cpp:1334
-#: src/muuli_wdr.cpp:1337
+#: src/muuli_wdr.cpp:1257 src/muuli_wdr.cpp:1323 src/muuli_wdr.cpp:1327
+#: src/muuli_wdr.cpp:1330
 msgid "The delay before showing tool-tips."
 msgstr "Verzögerung vor dem Anzeigen der Tooltips. "
 
@@ -3909,261 +3899,260 @@ msgstr "Benachrichtigungen anzeigen, wenn Downloads abgeschlossen sind"
 msgid "Enabling this will make aMule to show notifications when finished downloading."
 msgstr "Wenn aktiviert, zeigt aMule Benachrichtigungen an, sobald Downloads abgeschlossen sind."
 
-#: src/muuli_wdr.cpp:1323
-#, fuzzy
-msgid "Remember search history"
-msgstr "Diese Einstellungen speichern"
-
-#: src/muuli_wdr.cpp:1324
-msgid "Keeps a dropdown list of your past search terms in the Search tab's Name field. This remembers the queries you typed, not the results they returned."
-msgstr ""
-
-#: src/muuli_wdr.cpp:1329
+#: src/muuli_wdr.cpp:1322
 msgid "Tooltip delay time: "
 msgstr "Tooltip-Verzögerungszeit:"
 
-#: src/muuli_wdr.cpp:1336
+#: src/muuli_wdr.cpp:1329
 msgid "seconds"
 msgstr "Sekunden"
 
-#: src/muuli_wdr.cpp:1340
+#: src/muuli_wdr.cpp:1333
 msgid "Browser Selection"
 msgstr "Browser-Wahl"
 
-#: src/muuli_wdr.cpp:1346
+#: src/muuli_wdr.cpp:1339
 msgid "Enter your browser name here. Leave this field empty to use the system default browser."
 msgstr "Gib den Namen des gewünschten Browsers hier ein. Bei einem leeren Feld wird der voreingestellte Systembrowser benutzt."
 
-#: src/muuli_wdr.cpp:1353
+#: src/muuli_wdr.cpp:1346
 msgid "Open in new tab if possible"
 msgstr "Öffne in neuem Reiter, wenn möglich"
 
-#: src/muuli_wdr.cpp:1355
+#: src/muuli_wdr.cpp:1348
 msgid "Open the web page in a new tab instead of in a new window when possible"
 msgstr "Öffne die Webseite in einem neuen Reiter, statt einem neuen Fenster, wenn möglich"
 
-#: src/muuli_wdr.cpp:1359
+#: src/muuli_wdr.cpp:1352
 msgid "Video Player"
 msgstr "Videoplayer"
 
-#: src/muuli_wdr.cpp:1386
+#: src/muuli_wdr.cpp:1379
 msgid "Bandwidth limits"
 msgstr "Bandbreitenbegrenzungen"
 
-#: src/muuli_wdr.cpp:1400
+#: src/muuli_wdr.cpp:1393
 msgid "Upload"
 msgstr "Upload"
 
-#: src/muuli_wdr.cpp:1408
+#: src/muuli_wdr.cpp:1401
 msgid "Slot Allocation"
 msgstr "Slotzuteilung"
 
-#: src/muuli_wdr.cpp:1417
+#: src/muuli_wdr.cpp:1410
 msgid "Ports"
 msgstr "Ports"
 
-#: src/muuli_wdr.cpp:1427
+#: src/muuli_wdr.cpp:1420
 msgid "This is the standard eD2k port and cannot be disabled."
 msgstr "Dies ist der Standard-eD2k-Port. Er kann nicht deaktiviert werden."
 
-#: src/muuli_wdr.cpp:1430
+#: src/muuli_wdr.cpp:1423
 msgid "UDP port for server requests (TCP+3):"
 msgstr "UDP-Port für Serveranfragen (TCP+3):"
 
-#: src/muuli_wdr.cpp:1432
+#: src/muuli_wdr.cpp:1425
 msgid "4665"
 msgstr "4665"
 
-#: src/muuli_wdr.cpp:1439
+#: src/muuli_wdr.cpp:1432
 msgid "This UDP port is used for extended eD2k requests and Kad network"
 msgstr "Dieser UDP-Port wird für erweiterte ED2k-Anfragen und das Kad-Netzwerk benutzt."
 
-#: src/muuli_wdr.cpp:1446
+#: src/muuli_wdr.cpp:1439
 msgid "UPnP TCP Port (Optional):"
 msgstr "UPnP-TCP-Port (optional):"
 
-#: src/muuli_wdr.cpp:1456
+#: src/muuli_wdr.cpp:1449
 msgid "Bind local address to IP (empty for any):"
 msgstr "Verknüpfe lokale Adresse mit IP (Leer für beliebige):"
 
-#: src/muuli_wdr.cpp:1459
+#: src/muuli_wdr.cpp:1452
 msgid "Advanced users only: If you have multiple network interfaces, enter the address of the interface to which aMule should be bound."
 msgstr "Nur für fortgeschrittene Benutzer: Wenn es mehrere Netzwerkverbindungen gibt, hier die Adresse der Verbindung, mit der aMule verknüpft werden soll, eingeben."
 
-#: src/muuli_wdr.cpp:1462 src/muuli_wdr.cpp:2055
+#: src/muuli_wdr.cpp:1455 src/muuli_wdr.cpp:2054
 #, fuzzy
 msgid "Bind to network interface (empty for any):"
 msgstr "Verknüpfe lokale Adresse mit IP (Leer für beliebige):"
 
-#: src/muuli_wdr.cpp:1475
+#: src/muuli_wdr.cpp:1468
 msgid "Advanced users only: pin all of aMule's traffic to one network interface, chosen from the list or typed in by name (e.g. tun0, eth0, en0) or index. Unlike binding to an IP, this stops traffic leaking out via the default route - useful with a VPN. Requires no elevated privileges."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1481
+#: src/muuli_wdr.cpp:1474
 msgid "Max sources per downloading file:"
 msgstr "Maximale Anzahl Quellen pro heruntergeladener Datei:"
 
-#: src/muuli_wdr.cpp:1485
+#: src/muuli_wdr.cpp:1478
 msgid "Max simultaneous connections:"
 msgstr "Maximale gleichzeitige Verbindungen:"
 
-#: src/muuli_wdr.cpp:1498 src/muuli_wdr.cpp:3197
+#: src/muuli_wdr.cpp:1491 src/muuli_wdr.cpp:3169
 msgid "ED2K"
 msgstr "eD2k"
 
-#: src/muuli_wdr.cpp:1505
+#: src/muuli_wdr.cpp:1498
 msgid "Autoconnect on startup"
 msgstr "Automatisches Verbinden beim Start"
 
-#: src/muuli_wdr.cpp:1508
+#: src/muuli_wdr.cpp:1501
 msgid "Reconnect on loss"
 msgstr "Wiederverbinden nach Trennung"
 
-#: src/muuli_wdr.cpp:1530
+#: src/muuli_wdr.cpp:1523
 msgid "Remove dead server after"
 msgstr "Lösche tote Server nach"
 
-#: src/muuli_wdr.cpp:1531
+#: src/muuli_wdr.cpp:1524
 msgid "Static servers are never removed, even when unreachable."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1535
+#: src/muuli_wdr.cpp:1528
 msgid "retries"
 msgstr "Versuchen"
 
-#: src/muuli_wdr.cpp:1543
+#: src/muuli_wdr.cpp:1536
 msgid "List"
 msgstr "Liste"
 
-#: src/muuli_wdr.cpp:1546
+#: src/muuli_wdr.cpp:1539
 msgid "Update server list when connecting to a server"
 msgstr "Serverliste von verbundenem Server beziehen"
 
-#: src/muuli_wdr.cpp:1549
+#: src/muuli_wdr.cpp:1542
 msgid "Update server list when a client connects"
 msgstr "Serverliste beim Verbinden zu einem Client beziehen"
 
-#: src/muuli_wdr.cpp:1552
+#: src/muuli_wdr.cpp:1545
 msgid "Use priority system"
 msgstr "Benutze Prioritätssystem"
 
-#: src/muuli_wdr.cpp:1556
+#: src/muuli_wdr.cpp:1549
 msgid "Use smart LowID check on connect"
 msgstr "Benutze intelligente Prüfung für niedrige ID beim Verbinden"
 
-#: src/muuli_wdr.cpp:1560
+#: src/muuli_wdr.cpp:1553
 msgid "Safe connect"
 msgstr "Sicheres/langsames Verbinden zu Servern"
 
-#: src/muuli_wdr.cpp:1564
+#: src/muuli_wdr.cpp:1557
 msgid "Autoconnect to servers in static list only"
 msgstr "Automatisches Verbinden nur zu Servern aus der statischen Liste"
 
-#: src/muuli_wdr.cpp:1567
+#: src/muuli_wdr.cpp:1560
 msgid "Set manually added servers to High Priority"
 msgstr "Setze manuell hinzugefügte Server auf hohe Priorität"
 
-#: src/muuli_wdr.cpp:1588
+#: src/muuli_wdr.cpp:1581
 msgid "Add files to download in pause mode"
 msgstr "Neue Dateien dem Download pausiert hinzufügen"
 
-#: src/muuli_wdr.cpp:1590
+#: src/muuli_wdr.cpp:1583
 msgid "Add files to download with auto priority"
 msgstr "Neu hinzugefügte Dateien im Download auf Autopriorität stellen"
 
-#: src/muuli_wdr.cpp:1593
+#: src/muuli_wdr.cpp:1586
 msgid "Try to download first and last chunks first"
 msgstr "Versuche, zuerst die ersten und letzten Dateiteile herunterzuladen"
 
-#: src/muuli_wdr.cpp:1597
+#: src/muuli_wdr.cpp:1590
 msgid "Endgame mode: rotate to faster sources for the final blocks"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1600
+#: src/muuli_wdr.cpp:1593
 msgid "Start next paused file when a file completes"
 msgstr "Starte nächste pausierte Datei, wenn eine Datei fertiggestellt wird"
 
-#: src/muuli_wdr.cpp:1603
+#: src/muuli_wdr.cpp:1596
 msgid "From the same category"
 msgstr "Aus der selben Kategorie"
 
-#: src/muuli_wdr.cpp:1605
+#: src/muuli_wdr.cpp:1598
 msgid "In alphabetic order"
 msgstr "In alphabetischer Reihenfolge"
 
-#: src/muuli_wdr.cpp:1607
+#: src/muuli_wdr.cpp:1600
 msgid "Preallocate disk space for new files"
 msgstr "Reserviere Speicherplatz für neue Dateien"
 
-#: src/muuli_wdr.cpp:1608
+#: src/muuli_wdr.cpp:1601
 msgid "For new files preallocates disk space for the whole file, thus reduces fragmentation"
 msgstr "Reserviert für neue Dateien Speicherplatz für die ganze Datei und reduziert so Fragmentierung."
 
-#: src/muuli_wdr.cpp:1613
+#: src/muuli_wdr.cpp:1606
+msgid "Create new files as sparse files"
+msgstr ""
+
+#: src/muuli_wdr.cpp:1607
+msgid "A sparse file reserves its full size on disk immediately without writing real data to it -- fast, but unsupported or slow on some filesystems, and free-space accounting stays optimistic while the download is in progress. Turn this off to grow the file only as data arrives."
+msgstr ""
+
+#: src/muuli_wdr.cpp:1612
 msgid "Stop downloads when free disk space reaches "
 msgstr "Stoppe Downloads wenn freier Speicherplatz folgenden Wert erreicht:"
 
-#: src/muuli_wdr.cpp:1614
+#: src/muuli_wdr.cpp:1613
 msgid "Select this if you want aMule to check your disk space"
 msgstr "Wähle dies aus, wenn aMule deinen Festplattenplatz prüfen soll"
 
-#: src/muuli_wdr.cpp:1618
+#: src/muuli_wdr.cpp:1617
 msgid "Enter here the min disk space desired."
 msgstr "Hier den minimalen erwünschten Festplattenplatz angeben."
 
-#: src/muuli_wdr.cpp:1624
+#: src/muuli_wdr.cpp:1623
 msgid "Save 10 sources on rare files (< 20 sources)"
 msgstr "Bei seltenen (< 20 Quellen) Dateien zehn Quellen speichern"
 
-#: src/muuli_wdr.cpp:1628 src/Statistics.cpp:790
+#: src/muuli_wdr.cpp:1627 src/Statistics.cpp:790
 msgid "Uploads"
 msgstr "Uploads"
 
-#: src/muuli_wdr.cpp:1631
+#: src/muuli_wdr.cpp:1630
 msgid "Add new shared files with auto priority"
 msgstr "Neue freigegebene Dateien auf Autopriorität stellen"
 
-#: src/muuli_wdr.cpp:1637
+#: src/muuli_wdr.cpp:1636
 msgid "Intelligent Corruption Handling (I.C.H.)"
 msgstr "Intelligente Korruptionsverarbeitung (I.C.H.)"
 
-#: src/muuli_wdr.cpp:1640
+#: src/muuli_wdr.cpp:1639
 msgid "Enable"
 msgstr "Aktiviere"
 
-#: src/muuli_wdr.cpp:1643
+#: src/muuli_wdr.cpp:1642
 msgid "Advanced I.C.H. trusts every hash (not recommended)"
 msgstr "Advanced I.C.H vertraut jeder Prüfsumme (nicht empfohlen)"
 
-#: src/muuli_wdr.cpp:1655 src/PrefsUnifiedDlg.cpp:1990
+#: src/muuli_wdr.cpp:1654 src/PrefsUnifiedDlg.cpp:1910
 msgid "Media metadata extraction"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1659
+#: src/muuli_wdr.cpp:1658
 msgid "Extract length / bitrate / codec from shared audio and video files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1661
+#: src/muuli_wdr.cpp:1660
 msgid "When enabled, aMule runs ffprobe on each shared media file to fill in the Length / Bitrate / Codec columns other clients see when they find the file in a search. Requires ffmpeg (the ffprobe binary) to be installed."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1668
+#: src/muuli_wdr.cpp:1667
 msgid "Path to ffprobe:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1673
+#: src/muuli_wdr.cpp:1672
 msgid "Full path to the ffprobe binary. Leave empty to have aMule auto-detect it on startup."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1681
+#: src/muuli_wdr.cpp:1680
 msgid "Detect"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1682
+#: src/muuli_wdr.cpp:1681
 msgid "Search the standard install locations for an ffprobe binary and fill the path field."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1706
+#: src/muuli_wdr.cpp:1705
 msgid ""
 "Completed downloads are stored here. All files in this folder are automatically shared with other peers.\n"
 "If this folder also holds files you don't want to share, point it at an aMule-only sub-folder."
@@ -4171,697 +4160,674 @@ msgstr ""
 "Vollständige Downloads werden hier gespeichert. Alle Dateien in diesem Ordner werden automatisch geteilt\n"
 ". Falls dieser Ordner Dateien enthält die du nicht teilen willst, wähle einen eigenen Ordner nur für aMule aus."
 
-#: src/muuli_wdr.cpp:1709
+#: src/muuli_wdr.cpp:1708
 msgid "Pick the folder where completed downloads will be stored. All files in that folder will be shared with other peers."
 msgstr "Wähle einen Ordner in dem vollständige Downloads gepeichert werden sollen. Dieser Ordner wird automatisch geteilt."
 
-#: src/muuli_wdr.cpp:1723
+#: src/muuli_wdr.cpp:1722
 msgid "Shared folders"
 msgstr "Freigegebene Ordner"
 
-#: src/muuli_wdr.cpp:1729
+#: src/muuli_wdr.cpp:1728
 msgid "(Folders shared by the core. Enter a path to add one.)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1737
+#: src/muuli_wdr.cpp:1736
 msgid "Absolute path of a folder on the core's machine, e.g. /home/user/shared"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1739 src/PrefsUnifiedDlg.cpp:2874
+#: src/muuli_wdr.cpp:1738 src/PrefsUnifiedDlg.cpp:2794
 msgid "Recursive"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1740
+#: src/muuli_wdr.cpp:1739
 msgid "Share every sub-folder underneath this one, including ones created later."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1744 src/utils/aLinkCreator/src/alcframe.cpp:141
+#: src/muuli_wdr.cpp:1743 src/utils/aLinkCreator/src/alcframe.cpp:141
 msgid "Remove"
 msgstr "Entferne"
 
-#: src/muuli_wdr.cpp:1748
+#: src/muuli_wdr.cpp:1747
 msgid "(Right click on folder icon for recursive share)"
 msgstr "(Rechtsklick auf das Symbol des rekursiv freizugebenden Verzeichnisses)"
 
-#: src/muuli_wdr.cpp:1755
+#: src/muuli_wdr.cpp:1754
 msgid "Share hidden files"
 msgstr "Versteckte Dateien freigeben"
 
-#: src/muuli_wdr.cpp:1761
+#: src/muuli_wdr.cpp:1760
 msgid "Automatically rescan shared folders for changes"
 msgstr "Ornder automatisch auf Änderungen überwachen"
 
-#: src/muuli_wdr.cpp:1767
+#: src/muuli_wdr.cpp:1766
 msgid "Follow symbolic links in shared folders"
 msgstr "Symbolischen Links in geteilten Ordnern folgen"
 
-#: src/muuli_wdr.cpp:1773
+#: src/muuli_wdr.cpp:1772
 msgid "Exclude files matching:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1776
+#: src/muuli_wdr.cpp:1775
 msgid "Wildcard patterns separated by '|', e.g. .DS_Store|Thumbs.db|*.tmp. Files whose name matches are not shared. Matching is case-insensitive."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1780
+#: src/muuli_wdr.cpp:1779
 msgid "Patterns are regular expressions"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1781
+#: src/muuli_wdr.cpp:1780
 msgid "When set, the whole field is one regular expression ('|' is alternation). When unset, it is a list of '|'-separated wildcards."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1791
+#: src/muuli_wdr.cpp:1790
 msgid "Show how many shared files the current pattern would exclude."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1812
+#: src/muuli_wdr.cpp:1811
 msgid "Graphs"
 msgstr "Graphen"
 
-#: src/muuli_wdr.cpp:1815 src/muuli_wdr.cpp:1877
+#: src/muuli_wdr.cpp:1814 src/muuli_wdr.cpp:1876
 msgid "Update delay : 5 secs"
 msgstr "Aktualisierungsverzögerung: 5 Sekunden"
 
-#: src/muuli_wdr.cpp:1819
+#: src/muuli_wdr.cpp:1818
 msgid "Time for average graph: 100 mins"
 msgstr "Durchschnittsgraphen in Minuten berechnen: 100 min"
 
-#: src/muuli_wdr.cpp:1823
+#: src/muuli_wdr.cpp:1822
 msgid "Connections Graph Scale: 100 "
 msgstr "Verbindungsgraphenskalierung: 100"
 
-#: src/muuli_wdr.cpp:1830
+#: src/muuli_wdr.cpp:1829
 msgid "Download graph scale:"
 msgstr "Downloadgraphenskalierung:"
 
-#: src/muuli_wdr.cpp:1838
+#: src/muuli_wdr.cpp:1837
 msgid "Upload graph scale:"
 msgstr "Uploadgraphenskalierung:"
 
-#: src/muuli_wdr.cpp:1848
+#: src/muuli_wdr.cpp:1847
 msgid "Colors: "
 msgstr "Farben: "
 
-#: src/muuli_wdr.cpp:1852
+#: src/muuli_wdr.cpp:1851
 msgid "Background"
 msgstr "Hintergrund"
 
-#: src/muuli_wdr.cpp:1853
+#: src/muuli_wdr.cpp:1852
 msgid "Grid"
 msgstr "Gitter"
 
-#: src/muuli_wdr.cpp:1854
+#: src/muuli_wdr.cpp:1853
 msgid "Download current"
 msgstr "Aktueller Download"
 
-#: src/muuli_wdr.cpp:1855
+#: src/muuli_wdr.cpp:1854
 msgid "Download running average"
 msgstr "Download: Durchschnitt"
 
-#: src/muuli_wdr.cpp:1856
+#: src/muuli_wdr.cpp:1855
 msgid "Download session average"
 msgstr "Download: Sitzungsdurchschnitt"
 
-#: src/muuli_wdr.cpp:1857
+#: src/muuli_wdr.cpp:1856
 msgid "Upload current"
 msgstr "Aktueller Upload"
 
-#: src/muuli_wdr.cpp:1858
+#: src/muuli_wdr.cpp:1857
 msgid "Upload running average"
 msgstr "Upload: Durchschnitt"
 
-#: src/muuli_wdr.cpp:1859
+#: src/muuli_wdr.cpp:1858
 msgid "Upload session average"
 msgstr "Upload: Sitzungsdurchschnitt"
 
-#: src/muuli_wdr.cpp:1860
+#: src/muuli_wdr.cpp:1859
 msgid "Active connections"
 msgstr "Aktive Verbindungen"
 
-#: src/muuli_wdr.cpp:1863
+#: src/muuli_wdr.cpp:1862
 msgid "Systray Icon Speed Bar"
 msgstr "Transferbalken des Symbols im Infobereich"
 
-#: src/muuli_wdr.cpp:1864
+#: src/muuli_wdr.cpp:1863
 msgid "Kad-nodes current"
 msgstr "Momentane Kad-Knoten"
 
-#: src/muuli_wdr.cpp:1865
+#: src/muuli_wdr.cpp:1864
 msgid "Kad-nodes running"
 msgstr "Laufende Kad-Knoten"
 
-#: src/muuli_wdr.cpp:1866
+#: src/muuli_wdr.cpp:1865
 msgid "Kad-nodes session"
 msgstr "Kad-Knoten Sitzung"
 
-#: src/muuli_wdr.cpp:1870 src/muuli_wdr.cpp:2324
+#: src/muuli_wdr.cpp:1869 src/muuli_wdr.cpp:2296
 msgid "Select"
 msgstr "Auswahl"
 
-#: src/muuli_wdr.cpp:1874
+#: src/muuli_wdr.cpp:1873
 msgid "Tree"
 msgstr "Baum"
 
-#: src/muuli_wdr.cpp:1884
+#: src/muuli_wdr.cpp:1883
 msgid "Number of Client Versions shown (0=unlimited)"
 msgstr "Anzahl angezeigter Client-Versionen (0=unbegrenzt)"
 
-#: src/muuli_wdr.cpp:1909
+#: src/muuli_wdr.cpp:1908
 msgid "!!! WARNING !!!"
 msgstr "!!! WARNUNG !!!"
 
-#: src/muuli_wdr.cpp:1924
+#: src/muuli_wdr.cpp:1923
 msgid "Max new connections / 5 secs"
 msgstr "Maximale neue Verbindungen pro 5 Sekunden"
 
-#: src/muuli_wdr.cpp:1926
+#: src/muuli_wdr.cpp:1925
 msgid "Concurrent Kad source lookups"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1928
+#: src/muuli_wdr.cpp:1927
 #, fuzzy
 msgid "Kad source re-search interval (minutes)"
 msgstr "FTP-Aktualisierungsintervall in Minuten"
 
-#: src/muuli_wdr.cpp:1930
+#: src/muuli_wdr.cpp:1929
 #, fuzzy
 msgid "Source re-ask interval (minutes)"
 msgstr "FTP-Aktualisierungsintervall in Minuten"
 
-#: src/muuli_wdr.cpp:1934
+#: src/muuli_wdr.cpp:1933
 msgid "File Buffer Size: 240000 bytes"
 msgstr "Dateipuffergröße: 240000 Bytes"
 
-#: src/muuli_wdr.cpp:1938
+#: src/muuli_wdr.cpp:1937
 msgid "Use MMAP: memory-mapped file access (lower memory use)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1939
+#: src/muuli_wdr.cpp:1938
 msgid "Maps part files into memory instead of buffering them on the heap, lowering the process memory footprint. May reduce download speed on some disks; best for memory-constrained or upload-heavy hosts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1941
+#: src/muuli_wdr.cpp:1940
 msgid "Upload Queue Size: 5000 clients"
 msgstr "Upload-Warteschlangengröße: 5000 Clients"
 
-#: src/muuli_wdr.cpp:1945
+#: src/muuli_wdr.cpp:1944
 msgid "Server connection refresh interval: Disable"
 msgstr "Server-Wiederverbindungsintervall: Aus"
 
-#: src/muuli_wdr.cpp:1949
+#: src/muuli_wdr.cpp:1948
 msgid "Disable computer's timed standby mode"
 msgstr "Zeitgesteuerten Bereitschaftsmodus des Computers deaktivieren"
 
-#: src/muuli_wdr.cpp:1968
+#: src/muuli_wdr.cpp:1967
 msgid "Skin to use: "
 msgstr "benutztes Aussehen:"
 
-#: src/muuli_wdr.cpp:1977
+#: src/muuli_wdr.cpp:1976
 msgid "Show \"Fast eD2k Links Handler\" in every window."
 msgstr "Zeige \"schnelle eD2k-Linkverarbeitung\" in jedem Fenster"
 
-#: src/muuli_wdr.cpp:1980
+#: src/muuli_wdr.cpp:1979
 msgid "Show extended info on categories tabs"
 msgstr "Zeige erweiterte Informationen auf Kategorie-Reitern"
 
-#: src/muuli_wdr.cpp:1983
+#: src/muuli_wdr.cpp:1982
 msgid "Show application version on title"
 msgstr "Zeige Programmversion im Titel"
 
-#: src/muuli_wdr.cpp:1985
+#: src/muuli_wdr.cpp:1984
 msgid "Show transfer rates on title"
 msgstr "Zeige Transferraten im Titel"
 
-#: src/muuli_wdr.cpp:1987
+#: src/muuli_wdr.cpp:1986
 msgid "Before application name"
 msgstr "Vor dem Anwendungsnamen"
 
-#: src/muuli_wdr.cpp:1989
+#: src/muuli_wdr.cpp:1988
 msgid "After application name"
 msgstr "Nach dem Anwendungsnamen"
 
-#: src/muuli_wdr.cpp:1992
+#: src/muuli_wdr.cpp:1991
 msgid "Show overhead bandwidth"
 msgstr "Zeige Overhead-Bandbreite"
 
-#: src/muuli_wdr.cpp:1996
+#: src/muuli_wdr.cpp:1995
 msgid "Vertical toolbar orientation"
 msgstr "Toolbar senkrecht ausrichten"
 
-#: src/muuli_wdr.cpp:1998
+#: src/muuli_wdr.cpp:1997
 msgid "Live column sorting (auto-reorder rows as their values change)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2005
+#: src/muuli_wdr.cpp:2004
 msgid "Download Queue Files"
 msgstr "Downloadwarteschlangendateien"
 
-#: src/muuli_wdr.cpp:2008
+#: src/muuli_wdr.cpp:2007
 msgid "Show progress percentage"
 msgstr "Zeige Prozent des Fortschritts"
 
-#: src/muuli_wdr.cpp:2014
+#: src/muuli_wdr.cpp:2013
 msgid "Show progress bar"
 msgstr "Zeige Fortschrittsbalken"
 
-#: src/muuli_wdr.cpp:2017
+#: src/muuli_wdr.cpp:2016
 msgid "Flat"
 msgstr "Flach"
 
-#: src/muuli_wdr.cpp:2021
+#: src/muuli_wdr.cpp:2020
 msgid "Round"
 msgstr "Rund"
 
-#: src/muuli_wdr.cpp:2039
+#: src/muuli_wdr.cpp:2038
 msgid "External Connection Parameters"
 msgstr "Parameter für externe Verbindungen"
 
-#: src/muuli_wdr.cpp:2042
+#: src/muuli_wdr.cpp:2041
 msgid "Accept external connections"
 msgstr "Externe Verbindungen annehmen"
 
-#: src/muuli_wdr.cpp:2049 src/muuli_wdr.cpp:2108
+#: src/muuli_wdr.cpp:2048 src/muuli_wdr.cpp:2107
 msgid "IP of the listening interface:"
 msgstr "IP der lauschenden Schnittstelle:"
 
-#: src/muuli_wdr.cpp:2052
+#: src/muuli_wdr.cpp:2051
 msgid "Enter here a valid ip in the a.b.c.d format for the listening EC interface. An empty field or 0.0.0.0 will mean any interface."
 msgstr "Hier eine gültige IP im Format a.b.c.d für das lauschende EC-Interface eingeben. Ein leeres Feld oder 0.0.0.0 bedeutet ein beliebiges Interface."
 
-#: src/muuli_wdr.cpp:2073 src/muuli_wdr.cpp:2184
+#: src/muuli_wdr.cpp:2072 src/muuli_wdr.cpp:2156
 msgid "TCP port:"
 msgstr "TCP-Port:"
 
-#: src/muuli_wdr.cpp:2079
+#: src/muuli_wdr.cpp:2078
 msgid "Enable UPnP port forwarding on the EC port"
 msgstr "Aktiviere UPnP-Port-Weiterleitung zu EC-Port"
 
-#: src/muuli_wdr.cpp:2083 src/muuli_wdr.cpp:3069
+#: src/muuli_wdr.cpp:2082 src/muuli_wdr.cpp:3041
 #: src/utils/wxCas/src/wxcasprefs.cpp:167
 msgid "Password"
 msgstr "Passwort"
 
-#: src/muuli_wdr.cpp:2089
+#: src/muuli_wdr.cpp:2088
 #, fuzzy
 msgid "aMule API server parameters"
 msgstr "Webserver-Parameter"
 
-#: src/muuli_wdr.cpp:2092
+#: src/muuli_wdr.cpp:2091
 msgid "Run amuleapi (REST API) on startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2097
+#: src/muuli_wdr.cpp:2096
 #, fuzzy
 msgid "HTTP port:"
 msgstr "TCP-Port:"
 
-#: src/muuli_wdr.cpp:2111
+#: src/muuli_wdr.cpp:2110
 msgid "The interface amuleapi's HTTP server listens on. 127.0.0.1 (default) accepts only local connections; use 0.0.0.0 or a specific IP to expose it to other hosts (set an admin password below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2116
-msgid "Type a password to set or change it. Stored passwords cannot be shown, so leaving this empty keeps the current one."
-msgstr ""
-
-#: src/muuli_wdr.cpp:2118
+#: src/muuli_wdr.cpp:2113
 #, fuzzy
 msgid "Admin password"
 msgstr "Prüfe Passwort\n"
 
-#: src/muuli_wdr.cpp:2130 src/muuli_wdr.cpp:2147 src/PrefsUnifiedDlg.cpp:1103
-#, fuzzy
-msgid "A password is set."
-msgstr "Prüfe Passwort\n"
+#: src/muuli_wdr.cpp:2118 src/muuli_wdr.cpp:2149
+msgid "Low rights password"
+msgstr "Kennwort für eingeschränkten Zugriff"
 
-#: src/muuli_wdr.cpp:2134
-#, fuzzy
-msgid "Enable guest access"
-msgstr "Verweigere Gastzugriff"
-
-#: src/muuli_wdr.cpp:2135
-msgid "Guest sessions may read status and listings but cannot change anything. Turning this off clears the stored guest password."
-msgstr ""
-
-#: src/muuli_wdr.cpp:2139
-#, fuzzy
-msgid "Guest password"
-msgstr "Gast-Passwort für den Webserver"
-
-#: src/muuli_wdr.cpp:2154
+#: src/muuli_wdr.cpp:2126
 msgid "Web server parameters"
 msgstr "Webserver-Parameter"
 
-#: src/muuli_wdr.cpp:2157
+#: src/muuli_wdr.cpp:2129
 #, fuzzy
 msgid "Run webserver on startup (deprecated)"
 msgstr "Starte Webserver mit aMule"
 
-#: src/muuli_wdr.cpp:2163
+#: src/muuli_wdr.cpp:2135
 msgid "Web template"
 msgstr "Webvorlage"
 
-#: src/muuli_wdr.cpp:2168
+#: src/muuli_wdr.cpp:2140
 msgid "Full rights password"
 msgstr "Kennwort für Vollzugriff"
 
-#: src/muuli_wdr.cpp:2172
+#: src/muuli_wdr.cpp:2144
 msgid "Enable Low rights User"
 msgstr "Eingeschränkten Benutzer aktivieren"
 
-#: src/muuli_wdr.cpp:2177
-msgid "Low rights password"
-msgstr "Kennwort für eingeschränkten Zugriff"
-
-#: src/muuli_wdr.cpp:2191
+#: src/muuli_wdr.cpp:2163
 msgid "Enable UPnP port forwarding of the web server port"
 msgstr "Aktiviere UPnP-Port-Weiterleitung des Webserverports"
 
-#: src/muuli_wdr.cpp:2196
+#: src/muuli_wdr.cpp:2168
 msgid "Web server UPnP TCP port (Optional)"
 msgstr "Webserver UPnP-TCP-Port (optional)"
 
-#: src/muuli_wdr.cpp:2204
+#: src/muuli_wdr.cpp:2176
 msgid "Page Refresh Time (in secs)"
 msgstr "Aktualisierungsintervall in Sekunden"
 
-#: src/muuli_wdr.cpp:2211
+#: src/muuli_wdr.cpp:2183
 msgid "Enable Gzip compression"
 msgstr "Gzip-Kompression an"
 
-#: src/muuli_wdr.cpp:2245
+#: src/muuli_wdr.cpp:2217
 #, fuzzy
 msgid "Reset page to defaults"
 msgstr "Systemvorgabe"
 
-#: src/muuli_wdr.cpp:2246
+#: src/muuli_wdr.cpp:2218
 msgid "Reset the settings on the current page to their default values."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2248 src/muuli_wdr.cpp:2334 src/ServerWnd.cpp:274
+#: src/muuli_wdr.cpp:2220 src/muuli_wdr.cpp:2306 src/ServerWnd.cpp:274
 #: src/ServerWnd.cpp:282
 msgid "OK"
 msgstr "OK"
 
-#: src/muuli_wdr.cpp:2250
+#: src/muuli_wdr.cpp:2222
 msgid "Click here to apply any changes made to the preferences."
 msgstr "Hier klicken, um alle Einstellungsänderungen zu übernehmen."
 
-#: src/muuli_wdr.cpp:2253
+#: src/muuli_wdr.cpp:2225
 msgid "Reset any changes made to the preferences."
 msgstr "Alle Änderungen zu den Einstellungen zurücksetzen."
 
-#: src/muuli_wdr.cpp:2282
+#: src/muuli_wdr.cpp:2254
 msgid "Comment :"
 msgstr "Kommentar:"
 
-#: src/muuli_wdr.cpp:2289
+#: src/muuli_wdr.cpp:2261
 msgid "Incoming Dir :"
 msgstr "Verzeichnis für eingehende Dateien:"
 
-#: src/muuli_wdr.cpp:2298
+#: src/muuli_wdr.cpp:2270
 msgid "Change priority for new assigned files :"
 msgstr "Priorität bei neu zugewiesenen Dateien ändern:"
 
-#: src/muuli_wdr.cpp:2302
+#: src/muuli_wdr.cpp:2274
 msgid "Don't change"
 msgstr "Nicht ändern"
 
-#: src/muuli_wdr.cpp:2314
+#: src/muuli_wdr.cpp:2286
 msgid "Select color for this Category (currently selected) :"
 msgstr "Farbe für diese Kategorie wählen (momentan ausgewählt):"
 
-#: src/muuli_wdr.cpp:2381 src/muuli_wdr.cpp:2400 src/muuli_wdr.cpp:2422
+#: src/muuli_wdr.cpp:2353 src/muuli_wdr.cpp:2372 src/muuli_wdr.cpp:2394
 msgid "Click this button to reset the log."
 msgstr "Drücke diesen Knopf, um das Log zurückzusetzen."
 
-#: src/muuli_wdr.cpp:2441
+#: src/muuli_wdr.cpp:2413
 msgid "Click on this button to update the servers list from URL ..."
 msgstr "Hier klicken, um die Serverliste über die angegebene URL zu aktualisieren"
 
-#: src/muuli_wdr.cpp:2445
+#: src/muuli_wdr.cpp:2417
 msgid "Server list"
 msgstr "Serverliste"
 
-#: src/muuli_wdr.cpp:2449
+#: src/muuli_wdr.cpp:2421
 msgid "Enter the url to a server.met file here and press the button to the left to update the list of known servers."
 msgstr "Hier die URL einer server.met eingeben, und dann den Knopf links vom Eingabefeld drücken, um die Serverliste zu aktualisieren."
 
-#: src/muuli_wdr.cpp:2454
+#: src/muuli_wdr.cpp:2426
 msgid "Add server manually: Name"
 msgstr "Server manuell hinzufügen: Name"
 
-#: src/muuli_wdr.cpp:2457
+#: src/muuli_wdr.cpp:2429
 msgid "Enter the name of the new server here"
 msgstr "Gib den Namen das neuen Servers hier ein"
 
-#: src/muuli_wdr.cpp:2459 src/ServerWnd.cpp:206
+#: src/muuli_wdr.cpp:2431 src/ServerWnd.cpp:206
 msgid "IP:Port"
 msgstr "IP:Port"
 
-#: src/muuli_wdr.cpp:2462
+#: src/muuli_wdr.cpp:2434
 msgid "Enter the IP of the server here, using the x.x.x.x format."
 msgstr "Hier die IP des Servers im Format x.x.x.x eingeben."
 
-#: src/muuli_wdr.cpp:2468
+#: src/muuli_wdr.cpp:2440
 msgid "Enter the port of the server here."
 msgstr "Hier den Serverport eingeben."
 
-#: src/muuli_wdr.cpp:2471
+#: src/muuli_wdr.cpp:2443
 msgid "Add manually a server (fill fields to the left before) ..."
 msgstr "Einen Server manuell hinzufügen (vorher bitte links die Felder ausfüllen)..."
 
-#: src/muuli_wdr.cpp:2500
+#: src/muuli_wdr.cpp:2472
 msgid "aMule Log"
 msgstr "aMule-Log"
 
-#: src/muuli_wdr.cpp:2508
+#: src/muuli_wdr.cpp:2480
 msgid "Server Info"
 msgstr "Serverinformation"
 
-#: src/muuli_wdr.cpp:2512
+#: src/muuli_wdr.cpp:2484
 msgid "ED2K Info"
 msgstr "eD2k-Info"
 
-#: src/muuli_wdr.cpp:2516
+#: src/muuli_wdr.cpp:2488
 msgid "Kad Info"
 msgstr "Kad-Info"
 
-#: src/muuli_wdr.cpp:2544
+#: src/muuli_wdr.cpp:2516
 msgid "Click on this button to update the nodes list from URL ..."
 msgstr "Zum Aktualisieren der nodes.dat von URL diese Schaltfläche drücken."
 
-#: src/muuli_wdr.cpp:2548
+#: src/muuli_wdr.cpp:2520
 msgid "Nodes (0)"
 msgstr "Knoten (0)"
 
-#: src/muuli_wdr.cpp:2552
+#: src/muuli_wdr.cpp:2524
 msgid "Enter the url to a nodes.dat file here and press the button to the left to update the list of known nodes."
 msgstr "Hier die URL einer nodes.dat eingeben, und dann den Knopf links vom Eingabefeld drücken, um die Liste der bekannten Knoten zu aktualisieren."
 
-#: src/muuli_wdr.cpp:2555
+#: src/muuli_wdr.cpp:2527
 msgid "Nodes stats"
 msgstr "Knotenstatistik"
 
-#: src/muuli_wdr.cpp:2597
+#: src/muuli_wdr.cpp:2569
 msgid "Bootstrap"
 msgstr "Bootstrap"
 
-#: src/muuli_wdr.cpp:2600
+#: src/muuli_wdr.cpp:2572
 msgid "New node"
 msgstr "Neuer Knoten"
 
-#: src/muuli_wdr.cpp:2605
+#: src/muuli_wdr.cpp:2577
 msgid "IP:"
 msgstr "IP:"
 
-#: src/muuli_wdr.cpp:2625
+#: src/muuli_wdr.cpp:2597
 msgid "Port:"
 msgstr "Port:"
 
-#: src/muuli_wdr.cpp:2638
+#: src/muuli_wdr.cpp:2610
 msgid "Bootstrap from known clients"
 msgstr "Bootstrap von bekannten Clients"
 
-#: src/muuli_wdr.cpp:2640
+#: src/muuli_wdr.cpp:2612
 msgid "Disconnect Kad"
 msgstr "Kad trennen"
 
-#: src/muuli_wdr.cpp:2674
+#: src/muuli_wdr.cpp:2646
 msgid "Use Secure User Identification"
 msgstr "Benutze sichere Benutzeridentifikation"
 
-#: src/muuli_wdr.cpp:2676
+#: src/muuli_wdr.cpp:2648
 msgid "It is recommended to enable this option. You will not receive credits if SUI is not enabled."
 msgstr "Es wird empfohlen diese Option zu aktivieren. Du wirst keine Credits erhalten, wenn SUI nicht aktiviert ist."
 
-#: src/muuli_wdr.cpp:2678
+#: src/muuli_wdr.cpp:2650
 msgid "Protocol Obfuscation"
 msgstr "Protokollverschleierung"
 
-#: src/muuli_wdr.cpp:2681
+#: src/muuli_wdr.cpp:2653
 msgid "Support Protocol Obfuscation"
 msgstr "Unterstütze Protokollverschleierung"
 
-#: src/muuli_wdr.cpp:2683
+#: src/muuli_wdr.cpp:2655
 msgid "This option enabled Protocol Obfuscation, and makes aMule accept obfuscated connections from other clients."
 msgstr "Diese Option aktiviert die Protokollverschleierung und verfügt aMule, verschleierte Verbindungen von anderen Clients anzunehmen."
 
-#: src/muuli_wdr.cpp:2685
+#: src/muuli_wdr.cpp:2657
 msgid "Use obfuscation for outgoing connections"
 msgstr "Verschleiere ausgehende Verbindungen"
 
-#: src/muuli_wdr.cpp:2687
+#: src/muuli_wdr.cpp:2659
 msgid "This option makes aMule use Protocol Obfuscation when connecting other clients/servers."
 msgstr "Diese Option verfügt aMule, Protokollverschleierung zu verwenden bei der Verbindung zu anderen Clients und/oder Servern."
 
-#: src/muuli_wdr.cpp:2689
+#: src/muuli_wdr.cpp:2661
 msgid "Accept only obfuscated connections"
 msgstr "Akzeptiere ausschließlich verschleierte Verbindungen"
 
-#: src/muuli_wdr.cpp:2690
+#: src/muuli_wdr.cpp:2662
 msgid "This option makes aMule only accept obfuscated connections. You will have less sources, but all your traffic will be obfuscated"
 msgstr "Diese Option verfügt aMule, ausschließlich verschleierte Verbindungen zu akzeptieren. Das führt zu weniger Quellen, jedoch ist sämtlicher Verkehr verschleiert."
 
-#: src/muuli_wdr.cpp:2695
+#: src/muuli_wdr.cpp:2667
 msgid "Everybody"
 msgstr "Jeder"
 
-#: src/muuli_wdr.cpp:2697
+#: src/muuli_wdr.cpp:2669
 msgid "No one"
 msgstr "Niemand"
 
-#: src/muuli_wdr.cpp:2699
+#: src/muuli_wdr.cpp:2671
 msgid "Who can see my shared files:"
 msgstr "Wer kann freigegebene Dateien sehen:"
 
-#: src/muuli_wdr.cpp:2700
+#: src/muuli_wdr.cpp:2672
 msgid "Select who can request to view a list of your shared files."
 msgstr "Wähle, wer deine freigegebenen Dateien einsehen darf."
 
-#: src/muuli_wdr.cpp:2702
+#: src/muuli_wdr.cpp:2674
 msgid "IP-Filtering"
 msgstr "IP-Filterung"
 
-#: src/muuli_wdr.cpp:2709
+#: src/muuli_wdr.cpp:2681
 msgid "Filter clients"
 msgstr "Filtere Clients"
 
-#: src/muuli_wdr.cpp:2711
+#: src/muuli_wdr.cpp:2683
 msgid "Enable filtering of the client IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "Aktiviere die Filterung von Client-IPs, die in der Datei ~/.aMule/ipfilter.dat definiert sind."
 
-#: src/muuli_wdr.cpp:2713
+#: src/muuli_wdr.cpp:2685
 msgid "Filter servers"
 msgstr "Filtere Server"
 
-#: src/muuli_wdr.cpp:2715
+#: src/muuli_wdr.cpp:2687
 msgid "Enable filtering of the server IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "Aktiviere das Filtern von Server-IPs, die in der Datei ~/.aMule/ipfilter.dat definiert sind."
 
-#: src/muuli_wdr.cpp:2719
+#: src/muuli_wdr.cpp:2691
 msgid "Reload List"
 msgstr "Aktualisieren der Liste"
 
-#: src/muuli_wdr.cpp:2720
+#: src/muuli_wdr.cpp:2692
 msgid "Reload the list of IPs to filter from the file ~/.aMule/ipfilter.dat"
 msgstr "Aktualisiert die Liste der zu filternden IPs in der ~/.aMule/ipfilter.dat"
 
-#: src/muuli_wdr.cpp:2726
+#: src/muuli_wdr.cpp:2698
 msgid "URL:"
 msgstr "URL:"
 
-#: src/muuli_wdr.cpp:2730 src/muuli_wdr.cpp:2923
+#: src/muuli_wdr.cpp:2702 src/muuli_wdr.cpp:2895
 msgid "Update now"
 msgstr "Jetzt aktualisieren"
 
-#: src/muuli_wdr.cpp:2733
+#: src/muuli_wdr.cpp:2705
 msgid "Auto-update ipfilter at startup"
 msgstr "IP-Filter beim Start automatisch aktualisieren"
 
-#: src/muuli_wdr.cpp:2737
+#: src/muuli_wdr.cpp:2709
 msgid "Filtering Level:"
 msgstr "Filterstufe:"
 
-#: src/muuli_wdr.cpp:2743
+#: src/muuli_wdr.cpp:2715
 msgid "Always filter LAN IPs"
 msgstr "LAN-IP-Adressen immer filtern"
 
-#: src/muuli_wdr.cpp:2746
+#: src/muuli_wdr.cpp:2718
 msgid "Paranoid handling of non-matching IPs"
 msgstr "Paranoides Handhaben nicht-passender IP-Adressen"
 
-#: src/muuli_wdr.cpp:2748
+#: src/muuli_wdr.cpp:2720
 msgid "Rejects a packet when its source IP differs from the IP the client claims (an anti-spoofing check). Disable only if it causes connection problems."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2750
+#: src/muuli_wdr.cpp:2722
 msgid "Use system-wide ipfilter.dat if available"
 msgstr "Benutze systemweite ipfilter.dat, wenn verfügbar."
 
-#: src/muuli_wdr.cpp:2751
+#: src/muuli_wdr.cpp:2723
 msgid "If there's no local ipfilter.dat found, allow usage of a system-wide ipfilter file."
 msgstr "Erlaube die Benutzung der systemweiten ipfilter-Datei, falls keine lokale ipfilter.dat gefunden wird."
 
-#: src/muuli_wdr.cpp:2768
+#: src/muuli_wdr.cpp:2740
 msgid "Enable Online-Signature"
 msgstr "Online-Signatur aktivieren"
 
-#: src/muuli_wdr.cpp:2770
+#: src/muuli_wdr.cpp:2742
 msgid "Enables the writing of the OS file, which can be used by external apps to create signatures and the like."
 msgstr "Aktiviert das Schreiben der Online-Signaturdatei, die von externen Programmen verwendet werden kann, um Signaturen o.ä. zu erstellen."
 
-#: src/muuli_wdr.cpp:2774
+#: src/muuli_wdr.cpp:2746
 msgid "Update Frequency (Secs):"
 msgstr "Aktualisierungsintervall (Sekunden):"
 
-#: src/muuli_wdr.cpp:2777
+#: src/muuli_wdr.cpp:2749
 msgid "Change the frequency (in seconds) of Online Signature updates."
 msgstr "Ändern des Online-Signatur-Aktualisierungsintervalls (in Sekunden)."
 
-#: src/muuli_wdr.cpp:2785
+#: src/muuli_wdr.cpp:2757
 msgid "Save online signature file in: "
 msgstr "Speichere Online-Signatur-Datei in:"
 
-#: src/muuli_wdr.cpp:2791
+#: src/muuli_wdr.cpp:2763
 msgid "Click here to select the directory containing the the Online Signature files."
 msgstr "Hier klicken, um das Verzeichnis mit den Dateien für die Online-Signatur auszuwählen."
 
-#: src/muuli_wdr.cpp:2824
+#: src/muuli_wdr.cpp:2796
 msgid "Show country flags for clients"
 msgstr "Landesflaggen für Clients anzeigen"
 
-#: src/muuli_wdr.cpp:2825
+#: src/muuli_wdr.cpp:2797
 msgid "Render the country flag column in the transfers, queue and search views. Requires a valid MMDB GeoIP database (see below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2830
+#: src/muuli_wdr.cpp:2802
 #, fuzzy
 msgid "Database"
 msgstr "Datenrate:"
 
-#: src/muuli_wdr.cpp:2846
+#: src/muuli_wdr.cpp:2818
 #, fuzzy
 msgid "Source:"
 msgstr "Quellen"
 
-#: src/muuli_wdr.cpp:2849
+#: src/muuli_wdr.cpp:2821
 msgid "DB-IP (free, no account)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2850
+#: src/muuli_wdr.cpp:2822
 msgid "MaxMind GeoLite2 (free, account required)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2851
+#: src/muuli_wdr.cpp:2823
 msgid "Custom URL"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2854
+#: src/muuli_wdr.cpp:2826
 msgid "Choose which provider supplies the GeoIP MMDB database. DB-IP is the default - no account required. MaxMind requires a free account + license key. Use Custom URL to point at any other MMDB host (e.g. a local mirror)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2871
+#: src/muuli_wdr.cpp:2843
 msgid ""
 "No configuration required.\n"
 "\n"
@@ -4869,11 +4835,11 @@ msgid ""
 "License: Creative Commons BY 4.0 - https://creativecommons.org/licenses/by/4.0/"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2884
+#: src/muuli_wdr.cpp:2856
 msgid "License key:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2890
+#: src/muuli_wdr.cpp:2862
 msgid ""
 "Sign up for a free MaxMind account, then generate a License Key:\n"
 "https://www.maxmind.com/en/geolite2/signup\n"
@@ -4883,224 +4849,224 @@ msgid ""
 "Requires attribution and account registration; refresh at least every 30 days."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2905
+#: src/muuli_wdr.cpp:2877
 #, fuzzy
 msgid "Download URL:"
 msgstr "Download: "
 
-#: src/muuli_wdr.cpp:2911
+#: src/muuli_wdr.cpp:2883
 msgid ""
 "Must point to an .mmdb file or a .gz / .tar.gz containing one.\n"
 "URL may include credentials (https://user:pass@host/...).\n"
 "License and attribution terms are set by the upstream URL - you are responsible."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2924
+#: src/muuli_wdr.cpp:2896
 msgid "Download the GeoIP database from the selected source."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2926
+#: src/muuli_wdr.cpp:2898
 #, fuzzy
 msgid "Auto-update on startup"
 msgstr "IP-Filter beim Start automatisch aktualisieren"
 
-#: src/muuli_wdr.cpp:2927
+#: src/muuli_wdr.cpp:2899
 msgid "Re-download the GeoIP database from the selected source every time aMule starts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2950
+#: src/muuli_wdr.cpp:2922
 msgid "Filter incoming messages (except current chat):"
 msgstr "Eingehende Nachrichten filtern (außer momentanen Chats):"
 
-#: src/muuli_wdr.cpp:2952
+#: src/muuli_wdr.cpp:2924
 msgid "Filter all messages"
 msgstr "Filtere alle Nachrichten"
 
-#: src/muuli_wdr.cpp:2954
+#: src/muuli_wdr.cpp:2926
 msgid "Filter messages from people not on your friend list"
 msgstr "Filtere Nachrichten von Benutzern, die nicht auf deiner Freundesliste stehen"
 
-#: src/muuli_wdr.cpp:2956
+#: src/muuli_wdr.cpp:2928
 msgid "Filter messages from unknown clients"
 msgstr "Filtere Nachrichten von unbekannten Clients"
 
-#: src/muuli_wdr.cpp:2958
+#: src/muuli_wdr.cpp:2930
 msgid "Filter messages containing (use ',' as separator):"
 msgstr "Filtere Nachrichten, die folgende Worte enthalten (benutze ',' als Trenner):"
 
-#: src/muuli_wdr.cpp:2961 src/muuli_wdr.cpp:2972
+#: src/muuli_wdr.cpp:2933 src/muuli_wdr.cpp:2944
 msgid "add here the words amule should filter and block messages including it"
 msgstr "Hier die Worte eingeben, die aMule filtern soll, und um Nachrichten abzuweisen, in denen sie vorkommen"
 
-#: src/muuli_wdr.cpp:2963
+#: src/muuli_wdr.cpp:2935
 msgid "Show received messages in the log"
 msgstr "Zeige empfangene Nachrichten im Log an"
 
-#: src/muuli_wdr.cpp:2966
+#: src/muuli_wdr.cpp:2938
 msgid "Comments"
 msgstr "Kommentare"
 
-#: src/muuli_wdr.cpp:2969
+#: src/muuli_wdr.cpp:2941
 msgid "Filter comments containing (use ',' as separator):"
 msgstr "Filtere Komentare, die folgende Worte enthalten (benutze ',' als Trenner):"
 
-#: src/muuli_wdr.cpp:2994
+#: src/muuli_wdr.cpp:2966
 msgid "Enable Proxy"
 msgstr "Proxy aktivieren"
 
-#: src/muuli_wdr.cpp:2995
+#: src/muuli_wdr.cpp:2967
 msgid "Enable/disable proxy support"
 msgstr "Aktiviere/Deaktiviere Proxy-Unterstützung"
 
-#: src/muuli_wdr.cpp:2998
+#: src/muuli_wdr.cpp:2970
 msgid "Proxy type:"
 msgstr "Proxy-Typ:"
 
-#: src/muuli_wdr.cpp:3009
+#: src/muuli_wdr.cpp:2981
 msgid "Proxy host:"
 msgstr "Proxy-Host:"
 
-#: src/muuli_wdr.cpp:3012
+#: src/muuli_wdr.cpp:2984
 msgid "The proxy host name"
 msgstr "Der Hostname des Proxy"
 
-#: src/muuli_wdr.cpp:3014
+#: src/muuli_wdr.cpp:2986
 msgid "Proxy port:"
 msgstr "Proxy-Port:"
 
-#: src/muuli_wdr.cpp:3017
+#: src/muuli_wdr.cpp:2989
 msgid "The proxy port"
 msgstr "Der Port des Proxy"
 
-#: src/muuli_wdr.cpp:3019
+#: src/muuli_wdr.cpp:2991
 msgid "Enable authentication"
 msgstr "Authentifizierung aktivieren"
 
-#: src/muuli_wdr.cpp:3020
+#: src/muuli_wdr.cpp:2992
 msgid "Enable/disable username/password authentication"
 msgstr "Aktiviere/Deaktiviere Authentifizierung mit Benutzername/Passwort"
 
-#: src/muuli_wdr.cpp:3023
+#: src/muuli_wdr.cpp:2995
 msgid "Username: "
 msgstr "Benutzername:"
 
-#: src/muuli_wdr.cpp:3026
+#: src/muuli_wdr.cpp:2998
 msgid "The username to use to connect to the proxy"
 msgstr "Der Benutzername, um sich beim Proxy anzumelden"
 
-#: src/muuli_wdr.cpp:3028
+#: src/muuli_wdr.cpp:3000
 msgid "Password:"
 msgstr "Passwort:"
 
-#: src/muuli_wdr.cpp:3031
+#: src/muuli_wdr.cpp:3003
 msgid "The password to use to connect to the proxy"
 msgstr "Proxy-Verbindungspasswort"
 
-#: src/muuli_wdr.cpp:3050
+#: src/muuli_wdr.cpp:3022
 msgid "Connect to:"
 msgstr "Verbinde zu:"
 
-#: src/muuli_wdr.cpp:3059
+#: src/muuli_wdr.cpp:3031
 msgid "Login to remote amule"
 msgstr "Beim entfernten aMule anmelden"
 
-#: src/muuli_wdr.cpp:3064
+#: src/muuli_wdr.cpp:3036
 msgid "User name"
 msgstr "Benutzername"
 
-#: src/muuli_wdr.cpp:3075
+#: src/muuli_wdr.cpp:3047
 msgid "Remember those settings"
 msgstr "Diese Einstellungen speichern"
 
-#: src/muuli_wdr.cpp:3078
+#: src/muuli_wdr.cpp:3050
 msgid "Force ZLIB compression"
 msgstr "ZLIB-Kompression erzwingen"
 
-#: src/muuli_wdr.cpp:3102
+#: src/muuli_wdr.cpp:3074
 msgid "Enable Verbose Debug-Logging."
 msgstr "Aktiviere ausführliche Debug-Protokollierung"
 
-#: src/muuli_wdr.cpp:3104
+#: src/muuli_wdr.cpp:3076
 msgid "Only to Logfile"
 msgstr "Nur in Logdatei"
 
-#: src/muuli_wdr.cpp:3106
+#: src/muuli_wdr.cpp:3078
 msgid "Message Categories:"
 msgstr "Nachrichtenkategorien:"
 
-#: src/muuli_wdr.cpp:3130 src/PartFileConvertDlg.cpp:160
+#: src/muuli_wdr.cpp:3102 src/PartFileConvertDlg.cpp:160
 msgid "Waiting..."
 msgstr "Wartend..."
 
-#: src/muuli_wdr.cpp:3150
+#: src/muuli_wdr.cpp:3122
 msgid "Add imports"
 msgstr "Füge Importe hinzu"
 
-#: src/muuli_wdr.cpp:3153
+#: src/muuli_wdr.cpp:3125
 msgid "Retry selected"
 msgstr "Versuche Ausgewähltes noch einmal"
 
-#: src/muuli_wdr.cpp:3155
+#: src/muuli_wdr.cpp:3127
 msgid "Remove selected"
 msgstr "Auswahl entfernen"
 
-#: src/muuli_wdr.cpp:3218
+#: src/muuli_wdr.cpp:3190
 msgid "Event Types"
 msgstr "Ereignisarten"
 
-#: src/muuli_wdr.cpp:3237
+#: src/muuli_wdr.cpp:3209
 msgid "Statistics and queued clients for selected file(s) : Session / All time"
 msgstr "Statistiken und Clients in der Warteschlange für ausgewählte Datei(en): Sitzung / Insgesamt"
 
-#: src/muuli_wdr.cpp:3261
+#: src/muuli_wdr.cpp:3233
 msgid "Active Uploads"
 msgstr "Aktive Uploads"
 
-#: src/muuli_wdr.cpp:3275
+#: src/muuli_wdr.cpp:3247
 msgid "Percent of total files"
 msgstr "Prozent aller Dateien"
 
-#: src/muuli_wdr.cpp:3327
+#: src/muuli_wdr.cpp:3299
 msgid "Show Clients for"
 msgstr "Clients anzeigen für"
 
-#: src/muuli_wdr.cpp:3329
+#: src/muuli_wdr.cpp:3301
 msgid "All files"
 msgstr "Alle Dateien"
 
-#: src/muuli_wdr.cpp:3332
+#: src/muuli_wdr.cpp:3304
 msgid "Selected files"
 msgstr "Ausgewählte Dateien"
 
-#: src/muuli_wdr.cpp:3335
+#: src/muuli_wdr.cpp:3307
 msgid "Active uploads only"
 msgstr "Nur aktive Uploads"
 
-#: src/muuli_wdr.cpp:3342
+#: src/muuli_wdr.cpp:3314
 msgid "Reload:"
 msgstr "Aktualisieren:"
 
-#: src/muuli_wdr.cpp:3346
+#: src/muuli_wdr.cpp:3318
 msgid "Reload your shared files"
 msgstr "Freigegebene Dateien neu laden"
 
-#: src/muuli_wdr.cpp:3409
+#: src/muuli_wdr.cpp:3381
 msgid "Send"
 msgstr "Senden"
 
-#: src/muuli_wdr.cpp:3410
+#: src/muuli_wdr.cpp:3382
 msgid "Sends the specified message."
 msgstr "Sendet die angegebene Nachricht."
 
-#: src/muuli_wdr.cpp:3414
+#: src/muuli_wdr.cpp:3386
 msgid "Close this chat-session."
 msgstr "Schließe diese Chat-Sitzung."
 
-#: src/muuli_wdr.cpp:3437
+#: src/muuli_wdr.cpp:3409
 msgid "Connect to any server and/or Kad"
 msgstr "Mit irgendeinem Server und/oder Kad verbinden"
 
-#: src/muuli_wdr.cpp:3443 src/SharedFilesCtrl.cpp:142 src/Statistics.cpp:941
+#: src/muuli_wdr.cpp:3415 src/SharedFilesCtrl.cpp:142 src/Statistics.cpp:941
 msgid "Shared Files"
 msgstr "Freigaben"
 
@@ -5460,249 +5426,249 @@ msgstr "Heruntergeladen"
 msgid "ERROR: Failed to open partfile '%s'"
 msgstr "FEHLER: Öffnen von Partfile '%s' fehlgeschlagen"
 
-#: src/Preferences.cpp:701
+#: src/Preferences.cpp:673
 msgid "System default"
 msgstr "Systemvorgabe"
 
-#: src/Preferences.cpp:702
+#: src/Preferences.cpp:674
 msgid "Albanian"
 msgstr "Albanisch"
 
-#: src/Preferences.cpp:703
+#: src/Preferences.cpp:675
 msgid "Arabic"
 msgstr "Arabisch"
 
-#: src/Preferences.cpp:704
+#: src/Preferences.cpp:676
 msgid "Asturian"
 msgstr "Asturisch"
 
-#: src/Preferences.cpp:705
+#: src/Preferences.cpp:677
 msgid "Basque"
 msgstr "Baskisch"
 
-#: src/Preferences.cpp:706
+#: src/Preferences.cpp:678
 msgid "Bulgarian"
 msgstr "Bulgarisch"
 
-#: src/Preferences.cpp:707
+#: src/Preferences.cpp:679
 msgid "Catalan"
 msgstr "Katalanisch"
 
-#: src/Preferences.cpp:708
+#: src/Preferences.cpp:680
 msgid "Chinese (Simplified)"
 msgstr "Chinesisch (vereinfacht)"
 
-#: src/Preferences.cpp:709
+#: src/Preferences.cpp:681
 msgid "Chinese (Traditional)"
 msgstr "Chinesisch (traditionell)"
 
-#: src/Preferences.cpp:710
+#: src/Preferences.cpp:682
 msgid "Croatian"
 msgstr "Kroatisch"
 
-#: src/Preferences.cpp:711
+#: src/Preferences.cpp:683
 msgid "Czech"
 msgstr "Tschechisch"
 
-#: src/Preferences.cpp:712
+#: src/Preferences.cpp:684
 msgid "Danish"
 msgstr "Dänisch"
 
-#: src/Preferences.cpp:713
+#: src/Preferences.cpp:685
 msgid "Dutch"
 msgstr "Holländisch"
 
-#: src/Preferences.cpp:714
+#: src/Preferences.cpp:686
 msgid "English (U.K.)"
 msgstr "Englisch (UK)"
 
-#: src/Preferences.cpp:715
+#: src/Preferences.cpp:687
 #, fuzzy
 msgid "English (U.S.)"
 msgstr "Englisch (UK)"
 
-#: src/Preferences.cpp:716
+#: src/Preferences.cpp:688
 msgid "Estonian"
 msgstr "Estnisch"
 
-#: src/Preferences.cpp:717
+#: src/Preferences.cpp:689
 msgid "Finnish"
 msgstr "Finnisch"
 
-#: src/Preferences.cpp:718
+#: src/Preferences.cpp:690
 msgid "French"
 msgstr "Französisch"
 
-#: src/Preferences.cpp:719
+#: src/Preferences.cpp:691
 msgid "Galician"
 msgstr "Galizisch"
 
-#: src/Preferences.cpp:720
+#: src/Preferences.cpp:692
 msgid "German"
 msgstr "Deutsch"
 
-#: src/Preferences.cpp:721
+#: src/Preferences.cpp:693
 msgid "Greek"
 msgstr "Griechisch"
 
-#: src/Preferences.cpp:722
+#: src/Preferences.cpp:694
 msgid "Hebrew"
 msgstr "Hebräisch"
 
-#: src/Preferences.cpp:723
+#: src/Preferences.cpp:695
 msgid "Hungarian"
 msgstr "Ungarisch"
 
-#: src/Preferences.cpp:724
+#: src/Preferences.cpp:696
 msgid "Italian"
 msgstr "Italienisch"
 
-#: src/Preferences.cpp:725
+#: src/Preferences.cpp:697
 msgid "Japanese"
 msgstr "Japanisch"
 
-#: src/Preferences.cpp:726
+#: src/Preferences.cpp:698
 msgid "Korean"
 msgstr "Koreanisch"
 
-#: src/Preferences.cpp:727
+#: src/Preferences.cpp:699
 msgid "Latvian"
 msgstr ""
 
-#: src/Preferences.cpp:728
+#: src/Preferences.cpp:700
 msgid "Lithuanian"
 msgstr "Litauisch"
 
-#: src/Preferences.cpp:729
+#: src/Preferences.cpp:701
 msgid "Norwegian (Nynorsk)"
 msgstr "Norwegisch"
 
-#: src/Preferences.cpp:730
+#: src/Preferences.cpp:702
 msgid "Polish"
 msgstr "Polnisch"
 
-#: src/Preferences.cpp:731
+#: src/Preferences.cpp:703
 msgid "Portuguese"
 msgstr "Portugiesisch"
 
-#: src/Preferences.cpp:732
+#: src/Preferences.cpp:704
 msgid "Portuguese (Brazilian)"
 msgstr "Portugiesisch (Brasilianisch)"
 
-#: src/Preferences.cpp:733
+#: src/Preferences.cpp:705
 msgid "Romanian"
 msgstr "Rumänisch"
 
-#: src/Preferences.cpp:734
+#: src/Preferences.cpp:706
 msgid "Russian"
 msgstr "Russisch"
 
-#: src/Preferences.cpp:735
+#: src/Preferences.cpp:707
 msgid "Slovenian"
 msgstr "Slowenisch"
 
-#: src/Preferences.cpp:736
+#: src/Preferences.cpp:708
 msgid "Spanish"
 msgstr "Spanisch"
 
-#: src/Preferences.cpp:737
+#: src/Preferences.cpp:709
 msgid "Swedish"
 msgstr "Schwedisch"
 
-#: src/Preferences.cpp:738
+#: src/Preferences.cpp:710
 msgid "Turkish"
 msgstr "Türkisch"
 
-#: src/Preferences.cpp:739
+#: src/Preferences.cpp:711
 msgid "Ukrainian"
 msgstr "Ukrainisch"
 
-#: src/Preferences.cpp:842
+#: src/Preferences.cpp:814
 msgid "Change Language"
 msgstr "Sprache ändern"
 
-#: src/Preferences.cpp:906
+#: src/Preferences.cpp:878
 msgid "There are no translations installed for aMule"
 msgstr "Für aMule sind keine Übersetzungen installiert"
 
-#: src/Preferences.cpp:907
+#: src/Preferences.cpp:879
 msgid "No languages available"
 msgstr "Keine Sprachen verfügbar"
 
-#: src/Preferences.cpp:1038
+#: src/Preferences.cpp:1010
 msgid "no options available"
 msgstr "keine Optionen verfügbar"
 
-#: src/Preferences.cpp:2226
+#: src/Preferences.cpp:2179
 msgid "Invalid category found, skipping"
 msgstr "Ungültige Kategorie gefunden, überspringe."
 
-#: src/Preferences.cpp:2395
+#: src/Preferences.cpp:2348
 msgid "TCP port can't be higher than 65532 due to server UDP socket being TCP+3"
 msgstr "TCP-Port kann nicht größer als 65532 sein, da der Server-UDP-Port=TCP-Port+3 ist"
 
-#: src/Preferences.cpp:2396
+#: src/Preferences.cpp:2349
 #, c-format
 msgid "Default port will be used (%d)"
 msgstr "Standard-Port wird verwendet (%d)"
 
-#: src/PrefsUnifiedDlg.cpp:300 src/Statistics.cpp:866
+#: src/PrefsUnifiedDlg.cpp:298 src/Statistics.cpp:866
 msgid "Connection"
 msgstr "Verbindung"
 
-#: src/PrefsUnifiedDlg.cpp:301 src/SearchListCtrl.cpp:117
+#: src/PrefsUnifiedDlg.cpp:299 src/SearchListCtrl.cpp:117
 msgid "Directories"
 msgstr "Verzeichnisse"
 
-#: src/PrefsUnifiedDlg.cpp:302 src/Statistics.cpp:917
+#: src/PrefsUnifiedDlg.cpp:300 src/Statistics.cpp:917
 msgid "Servers"
 msgstr "Server"
 
-#: src/PrefsUnifiedDlg.cpp:303 src/ServerListCtrl.cpp:96
+#: src/PrefsUnifiedDlg.cpp:301 src/ServerListCtrl.cpp:96
 msgid "Files"
 msgstr "Dateien"
 
-#: src/PrefsUnifiedDlg.cpp:304
+#: src/PrefsUnifiedDlg.cpp:302
 msgid "Security"
 msgstr "Sicherheit"
 
-#: src/PrefsUnifiedDlg.cpp:305
+#: src/PrefsUnifiedDlg.cpp:303
 msgid "Interface"
 msgstr "Aussehen"
 
-#: src/PrefsUnifiedDlg.cpp:312
+#: src/PrefsUnifiedDlg.cpp:310
 msgid "IP2Country"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:315
+#: src/PrefsUnifiedDlg.cpp:313
 msgid "Proxy"
 msgstr "Proxy"
 
-#: src/PrefsUnifiedDlg.cpp:316
+#: src/PrefsUnifiedDlg.cpp:314
 msgid "Filters"
 msgstr "Filter"
 
-#: src/PrefsUnifiedDlg.cpp:317
+#: src/PrefsUnifiedDlg.cpp:315
 msgid "Remote Controls"
 msgstr "Fernsteuerung"
 
-#: src/PrefsUnifiedDlg.cpp:318
+#: src/PrefsUnifiedDlg.cpp:316
 msgid "Online Signature"
 msgstr "Onlinesignatur"
 
-#: src/PrefsUnifiedDlg.cpp:319
+#: src/PrefsUnifiedDlg.cpp:317
 msgid "Advanced"
 msgstr "Fortgeschritten"
 
-#: src/PrefsUnifiedDlg.cpp:320
+#: src/PrefsUnifiedDlg.cpp:318
 msgid "Events"
 msgstr "Ereignisse"
 
-#: src/PrefsUnifiedDlg.cpp:323
+#: src/PrefsUnifiedDlg.cpp:321
 msgid "Debugging"
 msgstr "Fehlersuche (Debugging)"
 
-#: src/PrefsUnifiedDlg.cpp:453
+#: src/PrefsUnifiedDlg.cpp:451
 msgid ""
 "The following variables will be substituted:\n"
 "    %PARTFILE - full path to the file\n"
@@ -5712,15 +5678,15 @@ msgstr ""
 "    %PARTFILE - ganzer Pfad zur Datei\n"
 "    %PARTNAME - nur der Dateiname"
 
-#: src/PrefsUnifiedDlg.cpp:474
+#: src/PrefsUnifiedDlg.cpp:472
 msgid "Tray icon support requires libayatana-appindicator3 at compile time."
 msgstr "Tray-Icon unterstützung benötigt libayatana-appindicator3 beim kompilieren."
 
-#: src/PrefsUnifiedDlg.cpp:490
+#: src/PrefsUnifiedDlg.cpp:488
 msgid "Not available on Wayland: the protocol does not report when a window is minimized, so this option cannot intercept the system minimize button. Workaround: launch aMule with `GDK_BACKEND=x11` to use XWayland instead."
 msgstr "Auf Wayland nicht verfügbar: Das Protokoll meldet nicht wenn ein Fenster minimiert is, sodass diese Option nicht auf die Minimieren Schaltfläche des System reagieren kann. Workaround: aMule mit `GDK_BACKEND=x11 starten um XWayland zu verwenden."
 
-#: src/PrefsUnifiedDlg.cpp:536
+#: src/PrefsUnifiedDlg.cpp:534
 msgid ""
 "Do not change these setting unless you know\n"
 "what you are doing, otherwise you can easily\n"
@@ -5736,35 +5702,26 @@ msgstr ""
 "aMule funktioniert auch hervorragend, ohne\n"
 "dass diese Einstellungen verändert werden."
 
-#: src/PrefsUnifiedDlg.cpp:647
+#: src/PrefsUnifiedDlg.cpp:645
 #, c-format
 msgid "Failed to connect Cfg to widget with the ID %d and key %s"
 msgstr "Verbindung von Einstellung zu Steuerelement mit ID %d und Schlüssel %s fehlgeschlagen."
 
-#: src/PrefsUnifiedDlg.cpp:695
+#: src/PrefsUnifiedDlg.cpp:693
 #, c-format
 msgid "Failed to transfer data from Cfg to Widget with the ID %d and key %s"
 msgstr "Datentransfer von Einstellung zu Steuerelement mit ID %d und Schlüssel %s fehlgeschlagen."
 
-#: src/PrefsUnifiedDlg.cpp:801
+#: src/PrefsUnifiedDlg.cpp:799
 msgid "The type of proxy you are connecting to"
 msgstr "Der Typ des Proxy, zu dem du verbindest"
 
-#: src/PrefsUnifiedDlg.cpp:1020
+#: src/PrefsUnifiedDlg.cpp:1003
 #, c-format
 msgid "Failed to transfer data from Widget to Cfg with the ID %d and key %s"
 msgstr "Datentransfer von Steuerelement zu Einstellung mit ID %d und Schlüssel %s fehlgeschlagen."
 
 #: src/PrefsUnifiedDlg.cpp:1103
-#, fuzzy
-msgid "No password set."
-msgstr "Prüfe Passwort\n"
-
-#: src/PrefsUnifiedDlg.cpp:1132
-msgid "Guest access needs a password. Type one in the guest password field, or untick Enable guest access."
-msgstr ""
-
-#: src/PrefsUnifiedDlg.cpp:1144
 msgid ""
 "aMule must be restarted to enable these changes:\n"
 "\n"
@@ -5772,41 +5729,41 @@ msgstr ""
 "aMule muss neu gestartet werden, um diese Änderungen zu übernehmen:\n"
 "\n"
 
-#: src/PrefsUnifiedDlg.cpp:1151
+#: src/PrefsUnifiedDlg.cpp:1110
 msgid "- TCP port changed.\n"
 msgstr "- TCP-Port geändert.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1156
+#: src/PrefsUnifiedDlg.cpp:1115
 msgid "- UDP port changed.\n"
 msgstr "- UDP-Port geändert.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1161
+#: src/PrefsUnifiedDlg.cpp:1120
 #, fuzzy
 msgid "- Network interface binding changed.\n"
 msgstr "- Schnittstelle der externen Verbindung geändert.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1166
+#: src/PrefsUnifiedDlg.cpp:1125
 msgid "- External connect port changed.\n"
 msgstr "- Port externer Verbindung geändert.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1170
+#: src/PrefsUnifiedDlg.cpp:1129
 msgid "- External connect acceptance changed.\n"
 msgstr "- Akzeptanz externer Verbindung geändert.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1174
+#: src/PrefsUnifiedDlg.cpp:1133
 msgid "- External connect interface changed.\n"
 msgstr "- Schnittstelle der externen Verbindung geändert.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1178
+#: src/PrefsUnifiedDlg.cpp:1137
 msgid "- Protocol obfuscation support changed.\n"
 msgstr "- Unterstützung für Protokollverschleierung geändert.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1193
+#: src/PrefsUnifiedDlg.cpp:1151
 #, fuzzy
 msgid "- amuleapi settings changed.\n"
 msgstr "- Sprache geändert.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1202
+#: src/PrefsUnifiedDlg.cpp:1160
 msgid ""
 "Your Auto-update server list is empty.\n"
 "'Auto-update server list at startup' will be disabled."
@@ -5814,7 +5771,7 @@ msgstr ""
 "Die Auto-Update-Serverliste ist leer.\n"
 "'Serverliste beim Programmstart aktualisieren' wird deaktiviert."
 
-#: src/PrefsUnifiedDlg.cpp:1213
+#: src/PrefsUnifiedDlg.cpp:1171
 msgid ""
 "You have enabled external connections but have not specified a password.\n"
 "External connections cannot be enabled unless a valid password is specified."
@@ -5822,33 +5779,28 @@ msgstr ""
 "Du hast die externen Verbindungen aktiviert, aber kein Passwort angegeben.\n"
 "Externe Verbindungen können nur aktiviert werden, wenn ein gültiges Passwort angegeben wird."
 
-#: src/PrefsUnifiedDlg.cpp:1246
-#, c-format
-msgid "The amuleapi password could not be saved: %s"
-msgstr ""
-
-#: src/PrefsUnifiedDlg.cpp:1276
+#: src/PrefsUnifiedDlg.cpp:1202
 msgid "- Language changed.\n"
 msgstr "- Sprache geändert.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1281
+#: src/PrefsUnifiedDlg.cpp:1207
 msgid "- Temp folder changed.\n"
 msgstr "- Temp-Verzeichnis geändert.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1286
+#: src/PrefsUnifiedDlg.cpp:1212
 msgid "- ED2K network enabled.\n"
 msgstr "- ED2k-Netzwerk aktiviert.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1319
+#: src/PrefsUnifiedDlg.cpp:1245
 msgid "The shared-file exclusion pattern is not a valid regular expression. The filter has been left disabled."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1321 src/PrefsUnifiedDlg.cpp:1921
+#: src/PrefsUnifiedDlg.cpp:1247 src/PrefsUnifiedDlg.cpp:1841
 #, fuzzy
 msgid "Invalid regular expression"
 msgstr "Ungültige Protokollversion."
 
-#: src/PrefsUnifiedDlg.cpp:1398
+#: src/PrefsUnifiedDlg.cpp:1324
 msgid ""
 "Both eD2k and Kad network are disabled.\n"
 "You won't be able to connect until you enable at least one of them."
@@ -5856,7 +5808,7 @@ msgstr ""
 "Beide Netzwerke, eD2k und Kad, sind deaktiviert.\n"
 "Mindestens eins davon muss aktiviert sein, um sich verbinden zu können."
 
-#: src/PrefsUnifiedDlg.cpp:1403
+#: src/PrefsUnifiedDlg.cpp:1329
 msgid ""
 "Kad will not start if your UDP port is disabled.\n"
 "Enable UDP port or disable Kad."
@@ -5864,7 +5816,7 @@ msgstr ""
 "Kad wird nicht starten, solange der UDP-Port deaktiviert ist.\n"
 "Bitte UDP-Port aktivieren, oder Kad ausschalten."
 
-#: src/PrefsUnifiedDlg.cpp:1459
+#: src/PrefsUnifiedDlg.cpp:1385
 msgid ""
 "\n"
 "You MUST restart aMule now.\n"
@@ -5874,71 +5826,71 @@ msgstr ""
 "aMule MUSS jetzt neu gestartet werden.\n"
 "Wenn du jetzt nicht neu startest, beklage dich nicht, wenn irgendwas übles passiert.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1524
+#: src/PrefsUnifiedDlg.cpp:1450
 msgid "Could not register aMule for autostart at login. The autostart store may be read-only."
 msgstr "Konnte aMule nicht für Autostart registrieren. Der Ort dafür könnte nicht beschreibbar sein."
 
-#: src/PrefsUnifiedDlg.cpp:1526
+#: src/PrefsUnifiedDlg.cpp:1452
 msgid "Could not remove the autostart-at-login entry."
 msgstr "Konnte den Autostart-Bei-Login Eintrag nicht entfernen."
 
-#: src/PrefsUnifiedDlg.cpp:1527
+#: src/PrefsUnifiedDlg.cpp:1453
 msgid "Autostart"
 msgstr "Autostart"
 
-#: src/PrefsUnifiedDlg.cpp:1542
+#: src/PrefsUnifiedDlg.cpp:1468
 msgid "Register file type"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1542
+#: src/PrefsUnifiedDlg.cpp:1468
 msgid "Register URL handler"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1550
+#: src/PrefsUnifiedDlg.cpp:1476
 #, c-format
 msgid "aMule only handles eD2k-compatible magnets. If you replace the current magnet handler (%s), BitTorrent magnet links will stop working - aMule cannot download BitTorrent content. Continue?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1555
+#: src/PrefsUnifiedDlg.cpp:1481
 #, c-format
 msgid "Another application currently opens .emulecollection files (%s). Replace it with aMule?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1560
+#: src/PrefsUnifiedDlg.cpp:1486
 #, c-format
 msgid "Another application is currently the default handler for these links (%s). Replace it with aMule?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1585
+#: src/PrefsUnifiedDlg.cpp:1511
 #, fuzzy
 msgid "Could not register aMule for .emulecollection files. The registration store may be read-only."
 msgstr "Konnte aMule nicht für Autostart registrieren. Der Ort dafür könnte nicht beschreibbar sein."
 
-#: src/PrefsUnifiedDlg.cpp:1587
+#: src/PrefsUnifiedDlg.cpp:1513
 #, fuzzy
 msgid "Could not remove the file type registration."
 msgstr "Konnte den Autostart-Bei-Login Eintrag nicht entfernen."
 
-#: src/PrefsUnifiedDlg.cpp:1589
+#: src/PrefsUnifiedDlg.cpp:1515
 #, fuzzy
 msgid "Could not register aMule as the URL handler. The registration store may be read-only."
 msgstr "Konnte aMule nicht für Autostart registrieren. Der Ort dafür könnte nicht beschreibbar sein."
 
-#: src/PrefsUnifiedDlg.cpp:1591
+#: src/PrefsUnifiedDlg.cpp:1517
 #, fuzzy
 msgid "Could not remove the URL handler registration."
 msgstr "Konnte den Autostart-Bei-Login Eintrag nicht entfernen."
 
-#: src/PrefsUnifiedDlg.cpp:1661 src/PrefsUnifiedDlg.cpp:1688
+#: src/PrefsUnifiedDlg.cpp:1587 src/PrefsUnifiedDlg.cpp:1614
 #, fuzzy
 msgid "The web server and aMule API require external connections to be enabled."
 msgstr "Passwort eingestellt und externe Verbindungen aktiviert."
 
-#: src/PrefsUnifiedDlg.cpp:1671
+#: src/PrefsUnifiedDlg.cpp:1597
 msgid "The aMule web server is deprecated. Consider running the aMule API instead."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1735
+#: src/PrefsUnifiedDlg.cpp:1655
 msgid ""
 "Your Auto-update servers list is in blank.\n"
 "Please fill in at least one URL to point to a valid server.met file.\n"
@@ -5948,66 +5900,66 @@ msgstr ""
 "Bitte gib mindestens eine URL zu einer gültigen server.met ein.\n"
 "Drücke dazu den Knopf \"Liste\" neben diesem Kontrollkästchen."
 
-#: src/PrefsUnifiedDlg.cpp:1876
+#: src/PrefsUnifiedDlg.cpp:1796
 msgid "Temporary files"
 msgstr "Temporäre Dateien"
 
-#: src/PrefsUnifiedDlg.cpp:1881
+#: src/PrefsUnifiedDlg.cpp:1801
 msgid "Incoming files"
 msgstr "Fertige Dateien"
 
-#: src/PrefsUnifiedDlg.cpp:1886
+#: src/PrefsUnifiedDlg.cpp:1806
 msgid "Online Signatures"
 msgstr "Online-Signaturen"
 
-#: src/PrefsUnifiedDlg.cpp:1899
+#: src/PrefsUnifiedDlg.cpp:1819
 #, c-format
 msgid "Choose a folder for %s"
 msgstr "Wähle einen Ordner für %s"
 
-#: src/PrefsUnifiedDlg.cpp:1923
+#: src/PrefsUnifiedDlg.cpp:1843
 #, fuzzy, c-format
 msgid "Would exclude %u of %u shared file"
 msgid_plural "Would exclude %u of %u shared files"
 msgstr[0] "%i bekannte freigegebene Datei gefunden"
 msgstr[1] "%i bekannte freigegebene Dateien gefunden"
 
-#: src/PrefsUnifiedDlg.cpp:1940
+#: src/PrefsUnifiedDlg.cpp:1860
 msgid "Browse for videoplayer"
 msgstr "Suche nach einem Videoplayer"
 
-#: src/PrefsUnifiedDlg.cpp:1944
+#: src/PrefsUnifiedDlg.cpp:1864
 msgid "Select browser"
 msgstr "Browser-Wahl"
 
-#: src/PrefsUnifiedDlg.cpp:1948
+#: src/PrefsUnifiedDlg.cpp:1868
 #, fuzzy
 msgid "Select ffprobe binary"
 msgstr "Browser-Wahl"
 
-#: src/PrefsUnifiedDlg.cpp:1954
+#: src/PrefsUnifiedDlg.cpp:1874
 #, c-format
 msgid "Executable%s"
 msgstr "Ausführbar%s"
 
-#: src/PrefsUnifiedDlg.cpp:1988
+#: src/PrefsUnifiedDlg.cpp:1908
 msgid "ffprobe not found on PATH or in the standard install locations. Install ffmpeg (which ships ffprobe) or use Browse to pick a binary manually."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2000
+#: src/PrefsUnifiedDlg.cpp:1920
 msgid "Reset the settings on this page to their default values?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2001
+#: src/PrefsUnifiedDlg.cpp:1921
 #, fuzzy
 msgid "Reset to defaults"
 msgstr "Systemvorgabe"
 
-#: src/PrefsUnifiedDlg.cpp:2028
+#: src/PrefsUnifiedDlg.cpp:1948
 msgid "Edit server list"
 msgstr "Serverliste bearbeiten"
 
-#: src/PrefsUnifiedDlg.cpp:2029
+#: src/PrefsUnifiedDlg.cpp:1949
 msgid ""
 "Add here URL's to download server.met files.\n"
 "Only one url on each line."
@@ -6015,115 +5967,115 @@ msgstr ""
 "Hier URL's für server.met-Dateien eintragen.\n"
 "Nur eine URL pro Zeile!"
 
-#: src/PrefsUnifiedDlg.cpp:2084
+#: src/PrefsUnifiedDlg.cpp:2004
 msgid "IP2Country update failed"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2229 src/PrefsUnifiedDlg.cpp:2260
+#: src/PrefsUnifiedDlg.cpp:2149 src/PrefsUnifiedDlg.cpp:2180
 msgid "Data by MaxMind GeoLite2"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2231 src/PrefsUnifiedDlg.cpp:2262
+#: src/PrefsUnifiedDlg.cpp:2151 src/PrefsUnifiedDlg.cpp:2182
 #, fuzzy
 msgid "Custom source"
 msgstr "vollständige Quellen"
 
-#: src/PrefsUnifiedDlg.cpp:2233 src/PrefsUnifiedDlg.cpp:2264
+#: src/PrefsUnifiedDlg.cpp:2153 src/PrefsUnifiedDlg.cpp:2184
 msgid "Data by DB-IP.com"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2284
+#: src/PrefsUnifiedDlg.cpp:2204
 #, fuzzy, c-format
 msgid "Status: Loaded%s"
 msgstr "Status:"
 
-#: src/PrefsUnifiedDlg.cpp:2286
+#: src/PrefsUnifiedDlg.cpp:2206
 #, fuzzy, c-format
 msgid "Status: Loaded%s - %s"
 msgstr "Status:"
 
-#: src/PrefsUnifiedDlg.cpp:2290
+#: src/PrefsUnifiedDlg.cpp:2210
 msgid "Status: Failed to load - click 'Update now' to refresh."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2292
+#: src/PrefsUnifiedDlg.cpp:2212
 msgid "Status: Not found - click 'Update now' to download."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2350 src/PrefsUnifiedDlg.cpp:2374
+#: src/PrefsUnifiedDlg.cpp:2270 src/PrefsUnifiedDlg.cpp:2294
 #, c-format
 msgid "Update delay: %d second"
 msgid_plural "Update delay: %d seconds"
 msgstr[0] "Aktualisierungsverzögerung: %d Sekunde"
 msgstr[1] "Aktualisierungsverzögerung: %d Sekunden"
 
-#: src/PrefsUnifiedDlg.cpp:2358
+#: src/PrefsUnifiedDlg.cpp:2278
 #, c-format
 msgid "Time for average graph: %d minute"
 msgid_plural "Time for average graph: %d minutes"
 msgstr[0] "Zeit für Durchschnittslinie: %d Minute"
 msgstr[1] "Zeit für Durchschnittslinie: %d Minuten"
 
-#: src/PrefsUnifiedDlg.cpp:2367
+#: src/PrefsUnifiedDlg.cpp:2287
 #, c-format
 msgid "Connections Graph Scale: %d"
 msgstr "Verbindungsgraphenskala: %d"
 
-#: src/PrefsUnifiedDlg.cpp:2382
+#: src/PrefsUnifiedDlg.cpp:2302
 #, c-format
 msgid "File Buffer Size: %d byte"
 msgid_plural "File Buffer Size: %d bytes"
 msgstr[0] "Dateipuffergröße: %d Byte"
 msgstr[1] "Dateipuffergröße: %d Bytes"
 
-#: src/PrefsUnifiedDlg.cpp:2392
+#: src/PrefsUnifiedDlg.cpp:2312
 #, c-format
 msgid "Upload Queue Size: %d client"
 msgid_plural "Upload Queue Size: %d clients"
 msgstr[0] "Upload-Warteschlangengröße: %d Client"
 msgstr[1] "Upload-Warteschlangengröße: %d Clients"
 
-#: src/PrefsUnifiedDlg.cpp:2402
+#: src/PrefsUnifiedDlg.cpp:2322
 #, c-format
 msgid "Server connection refresh interval: %d minute"
 msgid_plural "Server connection refresh interval: %d minutes"
 msgstr[0] "Server-Wiederverbindungsintervall: %d Minute"
 msgstr[1] "Server-Wiederverbindungsintervall: %d Minuten"
 
-#: src/PrefsUnifiedDlg.cpp:2407
+#: src/PrefsUnifiedDlg.cpp:2327
 msgid "Server connection refresh interval: Disabled"
 msgstr "Server-Wiederverbindungsintervall: Aus"
 
-#: src/PrefsUnifiedDlg.cpp:2451
+#: src/PrefsUnifiedDlg.cpp:2371
 msgid "disabled"
 msgstr "deaktiviert"
 
-#: src/PrefsUnifiedDlg.cpp:2477
+#: src/PrefsUnifiedDlg.cpp:2397
 #, c-format
 msgid "Execute command on '%s' event"
 msgstr "Führe Kommando beim '%s' Ereignis aus"
 
-#: src/PrefsUnifiedDlg.cpp:2484
+#: src/PrefsUnifiedDlg.cpp:2404
 msgid "Enable command execution on core"
 msgstr "Aktiviere Befehlsausführung im Kern"
 
-#: src/PrefsUnifiedDlg.cpp:2496
+#: src/PrefsUnifiedDlg.cpp:2416
 msgid "Core command:"
 msgstr "Kern-Befehl:"
 
-#: src/PrefsUnifiedDlg.cpp:2512
+#: src/PrefsUnifiedDlg.cpp:2432
 msgid "Enable command execution on GUI"
 msgstr "Aktiviere Befehlsausführung in GUI"
 
-#: src/PrefsUnifiedDlg.cpp:2524
+#: src/PrefsUnifiedDlg.cpp:2444
 msgid "GUI command:"
 msgstr "GUI-Befehl:"
 
-#: src/PrefsUnifiedDlg.cpp:2540
+#: src/PrefsUnifiedDlg.cpp:2460
 msgid "The following variables will be replaced:"
 msgstr "Die folgenden Variablen werden ersetzt:"
 
-#: src/PrefsUnifiedDlg.cpp:2708
+#: src/PrefsUnifiedDlg.cpp:2628
 msgid ""
 "The following folders look like system or sensitive locations:\n"
 "\n"
@@ -6131,62 +6083,58 @@ msgstr ""
 "Die folgenden Ordner sehen nach System oder Sensiblen Daten aus.\n"
 "\n"
 
-#: src/PrefsUnifiedDlg.cpp:2713
+#: src/PrefsUnifiedDlg.cpp:2633
 msgid "Sharing them recursively will publish every file underneath on the eD2k/Kad networks. Do you really want to do this?"
 msgstr "Rekursives Teilen würde jede Datei im eD2k/Kad Netzwerk verfügbar machen. Willst du das wirklich?"
 
-#: src/PrefsUnifiedDlg.cpp:2716
+#: src/PrefsUnifiedDlg.cpp:2636
 msgid "Confirm shared folders"
 msgstr "Freigegebene Ordner bestätigen"
 
-#: src/PrefsUnifiedDlg.cpp:2744
+#: src/PrefsUnifiedDlg.cpp:2664
 msgid "Reloading shared files..."
 msgstr "Freigegebene Dateien neu laden..."
 
-#: src/PrefsUnifiedDlg.cpp:2745
+#: src/PrefsUnifiedDlg.cpp:2665
 msgid "Scanning for subdirectories..."
 msgstr "Suche nach Unterverzeichnissen..."
 
-#: src/PrefsUnifiedDlg.cpp:2746
+#: src/PrefsUnifiedDlg.cpp:2666
 msgid "Updating shared folders"
 msgstr "Freigegebene Ordner werden aktualisiert"
 
-#: src/PrefsUnifiedDlg.cpp:2773
+#: src/PrefsUnifiedDlg.cpp:2693
 #, c-format
 msgid "Scanned %u directories..."
 msgstr "%u Verzeichnisse durchsucht..."
 
-#: src/PrefsUnifiedDlg.cpp:2823
+#: src/PrefsUnifiedDlg.cpp:2743
 #, c-format
 msgid "Reloading shared files: %u files scanned"
 msgstr "Liste freigegebener Dateien neu laden: %u Dateien gelesen"
 
-#: src/PrefsUnifiedDlg.cpp:2873
+#: src/PrefsUnifiedDlg.cpp:2793
 #, fuzzy
 msgid "Shared folder"
 msgstr "Freigegebene Ordner"
 
-#: src/SearchDlg.cpp:280
-msgid "Clear search history"
-msgstr ""
-
-#: src/SearchDlg.cpp:584
+#: src/SearchDlg.cpp:425
 msgid "It's impossible to search when both eD2k and Kademlia are disabled."
 msgstr "Eine Suche ist nicht möglich, wenn sowohl eD2k als auch Kademlia deaktiviert sind."
 
-#: src/SearchDlg.cpp:585 src/SearchListCtrl.cpp:858
+#: src/SearchDlg.cpp:426 src/SearchListCtrl.cpp:858
 msgid "Search error"
 msgstr "Suchfehler"
 
-#: src/SearchDlg.cpp:929
+#: src/SearchDlg.cpp:768
 msgid "Min size must be smaller than max size. Max size ignored."
 msgstr "Mindestgröße muss kleiner sein, als die Höchstgröße: Höchstgröße ignoriert."
 
-#: src/SearchDlg.cpp:930 src/SearchDlg.cpp:1012
+#: src/SearchDlg.cpp:769 src/SearchDlg.cpp:851
 msgid "Search warning"
 msgstr "Suchwarnung"
 
-#: src/SearchDlg.cpp:1092 src/SearchListCtrl.cpp:735
+#: src/SearchDlg.cpp:929 src/SearchListCtrl.cpp:735
 msgid "Main"
 msgstr "Hauptkategorie"
 

--- a/po/de.po
+++ b/po/de.po
@@ -13,7 +13,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-28 10:19+0200\n"
+"POT-Creation-Date: 2026-07-28 12:17+0200\n"
 "PO-Revision-Date: 2026-07-27 11:34+0000\n"
 "Last-Translator: Werner Mahr <werner@vollstreckernet.de>\n"
 "Language-Team: German <>\n"
@@ -212,83 +212,83 @@ msgstr "Fehler beim Öffnen der ED2KLinks-Datei."
 msgid "WARNING: You can't add yourself as a source for an eD2k link while having a lowid."
 msgstr "WARNUNG: Man kann sich nicht als Quelle für einen eD2k-Verweis hinzufügen während man eine niedrige ID hat."
 
-#: src/amule.cpp:300
+#: src/amule.cpp:301
 msgid "Now, exiting main app..."
 msgstr "Beende nun Hauptanwendung ..."
 
-#: src/amule.cpp:330
+#: src/amule.cpp:331
 #, c-format
 msgid "Terminating amuleweb instance with pid '%d' ... "
 msgstr "Beende amuleweb-Instanz mit pid '%d' ... "
 
-#: src/amule.cpp:334
+#: src/amule.cpp:335
 #, c-format
 msgid "Killing amuleweb instance with pid '%d' ... "
 msgstr "Erzwinge Beenden der amuleweb-Instanz mit pid '%d' ... "
 
-#: src/amule.cpp:336 src/amule.cpp:349 src/ClientRef.cpp:180
+#: src/amule.cpp:337 src/amule.cpp:350 src/ClientRef.cpp:180
 #: src/SearchDlg.cpp:1041 src/ServerListCtrl.cpp:98
 msgid "Failed"
 msgstr "Fehlgeschlagen"
 
-#: src/amule.cpp:343
+#: src/amule.cpp:344
 #, fuzzy, c-format
 msgid "Terminating amuleapi instance with pid '%d' ... "
 msgstr "Beende amuleweb-Instanz mit pid '%d' ... "
 
-#: src/amule.cpp:347
+#: src/amule.cpp:348
 #, fuzzy, c-format
 msgid "Killing amuleapi instance with pid '%d' ... "
 msgstr "Erzwinge Beenden der amuleweb-Instanz mit pid '%d' ... "
 
-#: src/amule.cpp:355
+#: src/amule.cpp:356
 msgid "aMule OnExit: Terminating core."
 msgstr "aMule OnExit: Beende Programmkern."
 
-#: src/amule.cpp:466
+#: src/amule.cpp:467
 msgid "aMule shutdown completed."
 msgstr "aMule-Herunterfahren abgeschlossen."
 
-#: src/amule.cpp:470
+#: src/amule.cpp:471
 msgid "Memory debug results for aMule exit:"
 msgstr "Speicherfehlerbehebungsresultate für aMule-Beendung:"
 
-#: src/amule.cpp:651
+#: src/amule.cpp:652
 #, c-format
 msgid "Binding aMule's peer-to-peer traffic to interface: %s (HTTP updates use the default route)"
 msgstr ""
 
-#: src/amule.cpp:655
+#: src/amule.cpp:656
 #, c-format
 msgid "Binding all network traffic to interface: %s"
 msgstr ""
 
-#: src/amule.cpp:659
+#: src/amule.cpp:660
 #, c-format
 msgid "WARNING: configured network interface '%s' was not found - traffic is NOT bound to it and may leave via the default route. Check the interface name in Preferences."
 msgstr ""
 
-#: src/amule.cpp:665
+#: src/amule.cpp:666
 #, c-format
 msgid "WARNING: binding to network interface '%s' requires elevated privileges and was NOT applied - traffic may leave via the default route. Grant the capability (e.g. 'sudo setcap cap_net_raw+ep' on the aMule binary) or run with sufficient privileges."
 msgstr ""
 
-#: src/amule.cpp:673
+#: src/amule.cpp:674
 #, c-format
 msgid "WARNING: could not bind to network interface '%s' - traffic may leave via the default route."
 msgstr ""
 
-#: src/amule.cpp:732
+#: src/amule.cpp:733
 msgid "Your locale has been changed to System Default due to a configuration change. Sorry."
 msgstr "Deine Locale wurde wegen einer Konfigurationsänderung auf Systemstandard geändert. Sorry."
 
-#: src/amule.cpp:734 src/amule.cpp:1581 src/CatDialog.cpp:128
+#: src/amule.cpp:735 src/amule.cpp:1589 src/CatDialog.cpp:128
 #: src/CatDialog.cpp:136 src/CatDialog.cpp:149 src/ServerList.cpp:366
 #: src/ServerListCtrl.cpp:152
 msgid "Info"
 msgstr "Info"
 
-#: src/amule.cpp:741
+#: src/amule.cpp:742
 msgid ""
 "\n"
 "EC configuration"
@@ -296,20 +296,20 @@ msgstr ""
 "\n"
 "EC-Konfiguration"
 
-#: src/amule.cpp:744
+#: src/amule.cpp:745
 msgid "Password set and external connections enabled."
 msgstr "Passwort eingestellt und externe Verbindungen aktiviert."
 
-#: src/amule.cpp:754 src/KadDlg.cpp:176 src/KadDlg.cpp:185
-#: src/PrefsUnifiedDlg.cpp:1387 src/SharedFilesCtrl.cpp:476
+#: src/amule.cpp:755 src/KadDlg.cpp:176 src/KadDlg.cpp:185
+#: src/PrefsUnifiedDlg.cpp:1461 src/SharedFilesCtrl.cpp:476
 msgid "WARNING"
 msgstr "WARNUNG"
 
-#: src/amule.cpp:991
+#: src/amule.cpp:992
 msgid "Network bootstrap"
 msgstr "Netzwerk-Bootstrap"
 
-#: src/amule.cpp:996
+#: src/amule.cpp:997
 msgid ""
 "aMule has detected missing network bootstrap files.\n"
 "Select which ones to download:"
@@ -317,52 +317,52 @@ msgstr ""
 "aMule hat fehlende Netzwerk-Bootstrap-Dateien erkannt.\n"
 "Wählen Sie aus, welche heruntergeladen werden sollen:"
 
-#: src/amule.cpp:1005 src/FirstRunWizard.cpp:411
+#: src/amule.cpp:1006 src/FirstRunWizard.cpp:411
 msgid "eD2k server list (server.met)"
 msgstr "eD2k-Serverliste (server.met)"
 
-#: src/amule.cpp:1012 src/FirstRunWizard.cpp:416
+#: src/amule.cpp:1013 src/FirstRunWizard.cpp:416
 msgid "Kad bootstrap nodes (nodes.dat)"
 msgstr "Kad-Bootstrap-Knoten (nodes.dat)"
 
-#: src/amule.cpp:1102
+#: src/amule.cpp:1103
 #, c-format
 msgid "web server running on pid %d"
 msgstr "Webserver läuft mit pid %d"
 
-#: src/amule.cpp:1115
+#: src/amule.cpp:1116
 msgid "You requested to run web server on startup, but the amuleweb binary cannot be run. Please install the package containing aMule web server, or build aMule from source with -DBUILD_WEBSERVER=YES and install it."
 msgstr "Du hast \"amuleweb zusammen mit aMule starten\" aktiviert, allerdings kann die amuleweb-Programmdatei nicht gestartet werden. Bitte installiere das Paket, das amuleweb enthält, oder kompiliere aMule mit -DBUILD_WEBSERVER=YES  neu und installiere dies."
 
-#: src/amule.cpp:1120 src/amule.cpp:1177 src/amule.cpp:1291 src/amule.cpp:1593
+#: src/amule.cpp:1121 src/amule.cpp:1185 src/amule.cpp:1299 src/amule.cpp:1601
 #: src/amule-remote-gui.cpp:603 src/amule-remote-gui.cpp:671
 #: src/amule-remote-gui.cpp:709 src/amule-remote-gui.cpp:1282
 #: src/amule-remote-gui.cpp:1345 src/amule-remote-gui.cpp:1372
-#: src/DownloadQueue.cpp:1481
+#: src/DownloadQueue.cpp:1481 src/PrefsUnifiedDlg.cpp:1247
 msgid "ERROR"
 msgstr "FEHLER"
 
-#: src/amule.cpp:1166
+#: src/amule.cpp:1174
 #, fuzzy, c-format
 msgid "amuleapi running on pid %d"
 msgstr "Webserver läuft mit pid %d"
 
-#: src/amule.cpp:1172
+#: src/amule.cpp:1180
 #, fuzzy
 msgid "You requested to run amuleapi on startup, but the amuleapi binary cannot be run. Please install the package containing aMule's REST API server, or build aMule from source with -DBUILD_AMULEAPI=YES and install it."
 msgstr "Du hast \"amuleweb zusammen mit aMule starten\" aktiviert, allerdings kann die amuleweb-Programmdatei nicht gestartet werden. Bitte installiere das Paket, das amuleweb enthält, oder kompiliere aMule mit -DBUILD_WEBSERVER=YES  neu und installiere dies."
 
-#: src/amule.cpp:1259
+#: src/amule.cpp:1267
 #, c-format
 msgid "Could not bind ports to the specified address: %s"
 msgstr "Kann Ports nicht mit der festgelegten Adresse verbinden: %s"
 
-#: src/amule.cpp:1283
+#: src/amule.cpp:1291
 #, c-format
 msgid "Port %u is not available. You will be LOWID\n"
 msgstr "Port %u ist nicht erreichbar. Du wirst eine niedrige ID erhalten\n"
 
-#: src/amule.cpp:1288
+#: src/amule.cpp:1296
 #, c-format
 msgid ""
 "Port %u is not available!\n"
@@ -377,48 +377,48 @@ msgstr ""
 "\n"
 "Bitte überprüfe deine Netzwerkeinstellungen, um sicherzugehen, dass der Port für ein- und ausgehenden Traffic geöffnet ist."
 
-#: src/amule.cpp:1385
+#: src/amule.cpp:1393
 msgid "Failed to create OnlineSig File"
 msgstr "Erstellen der OnlineSig-Datei gescheitert"
 
-#: src/amule.cpp:1393
+#: src/amule.cpp:1401
 msgid "Failed to create aMule OnlineSig File"
 msgstr "Erstellen der aMule OnlineSig-Datei gescheitert"
 
-#: src/amule.cpp:1556
+#: src/amule.cpp:1564
 msgid "The selected locale seems not to be installed on your box. (Note: I'll try to set it anyway)"
 msgstr "Die ausgewählte Locale scheint nicht auf dem System installiert zu sein.(INFO: Ich werde trotzdem versuchen, sie zu setzen)"
 
-#: src/amule.cpp:1566
+#: src/amule.cpp:1574
 #, c-format
 msgid "This is the first time you run aMule %s"
 msgstr "Dies ist das erste Mal, dass du aMule %s startest"
 
-#: src/amule.cpp:1569
+#: src/amule.cpp:1577
 msgid "This version is a testing version, updated daily, and\n"
 msgstr "Dies ist eine Testversion, täglich aktualisiert, und\n"
 
-#: src/amule.cpp:1570
+#: src/amule.cpp:1578
 msgid "we give no warranty it won't break anything, burn your house,\n"
 msgstr "wir garantieren nicht, dass sie keine Daten zerstört, dein Haus anzündet\n"
 
-#: src/amule.cpp:1571
+#: src/amule.cpp:1579
 msgid "or kill your dog. But it *should* be safe to use anyway.\n"
 msgstr "oder deinen Hund tötet. Aber es *sollte* sicher sein, sie zu benutzen.\n"
 
-#: src/amule.cpp:1576
+#: src/amule.cpp:1584
 msgid "More information, support and new releases can found at our homepage,\n"
 msgstr "Mehr Informationen und neue Releases können auf unserer Homepage gefunden werden\n"
 
-#: src/amule.cpp:1577
+#: src/amule.cpp:1585
 msgid "at https://amule-org.github.io, or in our IRC channel #aMule at irc.libera.chat.\n"
 msgstr "unter https://amule-org.github.io, oder in unserem IRC-Channel #amule auf irc.libera.chat.\n"
 
-#: src/amule.cpp:1579
+#: src/amule.cpp:1587
 msgid "Feel free to report any bugs to https://github.com/amule-org/amule/issues"
 msgstr "Bitte melde Fehler unter https://github.com/amule-org/amule/issues"
 
-#: src/amule.cpp:1591
+#: src/amule.cpp:1599
 msgid ""
 "The folder for Online Signature files you specified is INVALID!\n"
 " OnlineSignature will be DISABLED until you fix it on preferences."
@@ -426,137 +426,137 @@ msgstr ""
 "Das angegebene Verzeichnis für die Online-Signaturdateien ist UNGÜLTIG!\n"
 "Online-Signatur wird bis zur Fehlerbehebung in den Einstellungen DEAKTIVIERT."
 
-#: src/amule.cpp:1654
+#: src/amule.cpp:1662
 msgid "Server hostname notified"
 msgstr "Server Hostname benachrichtigt"
 
-#: src/amule.cpp:2031
+#: src/amule.cpp:2039
 #, c-format
 msgid "Disk space preallocation for file '%s' failed: %s"
 msgstr "Speicherplatzvorbelegung für Datei '%s' fehlgeschlagen: %s"
 
-#: src/amule.cpp:2160
+#: src/amule.cpp:2168
 msgid "ERROR: can't open logfile"
 msgstr "FEHLER: kann Logdatei nicht öffnen"
 
-#: src/amule.cpp:2164
+#: src/amule.cpp:2172
 msgid "WARNING: logfile is empty. Something is wrong."
 msgstr "WARNUNG: Logdatei ist leer. Etwas ist falsch."
 
-#: src/amule.cpp:2181
+#: src/amule.cpp:2189
 msgid "Log has been reset"
 msgstr "Das Log wurde zurückgesetzt"
 
-#: src/amule.cpp:2205
+#: src/amule.cpp:2213
 #, c-format
 msgid "ServerMessage: %s"
 msgstr "Servernachricht: %s"
 
-#: src/amule.cpp:2248 src/IP2Country.cpp:220 src/IPFilter.cpp:514
+#: src/amule.cpp:2256 src/IP2Country.cpp:220 src/IPFilter.cpp:514
 #: src/ServerList.cpp:875
 #, c-format
 msgid "Skipped download of %s, because requested file is not newer."
 msgstr "Lade %s nicht herunter, weil die angeforderte Datei nicht neuer ist."
 
-#: src/amule.cpp:2251
+#: src/amule.cpp:2259
 msgid "Failed to download the nodes list."
 msgstr "Knotenliste kann nicht geholt werden."
 
-#: src/amule.cpp:2314
+#: src/amule.cpp:2322
 msgid "Failed to open the downloaded version check file"
 msgstr "Konnte heruntergeladene Datei zur Versionsprüfung nicht öffnen"
 
-#: src/amule.cpp:2317 src/amule.cpp:2336
+#: src/amule.cpp:2325 src/amule.cpp:2344
 msgid "Corrupted version check file"
 msgstr "Fehlerhafte Versionsprüfungsdatei"
 
-#: src/amule.cpp:2359
+#: src/amule.cpp:2367
 msgid "You are using an outdated version of aMule!"
 msgstr "Du benutzt eine veraltete aMule-Version!"
 
-#: src/amule.cpp:2361
+#: src/amule.cpp:2369
 #, c-format
 msgid "Your aMule version is %i.%i.%i and the latest version is %li.%li.%li"
 msgstr "Diese Version von aMule ist %i.%i.%i und die aktuelle Version ist %li.%li.%li"
 
-#: src/amule.cpp:2365
+#: src/amule.cpp:2373
 msgid "The latest version can always be found at https://github.com/amule-org/amule/releases/latest"
 msgstr "Die neueste Version kann man immer auf https://github.com/amule-org/amule/releases/latest finden."
 
-#: src/amule.cpp:2368
+#: src/amule.cpp:2376
 #, c-format
 msgid "WARNING: Your aMuled version is outdated: %i.%i.%i < %li.%li.%li"
 msgstr "WARNUNG: Diese Version von aMuled ist veraltet: %i.%i.%i < %li.%li.%li"
 
-#: src/amule.cpp:2374
+#: src/amule.cpp:2382
 msgid "Your copy of aMule is up to date."
 msgstr "Deine Kopie von aMule ist aktuell."
 
-#: src/amule.cpp:2381
+#: src/amule.cpp:2389
 msgid "Failed to download the version check file"
 msgstr "Konnte die Versionsprüfungsdatei nicht herunterladen"
 
-#: src/amule.cpp:2550 src/amule-remote-gui.cpp:1133
+#: src/amule.cpp:2558 src/amule-remote-gui.cpp:1133
 #, c-format
 msgid "Users: %s | Files: %s"
 msgstr "Benutzer: %s | Dateien: %s"
 
-#: src/amule.cpp:2551 src/amule-remote-gui.cpp:1134
+#: src/amule.cpp:2559 src/amule-remote-gui.cpp:1134
 #, c-format
 msgid "Users: E: %s K: %s | Files: E: %s K: %s"
 msgstr "Benutzer: E: %s K: %s | Dateien: E: %s K: %s"
 
-#: src/amule.cpp:2565 src/amule-remote-gui.cpp:1147
+#: src/amule.cpp:2573 src/amule-remote-gui.cpp:1147
 msgid "No networks selected"
 msgstr "Keine Netzwerke ausgewählt"
 
-#: src/amule.cpp:2633 src/TextClient.cpp:903
+#: src/amule.cpp:2641 src/TextClient.cpp:903
 msgid "with LowID"
 msgstr "mit niedriger ID"
 
-#: src/amule.cpp:2633 src/TextClient.cpp:904
+#: src/amule.cpp:2641 src/TextClient.cpp:904
 msgid "with HighID"
 msgstr "mit hoher ID"
 
-#: src/amule.cpp:2635
+#: src/amule.cpp:2643
 #, c-format
 msgid "Connected to %s %s"
 msgstr "Verbunden zu %s %s"
 
-#: src/amule.cpp:2640
+#: src/amule.cpp:2648
 #, c-format
 msgid "Connecting to %s"
 msgstr "Verbinde zu %s"
 
-#: src/amule.cpp:2642
+#: src/amule.cpp:2650
 msgid "Disconnected from eD2k"
 msgstr "eD2k getrennt"
 
-#: src/amule.cpp:2651
+#: src/amule.cpp:2659
 msgid "Kad started."
 msgstr "Kad gestartet."
 
-#: src/amule.cpp:2653
+#: src/amule.cpp:2661
 msgid "Kad stopped."
 msgstr "Kad beendet."
 
-#: src/amule.cpp:2661
+#: src/amule.cpp:2669
 msgid "Connected to Kad (ok)"
 msgstr "Kad verbunden (ok)"
 
-#: src/amule.cpp:2663
+#: src/amule.cpp:2671
 msgid "Connected to Kad (firewalled)"
 msgstr "Kad verbunden (firewalled)"
 
-#: src/amule.cpp:2667
+#: src/amule.cpp:2675
 msgid "Disconnected from Kad"
 msgstr "Kad getrennt"
 
-#: src/amule.cpp:2699
+#: src/amule.cpp:2707
 msgid "Kad network cannot be used if UDP port is disabled on preferences, not starting."
 msgstr "Kad-Netzwerk kann mit deaktiviertem UDP-Port nicht benutzt werden, nicht gestartet."
 
-#: src/amule.cpp:2703
+#: src/amule.cpp:2711
 msgid "Kad network disabled on preferences, not connecting."
 msgstr "Kad-Netzwerk ist in den Voreinstellungen deaktiviert, kein Verbindungsversuch."
 
@@ -600,36 +600,36 @@ msgid "FATAL ERROR: Failed to create Timer"
 msgstr "UNBEHEBBARER FEHLER: Es konnte kein Zeitgeber erstellt werden."
 
 #: src/amuleDlg.cpp:361 src/amuleDlg.cpp:1787 src/amuleDlg.cpp:2033
-#: src/muuli_wdr.cpp:1492 src/muuli_wdr.cpp:3418
+#: src/muuli_wdr.cpp:1492 src/muuli_wdr.cpp:3449
 msgid "Networks"
 msgstr "Netzwerke"
 
-#: src/amuleDlg.cpp:362 src/amuleDlg.cpp:1793 src/muuli_wdr.cpp:3419
+#: src/amuleDlg.cpp:362 src/amuleDlg.cpp:1793 src/muuli_wdr.cpp:3450
 msgid "Searches"
 msgstr "Suchen"
 
 #: src/amuleDlg.cpp:363 src/amuleDlg.cpp:1799 src/DownloadListCtrl.cpp:740
-#: src/muuli_wdr.cpp:392 src/muuli_wdr.cpp:1585 src/muuli_wdr.cpp:3420
+#: src/muuli_wdr.cpp:392 src/muuli_wdr.cpp:1585 src/muuli_wdr.cpp:3451
 #: src/Statistics.cpp:829
 msgid "Downloads"
 msgstr "Downloads"
 
-#: src/amuleDlg.cpp:364 src/amuleDlg.cpp:1805 src/muuli_wdr.cpp:3294
+#: src/amuleDlg.cpp:364 src/amuleDlg.cpp:1805 src/muuli_wdr.cpp:3325
 msgid "Shared files"
 msgstr "Freigegebene Dateien"
 
-#: src/amuleDlg.cpp:365 src/amuleDlg.cpp:1811 src/muuli_wdr.cpp:2926
-#: src/muuli_wdr.cpp:3376 src/muuli_wdr.cpp:3423
+#: src/amuleDlg.cpp:365 src/amuleDlg.cpp:1811 src/muuli_wdr.cpp:2957
+#: src/muuli_wdr.cpp:3407 src/muuli_wdr.cpp:3454
 msgid "Messages"
 msgstr "Nachrichten"
 
-#: src/amuleDlg.cpp:366 src/amuleDlg.cpp:1817 src/muuli_wdr.cpp:3424
-#: src/PrefsUnifiedDlg.cpp:312 src/Statistics.cpp:779 src/Statistics.cpp:1235
+#: src/amuleDlg.cpp:366 src/amuleDlg.cpp:1817 src/muuli_wdr.cpp:3455
+#: src/PrefsUnifiedDlg.cpp:314 src/Statistics.cpp:779 src/Statistics.cpp:1235
 msgid "Statistics"
 msgstr "Statistiken"
 
-#: src/amuleDlg.cpp:368 src/amuleDlg.cpp:1824 src/muuli_wdr.cpp:3426
-#: src/PrefsUnifiedDlg.cpp:328 src/utils/wxCas/src/wxcasprefs.cpp:39
+#: src/amuleDlg.cpp:368 src/amuleDlg.cpp:1824 src/muuli_wdr.cpp:3457
+#: src/PrefsUnifiedDlg.cpp:330 src/utils/wxCas/src/wxcasprefs.cpp:39
 msgid "Preferences"
 msgstr "Einstellungen"
 
@@ -687,8 +687,8 @@ msgstr "Kad: aus"
 #: src/amuleDlg.cpp:1029 src/DownloadListCtrl.cpp:505
 #: src/DownloadListCtrl.cpp:749 src/FriendListCtrl.cpp:180
 #: src/muuli_wdr.cpp:731 src/muuli_wdr.cpp:782 src/muuli_wdr.cpp:846
-#: src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2231 src/muuli_wdr.cpp:2316
-#: src/muuli_wdr.cpp:3064 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
+#: src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2262 src/muuli_wdr.cpp:2347
+#: src/muuli_wdr.cpp:3095 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
 #: src/ServerListCtrl.cpp:606 src/TransferWnd.cpp:378
 #: src/utils/wxCas/src/wxcasprefs.cpp:235
 msgid "Cancel"
@@ -699,7 +699,7 @@ msgid "Stop the current connection attempts"
 msgstr "Beendet die derzeitigen Verbindungsversuche"
 
 #: src/amuleDlg.cpp:1035 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976
-#: src/muuli_wdr.cpp:2454
+#: src/muuli_wdr.cpp:2485
 msgid "Disconnect"
 msgstr "Trennen"
 
@@ -708,7 +708,7 @@ msgid "Disconnect from the currently connected networks"
 msgstr "Von den momentan verbundenen Netzwerken trennen."
 
 #: src/amuleDlg.cpp:1041 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979
-#: src/muuli_wdr.cpp:2609 src/muuli_wdr.cpp:3061 src/muuli_wdr.cpp:3416
+#: src/muuli_wdr.cpp:2640 src/muuli_wdr.cpp:3092 src/muuli_wdr.cpp:3447
 msgid "Connect"
 msgstr "Verbinden"
 
@@ -762,7 +762,7 @@ msgstr "Beenden bestätigen"
 msgid "Launch Command: "
 msgstr "Startbefehl: "
 
-#: src/amuleDlg.cpp:1632 src/muuli_wdr.cpp:1978 src/Preferences.cpp:952
+#: src/amuleDlg.cpp:1632 src/muuli_wdr.cpp:1982 src/Preferences.cpp:979
 msgid "- default -"
 msgstr "- Voreinstellung -"
 
@@ -776,48 +776,48 @@ msgstr "Skin-Verzeichnis '%s' existiert nicht"
 msgid "WARNING: Unable to open skin file '%s' for read"
 msgstr "WARNUNG: Öffnen der Skin-Datei '%s' zum Lesen nicht möglich"
 
-#: src/amuleDlg.cpp:1791 src/muuli_wdr.cpp:3418
+#: src/amuleDlg.cpp:1791 src/muuli_wdr.cpp:3449
 msgid "Networks Window"
 msgstr "Übersicht der verwendeten Netzwerke"
 
-#: src/amuleDlg.cpp:1797 src/muuli_wdr.cpp:3419
+#: src/amuleDlg.cpp:1797 src/muuli_wdr.cpp:3450
 msgid "Searches Window"
 msgstr "Dateisuche in den verbundenen Netzwerken"
 
-#: src/amuleDlg.cpp:1803 src/muuli_wdr.cpp:3420
+#: src/amuleDlg.cpp:1803 src/muuli_wdr.cpp:3451
 msgid "Downloads Window"
 msgstr "Download-Fenster"
 
-#: src/amuleDlg.cpp:1809 src/muuli_wdr.cpp:3422
+#: src/amuleDlg.cpp:1809 src/muuli_wdr.cpp:3453
 msgid "Shared Files Window"
 msgstr "Übersicht der freigegebenen Dateien"
 
-#: src/amuleDlg.cpp:1815 src/muuli_wdr.cpp:3423
+#: src/amuleDlg.cpp:1815 src/muuli_wdr.cpp:3454
 msgid "Messages Window"
 msgstr "Nachrichten, Chat, Freundesliste"
 
-#: src/amuleDlg.cpp:1821 src/muuli_wdr.cpp:3424
+#: src/amuleDlg.cpp:1821 src/muuli_wdr.cpp:3455
 msgid "Statistics Graph Window"
 msgstr "Diverse Statistiken über Up- und Download, Verbindungen, Clients usw."
 
-#: src/amuleDlg.cpp:1828 src/muuli_wdr.cpp:3426
+#: src/amuleDlg.cpp:1828 src/muuli_wdr.cpp:3457
 msgid "Preferences Settings Window"
 msgstr "Fenster für Einstellungen"
 
-#: src/amuleDlg.cpp:1831 src/muuli_wdr.cpp:3427
+#: src/amuleDlg.cpp:1831 src/muuli_wdr.cpp:3458
 msgid "Import"
 msgstr "Importiere"
 
-#: src/amuleDlg.cpp:1835 src/muuli_wdr.cpp:3427
+#: src/amuleDlg.cpp:1835 src/muuli_wdr.cpp:3458
 msgid "The partfile importer tool"
 msgstr "Das Importierwerkzeug für Part-Dateien"
 
-#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3428
+#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3459
 #: src/utils/aLinkCreator/src/alcframe.cpp:262
 msgid "About"
 msgstr "Über"
 
-#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3428
+#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3459
 msgid "About/Help"
 msgstr "Über/Hilfe - Hinweise zur Version usw."
 
@@ -961,7 +961,7 @@ msgstr "Datei nicht gefunden."
 msgid "The core rejected these shared folders:%s"
 msgstr ""
 
-#: src/amule-remote-gui.cpp:1336 src/ExternalConn.cpp:2345
+#: src/amule-remote-gui.cpp:1336 src/ExternalConn.cpp:2346
 msgid "Invalid link or already on list."
 msgstr "Ungültiger Verweis oder schon auf der Liste"
 
@@ -977,7 +977,7 @@ msgstr "Konnte das Verzeichnis '%s' für die Kategorie '%s' nicht erstellen, nut
 #: src/ClientDetailDialog.cpp:123 src/DataToText.cpp:61 src/DataToText.cpp:86
 #: src/DataToText.cpp:101 src/DataToText.cpp:136 src/DataToText.cpp:165
 #: src/DownloadListCtrl.cpp:1172 src/DownloadListCtrl.cpp:1185
-#: src/DownloadListCtrl.cpp:1196 src/ExternalConn.cpp:608
+#: src/DownloadListCtrl.cpp:1196 src/ExternalConn.cpp:609
 #: src/FileDetailDialog.cpp:203 src/FileDetailDialog.cpp:235
 #: src/FileDetailDialog.cpp:242 src/GenericClientListCtrl.cpp:1171
 #: src/GenericClientListCtrl.cpp:1182 src/GenericClientListCtrl.cpp:1192
@@ -1364,19 +1364,19 @@ msgstr "Auto [Ho]"
 msgid "Very low"
 msgstr "Sehr niedrig"
 
-#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:743 src/muuli_wdr.cpp:2282
+#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:743 src/muuli_wdr.cpp:2313
 #: src/ServerListCtrl.cpp:263 src/ServerListCtrl.cpp:456
 #: src/SharedFilesCtrl.cpp:145
 msgid "Low"
 msgstr "Niedrig"
 
-#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:744 src/muuli_wdr.cpp:2283
+#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:744 src/muuli_wdr.cpp:2314
 #: src/ServerListCtrl.cpp:266 src/ServerListCtrl.cpp:457
 #: src/SharedFilesCtrl.cpp:146
 msgid "Normal"
 msgstr "Normal"
 
-#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:745 src/muuli_wdr.cpp:2284
+#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:745 src/muuli_wdr.cpp:2315
 #: src/ServerListCtrl.cpp:269 src/ServerListCtrl.cpp:458
 #: src/SharedFilesCtrl.cpp:147
 msgid "High"
@@ -1468,7 +1468,7 @@ msgstr "Lokaler Server"
 msgid "Remote Server"
 msgstr "Entfernter Server"
 
-#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3181
+#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3212
 #: src/SearchDlg.cpp:119 src/TextClient.cpp:911
 msgid "Kad"
 msgstr "Kad"
@@ -1539,7 +1539,7 @@ msgstr "Teil"
 msgid "Size"
 msgstr "Größe"
 
-#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3248
+#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3279
 msgid "Transferred"
 msgstr "Übertragen"
 
@@ -1597,7 +1597,7 @@ msgstr ""
 "Rückmeldung von: %s (%s)\n"
 "\n"
 
-#: src/DownloadListCtrl.cpp:746 src/muuli_wdr.cpp:2285
+#: src/DownloadListCtrl.cpp:746 src/muuli_wdr.cpp:2316
 #: src/SharedFilesCtrl.cpp:150
 msgid "Auto"
 msgstr "Automatisch"
@@ -1635,7 +1635,7 @@ msgid "Extended Options"
 msgstr "Erweiterte Optionen"
 
 #: src/DownloadListCtrl.cpp:770 src/DownloadListCtrl.cpp:822
-#: src/muuli_wdr.cpp:1796
+#: src/muuli_wdr.cpp:1800
 msgid "Preview"
 msgstr "Vorschau"
 
@@ -1810,225 +1810,230 @@ msgstr[1] "Konnte %u Links nicht hinzufügen (Details: siehe Log)"
 msgid "Invalid eD2k link! ERROR: %s"
 msgstr "Ungültiger eD2k-Link! Fehler: %s"
 
-#: src/ExternalConn.cpp:379
+#: src/ExternalConn.cpp:380
 msgid "Client sent packet after authentication failed."
 msgstr "Client sendete Paket nach fehlgeschlagener Authentifizierung."
 
-#: src/ExternalConn.cpp:396
+#: src/ExternalConn.cpp:397
 msgid "External connection closed."
 msgstr "Externe Verbindung getrennt."
 
-#: src/ExternalConn.cpp:473
+#: src/ExternalConn.cpp:474
 msgid "External connections disabled due to empty password!"
 msgstr "Externe Verbindungen deaktiviert. Leeres Passwort!"
 
-#: src/ExternalConn.cpp:494
+#: src/ExternalConn.cpp:495
 msgid "External connections disabled in config file"
 msgstr "Externe Verbindungen in der Konfigurationsdatei deaktiviert"
 
-#: src/ExternalConn.cpp:575
+#: src/ExternalConn.cpp:576
 msgid "New external connection accepted"
 msgstr "Neue externe Verbindung akzeptiert"
 
-#: src/ExternalConn.cpp:578
+#: src/ExternalConn.cpp:579
 msgid "ERROR: couldn't accept a new external connection"
 msgstr "FEHLER: Konnte keine neue externe Verbindung akzeptieren"
 
-#: src/ExternalConn.cpp:595
+#: src/ExternalConn.cpp:596
 msgid "External connection refused due to empty password in preferences!"
 msgstr "Externe Verbindung verweigert. Kein Passwort in den Einstellungen angegeben!"
 
-#: src/ExternalConn.cpp:607
+#: src/ExternalConn.cpp:608
 #, c-format
 msgid "Connecting client: %s %s"
 msgstr "Verbinde mit Client: %s %s"
 
-#: src/ExternalConn.cpp:609
+#: src/ExternalConn.cpp:610
 msgid "Unknown version"
 msgstr "Unbekannte Version"
 
-#: src/ExternalConn.cpp:622
+#: src/ExternalConn.cpp:623
 msgid "Incorrect EC version ID, there might be binary incompatibility. Use core and remote from same snapshot."
 msgstr "Unkorrekte EC-Versions-ID; es könnte eine binär-Inkompatibilität vorliegen. Benutze Kern und Fernsteuerung desselben Schnappschusses."
 
-#: src/ExternalConn.cpp:630
+#: src/ExternalConn.cpp:631
 msgid "You cannot connect to a release version from an arbitrary development snapshot! *sigh* possible crash prevented"
 msgstr "Du kannst nicht zu einer Release-Version von einer beliebigen Entwicklungs-Version verbinden! *seufz* möglicher Absturz verhindert"
 
-#: src/ExternalConn.cpp:713
+#: src/ExternalConn.cpp:714
 msgid "Invalid protocol version."
 msgstr "Ungültige Protokollversion."
 
-#: src/ExternalConn.cpp:719
+#: src/ExternalConn.cpp:720
 msgid "Missing protocol version tag."
 msgstr "Fehlende Protokollversionsmarke."
 
-#: src/ExternalConn.cpp:727
+#: src/ExternalConn.cpp:728
 msgid "Authentication failed: invalid hash specified as EC password."
 msgstr "Authentifizierung fehlgeschlagen: ungültiger Hash als EC-Passwort angegeben."
 
-#: src/ExternalConn.cpp:775
+#: src/ExternalConn.cpp:776
 msgid "Authentication failed: wrong password."
 msgstr "Authentifizierung fehlgeschlagen: falsches Passwort."
 
-#: src/ExternalConn.cpp:777
+#: src/ExternalConn.cpp:778
 msgid "Authentication failed: missing password."
 msgstr "Authentifizierung fehlgeschlagen: fehlendes Passwort."
 
-#: src/ExternalConn.cpp:788
+#: src/ExternalConn.cpp:789
 msgid "Invalid request, please authenticate first."
 msgstr "Ungültige Anfrage, bitte zuerst authentifizieren."
 
-#: src/ExternalConn.cpp:793
+#: src/ExternalConn.cpp:794
 msgid "Access granted."
 msgstr "Zugang gewährt."
 
-#: src/ExternalConn.cpp:801
+#: src/ExternalConn.cpp:802
 #, c-format
 msgid "Sent error message \"%s\" to client."
 msgstr "Fehlermeldung \"%s\" zu Client gesendet."
 
-#: src/ExternalConn.cpp:806
+#: src/ExternalConn.cpp:807
 #, c-format
 msgid "Unauthorized access attempt from %s. Connection closed."
 msgstr "Unerlaubter Verbindungsversuch von %s. Verbindung getrennt."
 
-#: src/ExternalConn.cpp:1419
+#: src/ExternalConn.cpp:1420
 #, c-format
 msgid "Remote PartFile command failed: FileHash not found: %s"
 msgstr "Fernsteuerungs-Part-Datei-Kommando gescheitert: Dateiprüfsumme nicht gefunden: %s"
 
-#: src/ExternalConn.cpp:1423
+#: src/ExternalConn.cpp:1424
 #, c-format
 msgid "FileHash not found: %s"
 msgstr "Dateiprüfsumme nicht gefunden: %s"
 
-#: src/ExternalConn.cpp:1470 src/ExternalConn.cpp:1558
-#: src/ExternalConn.cpp:1679
+#: src/ExternalConn.cpp:1471 src/ExternalConn.cpp:1559
+#: src/ExternalConn.cpp:1680
 msgid "OOPS! OpCode processing error!"
 msgstr "OOPS! OpCode-Verarbeitungsfehler!"
 
-#: src/ExternalConn.cpp:1501
+#: src/ExternalConn.cpp:1502
 msgid "Server not added"
 msgstr "Server nicht hinzugefügt"
 
-#: src/ExternalConn.cpp:1520
+#: src/ExternalConn.cpp:1521
 #, c-format
 msgid "server not found: %s"
 msgstr "Server nicht gefunden: %s"
 
-#: src/ExternalConn.cpp:1537
+#: src/ExternalConn.cpp:1538
 msgid "need to define server to be removed"
 msgstr "Der zu entfernende Server muss angegeben sein"
 
-#: src/ExternalConn.cpp:1552
+#: src/ExternalConn.cpp:1553
 msgid "eD2k is disabled in preferences."
 msgstr "eD2k ist in den Einstellungen deaktiviert."
 
-#: src/ExternalConn.cpp:1657
+#: src/ExternalConn.cpp:1658
 msgid "Friend not found."
 msgstr "Freund nicht gefunden."
 
-#: src/ExternalConn.cpp:1667
+#: src/ExternalConn.cpp:1668
 msgid "Client not found."
 msgstr "Client nicht gefunden."
 
-#: src/ExternalConn.cpp:1673
+#: src/ExternalConn.cpp:1674
 msgid "EC_TAG_FRIEND_SHARED requires EC_TAG_FRIEND or EC_TAG_CLIENT."
 msgstr "EC_TAG_FRIEND_SHARED erfordert EC_TAG_FRIEND oder EC_TAG_CLIENT."
 
-#: src/ExternalConn.cpp:1991
+#: src/ExternalConn.cpp:1992
 msgid "WebSearch from remote interface makes no sense."
 msgstr "Websuche mit der Fernsteuerungsschnittstelle macht keinen Sinn."
 
-#: src/ExternalConn.cpp:2026
+#: src/ExternalConn.cpp:2027
 msgid "Search in progress. Refetch results in a moment!"
 msgstr "Suche läuft gerade. Aktualisiere gleich die Ergebnisse!"
 
-#: src/ExternalConn.cpp:2265
+#: src/ExternalConn.cpp:2266
 msgid "No points for graph."
 msgstr "Keine Punkte für Graphen."
 
-#: src/ExternalConn.cpp:2275
+#: src/ExternalConn.cpp:2276
 msgid "Your client is not configured for this detail level."
 msgstr "Der Client ist nicht nicht für diese Detailstufe eingestellt."
 
-#: src/ExternalConn.cpp:2302
+#: src/ExternalConn.cpp:2303
 msgid "External Connection: shutdown requested"
 msgstr "Externe Verbindungen: Herunterfahren gefordert"
 
-#: src/ExternalConn.cpp:2314
+#: src/ExternalConn.cpp:2315
 msgid "Already shutting down."
 msgstr "Wird bereits heruntergefahren."
 
-#: src/ExternalConn.cpp:2332
+#: src/ExternalConn.cpp:2333
 #, c-format
 msgid "ExternalConn: adding link '%s'."
 msgstr "Externe Verbindungen: Füge hinzu Verweis '%s'."
 
-#: src/ExternalConn.cpp:2350
+#: src/ExternalConn.cpp:2351
 #, c-format
 msgid "%d of %d links failed (invalid or already on list)."
 msgstr "%d von %d Links fehlgeschlagen. Ungültiger Verweis oder schon auf der Liste"
 
-#: src/ExternalConn.cpp:2373
+#: src/ExternalConn.cpp:2374
 msgid "Version check throttled; try again shortly."
 msgstr ""
 
-#: src/ExternalConn.cpp:2378
+#: src/ExternalConn.cpp:2379
 msgid "Version check is not available on this daemon."
 msgstr ""
 
-#: src/ExternalConn.cpp:2508
+#: src/ExternalConn.cpp:2509
 msgid "File not found."
 msgstr "Datei nicht gefunden."
 
-#: src/ExternalConn.cpp:2513
+#: src/ExternalConn.cpp:2514
 msgid "Invalid file name."
 msgstr "Ungültiger Dateiname."
 
-#: src/ExternalConn.cpp:2521
+#: src/ExternalConn.cpp:2522
 msgid "Unable to rename file."
 msgstr "Datei kann nicht umbenannt werden."
 
-#: src/ExternalConn.cpp:2992 src/ExternalConn.cpp:3020
+#: src/ExternalConn.cpp:2839
+#, c-format
+msgid "Could not save the amuleapi password: %s"
+msgstr ""
+
+#: src/ExternalConn.cpp:3004 src/ExternalConn.cpp:3032
 msgid "Kad is disabled in preferences."
 msgstr "Kad ist in den Einstellungen deaktiviert."
 
-#: src/ExternalConn.cpp:3033
+#: src/ExternalConn.cpp:3045
 msgid "Already connected to eD2k."
 msgstr "Bereits mit eD2k verbunden."
 
-#: src/ExternalConn.cpp:3036
+#: src/ExternalConn.cpp:3048
 msgid "Connecting to eD2k..."
 msgstr "Verbinde mit eD2k..."
 
-#: src/ExternalConn.cpp:3045
+#: src/ExternalConn.cpp:3057
 msgid "Already connected to Kad."
 msgstr "Bereits mit Kad verbunden."
 
-#: src/ExternalConn.cpp:3048
+#: src/ExternalConn.cpp:3060
 msgid "Connecting to Kad..."
 msgstr "Verbinde mit Kad..."
 
-#: src/ExternalConn.cpp:3055
+#: src/ExternalConn.cpp:3067
 msgid "All networks are disabled."
 msgstr "Alle Netzwerke sind deaktiviert."
 
-#: src/ExternalConn.cpp:3064
+#: src/ExternalConn.cpp:3076
 msgid "Disconnected from eD2k."
 msgstr "Von eD2k getrennt."
 
-#: src/ExternalConn.cpp:3069
+#: src/ExternalConn.cpp:3081
 msgid "Disconnected from Kad."
 msgstr "Von Kad getrennt."
 
-#: src/ExternalConn.cpp:3078
+#: src/ExternalConn.cpp:3090
 #, c-format
 msgid "External Connection: invalid opcode received: %#x"
 msgstr "Externe Verbindungen: ungültigen Opcode empfangen: %#x"
 
-#: src/ExternalConn.cpp:3083
+#: src/ExternalConn.cpp:3095
 msgid "Invalid opcode (wrong protocol version?)"
 msgstr "Ungültiger OpCode (falsche Protokollversion?)"
 
@@ -2429,23 +2434,23 @@ msgid ""
 "want downloads on a different (e.g. larger) disk."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:549 src/FirstRunWizard.cpp:611 src/muuli_wdr.cpp:1708
+#: src/FirstRunWizard.cpp:549 src/FirstRunWizard.cpp:611 src/muuli_wdr.cpp:1712
 msgid "Destination folder for downloads"
 msgstr "Zielverzeichnis für Downloads."
 
 #: src/FirstRunWizard.cpp:553 src/FirstRunWizard.cpp:569 src/muuli_wdr.cpp:1349
-#: src/muuli_wdr.cpp:1366 src/muuli_wdr.cpp:1683 src/muuli_wdr.cpp:1714
-#: src/muuli_wdr.cpp:1726 src/muuli_wdr.cpp:2769
+#: src/muuli_wdr.cpp:1366 src/muuli_wdr.cpp:1687 src/muuli_wdr.cpp:1718
+#: src/muuli_wdr.cpp:1730 src/muuli_wdr.cpp:2800
 #: src/utils/aLinkCreator/src/alcframe.cpp:135
 #: src/utils/wxCas/src/wxcasprefs.cpp:52 src/utils/wxCas/src/wxcasprefs.cpp:118
 msgid "Browse"
 msgstr "Durchsuchen"
 
-#: src/FirstRunWizard.cpp:559 src/muuli_wdr.cpp:1719
+#: src/FirstRunWizard.cpp:559 src/muuli_wdr.cpp:1723
 msgid "(All files in this folder are shared with other peers)"
 msgstr "(Alle Dateien in diesem Ordner werden mit anderen Nutzern geteilt)"
 
-#: src/FirstRunWizard.cpp:565 src/FirstRunWizard.cpp:624 src/muuli_wdr.cpp:1721
+#: src/FirstRunWizard.cpp:565 src/FirstRunWizard.cpp:624 src/muuli_wdr.cpp:1725
 msgid "Folder for temporary download files"
 msgstr "Verzeichnis für temporäre Downloaddateien"
 
@@ -2476,7 +2481,7 @@ msgstr "Konnte Freundes-Liste 'emfriends.met' nicht schreiben!"
 msgid "CRITICAL - no client on StartChatSession"
 msgstr "KRITISCH - kein Client bei StartChatSession"
 
-#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2675 src/muuli_wdr.cpp:3352
+#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2706 src/muuli_wdr.cpp:3383
 msgid "Friends"
 msgstr "Freunde"
 
@@ -2586,8 +2591,8 @@ msgstr "Keine"
 msgid "No"
 msgstr "Nein"
 
-#: src/GenericClientListCtrl.cpp:1216 src/PrefsUnifiedDlg.cpp:2818
-#: src/PrefsUnifiedDlg.cpp:2868 src/ServerListCtrl.cpp:276
+#: src/GenericClientListCtrl.cpp:1216 src/PrefsUnifiedDlg.cpp:2898
+#: src/PrefsUnifiedDlg.cpp:2948 src/ServerListCtrl.cpp:276
 msgid "Yes"
 msgstr "Ja"
 
@@ -2756,10 +2761,10 @@ msgstr "Ungültiger Bootstrap-Port"
 msgid "Please fill all fields required"
 msgstr "Bitte alle erforderlichen Felder ausfüllen"
 
-#: src/KadDlg.cpp:192 src/PartFile.cpp:1031 src/PrefsUnifiedDlg.cpp:1162
-#: src/PrefsUnifiedDlg.cpp:1331 src/PrefsUnifiedDlg.cpp:1589
-#: src/PrefsUnifiedDlg.cpp:1599 src/PrefsUnifiedDlg.cpp:1616
-#: src/PrefsUnifiedDlg.cpp:1658
+#: src/KadDlg.cpp:192 src/PartFile.cpp:1031 src/PrefsUnifiedDlg.cpp:1134
+#: src/PrefsUnifiedDlg.cpp:1204 src/PrefsUnifiedDlg.cpp:1405
+#: src/PrefsUnifiedDlg.cpp:1663 src/PrefsUnifiedDlg.cpp:1673
+#: src/PrefsUnifiedDlg.cpp:1690 src/PrefsUnifiedDlg.cpp:1738
 msgid "Message"
 msgstr "Nachricht"
 
@@ -2861,7 +2866,7 @@ msgstr "Tauschverhältnis"
 msgid "Uploaded"
 msgstr "Hochgeladen"
 
-#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3232
+#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3263
 msgid "Requested"
 msgstr "Angefordert"
 
@@ -2985,7 +2990,7 @@ msgid "WARNING: "
 msgstr "WARNUNG: "
 
 #: src/MuleNotebook.cpp:179 src/muuli_wdr.cpp:817 src/muuli_wdr.cpp:1229
-#: src/muuli_wdr.cpp:3136 src/muuli_wdr.cpp:3392
+#: src/muuli_wdr.cpp:3167 src/muuli_wdr.cpp:3423
 msgid "Close"
 msgstr "Schließen"
 
@@ -3003,7 +3008,7 @@ msgid "Paste"
 msgstr "Einfügen"
 
 #: src/MuleTextCtrl.cpp:89 src/muuli_wdr.cpp:358 src/muuli_wdr.cpp:757
-#: src/muuli_wdr.cpp:2359 src/muuli_wdr.cpp:2378 src/muuli_wdr.cpp:2400
+#: src/muuli_wdr.cpp:2390 src/muuli_wdr.cpp:2409 src/muuli_wdr.cpp:2431
 #: src/utils/aLinkCreator/src/alcframe.cpp:142
 msgid "Clear"
 msgstr "Leeren"
@@ -3095,7 +3100,7 @@ msgstr "Schließen"
 
 #: src/MuleTrayIcon.cpp:579 src/MuleTrayIcon.cpp:945 src/MuleTrayIcon.cpp:965
 #: src/muuli_wdr.cpp:1398 src/muuli_wdr.cpp:1406 src/muuli_wdr.cpp:1413
-#: src/muuli_wdr.cpp:1842 src/muuli_wdr.cpp:1848 src/OtherFunctions.cpp:91
+#: src/muuli_wdr.cpp:1846 src/muuli_wdr.cpp:1852 src/OtherFunctions.cpp:91
 #: src/StatisticsDlg.cpp:93 src/StatisticsDlg.cpp:95
 msgid "kB/s"
 msgstr "kB/s"
@@ -3337,7 +3342,7 @@ msgstr "Bytes"
 msgid "KB"
 msgstr "KB"
 
-#: src/muuli_wdr.cpp:274 src/muuli_wdr.cpp:293 src/muuli_wdr.cpp:1627
+#: src/muuli_wdr.cpp:274 src/muuli_wdr.cpp:293 src/muuli_wdr.cpp:1631
 #: src/OtherFunctions.cpp:64
 msgid "MB"
 msgstr "MB"
@@ -3354,7 +3359,7 @@ msgstr "Höchstgröße"
 msgid "Availability"
 msgstr "Verfügbarkeit"
 
-#: src/muuli_wdr.cpp:312 src/muuli_wdr.cpp:398 src/muuli_wdr.cpp:3297
+#: src/muuli_wdr.cpp:312 src/muuli_wdr.cpp:398 src/muuli_wdr.cpp:3328
 msgid "Filter:"
 msgstr "Filter:"
 
@@ -3417,12 +3422,12 @@ msgstr "Dateiquellen:"
 #: src/muuli_wdr.cpp:1160 src/muuli_wdr.cpp:1167 src/muuli_wdr.cpp:1172
 #: src/muuli_wdr.cpp:1179 src/muuli_wdr.cpp:1184 src/muuli_wdr.cpp:1191
 #: src/muuli_wdr.cpp:1205 src/muuli_wdr.cpp:1212 src/muuli_wdr.cpp:1217
-#: src/muuli_wdr.cpp:1224 src/muuli_wdr.cpp:3234 src/muuli_wdr.cpp:3242
-#: src/muuli_wdr.cpp:3250
+#: src/muuli_wdr.cpp:1224 src/muuli_wdr.cpp:3265 src/muuli_wdr.cpp:3273
+#: src/muuli_wdr.cpp:3281
 msgid "N/A"
 msgstr "Nicht verfügbar"
 
-#: src/muuli_wdr.cpp:508 src/muuli_wdr.cpp:1065 src/PrefsUnifiedDlg.cpp:297
+#: src/muuli_wdr.cpp:508 src/muuli_wdr.cpp:1065 src/PrefsUnifiedDlg.cpp:299
 msgid "General"
 msgstr "Allgemein"
 
@@ -3563,7 +3568,7 @@ msgstr ""
 msgid "Album :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:685 src/muuli_wdr.cpp:2254
+#: src/muuli_wdr.cpp:685 src/muuli_wdr.cpp:2285
 msgid "Title :"
 msgstr "Titel:"
 
@@ -3672,7 +3677,7 @@ msgstr "Benutzername:"
 msgid "Userhash :"
 msgstr "Benutzerprüfsumme:"
 
-#: src/muuli_wdr.cpp:895 src/muuli_wdr.cpp:1748 src/muuli_wdr.cpp:2449
+#: src/muuli_wdr.cpp:895 src/muuli_wdr.cpp:1752 src/muuli_wdr.cpp:2480
 #: src/utils/aLinkCreator/src/alcframe.cpp:137
 msgid "Add"
 msgstr "Hinzufügen"
@@ -3681,15 +3686,15 @@ msgstr "Hinzufügen"
 msgid "Download-Speed"
 msgstr "Download-Geschwindigkeit"
 
-#: src/muuli_wdr.cpp:954 src/muuli_wdr.cpp:989 src/muuli_wdr.cpp:2553
+#: src/muuli_wdr.cpp:954 src/muuli_wdr.cpp:989 src/muuli_wdr.cpp:2584
 msgid "Current"
 msgstr "Aktuell"
 
-#: src/muuli_wdr.cpp:962 src/muuli_wdr.cpp:997 src/muuli_wdr.cpp:2561
+#: src/muuli_wdr.cpp:962 src/muuli_wdr.cpp:997 src/muuli_wdr.cpp:2592
 msgid "Running average"
 msgstr "gleitender Mittelwert"
 
-#: src/muuli_wdr.cpp:970 src/muuli_wdr.cpp:1005 src/muuli_wdr.cpp:2569
+#: src/muuli_wdr.cpp:970 src/muuli_wdr.cpp:1005 src/muuli_wdr.cpp:2600
 msgid "Session average"
 msgstr "Sitzungsdurchschnitt"
 
@@ -3701,7 +3706,7 @@ msgstr "Upload-Geschwindigkeit"
 msgid "Connections"
 msgstr "Verbindungen"
 
-#: src/muuli_wdr.cpp:1024 src/muuli_wdr.cpp:1867
+#: src/muuli_wdr.cpp:1024 src/muuli_wdr.cpp:1871
 msgid "Active downloads"
 msgstr "Aktive Downloads"
 
@@ -3709,7 +3714,7 @@ msgstr "Aktive Downloads"
 msgid "Active connections (1:1)"
 msgstr "Aktive Verbindungen (1:1)"
 
-#: src/muuli_wdr.cpp:1040 src/muuli_wdr.cpp:1868
+#: src/muuli_wdr.cpp:1040 src/muuli_wdr.cpp:1872
 msgid "Active uploads"
 msgstr "Aktive Uploads"
 
@@ -3985,7 +3990,7 @@ msgstr "Verknüpfe lokale Adresse mit IP (Leer für beliebige):"
 msgid "Advanced users only: If you have multiple network interfaces, enter the address of the interface to which aMule should be bound."
 msgstr "Nur für fortgeschrittene Benutzer: Wenn es mehrere Netzwerkverbindungen gibt, hier die Adresse der Verbindung, mit der aMule verknüpft werden soll, eingeben."
 
-#: src/muuli_wdr.cpp:1462 src/muuli_wdr.cpp:2061
+#: src/muuli_wdr.cpp:1462 src/muuli_wdr.cpp:2065
 #, fuzzy
 msgid "Bind to network interface (empty for any):"
 msgstr "Verknüpfe lokale Adresse mit IP (Leer für beliebige):"
@@ -4002,7 +4007,7 @@ msgstr "Maximale Anzahl Quellen pro heruntergeladener Datei:"
 msgid "Max simultaneous connections:"
 msgstr "Maximale gleichzeitige Verbindungen:"
 
-#: src/muuli_wdr.cpp:1498 src/muuli_wdr.cpp:3176
+#: src/muuli_wdr.cpp:1498 src/muuli_wdr.cpp:3207
 msgid "ED2K"
 msgstr "eD2k"
 
@@ -4094,79 +4099,79 @@ msgstr "Reserviere Speicherplatz für neue Dateien"
 msgid "For new files preallocates disk space for the whole file, thus reduces fragmentation"
 msgstr "Reserviert für neue Dateien Speicherplatz für die ganze Datei und reduziert so Fragmentierung."
 
-#: src/muuli_wdr.cpp:1613
+#: src/muuli_wdr.cpp:1617
 msgid "Create new files as sparse files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1614
-msgid "A sparse file reserves its full size on disk immediately without writing real data to it -- fast, but unsupported or slow on some filesystems, and free-space accounting stays optimistic while the download is in progress. Turn this off to grow the file only as data arrives."
+#: src/muuli_wdr.cpp:1618
+msgid "Sparse part files only occupy disk space for the parts already downloaded, so free space is used up gradually as the file fills in. Turn this off to use an ordinary file instead - useful where sparse files are unsupported or slow, or where backup/de-duplication tools handle them badly. Applies only when the core runs on Windows; on Linux and macOS part files are sparse anyway and this setting has no effect."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1619
+#: src/muuli_wdr.cpp:1623
 msgid "Stop downloads when free disk space reaches "
 msgstr "Stoppe Downloads wenn freier Speicherplatz folgenden Wert erreicht:"
 
-#: src/muuli_wdr.cpp:1620
+#: src/muuli_wdr.cpp:1624
 msgid "Select this if you want aMule to check your disk space"
 msgstr "Wähle dies aus, wenn aMule deinen Festplattenplatz prüfen soll"
 
-#: src/muuli_wdr.cpp:1624
+#: src/muuli_wdr.cpp:1628
 msgid "Enter here the min disk space desired."
 msgstr "Hier den minimalen erwünschten Festplattenplatz angeben."
 
-#: src/muuli_wdr.cpp:1630
+#: src/muuli_wdr.cpp:1634
 msgid "Save 10 sources on rare files (< 20 sources)"
 msgstr "Bei seltenen (< 20 Quellen) Dateien zehn Quellen speichern"
 
-#: src/muuli_wdr.cpp:1634 src/Statistics.cpp:790
+#: src/muuli_wdr.cpp:1638 src/Statistics.cpp:790
 msgid "Uploads"
 msgstr "Uploads"
 
-#: src/muuli_wdr.cpp:1637
+#: src/muuli_wdr.cpp:1641
 msgid "Add new shared files with auto priority"
 msgstr "Neue freigegebene Dateien auf Autopriorität stellen"
 
-#: src/muuli_wdr.cpp:1643
+#: src/muuli_wdr.cpp:1647
 msgid "Intelligent Corruption Handling (I.C.H.)"
 msgstr "Intelligente Korruptionsverarbeitung (I.C.H.)"
 
-#: src/muuli_wdr.cpp:1646
+#: src/muuli_wdr.cpp:1650
 msgid "Enable"
 msgstr "Aktiviere"
 
-#: src/muuli_wdr.cpp:1649
+#: src/muuli_wdr.cpp:1653
 msgid "Advanced I.C.H. trusts every hash (not recommended)"
 msgstr "Advanced I.C.H vertraut jeder Prüfsumme (nicht empfohlen)"
 
-#: src/muuli_wdr.cpp:1661 src/PrefsUnifiedDlg.cpp:1910
+#: src/muuli_wdr.cpp:1665 src/PrefsUnifiedDlg.cpp:1990
 msgid "Media metadata extraction"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1665
+#: src/muuli_wdr.cpp:1669
 msgid "Extract length / bitrate / codec from shared audio and video files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1667
+#: src/muuli_wdr.cpp:1671
 msgid "When enabled, aMule runs ffprobe on each shared media file to fill in the Length / Bitrate / Codec columns other clients see when they find the file in a search. Requires ffmpeg (the ffprobe binary) to be installed."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1674
+#: src/muuli_wdr.cpp:1678
 msgid "Path to ffprobe:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1679
+#: src/muuli_wdr.cpp:1683
 msgid "Full path to the ffprobe binary. Leave empty to have aMule auto-detect it on startup."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1687
+#: src/muuli_wdr.cpp:1691
 msgid "Detect"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1688
+#: src/muuli_wdr.cpp:1692
 msgid "Search the standard install locations for an ffprobe binary and fill the path field."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1712
+#: src/muuli_wdr.cpp:1716
 msgid ""
 "Completed downloads are stored here. All files in this folder are automatically shared with other peers.\n"
 "If this folder also holds files you don't want to share, point it at an aMule-only sub-folder."
@@ -4174,674 +4179,697 @@ msgstr ""
 "Vollständige Downloads werden hier gespeichert. Alle Dateien in diesem Ordner werden automatisch geteilt\n"
 ". Falls dieser Ordner Dateien enthält die du nicht teilen willst, wähle einen eigenen Ordner nur für aMule aus."
 
-#: src/muuli_wdr.cpp:1715
+#: src/muuli_wdr.cpp:1719
 msgid "Pick the folder where completed downloads will be stored. All files in that folder will be shared with other peers."
 msgstr "Wähle einen Ordner in dem vollständige Downloads gepeichert werden sollen. Dieser Ordner wird automatisch geteilt."
 
-#: src/muuli_wdr.cpp:1729
+#: src/muuli_wdr.cpp:1733
 msgid "Shared folders"
 msgstr "Freigegebene Ordner"
 
-#: src/muuli_wdr.cpp:1735
+#: src/muuli_wdr.cpp:1739
 msgid "(Folders shared by the core. Enter a path to add one.)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1743
+#: src/muuli_wdr.cpp:1747
 msgid "Absolute path of a folder on the core's machine, e.g. /home/user/shared"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1745 src/PrefsUnifiedDlg.cpp:2794
+#: src/muuli_wdr.cpp:1749 src/PrefsUnifiedDlg.cpp:2874
 msgid "Recursive"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1746
+#: src/muuli_wdr.cpp:1750
 msgid "Share every sub-folder underneath this one, including ones created later."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1750 src/utils/aLinkCreator/src/alcframe.cpp:141
+#: src/muuli_wdr.cpp:1754 src/utils/aLinkCreator/src/alcframe.cpp:141
 msgid "Remove"
 msgstr "Entferne"
 
-#: src/muuli_wdr.cpp:1754
+#: src/muuli_wdr.cpp:1758
 msgid "(Right click on folder icon for recursive share)"
 msgstr "(Rechtsklick auf das Symbol des rekursiv freizugebenden Verzeichnisses)"
 
-#: src/muuli_wdr.cpp:1761
+#: src/muuli_wdr.cpp:1765
 msgid "Share hidden files"
 msgstr "Versteckte Dateien freigeben"
 
-#: src/muuli_wdr.cpp:1767
+#: src/muuli_wdr.cpp:1771
 msgid "Automatically rescan shared folders for changes"
 msgstr "Ornder automatisch auf Änderungen überwachen"
 
-#: src/muuli_wdr.cpp:1773
+#: src/muuli_wdr.cpp:1777
 msgid "Follow symbolic links in shared folders"
 msgstr "Symbolischen Links in geteilten Ordnern folgen"
 
-#: src/muuli_wdr.cpp:1779
+#: src/muuli_wdr.cpp:1783
 msgid "Exclude files matching:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1782
+#: src/muuli_wdr.cpp:1786
 msgid "Wildcard patterns separated by '|', e.g. .DS_Store|Thumbs.db|*.tmp. Files whose name matches are not shared. Matching is case-insensitive."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1786
+#: src/muuli_wdr.cpp:1790
 msgid "Patterns are regular expressions"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1787
+#: src/muuli_wdr.cpp:1791
 msgid "When set, the whole field is one regular expression ('|' is alternation). When unset, it is a list of '|'-separated wildcards."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1797
+#: src/muuli_wdr.cpp:1801
 msgid "Show how many shared files the current pattern would exclude."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1818
+#: src/muuli_wdr.cpp:1822
 msgid "Graphs"
 msgstr "Graphen"
 
-#: src/muuli_wdr.cpp:1821 src/muuli_wdr.cpp:1883
+#: src/muuli_wdr.cpp:1825 src/muuli_wdr.cpp:1887
 msgid "Update delay : 5 secs"
 msgstr "Aktualisierungsverzögerung: 5 Sekunden"
 
-#: src/muuli_wdr.cpp:1825
+#: src/muuli_wdr.cpp:1829
 msgid "Time for average graph: 100 mins"
 msgstr "Durchschnittsgraphen in Minuten berechnen: 100 min"
 
-#: src/muuli_wdr.cpp:1829
+#: src/muuli_wdr.cpp:1833
 msgid "Connections Graph Scale: 100 "
 msgstr "Verbindungsgraphenskalierung: 100"
 
-#: src/muuli_wdr.cpp:1836
+#: src/muuli_wdr.cpp:1840
 msgid "Download graph scale:"
 msgstr "Downloadgraphenskalierung:"
 
-#: src/muuli_wdr.cpp:1844
+#: src/muuli_wdr.cpp:1848
 msgid "Upload graph scale:"
 msgstr "Uploadgraphenskalierung:"
 
-#: src/muuli_wdr.cpp:1854
+#: src/muuli_wdr.cpp:1858
 msgid "Colors: "
 msgstr "Farben: "
 
-#: src/muuli_wdr.cpp:1858
+#: src/muuli_wdr.cpp:1862
 msgid "Background"
 msgstr "Hintergrund"
 
-#: src/muuli_wdr.cpp:1859
+#: src/muuli_wdr.cpp:1863
 msgid "Grid"
 msgstr "Gitter"
 
-#: src/muuli_wdr.cpp:1860
+#: src/muuli_wdr.cpp:1864
 msgid "Download current"
 msgstr "Aktueller Download"
 
-#: src/muuli_wdr.cpp:1861
+#: src/muuli_wdr.cpp:1865
 msgid "Download running average"
 msgstr "Download: Durchschnitt"
 
-#: src/muuli_wdr.cpp:1862
+#: src/muuli_wdr.cpp:1866
 msgid "Download session average"
 msgstr "Download: Sitzungsdurchschnitt"
 
-#: src/muuli_wdr.cpp:1863
+#: src/muuli_wdr.cpp:1867
 msgid "Upload current"
 msgstr "Aktueller Upload"
 
-#: src/muuli_wdr.cpp:1864
+#: src/muuli_wdr.cpp:1868
 msgid "Upload running average"
 msgstr "Upload: Durchschnitt"
 
-#: src/muuli_wdr.cpp:1865
+#: src/muuli_wdr.cpp:1869
 msgid "Upload session average"
 msgstr "Upload: Sitzungsdurchschnitt"
 
-#: src/muuli_wdr.cpp:1866
+#: src/muuli_wdr.cpp:1870
 msgid "Active connections"
 msgstr "Aktive Verbindungen"
 
-#: src/muuli_wdr.cpp:1869
+#: src/muuli_wdr.cpp:1873
 msgid "Systray Icon Speed Bar"
 msgstr "Transferbalken des Symbols im Infobereich"
 
-#: src/muuli_wdr.cpp:1870
+#: src/muuli_wdr.cpp:1874
 msgid "Kad-nodes current"
 msgstr "Momentane Kad-Knoten"
 
-#: src/muuli_wdr.cpp:1871
+#: src/muuli_wdr.cpp:1875
 msgid "Kad-nodes running"
 msgstr "Laufende Kad-Knoten"
 
-#: src/muuli_wdr.cpp:1872
+#: src/muuli_wdr.cpp:1876
 msgid "Kad-nodes session"
 msgstr "Kad-Knoten Sitzung"
 
-#: src/muuli_wdr.cpp:1876 src/muuli_wdr.cpp:2303
+#: src/muuli_wdr.cpp:1880 src/muuli_wdr.cpp:2334
 msgid "Select"
 msgstr "Auswahl"
 
-#: src/muuli_wdr.cpp:1880
+#: src/muuli_wdr.cpp:1884
 msgid "Tree"
 msgstr "Baum"
 
-#: src/muuli_wdr.cpp:1890
+#: src/muuli_wdr.cpp:1894
 msgid "Number of Client Versions shown (0=unlimited)"
 msgstr "Anzahl angezeigter Client-Versionen (0=unbegrenzt)"
 
-#: src/muuli_wdr.cpp:1915
+#: src/muuli_wdr.cpp:1919
 msgid "!!! WARNING !!!"
 msgstr "!!! WARNUNG !!!"
 
-#: src/muuli_wdr.cpp:1930
+#: src/muuli_wdr.cpp:1934
 msgid "Max new connections / 5 secs"
 msgstr "Maximale neue Verbindungen pro 5 Sekunden"
 
-#: src/muuli_wdr.cpp:1932
+#: src/muuli_wdr.cpp:1936
 msgid "Concurrent Kad source lookups"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1934
+#: src/muuli_wdr.cpp:1938
 #, fuzzy
 msgid "Kad source re-search interval (minutes)"
 msgstr "FTP-Aktualisierungsintervall in Minuten"
 
-#: src/muuli_wdr.cpp:1936
+#: src/muuli_wdr.cpp:1940
 #, fuzzy
 msgid "Source re-ask interval (minutes)"
 msgstr "FTP-Aktualisierungsintervall in Minuten"
 
-#: src/muuli_wdr.cpp:1940
+#: src/muuli_wdr.cpp:1944
 msgid "File Buffer Size: 240000 bytes"
 msgstr "Dateipuffergröße: 240000 Bytes"
 
-#: src/muuli_wdr.cpp:1944
+#: src/muuli_wdr.cpp:1948
 msgid "Use MMAP: memory-mapped file access (lower memory use)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1945
+#: src/muuli_wdr.cpp:1949
 msgid "Maps part files into memory instead of buffering them on the heap, lowering the process memory footprint. May reduce download speed on some disks; best for memory-constrained or upload-heavy hosts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1947
+#: src/muuli_wdr.cpp:1951
 msgid "Upload Queue Size: 5000 clients"
 msgstr "Upload-Warteschlangengröße: 5000 Clients"
 
-#: src/muuli_wdr.cpp:1951
+#: src/muuli_wdr.cpp:1955
 msgid "Server connection refresh interval: Disable"
 msgstr "Server-Wiederverbindungsintervall: Aus"
 
-#: src/muuli_wdr.cpp:1955
+#: src/muuli_wdr.cpp:1959
 msgid "Disable computer's timed standby mode"
 msgstr "Zeitgesteuerten Bereitschaftsmodus des Computers deaktivieren"
 
-#: src/muuli_wdr.cpp:1974
+#: src/muuli_wdr.cpp:1978
 msgid "Skin to use: "
 msgstr "benutztes Aussehen:"
 
-#: src/muuli_wdr.cpp:1983
+#: src/muuli_wdr.cpp:1987
 msgid "Show \"Fast eD2k Links Handler\" in every window."
 msgstr "Zeige \"schnelle eD2k-Linkverarbeitung\" in jedem Fenster"
 
-#: src/muuli_wdr.cpp:1986
+#: src/muuli_wdr.cpp:1990
 msgid "Show extended info on categories tabs"
 msgstr "Zeige erweiterte Informationen auf Kategorie-Reitern"
 
-#: src/muuli_wdr.cpp:1989
+#: src/muuli_wdr.cpp:1993
 msgid "Show application version on title"
 msgstr "Zeige Programmversion im Titel"
 
-#: src/muuli_wdr.cpp:1991
+#: src/muuli_wdr.cpp:1995
 msgid "Show transfer rates on title"
 msgstr "Zeige Transferraten im Titel"
 
-#: src/muuli_wdr.cpp:1993
+#: src/muuli_wdr.cpp:1997
 msgid "Before application name"
 msgstr "Vor dem Anwendungsnamen"
 
-#: src/muuli_wdr.cpp:1995
+#: src/muuli_wdr.cpp:1999
 msgid "After application name"
 msgstr "Nach dem Anwendungsnamen"
 
-#: src/muuli_wdr.cpp:1998
+#: src/muuli_wdr.cpp:2002
 msgid "Show overhead bandwidth"
 msgstr "Zeige Overhead-Bandbreite"
 
-#: src/muuli_wdr.cpp:2002
+#: src/muuli_wdr.cpp:2006
 msgid "Vertical toolbar orientation"
 msgstr "Toolbar senkrecht ausrichten"
 
-#: src/muuli_wdr.cpp:2004
+#: src/muuli_wdr.cpp:2008
 msgid "Live column sorting (auto-reorder rows as their values change)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2011
+#: src/muuli_wdr.cpp:2015
 msgid "Download Queue Files"
 msgstr "Downloadwarteschlangendateien"
 
-#: src/muuli_wdr.cpp:2014
+#: src/muuli_wdr.cpp:2018
 msgid "Show progress percentage"
 msgstr "Zeige Prozent des Fortschritts"
 
-#: src/muuli_wdr.cpp:2020
+#: src/muuli_wdr.cpp:2024
 msgid "Show progress bar"
 msgstr "Zeige Fortschrittsbalken"
 
-#: src/muuli_wdr.cpp:2023
+#: src/muuli_wdr.cpp:2027
 msgid "Flat"
 msgstr "Flach"
 
-#: src/muuli_wdr.cpp:2027
+#: src/muuli_wdr.cpp:2031
 msgid "Round"
 msgstr "Rund"
 
-#: src/muuli_wdr.cpp:2045
+#: src/muuli_wdr.cpp:2049
 msgid "External Connection Parameters"
 msgstr "Parameter für externe Verbindungen"
 
-#: src/muuli_wdr.cpp:2048
+#: src/muuli_wdr.cpp:2052
 msgid "Accept external connections"
 msgstr "Externe Verbindungen annehmen"
 
-#: src/muuli_wdr.cpp:2055 src/muuli_wdr.cpp:2114
+#: src/muuli_wdr.cpp:2059 src/muuli_wdr.cpp:2118
 msgid "IP of the listening interface:"
 msgstr "IP der lauschenden Schnittstelle:"
 
-#: src/muuli_wdr.cpp:2058
+#: src/muuli_wdr.cpp:2062
 msgid "Enter here a valid ip in the a.b.c.d format for the listening EC interface. An empty field or 0.0.0.0 will mean any interface."
 msgstr "Hier eine gültige IP im Format a.b.c.d für das lauschende EC-Interface eingeben. Ein leeres Feld oder 0.0.0.0 bedeutet ein beliebiges Interface."
 
-#: src/muuli_wdr.cpp:2079 src/muuli_wdr.cpp:2163
+#: src/muuli_wdr.cpp:2083 src/muuli_wdr.cpp:2194
 msgid "TCP port:"
 msgstr "TCP-Port:"
 
-#: src/muuli_wdr.cpp:2085
+#: src/muuli_wdr.cpp:2089
 msgid "Enable UPnP port forwarding on the EC port"
 msgstr "Aktiviere UPnP-Port-Weiterleitung zu EC-Port"
 
-#: src/muuli_wdr.cpp:2089 src/muuli_wdr.cpp:3048
+#: src/muuli_wdr.cpp:2093 src/muuli_wdr.cpp:3079
 #: src/utils/wxCas/src/wxcasprefs.cpp:167
 msgid "Password"
 msgstr "Passwort"
 
-#: src/muuli_wdr.cpp:2095
+#: src/muuli_wdr.cpp:2099
 #, fuzzy
 msgid "aMule API server parameters"
 msgstr "Webserver-Parameter"
 
-#: src/muuli_wdr.cpp:2098
+#: src/muuli_wdr.cpp:2102
 msgid "Run amuleapi (REST API) on startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2103
+#: src/muuli_wdr.cpp:2107
 #, fuzzy
 msgid "HTTP port:"
 msgstr "TCP-Port:"
 
-#: src/muuli_wdr.cpp:2117
+#: src/muuli_wdr.cpp:2121
 msgid "The interface amuleapi's HTTP server listens on. 127.0.0.1 (default) accepts only local connections; use 0.0.0.0 or a specific IP to expose it to other hosts (set an admin password below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2120
+#: src/muuli_wdr.cpp:2126
+msgid "Type a password to set or change it. Stored passwords cannot be shown, so leaving this empty keeps the current one."
+msgstr ""
+
+#: src/muuli_wdr.cpp:2128
 #, fuzzy
 msgid "Admin password"
 msgstr "Prüfe Passwort\n"
 
-#: src/muuli_wdr.cpp:2125 src/muuli_wdr.cpp:2156
-msgid "Low rights password"
-msgstr "Kennwort für eingeschränkten Zugriff"
+#: src/muuli_wdr.cpp:2140 src/muuli_wdr.cpp:2157 src/PrefsUnifiedDlg.cpp:1103
+#, fuzzy
+msgid "A password is set."
+msgstr "Prüfe Passwort\n"
 
-#: src/muuli_wdr.cpp:2133
+#: src/muuli_wdr.cpp:2144
+#, fuzzy
+msgid "Enable guest access"
+msgstr "Verweigere Gastzugriff"
+
+#: src/muuli_wdr.cpp:2145
+msgid "Guest sessions may read status and listings but cannot change anything. Turning this off clears the stored guest password."
+msgstr ""
+
+#: src/muuli_wdr.cpp:2149
+#, fuzzy
+msgid "Guest password"
+msgstr "Gast-Passwort für den Webserver"
+
+#: src/muuli_wdr.cpp:2164
 msgid "Web server parameters"
 msgstr "Webserver-Parameter"
 
-#: src/muuli_wdr.cpp:2136
+#: src/muuli_wdr.cpp:2167
 #, fuzzy
 msgid "Run webserver on startup (deprecated)"
 msgstr "Starte Webserver mit aMule"
 
-#: src/muuli_wdr.cpp:2142
+#: src/muuli_wdr.cpp:2173
 msgid "Web template"
 msgstr "Webvorlage"
 
-#: src/muuli_wdr.cpp:2147
+#: src/muuli_wdr.cpp:2178
 msgid "Full rights password"
 msgstr "Kennwort für Vollzugriff"
 
-#: src/muuli_wdr.cpp:2151
+#: src/muuli_wdr.cpp:2182
 msgid "Enable Low rights User"
 msgstr "Eingeschränkten Benutzer aktivieren"
 
-#: src/muuli_wdr.cpp:2170
+#: src/muuli_wdr.cpp:2187
+msgid "Low rights password"
+msgstr "Kennwort für eingeschränkten Zugriff"
+
+#: src/muuli_wdr.cpp:2201
 msgid "Enable UPnP port forwarding of the web server port"
 msgstr "Aktiviere UPnP-Port-Weiterleitung des Webserverports"
 
-#: src/muuli_wdr.cpp:2175
+#: src/muuli_wdr.cpp:2206
 msgid "Web server UPnP TCP port (Optional)"
 msgstr "Webserver UPnP-TCP-Port (optional)"
 
-#: src/muuli_wdr.cpp:2183
+#: src/muuli_wdr.cpp:2214
 msgid "Page Refresh Time (in secs)"
 msgstr "Aktualisierungsintervall in Sekunden"
 
-#: src/muuli_wdr.cpp:2190
+#: src/muuli_wdr.cpp:2221
 msgid "Enable Gzip compression"
 msgstr "Gzip-Kompression an"
 
-#: src/muuli_wdr.cpp:2224
+#: src/muuli_wdr.cpp:2255
 #, fuzzy
 msgid "Reset page to defaults"
 msgstr "Systemvorgabe"
 
-#: src/muuli_wdr.cpp:2225
+#: src/muuli_wdr.cpp:2256
 msgid "Reset the settings on the current page to their default values."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2227 src/muuli_wdr.cpp:2313 src/ServerWnd.cpp:274
+#: src/muuli_wdr.cpp:2258 src/muuli_wdr.cpp:2344 src/ServerWnd.cpp:274
 #: src/ServerWnd.cpp:282
 msgid "OK"
 msgstr "OK"
 
-#: src/muuli_wdr.cpp:2229
+#: src/muuli_wdr.cpp:2260
 msgid "Click here to apply any changes made to the preferences."
 msgstr "Hier klicken, um alle Einstellungsänderungen zu übernehmen."
 
-#: src/muuli_wdr.cpp:2232
+#: src/muuli_wdr.cpp:2263
 msgid "Reset any changes made to the preferences."
 msgstr "Alle Änderungen zu den Einstellungen zurücksetzen."
 
-#: src/muuli_wdr.cpp:2261
+#: src/muuli_wdr.cpp:2292
 msgid "Comment :"
 msgstr "Kommentar:"
 
-#: src/muuli_wdr.cpp:2268
+#: src/muuli_wdr.cpp:2299
 msgid "Incoming Dir :"
 msgstr "Verzeichnis für eingehende Dateien:"
 
-#: src/muuli_wdr.cpp:2277
+#: src/muuli_wdr.cpp:2308
 msgid "Change priority for new assigned files :"
 msgstr "Priorität bei neu zugewiesenen Dateien ändern:"
 
-#: src/muuli_wdr.cpp:2281
+#: src/muuli_wdr.cpp:2312
 msgid "Don't change"
 msgstr "Nicht ändern"
 
-#: src/muuli_wdr.cpp:2293
+#: src/muuli_wdr.cpp:2324
 msgid "Select color for this Category (currently selected) :"
 msgstr "Farbe für diese Kategorie wählen (momentan ausgewählt):"
 
-#: src/muuli_wdr.cpp:2360 src/muuli_wdr.cpp:2379 src/muuli_wdr.cpp:2401
+#: src/muuli_wdr.cpp:2391 src/muuli_wdr.cpp:2410 src/muuli_wdr.cpp:2432
 msgid "Click this button to reset the log."
 msgstr "Drücke diesen Knopf, um das Log zurückzusetzen."
 
-#: src/muuli_wdr.cpp:2420
+#: src/muuli_wdr.cpp:2451
 msgid "Click on this button to update the servers list from URL ..."
 msgstr "Hier klicken, um die Serverliste über die angegebene URL zu aktualisieren"
 
-#: src/muuli_wdr.cpp:2424
+#: src/muuli_wdr.cpp:2455
 msgid "Server list"
 msgstr "Serverliste"
 
-#: src/muuli_wdr.cpp:2428
+#: src/muuli_wdr.cpp:2459
 msgid "Enter the url to a server.met file here and press the button to the left to update the list of known servers."
 msgstr "Hier die URL einer server.met eingeben, und dann den Knopf links vom Eingabefeld drücken, um die Serverliste zu aktualisieren."
 
-#: src/muuli_wdr.cpp:2433
+#: src/muuli_wdr.cpp:2464
 msgid "Add server manually: Name"
 msgstr "Server manuell hinzufügen: Name"
 
-#: src/muuli_wdr.cpp:2436
+#: src/muuli_wdr.cpp:2467
 msgid "Enter the name of the new server here"
 msgstr "Gib den Namen das neuen Servers hier ein"
 
-#: src/muuli_wdr.cpp:2438 src/ServerWnd.cpp:206
+#: src/muuli_wdr.cpp:2469 src/ServerWnd.cpp:206
 msgid "IP:Port"
 msgstr "IP:Port"
 
-#: src/muuli_wdr.cpp:2441
+#: src/muuli_wdr.cpp:2472
 msgid "Enter the IP of the server here, using the x.x.x.x format."
 msgstr "Hier die IP des Servers im Format x.x.x.x eingeben."
 
-#: src/muuli_wdr.cpp:2447
+#: src/muuli_wdr.cpp:2478
 msgid "Enter the port of the server here."
 msgstr "Hier den Serverport eingeben."
 
-#: src/muuli_wdr.cpp:2450
+#: src/muuli_wdr.cpp:2481
 msgid "Add manually a server (fill fields to the left before) ..."
 msgstr "Einen Server manuell hinzufügen (vorher bitte links die Felder ausfüllen)..."
 
-#: src/muuli_wdr.cpp:2479
+#: src/muuli_wdr.cpp:2510
 msgid "aMule Log"
 msgstr "aMule-Log"
 
-#: src/muuli_wdr.cpp:2487
+#: src/muuli_wdr.cpp:2518
 msgid "Server Info"
 msgstr "Serverinformation"
 
-#: src/muuli_wdr.cpp:2491
+#: src/muuli_wdr.cpp:2522
 msgid "ED2K Info"
 msgstr "eD2k-Info"
 
-#: src/muuli_wdr.cpp:2495
+#: src/muuli_wdr.cpp:2526
 msgid "Kad Info"
 msgstr "Kad-Info"
 
-#: src/muuli_wdr.cpp:2523
+#: src/muuli_wdr.cpp:2554
 msgid "Click on this button to update the nodes list from URL ..."
 msgstr "Zum Aktualisieren der nodes.dat von URL diese Schaltfläche drücken."
 
-#: src/muuli_wdr.cpp:2527
+#: src/muuli_wdr.cpp:2558
 msgid "Nodes (0)"
 msgstr "Knoten (0)"
 
-#: src/muuli_wdr.cpp:2531
+#: src/muuli_wdr.cpp:2562
 msgid "Enter the url to a nodes.dat file here and press the button to the left to update the list of known nodes."
 msgstr "Hier die URL einer nodes.dat eingeben, und dann den Knopf links vom Eingabefeld drücken, um die Liste der bekannten Knoten zu aktualisieren."
 
-#: src/muuli_wdr.cpp:2534
+#: src/muuli_wdr.cpp:2565
 msgid "Nodes stats"
 msgstr "Knotenstatistik"
 
-#: src/muuli_wdr.cpp:2576
+#: src/muuli_wdr.cpp:2607
 msgid "Bootstrap"
 msgstr "Bootstrap"
 
-#: src/muuli_wdr.cpp:2579
+#: src/muuli_wdr.cpp:2610
 msgid "New node"
 msgstr "Neuer Knoten"
 
-#: src/muuli_wdr.cpp:2584
+#: src/muuli_wdr.cpp:2615
 msgid "IP:"
 msgstr "IP:"
 
-#: src/muuli_wdr.cpp:2604
+#: src/muuli_wdr.cpp:2635
 msgid "Port:"
 msgstr "Port:"
 
-#: src/muuli_wdr.cpp:2617
+#: src/muuli_wdr.cpp:2648
 msgid "Bootstrap from known clients"
 msgstr "Bootstrap von bekannten Clients"
 
-#: src/muuli_wdr.cpp:2619
+#: src/muuli_wdr.cpp:2650
 msgid "Disconnect Kad"
 msgstr "Kad trennen"
 
-#: src/muuli_wdr.cpp:2653
+#: src/muuli_wdr.cpp:2684
 msgid "Use Secure User Identification"
 msgstr "Benutze sichere Benutzeridentifikation"
 
-#: src/muuli_wdr.cpp:2655
+#: src/muuli_wdr.cpp:2686
 msgid "It is recommended to enable this option. You will not receive credits if SUI is not enabled."
 msgstr "Es wird empfohlen diese Option zu aktivieren. Du wirst keine Credits erhalten, wenn SUI nicht aktiviert ist."
 
-#: src/muuli_wdr.cpp:2657
+#: src/muuli_wdr.cpp:2688
 msgid "Protocol Obfuscation"
 msgstr "Protokollverschleierung"
 
-#: src/muuli_wdr.cpp:2660
+#: src/muuli_wdr.cpp:2691
 msgid "Support Protocol Obfuscation"
 msgstr "Unterstütze Protokollverschleierung"
 
-#: src/muuli_wdr.cpp:2662
+#: src/muuli_wdr.cpp:2693
 msgid "This option enabled Protocol Obfuscation, and makes aMule accept obfuscated connections from other clients."
 msgstr "Diese Option aktiviert die Protokollverschleierung und verfügt aMule, verschleierte Verbindungen von anderen Clients anzunehmen."
 
-#: src/muuli_wdr.cpp:2664
+#: src/muuli_wdr.cpp:2695
 msgid "Use obfuscation for outgoing connections"
 msgstr "Verschleiere ausgehende Verbindungen"
 
-#: src/muuli_wdr.cpp:2666
+#: src/muuli_wdr.cpp:2697
 msgid "This option makes aMule use Protocol Obfuscation when connecting other clients/servers."
 msgstr "Diese Option verfügt aMule, Protokollverschleierung zu verwenden bei der Verbindung zu anderen Clients und/oder Servern."
 
-#: src/muuli_wdr.cpp:2668
+#: src/muuli_wdr.cpp:2699
 msgid "Accept only obfuscated connections"
 msgstr "Akzeptiere ausschließlich verschleierte Verbindungen"
 
-#: src/muuli_wdr.cpp:2669
+#: src/muuli_wdr.cpp:2700
 msgid "This option makes aMule only accept obfuscated connections. You will have less sources, but all your traffic will be obfuscated"
 msgstr "Diese Option verfügt aMule, ausschließlich verschleierte Verbindungen zu akzeptieren. Das führt zu weniger Quellen, jedoch ist sämtlicher Verkehr verschleiert."
 
-#: src/muuli_wdr.cpp:2674
+#: src/muuli_wdr.cpp:2705
 msgid "Everybody"
 msgstr "Jeder"
 
-#: src/muuli_wdr.cpp:2676
+#: src/muuli_wdr.cpp:2707
 msgid "No one"
 msgstr "Niemand"
 
-#: src/muuli_wdr.cpp:2678
+#: src/muuli_wdr.cpp:2709
 msgid "Who can see my shared files:"
 msgstr "Wer kann freigegebene Dateien sehen:"
 
-#: src/muuli_wdr.cpp:2679
+#: src/muuli_wdr.cpp:2710
 msgid "Select who can request to view a list of your shared files."
 msgstr "Wähle, wer deine freigegebenen Dateien einsehen darf."
 
-#: src/muuli_wdr.cpp:2681
+#: src/muuli_wdr.cpp:2712
 msgid "IP-Filtering"
 msgstr "IP-Filterung"
 
-#: src/muuli_wdr.cpp:2688
+#: src/muuli_wdr.cpp:2719
 msgid "Filter clients"
 msgstr "Filtere Clients"
 
-#: src/muuli_wdr.cpp:2690
+#: src/muuli_wdr.cpp:2721
 msgid "Enable filtering of the client IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "Aktiviere die Filterung von Client-IPs, die in der Datei ~/.aMule/ipfilter.dat definiert sind."
 
-#: src/muuli_wdr.cpp:2692
+#: src/muuli_wdr.cpp:2723
 msgid "Filter servers"
 msgstr "Filtere Server"
 
-#: src/muuli_wdr.cpp:2694
+#: src/muuli_wdr.cpp:2725
 msgid "Enable filtering of the server IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "Aktiviere das Filtern von Server-IPs, die in der Datei ~/.aMule/ipfilter.dat definiert sind."
 
-#: src/muuli_wdr.cpp:2698
+#: src/muuli_wdr.cpp:2729
 msgid "Reload List"
 msgstr "Aktualisieren der Liste"
 
-#: src/muuli_wdr.cpp:2699
+#: src/muuli_wdr.cpp:2730
 msgid "Reload the list of IPs to filter from the file ~/.aMule/ipfilter.dat"
 msgstr "Aktualisiert die Liste der zu filternden IPs in der ~/.aMule/ipfilter.dat"
 
-#: src/muuli_wdr.cpp:2705
+#: src/muuli_wdr.cpp:2736
 msgid "URL:"
 msgstr "URL:"
 
-#: src/muuli_wdr.cpp:2709 src/muuli_wdr.cpp:2902
+#: src/muuli_wdr.cpp:2740 src/muuli_wdr.cpp:2933
 msgid "Update now"
 msgstr "Jetzt aktualisieren"
 
-#: src/muuli_wdr.cpp:2712
+#: src/muuli_wdr.cpp:2743
 msgid "Auto-update ipfilter at startup"
 msgstr "IP-Filter beim Start automatisch aktualisieren"
 
-#: src/muuli_wdr.cpp:2716
+#: src/muuli_wdr.cpp:2747
 msgid "Filtering Level:"
 msgstr "Filterstufe:"
 
-#: src/muuli_wdr.cpp:2722
+#: src/muuli_wdr.cpp:2753
 msgid "Always filter LAN IPs"
 msgstr "LAN-IP-Adressen immer filtern"
 
-#: src/muuli_wdr.cpp:2725
+#: src/muuli_wdr.cpp:2756
 msgid "Paranoid handling of non-matching IPs"
 msgstr "Paranoides Handhaben nicht-passender IP-Adressen"
 
-#: src/muuli_wdr.cpp:2727
+#: src/muuli_wdr.cpp:2758
 msgid "Rejects a packet when its source IP differs from the IP the client claims (an anti-spoofing check). Disable only if it causes connection problems."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2729
+#: src/muuli_wdr.cpp:2760
 msgid "Use system-wide ipfilter.dat if available"
 msgstr "Benutze systemweite ipfilter.dat, wenn verfügbar."
 
-#: src/muuli_wdr.cpp:2730
+#: src/muuli_wdr.cpp:2761
 msgid "If there's no local ipfilter.dat found, allow usage of a system-wide ipfilter file."
 msgstr "Erlaube die Benutzung der systemweiten ipfilter-Datei, falls keine lokale ipfilter.dat gefunden wird."
 
-#: src/muuli_wdr.cpp:2747
+#: src/muuli_wdr.cpp:2778
 msgid "Enable Online-Signature"
 msgstr "Online-Signatur aktivieren"
 
-#: src/muuli_wdr.cpp:2749
+#: src/muuli_wdr.cpp:2780
 msgid "Enables the writing of the OS file, which can be used by external apps to create signatures and the like."
 msgstr "Aktiviert das Schreiben der Online-Signaturdatei, die von externen Programmen verwendet werden kann, um Signaturen o.ä. zu erstellen."
 
-#: src/muuli_wdr.cpp:2753
+#: src/muuli_wdr.cpp:2784
 msgid "Update Frequency (Secs):"
 msgstr "Aktualisierungsintervall (Sekunden):"
 
-#: src/muuli_wdr.cpp:2756
+#: src/muuli_wdr.cpp:2787
 msgid "Change the frequency (in seconds) of Online Signature updates."
 msgstr "Ändern des Online-Signatur-Aktualisierungsintervalls (in Sekunden)."
 
-#: src/muuli_wdr.cpp:2764
+#: src/muuli_wdr.cpp:2795
 msgid "Save online signature file in: "
 msgstr "Speichere Online-Signatur-Datei in:"
 
-#: src/muuli_wdr.cpp:2770
+#: src/muuli_wdr.cpp:2801
 msgid "Click here to select the directory containing the the Online Signature files."
 msgstr "Hier klicken, um das Verzeichnis mit den Dateien für die Online-Signatur auszuwählen."
 
-#: src/muuli_wdr.cpp:2803
+#: src/muuli_wdr.cpp:2834
 msgid "Show country flags for clients"
 msgstr "Landesflaggen für Clients anzeigen"
 
-#: src/muuli_wdr.cpp:2804
+#: src/muuli_wdr.cpp:2835
 msgid "Render the country flag column in the transfers, queue and search views. Requires a valid MMDB GeoIP database (see below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2809
+#: src/muuli_wdr.cpp:2840
 #, fuzzy
 msgid "Database"
 msgstr "Datenrate:"
 
-#: src/muuli_wdr.cpp:2825
+#: src/muuli_wdr.cpp:2856
 #, fuzzy
 msgid "Source:"
 msgstr "Quellen"
 
-#: src/muuli_wdr.cpp:2828
+#: src/muuli_wdr.cpp:2859
 msgid "DB-IP (free, no account)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2829
+#: src/muuli_wdr.cpp:2860
 msgid "MaxMind GeoLite2 (free, account required)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2830
+#: src/muuli_wdr.cpp:2861
 msgid "Custom URL"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2833
+#: src/muuli_wdr.cpp:2864
 msgid "Choose which provider supplies the GeoIP MMDB database. DB-IP is the default - no account required. MaxMind requires a free account + license key. Use Custom URL to point at any other MMDB host (e.g. a local mirror)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2850
+#: src/muuli_wdr.cpp:2881
 msgid ""
 "No configuration required.\n"
 "\n"
@@ -4849,11 +4877,11 @@ msgid ""
 "License: Creative Commons BY 4.0 - https://creativecommons.org/licenses/by/4.0/"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2863
+#: src/muuli_wdr.cpp:2894
 msgid "License key:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2869
+#: src/muuli_wdr.cpp:2900
 msgid ""
 "Sign up for a free MaxMind account, then generate a License Key:\n"
 "https://www.maxmind.com/en/geolite2/signup\n"
@@ -4863,224 +4891,224 @@ msgid ""
 "Requires attribution and account registration; refresh at least every 30 days."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2884
+#: src/muuli_wdr.cpp:2915
 #, fuzzy
 msgid "Download URL:"
 msgstr "Download: "
 
-#: src/muuli_wdr.cpp:2890
+#: src/muuli_wdr.cpp:2921
 msgid ""
 "Must point to an .mmdb file or a .gz / .tar.gz containing one.\n"
 "URL may include credentials (https://user:pass@host/...).\n"
 "License and attribution terms are set by the upstream URL - you are responsible."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2903
+#: src/muuli_wdr.cpp:2934
 msgid "Download the GeoIP database from the selected source."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2905
+#: src/muuli_wdr.cpp:2936
 #, fuzzy
 msgid "Auto-update on startup"
 msgstr "IP-Filter beim Start automatisch aktualisieren"
 
-#: src/muuli_wdr.cpp:2906
+#: src/muuli_wdr.cpp:2937
 msgid "Re-download the GeoIP database from the selected source every time aMule starts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2929
+#: src/muuli_wdr.cpp:2960
 msgid "Filter incoming messages (except current chat):"
 msgstr "Eingehende Nachrichten filtern (außer momentanen Chats):"
 
-#: src/muuli_wdr.cpp:2931
+#: src/muuli_wdr.cpp:2962
 msgid "Filter all messages"
 msgstr "Filtere alle Nachrichten"
 
-#: src/muuli_wdr.cpp:2933
+#: src/muuli_wdr.cpp:2964
 msgid "Filter messages from people not on your friend list"
 msgstr "Filtere Nachrichten von Benutzern, die nicht auf deiner Freundesliste stehen"
 
-#: src/muuli_wdr.cpp:2935
+#: src/muuli_wdr.cpp:2966
 msgid "Filter messages from unknown clients"
 msgstr "Filtere Nachrichten von unbekannten Clients"
 
-#: src/muuli_wdr.cpp:2937
+#: src/muuli_wdr.cpp:2968
 msgid "Filter messages containing (use ',' as separator):"
 msgstr "Filtere Nachrichten, die folgende Worte enthalten (benutze ',' als Trenner):"
 
-#: src/muuli_wdr.cpp:2940 src/muuli_wdr.cpp:2951
+#: src/muuli_wdr.cpp:2971 src/muuli_wdr.cpp:2982
 msgid "add here the words amule should filter and block messages including it"
 msgstr "Hier die Worte eingeben, die aMule filtern soll, und um Nachrichten abzuweisen, in denen sie vorkommen"
 
-#: src/muuli_wdr.cpp:2942
+#: src/muuli_wdr.cpp:2973
 msgid "Show received messages in the log"
 msgstr "Zeige empfangene Nachrichten im Log an"
 
-#: src/muuli_wdr.cpp:2945
+#: src/muuli_wdr.cpp:2976
 msgid "Comments"
 msgstr "Kommentare"
 
-#: src/muuli_wdr.cpp:2948
+#: src/muuli_wdr.cpp:2979
 msgid "Filter comments containing (use ',' as separator):"
 msgstr "Filtere Komentare, die folgende Worte enthalten (benutze ',' als Trenner):"
 
-#: src/muuli_wdr.cpp:2973
+#: src/muuli_wdr.cpp:3004
 msgid "Enable Proxy"
 msgstr "Proxy aktivieren"
 
-#: src/muuli_wdr.cpp:2974
+#: src/muuli_wdr.cpp:3005
 msgid "Enable/disable proxy support"
 msgstr "Aktiviere/Deaktiviere Proxy-Unterstützung"
 
-#: src/muuli_wdr.cpp:2977
+#: src/muuli_wdr.cpp:3008
 msgid "Proxy type:"
 msgstr "Proxy-Typ:"
 
-#: src/muuli_wdr.cpp:2988
+#: src/muuli_wdr.cpp:3019
 msgid "Proxy host:"
 msgstr "Proxy-Host:"
 
-#: src/muuli_wdr.cpp:2991
+#: src/muuli_wdr.cpp:3022
 msgid "The proxy host name"
 msgstr "Der Hostname des Proxy"
 
-#: src/muuli_wdr.cpp:2993
+#: src/muuli_wdr.cpp:3024
 msgid "Proxy port:"
 msgstr "Proxy-Port:"
 
-#: src/muuli_wdr.cpp:2996
+#: src/muuli_wdr.cpp:3027
 msgid "The proxy port"
 msgstr "Der Port des Proxy"
 
-#: src/muuli_wdr.cpp:2998
+#: src/muuli_wdr.cpp:3029
 msgid "Enable authentication"
 msgstr "Authentifizierung aktivieren"
 
-#: src/muuli_wdr.cpp:2999
+#: src/muuli_wdr.cpp:3030
 msgid "Enable/disable username/password authentication"
 msgstr "Aktiviere/Deaktiviere Authentifizierung mit Benutzername/Passwort"
 
-#: src/muuli_wdr.cpp:3002
+#: src/muuli_wdr.cpp:3033
 msgid "Username: "
 msgstr "Benutzername:"
 
-#: src/muuli_wdr.cpp:3005
+#: src/muuli_wdr.cpp:3036
 msgid "The username to use to connect to the proxy"
 msgstr "Der Benutzername, um sich beim Proxy anzumelden"
 
-#: src/muuli_wdr.cpp:3007
+#: src/muuli_wdr.cpp:3038
 msgid "Password:"
 msgstr "Passwort:"
 
-#: src/muuli_wdr.cpp:3010
+#: src/muuli_wdr.cpp:3041
 msgid "The password to use to connect to the proxy"
 msgstr "Proxy-Verbindungspasswort"
 
-#: src/muuli_wdr.cpp:3029
+#: src/muuli_wdr.cpp:3060
 msgid "Connect to:"
 msgstr "Verbinde zu:"
 
-#: src/muuli_wdr.cpp:3038
+#: src/muuli_wdr.cpp:3069
 msgid "Login to remote amule"
 msgstr "Beim entfernten aMule anmelden"
 
-#: src/muuli_wdr.cpp:3043
+#: src/muuli_wdr.cpp:3074
 msgid "User name"
 msgstr "Benutzername"
 
-#: src/muuli_wdr.cpp:3054
+#: src/muuli_wdr.cpp:3085
 msgid "Remember those settings"
 msgstr "Diese Einstellungen speichern"
 
-#: src/muuli_wdr.cpp:3057
+#: src/muuli_wdr.cpp:3088
 msgid "Force ZLIB compression"
 msgstr "ZLIB-Kompression erzwingen"
 
-#: src/muuli_wdr.cpp:3081
+#: src/muuli_wdr.cpp:3112
 msgid "Enable Verbose Debug-Logging."
 msgstr "Aktiviere ausführliche Debug-Protokollierung"
 
-#: src/muuli_wdr.cpp:3083
+#: src/muuli_wdr.cpp:3114
 msgid "Only to Logfile"
 msgstr "Nur in Logdatei"
 
-#: src/muuli_wdr.cpp:3085
+#: src/muuli_wdr.cpp:3116
 msgid "Message Categories:"
 msgstr "Nachrichtenkategorien:"
 
-#: src/muuli_wdr.cpp:3109 src/PartFileConvertDlg.cpp:160
+#: src/muuli_wdr.cpp:3140 src/PartFileConvertDlg.cpp:160
 msgid "Waiting..."
 msgstr "Wartend..."
 
-#: src/muuli_wdr.cpp:3129
+#: src/muuli_wdr.cpp:3160
 msgid "Add imports"
 msgstr "Füge Importe hinzu"
 
-#: src/muuli_wdr.cpp:3132
+#: src/muuli_wdr.cpp:3163
 msgid "Retry selected"
 msgstr "Versuche Ausgewähltes noch einmal"
 
-#: src/muuli_wdr.cpp:3134
+#: src/muuli_wdr.cpp:3165
 msgid "Remove selected"
 msgstr "Auswahl entfernen"
 
-#: src/muuli_wdr.cpp:3197
+#: src/muuli_wdr.cpp:3228
 msgid "Event Types"
 msgstr "Ereignisarten"
 
-#: src/muuli_wdr.cpp:3216
+#: src/muuli_wdr.cpp:3247
 msgid "Statistics and queued clients for selected file(s) : Session / All time"
 msgstr "Statistiken und Clients in der Warteschlange für ausgewählte Datei(en): Sitzung / Insgesamt"
 
-#: src/muuli_wdr.cpp:3240
+#: src/muuli_wdr.cpp:3271
 msgid "Active Uploads"
 msgstr "Aktive Uploads"
 
-#: src/muuli_wdr.cpp:3254
+#: src/muuli_wdr.cpp:3285
 msgid "Percent of total files"
 msgstr "Prozent aller Dateien"
 
-#: src/muuli_wdr.cpp:3306
+#: src/muuli_wdr.cpp:3337
 msgid "Show Clients for"
 msgstr "Clients anzeigen für"
 
-#: src/muuli_wdr.cpp:3308
+#: src/muuli_wdr.cpp:3339
 msgid "All files"
 msgstr "Alle Dateien"
 
-#: src/muuli_wdr.cpp:3311
+#: src/muuli_wdr.cpp:3342
 msgid "Selected files"
 msgstr "Ausgewählte Dateien"
 
-#: src/muuli_wdr.cpp:3314
+#: src/muuli_wdr.cpp:3345
 msgid "Active uploads only"
 msgstr "Nur aktive Uploads"
 
-#: src/muuli_wdr.cpp:3321
+#: src/muuli_wdr.cpp:3352
 msgid "Reload:"
 msgstr "Aktualisieren:"
 
-#: src/muuli_wdr.cpp:3325
+#: src/muuli_wdr.cpp:3356
 msgid "Reload your shared files"
 msgstr "Freigegebene Dateien neu laden"
 
-#: src/muuli_wdr.cpp:3388
+#: src/muuli_wdr.cpp:3419
 msgid "Send"
 msgstr "Senden"
 
-#: src/muuli_wdr.cpp:3389
+#: src/muuli_wdr.cpp:3420
 msgid "Sends the specified message."
 msgstr "Sendet die angegebene Nachricht."
 
-#: src/muuli_wdr.cpp:3393
+#: src/muuli_wdr.cpp:3424
 msgid "Close this chat-session."
 msgstr "Schließe diese Chat-Sitzung."
 
-#: src/muuli_wdr.cpp:3416
+#: src/muuli_wdr.cpp:3447
 msgid "Connect to any server and/or Kad"
 msgstr "Mit irgendeinem Server und/oder Kad verbinden"
 
-#: src/muuli_wdr.cpp:3422 src/SharedFilesCtrl.cpp:142 src/Statistics.cpp:941
+#: src/muuli_wdr.cpp:3453 src/SharedFilesCtrl.cpp:142 src/Statistics.cpp:941
 msgid "Shared Files"
 msgstr "Freigaben"
 
@@ -5440,249 +5468,249 @@ msgstr "Heruntergeladen"
 msgid "ERROR: Failed to open partfile '%s'"
 msgstr "FEHLER: Öffnen von Partfile '%s' fehlgeschlagen"
 
-#: src/Preferences.cpp:674
+#: src/Preferences.cpp:701
 msgid "System default"
 msgstr "Systemvorgabe"
 
-#: src/Preferences.cpp:675
+#: src/Preferences.cpp:702
 msgid "Albanian"
 msgstr "Albanisch"
 
-#: src/Preferences.cpp:676
+#: src/Preferences.cpp:703
 msgid "Arabic"
 msgstr "Arabisch"
 
-#: src/Preferences.cpp:677
+#: src/Preferences.cpp:704
 msgid "Asturian"
 msgstr "Asturisch"
 
-#: src/Preferences.cpp:678
+#: src/Preferences.cpp:705
 msgid "Basque"
 msgstr "Baskisch"
 
-#: src/Preferences.cpp:679
+#: src/Preferences.cpp:706
 msgid "Bulgarian"
 msgstr "Bulgarisch"
 
-#: src/Preferences.cpp:680
+#: src/Preferences.cpp:707
 msgid "Catalan"
 msgstr "Katalanisch"
 
-#: src/Preferences.cpp:681
+#: src/Preferences.cpp:708
 msgid "Chinese (Simplified)"
 msgstr "Chinesisch (vereinfacht)"
 
-#: src/Preferences.cpp:682
+#: src/Preferences.cpp:709
 msgid "Chinese (Traditional)"
 msgstr "Chinesisch (traditionell)"
 
-#: src/Preferences.cpp:683
+#: src/Preferences.cpp:710
 msgid "Croatian"
 msgstr "Kroatisch"
 
-#: src/Preferences.cpp:684
+#: src/Preferences.cpp:711
 msgid "Czech"
 msgstr "Tschechisch"
 
-#: src/Preferences.cpp:685
+#: src/Preferences.cpp:712
 msgid "Danish"
 msgstr "Dänisch"
 
-#: src/Preferences.cpp:686
+#: src/Preferences.cpp:713
 msgid "Dutch"
 msgstr "Holländisch"
 
-#: src/Preferences.cpp:687
+#: src/Preferences.cpp:714
 msgid "English (U.K.)"
 msgstr "Englisch (UK)"
 
-#: src/Preferences.cpp:688
+#: src/Preferences.cpp:715
 #, fuzzy
 msgid "English (U.S.)"
 msgstr "Englisch (UK)"
 
-#: src/Preferences.cpp:689
+#: src/Preferences.cpp:716
 msgid "Estonian"
 msgstr "Estnisch"
 
-#: src/Preferences.cpp:690
+#: src/Preferences.cpp:717
 msgid "Finnish"
 msgstr "Finnisch"
 
-#: src/Preferences.cpp:691
+#: src/Preferences.cpp:718
 msgid "French"
 msgstr "Französisch"
 
-#: src/Preferences.cpp:692
+#: src/Preferences.cpp:719
 msgid "Galician"
 msgstr "Galizisch"
 
-#: src/Preferences.cpp:693
+#: src/Preferences.cpp:720
 msgid "German"
 msgstr "Deutsch"
 
-#: src/Preferences.cpp:694
+#: src/Preferences.cpp:721
 msgid "Greek"
 msgstr "Griechisch"
 
-#: src/Preferences.cpp:695
+#: src/Preferences.cpp:722
 msgid "Hebrew"
 msgstr "Hebräisch"
 
-#: src/Preferences.cpp:696
+#: src/Preferences.cpp:723
 msgid "Hungarian"
 msgstr "Ungarisch"
 
-#: src/Preferences.cpp:697
+#: src/Preferences.cpp:724
 msgid "Italian"
 msgstr "Italienisch"
 
-#: src/Preferences.cpp:698
+#: src/Preferences.cpp:725
 msgid "Japanese"
 msgstr "Japanisch"
 
-#: src/Preferences.cpp:699
+#: src/Preferences.cpp:726
 msgid "Korean"
 msgstr "Koreanisch"
 
-#: src/Preferences.cpp:700
+#: src/Preferences.cpp:727
 msgid "Latvian"
 msgstr ""
 
-#: src/Preferences.cpp:701
+#: src/Preferences.cpp:728
 msgid "Lithuanian"
 msgstr "Litauisch"
 
-#: src/Preferences.cpp:702
+#: src/Preferences.cpp:729
 msgid "Norwegian (Nynorsk)"
 msgstr "Norwegisch"
 
-#: src/Preferences.cpp:703
+#: src/Preferences.cpp:730
 msgid "Polish"
 msgstr "Polnisch"
 
-#: src/Preferences.cpp:704
+#: src/Preferences.cpp:731
 msgid "Portuguese"
 msgstr "Portugiesisch"
 
-#: src/Preferences.cpp:705
+#: src/Preferences.cpp:732
 msgid "Portuguese (Brazilian)"
 msgstr "Portugiesisch (Brasilianisch)"
 
-#: src/Preferences.cpp:706
+#: src/Preferences.cpp:733
 msgid "Romanian"
 msgstr "Rumänisch"
 
-#: src/Preferences.cpp:707
+#: src/Preferences.cpp:734
 msgid "Russian"
 msgstr "Russisch"
 
-#: src/Preferences.cpp:708
+#: src/Preferences.cpp:735
 msgid "Slovenian"
 msgstr "Slowenisch"
 
-#: src/Preferences.cpp:709
+#: src/Preferences.cpp:736
 msgid "Spanish"
 msgstr "Spanisch"
 
-#: src/Preferences.cpp:710
+#: src/Preferences.cpp:737
 msgid "Swedish"
 msgstr "Schwedisch"
 
-#: src/Preferences.cpp:711
+#: src/Preferences.cpp:738
 msgid "Turkish"
 msgstr "Türkisch"
 
-#: src/Preferences.cpp:712
+#: src/Preferences.cpp:739
 msgid "Ukrainian"
 msgstr "Ukrainisch"
 
-#: src/Preferences.cpp:815
+#: src/Preferences.cpp:842
 msgid "Change Language"
 msgstr "Sprache ändern"
 
-#: src/Preferences.cpp:879
+#: src/Preferences.cpp:906
 msgid "There are no translations installed for aMule"
 msgstr "Für aMule sind keine Übersetzungen installiert"
 
-#: src/Preferences.cpp:880
+#: src/Preferences.cpp:907
 msgid "No languages available"
 msgstr "Keine Sprachen verfügbar"
 
-#: src/Preferences.cpp:1011
+#: src/Preferences.cpp:1038
 msgid "no options available"
 msgstr "keine Optionen verfügbar"
 
-#: src/Preferences.cpp:2182
+#: src/Preferences.cpp:2227
 msgid "Invalid category found, skipping"
 msgstr "Ungültige Kategorie gefunden, überspringe."
 
-#: src/Preferences.cpp:2351
+#: src/Preferences.cpp:2396
 msgid "TCP port can't be higher than 65532 due to server UDP socket being TCP+3"
 msgstr "TCP-Port kann nicht größer als 65532 sein, da der Server-UDP-Port=TCP-Port+3 ist"
 
-#: src/Preferences.cpp:2352
+#: src/Preferences.cpp:2397
 #, c-format
 msgid "Default port will be used (%d)"
 msgstr "Standard-Port wird verwendet (%d)"
 
-#: src/PrefsUnifiedDlg.cpp:298 src/Statistics.cpp:866
+#: src/PrefsUnifiedDlg.cpp:300 src/Statistics.cpp:866
 msgid "Connection"
 msgstr "Verbindung"
 
-#: src/PrefsUnifiedDlg.cpp:299 src/SearchListCtrl.cpp:117
+#: src/PrefsUnifiedDlg.cpp:301 src/SearchListCtrl.cpp:117
 msgid "Directories"
 msgstr "Verzeichnisse"
 
-#: src/PrefsUnifiedDlg.cpp:300 src/Statistics.cpp:917
+#: src/PrefsUnifiedDlg.cpp:302 src/Statistics.cpp:917
 msgid "Servers"
 msgstr "Server"
 
-#: src/PrefsUnifiedDlg.cpp:301 src/ServerListCtrl.cpp:96
+#: src/PrefsUnifiedDlg.cpp:303 src/ServerListCtrl.cpp:96
 msgid "Files"
 msgstr "Dateien"
 
-#: src/PrefsUnifiedDlg.cpp:302
+#: src/PrefsUnifiedDlg.cpp:304
 msgid "Security"
 msgstr "Sicherheit"
 
-#: src/PrefsUnifiedDlg.cpp:303
+#: src/PrefsUnifiedDlg.cpp:305
 msgid "Interface"
 msgstr "Aussehen"
 
-#: src/PrefsUnifiedDlg.cpp:310
+#: src/PrefsUnifiedDlg.cpp:312
 msgid "IP2Country"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:313
+#: src/PrefsUnifiedDlg.cpp:315
 msgid "Proxy"
 msgstr "Proxy"
 
-#: src/PrefsUnifiedDlg.cpp:314
+#: src/PrefsUnifiedDlg.cpp:316
 msgid "Filters"
 msgstr "Filter"
 
-#: src/PrefsUnifiedDlg.cpp:315
+#: src/PrefsUnifiedDlg.cpp:317
 msgid "Remote Controls"
 msgstr "Fernsteuerung"
 
-#: src/PrefsUnifiedDlg.cpp:316
+#: src/PrefsUnifiedDlg.cpp:318
 msgid "Online Signature"
 msgstr "Onlinesignatur"
 
-#: src/PrefsUnifiedDlg.cpp:317
+#: src/PrefsUnifiedDlg.cpp:319
 msgid "Advanced"
 msgstr "Fortgeschritten"
 
-#: src/PrefsUnifiedDlg.cpp:318
+#: src/PrefsUnifiedDlg.cpp:320
 msgid "Events"
 msgstr "Ereignisse"
 
-#: src/PrefsUnifiedDlg.cpp:321
+#: src/PrefsUnifiedDlg.cpp:323
 msgid "Debugging"
 msgstr "Fehlersuche (Debugging)"
 
-#: src/PrefsUnifiedDlg.cpp:451
+#: src/PrefsUnifiedDlg.cpp:453
 msgid ""
 "The following variables will be substituted:\n"
 "    %PARTFILE - full path to the file\n"
@@ -5692,15 +5720,15 @@ msgstr ""
 "    %PARTFILE - ganzer Pfad zur Datei\n"
 "    %PARTNAME - nur der Dateiname"
 
-#: src/PrefsUnifiedDlg.cpp:472
+#: src/PrefsUnifiedDlg.cpp:474
 msgid "Tray icon support requires libayatana-appindicator3 at compile time."
 msgstr "Tray-Icon unterstützung benötigt libayatana-appindicator3 beim kompilieren."
 
-#: src/PrefsUnifiedDlg.cpp:488
+#: src/PrefsUnifiedDlg.cpp:490
 msgid "Not available on Wayland: the protocol does not report when a window is minimized, so this option cannot intercept the system minimize button. Workaround: launch aMule with `GDK_BACKEND=x11` to use XWayland instead."
 msgstr "Auf Wayland nicht verfügbar: Das Protokoll meldet nicht wenn ein Fenster minimiert is, sodass diese Option nicht auf die Minimieren Schaltfläche des System reagieren kann. Workaround: aMule mit `GDK_BACKEND=x11 starten um XWayland zu verwenden."
 
-#: src/PrefsUnifiedDlg.cpp:534
+#: src/PrefsUnifiedDlg.cpp:536
 msgid ""
 "Do not change these setting unless you know\n"
 "what you are doing, otherwise you can easily\n"
@@ -5716,26 +5744,35 @@ msgstr ""
 "aMule funktioniert auch hervorragend, ohne\n"
 "dass diese Einstellungen verändert werden."
 
-#: src/PrefsUnifiedDlg.cpp:645
+#: src/PrefsUnifiedDlg.cpp:647
 #, c-format
 msgid "Failed to connect Cfg to widget with the ID %d and key %s"
 msgstr "Verbindung von Einstellung zu Steuerelement mit ID %d und Schlüssel %s fehlgeschlagen."
 
-#: src/PrefsUnifiedDlg.cpp:693
+#: src/PrefsUnifiedDlg.cpp:695
 #, c-format
 msgid "Failed to transfer data from Cfg to Widget with the ID %d and key %s"
 msgstr "Datentransfer von Einstellung zu Steuerelement mit ID %d und Schlüssel %s fehlgeschlagen."
 
-#: src/PrefsUnifiedDlg.cpp:799
+#: src/PrefsUnifiedDlg.cpp:801
 msgid "The type of proxy you are connecting to"
 msgstr "Der Typ des Proxy, zu dem du verbindest"
 
-#: src/PrefsUnifiedDlg.cpp:1003
+#: src/PrefsUnifiedDlg.cpp:1020
 #, c-format
 msgid "Failed to transfer data from Widget to Cfg with the ID %d and key %s"
 msgstr "Datentransfer von Steuerelement zu Einstellung mit ID %d und Schlüssel %s fehlgeschlagen."
 
 #: src/PrefsUnifiedDlg.cpp:1103
+#, fuzzy
+msgid "No password set."
+msgstr "Prüfe Passwort\n"
+
+#: src/PrefsUnifiedDlg.cpp:1132
+msgid "Guest access needs a password. Type one in the guest password field, or untick Enable guest access."
+msgstr ""
+
+#: src/PrefsUnifiedDlg.cpp:1144
 msgid ""
 "aMule must be restarted to enable these changes:\n"
 "\n"
@@ -5743,41 +5780,41 @@ msgstr ""
 "aMule muss neu gestartet werden, um diese Änderungen zu übernehmen:\n"
 "\n"
 
-#: src/PrefsUnifiedDlg.cpp:1110
+#: src/PrefsUnifiedDlg.cpp:1151
 msgid "- TCP port changed.\n"
 msgstr "- TCP-Port geändert.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1115
+#: src/PrefsUnifiedDlg.cpp:1156
 msgid "- UDP port changed.\n"
 msgstr "- UDP-Port geändert.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1120
+#: src/PrefsUnifiedDlg.cpp:1161
 #, fuzzy
 msgid "- Network interface binding changed.\n"
 msgstr "- Schnittstelle der externen Verbindung geändert.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1125
+#: src/PrefsUnifiedDlg.cpp:1166
 msgid "- External connect port changed.\n"
 msgstr "- Port externer Verbindung geändert.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1129
+#: src/PrefsUnifiedDlg.cpp:1170
 msgid "- External connect acceptance changed.\n"
 msgstr "- Akzeptanz externer Verbindung geändert.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1133
+#: src/PrefsUnifiedDlg.cpp:1174
 msgid "- External connect interface changed.\n"
 msgstr "- Schnittstelle der externen Verbindung geändert.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1137
+#: src/PrefsUnifiedDlg.cpp:1178
 msgid "- Protocol obfuscation support changed.\n"
 msgstr "- Unterstützung für Protokollverschleierung geändert.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1151
+#: src/PrefsUnifiedDlg.cpp:1193
 #, fuzzy
 msgid "- amuleapi settings changed.\n"
 msgstr "- Sprache geändert.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1160
+#: src/PrefsUnifiedDlg.cpp:1202
 msgid ""
 "Your Auto-update server list is empty.\n"
 "'Auto-update server list at startup' will be disabled."
@@ -5785,7 +5822,7 @@ msgstr ""
 "Die Auto-Update-Serverliste ist leer.\n"
 "'Serverliste beim Programmstart aktualisieren' wird deaktiviert."
 
-#: src/PrefsUnifiedDlg.cpp:1171
+#: src/PrefsUnifiedDlg.cpp:1213
 msgid ""
 "You have enabled external connections but have not specified a password.\n"
 "External connections cannot be enabled unless a valid password is specified."
@@ -5793,28 +5830,33 @@ msgstr ""
 "Du hast die externen Verbindungen aktiviert, aber kein Passwort angegeben.\n"
 "Externe Verbindungen können nur aktiviert werden, wenn ein gültiges Passwort angegeben wird."
 
-#: src/PrefsUnifiedDlg.cpp:1202
+#: src/PrefsUnifiedDlg.cpp:1246
+#, c-format
+msgid "The amuleapi password could not be saved: %s"
+msgstr ""
+
+#: src/PrefsUnifiedDlg.cpp:1276
 msgid "- Language changed.\n"
 msgstr "- Sprache geändert.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1207
+#: src/PrefsUnifiedDlg.cpp:1281
 msgid "- Temp folder changed.\n"
 msgstr "- Temp-Verzeichnis geändert.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1212
+#: src/PrefsUnifiedDlg.cpp:1286
 msgid "- ED2K network enabled.\n"
 msgstr "- ED2k-Netzwerk aktiviert.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1245
+#: src/PrefsUnifiedDlg.cpp:1319
 msgid "The shared-file exclusion pattern is not a valid regular expression. The filter has been left disabled."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1247 src/PrefsUnifiedDlg.cpp:1841
+#: src/PrefsUnifiedDlg.cpp:1321 src/PrefsUnifiedDlg.cpp:1921
 #, fuzzy
 msgid "Invalid regular expression"
 msgstr "Ungültige Protokollversion."
 
-#: src/PrefsUnifiedDlg.cpp:1324
+#: src/PrefsUnifiedDlg.cpp:1398
 msgid ""
 "Both eD2k and Kad network are disabled.\n"
 "You won't be able to connect until you enable at least one of them."
@@ -5822,7 +5864,7 @@ msgstr ""
 "Beide Netzwerke, eD2k und Kad, sind deaktiviert.\n"
 "Mindestens eins davon muss aktiviert sein, um sich verbinden zu können."
 
-#: src/PrefsUnifiedDlg.cpp:1329
+#: src/PrefsUnifiedDlg.cpp:1403
 msgid ""
 "Kad will not start if your UDP port is disabled.\n"
 "Enable UDP port or disable Kad."
@@ -5830,7 +5872,7 @@ msgstr ""
 "Kad wird nicht starten, solange der UDP-Port deaktiviert ist.\n"
 "Bitte UDP-Port aktivieren, oder Kad ausschalten."
 
-#: src/PrefsUnifiedDlg.cpp:1385
+#: src/PrefsUnifiedDlg.cpp:1459
 msgid ""
 "\n"
 "You MUST restart aMule now.\n"
@@ -5840,71 +5882,71 @@ msgstr ""
 "aMule MUSS jetzt neu gestartet werden.\n"
 "Wenn du jetzt nicht neu startest, beklage dich nicht, wenn irgendwas übles passiert.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1450
+#: src/PrefsUnifiedDlg.cpp:1524
 msgid "Could not register aMule for autostart at login. The autostart store may be read-only."
 msgstr "Konnte aMule nicht für Autostart registrieren. Der Ort dafür könnte nicht beschreibbar sein."
 
-#: src/PrefsUnifiedDlg.cpp:1452
+#: src/PrefsUnifiedDlg.cpp:1526
 msgid "Could not remove the autostart-at-login entry."
 msgstr "Konnte den Autostart-Bei-Login Eintrag nicht entfernen."
 
-#: src/PrefsUnifiedDlg.cpp:1453
+#: src/PrefsUnifiedDlg.cpp:1527
 msgid "Autostart"
 msgstr "Autostart"
 
-#: src/PrefsUnifiedDlg.cpp:1468
+#: src/PrefsUnifiedDlg.cpp:1542
 msgid "Register file type"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1468
+#: src/PrefsUnifiedDlg.cpp:1542
 msgid "Register URL handler"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1476
+#: src/PrefsUnifiedDlg.cpp:1550
 #, c-format
 msgid "aMule only handles eD2k-compatible magnets. If you replace the current magnet handler (%s), BitTorrent magnet links will stop working - aMule cannot download BitTorrent content. Continue?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1481
+#: src/PrefsUnifiedDlg.cpp:1555
 #, c-format
 msgid "Another application currently opens .emulecollection files (%s). Replace it with aMule?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1486
+#: src/PrefsUnifiedDlg.cpp:1560
 #, c-format
 msgid "Another application is currently the default handler for these links (%s). Replace it with aMule?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1511
+#: src/PrefsUnifiedDlg.cpp:1585
 #, fuzzy
 msgid "Could not register aMule for .emulecollection files. The registration store may be read-only."
 msgstr "Konnte aMule nicht für Autostart registrieren. Der Ort dafür könnte nicht beschreibbar sein."
 
-#: src/PrefsUnifiedDlg.cpp:1513
+#: src/PrefsUnifiedDlg.cpp:1587
 #, fuzzy
 msgid "Could not remove the file type registration."
 msgstr "Konnte den Autostart-Bei-Login Eintrag nicht entfernen."
 
-#: src/PrefsUnifiedDlg.cpp:1515
+#: src/PrefsUnifiedDlg.cpp:1589
 #, fuzzy
 msgid "Could not register aMule as the URL handler. The registration store may be read-only."
 msgstr "Konnte aMule nicht für Autostart registrieren. Der Ort dafür könnte nicht beschreibbar sein."
 
-#: src/PrefsUnifiedDlg.cpp:1517
+#: src/PrefsUnifiedDlg.cpp:1591
 #, fuzzy
 msgid "Could not remove the URL handler registration."
 msgstr "Konnte den Autostart-Bei-Login Eintrag nicht entfernen."
 
-#: src/PrefsUnifiedDlg.cpp:1587 src/PrefsUnifiedDlg.cpp:1614
+#: src/PrefsUnifiedDlg.cpp:1661 src/PrefsUnifiedDlg.cpp:1688
 #, fuzzy
 msgid "The web server and aMule API require external connections to be enabled."
 msgstr "Passwort eingestellt und externe Verbindungen aktiviert."
 
-#: src/PrefsUnifiedDlg.cpp:1597
+#: src/PrefsUnifiedDlg.cpp:1671
 msgid "The aMule web server is deprecated. Consider running the aMule API instead."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1655
+#: src/PrefsUnifiedDlg.cpp:1735
 msgid ""
 "Your Auto-update servers list is in blank.\n"
 "Please fill in at least one URL to point to a valid server.met file.\n"
@@ -5914,66 +5956,66 @@ msgstr ""
 "Bitte gib mindestens eine URL zu einer gültigen server.met ein.\n"
 "Drücke dazu den Knopf \"Liste\" neben diesem Kontrollkästchen."
 
-#: src/PrefsUnifiedDlg.cpp:1796
+#: src/PrefsUnifiedDlg.cpp:1876
 msgid "Temporary files"
 msgstr "Temporäre Dateien"
 
-#: src/PrefsUnifiedDlg.cpp:1801
+#: src/PrefsUnifiedDlg.cpp:1881
 msgid "Incoming files"
 msgstr "Fertige Dateien"
 
-#: src/PrefsUnifiedDlg.cpp:1806
+#: src/PrefsUnifiedDlg.cpp:1886
 msgid "Online Signatures"
 msgstr "Online-Signaturen"
 
-#: src/PrefsUnifiedDlg.cpp:1819
+#: src/PrefsUnifiedDlg.cpp:1899
 #, c-format
 msgid "Choose a folder for %s"
 msgstr "Wähle einen Ordner für %s"
 
-#: src/PrefsUnifiedDlg.cpp:1843
+#: src/PrefsUnifiedDlg.cpp:1923
 #, fuzzy, c-format
 msgid "Would exclude %u of %u shared file"
 msgid_plural "Would exclude %u of %u shared files"
 msgstr[0] "%i bekannte freigegebene Datei gefunden"
 msgstr[1] "%i bekannte freigegebene Dateien gefunden"
 
-#: src/PrefsUnifiedDlg.cpp:1860
+#: src/PrefsUnifiedDlg.cpp:1940
 msgid "Browse for videoplayer"
 msgstr "Suche nach einem Videoplayer"
 
-#: src/PrefsUnifiedDlg.cpp:1864
+#: src/PrefsUnifiedDlg.cpp:1944
 msgid "Select browser"
 msgstr "Browser-Wahl"
 
-#: src/PrefsUnifiedDlg.cpp:1868
+#: src/PrefsUnifiedDlg.cpp:1948
 #, fuzzy
 msgid "Select ffprobe binary"
 msgstr "Browser-Wahl"
 
-#: src/PrefsUnifiedDlg.cpp:1874
+#: src/PrefsUnifiedDlg.cpp:1954
 #, c-format
 msgid "Executable%s"
 msgstr "Ausführbar%s"
 
-#: src/PrefsUnifiedDlg.cpp:1908
+#: src/PrefsUnifiedDlg.cpp:1988
 msgid "ffprobe not found on PATH or in the standard install locations. Install ffmpeg (which ships ffprobe) or use Browse to pick a binary manually."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1920
+#: src/PrefsUnifiedDlg.cpp:2000
 msgid "Reset the settings on this page to their default values?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1921
+#: src/PrefsUnifiedDlg.cpp:2001
 #, fuzzy
 msgid "Reset to defaults"
 msgstr "Systemvorgabe"
 
-#: src/PrefsUnifiedDlg.cpp:1948
+#: src/PrefsUnifiedDlg.cpp:2028
 msgid "Edit server list"
 msgstr "Serverliste bearbeiten"
 
-#: src/PrefsUnifiedDlg.cpp:1949
+#: src/PrefsUnifiedDlg.cpp:2029
 msgid ""
 "Add here URL's to download server.met files.\n"
 "Only one url on each line."
@@ -5981,115 +6023,115 @@ msgstr ""
 "Hier URL's für server.met-Dateien eintragen.\n"
 "Nur eine URL pro Zeile!"
 
-#: src/PrefsUnifiedDlg.cpp:2004
+#: src/PrefsUnifiedDlg.cpp:2084
 msgid "IP2Country update failed"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2149 src/PrefsUnifiedDlg.cpp:2180
+#: src/PrefsUnifiedDlg.cpp:2229 src/PrefsUnifiedDlg.cpp:2260
 msgid "Data by MaxMind GeoLite2"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2151 src/PrefsUnifiedDlg.cpp:2182
+#: src/PrefsUnifiedDlg.cpp:2231 src/PrefsUnifiedDlg.cpp:2262
 #, fuzzy
 msgid "Custom source"
 msgstr "vollständige Quellen"
 
-#: src/PrefsUnifiedDlg.cpp:2153 src/PrefsUnifiedDlg.cpp:2184
+#: src/PrefsUnifiedDlg.cpp:2233 src/PrefsUnifiedDlg.cpp:2264
 msgid "Data by DB-IP.com"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2204
+#: src/PrefsUnifiedDlg.cpp:2284
 #, fuzzy, c-format
 msgid "Status: Loaded%s"
 msgstr "Status:"
 
-#: src/PrefsUnifiedDlg.cpp:2206
+#: src/PrefsUnifiedDlg.cpp:2286
 #, fuzzy, c-format
 msgid "Status: Loaded%s - %s"
 msgstr "Status:"
 
-#: src/PrefsUnifiedDlg.cpp:2210
+#: src/PrefsUnifiedDlg.cpp:2290
 msgid "Status: Failed to load - click 'Update now' to refresh."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2212
+#: src/PrefsUnifiedDlg.cpp:2292
 msgid "Status: Not found - click 'Update now' to download."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2270 src/PrefsUnifiedDlg.cpp:2294
+#: src/PrefsUnifiedDlg.cpp:2350 src/PrefsUnifiedDlg.cpp:2374
 #, c-format
 msgid "Update delay: %d second"
 msgid_plural "Update delay: %d seconds"
 msgstr[0] "Aktualisierungsverzögerung: %d Sekunde"
 msgstr[1] "Aktualisierungsverzögerung: %d Sekunden"
 
-#: src/PrefsUnifiedDlg.cpp:2278
+#: src/PrefsUnifiedDlg.cpp:2358
 #, c-format
 msgid "Time for average graph: %d minute"
 msgid_plural "Time for average graph: %d minutes"
 msgstr[0] "Zeit für Durchschnittslinie: %d Minute"
 msgstr[1] "Zeit für Durchschnittslinie: %d Minuten"
 
-#: src/PrefsUnifiedDlg.cpp:2287
+#: src/PrefsUnifiedDlg.cpp:2367
 #, c-format
 msgid "Connections Graph Scale: %d"
 msgstr "Verbindungsgraphenskala: %d"
 
-#: src/PrefsUnifiedDlg.cpp:2302
+#: src/PrefsUnifiedDlg.cpp:2382
 #, c-format
 msgid "File Buffer Size: %d byte"
 msgid_plural "File Buffer Size: %d bytes"
 msgstr[0] "Dateipuffergröße: %d Byte"
 msgstr[1] "Dateipuffergröße: %d Bytes"
 
-#: src/PrefsUnifiedDlg.cpp:2312
+#: src/PrefsUnifiedDlg.cpp:2392
 #, c-format
 msgid "Upload Queue Size: %d client"
 msgid_plural "Upload Queue Size: %d clients"
 msgstr[0] "Upload-Warteschlangengröße: %d Client"
 msgstr[1] "Upload-Warteschlangengröße: %d Clients"
 
-#: src/PrefsUnifiedDlg.cpp:2322
+#: src/PrefsUnifiedDlg.cpp:2402
 #, c-format
 msgid "Server connection refresh interval: %d minute"
 msgid_plural "Server connection refresh interval: %d minutes"
 msgstr[0] "Server-Wiederverbindungsintervall: %d Minute"
 msgstr[1] "Server-Wiederverbindungsintervall: %d Minuten"
 
-#: src/PrefsUnifiedDlg.cpp:2327
+#: src/PrefsUnifiedDlg.cpp:2407
 msgid "Server connection refresh interval: Disabled"
 msgstr "Server-Wiederverbindungsintervall: Aus"
 
-#: src/PrefsUnifiedDlg.cpp:2371
+#: src/PrefsUnifiedDlg.cpp:2451
 msgid "disabled"
 msgstr "deaktiviert"
 
-#: src/PrefsUnifiedDlg.cpp:2397
+#: src/PrefsUnifiedDlg.cpp:2477
 #, c-format
 msgid "Execute command on '%s' event"
 msgstr "Führe Kommando beim '%s' Ereignis aus"
 
-#: src/PrefsUnifiedDlg.cpp:2404
+#: src/PrefsUnifiedDlg.cpp:2484
 msgid "Enable command execution on core"
 msgstr "Aktiviere Befehlsausführung im Kern"
 
-#: src/PrefsUnifiedDlg.cpp:2416
+#: src/PrefsUnifiedDlg.cpp:2496
 msgid "Core command:"
 msgstr "Kern-Befehl:"
 
-#: src/PrefsUnifiedDlg.cpp:2432
+#: src/PrefsUnifiedDlg.cpp:2512
 msgid "Enable command execution on GUI"
 msgstr "Aktiviere Befehlsausführung in GUI"
 
-#: src/PrefsUnifiedDlg.cpp:2444
+#: src/PrefsUnifiedDlg.cpp:2524
 msgid "GUI command:"
 msgstr "GUI-Befehl:"
 
-#: src/PrefsUnifiedDlg.cpp:2460
+#: src/PrefsUnifiedDlg.cpp:2540
 msgid "The following variables will be replaced:"
 msgstr "Die folgenden Variablen werden ersetzt:"
 
-#: src/PrefsUnifiedDlg.cpp:2628
+#: src/PrefsUnifiedDlg.cpp:2708
 msgid ""
 "The following folders look like system or sensitive locations:\n"
 "\n"
@@ -6097,37 +6139,37 @@ msgstr ""
 "Die folgenden Ordner sehen nach System oder Sensiblen Daten aus.\n"
 "\n"
 
-#: src/PrefsUnifiedDlg.cpp:2633
+#: src/PrefsUnifiedDlg.cpp:2713
 msgid "Sharing them recursively will publish every file underneath on the eD2k/Kad networks. Do you really want to do this?"
 msgstr "Rekursives Teilen würde jede Datei im eD2k/Kad Netzwerk verfügbar machen. Willst du das wirklich?"
 
-#: src/PrefsUnifiedDlg.cpp:2636
+#: src/PrefsUnifiedDlg.cpp:2716
 msgid "Confirm shared folders"
 msgstr "Freigegebene Ordner bestätigen"
 
-#: src/PrefsUnifiedDlg.cpp:2664
+#: src/PrefsUnifiedDlg.cpp:2744
 msgid "Reloading shared files..."
 msgstr "Freigegebene Dateien neu laden..."
 
-#: src/PrefsUnifiedDlg.cpp:2665
+#: src/PrefsUnifiedDlg.cpp:2745
 msgid "Scanning for subdirectories..."
 msgstr "Suche nach Unterverzeichnissen..."
 
-#: src/PrefsUnifiedDlg.cpp:2666
+#: src/PrefsUnifiedDlg.cpp:2746
 msgid "Updating shared folders"
 msgstr "Freigegebene Ordner werden aktualisiert"
 
-#: src/PrefsUnifiedDlg.cpp:2693
+#: src/PrefsUnifiedDlg.cpp:2773
 #, c-format
 msgid "Scanned %u directories..."
 msgstr "%u Verzeichnisse durchsucht..."
 
-#: src/PrefsUnifiedDlg.cpp:2743
+#: src/PrefsUnifiedDlg.cpp:2823
 #, c-format
 msgid "Reloading shared files: %u files scanned"
 msgstr "Liste freigegebener Dateien neu laden: %u Dateien gelesen"
 
-#: src/PrefsUnifiedDlg.cpp:2793
+#: src/PrefsUnifiedDlg.cpp:2873
 #, fuzzy
 msgid "Shared folder"
 msgstr "Freigegebene Ordner"

--- a/po/de.po
+++ b/po/de.po
@@ -13,7 +13,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-28 12:17+0200\n"
+"POT-Creation-Date: 2026-07-28 13:09+0200\n"
 "PO-Revision-Date: 2026-07-27 11:34+0000\n"
 "Last-Translator: Werner Mahr <werner@vollstreckernet.de>\n"
 "Language-Team: German <>\n"
@@ -301,7 +301,7 @@ msgid "Password set and external connections enabled."
 msgstr "Passwort eingestellt und externe Verbindungen aktiviert."
 
 #: src/amule.cpp:755 src/KadDlg.cpp:176 src/KadDlg.cpp:185
-#: src/PrefsUnifiedDlg.cpp:1461 src/SharedFilesCtrl.cpp:476
+#: src/PrefsUnifiedDlg.cpp:1470 src/SharedFilesCtrl.cpp:476
 msgid "WARNING"
 msgstr "WARNUNG"
 
@@ -338,7 +338,7 @@ msgstr "Du hast \"amuleweb zusammen mit aMule starten\" aktiviert, allerdings ka
 #: src/amule-remote-gui.cpp:603 src/amule-remote-gui.cpp:671
 #: src/amule-remote-gui.cpp:709 src/amule-remote-gui.cpp:1282
 #: src/amule-remote-gui.cpp:1345 src/amule-remote-gui.cpp:1372
-#: src/DownloadQueue.cpp:1481 src/PrefsUnifiedDlg.cpp:1247
+#: src/DownloadQueue.cpp:1481 src/PrefsUnifiedDlg.cpp:1256
 msgid "ERROR"
 msgstr "FEHLER"
 
@@ -599,36 +599,36 @@ msgstr "Besuche https://github.com/amule-org/amule/releases/latest um zu sehen, 
 msgid "FATAL ERROR: Failed to create Timer"
 msgstr "UNBEHEBBARER FEHLER: Es konnte kein Zeitgeber erstellt werden."
 
-#: src/amuleDlg.cpp:361 src/amuleDlg.cpp:1787 src/amuleDlg.cpp:2033
-#: src/muuli_wdr.cpp:1492 src/muuli_wdr.cpp:3449
+#: src/amuleDlg.cpp:361 src/amuleDlg.cpp:1810 src/amuleDlg.cpp:2056
+#: src/muuli_wdr.cpp:1492 src/muuli_wdr.cpp:3453
 msgid "Networks"
 msgstr "Netzwerke"
 
-#: src/amuleDlg.cpp:362 src/amuleDlg.cpp:1793 src/muuli_wdr.cpp:3450
+#: src/amuleDlg.cpp:362 src/amuleDlg.cpp:1816 src/muuli_wdr.cpp:3454
 msgid "Searches"
 msgstr "Suchen"
 
-#: src/amuleDlg.cpp:363 src/amuleDlg.cpp:1799 src/DownloadListCtrl.cpp:740
-#: src/muuli_wdr.cpp:392 src/muuli_wdr.cpp:1585 src/muuli_wdr.cpp:3451
+#: src/amuleDlg.cpp:363 src/amuleDlg.cpp:1822 src/DownloadListCtrl.cpp:740
+#: src/muuli_wdr.cpp:392 src/muuli_wdr.cpp:1585 src/muuli_wdr.cpp:3455
 #: src/Statistics.cpp:829
 msgid "Downloads"
 msgstr "Downloads"
 
-#: src/amuleDlg.cpp:364 src/amuleDlg.cpp:1805 src/muuli_wdr.cpp:3325
+#: src/amuleDlg.cpp:364 src/amuleDlg.cpp:1828 src/muuli_wdr.cpp:3329
 msgid "Shared files"
 msgstr "Freigegebene Dateien"
 
-#: src/amuleDlg.cpp:365 src/amuleDlg.cpp:1811 src/muuli_wdr.cpp:2957
-#: src/muuli_wdr.cpp:3407 src/muuli_wdr.cpp:3454
+#: src/amuleDlg.cpp:365 src/amuleDlg.cpp:1834 src/muuli_wdr.cpp:2961
+#: src/muuli_wdr.cpp:3411 src/muuli_wdr.cpp:3458
 msgid "Messages"
 msgstr "Nachrichten"
 
-#: src/amuleDlg.cpp:366 src/amuleDlg.cpp:1817 src/muuli_wdr.cpp:3455
+#: src/amuleDlg.cpp:366 src/amuleDlg.cpp:1840 src/muuli_wdr.cpp:3459
 #: src/PrefsUnifiedDlg.cpp:314 src/Statistics.cpp:779 src/Statistics.cpp:1235
 msgid "Statistics"
 msgstr "Statistiken"
 
-#: src/amuleDlg.cpp:368 src/amuleDlg.cpp:1824 src/muuli_wdr.cpp:3457
+#: src/amuleDlg.cpp:368 src/amuleDlg.cpp:1847 src/muuli_wdr.cpp:3461
 #: src/PrefsUnifiedDlg.cpp:330 src/utils/wxCas/src/wxcasprefs.cpp:39
 msgid "Preferences"
 msgstr "Einstellungen"
@@ -687,8 +687,8 @@ msgstr "Kad: aus"
 #: src/amuleDlg.cpp:1029 src/DownloadListCtrl.cpp:505
 #: src/DownloadListCtrl.cpp:749 src/FriendListCtrl.cpp:180
 #: src/muuli_wdr.cpp:731 src/muuli_wdr.cpp:782 src/muuli_wdr.cpp:846
-#: src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2262 src/muuli_wdr.cpp:2347
-#: src/muuli_wdr.cpp:3095 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
+#: src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2266 src/muuli_wdr.cpp:2351
+#: src/muuli_wdr.cpp:3099 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
 #: src/ServerListCtrl.cpp:606 src/TransferWnd.cpp:378
 #: src/utils/wxCas/src/wxcasprefs.cpp:235
 msgid "Cancel"
@@ -699,7 +699,7 @@ msgid "Stop the current connection attempts"
 msgstr "Beendet die derzeitigen Verbindungsversuche"
 
 #: src/amuleDlg.cpp:1035 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976
-#: src/muuli_wdr.cpp:2485
+#: src/muuli_wdr.cpp:2489
 msgid "Disconnect"
 msgstr "Trennen"
 
@@ -708,7 +708,7 @@ msgid "Disconnect from the currently connected networks"
 msgstr "Von den momentan verbundenen Netzwerken trennen."
 
 #: src/amuleDlg.cpp:1041 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979
-#: src/muuli_wdr.cpp:2640 src/muuli_wdr.cpp:3092 src/muuli_wdr.cpp:3447
+#: src/muuli_wdr.cpp:2644 src/muuli_wdr.cpp:3096 src/muuli_wdr.cpp:3451
 msgid "Connect"
 msgstr "Verbinden"
 
@@ -762,7 +762,7 @@ msgstr "Beenden bestätigen"
 msgid "Launch Command: "
 msgstr "Startbefehl: "
 
-#: src/amuleDlg.cpp:1632 src/muuli_wdr.cpp:1982 src/Preferences.cpp:979
+#: src/amuleDlg.cpp:1632 src/muuli_wdr.cpp:1986 src/Preferences.cpp:979
 msgid "- default -"
 msgstr "- Voreinstellung -"
 
@@ -776,60 +776,60 @@ msgstr "Skin-Verzeichnis '%s' existiert nicht"
 msgid "WARNING: Unable to open skin file '%s' for read"
 msgstr "WARNUNG: Öffnen der Skin-Datei '%s' zum Lesen nicht möglich"
 
-#: src/amuleDlg.cpp:1791 src/muuli_wdr.cpp:3449
+#: src/amuleDlg.cpp:1814 src/muuli_wdr.cpp:3453
 msgid "Networks Window"
 msgstr "Übersicht der verwendeten Netzwerke"
 
-#: src/amuleDlg.cpp:1797 src/muuli_wdr.cpp:3450
+#: src/amuleDlg.cpp:1820 src/muuli_wdr.cpp:3454
 msgid "Searches Window"
 msgstr "Dateisuche in den verbundenen Netzwerken"
 
-#: src/amuleDlg.cpp:1803 src/muuli_wdr.cpp:3451
+#: src/amuleDlg.cpp:1826 src/muuli_wdr.cpp:3455
 msgid "Downloads Window"
 msgstr "Download-Fenster"
 
-#: src/amuleDlg.cpp:1809 src/muuli_wdr.cpp:3453
+#: src/amuleDlg.cpp:1832 src/muuli_wdr.cpp:3457
 msgid "Shared Files Window"
 msgstr "Übersicht der freigegebenen Dateien"
 
-#: src/amuleDlg.cpp:1815 src/muuli_wdr.cpp:3454
+#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3458
 msgid "Messages Window"
 msgstr "Nachrichten, Chat, Freundesliste"
 
-#: src/amuleDlg.cpp:1821 src/muuli_wdr.cpp:3455
+#: src/amuleDlg.cpp:1844 src/muuli_wdr.cpp:3459
 msgid "Statistics Graph Window"
 msgstr "Diverse Statistiken über Up- und Download, Verbindungen, Clients usw."
 
-#: src/amuleDlg.cpp:1828 src/muuli_wdr.cpp:3457
+#: src/amuleDlg.cpp:1851 src/muuli_wdr.cpp:3461
 msgid "Preferences Settings Window"
 msgstr "Fenster für Einstellungen"
 
-#: src/amuleDlg.cpp:1831 src/muuli_wdr.cpp:3458
+#: src/amuleDlg.cpp:1854 src/muuli_wdr.cpp:3462
 msgid "Import"
 msgstr "Importiere"
 
-#: src/amuleDlg.cpp:1835 src/muuli_wdr.cpp:3458
+#: src/amuleDlg.cpp:1858 src/muuli_wdr.cpp:3462
 msgid "The partfile importer tool"
 msgstr "Das Importierwerkzeug für Part-Dateien"
 
-#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3459
+#: src/amuleDlg.cpp:1861 src/muuli_wdr.cpp:3463
 #: src/utils/aLinkCreator/src/alcframe.cpp:262
 msgid "About"
 msgstr "Über"
 
-#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3459
+#: src/amuleDlg.cpp:1861 src/muuli_wdr.cpp:3463
 msgid "About/Help"
 msgstr "Über/Hilfe - Hinweise zur Version usw."
 
-#: src/amuleDlg.cpp:2036
+#: src/amuleDlg.cpp:2059
 msgid "eD2k network"
 msgstr "eD2k-Netzwerk"
 
-#: src/amuleDlg.cpp:2039
+#: src/amuleDlg.cpp:2062
 msgid "Kad network"
 msgstr "Kad-Netzwerk"
 
-#: src/amuleDlg.cpp:2039
+#: src/amuleDlg.cpp:2062
 msgid "No network"
 msgstr "Kein Netzwerk"
 
@@ -1364,19 +1364,19 @@ msgstr "Auto [Ho]"
 msgid "Very low"
 msgstr "Sehr niedrig"
 
-#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:743 src/muuli_wdr.cpp:2313
+#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:743 src/muuli_wdr.cpp:2317
 #: src/ServerListCtrl.cpp:263 src/ServerListCtrl.cpp:456
 #: src/SharedFilesCtrl.cpp:145
 msgid "Low"
 msgstr "Niedrig"
 
-#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:744 src/muuli_wdr.cpp:2314
+#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:744 src/muuli_wdr.cpp:2318
 #: src/ServerListCtrl.cpp:266 src/ServerListCtrl.cpp:457
 #: src/SharedFilesCtrl.cpp:146
 msgid "Normal"
 msgstr "Normal"
 
-#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:745 src/muuli_wdr.cpp:2315
+#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:745 src/muuli_wdr.cpp:2319
 #: src/ServerListCtrl.cpp:269 src/ServerListCtrl.cpp:458
 #: src/SharedFilesCtrl.cpp:147
 msgid "High"
@@ -1468,7 +1468,7 @@ msgstr "Lokaler Server"
 msgid "Remote Server"
 msgstr "Entfernter Server"
 
-#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3212
+#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3216
 #: src/SearchDlg.cpp:119 src/TextClient.cpp:911
 msgid "Kad"
 msgstr "Kad"
@@ -1539,7 +1539,7 @@ msgstr "Teil"
 msgid "Size"
 msgstr "Größe"
 
-#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3279
+#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3283
 msgid "Transferred"
 msgstr "Übertragen"
 
@@ -1597,7 +1597,7 @@ msgstr ""
 "Rückmeldung von: %s (%s)\n"
 "\n"
 
-#: src/DownloadListCtrl.cpp:746 src/muuli_wdr.cpp:2316
+#: src/DownloadListCtrl.cpp:746 src/muuli_wdr.cpp:2320
 #: src/SharedFilesCtrl.cpp:150
 msgid "Auto"
 msgstr "Automatisch"
@@ -1635,7 +1635,7 @@ msgid "Extended Options"
 msgstr "Erweiterte Optionen"
 
 #: src/DownloadListCtrl.cpp:770 src/DownloadListCtrl.cpp:822
-#: src/muuli_wdr.cpp:1800
+#: src/muuli_wdr.cpp:1804
 msgid "Preview"
 msgstr "Vorschau"
 
@@ -2434,23 +2434,23 @@ msgid ""
 "want downloads on a different (e.g. larger) disk."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:549 src/FirstRunWizard.cpp:611 src/muuli_wdr.cpp:1712
+#: src/FirstRunWizard.cpp:549 src/FirstRunWizard.cpp:611 src/muuli_wdr.cpp:1716
 msgid "Destination folder for downloads"
 msgstr "Zielverzeichnis für Downloads."
 
 #: src/FirstRunWizard.cpp:553 src/FirstRunWizard.cpp:569 src/muuli_wdr.cpp:1349
-#: src/muuli_wdr.cpp:1366 src/muuli_wdr.cpp:1687 src/muuli_wdr.cpp:1718
-#: src/muuli_wdr.cpp:1730 src/muuli_wdr.cpp:2800
+#: src/muuli_wdr.cpp:1366 src/muuli_wdr.cpp:1691 src/muuli_wdr.cpp:1722
+#: src/muuli_wdr.cpp:1734 src/muuli_wdr.cpp:2804
 #: src/utils/aLinkCreator/src/alcframe.cpp:135
 #: src/utils/wxCas/src/wxcasprefs.cpp:52 src/utils/wxCas/src/wxcasprefs.cpp:118
 msgid "Browse"
 msgstr "Durchsuchen"
 
-#: src/FirstRunWizard.cpp:559 src/muuli_wdr.cpp:1723
+#: src/FirstRunWizard.cpp:559 src/muuli_wdr.cpp:1727
 msgid "(All files in this folder are shared with other peers)"
 msgstr "(Alle Dateien in diesem Ordner werden mit anderen Nutzern geteilt)"
 
-#: src/FirstRunWizard.cpp:565 src/FirstRunWizard.cpp:624 src/muuli_wdr.cpp:1725
+#: src/FirstRunWizard.cpp:565 src/FirstRunWizard.cpp:624 src/muuli_wdr.cpp:1729
 msgid "Folder for temporary download files"
 msgstr "Verzeichnis für temporäre Downloaddateien"
 
@@ -2481,7 +2481,7 @@ msgstr "Konnte Freundes-Liste 'emfriends.met' nicht schreiben!"
 msgid "CRITICAL - no client on StartChatSession"
 msgstr "KRITISCH - kein Client bei StartChatSession"
 
-#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2706 src/muuli_wdr.cpp:3383
+#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2710 src/muuli_wdr.cpp:3387
 msgid "Friends"
 msgstr "Freunde"
 
@@ -2591,8 +2591,8 @@ msgstr "Keine"
 msgid "No"
 msgstr "Nein"
 
-#: src/GenericClientListCtrl.cpp:1216 src/PrefsUnifiedDlg.cpp:2898
-#: src/PrefsUnifiedDlg.cpp:2948 src/ServerListCtrl.cpp:276
+#: src/GenericClientListCtrl.cpp:1216 src/PrefsUnifiedDlg.cpp:2907
+#: src/PrefsUnifiedDlg.cpp:2957 src/ServerListCtrl.cpp:276
 msgid "Yes"
 msgstr "Ja"
 
@@ -2761,10 +2761,10 @@ msgstr "Ungültiger Bootstrap-Port"
 msgid "Please fill all fields required"
 msgstr "Bitte alle erforderlichen Felder ausfüllen"
 
-#: src/KadDlg.cpp:192 src/PartFile.cpp:1031 src/PrefsUnifiedDlg.cpp:1134
-#: src/PrefsUnifiedDlg.cpp:1204 src/PrefsUnifiedDlg.cpp:1405
-#: src/PrefsUnifiedDlg.cpp:1663 src/PrefsUnifiedDlg.cpp:1673
-#: src/PrefsUnifiedDlg.cpp:1690 src/PrefsUnifiedDlg.cpp:1738
+#: src/KadDlg.cpp:192 src/PartFile.cpp:1031 src/PrefsUnifiedDlg.cpp:1143
+#: src/PrefsUnifiedDlg.cpp:1213 src/PrefsUnifiedDlg.cpp:1414
+#: src/PrefsUnifiedDlg.cpp:1672 src/PrefsUnifiedDlg.cpp:1682
+#: src/PrefsUnifiedDlg.cpp:1699 src/PrefsUnifiedDlg.cpp:1747
 msgid "Message"
 msgstr "Nachricht"
 
@@ -2866,7 +2866,7 @@ msgstr "Tauschverhältnis"
 msgid "Uploaded"
 msgstr "Hochgeladen"
 
-#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3263
+#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3267
 msgid "Requested"
 msgstr "Angefordert"
 
@@ -2990,7 +2990,7 @@ msgid "WARNING: "
 msgstr "WARNUNG: "
 
 #: src/MuleNotebook.cpp:179 src/muuli_wdr.cpp:817 src/muuli_wdr.cpp:1229
-#: src/muuli_wdr.cpp:3167 src/muuli_wdr.cpp:3423
+#: src/muuli_wdr.cpp:3171 src/muuli_wdr.cpp:3427
 msgid "Close"
 msgstr "Schließen"
 
@@ -3008,7 +3008,7 @@ msgid "Paste"
 msgstr "Einfügen"
 
 #: src/MuleTextCtrl.cpp:89 src/muuli_wdr.cpp:358 src/muuli_wdr.cpp:757
-#: src/muuli_wdr.cpp:2390 src/muuli_wdr.cpp:2409 src/muuli_wdr.cpp:2431
+#: src/muuli_wdr.cpp:2394 src/muuli_wdr.cpp:2413 src/muuli_wdr.cpp:2435
 #: src/utils/aLinkCreator/src/alcframe.cpp:142
 msgid "Clear"
 msgstr "Leeren"
@@ -3100,7 +3100,7 @@ msgstr "Schließen"
 
 #: src/MuleTrayIcon.cpp:579 src/MuleTrayIcon.cpp:945 src/MuleTrayIcon.cpp:965
 #: src/muuli_wdr.cpp:1398 src/muuli_wdr.cpp:1406 src/muuli_wdr.cpp:1413
-#: src/muuli_wdr.cpp:1846 src/muuli_wdr.cpp:1852 src/OtherFunctions.cpp:91
+#: src/muuli_wdr.cpp:1850 src/muuli_wdr.cpp:1856 src/OtherFunctions.cpp:91
 #: src/StatisticsDlg.cpp:93 src/StatisticsDlg.cpp:95
 msgid "kB/s"
 msgstr "kB/s"
@@ -3342,7 +3342,7 @@ msgstr "Bytes"
 msgid "KB"
 msgstr "KB"
 
-#: src/muuli_wdr.cpp:274 src/muuli_wdr.cpp:293 src/muuli_wdr.cpp:1631
+#: src/muuli_wdr.cpp:274 src/muuli_wdr.cpp:293 src/muuli_wdr.cpp:1635
 #: src/OtherFunctions.cpp:64
 msgid "MB"
 msgstr "MB"
@@ -3359,7 +3359,7 @@ msgstr "Höchstgröße"
 msgid "Availability"
 msgstr "Verfügbarkeit"
 
-#: src/muuli_wdr.cpp:312 src/muuli_wdr.cpp:398 src/muuli_wdr.cpp:3328
+#: src/muuli_wdr.cpp:312 src/muuli_wdr.cpp:398 src/muuli_wdr.cpp:3332
 msgid "Filter:"
 msgstr "Filter:"
 
@@ -3422,8 +3422,8 @@ msgstr "Dateiquellen:"
 #: src/muuli_wdr.cpp:1160 src/muuli_wdr.cpp:1167 src/muuli_wdr.cpp:1172
 #: src/muuli_wdr.cpp:1179 src/muuli_wdr.cpp:1184 src/muuli_wdr.cpp:1191
 #: src/muuli_wdr.cpp:1205 src/muuli_wdr.cpp:1212 src/muuli_wdr.cpp:1217
-#: src/muuli_wdr.cpp:1224 src/muuli_wdr.cpp:3265 src/muuli_wdr.cpp:3273
-#: src/muuli_wdr.cpp:3281
+#: src/muuli_wdr.cpp:1224 src/muuli_wdr.cpp:3269 src/muuli_wdr.cpp:3277
+#: src/muuli_wdr.cpp:3285
 msgid "N/A"
 msgstr "Nicht verfügbar"
 
@@ -3568,7 +3568,7 @@ msgstr ""
 msgid "Album :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:685 src/muuli_wdr.cpp:2285
+#: src/muuli_wdr.cpp:685 src/muuli_wdr.cpp:2289
 msgid "Title :"
 msgstr "Titel:"
 
@@ -3677,7 +3677,7 @@ msgstr "Benutzername:"
 msgid "Userhash :"
 msgstr "Benutzerprüfsumme:"
 
-#: src/muuli_wdr.cpp:895 src/muuli_wdr.cpp:1752 src/muuli_wdr.cpp:2480
+#: src/muuli_wdr.cpp:895 src/muuli_wdr.cpp:1756 src/muuli_wdr.cpp:2484
 #: src/utils/aLinkCreator/src/alcframe.cpp:137
 msgid "Add"
 msgstr "Hinzufügen"
@@ -3686,15 +3686,15 @@ msgstr "Hinzufügen"
 msgid "Download-Speed"
 msgstr "Download-Geschwindigkeit"
 
-#: src/muuli_wdr.cpp:954 src/muuli_wdr.cpp:989 src/muuli_wdr.cpp:2584
+#: src/muuli_wdr.cpp:954 src/muuli_wdr.cpp:989 src/muuli_wdr.cpp:2588
 msgid "Current"
 msgstr "Aktuell"
 
-#: src/muuli_wdr.cpp:962 src/muuli_wdr.cpp:997 src/muuli_wdr.cpp:2592
+#: src/muuli_wdr.cpp:962 src/muuli_wdr.cpp:997 src/muuli_wdr.cpp:2596
 msgid "Running average"
 msgstr "gleitender Mittelwert"
 
-#: src/muuli_wdr.cpp:970 src/muuli_wdr.cpp:1005 src/muuli_wdr.cpp:2600
+#: src/muuli_wdr.cpp:970 src/muuli_wdr.cpp:1005 src/muuli_wdr.cpp:2604
 msgid "Session average"
 msgstr "Sitzungsdurchschnitt"
 
@@ -3706,7 +3706,7 @@ msgstr "Upload-Geschwindigkeit"
 msgid "Connections"
 msgstr "Verbindungen"
 
-#: src/muuli_wdr.cpp:1024 src/muuli_wdr.cpp:1871
+#: src/muuli_wdr.cpp:1024 src/muuli_wdr.cpp:1875
 msgid "Active downloads"
 msgstr "Aktive Downloads"
 
@@ -3714,7 +3714,7 @@ msgstr "Aktive Downloads"
 msgid "Active connections (1:1)"
 msgstr "Aktive Verbindungen (1:1)"
 
-#: src/muuli_wdr.cpp:1040 src/muuli_wdr.cpp:1872
+#: src/muuli_wdr.cpp:1040 src/muuli_wdr.cpp:1876
 msgid "Active uploads"
 msgstr "Aktive Uploads"
 
@@ -3990,7 +3990,7 @@ msgstr "Verknüpfe lokale Adresse mit IP (Leer für beliebige):"
 msgid "Advanced users only: If you have multiple network interfaces, enter the address of the interface to which aMule should be bound."
 msgstr "Nur für fortgeschrittene Benutzer: Wenn es mehrere Netzwerkverbindungen gibt, hier die Adresse der Verbindung, mit der aMule verknüpft werden soll, eingeben."
 
-#: src/muuli_wdr.cpp:1462 src/muuli_wdr.cpp:2065
+#: src/muuli_wdr.cpp:1462 src/muuli_wdr.cpp:2069
 #, fuzzy
 msgid "Bind to network interface (empty for any):"
 msgstr "Verknüpfe lokale Adresse mit IP (Leer für beliebige):"
@@ -4007,7 +4007,7 @@ msgstr "Maximale Anzahl Quellen pro heruntergeladener Datei:"
 msgid "Max simultaneous connections:"
 msgstr "Maximale gleichzeitige Verbindungen:"
 
-#: src/muuli_wdr.cpp:1498 src/muuli_wdr.cpp:3207
+#: src/muuli_wdr.cpp:1498 src/muuli_wdr.cpp:3211
 msgid "ED2K"
 msgstr "eD2k"
 
@@ -4099,79 +4099,79 @@ msgstr "Reserviere Speicherplatz für neue Dateien"
 msgid "For new files preallocates disk space for the whole file, thus reduces fragmentation"
 msgstr "Reserviert für neue Dateien Speicherplatz für die ganze Datei und reduziert so Fragmentierung."
 
-#: src/muuli_wdr.cpp:1617
+#: src/muuli_wdr.cpp:1621
 msgid "Create new files as sparse files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1618
+#: src/muuli_wdr.cpp:1622
 msgid "Sparse part files only occupy disk space for the parts already downloaded, so free space is used up gradually as the file fills in. Turn this off to use an ordinary file instead - useful where sparse files are unsupported or slow, or where backup/de-duplication tools handle them badly. Applies only when the core runs on Windows; on Linux and macOS part files are sparse anyway and this setting has no effect."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1623
+#: src/muuli_wdr.cpp:1627
 msgid "Stop downloads when free disk space reaches "
 msgstr "Stoppe Downloads wenn freier Speicherplatz folgenden Wert erreicht:"
 
-#: src/muuli_wdr.cpp:1624
+#: src/muuli_wdr.cpp:1628
 msgid "Select this if you want aMule to check your disk space"
 msgstr "Wähle dies aus, wenn aMule deinen Festplattenplatz prüfen soll"
 
-#: src/muuli_wdr.cpp:1628
+#: src/muuli_wdr.cpp:1632
 msgid "Enter here the min disk space desired."
 msgstr "Hier den minimalen erwünschten Festplattenplatz angeben."
 
-#: src/muuli_wdr.cpp:1634
+#: src/muuli_wdr.cpp:1638
 msgid "Save 10 sources on rare files (< 20 sources)"
 msgstr "Bei seltenen (< 20 Quellen) Dateien zehn Quellen speichern"
 
-#: src/muuli_wdr.cpp:1638 src/Statistics.cpp:790
+#: src/muuli_wdr.cpp:1642 src/Statistics.cpp:790
 msgid "Uploads"
 msgstr "Uploads"
 
-#: src/muuli_wdr.cpp:1641
+#: src/muuli_wdr.cpp:1645
 msgid "Add new shared files with auto priority"
 msgstr "Neue freigegebene Dateien auf Autopriorität stellen"
 
-#: src/muuli_wdr.cpp:1647
+#: src/muuli_wdr.cpp:1651
 msgid "Intelligent Corruption Handling (I.C.H.)"
 msgstr "Intelligente Korruptionsverarbeitung (I.C.H.)"
 
-#: src/muuli_wdr.cpp:1650
+#: src/muuli_wdr.cpp:1654
 msgid "Enable"
 msgstr "Aktiviere"
 
-#: src/muuli_wdr.cpp:1653
+#: src/muuli_wdr.cpp:1657
 msgid "Advanced I.C.H. trusts every hash (not recommended)"
 msgstr "Advanced I.C.H vertraut jeder Prüfsumme (nicht empfohlen)"
 
-#: src/muuli_wdr.cpp:1665 src/PrefsUnifiedDlg.cpp:1990
+#: src/muuli_wdr.cpp:1669 src/PrefsUnifiedDlg.cpp:1999
 msgid "Media metadata extraction"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1669
+#: src/muuli_wdr.cpp:1673
 msgid "Extract length / bitrate / codec from shared audio and video files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1671
+#: src/muuli_wdr.cpp:1675
 msgid "When enabled, aMule runs ffprobe on each shared media file to fill in the Length / Bitrate / Codec columns other clients see when they find the file in a search. Requires ffmpeg (the ffprobe binary) to be installed."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1678
+#: src/muuli_wdr.cpp:1682
 msgid "Path to ffprobe:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1683
+#: src/muuli_wdr.cpp:1687
 msgid "Full path to the ffprobe binary. Leave empty to have aMule auto-detect it on startup."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1691
+#: src/muuli_wdr.cpp:1695
 msgid "Detect"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1692
+#: src/muuli_wdr.cpp:1696
 msgid "Search the standard install locations for an ffprobe binary and fill the path field."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1716
+#: src/muuli_wdr.cpp:1720
 msgid ""
 "Completed downloads are stored here. All files in this folder are automatically shared with other peers.\n"
 "If this folder also holds files you don't want to share, point it at an aMule-only sub-folder."
@@ -4179,697 +4179,697 @@ msgstr ""
 "Vollständige Downloads werden hier gespeichert. Alle Dateien in diesem Ordner werden automatisch geteilt\n"
 ". Falls dieser Ordner Dateien enthält die du nicht teilen willst, wähle einen eigenen Ordner nur für aMule aus."
 
-#: src/muuli_wdr.cpp:1719
+#: src/muuli_wdr.cpp:1723
 msgid "Pick the folder where completed downloads will be stored. All files in that folder will be shared with other peers."
 msgstr "Wähle einen Ordner in dem vollständige Downloads gepeichert werden sollen. Dieser Ordner wird automatisch geteilt."
 
-#: src/muuli_wdr.cpp:1733
+#: src/muuli_wdr.cpp:1737
 msgid "Shared folders"
 msgstr "Freigegebene Ordner"
 
-#: src/muuli_wdr.cpp:1739
+#: src/muuli_wdr.cpp:1743
 msgid "(Folders shared by the core. Enter a path to add one.)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1747
+#: src/muuli_wdr.cpp:1751
 msgid "Absolute path of a folder on the core's machine, e.g. /home/user/shared"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1749 src/PrefsUnifiedDlg.cpp:2874
+#: src/muuli_wdr.cpp:1753 src/PrefsUnifiedDlg.cpp:2883
 msgid "Recursive"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1750
+#: src/muuli_wdr.cpp:1754
 msgid "Share every sub-folder underneath this one, including ones created later."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1754 src/utils/aLinkCreator/src/alcframe.cpp:141
+#: src/muuli_wdr.cpp:1758 src/utils/aLinkCreator/src/alcframe.cpp:141
 msgid "Remove"
 msgstr "Entferne"
 
-#: src/muuli_wdr.cpp:1758
+#: src/muuli_wdr.cpp:1762
 msgid "(Right click on folder icon for recursive share)"
 msgstr "(Rechtsklick auf das Symbol des rekursiv freizugebenden Verzeichnisses)"
 
-#: src/muuli_wdr.cpp:1765
+#: src/muuli_wdr.cpp:1769
 msgid "Share hidden files"
 msgstr "Versteckte Dateien freigeben"
 
-#: src/muuli_wdr.cpp:1771
+#: src/muuli_wdr.cpp:1775
 msgid "Automatically rescan shared folders for changes"
 msgstr "Ornder automatisch auf Änderungen überwachen"
 
-#: src/muuli_wdr.cpp:1777
+#: src/muuli_wdr.cpp:1781
 msgid "Follow symbolic links in shared folders"
 msgstr "Symbolischen Links in geteilten Ordnern folgen"
 
-#: src/muuli_wdr.cpp:1783
+#: src/muuli_wdr.cpp:1787
 msgid "Exclude files matching:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1786
+#: src/muuli_wdr.cpp:1790
 msgid "Wildcard patterns separated by '|', e.g. .DS_Store|Thumbs.db|*.tmp. Files whose name matches are not shared. Matching is case-insensitive."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1790
+#: src/muuli_wdr.cpp:1794
 msgid "Patterns are regular expressions"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1791
+#: src/muuli_wdr.cpp:1795
 msgid "When set, the whole field is one regular expression ('|' is alternation). When unset, it is a list of '|'-separated wildcards."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1801
+#: src/muuli_wdr.cpp:1805
 msgid "Show how many shared files the current pattern would exclude."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1822
+#: src/muuli_wdr.cpp:1826
 msgid "Graphs"
 msgstr "Graphen"
 
-#: src/muuli_wdr.cpp:1825 src/muuli_wdr.cpp:1887
+#: src/muuli_wdr.cpp:1829 src/muuli_wdr.cpp:1891
 msgid "Update delay : 5 secs"
 msgstr "Aktualisierungsverzögerung: 5 Sekunden"
 
-#: src/muuli_wdr.cpp:1829
+#: src/muuli_wdr.cpp:1833
 msgid "Time for average graph: 100 mins"
 msgstr "Durchschnittsgraphen in Minuten berechnen: 100 min"
 
-#: src/muuli_wdr.cpp:1833
+#: src/muuli_wdr.cpp:1837
 msgid "Connections Graph Scale: 100 "
 msgstr "Verbindungsgraphenskalierung: 100"
 
-#: src/muuli_wdr.cpp:1840
+#: src/muuli_wdr.cpp:1844
 msgid "Download graph scale:"
 msgstr "Downloadgraphenskalierung:"
 
-#: src/muuli_wdr.cpp:1848
+#: src/muuli_wdr.cpp:1852
 msgid "Upload graph scale:"
 msgstr "Uploadgraphenskalierung:"
 
-#: src/muuli_wdr.cpp:1858
+#: src/muuli_wdr.cpp:1862
 msgid "Colors: "
 msgstr "Farben: "
 
-#: src/muuli_wdr.cpp:1862
+#: src/muuli_wdr.cpp:1866
 msgid "Background"
 msgstr "Hintergrund"
 
-#: src/muuli_wdr.cpp:1863
+#: src/muuli_wdr.cpp:1867
 msgid "Grid"
 msgstr "Gitter"
 
-#: src/muuli_wdr.cpp:1864
+#: src/muuli_wdr.cpp:1868
 msgid "Download current"
 msgstr "Aktueller Download"
 
-#: src/muuli_wdr.cpp:1865
+#: src/muuli_wdr.cpp:1869
 msgid "Download running average"
 msgstr "Download: Durchschnitt"
 
-#: src/muuli_wdr.cpp:1866
+#: src/muuli_wdr.cpp:1870
 msgid "Download session average"
 msgstr "Download: Sitzungsdurchschnitt"
 
-#: src/muuli_wdr.cpp:1867
+#: src/muuli_wdr.cpp:1871
 msgid "Upload current"
 msgstr "Aktueller Upload"
 
-#: src/muuli_wdr.cpp:1868
+#: src/muuli_wdr.cpp:1872
 msgid "Upload running average"
 msgstr "Upload: Durchschnitt"
 
-#: src/muuli_wdr.cpp:1869
+#: src/muuli_wdr.cpp:1873
 msgid "Upload session average"
 msgstr "Upload: Sitzungsdurchschnitt"
 
-#: src/muuli_wdr.cpp:1870
+#: src/muuli_wdr.cpp:1874
 msgid "Active connections"
 msgstr "Aktive Verbindungen"
 
-#: src/muuli_wdr.cpp:1873
+#: src/muuli_wdr.cpp:1877
 msgid "Systray Icon Speed Bar"
 msgstr "Transferbalken des Symbols im Infobereich"
 
-#: src/muuli_wdr.cpp:1874
+#: src/muuli_wdr.cpp:1878
 msgid "Kad-nodes current"
 msgstr "Momentane Kad-Knoten"
 
-#: src/muuli_wdr.cpp:1875
+#: src/muuli_wdr.cpp:1879
 msgid "Kad-nodes running"
 msgstr "Laufende Kad-Knoten"
 
-#: src/muuli_wdr.cpp:1876
+#: src/muuli_wdr.cpp:1880
 msgid "Kad-nodes session"
 msgstr "Kad-Knoten Sitzung"
 
-#: src/muuli_wdr.cpp:1880 src/muuli_wdr.cpp:2334
+#: src/muuli_wdr.cpp:1884 src/muuli_wdr.cpp:2338
 msgid "Select"
 msgstr "Auswahl"
 
-#: src/muuli_wdr.cpp:1884
+#: src/muuli_wdr.cpp:1888
 msgid "Tree"
 msgstr "Baum"
 
-#: src/muuli_wdr.cpp:1894
+#: src/muuli_wdr.cpp:1898
 msgid "Number of Client Versions shown (0=unlimited)"
 msgstr "Anzahl angezeigter Client-Versionen (0=unbegrenzt)"
 
-#: src/muuli_wdr.cpp:1919
+#: src/muuli_wdr.cpp:1923
 msgid "!!! WARNING !!!"
 msgstr "!!! WARNUNG !!!"
 
-#: src/muuli_wdr.cpp:1934
+#: src/muuli_wdr.cpp:1938
 msgid "Max new connections / 5 secs"
 msgstr "Maximale neue Verbindungen pro 5 Sekunden"
 
-#: src/muuli_wdr.cpp:1936
+#: src/muuli_wdr.cpp:1940
 msgid "Concurrent Kad source lookups"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1938
+#: src/muuli_wdr.cpp:1942
 #, fuzzy
 msgid "Kad source re-search interval (minutes)"
 msgstr "FTP-Aktualisierungsintervall in Minuten"
 
-#: src/muuli_wdr.cpp:1940
+#: src/muuli_wdr.cpp:1944
 #, fuzzy
 msgid "Source re-ask interval (minutes)"
 msgstr "FTP-Aktualisierungsintervall in Minuten"
 
-#: src/muuli_wdr.cpp:1944
+#: src/muuli_wdr.cpp:1948
 msgid "File Buffer Size: 240000 bytes"
 msgstr "Dateipuffergröße: 240000 Bytes"
 
-#: src/muuli_wdr.cpp:1948
+#: src/muuli_wdr.cpp:1952
 msgid "Use MMAP: memory-mapped file access (lower memory use)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1949
+#: src/muuli_wdr.cpp:1953
 msgid "Maps part files into memory instead of buffering them on the heap, lowering the process memory footprint. May reduce download speed on some disks; best for memory-constrained or upload-heavy hosts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1951
+#: src/muuli_wdr.cpp:1955
 msgid "Upload Queue Size: 5000 clients"
 msgstr "Upload-Warteschlangengröße: 5000 Clients"
 
-#: src/muuli_wdr.cpp:1955
+#: src/muuli_wdr.cpp:1959
 msgid "Server connection refresh interval: Disable"
 msgstr "Server-Wiederverbindungsintervall: Aus"
 
-#: src/muuli_wdr.cpp:1959
+#: src/muuli_wdr.cpp:1963
 msgid "Disable computer's timed standby mode"
 msgstr "Zeitgesteuerten Bereitschaftsmodus des Computers deaktivieren"
 
-#: src/muuli_wdr.cpp:1978
+#: src/muuli_wdr.cpp:1982
 msgid "Skin to use: "
 msgstr "benutztes Aussehen:"
 
-#: src/muuli_wdr.cpp:1987
+#: src/muuli_wdr.cpp:1991
 msgid "Show \"Fast eD2k Links Handler\" in every window."
 msgstr "Zeige \"schnelle eD2k-Linkverarbeitung\" in jedem Fenster"
 
-#: src/muuli_wdr.cpp:1990
+#: src/muuli_wdr.cpp:1994
 msgid "Show extended info on categories tabs"
 msgstr "Zeige erweiterte Informationen auf Kategorie-Reitern"
 
-#: src/muuli_wdr.cpp:1993
+#: src/muuli_wdr.cpp:1997
 msgid "Show application version on title"
 msgstr "Zeige Programmversion im Titel"
 
-#: src/muuli_wdr.cpp:1995
+#: src/muuli_wdr.cpp:1999
 msgid "Show transfer rates on title"
 msgstr "Zeige Transferraten im Titel"
 
-#: src/muuli_wdr.cpp:1997
+#: src/muuli_wdr.cpp:2001
 msgid "Before application name"
 msgstr "Vor dem Anwendungsnamen"
 
-#: src/muuli_wdr.cpp:1999
+#: src/muuli_wdr.cpp:2003
 msgid "After application name"
 msgstr "Nach dem Anwendungsnamen"
 
-#: src/muuli_wdr.cpp:2002
+#: src/muuli_wdr.cpp:2006
 msgid "Show overhead bandwidth"
 msgstr "Zeige Overhead-Bandbreite"
 
-#: src/muuli_wdr.cpp:2006
+#: src/muuli_wdr.cpp:2010
 msgid "Vertical toolbar orientation"
 msgstr "Toolbar senkrecht ausrichten"
 
-#: src/muuli_wdr.cpp:2008
+#: src/muuli_wdr.cpp:2012
 msgid "Live column sorting (auto-reorder rows as their values change)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2015
+#: src/muuli_wdr.cpp:2019
 msgid "Download Queue Files"
 msgstr "Downloadwarteschlangendateien"
 
-#: src/muuli_wdr.cpp:2018
+#: src/muuli_wdr.cpp:2022
 msgid "Show progress percentage"
 msgstr "Zeige Prozent des Fortschritts"
 
-#: src/muuli_wdr.cpp:2024
+#: src/muuli_wdr.cpp:2028
 msgid "Show progress bar"
 msgstr "Zeige Fortschrittsbalken"
 
-#: src/muuli_wdr.cpp:2027
+#: src/muuli_wdr.cpp:2031
 msgid "Flat"
 msgstr "Flach"
 
-#: src/muuli_wdr.cpp:2031
+#: src/muuli_wdr.cpp:2035
 msgid "Round"
 msgstr "Rund"
 
-#: src/muuli_wdr.cpp:2049
+#: src/muuli_wdr.cpp:2053
 msgid "External Connection Parameters"
 msgstr "Parameter für externe Verbindungen"
 
-#: src/muuli_wdr.cpp:2052
+#: src/muuli_wdr.cpp:2056
 msgid "Accept external connections"
 msgstr "Externe Verbindungen annehmen"
 
-#: src/muuli_wdr.cpp:2059 src/muuli_wdr.cpp:2118
+#: src/muuli_wdr.cpp:2063 src/muuli_wdr.cpp:2122
 msgid "IP of the listening interface:"
 msgstr "IP der lauschenden Schnittstelle:"
 
-#: src/muuli_wdr.cpp:2062
+#: src/muuli_wdr.cpp:2066
 msgid "Enter here a valid ip in the a.b.c.d format for the listening EC interface. An empty field or 0.0.0.0 will mean any interface."
 msgstr "Hier eine gültige IP im Format a.b.c.d für das lauschende EC-Interface eingeben. Ein leeres Feld oder 0.0.0.0 bedeutet ein beliebiges Interface."
 
-#: src/muuli_wdr.cpp:2083 src/muuli_wdr.cpp:2194
+#: src/muuli_wdr.cpp:2087 src/muuli_wdr.cpp:2198
 msgid "TCP port:"
 msgstr "TCP-Port:"
 
-#: src/muuli_wdr.cpp:2089
+#: src/muuli_wdr.cpp:2093
 msgid "Enable UPnP port forwarding on the EC port"
 msgstr "Aktiviere UPnP-Port-Weiterleitung zu EC-Port"
 
-#: src/muuli_wdr.cpp:2093 src/muuli_wdr.cpp:3079
+#: src/muuli_wdr.cpp:2097 src/muuli_wdr.cpp:3083
 #: src/utils/wxCas/src/wxcasprefs.cpp:167
 msgid "Password"
 msgstr "Passwort"
 
-#: src/muuli_wdr.cpp:2099
+#: src/muuli_wdr.cpp:2103
 #, fuzzy
 msgid "aMule API server parameters"
 msgstr "Webserver-Parameter"
 
-#: src/muuli_wdr.cpp:2102
+#: src/muuli_wdr.cpp:2106
 msgid "Run amuleapi (REST API) on startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2107
+#: src/muuli_wdr.cpp:2111
 #, fuzzy
 msgid "HTTP port:"
 msgstr "TCP-Port:"
 
-#: src/muuli_wdr.cpp:2121
+#: src/muuli_wdr.cpp:2125
 msgid "The interface amuleapi's HTTP server listens on. 127.0.0.1 (default) accepts only local connections; use 0.0.0.0 or a specific IP to expose it to other hosts (set an admin password below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2126
+#: src/muuli_wdr.cpp:2130
 msgid "Type a password to set or change it. Stored passwords cannot be shown, so leaving this empty keeps the current one."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2128
+#: src/muuli_wdr.cpp:2132
 #, fuzzy
 msgid "Admin password"
 msgstr "Prüfe Passwort\n"
 
-#: src/muuli_wdr.cpp:2140 src/muuli_wdr.cpp:2157 src/PrefsUnifiedDlg.cpp:1103
+#: src/muuli_wdr.cpp:2144 src/muuli_wdr.cpp:2161 src/PrefsUnifiedDlg.cpp:1112
 #, fuzzy
 msgid "A password is set."
 msgstr "Prüfe Passwort\n"
 
-#: src/muuli_wdr.cpp:2144
+#: src/muuli_wdr.cpp:2148
 #, fuzzy
 msgid "Enable guest access"
 msgstr "Verweigere Gastzugriff"
 
-#: src/muuli_wdr.cpp:2145
+#: src/muuli_wdr.cpp:2149
 msgid "Guest sessions may read status and listings but cannot change anything. Turning this off clears the stored guest password."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2149
+#: src/muuli_wdr.cpp:2153
 #, fuzzy
 msgid "Guest password"
 msgstr "Gast-Passwort für den Webserver"
 
-#: src/muuli_wdr.cpp:2164
+#: src/muuli_wdr.cpp:2168
 msgid "Web server parameters"
 msgstr "Webserver-Parameter"
 
-#: src/muuli_wdr.cpp:2167
+#: src/muuli_wdr.cpp:2171
 #, fuzzy
 msgid "Run webserver on startup (deprecated)"
 msgstr "Starte Webserver mit aMule"
 
-#: src/muuli_wdr.cpp:2173
+#: src/muuli_wdr.cpp:2177
 msgid "Web template"
 msgstr "Webvorlage"
 
-#: src/muuli_wdr.cpp:2178
+#: src/muuli_wdr.cpp:2182
 msgid "Full rights password"
 msgstr "Kennwort für Vollzugriff"
 
-#: src/muuli_wdr.cpp:2182
+#: src/muuli_wdr.cpp:2186
 msgid "Enable Low rights User"
 msgstr "Eingeschränkten Benutzer aktivieren"
 
-#: src/muuli_wdr.cpp:2187
+#: src/muuli_wdr.cpp:2191
 msgid "Low rights password"
 msgstr "Kennwort für eingeschränkten Zugriff"
 
-#: src/muuli_wdr.cpp:2201
+#: src/muuli_wdr.cpp:2205
 msgid "Enable UPnP port forwarding of the web server port"
 msgstr "Aktiviere UPnP-Port-Weiterleitung des Webserverports"
 
-#: src/muuli_wdr.cpp:2206
+#: src/muuli_wdr.cpp:2210
 msgid "Web server UPnP TCP port (Optional)"
 msgstr "Webserver UPnP-TCP-Port (optional)"
 
-#: src/muuli_wdr.cpp:2214
+#: src/muuli_wdr.cpp:2218
 msgid "Page Refresh Time (in secs)"
 msgstr "Aktualisierungsintervall in Sekunden"
 
-#: src/muuli_wdr.cpp:2221
+#: src/muuli_wdr.cpp:2225
 msgid "Enable Gzip compression"
 msgstr "Gzip-Kompression an"
 
-#: src/muuli_wdr.cpp:2255
+#: src/muuli_wdr.cpp:2259
 #, fuzzy
 msgid "Reset page to defaults"
 msgstr "Systemvorgabe"
 
-#: src/muuli_wdr.cpp:2256
+#: src/muuli_wdr.cpp:2260
 msgid "Reset the settings on the current page to their default values."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2258 src/muuli_wdr.cpp:2344 src/ServerWnd.cpp:274
+#: src/muuli_wdr.cpp:2262 src/muuli_wdr.cpp:2348 src/ServerWnd.cpp:274
 #: src/ServerWnd.cpp:282
 msgid "OK"
 msgstr "OK"
 
-#: src/muuli_wdr.cpp:2260
+#: src/muuli_wdr.cpp:2264
 msgid "Click here to apply any changes made to the preferences."
 msgstr "Hier klicken, um alle Einstellungsänderungen zu übernehmen."
 
-#: src/muuli_wdr.cpp:2263
+#: src/muuli_wdr.cpp:2267
 msgid "Reset any changes made to the preferences."
 msgstr "Alle Änderungen zu den Einstellungen zurücksetzen."
 
-#: src/muuli_wdr.cpp:2292
+#: src/muuli_wdr.cpp:2296
 msgid "Comment :"
 msgstr "Kommentar:"
 
-#: src/muuli_wdr.cpp:2299
+#: src/muuli_wdr.cpp:2303
 msgid "Incoming Dir :"
 msgstr "Verzeichnis für eingehende Dateien:"
 
-#: src/muuli_wdr.cpp:2308
+#: src/muuli_wdr.cpp:2312
 msgid "Change priority for new assigned files :"
 msgstr "Priorität bei neu zugewiesenen Dateien ändern:"
 
-#: src/muuli_wdr.cpp:2312
+#: src/muuli_wdr.cpp:2316
 msgid "Don't change"
 msgstr "Nicht ändern"
 
-#: src/muuli_wdr.cpp:2324
+#: src/muuli_wdr.cpp:2328
 msgid "Select color for this Category (currently selected) :"
 msgstr "Farbe für diese Kategorie wählen (momentan ausgewählt):"
 
-#: src/muuli_wdr.cpp:2391 src/muuli_wdr.cpp:2410 src/muuli_wdr.cpp:2432
+#: src/muuli_wdr.cpp:2395 src/muuli_wdr.cpp:2414 src/muuli_wdr.cpp:2436
 msgid "Click this button to reset the log."
 msgstr "Drücke diesen Knopf, um das Log zurückzusetzen."
 
-#: src/muuli_wdr.cpp:2451
+#: src/muuli_wdr.cpp:2455
 msgid "Click on this button to update the servers list from URL ..."
 msgstr "Hier klicken, um die Serverliste über die angegebene URL zu aktualisieren"
 
-#: src/muuli_wdr.cpp:2455
+#: src/muuli_wdr.cpp:2459
 msgid "Server list"
 msgstr "Serverliste"
 
-#: src/muuli_wdr.cpp:2459
+#: src/muuli_wdr.cpp:2463
 msgid "Enter the url to a server.met file here and press the button to the left to update the list of known servers."
 msgstr "Hier die URL einer server.met eingeben, und dann den Knopf links vom Eingabefeld drücken, um die Serverliste zu aktualisieren."
 
-#: src/muuli_wdr.cpp:2464
+#: src/muuli_wdr.cpp:2468
 msgid "Add server manually: Name"
 msgstr "Server manuell hinzufügen: Name"
 
-#: src/muuli_wdr.cpp:2467
+#: src/muuli_wdr.cpp:2471
 msgid "Enter the name of the new server here"
 msgstr "Gib den Namen das neuen Servers hier ein"
 
-#: src/muuli_wdr.cpp:2469 src/ServerWnd.cpp:206
+#: src/muuli_wdr.cpp:2473 src/ServerWnd.cpp:206
 msgid "IP:Port"
 msgstr "IP:Port"
 
-#: src/muuli_wdr.cpp:2472
+#: src/muuli_wdr.cpp:2476
 msgid "Enter the IP of the server here, using the x.x.x.x format."
 msgstr "Hier die IP des Servers im Format x.x.x.x eingeben."
 
-#: src/muuli_wdr.cpp:2478
+#: src/muuli_wdr.cpp:2482
 msgid "Enter the port of the server here."
 msgstr "Hier den Serverport eingeben."
 
-#: src/muuli_wdr.cpp:2481
+#: src/muuli_wdr.cpp:2485
 msgid "Add manually a server (fill fields to the left before) ..."
 msgstr "Einen Server manuell hinzufügen (vorher bitte links die Felder ausfüllen)..."
 
-#: src/muuli_wdr.cpp:2510
+#: src/muuli_wdr.cpp:2514
 msgid "aMule Log"
 msgstr "aMule-Log"
 
-#: src/muuli_wdr.cpp:2518
+#: src/muuli_wdr.cpp:2522
 msgid "Server Info"
 msgstr "Serverinformation"
 
-#: src/muuli_wdr.cpp:2522
+#: src/muuli_wdr.cpp:2526
 msgid "ED2K Info"
 msgstr "eD2k-Info"
 
-#: src/muuli_wdr.cpp:2526
+#: src/muuli_wdr.cpp:2530
 msgid "Kad Info"
 msgstr "Kad-Info"
 
-#: src/muuli_wdr.cpp:2554
+#: src/muuli_wdr.cpp:2558
 msgid "Click on this button to update the nodes list from URL ..."
 msgstr "Zum Aktualisieren der nodes.dat von URL diese Schaltfläche drücken."
 
-#: src/muuli_wdr.cpp:2558
+#: src/muuli_wdr.cpp:2562
 msgid "Nodes (0)"
 msgstr "Knoten (0)"
 
-#: src/muuli_wdr.cpp:2562
+#: src/muuli_wdr.cpp:2566
 msgid "Enter the url to a nodes.dat file here and press the button to the left to update the list of known nodes."
 msgstr "Hier die URL einer nodes.dat eingeben, und dann den Knopf links vom Eingabefeld drücken, um die Liste der bekannten Knoten zu aktualisieren."
 
-#: src/muuli_wdr.cpp:2565
+#: src/muuli_wdr.cpp:2569
 msgid "Nodes stats"
 msgstr "Knotenstatistik"
 
-#: src/muuli_wdr.cpp:2607
+#: src/muuli_wdr.cpp:2611
 msgid "Bootstrap"
 msgstr "Bootstrap"
 
-#: src/muuli_wdr.cpp:2610
+#: src/muuli_wdr.cpp:2614
 msgid "New node"
 msgstr "Neuer Knoten"
 
-#: src/muuli_wdr.cpp:2615
+#: src/muuli_wdr.cpp:2619
 msgid "IP:"
 msgstr "IP:"
 
-#: src/muuli_wdr.cpp:2635
+#: src/muuli_wdr.cpp:2639
 msgid "Port:"
 msgstr "Port:"
 
-#: src/muuli_wdr.cpp:2648
+#: src/muuli_wdr.cpp:2652
 msgid "Bootstrap from known clients"
 msgstr "Bootstrap von bekannten Clients"
 
-#: src/muuli_wdr.cpp:2650
+#: src/muuli_wdr.cpp:2654
 msgid "Disconnect Kad"
 msgstr "Kad trennen"
 
-#: src/muuli_wdr.cpp:2684
+#: src/muuli_wdr.cpp:2688
 msgid "Use Secure User Identification"
 msgstr "Benutze sichere Benutzeridentifikation"
 
-#: src/muuli_wdr.cpp:2686
+#: src/muuli_wdr.cpp:2690
 msgid "It is recommended to enable this option. You will not receive credits if SUI is not enabled."
 msgstr "Es wird empfohlen diese Option zu aktivieren. Du wirst keine Credits erhalten, wenn SUI nicht aktiviert ist."
 
-#: src/muuli_wdr.cpp:2688
+#: src/muuli_wdr.cpp:2692
 msgid "Protocol Obfuscation"
 msgstr "Protokollverschleierung"
 
-#: src/muuli_wdr.cpp:2691
+#: src/muuli_wdr.cpp:2695
 msgid "Support Protocol Obfuscation"
 msgstr "Unterstütze Protokollverschleierung"
 
-#: src/muuli_wdr.cpp:2693
+#: src/muuli_wdr.cpp:2697
 msgid "This option enabled Protocol Obfuscation, and makes aMule accept obfuscated connections from other clients."
 msgstr "Diese Option aktiviert die Protokollverschleierung und verfügt aMule, verschleierte Verbindungen von anderen Clients anzunehmen."
 
-#: src/muuli_wdr.cpp:2695
+#: src/muuli_wdr.cpp:2699
 msgid "Use obfuscation for outgoing connections"
 msgstr "Verschleiere ausgehende Verbindungen"
 
-#: src/muuli_wdr.cpp:2697
+#: src/muuli_wdr.cpp:2701
 msgid "This option makes aMule use Protocol Obfuscation when connecting other clients/servers."
 msgstr "Diese Option verfügt aMule, Protokollverschleierung zu verwenden bei der Verbindung zu anderen Clients und/oder Servern."
 
-#: src/muuli_wdr.cpp:2699
+#: src/muuli_wdr.cpp:2703
 msgid "Accept only obfuscated connections"
 msgstr "Akzeptiere ausschließlich verschleierte Verbindungen"
 
-#: src/muuli_wdr.cpp:2700
+#: src/muuli_wdr.cpp:2704
 msgid "This option makes aMule only accept obfuscated connections. You will have less sources, but all your traffic will be obfuscated"
 msgstr "Diese Option verfügt aMule, ausschließlich verschleierte Verbindungen zu akzeptieren. Das führt zu weniger Quellen, jedoch ist sämtlicher Verkehr verschleiert."
 
-#: src/muuli_wdr.cpp:2705
+#: src/muuli_wdr.cpp:2709
 msgid "Everybody"
 msgstr "Jeder"
 
-#: src/muuli_wdr.cpp:2707
+#: src/muuli_wdr.cpp:2711
 msgid "No one"
 msgstr "Niemand"
 
-#: src/muuli_wdr.cpp:2709
+#: src/muuli_wdr.cpp:2713
 msgid "Who can see my shared files:"
 msgstr "Wer kann freigegebene Dateien sehen:"
 
-#: src/muuli_wdr.cpp:2710
+#: src/muuli_wdr.cpp:2714
 msgid "Select who can request to view a list of your shared files."
 msgstr "Wähle, wer deine freigegebenen Dateien einsehen darf."
 
-#: src/muuli_wdr.cpp:2712
+#: src/muuli_wdr.cpp:2716
 msgid "IP-Filtering"
 msgstr "IP-Filterung"
 
-#: src/muuli_wdr.cpp:2719
+#: src/muuli_wdr.cpp:2723
 msgid "Filter clients"
 msgstr "Filtere Clients"
 
-#: src/muuli_wdr.cpp:2721
+#: src/muuli_wdr.cpp:2725
 msgid "Enable filtering of the client IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "Aktiviere die Filterung von Client-IPs, die in der Datei ~/.aMule/ipfilter.dat definiert sind."
 
-#: src/muuli_wdr.cpp:2723
+#: src/muuli_wdr.cpp:2727
 msgid "Filter servers"
 msgstr "Filtere Server"
 
-#: src/muuli_wdr.cpp:2725
+#: src/muuli_wdr.cpp:2729
 msgid "Enable filtering of the server IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "Aktiviere das Filtern von Server-IPs, die in der Datei ~/.aMule/ipfilter.dat definiert sind."
 
-#: src/muuli_wdr.cpp:2729
+#: src/muuli_wdr.cpp:2733
 msgid "Reload List"
 msgstr "Aktualisieren der Liste"
 
-#: src/muuli_wdr.cpp:2730
+#: src/muuli_wdr.cpp:2734
 msgid "Reload the list of IPs to filter from the file ~/.aMule/ipfilter.dat"
 msgstr "Aktualisiert die Liste der zu filternden IPs in der ~/.aMule/ipfilter.dat"
 
-#: src/muuli_wdr.cpp:2736
+#: src/muuli_wdr.cpp:2740
 msgid "URL:"
 msgstr "URL:"
 
-#: src/muuli_wdr.cpp:2740 src/muuli_wdr.cpp:2933
+#: src/muuli_wdr.cpp:2744 src/muuli_wdr.cpp:2937
 msgid "Update now"
 msgstr "Jetzt aktualisieren"
 
-#: src/muuli_wdr.cpp:2743
+#: src/muuli_wdr.cpp:2747
 msgid "Auto-update ipfilter at startup"
 msgstr "IP-Filter beim Start automatisch aktualisieren"
 
-#: src/muuli_wdr.cpp:2747
+#: src/muuli_wdr.cpp:2751
 msgid "Filtering Level:"
 msgstr "Filterstufe:"
 
-#: src/muuli_wdr.cpp:2753
+#: src/muuli_wdr.cpp:2757
 msgid "Always filter LAN IPs"
 msgstr "LAN-IP-Adressen immer filtern"
 
-#: src/muuli_wdr.cpp:2756
+#: src/muuli_wdr.cpp:2760
 msgid "Paranoid handling of non-matching IPs"
 msgstr "Paranoides Handhaben nicht-passender IP-Adressen"
 
-#: src/muuli_wdr.cpp:2758
+#: src/muuli_wdr.cpp:2762
 msgid "Rejects a packet when its source IP differs from the IP the client claims (an anti-spoofing check). Disable only if it causes connection problems."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2760
+#: src/muuli_wdr.cpp:2764
 msgid "Use system-wide ipfilter.dat if available"
 msgstr "Benutze systemweite ipfilter.dat, wenn verfügbar."
 
-#: src/muuli_wdr.cpp:2761
+#: src/muuli_wdr.cpp:2765
 msgid "If there's no local ipfilter.dat found, allow usage of a system-wide ipfilter file."
 msgstr "Erlaube die Benutzung der systemweiten ipfilter-Datei, falls keine lokale ipfilter.dat gefunden wird."
 
-#: src/muuli_wdr.cpp:2778
+#: src/muuli_wdr.cpp:2782
 msgid "Enable Online-Signature"
 msgstr "Online-Signatur aktivieren"
 
-#: src/muuli_wdr.cpp:2780
+#: src/muuli_wdr.cpp:2784
 msgid "Enables the writing of the OS file, which can be used by external apps to create signatures and the like."
 msgstr "Aktiviert das Schreiben der Online-Signaturdatei, die von externen Programmen verwendet werden kann, um Signaturen o.ä. zu erstellen."
 
-#: src/muuli_wdr.cpp:2784
+#: src/muuli_wdr.cpp:2788
 msgid "Update Frequency (Secs):"
 msgstr "Aktualisierungsintervall (Sekunden):"
 
-#: src/muuli_wdr.cpp:2787
+#: src/muuli_wdr.cpp:2791
 msgid "Change the frequency (in seconds) of Online Signature updates."
 msgstr "Ändern des Online-Signatur-Aktualisierungsintervalls (in Sekunden)."
 
-#: src/muuli_wdr.cpp:2795
+#: src/muuli_wdr.cpp:2799
 msgid "Save online signature file in: "
 msgstr "Speichere Online-Signatur-Datei in:"
 
-#: src/muuli_wdr.cpp:2801
+#: src/muuli_wdr.cpp:2805
 msgid "Click here to select the directory containing the the Online Signature files."
 msgstr "Hier klicken, um das Verzeichnis mit den Dateien für die Online-Signatur auszuwählen."
 
-#: src/muuli_wdr.cpp:2834
+#: src/muuli_wdr.cpp:2838
 msgid "Show country flags for clients"
 msgstr "Landesflaggen für Clients anzeigen"
 
-#: src/muuli_wdr.cpp:2835
+#: src/muuli_wdr.cpp:2839
 msgid "Render the country flag column in the transfers, queue and search views. Requires a valid MMDB GeoIP database (see below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2840
+#: src/muuli_wdr.cpp:2844
 #, fuzzy
 msgid "Database"
 msgstr "Datenrate:"
 
-#: src/muuli_wdr.cpp:2856
+#: src/muuli_wdr.cpp:2860
 #, fuzzy
 msgid "Source:"
 msgstr "Quellen"
 
-#: src/muuli_wdr.cpp:2859
+#: src/muuli_wdr.cpp:2863
 msgid "DB-IP (free, no account)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2860
+#: src/muuli_wdr.cpp:2864
 msgid "MaxMind GeoLite2 (free, account required)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2861
+#: src/muuli_wdr.cpp:2865
 msgid "Custom URL"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2864
+#: src/muuli_wdr.cpp:2868
 msgid "Choose which provider supplies the GeoIP MMDB database. DB-IP is the default - no account required. MaxMind requires a free account + license key. Use Custom URL to point at any other MMDB host (e.g. a local mirror)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2881
+#: src/muuli_wdr.cpp:2885
 msgid ""
 "No configuration required.\n"
 "\n"
@@ -4877,11 +4877,11 @@ msgid ""
 "License: Creative Commons BY 4.0 - https://creativecommons.org/licenses/by/4.0/"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2894
+#: src/muuli_wdr.cpp:2898
 msgid "License key:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2900
+#: src/muuli_wdr.cpp:2904
 msgid ""
 "Sign up for a free MaxMind account, then generate a License Key:\n"
 "https://www.maxmind.com/en/geolite2/signup\n"
@@ -4891,224 +4891,224 @@ msgid ""
 "Requires attribution and account registration; refresh at least every 30 days."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2915
+#: src/muuli_wdr.cpp:2919
 #, fuzzy
 msgid "Download URL:"
 msgstr "Download: "
 
-#: src/muuli_wdr.cpp:2921
+#: src/muuli_wdr.cpp:2925
 msgid ""
 "Must point to an .mmdb file or a .gz / .tar.gz containing one.\n"
 "URL may include credentials (https://user:pass@host/...).\n"
 "License and attribution terms are set by the upstream URL - you are responsible."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2934
+#: src/muuli_wdr.cpp:2938
 msgid "Download the GeoIP database from the selected source."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2936
+#: src/muuli_wdr.cpp:2940
 #, fuzzy
 msgid "Auto-update on startup"
 msgstr "IP-Filter beim Start automatisch aktualisieren"
 
-#: src/muuli_wdr.cpp:2937
+#: src/muuli_wdr.cpp:2941
 msgid "Re-download the GeoIP database from the selected source every time aMule starts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2960
+#: src/muuli_wdr.cpp:2964
 msgid "Filter incoming messages (except current chat):"
 msgstr "Eingehende Nachrichten filtern (außer momentanen Chats):"
 
-#: src/muuli_wdr.cpp:2962
+#: src/muuli_wdr.cpp:2966
 msgid "Filter all messages"
 msgstr "Filtere alle Nachrichten"
 
-#: src/muuli_wdr.cpp:2964
+#: src/muuli_wdr.cpp:2968
 msgid "Filter messages from people not on your friend list"
 msgstr "Filtere Nachrichten von Benutzern, die nicht auf deiner Freundesliste stehen"
 
-#: src/muuli_wdr.cpp:2966
+#: src/muuli_wdr.cpp:2970
 msgid "Filter messages from unknown clients"
 msgstr "Filtere Nachrichten von unbekannten Clients"
 
-#: src/muuli_wdr.cpp:2968
+#: src/muuli_wdr.cpp:2972
 msgid "Filter messages containing (use ',' as separator):"
 msgstr "Filtere Nachrichten, die folgende Worte enthalten (benutze ',' als Trenner):"
 
-#: src/muuli_wdr.cpp:2971 src/muuli_wdr.cpp:2982
+#: src/muuli_wdr.cpp:2975 src/muuli_wdr.cpp:2986
 msgid "add here the words amule should filter and block messages including it"
 msgstr "Hier die Worte eingeben, die aMule filtern soll, und um Nachrichten abzuweisen, in denen sie vorkommen"
 
-#: src/muuli_wdr.cpp:2973
+#: src/muuli_wdr.cpp:2977
 msgid "Show received messages in the log"
 msgstr "Zeige empfangene Nachrichten im Log an"
 
-#: src/muuli_wdr.cpp:2976
+#: src/muuli_wdr.cpp:2980
 msgid "Comments"
 msgstr "Kommentare"
 
-#: src/muuli_wdr.cpp:2979
+#: src/muuli_wdr.cpp:2983
 msgid "Filter comments containing (use ',' as separator):"
 msgstr "Filtere Komentare, die folgende Worte enthalten (benutze ',' als Trenner):"
 
-#: src/muuli_wdr.cpp:3004
+#: src/muuli_wdr.cpp:3008
 msgid "Enable Proxy"
 msgstr "Proxy aktivieren"
 
-#: src/muuli_wdr.cpp:3005
+#: src/muuli_wdr.cpp:3009
 msgid "Enable/disable proxy support"
 msgstr "Aktiviere/Deaktiviere Proxy-Unterstützung"
 
-#: src/muuli_wdr.cpp:3008
+#: src/muuli_wdr.cpp:3012
 msgid "Proxy type:"
 msgstr "Proxy-Typ:"
 
-#: src/muuli_wdr.cpp:3019
+#: src/muuli_wdr.cpp:3023
 msgid "Proxy host:"
 msgstr "Proxy-Host:"
 
-#: src/muuli_wdr.cpp:3022
+#: src/muuli_wdr.cpp:3026
 msgid "The proxy host name"
 msgstr "Der Hostname des Proxy"
 
-#: src/muuli_wdr.cpp:3024
+#: src/muuli_wdr.cpp:3028
 msgid "Proxy port:"
 msgstr "Proxy-Port:"
 
-#: src/muuli_wdr.cpp:3027
+#: src/muuli_wdr.cpp:3031
 msgid "The proxy port"
 msgstr "Der Port des Proxy"
 
-#: src/muuli_wdr.cpp:3029
+#: src/muuli_wdr.cpp:3033
 msgid "Enable authentication"
 msgstr "Authentifizierung aktivieren"
 
-#: src/muuli_wdr.cpp:3030
+#: src/muuli_wdr.cpp:3034
 msgid "Enable/disable username/password authentication"
 msgstr "Aktiviere/Deaktiviere Authentifizierung mit Benutzername/Passwort"
 
-#: src/muuli_wdr.cpp:3033
+#: src/muuli_wdr.cpp:3037
 msgid "Username: "
 msgstr "Benutzername:"
 
-#: src/muuli_wdr.cpp:3036
+#: src/muuli_wdr.cpp:3040
 msgid "The username to use to connect to the proxy"
 msgstr "Der Benutzername, um sich beim Proxy anzumelden"
 
-#: src/muuli_wdr.cpp:3038
+#: src/muuli_wdr.cpp:3042
 msgid "Password:"
 msgstr "Passwort:"
 
-#: src/muuli_wdr.cpp:3041
+#: src/muuli_wdr.cpp:3045
 msgid "The password to use to connect to the proxy"
 msgstr "Proxy-Verbindungspasswort"
 
-#: src/muuli_wdr.cpp:3060
+#: src/muuli_wdr.cpp:3064
 msgid "Connect to:"
 msgstr "Verbinde zu:"
 
-#: src/muuli_wdr.cpp:3069
+#: src/muuli_wdr.cpp:3073
 msgid "Login to remote amule"
 msgstr "Beim entfernten aMule anmelden"
 
-#: src/muuli_wdr.cpp:3074
+#: src/muuli_wdr.cpp:3078
 msgid "User name"
 msgstr "Benutzername"
 
-#: src/muuli_wdr.cpp:3085
+#: src/muuli_wdr.cpp:3089
 msgid "Remember those settings"
 msgstr "Diese Einstellungen speichern"
 
-#: src/muuli_wdr.cpp:3088
+#: src/muuli_wdr.cpp:3092
 msgid "Force ZLIB compression"
 msgstr "ZLIB-Kompression erzwingen"
 
-#: src/muuli_wdr.cpp:3112
+#: src/muuli_wdr.cpp:3116
 msgid "Enable Verbose Debug-Logging."
 msgstr "Aktiviere ausführliche Debug-Protokollierung"
 
-#: src/muuli_wdr.cpp:3114
+#: src/muuli_wdr.cpp:3118
 msgid "Only to Logfile"
 msgstr "Nur in Logdatei"
 
-#: src/muuli_wdr.cpp:3116
+#: src/muuli_wdr.cpp:3120
 msgid "Message Categories:"
 msgstr "Nachrichtenkategorien:"
 
-#: src/muuli_wdr.cpp:3140 src/PartFileConvertDlg.cpp:160
+#: src/muuli_wdr.cpp:3144 src/PartFileConvertDlg.cpp:160
 msgid "Waiting..."
 msgstr "Wartend..."
 
-#: src/muuli_wdr.cpp:3160
+#: src/muuli_wdr.cpp:3164
 msgid "Add imports"
 msgstr "Füge Importe hinzu"
 
-#: src/muuli_wdr.cpp:3163
+#: src/muuli_wdr.cpp:3167
 msgid "Retry selected"
 msgstr "Versuche Ausgewähltes noch einmal"
 
-#: src/muuli_wdr.cpp:3165
+#: src/muuli_wdr.cpp:3169
 msgid "Remove selected"
 msgstr "Auswahl entfernen"
 
-#: src/muuli_wdr.cpp:3228
+#: src/muuli_wdr.cpp:3232
 msgid "Event Types"
 msgstr "Ereignisarten"
 
-#: src/muuli_wdr.cpp:3247
+#: src/muuli_wdr.cpp:3251
 msgid "Statistics and queued clients for selected file(s) : Session / All time"
 msgstr "Statistiken und Clients in der Warteschlange für ausgewählte Datei(en): Sitzung / Insgesamt"
 
-#: src/muuli_wdr.cpp:3271
+#: src/muuli_wdr.cpp:3275
 msgid "Active Uploads"
 msgstr "Aktive Uploads"
 
-#: src/muuli_wdr.cpp:3285
+#: src/muuli_wdr.cpp:3289
 msgid "Percent of total files"
 msgstr "Prozent aller Dateien"
 
-#: src/muuli_wdr.cpp:3337
+#: src/muuli_wdr.cpp:3341
 msgid "Show Clients for"
 msgstr "Clients anzeigen für"
 
-#: src/muuli_wdr.cpp:3339
+#: src/muuli_wdr.cpp:3343
 msgid "All files"
 msgstr "Alle Dateien"
 
-#: src/muuli_wdr.cpp:3342
+#: src/muuli_wdr.cpp:3346
 msgid "Selected files"
 msgstr "Ausgewählte Dateien"
 
-#: src/muuli_wdr.cpp:3345
+#: src/muuli_wdr.cpp:3349
 msgid "Active uploads only"
 msgstr "Nur aktive Uploads"
 
-#: src/muuli_wdr.cpp:3352
+#: src/muuli_wdr.cpp:3356
 msgid "Reload:"
 msgstr "Aktualisieren:"
 
-#: src/muuli_wdr.cpp:3356
+#: src/muuli_wdr.cpp:3360
 msgid "Reload your shared files"
 msgstr "Freigegebene Dateien neu laden"
 
-#: src/muuli_wdr.cpp:3419
+#: src/muuli_wdr.cpp:3423
 msgid "Send"
 msgstr "Senden"
 
-#: src/muuli_wdr.cpp:3420
+#: src/muuli_wdr.cpp:3424
 msgid "Sends the specified message."
 msgstr "Sendet die angegebene Nachricht."
 
-#: src/muuli_wdr.cpp:3424
+#: src/muuli_wdr.cpp:3428
 msgid "Close this chat-session."
 msgstr "Schließe diese Chat-Sitzung."
 
-#: src/muuli_wdr.cpp:3447
+#: src/muuli_wdr.cpp:3451
 msgid "Connect to any server and/or Kad"
 msgstr "Mit irgendeinem Server und/oder Kad verbinden"
 
-#: src/muuli_wdr.cpp:3453 src/SharedFilesCtrl.cpp:142 src/Statistics.cpp:941
+#: src/muuli_wdr.cpp:3457 src/SharedFilesCtrl.cpp:142 src/Statistics.cpp:941
 msgid "Shared Files"
 msgstr "Freigaben"
 
@@ -5744,35 +5744,35 @@ msgstr ""
 "aMule funktioniert auch hervorragend, ohne\n"
 "dass diese Einstellungen verändert werden."
 
-#: src/PrefsUnifiedDlg.cpp:647
+#: src/PrefsUnifiedDlg.cpp:656
 #, c-format
 msgid "Failed to connect Cfg to widget with the ID %d and key %s"
 msgstr "Verbindung von Einstellung zu Steuerelement mit ID %d und Schlüssel %s fehlgeschlagen."
 
-#: src/PrefsUnifiedDlg.cpp:695
+#: src/PrefsUnifiedDlg.cpp:704
 #, c-format
 msgid "Failed to transfer data from Cfg to Widget with the ID %d and key %s"
 msgstr "Datentransfer von Einstellung zu Steuerelement mit ID %d und Schlüssel %s fehlgeschlagen."
 
-#: src/PrefsUnifiedDlg.cpp:801
+#: src/PrefsUnifiedDlg.cpp:810
 msgid "The type of proxy you are connecting to"
 msgstr "Der Typ des Proxy, zu dem du verbindest"
 
-#: src/PrefsUnifiedDlg.cpp:1020
+#: src/PrefsUnifiedDlg.cpp:1029
 #, c-format
 msgid "Failed to transfer data from Widget to Cfg with the ID %d and key %s"
 msgstr "Datentransfer von Steuerelement zu Einstellung mit ID %d und Schlüssel %s fehlgeschlagen."
 
-#: src/PrefsUnifiedDlg.cpp:1103
+#: src/PrefsUnifiedDlg.cpp:1112
 #, fuzzy
 msgid "No password set."
 msgstr "Prüfe Passwort\n"
 
-#: src/PrefsUnifiedDlg.cpp:1132
+#: src/PrefsUnifiedDlg.cpp:1141
 msgid "Guest access needs a password. Type one in the guest password field, or untick Enable guest access."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1144
+#: src/PrefsUnifiedDlg.cpp:1153
 msgid ""
 "aMule must be restarted to enable these changes:\n"
 "\n"
@@ -5780,41 +5780,41 @@ msgstr ""
 "aMule muss neu gestartet werden, um diese Änderungen zu übernehmen:\n"
 "\n"
 
-#: src/PrefsUnifiedDlg.cpp:1151
+#: src/PrefsUnifiedDlg.cpp:1160
 msgid "- TCP port changed.\n"
 msgstr "- TCP-Port geändert.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1156
+#: src/PrefsUnifiedDlg.cpp:1165
 msgid "- UDP port changed.\n"
 msgstr "- UDP-Port geändert.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1161
+#: src/PrefsUnifiedDlg.cpp:1170
 #, fuzzy
 msgid "- Network interface binding changed.\n"
 msgstr "- Schnittstelle der externen Verbindung geändert.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1166
+#: src/PrefsUnifiedDlg.cpp:1175
 msgid "- External connect port changed.\n"
 msgstr "- Port externer Verbindung geändert.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1170
+#: src/PrefsUnifiedDlg.cpp:1179
 msgid "- External connect acceptance changed.\n"
 msgstr "- Akzeptanz externer Verbindung geändert.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1174
+#: src/PrefsUnifiedDlg.cpp:1183
 msgid "- External connect interface changed.\n"
 msgstr "- Schnittstelle der externen Verbindung geändert.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1178
+#: src/PrefsUnifiedDlg.cpp:1187
 msgid "- Protocol obfuscation support changed.\n"
 msgstr "- Unterstützung für Protokollverschleierung geändert.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1193
+#: src/PrefsUnifiedDlg.cpp:1202
 #, fuzzy
 msgid "- amuleapi settings changed.\n"
 msgstr "- Sprache geändert.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1202
+#: src/PrefsUnifiedDlg.cpp:1211
 msgid ""
 "Your Auto-update server list is empty.\n"
 "'Auto-update server list at startup' will be disabled."
@@ -5822,7 +5822,7 @@ msgstr ""
 "Die Auto-Update-Serverliste ist leer.\n"
 "'Serverliste beim Programmstart aktualisieren' wird deaktiviert."
 
-#: src/PrefsUnifiedDlg.cpp:1213
+#: src/PrefsUnifiedDlg.cpp:1222
 msgid ""
 "You have enabled external connections but have not specified a password.\n"
 "External connections cannot be enabled unless a valid password is specified."
@@ -5830,33 +5830,33 @@ msgstr ""
 "Du hast die externen Verbindungen aktiviert, aber kein Passwort angegeben.\n"
 "Externe Verbindungen können nur aktiviert werden, wenn ein gültiges Passwort angegeben wird."
 
-#: src/PrefsUnifiedDlg.cpp:1246
+#: src/PrefsUnifiedDlg.cpp:1255
 #, c-format
 msgid "The amuleapi password could not be saved: %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1276
+#: src/PrefsUnifiedDlg.cpp:1285
 msgid "- Language changed.\n"
 msgstr "- Sprache geändert.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1281
+#: src/PrefsUnifiedDlg.cpp:1290
 msgid "- Temp folder changed.\n"
 msgstr "- Temp-Verzeichnis geändert.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1286
+#: src/PrefsUnifiedDlg.cpp:1295
 msgid "- ED2K network enabled.\n"
 msgstr "- ED2k-Netzwerk aktiviert.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1319
+#: src/PrefsUnifiedDlg.cpp:1328
 msgid "The shared-file exclusion pattern is not a valid regular expression. The filter has been left disabled."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1321 src/PrefsUnifiedDlg.cpp:1921
+#: src/PrefsUnifiedDlg.cpp:1330 src/PrefsUnifiedDlg.cpp:1930
 #, fuzzy
 msgid "Invalid regular expression"
 msgstr "Ungültige Protokollversion."
 
-#: src/PrefsUnifiedDlg.cpp:1398
+#: src/PrefsUnifiedDlg.cpp:1407
 msgid ""
 "Both eD2k and Kad network are disabled.\n"
 "You won't be able to connect until you enable at least one of them."
@@ -5864,7 +5864,7 @@ msgstr ""
 "Beide Netzwerke, eD2k und Kad, sind deaktiviert.\n"
 "Mindestens eins davon muss aktiviert sein, um sich verbinden zu können."
 
-#: src/PrefsUnifiedDlg.cpp:1403
+#: src/PrefsUnifiedDlg.cpp:1412
 msgid ""
 "Kad will not start if your UDP port is disabled.\n"
 "Enable UDP port or disable Kad."
@@ -5872,7 +5872,7 @@ msgstr ""
 "Kad wird nicht starten, solange der UDP-Port deaktiviert ist.\n"
 "Bitte UDP-Port aktivieren, oder Kad ausschalten."
 
-#: src/PrefsUnifiedDlg.cpp:1459
+#: src/PrefsUnifiedDlg.cpp:1468
 msgid ""
 "\n"
 "You MUST restart aMule now.\n"
@@ -5882,71 +5882,71 @@ msgstr ""
 "aMule MUSS jetzt neu gestartet werden.\n"
 "Wenn du jetzt nicht neu startest, beklage dich nicht, wenn irgendwas übles passiert.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1524
+#: src/PrefsUnifiedDlg.cpp:1533
 msgid "Could not register aMule for autostart at login. The autostart store may be read-only."
 msgstr "Konnte aMule nicht für Autostart registrieren. Der Ort dafür könnte nicht beschreibbar sein."
 
-#: src/PrefsUnifiedDlg.cpp:1526
+#: src/PrefsUnifiedDlg.cpp:1535
 msgid "Could not remove the autostart-at-login entry."
 msgstr "Konnte den Autostart-Bei-Login Eintrag nicht entfernen."
 
-#: src/PrefsUnifiedDlg.cpp:1527
+#: src/PrefsUnifiedDlg.cpp:1536
 msgid "Autostart"
 msgstr "Autostart"
 
-#: src/PrefsUnifiedDlg.cpp:1542
+#: src/PrefsUnifiedDlg.cpp:1551
 msgid "Register file type"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1542
+#: src/PrefsUnifiedDlg.cpp:1551
 msgid "Register URL handler"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1550
+#: src/PrefsUnifiedDlg.cpp:1559
 #, c-format
 msgid "aMule only handles eD2k-compatible magnets. If you replace the current magnet handler (%s), BitTorrent magnet links will stop working - aMule cannot download BitTorrent content. Continue?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1555
+#: src/PrefsUnifiedDlg.cpp:1564
 #, c-format
 msgid "Another application currently opens .emulecollection files (%s). Replace it with aMule?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1560
+#: src/PrefsUnifiedDlg.cpp:1569
 #, c-format
 msgid "Another application is currently the default handler for these links (%s). Replace it with aMule?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1585
+#: src/PrefsUnifiedDlg.cpp:1594
 #, fuzzy
 msgid "Could not register aMule for .emulecollection files. The registration store may be read-only."
 msgstr "Konnte aMule nicht für Autostart registrieren. Der Ort dafür könnte nicht beschreibbar sein."
 
-#: src/PrefsUnifiedDlg.cpp:1587
+#: src/PrefsUnifiedDlg.cpp:1596
 #, fuzzy
 msgid "Could not remove the file type registration."
 msgstr "Konnte den Autostart-Bei-Login Eintrag nicht entfernen."
 
-#: src/PrefsUnifiedDlg.cpp:1589
+#: src/PrefsUnifiedDlg.cpp:1598
 #, fuzzy
 msgid "Could not register aMule as the URL handler. The registration store may be read-only."
 msgstr "Konnte aMule nicht für Autostart registrieren. Der Ort dafür könnte nicht beschreibbar sein."
 
-#: src/PrefsUnifiedDlg.cpp:1591
+#: src/PrefsUnifiedDlg.cpp:1600
 #, fuzzy
 msgid "Could not remove the URL handler registration."
 msgstr "Konnte den Autostart-Bei-Login Eintrag nicht entfernen."
 
-#: src/PrefsUnifiedDlg.cpp:1661 src/PrefsUnifiedDlg.cpp:1688
+#: src/PrefsUnifiedDlg.cpp:1670 src/PrefsUnifiedDlg.cpp:1697
 #, fuzzy
 msgid "The web server and aMule API require external connections to be enabled."
 msgstr "Passwort eingestellt und externe Verbindungen aktiviert."
 
-#: src/PrefsUnifiedDlg.cpp:1671
+#: src/PrefsUnifiedDlg.cpp:1680
 msgid "The aMule web server is deprecated. Consider running the aMule API instead."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1735
+#: src/PrefsUnifiedDlg.cpp:1744
 msgid ""
 "Your Auto-update servers list is in blank.\n"
 "Please fill in at least one URL to point to a valid server.met file.\n"
@@ -5956,66 +5956,66 @@ msgstr ""
 "Bitte gib mindestens eine URL zu einer gültigen server.met ein.\n"
 "Drücke dazu den Knopf \"Liste\" neben diesem Kontrollkästchen."
 
-#: src/PrefsUnifiedDlg.cpp:1876
+#: src/PrefsUnifiedDlg.cpp:1885
 msgid "Temporary files"
 msgstr "Temporäre Dateien"
 
-#: src/PrefsUnifiedDlg.cpp:1881
+#: src/PrefsUnifiedDlg.cpp:1890
 msgid "Incoming files"
 msgstr "Fertige Dateien"
 
-#: src/PrefsUnifiedDlg.cpp:1886
+#: src/PrefsUnifiedDlg.cpp:1895
 msgid "Online Signatures"
 msgstr "Online-Signaturen"
 
-#: src/PrefsUnifiedDlg.cpp:1899
+#: src/PrefsUnifiedDlg.cpp:1908
 #, c-format
 msgid "Choose a folder for %s"
 msgstr "Wähle einen Ordner für %s"
 
-#: src/PrefsUnifiedDlg.cpp:1923
+#: src/PrefsUnifiedDlg.cpp:1932
 #, fuzzy, c-format
 msgid "Would exclude %u of %u shared file"
 msgid_plural "Would exclude %u of %u shared files"
 msgstr[0] "%i bekannte freigegebene Datei gefunden"
 msgstr[1] "%i bekannte freigegebene Dateien gefunden"
 
-#: src/PrefsUnifiedDlg.cpp:1940
+#: src/PrefsUnifiedDlg.cpp:1949
 msgid "Browse for videoplayer"
 msgstr "Suche nach einem Videoplayer"
 
-#: src/PrefsUnifiedDlg.cpp:1944
+#: src/PrefsUnifiedDlg.cpp:1953
 msgid "Select browser"
 msgstr "Browser-Wahl"
 
-#: src/PrefsUnifiedDlg.cpp:1948
+#: src/PrefsUnifiedDlg.cpp:1957
 #, fuzzy
 msgid "Select ffprobe binary"
 msgstr "Browser-Wahl"
 
-#: src/PrefsUnifiedDlg.cpp:1954
+#: src/PrefsUnifiedDlg.cpp:1963
 #, c-format
 msgid "Executable%s"
 msgstr "Ausführbar%s"
 
-#: src/PrefsUnifiedDlg.cpp:1988
+#: src/PrefsUnifiedDlg.cpp:1997
 msgid "ffprobe not found on PATH or in the standard install locations. Install ffmpeg (which ships ffprobe) or use Browse to pick a binary manually."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2000
+#: src/PrefsUnifiedDlg.cpp:2009
 msgid "Reset the settings on this page to their default values?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2001
+#: src/PrefsUnifiedDlg.cpp:2010
 #, fuzzy
 msgid "Reset to defaults"
 msgstr "Systemvorgabe"
 
-#: src/PrefsUnifiedDlg.cpp:2028
+#: src/PrefsUnifiedDlg.cpp:2037
 msgid "Edit server list"
 msgstr "Serverliste bearbeiten"
 
-#: src/PrefsUnifiedDlg.cpp:2029
+#: src/PrefsUnifiedDlg.cpp:2038
 msgid ""
 "Add here URL's to download server.met files.\n"
 "Only one url on each line."
@@ -6023,115 +6023,115 @@ msgstr ""
 "Hier URL's für server.met-Dateien eintragen.\n"
 "Nur eine URL pro Zeile!"
 
-#: src/PrefsUnifiedDlg.cpp:2084
+#: src/PrefsUnifiedDlg.cpp:2093
 msgid "IP2Country update failed"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2229 src/PrefsUnifiedDlg.cpp:2260
+#: src/PrefsUnifiedDlg.cpp:2238 src/PrefsUnifiedDlg.cpp:2269
 msgid "Data by MaxMind GeoLite2"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2231 src/PrefsUnifiedDlg.cpp:2262
+#: src/PrefsUnifiedDlg.cpp:2240 src/PrefsUnifiedDlg.cpp:2271
 #, fuzzy
 msgid "Custom source"
 msgstr "vollständige Quellen"
 
-#: src/PrefsUnifiedDlg.cpp:2233 src/PrefsUnifiedDlg.cpp:2264
+#: src/PrefsUnifiedDlg.cpp:2242 src/PrefsUnifiedDlg.cpp:2273
 msgid "Data by DB-IP.com"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2284
+#: src/PrefsUnifiedDlg.cpp:2293
 #, fuzzy, c-format
 msgid "Status: Loaded%s"
 msgstr "Status:"
 
-#: src/PrefsUnifiedDlg.cpp:2286
+#: src/PrefsUnifiedDlg.cpp:2295
 #, fuzzy, c-format
 msgid "Status: Loaded%s - %s"
 msgstr "Status:"
 
-#: src/PrefsUnifiedDlg.cpp:2290
+#: src/PrefsUnifiedDlg.cpp:2299
 msgid "Status: Failed to load - click 'Update now' to refresh."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2292
+#: src/PrefsUnifiedDlg.cpp:2301
 msgid "Status: Not found - click 'Update now' to download."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2350 src/PrefsUnifiedDlg.cpp:2374
+#: src/PrefsUnifiedDlg.cpp:2359 src/PrefsUnifiedDlg.cpp:2383
 #, c-format
 msgid "Update delay: %d second"
 msgid_plural "Update delay: %d seconds"
 msgstr[0] "Aktualisierungsverzögerung: %d Sekunde"
 msgstr[1] "Aktualisierungsverzögerung: %d Sekunden"
 
-#: src/PrefsUnifiedDlg.cpp:2358
+#: src/PrefsUnifiedDlg.cpp:2367
 #, c-format
 msgid "Time for average graph: %d minute"
 msgid_plural "Time for average graph: %d minutes"
 msgstr[0] "Zeit für Durchschnittslinie: %d Minute"
 msgstr[1] "Zeit für Durchschnittslinie: %d Minuten"
 
-#: src/PrefsUnifiedDlg.cpp:2367
+#: src/PrefsUnifiedDlg.cpp:2376
 #, c-format
 msgid "Connections Graph Scale: %d"
 msgstr "Verbindungsgraphenskala: %d"
 
-#: src/PrefsUnifiedDlg.cpp:2382
+#: src/PrefsUnifiedDlg.cpp:2391
 #, c-format
 msgid "File Buffer Size: %d byte"
 msgid_plural "File Buffer Size: %d bytes"
 msgstr[0] "Dateipuffergröße: %d Byte"
 msgstr[1] "Dateipuffergröße: %d Bytes"
 
-#: src/PrefsUnifiedDlg.cpp:2392
+#: src/PrefsUnifiedDlg.cpp:2401
 #, c-format
 msgid "Upload Queue Size: %d client"
 msgid_plural "Upload Queue Size: %d clients"
 msgstr[0] "Upload-Warteschlangengröße: %d Client"
 msgstr[1] "Upload-Warteschlangengröße: %d Clients"
 
-#: src/PrefsUnifiedDlg.cpp:2402
+#: src/PrefsUnifiedDlg.cpp:2411
 #, c-format
 msgid "Server connection refresh interval: %d minute"
 msgid_plural "Server connection refresh interval: %d minutes"
 msgstr[0] "Server-Wiederverbindungsintervall: %d Minute"
 msgstr[1] "Server-Wiederverbindungsintervall: %d Minuten"
 
-#: src/PrefsUnifiedDlg.cpp:2407
+#: src/PrefsUnifiedDlg.cpp:2416
 msgid "Server connection refresh interval: Disabled"
 msgstr "Server-Wiederverbindungsintervall: Aus"
 
-#: src/PrefsUnifiedDlg.cpp:2451
+#: src/PrefsUnifiedDlg.cpp:2460
 msgid "disabled"
 msgstr "deaktiviert"
 
-#: src/PrefsUnifiedDlg.cpp:2477
+#: src/PrefsUnifiedDlg.cpp:2486
 #, c-format
 msgid "Execute command on '%s' event"
 msgstr "Führe Kommando beim '%s' Ereignis aus"
 
-#: src/PrefsUnifiedDlg.cpp:2484
+#: src/PrefsUnifiedDlg.cpp:2493
 msgid "Enable command execution on core"
 msgstr "Aktiviere Befehlsausführung im Kern"
 
-#: src/PrefsUnifiedDlg.cpp:2496
+#: src/PrefsUnifiedDlg.cpp:2505
 msgid "Core command:"
 msgstr "Kern-Befehl:"
 
-#: src/PrefsUnifiedDlg.cpp:2512
+#: src/PrefsUnifiedDlg.cpp:2521
 msgid "Enable command execution on GUI"
 msgstr "Aktiviere Befehlsausführung in GUI"
 
-#: src/PrefsUnifiedDlg.cpp:2524
+#: src/PrefsUnifiedDlg.cpp:2533
 msgid "GUI command:"
 msgstr "GUI-Befehl:"
 
-#: src/PrefsUnifiedDlg.cpp:2540
+#: src/PrefsUnifiedDlg.cpp:2549
 msgid "The following variables will be replaced:"
 msgstr "Die folgenden Variablen werden ersetzt:"
 
-#: src/PrefsUnifiedDlg.cpp:2708
+#: src/PrefsUnifiedDlg.cpp:2717
 msgid ""
 "The following folders look like system or sensitive locations:\n"
 "\n"
@@ -6139,37 +6139,37 @@ msgstr ""
 "Die folgenden Ordner sehen nach System oder Sensiblen Daten aus.\n"
 "\n"
 
-#: src/PrefsUnifiedDlg.cpp:2713
+#: src/PrefsUnifiedDlg.cpp:2722
 msgid "Sharing them recursively will publish every file underneath on the eD2k/Kad networks. Do you really want to do this?"
 msgstr "Rekursives Teilen würde jede Datei im eD2k/Kad Netzwerk verfügbar machen. Willst du das wirklich?"
 
-#: src/PrefsUnifiedDlg.cpp:2716
+#: src/PrefsUnifiedDlg.cpp:2725
 msgid "Confirm shared folders"
 msgstr "Freigegebene Ordner bestätigen"
 
-#: src/PrefsUnifiedDlg.cpp:2744
+#: src/PrefsUnifiedDlg.cpp:2753
 msgid "Reloading shared files..."
 msgstr "Freigegebene Dateien neu laden..."
 
-#: src/PrefsUnifiedDlg.cpp:2745
+#: src/PrefsUnifiedDlg.cpp:2754
 msgid "Scanning for subdirectories..."
 msgstr "Suche nach Unterverzeichnissen..."
 
-#: src/PrefsUnifiedDlg.cpp:2746
+#: src/PrefsUnifiedDlg.cpp:2755
 msgid "Updating shared folders"
 msgstr "Freigegebene Ordner werden aktualisiert"
 
-#: src/PrefsUnifiedDlg.cpp:2773
+#: src/PrefsUnifiedDlg.cpp:2782
 #, c-format
 msgid "Scanned %u directories..."
 msgstr "%u Verzeichnisse durchsucht..."
 
-#: src/PrefsUnifiedDlg.cpp:2823
+#: src/PrefsUnifiedDlg.cpp:2832
 #, c-format
 msgid "Reloading shared files: %u files scanned"
 msgstr "Liste freigegebener Dateien neu laden: %u Dateien gelesen"
 
-#: src/PrefsUnifiedDlg.cpp:2873
+#: src/PrefsUnifiedDlg.cpp:2882
 #, fuzzy
 msgid "Shared folder"
 msgstr "Freigegebene Ordner"
@@ -7861,12 +7861,12 @@ msgstr "Kategorie entfernen"
 msgid "Hashset requested for unknown file: %s"
 msgstr "Prüfsummensatz angefordert für unbekannte Datei '%s'"
 
-#: src/UploadQueue.cpp:618
+#: src/UploadQueue.cpp:627
 #, c-format
 msgid "Resuming uploads of file: %s"
 msgstr "Wiederaufnahme des Hochladens der Datei '%s'."
 
-#: src/UploadQueue.cpp:634
+#: src/UploadQueue.cpp:643
 #, c-format
 msgid "Suspending upload of file: %s"
 msgstr "Aussetzen des Hochladens der Datei '%s'."

--- a/po/de.po
+++ b/po/de.po
@@ -13,7 +13,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-28 08:06+0200\n"
+"POT-Creation-Date: 2026-07-28 10:19+0200\n"
 "PO-Revision-Date: 2026-07-27 11:34+0000\n"
 "Last-Translator: Werner Mahr <werner@vollstreckernet.de>\n"
 "Language-Team: German <>\n"
@@ -150,7 +150,7 @@ msgstr "Installieren"
 msgid "Not now"
 msgstr "Nicht jetzt"
 
-#: src/AppImageIntegration.cpp:422 src/amuleDlg.cpp:600
+#: src/AppImageIntegration.cpp:422 src/amuleDlg.cpp:665
 msgid "Don't ask again"
 msgstr "Nicht erneut fragen"
 
@@ -227,7 +227,7 @@ msgid "Killing amuleweb instance with pid '%d' ... "
 msgstr "Erzwinge Beenden der amuleweb-Instanz mit pid '%d' ... "
 
 #: src/amule.cpp:336 src/amule.cpp:349 src/ClientRef.cpp:180
-#: src/SearchDlg.cpp:880 src/ServerListCtrl.cpp:98
+#: src/SearchDlg.cpp:1041 src/ServerListCtrl.cpp:98
 msgid "Failed"
 msgstr "Fehlgeschlagen"
 
@@ -581,30 +581,68 @@ msgstr "Kann keine Pid-Datei erstellen"
 msgid "ERROR: %s"
 msgstr "FEHLER: %s"
 
-#: src/amuleDlg.cpp:236
+#: src/amuleDlg.cpp:250
 #, c-format
 msgid "This is aMule %s based on eMule."
 msgstr "Dies ist aMule %s, basierend auf eMule."
 
-#: src/amuleDlg.cpp:237
+#: src/amuleDlg.cpp:251
 #, c-format
 msgid "Running on %s"
 msgstr "Läuft auf %s"
 
-#: src/amuleDlg.cpp:239
+#: src/amuleDlg.cpp:253
 msgid "Visit https://github.com/amule-org/amule/releases/latest to check if a new version is available."
 msgstr "Besuche https://github.com/amule-org/amule/releases/latest um zu sehen, ob eine neue Version verfügbar ist."
 
-#: src/amuleDlg.cpp:268
+#: src/amuleDlg.cpp:282
 msgid "FATAL ERROR: Failed to create Timer"
 msgstr "UNBEHEBBARER FEHLER: Es konnte kein Zeitgeber erstellt werden."
 
-#: src/amuleDlg.cpp:592
+#: src/amuleDlg.cpp:361 src/amuleDlg.cpp:1787 src/amuleDlg.cpp:2033
+#: src/muuli_wdr.cpp:1492 src/muuli_wdr.cpp:3418
+msgid "Networks"
+msgstr "Netzwerke"
+
+#: src/amuleDlg.cpp:362 src/amuleDlg.cpp:1793 src/muuli_wdr.cpp:3419
+msgid "Searches"
+msgstr "Suchen"
+
+#: src/amuleDlg.cpp:363 src/amuleDlg.cpp:1799 src/DownloadListCtrl.cpp:740
+#: src/muuli_wdr.cpp:392 src/muuli_wdr.cpp:1585 src/muuli_wdr.cpp:3420
+#: src/Statistics.cpp:829
+msgid "Downloads"
+msgstr "Downloads"
+
+#: src/amuleDlg.cpp:364 src/amuleDlg.cpp:1805 src/muuli_wdr.cpp:3294
+msgid "Shared files"
+msgstr "Freigegebene Dateien"
+
+#: src/amuleDlg.cpp:365 src/amuleDlg.cpp:1811 src/muuli_wdr.cpp:2926
+#: src/muuli_wdr.cpp:3376 src/muuli_wdr.cpp:3423
+msgid "Messages"
+msgstr "Nachrichten"
+
+#: src/amuleDlg.cpp:366 src/amuleDlg.cpp:1817 src/muuli_wdr.cpp:3424
+#: src/PrefsUnifiedDlg.cpp:312 src/Statistics.cpp:779 src/Statistics.cpp:1235
+msgid "Statistics"
+msgstr "Statistiken"
+
+#: src/amuleDlg.cpp:368 src/amuleDlg.cpp:1824 src/muuli_wdr.cpp:3426
+#: src/PrefsUnifiedDlg.cpp:328 src/utils/wxCas/src/wxcasprefs.cpp:39
+msgid "Preferences"
+msgstr "Einstellungen"
+
+#: src/amuleDlg.cpp:371
+msgid "Navigate"
+msgstr ""
+
+#: src/amuleDlg.cpp:657
 #, fuzzy
 msgid "New version available"
 msgstr "Nicht verfügbar"
 
-#: src/amuleDlg.cpp:596
+#: src/amuleDlg.cpp:661
 #, fuzzy, c-format
 msgid ""
 "A new version of aMule (%s) is available.\n"
@@ -614,217 +652,184 @@ msgid ""
 "Would you like to open the download page?"
 msgstr "Die neueste Version kann man immer auf https://github.com/amule-org/amule/releases/latest finden."
 
-#: src/amuleDlg.cpp:678
+#: src/amuleDlg.cpp:743
 msgid "aMule dialog destroyed"
 msgstr "aMule Dialog zerstört."
 
-#: src/amuleDlg.cpp:701 src/DataToText.cpp:68 src/IPFilter.cpp:547
+#: src/amuleDlg.cpp:766 src/DataToText.cpp:68 src/IPFilter.cpp:547
 msgid "Connecting"
 msgstr "Verbinden"
 
-#: src/amuleDlg.cpp:893
+#: src/amuleDlg.cpp:958
 msgid "eD2k: Connecting"
 msgstr "eD2k: Baue Verbindung auf"
 
-#: src/amuleDlg.cpp:897
+#: src/amuleDlg.cpp:962
 msgid "eD2k: Disconnected"
 msgstr "eD2k: Verbindung getrennt"
 
-#: src/amuleDlg.cpp:903
+#: src/amuleDlg.cpp:968
 msgid "Kad: Firewalled"
 msgstr "Kad: Firewalled"
 
-#: src/amuleDlg.cpp:907
+#: src/amuleDlg.cpp:972
 msgid "Kad: Connected"
 msgstr "Kad: Verbunden"
 
-#: src/amuleDlg.cpp:912
+#: src/amuleDlg.cpp:977
 msgid "Kad: Connecting"
 msgstr "Kad: Baue Verbindung auf"
 
-#: src/amuleDlg.cpp:916
+#: src/amuleDlg.cpp:981
 msgid "Kad: Off"
 msgstr "Kad: aus"
 
-#: src/amuleDlg.cpp:964 src/DownloadListCtrl.cpp:505
+#: src/amuleDlg.cpp:1029 src/DownloadListCtrl.cpp:505
 #: src/DownloadListCtrl.cpp:749 src/FriendListCtrl.cpp:180
 #: src/muuli_wdr.cpp:731 src/muuli_wdr.cpp:782 src/muuli_wdr.cpp:846
-#: src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2224 src/muuli_wdr.cpp:2309
-#: src/muuli_wdr.cpp:3057 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
+#: src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2231 src/muuli_wdr.cpp:2316
+#: src/muuli_wdr.cpp:3064 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
 #: src/ServerListCtrl.cpp:606 src/TransferWnd.cpp:378
 #: src/utils/wxCas/src/wxcasprefs.cpp:235
 msgid "Cancel"
 msgstr "Abbruch"
 
-#: src/amuleDlg.cpp:965
+#: src/amuleDlg.cpp:1030
 msgid "Stop the current connection attempts"
 msgstr "Beendet die derzeitigen Verbindungsversuche"
 
-#: src/amuleDlg.cpp:970 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976
-#: src/muuli_wdr.cpp:2447
+#: src/amuleDlg.cpp:1035 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976
+#: src/muuli_wdr.cpp:2454
 msgid "Disconnect"
 msgstr "Trennen"
 
-#: src/amuleDlg.cpp:971
+#: src/amuleDlg.cpp:1036
 msgid "Disconnect from the currently connected networks"
 msgstr "Von den momentan verbundenen Netzwerken trennen."
 
-#: src/amuleDlg.cpp:976 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979
-#: src/muuli_wdr.cpp:2602 src/muuli_wdr.cpp:3054 src/muuli_wdr.cpp:3409
+#: src/amuleDlg.cpp:1041 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979
+#: src/muuli_wdr.cpp:2609 src/muuli_wdr.cpp:3061 src/muuli_wdr.cpp:3416
 msgid "Connect"
 msgstr "Verbinden"
 
-#: src/amuleDlg.cpp:977
+#: src/amuleDlg.cpp:1042
 msgid "Connect to the currently enabled networks"
 msgstr "Mit den aktuell aktivierten Netzwerken verbinden."
 
-#: src/amuleDlg.cpp:1089
+#: src/amuleDlg.cpp:1154
 #, c-format
 msgid "Up: %.1f%s (%.1f) | Down: %.1f%s (%.1f)"
 msgstr "Up: %.1f%s (%.1f) | Down: %.1f%s (%.1f)"
 
-#: src/amuleDlg.cpp:1091 src/amuleDlg.cpp:1093 src/amuleDlg.cpp:1097
-#: src/amuleDlg.cpp:1099 src/amuleDlg.cpp:1110 src/amuleDlg.cpp:1112
+#: src/amuleDlg.cpp:1156 src/amuleDlg.cpp:1158 src/amuleDlg.cpp:1162
+#: src/amuleDlg.cpp:1164 src/amuleDlg.cpp:1175 src/amuleDlg.cpp:1177
 #: src/MuleTrayIcon.cpp:796 src/MuleTrayIcon.cpp:799
 msgid " MB/s"
 msgstr " MB/s"
 
-#: src/amuleDlg.cpp:1091 src/amuleDlg.cpp:1093 src/amuleDlg.cpp:1097
-#: src/amuleDlg.cpp:1099 src/amuleDlg.cpp:1110 src/amuleDlg.cpp:1112
+#: src/amuleDlg.cpp:1156 src/amuleDlg.cpp:1158 src/amuleDlg.cpp:1162
+#: src/amuleDlg.cpp:1164 src/amuleDlg.cpp:1175 src/amuleDlg.cpp:1177
 #: src/MuleTrayIcon.cpp:796 src/MuleTrayIcon.cpp:799
 #: src/utils/wxCas/src/wxcasframe.cpp:1041
 msgid " kB/s"
 msgstr " kB/s"
 
-#: src/amuleDlg.cpp:1096
+#: src/amuleDlg.cpp:1161
 #, c-format
 msgid "Up: %.1f%s | Down: %.1f%s"
 msgstr "Up: %.1f%s | Down: %.1f%s"
 
-#: src/amuleDlg.cpp:1128
+#: src/amuleDlg.cpp:1193
 #, c-format
 msgid "aMule (%s | Connected)"
 msgstr "aMule (%s | Verbunden)"
 
-#: src/amuleDlg.cpp:1130
+#: src/amuleDlg.cpp:1195
 #, c-format
 msgid "aMule (%s | Disconnected)"
 msgstr "aMule (%s | Getrennt)"
 
-#: src/amuleDlg.cpp:1183
+#: src/amuleDlg.cpp:1248
 #, c-format
 msgid "Do you really want to exit %s?"
 msgstr "%s wirklich beenden?"
 
-#: src/amuleDlg.cpp:1185
+#: src/amuleDlg.cpp:1250
 msgid "Exit confirmation"
 msgstr "Beenden bestätigen"
 
-#: src/amuleDlg.cpp:1548
+#: src/amuleDlg.cpp:1613
 msgid "Launch Command: "
 msgstr "Startbefehl: "
 
-#: src/amuleDlg.cpp:1567 src/muuli_wdr.cpp:1971 src/Preferences.cpp:951
+#: src/amuleDlg.cpp:1632 src/muuli_wdr.cpp:1978 src/Preferences.cpp:952
 msgid "- default -"
 msgstr "- Voreinstellung -"
 
-#: src/amuleDlg.cpp:1595
+#: src/amuleDlg.cpp:1660
 #, c-format
 msgid "Skin directory '%s' does not exist"
 msgstr "Skin-Verzeichnis '%s' existiert nicht"
 
-#: src/amuleDlg.cpp:1598
+#: src/amuleDlg.cpp:1663
 #, c-format
 msgid "WARNING: Unable to open skin file '%s' for read"
 msgstr "WARNUNG: Öffnen der Skin-Datei '%s' zum Lesen nicht möglich"
 
-#: src/amuleDlg.cpp:1722 src/amuleDlg.cpp:1968 src/muuli_wdr.cpp:1485
-#: src/muuli_wdr.cpp:3411
-msgid "Networks"
-msgstr "Netzwerke"
-
-#: src/amuleDlg.cpp:1726 src/muuli_wdr.cpp:3411
+#: src/amuleDlg.cpp:1791 src/muuli_wdr.cpp:3418
 msgid "Networks Window"
 msgstr "Übersicht der verwendeten Netzwerke"
 
-#: src/amuleDlg.cpp:1728 src/muuli_wdr.cpp:3412
-msgid "Searches"
-msgstr "Suchen"
-
-#: src/amuleDlg.cpp:1732 src/muuli_wdr.cpp:3412
+#: src/amuleDlg.cpp:1797 src/muuli_wdr.cpp:3419
 msgid "Searches Window"
 msgstr "Dateisuche in den verbundenen Netzwerken"
 
-#: src/amuleDlg.cpp:1734 src/DownloadListCtrl.cpp:740 src/muuli_wdr.cpp:392
-#: src/muuli_wdr.cpp:1578 src/muuli_wdr.cpp:3413 src/Statistics.cpp:829
-msgid "Downloads"
-msgstr "Downloads"
-
-#: src/amuleDlg.cpp:1738 src/muuli_wdr.cpp:3413
+#: src/amuleDlg.cpp:1803 src/muuli_wdr.cpp:3420
 msgid "Downloads Window"
 msgstr "Download-Fenster"
 
-#: src/amuleDlg.cpp:1740 src/muuli_wdr.cpp:3287
-msgid "Shared files"
-msgstr "Freigegebene Dateien"
-
-#: src/amuleDlg.cpp:1744 src/muuli_wdr.cpp:3415
+#: src/amuleDlg.cpp:1809 src/muuli_wdr.cpp:3422
 msgid "Shared Files Window"
 msgstr "Übersicht der freigegebenen Dateien"
 
-#: src/amuleDlg.cpp:1746 src/muuli_wdr.cpp:2919 src/muuli_wdr.cpp:3369
-#: src/muuli_wdr.cpp:3416
-msgid "Messages"
-msgstr "Nachrichten"
-
-#: src/amuleDlg.cpp:1750 src/muuli_wdr.cpp:3416
+#: src/amuleDlg.cpp:1815 src/muuli_wdr.cpp:3423
 msgid "Messages Window"
 msgstr "Nachrichten, Chat, Freundesliste"
 
-#: src/amuleDlg.cpp:1752 src/muuli_wdr.cpp:3417 src/PrefsUnifiedDlg.cpp:312
-#: src/Statistics.cpp:779 src/Statistics.cpp:1235
-msgid "Statistics"
-msgstr "Statistiken"
-
-#: src/amuleDlg.cpp:1756 src/muuli_wdr.cpp:3417
+#: src/amuleDlg.cpp:1821 src/muuli_wdr.cpp:3424
 msgid "Statistics Graph Window"
 msgstr "Diverse Statistiken über Up- und Download, Verbindungen, Clients usw."
 
-#: src/amuleDlg.cpp:1759 src/muuli_wdr.cpp:3419 src/PrefsUnifiedDlg.cpp:328
-#: src/utils/wxCas/src/wxcasprefs.cpp:39
-msgid "Preferences"
-msgstr "Einstellungen"
-
-#: src/amuleDlg.cpp:1763 src/muuli_wdr.cpp:3419
+#: src/amuleDlg.cpp:1828 src/muuli_wdr.cpp:3426
 msgid "Preferences Settings Window"
 msgstr "Fenster für Einstellungen"
 
-#: src/amuleDlg.cpp:1766 src/muuli_wdr.cpp:3420
+#: src/amuleDlg.cpp:1831 src/muuli_wdr.cpp:3427
 msgid "Import"
 msgstr "Importiere"
 
-#: src/amuleDlg.cpp:1770 src/muuli_wdr.cpp:3420
+#: src/amuleDlg.cpp:1835 src/muuli_wdr.cpp:3427
 msgid "The partfile importer tool"
 msgstr "Das Importierwerkzeug für Part-Dateien"
 
-#: src/amuleDlg.cpp:1773 src/muuli_wdr.cpp:3421
+#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3428
 #: src/utils/aLinkCreator/src/alcframe.cpp:262
 msgid "About"
 msgstr "Über"
 
-#: src/amuleDlg.cpp:1773 src/muuli_wdr.cpp:3421
+#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3428
 msgid "About/Help"
 msgstr "Über/Hilfe - Hinweise zur Version usw."
 
-#: src/amuleDlg.cpp:1971
+#: src/amuleDlg.cpp:2036
 msgid "eD2k network"
 msgstr "eD2k-Netzwerk"
 
-#: src/amuleDlg.cpp:1974
+#: src/amuleDlg.cpp:2039
 msgid "Kad network"
 msgstr "Kad-Netzwerk"
 
-#: src/amuleDlg.cpp:1974
+#: src/amuleDlg.cpp:2039
 msgid "No network"
 msgstr "Kein Netzwerk"
 
@@ -1359,19 +1364,19 @@ msgstr "Auto [Ho]"
 msgid "Very low"
 msgstr "Sehr niedrig"
 
-#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:743 src/muuli_wdr.cpp:2275
+#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:743 src/muuli_wdr.cpp:2282
 #: src/ServerListCtrl.cpp:263 src/ServerListCtrl.cpp:456
 #: src/SharedFilesCtrl.cpp:145
 msgid "Low"
 msgstr "Niedrig"
 
-#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:744 src/muuli_wdr.cpp:2276
+#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:744 src/muuli_wdr.cpp:2283
 #: src/ServerListCtrl.cpp:266 src/ServerListCtrl.cpp:457
 #: src/SharedFilesCtrl.cpp:146
 msgid "Normal"
 msgstr "Normal"
 
-#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:745 src/muuli_wdr.cpp:2277
+#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:745 src/muuli_wdr.cpp:2284
 #: src/ServerListCtrl.cpp:269 src/ServerListCtrl.cpp:458
 #: src/SharedFilesCtrl.cpp:147
 msgid "High"
@@ -1463,8 +1468,8 @@ msgstr "Lokaler Server"
 msgid "Remote Server"
 msgstr "Entfernter Server"
 
-#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3174
-#: src/SearchDlg.cpp:111 src/TextClient.cpp:911
+#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3181
+#: src/SearchDlg.cpp:119 src/TextClient.cpp:911
 msgid "Kad"
 msgstr "Kad"
 
@@ -1534,7 +1539,7 @@ msgstr "Teil"
 msgid "Size"
 msgstr "Größe"
 
-#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3241
+#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3248
 msgid "Transferred"
 msgstr "Übertragen"
 
@@ -1592,7 +1597,7 @@ msgstr ""
 "Rückmeldung von: %s (%s)\n"
 "\n"
 
-#: src/DownloadListCtrl.cpp:746 src/muuli_wdr.cpp:2278
+#: src/DownloadListCtrl.cpp:746 src/muuli_wdr.cpp:2285
 #: src/SharedFilesCtrl.cpp:150
 msgid "Auto"
 msgstr "Automatisch"
@@ -1630,7 +1635,7 @@ msgid "Extended Options"
 msgstr "Erweiterte Optionen"
 
 #: src/DownloadListCtrl.cpp:770 src/DownloadListCtrl.cpp:822
-#: src/muuli_wdr.cpp:1789
+#: src/muuli_wdr.cpp:1796
 msgid "Preview"
 msgstr "Vorschau"
 
@@ -2339,19 +2344,19 @@ msgstr ""
 msgid "eD2k"
 msgstr "eD2k"
 
-#: src/FirstRunWizard.cpp:349 src/muuli_wdr.cpp:1488
+#: src/FirstRunWizard.cpp:349 src/muuli_wdr.cpp:1495
 msgid "Kademlia"
 msgstr "Kademlia"
 
-#: src/FirstRunWizard.cpp:359 src/muuli_wdr.cpp:1416
+#: src/FirstRunWizard.cpp:359 src/muuli_wdr.cpp:1423
 msgid "Standard TCP Port "
 msgstr "Standard-TCP-Port"
 
-#: src/FirstRunWizard.cpp:365 src/muuli_wdr.cpp:1428
+#: src/FirstRunWizard.cpp:365 src/muuli_wdr.cpp:1435
 msgid "Extended UDP port (Kad / global search) "
 msgstr "Erweiterter UDP-Port (Kad / globale Suche)"
 
-#: src/FirstRunWizard.cpp:377 src/muuli_wdr.cpp:1435
+#: src/FirstRunWizard.cpp:377 src/muuli_wdr.cpp:1442
 msgid "Enable UPnP for router port forwarding"
 msgstr "Aktiviere UPnP für Router-Port-Weiterleitung"
 
@@ -2378,7 +2383,7 @@ msgstr ""
 msgid "Your peer lists are already in place - nothing to download."
 msgstr "Die Datei %s wird bereits heruntergeladen"
 
-#: src/FirstRunWizard.cpp:434 src/muuli_wdr.cpp:1533
+#: src/FirstRunWizard.cpp:434 src/muuli_wdr.cpp:1540
 msgid "Auto-update server list at startup"
 msgstr "Serverliste beim Programmstart aktualisieren"
 
@@ -2424,23 +2429,23 @@ msgid ""
 "want downloads on a different (e.g. larger) disk."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:549 src/FirstRunWizard.cpp:611 src/muuli_wdr.cpp:1701
+#: src/FirstRunWizard.cpp:549 src/FirstRunWizard.cpp:611 src/muuli_wdr.cpp:1708
 msgid "Destination folder for downloads"
 msgstr "Zielverzeichnis für Downloads."
 
-#: src/FirstRunWizard.cpp:553 src/FirstRunWizard.cpp:569 src/muuli_wdr.cpp:1342
-#: src/muuli_wdr.cpp:1359 src/muuli_wdr.cpp:1676 src/muuli_wdr.cpp:1707
-#: src/muuli_wdr.cpp:1719 src/muuli_wdr.cpp:2762
+#: src/FirstRunWizard.cpp:553 src/FirstRunWizard.cpp:569 src/muuli_wdr.cpp:1349
+#: src/muuli_wdr.cpp:1366 src/muuli_wdr.cpp:1683 src/muuli_wdr.cpp:1714
+#: src/muuli_wdr.cpp:1726 src/muuli_wdr.cpp:2769
 #: src/utils/aLinkCreator/src/alcframe.cpp:135
 #: src/utils/wxCas/src/wxcasprefs.cpp:52 src/utils/wxCas/src/wxcasprefs.cpp:118
 msgid "Browse"
 msgstr "Durchsuchen"
 
-#: src/FirstRunWizard.cpp:559 src/muuli_wdr.cpp:1712
+#: src/FirstRunWizard.cpp:559 src/muuli_wdr.cpp:1719
 msgid "(All files in this folder are shared with other peers)"
 msgstr "(Alle Dateien in diesem Ordner werden mit anderen Nutzern geteilt)"
 
-#: src/FirstRunWizard.cpp:565 src/FirstRunWizard.cpp:624 src/muuli_wdr.cpp:1714
+#: src/FirstRunWizard.cpp:565 src/FirstRunWizard.cpp:624 src/muuli_wdr.cpp:1721
 msgid "Folder for temporary download files"
 msgstr "Verzeichnis für temporäre Downloaddateien"
 
@@ -2471,7 +2476,7 @@ msgstr "Konnte Freundes-Liste 'emfriends.met' nicht schreiben!"
 msgid "CRITICAL - no client on StartChatSession"
 msgstr "KRITISCH - kein Client bei StartChatSession"
 
-#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2668 src/muuli_wdr.cpp:3345
+#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2675 src/muuli_wdr.cpp:3352
 msgid "Friends"
 msgstr "Freunde"
 
@@ -2856,7 +2861,7 @@ msgstr "Tauschverhältnis"
 msgid "Uploaded"
 msgstr "Hochgeladen"
 
-#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3225
+#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3232
 msgid "Requested"
 msgstr "Angefordert"
 
@@ -2980,7 +2985,7 @@ msgid "WARNING: "
 msgstr "WARNUNG: "
 
 #: src/MuleNotebook.cpp:179 src/muuli_wdr.cpp:817 src/muuli_wdr.cpp:1229
-#: src/muuli_wdr.cpp:3129 src/muuli_wdr.cpp:3385
+#: src/muuli_wdr.cpp:3136 src/muuli_wdr.cpp:3392
 msgid "Close"
 msgstr "Schließen"
 
@@ -2993,12 +2998,12 @@ msgstr "Ausschneiden"
 msgid "Copy"
 msgstr "Kopieren"
 
-#: src/MuleTextCtrl.cpp:88
+#: src/MuleTextCtrl.cpp:88 src/SearchDlg.cpp:261
 msgid "Paste"
 msgstr "Einfügen"
 
 #: src/MuleTextCtrl.cpp:89 src/muuli_wdr.cpp:358 src/muuli_wdr.cpp:757
-#: src/muuli_wdr.cpp:2352 src/muuli_wdr.cpp:2371 src/muuli_wdr.cpp:2393
+#: src/muuli_wdr.cpp:2359 src/muuli_wdr.cpp:2378 src/muuli_wdr.cpp:2400
 #: src/utils/aLinkCreator/src/alcframe.cpp:142
 msgid "Clear"
 msgstr "Leeren"
@@ -3089,8 +3094,8 @@ msgid "Exit"
 msgstr "Schließen"
 
 #: src/MuleTrayIcon.cpp:579 src/MuleTrayIcon.cpp:945 src/MuleTrayIcon.cpp:965
-#: src/muuli_wdr.cpp:1391 src/muuli_wdr.cpp:1399 src/muuli_wdr.cpp:1406
-#: src/muuli_wdr.cpp:1835 src/muuli_wdr.cpp:1841 src/OtherFunctions.cpp:91
+#: src/muuli_wdr.cpp:1398 src/muuli_wdr.cpp:1406 src/muuli_wdr.cpp:1413
+#: src/muuli_wdr.cpp:1842 src/muuli_wdr.cpp:1848 src/OtherFunctions.cpp:91
 #: src/StatisticsDlg.cpp:93 src/StatisticsDlg.cpp:95
 msgid "kB/s"
 msgstr "kB/s"
@@ -3261,7 +3266,7 @@ msgstr "Name:"
 msgid "Type"
 msgstr "Suchtyp"
 
-#: src/muuli_wdr.cpp:215 src/SearchDlg.cpp:110 src/SearchListCtrl.cpp:853
+#: src/muuli_wdr.cpp:215 src/SearchDlg.cpp:118 src/SearchListCtrl.cpp:853
 msgid "Local"
 msgstr "Lokal"
 
@@ -3332,7 +3337,7 @@ msgstr "Bytes"
 msgid "KB"
 msgstr "KB"
 
-#: src/muuli_wdr.cpp:274 src/muuli_wdr.cpp:293 src/muuli_wdr.cpp:1620
+#: src/muuli_wdr.cpp:274 src/muuli_wdr.cpp:293 src/muuli_wdr.cpp:1627
 #: src/OtherFunctions.cpp:64
 msgid "MB"
 msgstr "MB"
@@ -3349,7 +3354,7 @@ msgstr "Höchstgröße"
 msgid "Availability"
 msgstr "Verfügbarkeit"
 
-#: src/muuli_wdr.cpp:312 src/muuli_wdr.cpp:398 src/muuli_wdr.cpp:3290
+#: src/muuli_wdr.cpp:312 src/muuli_wdr.cpp:398 src/muuli_wdr.cpp:3297
 msgid "Filter:"
 msgstr "Filter:"
 
@@ -3381,7 +3386,7 @@ msgstr "Bittet Kad-Peers, die bereits geantwortet haben, die Suche zu erweitern.
 msgid "Stop"
 msgstr "Stopp"
 
-#: src/muuli_wdr.cpp:348 src/muuli_wdr.cpp:1385 src/SearchListCtrl.cpp:732
+#: src/muuli_wdr.cpp:348 src/muuli_wdr.cpp:1392 src/SearchListCtrl.cpp:732
 msgid "Download"
 msgstr "Download"
 
@@ -3412,8 +3417,8 @@ msgstr "Dateiquellen:"
 #: src/muuli_wdr.cpp:1160 src/muuli_wdr.cpp:1167 src/muuli_wdr.cpp:1172
 #: src/muuli_wdr.cpp:1179 src/muuli_wdr.cpp:1184 src/muuli_wdr.cpp:1191
 #: src/muuli_wdr.cpp:1205 src/muuli_wdr.cpp:1212 src/muuli_wdr.cpp:1217
-#: src/muuli_wdr.cpp:1224 src/muuli_wdr.cpp:3227 src/muuli_wdr.cpp:3235
-#: src/muuli_wdr.cpp:3243
+#: src/muuli_wdr.cpp:1224 src/muuli_wdr.cpp:3234 src/muuli_wdr.cpp:3242
+#: src/muuli_wdr.cpp:3250
 msgid "N/A"
 msgstr "Nicht verfügbar"
 
@@ -3558,7 +3563,7 @@ msgstr ""
 msgid "Album :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:685 src/muuli_wdr.cpp:2247
+#: src/muuli_wdr.cpp:685 src/muuli_wdr.cpp:2254
 msgid "Title :"
 msgstr "Titel:"
 
@@ -3667,7 +3672,7 @@ msgstr "Benutzername:"
 msgid "Userhash :"
 msgstr "Benutzerprüfsumme:"
 
-#: src/muuli_wdr.cpp:895 src/muuli_wdr.cpp:1741 src/muuli_wdr.cpp:2442
+#: src/muuli_wdr.cpp:895 src/muuli_wdr.cpp:1748 src/muuli_wdr.cpp:2449
 #: src/utils/aLinkCreator/src/alcframe.cpp:137
 msgid "Add"
 msgstr "Hinzufügen"
@@ -3676,15 +3681,15 @@ msgstr "Hinzufügen"
 msgid "Download-Speed"
 msgstr "Download-Geschwindigkeit"
 
-#: src/muuli_wdr.cpp:954 src/muuli_wdr.cpp:989 src/muuli_wdr.cpp:2546
+#: src/muuli_wdr.cpp:954 src/muuli_wdr.cpp:989 src/muuli_wdr.cpp:2553
 msgid "Current"
 msgstr "Aktuell"
 
-#: src/muuli_wdr.cpp:962 src/muuli_wdr.cpp:997 src/muuli_wdr.cpp:2554
+#: src/muuli_wdr.cpp:962 src/muuli_wdr.cpp:997 src/muuli_wdr.cpp:2561
 msgid "Running average"
 msgstr "gleitender Mittelwert"
 
-#: src/muuli_wdr.cpp:970 src/muuli_wdr.cpp:1005 src/muuli_wdr.cpp:2562
+#: src/muuli_wdr.cpp:970 src/muuli_wdr.cpp:1005 src/muuli_wdr.cpp:2569
 msgid "Session average"
 msgstr "Sitzungsdurchschnitt"
 
@@ -3696,7 +3701,7 @@ msgstr "Upload-Geschwindigkeit"
 msgid "Connections"
 msgstr "Verbindungen"
 
-#: src/muuli_wdr.cpp:1024 src/muuli_wdr.cpp:1860
+#: src/muuli_wdr.cpp:1024 src/muuli_wdr.cpp:1867
 msgid "Active downloads"
 msgstr "Aktive Downloads"
 
@@ -3704,7 +3709,7 @@ msgstr "Aktive Downloads"
 msgid "Active connections (1:1)"
 msgstr "Aktive Verbindungen (1:1)"
 
-#: src/muuli_wdr.cpp:1040 src/muuli_wdr.cpp:1861
+#: src/muuli_wdr.cpp:1040 src/muuli_wdr.cpp:1868
 msgid "Active uploads"
 msgstr "Aktive Uploads"
 
@@ -3820,8 +3825,8 @@ msgstr "Dies ist der Name, den andere Benutzer sehen, wenn sie mit dir verbunden
 msgid "Language: "
 msgstr "Sprache:"
 
-#: src/muuli_wdr.cpp:1257 src/muuli_wdr.cpp:1323 src/muuli_wdr.cpp:1327
-#: src/muuli_wdr.cpp:1330
+#: src/muuli_wdr.cpp:1257 src/muuli_wdr.cpp:1330 src/muuli_wdr.cpp:1334
+#: src/muuli_wdr.cpp:1337
 msgid "The delay before showing tool-tips."
 msgstr "Verzögerung vor dem Anzeigen der Tooltips. "
 
@@ -3899,260 +3904,269 @@ msgstr "Benachrichtigungen anzeigen, wenn Downloads abgeschlossen sind"
 msgid "Enabling this will make aMule to show notifications when finished downloading."
 msgstr "Wenn aktiviert, zeigt aMule Benachrichtigungen an, sobald Downloads abgeschlossen sind."
 
-#: src/muuli_wdr.cpp:1322
+#: src/muuli_wdr.cpp:1323
+#, fuzzy
+msgid "Remember search history"
+msgstr "Diese Einstellungen speichern"
+
+#: src/muuli_wdr.cpp:1324
+msgid "Keeps a dropdown list of your past search terms in the Search tab's Name field. This remembers the queries you typed, not the results they returned."
+msgstr ""
+
+#: src/muuli_wdr.cpp:1329
 msgid "Tooltip delay time: "
 msgstr "Tooltip-Verzögerungszeit:"
 
-#: src/muuli_wdr.cpp:1329
+#: src/muuli_wdr.cpp:1336
 msgid "seconds"
 msgstr "Sekunden"
 
-#: src/muuli_wdr.cpp:1333
+#: src/muuli_wdr.cpp:1340
 msgid "Browser Selection"
 msgstr "Browser-Wahl"
 
-#: src/muuli_wdr.cpp:1339
+#: src/muuli_wdr.cpp:1346
 msgid "Enter your browser name here. Leave this field empty to use the system default browser."
 msgstr "Gib den Namen des gewünschten Browsers hier ein. Bei einem leeren Feld wird der voreingestellte Systembrowser benutzt."
 
-#: src/muuli_wdr.cpp:1346
+#: src/muuli_wdr.cpp:1353
 msgid "Open in new tab if possible"
 msgstr "Öffne in neuem Reiter, wenn möglich"
 
-#: src/muuli_wdr.cpp:1348
+#: src/muuli_wdr.cpp:1355
 msgid "Open the web page in a new tab instead of in a new window when possible"
 msgstr "Öffne die Webseite in einem neuen Reiter, statt einem neuen Fenster, wenn möglich"
 
-#: src/muuli_wdr.cpp:1352
+#: src/muuli_wdr.cpp:1359
 msgid "Video Player"
 msgstr "Videoplayer"
 
-#: src/muuli_wdr.cpp:1379
+#: src/muuli_wdr.cpp:1386
 msgid "Bandwidth limits"
 msgstr "Bandbreitenbegrenzungen"
 
-#: src/muuli_wdr.cpp:1393
+#: src/muuli_wdr.cpp:1400
 msgid "Upload"
 msgstr "Upload"
 
-#: src/muuli_wdr.cpp:1401
+#: src/muuli_wdr.cpp:1408
 msgid "Slot Allocation"
 msgstr "Slotzuteilung"
 
-#: src/muuli_wdr.cpp:1410
+#: src/muuli_wdr.cpp:1417
 msgid "Ports"
 msgstr "Ports"
 
-#: src/muuli_wdr.cpp:1420
+#: src/muuli_wdr.cpp:1427
 msgid "This is the standard eD2k port and cannot be disabled."
 msgstr "Dies ist der Standard-eD2k-Port. Er kann nicht deaktiviert werden."
 
-#: src/muuli_wdr.cpp:1423
+#: src/muuli_wdr.cpp:1430
 msgid "UDP port for server requests (TCP+3):"
 msgstr "UDP-Port für Serveranfragen (TCP+3):"
 
-#: src/muuli_wdr.cpp:1425
+#: src/muuli_wdr.cpp:1432
 msgid "4665"
 msgstr "4665"
 
-#: src/muuli_wdr.cpp:1432
+#: src/muuli_wdr.cpp:1439
 msgid "This UDP port is used for extended eD2k requests and Kad network"
 msgstr "Dieser UDP-Port wird für erweiterte ED2k-Anfragen und das Kad-Netzwerk benutzt."
 
-#: src/muuli_wdr.cpp:1439
+#: src/muuli_wdr.cpp:1446
 msgid "UPnP TCP Port (Optional):"
 msgstr "UPnP-TCP-Port (optional):"
 
-#: src/muuli_wdr.cpp:1449
+#: src/muuli_wdr.cpp:1456
 msgid "Bind local address to IP (empty for any):"
 msgstr "Verknüpfe lokale Adresse mit IP (Leer für beliebige):"
 
-#: src/muuli_wdr.cpp:1452
+#: src/muuli_wdr.cpp:1459
 msgid "Advanced users only: If you have multiple network interfaces, enter the address of the interface to which aMule should be bound."
 msgstr "Nur für fortgeschrittene Benutzer: Wenn es mehrere Netzwerkverbindungen gibt, hier die Adresse der Verbindung, mit der aMule verknüpft werden soll, eingeben."
 
-#: src/muuli_wdr.cpp:1455 src/muuli_wdr.cpp:2054
+#: src/muuli_wdr.cpp:1462 src/muuli_wdr.cpp:2061
 #, fuzzy
 msgid "Bind to network interface (empty for any):"
 msgstr "Verknüpfe lokale Adresse mit IP (Leer für beliebige):"
 
-#: src/muuli_wdr.cpp:1468
+#: src/muuli_wdr.cpp:1475
 msgid "Advanced users only: pin all of aMule's traffic to one network interface, chosen from the list or typed in by name (e.g. tun0, eth0, en0) or index. Unlike binding to an IP, this stops traffic leaking out via the default route - useful with a VPN. Requires no elevated privileges."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1474
+#: src/muuli_wdr.cpp:1481
 msgid "Max sources per downloading file:"
 msgstr "Maximale Anzahl Quellen pro heruntergeladener Datei:"
 
-#: src/muuli_wdr.cpp:1478
+#: src/muuli_wdr.cpp:1485
 msgid "Max simultaneous connections:"
 msgstr "Maximale gleichzeitige Verbindungen:"
 
-#: src/muuli_wdr.cpp:1491 src/muuli_wdr.cpp:3169
+#: src/muuli_wdr.cpp:1498 src/muuli_wdr.cpp:3176
 msgid "ED2K"
 msgstr "eD2k"
 
-#: src/muuli_wdr.cpp:1498
+#: src/muuli_wdr.cpp:1505
 msgid "Autoconnect on startup"
 msgstr "Automatisches Verbinden beim Start"
 
-#: src/muuli_wdr.cpp:1501
+#: src/muuli_wdr.cpp:1508
 msgid "Reconnect on loss"
 msgstr "Wiederverbinden nach Trennung"
 
-#: src/muuli_wdr.cpp:1523
+#: src/muuli_wdr.cpp:1530
 msgid "Remove dead server after"
 msgstr "Lösche tote Server nach"
 
-#: src/muuli_wdr.cpp:1524
+#: src/muuli_wdr.cpp:1531
 msgid "Static servers are never removed, even when unreachable."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1528
+#: src/muuli_wdr.cpp:1535
 msgid "retries"
 msgstr "Versuchen"
 
-#: src/muuli_wdr.cpp:1536
+#: src/muuli_wdr.cpp:1543
 msgid "List"
 msgstr "Liste"
 
-#: src/muuli_wdr.cpp:1539
+#: src/muuli_wdr.cpp:1546
 msgid "Update server list when connecting to a server"
 msgstr "Serverliste von verbundenem Server beziehen"
 
-#: src/muuli_wdr.cpp:1542
+#: src/muuli_wdr.cpp:1549
 msgid "Update server list when a client connects"
 msgstr "Serverliste beim Verbinden zu einem Client beziehen"
 
-#: src/muuli_wdr.cpp:1545
+#: src/muuli_wdr.cpp:1552
 msgid "Use priority system"
 msgstr "Benutze Prioritätssystem"
 
-#: src/muuli_wdr.cpp:1549
+#: src/muuli_wdr.cpp:1556
 msgid "Use smart LowID check on connect"
 msgstr "Benutze intelligente Prüfung für niedrige ID beim Verbinden"
 
-#: src/muuli_wdr.cpp:1553
+#: src/muuli_wdr.cpp:1560
 msgid "Safe connect"
 msgstr "Sicheres/langsames Verbinden zu Servern"
 
-#: src/muuli_wdr.cpp:1557
+#: src/muuli_wdr.cpp:1564
 msgid "Autoconnect to servers in static list only"
 msgstr "Automatisches Verbinden nur zu Servern aus der statischen Liste"
 
-#: src/muuli_wdr.cpp:1560
+#: src/muuli_wdr.cpp:1567
 msgid "Set manually added servers to High Priority"
 msgstr "Setze manuell hinzugefügte Server auf hohe Priorität"
 
-#: src/muuli_wdr.cpp:1581
+#: src/muuli_wdr.cpp:1588
 msgid "Add files to download in pause mode"
 msgstr "Neue Dateien dem Download pausiert hinzufügen"
 
-#: src/muuli_wdr.cpp:1583
+#: src/muuli_wdr.cpp:1590
 msgid "Add files to download with auto priority"
 msgstr "Neu hinzugefügte Dateien im Download auf Autopriorität stellen"
 
-#: src/muuli_wdr.cpp:1586
+#: src/muuli_wdr.cpp:1593
 msgid "Try to download first and last chunks first"
 msgstr "Versuche, zuerst die ersten und letzten Dateiteile herunterzuladen"
 
-#: src/muuli_wdr.cpp:1590
+#: src/muuli_wdr.cpp:1597
 msgid "Endgame mode: rotate to faster sources for the final blocks"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1593
+#: src/muuli_wdr.cpp:1600
 msgid "Start next paused file when a file completes"
 msgstr "Starte nächste pausierte Datei, wenn eine Datei fertiggestellt wird"
 
-#: src/muuli_wdr.cpp:1596
+#: src/muuli_wdr.cpp:1603
 msgid "From the same category"
 msgstr "Aus der selben Kategorie"
 
-#: src/muuli_wdr.cpp:1598
+#: src/muuli_wdr.cpp:1605
 msgid "In alphabetic order"
 msgstr "In alphabetischer Reihenfolge"
 
-#: src/muuli_wdr.cpp:1600
+#: src/muuli_wdr.cpp:1607
 msgid "Preallocate disk space for new files"
 msgstr "Reserviere Speicherplatz für neue Dateien"
 
-#: src/muuli_wdr.cpp:1601
+#: src/muuli_wdr.cpp:1608
 msgid "For new files preallocates disk space for the whole file, thus reduces fragmentation"
 msgstr "Reserviert für neue Dateien Speicherplatz für die ganze Datei und reduziert so Fragmentierung."
 
-#: src/muuli_wdr.cpp:1606
+#: src/muuli_wdr.cpp:1613
 msgid "Create new files as sparse files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1607
+#: src/muuli_wdr.cpp:1614
 msgid "A sparse file reserves its full size on disk immediately without writing real data to it -- fast, but unsupported or slow on some filesystems, and free-space accounting stays optimistic while the download is in progress. Turn this off to grow the file only as data arrives."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1612
+#: src/muuli_wdr.cpp:1619
 msgid "Stop downloads when free disk space reaches "
 msgstr "Stoppe Downloads wenn freier Speicherplatz folgenden Wert erreicht:"
 
-#: src/muuli_wdr.cpp:1613
+#: src/muuli_wdr.cpp:1620
 msgid "Select this if you want aMule to check your disk space"
 msgstr "Wähle dies aus, wenn aMule deinen Festplattenplatz prüfen soll"
 
-#: src/muuli_wdr.cpp:1617
+#: src/muuli_wdr.cpp:1624
 msgid "Enter here the min disk space desired."
 msgstr "Hier den minimalen erwünschten Festplattenplatz angeben."
 
-#: src/muuli_wdr.cpp:1623
+#: src/muuli_wdr.cpp:1630
 msgid "Save 10 sources on rare files (< 20 sources)"
 msgstr "Bei seltenen (< 20 Quellen) Dateien zehn Quellen speichern"
 
-#: src/muuli_wdr.cpp:1627 src/Statistics.cpp:790
+#: src/muuli_wdr.cpp:1634 src/Statistics.cpp:790
 msgid "Uploads"
 msgstr "Uploads"
 
-#: src/muuli_wdr.cpp:1630
+#: src/muuli_wdr.cpp:1637
 msgid "Add new shared files with auto priority"
 msgstr "Neue freigegebene Dateien auf Autopriorität stellen"
 
-#: src/muuli_wdr.cpp:1636
+#: src/muuli_wdr.cpp:1643
 msgid "Intelligent Corruption Handling (I.C.H.)"
 msgstr "Intelligente Korruptionsverarbeitung (I.C.H.)"
 
-#: src/muuli_wdr.cpp:1639
+#: src/muuli_wdr.cpp:1646
 msgid "Enable"
 msgstr "Aktiviere"
 
-#: src/muuli_wdr.cpp:1642
+#: src/muuli_wdr.cpp:1649
 msgid "Advanced I.C.H. trusts every hash (not recommended)"
 msgstr "Advanced I.C.H vertraut jeder Prüfsumme (nicht empfohlen)"
 
-#: src/muuli_wdr.cpp:1654 src/PrefsUnifiedDlg.cpp:1910
+#: src/muuli_wdr.cpp:1661 src/PrefsUnifiedDlg.cpp:1910
 msgid "Media metadata extraction"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1658
+#: src/muuli_wdr.cpp:1665
 msgid "Extract length / bitrate / codec from shared audio and video files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1660
+#: src/muuli_wdr.cpp:1667
 msgid "When enabled, aMule runs ffprobe on each shared media file to fill in the Length / Bitrate / Codec columns other clients see when they find the file in a search. Requires ffmpeg (the ffprobe binary) to be installed."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1667
+#: src/muuli_wdr.cpp:1674
 msgid "Path to ffprobe:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1672
+#: src/muuli_wdr.cpp:1679
 msgid "Full path to the ffprobe binary. Leave empty to have aMule auto-detect it on startup."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1680
+#: src/muuli_wdr.cpp:1687
 msgid "Detect"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1681
+#: src/muuli_wdr.cpp:1688
 msgid "Search the standard install locations for an ffprobe binary and fill the path field."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1705
+#: src/muuli_wdr.cpp:1712
 msgid ""
 "Completed downloads are stored here. All files in this folder are automatically shared with other peers.\n"
 "If this folder also holds files you don't want to share, point it at an aMule-only sub-folder."
@@ -4160,674 +4174,674 @@ msgstr ""
 "Vollständige Downloads werden hier gespeichert. Alle Dateien in diesem Ordner werden automatisch geteilt\n"
 ". Falls dieser Ordner Dateien enthält die du nicht teilen willst, wähle einen eigenen Ordner nur für aMule aus."
 
-#: src/muuli_wdr.cpp:1708
+#: src/muuli_wdr.cpp:1715
 msgid "Pick the folder where completed downloads will be stored. All files in that folder will be shared with other peers."
 msgstr "Wähle einen Ordner in dem vollständige Downloads gepeichert werden sollen. Dieser Ordner wird automatisch geteilt."
 
-#: src/muuli_wdr.cpp:1722
+#: src/muuli_wdr.cpp:1729
 msgid "Shared folders"
 msgstr "Freigegebene Ordner"
 
-#: src/muuli_wdr.cpp:1728
+#: src/muuli_wdr.cpp:1735
 msgid "(Folders shared by the core. Enter a path to add one.)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1736
+#: src/muuli_wdr.cpp:1743
 msgid "Absolute path of a folder on the core's machine, e.g. /home/user/shared"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1738 src/PrefsUnifiedDlg.cpp:2794
+#: src/muuli_wdr.cpp:1745 src/PrefsUnifiedDlg.cpp:2794
 msgid "Recursive"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1739
+#: src/muuli_wdr.cpp:1746
 msgid "Share every sub-folder underneath this one, including ones created later."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1743 src/utils/aLinkCreator/src/alcframe.cpp:141
+#: src/muuli_wdr.cpp:1750 src/utils/aLinkCreator/src/alcframe.cpp:141
 msgid "Remove"
 msgstr "Entferne"
 
-#: src/muuli_wdr.cpp:1747
+#: src/muuli_wdr.cpp:1754
 msgid "(Right click on folder icon for recursive share)"
 msgstr "(Rechtsklick auf das Symbol des rekursiv freizugebenden Verzeichnisses)"
 
-#: src/muuli_wdr.cpp:1754
+#: src/muuli_wdr.cpp:1761
 msgid "Share hidden files"
 msgstr "Versteckte Dateien freigeben"
 
-#: src/muuli_wdr.cpp:1760
+#: src/muuli_wdr.cpp:1767
 msgid "Automatically rescan shared folders for changes"
 msgstr "Ornder automatisch auf Änderungen überwachen"
 
-#: src/muuli_wdr.cpp:1766
+#: src/muuli_wdr.cpp:1773
 msgid "Follow symbolic links in shared folders"
 msgstr "Symbolischen Links in geteilten Ordnern folgen"
 
-#: src/muuli_wdr.cpp:1772
+#: src/muuli_wdr.cpp:1779
 msgid "Exclude files matching:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1775
+#: src/muuli_wdr.cpp:1782
 msgid "Wildcard patterns separated by '|', e.g. .DS_Store|Thumbs.db|*.tmp. Files whose name matches are not shared. Matching is case-insensitive."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1779
+#: src/muuli_wdr.cpp:1786
 msgid "Patterns are regular expressions"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1780
+#: src/muuli_wdr.cpp:1787
 msgid "When set, the whole field is one regular expression ('|' is alternation). When unset, it is a list of '|'-separated wildcards."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1790
+#: src/muuli_wdr.cpp:1797
 msgid "Show how many shared files the current pattern would exclude."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1811
+#: src/muuli_wdr.cpp:1818
 msgid "Graphs"
 msgstr "Graphen"
 
-#: src/muuli_wdr.cpp:1814 src/muuli_wdr.cpp:1876
+#: src/muuli_wdr.cpp:1821 src/muuli_wdr.cpp:1883
 msgid "Update delay : 5 secs"
 msgstr "Aktualisierungsverzögerung: 5 Sekunden"
 
-#: src/muuli_wdr.cpp:1818
+#: src/muuli_wdr.cpp:1825
 msgid "Time for average graph: 100 mins"
 msgstr "Durchschnittsgraphen in Minuten berechnen: 100 min"
 
-#: src/muuli_wdr.cpp:1822
+#: src/muuli_wdr.cpp:1829
 msgid "Connections Graph Scale: 100 "
 msgstr "Verbindungsgraphenskalierung: 100"
 
-#: src/muuli_wdr.cpp:1829
+#: src/muuli_wdr.cpp:1836
 msgid "Download graph scale:"
 msgstr "Downloadgraphenskalierung:"
 
-#: src/muuli_wdr.cpp:1837
+#: src/muuli_wdr.cpp:1844
 msgid "Upload graph scale:"
 msgstr "Uploadgraphenskalierung:"
 
-#: src/muuli_wdr.cpp:1847
+#: src/muuli_wdr.cpp:1854
 msgid "Colors: "
 msgstr "Farben: "
 
-#: src/muuli_wdr.cpp:1851
+#: src/muuli_wdr.cpp:1858
 msgid "Background"
 msgstr "Hintergrund"
 
-#: src/muuli_wdr.cpp:1852
+#: src/muuli_wdr.cpp:1859
 msgid "Grid"
 msgstr "Gitter"
 
-#: src/muuli_wdr.cpp:1853
+#: src/muuli_wdr.cpp:1860
 msgid "Download current"
 msgstr "Aktueller Download"
 
-#: src/muuli_wdr.cpp:1854
+#: src/muuli_wdr.cpp:1861
 msgid "Download running average"
 msgstr "Download: Durchschnitt"
 
-#: src/muuli_wdr.cpp:1855
+#: src/muuli_wdr.cpp:1862
 msgid "Download session average"
 msgstr "Download: Sitzungsdurchschnitt"
 
-#: src/muuli_wdr.cpp:1856
+#: src/muuli_wdr.cpp:1863
 msgid "Upload current"
 msgstr "Aktueller Upload"
 
-#: src/muuli_wdr.cpp:1857
+#: src/muuli_wdr.cpp:1864
 msgid "Upload running average"
 msgstr "Upload: Durchschnitt"
 
-#: src/muuli_wdr.cpp:1858
+#: src/muuli_wdr.cpp:1865
 msgid "Upload session average"
 msgstr "Upload: Sitzungsdurchschnitt"
 
-#: src/muuli_wdr.cpp:1859
+#: src/muuli_wdr.cpp:1866
 msgid "Active connections"
 msgstr "Aktive Verbindungen"
 
-#: src/muuli_wdr.cpp:1862
+#: src/muuli_wdr.cpp:1869
 msgid "Systray Icon Speed Bar"
 msgstr "Transferbalken des Symbols im Infobereich"
 
-#: src/muuli_wdr.cpp:1863
+#: src/muuli_wdr.cpp:1870
 msgid "Kad-nodes current"
 msgstr "Momentane Kad-Knoten"
 
-#: src/muuli_wdr.cpp:1864
+#: src/muuli_wdr.cpp:1871
 msgid "Kad-nodes running"
 msgstr "Laufende Kad-Knoten"
 
-#: src/muuli_wdr.cpp:1865
+#: src/muuli_wdr.cpp:1872
 msgid "Kad-nodes session"
 msgstr "Kad-Knoten Sitzung"
 
-#: src/muuli_wdr.cpp:1869 src/muuli_wdr.cpp:2296
+#: src/muuli_wdr.cpp:1876 src/muuli_wdr.cpp:2303
 msgid "Select"
 msgstr "Auswahl"
 
-#: src/muuli_wdr.cpp:1873
+#: src/muuli_wdr.cpp:1880
 msgid "Tree"
 msgstr "Baum"
 
-#: src/muuli_wdr.cpp:1883
+#: src/muuli_wdr.cpp:1890
 msgid "Number of Client Versions shown (0=unlimited)"
 msgstr "Anzahl angezeigter Client-Versionen (0=unbegrenzt)"
 
-#: src/muuli_wdr.cpp:1908
+#: src/muuli_wdr.cpp:1915
 msgid "!!! WARNING !!!"
 msgstr "!!! WARNUNG !!!"
 
-#: src/muuli_wdr.cpp:1923
+#: src/muuli_wdr.cpp:1930
 msgid "Max new connections / 5 secs"
 msgstr "Maximale neue Verbindungen pro 5 Sekunden"
 
-#: src/muuli_wdr.cpp:1925
+#: src/muuli_wdr.cpp:1932
 msgid "Concurrent Kad source lookups"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1927
+#: src/muuli_wdr.cpp:1934
 #, fuzzy
 msgid "Kad source re-search interval (minutes)"
 msgstr "FTP-Aktualisierungsintervall in Minuten"
 
-#: src/muuli_wdr.cpp:1929
+#: src/muuli_wdr.cpp:1936
 #, fuzzy
 msgid "Source re-ask interval (minutes)"
 msgstr "FTP-Aktualisierungsintervall in Minuten"
 
-#: src/muuli_wdr.cpp:1933
+#: src/muuli_wdr.cpp:1940
 msgid "File Buffer Size: 240000 bytes"
 msgstr "Dateipuffergröße: 240000 Bytes"
 
-#: src/muuli_wdr.cpp:1937
+#: src/muuli_wdr.cpp:1944
 msgid "Use MMAP: memory-mapped file access (lower memory use)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1938
+#: src/muuli_wdr.cpp:1945
 msgid "Maps part files into memory instead of buffering them on the heap, lowering the process memory footprint. May reduce download speed on some disks; best for memory-constrained or upload-heavy hosts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1940
+#: src/muuli_wdr.cpp:1947
 msgid "Upload Queue Size: 5000 clients"
 msgstr "Upload-Warteschlangengröße: 5000 Clients"
 
-#: src/muuli_wdr.cpp:1944
+#: src/muuli_wdr.cpp:1951
 msgid "Server connection refresh interval: Disable"
 msgstr "Server-Wiederverbindungsintervall: Aus"
 
-#: src/muuli_wdr.cpp:1948
+#: src/muuli_wdr.cpp:1955
 msgid "Disable computer's timed standby mode"
 msgstr "Zeitgesteuerten Bereitschaftsmodus des Computers deaktivieren"
 
-#: src/muuli_wdr.cpp:1967
+#: src/muuli_wdr.cpp:1974
 msgid "Skin to use: "
 msgstr "benutztes Aussehen:"
 
-#: src/muuli_wdr.cpp:1976
+#: src/muuli_wdr.cpp:1983
 msgid "Show \"Fast eD2k Links Handler\" in every window."
 msgstr "Zeige \"schnelle eD2k-Linkverarbeitung\" in jedem Fenster"
 
-#: src/muuli_wdr.cpp:1979
+#: src/muuli_wdr.cpp:1986
 msgid "Show extended info on categories tabs"
 msgstr "Zeige erweiterte Informationen auf Kategorie-Reitern"
 
-#: src/muuli_wdr.cpp:1982
+#: src/muuli_wdr.cpp:1989
 msgid "Show application version on title"
 msgstr "Zeige Programmversion im Titel"
 
-#: src/muuli_wdr.cpp:1984
+#: src/muuli_wdr.cpp:1991
 msgid "Show transfer rates on title"
 msgstr "Zeige Transferraten im Titel"
 
-#: src/muuli_wdr.cpp:1986
+#: src/muuli_wdr.cpp:1993
 msgid "Before application name"
 msgstr "Vor dem Anwendungsnamen"
 
-#: src/muuli_wdr.cpp:1988
+#: src/muuli_wdr.cpp:1995
 msgid "After application name"
 msgstr "Nach dem Anwendungsnamen"
 
-#: src/muuli_wdr.cpp:1991
+#: src/muuli_wdr.cpp:1998
 msgid "Show overhead bandwidth"
 msgstr "Zeige Overhead-Bandbreite"
 
-#: src/muuli_wdr.cpp:1995
+#: src/muuli_wdr.cpp:2002
 msgid "Vertical toolbar orientation"
 msgstr "Toolbar senkrecht ausrichten"
 
-#: src/muuli_wdr.cpp:1997
+#: src/muuli_wdr.cpp:2004
 msgid "Live column sorting (auto-reorder rows as their values change)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2004
+#: src/muuli_wdr.cpp:2011
 msgid "Download Queue Files"
 msgstr "Downloadwarteschlangendateien"
 
-#: src/muuli_wdr.cpp:2007
+#: src/muuli_wdr.cpp:2014
 msgid "Show progress percentage"
 msgstr "Zeige Prozent des Fortschritts"
 
-#: src/muuli_wdr.cpp:2013
+#: src/muuli_wdr.cpp:2020
 msgid "Show progress bar"
 msgstr "Zeige Fortschrittsbalken"
 
-#: src/muuli_wdr.cpp:2016
+#: src/muuli_wdr.cpp:2023
 msgid "Flat"
 msgstr "Flach"
 
-#: src/muuli_wdr.cpp:2020
+#: src/muuli_wdr.cpp:2027
 msgid "Round"
 msgstr "Rund"
 
-#: src/muuli_wdr.cpp:2038
+#: src/muuli_wdr.cpp:2045
 msgid "External Connection Parameters"
 msgstr "Parameter für externe Verbindungen"
 
-#: src/muuli_wdr.cpp:2041
+#: src/muuli_wdr.cpp:2048
 msgid "Accept external connections"
 msgstr "Externe Verbindungen annehmen"
 
-#: src/muuli_wdr.cpp:2048 src/muuli_wdr.cpp:2107
+#: src/muuli_wdr.cpp:2055 src/muuli_wdr.cpp:2114
 msgid "IP of the listening interface:"
 msgstr "IP der lauschenden Schnittstelle:"
 
-#: src/muuli_wdr.cpp:2051
+#: src/muuli_wdr.cpp:2058
 msgid "Enter here a valid ip in the a.b.c.d format for the listening EC interface. An empty field or 0.0.0.0 will mean any interface."
 msgstr "Hier eine gültige IP im Format a.b.c.d für das lauschende EC-Interface eingeben. Ein leeres Feld oder 0.0.0.0 bedeutet ein beliebiges Interface."
 
-#: src/muuli_wdr.cpp:2072 src/muuli_wdr.cpp:2156
+#: src/muuli_wdr.cpp:2079 src/muuli_wdr.cpp:2163
 msgid "TCP port:"
 msgstr "TCP-Port:"
 
-#: src/muuli_wdr.cpp:2078
+#: src/muuli_wdr.cpp:2085
 msgid "Enable UPnP port forwarding on the EC port"
 msgstr "Aktiviere UPnP-Port-Weiterleitung zu EC-Port"
 
-#: src/muuli_wdr.cpp:2082 src/muuli_wdr.cpp:3041
+#: src/muuli_wdr.cpp:2089 src/muuli_wdr.cpp:3048
 #: src/utils/wxCas/src/wxcasprefs.cpp:167
 msgid "Password"
 msgstr "Passwort"
 
-#: src/muuli_wdr.cpp:2088
+#: src/muuli_wdr.cpp:2095
 #, fuzzy
 msgid "aMule API server parameters"
 msgstr "Webserver-Parameter"
 
-#: src/muuli_wdr.cpp:2091
+#: src/muuli_wdr.cpp:2098
 msgid "Run amuleapi (REST API) on startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2096
+#: src/muuli_wdr.cpp:2103
 #, fuzzy
 msgid "HTTP port:"
 msgstr "TCP-Port:"
 
-#: src/muuli_wdr.cpp:2110
+#: src/muuli_wdr.cpp:2117
 msgid "The interface amuleapi's HTTP server listens on. 127.0.0.1 (default) accepts only local connections; use 0.0.0.0 or a specific IP to expose it to other hosts (set an admin password below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2113
+#: src/muuli_wdr.cpp:2120
 #, fuzzy
 msgid "Admin password"
 msgstr "Prüfe Passwort\n"
 
-#: src/muuli_wdr.cpp:2118 src/muuli_wdr.cpp:2149
+#: src/muuli_wdr.cpp:2125 src/muuli_wdr.cpp:2156
 msgid "Low rights password"
 msgstr "Kennwort für eingeschränkten Zugriff"
 
-#: src/muuli_wdr.cpp:2126
+#: src/muuli_wdr.cpp:2133
 msgid "Web server parameters"
 msgstr "Webserver-Parameter"
 
-#: src/muuli_wdr.cpp:2129
+#: src/muuli_wdr.cpp:2136
 #, fuzzy
 msgid "Run webserver on startup (deprecated)"
 msgstr "Starte Webserver mit aMule"
 
-#: src/muuli_wdr.cpp:2135
+#: src/muuli_wdr.cpp:2142
 msgid "Web template"
 msgstr "Webvorlage"
 
-#: src/muuli_wdr.cpp:2140
+#: src/muuli_wdr.cpp:2147
 msgid "Full rights password"
 msgstr "Kennwort für Vollzugriff"
 
-#: src/muuli_wdr.cpp:2144
+#: src/muuli_wdr.cpp:2151
 msgid "Enable Low rights User"
 msgstr "Eingeschränkten Benutzer aktivieren"
 
-#: src/muuli_wdr.cpp:2163
+#: src/muuli_wdr.cpp:2170
 msgid "Enable UPnP port forwarding of the web server port"
 msgstr "Aktiviere UPnP-Port-Weiterleitung des Webserverports"
 
-#: src/muuli_wdr.cpp:2168
+#: src/muuli_wdr.cpp:2175
 msgid "Web server UPnP TCP port (Optional)"
 msgstr "Webserver UPnP-TCP-Port (optional)"
 
-#: src/muuli_wdr.cpp:2176
+#: src/muuli_wdr.cpp:2183
 msgid "Page Refresh Time (in secs)"
 msgstr "Aktualisierungsintervall in Sekunden"
 
-#: src/muuli_wdr.cpp:2183
+#: src/muuli_wdr.cpp:2190
 msgid "Enable Gzip compression"
 msgstr "Gzip-Kompression an"
 
-#: src/muuli_wdr.cpp:2217
+#: src/muuli_wdr.cpp:2224
 #, fuzzy
 msgid "Reset page to defaults"
 msgstr "Systemvorgabe"
 
-#: src/muuli_wdr.cpp:2218
+#: src/muuli_wdr.cpp:2225
 msgid "Reset the settings on the current page to their default values."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2220 src/muuli_wdr.cpp:2306 src/ServerWnd.cpp:274
+#: src/muuli_wdr.cpp:2227 src/muuli_wdr.cpp:2313 src/ServerWnd.cpp:274
 #: src/ServerWnd.cpp:282
 msgid "OK"
 msgstr "OK"
 
-#: src/muuli_wdr.cpp:2222
+#: src/muuli_wdr.cpp:2229
 msgid "Click here to apply any changes made to the preferences."
 msgstr "Hier klicken, um alle Einstellungsänderungen zu übernehmen."
 
-#: src/muuli_wdr.cpp:2225
+#: src/muuli_wdr.cpp:2232
 msgid "Reset any changes made to the preferences."
 msgstr "Alle Änderungen zu den Einstellungen zurücksetzen."
 
-#: src/muuli_wdr.cpp:2254
+#: src/muuli_wdr.cpp:2261
 msgid "Comment :"
 msgstr "Kommentar:"
 
-#: src/muuli_wdr.cpp:2261
+#: src/muuli_wdr.cpp:2268
 msgid "Incoming Dir :"
 msgstr "Verzeichnis für eingehende Dateien:"
 
-#: src/muuli_wdr.cpp:2270
+#: src/muuli_wdr.cpp:2277
 msgid "Change priority for new assigned files :"
 msgstr "Priorität bei neu zugewiesenen Dateien ändern:"
 
-#: src/muuli_wdr.cpp:2274
+#: src/muuli_wdr.cpp:2281
 msgid "Don't change"
 msgstr "Nicht ändern"
 
-#: src/muuli_wdr.cpp:2286
+#: src/muuli_wdr.cpp:2293
 msgid "Select color for this Category (currently selected) :"
 msgstr "Farbe für diese Kategorie wählen (momentan ausgewählt):"
 
-#: src/muuli_wdr.cpp:2353 src/muuli_wdr.cpp:2372 src/muuli_wdr.cpp:2394
+#: src/muuli_wdr.cpp:2360 src/muuli_wdr.cpp:2379 src/muuli_wdr.cpp:2401
 msgid "Click this button to reset the log."
 msgstr "Drücke diesen Knopf, um das Log zurückzusetzen."
 
-#: src/muuli_wdr.cpp:2413
+#: src/muuli_wdr.cpp:2420
 msgid "Click on this button to update the servers list from URL ..."
 msgstr "Hier klicken, um die Serverliste über die angegebene URL zu aktualisieren"
 
-#: src/muuli_wdr.cpp:2417
+#: src/muuli_wdr.cpp:2424
 msgid "Server list"
 msgstr "Serverliste"
 
-#: src/muuli_wdr.cpp:2421
+#: src/muuli_wdr.cpp:2428
 msgid "Enter the url to a server.met file here and press the button to the left to update the list of known servers."
 msgstr "Hier die URL einer server.met eingeben, und dann den Knopf links vom Eingabefeld drücken, um die Serverliste zu aktualisieren."
 
-#: src/muuli_wdr.cpp:2426
+#: src/muuli_wdr.cpp:2433
 msgid "Add server manually: Name"
 msgstr "Server manuell hinzufügen: Name"
 
-#: src/muuli_wdr.cpp:2429
+#: src/muuli_wdr.cpp:2436
 msgid "Enter the name of the new server here"
 msgstr "Gib den Namen das neuen Servers hier ein"
 
-#: src/muuli_wdr.cpp:2431 src/ServerWnd.cpp:206
+#: src/muuli_wdr.cpp:2438 src/ServerWnd.cpp:206
 msgid "IP:Port"
 msgstr "IP:Port"
 
-#: src/muuli_wdr.cpp:2434
+#: src/muuli_wdr.cpp:2441
 msgid "Enter the IP of the server here, using the x.x.x.x format."
 msgstr "Hier die IP des Servers im Format x.x.x.x eingeben."
 
-#: src/muuli_wdr.cpp:2440
+#: src/muuli_wdr.cpp:2447
 msgid "Enter the port of the server here."
 msgstr "Hier den Serverport eingeben."
 
-#: src/muuli_wdr.cpp:2443
+#: src/muuli_wdr.cpp:2450
 msgid "Add manually a server (fill fields to the left before) ..."
 msgstr "Einen Server manuell hinzufügen (vorher bitte links die Felder ausfüllen)..."
 
-#: src/muuli_wdr.cpp:2472
+#: src/muuli_wdr.cpp:2479
 msgid "aMule Log"
 msgstr "aMule-Log"
 
-#: src/muuli_wdr.cpp:2480
+#: src/muuli_wdr.cpp:2487
 msgid "Server Info"
 msgstr "Serverinformation"
 
-#: src/muuli_wdr.cpp:2484
+#: src/muuli_wdr.cpp:2491
 msgid "ED2K Info"
 msgstr "eD2k-Info"
 
-#: src/muuli_wdr.cpp:2488
+#: src/muuli_wdr.cpp:2495
 msgid "Kad Info"
 msgstr "Kad-Info"
 
-#: src/muuli_wdr.cpp:2516
+#: src/muuli_wdr.cpp:2523
 msgid "Click on this button to update the nodes list from URL ..."
 msgstr "Zum Aktualisieren der nodes.dat von URL diese Schaltfläche drücken."
 
-#: src/muuli_wdr.cpp:2520
+#: src/muuli_wdr.cpp:2527
 msgid "Nodes (0)"
 msgstr "Knoten (0)"
 
-#: src/muuli_wdr.cpp:2524
+#: src/muuli_wdr.cpp:2531
 msgid "Enter the url to a nodes.dat file here and press the button to the left to update the list of known nodes."
 msgstr "Hier die URL einer nodes.dat eingeben, und dann den Knopf links vom Eingabefeld drücken, um die Liste der bekannten Knoten zu aktualisieren."
 
-#: src/muuli_wdr.cpp:2527
+#: src/muuli_wdr.cpp:2534
 msgid "Nodes stats"
 msgstr "Knotenstatistik"
 
-#: src/muuli_wdr.cpp:2569
+#: src/muuli_wdr.cpp:2576
 msgid "Bootstrap"
 msgstr "Bootstrap"
 
-#: src/muuli_wdr.cpp:2572
+#: src/muuli_wdr.cpp:2579
 msgid "New node"
 msgstr "Neuer Knoten"
 
-#: src/muuli_wdr.cpp:2577
+#: src/muuli_wdr.cpp:2584
 msgid "IP:"
 msgstr "IP:"
 
-#: src/muuli_wdr.cpp:2597
+#: src/muuli_wdr.cpp:2604
 msgid "Port:"
 msgstr "Port:"
 
-#: src/muuli_wdr.cpp:2610
+#: src/muuli_wdr.cpp:2617
 msgid "Bootstrap from known clients"
 msgstr "Bootstrap von bekannten Clients"
 
-#: src/muuli_wdr.cpp:2612
+#: src/muuli_wdr.cpp:2619
 msgid "Disconnect Kad"
 msgstr "Kad trennen"
 
-#: src/muuli_wdr.cpp:2646
+#: src/muuli_wdr.cpp:2653
 msgid "Use Secure User Identification"
 msgstr "Benutze sichere Benutzeridentifikation"
 
-#: src/muuli_wdr.cpp:2648
+#: src/muuli_wdr.cpp:2655
 msgid "It is recommended to enable this option. You will not receive credits if SUI is not enabled."
 msgstr "Es wird empfohlen diese Option zu aktivieren. Du wirst keine Credits erhalten, wenn SUI nicht aktiviert ist."
 
-#: src/muuli_wdr.cpp:2650
+#: src/muuli_wdr.cpp:2657
 msgid "Protocol Obfuscation"
 msgstr "Protokollverschleierung"
 
-#: src/muuli_wdr.cpp:2653
+#: src/muuli_wdr.cpp:2660
 msgid "Support Protocol Obfuscation"
 msgstr "Unterstütze Protokollverschleierung"
 
-#: src/muuli_wdr.cpp:2655
+#: src/muuli_wdr.cpp:2662
 msgid "This option enabled Protocol Obfuscation, and makes aMule accept obfuscated connections from other clients."
 msgstr "Diese Option aktiviert die Protokollverschleierung und verfügt aMule, verschleierte Verbindungen von anderen Clients anzunehmen."
 
-#: src/muuli_wdr.cpp:2657
+#: src/muuli_wdr.cpp:2664
 msgid "Use obfuscation for outgoing connections"
 msgstr "Verschleiere ausgehende Verbindungen"
 
-#: src/muuli_wdr.cpp:2659
+#: src/muuli_wdr.cpp:2666
 msgid "This option makes aMule use Protocol Obfuscation when connecting other clients/servers."
 msgstr "Diese Option verfügt aMule, Protokollverschleierung zu verwenden bei der Verbindung zu anderen Clients und/oder Servern."
 
-#: src/muuli_wdr.cpp:2661
+#: src/muuli_wdr.cpp:2668
 msgid "Accept only obfuscated connections"
 msgstr "Akzeptiere ausschließlich verschleierte Verbindungen"
 
-#: src/muuli_wdr.cpp:2662
+#: src/muuli_wdr.cpp:2669
 msgid "This option makes aMule only accept obfuscated connections. You will have less sources, but all your traffic will be obfuscated"
 msgstr "Diese Option verfügt aMule, ausschließlich verschleierte Verbindungen zu akzeptieren. Das führt zu weniger Quellen, jedoch ist sämtlicher Verkehr verschleiert."
 
-#: src/muuli_wdr.cpp:2667
+#: src/muuli_wdr.cpp:2674
 msgid "Everybody"
 msgstr "Jeder"
 
-#: src/muuli_wdr.cpp:2669
+#: src/muuli_wdr.cpp:2676
 msgid "No one"
 msgstr "Niemand"
 
-#: src/muuli_wdr.cpp:2671
+#: src/muuli_wdr.cpp:2678
 msgid "Who can see my shared files:"
 msgstr "Wer kann freigegebene Dateien sehen:"
 
-#: src/muuli_wdr.cpp:2672
+#: src/muuli_wdr.cpp:2679
 msgid "Select who can request to view a list of your shared files."
 msgstr "Wähle, wer deine freigegebenen Dateien einsehen darf."
 
-#: src/muuli_wdr.cpp:2674
+#: src/muuli_wdr.cpp:2681
 msgid "IP-Filtering"
 msgstr "IP-Filterung"
 
-#: src/muuli_wdr.cpp:2681
+#: src/muuli_wdr.cpp:2688
 msgid "Filter clients"
 msgstr "Filtere Clients"
 
-#: src/muuli_wdr.cpp:2683
+#: src/muuli_wdr.cpp:2690
 msgid "Enable filtering of the client IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "Aktiviere die Filterung von Client-IPs, die in der Datei ~/.aMule/ipfilter.dat definiert sind."
 
-#: src/muuli_wdr.cpp:2685
+#: src/muuli_wdr.cpp:2692
 msgid "Filter servers"
 msgstr "Filtere Server"
 
-#: src/muuli_wdr.cpp:2687
+#: src/muuli_wdr.cpp:2694
 msgid "Enable filtering of the server IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "Aktiviere das Filtern von Server-IPs, die in der Datei ~/.aMule/ipfilter.dat definiert sind."
 
-#: src/muuli_wdr.cpp:2691
+#: src/muuli_wdr.cpp:2698
 msgid "Reload List"
 msgstr "Aktualisieren der Liste"
 
-#: src/muuli_wdr.cpp:2692
+#: src/muuli_wdr.cpp:2699
 msgid "Reload the list of IPs to filter from the file ~/.aMule/ipfilter.dat"
 msgstr "Aktualisiert die Liste der zu filternden IPs in der ~/.aMule/ipfilter.dat"
 
-#: src/muuli_wdr.cpp:2698
+#: src/muuli_wdr.cpp:2705
 msgid "URL:"
 msgstr "URL:"
 
-#: src/muuli_wdr.cpp:2702 src/muuli_wdr.cpp:2895
+#: src/muuli_wdr.cpp:2709 src/muuli_wdr.cpp:2902
 msgid "Update now"
 msgstr "Jetzt aktualisieren"
 
-#: src/muuli_wdr.cpp:2705
+#: src/muuli_wdr.cpp:2712
 msgid "Auto-update ipfilter at startup"
 msgstr "IP-Filter beim Start automatisch aktualisieren"
 
-#: src/muuli_wdr.cpp:2709
+#: src/muuli_wdr.cpp:2716
 msgid "Filtering Level:"
 msgstr "Filterstufe:"
 
-#: src/muuli_wdr.cpp:2715
+#: src/muuli_wdr.cpp:2722
 msgid "Always filter LAN IPs"
 msgstr "LAN-IP-Adressen immer filtern"
 
-#: src/muuli_wdr.cpp:2718
+#: src/muuli_wdr.cpp:2725
 msgid "Paranoid handling of non-matching IPs"
 msgstr "Paranoides Handhaben nicht-passender IP-Adressen"
 
-#: src/muuli_wdr.cpp:2720
+#: src/muuli_wdr.cpp:2727
 msgid "Rejects a packet when its source IP differs from the IP the client claims (an anti-spoofing check). Disable only if it causes connection problems."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2722
+#: src/muuli_wdr.cpp:2729
 msgid "Use system-wide ipfilter.dat if available"
 msgstr "Benutze systemweite ipfilter.dat, wenn verfügbar."
 
-#: src/muuli_wdr.cpp:2723
+#: src/muuli_wdr.cpp:2730
 msgid "If there's no local ipfilter.dat found, allow usage of a system-wide ipfilter file."
 msgstr "Erlaube die Benutzung der systemweiten ipfilter-Datei, falls keine lokale ipfilter.dat gefunden wird."
 
-#: src/muuli_wdr.cpp:2740
+#: src/muuli_wdr.cpp:2747
 msgid "Enable Online-Signature"
 msgstr "Online-Signatur aktivieren"
 
-#: src/muuli_wdr.cpp:2742
+#: src/muuli_wdr.cpp:2749
 msgid "Enables the writing of the OS file, which can be used by external apps to create signatures and the like."
 msgstr "Aktiviert das Schreiben der Online-Signaturdatei, die von externen Programmen verwendet werden kann, um Signaturen o.ä. zu erstellen."
 
-#: src/muuli_wdr.cpp:2746
+#: src/muuli_wdr.cpp:2753
 msgid "Update Frequency (Secs):"
 msgstr "Aktualisierungsintervall (Sekunden):"
 
-#: src/muuli_wdr.cpp:2749
+#: src/muuli_wdr.cpp:2756
 msgid "Change the frequency (in seconds) of Online Signature updates."
 msgstr "Ändern des Online-Signatur-Aktualisierungsintervalls (in Sekunden)."
 
-#: src/muuli_wdr.cpp:2757
+#: src/muuli_wdr.cpp:2764
 msgid "Save online signature file in: "
 msgstr "Speichere Online-Signatur-Datei in:"
 
-#: src/muuli_wdr.cpp:2763
+#: src/muuli_wdr.cpp:2770
 msgid "Click here to select the directory containing the the Online Signature files."
 msgstr "Hier klicken, um das Verzeichnis mit den Dateien für die Online-Signatur auszuwählen."
 
-#: src/muuli_wdr.cpp:2796
+#: src/muuli_wdr.cpp:2803
 msgid "Show country flags for clients"
 msgstr "Landesflaggen für Clients anzeigen"
 
-#: src/muuli_wdr.cpp:2797
+#: src/muuli_wdr.cpp:2804
 msgid "Render the country flag column in the transfers, queue and search views. Requires a valid MMDB GeoIP database (see below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2802
+#: src/muuli_wdr.cpp:2809
 #, fuzzy
 msgid "Database"
 msgstr "Datenrate:"
 
-#: src/muuli_wdr.cpp:2818
+#: src/muuli_wdr.cpp:2825
 #, fuzzy
 msgid "Source:"
 msgstr "Quellen"
 
-#: src/muuli_wdr.cpp:2821
+#: src/muuli_wdr.cpp:2828
 msgid "DB-IP (free, no account)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2822
+#: src/muuli_wdr.cpp:2829
 msgid "MaxMind GeoLite2 (free, account required)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2823
+#: src/muuli_wdr.cpp:2830
 msgid "Custom URL"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2826
+#: src/muuli_wdr.cpp:2833
 msgid "Choose which provider supplies the GeoIP MMDB database. DB-IP is the default - no account required. MaxMind requires a free account + license key. Use Custom URL to point at any other MMDB host (e.g. a local mirror)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2843
+#: src/muuli_wdr.cpp:2850
 msgid ""
 "No configuration required.\n"
 "\n"
@@ -4835,11 +4849,11 @@ msgid ""
 "License: Creative Commons BY 4.0 - https://creativecommons.org/licenses/by/4.0/"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2856
+#: src/muuli_wdr.cpp:2863
 msgid "License key:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2862
+#: src/muuli_wdr.cpp:2869
 msgid ""
 "Sign up for a free MaxMind account, then generate a License Key:\n"
 "https://www.maxmind.com/en/geolite2/signup\n"
@@ -4849,224 +4863,224 @@ msgid ""
 "Requires attribution and account registration; refresh at least every 30 days."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2877
+#: src/muuli_wdr.cpp:2884
 #, fuzzy
 msgid "Download URL:"
 msgstr "Download: "
 
-#: src/muuli_wdr.cpp:2883
+#: src/muuli_wdr.cpp:2890
 msgid ""
 "Must point to an .mmdb file or a .gz / .tar.gz containing one.\n"
 "URL may include credentials (https://user:pass@host/...).\n"
 "License and attribution terms are set by the upstream URL - you are responsible."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2896
+#: src/muuli_wdr.cpp:2903
 msgid "Download the GeoIP database from the selected source."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2898
+#: src/muuli_wdr.cpp:2905
 #, fuzzy
 msgid "Auto-update on startup"
 msgstr "IP-Filter beim Start automatisch aktualisieren"
 
-#: src/muuli_wdr.cpp:2899
+#: src/muuli_wdr.cpp:2906
 msgid "Re-download the GeoIP database from the selected source every time aMule starts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2922
+#: src/muuli_wdr.cpp:2929
 msgid "Filter incoming messages (except current chat):"
 msgstr "Eingehende Nachrichten filtern (außer momentanen Chats):"
 
-#: src/muuli_wdr.cpp:2924
+#: src/muuli_wdr.cpp:2931
 msgid "Filter all messages"
 msgstr "Filtere alle Nachrichten"
 
-#: src/muuli_wdr.cpp:2926
+#: src/muuli_wdr.cpp:2933
 msgid "Filter messages from people not on your friend list"
 msgstr "Filtere Nachrichten von Benutzern, die nicht auf deiner Freundesliste stehen"
 
-#: src/muuli_wdr.cpp:2928
+#: src/muuli_wdr.cpp:2935
 msgid "Filter messages from unknown clients"
 msgstr "Filtere Nachrichten von unbekannten Clients"
 
-#: src/muuli_wdr.cpp:2930
+#: src/muuli_wdr.cpp:2937
 msgid "Filter messages containing (use ',' as separator):"
 msgstr "Filtere Nachrichten, die folgende Worte enthalten (benutze ',' als Trenner):"
 
-#: src/muuli_wdr.cpp:2933 src/muuli_wdr.cpp:2944
+#: src/muuli_wdr.cpp:2940 src/muuli_wdr.cpp:2951
 msgid "add here the words amule should filter and block messages including it"
 msgstr "Hier die Worte eingeben, die aMule filtern soll, und um Nachrichten abzuweisen, in denen sie vorkommen"
 
-#: src/muuli_wdr.cpp:2935
+#: src/muuli_wdr.cpp:2942
 msgid "Show received messages in the log"
 msgstr "Zeige empfangene Nachrichten im Log an"
 
-#: src/muuli_wdr.cpp:2938
+#: src/muuli_wdr.cpp:2945
 msgid "Comments"
 msgstr "Kommentare"
 
-#: src/muuli_wdr.cpp:2941
+#: src/muuli_wdr.cpp:2948
 msgid "Filter comments containing (use ',' as separator):"
 msgstr "Filtere Komentare, die folgende Worte enthalten (benutze ',' als Trenner):"
 
-#: src/muuli_wdr.cpp:2966
+#: src/muuli_wdr.cpp:2973
 msgid "Enable Proxy"
 msgstr "Proxy aktivieren"
 
-#: src/muuli_wdr.cpp:2967
+#: src/muuli_wdr.cpp:2974
 msgid "Enable/disable proxy support"
 msgstr "Aktiviere/Deaktiviere Proxy-Unterstützung"
 
-#: src/muuli_wdr.cpp:2970
+#: src/muuli_wdr.cpp:2977
 msgid "Proxy type:"
 msgstr "Proxy-Typ:"
 
-#: src/muuli_wdr.cpp:2981
+#: src/muuli_wdr.cpp:2988
 msgid "Proxy host:"
 msgstr "Proxy-Host:"
 
-#: src/muuli_wdr.cpp:2984
+#: src/muuli_wdr.cpp:2991
 msgid "The proxy host name"
 msgstr "Der Hostname des Proxy"
 
-#: src/muuli_wdr.cpp:2986
+#: src/muuli_wdr.cpp:2993
 msgid "Proxy port:"
 msgstr "Proxy-Port:"
 
-#: src/muuli_wdr.cpp:2989
+#: src/muuli_wdr.cpp:2996
 msgid "The proxy port"
 msgstr "Der Port des Proxy"
 
-#: src/muuli_wdr.cpp:2991
+#: src/muuli_wdr.cpp:2998
 msgid "Enable authentication"
 msgstr "Authentifizierung aktivieren"
 
-#: src/muuli_wdr.cpp:2992
+#: src/muuli_wdr.cpp:2999
 msgid "Enable/disable username/password authentication"
 msgstr "Aktiviere/Deaktiviere Authentifizierung mit Benutzername/Passwort"
 
-#: src/muuli_wdr.cpp:2995
+#: src/muuli_wdr.cpp:3002
 msgid "Username: "
 msgstr "Benutzername:"
 
-#: src/muuli_wdr.cpp:2998
+#: src/muuli_wdr.cpp:3005
 msgid "The username to use to connect to the proxy"
 msgstr "Der Benutzername, um sich beim Proxy anzumelden"
 
-#: src/muuli_wdr.cpp:3000
+#: src/muuli_wdr.cpp:3007
 msgid "Password:"
 msgstr "Passwort:"
 
-#: src/muuli_wdr.cpp:3003
+#: src/muuli_wdr.cpp:3010
 msgid "The password to use to connect to the proxy"
 msgstr "Proxy-Verbindungspasswort"
 
-#: src/muuli_wdr.cpp:3022
+#: src/muuli_wdr.cpp:3029
 msgid "Connect to:"
 msgstr "Verbinde zu:"
 
-#: src/muuli_wdr.cpp:3031
+#: src/muuli_wdr.cpp:3038
 msgid "Login to remote amule"
 msgstr "Beim entfernten aMule anmelden"
 
-#: src/muuli_wdr.cpp:3036
+#: src/muuli_wdr.cpp:3043
 msgid "User name"
 msgstr "Benutzername"
 
-#: src/muuli_wdr.cpp:3047
+#: src/muuli_wdr.cpp:3054
 msgid "Remember those settings"
 msgstr "Diese Einstellungen speichern"
 
-#: src/muuli_wdr.cpp:3050
+#: src/muuli_wdr.cpp:3057
 msgid "Force ZLIB compression"
 msgstr "ZLIB-Kompression erzwingen"
 
-#: src/muuli_wdr.cpp:3074
+#: src/muuli_wdr.cpp:3081
 msgid "Enable Verbose Debug-Logging."
 msgstr "Aktiviere ausführliche Debug-Protokollierung"
 
-#: src/muuli_wdr.cpp:3076
+#: src/muuli_wdr.cpp:3083
 msgid "Only to Logfile"
 msgstr "Nur in Logdatei"
 
-#: src/muuli_wdr.cpp:3078
+#: src/muuli_wdr.cpp:3085
 msgid "Message Categories:"
 msgstr "Nachrichtenkategorien:"
 
-#: src/muuli_wdr.cpp:3102 src/PartFileConvertDlg.cpp:160
+#: src/muuli_wdr.cpp:3109 src/PartFileConvertDlg.cpp:160
 msgid "Waiting..."
 msgstr "Wartend..."
 
-#: src/muuli_wdr.cpp:3122
+#: src/muuli_wdr.cpp:3129
 msgid "Add imports"
 msgstr "Füge Importe hinzu"
 
-#: src/muuli_wdr.cpp:3125
+#: src/muuli_wdr.cpp:3132
 msgid "Retry selected"
 msgstr "Versuche Ausgewähltes noch einmal"
 
-#: src/muuli_wdr.cpp:3127
+#: src/muuli_wdr.cpp:3134
 msgid "Remove selected"
 msgstr "Auswahl entfernen"
 
-#: src/muuli_wdr.cpp:3190
+#: src/muuli_wdr.cpp:3197
 msgid "Event Types"
 msgstr "Ereignisarten"
 
-#: src/muuli_wdr.cpp:3209
+#: src/muuli_wdr.cpp:3216
 msgid "Statistics and queued clients for selected file(s) : Session / All time"
 msgstr "Statistiken und Clients in der Warteschlange für ausgewählte Datei(en): Sitzung / Insgesamt"
 
-#: src/muuli_wdr.cpp:3233
+#: src/muuli_wdr.cpp:3240
 msgid "Active Uploads"
 msgstr "Aktive Uploads"
 
-#: src/muuli_wdr.cpp:3247
+#: src/muuli_wdr.cpp:3254
 msgid "Percent of total files"
 msgstr "Prozent aller Dateien"
 
-#: src/muuli_wdr.cpp:3299
+#: src/muuli_wdr.cpp:3306
 msgid "Show Clients for"
 msgstr "Clients anzeigen für"
 
-#: src/muuli_wdr.cpp:3301
+#: src/muuli_wdr.cpp:3308
 msgid "All files"
 msgstr "Alle Dateien"
 
-#: src/muuli_wdr.cpp:3304
+#: src/muuli_wdr.cpp:3311
 msgid "Selected files"
 msgstr "Ausgewählte Dateien"
 
-#: src/muuli_wdr.cpp:3307
+#: src/muuli_wdr.cpp:3314
 msgid "Active uploads only"
 msgstr "Nur aktive Uploads"
 
-#: src/muuli_wdr.cpp:3314
+#: src/muuli_wdr.cpp:3321
 msgid "Reload:"
 msgstr "Aktualisieren:"
 
-#: src/muuli_wdr.cpp:3318
+#: src/muuli_wdr.cpp:3325
 msgid "Reload your shared files"
 msgstr "Freigegebene Dateien neu laden"
 
-#: src/muuli_wdr.cpp:3381
+#: src/muuli_wdr.cpp:3388
 msgid "Send"
 msgstr "Senden"
 
-#: src/muuli_wdr.cpp:3382
+#: src/muuli_wdr.cpp:3389
 msgid "Sends the specified message."
 msgstr "Sendet die angegebene Nachricht."
 
-#: src/muuli_wdr.cpp:3386
+#: src/muuli_wdr.cpp:3393
 msgid "Close this chat-session."
 msgstr "Schließe diese Chat-Sitzung."
 
-#: src/muuli_wdr.cpp:3409
+#: src/muuli_wdr.cpp:3416
 msgid "Connect to any server and/or Kad"
 msgstr "Mit irgendeinem Server und/oder Kad verbinden"
 
-#: src/muuli_wdr.cpp:3415 src/SharedFilesCtrl.cpp:142 src/Statistics.cpp:941
+#: src/muuli_wdr.cpp:3422 src/SharedFilesCtrl.cpp:142 src/Statistics.cpp:941
 msgid "Shared Files"
 msgstr "Freigaben"
 
@@ -5426,188 +5440,188 @@ msgstr "Heruntergeladen"
 msgid "ERROR: Failed to open partfile '%s'"
 msgstr "FEHLER: Öffnen von Partfile '%s' fehlgeschlagen"
 
-#: src/Preferences.cpp:673
+#: src/Preferences.cpp:674
 msgid "System default"
 msgstr "Systemvorgabe"
 
-#: src/Preferences.cpp:674
+#: src/Preferences.cpp:675
 msgid "Albanian"
 msgstr "Albanisch"
 
-#: src/Preferences.cpp:675
+#: src/Preferences.cpp:676
 msgid "Arabic"
 msgstr "Arabisch"
 
-#: src/Preferences.cpp:676
+#: src/Preferences.cpp:677
 msgid "Asturian"
 msgstr "Asturisch"
 
-#: src/Preferences.cpp:677
+#: src/Preferences.cpp:678
 msgid "Basque"
 msgstr "Baskisch"
 
-#: src/Preferences.cpp:678
+#: src/Preferences.cpp:679
 msgid "Bulgarian"
 msgstr "Bulgarisch"
 
-#: src/Preferences.cpp:679
+#: src/Preferences.cpp:680
 msgid "Catalan"
 msgstr "Katalanisch"
 
-#: src/Preferences.cpp:680
+#: src/Preferences.cpp:681
 msgid "Chinese (Simplified)"
 msgstr "Chinesisch (vereinfacht)"
 
-#: src/Preferences.cpp:681
+#: src/Preferences.cpp:682
 msgid "Chinese (Traditional)"
 msgstr "Chinesisch (traditionell)"
 
-#: src/Preferences.cpp:682
+#: src/Preferences.cpp:683
 msgid "Croatian"
 msgstr "Kroatisch"
 
-#: src/Preferences.cpp:683
+#: src/Preferences.cpp:684
 msgid "Czech"
 msgstr "Tschechisch"
 
-#: src/Preferences.cpp:684
+#: src/Preferences.cpp:685
 msgid "Danish"
 msgstr "Dänisch"
 
-#: src/Preferences.cpp:685
+#: src/Preferences.cpp:686
 msgid "Dutch"
 msgstr "Holländisch"
 
-#: src/Preferences.cpp:686
+#: src/Preferences.cpp:687
 msgid "English (U.K.)"
 msgstr "Englisch (UK)"
 
-#: src/Preferences.cpp:687
+#: src/Preferences.cpp:688
 #, fuzzy
 msgid "English (U.S.)"
 msgstr "Englisch (UK)"
 
-#: src/Preferences.cpp:688
+#: src/Preferences.cpp:689
 msgid "Estonian"
 msgstr "Estnisch"
 
-#: src/Preferences.cpp:689
+#: src/Preferences.cpp:690
 msgid "Finnish"
 msgstr "Finnisch"
 
-#: src/Preferences.cpp:690
+#: src/Preferences.cpp:691
 msgid "French"
 msgstr "Französisch"
 
-#: src/Preferences.cpp:691
+#: src/Preferences.cpp:692
 msgid "Galician"
 msgstr "Galizisch"
 
-#: src/Preferences.cpp:692
+#: src/Preferences.cpp:693
 msgid "German"
 msgstr "Deutsch"
 
-#: src/Preferences.cpp:693
+#: src/Preferences.cpp:694
 msgid "Greek"
 msgstr "Griechisch"
 
-#: src/Preferences.cpp:694
+#: src/Preferences.cpp:695
 msgid "Hebrew"
 msgstr "Hebräisch"
 
-#: src/Preferences.cpp:695
+#: src/Preferences.cpp:696
 msgid "Hungarian"
 msgstr "Ungarisch"
 
-#: src/Preferences.cpp:696
+#: src/Preferences.cpp:697
 msgid "Italian"
 msgstr "Italienisch"
 
-#: src/Preferences.cpp:697
+#: src/Preferences.cpp:698
 msgid "Japanese"
 msgstr "Japanisch"
 
-#: src/Preferences.cpp:698
+#: src/Preferences.cpp:699
 msgid "Korean"
 msgstr "Koreanisch"
 
-#: src/Preferences.cpp:699
+#: src/Preferences.cpp:700
 msgid "Latvian"
 msgstr ""
 
-#: src/Preferences.cpp:700
+#: src/Preferences.cpp:701
 msgid "Lithuanian"
 msgstr "Litauisch"
 
-#: src/Preferences.cpp:701
+#: src/Preferences.cpp:702
 msgid "Norwegian (Nynorsk)"
 msgstr "Norwegisch"
 
-#: src/Preferences.cpp:702
+#: src/Preferences.cpp:703
 msgid "Polish"
 msgstr "Polnisch"
 
-#: src/Preferences.cpp:703
+#: src/Preferences.cpp:704
 msgid "Portuguese"
 msgstr "Portugiesisch"
 
-#: src/Preferences.cpp:704
+#: src/Preferences.cpp:705
 msgid "Portuguese (Brazilian)"
 msgstr "Portugiesisch (Brasilianisch)"
 
-#: src/Preferences.cpp:705
+#: src/Preferences.cpp:706
 msgid "Romanian"
 msgstr "Rumänisch"
 
-#: src/Preferences.cpp:706
+#: src/Preferences.cpp:707
 msgid "Russian"
 msgstr "Russisch"
 
-#: src/Preferences.cpp:707
+#: src/Preferences.cpp:708
 msgid "Slovenian"
 msgstr "Slowenisch"
 
-#: src/Preferences.cpp:708
+#: src/Preferences.cpp:709
 msgid "Spanish"
 msgstr "Spanisch"
 
-#: src/Preferences.cpp:709
+#: src/Preferences.cpp:710
 msgid "Swedish"
 msgstr "Schwedisch"
 
-#: src/Preferences.cpp:710
+#: src/Preferences.cpp:711
 msgid "Turkish"
 msgstr "Türkisch"
 
-#: src/Preferences.cpp:711
+#: src/Preferences.cpp:712
 msgid "Ukrainian"
 msgstr "Ukrainisch"
 
-#: src/Preferences.cpp:814
+#: src/Preferences.cpp:815
 msgid "Change Language"
 msgstr "Sprache ändern"
 
-#: src/Preferences.cpp:878
+#: src/Preferences.cpp:879
 msgid "There are no translations installed for aMule"
 msgstr "Für aMule sind keine Übersetzungen installiert"
 
-#: src/Preferences.cpp:879
+#: src/Preferences.cpp:880
 msgid "No languages available"
 msgstr "Keine Sprachen verfügbar"
 
-#: src/Preferences.cpp:1010
+#: src/Preferences.cpp:1011
 msgid "no options available"
 msgstr "keine Optionen verfügbar"
 
-#: src/Preferences.cpp:2179
+#: src/Preferences.cpp:2182
 msgid "Invalid category found, skipping"
 msgstr "Ungültige Kategorie gefunden, überspringe."
 
-#: src/Preferences.cpp:2348
+#: src/Preferences.cpp:2351
 msgid "TCP port can't be higher than 65532 due to server UDP socket being TCP+3"
 msgstr "TCP-Port kann nicht größer als 65532 sein, da der Server-UDP-Port=TCP-Port+3 ist"
 
-#: src/Preferences.cpp:2349
+#: src/Preferences.cpp:2352
 #, c-format
 msgid "Default port will be used (%d)"
 msgstr "Standard-Port wird verwendet (%d)"
@@ -6118,23 +6132,27 @@ msgstr "Liste freigegebener Dateien neu laden: %u Dateien gelesen"
 msgid "Shared folder"
 msgstr "Freigegebene Ordner"
 
-#: src/SearchDlg.cpp:425
+#: src/SearchDlg.cpp:280
+msgid "Clear search history"
+msgstr ""
+
+#: src/SearchDlg.cpp:584
 msgid "It's impossible to search when both eD2k and Kademlia are disabled."
 msgstr "Eine Suche ist nicht möglich, wenn sowohl eD2k als auch Kademlia deaktiviert sind."
 
-#: src/SearchDlg.cpp:426 src/SearchListCtrl.cpp:858
+#: src/SearchDlg.cpp:585 src/SearchListCtrl.cpp:858
 msgid "Search error"
 msgstr "Suchfehler"
 
-#: src/SearchDlg.cpp:768
+#: src/SearchDlg.cpp:929
 msgid "Min size must be smaller than max size. Max size ignored."
 msgstr "Mindestgröße muss kleiner sein, als die Höchstgröße: Höchstgröße ignoriert."
 
-#: src/SearchDlg.cpp:769 src/SearchDlg.cpp:851
+#: src/SearchDlg.cpp:930 src/SearchDlg.cpp:1012
 msgid "Search warning"
 msgstr "Suchwarnung"
 
-#: src/SearchDlg.cpp:929 src/SearchListCtrl.cpp:735
+#: src/SearchDlg.cpp:1092 src/SearchListCtrl.cpp:735
 msgid "Main"
 msgstr "Hauptkategorie"
 

--- a/po/el.po
+++ b/po/el.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-28 08:06+0200\n"
+"POT-Creation-Date: 2026-07-28 10:19+0200\n"
 "PO-Revision-Date: 2026-07-27 11:35+0000\n"
 "Last-Translator: Dimitris <dgalanak@yahoo.com>\n"
 "Language-Team: Greek\n"
@@ -144,7 +144,7 @@ msgstr ""
 msgid "Not now"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:422 src/amuleDlg.cpp:600
+#: src/AppImageIntegration.cpp:422 src/amuleDlg.cpp:665
 msgid "Don't ask again"
 msgstr ""
 
@@ -221,7 +221,7 @@ msgid "Killing amuleweb instance with pid '%d' ... "
 msgstr ""
 
 #: src/amule.cpp:336 src/amule.cpp:349 src/ClientRef.cpp:180
-#: src/SearchDlg.cpp:880 src/ServerListCtrl.cpp:98
+#: src/SearchDlg.cpp:1041 src/ServerListCtrl.cpp:98
 msgid "Failed"
 msgstr "Απέτυχε"
 
@@ -579,30 +579,68 @@ msgstr ""
 msgid "ERROR: %s"
 msgstr "ΣΦΑΛΜΑ: %s"
 
-#: src/amuleDlg.cpp:236
+#: src/amuleDlg.cpp:250
 #, c-format
 msgid "This is aMule %s based on eMule."
 msgstr "Αυτό το aMule %s είναι βασισμένο στο eMule."
 
-#: src/amuleDlg.cpp:237
+#: src/amuleDlg.cpp:251
 #, c-format
 msgid "Running on %s"
 msgstr "Τρέχει στο %s"
 
-#: src/amuleDlg.cpp:239
+#: src/amuleDlg.cpp:253
 msgid "Visit https://github.com/amule-org/amule/releases/latest to check if a new version is available."
 msgstr "Επισκεφτείτε το https://github.com/amule-org/amule/releases/latest για να δείτε αν υπάρχει νέα έκδοση."
 
-#: src/amuleDlg.cpp:268
+#: src/amuleDlg.cpp:282
 msgid "FATAL ERROR: Failed to create Timer"
 msgstr "ΜΟΙΡΑΙΟ ΣΦΑΛΜΑ: Αποτυχία δημιουργίας Χρονομέτρου"
 
-#: src/amuleDlg.cpp:592
+#: src/amuleDlg.cpp:361 src/amuleDlg.cpp:1787 src/amuleDlg.cpp:2033
+#: src/muuli_wdr.cpp:1492 src/muuli_wdr.cpp:3418
+msgid "Networks"
+msgstr "Δίκτυα"
+
+#: src/amuleDlg.cpp:362 src/amuleDlg.cpp:1793 src/muuli_wdr.cpp:3419
+msgid "Searches"
+msgstr "Αναζητήσεις"
+
+#: src/amuleDlg.cpp:363 src/amuleDlg.cpp:1799 src/DownloadListCtrl.cpp:740
+#: src/muuli_wdr.cpp:392 src/muuli_wdr.cpp:1585 src/muuli_wdr.cpp:3420
+#: src/Statistics.cpp:829
+msgid "Downloads"
+msgstr "Κατεβασμένα"
+
+#: src/amuleDlg.cpp:364 src/amuleDlg.cpp:1805 src/muuli_wdr.cpp:3294
+msgid "Shared files"
+msgstr "Κοινόχρηστα αρχεία"
+
+#: src/amuleDlg.cpp:365 src/amuleDlg.cpp:1811 src/muuli_wdr.cpp:2926
+#: src/muuli_wdr.cpp:3376 src/muuli_wdr.cpp:3423
+msgid "Messages"
+msgstr "Μηνύματα"
+
+#: src/amuleDlg.cpp:366 src/amuleDlg.cpp:1817 src/muuli_wdr.cpp:3424
+#: src/PrefsUnifiedDlg.cpp:312 src/Statistics.cpp:779 src/Statistics.cpp:1235
+msgid "Statistics"
+msgstr "Στατιστικές"
+
+#: src/amuleDlg.cpp:368 src/amuleDlg.cpp:1824 src/muuli_wdr.cpp:3426
+#: src/PrefsUnifiedDlg.cpp:328 src/utils/wxCas/src/wxcasprefs.cpp:39
+msgid "Preferences"
+msgstr "Προτιμήσεις"
+
+#: src/amuleDlg.cpp:371
+msgid "Navigate"
+msgstr ""
+
+#: src/amuleDlg.cpp:657
 #, fuzzy
 msgid "New version available"
 msgstr "Δεν είναι διαθέσιμο"
 
-#: src/amuleDlg.cpp:596
+#: src/amuleDlg.cpp:661
 #, fuzzy, c-format
 msgid ""
 "A new version of aMule (%s) is available.\n"
@@ -612,219 +650,186 @@ msgid ""
 "Would you like to open the download page?"
 msgstr "Η τελευταία έκδοση μπορεί να βρεθεί στο https://github.com/amule-org/amule/releases/latest"
 
-#: src/amuleDlg.cpp:678
+#: src/amuleDlg.cpp:743
 msgid "aMule dialog destroyed"
 msgstr ""
 
-#: src/amuleDlg.cpp:701 src/DataToText.cpp:68 src/IPFilter.cpp:547
+#: src/amuleDlg.cpp:766 src/DataToText.cpp:68 src/IPFilter.cpp:547
 msgid "Connecting"
 msgstr "Συνδέοντας"
 
-#: src/amuleDlg.cpp:893
+#: src/amuleDlg.cpp:958
 msgid "eD2k: Connecting"
 msgstr "eD2k: Συνδέεται"
 
-#: src/amuleDlg.cpp:897
+#: src/amuleDlg.cpp:962
 msgid "eD2k: Disconnected"
 msgstr "eD2k: Αποσυνδεδεμένο"
 
-#: src/amuleDlg.cpp:903
+#: src/amuleDlg.cpp:968
 msgid "Kad: Firewalled"
 msgstr "Kad: Πίσω από τοίχο προστασίας"
 
-#: src/amuleDlg.cpp:907
+#: src/amuleDlg.cpp:972
 msgid "Kad: Connected"
 msgstr "Kad: Συνδεδεμένο"
 
-#: src/amuleDlg.cpp:912
+#: src/amuleDlg.cpp:977
 msgid "Kad: Connecting"
 msgstr "Kad: Σε διαδικασία σύνδεσης"
 
-#: src/amuleDlg.cpp:916
+#: src/amuleDlg.cpp:981
 msgid "Kad: Off"
 msgstr "Kad: Εκτός"
 
-#: src/amuleDlg.cpp:964 src/DownloadListCtrl.cpp:505
+#: src/amuleDlg.cpp:1029 src/DownloadListCtrl.cpp:505
 #: src/DownloadListCtrl.cpp:749 src/FriendListCtrl.cpp:180
 #: src/muuli_wdr.cpp:731 src/muuli_wdr.cpp:782 src/muuli_wdr.cpp:846
-#: src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2224 src/muuli_wdr.cpp:2309
-#: src/muuli_wdr.cpp:3057 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
+#: src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2231 src/muuli_wdr.cpp:2316
+#: src/muuli_wdr.cpp:3064 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
 #: src/ServerListCtrl.cpp:606 src/TransferWnd.cpp:378
 #: src/utils/wxCas/src/wxcasprefs.cpp:235
 msgid "Cancel"
 msgstr "Ακύρωση"
 
-#: src/amuleDlg.cpp:965
+#: src/amuleDlg.cpp:1030
 msgid "Stop the current connection attempts"
 msgstr "Σταμάτησε τις τρέχουσες απόπειρες σύνδεσης"
 
-#: src/amuleDlg.cpp:970 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976
-#: src/muuli_wdr.cpp:2447
+#: src/amuleDlg.cpp:1035 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976
+#: src/muuli_wdr.cpp:2454
 msgid "Disconnect"
 msgstr "Αποσύνδεση"
 
-#: src/amuleDlg.cpp:971
+#: src/amuleDlg.cpp:1036
 msgid "Disconnect from the currently connected networks"
 msgstr "Αποσύνδεση από τα συνδεδεμένα δίκτυα"
 
-#: src/amuleDlg.cpp:976 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979
-#: src/muuli_wdr.cpp:2602 src/muuli_wdr.cpp:3054 src/muuli_wdr.cpp:3409
+#: src/amuleDlg.cpp:1041 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979
+#: src/muuli_wdr.cpp:2609 src/muuli_wdr.cpp:3061 src/muuli_wdr.cpp:3416
 msgid "Connect"
 msgstr "Σύνδεση"
 
-#: src/amuleDlg.cpp:977
+#: src/amuleDlg.cpp:1042
 msgid "Connect to the currently enabled networks"
 msgstr "Σύνδεση στα ενεργοποιημένα δίκτυα"
 
-#: src/amuleDlg.cpp:1089
+#: src/amuleDlg.cpp:1154
 #, fuzzy, c-format
 msgid "Up: %.1f%s (%.1f) | Down: %.1f%s (%.1f)"
 msgstr "Πάνω: %.1f(%.1f) | Κάτω: %.1f(%.1f)"
 
-#: src/amuleDlg.cpp:1091 src/amuleDlg.cpp:1093 src/amuleDlg.cpp:1097
-#: src/amuleDlg.cpp:1099 src/amuleDlg.cpp:1110 src/amuleDlg.cpp:1112
+#: src/amuleDlg.cpp:1156 src/amuleDlg.cpp:1158 src/amuleDlg.cpp:1162
+#: src/amuleDlg.cpp:1164 src/amuleDlg.cpp:1175 src/amuleDlg.cpp:1177
 #: src/MuleTrayIcon.cpp:796 src/MuleTrayIcon.cpp:799
 #, fuzzy
 msgid " MB/s"
 msgstr "MB/s"
 
-#: src/amuleDlg.cpp:1091 src/amuleDlg.cpp:1093 src/amuleDlg.cpp:1097
-#: src/amuleDlg.cpp:1099 src/amuleDlg.cpp:1110 src/amuleDlg.cpp:1112
+#: src/amuleDlg.cpp:1156 src/amuleDlg.cpp:1158 src/amuleDlg.cpp:1162
+#: src/amuleDlg.cpp:1164 src/amuleDlg.cpp:1175 src/amuleDlg.cpp:1177
 #: src/MuleTrayIcon.cpp:796 src/MuleTrayIcon.cpp:799
 #: src/utils/wxCas/src/wxcasframe.cpp:1041
 msgid " kB/s"
 msgstr " kB/s"
 
-#: src/amuleDlg.cpp:1096
+#: src/amuleDlg.cpp:1161
 #, fuzzy, c-format
 msgid "Up: %.1f%s | Down: %.1f%s"
 msgstr "Πάνω: %.1f | Κάτω: %.1f"
 
-#: src/amuleDlg.cpp:1128
+#: src/amuleDlg.cpp:1193
 #, c-format
 msgid "aMule (%s | Connected)"
 msgstr "aMule (%s | Συνδεδεμένο)"
 
-#: src/amuleDlg.cpp:1130
+#: src/amuleDlg.cpp:1195
 #, c-format
 msgid "aMule (%s | Disconnected)"
 msgstr "aMule (%s | Αποσυνδεδεμένο)"
 
-#: src/amuleDlg.cpp:1183
+#: src/amuleDlg.cpp:1248
 #, fuzzy, c-format
 msgid "Do you really want to exit %s?"
 msgstr "Σίγουρα θέλετε να κλείσετε το aMule;"
 
-#: src/amuleDlg.cpp:1185
+#: src/amuleDlg.cpp:1250
 msgid "Exit confirmation"
 msgstr "Έξοδος επιβεβαίωσης"
 
-#: src/amuleDlg.cpp:1548
+#: src/amuleDlg.cpp:1613
 msgid "Launch Command: "
 msgstr ""
 
-#: src/amuleDlg.cpp:1567 src/muuli_wdr.cpp:1971 src/Preferences.cpp:951
+#: src/amuleDlg.cpp:1632 src/muuli_wdr.cpp:1978 src/Preferences.cpp:952
 msgid "- default -"
 msgstr "- Προεπιλεγμένο -"
 
-#: src/amuleDlg.cpp:1595
+#: src/amuleDlg.cpp:1660
 #, c-format
 msgid "Skin directory '%s' does not exist"
 msgstr "Ο κατάλογος των θεμάτων '%s'  δεν υπάρχει"
 
-#: src/amuleDlg.cpp:1598
+#: src/amuleDlg.cpp:1663
 #, c-format
 msgid "WARNING: Unable to open skin file '%s' for read"
 msgstr "ΠΡΟΕΙΔΟΠΟΙΗΣΗ: Δεν είναι δυνατή η ανάγνωση του αρχείου θέματος '%s' "
 
-#: src/amuleDlg.cpp:1722 src/amuleDlg.cpp:1968 src/muuli_wdr.cpp:1485
-#: src/muuli_wdr.cpp:3411
-msgid "Networks"
-msgstr "Δίκτυα"
-
-#: src/amuleDlg.cpp:1726 src/muuli_wdr.cpp:3411
+#: src/amuleDlg.cpp:1791 src/muuli_wdr.cpp:3418
 msgid "Networks Window"
 msgstr "Παράθυρο δικτύων"
 
-#: src/amuleDlg.cpp:1728 src/muuli_wdr.cpp:3412
-msgid "Searches"
-msgstr "Αναζητήσεις"
-
-#: src/amuleDlg.cpp:1732 src/muuli_wdr.cpp:3412
+#: src/amuleDlg.cpp:1797 src/muuli_wdr.cpp:3419
 msgid "Searches Window"
 msgstr "Παράθυρο αναζητήσεων"
 
-#: src/amuleDlg.cpp:1734 src/DownloadListCtrl.cpp:740 src/muuli_wdr.cpp:392
-#: src/muuli_wdr.cpp:1578 src/muuli_wdr.cpp:3413 src/Statistics.cpp:829
-msgid "Downloads"
-msgstr "Κατεβασμένα"
-
-#: src/amuleDlg.cpp:1738 src/muuli_wdr.cpp:3413
+#: src/amuleDlg.cpp:1803 src/muuli_wdr.cpp:3420
 #, fuzzy
 msgid "Downloads Window"
 msgstr "Κατεβαίνει"
 
-#: src/amuleDlg.cpp:1740 src/muuli_wdr.cpp:3287
-msgid "Shared files"
-msgstr "Κοινόχρηστα αρχεία"
-
-#: src/amuleDlg.cpp:1744 src/muuli_wdr.cpp:3415
+#: src/amuleDlg.cpp:1809 src/muuli_wdr.cpp:3422
 msgid "Shared Files Window"
 msgstr "Παράθυρο κοινόχρηστων αρχείων"
 
-#: src/amuleDlg.cpp:1746 src/muuli_wdr.cpp:2919 src/muuli_wdr.cpp:3369
-#: src/muuli_wdr.cpp:3416
-msgid "Messages"
-msgstr "Μηνύματα"
-
-#: src/amuleDlg.cpp:1750 src/muuli_wdr.cpp:3416
+#: src/amuleDlg.cpp:1815 src/muuli_wdr.cpp:3423
 msgid "Messages Window"
 msgstr "Παράθυρό μηνυμάτων"
 
-#: src/amuleDlg.cpp:1752 src/muuli_wdr.cpp:3417 src/PrefsUnifiedDlg.cpp:312
-#: src/Statistics.cpp:779 src/Statistics.cpp:1235
-msgid "Statistics"
-msgstr "Στατιστικές"
-
-#: src/amuleDlg.cpp:1756 src/muuli_wdr.cpp:3417
+#: src/amuleDlg.cpp:1821 src/muuli_wdr.cpp:3424
 msgid "Statistics Graph Window"
 msgstr "Παράθυρο στατιστικών διαγραμμάτων"
 
-#: src/amuleDlg.cpp:1759 src/muuli_wdr.cpp:3419 src/PrefsUnifiedDlg.cpp:328
-#: src/utils/wxCas/src/wxcasprefs.cpp:39
-msgid "Preferences"
-msgstr "Προτιμήσεις"
-
-#: src/amuleDlg.cpp:1763 src/muuli_wdr.cpp:3419
+#: src/amuleDlg.cpp:1828 src/muuli_wdr.cpp:3426
 msgid "Preferences Settings Window"
 msgstr "Παράθυρο ρυθμίσεων"
 
-#: src/amuleDlg.cpp:1766 src/muuli_wdr.cpp:3420
+#: src/amuleDlg.cpp:1831 src/muuli_wdr.cpp:3427
 msgid "Import"
 msgstr "Εισαγωγή"
 
-#: src/amuleDlg.cpp:1770 src/muuli_wdr.cpp:3420
+#: src/amuleDlg.cpp:1835 src/muuli_wdr.cpp:3427
 msgid "The partfile importer tool"
 msgstr "Το εργαλείο εισαγωγής ημιτελών αρχείων"
 
-#: src/amuleDlg.cpp:1773 src/muuli_wdr.cpp:3421
+#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3428
 #: src/utils/aLinkCreator/src/alcframe.cpp:262
 msgid "About"
 msgstr "Σχετικά"
 
-#: src/amuleDlg.cpp:1773 src/muuli_wdr.cpp:3421
+#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3428
 msgid "About/Help"
 msgstr "Σχετικά/Βοήθεια"
 
-#: src/amuleDlg.cpp:1971
+#: src/amuleDlg.cpp:2036
 msgid "eD2k network"
 msgstr "Δίκτυο eD2k"
 
-#: src/amuleDlg.cpp:1974
+#: src/amuleDlg.cpp:2039
 msgid "Kad network"
 msgstr "Δίκτυο Kad"
 
-#: src/amuleDlg.cpp:1974
+#: src/amuleDlg.cpp:2039
 msgid "No network"
 msgstr "Κανένα δίκτυο"
 
@@ -1361,19 +1366,19 @@ msgstr "Αυτόματη [Υψηλή]"
 msgid "Very low"
 msgstr "Πολύ χαμηλή"
 
-#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:743 src/muuli_wdr.cpp:2275
+#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:743 src/muuli_wdr.cpp:2282
 #: src/ServerListCtrl.cpp:263 src/ServerListCtrl.cpp:456
 #: src/SharedFilesCtrl.cpp:145
 msgid "Low"
 msgstr "Χαμηλή"
 
-#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:744 src/muuli_wdr.cpp:2276
+#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:744 src/muuli_wdr.cpp:2283
 #: src/ServerListCtrl.cpp:266 src/ServerListCtrl.cpp:457
 #: src/SharedFilesCtrl.cpp:146
 msgid "Normal"
 msgstr "Κανονική"
 
-#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:745 src/muuli_wdr.cpp:2277
+#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:745 src/muuli_wdr.cpp:2284
 #: src/ServerListCtrl.cpp:269 src/ServerListCtrl.cpp:458
 #: src/SharedFilesCtrl.cpp:147
 msgid "High"
@@ -1465,8 +1470,8 @@ msgstr "Τοπικός διακομιστής"
 msgid "Remote Server"
 msgstr "Απομακρυσμένος διακομιστής"
 
-#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3174
-#: src/SearchDlg.cpp:111 src/TextClient.cpp:911
+#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3181
+#: src/SearchDlg.cpp:119 src/TextClient.cpp:911
 msgid "Kad"
 msgstr "Kad"
 
@@ -1537,7 +1542,7 @@ msgstr "Μέρος"
 msgid "Size"
 msgstr "Μέγεθος"
 
-#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3241
+#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3248
 msgid "Transferred"
 msgstr "Μεταφέρθηκαν"
 
@@ -1595,7 +1600,7 @@ msgstr ""
 "Αντίδραση από %s (%s)\n"
 "\n"
 
-#: src/DownloadListCtrl.cpp:746 src/muuli_wdr.cpp:2278
+#: src/DownloadListCtrl.cpp:746 src/muuli_wdr.cpp:2285
 #: src/SharedFilesCtrl.cpp:150
 msgid "Auto"
 msgstr "Αυτόματη"
@@ -1633,7 +1638,7 @@ msgid "Extended Options"
 msgstr "Εκτεταμένες Προτιμήσεις"
 
 #: src/DownloadListCtrl.cpp:770 src/DownloadListCtrl.cpp:822
-#: src/muuli_wdr.cpp:1789
+#: src/muuli_wdr.cpp:1796
 msgid "Preview"
 msgstr "Προεπισκόπιση"
 
@@ -2348,19 +2353,19 @@ msgstr ""
 msgid "eD2k"
 msgstr "eD2k"
 
-#: src/FirstRunWizard.cpp:349 src/muuli_wdr.cpp:1488
+#: src/FirstRunWizard.cpp:349 src/muuli_wdr.cpp:1495
 msgid "Kademlia"
 msgstr "Kademlia"
 
-#: src/FirstRunWizard.cpp:359 src/muuli_wdr.cpp:1416
+#: src/FirstRunWizard.cpp:359 src/muuli_wdr.cpp:1423
 msgid "Standard TCP Port "
 msgstr "Πρότυπη θύρα TCP"
 
-#: src/FirstRunWizard.cpp:365 src/muuli_wdr.cpp:1428
+#: src/FirstRunWizard.cpp:365 src/muuli_wdr.cpp:1435
 msgid "Extended UDP port (Kad / global search) "
 msgstr "Εκτεταμένη θύρα UDP (Kad / καθολική αναζήτηση)"
 
-#: src/FirstRunWizard.cpp:377 src/muuli_wdr.cpp:1435
+#: src/FirstRunWizard.cpp:377 src/muuli_wdr.cpp:1442
 msgid "Enable UPnP for router port forwarding"
 msgstr "Ενεργοποίηση UPnP για προώθηση της θύρας του δρομολογητή"
 
@@ -2387,7 +2392,7 @@ msgstr ""
 msgid "Your peer lists are already in place - nothing to download."
 msgstr "Ήδη προσπαθείτε να κατεβάσετε το αρχείο %s"
 
-#: src/FirstRunWizard.cpp:434 src/muuli_wdr.cpp:1533
+#: src/FirstRunWizard.cpp:434 src/muuli_wdr.cpp:1540
 msgid "Auto-update server list at startup"
 msgstr "Αυτόματη ενημέρωση λίστας διακομιστών κατά την εκκίνηση"
 
@@ -2433,23 +2438,23 @@ msgid ""
 "want downloads on a different (e.g. larger) disk."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:549 src/FirstRunWizard.cpp:611 src/muuli_wdr.cpp:1701
+#: src/FirstRunWizard.cpp:549 src/FirstRunWizard.cpp:611 src/muuli_wdr.cpp:1708
 msgid "Destination folder for downloads"
 msgstr "Κατάλογος για τα εισερχόμενα"
 
-#: src/FirstRunWizard.cpp:553 src/FirstRunWizard.cpp:569 src/muuli_wdr.cpp:1342
-#: src/muuli_wdr.cpp:1359 src/muuli_wdr.cpp:1676 src/muuli_wdr.cpp:1707
-#: src/muuli_wdr.cpp:1719 src/muuli_wdr.cpp:2762
+#: src/FirstRunWizard.cpp:553 src/FirstRunWizard.cpp:569 src/muuli_wdr.cpp:1349
+#: src/muuli_wdr.cpp:1366 src/muuli_wdr.cpp:1683 src/muuli_wdr.cpp:1714
+#: src/muuli_wdr.cpp:1726 src/muuli_wdr.cpp:2769
 #: src/utils/aLinkCreator/src/alcframe.cpp:135
 #: src/utils/wxCas/src/wxcasprefs.cpp:52 src/utils/wxCas/src/wxcasprefs.cpp:118
 msgid "Browse"
 msgstr "Επιλογή"
 
-#: src/FirstRunWizard.cpp:559 src/muuli_wdr.cpp:1712
+#: src/FirstRunWizard.cpp:559 src/muuli_wdr.cpp:1719
 msgid "(All files in this folder are shared with other peers)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:565 src/FirstRunWizard.cpp:624 src/muuli_wdr.cpp:1714
+#: src/FirstRunWizard.cpp:565 src/FirstRunWizard.cpp:624 src/muuli_wdr.cpp:1721
 msgid "Folder for temporary download files"
 msgstr "Κατάλογος για τα προσωρινά αρχεία"
 
@@ -2480,7 +2485,7 @@ msgstr "Αποτυχία γραψίματος στο αρχείο της λίσ�
 msgid "CRITICAL - no client on StartChatSession"
 msgstr ""
 
-#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2668 src/muuli_wdr.cpp:3345
+#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2675 src/muuli_wdr.cpp:3352
 msgid "Friends"
 msgstr "Φίλοι"
 
@@ -2870,7 +2875,7 @@ msgstr "Λόγος μοιράσματος"
 msgid "Uploaded"
 msgstr "Ανέβηκε"
 
-#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3225
+#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3232
 msgid "Requested"
 msgstr "Ζητήθηκε:"
 
@@ -2996,7 +3001,7 @@ msgid "WARNING: "
 msgstr "ΠΡΟΕΙΔΟΠΟΙΗΣΗ:"
 
 #: src/MuleNotebook.cpp:179 src/muuli_wdr.cpp:817 src/muuli_wdr.cpp:1229
-#: src/muuli_wdr.cpp:3129 src/muuli_wdr.cpp:3385
+#: src/muuli_wdr.cpp:3136 src/muuli_wdr.cpp:3392
 msgid "Close"
 msgstr "Κλείσιμο"
 
@@ -3009,12 +3014,12 @@ msgstr "Αποκοπή"
 msgid "Copy"
 msgstr "Αντιγραφή"
 
-#: src/MuleTextCtrl.cpp:88
+#: src/MuleTextCtrl.cpp:88 src/SearchDlg.cpp:261
 msgid "Paste"
 msgstr "Επικόλληση"
 
 #: src/MuleTextCtrl.cpp:89 src/muuli_wdr.cpp:358 src/muuli_wdr.cpp:757
-#: src/muuli_wdr.cpp:2352 src/muuli_wdr.cpp:2371 src/muuli_wdr.cpp:2393
+#: src/muuli_wdr.cpp:2359 src/muuli_wdr.cpp:2378 src/muuli_wdr.cpp:2400
 #: src/utils/aLinkCreator/src/alcframe.cpp:142
 msgid "Clear"
 msgstr "Καθαρισμός"
@@ -3112,8 +3117,8 @@ msgid "Exit"
 msgstr "Έξοδος"
 
 #: src/MuleTrayIcon.cpp:579 src/MuleTrayIcon.cpp:945 src/MuleTrayIcon.cpp:965
-#: src/muuli_wdr.cpp:1391 src/muuli_wdr.cpp:1399 src/muuli_wdr.cpp:1406
-#: src/muuli_wdr.cpp:1835 src/muuli_wdr.cpp:1841 src/OtherFunctions.cpp:91
+#: src/muuli_wdr.cpp:1398 src/muuli_wdr.cpp:1406 src/muuli_wdr.cpp:1413
+#: src/muuli_wdr.cpp:1842 src/muuli_wdr.cpp:1848 src/OtherFunctions.cpp:91
 #: src/StatisticsDlg.cpp:93 src/StatisticsDlg.cpp:95
 msgid "kB/s"
 msgstr "kB/s"
@@ -3284,7 +3289,7 @@ msgstr "Όνομα:"
 msgid "Type"
 msgstr "Τύπος"
 
-#: src/muuli_wdr.cpp:215 src/SearchDlg.cpp:110 src/SearchListCtrl.cpp:853
+#: src/muuli_wdr.cpp:215 src/SearchDlg.cpp:118 src/SearchListCtrl.cpp:853
 msgid "Local"
 msgstr "Τοπικό"
 
@@ -3355,7 +3360,7 @@ msgstr "Bytes"
 msgid "KB"
 msgstr "KB"
 
-#: src/muuli_wdr.cpp:274 src/muuli_wdr.cpp:293 src/muuli_wdr.cpp:1620
+#: src/muuli_wdr.cpp:274 src/muuli_wdr.cpp:293 src/muuli_wdr.cpp:1627
 #: src/OtherFunctions.cpp:64
 msgid "MB"
 msgstr "MB"
@@ -3372,7 +3377,7 @@ msgstr "Μέγιστο αρχείο"
 msgid "Availability"
 msgstr "Διαθεσιμότητα"
 
-#: src/muuli_wdr.cpp:312 src/muuli_wdr.cpp:398 src/muuli_wdr.cpp:3290
+#: src/muuli_wdr.cpp:312 src/muuli_wdr.cpp:398 src/muuli_wdr.cpp:3297
 msgid "Filter:"
 msgstr "Φίλτρο:"
 
@@ -3404,7 +3409,7 @@ msgstr ""
 msgid "Stop"
 msgstr "Σταμάτημα"
 
-#: src/muuli_wdr.cpp:348 src/muuli_wdr.cpp:1385 src/SearchListCtrl.cpp:732
+#: src/muuli_wdr.cpp:348 src/muuli_wdr.cpp:1392 src/SearchListCtrl.cpp:732
 msgid "Download"
 msgstr "Κατέβασμα"
 
@@ -3436,8 +3441,8 @@ msgstr "Ολοκλήρωση πηγών"
 #: src/muuli_wdr.cpp:1160 src/muuli_wdr.cpp:1167 src/muuli_wdr.cpp:1172
 #: src/muuli_wdr.cpp:1179 src/muuli_wdr.cpp:1184 src/muuli_wdr.cpp:1191
 #: src/muuli_wdr.cpp:1205 src/muuli_wdr.cpp:1212 src/muuli_wdr.cpp:1217
-#: src/muuli_wdr.cpp:1224 src/muuli_wdr.cpp:3227 src/muuli_wdr.cpp:3235
-#: src/muuli_wdr.cpp:3243
+#: src/muuli_wdr.cpp:1224 src/muuli_wdr.cpp:3234 src/muuli_wdr.cpp:3242
+#: src/muuli_wdr.cpp:3250
 msgid "N/A"
 msgstr "Δεν υπάρχει"
 
@@ -3582,7 +3587,7 @@ msgstr ""
 msgid "Album :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:685 src/muuli_wdr.cpp:2247
+#: src/muuli_wdr.cpp:685 src/muuli_wdr.cpp:2254
 msgid "Title :"
 msgstr "Τίτλος:"
 
@@ -3691,7 +3696,7 @@ msgstr "Όνομα χρήστη :"
 msgid "Userhash :"
 msgstr "Τεμάχιο χρήστη :"
 
-#: src/muuli_wdr.cpp:895 src/muuli_wdr.cpp:1741 src/muuli_wdr.cpp:2442
+#: src/muuli_wdr.cpp:895 src/muuli_wdr.cpp:1748 src/muuli_wdr.cpp:2449
 #: src/utils/aLinkCreator/src/alcframe.cpp:137
 msgid "Add"
 msgstr "Προσθήκη"
@@ -3700,15 +3705,15 @@ msgstr "Προσθήκη"
 msgid "Download-Speed"
 msgstr "Ταχύτητα κατεβάσματος"
 
-#: src/muuli_wdr.cpp:954 src/muuli_wdr.cpp:989 src/muuli_wdr.cpp:2546
+#: src/muuli_wdr.cpp:954 src/muuli_wdr.cpp:989 src/muuli_wdr.cpp:2553
 msgid "Current"
 msgstr "Τρέχων"
 
-#: src/muuli_wdr.cpp:962 src/muuli_wdr.cpp:997 src/muuli_wdr.cpp:2554
+#: src/muuli_wdr.cpp:962 src/muuli_wdr.cpp:997 src/muuli_wdr.cpp:2561
 msgid "Running average"
 msgstr "Μέσο τρεξίματος"
 
-#: src/muuli_wdr.cpp:970 src/muuli_wdr.cpp:1005 src/muuli_wdr.cpp:2562
+#: src/muuli_wdr.cpp:970 src/muuli_wdr.cpp:1005 src/muuli_wdr.cpp:2569
 msgid "Session average"
 msgstr "Μέσο περιόδου"
 
@@ -3720,7 +3725,7 @@ msgstr "Ταχύτητα ανεβάσματος"
 msgid "Connections"
 msgstr "Συνδέσεις"
 
-#: src/muuli_wdr.cpp:1024 src/muuli_wdr.cpp:1860
+#: src/muuli_wdr.cpp:1024 src/muuli_wdr.cpp:1867
 msgid "Active downloads"
 msgstr "Ενεργά κατεβάσματα"
 
@@ -3728,7 +3733,7 @@ msgstr "Ενεργά κατεβάσματα"
 msgid "Active connections (1:1)"
 msgstr "Ενεργές συνδέσεις (1:1)"
 
-#: src/muuli_wdr.cpp:1040 src/muuli_wdr.cpp:1861
+#: src/muuli_wdr.cpp:1040 src/muuli_wdr.cpp:1868
 msgid "Active uploads"
 msgstr "Ενεργά ανεβάσματα"
 
@@ -3845,8 +3850,8 @@ msgstr "Αυτό είναι το όνομα που οι άλλοι χρήστε�
 msgid "Language: "
 msgstr "Γλώσσα:"
 
-#: src/muuli_wdr.cpp:1257 src/muuli_wdr.cpp:1323 src/muuli_wdr.cpp:1327
-#: src/muuli_wdr.cpp:1330
+#: src/muuli_wdr.cpp:1257 src/muuli_wdr.cpp:1330 src/muuli_wdr.cpp:1334
+#: src/muuli_wdr.cpp:1337
 msgid "The delay before showing tool-tips."
 msgstr "Ο χρόνος πριν εμφανιστεί το επεξηγηματικό κείμενο."
 
@@ -3924,941 +3929,950 @@ msgstr ""
 msgid "Enabling this will make aMule to show notifications when finished downloading."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1322
+#: src/muuli_wdr.cpp:1323
+#, fuzzy
+msgid "Remember search history"
+msgstr "Απομνημόνευση αυτών των ρυθμίσεων"
+
+#: src/muuli_wdr.cpp:1324
+msgid "Keeps a dropdown list of your past search terms in the Search tab's Name field. This remembers the queries you typed, not the results they returned."
+msgstr ""
+
+#: src/muuli_wdr.cpp:1329
 msgid "Tooltip delay time: "
 msgstr "Χρόνος καθυστέρησης επεξηγήσεων:"
 
-#: src/muuli_wdr.cpp:1329
+#: src/muuli_wdr.cpp:1336
 msgid "seconds"
 msgstr "δεπτερόλεπτα"
 
-#: src/muuli_wdr.cpp:1333
+#: src/muuli_wdr.cpp:1340
 msgid "Browser Selection"
 msgstr "Επιλογή περιηγητή ιστοσελίδων"
 
-#: src/muuli_wdr.cpp:1339
+#: src/muuli_wdr.cpp:1346
 msgid "Enter your browser name here. Leave this field empty to use the system default browser."
 msgstr "Εισάγετε το όνομα το περιηγητή ιστολελίδων. Αφήστε αυτό το πεδίο κενό για τον προεπιλεγμένο περιηγητή."
 
-#: src/muuli_wdr.cpp:1346
+#: src/muuli_wdr.cpp:1353
 msgid "Open in new tab if possible"
 msgstr "Αν είναι δυνατόν, άνοιξε τη σελίδα σε καινούρια καρτέλα"
 
-#: src/muuli_wdr.cpp:1348
+#: src/muuli_wdr.cpp:1355
 msgid "Open the web page in a new tab instead of in a new window when possible"
 msgstr "Άνοιξε την ιστοσελίδα σε καινούρια καρτέλα αντί σε καινούριο παράθυρο αν αυτό είναι εφικτό"
 
-#: src/muuli_wdr.cpp:1352
+#: src/muuli_wdr.cpp:1359
 msgid "Video Player"
 msgstr "Πρόγραμμα προβολής βίντεο"
 
-#: src/muuli_wdr.cpp:1379
+#: src/muuli_wdr.cpp:1386
 msgid "Bandwidth limits"
 msgstr "Ευρυζωνικά όρια"
 
-#: src/muuli_wdr.cpp:1393
+#: src/muuli_wdr.cpp:1400
 msgid "Upload"
 msgstr "Ανέβασμα"
 
-#: src/muuli_wdr.cpp:1401
+#: src/muuli_wdr.cpp:1408
 msgid "Slot Allocation"
 msgstr "Ανάθεση θυρίδας"
 
-#: src/muuli_wdr.cpp:1410
+#: src/muuli_wdr.cpp:1417
 msgid "Ports"
 msgstr "Θύρες"
 
-#: src/muuli_wdr.cpp:1420
+#: src/muuli_wdr.cpp:1427
 msgid "This is the standard eD2k port and cannot be disabled."
 msgstr "Αυτή είναι η βασική θύρα eD2k και δεν μπορεί να απενεργοποιηθεί."
 
-#: src/muuli_wdr.cpp:1423
+#: src/muuli_wdr.cpp:1430
 msgid "UDP port for server requests (TCP+3):"
 msgstr "Θύρα UDP για αιτήσεις εξυπηρετητή (TCP+3):"
 
-#: src/muuli_wdr.cpp:1425
+#: src/muuli_wdr.cpp:1432
 msgid "4665"
 msgstr "4665"
 
-#: src/muuli_wdr.cpp:1432
+#: src/muuli_wdr.cpp:1439
 msgid "This UDP port is used for extended eD2k requests and Kad network"
 msgstr "Αυτή η θύρα UDP χρησιμοποιήται για εκτεταμένες αιτήσεις eD2k και για το δίκτυο Kad"
 
-#: src/muuli_wdr.cpp:1439
+#: src/muuli_wdr.cpp:1446
 msgid "UPnP TCP Port (Optional):"
 msgstr "Θύρα UPnP TCP (Προαιρετική):"
 
-#: src/muuli_wdr.cpp:1449
+#: src/muuli_wdr.cpp:1456
 msgid "Bind local address to IP (empty for any):"
 msgstr "Συνέδεσε την τοπική διεύθυνση στην διεύθυνση (κενό για όλες):"
 
-#: src/muuli_wdr.cpp:1452
+#: src/muuli_wdr.cpp:1459
 msgid "Advanced users only: If you have multiple network interfaces, enter the address of the interface to which aMule should be bound."
 msgstr "Μόνο για προχωρημένους χρήστες: Αν έχετε πολλαπλά δικτυακά περιβάλλοντα, εισάγετε την διεύθυνση του περιβάλλοντος με το οποίο το aMule πρέπει να συνδεθεί."
 
-#: src/muuli_wdr.cpp:1455 src/muuli_wdr.cpp:2054
+#: src/muuli_wdr.cpp:1462 src/muuli_wdr.cpp:2061
 #, fuzzy
 msgid "Bind to network interface (empty for any):"
 msgstr "Συνέδεσε την τοπική διεύθυνση στην διεύθυνση (κενό για όλες):"
 
-#: src/muuli_wdr.cpp:1468
+#: src/muuli_wdr.cpp:1475
 msgid "Advanced users only: pin all of aMule's traffic to one network interface, chosen from the list or typed in by name (e.g. tun0, eth0, en0) or index. Unlike binding to an IP, this stops traffic leaking out via the default route - useful with a VPN. Requires no elevated privileges."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1474
+#: src/muuli_wdr.cpp:1481
 msgid "Max sources per downloading file:"
 msgstr "Μέγιστος αριθμός πηγών ανά εισερχόμενο αρχείο:"
 
-#: src/muuli_wdr.cpp:1478
+#: src/muuli_wdr.cpp:1485
 msgid "Max simultaneous connections:"
 msgstr "Μέγιστος αριθμός παράλληλων συνδέσεων:"
 
-#: src/muuli_wdr.cpp:1491 src/muuli_wdr.cpp:3169
+#: src/muuli_wdr.cpp:1498 src/muuli_wdr.cpp:3176
 msgid "ED2K"
 msgstr "ED2K"
 
-#: src/muuli_wdr.cpp:1498
+#: src/muuli_wdr.cpp:1505
 msgid "Autoconnect on startup"
 msgstr "Αυτόματη σύνδεση κατά την εκκίνηση"
 
-#: src/muuli_wdr.cpp:1501
+#: src/muuli_wdr.cpp:1508
 msgid "Reconnect on loss"
 msgstr "Επανασύνδεση σε περίπτωση διακοπής"
 
-#: src/muuli_wdr.cpp:1523
+#: src/muuli_wdr.cpp:1530
 msgid "Remove dead server after"
 msgstr "Αφαίρεση του νεκρού διακομιστή ύστερα από"
 
-#: src/muuli_wdr.cpp:1524
+#: src/muuli_wdr.cpp:1531
 msgid "Static servers are never removed, even when unreachable."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1528
+#: src/muuli_wdr.cpp:1535
 msgid "retries"
 msgstr "προσπάθειες"
 
-#: src/muuli_wdr.cpp:1536
+#: src/muuli_wdr.cpp:1543
 msgid "List"
 msgstr "Λίστα"
 
-#: src/muuli_wdr.cpp:1539
+#: src/muuli_wdr.cpp:1546
 msgid "Update server list when connecting to a server"
 msgstr "Ενημέρωση της λίστας διακομιστών κατά τη σύνδεση σε διακομιστή"
 
-#: src/muuli_wdr.cpp:1542
+#: src/muuli_wdr.cpp:1549
 msgid "Update server list when a client connects"
 msgstr "Ενημέρωση της λίστας διακομιστών κατά τη σύνδεση σε πελάτη"
 
-#: src/muuli_wdr.cpp:1545
+#: src/muuli_wdr.cpp:1552
 msgid "Use priority system"
 msgstr "Χρήση συστήματος προτεραιότητα"
 
-#: src/muuli_wdr.cpp:1549
+#: src/muuli_wdr.cpp:1556
 msgid "Use smart LowID check on connect"
 msgstr "Χρήση έξυπνου ελέγχου LowID κατά τη σύνδεση"
 
-#: src/muuli_wdr.cpp:1553
+#: src/muuli_wdr.cpp:1560
 msgid "Safe connect"
 msgstr "Ασφαλής σύνδεση"
 
-#: src/muuli_wdr.cpp:1557
+#: src/muuli_wdr.cpp:1564
 msgid "Autoconnect to servers in static list only"
 msgstr "Αυτόματη σύνδεση μόνο με τους διακομιστές της στατικής λίστας"
 
-#: src/muuli_wdr.cpp:1560
+#: src/muuli_wdr.cpp:1567
 msgid "Set manually added servers to High Priority"
 msgstr "Υψηλή προτεραιότητα στους διακομιστές που προστέθηκαν με το χέρι"
 
-#: src/muuli_wdr.cpp:1581
+#: src/muuli_wdr.cpp:1588
 msgid "Add files to download in pause mode"
 msgstr "Προσθήκη αρχείων προς κατέβασμα κατά τη διάρκεια παύσης"
 
-#: src/muuli_wdr.cpp:1583
+#: src/muuli_wdr.cpp:1590
 msgid "Add files to download with auto priority"
 msgstr "Προσθήκη αρχείων προς κατέβασμα με αυτόματη προτεραιότητα"
 
-#: src/muuli_wdr.cpp:1586
+#: src/muuli_wdr.cpp:1593
 msgid "Try to download first and last chunks first"
 msgstr "Προσπάθησε να κατεβάσεις πρώτα τα αρχικά και τελικά κομμάτια"
 
-#: src/muuli_wdr.cpp:1590
+#: src/muuli_wdr.cpp:1597
 msgid "Endgame mode: rotate to faster sources for the final blocks"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1593
+#: src/muuli_wdr.cpp:1600
 msgid "Start next paused file when a file completes"
 msgstr "Εκκίνηση του επόμενου σταματημένου αρχείου όταν ένα αρχείο ολοκληρωθεί"
 
-#: src/muuli_wdr.cpp:1596
+#: src/muuli_wdr.cpp:1603
 msgid "From the same category"
 msgstr "Από την ίδια κατηγορία"
 
-#: src/muuli_wdr.cpp:1598
+#: src/muuli_wdr.cpp:1605
 msgid "In alphabetic order"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1600
+#: src/muuli_wdr.cpp:1607
 msgid "Preallocate disk space for new files"
 msgstr "Δέσμευση χώρου στο δίσκο για καινούρια αρχεία"
 
-#: src/muuli_wdr.cpp:1601
+#: src/muuli_wdr.cpp:1608
 msgid "For new files preallocates disk space for the whole file, thus reduces fragmentation"
 msgstr "Δεσμεύει χώρο στο δίσκο για καινούρια αρχεία και έτσι μειώνει τον κατακερματισμό"
 
-#: src/muuli_wdr.cpp:1606
+#: src/muuli_wdr.cpp:1613
 msgid "Create new files as sparse files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1607
+#: src/muuli_wdr.cpp:1614
 msgid "A sparse file reserves its full size on disk immediately without writing real data to it -- fast, but unsupported or slow on some filesystems, and free-space accounting stays optimistic while the download is in progress. Turn this off to grow the file only as data arrives."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1612
+#: src/muuli_wdr.cpp:1619
 msgid "Stop downloads when free disk space reaches "
 msgstr "Σταμάτημα του κατεβάσματος όταν ο ελεύθερος δίσκος φτάσει τα"
 
-#: src/muuli_wdr.cpp:1613
+#: src/muuli_wdr.cpp:1620
 msgid "Select this if you want aMule to check your disk space"
 msgstr "Επιλέξτε αυτό αν θέλετε το aMule να ελέγξει τον χώρο στον δίσκο σας"
 
-#: src/muuli_wdr.cpp:1617
+#: src/muuli_wdr.cpp:1624
 msgid "Enter here the min disk space desired."
 msgstr "Γράψτε εδώ των ελάχιστο επιθυμητό χώρο στον δίσκο."
 
-#: src/muuli_wdr.cpp:1623
+#: src/muuli_wdr.cpp:1630
 msgid "Save 10 sources on rare files (< 20 sources)"
 msgstr "Αποθήκευση 10 πηγών σε σπάνια αρχεία (<20 πηγές)"
 
-#: src/muuli_wdr.cpp:1627 src/Statistics.cpp:790
+#: src/muuli_wdr.cpp:1634 src/Statistics.cpp:790
 msgid "Uploads"
 msgstr "Ανεβασμένα"
 
-#: src/muuli_wdr.cpp:1630
+#: src/muuli_wdr.cpp:1637
 msgid "Add new shared files with auto priority"
 msgstr "Προσθήκη νέων κοινόχρηστων αρχείων με αυτόματη προτεραιότητα"
 
-#: src/muuli_wdr.cpp:1636
+#: src/muuli_wdr.cpp:1643
 msgid "Intelligent Corruption Handling (I.C.H.)"
 msgstr "Έξυπνη διαχείριση φθοράς (Ε.Δ.Φ.)"
 
-#: src/muuli_wdr.cpp:1639
+#: src/muuli_wdr.cpp:1646
 msgid "Enable"
 msgstr "Ενεργοποιήση"
 
-#: src/muuli_wdr.cpp:1642
+#: src/muuli_wdr.cpp:1649
 msgid "Advanced I.C.H. trusts every hash (not recommended)"
 msgstr "Προχωρημένη Ε.Δ.Φ. εμπιστεύεται κάθε κατακερματισμό (δεν συνιστάται)"
 
-#: src/muuli_wdr.cpp:1654 src/PrefsUnifiedDlg.cpp:1910
+#: src/muuli_wdr.cpp:1661 src/PrefsUnifiedDlg.cpp:1910
 msgid "Media metadata extraction"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1658
+#: src/muuli_wdr.cpp:1665
 msgid "Extract length / bitrate / codec from shared audio and video files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1660
+#: src/muuli_wdr.cpp:1667
 msgid "When enabled, aMule runs ffprobe on each shared media file to fill in the Length / Bitrate / Codec columns other clients see when they find the file in a search. Requires ffmpeg (the ffprobe binary) to be installed."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1667
+#: src/muuli_wdr.cpp:1674
 msgid "Path to ffprobe:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1672
+#: src/muuli_wdr.cpp:1679
 msgid "Full path to the ffprobe binary. Leave empty to have aMule auto-detect it on startup."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1680
+#: src/muuli_wdr.cpp:1687
 msgid "Detect"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1681
+#: src/muuli_wdr.cpp:1688
 msgid "Search the standard install locations for an ffprobe binary and fill the path field."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1705
+#: src/muuli_wdr.cpp:1712
 msgid ""
 "Completed downloads are stored here. All files in this folder are automatically shared with other peers.\n"
 "If this folder also holds files you don't want to share, point it at an aMule-only sub-folder."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1708
+#: src/muuli_wdr.cpp:1715
 msgid "Pick the folder where completed downloads will be stored. All files in that folder will be shared with other peers."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1722
+#: src/muuli_wdr.cpp:1729
 msgid "Shared folders"
 msgstr "Κοινόχρηστα αρχεία"
 
-#: src/muuli_wdr.cpp:1728
+#: src/muuli_wdr.cpp:1735
 msgid "(Folders shared by the core. Enter a path to add one.)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1736
+#: src/muuli_wdr.cpp:1743
 msgid "Absolute path of a folder on the core's machine, e.g. /home/user/shared"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1738 src/PrefsUnifiedDlg.cpp:2794
+#: src/muuli_wdr.cpp:1745 src/PrefsUnifiedDlg.cpp:2794
 msgid "Recursive"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1739
+#: src/muuli_wdr.cpp:1746
 msgid "Share every sub-folder underneath this one, including ones created later."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1743 src/utils/aLinkCreator/src/alcframe.cpp:141
+#: src/muuli_wdr.cpp:1750 src/utils/aLinkCreator/src/alcframe.cpp:141
 msgid "Remove"
 msgstr "Αφαίρεση"
 
-#: src/muuli_wdr.cpp:1747
+#: src/muuli_wdr.cpp:1754
 msgid "(Right click on folder icon for recursive share)"
 msgstr "(Δεξί κλικ στην εικόνα του καταλόγου για να γίνουν κοινόχρηστοι οι υποκατάλογοι)"
 
-#: src/muuli_wdr.cpp:1754
+#: src/muuli_wdr.cpp:1761
 msgid "Share hidden files"
 msgstr "Κάνε τα κρυφά αρχεία κοινόχρηστα"
 
-#: src/muuli_wdr.cpp:1760
+#: src/muuli_wdr.cpp:1767
 msgid "Automatically rescan shared folders for changes"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1766
+#: src/muuli_wdr.cpp:1773
 msgid "Follow symbolic links in shared folders"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1772
+#: src/muuli_wdr.cpp:1779
 msgid "Exclude files matching:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1775
+#: src/muuli_wdr.cpp:1782
 msgid "Wildcard patterns separated by '|', e.g. .DS_Store|Thumbs.db|*.tmp. Files whose name matches are not shared. Matching is case-insensitive."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1779
+#: src/muuli_wdr.cpp:1786
 msgid "Patterns are regular expressions"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1780
+#: src/muuli_wdr.cpp:1787
 msgid "When set, the whole field is one regular expression ('|' is alternation). When unset, it is a list of '|'-separated wildcards."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1790
+#: src/muuli_wdr.cpp:1797
 msgid "Show how many shared files the current pattern would exclude."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1811
+#: src/muuli_wdr.cpp:1818
 msgid "Graphs"
 msgstr "Γραφικές Παραστάσεις"
 
-#: src/muuli_wdr.cpp:1814 src/muuli_wdr.cpp:1876
+#: src/muuli_wdr.cpp:1821 src/muuli_wdr.cpp:1883
 msgid "Update delay : 5 secs"
 msgstr "Χρόνος καθυστέρηση ενημέρωσης : 5 δευτερόλεπτα"
 
-#: src/muuli_wdr.cpp:1818
+#: src/muuli_wdr.cpp:1825
 msgid "Time for average graph: 100 mins"
 msgstr "Χρόνος μέσου γραφήματος: 100 λεπτά"
 
-#: src/muuli_wdr.cpp:1822
+#: src/muuli_wdr.cpp:1829
 msgid "Connections Graph Scale: 100 "
 msgstr "Κλίμακα διαγράμματος συνδέσεων: 100"
 
-#: src/muuli_wdr.cpp:1829
+#: src/muuli_wdr.cpp:1836
 msgid "Download graph scale:"
 msgstr "Κλιματα του γραφήματος εισερχομένων:"
 
-#: src/muuli_wdr.cpp:1837
+#: src/muuli_wdr.cpp:1844
 msgid "Upload graph scale:"
 msgstr "Κλιμακα του γραφήματος εξερχομένων"
 
-#: src/muuli_wdr.cpp:1847
+#: src/muuli_wdr.cpp:1854
 #, fuzzy
 msgid "Colors: "
 msgstr "Χρώματα:"
 
-#: src/muuli_wdr.cpp:1851
+#: src/muuli_wdr.cpp:1858
 msgid "Background"
 msgstr "Υπόβαθρο"
 
-#: src/muuli_wdr.cpp:1852
+#: src/muuli_wdr.cpp:1859
 msgid "Grid"
 msgstr "Πλέγμα"
 
-#: src/muuli_wdr.cpp:1853
+#: src/muuli_wdr.cpp:1860
 msgid "Download current"
 msgstr "Κατέβασμα του τρέχοντος"
 
-#: src/muuli_wdr.cpp:1854
+#: src/muuli_wdr.cpp:1861
 msgid "Download running average"
 msgstr "Μέσο τρέξιμο κατεβάσματος"
 
-#: src/muuli_wdr.cpp:1855
+#: src/muuli_wdr.cpp:1862
 msgid "Download session average"
 msgstr "Μέσο συνεδρίας κατεβάσματος"
 
-#: src/muuli_wdr.cpp:1856
+#: src/muuli_wdr.cpp:1863
 msgid "Upload current"
 msgstr "Ανέβασμα του τρέχοντος"
 
-#: src/muuli_wdr.cpp:1857
+#: src/muuli_wdr.cpp:1864
 msgid "Upload running average"
 msgstr "Μέσο τρέξιμο ανεβάσματος"
 
-#: src/muuli_wdr.cpp:1858
+#: src/muuli_wdr.cpp:1865
 msgid "Upload session average"
 msgstr "Μέσο συνεδρίας ανεβάσματος"
 
-#: src/muuli_wdr.cpp:1859
+#: src/muuli_wdr.cpp:1866
 msgid "Active connections"
 msgstr "Ενεργές συνδέσεις"
 
-#: src/muuli_wdr.cpp:1862
+#: src/muuli_wdr.cpp:1869
 #, fuzzy
 msgid "Systray Icon Speed Bar"
 msgstr "Εικόνα για την μπάρα ταχείας πρόσβασης του Systray"
 
-#: src/muuli_wdr.cpp:1863
+#: src/muuli_wdr.cpp:1870
 msgid "Kad-nodes current"
 msgstr "Σύνδεσμοι-Kad παρόντες"
 
-#: src/muuli_wdr.cpp:1864
+#: src/muuli_wdr.cpp:1871
 msgid "Kad-nodes running"
 msgstr "Σύνδεσμοι-Kad τρέχοντες"
 
-#: src/muuli_wdr.cpp:1865
+#: src/muuli_wdr.cpp:1872
 msgid "Kad-nodes session"
 msgstr "Σύνδεσμοι-Kad συνεδρία"
 
-#: src/muuli_wdr.cpp:1869 src/muuli_wdr.cpp:2296
+#: src/muuli_wdr.cpp:1876 src/muuli_wdr.cpp:2303
 msgid "Select"
 msgstr "Επέλεξε"
 
-#: src/muuli_wdr.cpp:1873
+#: src/muuli_wdr.cpp:1880
 msgid "Tree"
 msgstr "Δέντρο"
 
-#: src/muuli_wdr.cpp:1883
+#: src/muuli_wdr.cpp:1890
 msgid "Number of Client Versions shown (0=unlimited)"
 msgstr "Αριθμός των εμφανιζόμενων εκδόσεων πελάτη (0=απεριόριστος)"
 
-#: src/muuli_wdr.cpp:1908
+#: src/muuli_wdr.cpp:1915
 msgid "!!! WARNING !!!"
 msgstr "!!! Προειδοποίηση !!!"
 
-#: src/muuli_wdr.cpp:1923
+#: src/muuli_wdr.cpp:1930
 msgid "Max new connections / 5 secs"
 msgstr "Μέγιστος αρ. νέων συνδέσεων /5 δευτερόλεπτα"
 
-#: src/muuli_wdr.cpp:1925
+#: src/muuli_wdr.cpp:1932
 msgid "Concurrent Kad source lookups"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1927
+#: src/muuli_wdr.cpp:1934
 #, fuzzy
 msgid "Kad source re-search interval (minutes)"
 msgstr "Περίοδος ενημέρωσης του FTP σε λεπτά"
 
-#: src/muuli_wdr.cpp:1929
+#: src/muuli_wdr.cpp:1936
 #, fuzzy
 msgid "Source re-ask interval (minutes)"
 msgstr "Περίοδος ενημέρωσης του FTP σε λεπτά"
 
-#: src/muuli_wdr.cpp:1933
+#: src/muuli_wdr.cpp:1940
 msgid "File Buffer Size: 240000 bytes"
 msgstr "Χώρος προσωρινής αποθήκευσης αρχείου: 240000 bytes"
 
-#: src/muuli_wdr.cpp:1937
+#: src/muuli_wdr.cpp:1944
 msgid "Use MMAP: memory-mapped file access (lower memory use)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1938
+#: src/muuli_wdr.cpp:1945
 msgid "Maps part files into memory instead of buffering them on the heap, lowering the process memory footprint. May reduce download speed on some disks; best for memory-constrained or upload-heavy hosts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1940
+#: src/muuli_wdr.cpp:1947
 msgid "Upload Queue Size: 5000 clients"
 msgstr "Λίστα αναμονής ανεβάσματος: 5000 πελάτες"
 
-#: src/muuli_wdr.cpp:1944
+#: src/muuli_wdr.cpp:1951
 msgid "Server connection refresh interval: Disable"
 msgstr "Διάστημα ανανέωσης της σύνδεσης σε διακομιστή: Απενεργοποίηση"
 
-#: src/muuli_wdr.cpp:1948
+#: src/muuli_wdr.cpp:1955
 msgid "Disable computer's timed standby mode"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1967
+#: src/muuli_wdr.cpp:1974
 msgid "Skin to use: "
 msgstr "Θέμα:"
 
-#: src/muuli_wdr.cpp:1976
+#: src/muuli_wdr.cpp:1983
 msgid "Show \"Fast eD2k Links Handler\" in every window."
 msgstr "Εμφάνιση \"Γρήγορου διαχειριστή συνδέσμων eD2k\" σε όλα τα παράθυρα."
 
-#: src/muuli_wdr.cpp:1979
+#: src/muuli_wdr.cpp:1986
 msgid "Show extended info on categories tabs"
 msgstr "Εμφάνιση εκτεταμένων πληροφοριών στην καρτέλα κατηγοριών"
 
-#: src/muuli_wdr.cpp:1982
+#: src/muuli_wdr.cpp:1989
 #, fuzzy
 msgid "Show application version on title"
 msgstr "Εμφάνιση των ταχυτήτων μεταφοράς στον τίτλο"
 
-#: src/muuli_wdr.cpp:1984
+#: src/muuli_wdr.cpp:1991
 msgid "Show transfer rates on title"
 msgstr "Εμφάνιση των ταχυτήτων μεταφοράς στον τίτλο"
 
-#: src/muuli_wdr.cpp:1986
+#: src/muuli_wdr.cpp:1993
 msgid "Before application name"
 msgstr "Πριν απο το όνομα της εφαρμογής"
 
-#: src/muuli_wdr.cpp:1988
+#: src/muuli_wdr.cpp:1995
 msgid "After application name"
 msgstr "Μετά το όνομα της εφαρμογής"
 
-#: src/muuli_wdr.cpp:1991
+#: src/muuli_wdr.cpp:1998
 msgid "Show overhead bandwidth"
 msgstr "Εμφάνιση επιβάρυνσης στο εύρος ζώνης"
 
-#: src/muuli_wdr.cpp:1995
+#: src/muuli_wdr.cpp:2002
 msgid "Vertical toolbar orientation"
 msgstr "Κατακόρυφος προσανατολισμός της γραμμής εντολών"
 
-#: src/muuli_wdr.cpp:1997
+#: src/muuli_wdr.cpp:2004
 msgid "Live column sorting (auto-reorder rows as their values change)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2004
+#: src/muuli_wdr.cpp:2011
 msgid "Download Queue Files"
 msgstr "Ουρά εισερχομένων αρχείων"
 
-#: src/muuli_wdr.cpp:2007
+#: src/muuli_wdr.cpp:2014
 msgid "Show progress percentage"
 msgstr "Εμφάνιση ποσοστού προόδου"
 
-#: src/muuli_wdr.cpp:2013
+#: src/muuli_wdr.cpp:2020
 msgid "Show progress bar"
 msgstr "Εμφάνιση μπάρας προόδου"
 
-#: src/muuli_wdr.cpp:2016
+#: src/muuli_wdr.cpp:2023
 msgid "Flat"
 msgstr "Επίπεδη"
 
-#: src/muuli_wdr.cpp:2020
+#: src/muuli_wdr.cpp:2027
 msgid "Round"
 msgstr "Στρογγυλή"
 
-#: src/muuli_wdr.cpp:2038
+#: src/muuli_wdr.cpp:2045
 msgid "External Connection Parameters"
 msgstr "Παράμετροι εξωτερικών συνδέσεων"
 
-#: src/muuli_wdr.cpp:2041
+#: src/muuli_wdr.cpp:2048
 msgid "Accept external connections"
 msgstr "Να γίνονται αποδεκτές οι εξωτερικές συνδέσεις"
 
-#: src/muuli_wdr.cpp:2048 src/muuli_wdr.cpp:2107
+#: src/muuli_wdr.cpp:2055 src/muuli_wdr.cpp:2114
 msgid "IP of the listening interface:"
 msgstr "Η διεύθυνση του εισακούοντος περιβάλλοντος:"
 
-#: src/muuli_wdr.cpp:2051
+#: src/muuli_wdr.cpp:2058
 msgid "Enter here a valid ip in the a.b.c.d format for the listening EC interface. An empty field or 0.0.0.0 will mean any interface."
 msgstr "Εισάγετε μία έγκυρη διεύθυνση με φόρμα a.b.c.d για σύνδεση με το περιβάλλον EC. Άδειο πεδίου ή 0.0.0.0 συμβολίζει όλα τα περιβάλλοντα."
 
-#: src/muuli_wdr.cpp:2072 src/muuli_wdr.cpp:2156
+#: src/muuli_wdr.cpp:2079 src/muuli_wdr.cpp:2163
 msgid "TCP port:"
 msgstr "Θύρα TCP:"
 
-#: src/muuli_wdr.cpp:2078
+#: src/muuli_wdr.cpp:2085
 msgid "Enable UPnP port forwarding on the EC port"
 msgstr "Ενεργοποίηση της προώθησης της θύρας UPnP στην θύρα EC"
 
-#: src/muuli_wdr.cpp:2082 src/muuli_wdr.cpp:3041
+#: src/muuli_wdr.cpp:2089 src/muuli_wdr.cpp:3048
 #: src/utils/wxCas/src/wxcasprefs.cpp:167
 msgid "Password"
 msgstr "Κωδικός"
 
-#: src/muuli_wdr.cpp:2088
+#: src/muuli_wdr.cpp:2095
 #, fuzzy
 msgid "aMule API server parameters"
 msgstr "Παράμετροι διακομιστή ιστού"
 
-#: src/muuli_wdr.cpp:2091
+#: src/muuli_wdr.cpp:2098
 msgid "Run amuleapi (REST API) on startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2096
+#: src/muuli_wdr.cpp:2103
 #, fuzzy
 msgid "HTTP port:"
 msgstr "Θύρα TCP:"
 
-#: src/muuli_wdr.cpp:2110
+#: src/muuli_wdr.cpp:2117
 msgid "The interface amuleapi's HTTP server listens on. 127.0.0.1 (default) accepts only local connections; use 0.0.0.0 or a specific IP to expose it to other hosts (set an admin password below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2113
+#: src/muuli_wdr.cpp:2120
 #, fuzzy
 msgid "Admin password"
 msgstr "Έλεγχος κωδικού\n"
 
-#: src/muuli_wdr.cpp:2118 src/muuli_wdr.cpp:2149
+#: src/muuli_wdr.cpp:2125 src/muuli_wdr.cpp:2156
 msgid "Low rights password"
 msgstr "Κωδικός μειωμένων δικαιωμάτων"
 
-#: src/muuli_wdr.cpp:2126
+#: src/muuli_wdr.cpp:2133
 msgid "Web server parameters"
 msgstr "Παράμετροι διακομιστή ιστού"
 
-#: src/muuli_wdr.cpp:2129
+#: src/muuli_wdr.cpp:2136
 #, fuzzy
 msgid "Run webserver on startup (deprecated)"
 msgstr "Έναρξη του εξυπηρετητή ιστού κατά την εκκίνηση"
 
-#: src/muuli_wdr.cpp:2135
+#: src/muuli_wdr.cpp:2142
 msgid "Web template"
 msgstr "Πρότυπη σελίδα"
 
-#: src/muuli_wdr.cpp:2140
+#: src/muuli_wdr.cpp:2147
 msgid "Full rights password"
 msgstr "Κωδικός πλήρων δικαιωμάτων"
 
-#: src/muuli_wdr.cpp:2144
+#: src/muuli_wdr.cpp:2151
 msgid "Enable Low rights User"
 msgstr "Ενεργοποίηση χρήστη μειωμένων δικαιωμάτων"
 
-#: src/muuli_wdr.cpp:2163
+#: src/muuli_wdr.cpp:2170
 msgid "Enable UPnP port forwarding of the web server port"
 msgstr "Ενεργοποίηση της προώθησης της θύρας του εξηπηρετητή ιστού στη θύρα UPnP"
 
-#: src/muuli_wdr.cpp:2168
+#: src/muuli_wdr.cpp:2175
 msgid "Web server UPnP TCP port (Optional)"
 msgstr "Θύρα UPnP TCP του εξυπηρετητή (Προαιρετική)"
 
-#: src/muuli_wdr.cpp:2176
+#: src/muuli_wdr.cpp:2183
 msgid "Page Refresh Time (in secs)"
 msgstr "Χρόνος ανανέωσης σελίδας (σε δευτερόλεπτα)"
 
-#: src/muuli_wdr.cpp:2183
+#: src/muuli_wdr.cpp:2190
 msgid "Enable Gzip compression"
 msgstr "Ενεργοποίηση συμπίεσης Gzip"
 
-#: src/muuli_wdr.cpp:2217
+#: src/muuli_wdr.cpp:2224
 #, fuzzy
 msgid "Reset page to defaults"
 msgstr "Εργοστασιακές ρυθμίσεις"
 
-#: src/muuli_wdr.cpp:2218
+#: src/muuli_wdr.cpp:2225
 msgid "Reset the settings on the current page to their default values."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2220 src/muuli_wdr.cpp:2306 src/ServerWnd.cpp:274
+#: src/muuli_wdr.cpp:2227 src/muuli_wdr.cpp:2313 src/ServerWnd.cpp:274
 #: src/ServerWnd.cpp:282
 msgid "OK"
 msgstr "Εντάξει"
 
-#: src/muuli_wdr.cpp:2222
+#: src/muuli_wdr.cpp:2229
 msgid "Click here to apply any changes made to the preferences."
 msgstr "Κλικ εδώ για εφαρμογή των αλλαγών που έγιναν στις προτιμήσεις."
 
-#: src/muuli_wdr.cpp:2225
+#: src/muuli_wdr.cpp:2232
 msgid "Reset any changes made to the preferences."
 msgstr "Επαναφορά κάθε αλλαγής που έγινε στις προτιμήσεις."
 
-#: src/muuli_wdr.cpp:2254
+#: src/muuli_wdr.cpp:2261
 msgid "Comment :"
 msgstr "Σχόλιο:"
 
-#: src/muuli_wdr.cpp:2261
+#: src/muuli_wdr.cpp:2268
 msgid "Incoming Dir :"
 msgstr "Κατάλογος εισερχομένων :"
 
-#: src/muuli_wdr.cpp:2270
+#: src/muuli_wdr.cpp:2277
 msgid "Change priority for new assigned files :"
 msgstr "Αλλαγή προτεραιότητας για τα νέα προσδιορισμένα αρχεία :"
 
-#: src/muuli_wdr.cpp:2274
+#: src/muuli_wdr.cpp:2281
 #, fuzzy
 msgid "Don't change"
 msgstr "Να μην αλλάξει"
 
-#: src/muuli_wdr.cpp:2286
+#: src/muuli_wdr.cpp:2293
 msgid "Select color for this Category (currently selected) :"
 msgstr "Επιλογή χρώματος για τη συγκεκριμένη κατηγορία (τρέχουσα επιλογή) :"
 
-#: src/muuli_wdr.cpp:2353 src/muuli_wdr.cpp:2372 src/muuli_wdr.cpp:2394
+#: src/muuli_wdr.cpp:2360 src/muuli_wdr.cpp:2379 src/muuli_wdr.cpp:2401
 msgid "Click this button to reset the log."
 msgstr "Πατήστε αυτό το κουμπί για το καθάρισμα του αρχείου καταγραφής."
 
-#: src/muuli_wdr.cpp:2413
+#: src/muuli_wdr.cpp:2420
 msgid "Click on this button to update the servers list from URL ..."
 msgstr "Πατήστε αυτό το αρχείο για να ανανεώσετε την λίστα διακομιστών από την URL ..."
 
-#: src/muuli_wdr.cpp:2417
+#: src/muuli_wdr.cpp:2424
 msgid "Server list"
 msgstr "Λίστα διακομιστών"
 
-#: src/muuli_wdr.cpp:2421
+#: src/muuli_wdr.cpp:2428
 msgid "Enter the url to a server.met file here and press the button to the left to update the list of known servers."
 msgstr "Εισάγετε την url ενός αρχείου server.met και πατήστε το κουμπί στα αριστερά για να ανανεώσετε τη λίστα με τους γνωστούς διακομιστές"
 
-#: src/muuli_wdr.cpp:2426
+#: src/muuli_wdr.cpp:2433
 msgid "Add server manually: Name"
 msgstr "Προσθήκη διακομιστή: Όνομα"
 
-#: src/muuli_wdr.cpp:2429
+#: src/muuli_wdr.cpp:2436
 msgid "Enter the name of the new server here"
 msgstr "Γράψτε το όνομα του νέου διακομιστή εδώ"
 
-#: src/muuli_wdr.cpp:2431 src/ServerWnd.cpp:206
+#: src/muuli_wdr.cpp:2438 src/ServerWnd.cpp:206
 msgid "IP:Port"
 msgstr "Διεύθυνση:Θύρα"
 
-#: src/muuli_wdr.cpp:2434
+#: src/muuli_wdr.cpp:2441
 msgid "Enter the IP of the server here, using the x.x.x.x format."
 msgstr "Γράψτε την IP του διακομιστή εδώ, σε μορφή x.x.x.x"
 
-#: src/muuli_wdr.cpp:2440
+#: src/muuli_wdr.cpp:2447
 msgid "Enter the port of the server here."
 msgstr "Γράψτε την θύρα του διακομιστή εδώ."
 
-#: src/muuli_wdr.cpp:2443
+#: src/muuli_wdr.cpp:2450
 msgid "Add manually a server (fill fields to the left before) ..."
 msgstr "Βάλτε τον διακομιστή με το χέρι (γεμίστε πρώτα τα πεδία στα αριστερά) ..."
 
-#: src/muuli_wdr.cpp:2472
+#: src/muuli_wdr.cpp:2479
 msgid "aMule Log"
 msgstr "Αρχείο καταγραφής aMule"
 
-#: src/muuli_wdr.cpp:2480
+#: src/muuli_wdr.cpp:2487
 msgid "Server Info"
 msgstr "Πληροφορίες διακομιστή"
 
-#: src/muuli_wdr.cpp:2484
+#: src/muuli_wdr.cpp:2491
 msgid "ED2K Info"
 msgstr "Πληροφορίες ED2K"
 
-#: src/muuli_wdr.cpp:2488
+#: src/muuli_wdr.cpp:2495
 msgid "Kad Info"
 msgstr "Πληροφορίες Kad"
 
-#: src/muuli_wdr.cpp:2516
+#: src/muuli_wdr.cpp:2523
 msgid "Click on this button to update the nodes list from URL ..."
 msgstr "Πατήστε το κουμπί για να ανανεώσετε την λίστα των κόμβων από την URL ..."
 
-#: src/muuli_wdr.cpp:2520
+#: src/muuli_wdr.cpp:2527
 msgid "Nodes (0)"
 msgstr "Κόμβοι (0)"
 
-#: src/muuli_wdr.cpp:2524
+#: src/muuli_wdr.cpp:2531
 msgid "Enter the url to a nodes.dat file here and press the button to the left to update the list of known nodes."
 msgstr "Βάλτε εδώ την url ενός αρχείου nodes.dat και πατήστε το κουμπί στα αριστερά για να ανανεώσετε την λίστα των γνωστών κόμβων."
 
-#: src/muuli_wdr.cpp:2527
+#: src/muuli_wdr.cpp:2534
 msgid "Nodes stats"
 msgstr "Στατιστικές κόμβων"
 
-#: src/muuli_wdr.cpp:2569
+#: src/muuli_wdr.cpp:2576
 msgid "Bootstrap"
 msgstr "Εκκινητήρας"
 
-#: src/muuli_wdr.cpp:2572
+#: src/muuli_wdr.cpp:2579
 msgid "New node"
 msgstr "Καινούριος κόμβος"
 
-#: src/muuli_wdr.cpp:2577
+#: src/muuli_wdr.cpp:2584
 msgid "IP:"
 msgstr "IP:"
 
-#: src/muuli_wdr.cpp:2597
+#: src/muuli_wdr.cpp:2604
 msgid "Port:"
 msgstr "Θύρα:"
 
-#: src/muuli_wdr.cpp:2610
+#: src/muuli_wdr.cpp:2617
 #, fuzzy
 msgid "Bootstrap from known clients"
 msgstr ""
 "Εκκίνηση από\n"
 "γνωστούς πελάτες"
 
-#: src/muuli_wdr.cpp:2612
+#: src/muuli_wdr.cpp:2619
 msgid "Disconnect Kad"
 msgstr "Αποσυνδεδεμένο Kad"
 
-#: src/muuli_wdr.cpp:2646
+#: src/muuli_wdr.cpp:2653
 msgid "Use Secure User Identification"
 msgstr "Χρήση Ασφαλούς Ταυτοποίησης χρήστη"
 
-#: src/muuli_wdr.cpp:2648
+#: src/muuli_wdr.cpp:2655
 msgid "It is recommended to enable this option. You will not receive credits if SUI is not enabled."
 msgstr "Ενδείκνυται να ενεργοποιήσετε αυτήν την προτίμηση. Δεν θα λάβετε πίστωση αν το SUI δεν είναι ενεργοποιημένο."
 
-#: src/muuli_wdr.cpp:2650
+#: src/muuli_wdr.cpp:2657
 msgid "Protocol Obfuscation"
 msgstr "Συσκότιση πρωτοκόλλου"
 
-#: src/muuli_wdr.cpp:2653
+#: src/muuli_wdr.cpp:2660
 msgid "Support Protocol Obfuscation"
 msgstr "Υποστήριξη συσκότισης πρωτοκόλλου"
 
-#: src/muuli_wdr.cpp:2655
+#: src/muuli_wdr.cpp:2662
 msgid "This option enabled Protocol Obfuscation, and makes aMule accept obfuscated connections from other clients."
 msgstr "Αυτή η επιλογή ενεργοποίησε την συσκότιση πρωτοκόλλου και κάνει το aMule να δέχεται συσκοτισμένες συνδέσεις από άλλους πελάτες"
 
-#: src/muuli_wdr.cpp:2657
+#: src/muuli_wdr.cpp:2664
 msgid "Use obfuscation for outgoing connections"
 msgstr "Χρήση συσκότισης για εξωτερικές συνδέσεις"
 
-#: src/muuli_wdr.cpp:2659
+#: src/muuli_wdr.cpp:2666
 msgid "This option makes aMule use Protocol Obfuscation when connecting other clients/servers."
 msgstr "Αυτή η επιλογή κάνει το aMule να χρησιμοποιεί συσκότιση πρωτοκόλλου όταν συνδέεται σε άλλους πελάτες/διακομιστές."
 
-#: src/muuli_wdr.cpp:2661
+#: src/muuli_wdr.cpp:2668
 msgid "Accept only obfuscated connections"
 msgstr "Να γίνονται δεκτές μόνο συσκοτισμένες συνδέσεις"
 
-#: src/muuli_wdr.cpp:2662
+#: src/muuli_wdr.cpp:2669
 msgid "This option makes aMule only accept obfuscated connections. You will have less sources, but all your traffic will be obfuscated"
 msgstr "Αυτή η επιλογή κάνει το aMule να δέχεται μόνο συσκοτισμένες συνδέσεις. Θα υπάρχουν λιγότερες πηγές αλλά όλη η κυκλοφορία θα είναι συσκοτισμένη"
 
-#: src/muuli_wdr.cpp:2667
+#: src/muuli_wdr.cpp:2674
 msgid "Everybody"
 msgstr "Οι πάντες"
 
-#: src/muuli_wdr.cpp:2669
+#: src/muuli_wdr.cpp:2676
 msgid "No one"
 msgstr "Κανείς"
 
-#: src/muuli_wdr.cpp:2671
+#: src/muuli_wdr.cpp:2678
 msgid "Who can see my shared files:"
 msgstr "Ποίος μπορεί να δεί τα κοινόχρηστα αρχεία μου:"
 
-#: src/muuli_wdr.cpp:2672
+#: src/muuli_wdr.cpp:2679
 msgid "Select who can request to view a list of your shared files."
 msgstr "Επιλέξτε ποίος μπορεί να ζητήσει να δει τη λίστα με τα κοινόχρηστα αρχεία σας."
 
-#: src/muuli_wdr.cpp:2674
+#: src/muuli_wdr.cpp:2681
 msgid "IP-Filtering"
 msgstr "Φίλτρο IP"
 
-#: src/muuli_wdr.cpp:2681
+#: src/muuli_wdr.cpp:2688
 msgid "Filter clients"
 msgstr "Φιλτράρισμα πελατών"
 
-#: src/muuli_wdr.cpp:2683
+#: src/muuli_wdr.cpp:2690
 msgid "Enable filtering of the client IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "Ενεργοποίηση φίλτρου του IP των πελατών όπως ορίζεται στο ~/.aMule/ipfilter.dat."
 
-#: src/muuli_wdr.cpp:2685
+#: src/muuli_wdr.cpp:2692
 msgid "Filter servers"
 msgstr "Φιλτράρισμα διακομιστών"
 
-#: src/muuli_wdr.cpp:2687
+#: src/muuli_wdr.cpp:2694
 msgid "Enable filtering of the server IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "Ενεργοποίηση φίλτρου του IP των διακομιστών όπως ορίζεται στο ~/.aMule/ipfilter.dat."
 
-#: src/muuli_wdr.cpp:2691
+#: src/muuli_wdr.cpp:2698
 msgid "Reload List"
 msgstr "Επαναφόρτωση λίστας"
 
-#: src/muuli_wdr.cpp:2692
+#: src/muuli_wdr.cpp:2699
 msgid "Reload the list of IPs to filter from the file ~/.aMule/ipfilter.dat"
 msgstr "Επαναφόρτωση για φιλτράρισμα της λίστας των IP από το ~/.aMule/ipfilter.dat"
 
-#: src/muuli_wdr.cpp:2698
+#: src/muuli_wdr.cpp:2705
 msgid "URL:"
 msgstr "URL:"
 
-#: src/muuli_wdr.cpp:2702 src/muuli_wdr.cpp:2895
+#: src/muuli_wdr.cpp:2709 src/muuli_wdr.cpp:2902
 msgid "Update now"
 msgstr "Ανανέωσε τώρα"
 
-#: src/muuli_wdr.cpp:2705
+#: src/muuli_wdr.cpp:2712
 msgid "Auto-update ipfilter at startup"
 msgstr "Αυτόματη ανανέωση του ipfilter κατά την εκκίνηση"
 
-#: src/muuli_wdr.cpp:2709
+#: src/muuli_wdr.cpp:2716
 msgid "Filtering Level:"
 msgstr "Επίπεδο φιλτραρίσματος:"
 
-#: src/muuli_wdr.cpp:2715
+#: src/muuli_wdr.cpp:2722
 msgid "Always filter LAN IPs"
 msgstr "Πάντα φίλτραρε τις IP του τοπικού δικτύου"
 
-#: src/muuli_wdr.cpp:2718
+#: src/muuli_wdr.cpp:2725
 msgid "Paranoid handling of non-matching IPs"
 msgstr "Παρανοϊκή διαχείριση των αταίριαστων διευθύνσεων IP"
 
-#: src/muuli_wdr.cpp:2720
+#: src/muuli_wdr.cpp:2727
 msgid "Rejects a packet when its source IP differs from the IP the client claims (an anti-spoofing check). Disable only if it causes connection problems."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2722
+#: src/muuli_wdr.cpp:2729
 msgid "Use system-wide ipfilter.dat if available"
 msgstr "Χρήση του ipfilter.dat όλου του συστήματος αν αυτό υπάρχει"
 
-#: src/muuli_wdr.cpp:2723
+#: src/muuli_wdr.cpp:2730
 #, fuzzy
 msgid "If there's no local ipfilter.dat found, allow usage of a system-wide ipfilter file."
 msgstr "Αν δεν βρεθεί τοπικό ipfilter.dat, να γίνει επιτρεπτή η χρήση του αρχείου ipfilter (φίλτρο διευθύνσεων) όλου του συστήματος."
 
-#: src/muuli_wdr.cpp:2740
+#: src/muuli_wdr.cpp:2747
 msgid "Enable Online-Signature"
 msgstr "Ενεργοποίηση συνδεδεμένων υπογραφών"
 
-#: src/muuli_wdr.cpp:2742
+#: src/muuli_wdr.cpp:2749
 msgid "Enables the writing of the OS file, which can be used by external apps to create signatures and the like."
 msgstr "Ενεργοποίηση γραψίματος του αρχείου συστήματος, το οποίο μπορεί να χρησιμοποιηθεί από εξωτερικές εφαρμογές για τη δημιουργία υπογραφών κτλ."
 
-#: src/muuli_wdr.cpp:2746
+#: src/muuli_wdr.cpp:2753
 msgid "Update Frequency (Secs):"
 msgstr "Συχνότητα ανανέωσης (δευτερόλεπτα):"
 
-#: src/muuli_wdr.cpp:2749
+#: src/muuli_wdr.cpp:2756
 msgid "Change the frequency (in seconds) of Online Signature updates."
 msgstr "Αλλαγή της συχνότητας (σε δευτερόλεπτα) για την ενημέρωση Συνδεδεμένων υπογραφών."
 
-#: src/muuli_wdr.cpp:2757
+#: src/muuli_wdr.cpp:2764
 msgid "Save online signature file in: "
 msgstr "Αποθύκευση του αρχείου συνδεδεμένων υπογραφών σε:"
 
-#: src/muuli_wdr.cpp:2763
+#: src/muuli_wdr.cpp:2770
 msgid "Click here to select the directory containing the the Online Signature files."
 msgstr "Κλικ εδώ για την επιλογή του καταλόγου που περιέχει τα αρχεία Συνδεδεμένων Υπογραφών."
 
-#: src/muuli_wdr.cpp:2796
+#: src/muuli_wdr.cpp:2803
 msgid "Show country flags for clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2797
+#: src/muuli_wdr.cpp:2804
 msgid "Render the country flag column in the transfers, queue and search views. Requires a valid MMDB GeoIP database (see below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2802
+#: src/muuli_wdr.cpp:2809
 #, fuzzy
 msgid "Database"
 msgstr "Ρυθμός ροής δεδομένων :"
 
-#: src/muuli_wdr.cpp:2818
+#: src/muuli_wdr.cpp:2825
 #, fuzzy
 msgid "Source:"
 msgstr "Αρ. πηγών"
 
-#: src/muuli_wdr.cpp:2821
+#: src/muuli_wdr.cpp:2828
 msgid "DB-IP (free, no account)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2822
+#: src/muuli_wdr.cpp:2829
 msgid "MaxMind GeoLite2 (free, account required)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2823
+#: src/muuli_wdr.cpp:2830
 msgid "Custom URL"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2826
+#: src/muuli_wdr.cpp:2833
 msgid "Choose which provider supplies the GeoIP MMDB database. DB-IP is the default - no account required. MaxMind requires a free account + license key. Use Custom URL to point at any other MMDB host (e.g. a local mirror)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2843
+#: src/muuli_wdr.cpp:2850
 msgid ""
 "No configuration required.\n"
 "\n"
@@ -4866,11 +4880,11 @@ msgid ""
 "License: Creative Commons BY 4.0 - https://creativecommons.org/licenses/by/4.0/"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2856
+#: src/muuli_wdr.cpp:2863
 msgid "License key:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2862
+#: src/muuli_wdr.cpp:2869
 msgid ""
 "Sign up for a free MaxMind account, then generate a License Key:\n"
 "https://www.maxmind.com/en/geolite2/signup\n"
@@ -4880,232 +4894,232 @@ msgid ""
 "Requires attribution and account registration; refresh at least every 30 days."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2877
+#: src/muuli_wdr.cpp:2884
 #, fuzzy
 msgid "Download URL:"
 msgstr "Μεταφόρτωση"
 
-#: src/muuli_wdr.cpp:2883
+#: src/muuli_wdr.cpp:2890
 msgid ""
 "Must point to an .mmdb file or a .gz / .tar.gz containing one.\n"
 "URL may include credentials (https://user:pass@host/...).\n"
 "License and attribution terms are set by the upstream URL - you are responsible."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2896
+#: src/muuli_wdr.cpp:2903
 msgid "Download the GeoIP database from the selected source."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2898
+#: src/muuli_wdr.cpp:2905
 #, fuzzy
 msgid "Auto-update on startup"
 msgstr "Αυτόματη ανανέωση του ipfilter κατά την εκκίνηση"
 
-#: src/muuli_wdr.cpp:2899
+#: src/muuli_wdr.cpp:2906
 msgid "Re-download the GeoIP database from the selected source every time aMule starts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2922
+#: src/muuli_wdr.cpp:2929
 msgid "Filter incoming messages (except current chat):"
 msgstr "Φιλτράρισμα εισερχομένων μηνυμάτων (εκτός από την τρέχουσα συνομιλία):"
 
-#: src/muuli_wdr.cpp:2924
+#: src/muuli_wdr.cpp:2931
 msgid "Filter all messages"
 msgstr "Διήθηση όλων των μηνυμάτων"
 
-#: src/muuli_wdr.cpp:2926
+#: src/muuli_wdr.cpp:2933
 msgid "Filter messages from people not on your friend list"
 msgstr "Διήθηση των μηνυμάτων από μέλη εκτός της λίστας φίλων"
 
-#: src/muuli_wdr.cpp:2928
+#: src/muuli_wdr.cpp:2935
 msgid "Filter messages from unknown clients"
 msgstr "Διήθηση μηνυμάτων από άγνωστους πελάτες"
 
-#: src/muuli_wdr.cpp:2930
+#: src/muuli_wdr.cpp:2937
 msgid "Filter messages containing (use ',' as separator):"
 msgstr "Διήθηση των μηνυμάτων που περιέχουν (χρήση ',' ως διαχωριστικού):"
 
-#: src/muuli_wdr.cpp:2933 src/muuli_wdr.cpp:2944
+#: src/muuli_wdr.cpp:2940 src/muuli_wdr.cpp:2951
 msgid "add here the words amule should filter and block messages including it"
 msgstr "προσθήκη σε αυτό το σημείο των λέξεων που το aMule πρέπει να φιλτράρει και μπλοκάρισμα μηνυμάτων που το περιέχουν"
 
-#: src/muuli_wdr.cpp:2935
+#: src/muuli_wdr.cpp:2942
 msgid "Show received messages in the log"
 msgstr "Εμφάνιση των ληφθέντων μηνυμάτων στο αρχείο καταγραφής"
 
-#: src/muuli_wdr.cpp:2938
+#: src/muuli_wdr.cpp:2945
 msgid "Comments"
 msgstr "Σχόλια"
 
-#: src/muuli_wdr.cpp:2941
+#: src/muuli_wdr.cpp:2948
 msgid "Filter comments containing (use ',' as separator):"
 msgstr "Φιλτράρισμα σχολίων που περιέχουν (χρησιμοποίηση ',' ως διαχωριστή):"
 
-#: src/muuli_wdr.cpp:2966
+#: src/muuli_wdr.cpp:2973
 msgid "Enable Proxy"
 msgstr "Ενεργοποίηση διακομιστή μεσολάβησης"
 
-#: src/muuli_wdr.cpp:2967
+#: src/muuli_wdr.cpp:2974
 msgid "Enable/disable proxy support"
 msgstr "Ενεργοποίηση/Απενεργοποίηση υποστήριξης διακομιστή μεσολάβησης"
 
-#: src/muuli_wdr.cpp:2970
+#: src/muuli_wdr.cpp:2977
 msgid "Proxy type:"
 msgstr "Τύπος διαμεσολάβησης"
 
-#: src/muuli_wdr.cpp:2981
+#: src/muuli_wdr.cpp:2988
 msgid "Proxy host:"
 msgstr "Διεύθυνση διακομιστή μεσολάβησης:"
 
-#: src/muuli_wdr.cpp:2984
+#: src/muuli_wdr.cpp:2991
 msgid "The proxy host name"
 msgstr "Όνομα του διακομιστή μεσολάβησης"
 
-#: src/muuli_wdr.cpp:2986
+#: src/muuli_wdr.cpp:2993
 msgid "Proxy port:"
 msgstr "Θύρα διακομιστή μεσολάβησης:"
 
-#: src/muuli_wdr.cpp:2989
+#: src/muuli_wdr.cpp:2996
 msgid "The proxy port"
 msgstr "Η θύρα διακομιστή μεσολάβησης"
 
-#: src/muuli_wdr.cpp:2991
+#: src/muuli_wdr.cpp:2998
 msgid "Enable authentication"
 msgstr "Ενεργοποίηση πιστοποίησης"
 
-#: src/muuli_wdr.cpp:2992
+#: src/muuli_wdr.cpp:2999
 msgid "Enable/disable username/password authentication"
 msgstr "Ενεργοποίηση/Απενεργοποίηση πιστοποίησης ονόματος χρήστη/κωδικού"
 
-#: src/muuli_wdr.cpp:2995
+#: src/muuli_wdr.cpp:3002
 msgid "Username: "
 msgstr "Όνομα χρήστη:"
 
-#: src/muuli_wdr.cpp:2998
+#: src/muuli_wdr.cpp:3005
 msgid "The username to use to connect to the proxy"
 msgstr "Το όνομα χρήστη για τη σύνδεση με τον μεσολαβητή"
 
-#: src/muuli_wdr.cpp:3000
+#: src/muuli_wdr.cpp:3007
 msgid "Password:"
 msgstr "Κωδικός:"
 
-#: src/muuli_wdr.cpp:3003
+#: src/muuli_wdr.cpp:3010
 msgid "The password to use to connect to the proxy"
 msgstr "Ο κωδικός που χρειάζεται για τη σύνδεση με τον μεσολαβητή"
 
-#: src/muuli_wdr.cpp:3022
+#: src/muuli_wdr.cpp:3029
 msgid "Connect to:"
 msgstr "Σύνδεση με:"
 
-#: src/muuli_wdr.cpp:3031
+#: src/muuli_wdr.cpp:3038
 msgid "Login to remote amule"
 msgstr "Σύνδεση σε απομακρυσμένο amule"
 
-#: src/muuli_wdr.cpp:3036
+#: src/muuli_wdr.cpp:3043
 msgid "User name"
 msgstr "Όνομα χρήστη"
 
-#: src/muuli_wdr.cpp:3047
+#: src/muuli_wdr.cpp:3054
 msgid "Remember those settings"
 msgstr "Απομνημόνευση αυτών των ρυθμίσεων"
 
-#: src/muuli_wdr.cpp:3050
+#: src/muuli_wdr.cpp:3057
 #, fuzzy
 msgid "Force ZLIB compression"
 msgstr "Χρήση συμπίεσης τύπου gzip"
 
-#: src/muuli_wdr.cpp:3074
+#: src/muuli_wdr.cpp:3081
 msgid "Enable Verbose Debug-Logging."
 msgstr "Ενεργοποίηση λεπτομερούς καταγραφής για έλεγχο σφαλμάτων"
 
-#: src/muuli_wdr.cpp:3076
+#: src/muuli_wdr.cpp:3083
 #, fuzzy
 msgid "Only to Logfile"
 msgstr "&Άνοιγμα αρχείου"
 
-#: src/muuli_wdr.cpp:3078
+#: src/muuli_wdr.cpp:3085
 msgid "Message Categories:"
 msgstr "Κατηγορίες μηνυμάτων:"
 
-#: src/muuli_wdr.cpp:3102 src/PartFileConvertDlg.cpp:160
+#: src/muuli_wdr.cpp:3109 src/PartFileConvertDlg.cpp:160
 msgid "Waiting..."
 msgstr "Αναμονή..."
 
-#: src/muuli_wdr.cpp:3122
+#: src/muuli_wdr.cpp:3129
 msgid "Add imports"
 msgstr "Προσθήκη εισακτέων"
 
-#: src/muuli_wdr.cpp:3125
+#: src/muuli_wdr.cpp:3132
 msgid "Retry selected"
 msgstr "Επαναπροσπάθεια των επιλεγμένων"
 
-#: src/muuli_wdr.cpp:3127
+#: src/muuli_wdr.cpp:3134
 msgid "Remove selected"
 msgstr "Αφαίρεση των επιλεγμένων"
 
-#: src/muuli_wdr.cpp:3190
+#: src/muuli_wdr.cpp:3197
 msgid "Event Types"
 msgstr "Τύποι συμβάντων"
 
-#: src/muuli_wdr.cpp:3209
+#: src/muuli_wdr.cpp:3216
 msgid "Statistics and queued clients for selected file(s) : Session / All time"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3233
+#: src/muuli_wdr.cpp:3240
 #, fuzzy
 msgid "Active Uploads"
 msgstr "Ενεργά ανεβάσματα :"
 
-#: src/muuli_wdr.cpp:3247
+#: src/muuli_wdr.cpp:3254
 msgid "Percent of total files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3299
+#: src/muuli_wdr.cpp:3306
 #, fuzzy
 msgid "Show Clients for"
 msgstr "Δείξε τους πελάτες"
 
-#: src/muuli_wdr.cpp:3301
+#: src/muuli_wdr.cpp:3308
 #, fuzzy
 msgid "All files"
 msgstr "Κρύψιμο των κοινόχρηστων αρχείων "
 
-#: src/muuli_wdr.cpp:3304
+#: src/muuli_wdr.cpp:3311
 #, fuzzy
 msgid "Selected files"
 msgstr "Επιλογή φίλτρου εμφάνισης"
 
-#: src/muuli_wdr.cpp:3307
+#: src/muuli_wdr.cpp:3314
 #, fuzzy
 msgid "Active uploads only"
 msgstr "Ενεργά ανεβάσματα"
 
-#: src/muuli_wdr.cpp:3314
+#: src/muuli_wdr.cpp:3321
 #, fuzzy
 msgid "Reload:"
 msgstr "Επαναφόρτωση λίστας"
 
-#: src/muuli_wdr.cpp:3318
+#: src/muuli_wdr.cpp:3325
 msgid "Reload your shared files"
 msgstr "Επαναφόρτωση των κοινόχρηστων αρχείων"
 
-#: src/muuli_wdr.cpp:3381
+#: src/muuli_wdr.cpp:3388
 msgid "Send"
 msgstr "Αποστολή"
 
-#: src/muuli_wdr.cpp:3382
+#: src/muuli_wdr.cpp:3389
 msgid "Sends the specified message."
 msgstr "Αποστολή του προσδιορισμένου μηνύματος."
 
-#: src/muuli_wdr.cpp:3386
+#: src/muuli_wdr.cpp:3393
 msgid "Close this chat-session."
 msgstr "Κλείσιμο της συνομιλίας."
 
-#: src/muuli_wdr.cpp:3409
+#: src/muuli_wdr.cpp:3416
 msgid "Connect to any server and/or Kad"
 msgstr "Σύνδεση σε κάθε διακομιστή ή/και Kad"
 
-#: src/muuli_wdr.cpp:3415 src/SharedFilesCtrl.cpp:142 src/Statistics.cpp:941
+#: src/muuli_wdr.cpp:3422 src/SharedFilesCtrl.cpp:142 src/Statistics.cpp:941
 msgid "Shared Files"
 msgstr "Κοινόχρηστα αρχεία"
 
@@ -5466,192 +5480,192 @@ msgstr "Έχει κατεβεί"
 msgid "ERROR: Failed to open partfile '%s'"
 msgstr "ΣΦΑΛΜΑ: Αποτυχία ανοίγματος του ημιτελούς αρχείου '%s'"
 
-#: src/Preferences.cpp:673
+#: src/Preferences.cpp:674
 msgid "System default"
 msgstr "Εργοστασιακές ρυθμίσεις"
 
-#: src/Preferences.cpp:674
+#: src/Preferences.cpp:675
 msgid "Albanian"
 msgstr "Αλβανικά"
 
-#: src/Preferences.cpp:675
+#: src/Preferences.cpp:676
 msgid "Arabic"
 msgstr "Αραβικά"
 
-#: src/Preferences.cpp:676
+#: src/Preferences.cpp:677
 #, fuzzy
 msgid "Asturian"
 msgstr "Εσθονικά"
 
-#: src/Preferences.cpp:677
+#: src/Preferences.cpp:678
 msgid "Basque"
 msgstr "Βάσκικα"
 
-#: src/Preferences.cpp:678
+#: src/Preferences.cpp:679
 msgid "Bulgarian"
 msgstr "Βουλγάρικα"
 
-#: src/Preferences.cpp:679
+#: src/Preferences.cpp:680
 msgid "Catalan"
 msgstr "Καταλανικά"
 
-#: src/Preferences.cpp:680
+#: src/Preferences.cpp:681
 msgid "Chinese (Simplified)"
 msgstr "Κινέζικα (απλοποιημένα)"
 
-#: src/Preferences.cpp:681
+#: src/Preferences.cpp:682
 msgid "Chinese (Traditional)"
 msgstr "Κινέζικα (Παραδοσιακά)"
 
-#: src/Preferences.cpp:682
+#: src/Preferences.cpp:683
 msgid "Croatian"
 msgstr "Κροατικά"
 
-#: src/Preferences.cpp:683
+#: src/Preferences.cpp:684
 msgid "Czech"
 msgstr "Τσέχικα"
 
-#: src/Preferences.cpp:684
+#: src/Preferences.cpp:685
 msgid "Danish"
 msgstr "Δανέζικα"
 
-#: src/Preferences.cpp:685
+#: src/Preferences.cpp:686
 msgid "Dutch"
 msgstr "Ολλανδικά"
 
-#: src/Preferences.cpp:686
+#: src/Preferences.cpp:687
 msgid "English (U.K.)"
 msgstr "Αγγλικά (Ην. Βασίλειο)"
 
-#: src/Preferences.cpp:687
+#: src/Preferences.cpp:688
 #, fuzzy
 msgid "English (U.S.)"
 msgstr "Αγγλικά (Ην. Βασίλειο)"
 
-#: src/Preferences.cpp:688
+#: src/Preferences.cpp:689
 msgid "Estonian"
 msgstr "Εσθονικά"
 
-#: src/Preferences.cpp:689
+#: src/Preferences.cpp:690
 msgid "Finnish"
 msgstr "Φιλανδικά"
 
-#: src/Preferences.cpp:690
+#: src/Preferences.cpp:691
 msgid "French"
 msgstr "Γαλλικά"
 
-#: src/Preferences.cpp:691
+#: src/Preferences.cpp:692
 msgid "Galician"
 msgstr "Γαλικιακά"
 
-#: src/Preferences.cpp:692
+#: src/Preferences.cpp:693
 msgid "German"
 msgstr "Γερμανικά"
 
-#: src/Preferences.cpp:693
+#: src/Preferences.cpp:694
 msgid "Greek"
 msgstr "Ελληνικά"
 
-#: src/Preferences.cpp:694
+#: src/Preferences.cpp:695
 msgid "Hebrew"
 msgstr "Εβραϊκά"
 
-#: src/Preferences.cpp:695
+#: src/Preferences.cpp:696
 msgid "Hungarian"
 msgstr "Ουγγαρέζικα"
 
-#: src/Preferences.cpp:696
+#: src/Preferences.cpp:697
 msgid "Italian"
 msgstr "Ιταλικά"
 
-#: src/Preferences.cpp:697
+#: src/Preferences.cpp:698
 msgid "Japanese"
 msgstr "Γιαπωνέζικα"
 
-#: src/Preferences.cpp:698
+#: src/Preferences.cpp:699
 msgid "Korean"
 msgstr "Κορεάτικα"
 
-#: src/Preferences.cpp:699
+#: src/Preferences.cpp:700
 msgid "Latvian"
 msgstr ""
 
-#: src/Preferences.cpp:700
+#: src/Preferences.cpp:701
 msgid "Lithuanian"
 msgstr "Λιθουανικά"
 
-#: src/Preferences.cpp:701
+#: src/Preferences.cpp:702
 msgid "Norwegian (Nynorsk)"
 msgstr "Νορβηγικά"
 
-#: src/Preferences.cpp:702
+#: src/Preferences.cpp:703
 msgid "Polish"
 msgstr "Πολωνέζικα"
 
-#: src/Preferences.cpp:703
+#: src/Preferences.cpp:704
 msgid "Portuguese"
 msgstr "Πορτογαλλικά"
 
-#: src/Preferences.cpp:704
+#: src/Preferences.cpp:705
 msgid "Portuguese (Brazilian)"
 msgstr "Πορτογαλλικά (Βραζιλίας)"
 
-#: src/Preferences.cpp:705
+#: src/Preferences.cpp:706
 #, fuzzy
 msgid "Romanian"
 msgstr "Αλβανικά"
 
-#: src/Preferences.cpp:706
+#: src/Preferences.cpp:707
 msgid "Russian"
 msgstr "Ρωσικά"
 
-#: src/Preferences.cpp:707
+#: src/Preferences.cpp:708
 msgid "Slovenian"
 msgstr "Σλοβένικα"
 
-#: src/Preferences.cpp:708
+#: src/Preferences.cpp:709
 msgid "Spanish"
 msgstr "Ισπανικά"
 
-#: src/Preferences.cpp:709
+#: src/Preferences.cpp:710
 msgid "Swedish"
 msgstr "Σουηδικά"
 
-#: src/Preferences.cpp:710
+#: src/Preferences.cpp:711
 msgid "Turkish"
 msgstr "Τούρκικα"
 
-#: src/Preferences.cpp:711
+#: src/Preferences.cpp:712
 msgid "Ukrainian"
 msgstr ""
 
-#: src/Preferences.cpp:814
+#: src/Preferences.cpp:815
 #, fuzzy
 msgid "Change Language"
 msgstr "Γλώσσα"
 
-#: src/Preferences.cpp:878
+#: src/Preferences.cpp:879
 msgid "There are no translations installed for aMule"
 msgstr ""
 
-#: src/Preferences.cpp:879
+#: src/Preferences.cpp:880
 #, fuzzy
 msgid "No languages available"
 msgstr "Δεν είναι διαθέσιμο"
 
-#: src/Preferences.cpp:1010
+#: src/Preferences.cpp:1011
 msgid "no options available"
 msgstr "Δεν υπάρχουν επιλογές"
 
-#: src/Preferences.cpp:2179
+#: src/Preferences.cpp:2182
 msgid "Invalid category found, skipping"
 msgstr ""
 
-#: src/Preferences.cpp:2348
+#: src/Preferences.cpp:2351
 msgid "TCP port can't be higher than 65532 due to server UDP socket being TCP+3"
 msgstr "Η θύρα TCP δεν μπορεί να είναι μεγαλύτερη από 65532, διότι η θύρα UDP του διακομιστή είναι TCP+3"
 
-#: src/Preferences.cpp:2349
+#: src/Preferences.cpp:2352
 #, c-format
 msgid "Default port will be used (%d)"
 msgstr "Θα χρησιμοποιηθεί η στάνταρ θύρα (%d)"
@@ -6163,24 +6177,28 @@ msgstr "Επαναφορτώνει τη λίστα κοινοχρήστων αρ
 msgid "Shared folder"
 msgstr "Κοινόχρηστα αρχεία"
 
-#: src/SearchDlg.cpp:425
+#: src/SearchDlg.cpp:280
+msgid "Clear search history"
+msgstr ""
+
+#: src/SearchDlg.cpp:584
 msgid "It's impossible to search when both eD2k and Kademlia are disabled."
 msgstr ""
 
-#: src/SearchDlg.cpp:426 src/SearchListCtrl.cpp:858
+#: src/SearchDlg.cpp:585 src/SearchListCtrl.cpp:858
 #, fuzzy
 msgid "Search error"
 msgstr "Αναζητήσεις"
 
-#: src/SearchDlg.cpp:768
+#: src/SearchDlg.cpp:929
 msgid "Min size must be smaller than max size. Max size ignored."
 msgstr "Το ελάχιστο μέγεθος πρέπει να είναι μικρότερο από το μέγιστο. Το μέγιστο μέγεθος θα αγνοηθεί."
 
-#: src/SearchDlg.cpp:769 src/SearchDlg.cpp:851
+#: src/SearchDlg.cpp:930 src/SearchDlg.cpp:1012
 msgid "Search warning"
 msgstr "Προειδοποίηση ψαξίματος"
 
-#: src/SearchDlg.cpp:929 src/SearchListCtrl.cpp:735
+#: src/SearchDlg.cpp:1092 src/SearchListCtrl.cpp:735
 msgid "Main"
 msgstr "Κύρια"
 

--- a/po/el.po
+++ b/po/el.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-28 12:17+0200\n"
+"POT-Creation-Date: 2026-07-28 13:09+0200\n"
 "PO-Revision-Date: 2026-07-27 11:35+0000\n"
 "Last-Translator: Dimitris <dgalanak@yahoo.com>\n"
 "Language-Team: Greek\n"
@@ -296,7 +296,7 @@ msgid "Password set and external connections enabled."
 msgstr "Νέα εξωτερική σύνδεση έγινε δεκτή"
 
 #: src/amule.cpp:755 src/KadDlg.cpp:176 src/KadDlg.cpp:185
-#: src/PrefsUnifiedDlg.cpp:1461 src/SharedFilesCtrl.cpp:476
+#: src/PrefsUnifiedDlg.cpp:1470 src/SharedFilesCtrl.cpp:476
 msgid "WARNING"
 msgstr "ΠΡΟΕΙΔΟΠΟΙΗΣΗ"
 
@@ -334,7 +334,7 @@ msgstr "Ζητήσατε να τρέχετε τον διακομιστή ιστ�
 #: src/amule-remote-gui.cpp:603 src/amule-remote-gui.cpp:671
 #: src/amule-remote-gui.cpp:709 src/amule-remote-gui.cpp:1282
 #: src/amule-remote-gui.cpp:1345 src/amule-remote-gui.cpp:1372
-#: src/DownloadQueue.cpp:1481 src/PrefsUnifiedDlg.cpp:1247
+#: src/DownloadQueue.cpp:1481 src/PrefsUnifiedDlg.cpp:1256
 msgid "ERROR"
 msgstr "ΣΦΑΛΜΑ"
 
@@ -597,36 +597,36 @@ msgstr "Επισκεφτείτε το https://github.com/amule-org/amule/release
 msgid "FATAL ERROR: Failed to create Timer"
 msgstr "ΜΟΙΡΑΙΟ ΣΦΑΛΜΑ: Αποτυχία δημιουργίας Χρονομέτρου"
 
-#: src/amuleDlg.cpp:361 src/amuleDlg.cpp:1787 src/amuleDlg.cpp:2033
-#: src/muuli_wdr.cpp:1492 src/muuli_wdr.cpp:3449
+#: src/amuleDlg.cpp:361 src/amuleDlg.cpp:1810 src/amuleDlg.cpp:2056
+#: src/muuli_wdr.cpp:1492 src/muuli_wdr.cpp:3453
 msgid "Networks"
 msgstr "Δίκτυα"
 
-#: src/amuleDlg.cpp:362 src/amuleDlg.cpp:1793 src/muuli_wdr.cpp:3450
+#: src/amuleDlg.cpp:362 src/amuleDlg.cpp:1816 src/muuli_wdr.cpp:3454
 msgid "Searches"
 msgstr "Αναζητήσεις"
 
-#: src/amuleDlg.cpp:363 src/amuleDlg.cpp:1799 src/DownloadListCtrl.cpp:740
-#: src/muuli_wdr.cpp:392 src/muuli_wdr.cpp:1585 src/muuli_wdr.cpp:3451
+#: src/amuleDlg.cpp:363 src/amuleDlg.cpp:1822 src/DownloadListCtrl.cpp:740
+#: src/muuli_wdr.cpp:392 src/muuli_wdr.cpp:1585 src/muuli_wdr.cpp:3455
 #: src/Statistics.cpp:829
 msgid "Downloads"
 msgstr "Κατεβασμένα"
 
-#: src/amuleDlg.cpp:364 src/amuleDlg.cpp:1805 src/muuli_wdr.cpp:3325
+#: src/amuleDlg.cpp:364 src/amuleDlg.cpp:1828 src/muuli_wdr.cpp:3329
 msgid "Shared files"
 msgstr "Κοινόχρηστα αρχεία"
 
-#: src/amuleDlg.cpp:365 src/amuleDlg.cpp:1811 src/muuli_wdr.cpp:2957
-#: src/muuli_wdr.cpp:3407 src/muuli_wdr.cpp:3454
+#: src/amuleDlg.cpp:365 src/amuleDlg.cpp:1834 src/muuli_wdr.cpp:2961
+#: src/muuli_wdr.cpp:3411 src/muuli_wdr.cpp:3458
 msgid "Messages"
 msgstr "Μηνύματα"
 
-#: src/amuleDlg.cpp:366 src/amuleDlg.cpp:1817 src/muuli_wdr.cpp:3455
+#: src/amuleDlg.cpp:366 src/amuleDlg.cpp:1840 src/muuli_wdr.cpp:3459
 #: src/PrefsUnifiedDlg.cpp:314 src/Statistics.cpp:779 src/Statistics.cpp:1235
 msgid "Statistics"
 msgstr "Στατιστικές"
 
-#: src/amuleDlg.cpp:368 src/amuleDlg.cpp:1824 src/muuli_wdr.cpp:3457
+#: src/amuleDlg.cpp:368 src/amuleDlg.cpp:1847 src/muuli_wdr.cpp:3461
 #: src/PrefsUnifiedDlg.cpp:330 src/utils/wxCas/src/wxcasprefs.cpp:39
 msgid "Preferences"
 msgstr "Προτιμήσεις"
@@ -685,8 +685,8 @@ msgstr "Kad: Εκτός"
 #: src/amuleDlg.cpp:1029 src/DownloadListCtrl.cpp:505
 #: src/DownloadListCtrl.cpp:749 src/FriendListCtrl.cpp:180
 #: src/muuli_wdr.cpp:731 src/muuli_wdr.cpp:782 src/muuli_wdr.cpp:846
-#: src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2262 src/muuli_wdr.cpp:2347
-#: src/muuli_wdr.cpp:3095 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
+#: src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2266 src/muuli_wdr.cpp:2351
+#: src/muuli_wdr.cpp:3099 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
 #: src/ServerListCtrl.cpp:606 src/TransferWnd.cpp:378
 #: src/utils/wxCas/src/wxcasprefs.cpp:235
 msgid "Cancel"
@@ -697,7 +697,7 @@ msgid "Stop the current connection attempts"
 msgstr "Σταμάτησε τις τρέχουσες απόπειρες σύνδεσης"
 
 #: src/amuleDlg.cpp:1035 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976
-#: src/muuli_wdr.cpp:2485
+#: src/muuli_wdr.cpp:2489
 msgid "Disconnect"
 msgstr "Αποσύνδεση"
 
@@ -706,7 +706,7 @@ msgid "Disconnect from the currently connected networks"
 msgstr "Αποσύνδεση από τα συνδεδεμένα δίκτυα"
 
 #: src/amuleDlg.cpp:1041 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979
-#: src/muuli_wdr.cpp:2640 src/muuli_wdr.cpp:3092 src/muuli_wdr.cpp:3447
+#: src/muuli_wdr.cpp:2644 src/muuli_wdr.cpp:3096 src/muuli_wdr.cpp:3451
 msgid "Connect"
 msgstr "Σύνδεση"
 
@@ -761,7 +761,7 @@ msgstr "Έξοδος επιβεβαίωσης"
 msgid "Launch Command: "
 msgstr ""
 
-#: src/amuleDlg.cpp:1632 src/muuli_wdr.cpp:1982 src/Preferences.cpp:979
+#: src/amuleDlg.cpp:1632 src/muuli_wdr.cpp:1986 src/Preferences.cpp:979
 msgid "- default -"
 msgstr "- Προεπιλεγμένο -"
 
@@ -775,61 +775,61 @@ msgstr "Ο κατάλογος των θεμάτων '%s'  δεν υπάρχει"
 msgid "WARNING: Unable to open skin file '%s' for read"
 msgstr "ΠΡΟΕΙΔΟΠΟΙΗΣΗ: Δεν είναι δυνατή η ανάγνωση του αρχείου θέματος '%s' "
 
-#: src/amuleDlg.cpp:1791 src/muuli_wdr.cpp:3449
+#: src/amuleDlg.cpp:1814 src/muuli_wdr.cpp:3453
 msgid "Networks Window"
 msgstr "Παράθυρο δικτύων"
 
-#: src/amuleDlg.cpp:1797 src/muuli_wdr.cpp:3450
+#: src/amuleDlg.cpp:1820 src/muuli_wdr.cpp:3454
 msgid "Searches Window"
 msgstr "Παράθυρο αναζητήσεων"
 
-#: src/amuleDlg.cpp:1803 src/muuli_wdr.cpp:3451
+#: src/amuleDlg.cpp:1826 src/muuli_wdr.cpp:3455
 #, fuzzy
 msgid "Downloads Window"
 msgstr "Κατεβαίνει"
 
-#: src/amuleDlg.cpp:1809 src/muuli_wdr.cpp:3453
+#: src/amuleDlg.cpp:1832 src/muuli_wdr.cpp:3457
 msgid "Shared Files Window"
 msgstr "Παράθυρο κοινόχρηστων αρχείων"
 
-#: src/amuleDlg.cpp:1815 src/muuli_wdr.cpp:3454
+#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3458
 msgid "Messages Window"
 msgstr "Παράθυρό μηνυμάτων"
 
-#: src/amuleDlg.cpp:1821 src/muuli_wdr.cpp:3455
+#: src/amuleDlg.cpp:1844 src/muuli_wdr.cpp:3459
 msgid "Statistics Graph Window"
 msgstr "Παράθυρο στατιστικών διαγραμμάτων"
 
-#: src/amuleDlg.cpp:1828 src/muuli_wdr.cpp:3457
+#: src/amuleDlg.cpp:1851 src/muuli_wdr.cpp:3461
 msgid "Preferences Settings Window"
 msgstr "Παράθυρο ρυθμίσεων"
 
-#: src/amuleDlg.cpp:1831 src/muuli_wdr.cpp:3458
+#: src/amuleDlg.cpp:1854 src/muuli_wdr.cpp:3462
 msgid "Import"
 msgstr "Εισαγωγή"
 
-#: src/amuleDlg.cpp:1835 src/muuli_wdr.cpp:3458
+#: src/amuleDlg.cpp:1858 src/muuli_wdr.cpp:3462
 msgid "The partfile importer tool"
 msgstr "Το εργαλείο εισαγωγής ημιτελών αρχείων"
 
-#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3459
+#: src/amuleDlg.cpp:1861 src/muuli_wdr.cpp:3463
 #: src/utils/aLinkCreator/src/alcframe.cpp:262
 msgid "About"
 msgstr "Σχετικά"
 
-#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3459
+#: src/amuleDlg.cpp:1861 src/muuli_wdr.cpp:3463
 msgid "About/Help"
 msgstr "Σχετικά/Βοήθεια"
 
-#: src/amuleDlg.cpp:2036
+#: src/amuleDlg.cpp:2059
 msgid "eD2k network"
 msgstr "Δίκτυο eD2k"
 
-#: src/amuleDlg.cpp:2039
+#: src/amuleDlg.cpp:2062
 msgid "Kad network"
 msgstr "Δίκτυο Kad"
 
-#: src/amuleDlg.cpp:2039
+#: src/amuleDlg.cpp:2062
 msgid "No network"
 msgstr "Κανένα δίκτυο"
 
@@ -1366,19 +1366,19 @@ msgstr "Αυτόματη [Υψηλή]"
 msgid "Very low"
 msgstr "Πολύ χαμηλή"
 
-#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:743 src/muuli_wdr.cpp:2313
+#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:743 src/muuli_wdr.cpp:2317
 #: src/ServerListCtrl.cpp:263 src/ServerListCtrl.cpp:456
 #: src/SharedFilesCtrl.cpp:145
 msgid "Low"
 msgstr "Χαμηλή"
 
-#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:744 src/muuli_wdr.cpp:2314
+#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:744 src/muuli_wdr.cpp:2318
 #: src/ServerListCtrl.cpp:266 src/ServerListCtrl.cpp:457
 #: src/SharedFilesCtrl.cpp:146
 msgid "Normal"
 msgstr "Κανονική"
 
-#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:745 src/muuli_wdr.cpp:2315
+#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:745 src/muuli_wdr.cpp:2319
 #: src/ServerListCtrl.cpp:269 src/ServerListCtrl.cpp:458
 #: src/SharedFilesCtrl.cpp:147
 msgid "High"
@@ -1470,7 +1470,7 @@ msgstr "Τοπικός διακομιστής"
 msgid "Remote Server"
 msgstr "Απομακρυσμένος διακομιστής"
 
-#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3212
+#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3216
 #: src/SearchDlg.cpp:119 src/TextClient.cpp:911
 msgid "Kad"
 msgstr "Kad"
@@ -1542,7 +1542,7 @@ msgstr "Μέρος"
 msgid "Size"
 msgstr "Μέγεθος"
 
-#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3279
+#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3283
 msgid "Transferred"
 msgstr "Μεταφέρθηκαν"
 
@@ -1600,7 +1600,7 @@ msgstr ""
 "Αντίδραση από %s (%s)\n"
 "\n"
 
-#: src/DownloadListCtrl.cpp:746 src/muuli_wdr.cpp:2316
+#: src/DownloadListCtrl.cpp:746 src/muuli_wdr.cpp:2320
 #: src/SharedFilesCtrl.cpp:150
 msgid "Auto"
 msgstr "Αυτόματη"
@@ -1638,7 +1638,7 @@ msgid "Extended Options"
 msgstr "Εκτεταμένες Προτιμήσεις"
 
 #: src/DownloadListCtrl.cpp:770 src/DownloadListCtrl.cpp:822
-#: src/muuli_wdr.cpp:1800
+#: src/muuli_wdr.cpp:1804
 msgid "Preview"
 msgstr "Προεπισκόπιση"
 
@@ -2443,23 +2443,23 @@ msgid ""
 "want downloads on a different (e.g. larger) disk."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:549 src/FirstRunWizard.cpp:611 src/muuli_wdr.cpp:1712
+#: src/FirstRunWizard.cpp:549 src/FirstRunWizard.cpp:611 src/muuli_wdr.cpp:1716
 msgid "Destination folder for downloads"
 msgstr "Κατάλογος για τα εισερχόμενα"
 
 #: src/FirstRunWizard.cpp:553 src/FirstRunWizard.cpp:569 src/muuli_wdr.cpp:1349
-#: src/muuli_wdr.cpp:1366 src/muuli_wdr.cpp:1687 src/muuli_wdr.cpp:1718
-#: src/muuli_wdr.cpp:1730 src/muuli_wdr.cpp:2800
+#: src/muuli_wdr.cpp:1366 src/muuli_wdr.cpp:1691 src/muuli_wdr.cpp:1722
+#: src/muuli_wdr.cpp:1734 src/muuli_wdr.cpp:2804
 #: src/utils/aLinkCreator/src/alcframe.cpp:135
 #: src/utils/wxCas/src/wxcasprefs.cpp:52 src/utils/wxCas/src/wxcasprefs.cpp:118
 msgid "Browse"
 msgstr "Επιλογή"
 
-#: src/FirstRunWizard.cpp:559 src/muuli_wdr.cpp:1723
+#: src/FirstRunWizard.cpp:559 src/muuli_wdr.cpp:1727
 msgid "(All files in this folder are shared with other peers)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:565 src/FirstRunWizard.cpp:624 src/muuli_wdr.cpp:1725
+#: src/FirstRunWizard.cpp:565 src/FirstRunWizard.cpp:624 src/muuli_wdr.cpp:1729
 msgid "Folder for temporary download files"
 msgstr "Κατάλογος για τα προσωρινά αρχεία"
 
@@ -2490,7 +2490,7 @@ msgstr "Αποτυχία γραψίματος στο αρχείο της λίσ�
 msgid "CRITICAL - no client on StartChatSession"
 msgstr ""
 
-#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2706 src/muuli_wdr.cpp:3383
+#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2710 src/muuli_wdr.cpp:3387
 msgid "Friends"
 msgstr "Φίλοι"
 
@@ -2604,8 +2604,8 @@ msgstr "Κανείς"
 msgid "No"
 msgstr "Όχι"
 
-#: src/GenericClientListCtrl.cpp:1216 src/PrefsUnifiedDlg.cpp:2898
-#: src/PrefsUnifiedDlg.cpp:2948 src/ServerListCtrl.cpp:276
+#: src/GenericClientListCtrl.cpp:1216 src/PrefsUnifiedDlg.cpp:2907
+#: src/PrefsUnifiedDlg.cpp:2957 src/ServerListCtrl.cpp:276
 msgid "Yes"
 msgstr "Ναι"
 
@@ -2775,10 +2775,10 @@ msgstr "Άκυρη θύρα για εκκινητήρα"
 msgid "Please fill all fields required"
 msgstr "Παρακαλώ συμπληρώστε όλα τα απαιτούμενα πεδία"
 
-#: src/KadDlg.cpp:192 src/PartFile.cpp:1031 src/PrefsUnifiedDlg.cpp:1134
-#: src/PrefsUnifiedDlg.cpp:1204 src/PrefsUnifiedDlg.cpp:1405
-#: src/PrefsUnifiedDlg.cpp:1663 src/PrefsUnifiedDlg.cpp:1673
-#: src/PrefsUnifiedDlg.cpp:1690 src/PrefsUnifiedDlg.cpp:1738
+#: src/KadDlg.cpp:192 src/PartFile.cpp:1031 src/PrefsUnifiedDlg.cpp:1143
+#: src/PrefsUnifiedDlg.cpp:1213 src/PrefsUnifiedDlg.cpp:1414
+#: src/PrefsUnifiedDlg.cpp:1672 src/PrefsUnifiedDlg.cpp:1682
+#: src/PrefsUnifiedDlg.cpp:1699 src/PrefsUnifiedDlg.cpp:1747
 msgid "Message"
 msgstr "Μήνυμα"
 
@@ -2880,7 +2880,7 @@ msgstr "Λόγος μοιράσματος"
 msgid "Uploaded"
 msgstr "Ανέβηκε"
 
-#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3263
+#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3267
 msgid "Requested"
 msgstr "Ζητήθηκε:"
 
@@ -3006,7 +3006,7 @@ msgid "WARNING: "
 msgstr "ΠΡΟΕΙΔΟΠΟΙΗΣΗ:"
 
 #: src/MuleNotebook.cpp:179 src/muuli_wdr.cpp:817 src/muuli_wdr.cpp:1229
-#: src/muuli_wdr.cpp:3167 src/muuli_wdr.cpp:3423
+#: src/muuli_wdr.cpp:3171 src/muuli_wdr.cpp:3427
 msgid "Close"
 msgstr "Κλείσιμο"
 
@@ -3024,7 +3024,7 @@ msgid "Paste"
 msgstr "Επικόλληση"
 
 #: src/MuleTextCtrl.cpp:89 src/muuli_wdr.cpp:358 src/muuli_wdr.cpp:757
-#: src/muuli_wdr.cpp:2390 src/muuli_wdr.cpp:2409 src/muuli_wdr.cpp:2431
+#: src/muuli_wdr.cpp:2394 src/muuli_wdr.cpp:2413 src/muuli_wdr.cpp:2435
 #: src/utils/aLinkCreator/src/alcframe.cpp:142
 msgid "Clear"
 msgstr "Καθαρισμός"
@@ -3123,7 +3123,7 @@ msgstr "Έξοδος"
 
 #: src/MuleTrayIcon.cpp:579 src/MuleTrayIcon.cpp:945 src/MuleTrayIcon.cpp:965
 #: src/muuli_wdr.cpp:1398 src/muuli_wdr.cpp:1406 src/muuli_wdr.cpp:1413
-#: src/muuli_wdr.cpp:1846 src/muuli_wdr.cpp:1852 src/OtherFunctions.cpp:91
+#: src/muuli_wdr.cpp:1850 src/muuli_wdr.cpp:1856 src/OtherFunctions.cpp:91
 #: src/StatisticsDlg.cpp:93 src/StatisticsDlg.cpp:95
 msgid "kB/s"
 msgstr "kB/s"
@@ -3365,7 +3365,7 @@ msgstr "Bytes"
 msgid "KB"
 msgstr "KB"
 
-#: src/muuli_wdr.cpp:274 src/muuli_wdr.cpp:293 src/muuli_wdr.cpp:1631
+#: src/muuli_wdr.cpp:274 src/muuli_wdr.cpp:293 src/muuli_wdr.cpp:1635
 #: src/OtherFunctions.cpp:64
 msgid "MB"
 msgstr "MB"
@@ -3382,7 +3382,7 @@ msgstr "Μέγιστο αρχείο"
 msgid "Availability"
 msgstr "Διαθεσιμότητα"
 
-#: src/muuli_wdr.cpp:312 src/muuli_wdr.cpp:398 src/muuli_wdr.cpp:3328
+#: src/muuli_wdr.cpp:312 src/muuli_wdr.cpp:398 src/muuli_wdr.cpp:3332
 msgid "Filter:"
 msgstr "Φίλτρο:"
 
@@ -3446,8 +3446,8 @@ msgstr "Ολοκλήρωση πηγών"
 #: src/muuli_wdr.cpp:1160 src/muuli_wdr.cpp:1167 src/muuli_wdr.cpp:1172
 #: src/muuli_wdr.cpp:1179 src/muuli_wdr.cpp:1184 src/muuli_wdr.cpp:1191
 #: src/muuli_wdr.cpp:1205 src/muuli_wdr.cpp:1212 src/muuli_wdr.cpp:1217
-#: src/muuli_wdr.cpp:1224 src/muuli_wdr.cpp:3265 src/muuli_wdr.cpp:3273
-#: src/muuli_wdr.cpp:3281
+#: src/muuli_wdr.cpp:1224 src/muuli_wdr.cpp:3269 src/muuli_wdr.cpp:3277
+#: src/muuli_wdr.cpp:3285
 msgid "N/A"
 msgstr "Δεν υπάρχει"
 
@@ -3592,7 +3592,7 @@ msgstr ""
 msgid "Album :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:685 src/muuli_wdr.cpp:2285
+#: src/muuli_wdr.cpp:685 src/muuli_wdr.cpp:2289
 msgid "Title :"
 msgstr "Τίτλος:"
 
@@ -3701,7 +3701,7 @@ msgstr "Όνομα χρήστη :"
 msgid "Userhash :"
 msgstr "Τεμάχιο χρήστη :"
 
-#: src/muuli_wdr.cpp:895 src/muuli_wdr.cpp:1752 src/muuli_wdr.cpp:2480
+#: src/muuli_wdr.cpp:895 src/muuli_wdr.cpp:1756 src/muuli_wdr.cpp:2484
 #: src/utils/aLinkCreator/src/alcframe.cpp:137
 msgid "Add"
 msgstr "Προσθήκη"
@@ -3710,15 +3710,15 @@ msgstr "Προσθήκη"
 msgid "Download-Speed"
 msgstr "Ταχύτητα κατεβάσματος"
 
-#: src/muuli_wdr.cpp:954 src/muuli_wdr.cpp:989 src/muuli_wdr.cpp:2584
+#: src/muuli_wdr.cpp:954 src/muuli_wdr.cpp:989 src/muuli_wdr.cpp:2588
 msgid "Current"
 msgstr "Τρέχων"
 
-#: src/muuli_wdr.cpp:962 src/muuli_wdr.cpp:997 src/muuli_wdr.cpp:2592
+#: src/muuli_wdr.cpp:962 src/muuli_wdr.cpp:997 src/muuli_wdr.cpp:2596
 msgid "Running average"
 msgstr "Μέσο τρεξίματος"
 
-#: src/muuli_wdr.cpp:970 src/muuli_wdr.cpp:1005 src/muuli_wdr.cpp:2600
+#: src/muuli_wdr.cpp:970 src/muuli_wdr.cpp:1005 src/muuli_wdr.cpp:2604
 msgid "Session average"
 msgstr "Μέσο περιόδου"
 
@@ -3730,7 +3730,7 @@ msgstr "Ταχύτητα ανεβάσματος"
 msgid "Connections"
 msgstr "Συνδέσεις"
 
-#: src/muuli_wdr.cpp:1024 src/muuli_wdr.cpp:1871
+#: src/muuli_wdr.cpp:1024 src/muuli_wdr.cpp:1875
 msgid "Active downloads"
 msgstr "Ενεργά κατεβάσματα"
 
@@ -3738,7 +3738,7 @@ msgstr "Ενεργά κατεβάσματα"
 msgid "Active connections (1:1)"
 msgstr "Ενεργές συνδέσεις (1:1)"
 
-#: src/muuli_wdr.cpp:1040 src/muuli_wdr.cpp:1872
+#: src/muuli_wdr.cpp:1040 src/muuli_wdr.cpp:1876
 msgid "Active uploads"
 msgstr "Ενεργά ανεβάσματα"
 
@@ -4015,7 +4015,7 @@ msgstr "Συνέδεσε την τοπική διεύθυνση στην διε�
 msgid "Advanced users only: If you have multiple network interfaces, enter the address of the interface to which aMule should be bound."
 msgstr "Μόνο για προχωρημένους χρήστες: Αν έχετε πολλαπλά δικτυακά περιβάλλοντα, εισάγετε την διεύθυνση του περιβάλλοντος με το οποίο το aMule πρέπει να συνδεθεί."
 
-#: src/muuli_wdr.cpp:1462 src/muuli_wdr.cpp:2065
+#: src/muuli_wdr.cpp:1462 src/muuli_wdr.cpp:2069
 #, fuzzy
 msgid "Bind to network interface (empty for any):"
 msgstr "Συνέδεσε την τοπική διεύθυνση στην διεύθυνση (κενό για όλες):"
@@ -4032,7 +4032,7 @@ msgstr "Μέγιστος αριθμός πηγών ανά εισερχόμενο
 msgid "Max simultaneous connections:"
 msgstr "Μέγιστος αριθμός παράλληλων συνδέσεων:"
 
-#: src/muuli_wdr.cpp:1498 src/muuli_wdr.cpp:3207
+#: src/muuli_wdr.cpp:1498 src/muuli_wdr.cpp:3211
 msgid "ED2K"
 msgstr "ED2K"
 
@@ -4124,783 +4124,783 @@ msgstr "Δέσμευση χώρου στο δίσκο για καινούρια 
 msgid "For new files preallocates disk space for the whole file, thus reduces fragmentation"
 msgstr "Δεσμεύει χώρο στο δίσκο για καινούρια αρχεία και έτσι μειώνει τον κατακερματισμό"
 
-#: src/muuli_wdr.cpp:1617
+#: src/muuli_wdr.cpp:1621
 msgid "Create new files as sparse files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1618
+#: src/muuli_wdr.cpp:1622
 msgid "Sparse part files only occupy disk space for the parts already downloaded, so free space is used up gradually as the file fills in. Turn this off to use an ordinary file instead - useful where sparse files are unsupported or slow, or where backup/de-duplication tools handle them badly. Applies only when the core runs on Windows; on Linux and macOS part files are sparse anyway and this setting has no effect."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1623
+#: src/muuli_wdr.cpp:1627
 msgid "Stop downloads when free disk space reaches "
 msgstr "Σταμάτημα του κατεβάσματος όταν ο ελεύθερος δίσκος φτάσει τα"
 
-#: src/muuli_wdr.cpp:1624
+#: src/muuli_wdr.cpp:1628
 msgid "Select this if you want aMule to check your disk space"
 msgstr "Επιλέξτε αυτό αν θέλετε το aMule να ελέγξει τον χώρο στον δίσκο σας"
 
-#: src/muuli_wdr.cpp:1628
+#: src/muuli_wdr.cpp:1632
 msgid "Enter here the min disk space desired."
 msgstr "Γράψτε εδώ των ελάχιστο επιθυμητό χώρο στον δίσκο."
 
-#: src/muuli_wdr.cpp:1634
+#: src/muuli_wdr.cpp:1638
 msgid "Save 10 sources on rare files (< 20 sources)"
 msgstr "Αποθήκευση 10 πηγών σε σπάνια αρχεία (<20 πηγές)"
 
-#: src/muuli_wdr.cpp:1638 src/Statistics.cpp:790
+#: src/muuli_wdr.cpp:1642 src/Statistics.cpp:790
 msgid "Uploads"
 msgstr "Ανεβασμένα"
 
-#: src/muuli_wdr.cpp:1641
+#: src/muuli_wdr.cpp:1645
 msgid "Add new shared files with auto priority"
 msgstr "Προσθήκη νέων κοινόχρηστων αρχείων με αυτόματη προτεραιότητα"
 
-#: src/muuli_wdr.cpp:1647
+#: src/muuli_wdr.cpp:1651
 msgid "Intelligent Corruption Handling (I.C.H.)"
 msgstr "Έξυπνη διαχείριση φθοράς (Ε.Δ.Φ.)"
 
-#: src/muuli_wdr.cpp:1650
+#: src/muuli_wdr.cpp:1654
 msgid "Enable"
 msgstr "Ενεργοποιήση"
 
-#: src/muuli_wdr.cpp:1653
+#: src/muuli_wdr.cpp:1657
 msgid "Advanced I.C.H. trusts every hash (not recommended)"
 msgstr "Προχωρημένη Ε.Δ.Φ. εμπιστεύεται κάθε κατακερματισμό (δεν συνιστάται)"
 
-#: src/muuli_wdr.cpp:1665 src/PrefsUnifiedDlg.cpp:1990
+#: src/muuli_wdr.cpp:1669 src/PrefsUnifiedDlg.cpp:1999
 msgid "Media metadata extraction"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1669
+#: src/muuli_wdr.cpp:1673
 msgid "Extract length / bitrate / codec from shared audio and video files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1671
+#: src/muuli_wdr.cpp:1675
 msgid "When enabled, aMule runs ffprobe on each shared media file to fill in the Length / Bitrate / Codec columns other clients see when they find the file in a search. Requires ffmpeg (the ffprobe binary) to be installed."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1678
+#: src/muuli_wdr.cpp:1682
 msgid "Path to ffprobe:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1683
+#: src/muuli_wdr.cpp:1687
 msgid "Full path to the ffprobe binary. Leave empty to have aMule auto-detect it on startup."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1691
+#: src/muuli_wdr.cpp:1695
 msgid "Detect"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1692
+#: src/muuli_wdr.cpp:1696
 msgid "Search the standard install locations for an ffprobe binary and fill the path field."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1716
+#: src/muuli_wdr.cpp:1720
 msgid ""
 "Completed downloads are stored here. All files in this folder are automatically shared with other peers.\n"
 "If this folder also holds files you don't want to share, point it at an aMule-only sub-folder."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1719
+#: src/muuli_wdr.cpp:1723
 msgid "Pick the folder where completed downloads will be stored. All files in that folder will be shared with other peers."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1733
+#: src/muuli_wdr.cpp:1737
 msgid "Shared folders"
 msgstr "Κοινόχρηστα αρχεία"
 
-#: src/muuli_wdr.cpp:1739
+#: src/muuli_wdr.cpp:1743
 msgid "(Folders shared by the core. Enter a path to add one.)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1747
+#: src/muuli_wdr.cpp:1751
 msgid "Absolute path of a folder on the core's machine, e.g. /home/user/shared"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1749 src/PrefsUnifiedDlg.cpp:2874
+#: src/muuli_wdr.cpp:1753 src/PrefsUnifiedDlg.cpp:2883
 msgid "Recursive"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1750
+#: src/muuli_wdr.cpp:1754
 msgid "Share every sub-folder underneath this one, including ones created later."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1754 src/utils/aLinkCreator/src/alcframe.cpp:141
+#: src/muuli_wdr.cpp:1758 src/utils/aLinkCreator/src/alcframe.cpp:141
 msgid "Remove"
 msgstr "Αφαίρεση"
 
-#: src/muuli_wdr.cpp:1758
+#: src/muuli_wdr.cpp:1762
 msgid "(Right click on folder icon for recursive share)"
 msgstr "(Δεξί κλικ στην εικόνα του καταλόγου για να γίνουν κοινόχρηστοι οι υποκατάλογοι)"
 
-#: src/muuli_wdr.cpp:1765
+#: src/muuli_wdr.cpp:1769
 msgid "Share hidden files"
 msgstr "Κάνε τα κρυφά αρχεία κοινόχρηστα"
 
-#: src/muuli_wdr.cpp:1771
+#: src/muuli_wdr.cpp:1775
 msgid "Automatically rescan shared folders for changes"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1777
+#: src/muuli_wdr.cpp:1781
 msgid "Follow symbolic links in shared folders"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1783
+#: src/muuli_wdr.cpp:1787
 msgid "Exclude files matching:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1786
+#: src/muuli_wdr.cpp:1790
 msgid "Wildcard patterns separated by '|', e.g. .DS_Store|Thumbs.db|*.tmp. Files whose name matches are not shared. Matching is case-insensitive."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1790
+#: src/muuli_wdr.cpp:1794
 msgid "Patterns are regular expressions"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1791
+#: src/muuli_wdr.cpp:1795
 msgid "When set, the whole field is one regular expression ('|' is alternation). When unset, it is a list of '|'-separated wildcards."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1801
+#: src/muuli_wdr.cpp:1805
 msgid "Show how many shared files the current pattern would exclude."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1822
+#: src/muuli_wdr.cpp:1826
 msgid "Graphs"
 msgstr "Γραφικές Παραστάσεις"
 
-#: src/muuli_wdr.cpp:1825 src/muuli_wdr.cpp:1887
+#: src/muuli_wdr.cpp:1829 src/muuli_wdr.cpp:1891
 msgid "Update delay : 5 secs"
 msgstr "Χρόνος καθυστέρηση ενημέρωσης : 5 δευτερόλεπτα"
 
-#: src/muuli_wdr.cpp:1829
+#: src/muuli_wdr.cpp:1833
 msgid "Time for average graph: 100 mins"
 msgstr "Χρόνος μέσου γραφήματος: 100 λεπτά"
 
-#: src/muuli_wdr.cpp:1833
+#: src/muuli_wdr.cpp:1837
 msgid "Connections Graph Scale: 100 "
 msgstr "Κλίμακα διαγράμματος συνδέσεων: 100"
 
-#: src/muuli_wdr.cpp:1840
+#: src/muuli_wdr.cpp:1844
 msgid "Download graph scale:"
 msgstr "Κλιματα του γραφήματος εισερχομένων:"
 
-#: src/muuli_wdr.cpp:1848
+#: src/muuli_wdr.cpp:1852
 msgid "Upload graph scale:"
 msgstr "Κλιμακα του γραφήματος εξερχομένων"
 
-#: src/muuli_wdr.cpp:1858
+#: src/muuli_wdr.cpp:1862
 #, fuzzy
 msgid "Colors: "
 msgstr "Χρώματα:"
 
-#: src/muuli_wdr.cpp:1862
+#: src/muuli_wdr.cpp:1866
 msgid "Background"
 msgstr "Υπόβαθρο"
 
-#: src/muuli_wdr.cpp:1863
+#: src/muuli_wdr.cpp:1867
 msgid "Grid"
 msgstr "Πλέγμα"
 
-#: src/muuli_wdr.cpp:1864
+#: src/muuli_wdr.cpp:1868
 msgid "Download current"
 msgstr "Κατέβασμα του τρέχοντος"
 
-#: src/muuli_wdr.cpp:1865
+#: src/muuli_wdr.cpp:1869
 msgid "Download running average"
 msgstr "Μέσο τρέξιμο κατεβάσματος"
 
-#: src/muuli_wdr.cpp:1866
+#: src/muuli_wdr.cpp:1870
 msgid "Download session average"
 msgstr "Μέσο συνεδρίας κατεβάσματος"
 
-#: src/muuli_wdr.cpp:1867
+#: src/muuli_wdr.cpp:1871
 msgid "Upload current"
 msgstr "Ανέβασμα του τρέχοντος"
 
-#: src/muuli_wdr.cpp:1868
+#: src/muuli_wdr.cpp:1872
 msgid "Upload running average"
 msgstr "Μέσο τρέξιμο ανεβάσματος"
 
-#: src/muuli_wdr.cpp:1869
+#: src/muuli_wdr.cpp:1873
 msgid "Upload session average"
 msgstr "Μέσο συνεδρίας ανεβάσματος"
 
-#: src/muuli_wdr.cpp:1870
+#: src/muuli_wdr.cpp:1874
 msgid "Active connections"
 msgstr "Ενεργές συνδέσεις"
 
-#: src/muuli_wdr.cpp:1873
+#: src/muuli_wdr.cpp:1877
 #, fuzzy
 msgid "Systray Icon Speed Bar"
 msgstr "Εικόνα για την μπάρα ταχείας πρόσβασης του Systray"
 
-#: src/muuli_wdr.cpp:1874
+#: src/muuli_wdr.cpp:1878
 msgid "Kad-nodes current"
 msgstr "Σύνδεσμοι-Kad παρόντες"
 
-#: src/muuli_wdr.cpp:1875
+#: src/muuli_wdr.cpp:1879
 msgid "Kad-nodes running"
 msgstr "Σύνδεσμοι-Kad τρέχοντες"
 
-#: src/muuli_wdr.cpp:1876
+#: src/muuli_wdr.cpp:1880
 msgid "Kad-nodes session"
 msgstr "Σύνδεσμοι-Kad συνεδρία"
 
-#: src/muuli_wdr.cpp:1880 src/muuli_wdr.cpp:2334
+#: src/muuli_wdr.cpp:1884 src/muuli_wdr.cpp:2338
 msgid "Select"
 msgstr "Επέλεξε"
 
-#: src/muuli_wdr.cpp:1884
+#: src/muuli_wdr.cpp:1888
 msgid "Tree"
 msgstr "Δέντρο"
 
-#: src/muuli_wdr.cpp:1894
+#: src/muuli_wdr.cpp:1898
 msgid "Number of Client Versions shown (0=unlimited)"
 msgstr "Αριθμός των εμφανιζόμενων εκδόσεων πελάτη (0=απεριόριστος)"
 
-#: src/muuli_wdr.cpp:1919
+#: src/muuli_wdr.cpp:1923
 msgid "!!! WARNING !!!"
 msgstr "!!! Προειδοποίηση !!!"
 
-#: src/muuli_wdr.cpp:1934
+#: src/muuli_wdr.cpp:1938
 msgid "Max new connections / 5 secs"
 msgstr "Μέγιστος αρ. νέων συνδέσεων /5 δευτερόλεπτα"
 
-#: src/muuli_wdr.cpp:1936
+#: src/muuli_wdr.cpp:1940
 msgid "Concurrent Kad source lookups"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1938
+#: src/muuli_wdr.cpp:1942
 #, fuzzy
 msgid "Kad source re-search interval (minutes)"
 msgstr "Περίοδος ενημέρωσης του FTP σε λεπτά"
 
-#: src/muuli_wdr.cpp:1940
+#: src/muuli_wdr.cpp:1944
 #, fuzzy
 msgid "Source re-ask interval (minutes)"
 msgstr "Περίοδος ενημέρωσης του FTP σε λεπτά"
 
-#: src/muuli_wdr.cpp:1944
+#: src/muuli_wdr.cpp:1948
 msgid "File Buffer Size: 240000 bytes"
 msgstr "Χώρος προσωρινής αποθήκευσης αρχείου: 240000 bytes"
 
-#: src/muuli_wdr.cpp:1948
+#: src/muuli_wdr.cpp:1952
 msgid "Use MMAP: memory-mapped file access (lower memory use)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1949
+#: src/muuli_wdr.cpp:1953
 msgid "Maps part files into memory instead of buffering them on the heap, lowering the process memory footprint. May reduce download speed on some disks; best for memory-constrained or upload-heavy hosts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1951
+#: src/muuli_wdr.cpp:1955
 msgid "Upload Queue Size: 5000 clients"
 msgstr "Λίστα αναμονής ανεβάσματος: 5000 πελάτες"
 
-#: src/muuli_wdr.cpp:1955
+#: src/muuli_wdr.cpp:1959
 msgid "Server connection refresh interval: Disable"
 msgstr "Διάστημα ανανέωσης της σύνδεσης σε διακομιστή: Απενεργοποίηση"
 
-#: src/muuli_wdr.cpp:1959
+#: src/muuli_wdr.cpp:1963
 msgid "Disable computer's timed standby mode"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1978
+#: src/muuli_wdr.cpp:1982
 msgid "Skin to use: "
 msgstr "Θέμα:"
 
-#: src/muuli_wdr.cpp:1987
+#: src/muuli_wdr.cpp:1991
 msgid "Show \"Fast eD2k Links Handler\" in every window."
 msgstr "Εμφάνιση \"Γρήγορου διαχειριστή συνδέσμων eD2k\" σε όλα τα παράθυρα."
 
-#: src/muuli_wdr.cpp:1990
+#: src/muuli_wdr.cpp:1994
 msgid "Show extended info on categories tabs"
 msgstr "Εμφάνιση εκτεταμένων πληροφοριών στην καρτέλα κατηγοριών"
 
-#: src/muuli_wdr.cpp:1993
+#: src/muuli_wdr.cpp:1997
 #, fuzzy
 msgid "Show application version on title"
 msgstr "Εμφάνιση των ταχυτήτων μεταφοράς στον τίτλο"
 
-#: src/muuli_wdr.cpp:1995
+#: src/muuli_wdr.cpp:1999
 msgid "Show transfer rates on title"
 msgstr "Εμφάνιση των ταχυτήτων μεταφοράς στον τίτλο"
 
-#: src/muuli_wdr.cpp:1997
+#: src/muuli_wdr.cpp:2001
 msgid "Before application name"
 msgstr "Πριν απο το όνομα της εφαρμογής"
 
-#: src/muuli_wdr.cpp:1999
+#: src/muuli_wdr.cpp:2003
 msgid "After application name"
 msgstr "Μετά το όνομα της εφαρμογής"
 
-#: src/muuli_wdr.cpp:2002
+#: src/muuli_wdr.cpp:2006
 msgid "Show overhead bandwidth"
 msgstr "Εμφάνιση επιβάρυνσης στο εύρος ζώνης"
 
-#: src/muuli_wdr.cpp:2006
+#: src/muuli_wdr.cpp:2010
 msgid "Vertical toolbar orientation"
 msgstr "Κατακόρυφος προσανατολισμός της γραμμής εντολών"
 
-#: src/muuli_wdr.cpp:2008
+#: src/muuli_wdr.cpp:2012
 msgid "Live column sorting (auto-reorder rows as their values change)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2015
+#: src/muuli_wdr.cpp:2019
 msgid "Download Queue Files"
 msgstr "Ουρά εισερχομένων αρχείων"
 
-#: src/muuli_wdr.cpp:2018
+#: src/muuli_wdr.cpp:2022
 msgid "Show progress percentage"
 msgstr "Εμφάνιση ποσοστού προόδου"
 
-#: src/muuli_wdr.cpp:2024
+#: src/muuli_wdr.cpp:2028
 msgid "Show progress bar"
 msgstr "Εμφάνιση μπάρας προόδου"
 
-#: src/muuli_wdr.cpp:2027
+#: src/muuli_wdr.cpp:2031
 msgid "Flat"
 msgstr "Επίπεδη"
 
-#: src/muuli_wdr.cpp:2031
+#: src/muuli_wdr.cpp:2035
 msgid "Round"
 msgstr "Στρογγυλή"
 
-#: src/muuli_wdr.cpp:2049
+#: src/muuli_wdr.cpp:2053
 msgid "External Connection Parameters"
 msgstr "Παράμετροι εξωτερικών συνδέσεων"
 
-#: src/muuli_wdr.cpp:2052
+#: src/muuli_wdr.cpp:2056
 msgid "Accept external connections"
 msgstr "Να γίνονται αποδεκτές οι εξωτερικές συνδέσεις"
 
-#: src/muuli_wdr.cpp:2059 src/muuli_wdr.cpp:2118
+#: src/muuli_wdr.cpp:2063 src/muuli_wdr.cpp:2122
 msgid "IP of the listening interface:"
 msgstr "Η διεύθυνση του εισακούοντος περιβάλλοντος:"
 
-#: src/muuli_wdr.cpp:2062
+#: src/muuli_wdr.cpp:2066
 msgid "Enter here a valid ip in the a.b.c.d format for the listening EC interface. An empty field or 0.0.0.0 will mean any interface."
 msgstr "Εισάγετε μία έγκυρη διεύθυνση με φόρμα a.b.c.d για σύνδεση με το περιβάλλον EC. Άδειο πεδίου ή 0.0.0.0 συμβολίζει όλα τα περιβάλλοντα."
 
-#: src/muuli_wdr.cpp:2083 src/muuli_wdr.cpp:2194
+#: src/muuli_wdr.cpp:2087 src/muuli_wdr.cpp:2198
 msgid "TCP port:"
 msgstr "Θύρα TCP:"
 
-#: src/muuli_wdr.cpp:2089
+#: src/muuli_wdr.cpp:2093
 msgid "Enable UPnP port forwarding on the EC port"
 msgstr "Ενεργοποίηση της προώθησης της θύρας UPnP στην θύρα EC"
 
-#: src/muuli_wdr.cpp:2093 src/muuli_wdr.cpp:3079
+#: src/muuli_wdr.cpp:2097 src/muuli_wdr.cpp:3083
 #: src/utils/wxCas/src/wxcasprefs.cpp:167
 msgid "Password"
 msgstr "Κωδικός"
 
-#: src/muuli_wdr.cpp:2099
+#: src/muuli_wdr.cpp:2103
 #, fuzzy
 msgid "aMule API server parameters"
 msgstr "Παράμετροι διακομιστή ιστού"
 
-#: src/muuli_wdr.cpp:2102
+#: src/muuli_wdr.cpp:2106
 msgid "Run amuleapi (REST API) on startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2107
+#: src/muuli_wdr.cpp:2111
 #, fuzzy
 msgid "HTTP port:"
 msgstr "Θύρα TCP:"
 
-#: src/muuli_wdr.cpp:2121
+#: src/muuli_wdr.cpp:2125
 msgid "The interface amuleapi's HTTP server listens on. 127.0.0.1 (default) accepts only local connections; use 0.0.0.0 or a specific IP to expose it to other hosts (set an admin password below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2126
+#: src/muuli_wdr.cpp:2130
 msgid "Type a password to set or change it. Stored passwords cannot be shown, so leaving this empty keeps the current one."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2128
+#: src/muuli_wdr.cpp:2132
 #, fuzzy
 msgid "Admin password"
 msgstr "Έλεγχος κωδικού\n"
 
-#: src/muuli_wdr.cpp:2140 src/muuli_wdr.cpp:2157 src/PrefsUnifiedDlg.cpp:1103
+#: src/muuli_wdr.cpp:2144 src/muuli_wdr.cpp:2161 src/PrefsUnifiedDlg.cpp:1112
 #, fuzzy
 msgid "A password is set."
 msgstr "Έλεγχος κωδικού\n"
 
-#: src/muuli_wdr.cpp:2144
+#: src/muuli_wdr.cpp:2148
 #, fuzzy
 msgid "Enable guest access"
 msgstr "Να απαγορεύεται η πρόσβαση σε επισκέπτες"
 
-#: src/muuli_wdr.cpp:2145
+#: src/muuli_wdr.cpp:2149
 msgid "Guest sessions may read status and listings but cannot change anything. Turning this off clears the stored guest password."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2149
+#: src/muuli_wdr.cpp:2153
 #, fuzzy
 msgid "Guest password"
 msgstr "Κωδικός επισκέπτη για τον διακομιστή ιστού"
 
-#: src/muuli_wdr.cpp:2164
+#: src/muuli_wdr.cpp:2168
 msgid "Web server parameters"
 msgstr "Παράμετροι διακομιστή ιστού"
 
-#: src/muuli_wdr.cpp:2167
+#: src/muuli_wdr.cpp:2171
 #, fuzzy
 msgid "Run webserver on startup (deprecated)"
 msgstr "Έναρξη του εξυπηρετητή ιστού κατά την εκκίνηση"
 
-#: src/muuli_wdr.cpp:2173
+#: src/muuli_wdr.cpp:2177
 msgid "Web template"
 msgstr "Πρότυπη σελίδα"
 
-#: src/muuli_wdr.cpp:2178
+#: src/muuli_wdr.cpp:2182
 msgid "Full rights password"
 msgstr "Κωδικός πλήρων δικαιωμάτων"
 
-#: src/muuli_wdr.cpp:2182
+#: src/muuli_wdr.cpp:2186
 msgid "Enable Low rights User"
 msgstr "Ενεργοποίηση χρήστη μειωμένων δικαιωμάτων"
 
-#: src/muuli_wdr.cpp:2187
+#: src/muuli_wdr.cpp:2191
 msgid "Low rights password"
 msgstr "Κωδικός μειωμένων δικαιωμάτων"
 
-#: src/muuli_wdr.cpp:2201
+#: src/muuli_wdr.cpp:2205
 msgid "Enable UPnP port forwarding of the web server port"
 msgstr "Ενεργοποίηση της προώθησης της θύρας του εξηπηρετητή ιστού στη θύρα UPnP"
 
-#: src/muuli_wdr.cpp:2206
+#: src/muuli_wdr.cpp:2210
 msgid "Web server UPnP TCP port (Optional)"
 msgstr "Θύρα UPnP TCP του εξυπηρετητή (Προαιρετική)"
 
-#: src/muuli_wdr.cpp:2214
+#: src/muuli_wdr.cpp:2218
 msgid "Page Refresh Time (in secs)"
 msgstr "Χρόνος ανανέωσης σελίδας (σε δευτερόλεπτα)"
 
-#: src/muuli_wdr.cpp:2221
+#: src/muuli_wdr.cpp:2225
 msgid "Enable Gzip compression"
 msgstr "Ενεργοποίηση συμπίεσης Gzip"
 
-#: src/muuli_wdr.cpp:2255
+#: src/muuli_wdr.cpp:2259
 #, fuzzy
 msgid "Reset page to defaults"
 msgstr "Εργοστασιακές ρυθμίσεις"
 
-#: src/muuli_wdr.cpp:2256
+#: src/muuli_wdr.cpp:2260
 msgid "Reset the settings on the current page to their default values."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2258 src/muuli_wdr.cpp:2344 src/ServerWnd.cpp:274
+#: src/muuli_wdr.cpp:2262 src/muuli_wdr.cpp:2348 src/ServerWnd.cpp:274
 #: src/ServerWnd.cpp:282
 msgid "OK"
 msgstr "Εντάξει"
 
-#: src/muuli_wdr.cpp:2260
+#: src/muuli_wdr.cpp:2264
 msgid "Click here to apply any changes made to the preferences."
 msgstr "Κλικ εδώ για εφαρμογή των αλλαγών που έγιναν στις προτιμήσεις."
 
-#: src/muuli_wdr.cpp:2263
+#: src/muuli_wdr.cpp:2267
 msgid "Reset any changes made to the preferences."
 msgstr "Επαναφορά κάθε αλλαγής που έγινε στις προτιμήσεις."
 
-#: src/muuli_wdr.cpp:2292
+#: src/muuli_wdr.cpp:2296
 msgid "Comment :"
 msgstr "Σχόλιο:"
 
-#: src/muuli_wdr.cpp:2299
+#: src/muuli_wdr.cpp:2303
 msgid "Incoming Dir :"
 msgstr "Κατάλογος εισερχομένων :"
 
-#: src/muuli_wdr.cpp:2308
+#: src/muuli_wdr.cpp:2312
 msgid "Change priority for new assigned files :"
 msgstr "Αλλαγή προτεραιότητας για τα νέα προσδιορισμένα αρχεία :"
 
-#: src/muuli_wdr.cpp:2312
+#: src/muuli_wdr.cpp:2316
 #, fuzzy
 msgid "Don't change"
 msgstr "Να μην αλλάξει"
 
-#: src/muuli_wdr.cpp:2324
+#: src/muuli_wdr.cpp:2328
 msgid "Select color for this Category (currently selected) :"
 msgstr "Επιλογή χρώματος για τη συγκεκριμένη κατηγορία (τρέχουσα επιλογή) :"
 
-#: src/muuli_wdr.cpp:2391 src/muuli_wdr.cpp:2410 src/muuli_wdr.cpp:2432
+#: src/muuli_wdr.cpp:2395 src/muuli_wdr.cpp:2414 src/muuli_wdr.cpp:2436
 msgid "Click this button to reset the log."
 msgstr "Πατήστε αυτό το κουμπί για το καθάρισμα του αρχείου καταγραφής."
 
-#: src/muuli_wdr.cpp:2451
+#: src/muuli_wdr.cpp:2455
 msgid "Click on this button to update the servers list from URL ..."
 msgstr "Πατήστε αυτό το αρχείο για να ανανεώσετε την λίστα διακομιστών από την URL ..."
 
-#: src/muuli_wdr.cpp:2455
+#: src/muuli_wdr.cpp:2459
 msgid "Server list"
 msgstr "Λίστα διακομιστών"
 
-#: src/muuli_wdr.cpp:2459
+#: src/muuli_wdr.cpp:2463
 msgid "Enter the url to a server.met file here and press the button to the left to update the list of known servers."
 msgstr "Εισάγετε την url ενός αρχείου server.met και πατήστε το κουμπί στα αριστερά για να ανανεώσετε τη λίστα με τους γνωστούς διακομιστές"
 
-#: src/muuli_wdr.cpp:2464
+#: src/muuli_wdr.cpp:2468
 msgid "Add server manually: Name"
 msgstr "Προσθήκη διακομιστή: Όνομα"
 
-#: src/muuli_wdr.cpp:2467
+#: src/muuli_wdr.cpp:2471
 msgid "Enter the name of the new server here"
 msgstr "Γράψτε το όνομα του νέου διακομιστή εδώ"
 
-#: src/muuli_wdr.cpp:2469 src/ServerWnd.cpp:206
+#: src/muuli_wdr.cpp:2473 src/ServerWnd.cpp:206
 msgid "IP:Port"
 msgstr "Διεύθυνση:Θύρα"
 
-#: src/muuli_wdr.cpp:2472
+#: src/muuli_wdr.cpp:2476
 msgid "Enter the IP of the server here, using the x.x.x.x format."
 msgstr "Γράψτε την IP του διακομιστή εδώ, σε μορφή x.x.x.x"
 
-#: src/muuli_wdr.cpp:2478
+#: src/muuli_wdr.cpp:2482
 msgid "Enter the port of the server here."
 msgstr "Γράψτε την θύρα του διακομιστή εδώ."
 
-#: src/muuli_wdr.cpp:2481
+#: src/muuli_wdr.cpp:2485
 msgid "Add manually a server (fill fields to the left before) ..."
 msgstr "Βάλτε τον διακομιστή με το χέρι (γεμίστε πρώτα τα πεδία στα αριστερά) ..."
 
-#: src/muuli_wdr.cpp:2510
+#: src/muuli_wdr.cpp:2514
 msgid "aMule Log"
 msgstr "Αρχείο καταγραφής aMule"
 
-#: src/muuli_wdr.cpp:2518
+#: src/muuli_wdr.cpp:2522
 msgid "Server Info"
 msgstr "Πληροφορίες διακομιστή"
 
-#: src/muuli_wdr.cpp:2522
+#: src/muuli_wdr.cpp:2526
 msgid "ED2K Info"
 msgstr "Πληροφορίες ED2K"
 
-#: src/muuli_wdr.cpp:2526
+#: src/muuli_wdr.cpp:2530
 msgid "Kad Info"
 msgstr "Πληροφορίες Kad"
 
-#: src/muuli_wdr.cpp:2554
+#: src/muuli_wdr.cpp:2558
 msgid "Click on this button to update the nodes list from URL ..."
 msgstr "Πατήστε το κουμπί για να ανανεώσετε την λίστα των κόμβων από την URL ..."
 
-#: src/muuli_wdr.cpp:2558
+#: src/muuli_wdr.cpp:2562
 msgid "Nodes (0)"
 msgstr "Κόμβοι (0)"
 
-#: src/muuli_wdr.cpp:2562
+#: src/muuli_wdr.cpp:2566
 msgid "Enter the url to a nodes.dat file here and press the button to the left to update the list of known nodes."
 msgstr "Βάλτε εδώ την url ενός αρχείου nodes.dat και πατήστε το κουμπί στα αριστερά για να ανανεώσετε την λίστα των γνωστών κόμβων."
 
-#: src/muuli_wdr.cpp:2565
+#: src/muuli_wdr.cpp:2569
 msgid "Nodes stats"
 msgstr "Στατιστικές κόμβων"
 
-#: src/muuli_wdr.cpp:2607
+#: src/muuli_wdr.cpp:2611
 msgid "Bootstrap"
 msgstr "Εκκινητήρας"
 
-#: src/muuli_wdr.cpp:2610
+#: src/muuli_wdr.cpp:2614
 msgid "New node"
 msgstr "Καινούριος κόμβος"
 
-#: src/muuli_wdr.cpp:2615
+#: src/muuli_wdr.cpp:2619
 msgid "IP:"
 msgstr "IP:"
 
-#: src/muuli_wdr.cpp:2635
+#: src/muuli_wdr.cpp:2639
 msgid "Port:"
 msgstr "Θύρα:"
 
-#: src/muuli_wdr.cpp:2648
+#: src/muuli_wdr.cpp:2652
 #, fuzzy
 msgid "Bootstrap from known clients"
 msgstr ""
 "Εκκίνηση από\n"
 "γνωστούς πελάτες"
 
-#: src/muuli_wdr.cpp:2650
+#: src/muuli_wdr.cpp:2654
 msgid "Disconnect Kad"
 msgstr "Αποσυνδεδεμένο Kad"
 
-#: src/muuli_wdr.cpp:2684
+#: src/muuli_wdr.cpp:2688
 msgid "Use Secure User Identification"
 msgstr "Χρήση Ασφαλούς Ταυτοποίησης χρήστη"
 
-#: src/muuli_wdr.cpp:2686
+#: src/muuli_wdr.cpp:2690
 msgid "It is recommended to enable this option. You will not receive credits if SUI is not enabled."
 msgstr "Ενδείκνυται να ενεργοποιήσετε αυτήν την προτίμηση. Δεν θα λάβετε πίστωση αν το SUI δεν είναι ενεργοποιημένο."
 
-#: src/muuli_wdr.cpp:2688
+#: src/muuli_wdr.cpp:2692
 msgid "Protocol Obfuscation"
 msgstr "Συσκότιση πρωτοκόλλου"
 
-#: src/muuli_wdr.cpp:2691
+#: src/muuli_wdr.cpp:2695
 msgid "Support Protocol Obfuscation"
 msgstr "Υποστήριξη συσκότισης πρωτοκόλλου"
 
-#: src/muuli_wdr.cpp:2693
+#: src/muuli_wdr.cpp:2697
 msgid "This option enabled Protocol Obfuscation, and makes aMule accept obfuscated connections from other clients."
 msgstr "Αυτή η επιλογή ενεργοποίησε την συσκότιση πρωτοκόλλου και κάνει το aMule να δέχεται συσκοτισμένες συνδέσεις από άλλους πελάτες"
 
-#: src/muuli_wdr.cpp:2695
+#: src/muuli_wdr.cpp:2699
 msgid "Use obfuscation for outgoing connections"
 msgstr "Χρήση συσκότισης για εξωτερικές συνδέσεις"
 
-#: src/muuli_wdr.cpp:2697
+#: src/muuli_wdr.cpp:2701
 msgid "This option makes aMule use Protocol Obfuscation when connecting other clients/servers."
 msgstr "Αυτή η επιλογή κάνει το aMule να χρησιμοποιεί συσκότιση πρωτοκόλλου όταν συνδέεται σε άλλους πελάτες/διακομιστές."
 
-#: src/muuli_wdr.cpp:2699
+#: src/muuli_wdr.cpp:2703
 msgid "Accept only obfuscated connections"
 msgstr "Να γίνονται δεκτές μόνο συσκοτισμένες συνδέσεις"
 
-#: src/muuli_wdr.cpp:2700
+#: src/muuli_wdr.cpp:2704
 msgid "This option makes aMule only accept obfuscated connections. You will have less sources, but all your traffic will be obfuscated"
 msgstr "Αυτή η επιλογή κάνει το aMule να δέχεται μόνο συσκοτισμένες συνδέσεις. Θα υπάρχουν λιγότερες πηγές αλλά όλη η κυκλοφορία θα είναι συσκοτισμένη"
 
-#: src/muuli_wdr.cpp:2705
+#: src/muuli_wdr.cpp:2709
 msgid "Everybody"
 msgstr "Οι πάντες"
 
-#: src/muuli_wdr.cpp:2707
+#: src/muuli_wdr.cpp:2711
 msgid "No one"
 msgstr "Κανείς"
 
-#: src/muuli_wdr.cpp:2709
+#: src/muuli_wdr.cpp:2713
 msgid "Who can see my shared files:"
 msgstr "Ποίος μπορεί να δεί τα κοινόχρηστα αρχεία μου:"
 
-#: src/muuli_wdr.cpp:2710
+#: src/muuli_wdr.cpp:2714
 msgid "Select who can request to view a list of your shared files."
 msgstr "Επιλέξτε ποίος μπορεί να ζητήσει να δει τη λίστα με τα κοινόχρηστα αρχεία σας."
 
-#: src/muuli_wdr.cpp:2712
+#: src/muuli_wdr.cpp:2716
 msgid "IP-Filtering"
 msgstr "Φίλτρο IP"
 
-#: src/muuli_wdr.cpp:2719
+#: src/muuli_wdr.cpp:2723
 msgid "Filter clients"
 msgstr "Φιλτράρισμα πελατών"
 
-#: src/muuli_wdr.cpp:2721
+#: src/muuli_wdr.cpp:2725
 msgid "Enable filtering of the client IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "Ενεργοποίηση φίλτρου του IP των πελατών όπως ορίζεται στο ~/.aMule/ipfilter.dat."
 
-#: src/muuli_wdr.cpp:2723
+#: src/muuli_wdr.cpp:2727
 msgid "Filter servers"
 msgstr "Φιλτράρισμα διακομιστών"
 
-#: src/muuli_wdr.cpp:2725
+#: src/muuli_wdr.cpp:2729
 msgid "Enable filtering of the server IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "Ενεργοποίηση φίλτρου του IP των διακομιστών όπως ορίζεται στο ~/.aMule/ipfilter.dat."
 
-#: src/muuli_wdr.cpp:2729
+#: src/muuli_wdr.cpp:2733
 msgid "Reload List"
 msgstr "Επαναφόρτωση λίστας"
 
-#: src/muuli_wdr.cpp:2730
+#: src/muuli_wdr.cpp:2734
 msgid "Reload the list of IPs to filter from the file ~/.aMule/ipfilter.dat"
 msgstr "Επαναφόρτωση για φιλτράρισμα της λίστας των IP από το ~/.aMule/ipfilter.dat"
 
-#: src/muuli_wdr.cpp:2736
+#: src/muuli_wdr.cpp:2740
 msgid "URL:"
 msgstr "URL:"
 
-#: src/muuli_wdr.cpp:2740 src/muuli_wdr.cpp:2933
+#: src/muuli_wdr.cpp:2744 src/muuli_wdr.cpp:2937
 msgid "Update now"
 msgstr "Ανανέωσε τώρα"
 
-#: src/muuli_wdr.cpp:2743
+#: src/muuli_wdr.cpp:2747
 msgid "Auto-update ipfilter at startup"
 msgstr "Αυτόματη ανανέωση του ipfilter κατά την εκκίνηση"
 
-#: src/muuli_wdr.cpp:2747
+#: src/muuli_wdr.cpp:2751
 msgid "Filtering Level:"
 msgstr "Επίπεδο φιλτραρίσματος:"
 
-#: src/muuli_wdr.cpp:2753
+#: src/muuli_wdr.cpp:2757
 msgid "Always filter LAN IPs"
 msgstr "Πάντα φίλτραρε τις IP του τοπικού δικτύου"
 
-#: src/muuli_wdr.cpp:2756
+#: src/muuli_wdr.cpp:2760
 msgid "Paranoid handling of non-matching IPs"
 msgstr "Παρανοϊκή διαχείριση των αταίριαστων διευθύνσεων IP"
 
-#: src/muuli_wdr.cpp:2758
+#: src/muuli_wdr.cpp:2762
 msgid "Rejects a packet when its source IP differs from the IP the client claims (an anti-spoofing check). Disable only if it causes connection problems."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2760
+#: src/muuli_wdr.cpp:2764
 msgid "Use system-wide ipfilter.dat if available"
 msgstr "Χρήση του ipfilter.dat όλου του συστήματος αν αυτό υπάρχει"
 
-#: src/muuli_wdr.cpp:2761
+#: src/muuli_wdr.cpp:2765
 #, fuzzy
 msgid "If there's no local ipfilter.dat found, allow usage of a system-wide ipfilter file."
 msgstr "Αν δεν βρεθεί τοπικό ipfilter.dat, να γίνει επιτρεπτή η χρήση του αρχείου ipfilter (φίλτρο διευθύνσεων) όλου του συστήματος."
 
-#: src/muuli_wdr.cpp:2778
+#: src/muuli_wdr.cpp:2782
 msgid "Enable Online-Signature"
 msgstr "Ενεργοποίηση συνδεδεμένων υπογραφών"
 
-#: src/muuli_wdr.cpp:2780
+#: src/muuli_wdr.cpp:2784
 msgid "Enables the writing of the OS file, which can be used by external apps to create signatures and the like."
 msgstr "Ενεργοποίηση γραψίματος του αρχείου συστήματος, το οποίο μπορεί να χρησιμοποιηθεί από εξωτερικές εφαρμογές για τη δημιουργία υπογραφών κτλ."
 
-#: src/muuli_wdr.cpp:2784
+#: src/muuli_wdr.cpp:2788
 msgid "Update Frequency (Secs):"
 msgstr "Συχνότητα ανανέωσης (δευτερόλεπτα):"
 
-#: src/muuli_wdr.cpp:2787
+#: src/muuli_wdr.cpp:2791
 msgid "Change the frequency (in seconds) of Online Signature updates."
 msgstr "Αλλαγή της συχνότητας (σε δευτερόλεπτα) για την ενημέρωση Συνδεδεμένων υπογραφών."
 
-#: src/muuli_wdr.cpp:2795
+#: src/muuli_wdr.cpp:2799
 msgid "Save online signature file in: "
 msgstr "Αποθύκευση του αρχείου συνδεδεμένων υπογραφών σε:"
 
-#: src/muuli_wdr.cpp:2801
+#: src/muuli_wdr.cpp:2805
 msgid "Click here to select the directory containing the the Online Signature files."
 msgstr "Κλικ εδώ για την επιλογή του καταλόγου που περιέχει τα αρχεία Συνδεδεμένων Υπογραφών."
 
-#: src/muuli_wdr.cpp:2834
+#: src/muuli_wdr.cpp:2838
 msgid "Show country flags for clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2835
+#: src/muuli_wdr.cpp:2839
 msgid "Render the country flag column in the transfers, queue and search views. Requires a valid MMDB GeoIP database (see below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2840
+#: src/muuli_wdr.cpp:2844
 #, fuzzy
 msgid "Database"
 msgstr "Ρυθμός ροής δεδομένων :"
 
-#: src/muuli_wdr.cpp:2856
+#: src/muuli_wdr.cpp:2860
 #, fuzzy
 msgid "Source:"
 msgstr "Αρ. πηγών"
 
-#: src/muuli_wdr.cpp:2859
+#: src/muuli_wdr.cpp:2863
 msgid "DB-IP (free, no account)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2860
+#: src/muuli_wdr.cpp:2864
 msgid "MaxMind GeoLite2 (free, account required)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2861
+#: src/muuli_wdr.cpp:2865
 msgid "Custom URL"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2864
+#: src/muuli_wdr.cpp:2868
 msgid "Choose which provider supplies the GeoIP MMDB database. DB-IP is the default - no account required. MaxMind requires a free account + license key. Use Custom URL to point at any other MMDB host (e.g. a local mirror)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2881
+#: src/muuli_wdr.cpp:2885
 msgid ""
 "No configuration required.\n"
 "\n"
@@ -4908,11 +4908,11 @@ msgid ""
 "License: Creative Commons BY 4.0 - https://creativecommons.org/licenses/by/4.0/"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2894
+#: src/muuli_wdr.cpp:2898
 msgid "License key:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2900
+#: src/muuli_wdr.cpp:2904
 msgid ""
 "Sign up for a free MaxMind account, then generate a License Key:\n"
 "https://www.maxmind.com/en/geolite2/signup\n"
@@ -4922,232 +4922,232 @@ msgid ""
 "Requires attribution and account registration; refresh at least every 30 days."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2915
+#: src/muuli_wdr.cpp:2919
 #, fuzzy
 msgid "Download URL:"
 msgstr "Μεταφόρτωση"
 
-#: src/muuli_wdr.cpp:2921
+#: src/muuli_wdr.cpp:2925
 msgid ""
 "Must point to an .mmdb file or a .gz / .tar.gz containing one.\n"
 "URL may include credentials (https://user:pass@host/...).\n"
 "License and attribution terms are set by the upstream URL - you are responsible."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2934
+#: src/muuli_wdr.cpp:2938
 msgid "Download the GeoIP database from the selected source."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2936
+#: src/muuli_wdr.cpp:2940
 #, fuzzy
 msgid "Auto-update on startup"
 msgstr "Αυτόματη ανανέωση του ipfilter κατά την εκκίνηση"
 
-#: src/muuli_wdr.cpp:2937
+#: src/muuli_wdr.cpp:2941
 msgid "Re-download the GeoIP database from the selected source every time aMule starts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2960
+#: src/muuli_wdr.cpp:2964
 msgid "Filter incoming messages (except current chat):"
 msgstr "Φιλτράρισμα εισερχομένων μηνυμάτων (εκτός από την τρέχουσα συνομιλία):"
 
-#: src/muuli_wdr.cpp:2962
+#: src/muuli_wdr.cpp:2966
 msgid "Filter all messages"
 msgstr "Διήθηση όλων των μηνυμάτων"
 
-#: src/muuli_wdr.cpp:2964
+#: src/muuli_wdr.cpp:2968
 msgid "Filter messages from people not on your friend list"
 msgstr "Διήθηση των μηνυμάτων από μέλη εκτός της λίστας φίλων"
 
-#: src/muuli_wdr.cpp:2966
+#: src/muuli_wdr.cpp:2970
 msgid "Filter messages from unknown clients"
 msgstr "Διήθηση μηνυμάτων από άγνωστους πελάτες"
 
-#: src/muuli_wdr.cpp:2968
+#: src/muuli_wdr.cpp:2972
 msgid "Filter messages containing (use ',' as separator):"
 msgstr "Διήθηση των μηνυμάτων που περιέχουν (χρήση ',' ως διαχωριστικού):"
 
-#: src/muuli_wdr.cpp:2971 src/muuli_wdr.cpp:2982
+#: src/muuli_wdr.cpp:2975 src/muuli_wdr.cpp:2986
 msgid "add here the words amule should filter and block messages including it"
 msgstr "προσθήκη σε αυτό το σημείο των λέξεων που το aMule πρέπει να φιλτράρει και μπλοκάρισμα μηνυμάτων που το περιέχουν"
 
-#: src/muuli_wdr.cpp:2973
+#: src/muuli_wdr.cpp:2977
 msgid "Show received messages in the log"
 msgstr "Εμφάνιση των ληφθέντων μηνυμάτων στο αρχείο καταγραφής"
 
-#: src/muuli_wdr.cpp:2976
+#: src/muuli_wdr.cpp:2980
 msgid "Comments"
 msgstr "Σχόλια"
 
-#: src/muuli_wdr.cpp:2979
+#: src/muuli_wdr.cpp:2983
 msgid "Filter comments containing (use ',' as separator):"
 msgstr "Φιλτράρισμα σχολίων που περιέχουν (χρησιμοποίηση ',' ως διαχωριστή):"
 
-#: src/muuli_wdr.cpp:3004
+#: src/muuli_wdr.cpp:3008
 msgid "Enable Proxy"
 msgstr "Ενεργοποίηση διακομιστή μεσολάβησης"
 
-#: src/muuli_wdr.cpp:3005
+#: src/muuli_wdr.cpp:3009
 msgid "Enable/disable proxy support"
 msgstr "Ενεργοποίηση/Απενεργοποίηση υποστήριξης διακομιστή μεσολάβησης"
 
-#: src/muuli_wdr.cpp:3008
+#: src/muuli_wdr.cpp:3012
 msgid "Proxy type:"
 msgstr "Τύπος διαμεσολάβησης"
 
-#: src/muuli_wdr.cpp:3019
+#: src/muuli_wdr.cpp:3023
 msgid "Proxy host:"
 msgstr "Διεύθυνση διακομιστή μεσολάβησης:"
 
-#: src/muuli_wdr.cpp:3022
+#: src/muuli_wdr.cpp:3026
 msgid "The proxy host name"
 msgstr "Όνομα του διακομιστή μεσολάβησης"
 
-#: src/muuli_wdr.cpp:3024
+#: src/muuli_wdr.cpp:3028
 msgid "Proxy port:"
 msgstr "Θύρα διακομιστή μεσολάβησης:"
 
-#: src/muuli_wdr.cpp:3027
+#: src/muuli_wdr.cpp:3031
 msgid "The proxy port"
 msgstr "Η θύρα διακομιστή μεσολάβησης"
 
-#: src/muuli_wdr.cpp:3029
+#: src/muuli_wdr.cpp:3033
 msgid "Enable authentication"
 msgstr "Ενεργοποίηση πιστοποίησης"
 
-#: src/muuli_wdr.cpp:3030
+#: src/muuli_wdr.cpp:3034
 msgid "Enable/disable username/password authentication"
 msgstr "Ενεργοποίηση/Απενεργοποίηση πιστοποίησης ονόματος χρήστη/κωδικού"
 
-#: src/muuli_wdr.cpp:3033
+#: src/muuli_wdr.cpp:3037
 msgid "Username: "
 msgstr "Όνομα χρήστη:"
 
-#: src/muuli_wdr.cpp:3036
+#: src/muuli_wdr.cpp:3040
 msgid "The username to use to connect to the proxy"
 msgstr "Το όνομα χρήστη για τη σύνδεση με τον μεσολαβητή"
 
-#: src/muuli_wdr.cpp:3038
+#: src/muuli_wdr.cpp:3042
 msgid "Password:"
 msgstr "Κωδικός:"
 
-#: src/muuli_wdr.cpp:3041
+#: src/muuli_wdr.cpp:3045
 msgid "The password to use to connect to the proxy"
 msgstr "Ο κωδικός που χρειάζεται για τη σύνδεση με τον μεσολαβητή"
 
-#: src/muuli_wdr.cpp:3060
+#: src/muuli_wdr.cpp:3064
 msgid "Connect to:"
 msgstr "Σύνδεση με:"
 
-#: src/muuli_wdr.cpp:3069
+#: src/muuli_wdr.cpp:3073
 msgid "Login to remote amule"
 msgstr "Σύνδεση σε απομακρυσμένο amule"
 
-#: src/muuli_wdr.cpp:3074
+#: src/muuli_wdr.cpp:3078
 msgid "User name"
 msgstr "Όνομα χρήστη"
 
-#: src/muuli_wdr.cpp:3085
+#: src/muuli_wdr.cpp:3089
 msgid "Remember those settings"
 msgstr "Απομνημόνευση αυτών των ρυθμίσεων"
 
-#: src/muuli_wdr.cpp:3088
+#: src/muuli_wdr.cpp:3092
 #, fuzzy
 msgid "Force ZLIB compression"
 msgstr "Χρήση συμπίεσης τύπου gzip"
 
-#: src/muuli_wdr.cpp:3112
+#: src/muuli_wdr.cpp:3116
 msgid "Enable Verbose Debug-Logging."
 msgstr "Ενεργοποίηση λεπτομερούς καταγραφής για έλεγχο σφαλμάτων"
 
-#: src/muuli_wdr.cpp:3114
+#: src/muuli_wdr.cpp:3118
 #, fuzzy
 msgid "Only to Logfile"
 msgstr "&Άνοιγμα αρχείου"
 
-#: src/muuli_wdr.cpp:3116
+#: src/muuli_wdr.cpp:3120
 msgid "Message Categories:"
 msgstr "Κατηγορίες μηνυμάτων:"
 
-#: src/muuli_wdr.cpp:3140 src/PartFileConvertDlg.cpp:160
+#: src/muuli_wdr.cpp:3144 src/PartFileConvertDlg.cpp:160
 msgid "Waiting..."
 msgstr "Αναμονή..."
 
-#: src/muuli_wdr.cpp:3160
+#: src/muuli_wdr.cpp:3164
 msgid "Add imports"
 msgstr "Προσθήκη εισακτέων"
 
-#: src/muuli_wdr.cpp:3163
+#: src/muuli_wdr.cpp:3167
 msgid "Retry selected"
 msgstr "Επαναπροσπάθεια των επιλεγμένων"
 
-#: src/muuli_wdr.cpp:3165
+#: src/muuli_wdr.cpp:3169
 msgid "Remove selected"
 msgstr "Αφαίρεση των επιλεγμένων"
 
-#: src/muuli_wdr.cpp:3228
+#: src/muuli_wdr.cpp:3232
 msgid "Event Types"
 msgstr "Τύποι συμβάντων"
 
-#: src/muuli_wdr.cpp:3247
+#: src/muuli_wdr.cpp:3251
 msgid "Statistics and queued clients for selected file(s) : Session / All time"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3271
+#: src/muuli_wdr.cpp:3275
 #, fuzzy
 msgid "Active Uploads"
 msgstr "Ενεργά ανεβάσματα :"
 
-#: src/muuli_wdr.cpp:3285
+#: src/muuli_wdr.cpp:3289
 msgid "Percent of total files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3337
+#: src/muuli_wdr.cpp:3341
 #, fuzzy
 msgid "Show Clients for"
 msgstr "Δείξε τους πελάτες"
 
-#: src/muuli_wdr.cpp:3339
+#: src/muuli_wdr.cpp:3343
 #, fuzzy
 msgid "All files"
 msgstr "Κρύψιμο των κοινόχρηστων αρχείων "
 
-#: src/muuli_wdr.cpp:3342
+#: src/muuli_wdr.cpp:3346
 #, fuzzy
 msgid "Selected files"
 msgstr "Επιλογή φίλτρου εμφάνισης"
 
-#: src/muuli_wdr.cpp:3345
+#: src/muuli_wdr.cpp:3349
 #, fuzzy
 msgid "Active uploads only"
 msgstr "Ενεργά ανεβάσματα"
 
-#: src/muuli_wdr.cpp:3352
+#: src/muuli_wdr.cpp:3356
 #, fuzzy
 msgid "Reload:"
 msgstr "Επαναφόρτωση λίστας"
 
-#: src/muuli_wdr.cpp:3356
+#: src/muuli_wdr.cpp:3360
 msgid "Reload your shared files"
 msgstr "Επαναφόρτωση των κοινόχρηστων αρχείων"
 
-#: src/muuli_wdr.cpp:3419
+#: src/muuli_wdr.cpp:3423
 msgid "Send"
 msgstr "Αποστολή"
 
-#: src/muuli_wdr.cpp:3420
+#: src/muuli_wdr.cpp:3424
 msgid "Sends the specified message."
 msgstr "Αποστολή του προσδιορισμένου μηνύματος."
 
-#: src/muuli_wdr.cpp:3424
+#: src/muuli_wdr.cpp:3428
 msgid "Close this chat-session."
 msgstr "Κλείσιμο της συνομιλίας."
 
-#: src/muuli_wdr.cpp:3447
+#: src/muuli_wdr.cpp:3451
 msgid "Connect to any server and/or Kad"
 msgstr "Σύνδεση σε κάθε διακομιστή ή/και Kad"
 
-#: src/muuli_wdr.cpp:3453 src/SharedFilesCtrl.cpp:142 src/Statistics.cpp:941
+#: src/muuli_wdr.cpp:3457 src/SharedFilesCtrl.cpp:142 src/Statistics.cpp:941
 msgid "Shared Files"
 msgstr "Κοινόχρηστα αρχεία"
 
@@ -5784,35 +5784,35 @@ msgstr ""
 "Το aMule θα τρέχει μια χαρά χωρίς την αλλαγή καμιάς από αυτές\n"
 " τις ρυθμίσεις."
 
-#: src/PrefsUnifiedDlg.cpp:647
+#: src/PrefsUnifiedDlg.cpp:656
 #, c-format
 msgid "Failed to connect Cfg to widget with the ID %d and key %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:695
+#: src/PrefsUnifiedDlg.cpp:704
 #, c-format
 msgid "Failed to transfer data from Cfg to Widget with the ID %d and key %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:801
+#: src/PrefsUnifiedDlg.cpp:810
 msgid "The type of proxy you are connecting to"
 msgstr "Ο τύπος του διακομιστή μεσολάβησης στον οποίον συνδέεστε"
 
-#: src/PrefsUnifiedDlg.cpp:1020
+#: src/PrefsUnifiedDlg.cpp:1029
 #, c-format
 msgid "Failed to transfer data from Widget to Cfg with the ID %d and key %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1103
+#: src/PrefsUnifiedDlg.cpp:1112
 #, fuzzy
 msgid "No password set."
 msgstr "Έλεγχος κωδικού\n"
 
-#: src/PrefsUnifiedDlg.cpp:1132
+#: src/PrefsUnifiedDlg.cpp:1141
 msgid "Guest access needs a password. Type one in the guest password field, or untick Enable guest access."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1144
+#: src/PrefsUnifiedDlg.cpp:1153
 msgid ""
 "aMule must be restarted to enable these changes:\n"
 "\n"
@@ -5820,45 +5820,45 @@ msgstr ""
 "το aMule πρέπει να επανεκινηθεί για να ενεργοποιηθούν αυτές οι αλλαγές: \n"
 "\n"
 
-#: src/PrefsUnifiedDlg.cpp:1151
+#: src/PrefsUnifiedDlg.cpp:1160
 msgid "- TCP port changed.\n"
 msgstr "- Άλλαξε η θύρα TCP.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1156
+#: src/PrefsUnifiedDlg.cpp:1165
 msgid "- UDP port changed.\n"
 msgstr "- Άλλαξε η θύρα UDP.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1161
+#: src/PrefsUnifiedDlg.cpp:1170
 #, fuzzy
 msgid "- Network interface binding changed.\n"
 msgstr "Η εξωτερική σύνδεση έκλεισε."
 
-#: src/PrefsUnifiedDlg.cpp:1166
+#: src/PrefsUnifiedDlg.cpp:1175
 #, fuzzy
 msgid "- External connect port changed.\n"
 msgstr "Η εξωτερική σύνδεση έκλεισε."
 
-#: src/PrefsUnifiedDlg.cpp:1170
+#: src/PrefsUnifiedDlg.cpp:1179
 #, fuzzy
 msgid "- External connect acceptance changed.\n"
 msgstr "Νέα εξωτερική σύνδεση έγινε δεκτή"
 
-#: src/PrefsUnifiedDlg.cpp:1174
+#: src/PrefsUnifiedDlg.cpp:1183
 #, fuzzy
 msgid "- External connect interface changed.\n"
 msgstr "Η εξωτερική σύνδεση έκλεισε."
 
-#: src/PrefsUnifiedDlg.cpp:1178
+#: src/PrefsUnifiedDlg.cpp:1187
 #, fuzzy
 msgid "- Protocol obfuscation support changed.\n"
 msgstr "Συσκότιση πρωτοκόλλου"
 
-#: src/PrefsUnifiedDlg.cpp:1193
+#: src/PrefsUnifiedDlg.cpp:1202
 #, fuzzy
 msgid "- amuleapi settings changed.\n"
 msgstr "- Η γλώσσα άλλαξε.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1202
+#: src/PrefsUnifiedDlg.cpp:1211
 msgid ""
 "Your Auto-update server list is empty.\n"
 "'Auto-update server list at startup' will be disabled."
@@ -5866,7 +5866,7 @@ msgstr ""
 "Η λίστα αυτόματης ενημέρωσης διακομιστών είναι κενή.\n"
 "Θα απενεργοποιηθεί η επιλογή: 'Αυτόματη ενημέρωση λίστας διακομιστών κατά την εκκίνηση' "
 
-#: src/PrefsUnifiedDlg.cpp:1213
+#: src/PrefsUnifiedDlg.cpp:1222
 msgid ""
 "You have enabled external connections but have not specified a password.\n"
 "External connections cannot be enabled unless a valid password is specified."
@@ -5874,34 +5874,34 @@ msgstr ""
 "Έχετε ενεργοποιήσει τις εξωτερικές συνδέσεις αλλά δεν έχετε προσδιορίσει κωδικό.\n"
 "Οι εξωτερικές συνδέσεις δεν μπορούν να ενεργοποιηθούν μέχρι να προσδιοριστεί ένας έγκυρος κωδικός."
 
-#: src/PrefsUnifiedDlg.cpp:1246
+#: src/PrefsUnifiedDlg.cpp:1255
 #, c-format
 msgid "The amuleapi password could not be saved: %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1276
+#: src/PrefsUnifiedDlg.cpp:1285
 msgid "- Language changed.\n"
 msgstr "- Η γλώσσα άλλαξε.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1281
+#: src/PrefsUnifiedDlg.cpp:1290
 msgid "- Temp folder changed.\n"
 msgstr "- Ο προσωρινός κατάλογος άλλαξε.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1286
+#: src/PrefsUnifiedDlg.cpp:1295
 #, fuzzy
 msgid "- ED2K network enabled.\n"
 msgstr "Όλα τα δίκτυα είναι απενεργοποιημένα."
 
-#: src/PrefsUnifiedDlg.cpp:1319
+#: src/PrefsUnifiedDlg.cpp:1328
 msgid "The shared-file exclusion pattern is not a valid regular expression. The filter has been left disabled."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1321 src/PrefsUnifiedDlg.cpp:1921
+#: src/PrefsUnifiedDlg.cpp:1330 src/PrefsUnifiedDlg.cpp:1930
 #, fuzzy
 msgid "Invalid regular expression"
 msgstr "Άκυρη έκδοση πρωτοκόλλου."
 
-#: src/PrefsUnifiedDlg.cpp:1398
+#: src/PrefsUnifiedDlg.cpp:1407
 msgid ""
 "Both eD2k and Kad network are disabled.\n"
 "You won't be able to connect until you enable at least one of them."
@@ -5909,7 +5909,7 @@ msgstr ""
 "Και το δίκτυο eD2k και το Kad είναι απενεργοποιημένα.\n"
 "Δεν θα μπορέσετε να συνδεθείτε μέχρι να ενεργοποιήσετε τουλάχιστον ένα από αυτα."
 
-#: src/PrefsUnifiedDlg.cpp:1403
+#: src/PrefsUnifiedDlg.cpp:1412
 msgid ""
 "Kad will not start if your UDP port is disabled.\n"
 "Enable UDP port or disable Kad."
@@ -5917,7 +5917,7 @@ msgstr ""
 "Το δίκτυο Kad δεν θα ξεκινήσει αν η θύρα UDP είναι απενεργοποιημένη.\n"
 "Ενεργοποιήστε τη θύρα UDP ή απενεργοποιήστε το Kad."
 
-#: src/PrefsUnifiedDlg.cpp:1459
+#: src/PrefsUnifiedDlg.cpp:1468
 msgid ""
 "\n"
 "You MUST restart aMule now.\n"
@@ -5927,69 +5927,69 @@ msgstr ""
 "Τώρα πρέπει να επανεκινήσετε το aMule.\n"
 "Διαφορετικά μην διαμαρτυρηθείτε αν συμβεί κάτι κακό.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1524
+#: src/PrefsUnifiedDlg.cpp:1533
 msgid "Could not register aMule for autostart at login. The autostart store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1526
+#: src/PrefsUnifiedDlg.cpp:1535
 msgid "Could not remove the autostart-at-login entry."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1527
+#: src/PrefsUnifiedDlg.cpp:1536
 #, fuzzy
 msgid "Autostart"
 msgstr "Η αυτόματη ανανέωση ξεκίνησε"
 
-#: src/PrefsUnifiedDlg.cpp:1542
+#: src/PrefsUnifiedDlg.cpp:1551
 msgid "Register file type"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1542
+#: src/PrefsUnifiedDlg.cpp:1551
 msgid "Register URL handler"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1550
+#: src/PrefsUnifiedDlg.cpp:1559
 #, c-format
 msgid "aMule only handles eD2k-compatible magnets. If you replace the current magnet handler (%s), BitTorrent magnet links will stop working - aMule cannot download BitTorrent content. Continue?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1555
+#: src/PrefsUnifiedDlg.cpp:1564
 #, c-format
 msgid "Another application currently opens .emulecollection files (%s). Replace it with aMule?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1560
+#: src/PrefsUnifiedDlg.cpp:1569
 #, c-format
 msgid "Another application is currently the default handler for these links (%s). Replace it with aMule?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1585
+#: src/PrefsUnifiedDlg.cpp:1594
 msgid "Could not register aMule for .emulecollection files. The registration store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1587
+#: src/PrefsUnifiedDlg.cpp:1596
 #, fuzzy
 msgid "Could not remove the file type registration."
 msgstr "Κατάλογος για τα προσωρινά αρχεία"
 
-#: src/PrefsUnifiedDlg.cpp:1589
+#: src/PrefsUnifiedDlg.cpp:1598
 msgid "Could not register aMule as the URL handler. The registration store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1591
+#: src/PrefsUnifiedDlg.cpp:1600
 msgid "Could not remove the URL handler registration."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1661 src/PrefsUnifiedDlg.cpp:1688
+#: src/PrefsUnifiedDlg.cpp:1670 src/PrefsUnifiedDlg.cpp:1697
 #, fuzzy
 msgid "The web server and aMule API require external connections to be enabled."
 msgstr "Νέα εξωτερική σύνδεση έγινε δεκτή"
 
-#: src/PrefsUnifiedDlg.cpp:1671
+#: src/PrefsUnifiedDlg.cpp:1680
 msgid "The aMule web server is deprecated. Consider running the aMule API instead."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1735
+#: src/PrefsUnifiedDlg.cpp:1744
 msgid ""
 "Your Auto-update servers list is in blank.\n"
 "Please fill in at least one URL to point to a valid server.met file.\n"
@@ -5999,66 +5999,66 @@ msgstr ""
 "Παρακαλώ βάλτε τουλάχιστον μία URL που να δείχνει σε ένα έγκυρο αρχείο sever.met.\n"
 "Πατήστε το διπλανό κουμπί \"List\" για να βάλετε ένα URL."
 
-#: src/PrefsUnifiedDlg.cpp:1876
+#: src/PrefsUnifiedDlg.cpp:1885
 msgid "Temporary files"
 msgstr "Προσωρινά αρχεία"
 
-#: src/PrefsUnifiedDlg.cpp:1881
+#: src/PrefsUnifiedDlg.cpp:1890
 msgid "Incoming files"
 msgstr "Εισερχόμενα αρχεία"
 
-#: src/PrefsUnifiedDlg.cpp:1886
+#: src/PrefsUnifiedDlg.cpp:1895
 msgid "Online Signatures"
 msgstr "Συνδεδεμένες υπογραφές"
 
-#: src/PrefsUnifiedDlg.cpp:1899
+#: src/PrefsUnifiedDlg.cpp:1908
 #, c-format
 msgid "Choose a folder for %s"
 msgstr "Επιλέξτε κατάλογο για %s"
 
-#: src/PrefsUnifiedDlg.cpp:1923
+#: src/PrefsUnifiedDlg.cpp:1932
 #, fuzzy, c-format
 msgid "Would exclude %u of %u shared file"
 msgid_plural "Would exclude %u of %u shared files"
 msgstr[0] "Βρέθηκε %i γνωστό κοινόχρηστο αρχείο"
 msgstr[1] "Βρέθηκαν %i γνωστά κοινόχρηστα αρχεία"
 
-#: src/PrefsUnifiedDlg.cpp:1940
+#: src/PrefsUnifiedDlg.cpp:1949
 msgid "Browse for videoplayer"
 msgstr "Αναζήτηση του προγράμματος για βίντεο"
 
-#: src/PrefsUnifiedDlg.cpp:1944
+#: src/PrefsUnifiedDlg.cpp:1953
 msgid "Select browser"
 msgstr "Επιλογή περιηγητή"
 
-#: src/PrefsUnifiedDlg.cpp:1948
+#: src/PrefsUnifiedDlg.cpp:1957
 #, fuzzy
 msgid "Select ffprobe binary"
 msgstr "Επιλογή περιηγητή"
 
-#: src/PrefsUnifiedDlg.cpp:1954
+#: src/PrefsUnifiedDlg.cpp:1963
 #, c-format
 msgid "Executable%s"
 msgstr "Εκτελέσιμο%s"
 
-#: src/PrefsUnifiedDlg.cpp:1988
+#: src/PrefsUnifiedDlg.cpp:1997
 msgid "ffprobe not found on PATH or in the standard install locations. Install ffmpeg (which ships ffprobe) or use Browse to pick a binary manually."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2000
+#: src/PrefsUnifiedDlg.cpp:2009
 msgid "Reset the settings on this page to their default values?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2001
+#: src/PrefsUnifiedDlg.cpp:2010
 #, fuzzy
 msgid "Reset to defaults"
 msgstr "Εργοστασιακές ρυθμίσεις"
 
-#: src/PrefsUnifiedDlg.cpp:2028
+#: src/PrefsUnifiedDlg.cpp:2037
 msgid "Edit server list"
 msgstr "Επεξεργασία λίστας διακομιστών"
 
-#: src/PrefsUnifiedDlg.cpp:2029
+#: src/PrefsUnifiedDlg.cpp:2038
 msgid ""
 "Add here URL's to download server.met files.\n"
 "Only one url on each line."
@@ -6066,155 +6066,155 @@ msgstr ""
 "Βάλτε εδώ τη διεύθυνση για το κατέβασμα των αρχείων server.met. \n"
 "Μία διεύθυνση σε κάθε γραμμή"
 
-#: src/PrefsUnifiedDlg.cpp:2084
+#: src/PrefsUnifiedDlg.cpp:2093
 msgid "IP2Country update failed"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2229 src/PrefsUnifiedDlg.cpp:2260
+#: src/PrefsUnifiedDlg.cpp:2238 src/PrefsUnifiedDlg.cpp:2269
 msgid "Data by MaxMind GeoLite2"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2231 src/PrefsUnifiedDlg.cpp:2262
+#: src/PrefsUnifiedDlg.cpp:2240 src/PrefsUnifiedDlg.cpp:2271
 #, fuzzy
 msgid "Custom source"
 msgstr "Ολοκλήρωση πηγών"
 
-#: src/PrefsUnifiedDlg.cpp:2233 src/PrefsUnifiedDlg.cpp:2264
+#: src/PrefsUnifiedDlg.cpp:2242 src/PrefsUnifiedDlg.cpp:2273
 msgid "Data by DB-IP.com"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2284
+#: src/PrefsUnifiedDlg.cpp:2293
 #, fuzzy, c-format
 msgid "Status: Loaded%s"
 msgstr "Κατάσταση:"
 
-#: src/PrefsUnifiedDlg.cpp:2286
+#: src/PrefsUnifiedDlg.cpp:2295
 #, fuzzy, c-format
 msgid "Status: Loaded%s - %s"
 msgstr "Κατάσταση:"
 
-#: src/PrefsUnifiedDlg.cpp:2290
+#: src/PrefsUnifiedDlg.cpp:2299
 msgid "Status: Failed to load - click 'Update now' to refresh."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2292
+#: src/PrefsUnifiedDlg.cpp:2301
 msgid "Status: Not found - click 'Update now' to download."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2350 src/PrefsUnifiedDlg.cpp:2374
+#: src/PrefsUnifiedDlg.cpp:2359 src/PrefsUnifiedDlg.cpp:2383
 #, c-format
 msgid "Update delay: %d second"
 msgid_plural "Update delay: %d seconds"
 msgstr[0] "Καθυστέρηση ενημέρωσης: %d δευτερόλεπτο"
 msgstr[1] "Καθυστέρηση ενημέρωσης: %d δευτερόλεπτα"
 
-#: src/PrefsUnifiedDlg.cpp:2358
+#: src/PrefsUnifiedDlg.cpp:2367
 #, c-format
 msgid "Time for average graph: %d minute"
 msgid_plural "Time for average graph: %d minutes"
 msgstr[0] "Χρόνος για μέσο γράφημα: %d λεπτό"
 msgstr[1] "Χρόνος για μέσο γράφημα: %d λεπτά"
 
-#: src/PrefsUnifiedDlg.cpp:2367
+#: src/PrefsUnifiedDlg.cpp:2376
 #, c-format
 msgid "Connections Graph Scale: %d"
 msgstr "Κλίμακα γραφήματος συνδέσεων: %d"
 
-#: src/PrefsUnifiedDlg.cpp:2382
+#: src/PrefsUnifiedDlg.cpp:2391
 #, c-format
 msgid "File Buffer Size: %d byte"
 msgid_plural "File Buffer Size: %d bytes"
 msgstr[0] "Μέγεθος χώρου ενδιάμεσης αποθήκευση αρχείου: %d byte"
 msgstr[1] "Μέγεθος χώρου ενδιάμεσης αποθήκευση αρχείου: %d byteς"
 
-#: src/PrefsUnifiedDlg.cpp:2392
+#: src/PrefsUnifiedDlg.cpp:2401
 #, c-format
 msgid "Upload Queue Size: %d client"
 msgid_plural "Upload Queue Size: %d clients"
 msgstr[0] "Μέγεθος λίστας αναμονής αποστελλόμενων: %d πελάτης"
 msgstr[1] "Μέγεθος λίστας αναμονής ανεβασμάτων: %d πελάτες"
 
-#: src/PrefsUnifiedDlg.cpp:2402
+#: src/PrefsUnifiedDlg.cpp:2411
 #, c-format
 msgid "Server connection refresh interval: %d minute"
 msgid_plural "Server connection refresh interval: %d minutes"
 msgstr[0] "Διάστημα ανανέωσης της σύνδεσης σε διακομιστή: %d λεπτό"
 msgstr[1] "Διάστημα ανανέωσης της σύνδεσης σε διακομιστή: %d λεπτά"
 
-#: src/PrefsUnifiedDlg.cpp:2407
+#: src/PrefsUnifiedDlg.cpp:2416
 msgid "Server connection refresh interval: Disabled"
 msgstr "Διάστημα ανανέωσης της σύνδεσης σε διακομιστή: Απενεργοποιημένο"
 
-#: src/PrefsUnifiedDlg.cpp:2451
+#: src/PrefsUnifiedDlg.cpp:2460
 #, fuzzy
 msgid "disabled"
 msgstr "απενεργοποίηση"
 
-#: src/PrefsUnifiedDlg.cpp:2477
+#: src/PrefsUnifiedDlg.cpp:2486
 #, fuzzy, c-format
 msgid "Execute command on '%s' event"
 msgstr "Εκτέλεση εντολής κατά το γεγονός `%s'"
 
-#: src/PrefsUnifiedDlg.cpp:2484
+#: src/PrefsUnifiedDlg.cpp:2493
 msgid "Enable command execution on core"
 msgstr "Ενεργοποίηση εκτέλεσης εντολών στον πυρήνα"
 
-#: src/PrefsUnifiedDlg.cpp:2496
+#: src/PrefsUnifiedDlg.cpp:2505
 msgid "Core command:"
 msgstr "Εντολή πυρήνα:"
 
-#: src/PrefsUnifiedDlg.cpp:2512
+#: src/PrefsUnifiedDlg.cpp:2521
 msgid "Enable command execution on GUI"
 msgstr "Ενεργοποίηση εκτέλεσης εντολών στο γραφικό περιβάλλον"
 
-#: src/PrefsUnifiedDlg.cpp:2524
+#: src/PrefsUnifiedDlg.cpp:2533
 msgid "GUI command:"
 msgstr "Εντολή γραφικού περιβάλλοντος:"
 
-#: src/PrefsUnifiedDlg.cpp:2540
+#: src/PrefsUnifiedDlg.cpp:2549
 msgid "The following variables will be replaced:"
 msgstr "Οι παρακάτω μεταβλητές θα αντικατασταθούν:"
 
-#: src/PrefsUnifiedDlg.cpp:2708
+#: src/PrefsUnifiedDlg.cpp:2717
 msgid ""
 "The following folders look like system or sensitive locations:\n"
 "\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2713
+#: src/PrefsUnifiedDlg.cpp:2722
 msgid "Sharing them recursively will publish every file underneath on the eD2k/Kad networks. Do you really want to do this?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2716
+#: src/PrefsUnifiedDlg.cpp:2725
 #, fuzzy
 msgid "Confirm shared folders"
 msgstr "Κοινόχρηστα αρχεία"
 
-#: src/PrefsUnifiedDlg.cpp:2744
+#: src/PrefsUnifiedDlg.cpp:2753
 #, fuzzy
 msgid "Reloading shared files..."
 msgstr "Επαναφόρτωση των κοινόχρηστων αρχείων"
 
-#: src/PrefsUnifiedDlg.cpp:2745
+#: src/PrefsUnifiedDlg.cpp:2754
 msgid "Scanning for subdirectories..."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2746
+#: src/PrefsUnifiedDlg.cpp:2755
 #, fuzzy
 msgid "Updating shared folders"
 msgstr "Κοινόχρηστα αρχεία"
 
-#: src/PrefsUnifiedDlg.cpp:2773
+#: src/PrefsUnifiedDlg.cpp:2782
 #, c-format
 msgid "Scanned %u directories..."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2823
+#: src/PrefsUnifiedDlg.cpp:2832
 #, fuzzy, c-format
 msgid "Reloading shared files: %u files scanned"
 msgstr "Επαναφορτώνει τη λίστα κοινοχρήστων αρχείων."
 
-#: src/PrefsUnifiedDlg.cpp:2873
+#: src/PrefsUnifiedDlg.cpp:2882
 #, fuzzy
 msgid "Shared folder"
 msgstr "Κοινόχρηστα αρχεία"
@@ -7930,12 +7930,12 @@ msgstr "Διαγραφή κατηγορίας"
 msgid "Hashset requested for unknown file: %s"
 msgstr "Σύνολο κατακερματισμού για άγνωστο αρχείο: %s"
 
-#: src/UploadQueue.cpp:618
+#: src/UploadQueue.cpp:627
 #, c-format
 msgid "Resuming uploads of file: %s"
 msgstr "Συνέχεια του ανεβάσματος του αρχείου: %s"
 
-#: src/UploadQueue.cpp:634
+#: src/UploadQueue.cpp:643
 #, c-format
 msgid "Suspending upload of file: %s"
 msgstr "Αναστολή ανεβάσματος του αρχείου: %s"

--- a/po/el.po
+++ b/po/el.po
@@ -9,8 +9,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-28 12:12+0200\n"
-"PO-Revision-Date: 2026-07-27 10:19+0000\n"
+"POT-Creation-Date: 2026-07-28 08:06+0200\n"
+"PO-Revision-Date: 2026-07-27 11:35+0000\n"
 "Last-Translator: Dimitris <dgalanak@yahoo.com>\n"
 "Language-Team: Greek\n"
 "Language: el\n"
@@ -144,7 +144,7 @@ msgstr ""
 msgid "Not now"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:422 src/amuleDlg.cpp:665
+#: src/AppImageIntegration.cpp:422 src/amuleDlg.cpp:600
 msgid "Don't ask again"
 msgstr ""
 
@@ -203,162 +203,162 @@ msgstr "Αποτυχία ανοίγματος %s (%s)"
 msgid "WARNING: You can't add yourself as a source for an eD2k link while having a lowid."
 msgstr "ΠΡΟΕΙΔΟΠΟΙΗΣΗ: Δεν μπορείτε να προσθέσετε τον εαυτό σας σαν πηγή για έναν σύνδεσμο eD2k ενώ έχετε χαμηλή προτεραιότητα."
 
-#: src/amule.cpp:301
+#: src/amule.cpp:300
 #, fuzzy
 msgid "Now, exiting main app..."
 msgstr ""
 "\n"
 "Όλα μια χαρά, έξοδος %s...\n"
 
-#: src/amule.cpp:331
+#: src/amule.cpp:330
 #, c-format
 msgid "Terminating amuleweb instance with pid '%d' ... "
 msgstr ""
 
-#: src/amule.cpp:335
+#: src/amule.cpp:334
 #, c-format
 msgid "Killing amuleweb instance with pid '%d' ... "
 msgstr ""
 
-#: src/amule.cpp:337 src/amule.cpp:350 src/ClientRef.cpp:180
-#: src/SearchDlg.cpp:1041 src/ServerListCtrl.cpp:98
+#: src/amule.cpp:336 src/amule.cpp:349 src/ClientRef.cpp:180
+#: src/SearchDlg.cpp:880 src/ServerListCtrl.cpp:98
 msgid "Failed"
 msgstr "Απέτυχε"
 
-#: src/amule.cpp:344
+#: src/amule.cpp:343
 #, c-format
 msgid "Terminating amuleapi instance with pid '%d' ... "
 msgstr ""
 
-#: src/amule.cpp:348
+#: src/amule.cpp:347
 #, c-format
 msgid "Killing amuleapi instance with pid '%d' ... "
 msgstr ""
 
-#: src/amule.cpp:356
+#: src/amule.cpp:355
 msgid "aMule OnExit: Terminating core."
 msgstr ""
 
-#: src/amule.cpp:467
+#: src/amule.cpp:466
 #, fuzzy
 msgid "aMule shutdown completed."
 msgstr "Το κατέβασμα ολοκληρώθηκε"
 
-#: src/amule.cpp:471
+#: src/amule.cpp:470
 msgid "Memory debug results for aMule exit:"
 msgstr ""
 
-#: src/amule.cpp:652
+#: src/amule.cpp:651
 #, c-format
 msgid "Binding aMule's peer-to-peer traffic to interface: %s (HTTP updates use the default route)"
 msgstr ""
 
-#: src/amule.cpp:656
+#: src/amule.cpp:655
 #, c-format
 msgid "Binding all network traffic to interface: %s"
 msgstr ""
 
-#: src/amule.cpp:660
+#: src/amule.cpp:659
 #, c-format
 msgid "WARNING: configured network interface '%s' was not found - traffic is NOT bound to it and may leave via the default route. Check the interface name in Preferences."
 msgstr ""
 
-#: src/amule.cpp:666
+#: src/amule.cpp:665
 #, c-format
 msgid "WARNING: binding to network interface '%s' requires elevated privileges and was NOT applied - traffic may leave via the default route. Grant the capability (e.g. 'sudo setcap cap_net_raw+ep' on the aMule binary) or run with sufficient privileges."
 msgstr ""
 
-#: src/amule.cpp:674
+#: src/amule.cpp:673
 #, c-format
 msgid "WARNING: could not bind to network interface '%s' - traffic may leave via the default route."
 msgstr ""
 
-#: src/amule.cpp:733
+#: src/amule.cpp:732
 msgid "Your locale has been changed to System Default due to a configuration change. Sorry."
 msgstr "Οι τοπικές ρυθμίσεις άλλαξαν στις προεπιλεγμένες του συστήματος λόγο μιας αλλαγής παραμέτρων. Sorry!"
 
-#: src/amule.cpp:735 src/amule.cpp:1589 src/CatDialog.cpp:128
+#: src/amule.cpp:734 src/amule.cpp:1581 src/CatDialog.cpp:128
 #: src/CatDialog.cpp:136 src/CatDialog.cpp:149 src/ServerList.cpp:366
 #: src/ServerListCtrl.cpp:152
 msgid "Info"
 msgstr "Πληροφορίες"
 
-#: src/amule.cpp:742
+#: src/amule.cpp:741
 #, fuzzy
 msgid ""
 "\n"
 "EC configuration"
 msgstr "Έξοδος επιβεβαίωσης"
 
-#: src/amule.cpp:745
+#: src/amule.cpp:744
 #, fuzzy
 msgid "Password set and external connections enabled."
 msgstr "Νέα εξωτερική σύνδεση έγινε δεκτή"
 
-#: src/amule.cpp:755 src/KadDlg.cpp:176 src/KadDlg.cpp:185
-#: src/PrefsUnifiedDlg.cpp:1461 src/SharedFilesCtrl.cpp:476
+#: src/amule.cpp:754 src/KadDlg.cpp:176 src/KadDlg.cpp:185
+#: src/PrefsUnifiedDlg.cpp:1387 src/SharedFilesCtrl.cpp:476
 msgid "WARNING"
 msgstr "ΠΡΟΕΙΔΟΠΟΙΗΣΗ"
 
-#: src/amule.cpp:992
+#: src/amule.cpp:991
 #, fuzzy
 msgid "Network bootstrap"
 msgstr "Δίκτυα"
 
-#: src/amule.cpp:997
+#: src/amule.cpp:996
 msgid ""
 "aMule has detected missing network bootstrap files.\n"
 "Select which ones to download:"
 msgstr ""
 
-#: src/amule.cpp:1006 src/FirstRunWizard.cpp:411
+#: src/amule.cpp:1005 src/FirstRunWizard.cpp:411
 #, fuzzy
 msgid "eD2k server list (server.met)"
 msgstr "βρέθηκε %i διακομιστής στο server.met"
 
-#: src/amule.cpp:1013 src/FirstRunWizard.cpp:416
+#: src/amule.cpp:1012 src/FirstRunWizard.cpp:416
 msgid "Kad bootstrap nodes (nodes.dat)"
 msgstr ""
 
-#: src/amule.cpp:1103
+#: src/amule.cpp:1102
 #, c-format
 msgid "web server running on pid %d"
 msgstr "διακομιστής ιστού τρέχει με αριθμό διεργασίας %d"
 
-#: src/amule.cpp:1116
+#: src/amule.cpp:1115
 #, fuzzy
 msgid "You requested to run web server on startup, but the amuleweb binary cannot be run. Please install the package containing aMule web server, or build aMule from source with -DBUILD_WEBSERVER=YES and install it."
 msgstr "Ζητήσατε να τρέχετε τον διακομιστή ιστού κατά την εκκίνηση, αλλά το εκτελέσιμο αρχείο amuleweb δεν βρέθηκε. Παρακαλώ εγκαταστήστε το πακέτο που περιέχει τον διακομιστή ιστού του aMule, ή μεταφράστε το aMule χρησιμοποιώντας την παράμετρο --enable-webserver"
 
-#: src/amule.cpp:1121 src/amule.cpp:1185 src/amule.cpp:1299 src/amule.cpp:1601
+#: src/amule.cpp:1120 src/amule.cpp:1177 src/amule.cpp:1291 src/amule.cpp:1593
 #: src/amule-remote-gui.cpp:603 src/amule-remote-gui.cpp:671
 #: src/amule-remote-gui.cpp:709 src/amule-remote-gui.cpp:1282
 #: src/amule-remote-gui.cpp:1345 src/amule-remote-gui.cpp:1372
-#: src/DownloadQueue.cpp:1481 src/PrefsUnifiedDlg.cpp:1247
+#: src/DownloadQueue.cpp:1481
 msgid "ERROR"
 msgstr "ΣΦΑΛΜΑ"
 
-#: src/amule.cpp:1174
+#: src/amule.cpp:1166
 #, fuzzy, c-format
 msgid "amuleapi running on pid %d"
 msgstr "διακομιστής ιστού τρέχει με αριθμό διεργασίας %d"
 
-#: src/amule.cpp:1180
+#: src/amule.cpp:1172
 #, fuzzy
 msgid "You requested to run amuleapi on startup, but the amuleapi binary cannot be run. Please install the package containing aMule's REST API server, or build aMule from source with -DBUILD_AMULEAPI=YES and install it."
 msgstr "Ζητήσατε να τρέχετε τον διακομιστή ιστού κατά την εκκίνηση, αλλά το εκτελέσιμο αρχείο amuleweb δεν βρέθηκε. Παρακαλώ εγκαταστήστε το πακέτο που περιέχει τον διακομιστή ιστού του aMule, ή μεταφράστε το aMule χρησιμοποιώντας την παράμετρο --enable-webserver"
 
-#: src/amule.cpp:1267
+#: src/amule.cpp:1259
 #, c-format
 msgid "Could not bind ports to the specified address: %s"
 msgstr "Δεν μπόρεσε να προσδέσει τις θύρες στην προσδιορισμένη διεύθυνση: %s"
 
-#: src/amule.cpp:1291
+#: src/amule.cpp:1283
 #, c-format
 msgid "Port %u is not available. You will be LOWID\n"
 msgstr "Η θύρα %u δεν είναι διαθέσιμη. Θα σας αποδωθεί LOWID (χαμηλή προτεραιότητα)\n"
 
-#: src/amule.cpp:1296
+#: src/amule.cpp:1288
 #, c-format
 msgid ""
 "Port %u is not available!\n"
@@ -373,48 +373,48 @@ msgstr ""
 "\n"
 "Ελέξτε το δίκτυο σας για να βεβαιωθήτε ότι η θύρα είναι ανοιχτή για είσοδο και έξοδο."
 
-#: src/amule.cpp:1393
+#: src/amule.cpp:1385
 msgid "Failed to create OnlineSig File"
 msgstr "Αποτυχία δημιουργίας αρχείου Συνδεδεμένων Υπογραφών"
 
-#: src/amule.cpp:1401
+#: src/amule.cpp:1393
 msgid "Failed to create aMule OnlineSig File"
 msgstr "Αποτυχία δημιουργίας αρχείου Συνδεδεμένων Υπογραφών του aMule"
 
-#: src/amule.cpp:1564
+#: src/amule.cpp:1556
 msgid "The selected locale seems not to be installed on your box. (Note: I'll try to set it anyway)"
 msgstr "Οι επιλεγμένες τοπικές ρυθμίσεις δεν φαίνεται να είναι εγκατεστημένες στο σύστημά σας. (Σημ. Θα προσπαθήσω να τις θέσω ούτως ή άλλως)"
 
-#: src/amule.cpp:1574
+#: src/amule.cpp:1566
 #, c-format
 msgid "This is the first time you run aMule %s"
 msgstr "Αυτή είναι η πρώτη φορά που τρέχετε το aMule %s"
 
-#: src/amule.cpp:1577
+#: src/amule.cpp:1569
 msgid "This version is a testing version, updated daily, and\n"
 msgstr "Αυτή η έκδοση είναι δοκιμαστική, και αναβαθμίζεται καθημερινά, και\n"
 
-#: src/amule.cpp:1578
+#: src/amule.cpp:1570
 msgid "we give no warranty it won't break anything, burn your house,\n"
 msgstr "δεν δίνουμε εγγύηση ότι δεν θα χαλάσει κάτι, δεν θα κάψει το σπίτι σας,\n"
 
-#: src/amule.cpp:1579
+#: src/amule.cpp:1571
 msgid "or kill your dog. But it *should* be safe to use anyway.\n"
 msgstr "ή δεν θα σκοτώσει το σκύλο σας. Αλλά πρέπει να είναι ασφαλές στη χρήση\n"
 
-#: src/amule.cpp:1584
+#: src/amule.cpp:1576
 msgid "More information, support and new releases can found at our homepage,\n"
 msgstr "Περισσότερες πληροφορίες, υποστήριξη και νέες εκδόσεις μπορούν να βρεθούν στην ιστοσελίδα μας,\n"
 
-#: src/amule.cpp:1585
+#: src/amule.cpp:1577
 msgid "at https://amule-org.github.io, or in our IRC channel #aMule at irc.libera.chat.\n"
 msgstr "στο https://amule-org.github.io, ή στο κανάλι #aMule του IRC στο irc.libera.chat.\n"
 
-#: src/amule.cpp:1587
+#: src/amule.cpp:1579
 msgid "Feel free to report any bugs to https://github.com/amule-org/amule/issues"
 msgstr "Παρακαλούμε αναφέρετε σφάλματα του προγράμματος στο https://github.com/amule-org/amule/issues"
 
-#: src/amule.cpp:1599
+#: src/amule.cpp:1591
 msgid ""
 "The folder for Online Signature files you specified is INVALID!\n"
 " OnlineSignature will be DISABLED until you fix it on preferences."
@@ -422,138 +422,138 @@ msgstr ""
 "Ο δικτυακός κατάλογος των ηλεκτρονικών αρχείων υπογραφών που προσδιορίσατε είναι ΑΚΥΡΟΣ!\n"
 "Οι ηλεκτρονικές υπογραφές θα ΑΠΕΝΕΡΓΟΠΟΙΗΘΟΥΝ μέχρι να το φτιάξετε στις προτιμήσεις."
 
-#: src/amule.cpp:1662
+#: src/amule.cpp:1654
 #, fuzzy
 msgid "Server hostname notified"
 msgstr "Όνομα διακομιστή:"
 
-#: src/amule.cpp:2039
+#: src/amule.cpp:2031
 #, c-format
 msgid "Disk space preallocation for file '%s' failed: %s"
 msgstr "Η εκχώρηση χώρου για το αρχείο '%s' απέτυχε: '%s'"
 
-#: src/amule.cpp:2168
+#: src/amule.cpp:2160
 msgid "ERROR: can't open logfile"
 msgstr "ΣΦΑΛΜΑ: το αρχείο καταγραφής δεν μπορεί να ανοίξει"
 
-#: src/amule.cpp:2172
+#: src/amule.cpp:2164
 msgid "WARNING: logfile is empty. Something is wrong."
 msgstr "ΠΡΟΕΙΔΟΠΟΙΗΣΗ: το αρχείο καταγραφών είναι άδειο. Κάτι δεν πάει καλά."
 
-#: src/amule.cpp:2189
+#: src/amule.cpp:2181
 msgid "Log has been reset"
 msgstr "Το αρχείο καταγραφών επαναφέρθηκε στην αρχική κατάσταση"
 
-#: src/amule.cpp:2213
+#: src/amule.cpp:2205
 #, c-format
 msgid "ServerMessage: %s"
 msgstr "Μήνυμα Διακομιστή: %s"
 
-#: src/amule.cpp:2256 src/IP2Country.cpp:220 src/IPFilter.cpp:514
+#: src/amule.cpp:2248 src/IP2Country.cpp:220 src/IPFilter.cpp:514
 #: src/ServerList.cpp:875
 #, c-format
 msgid "Skipped download of %s, because requested file is not newer."
 msgstr ""
 
-#: src/amule.cpp:2259
+#: src/amule.cpp:2251
 msgid "Failed to download the nodes list."
 msgstr "Αποτυχία κατεβάσματος της λίστας κόμβων."
 
-#: src/amule.cpp:2322
+#: src/amule.cpp:2314
 msgid "Failed to open the downloaded version check file"
 msgstr "Αποτυχία ανοίγματος του κατεβασμένου αρχείου ελέγχου έκδοσης"
 
-#: src/amule.cpp:2325 src/amule.cpp:2344
+#: src/amule.cpp:2317 src/amule.cpp:2336
 msgid "Corrupted version check file"
 msgstr "Φθαρμένο αρχείο ελέγχου έκδοσης"
 
-#: src/amule.cpp:2367
+#: src/amule.cpp:2359
 msgid "You are using an outdated version of aMule!"
 msgstr "Χρησιμοποιείται μία ξεπερασμένη έκδοση του aMule!"
 
-#: src/amule.cpp:2369
+#: src/amule.cpp:2361
 #, c-format
 msgid "Your aMule version is %i.%i.%i and the latest version is %li.%li.%li"
 msgstr "Η παρούσα έκδοση του aMule είναι %i.%i.%i και η τελευταία %li.%li.%li"
 
-#: src/amule.cpp:2373
+#: src/amule.cpp:2365
 msgid "The latest version can always be found at https://github.com/amule-org/amule/releases/latest"
 msgstr "Η τελευταία έκδοση μπορεί να βρεθεί στο https://github.com/amule-org/amule/releases/latest"
 
-#: src/amule.cpp:2376
+#: src/amule.cpp:2368
 #, c-format
 msgid "WARNING: Your aMuled version is outdated: %i.%i.%i < %li.%li.%li"
 msgstr "ΠΡΟΕΙΔΟΠΟΙΗΣΗ: Η έκδοση του aMuled είναι ξεπερασμένη: %i.%i.%i < %li.%li.%li"
 
-#: src/amule.cpp:2382
+#: src/amule.cpp:2374
 msgid "Your copy of aMule is up to date."
 msgstr "Αυτό το αντίγραφο του aMule είναι σύγχρονο. "
 
-#: src/amule.cpp:2389
+#: src/amule.cpp:2381
 msgid "Failed to download the version check file"
 msgstr "Αποτυχία κατεβάσματος του αρχείου ελέγχου έκδοσης"
 
-#: src/amule.cpp:2558 src/amule-remote-gui.cpp:1133
+#: src/amule.cpp:2550 src/amule-remote-gui.cpp:1133
 #, c-format
 msgid "Users: %s | Files: %s"
 msgstr "Χρήστες: %s | Αρχεία: %s"
 
-#: src/amule.cpp:2559 src/amule-remote-gui.cpp:1134
+#: src/amule.cpp:2551 src/amule-remote-gui.cpp:1134
 #, c-format
 msgid "Users: E: %s K: %s | Files: E: %s K: %s"
 msgstr "Χρήστες: E: %s K: %s | Αρχεία: E: %s K: %s"
 
-#: src/amule.cpp:2573 src/amule-remote-gui.cpp:1147
+#: src/amule.cpp:2565 src/amule-remote-gui.cpp:1147
 msgid "No networks selected"
 msgstr "Δεν έχουν επιλεχθεί δίκτυα"
 
-#: src/amule.cpp:2641 src/TextClient.cpp:903
+#: src/amule.cpp:2633 src/TextClient.cpp:903
 msgid "with LowID"
 msgstr "με Χαμηλή Προτεραιότητα"
 
-#: src/amule.cpp:2641 src/TextClient.cpp:904
+#: src/amule.cpp:2633 src/TextClient.cpp:904
 msgid "with HighID"
 msgstr "με Υψηλή Προτεραιότητα"
 
-#: src/amule.cpp:2643
+#: src/amule.cpp:2635
 #, c-format
 msgid "Connected to %s %s"
 msgstr "Σύνδεση με το %s %s"
 
-#: src/amule.cpp:2648
+#: src/amule.cpp:2640
 #, c-format
 msgid "Connecting to %s"
 msgstr "Διαδικασία σύνδεσης με %s"
 
-#: src/amule.cpp:2650
+#: src/amule.cpp:2642
 msgid "Disconnected from eD2k"
 msgstr "Αποσυνδεδεμένο από το eD2k"
 
-#: src/amule.cpp:2659
+#: src/amule.cpp:2651
 msgid "Kad started."
 msgstr "Το Kad ξεκίνησε."
 
-#: src/amule.cpp:2661
+#: src/amule.cpp:2653
 msgid "Kad stopped."
 msgstr "Το Kad είναι σταματημένο."
 
-#: src/amule.cpp:2669
+#: src/amule.cpp:2661
 msgid "Connected to Kad (ok)"
 msgstr "Συνδεδεμένο στο Kad (ΟΚ)"
 
-#: src/amule.cpp:2671
+#: src/amule.cpp:2663
 msgid "Connected to Kad (firewalled)"
 msgstr "Συνδεδεμένο στο Kad (με προστατευτικό τοίχο)"
 
-#: src/amule.cpp:2675
+#: src/amule.cpp:2667
 msgid "Disconnected from Kad"
 msgstr "Αποσυνδεδεμένο από το Kad"
 
-#: src/amule.cpp:2707
+#: src/amule.cpp:2699
 msgid "Kad network cannot be used if UDP port is disabled on preferences, not starting."
 msgstr "Το δίκτυο Kad δεν μπορεί να χρησιμοποιηθεί αν η θύρα UDP είναι απενεργοποιημένη στις προτιμήσεις. Δεν έγινε εκκίνηση."
 
-#: src/amule.cpp:2711
+#: src/amule.cpp:2703
 msgid "Kad network disabled on preferences, not connecting."
 msgstr "Το δίκτυο Kad είναι απενεργοποιημένο από τις προτιμήσεις. Δεν έγινε σύνδεση."
 
@@ -579,68 +579,30 @@ msgstr ""
 msgid "ERROR: %s"
 msgstr "ΣΦΑΛΜΑ: %s"
 
-#: src/amuleDlg.cpp:250
+#: src/amuleDlg.cpp:236
 #, c-format
 msgid "This is aMule %s based on eMule."
 msgstr "Αυτό το aMule %s είναι βασισμένο στο eMule."
 
-#: src/amuleDlg.cpp:251
+#: src/amuleDlg.cpp:237
 #, c-format
 msgid "Running on %s"
 msgstr "Τρέχει στο %s"
 
-#: src/amuleDlg.cpp:253
+#: src/amuleDlg.cpp:239
 msgid "Visit https://github.com/amule-org/amule/releases/latest to check if a new version is available."
 msgstr "Επισκεφτείτε το https://github.com/amule-org/amule/releases/latest για να δείτε αν υπάρχει νέα έκδοση."
 
-#: src/amuleDlg.cpp:282
+#: src/amuleDlg.cpp:268
 msgid "FATAL ERROR: Failed to create Timer"
 msgstr "ΜΟΙΡΑΙΟ ΣΦΑΛΜΑ: Αποτυχία δημιουργίας Χρονομέτρου"
 
-#: src/amuleDlg.cpp:361 src/amuleDlg.cpp:1810 src/amuleDlg.cpp:2056
-#: src/muuli_wdr.cpp:1492 src/muuli_wdr.cpp:3439
-msgid "Networks"
-msgstr "Δίκτυα"
-
-#: src/amuleDlg.cpp:362 src/amuleDlg.cpp:1816 src/muuli_wdr.cpp:3440
-msgid "Searches"
-msgstr "Αναζητήσεις"
-
-#: src/amuleDlg.cpp:363 src/amuleDlg.cpp:1822 src/DownloadListCtrl.cpp:740
-#: src/muuli_wdr.cpp:392 src/muuli_wdr.cpp:1585 src/muuli_wdr.cpp:3441
-#: src/Statistics.cpp:829
-msgid "Downloads"
-msgstr "Κατεβασμένα"
-
-#: src/amuleDlg.cpp:364 src/amuleDlg.cpp:1828 src/muuli_wdr.cpp:3315
-msgid "Shared files"
-msgstr "Κοινόχρηστα αρχεία"
-
-#: src/amuleDlg.cpp:365 src/amuleDlg.cpp:1834 src/muuli_wdr.cpp:2947
-#: src/muuli_wdr.cpp:3397 src/muuli_wdr.cpp:3444
-msgid "Messages"
-msgstr "Μηνύματα"
-
-#: src/amuleDlg.cpp:366 src/amuleDlg.cpp:1840 src/muuli_wdr.cpp:3445
-#: src/PrefsUnifiedDlg.cpp:314 src/Statistics.cpp:779 src/Statistics.cpp:1235
-msgid "Statistics"
-msgstr "Στατιστικές"
-
-#: src/amuleDlg.cpp:368 src/amuleDlg.cpp:1847 src/muuli_wdr.cpp:3447
-#: src/PrefsUnifiedDlg.cpp:330 src/utils/wxCas/src/wxcasprefs.cpp:39
-msgid "Preferences"
-msgstr "Προτιμήσεις"
-
-#: src/amuleDlg.cpp:371
-msgid "Navigate"
-msgstr ""
-
-#: src/amuleDlg.cpp:657
+#: src/amuleDlg.cpp:592
 #, fuzzy
 msgid "New version available"
 msgstr "Δεν είναι διαθέσιμο"
 
-#: src/amuleDlg.cpp:661
+#: src/amuleDlg.cpp:596
 #, fuzzy, c-format
 msgid ""
 "A new version of aMule (%s) is available.\n"
@@ -650,186 +612,219 @@ msgid ""
 "Would you like to open the download page?"
 msgstr "Η τελευταία έκδοση μπορεί να βρεθεί στο https://github.com/amule-org/amule/releases/latest"
 
-#: src/amuleDlg.cpp:743
+#: src/amuleDlg.cpp:678
 msgid "aMule dialog destroyed"
 msgstr ""
 
-#: src/amuleDlg.cpp:766 src/DataToText.cpp:68 src/IPFilter.cpp:547
+#: src/amuleDlg.cpp:701 src/DataToText.cpp:68 src/IPFilter.cpp:547
 msgid "Connecting"
 msgstr "Συνδέοντας"
 
-#: src/amuleDlg.cpp:958
+#: src/amuleDlg.cpp:893
 msgid "eD2k: Connecting"
 msgstr "eD2k: Συνδέεται"
 
-#: src/amuleDlg.cpp:962
+#: src/amuleDlg.cpp:897
 msgid "eD2k: Disconnected"
 msgstr "eD2k: Αποσυνδεδεμένο"
 
-#: src/amuleDlg.cpp:968
+#: src/amuleDlg.cpp:903
 msgid "Kad: Firewalled"
 msgstr "Kad: Πίσω από τοίχο προστασίας"
 
-#: src/amuleDlg.cpp:972
+#: src/amuleDlg.cpp:907
 msgid "Kad: Connected"
 msgstr "Kad: Συνδεδεμένο"
 
-#: src/amuleDlg.cpp:977
+#: src/amuleDlg.cpp:912
 msgid "Kad: Connecting"
 msgstr "Kad: Σε διαδικασία σύνδεσης"
 
-#: src/amuleDlg.cpp:981
+#: src/amuleDlg.cpp:916
 msgid "Kad: Off"
 msgstr "Kad: Εκτός"
 
-#: src/amuleDlg.cpp:1029 src/DownloadListCtrl.cpp:505
+#: src/amuleDlg.cpp:964 src/DownloadListCtrl.cpp:505
 #: src/DownloadListCtrl.cpp:749 src/FriendListCtrl.cpp:180
 #: src/muuli_wdr.cpp:731 src/muuli_wdr.cpp:782 src/muuli_wdr.cpp:846
-#: src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2252 src/muuli_wdr.cpp:2337
-#: src/muuli_wdr.cpp:3085 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
+#: src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2224 src/muuli_wdr.cpp:2309
+#: src/muuli_wdr.cpp:3057 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
 #: src/ServerListCtrl.cpp:606 src/TransferWnd.cpp:378
 #: src/utils/wxCas/src/wxcasprefs.cpp:235
 msgid "Cancel"
 msgstr "Ακύρωση"
 
-#: src/amuleDlg.cpp:1030
+#: src/amuleDlg.cpp:965
 msgid "Stop the current connection attempts"
 msgstr "Σταμάτησε τις τρέχουσες απόπειρες σύνδεσης"
 
-#: src/amuleDlg.cpp:1035 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976
-#: src/muuli_wdr.cpp:2475
+#: src/amuleDlg.cpp:970 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976
+#: src/muuli_wdr.cpp:2447
 msgid "Disconnect"
 msgstr "Αποσύνδεση"
 
-#: src/amuleDlg.cpp:1036
+#: src/amuleDlg.cpp:971
 msgid "Disconnect from the currently connected networks"
 msgstr "Αποσύνδεση από τα συνδεδεμένα δίκτυα"
 
-#: src/amuleDlg.cpp:1041 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979
-#: src/muuli_wdr.cpp:2630 src/muuli_wdr.cpp:3082 src/muuli_wdr.cpp:3437
+#: src/amuleDlg.cpp:976 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979
+#: src/muuli_wdr.cpp:2602 src/muuli_wdr.cpp:3054 src/muuli_wdr.cpp:3409
 msgid "Connect"
 msgstr "Σύνδεση"
 
-#: src/amuleDlg.cpp:1042
+#: src/amuleDlg.cpp:977
 msgid "Connect to the currently enabled networks"
 msgstr "Σύνδεση στα ενεργοποιημένα δίκτυα"
 
-#: src/amuleDlg.cpp:1154
+#: src/amuleDlg.cpp:1089
 #, fuzzy, c-format
 msgid "Up: %.1f%s (%.1f) | Down: %.1f%s (%.1f)"
 msgstr "Πάνω: %.1f(%.1f) | Κάτω: %.1f(%.1f)"
 
-#: src/amuleDlg.cpp:1156 src/amuleDlg.cpp:1158 src/amuleDlg.cpp:1162
-#: src/amuleDlg.cpp:1164 src/amuleDlg.cpp:1175 src/amuleDlg.cpp:1177
+#: src/amuleDlg.cpp:1091 src/amuleDlg.cpp:1093 src/amuleDlg.cpp:1097
+#: src/amuleDlg.cpp:1099 src/amuleDlg.cpp:1110 src/amuleDlg.cpp:1112
 #: src/MuleTrayIcon.cpp:796 src/MuleTrayIcon.cpp:799
 #, fuzzy
 msgid " MB/s"
 msgstr "MB/s"
 
-#: src/amuleDlg.cpp:1156 src/amuleDlg.cpp:1158 src/amuleDlg.cpp:1162
-#: src/amuleDlg.cpp:1164 src/amuleDlg.cpp:1175 src/amuleDlg.cpp:1177
+#: src/amuleDlg.cpp:1091 src/amuleDlg.cpp:1093 src/amuleDlg.cpp:1097
+#: src/amuleDlg.cpp:1099 src/amuleDlg.cpp:1110 src/amuleDlg.cpp:1112
 #: src/MuleTrayIcon.cpp:796 src/MuleTrayIcon.cpp:799
 #: src/utils/wxCas/src/wxcasframe.cpp:1041
 msgid " kB/s"
 msgstr " kB/s"
 
-#: src/amuleDlg.cpp:1161
+#: src/amuleDlg.cpp:1096
 #, fuzzy, c-format
 msgid "Up: %.1f%s | Down: %.1f%s"
 msgstr "Πάνω: %.1f | Κάτω: %.1f"
 
-#: src/amuleDlg.cpp:1193
+#: src/amuleDlg.cpp:1128
 #, c-format
 msgid "aMule (%s | Connected)"
 msgstr "aMule (%s | Συνδεδεμένο)"
 
-#: src/amuleDlg.cpp:1195
+#: src/amuleDlg.cpp:1130
 #, c-format
 msgid "aMule (%s | Disconnected)"
 msgstr "aMule (%s | Αποσυνδεδεμένο)"
 
-#: src/amuleDlg.cpp:1248
+#: src/amuleDlg.cpp:1183
 #, fuzzy, c-format
 msgid "Do you really want to exit %s?"
 msgstr "Σίγουρα θέλετε να κλείσετε το aMule;"
 
-#: src/amuleDlg.cpp:1250
+#: src/amuleDlg.cpp:1185
 msgid "Exit confirmation"
 msgstr "Έξοδος επιβεβαίωσης"
 
-#: src/amuleDlg.cpp:1613
+#: src/amuleDlg.cpp:1548
 msgid "Launch Command: "
 msgstr ""
 
-#: src/amuleDlg.cpp:1632 src/muuli_wdr.cpp:1972 src/Preferences.cpp:979
+#: src/amuleDlg.cpp:1567 src/muuli_wdr.cpp:1971 src/Preferences.cpp:951
 msgid "- default -"
 msgstr "- Προεπιλεγμένο -"
 
-#: src/amuleDlg.cpp:1660
+#: src/amuleDlg.cpp:1595
 #, c-format
 msgid "Skin directory '%s' does not exist"
 msgstr "Ο κατάλογος των θεμάτων '%s'  δεν υπάρχει"
 
-#: src/amuleDlg.cpp:1663
+#: src/amuleDlg.cpp:1598
 #, c-format
 msgid "WARNING: Unable to open skin file '%s' for read"
 msgstr "ΠΡΟΕΙΔΟΠΟΙΗΣΗ: Δεν είναι δυνατή η ανάγνωση του αρχείου θέματος '%s' "
 
-#: src/amuleDlg.cpp:1814 src/muuli_wdr.cpp:3439
+#: src/amuleDlg.cpp:1722 src/amuleDlg.cpp:1968 src/muuli_wdr.cpp:1485
+#: src/muuli_wdr.cpp:3411
+msgid "Networks"
+msgstr "Δίκτυα"
+
+#: src/amuleDlg.cpp:1726 src/muuli_wdr.cpp:3411
 msgid "Networks Window"
 msgstr "Παράθυρο δικτύων"
 
-#: src/amuleDlg.cpp:1820 src/muuli_wdr.cpp:3440
+#: src/amuleDlg.cpp:1728 src/muuli_wdr.cpp:3412
+msgid "Searches"
+msgstr "Αναζητήσεις"
+
+#: src/amuleDlg.cpp:1732 src/muuli_wdr.cpp:3412
 msgid "Searches Window"
 msgstr "Παράθυρο αναζητήσεων"
 
-#: src/amuleDlg.cpp:1826 src/muuli_wdr.cpp:3441
+#: src/amuleDlg.cpp:1734 src/DownloadListCtrl.cpp:740 src/muuli_wdr.cpp:392
+#: src/muuli_wdr.cpp:1578 src/muuli_wdr.cpp:3413 src/Statistics.cpp:829
+msgid "Downloads"
+msgstr "Κατεβασμένα"
+
+#: src/amuleDlg.cpp:1738 src/muuli_wdr.cpp:3413
 #, fuzzy
 msgid "Downloads Window"
 msgstr "Κατεβαίνει"
 
-#: src/amuleDlg.cpp:1832 src/muuli_wdr.cpp:3443
+#: src/amuleDlg.cpp:1740 src/muuli_wdr.cpp:3287
+msgid "Shared files"
+msgstr "Κοινόχρηστα αρχεία"
+
+#: src/amuleDlg.cpp:1744 src/muuli_wdr.cpp:3415
 msgid "Shared Files Window"
 msgstr "Παράθυρο κοινόχρηστων αρχείων"
 
-#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3444
+#: src/amuleDlg.cpp:1746 src/muuli_wdr.cpp:2919 src/muuli_wdr.cpp:3369
+#: src/muuli_wdr.cpp:3416
+msgid "Messages"
+msgstr "Μηνύματα"
+
+#: src/amuleDlg.cpp:1750 src/muuli_wdr.cpp:3416
 msgid "Messages Window"
 msgstr "Παράθυρό μηνυμάτων"
 
-#: src/amuleDlg.cpp:1844 src/muuli_wdr.cpp:3445
+#: src/amuleDlg.cpp:1752 src/muuli_wdr.cpp:3417 src/PrefsUnifiedDlg.cpp:312
+#: src/Statistics.cpp:779 src/Statistics.cpp:1235
+msgid "Statistics"
+msgstr "Στατιστικές"
+
+#: src/amuleDlg.cpp:1756 src/muuli_wdr.cpp:3417
 msgid "Statistics Graph Window"
 msgstr "Παράθυρο στατιστικών διαγραμμάτων"
 
-#: src/amuleDlg.cpp:1851 src/muuli_wdr.cpp:3447
+#: src/amuleDlg.cpp:1759 src/muuli_wdr.cpp:3419 src/PrefsUnifiedDlg.cpp:328
+#: src/utils/wxCas/src/wxcasprefs.cpp:39
+msgid "Preferences"
+msgstr "Προτιμήσεις"
+
+#: src/amuleDlg.cpp:1763 src/muuli_wdr.cpp:3419
 msgid "Preferences Settings Window"
 msgstr "Παράθυρο ρυθμίσεων"
 
-#: src/amuleDlg.cpp:1854 src/muuli_wdr.cpp:3448
+#: src/amuleDlg.cpp:1766 src/muuli_wdr.cpp:3420
 msgid "Import"
 msgstr "Εισαγωγή"
 
-#: src/amuleDlg.cpp:1858 src/muuli_wdr.cpp:3448
+#: src/amuleDlg.cpp:1770 src/muuli_wdr.cpp:3420
 msgid "The partfile importer tool"
 msgstr "Το εργαλείο εισαγωγής ημιτελών αρχείων"
 
-#: src/amuleDlg.cpp:1861 src/muuli_wdr.cpp:3449
+#: src/amuleDlg.cpp:1773 src/muuli_wdr.cpp:3421
 #: src/utils/aLinkCreator/src/alcframe.cpp:262
 msgid "About"
 msgstr "Σχετικά"
 
-#: src/amuleDlg.cpp:1861 src/muuli_wdr.cpp:3449
+#: src/amuleDlg.cpp:1773 src/muuli_wdr.cpp:3421
 msgid "About/Help"
 msgstr "Σχετικά/Βοήθεια"
 
-#: src/amuleDlg.cpp:2059
+#: src/amuleDlg.cpp:1971
 msgid "eD2k network"
 msgstr "Δίκτυο eD2k"
 
-#: src/amuleDlg.cpp:2062
+#: src/amuleDlg.cpp:1974
 msgid "Kad network"
 msgstr "Δίκτυο Kad"
 
-#: src/amuleDlg.cpp:2062
+#: src/amuleDlg.cpp:1974
 msgid "No network"
 msgstr "Κανένα δίκτυο"
 
@@ -963,7 +958,7 @@ msgstr "Το αρχείο δεν βρέθηκε."
 msgid "The core rejected these shared folders:%s"
 msgstr ""
 
-#: src/amule-remote-gui.cpp:1336 src/ExternalConn.cpp:2346
+#: src/amule-remote-gui.cpp:1336 src/ExternalConn.cpp:2345
 msgid "Invalid link or already on list."
 msgstr "Άκυρος σύνδεσμο ή ήδη στην λίστα."
 
@@ -979,7 +974,7 @@ msgstr ""
 #: src/ClientDetailDialog.cpp:123 src/DataToText.cpp:61 src/DataToText.cpp:86
 #: src/DataToText.cpp:101 src/DataToText.cpp:136 src/DataToText.cpp:165
 #: src/DownloadListCtrl.cpp:1172 src/DownloadListCtrl.cpp:1185
-#: src/DownloadListCtrl.cpp:1196 src/ExternalConn.cpp:609
+#: src/DownloadListCtrl.cpp:1196 src/ExternalConn.cpp:608
 #: src/FileDetailDialog.cpp:203 src/FileDetailDialog.cpp:235
 #: src/FileDetailDialog.cpp:242 src/GenericClientListCtrl.cpp:1171
 #: src/GenericClientListCtrl.cpp:1182 src/GenericClientListCtrl.cpp:1192
@@ -1366,19 +1361,19 @@ msgstr "Αυτόματη [Υψηλή]"
 msgid "Very low"
 msgstr "Πολύ χαμηλή"
 
-#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:743 src/muuli_wdr.cpp:2303
+#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:743 src/muuli_wdr.cpp:2275
 #: src/ServerListCtrl.cpp:263 src/ServerListCtrl.cpp:456
 #: src/SharedFilesCtrl.cpp:145
 msgid "Low"
 msgstr "Χαμηλή"
 
-#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:744 src/muuli_wdr.cpp:2304
+#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:744 src/muuli_wdr.cpp:2276
 #: src/ServerListCtrl.cpp:266 src/ServerListCtrl.cpp:457
 #: src/SharedFilesCtrl.cpp:146
 msgid "Normal"
 msgstr "Κανονική"
 
-#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:745 src/muuli_wdr.cpp:2305
+#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:745 src/muuli_wdr.cpp:2277
 #: src/ServerListCtrl.cpp:269 src/ServerListCtrl.cpp:458
 #: src/SharedFilesCtrl.cpp:147
 msgid "High"
@@ -1470,8 +1465,8 @@ msgstr "Τοπικός διακομιστής"
 msgid "Remote Server"
 msgstr "Απομακρυσμένος διακομιστής"
 
-#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3202
-#: src/SearchDlg.cpp:119 src/TextClient.cpp:911
+#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3174
+#: src/SearchDlg.cpp:111 src/TextClient.cpp:911
 msgid "Kad"
 msgstr "Kad"
 
@@ -1542,7 +1537,7 @@ msgstr "Μέρος"
 msgid "Size"
 msgstr "Μέγεθος"
 
-#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3269
+#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3241
 msgid "Transferred"
 msgstr "Μεταφέρθηκαν"
 
@@ -1600,7 +1595,7 @@ msgstr ""
 "Αντίδραση από %s (%s)\n"
 "\n"
 
-#: src/DownloadListCtrl.cpp:746 src/muuli_wdr.cpp:2306
+#: src/DownloadListCtrl.cpp:746 src/muuli_wdr.cpp:2278
 #: src/SharedFilesCtrl.cpp:150
 msgid "Auto"
 msgstr "Αυτόματη"
@@ -1638,7 +1633,7 @@ msgid "Extended Options"
 msgstr "Εκτεταμένες Προτιμήσεις"
 
 #: src/DownloadListCtrl.cpp:770 src/DownloadListCtrl.cpp:822
-#: src/muuli_wdr.cpp:1790
+#: src/muuli_wdr.cpp:1789
 msgid "Preview"
 msgstr "Προεπισκόπιση"
 
@@ -1813,237 +1808,232 @@ msgstr[1] ""
 msgid "Invalid eD2k link! ERROR: %s"
 msgstr "Άκυρος σύνδεσμος eD2k! ΣΦΑΛΜΑ: %s"
 
-#: src/ExternalConn.cpp:380
+#: src/ExternalConn.cpp:379
 #, fuzzy
 msgid "Client sent packet after authentication failed."
 msgstr "Η πιστοποίηση απέτυχε."
 
-#: src/ExternalConn.cpp:397
+#: src/ExternalConn.cpp:396
 msgid "External connection closed."
 msgstr "Η εξωτερική σύνδεση έκλεισε."
 
-#: src/ExternalConn.cpp:474
+#: src/ExternalConn.cpp:473
 msgid "External connections disabled due to empty password!"
 msgstr "Οι εξωτερικές συνδέσεις απενεργοποιήθηκαν λόγω καινού κωδικού!"
 
-#: src/ExternalConn.cpp:495
+#: src/ExternalConn.cpp:494
 msgid "External connections disabled in config file"
 msgstr "Οι εξωτερικές συνδέσεις απενεργοποιήθηκαν στο αρχείο ρυθμίσεων"
 
-#: src/ExternalConn.cpp:576
+#: src/ExternalConn.cpp:575
 msgid "New external connection accepted"
 msgstr "Νέα εξωτερική σύνδεση έγινε δεκτή"
 
-#: src/ExternalConn.cpp:579
+#: src/ExternalConn.cpp:578
 msgid "ERROR: couldn't accept a new external connection"
 msgstr "ΣΦΑΛΜΑ: δεν μπόρεσα να αποδεχτώ νέα εξωτερική σύνδεση"
 
-#: src/ExternalConn.cpp:596
+#: src/ExternalConn.cpp:595
 msgid "External connection refused due to empty password in preferences!"
 msgstr "Οι εξωτερικές συνδέσεις απενεργοποιήθηκαν λόγω καινού κωδικού στις προτιμήσεις!"
 
-#: src/ExternalConn.cpp:608
+#: src/ExternalConn.cpp:607
 #, c-format
 msgid "Connecting client: %s %s"
 msgstr "Συνδεόμενος πελάτης: %s %s"
 
-#: src/ExternalConn.cpp:610
+#: src/ExternalConn.cpp:609
 msgid "Unknown version"
 msgstr "Άγνωστη έκδοση"
 
-#: src/ExternalConn.cpp:623
+#: src/ExternalConn.cpp:622
 msgid "Incorrect EC version ID, there might be binary incompatibility. Use core and remote from same snapshot."
 msgstr "Λανθασμένη ταυτότητα έκδοσης EC, ίσως υπάρχει δυαδική ασυμβατότητα. Χρησιμοποιήστε πυρήνα και απομακρυσμένο μέρος από το ίδιο στιγμιότυπο."
 
-#: src/ExternalConn.cpp:631
+#: src/ExternalConn.cpp:630
 #, fuzzy
 msgid "You cannot connect to a release version from an arbitrary development snapshot! *sigh* possible crash prevented"
 msgstr "Δεν μπορείτε να συνδεθείτε σε μια επίσημη έκδοση από μια αναπτυσσόμενη (SVN) έκδοση! *ουφ* αποφευχθεί πιθανό κρέμασμα"
 
-#: src/ExternalConn.cpp:714
+#: src/ExternalConn.cpp:713
 msgid "Invalid protocol version."
 msgstr "Άκυρη έκδοση πρωτοκόλλου."
 
-#: src/ExternalConn.cpp:720
+#: src/ExternalConn.cpp:719
 msgid "Missing protocol version tag."
 msgstr "Λείπει η ετικέτα με την έκδοση του πρωτοκόλλου."
 
-#: src/ExternalConn.cpp:728
+#: src/ExternalConn.cpp:727
 msgid "Authentication failed: invalid hash specified as EC password."
 msgstr ""
 
-#: src/ExternalConn.cpp:776
+#: src/ExternalConn.cpp:775
 #, fuzzy
 msgid "Authentication failed: wrong password."
 msgstr "Η πιστοποίηση απέτυχε."
 
-#: src/ExternalConn.cpp:778
+#: src/ExternalConn.cpp:777
 #, fuzzy
 msgid "Authentication failed: missing password."
 msgstr "Η πιστοποίηση απέτυχε."
 
-#: src/ExternalConn.cpp:789
+#: src/ExternalConn.cpp:788
 #, fuzzy
 msgid "Invalid request, please authenticate first."
 msgstr "Άκυρη αίτηση, πρέπει πρώτα να πιστοποιηθήτε."
 
-#: src/ExternalConn.cpp:794
+#: src/ExternalConn.cpp:793
 msgid "Access granted."
 msgstr "Η πρόσβαση επικυρώθηκε."
 
-#: src/ExternalConn.cpp:802
+#: src/ExternalConn.cpp:801
 #, fuzzy, c-format
 msgid "Sent error message \"%s\" to client."
 msgstr "Διήθηση μηνυμάτων από άγνωστους πελάτες"
 
-#: src/ExternalConn.cpp:807
+#: src/ExternalConn.cpp:806
 #, fuzzy, c-format
 msgid "Unauthorized access attempt from %s. Connection closed."
 msgstr "Απόπειρα μη εξουσιοδοτημένης πρόσβασης. Η σύνδεση έκλεισε."
 
-#: src/ExternalConn.cpp:1420
+#: src/ExternalConn.cpp:1419
 #, c-format
 msgid "Remote PartFile command failed: FileHash not found: %s"
 msgstr "Η απομακρυσμένη εντολή ημιτελούς αρχείου απέτυχε: Ο κατακερματισμός αρχείου δεν βρέθηκε: %s"
 
-#: src/ExternalConn.cpp:1424
+#: src/ExternalConn.cpp:1423
 #, c-format
 msgid "FileHash not found: %s"
 msgstr "Ο κατακερματισμός αρχείου δεν βρέθηκε: %s"
 
-#: src/ExternalConn.cpp:1471 src/ExternalConn.cpp:1559
-#: src/ExternalConn.cpp:1680
+#: src/ExternalConn.cpp:1470 src/ExternalConn.cpp:1558
+#: src/ExternalConn.cpp:1679
 msgid "OOPS! OpCode processing error!"
 msgstr "Όπα! Σφάλμα επεξεργασίας OpCode!"
 
-#: src/ExternalConn.cpp:1502
+#: src/ExternalConn.cpp:1501
 msgid "Server not added"
 msgstr "Ο διακομιστής δεν προστέθηκε"
 
-#: src/ExternalConn.cpp:1521
+#: src/ExternalConn.cpp:1520
 #, c-format
 msgid "server not found: %s"
 msgstr "Ο διακομιστής δεν βρέθηκε: %s"
 
-#: src/ExternalConn.cpp:1538
+#: src/ExternalConn.cpp:1537
 msgid "need to define server to be removed"
 msgstr "χρειάζεται να οριστεί ο διακομιστής που να διαγραφεί"
 
-#: src/ExternalConn.cpp:1553
+#: src/ExternalConn.cpp:1552
 msgid "eD2k is disabled in preferences."
 msgstr "Το eD2k είναι απενεργοποιημένο στις ρυθμίσεις."
 
-#: src/ExternalConn.cpp:1658
+#: src/ExternalConn.cpp:1657
 #, fuzzy
 msgid "Friend not found."
 msgstr "Το αρχείο δεν βρέθηκε."
 
-#: src/ExternalConn.cpp:1668
+#: src/ExternalConn.cpp:1667
 #, fuzzy
 msgid "Client not found."
 msgstr "Το αρχείο δεν βρέθηκε."
 
-#: src/ExternalConn.cpp:1674
+#: src/ExternalConn.cpp:1673
 msgid "EC_TAG_FRIEND_SHARED requires EC_TAG_FRIEND or EC_TAG_CLIENT."
 msgstr ""
 
-#: src/ExternalConn.cpp:1992
+#: src/ExternalConn.cpp:1991
 msgid "WebSearch from remote interface makes no sense."
 msgstr "Η αναζήτηση από τον ιστό από απομακρυσμένο περιβάλλον δεν έχει κανένα νόημα."
 
-#: src/ExternalConn.cpp:2027
+#: src/ExternalConn.cpp:2026
 msgid "Search in progress. Refetch results in a moment!"
 msgstr "Αναζήτηση δια εξέλιξη. Επανάκτηση αποτελεσμάτων σε λίγο!"
 
-#: src/ExternalConn.cpp:2266
+#: src/ExternalConn.cpp:2265
 msgid "No points for graph."
 msgstr "Δεν υπάρχουν σημεία για γράφημα."
 
-#: src/ExternalConn.cpp:2276
+#: src/ExternalConn.cpp:2275
 msgid "Your client is not configured for this detail level."
 msgstr "Ο πελάτης σας δεν έχει ρυθμιστεί με τόση λεπτομέρεια"
 
-#: src/ExternalConn.cpp:2303
+#: src/ExternalConn.cpp:2302
 msgid "External Connection: shutdown requested"
 msgstr "Εξωτερική σύνδεση: ζητήθηκε κλείσιμο"
 
-#: src/ExternalConn.cpp:2315
+#: src/ExternalConn.cpp:2314
 msgid "Already shutting down."
 msgstr "Ήδη η λειτουργία είναι σε φάση διακοπής"
 
-#: src/ExternalConn.cpp:2333
+#: src/ExternalConn.cpp:2332
 #, c-format
 msgid "ExternalConn: adding link '%s'."
 msgstr "Εξωτερική Σύνδεση: προστίθεται ο σύνδεσμος '%s'."
 
-#: src/ExternalConn.cpp:2351
+#: src/ExternalConn.cpp:2350
 #, fuzzy, c-format
 msgid "%d of %d links failed (invalid or already on list)."
 msgstr "Άκυρος σύνδεσμο ή ήδη στην λίστα."
 
-#: src/ExternalConn.cpp:2374
+#: src/ExternalConn.cpp:2373
 msgid "Version check throttled; try again shortly."
 msgstr ""
 
-#: src/ExternalConn.cpp:2379
+#: src/ExternalConn.cpp:2378
 msgid "Version check is not available on this daemon."
 msgstr ""
 
-#: src/ExternalConn.cpp:2509
+#: src/ExternalConn.cpp:2508
 msgid "File not found."
 msgstr "Το αρχείο δεν βρέθηκε."
 
-#: src/ExternalConn.cpp:2514
+#: src/ExternalConn.cpp:2513
 msgid "Invalid file name."
 msgstr "Άκυρο όνομα αρχείου."
 
-#: src/ExternalConn.cpp:2522
+#: src/ExternalConn.cpp:2521
 msgid "Unable to rename file."
 msgstr "Αποτυχία μετονομασίας αρχείου."
 
-#: src/ExternalConn.cpp:2839
-#, c-format
-msgid "Could not save the amuleapi password: %s"
-msgstr ""
-
-#: src/ExternalConn.cpp:3004 src/ExternalConn.cpp:3032
+#: src/ExternalConn.cpp:2992 src/ExternalConn.cpp:3020
 msgid "Kad is disabled in preferences."
 msgstr "Το Kad έχει απενεργοποιηθεί στις προτιμήσεις."
 
-#: src/ExternalConn.cpp:3045
+#: src/ExternalConn.cpp:3033
 msgid "Already connected to eD2k."
 msgstr "Ήδη συνδεδεμένο στο eD2k."
 
-#: src/ExternalConn.cpp:3048
+#: src/ExternalConn.cpp:3036
 msgid "Connecting to eD2k..."
 msgstr "Συνδέεται στο eD2k..."
 
-#: src/ExternalConn.cpp:3057
+#: src/ExternalConn.cpp:3045
 msgid "Already connected to Kad."
 msgstr "Ήδη συνδεδεμένο στο Kad."
 
-#: src/ExternalConn.cpp:3060
+#: src/ExternalConn.cpp:3048
 msgid "Connecting to Kad..."
 msgstr "Διαδικασία σύνδεσης στο Kad..."
 
-#: src/ExternalConn.cpp:3067
+#: src/ExternalConn.cpp:3055
 msgid "All networks are disabled."
 msgstr "Όλα τα δίκτυα είναι απενεργοποιημένα."
 
-#: src/ExternalConn.cpp:3076
+#: src/ExternalConn.cpp:3064
 msgid "Disconnected from eD2k."
 msgstr "Αποσυνδεδεμένο από το eD2k."
 
-#: src/ExternalConn.cpp:3081
+#: src/ExternalConn.cpp:3069
 msgid "Disconnected from Kad."
 msgstr "Αποσυνδεδεμένο από το Kad."
 
-#: src/ExternalConn.cpp:3090
+#: src/ExternalConn.cpp:3078
 #, c-format
 msgid "External Connection: invalid opcode received: %#x"
 msgstr "Εξωτερική σύνδεση: λήφθηκε άκυρος opcode: %#x"
 
-#: src/ExternalConn.cpp:3095
+#: src/ExternalConn.cpp:3083
 msgid "Invalid opcode (wrong protocol version?)"
 msgstr "Εσφαλμένος κωδικός (λάθος έκδοση πρωτοκόλλου;)"
 
@@ -2358,19 +2348,19 @@ msgstr ""
 msgid "eD2k"
 msgstr "eD2k"
 
-#: src/FirstRunWizard.cpp:349 src/muuli_wdr.cpp:1495
+#: src/FirstRunWizard.cpp:349 src/muuli_wdr.cpp:1488
 msgid "Kademlia"
 msgstr "Kademlia"
 
-#: src/FirstRunWizard.cpp:359 src/muuli_wdr.cpp:1423
+#: src/FirstRunWizard.cpp:359 src/muuli_wdr.cpp:1416
 msgid "Standard TCP Port "
 msgstr "Πρότυπη θύρα TCP"
 
-#: src/FirstRunWizard.cpp:365 src/muuli_wdr.cpp:1435
+#: src/FirstRunWizard.cpp:365 src/muuli_wdr.cpp:1428
 msgid "Extended UDP port (Kad / global search) "
 msgstr "Εκτεταμένη θύρα UDP (Kad / καθολική αναζήτηση)"
 
-#: src/FirstRunWizard.cpp:377 src/muuli_wdr.cpp:1442
+#: src/FirstRunWizard.cpp:377 src/muuli_wdr.cpp:1435
 msgid "Enable UPnP for router port forwarding"
 msgstr "Ενεργοποίηση UPnP για προώθηση της θύρας του δρομολογητή"
 
@@ -2397,7 +2387,7 @@ msgstr ""
 msgid "Your peer lists are already in place - nothing to download."
 msgstr "Ήδη προσπαθείτε να κατεβάσετε το αρχείο %s"
 
-#: src/FirstRunWizard.cpp:434 src/muuli_wdr.cpp:1540
+#: src/FirstRunWizard.cpp:434 src/muuli_wdr.cpp:1533
 msgid "Auto-update server list at startup"
 msgstr "Αυτόματη ενημέρωση λίστας διακομιστών κατά την εκκίνηση"
 
@@ -2443,23 +2433,23 @@ msgid ""
 "want downloads on a different (e.g. larger) disk."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:549 src/FirstRunWizard.cpp:611 src/muuli_wdr.cpp:1702
+#: src/FirstRunWizard.cpp:549 src/FirstRunWizard.cpp:611 src/muuli_wdr.cpp:1701
 msgid "Destination folder for downloads"
 msgstr "Κατάλογος για τα εισερχόμενα"
 
-#: src/FirstRunWizard.cpp:553 src/FirstRunWizard.cpp:569 src/muuli_wdr.cpp:1349
-#: src/muuli_wdr.cpp:1366 src/muuli_wdr.cpp:1677 src/muuli_wdr.cpp:1708
-#: src/muuli_wdr.cpp:1720 src/muuli_wdr.cpp:2790
+#: src/FirstRunWizard.cpp:553 src/FirstRunWizard.cpp:569 src/muuli_wdr.cpp:1342
+#: src/muuli_wdr.cpp:1359 src/muuli_wdr.cpp:1676 src/muuli_wdr.cpp:1707
+#: src/muuli_wdr.cpp:1719 src/muuli_wdr.cpp:2762
 #: src/utils/aLinkCreator/src/alcframe.cpp:135
 #: src/utils/wxCas/src/wxcasprefs.cpp:52 src/utils/wxCas/src/wxcasprefs.cpp:118
 msgid "Browse"
 msgstr "Επιλογή"
 
-#: src/FirstRunWizard.cpp:559 src/muuli_wdr.cpp:1713
+#: src/FirstRunWizard.cpp:559 src/muuli_wdr.cpp:1712
 msgid "(All files in this folder are shared with other peers)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:565 src/FirstRunWizard.cpp:624 src/muuli_wdr.cpp:1715
+#: src/FirstRunWizard.cpp:565 src/FirstRunWizard.cpp:624 src/muuli_wdr.cpp:1714
 msgid "Folder for temporary download files"
 msgstr "Κατάλογος για τα προσωρινά αρχεία"
 
@@ -2490,7 +2480,7 @@ msgstr "Αποτυχία γραψίματος στο αρχείο της λίσ�
 msgid "CRITICAL - no client on StartChatSession"
 msgstr ""
 
-#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2696 src/muuli_wdr.cpp:3373
+#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2668 src/muuli_wdr.cpp:3345
 msgid "Friends"
 msgstr "Φίλοι"
 
@@ -2604,8 +2594,8 @@ msgstr "Κανείς"
 msgid "No"
 msgstr "Όχι"
 
-#: src/GenericClientListCtrl.cpp:1216 src/PrefsUnifiedDlg.cpp:2898
-#: src/PrefsUnifiedDlg.cpp:2948 src/ServerListCtrl.cpp:276
+#: src/GenericClientListCtrl.cpp:1216 src/PrefsUnifiedDlg.cpp:2818
+#: src/PrefsUnifiedDlg.cpp:2868 src/ServerListCtrl.cpp:276
 msgid "Yes"
 msgstr "Ναι"
 
@@ -2775,10 +2765,10 @@ msgstr "Άκυρη θύρα για εκκινητήρα"
 msgid "Please fill all fields required"
 msgstr "Παρακαλώ συμπληρώστε όλα τα απαιτούμενα πεδία"
 
-#: src/KadDlg.cpp:192 src/PartFile.cpp:1031 src/PrefsUnifiedDlg.cpp:1134
-#: src/PrefsUnifiedDlg.cpp:1204 src/PrefsUnifiedDlg.cpp:1405
-#: src/PrefsUnifiedDlg.cpp:1663 src/PrefsUnifiedDlg.cpp:1673
-#: src/PrefsUnifiedDlg.cpp:1690 src/PrefsUnifiedDlg.cpp:1738
+#: src/KadDlg.cpp:192 src/PartFile.cpp:1031 src/PrefsUnifiedDlg.cpp:1162
+#: src/PrefsUnifiedDlg.cpp:1331 src/PrefsUnifiedDlg.cpp:1589
+#: src/PrefsUnifiedDlg.cpp:1599 src/PrefsUnifiedDlg.cpp:1616
+#: src/PrefsUnifiedDlg.cpp:1658
 msgid "Message"
 msgstr "Μήνυμα"
 
@@ -2880,7 +2870,7 @@ msgstr "Λόγος μοιράσματος"
 msgid "Uploaded"
 msgstr "Ανέβηκε"
 
-#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3253
+#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3225
 msgid "Requested"
 msgstr "Ζητήθηκε:"
 
@@ -3006,7 +2996,7 @@ msgid "WARNING: "
 msgstr "ΠΡΟΕΙΔΟΠΟΙΗΣΗ:"
 
 #: src/MuleNotebook.cpp:179 src/muuli_wdr.cpp:817 src/muuli_wdr.cpp:1229
-#: src/muuli_wdr.cpp:3157 src/muuli_wdr.cpp:3413
+#: src/muuli_wdr.cpp:3129 src/muuli_wdr.cpp:3385
 msgid "Close"
 msgstr "Κλείσιμο"
 
@@ -3019,12 +3009,12 @@ msgstr "Αποκοπή"
 msgid "Copy"
 msgstr "Αντιγραφή"
 
-#: src/MuleTextCtrl.cpp:88 src/SearchDlg.cpp:261
+#: src/MuleTextCtrl.cpp:88
 msgid "Paste"
 msgstr "Επικόλληση"
 
 #: src/MuleTextCtrl.cpp:89 src/muuli_wdr.cpp:358 src/muuli_wdr.cpp:757
-#: src/muuli_wdr.cpp:2380 src/muuli_wdr.cpp:2399 src/muuli_wdr.cpp:2421
+#: src/muuli_wdr.cpp:2352 src/muuli_wdr.cpp:2371 src/muuli_wdr.cpp:2393
 #: src/utils/aLinkCreator/src/alcframe.cpp:142
 msgid "Clear"
 msgstr "Καθαρισμός"
@@ -3122,8 +3112,8 @@ msgid "Exit"
 msgstr "Έξοδος"
 
 #: src/MuleTrayIcon.cpp:579 src/MuleTrayIcon.cpp:945 src/MuleTrayIcon.cpp:965
-#: src/muuli_wdr.cpp:1398 src/muuli_wdr.cpp:1406 src/muuli_wdr.cpp:1413
-#: src/muuli_wdr.cpp:1836 src/muuli_wdr.cpp:1842 src/OtherFunctions.cpp:91
+#: src/muuli_wdr.cpp:1391 src/muuli_wdr.cpp:1399 src/muuli_wdr.cpp:1406
+#: src/muuli_wdr.cpp:1835 src/muuli_wdr.cpp:1841 src/OtherFunctions.cpp:91
 #: src/StatisticsDlg.cpp:93 src/StatisticsDlg.cpp:95
 msgid "kB/s"
 msgstr "kB/s"
@@ -3294,7 +3284,7 @@ msgstr "Όνομα:"
 msgid "Type"
 msgstr "Τύπος"
 
-#: src/muuli_wdr.cpp:215 src/SearchDlg.cpp:118 src/SearchListCtrl.cpp:853
+#: src/muuli_wdr.cpp:215 src/SearchDlg.cpp:110 src/SearchListCtrl.cpp:853
 msgid "Local"
 msgstr "Τοπικό"
 
@@ -3365,7 +3355,7 @@ msgstr "Bytes"
 msgid "KB"
 msgstr "KB"
 
-#: src/muuli_wdr.cpp:274 src/muuli_wdr.cpp:293 src/muuli_wdr.cpp:1621
+#: src/muuli_wdr.cpp:274 src/muuli_wdr.cpp:293 src/muuli_wdr.cpp:1620
 #: src/OtherFunctions.cpp:64
 msgid "MB"
 msgstr "MB"
@@ -3382,7 +3372,7 @@ msgstr "Μέγιστο αρχείο"
 msgid "Availability"
 msgstr "Διαθεσιμότητα"
 
-#: src/muuli_wdr.cpp:312 src/muuli_wdr.cpp:398 src/muuli_wdr.cpp:3318
+#: src/muuli_wdr.cpp:312 src/muuli_wdr.cpp:398 src/muuli_wdr.cpp:3290
 msgid "Filter:"
 msgstr "Φίλτρο:"
 
@@ -3414,7 +3404,7 @@ msgstr ""
 msgid "Stop"
 msgstr "Σταμάτημα"
 
-#: src/muuli_wdr.cpp:348 src/muuli_wdr.cpp:1392 src/SearchListCtrl.cpp:732
+#: src/muuli_wdr.cpp:348 src/muuli_wdr.cpp:1385 src/SearchListCtrl.cpp:732
 msgid "Download"
 msgstr "Κατέβασμα"
 
@@ -3446,12 +3436,12 @@ msgstr "Ολοκλήρωση πηγών"
 #: src/muuli_wdr.cpp:1160 src/muuli_wdr.cpp:1167 src/muuli_wdr.cpp:1172
 #: src/muuli_wdr.cpp:1179 src/muuli_wdr.cpp:1184 src/muuli_wdr.cpp:1191
 #: src/muuli_wdr.cpp:1205 src/muuli_wdr.cpp:1212 src/muuli_wdr.cpp:1217
-#: src/muuli_wdr.cpp:1224 src/muuli_wdr.cpp:3255 src/muuli_wdr.cpp:3263
-#: src/muuli_wdr.cpp:3271
+#: src/muuli_wdr.cpp:1224 src/muuli_wdr.cpp:3227 src/muuli_wdr.cpp:3235
+#: src/muuli_wdr.cpp:3243
 msgid "N/A"
 msgstr "Δεν υπάρχει"
 
-#: src/muuli_wdr.cpp:508 src/muuli_wdr.cpp:1065 src/PrefsUnifiedDlg.cpp:299
+#: src/muuli_wdr.cpp:508 src/muuli_wdr.cpp:1065 src/PrefsUnifiedDlg.cpp:297
 msgid "General"
 msgstr "Γενικά"
 
@@ -3592,7 +3582,7 @@ msgstr ""
 msgid "Album :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:685 src/muuli_wdr.cpp:2275
+#: src/muuli_wdr.cpp:685 src/muuli_wdr.cpp:2247
 msgid "Title :"
 msgstr "Τίτλος:"
 
@@ -3701,7 +3691,7 @@ msgstr "Όνομα χρήστη :"
 msgid "Userhash :"
 msgstr "Τεμάχιο χρήστη :"
 
-#: src/muuli_wdr.cpp:895 src/muuli_wdr.cpp:1742 src/muuli_wdr.cpp:2470
+#: src/muuli_wdr.cpp:895 src/muuli_wdr.cpp:1741 src/muuli_wdr.cpp:2442
 #: src/utils/aLinkCreator/src/alcframe.cpp:137
 msgid "Add"
 msgstr "Προσθήκη"
@@ -3710,15 +3700,15 @@ msgstr "Προσθήκη"
 msgid "Download-Speed"
 msgstr "Ταχύτητα κατεβάσματος"
 
-#: src/muuli_wdr.cpp:954 src/muuli_wdr.cpp:989 src/muuli_wdr.cpp:2574
+#: src/muuli_wdr.cpp:954 src/muuli_wdr.cpp:989 src/muuli_wdr.cpp:2546
 msgid "Current"
 msgstr "Τρέχων"
 
-#: src/muuli_wdr.cpp:962 src/muuli_wdr.cpp:997 src/muuli_wdr.cpp:2582
+#: src/muuli_wdr.cpp:962 src/muuli_wdr.cpp:997 src/muuli_wdr.cpp:2554
 msgid "Running average"
 msgstr "Μέσο τρεξίματος"
 
-#: src/muuli_wdr.cpp:970 src/muuli_wdr.cpp:1005 src/muuli_wdr.cpp:2590
+#: src/muuli_wdr.cpp:970 src/muuli_wdr.cpp:1005 src/muuli_wdr.cpp:2562
 msgid "Session average"
 msgstr "Μέσο περιόδου"
 
@@ -3730,7 +3720,7 @@ msgstr "Ταχύτητα ανεβάσματος"
 msgid "Connections"
 msgstr "Συνδέσεις"
 
-#: src/muuli_wdr.cpp:1024 src/muuli_wdr.cpp:1861
+#: src/muuli_wdr.cpp:1024 src/muuli_wdr.cpp:1860
 msgid "Active downloads"
 msgstr "Ενεργά κατεβάσματα"
 
@@ -3738,7 +3728,7 @@ msgstr "Ενεργά κατεβάσματα"
 msgid "Active connections (1:1)"
 msgstr "Ενεργές συνδέσεις (1:1)"
 
-#: src/muuli_wdr.cpp:1040 src/muuli_wdr.cpp:1862
+#: src/muuli_wdr.cpp:1040 src/muuli_wdr.cpp:1861
 msgid "Active uploads"
 msgstr "Ενεργά ανεβάσματα"
 
@@ -3855,8 +3845,8 @@ msgstr "Αυτό είναι το όνομα που οι άλλοι χρήστε�
 msgid "Language: "
 msgstr "Γλώσσα:"
 
-#: src/muuli_wdr.cpp:1257 src/muuli_wdr.cpp:1330 src/muuli_wdr.cpp:1334
-#: src/muuli_wdr.cpp:1337
+#: src/muuli_wdr.cpp:1257 src/muuli_wdr.cpp:1323 src/muuli_wdr.cpp:1327
+#: src/muuli_wdr.cpp:1330
 msgid "The delay before showing tool-tips."
 msgstr "Ο χρόνος πριν εμφανιστεί το επεξηγηματικό κείμενο."
 
@@ -3934,965 +3924,941 @@ msgstr ""
 msgid "Enabling this will make aMule to show notifications when finished downloading."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1323
-#, fuzzy
-msgid "Remember search history"
-msgstr "Απομνημόνευση αυτών των ρυθμίσεων"
-
-#: src/muuli_wdr.cpp:1324
-msgid "Keeps a dropdown list of your past search terms in the Search tab's Name field. This remembers the queries you typed, not the results they returned."
-msgstr ""
-
-#: src/muuli_wdr.cpp:1329
+#: src/muuli_wdr.cpp:1322
 msgid "Tooltip delay time: "
 msgstr "Χρόνος καθυστέρησης επεξηγήσεων:"
 
-#: src/muuli_wdr.cpp:1336
+#: src/muuli_wdr.cpp:1329
 msgid "seconds"
 msgstr "δεπτερόλεπτα"
 
-#: src/muuli_wdr.cpp:1340
+#: src/muuli_wdr.cpp:1333
 msgid "Browser Selection"
 msgstr "Επιλογή περιηγητή ιστοσελίδων"
 
-#: src/muuli_wdr.cpp:1346
+#: src/muuli_wdr.cpp:1339
 msgid "Enter your browser name here. Leave this field empty to use the system default browser."
 msgstr "Εισάγετε το όνομα το περιηγητή ιστολελίδων. Αφήστε αυτό το πεδίο κενό για τον προεπιλεγμένο περιηγητή."
 
-#: src/muuli_wdr.cpp:1353
+#: src/muuli_wdr.cpp:1346
 msgid "Open in new tab if possible"
 msgstr "Αν είναι δυνατόν, άνοιξε τη σελίδα σε καινούρια καρτέλα"
 
-#: src/muuli_wdr.cpp:1355
+#: src/muuli_wdr.cpp:1348
 msgid "Open the web page in a new tab instead of in a new window when possible"
 msgstr "Άνοιξε την ιστοσελίδα σε καινούρια καρτέλα αντί σε καινούριο παράθυρο αν αυτό είναι εφικτό"
 
-#: src/muuli_wdr.cpp:1359
+#: src/muuli_wdr.cpp:1352
 msgid "Video Player"
 msgstr "Πρόγραμμα προβολής βίντεο"
 
-#: src/muuli_wdr.cpp:1386
+#: src/muuli_wdr.cpp:1379
 msgid "Bandwidth limits"
 msgstr "Ευρυζωνικά όρια"
 
-#: src/muuli_wdr.cpp:1400
+#: src/muuli_wdr.cpp:1393
 msgid "Upload"
 msgstr "Ανέβασμα"
 
-#: src/muuli_wdr.cpp:1408
+#: src/muuli_wdr.cpp:1401
 msgid "Slot Allocation"
 msgstr "Ανάθεση θυρίδας"
 
-#: src/muuli_wdr.cpp:1417
+#: src/muuli_wdr.cpp:1410
 msgid "Ports"
 msgstr "Θύρες"
 
-#: src/muuli_wdr.cpp:1427
+#: src/muuli_wdr.cpp:1420
 msgid "This is the standard eD2k port and cannot be disabled."
 msgstr "Αυτή είναι η βασική θύρα eD2k και δεν μπορεί να απενεργοποιηθεί."
 
-#: src/muuli_wdr.cpp:1430
+#: src/muuli_wdr.cpp:1423
 msgid "UDP port for server requests (TCP+3):"
 msgstr "Θύρα UDP για αιτήσεις εξυπηρετητή (TCP+3):"
 
-#: src/muuli_wdr.cpp:1432
+#: src/muuli_wdr.cpp:1425
 msgid "4665"
 msgstr "4665"
 
-#: src/muuli_wdr.cpp:1439
+#: src/muuli_wdr.cpp:1432
 msgid "This UDP port is used for extended eD2k requests and Kad network"
 msgstr "Αυτή η θύρα UDP χρησιμοποιήται για εκτεταμένες αιτήσεις eD2k και για το δίκτυο Kad"
 
-#: src/muuli_wdr.cpp:1446
+#: src/muuli_wdr.cpp:1439
 msgid "UPnP TCP Port (Optional):"
 msgstr "Θύρα UPnP TCP (Προαιρετική):"
 
-#: src/muuli_wdr.cpp:1456
+#: src/muuli_wdr.cpp:1449
 msgid "Bind local address to IP (empty for any):"
 msgstr "Συνέδεσε την τοπική διεύθυνση στην διεύθυνση (κενό για όλες):"
 
-#: src/muuli_wdr.cpp:1459
+#: src/muuli_wdr.cpp:1452
 msgid "Advanced users only: If you have multiple network interfaces, enter the address of the interface to which aMule should be bound."
 msgstr "Μόνο για προχωρημένους χρήστες: Αν έχετε πολλαπλά δικτυακά περιβάλλοντα, εισάγετε την διεύθυνση του περιβάλλοντος με το οποίο το aMule πρέπει να συνδεθεί."
 
-#: src/muuli_wdr.cpp:1462 src/muuli_wdr.cpp:2055
+#: src/muuli_wdr.cpp:1455 src/muuli_wdr.cpp:2054
 #, fuzzy
 msgid "Bind to network interface (empty for any):"
 msgstr "Συνέδεσε την τοπική διεύθυνση στην διεύθυνση (κενό για όλες):"
 
-#: src/muuli_wdr.cpp:1475
+#: src/muuli_wdr.cpp:1468
 msgid "Advanced users only: pin all of aMule's traffic to one network interface, chosen from the list or typed in by name (e.g. tun0, eth0, en0) or index. Unlike binding to an IP, this stops traffic leaking out via the default route - useful with a VPN. Requires no elevated privileges."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1481
+#: src/muuli_wdr.cpp:1474
 msgid "Max sources per downloading file:"
 msgstr "Μέγιστος αριθμός πηγών ανά εισερχόμενο αρχείο:"
 
-#: src/muuli_wdr.cpp:1485
+#: src/muuli_wdr.cpp:1478
 msgid "Max simultaneous connections:"
 msgstr "Μέγιστος αριθμός παράλληλων συνδέσεων:"
 
-#: src/muuli_wdr.cpp:1498 src/muuli_wdr.cpp:3197
+#: src/muuli_wdr.cpp:1491 src/muuli_wdr.cpp:3169
 msgid "ED2K"
 msgstr "ED2K"
 
-#: src/muuli_wdr.cpp:1505
+#: src/muuli_wdr.cpp:1498
 msgid "Autoconnect on startup"
 msgstr "Αυτόματη σύνδεση κατά την εκκίνηση"
 
-#: src/muuli_wdr.cpp:1508
+#: src/muuli_wdr.cpp:1501
 msgid "Reconnect on loss"
 msgstr "Επανασύνδεση σε περίπτωση διακοπής"
 
-#: src/muuli_wdr.cpp:1530
+#: src/muuli_wdr.cpp:1523
 msgid "Remove dead server after"
 msgstr "Αφαίρεση του νεκρού διακομιστή ύστερα από"
 
-#: src/muuli_wdr.cpp:1531
+#: src/muuli_wdr.cpp:1524
 msgid "Static servers are never removed, even when unreachable."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1535
+#: src/muuli_wdr.cpp:1528
 msgid "retries"
 msgstr "προσπάθειες"
 
-#: src/muuli_wdr.cpp:1543
+#: src/muuli_wdr.cpp:1536
 msgid "List"
 msgstr "Λίστα"
 
-#: src/muuli_wdr.cpp:1546
+#: src/muuli_wdr.cpp:1539
 msgid "Update server list when connecting to a server"
 msgstr "Ενημέρωση της λίστας διακομιστών κατά τη σύνδεση σε διακομιστή"
 
-#: src/muuli_wdr.cpp:1549
+#: src/muuli_wdr.cpp:1542
 msgid "Update server list when a client connects"
 msgstr "Ενημέρωση της λίστας διακομιστών κατά τη σύνδεση σε πελάτη"
 
-#: src/muuli_wdr.cpp:1552
+#: src/muuli_wdr.cpp:1545
 msgid "Use priority system"
 msgstr "Χρήση συστήματος προτεραιότητα"
 
-#: src/muuli_wdr.cpp:1556
+#: src/muuli_wdr.cpp:1549
 msgid "Use smart LowID check on connect"
 msgstr "Χρήση έξυπνου ελέγχου LowID κατά τη σύνδεση"
 
-#: src/muuli_wdr.cpp:1560
+#: src/muuli_wdr.cpp:1553
 msgid "Safe connect"
 msgstr "Ασφαλής σύνδεση"
 
-#: src/muuli_wdr.cpp:1564
+#: src/muuli_wdr.cpp:1557
 msgid "Autoconnect to servers in static list only"
 msgstr "Αυτόματη σύνδεση μόνο με τους διακομιστές της στατικής λίστας"
 
-#: src/muuli_wdr.cpp:1567
+#: src/muuli_wdr.cpp:1560
 msgid "Set manually added servers to High Priority"
 msgstr "Υψηλή προτεραιότητα στους διακομιστές που προστέθηκαν με το χέρι"
 
-#: src/muuli_wdr.cpp:1588
+#: src/muuli_wdr.cpp:1581
 msgid "Add files to download in pause mode"
 msgstr "Προσθήκη αρχείων προς κατέβασμα κατά τη διάρκεια παύσης"
 
-#: src/muuli_wdr.cpp:1590
+#: src/muuli_wdr.cpp:1583
 msgid "Add files to download with auto priority"
 msgstr "Προσθήκη αρχείων προς κατέβασμα με αυτόματη προτεραιότητα"
 
-#: src/muuli_wdr.cpp:1593
+#: src/muuli_wdr.cpp:1586
 msgid "Try to download first and last chunks first"
 msgstr "Προσπάθησε να κατεβάσεις πρώτα τα αρχικά και τελικά κομμάτια"
 
-#: src/muuli_wdr.cpp:1597
+#: src/muuli_wdr.cpp:1590
 msgid "Endgame mode: rotate to faster sources for the final blocks"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1600
+#: src/muuli_wdr.cpp:1593
 msgid "Start next paused file when a file completes"
 msgstr "Εκκίνηση του επόμενου σταματημένου αρχείου όταν ένα αρχείο ολοκληρωθεί"
 
-#: src/muuli_wdr.cpp:1603
+#: src/muuli_wdr.cpp:1596
 msgid "From the same category"
 msgstr "Από την ίδια κατηγορία"
 
-#: src/muuli_wdr.cpp:1605
+#: src/muuli_wdr.cpp:1598
 msgid "In alphabetic order"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1607
+#: src/muuli_wdr.cpp:1600
 msgid "Preallocate disk space for new files"
 msgstr "Δέσμευση χώρου στο δίσκο για καινούρια αρχεία"
 
-#: src/muuli_wdr.cpp:1608
+#: src/muuli_wdr.cpp:1601
 msgid "For new files preallocates disk space for the whole file, thus reduces fragmentation"
 msgstr "Δεσμεύει χώρο στο δίσκο για καινούρια αρχεία και έτσι μειώνει τον κατακερματισμό"
 
-#: src/muuli_wdr.cpp:1613
+#: src/muuli_wdr.cpp:1606
+msgid "Create new files as sparse files"
+msgstr ""
+
+#: src/muuli_wdr.cpp:1607
+msgid "A sparse file reserves its full size on disk immediately without writing real data to it -- fast, but unsupported or slow on some filesystems, and free-space accounting stays optimistic while the download is in progress. Turn this off to grow the file only as data arrives."
+msgstr ""
+
+#: src/muuli_wdr.cpp:1612
 msgid "Stop downloads when free disk space reaches "
 msgstr "Σταμάτημα του κατεβάσματος όταν ο ελεύθερος δίσκος φτάσει τα"
 
-#: src/muuli_wdr.cpp:1614
+#: src/muuli_wdr.cpp:1613
 msgid "Select this if you want aMule to check your disk space"
 msgstr "Επιλέξτε αυτό αν θέλετε το aMule να ελέγξει τον χώρο στον δίσκο σας"
 
-#: src/muuli_wdr.cpp:1618
+#: src/muuli_wdr.cpp:1617
 msgid "Enter here the min disk space desired."
 msgstr "Γράψτε εδώ των ελάχιστο επιθυμητό χώρο στον δίσκο."
 
-#: src/muuli_wdr.cpp:1624
+#: src/muuli_wdr.cpp:1623
 msgid "Save 10 sources on rare files (< 20 sources)"
 msgstr "Αποθήκευση 10 πηγών σε σπάνια αρχεία (<20 πηγές)"
 
-#: src/muuli_wdr.cpp:1628 src/Statistics.cpp:790
+#: src/muuli_wdr.cpp:1627 src/Statistics.cpp:790
 msgid "Uploads"
 msgstr "Ανεβασμένα"
 
-#: src/muuli_wdr.cpp:1631
+#: src/muuli_wdr.cpp:1630
 msgid "Add new shared files with auto priority"
 msgstr "Προσθήκη νέων κοινόχρηστων αρχείων με αυτόματη προτεραιότητα"
 
-#: src/muuli_wdr.cpp:1637
+#: src/muuli_wdr.cpp:1636
 msgid "Intelligent Corruption Handling (I.C.H.)"
 msgstr "Έξυπνη διαχείριση φθοράς (Ε.Δ.Φ.)"
 
-#: src/muuli_wdr.cpp:1640
+#: src/muuli_wdr.cpp:1639
 msgid "Enable"
 msgstr "Ενεργοποιήση"
 
-#: src/muuli_wdr.cpp:1643
+#: src/muuli_wdr.cpp:1642
 msgid "Advanced I.C.H. trusts every hash (not recommended)"
 msgstr "Προχωρημένη Ε.Δ.Φ. εμπιστεύεται κάθε κατακερματισμό (δεν συνιστάται)"
 
-#: src/muuli_wdr.cpp:1655 src/PrefsUnifiedDlg.cpp:1990
+#: src/muuli_wdr.cpp:1654 src/PrefsUnifiedDlg.cpp:1910
 msgid "Media metadata extraction"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1659
+#: src/muuli_wdr.cpp:1658
 msgid "Extract length / bitrate / codec from shared audio and video files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1661
+#: src/muuli_wdr.cpp:1660
 msgid "When enabled, aMule runs ffprobe on each shared media file to fill in the Length / Bitrate / Codec columns other clients see when they find the file in a search. Requires ffmpeg (the ffprobe binary) to be installed."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1668
+#: src/muuli_wdr.cpp:1667
 msgid "Path to ffprobe:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1673
+#: src/muuli_wdr.cpp:1672
 msgid "Full path to the ffprobe binary. Leave empty to have aMule auto-detect it on startup."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1681
+#: src/muuli_wdr.cpp:1680
 msgid "Detect"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1682
+#: src/muuli_wdr.cpp:1681
 msgid "Search the standard install locations for an ffprobe binary and fill the path field."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1706
+#: src/muuli_wdr.cpp:1705
 msgid ""
 "Completed downloads are stored here. All files in this folder are automatically shared with other peers.\n"
 "If this folder also holds files you don't want to share, point it at an aMule-only sub-folder."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1709
+#: src/muuli_wdr.cpp:1708
 msgid "Pick the folder where completed downloads will be stored. All files in that folder will be shared with other peers."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1723
+#: src/muuli_wdr.cpp:1722
 msgid "Shared folders"
 msgstr "Κοινόχρηστα αρχεία"
 
-#: src/muuli_wdr.cpp:1729
+#: src/muuli_wdr.cpp:1728
 msgid "(Folders shared by the core. Enter a path to add one.)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1737
+#: src/muuli_wdr.cpp:1736
 msgid "Absolute path of a folder on the core's machine, e.g. /home/user/shared"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1739 src/PrefsUnifiedDlg.cpp:2874
+#: src/muuli_wdr.cpp:1738 src/PrefsUnifiedDlg.cpp:2794
 msgid "Recursive"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1740
+#: src/muuli_wdr.cpp:1739
 msgid "Share every sub-folder underneath this one, including ones created later."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1744 src/utils/aLinkCreator/src/alcframe.cpp:141
+#: src/muuli_wdr.cpp:1743 src/utils/aLinkCreator/src/alcframe.cpp:141
 msgid "Remove"
 msgstr "Αφαίρεση"
 
-#: src/muuli_wdr.cpp:1748
+#: src/muuli_wdr.cpp:1747
 msgid "(Right click on folder icon for recursive share)"
 msgstr "(Δεξί κλικ στην εικόνα του καταλόγου για να γίνουν κοινόχρηστοι οι υποκατάλογοι)"
 
-#: src/muuli_wdr.cpp:1755
+#: src/muuli_wdr.cpp:1754
 msgid "Share hidden files"
 msgstr "Κάνε τα κρυφά αρχεία κοινόχρηστα"
 
-#: src/muuli_wdr.cpp:1761
+#: src/muuli_wdr.cpp:1760
 msgid "Automatically rescan shared folders for changes"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1767
+#: src/muuli_wdr.cpp:1766
 msgid "Follow symbolic links in shared folders"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1773
+#: src/muuli_wdr.cpp:1772
 msgid "Exclude files matching:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1776
+#: src/muuli_wdr.cpp:1775
 msgid "Wildcard patterns separated by '|', e.g. .DS_Store|Thumbs.db|*.tmp. Files whose name matches are not shared. Matching is case-insensitive."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1780
+#: src/muuli_wdr.cpp:1779
 msgid "Patterns are regular expressions"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1781
+#: src/muuli_wdr.cpp:1780
 msgid "When set, the whole field is one regular expression ('|' is alternation). When unset, it is a list of '|'-separated wildcards."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1791
+#: src/muuli_wdr.cpp:1790
 msgid "Show how many shared files the current pattern would exclude."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1812
+#: src/muuli_wdr.cpp:1811
 msgid "Graphs"
 msgstr "Γραφικές Παραστάσεις"
 
-#: src/muuli_wdr.cpp:1815 src/muuli_wdr.cpp:1877
+#: src/muuli_wdr.cpp:1814 src/muuli_wdr.cpp:1876
 msgid "Update delay : 5 secs"
 msgstr "Χρόνος καθυστέρηση ενημέρωσης : 5 δευτερόλεπτα"
 
-#: src/muuli_wdr.cpp:1819
+#: src/muuli_wdr.cpp:1818
 msgid "Time for average graph: 100 mins"
 msgstr "Χρόνος μέσου γραφήματος: 100 λεπτά"
 
-#: src/muuli_wdr.cpp:1823
+#: src/muuli_wdr.cpp:1822
 msgid "Connections Graph Scale: 100 "
 msgstr "Κλίμακα διαγράμματος συνδέσεων: 100"
 
-#: src/muuli_wdr.cpp:1830
+#: src/muuli_wdr.cpp:1829
 msgid "Download graph scale:"
 msgstr "Κλιματα του γραφήματος εισερχομένων:"
 
-#: src/muuli_wdr.cpp:1838
+#: src/muuli_wdr.cpp:1837
 msgid "Upload graph scale:"
 msgstr "Κλιμακα του γραφήματος εξερχομένων"
 
-#: src/muuli_wdr.cpp:1848
+#: src/muuli_wdr.cpp:1847
 #, fuzzy
 msgid "Colors: "
 msgstr "Χρώματα:"
 
-#: src/muuli_wdr.cpp:1852
+#: src/muuli_wdr.cpp:1851
 msgid "Background"
 msgstr "Υπόβαθρο"
 
-#: src/muuli_wdr.cpp:1853
+#: src/muuli_wdr.cpp:1852
 msgid "Grid"
 msgstr "Πλέγμα"
 
-#: src/muuli_wdr.cpp:1854
+#: src/muuli_wdr.cpp:1853
 msgid "Download current"
 msgstr "Κατέβασμα του τρέχοντος"
 
-#: src/muuli_wdr.cpp:1855
+#: src/muuli_wdr.cpp:1854
 msgid "Download running average"
 msgstr "Μέσο τρέξιμο κατεβάσματος"
 
-#: src/muuli_wdr.cpp:1856
+#: src/muuli_wdr.cpp:1855
 msgid "Download session average"
 msgstr "Μέσο συνεδρίας κατεβάσματος"
 
-#: src/muuli_wdr.cpp:1857
+#: src/muuli_wdr.cpp:1856
 msgid "Upload current"
 msgstr "Ανέβασμα του τρέχοντος"
 
-#: src/muuli_wdr.cpp:1858
+#: src/muuli_wdr.cpp:1857
 msgid "Upload running average"
 msgstr "Μέσο τρέξιμο ανεβάσματος"
 
-#: src/muuli_wdr.cpp:1859
+#: src/muuli_wdr.cpp:1858
 msgid "Upload session average"
 msgstr "Μέσο συνεδρίας ανεβάσματος"
 
-#: src/muuli_wdr.cpp:1860
+#: src/muuli_wdr.cpp:1859
 msgid "Active connections"
 msgstr "Ενεργές συνδέσεις"
 
-#: src/muuli_wdr.cpp:1863
+#: src/muuli_wdr.cpp:1862
 #, fuzzy
 msgid "Systray Icon Speed Bar"
 msgstr "Εικόνα για την μπάρα ταχείας πρόσβασης του Systray"
 
-#: src/muuli_wdr.cpp:1864
+#: src/muuli_wdr.cpp:1863
 msgid "Kad-nodes current"
 msgstr "Σύνδεσμοι-Kad παρόντες"
 
-#: src/muuli_wdr.cpp:1865
+#: src/muuli_wdr.cpp:1864
 msgid "Kad-nodes running"
 msgstr "Σύνδεσμοι-Kad τρέχοντες"
 
-#: src/muuli_wdr.cpp:1866
+#: src/muuli_wdr.cpp:1865
 msgid "Kad-nodes session"
 msgstr "Σύνδεσμοι-Kad συνεδρία"
 
-#: src/muuli_wdr.cpp:1870 src/muuli_wdr.cpp:2324
+#: src/muuli_wdr.cpp:1869 src/muuli_wdr.cpp:2296
 msgid "Select"
 msgstr "Επέλεξε"
 
-#: src/muuli_wdr.cpp:1874
+#: src/muuli_wdr.cpp:1873
 msgid "Tree"
 msgstr "Δέντρο"
 
-#: src/muuli_wdr.cpp:1884
+#: src/muuli_wdr.cpp:1883
 msgid "Number of Client Versions shown (0=unlimited)"
 msgstr "Αριθμός των εμφανιζόμενων εκδόσεων πελάτη (0=απεριόριστος)"
 
-#: src/muuli_wdr.cpp:1909
+#: src/muuli_wdr.cpp:1908
 msgid "!!! WARNING !!!"
 msgstr "!!! Προειδοποίηση !!!"
 
-#: src/muuli_wdr.cpp:1924
+#: src/muuli_wdr.cpp:1923
 msgid "Max new connections / 5 secs"
 msgstr "Μέγιστος αρ. νέων συνδέσεων /5 δευτερόλεπτα"
 
-#: src/muuli_wdr.cpp:1926
+#: src/muuli_wdr.cpp:1925
 msgid "Concurrent Kad source lookups"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1928
+#: src/muuli_wdr.cpp:1927
 #, fuzzy
 msgid "Kad source re-search interval (minutes)"
 msgstr "Περίοδος ενημέρωσης του FTP σε λεπτά"
 
-#: src/muuli_wdr.cpp:1930
+#: src/muuli_wdr.cpp:1929
 #, fuzzy
 msgid "Source re-ask interval (minutes)"
 msgstr "Περίοδος ενημέρωσης του FTP σε λεπτά"
 
-#: src/muuli_wdr.cpp:1934
+#: src/muuli_wdr.cpp:1933
 msgid "File Buffer Size: 240000 bytes"
 msgstr "Χώρος προσωρινής αποθήκευσης αρχείου: 240000 bytes"
 
-#: src/muuli_wdr.cpp:1938
+#: src/muuli_wdr.cpp:1937
 msgid "Use MMAP: memory-mapped file access (lower memory use)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1939
+#: src/muuli_wdr.cpp:1938
 msgid "Maps part files into memory instead of buffering them on the heap, lowering the process memory footprint. May reduce download speed on some disks; best for memory-constrained or upload-heavy hosts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1941
+#: src/muuli_wdr.cpp:1940
 msgid "Upload Queue Size: 5000 clients"
 msgstr "Λίστα αναμονής ανεβάσματος: 5000 πελάτες"
 
-#: src/muuli_wdr.cpp:1945
+#: src/muuli_wdr.cpp:1944
 msgid "Server connection refresh interval: Disable"
 msgstr "Διάστημα ανανέωσης της σύνδεσης σε διακομιστή: Απενεργοποίηση"
 
-#: src/muuli_wdr.cpp:1949
+#: src/muuli_wdr.cpp:1948
 msgid "Disable computer's timed standby mode"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1968
+#: src/muuli_wdr.cpp:1967
 msgid "Skin to use: "
 msgstr "Θέμα:"
 
-#: src/muuli_wdr.cpp:1977
+#: src/muuli_wdr.cpp:1976
 msgid "Show \"Fast eD2k Links Handler\" in every window."
 msgstr "Εμφάνιση \"Γρήγορου διαχειριστή συνδέσμων eD2k\" σε όλα τα παράθυρα."
 
-#: src/muuli_wdr.cpp:1980
+#: src/muuli_wdr.cpp:1979
 msgid "Show extended info on categories tabs"
 msgstr "Εμφάνιση εκτεταμένων πληροφοριών στην καρτέλα κατηγοριών"
 
-#: src/muuli_wdr.cpp:1983
+#: src/muuli_wdr.cpp:1982
 #, fuzzy
 msgid "Show application version on title"
 msgstr "Εμφάνιση των ταχυτήτων μεταφοράς στον τίτλο"
 
-#: src/muuli_wdr.cpp:1985
+#: src/muuli_wdr.cpp:1984
 msgid "Show transfer rates on title"
 msgstr "Εμφάνιση των ταχυτήτων μεταφοράς στον τίτλο"
 
-#: src/muuli_wdr.cpp:1987
+#: src/muuli_wdr.cpp:1986
 msgid "Before application name"
 msgstr "Πριν απο το όνομα της εφαρμογής"
 
-#: src/muuli_wdr.cpp:1989
+#: src/muuli_wdr.cpp:1988
 msgid "After application name"
 msgstr "Μετά το όνομα της εφαρμογής"
 
-#: src/muuli_wdr.cpp:1992
+#: src/muuli_wdr.cpp:1991
 msgid "Show overhead bandwidth"
 msgstr "Εμφάνιση επιβάρυνσης στο εύρος ζώνης"
 
-#: src/muuli_wdr.cpp:1996
+#: src/muuli_wdr.cpp:1995
 msgid "Vertical toolbar orientation"
 msgstr "Κατακόρυφος προσανατολισμός της γραμμής εντολών"
 
-#: src/muuli_wdr.cpp:1998
+#: src/muuli_wdr.cpp:1997
 msgid "Live column sorting (auto-reorder rows as their values change)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2005
+#: src/muuli_wdr.cpp:2004
 msgid "Download Queue Files"
 msgstr "Ουρά εισερχομένων αρχείων"
 
-#: src/muuli_wdr.cpp:2008
+#: src/muuli_wdr.cpp:2007
 msgid "Show progress percentage"
 msgstr "Εμφάνιση ποσοστού προόδου"
 
-#: src/muuli_wdr.cpp:2014
+#: src/muuli_wdr.cpp:2013
 msgid "Show progress bar"
 msgstr "Εμφάνιση μπάρας προόδου"
 
-#: src/muuli_wdr.cpp:2017
+#: src/muuli_wdr.cpp:2016
 msgid "Flat"
 msgstr "Επίπεδη"
 
-#: src/muuli_wdr.cpp:2021
+#: src/muuli_wdr.cpp:2020
 msgid "Round"
 msgstr "Στρογγυλή"
 
-#: src/muuli_wdr.cpp:2039
+#: src/muuli_wdr.cpp:2038
 msgid "External Connection Parameters"
 msgstr "Παράμετροι εξωτερικών συνδέσεων"
 
-#: src/muuli_wdr.cpp:2042
+#: src/muuli_wdr.cpp:2041
 msgid "Accept external connections"
 msgstr "Να γίνονται αποδεκτές οι εξωτερικές συνδέσεις"
 
-#: src/muuli_wdr.cpp:2049 src/muuli_wdr.cpp:2108
+#: src/muuli_wdr.cpp:2048 src/muuli_wdr.cpp:2107
 msgid "IP of the listening interface:"
 msgstr "Η διεύθυνση του εισακούοντος περιβάλλοντος:"
 
-#: src/muuli_wdr.cpp:2052
+#: src/muuli_wdr.cpp:2051
 msgid "Enter here a valid ip in the a.b.c.d format for the listening EC interface. An empty field or 0.0.0.0 will mean any interface."
 msgstr "Εισάγετε μία έγκυρη διεύθυνση με φόρμα a.b.c.d για σύνδεση με το περιβάλλον EC. Άδειο πεδίου ή 0.0.0.0 συμβολίζει όλα τα περιβάλλοντα."
 
-#: src/muuli_wdr.cpp:2073 src/muuli_wdr.cpp:2184
+#: src/muuli_wdr.cpp:2072 src/muuli_wdr.cpp:2156
 msgid "TCP port:"
 msgstr "Θύρα TCP:"
 
-#: src/muuli_wdr.cpp:2079
+#: src/muuli_wdr.cpp:2078
 msgid "Enable UPnP port forwarding on the EC port"
 msgstr "Ενεργοποίηση της προώθησης της θύρας UPnP στην θύρα EC"
 
-#: src/muuli_wdr.cpp:2083 src/muuli_wdr.cpp:3069
+#: src/muuli_wdr.cpp:2082 src/muuli_wdr.cpp:3041
 #: src/utils/wxCas/src/wxcasprefs.cpp:167
 msgid "Password"
 msgstr "Κωδικός"
 
-#: src/muuli_wdr.cpp:2089
+#: src/muuli_wdr.cpp:2088
 #, fuzzy
 msgid "aMule API server parameters"
 msgstr "Παράμετροι διακομιστή ιστού"
 
-#: src/muuli_wdr.cpp:2092
+#: src/muuli_wdr.cpp:2091
 msgid "Run amuleapi (REST API) on startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2097
+#: src/muuli_wdr.cpp:2096
 #, fuzzy
 msgid "HTTP port:"
 msgstr "Θύρα TCP:"
 
-#: src/muuli_wdr.cpp:2111
+#: src/muuli_wdr.cpp:2110
 msgid "The interface amuleapi's HTTP server listens on. 127.0.0.1 (default) accepts only local connections; use 0.0.0.0 or a specific IP to expose it to other hosts (set an admin password below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2116
-msgid "Type a password to set or change it. Stored passwords cannot be shown, so leaving this empty keeps the current one."
-msgstr ""
-
-#: src/muuli_wdr.cpp:2118
+#: src/muuli_wdr.cpp:2113
 #, fuzzy
 msgid "Admin password"
 msgstr "Έλεγχος κωδικού\n"
 
-#: src/muuli_wdr.cpp:2130 src/muuli_wdr.cpp:2147 src/PrefsUnifiedDlg.cpp:1103
-#, fuzzy
-msgid "A password is set."
-msgstr "Έλεγχος κωδικού\n"
+#: src/muuli_wdr.cpp:2118 src/muuli_wdr.cpp:2149
+msgid "Low rights password"
+msgstr "Κωδικός μειωμένων δικαιωμάτων"
 
-#: src/muuli_wdr.cpp:2134
-#, fuzzy
-msgid "Enable guest access"
-msgstr "Να απαγορεύεται η πρόσβαση σε επισκέπτες"
-
-#: src/muuli_wdr.cpp:2135
-msgid "Guest sessions may read status and listings but cannot change anything. Turning this off clears the stored guest password."
-msgstr ""
-
-#: src/muuli_wdr.cpp:2139
-#, fuzzy
-msgid "Guest password"
-msgstr "Κωδικός επισκέπτη για τον διακομιστή ιστού"
-
-#: src/muuli_wdr.cpp:2154
+#: src/muuli_wdr.cpp:2126
 msgid "Web server parameters"
 msgstr "Παράμετροι διακομιστή ιστού"
 
-#: src/muuli_wdr.cpp:2157
+#: src/muuli_wdr.cpp:2129
 #, fuzzy
 msgid "Run webserver on startup (deprecated)"
 msgstr "Έναρξη του εξυπηρετητή ιστού κατά την εκκίνηση"
 
-#: src/muuli_wdr.cpp:2163
+#: src/muuli_wdr.cpp:2135
 msgid "Web template"
 msgstr "Πρότυπη σελίδα"
 
-#: src/muuli_wdr.cpp:2168
+#: src/muuli_wdr.cpp:2140
 msgid "Full rights password"
 msgstr "Κωδικός πλήρων δικαιωμάτων"
 
-#: src/muuli_wdr.cpp:2172
+#: src/muuli_wdr.cpp:2144
 msgid "Enable Low rights User"
 msgstr "Ενεργοποίηση χρήστη μειωμένων δικαιωμάτων"
 
-#: src/muuli_wdr.cpp:2177
-msgid "Low rights password"
-msgstr "Κωδικός μειωμένων δικαιωμάτων"
-
-#: src/muuli_wdr.cpp:2191
+#: src/muuli_wdr.cpp:2163
 msgid "Enable UPnP port forwarding of the web server port"
 msgstr "Ενεργοποίηση της προώθησης της θύρας του εξηπηρετητή ιστού στη θύρα UPnP"
 
-#: src/muuli_wdr.cpp:2196
+#: src/muuli_wdr.cpp:2168
 msgid "Web server UPnP TCP port (Optional)"
 msgstr "Θύρα UPnP TCP του εξυπηρετητή (Προαιρετική)"
 
-#: src/muuli_wdr.cpp:2204
+#: src/muuli_wdr.cpp:2176
 msgid "Page Refresh Time (in secs)"
 msgstr "Χρόνος ανανέωσης σελίδας (σε δευτερόλεπτα)"
 
-#: src/muuli_wdr.cpp:2211
+#: src/muuli_wdr.cpp:2183
 msgid "Enable Gzip compression"
 msgstr "Ενεργοποίηση συμπίεσης Gzip"
 
-#: src/muuli_wdr.cpp:2245
+#: src/muuli_wdr.cpp:2217
 #, fuzzy
 msgid "Reset page to defaults"
 msgstr "Εργοστασιακές ρυθμίσεις"
 
-#: src/muuli_wdr.cpp:2246
+#: src/muuli_wdr.cpp:2218
 msgid "Reset the settings on the current page to their default values."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2248 src/muuli_wdr.cpp:2334 src/ServerWnd.cpp:274
+#: src/muuli_wdr.cpp:2220 src/muuli_wdr.cpp:2306 src/ServerWnd.cpp:274
 #: src/ServerWnd.cpp:282
 msgid "OK"
 msgstr "Εντάξει"
 
-#: src/muuli_wdr.cpp:2250
+#: src/muuli_wdr.cpp:2222
 msgid "Click here to apply any changes made to the preferences."
 msgstr "Κλικ εδώ για εφαρμογή των αλλαγών που έγιναν στις προτιμήσεις."
 
-#: src/muuli_wdr.cpp:2253
+#: src/muuli_wdr.cpp:2225
 msgid "Reset any changes made to the preferences."
 msgstr "Επαναφορά κάθε αλλαγής που έγινε στις προτιμήσεις."
 
-#: src/muuli_wdr.cpp:2282
+#: src/muuli_wdr.cpp:2254
 msgid "Comment :"
 msgstr "Σχόλιο:"
 
-#: src/muuli_wdr.cpp:2289
+#: src/muuli_wdr.cpp:2261
 msgid "Incoming Dir :"
 msgstr "Κατάλογος εισερχομένων :"
 
-#: src/muuli_wdr.cpp:2298
+#: src/muuli_wdr.cpp:2270
 msgid "Change priority for new assigned files :"
 msgstr "Αλλαγή προτεραιότητας για τα νέα προσδιορισμένα αρχεία :"
 
-#: src/muuli_wdr.cpp:2302
+#: src/muuli_wdr.cpp:2274
 #, fuzzy
 msgid "Don't change"
 msgstr "Να μην αλλάξει"
 
-#: src/muuli_wdr.cpp:2314
+#: src/muuli_wdr.cpp:2286
 msgid "Select color for this Category (currently selected) :"
 msgstr "Επιλογή χρώματος για τη συγκεκριμένη κατηγορία (τρέχουσα επιλογή) :"
 
-#: src/muuli_wdr.cpp:2381 src/muuli_wdr.cpp:2400 src/muuli_wdr.cpp:2422
+#: src/muuli_wdr.cpp:2353 src/muuli_wdr.cpp:2372 src/muuli_wdr.cpp:2394
 msgid "Click this button to reset the log."
 msgstr "Πατήστε αυτό το κουμπί για το καθάρισμα του αρχείου καταγραφής."
 
-#: src/muuli_wdr.cpp:2441
+#: src/muuli_wdr.cpp:2413
 msgid "Click on this button to update the servers list from URL ..."
 msgstr "Πατήστε αυτό το αρχείο για να ανανεώσετε την λίστα διακομιστών από την URL ..."
 
-#: src/muuli_wdr.cpp:2445
+#: src/muuli_wdr.cpp:2417
 msgid "Server list"
 msgstr "Λίστα διακομιστών"
 
-#: src/muuli_wdr.cpp:2449
+#: src/muuli_wdr.cpp:2421
 msgid "Enter the url to a server.met file here and press the button to the left to update the list of known servers."
 msgstr "Εισάγετε την url ενός αρχείου server.met και πατήστε το κουμπί στα αριστερά για να ανανεώσετε τη λίστα με τους γνωστούς διακομιστές"
 
-#: src/muuli_wdr.cpp:2454
+#: src/muuli_wdr.cpp:2426
 msgid "Add server manually: Name"
 msgstr "Προσθήκη διακομιστή: Όνομα"
 
-#: src/muuli_wdr.cpp:2457
+#: src/muuli_wdr.cpp:2429
 msgid "Enter the name of the new server here"
 msgstr "Γράψτε το όνομα του νέου διακομιστή εδώ"
 
-#: src/muuli_wdr.cpp:2459 src/ServerWnd.cpp:206
+#: src/muuli_wdr.cpp:2431 src/ServerWnd.cpp:206
 msgid "IP:Port"
 msgstr "Διεύθυνση:Θύρα"
 
-#: src/muuli_wdr.cpp:2462
+#: src/muuli_wdr.cpp:2434
 msgid "Enter the IP of the server here, using the x.x.x.x format."
 msgstr "Γράψτε την IP του διακομιστή εδώ, σε μορφή x.x.x.x"
 
-#: src/muuli_wdr.cpp:2468
+#: src/muuli_wdr.cpp:2440
 msgid "Enter the port of the server here."
 msgstr "Γράψτε την θύρα του διακομιστή εδώ."
 
-#: src/muuli_wdr.cpp:2471
+#: src/muuli_wdr.cpp:2443
 msgid "Add manually a server (fill fields to the left before) ..."
 msgstr "Βάλτε τον διακομιστή με το χέρι (γεμίστε πρώτα τα πεδία στα αριστερά) ..."
 
-#: src/muuli_wdr.cpp:2500
+#: src/muuli_wdr.cpp:2472
 msgid "aMule Log"
 msgstr "Αρχείο καταγραφής aMule"
 
-#: src/muuli_wdr.cpp:2508
+#: src/muuli_wdr.cpp:2480
 msgid "Server Info"
 msgstr "Πληροφορίες διακομιστή"
 
-#: src/muuli_wdr.cpp:2512
+#: src/muuli_wdr.cpp:2484
 msgid "ED2K Info"
 msgstr "Πληροφορίες ED2K"
 
-#: src/muuli_wdr.cpp:2516
+#: src/muuli_wdr.cpp:2488
 msgid "Kad Info"
 msgstr "Πληροφορίες Kad"
 
-#: src/muuli_wdr.cpp:2544
+#: src/muuli_wdr.cpp:2516
 msgid "Click on this button to update the nodes list from URL ..."
 msgstr "Πατήστε το κουμπί για να ανανεώσετε την λίστα των κόμβων από την URL ..."
 
-#: src/muuli_wdr.cpp:2548
+#: src/muuli_wdr.cpp:2520
 msgid "Nodes (0)"
 msgstr "Κόμβοι (0)"
 
-#: src/muuli_wdr.cpp:2552
+#: src/muuli_wdr.cpp:2524
 msgid "Enter the url to a nodes.dat file here and press the button to the left to update the list of known nodes."
 msgstr "Βάλτε εδώ την url ενός αρχείου nodes.dat και πατήστε το κουμπί στα αριστερά για να ανανεώσετε την λίστα των γνωστών κόμβων."
 
-#: src/muuli_wdr.cpp:2555
+#: src/muuli_wdr.cpp:2527
 msgid "Nodes stats"
 msgstr "Στατιστικές κόμβων"
 
-#: src/muuli_wdr.cpp:2597
+#: src/muuli_wdr.cpp:2569
 msgid "Bootstrap"
 msgstr "Εκκινητήρας"
 
-#: src/muuli_wdr.cpp:2600
+#: src/muuli_wdr.cpp:2572
 msgid "New node"
 msgstr "Καινούριος κόμβος"
 
-#: src/muuli_wdr.cpp:2605
+#: src/muuli_wdr.cpp:2577
 msgid "IP:"
 msgstr "IP:"
 
-#: src/muuli_wdr.cpp:2625
+#: src/muuli_wdr.cpp:2597
 msgid "Port:"
 msgstr "Θύρα:"
 
-#: src/muuli_wdr.cpp:2638
+#: src/muuli_wdr.cpp:2610
 #, fuzzy
 msgid "Bootstrap from known clients"
 msgstr ""
 "Εκκίνηση από\n"
 "γνωστούς πελάτες"
 
-#: src/muuli_wdr.cpp:2640
+#: src/muuli_wdr.cpp:2612
 msgid "Disconnect Kad"
 msgstr "Αποσυνδεδεμένο Kad"
 
-#: src/muuli_wdr.cpp:2674
+#: src/muuli_wdr.cpp:2646
 msgid "Use Secure User Identification"
 msgstr "Χρήση Ασφαλούς Ταυτοποίησης χρήστη"
 
-#: src/muuli_wdr.cpp:2676
+#: src/muuli_wdr.cpp:2648
 msgid "It is recommended to enable this option. You will not receive credits if SUI is not enabled."
 msgstr "Ενδείκνυται να ενεργοποιήσετε αυτήν την προτίμηση. Δεν θα λάβετε πίστωση αν το SUI δεν είναι ενεργοποιημένο."
 
-#: src/muuli_wdr.cpp:2678
+#: src/muuli_wdr.cpp:2650
 msgid "Protocol Obfuscation"
 msgstr "Συσκότιση πρωτοκόλλου"
 
-#: src/muuli_wdr.cpp:2681
+#: src/muuli_wdr.cpp:2653
 msgid "Support Protocol Obfuscation"
 msgstr "Υποστήριξη συσκότισης πρωτοκόλλου"
 
-#: src/muuli_wdr.cpp:2683
+#: src/muuli_wdr.cpp:2655
 msgid "This option enabled Protocol Obfuscation, and makes aMule accept obfuscated connections from other clients."
 msgstr "Αυτή η επιλογή ενεργοποίησε την συσκότιση πρωτοκόλλου και κάνει το aMule να δέχεται συσκοτισμένες συνδέσεις από άλλους πελάτες"
 
-#: src/muuli_wdr.cpp:2685
+#: src/muuli_wdr.cpp:2657
 msgid "Use obfuscation for outgoing connections"
 msgstr "Χρήση συσκότισης για εξωτερικές συνδέσεις"
 
-#: src/muuli_wdr.cpp:2687
+#: src/muuli_wdr.cpp:2659
 msgid "This option makes aMule use Protocol Obfuscation when connecting other clients/servers."
 msgstr "Αυτή η επιλογή κάνει το aMule να χρησιμοποιεί συσκότιση πρωτοκόλλου όταν συνδέεται σε άλλους πελάτες/διακομιστές."
 
-#: src/muuli_wdr.cpp:2689
+#: src/muuli_wdr.cpp:2661
 msgid "Accept only obfuscated connections"
 msgstr "Να γίνονται δεκτές μόνο συσκοτισμένες συνδέσεις"
 
-#: src/muuli_wdr.cpp:2690
+#: src/muuli_wdr.cpp:2662
 msgid "This option makes aMule only accept obfuscated connections. You will have less sources, but all your traffic will be obfuscated"
 msgstr "Αυτή η επιλογή κάνει το aMule να δέχεται μόνο συσκοτισμένες συνδέσεις. Θα υπάρχουν λιγότερες πηγές αλλά όλη η κυκλοφορία θα είναι συσκοτισμένη"
 
-#: src/muuli_wdr.cpp:2695
+#: src/muuli_wdr.cpp:2667
 msgid "Everybody"
 msgstr "Οι πάντες"
 
-#: src/muuli_wdr.cpp:2697
+#: src/muuli_wdr.cpp:2669
 msgid "No one"
 msgstr "Κανείς"
 
-#: src/muuli_wdr.cpp:2699
+#: src/muuli_wdr.cpp:2671
 msgid "Who can see my shared files:"
 msgstr "Ποίος μπορεί να δεί τα κοινόχρηστα αρχεία μου:"
 
-#: src/muuli_wdr.cpp:2700
+#: src/muuli_wdr.cpp:2672
 msgid "Select who can request to view a list of your shared files."
 msgstr "Επιλέξτε ποίος μπορεί να ζητήσει να δει τη λίστα με τα κοινόχρηστα αρχεία σας."
 
-#: src/muuli_wdr.cpp:2702
+#: src/muuli_wdr.cpp:2674
 msgid "IP-Filtering"
 msgstr "Φίλτρο IP"
 
-#: src/muuli_wdr.cpp:2709
+#: src/muuli_wdr.cpp:2681
 msgid "Filter clients"
 msgstr "Φιλτράρισμα πελατών"
 
-#: src/muuli_wdr.cpp:2711
+#: src/muuli_wdr.cpp:2683
 msgid "Enable filtering of the client IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "Ενεργοποίηση φίλτρου του IP των πελατών όπως ορίζεται στο ~/.aMule/ipfilter.dat."
 
-#: src/muuli_wdr.cpp:2713
+#: src/muuli_wdr.cpp:2685
 msgid "Filter servers"
 msgstr "Φιλτράρισμα διακομιστών"
 
-#: src/muuli_wdr.cpp:2715
+#: src/muuli_wdr.cpp:2687
 msgid "Enable filtering of the server IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "Ενεργοποίηση φίλτρου του IP των διακομιστών όπως ορίζεται στο ~/.aMule/ipfilter.dat."
 
-#: src/muuli_wdr.cpp:2719
+#: src/muuli_wdr.cpp:2691
 msgid "Reload List"
 msgstr "Επαναφόρτωση λίστας"
 
-#: src/muuli_wdr.cpp:2720
+#: src/muuli_wdr.cpp:2692
 msgid "Reload the list of IPs to filter from the file ~/.aMule/ipfilter.dat"
 msgstr "Επαναφόρτωση για φιλτράρισμα της λίστας των IP από το ~/.aMule/ipfilter.dat"
 
-#: src/muuli_wdr.cpp:2726
+#: src/muuli_wdr.cpp:2698
 msgid "URL:"
 msgstr "URL:"
 
-#: src/muuli_wdr.cpp:2730 src/muuli_wdr.cpp:2923
+#: src/muuli_wdr.cpp:2702 src/muuli_wdr.cpp:2895
 msgid "Update now"
 msgstr "Ανανέωσε τώρα"
 
-#: src/muuli_wdr.cpp:2733
+#: src/muuli_wdr.cpp:2705
 msgid "Auto-update ipfilter at startup"
 msgstr "Αυτόματη ανανέωση του ipfilter κατά την εκκίνηση"
 
-#: src/muuli_wdr.cpp:2737
+#: src/muuli_wdr.cpp:2709
 msgid "Filtering Level:"
 msgstr "Επίπεδο φιλτραρίσματος:"
 
-#: src/muuli_wdr.cpp:2743
+#: src/muuli_wdr.cpp:2715
 msgid "Always filter LAN IPs"
 msgstr "Πάντα φίλτραρε τις IP του τοπικού δικτύου"
 
-#: src/muuli_wdr.cpp:2746
+#: src/muuli_wdr.cpp:2718
 msgid "Paranoid handling of non-matching IPs"
 msgstr "Παρανοϊκή διαχείριση των αταίριαστων διευθύνσεων IP"
 
-#: src/muuli_wdr.cpp:2748
+#: src/muuli_wdr.cpp:2720
 msgid "Rejects a packet when its source IP differs from the IP the client claims (an anti-spoofing check). Disable only if it causes connection problems."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2750
+#: src/muuli_wdr.cpp:2722
 msgid "Use system-wide ipfilter.dat if available"
 msgstr "Χρήση του ipfilter.dat όλου του συστήματος αν αυτό υπάρχει"
 
-#: src/muuli_wdr.cpp:2751
+#: src/muuli_wdr.cpp:2723
 #, fuzzy
 msgid "If there's no local ipfilter.dat found, allow usage of a system-wide ipfilter file."
 msgstr "Αν δεν βρεθεί τοπικό ipfilter.dat, να γίνει επιτρεπτή η χρήση του αρχείου ipfilter (φίλτρο διευθύνσεων) όλου του συστήματος."
 
-#: src/muuli_wdr.cpp:2768
+#: src/muuli_wdr.cpp:2740
 msgid "Enable Online-Signature"
 msgstr "Ενεργοποίηση συνδεδεμένων υπογραφών"
 
-#: src/muuli_wdr.cpp:2770
+#: src/muuli_wdr.cpp:2742
 msgid "Enables the writing of the OS file, which can be used by external apps to create signatures and the like."
 msgstr "Ενεργοποίηση γραψίματος του αρχείου συστήματος, το οποίο μπορεί να χρησιμοποιηθεί από εξωτερικές εφαρμογές για τη δημιουργία υπογραφών κτλ."
 
-#: src/muuli_wdr.cpp:2774
+#: src/muuli_wdr.cpp:2746
 msgid "Update Frequency (Secs):"
 msgstr "Συχνότητα ανανέωσης (δευτερόλεπτα):"
 
-#: src/muuli_wdr.cpp:2777
+#: src/muuli_wdr.cpp:2749
 msgid "Change the frequency (in seconds) of Online Signature updates."
 msgstr "Αλλαγή της συχνότητας (σε δευτερόλεπτα) για την ενημέρωση Συνδεδεμένων υπογραφών."
 
-#: src/muuli_wdr.cpp:2785
+#: src/muuli_wdr.cpp:2757
 msgid "Save online signature file in: "
 msgstr "Αποθύκευση του αρχείου συνδεδεμένων υπογραφών σε:"
 
-#: src/muuli_wdr.cpp:2791
+#: src/muuli_wdr.cpp:2763
 msgid "Click here to select the directory containing the the Online Signature files."
 msgstr "Κλικ εδώ για την επιλογή του καταλόγου που περιέχει τα αρχεία Συνδεδεμένων Υπογραφών."
 
-#: src/muuli_wdr.cpp:2824
+#: src/muuli_wdr.cpp:2796
 msgid "Show country flags for clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2825
+#: src/muuli_wdr.cpp:2797
 msgid "Render the country flag column in the transfers, queue and search views. Requires a valid MMDB GeoIP database (see below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2830
+#: src/muuli_wdr.cpp:2802
 #, fuzzy
 msgid "Database"
 msgstr "Ρυθμός ροής δεδομένων :"
 
-#: src/muuli_wdr.cpp:2846
+#: src/muuli_wdr.cpp:2818
 #, fuzzy
 msgid "Source:"
 msgstr "Αρ. πηγών"
 
-#: src/muuli_wdr.cpp:2849
+#: src/muuli_wdr.cpp:2821
 msgid "DB-IP (free, no account)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2850
+#: src/muuli_wdr.cpp:2822
 msgid "MaxMind GeoLite2 (free, account required)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2851
+#: src/muuli_wdr.cpp:2823
 msgid "Custom URL"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2854
+#: src/muuli_wdr.cpp:2826
 msgid "Choose which provider supplies the GeoIP MMDB database. DB-IP is the default - no account required. MaxMind requires a free account + license key. Use Custom URL to point at any other MMDB host (e.g. a local mirror)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2871
+#: src/muuli_wdr.cpp:2843
 msgid ""
 "No configuration required.\n"
 "\n"
@@ -4900,11 +4866,11 @@ msgid ""
 "License: Creative Commons BY 4.0 - https://creativecommons.org/licenses/by/4.0/"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2884
+#: src/muuli_wdr.cpp:2856
 msgid "License key:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2890
+#: src/muuli_wdr.cpp:2862
 msgid ""
 "Sign up for a free MaxMind account, then generate a License Key:\n"
 "https://www.maxmind.com/en/geolite2/signup\n"
@@ -4914,232 +4880,232 @@ msgid ""
 "Requires attribution and account registration; refresh at least every 30 days."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2905
+#: src/muuli_wdr.cpp:2877
 #, fuzzy
 msgid "Download URL:"
 msgstr "Μεταφόρτωση"
 
-#: src/muuli_wdr.cpp:2911
+#: src/muuli_wdr.cpp:2883
 msgid ""
 "Must point to an .mmdb file or a .gz / .tar.gz containing one.\n"
 "URL may include credentials (https://user:pass@host/...).\n"
 "License and attribution terms are set by the upstream URL - you are responsible."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2924
+#: src/muuli_wdr.cpp:2896
 msgid "Download the GeoIP database from the selected source."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2926
+#: src/muuli_wdr.cpp:2898
 #, fuzzy
 msgid "Auto-update on startup"
 msgstr "Αυτόματη ανανέωση του ipfilter κατά την εκκίνηση"
 
-#: src/muuli_wdr.cpp:2927
+#: src/muuli_wdr.cpp:2899
 msgid "Re-download the GeoIP database from the selected source every time aMule starts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2950
+#: src/muuli_wdr.cpp:2922
 msgid "Filter incoming messages (except current chat):"
 msgstr "Φιλτράρισμα εισερχομένων μηνυμάτων (εκτός από την τρέχουσα συνομιλία):"
 
-#: src/muuli_wdr.cpp:2952
+#: src/muuli_wdr.cpp:2924
 msgid "Filter all messages"
 msgstr "Διήθηση όλων των μηνυμάτων"
 
-#: src/muuli_wdr.cpp:2954
+#: src/muuli_wdr.cpp:2926
 msgid "Filter messages from people not on your friend list"
 msgstr "Διήθηση των μηνυμάτων από μέλη εκτός της λίστας φίλων"
 
-#: src/muuli_wdr.cpp:2956
+#: src/muuli_wdr.cpp:2928
 msgid "Filter messages from unknown clients"
 msgstr "Διήθηση μηνυμάτων από άγνωστους πελάτες"
 
-#: src/muuli_wdr.cpp:2958
+#: src/muuli_wdr.cpp:2930
 msgid "Filter messages containing (use ',' as separator):"
 msgstr "Διήθηση των μηνυμάτων που περιέχουν (χρήση ',' ως διαχωριστικού):"
 
-#: src/muuli_wdr.cpp:2961 src/muuli_wdr.cpp:2972
+#: src/muuli_wdr.cpp:2933 src/muuli_wdr.cpp:2944
 msgid "add here the words amule should filter and block messages including it"
 msgstr "προσθήκη σε αυτό το σημείο των λέξεων που το aMule πρέπει να φιλτράρει και μπλοκάρισμα μηνυμάτων που το περιέχουν"
 
-#: src/muuli_wdr.cpp:2963
+#: src/muuli_wdr.cpp:2935
 msgid "Show received messages in the log"
 msgstr "Εμφάνιση των ληφθέντων μηνυμάτων στο αρχείο καταγραφής"
 
-#: src/muuli_wdr.cpp:2966
+#: src/muuli_wdr.cpp:2938
 msgid "Comments"
 msgstr "Σχόλια"
 
-#: src/muuli_wdr.cpp:2969
+#: src/muuli_wdr.cpp:2941
 msgid "Filter comments containing (use ',' as separator):"
 msgstr "Φιλτράρισμα σχολίων που περιέχουν (χρησιμοποίηση ',' ως διαχωριστή):"
 
-#: src/muuli_wdr.cpp:2994
+#: src/muuli_wdr.cpp:2966
 msgid "Enable Proxy"
 msgstr "Ενεργοποίηση διακομιστή μεσολάβησης"
 
-#: src/muuli_wdr.cpp:2995
+#: src/muuli_wdr.cpp:2967
 msgid "Enable/disable proxy support"
 msgstr "Ενεργοποίηση/Απενεργοποίηση υποστήριξης διακομιστή μεσολάβησης"
 
-#: src/muuli_wdr.cpp:2998
+#: src/muuli_wdr.cpp:2970
 msgid "Proxy type:"
 msgstr "Τύπος διαμεσολάβησης"
 
-#: src/muuli_wdr.cpp:3009
+#: src/muuli_wdr.cpp:2981
 msgid "Proxy host:"
 msgstr "Διεύθυνση διακομιστή μεσολάβησης:"
 
-#: src/muuli_wdr.cpp:3012
+#: src/muuli_wdr.cpp:2984
 msgid "The proxy host name"
 msgstr "Όνομα του διακομιστή μεσολάβησης"
 
-#: src/muuli_wdr.cpp:3014
+#: src/muuli_wdr.cpp:2986
 msgid "Proxy port:"
 msgstr "Θύρα διακομιστή μεσολάβησης:"
 
-#: src/muuli_wdr.cpp:3017
+#: src/muuli_wdr.cpp:2989
 msgid "The proxy port"
 msgstr "Η θύρα διακομιστή μεσολάβησης"
 
-#: src/muuli_wdr.cpp:3019
+#: src/muuli_wdr.cpp:2991
 msgid "Enable authentication"
 msgstr "Ενεργοποίηση πιστοποίησης"
 
-#: src/muuli_wdr.cpp:3020
+#: src/muuli_wdr.cpp:2992
 msgid "Enable/disable username/password authentication"
 msgstr "Ενεργοποίηση/Απενεργοποίηση πιστοποίησης ονόματος χρήστη/κωδικού"
 
-#: src/muuli_wdr.cpp:3023
+#: src/muuli_wdr.cpp:2995
 msgid "Username: "
 msgstr "Όνομα χρήστη:"
 
-#: src/muuli_wdr.cpp:3026
+#: src/muuli_wdr.cpp:2998
 msgid "The username to use to connect to the proxy"
 msgstr "Το όνομα χρήστη για τη σύνδεση με τον μεσολαβητή"
 
-#: src/muuli_wdr.cpp:3028
+#: src/muuli_wdr.cpp:3000
 msgid "Password:"
 msgstr "Κωδικός:"
 
-#: src/muuli_wdr.cpp:3031
+#: src/muuli_wdr.cpp:3003
 msgid "The password to use to connect to the proxy"
 msgstr "Ο κωδικός που χρειάζεται για τη σύνδεση με τον μεσολαβητή"
 
-#: src/muuli_wdr.cpp:3050
+#: src/muuli_wdr.cpp:3022
 msgid "Connect to:"
 msgstr "Σύνδεση με:"
 
-#: src/muuli_wdr.cpp:3059
+#: src/muuli_wdr.cpp:3031
 msgid "Login to remote amule"
 msgstr "Σύνδεση σε απομακρυσμένο amule"
 
-#: src/muuli_wdr.cpp:3064
+#: src/muuli_wdr.cpp:3036
 msgid "User name"
 msgstr "Όνομα χρήστη"
 
-#: src/muuli_wdr.cpp:3075
+#: src/muuli_wdr.cpp:3047
 msgid "Remember those settings"
 msgstr "Απομνημόνευση αυτών των ρυθμίσεων"
 
-#: src/muuli_wdr.cpp:3078
+#: src/muuli_wdr.cpp:3050
 #, fuzzy
 msgid "Force ZLIB compression"
 msgstr "Χρήση συμπίεσης τύπου gzip"
 
-#: src/muuli_wdr.cpp:3102
+#: src/muuli_wdr.cpp:3074
 msgid "Enable Verbose Debug-Logging."
 msgstr "Ενεργοποίηση λεπτομερούς καταγραφής για έλεγχο σφαλμάτων"
 
-#: src/muuli_wdr.cpp:3104
+#: src/muuli_wdr.cpp:3076
 #, fuzzy
 msgid "Only to Logfile"
 msgstr "&Άνοιγμα αρχείου"
 
-#: src/muuli_wdr.cpp:3106
+#: src/muuli_wdr.cpp:3078
 msgid "Message Categories:"
 msgstr "Κατηγορίες μηνυμάτων:"
 
-#: src/muuli_wdr.cpp:3130 src/PartFileConvertDlg.cpp:160
+#: src/muuli_wdr.cpp:3102 src/PartFileConvertDlg.cpp:160
 msgid "Waiting..."
 msgstr "Αναμονή..."
 
-#: src/muuli_wdr.cpp:3150
+#: src/muuli_wdr.cpp:3122
 msgid "Add imports"
 msgstr "Προσθήκη εισακτέων"
 
-#: src/muuli_wdr.cpp:3153
+#: src/muuli_wdr.cpp:3125
 msgid "Retry selected"
 msgstr "Επαναπροσπάθεια των επιλεγμένων"
 
-#: src/muuli_wdr.cpp:3155
+#: src/muuli_wdr.cpp:3127
 msgid "Remove selected"
 msgstr "Αφαίρεση των επιλεγμένων"
 
-#: src/muuli_wdr.cpp:3218
+#: src/muuli_wdr.cpp:3190
 msgid "Event Types"
 msgstr "Τύποι συμβάντων"
 
-#: src/muuli_wdr.cpp:3237
+#: src/muuli_wdr.cpp:3209
 msgid "Statistics and queued clients for selected file(s) : Session / All time"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3261
+#: src/muuli_wdr.cpp:3233
 #, fuzzy
 msgid "Active Uploads"
 msgstr "Ενεργά ανεβάσματα :"
 
-#: src/muuli_wdr.cpp:3275
+#: src/muuli_wdr.cpp:3247
 msgid "Percent of total files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3327
+#: src/muuli_wdr.cpp:3299
 #, fuzzy
 msgid "Show Clients for"
 msgstr "Δείξε τους πελάτες"
 
-#: src/muuli_wdr.cpp:3329
+#: src/muuli_wdr.cpp:3301
 #, fuzzy
 msgid "All files"
 msgstr "Κρύψιμο των κοινόχρηστων αρχείων "
 
-#: src/muuli_wdr.cpp:3332
+#: src/muuli_wdr.cpp:3304
 #, fuzzy
 msgid "Selected files"
 msgstr "Επιλογή φίλτρου εμφάνισης"
 
-#: src/muuli_wdr.cpp:3335
+#: src/muuli_wdr.cpp:3307
 #, fuzzy
 msgid "Active uploads only"
 msgstr "Ενεργά ανεβάσματα"
 
-#: src/muuli_wdr.cpp:3342
+#: src/muuli_wdr.cpp:3314
 #, fuzzy
 msgid "Reload:"
 msgstr "Επαναφόρτωση λίστας"
 
-#: src/muuli_wdr.cpp:3346
+#: src/muuli_wdr.cpp:3318
 msgid "Reload your shared files"
 msgstr "Επαναφόρτωση των κοινόχρηστων αρχείων"
 
-#: src/muuli_wdr.cpp:3409
+#: src/muuli_wdr.cpp:3381
 msgid "Send"
 msgstr "Αποστολή"
 
-#: src/muuli_wdr.cpp:3410
+#: src/muuli_wdr.cpp:3382
 msgid "Sends the specified message."
 msgstr "Αποστολή του προσδιορισμένου μηνύματος."
 
-#: src/muuli_wdr.cpp:3414
+#: src/muuli_wdr.cpp:3386
 msgid "Close this chat-session."
 msgstr "Κλείσιμο της συνομιλίας."
 
-#: src/muuli_wdr.cpp:3437
+#: src/muuli_wdr.cpp:3409
 msgid "Connect to any server and/or Kad"
 msgstr "Σύνδεση σε κάθε διακομιστή ή/και Kad"
 
-#: src/muuli_wdr.cpp:3443 src/SharedFilesCtrl.cpp:142 src/Statistics.cpp:941
+#: src/muuli_wdr.cpp:3415 src/SharedFilesCtrl.cpp:142 src/Statistics.cpp:941
 msgid "Shared Files"
 msgstr "Κοινόχρηστα αρχεία"
 
@@ -5500,268 +5466,268 @@ msgstr "Έχει κατεβεί"
 msgid "ERROR: Failed to open partfile '%s'"
 msgstr "ΣΦΑΛΜΑ: Αποτυχία ανοίγματος του ημιτελούς αρχείου '%s'"
 
-#: src/Preferences.cpp:701
+#: src/Preferences.cpp:673
 msgid "System default"
 msgstr "Εργοστασιακές ρυθμίσεις"
 
-#: src/Preferences.cpp:702
+#: src/Preferences.cpp:674
 msgid "Albanian"
 msgstr "Αλβανικά"
 
-#: src/Preferences.cpp:703
+#: src/Preferences.cpp:675
 msgid "Arabic"
 msgstr "Αραβικά"
 
-#: src/Preferences.cpp:704
+#: src/Preferences.cpp:676
 #, fuzzy
 msgid "Asturian"
 msgstr "Εσθονικά"
 
-#: src/Preferences.cpp:705
+#: src/Preferences.cpp:677
 msgid "Basque"
 msgstr "Βάσκικα"
 
-#: src/Preferences.cpp:706
+#: src/Preferences.cpp:678
 msgid "Bulgarian"
 msgstr "Βουλγάρικα"
 
-#: src/Preferences.cpp:707
+#: src/Preferences.cpp:679
 msgid "Catalan"
 msgstr "Καταλανικά"
 
-#: src/Preferences.cpp:708
+#: src/Preferences.cpp:680
 msgid "Chinese (Simplified)"
 msgstr "Κινέζικα (απλοποιημένα)"
 
-#: src/Preferences.cpp:709
+#: src/Preferences.cpp:681
 msgid "Chinese (Traditional)"
 msgstr "Κινέζικα (Παραδοσιακά)"
 
-#: src/Preferences.cpp:710
+#: src/Preferences.cpp:682
 msgid "Croatian"
 msgstr "Κροατικά"
 
-#: src/Preferences.cpp:711
+#: src/Preferences.cpp:683
 msgid "Czech"
 msgstr "Τσέχικα"
 
-#: src/Preferences.cpp:712
+#: src/Preferences.cpp:684
 msgid "Danish"
 msgstr "Δανέζικα"
 
-#: src/Preferences.cpp:713
+#: src/Preferences.cpp:685
 msgid "Dutch"
 msgstr "Ολλανδικά"
 
-#: src/Preferences.cpp:714
+#: src/Preferences.cpp:686
 msgid "English (U.K.)"
 msgstr "Αγγλικά (Ην. Βασίλειο)"
 
-#: src/Preferences.cpp:715
+#: src/Preferences.cpp:687
 #, fuzzy
 msgid "English (U.S.)"
 msgstr "Αγγλικά (Ην. Βασίλειο)"
 
-#: src/Preferences.cpp:716
+#: src/Preferences.cpp:688
 msgid "Estonian"
 msgstr "Εσθονικά"
 
-#: src/Preferences.cpp:717
+#: src/Preferences.cpp:689
 msgid "Finnish"
 msgstr "Φιλανδικά"
 
-#: src/Preferences.cpp:718
+#: src/Preferences.cpp:690
 msgid "French"
 msgstr "Γαλλικά"
 
-#: src/Preferences.cpp:719
+#: src/Preferences.cpp:691
 msgid "Galician"
 msgstr "Γαλικιακά"
 
-#: src/Preferences.cpp:720
+#: src/Preferences.cpp:692
 msgid "German"
 msgstr "Γερμανικά"
 
-#: src/Preferences.cpp:721
+#: src/Preferences.cpp:693
 msgid "Greek"
 msgstr "Ελληνικά"
 
-#: src/Preferences.cpp:722
+#: src/Preferences.cpp:694
 msgid "Hebrew"
 msgstr "Εβραϊκά"
 
-#: src/Preferences.cpp:723
+#: src/Preferences.cpp:695
 msgid "Hungarian"
 msgstr "Ουγγαρέζικα"
 
-#: src/Preferences.cpp:724
+#: src/Preferences.cpp:696
 msgid "Italian"
 msgstr "Ιταλικά"
 
-#: src/Preferences.cpp:725
+#: src/Preferences.cpp:697
 msgid "Japanese"
 msgstr "Γιαπωνέζικα"
 
-#: src/Preferences.cpp:726
+#: src/Preferences.cpp:698
 msgid "Korean"
 msgstr "Κορεάτικα"
 
-#: src/Preferences.cpp:727
+#: src/Preferences.cpp:699
 msgid "Latvian"
 msgstr ""
 
-#: src/Preferences.cpp:728
+#: src/Preferences.cpp:700
 msgid "Lithuanian"
 msgstr "Λιθουανικά"
 
-#: src/Preferences.cpp:729
+#: src/Preferences.cpp:701
 msgid "Norwegian (Nynorsk)"
 msgstr "Νορβηγικά"
 
-#: src/Preferences.cpp:730
+#: src/Preferences.cpp:702
 msgid "Polish"
 msgstr "Πολωνέζικα"
 
-#: src/Preferences.cpp:731
+#: src/Preferences.cpp:703
 msgid "Portuguese"
 msgstr "Πορτογαλλικά"
 
-#: src/Preferences.cpp:732
+#: src/Preferences.cpp:704
 msgid "Portuguese (Brazilian)"
 msgstr "Πορτογαλλικά (Βραζιλίας)"
 
-#: src/Preferences.cpp:733
+#: src/Preferences.cpp:705
 #, fuzzy
 msgid "Romanian"
 msgstr "Αλβανικά"
 
-#: src/Preferences.cpp:734
+#: src/Preferences.cpp:706
 msgid "Russian"
 msgstr "Ρωσικά"
 
-#: src/Preferences.cpp:735
+#: src/Preferences.cpp:707
 msgid "Slovenian"
 msgstr "Σλοβένικα"
 
-#: src/Preferences.cpp:736
+#: src/Preferences.cpp:708
 msgid "Spanish"
 msgstr "Ισπανικά"
 
-#: src/Preferences.cpp:737
+#: src/Preferences.cpp:709
 msgid "Swedish"
 msgstr "Σουηδικά"
 
-#: src/Preferences.cpp:738
+#: src/Preferences.cpp:710
 msgid "Turkish"
 msgstr "Τούρκικα"
 
-#: src/Preferences.cpp:739
+#: src/Preferences.cpp:711
 msgid "Ukrainian"
 msgstr ""
 
-#: src/Preferences.cpp:842
+#: src/Preferences.cpp:814
 #, fuzzy
 msgid "Change Language"
 msgstr "Γλώσσα"
 
-#: src/Preferences.cpp:906
+#: src/Preferences.cpp:878
 msgid "There are no translations installed for aMule"
 msgstr ""
 
-#: src/Preferences.cpp:907
+#: src/Preferences.cpp:879
 #, fuzzy
 msgid "No languages available"
 msgstr "Δεν είναι διαθέσιμο"
 
-#: src/Preferences.cpp:1038
+#: src/Preferences.cpp:1010
 msgid "no options available"
 msgstr "Δεν υπάρχουν επιλογές"
 
-#: src/Preferences.cpp:2226
+#: src/Preferences.cpp:2179
 msgid "Invalid category found, skipping"
 msgstr ""
 
-#: src/Preferences.cpp:2395
+#: src/Preferences.cpp:2348
 msgid "TCP port can't be higher than 65532 due to server UDP socket being TCP+3"
 msgstr "Η θύρα TCP δεν μπορεί να είναι μεγαλύτερη από 65532, διότι η θύρα UDP του διακομιστή είναι TCP+3"
 
-#: src/Preferences.cpp:2396
+#: src/Preferences.cpp:2349
 #, c-format
 msgid "Default port will be used (%d)"
 msgstr "Θα χρησιμοποιηθεί η στάνταρ θύρα (%d)"
 
-#: src/PrefsUnifiedDlg.cpp:300 src/Statistics.cpp:866
+#: src/PrefsUnifiedDlg.cpp:298 src/Statistics.cpp:866
 msgid "Connection"
 msgstr "Σύνδεση"
 
-#: src/PrefsUnifiedDlg.cpp:301 src/SearchListCtrl.cpp:117
+#: src/PrefsUnifiedDlg.cpp:299 src/SearchListCtrl.cpp:117
 msgid "Directories"
 msgstr "Κατάλογοι Αρχείων"
 
-#: src/PrefsUnifiedDlg.cpp:302 src/Statistics.cpp:917
+#: src/PrefsUnifiedDlg.cpp:300 src/Statistics.cpp:917
 msgid "Servers"
 msgstr "Διακομιστές"
 
-#: src/PrefsUnifiedDlg.cpp:303 src/ServerListCtrl.cpp:96
+#: src/PrefsUnifiedDlg.cpp:301 src/ServerListCtrl.cpp:96
 msgid "Files"
 msgstr "Αρχεία"
 
-#: src/PrefsUnifiedDlg.cpp:304
+#: src/PrefsUnifiedDlg.cpp:302
 msgid "Security"
 msgstr "Ασφάλεια"
 
-#: src/PrefsUnifiedDlg.cpp:305
+#: src/PrefsUnifiedDlg.cpp:303
 msgid "Interface"
 msgstr "Περιβάλλον"
 
-#: src/PrefsUnifiedDlg.cpp:312
+#: src/PrefsUnifiedDlg.cpp:310
 msgid "IP2Country"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:315
+#: src/PrefsUnifiedDlg.cpp:313
 msgid "Proxy"
 msgstr "Διακομιστής διαμεσολάβησης"
 
-#: src/PrefsUnifiedDlg.cpp:316
+#: src/PrefsUnifiedDlg.cpp:314
 msgid "Filters"
 msgstr "Φίλτρα"
 
-#: src/PrefsUnifiedDlg.cpp:317
+#: src/PrefsUnifiedDlg.cpp:315
 msgid "Remote Controls"
 msgstr "Τηλεχειρισμός"
 
-#: src/PrefsUnifiedDlg.cpp:318
+#: src/PrefsUnifiedDlg.cpp:316
 msgid "Online Signature"
 msgstr "Διασυνδεδεμένη υπογραφή"
 
-#: src/PrefsUnifiedDlg.cpp:319
+#: src/PrefsUnifiedDlg.cpp:317
 msgid "Advanced"
 msgstr "Προχωρημένες"
 
-#: src/PrefsUnifiedDlg.cpp:320
+#: src/PrefsUnifiedDlg.cpp:318
 msgid "Events"
 msgstr "Γεγονότα"
 
-#: src/PrefsUnifiedDlg.cpp:323
+#: src/PrefsUnifiedDlg.cpp:321
 msgid "Debugging"
 msgstr "Έλεγχος σφαλμάτων προγράμματος"
 
-#: src/PrefsUnifiedDlg.cpp:453
+#: src/PrefsUnifiedDlg.cpp:451
 msgid ""
 "The following variables will be substituted:\n"
 "    %PARTFILE - full path to the file\n"
 "    %PARTNAME - file name only"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:474
+#: src/PrefsUnifiedDlg.cpp:472
 msgid "Tray icon support requires libayatana-appindicator3 at compile time."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:490
+#: src/PrefsUnifiedDlg.cpp:488
 msgid "Not available on Wayland: the protocol does not report when a window is minimized, so this option cannot intercept the system minimize button. Workaround: launch aMule with `GDK_BACKEND=x11` to use XWayland instead."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:536
+#: src/PrefsUnifiedDlg.cpp:534
 msgid ""
 "Do not change these setting unless you know\n"
 "what you are doing, otherwise you can easily\n"
@@ -5776,35 +5742,26 @@ msgstr ""
 "Το aMule θα τρέχει μια χαρά χωρίς την αλλαγή καμιάς από αυτές\n"
 " τις ρυθμίσεις."
 
-#: src/PrefsUnifiedDlg.cpp:647
+#: src/PrefsUnifiedDlg.cpp:645
 #, c-format
 msgid "Failed to connect Cfg to widget with the ID %d and key %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:695
+#: src/PrefsUnifiedDlg.cpp:693
 #, c-format
 msgid "Failed to transfer data from Cfg to Widget with the ID %d and key %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:801
+#: src/PrefsUnifiedDlg.cpp:799
 msgid "The type of proxy you are connecting to"
 msgstr "Ο τύπος του διακομιστή μεσολάβησης στον οποίον συνδέεστε"
 
-#: src/PrefsUnifiedDlg.cpp:1020
+#: src/PrefsUnifiedDlg.cpp:1003
 #, c-format
 msgid "Failed to transfer data from Widget to Cfg with the ID %d and key %s"
 msgstr ""
 
 #: src/PrefsUnifiedDlg.cpp:1103
-#, fuzzy
-msgid "No password set."
-msgstr "Έλεγχος κωδικού\n"
-
-#: src/PrefsUnifiedDlg.cpp:1132
-msgid "Guest access needs a password. Type one in the guest password field, or untick Enable guest access."
-msgstr ""
-
-#: src/PrefsUnifiedDlg.cpp:1144
 msgid ""
 "aMule must be restarted to enable these changes:\n"
 "\n"
@@ -5812,45 +5769,45 @@ msgstr ""
 "το aMule πρέπει να επανεκινηθεί για να ενεργοποιηθούν αυτές οι αλλαγές: \n"
 "\n"
 
-#: src/PrefsUnifiedDlg.cpp:1151
+#: src/PrefsUnifiedDlg.cpp:1110
 msgid "- TCP port changed.\n"
 msgstr "- Άλλαξε η θύρα TCP.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1156
+#: src/PrefsUnifiedDlg.cpp:1115
 msgid "- UDP port changed.\n"
 msgstr "- Άλλαξε η θύρα UDP.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1161
+#: src/PrefsUnifiedDlg.cpp:1120
 #, fuzzy
 msgid "- Network interface binding changed.\n"
 msgstr "Η εξωτερική σύνδεση έκλεισε."
 
-#: src/PrefsUnifiedDlg.cpp:1166
+#: src/PrefsUnifiedDlg.cpp:1125
 #, fuzzy
 msgid "- External connect port changed.\n"
 msgstr "Η εξωτερική σύνδεση έκλεισε."
 
-#: src/PrefsUnifiedDlg.cpp:1170
+#: src/PrefsUnifiedDlg.cpp:1129
 #, fuzzy
 msgid "- External connect acceptance changed.\n"
 msgstr "Νέα εξωτερική σύνδεση έγινε δεκτή"
 
-#: src/PrefsUnifiedDlg.cpp:1174
+#: src/PrefsUnifiedDlg.cpp:1133
 #, fuzzy
 msgid "- External connect interface changed.\n"
 msgstr "Η εξωτερική σύνδεση έκλεισε."
 
-#: src/PrefsUnifiedDlg.cpp:1178
+#: src/PrefsUnifiedDlg.cpp:1137
 #, fuzzy
 msgid "- Protocol obfuscation support changed.\n"
 msgstr "Συσκότιση πρωτοκόλλου"
 
-#: src/PrefsUnifiedDlg.cpp:1193
+#: src/PrefsUnifiedDlg.cpp:1151
 #, fuzzy
 msgid "- amuleapi settings changed.\n"
 msgstr "- Η γλώσσα άλλαξε.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1202
+#: src/PrefsUnifiedDlg.cpp:1160
 msgid ""
 "Your Auto-update server list is empty.\n"
 "'Auto-update server list at startup' will be disabled."
@@ -5858,7 +5815,7 @@ msgstr ""
 "Η λίστα αυτόματης ενημέρωσης διακομιστών είναι κενή.\n"
 "Θα απενεργοποιηθεί η επιλογή: 'Αυτόματη ενημέρωση λίστας διακομιστών κατά την εκκίνηση' "
 
-#: src/PrefsUnifiedDlg.cpp:1213
+#: src/PrefsUnifiedDlg.cpp:1171
 msgid ""
 "You have enabled external connections but have not specified a password.\n"
 "External connections cannot be enabled unless a valid password is specified."
@@ -5866,34 +5823,29 @@ msgstr ""
 "Έχετε ενεργοποιήσει τις εξωτερικές συνδέσεις αλλά δεν έχετε προσδιορίσει κωδικό.\n"
 "Οι εξωτερικές συνδέσεις δεν μπορούν να ενεργοποιηθούν μέχρι να προσδιοριστεί ένας έγκυρος κωδικός."
 
-#: src/PrefsUnifiedDlg.cpp:1246
-#, c-format
-msgid "The amuleapi password could not be saved: %s"
-msgstr ""
-
-#: src/PrefsUnifiedDlg.cpp:1276
+#: src/PrefsUnifiedDlg.cpp:1202
 msgid "- Language changed.\n"
 msgstr "- Η γλώσσα άλλαξε.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1281
+#: src/PrefsUnifiedDlg.cpp:1207
 msgid "- Temp folder changed.\n"
 msgstr "- Ο προσωρινός κατάλογος άλλαξε.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1286
+#: src/PrefsUnifiedDlg.cpp:1212
 #, fuzzy
 msgid "- ED2K network enabled.\n"
 msgstr "Όλα τα δίκτυα είναι απενεργοποιημένα."
 
-#: src/PrefsUnifiedDlg.cpp:1319
+#: src/PrefsUnifiedDlg.cpp:1245
 msgid "The shared-file exclusion pattern is not a valid regular expression. The filter has been left disabled."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1321 src/PrefsUnifiedDlg.cpp:1921
+#: src/PrefsUnifiedDlg.cpp:1247 src/PrefsUnifiedDlg.cpp:1841
 #, fuzzy
 msgid "Invalid regular expression"
 msgstr "Άκυρη έκδοση πρωτοκόλλου."
 
-#: src/PrefsUnifiedDlg.cpp:1398
+#: src/PrefsUnifiedDlg.cpp:1324
 msgid ""
 "Both eD2k and Kad network are disabled.\n"
 "You won't be able to connect until you enable at least one of them."
@@ -5901,7 +5853,7 @@ msgstr ""
 "Και το δίκτυο eD2k και το Kad είναι απενεργοποιημένα.\n"
 "Δεν θα μπορέσετε να συνδεθείτε μέχρι να ενεργοποιήσετε τουλάχιστον ένα από αυτα."
 
-#: src/PrefsUnifiedDlg.cpp:1403
+#: src/PrefsUnifiedDlg.cpp:1329
 msgid ""
 "Kad will not start if your UDP port is disabled.\n"
 "Enable UDP port or disable Kad."
@@ -5909,7 +5861,7 @@ msgstr ""
 "Το δίκτυο Kad δεν θα ξεκινήσει αν η θύρα UDP είναι απενεργοποιημένη.\n"
 "Ενεργοποιήστε τη θύρα UDP ή απενεργοποιήστε το Kad."
 
-#: src/PrefsUnifiedDlg.cpp:1459
+#: src/PrefsUnifiedDlg.cpp:1385
 msgid ""
 "\n"
 "You MUST restart aMule now.\n"
@@ -5919,69 +5871,69 @@ msgstr ""
 "Τώρα πρέπει να επανεκινήσετε το aMule.\n"
 "Διαφορετικά μην διαμαρτυρηθείτε αν συμβεί κάτι κακό.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1524
+#: src/PrefsUnifiedDlg.cpp:1450
 msgid "Could not register aMule for autostart at login. The autostart store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1526
+#: src/PrefsUnifiedDlg.cpp:1452
 msgid "Could not remove the autostart-at-login entry."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1527
+#: src/PrefsUnifiedDlg.cpp:1453
 #, fuzzy
 msgid "Autostart"
 msgstr "Η αυτόματη ανανέωση ξεκίνησε"
 
-#: src/PrefsUnifiedDlg.cpp:1542
+#: src/PrefsUnifiedDlg.cpp:1468
 msgid "Register file type"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1542
+#: src/PrefsUnifiedDlg.cpp:1468
 msgid "Register URL handler"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1550
+#: src/PrefsUnifiedDlg.cpp:1476
 #, c-format
 msgid "aMule only handles eD2k-compatible magnets. If you replace the current magnet handler (%s), BitTorrent magnet links will stop working - aMule cannot download BitTorrent content. Continue?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1555
+#: src/PrefsUnifiedDlg.cpp:1481
 #, c-format
 msgid "Another application currently opens .emulecollection files (%s). Replace it with aMule?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1560
+#: src/PrefsUnifiedDlg.cpp:1486
 #, c-format
 msgid "Another application is currently the default handler for these links (%s). Replace it with aMule?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1585
+#: src/PrefsUnifiedDlg.cpp:1511
 msgid "Could not register aMule for .emulecollection files. The registration store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1587
+#: src/PrefsUnifiedDlg.cpp:1513
 #, fuzzy
 msgid "Could not remove the file type registration."
 msgstr "Κατάλογος για τα προσωρινά αρχεία"
 
-#: src/PrefsUnifiedDlg.cpp:1589
+#: src/PrefsUnifiedDlg.cpp:1515
 msgid "Could not register aMule as the URL handler. The registration store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1591
+#: src/PrefsUnifiedDlg.cpp:1517
 msgid "Could not remove the URL handler registration."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1661 src/PrefsUnifiedDlg.cpp:1688
+#: src/PrefsUnifiedDlg.cpp:1587 src/PrefsUnifiedDlg.cpp:1614
 #, fuzzy
 msgid "The web server and aMule API require external connections to be enabled."
 msgstr "Νέα εξωτερική σύνδεση έγινε δεκτή"
 
-#: src/PrefsUnifiedDlg.cpp:1671
+#: src/PrefsUnifiedDlg.cpp:1597
 msgid "The aMule web server is deprecated. Consider running the aMule API instead."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1735
+#: src/PrefsUnifiedDlg.cpp:1655
 msgid ""
 "Your Auto-update servers list is in blank.\n"
 "Please fill in at least one URL to point to a valid server.met file.\n"
@@ -5991,66 +5943,66 @@ msgstr ""
 "Παρακαλώ βάλτε τουλάχιστον μία URL που να δείχνει σε ένα έγκυρο αρχείο sever.met.\n"
 "Πατήστε το διπλανό κουμπί \"List\" για να βάλετε ένα URL."
 
-#: src/PrefsUnifiedDlg.cpp:1876
+#: src/PrefsUnifiedDlg.cpp:1796
 msgid "Temporary files"
 msgstr "Προσωρινά αρχεία"
 
-#: src/PrefsUnifiedDlg.cpp:1881
+#: src/PrefsUnifiedDlg.cpp:1801
 msgid "Incoming files"
 msgstr "Εισερχόμενα αρχεία"
 
-#: src/PrefsUnifiedDlg.cpp:1886
+#: src/PrefsUnifiedDlg.cpp:1806
 msgid "Online Signatures"
 msgstr "Συνδεδεμένες υπογραφές"
 
-#: src/PrefsUnifiedDlg.cpp:1899
+#: src/PrefsUnifiedDlg.cpp:1819
 #, c-format
 msgid "Choose a folder for %s"
 msgstr "Επιλέξτε κατάλογο για %s"
 
-#: src/PrefsUnifiedDlg.cpp:1923
+#: src/PrefsUnifiedDlg.cpp:1843
 #, fuzzy, c-format
 msgid "Would exclude %u of %u shared file"
 msgid_plural "Would exclude %u of %u shared files"
 msgstr[0] "Βρέθηκε %i γνωστό κοινόχρηστο αρχείο"
 msgstr[1] "Βρέθηκαν %i γνωστά κοινόχρηστα αρχεία"
 
-#: src/PrefsUnifiedDlg.cpp:1940
+#: src/PrefsUnifiedDlg.cpp:1860
 msgid "Browse for videoplayer"
 msgstr "Αναζήτηση του προγράμματος για βίντεο"
 
-#: src/PrefsUnifiedDlg.cpp:1944
+#: src/PrefsUnifiedDlg.cpp:1864
 msgid "Select browser"
 msgstr "Επιλογή περιηγητή"
 
-#: src/PrefsUnifiedDlg.cpp:1948
+#: src/PrefsUnifiedDlg.cpp:1868
 #, fuzzy
 msgid "Select ffprobe binary"
 msgstr "Επιλογή περιηγητή"
 
-#: src/PrefsUnifiedDlg.cpp:1954
+#: src/PrefsUnifiedDlg.cpp:1874
 #, c-format
 msgid "Executable%s"
 msgstr "Εκτελέσιμο%s"
 
-#: src/PrefsUnifiedDlg.cpp:1988
+#: src/PrefsUnifiedDlg.cpp:1908
 msgid "ffprobe not found on PATH or in the standard install locations. Install ffmpeg (which ships ffprobe) or use Browse to pick a binary manually."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2000
+#: src/PrefsUnifiedDlg.cpp:1920
 msgid "Reset the settings on this page to their default values?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2001
+#: src/PrefsUnifiedDlg.cpp:1921
 #, fuzzy
 msgid "Reset to defaults"
 msgstr "Εργοστασιακές ρυθμίσεις"
 
-#: src/PrefsUnifiedDlg.cpp:2028
+#: src/PrefsUnifiedDlg.cpp:1948
 msgid "Edit server list"
 msgstr "Επεξεργασία λίστας διακομιστών"
 
-#: src/PrefsUnifiedDlg.cpp:2029
+#: src/PrefsUnifiedDlg.cpp:1949
 msgid ""
 "Add here URL's to download server.met files.\n"
 "Only one url on each line."
@@ -6058,181 +6010,177 @@ msgstr ""
 "Βάλτε εδώ τη διεύθυνση για το κατέβασμα των αρχείων server.met. \n"
 "Μία διεύθυνση σε κάθε γραμμή"
 
-#: src/PrefsUnifiedDlg.cpp:2084
+#: src/PrefsUnifiedDlg.cpp:2004
 msgid "IP2Country update failed"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2229 src/PrefsUnifiedDlg.cpp:2260
+#: src/PrefsUnifiedDlg.cpp:2149 src/PrefsUnifiedDlg.cpp:2180
 msgid "Data by MaxMind GeoLite2"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2231 src/PrefsUnifiedDlg.cpp:2262
+#: src/PrefsUnifiedDlg.cpp:2151 src/PrefsUnifiedDlg.cpp:2182
 #, fuzzy
 msgid "Custom source"
 msgstr "Ολοκλήρωση πηγών"
 
-#: src/PrefsUnifiedDlg.cpp:2233 src/PrefsUnifiedDlg.cpp:2264
+#: src/PrefsUnifiedDlg.cpp:2153 src/PrefsUnifiedDlg.cpp:2184
 msgid "Data by DB-IP.com"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2284
+#: src/PrefsUnifiedDlg.cpp:2204
 #, fuzzy, c-format
 msgid "Status: Loaded%s"
 msgstr "Κατάσταση:"
 
-#: src/PrefsUnifiedDlg.cpp:2286
+#: src/PrefsUnifiedDlg.cpp:2206
 #, fuzzy, c-format
 msgid "Status: Loaded%s - %s"
 msgstr "Κατάσταση:"
 
-#: src/PrefsUnifiedDlg.cpp:2290
+#: src/PrefsUnifiedDlg.cpp:2210
 msgid "Status: Failed to load - click 'Update now' to refresh."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2292
+#: src/PrefsUnifiedDlg.cpp:2212
 msgid "Status: Not found - click 'Update now' to download."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2350 src/PrefsUnifiedDlg.cpp:2374
+#: src/PrefsUnifiedDlg.cpp:2270 src/PrefsUnifiedDlg.cpp:2294
 #, c-format
 msgid "Update delay: %d second"
 msgid_plural "Update delay: %d seconds"
 msgstr[0] "Καθυστέρηση ενημέρωσης: %d δευτερόλεπτο"
 msgstr[1] "Καθυστέρηση ενημέρωσης: %d δευτερόλεπτα"
 
-#: src/PrefsUnifiedDlg.cpp:2358
+#: src/PrefsUnifiedDlg.cpp:2278
 #, c-format
 msgid "Time for average graph: %d minute"
 msgid_plural "Time for average graph: %d minutes"
 msgstr[0] "Χρόνος για μέσο γράφημα: %d λεπτό"
 msgstr[1] "Χρόνος για μέσο γράφημα: %d λεπτά"
 
-#: src/PrefsUnifiedDlg.cpp:2367
+#: src/PrefsUnifiedDlg.cpp:2287
 #, c-format
 msgid "Connections Graph Scale: %d"
 msgstr "Κλίμακα γραφήματος συνδέσεων: %d"
 
-#: src/PrefsUnifiedDlg.cpp:2382
+#: src/PrefsUnifiedDlg.cpp:2302
 #, c-format
 msgid "File Buffer Size: %d byte"
 msgid_plural "File Buffer Size: %d bytes"
 msgstr[0] "Μέγεθος χώρου ενδιάμεσης αποθήκευση αρχείου: %d byte"
 msgstr[1] "Μέγεθος χώρου ενδιάμεσης αποθήκευση αρχείου: %d byteς"
 
-#: src/PrefsUnifiedDlg.cpp:2392
+#: src/PrefsUnifiedDlg.cpp:2312
 #, c-format
 msgid "Upload Queue Size: %d client"
 msgid_plural "Upload Queue Size: %d clients"
 msgstr[0] "Μέγεθος λίστας αναμονής αποστελλόμενων: %d πελάτης"
 msgstr[1] "Μέγεθος λίστας αναμονής ανεβασμάτων: %d πελάτες"
 
-#: src/PrefsUnifiedDlg.cpp:2402
+#: src/PrefsUnifiedDlg.cpp:2322
 #, c-format
 msgid "Server connection refresh interval: %d minute"
 msgid_plural "Server connection refresh interval: %d minutes"
 msgstr[0] "Διάστημα ανανέωσης της σύνδεσης σε διακομιστή: %d λεπτό"
 msgstr[1] "Διάστημα ανανέωσης της σύνδεσης σε διακομιστή: %d λεπτά"
 
-#: src/PrefsUnifiedDlg.cpp:2407
+#: src/PrefsUnifiedDlg.cpp:2327
 msgid "Server connection refresh interval: Disabled"
 msgstr "Διάστημα ανανέωσης της σύνδεσης σε διακομιστή: Απενεργοποιημένο"
 
-#: src/PrefsUnifiedDlg.cpp:2451
+#: src/PrefsUnifiedDlg.cpp:2371
 #, fuzzy
 msgid "disabled"
 msgstr "απενεργοποίηση"
 
-#: src/PrefsUnifiedDlg.cpp:2477
+#: src/PrefsUnifiedDlg.cpp:2397
 #, fuzzy, c-format
 msgid "Execute command on '%s' event"
 msgstr "Εκτέλεση εντολής κατά το γεγονός `%s'"
 
-#: src/PrefsUnifiedDlg.cpp:2484
+#: src/PrefsUnifiedDlg.cpp:2404
 msgid "Enable command execution on core"
 msgstr "Ενεργοποίηση εκτέλεσης εντολών στον πυρήνα"
 
-#: src/PrefsUnifiedDlg.cpp:2496
+#: src/PrefsUnifiedDlg.cpp:2416
 msgid "Core command:"
 msgstr "Εντολή πυρήνα:"
 
-#: src/PrefsUnifiedDlg.cpp:2512
+#: src/PrefsUnifiedDlg.cpp:2432
 msgid "Enable command execution on GUI"
 msgstr "Ενεργοποίηση εκτέλεσης εντολών στο γραφικό περιβάλλον"
 
-#: src/PrefsUnifiedDlg.cpp:2524
+#: src/PrefsUnifiedDlg.cpp:2444
 msgid "GUI command:"
 msgstr "Εντολή γραφικού περιβάλλοντος:"
 
-#: src/PrefsUnifiedDlg.cpp:2540
+#: src/PrefsUnifiedDlg.cpp:2460
 msgid "The following variables will be replaced:"
 msgstr "Οι παρακάτω μεταβλητές θα αντικατασταθούν:"
 
-#: src/PrefsUnifiedDlg.cpp:2708
+#: src/PrefsUnifiedDlg.cpp:2628
 msgid ""
 "The following folders look like system or sensitive locations:\n"
 "\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2713
+#: src/PrefsUnifiedDlg.cpp:2633
 msgid "Sharing them recursively will publish every file underneath on the eD2k/Kad networks. Do you really want to do this?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2716
+#: src/PrefsUnifiedDlg.cpp:2636
 #, fuzzy
 msgid "Confirm shared folders"
 msgstr "Κοινόχρηστα αρχεία"
 
-#: src/PrefsUnifiedDlg.cpp:2744
+#: src/PrefsUnifiedDlg.cpp:2664
 #, fuzzy
 msgid "Reloading shared files..."
 msgstr "Επαναφόρτωση των κοινόχρηστων αρχείων"
 
-#: src/PrefsUnifiedDlg.cpp:2745
+#: src/PrefsUnifiedDlg.cpp:2665
 msgid "Scanning for subdirectories..."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2746
+#: src/PrefsUnifiedDlg.cpp:2666
 #, fuzzy
 msgid "Updating shared folders"
 msgstr "Κοινόχρηστα αρχεία"
 
-#: src/PrefsUnifiedDlg.cpp:2773
+#: src/PrefsUnifiedDlg.cpp:2693
 #, c-format
 msgid "Scanned %u directories..."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2823
+#: src/PrefsUnifiedDlg.cpp:2743
 #, fuzzy, c-format
 msgid "Reloading shared files: %u files scanned"
 msgstr "Επαναφορτώνει τη λίστα κοινοχρήστων αρχείων."
 
-#: src/PrefsUnifiedDlg.cpp:2873
+#: src/PrefsUnifiedDlg.cpp:2793
 #, fuzzy
 msgid "Shared folder"
 msgstr "Κοινόχρηστα αρχεία"
 
-#: src/SearchDlg.cpp:280
-msgid "Clear search history"
-msgstr ""
-
-#: src/SearchDlg.cpp:584
+#: src/SearchDlg.cpp:425
 msgid "It's impossible to search when both eD2k and Kademlia are disabled."
 msgstr ""
 
-#: src/SearchDlg.cpp:585 src/SearchListCtrl.cpp:858
+#: src/SearchDlg.cpp:426 src/SearchListCtrl.cpp:858
 #, fuzzy
 msgid "Search error"
 msgstr "Αναζητήσεις"
 
-#: src/SearchDlg.cpp:929
+#: src/SearchDlg.cpp:768
 msgid "Min size must be smaller than max size. Max size ignored."
 msgstr "Το ελάχιστο μέγεθος πρέπει να είναι μικρότερο από το μέγιστο. Το μέγιστο μέγεθος θα αγνοηθεί."
 
-#: src/SearchDlg.cpp:930 src/SearchDlg.cpp:1012
+#: src/SearchDlg.cpp:769 src/SearchDlg.cpp:851
 msgid "Search warning"
 msgstr "Προειδοποίηση ψαξίματος"
 
-#: src/SearchDlg.cpp:1092 src/SearchListCtrl.cpp:735
+#: src/SearchDlg.cpp:929 src/SearchListCtrl.cpp:735
 msgid "Main"
 msgstr "Κύρια"
 

--- a/po/el.po
+++ b/po/el.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-28 10:19+0200\n"
+"POT-Creation-Date: 2026-07-28 12:17+0200\n"
 "PO-Revision-Date: 2026-07-27 11:35+0000\n"
 "Last-Translator: Dimitris <dgalanak@yahoo.com>\n"
 "Language-Team: Greek\n"
@@ -203,162 +203,162 @@ msgstr "Αποτυχία ανοίγματος %s (%s)"
 msgid "WARNING: You can't add yourself as a source for an eD2k link while having a lowid."
 msgstr "ΠΡΟΕΙΔΟΠΟΙΗΣΗ: Δεν μπορείτε να προσθέσετε τον εαυτό σας σαν πηγή για έναν σύνδεσμο eD2k ενώ έχετε χαμηλή προτεραιότητα."
 
-#: src/amule.cpp:300
+#: src/amule.cpp:301
 #, fuzzy
 msgid "Now, exiting main app..."
 msgstr ""
 "\n"
 "Όλα μια χαρά, έξοδος %s...\n"
 
-#: src/amule.cpp:330
+#: src/amule.cpp:331
 #, c-format
 msgid "Terminating amuleweb instance with pid '%d' ... "
 msgstr ""
 
-#: src/amule.cpp:334
+#: src/amule.cpp:335
 #, c-format
 msgid "Killing amuleweb instance with pid '%d' ... "
 msgstr ""
 
-#: src/amule.cpp:336 src/amule.cpp:349 src/ClientRef.cpp:180
+#: src/amule.cpp:337 src/amule.cpp:350 src/ClientRef.cpp:180
 #: src/SearchDlg.cpp:1041 src/ServerListCtrl.cpp:98
 msgid "Failed"
 msgstr "Απέτυχε"
 
-#: src/amule.cpp:343
+#: src/amule.cpp:344
 #, c-format
 msgid "Terminating amuleapi instance with pid '%d' ... "
 msgstr ""
 
-#: src/amule.cpp:347
+#: src/amule.cpp:348
 #, c-format
 msgid "Killing amuleapi instance with pid '%d' ... "
 msgstr ""
 
-#: src/amule.cpp:355
+#: src/amule.cpp:356
 msgid "aMule OnExit: Terminating core."
 msgstr ""
 
-#: src/amule.cpp:466
+#: src/amule.cpp:467
 #, fuzzy
 msgid "aMule shutdown completed."
 msgstr "Το κατέβασμα ολοκληρώθηκε"
 
-#: src/amule.cpp:470
+#: src/amule.cpp:471
 msgid "Memory debug results for aMule exit:"
 msgstr ""
 
-#: src/amule.cpp:651
+#: src/amule.cpp:652
 #, c-format
 msgid "Binding aMule's peer-to-peer traffic to interface: %s (HTTP updates use the default route)"
 msgstr ""
 
-#: src/amule.cpp:655
+#: src/amule.cpp:656
 #, c-format
 msgid "Binding all network traffic to interface: %s"
 msgstr ""
 
-#: src/amule.cpp:659
+#: src/amule.cpp:660
 #, c-format
 msgid "WARNING: configured network interface '%s' was not found - traffic is NOT bound to it and may leave via the default route. Check the interface name in Preferences."
 msgstr ""
 
-#: src/amule.cpp:665
+#: src/amule.cpp:666
 #, c-format
 msgid "WARNING: binding to network interface '%s' requires elevated privileges and was NOT applied - traffic may leave via the default route. Grant the capability (e.g. 'sudo setcap cap_net_raw+ep' on the aMule binary) or run with sufficient privileges."
 msgstr ""
 
-#: src/amule.cpp:673
+#: src/amule.cpp:674
 #, c-format
 msgid "WARNING: could not bind to network interface '%s' - traffic may leave via the default route."
 msgstr ""
 
-#: src/amule.cpp:732
+#: src/amule.cpp:733
 msgid "Your locale has been changed to System Default due to a configuration change. Sorry."
 msgstr "Οι τοπικές ρυθμίσεις άλλαξαν στις προεπιλεγμένες του συστήματος λόγο μιας αλλαγής παραμέτρων. Sorry!"
 
-#: src/amule.cpp:734 src/amule.cpp:1581 src/CatDialog.cpp:128
+#: src/amule.cpp:735 src/amule.cpp:1589 src/CatDialog.cpp:128
 #: src/CatDialog.cpp:136 src/CatDialog.cpp:149 src/ServerList.cpp:366
 #: src/ServerListCtrl.cpp:152
 msgid "Info"
 msgstr "Πληροφορίες"
 
-#: src/amule.cpp:741
+#: src/amule.cpp:742
 #, fuzzy
 msgid ""
 "\n"
 "EC configuration"
 msgstr "Έξοδος επιβεβαίωσης"
 
-#: src/amule.cpp:744
+#: src/amule.cpp:745
 #, fuzzy
 msgid "Password set and external connections enabled."
 msgstr "Νέα εξωτερική σύνδεση έγινε δεκτή"
 
-#: src/amule.cpp:754 src/KadDlg.cpp:176 src/KadDlg.cpp:185
-#: src/PrefsUnifiedDlg.cpp:1387 src/SharedFilesCtrl.cpp:476
+#: src/amule.cpp:755 src/KadDlg.cpp:176 src/KadDlg.cpp:185
+#: src/PrefsUnifiedDlg.cpp:1461 src/SharedFilesCtrl.cpp:476
 msgid "WARNING"
 msgstr "ΠΡΟΕΙΔΟΠΟΙΗΣΗ"
 
-#: src/amule.cpp:991
+#: src/amule.cpp:992
 #, fuzzy
 msgid "Network bootstrap"
 msgstr "Δίκτυα"
 
-#: src/amule.cpp:996
+#: src/amule.cpp:997
 msgid ""
 "aMule has detected missing network bootstrap files.\n"
 "Select which ones to download:"
 msgstr ""
 
-#: src/amule.cpp:1005 src/FirstRunWizard.cpp:411
+#: src/amule.cpp:1006 src/FirstRunWizard.cpp:411
 #, fuzzy
 msgid "eD2k server list (server.met)"
 msgstr "βρέθηκε %i διακομιστής στο server.met"
 
-#: src/amule.cpp:1012 src/FirstRunWizard.cpp:416
+#: src/amule.cpp:1013 src/FirstRunWizard.cpp:416
 msgid "Kad bootstrap nodes (nodes.dat)"
 msgstr ""
 
-#: src/amule.cpp:1102
+#: src/amule.cpp:1103
 #, c-format
 msgid "web server running on pid %d"
 msgstr "διακομιστής ιστού τρέχει με αριθμό διεργασίας %d"
 
-#: src/amule.cpp:1115
+#: src/amule.cpp:1116
 #, fuzzy
 msgid "You requested to run web server on startup, but the amuleweb binary cannot be run. Please install the package containing aMule web server, or build aMule from source with -DBUILD_WEBSERVER=YES and install it."
 msgstr "Ζητήσατε να τρέχετε τον διακομιστή ιστού κατά την εκκίνηση, αλλά το εκτελέσιμο αρχείο amuleweb δεν βρέθηκε. Παρακαλώ εγκαταστήστε το πακέτο που περιέχει τον διακομιστή ιστού του aMule, ή μεταφράστε το aMule χρησιμοποιώντας την παράμετρο --enable-webserver"
 
-#: src/amule.cpp:1120 src/amule.cpp:1177 src/amule.cpp:1291 src/amule.cpp:1593
+#: src/amule.cpp:1121 src/amule.cpp:1185 src/amule.cpp:1299 src/amule.cpp:1601
 #: src/amule-remote-gui.cpp:603 src/amule-remote-gui.cpp:671
 #: src/amule-remote-gui.cpp:709 src/amule-remote-gui.cpp:1282
 #: src/amule-remote-gui.cpp:1345 src/amule-remote-gui.cpp:1372
-#: src/DownloadQueue.cpp:1481
+#: src/DownloadQueue.cpp:1481 src/PrefsUnifiedDlg.cpp:1247
 msgid "ERROR"
 msgstr "ΣΦΑΛΜΑ"
 
-#: src/amule.cpp:1166
+#: src/amule.cpp:1174
 #, fuzzy, c-format
 msgid "amuleapi running on pid %d"
 msgstr "διακομιστής ιστού τρέχει με αριθμό διεργασίας %d"
 
-#: src/amule.cpp:1172
+#: src/amule.cpp:1180
 #, fuzzy
 msgid "You requested to run amuleapi on startup, but the amuleapi binary cannot be run. Please install the package containing aMule's REST API server, or build aMule from source with -DBUILD_AMULEAPI=YES and install it."
 msgstr "Ζητήσατε να τρέχετε τον διακομιστή ιστού κατά την εκκίνηση, αλλά το εκτελέσιμο αρχείο amuleweb δεν βρέθηκε. Παρακαλώ εγκαταστήστε το πακέτο που περιέχει τον διακομιστή ιστού του aMule, ή μεταφράστε το aMule χρησιμοποιώντας την παράμετρο --enable-webserver"
 
-#: src/amule.cpp:1259
+#: src/amule.cpp:1267
 #, c-format
 msgid "Could not bind ports to the specified address: %s"
 msgstr "Δεν μπόρεσε να προσδέσει τις θύρες στην προσδιορισμένη διεύθυνση: %s"
 
-#: src/amule.cpp:1283
+#: src/amule.cpp:1291
 #, c-format
 msgid "Port %u is not available. You will be LOWID\n"
 msgstr "Η θύρα %u δεν είναι διαθέσιμη. Θα σας αποδωθεί LOWID (χαμηλή προτεραιότητα)\n"
 
-#: src/amule.cpp:1288
+#: src/amule.cpp:1296
 #, c-format
 msgid ""
 "Port %u is not available!\n"
@@ -373,48 +373,48 @@ msgstr ""
 "\n"
 "Ελέξτε το δίκτυο σας για να βεβαιωθήτε ότι η θύρα είναι ανοιχτή για είσοδο και έξοδο."
 
-#: src/amule.cpp:1385
+#: src/amule.cpp:1393
 msgid "Failed to create OnlineSig File"
 msgstr "Αποτυχία δημιουργίας αρχείου Συνδεδεμένων Υπογραφών"
 
-#: src/amule.cpp:1393
+#: src/amule.cpp:1401
 msgid "Failed to create aMule OnlineSig File"
 msgstr "Αποτυχία δημιουργίας αρχείου Συνδεδεμένων Υπογραφών του aMule"
 
-#: src/amule.cpp:1556
+#: src/amule.cpp:1564
 msgid "The selected locale seems not to be installed on your box. (Note: I'll try to set it anyway)"
 msgstr "Οι επιλεγμένες τοπικές ρυθμίσεις δεν φαίνεται να είναι εγκατεστημένες στο σύστημά σας. (Σημ. Θα προσπαθήσω να τις θέσω ούτως ή άλλως)"
 
-#: src/amule.cpp:1566
+#: src/amule.cpp:1574
 #, c-format
 msgid "This is the first time you run aMule %s"
 msgstr "Αυτή είναι η πρώτη φορά που τρέχετε το aMule %s"
 
-#: src/amule.cpp:1569
+#: src/amule.cpp:1577
 msgid "This version is a testing version, updated daily, and\n"
 msgstr "Αυτή η έκδοση είναι δοκιμαστική, και αναβαθμίζεται καθημερινά, και\n"
 
-#: src/amule.cpp:1570
+#: src/amule.cpp:1578
 msgid "we give no warranty it won't break anything, burn your house,\n"
 msgstr "δεν δίνουμε εγγύηση ότι δεν θα χαλάσει κάτι, δεν θα κάψει το σπίτι σας,\n"
 
-#: src/amule.cpp:1571
+#: src/amule.cpp:1579
 msgid "or kill your dog. But it *should* be safe to use anyway.\n"
 msgstr "ή δεν θα σκοτώσει το σκύλο σας. Αλλά πρέπει να είναι ασφαλές στη χρήση\n"
 
-#: src/amule.cpp:1576
+#: src/amule.cpp:1584
 msgid "More information, support and new releases can found at our homepage,\n"
 msgstr "Περισσότερες πληροφορίες, υποστήριξη και νέες εκδόσεις μπορούν να βρεθούν στην ιστοσελίδα μας,\n"
 
-#: src/amule.cpp:1577
+#: src/amule.cpp:1585
 msgid "at https://amule-org.github.io, or in our IRC channel #aMule at irc.libera.chat.\n"
 msgstr "στο https://amule-org.github.io, ή στο κανάλι #aMule του IRC στο irc.libera.chat.\n"
 
-#: src/amule.cpp:1579
+#: src/amule.cpp:1587
 msgid "Feel free to report any bugs to https://github.com/amule-org/amule/issues"
 msgstr "Παρακαλούμε αναφέρετε σφάλματα του προγράμματος στο https://github.com/amule-org/amule/issues"
 
-#: src/amule.cpp:1591
+#: src/amule.cpp:1599
 msgid ""
 "The folder for Online Signature files you specified is INVALID!\n"
 " OnlineSignature will be DISABLED until you fix it on preferences."
@@ -422,138 +422,138 @@ msgstr ""
 "Ο δικτυακός κατάλογος των ηλεκτρονικών αρχείων υπογραφών που προσδιορίσατε είναι ΑΚΥΡΟΣ!\n"
 "Οι ηλεκτρονικές υπογραφές θα ΑΠΕΝΕΡΓΟΠΟΙΗΘΟΥΝ μέχρι να το φτιάξετε στις προτιμήσεις."
 
-#: src/amule.cpp:1654
+#: src/amule.cpp:1662
 #, fuzzy
 msgid "Server hostname notified"
 msgstr "Όνομα διακομιστή:"
 
-#: src/amule.cpp:2031
+#: src/amule.cpp:2039
 #, c-format
 msgid "Disk space preallocation for file '%s' failed: %s"
 msgstr "Η εκχώρηση χώρου για το αρχείο '%s' απέτυχε: '%s'"
 
-#: src/amule.cpp:2160
+#: src/amule.cpp:2168
 msgid "ERROR: can't open logfile"
 msgstr "ΣΦΑΛΜΑ: το αρχείο καταγραφής δεν μπορεί να ανοίξει"
 
-#: src/amule.cpp:2164
+#: src/amule.cpp:2172
 msgid "WARNING: logfile is empty. Something is wrong."
 msgstr "ΠΡΟΕΙΔΟΠΟΙΗΣΗ: το αρχείο καταγραφών είναι άδειο. Κάτι δεν πάει καλά."
 
-#: src/amule.cpp:2181
+#: src/amule.cpp:2189
 msgid "Log has been reset"
 msgstr "Το αρχείο καταγραφών επαναφέρθηκε στην αρχική κατάσταση"
 
-#: src/amule.cpp:2205
+#: src/amule.cpp:2213
 #, c-format
 msgid "ServerMessage: %s"
 msgstr "Μήνυμα Διακομιστή: %s"
 
-#: src/amule.cpp:2248 src/IP2Country.cpp:220 src/IPFilter.cpp:514
+#: src/amule.cpp:2256 src/IP2Country.cpp:220 src/IPFilter.cpp:514
 #: src/ServerList.cpp:875
 #, c-format
 msgid "Skipped download of %s, because requested file is not newer."
 msgstr ""
 
-#: src/amule.cpp:2251
+#: src/amule.cpp:2259
 msgid "Failed to download the nodes list."
 msgstr "Αποτυχία κατεβάσματος της λίστας κόμβων."
 
-#: src/amule.cpp:2314
+#: src/amule.cpp:2322
 msgid "Failed to open the downloaded version check file"
 msgstr "Αποτυχία ανοίγματος του κατεβασμένου αρχείου ελέγχου έκδοσης"
 
-#: src/amule.cpp:2317 src/amule.cpp:2336
+#: src/amule.cpp:2325 src/amule.cpp:2344
 msgid "Corrupted version check file"
 msgstr "Φθαρμένο αρχείο ελέγχου έκδοσης"
 
-#: src/amule.cpp:2359
+#: src/amule.cpp:2367
 msgid "You are using an outdated version of aMule!"
 msgstr "Χρησιμοποιείται μία ξεπερασμένη έκδοση του aMule!"
 
-#: src/amule.cpp:2361
+#: src/amule.cpp:2369
 #, c-format
 msgid "Your aMule version is %i.%i.%i and the latest version is %li.%li.%li"
 msgstr "Η παρούσα έκδοση του aMule είναι %i.%i.%i και η τελευταία %li.%li.%li"
 
-#: src/amule.cpp:2365
+#: src/amule.cpp:2373
 msgid "The latest version can always be found at https://github.com/amule-org/amule/releases/latest"
 msgstr "Η τελευταία έκδοση μπορεί να βρεθεί στο https://github.com/amule-org/amule/releases/latest"
 
-#: src/amule.cpp:2368
+#: src/amule.cpp:2376
 #, c-format
 msgid "WARNING: Your aMuled version is outdated: %i.%i.%i < %li.%li.%li"
 msgstr "ΠΡΟΕΙΔΟΠΟΙΗΣΗ: Η έκδοση του aMuled είναι ξεπερασμένη: %i.%i.%i < %li.%li.%li"
 
-#: src/amule.cpp:2374
+#: src/amule.cpp:2382
 msgid "Your copy of aMule is up to date."
 msgstr "Αυτό το αντίγραφο του aMule είναι σύγχρονο. "
 
-#: src/amule.cpp:2381
+#: src/amule.cpp:2389
 msgid "Failed to download the version check file"
 msgstr "Αποτυχία κατεβάσματος του αρχείου ελέγχου έκδοσης"
 
-#: src/amule.cpp:2550 src/amule-remote-gui.cpp:1133
+#: src/amule.cpp:2558 src/amule-remote-gui.cpp:1133
 #, c-format
 msgid "Users: %s | Files: %s"
 msgstr "Χρήστες: %s | Αρχεία: %s"
 
-#: src/amule.cpp:2551 src/amule-remote-gui.cpp:1134
+#: src/amule.cpp:2559 src/amule-remote-gui.cpp:1134
 #, c-format
 msgid "Users: E: %s K: %s | Files: E: %s K: %s"
 msgstr "Χρήστες: E: %s K: %s | Αρχεία: E: %s K: %s"
 
-#: src/amule.cpp:2565 src/amule-remote-gui.cpp:1147
+#: src/amule.cpp:2573 src/amule-remote-gui.cpp:1147
 msgid "No networks selected"
 msgstr "Δεν έχουν επιλεχθεί δίκτυα"
 
-#: src/amule.cpp:2633 src/TextClient.cpp:903
+#: src/amule.cpp:2641 src/TextClient.cpp:903
 msgid "with LowID"
 msgstr "με Χαμηλή Προτεραιότητα"
 
-#: src/amule.cpp:2633 src/TextClient.cpp:904
+#: src/amule.cpp:2641 src/TextClient.cpp:904
 msgid "with HighID"
 msgstr "με Υψηλή Προτεραιότητα"
 
-#: src/amule.cpp:2635
+#: src/amule.cpp:2643
 #, c-format
 msgid "Connected to %s %s"
 msgstr "Σύνδεση με το %s %s"
 
-#: src/amule.cpp:2640
+#: src/amule.cpp:2648
 #, c-format
 msgid "Connecting to %s"
 msgstr "Διαδικασία σύνδεσης με %s"
 
-#: src/amule.cpp:2642
+#: src/amule.cpp:2650
 msgid "Disconnected from eD2k"
 msgstr "Αποσυνδεδεμένο από το eD2k"
 
-#: src/amule.cpp:2651
+#: src/amule.cpp:2659
 msgid "Kad started."
 msgstr "Το Kad ξεκίνησε."
 
-#: src/amule.cpp:2653
+#: src/amule.cpp:2661
 msgid "Kad stopped."
 msgstr "Το Kad είναι σταματημένο."
 
-#: src/amule.cpp:2661
+#: src/amule.cpp:2669
 msgid "Connected to Kad (ok)"
 msgstr "Συνδεδεμένο στο Kad (ΟΚ)"
 
-#: src/amule.cpp:2663
+#: src/amule.cpp:2671
 msgid "Connected to Kad (firewalled)"
 msgstr "Συνδεδεμένο στο Kad (με προστατευτικό τοίχο)"
 
-#: src/amule.cpp:2667
+#: src/amule.cpp:2675
 msgid "Disconnected from Kad"
 msgstr "Αποσυνδεδεμένο από το Kad"
 
-#: src/amule.cpp:2699
+#: src/amule.cpp:2707
 msgid "Kad network cannot be used if UDP port is disabled on preferences, not starting."
 msgstr "Το δίκτυο Kad δεν μπορεί να χρησιμοποιηθεί αν η θύρα UDP είναι απενεργοποιημένη στις προτιμήσεις. Δεν έγινε εκκίνηση."
 
-#: src/amule.cpp:2703
+#: src/amule.cpp:2711
 msgid "Kad network disabled on preferences, not connecting."
 msgstr "Το δίκτυο Kad είναι απενεργοποιημένο από τις προτιμήσεις. Δεν έγινε σύνδεση."
 
@@ -598,36 +598,36 @@ msgid "FATAL ERROR: Failed to create Timer"
 msgstr "ΜΟΙΡΑΙΟ ΣΦΑΛΜΑ: Αποτυχία δημιουργίας Χρονομέτρου"
 
 #: src/amuleDlg.cpp:361 src/amuleDlg.cpp:1787 src/amuleDlg.cpp:2033
-#: src/muuli_wdr.cpp:1492 src/muuli_wdr.cpp:3418
+#: src/muuli_wdr.cpp:1492 src/muuli_wdr.cpp:3449
 msgid "Networks"
 msgstr "Δίκτυα"
 
-#: src/amuleDlg.cpp:362 src/amuleDlg.cpp:1793 src/muuli_wdr.cpp:3419
+#: src/amuleDlg.cpp:362 src/amuleDlg.cpp:1793 src/muuli_wdr.cpp:3450
 msgid "Searches"
 msgstr "Αναζητήσεις"
 
 #: src/amuleDlg.cpp:363 src/amuleDlg.cpp:1799 src/DownloadListCtrl.cpp:740
-#: src/muuli_wdr.cpp:392 src/muuli_wdr.cpp:1585 src/muuli_wdr.cpp:3420
+#: src/muuli_wdr.cpp:392 src/muuli_wdr.cpp:1585 src/muuli_wdr.cpp:3451
 #: src/Statistics.cpp:829
 msgid "Downloads"
 msgstr "Κατεβασμένα"
 
-#: src/amuleDlg.cpp:364 src/amuleDlg.cpp:1805 src/muuli_wdr.cpp:3294
+#: src/amuleDlg.cpp:364 src/amuleDlg.cpp:1805 src/muuli_wdr.cpp:3325
 msgid "Shared files"
 msgstr "Κοινόχρηστα αρχεία"
 
-#: src/amuleDlg.cpp:365 src/amuleDlg.cpp:1811 src/muuli_wdr.cpp:2926
-#: src/muuli_wdr.cpp:3376 src/muuli_wdr.cpp:3423
+#: src/amuleDlg.cpp:365 src/amuleDlg.cpp:1811 src/muuli_wdr.cpp:2957
+#: src/muuli_wdr.cpp:3407 src/muuli_wdr.cpp:3454
 msgid "Messages"
 msgstr "Μηνύματα"
 
-#: src/amuleDlg.cpp:366 src/amuleDlg.cpp:1817 src/muuli_wdr.cpp:3424
-#: src/PrefsUnifiedDlg.cpp:312 src/Statistics.cpp:779 src/Statistics.cpp:1235
+#: src/amuleDlg.cpp:366 src/amuleDlg.cpp:1817 src/muuli_wdr.cpp:3455
+#: src/PrefsUnifiedDlg.cpp:314 src/Statistics.cpp:779 src/Statistics.cpp:1235
 msgid "Statistics"
 msgstr "Στατιστικές"
 
-#: src/amuleDlg.cpp:368 src/amuleDlg.cpp:1824 src/muuli_wdr.cpp:3426
-#: src/PrefsUnifiedDlg.cpp:328 src/utils/wxCas/src/wxcasprefs.cpp:39
+#: src/amuleDlg.cpp:368 src/amuleDlg.cpp:1824 src/muuli_wdr.cpp:3457
+#: src/PrefsUnifiedDlg.cpp:330 src/utils/wxCas/src/wxcasprefs.cpp:39
 msgid "Preferences"
 msgstr "Προτιμήσεις"
 
@@ -685,8 +685,8 @@ msgstr "Kad: Εκτός"
 #: src/amuleDlg.cpp:1029 src/DownloadListCtrl.cpp:505
 #: src/DownloadListCtrl.cpp:749 src/FriendListCtrl.cpp:180
 #: src/muuli_wdr.cpp:731 src/muuli_wdr.cpp:782 src/muuli_wdr.cpp:846
-#: src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2231 src/muuli_wdr.cpp:2316
-#: src/muuli_wdr.cpp:3064 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
+#: src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2262 src/muuli_wdr.cpp:2347
+#: src/muuli_wdr.cpp:3095 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
 #: src/ServerListCtrl.cpp:606 src/TransferWnd.cpp:378
 #: src/utils/wxCas/src/wxcasprefs.cpp:235
 msgid "Cancel"
@@ -697,7 +697,7 @@ msgid "Stop the current connection attempts"
 msgstr "Σταμάτησε τις τρέχουσες απόπειρες σύνδεσης"
 
 #: src/amuleDlg.cpp:1035 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976
-#: src/muuli_wdr.cpp:2454
+#: src/muuli_wdr.cpp:2485
 msgid "Disconnect"
 msgstr "Αποσύνδεση"
 
@@ -706,7 +706,7 @@ msgid "Disconnect from the currently connected networks"
 msgstr "Αποσύνδεση από τα συνδεδεμένα δίκτυα"
 
 #: src/amuleDlg.cpp:1041 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979
-#: src/muuli_wdr.cpp:2609 src/muuli_wdr.cpp:3061 src/muuli_wdr.cpp:3416
+#: src/muuli_wdr.cpp:2640 src/muuli_wdr.cpp:3092 src/muuli_wdr.cpp:3447
 msgid "Connect"
 msgstr "Σύνδεση"
 
@@ -761,7 +761,7 @@ msgstr "Έξοδος επιβεβαίωσης"
 msgid "Launch Command: "
 msgstr ""
 
-#: src/amuleDlg.cpp:1632 src/muuli_wdr.cpp:1978 src/Preferences.cpp:952
+#: src/amuleDlg.cpp:1632 src/muuli_wdr.cpp:1982 src/Preferences.cpp:979
 msgid "- default -"
 msgstr "- Προεπιλεγμένο -"
 
@@ -775,49 +775,49 @@ msgstr "Ο κατάλογος των θεμάτων '%s'  δεν υπάρχει"
 msgid "WARNING: Unable to open skin file '%s' for read"
 msgstr "ΠΡΟΕΙΔΟΠΟΙΗΣΗ: Δεν είναι δυνατή η ανάγνωση του αρχείου θέματος '%s' "
 
-#: src/amuleDlg.cpp:1791 src/muuli_wdr.cpp:3418
+#: src/amuleDlg.cpp:1791 src/muuli_wdr.cpp:3449
 msgid "Networks Window"
 msgstr "Παράθυρο δικτύων"
 
-#: src/amuleDlg.cpp:1797 src/muuli_wdr.cpp:3419
+#: src/amuleDlg.cpp:1797 src/muuli_wdr.cpp:3450
 msgid "Searches Window"
 msgstr "Παράθυρο αναζητήσεων"
 
-#: src/amuleDlg.cpp:1803 src/muuli_wdr.cpp:3420
+#: src/amuleDlg.cpp:1803 src/muuli_wdr.cpp:3451
 #, fuzzy
 msgid "Downloads Window"
 msgstr "Κατεβαίνει"
 
-#: src/amuleDlg.cpp:1809 src/muuli_wdr.cpp:3422
+#: src/amuleDlg.cpp:1809 src/muuli_wdr.cpp:3453
 msgid "Shared Files Window"
 msgstr "Παράθυρο κοινόχρηστων αρχείων"
 
-#: src/amuleDlg.cpp:1815 src/muuli_wdr.cpp:3423
+#: src/amuleDlg.cpp:1815 src/muuli_wdr.cpp:3454
 msgid "Messages Window"
 msgstr "Παράθυρό μηνυμάτων"
 
-#: src/amuleDlg.cpp:1821 src/muuli_wdr.cpp:3424
+#: src/amuleDlg.cpp:1821 src/muuli_wdr.cpp:3455
 msgid "Statistics Graph Window"
 msgstr "Παράθυρο στατιστικών διαγραμμάτων"
 
-#: src/amuleDlg.cpp:1828 src/muuli_wdr.cpp:3426
+#: src/amuleDlg.cpp:1828 src/muuli_wdr.cpp:3457
 msgid "Preferences Settings Window"
 msgstr "Παράθυρο ρυθμίσεων"
 
-#: src/amuleDlg.cpp:1831 src/muuli_wdr.cpp:3427
+#: src/amuleDlg.cpp:1831 src/muuli_wdr.cpp:3458
 msgid "Import"
 msgstr "Εισαγωγή"
 
-#: src/amuleDlg.cpp:1835 src/muuli_wdr.cpp:3427
+#: src/amuleDlg.cpp:1835 src/muuli_wdr.cpp:3458
 msgid "The partfile importer tool"
 msgstr "Το εργαλείο εισαγωγής ημιτελών αρχείων"
 
-#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3428
+#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3459
 #: src/utils/aLinkCreator/src/alcframe.cpp:262
 msgid "About"
 msgstr "Σχετικά"
 
-#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3428
+#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3459
 msgid "About/Help"
 msgstr "Σχετικά/Βοήθεια"
 
@@ -963,7 +963,7 @@ msgstr "Το αρχείο δεν βρέθηκε."
 msgid "The core rejected these shared folders:%s"
 msgstr ""
 
-#: src/amule-remote-gui.cpp:1336 src/ExternalConn.cpp:2345
+#: src/amule-remote-gui.cpp:1336 src/ExternalConn.cpp:2346
 msgid "Invalid link or already on list."
 msgstr "Άκυρος σύνδεσμο ή ήδη στην λίστα."
 
@@ -979,7 +979,7 @@ msgstr ""
 #: src/ClientDetailDialog.cpp:123 src/DataToText.cpp:61 src/DataToText.cpp:86
 #: src/DataToText.cpp:101 src/DataToText.cpp:136 src/DataToText.cpp:165
 #: src/DownloadListCtrl.cpp:1172 src/DownloadListCtrl.cpp:1185
-#: src/DownloadListCtrl.cpp:1196 src/ExternalConn.cpp:608
+#: src/DownloadListCtrl.cpp:1196 src/ExternalConn.cpp:609
 #: src/FileDetailDialog.cpp:203 src/FileDetailDialog.cpp:235
 #: src/FileDetailDialog.cpp:242 src/GenericClientListCtrl.cpp:1171
 #: src/GenericClientListCtrl.cpp:1182 src/GenericClientListCtrl.cpp:1192
@@ -1366,19 +1366,19 @@ msgstr "Αυτόματη [Υψηλή]"
 msgid "Very low"
 msgstr "Πολύ χαμηλή"
 
-#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:743 src/muuli_wdr.cpp:2282
+#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:743 src/muuli_wdr.cpp:2313
 #: src/ServerListCtrl.cpp:263 src/ServerListCtrl.cpp:456
 #: src/SharedFilesCtrl.cpp:145
 msgid "Low"
 msgstr "Χαμηλή"
 
-#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:744 src/muuli_wdr.cpp:2283
+#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:744 src/muuli_wdr.cpp:2314
 #: src/ServerListCtrl.cpp:266 src/ServerListCtrl.cpp:457
 #: src/SharedFilesCtrl.cpp:146
 msgid "Normal"
 msgstr "Κανονική"
 
-#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:745 src/muuli_wdr.cpp:2284
+#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:745 src/muuli_wdr.cpp:2315
 #: src/ServerListCtrl.cpp:269 src/ServerListCtrl.cpp:458
 #: src/SharedFilesCtrl.cpp:147
 msgid "High"
@@ -1470,7 +1470,7 @@ msgstr "Τοπικός διακομιστής"
 msgid "Remote Server"
 msgstr "Απομακρυσμένος διακομιστής"
 
-#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3181
+#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3212
 #: src/SearchDlg.cpp:119 src/TextClient.cpp:911
 msgid "Kad"
 msgstr "Kad"
@@ -1542,7 +1542,7 @@ msgstr "Μέρος"
 msgid "Size"
 msgstr "Μέγεθος"
 
-#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3248
+#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3279
 msgid "Transferred"
 msgstr "Μεταφέρθηκαν"
 
@@ -1600,7 +1600,7 @@ msgstr ""
 "Αντίδραση από %s (%s)\n"
 "\n"
 
-#: src/DownloadListCtrl.cpp:746 src/muuli_wdr.cpp:2285
+#: src/DownloadListCtrl.cpp:746 src/muuli_wdr.cpp:2316
 #: src/SharedFilesCtrl.cpp:150
 msgid "Auto"
 msgstr "Αυτόματη"
@@ -1638,7 +1638,7 @@ msgid "Extended Options"
 msgstr "Εκτεταμένες Προτιμήσεις"
 
 #: src/DownloadListCtrl.cpp:770 src/DownloadListCtrl.cpp:822
-#: src/muuli_wdr.cpp:1796
+#: src/muuli_wdr.cpp:1800
 msgid "Preview"
 msgstr "Προεπισκόπιση"
 
@@ -1813,232 +1813,237 @@ msgstr[1] ""
 msgid "Invalid eD2k link! ERROR: %s"
 msgstr "Άκυρος σύνδεσμος eD2k! ΣΦΑΛΜΑ: %s"
 
-#: src/ExternalConn.cpp:379
+#: src/ExternalConn.cpp:380
 #, fuzzy
 msgid "Client sent packet after authentication failed."
 msgstr "Η πιστοποίηση απέτυχε."
 
-#: src/ExternalConn.cpp:396
+#: src/ExternalConn.cpp:397
 msgid "External connection closed."
 msgstr "Η εξωτερική σύνδεση έκλεισε."
 
-#: src/ExternalConn.cpp:473
+#: src/ExternalConn.cpp:474
 msgid "External connections disabled due to empty password!"
 msgstr "Οι εξωτερικές συνδέσεις απενεργοποιήθηκαν λόγω καινού κωδικού!"
 
-#: src/ExternalConn.cpp:494
+#: src/ExternalConn.cpp:495
 msgid "External connections disabled in config file"
 msgstr "Οι εξωτερικές συνδέσεις απενεργοποιήθηκαν στο αρχείο ρυθμίσεων"
 
-#: src/ExternalConn.cpp:575
+#: src/ExternalConn.cpp:576
 msgid "New external connection accepted"
 msgstr "Νέα εξωτερική σύνδεση έγινε δεκτή"
 
-#: src/ExternalConn.cpp:578
+#: src/ExternalConn.cpp:579
 msgid "ERROR: couldn't accept a new external connection"
 msgstr "ΣΦΑΛΜΑ: δεν μπόρεσα να αποδεχτώ νέα εξωτερική σύνδεση"
 
-#: src/ExternalConn.cpp:595
+#: src/ExternalConn.cpp:596
 msgid "External connection refused due to empty password in preferences!"
 msgstr "Οι εξωτερικές συνδέσεις απενεργοποιήθηκαν λόγω καινού κωδικού στις προτιμήσεις!"
 
-#: src/ExternalConn.cpp:607
+#: src/ExternalConn.cpp:608
 #, c-format
 msgid "Connecting client: %s %s"
 msgstr "Συνδεόμενος πελάτης: %s %s"
 
-#: src/ExternalConn.cpp:609
+#: src/ExternalConn.cpp:610
 msgid "Unknown version"
 msgstr "Άγνωστη έκδοση"
 
-#: src/ExternalConn.cpp:622
+#: src/ExternalConn.cpp:623
 msgid "Incorrect EC version ID, there might be binary incompatibility. Use core and remote from same snapshot."
 msgstr "Λανθασμένη ταυτότητα έκδοσης EC, ίσως υπάρχει δυαδική ασυμβατότητα. Χρησιμοποιήστε πυρήνα και απομακρυσμένο μέρος από το ίδιο στιγμιότυπο."
 
-#: src/ExternalConn.cpp:630
+#: src/ExternalConn.cpp:631
 #, fuzzy
 msgid "You cannot connect to a release version from an arbitrary development snapshot! *sigh* possible crash prevented"
 msgstr "Δεν μπορείτε να συνδεθείτε σε μια επίσημη έκδοση από μια αναπτυσσόμενη (SVN) έκδοση! *ουφ* αποφευχθεί πιθανό κρέμασμα"
 
-#: src/ExternalConn.cpp:713
+#: src/ExternalConn.cpp:714
 msgid "Invalid protocol version."
 msgstr "Άκυρη έκδοση πρωτοκόλλου."
 
-#: src/ExternalConn.cpp:719
+#: src/ExternalConn.cpp:720
 msgid "Missing protocol version tag."
 msgstr "Λείπει η ετικέτα με την έκδοση του πρωτοκόλλου."
 
-#: src/ExternalConn.cpp:727
+#: src/ExternalConn.cpp:728
 msgid "Authentication failed: invalid hash specified as EC password."
 msgstr ""
 
-#: src/ExternalConn.cpp:775
+#: src/ExternalConn.cpp:776
 #, fuzzy
 msgid "Authentication failed: wrong password."
 msgstr "Η πιστοποίηση απέτυχε."
 
-#: src/ExternalConn.cpp:777
+#: src/ExternalConn.cpp:778
 #, fuzzy
 msgid "Authentication failed: missing password."
 msgstr "Η πιστοποίηση απέτυχε."
 
-#: src/ExternalConn.cpp:788
+#: src/ExternalConn.cpp:789
 #, fuzzy
 msgid "Invalid request, please authenticate first."
 msgstr "Άκυρη αίτηση, πρέπει πρώτα να πιστοποιηθήτε."
 
-#: src/ExternalConn.cpp:793
+#: src/ExternalConn.cpp:794
 msgid "Access granted."
 msgstr "Η πρόσβαση επικυρώθηκε."
 
-#: src/ExternalConn.cpp:801
+#: src/ExternalConn.cpp:802
 #, fuzzy, c-format
 msgid "Sent error message \"%s\" to client."
 msgstr "Διήθηση μηνυμάτων από άγνωστους πελάτες"
 
-#: src/ExternalConn.cpp:806
+#: src/ExternalConn.cpp:807
 #, fuzzy, c-format
 msgid "Unauthorized access attempt from %s. Connection closed."
 msgstr "Απόπειρα μη εξουσιοδοτημένης πρόσβασης. Η σύνδεση έκλεισε."
 
-#: src/ExternalConn.cpp:1419
+#: src/ExternalConn.cpp:1420
 #, c-format
 msgid "Remote PartFile command failed: FileHash not found: %s"
 msgstr "Η απομακρυσμένη εντολή ημιτελούς αρχείου απέτυχε: Ο κατακερματισμός αρχείου δεν βρέθηκε: %s"
 
-#: src/ExternalConn.cpp:1423
+#: src/ExternalConn.cpp:1424
 #, c-format
 msgid "FileHash not found: %s"
 msgstr "Ο κατακερματισμός αρχείου δεν βρέθηκε: %s"
 
-#: src/ExternalConn.cpp:1470 src/ExternalConn.cpp:1558
-#: src/ExternalConn.cpp:1679
+#: src/ExternalConn.cpp:1471 src/ExternalConn.cpp:1559
+#: src/ExternalConn.cpp:1680
 msgid "OOPS! OpCode processing error!"
 msgstr "Όπα! Σφάλμα επεξεργασίας OpCode!"
 
-#: src/ExternalConn.cpp:1501
+#: src/ExternalConn.cpp:1502
 msgid "Server not added"
 msgstr "Ο διακομιστής δεν προστέθηκε"
 
-#: src/ExternalConn.cpp:1520
+#: src/ExternalConn.cpp:1521
 #, c-format
 msgid "server not found: %s"
 msgstr "Ο διακομιστής δεν βρέθηκε: %s"
 
-#: src/ExternalConn.cpp:1537
+#: src/ExternalConn.cpp:1538
 msgid "need to define server to be removed"
 msgstr "χρειάζεται να οριστεί ο διακομιστής που να διαγραφεί"
 
-#: src/ExternalConn.cpp:1552
+#: src/ExternalConn.cpp:1553
 msgid "eD2k is disabled in preferences."
 msgstr "Το eD2k είναι απενεργοποιημένο στις ρυθμίσεις."
 
-#: src/ExternalConn.cpp:1657
+#: src/ExternalConn.cpp:1658
 #, fuzzy
 msgid "Friend not found."
 msgstr "Το αρχείο δεν βρέθηκε."
 
-#: src/ExternalConn.cpp:1667
+#: src/ExternalConn.cpp:1668
 #, fuzzy
 msgid "Client not found."
 msgstr "Το αρχείο δεν βρέθηκε."
 
-#: src/ExternalConn.cpp:1673
+#: src/ExternalConn.cpp:1674
 msgid "EC_TAG_FRIEND_SHARED requires EC_TAG_FRIEND or EC_TAG_CLIENT."
 msgstr ""
 
-#: src/ExternalConn.cpp:1991
+#: src/ExternalConn.cpp:1992
 msgid "WebSearch from remote interface makes no sense."
 msgstr "Η αναζήτηση από τον ιστό από απομακρυσμένο περιβάλλον δεν έχει κανένα νόημα."
 
-#: src/ExternalConn.cpp:2026
+#: src/ExternalConn.cpp:2027
 msgid "Search in progress. Refetch results in a moment!"
 msgstr "Αναζήτηση δια εξέλιξη. Επανάκτηση αποτελεσμάτων σε λίγο!"
 
-#: src/ExternalConn.cpp:2265
+#: src/ExternalConn.cpp:2266
 msgid "No points for graph."
 msgstr "Δεν υπάρχουν σημεία για γράφημα."
 
-#: src/ExternalConn.cpp:2275
+#: src/ExternalConn.cpp:2276
 msgid "Your client is not configured for this detail level."
 msgstr "Ο πελάτης σας δεν έχει ρυθμιστεί με τόση λεπτομέρεια"
 
-#: src/ExternalConn.cpp:2302
+#: src/ExternalConn.cpp:2303
 msgid "External Connection: shutdown requested"
 msgstr "Εξωτερική σύνδεση: ζητήθηκε κλείσιμο"
 
-#: src/ExternalConn.cpp:2314
+#: src/ExternalConn.cpp:2315
 msgid "Already shutting down."
 msgstr "Ήδη η λειτουργία είναι σε φάση διακοπής"
 
-#: src/ExternalConn.cpp:2332
+#: src/ExternalConn.cpp:2333
 #, c-format
 msgid "ExternalConn: adding link '%s'."
 msgstr "Εξωτερική Σύνδεση: προστίθεται ο σύνδεσμος '%s'."
 
-#: src/ExternalConn.cpp:2350
+#: src/ExternalConn.cpp:2351
 #, fuzzy, c-format
 msgid "%d of %d links failed (invalid or already on list)."
 msgstr "Άκυρος σύνδεσμο ή ήδη στην λίστα."
 
-#: src/ExternalConn.cpp:2373
+#: src/ExternalConn.cpp:2374
 msgid "Version check throttled; try again shortly."
 msgstr ""
 
-#: src/ExternalConn.cpp:2378
+#: src/ExternalConn.cpp:2379
 msgid "Version check is not available on this daemon."
 msgstr ""
 
-#: src/ExternalConn.cpp:2508
+#: src/ExternalConn.cpp:2509
 msgid "File not found."
 msgstr "Το αρχείο δεν βρέθηκε."
 
-#: src/ExternalConn.cpp:2513
+#: src/ExternalConn.cpp:2514
 msgid "Invalid file name."
 msgstr "Άκυρο όνομα αρχείου."
 
-#: src/ExternalConn.cpp:2521
+#: src/ExternalConn.cpp:2522
 msgid "Unable to rename file."
 msgstr "Αποτυχία μετονομασίας αρχείου."
 
-#: src/ExternalConn.cpp:2992 src/ExternalConn.cpp:3020
+#: src/ExternalConn.cpp:2839
+#, c-format
+msgid "Could not save the amuleapi password: %s"
+msgstr ""
+
+#: src/ExternalConn.cpp:3004 src/ExternalConn.cpp:3032
 msgid "Kad is disabled in preferences."
 msgstr "Το Kad έχει απενεργοποιηθεί στις προτιμήσεις."
 
-#: src/ExternalConn.cpp:3033
+#: src/ExternalConn.cpp:3045
 msgid "Already connected to eD2k."
 msgstr "Ήδη συνδεδεμένο στο eD2k."
 
-#: src/ExternalConn.cpp:3036
+#: src/ExternalConn.cpp:3048
 msgid "Connecting to eD2k..."
 msgstr "Συνδέεται στο eD2k..."
 
-#: src/ExternalConn.cpp:3045
+#: src/ExternalConn.cpp:3057
 msgid "Already connected to Kad."
 msgstr "Ήδη συνδεδεμένο στο Kad."
 
-#: src/ExternalConn.cpp:3048
+#: src/ExternalConn.cpp:3060
 msgid "Connecting to Kad..."
 msgstr "Διαδικασία σύνδεσης στο Kad..."
 
-#: src/ExternalConn.cpp:3055
+#: src/ExternalConn.cpp:3067
 msgid "All networks are disabled."
 msgstr "Όλα τα δίκτυα είναι απενεργοποιημένα."
 
-#: src/ExternalConn.cpp:3064
+#: src/ExternalConn.cpp:3076
 msgid "Disconnected from eD2k."
 msgstr "Αποσυνδεδεμένο από το eD2k."
 
-#: src/ExternalConn.cpp:3069
+#: src/ExternalConn.cpp:3081
 msgid "Disconnected from Kad."
 msgstr "Αποσυνδεδεμένο από το Kad."
 
-#: src/ExternalConn.cpp:3078
+#: src/ExternalConn.cpp:3090
 #, c-format
 msgid "External Connection: invalid opcode received: %#x"
 msgstr "Εξωτερική σύνδεση: λήφθηκε άκυρος opcode: %#x"
 
-#: src/ExternalConn.cpp:3083
+#: src/ExternalConn.cpp:3095
 msgid "Invalid opcode (wrong protocol version?)"
 msgstr "Εσφαλμένος κωδικός (λάθος έκδοση πρωτοκόλλου;)"
 
@@ -2438,23 +2443,23 @@ msgid ""
 "want downloads on a different (e.g. larger) disk."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:549 src/FirstRunWizard.cpp:611 src/muuli_wdr.cpp:1708
+#: src/FirstRunWizard.cpp:549 src/FirstRunWizard.cpp:611 src/muuli_wdr.cpp:1712
 msgid "Destination folder for downloads"
 msgstr "Κατάλογος για τα εισερχόμενα"
 
 #: src/FirstRunWizard.cpp:553 src/FirstRunWizard.cpp:569 src/muuli_wdr.cpp:1349
-#: src/muuli_wdr.cpp:1366 src/muuli_wdr.cpp:1683 src/muuli_wdr.cpp:1714
-#: src/muuli_wdr.cpp:1726 src/muuli_wdr.cpp:2769
+#: src/muuli_wdr.cpp:1366 src/muuli_wdr.cpp:1687 src/muuli_wdr.cpp:1718
+#: src/muuli_wdr.cpp:1730 src/muuli_wdr.cpp:2800
 #: src/utils/aLinkCreator/src/alcframe.cpp:135
 #: src/utils/wxCas/src/wxcasprefs.cpp:52 src/utils/wxCas/src/wxcasprefs.cpp:118
 msgid "Browse"
 msgstr "Επιλογή"
 
-#: src/FirstRunWizard.cpp:559 src/muuli_wdr.cpp:1719
+#: src/FirstRunWizard.cpp:559 src/muuli_wdr.cpp:1723
 msgid "(All files in this folder are shared with other peers)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:565 src/FirstRunWizard.cpp:624 src/muuli_wdr.cpp:1721
+#: src/FirstRunWizard.cpp:565 src/FirstRunWizard.cpp:624 src/muuli_wdr.cpp:1725
 msgid "Folder for temporary download files"
 msgstr "Κατάλογος για τα προσωρινά αρχεία"
 
@@ -2485,7 +2490,7 @@ msgstr "Αποτυχία γραψίματος στο αρχείο της λίσ�
 msgid "CRITICAL - no client on StartChatSession"
 msgstr ""
 
-#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2675 src/muuli_wdr.cpp:3352
+#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2706 src/muuli_wdr.cpp:3383
 msgid "Friends"
 msgstr "Φίλοι"
 
@@ -2599,8 +2604,8 @@ msgstr "Κανείς"
 msgid "No"
 msgstr "Όχι"
 
-#: src/GenericClientListCtrl.cpp:1216 src/PrefsUnifiedDlg.cpp:2818
-#: src/PrefsUnifiedDlg.cpp:2868 src/ServerListCtrl.cpp:276
+#: src/GenericClientListCtrl.cpp:1216 src/PrefsUnifiedDlg.cpp:2898
+#: src/PrefsUnifiedDlg.cpp:2948 src/ServerListCtrl.cpp:276
 msgid "Yes"
 msgstr "Ναι"
 
@@ -2770,10 +2775,10 @@ msgstr "Άκυρη θύρα για εκκινητήρα"
 msgid "Please fill all fields required"
 msgstr "Παρακαλώ συμπληρώστε όλα τα απαιτούμενα πεδία"
 
-#: src/KadDlg.cpp:192 src/PartFile.cpp:1031 src/PrefsUnifiedDlg.cpp:1162
-#: src/PrefsUnifiedDlg.cpp:1331 src/PrefsUnifiedDlg.cpp:1589
-#: src/PrefsUnifiedDlg.cpp:1599 src/PrefsUnifiedDlg.cpp:1616
-#: src/PrefsUnifiedDlg.cpp:1658
+#: src/KadDlg.cpp:192 src/PartFile.cpp:1031 src/PrefsUnifiedDlg.cpp:1134
+#: src/PrefsUnifiedDlg.cpp:1204 src/PrefsUnifiedDlg.cpp:1405
+#: src/PrefsUnifiedDlg.cpp:1663 src/PrefsUnifiedDlg.cpp:1673
+#: src/PrefsUnifiedDlg.cpp:1690 src/PrefsUnifiedDlg.cpp:1738
 msgid "Message"
 msgstr "Μήνυμα"
 
@@ -2875,7 +2880,7 @@ msgstr "Λόγος μοιράσματος"
 msgid "Uploaded"
 msgstr "Ανέβηκε"
 
-#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3232
+#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3263
 msgid "Requested"
 msgstr "Ζητήθηκε:"
 
@@ -3001,7 +3006,7 @@ msgid "WARNING: "
 msgstr "ΠΡΟΕΙΔΟΠΟΙΗΣΗ:"
 
 #: src/MuleNotebook.cpp:179 src/muuli_wdr.cpp:817 src/muuli_wdr.cpp:1229
-#: src/muuli_wdr.cpp:3136 src/muuli_wdr.cpp:3392
+#: src/muuli_wdr.cpp:3167 src/muuli_wdr.cpp:3423
 msgid "Close"
 msgstr "Κλείσιμο"
 
@@ -3019,7 +3024,7 @@ msgid "Paste"
 msgstr "Επικόλληση"
 
 #: src/MuleTextCtrl.cpp:89 src/muuli_wdr.cpp:358 src/muuli_wdr.cpp:757
-#: src/muuli_wdr.cpp:2359 src/muuli_wdr.cpp:2378 src/muuli_wdr.cpp:2400
+#: src/muuli_wdr.cpp:2390 src/muuli_wdr.cpp:2409 src/muuli_wdr.cpp:2431
 #: src/utils/aLinkCreator/src/alcframe.cpp:142
 msgid "Clear"
 msgstr "Καθαρισμός"
@@ -3118,7 +3123,7 @@ msgstr "Έξοδος"
 
 #: src/MuleTrayIcon.cpp:579 src/MuleTrayIcon.cpp:945 src/MuleTrayIcon.cpp:965
 #: src/muuli_wdr.cpp:1398 src/muuli_wdr.cpp:1406 src/muuli_wdr.cpp:1413
-#: src/muuli_wdr.cpp:1842 src/muuli_wdr.cpp:1848 src/OtherFunctions.cpp:91
+#: src/muuli_wdr.cpp:1846 src/muuli_wdr.cpp:1852 src/OtherFunctions.cpp:91
 #: src/StatisticsDlg.cpp:93 src/StatisticsDlg.cpp:95
 msgid "kB/s"
 msgstr "kB/s"
@@ -3360,7 +3365,7 @@ msgstr "Bytes"
 msgid "KB"
 msgstr "KB"
 
-#: src/muuli_wdr.cpp:274 src/muuli_wdr.cpp:293 src/muuli_wdr.cpp:1627
+#: src/muuli_wdr.cpp:274 src/muuli_wdr.cpp:293 src/muuli_wdr.cpp:1631
 #: src/OtherFunctions.cpp:64
 msgid "MB"
 msgstr "MB"
@@ -3377,7 +3382,7 @@ msgstr "Μέγιστο αρχείο"
 msgid "Availability"
 msgstr "Διαθεσιμότητα"
 
-#: src/muuli_wdr.cpp:312 src/muuli_wdr.cpp:398 src/muuli_wdr.cpp:3297
+#: src/muuli_wdr.cpp:312 src/muuli_wdr.cpp:398 src/muuli_wdr.cpp:3328
 msgid "Filter:"
 msgstr "Φίλτρο:"
 
@@ -3441,12 +3446,12 @@ msgstr "Ολοκλήρωση πηγών"
 #: src/muuli_wdr.cpp:1160 src/muuli_wdr.cpp:1167 src/muuli_wdr.cpp:1172
 #: src/muuli_wdr.cpp:1179 src/muuli_wdr.cpp:1184 src/muuli_wdr.cpp:1191
 #: src/muuli_wdr.cpp:1205 src/muuli_wdr.cpp:1212 src/muuli_wdr.cpp:1217
-#: src/muuli_wdr.cpp:1224 src/muuli_wdr.cpp:3234 src/muuli_wdr.cpp:3242
-#: src/muuli_wdr.cpp:3250
+#: src/muuli_wdr.cpp:1224 src/muuli_wdr.cpp:3265 src/muuli_wdr.cpp:3273
+#: src/muuli_wdr.cpp:3281
 msgid "N/A"
 msgstr "Δεν υπάρχει"
 
-#: src/muuli_wdr.cpp:508 src/muuli_wdr.cpp:1065 src/PrefsUnifiedDlg.cpp:297
+#: src/muuli_wdr.cpp:508 src/muuli_wdr.cpp:1065 src/PrefsUnifiedDlg.cpp:299
 msgid "General"
 msgstr "Γενικά"
 
@@ -3587,7 +3592,7 @@ msgstr ""
 msgid "Album :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:685 src/muuli_wdr.cpp:2254
+#: src/muuli_wdr.cpp:685 src/muuli_wdr.cpp:2285
 msgid "Title :"
 msgstr "Τίτλος:"
 
@@ -3696,7 +3701,7 @@ msgstr "Όνομα χρήστη :"
 msgid "Userhash :"
 msgstr "Τεμάχιο χρήστη :"
 
-#: src/muuli_wdr.cpp:895 src/muuli_wdr.cpp:1748 src/muuli_wdr.cpp:2449
+#: src/muuli_wdr.cpp:895 src/muuli_wdr.cpp:1752 src/muuli_wdr.cpp:2480
 #: src/utils/aLinkCreator/src/alcframe.cpp:137
 msgid "Add"
 msgstr "Προσθήκη"
@@ -3705,15 +3710,15 @@ msgstr "Προσθήκη"
 msgid "Download-Speed"
 msgstr "Ταχύτητα κατεβάσματος"
 
-#: src/muuli_wdr.cpp:954 src/muuli_wdr.cpp:989 src/muuli_wdr.cpp:2553
+#: src/muuli_wdr.cpp:954 src/muuli_wdr.cpp:989 src/muuli_wdr.cpp:2584
 msgid "Current"
 msgstr "Τρέχων"
 
-#: src/muuli_wdr.cpp:962 src/muuli_wdr.cpp:997 src/muuli_wdr.cpp:2561
+#: src/muuli_wdr.cpp:962 src/muuli_wdr.cpp:997 src/muuli_wdr.cpp:2592
 msgid "Running average"
 msgstr "Μέσο τρεξίματος"
 
-#: src/muuli_wdr.cpp:970 src/muuli_wdr.cpp:1005 src/muuli_wdr.cpp:2569
+#: src/muuli_wdr.cpp:970 src/muuli_wdr.cpp:1005 src/muuli_wdr.cpp:2600
 msgid "Session average"
 msgstr "Μέσο περιόδου"
 
@@ -3725,7 +3730,7 @@ msgstr "Ταχύτητα ανεβάσματος"
 msgid "Connections"
 msgstr "Συνδέσεις"
 
-#: src/muuli_wdr.cpp:1024 src/muuli_wdr.cpp:1867
+#: src/muuli_wdr.cpp:1024 src/muuli_wdr.cpp:1871
 msgid "Active downloads"
 msgstr "Ενεργά κατεβάσματα"
 
@@ -3733,7 +3738,7 @@ msgstr "Ενεργά κατεβάσματα"
 msgid "Active connections (1:1)"
 msgstr "Ενεργές συνδέσεις (1:1)"
 
-#: src/muuli_wdr.cpp:1040 src/muuli_wdr.cpp:1868
+#: src/muuli_wdr.cpp:1040 src/muuli_wdr.cpp:1872
 msgid "Active uploads"
 msgstr "Ενεργά ανεβάσματα"
 
@@ -4010,7 +4015,7 @@ msgstr "Συνέδεσε την τοπική διεύθυνση στην διε�
 msgid "Advanced users only: If you have multiple network interfaces, enter the address of the interface to which aMule should be bound."
 msgstr "Μόνο για προχωρημένους χρήστες: Αν έχετε πολλαπλά δικτυακά περιβάλλοντα, εισάγετε την διεύθυνση του περιβάλλοντος με το οποίο το aMule πρέπει να συνδεθεί."
 
-#: src/muuli_wdr.cpp:1462 src/muuli_wdr.cpp:2061
+#: src/muuli_wdr.cpp:1462 src/muuli_wdr.cpp:2065
 #, fuzzy
 msgid "Bind to network interface (empty for any):"
 msgstr "Συνέδεσε την τοπική διεύθυνση στην διεύθυνση (κενό για όλες):"
@@ -4027,7 +4032,7 @@ msgstr "Μέγιστος αριθμός πηγών ανά εισερχόμενο
 msgid "Max simultaneous connections:"
 msgstr "Μέγιστος αριθμός παράλληλων συνδέσεων:"
 
-#: src/muuli_wdr.cpp:1498 src/muuli_wdr.cpp:3176
+#: src/muuli_wdr.cpp:1498 src/muuli_wdr.cpp:3207
 msgid "ED2K"
 msgstr "ED2K"
 
@@ -4119,760 +4124,783 @@ msgstr "Δέσμευση χώρου στο δίσκο για καινούρια 
 msgid "For new files preallocates disk space for the whole file, thus reduces fragmentation"
 msgstr "Δεσμεύει χώρο στο δίσκο για καινούρια αρχεία και έτσι μειώνει τον κατακερματισμό"
 
-#: src/muuli_wdr.cpp:1613
+#: src/muuli_wdr.cpp:1617
 msgid "Create new files as sparse files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1614
-msgid "A sparse file reserves its full size on disk immediately without writing real data to it -- fast, but unsupported or slow on some filesystems, and free-space accounting stays optimistic while the download is in progress. Turn this off to grow the file only as data arrives."
+#: src/muuli_wdr.cpp:1618
+msgid "Sparse part files only occupy disk space for the parts already downloaded, so free space is used up gradually as the file fills in. Turn this off to use an ordinary file instead - useful where sparse files are unsupported or slow, or where backup/de-duplication tools handle them badly. Applies only when the core runs on Windows; on Linux and macOS part files are sparse anyway and this setting has no effect."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1619
+#: src/muuli_wdr.cpp:1623
 msgid "Stop downloads when free disk space reaches "
 msgstr "Σταμάτημα του κατεβάσματος όταν ο ελεύθερος δίσκος φτάσει τα"
 
-#: src/muuli_wdr.cpp:1620
+#: src/muuli_wdr.cpp:1624
 msgid "Select this if you want aMule to check your disk space"
 msgstr "Επιλέξτε αυτό αν θέλετε το aMule να ελέγξει τον χώρο στον δίσκο σας"
 
-#: src/muuli_wdr.cpp:1624
+#: src/muuli_wdr.cpp:1628
 msgid "Enter here the min disk space desired."
 msgstr "Γράψτε εδώ των ελάχιστο επιθυμητό χώρο στον δίσκο."
 
-#: src/muuli_wdr.cpp:1630
+#: src/muuli_wdr.cpp:1634
 msgid "Save 10 sources on rare files (< 20 sources)"
 msgstr "Αποθήκευση 10 πηγών σε σπάνια αρχεία (<20 πηγές)"
 
-#: src/muuli_wdr.cpp:1634 src/Statistics.cpp:790
+#: src/muuli_wdr.cpp:1638 src/Statistics.cpp:790
 msgid "Uploads"
 msgstr "Ανεβασμένα"
 
-#: src/muuli_wdr.cpp:1637
+#: src/muuli_wdr.cpp:1641
 msgid "Add new shared files with auto priority"
 msgstr "Προσθήκη νέων κοινόχρηστων αρχείων με αυτόματη προτεραιότητα"
 
-#: src/muuli_wdr.cpp:1643
+#: src/muuli_wdr.cpp:1647
 msgid "Intelligent Corruption Handling (I.C.H.)"
 msgstr "Έξυπνη διαχείριση φθοράς (Ε.Δ.Φ.)"
 
-#: src/muuli_wdr.cpp:1646
+#: src/muuli_wdr.cpp:1650
 msgid "Enable"
 msgstr "Ενεργοποιήση"
 
-#: src/muuli_wdr.cpp:1649
+#: src/muuli_wdr.cpp:1653
 msgid "Advanced I.C.H. trusts every hash (not recommended)"
 msgstr "Προχωρημένη Ε.Δ.Φ. εμπιστεύεται κάθε κατακερματισμό (δεν συνιστάται)"
 
-#: src/muuli_wdr.cpp:1661 src/PrefsUnifiedDlg.cpp:1910
+#: src/muuli_wdr.cpp:1665 src/PrefsUnifiedDlg.cpp:1990
 msgid "Media metadata extraction"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1665
+#: src/muuli_wdr.cpp:1669
 msgid "Extract length / bitrate / codec from shared audio and video files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1667
+#: src/muuli_wdr.cpp:1671
 msgid "When enabled, aMule runs ffprobe on each shared media file to fill in the Length / Bitrate / Codec columns other clients see when they find the file in a search. Requires ffmpeg (the ffprobe binary) to be installed."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1674
+#: src/muuli_wdr.cpp:1678
 msgid "Path to ffprobe:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1679
+#: src/muuli_wdr.cpp:1683
 msgid "Full path to the ffprobe binary. Leave empty to have aMule auto-detect it on startup."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1687
+#: src/muuli_wdr.cpp:1691
 msgid "Detect"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1688
+#: src/muuli_wdr.cpp:1692
 msgid "Search the standard install locations for an ffprobe binary and fill the path field."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1712
+#: src/muuli_wdr.cpp:1716
 msgid ""
 "Completed downloads are stored here. All files in this folder are automatically shared with other peers.\n"
 "If this folder also holds files you don't want to share, point it at an aMule-only sub-folder."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1715
+#: src/muuli_wdr.cpp:1719
 msgid "Pick the folder where completed downloads will be stored. All files in that folder will be shared with other peers."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1729
+#: src/muuli_wdr.cpp:1733
 msgid "Shared folders"
 msgstr "Κοινόχρηστα αρχεία"
 
-#: src/muuli_wdr.cpp:1735
+#: src/muuli_wdr.cpp:1739
 msgid "(Folders shared by the core. Enter a path to add one.)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1743
+#: src/muuli_wdr.cpp:1747
 msgid "Absolute path of a folder on the core's machine, e.g. /home/user/shared"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1745 src/PrefsUnifiedDlg.cpp:2794
+#: src/muuli_wdr.cpp:1749 src/PrefsUnifiedDlg.cpp:2874
 msgid "Recursive"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1746
+#: src/muuli_wdr.cpp:1750
 msgid "Share every sub-folder underneath this one, including ones created later."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1750 src/utils/aLinkCreator/src/alcframe.cpp:141
+#: src/muuli_wdr.cpp:1754 src/utils/aLinkCreator/src/alcframe.cpp:141
 msgid "Remove"
 msgstr "Αφαίρεση"
 
-#: src/muuli_wdr.cpp:1754
+#: src/muuli_wdr.cpp:1758
 msgid "(Right click on folder icon for recursive share)"
 msgstr "(Δεξί κλικ στην εικόνα του καταλόγου για να γίνουν κοινόχρηστοι οι υποκατάλογοι)"
 
-#: src/muuli_wdr.cpp:1761
+#: src/muuli_wdr.cpp:1765
 msgid "Share hidden files"
 msgstr "Κάνε τα κρυφά αρχεία κοινόχρηστα"
 
-#: src/muuli_wdr.cpp:1767
+#: src/muuli_wdr.cpp:1771
 msgid "Automatically rescan shared folders for changes"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1773
+#: src/muuli_wdr.cpp:1777
 msgid "Follow symbolic links in shared folders"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1779
+#: src/muuli_wdr.cpp:1783
 msgid "Exclude files matching:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1782
+#: src/muuli_wdr.cpp:1786
 msgid "Wildcard patterns separated by '|', e.g. .DS_Store|Thumbs.db|*.tmp. Files whose name matches are not shared. Matching is case-insensitive."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1786
+#: src/muuli_wdr.cpp:1790
 msgid "Patterns are regular expressions"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1787
+#: src/muuli_wdr.cpp:1791
 msgid "When set, the whole field is one regular expression ('|' is alternation). When unset, it is a list of '|'-separated wildcards."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1797
+#: src/muuli_wdr.cpp:1801
 msgid "Show how many shared files the current pattern would exclude."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1818
+#: src/muuli_wdr.cpp:1822
 msgid "Graphs"
 msgstr "Γραφικές Παραστάσεις"
 
-#: src/muuli_wdr.cpp:1821 src/muuli_wdr.cpp:1883
+#: src/muuli_wdr.cpp:1825 src/muuli_wdr.cpp:1887
 msgid "Update delay : 5 secs"
 msgstr "Χρόνος καθυστέρηση ενημέρωσης : 5 δευτερόλεπτα"
 
-#: src/muuli_wdr.cpp:1825
+#: src/muuli_wdr.cpp:1829
 msgid "Time for average graph: 100 mins"
 msgstr "Χρόνος μέσου γραφήματος: 100 λεπτά"
 
-#: src/muuli_wdr.cpp:1829
+#: src/muuli_wdr.cpp:1833
 msgid "Connections Graph Scale: 100 "
 msgstr "Κλίμακα διαγράμματος συνδέσεων: 100"
 
-#: src/muuli_wdr.cpp:1836
+#: src/muuli_wdr.cpp:1840
 msgid "Download graph scale:"
 msgstr "Κλιματα του γραφήματος εισερχομένων:"
 
-#: src/muuli_wdr.cpp:1844
+#: src/muuli_wdr.cpp:1848
 msgid "Upload graph scale:"
 msgstr "Κλιμακα του γραφήματος εξερχομένων"
 
-#: src/muuli_wdr.cpp:1854
+#: src/muuli_wdr.cpp:1858
 #, fuzzy
 msgid "Colors: "
 msgstr "Χρώματα:"
 
-#: src/muuli_wdr.cpp:1858
+#: src/muuli_wdr.cpp:1862
 msgid "Background"
 msgstr "Υπόβαθρο"
 
-#: src/muuli_wdr.cpp:1859
+#: src/muuli_wdr.cpp:1863
 msgid "Grid"
 msgstr "Πλέγμα"
 
-#: src/muuli_wdr.cpp:1860
+#: src/muuli_wdr.cpp:1864
 msgid "Download current"
 msgstr "Κατέβασμα του τρέχοντος"
 
-#: src/muuli_wdr.cpp:1861
+#: src/muuli_wdr.cpp:1865
 msgid "Download running average"
 msgstr "Μέσο τρέξιμο κατεβάσματος"
 
-#: src/muuli_wdr.cpp:1862
+#: src/muuli_wdr.cpp:1866
 msgid "Download session average"
 msgstr "Μέσο συνεδρίας κατεβάσματος"
 
-#: src/muuli_wdr.cpp:1863
+#: src/muuli_wdr.cpp:1867
 msgid "Upload current"
 msgstr "Ανέβασμα του τρέχοντος"
 
-#: src/muuli_wdr.cpp:1864
+#: src/muuli_wdr.cpp:1868
 msgid "Upload running average"
 msgstr "Μέσο τρέξιμο ανεβάσματος"
 
-#: src/muuli_wdr.cpp:1865
+#: src/muuli_wdr.cpp:1869
 msgid "Upload session average"
 msgstr "Μέσο συνεδρίας ανεβάσματος"
 
-#: src/muuli_wdr.cpp:1866
+#: src/muuli_wdr.cpp:1870
 msgid "Active connections"
 msgstr "Ενεργές συνδέσεις"
 
-#: src/muuli_wdr.cpp:1869
+#: src/muuli_wdr.cpp:1873
 #, fuzzy
 msgid "Systray Icon Speed Bar"
 msgstr "Εικόνα για την μπάρα ταχείας πρόσβασης του Systray"
 
-#: src/muuli_wdr.cpp:1870
+#: src/muuli_wdr.cpp:1874
 msgid "Kad-nodes current"
 msgstr "Σύνδεσμοι-Kad παρόντες"
 
-#: src/muuli_wdr.cpp:1871
+#: src/muuli_wdr.cpp:1875
 msgid "Kad-nodes running"
 msgstr "Σύνδεσμοι-Kad τρέχοντες"
 
-#: src/muuli_wdr.cpp:1872
+#: src/muuli_wdr.cpp:1876
 msgid "Kad-nodes session"
 msgstr "Σύνδεσμοι-Kad συνεδρία"
 
-#: src/muuli_wdr.cpp:1876 src/muuli_wdr.cpp:2303
+#: src/muuli_wdr.cpp:1880 src/muuli_wdr.cpp:2334
 msgid "Select"
 msgstr "Επέλεξε"
 
-#: src/muuli_wdr.cpp:1880
+#: src/muuli_wdr.cpp:1884
 msgid "Tree"
 msgstr "Δέντρο"
 
-#: src/muuli_wdr.cpp:1890
+#: src/muuli_wdr.cpp:1894
 msgid "Number of Client Versions shown (0=unlimited)"
 msgstr "Αριθμός των εμφανιζόμενων εκδόσεων πελάτη (0=απεριόριστος)"
 
-#: src/muuli_wdr.cpp:1915
+#: src/muuli_wdr.cpp:1919
 msgid "!!! WARNING !!!"
 msgstr "!!! Προειδοποίηση !!!"
 
-#: src/muuli_wdr.cpp:1930
+#: src/muuli_wdr.cpp:1934
 msgid "Max new connections / 5 secs"
 msgstr "Μέγιστος αρ. νέων συνδέσεων /5 δευτερόλεπτα"
 
-#: src/muuli_wdr.cpp:1932
+#: src/muuli_wdr.cpp:1936
 msgid "Concurrent Kad source lookups"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1934
+#: src/muuli_wdr.cpp:1938
 #, fuzzy
 msgid "Kad source re-search interval (minutes)"
 msgstr "Περίοδος ενημέρωσης του FTP σε λεπτά"
 
-#: src/muuli_wdr.cpp:1936
+#: src/muuli_wdr.cpp:1940
 #, fuzzy
 msgid "Source re-ask interval (minutes)"
 msgstr "Περίοδος ενημέρωσης του FTP σε λεπτά"
 
-#: src/muuli_wdr.cpp:1940
+#: src/muuli_wdr.cpp:1944
 msgid "File Buffer Size: 240000 bytes"
 msgstr "Χώρος προσωρινής αποθήκευσης αρχείου: 240000 bytes"
 
-#: src/muuli_wdr.cpp:1944
+#: src/muuli_wdr.cpp:1948
 msgid "Use MMAP: memory-mapped file access (lower memory use)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1945
+#: src/muuli_wdr.cpp:1949
 msgid "Maps part files into memory instead of buffering them on the heap, lowering the process memory footprint. May reduce download speed on some disks; best for memory-constrained or upload-heavy hosts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1947
+#: src/muuli_wdr.cpp:1951
 msgid "Upload Queue Size: 5000 clients"
 msgstr "Λίστα αναμονής ανεβάσματος: 5000 πελάτες"
 
-#: src/muuli_wdr.cpp:1951
+#: src/muuli_wdr.cpp:1955
 msgid "Server connection refresh interval: Disable"
 msgstr "Διάστημα ανανέωσης της σύνδεσης σε διακομιστή: Απενεργοποίηση"
 
-#: src/muuli_wdr.cpp:1955
+#: src/muuli_wdr.cpp:1959
 msgid "Disable computer's timed standby mode"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1974
+#: src/muuli_wdr.cpp:1978
 msgid "Skin to use: "
 msgstr "Θέμα:"
 
-#: src/muuli_wdr.cpp:1983
+#: src/muuli_wdr.cpp:1987
 msgid "Show \"Fast eD2k Links Handler\" in every window."
 msgstr "Εμφάνιση \"Γρήγορου διαχειριστή συνδέσμων eD2k\" σε όλα τα παράθυρα."
 
-#: src/muuli_wdr.cpp:1986
+#: src/muuli_wdr.cpp:1990
 msgid "Show extended info on categories tabs"
 msgstr "Εμφάνιση εκτεταμένων πληροφοριών στην καρτέλα κατηγοριών"
 
-#: src/muuli_wdr.cpp:1989
+#: src/muuli_wdr.cpp:1993
 #, fuzzy
 msgid "Show application version on title"
 msgstr "Εμφάνιση των ταχυτήτων μεταφοράς στον τίτλο"
 
-#: src/muuli_wdr.cpp:1991
+#: src/muuli_wdr.cpp:1995
 msgid "Show transfer rates on title"
 msgstr "Εμφάνιση των ταχυτήτων μεταφοράς στον τίτλο"
 
-#: src/muuli_wdr.cpp:1993
+#: src/muuli_wdr.cpp:1997
 msgid "Before application name"
 msgstr "Πριν απο το όνομα της εφαρμογής"
 
-#: src/muuli_wdr.cpp:1995
+#: src/muuli_wdr.cpp:1999
 msgid "After application name"
 msgstr "Μετά το όνομα της εφαρμογής"
 
-#: src/muuli_wdr.cpp:1998
+#: src/muuli_wdr.cpp:2002
 msgid "Show overhead bandwidth"
 msgstr "Εμφάνιση επιβάρυνσης στο εύρος ζώνης"
 
-#: src/muuli_wdr.cpp:2002
+#: src/muuli_wdr.cpp:2006
 msgid "Vertical toolbar orientation"
 msgstr "Κατακόρυφος προσανατολισμός της γραμμής εντολών"
 
-#: src/muuli_wdr.cpp:2004
+#: src/muuli_wdr.cpp:2008
 msgid "Live column sorting (auto-reorder rows as their values change)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2011
+#: src/muuli_wdr.cpp:2015
 msgid "Download Queue Files"
 msgstr "Ουρά εισερχομένων αρχείων"
 
-#: src/muuli_wdr.cpp:2014
+#: src/muuli_wdr.cpp:2018
 msgid "Show progress percentage"
 msgstr "Εμφάνιση ποσοστού προόδου"
 
-#: src/muuli_wdr.cpp:2020
+#: src/muuli_wdr.cpp:2024
 msgid "Show progress bar"
 msgstr "Εμφάνιση μπάρας προόδου"
 
-#: src/muuli_wdr.cpp:2023
+#: src/muuli_wdr.cpp:2027
 msgid "Flat"
 msgstr "Επίπεδη"
 
-#: src/muuli_wdr.cpp:2027
+#: src/muuli_wdr.cpp:2031
 msgid "Round"
 msgstr "Στρογγυλή"
 
-#: src/muuli_wdr.cpp:2045
+#: src/muuli_wdr.cpp:2049
 msgid "External Connection Parameters"
 msgstr "Παράμετροι εξωτερικών συνδέσεων"
 
-#: src/muuli_wdr.cpp:2048
+#: src/muuli_wdr.cpp:2052
 msgid "Accept external connections"
 msgstr "Να γίνονται αποδεκτές οι εξωτερικές συνδέσεις"
 
-#: src/muuli_wdr.cpp:2055 src/muuli_wdr.cpp:2114
+#: src/muuli_wdr.cpp:2059 src/muuli_wdr.cpp:2118
 msgid "IP of the listening interface:"
 msgstr "Η διεύθυνση του εισακούοντος περιβάλλοντος:"
 
-#: src/muuli_wdr.cpp:2058
+#: src/muuli_wdr.cpp:2062
 msgid "Enter here a valid ip in the a.b.c.d format for the listening EC interface. An empty field or 0.0.0.0 will mean any interface."
 msgstr "Εισάγετε μία έγκυρη διεύθυνση με φόρμα a.b.c.d για σύνδεση με το περιβάλλον EC. Άδειο πεδίου ή 0.0.0.0 συμβολίζει όλα τα περιβάλλοντα."
 
-#: src/muuli_wdr.cpp:2079 src/muuli_wdr.cpp:2163
+#: src/muuli_wdr.cpp:2083 src/muuli_wdr.cpp:2194
 msgid "TCP port:"
 msgstr "Θύρα TCP:"
 
-#: src/muuli_wdr.cpp:2085
+#: src/muuli_wdr.cpp:2089
 msgid "Enable UPnP port forwarding on the EC port"
 msgstr "Ενεργοποίηση της προώθησης της θύρας UPnP στην θύρα EC"
 
-#: src/muuli_wdr.cpp:2089 src/muuli_wdr.cpp:3048
+#: src/muuli_wdr.cpp:2093 src/muuli_wdr.cpp:3079
 #: src/utils/wxCas/src/wxcasprefs.cpp:167
 msgid "Password"
 msgstr "Κωδικός"
 
-#: src/muuli_wdr.cpp:2095
+#: src/muuli_wdr.cpp:2099
 #, fuzzy
 msgid "aMule API server parameters"
 msgstr "Παράμετροι διακομιστή ιστού"
 
-#: src/muuli_wdr.cpp:2098
+#: src/muuli_wdr.cpp:2102
 msgid "Run amuleapi (REST API) on startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2103
+#: src/muuli_wdr.cpp:2107
 #, fuzzy
 msgid "HTTP port:"
 msgstr "Θύρα TCP:"
 
-#: src/muuli_wdr.cpp:2117
+#: src/muuli_wdr.cpp:2121
 msgid "The interface amuleapi's HTTP server listens on. 127.0.0.1 (default) accepts only local connections; use 0.0.0.0 or a specific IP to expose it to other hosts (set an admin password below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2120
+#: src/muuli_wdr.cpp:2126
+msgid "Type a password to set or change it. Stored passwords cannot be shown, so leaving this empty keeps the current one."
+msgstr ""
+
+#: src/muuli_wdr.cpp:2128
 #, fuzzy
 msgid "Admin password"
 msgstr "Έλεγχος κωδικού\n"
 
-#: src/muuli_wdr.cpp:2125 src/muuli_wdr.cpp:2156
-msgid "Low rights password"
-msgstr "Κωδικός μειωμένων δικαιωμάτων"
+#: src/muuli_wdr.cpp:2140 src/muuli_wdr.cpp:2157 src/PrefsUnifiedDlg.cpp:1103
+#, fuzzy
+msgid "A password is set."
+msgstr "Έλεγχος κωδικού\n"
 
-#: src/muuli_wdr.cpp:2133
+#: src/muuli_wdr.cpp:2144
+#, fuzzy
+msgid "Enable guest access"
+msgstr "Να απαγορεύεται η πρόσβαση σε επισκέπτες"
+
+#: src/muuli_wdr.cpp:2145
+msgid "Guest sessions may read status and listings but cannot change anything. Turning this off clears the stored guest password."
+msgstr ""
+
+#: src/muuli_wdr.cpp:2149
+#, fuzzy
+msgid "Guest password"
+msgstr "Κωδικός επισκέπτη για τον διακομιστή ιστού"
+
+#: src/muuli_wdr.cpp:2164
 msgid "Web server parameters"
 msgstr "Παράμετροι διακομιστή ιστού"
 
-#: src/muuli_wdr.cpp:2136
+#: src/muuli_wdr.cpp:2167
 #, fuzzy
 msgid "Run webserver on startup (deprecated)"
 msgstr "Έναρξη του εξυπηρετητή ιστού κατά την εκκίνηση"
 
-#: src/muuli_wdr.cpp:2142
+#: src/muuli_wdr.cpp:2173
 msgid "Web template"
 msgstr "Πρότυπη σελίδα"
 
-#: src/muuli_wdr.cpp:2147
+#: src/muuli_wdr.cpp:2178
 msgid "Full rights password"
 msgstr "Κωδικός πλήρων δικαιωμάτων"
 
-#: src/muuli_wdr.cpp:2151
+#: src/muuli_wdr.cpp:2182
 msgid "Enable Low rights User"
 msgstr "Ενεργοποίηση χρήστη μειωμένων δικαιωμάτων"
 
-#: src/muuli_wdr.cpp:2170
+#: src/muuli_wdr.cpp:2187
+msgid "Low rights password"
+msgstr "Κωδικός μειωμένων δικαιωμάτων"
+
+#: src/muuli_wdr.cpp:2201
 msgid "Enable UPnP port forwarding of the web server port"
 msgstr "Ενεργοποίηση της προώθησης της θύρας του εξηπηρετητή ιστού στη θύρα UPnP"
 
-#: src/muuli_wdr.cpp:2175
+#: src/muuli_wdr.cpp:2206
 msgid "Web server UPnP TCP port (Optional)"
 msgstr "Θύρα UPnP TCP του εξυπηρετητή (Προαιρετική)"
 
-#: src/muuli_wdr.cpp:2183
+#: src/muuli_wdr.cpp:2214
 msgid "Page Refresh Time (in secs)"
 msgstr "Χρόνος ανανέωσης σελίδας (σε δευτερόλεπτα)"
 
-#: src/muuli_wdr.cpp:2190
+#: src/muuli_wdr.cpp:2221
 msgid "Enable Gzip compression"
 msgstr "Ενεργοποίηση συμπίεσης Gzip"
 
-#: src/muuli_wdr.cpp:2224
+#: src/muuli_wdr.cpp:2255
 #, fuzzy
 msgid "Reset page to defaults"
 msgstr "Εργοστασιακές ρυθμίσεις"
 
-#: src/muuli_wdr.cpp:2225
+#: src/muuli_wdr.cpp:2256
 msgid "Reset the settings on the current page to their default values."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2227 src/muuli_wdr.cpp:2313 src/ServerWnd.cpp:274
+#: src/muuli_wdr.cpp:2258 src/muuli_wdr.cpp:2344 src/ServerWnd.cpp:274
 #: src/ServerWnd.cpp:282
 msgid "OK"
 msgstr "Εντάξει"
 
-#: src/muuli_wdr.cpp:2229
+#: src/muuli_wdr.cpp:2260
 msgid "Click here to apply any changes made to the preferences."
 msgstr "Κλικ εδώ για εφαρμογή των αλλαγών που έγιναν στις προτιμήσεις."
 
-#: src/muuli_wdr.cpp:2232
+#: src/muuli_wdr.cpp:2263
 msgid "Reset any changes made to the preferences."
 msgstr "Επαναφορά κάθε αλλαγής που έγινε στις προτιμήσεις."
 
-#: src/muuli_wdr.cpp:2261
+#: src/muuli_wdr.cpp:2292
 msgid "Comment :"
 msgstr "Σχόλιο:"
 
-#: src/muuli_wdr.cpp:2268
+#: src/muuli_wdr.cpp:2299
 msgid "Incoming Dir :"
 msgstr "Κατάλογος εισερχομένων :"
 
-#: src/muuli_wdr.cpp:2277
+#: src/muuli_wdr.cpp:2308
 msgid "Change priority for new assigned files :"
 msgstr "Αλλαγή προτεραιότητας για τα νέα προσδιορισμένα αρχεία :"
 
-#: src/muuli_wdr.cpp:2281
+#: src/muuli_wdr.cpp:2312
 #, fuzzy
 msgid "Don't change"
 msgstr "Να μην αλλάξει"
 
-#: src/muuli_wdr.cpp:2293
+#: src/muuli_wdr.cpp:2324
 msgid "Select color for this Category (currently selected) :"
 msgstr "Επιλογή χρώματος για τη συγκεκριμένη κατηγορία (τρέχουσα επιλογή) :"
 
-#: src/muuli_wdr.cpp:2360 src/muuli_wdr.cpp:2379 src/muuli_wdr.cpp:2401
+#: src/muuli_wdr.cpp:2391 src/muuli_wdr.cpp:2410 src/muuli_wdr.cpp:2432
 msgid "Click this button to reset the log."
 msgstr "Πατήστε αυτό το κουμπί για το καθάρισμα του αρχείου καταγραφής."
 
-#: src/muuli_wdr.cpp:2420
+#: src/muuli_wdr.cpp:2451
 msgid "Click on this button to update the servers list from URL ..."
 msgstr "Πατήστε αυτό το αρχείο για να ανανεώσετε την λίστα διακομιστών από την URL ..."
 
-#: src/muuli_wdr.cpp:2424
+#: src/muuli_wdr.cpp:2455
 msgid "Server list"
 msgstr "Λίστα διακομιστών"
 
-#: src/muuli_wdr.cpp:2428
+#: src/muuli_wdr.cpp:2459
 msgid "Enter the url to a server.met file here and press the button to the left to update the list of known servers."
 msgstr "Εισάγετε την url ενός αρχείου server.met και πατήστε το κουμπί στα αριστερά για να ανανεώσετε τη λίστα με τους γνωστούς διακομιστές"
 
-#: src/muuli_wdr.cpp:2433
+#: src/muuli_wdr.cpp:2464
 msgid "Add server manually: Name"
 msgstr "Προσθήκη διακομιστή: Όνομα"
 
-#: src/muuli_wdr.cpp:2436
+#: src/muuli_wdr.cpp:2467
 msgid "Enter the name of the new server here"
 msgstr "Γράψτε το όνομα του νέου διακομιστή εδώ"
 
-#: src/muuli_wdr.cpp:2438 src/ServerWnd.cpp:206
+#: src/muuli_wdr.cpp:2469 src/ServerWnd.cpp:206
 msgid "IP:Port"
 msgstr "Διεύθυνση:Θύρα"
 
-#: src/muuli_wdr.cpp:2441
+#: src/muuli_wdr.cpp:2472
 msgid "Enter the IP of the server here, using the x.x.x.x format."
 msgstr "Γράψτε την IP του διακομιστή εδώ, σε μορφή x.x.x.x"
 
-#: src/muuli_wdr.cpp:2447
+#: src/muuli_wdr.cpp:2478
 msgid "Enter the port of the server here."
 msgstr "Γράψτε την θύρα του διακομιστή εδώ."
 
-#: src/muuli_wdr.cpp:2450
+#: src/muuli_wdr.cpp:2481
 msgid "Add manually a server (fill fields to the left before) ..."
 msgstr "Βάλτε τον διακομιστή με το χέρι (γεμίστε πρώτα τα πεδία στα αριστερά) ..."
 
-#: src/muuli_wdr.cpp:2479
+#: src/muuli_wdr.cpp:2510
 msgid "aMule Log"
 msgstr "Αρχείο καταγραφής aMule"
 
-#: src/muuli_wdr.cpp:2487
+#: src/muuli_wdr.cpp:2518
 msgid "Server Info"
 msgstr "Πληροφορίες διακομιστή"
 
-#: src/muuli_wdr.cpp:2491
+#: src/muuli_wdr.cpp:2522
 msgid "ED2K Info"
 msgstr "Πληροφορίες ED2K"
 
-#: src/muuli_wdr.cpp:2495
+#: src/muuli_wdr.cpp:2526
 msgid "Kad Info"
 msgstr "Πληροφορίες Kad"
 
-#: src/muuli_wdr.cpp:2523
+#: src/muuli_wdr.cpp:2554
 msgid "Click on this button to update the nodes list from URL ..."
 msgstr "Πατήστε το κουμπί για να ανανεώσετε την λίστα των κόμβων από την URL ..."
 
-#: src/muuli_wdr.cpp:2527
+#: src/muuli_wdr.cpp:2558
 msgid "Nodes (0)"
 msgstr "Κόμβοι (0)"
 
-#: src/muuli_wdr.cpp:2531
+#: src/muuli_wdr.cpp:2562
 msgid "Enter the url to a nodes.dat file here and press the button to the left to update the list of known nodes."
 msgstr "Βάλτε εδώ την url ενός αρχείου nodes.dat και πατήστε το κουμπί στα αριστερά για να ανανεώσετε την λίστα των γνωστών κόμβων."
 
-#: src/muuli_wdr.cpp:2534
+#: src/muuli_wdr.cpp:2565
 msgid "Nodes stats"
 msgstr "Στατιστικές κόμβων"
 
-#: src/muuli_wdr.cpp:2576
+#: src/muuli_wdr.cpp:2607
 msgid "Bootstrap"
 msgstr "Εκκινητήρας"
 
-#: src/muuli_wdr.cpp:2579
+#: src/muuli_wdr.cpp:2610
 msgid "New node"
 msgstr "Καινούριος κόμβος"
 
-#: src/muuli_wdr.cpp:2584
+#: src/muuli_wdr.cpp:2615
 msgid "IP:"
 msgstr "IP:"
 
-#: src/muuli_wdr.cpp:2604
+#: src/muuli_wdr.cpp:2635
 msgid "Port:"
 msgstr "Θύρα:"
 
-#: src/muuli_wdr.cpp:2617
+#: src/muuli_wdr.cpp:2648
 #, fuzzy
 msgid "Bootstrap from known clients"
 msgstr ""
 "Εκκίνηση από\n"
 "γνωστούς πελάτες"
 
-#: src/muuli_wdr.cpp:2619
+#: src/muuli_wdr.cpp:2650
 msgid "Disconnect Kad"
 msgstr "Αποσυνδεδεμένο Kad"
 
-#: src/muuli_wdr.cpp:2653
+#: src/muuli_wdr.cpp:2684
 msgid "Use Secure User Identification"
 msgstr "Χρήση Ασφαλούς Ταυτοποίησης χρήστη"
 
-#: src/muuli_wdr.cpp:2655
+#: src/muuli_wdr.cpp:2686
 msgid "It is recommended to enable this option. You will not receive credits if SUI is not enabled."
 msgstr "Ενδείκνυται να ενεργοποιήσετε αυτήν την προτίμηση. Δεν θα λάβετε πίστωση αν το SUI δεν είναι ενεργοποιημένο."
 
-#: src/muuli_wdr.cpp:2657
+#: src/muuli_wdr.cpp:2688
 msgid "Protocol Obfuscation"
 msgstr "Συσκότιση πρωτοκόλλου"
 
-#: src/muuli_wdr.cpp:2660
+#: src/muuli_wdr.cpp:2691
 msgid "Support Protocol Obfuscation"
 msgstr "Υποστήριξη συσκότισης πρωτοκόλλου"
 
-#: src/muuli_wdr.cpp:2662
+#: src/muuli_wdr.cpp:2693
 msgid "This option enabled Protocol Obfuscation, and makes aMule accept obfuscated connections from other clients."
 msgstr "Αυτή η επιλογή ενεργοποίησε την συσκότιση πρωτοκόλλου και κάνει το aMule να δέχεται συσκοτισμένες συνδέσεις από άλλους πελάτες"
 
-#: src/muuli_wdr.cpp:2664
+#: src/muuli_wdr.cpp:2695
 msgid "Use obfuscation for outgoing connections"
 msgstr "Χρήση συσκότισης για εξωτερικές συνδέσεις"
 
-#: src/muuli_wdr.cpp:2666
+#: src/muuli_wdr.cpp:2697
 msgid "This option makes aMule use Protocol Obfuscation when connecting other clients/servers."
 msgstr "Αυτή η επιλογή κάνει το aMule να χρησιμοποιεί συσκότιση πρωτοκόλλου όταν συνδέεται σε άλλους πελάτες/διακομιστές."
 
-#: src/muuli_wdr.cpp:2668
+#: src/muuli_wdr.cpp:2699
 msgid "Accept only obfuscated connections"
 msgstr "Να γίνονται δεκτές μόνο συσκοτισμένες συνδέσεις"
 
-#: src/muuli_wdr.cpp:2669
+#: src/muuli_wdr.cpp:2700
 msgid "This option makes aMule only accept obfuscated connections. You will have less sources, but all your traffic will be obfuscated"
 msgstr "Αυτή η επιλογή κάνει το aMule να δέχεται μόνο συσκοτισμένες συνδέσεις. Θα υπάρχουν λιγότερες πηγές αλλά όλη η κυκλοφορία θα είναι συσκοτισμένη"
 
-#: src/muuli_wdr.cpp:2674
+#: src/muuli_wdr.cpp:2705
 msgid "Everybody"
 msgstr "Οι πάντες"
 
-#: src/muuli_wdr.cpp:2676
+#: src/muuli_wdr.cpp:2707
 msgid "No one"
 msgstr "Κανείς"
 
-#: src/muuli_wdr.cpp:2678
+#: src/muuli_wdr.cpp:2709
 msgid "Who can see my shared files:"
 msgstr "Ποίος μπορεί να δεί τα κοινόχρηστα αρχεία μου:"
 
-#: src/muuli_wdr.cpp:2679
+#: src/muuli_wdr.cpp:2710
 msgid "Select who can request to view a list of your shared files."
 msgstr "Επιλέξτε ποίος μπορεί να ζητήσει να δει τη λίστα με τα κοινόχρηστα αρχεία σας."
 
-#: src/muuli_wdr.cpp:2681
+#: src/muuli_wdr.cpp:2712
 msgid "IP-Filtering"
 msgstr "Φίλτρο IP"
 
-#: src/muuli_wdr.cpp:2688
+#: src/muuli_wdr.cpp:2719
 msgid "Filter clients"
 msgstr "Φιλτράρισμα πελατών"
 
-#: src/muuli_wdr.cpp:2690
+#: src/muuli_wdr.cpp:2721
 msgid "Enable filtering of the client IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "Ενεργοποίηση φίλτρου του IP των πελατών όπως ορίζεται στο ~/.aMule/ipfilter.dat."
 
-#: src/muuli_wdr.cpp:2692
+#: src/muuli_wdr.cpp:2723
 msgid "Filter servers"
 msgstr "Φιλτράρισμα διακομιστών"
 
-#: src/muuli_wdr.cpp:2694
+#: src/muuli_wdr.cpp:2725
 msgid "Enable filtering of the server IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "Ενεργοποίηση φίλτρου του IP των διακομιστών όπως ορίζεται στο ~/.aMule/ipfilter.dat."
 
-#: src/muuli_wdr.cpp:2698
+#: src/muuli_wdr.cpp:2729
 msgid "Reload List"
 msgstr "Επαναφόρτωση λίστας"
 
-#: src/muuli_wdr.cpp:2699
+#: src/muuli_wdr.cpp:2730
 msgid "Reload the list of IPs to filter from the file ~/.aMule/ipfilter.dat"
 msgstr "Επαναφόρτωση για φιλτράρισμα της λίστας των IP από το ~/.aMule/ipfilter.dat"
 
-#: src/muuli_wdr.cpp:2705
+#: src/muuli_wdr.cpp:2736
 msgid "URL:"
 msgstr "URL:"
 
-#: src/muuli_wdr.cpp:2709 src/muuli_wdr.cpp:2902
+#: src/muuli_wdr.cpp:2740 src/muuli_wdr.cpp:2933
 msgid "Update now"
 msgstr "Ανανέωσε τώρα"
 
-#: src/muuli_wdr.cpp:2712
+#: src/muuli_wdr.cpp:2743
 msgid "Auto-update ipfilter at startup"
 msgstr "Αυτόματη ανανέωση του ipfilter κατά την εκκίνηση"
 
-#: src/muuli_wdr.cpp:2716
+#: src/muuli_wdr.cpp:2747
 msgid "Filtering Level:"
 msgstr "Επίπεδο φιλτραρίσματος:"
 
-#: src/muuli_wdr.cpp:2722
+#: src/muuli_wdr.cpp:2753
 msgid "Always filter LAN IPs"
 msgstr "Πάντα φίλτραρε τις IP του τοπικού δικτύου"
 
-#: src/muuli_wdr.cpp:2725
+#: src/muuli_wdr.cpp:2756
 msgid "Paranoid handling of non-matching IPs"
 msgstr "Παρανοϊκή διαχείριση των αταίριαστων διευθύνσεων IP"
 
-#: src/muuli_wdr.cpp:2727
+#: src/muuli_wdr.cpp:2758
 msgid "Rejects a packet when its source IP differs from the IP the client claims (an anti-spoofing check). Disable only if it causes connection problems."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2729
+#: src/muuli_wdr.cpp:2760
 msgid "Use system-wide ipfilter.dat if available"
 msgstr "Χρήση του ipfilter.dat όλου του συστήματος αν αυτό υπάρχει"
 
-#: src/muuli_wdr.cpp:2730
+#: src/muuli_wdr.cpp:2761
 #, fuzzy
 msgid "If there's no local ipfilter.dat found, allow usage of a system-wide ipfilter file."
 msgstr "Αν δεν βρεθεί τοπικό ipfilter.dat, να γίνει επιτρεπτή η χρήση του αρχείου ipfilter (φίλτρο διευθύνσεων) όλου του συστήματος."
 
-#: src/muuli_wdr.cpp:2747
+#: src/muuli_wdr.cpp:2778
 msgid "Enable Online-Signature"
 msgstr "Ενεργοποίηση συνδεδεμένων υπογραφών"
 
-#: src/muuli_wdr.cpp:2749
+#: src/muuli_wdr.cpp:2780
 msgid "Enables the writing of the OS file, which can be used by external apps to create signatures and the like."
 msgstr "Ενεργοποίηση γραψίματος του αρχείου συστήματος, το οποίο μπορεί να χρησιμοποιηθεί από εξωτερικές εφαρμογές για τη δημιουργία υπογραφών κτλ."
 
-#: src/muuli_wdr.cpp:2753
+#: src/muuli_wdr.cpp:2784
 msgid "Update Frequency (Secs):"
 msgstr "Συχνότητα ανανέωσης (δευτερόλεπτα):"
 
-#: src/muuli_wdr.cpp:2756
+#: src/muuli_wdr.cpp:2787
 msgid "Change the frequency (in seconds) of Online Signature updates."
 msgstr "Αλλαγή της συχνότητας (σε δευτερόλεπτα) για την ενημέρωση Συνδεδεμένων υπογραφών."
 
-#: src/muuli_wdr.cpp:2764
+#: src/muuli_wdr.cpp:2795
 msgid "Save online signature file in: "
 msgstr "Αποθύκευση του αρχείου συνδεδεμένων υπογραφών σε:"
 
-#: src/muuli_wdr.cpp:2770
+#: src/muuli_wdr.cpp:2801
 msgid "Click here to select the directory containing the the Online Signature files."
 msgstr "Κλικ εδώ για την επιλογή του καταλόγου που περιέχει τα αρχεία Συνδεδεμένων Υπογραφών."
 
-#: src/muuli_wdr.cpp:2803
+#: src/muuli_wdr.cpp:2834
 msgid "Show country flags for clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2804
+#: src/muuli_wdr.cpp:2835
 msgid "Render the country flag column in the transfers, queue and search views. Requires a valid MMDB GeoIP database (see below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2809
+#: src/muuli_wdr.cpp:2840
 #, fuzzy
 msgid "Database"
 msgstr "Ρυθμός ροής δεδομένων :"
 
-#: src/muuli_wdr.cpp:2825
+#: src/muuli_wdr.cpp:2856
 #, fuzzy
 msgid "Source:"
 msgstr "Αρ. πηγών"
 
-#: src/muuli_wdr.cpp:2828
+#: src/muuli_wdr.cpp:2859
 msgid "DB-IP (free, no account)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2829
+#: src/muuli_wdr.cpp:2860
 msgid "MaxMind GeoLite2 (free, account required)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2830
+#: src/muuli_wdr.cpp:2861
 msgid "Custom URL"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2833
+#: src/muuli_wdr.cpp:2864
 msgid "Choose which provider supplies the GeoIP MMDB database. DB-IP is the default - no account required. MaxMind requires a free account + license key. Use Custom URL to point at any other MMDB host (e.g. a local mirror)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2850
+#: src/muuli_wdr.cpp:2881
 msgid ""
 "No configuration required.\n"
 "\n"
@@ -4880,11 +4908,11 @@ msgid ""
 "License: Creative Commons BY 4.0 - https://creativecommons.org/licenses/by/4.0/"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2863
+#: src/muuli_wdr.cpp:2894
 msgid "License key:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2869
+#: src/muuli_wdr.cpp:2900
 msgid ""
 "Sign up for a free MaxMind account, then generate a License Key:\n"
 "https://www.maxmind.com/en/geolite2/signup\n"
@@ -4894,232 +4922,232 @@ msgid ""
 "Requires attribution and account registration; refresh at least every 30 days."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2884
+#: src/muuli_wdr.cpp:2915
 #, fuzzy
 msgid "Download URL:"
 msgstr "Μεταφόρτωση"
 
-#: src/muuli_wdr.cpp:2890
+#: src/muuli_wdr.cpp:2921
 msgid ""
 "Must point to an .mmdb file or a .gz / .tar.gz containing one.\n"
 "URL may include credentials (https://user:pass@host/...).\n"
 "License and attribution terms are set by the upstream URL - you are responsible."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2903
+#: src/muuli_wdr.cpp:2934
 msgid "Download the GeoIP database from the selected source."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2905
+#: src/muuli_wdr.cpp:2936
 #, fuzzy
 msgid "Auto-update on startup"
 msgstr "Αυτόματη ανανέωση του ipfilter κατά την εκκίνηση"
 
-#: src/muuli_wdr.cpp:2906
+#: src/muuli_wdr.cpp:2937
 msgid "Re-download the GeoIP database from the selected source every time aMule starts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2929
+#: src/muuli_wdr.cpp:2960
 msgid "Filter incoming messages (except current chat):"
 msgstr "Φιλτράρισμα εισερχομένων μηνυμάτων (εκτός από την τρέχουσα συνομιλία):"
 
-#: src/muuli_wdr.cpp:2931
+#: src/muuli_wdr.cpp:2962
 msgid "Filter all messages"
 msgstr "Διήθηση όλων των μηνυμάτων"
 
-#: src/muuli_wdr.cpp:2933
+#: src/muuli_wdr.cpp:2964
 msgid "Filter messages from people not on your friend list"
 msgstr "Διήθηση των μηνυμάτων από μέλη εκτός της λίστας φίλων"
 
-#: src/muuli_wdr.cpp:2935
+#: src/muuli_wdr.cpp:2966
 msgid "Filter messages from unknown clients"
 msgstr "Διήθηση μηνυμάτων από άγνωστους πελάτες"
 
-#: src/muuli_wdr.cpp:2937
+#: src/muuli_wdr.cpp:2968
 msgid "Filter messages containing (use ',' as separator):"
 msgstr "Διήθηση των μηνυμάτων που περιέχουν (χρήση ',' ως διαχωριστικού):"
 
-#: src/muuli_wdr.cpp:2940 src/muuli_wdr.cpp:2951
+#: src/muuli_wdr.cpp:2971 src/muuli_wdr.cpp:2982
 msgid "add here the words amule should filter and block messages including it"
 msgstr "προσθήκη σε αυτό το σημείο των λέξεων που το aMule πρέπει να φιλτράρει και μπλοκάρισμα μηνυμάτων που το περιέχουν"
 
-#: src/muuli_wdr.cpp:2942
+#: src/muuli_wdr.cpp:2973
 msgid "Show received messages in the log"
 msgstr "Εμφάνιση των ληφθέντων μηνυμάτων στο αρχείο καταγραφής"
 
-#: src/muuli_wdr.cpp:2945
+#: src/muuli_wdr.cpp:2976
 msgid "Comments"
 msgstr "Σχόλια"
 
-#: src/muuli_wdr.cpp:2948
+#: src/muuli_wdr.cpp:2979
 msgid "Filter comments containing (use ',' as separator):"
 msgstr "Φιλτράρισμα σχολίων που περιέχουν (χρησιμοποίηση ',' ως διαχωριστή):"
 
-#: src/muuli_wdr.cpp:2973
+#: src/muuli_wdr.cpp:3004
 msgid "Enable Proxy"
 msgstr "Ενεργοποίηση διακομιστή μεσολάβησης"
 
-#: src/muuli_wdr.cpp:2974
+#: src/muuli_wdr.cpp:3005
 msgid "Enable/disable proxy support"
 msgstr "Ενεργοποίηση/Απενεργοποίηση υποστήριξης διακομιστή μεσολάβησης"
 
-#: src/muuli_wdr.cpp:2977
+#: src/muuli_wdr.cpp:3008
 msgid "Proxy type:"
 msgstr "Τύπος διαμεσολάβησης"
 
-#: src/muuli_wdr.cpp:2988
+#: src/muuli_wdr.cpp:3019
 msgid "Proxy host:"
 msgstr "Διεύθυνση διακομιστή μεσολάβησης:"
 
-#: src/muuli_wdr.cpp:2991
+#: src/muuli_wdr.cpp:3022
 msgid "The proxy host name"
 msgstr "Όνομα του διακομιστή μεσολάβησης"
 
-#: src/muuli_wdr.cpp:2993
+#: src/muuli_wdr.cpp:3024
 msgid "Proxy port:"
 msgstr "Θύρα διακομιστή μεσολάβησης:"
 
-#: src/muuli_wdr.cpp:2996
+#: src/muuli_wdr.cpp:3027
 msgid "The proxy port"
 msgstr "Η θύρα διακομιστή μεσολάβησης"
 
-#: src/muuli_wdr.cpp:2998
+#: src/muuli_wdr.cpp:3029
 msgid "Enable authentication"
 msgstr "Ενεργοποίηση πιστοποίησης"
 
-#: src/muuli_wdr.cpp:2999
+#: src/muuli_wdr.cpp:3030
 msgid "Enable/disable username/password authentication"
 msgstr "Ενεργοποίηση/Απενεργοποίηση πιστοποίησης ονόματος χρήστη/κωδικού"
 
-#: src/muuli_wdr.cpp:3002
+#: src/muuli_wdr.cpp:3033
 msgid "Username: "
 msgstr "Όνομα χρήστη:"
 
-#: src/muuli_wdr.cpp:3005
+#: src/muuli_wdr.cpp:3036
 msgid "The username to use to connect to the proxy"
 msgstr "Το όνομα χρήστη για τη σύνδεση με τον μεσολαβητή"
 
-#: src/muuli_wdr.cpp:3007
+#: src/muuli_wdr.cpp:3038
 msgid "Password:"
 msgstr "Κωδικός:"
 
-#: src/muuli_wdr.cpp:3010
+#: src/muuli_wdr.cpp:3041
 msgid "The password to use to connect to the proxy"
 msgstr "Ο κωδικός που χρειάζεται για τη σύνδεση με τον μεσολαβητή"
 
-#: src/muuli_wdr.cpp:3029
+#: src/muuli_wdr.cpp:3060
 msgid "Connect to:"
 msgstr "Σύνδεση με:"
 
-#: src/muuli_wdr.cpp:3038
+#: src/muuli_wdr.cpp:3069
 msgid "Login to remote amule"
 msgstr "Σύνδεση σε απομακρυσμένο amule"
 
-#: src/muuli_wdr.cpp:3043
+#: src/muuli_wdr.cpp:3074
 msgid "User name"
 msgstr "Όνομα χρήστη"
 
-#: src/muuli_wdr.cpp:3054
+#: src/muuli_wdr.cpp:3085
 msgid "Remember those settings"
 msgstr "Απομνημόνευση αυτών των ρυθμίσεων"
 
-#: src/muuli_wdr.cpp:3057
+#: src/muuli_wdr.cpp:3088
 #, fuzzy
 msgid "Force ZLIB compression"
 msgstr "Χρήση συμπίεσης τύπου gzip"
 
-#: src/muuli_wdr.cpp:3081
+#: src/muuli_wdr.cpp:3112
 msgid "Enable Verbose Debug-Logging."
 msgstr "Ενεργοποίηση λεπτομερούς καταγραφής για έλεγχο σφαλμάτων"
 
-#: src/muuli_wdr.cpp:3083
+#: src/muuli_wdr.cpp:3114
 #, fuzzy
 msgid "Only to Logfile"
 msgstr "&Άνοιγμα αρχείου"
 
-#: src/muuli_wdr.cpp:3085
+#: src/muuli_wdr.cpp:3116
 msgid "Message Categories:"
 msgstr "Κατηγορίες μηνυμάτων:"
 
-#: src/muuli_wdr.cpp:3109 src/PartFileConvertDlg.cpp:160
+#: src/muuli_wdr.cpp:3140 src/PartFileConvertDlg.cpp:160
 msgid "Waiting..."
 msgstr "Αναμονή..."
 
-#: src/muuli_wdr.cpp:3129
+#: src/muuli_wdr.cpp:3160
 msgid "Add imports"
 msgstr "Προσθήκη εισακτέων"
 
-#: src/muuli_wdr.cpp:3132
+#: src/muuli_wdr.cpp:3163
 msgid "Retry selected"
 msgstr "Επαναπροσπάθεια των επιλεγμένων"
 
-#: src/muuli_wdr.cpp:3134
+#: src/muuli_wdr.cpp:3165
 msgid "Remove selected"
 msgstr "Αφαίρεση των επιλεγμένων"
 
-#: src/muuli_wdr.cpp:3197
+#: src/muuli_wdr.cpp:3228
 msgid "Event Types"
 msgstr "Τύποι συμβάντων"
 
-#: src/muuli_wdr.cpp:3216
+#: src/muuli_wdr.cpp:3247
 msgid "Statistics and queued clients for selected file(s) : Session / All time"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3240
+#: src/muuli_wdr.cpp:3271
 #, fuzzy
 msgid "Active Uploads"
 msgstr "Ενεργά ανεβάσματα :"
 
-#: src/muuli_wdr.cpp:3254
+#: src/muuli_wdr.cpp:3285
 msgid "Percent of total files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3306
+#: src/muuli_wdr.cpp:3337
 #, fuzzy
 msgid "Show Clients for"
 msgstr "Δείξε τους πελάτες"
 
-#: src/muuli_wdr.cpp:3308
+#: src/muuli_wdr.cpp:3339
 #, fuzzy
 msgid "All files"
 msgstr "Κρύψιμο των κοινόχρηστων αρχείων "
 
-#: src/muuli_wdr.cpp:3311
+#: src/muuli_wdr.cpp:3342
 #, fuzzy
 msgid "Selected files"
 msgstr "Επιλογή φίλτρου εμφάνισης"
 
-#: src/muuli_wdr.cpp:3314
+#: src/muuli_wdr.cpp:3345
 #, fuzzy
 msgid "Active uploads only"
 msgstr "Ενεργά ανεβάσματα"
 
-#: src/muuli_wdr.cpp:3321
+#: src/muuli_wdr.cpp:3352
 #, fuzzy
 msgid "Reload:"
 msgstr "Επαναφόρτωση λίστας"
 
-#: src/muuli_wdr.cpp:3325
+#: src/muuli_wdr.cpp:3356
 msgid "Reload your shared files"
 msgstr "Επαναφόρτωση των κοινόχρηστων αρχείων"
 
-#: src/muuli_wdr.cpp:3388
+#: src/muuli_wdr.cpp:3419
 msgid "Send"
 msgstr "Αποστολή"
 
-#: src/muuli_wdr.cpp:3389
+#: src/muuli_wdr.cpp:3420
 msgid "Sends the specified message."
 msgstr "Αποστολή του προσδιορισμένου μηνύματος."
 
-#: src/muuli_wdr.cpp:3393
+#: src/muuli_wdr.cpp:3424
 msgid "Close this chat-session."
 msgstr "Κλείσιμο της συνομιλίας."
 
-#: src/muuli_wdr.cpp:3416
+#: src/muuli_wdr.cpp:3447
 msgid "Connect to any server and/or Kad"
 msgstr "Σύνδεση σε κάθε διακομιστή ή/και Kad"
 
-#: src/muuli_wdr.cpp:3422 src/SharedFilesCtrl.cpp:142 src/Statistics.cpp:941
+#: src/muuli_wdr.cpp:3453 src/SharedFilesCtrl.cpp:142 src/Statistics.cpp:941
 msgid "Shared Files"
 msgstr "Κοινόχρηστα αρχεία"
 
@@ -5480,268 +5508,268 @@ msgstr "Έχει κατεβεί"
 msgid "ERROR: Failed to open partfile '%s'"
 msgstr "ΣΦΑΛΜΑ: Αποτυχία ανοίγματος του ημιτελούς αρχείου '%s'"
 
-#: src/Preferences.cpp:674
+#: src/Preferences.cpp:701
 msgid "System default"
 msgstr "Εργοστασιακές ρυθμίσεις"
 
-#: src/Preferences.cpp:675
+#: src/Preferences.cpp:702
 msgid "Albanian"
 msgstr "Αλβανικά"
 
-#: src/Preferences.cpp:676
+#: src/Preferences.cpp:703
 msgid "Arabic"
 msgstr "Αραβικά"
 
-#: src/Preferences.cpp:677
+#: src/Preferences.cpp:704
 #, fuzzy
 msgid "Asturian"
 msgstr "Εσθονικά"
 
-#: src/Preferences.cpp:678
+#: src/Preferences.cpp:705
 msgid "Basque"
 msgstr "Βάσκικα"
 
-#: src/Preferences.cpp:679
+#: src/Preferences.cpp:706
 msgid "Bulgarian"
 msgstr "Βουλγάρικα"
 
-#: src/Preferences.cpp:680
+#: src/Preferences.cpp:707
 msgid "Catalan"
 msgstr "Καταλανικά"
 
-#: src/Preferences.cpp:681
+#: src/Preferences.cpp:708
 msgid "Chinese (Simplified)"
 msgstr "Κινέζικα (απλοποιημένα)"
 
-#: src/Preferences.cpp:682
+#: src/Preferences.cpp:709
 msgid "Chinese (Traditional)"
 msgstr "Κινέζικα (Παραδοσιακά)"
 
-#: src/Preferences.cpp:683
+#: src/Preferences.cpp:710
 msgid "Croatian"
 msgstr "Κροατικά"
 
-#: src/Preferences.cpp:684
+#: src/Preferences.cpp:711
 msgid "Czech"
 msgstr "Τσέχικα"
 
-#: src/Preferences.cpp:685
+#: src/Preferences.cpp:712
 msgid "Danish"
 msgstr "Δανέζικα"
 
-#: src/Preferences.cpp:686
+#: src/Preferences.cpp:713
 msgid "Dutch"
 msgstr "Ολλανδικά"
 
-#: src/Preferences.cpp:687
+#: src/Preferences.cpp:714
 msgid "English (U.K.)"
 msgstr "Αγγλικά (Ην. Βασίλειο)"
 
-#: src/Preferences.cpp:688
+#: src/Preferences.cpp:715
 #, fuzzy
 msgid "English (U.S.)"
 msgstr "Αγγλικά (Ην. Βασίλειο)"
 
-#: src/Preferences.cpp:689
+#: src/Preferences.cpp:716
 msgid "Estonian"
 msgstr "Εσθονικά"
 
-#: src/Preferences.cpp:690
+#: src/Preferences.cpp:717
 msgid "Finnish"
 msgstr "Φιλανδικά"
 
-#: src/Preferences.cpp:691
+#: src/Preferences.cpp:718
 msgid "French"
 msgstr "Γαλλικά"
 
-#: src/Preferences.cpp:692
+#: src/Preferences.cpp:719
 msgid "Galician"
 msgstr "Γαλικιακά"
 
-#: src/Preferences.cpp:693
+#: src/Preferences.cpp:720
 msgid "German"
 msgstr "Γερμανικά"
 
-#: src/Preferences.cpp:694
+#: src/Preferences.cpp:721
 msgid "Greek"
 msgstr "Ελληνικά"
 
-#: src/Preferences.cpp:695
+#: src/Preferences.cpp:722
 msgid "Hebrew"
 msgstr "Εβραϊκά"
 
-#: src/Preferences.cpp:696
+#: src/Preferences.cpp:723
 msgid "Hungarian"
 msgstr "Ουγγαρέζικα"
 
-#: src/Preferences.cpp:697
+#: src/Preferences.cpp:724
 msgid "Italian"
 msgstr "Ιταλικά"
 
-#: src/Preferences.cpp:698
+#: src/Preferences.cpp:725
 msgid "Japanese"
 msgstr "Γιαπωνέζικα"
 
-#: src/Preferences.cpp:699
+#: src/Preferences.cpp:726
 msgid "Korean"
 msgstr "Κορεάτικα"
 
-#: src/Preferences.cpp:700
+#: src/Preferences.cpp:727
 msgid "Latvian"
 msgstr ""
 
-#: src/Preferences.cpp:701
+#: src/Preferences.cpp:728
 msgid "Lithuanian"
 msgstr "Λιθουανικά"
 
-#: src/Preferences.cpp:702
+#: src/Preferences.cpp:729
 msgid "Norwegian (Nynorsk)"
 msgstr "Νορβηγικά"
 
-#: src/Preferences.cpp:703
+#: src/Preferences.cpp:730
 msgid "Polish"
 msgstr "Πολωνέζικα"
 
-#: src/Preferences.cpp:704
+#: src/Preferences.cpp:731
 msgid "Portuguese"
 msgstr "Πορτογαλλικά"
 
-#: src/Preferences.cpp:705
+#: src/Preferences.cpp:732
 msgid "Portuguese (Brazilian)"
 msgstr "Πορτογαλλικά (Βραζιλίας)"
 
-#: src/Preferences.cpp:706
+#: src/Preferences.cpp:733
 #, fuzzy
 msgid "Romanian"
 msgstr "Αλβανικά"
 
-#: src/Preferences.cpp:707
+#: src/Preferences.cpp:734
 msgid "Russian"
 msgstr "Ρωσικά"
 
-#: src/Preferences.cpp:708
+#: src/Preferences.cpp:735
 msgid "Slovenian"
 msgstr "Σλοβένικα"
 
-#: src/Preferences.cpp:709
+#: src/Preferences.cpp:736
 msgid "Spanish"
 msgstr "Ισπανικά"
 
-#: src/Preferences.cpp:710
+#: src/Preferences.cpp:737
 msgid "Swedish"
 msgstr "Σουηδικά"
 
-#: src/Preferences.cpp:711
+#: src/Preferences.cpp:738
 msgid "Turkish"
 msgstr "Τούρκικα"
 
-#: src/Preferences.cpp:712
+#: src/Preferences.cpp:739
 msgid "Ukrainian"
 msgstr ""
 
-#: src/Preferences.cpp:815
+#: src/Preferences.cpp:842
 #, fuzzy
 msgid "Change Language"
 msgstr "Γλώσσα"
 
-#: src/Preferences.cpp:879
+#: src/Preferences.cpp:906
 msgid "There are no translations installed for aMule"
 msgstr ""
 
-#: src/Preferences.cpp:880
+#: src/Preferences.cpp:907
 #, fuzzy
 msgid "No languages available"
 msgstr "Δεν είναι διαθέσιμο"
 
-#: src/Preferences.cpp:1011
+#: src/Preferences.cpp:1038
 msgid "no options available"
 msgstr "Δεν υπάρχουν επιλογές"
 
-#: src/Preferences.cpp:2182
+#: src/Preferences.cpp:2227
 msgid "Invalid category found, skipping"
 msgstr ""
 
-#: src/Preferences.cpp:2351
+#: src/Preferences.cpp:2396
 msgid "TCP port can't be higher than 65532 due to server UDP socket being TCP+3"
 msgstr "Η θύρα TCP δεν μπορεί να είναι μεγαλύτερη από 65532, διότι η θύρα UDP του διακομιστή είναι TCP+3"
 
-#: src/Preferences.cpp:2352
+#: src/Preferences.cpp:2397
 #, c-format
 msgid "Default port will be used (%d)"
 msgstr "Θα χρησιμοποιηθεί η στάνταρ θύρα (%d)"
 
-#: src/PrefsUnifiedDlg.cpp:298 src/Statistics.cpp:866
+#: src/PrefsUnifiedDlg.cpp:300 src/Statistics.cpp:866
 msgid "Connection"
 msgstr "Σύνδεση"
 
-#: src/PrefsUnifiedDlg.cpp:299 src/SearchListCtrl.cpp:117
+#: src/PrefsUnifiedDlg.cpp:301 src/SearchListCtrl.cpp:117
 msgid "Directories"
 msgstr "Κατάλογοι Αρχείων"
 
-#: src/PrefsUnifiedDlg.cpp:300 src/Statistics.cpp:917
+#: src/PrefsUnifiedDlg.cpp:302 src/Statistics.cpp:917
 msgid "Servers"
 msgstr "Διακομιστές"
 
-#: src/PrefsUnifiedDlg.cpp:301 src/ServerListCtrl.cpp:96
+#: src/PrefsUnifiedDlg.cpp:303 src/ServerListCtrl.cpp:96
 msgid "Files"
 msgstr "Αρχεία"
 
-#: src/PrefsUnifiedDlg.cpp:302
+#: src/PrefsUnifiedDlg.cpp:304
 msgid "Security"
 msgstr "Ασφάλεια"
 
-#: src/PrefsUnifiedDlg.cpp:303
+#: src/PrefsUnifiedDlg.cpp:305
 msgid "Interface"
 msgstr "Περιβάλλον"
 
-#: src/PrefsUnifiedDlg.cpp:310
+#: src/PrefsUnifiedDlg.cpp:312
 msgid "IP2Country"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:313
+#: src/PrefsUnifiedDlg.cpp:315
 msgid "Proxy"
 msgstr "Διακομιστής διαμεσολάβησης"
 
-#: src/PrefsUnifiedDlg.cpp:314
+#: src/PrefsUnifiedDlg.cpp:316
 msgid "Filters"
 msgstr "Φίλτρα"
 
-#: src/PrefsUnifiedDlg.cpp:315
+#: src/PrefsUnifiedDlg.cpp:317
 msgid "Remote Controls"
 msgstr "Τηλεχειρισμός"
 
-#: src/PrefsUnifiedDlg.cpp:316
+#: src/PrefsUnifiedDlg.cpp:318
 msgid "Online Signature"
 msgstr "Διασυνδεδεμένη υπογραφή"
 
-#: src/PrefsUnifiedDlg.cpp:317
+#: src/PrefsUnifiedDlg.cpp:319
 msgid "Advanced"
 msgstr "Προχωρημένες"
 
-#: src/PrefsUnifiedDlg.cpp:318
+#: src/PrefsUnifiedDlg.cpp:320
 msgid "Events"
 msgstr "Γεγονότα"
 
-#: src/PrefsUnifiedDlg.cpp:321
+#: src/PrefsUnifiedDlg.cpp:323
 msgid "Debugging"
 msgstr "Έλεγχος σφαλμάτων προγράμματος"
 
-#: src/PrefsUnifiedDlg.cpp:451
+#: src/PrefsUnifiedDlg.cpp:453
 msgid ""
 "The following variables will be substituted:\n"
 "    %PARTFILE - full path to the file\n"
 "    %PARTNAME - file name only"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:472
+#: src/PrefsUnifiedDlg.cpp:474
 msgid "Tray icon support requires libayatana-appindicator3 at compile time."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:488
+#: src/PrefsUnifiedDlg.cpp:490
 msgid "Not available on Wayland: the protocol does not report when a window is minimized, so this option cannot intercept the system minimize button. Workaround: launch aMule with `GDK_BACKEND=x11` to use XWayland instead."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:534
+#: src/PrefsUnifiedDlg.cpp:536
 msgid ""
 "Do not change these setting unless you know\n"
 "what you are doing, otherwise you can easily\n"
@@ -5756,26 +5784,35 @@ msgstr ""
 "Το aMule θα τρέχει μια χαρά χωρίς την αλλαγή καμιάς από αυτές\n"
 " τις ρυθμίσεις."
 
-#: src/PrefsUnifiedDlg.cpp:645
+#: src/PrefsUnifiedDlg.cpp:647
 #, c-format
 msgid "Failed to connect Cfg to widget with the ID %d and key %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:693
+#: src/PrefsUnifiedDlg.cpp:695
 #, c-format
 msgid "Failed to transfer data from Cfg to Widget with the ID %d and key %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:799
+#: src/PrefsUnifiedDlg.cpp:801
 msgid "The type of proxy you are connecting to"
 msgstr "Ο τύπος του διακομιστή μεσολάβησης στον οποίον συνδέεστε"
 
-#: src/PrefsUnifiedDlg.cpp:1003
+#: src/PrefsUnifiedDlg.cpp:1020
 #, c-format
 msgid "Failed to transfer data from Widget to Cfg with the ID %d and key %s"
 msgstr ""
 
 #: src/PrefsUnifiedDlg.cpp:1103
+#, fuzzy
+msgid "No password set."
+msgstr "Έλεγχος κωδικού\n"
+
+#: src/PrefsUnifiedDlg.cpp:1132
+msgid "Guest access needs a password. Type one in the guest password field, or untick Enable guest access."
+msgstr ""
+
+#: src/PrefsUnifiedDlg.cpp:1144
 msgid ""
 "aMule must be restarted to enable these changes:\n"
 "\n"
@@ -5783,45 +5820,45 @@ msgstr ""
 "το aMule πρέπει να επανεκινηθεί για να ενεργοποιηθούν αυτές οι αλλαγές: \n"
 "\n"
 
-#: src/PrefsUnifiedDlg.cpp:1110
+#: src/PrefsUnifiedDlg.cpp:1151
 msgid "- TCP port changed.\n"
 msgstr "- Άλλαξε η θύρα TCP.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1115
+#: src/PrefsUnifiedDlg.cpp:1156
 msgid "- UDP port changed.\n"
 msgstr "- Άλλαξε η θύρα UDP.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1120
+#: src/PrefsUnifiedDlg.cpp:1161
 #, fuzzy
 msgid "- Network interface binding changed.\n"
 msgstr "Η εξωτερική σύνδεση έκλεισε."
 
-#: src/PrefsUnifiedDlg.cpp:1125
+#: src/PrefsUnifiedDlg.cpp:1166
 #, fuzzy
 msgid "- External connect port changed.\n"
 msgstr "Η εξωτερική σύνδεση έκλεισε."
 
-#: src/PrefsUnifiedDlg.cpp:1129
+#: src/PrefsUnifiedDlg.cpp:1170
 #, fuzzy
 msgid "- External connect acceptance changed.\n"
 msgstr "Νέα εξωτερική σύνδεση έγινε δεκτή"
 
-#: src/PrefsUnifiedDlg.cpp:1133
+#: src/PrefsUnifiedDlg.cpp:1174
 #, fuzzy
 msgid "- External connect interface changed.\n"
 msgstr "Η εξωτερική σύνδεση έκλεισε."
 
-#: src/PrefsUnifiedDlg.cpp:1137
+#: src/PrefsUnifiedDlg.cpp:1178
 #, fuzzy
 msgid "- Protocol obfuscation support changed.\n"
 msgstr "Συσκότιση πρωτοκόλλου"
 
-#: src/PrefsUnifiedDlg.cpp:1151
+#: src/PrefsUnifiedDlg.cpp:1193
 #, fuzzy
 msgid "- amuleapi settings changed.\n"
 msgstr "- Η γλώσσα άλλαξε.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1160
+#: src/PrefsUnifiedDlg.cpp:1202
 msgid ""
 "Your Auto-update server list is empty.\n"
 "'Auto-update server list at startup' will be disabled."
@@ -5829,7 +5866,7 @@ msgstr ""
 "Η λίστα αυτόματης ενημέρωσης διακομιστών είναι κενή.\n"
 "Θα απενεργοποιηθεί η επιλογή: 'Αυτόματη ενημέρωση λίστας διακομιστών κατά την εκκίνηση' "
 
-#: src/PrefsUnifiedDlg.cpp:1171
+#: src/PrefsUnifiedDlg.cpp:1213
 msgid ""
 "You have enabled external connections but have not specified a password.\n"
 "External connections cannot be enabled unless a valid password is specified."
@@ -5837,29 +5874,34 @@ msgstr ""
 "Έχετε ενεργοποιήσει τις εξωτερικές συνδέσεις αλλά δεν έχετε προσδιορίσει κωδικό.\n"
 "Οι εξωτερικές συνδέσεις δεν μπορούν να ενεργοποιηθούν μέχρι να προσδιοριστεί ένας έγκυρος κωδικός."
 
-#: src/PrefsUnifiedDlg.cpp:1202
+#: src/PrefsUnifiedDlg.cpp:1246
+#, c-format
+msgid "The amuleapi password could not be saved: %s"
+msgstr ""
+
+#: src/PrefsUnifiedDlg.cpp:1276
 msgid "- Language changed.\n"
 msgstr "- Η γλώσσα άλλαξε.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1207
+#: src/PrefsUnifiedDlg.cpp:1281
 msgid "- Temp folder changed.\n"
 msgstr "- Ο προσωρινός κατάλογος άλλαξε.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1212
+#: src/PrefsUnifiedDlg.cpp:1286
 #, fuzzy
 msgid "- ED2K network enabled.\n"
 msgstr "Όλα τα δίκτυα είναι απενεργοποιημένα."
 
-#: src/PrefsUnifiedDlg.cpp:1245
+#: src/PrefsUnifiedDlg.cpp:1319
 msgid "The shared-file exclusion pattern is not a valid regular expression. The filter has been left disabled."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1247 src/PrefsUnifiedDlg.cpp:1841
+#: src/PrefsUnifiedDlg.cpp:1321 src/PrefsUnifiedDlg.cpp:1921
 #, fuzzy
 msgid "Invalid regular expression"
 msgstr "Άκυρη έκδοση πρωτοκόλλου."
 
-#: src/PrefsUnifiedDlg.cpp:1324
+#: src/PrefsUnifiedDlg.cpp:1398
 msgid ""
 "Both eD2k and Kad network are disabled.\n"
 "You won't be able to connect until you enable at least one of them."
@@ -5867,7 +5909,7 @@ msgstr ""
 "Και το δίκτυο eD2k και το Kad είναι απενεργοποιημένα.\n"
 "Δεν θα μπορέσετε να συνδεθείτε μέχρι να ενεργοποιήσετε τουλάχιστον ένα από αυτα."
 
-#: src/PrefsUnifiedDlg.cpp:1329
+#: src/PrefsUnifiedDlg.cpp:1403
 msgid ""
 "Kad will not start if your UDP port is disabled.\n"
 "Enable UDP port or disable Kad."
@@ -5875,7 +5917,7 @@ msgstr ""
 "Το δίκτυο Kad δεν θα ξεκινήσει αν η θύρα UDP είναι απενεργοποιημένη.\n"
 "Ενεργοποιήστε τη θύρα UDP ή απενεργοποιήστε το Kad."
 
-#: src/PrefsUnifiedDlg.cpp:1385
+#: src/PrefsUnifiedDlg.cpp:1459
 msgid ""
 "\n"
 "You MUST restart aMule now.\n"
@@ -5885,69 +5927,69 @@ msgstr ""
 "Τώρα πρέπει να επανεκινήσετε το aMule.\n"
 "Διαφορετικά μην διαμαρτυρηθείτε αν συμβεί κάτι κακό.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1450
+#: src/PrefsUnifiedDlg.cpp:1524
 msgid "Could not register aMule for autostart at login. The autostart store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1452
+#: src/PrefsUnifiedDlg.cpp:1526
 msgid "Could not remove the autostart-at-login entry."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1453
+#: src/PrefsUnifiedDlg.cpp:1527
 #, fuzzy
 msgid "Autostart"
 msgstr "Η αυτόματη ανανέωση ξεκίνησε"
 
-#: src/PrefsUnifiedDlg.cpp:1468
+#: src/PrefsUnifiedDlg.cpp:1542
 msgid "Register file type"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1468
+#: src/PrefsUnifiedDlg.cpp:1542
 msgid "Register URL handler"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1476
+#: src/PrefsUnifiedDlg.cpp:1550
 #, c-format
 msgid "aMule only handles eD2k-compatible magnets. If you replace the current magnet handler (%s), BitTorrent magnet links will stop working - aMule cannot download BitTorrent content. Continue?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1481
+#: src/PrefsUnifiedDlg.cpp:1555
 #, c-format
 msgid "Another application currently opens .emulecollection files (%s). Replace it with aMule?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1486
+#: src/PrefsUnifiedDlg.cpp:1560
 #, c-format
 msgid "Another application is currently the default handler for these links (%s). Replace it with aMule?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1511
+#: src/PrefsUnifiedDlg.cpp:1585
 msgid "Could not register aMule for .emulecollection files. The registration store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1513
+#: src/PrefsUnifiedDlg.cpp:1587
 #, fuzzy
 msgid "Could not remove the file type registration."
 msgstr "Κατάλογος για τα προσωρινά αρχεία"
 
-#: src/PrefsUnifiedDlg.cpp:1515
+#: src/PrefsUnifiedDlg.cpp:1589
 msgid "Could not register aMule as the URL handler. The registration store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1517
+#: src/PrefsUnifiedDlg.cpp:1591
 msgid "Could not remove the URL handler registration."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1587 src/PrefsUnifiedDlg.cpp:1614
+#: src/PrefsUnifiedDlg.cpp:1661 src/PrefsUnifiedDlg.cpp:1688
 #, fuzzy
 msgid "The web server and aMule API require external connections to be enabled."
 msgstr "Νέα εξωτερική σύνδεση έγινε δεκτή"
 
-#: src/PrefsUnifiedDlg.cpp:1597
+#: src/PrefsUnifiedDlg.cpp:1671
 msgid "The aMule web server is deprecated. Consider running the aMule API instead."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1655
+#: src/PrefsUnifiedDlg.cpp:1735
 msgid ""
 "Your Auto-update servers list is in blank.\n"
 "Please fill in at least one URL to point to a valid server.met file.\n"
@@ -5957,66 +5999,66 @@ msgstr ""
 "Παρακαλώ βάλτε τουλάχιστον μία URL που να δείχνει σε ένα έγκυρο αρχείο sever.met.\n"
 "Πατήστε το διπλανό κουμπί \"List\" για να βάλετε ένα URL."
 
-#: src/PrefsUnifiedDlg.cpp:1796
+#: src/PrefsUnifiedDlg.cpp:1876
 msgid "Temporary files"
 msgstr "Προσωρινά αρχεία"
 
-#: src/PrefsUnifiedDlg.cpp:1801
+#: src/PrefsUnifiedDlg.cpp:1881
 msgid "Incoming files"
 msgstr "Εισερχόμενα αρχεία"
 
-#: src/PrefsUnifiedDlg.cpp:1806
+#: src/PrefsUnifiedDlg.cpp:1886
 msgid "Online Signatures"
 msgstr "Συνδεδεμένες υπογραφές"
 
-#: src/PrefsUnifiedDlg.cpp:1819
+#: src/PrefsUnifiedDlg.cpp:1899
 #, c-format
 msgid "Choose a folder for %s"
 msgstr "Επιλέξτε κατάλογο για %s"
 
-#: src/PrefsUnifiedDlg.cpp:1843
+#: src/PrefsUnifiedDlg.cpp:1923
 #, fuzzy, c-format
 msgid "Would exclude %u of %u shared file"
 msgid_plural "Would exclude %u of %u shared files"
 msgstr[0] "Βρέθηκε %i γνωστό κοινόχρηστο αρχείο"
 msgstr[1] "Βρέθηκαν %i γνωστά κοινόχρηστα αρχεία"
 
-#: src/PrefsUnifiedDlg.cpp:1860
+#: src/PrefsUnifiedDlg.cpp:1940
 msgid "Browse for videoplayer"
 msgstr "Αναζήτηση του προγράμματος για βίντεο"
 
-#: src/PrefsUnifiedDlg.cpp:1864
+#: src/PrefsUnifiedDlg.cpp:1944
 msgid "Select browser"
 msgstr "Επιλογή περιηγητή"
 
-#: src/PrefsUnifiedDlg.cpp:1868
+#: src/PrefsUnifiedDlg.cpp:1948
 #, fuzzy
 msgid "Select ffprobe binary"
 msgstr "Επιλογή περιηγητή"
 
-#: src/PrefsUnifiedDlg.cpp:1874
+#: src/PrefsUnifiedDlg.cpp:1954
 #, c-format
 msgid "Executable%s"
 msgstr "Εκτελέσιμο%s"
 
-#: src/PrefsUnifiedDlg.cpp:1908
+#: src/PrefsUnifiedDlg.cpp:1988
 msgid "ffprobe not found on PATH or in the standard install locations. Install ffmpeg (which ships ffprobe) or use Browse to pick a binary manually."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1920
+#: src/PrefsUnifiedDlg.cpp:2000
 msgid "Reset the settings on this page to their default values?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1921
+#: src/PrefsUnifiedDlg.cpp:2001
 #, fuzzy
 msgid "Reset to defaults"
 msgstr "Εργοστασιακές ρυθμίσεις"
 
-#: src/PrefsUnifiedDlg.cpp:1948
+#: src/PrefsUnifiedDlg.cpp:2028
 msgid "Edit server list"
 msgstr "Επεξεργασία λίστας διακομιστών"
 
-#: src/PrefsUnifiedDlg.cpp:1949
+#: src/PrefsUnifiedDlg.cpp:2029
 msgid ""
 "Add here URL's to download server.met files.\n"
 "Only one url on each line."
@@ -6024,155 +6066,155 @@ msgstr ""
 "Βάλτε εδώ τη διεύθυνση για το κατέβασμα των αρχείων server.met. \n"
 "Μία διεύθυνση σε κάθε γραμμή"
 
-#: src/PrefsUnifiedDlg.cpp:2004
+#: src/PrefsUnifiedDlg.cpp:2084
 msgid "IP2Country update failed"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2149 src/PrefsUnifiedDlg.cpp:2180
+#: src/PrefsUnifiedDlg.cpp:2229 src/PrefsUnifiedDlg.cpp:2260
 msgid "Data by MaxMind GeoLite2"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2151 src/PrefsUnifiedDlg.cpp:2182
+#: src/PrefsUnifiedDlg.cpp:2231 src/PrefsUnifiedDlg.cpp:2262
 #, fuzzy
 msgid "Custom source"
 msgstr "Ολοκλήρωση πηγών"
 
-#: src/PrefsUnifiedDlg.cpp:2153 src/PrefsUnifiedDlg.cpp:2184
+#: src/PrefsUnifiedDlg.cpp:2233 src/PrefsUnifiedDlg.cpp:2264
 msgid "Data by DB-IP.com"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2204
+#: src/PrefsUnifiedDlg.cpp:2284
 #, fuzzy, c-format
 msgid "Status: Loaded%s"
 msgstr "Κατάσταση:"
 
-#: src/PrefsUnifiedDlg.cpp:2206
+#: src/PrefsUnifiedDlg.cpp:2286
 #, fuzzy, c-format
 msgid "Status: Loaded%s - %s"
 msgstr "Κατάσταση:"
 
-#: src/PrefsUnifiedDlg.cpp:2210
+#: src/PrefsUnifiedDlg.cpp:2290
 msgid "Status: Failed to load - click 'Update now' to refresh."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2212
+#: src/PrefsUnifiedDlg.cpp:2292
 msgid "Status: Not found - click 'Update now' to download."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2270 src/PrefsUnifiedDlg.cpp:2294
+#: src/PrefsUnifiedDlg.cpp:2350 src/PrefsUnifiedDlg.cpp:2374
 #, c-format
 msgid "Update delay: %d second"
 msgid_plural "Update delay: %d seconds"
 msgstr[0] "Καθυστέρηση ενημέρωσης: %d δευτερόλεπτο"
 msgstr[1] "Καθυστέρηση ενημέρωσης: %d δευτερόλεπτα"
 
-#: src/PrefsUnifiedDlg.cpp:2278
+#: src/PrefsUnifiedDlg.cpp:2358
 #, c-format
 msgid "Time for average graph: %d minute"
 msgid_plural "Time for average graph: %d minutes"
 msgstr[0] "Χρόνος για μέσο γράφημα: %d λεπτό"
 msgstr[1] "Χρόνος για μέσο γράφημα: %d λεπτά"
 
-#: src/PrefsUnifiedDlg.cpp:2287
+#: src/PrefsUnifiedDlg.cpp:2367
 #, c-format
 msgid "Connections Graph Scale: %d"
 msgstr "Κλίμακα γραφήματος συνδέσεων: %d"
 
-#: src/PrefsUnifiedDlg.cpp:2302
+#: src/PrefsUnifiedDlg.cpp:2382
 #, c-format
 msgid "File Buffer Size: %d byte"
 msgid_plural "File Buffer Size: %d bytes"
 msgstr[0] "Μέγεθος χώρου ενδιάμεσης αποθήκευση αρχείου: %d byte"
 msgstr[1] "Μέγεθος χώρου ενδιάμεσης αποθήκευση αρχείου: %d byteς"
 
-#: src/PrefsUnifiedDlg.cpp:2312
+#: src/PrefsUnifiedDlg.cpp:2392
 #, c-format
 msgid "Upload Queue Size: %d client"
 msgid_plural "Upload Queue Size: %d clients"
 msgstr[0] "Μέγεθος λίστας αναμονής αποστελλόμενων: %d πελάτης"
 msgstr[1] "Μέγεθος λίστας αναμονής ανεβασμάτων: %d πελάτες"
 
-#: src/PrefsUnifiedDlg.cpp:2322
+#: src/PrefsUnifiedDlg.cpp:2402
 #, c-format
 msgid "Server connection refresh interval: %d minute"
 msgid_plural "Server connection refresh interval: %d minutes"
 msgstr[0] "Διάστημα ανανέωσης της σύνδεσης σε διακομιστή: %d λεπτό"
 msgstr[1] "Διάστημα ανανέωσης της σύνδεσης σε διακομιστή: %d λεπτά"
 
-#: src/PrefsUnifiedDlg.cpp:2327
+#: src/PrefsUnifiedDlg.cpp:2407
 msgid "Server connection refresh interval: Disabled"
 msgstr "Διάστημα ανανέωσης της σύνδεσης σε διακομιστή: Απενεργοποιημένο"
 
-#: src/PrefsUnifiedDlg.cpp:2371
+#: src/PrefsUnifiedDlg.cpp:2451
 #, fuzzy
 msgid "disabled"
 msgstr "απενεργοποίηση"
 
-#: src/PrefsUnifiedDlg.cpp:2397
+#: src/PrefsUnifiedDlg.cpp:2477
 #, fuzzy, c-format
 msgid "Execute command on '%s' event"
 msgstr "Εκτέλεση εντολής κατά το γεγονός `%s'"
 
-#: src/PrefsUnifiedDlg.cpp:2404
+#: src/PrefsUnifiedDlg.cpp:2484
 msgid "Enable command execution on core"
 msgstr "Ενεργοποίηση εκτέλεσης εντολών στον πυρήνα"
 
-#: src/PrefsUnifiedDlg.cpp:2416
+#: src/PrefsUnifiedDlg.cpp:2496
 msgid "Core command:"
 msgstr "Εντολή πυρήνα:"
 
-#: src/PrefsUnifiedDlg.cpp:2432
+#: src/PrefsUnifiedDlg.cpp:2512
 msgid "Enable command execution on GUI"
 msgstr "Ενεργοποίηση εκτέλεσης εντολών στο γραφικό περιβάλλον"
 
-#: src/PrefsUnifiedDlg.cpp:2444
+#: src/PrefsUnifiedDlg.cpp:2524
 msgid "GUI command:"
 msgstr "Εντολή γραφικού περιβάλλοντος:"
 
-#: src/PrefsUnifiedDlg.cpp:2460
+#: src/PrefsUnifiedDlg.cpp:2540
 msgid "The following variables will be replaced:"
 msgstr "Οι παρακάτω μεταβλητές θα αντικατασταθούν:"
 
-#: src/PrefsUnifiedDlg.cpp:2628
+#: src/PrefsUnifiedDlg.cpp:2708
 msgid ""
 "The following folders look like system or sensitive locations:\n"
 "\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2633
+#: src/PrefsUnifiedDlg.cpp:2713
 msgid "Sharing them recursively will publish every file underneath on the eD2k/Kad networks. Do you really want to do this?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2636
+#: src/PrefsUnifiedDlg.cpp:2716
 #, fuzzy
 msgid "Confirm shared folders"
 msgstr "Κοινόχρηστα αρχεία"
 
-#: src/PrefsUnifiedDlg.cpp:2664
+#: src/PrefsUnifiedDlg.cpp:2744
 #, fuzzy
 msgid "Reloading shared files..."
 msgstr "Επαναφόρτωση των κοινόχρηστων αρχείων"
 
-#: src/PrefsUnifiedDlg.cpp:2665
+#: src/PrefsUnifiedDlg.cpp:2745
 msgid "Scanning for subdirectories..."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2666
+#: src/PrefsUnifiedDlg.cpp:2746
 #, fuzzy
 msgid "Updating shared folders"
 msgstr "Κοινόχρηστα αρχεία"
 
-#: src/PrefsUnifiedDlg.cpp:2693
+#: src/PrefsUnifiedDlg.cpp:2773
 #, c-format
 msgid "Scanned %u directories..."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2743
+#: src/PrefsUnifiedDlg.cpp:2823
 #, fuzzy, c-format
 msgid "Reloading shared files: %u files scanned"
 msgstr "Επαναφορτώνει τη λίστα κοινοχρήστων αρχείων."
 
-#: src/PrefsUnifiedDlg.cpp:2793
+#: src/PrefsUnifiedDlg.cpp:2873
 #, fuzzy
 msgid "Shared folder"
 msgstr "Κοινόχρηστα αρχεία"

--- a/po/en_GB.po
+++ b/po/en_GB.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-28 10:19+0200\n"
+"POT-Creation-Date: 2026-07-28 12:17+0200\n"
 "PO-Revision-Date: 2020-03-04 14:43+0100\n"
 "Last-Translator: Dévai Tamás <devait@vnet.hu>\n"
 "Language-Team: aMule Team <https://github.com/amule-org/amule>\n"
@@ -189,152 +189,152 @@ msgstr ""
 msgid "WARNING: You can't add yourself as a source for an eD2k link while having a lowid."
 msgstr ""
 
-#: src/amule.cpp:300
+#: src/amule.cpp:301
 msgid "Now, exiting main app..."
 msgstr ""
 
-#: src/amule.cpp:330
+#: src/amule.cpp:331
 #, c-format
 msgid "Terminating amuleweb instance with pid '%d' ... "
 msgstr ""
 
-#: src/amule.cpp:334
+#: src/amule.cpp:335
 #, c-format
 msgid "Killing amuleweb instance with pid '%d' ... "
 msgstr ""
 
-#: src/amule.cpp:336 src/amule.cpp:349 src/ClientRef.cpp:180
+#: src/amule.cpp:337 src/amule.cpp:350 src/ClientRef.cpp:180
 #: src/SearchDlg.cpp:1041 src/ServerListCtrl.cpp:98
 msgid "Failed"
 msgstr ""
 
-#: src/amule.cpp:343
+#: src/amule.cpp:344
 #, c-format
 msgid "Terminating amuleapi instance with pid '%d' ... "
 msgstr ""
 
-#: src/amule.cpp:347
+#: src/amule.cpp:348
 #, c-format
 msgid "Killing amuleapi instance with pid '%d' ... "
 msgstr ""
 
-#: src/amule.cpp:355
+#: src/amule.cpp:356
 msgid "aMule OnExit: Terminating core."
 msgstr ""
 
-#: src/amule.cpp:466
+#: src/amule.cpp:467
 msgid "aMule shutdown completed."
 msgstr ""
 
-#: src/amule.cpp:470
+#: src/amule.cpp:471
 msgid "Memory debug results for aMule exit:"
 msgstr ""
 
-#: src/amule.cpp:651
+#: src/amule.cpp:652
 #, c-format
 msgid "Binding aMule's peer-to-peer traffic to interface: %s (HTTP updates use the default route)"
 msgstr ""
 
-#: src/amule.cpp:655
+#: src/amule.cpp:656
 #, c-format
 msgid "Binding all network traffic to interface: %s"
 msgstr ""
 
-#: src/amule.cpp:659
+#: src/amule.cpp:660
 #, c-format
 msgid "WARNING: configured network interface '%s' was not found - traffic is NOT bound to it and may leave via the default route. Check the interface name in Preferences."
 msgstr ""
 
-#: src/amule.cpp:665
+#: src/amule.cpp:666
 #, c-format
 msgid "WARNING: binding to network interface '%s' requires elevated privileges and was NOT applied - traffic may leave via the default route. Grant the capability (e.g. 'sudo setcap cap_net_raw+ep' on the aMule binary) or run with sufficient privileges."
 msgstr ""
 
-#: src/amule.cpp:673
+#: src/amule.cpp:674
 #, c-format
 msgid "WARNING: could not bind to network interface '%s' - traffic may leave via the default route."
 msgstr ""
 
-#: src/amule.cpp:732
+#: src/amule.cpp:733
 msgid "Your locale has been changed to System Default due to a configuration change. Sorry."
 msgstr ""
 
-#: src/amule.cpp:734 src/amule.cpp:1581 src/CatDialog.cpp:128
+#: src/amule.cpp:735 src/amule.cpp:1589 src/CatDialog.cpp:128
 #: src/CatDialog.cpp:136 src/CatDialog.cpp:149 src/ServerList.cpp:366
 #: src/ServerListCtrl.cpp:152
 msgid "Info"
 msgstr ""
 
-#: src/amule.cpp:741
+#: src/amule.cpp:742
 msgid ""
 "\n"
 "EC configuration"
 msgstr ""
 
-#: src/amule.cpp:744
+#: src/amule.cpp:745
 msgid "Password set and external connections enabled."
 msgstr ""
 
-#: src/amule.cpp:754 src/KadDlg.cpp:176 src/KadDlg.cpp:185
-#: src/PrefsUnifiedDlg.cpp:1387 src/SharedFilesCtrl.cpp:476
+#: src/amule.cpp:755 src/KadDlg.cpp:176 src/KadDlg.cpp:185
+#: src/PrefsUnifiedDlg.cpp:1461 src/SharedFilesCtrl.cpp:476
 msgid "WARNING"
 msgstr ""
 
-#: src/amule.cpp:991
+#: src/amule.cpp:992
 msgid "Network bootstrap"
 msgstr ""
 
-#: src/amule.cpp:996
+#: src/amule.cpp:997
 msgid ""
 "aMule has detected missing network bootstrap files.\n"
 "Select which ones to download:"
 msgstr ""
 
-#: src/amule.cpp:1005 src/FirstRunWizard.cpp:411
+#: src/amule.cpp:1006 src/FirstRunWizard.cpp:411
 msgid "eD2k server list (server.met)"
 msgstr ""
 
-#: src/amule.cpp:1012 src/FirstRunWizard.cpp:416
+#: src/amule.cpp:1013 src/FirstRunWizard.cpp:416
 msgid "Kad bootstrap nodes (nodes.dat)"
 msgstr ""
 
-#: src/amule.cpp:1102
+#: src/amule.cpp:1103
 #, c-format
 msgid "web server running on pid %d"
 msgstr ""
 
-#: src/amule.cpp:1115
+#: src/amule.cpp:1116
 msgid "You requested to run web server on startup, but the amuleweb binary cannot be run. Please install the package containing aMule web server, or build aMule from source with -DBUILD_WEBSERVER=YES and install it."
 msgstr ""
 
-#: src/amule.cpp:1120 src/amule.cpp:1177 src/amule.cpp:1291 src/amule.cpp:1593
+#: src/amule.cpp:1121 src/amule.cpp:1185 src/amule.cpp:1299 src/amule.cpp:1601
 #: src/amule-remote-gui.cpp:603 src/amule-remote-gui.cpp:671
 #: src/amule-remote-gui.cpp:709 src/amule-remote-gui.cpp:1282
 #: src/amule-remote-gui.cpp:1345 src/amule-remote-gui.cpp:1372
-#: src/DownloadQueue.cpp:1481
+#: src/DownloadQueue.cpp:1481 src/PrefsUnifiedDlg.cpp:1247
 msgid "ERROR"
 msgstr ""
 
-#: src/amule.cpp:1166
+#: src/amule.cpp:1174
 #, c-format
 msgid "amuleapi running on pid %d"
 msgstr ""
 
-#: src/amule.cpp:1172
+#: src/amule.cpp:1180
 msgid "You requested to run amuleapi on startup, but the amuleapi binary cannot be run. Please install the package containing aMule's REST API server, or build aMule from source with -DBUILD_AMULEAPI=YES and install it."
 msgstr ""
 
-#: src/amule.cpp:1259
+#: src/amule.cpp:1267
 #, c-format
 msgid "Could not bind ports to the specified address: %s"
 msgstr ""
 
-#: src/amule.cpp:1283
+#: src/amule.cpp:1291
 #, c-format
 msgid "Port %u is not available. You will be LOWID\n"
 msgstr ""
 
-#: src/amule.cpp:1288
+#: src/amule.cpp:1296
 #, c-format
 msgid ""
 "Port %u is not available!\n"
@@ -344,184 +344,184 @@ msgid ""
 "Check your network to make sure the port is open for output and input."
 msgstr ""
 
-#: src/amule.cpp:1385
+#: src/amule.cpp:1393
 msgid "Failed to create OnlineSig File"
 msgstr ""
 
-#: src/amule.cpp:1393
+#: src/amule.cpp:1401
 msgid "Failed to create aMule OnlineSig File"
 msgstr ""
 
-#: src/amule.cpp:1556
+#: src/amule.cpp:1564
 msgid "The selected locale seems not to be installed on your box. (Note: I'll try to set it anyway)"
 msgstr ""
 
-#: src/amule.cpp:1566
+#: src/amule.cpp:1574
 #, c-format
 msgid "This is the first time you run aMule %s"
 msgstr ""
 
-#: src/amule.cpp:1569
+#: src/amule.cpp:1577
 msgid "This version is a testing version, updated daily, and\n"
 msgstr ""
 
-#: src/amule.cpp:1570
+#: src/amule.cpp:1578
 msgid "we give no warranty it won't break anything, burn your house,\n"
 msgstr ""
 
-#: src/amule.cpp:1571
+#: src/amule.cpp:1579
 msgid "or kill your dog. But it *should* be safe to use anyway.\n"
 msgstr ""
 
-#: src/amule.cpp:1576
+#: src/amule.cpp:1584
 msgid "More information, support and new releases can found at our homepage,\n"
 msgstr ""
 
-#: src/amule.cpp:1577
+#: src/amule.cpp:1585
 msgid "at https://amule-org.github.io, or in our IRC channel #aMule at irc.libera.chat.\n"
 msgstr ""
 
-#: src/amule.cpp:1579
+#: src/amule.cpp:1587
 msgid "Feel free to report any bugs to https://github.com/amule-org/amule/issues"
 msgstr ""
 
-#: src/amule.cpp:1591
+#: src/amule.cpp:1599
 msgid ""
 "The folder for Online Signature files you specified is INVALID!\n"
 " OnlineSignature will be DISABLED until you fix it on preferences."
 msgstr ""
 
-#: src/amule.cpp:1654
+#: src/amule.cpp:1662
 msgid "Server hostname notified"
 msgstr ""
 
-#: src/amule.cpp:2031
+#: src/amule.cpp:2039
 #, c-format
 msgid "Disk space preallocation for file '%s' failed: %s"
 msgstr ""
 
-#: src/amule.cpp:2160
+#: src/amule.cpp:2168
 msgid "ERROR: can't open logfile"
 msgstr ""
 
-#: src/amule.cpp:2164
+#: src/amule.cpp:2172
 msgid "WARNING: logfile is empty. Something is wrong."
 msgstr ""
 
-#: src/amule.cpp:2181
+#: src/amule.cpp:2189
 msgid "Log has been reset"
 msgstr ""
 
-#: src/amule.cpp:2205
+#: src/amule.cpp:2213
 #, c-format
 msgid "ServerMessage: %s"
 msgstr ""
 
-#: src/amule.cpp:2248 src/IP2Country.cpp:220 src/IPFilter.cpp:514
+#: src/amule.cpp:2256 src/IP2Country.cpp:220 src/IPFilter.cpp:514
 #: src/ServerList.cpp:875
 #, c-format
 msgid "Skipped download of %s, because requested file is not newer."
 msgstr ""
 
-#: src/amule.cpp:2251
+#: src/amule.cpp:2259
 msgid "Failed to download the nodes list."
 msgstr ""
 
-#: src/amule.cpp:2314
+#: src/amule.cpp:2322
 msgid "Failed to open the downloaded version check file"
 msgstr ""
 
-#: src/amule.cpp:2317 src/amule.cpp:2336
+#: src/amule.cpp:2325 src/amule.cpp:2344
 msgid "Corrupted version check file"
 msgstr ""
 
-#: src/amule.cpp:2359
+#: src/amule.cpp:2367
 msgid "You are using an outdated version of aMule!"
 msgstr ""
 
-#: src/amule.cpp:2361
+#: src/amule.cpp:2369
 #, c-format
 msgid "Your aMule version is %i.%i.%i and the latest version is %li.%li.%li"
 msgstr ""
 
-#: src/amule.cpp:2365
+#: src/amule.cpp:2373
 msgid "The latest version can always be found at https://github.com/amule-org/amule/releases/latest"
 msgstr ""
 
-#: src/amule.cpp:2368
+#: src/amule.cpp:2376
 #, c-format
 msgid "WARNING: Your aMuled version is outdated: %i.%i.%i < %li.%li.%li"
 msgstr ""
 
-#: src/amule.cpp:2374
+#: src/amule.cpp:2382
 msgid "Your copy of aMule is up to date."
 msgstr ""
 
-#: src/amule.cpp:2381
+#: src/amule.cpp:2389
 msgid "Failed to download the version check file"
 msgstr ""
 
-#: src/amule.cpp:2550 src/amule-remote-gui.cpp:1133
+#: src/amule.cpp:2558 src/amule-remote-gui.cpp:1133
 #, c-format
 msgid "Users: %s | Files: %s"
 msgstr ""
 
-#: src/amule.cpp:2551 src/amule-remote-gui.cpp:1134
+#: src/amule.cpp:2559 src/amule-remote-gui.cpp:1134
 #, c-format
 msgid "Users: E: %s K: %s | Files: E: %s K: %s"
 msgstr ""
 
-#: src/amule.cpp:2565 src/amule-remote-gui.cpp:1147
+#: src/amule.cpp:2573 src/amule-remote-gui.cpp:1147
 msgid "No networks selected"
 msgstr ""
 
-#: src/amule.cpp:2633 src/TextClient.cpp:903
+#: src/amule.cpp:2641 src/TextClient.cpp:903
 msgid "with LowID"
 msgstr ""
 
-#: src/amule.cpp:2633 src/TextClient.cpp:904
+#: src/amule.cpp:2641 src/TextClient.cpp:904
 msgid "with HighID"
 msgstr ""
 
-#: src/amule.cpp:2635
+#: src/amule.cpp:2643
 #, c-format
 msgid "Connected to %s %s"
 msgstr ""
 
-#: src/amule.cpp:2640
+#: src/amule.cpp:2648
 #, c-format
 msgid "Connecting to %s"
 msgstr ""
 
-#: src/amule.cpp:2642
+#: src/amule.cpp:2650
 msgid "Disconnected from eD2k"
 msgstr ""
 
-#: src/amule.cpp:2651
+#: src/amule.cpp:2659
 msgid "Kad started."
 msgstr ""
 
-#: src/amule.cpp:2653
+#: src/amule.cpp:2661
 msgid "Kad stopped."
 msgstr ""
 
-#: src/amule.cpp:2661
+#: src/amule.cpp:2669
 msgid "Connected to Kad (ok)"
 msgstr ""
 
-#: src/amule.cpp:2663
+#: src/amule.cpp:2671
 msgid "Connected to Kad (firewalled)"
 msgstr ""
 
-#: src/amule.cpp:2667
+#: src/amule.cpp:2675
 msgid "Disconnected from Kad"
 msgstr ""
 
-#: src/amule.cpp:2699
+#: src/amule.cpp:2707
 msgid "Kad network cannot be used if UDP port is disabled on preferences, not starting."
 msgstr ""
 
-#: src/amule.cpp:2703
+#: src/amule.cpp:2711
 msgid "Kad network disabled on preferences, not connecting."
 msgstr ""
 
@@ -565,36 +565,36 @@ msgid "FATAL ERROR: Failed to create Timer"
 msgstr ""
 
 #: src/amuleDlg.cpp:361 src/amuleDlg.cpp:1787 src/amuleDlg.cpp:2033
-#: src/muuli_wdr.cpp:1492 src/muuli_wdr.cpp:3418
+#: src/muuli_wdr.cpp:1492 src/muuli_wdr.cpp:3449
 msgid "Networks"
 msgstr ""
 
-#: src/amuleDlg.cpp:362 src/amuleDlg.cpp:1793 src/muuli_wdr.cpp:3419
+#: src/amuleDlg.cpp:362 src/amuleDlg.cpp:1793 src/muuli_wdr.cpp:3450
 msgid "Searches"
 msgstr ""
 
 #: src/amuleDlg.cpp:363 src/amuleDlg.cpp:1799 src/DownloadListCtrl.cpp:740
-#: src/muuli_wdr.cpp:392 src/muuli_wdr.cpp:1585 src/muuli_wdr.cpp:3420
+#: src/muuli_wdr.cpp:392 src/muuli_wdr.cpp:1585 src/muuli_wdr.cpp:3451
 #: src/Statistics.cpp:829
 msgid "Downloads"
 msgstr ""
 
-#: src/amuleDlg.cpp:364 src/amuleDlg.cpp:1805 src/muuli_wdr.cpp:3294
+#: src/amuleDlg.cpp:364 src/amuleDlg.cpp:1805 src/muuli_wdr.cpp:3325
 msgid "Shared files"
 msgstr ""
 
-#: src/amuleDlg.cpp:365 src/amuleDlg.cpp:1811 src/muuli_wdr.cpp:2926
-#: src/muuli_wdr.cpp:3376 src/muuli_wdr.cpp:3423
+#: src/amuleDlg.cpp:365 src/amuleDlg.cpp:1811 src/muuli_wdr.cpp:2957
+#: src/muuli_wdr.cpp:3407 src/muuli_wdr.cpp:3454
 msgid "Messages"
 msgstr ""
 
-#: src/amuleDlg.cpp:366 src/amuleDlg.cpp:1817 src/muuli_wdr.cpp:3424
-#: src/PrefsUnifiedDlg.cpp:312 src/Statistics.cpp:779 src/Statistics.cpp:1235
+#: src/amuleDlg.cpp:366 src/amuleDlg.cpp:1817 src/muuli_wdr.cpp:3455
+#: src/PrefsUnifiedDlg.cpp:314 src/Statistics.cpp:779 src/Statistics.cpp:1235
 msgid "Statistics"
 msgstr ""
 
-#: src/amuleDlg.cpp:368 src/amuleDlg.cpp:1824 src/muuli_wdr.cpp:3426
-#: src/PrefsUnifiedDlg.cpp:328 src/utils/wxCas/src/wxcasprefs.cpp:39
+#: src/amuleDlg.cpp:368 src/amuleDlg.cpp:1824 src/muuli_wdr.cpp:3457
+#: src/PrefsUnifiedDlg.cpp:330 src/utils/wxCas/src/wxcasprefs.cpp:39
 msgid "Preferences"
 msgstr ""
 
@@ -651,8 +651,8 @@ msgstr ""
 #: src/amuleDlg.cpp:1029 src/DownloadListCtrl.cpp:505
 #: src/DownloadListCtrl.cpp:749 src/FriendListCtrl.cpp:180
 #: src/muuli_wdr.cpp:731 src/muuli_wdr.cpp:782 src/muuli_wdr.cpp:846
-#: src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2231 src/muuli_wdr.cpp:2316
-#: src/muuli_wdr.cpp:3064 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
+#: src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2262 src/muuli_wdr.cpp:2347
+#: src/muuli_wdr.cpp:3095 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
 #: src/ServerListCtrl.cpp:606 src/TransferWnd.cpp:378
 #: src/utils/wxCas/src/wxcasprefs.cpp:235
 msgid "Cancel"
@@ -663,7 +663,7 @@ msgid "Stop the current connection attempts"
 msgstr ""
 
 #: src/amuleDlg.cpp:1035 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976
-#: src/muuli_wdr.cpp:2454
+#: src/muuli_wdr.cpp:2485
 msgid "Disconnect"
 msgstr ""
 
@@ -672,7 +672,7 @@ msgid "Disconnect from the currently connected networks"
 msgstr ""
 
 #: src/amuleDlg.cpp:1041 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979
-#: src/muuli_wdr.cpp:2609 src/muuli_wdr.cpp:3061 src/muuli_wdr.cpp:3416
+#: src/muuli_wdr.cpp:2640 src/muuli_wdr.cpp:3092 src/muuli_wdr.cpp:3447
 msgid "Connect"
 msgstr ""
 
@@ -726,7 +726,7 @@ msgstr ""
 msgid "Launch Command: "
 msgstr ""
 
-#: src/amuleDlg.cpp:1632 src/muuli_wdr.cpp:1978 src/Preferences.cpp:952
+#: src/amuleDlg.cpp:1632 src/muuli_wdr.cpp:1982 src/Preferences.cpp:979
 msgid "- default -"
 msgstr ""
 
@@ -740,48 +740,48 @@ msgstr ""
 msgid "WARNING: Unable to open skin file '%s' for read"
 msgstr ""
 
-#: src/amuleDlg.cpp:1791 src/muuli_wdr.cpp:3418
+#: src/amuleDlg.cpp:1791 src/muuli_wdr.cpp:3449
 msgid "Networks Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1797 src/muuli_wdr.cpp:3419
+#: src/amuleDlg.cpp:1797 src/muuli_wdr.cpp:3450
 msgid "Searches Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1803 src/muuli_wdr.cpp:3420
+#: src/amuleDlg.cpp:1803 src/muuli_wdr.cpp:3451
 msgid "Downloads Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1809 src/muuli_wdr.cpp:3422
+#: src/amuleDlg.cpp:1809 src/muuli_wdr.cpp:3453
 msgid "Shared Files Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1815 src/muuli_wdr.cpp:3423
+#: src/amuleDlg.cpp:1815 src/muuli_wdr.cpp:3454
 msgid "Messages Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1821 src/muuli_wdr.cpp:3424
+#: src/amuleDlg.cpp:1821 src/muuli_wdr.cpp:3455
 msgid "Statistics Graph Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1828 src/muuli_wdr.cpp:3426
+#: src/amuleDlg.cpp:1828 src/muuli_wdr.cpp:3457
 msgid "Preferences Settings Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1831 src/muuli_wdr.cpp:3427
+#: src/amuleDlg.cpp:1831 src/muuli_wdr.cpp:3458
 msgid "Import"
 msgstr ""
 
-#: src/amuleDlg.cpp:1835 src/muuli_wdr.cpp:3427
+#: src/amuleDlg.cpp:1835 src/muuli_wdr.cpp:3458
 msgid "The partfile importer tool"
 msgstr ""
 
-#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3428
+#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3459
 #: src/utils/aLinkCreator/src/alcframe.cpp:262
 msgid "About"
 msgstr ""
 
-#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3428
+#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3459
 msgid "About/Help"
 msgstr ""
 
@@ -918,7 +918,7 @@ msgstr ""
 msgid "The core rejected these shared folders:%s"
 msgstr ""
 
-#: src/amule-remote-gui.cpp:1336 src/ExternalConn.cpp:2345
+#: src/amule-remote-gui.cpp:1336 src/ExternalConn.cpp:2346
 msgid "Invalid link or already on list."
 msgstr ""
 
@@ -934,7 +934,7 @@ msgstr ""
 #: src/ClientDetailDialog.cpp:123 src/DataToText.cpp:61 src/DataToText.cpp:86
 #: src/DataToText.cpp:101 src/DataToText.cpp:136 src/DataToText.cpp:165
 #: src/DownloadListCtrl.cpp:1172 src/DownloadListCtrl.cpp:1185
-#: src/DownloadListCtrl.cpp:1196 src/ExternalConn.cpp:608
+#: src/DownloadListCtrl.cpp:1196 src/ExternalConn.cpp:609
 #: src/FileDetailDialog.cpp:203 src/FileDetailDialog.cpp:235
 #: src/FileDetailDialog.cpp:242 src/GenericClientListCtrl.cpp:1171
 #: src/GenericClientListCtrl.cpp:1182 src/GenericClientListCtrl.cpp:1192
@@ -1320,19 +1320,19 @@ msgstr ""
 msgid "Very low"
 msgstr ""
 
-#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:743 src/muuli_wdr.cpp:2282
+#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:743 src/muuli_wdr.cpp:2313
 #: src/ServerListCtrl.cpp:263 src/ServerListCtrl.cpp:456
 #: src/SharedFilesCtrl.cpp:145
 msgid "Low"
 msgstr ""
 
-#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:744 src/muuli_wdr.cpp:2283
+#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:744 src/muuli_wdr.cpp:2314
 #: src/ServerListCtrl.cpp:266 src/ServerListCtrl.cpp:457
 #: src/SharedFilesCtrl.cpp:146
 msgid "Normal"
 msgstr ""
 
-#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:745 src/muuli_wdr.cpp:2284
+#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:745 src/muuli_wdr.cpp:2315
 #: src/ServerListCtrl.cpp:269 src/ServerListCtrl.cpp:458
 #: src/SharedFilesCtrl.cpp:147
 msgid "High"
@@ -1424,7 +1424,7 @@ msgstr ""
 msgid "Remote Server"
 msgstr ""
 
-#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3181
+#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3212
 #: src/SearchDlg.cpp:119 src/TextClient.cpp:911
 msgid "Kad"
 msgstr ""
@@ -1495,7 +1495,7 @@ msgstr ""
 msgid "Size"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3248
+#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3279
 msgid "Transferred"
 msgstr ""
 
@@ -1551,7 +1551,7 @@ msgid ""
 "\n"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:746 src/muuli_wdr.cpp:2285
+#: src/DownloadListCtrl.cpp:746 src/muuli_wdr.cpp:2316
 #: src/SharedFilesCtrl.cpp:150
 msgid "Auto"
 msgstr ""
@@ -1589,7 +1589,7 @@ msgid "Extended Options"
 msgstr ""
 
 #: src/DownloadListCtrl.cpp:770 src/DownloadListCtrl.cpp:822
-#: src/muuli_wdr.cpp:1796
+#: src/muuli_wdr.cpp:1800
 msgid "Preview"
 msgstr ""
 
@@ -1762,225 +1762,230 @@ msgstr[1] ""
 msgid "Invalid eD2k link! ERROR: %s"
 msgstr ""
 
-#: src/ExternalConn.cpp:379
+#: src/ExternalConn.cpp:380
 msgid "Client sent packet after authentication failed."
 msgstr ""
 
-#: src/ExternalConn.cpp:396
+#: src/ExternalConn.cpp:397
 msgid "External connection closed."
 msgstr ""
 
-#: src/ExternalConn.cpp:473
+#: src/ExternalConn.cpp:474
 msgid "External connections disabled due to empty password!"
 msgstr ""
 
-#: src/ExternalConn.cpp:494
+#: src/ExternalConn.cpp:495
 msgid "External connections disabled in config file"
 msgstr ""
 
-#: src/ExternalConn.cpp:575
+#: src/ExternalConn.cpp:576
 msgid "New external connection accepted"
 msgstr ""
 
-#: src/ExternalConn.cpp:578
+#: src/ExternalConn.cpp:579
 msgid "ERROR: couldn't accept a new external connection"
 msgstr ""
 
-#: src/ExternalConn.cpp:595
+#: src/ExternalConn.cpp:596
 msgid "External connection refused due to empty password in preferences!"
 msgstr ""
 
-#: src/ExternalConn.cpp:607
+#: src/ExternalConn.cpp:608
 #, c-format
 msgid "Connecting client: %s %s"
 msgstr ""
 
-#: src/ExternalConn.cpp:609
+#: src/ExternalConn.cpp:610
 msgid "Unknown version"
 msgstr ""
 
-#: src/ExternalConn.cpp:622
+#: src/ExternalConn.cpp:623
 msgid "Incorrect EC version ID, there might be binary incompatibility. Use core and remote from same snapshot."
 msgstr ""
 
-#: src/ExternalConn.cpp:630
+#: src/ExternalConn.cpp:631
 msgid "You cannot connect to a release version from an arbitrary development snapshot! *sigh* possible crash prevented"
 msgstr ""
 
-#: src/ExternalConn.cpp:713
+#: src/ExternalConn.cpp:714
 msgid "Invalid protocol version."
 msgstr ""
 
-#: src/ExternalConn.cpp:719
+#: src/ExternalConn.cpp:720
 msgid "Missing protocol version tag."
 msgstr ""
 
-#: src/ExternalConn.cpp:727
+#: src/ExternalConn.cpp:728
 msgid "Authentication failed: invalid hash specified as EC password."
 msgstr ""
 
-#: src/ExternalConn.cpp:775
+#: src/ExternalConn.cpp:776
 msgid "Authentication failed: wrong password."
 msgstr ""
 
-#: src/ExternalConn.cpp:777
+#: src/ExternalConn.cpp:778
 msgid "Authentication failed: missing password."
 msgstr ""
 
-#: src/ExternalConn.cpp:788
+#: src/ExternalConn.cpp:789
 msgid "Invalid request, please authenticate first."
 msgstr ""
 
-#: src/ExternalConn.cpp:793
+#: src/ExternalConn.cpp:794
 msgid "Access granted."
 msgstr ""
 
-#: src/ExternalConn.cpp:801
+#: src/ExternalConn.cpp:802
 #, c-format
 msgid "Sent error message \"%s\" to client."
 msgstr ""
 
-#: src/ExternalConn.cpp:806
+#: src/ExternalConn.cpp:807
 #, c-format
 msgid "Unauthorized access attempt from %s. Connection closed."
 msgstr ""
 
-#: src/ExternalConn.cpp:1419
+#: src/ExternalConn.cpp:1420
 #, c-format
 msgid "Remote PartFile command failed: FileHash not found: %s"
 msgstr ""
 
-#: src/ExternalConn.cpp:1423
+#: src/ExternalConn.cpp:1424
 #, c-format
 msgid "FileHash not found: %s"
 msgstr ""
 
-#: src/ExternalConn.cpp:1470 src/ExternalConn.cpp:1558
-#: src/ExternalConn.cpp:1679
+#: src/ExternalConn.cpp:1471 src/ExternalConn.cpp:1559
+#: src/ExternalConn.cpp:1680
 msgid "OOPS! OpCode processing error!"
 msgstr ""
 
-#: src/ExternalConn.cpp:1501
+#: src/ExternalConn.cpp:1502
 msgid "Server not added"
 msgstr ""
 
-#: src/ExternalConn.cpp:1520
+#: src/ExternalConn.cpp:1521
 #, c-format
 msgid "server not found: %s"
 msgstr ""
 
-#: src/ExternalConn.cpp:1537
+#: src/ExternalConn.cpp:1538
 msgid "need to define server to be removed"
 msgstr ""
 
-#: src/ExternalConn.cpp:1552
+#: src/ExternalConn.cpp:1553
 msgid "eD2k is disabled in preferences."
 msgstr ""
 
-#: src/ExternalConn.cpp:1657
+#: src/ExternalConn.cpp:1658
 msgid "Friend not found."
 msgstr ""
 
-#: src/ExternalConn.cpp:1667
+#: src/ExternalConn.cpp:1668
 msgid "Client not found."
 msgstr ""
 
-#: src/ExternalConn.cpp:1673
+#: src/ExternalConn.cpp:1674
 msgid "EC_TAG_FRIEND_SHARED requires EC_TAG_FRIEND or EC_TAG_CLIENT."
 msgstr ""
 
-#: src/ExternalConn.cpp:1991
+#: src/ExternalConn.cpp:1992
 msgid "WebSearch from remote interface makes no sense."
 msgstr ""
 
-#: src/ExternalConn.cpp:2026
+#: src/ExternalConn.cpp:2027
 msgid "Search in progress. Refetch results in a moment!"
 msgstr ""
 
-#: src/ExternalConn.cpp:2265
+#: src/ExternalConn.cpp:2266
 msgid "No points for graph."
 msgstr ""
 
-#: src/ExternalConn.cpp:2275
+#: src/ExternalConn.cpp:2276
 msgid "Your client is not configured for this detail level."
 msgstr ""
 
-#: src/ExternalConn.cpp:2302
+#: src/ExternalConn.cpp:2303
 msgid "External Connection: shutdown requested"
 msgstr ""
 
-#: src/ExternalConn.cpp:2314
+#: src/ExternalConn.cpp:2315
 msgid "Already shutting down."
 msgstr ""
 
-#: src/ExternalConn.cpp:2332
+#: src/ExternalConn.cpp:2333
 #, c-format
 msgid "ExternalConn: adding link '%s'."
 msgstr ""
 
-#: src/ExternalConn.cpp:2350
+#: src/ExternalConn.cpp:2351
 #, c-format
 msgid "%d of %d links failed (invalid or already on list)."
 msgstr ""
 
-#: src/ExternalConn.cpp:2373
+#: src/ExternalConn.cpp:2374
 msgid "Version check throttled; try again shortly."
 msgstr ""
 
-#: src/ExternalConn.cpp:2378
+#: src/ExternalConn.cpp:2379
 msgid "Version check is not available on this daemon."
 msgstr ""
 
-#: src/ExternalConn.cpp:2508
+#: src/ExternalConn.cpp:2509
 msgid "File not found."
 msgstr ""
 
-#: src/ExternalConn.cpp:2513
+#: src/ExternalConn.cpp:2514
 msgid "Invalid file name."
 msgstr ""
 
-#: src/ExternalConn.cpp:2521
+#: src/ExternalConn.cpp:2522
 msgid "Unable to rename file."
 msgstr ""
 
-#: src/ExternalConn.cpp:2992 src/ExternalConn.cpp:3020
+#: src/ExternalConn.cpp:2839
+#, c-format
+msgid "Could not save the amuleapi password: %s"
+msgstr ""
+
+#: src/ExternalConn.cpp:3004 src/ExternalConn.cpp:3032
 msgid "Kad is disabled in preferences."
 msgstr ""
 
-#: src/ExternalConn.cpp:3033
+#: src/ExternalConn.cpp:3045
 msgid "Already connected to eD2k."
 msgstr ""
 
-#: src/ExternalConn.cpp:3036
+#: src/ExternalConn.cpp:3048
 msgid "Connecting to eD2k..."
 msgstr ""
 
-#: src/ExternalConn.cpp:3045
+#: src/ExternalConn.cpp:3057
 msgid "Already connected to Kad."
 msgstr ""
 
-#: src/ExternalConn.cpp:3048
+#: src/ExternalConn.cpp:3060
 msgid "Connecting to Kad..."
 msgstr ""
 
-#: src/ExternalConn.cpp:3055
+#: src/ExternalConn.cpp:3067
 msgid "All networks are disabled."
 msgstr ""
 
-#: src/ExternalConn.cpp:3064
+#: src/ExternalConn.cpp:3076
 msgid "Disconnected from eD2k."
 msgstr ""
 
-#: src/ExternalConn.cpp:3069
+#: src/ExternalConn.cpp:3081
 msgid "Disconnected from Kad."
 msgstr ""
 
-#: src/ExternalConn.cpp:3078
+#: src/ExternalConn.cpp:3090
 #, c-format
 msgid "External Connection: invalid opcode received: %#x"
 msgstr ""
 
-#: src/ExternalConn.cpp:3083
+#: src/ExternalConn.cpp:3095
 msgid "Invalid opcode (wrong protocol version?)"
 msgstr ""
 
@@ -2350,23 +2355,23 @@ msgid ""
 "want downloads on a different (e.g. larger) disk."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:549 src/FirstRunWizard.cpp:611 src/muuli_wdr.cpp:1708
+#: src/FirstRunWizard.cpp:549 src/FirstRunWizard.cpp:611 src/muuli_wdr.cpp:1712
 msgid "Destination folder for downloads"
 msgstr ""
 
 #: src/FirstRunWizard.cpp:553 src/FirstRunWizard.cpp:569 src/muuli_wdr.cpp:1349
-#: src/muuli_wdr.cpp:1366 src/muuli_wdr.cpp:1683 src/muuli_wdr.cpp:1714
-#: src/muuli_wdr.cpp:1726 src/muuli_wdr.cpp:2769
+#: src/muuli_wdr.cpp:1366 src/muuli_wdr.cpp:1687 src/muuli_wdr.cpp:1718
+#: src/muuli_wdr.cpp:1730 src/muuli_wdr.cpp:2800
 #: src/utils/aLinkCreator/src/alcframe.cpp:135
 #: src/utils/wxCas/src/wxcasprefs.cpp:52 src/utils/wxCas/src/wxcasprefs.cpp:118
 msgid "Browse"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:559 src/muuli_wdr.cpp:1719
+#: src/FirstRunWizard.cpp:559 src/muuli_wdr.cpp:1723
 msgid "(All files in this folder are shared with other peers)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:565 src/FirstRunWizard.cpp:624 src/muuli_wdr.cpp:1721
+#: src/FirstRunWizard.cpp:565 src/FirstRunWizard.cpp:624 src/muuli_wdr.cpp:1725
 msgid "Folder for temporary download files"
 msgstr ""
 
@@ -2397,7 +2402,7 @@ msgstr ""
 msgid "CRITICAL - no client on StartChatSession"
 msgstr ""
 
-#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2675 src/muuli_wdr.cpp:3352
+#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2706 src/muuli_wdr.cpp:3383
 msgid "Friends"
 msgstr ""
 
@@ -2503,8 +2508,8 @@ msgstr ""
 msgid "No"
 msgstr ""
 
-#: src/GenericClientListCtrl.cpp:1216 src/PrefsUnifiedDlg.cpp:2818
-#: src/PrefsUnifiedDlg.cpp:2868 src/ServerListCtrl.cpp:276
+#: src/GenericClientListCtrl.cpp:1216 src/PrefsUnifiedDlg.cpp:2898
+#: src/PrefsUnifiedDlg.cpp:2948 src/ServerListCtrl.cpp:276
 msgid "Yes"
 msgstr ""
 
@@ -2671,10 +2676,10 @@ msgstr ""
 msgid "Please fill all fields required"
 msgstr ""
 
-#: src/KadDlg.cpp:192 src/PartFile.cpp:1031 src/PrefsUnifiedDlg.cpp:1162
-#: src/PrefsUnifiedDlg.cpp:1331 src/PrefsUnifiedDlg.cpp:1589
-#: src/PrefsUnifiedDlg.cpp:1599 src/PrefsUnifiedDlg.cpp:1616
-#: src/PrefsUnifiedDlg.cpp:1658
+#: src/KadDlg.cpp:192 src/PartFile.cpp:1031 src/PrefsUnifiedDlg.cpp:1134
+#: src/PrefsUnifiedDlg.cpp:1204 src/PrefsUnifiedDlg.cpp:1405
+#: src/PrefsUnifiedDlg.cpp:1663 src/PrefsUnifiedDlg.cpp:1673
+#: src/PrefsUnifiedDlg.cpp:1690 src/PrefsUnifiedDlg.cpp:1738
 msgid "Message"
 msgstr ""
 
@@ -2775,7 +2780,7 @@ msgstr ""
 msgid "Uploaded"
 msgstr ""
 
-#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3232
+#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3263
 msgid "Requested"
 msgstr ""
 
@@ -2898,7 +2903,7 @@ msgid "WARNING: "
 msgstr ""
 
 #: src/MuleNotebook.cpp:179 src/muuli_wdr.cpp:817 src/muuli_wdr.cpp:1229
-#: src/muuli_wdr.cpp:3136 src/muuli_wdr.cpp:3392
+#: src/muuli_wdr.cpp:3167 src/muuli_wdr.cpp:3423
 msgid "Close"
 msgstr ""
 
@@ -2916,7 +2921,7 @@ msgid "Paste"
 msgstr ""
 
 #: src/MuleTextCtrl.cpp:89 src/muuli_wdr.cpp:358 src/muuli_wdr.cpp:757
-#: src/muuli_wdr.cpp:2359 src/muuli_wdr.cpp:2378 src/muuli_wdr.cpp:2400
+#: src/muuli_wdr.cpp:2390 src/muuli_wdr.cpp:2409 src/muuli_wdr.cpp:2431
 #: src/utils/aLinkCreator/src/alcframe.cpp:142
 msgid "Clear"
 msgstr ""
@@ -3008,7 +3013,7 @@ msgstr ""
 
 #: src/MuleTrayIcon.cpp:579 src/MuleTrayIcon.cpp:945 src/MuleTrayIcon.cpp:965
 #: src/muuli_wdr.cpp:1398 src/muuli_wdr.cpp:1406 src/muuli_wdr.cpp:1413
-#: src/muuli_wdr.cpp:1842 src/muuli_wdr.cpp:1848 src/OtherFunctions.cpp:91
+#: src/muuli_wdr.cpp:1846 src/muuli_wdr.cpp:1852 src/OtherFunctions.cpp:91
 #: src/StatisticsDlg.cpp:93 src/StatisticsDlg.cpp:95
 msgid "kB/s"
 msgstr ""
@@ -3248,7 +3253,7 @@ msgstr ""
 msgid "KB"
 msgstr ""
 
-#: src/muuli_wdr.cpp:274 src/muuli_wdr.cpp:293 src/muuli_wdr.cpp:1627
+#: src/muuli_wdr.cpp:274 src/muuli_wdr.cpp:293 src/muuli_wdr.cpp:1631
 #: src/OtherFunctions.cpp:64
 msgid "MB"
 msgstr ""
@@ -3265,7 +3270,7 @@ msgstr ""
 msgid "Availability"
 msgstr ""
 
-#: src/muuli_wdr.cpp:312 src/muuli_wdr.cpp:398 src/muuli_wdr.cpp:3297
+#: src/muuli_wdr.cpp:312 src/muuli_wdr.cpp:398 src/muuli_wdr.cpp:3328
 msgid "Filter:"
 msgstr ""
 
@@ -3328,12 +3333,12 @@ msgstr ""
 #: src/muuli_wdr.cpp:1160 src/muuli_wdr.cpp:1167 src/muuli_wdr.cpp:1172
 #: src/muuli_wdr.cpp:1179 src/muuli_wdr.cpp:1184 src/muuli_wdr.cpp:1191
 #: src/muuli_wdr.cpp:1205 src/muuli_wdr.cpp:1212 src/muuli_wdr.cpp:1217
-#: src/muuli_wdr.cpp:1224 src/muuli_wdr.cpp:3234 src/muuli_wdr.cpp:3242
-#: src/muuli_wdr.cpp:3250
+#: src/muuli_wdr.cpp:1224 src/muuli_wdr.cpp:3265 src/muuli_wdr.cpp:3273
+#: src/muuli_wdr.cpp:3281
 msgid "N/A"
 msgstr ""
 
-#: src/muuli_wdr.cpp:508 src/muuli_wdr.cpp:1065 src/PrefsUnifiedDlg.cpp:297
+#: src/muuli_wdr.cpp:508 src/muuli_wdr.cpp:1065 src/PrefsUnifiedDlg.cpp:299
 msgid "General"
 msgstr ""
 
@@ -3469,7 +3474,7 @@ msgstr ""
 msgid "Album :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:685 src/muuli_wdr.cpp:2254
+#: src/muuli_wdr.cpp:685 src/muuli_wdr.cpp:2285
 msgid "Title :"
 msgstr ""
 
@@ -3575,7 +3580,7 @@ msgstr ""
 msgid "Userhash :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:895 src/muuli_wdr.cpp:1748 src/muuli_wdr.cpp:2449
+#: src/muuli_wdr.cpp:895 src/muuli_wdr.cpp:1752 src/muuli_wdr.cpp:2480
 #: src/utils/aLinkCreator/src/alcframe.cpp:137
 msgid "Add"
 msgstr ""
@@ -3584,15 +3589,15 @@ msgstr ""
 msgid "Download-Speed"
 msgstr ""
 
-#: src/muuli_wdr.cpp:954 src/muuli_wdr.cpp:989 src/muuli_wdr.cpp:2553
+#: src/muuli_wdr.cpp:954 src/muuli_wdr.cpp:989 src/muuli_wdr.cpp:2584
 msgid "Current"
 msgstr ""
 
-#: src/muuli_wdr.cpp:962 src/muuli_wdr.cpp:997 src/muuli_wdr.cpp:2561
+#: src/muuli_wdr.cpp:962 src/muuli_wdr.cpp:997 src/muuli_wdr.cpp:2592
 msgid "Running average"
 msgstr ""
 
-#: src/muuli_wdr.cpp:970 src/muuli_wdr.cpp:1005 src/muuli_wdr.cpp:2569
+#: src/muuli_wdr.cpp:970 src/muuli_wdr.cpp:1005 src/muuli_wdr.cpp:2600
 msgid "Session average"
 msgstr ""
 
@@ -3604,7 +3609,7 @@ msgstr ""
 msgid "Connections"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1024 src/muuli_wdr.cpp:1867
+#: src/muuli_wdr.cpp:1024 src/muuli_wdr.cpp:1871
 msgid "Active downloads"
 msgstr ""
 
@@ -3612,7 +3617,7 @@ msgstr ""
 msgid "Active connections (1:1)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1040 src/muuli_wdr.cpp:1868
+#: src/muuli_wdr.cpp:1040 src/muuli_wdr.cpp:1872
 msgid "Active uploads"
 msgstr ""
 
@@ -3885,7 +3890,7 @@ msgstr ""
 msgid "Advanced users only: If you have multiple network interfaces, enter the address of the interface to which aMule should be bound."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1462 src/muuli_wdr.cpp:2061
+#: src/muuli_wdr.cpp:1462 src/muuli_wdr.cpp:2065
 msgid "Bind to network interface (empty for any):"
 msgstr ""
 
@@ -3901,7 +3906,7 @@ msgstr ""
 msgid "Max simultaneous connections:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1498 src/muuli_wdr.cpp:3176
+#: src/muuli_wdr.cpp:1498 src/muuli_wdr.cpp:3207
 msgid "ED2K"
 msgstr ""
 
@@ -3993,743 +3998,763 @@ msgstr ""
 msgid "For new files preallocates disk space for the whole file, thus reduces fragmentation"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1613
+#: src/muuli_wdr.cpp:1617
 msgid "Create new files as sparse files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1614
-msgid "A sparse file reserves its full size on disk immediately without writing real data to it -- fast, but unsupported or slow on some filesystems, and free-space accounting stays optimistic while the download is in progress. Turn this off to grow the file only as data arrives."
+#: src/muuli_wdr.cpp:1618
+msgid "Sparse part files only occupy disk space for the parts already downloaded, so free space is used up gradually as the file fills in. Turn this off to use an ordinary file instead - useful where sparse files are unsupported or slow, or where backup/de-duplication tools handle them badly. Applies only when the core runs on Windows; on Linux and macOS part files are sparse anyway and this setting has no effect."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1619
+#: src/muuli_wdr.cpp:1623
 msgid "Stop downloads when free disk space reaches "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1620
+#: src/muuli_wdr.cpp:1624
 msgid "Select this if you want aMule to check your disk space"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1624
+#: src/muuli_wdr.cpp:1628
 msgid "Enter here the min disk space desired."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1630
+#: src/muuli_wdr.cpp:1634
 msgid "Save 10 sources on rare files (< 20 sources)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1634 src/Statistics.cpp:790
+#: src/muuli_wdr.cpp:1638 src/Statistics.cpp:790
 msgid "Uploads"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1637
+#: src/muuli_wdr.cpp:1641
 msgid "Add new shared files with auto priority"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1643
+#: src/muuli_wdr.cpp:1647
 msgid "Intelligent Corruption Handling (I.C.H.)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1646
+#: src/muuli_wdr.cpp:1650
 msgid "Enable"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1649
+#: src/muuli_wdr.cpp:1653
 msgid "Advanced I.C.H. trusts every hash (not recommended)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1661 src/PrefsUnifiedDlg.cpp:1910
+#: src/muuli_wdr.cpp:1665 src/PrefsUnifiedDlg.cpp:1990
 msgid "Media metadata extraction"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1665
+#: src/muuli_wdr.cpp:1669
 msgid "Extract length / bitrate / codec from shared audio and video files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1667
+#: src/muuli_wdr.cpp:1671
 msgid "When enabled, aMule runs ffprobe on each shared media file to fill in the Length / Bitrate / Codec columns other clients see when they find the file in a search. Requires ffmpeg (the ffprobe binary) to be installed."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1674
+#: src/muuli_wdr.cpp:1678
 msgid "Path to ffprobe:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1679
+#: src/muuli_wdr.cpp:1683
 msgid "Full path to the ffprobe binary. Leave empty to have aMule auto-detect it on startup."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1687
+#: src/muuli_wdr.cpp:1691
 msgid "Detect"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1688
+#: src/muuli_wdr.cpp:1692
 msgid "Search the standard install locations for an ffprobe binary and fill the path field."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1712
+#: src/muuli_wdr.cpp:1716
 msgid ""
 "Completed downloads are stored here. All files in this folder are automatically shared with other peers.\n"
 "If this folder also holds files you don't want to share, point it at an aMule-only sub-folder."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1715
+#: src/muuli_wdr.cpp:1719
 msgid "Pick the folder where completed downloads will be stored. All files in that folder will be shared with other peers."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1729
+#: src/muuli_wdr.cpp:1733
 msgid "Shared folders"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1735
+#: src/muuli_wdr.cpp:1739
 msgid "(Folders shared by the core. Enter a path to add one.)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1743
+#: src/muuli_wdr.cpp:1747
 msgid "Absolute path of a folder on the core's machine, e.g. /home/user/shared"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1745 src/PrefsUnifiedDlg.cpp:2794
+#: src/muuli_wdr.cpp:1749 src/PrefsUnifiedDlg.cpp:2874
 msgid "Recursive"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1746
+#: src/muuli_wdr.cpp:1750
 msgid "Share every sub-folder underneath this one, including ones created later."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1750 src/utils/aLinkCreator/src/alcframe.cpp:141
+#: src/muuli_wdr.cpp:1754 src/utils/aLinkCreator/src/alcframe.cpp:141
 msgid "Remove"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1754
+#: src/muuli_wdr.cpp:1758
 msgid "(Right click on folder icon for recursive share)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1761
+#: src/muuli_wdr.cpp:1765
 msgid "Share hidden files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1767
+#: src/muuli_wdr.cpp:1771
 msgid "Automatically rescan shared folders for changes"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1773
+#: src/muuli_wdr.cpp:1777
 msgid "Follow symbolic links in shared folders"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1779
+#: src/muuli_wdr.cpp:1783
 msgid "Exclude files matching:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1782
+#: src/muuli_wdr.cpp:1786
 msgid "Wildcard patterns separated by '|', e.g. .DS_Store|Thumbs.db|*.tmp. Files whose name matches are not shared. Matching is case-insensitive."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1786
+#: src/muuli_wdr.cpp:1790
 msgid "Patterns are regular expressions"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1787
+#: src/muuli_wdr.cpp:1791
 msgid "When set, the whole field is one regular expression ('|' is alternation). When unset, it is a list of '|'-separated wildcards."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1797
+#: src/muuli_wdr.cpp:1801
 msgid "Show how many shared files the current pattern would exclude."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1818
+#: src/muuli_wdr.cpp:1822
 msgid "Graphs"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1821 src/muuli_wdr.cpp:1883
+#: src/muuli_wdr.cpp:1825 src/muuli_wdr.cpp:1887
 msgid "Update delay : 5 secs"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1825
+#: src/muuli_wdr.cpp:1829
 msgid "Time for average graph: 100 mins"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1829
+#: src/muuli_wdr.cpp:1833
 msgid "Connections Graph Scale: 100 "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1836
+#: src/muuli_wdr.cpp:1840
 msgid "Download graph scale:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1844
+#: src/muuli_wdr.cpp:1848
 msgid "Upload graph scale:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1854
+#: src/muuli_wdr.cpp:1858
 msgid "Colors: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1858
+#: src/muuli_wdr.cpp:1862
 msgid "Background"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1859
+#: src/muuli_wdr.cpp:1863
 msgid "Grid"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1860
+#: src/muuli_wdr.cpp:1864
 msgid "Download current"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1861
+#: src/muuli_wdr.cpp:1865
 msgid "Download running average"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1862
+#: src/muuli_wdr.cpp:1866
 msgid "Download session average"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1863
+#: src/muuli_wdr.cpp:1867
 msgid "Upload current"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1864
+#: src/muuli_wdr.cpp:1868
 msgid "Upload running average"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1865
+#: src/muuli_wdr.cpp:1869
 msgid "Upload session average"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1866
+#: src/muuli_wdr.cpp:1870
 msgid "Active connections"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1869
+#: src/muuli_wdr.cpp:1873
 msgid "Systray Icon Speed Bar"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1870
+#: src/muuli_wdr.cpp:1874
 msgid "Kad-nodes current"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1871
+#: src/muuli_wdr.cpp:1875
 msgid "Kad-nodes running"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1872
+#: src/muuli_wdr.cpp:1876
 msgid "Kad-nodes session"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1876 src/muuli_wdr.cpp:2303
+#: src/muuli_wdr.cpp:1880 src/muuli_wdr.cpp:2334
 msgid "Select"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1880
+#: src/muuli_wdr.cpp:1884
 msgid "Tree"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1890
+#: src/muuli_wdr.cpp:1894
 msgid "Number of Client Versions shown (0=unlimited)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1915
+#: src/muuli_wdr.cpp:1919
 msgid "!!! WARNING !!!"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1930
+#: src/muuli_wdr.cpp:1934
 msgid "Max new connections / 5 secs"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1932
+#: src/muuli_wdr.cpp:1936
 msgid "Concurrent Kad source lookups"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1934
+#: src/muuli_wdr.cpp:1938
 msgid "Kad source re-search interval (minutes)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1936
+#: src/muuli_wdr.cpp:1940
 msgid "Source re-ask interval (minutes)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1940
+#: src/muuli_wdr.cpp:1944
 msgid "File Buffer Size: 240000 bytes"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1944
+#: src/muuli_wdr.cpp:1948
 msgid "Use MMAP: memory-mapped file access (lower memory use)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1945
+#: src/muuli_wdr.cpp:1949
 msgid "Maps part files into memory instead of buffering them on the heap, lowering the process memory footprint. May reduce download speed on some disks; best for memory-constrained or upload-heavy hosts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1947
+#: src/muuli_wdr.cpp:1951
 msgid "Upload Queue Size: 5000 clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1951
+#: src/muuli_wdr.cpp:1955
 msgid "Server connection refresh interval: Disable"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1955
+#: src/muuli_wdr.cpp:1959
 msgid "Disable computer's timed standby mode"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1974
+#: src/muuli_wdr.cpp:1978
 msgid "Skin to use: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1983
+#: src/muuli_wdr.cpp:1987
 msgid "Show \"Fast eD2k Links Handler\" in every window."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1986
+#: src/muuli_wdr.cpp:1990
 msgid "Show extended info on categories tabs"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1989
+#: src/muuli_wdr.cpp:1993
 msgid "Show application version on title"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1991
+#: src/muuli_wdr.cpp:1995
 msgid "Show transfer rates on title"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1993
+#: src/muuli_wdr.cpp:1997
 msgid "Before application name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1995
+#: src/muuli_wdr.cpp:1999
 msgid "After application name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1998
+#: src/muuli_wdr.cpp:2002
 msgid "Show overhead bandwidth"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2002
+#: src/muuli_wdr.cpp:2006
 msgid "Vertical toolbar orientation"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2004
+#: src/muuli_wdr.cpp:2008
 msgid "Live column sorting (auto-reorder rows as their values change)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2011
+#: src/muuli_wdr.cpp:2015
 msgid "Download Queue Files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2014
+#: src/muuli_wdr.cpp:2018
 msgid "Show progress percentage"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2020
+#: src/muuli_wdr.cpp:2024
 msgid "Show progress bar"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2023
+#: src/muuli_wdr.cpp:2027
 msgid "Flat"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2027
+#: src/muuli_wdr.cpp:2031
 msgid "Round"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2045
+#: src/muuli_wdr.cpp:2049
 msgid "External Connection Parameters"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2048
+#: src/muuli_wdr.cpp:2052
 msgid "Accept external connections"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2055 src/muuli_wdr.cpp:2114
+#: src/muuli_wdr.cpp:2059 src/muuli_wdr.cpp:2118
 msgid "IP of the listening interface:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2058
+#: src/muuli_wdr.cpp:2062
 msgid "Enter here a valid ip in the a.b.c.d format for the listening EC interface. An empty field or 0.0.0.0 will mean any interface."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2079 src/muuli_wdr.cpp:2163
+#: src/muuli_wdr.cpp:2083 src/muuli_wdr.cpp:2194
 msgid "TCP port:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2085
+#: src/muuli_wdr.cpp:2089
 msgid "Enable UPnP port forwarding on the EC port"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2089 src/muuli_wdr.cpp:3048
+#: src/muuli_wdr.cpp:2093 src/muuli_wdr.cpp:3079
 #: src/utils/wxCas/src/wxcasprefs.cpp:167
 msgid "Password"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2095
+#: src/muuli_wdr.cpp:2099
 msgid "aMule API server parameters"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2098
+#: src/muuli_wdr.cpp:2102
 msgid "Run amuleapi (REST API) on startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2103
+#: src/muuli_wdr.cpp:2107
 msgid "HTTP port:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2117
+#: src/muuli_wdr.cpp:2121
 msgid "The interface amuleapi's HTTP server listens on. 127.0.0.1 (default) accepts only local connections; use 0.0.0.0 or a specific IP to expose it to other hosts (set an admin password below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2120
+#: src/muuli_wdr.cpp:2126
+msgid "Type a password to set or change it. Stored passwords cannot be shown, so leaving this empty keeps the current one."
+msgstr ""
+
+#: src/muuli_wdr.cpp:2128
 msgid "Admin password"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2125 src/muuli_wdr.cpp:2156
-msgid "Low rights password"
+#: src/muuli_wdr.cpp:2140 src/muuli_wdr.cpp:2157 src/PrefsUnifiedDlg.cpp:1103
+msgid "A password is set."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2133
+#: src/muuli_wdr.cpp:2144
+msgid "Enable guest access"
+msgstr ""
+
+#: src/muuli_wdr.cpp:2145
+msgid "Guest sessions may read status and listings but cannot change anything. Turning this off clears the stored guest password."
+msgstr ""
+
+#: src/muuli_wdr.cpp:2149
+msgid "Guest password"
+msgstr ""
+
+#: src/muuli_wdr.cpp:2164
 msgid "Web server parameters"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2136
+#: src/muuli_wdr.cpp:2167
 msgid "Run webserver on startup (deprecated)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2142
+#: src/muuli_wdr.cpp:2173
 msgid "Web template"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2147
+#: src/muuli_wdr.cpp:2178
 msgid "Full rights password"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2151
+#: src/muuli_wdr.cpp:2182
 msgid "Enable Low rights User"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2170
+#: src/muuli_wdr.cpp:2187
+msgid "Low rights password"
+msgstr ""
+
+#: src/muuli_wdr.cpp:2201
 msgid "Enable UPnP port forwarding of the web server port"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2175
+#: src/muuli_wdr.cpp:2206
 msgid "Web server UPnP TCP port (Optional)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2183
+#: src/muuli_wdr.cpp:2214
 msgid "Page Refresh Time (in secs)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2190
+#: src/muuli_wdr.cpp:2221
 msgid "Enable Gzip compression"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2224
+#: src/muuli_wdr.cpp:2255
 msgid "Reset page to defaults"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2225
+#: src/muuli_wdr.cpp:2256
 msgid "Reset the settings on the current page to their default values."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2227 src/muuli_wdr.cpp:2313 src/ServerWnd.cpp:274
+#: src/muuli_wdr.cpp:2258 src/muuli_wdr.cpp:2344 src/ServerWnd.cpp:274
 #: src/ServerWnd.cpp:282
 msgid "OK"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2229
+#: src/muuli_wdr.cpp:2260
 msgid "Click here to apply any changes made to the preferences."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2232
+#: src/muuli_wdr.cpp:2263
 msgid "Reset any changes made to the preferences."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2261
+#: src/muuli_wdr.cpp:2292
 msgid "Comment :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2268
+#: src/muuli_wdr.cpp:2299
 msgid "Incoming Dir :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2277
+#: src/muuli_wdr.cpp:2308
 msgid "Change priority for new assigned files :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2281
+#: src/muuli_wdr.cpp:2312
 msgid "Don't change"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2293
+#: src/muuli_wdr.cpp:2324
 msgid "Select color for this Category (currently selected) :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2360 src/muuli_wdr.cpp:2379 src/muuli_wdr.cpp:2401
+#: src/muuli_wdr.cpp:2391 src/muuli_wdr.cpp:2410 src/muuli_wdr.cpp:2432
 msgid "Click this button to reset the log."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2420
+#: src/muuli_wdr.cpp:2451
 msgid "Click on this button to update the servers list from URL ..."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2424
+#: src/muuli_wdr.cpp:2455
 msgid "Server list"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2428
+#: src/muuli_wdr.cpp:2459
 msgid "Enter the url to a server.met file here and press the button to the left to update the list of known servers."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2433
+#: src/muuli_wdr.cpp:2464
 msgid "Add server manually: Name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2436
+#: src/muuli_wdr.cpp:2467
 msgid "Enter the name of the new server here"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2438 src/ServerWnd.cpp:206
+#: src/muuli_wdr.cpp:2469 src/ServerWnd.cpp:206
 msgid "IP:Port"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2441
+#: src/muuli_wdr.cpp:2472
 msgid "Enter the IP of the server here, using the x.x.x.x format."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2447
+#: src/muuli_wdr.cpp:2478
 msgid "Enter the port of the server here."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2450
+#: src/muuli_wdr.cpp:2481
 msgid "Add manually a server (fill fields to the left before) ..."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2479
+#: src/muuli_wdr.cpp:2510
 msgid "aMule Log"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2487
+#: src/muuli_wdr.cpp:2518
 msgid "Server Info"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2491
+#: src/muuli_wdr.cpp:2522
 msgid "ED2K Info"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2495
+#: src/muuli_wdr.cpp:2526
 msgid "Kad Info"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2523
+#: src/muuli_wdr.cpp:2554
 msgid "Click on this button to update the nodes list from URL ..."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2527
+#: src/muuli_wdr.cpp:2558
 msgid "Nodes (0)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2531
+#: src/muuli_wdr.cpp:2562
 msgid "Enter the url to a nodes.dat file here and press the button to the left to update the list of known nodes."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2534
+#: src/muuli_wdr.cpp:2565
 msgid "Nodes stats"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2576
+#: src/muuli_wdr.cpp:2607
 msgid "Bootstrap"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2579
+#: src/muuli_wdr.cpp:2610
 msgid "New node"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2584
+#: src/muuli_wdr.cpp:2615
 msgid "IP:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2604
+#: src/muuli_wdr.cpp:2635
 msgid "Port:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2617
+#: src/muuli_wdr.cpp:2648
 msgid "Bootstrap from known clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2619
+#: src/muuli_wdr.cpp:2650
 msgid "Disconnect Kad"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2653
+#: src/muuli_wdr.cpp:2684
 msgid "Use Secure User Identification"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2655
+#: src/muuli_wdr.cpp:2686
 msgid "It is recommended to enable this option. You will not receive credits if SUI is not enabled."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2657
+#: src/muuli_wdr.cpp:2688
 msgid "Protocol Obfuscation"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2660
+#: src/muuli_wdr.cpp:2691
 msgid "Support Protocol Obfuscation"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2662
+#: src/muuli_wdr.cpp:2693
 msgid "This option enabled Protocol Obfuscation, and makes aMule accept obfuscated connections from other clients."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2664
+#: src/muuli_wdr.cpp:2695
 msgid "Use obfuscation for outgoing connections"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2666
+#: src/muuli_wdr.cpp:2697
 msgid "This option makes aMule use Protocol Obfuscation when connecting other clients/servers."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2668
+#: src/muuli_wdr.cpp:2699
 msgid "Accept only obfuscated connections"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2669
+#: src/muuli_wdr.cpp:2700
 msgid "This option makes aMule only accept obfuscated connections. You will have less sources, but all your traffic will be obfuscated"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2674
+#: src/muuli_wdr.cpp:2705
 msgid "Everybody"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2676
+#: src/muuli_wdr.cpp:2707
 msgid "No one"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2678
+#: src/muuli_wdr.cpp:2709
 msgid "Who can see my shared files:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2679
+#: src/muuli_wdr.cpp:2710
 msgid "Select who can request to view a list of your shared files."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2681
+#: src/muuli_wdr.cpp:2712
 msgid "IP-Filtering"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2688
+#: src/muuli_wdr.cpp:2719
 msgid "Filter clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2690
+#: src/muuli_wdr.cpp:2721
 msgid "Enable filtering of the client IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2692
+#: src/muuli_wdr.cpp:2723
 msgid "Filter servers"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2694
+#: src/muuli_wdr.cpp:2725
 msgid "Enable filtering of the server IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2698
+#: src/muuli_wdr.cpp:2729
 msgid "Reload List"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2699
+#: src/muuli_wdr.cpp:2730
 msgid "Reload the list of IPs to filter from the file ~/.aMule/ipfilter.dat"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2705
+#: src/muuli_wdr.cpp:2736
 msgid "URL:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2709 src/muuli_wdr.cpp:2902
+#: src/muuli_wdr.cpp:2740 src/muuli_wdr.cpp:2933
 msgid "Update now"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2712
+#: src/muuli_wdr.cpp:2743
 msgid "Auto-update ipfilter at startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2716
+#: src/muuli_wdr.cpp:2747
 msgid "Filtering Level:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2722
+#: src/muuli_wdr.cpp:2753
 msgid "Always filter LAN IPs"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2725
+#: src/muuli_wdr.cpp:2756
 msgid "Paranoid handling of non-matching IPs"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2727
+#: src/muuli_wdr.cpp:2758
 msgid "Rejects a packet when its source IP differs from the IP the client claims (an anti-spoofing check). Disable only if it causes connection problems."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2729
+#: src/muuli_wdr.cpp:2760
 msgid "Use system-wide ipfilter.dat if available"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2730
+#: src/muuli_wdr.cpp:2761
 msgid "If there's no local ipfilter.dat found, allow usage of a system-wide ipfilter file."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2747
+#: src/muuli_wdr.cpp:2778
 msgid "Enable Online-Signature"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2749
+#: src/muuli_wdr.cpp:2780
 msgid "Enables the writing of the OS file, which can be used by external apps to create signatures and the like."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2753
+#: src/muuli_wdr.cpp:2784
 msgid "Update Frequency (Secs):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2756
+#: src/muuli_wdr.cpp:2787
 msgid "Change the frequency (in seconds) of Online Signature updates."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2764
+#: src/muuli_wdr.cpp:2795
 msgid "Save online signature file in: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:2770
+#: src/muuli_wdr.cpp:2801
 msgid "Click here to select the directory containing the the Online Signature files."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2803
+#: src/muuli_wdr.cpp:2834
 msgid "Show country flags for clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2804
+#: src/muuli_wdr.cpp:2835
 msgid "Render the country flag column in the transfers, queue and search views. Requires a valid MMDB GeoIP database (see below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2809
+#: src/muuli_wdr.cpp:2840
 msgid "Database"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2825
+#: src/muuli_wdr.cpp:2856
 msgid "Source:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2828
+#: src/muuli_wdr.cpp:2859
 msgid "DB-IP (free, no account)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2829
+#: src/muuli_wdr.cpp:2860
 msgid "MaxMind GeoLite2 (free, account required)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2830
+#: src/muuli_wdr.cpp:2861
 msgid "Custom URL"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2833
+#: src/muuli_wdr.cpp:2864
 msgid "Choose which provider supplies the GeoIP MMDB database. DB-IP is the default - no account required. MaxMind requires a free account + license key. Use Custom URL to point at any other MMDB host (e.g. a local mirror)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2850
+#: src/muuli_wdr.cpp:2881
 msgid ""
 "No configuration required.\n"
 "\n"
@@ -4737,11 +4762,11 @@ msgid ""
 "License: Creative Commons BY 4.0 - https://creativecommons.org/licenses/by/4.0/"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2863
+#: src/muuli_wdr.cpp:2894
 msgid "License key:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2869
+#: src/muuli_wdr.cpp:2900
 msgid ""
 "Sign up for a free MaxMind account, then generate a License Key:\n"
 "https://www.maxmind.com/en/geolite2/signup\n"
@@ -4751,222 +4776,222 @@ msgid ""
 "Requires attribution and account registration; refresh at least every 30 days."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2884
+#: src/muuli_wdr.cpp:2915
 msgid "Download URL:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2890
+#: src/muuli_wdr.cpp:2921
 msgid ""
 "Must point to an .mmdb file or a .gz / .tar.gz containing one.\n"
 "URL may include credentials (https://user:pass@host/...).\n"
 "License and attribution terms are set by the upstream URL - you are responsible."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2903
+#: src/muuli_wdr.cpp:2934
 msgid "Download the GeoIP database from the selected source."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2905
+#: src/muuli_wdr.cpp:2936
 msgid "Auto-update on startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2906
+#: src/muuli_wdr.cpp:2937
 msgid "Re-download the GeoIP database from the selected source every time aMule starts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2929
+#: src/muuli_wdr.cpp:2960
 msgid "Filter incoming messages (except current chat):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2931
+#: src/muuli_wdr.cpp:2962
 msgid "Filter all messages"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2933
+#: src/muuli_wdr.cpp:2964
 msgid "Filter messages from people not on your friend list"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2935
+#: src/muuli_wdr.cpp:2966
 msgid "Filter messages from unknown clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2937
+#: src/muuli_wdr.cpp:2968
 msgid "Filter messages containing (use ',' as separator):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2940 src/muuli_wdr.cpp:2951
+#: src/muuli_wdr.cpp:2971 src/muuli_wdr.cpp:2982
 msgid "add here the words amule should filter and block messages including it"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2942
+#: src/muuli_wdr.cpp:2973
 msgid "Show received messages in the log"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2945
+#: src/muuli_wdr.cpp:2976
 msgid "Comments"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2948
+#: src/muuli_wdr.cpp:2979
 msgid "Filter comments containing (use ',' as separator):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2973
+#: src/muuli_wdr.cpp:3004
 msgid "Enable Proxy"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2974
+#: src/muuli_wdr.cpp:3005
 msgid "Enable/disable proxy support"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2977
+#: src/muuli_wdr.cpp:3008
 msgid "Proxy type:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2988
+#: src/muuli_wdr.cpp:3019
 msgid "Proxy host:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2991
+#: src/muuli_wdr.cpp:3022
 msgid "The proxy host name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2993
+#: src/muuli_wdr.cpp:3024
 msgid "Proxy port:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2996
+#: src/muuli_wdr.cpp:3027
 msgid "The proxy port"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2998
+#: src/muuli_wdr.cpp:3029
 msgid "Enable authentication"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2999
+#: src/muuli_wdr.cpp:3030
 msgid "Enable/disable username/password authentication"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3002
+#: src/muuli_wdr.cpp:3033
 msgid "Username: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:3005
+#: src/muuli_wdr.cpp:3036
 msgid "The username to use to connect to the proxy"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3007
+#: src/muuli_wdr.cpp:3038
 msgid "Password:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3010
+#: src/muuli_wdr.cpp:3041
 msgid "The password to use to connect to the proxy"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3029
+#: src/muuli_wdr.cpp:3060
 msgid "Connect to:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3038
+#: src/muuli_wdr.cpp:3069
 msgid "Login to remote amule"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3043
+#: src/muuli_wdr.cpp:3074
 msgid "User name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3054
+#: src/muuli_wdr.cpp:3085
 msgid "Remember those settings"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3057
+#: src/muuli_wdr.cpp:3088
 msgid "Force ZLIB compression"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3081
+#: src/muuli_wdr.cpp:3112
 msgid "Enable Verbose Debug-Logging."
 msgstr ""
 
-#: src/muuli_wdr.cpp:3083
+#: src/muuli_wdr.cpp:3114
 msgid "Only to Logfile"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3085
+#: src/muuli_wdr.cpp:3116
 msgid "Message Categories:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3109 src/PartFileConvertDlg.cpp:160
+#: src/muuli_wdr.cpp:3140 src/PartFileConvertDlg.cpp:160
 msgid "Waiting..."
 msgstr ""
 
-#: src/muuli_wdr.cpp:3129
+#: src/muuli_wdr.cpp:3160
 msgid "Add imports"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3132
+#: src/muuli_wdr.cpp:3163
 msgid "Retry selected"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3134
+#: src/muuli_wdr.cpp:3165
 msgid "Remove selected"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3197
+#: src/muuli_wdr.cpp:3228
 msgid "Event Types"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3216
+#: src/muuli_wdr.cpp:3247
 msgid "Statistics and queued clients for selected file(s) : Session / All time"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3240
+#: src/muuli_wdr.cpp:3271
 msgid "Active Uploads"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3254
+#: src/muuli_wdr.cpp:3285
 msgid "Percent of total files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3306
+#: src/muuli_wdr.cpp:3337
 msgid "Show Clients for"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3308
+#: src/muuli_wdr.cpp:3339
 msgid "All files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3311
+#: src/muuli_wdr.cpp:3342
 msgid "Selected files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3314
+#: src/muuli_wdr.cpp:3345
 msgid "Active uploads only"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3321
+#: src/muuli_wdr.cpp:3352
 msgid "Reload:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3325
+#: src/muuli_wdr.cpp:3356
 msgid "Reload your shared files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3388
+#: src/muuli_wdr.cpp:3419
 msgid "Send"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3389
+#: src/muuli_wdr.cpp:3420
 msgid "Sends the specified message."
 msgstr ""
 
-#: src/muuli_wdr.cpp:3393
+#: src/muuli_wdr.cpp:3424
 msgid "Close this chat-session."
 msgstr ""
 
-#: src/muuli_wdr.cpp:3416
+#: src/muuli_wdr.cpp:3447
 msgid "Connect to any server and/or Kad"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3422 src/SharedFilesCtrl.cpp:142 src/Statistics.cpp:941
+#: src/muuli_wdr.cpp:3453 src/SharedFilesCtrl.cpp:142 src/Statistics.cpp:941
 msgid "Shared Files"
 msgstr ""
 
@@ -5324,263 +5349,263 @@ msgstr ""
 msgid "ERROR: Failed to open partfile '%s'"
 msgstr ""
 
-#: src/Preferences.cpp:674
+#: src/Preferences.cpp:701
 msgid "System default"
 msgstr ""
 
-#: src/Preferences.cpp:675
+#: src/Preferences.cpp:702
 msgid "Albanian"
 msgstr ""
 
-#: src/Preferences.cpp:676
+#: src/Preferences.cpp:703
 msgid "Arabic"
 msgstr ""
 
-#: src/Preferences.cpp:677
+#: src/Preferences.cpp:704
 msgid "Asturian"
 msgstr ""
 
-#: src/Preferences.cpp:678
+#: src/Preferences.cpp:705
 msgid "Basque"
 msgstr ""
 
-#: src/Preferences.cpp:679
+#: src/Preferences.cpp:706
 msgid "Bulgarian"
 msgstr ""
 
-#: src/Preferences.cpp:680
+#: src/Preferences.cpp:707
 msgid "Catalan"
 msgstr ""
 
-#: src/Preferences.cpp:681
+#: src/Preferences.cpp:708
 msgid "Chinese (Simplified)"
 msgstr ""
 
-#: src/Preferences.cpp:682
+#: src/Preferences.cpp:709
 msgid "Chinese (Traditional)"
 msgstr ""
 
-#: src/Preferences.cpp:683
+#: src/Preferences.cpp:710
 msgid "Croatian"
 msgstr ""
 
-#: src/Preferences.cpp:684
+#: src/Preferences.cpp:711
 msgid "Czech"
 msgstr ""
 
-#: src/Preferences.cpp:685
+#: src/Preferences.cpp:712
 msgid "Danish"
 msgstr ""
 
-#: src/Preferences.cpp:686
+#: src/Preferences.cpp:713
 msgid "Dutch"
 msgstr ""
 
-#: src/Preferences.cpp:687
+#: src/Preferences.cpp:714
 msgid "English (U.K.)"
 msgstr ""
 
-#: src/Preferences.cpp:688
+#: src/Preferences.cpp:715
 msgid "English (U.S.)"
 msgstr ""
 
-#: src/Preferences.cpp:689
+#: src/Preferences.cpp:716
 msgid "Estonian"
 msgstr ""
 
-#: src/Preferences.cpp:690
+#: src/Preferences.cpp:717
 msgid "Finnish"
 msgstr ""
 
-#: src/Preferences.cpp:691
+#: src/Preferences.cpp:718
 msgid "French"
 msgstr ""
 
-#: src/Preferences.cpp:692
+#: src/Preferences.cpp:719
 msgid "Galician"
 msgstr ""
 
-#: src/Preferences.cpp:693
+#: src/Preferences.cpp:720
 msgid "German"
 msgstr ""
 
-#: src/Preferences.cpp:694
+#: src/Preferences.cpp:721
 msgid "Greek"
 msgstr ""
 
-#: src/Preferences.cpp:695
+#: src/Preferences.cpp:722
 msgid "Hebrew"
 msgstr ""
 
-#: src/Preferences.cpp:696
+#: src/Preferences.cpp:723
 msgid "Hungarian"
 msgstr ""
 
-#: src/Preferences.cpp:697
+#: src/Preferences.cpp:724
 msgid "Italian"
 msgstr ""
 
-#: src/Preferences.cpp:698
+#: src/Preferences.cpp:725
 msgid "Japanese"
 msgstr ""
 
-#: src/Preferences.cpp:699
+#: src/Preferences.cpp:726
 msgid "Korean"
 msgstr ""
 
-#: src/Preferences.cpp:700
+#: src/Preferences.cpp:727
 msgid "Latvian"
 msgstr ""
 
-#: src/Preferences.cpp:701
+#: src/Preferences.cpp:728
 msgid "Lithuanian"
 msgstr ""
 
-#: src/Preferences.cpp:702
+#: src/Preferences.cpp:729
 msgid "Norwegian (Nynorsk)"
 msgstr ""
 
-#: src/Preferences.cpp:703
+#: src/Preferences.cpp:730
 msgid "Polish"
 msgstr ""
 
-#: src/Preferences.cpp:704
+#: src/Preferences.cpp:731
 msgid "Portuguese"
 msgstr ""
 
-#: src/Preferences.cpp:705
+#: src/Preferences.cpp:732
 msgid "Portuguese (Brazilian)"
 msgstr ""
 
-#: src/Preferences.cpp:706
+#: src/Preferences.cpp:733
 msgid "Romanian"
 msgstr ""
 
-#: src/Preferences.cpp:707
+#: src/Preferences.cpp:734
 msgid "Russian"
 msgstr ""
 
-#: src/Preferences.cpp:708
+#: src/Preferences.cpp:735
 msgid "Slovenian"
 msgstr ""
 
-#: src/Preferences.cpp:709
+#: src/Preferences.cpp:736
 msgid "Spanish"
 msgstr ""
 
-#: src/Preferences.cpp:710
+#: src/Preferences.cpp:737
 msgid "Swedish"
 msgstr ""
 
-#: src/Preferences.cpp:711
+#: src/Preferences.cpp:738
 msgid "Turkish"
 msgstr ""
 
-#: src/Preferences.cpp:712
+#: src/Preferences.cpp:739
 msgid "Ukrainian"
 msgstr ""
 
-#: src/Preferences.cpp:815
+#: src/Preferences.cpp:842
 msgid "Change Language"
 msgstr ""
 
-#: src/Preferences.cpp:879
+#: src/Preferences.cpp:906
 msgid "There are no translations installed for aMule"
 msgstr ""
 
-#: src/Preferences.cpp:880
+#: src/Preferences.cpp:907
 msgid "No languages available"
 msgstr ""
 
-#: src/Preferences.cpp:1011
+#: src/Preferences.cpp:1038
 msgid "no options available"
 msgstr ""
 
-#: src/Preferences.cpp:2182
+#: src/Preferences.cpp:2227
 msgid "Invalid category found, skipping"
 msgstr ""
 
-#: src/Preferences.cpp:2351
+#: src/Preferences.cpp:2396
 msgid "TCP port can't be higher than 65532 due to server UDP socket being TCP+3"
 msgstr ""
 
-#: src/Preferences.cpp:2352
+#: src/Preferences.cpp:2397
 #, c-format
 msgid "Default port will be used (%d)"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:298 src/Statistics.cpp:866
+#: src/PrefsUnifiedDlg.cpp:300 src/Statistics.cpp:866
 msgid "Connection"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:299 src/SearchListCtrl.cpp:117
+#: src/PrefsUnifiedDlg.cpp:301 src/SearchListCtrl.cpp:117
 msgid "Directories"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:300 src/Statistics.cpp:917
+#: src/PrefsUnifiedDlg.cpp:302 src/Statistics.cpp:917
 msgid "Servers"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:301 src/ServerListCtrl.cpp:96
+#: src/PrefsUnifiedDlg.cpp:303 src/ServerListCtrl.cpp:96
 msgid "Files"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:302
+#: src/PrefsUnifiedDlg.cpp:304
 msgid "Security"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:303
+#: src/PrefsUnifiedDlg.cpp:305
 msgid "Interface"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:310
+#: src/PrefsUnifiedDlg.cpp:312
 msgid "IP2Country"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:313
+#: src/PrefsUnifiedDlg.cpp:315
 msgid "Proxy"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:314
+#: src/PrefsUnifiedDlg.cpp:316
 msgid "Filters"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:315
+#: src/PrefsUnifiedDlg.cpp:317
 msgid "Remote Controls"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:316
+#: src/PrefsUnifiedDlg.cpp:318
 msgid "Online Signature"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:317
+#: src/PrefsUnifiedDlg.cpp:319
 msgid "Advanced"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:318
+#: src/PrefsUnifiedDlg.cpp:320
 msgid "Events"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:321
+#: src/PrefsUnifiedDlg.cpp:323
 msgid "Debugging"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:451
+#: src/PrefsUnifiedDlg.cpp:453
 msgid ""
 "The following variables will be substituted:\n"
 "    %PARTFILE - full path to the file\n"
 "    %PARTNAME - file name only"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:472
+#: src/PrefsUnifiedDlg.cpp:474
 msgid "Tray icon support requires libayatana-appindicator3 at compile time."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:488
+#: src/PrefsUnifiedDlg.cpp:490
 msgid "Not available on Wayland: the protocol does not report when a window is minimized, so this option cannot intercept the system minimize button. Workaround: launch aMule with `GDK_BACKEND=x11` to use XWayland instead."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:534
+#: src/PrefsUnifiedDlg.cpp:536
 msgid ""
 "Do not change these setting unless you know\n"
 "what you are doing, otherwise you can easily\n"
@@ -5590,387 +5615,400 @@ msgid ""
 "these settings."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:645
+#: src/PrefsUnifiedDlg.cpp:647
 #, c-format
 msgid "Failed to connect Cfg to widget with the ID %d and key %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:693
+#: src/PrefsUnifiedDlg.cpp:695
 #, c-format
 msgid "Failed to transfer data from Cfg to Widget with the ID %d and key %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:799
+#: src/PrefsUnifiedDlg.cpp:801
 msgid "The type of proxy you are connecting to"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1003
+#: src/PrefsUnifiedDlg.cpp:1020
 #, c-format
 msgid "Failed to transfer data from Widget to Cfg with the ID %d and key %s"
 msgstr ""
 
 #: src/PrefsUnifiedDlg.cpp:1103
+msgid "No password set."
+msgstr ""
+
+#: src/PrefsUnifiedDlg.cpp:1132
+msgid "Guest access needs a password. Type one in the guest password field, or untick Enable guest access."
+msgstr ""
+
+#: src/PrefsUnifiedDlg.cpp:1144
 msgid ""
 "aMule must be restarted to enable these changes:\n"
 "\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1110
+#: src/PrefsUnifiedDlg.cpp:1151
 msgid "- TCP port changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1115
+#: src/PrefsUnifiedDlg.cpp:1156
 msgid "- UDP port changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1120
+#: src/PrefsUnifiedDlg.cpp:1161
 msgid "- Network interface binding changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1125
+#: src/PrefsUnifiedDlg.cpp:1166
 msgid "- External connect port changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1129
+#: src/PrefsUnifiedDlg.cpp:1170
 msgid "- External connect acceptance changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1133
+#: src/PrefsUnifiedDlg.cpp:1174
 msgid "- External connect interface changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1137
+#: src/PrefsUnifiedDlg.cpp:1178
 msgid "- Protocol obfuscation support changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1151
+#: src/PrefsUnifiedDlg.cpp:1193
 msgid "- amuleapi settings changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1160
+#: src/PrefsUnifiedDlg.cpp:1202
 msgid ""
 "Your Auto-update server list is empty.\n"
 "'Auto-update server list at startup' will be disabled."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1171
+#: src/PrefsUnifiedDlg.cpp:1213
 msgid ""
 "You have enabled external connections but have not specified a password.\n"
 "External connections cannot be enabled unless a valid password is specified."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1202
+#: src/PrefsUnifiedDlg.cpp:1246
+#, c-format
+msgid "The amuleapi password could not be saved: %s"
+msgstr ""
+
+#: src/PrefsUnifiedDlg.cpp:1276
 msgid "- Language changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1207
+#: src/PrefsUnifiedDlg.cpp:1281
 msgid "- Temp folder changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1212
+#: src/PrefsUnifiedDlg.cpp:1286
 msgid "- ED2K network enabled.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1245
+#: src/PrefsUnifiedDlg.cpp:1319
 msgid "The shared-file exclusion pattern is not a valid regular expression. The filter has been left disabled."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1247 src/PrefsUnifiedDlg.cpp:1841
+#: src/PrefsUnifiedDlg.cpp:1321 src/PrefsUnifiedDlg.cpp:1921
 msgid "Invalid regular expression"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1324
+#: src/PrefsUnifiedDlg.cpp:1398
 msgid ""
 "Both eD2k and Kad network are disabled.\n"
 "You won't be able to connect until you enable at least one of them."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1329
+#: src/PrefsUnifiedDlg.cpp:1403
 msgid ""
 "Kad will not start if your UDP port is disabled.\n"
 "Enable UDP port or disable Kad."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1385
+#: src/PrefsUnifiedDlg.cpp:1459
 msgid ""
 "\n"
 "You MUST restart aMule now.\n"
 "If you do not restart now, don't complain if anything bad happens.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1450
+#: src/PrefsUnifiedDlg.cpp:1524
 msgid "Could not register aMule for autostart at login. The autostart store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1452
+#: src/PrefsUnifiedDlg.cpp:1526
 msgid "Could not remove the autostart-at-login entry."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1453
+#: src/PrefsUnifiedDlg.cpp:1527
 msgid "Autostart"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1468
+#: src/PrefsUnifiedDlg.cpp:1542
 msgid "Register file type"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1468
+#: src/PrefsUnifiedDlg.cpp:1542
 msgid "Register URL handler"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1476
+#: src/PrefsUnifiedDlg.cpp:1550
 #, c-format
 msgid "aMule only handles eD2k-compatible magnets. If you replace the current magnet handler (%s), BitTorrent magnet links will stop working - aMule cannot download BitTorrent content. Continue?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1481
+#: src/PrefsUnifiedDlg.cpp:1555
 #, c-format
 msgid "Another application currently opens .emulecollection files (%s). Replace it with aMule?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1486
+#: src/PrefsUnifiedDlg.cpp:1560
 #, c-format
 msgid "Another application is currently the default handler for these links (%s). Replace it with aMule?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1511
+#: src/PrefsUnifiedDlg.cpp:1585
 msgid "Could not register aMule for .emulecollection files. The registration store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1513
+#: src/PrefsUnifiedDlg.cpp:1587
 msgid "Could not remove the file type registration."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1515
+#: src/PrefsUnifiedDlg.cpp:1589
 msgid "Could not register aMule as the URL handler. The registration store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1517
+#: src/PrefsUnifiedDlg.cpp:1591
 msgid "Could not remove the URL handler registration."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1587 src/PrefsUnifiedDlg.cpp:1614
+#: src/PrefsUnifiedDlg.cpp:1661 src/PrefsUnifiedDlg.cpp:1688
 msgid "The web server and aMule API require external connections to be enabled."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1597
+#: src/PrefsUnifiedDlg.cpp:1671
 msgid "The aMule web server is deprecated. Consider running the aMule API instead."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1655
+#: src/PrefsUnifiedDlg.cpp:1735
 msgid ""
 "Your Auto-update servers list is in blank.\n"
 "Please fill in at least one URL to point to a valid server.met file.\n"
 "Click on the button \"List\" by this checkbox to enter an URL."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1796
+#: src/PrefsUnifiedDlg.cpp:1876
 msgid "Temporary files"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1801
+#: src/PrefsUnifiedDlg.cpp:1881
 msgid "Incoming files"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1806
+#: src/PrefsUnifiedDlg.cpp:1886
 msgid "Online Signatures"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1819
+#: src/PrefsUnifiedDlg.cpp:1899
 #, c-format
 msgid "Choose a folder for %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1843
+#: src/PrefsUnifiedDlg.cpp:1923
 #, c-format
 msgid "Would exclude %u of %u shared file"
 msgid_plural "Would exclude %u of %u shared files"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/PrefsUnifiedDlg.cpp:1860
+#: src/PrefsUnifiedDlg.cpp:1940
 msgid "Browse for videoplayer"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1864
+#: src/PrefsUnifiedDlg.cpp:1944
 msgid "Select browser"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1868
+#: src/PrefsUnifiedDlg.cpp:1948
 msgid "Select ffprobe binary"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1874
+#: src/PrefsUnifiedDlg.cpp:1954
 #, c-format
 msgid "Executable%s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1908
+#: src/PrefsUnifiedDlg.cpp:1988
 msgid "ffprobe not found on PATH or in the standard install locations. Install ffmpeg (which ships ffprobe) or use Browse to pick a binary manually."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1920
+#: src/PrefsUnifiedDlg.cpp:2000
 msgid "Reset the settings on this page to their default values?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1921
+#: src/PrefsUnifiedDlg.cpp:2001
 msgid "Reset to defaults"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1948
+#: src/PrefsUnifiedDlg.cpp:2028
 msgid "Edit server list"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1949
+#: src/PrefsUnifiedDlg.cpp:2029
 msgid ""
 "Add here URL's to download server.met files.\n"
 "Only one url on each line."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2004
+#: src/PrefsUnifiedDlg.cpp:2084
 msgid "IP2Country update failed"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2149 src/PrefsUnifiedDlg.cpp:2180
+#: src/PrefsUnifiedDlg.cpp:2229 src/PrefsUnifiedDlg.cpp:2260
 msgid "Data by MaxMind GeoLite2"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2151 src/PrefsUnifiedDlg.cpp:2182
+#: src/PrefsUnifiedDlg.cpp:2231 src/PrefsUnifiedDlg.cpp:2262
 msgid "Custom source"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2153 src/PrefsUnifiedDlg.cpp:2184
+#: src/PrefsUnifiedDlg.cpp:2233 src/PrefsUnifiedDlg.cpp:2264
 msgid "Data by DB-IP.com"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2204
+#: src/PrefsUnifiedDlg.cpp:2284
 #, c-format
 msgid "Status: Loaded%s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2206
+#: src/PrefsUnifiedDlg.cpp:2286
 #, c-format
 msgid "Status: Loaded%s - %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2210
+#: src/PrefsUnifiedDlg.cpp:2290
 msgid "Status: Failed to load - click 'Update now' to refresh."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2212
+#: src/PrefsUnifiedDlg.cpp:2292
 msgid "Status: Not found - click 'Update now' to download."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2270 src/PrefsUnifiedDlg.cpp:2294
+#: src/PrefsUnifiedDlg.cpp:2350 src/PrefsUnifiedDlg.cpp:2374
 #, c-format
 msgid "Update delay: %d second"
 msgid_plural "Update delay: %d seconds"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/PrefsUnifiedDlg.cpp:2278
+#: src/PrefsUnifiedDlg.cpp:2358
 #, c-format
 msgid "Time for average graph: %d minute"
 msgid_plural "Time for average graph: %d minutes"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/PrefsUnifiedDlg.cpp:2287
+#: src/PrefsUnifiedDlg.cpp:2367
 #, c-format
 msgid "Connections Graph Scale: %d"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2302
+#: src/PrefsUnifiedDlg.cpp:2382
 #, c-format
 msgid "File Buffer Size: %d byte"
 msgid_plural "File Buffer Size: %d bytes"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/PrefsUnifiedDlg.cpp:2312
+#: src/PrefsUnifiedDlg.cpp:2392
 #, c-format
 msgid "Upload Queue Size: %d client"
 msgid_plural "Upload Queue Size: %d clients"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/PrefsUnifiedDlg.cpp:2322
+#: src/PrefsUnifiedDlg.cpp:2402
 #, c-format
 msgid "Server connection refresh interval: %d minute"
 msgid_plural "Server connection refresh interval: %d minutes"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/PrefsUnifiedDlg.cpp:2327
+#: src/PrefsUnifiedDlg.cpp:2407
 msgid "Server connection refresh interval: Disabled"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2371
+#: src/PrefsUnifiedDlg.cpp:2451
 msgid "disabled"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2397
+#: src/PrefsUnifiedDlg.cpp:2477
 #, c-format
 msgid "Execute command on '%s' event"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2404
+#: src/PrefsUnifiedDlg.cpp:2484
 msgid "Enable command execution on core"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2416
+#: src/PrefsUnifiedDlg.cpp:2496
 msgid "Core command:"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2432
+#: src/PrefsUnifiedDlg.cpp:2512
 msgid "Enable command execution on GUI"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2444
+#: src/PrefsUnifiedDlg.cpp:2524
 msgid "GUI command:"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2460
+#: src/PrefsUnifiedDlg.cpp:2540
 msgid "The following variables will be replaced:"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2628
+#: src/PrefsUnifiedDlg.cpp:2708
 msgid ""
 "The following folders look like system or sensitive locations:\n"
 "\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2633
+#: src/PrefsUnifiedDlg.cpp:2713
 msgid "Sharing them recursively will publish every file underneath on the eD2k/Kad networks. Do you really want to do this?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2636
+#: src/PrefsUnifiedDlg.cpp:2716
 msgid "Confirm shared folders"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2664
+#: src/PrefsUnifiedDlg.cpp:2744
 msgid "Reloading shared files..."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2665
+#: src/PrefsUnifiedDlg.cpp:2745
 msgid "Scanning for subdirectories..."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2666
+#: src/PrefsUnifiedDlg.cpp:2746
 msgid "Updating shared folders"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2693
+#: src/PrefsUnifiedDlg.cpp:2773
 #, c-format
 msgid "Scanned %u directories..."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2743
+#: src/PrefsUnifiedDlg.cpp:2823
 #, c-format
 msgid "Reloading shared files: %u files scanned"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2793
+#: src/PrefsUnifiedDlg.cpp:2873
 msgid "Shared folder"
 msgstr ""
 

--- a/po/en_GB.po
+++ b/po/en_GB.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-28 12:12+0200\n"
+"POT-Creation-Date: 2026-07-28 08:06+0200\n"
 "PO-Revision-Date: 2020-03-04 14:43+0100\n"
 "Last-Translator: Dévai Tamás <devait@vnet.hu>\n"
 "Language-Team: aMule Team <https://github.com/amule-org/amule>\n"
@@ -132,7 +132,7 @@ msgstr ""
 msgid "Not now"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:422 src/amuleDlg.cpp:665
+#: src/AppImageIntegration.cpp:422 src/amuleDlg.cpp:600
 msgid "Don't ask again"
 msgstr ""
 
@@ -189,152 +189,152 @@ msgstr ""
 msgid "WARNING: You can't add yourself as a source for an eD2k link while having a lowid."
 msgstr ""
 
-#: src/amule.cpp:301
+#: src/amule.cpp:300
 msgid "Now, exiting main app..."
 msgstr ""
 
-#: src/amule.cpp:331
+#: src/amule.cpp:330
 #, c-format
 msgid "Terminating amuleweb instance with pid '%d' ... "
 msgstr ""
 
-#: src/amule.cpp:335
+#: src/amule.cpp:334
 #, c-format
 msgid "Killing amuleweb instance with pid '%d' ... "
 msgstr ""
 
-#: src/amule.cpp:337 src/amule.cpp:350 src/ClientRef.cpp:180
-#: src/SearchDlg.cpp:1041 src/ServerListCtrl.cpp:98
+#: src/amule.cpp:336 src/amule.cpp:349 src/ClientRef.cpp:180
+#: src/SearchDlg.cpp:880 src/ServerListCtrl.cpp:98
 msgid "Failed"
 msgstr ""
 
-#: src/amule.cpp:344
+#: src/amule.cpp:343
 #, c-format
 msgid "Terminating amuleapi instance with pid '%d' ... "
 msgstr ""
 
-#: src/amule.cpp:348
+#: src/amule.cpp:347
 #, c-format
 msgid "Killing amuleapi instance with pid '%d' ... "
 msgstr ""
 
-#: src/amule.cpp:356
+#: src/amule.cpp:355
 msgid "aMule OnExit: Terminating core."
 msgstr ""
 
-#: src/amule.cpp:467
+#: src/amule.cpp:466
 msgid "aMule shutdown completed."
 msgstr ""
 
-#: src/amule.cpp:471
+#: src/amule.cpp:470
 msgid "Memory debug results for aMule exit:"
 msgstr ""
 
-#: src/amule.cpp:652
+#: src/amule.cpp:651
 #, c-format
 msgid "Binding aMule's peer-to-peer traffic to interface: %s (HTTP updates use the default route)"
 msgstr ""
 
-#: src/amule.cpp:656
+#: src/amule.cpp:655
 #, c-format
 msgid "Binding all network traffic to interface: %s"
 msgstr ""
 
-#: src/amule.cpp:660
+#: src/amule.cpp:659
 #, c-format
 msgid "WARNING: configured network interface '%s' was not found - traffic is NOT bound to it and may leave via the default route. Check the interface name in Preferences."
 msgstr ""
 
-#: src/amule.cpp:666
+#: src/amule.cpp:665
 #, c-format
 msgid "WARNING: binding to network interface '%s' requires elevated privileges and was NOT applied - traffic may leave via the default route. Grant the capability (e.g. 'sudo setcap cap_net_raw+ep' on the aMule binary) or run with sufficient privileges."
 msgstr ""
 
-#: src/amule.cpp:674
+#: src/amule.cpp:673
 #, c-format
 msgid "WARNING: could not bind to network interface '%s' - traffic may leave via the default route."
 msgstr ""
 
-#: src/amule.cpp:733
+#: src/amule.cpp:732
 msgid "Your locale has been changed to System Default due to a configuration change. Sorry."
 msgstr ""
 
-#: src/amule.cpp:735 src/amule.cpp:1589 src/CatDialog.cpp:128
+#: src/amule.cpp:734 src/amule.cpp:1581 src/CatDialog.cpp:128
 #: src/CatDialog.cpp:136 src/CatDialog.cpp:149 src/ServerList.cpp:366
 #: src/ServerListCtrl.cpp:152
 msgid "Info"
 msgstr ""
 
-#: src/amule.cpp:742
+#: src/amule.cpp:741
 msgid ""
 "\n"
 "EC configuration"
 msgstr ""
 
-#: src/amule.cpp:745
+#: src/amule.cpp:744
 msgid "Password set and external connections enabled."
 msgstr ""
 
-#: src/amule.cpp:755 src/KadDlg.cpp:176 src/KadDlg.cpp:185
-#: src/PrefsUnifiedDlg.cpp:1461 src/SharedFilesCtrl.cpp:476
+#: src/amule.cpp:754 src/KadDlg.cpp:176 src/KadDlg.cpp:185
+#: src/PrefsUnifiedDlg.cpp:1387 src/SharedFilesCtrl.cpp:476
 msgid "WARNING"
 msgstr ""
 
-#: src/amule.cpp:992
+#: src/amule.cpp:991
 msgid "Network bootstrap"
 msgstr ""
 
-#: src/amule.cpp:997
+#: src/amule.cpp:996
 msgid ""
 "aMule has detected missing network bootstrap files.\n"
 "Select which ones to download:"
 msgstr ""
 
-#: src/amule.cpp:1006 src/FirstRunWizard.cpp:411
+#: src/amule.cpp:1005 src/FirstRunWizard.cpp:411
 msgid "eD2k server list (server.met)"
 msgstr ""
 
-#: src/amule.cpp:1013 src/FirstRunWizard.cpp:416
+#: src/amule.cpp:1012 src/FirstRunWizard.cpp:416
 msgid "Kad bootstrap nodes (nodes.dat)"
 msgstr ""
 
-#: src/amule.cpp:1103
+#: src/amule.cpp:1102
 #, c-format
 msgid "web server running on pid %d"
 msgstr ""
 
-#: src/amule.cpp:1116
+#: src/amule.cpp:1115
 msgid "You requested to run web server on startup, but the amuleweb binary cannot be run. Please install the package containing aMule web server, or build aMule from source with -DBUILD_WEBSERVER=YES and install it."
 msgstr ""
 
-#: src/amule.cpp:1121 src/amule.cpp:1185 src/amule.cpp:1299 src/amule.cpp:1601
+#: src/amule.cpp:1120 src/amule.cpp:1177 src/amule.cpp:1291 src/amule.cpp:1593
 #: src/amule-remote-gui.cpp:603 src/amule-remote-gui.cpp:671
 #: src/amule-remote-gui.cpp:709 src/amule-remote-gui.cpp:1282
 #: src/amule-remote-gui.cpp:1345 src/amule-remote-gui.cpp:1372
-#: src/DownloadQueue.cpp:1481 src/PrefsUnifiedDlg.cpp:1247
+#: src/DownloadQueue.cpp:1481
 msgid "ERROR"
 msgstr ""
 
-#: src/amule.cpp:1174
+#: src/amule.cpp:1166
 #, c-format
 msgid "amuleapi running on pid %d"
 msgstr ""
 
-#: src/amule.cpp:1180
+#: src/amule.cpp:1172
 msgid "You requested to run amuleapi on startup, but the amuleapi binary cannot be run. Please install the package containing aMule's REST API server, or build aMule from source with -DBUILD_AMULEAPI=YES and install it."
 msgstr ""
 
-#: src/amule.cpp:1267
+#: src/amule.cpp:1259
 #, c-format
 msgid "Could not bind ports to the specified address: %s"
 msgstr ""
 
-#: src/amule.cpp:1291
+#: src/amule.cpp:1283
 #, c-format
 msgid "Port %u is not available. You will be LOWID\n"
 msgstr ""
 
-#: src/amule.cpp:1296
+#: src/amule.cpp:1288
 #, c-format
 msgid ""
 "Port %u is not available!\n"
@@ -344,184 +344,184 @@ msgid ""
 "Check your network to make sure the port is open for output and input."
 msgstr ""
 
-#: src/amule.cpp:1393
+#: src/amule.cpp:1385
 msgid "Failed to create OnlineSig File"
 msgstr ""
 
-#: src/amule.cpp:1401
+#: src/amule.cpp:1393
 msgid "Failed to create aMule OnlineSig File"
 msgstr ""
 
-#: src/amule.cpp:1564
+#: src/amule.cpp:1556
 msgid "The selected locale seems not to be installed on your box. (Note: I'll try to set it anyway)"
 msgstr ""
 
-#: src/amule.cpp:1574
+#: src/amule.cpp:1566
 #, c-format
 msgid "This is the first time you run aMule %s"
 msgstr ""
 
-#: src/amule.cpp:1577
+#: src/amule.cpp:1569
 msgid "This version is a testing version, updated daily, and\n"
 msgstr ""
 
-#: src/amule.cpp:1578
+#: src/amule.cpp:1570
 msgid "we give no warranty it won't break anything, burn your house,\n"
 msgstr ""
 
-#: src/amule.cpp:1579
+#: src/amule.cpp:1571
 msgid "or kill your dog. But it *should* be safe to use anyway.\n"
 msgstr ""
 
-#: src/amule.cpp:1584
+#: src/amule.cpp:1576
 msgid "More information, support and new releases can found at our homepage,\n"
 msgstr ""
 
-#: src/amule.cpp:1585
+#: src/amule.cpp:1577
 msgid "at https://amule-org.github.io, or in our IRC channel #aMule at irc.libera.chat.\n"
 msgstr ""
 
-#: src/amule.cpp:1587
+#: src/amule.cpp:1579
 msgid "Feel free to report any bugs to https://github.com/amule-org/amule/issues"
 msgstr ""
 
-#: src/amule.cpp:1599
+#: src/amule.cpp:1591
 msgid ""
 "The folder for Online Signature files you specified is INVALID!\n"
 " OnlineSignature will be DISABLED until you fix it on preferences."
 msgstr ""
 
-#: src/amule.cpp:1662
+#: src/amule.cpp:1654
 msgid "Server hostname notified"
 msgstr ""
 
-#: src/amule.cpp:2039
+#: src/amule.cpp:2031
 #, c-format
 msgid "Disk space preallocation for file '%s' failed: %s"
 msgstr ""
 
-#: src/amule.cpp:2168
+#: src/amule.cpp:2160
 msgid "ERROR: can't open logfile"
 msgstr ""
 
-#: src/amule.cpp:2172
+#: src/amule.cpp:2164
 msgid "WARNING: logfile is empty. Something is wrong."
 msgstr ""
 
-#: src/amule.cpp:2189
+#: src/amule.cpp:2181
 msgid "Log has been reset"
 msgstr ""
 
-#: src/amule.cpp:2213
+#: src/amule.cpp:2205
 #, c-format
 msgid "ServerMessage: %s"
 msgstr ""
 
-#: src/amule.cpp:2256 src/IP2Country.cpp:220 src/IPFilter.cpp:514
+#: src/amule.cpp:2248 src/IP2Country.cpp:220 src/IPFilter.cpp:514
 #: src/ServerList.cpp:875
 #, c-format
 msgid "Skipped download of %s, because requested file is not newer."
 msgstr ""
 
-#: src/amule.cpp:2259
+#: src/amule.cpp:2251
 msgid "Failed to download the nodes list."
 msgstr ""
 
-#: src/amule.cpp:2322
+#: src/amule.cpp:2314
 msgid "Failed to open the downloaded version check file"
 msgstr ""
 
-#: src/amule.cpp:2325 src/amule.cpp:2344
+#: src/amule.cpp:2317 src/amule.cpp:2336
 msgid "Corrupted version check file"
 msgstr ""
 
-#: src/amule.cpp:2367
+#: src/amule.cpp:2359
 msgid "You are using an outdated version of aMule!"
 msgstr ""
 
-#: src/amule.cpp:2369
+#: src/amule.cpp:2361
 #, c-format
 msgid "Your aMule version is %i.%i.%i and the latest version is %li.%li.%li"
 msgstr ""
 
-#: src/amule.cpp:2373
+#: src/amule.cpp:2365
 msgid "The latest version can always be found at https://github.com/amule-org/amule/releases/latest"
 msgstr ""
 
-#: src/amule.cpp:2376
+#: src/amule.cpp:2368
 #, c-format
 msgid "WARNING: Your aMuled version is outdated: %i.%i.%i < %li.%li.%li"
 msgstr ""
 
-#: src/amule.cpp:2382
+#: src/amule.cpp:2374
 msgid "Your copy of aMule is up to date."
 msgstr ""
 
-#: src/amule.cpp:2389
+#: src/amule.cpp:2381
 msgid "Failed to download the version check file"
 msgstr ""
 
-#: src/amule.cpp:2558 src/amule-remote-gui.cpp:1133
+#: src/amule.cpp:2550 src/amule-remote-gui.cpp:1133
 #, c-format
 msgid "Users: %s | Files: %s"
 msgstr ""
 
-#: src/amule.cpp:2559 src/amule-remote-gui.cpp:1134
+#: src/amule.cpp:2551 src/amule-remote-gui.cpp:1134
 #, c-format
 msgid "Users: E: %s K: %s | Files: E: %s K: %s"
 msgstr ""
 
-#: src/amule.cpp:2573 src/amule-remote-gui.cpp:1147
+#: src/amule.cpp:2565 src/amule-remote-gui.cpp:1147
 msgid "No networks selected"
 msgstr ""
 
-#: src/amule.cpp:2641 src/TextClient.cpp:903
+#: src/amule.cpp:2633 src/TextClient.cpp:903
 msgid "with LowID"
 msgstr ""
 
-#: src/amule.cpp:2641 src/TextClient.cpp:904
+#: src/amule.cpp:2633 src/TextClient.cpp:904
 msgid "with HighID"
 msgstr ""
 
-#: src/amule.cpp:2643
+#: src/amule.cpp:2635
 #, c-format
 msgid "Connected to %s %s"
 msgstr ""
 
-#: src/amule.cpp:2648
+#: src/amule.cpp:2640
 #, c-format
 msgid "Connecting to %s"
 msgstr ""
 
-#: src/amule.cpp:2650
+#: src/amule.cpp:2642
 msgid "Disconnected from eD2k"
 msgstr ""
 
-#: src/amule.cpp:2659
+#: src/amule.cpp:2651
 msgid "Kad started."
 msgstr ""
 
-#: src/amule.cpp:2661
+#: src/amule.cpp:2653
 msgid "Kad stopped."
 msgstr ""
 
-#: src/amule.cpp:2669
+#: src/amule.cpp:2661
 msgid "Connected to Kad (ok)"
 msgstr ""
 
-#: src/amule.cpp:2671
+#: src/amule.cpp:2663
 msgid "Connected to Kad (firewalled)"
 msgstr ""
 
-#: src/amule.cpp:2675
+#: src/amule.cpp:2667
 msgid "Disconnected from Kad"
 msgstr ""
 
-#: src/amule.cpp:2707
+#: src/amule.cpp:2699
 msgid "Kad network cannot be used if UDP port is disabled on preferences, not starting."
 msgstr ""
 
-#: src/amule.cpp:2711
+#: src/amule.cpp:2703
 msgid "Kad network disabled on preferences, not connecting."
 msgstr ""
 
@@ -546,67 +546,29 @@ msgstr ""
 msgid "ERROR: %s"
 msgstr ""
 
-#: src/amuleDlg.cpp:250
+#: src/amuleDlg.cpp:236
 #, c-format
 msgid "This is aMule %s based on eMule."
 msgstr ""
 
-#: src/amuleDlg.cpp:251
+#: src/amuleDlg.cpp:237
 #, c-format
 msgid "Running on %s"
 msgstr ""
 
-#: src/amuleDlg.cpp:253
+#: src/amuleDlg.cpp:239
 msgid "Visit https://github.com/amule-org/amule/releases/latest to check if a new version is available."
 msgstr ""
 
-#: src/amuleDlg.cpp:282
+#: src/amuleDlg.cpp:268
 msgid "FATAL ERROR: Failed to create Timer"
 msgstr ""
 
-#: src/amuleDlg.cpp:361 src/amuleDlg.cpp:1810 src/amuleDlg.cpp:2056
-#: src/muuli_wdr.cpp:1492 src/muuli_wdr.cpp:3439
-msgid "Networks"
-msgstr ""
-
-#: src/amuleDlg.cpp:362 src/amuleDlg.cpp:1816 src/muuli_wdr.cpp:3440
-msgid "Searches"
-msgstr ""
-
-#: src/amuleDlg.cpp:363 src/amuleDlg.cpp:1822 src/DownloadListCtrl.cpp:740
-#: src/muuli_wdr.cpp:392 src/muuli_wdr.cpp:1585 src/muuli_wdr.cpp:3441
-#: src/Statistics.cpp:829
-msgid "Downloads"
-msgstr ""
-
-#: src/amuleDlg.cpp:364 src/amuleDlg.cpp:1828 src/muuli_wdr.cpp:3315
-msgid "Shared files"
-msgstr ""
-
-#: src/amuleDlg.cpp:365 src/amuleDlg.cpp:1834 src/muuli_wdr.cpp:2947
-#: src/muuli_wdr.cpp:3397 src/muuli_wdr.cpp:3444
-msgid "Messages"
-msgstr ""
-
-#: src/amuleDlg.cpp:366 src/amuleDlg.cpp:1840 src/muuli_wdr.cpp:3445
-#: src/PrefsUnifiedDlg.cpp:314 src/Statistics.cpp:779 src/Statistics.cpp:1235
-msgid "Statistics"
-msgstr ""
-
-#: src/amuleDlg.cpp:368 src/amuleDlg.cpp:1847 src/muuli_wdr.cpp:3447
-#: src/PrefsUnifiedDlg.cpp:330 src/utils/wxCas/src/wxcasprefs.cpp:39
-msgid "Preferences"
-msgstr ""
-
-#: src/amuleDlg.cpp:371
-msgid "Navigate"
-msgstr ""
-
-#: src/amuleDlg.cpp:657
+#: src/amuleDlg.cpp:592
 msgid "New version available"
 msgstr ""
 
-#: src/amuleDlg.cpp:661
+#: src/amuleDlg.cpp:596
 #, c-format
 msgid ""
 "A new version of aMule (%s) is available.\n"
@@ -616,184 +578,217 @@ msgid ""
 "Would you like to open the download page?"
 msgstr ""
 
-#: src/amuleDlg.cpp:743
+#: src/amuleDlg.cpp:678
 msgid "aMule dialog destroyed"
 msgstr ""
 
-#: src/amuleDlg.cpp:766 src/DataToText.cpp:68 src/IPFilter.cpp:547
+#: src/amuleDlg.cpp:701 src/DataToText.cpp:68 src/IPFilter.cpp:547
 msgid "Connecting"
 msgstr ""
 
-#: src/amuleDlg.cpp:958
+#: src/amuleDlg.cpp:893
 msgid "eD2k: Connecting"
 msgstr ""
 
-#: src/amuleDlg.cpp:962
+#: src/amuleDlg.cpp:897
 msgid "eD2k: Disconnected"
 msgstr ""
 
-#: src/amuleDlg.cpp:968
+#: src/amuleDlg.cpp:903
 msgid "Kad: Firewalled"
 msgstr ""
 
-#: src/amuleDlg.cpp:972
+#: src/amuleDlg.cpp:907
 msgid "Kad: Connected"
 msgstr ""
 
-#: src/amuleDlg.cpp:977
+#: src/amuleDlg.cpp:912
 msgid "Kad: Connecting"
 msgstr ""
 
-#: src/amuleDlg.cpp:981
+#: src/amuleDlg.cpp:916
 msgid "Kad: Off"
 msgstr ""
 
-#: src/amuleDlg.cpp:1029 src/DownloadListCtrl.cpp:505
+#: src/amuleDlg.cpp:964 src/DownloadListCtrl.cpp:505
 #: src/DownloadListCtrl.cpp:749 src/FriendListCtrl.cpp:180
 #: src/muuli_wdr.cpp:731 src/muuli_wdr.cpp:782 src/muuli_wdr.cpp:846
-#: src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2252 src/muuli_wdr.cpp:2337
-#: src/muuli_wdr.cpp:3085 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
+#: src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2224 src/muuli_wdr.cpp:2309
+#: src/muuli_wdr.cpp:3057 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
 #: src/ServerListCtrl.cpp:606 src/TransferWnd.cpp:378
 #: src/utils/wxCas/src/wxcasprefs.cpp:235
 msgid "Cancel"
 msgstr ""
 
-#: src/amuleDlg.cpp:1030
+#: src/amuleDlg.cpp:965
 msgid "Stop the current connection attempts"
 msgstr ""
 
-#: src/amuleDlg.cpp:1035 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976
-#: src/muuli_wdr.cpp:2475
+#: src/amuleDlg.cpp:970 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976
+#: src/muuli_wdr.cpp:2447
 msgid "Disconnect"
 msgstr ""
 
-#: src/amuleDlg.cpp:1036
+#: src/amuleDlg.cpp:971
 msgid "Disconnect from the currently connected networks"
 msgstr ""
 
-#: src/amuleDlg.cpp:1041 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979
-#: src/muuli_wdr.cpp:2630 src/muuli_wdr.cpp:3082 src/muuli_wdr.cpp:3437
+#: src/amuleDlg.cpp:976 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979
+#: src/muuli_wdr.cpp:2602 src/muuli_wdr.cpp:3054 src/muuli_wdr.cpp:3409
 msgid "Connect"
 msgstr ""
 
-#: src/amuleDlg.cpp:1042
+#: src/amuleDlg.cpp:977
 msgid "Connect to the currently enabled networks"
 msgstr ""
 
-#: src/amuleDlg.cpp:1154
+#: src/amuleDlg.cpp:1089
 #, c-format
 msgid "Up: %.1f%s (%.1f) | Down: %.1f%s (%.1f)"
 msgstr ""
 
-#: src/amuleDlg.cpp:1156 src/amuleDlg.cpp:1158 src/amuleDlg.cpp:1162
-#: src/amuleDlg.cpp:1164 src/amuleDlg.cpp:1175 src/amuleDlg.cpp:1177
+#: src/amuleDlg.cpp:1091 src/amuleDlg.cpp:1093 src/amuleDlg.cpp:1097
+#: src/amuleDlg.cpp:1099 src/amuleDlg.cpp:1110 src/amuleDlg.cpp:1112
 #: src/MuleTrayIcon.cpp:796 src/MuleTrayIcon.cpp:799
 msgid " MB/s"
 msgstr ""
 
-#: src/amuleDlg.cpp:1156 src/amuleDlg.cpp:1158 src/amuleDlg.cpp:1162
-#: src/amuleDlg.cpp:1164 src/amuleDlg.cpp:1175 src/amuleDlg.cpp:1177
+#: src/amuleDlg.cpp:1091 src/amuleDlg.cpp:1093 src/amuleDlg.cpp:1097
+#: src/amuleDlg.cpp:1099 src/amuleDlg.cpp:1110 src/amuleDlg.cpp:1112
 #: src/MuleTrayIcon.cpp:796 src/MuleTrayIcon.cpp:799
 #: src/utils/wxCas/src/wxcasframe.cpp:1041
 msgid " kB/s"
 msgstr ""
 
-#: src/amuleDlg.cpp:1161
+#: src/amuleDlg.cpp:1096
 #, c-format
 msgid "Up: %.1f%s | Down: %.1f%s"
 msgstr ""
 
-#: src/amuleDlg.cpp:1193
+#: src/amuleDlg.cpp:1128
 #, c-format
 msgid "aMule (%s | Connected)"
 msgstr ""
 
-#: src/amuleDlg.cpp:1195
+#: src/amuleDlg.cpp:1130
 #, c-format
 msgid "aMule (%s | Disconnected)"
 msgstr ""
 
-#: src/amuleDlg.cpp:1248
+#: src/amuleDlg.cpp:1183
 #, c-format
 msgid "Do you really want to exit %s?"
 msgstr ""
 
-#: src/amuleDlg.cpp:1250
+#: src/amuleDlg.cpp:1185
 msgid "Exit confirmation"
 msgstr ""
 
-#: src/amuleDlg.cpp:1613
+#: src/amuleDlg.cpp:1548
 msgid "Launch Command: "
 msgstr ""
 
-#: src/amuleDlg.cpp:1632 src/muuli_wdr.cpp:1972 src/Preferences.cpp:979
+#: src/amuleDlg.cpp:1567 src/muuli_wdr.cpp:1971 src/Preferences.cpp:951
 msgid "- default -"
 msgstr ""
 
-#: src/amuleDlg.cpp:1660
+#: src/amuleDlg.cpp:1595
 #, c-format
 msgid "Skin directory '%s' does not exist"
 msgstr ""
 
-#: src/amuleDlg.cpp:1663
+#: src/amuleDlg.cpp:1598
 #, c-format
 msgid "WARNING: Unable to open skin file '%s' for read"
 msgstr ""
 
-#: src/amuleDlg.cpp:1814 src/muuli_wdr.cpp:3439
+#: src/amuleDlg.cpp:1722 src/amuleDlg.cpp:1968 src/muuli_wdr.cpp:1485
+#: src/muuli_wdr.cpp:3411
+msgid "Networks"
+msgstr ""
+
+#: src/amuleDlg.cpp:1726 src/muuli_wdr.cpp:3411
 msgid "Networks Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1820 src/muuli_wdr.cpp:3440
+#: src/amuleDlg.cpp:1728 src/muuli_wdr.cpp:3412
+msgid "Searches"
+msgstr ""
+
+#: src/amuleDlg.cpp:1732 src/muuli_wdr.cpp:3412
 msgid "Searches Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1826 src/muuli_wdr.cpp:3441
+#: src/amuleDlg.cpp:1734 src/DownloadListCtrl.cpp:740 src/muuli_wdr.cpp:392
+#: src/muuli_wdr.cpp:1578 src/muuli_wdr.cpp:3413 src/Statistics.cpp:829
+msgid "Downloads"
+msgstr ""
+
+#: src/amuleDlg.cpp:1738 src/muuli_wdr.cpp:3413
 msgid "Downloads Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1832 src/muuli_wdr.cpp:3443
+#: src/amuleDlg.cpp:1740 src/muuli_wdr.cpp:3287
+msgid "Shared files"
+msgstr ""
+
+#: src/amuleDlg.cpp:1744 src/muuli_wdr.cpp:3415
 msgid "Shared Files Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3444
+#: src/amuleDlg.cpp:1746 src/muuli_wdr.cpp:2919 src/muuli_wdr.cpp:3369
+#: src/muuli_wdr.cpp:3416
+msgid "Messages"
+msgstr ""
+
+#: src/amuleDlg.cpp:1750 src/muuli_wdr.cpp:3416
 msgid "Messages Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1844 src/muuli_wdr.cpp:3445
+#: src/amuleDlg.cpp:1752 src/muuli_wdr.cpp:3417 src/PrefsUnifiedDlg.cpp:312
+#: src/Statistics.cpp:779 src/Statistics.cpp:1235
+msgid "Statistics"
+msgstr ""
+
+#: src/amuleDlg.cpp:1756 src/muuli_wdr.cpp:3417
 msgid "Statistics Graph Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1851 src/muuli_wdr.cpp:3447
+#: src/amuleDlg.cpp:1759 src/muuli_wdr.cpp:3419 src/PrefsUnifiedDlg.cpp:328
+#: src/utils/wxCas/src/wxcasprefs.cpp:39
+msgid "Preferences"
+msgstr ""
+
+#: src/amuleDlg.cpp:1763 src/muuli_wdr.cpp:3419
 msgid "Preferences Settings Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1854 src/muuli_wdr.cpp:3448
+#: src/amuleDlg.cpp:1766 src/muuli_wdr.cpp:3420
 msgid "Import"
 msgstr ""
 
-#: src/amuleDlg.cpp:1858 src/muuli_wdr.cpp:3448
+#: src/amuleDlg.cpp:1770 src/muuli_wdr.cpp:3420
 msgid "The partfile importer tool"
 msgstr ""
 
-#: src/amuleDlg.cpp:1861 src/muuli_wdr.cpp:3449
+#: src/amuleDlg.cpp:1773 src/muuli_wdr.cpp:3421
 #: src/utils/aLinkCreator/src/alcframe.cpp:262
 msgid "About"
 msgstr ""
 
-#: src/amuleDlg.cpp:1861 src/muuli_wdr.cpp:3449
+#: src/amuleDlg.cpp:1773 src/muuli_wdr.cpp:3421
 msgid "About/Help"
 msgstr ""
 
-#: src/amuleDlg.cpp:2059
+#: src/amuleDlg.cpp:1971
 msgid "eD2k network"
 msgstr ""
 
-#: src/amuleDlg.cpp:2062
+#: src/amuleDlg.cpp:1974
 msgid "Kad network"
 msgstr ""
 
-#: src/amuleDlg.cpp:2062
+#: src/amuleDlg.cpp:1974
 msgid "No network"
 msgstr ""
 
@@ -918,7 +913,7 @@ msgstr ""
 msgid "The core rejected these shared folders:%s"
 msgstr ""
 
-#: src/amule-remote-gui.cpp:1336 src/ExternalConn.cpp:2346
+#: src/amule-remote-gui.cpp:1336 src/ExternalConn.cpp:2345
 msgid "Invalid link or already on list."
 msgstr ""
 
@@ -934,7 +929,7 @@ msgstr ""
 #: src/ClientDetailDialog.cpp:123 src/DataToText.cpp:61 src/DataToText.cpp:86
 #: src/DataToText.cpp:101 src/DataToText.cpp:136 src/DataToText.cpp:165
 #: src/DownloadListCtrl.cpp:1172 src/DownloadListCtrl.cpp:1185
-#: src/DownloadListCtrl.cpp:1196 src/ExternalConn.cpp:609
+#: src/DownloadListCtrl.cpp:1196 src/ExternalConn.cpp:608
 #: src/FileDetailDialog.cpp:203 src/FileDetailDialog.cpp:235
 #: src/FileDetailDialog.cpp:242 src/GenericClientListCtrl.cpp:1171
 #: src/GenericClientListCtrl.cpp:1182 src/GenericClientListCtrl.cpp:1192
@@ -1320,19 +1315,19 @@ msgstr ""
 msgid "Very low"
 msgstr ""
 
-#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:743 src/muuli_wdr.cpp:2303
+#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:743 src/muuli_wdr.cpp:2275
 #: src/ServerListCtrl.cpp:263 src/ServerListCtrl.cpp:456
 #: src/SharedFilesCtrl.cpp:145
 msgid "Low"
 msgstr ""
 
-#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:744 src/muuli_wdr.cpp:2304
+#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:744 src/muuli_wdr.cpp:2276
 #: src/ServerListCtrl.cpp:266 src/ServerListCtrl.cpp:457
 #: src/SharedFilesCtrl.cpp:146
 msgid "Normal"
 msgstr ""
 
-#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:745 src/muuli_wdr.cpp:2305
+#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:745 src/muuli_wdr.cpp:2277
 #: src/ServerListCtrl.cpp:269 src/ServerListCtrl.cpp:458
 #: src/SharedFilesCtrl.cpp:147
 msgid "High"
@@ -1424,8 +1419,8 @@ msgstr ""
 msgid "Remote Server"
 msgstr ""
 
-#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3202
-#: src/SearchDlg.cpp:119 src/TextClient.cpp:911
+#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3174
+#: src/SearchDlg.cpp:111 src/TextClient.cpp:911
 msgid "Kad"
 msgstr ""
 
@@ -1495,7 +1490,7 @@ msgstr ""
 msgid "Size"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3269
+#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3241
 msgid "Transferred"
 msgstr ""
 
@@ -1551,7 +1546,7 @@ msgid ""
 "\n"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:746 src/muuli_wdr.cpp:2306
+#: src/DownloadListCtrl.cpp:746 src/muuli_wdr.cpp:2278
 #: src/SharedFilesCtrl.cpp:150
 msgid "Auto"
 msgstr ""
@@ -1589,7 +1584,7 @@ msgid "Extended Options"
 msgstr ""
 
 #: src/DownloadListCtrl.cpp:770 src/DownloadListCtrl.cpp:822
-#: src/muuli_wdr.cpp:1790
+#: src/muuli_wdr.cpp:1789
 msgid "Preview"
 msgstr ""
 
@@ -1762,230 +1757,225 @@ msgstr[1] ""
 msgid "Invalid eD2k link! ERROR: %s"
 msgstr ""
 
-#: src/ExternalConn.cpp:380
+#: src/ExternalConn.cpp:379
 msgid "Client sent packet after authentication failed."
 msgstr ""
 
-#: src/ExternalConn.cpp:397
+#: src/ExternalConn.cpp:396
 msgid "External connection closed."
 msgstr ""
 
-#: src/ExternalConn.cpp:474
+#: src/ExternalConn.cpp:473
 msgid "External connections disabled due to empty password!"
 msgstr ""
 
-#: src/ExternalConn.cpp:495
+#: src/ExternalConn.cpp:494
 msgid "External connections disabled in config file"
 msgstr ""
 
-#: src/ExternalConn.cpp:576
+#: src/ExternalConn.cpp:575
 msgid "New external connection accepted"
 msgstr ""
 
-#: src/ExternalConn.cpp:579
+#: src/ExternalConn.cpp:578
 msgid "ERROR: couldn't accept a new external connection"
 msgstr ""
 
-#: src/ExternalConn.cpp:596
+#: src/ExternalConn.cpp:595
 msgid "External connection refused due to empty password in preferences!"
 msgstr ""
 
-#: src/ExternalConn.cpp:608
+#: src/ExternalConn.cpp:607
 #, c-format
 msgid "Connecting client: %s %s"
 msgstr ""
 
-#: src/ExternalConn.cpp:610
+#: src/ExternalConn.cpp:609
 msgid "Unknown version"
 msgstr ""
 
-#: src/ExternalConn.cpp:623
+#: src/ExternalConn.cpp:622
 msgid "Incorrect EC version ID, there might be binary incompatibility. Use core and remote from same snapshot."
 msgstr ""
 
-#: src/ExternalConn.cpp:631
+#: src/ExternalConn.cpp:630
 msgid "You cannot connect to a release version from an arbitrary development snapshot! *sigh* possible crash prevented"
 msgstr ""
 
-#: src/ExternalConn.cpp:714
+#: src/ExternalConn.cpp:713
 msgid "Invalid protocol version."
 msgstr ""
 
-#: src/ExternalConn.cpp:720
+#: src/ExternalConn.cpp:719
 msgid "Missing protocol version tag."
 msgstr ""
 
-#: src/ExternalConn.cpp:728
+#: src/ExternalConn.cpp:727
 msgid "Authentication failed: invalid hash specified as EC password."
 msgstr ""
 
-#: src/ExternalConn.cpp:776
+#: src/ExternalConn.cpp:775
 msgid "Authentication failed: wrong password."
 msgstr ""
 
-#: src/ExternalConn.cpp:778
+#: src/ExternalConn.cpp:777
 msgid "Authentication failed: missing password."
 msgstr ""
 
-#: src/ExternalConn.cpp:789
+#: src/ExternalConn.cpp:788
 msgid "Invalid request, please authenticate first."
 msgstr ""
 
-#: src/ExternalConn.cpp:794
+#: src/ExternalConn.cpp:793
 msgid "Access granted."
 msgstr ""
 
-#: src/ExternalConn.cpp:802
+#: src/ExternalConn.cpp:801
 #, c-format
 msgid "Sent error message \"%s\" to client."
 msgstr ""
 
-#: src/ExternalConn.cpp:807
+#: src/ExternalConn.cpp:806
 #, c-format
 msgid "Unauthorized access attempt from %s. Connection closed."
 msgstr ""
 
-#: src/ExternalConn.cpp:1420
+#: src/ExternalConn.cpp:1419
 #, c-format
 msgid "Remote PartFile command failed: FileHash not found: %s"
 msgstr ""
 
-#: src/ExternalConn.cpp:1424
+#: src/ExternalConn.cpp:1423
 #, c-format
 msgid "FileHash not found: %s"
 msgstr ""
 
-#: src/ExternalConn.cpp:1471 src/ExternalConn.cpp:1559
-#: src/ExternalConn.cpp:1680
+#: src/ExternalConn.cpp:1470 src/ExternalConn.cpp:1558
+#: src/ExternalConn.cpp:1679
 msgid "OOPS! OpCode processing error!"
 msgstr ""
 
-#: src/ExternalConn.cpp:1502
+#: src/ExternalConn.cpp:1501
 msgid "Server not added"
 msgstr ""
 
-#: src/ExternalConn.cpp:1521
+#: src/ExternalConn.cpp:1520
 #, c-format
 msgid "server not found: %s"
 msgstr ""
 
-#: src/ExternalConn.cpp:1538
+#: src/ExternalConn.cpp:1537
 msgid "need to define server to be removed"
 msgstr ""
 
-#: src/ExternalConn.cpp:1553
+#: src/ExternalConn.cpp:1552
 msgid "eD2k is disabled in preferences."
 msgstr ""
 
-#: src/ExternalConn.cpp:1658
+#: src/ExternalConn.cpp:1657
 msgid "Friend not found."
 msgstr ""
 
-#: src/ExternalConn.cpp:1668
+#: src/ExternalConn.cpp:1667
 msgid "Client not found."
 msgstr ""
 
-#: src/ExternalConn.cpp:1674
+#: src/ExternalConn.cpp:1673
 msgid "EC_TAG_FRIEND_SHARED requires EC_TAG_FRIEND or EC_TAG_CLIENT."
 msgstr ""
 
-#: src/ExternalConn.cpp:1992
+#: src/ExternalConn.cpp:1991
 msgid "WebSearch from remote interface makes no sense."
 msgstr ""
 
-#: src/ExternalConn.cpp:2027
+#: src/ExternalConn.cpp:2026
 msgid "Search in progress. Refetch results in a moment!"
 msgstr ""
 
-#: src/ExternalConn.cpp:2266
+#: src/ExternalConn.cpp:2265
 msgid "No points for graph."
 msgstr ""
 
-#: src/ExternalConn.cpp:2276
+#: src/ExternalConn.cpp:2275
 msgid "Your client is not configured for this detail level."
 msgstr ""
 
-#: src/ExternalConn.cpp:2303
+#: src/ExternalConn.cpp:2302
 msgid "External Connection: shutdown requested"
 msgstr ""
 
-#: src/ExternalConn.cpp:2315
+#: src/ExternalConn.cpp:2314
 msgid "Already shutting down."
 msgstr ""
 
-#: src/ExternalConn.cpp:2333
+#: src/ExternalConn.cpp:2332
 #, c-format
 msgid "ExternalConn: adding link '%s'."
 msgstr ""
 
-#: src/ExternalConn.cpp:2351
+#: src/ExternalConn.cpp:2350
 #, c-format
 msgid "%d of %d links failed (invalid or already on list)."
 msgstr ""
 
-#: src/ExternalConn.cpp:2374
+#: src/ExternalConn.cpp:2373
 msgid "Version check throttled; try again shortly."
 msgstr ""
 
-#: src/ExternalConn.cpp:2379
+#: src/ExternalConn.cpp:2378
 msgid "Version check is not available on this daemon."
 msgstr ""
 
-#: src/ExternalConn.cpp:2509
+#: src/ExternalConn.cpp:2508
 msgid "File not found."
 msgstr ""
 
-#: src/ExternalConn.cpp:2514
+#: src/ExternalConn.cpp:2513
 msgid "Invalid file name."
 msgstr ""
 
-#: src/ExternalConn.cpp:2522
+#: src/ExternalConn.cpp:2521
 msgid "Unable to rename file."
 msgstr ""
 
-#: src/ExternalConn.cpp:2839
-#, c-format
-msgid "Could not save the amuleapi password: %s"
-msgstr ""
-
-#: src/ExternalConn.cpp:3004 src/ExternalConn.cpp:3032
+#: src/ExternalConn.cpp:2992 src/ExternalConn.cpp:3020
 msgid "Kad is disabled in preferences."
 msgstr ""
 
-#: src/ExternalConn.cpp:3045
+#: src/ExternalConn.cpp:3033
 msgid "Already connected to eD2k."
 msgstr ""
 
-#: src/ExternalConn.cpp:3048
+#: src/ExternalConn.cpp:3036
 msgid "Connecting to eD2k..."
 msgstr ""
 
-#: src/ExternalConn.cpp:3057
+#: src/ExternalConn.cpp:3045
 msgid "Already connected to Kad."
 msgstr ""
 
-#: src/ExternalConn.cpp:3060
+#: src/ExternalConn.cpp:3048
 msgid "Connecting to Kad..."
 msgstr ""
 
-#: src/ExternalConn.cpp:3067
+#: src/ExternalConn.cpp:3055
 msgid "All networks are disabled."
 msgstr ""
 
-#: src/ExternalConn.cpp:3076
+#: src/ExternalConn.cpp:3064
 msgid "Disconnected from eD2k."
 msgstr ""
 
-#: src/ExternalConn.cpp:3081
+#: src/ExternalConn.cpp:3069
 msgid "Disconnected from Kad."
 msgstr ""
 
-#: src/ExternalConn.cpp:3090
+#: src/ExternalConn.cpp:3078
 #, c-format
 msgid "External Connection: invalid opcode received: %#x"
 msgstr ""
 
-#: src/ExternalConn.cpp:3095
+#: src/ExternalConn.cpp:3083
 msgid "Invalid opcode (wrong protocol version?)"
 msgstr ""
 
@@ -2272,19 +2262,19 @@ msgstr ""
 msgid "eD2k"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:349 src/muuli_wdr.cpp:1495
+#: src/FirstRunWizard.cpp:349 src/muuli_wdr.cpp:1488
 msgid "Kademlia"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:359 src/muuli_wdr.cpp:1423
+#: src/FirstRunWizard.cpp:359 src/muuli_wdr.cpp:1416
 msgid "Standard TCP Port "
 msgstr ""
 
-#: src/FirstRunWizard.cpp:365 src/muuli_wdr.cpp:1435
+#: src/FirstRunWizard.cpp:365 src/muuli_wdr.cpp:1428
 msgid "Extended UDP port (Kad / global search) "
 msgstr ""
 
-#: src/FirstRunWizard.cpp:377 src/muuli_wdr.cpp:1442
+#: src/FirstRunWizard.cpp:377 src/muuli_wdr.cpp:1435
 msgid "Enable UPnP for router port forwarding"
 msgstr ""
 
@@ -2309,7 +2299,7 @@ msgstr ""
 msgid "Your peer lists are already in place - nothing to download."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:434 src/muuli_wdr.cpp:1540
+#: src/FirstRunWizard.cpp:434 src/muuli_wdr.cpp:1533
 msgid "Auto-update server list at startup"
 msgstr ""
 
@@ -2355,23 +2345,23 @@ msgid ""
 "want downloads on a different (e.g. larger) disk."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:549 src/FirstRunWizard.cpp:611 src/muuli_wdr.cpp:1702
+#: src/FirstRunWizard.cpp:549 src/FirstRunWizard.cpp:611 src/muuli_wdr.cpp:1701
 msgid "Destination folder for downloads"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:553 src/FirstRunWizard.cpp:569 src/muuli_wdr.cpp:1349
-#: src/muuli_wdr.cpp:1366 src/muuli_wdr.cpp:1677 src/muuli_wdr.cpp:1708
-#: src/muuli_wdr.cpp:1720 src/muuli_wdr.cpp:2790
+#: src/FirstRunWizard.cpp:553 src/FirstRunWizard.cpp:569 src/muuli_wdr.cpp:1342
+#: src/muuli_wdr.cpp:1359 src/muuli_wdr.cpp:1676 src/muuli_wdr.cpp:1707
+#: src/muuli_wdr.cpp:1719 src/muuli_wdr.cpp:2762
 #: src/utils/aLinkCreator/src/alcframe.cpp:135
 #: src/utils/wxCas/src/wxcasprefs.cpp:52 src/utils/wxCas/src/wxcasprefs.cpp:118
 msgid "Browse"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:559 src/muuli_wdr.cpp:1713
+#: src/FirstRunWizard.cpp:559 src/muuli_wdr.cpp:1712
 msgid "(All files in this folder are shared with other peers)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:565 src/FirstRunWizard.cpp:624 src/muuli_wdr.cpp:1715
+#: src/FirstRunWizard.cpp:565 src/FirstRunWizard.cpp:624 src/muuli_wdr.cpp:1714
 msgid "Folder for temporary download files"
 msgstr ""
 
@@ -2402,7 +2392,7 @@ msgstr ""
 msgid "CRITICAL - no client on StartChatSession"
 msgstr ""
 
-#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2696 src/muuli_wdr.cpp:3373
+#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2668 src/muuli_wdr.cpp:3345
 msgid "Friends"
 msgstr ""
 
@@ -2508,8 +2498,8 @@ msgstr ""
 msgid "No"
 msgstr ""
 
-#: src/GenericClientListCtrl.cpp:1216 src/PrefsUnifiedDlg.cpp:2898
-#: src/PrefsUnifiedDlg.cpp:2948 src/ServerListCtrl.cpp:276
+#: src/GenericClientListCtrl.cpp:1216 src/PrefsUnifiedDlg.cpp:2818
+#: src/PrefsUnifiedDlg.cpp:2868 src/ServerListCtrl.cpp:276
 msgid "Yes"
 msgstr ""
 
@@ -2676,10 +2666,10 @@ msgstr ""
 msgid "Please fill all fields required"
 msgstr ""
 
-#: src/KadDlg.cpp:192 src/PartFile.cpp:1031 src/PrefsUnifiedDlg.cpp:1134
-#: src/PrefsUnifiedDlg.cpp:1204 src/PrefsUnifiedDlg.cpp:1405
-#: src/PrefsUnifiedDlg.cpp:1663 src/PrefsUnifiedDlg.cpp:1673
-#: src/PrefsUnifiedDlg.cpp:1690 src/PrefsUnifiedDlg.cpp:1738
+#: src/KadDlg.cpp:192 src/PartFile.cpp:1031 src/PrefsUnifiedDlg.cpp:1162
+#: src/PrefsUnifiedDlg.cpp:1331 src/PrefsUnifiedDlg.cpp:1589
+#: src/PrefsUnifiedDlg.cpp:1599 src/PrefsUnifiedDlg.cpp:1616
+#: src/PrefsUnifiedDlg.cpp:1658
 msgid "Message"
 msgstr ""
 
@@ -2780,7 +2770,7 @@ msgstr ""
 msgid "Uploaded"
 msgstr ""
 
-#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3253
+#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3225
 msgid "Requested"
 msgstr ""
 
@@ -2903,7 +2893,7 @@ msgid "WARNING: "
 msgstr ""
 
 #: src/MuleNotebook.cpp:179 src/muuli_wdr.cpp:817 src/muuli_wdr.cpp:1229
-#: src/muuli_wdr.cpp:3157 src/muuli_wdr.cpp:3413
+#: src/muuli_wdr.cpp:3129 src/muuli_wdr.cpp:3385
 msgid "Close"
 msgstr ""
 
@@ -2916,12 +2906,12 @@ msgstr ""
 msgid "Copy"
 msgstr ""
 
-#: src/MuleTextCtrl.cpp:88 src/SearchDlg.cpp:261
+#: src/MuleTextCtrl.cpp:88
 msgid "Paste"
 msgstr ""
 
 #: src/MuleTextCtrl.cpp:89 src/muuli_wdr.cpp:358 src/muuli_wdr.cpp:757
-#: src/muuli_wdr.cpp:2380 src/muuli_wdr.cpp:2399 src/muuli_wdr.cpp:2421
+#: src/muuli_wdr.cpp:2352 src/muuli_wdr.cpp:2371 src/muuli_wdr.cpp:2393
 #: src/utils/aLinkCreator/src/alcframe.cpp:142
 msgid "Clear"
 msgstr ""
@@ -3012,8 +3002,8 @@ msgid "Exit"
 msgstr ""
 
 #: src/MuleTrayIcon.cpp:579 src/MuleTrayIcon.cpp:945 src/MuleTrayIcon.cpp:965
-#: src/muuli_wdr.cpp:1398 src/muuli_wdr.cpp:1406 src/muuli_wdr.cpp:1413
-#: src/muuli_wdr.cpp:1836 src/muuli_wdr.cpp:1842 src/OtherFunctions.cpp:91
+#: src/muuli_wdr.cpp:1391 src/muuli_wdr.cpp:1399 src/muuli_wdr.cpp:1406
+#: src/muuli_wdr.cpp:1835 src/muuli_wdr.cpp:1841 src/OtherFunctions.cpp:91
 #: src/StatisticsDlg.cpp:93 src/StatisticsDlg.cpp:95
 msgid "kB/s"
 msgstr ""
@@ -3182,7 +3172,7 @@ msgstr ""
 msgid "Type"
 msgstr ""
 
-#: src/muuli_wdr.cpp:215 src/SearchDlg.cpp:118 src/SearchListCtrl.cpp:853
+#: src/muuli_wdr.cpp:215 src/SearchDlg.cpp:110 src/SearchListCtrl.cpp:853
 msgid "Local"
 msgstr ""
 
@@ -3253,7 +3243,7 @@ msgstr ""
 msgid "KB"
 msgstr ""
 
-#: src/muuli_wdr.cpp:274 src/muuli_wdr.cpp:293 src/muuli_wdr.cpp:1621
+#: src/muuli_wdr.cpp:274 src/muuli_wdr.cpp:293 src/muuli_wdr.cpp:1620
 #: src/OtherFunctions.cpp:64
 msgid "MB"
 msgstr ""
@@ -3270,7 +3260,7 @@ msgstr ""
 msgid "Availability"
 msgstr ""
 
-#: src/muuli_wdr.cpp:312 src/muuli_wdr.cpp:398 src/muuli_wdr.cpp:3318
+#: src/muuli_wdr.cpp:312 src/muuli_wdr.cpp:398 src/muuli_wdr.cpp:3290
 msgid "Filter:"
 msgstr ""
 
@@ -3302,7 +3292,7 @@ msgstr ""
 msgid "Stop"
 msgstr ""
 
-#: src/muuli_wdr.cpp:348 src/muuli_wdr.cpp:1392 src/SearchListCtrl.cpp:732
+#: src/muuli_wdr.cpp:348 src/muuli_wdr.cpp:1385 src/SearchListCtrl.cpp:732
 msgid "Download"
 msgstr ""
 
@@ -3333,12 +3323,12 @@ msgstr ""
 #: src/muuli_wdr.cpp:1160 src/muuli_wdr.cpp:1167 src/muuli_wdr.cpp:1172
 #: src/muuli_wdr.cpp:1179 src/muuli_wdr.cpp:1184 src/muuli_wdr.cpp:1191
 #: src/muuli_wdr.cpp:1205 src/muuli_wdr.cpp:1212 src/muuli_wdr.cpp:1217
-#: src/muuli_wdr.cpp:1224 src/muuli_wdr.cpp:3255 src/muuli_wdr.cpp:3263
-#: src/muuli_wdr.cpp:3271
+#: src/muuli_wdr.cpp:1224 src/muuli_wdr.cpp:3227 src/muuli_wdr.cpp:3235
+#: src/muuli_wdr.cpp:3243
 msgid "N/A"
 msgstr ""
 
-#: src/muuli_wdr.cpp:508 src/muuli_wdr.cpp:1065 src/PrefsUnifiedDlg.cpp:299
+#: src/muuli_wdr.cpp:508 src/muuli_wdr.cpp:1065 src/PrefsUnifiedDlg.cpp:297
 msgid "General"
 msgstr ""
 
@@ -3474,7 +3464,7 @@ msgstr ""
 msgid "Album :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:685 src/muuli_wdr.cpp:2275
+#: src/muuli_wdr.cpp:685 src/muuli_wdr.cpp:2247
 msgid "Title :"
 msgstr ""
 
@@ -3580,7 +3570,7 @@ msgstr ""
 msgid "Userhash :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:895 src/muuli_wdr.cpp:1742 src/muuli_wdr.cpp:2470
+#: src/muuli_wdr.cpp:895 src/muuli_wdr.cpp:1741 src/muuli_wdr.cpp:2442
 #: src/utils/aLinkCreator/src/alcframe.cpp:137
 msgid "Add"
 msgstr ""
@@ -3589,15 +3579,15 @@ msgstr ""
 msgid "Download-Speed"
 msgstr ""
 
-#: src/muuli_wdr.cpp:954 src/muuli_wdr.cpp:989 src/muuli_wdr.cpp:2574
+#: src/muuli_wdr.cpp:954 src/muuli_wdr.cpp:989 src/muuli_wdr.cpp:2546
 msgid "Current"
 msgstr ""
 
-#: src/muuli_wdr.cpp:962 src/muuli_wdr.cpp:997 src/muuli_wdr.cpp:2582
+#: src/muuli_wdr.cpp:962 src/muuli_wdr.cpp:997 src/muuli_wdr.cpp:2554
 msgid "Running average"
 msgstr ""
 
-#: src/muuli_wdr.cpp:970 src/muuli_wdr.cpp:1005 src/muuli_wdr.cpp:2590
+#: src/muuli_wdr.cpp:970 src/muuli_wdr.cpp:1005 src/muuli_wdr.cpp:2562
 msgid "Session average"
 msgstr ""
 
@@ -3609,7 +3599,7 @@ msgstr ""
 msgid "Connections"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1024 src/muuli_wdr.cpp:1861
+#: src/muuli_wdr.cpp:1024 src/muuli_wdr.cpp:1860
 msgid "Active downloads"
 msgstr ""
 
@@ -3617,7 +3607,7 @@ msgstr ""
 msgid "Active connections (1:1)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1040 src/muuli_wdr.cpp:1862
+#: src/muuli_wdr.cpp:1040 src/muuli_wdr.cpp:1861
 msgid "Active uploads"
 msgstr ""
 
@@ -3733,8 +3723,8 @@ msgstr ""
 msgid "Language: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1257 src/muuli_wdr.cpp:1330 src/muuli_wdr.cpp:1334
-#: src/muuli_wdr.cpp:1337
+#: src/muuli_wdr.cpp:1257 src/muuli_wdr.cpp:1323 src/muuli_wdr.cpp:1327
+#: src/muuli_wdr.cpp:1330
 msgid "The delay before showing tool-tips."
 msgstr ""
 
@@ -3810,943 +3800,923 @@ msgstr ""
 msgid "Enabling this will make aMule to show notifications when finished downloading."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1323
-msgid "Remember search history"
-msgstr ""
-
-#: src/muuli_wdr.cpp:1324
-msgid "Keeps a dropdown list of your past search terms in the Search tab's Name field. This remembers the queries you typed, not the results they returned."
-msgstr ""
-
-#: src/muuli_wdr.cpp:1329
+#: src/muuli_wdr.cpp:1322
 msgid "Tooltip delay time: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1336
+#: src/muuli_wdr.cpp:1329
 msgid "seconds"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1340
+#: src/muuli_wdr.cpp:1333
 msgid "Browser Selection"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1346
+#: src/muuli_wdr.cpp:1339
 msgid "Enter your browser name here. Leave this field empty to use the system default browser."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1353
+#: src/muuli_wdr.cpp:1346
 msgid "Open in new tab if possible"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1355
+#: src/muuli_wdr.cpp:1348
 msgid "Open the web page in a new tab instead of in a new window when possible"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1359
+#: src/muuli_wdr.cpp:1352
 msgid "Video Player"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1386
+#: src/muuli_wdr.cpp:1379
 msgid "Bandwidth limits"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1400
+#: src/muuli_wdr.cpp:1393
 msgid "Upload"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1408
+#: src/muuli_wdr.cpp:1401
 msgid "Slot Allocation"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1417
+#: src/muuli_wdr.cpp:1410
 msgid "Ports"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1427
+#: src/muuli_wdr.cpp:1420
 msgid "This is the standard eD2k port and cannot be disabled."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1430
+#: src/muuli_wdr.cpp:1423
 msgid "UDP port for server requests (TCP+3):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1432
+#: src/muuli_wdr.cpp:1425
 msgid "4665"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1439
+#: src/muuli_wdr.cpp:1432
 msgid "This UDP port is used for extended eD2k requests and Kad network"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1446
+#: src/muuli_wdr.cpp:1439
 msgid "UPnP TCP Port (Optional):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1456
+#: src/muuli_wdr.cpp:1449
 msgid "Bind local address to IP (empty for any):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1459
+#: src/muuli_wdr.cpp:1452
 msgid "Advanced users only: If you have multiple network interfaces, enter the address of the interface to which aMule should be bound."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1462 src/muuli_wdr.cpp:2055
+#: src/muuli_wdr.cpp:1455 src/muuli_wdr.cpp:2054
 msgid "Bind to network interface (empty for any):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1475
+#: src/muuli_wdr.cpp:1468
 msgid "Advanced users only: pin all of aMule's traffic to one network interface, chosen from the list or typed in by name (e.g. tun0, eth0, en0) or index. Unlike binding to an IP, this stops traffic leaking out via the default route - useful with a VPN. Requires no elevated privileges."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1481
+#: src/muuli_wdr.cpp:1474
 msgid "Max sources per downloading file:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1485
+#: src/muuli_wdr.cpp:1478
 msgid "Max simultaneous connections:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1498 src/muuli_wdr.cpp:3197
+#: src/muuli_wdr.cpp:1491 src/muuli_wdr.cpp:3169
 msgid "ED2K"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1505
+#: src/muuli_wdr.cpp:1498
 msgid "Autoconnect on startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1508
+#: src/muuli_wdr.cpp:1501
 msgid "Reconnect on loss"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1530
+#: src/muuli_wdr.cpp:1523
 msgid "Remove dead server after"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1531
+#: src/muuli_wdr.cpp:1524
 msgid "Static servers are never removed, even when unreachable."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1535
+#: src/muuli_wdr.cpp:1528
 msgid "retries"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1543
+#: src/muuli_wdr.cpp:1536
 msgid "List"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1546
+#: src/muuli_wdr.cpp:1539
 msgid "Update server list when connecting to a server"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1549
+#: src/muuli_wdr.cpp:1542
 msgid "Update server list when a client connects"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1552
+#: src/muuli_wdr.cpp:1545
 msgid "Use priority system"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1556
+#: src/muuli_wdr.cpp:1549
 msgid "Use smart LowID check on connect"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1560
+#: src/muuli_wdr.cpp:1553
 msgid "Safe connect"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1564
+#: src/muuli_wdr.cpp:1557
 msgid "Autoconnect to servers in static list only"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1567
+#: src/muuli_wdr.cpp:1560
 msgid "Set manually added servers to High Priority"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1588
+#: src/muuli_wdr.cpp:1581
 msgid "Add files to download in pause mode"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1590
+#: src/muuli_wdr.cpp:1583
 msgid "Add files to download with auto priority"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1593
+#: src/muuli_wdr.cpp:1586
 msgid "Try to download first and last chunks first"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1597
+#: src/muuli_wdr.cpp:1590
 msgid "Endgame mode: rotate to faster sources for the final blocks"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1600
+#: src/muuli_wdr.cpp:1593
 msgid "Start next paused file when a file completes"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1603
+#: src/muuli_wdr.cpp:1596
 msgid "From the same category"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1605
+#: src/muuli_wdr.cpp:1598
 msgid "In alphabetic order"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1607
+#: src/muuli_wdr.cpp:1600
 msgid "Preallocate disk space for new files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1608
+#: src/muuli_wdr.cpp:1601
 msgid "For new files preallocates disk space for the whole file, thus reduces fragmentation"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1613
+#: src/muuli_wdr.cpp:1606
+msgid "Create new files as sparse files"
+msgstr ""
+
+#: src/muuli_wdr.cpp:1607
+msgid "A sparse file reserves its full size on disk immediately without writing real data to it -- fast, but unsupported or slow on some filesystems, and free-space accounting stays optimistic while the download is in progress. Turn this off to grow the file only as data arrives."
+msgstr ""
+
+#: src/muuli_wdr.cpp:1612
 msgid "Stop downloads when free disk space reaches "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1614
+#: src/muuli_wdr.cpp:1613
 msgid "Select this if you want aMule to check your disk space"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1618
+#: src/muuli_wdr.cpp:1617
 msgid "Enter here the min disk space desired."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1624
+#: src/muuli_wdr.cpp:1623
 msgid "Save 10 sources on rare files (< 20 sources)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1628 src/Statistics.cpp:790
+#: src/muuli_wdr.cpp:1627 src/Statistics.cpp:790
 msgid "Uploads"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1631
+#: src/muuli_wdr.cpp:1630
 msgid "Add new shared files with auto priority"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1637
+#: src/muuli_wdr.cpp:1636
 msgid "Intelligent Corruption Handling (I.C.H.)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1640
+#: src/muuli_wdr.cpp:1639
 msgid "Enable"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1643
+#: src/muuli_wdr.cpp:1642
 msgid "Advanced I.C.H. trusts every hash (not recommended)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1655 src/PrefsUnifiedDlg.cpp:1990
+#: src/muuli_wdr.cpp:1654 src/PrefsUnifiedDlg.cpp:1910
 msgid "Media metadata extraction"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1659
+#: src/muuli_wdr.cpp:1658
 msgid "Extract length / bitrate / codec from shared audio and video files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1661
+#: src/muuli_wdr.cpp:1660
 msgid "When enabled, aMule runs ffprobe on each shared media file to fill in the Length / Bitrate / Codec columns other clients see when they find the file in a search. Requires ffmpeg (the ffprobe binary) to be installed."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1668
+#: src/muuli_wdr.cpp:1667
 msgid "Path to ffprobe:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1673
+#: src/muuli_wdr.cpp:1672
 msgid "Full path to the ffprobe binary. Leave empty to have aMule auto-detect it on startup."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1681
+#: src/muuli_wdr.cpp:1680
 msgid "Detect"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1682
+#: src/muuli_wdr.cpp:1681
 msgid "Search the standard install locations for an ffprobe binary and fill the path field."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1706
+#: src/muuli_wdr.cpp:1705
 msgid ""
 "Completed downloads are stored here. All files in this folder are automatically shared with other peers.\n"
 "If this folder also holds files you don't want to share, point it at an aMule-only sub-folder."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1709
+#: src/muuli_wdr.cpp:1708
 msgid "Pick the folder where completed downloads will be stored. All files in that folder will be shared with other peers."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1723
+#: src/muuli_wdr.cpp:1722
 msgid "Shared folders"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1729
+#: src/muuli_wdr.cpp:1728
 msgid "(Folders shared by the core. Enter a path to add one.)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1737
+#: src/muuli_wdr.cpp:1736
 msgid "Absolute path of a folder on the core's machine, e.g. /home/user/shared"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1739 src/PrefsUnifiedDlg.cpp:2874
+#: src/muuli_wdr.cpp:1738 src/PrefsUnifiedDlg.cpp:2794
 msgid "Recursive"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1740
+#: src/muuli_wdr.cpp:1739
 msgid "Share every sub-folder underneath this one, including ones created later."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1744 src/utils/aLinkCreator/src/alcframe.cpp:141
+#: src/muuli_wdr.cpp:1743 src/utils/aLinkCreator/src/alcframe.cpp:141
 msgid "Remove"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1748
+#: src/muuli_wdr.cpp:1747
 msgid "(Right click on folder icon for recursive share)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1755
+#: src/muuli_wdr.cpp:1754
 msgid "Share hidden files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1761
+#: src/muuli_wdr.cpp:1760
 msgid "Automatically rescan shared folders for changes"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1767
+#: src/muuli_wdr.cpp:1766
 msgid "Follow symbolic links in shared folders"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1773
+#: src/muuli_wdr.cpp:1772
 msgid "Exclude files matching:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1776
+#: src/muuli_wdr.cpp:1775
 msgid "Wildcard patterns separated by '|', e.g. .DS_Store|Thumbs.db|*.tmp. Files whose name matches are not shared. Matching is case-insensitive."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1780
+#: src/muuli_wdr.cpp:1779
 msgid "Patterns are regular expressions"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1781
+#: src/muuli_wdr.cpp:1780
 msgid "When set, the whole field is one regular expression ('|' is alternation). When unset, it is a list of '|'-separated wildcards."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1791
+#: src/muuli_wdr.cpp:1790
 msgid "Show how many shared files the current pattern would exclude."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1812
+#: src/muuli_wdr.cpp:1811
 msgid "Graphs"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1815 src/muuli_wdr.cpp:1877
+#: src/muuli_wdr.cpp:1814 src/muuli_wdr.cpp:1876
 msgid "Update delay : 5 secs"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1819
+#: src/muuli_wdr.cpp:1818
 msgid "Time for average graph: 100 mins"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1823
+#: src/muuli_wdr.cpp:1822
 msgid "Connections Graph Scale: 100 "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1830
+#: src/muuli_wdr.cpp:1829
 msgid "Download graph scale:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1838
+#: src/muuli_wdr.cpp:1837
 msgid "Upload graph scale:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1848
+#: src/muuli_wdr.cpp:1847
 msgid "Colors: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1852
+#: src/muuli_wdr.cpp:1851
 msgid "Background"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1853
+#: src/muuli_wdr.cpp:1852
 msgid "Grid"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1854
+#: src/muuli_wdr.cpp:1853
 msgid "Download current"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1855
+#: src/muuli_wdr.cpp:1854
 msgid "Download running average"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1856
+#: src/muuli_wdr.cpp:1855
 msgid "Download session average"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1857
+#: src/muuli_wdr.cpp:1856
 msgid "Upload current"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1858
+#: src/muuli_wdr.cpp:1857
 msgid "Upload running average"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1859
+#: src/muuli_wdr.cpp:1858
 msgid "Upload session average"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1860
+#: src/muuli_wdr.cpp:1859
 msgid "Active connections"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1863
+#: src/muuli_wdr.cpp:1862
 msgid "Systray Icon Speed Bar"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1864
+#: src/muuli_wdr.cpp:1863
 msgid "Kad-nodes current"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1865
+#: src/muuli_wdr.cpp:1864
 msgid "Kad-nodes running"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1866
+#: src/muuli_wdr.cpp:1865
 msgid "Kad-nodes session"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1870 src/muuli_wdr.cpp:2324
+#: src/muuli_wdr.cpp:1869 src/muuli_wdr.cpp:2296
 msgid "Select"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1874
+#: src/muuli_wdr.cpp:1873
 msgid "Tree"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1884
+#: src/muuli_wdr.cpp:1883
 msgid "Number of Client Versions shown (0=unlimited)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1909
+#: src/muuli_wdr.cpp:1908
 msgid "!!! WARNING !!!"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1924
+#: src/muuli_wdr.cpp:1923
 msgid "Max new connections / 5 secs"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1926
+#: src/muuli_wdr.cpp:1925
 msgid "Concurrent Kad source lookups"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1928
+#: src/muuli_wdr.cpp:1927
 msgid "Kad source re-search interval (minutes)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1930
+#: src/muuli_wdr.cpp:1929
 msgid "Source re-ask interval (minutes)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1934
+#: src/muuli_wdr.cpp:1933
 msgid "File Buffer Size: 240000 bytes"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1938
+#: src/muuli_wdr.cpp:1937
 msgid "Use MMAP: memory-mapped file access (lower memory use)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1939
+#: src/muuli_wdr.cpp:1938
 msgid "Maps part files into memory instead of buffering them on the heap, lowering the process memory footprint. May reduce download speed on some disks; best for memory-constrained or upload-heavy hosts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1941
+#: src/muuli_wdr.cpp:1940
 msgid "Upload Queue Size: 5000 clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1945
+#: src/muuli_wdr.cpp:1944
 msgid "Server connection refresh interval: Disable"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1949
+#: src/muuli_wdr.cpp:1948
 msgid "Disable computer's timed standby mode"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1968
+#: src/muuli_wdr.cpp:1967
 msgid "Skin to use: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1977
+#: src/muuli_wdr.cpp:1976
 msgid "Show \"Fast eD2k Links Handler\" in every window."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1980
+#: src/muuli_wdr.cpp:1979
 msgid "Show extended info on categories tabs"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1983
+#: src/muuli_wdr.cpp:1982
 msgid "Show application version on title"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1985
+#: src/muuli_wdr.cpp:1984
 msgid "Show transfer rates on title"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1987
+#: src/muuli_wdr.cpp:1986
 msgid "Before application name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1989
+#: src/muuli_wdr.cpp:1988
 msgid "After application name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1992
+#: src/muuli_wdr.cpp:1991
 msgid "Show overhead bandwidth"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1996
+#: src/muuli_wdr.cpp:1995
 msgid "Vertical toolbar orientation"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1998
+#: src/muuli_wdr.cpp:1997
 msgid "Live column sorting (auto-reorder rows as their values change)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2005
+#: src/muuli_wdr.cpp:2004
 msgid "Download Queue Files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2008
+#: src/muuli_wdr.cpp:2007
 msgid "Show progress percentage"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2014
+#: src/muuli_wdr.cpp:2013
 msgid "Show progress bar"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2017
+#: src/muuli_wdr.cpp:2016
 msgid "Flat"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2021
+#: src/muuli_wdr.cpp:2020
 msgid "Round"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2039
+#: src/muuli_wdr.cpp:2038
 msgid "External Connection Parameters"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2042
+#: src/muuli_wdr.cpp:2041
 msgid "Accept external connections"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2049 src/muuli_wdr.cpp:2108
+#: src/muuli_wdr.cpp:2048 src/muuli_wdr.cpp:2107
 msgid "IP of the listening interface:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2052
+#: src/muuli_wdr.cpp:2051
 msgid "Enter here a valid ip in the a.b.c.d format for the listening EC interface. An empty field or 0.0.0.0 will mean any interface."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2073 src/muuli_wdr.cpp:2184
+#: src/muuli_wdr.cpp:2072 src/muuli_wdr.cpp:2156
 msgid "TCP port:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2079
+#: src/muuli_wdr.cpp:2078
 msgid "Enable UPnP port forwarding on the EC port"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2083 src/muuli_wdr.cpp:3069
+#: src/muuli_wdr.cpp:2082 src/muuli_wdr.cpp:3041
 #: src/utils/wxCas/src/wxcasprefs.cpp:167
 msgid "Password"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2089
+#: src/muuli_wdr.cpp:2088
 msgid "aMule API server parameters"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2092
+#: src/muuli_wdr.cpp:2091
 msgid "Run amuleapi (REST API) on startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2097
+#: src/muuli_wdr.cpp:2096
 msgid "HTTP port:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2111
+#: src/muuli_wdr.cpp:2110
 msgid "The interface amuleapi's HTTP server listens on. 127.0.0.1 (default) accepts only local connections; use 0.0.0.0 or a specific IP to expose it to other hosts (set an admin password below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2116
-msgid "Type a password to set or change it. Stored passwords cannot be shown, so leaving this empty keeps the current one."
-msgstr ""
-
-#: src/muuli_wdr.cpp:2118
+#: src/muuli_wdr.cpp:2113
 msgid "Admin password"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2130 src/muuli_wdr.cpp:2147 src/PrefsUnifiedDlg.cpp:1103
-msgid "A password is set."
-msgstr ""
-
-#: src/muuli_wdr.cpp:2134
-msgid "Enable guest access"
-msgstr ""
-
-#: src/muuli_wdr.cpp:2135
-msgid "Guest sessions may read status and listings but cannot change anything. Turning this off clears the stored guest password."
-msgstr ""
-
-#: src/muuli_wdr.cpp:2139
-msgid "Guest password"
-msgstr ""
-
-#: src/muuli_wdr.cpp:2154
-msgid "Web server parameters"
-msgstr ""
-
-#: src/muuli_wdr.cpp:2157
-msgid "Run webserver on startup (deprecated)"
-msgstr ""
-
-#: src/muuli_wdr.cpp:2163
-msgid "Web template"
-msgstr ""
-
-#: src/muuli_wdr.cpp:2168
-msgid "Full rights password"
-msgstr ""
-
-#: src/muuli_wdr.cpp:2172
-msgid "Enable Low rights User"
-msgstr ""
-
-#: src/muuli_wdr.cpp:2177
+#: src/muuli_wdr.cpp:2118 src/muuli_wdr.cpp:2149
 msgid "Low rights password"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2191
+#: src/muuli_wdr.cpp:2126
+msgid "Web server parameters"
+msgstr ""
+
+#: src/muuli_wdr.cpp:2129
+msgid "Run webserver on startup (deprecated)"
+msgstr ""
+
+#: src/muuli_wdr.cpp:2135
+msgid "Web template"
+msgstr ""
+
+#: src/muuli_wdr.cpp:2140
+msgid "Full rights password"
+msgstr ""
+
+#: src/muuli_wdr.cpp:2144
+msgid "Enable Low rights User"
+msgstr ""
+
+#: src/muuli_wdr.cpp:2163
 msgid "Enable UPnP port forwarding of the web server port"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2196
+#: src/muuli_wdr.cpp:2168
 msgid "Web server UPnP TCP port (Optional)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2204
+#: src/muuli_wdr.cpp:2176
 msgid "Page Refresh Time (in secs)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2211
+#: src/muuli_wdr.cpp:2183
 msgid "Enable Gzip compression"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2245
+#: src/muuli_wdr.cpp:2217
 msgid "Reset page to defaults"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2246
+#: src/muuli_wdr.cpp:2218
 msgid "Reset the settings on the current page to their default values."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2248 src/muuli_wdr.cpp:2334 src/ServerWnd.cpp:274
+#: src/muuli_wdr.cpp:2220 src/muuli_wdr.cpp:2306 src/ServerWnd.cpp:274
 #: src/ServerWnd.cpp:282
 msgid "OK"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2250
+#: src/muuli_wdr.cpp:2222
 msgid "Click here to apply any changes made to the preferences."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2253
+#: src/muuli_wdr.cpp:2225
 msgid "Reset any changes made to the preferences."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2282
+#: src/muuli_wdr.cpp:2254
 msgid "Comment :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2289
+#: src/muuli_wdr.cpp:2261
 msgid "Incoming Dir :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2298
+#: src/muuli_wdr.cpp:2270
 msgid "Change priority for new assigned files :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2302
+#: src/muuli_wdr.cpp:2274
 msgid "Don't change"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2314
+#: src/muuli_wdr.cpp:2286
 msgid "Select color for this Category (currently selected) :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2381 src/muuli_wdr.cpp:2400 src/muuli_wdr.cpp:2422
+#: src/muuli_wdr.cpp:2353 src/muuli_wdr.cpp:2372 src/muuli_wdr.cpp:2394
 msgid "Click this button to reset the log."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2441
+#: src/muuli_wdr.cpp:2413
 msgid "Click on this button to update the servers list from URL ..."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2445
+#: src/muuli_wdr.cpp:2417
 msgid "Server list"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2449
+#: src/muuli_wdr.cpp:2421
 msgid "Enter the url to a server.met file here and press the button to the left to update the list of known servers."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2454
+#: src/muuli_wdr.cpp:2426
 msgid "Add server manually: Name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2457
+#: src/muuli_wdr.cpp:2429
 msgid "Enter the name of the new server here"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2459 src/ServerWnd.cpp:206
+#: src/muuli_wdr.cpp:2431 src/ServerWnd.cpp:206
 msgid "IP:Port"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2462
+#: src/muuli_wdr.cpp:2434
 msgid "Enter the IP of the server here, using the x.x.x.x format."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2468
+#: src/muuli_wdr.cpp:2440
 msgid "Enter the port of the server here."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2471
+#: src/muuli_wdr.cpp:2443
 msgid "Add manually a server (fill fields to the left before) ..."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2500
+#: src/muuli_wdr.cpp:2472
 msgid "aMule Log"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2508
+#: src/muuli_wdr.cpp:2480
 msgid "Server Info"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2512
+#: src/muuli_wdr.cpp:2484
 msgid "ED2K Info"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2516
+#: src/muuli_wdr.cpp:2488
 msgid "Kad Info"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2544
+#: src/muuli_wdr.cpp:2516
 msgid "Click on this button to update the nodes list from URL ..."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2548
+#: src/muuli_wdr.cpp:2520
 msgid "Nodes (0)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2552
+#: src/muuli_wdr.cpp:2524
 msgid "Enter the url to a nodes.dat file here and press the button to the left to update the list of known nodes."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2555
+#: src/muuli_wdr.cpp:2527
 msgid "Nodes stats"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2597
+#: src/muuli_wdr.cpp:2569
 msgid "Bootstrap"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2600
+#: src/muuli_wdr.cpp:2572
 msgid "New node"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2605
+#: src/muuli_wdr.cpp:2577
 msgid "IP:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2625
+#: src/muuli_wdr.cpp:2597
 msgid "Port:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2638
+#: src/muuli_wdr.cpp:2610
 msgid "Bootstrap from known clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2640
+#: src/muuli_wdr.cpp:2612
 msgid "Disconnect Kad"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2674
+#: src/muuli_wdr.cpp:2646
 msgid "Use Secure User Identification"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2676
+#: src/muuli_wdr.cpp:2648
 msgid "It is recommended to enable this option. You will not receive credits if SUI is not enabled."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2678
+#: src/muuli_wdr.cpp:2650
 msgid "Protocol Obfuscation"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2681
+#: src/muuli_wdr.cpp:2653
 msgid "Support Protocol Obfuscation"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2683
+#: src/muuli_wdr.cpp:2655
 msgid "This option enabled Protocol Obfuscation, and makes aMule accept obfuscated connections from other clients."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2685
+#: src/muuli_wdr.cpp:2657
 msgid "Use obfuscation for outgoing connections"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2687
+#: src/muuli_wdr.cpp:2659
 msgid "This option makes aMule use Protocol Obfuscation when connecting other clients/servers."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2689
+#: src/muuli_wdr.cpp:2661
 msgid "Accept only obfuscated connections"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2690
+#: src/muuli_wdr.cpp:2662
 msgid "This option makes aMule only accept obfuscated connections. You will have less sources, but all your traffic will be obfuscated"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2695
+#: src/muuli_wdr.cpp:2667
 msgid "Everybody"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2697
+#: src/muuli_wdr.cpp:2669
 msgid "No one"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2699
+#: src/muuli_wdr.cpp:2671
 msgid "Who can see my shared files:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2700
+#: src/muuli_wdr.cpp:2672
 msgid "Select who can request to view a list of your shared files."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2702
+#: src/muuli_wdr.cpp:2674
 msgid "IP-Filtering"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2709
+#: src/muuli_wdr.cpp:2681
 msgid "Filter clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2711
+#: src/muuli_wdr.cpp:2683
 msgid "Enable filtering of the client IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2713
+#: src/muuli_wdr.cpp:2685
 msgid "Filter servers"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2715
+#: src/muuli_wdr.cpp:2687
 msgid "Enable filtering of the server IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2719
+#: src/muuli_wdr.cpp:2691
 msgid "Reload List"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2720
+#: src/muuli_wdr.cpp:2692
 msgid "Reload the list of IPs to filter from the file ~/.aMule/ipfilter.dat"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2726
+#: src/muuli_wdr.cpp:2698
 msgid "URL:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2730 src/muuli_wdr.cpp:2923
+#: src/muuli_wdr.cpp:2702 src/muuli_wdr.cpp:2895
 msgid "Update now"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2733
+#: src/muuli_wdr.cpp:2705
 msgid "Auto-update ipfilter at startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2737
+#: src/muuli_wdr.cpp:2709
 msgid "Filtering Level:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2743
+#: src/muuli_wdr.cpp:2715
 msgid "Always filter LAN IPs"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2746
+#: src/muuli_wdr.cpp:2718
 msgid "Paranoid handling of non-matching IPs"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2748
+#: src/muuli_wdr.cpp:2720
 msgid "Rejects a packet when its source IP differs from the IP the client claims (an anti-spoofing check). Disable only if it causes connection problems."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2750
+#: src/muuli_wdr.cpp:2722
 msgid "Use system-wide ipfilter.dat if available"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2751
+#: src/muuli_wdr.cpp:2723
 msgid "If there's no local ipfilter.dat found, allow usage of a system-wide ipfilter file."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2768
+#: src/muuli_wdr.cpp:2740
 msgid "Enable Online-Signature"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2770
+#: src/muuli_wdr.cpp:2742
 msgid "Enables the writing of the OS file, which can be used by external apps to create signatures and the like."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2774
+#: src/muuli_wdr.cpp:2746
 msgid "Update Frequency (Secs):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2777
+#: src/muuli_wdr.cpp:2749
 msgid "Change the frequency (in seconds) of Online Signature updates."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2785
+#: src/muuli_wdr.cpp:2757
 msgid "Save online signature file in: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:2791
+#: src/muuli_wdr.cpp:2763
 msgid "Click here to select the directory containing the the Online Signature files."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2824
+#: src/muuli_wdr.cpp:2796
 msgid "Show country flags for clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2825
+#: src/muuli_wdr.cpp:2797
 msgid "Render the country flag column in the transfers, queue and search views. Requires a valid MMDB GeoIP database (see below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2830
+#: src/muuli_wdr.cpp:2802
 msgid "Database"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2846
+#: src/muuli_wdr.cpp:2818
 msgid "Source:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2849
+#: src/muuli_wdr.cpp:2821
 msgid "DB-IP (free, no account)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2850
+#: src/muuli_wdr.cpp:2822
 msgid "MaxMind GeoLite2 (free, account required)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2851
+#: src/muuli_wdr.cpp:2823
 msgid "Custom URL"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2854
+#: src/muuli_wdr.cpp:2826
 msgid "Choose which provider supplies the GeoIP MMDB database. DB-IP is the default - no account required. MaxMind requires a free account + license key. Use Custom URL to point at any other MMDB host (e.g. a local mirror)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2871
+#: src/muuli_wdr.cpp:2843
 msgid ""
 "No configuration required.\n"
 "\n"
@@ -4754,11 +4724,11 @@ msgid ""
 "License: Creative Commons BY 4.0 - https://creativecommons.org/licenses/by/4.0/"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2884
+#: src/muuli_wdr.cpp:2856
 msgid "License key:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2890
+#: src/muuli_wdr.cpp:2862
 msgid ""
 "Sign up for a free MaxMind account, then generate a License Key:\n"
 "https://www.maxmind.com/en/geolite2/signup\n"
@@ -4768,222 +4738,222 @@ msgid ""
 "Requires attribution and account registration; refresh at least every 30 days."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2905
+#: src/muuli_wdr.cpp:2877
 msgid "Download URL:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2911
+#: src/muuli_wdr.cpp:2883
 msgid ""
 "Must point to an .mmdb file or a .gz / .tar.gz containing one.\n"
 "URL may include credentials (https://user:pass@host/...).\n"
 "License and attribution terms are set by the upstream URL - you are responsible."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2924
+#: src/muuli_wdr.cpp:2896
 msgid "Download the GeoIP database from the selected source."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2926
+#: src/muuli_wdr.cpp:2898
 msgid "Auto-update on startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2927
+#: src/muuli_wdr.cpp:2899
 msgid "Re-download the GeoIP database from the selected source every time aMule starts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2950
+#: src/muuli_wdr.cpp:2922
 msgid "Filter incoming messages (except current chat):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2952
+#: src/muuli_wdr.cpp:2924
 msgid "Filter all messages"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2954
+#: src/muuli_wdr.cpp:2926
 msgid "Filter messages from people not on your friend list"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2956
+#: src/muuli_wdr.cpp:2928
 msgid "Filter messages from unknown clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2958
+#: src/muuli_wdr.cpp:2930
 msgid "Filter messages containing (use ',' as separator):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2961 src/muuli_wdr.cpp:2972
+#: src/muuli_wdr.cpp:2933 src/muuli_wdr.cpp:2944
 msgid "add here the words amule should filter and block messages including it"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2963
+#: src/muuli_wdr.cpp:2935
 msgid "Show received messages in the log"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2966
+#: src/muuli_wdr.cpp:2938
 msgid "Comments"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2969
+#: src/muuli_wdr.cpp:2941
 msgid "Filter comments containing (use ',' as separator):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2994
+#: src/muuli_wdr.cpp:2966
 msgid "Enable Proxy"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2995
+#: src/muuli_wdr.cpp:2967
 msgid "Enable/disable proxy support"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2998
+#: src/muuli_wdr.cpp:2970
 msgid "Proxy type:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3009
+#: src/muuli_wdr.cpp:2981
 msgid "Proxy host:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3012
+#: src/muuli_wdr.cpp:2984
 msgid "The proxy host name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3014
+#: src/muuli_wdr.cpp:2986
 msgid "Proxy port:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3017
+#: src/muuli_wdr.cpp:2989
 msgid "The proxy port"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3019
+#: src/muuli_wdr.cpp:2991
 msgid "Enable authentication"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3020
+#: src/muuli_wdr.cpp:2992
 msgid "Enable/disable username/password authentication"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3023
+#: src/muuli_wdr.cpp:2995
 msgid "Username: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:3026
+#: src/muuli_wdr.cpp:2998
 msgid "The username to use to connect to the proxy"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3028
+#: src/muuli_wdr.cpp:3000
 msgid "Password:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3031
+#: src/muuli_wdr.cpp:3003
 msgid "The password to use to connect to the proxy"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3050
+#: src/muuli_wdr.cpp:3022
 msgid "Connect to:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3059
+#: src/muuli_wdr.cpp:3031
 msgid "Login to remote amule"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3064
+#: src/muuli_wdr.cpp:3036
 msgid "User name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3075
+#: src/muuli_wdr.cpp:3047
 msgid "Remember those settings"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3078
+#: src/muuli_wdr.cpp:3050
 msgid "Force ZLIB compression"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3102
+#: src/muuli_wdr.cpp:3074
 msgid "Enable Verbose Debug-Logging."
 msgstr ""
 
-#: src/muuli_wdr.cpp:3104
+#: src/muuli_wdr.cpp:3076
 msgid "Only to Logfile"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3106
+#: src/muuli_wdr.cpp:3078
 msgid "Message Categories:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3130 src/PartFileConvertDlg.cpp:160
+#: src/muuli_wdr.cpp:3102 src/PartFileConvertDlg.cpp:160
 msgid "Waiting..."
 msgstr ""
 
-#: src/muuli_wdr.cpp:3150
+#: src/muuli_wdr.cpp:3122
 msgid "Add imports"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3153
+#: src/muuli_wdr.cpp:3125
 msgid "Retry selected"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3155
+#: src/muuli_wdr.cpp:3127
 msgid "Remove selected"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3218
+#: src/muuli_wdr.cpp:3190
 msgid "Event Types"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3237
+#: src/muuli_wdr.cpp:3209
 msgid "Statistics and queued clients for selected file(s) : Session / All time"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3261
+#: src/muuli_wdr.cpp:3233
 msgid "Active Uploads"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3275
+#: src/muuli_wdr.cpp:3247
 msgid "Percent of total files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3327
+#: src/muuli_wdr.cpp:3299
 msgid "Show Clients for"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3329
+#: src/muuli_wdr.cpp:3301
 msgid "All files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3332
+#: src/muuli_wdr.cpp:3304
 msgid "Selected files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3335
+#: src/muuli_wdr.cpp:3307
 msgid "Active uploads only"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3342
+#: src/muuli_wdr.cpp:3314
 msgid "Reload:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3346
+#: src/muuli_wdr.cpp:3318
 msgid "Reload your shared files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3409
+#: src/muuli_wdr.cpp:3381
 msgid "Send"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3410
+#: src/muuli_wdr.cpp:3382
 msgid "Sends the specified message."
 msgstr ""
 
-#: src/muuli_wdr.cpp:3414
+#: src/muuli_wdr.cpp:3386
 msgid "Close this chat-session."
 msgstr ""
 
-#: src/muuli_wdr.cpp:3437
+#: src/muuli_wdr.cpp:3409
 msgid "Connect to any server and/or Kad"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3443 src/SharedFilesCtrl.cpp:142 src/Statistics.cpp:941
+#: src/muuli_wdr.cpp:3415 src/SharedFilesCtrl.cpp:142 src/Statistics.cpp:941
 msgid "Shared Files"
 msgstr ""
 
@@ -5341,263 +5311,263 @@ msgstr ""
 msgid "ERROR: Failed to open partfile '%s'"
 msgstr ""
 
-#: src/Preferences.cpp:701
+#: src/Preferences.cpp:673
 msgid "System default"
 msgstr ""
 
-#: src/Preferences.cpp:702
+#: src/Preferences.cpp:674
 msgid "Albanian"
 msgstr ""
 
-#: src/Preferences.cpp:703
+#: src/Preferences.cpp:675
 msgid "Arabic"
 msgstr ""
 
-#: src/Preferences.cpp:704
+#: src/Preferences.cpp:676
 msgid "Asturian"
 msgstr ""
 
-#: src/Preferences.cpp:705
+#: src/Preferences.cpp:677
 msgid "Basque"
 msgstr ""
 
-#: src/Preferences.cpp:706
+#: src/Preferences.cpp:678
 msgid "Bulgarian"
 msgstr ""
 
-#: src/Preferences.cpp:707
+#: src/Preferences.cpp:679
 msgid "Catalan"
 msgstr ""
 
-#: src/Preferences.cpp:708
+#: src/Preferences.cpp:680
 msgid "Chinese (Simplified)"
 msgstr ""
 
-#: src/Preferences.cpp:709
+#: src/Preferences.cpp:681
 msgid "Chinese (Traditional)"
 msgstr ""
 
-#: src/Preferences.cpp:710
+#: src/Preferences.cpp:682
 msgid "Croatian"
 msgstr ""
 
-#: src/Preferences.cpp:711
+#: src/Preferences.cpp:683
 msgid "Czech"
 msgstr ""
 
-#: src/Preferences.cpp:712
+#: src/Preferences.cpp:684
 msgid "Danish"
 msgstr ""
 
-#: src/Preferences.cpp:713
+#: src/Preferences.cpp:685
 msgid "Dutch"
 msgstr ""
 
-#: src/Preferences.cpp:714
+#: src/Preferences.cpp:686
 msgid "English (U.K.)"
 msgstr ""
 
-#: src/Preferences.cpp:715
+#: src/Preferences.cpp:687
 msgid "English (U.S.)"
 msgstr ""
 
-#: src/Preferences.cpp:716
+#: src/Preferences.cpp:688
 msgid "Estonian"
 msgstr ""
 
-#: src/Preferences.cpp:717
+#: src/Preferences.cpp:689
 msgid "Finnish"
 msgstr ""
 
-#: src/Preferences.cpp:718
+#: src/Preferences.cpp:690
 msgid "French"
 msgstr ""
 
-#: src/Preferences.cpp:719
+#: src/Preferences.cpp:691
 msgid "Galician"
 msgstr ""
 
-#: src/Preferences.cpp:720
+#: src/Preferences.cpp:692
 msgid "German"
 msgstr ""
 
-#: src/Preferences.cpp:721
+#: src/Preferences.cpp:693
 msgid "Greek"
 msgstr ""
 
-#: src/Preferences.cpp:722
+#: src/Preferences.cpp:694
 msgid "Hebrew"
 msgstr ""
 
-#: src/Preferences.cpp:723
+#: src/Preferences.cpp:695
 msgid "Hungarian"
 msgstr ""
 
-#: src/Preferences.cpp:724
+#: src/Preferences.cpp:696
 msgid "Italian"
 msgstr ""
 
-#: src/Preferences.cpp:725
+#: src/Preferences.cpp:697
 msgid "Japanese"
 msgstr ""
 
-#: src/Preferences.cpp:726
+#: src/Preferences.cpp:698
 msgid "Korean"
 msgstr ""
 
-#: src/Preferences.cpp:727
+#: src/Preferences.cpp:699
 msgid "Latvian"
 msgstr ""
 
-#: src/Preferences.cpp:728
+#: src/Preferences.cpp:700
 msgid "Lithuanian"
 msgstr ""
 
-#: src/Preferences.cpp:729
+#: src/Preferences.cpp:701
 msgid "Norwegian (Nynorsk)"
 msgstr ""
 
-#: src/Preferences.cpp:730
+#: src/Preferences.cpp:702
 msgid "Polish"
 msgstr ""
 
-#: src/Preferences.cpp:731
+#: src/Preferences.cpp:703
 msgid "Portuguese"
 msgstr ""
 
-#: src/Preferences.cpp:732
+#: src/Preferences.cpp:704
 msgid "Portuguese (Brazilian)"
 msgstr ""
 
-#: src/Preferences.cpp:733
+#: src/Preferences.cpp:705
 msgid "Romanian"
 msgstr ""
 
-#: src/Preferences.cpp:734
+#: src/Preferences.cpp:706
 msgid "Russian"
 msgstr ""
 
-#: src/Preferences.cpp:735
+#: src/Preferences.cpp:707
 msgid "Slovenian"
 msgstr ""
 
-#: src/Preferences.cpp:736
+#: src/Preferences.cpp:708
 msgid "Spanish"
 msgstr ""
 
-#: src/Preferences.cpp:737
+#: src/Preferences.cpp:709
 msgid "Swedish"
 msgstr ""
 
-#: src/Preferences.cpp:738
+#: src/Preferences.cpp:710
 msgid "Turkish"
 msgstr ""
 
-#: src/Preferences.cpp:739
+#: src/Preferences.cpp:711
 msgid "Ukrainian"
 msgstr ""
 
-#: src/Preferences.cpp:842
+#: src/Preferences.cpp:814
 msgid "Change Language"
 msgstr ""
 
-#: src/Preferences.cpp:906
+#: src/Preferences.cpp:878
 msgid "There are no translations installed for aMule"
 msgstr ""
 
-#: src/Preferences.cpp:907
+#: src/Preferences.cpp:879
 msgid "No languages available"
 msgstr ""
 
-#: src/Preferences.cpp:1038
+#: src/Preferences.cpp:1010
 msgid "no options available"
 msgstr ""
 
-#: src/Preferences.cpp:2226
+#: src/Preferences.cpp:2179
 msgid "Invalid category found, skipping"
 msgstr ""
 
-#: src/Preferences.cpp:2395
+#: src/Preferences.cpp:2348
 msgid "TCP port can't be higher than 65532 due to server UDP socket being TCP+3"
 msgstr ""
 
-#: src/Preferences.cpp:2396
+#: src/Preferences.cpp:2349
 #, c-format
 msgid "Default port will be used (%d)"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:300 src/Statistics.cpp:866
+#: src/PrefsUnifiedDlg.cpp:298 src/Statistics.cpp:866
 msgid "Connection"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:301 src/SearchListCtrl.cpp:117
+#: src/PrefsUnifiedDlg.cpp:299 src/SearchListCtrl.cpp:117
 msgid "Directories"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:302 src/Statistics.cpp:917
+#: src/PrefsUnifiedDlg.cpp:300 src/Statistics.cpp:917
 msgid "Servers"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:303 src/ServerListCtrl.cpp:96
+#: src/PrefsUnifiedDlg.cpp:301 src/ServerListCtrl.cpp:96
 msgid "Files"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:304
+#: src/PrefsUnifiedDlg.cpp:302
 msgid "Security"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:305
+#: src/PrefsUnifiedDlg.cpp:303
 msgid "Interface"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:312
+#: src/PrefsUnifiedDlg.cpp:310
 msgid "IP2Country"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:315
+#: src/PrefsUnifiedDlg.cpp:313
 msgid "Proxy"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:316
+#: src/PrefsUnifiedDlg.cpp:314
 msgid "Filters"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:317
+#: src/PrefsUnifiedDlg.cpp:315
 msgid "Remote Controls"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:318
+#: src/PrefsUnifiedDlg.cpp:316
 msgid "Online Signature"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:319
+#: src/PrefsUnifiedDlg.cpp:317
 msgid "Advanced"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:320
+#: src/PrefsUnifiedDlg.cpp:318
 msgid "Events"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:323
+#: src/PrefsUnifiedDlg.cpp:321
 msgid "Debugging"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:453
+#: src/PrefsUnifiedDlg.cpp:451
 msgid ""
 "The following variables will be substituted:\n"
 "    %PARTFILE - full path to the file\n"
 "    %PARTNAME - file name only"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:474
+#: src/PrefsUnifiedDlg.cpp:472
 msgid "Tray icon support requires libayatana-appindicator3 at compile time."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:490
+#: src/PrefsUnifiedDlg.cpp:488
 msgid "Not available on Wayland: the protocol does not report when a window is minimized, so this option cannot intercept the system minimize button. Workaround: launch aMule with `GDK_BACKEND=x11` to use XWayland instead."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:536
+#: src/PrefsUnifiedDlg.cpp:534
 msgid ""
 "Do not change these setting unless you know\n"
 "what you are doing, otherwise you can easily\n"
@@ -5607,424 +5577,407 @@ msgid ""
 "these settings."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:647
+#: src/PrefsUnifiedDlg.cpp:645
 #, c-format
 msgid "Failed to connect Cfg to widget with the ID %d and key %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:695
+#: src/PrefsUnifiedDlg.cpp:693
 #, c-format
 msgid "Failed to transfer data from Cfg to Widget with the ID %d and key %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:801
+#: src/PrefsUnifiedDlg.cpp:799
 msgid "The type of proxy you are connecting to"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1020
+#: src/PrefsUnifiedDlg.cpp:1003
 #, c-format
 msgid "Failed to transfer data from Widget to Cfg with the ID %d and key %s"
 msgstr ""
 
 #: src/PrefsUnifiedDlg.cpp:1103
-msgid "No password set."
-msgstr ""
-
-#: src/PrefsUnifiedDlg.cpp:1132
-msgid "Guest access needs a password. Type one in the guest password field, or untick Enable guest access."
-msgstr ""
-
-#: src/PrefsUnifiedDlg.cpp:1144
 msgid ""
 "aMule must be restarted to enable these changes:\n"
 "\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1151
+#: src/PrefsUnifiedDlg.cpp:1110
 msgid "- TCP port changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1156
+#: src/PrefsUnifiedDlg.cpp:1115
 msgid "- UDP port changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1161
+#: src/PrefsUnifiedDlg.cpp:1120
 msgid "- Network interface binding changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1166
+#: src/PrefsUnifiedDlg.cpp:1125
 msgid "- External connect port changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1170
+#: src/PrefsUnifiedDlg.cpp:1129
 msgid "- External connect acceptance changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1174
+#: src/PrefsUnifiedDlg.cpp:1133
 msgid "- External connect interface changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1178
+#: src/PrefsUnifiedDlg.cpp:1137
 msgid "- Protocol obfuscation support changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1193
+#: src/PrefsUnifiedDlg.cpp:1151
 msgid "- amuleapi settings changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1202
+#: src/PrefsUnifiedDlg.cpp:1160
 msgid ""
 "Your Auto-update server list is empty.\n"
 "'Auto-update server list at startup' will be disabled."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1213
+#: src/PrefsUnifiedDlg.cpp:1171
 msgid ""
 "You have enabled external connections but have not specified a password.\n"
 "External connections cannot be enabled unless a valid password is specified."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1246
-#, c-format
-msgid "The amuleapi password could not be saved: %s"
-msgstr ""
-
-#: src/PrefsUnifiedDlg.cpp:1276
+#: src/PrefsUnifiedDlg.cpp:1202
 msgid "- Language changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1281
+#: src/PrefsUnifiedDlg.cpp:1207
 msgid "- Temp folder changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1286
+#: src/PrefsUnifiedDlg.cpp:1212
 msgid "- ED2K network enabled.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1319
+#: src/PrefsUnifiedDlg.cpp:1245
 msgid "The shared-file exclusion pattern is not a valid regular expression. The filter has been left disabled."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1321 src/PrefsUnifiedDlg.cpp:1921
+#: src/PrefsUnifiedDlg.cpp:1247 src/PrefsUnifiedDlg.cpp:1841
 msgid "Invalid regular expression"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1398
+#: src/PrefsUnifiedDlg.cpp:1324
 msgid ""
 "Both eD2k and Kad network are disabled.\n"
 "You won't be able to connect until you enable at least one of them."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1403
+#: src/PrefsUnifiedDlg.cpp:1329
 msgid ""
 "Kad will not start if your UDP port is disabled.\n"
 "Enable UDP port or disable Kad."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1459
+#: src/PrefsUnifiedDlg.cpp:1385
 msgid ""
 "\n"
 "You MUST restart aMule now.\n"
 "If you do not restart now, don't complain if anything bad happens.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1524
+#: src/PrefsUnifiedDlg.cpp:1450
 msgid "Could not register aMule for autostart at login. The autostart store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1526
+#: src/PrefsUnifiedDlg.cpp:1452
 msgid "Could not remove the autostart-at-login entry."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1527
+#: src/PrefsUnifiedDlg.cpp:1453
 msgid "Autostart"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1542
+#: src/PrefsUnifiedDlg.cpp:1468
 msgid "Register file type"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1542
+#: src/PrefsUnifiedDlg.cpp:1468
 msgid "Register URL handler"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1550
+#: src/PrefsUnifiedDlg.cpp:1476
 #, c-format
 msgid "aMule only handles eD2k-compatible magnets. If you replace the current magnet handler (%s), BitTorrent magnet links will stop working - aMule cannot download BitTorrent content. Continue?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1555
+#: src/PrefsUnifiedDlg.cpp:1481
 #, c-format
 msgid "Another application currently opens .emulecollection files (%s). Replace it with aMule?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1560
+#: src/PrefsUnifiedDlg.cpp:1486
 #, c-format
 msgid "Another application is currently the default handler for these links (%s). Replace it with aMule?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1585
+#: src/PrefsUnifiedDlg.cpp:1511
 msgid "Could not register aMule for .emulecollection files. The registration store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1587
+#: src/PrefsUnifiedDlg.cpp:1513
 msgid "Could not remove the file type registration."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1589
+#: src/PrefsUnifiedDlg.cpp:1515
 msgid "Could not register aMule as the URL handler. The registration store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1591
+#: src/PrefsUnifiedDlg.cpp:1517
 msgid "Could not remove the URL handler registration."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1661 src/PrefsUnifiedDlg.cpp:1688
+#: src/PrefsUnifiedDlg.cpp:1587 src/PrefsUnifiedDlg.cpp:1614
 msgid "The web server and aMule API require external connections to be enabled."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1671
+#: src/PrefsUnifiedDlg.cpp:1597
 msgid "The aMule web server is deprecated. Consider running the aMule API instead."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1735
+#: src/PrefsUnifiedDlg.cpp:1655
 msgid ""
 "Your Auto-update servers list is in blank.\n"
 "Please fill in at least one URL to point to a valid server.met file.\n"
 "Click on the button \"List\" by this checkbox to enter an URL."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1876
+#: src/PrefsUnifiedDlg.cpp:1796
 msgid "Temporary files"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1881
+#: src/PrefsUnifiedDlg.cpp:1801
 msgid "Incoming files"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1886
+#: src/PrefsUnifiedDlg.cpp:1806
 msgid "Online Signatures"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1899
+#: src/PrefsUnifiedDlg.cpp:1819
 #, c-format
 msgid "Choose a folder for %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1923
+#: src/PrefsUnifiedDlg.cpp:1843
 #, c-format
 msgid "Would exclude %u of %u shared file"
 msgid_plural "Would exclude %u of %u shared files"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/PrefsUnifiedDlg.cpp:1940
+#: src/PrefsUnifiedDlg.cpp:1860
 msgid "Browse for videoplayer"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1944
+#: src/PrefsUnifiedDlg.cpp:1864
 msgid "Select browser"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1948
+#: src/PrefsUnifiedDlg.cpp:1868
 msgid "Select ffprobe binary"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1954
+#: src/PrefsUnifiedDlg.cpp:1874
 #, c-format
 msgid "Executable%s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1988
+#: src/PrefsUnifiedDlg.cpp:1908
 msgid "ffprobe not found on PATH or in the standard install locations. Install ffmpeg (which ships ffprobe) or use Browse to pick a binary manually."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2000
+#: src/PrefsUnifiedDlg.cpp:1920
 msgid "Reset the settings on this page to their default values?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2001
+#: src/PrefsUnifiedDlg.cpp:1921
 msgid "Reset to defaults"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2028
+#: src/PrefsUnifiedDlg.cpp:1948
 msgid "Edit server list"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2029
+#: src/PrefsUnifiedDlg.cpp:1949
 msgid ""
 "Add here URL's to download server.met files.\n"
 "Only one url on each line."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2084
+#: src/PrefsUnifiedDlg.cpp:2004
 msgid "IP2Country update failed"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2229 src/PrefsUnifiedDlg.cpp:2260
+#: src/PrefsUnifiedDlg.cpp:2149 src/PrefsUnifiedDlg.cpp:2180
 msgid "Data by MaxMind GeoLite2"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2231 src/PrefsUnifiedDlg.cpp:2262
+#: src/PrefsUnifiedDlg.cpp:2151 src/PrefsUnifiedDlg.cpp:2182
 msgid "Custom source"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2233 src/PrefsUnifiedDlg.cpp:2264
+#: src/PrefsUnifiedDlg.cpp:2153 src/PrefsUnifiedDlg.cpp:2184
 msgid "Data by DB-IP.com"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2284
+#: src/PrefsUnifiedDlg.cpp:2204
 #, c-format
 msgid "Status: Loaded%s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2286
+#: src/PrefsUnifiedDlg.cpp:2206
 #, c-format
 msgid "Status: Loaded%s - %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2290
+#: src/PrefsUnifiedDlg.cpp:2210
 msgid "Status: Failed to load - click 'Update now' to refresh."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2292
+#: src/PrefsUnifiedDlg.cpp:2212
 msgid "Status: Not found - click 'Update now' to download."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2350 src/PrefsUnifiedDlg.cpp:2374
+#: src/PrefsUnifiedDlg.cpp:2270 src/PrefsUnifiedDlg.cpp:2294
 #, c-format
 msgid "Update delay: %d second"
 msgid_plural "Update delay: %d seconds"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/PrefsUnifiedDlg.cpp:2358
+#: src/PrefsUnifiedDlg.cpp:2278
 #, c-format
 msgid "Time for average graph: %d minute"
 msgid_plural "Time for average graph: %d minutes"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/PrefsUnifiedDlg.cpp:2367
+#: src/PrefsUnifiedDlg.cpp:2287
 #, c-format
 msgid "Connections Graph Scale: %d"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2382
+#: src/PrefsUnifiedDlg.cpp:2302
 #, c-format
 msgid "File Buffer Size: %d byte"
 msgid_plural "File Buffer Size: %d bytes"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/PrefsUnifiedDlg.cpp:2392
+#: src/PrefsUnifiedDlg.cpp:2312
 #, c-format
 msgid "Upload Queue Size: %d client"
 msgid_plural "Upload Queue Size: %d clients"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/PrefsUnifiedDlg.cpp:2402
+#: src/PrefsUnifiedDlg.cpp:2322
 #, c-format
 msgid "Server connection refresh interval: %d minute"
 msgid_plural "Server connection refresh interval: %d minutes"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/PrefsUnifiedDlg.cpp:2407
+#: src/PrefsUnifiedDlg.cpp:2327
 msgid "Server connection refresh interval: Disabled"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2451
+#: src/PrefsUnifiedDlg.cpp:2371
 msgid "disabled"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2477
+#: src/PrefsUnifiedDlg.cpp:2397
 #, c-format
 msgid "Execute command on '%s' event"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2484
+#: src/PrefsUnifiedDlg.cpp:2404
 msgid "Enable command execution on core"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2496
+#: src/PrefsUnifiedDlg.cpp:2416
 msgid "Core command:"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2512
+#: src/PrefsUnifiedDlg.cpp:2432
 msgid "Enable command execution on GUI"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2524
+#: src/PrefsUnifiedDlg.cpp:2444
 msgid "GUI command:"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2540
+#: src/PrefsUnifiedDlg.cpp:2460
 msgid "The following variables will be replaced:"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2708
+#: src/PrefsUnifiedDlg.cpp:2628
 msgid ""
 "The following folders look like system or sensitive locations:\n"
 "\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2713
+#: src/PrefsUnifiedDlg.cpp:2633
 msgid "Sharing them recursively will publish every file underneath on the eD2k/Kad networks. Do you really want to do this?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2716
+#: src/PrefsUnifiedDlg.cpp:2636
 msgid "Confirm shared folders"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2744
+#: src/PrefsUnifiedDlg.cpp:2664
 msgid "Reloading shared files..."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2745
+#: src/PrefsUnifiedDlg.cpp:2665
 msgid "Scanning for subdirectories..."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2746
+#: src/PrefsUnifiedDlg.cpp:2666
 msgid "Updating shared folders"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2773
+#: src/PrefsUnifiedDlg.cpp:2693
 #, c-format
 msgid "Scanned %u directories..."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2823
+#: src/PrefsUnifiedDlg.cpp:2743
 #, c-format
 msgid "Reloading shared files: %u files scanned"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2873
+#: src/PrefsUnifiedDlg.cpp:2793
 msgid "Shared folder"
 msgstr ""
 
-#: src/SearchDlg.cpp:280
-msgid "Clear search history"
-msgstr ""
-
-#: src/SearchDlg.cpp:584
+#: src/SearchDlg.cpp:425
 msgid "It's impossible to search when both eD2k and Kademlia are disabled."
 msgstr ""
 
-#: src/SearchDlg.cpp:585 src/SearchListCtrl.cpp:858
+#: src/SearchDlg.cpp:426 src/SearchListCtrl.cpp:858
 msgid "Search error"
 msgstr ""
 
-#: src/SearchDlg.cpp:929
+#: src/SearchDlg.cpp:768
 msgid "Min size must be smaller than max size. Max size ignored."
 msgstr ""
 
-#: src/SearchDlg.cpp:930 src/SearchDlg.cpp:1012
+#: src/SearchDlg.cpp:769 src/SearchDlg.cpp:851
 msgid "Search warning"
 msgstr ""
 
-#: src/SearchDlg.cpp:1092 src/SearchListCtrl.cpp:735
+#: src/SearchDlg.cpp:929 src/SearchListCtrl.cpp:735
 msgid "Main"
 msgstr ""
 

--- a/po/en_GB.po
+++ b/po/en_GB.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-28 08:06+0200\n"
+"POT-Creation-Date: 2026-07-28 10:19+0200\n"
 "PO-Revision-Date: 2020-03-04 14:43+0100\n"
 "Last-Translator: Dévai Tamás <devait@vnet.hu>\n"
 "Language-Team: aMule Team <https://github.com/amule-org/amule>\n"
@@ -132,7 +132,7 @@ msgstr ""
 msgid "Not now"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:422 src/amuleDlg.cpp:600
+#: src/AppImageIntegration.cpp:422 src/amuleDlg.cpp:665
 msgid "Don't ask again"
 msgstr ""
 
@@ -204,7 +204,7 @@ msgid "Killing amuleweb instance with pid '%d' ... "
 msgstr ""
 
 #: src/amule.cpp:336 src/amule.cpp:349 src/ClientRef.cpp:180
-#: src/SearchDlg.cpp:880 src/ServerListCtrl.cpp:98
+#: src/SearchDlg.cpp:1041 src/ServerListCtrl.cpp:98
 msgid "Failed"
 msgstr ""
 
@@ -546,29 +546,67 @@ msgstr ""
 msgid "ERROR: %s"
 msgstr ""
 
-#: src/amuleDlg.cpp:236
+#: src/amuleDlg.cpp:250
 #, c-format
 msgid "This is aMule %s based on eMule."
 msgstr ""
 
-#: src/amuleDlg.cpp:237
+#: src/amuleDlg.cpp:251
 #, c-format
 msgid "Running on %s"
 msgstr ""
 
-#: src/amuleDlg.cpp:239
+#: src/amuleDlg.cpp:253
 msgid "Visit https://github.com/amule-org/amule/releases/latest to check if a new version is available."
 msgstr ""
 
-#: src/amuleDlg.cpp:268
+#: src/amuleDlg.cpp:282
 msgid "FATAL ERROR: Failed to create Timer"
 msgstr ""
 
-#: src/amuleDlg.cpp:592
+#: src/amuleDlg.cpp:361 src/amuleDlg.cpp:1787 src/amuleDlg.cpp:2033
+#: src/muuli_wdr.cpp:1492 src/muuli_wdr.cpp:3418
+msgid "Networks"
+msgstr ""
+
+#: src/amuleDlg.cpp:362 src/amuleDlg.cpp:1793 src/muuli_wdr.cpp:3419
+msgid "Searches"
+msgstr ""
+
+#: src/amuleDlg.cpp:363 src/amuleDlg.cpp:1799 src/DownloadListCtrl.cpp:740
+#: src/muuli_wdr.cpp:392 src/muuli_wdr.cpp:1585 src/muuli_wdr.cpp:3420
+#: src/Statistics.cpp:829
+msgid "Downloads"
+msgstr ""
+
+#: src/amuleDlg.cpp:364 src/amuleDlg.cpp:1805 src/muuli_wdr.cpp:3294
+msgid "Shared files"
+msgstr ""
+
+#: src/amuleDlg.cpp:365 src/amuleDlg.cpp:1811 src/muuli_wdr.cpp:2926
+#: src/muuli_wdr.cpp:3376 src/muuli_wdr.cpp:3423
+msgid "Messages"
+msgstr ""
+
+#: src/amuleDlg.cpp:366 src/amuleDlg.cpp:1817 src/muuli_wdr.cpp:3424
+#: src/PrefsUnifiedDlg.cpp:312 src/Statistics.cpp:779 src/Statistics.cpp:1235
+msgid "Statistics"
+msgstr ""
+
+#: src/amuleDlg.cpp:368 src/amuleDlg.cpp:1824 src/muuli_wdr.cpp:3426
+#: src/PrefsUnifiedDlg.cpp:328 src/utils/wxCas/src/wxcasprefs.cpp:39
+msgid "Preferences"
+msgstr ""
+
+#: src/amuleDlg.cpp:371
+msgid "Navigate"
+msgstr ""
+
+#: src/amuleDlg.cpp:657
 msgid "New version available"
 msgstr ""
 
-#: src/amuleDlg.cpp:596
+#: src/amuleDlg.cpp:661
 #, c-format
 msgid ""
 "A new version of aMule (%s) is available.\n"
@@ -578,217 +616,184 @@ msgid ""
 "Would you like to open the download page?"
 msgstr ""
 
-#: src/amuleDlg.cpp:678
+#: src/amuleDlg.cpp:743
 msgid "aMule dialog destroyed"
 msgstr ""
 
-#: src/amuleDlg.cpp:701 src/DataToText.cpp:68 src/IPFilter.cpp:547
+#: src/amuleDlg.cpp:766 src/DataToText.cpp:68 src/IPFilter.cpp:547
 msgid "Connecting"
 msgstr ""
 
-#: src/amuleDlg.cpp:893
+#: src/amuleDlg.cpp:958
 msgid "eD2k: Connecting"
 msgstr ""
 
-#: src/amuleDlg.cpp:897
+#: src/amuleDlg.cpp:962
 msgid "eD2k: Disconnected"
 msgstr ""
 
-#: src/amuleDlg.cpp:903
+#: src/amuleDlg.cpp:968
 msgid "Kad: Firewalled"
 msgstr ""
 
-#: src/amuleDlg.cpp:907
+#: src/amuleDlg.cpp:972
 msgid "Kad: Connected"
 msgstr ""
 
-#: src/amuleDlg.cpp:912
+#: src/amuleDlg.cpp:977
 msgid "Kad: Connecting"
 msgstr ""
 
-#: src/amuleDlg.cpp:916
+#: src/amuleDlg.cpp:981
 msgid "Kad: Off"
 msgstr ""
 
-#: src/amuleDlg.cpp:964 src/DownloadListCtrl.cpp:505
+#: src/amuleDlg.cpp:1029 src/DownloadListCtrl.cpp:505
 #: src/DownloadListCtrl.cpp:749 src/FriendListCtrl.cpp:180
 #: src/muuli_wdr.cpp:731 src/muuli_wdr.cpp:782 src/muuli_wdr.cpp:846
-#: src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2224 src/muuli_wdr.cpp:2309
-#: src/muuli_wdr.cpp:3057 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
+#: src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2231 src/muuli_wdr.cpp:2316
+#: src/muuli_wdr.cpp:3064 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
 #: src/ServerListCtrl.cpp:606 src/TransferWnd.cpp:378
 #: src/utils/wxCas/src/wxcasprefs.cpp:235
 msgid "Cancel"
 msgstr ""
 
-#: src/amuleDlg.cpp:965
+#: src/amuleDlg.cpp:1030
 msgid "Stop the current connection attempts"
 msgstr ""
 
-#: src/amuleDlg.cpp:970 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976
-#: src/muuli_wdr.cpp:2447
+#: src/amuleDlg.cpp:1035 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976
+#: src/muuli_wdr.cpp:2454
 msgid "Disconnect"
 msgstr ""
 
-#: src/amuleDlg.cpp:971
+#: src/amuleDlg.cpp:1036
 msgid "Disconnect from the currently connected networks"
 msgstr ""
 
-#: src/amuleDlg.cpp:976 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979
-#: src/muuli_wdr.cpp:2602 src/muuli_wdr.cpp:3054 src/muuli_wdr.cpp:3409
+#: src/amuleDlg.cpp:1041 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979
+#: src/muuli_wdr.cpp:2609 src/muuli_wdr.cpp:3061 src/muuli_wdr.cpp:3416
 msgid "Connect"
 msgstr ""
 
-#: src/amuleDlg.cpp:977
+#: src/amuleDlg.cpp:1042
 msgid "Connect to the currently enabled networks"
 msgstr ""
 
-#: src/amuleDlg.cpp:1089
+#: src/amuleDlg.cpp:1154
 #, c-format
 msgid "Up: %.1f%s (%.1f) | Down: %.1f%s (%.1f)"
 msgstr ""
 
-#: src/amuleDlg.cpp:1091 src/amuleDlg.cpp:1093 src/amuleDlg.cpp:1097
-#: src/amuleDlg.cpp:1099 src/amuleDlg.cpp:1110 src/amuleDlg.cpp:1112
+#: src/amuleDlg.cpp:1156 src/amuleDlg.cpp:1158 src/amuleDlg.cpp:1162
+#: src/amuleDlg.cpp:1164 src/amuleDlg.cpp:1175 src/amuleDlg.cpp:1177
 #: src/MuleTrayIcon.cpp:796 src/MuleTrayIcon.cpp:799
 msgid " MB/s"
 msgstr ""
 
-#: src/amuleDlg.cpp:1091 src/amuleDlg.cpp:1093 src/amuleDlg.cpp:1097
-#: src/amuleDlg.cpp:1099 src/amuleDlg.cpp:1110 src/amuleDlg.cpp:1112
+#: src/amuleDlg.cpp:1156 src/amuleDlg.cpp:1158 src/amuleDlg.cpp:1162
+#: src/amuleDlg.cpp:1164 src/amuleDlg.cpp:1175 src/amuleDlg.cpp:1177
 #: src/MuleTrayIcon.cpp:796 src/MuleTrayIcon.cpp:799
 #: src/utils/wxCas/src/wxcasframe.cpp:1041
 msgid " kB/s"
 msgstr ""
 
-#: src/amuleDlg.cpp:1096
+#: src/amuleDlg.cpp:1161
 #, c-format
 msgid "Up: %.1f%s | Down: %.1f%s"
 msgstr ""
 
-#: src/amuleDlg.cpp:1128
+#: src/amuleDlg.cpp:1193
 #, c-format
 msgid "aMule (%s | Connected)"
 msgstr ""
 
-#: src/amuleDlg.cpp:1130
+#: src/amuleDlg.cpp:1195
 #, c-format
 msgid "aMule (%s | Disconnected)"
 msgstr ""
 
-#: src/amuleDlg.cpp:1183
+#: src/amuleDlg.cpp:1248
 #, c-format
 msgid "Do you really want to exit %s?"
 msgstr ""
 
-#: src/amuleDlg.cpp:1185
+#: src/amuleDlg.cpp:1250
 msgid "Exit confirmation"
 msgstr ""
 
-#: src/amuleDlg.cpp:1548
+#: src/amuleDlg.cpp:1613
 msgid "Launch Command: "
 msgstr ""
 
-#: src/amuleDlg.cpp:1567 src/muuli_wdr.cpp:1971 src/Preferences.cpp:951
+#: src/amuleDlg.cpp:1632 src/muuli_wdr.cpp:1978 src/Preferences.cpp:952
 msgid "- default -"
 msgstr ""
 
-#: src/amuleDlg.cpp:1595
+#: src/amuleDlg.cpp:1660
 #, c-format
 msgid "Skin directory '%s' does not exist"
 msgstr ""
 
-#: src/amuleDlg.cpp:1598
+#: src/amuleDlg.cpp:1663
 #, c-format
 msgid "WARNING: Unable to open skin file '%s' for read"
 msgstr ""
 
-#: src/amuleDlg.cpp:1722 src/amuleDlg.cpp:1968 src/muuli_wdr.cpp:1485
-#: src/muuli_wdr.cpp:3411
-msgid "Networks"
-msgstr ""
-
-#: src/amuleDlg.cpp:1726 src/muuli_wdr.cpp:3411
+#: src/amuleDlg.cpp:1791 src/muuli_wdr.cpp:3418
 msgid "Networks Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1728 src/muuli_wdr.cpp:3412
-msgid "Searches"
-msgstr ""
-
-#: src/amuleDlg.cpp:1732 src/muuli_wdr.cpp:3412
+#: src/amuleDlg.cpp:1797 src/muuli_wdr.cpp:3419
 msgid "Searches Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1734 src/DownloadListCtrl.cpp:740 src/muuli_wdr.cpp:392
-#: src/muuli_wdr.cpp:1578 src/muuli_wdr.cpp:3413 src/Statistics.cpp:829
-msgid "Downloads"
-msgstr ""
-
-#: src/amuleDlg.cpp:1738 src/muuli_wdr.cpp:3413
+#: src/amuleDlg.cpp:1803 src/muuli_wdr.cpp:3420
 msgid "Downloads Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1740 src/muuli_wdr.cpp:3287
-msgid "Shared files"
-msgstr ""
-
-#: src/amuleDlg.cpp:1744 src/muuli_wdr.cpp:3415
+#: src/amuleDlg.cpp:1809 src/muuli_wdr.cpp:3422
 msgid "Shared Files Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1746 src/muuli_wdr.cpp:2919 src/muuli_wdr.cpp:3369
-#: src/muuli_wdr.cpp:3416
-msgid "Messages"
-msgstr ""
-
-#: src/amuleDlg.cpp:1750 src/muuli_wdr.cpp:3416
+#: src/amuleDlg.cpp:1815 src/muuli_wdr.cpp:3423
 msgid "Messages Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1752 src/muuli_wdr.cpp:3417 src/PrefsUnifiedDlg.cpp:312
-#: src/Statistics.cpp:779 src/Statistics.cpp:1235
-msgid "Statistics"
-msgstr ""
-
-#: src/amuleDlg.cpp:1756 src/muuli_wdr.cpp:3417
+#: src/amuleDlg.cpp:1821 src/muuli_wdr.cpp:3424
 msgid "Statistics Graph Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1759 src/muuli_wdr.cpp:3419 src/PrefsUnifiedDlg.cpp:328
-#: src/utils/wxCas/src/wxcasprefs.cpp:39
-msgid "Preferences"
-msgstr ""
-
-#: src/amuleDlg.cpp:1763 src/muuli_wdr.cpp:3419
+#: src/amuleDlg.cpp:1828 src/muuli_wdr.cpp:3426
 msgid "Preferences Settings Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1766 src/muuli_wdr.cpp:3420
+#: src/amuleDlg.cpp:1831 src/muuli_wdr.cpp:3427
 msgid "Import"
 msgstr ""
 
-#: src/amuleDlg.cpp:1770 src/muuli_wdr.cpp:3420
+#: src/amuleDlg.cpp:1835 src/muuli_wdr.cpp:3427
 msgid "The partfile importer tool"
 msgstr ""
 
-#: src/amuleDlg.cpp:1773 src/muuli_wdr.cpp:3421
+#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3428
 #: src/utils/aLinkCreator/src/alcframe.cpp:262
 msgid "About"
 msgstr ""
 
-#: src/amuleDlg.cpp:1773 src/muuli_wdr.cpp:3421
+#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3428
 msgid "About/Help"
 msgstr ""
 
-#: src/amuleDlg.cpp:1971
+#: src/amuleDlg.cpp:2036
 msgid "eD2k network"
 msgstr ""
 
-#: src/amuleDlg.cpp:1974
+#: src/amuleDlg.cpp:2039
 msgid "Kad network"
 msgstr ""
 
-#: src/amuleDlg.cpp:1974
+#: src/amuleDlg.cpp:2039
 msgid "No network"
 msgstr ""
 
@@ -1315,19 +1320,19 @@ msgstr ""
 msgid "Very low"
 msgstr ""
 
-#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:743 src/muuli_wdr.cpp:2275
+#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:743 src/muuli_wdr.cpp:2282
 #: src/ServerListCtrl.cpp:263 src/ServerListCtrl.cpp:456
 #: src/SharedFilesCtrl.cpp:145
 msgid "Low"
 msgstr ""
 
-#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:744 src/muuli_wdr.cpp:2276
+#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:744 src/muuli_wdr.cpp:2283
 #: src/ServerListCtrl.cpp:266 src/ServerListCtrl.cpp:457
 #: src/SharedFilesCtrl.cpp:146
 msgid "Normal"
 msgstr ""
 
-#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:745 src/muuli_wdr.cpp:2277
+#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:745 src/muuli_wdr.cpp:2284
 #: src/ServerListCtrl.cpp:269 src/ServerListCtrl.cpp:458
 #: src/SharedFilesCtrl.cpp:147
 msgid "High"
@@ -1419,8 +1424,8 @@ msgstr ""
 msgid "Remote Server"
 msgstr ""
 
-#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3174
-#: src/SearchDlg.cpp:111 src/TextClient.cpp:911
+#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3181
+#: src/SearchDlg.cpp:119 src/TextClient.cpp:911
 msgid "Kad"
 msgstr ""
 
@@ -1490,7 +1495,7 @@ msgstr ""
 msgid "Size"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3241
+#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3248
 msgid "Transferred"
 msgstr ""
 
@@ -1546,7 +1551,7 @@ msgid ""
 "\n"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:746 src/muuli_wdr.cpp:2278
+#: src/DownloadListCtrl.cpp:746 src/muuli_wdr.cpp:2285
 #: src/SharedFilesCtrl.cpp:150
 msgid "Auto"
 msgstr ""
@@ -1584,7 +1589,7 @@ msgid "Extended Options"
 msgstr ""
 
 #: src/DownloadListCtrl.cpp:770 src/DownloadListCtrl.cpp:822
-#: src/muuli_wdr.cpp:1789
+#: src/muuli_wdr.cpp:1796
 msgid "Preview"
 msgstr ""
 
@@ -2262,19 +2267,19 @@ msgstr ""
 msgid "eD2k"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:349 src/muuli_wdr.cpp:1488
+#: src/FirstRunWizard.cpp:349 src/muuli_wdr.cpp:1495
 msgid "Kademlia"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:359 src/muuli_wdr.cpp:1416
+#: src/FirstRunWizard.cpp:359 src/muuli_wdr.cpp:1423
 msgid "Standard TCP Port "
 msgstr ""
 
-#: src/FirstRunWizard.cpp:365 src/muuli_wdr.cpp:1428
+#: src/FirstRunWizard.cpp:365 src/muuli_wdr.cpp:1435
 msgid "Extended UDP port (Kad / global search) "
 msgstr ""
 
-#: src/FirstRunWizard.cpp:377 src/muuli_wdr.cpp:1435
+#: src/FirstRunWizard.cpp:377 src/muuli_wdr.cpp:1442
 msgid "Enable UPnP for router port forwarding"
 msgstr ""
 
@@ -2299,7 +2304,7 @@ msgstr ""
 msgid "Your peer lists are already in place - nothing to download."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:434 src/muuli_wdr.cpp:1533
+#: src/FirstRunWizard.cpp:434 src/muuli_wdr.cpp:1540
 msgid "Auto-update server list at startup"
 msgstr ""
 
@@ -2345,23 +2350,23 @@ msgid ""
 "want downloads on a different (e.g. larger) disk."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:549 src/FirstRunWizard.cpp:611 src/muuli_wdr.cpp:1701
+#: src/FirstRunWizard.cpp:549 src/FirstRunWizard.cpp:611 src/muuli_wdr.cpp:1708
 msgid "Destination folder for downloads"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:553 src/FirstRunWizard.cpp:569 src/muuli_wdr.cpp:1342
-#: src/muuli_wdr.cpp:1359 src/muuli_wdr.cpp:1676 src/muuli_wdr.cpp:1707
-#: src/muuli_wdr.cpp:1719 src/muuli_wdr.cpp:2762
+#: src/FirstRunWizard.cpp:553 src/FirstRunWizard.cpp:569 src/muuli_wdr.cpp:1349
+#: src/muuli_wdr.cpp:1366 src/muuli_wdr.cpp:1683 src/muuli_wdr.cpp:1714
+#: src/muuli_wdr.cpp:1726 src/muuli_wdr.cpp:2769
 #: src/utils/aLinkCreator/src/alcframe.cpp:135
 #: src/utils/wxCas/src/wxcasprefs.cpp:52 src/utils/wxCas/src/wxcasprefs.cpp:118
 msgid "Browse"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:559 src/muuli_wdr.cpp:1712
+#: src/FirstRunWizard.cpp:559 src/muuli_wdr.cpp:1719
 msgid "(All files in this folder are shared with other peers)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:565 src/FirstRunWizard.cpp:624 src/muuli_wdr.cpp:1714
+#: src/FirstRunWizard.cpp:565 src/FirstRunWizard.cpp:624 src/muuli_wdr.cpp:1721
 msgid "Folder for temporary download files"
 msgstr ""
 
@@ -2392,7 +2397,7 @@ msgstr ""
 msgid "CRITICAL - no client on StartChatSession"
 msgstr ""
 
-#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2668 src/muuli_wdr.cpp:3345
+#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2675 src/muuli_wdr.cpp:3352
 msgid "Friends"
 msgstr ""
 
@@ -2770,7 +2775,7 @@ msgstr ""
 msgid "Uploaded"
 msgstr ""
 
-#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3225
+#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3232
 msgid "Requested"
 msgstr ""
 
@@ -2893,7 +2898,7 @@ msgid "WARNING: "
 msgstr ""
 
 #: src/MuleNotebook.cpp:179 src/muuli_wdr.cpp:817 src/muuli_wdr.cpp:1229
-#: src/muuli_wdr.cpp:3129 src/muuli_wdr.cpp:3385
+#: src/muuli_wdr.cpp:3136 src/muuli_wdr.cpp:3392
 msgid "Close"
 msgstr ""
 
@@ -2906,12 +2911,12 @@ msgstr ""
 msgid "Copy"
 msgstr ""
 
-#: src/MuleTextCtrl.cpp:88
+#: src/MuleTextCtrl.cpp:88 src/SearchDlg.cpp:261
 msgid "Paste"
 msgstr ""
 
 #: src/MuleTextCtrl.cpp:89 src/muuli_wdr.cpp:358 src/muuli_wdr.cpp:757
-#: src/muuli_wdr.cpp:2352 src/muuli_wdr.cpp:2371 src/muuli_wdr.cpp:2393
+#: src/muuli_wdr.cpp:2359 src/muuli_wdr.cpp:2378 src/muuli_wdr.cpp:2400
 #: src/utils/aLinkCreator/src/alcframe.cpp:142
 msgid "Clear"
 msgstr ""
@@ -3002,8 +3007,8 @@ msgid "Exit"
 msgstr ""
 
 #: src/MuleTrayIcon.cpp:579 src/MuleTrayIcon.cpp:945 src/MuleTrayIcon.cpp:965
-#: src/muuli_wdr.cpp:1391 src/muuli_wdr.cpp:1399 src/muuli_wdr.cpp:1406
-#: src/muuli_wdr.cpp:1835 src/muuli_wdr.cpp:1841 src/OtherFunctions.cpp:91
+#: src/muuli_wdr.cpp:1398 src/muuli_wdr.cpp:1406 src/muuli_wdr.cpp:1413
+#: src/muuli_wdr.cpp:1842 src/muuli_wdr.cpp:1848 src/OtherFunctions.cpp:91
 #: src/StatisticsDlg.cpp:93 src/StatisticsDlg.cpp:95
 msgid "kB/s"
 msgstr ""
@@ -3172,7 +3177,7 @@ msgstr ""
 msgid "Type"
 msgstr ""
 
-#: src/muuli_wdr.cpp:215 src/SearchDlg.cpp:110 src/SearchListCtrl.cpp:853
+#: src/muuli_wdr.cpp:215 src/SearchDlg.cpp:118 src/SearchListCtrl.cpp:853
 msgid "Local"
 msgstr ""
 
@@ -3243,7 +3248,7 @@ msgstr ""
 msgid "KB"
 msgstr ""
 
-#: src/muuli_wdr.cpp:274 src/muuli_wdr.cpp:293 src/muuli_wdr.cpp:1620
+#: src/muuli_wdr.cpp:274 src/muuli_wdr.cpp:293 src/muuli_wdr.cpp:1627
 #: src/OtherFunctions.cpp:64
 msgid "MB"
 msgstr ""
@@ -3260,7 +3265,7 @@ msgstr ""
 msgid "Availability"
 msgstr ""
 
-#: src/muuli_wdr.cpp:312 src/muuli_wdr.cpp:398 src/muuli_wdr.cpp:3290
+#: src/muuli_wdr.cpp:312 src/muuli_wdr.cpp:398 src/muuli_wdr.cpp:3297
 msgid "Filter:"
 msgstr ""
 
@@ -3292,7 +3297,7 @@ msgstr ""
 msgid "Stop"
 msgstr ""
 
-#: src/muuli_wdr.cpp:348 src/muuli_wdr.cpp:1385 src/SearchListCtrl.cpp:732
+#: src/muuli_wdr.cpp:348 src/muuli_wdr.cpp:1392 src/SearchListCtrl.cpp:732
 msgid "Download"
 msgstr ""
 
@@ -3323,8 +3328,8 @@ msgstr ""
 #: src/muuli_wdr.cpp:1160 src/muuli_wdr.cpp:1167 src/muuli_wdr.cpp:1172
 #: src/muuli_wdr.cpp:1179 src/muuli_wdr.cpp:1184 src/muuli_wdr.cpp:1191
 #: src/muuli_wdr.cpp:1205 src/muuli_wdr.cpp:1212 src/muuli_wdr.cpp:1217
-#: src/muuli_wdr.cpp:1224 src/muuli_wdr.cpp:3227 src/muuli_wdr.cpp:3235
-#: src/muuli_wdr.cpp:3243
+#: src/muuli_wdr.cpp:1224 src/muuli_wdr.cpp:3234 src/muuli_wdr.cpp:3242
+#: src/muuli_wdr.cpp:3250
 msgid "N/A"
 msgstr ""
 
@@ -3464,7 +3469,7 @@ msgstr ""
 msgid "Album :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:685 src/muuli_wdr.cpp:2247
+#: src/muuli_wdr.cpp:685 src/muuli_wdr.cpp:2254
 msgid "Title :"
 msgstr ""
 
@@ -3570,7 +3575,7 @@ msgstr ""
 msgid "Userhash :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:895 src/muuli_wdr.cpp:1741 src/muuli_wdr.cpp:2442
+#: src/muuli_wdr.cpp:895 src/muuli_wdr.cpp:1748 src/muuli_wdr.cpp:2449
 #: src/utils/aLinkCreator/src/alcframe.cpp:137
 msgid "Add"
 msgstr ""
@@ -3579,15 +3584,15 @@ msgstr ""
 msgid "Download-Speed"
 msgstr ""
 
-#: src/muuli_wdr.cpp:954 src/muuli_wdr.cpp:989 src/muuli_wdr.cpp:2546
+#: src/muuli_wdr.cpp:954 src/muuli_wdr.cpp:989 src/muuli_wdr.cpp:2553
 msgid "Current"
 msgstr ""
 
-#: src/muuli_wdr.cpp:962 src/muuli_wdr.cpp:997 src/muuli_wdr.cpp:2554
+#: src/muuli_wdr.cpp:962 src/muuli_wdr.cpp:997 src/muuli_wdr.cpp:2561
 msgid "Running average"
 msgstr ""
 
-#: src/muuli_wdr.cpp:970 src/muuli_wdr.cpp:1005 src/muuli_wdr.cpp:2562
+#: src/muuli_wdr.cpp:970 src/muuli_wdr.cpp:1005 src/muuli_wdr.cpp:2569
 msgid "Session average"
 msgstr ""
 
@@ -3599,7 +3604,7 @@ msgstr ""
 msgid "Connections"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1024 src/muuli_wdr.cpp:1860
+#: src/muuli_wdr.cpp:1024 src/muuli_wdr.cpp:1867
 msgid "Active downloads"
 msgstr ""
 
@@ -3607,7 +3612,7 @@ msgstr ""
 msgid "Active connections (1:1)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1040 src/muuli_wdr.cpp:1861
+#: src/muuli_wdr.cpp:1040 src/muuli_wdr.cpp:1868
 msgid "Active uploads"
 msgstr ""
 
@@ -3723,8 +3728,8 @@ msgstr ""
 msgid "Language: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1257 src/muuli_wdr.cpp:1323 src/muuli_wdr.cpp:1327
-#: src/muuli_wdr.cpp:1330
+#: src/muuli_wdr.cpp:1257 src/muuli_wdr.cpp:1330 src/muuli_wdr.cpp:1334
+#: src/muuli_wdr.cpp:1337
 msgid "The delay before showing tool-tips."
 msgstr ""
 
@@ -3800,923 +3805,931 @@ msgstr ""
 msgid "Enabling this will make aMule to show notifications when finished downloading."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1322
-msgid "Tooltip delay time: "
+#: src/muuli_wdr.cpp:1323
+msgid "Remember search history"
+msgstr ""
+
+#: src/muuli_wdr.cpp:1324
+msgid "Keeps a dropdown list of your past search terms in the Search tab's Name field. This remembers the queries you typed, not the results they returned."
 msgstr ""
 
 #: src/muuli_wdr.cpp:1329
+msgid "Tooltip delay time: "
+msgstr ""
+
+#: src/muuli_wdr.cpp:1336
 msgid "seconds"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1333
+#: src/muuli_wdr.cpp:1340
 msgid "Browser Selection"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1339
+#: src/muuli_wdr.cpp:1346
 msgid "Enter your browser name here. Leave this field empty to use the system default browser."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1346
+#: src/muuli_wdr.cpp:1353
 msgid "Open in new tab if possible"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1348
+#: src/muuli_wdr.cpp:1355
 msgid "Open the web page in a new tab instead of in a new window when possible"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1352
+#: src/muuli_wdr.cpp:1359
 msgid "Video Player"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1379
+#: src/muuli_wdr.cpp:1386
 msgid "Bandwidth limits"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1393
+#: src/muuli_wdr.cpp:1400
 msgid "Upload"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1401
+#: src/muuli_wdr.cpp:1408
 msgid "Slot Allocation"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1410
+#: src/muuli_wdr.cpp:1417
 msgid "Ports"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1420
+#: src/muuli_wdr.cpp:1427
 msgid "This is the standard eD2k port and cannot be disabled."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1423
+#: src/muuli_wdr.cpp:1430
 msgid "UDP port for server requests (TCP+3):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1425
+#: src/muuli_wdr.cpp:1432
 msgid "4665"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1432
+#: src/muuli_wdr.cpp:1439
 msgid "This UDP port is used for extended eD2k requests and Kad network"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1439
+#: src/muuli_wdr.cpp:1446
 msgid "UPnP TCP Port (Optional):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1449
+#: src/muuli_wdr.cpp:1456
 msgid "Bind local address to IP (empty for any):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1452
+#: src/muuli_wdr.cpp:1459
 msgid "Advanced users only: If you have multiple network interfaces, enter the address of the interface to which aMule should be bound."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1455 src/muuli_wdr.cpp:2054
+#: src/muuli_wdr.cpp:1462 src/muuli_wdr.cpp:2061
 msgid "Bind to network interface (empty for any):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1468
+#: src/muuli_wdr.cpp:1475
 msgid "Advanced users only: pin all of aMule's traffic to one network interface, chosen from the list or typed in by name (e.g. tun0, eth0, en0) or index. Unlike binding to an IP, this stops traffic leaking out via the default route - useful with a VPN. Requires no elevated privileges."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1474
+#: src/muuli_wdr.cpp:1481
 msgid "Max sources per downloading file:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1478
+#: src/muuli_wdr.cpp:1485
 msgid "Max simultaneous connections:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1491 src/muuli_wdr.cpp:3169
+#: src/muuli_wdr.cpp:1498 src/muuli_wdr.cpp:3176
 msgid "ED2K"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1498
+#: src/muuli_wdr.cpp:1505
 msgid "Autoconnect on startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1501
+#: src/muuli_wdr.cpp:1508
 msgid "Reconnect on loss"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1523
+#: src/muuli_wdr.cpp:1530
 msgid "Remove dead server after"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1524
+#: src/muuli_wdr.cpp:1531
 msgid "Static servers are never removed, even when unreachable."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1528
+#: src/muuli_wdr.cpp:1535
 msgid "retries"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1536
+#: src/muuli_wdr.cpp:1543
 msgid "List"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1539
+#: src/muuli_wdr.cpp:1546
 msgid "Update server list when connecting to a server"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1542
+#: src/muuli_wdr.cpp:1549
 msgid "Update server list when a client connects"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1545
+#: src/muuli_wdr.cpp:1552
 msgid "Use priority system"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1549
+#: src/muuli_wdr.cpp:1556
 msgid "Use smart LowID check on connect"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1553
+#: src/muuli_wdr.cpp:1560
 msgid "Safe connect"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1557
+#: src/muuli_wdr.cpp:1564
 msgid "Autoconnect to servers in static list only"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1560
+#: src/muuli_wdr.cpp:1567
 msgid "Set manually added servers to High Priority"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1581
+#: src/muuli_wdr.cpp:1588
 msgid "Add files to download in pause mode"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1583
+#: src/muuli_wdr.cpp:1590
 msgid "Add files to download with auto priority"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1586
+#: src/muuli_wdr.cpp:1593
 msgid "Try to download first and last chunks first"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1590
+#: src/muuli_wdr.cpp:1597
 msgid "Endgame mode: rotate to faster sources for the final blocks"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1593
+#: src/muuli_wdr.cpp:1600
 msgid "Start next paused file when a file completes"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1596
+#: src/muuli_wdr.cpp:1603
 msgid "From the same category"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1598
+#: src/muuli_wdr.cpp:1605
 msgid "In alphabetic order"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1600
+#: src/muuli_wdr.cpp:1607
 msgid "Preallocate disk space for new files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1601
+#: src/muuli_wdr.cpp:1608
 msgid "For new files preallocates disk space for the whole file, thus reduces fragmentation"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1606
+#: src/muuli_wdr.cpp:1613
 msgid "Create new files as sparse files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1607
+#: src/muuli_wdr.cpp:1614
 msgid "A sparse file reserves its full size on disk immediately without writing real data to it -- fast, but unsupported or slow on some filesystems, and free-space accounting stays optimistic while the download is in progress. Turn this off to grow the file only as data arrives."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1612
+#: src/muuli_wdr.cpp:1619
 msgid "Stop downloads when free disk space reaches "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1613
+#: src/muuli_wdr.cpp:1620
 msgid "Select this if you want aMule to check your disk space"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1617
+#: src/muuli_wdr.cpp:1624
 msgid "Enter here the min disk space desired."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1623
+#: src/muuli_wdr.cpp:1630
 msgid "Save 10 sources on rare files (< 20 sources)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1627 src/Statistics.cpp:790
+#: src/muuli_wdr.cpp:1634 src/Statistics.cpp:790
 msgid "Uploads"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1630
+#: src/muuli_wdr.cpp:1637
 msgid "Add new shared files with auto priority"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1636
+#: src/muuli_wdr.cpp:1643
 msgid "Intelligent Corruption Handling (I.C.H.)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1639
+#: src/muuli_wdr.cpp:1646
 msgid "Enable"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1642
+#: src/muuli_wdr.cpp:1649
 msgid "Advanced I.C.H. trusts every hash (not recommended)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1654 src/PrefsUnifiedDlg.cpp:1910
+#: src/muuli_wdr.cpp:1661 src/PrefsUnifiedDlg.cpp:1910
 msgid "Media metadata extraction"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1658
+#: src/muuli_wdr.cpp:1665
 msgid "Extract length / bitrate / codec from shared audio and video files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1660
+#: src/muuli_wdr.cpp:1667
 msgid "When enabled, aMule runs ffprobe on each shared media file to fill in the Length / Bitrate / Codec columns other clients see when they find the file in a search. Requires ffmpeg (the ffprobe binary) to be installed."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1667
+#: src/muuli_wdr.cpp:1674
 msgid "Path to ffprobe:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1672
+#: src/muuli_wdr.cpp:1679
 msgid "Full path to the ffprobe binary. Leave empty to have aMule auto-detect it on startup."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1680
+#: src/muuli_wdr.cpp:1687
 msgid "Detect"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1681
+#: src/muuli_wdr.cpp:1688
 msgid "Search the standard install locations for an ffprobe binary and fill the path field."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1705
+#: src/muuli_wdr.cpp:1712
 msgid ""
 "Completed downloads are stored here. All files in this folder are automatically shared with other peers.\n"
 "If this folder also holds files you don't want to share, point it at an aMule-only sub-folder."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1708
+#: src/muuli_wdr.cpp:1715
 msgid "Pick the folder where completed downloads will be stored. All files in that folder will be shared with other peers."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1722
+#: src/muuli_wdr.cpp:1729
 msgid "Shared folders"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1728
+#: src/muuli_wdr.cpp:1735
 msgid "(Folders shared by the core. Enter a path to add one.)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1736
+#: src/muuli_wdr.cpp:1743
 msgid "Absolute path of a folder on the core's machine, e.g. /home/user/shared"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1738 src/PrefsUnifiedDlg.cpp:2794
+#: src/muuli_wdr.cpp:1745 src/PrefsUnifiedDlg.cpp:2794
 msgid "Recursive"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1739
+#: src/muuli_wdr.cpp:1746
 msgid "Share every sub-folder underneath this one, including ones created later."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1743 src/utils/aLinkCreator/src/alcframe.cpp:141
+#: src/muuli_wdr.cpp:1750 src/utils/aLinkCreator/src/alcframe.cpp:141
 msgid "Remove"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1747
+#: src/muuli_wdr.cpp:1754
 msgid "(Right click on folder icon for recursive share)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1754
+#: src/muuli_wdr.cpp:1761
 msgid "Share hidden files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1760
+#: src/muuli_wdr.cpp:1767
 msgid "Automatically rescan shared folders for changes"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1766
+#: src/muuli_wdr.cpp:1773
 msgid "Follow symbolic links in shared folders"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1772
+#: src/muuli_wdr.cpp:1779
 msgid "Exclude files matching:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1775
+#: src/muuli_wdr.cpp:1782
 msgid "Wildcard patterns separated by '|', e.g. .DS_Store|Thumbs.db|*.tmp. Files whose name matches are not shared. Matching is case-insensitive."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1779
+#: src/muuli_wdr.cpp:1786
 msgid "Patterns are regular expressions"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1780
+#: src/muuli_wdr.cpp:1787
 msgid "When set, the whole field is one regular expression ('|' is alternation). When unset, it is a list of '|'-separated wildcards."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1790
+#: src/muuli_wdr.cpp:1797
 msgid "Show how many shared files the current pattern would exclude."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1811
+#: src/muuli_wdr.cpp:1818
 msgid "Graphs"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1814 src/muuli_wdr.cpp:1876
+#: src/muuli_wdr.cpp:1821 src/muuli_wdr.cpp:1883
 msgid "Update delay : 5 secs"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1818
+#: src/muuli_wdr.cpp:1825
 msgid "Time for average graph: 100 mins"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1822
+#: src/muuli_wdr.cpp:1829
 msgid "Connections Graph Scale: 100 "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1829
+#: src/muuli_wdr.cpp:1836
 msgid "Download graph scale:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1837
+#: src/muuli_wdr.cpp:1844
 msgid "Upload graph scale:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1847
+#: src/muuli_wdr.cpp:1854
 msgid "Colors: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1851
+#: src/muuli_wdr.cpp:1858
 msgid "Background"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1852
+#: src/muuli_wdr.cpp:1859
 msgid "Grid"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1853
+#: src/muuli_wdr.cpp:1860
 msgid "Download current"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1854
+#: src/muuli_wdr.cpp:1861
 msgid "Download running average"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1855
+#: src/muuli_wdr.cpp:1862
 msgid "Download session average"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1856
+#: src/muuli_wdr.cpp:1863
 msgid "Upload current"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1857
+#: src/muuli_wdr.cpp:1864
 msgid "Upload running average"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1858
+#: src/muuli_wdr.cpp:1865
 msgid "Upload session average"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1859
+#: src/muuli_wdr.cpp:1866
 msgid "Active connections"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1862
+#: src/muuli_wdr.cpp:1869
 msgid "Systray Icon Speed Bar"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1863
+#: src/muuli_wdr.cpp:1870
 msgid "Kad-nodes current"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1864
+#: src/muuli_wdr.cpp:1871
 msgid "Kad-nodes running"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1865
+#: src/muuli_wdr.cpp:1872
 msgid "Kad-nodes session"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1869 src/muuli_wdr.cpp:2296
+#: src/muuli_wdr.cpp:1876 src/muuli_wdr.cpp:2303
 msgid "Select"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1873
+#: src/muuli_wdr.cpp:1880
 msgid "Tree"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1883
+#: src/muuli_wdr.cpp:1890
 msgid "Number of Client Versions shown (0=unlimited)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1908
+#: src/muuli_wdr.cpp:1915
 msgid "!!! WARNING !!!"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1923
+#: src/muuli_wdr.cpp:1930
 msgid "Max new connections / 5 secs"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1925
+#: src/muuli_wdr.cpp:1932
 msgid "Concurrent Kad source lookups"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1927
+#: src/muuli_wdr.cpp:1934
 msgid "Kad source re-search interval (minutes)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1929
+#: src/muuli_wdr.cpp:1936
 msgid "Source re-ask interval (minutes)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1933
+#: src/muuli_wdr.cpp:1940
 msgid "File Buffer Size: 240000 bytes"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1937
+#: src/muuli_wdr.cpp:1944
 msgid "Use MMAP: memory-mapped file access (lower memory use)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1938
+#: src/muuli_wdr.cpp:1945
 msgid "Maps part files into memory instead of buffering them on the heap, lowering the process memory footprint. May reduce download speed on some disks; best for memory-constrained or upload-heavy hosts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1940
+#: src/muuli_wdr.cpp:1947
 msgid "Upload Queue Size: 5000 clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1944
+#: src/muuli_wdr.cpp:1951
 msgid "Server connection refresh interval: Disable"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1948
+#: src/muuli_wdr.cpp:1955
 msgid "Disable computer's timed standby mode"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1967
+#: src/muuli_wdr.cpp:1974
 msgid "Skin to use: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1976
+#: src/muuli_wdr.cpp:1983
 msgid "Show \"Fast eD2k Links Handler\" in every window."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1979
+#: src/muuli_wdr.cpp:1986
 msgid "Show extended info on categories tabs"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1982
+#: src/muuli_wdr.cpp:1989
 msgid "Show application version on title"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1984
+#: src/muuli_wdr.cpp:1991
 msgid "Show transfer rates on title"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1986
+#: src/muuli_wdr.cpp:1993
 msgid "Before application name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1988
+#: src/muuli_wdr.cpp:1995
 msgid "After application name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1991
+#: src/muuli_wdr.cpp:1998
 msgid "Show overhead bandwidth"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1995
+#: src/muuli_wdr.cpp:2002
 msgid "Vertical toolbar orientation"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1997
+#: src/muuli_wdr.cpp:2004
 msgid "Live column sorting (auto-reorder rows as their values change)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2004
+#: src/muuli_wdr.cpp:2011
 msgid "Download Queue Files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2007
+#: src/muuli_wdr.cpp:2014
 msgid "Show progress percentage"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2013
+#: src/muuli_wdr.cpp:2020
 msgid "Show progress bar"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2016
+#: src/muuli_wdr.cpp:2023
 msgid "Flat"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2020
+#: src/muuli_wdr.cpp:2027
 msgid "Round"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2038
+#: src/muuli_wdr.cpp:2045
 msgid "External Connection Parameters"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2041
+#: src/muuli_wdr.cpp:2048
 msgid "Accept external connections"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2048 src/muuli_wdr.cpp:2107
+#: src/muuli_wdr.cpp:2055 src/muuli_wdr.cpp:2114
 msgid "IP of the listening interface:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2051
+#: src/muuli_wdr.cpp:2058
 msgid "Enter here a valid ip in the a.b.c.d format for the listening EC interface. An empty field or 0.0.0.0 will mean any interface."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2072 src/muuli_wdr.cpp:2156
+#: src/muuli_wdr.cpp:2079 src/muuli_wdr.cpp:2163
 msgid "TCP port:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2078
+#: src/muuli_wdr.cpp:2085
 msgid "Enable UPnP port forwarding on the EC port"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2082 src/muuli_wdr.cpp:3041
+#: src/muuli_wdr.cpp:2089 src/muuli_wdr.cpp:3048
 #: src/utils/wxCas/src/wxcasprefs.cpp:167
 msgid "Password"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2088
+#: src/muuli_wdr.cpp:2095
 msgid "aMule API server parameters"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2091
+#: src/muuli_wdr.cpp:2098
 msgid "Run amuleapi (REST API) on startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2096
+#: src/muuli_wdr.cpp:2103
 msgid "HTTP port:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2110
+#: src/muuli_wdr.cpp:2117
 msgid "The interface amuleapi's HTTP server listens on. 127.0.0.1 (default) accepts only local connections; use 0.0.0.0 or a specific IP to expose it to other hosts (set an admin password below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2113
+#: src/muuli_wdr.cpp:2120
 msgid "Admin password"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2118 src/muuli_wdr.cpp:2149
+#: src/muuli_wdr.cpp:2125 src/muuli_wdr.cpp:2156
 msgid "Low rights password"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2126
+#: src/muuli_wdr.cpp:2133
 msgid "Web server parameters"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2129
+#: src/muuli_wdr.cpp:2136
 msgid "Run webserver on startup (deprecated)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2135
+#: src/muuli_wdr.cpp:2142
 msgid "Web template"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2140
+#: src/muuli_wdr.cpp:2147
 msgid "Full rights password"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2144
+#: src/muuli_wdr.cpp:2151
 msgid "Enable Low rights User"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2163
+#: src/muuli_wdr.cpp:2170
 msgid "Enable UPnP port forwarding of the web server port"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2168
+#: src/muuli_wdr.cpp:2175
 msgid "Web server UPnP TCP port (Optional)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2176
+#: src/muuli_wdr.cpp:2183
 msgid "Page Refresh Time (in secs)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2183
+#: src/muuli_wdr.cpp:2190
 msgid "Enable Gzip compression"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2217
+#: src/muuli_wdr.cpp:2224
 msgid "Reset page to defaults"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2218
+#: src/muuli_wdr.cpp:2225
 msgid "Reset the settings on the current page to their default values."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2220 src/muuli_wdr.cpp:2306 src/ServerWnd.cpp:274
+#: src/muuli_wdr.cpp:2227 src/muuli_wdr.cpp:2313 src/ServerWnd.cpp:274
 #: src/ServerWnd.cpp:282
 msgid "OK"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2222
+#: src/muuli_wdr.cpp:2229
 msgid "Click here to apply any changes made to the preferences."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2225
+#: src/muuli_wdr.cpp:2232
 msgid "Reset any changes made to the preferences."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2254
+#: src/muuli_wdr.cpp:2261
 msgid "Comment :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2261
+#: src/muuli_wdr.cpp:2268
 msgid "Incoming Dir :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2270
+#: src/muuli_wdr.cpp:2277
 msgid "Change priority for new assigned files :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2274
+#: src/muuli_wdr.cpp:2281
 msgid "Don't change"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2286
+#: src/muuli_wdr.cpp:2293
 msgid "Select color for this Category (currently selected) :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2353 src/muuli_wdr.cpp:2372 src/muuli_wdr.cpp:2394
+#: src/muuli_wdr.cpp:2360 src/muuli_wdr.cpp:2379 src/muuli_wdr.cpp:2401
 msgid "Click this button to reset the log."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2413
+#: src/muuli_wdr.cpp:2420
 msgid "Click on this button to update the servers list from URL ..."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2417
+#: src/muuli_wdr.cpp:2424
 msgid "Server list"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2421
+#: src/muuli_wdr.cpp:2428
 msgid "Enter the url to a server.met file here and press the button to the left to update the list of known servers."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2426
+#: src/muuli_wdr.cpp:2433
 msgid "Add server manually: Name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2429
+#: src/muuli_wdr.cpp:2436
 msgid "Enter the name of the new server here"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2431 src/ServerWnd.cpp:206
+#: src/muuli_wdr.cpp:2438 src/ServerWnd.cpp:206
 msgid "IP:Port"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2434
+#: src/muuli_wdr.cpp:2441
 msgid "Enter the IP of the server here, using the x.x.x.x format."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2440
+#: src/muuli_wdr.cpp:2447
 msgid "Enter the port of the server here."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2443
+#: src/muuli_wdr.cpp:2450
 msgid "Add manually a server (fill fields to the left before) ..."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2472
+#: src/muuli_wdr.cpp:2479
 msgid "aMule Log"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2480
+#: src/muuli_wdr.cpp:2487
 msgid "Server Info"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2484
+#: src/muuli_wdr.cpp:2491
 msgid "ED2K Info"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2488
+#: src/muuli_wdr.cpp:2495
 msgid "Kad Info"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2516
+#: src/muuli_wdr.cpp:2523
 msgid "Click on this button to update the nodes list from URL ..."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2520
+#: src/muuli_wdr.cpp:2527
 msgid "Nodes (0)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2524
+#: src/muuli_wdr.cpp:2531
 msgid "Enter the url to a nodes.dat file here and press the button to the left to update the list of known nodes."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2527
+#: src/muuli_wdr.cpp:2534
 msgid "Nodes stats"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2569
+#: src/muuli_wdr.cpp:2576
 msgid "Bootstrap"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2572
+#: src/muuli_wdr.cpp:2579
 msgid "New node"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2577
+#: src/muuli_wdr.cpp:2584
 msgid "IP:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2597
+#: src/muuli_wdr.cpp:2604
 msgid "Port:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2610
+#: src/muuli_wdr.cpp:2617
 msgid "Bootstrap from known clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2612
+#: src/muuli_wdr.cpp:2619
 msgid "Disconnect Kad"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2646
+#: src/muuli_wdr.cpp:2653
 msgid "Use Secure User Identification"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2648
+#: src/muuli_wdr.cpp:2655
 msgid "It is recommended to enable this option. You will not receive credits if SUI is not enabled."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2650
+#: src/muuli_wdr.cpp:2657
 msgid "Protocol Obfuscation"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2653
+#: src/muuli_wdr.cpp:2660
 msgid "Support Protocol Obfuscation"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2655
+#: src/muuli_wdr.cpp:2662
 msgid "This option enabled Protocol Obfuscation, and makes aMule accept obfuscated connections from other clients."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2657
+#: src/muuli_wdr.cpp:2664
 msgid "Use obfuscation for outgoing connections"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2659
+#: src/muuli_wdr.cpp:2666
 msgid "This option makes aMule use Protocol Obfuscation when connecting other clients/servers."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2661
+#: src/muuli_wdr.cpp:2668
 msgid "Accept only obfuscated connections"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2662
+#: src/muuli_wdr.cpp:2669
 msgid "This option makes aMule only accept obfuscated connections. You will have less sources, but all your traffic will be obfuscated"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2667
+#: src/muuli_wdr.cpp:2674
 msgid "Everybody"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2669
+#: src/muuli_wdr.cpp:2676
 msgid "No one"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2671
+#: src/muuli_wdr.cpp:2678
 msgid "Who can see my shared files:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2672
+#: src/muuli_wdr.cpp:2679
 msgid "Select who can request to view a list of your shared files."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2674
+#: src/muuli_wdr.cpp:2681
 msgid "IP-Filtering"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2681
+#: src/muuli_wdr.cpp:2688
 msgid "Filter clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2683
+#: src/muuli_wdr.cpp:2690
 msgid "Enable filtering of the client IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2685
+#: src/muuli_wdr.cpp:2692
 msgid "Filter servers"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2687
+#: src/muuli_wdr.cpp:2694
 msgid "Enable filtering of the server IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2691
+#: src/muuli_wdr.cpp:2698
 msgid "Reload List"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2692
+#: src/muuli_wdr.cpp:2699
 msgid "Reload the list of IPs to filter from the file ~/.aMule/ipfilter.dat"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2698
+#: src/muuli_wdr.cpp:2705
 msgid "URL:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2702 src/muuli_wdr.cpp:2895
+#: src/muuli_wdr.cpp:2709 src/muuli_wdr.cpp:2902
 msgid "Update now"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2705
+#: src/muuli_wdr.cpp:2712
 msgid "Auto-update ipfilter at startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2709
+#: src/muuli_wdr.cpp:2716
 msgid "Filtering Level:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2715
+#: src/muuli_wdr.cpp:2722
 msgid "Always filter LAN IPs"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2718
+#: src/muuli_wdr.cpp:2725
 msgid "Paranoid handling of non-matching IPs"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2720
+#: src/muuli_wdr.cpp:2727
 msgid "Rejects a packet when its source IP differs from the IP the client claims (an anti-spoofing check). Disable only if it causes connection problems."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2722
+#: src/muuli_wdr.cpp:2729
 msgid "Use system-wide ipfilter.dat if available"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2723
+#: src/muuli_wdr.cpp:2730
 msgid "If there's no local ipfilter.dat found, allow usage of a system-wide ipfilter file."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2740
+#: src/muuli_wdr.cpp:2747
 msgid "Enable Online-Signature"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2742
+#: src/muuli_wdr.cpp:2749
 msgid "Enables the writing of the OS file, which can be used by external apps to create signatures and the like."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2746
+#: src/muuli_wdr.cpp:2753
 msgid "Update Frequency (Secs):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2749
+#: src/muuli_wdr.cpp:2756
 msgid "Change the frequency (in seconds) of Online Signature updates."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2757
+#: src/muuli_wdr.cpp:2764
 msgid "Save online signature file in: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:2763
+#: src/muuli_wdr.cpp:2770
 msgid "Click here to select the directory containing the the Online Signature files."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2796
+#: src/muuli_wdr.cpp:2803
 msgid "Show country flags for clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2797
+#: src/muuli_wdr.cpp:2804
 msgid "Render the country flag column in the transfers, queue and search views. Requires a valid MMDB GeoIP database (see below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2802
+#: src/muuli_wdr.cpp:2809
 msgid "Database"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2818
+#: src/muuli_wdr.cpp:2825
 msgid "Source:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2821
+#: src/muuli_wdr.cpp:2828
 msgid "DB-IP (free, no account)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2822
+#: src/muuli_wdr.cpp:2829
 msgid "MaxMind GeoLite2 (free, account required)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2823
+#: src/muuli_wdr.cpp:2830
 msgid "Custom URL"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2826
+#: src/muuli_wdr.cpp:2833
 msgid "Choose which provider supplies the GeoIP MMDB database. DB-IP is the default - no account required. MaxMind requires a free account + license key. Use Custom URL to point at any other MMDB host (e.g. a local mirror)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2843
+#: src/muuli_wdr.cpp:2850
 msgid ""
 "No configuration required.\n"
 "\n"
@@ -4724,11 +4737,11 @@ msgid ""
 "License: Creative Commons BY 4.0 - https://creativecommons.org/licenses/by/4.0/"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2856
+#: src/muuli_wdr.cpp:2863
 msgid "License key:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2862
+#: src/muuli_wdr.cpp:2869
 msgid ""
 "Sign up for a free MaxMind account, then generate a License Key:\n"
 "https://www.maxmind.com/en/geolite2/signup\n"
@@ -4738,222 +4751,222 @@ msgid ""
 "Requires attribution and account registration; refresh at least every 30 days."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2877
+#: src/muuli_wdr.cpp:2884
 msgid "Download URL:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2883
+#: src/muuli_wdr.cpp:2890
 msgid ""
 "Must point to an .mmdb file or a .gz / .tar.gz containing one.\n"
 "URL may include credentials (https://user:pass@host/...).\n"
 "License and attribution terms are set by the upstream URL - you are responsible."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2896
+#: src/muuli_wdr.cpp:2903
 msgid "Download the GeoIP database from the selected source."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2898
+#: src/muuli_wdr.cpp:2905
 msgid "Auto-update on startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2899
+#: src/muuli_wdr.cpp:2906
 msgid "Re-download the GeoIP database from the selected source every time aMule starts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2922
+#: src/muuli_wdr.cpp:2929
 msgid "Filter incoming messages (except current chat):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2924
+#: src/muuli_wdr.cpp:2931
 msgid "Filter all messages"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2926
+#: src/muuli_wdr.cpp:2933
 msgid "Filter messages from people not on your friend list"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2928
+#: src/muuli_wdr.cpp:2935
 msgid "Filter messages from unknown clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2930
+#: src/muuli_wdr.cpp:2937
 msgid "Filter messages containing (use ',' as separator):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2933 src/muuli_wdr.cpp:2944
+#: src/muuli_wdr.cpp:2940 src/muuli_wdr.cpp:2951
 msgid "add here the words amule should filter and block messages including it"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2935
+#: src/muuli_wdr.cpp:2942
 msgid "Show received messages in the log"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2938
+#: src/muuli_wdr.cpp:2945
 msgid "Comments"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2941
+#: src/muuli_wdr.cpp:2948
 msgid "Filter comments containing (use ',' as separator):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2966
+#: src/muuli_wdr.cpp:2973
 msgid "Enable Proxy"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2967
+#: src/muuli_wdr.cpp:2974
 msgid "Enable/disable proxy support"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2970
+#: src/muuli_wdr.cpp:2977
 msgid "Proxy type:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2981
+#: src/muuli_wdr.cpp:2988
 msgid "Proxy host:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2984
+#: src/muuli_wdr.cpp:2991
 msgid "The proxy host name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2986
+#: src/muuli_wdr.cpp:2993
 msgid "Proxy port:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2989
+#: src/muuli_wdr.cpp:2996
 msgid "The proxy port"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2991
+#: src/muuli_wdr.cpp:2998
 msgid "Enable authentication"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2992
+#: src/muuli_wdr.cpp:2999
 msgid "Enable/disable username/password authentication"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2995
+#: src/muuli_wdr.cpp:3002
 msgid "Username: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:2998
+#: src/muuli_wdr.cpp:3005
 msgid "The username to use to connect to the proxy"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3000
+#: src/muuli_wdr.cpp:3007
 msgid "Password:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3003
+#: src/muuli_wdr.cpp:3010
 msgid "The password to use to connect to the proxy"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3022
+#: src/muuli_wdr.cpp:3029
 msgid "Connect to:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3031
+#: src/muuli_wdr.cpp:3038
 msgid "Login to remote amule"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3036
+#: src/muuli_wdr.cpp:3043
 msgid "User name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3047
+#: src/muuli_wdr.cpp:3054
 msgid "Remember those settings"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3050
+#: src/muuli_wdr.cpp:3057
 msgid "Force ZLIB compression"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3074
+#: src/muuli_wdr.cpp:3081
 msgid "Enable Verbose Debug-Logging."
 msgstr ""
 
-#: src/muuli_wdr.cpp:3076
+#: src/muuli_wdr.cpp:3083
 msgid "Only to Logfile"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3078
+#: src/muuli_wdr.cpp:3085
 msgid "Message Categories:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3102 src/PartFileConvertDlg.cpp:160
+#: src/muuli_wdr.cpp:3109 src/PartFileConvertDlg.cpp:160
 msgid "Waiting..."
 msgstr ""
 
-#: src/muuli_wdr.cpp:3122
+#: src/muuli_wdr.cpp:3129
 msgid "Add imports"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3125
+#: src/muuli_wdr.cpp:3132
 msgid "Retry selected"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3127
+#: src/muuli_wdr.cpp:3134
 msgid "Remove selected"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3190
+#: src/muuli_wdr.cpp:3197
 msgid "Event Types"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3209
+#: src/muuli_wdr.cpp:3216
 msgid "Statistics and queued clients for selected file(s) : Session / All time"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3233
+#: src/muuli_wdr.cpp:3240
 msgid "Active Uploads"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3247
+#: src/muuli_wdr.cpp:3254
 msgid "Percent of total files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3299
+#: src/muuli_wdr.cpp:3306
 msgid "Show Clients for"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3301
+#: src/muuli_wdr.cpp:3308
 msgid "All files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3304
+#: src/muuli_wdr.cpp:3311
 msgid "Selected files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3307
+#: src/muuli_wdr.cpp:3314
 msgid "Active uploads only"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3314
+#: src/muuli_wdr.cpp:3321
 msgid "Reload:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3318
+#: src/muuli_wdr.cpp:3325
 msgid "Reload your shared files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3381
+#: src/muuli_wdr.cpp:3388
 msgid "Send"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3382
+#: src/muuli_wdr.cpp:3389
 msgid "Sends the specified message."
 msgstr ""
 
-#: src/muuli_wdr.cpp:3386
+#: src/muuli_wdr.cpp:3393
 msgid "Close this chat-session."
 msgstr ""
 
-#: src/muuli_wdr.cpp:3409
+#: src/muuli_wdr.cpp:3416
 msgid "Connect to any server and/or Kad"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3415 src/SharedFilesCtrl.cpp:142 src/Statistics.cpp:941
+#: src/muuli_wdr.cpp:3422 src/SharedFilesCtrl.cpp:142 src/Statistics.cpp:941
 msgid "Shared Files"
 msgstr ""
 
@@ -5311,187 +5324,187 @@ msgstr ""
 msgid "ERROR: Failed to open partfile '%s'"
 msgstr ""
 
-#: src/Preferences.cpp:673
+#: src/Preferences.cpp:674
 msgid "System default"
 msgstr ""
 
-#: src/Preferences.cpp:674
+#: src/Preferences.cpp:675
 msgid "Albanian"
 msgstr ""
 
-#: src/Preferences.cpp:675
+#: src/Preferences.cpp:676
 msgid "Arabic"
 msgstr ""
 
-#: src/Preferences.cpp:676
+#: src/Preferences.cpp:677
 msgid "Asturian"
 msgstr ""
 
-#: src/Preferences.cpp:677
+#: src/Preferences.cpp:678
 msgid "Basque"
 msgstr ""
 
-#: src/Preferences.cpp:678
+#: src/Preferences.cpp:679
 msgid "Bulgarian"
 msgstr ""
 
-#: src/Preferences.cpp:679
+#: src/Preferences.cpp:680
 msgid "Catalan"
 msgstr ""
 
-#: src/Preferences.cpp:680
+#: src/Preferences.cpp:681
 msgid "Chinese (Simplified)"
 msgstr ""
 
-#: src/Preferences.cpp:681
+#: src/Preferences.cpp:682
 msgid "Chinese (Traditional)"
 msgstr ""
 
-#: src/Preferences.cpp:682
+#: src/Preferences.cpp:683
 msgid "Croatian"
 msgstr ""
 
-#: src/Preferences.cpp:683
+#: src/Preferences.cpp:684
 msgid "Czech"
 msgstr ""
 
-#: src/Preferences.cpp:684
+#: src/Preferences.cpp:685
 msgid "Danish"
 msgstr ""
 
-#: src/Preferences.cpp:685
+#: src/Preferences.cpp:686
 msgid "Dutch"
 msgstr ""
 
-#: src/Preferences.cpp:686
+#: src/Preferences.cpp:687
 msgid "English (U.K.)"
 msgstr ""
 
-#: src/Preferences.cpp:687
+#: src/Preferences.cpp:688
 msgid "English (U.S.)"
 msgstr ""
 
-#: src/Preferences.cpp:688
+#: src/Preferences.cpp:689
 msgid "Estonian"
 msgstr ""
 
-#: src/Preferences.cpp:689
+#: src/Preferences.cpp:690
 msgid "Finnish"
 msgstr ""
 
-#: src/Preferences.cpp:690
+#: src/Preferences.cpp:691
 msgid "French"
 msgstr ""
 
-#: src/Preferences.cpp:691
+#: src/Preferences.cpp:692
 msgid "Galician"
 msgstr ""
 
-#: src/Preferences.cpp:692
+#: src/Preferences.cpp:693
 msgid "German"
 msgstr ""
 
-#: src/Preferences.cpp:693
+#: src/Preferences.cpp:694
 msgid "Greek"
 msgstr ""
 
-#: src/Preferences.cpp:694
+#: src/Preferences.cpp:695
 msgid "Hebrew"
 msgstr ""
 
-#: src/Preferences.cpp:695
+#: src/Preferences.cpp:696
 msgid "Hungarian"
 msgstr ""
 
-#: src/Preferences.cpp:696
+#: src/Preferences.cpp:697
 msgid "Italian"
 msgstr ""
 
-#: src/Preferences.cpp:697
+#: src/Preferences.cpp:698
 msgid "Japanese"
 msgstr ""
 
-#: src/Preferences.cpp:698
+#: src/Preferences.cpp:699
 msgid "Korean"
 msgstr ""
 
-#: src/Preferences.cpp:699
+#: src/Preferences.cpp:700
 msgid "Latvian"
 msgstr ""
 
-#: src/Preferences.cpp:700
+#: src/Preferences.cpp:701
 msgid "Lithuanian"
 msgstr ""
 
-#: src/Preferences.cpp:701
+#: src/Preferences.cpp:702
 msgid "Norwegian (Nynorsk)"
 msgstr ""
 
-#: src/Preferences.cpp:702
+#: src/Preferences.cpp:703
 msgid "Polish"
 msgstr ""
 
-#: src/Preferences.cpp:703
+#: src/Preferences.cpp:704
 msgid "Portuguese"
 msgstr ""
 
-#: src/Preferences.cpp:704
+#: src/Preferences.cpp:705
 msgid "Portuguese (Brazilian)"
 msgstr ""
 
-#: src/Preferences.cpp:705
+#: src/Preferences.cpp:706
 msgid "Romanian"
 msgstr ""
 
-#: src/Preferences.cpp:706
+#: src/Preferences.cpp:707
 msgid "Russian"
 msgstr ""
 
-#: src/Preferences.cpp:707
+#: src/Preferences.cpp:708
 msgid "Slovenian"
 msgstr ""
 
-#: src/Preferences.cpp:708
+#: src/Preferences.cpp:709
 msgid "Spanish"
 msgstr ""
 
-#: src/Preferences.cpp:709
+#: src/Preferences.cpp:710
 msgid "Swedish"
 msgstr ""
 
-#: src/Preferences.cpp:710
+#: src/Preferences.cpp:711
 msgid "Turkish"
 msgstr ""
 
-#: src/Preferences.cpp:711
+#: src/Preferences.cpp:712
 msgid "Ukrainian"
 msgstr ""
 
-#: src/Preferences.cpp:814
+#: src/Preferences.cpp:815
 msgid "Change Language"
 msgstr ""
 
-#: src/Preferences.cpp:878
+#: src/Preferences.cpp:879
 msgid "There are no translations installed for aMule"
 msgstr ""
 
-#: src/Preferences.cpp:879
+#: src/Preferences.cpp:880
 msgid "No languages available"
 msgstr ""
 
-#: src/Preferences.cpp:1010
+#: src/Preferences.cpp:1011
 msgid "no options available"
 msgstr ""
 
-#: src/Preferences.cpp:2179
+#: src/Preferences.cpp:2182
 msgid "Invalid category found, skipping"
 msgstr ""
 
-#: src/Preferences.cpp:2348
+#: src/Preferences.cpp:2351
 msgid "TCP port can't be higher than 65532 due to server UDP socket being TCP+3"
 msgstr ""
 
-#: src/Preferences.cpp:2349
+#: src/Preferences.cpp:2352
 #, c-format
 msgid "Default port will be used (%d)"
 msgstr ""
@@ -5961,23 +5974,27 @@ msgstr ""
 msgid "Shared folder"
 msgstr ""
 
-#: src/SearchDlg.cpp:425
+#: src/SearchDlg.cpp:280
+msgid "Clear search history"
+msgstr ""
+
+#: src/SearchDlg.cpp:584
 msgid "It's impossible to search when both eD2k and Kademlia are disabled."
 msgstr ""
 
-#: src/SearchDlg.cpp:426 src/SearchListCtrl.cpp:858
+#: src/SearchDlg.cpp:585 src/SearchListCtrl.cpp:858
 msgid "Search error"
 msgstr ""
 
-#: src/SearchDlg.cpp:768
+#: src/SearchDlg.cpp:929
 msgid "Min size must be smaller than max size. Max size ignored."
 msgstr ""
 
-#: src/SearchDlg.cpp:769 src/SearchDlg.cpp:851
+#: src/SearchDlg.cpp:930 src/SearchDlg.cpp:1012
 msgid "Search warning"
 msgstr ""
 
-#: src/SearchDlg.cpp:929 src/SearchListCtrl.cpp:735
+#: src/SearchDlg.cpp:1092 src/SearchListCtrl.cpp:735
 msgid "Main"
 msgstr ""
 

--- a/po/en_GB.po
+++ b/po/en_GB.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-28 12:17+0200\n"
+"POT-Creation-Date: 2026-07-28 13:09+0200\n"
 "PO-Revision-Date: 2020-03-04 14:43+0100\n"
 "Last-Translator: Dévai Tamás <devait@vnet.hu>\n"
 "Language-Team: aMule Team <https://github.com/amule-org/amule>\n"
@@ -276,7 +276,7 @@ msgid "Password set and external connections enabled."
 msgstr ""
 
 #: src/amule.cpp:755 src/KadDlg.cpp:176 src/KadDlg.cpp:185
-#: src/PrefsUnifiedDlg.cpp:1461 src/SharedFilesCtrl.cpp:476
+#: src/PrefsUnifiedDlg.cpp:1470 src/SharedFilesCtrl.cpp:476
 msgid "WARNING"
 msgstr ""
 
@@ -311,7 +311,7 @@ msgstr ""
 #: src/amule-remote-gui.cpp:603 src/amule-remote-gui.cpp:671
 #: src/amule-remote-gui.cpp:709 src/amule-remote-gui.cpp:1282
 #: src/amule-remote-gui.cpp:1345 src/amule-remote-gui.cpp:1372
-#: src/DownloadQueue.cpp:1481 src/PrefsUnifiedDlg.cpp:1247
+#: src/DownloadQueue.cpp:1481 src/PrefsUnifiedDlg.cpp:1256
 msgid "ERROR"
 msgstr ""
 
@@ -564,36 +564,36 @@ msgstr ""
 msgid "FATAL ERROR: Failed to create Timer"
 msgstr ""
 
-#: src/amuleDlg.cpp:361 src/amuleDlg.cpp:1787 src/amuleDlg.cpp:2033
-#: src/muuli_wdr.cpp:1492 src/muuli_wdr.cpp:3449
+#: src/amuleDlg.cpp:361 src/amuleDlg.cpp:1810 src/amuleDlg.cpp:2056
+#: src/muuli_wdr.cpp:1492 src/muuli_wdr.cpp:3453
 msgid "Networks"
 msgstr ""
 
-#: src/amuleDlg.cpp:362 src/amuleDlg.cpp:1793 src/muuli_wdr.cpp:3450
+#: src/amuleDlg.cpp:362 src/amuleDlg.cpp:1816 src/muuli_wdr.cpp:3454
 msgid "Searches"
 msgstr ""
 
-#: src/amuleDlg.cpp:363 src/amuleDlg.cpp:1799 src/DownloadListCtrl.cpp:740
-#: src/muuli_wdr.cpp:392 src/muuli_wdr.cpp:1585 src/muuli_wdr.cpp:3451
+#: src/amuleDlg.cpp:363 src/amuleDlg.cpp:1822 src/DownloadListCtrl.cpp:740
+#: src/muuli_wdr.cpp:392 src/muuli_wdr.cpp:1585 src/muuli_wdr.cpp:3455
 #: src/Statistics.cpp:829
 msgid "Downloads"
 msgstr ""
 
-#: src/amuleDlg.cpp:364 src/amuleDlg.cpp:1805 src/muuli_wdr.cpp:3325
+#: src/amuleDlg.cpp:364 src/amuleDlg.cpp:1828 src/muuli_wdr.cpp:3329
 msgid "Shared files"
 msgstr ""
 
-#: src/amuleDlg.cpp:365 src/amuleDlg.cpp:1811 src/muuli_wdr.cpp:2957
-#: src/muuli_wdr.cpp:3407 src/muuli_wdr.cpp:3454
+#: src/amuleDlg.cpp:365 src/amuleDlg.cpp:1834 src/muuli_wdr.cpp:2961
+#: src/muuli_wdr.cpp:3411 src/muuli_wdr.cpp:3458
 msgid "Messages"
 msgstr ""
 
-#: src/amuleDlg.cpp:366 src/amuleDlg.cpp:1817 src/muuli_wdr.cpp:3455
+#: src/amuleDlg.cpp:366 src/amuleDlg.cpp:1840 src/muuli_wdr.cpp:3459
 #: src/PrefsUnifiedDlg.cpp:314 src/Statistics.cpp:779 src/Statistics.cpp:1235
 msgid "Statistics"
 msgstr ""
 
-#: src/amuleDlg.cpp:368 src/amuleDlg.cpp:1824 src/muuli_wdr.cpp:3457
+#: src/amuleDlg.cpp:368 src/amuleDlg.cpp:1847 src/muuli_wdr.cpp:3461
 #: src/PrefsUnifiedDlg.cpp:330 src/utils/wxCas/src/wxcasprefs.cpp:39
 msgid "Preferences"
 msgstr ""
@@ -651,8 +651,8 @@ msgstr ""
 #: src/amuleDlg.cpp:1029 src/DownloadListCtrl.cpp:505
 #: src/DownloadListCtrl.cpp:749 src/FriendListCtrl.cpp:180
 #: src/muuli_wdr.cpp:731 src/muuli_wdr.cpp:782 src/muuli_wdr.cpp:846
-#: src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2262 src/muuli_wdr.cpp:2347
-#: src/muuli_wdr.cpp:3095 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
+#: src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2266 src/muuli_wdr.cpp:2351
+#: src/muuli_wdr.cpp:3099 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
 #: src/ServerListCtrl.cpp:606 src/TransferWnd.cpp:378
 #: src/utils/wxCas/src/wxcasprefs.cpp:235
 msgid "Cancel"
@@ -663,7 +663,7 @@ msgid "Stop the current connection attempts"
 msgstr ""
 
 #: src/amuleDlg.cpp:1035 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976
-#: src/muuli_wdr.cpp:2485
+#: src/muuli_wdr.cpp:2489
 msgid "Disconnect"
 msgstr ""
 
@@ -672,7 +672,7 @@ msgid "Disconnect from the currently connected networks"
 msgstr ""
 
 #: src/amuleDlg.cpp:1041 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979
-#: src/muuli_wdr.cpp:2640 src/muuli_wdr.cpp:3092 src/muuli_wdr.cpp:3447
+#: src/muuli_wdr.cpp:2644 src/muuli_wdr.cpp:3096 src/muuli_wdr.cpp:3451
 msgid "Connect"
 msgstr ""
 
@@ -726,7 +726,7 @@ msgstr ""
 msgid "Launch Command: "
 msgstr ""
 
-#: src/amuleDlg.cpp:1632 src/muuli_wdr.cpp:1982 src/Preferences.cpp:979
+#: src/amuleDlg.cpp:1632 src/muuli_wdr.cpp:1986 src/Preferences.cpp:979
 msgid "- default -"
 msgstr ""
 
@@ -740,60 +740,60 @@ msgstr ""
 msgid "WARNING: Unable to open skin file '%s' for read"
 msgstr ""
 
-#: src/amuleDlg.cpp:1791 src/muuli_wdr.cpp:3449
+#: src/amuleDlg.cpp:1814 src/muuli_wdr.cpp:3453
 msgid "Networks Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1797 src/muuli_wdr.cpp:3450
+#: src/amuleDlg.cpp:1820 src/muuli_wdr.cpp:3454
 msgid "Searches Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1803 src/muuli_wdr.cpp:3451
+#: src/amuleDlg.cpp:1826 src/muuli_wdr.cpp:3455
 msgid "Downloads Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1809 src/muuli_wdr.cpp:3453
+#: src/amuleDlg.cpp:1832 src/muuli_wdr.cpp:3457
 msgid "Shared Files Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1815 src/muuli_wdr.cpp:3454
+#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3458
 msgid "Messages Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1821 src/muuli_wdr.cpp:3455
+#: src/amuleDlg.cpp:1844 src/muuli_wdr.cpp:3459
 msgid "Statistics Graph Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1828 src/muuli_wdr.cpp:3457
+#: src/amuleDlg.cpp:1851 src/muuli_wdr.cpp:3461
 msgid "Preferences Settings Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1831 src/muuli_wdr.cpp:3458
+#: src/amuleDlg.cpp:1854 src/muuli_wdr.cpp:3462
 msgid "Import"
 msgstr ""
 
-#: src/amuleDlg.cpp:1835 src/muuli_wdr.cpp:3458
+#: src/amuleDlg.cpp:1858 src/muuli_wdr.cpp:3462
 msgid "The partfile importer tool"
 msgstr ""
 
-#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3459
+#: src/amuleDlg.cpp:1861 src/muuli_wdr.cpp:3463
 #: src/utils/aLinkCreator/src/alcframe.cpp:262
 msgid "About"
 msgstr ""
 
-#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3459
+#: src/amuleDlg.cpp:1861 src/muuli_wdr.cpp:3463
 msgid "About/Help"
 msgstr ""
 
-#: src/amuleDlg.cpp:2036
+#: src/amuleDlg.cpp:2059
 msgid "eD2k network"
 msgstr ""
 
-#: src/amuleDlg.cpp:2039
+#: src/amuleDlg.cpp:2062
 msgid "Kad network"
 msgstr ""
 
-#: src/amuleDlg.cpp:2039
+#: src/amuleDlg.cpp:2062
 msgid "No network"
 msgstr ""
 
@@ -1320,19 +1320,19 @@ msgstr ""
 msgid "Very low"
 msgstr ""
 
-#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:743 src/muuli_wdr.cpp:2313
+#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:743 src/muuli_wdr.cpp:2317
 #: src/ServerListCtrl.cpp:263 src/ServerListCtrl.cpp:456
 #: src/SharedFilesCtrl.cpp:145
 msgid "Low"
 msgstr ""
 
-#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:744 src/muuli_wdr.cpp:2314
+#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:744 src/muuli_wdr.cpp:2318
 #: src/ServerListCtrl.cpp:266 src/ServerListCtrl.cpp:457
 #: src/SharedFilesCtrl.cpp:146
 msgid "Normal"
 msgstr ""
 
-#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:745 src/muuli_wdr.cpp:2315
+#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:745 src/muuli_wdr.cpp:2319
 #: src/ServerListCtrl.cpp:269 src/ServerListCtrl.cpp:458
 #: src/SharedFilesCtrl.cpp:147
 msgid "High"
@@ -1424,7 +1424,7 @@ msgstr ""
 msgid "Remote Server"
 msgstr ""
 
-#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3212
+#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3216
 #: src/SearchDlg.cpp:119 src/TextClient.cpp:911
 msgid "Kad"
 msgstr ""
@@ -1495,7 +1495,7 @@ msgstr ""
 msgid "Size"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3279
+#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3283
 msgid "Transferred"
 msgstr ""
 
@@ -1551,7 +1551,7 @@ msgid ""
 "\n"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:746 src/muuli_wdr.cpp:2316
+#: src/DownloadListCtrl.cpp:746 src/muuli_wdr.cpp:2320
 #: src/SharedFilesCtrl.cpp:150
 msgid "Auto"
 msgstr ""
@@ -1589,7 +1589,7 @@ msgid "Extended Options"
 msgstr ""
 
 #: src/DownloadListCtrl.cpp:770 src/DownloadListCtrl.cpp:822
-#: src/muuli_wdr.cpp:1800
+#: src/muuli_wdr.cpp:1804
 msgid "Preview"
 msgstr ""
 
@@ -2355,23 +2355,23 @@ msgid ""
 "want downloads on a different (e.g. larger) disk."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:549 src/FirstRunWizard.cpp:611 src/muuli_wdr.cpp:1712
+#: src/FirstRunWizard.cpp:549 src/FirstRunWizard.cpp:611 src/muuli_wdr.cpp:1716
 msgid "Destination folder for downloads"
 msgstr ""
 
 #: src/FirstRunWizard.cpp:553 src/FirstRunWizard.cpp:569 src/muuli_wdr.cpp:1349
-#: src/muuli_wdr.cpp:1366 src/muuli_wdr.cpp:1687 src/muuli_wdr.cpp:1718
-#: src/muuli_wdr.cpp:1730 src/muuli_wdr.cpp:2800
+#: src/muuli_wdr.cpp:1366 src/muuli_wdr.cpp:1691 src/muuli_wdr.cpp:1722
+#: src/muuli_wdr.cpp:1734 src/muuli_wdr.cpp:2804
 #: src/utils/aLinkCreator/src/alcframe.cpp:135
 #: src/utils/wxCas/src/wxcasprefs.cpp:52 src/utils/wxCas/src/wxcasprefs.cpp:118
 msgid "Browse"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:559 src/muuli_wdr.cpp:1723
+#: src/FirstRunWizard.cpp:559 src/muuli_wdr.cpp:1727
 msgid "(All files in this folder are shared with other peers)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:565 src/FirstRunWizard.cpp:624 src/muuli_wdr.cpp:1725
+#: src/FirstRunWizard.cpp:565 src/FirstRunWizard.cpp:624 src/muuli_wdr.cpp:1729
 msgid "Folder for temporary download files"
 msgstr ""
 
@@ -2402,7 +2402,7 @@ msgstr ""
 msgid "CRITICAL - no client on StartChatSession"
 msgstr ""
 
-#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2706 src/muuli_wdr.cpp:3383
+#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2710 src/muuli_wdr.cpp:3387
 msgid "Friends"
 msgstr ""
 
@@ -2508,8 +2508,8 @@ msgstr ""
 msgid "No"
 msgstr ""
 
-#: src/GenericClientListCtrl.cpp:1216 src/PrefsUnifiedDlg.cpp:2898
-#: src/PrefsUnifiedDlg.cpp:2948 src/ServerListCtrl.cpp:276
+#: src/GenericClientListCtrl.cpp:1216 src/PrefsUnifiedDlg.cpp:2907
+#: src/PrefsUnifiedDlg.cpp:2957 src/ServerListCtrl.cpp:276
 msgid "Yes"
 msgstr ""
 
@@ -2676,10 +2676,10 @@ msgstr ""
 msgid "Please fill all fields required"
 msgstr ""
 
-#: src/KadDlg.cpp:192 src/PartFile.cpp:1031 src/PrefsUnifiedDlg.cpp:1134
-#: src/PrefsUnifiedDlg.cpp:1204 src/PrefsUnifiedDlg.cpp:1405
-#: src/PrefsUnifiedDlg.cpp:1663 src/PrefsUnifiedDlg.cpp:1673
-#: src/PrefsUnifiedDlg.cpp:1690 src/PrefsUnifiedDlg.cpp:1738
+#: src/KadDlg.cpp:192 src/PartFile.cpp:1031 src/PrefsUnifiedDlg.cpp:1143
+#: src/PrefsUnifiedDlg.cpp:1213 src/PrefsUnifiedDlg.cpp:1414
+#: src/PrefsUnifiedDlg.cpp:1672 src/PrefsUnifiedDlg.cpp:1682
+#: src/PrefsUnifiedDlg.cpp:1699 src/PrefsUnifiedDlg.cpp:1747
 msgid "Message"
 msgstr ""
 
@@ -2780,7 +2780,7 @@ msgstr ""
 msgid "Uploaded"
 msgstr ""
 
-#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3263
+#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3267
 msgid "Requested"
 msgstr ""
 
@@ -2903,7 +2903,7 @@ msgid "WARNING: "
 msgstr ""
 
 #: src/MuleNotebook.cpp:179 src/muuli_wdr.cpp:817 src/muuli_wdr.cpp:1229
-#: src/muuli_wdr.cpp:3167 src/muuli_wdr.cpp:3423
+#: src/muuli_wdr.cpp:3171 src/muuli_wdr.cpp:3427
 msgid "Close"
 msgstr ""
 
@@ -2921,7 +2921,7 @@ msgid "Paste"
 msgstr ""
 
 #: src/MuleTextCtrl.cpp:89 src/muuli_wdr.cpp:358 src/muuli_wdr.cpp:757
-#: src/muuli_wdr.cpp:2390 src/muuli_wdr.cpp:2409 src/muuli_wdr.cpp:2431
+#: src/muuli_wdr.cpp:2394 src/muuli_wdr.cpp:2413 src/muuli_wdr.cpp:2435
 #: src/utils/aLinkCreator/src/alcframe.cpp:142
 msgid "Clear"
 msgstr ""
@@ -3013,7 +3013,7 @@ msgstr ""
 
 #: src/MuleTrayIcon.cpp:579 src/MuleTrayIcon.cpp:945 src/MuleTrayIcon.cpp:965
 #: src/muuli_wdr.cpp:1398 src/muuli_wdr.cpp:1406 src/muuli_wdr.cpp:1413
-#: src/muuli_wdr.cpp:1846 src/muuli_wdr.cpp:1852 src/OtherFunctions.cpp:91
+#: src/muuli_wdr.cpp:1850 src/muuli_wdr.cpp:1856 src/OtherFunctions.cpp:91
 #: src/StatisticsDlg.cpp:93 src/StatisticsDlg.cpp:95
 msgid "kB/s"
 msgstr ""
@@ -3253,7 +3253,7 @@ msgstr ""
 msgid "KB"
 msgstr ""
 
-#: src/muuli_wdr.cpp:274 src/muuli_wdr.cpp:293 src/muuli_wdr.cpp:1631
+#: src/muuli_wdr.cpp:274 src/muuli_wdr.cpp:293 src/muuli_wdr.cpp:1635
 #: src/OtherFunctions.cpp:64
 msgid "MB"
 msgstr ""
@@ -3270,7 +3270,7 @@ msgstr ""
 msgid "Availability"
 msgstr ""
 
-#: src/muuli_wdr.cpp:312 src/muuli_wdr.cpp:398 src/muuli_wdr.cpp:3328
+#: src/muuli_wdr.cpp:312 src/muuli_wdr.cpp:398 src/muuli_wdr.cpp:3332
 msgid "Filter:"
 msgstr ""
 
@@ -3333,8 +3333,8 @@ msgstr ""
 #: src/muuli_wdr.cpp:1160 src/muuli_wdr.cpp:1167 src/muuli_wdr.cpp:1172
 #: src/muuli_wdr.cpp:1179 src/muuli_wdr.cpp:1184 src/muuli_wdr.cpp:1191
 #: src/muuli_wdr.cpp:1205 src/muuli_wdr.cpp:1212 src/muuli_wdr.cpp:1217
-#: src/muuli_wdr.cpp:1224 src/muuli_wdr.cpp:3265 src/muuli_wdr.cpp:3273
-#: src/muuli_wdr.cpp:3281
+#: src/muuli_wdr.cpp:1224 src/muuli_wdr.cpp:3269 src/muuli_wdr.cpp:3277
+#: src/muuli_wdr.cpp:3285
 msgid "N/A"
 msgstr ""
 
@@ -3474,7 +3474,7 @@ msgstr ""
 msgid "Album :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:685 src/muuli_wdr.cpp:2285
+#: src/muuli_wdr.cpp:685 src/muuli_wdr.cpp:2289
 msgid "Title :"
 msgstr ""
 
@@ -3580,7 +3580,7 @@ msgstr ""
 msgid "Userhash :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:895 src/muuli_wdr.cpp:1752 src/muuli_wdr.cpp:2480
+#: src/muuli_wdr.cpp:895 src/muuli_wdr.cpp:1756 src/muuli_wdr.cpp:2484
 #: src/utils/aLinkCreator/src/alcframe.cpp:137
 msgid "Add"
 msgstr ""
@@ -3589,15 +3589,15 @@ msgstr ""
 msgid "Download-Speed"
 msgstr ""
 
-#: src/muuli_wdr.cpp:954 src/muuli_wdr.cpp:989 src/muuli_wdr.cpp:2584
+#: src/muuli_wdr.cpp:954 src/muuli_wdr.cpp:989 src/muuli_wdr.cpp:2588
 msgid "Current"
 msgstr ""
 
-#: src/muuli_wdr.cpp:962 src/muuli_wdr.cpp:997 src/muuli_wdr.cpp:2592
+#: src/muuli_wdr.cpp:962 src/muuli_wdr.cpp:997 src/muuli_wdr.cpp:2596
 msgid "Running average"
 msgstr ""
 
-#: src/muuli_wdr.cpp:970 src/muuli_wdr.cpp:1005 src/muuli_wdr.cpp:2600
+#: src/muuli_wdr.cpp:970 src/muuli_wdr.cpp:1005 src/muuli_wdr.cpp:2604
 msgid "Session average"
 msgstr ""
 
@@ -3609,7 +3609,7 @@ msgstr ""
 msgid "Connections"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1024 src/muuli_wdr.cpp:1871
+#: src/muuli_wdr.cpp:1024 src/muuli_wdr.cpp:1875
 msgid "Active downloads"
 msgstr ""
 
@@ -3617,7 +3617,7 @@ msgstr ""
 msgid "Active connections (1:1)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1040 src/muuli_wdr.cpp:1872
+#: src/muuli_wdr.cpp:1040 src/muuli_wdr.cpp:1876
 msgid "Active uploads"
 msgstr ""
 
@@ -3890,7 +3890,7 @@ msgstr ""
 msgid "Advanced users only: If you have multiple network interfaces, enter the address of the interface to which aMule should be bound."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1462 src/muuli_wdr.cpp:2065
+#: src/muuli_wdr.cpp:1462 src/muuli_wdr.cpp:2069
 msgid "Bind to network interface (empty for any):"
 msgstr ""
 
@@ -3906,7 +3906,7 @@ msgstr ""
 msgid "Max simultaneous connections:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1498 src/muuli_wdr.cpp:3207
+#: src/muuli_wdr.cpp:1498 src/muuli_wdr.cpp:3211
 msgid "ED2K"
 msgstr ""
 
@@ -3998,763 +3998,763 @@ msgstr ""
 msgid "For new files preallocates disk space for the whole file, thus reduces fragmentation"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1617
+#: src/muuli_wdr.cpp:1621
 msgid "Create new files as sparse files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1618
+#: src/muuli_wdr.cpp:1622
 msgid "Sparse part files only occupy disk space for the parts already downloaded, so free space is used up gradually as the file fills in. Turn this off to use an ordinary file instead - useful where sparse files are unsupported or slow, or where backup/de-duplication tools handle them badly. Applies only when the core runs on Windows; on Linux and macOS part files are sparse anyway and this setting has no effect."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1623
+#: src/muuli_wdr.cpp:1627
 msgid "Stop downloads when free disk space reaches "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1624
+#: src/muuli_wdr.cpp:1628
 msgid "Select this if you want aMule to check your disk space"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1628
+#: src/muuli_wdr.cpp:1632
 msgid "Enter here the min disk space desired."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1634
+#: src/muuli_wdr.cpp:1638
 msgid "Save 10 sources on rare files (< 20 sources)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1638 src/Statistics.cpp:790
+#: src/muuli_wdr.cpp:1642 src/Statistics.cpp:790
 msgid "Uploads"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1641
+#: src/muuli_wdr.cpp:1645
 msgid "Add new shared files with auto priority"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1647
+#: src/muuli_wdr.cpp:1651
 msgid "Intelligent Corruption Handling (I.C.H.)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1650
+#: src/muuli_wdr.cpp:1654
 msgid "Enable"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1653
+#: src/muuli_wdr.cpp:1657
 msgid "Advanced I.C.H. trusts every hash (not recommended)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1665 src/PrefsUnifiedDlg.cpp:1990
+#: src/muuli_wdr.cpp:1669 src/PrefsUnifiedDlg.cpp:1999
 msgid "Media metadata extraction"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1669
+#: src/muuli_wdr.cpp:1673
 msgid "Extract length / bitrate / codec from shared audio and video files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1671
+#: src/muuli_wdr.cpp:1675
 msgid "When enabled, aMule runs ffprobe on each shared media file to fill in the Length / Bitrate / Codec columns other clients see when they find the file in a search. Requires ffmpeg (the ffprobe binary) to be installed."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1678
+#: src/muuli_wdr.cpp:1682
 msgid "Path to ffprobe:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1683
+#: src/muuli_wdr.cpp:1687
 msgid "Full path to the ffprobe binary. Leave empty to have aMule auto-detect it on startup."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1691
+#: src/muuli_wdr.cpp:1695
 msgid "Detect"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1692
+#: src/muuli_wdr.cpp:1696
 msgid "Search the standard install locations for an ffprobe binary and fill the path field."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1716
+#: src/muuli_wdr.cpp:1720
 msgid ""
 "Completed downloads are stored here. All files in this folder are automatically shared with other peers.\n"
 "If this folder also holds files you don't want to share, point it at an aMule-only sub-folder."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1719
+#: src/muuli_wdr.cpp:1723
 msgid "Pick the folder where completed downloads will be stored. All files in that folder will be shared with other peers."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1733
+#: src/muuli_wdr.cpp:1737
 msgid "Shared folders"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1739
+#: src/muuli_wdr.cpp:1743
 msgid "(Folders shared by the core. Enter a path to add one.)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1747
+#: src/muuli_wdr.cpp:1751
 msgid "Absolute path of a folder on the core's machine, e.g. /home/user/shared"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1749 src/PrefsUnifiedDlg.cpp:2874
+#: src/muuli_wdr.cpp:1753 src/PrefsUnifiedDlg.cpp:2883
 msgid "Recursive"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1750
+#: src/muuli_wdr.cpp:1754
 msgid "Share every sub-folder underneath this one, including ones created later."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1754 src/utils/aLinkCreator/src/alcframe.cpp:141
+#: src/muuli_wdr.cpp:1758 src/utils/aLinkCreator/src/alcframe.cpp:141
 msgid "Remove"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1758
+#: src/muuli_wdr.cpp:1762
 msgid "(Right click on folder icon for recursive share)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1765
+#: src/muuli_wdr.cpp:1769
 msgid "Share hidden files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1771
+#: src/muuli_wdr.cpp:1775
 msgid "Automatically rescan shared folders for changes"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1777
+#: src/muuli_wdr.cpp:1781
 msgid "Follow symbolic links in shared folders"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1783
+#: src/muuli_wdr.cpp:1787
 msgid "Exclude files matching:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1786
+#: src/muuli_wdr.cpp:1790
 msgid "Wildcard patterns separated by '|', e.g. .DS_Store|Thumbs.db|*.tmp. Files whose name matches are not shared. Matching is case-insensitive."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1790
+#: src/muuli_wdr.cpp:1794
 msgid "Patterns are regular expressions"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1791
+#: src/muuli_wdr.cpp:1795
 msgid "When set, the whole field is one regular expression ('|' is alternation). When unset, it is a list of '|'-separated wildcards."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1801
+#: src/muuli_wdr.cpp:1805
 msgid "Show how many shared files the current pattern would exclude."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1822
+#: src/muuli_wdr.cpp:1826
 msgid "Graphs"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1825 src/muuli_wdr.cpp:1887
+#: src/muuli_wdr.cpp:1829 src/muuli_wdr.cpp:1891
 msgid "Update delay : 5 secs"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1829
+#: src/muuli_wdr.cpp:1833
 msgid "Time for average graph: 100 mins"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1833
+#: src/muuli_wdr.cpp:1837
 msgid "Connections Graph Scale: 100 "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1840
+#: src/muuli_wdr.cpp:1844
 msgid "Download graph scale:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1848
+#: src/muuli_wdr.cpp:1852
 msgid "Upload graph scale:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1858
+#: src/muuli_wdr.cpp:1862
 msgid "Colors: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1862
+#: src/muuli_wdr.cpp:1866
 msgid "Background"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1863
+#: src/muuli_wdr.cpp:1867
 msgid "Grid"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1864
+#: src/muuli_wdr.cpp:1868
 msgid "Download current"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1865
+#: src/muuli_wdr.cpp:1869
 msgid "Download running average"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1866
+#: src/muuli_wdr.cpp:1870
 msgid "Download session average"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1867
+#: src/muuli_wdr.cpp:1871
 msgid "Upload current"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1868
+#: src/muuli_wdr.cpp:1872
 msgid "Upload running average"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1869
+#: src/muuli_wdr.cpp:1873
 msgid "Upload session average"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1870
+#: src/muuli_wdr.cpp:1874
 msgid "Active connections"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1873
+#: src/muuli_wdr.cpp:1877
 msgid "Systray Icon Speed Bar"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1874
+#: src/muuli_wdr.cpp:1878
 msgid "Kad-nodes current"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1875
+#: src/muuli_wdr.cpp:1879
 msgid "Kad-nodes running"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1876
+#: src/muuli_wdr.cpp:1880
 msgid "Kad-nodes session"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1880 src/muuli_wdr.cpp:2334
+#: src/muuli_wdr.cpp:1884 src/muuli_wdr.cpp:2338
 msgid "Select"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1884
+#: src/muuli_wdr.cpp:1888
 msgid "Tree"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1894
+#: src/muuli_wdr.cpp:1898
 msgid "Number of Client Versions shown (0=unlimited)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1919
+#: src/muuli_wdr.cpp:1923
 msgid "!!! WARNING !!!"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1934
+#: src/muuli_wdr.cpp:1938
 msgid "Max new connections / 5 secs"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1936
+#: src/muuli_wdr.cpp:1940
 msgid "Concurrent Kad source lookups"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1938
+#: src/muuli_wdr.cpp:1942
 msgid "Kad source re-search interval (minutes)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1940
+#: src/muuli_wdr.cpp:1944
 msgid "Source re-ask interval (minutes)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1944
+#: src/muuli_wdr.cpp:1948
 msgid "File Buffer Size: 240000 bytes"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1948
+#: src/muuli_wdr.cpp:1952
 msgid "Use MMAP: memory-mapped file access (lower memory use)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1949
+#: src/muuli_wdr.cpp:1953
 msgid "Maps part files into memory instead of buffering them on the heap, lowering the process memory footprint. May reduce download speed on some disks; best for memory-constrained or upload-heavy hosts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1951
+#: src/muuli_wdr.cpp:1955
 msgid "Upload Queue Size: 5000 clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1955
+#: src/muuli_wdr.cpp:1959
 msgid "Server connection refresh interval: Disable"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1959
+#: src/muuli_wdr.cpp:1963
 msgid "Disable computer's timed standby mode"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1978
+#: src/muuli_wdr.cpp:1982
 msgid "Skin to use: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1987
+#: src/muuli_wdr.cpp:1991
 msgid "Show \"Fast eD2k Links Handler\" in every window."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1990
+#: src/muuli_wdr.cpp:1994
 msgid "Show extended info on categories tabs"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1993
+#: src/muuli_wdr.cpp:1997
 msgid "Show application version on title"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1995
+#: src/muuli_wdr.cpp:1999
 msgid "Show transfer rates on title"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1997
+#: src/muuli_wdr.cpp:2001
 msgid "Before application name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1999
+#: src/muuli_wdr.cpp:2003
 msgid "After application name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2002
+#: src/muuli_wdr.cpp:2006
 msgid "Show overhead bandwidth"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2006
+#: src/muuli_wdr.cpp:2010
 msgid "Vertical toolbar orientation"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2008
+#: src/muuli_wdr.cpp:2012
 msgid "Live column sorting (auto-reorder rows as their values change)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2015
+#: src/muuli_wdr.cpp:2019
 msgid "Download Queue Files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2018
+#: src/muuli_wdr.cpp:2022
 msgid "Show progress percentage"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2024
+#: src/muuli_wdr.cpp:2028
 msgid "Show progress bar"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2027
+#: src/muuli_wdr.cpp:2031
 msgid "Flat"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2031
+#: src/muuli_wdr.cpp:2035
 msgid "Round"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2049
+#: src/muuli_wdr.cpp:2053
 msgid "External Connection Parameters"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2052
+#: src/muuli_wdr.cpp:2056
 msgid "Accept external connections"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2059 src/muuli_wdr.cpp:2118
+#: src/muuli_wdr.cpp:2063 src/muuli_wdr.cpp:2122
 msgid "IP of the listening interface:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2062
+#: src/muuli_wdr.cpp:2066
 msgid "Enter here a valid ip in the a.b.c.d format for the listening EC interface. An empty field or 0.0.0.0 will mean any interface."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2083 src/muuli_wdr.cpp:2194
+#: src/muuli_wdr.cpp:2087 src/muuli_wdr.cpp:2198
 msgid "TCP port:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2089
+#: src/muuli_wdr.cpp:2093
 msgid "Enable UPnP port forwarding on the EC port"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2093 src/muuli_wdr.cpp:3079
+#: src/muuli_wdr.cpp:2097 src/muuli_wdr.cpp:3083
 #: src/utils/wxCas/src/wxcasprefs.cpp:167
 msgid "Password"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2099
+#: src/muuli_wdr.cpp:2103
 msgid "aMule API server parameters"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2102
+#: src/muuli_wdr.cpp:2106
 msgid "Run amuleapi (REST API) on startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2107
+#: src/muuli_wdr.cpp:2111
 msgid "HTTP port:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2121
+#: src/muuli_wdr.cpp:2125
 msgid "The interface amuleapi's HTTP server listens on. 127.0.0.1 (default) accepts only local connections; use 0.0.0.0 or a specific IP to expose it to other hosts (set an admin password below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2126
+#: src/muuli_wdr.cpp:2130
 msgid "Type a password to set or change it. Stored passwords cannot be shown, so leaving this empty keeps the current one."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2128
+#: src/muuli_wdr.cpp:2132
 msgid "Admin password"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2140 src/muuli_wdr.cpp:2157 src/PrefsUnifiedDlg.cpp:1103
+#: src/muuli_wdr.cpp:2144 src/muuli_wdr.cpp:2161 src/PrefsUnifiedDlg.cpp:1112
 msgid "A password is set."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2144
+#: src/muuli_wdr.cpp:2148
 msgid "Enable guest access"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2145
+#: src/muuli_wdr.cpp:2149
 msgid "Guest sessions may read status and listings but cannot change anything. Turning this off clears the stored guest password."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2149
+#: src/muuli_wdr.cpp:2153
 msgid "Guest password"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2164
+#: src/muuli_wdr.cpp:2168
 msgid "Web server parameters"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2167
+#: src/muuli_wdr.cpp:2171
 msgid "Run webserver on startup (deprecated)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2173
+#: src/muuli_wdr.cpp:2177
 msgid "Web template"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2178
+#: src/muuli_wdr.cpp:2182
 msgid "Full rights password"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2182
+#: src/muuli_wdr.cpp:2186
 msgid "Enable Low rights User"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2187
+#: src/muuli_wdr.cpp:2191
 msgid "Low rights password"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2201
+#: src/muuli_wdr.cpp:2205
 msgid "Enable UPnP port forwarding of the web server port"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2206
+#: src/muuli_wdr.cpp:2210
 msgid "Web server UPnP TCP port (Optional)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2214
+#: src/muuli_wdr.cpp:2218
 msgid "Page Refresh Time (in secs)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2221
+#: src/muuli_wdr.cpp:2225
 msgid "Enable Gzip compression"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2255
+#: src/muuli_wdr.cpp:2259
 msgid "Reset page to defaults"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2256
+#: src/muuli_wdr.cpp:2260
 msgid "Reset the settings on the current page to their default values."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2258 src/muuli_wdr.cpp:2344 src/ServerWnd.cpp:274
+#: src/muuli_wdr.cpp:2262 src/muuli_wdr.cpp:2348 src/ServerWnd.cpp:274
 #: src/ServerWnd.cpp:282
 msgid "OK"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2260
+#: src/muuli_wdr.cpp:2264
 msgid "Click here to apply any changes made to the preferences."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2263
+#: src/muuli_wdr.cpp:2267
 msgid "Reset any changes made to the preferences."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2292
+#: src/muuli_wdr.cpp:2296
 msgid "Comment :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2299
+#: src/muuli_wdr.cpp:2303
 msgid "Incoming Dir :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2308
+#: src/muuli_wdr.cpp:2312
 msgid "Change priority for new assigned files :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2312
+#: src/muuli_wdr.cpp:2316
 msgid "Don't change"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2324
+#: src/muuli_wdr.cpp:2328
 msgid "Select color for this Category (currently selected) :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2391 src/muuli_wdr.cpp:2410 src/muuli_wdr.cpp:2432
+#: src/muuli_wdr.cpp:2395 src/muuli_wdr.cpp:2414 src/muuli_wdr.cpp:2436
 msgid "Click this button to reset the log."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2451
+#: src/muuli_wdr.cpp:2455
 msgid "Click on this button to update the servers list from URL ..."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2455
+#: src/muuli_wdr.cpp:2459
 msgid "Server list"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2459
+#: src/muuli_wdr.cpp:2463
 msgid "Enter the url to a server.met file here and press the button to the left to update the list of known servers."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2464
+#: src/muuli_wdr.cpp:2468
 msgid "Add server manually: Name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2467
+#: src/muuli_wdr.cpp:2471
 msgid "Enter the name of the new server here"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2469 src/ServerWnd.cpp:206
+#: src/muuli_wdr.cpp:2473 src/ServerWnd.cpp:206
 msgid "IP:Port"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2472
+#: src/muuli_wdr.cpp:2476
 msgid "Enter the IP of the server here, using the x.x.x.x format."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2478
+#: src/muuli_wdr.cpp:2482
 msgid "Enter the port of the server here."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2481
+#: src/muuli_wdr.cpp:2485
 msgid "Add manually a server (fill fields to the left before) ..."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2510
+#: src/muuli_wdr.cpp:2514
 msgid "aMule Log"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2518
+#: src/muuli_wdr.cpp:2522
 msgid "Server Info"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2522
+#: src/muuli_wdr.cpp:2526
 msgid "ED2K Info"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2526
+#: src/muuli_wdr.cpp:2530
 msgid "Kad Info"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2554
+#: src/muuli_wdr.cpp:2558
 msgid "Click on this button to update the nodes list from URL ..."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2558
+#: src/muuli_wdr.cpp:2562
 msgid "Nodes (0)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2562
+#: src/muuli_wdr.cpp:2566
 msgid "Enter the url to a nodes.dat file here and press the button to the left to update the list of known nodes."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2565
+#: src/muuli_wdr.cpp:2569
 msgid "Nodes stats"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2607
+#: src/muuli_wdr.cpp:2611
 msgid "Bootstrap"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2610
+#: src/muuli_wdr.cpp:2614
 msgid "New node"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2615
+#: src/muuli_wdr.cpp:2619
 msgid "IP:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2635
+#: src/muuli_wdr.cpp:2639
 msgid "Port:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2648
+#: src/muuli_wdr.cpp:2652
 msgid "Bootstrap from known clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2650
+#: src/muuli_wdr.cpp:2654
 msgid "Disconnect Kad"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2684
+#: src/muuli_wdr.cpp:2688
 msgid "Use Secure User Identification"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2686
+#: src/muuli_wdr.cpp:2690
 msgid "It is recommended to enable this option. You will not receive credits if SUI is not enabled."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2688
+#: src/muuli_wdr.cpp:2692
 msgid "Protocol Obfuscation"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2691
+#: src/muuli_wdr.cpp:2695
 msgid "Support Protocol Obfuscation"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2693
+#: src/muuli_wdr.cpp:2697
 msgid "This option enabled Protocol Obfuscation, and makes aMule accept obfuscated connections from other clients."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2695
+#: src/muuli_wdr.cpp:2699
 msgid "Use obfuscation for outgoing connections"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2697
+#: src/muuli_wdr.cpp:2701
 msgid "This option makes aMule use Protocol Obfuscation when connecting other clients/servers."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2699
+#: src/muuli_wdr.cpp:2703
 msgid "Accept only obfuscated connections"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2700
+#: src/muuli_wdr.cpp:2704
 msgid "This option makes aMule only accept obfuscated connections. You will have less sources, but all your traffic will be obfuscated"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2705
+#: src/muuli_wdr.cpp:2709
 msgid "Everybody"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2707
+#: src/muuli_wdr.cpp:2711
 msgid "No one"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2709
+#: src/muuli_wdr.cpp:2713
 msgid "Who can see my shared files:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2710
+#: src/muuli_wdr.cpp:2714
 msgid "Select who can request to view a list of your shared files."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2712
+#: src/muuli_wdr.cpp:2716
 msgid "IP-Filtering"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2719
+#: src/muuli_wdr.cpp:2723
 msgid "Filter clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2721
+#: src/muuli_wdr.cpp:2725
 msgid "Enable filtering of the client IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2723
+#: src/muuli_wdr.cpp:2727
 msgid "Filter servers"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2725
+#: src/muuli_wdr.cpp:2729
 msgid "Enable filtering of the server IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2729
+#: src/muuli_wdr.cpp:2733
 msgid "Reload List"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2730
+#: src/muuli_wdr.cpp:2734
 msgid "Reload the list of IPs to filter from the file ~/.aMule/ipfilter.dat"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2736
+#: src/muuli_wdr.cpp:2740
 msgid "URL:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2740 src/muuli_wdr.cpp:2933
+#: src/muuli_wdr.cpp:2744 src/muuli_wdr.cpp:2937
 msgid "Update now"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2743
+#: src/muuli_wdr.cpp:2747
 msgid "Auto-update ipfilter at startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2747
+#: src/muuli_wdr.cpp:2751
 msgid "Filtering Level:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2753
+#: src/muuli_wdr.cpp:2757
 msgid "Always filter LAN IPs"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2756
+#: src/muuli_wdr.cpp:2760
 msgid "Paranoid handling of non-matching IPs"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2758
+#: src/muuli_wdr.cpp:2762
 msgid "Rejects a packet when its source IP differs from the IP the client claims (an anti-spoofing check). Disable only if it causes connection problems."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2760
+#: src/muuli_wdr.cpp:2764
 msgid "Use system-wide ipfilter.dat if available"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2761
+#: src/muuli_wdr.cpp:2765
 msgid "If there's no local ipfilter.dat found, allow usage of a system-wide ipfilter file."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2778
+#: src/muuli_wdr.cpp:2782
 msgid "Enable Online-Signature"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2780
+#: src/muuli_wdr.cpp:2784
 msgid "Enables the writing of the OS file, which can be used by external apps to create signatures and the like."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2784
+#: src/muuli_wdr.cpp:2788
 msgid "Update Frequency (Secs):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2787
+#: src/muuli_wdr.cpp:2791
 msgid "Change the frequency (in seconds) of Online Signature updates."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2795
+#: src/muuli_wdr.cpp:2799
 msgid "Save online signature file in: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:2801
+#: src/muuli_wdr.cpp:2805
 msgid "Click here to select the directory containing the the Online Signature files."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2834
+#: src/muuli_wdr.cpp:2838
 msgid "Show country flags for clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2835
+#: src/muuli_wdr.cpp:2839
 msgid "Render the country flag column in the transfers, queue and search views. Requires a valid MMDB GeoIP database (see below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2840
+#: src/muuli_wdr.cpp:2844
 msgid "Database"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2856
+#: src/muuli_wdr.cpp:2860
 msgid "Source:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2859
+#: src/muuli_wdr.cpp:2863
 msgid "DB-IP (free, no account)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2860
+#: src/muuli_wdr.cpp:2864
 msgid "MaxMind GeoLite2 (free, account required)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2861
+#: src/muuli_wdr.cpp:2865
 msgid "Custom URL"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2864
+#: src/muuli_wdr.cpp:2868
 msgid "Choose which provider supplies the GeoIP MMDB database. DB-IP is the default - no account required. MaxMind requires a free account + license key. Use Custom URL to point at any other MMDB host (e.g. a local mirror)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2881
+#: src/muuli_wdr.cpp:2885
 msgid ""
 "No configuration required.\n"
 "\n"
@@ -4762,11 +4762,11 @@ msgid ""
 "License: Creative Commons BY 4.0 - https://creativecommons.org/licenses/by/4.0/"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2894
+#: src/muuli_wdr.cpp:2898
 msgid "License key:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2900
+#: src/muuli_wdr.cpp:2904
 msgid ""
 "Sign up for a free MaxMind account, then generate a License Key:\n"
 "https://www.maxmind.com/en/geolite2/signup\n"
@@ -4776,222 +4776,222 @@ msgid ""
 "Requires attribution and account registration; refresh at least every 30 days."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2915
+#: src/muuli_wdr.cpp:2919
 msgid "Download URL:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2921
+#: src/muuli_wdr.cpp:2925
 msgid ""
 "Must point to an .mmdb file or a .gz / .tar.gz containing one.\n"
 "URL may include credentials (https://user:pass@host/...).\n"
 "License and attribution terms are set by the upstream URL - you are responsible."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2934
+#: src/muuli_wdr.cpp:2938
 msgid "Download the GeoIP database from the selected source."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2936
+#: src/muuli_wdr.cpp:2940
 msgid "Auto-update on startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2937
+#: src/muuli_wdr.cpp:2941
 msgid "Re-download the GeoIP database from the selected source every time aMule starts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2960
+#: src/muuli_wdr.cpp:2964
 msgid "Filter incoming messages (except current chat):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2962
+#: src/muuli_wdr.cpp:2966
 msgid "Filter all messages"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2964
+#: src/muuli_wdr.cpp:2968
 msgid "Filter messages from people not on your friend list"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2966
+#: src/muuli_wdr.cpp:2970
 msgid "Filter messages from unknown clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2968
+#: src/muuli_wdr.cpp:2972
 msgid "Filter messages containing (use ',' as separator):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2971 src/muuli_wdr.cpp:2982
+#: src/muuli_wdr.cpp:2975 src/muuli_wdr.cpp:2986
 msgid "add here the words amule should filter and block messages including it"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2973
+#: src/muuli_wdr.cpp:2977
 msgid "Show received messages in the log"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2976
+#: src/muuli_wdr.cpp:2980
 msgid "Comments"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2979
+#: src/muuli_wdr.cpp:2983
 msgid "Filter comments containing (use ',' as separator):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3004
+#: src/muuli_wdr.cpp:3008
 msgid "Enable Proxy"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3005
+#: src/muuli_wdr.cpp:3009
 msgid "Enable/disable proxy support"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3008
+#: src/muuli_wdr.cpp:3012
 msgid "Proxy type:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3019
+#: src/muuli_wdr.cpp:3023
 msgid "Proxy host:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3022
+#: src/muuli_wdr.cpp:3026
 msgid "The proxy host name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3024
+#: src/muuli_wdr.cpp:3028
 msgid "Proxy port:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3027
+#: src/muuli_wdr.cpp:3031
 msgid "The proxy port"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3029
+#: src/muuli_wdr.cpp:3033
 msgid "Enable authentication"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3030
+#: src/muuli_wdr.cpp:3034
 msgid "Enable/disable username/password authentication"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3033
+#: src/muuli_wdr.cpp:3037
 msgid "Username: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:3036
+#: src/muuli_wdr.cpp:3040
 msgid "The username to use to connect to the proxy"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3038
+#: src/muuli_wdr.cpp:3042
 msgid "Password:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3041
+#: src/muuli_wdr.cpp:3045
 msgid "The password to use to connect to the proxy"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3060
+#: src/muuli_wdr.cpp:3064
 msgid "Connect to:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3069
+#: src/muuli_wdr.cpp:3073
 msgid "Login to remote amule"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3074
+#: src/muuli_wdr.cpp:3078
 msgid "User name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3085
+#: src/muuli_wdr.cpp:3089
 msgid "Remember those settings"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3088
+#: src/muuli_wdr.cpp:3092
 msgid "Force ZLIB compression"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3112
+#: src/muuli_wdr.cpp:3116
 msgid "Enable Verbose Debug-Logging."
 msgstr ""
 
-#: src/muuli_wdr.cpp:3114
+#: src/muuli_wdr.cpp:3118
 msgid "Only to Logfile"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3116
+#: src/muuli_wdr.cpp:3120
 msgid "Message Categories:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3140 src/PartFileConvertDlg.cpp:160
+#: src/muuli_wdr.cpp:3144 src/PartFileConvertDlg.cpp:160
 msgid "Waiting..."
 msgstr ""
 
-#: src/muuli_wdr.cpp:3160
+#: src/muuli_wdr.cpp:3164
 msgid "Add imports"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3163
+#: src/muuli_wdr.cpp:3167
 msgid "Retry selected"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3165
+#: src/muuli_wdr.cpp:3169
 msgid "Remove selected"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3228
+#: src/muuli_wdr.cpp:3232
 msgid "Event Types"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3247
+#: src/muuli_wdr.cpp:3251
 msgid "Statistics and queued clients for selected file(s) : Session / All time"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3271
+#: src/muuli_wdr.cpp:3275
 msgid "Active Uploads"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3285
+#: src/muuli_wdr.cpp:3289
 msgid "Percent of total files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3337
+#: src/muuli_wdr.cpp:3341
 msgid "Show Clients for"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3339
+#: src/muuli_wdr.cpp:3343
 msgid "All files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3342
+#: src/muuli_wdr.cpp:3346
 msgid "Selected files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3345
+#: src/muuli_wdr.cpp:3349
 msgid "Active uploads only"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3352
+#: src/muuli_wdr.cpp:3356
 msgid "Reload:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3356
+#: src/muuli_wdr.cpp:3360
 msgid "Reload your shared files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3419
+#: src/muuli_wdr.cpp:3423
 msgid "Send"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3420
+#: src/muuli_wdr.cpp:3424
 msgid "Sends the specified message."
 msgstr ""
 
-#: src/muuli_wdr.cpp:3424
+#: src/muuli_wdr.cpp:3428
 msgid "Close this chat-session."
 msgstr ""
 
-#: src/muuli_wdr.cpp:3447
+#: src/muuli_wdr.cpp:3451
 msgid "Connect to any server and/or Kad"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3453 src/SharedFilesCtrl.cpp:142 src/Statistics.cpp:941
+#: src/muuli_wdr.cpp:3457 src/SharedFilesCtrl.cpp:142 src/Statistics.cpp:941
 msgid "Shared Files"
 msgstr ""
 
@@ -5615,400 +5615,400 @@ msgid ""
 "these settings."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:647
+#: src/PrefsUnifiedDlg.cpp:656
 #, c-format
 msgid "Failed to connect Cfg to widget with the ID %d and key %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:695
+#: src/PrefsUnifiedDlg.cpp:704
 #, c-format
 msgid "Failed to transfer data from Cfg to Widget with the ID %d and key %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:801
+#: src/PrefsUnifiedDlg.cpp:810
 msgid "The type of proxy you are connecting to"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1020
+#: src/PrefsUnifiedDlg.cpp:1029
 #, c-format
 msgid "Failed to transfer data from Widget to Cfg with the ID %d and key %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1103
+#: src/PrefsUnifiedDlg.cpp:1112
 msgid "No password set."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1132
+#: src/PrefsUnifiedDlg.cpp:1141
 msgid "Guest access needs a password. Type one in the guest password field, or untick Enable guest access."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1144
+#: src/PrefsUnifiedDlg.cpp:1153
 msgid ""
 "aMule must be restarted to enable these changes:\n"
 "\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1151
+#: src/PrefsUnifiedDlg.cpp:1160
 msgid "- TCP port changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1156
+#: src/PrefsUnifiedDlg.cpp:1165
 msgid "- UDP port changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1161
+#: src/PrefsUnifiedDlg.cpp:1170
 msgid "- Network interface binding changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1166
+#: src/PrefsUnifiedDlg.cpp:1175
 msgid "- External connect port changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1170
+#: src/PrefsUnifiedDlg.cpp:1179
 msgid "- External connect acceptance changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1174
+#: src/PrefsUnifiedDlg.cpp:1183
 msgid "- External connect interface changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1178
+#: src/PrefsUnifiedDlg.cpp:1187
 msgid "- Protocol obfuscation support changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1193
+#: src/PrefsUnifiedDlg.cpp:1202
 msgid "- amuleapi settings changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1202
+#: src/PrefsUnifiedDlg.cpp:1211
 msgid ""
 "Your Auto-update server list is empty.\n"
 "'Auto-update server list at startup' will be disabled."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1213
+#: src/PrefsUnifiedDlg.cpp:1222
 msgid ""
 "You have enabled external connections but have not specified a password.\n"
 "External connections cannot be enabled unless a valid password is specified."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1246
+#: src/PrefsUnifiedDlg.cpp:1255
 #, c-format
 msgid "The amuleapi password could not be saved: %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1276
+#: src/PrefsUnifiedDlg.cpp:1285
 msgid "- Language changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1281
+#: src/PrefsUnifiedDlg.cpp:1290
 msgid "- Temp folder changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1286
+#: src/PrefsUnifiedDlg.cpp:1295
 msgid "- ED2K network enabled.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1319
+#: src/PrefsUnifiedDlg.cpp:1328
 msgid "The shared-file exclusion pattern is not a valid regular expression. The filter has been left disabled."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1321 src/PrefsUnifiedDlg.cpp:1921
+#: src/PrefsUnifiedDlg.cpp:1330 src/PrefsUnifiedDlg.cpp:1930
 msgid "Invalid regular expression"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1398
+#: src/PrefsUnifiedDlg.cpp:1407
 msgid ""
 "Both eD2k and Kad network are disabled.\n"
 "You won't be able to connect until you enable at least one of them."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1403
+#: src/PrefsUnifiedDlg.cpp:1412
 msgid ""
 "Kad will not start if your UDP port is disabled.\n"
 "Enable UDP port or disable Kad."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1459
+#: src/PrefsUnifiedDlg.cpp:1468
 msgid ""
 "\n"
 "You MUST restart aMule now.\n"
 "If you do not restart now, don't complain if anything bad happens.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1524
+#: src/PrefsUnifiedDlg.cpp:1533
 msgid "Could not register aMule for autostart at login. The autostart store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1526
+#: src/PrefsUnifiedDlg.cpp:1535
 msgid "Could not remove the autostart-at-login entry."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1527
+#: src/PrefsUnifiedDlg.cpp:1536
 msgid "Autostart"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1542
+#: src/PrefsUnifiedDlg.cpp:1551
 msgid "Register file type"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1542
+#: src/PrefsUnifiedDlg.cpp:1551
 msgid "Register URL handler"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1550
+#: src/PrefsUnifiedDlg.cpp:1559
 #, c-format
 msgid "aMule only handles eD2k-compatible magnets. If you replace the current magnet handler (%s), BitTorrent magnet links will stop working - aMule cannot download BitTorrent content. Continue?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1555
+#: src/PrefsUnifiedDlg.cpp:1564
 #, c-format
 msgid "Another application currently opens .emulecollection files (%s). Replace it with aMule?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1560
+#: src/PrefsUnifiedDlg.cpp:1569
 #, c-format
 msgid "Another application is currently the default handler for these links (%s). Replace it with aMule?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1585
+#: src/PrefsUnifiedDlg.cpp:1594
 msgid "Could not register aMule for .emulecollection files. The registration store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1587
+#: src/PrefsUnifiedDlg.cpp:1596
 msgid "Could not remove the file type registration."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1589
+#: src/PrefsUnifiedDlg.cpp:1598
 msgid "Could not register aMule as the URL handler. The registration store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1591
+#: src/PrefsUnifiedDlg.cpp:1600
 msgid "Could not remove the URL handler registration."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1661 src/PrefsUnifiedDlg.cpp:1688
+#: src/PrefsUnifiedDlg.cpp:1670 src/PrefsUnifiedDlg.cpp:1697
 msgid "The web server and aMule API require external connections to be enabled."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1671
+#: src/PrefsUnifiedDlg.cpp:1680
 msgid "The aMule web server is deprecated. Consider running the aMule API instead."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1735
+#: src/PrefsUnifiedDlg.cpp:1744
 msgid ""
 "Your Auto-update servers list is in blank.\n"
 "Please fill in at least one URL to point to a valid server.met file.\n"
 "Click on the button \"List\" by this checkbox to enter an URL."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1876
+#: src/PrefsUnifiedDlg.cpp:1885
 msgid "Temporary files"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1881
+#: src/PrefsUnifiedDlg.cpp:1890
 msgid "Incoming files"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1886
+#: src/PrefsUnifiedDlg.cpp:1895
 msgid "Online Signatures"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1899
+#: src/PrefsUnifiedDlg.cpp:1908
 #, c-format
 msgid "Choose a folder for %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1923
+#: src/PrefsUnifiedDlg.cpp:1932
 #, c-format
 msgid "Would exclude %u of %u shared file"
 msgid_plural "Would exclude %u of %u shared files"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/PrefsUnifiedDlg.cpp:1940
+#: src/PrefsUnifiedDlg.cpp:1949
 msgid "Browse for videoplayer"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1944
+#: src/PrefsUnifiedDlg.cpp:1953
 msgid "Select browser"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1948
+#: src/PrefsUnifiedDlg.cpp:1957
 msgid "Select ffprobe binary"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1954
+#: src/PrefsUnifiedDlg.cpp:1963
 #, c-format
 msgid "Executable%s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1988
+#: src/PrefsUnifiedDlg.cpp:1997
 msgid "ffprobe not found on PATH or in the standard install locations. Install ffmpeg (which ships ffprobe) or use Browse to pick a binary manually."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2000
+#: src/PrefsUnifiedDlg.cpp:2009
 msgid "Reset the settings on this page to their default values?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2001
+#: src/PrefsUnifiedDlg.cpp:2010
 msgid "Reset to defaults"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2028
+#: src/PrefsUnifiedDlg.cpp:2037
 msgid "Edit server list"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2029
+#: src/PrefsUnifiedDlg.cpp:2038
 msgid ""
 "Add here URL's to download server.met files.\n"
 "Only one url on each line."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2084
+#: src/PrefsUnifiedDlg.cpp:2093
 msgid "IP2Country update failed"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2229 src/PrefsUnifiedDlg.cpp:2260
+#: src/PrefsUnifiedDlg.cpp:2238 src/PrefsUnifiedDlg.cpp:2269
 msgid "Data by MaxMind GeoLite2"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2231 src/PrefsUnifiedDlg.cpp:2262
+#: src/PrefsUnifiedDlg.cpp:2240 src/PrefsUnifiedDlg.cpp:2271
 msgid "Custom source"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2233 src/PrefsUnifiedDlg.cpp:2264
+#: src/PrefsUnifiedDlg.cpp:2242 src/PrefsUnifiedDlg.cpp:2273
 msgid "Data by DB-IP.com"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2284
+#: src/PrefsUnifiedDlg.cpp:2293
 #, c-format
 msgid "Status: Loaded%s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2286
+#: src/PrefsUnifiedDlg.cpp:2295
 #, c-format
 msgid "Status: Loaded%s - %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2290
+#: src/PrefsUnifiedDlg.cpp:2299
 msgid "Status: Failed to load - click 'Update now' to refresh."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2292
+#: src/PrefsUnifiedDlg.cpp:2301
 msgid "Status: Not found - click 'Update now' to download."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2350 src/PrefsUnifiedDlg.cpp:2374
+#: src/PrefsUnifiedDlg.cpp:2359 src/PrefsUnifiedDlg.cpp:2383
 #, c-format
 msgid "Update delay: %d second"
 msgid_plural "Update delay: %d seconds"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/PrefsUnifiedDlg.cpp:2358
+#: src/PrefsUnifiedDlg.cpp:2367
 #, c-format
 msgid "Time for average graph: %d minute"
 msgid_plural "Time for average graph: %d minutes"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/PrefsUnifiedDlg.cpp:2367
+#: src/PrefsUnifiedDlg.cpp:2376
 #, c-format
 msgid "Connections Graph Scale: %d"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2382
+#: src/PrefsUnifiedDlg.cpp:2391
 #, c-format
 msgid "File Buffer Size: %d byte"
 msgid_plural "File Buffer Size: %d bytes"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/PrefsUnifiedDlg.cpp:2392
+#: src/PrefsUnifiedDlg.cpp:2401
 #, c-format
 msgid "Upload Queue Size: %d client"
 msgid_plural "Upload Queue Size: %d clients"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/PrefsUnifiedDlg.cpp:2402
+#: src/PrefsUnifiedDlg.cpp:2411
 #, c-format
 msgid "Server connection refresh interval: %d minute"
 msgid_plural "Server connection refresh interval: %d minutes"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/PrefsUnifiedDlg.cpp:2407
+#: src/PrefsUnifiedDlg.cpp:2416
 msgid "Server connection refresh interval: Disabled"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2451
+#: src/PrefsUnifiedDlg.cpp:2460
 msgid "disabled"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2477
+#: src/PrefsUnifiedDlg.cpp:2486
 #, c-format
 msgid "Execute command on '%s' event"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2484
+#: src/PrefsUnifiedDlg.cpp:2493
 msgid "Enable command execution on core"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2496
+#: src/PrefsUnifiedDlg.cpp:2505
 msgid "Core command:"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2512
+#: src/PrefsUnifiedDlg.cpp:2521
 msgid "Enable command execution on GUI"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2524
+#: src/PrefsUnifiedDlg.cpp:2533
 msgid "GUI command:"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2540
+#: src/PrefsUnifiedDlg.cpp:2549
 msgid "The following variables will be replaced:"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2708
+#: src/PrefsUnifiedDlg.cpp:2717
 msgid ""
 "The following folders look like system or sensitive locations:\n"
 "\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2713
+#: src/PrefsUnifiedDlg.cpp:2722
 msgid "Sharing them recursively will publish every file underneath on the eD2k/Kad networks. Do you really want to do this?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2716
+#: src/PrefsUnifiedDlg.cpp:2725
 msgid "Confirm shared folders"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2744
+#: src/PrefsUnifiedDlg.cpp:2753
 msgid "Reloading shared files..."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2745
+#: src/PrefsUnifiedDlg.cpp:2754
 msgid "Scanning for subdirectories..."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2746
+#: src/PrefsUnifiedDlg.cpp:2755
 msgid "Updating shared folders"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2773
+#: src/PrefsUnifiedDlg.cpp:2782
 #, c-format
 msgid "Scanned %u directories..."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2823
+#: src/PrefsUnifiedDlg.cpp:2832
 #, c-format
 msgid "Reloading shared files: %u files scanned"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2873
+#: src/PrefsUnifiedDlg.cpp:2882
 msgid "Shared folder"
 msgstr ""
 
@@ -7636,12 +7636,12 @@ msgstr ""
 msgid "Hashset requested for unknown file: %s"
 msgstr ""
 
-#: src/UploadQueue.cpp:618
+#: src/UploadQueue.cpp:627
 #, c-format
 msgid "Resuming uploads of file: %s"
 msgstr ""
 
-#: src/UploadQueue.cpp:634
+#: src/UploadQueue.cpp:643
 #, c-format
 msgid "Suspending upload of file: %s"
 msgstr ""

--- a/po/es.po
+++ b/po/es.po
@@ -15,7 +15,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-28 08:06+0200\n"
+"POT-Creation-Date: 2026-07-28 10:19+0200\n"
 "PO-Revision-Date: 2026-07-27 11:36+0000\n"
 "Last-Translator: Diego Heras <ngosang@hotmail.es>\n"
 "Language-Team: Spanish <https://hosted.weblate.org/projects/amule/amule-application/es/>\n"
@@ -152,7 +152,7 @@ msgstr "Instalar"
 msgid "Not now"
 msgstr "Ahora no"
 
-#: src/AppImageIntegration.cpp:422 src/amuleDlg.cpp:600
+#: src/AppImageIntegration.cpp:422 src/amuleDlg.cpp:665
 msgid "Don't ask again"
 msgstr "No volver a preguntar"
 
@@ -229,7 +229,7 @@ msgid "Killing amuleweb instance with pid '%d' ... "
 msgstr "Matando la instancia de amuleweb con pid '%d'... "
 
 #: src/amule.cpp:336 src/amule.cpp:349 src/ClientRef.cpp:180
-#: src/SearchDlg.cpp:880 src/ServerListCtrl.cpp:98
+#: src/SearchDlg.cpp:1041 src/ServerListCtrl.cpp:98
 msgid "Failed"
 msgstr "Falló"
 
@@ -582,29 +582,67 @@ msgstr "No se puede crear el archivo Pid"
 msgid "ERROR: %s"
 msgstr "ERROR: %s"
 
-#: src/amuleDlg.cpp:236
+#: src/amuleDlg.cpp:250
 #, c-format
 msgid "This is aMule %s based on eMule."
 msgstr "Esto es aMule %s basado en eMule."
 
-#: src/amuleDlg.cpp:237
+#: src/amuleDlg.cpp:251
 #, c-format
 msgid "Running on %s"
 msgstr "Ejecutándose en %s"
 
-#: src/amuleDlg.cpp:239
+#: src/amuleDlg.cpp:253
 msgid "Visit https://github.com/amule-org/amule/releases/latest to check if a new version is available."
 msgstr "Visite https://github.com/amule-org/amule/releases/latest para comprobar si hay una nueva versión disponible."
 
-#: src/amuleDlg.cpp:268
+#: src/amuleDlg.cpp:282
 msgid "FATAL ERROR: Failed to create Timer"
 msgstr "ERROR FATAL: no se ha podido crear el temporizador"
 
-#: src/amuleDlg.cpp:592
+#: src/amuleDlg.cpp:361 src/amuleDlg.cpp:1787 src/amuleDlg.cpp:2033
+#: src/muuli_wdr.cpp:1492 src/muuli_wdr.cpp:3418
+msgid "Networks"
+msgstr "Redes"
+
+#: src/amuleDlg.cpp:362 src/amuleDlg.cpp:1793 src/muuli_wdr.cpp:3419
+msgid "Searches"
+msgstr "Búsquedas"
+
+#: src/amuleDlg.cpp:363 src/amuleDlg.cpp:1799 src/DownloadListCtrl.cpp:740
+#: src/muuli_wdr.cpp:392 src/muuli_wdr.cpp:1585 src/muuli_wdr.cpp:3420
+#: src/Statistics.cpp:829
+msgid "Downloads"
+msgstr "Descargas"
+
+#: src/amuleDlg.cpp:364 src/amuleDlg.cpp:1805 src/muuli_wdr.cpp:3294
+msgid "Shared files"
+msgstr "Compartidos"
+
+#: src/amuleDlg.cpp:365 src/amuleDlg.cpp:1811 src/muuli_wdr.cpp:2926
+#: src/muuli_wdr.cpp:3376 src/muuli_wdr.cpp:3423
+msgid "Messages"
+msgstr "Mensajes"
+
+#: src/amuleDlg.cpp:366 src/amuleDlg.cpp:1817 src/muuli_wdr.cpp:3424
+#: src/PrefsUnifiedDlg.cpp:312 src/Statistics.cpp:779 src/Statistics.cpp:1235
+msgid "Statistics"
+msgstr "Estadísticas"
+
+#: src/amuleDlg.cpp:368 src/amuleDlg.cpp:1824 src/muuli_wdr.cpp:3426
+#: src/PrefsUnifiedDlg.cpp:328 src/utils/wxCas/src/wxcasprefs.cpp:39
+msgid "Preferences"
+msgstr "Preferencias"
+
+#: src/amuleDlg.cpp:371
+msgid "Navigate"
+msgstr ""
+
+#: src/amuleDlg.cpp:657
 msgid "New version available"
 msgstr "Nueva versión disponible"
 
-#: src/amuleDlg.cpp:596
+#: src/amuleDlg.cpp:661
 #, c-format
 msgid ""
 "A new version of aMule (%s) is available.\n"
@@ -619,217 +657,184 @@ msgstr ""
 "\n"
 "¿Le gustaría abrir la página de descarga?"
 
-#: src/amuleDlg.cpp:678
+#: src/amuleDlg.cpp:743
 msgid "aMule dialog destroyed"
 msgstr "Diálogo de aMule destruido"
 
-#: src/amuleDlg.cpp:701 src/DataToText.cpp:68 src/IPFilter.cpp:547
+#: src/amuleDlg.cpp:766 src/DataToText.cpp:68 src/IPFilter.cpp:547
 msgid "Connecting"
 msgstr "Conectando"
 
-#: src/amuleDlg.cpp:893
+#: src/amuleDlg.cpp:958
 msgid "eD2k: Connecting"
 msgstr "eD2k: Conectando"
 
-#: src/amuleDlg.cpp:897
+#: src/amuleDlg.cpp:962
 msgid "eD2k: Disconnected"
 msgstr "eD2k: Desconectado"
 
-#: src/amuleDlg.cpp:903
+#: src/amuleDlg.cpp:968
 msgid "Kad: Firewalled"
 msgstr "Kad: tras cortafuegos"
 
-#: src/amuleDlg.cpp:907
+#: src/amuleDlg.cpp:972
 msgid "Kad: Connected"
 msgstr "Kad: conectado"
 
-#: src/amuleDlg.cpp:912
+#: src/amuleDlg.cpp:977
 msgid "Kad: Connecting"
 msgstr "Kad: conectando"
 
-#: src/amuleDlg.cpp:916
+#: src/amuleDlg.cpp:981
 msgid "Kad: Off"
 msgstr "Kad: apagado"
 
-#: src/amuleDlg.cpp:964 src/DownloadListCtrl.cpp:505
+#: src/amuleDlg.cpp:1029 src/DownloadListCtrl.cpp:505
 #: src/DownloadListCtrl.cpp:749 src/FriendListCtrl.cpp:180
 #: src/muuli_wdr.cpp:731 src/muuli_wdr.cpp:782 src/muuli_wdr.cpp:846
-#: src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2224 src/muuli_wdr.cpp:2309
-#: src/muuli_wdr.cpp:3057 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
+#: src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2231 src/muuli_wdr.cpp:2316
+#: src/muuli_wdr.cpp:3064 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
 #: src/ServerListCtrl.cpp:606 src/TransferWnd.cpp:378
 #: src/utils/wxCas/src/wxcasprefs.cpp:235
 msgid "Cancel"
 msgstr "Cancelar"
 
-#: src/amuleDlg.cpp:965
+#: src/amuleDlg.cpp:1030
 msgid "Stop the current connection attempts"
 msgstr "Detener los intentos de conexión actuales"
 
-#: src/amuleDlg.cpp:970 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976
-#: src/muuli_wdr.cpp:2447
+#: src/amuleDlg.cpp:1035 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976
+#: src/muuli_wdr.cpp:2454
 msgid "Disconnect"
 msgstr "Desconectar"
 
-#: src/amuleDlg.cpp:971
+#: src/amuleDlg.cpp:1036
 msgid "Disconnect from the currently connected networks"
 msgstr "Desconectarse de las redes conectadas"
 
-#: src/amuleDlg.cpp:976 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979
-#: src/muuli_wdr.cpp:2602 src/muuli_wdr.cpp:3054 src/muuli_wdr.cpp:3409
+#: src/amuleDlg.cpp:1041 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979
+#: src/muuli_wdr.cpp:2609 src/muuli_wdr.cpp:3061 src/muuli_wdr.cpp:3416
 msgid "Connect"
 msgstr "Conectar"
 
-#: src/amuleDlg.cpp:977
+#: src/amuleDlg.cpp:1042
 msgid "Connect to the currently enabled networks"
 msgstr "Conectarse a las redes habilitadas"
 
-#: src/amuleDlg.cpp:1089
+#: src/amuleDlg.cpp:1154
 #, c-format
 msgid "Up: %.1f%s (%.1f) | Down: %.1f%s (%.1f)"
 msgstr "Su: %.1f%s (%.1f) | De: %.1f%s (%.1f)"
 
-#: src/amuleDlg.cpp:1091 src/amuleDlg.cpp:1093 src/amuleDlg.cpp:1097
-#: src/amuleDlg.cpp:1099 src/amuleDlg.cpp:1110 src/amuleDlg.cpp:1112
+#: src/amuleDlg.cpp:1156 src/amuleDlg.cpp:1158 src/amuleDlg.cpp:1162
+#: src/amuleDlg.cpp:1164 src/amuleDlg.cpp:1175 src/amuleDlg.cpp:1177
 #: src/MuleTrayIcon.cpp:796 src/MuleTrayIcon.cpp:799
 msgid " MB/s"
 msgstr " MB/s"
 
-#: src/amuleDlg.cpp:1091 src/amuleDlg.cpp:1093 src/amuleDlg.cpp:1097
-#: src/amuleDlg.cpp:1099 src/amuleDlg.cpp:1110 src/amuleDlg.cpp:1112
+#: src/amuleDlg.cpp:1156 src/amuleDlg.cpp:1158 src/amuleDlg.cpp:1162
+#: src/amuleDlg.cpp:1164 src/amuleDlg.cpp:1175 src/amuleDlg.cpp:1177
 #: src/MuleTrayIcon.cpp:796 src/MuleTrayIcon.cpp:799
 #: src/utils/wxCas/src/wxcasframe.cpp:1041
 msgid " kB/s"
 msgstr " kB/s"
 
-#: src/amuleDlg.cpp:1096
+#: src/amuleDlg.cpp:1161
 #, c-format
 msgid "Up: %.1f%s | Down: %.1f%s"
 msgstr "Su: %.1f%s | De: %.1f%s"
 
-#: src/amuleDlg.cpp:1128
+#: src/amuleDlg.cpp:1193
 #, c-format
 msgid "aMule (%s | Connected)"
 msgstr "aMule (%s | Conectado)"
 
-#: src/amuleDlg.cpp:1130
+#: src/amuleDlg.cpp:1195
 #, c-format
 msgid "aMule (%s | Disconnected)"
 msgstr "aMule (%s | Desconectado)"
 
-#: src/amuleDlg.cpp:1183
+#: src/amuleDlg.cpp:1248
 #, c-format
 msgid "Do you really want to exit %s?"
 msgstr "¿Realmente desea cerrar %s?"
 
-#: src/amuleDlg.cpp:1185
+#: src/amuleDlg.cpp:1250
 msgid "Exit confirmation"
 msgstr "Confirmación de salida"
 
-#: src/amuleDlg.cpp:1548
+#: src/amuleDlg.cpp:1613
 msgid "Launch Command: "
 msgstr "Ejecutar comando: "
 
-#: src/amuleDlg.cpp:1567 src/muuli_wdr.cpp:1971 src/Preferences.cpp:951
+#: src/amuleDlg.cpp:1632 src/muuli_wdr.cpp:1978 src/Preferences.cpp:952
 msgid "- default -"
 msgstr "- predeterminado -"
 
-#: src/amuleDlg.cpp:1595
+#: src/amuleDlg.cpp:1660
 #, c-format
 msgid "Skin directory '%s' does not exist"
 msgstr "El directorio de tema '%s' no existe"
 
-#: src/amuleDlg.cpp:1598
+#: src/amuleDlg.cpp:1663
 #, c-format
 msgid "WARNING: Unable to open skin file '%s' for read"
 msgstr "AVISO: no se puede abrir el archivo de tema '%s' para lectura"
 
-#: src/amuleDlg.cpp:1722 src/amuleDlg.cpp:1968 src/muuli_wdr.cpp:1485
-#: src/muuli_wdr.cpp:3411
-msgid "Networks"
-msgstr "Redes"
-
-#: src/amuleDlg.cpp:1726 src/muuli_wdr.cpp:3411
+#: src/amuleDlg.cpp:1791 src/muuli_wdr.cpp:3418
 msgid "Networks Window"
 msgstr "Ventana de redes"
 
-#: src/amuleDlg.cpp:1728 src/muuli_wdr.cpp:3412
-msgid "Searches"
-msgstr "Búsquedas"
-
-#: src/amuleDlg.cpp:1732 src/muuli_wdr.cpp:3412
+#: src/amuleDlg.cpp:1797 src/muuli_wdr.cpp:3419
 msgid "Searches Window"
 msgstr "Ventana de búsquedas"
 
-#: src/amuleDlg.cpp:1734 src/DownloadListCtrl.cpp:740 src/muuli_wdr.cpp:392
-#: src/muuli_wdr.cpp:1578 src/muuli_wdr.cpp:3413 src/Statistics.cpp:829
-msgid "Downloads"
-msgstr "Descargas"
-
-#: src/amuleDlg.cpp:1738 src/muuli_wdr.cpp:3413
+#: src/amuleDlg.cpp:1803 src/muuli_wdr.cpp:3420
 msgid "Downloads Window"
 msgstr "Ventana de descargas"
 
-#: src/amuleDlg.cpp:1740 src/muuli_wdr.cpp:3287
-msgid "Shared files"
-msgstr "Compartidos"
-
-#: src/amuleDlg.cpp:1744 src/muuli_wdr.cpp:3415
+#: src/amuleDlg.cpp:1809 src/muuli_wdr.cpp:3422
 msgid "Shared Files Window"
 msgstr "Ventana de archivos compartidos"
 
-#: src/amuleDlg.cpp:1746 src/muuli_wdr.cpp:2919 src/muuli_wdr.cpp:3369
-#: src/muuli_wdr.cpp:3416
-msgid "Messages"
-msgstr "Mensajes"
-
-#: src/amuleDlg.cpp:1750 src/muuli_wdr.cpp:3416
+#: src/amuleDlg.cpp:1815 src/muuli_wdr.cpp:3423
 msgid "Messages Window"
 msgstr "Ventana de mensajes"
 
-#: src/amuleDlg.cpp:1752 src/muuli_wdr.cpp:3417 src/PrefsUnifiedDlg.cpp:312
-#: src/Statistics.cpp:779 src/Statistics.cpp:1235
-msgid "Statistics"
-msgstr "Estadísticas"
-
-#: src/amuleDlg.cpp:1756 src/muuli_wdr.cpp:3417
+#: src/amuleDlg.cpp:1821 src/muuli_wdr.cpp:3424
 msgid "Statistics Graph Window"
 msgstr "Ventana de gráficos de estadísticas"
 
-#: src/amuleDlg.cpp:1759 src/muuli_wdr.cpp:3419 src/PrefsUnifiedDlg.cpp:328
-#: src/utils/wxCas/src/wxcasprefs.cpp:39
-msgid "Preferences"
-msgstr "Preferencias"
-
-#: src/amuleDlg.cpp:1763 src/muuli_wdr.cpp:3419
+#: src/amuleDlg.cpp:1828 src/muuli_wdr.cpp:3426
 msgid "Preferences Settings Window"
 msgstr "Ventana de preferencias de configuración"
 
-#: src/amuleDlg.cpp:1766 src/muuli_wdr.cpp:3420
+#: src/amuleDlg.cpp:1831 src/muuli_wdr.cpp:3427
 msgid "Import"
 msgstr "Importar"
 
-#: src/amuleDlg.cpp:1770 src/muuli_wdr.cpp:3420
+#: src/amuleDlg.cpp:1835 src/muuli_wdr.cpp:3427
 msgid "The partfile importer tool"
 msgstr "La herramienta para importar archivos de partes"
 
-#: src/amuleDlg.cpp:1773 src/muuli_wdr.cpp:3421
+#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3428
 #: src/utils/aLinkCreator/src/alcframe.cpp:262
 msgid "About"
 msgstr "Acerca de"
 
-#: src/amuleDlg.cpp:1773 src/muuli_wdr.cpp:3421
+#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3428
 msgid "About/Help"
 msgstr "Acerca de/Ayuda"
 
-#: src/amuleDlg.cpp:1971
+#: src/amuleDlg.cpp:2036
 msgid "eD2k network"
 msgstr "Red eD2k"
 
-#: src/amuleDlg.cpp:1974
+#: src/amuleDlg.cpp:2039
 msgid "Kad network"
 msgstr "Red Kad"
 
-#: src/amuleDlg.cpp:1974
+#: src/amuleDlg.cpp:2039
 msgid "No network"
 msgstr "No hay red"
 
@@ -1362,19 +1367,19 @@ msgstr "Automática [Al]"
 msgid "Very low"
 msgstr "Muy baja"
 
-#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:743 src/muuli_wdr.cpp:2275
+#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:743 src/muuli_wdr.cpp:2282
 #: src/ServerListCtrl.cpp:263 src/ServerListCtrl.cpp:456
 #: src/SharedFilesCtrl.cpp:145
 msgid "Low"
 msgstr "Baja"
 
-#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:744 src/muuli_wdr.cpp:2276
+#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:744 src/muuli_wdr.cpp:2283
 #: src/ServerListCtrl.cpp:266 src/ServerListCtrl.cpp:457
 #: src/SharedFilesCtrl.cpp:146
 msgid "Normal"
 msgstr "Normal"
 
-#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:745 src/muuli_wdr.cpp:2277
+#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:745 src/muuli_wdr.cpp:2284
 #: src/ServerListCtrl.cpp:269 src/ServerListCtrl.cpp:458
 #: src/SharedFilesCtrl.cpp:147
 msgid "High"
@@ -1466,8 +1471,8 @@ msgstr "Servidor local"
 msgid "Remote Server"
 msgstr "Servidor remoto"
 
-#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3174
-#: src/SearchDlg.cpp:111 src/TextClient.cpp:911
+#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3181
+#: src/SearchDlg.cpp:119 src/TextClient.cpp:911
 msgid "Kad"
 msgstr "Kad"
 
@@ -1537,7 +1542,7 @@ msgstr "Parte"
 msgid "Size"
 msgstr "Tamaño"
 
-#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3241
+#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3248
 msgid "Transferred"
 msgstr "Transferido"
 
@@ -1595,7 +1600,7 @@ msgstr ""
 "Reacción desde: %s (%s)\n"
 "\n"
 
-#: src/DownloadListCtrl.cpp:746 src/muuli_wdr.cpp:2278
+#: src/DownloadListCtrl.cpp:746 src/muuli_wdr.cpp:2285
 #: src/SharedFilesCtrl.cpp:150
 msgid "Auto"
 msgstr "Automática"
@@ -1633,7 +1638,7 @@ msgid "Extended Options"
 msgstr "Opciones adicionales"
 
 #: src/DownloadListCtrl.cpp:770 src/DownloadListCtrl.cpp:822
-#: src/muuli_wdr.cpp:1789
+#: src/muuli_wdr.cpp:1796
 msgid "Preview"
 msgstr "Previsualizar"
 
@@ -2342,19 +2347,19 @@ msgstr ""
 msgid "eD2k"
 msgstr "eD2k"
 
-#: src/FirstRunWizard.cpp:349 src/muuli_wdr.cpp:1488
+#: src/FirstRunWizard.cpp:349 src/muuli_wdr.cpp:1495
 msgid "Kademlia"
 msgstr "Kademlia"
 
-#: src/FirstRunWizard.cpp:359 src/muuli_wdr.cpp:1416
+#: src/FirstRunWizard.cpp:359 src/muuli_wdr.cpp:1423
 msgid "Standard TCP Port "
 msgstr "Puerto TCP estándar "
 
-#: src/FirstRunWizard.cpp:365 src/muuli_wdr.cpp:1428
+#: src/FirstRunWizard.cpp:365 src/muuli_wdr.cpp:1435
 msgid "Extended UDP port (Kad / global search) "
 msgstr "Puerto UDP adicional (Kad / búsqueda global) "
 
-#: src/FirstRunWizard.cpp:377 src/muuli_wdr.cpp:1435
+#: src/FirstRunWizard.cpp:377 src/muuli_wdr.cpp:1442
 msgid "Enable UPnP for router port forwarding"
 msgstr "Habilitar UPnP para el reenvío del puerto del \"router\""
 
@@ -2381,7 +2386,7 @@ msgstr ""
 msgid "Your peer lists are already in place - nothing to download."
 msgstr "Ya está intentando descargar el archivo %s"
 
-#: src/FirstRunWizard.cpp:434 src/muuli_wdr.cpp:1533
+#: src/FirstRunWizard.cpp:434 src/muuli_wdr.cpp:1540
 msgid "Auto-update server list at startup"
 msgstr "Autoactualizar la lista de servidores al inicio"
 
@@ -2427,23 +2432,23 @@ msgid ""
 "want downloads on a different (e.g. larger) disk."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:549 src/FirstRunWizard.cpp:611 src/muuli_wdr.cpp:1701
+#: src/FirstRunWizard.cpp:549 src/FirstRunWizard.cpp:611 src/muuli_wdr.cpp:1708
 msgid "Destination folder for downloads"
 msgstr "Carpeta de destino para las descargas"
 
-#: src/FirstRunWizard.cpp:553 src/FirstRunWizard.cpp:569 src/muuli_wdr.cpp:1342
-#: src/muuli_wdr.cpp:1359 src/muuli_wdr.cpp:1676 src/muuli_wdr.cpp:1707
-#: src/muuli_wdr.cpp:1719 src/muuli_wdr.cpp:2762
+#: src/FirstRunWizard.cpp:553 src/FirstRunWizard.cpp:569 src/muuli_wdr.cpp:1349
+#: src/muuli_wdr.cpp:1366 src/muuli_wdr.cpp:1683 src/muuli_wdr.cpp:1714
+#: src/muuli_wdr.cpp:1726 src/muuli_wdr.cpp:2769
 #: src/utils/aLinkCreator/src/alcframe.cpp:135
 #: src/utils/wxCas/src/wxcasprefs.cpp:52 src/utils/wxCas/src/wxcasprefs.cpp:118
 msgid "Browse"
 msgstr "Examinar"
 
-#: src/FirstRunWizard.cpp:559 src/muuli_wdr.cpp:1712
+#: src/FirstRunWizard.cpp:559 src/muuli_wdr.cpp:1719
 msgid "(All files in this folder are shared with other peers)"
 msgstr "(Todos los archivos de esta carpeta se comparten con otros usuarios)"
 
-#: src/FirstRunWizard.cpp:565 src/FirstRunWizard.cpp:624 src/muuli_wdr.cpp:1714
+#: src/FirstRunWizard.cpp:565 src/FirstRunWizard.cpp:624 src/muuli_wdr.cpp:1721
 msgid "Folder for temporary download files"
 msgstr "Carpeta para los archivos temporales de las descargas"
 
@@ -2474,7 +2479,7 @@ msgstr "¡Error al abrir el archivo de amigos 'emfriends.met' para escritura!"
 msgid "CRITICAL - no client on StartChatSession"
 msgstr "CRÍTICO - no hay clientes en el inicio de sesión chat"
 
-#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2668 src/muuli_wdr.cpp:3345
+#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2675 src/muuli_wdr.cpp:3352
 msgid "Friends"
 msgstr "Amigos"
 
@@ -2858,7 +2863,7 @@ msgstr "Media de compartición"
 msgid "Uploaded"
 msgstr "Subido"
 
-#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3225
+#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3232
 msgid "Requested"
 msgstr "Pedido"
 
@@ -2981,7 +2986,7 @@ msgid "WARNING: "
 msgstr "AVISO: "
 
 #: src/MuleNotebook.cpp:179 src/muuli_wdr.cpp:817 src/muuli_wdr.cpp:1229
-#: src/muuli_wdr.cpp:3129 src/muuli_wdr.cpp:3385
+#: src/muuli_wdr.cpp:3136 src/muuli_wdr.cpp:3392
 msgid "Close"
 msgstr "Cerrar"
 
@@ -2994,12 +2999,12 @@ msgstr "Cortar"
 msgid "Copy"
 msgstr "Copiar"
 
-#: src/MuleTextCtrl.cpp:88
+#: src/MuleTextCtrl.cpp:88 src/SearchDlg.cpp:261
 msgid "Paste"
 msgstr "Pegar"
 
 #: src/MuleTextCtrl.cpp:89 src/muuli_wdr.cpp:358 src/muuli_wdr.cpp:757
-#: src/muuli_wdr.cpp:2352 src/muuli_wdr.cpp:2371 src/muuli_wdr.cpp:2393
+#: src/muuli_wdr.cpp:2359 src/muuli_wdr.cpp:2378 src/muuli_wdr.cpp:2400
 #: src/utils/aLinkCreator/src/alcframe.cpp:142
 msgid "Clear"
 msgstr "Limpiar"
@@ -3090,8 +3095,8 @@ msgid "Exit"
 msgstr "Salir"
 
 #: src/MuleTrayIcon.cpp:579 src/MuleTrayIcon.cpp:945 src/MuleTrayIcon.cpp:965
-#: src/muuli_wdr.cpp:1391 src/muuli_wdr.cpp:1399 src/muuli_wdr.cpp:1406
-#: src/muuli_wdr.cpp:1835 src/muuli_wdr.cpp:1841 src/OtherFunctions.cpp:91
+#: src/muuli_wdr.cpp:1398 src/muuli_wdr.cpp:1406 src/muuli_wdr.cpp:1413
+#: src/muuli_wdr.cpp:1842 src/muuli_wdr.cpp:1848 src/OtherFunctions.cpp:91
 #: src/StatisticsDlg.cpp:93 src/StatisticsDlg.cpp:95
 msgid "kB/s"
 msgstr "kB/s"
@@ -3260,7 +3265,7 @@ msgstr "Nombre:"
 msgid "Type"
 msgstr "Tipo"
 
-#: src/muuli_wdr.cpp:215 src/SearchDlg.cpp:110 src/SearchListCtrl.cpp:853
+#: src/muuli_wdr.cpp:215 src/SearchDlg.cpp:118 src/SearchListCtrl.cpp:853
 msgid "Local"
 msgstr "Local"
 
@@ -3331,7 +3336,7 @@ msgstr "Bytes"
 msgid "KB"
 msgstr "KB"
 
-#: src/muuli_wdr.cpp:274 src/muuli_wdr.cpp:293 src/muuli_wdr.cpp:1620
+#: src/muuli_wdr.cpp:274 src/muuli_wdr.cpp:293 src/muuli_wdr.cpp:1627
 #: src/OtherFunctions.cpp:64
 msgid "MB"
 msgstr "MB"
@@ -3348,7 +3353,7 @@ msgstr "Tamaño máximo"
 msgid "Availability"
 msgstr "Disponibilidad"
 
-#: src/muuli_wdr.cpp:312 src/muuli_wdr.cpp:398 src/muuli_wdr.cpp:3290
+#: src/muuli_wdr.cpp:312 src/muuli_wdr.cpp:398 src/muuli_wdr.cpp:3297
 msgid "Filter:"
 msgstr "Filtro:"
 
@@ -3380,7 +3385,7 @@ msgstr "Pide a los pares Kad que ya han respondido que amplíen la búsqueda. Ca
 msgid "Stop"
 msgstr "Parar"
 
-#: src/muuli_wdr.cpp:348 src/muuli_wdr.cpp:1385 src/SearchListCtrl.cpp:732
+#: src/muuli_wdr.cpp:348 src/muuli_wdr.cpp:1392 src/SearchListCtrl.cpp:732
 msgid "Download"
 msgstr "Descarga"
 
@@ -3411,8 +3416,8 @@ msgstr "Fuentes del archivo:"
 #: src/muuli_wdr.cpp:1160 src/muuli_wdr.cpp:1167 src/muuli_wdr.cpp:1172
 #: src/muuli_wdr.cpp:1179 src/muuli_wdr.cpp:1184 src/muuli_wdr.cpp:1191
 #: src/muuli_wdr.cpp:1205 src/muuli_wdr.cpp:1212 src/muuli_wdr.cpp:1217
-#: src/muuli_wdr.cpp:1224 src/muuli_wdr.cpp:3227 src/muuli_wdr.cpp:3235
-#: src/muuli_wdr.cpp:3243
+#: src/muuli_wdr.cpp:1224 src/muuli_wdr.cpp:3234 src/muuli_wdr.cpp:3242
+#: src/muuli_wdr.cpp:3250
 msgid "N/A"
 msgstr "N/D"
 
@@ -3552,7 +3557,7 @@ msgstr "Artista :"
 msgid "Album :"
 msgstr "Álbum :"
 
-#: src/muuli_wdr.cpp:685 src/muuli_wdr.cpp:2247
+#: src/muuli_wdr.cpp:685 src/muuli_wdr.cpp:2254
 msgid "Title :"
 msgstr "Título:"
 
@@ -3660,7 +3665,7 @@ msgstr "Nombre del usuario:"
 msgid "Userhash :"
 msgstr "Hash del usuario:"
 
-#: src/muuli_wdr.cpp:895 src/muuli_wdr.cpp:1741 src/muuli_wdr.cpp:2442
+#: src/muuli_wdr.cpp:895 src/muuli_wdr.cpp:1748 src/muuli_wdr.cpp:2449
 #: src/utils/aLinkCreator/src/alcframe.cpp:137
 msgid "Add"
 msgstr "Añadir"
@@ -3669,15 +3674,15 @@ msgstr "Añadir"
 msgid "Download-Speed"
 msgstr "Velocidad de descarga"
 
-#: src/muuli_wdr.cpp:954 src/muuli_wdr.cpp:989 src/muuli_wdr.cpp:2546
+#: src/muuli_wdr.cpp:954 src/muuli_wdr.cpp:989 src/muuli_wdr.cpp:2553
 msgid "Current"
 msgstr "Actual"
 
-#: src/muuli_wdr.cpp:962 src/muuli_wdr.cpp:997 src/muuli_wdr.cpp:2554
+#: src/muuli_wdr.cpp:962 src/muuli_wdr.cpp:997 src/muuli_wdr.cpp:2561
 msgid "Running average"
 msgstr "Media de ejecución"
 
-#: src/muuli_wdr.cpp:970 src/muuli_wdr.cpp:1005 src/muuli_wdr.cpp:2562
+#: src/muuli_wdr.cpp:970 src/muuli_wdr.cpp:1005 src/muuli_wdr.cpp:2569
 msgid "Session average"
 msgstr "Media de la sesión"
 
@@ -3689,7 +3694,7 @@ msgstr "Velocidad de subida"
 msgid "Connections"
 msgstr "Conexiones"
 
-#: src/muuli_wdr.cpp:1024 src/muuli_wdr.cpp:1860
+#: src/muuli_wdr.cpp:1024 src/muuli_wdr.cpp:1867
 msgid "Active downloads"
 msgstr "Descargas activas"
 
@@ -3697,7 +3702,7 @@ msgstr "Descargas activas"
 msgid "Active connections (1:1)"
 msgstr "Conexiones activas (1:1)"
 
-#: src/muuli_wdr.cpp:1040 src/muuli_wdr.cpp:1861
+#: src/muuli_wdr.cpp:1040 src/muuli_wdr.cpp:1868
 msgid "Active uploads"
 msgstr "Subidas activas"
 
@@ -3813,8 +3818,8 @@ msgstr "Este es el nombre que ven los otros usuarios al conectarse con usted."
 msgid "Language: "
 msgstr "Idioma: "
 
-#: src/muuli_wdr.cpp:1257 src/muuli_wdr.cpp:1323 src/muuli_wdr.cpp:1327
-#: src/muuli_wdr.cpp:1330
+#: src/muuli_wdr.cpp:1257 src/muuli_wdr.cpp:1330 src/muuli_wdr.cpp:1334
+#: src/muuli_wdr.cpp:1337
 msgid "The delay before showing tool-tips."
 msgstr "El retardo antes de mostrar los mensajes emergentes."
 
@@ -3890,259 +3895,268 @@ msgstr "Mostrar notificaciones cuando acabe de descargar"
 msgid "Enabling this will make aMule to show notifications when finished downloading."
 msgstr "Si se activa, aMule mostrará notificaciones cuando acabe de descargar."
 
-#: src/muuli_wdr.cpp:1322
+#: src/muuli_wdr.cpp:1323
+#, fuzzy
+msgid "Remember search history"
+msgstr "Recordar estas opciones"
+
+#: src/muuli_wdr.cpp:1324
+msgid "Keeps a dropdown list of your past search terms in the Search tab's Name field. This remembers the queries you typed, not the results they returned."
+msgstr ""
+
+#: src/muuli_wdr.cpp:1329
 msgid "Tooltip delay time: "
 msgstr "Retardo de los mensajes emergentes: "
 
-#: src/muuli_wdr.cpp:1329
+#: src/muuli_wdr.cpp:1336
 msgid "seconds"
 msgstr "segundos"
 
-#: src/muuli_wdr.cpp:1333
+#: src/muuli_wdr.cpp:1340
 msgid "Browser Selection"
 msgstr "Selección del navegador"
 
-#: src/muuli_wdr.cpp:1339
+#: src/muuli_wdr.cpp:1346
 msgid "Enter your browser name here. Leave this field empty to use the system default browser."
 msgstr "Introduzca el nombre de su navegador. Déjelo en blanco si quiere usar el predefinido del sistema."
 
-#: src/muuli_wdr.cpp:1346
+#: src/muuli_wdr.cpp:1353
 msgid "Open in new tab if possible"
 msgstr "Abrir en una pestaña nueva si es posible"
 
-#: src/muuli_wdr.cpp:1348
+#: src/muuli_wdr.cpp:1355
 msgid "Open the web page in a new tab instead of in a new window when possible"
 msgstr "Cuando sea posible, abrir la página web en una nueva pestaña en lugar de en una nueva ventana"
 
-#: src/muuli_wdr.cpp:1352
+#: src/muuli_wdr.cpp:1359
 msgid "Video Player"
 msgstr "Reproductor de vídeo"
 
-#: src/muuli_wdr.cpp:1379
+#: src/muuli_wdr.cpp:1386
 msgid "Bandwidth limits"
 msgstr "Límites del ancho de banda"
 
-#: src/muuli_wdr.cpp:1393
+#: src/muuli_wdr.cpp:1400
 msgid "Upload"
 msgstr "Subida"
 
-#: src/muuli_wdr.cpp:1401
+#: src/muuli_wdr.cpp:1408
 msgid "Slot Allocation"
 msgstr "Asignación de puesto reservado"
 
-#: src/muuli_wdr.cpp:1410
+#: src/muuli_wdr.cpp:1417
 msgid "Ports"
 msgstr "Puertos"
 
-#: src/muuli_wdr.cpp:1420
+#: src/muuli_wdr.cpp:1427
 msgid "This is the standard eD2k port and cannot be disabled."
 msgstr "Este es el puerto eD2k estándar y no puede ser deshabilitado."
 
-#: src/muuli_wdr.cpp:1423
+#: src/muuli_wdr.cpp:1430
 msgid "UDP port for server requests (TCP+3):"
 msgstr "Puerto UDP para peticiones del servidor (TCP+3):"
 
-#: src/muuli_wdr.cpp:1425
+#: src/muuli_wdr.cpp:1432
 msgid "4665"
 msgstr "4665"
 
-#: src/muuli_wdr.cpp:1432
+#: src/muuli_wdr.cpp:1439
 msgid "This UDP port is used for extended eD2k requests and Kad network"
 msgstr "Este puerto UDP se usa para peticiones adicionales de eD2k y la red Kad"
 
-#: src/muuli_wdr.cpp:1439
+#: src/muuli_wdr.cpp:1446
 msgid "UPnP TCP Port (Optional):"
 msgstr "Puerto TCP para UPnP (opcional):"
 
-#: src/muuli_wdr.cpp:1449
+#: src/muuli_wdr.cpp:1456
 msgid "Bind local address to IP (empty for any):"
 msgstr "Dirección IP local de enlace (vacía para cualquiera):"
 
-#: src/muuli_wdr.cpp:1452
+#: src/muuli_wdr.cpp:1459
 msgid "Advanced users only: If you have multiple network interfaces, enter the address of the interface to which aMule should be bound."
 msgstr "Solo usuarios avanzados: si tiene varias tarjetas de red, introduzca la dirección de la tarjeta que debe usar aMule."
 
-#: src/muuli_wdr.cpp:1455 src/muuli_wdr.cpp:2054
+#: src/muuli_wdr.cpp:1462 src/muuli_wdr.cpp:2061
 msgid "Bind to network interface (empty for any):"
 msgstr "Vincular a interfaz de red (vacío para cualquiera):"
 
-#: src/muuli_wdr.cpp:1468
+#: src/muuli_wdr.cpp:1475
 msgid "Advanced users only: pin all of aMule's traffic to one network interface, chosen from the list or typed in by name (e.g. tun0, eth0, en0) or index. Unlike binding to an IP, this stops traffic leaking out via the default route - useful with a VPN. Requires no elevated privileges."
 msgstr "Solo para usuarios avanzados: fija todo el tráfico de aMule a una única interfaz de red, seleccionada de la lista o introducida por nombre (p. ej., tun0, eth0, en0) o por índice. A diferencia de vincularlo a una IP, esto evita que el tráfico se filtre por la ruta predeterminada, lo cual es útil con una VPN. No requiere privilegios elevados."
 
-#: src/muuli_wdr.cpp:1474
+#: src/muuli_wdr.cpp:1481
 msgid "Max sources per downloading file:"
 msgstr "Número máximo de fuentes descargando un archivo:"
 
-#: src/muuli_wdr.cpp:1478
+#: src/muuli_wdr.cpp:1485
 msgid "Max simultaneous connections:"
 msgstr "Número máximo de conexiones simultáneas:"
 
-#: src/muuli_wdr.cpp:1491 src/muuli_wdr.cpp:3169
+#: src/muuli_wdr.cpp:1498 src/muuli_wdr.cpp:3176
 msgid "ED2K"
 msgstr "ED2K"
 
-#: src/muuli_wdr.cpp:1498
+#: src/muuli_wdr.cpp:1505
 msgid "Autoconnect on startup"
 msgstr "Autoconectar al iniciar"
 
-#: src/muuli_wdr.cpp:1501
+#: src/muuli_wdr.cpp:1508
 msgid "Reconnect on loss"
 msgstr "Reconectar al perder la conexión"
 
-#: src/muuli_wdr.cpp:1523
+#: src/muuli_wdr.cpp:1530
 msgid "Remove dead server after"
 msgstr "Eliminar los servidores caídos tras"
 
-#: src/muuli_wdr.cpp:1524
+#: src/muuli_wdr.cpp:1531
 msgid "Static servers are never removed, even when unreachable."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1528
+#: src/muuli_wdr.cpp:1535
 msgid "retries"
 msgstr "reintentos"
 
-#: src/muuli_wdr.cpp:1536
+#: src/muuli_wdr.cpp:1543
 msgid "List"
 msgstr "Lista"
 
-#: src/muuli_wdr.cpp:1539
+#: src/muuli_wdr.cpp:1546
 msgid "Update server list when connecting to a server"
 msgstr "Actualizar la lista de servidores al conectar a un servidor"
 
-#: src/muuli_wdr.cpp:1542
+#: src/muuli_wdr.cpp:1549
 msgid "Update server list when a client connects"
 msgstr "Actualizar la lista de servidores cuando se conecte un cliente"
 
-#: src/muuli_wdr.cpp:1545
+#: src/muuli_wdr.cpp:1552
 msgid "Use priority system"
 msgstr "Usar el sistema de prioridades"
 
-#: src/muuli_wdr.cpp:1549
+#: src/muuli_wdr.cpp:1556
 msgid "Use smart LowID check on connect"
 msgstr "Usar el control inteligente de Id Baja al conectar"
 
-#: src/muuli_wdr.cpp:1553
+#: src/muuli_wdr.cpp:1560
 msgid "Safe connect"
 msgstr "Conexión segura"
 
-#: src/muuli_wdr.cpp:1557
+#: src/muuli_wdr.cpp:1564
 msgid "Autoconnect to servers in static list only"
 msgstr "Autoconectar sólo a servidores fijos"
 
-#: src/muuli_wdr.cpp:1560
+#: src/muuli_wdr.cpp:1567
 msgid "Set manually added servers to High Priority"
 msgstr "Asignar la prioridad alta a los servidores añadidos manualmente"
 
-#: src/muuli_wdr.cpp:1581
+#: src/muuli_wdr.cpp:1588
 msgid "Add files to download in pause mode"
 msgstr "Añadir los archivos a descargar en modo pausado"
 
-#: src/muuli_wdr.cpp:1583
+#: src/muuli_wdr.cpp:1590
 msgid "Add files to download with auto priority"
 msgstr "Añadir las nuevas descargas con prioridad automática"
 
-#: src/muuli_wdr.cpp:1586
+#: src/muuli_wdr.cpp:1593
 msgid "Try to download first and last chunks first"
 msgstr "Intentar descargar antes el primer y último trozo"
 
-#: src/muuli_wdr.cpp:1590
+#: src/muuli_wdr.cpp:1597
 msgid "Endgame mode: rotate to faster sources for the final blocks"
 msgstr "Modo endgame: cambiar a fuentes más rápidas para los bloques finales"
 
-#: src/muuli_wdr.cpp:1593
+#: src/muuli_wdr.cpp:1600
 msgid "Start next paused file when a file completes"
 msgstr "Descargar el siguiente archivo pausado cuando otro se complete"
 
-#: src/muuli_wdr.cpp:1596
+#: src/muuli_wdr.cpp:1603
 msgid "From the same category"
 msgstr "Solo de la misma categoría"
 
-#: src/muuli_wdr.cpp:1598
+#: src/muuli_wdr.cpp:1605
 msgid "In alphabetic order"
 msgstr "En orden alfabético"
 
-#: src/muuli_wdr.cpp:1600
+#: src/muuli_wdr.cpp:1607
 msgid "Preallocate disk space for new files"
 msgstr "Reservar el espacio en disco para los archivos nuevos"
 
-#: src/muuli_wdr.cpp:1601
+#: src/muuli_wdr.cpp:1608
 msgid "For new files preallocates disk space for the whole file, thus reduces fragmentation"
 msgstr "Reserva en disco el espacio para los archivos nuevos enteros, reduciendo asíla fragmentación"
 
-#: src/muuli_wdr.cpp:1606
+#: src/muuli_wdr.cpp:1613
 msgid "Create new files as sparse files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1607
+#: src/muuli_wdr.cpp:1614
 msgid "A sparse file reserves its full size on disk immediately without writing real data to it -- fast, but unsupported or slow on some filesystems, and free-space accounting stays optimistic while the download is in progress. Turn this off to grow the file only as data arrives."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1612
+#: src/muuli_wdr.cpp:1619
 msgid "Stop downloads when free disk space reaches "
 msgstr "Detener las descargas cuando el espacio libre en disco alcance "
 
-#: src/muuli_wdr.cpp:1613
+#: src/muuli_wdr.cpp:1620
 msgid "Select this if you want aMule to check your disk space"
 msgstr "Seleccione esta opción si quiere que aMule compruebe el espacio en disco"
 
-#: src/muuli_wdr.cpp:1617
+#: src/muuli_wdr.cpp:1624
 msgid "Enter here the min disk space desired."
 msgstr "Introduzca el espacio mínimo de disco deseado."
 
-#: src/muuli_wdr.cpp:1623
+#: src/muuli_wdr.cpp:1630
 msgid "Save 10 sources on rare files (< 20 sources)"
 msgstr "Guardar 10 fuentes para archivos raros (< 20 fuentes)"
 
-#: src/muuli_wdr.cpp:1627 src/Statistics.cpp:790
+#: src/muuli_wdr.cpp:1634 src/Statistics.cpp:790
 msgid "Uploads"
 msgstr "Subidas"
 
-#: src/muuli_wdr.cpp:1630
+#: src/muuli_wdr.cpp:1637
 msgid "Add new shared files with auto priority"
 msgstr "Añadir los nuevos archivos compartidos con prioridad automática"
 
-#: src/muuli_wdr.cpp:1636
+#: src/muuli_wdr.cpp:1643
 msgid "Intelligent Corruption Handling (I.C.H.)"
 msgstr "Gestión inteligente de corrupción (I.C.H.)"
 
-#: src/muuli_wdr.cpp:1639
+#: src/muuli_wdr.cpp:1646
 msgid "Enable"
 msgstr "Habilitar"
 
-#: src/muuli_wdr.cpp:1642
+#: src/muuli_wdr.cpp:1649
 msgid "Advanced I.C.H. trusts every hash (not recommended)"
 msgstr "El I.C.H. avanzado confía en todos los hash (no recomendado)"
 
-#: src/muuli_wdr.cpp:1654 src/PrefsUnifiedDlg.cpp:1910
+#: src/muuli_wdr.cpp:1661 src/PrefsUnifiedDlg.cpp:1910
 msgid "Media metadata extraction"
 msgstr "Extracción de metadatos multimedia"
 
-#: src/muuli_wdr.cpp:1658
+#: src/muuli_wdr.cpp:1665
 msgid "Extract length / bitrate / codec from shared audio and video files"
 msgstr "Extraer la duración, el bitrate y el códec de los archivos multimedia compartidos"
 
-#: src/muuli_wdr.cpp:1660
+#: src/muuli_wdr.cpp:1667
 msgid "When enabled, aMule runs ffprobe on each shared media file to fill in the Length / Bitrate / Codec columns other clients see when they find the file in a search. Requires ffmpeg (the ffprobe binary) to be installed."
 msgstr "Cuando está activado, aMule ejecuta ffprobe en cada archivo multimedia compartido para rellenar las columnas de Duración / Bitrate / Códec que otros clientes ven cuando encuentran el archivo en una búsqueda. Requiere tener instalado ffmpeg (el binario ffprobe)."
 
-#: src/muuli_wdr.cpp:1667
+#: src/muuli_wdr.cpp:1674
 msgid "Path to ffprobe:"
 msgstr "Ruta a ffprobe:"
 
-#: src/muuli_wdr.cpp:1672
+#: src/muuli_wdr.cpp:1679
 msgid "Full path to the ffprobe binary. Leave empty to have aMule auto-detect it on startup."
 msgstr "Ruta completa al binario de ffprobe. Déjelo vacío para que aMule lo detecte automáticamente al iniciar."
 
-#: src/muuli_wdr.cpp:1680
+#: src/muuli_wdr.cpp:1687
 msgid "Detect"
 msgstr "Detectar"
 
-#: src/muuli_wdr.cpp:1681
+#: src/muuli_wdr.cpp:1688
 msgid "Search the standard install locations for an ffprobe binary and fill the path field."
 msgstr "Buscar los lugares de instalación estándar para un binario ffprobe y rellenar el campo de la ruta."
 
-#: src/muuli_wdr.cpp:1705
+#: src/muuli_wdr.cpp:1712
 msgid ""
 "Completed downloads are stored here. All files in this folder are automatically shared with other peers.\n"
 "If this folder also holds files you don't want to share, point it at an aMule-only sub-folder."
@@ -4150,360 +4164,360 @@ msgstr ""
 "Las descargas completadas se guardan aquí. Todos los archivos de esta carpeta se compartirán automáticamente con otros usuarios.\n"
 "Si esta carpeta contiene archivos que no quiere compartir, apúntelo a un sub-directorio exclusivo para aMule."
 
-#: src/muuli_wdr.cpp:1708
+#: src/muuli_wdr.cpp:1715
 msgid "Pick the folder where completed downloads will be stored. All files in that folder will be shared with other peers."
 msgstr "Elija la carpeta donde se guardarán las descargas terminadas. Todos los archivos de esa carpeta se compartirán con otros usuarios."
 
-#: src/muuli_wdr.cpp:1722
+#: src/muuli_wdr.cpp:1729
 msgid "Shared folders"
 msgstr "Carpetas compartidas"
 
-#: src/muuli_wdr.cpp:1728
+#: src/muuli_wdr.cpp:1735
 msgid "(Folders shared by the core. Enter a path to add one.)"
 msgstr "(Directorios compartidos por el núcleo. Introduzca una ruta para añadir uno.)"
 
-#: src/muuli_wdr.cpp:1736
+#: src/muuli_wdr.cpp:1743
 msgid "Absolute path of a folder on the core's machine, e.g. /home/user/shared"
 msgstr "Ruta absoluta de un directorio en la máquina del núcleo, p. ej. /home/user/compartido"
 
-#: src/muuli_wdr.cpp:1738 src/PrefsUnifiedDlg.cpp:2794
+#: src/muuli_wdr.cpp:1745 src/PrefsUnifiedDlg.cpp:2794
 msgid "Recursive"
 msgstr "Recursivo"
 
-#: src/muuli_wdr.cpp:1739
+#: src/muuli_wdr.cpp:1746
 msgid "Share every sub-folder underneath this one, including ones created later."
 msgstr "Compartir todos los subdirectorios bajo éste, incluyendo los creados en el futuro."
 
-#: src/muuli_wdr.cpp:1743 src/utils/aLinkCreator/src/alcframe.cpp:141
+#: src/muuli_wdr.cpp:1750 src/utils/aLinkCreator/src/alcframe.cpp:141
 msgid "Remove"
 msgstr "Borrar"
 
-#: src/muuli_wdr.cpp:1747
+#: src/muuli_wdr.cpp:1754
 msgid "(Right click on folder icon for recursive share)"
 msgstr "(Haga clic derecho en los iconos de carpetas para compartirlas recursivamente)"
 
-#: src/muuli_wdr.cpp:1754
+#: src/muuli_wdr.cpp:1761
 msgid "Share hidden files"
 msgstr "Compartir los archivos ocultos"
 
-#: src/muuli_wdr.cpp:1760
+#: src/muuli_wdr.cpp:1767
 msgid "Automatically rescan shared folders for changes"
 msgstr "Buscar cambios automáticamente en los directorios compartidos"
 
-#: src/muuli_wdr.cpp:1766
+#: src/muuli_wdr.cpp:1773
 msgid "Follow symbolic links in shared folders"
 msgstr "Seguir enlaces simbólicos en las carpetas compartidas"
 
-#: src/muuli_wdr.cpp:1772
+#: src/muuli_wdr.cpp:1779
 msgid "Exclude files matching:"
 msgstr "Excluir archivos coincidentes:"
 
-#: src/muuli_wdr.cpp:1775
+#: src/muuli_wdr.cpp:1782
 msgid "Wildcard patterns separated by '|', e.g. .DS_Store|Thumbs.db|*.tmp. Files whose name matches are not shared. Matching is case-insensitive."
 msgstr "Patrones comodines separados por '|', p.ej., .DS_Store|Thumbs.db|*.tmp. Los archivos cuyo nombre coincida no serán compartidos. No distingue mayúsculas/minúsculas."
 
-#: src/muuli_wdr.cpp:1779
+#: src/muuli_wdr.cpp:1786
 msgid "Patterns are regular expressions"
 msgstr "Los patrones son expresiones regulares"
 
-#: src/muuli_wdr.cpp:1780
+#: src/muuli_wdr.cpp:1787
 msgid "When set, the whole field is one regular expression ('|' is alternation). When unset, it is a list of '|'-separated wildcards."
 msgstr "Cuando se activa, el campo completo es una expresión regular ('|' es OR). Cuando no se activa, es un listado de comodines separados por '|'."
 
-#: src/muuli_wdr.cpp:1790
+#: src/muuli_wdr.cpp:1797
 msgid "Show how many shared files the current pattern would exclude."
 msgstr "Muestra cuántos archivos compartidos excluiría el patrón actual."
 
-#: src/muuli_wdr.cpp:1811
+#: src/muuli_wdr.cpp:1818
 msgid "Graphs"
 msgstr "Gráficos"
 
-#: src/muuli_wdr.cpp:1814 src/muuli_wdr.cpp:1876
+#: src/muuli_wdr.cpp:1821 src/muuli_wdr.cpp:1883
 msgid "Update delay : 5 secs"
 msgstr "Intervalo de actualización: 5 s"
 
-#: src/muuli_wdr.cpp:1818
+#: src/muuli_wdr.cpp:1825
 msgid "Time for average graph: 100 mins"
 msgstr "Tiempo de promedio del gráfico: 100 minutos"
 
-#: src/muuli_wdr.cpp:1822
+#: src/muuli_wdr.cpp:1829
 msgid "Connections Graph Scale: 100 "
 msgstr "Escala del gráfico de las conexiones: 100 "
 
-#: src/muuli_wdr.cpp:1829
+#: src/muuli_wdr.cpp:1836
 msgid "Download graph scale:"
 msgstr "Escala de la gráfica de descarga:"
 
-#: src/muuli_wdr.cpp:1837
+#: src/muuli_wdr.cpp:1844
 msgid "Upload graph scale:"
 msgstr "Escala de la gráfica de subida:"
 
-#: src/muuli_wdr.cpp:1847
+#: src/muuli_wdr.cpp:1854
 msgid "Colors: "
 msgstr "Colores: "
 
-#: src/muuli_wdr.cpp:1851
+#: src/muuli_wdr.cpp:1858
 msgid "Background"
 msgstr "Fondo"
 
-#: src/muuli_wdr.cpp:1852
+#: src/muuli_wdr.cpp:1859
 msgid "Grid"
 msgstr "Rejilla"
 
-#: src/muuli_wdr.cpp:1853
+#: src/muuli_wdr.cpp:1860
 msgid "Download current"
 msgstr "Descarga actual"
 
-#: src/muuli_wdr.cpp:1854
+#: src/muuli_wdr.cpp:1861
 msgid "Download running average"
 msgstr "Promedio de descarga en ejecución"
 
-#: src/muuli_wdr.cpp:1855
+#: src/muuli_wdr.cpp:1862
 msgid "Download session average"
 msgstr "Promedio de descarga en la sesión"
 
-#: src/muuli_wdr.cpp:1856
+#: src/muuli_wdr.cpp:1863
 msgid "Upload current"
 msgstr "Subida actual"
 
-#: src/muuli_wdr.cpp:1857
+#: src/muuli_wdr.cpp:1864
 msgid "Upload running average"
 msgstr "Promedio de subida en ejecución"
 
-#: src/muuli_wdr.cpp:1858
+#: src/muuli_wdr.cpp:1865
 msgid "Upload session average"
 msgstr "Promedio de subida en la sesión"
 
-#: src/muuli_wdr.cpp:1859
+#: src/muuli_wdr.cpp:1866
 msgid "Active connections"
 msgstr "Conexiones activas"
 
-#: src/muuli_wdr.cpp:1862
+#: src/muuli_wdr.cpp:1869
 msgid "Systray Icon Speed Bar"
 msgstr "Barra de velocidad en el icono de la bandeja del sistema"
 
-#: src/muuli_wdr.cpp:1863
+#: src/muuli_wdr.cpp:1870
 msgid "Kad-nodes current"
 msgstr "Nodos Kad actuales"
 
-#: src/muuli_wdr.cpp:1864
+#: src/muuli_wdr.cpp:1871
 msgid "Kad-nodes running"
 msgstr "Nodos Kad activos"
 
-#: src/muuli_wdr.cpp:1865
+#: src/muuli_wdr.cpp:1872
 msgid "Kad-nodes session"
 msgstr "Nodos Kad de la sesión"
 
-#: src/muuli_wdr.cpp:1869 src/muuli_wdr.cpp:2296
+#: src/muuli_wdr.cpp:1876 src/muuli_wdr.cpp:2303
 msgid "Select"
 msgstr "Seleccionar"
 
-#: src/muuli_wdr.cpp:1873
+#: src/muuli_wdr.cpp:1880
 msgid "Tree"
 msgstr "Árbol"
 
-#: src/muuli_wdr.cpp:1883
+#: src/muuli_wdr.cpp:1890
 msgid "Number of Client Versions shown (0=unlimited)"
 msgstr "Número de versiones de clientes a mostrar (0=sin límite)"
 
-#: src/muuli_wdr.cpp:1908
+#: src/muuli_wdr.cpp:1915
 msgid "!!! WARNING !!!"
 msgstr "¡¡¡ AVISO !!!"
 
-#: src/muuli_wdr.cpp:1923
+#: src/muuli_wdr.cpp:1930
 msgid "Max new connections / 5 secs"
 msgstr "Número máximo de nuevas conexiones cada 5 segundos"
 
-#: src/muuli_wdr.cpp:1925
+#: src/muuli_wdr.cpp:1932
 msgid "Concurrent Kad source lookups"
 msgstr "Búsquedas simultáneas de fuentes Kad"
 
-#: src/muuli_wdr.cpp:1927
+#: src/muuli_wdr.cpp:1934
 msgid "Kad source re-search interval (minutes)"
 msgstr "Intervalo de búsqueda de fuentes Kad (minutos)"
 
-#: src/muuli_wdr.cpp:1929
+#: src/muuli_wdr.cpp:1936
 msgid "Source re-ask interval (minutes)"
 msgstr "Intervalo re‐solicitud de fuentes (minutos)"
 
-#: src/muuli_wdr.cpp:1933
+#: src/muuli_wdr.cpp:1940
 msgid "File Buffer Size: 240000 bytes"
 msgstr "Tamaño del búfer de archivo: 240000 bytes"
 
-#: src/muuli_wdr.cpp:1937
+#: src/muuli_wdr.cpp:1944
 msgid "Use MMAP: memory-mapped file access (lower memory use)"
 msgstr "Usar MMAP: acceso a ficheros mapeados en memoria (menor uso de memoria)"
 
-#: src/muuli_wdr.cpp:1938
+#: src/muuli_wdr.cpp:1945
 msgid "Maps part files into memory instead of buffering them on the heap, lowering the process memory footprint. May reduce download speed on some disks; best for memory-constrained or upload-heavy hosts."
 msgstr "Mapea los ficheros de partes en memoria en vez de usar un buffer en la pila, reduciendo la huella de memoria del proceso. Puede reducir la velocidad de descarga en algunos discos; es mejor usarlo en entornos con poca memoria o nodos que principalmente suban datos."
 
-#: src/muuli_wdr.cpp:1940
+#: src/muuli_wdr.cpp:1947
 msgid "Upload Queue Size: 5000 clients"
 msgstr "Tamaño de cola de espera: 5000 clientes"
 
-#: src/muuli_wdr.cpp:1944
+#: src/muuli_wdr.cpp:1951
 msgid "Server connection refresh interval: Disable"
 msgstr "Intervalo de actualización de la conexión al servidor: desactivado"
 
-#: src/muuli_wdr.cpp:1948
+#: src/muuli_wdr.cpp:1955
 msgid "Disable computer's timed standby mode"
 msgstr "Deshabilitar el modo de reposo del ordenador"
 
-#: src/muuli_wdr.cpp:1967
+#: src/muuli_wdr.cpp:1974
 msgid "Skin to use: "
 msgstr "Tema a usar: "
 
-#: src/muuli_wdr.cpp:1976
+#: src/muuli_wdr.cpp:1983
 msgid "Show \"Fast eD2k Links Handler\" in every window."
 msgstr "Mostrar el \"Gestor rápido de enlaces eD2k\" en todas las ventanas."
 
-#: src/muuli_wdr.cpp:1979
+#: src/muuli_wdr.cpp:1986
 msgid "Show extended info on categories tabs"
 msgstr "Mostrar información adicional en las pestañas de las categorías"
 
-#: src/muuli_wdr.cpp:1982
+#: src/muuli_wdr.cpp:1989
 msgid "Show application version on title"
 msgstr "Mostrar la versión de la aplicación en el título"
 
-#: src/muuli_wdr.cpp:1984
+#: src/muuli_wdr.cpp:1991
 msgid "Show transfer rates on title"
 msgstr "Mostrar las tasas de transferencia en el título"
 
-#: src/muuli_wdr.cpp:1986
+#: src/muuli_wdr.cpp:1993
 msgid "Before application name"
 msgstr "Antes del nombre de la aplicación"
 
-#: src/muuli_wdr.cpp:1988
+#: src/muuli_wdr.cpp:1995
 msgid "After application name"
 msgstr "Después del nombre de la aplicación"
 
-#: src/muuli_wdr.cpp:1991
+#: src/muuli_wdr.cpp:1998
 msgid "Show overhead bandwidth"
 msgstr "Mostrar el ancho de banda adicional usado"
 
-#: src/muuli_wdr.cpp:1995
+#: src/muuli_wdr.cpp:2002
 msgid "Vertical toolbar orientation"
 msgstr "Orientación vertical de la barra de herramientas"
 
-#: src/muuli_wdr.cpp:1997
+#: src/muuli_wdr.cpp:2004
 msgid "Live column sorting (auto-reorder rows as their values change)"
 msgstr "Orden automático de columnas (reordena las filas según cambian sus valores)"
 
-#: src/muuli_wdr.cpp:2004
+#: src/muuli_wdr.cpp:2011
 msgid "Download Queue Files"
 msgstr "Archivos de la cola de descarga"
 
-#: src/muuli_wdr.cpp:2007
+#: src/muuli_wdr.cpp:2014
 msgid "Show progress percentage"
 msgstr "Mostrar el porcentaje de progreso"
 
-#: src/muuli_wdr.cpp:2013
+#: src/muuli_wdr.cpp:2020
 msgid "Show progress bar"
 msgstr "Mostrar la barra de progreso"
 
-#: src/muuli_wdr.cpp:2016
+#: src/muuli_wdr.cpp:2023
 msgid "Flat"
 msgstr "Plana"
 
-#: src/muuli_wdr.cpp:2020
+#: src/muuli_wdr.cpp:2027
 msgid "Round"
 msgstr "Redondeada"
 
-#: src/muuli_wdr.cpp:2038
+#: src/muuli_wdr.cpp:2045
 msgid "External Connection Parameters"
 msgstr "Parámetros de la conexión externa"
 
-#: src/muuli_wdr.cpp:2041
+#: src/muuli_wdr.cpp:2048
 msgid "Accept external connections"
 msgstr "Aceptar conexiones externas"
 
-#: src/muuli_wdr.cpp:2048 src/muuli_wdr.cpp:2107
+#: src/muuli_wdr.cpp:2055 src/muuli_wdr.cpp:2114
 msgid "IP of the listening interface:"
 msgstr "IP de la interfaz que está escuchando:"
 
-#: src/muuli_wdr.cpp:2051
+#: src/muuli_wdr.cpp:2058
 msgid "Enter here a valid ip in the a.b.c.d format for the listening EC interface. An empty field or 0.0.0.0 will mean any interface."
 msgstr "Introduzca aquí una IP válida en la forma a.b.c.d para la interfaz EC que está escuchando. Un campo vacío o 0.0.0.0 significará cualquier interfaz."
 
-#: src/muuli_wdr.cpp:2072 src/muuli_wdr.cpp:2156
+#: src/muuli_wdr.cpp:2079 src/muuli_wdr.cpp:2163
 msgid "TCP port:"
 msgstr "Puerto TCP:"
 
-#: src/muuli_wdr.cpp:2078
+#: src/muuli_wdr.cpp:2085
 msgid "Enable UPnP port forwarding on the EC port"
 msgstr "Habilitar la redirección de puertos UPnP en el puerto EC"
 
-#: src/muuli_wdr.cpp:2082 src/muuli_wdr.cpp:3041
+#: src/muuli_wdr.cpp:2089 src/muuli_wdr.cpp:3048
 #: src/utils/wxCas/src/wxcasprefs.cpp:167
 msgid "Password"
 msgstr "Contraseña"
 
-#: src/muuli_wdr.cpp:2088
+#: src/muuli_wdr.cpp:2095
 msgid "aMule API server parameters"
 msgstr "Parámetros del servidor aMule API"
 
-#: src/muuli_wdr.cpp:2091
+#: src/muuli_wdr.cpp:2098
 msgid "Run amuleapi (REST API) on startup"
 msgstr "Ejecutar amuleapi (API REST) al iniciar"
 
-#: src/muuli_wdr.cpp:2096
+#: src/muuli_wdr.cpp:2103
 msgid "HTTP port:"
 msgstr "Puerto HTTP:"
 
-#: src/muuli_wdr.cpp:2110
+#: src/muuli_wdr.cpp:2117
 msgid "The interface amuleapi's HTTP server listens on. 127.0.0.1 (default) accepts only local connections; use 0.0.0.0 or a specific IP to expose it to other hosts (set an admin password below)."
 msgstr "La interfaz en la que escucha el servidor HTTP de amuleapi es 127.0.0.1 (por defecto), que solo acepta conexiones locales; utilice 0.0.0.0 o una IP específica para exponerla a otros hosts (establezca una contraseña de administrador a continuación)."
 
-#: src/muuli_wdr.cpp:2113
+#: src/muuli_wdr.cpp:2120
 msgid "Admin password"
 msgstr "Contraseña Admin"
 
-#: src/muuli_wdr.cpp:2118 src/muuli_wdr.cpp:2149
+#: src/muuli_wdr.cpp:2125 src/muuli_wdr.cpp:2156
 msgid "Low rights password"
 msgstr "Contraseña del invitado"
 
-#: src/muuli_wdr.cpp:2126
+#: src/muuli_wdr.cpp:2133
 msgid "Web server parameters"
 msgstr "Parámetros del servidor web"
 
-#: src/muuli_wdr.cpp:2129
+#: src/muuli_wdr.cpp:2136
 msgid "Run webserver on startup (deprecated)"
 msgstr "Ejecutar webserver al iniciar (obsoleto)"
 
-#: src/muuli_wdr.cpp:2135
+#: src/muuli_wdr.cpp:2142
 msgid "Web template"
 msgstr "Plantilla web"
 
-#: src/muuli_wdr.cpp:2140
+#: src/muuli_wdr.cpp:2147
 msgid "Full rights password"
 msgstr "Contraseña de administrador"
 
-#: src/muuli_wdr.cpp:2144
+#: src/muuli_wdr.cpp:2151
 msgid "Enable Low rights User"
 msgstr "Permitir un invitado"
 
-#: src/muuli_wdr.cpp:2163
+#: src/muuli_wdr.cpp:2170
 msgid "Enable UPnP port forwarding of the web server port"
 msgstr "Habilitar el reenvío de puertos UPnP en el puerto del servidor web"
 
-#: src/muuli_wdr.cpp:2168
+#: src/muuli_wdr.cpp:2175
 msgid "Web server UPnP TCP port (Optional)"
 msgstr "Puerto TCP del servidor web para UPnP (opcional)"
 
-#: src/muuli_wdr.cpp:2176
+#: src/muuli_wdr.cpp:2183
 msgid "Page Refresh Time (in secs)"
 msgstr "Intervalo de actualización de la página (en segundos)"
 
-#: src/muuli_wdr.cpp:2183
+#: src/muuli_wdr.cpp:2190
 msgid "Enable Gzip compression"
 msgstr "Activar la compresión gzip"
 
-#: src/muuli_wdr.cpp:2217
+#: src/muuli_wdr.cpp:2224
 msgid "Reset page to defaults"
 msgstr "Restablecer a los valores por defecto"
 
-#: src/muuli_wdr.cpp:2218
+#: src/muuli_wdr.cpp:2225
 msgid "Reset the settings on the current page to their default values."
 msgstr "Restablece los ajustes de la página actual a sus valores por defecto."
 
@@ -4511,308 +4525,308 @@ msgstr "Restablece los ajustes de la página actual a sus valores por defecto."
 # botón para cerrar el diálogo de Preferencias guardando los cambios. La
 # traducción sería distinta en cada caso, así que hay que dejar el OK
 # original.
-#: src/muuli_wdr.cpp:2220 src/muuli_wdr.cpp:2306 src/ServerWnd.cpp:274
+#: src/muuli_wdr.cpp:2227 src/muuli_wdr.cpp:2313 src/ServerWnd.cpp:274
 #: src/ServerWnd.cpp:282
 msgid "OK"
 msgstr "OK"
 
-#: src/muuli_wdr.cpp:2222
+#: src/muuli_wdr.cpp:2229
 msgid "Click here to apply any changes made to the preferences."
 msgstr "Haga clic aquí para aplicar los cambios hechos en las preferencias."
 
-#: src/muuli_wdr.cpp:2225
+#: src/muuli_wdr.cpp:2232
 msgid "Reset any changes made to the preferences."
 msgstr "Cancelar los cambios hechos en las preferencias."
 
-#: src/muuli_wdr.cpp:2254
+#: src/muuli_wdr.cpp:2261
 msgid "Comment :"
 msgstr "Comentario:"
 
-#: src/muuli_wdr.cpp:2261
+#: src/muuli_wdr.cpp:2268
 msgid "Incoming Dir :"
 msgstr "Directorio entrante:"
 
-#: src/muuli_wdr.cpp:2270
+#: src/muuli_wdr.cpp:2277
 msgid "Change priority for new assigned files :"
 msgstr "Cambiar la prioridad de los nuevos archivos asignados:"
 
-#: src/muuli_wdr.cpp:2274
+#: src/muuli_wdr.cpp:2281
 msgid "Don't change"
 msgstr "No cambiar"
 
-#: src/muuli_wdr.cpp:2286
+#: src/muuli_wdr.cpp:2293
 msgid "Select color for this Category (currently selected) :"
 msgstr "Seleccione el color para esta categoría (actualmente seleccionado):"
 
-#: src/muuli_wdr.cpp:2353 src/muuli_wdr.cpp:2372 src/muuli_wdr.cpp:2394
+#: src/muuli_wdr.cpp:2360 src/muuli_wdr.cpp:2379 src/muuli_wdr.cpp:2401
 msgid "Click this button to reset the log."
 msgstr "Pulse este botón para borrar el registro."
 
-#: src/muuli_wdr.cpp:2413
+#: src/muuli_wdr.cpp:2420
 msgid "Click on this button to update the servers list from URL ..."
 msgstr "Pulse este botón para actualizar la lista de servidores desde un URL..."
 
-#: src/muuli_wdr.cpp:2417
+#: src/muuli_wdr.cpp:2424
 msgid "Server list"
 msgstr "Lista de servidores"
 
-#: src/muuli_wdr.cpp:2421
+#: src/muuli_wdr.cpp:2428
 msgid "Enter the url to a server.met file here and press the button to the left to update the list of known servers."
 msgstr "Introduzca la URL de un archivo server.met y pulse el botón de la izquierda para actualizar la lista de servidores conocidos."
 
-#: src/muuli_wdr.cpp:2426
+#: src/muuli_wdr.cpp:2433
 msgid "Add server manually: Name"
 msgstr "Añadir servidor manualmente: Nombre"
 
-#: src/muuli_wdr.cpp:2429
+#: src/muuli_wdr.cpp:2436
 msgid "Enter the name of the new server here"
 msgstr "Introduzca aquí el nombre del nuevo servidor"
 
-#: src/muuli_wdr.cpp:2431 src/ServerWnd.cpp:206
+#: src/muuli_wdr.cpp:2438 src/ServerWnd.cpp:206
 msgid "IP:Port"
 msgstr "IP:Puerto"
 
-#: src/muuli_wdr.cpp:2434
+#: src/muuli_wdr.cpp:2441
 msgid "Enter the IP of the server here, using the x.x.x.x format."
 msgstr "Introduzca aquí la IP del servidor, usando el formato \"x.x.x.x\"."
 
-#: src/muuli_wdr.cpp:2440
+#: src/muuli_wdr.cpp:2447
 msgid "Enter the port of the server here."
 msgstr "Introduzca el puerto del servidor."
 
-#: src/muuli_wdr.cpp:2443
+#: src/muuli_wdr.cpp:2450
 msgid "Add manually a server (fill fields to the left before) ..."
 msgstr "Añadir manualmente un servidor (rellene antes los campos de la izquierda)..."
 
-#: src/muuli_wdr.cpp:2472
+#: src/muuli_wdr.cpp:2479
 msgid "aMule Log"
 msgstr "Registro de aMule"
 
-#: src/muuli_wdr.cpp:2480
+#: src/muuli_wdr.cpp:2487
 msgid "Server Info"
 msgstr "Información del servidor"
 
-#: src/muuli_wdr.cpp:2484
+#: src/muuli_wdr.cpp:2491
 msgid "ED2K Info"
 msgstr "Información sobre ED2K"
 
-#: src/muuli_wdr.cpp:2488
+#: src/muuli_wdr.cpp:2495
 msgid "Kad Info"
 msgstr "Información sobre Kad"
 
-#: src/muuli_wdr.cpp:2516
+#: src/muuli_wdr.cpp:2523
 msgid "Click on this button to update the nodes list from URL ..."
 msgstr "Pulse este botón para actualizar la lista de nodos desde el URL..."
 
-#: src/muuli_wdr.cpp:2520
+#: src/muuli_wdr.cpp:2527
 msgid "Nodes (0)"
 msgstr "Nodos (0)"
 
-#: src/muuli_wdr.cpp:2524
+#: src/muuli_wdr.cpp:2531
 msgid "Enter the url to a nodes.dat file here and press the button to the left to update the list of known nodes."
 msgstr "Introduzca la URL del archivo nodes.dat y pulse el botón de la izquierda para actualizar la lista de nodos conocidos."
 
-#: src/muuli_wdr.cpp:2527
+#: src/muuli_wdr.cpp:2534
 msgid "Nodes stats"
 msgstr "Estadísticas de nodos"
 
-#: src/muuli_wdr.cpp:2569
+#: src/muuli_wdr.cpp:2576
 msgid "Bootstrap"
 msgstr "Inicialización"
 
-#: src/muuli_wdr.cpp:2572
+#: src/muuli_wdr.cpp:2579
 msgid "New node"
 msgstr "Nuevo nodo"
 
-#: src/muuli_wdr.cpp:2577
+#: src/muuli_wdr.cpp:2584
 msgid "IP:"
 msgstr "IP:"
 
-#: src/muuli_wdr.cpp:2597
+#: src/muuli_wdr.cpp:2604
 msgid "Port:"
 msgstr "Puerto:"
 
-#: src/muuli_wdr.cpp:2610
+#: src/muuli_wdr.cpp:2617
 msgid "Bootstrap from known clients"
 msgstr "Inicializar desde clientes conocidos"
 
-#: src/muuli_wdr.cpp:2612
+#: src/muuli_wdr.cpp:2619
 msgid "Disconnect Kad"
 msgstr "Desconectar Kad"
 
-#: src/muuli_wdr.cpp:2646
+#: src/muuli_wdr.cpp:2653
 msgid "Use Secure User Identification"
 msgstr "Usar la Identificación Segura de Usuario (ISU)"
 
-#: src/muuli_wdr.cpp:2648
+#: src/muuli_wdr.cpp:2655
 msgid "It is recommended to enable this option. You will not receive credits if SUI is not enabled."
 msgstr "Se recomienda activar esta opción. No recibirá créditos si la ISU no está habilitada."
 
-#: src/muuli_wdr.cpp:2650
+#: src/muuli_wdr.cpp:2657
 msgid "Protocol Obfuscation"
 msgstr "Ofuscación de protocolo"
 
-#: src/muuli_wdr.cpp:2653
+#: src/muuli_wdr.cpp:2660
 msgid "Support Protocol Obfuscation"
 msgstr "Permitir la ofuscación de protocolo"
 
-#: src/muuli_wdr.cpp:2655
+#: src/muuli_wdr.cpp:2662
 msgid "This option enabled Protocol Obfuscation, and makes aMule accept obfuscated connections from other clients."
 msgstr "Esta opción activa la ofuscación de protocolo y hace que aMule acepte conexiones ofuscadas de otros clientes."
 
-#: src/muuli_wdr.cpp:2657
+#: src/muuli_wdr.cpp:2664
 msgid "Use obfuscation for outgoing connections"
 msgstr "Usar la ofuscación para las conexiones salientes"
 
-#: src/muuli_wdr.cpp:2659
+#: src/muuli_wdr.cpp:2666
 msgid "This option makes aMule use Protocol Obfuscation when connecting other clients/servers."
 msgstr "Esta opción hace que aMule use la ofuscación de protocolo cuando se conecta a otros clientes/servidores."
 
-#: src/muuli_wdr.cpp:2661
+#: src/muuli_wdr.cpp:2668
 msgid "Accept only obfuscated connections"
 msgstr "Aceptar sólo conexiones ofuscadas"
 
-#: src/muuli_wdr.cpp:2662
+#: src/muuli_wdr.cpp:2669
 msgid "This option makes aMule only accept obfuscated connections. You will have less sources, but all your traffic will be obfuscated"
 msgstr "Esta opción hace que aMule sólo acepte conexiones ofuscadas. Tendrá menos fuentes, pero todo su tráfico estará ofuscado"
 
-#: src/muuli_wdr.cpp:2667
+#: src/muuli_wdr.cpp:2674
 msgid "Everybody"
 msgstr "Todos"
 
-#: src/muuli_wdr.cpp:2669
+#: src/muuli_wdr.cpp:2676
 msgid "No one"
 msgstr "Nadie"
 
-#: src/muuli_wdr.cpp:2671
+#: src/muuli_wdr.cpp:2678
 msgid "Who can see my shared files:"
 msgstr "Quién puede ver mis archivos compartidos:"
 
-#: src/muuli_wdr.cpp:2672
+#: src/muuli_wdr.cpp:2679
 msgid "Select who can request to view a list of your shared files."
 msgstr "Seleccione quién puede solicitar ver la lista de sus archivos compartidos."
 
-#: src/muuli_wdr.cpp:2674
+#: src/muuli_wdr.cpp:2681
 msgid "IP-Filtering"
 msgstr "Filtrado de direcciones IP"
 
-#: src/muuli_wdr.cpp:2681
+#: src/muuli_wdr.cpp:2688
 msgid "Filter clients"
 msgstr "Filtrar los clientes"
 
-#: src/muuli_wdr.cpp:2683
+#: src/muuli_wdr.cpp:2690
 msgid "Enable filtering of the client IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "Habilitar el filtrado de las IP de clientes definidas en el archivo ~/.aMule/ipfilter.dat."
 
-#: src/muuli_wdr.cpp:2685
+#: src/muuli_wdr.cpp:2692
 msgid "Filter servers"
 msgstr "Filtrar los servidores"
 
-#: src/muuli_wdr.cpp:2687
+#: src/muuli_wdr.cpp:2694
 msgid "Enable filtering of the server IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "Habilitar el filtrado de las IP de servidores definidas en el archivo ~/.aMule/ipfilter.dat."
 
-#: src/muuli_wdr.cpp:2691
+#: src/muuli_wdr.cpp:2698
 msgid "Reload List"
 msgstr "Recargar la lista"
 
-#: src/muuli_wdr.cpp:2692
+#: src/muuli_wdr.cpp:2699
 msgid "Reload the list of IPs to filter from the file ~/.aMule/ipfilter.dat"
 msgstr "Recargar la lista de filtrado de IP desde el archivo ~/.aMule/ipfilter.dat"
 
-#: src/muuli_wdr.cpp:2698
+#: src/muuli_wdr.cpp:2705
 msgid "URL:"
 msgstr "URL:"
 
-#: src/muuli_wdr.cpp:2702 src/muuli_wdr.cpp:2895
+#: src/muuli_wdr.cpp:2709 src/muuli_wdr.cpp:2902
 msgid "Update now"
 msgstr "Actualizar ahora"
 
-#: src/muuli_wdr.cpp:2705
+#: src/muuli_wdr.cpp:2712
 msgid "Auto-update ipfilter at startup"
 msgstr "Autoactualizar el filtro de IP al inicio"
 
-#: src/muuli_wdr.cpp:2709
+#: src/muuli_wdr.cpp:2716
 msgid "Filtering Level:"
 msgstr "Nivel de filtrado:"
 
-#: src/muuli_wdr.cpp:2715
+#: src/muuli_wdr.cpp:2722
 msgid "Always filter LAN IPs"
 msgstr "Filtrar siempre las IP de LAN"
 
-#: src/muuli_wdr.cpp:2718
+#: src/muuli_wdr.cpp:2725
 msgid "Paranoid handling of non-matching IPs"
 msgstr "Gestión paranoica de las IP que no coincidan"
 
-#: src/muuli_wdr.cpp:2720
+#: src/muuli_wdr.cpp:2727
 msgid "Rejects a packet when its source IP differs from the IP the client claims (an anti-spoofing check). Disable only if it causes connection problems."
 msgstr "Rechaza un paquete cuando su IP de origen es diferente de la IP que el cliente dice tener (comprobación anti-suplantación). Desactivar sólo si causa problemas de conexión."
 
-#: src/muuli_wdr.cpp:2722
+#: src/muuli_wdr.cpp:2729
 msgid "Use system-wide ipfilter.dat if available"
 msgstr "Usar el ipfilter.dat del sistema si está disponible"
 
-#: src/muuli_wdr.cpp:2723
+#: src/muuli_wdr.cpp:2730
 msgid "If there's no local ipfilter.dat found, allow usage of a system-wide ipfilter file."
 msgstr "Si no hay un archivo ipfilter.dat local, permitir el uso de un archivo ipfilter del sistema."
 
-#: src/muuli_wdr.cpp:2740
+#: src/muuli_wdr.cpp:2747
 msgid "Enable Online-Signature"
 msgstr "Habilitar la firma digital"
 
-#: src/muuli_wdr.cpp:2742
+#: src/muuli_wdr.cpp:2749
 msgid "Enables the writing of the OS file, which can be used by external apps to create signatures and the like."
 msgstr "Habilita la escritura de archivos de firma digital, algo que puede ser usado por las aplicaciones externas para crear firmas y cosas parecidas."
 
-#: src/muuli_wdr.cpp:2746
+#: src/muuli_wdr.cpp:2753
 msgid "Update Frequency (Secs):"
 msgstr "Frecuencia de actualización (segundos):"
 
-#: src/muuli_wdr.cpp:2749
+#: src/muuli_wdr.cpp:2756
 msgid "Change the frequency (in seconds) of Online Signature updates."
 msgstr "Cambiar la frecuencia (en segundos) de actualización de la firma digital."
 
-#: src/muuli_wdr.cpp:2757
+#: src/muuli_wdr.cpp:2764
 msgid "Save online signature file in: "
 msgstr "Guardar el archivo de firma digital en: "
 
-#: src/muuli_wdr.cpp:2763
+#: src/muuli_wdr.cpp:2770
 msgid "Click here to select the directory containing the the Online Signature files."
 msgstr "Pulse aquí para seleccionar el directorio que contiene los archivos de firmas digitales."
 
-#: src/muuli_wdr.cpp:2796
+#: src/muuli_wdr.cpp:2803
 msgid "Show country flags for clients"
 msgstr "Mostrar las banderas de los países para los clientes"
 
-#: src/muuli_wdr.cpp:2797
+#: src/muuli_wdr.cpp:2804
 msgid "Render the country flag column in the transfers, queue and search views. Requires a valid MMDB GeoIP database (see below)."
 msgstr "Mostrar la columna de la bandera del país en las vistas de transferencias, cola y búsqueda. Requiere una base de datos MMDB GeoIP válida (ver más abajo)."
 
-#: src/muuli_wdr.cpp:2802
+#: src/muuli_wdr.cpp:2809
 msgid "Database"
 msgstr "Base de datos"
 
-#: src/muuli_wdr.cpp:2818
+#: src/muuli_wdr.cpp:2825
 msgid "Source:"
 msgstr "Fuente:"
 
-#: src/muuli_wdr.cpp:2821
+#: src/muuli_wdr.cpp:2828
 msgid "DB-IP (free, no account)"
 msgstr "DB-IP (gratis, sin crear una cuenta)"
 
-#: src/muuli_wdr.cpp:2822
+#: src/muuli_wdr.cpp:2829
 msgid "MaxMind GeoLite2 (free, account required)"
 msgstr "MaxMind GeoLite2 (gratuito, requiere crear una cuenta)"
 
-#: src/muuli_wdr.cpp:2823
+#: src/muuli_wdr.cpp:2830
 msgid "Custom URL"
 msgstr "URL personalizada"
 
-#: src/muuli_wdr.cpp:2826
+#: src/muuli_wdr.cpp:2833
 msgid "Choose which provider supplies the GeoIP MMDB database. DB-IP is the default - no account required. MaxMind requires a free account + license key. Use Custom URL to point at any other MMDB host (e.g. a local mirror)."
 msgstr "Elige qué proveedor ofrece la base de datos GeoIP MMDB. DB-IP es la opción predeterminada; no se necesita cuenta. MaxMind requiere una cuenta gratuita y una clave de licencia. Utiliza la opción 'URL personalizada' para indicar cualquier otro servidor MMDB (por ejemplo, un servidor espejo local)."
 
-#: src/muuli_wdr.cpp:2843
+#: src/muuli_wdr.cpp:2850
 msgid ""
 "No configuration required.\n"
 "\n"
@@ -4824,11 +4838,11 @@ msgstr ""
 "Datos IP-País de DB-IP.com - https://db-ip.com\n"
 "Licencia: Creative Commons BY 4.0 - https://creativecommons.org/licenses/by/4.0/"
 
-#: src/muuli_wdr.cpp:2856
+#: src/muuli_wdr.cpp:2863
 msgid "License key:"
 msgstr "Clave de licencia:"
 
-#: src/muuli_wdr.cpp:2862
+#: src/muuli_wdr.cpp:2869
 msgid ""
 "Sign up for a free MaxMind account, then generate a License Key:\n"
 "https://www.maxmind.com/en/geolite2/signup\n"
@@ -4844,11 +4858,11 @@ msgstr ""
 "Licencia: EULA de MaxMind GeoLite2 - https://www.maxmind.com/en/geolite2/eula\n"
 "Requiere la atribución de la fuente y el registro de una cuenta; actualizar al menos cada 30 días."
 
-#: src/muuli_wdr.cpp:2877
+#: src/muuli_wdr.cpp:2884
 msgid "Download URL:"
 msgstr "URL de descarga:"
 
-#: src/muuli_wdr.cpp:2883
+#: src/muuli_wdr.cpp:2890
 msgid ""
 "Must point to an .mmdb file or a .gz / .tar.gz containing one.\n"
 "URL may include credentials (https://user:pass@host/...).\n"
@@ -4858,211 +4872,211 @@ msgstr ""
 "La URL puede incluir credenciales (https://user:pass@host/...).\n"
 "Las condiciones de licencia y atribución dependen de la URL de descarga; la responsabilidad recae en ti."
 
-#: src/muuli_wdr.cpp:2896
+#: src/muuli_wdr.cpp:2903
 msgid "Download the GeoIP database from the selected source."
 msgstr "Descarga la base de datos GeoIP de la fuente seleccionada."
 
-#: src/muuli_wdr.cpp:2898
+#: src/muuli_wdr.cpp:2905
 msgid "Auto-update on startup"
 msgstr "Autoactualizar al inicio"
 
-#: src/muuli_wdr.cpp:2899
+#: src/muuli_wdr.cpp:2906
 msgid "Re-download the GeoIP database from the selected source every time aMule starts."
 msgstr "Vuelve a descargar la base de datos GeoIP desde la fuente seleccionada cada vez que se inicie aMule."
 
-#: src/muuli_wdr.cpp:2922
+#: src/muuli_wdr.cpp:2929
 msgid "Filter incoming messages (except current chat):"
 msgstr "Filtrar los mensajes entrantes (salvo la conversación actual):"
 
-#: src/muuli_wdr.cpp:2924
+#: src/muuli_wdr.cpp:2931
 msgid "Filter all messages"
 msgstr "Filtrar todos los mensajes"
 
-#: src/muuli_wdr.cpp:2926
+#: src/muuli_wdr.cpp:2933
 msgid "Filter messages from people not on your friend list"
 msgstr "Filtrar los mensajes de gente que no esté en su lista de amigos"
 
-#: src/muuli_wdr.cpp:2928
+#: src/muuli_wdr.cpp:2935
 msgid "Filter messages from unknown clients"
 msgstr "Filtrar los mensajes de clientes desconocidos"
 
-#: src/muuli_wdr.cpp:2930
+#: src/muuli_wdr.cpp:2937
 msgid "Filter messages containing (use ',' as separator):"
 msgstr "Filtrar los mensajes que contengan (use ',' como separador):"
 
-#: src/muuli_wdr.cpp:2933 src/muuli_wdr.cpp:2944
+#: src/muuli_wdr.cpp:2940 src/muuli_wdr.cpp:2951
 msgid "add here the words amule should filter and block messages including it"
 msgstr "añada aquí las palabras que amule debe filtrar para bloquear los mensajes que las incluyan"
 
-#: src/muuli_wdr.cpp:2935
+#: src/muuli_wdr.cpp:2942
 msgid "Show received messages in the log"
 msgstr "Mostrar los mensajes recibidos en el registro"
 
-#: src/muuli_wdr.cpp:2938
+#: src/muuli_wdr.cpp:2945
 msgid "Comments"
 msgstr "Comentarios"
 
-#: src/muuli_wdr.cpp:2941
+#: src/muuli_wdr.cpp:2948
 msgid "Filter comments containing (use ',' as separator):"
 msgstr "Filtrar los comentarios que contengan (use ',' como separador):"
 
-#: src/muuli_wdr.cpp:2966
+#: src/muuli_wdr.cpp:2973
 msgid "Enable Proxy"
 msgstr "Habilitar el proxy"
 
-#: src/muuli_wdr.cpp:2967
+#: src/muuli_wdr.cpp:2974
 msgid "Enable/disable proxy support"
 msgstr "Habilitar/deshabilitar el soporte para proxy"
 
-#: src/muuli_wdr.cpp:2970
+#: src/muuli_wdr.cpp:2977
 msgid "Proxy type:"
 msgstr "Tipo de proxy:"
 
-#: src/muuli_wdr.cpp:2981
+#: src/muuli_wdr.cpp:2988
 msgid "Proxy host:"
 msgstr "Servidor proxy:"
 
-#: src/muuli_wdr.cpp:2984
+#: src/muuli_wdr.cpp:2991
 msgid "The proxy host name"
 msgstr "Nombre del host del proxy"
 
-#: src/muuli_wdr.cpp:2986
+#: src/muuli_wdr.cpp:2993
 msgid "Proxy port:"
 msgstr "Puerto del proxy:"
 
-#: src/muuli_wdr.cpp:2989
+#: src/muuli_wdr.cpp:2996
 msgid "The proxy port"
 msgstr "El puerto del proxy"
 
-#: src/muuli_wdr.cpp:2991
+#: src/muuli_wdr.cpp:2998
 msgid "Enable authentication"
 msgstr "Habilitar la autentificación"
 
-#: src/muuli_wdr.cpp:2992
+#: src/muuli_wdr.cpp:2999
 msgid "Enable/disable username/password authentication"
 msgstr "Habilitar/deshabilitar la autenticación mediante usuario/contraseña"
 
-#: src/muuli_wdr.cpp:2995
+#: src/muuli_wdr.cpp:3002
 msgid "Username: "
 msgstr "Nombre de usuario: "
 
-#: src/muuli_wdr.cpp:2998
+#: src/muuli_wdr.cpp:3005
 msgid "The username to use to connect to the proxy"
 msgstr "El nombre de usuario a usar para conectar al proxy"
 
-#: src/muuli_wdr.cpp:3000
+#: src/muuli_wdr.cpp:3007
 msgid "Password:"
 msgstr "Contraseña:"
 
-#: src/muuli_wdr.cpp:3003
+#: src/muuli_wdr.cpp:3010
 msgid "The password to use to connect to the proxy"
 msgstr "La contraseña a usar para conectar al proxy"
 
-#: src/muuli_wdr.cpp:3022
+#: src/muuli_wdr.cpp:3029
 msgid "Connect to:"
 msgstr "Conectar a:"
 
-#: src/muuli_wdr.cpp:3031
+#: src/muuli_wdr.cpp:3038
 msgid "Login to remote amule"
 msgstr "Conexión a aMule remoto"
 
-#: src/muuli_wdr.cpp:3036
+#: src/muuli_wdr.cpp:3043
 msgid "User name"
 msgstr "Nombre de usuario"
 
-#: src/muuli_wdr.cpp:3047
+#: src/muuli_wdr.cpp:3054
 msgid "Remember those settings"
 msgstr "Recordar estas opciones"
 
-#: src/muuli_wdr.cpp:3050
+#: src/muuli_wdr.cpp:3057
 msgid "Force ZLIB compression"
 msgstr "Forzar compresión ZLIB"
 
-#: src/muuli_wdr.cpp:3074
+#: src/muuli_wdr.cpp:3081
 msgid "Enable Verbose Debug-Logging."
 msgstr "Habilitar el modo detallado de depuración."
 
-#: src/muuli_wdr.cpp:3076
+#: src/muuli_wdr.cpp:3083
 msgid "Only to Logfile"
 msgstr "Sólo al archivo de registro"
 
-#: src/muuli_wdr.cpp:3078
+#: src/muuli_wdr.cpp:3085
 msgid "Message Categories:"
 msgstr "Categorías de mensajes:"
 
-#: src/muuli_wdr.cpp:3102 src/PartFileConvertDlg.cpp:160
+#: src/muuli_wdr.cpp:3109 src/PartFileConvertDlg.cpp:160
 msgid "Waiting..."
 msgstr "Esperando..."
 
-#: src/muuli_wdr.cpp:3122
+#: src/muuli_wdr.cpp:3129
 msgid "Add imports"
 msgstr "Añadir lo importado"
 
-#: src/muuli_wdr.cpp:3125
+#: src/muuli_wdr.cpp:3132
 msgid "Retry selected"
 msgstr "Reintentar seleccionado"
 
-#: src/muuli_wdr.cpp:3127
+#: src/muuli_wdr.cpp:3134
 msgid "Remove selected"
 msgstr "Borrar seleccionado"
 
-#: src/muuli_wdr.cpp:3190
+#: src/muuli_wdr.cpp:3197
 msgid "Event Types"
 msgstr "Tipos de evento"
 
-#: src/muuli_wdr.cpp:3209
+#: src/muuli_wdr.cpp:3216
 msgid "Statistics and queued clients for selected file(s) : Session / All time"
 msgstr "Estadísticas y clientes en la cola para los archivos seleccionados: Sesión / Total"
 
-#: src/muuli_wdr.cpp:3233
+#: src/muuli_wdr.cpp:3240
 msgid "Active Uploads"
 msgstr "Subidas activas"
 
-#: src/muuli_wdr.cpp:3247
+#: src/muuli_wdr.cpp:3254
 msgid "Percent of total files"
 msgstr "Porcentaje del total de archivos"
 
-#: src/muuli_wdr.cpp:3299
+#: src/muuli_wdr.cpp:3306
 msgid "Show Clients for"
 msgstr "Mostrar los clientes para"
 
-#: src/muuli_wdr.cpp:3301
+#: src/muuli_wdr.cpp:3308
 msgid "All files"
 msgstr "Todos los archivos"
 
-#: src/muuli_wdr.cpp:3304
+#: src/muuli_wdr.cpp:3311
 msgid "Selected files"
 msgstr "Archivos seleccionados"
 
-#: src/muuli_wdr.cpp:3307
+#: src/muuli_wdr.cpp:3314
 msgid "Active uploads only"
 msgstr "Solo las subidas activas"
 
-#: src/muuli_wdr.cpp:3314
+#: src/muuli_wdr.cpp:3321
 msgid "Reload:"
 msgstr "Recargar:"
 
-#: src/muuli_wdr.cpp:3318
+#: src/muuli_wdr.cpp:3325
 msgid "Reload your shared files"
 msgstr "Recargar los archivos compartidos"
 
-#: src/muuli_wdr.cpp:3381
+#: src/muuli_wdr.cpp:3388
 msgid "Send"
 msgstr "Enviar"
 
-#: src/muuli_wdr.cpp:3382
+#: src/muuli_wdr.cpp:3389
 msgid "Sends the specified message."
 msgstr "Envía el mensaje especificado."
 
-#: src/muuli_wdr.cpp:3386
+#: src/muuli_wdr.cpp:3393
 msgid "Close this chat-session."
 msgstr "Cerrar esta sesión de chat."
 
-#: src/muuli_wdr.cpp:3409
+#: src/muuli_wdr.cpp:3416
 msgid "Connect to any server and/or Kad"
 msgstr "Conectar a cualquier servidor y/o a Kad"
 
-#: src/muuli_wdr.cpp:3415 src/SharedFilesCtrl.cpp:142 src/Statistics.cpp:941
+#: src/muuli_wdr.cpp:3422 src/SharedFilesCtrl.cpp:142 src/Statistics.cpp:941
 msgid "Shared Files"
 msgstr "Compartidos"
 
@@ -5422,187 +5436,187 @@ msgstr "Descargado"
 msgid "ERROR: Failed to open partfile '%s'"
 msgstr "ERROR: no se ha podido abrir el archivo de partes '%s'"
 
-#: src/Preferences.cpp:673
+#: src/Preferences.cpp:674
 msgid "System default"
 msgstr "Por defecto"
 
-#: src/Preferences.cpp:674
+#: src/Preferences.cpp:675
 msgid "Albanian"
 msgstr "Albanés"
 
-#: src/Preferences.cpp:675
+#: src/Preferences.cpp:676
 msgid "Arabic"
 msgstr "Árabe"
 
-#: src/Preferences.cpp:676
+#: src/Preferences.cpp:677
 msgid "Asturian"
 msgstr "Asturiano"
 
-#: src/Preferences.cpp:677
+#: src/Preferences.cpp:678
 msgid "Basque"
 msgstr "Euskera"
 
-#: src/Preferences.cpp:678
+#: src/Preferences.cpp:679
 msgid "Bulgarian"
 msgstr "Búlgaro"
 
-#: src/Preferences.cpp:679
+#: src/Preferences.cpp:680
 msgid "Catalan"
 msgstr "Catalán"
 
-#: src/Preferences.cpp:680
+#: src/Preferences.cpp:681
 msgid "Chinese (Simplified)"
 msgstr "Chino (simplificado)"
 
-#: src/Preferences.cpp:681
+#: src/Preferences.cpp:682
 msgid "Chinese (Traditional)"
 msgstr "Chino (tradicional)"
 
-#: src/Preferences.cpp:682
+#: src/Preferences.cpp:683
 msgid "Croatian"
 msgstr "Croata"
 
-#: src/Preferences.cpp:683
+#: src/Preferences.cpp:684
 msgid "Czech"
 msgstr "Checo"
 
-#: src/Preferences.cpp:684
+#: src/Preferences.cpp:685
 msgid "Danish"
 msgstr "Danés"
 
-#: src/Preferences.cpp:685
+#: src/Preferences.cpp:686
 msgid "Dutch"
 msgstr "Holandés"
 
-#: src/Preferences.cpp:686
+#: src/Preferences.cpp:687
 msgid "English (U.K.)"
 msgstr "Inglés (Reino Unido)"
 
-#: src/Preferences.cpp:687
+#: src/Preferences.cpp:688
 msgid "English (U.S.)"
 msgstr "Inglés (EE.UU.)"
 
-#: src/Preferences.cpp:688
+#: src/Preferences.cpp:689
 msgid "Estonian"
 msgstr "Estonio"
 
-#: src/Preferences.cpp:689
+#: src/Preferences.cpp:690
 msgid "Finnish"
 msgstr "Finés"
 
-#: src/Preferences.cpp:690
+#: src/Preferences.cpp:691
 msgid "French"
 msgstr "Francés"
 
-#: src/Preferences.cpp:691
+#: src/Preferences.cpp:692
 msgid "Galician"
 msgstr "Gallego"
 
-#: src/Preferences.cpp:692
+#: src/Preferences.cpp:693
 msgid "German"
 msgstr "Alemán"
 
-#: src/Preferences.cpp:693
+#: src/Preferences.cpp:694
 msgid "Greek"
 msgstr "Griego"
 
-#: src/Preferences.cpp:694
+#: src/Preferences.cpp:695
 msgid "Hebrew"
 msgstr "Hebreo"
 
-#: src/Preferences.cpp:695
+#: src/Preferences.cpp:696
 msgid "Hungarian"
 msgstr "Húngaro"
 
-#: src/Preferences.cpp:696
+#: src/Preferences.cpp:697
 msgid "Italian"
 msgstr "Italiano"
 
-#: src/Preferences.cpp:697
+#: src/Preferences.cpp:698
 msgid "Japanese"
 msgstr "Japonés"
 
-#: src/Preferences.cpp:698
+#: src/Preferences.cpp:699
 msgid "Korean"
 msgstr "Coreano"
 
-#: src/Preferences.cpp:699
+#: src/Preferences.cpp:700
 msgid "Latvian"
 msgstr "Letón"
 
-#: src/Preferences.cpp:700
+#: src/Preferences.cpp:701
 msgid "Lithuanian"
 msgstr "Lituano"
 
-#: src/Preferences.cpp:701
+#: src/Preferences.cpp:702
 msgid "Norwegian (Nynorsk)"
 msgstr "Noruego (Nynorsk)"
 
-#: src/Preferences.cpp:702
+#: src/Preferences.cpp:703
 msgid "Polish"
 msgstr "Polaco"
 
-#: src/Preferences.cpp:703
+#: src/Preferences.cpp:704
 msgid "Portuguese"
 msgstr "Portugués"
 
-#: src/Preferences.cpp:704
+#: src/Preferences.cpp:705
 msgid "Portuguese (Brazilian)"
 msgstr "Portugués (brasileño)"
 
-#: src/Preferences.cpp:705
+#: src/Preferences.cpp:706
 msgid "Romanian"
 msgstr "Rumano"
 
-#: src/Preferences.cpp:706
+#: src/Preferences.cpp:707
 msgid "Russian"
 msgstr "Ruso"
 
-#: src/Preferences.cpp:707
+#: src/Preferences.cpp:708
 msgid "Slovenian"
 msgstr "Esloveno"
 
-#: src/Preferences.cpp:708
+#: src/Preferences.cpp:709
 msgid "Spanish"
 msgstr "Español"
 
-#: src/Preferences.cpp:709
+#: src/Preferences.cpp:710
 msgid "Swedish"
 msgstr "Sueco"
 
-#: src/Preferences.cpp:710
+#: src/Preferences.cpp:711
 msgid "Turkish"
 msgstr "Turco"
 
-#: src/Preferences.cpp:711
+#: src/Preferences.cpp:712
 msgid "Ukrainian"
 msgstr "Ucraniano"
 
-#: src/Preferences.cpp:814
+#: src/Preferences.cpp:815
 msgid "Change Language"
 msgstr "Cambiar el idioma"
 
-#: src/Preferences.cpp:878
+#: src/Preferences.cpp:879
 msgid "There are no translations installed for aMule"
 msgstr "No hay traducciones instaladas para aMule"
 
-#: src/Preferences.cpp:879
+#: src/Preferences.cpp:880
 msgid "No languages available"
 msgstr "No hay idiomas disponibles"
 
-#: src/Preferences.cpp:1010
+#: src/Preferences.cpp:1011
 msgid "no options available"
 msgstr "no hay opciones disponibles"
 
-#: src/Preferences.cpp:2179
+#: src/Preferences.cpp:2182
 msgid "Invalid category found, skipping"
 msgstr "Categoría inválida encontrada, se omite"
 
-#: src/Preferences.cpp:2348
+#: src/Preferences.cpp:2351
 msgid "TCP port can't be higher than 65532 due to server UDP socket being TCP+3"
 msgstr "El puerto TCP no puede ser mayor que 65532 debido a que el socket del servidor UDP es TCP+3"
 
-#: src/Preferences.cpp:2349
+#: src/Preferences.cpp:2352
 #, c-format
 msgid "Default port will be used (%d)"
 msgstr "Puerto por defecto que será usado (%d)"
@@ -6103,23 +6117,27 @@ msgstr "Recargando archivos compartidos: %u archivos escaneados"
 msgid "Shared folder"
 msgstr "Carpeta compartida"
 
-#: src/SearchDlg.cpp:425
+#: src/SearchDlg.cpp:280
+msgid "Clear search history"
+msgstr ""
+
+#: src/SearchDlg.cpp:584
 msgid "It's impossible to search when both eD2k and Kademlia are disabled."
 msgstr "No se puede buscar con eD2K y Kademlia deshabilitadas."
 
-#: src/SearchDlg.cpp:426 src/SearchListCtrl.cpp:858
+#: src/SearchDlg.cpp:585 src/SearchListCtrl.cpp:858
 msgid "Search error"
 msgstr "Error de búsqueda"
 
-#: src/SearchDlg.cpp:768
+#: src/SearchDlg.cpp:929
 msgid "Min size must be smaller than max size. Max size ignored."
 msgstr "El tamaño mínimo debe ser menor que el tamaño máximo. Tamaño máximo ignorado."
 
-#: src/SearchDlg.cpp:769 src/SearchDlg.cpp:851
+#: src/SearchDlg.cpp:930 src/SearchDlg.cpp:1012
 msgid "Search warning"
 msgstr "Aviso de búsqueda"
 
-#: src/SearchDlg.cpp:929 src/SearchListCtrl.cpp:735
+#: src/SearchDlg.cpp:1092 src/SearchListCtrl.cpp:735
 msgid "Main"
 msgstr "Principal"
 

--- a/po/es.po
+++ b/po/es.po
@@ -15,7 +15,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-28 10:19+0200\n"
+"POT-Creation-Date: 2026-07-28 12:17+0200\n"
 "PO-Revision-Date: 2026-07-27 11:36+0000\n"
 "Last-Translator: Diego Heras <ngosang@hotmail.es>\n"
 "Language-Team: Spanish <https://hosted.weblate.org/projects/amule/amule-application/es/>\n"
@@ -214,83 +214,83 @@ msgstr "Error al abrir el archivo de enlaces ED2K."
 msgid "WARNING: You can't add yourself as a source for an eD2k link while having a lowid."
 msgstr "AVISO: no puede añadirse a sí mismo como fuente para un enlace eD2k teniendo Id Baja."
 
-#: src/amule.cpp:300
+#: src/amule.cpp:301
 msgid "Now, exiting main app..."
 msgstr "Ahora, saliendo de la aplicación principal..."
 
-#: src/amule.cpp:330
+#: src/amule.cpp:331
 #, c-format
 msgid "Terminating amuleweb instance with pid '%d' ... "
 msgstr "Cerrando la instancia de amuleweb con pid '%d'... "
 
-#: src/amule.cpp:334
+#: src/amule.cpp:335
 #, c-format
 msgid "Killing amuleweb instance with pid '%d' ... "
 msgstr "Matando la instancia de amuleweb con pid '%d'... "
 
-#: src/amule.cpp:336 src/amule.cpp:349 src/ClientRef.cpp:180
+#: src/amule.cpp:337 src/amule.cpp:350 src/ClientRef.cpp:180
 #: src/SearchDlg.cpp:1041 src/ServerListCtrl.cpp:98
 msgid "Failed"
 msgstr "Falló"
 
-#: src/amule.cpp:343
+#: src/amule.cpp:344
 #, c-format
 msgid "Terminating amuleapi instance with pid '%d' ... "
 msgstr "Cerrando la instancia de amuleapi con pid '%d'... "
 
-#: src/amule.cpp:347
+#: src/amule.cpp:348
 #, c-format
 msgid "Killing amuleapi instance with pid '%d' ... "
 msgstr "Matando la instancia de amuleapi con pid '%d'... "
 
-#: src/amule.cpp:355
+#: src/amule.cpp:356
 msgid "aMule OnExit: Terminating core."
 msgstr "aMule OnExit: terminando el núcleo."
 
-#: src/amule.cpp:466
+#: src/amule.cpp:467
 msgid "aMule shutdown completed."
 msgstr "Cierre de aMule completado."
 
-#: src/amule.cpp:470
+#: src/amule.cpp:471
 msgid "Memory debug results for aMule exit:"
 msgstr "Resultados de depuración de memoria en la salida de aMule:"
 
-#: src/amule.cpp:651
+#: src/amule.cpp:652
 #, c-format
 msgid "Binding aMule's peer-to-peer traffic to interface: %s (HTTP updates use the default route)"
 msgstr "Vinculando el tráfico P2P de aMule a la interfaz: %s (las actualizaciones HTTP usan la ruta predeterminada)"
 
-#: src/amule.cpp:655
+#: src/amule.cpp:656
 #, c-format
 msgid "Binding all network traffic to interface: %s"
 msgstr "Vinculando todo el tráfico de red a la interfaz: %s"
 
-#: src/amule.cpp:659
+#: src/amule.cpp:660
 #, c-format
 msgid "WARNING: configured network interface '%s' was not found - traffic is NOT bound to it and may leave via the default route. Check the interface name in Preferences."
 msgstr "ADVERTENCIA: la interfaz de red configurada '%s' no se encontró; el tráfico NO está vinculado a ella y puede salir por la ruta predeterminada. Compruebe el nombre de la interfaz en Preferencias."
 
-#: src/amule.cpp:665
+#: src/amule.cpp:666
 #, c-format
 msgid "WARNING: binding to network interface '%s' requires elevated privileges and was NOT applied - traffic may leave via the default route. Grant the capability (e.g. 'sudo setcap cap_net_raw+ep' on the aMule binary) or run with sufficient privileges."
 msgstr "ADVERTENCIA: vincularse a la interfaz de red '%s' requiere privilegios elevados y NO se aplicó; el tráfico puede salir por la ruta predeterminada. Conceda la capacidad (por ejemplo, \"sudo setcap capnetraw+ep\" al binario de aMule) o ejecute con privilegios suficientes."
 
-#: src/amule.cpp:673
+#: src/amule.cpp:674
 #, c-format
 msgid "WARNING: could not bind to network interface '%s' - traffic may leave via the default route."
 msgstr "ADVERTENCIA: no se pudo vincular a la interfaz de red '%s'; el tráfico puede salir por la ruta predeterminada."
 
-#: src/amule.cpp:732
+#: src/amule.cpp:733
 msgid "Your locale has been changed to System Default due to a configuration change. Sorry."
 msgstr "Su configuración regional se ha cambiado a la predefinida del sistema debido a un cambio en la configuración. Disculpe."
 
-#: src/amule.cpp:734 src/amule.cpp:1581 src/CatDialog.cpp:128
+#: src/amule.cpp:735 src/amule.cpp:1589 src/CatDialog.cpp:128
 #: src/CatDialog.cpp:136 src/CatDialog.cpp:149 src/ServerList.cpp:366
 #: src/ServerListCtrl.cpp:152
 msgid "Info"
 msgstr "Información"
 
-#: src/amule.cpp:741
+#: src/amule.cpp:742
 msgid ""
 "\n"
 "EC configuration"
@@ -298,20 +298,20 @@ msgstr ""
 "\n"
 "Configuración de la EC"
 
-#: src/amule.cpp:744
+#: src/amule.cpp:745
 msgid "Password set and external connections enabled."
 msgstr "Contraseña fijada y conexiones externas habilitadas."
 
-#: src/amule.cpp:754 src/KadDlg.cpp:176 src/KadDlg.cpp:185
-#: src/PrefsUnifiedDlg.cpp:1387 src/SharedFilesCtrl.cpp:476
+#: src/amule.cpp:755 src/KadDlg.cpp:176 src/KadDlg.cpp:185
+#: src/PrefsUnifiedDlg.cpp:1461 src/SharedFilesCtrl.cpp:476
 msgid "WARNING"
 msgstr "AVISO"
 
-#: src/amule.cpp:991
+#: src/amule.cpp:992
 msgid "Network bootstrap"
 msgstr "Bootstrap de red"
 
-#: src/amule.cpp:996
+#: src/amule.cpp:997
 msgid ""
 "aMule has detected missing network bootstrap files.\n"
 "Select which ones to download:"
@@ -319,51 +319,51 @@ msgstr ""
 "aMule ha detectado archivos de bootstrap de red faltantes.\n"
 "Seleccione cuáles descargar:"
 
-#: src/amule.cpp:1005 src/FirstRunWizard.cpp:411
+#: src/amule.cpp:1006 src/FirstRunWizard.cpp:411
 msgid "eD2k server list (server.met)"
 msgstr "Lista de servidores eD2k (server.met)"
 
-#: src/amule.cpp:1012 src/FirstRunWizard.cpp:416
+#: src/amule.cpp:1013 src/FirstRunWizard.cpp:416
 msgid "Kad bootstrap nodes (nodes.dat)"
 msgstr "Nodos de bootstrap Kad (nodes.dat)"
 
-#: src/amule.cpp:1102
+#: src/amule.cpp:1103
 #, c-format
 msgid "web server running on pid %d"
 msgstr "servidor web corriendo con pid: %d"
 
-#: src/amule.cpp:1115
+#: src/amule.cpp:1116
 msgid "You requested to run web server on startup, but the amuleweb binary cannot be run. Please install the package containing aMule web server, or build aMule from source with -DBUILD_WEBSERVER=YES and install it."
 msgstr "Ha solicitado ejecutar el servidor web al inicio pero no se puede ejecutar el binario amuleweb. Por favor, instale el paquete que contiene el servidor web de aMule, o compile aMule desde el código fuente con -DBUILD_WEBSERVER=YES e instálelo."
 
-#: src/amule.cpp:1120 src/amule.cpp:1177 src/amule.cpp:1291 src/amule.cpp:1593
+#: src/amule.cpp:1121 src/amule.cpp:1185 src/amule.cpp:1299 src/amule.cpp:1601
 #: src/amule-remote-gui.cpp:603 src/amule-remote-gui.cpp:671
 #: src/amule-remote-gui.cpp:709 src/amule-remote-gui.cpp:1282
 #: src/amule-remote-gui.cpp:1345 src/amule-remote-gui.cpp:1372
-#: src/DownloadQueue.cpp:1481
+#: src/DownloadQueue.cpp:1481 src/PrefsUnifiedDlg.cpp:1247
 msgid "ERROR"
 msgstr "ERROR"
 
-#: src/amule.cpp:1166
+#: src/amule.cpp:1174
 #, c-format
 msgid "amuleapi running on pid %d"
 msgstr "amuleapi corriendo con pid %d"
 
-#: src/amule.cpp:1172
+#: src/amule.cpp:1180
 msgid "You requested to run amuleapi on startup, but the amuleapi binary cannot be run. Please install the package containing aMule's REST API server, or build aMule from source with -DBUILD_AMULEAPI=YES and install it."
 msgstr "Ha solicitado ejecutar amuleapi al inicio pero no se puede ejecutar el binario amuleapi. Por favor, instale el paquete que contiene el servidor API REST de aMule, o compile aMule desde el código fuente con -DBUILD_AMULEAPI=YES e instálelo."
 
-#: src/amule.cpp:1259
+#: src/amule.cpp:1267
 #, c-format
 msgid "Could not bind ports to the specified address: %s"
 msgstr "No se pueden asociar los puertos con la dirección especificada: %s"
 
-#: src/amule.cpp:1283
+#: src/amule.cpp:1291
 #, c-format
 msgid "Port %u is not available. You will be LOWID\n"
 msgstr "El puerto %u no está disponible. Tendrás Id Baja\n"
 
-#: src/amule.cpp:1288
+#: src/amule.cpp:1296
 #, c-format
 msgid ""
 "Port %u is not available!\n"
@@ -378,48 +378,48 @@ msgstr ""
 "\n"
 "Comprueba la red y asegúrate de que el puerto está abierto para salida y entrada."
 
-#: src/amule.cpp:1385
+#: src/amule.cpp:1393
 msgid "Failed to create OnlineSig File"
 msgstr "Error al crear el archivo de firma online"
 
-#: src/amule.cpp:1393
+#: src/amule.cpp:1401
 msgid "Failed to create aMule OnlineSig File"
 msgstr "Error al crear el archivo de firma online de aMule"
 
-#: src/amule.cpp:1556
+#: src/amule.cpp:1564
 msgid "The selected locale seems not to be installed on your box. (Note: I'll try to set it anyway)"
 msgstr "El idioma seleccionado no parece estar instalado en tu sistema. (Nota: intentaré configurarlo de todos modos)"
 
-#: src/amule.cpp:1566
+#: src/amule.cpp:1574
 #, c-format
 msgid "This is the first time you run aMule %s"
 msgstr "Es la primera vez que inicias aMule %s"
 
-#: src/amule.cpp:1569
+#: src/amule.cpp:1577
 msgid "This version is a testing version, updated daily, and\n"
 msgstr "Esta es una versión de prueba, actualizada diariamente, y\n"
 
-#: src/amule.cpp:1570
+#: src/amule.cpp:1578
 msgid "we give no warranty it won't break anything, burn your house,\n"
 msgstr "no garantizamos que no rompa nada, no queme su casa,\n"
 
-#: src/amule.cpp:1571
+#: src/amule.cpp:1579
 msgid "or kill your dog. But it *should* be safe to use anyway.\n"
 msgstr "o no mate a su perro. Pero *debería* ser seguro usarla de todas formas.\n"
 
-#: src/amule.cpp:1576
+#: src/amule.cpp:1584
 msgid "More information, support and new releases can found at our homepage,\n"
 msgstr "En nuestra web podrá encontrar más información, soporte y nuevas versiones,\n"
 
-#: src/amule.cpp:1577
+#: src/amule.cpp:1585
 msgid "at https://amule-org.github.io, or in our IRC channel #aMule at irc.libera.chat.\n"
 msgstr "en https://amule-org.github.io, o en nuestro canal de IRC #aMule en irc.libera.chat.\n"
 
-#: src/amule.cpp:1579
+#: src/amule.cpp:1587
 msgid "Feel free to report any bugs to https://github.com/amule-org/amule/issues"
 msgstr "Envíenos cualquier fallo a https://github.com/amule-org/amule/issues"
 
-#: src/amule.cpp:1591
+#: src/amule.cpp:1599
 msgid ""
 "The folder for Online Signature files you specified is INVALID!\n"
 " OnlineSignature will be DISABLED until you fix it on preferences."
@@ -427,137 +427,137 @@ msgstr ""
 "¡El directorio que ha especificado para archivos de firma digital no es válido!\n"
 "La firma digital se ha deshabilitado hasta que lo arregle en las preferencias."
 
-#: src/amule.cpp:1654
+#: src/amule.cpp:1662
 msgid "Server hostname notified"
 msgstr "Nombre de servidor notificado"
 
-#: src/amule.cpp:2031
+#: src/amule.cpp:2039
 #, c-format
 msgid "Disk space preallocation for file '%s' failed: %s"
 msgstr "La reserva del espacio en disco para el archivo '%s' ha fallado: %s"
 
-#: src/amule.cpp:2160
+#: src/amule.cpp:2168
 msgid "ERROR: can't open logfile"
 msgstr "ERROR: no se puede abrir el archivo de registro"
 
-#: src/amule.cpp:2164
+#: src/amule.cpp:2172
 msgid "WARNING: logfile is empty. Something is wrong."
 msgstr "AVISO: el archivo de registro está vacío. Algo está mal."
 
-#: src/amule.cpp:2181
+#: src/amule.cpp:2189
 msgid "Log has been reset"
 msgstr "El registro se ha borrado"
 
-#: src/amule.cpp:2205
+#: src/amule.cpp:2213
 #, c-format
 msgid "ServerMessage: %s"
 msgstr "Mensaje del servidor: %s"
 
-#: src/amule.cpp:2248 src/IP2Country.cpp:220 src/IPFilter.cpp:514
+#: src/amule.cpp:2256 src/IP2Country.cpp:220 src/IPFilter.cpp:514
 #: src/ServerList.cpp:875
 #, c-format
 msgid "Skipped download of %s, because requested file is not newer."
 msgstr "Se ha descartado la descarga de %s, porque el archivo solicitado no es más nuevo."
 
-#: src/amule.cpp:2251
+#: src/amule.cpp:2259
 msgid "Failed to download the nodes list."
 msgstr "Error al descargar la lista de nodos."
 
-#: src/amule.cpp:2314
+#: src/amule.cpp:2322
 msgid "Failed to open the downloaded version check file"
 msgstr "Error al abrir el archivo de comprobación de versión descargado"
 
-#: src/amule.cpp:2317 src/amule.cpp:2336
+#: src/amule.cpp:2325 src/amule.cpp:2344
 msgid "Corrupted version check file"
 msgstr "Archivo de comprobación de versión dañado"
 
-#: src/amule.cpp:2359
+#: src/amule.cpp:2367
 msgid "You are using an outdated version of aMule!"
 msgstr "¡Estás usando una versión desactualizada de aMule!"
 
-#: src/amule.cpp:2361
+#: src/amule.cpp:2369
 #, c-format
 msgid "Your aMule version is %i.%i.%i and the latest version is %li.%li.%li"
 msgstr "Su versión de aMule es %i.%i.%i y la última versión es %li.%li.%li"
 
-#: src/amule.cpp:2365
+#: src/amule.cpp:2373
 msgid "The latest version can always be found at https://github.com/amule-org/amule/releases/latest"
 msgstr "La última versión siempre se puede encontrar en https://github.com/amule-org/amule/releases/latest"
 
-#: src/amule.cpp:2368
+#: src/amule.cpp:2376
 #, c-format
 msgid "WARNING: Your aMuled version is outdated: %i.%i.%i < %li.%li.%li"
 msgstr "AVISO: su versión de aMuled está desactualizada: %i.%i.%i < %li.%li.%li"
 
-#: src/amule.cpp:2374
+#: src/amule.cpp:2382
 msgid "Your copy of aMule is up to date."
 msgstr "Su copia de aMule está actualizada."
 
-#: src/amule.cpp:2381
+#: src/amule.cpp:2389
 msgid "Failed to download the version check file"
 msgstr "Error al descargar el archivo de comprobación de la versión"
 
-#: src/amule.cpp:2550 src/amule-remote-gui.cpp:1133
+#: src/amule.cpp:2558 src/amule-remote-gui.cpp:1133
 #, c-format
 msgid "Users: %s | Files: %s"
 msgstr "Usuarios: %s | Archivos: %s"
 
-#: src/amule.cpp:2551 src/amule-remote-gui.cpp:1134
+#: src/amule.cpp:2559 src/amule-remote-gui.cpp:1134
 #, c-format
 msgid "Users: E: %s K: %s | Files: E: %s K: %s"
 msgstr "Usuarios: E: %s K: %s | Archivos: E: %s K: %s"
 
-#: src/amule.cpp:2565 src/amule-remote-gui.cpp:1147
+#: src/amule.cpp:2573 src/amule-remote-gui.cpp:1147
 msgid "No networks selected"
 msgstr "No hay redes seleccionadas"
 
-#: src/amule.cpp:2633 src/TextClient.cpp:903
+#: src/amule.cpp:2641 src/TextClient.cpp:903
 msgid "with LowID"
 msgstr "con Id Baja"
 
-#: src/amule.cpp:2633 src/TextClient.cpp:904
+#: src/amule.cpp:2641 src/TextClient.cpp:904
 msgid "with HighID"
 msgstr "con Id Alta"
 
-#: src/amule.cpp:2635
+#: src/amule.cpp:2643
 #, c-format
 msgid "Connected to %s %s"
 msgstr "Conectado a %s %s"
 
-#: src/amule.cpp:2640
+#: src/amule.cpp:2648
 #, c-format
 msgid "Connecting to %s"
 msgstr "Conectando a %s"
 
-#: src/amule.cpp:2642
+#: src/amule.cpp:2650
 msgid "Disconnected from eD2k"
 msgstr "Desconectado de eD2k"
 
-#: src/amule.cpp:2651
+#: src/amule.cpp:2659
 msgid "Kad started."
 msgstr "Kad iniciado."
 
-#: src/amule.cpp:2653
+#: src/amule.cpp:2661
 msgid "Kad stopped."
 msgstr "Kad detenido."
 
-#: src/amule.cpp:2661
+#: src/amule.cpp:2669
 msgid "Connected to Kad (ok)"
 msgstr "Conectado a Kad (correcto)"
 
-#: src/amule.cpp:2663
+#: src/amule.cpp:2671
 msgid "Connected to Kad (firewalled)"
 msgstr "Conectado a Kad (tras cortafuegos)"
 
-#: src/amule.cpp:2667
+#: src/amule.cpp:2675
 msgid "Disconnected from Kad"
 msgstr "Desconectado de Kad"
 
-#: src/amule.cpp:2699
+#: src/amule.cpp:2707
 msgid "Kad network cannot be used if UDP port is disabled on preferences, not starting."
 msgstr "La red Kad no se puede usar si el puerto UDP está deshabilitado en las preferencias, no se inicia."
 
-#: src/amule.cpp:2703
+#: src/amule.cpp:2711
 msgid "Kad network disabled on preferences, not connecting."
 msgstr "Red Kad deshabilitada en las preferencias, no se conecta."
 
@@ -601,36 +601,36 @@ msgid "FATAL ERROR: Failed to create Timer"
 msgstr "ERROR FATAL: no se ha podido crear el temporizador"
 
 #: src/amuleDlg.cpp:361 src/amuleDlg.cpp:1787 src/amuleDlg.cpp:2033
-#: src/muuli_wdr.cpp:1492 src/muuli_wdr.cpp:3418
+#: src/muuli_wdr.cpp:1492 src/muuli_wdr.cpp:3449
 msgid "Networks"
 msgstr "Redes"
 
-#: src/amuleDlg.cpp:362 src/amuleDlg.cpp:1793 src/muuli_wdr.cpp:3419
+#: src/amuleDlg.cpp:362 src/amuleDlg.cpp:1793 src/muuli_wdr.cpp:3450
 msgid "Searches"
 msgstr "Búsquedas"
 
 #: src/amuleDlg.cpp:363 src/amuleDlg.cpp:1799 src/DownloadListCtrl.cpp:740
-#: src/muuli_wdr.cpp:392 src/muuli_wdr.cpp:1585 src/muuli_wdr.cpp:3420
+#: src/muuli_wdr.cpp:392 src/muuli_wdr.cpp:1585 src/muuli_wdr.cpp:3451
 #: src/Statistics.cpp:829
 msgid "Downloads"
 msgstr "Descargas"
 
-#: src/amuleDlg.cpp:364 src/amuleDlg.cpp:1805 src/muuli_wdr.cpp:3294
+#: src/amuleDlg.cpp:364 src/amuleDlg.cpp:1805 src/muuli_wdr.cpp:3325
 msgid "Shared files"
 msgstr "Compartidos"
 
-#: src/amuleDlg.cpp:365 src/amuleDlg.cpp:1811 src/muuli_wdr.cpp:2926
-#: src/muuli_wdr.cpp:3376 src/muuli_wdr.cpp:3423
+#: src/amuleDlg.cpp:365 src/amuleDlg.cpp:1811 src/muuli_wdr.cpp:2957
+#: src/muuli_wdr.cpp:3407 src/muuli_wdr.cpp:3454
 msgid "Messages"
 msgstr "Mensajes"
 
-#: src/amuleDlg.cpp:366 src/amuleDlg.cpp:1817 src/muuli_wdr.cpp:3424
-#: src/PrefsUnifiedDlg.cpp:312 src/Statistics.cpp:779 src/Statistics.cpp:1235
+#: src/amuleDlg.cpp:366 src/amuleDlg.cpp:1817 src/muuli_wdr.cpp:3455
+#: src/PrefsUnifiedDlg.cpp:314 src/Statistics.cpp:779 src/Statistics.cpp:1235
 msgid "Statistics"
 msgstr "Estadísticas"
 
-#: src/amuleDlg.cpp:368 src/amuleDlg.cpp:1824 src/muuli_wdr.cpp:3426
-#: src/PrefsUnifiedDlg.cpp:328 src/utils/wxCas/src/wxcasprefs.cpp:39
+#: src/amuleDlg.cpp:368 src/amuleDlg.cpp:1824 src/muuli_wdr.cpp:3457
+#: src/PrefsUnifiedDlg.cpp:330 src/utils/wxCas/src/wxcasprefs.cpp:39
 msgid "Preferences"
 msgstr "Preferencias"
 
@@ -692,8 +692,8 @@ msgstr "Kad: apagado"
 #: src/amuleDlg.cpp:1029 src/DownloadListCtrl.cpp:505
 #: src/DownloadListCtrl.cpp:749 src/FriendListCtrl.cpp:180
 #: src/muuli_wdr.cpp:731 src/muuli_wdr.cpp:782 src/muuli_wdr.cpp:846
-#: src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2231 src/muuli_wdr.cpp:2316
-#: src/muuli_wdr.cpp:3064 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
+#: src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2262 src/muuli_wdr.cpp:2347
+#: src/muuli_wdr.cpp:3095 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
 #: src/ServerListCtrl.cpp:606 src/TransferWnd.cpp:378
 #: src/utils/wxCas/src/wxcasprefs.cpp:235
 msgid "Cancel"
@@ -704,7 +704,7 @@ msgid "Stop the current connection attempts"
 msgstr "Detener los intentos de conexión actuales"
 
 #: src/amuleDlg.cpp:1035 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976
-#: src/muuli_wdr.cpp:2454
+#: src/muuli_wdr.cpp:2485
 msgid "Disconnect"
 msgstr "Desconectar"
 
@@ -713,7 +713,7 @@ msgid "Disconnect from the currently connected networks"
 msgstr "Desconectarse de las redes conectadas"
 
 #: src/amuleDlg.cpp:1041 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979
-#: src/muuli_wdr.cpp:2609 src/muuli_wdr.cpp:3061 src/muuli_wdr.cpp:3416
+#: src/muuli_wdr.cpp:2640 src/muuli_wdr.cpp:3092 src/muuli_wdr.cpp:3447
 msgid "Connect"
 msgstr "Conectar"
 
@@ -767,7 +767,7 @@ msgstr "Confirmación de salida"
 msgid "Launch Command: "
 msgstr "Ejecutar comando: "
 
-#: src/amuleDlg.cpp:1632 src/muuli_wdr.cpp:1978 src/Preferences.cpp:952
+#: src/amuleDlg.cpp:1632 src/muuli_wdr.cpp:1982 src/Preferences.cpp:979
 msgid "- default -"
 msgstr "- predeterminado -"
 
@@ -781,48 +781,48 @@ msgstr "El directorio de tema '%s' no existe"
 msgid "WARNING: Unable to open skin file '%s' for read"
 msgstr "AVISO: no se puede abrir el archivo de tema '%s' para lectura"
 
-#: src/amuleDlg.cpp:1791 src/muuli_wdr.cpp:3418
+#: src/amuleDlg.cpp:1791 src/muuli_wdr.cpp:3449
 msgid "Networks Window"
 msgstr "Ventana de redes"
 
-#: src/amuleDlg.cpp:1797 src/muuli_wdr.cpp:3419
+#: src/amuleDlg.cpp:1797 src/muuli_wdr.cpp:3450
 msgid "Searches Window"
 msgstr "Ventana de búsquedas"
 
-#: src/amuleDlg.cpp:1803 src/muuli_wdr.cpp:3420
+#: src/amuleDlg.cpp:1803 src/muuli_wdr.cpp:3451
 msgid "Downloads Window"
 msgstr "Ventana de descargas"
 
-#: src/amuleDlg.cpp:1809 src/muuli_wdr.cpp:3422
+#: src/amuleDlg.cpp:1809 src/muuli_wdr.cpp:3453
 msgid "Shared Files Window"
 msgstr "Ventana de archivos compartidos"
 
-#: src/amuleDlg.cpp:1815 src/muuli_wdr.cpp:3423
+#: src/amuleDlg.cpp:1815 src/muuli_wdr.cpp:3454
 msgid "Messages Window"
 msgstr "Ventana de mensajes"
 
-#: src/amuleDlg.cpp:1821 src/muuli_wdr.cpp:3424
+#: src/amuleDlg.cpp:1821 src/muuli_wdr.cpp:3455
 msgid "Statistics Graph Window"
 msgstr "Ventana de gráficos de estadísticas"
 
-#: src/amuleDlg.cpp:1828 src/muuli_wdr.cpp:3426
+#: src/amuleDlg.cpp:1828 src/muuli_wdr.cpp:3457
 msgid "Preferences Settings Window"
 msgstr "Ventana de preferencias de configuración"
 
-#: src/amuleDlg.cpp:1831 src/muuli_wdr.cpp:3427
+#: src/amuleDlg.cpp:1831 src/muuli_wdr.cpp:3458
 msgid "Import"
 msgstr "Importar"
 
-#: src/amuleDlg.cpp:1835 src/muuli_wdr.cpp:3427
+#: src/amuleDlg.cpp:1835 src/muuli_wdr.cpp:3458
 msgid "The partfile importer tool"
 msgstr "La herramienta para importar archivos de partes"
 
-#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3428
+#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3459
 #: src/utils/aLinkCreator/src/alcframe.cpp:262
 msgid "About"
 msgstr "Acerca de"
 
-#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3428
+#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3459
 msgid "About/Help"
 msgstr "Acerca de/Ayuda"
 
@@ -965,7 +965,7 @@ msgstr "no encontrado"
 msgid "The core rejected these shared folders:%s"
 msgstr "El núcleo rechazó estas carpetas compartidas: %s"
 
-#: src/amule-remote-gui.cpp:1336 src/ExternalConn.cpp:2345
+#: src/amule-remote-gui.cpp:1336 src/ExternalConn.cpp:2346
 msgid "Invalid link or already on list."
 msgstr "El enlace no es válido o ya está en la lista."
 
@@ -981,7 +981,7 @@ msgstr "No se puede crear el directorio '%s' para la categoría '%s', se mantien
 #: src/ClientDetailDialog.cpp:123 src/DataToText.cpp:61 src/DataToText.cpp:86
 #: src/DataToText.cpp:101 src/DataToText.cpp:136 src/DataToText.cpp:165
 #: src/DownloadListCtrl.cpp:1172 src/DownloadListCtrl.cpp:1185
-#: src/DownloadListCtrl.cpp:1196 src/ExternalConn.cpp:608
+#: src/DownloadListCtrl.cpp:1196 src/ExternalConn.cpp:609
 #: src/FileDetailDialog.cpp:203 src/FileDetailDialog.cpp:235
 #: src/FileDetailDialog.cpp:242 src/GenericClientListCtrl.cpp:1171
 #: src/GenericClientListCtrl.cpp:1182 src/GenericClientListCtrl.cpp:1192
@@ -1367,19 +1367,19 @@ msgstr "Automática [Al]"
 msgid "Very low"
 msgstr "Muy baja"
 
-#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:743 src/muuli_wdr.cpp:2282
+#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:743 src/muuli_wdr.cpp:2313
 #: src/ServerListCtrl.cpp:263 src/ServerListCtrl.cpp:456
 #: src/SharedFilesCtrl.cpp:145
 msgid "Low"
 msgstr "Baja"
 
-#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:744 src/muuli_wdr.cpp:2283
+#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:744 src/muuli_wdr.cpp:2314
 #: src/ServerListCtrl.cpp:266 src/ServerListCtrl.cpp:457
 #: src/SharedFilesCtrl.cpp:146
 msgid "Normal"
 msgstr "Normal"
 
-#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:745 src/muuli_wdr.cpp:2284
+#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:745 src/muuli_wdr.cpp:2315
 #: src/ServerListCtrl.cpp:269 src/ServerListCtrl.cpp:458
 #: src/SharedFilesCtrl.cpp:147
 msgid "High"
@@ -1471,7 +1471,7 @@ msgstr "Servidor local"
 msgid "Remote Server"
 msgstr "Servidor remoto"
 
-#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3181
+#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3212
 #: src/SearchDlg.cpp:119 src/TextClient.cpp:911
 msgid "Kad"
 msgstr "Kad"
@@ -1542,7 +1542,7 @@ msgstr "Parte"
 msgid "Size"
 msgstr "Tamaño"
 
-#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3248
+#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3279
 msgid "Transferred"
 msgstr "Transferido"
 
@@ -1600,7 +1600,7 @@ msgstr ""
 "Reacción desde: %s (%s)\n"
 "\n"
 
-#: src/DownloadListCtrl.cpp:746 src/muuli_wdr.cpp:2285
+#: src/DownloadListCtrl.cpp:746 src/muuli_wdr.cpp:2316
 #: src/SharedFilesCtrl.cpp:150
 msgid "Auto"
 msgstr "Automática"
@@ -1638,7 +1638,7 @@ msgid "Extended Options"
 msgstr "Opciones adicionales"
 
 #: src/DownloadListCtrl.cpp:770 src/DownloadListCtrl.cpp:822
-#: src/muuli_wdr.cpp:1796
+#: src/muuli_wdr.cpp:1800
 msgid "Preview"
 msgstr "Previsualizar"
 
@@ -1813,225 +1813,230 @@ msgstr[1] "No se pudieron añadir los enlaces %u (consulte el registro para más
 msgid "Invalid eD2k link! ERROR: %s"
 msgstr "¡Enlace eD2k inválido! ERROR: %s"
 
-#: src/ExternalConn.cpp:379
+#: src/ExternalConn.cpp:380
 msgid "Client sent packet after authentication failed."
 msgstr "El cliente ha enviado un paquete después de una autentificación fallida."
 
-#: src/ExternalConn.cpp:396
+#: src/ExternalConn.cpp:397
 msgid "External connection closed."
 msgstr "Conexión externa cerrada."
 
-#: src/ExternalConn.cpp:473
+#: src/ExternalConn.cpp:474
 msgid "External connections disabled due to empty password!"
 msgstr "¡Las conexiones externas están deshabilitadas por estar la contraseña en blanco!"
 
-#: src/ExternalConn.cpp:494
+#: src/ExternalConn.cpp:495
 msgid "External connections disabled in config file"
 msgstr "Conexiones externas deshabilitadas en el archivo de configuración"
 
-#: src/ExternalConn.cpp:575
+#: src/ExternalConn.cpp:576
 msgid "New external connection accepted"
 msgstr "Nueva conexión externa aceptada"
 
-#: src/ExternalConn.cpp:578
+#: src/ExternalConn.cpp:579
 msgid "ERROR: couldn't accept a new external connection"
 msgstr "ERROR: no se ha podido aceptar una nueva conexión externa"
 
-#: src/ExternalConn.cpp:595
+#: src/ExternalConn.cpp:596
 msgid "External connection refused due to empty password in preferences!"
 msgstr "¡Conexión externa rechazada por estar la contraseña en blanco en las preferencias!"
 
-#: src/ExternalConn.cpp:607
+#: src/ExternalConn.cpp:608
 #, c-format
 msgid "Connecting client: %s %s"
 msgstr "Conectando con el cliente: %s %s"
 
-#: src/ExternalConn.cpp:609
+#: src/ExternalConn.cpp:610
 msgid "Unknown version"
 msgstr "Versión desconocida"
 
-#: src/ExternalConn.cpp:622
+#: src/ExternalConn.cpp:623
 msgid "Incorrect EC version ID, there might be binary incompatibility. Use core and remote from same snapshot."
 msgstr "ID de versión de EC incorrecto, debe haber una incompatibilidad. Use núcleo y remoto de la misma versión."
 
-#: src/ExternalConn.cpp:630
+#: src/ExternalConn.cpp:631
 msgid "You cannot connect to a release version from an arbitrary development snapshot! *sigh* possible crash prevented"
 msgstr "¡No puede conectar a una versión final desde una versión de desarrollo cualquiera! *suspiro* posible error evitado"
 
-#: src/ExternalConn.cpp:713
+#: src/ExternalConn.cpp:714
 msgid "Invalid protocol version."
 msgstr "Versión de protocolo no válida."
 
-#: src/ExternalConn.cpp:719
+#: src/ExternalConn.cpp:720
 msgid "Missing protocol version tag."
 msgstr "Falta la etiqueta de versión de protocolo."
 
-#: src/ExternalConn.cpp:727
+#: src/ExternalConn.cpp:728
 msgid "Authentication failed: invalid hash specified as EC password."
 msgstr "Error de autentificación: se ha dado un hash inválido como contraseña de la EC."
 
-#: src/ExternalConn.cpp:775
+#: src/ExternalConn.cpp:776
 msgid "Authentication failed: wrong password."
 msgstr "Error de autentificación: contraseña incorrecta."
 
-#: src/ExternalConn.cpp:777
+#: src/ExternalConn.cpp:778
 msgid "Authentication failed: missing password."
 msgstr "Error de autentificación: falta la contraseña."
 
-#: src/ExternalConn.cpp:788
+#: src/ExternalConn.cpp:789
 msgid "Invalid request, please authenticate first."
 msgstr "Solicitud no válida, debe autentificarse primero."
 
-#: src/ExternalConn.cpp:793
+#: src/ExternalConn.cpp:794
 msgid "Access granted."
 msgstr "Acceso concedido."
 
-#: src/ExternalConn.cpp:801
+#: src/ExternalConn.cpp:802
 #, c-format
 msgid "Sent error message \"%s\" to client."
 msgstr "Enviar el mensaje de error \"%s\" al cliente."
 
-#: src/ExternalConn.cpp:806
+#: src/ExternalConn.cpp:807
 #, c-format
 msgid "Unauthorized access attempt from %s. Connection closed."
 msgstr "Intento de acceso no autorizado desde %s. Conexión cerrada."
 
-#: src/ExternalConn.cpp:1419
+#: src/ExternalConn.cpp:1420
 #, c-format
 msgid "Remote PartFile command failed: FileHash not found: %s"
 msgstr "Error en el comando del archivo de partes remoto: hash de archivo no encontrado: %s"
 
-#: src/ExternalConn.cpp:1423
+#: src/ExternalConn.cpp:1424
 #, c-format
 msgid "FileHash not found: %s"
 msgstr "Hash de archivo no encontrado: %s"
 
-#: src/ExternalConn.cpp:1470 src/ExternalConn.cpp:1558
-#: src/ExternalConn.cpp:1679
+#: src/ExternalConn.cpp:1471 src/ExternalConn.cpp:1559
+#: src/ExternalConn.cpp:1680
 msgid "OOPS! OpCode processing error!"
 msgstr "¡Huy! ¡Error procesando el código de operación!"
 
-#: src/ExternalConn.cpp:1501
+#: src/ExternalConn.cpp:1502
 msgid "Server not added"
 msgstr "Servidor no añadido"
 
-#: src/ExternalConn.cpp:1520
+#: src/ExternalConn.cpp:1521
 #, c-format
 msgid "server not found: %s"
 msgstr "servidor no encontrado: %s"
 
-#: src/ExternalConn.cpp:1537
+#: src/ExternalConn.cpp:1538
 msgid "need to define server to be removed"
 msgstr "necesita definir el servidor que va a borrar"
 
-#: src/ExternalConn.cpp:1552
+#: src/ExternalConn.cpp:1553
 msgid "eD2k is disabled in preferences."
 msgstr "eD2k está deshabilitado en las preferencias."
 
-#: src/ExternalConn.cpp:1657
+#: src/ExternalConn.cpp:1658
 msgid "Friend not found."
 msgstr "Amigo no encontrado."
 
-#: src/ExternalConn.cpp:1667
+#: src/ExternalConn.cpp:1668
 msgid "Client not found."
 msgstr "Cliente no encontrado."
 
-#: src/ExternalConn.cpp:1673
+#: src/ExternalConn.cpp:1674
 msgid "EC_TAG_FRIEND_SHARED requires EC_TAG_FRIEND or EC_TAG_CLIENT."
 msgstr "EC_TAG_FRIEND_SHARED requiere EC_TAG_FRIEND o EC_TAG_CLIENT."
 
-#: src/ExternalConn.cpp:1991
+#: src/ExternalConn.cpp:1992
 msgid "WebSearch from remote interface makes no sense."
 msgstr "La búsqueda web desde una interfaz remota no tiene sentido."
 
-#: src/ExternalConn.cpp:2026
+#: src/ExternalConn.cpp:2027
 msgid "Search in progress. Refetch results in a moment!"
 msgstr "Búsqueda en proceso. ¡Resultados obtenidos en breve!"
 
-#: src/ExternalConn.cpp:2265
+#: src/ExternalConn.cpp:2266
 msgid "No points for graph."
 msgstr "No hay puntos para el gráfico."
 
-#: src/ExternalConn.cpp:2275
+#: src/ExternalConn.cpp:2276
 msgid "Your client is not configured for this detail level."
 msgstr "Su cliente no está configurado para este nivel de detalle."
 
-#: src/ExternalConn.cpp:2302
+#: src/ExternalConn.cpp:2303
 msgid "External Connection: shutdown requested"
 msgstr "Conexión externa: apagado solicitado"
 
-#: src/ExternalConn.cpp:2314
+#: src/ExternalConn.cpp:2315
 msgid "Already shutting down."
 msgstr "Ya se está cerrando."
 
-#: src/ExternalConn.cpp:2332
+#: src/ExternalConn.cpp:2333
 #, c-format
 msgid "ExternalConn: adding link '%s'."
 msgstr "Conexión externa: añadiendo el enlace '%s'."
 
-#: src/ExternalConn.cpp:2350
+#: src/ExternalConn.cpp:2351
 #, c-format
 msgid "%d of %d links failed (invalid or already on list)."
 msgstr "%d de %d enlaces fallaron(no válidos o ya está en la lista)."
 
-#: src/ExternalConn.cpp:2373
+#: src/ExternalConn.cpp:2374
 msgid "Version check throttled; try again shortly."
 msgstr "La comprobación de versión se ha limitado; inténtelo de nuevo en breve."
 
-#: src/ExternalConn.cpp:2378
+#: src/ExternalConn.cpp:2379
 msgid "Version check is not available on this daemon."
 msgstr "La comprobación de versión no está disponible en este demonio."
 
-#: src/ExternalConn.cpp:2508
+#: src/ExternalConn.cpp:2509
 msgid "File not found."
 msgstr "Archivo no encontrado."
 
-#: src/ExternalConn.cpp:2513
+#: src/ExternalConn.cpp:2514
 msgid "Invalid file name."
 msgstr "Nombre de archivo incorrecto."
 
-#: src/ExternalConn.cpp:2521
+#: src/ExternalConn.cpp:2522
 msgid "Unable to rename file."
 msgstr "No se puede renombrar el archivo."
 
-#: src/ExternalConn.cpp:2992 src/ExternalConn.cpp:3020
+#: src/ExternalConn.cpp:2839
+#, c-format
+msgid "Could not save the amuleapi password: %s"
+msgstr ""
+
+#: src/ExternalConn.cpp:3004 src/ExternalConn.cpp:3032
 msgid "Kad is disabled in preferences."
 msgstr "Kad está deshabilitado en las preferencias."
 
-#: src/ExternalConn.cpp:3033
+#: src/ExternalConn.cpp:3045
 msgid "Already connected to eD2k."
 msgstr "Ya está conectado a eD2k."
 
-#: src/ExternalConn.cpp:3036
+#: src/ExternalConn.cpp:3048
 msgid "Connecting to eD2k..."
 msgstr "Conectado a eD2k..."
 
-#: src/ExternalConn.cpp:3045
+#: src/ExternalConn.cpp:3057
 msgid "Already connected to Kad."
 msgstr "Ya está conectado a Kad."
 
-#: src/ExternalConn.cpp:3048
+#: src/ExternalConn.cpp:3060
 msgid "Connecting to Kad..."
 msgstr "Conectando a Kad..."
 
-#: src/ExternalConn.cpp:3055
+#: src/ExternalConn.cpp:3067
 msgid "All networks are disabled."
 msgstr "Todas las redes están deshabilitadas."
 
-#: src/ExternalConn.cpp:3064
+#: src/ExternalConn.cpp:3076
 msgid "Disconnected from eD2k."
 msgstr "Desconectado de eD2k."
 
-#: src/ExternalConn.cpp:3069
+#: src/ExternalConn.cpp:3081
 msgid "Disconnected from Kad."
 msgstr "Desconectado de Kad."
 
-#: src/ExternalConn.cpp:3078
+#: src/ExternalConn.cpp:3090
 #, c-format
 msgid "External Connection: invalid opcode received: %#x"
 msgstr "Conexión externa: se ha recibido un código de operación inválido: %#x"
 
-#: src/ExternalConn.cpp:3083
+#: src/ExternalConn.cpp:3095
 msgid "Invalid opcode (wrong protocol version?)"
 msgstr "Código de operación no válido (¿versión de protocolo incorrecta?)"
 
@@ -2432,23 +2437,23 @@ msgid ""
 "want downloads on a different (e.g. larger) disk."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:549 src/FirstRunWizard.cpp:611 src/muuli_wdr.cpp:1708
+#: src/FirstRunWizard.cpp:549 src/FirstRunWizard.cpp:611 src/muuli_wdr.cpp:1712
 msgid "Destination folder for downloads"
 msgstr "Carpeta de destino para las descargas"
 
 #: src/FirstRunWizard.cpp:553 src/FirstRunWizard.cpp:569 src/muuli_wdr.cpp:1349
-#: src/muuli_wdr.cpp:1366 src/muuli_wdr.cpp:1683 src/muuli_wdr.cpp:1714
-#: src/muuli_wdr.cpp:1726 src/muuli_wdr.cpp:2769
+#: src/muuli_wdr.cpp:1366 src/muuli_wdr.cpp:1687 src/muuli_wdr.cpp:1718
+#: src/muuli_wdr.cpp:1730 src/muuli_wdr.cpp:2800
 #: src/utils/aLinkCreator/src/alcframe.cpp:135
 #: src/utils/wxCas/src/wxcasprefs.cpp:52 src/utils/wxCas/src/wxcasprefs.cpp:118
 msgid "Browse"
 msgstr "Examinar"
 
-#: src/FirstRunWizard.cpp:559 src/muuli_wdr.cpp:1719
+#: src/FirstRunWizard.cpp:559 src/muuli_wdr.cpp:1723
 msgid "(All files in this folder are shared with other peers)"
 msgstr "(Todos los archivos de esta carpeta se comparten con otros usuarios)"
 
-#: src/FirstRunWizard.cpp:565 src/FirstRunWizard.cpp:624 src/muuli_wdr.cpp:1721
+#: src/FirstRunWizard.cpp:565 src/FirstRunWizard.cpp:624 src/muuli_wdr.cpp:1725
 msgid "Folder for temporary download files"
 msgstr "Carpeta para los archivos temporales de las descargas"
 
@@ -2479,7 +2484,7 @@ msgstr "¡Error al abrir el archivo de amigos 'emfriends.met' para escritura!"
 msgid "CRITICAL - no client on StartChatSession"
 msgstr "CRÍTICO - no hay clientes en el inicio de sesión chat"
 
-#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2675 src/muuli_wdr.cpp:3352
+#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2706 src/muuli_wdr.cpp:3383
 msgid "Friends"
 msgstr "Amigos"
 
@@ -2589,8 +2594,8 @@ msgstr "Ninguno"
 msgid "No"
 msgstr "No"
 
-#: src/GenericClientListCtrl.cpp:1216 src/PrefsUnifiedDlg.cpp:2818
-#: src/PrefsUnifiedDlg.cpp:2868 src/ServerListCtrl.cpp:276
+#: src/GenericClientListCtrl.cpp:1216 src/PrefsUnifiedDlg.cpp:2898
+#: src/PrefsUnifiedDlg.cpp:2948 src/ServerListCtrl.cpp:276
 msgid "Yes"
 msgstr "Sí"
 
@@ -2759,10 +2764,10 @@ msgstr "Puerto no válido para la inicialización"
 msgid "Please fill all fields required"
 msgstr "Por favor, rellene todos los campos requeridos"
 
-#: src/KadDlg.cpp:192 src/PartFile.cpp:1031 src/PrefsUnifiedDlg.cpp:1162
-#: src/PrefsUnifiedDlg.cpp:1331 src/PrefsUnifiedDlg.cpp:1589
-#: src/PrefsUnifiedDlg.cpp:1599 src/PrefsUnifiedDlg.cpp:1616
-#: src/PrefsUnifiedDlg.cpp:1658
+#: src/KadDlg.cpp:192 src/PartFile.cpp:1031 src/PrefsUnifiedDlg.cpp:1134
+#: src/PrefsUnifiedDlg.cpp:1204 src/PrefsUnifiedDlg.cpp:1405
+#: src/PrefsUnifiedDlg.cpp:1663 src/PrefsUnifiedDlg.cpp:1673
+#: src/PrefsUnifiedDlg.cpp:1690 src/PrefsUnifiedDlg.cpp:1738
 msgid "Message"
 msgstr "Mensaje"
 
@@ -2863,7 +2868,7 @@ msgstr "Media de compartición"
 msgid "Uploaded"
 msgstr "Subido"
 
-#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3232
+#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3263
 msgid "Requested"
 msgstr "Pedido"
 
@@ -2986,7 +2991,7 @@ msgid "WARNING: "
 msgstr "AVISO: "
 
 #: src/MuleNotebook.cpp:179 src/muuli_wdr.cpp:817 src/muuli_wdr.cpp:1229
-#: src/muuli_wdr.cpp:3136 src/muuli_wdr.cpp:3392
+#: src/muuli_wdr.cpp:3167 src/muuli_wdr.cpp:3423
 msgid "Close"
 msgstr "Cerrar"
 
@@ -3004,7 +3009,7 @@ msgid "Paste"
 msgstr "Pegar"
 
 #: src/MuleTextCtrl.cpp:89 src/muuli_wdr.cpp:358 src/muuli_wdr.cpp:757
-#: src/muuli_wdr.cpp:2359 src/muuli_wdr.cpp:2378 src/muuli_wdr.cpp:2400
+#: src/muuli_wdr.cpp:2390 src/muuli_wdr.cpp:2409 src/muuli_wdr.cpp:2431
 #: src/utils/aLinkCreator/src/alcframe.cpp:142
 msgid "Clear"
 msgstr "Limpiar"
@@ -3096,7 +3101,7 @@ msgstr "Salir"
 
 #: src/MuleTrayIcon.cpp:579 src/MuleTrayIcon.cpp:945 src/MuleTrayIcon.cpp:965
 #: src/muuli_wdr.cpp:1398 src/muuli_wdr.cpp:1406 src/muuli_wdr.cpp:1413
-#: src/muuli_wdr.cpp:1842 src/muuli_wdr.cpp:1848 src/OtherFunctions.cpp:91
+#: src/muuli_wdr.cpp:1846 src/muuli_wdr.cpp:1852 src/OtherFunctions.cpp:91
 #: src/StatisticsDlg.cpp:93 src/StatisticsDlg.cpp:95
 msgid "kB/s"
 msgstr "kB/s"
@@ -3336,7 +3341,7 @@ msgstr "Bytes"
 msgid "KB"
 msgstr "KB"
 
-#: src/muuli_wdr.cpp:274 src/muuli_wdr.cpp:293 src/muuli_wdr.cpp:1627
+#: src/muuli_wdr.cpp:274 src/muuli_wdr.cpp:293 src/muuli_wdr.cpp:1631
 #: src/OtherFunctions.cpp:64
 msgid "MB"
 msgstr "MB"
@@ -3353,7 +3358,7 @@ msgstr "Tamaño máximo"
 msgid "Availability"
 msgstr "Disponibilidad"
 
-#: src/muuli_wdr.cpp:312 src/muuli_wdr.cpp:398 src/muuli_wdr.cpp:3297
+#: src/muuli_wdr.cpp:312 src/muuli_wdr.cpp:398 src/muuli_wdr.cpp:3328
 msgid "Filter:"
 msgstr "Filtro:"
 
@@ -3416,12 +3421,12 @@ msgstr "Fuentes del archivo:"
 #: src/muuli_wdr.cpp:1160 src/muuli_wdr.cpp:1167 src/muuli_wdr.cpp:1172
 #: src/muuli_wdr.cpp:1179 src/muuli_wdr.cpp:1184 src/muuli_wdr.cpp:1191
 #: src/muuli_wdr.cpp:1205 src/muuli_wdr.cpp:1212 src/muuli_wdr.cpp:1217
-#: src/muuli_wdr.cpp:1224 src/muuli_wdr.cpp:3234 src/muuli_wdr.cpp:3242
-#: src/muuli_wdr.cpp:3250
+#: src/muuli_wdr.cpp:1224 src/muuli_wdr.cpp:3265 src/muuli_wdr.cpp:3273
+#: src/muuli_wdr.cpp:3281
 msgid "N/A"
 msgstr "N/D"
 
-#: src/muuli_wdr.cpp:508 src/muuli_wdr.cpp:1065 src/PrefsUnifiedDlg.cpp:297
+#: src/muuli_wdr.cpp:508 src/muuli_wdr.cpp:1065 src/PrefsUnifiedDlg.cpp:299
 msgid "General"
 msgstr "General"
 
@@ -3557,7 +3562,7 @@ msgstr "Artista :"
 msgid "Album :"
 msgstr "Álbum :"
 
-#: src/muuli_wdr.cpp:685 src/muuli_wdr.cpp:2254
+#: src/muuli_wdr.cpp:685 src/muuli_wdr.cpp:2285
 msgid "Title :"
 msgstr "Título:"
 
@@ -3665,7 +3670,7 @@ msgstr "Nombre del usuario:"
 msgid "Userhash :"
 msgstr "Hash del usuario:"
 
-#: src/muuli_wdr.cpp:895 src/muuli_wdr.cpp:1748 src/muuli_wdr.cpp:2449
+#: src/muuli_wdr.cpp:895 src/muuli_wdr.cpp:1752 src/muuli_wdr.cpp:2480
 #: src/utils/aLinkCreator/src/alcframe.cpp:137
 msgid "Add"
 msgstr "Añadir"
@@ -3674,15 +3679,15 @@ msgstr "Añadir"
 msgid "Download-Speed"
 msgstr "Velocidad de descarga"
 
-#: src/muuli_wdr.cpp:954 src/muuli_wdr.cpp:989 src/muuli_wdr.cpp:2553
+#: src/muuli_wdr.cpp:954 src/muuli_wdr.cpp:989 src/muuli_wdr.cpp:2584
 msgid "Current"
 msgstr "Actual"
 
-#: src/muuli_wdr.cpp:962 src/muuli_wdr.cpp:997 src/muuli_wdr.cpp:2561
+#: src/muuli_wdr.cpp:962 src/muuli_wdr.cpp:997 src/muuli_wdr.cpp:2592
 msgid "Running average"
 msgstr "Media de ejecución"
 
-#: src/muuli_wdr.cpp:970 src/muuli_wdr.cpp:1005 src/muuli_wdr.cpp:2569
+#: src/muuli_wdr.cpp:970 src/muuli_wdr.cpp:1005 src/muuli_wdr.cpp:2600
 msgid "Session average"
 msgstr "Media de la sesión"
 
@@ -3694,7 +3699,7 @@ msgstr "Velocidad de subida"
 msgid "Connections"
 msgstr "Conexiones"
 
-#: src/muuli_wdr.cpp:1024 src/muuli_wdr.cpp:1867
+#: src/muuli_wdr.cpp:1024 src/muuli_wdr.cpp:1871
 msgid "Active downloads"
 msgstr "Descargas activas"
 
@@ -3702,7 +3707,7 @@ msgstr "Descargas activas"
 msgid "Active connections (1:1)"
 msgstr "Conexiones activas (1:1)"
 
-#: src/muuli_wdr.cpp:1040 src/muuli_wdr.cpp:1868
+#: src/muuli_wdr.cpp:1040 src/muuli_wdr.cpp:1872
 msgid "Active uploads"
 msgstr "Subidas activas"
 
@@ -3976,7 +3981,7 @@ msgstr "Dirección IP local de enlace (vacía para cualquiera):"
 msgid "Advanced users only: If you have multiple network interfaces, enter the address of the interface to which aMule should be bound."
 msgstr "Solo usuarios avanzados: si tiene varias tarjetas de red, introduzca la dirección de la tarjeta que debe usar aMule."
 
-#: src/muuli_wdr.cpp:1462 src/muuli_wdr.cpp:2061
+#: src/muuli_wdr.cpp:1462 src/muuli_wdr.cpp:2065
 msgid "Bind to network interface (empty for any):"
 msgstr "Vincular a interfaz de red (vacío para cualquiera):"
 
@@ -3992,7 +3997,7 @@ msgstr "Número máximo de fuentes descargando un archivo:"
 msgid "Max simultaneous connections:"
 msgstr "Número máximo de conexiones simultáneas:"
 
-#: src/muuli_wdr.cpp:1498 src/muuli_wdr.cpp:3176
+#: src/muuli_wdr.cpp:1498 src/muuli_wdr.cpp:3207
 msgid "ED2K"
 msgstr "ED2K"
 
@@ -4084,79 +4089,79 @@ msgstr "Reservar el espacio en disco para los archivos nuevos"
 msgid "For new files preallocates disk space for the whole file, thus reduces fragmentation"
 msgstr "Reserva en disco el espacio para los archivos nuevos enteros, reduciendo asíla fragmentación"
 
-#: src/muuli_wdr.cpp:1613
+#: src/muuli_wdr.cpp:1617
 msgid "Create new files as sparse files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1614
-msgid "A sparse file reserves its full size on disk immediately without writing real data to it -- fast, but unsupported or slow on some filesystems, and free-space accounting stays optimistic while the download is in progress. Turn this off to grow the file only as data arrives."
+#: src/muuli_wdr.cpp:1618
+msgid "Sparse part files only occupy disk space for the parts already downloaded, so free space is used up gradually as the file fills in. Turn this off to use an ordinary file instead - useful where sparse files are unsupported or slow, or where backup/de-duplication tools handle them badly. Applies only when the core runs on Windows; on Linux and macOS part files are sparse anyway and this setting has no effect."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1619
+#: src/muuli_wdr.cpp:1623
 msgid "Stop downloads when free disk space reaches "
 msgstr "Detener las descargas cuando el espacio libre en disco alcance "
 
-#: src/muuli_wdr.cpp:1620
+#: src/muuli_wdr.cpp:1624
 msgid "Select this if you want aMule to check your disk space"
 msgstr "Seleccione esta opción si quiere que aMule compruebe el espacio en disco"
 
-#: src/muuli_wdr.cpp:1624
+#: src/muuli_wdr.cpp:1628
 msgid "Enter here the min disk space desired."
 msgstr "Introduzca el espacio mínimo de disco deseado."
 
-#: src/muuli_wdr.cpp:1630
+#: src/muuli_wdr.cpp:1634
 msgid "Save 10 sources on rare files (< 20 sources)"
 msgstr "Guardar 10 fuentes para archivos raros (< 20 fuentes)"
 
-#: src/muuli_wdr.cpp:1634 src/Statistics.cpp:790
+#: src/muuli_wdr.cpp:1638 src/Statistics.cpp:790
 msgid "Uploads"
 msgstr "Subidas"
 
-#: src/muuli_wdr.cpp:1637
+#: src/muuli_wdr.cpp:1641
 msgid "Add new shared files with auto priority"
 msgstr "Añadir los nuevos archivos compartidos con prioridad automática"
 
-#: src/muuli_wdr.cpp:1643
+#: src/muuli_wdr.cpp:1647
 msgid "Intelligent Corruption Handling (I.C.H.)"
 msgstr "Gestión inteligente de corrupción (I.C.H.)"
 
-#: src/muuli_wdr.cpp:1646
+#: src/muuli_wdr.cpp:1650
 msgid "Enable"
 msgstr "Habilitar"
 
-#: src/muuli_wdr.cpp:1649
+#: src/muuli_wdr.cpp:1653
 msgid "Advanced I.C.H. trusts every hash (not recommended)"
 msgstr "El I.C.H. avanzado confía en todos los hash (no recomendado)"
 
-#: src/muuli_wdr.cpp:1661 src/PrefsUnifiedDlg.cpp:1910
+#: src/muuli_wdr.cpp:1665 src/PrefsUnifiedDlg.cpp:1990
 msgid "Media metadata extraction"
 msgstr "Extracción de metadatos multimedia"
 
-#: src/muuli_wdr.cpp:1665
+#: src/muuli_wdr.cpp:1669
 msgid "Extract length / bitrate / codec from shared audio and video files"
 msgstr "Extraer la duración, el bitrate y el códec de los archivos multimedia compartidos"
 
-#: src/muuli_wdr.cpp:1667
+#: src/muuli_wdr.cpp:1671
 msgid "When enabled, aMule runs ffprobe on each shared media file to fill in the Length / Bitrate / Codec columns other clients see when they find the file in a search. Requires ffmpeg (the ffprobe binary) to be installed."
 msgstr "Cuando está activado, aMule ejecuta ffprobe en cada archivo multimedia compartido para rellenar las columnas de Duración / Bitrate / Códec que otros clientes ven cuando encuentran el archivo en una búsqueda. Requiere tener instalado ffmpeg (el binario ffprobe)."
 
-#: src/muuli_wdr.cpp:1674
+#: src/muuli_wdr.cpp:1678
 msgid "Path to ffprobe:"
 msgstr "Ruta a ffprobe:"
 
-#: src/muuli_wdr.cpp:1679
+#: src/muuli_wdr.cpp:1683
 msgid "Full path to the ffprobe binary. Leave empty to have aMule auto-detect it on startup."
 msgstr "Ruta completa al binario de ffprobe. Déjelo vacío para que aMule lo detecte automáticamente al iniciar."
 
-#: src/muuli_wdr.cpp:1687
+#: src/muuli_wdr.cpp:1691
 msgid "Detect"
 msgstr "Detectar"
 
-#: src/muuli_wdr.cpp:1688
+#: src/muuli_wdr.cpp:1692
 msgid "Search the standard install locations for an ffprobe binary and fill the path field."
 msgstr "Buscar los lugares de instalación estándar para un binario ffprobe y rellenar el campo de la ruta."
 
-#: src/muuli_wdr.cpp:1712
+#: src/muuli_wdr.cpp:1716
 msgid ""
 "Completed downloads are stored here. All files in this folder are automatically shared with other peers.\n"
 "If this folder also holds files you don't want to share, point it at an aMule-only sub-folder."
@@ -4164,360 +4169,383 @@ msgstr ""
 "Las descargas completadas se guardan aquí. Todos los archivos de esta carpeta se compartirán automáticamente con otros usuarios.\n"
 "Si esta carpeta contiene archivos que no quiere compartir, apúntelo a un sub-directorio exclusivo para aMule."
 
-#: src/muuli_wdr.cpp:1715
+#: src/muuli_wdr.cpp:1719
 msgid "Pick the folder where completed downloads will be stored. All files in that folder will be shared with other peers."
 msgstr "Elija la carpeta donde se guardarán las descargas terminadas. Todos los archivos de esa carpeta se compartirán con otros usuarios."
 
-#: src/muuli_wdr.cpp:1729
+#: src/muuli_wdr.cpp:1733
 msgid "Shared folders"
 msgstr "Carpetas compartidas"
 
-#: src/muuli_wdr.cpp:1735
+#: src/muuli_wdr.cpp:1739
 msgid "(Folders shared by the core. Enter a path to add one.)"
 msgstr "(Directorios compartidos por el núcleo. Introduzca una ruta para añadir uno.)"
 
-#: src/muuli_wdr.cpp:1743
+#: src/muuli_wdr.cpp:1747
 msgid "Absolute path of a folder on the core's machine, e.g. /home/user/shared"
 msgstr "Ruta absoluta de un directorio en la máquina del núcleo, p. ej. /home/user/compartido"
 
-#: src/muuli_wdr.cpp:1745 src/PrefsUnifiedDlg.cpp:2794
+#: src/muuli_wdr.cpp:1749 src/PrefsUnifiedDlg.cpp:2874
 msgid "Recursive"
 msgstr "Recursivo"
 
-#: src/muuli_wdr.cpp:1746
+#: src/muuli_wdr.cpp:1750
 msgid "Share every sub-folder underneath this one, including ones created later."
 msgstr "Compartir todos los subdirectorios bajo éste, incluyendo los creados en el futuro."
 
-#: src/muuli_wdr.cpp:1750 src/utils/aLinkCreator/src/alcframe.cpp:141
+#: src/muuli_wdr.cpp:1754 src/utils/aLinkCreator/src/alcframe.cpp:141
 msgid "Remove"
 msgstr "Borrar"
 
-#: src/muuli_wdr.cpp:1754
+#: src/muuli_wdr.cpp:1758
 msgid "(Right click on folder icon for recursive share)"
 msgstr "(Haga clic derecho en los iconos de carpetas para compartirlas recursivamente)"
 
-#: src/muuli_wdr.cpp:1761
+#: src/muuli_wdr.cpp:1765
 msgid "Share hidden files"
 msgstr "Compartir los archivos ocultos"
 
-#: src/muuli_wdr.cpp:1767
+#: src/muuli_wdr.cpp:1771
 msgid "Automatically rescan shared folders for changes"
 msgstr "Buscar cambios automáticamente en los directorios compartidos"
 
-#: src/muuli_wdr.cpp:1773
+#: src/muuli_wdr.cpp:1777
 msgid "Follow symbolic links in shared folders"
 msgstr "Seguir enlaces simbólicos en las carpetas compartidas"
 
-#: src/muuli_wdr.cpp:1779
+#: src/muuli_wdr.cpp:1783
 msgid "Exclude files matching:"
 msgstr "Excluir archivos coincidentes:"
 
-#: src/muuli_wdr.cpp:1782
+#: src/muuli_wdr.cpp:1786
 msgid "Wildcard patterns separated by '|', e.g. .DS_Store|Thumbs.db|*.tmp. Files whose name matches are not shared. Matching is case-insensitive."
 msgstr "Patrones comodines separados por '|', p.ej., .DS_Store|Thumbs.db|*.tmp. Los archivos cuyo nombre coincida no serán compartidos. No distingue mayúsculas/minúsculas."
 
-#: src/muuli_wdr.cpp:1786
+#: src/muuli_wdr.cpp:1790
 msgid "Patterns are regular expressions"
 msgstr "Los patrones son expresiones regulares"
 
-#: src/muuli_wdr.cpp:1787
+#: src/muuli_wdr.cpp:1791
 msgid "When set, the whole field is one regular expression ('|' is alternation). When unset, it is a list of '|'-separated wildcards."
 msgstr "Cuando se activa, el campo completo es una expresión regular ('|' es OR). Cuando no se activa, es un listado de comodines separados por '|'."
 
-#: src/muuli_wdr.cpp:1797
+#: src/muuli_wdr.cpp:1801
 msgid "Show how many shared files the current pattern would exclude."
 msgstr "Muestra cuántos archivos compartidos excluiría el patrón actual."
 
-#: src/muuli_wdr.cpp:1818
+#: src/muuli_wdr.cpp:1822
 msgid "Graphs"
 msgstr "Gráficos"
 
-#: src/muuli_wdr.cpp:1821 src/muuli_wdr.cpp:1883
+#: src/muuli_wdr.cpp:1825 src/muuli_wdr.cpp:1887
 msgid "Update delay : 5 secs"
 msgstr "Intervalo de actualización: 5 s"
 
-#: src/muuli_wdr.cpp:1825
+#: src/muuli_wdr.cpp:1829
 msgid "Time for average graph: 100 mins"
 msgstr "Tiempo de promedio del gráfico: 100 minutos"
 
-#: src/muuli_wdr.cpp:1829
+#: src/muuli_wdr.cpp:1833
 msgid "Connections Graph Scale: 100 "
 msgstr "Escala del gráfico de las conexiones: 100 "
 
-#: src/muuli_wdr.cpp:1836
+#: src/muuli_wdr.cpp:1840
 msgid "Download graph scale:"
 msgstr "Escala de la gráfica de descarga:"
 
-#: src/muuli_wdr.cpp:1844
+#: src/muuli_wdr.cpp:1848
 msgid "Upload graph scale:"
 msgstr "Escala de la gráfica de subida:"
 
-#: src/muuli_wdr.cpp:1854
+#: src/muuli_wdr.cpp:1858
 msgid "Colors: "
 msgstr "Colores: "
 
-#: src/muuli_wdr.cpp:1858
+#: src/muuli_wdr.cpp:1862
 msgid "Background"
 msgstr "Fondo"
 
-#: src/muuli_wdr.cpp:1859
+#: src/muuli_wdr.cpp:1863
 msgid "Grid"
 msgstr "Rejilla"
 
-#: src/muuli_wdr.cpp:1860
+#: src/muuli_wdr.cpp:1864
 msgid "Download current"
 msgstr "Descarga actual"
 
-#: src/muuli_wdr.cpp:1861
+#: src/muuli_wdr.cpp:1865
 msgid "Download running average"
 msgstr "Promedio de descarga en ejecución"
 
-#: src/muuli_wdr.cpp:1862
+#: src/muuli_wdr.cpp:1866
 msgid "Download session average"
 msgstr "Promedio de descarga en la sesión"
 
-#: src/muuli_wdr.cpp:1863
+#: src/muuli_wdr.cpp:1867
 msgid "Upload current"
 msgstr "Subida actual"
 
-#: src/muuli_wdr.cpp:1864
+#: src/muuli_wdr.cpp:1868
 msgid "Upload running average"
 msgstr "Promedio de subida en ejecución"
 
-#: src/muuli_wdr.cpp:1865
+#: src/muuli_wdr.cpp:1869
 msgid "Upload session average"
 msgstr "Promedio de subida en la sesión"
 
-#: src/muuli_wdr.cpp:1866
+#: src/muuli_wdr.cpp:1870
 msgid "Active connections"
 msgstr "Conexiones activas"
 
-#: src/muuli_wdr.cpp:1869
+#: src/muuli_wdr.cpp:1873
 msgid "Systray Icon Speed Bar"
 msgstr "Barra de velocidad en el icono de la bandeja del sistema"
 
-#: src/muuli_wdr.cpp:1870
+#: src/muuli_wdr.cpp:1874
 msgid "Kad-nodes current"
 msgstr "Nodos Kad actuales"
 
-#: src/muuli_wdr.cpp:1871
+#: src/muuli_wdr.cpp:1875
 msgid "Kad-nodes running"
 msgstr "Nodos Kad activos"
 
-#: src/muuli_wdr.cpp:1872
+#: src/muuli_wdr.cpp:1876
 msgid "Kad-nodes session"
 msgstr "Nodos Kad de la sesión"
 
-#: src/muuli_wdr.cpp:1876 src/muuli_wdr.cpp:2303
+#: src/muuli_wdr.cpp:1880 src/muuli_wdr.cpp:2334
 msgid "Select"
 msgstr "Seleccionar"
 
-#: src/muuli_wdr.cpp:1880
+#: src/muuli_wdr.cpp:1884
 msgid "Tree"
 msgstr "Árbol"
 
-#: src/muuli_wdr.cpp:1890
+#: src/muuli_wdr.cpp:1894
 msgid "Number of Client Versions shown (0=unlimited)"
 msgstr "Número de versiones de clientes a mostrar (0=sin límite)"
 
-#: src/muuli_wdr.cpp:1915
+#: src/muuli_wdr.cpp:1919
 msgid "!!! WARNING !!!"
 msgstr "¡¡¡ AVISO !!!"
 
-#: src/muuli_wdr.cpp:1930
+#: src/muuli_wdr.cpp:1934
 msgid "Max new connections / 5 secs"
 msgstr "Número máximo de nuevas conexiones cada 5 segundos"
 
-#: src/muuli_wdr.cpp:1932
+#: src/muuli_wdr.cpp:1936
 msgid "Concurrent Kad source lookups"
 msgstr "Búsquedas simultáneas de fuentes Kad"
 
-#: src/muuli_wdr.cpp:1934
+#: src/muuli_wdr.cpp:1938
 msgid "Kad source re-search interval (minutes)"
 msgstr "Intervalo de búsqueda de fuentes Kad (minutos)"
 
-#: src/muuli_wdr.cpp:1936
+#: src/muuli_wdr.cpp:1940
 msgid "Source re-ask interval (minutes)"
 msgstr "Intervalo re‐solicitud de fuentes (minutos)"
 
-#: src/muuli_wdr.cpp:1940
+#: src/muuli_wdr.cpp:1944
 msgid "File Buffer Size: 240000 bytes"
 msgstr "Tamaño del búfer de archivo: 240000 bytes"
 
-#: src/muuli_wdr.cpp:1944
+#: src/muuli_wdr.cpp:1948
 msgid "Use MMAP: memory-mapped file access (lower memory use)"
 msgstr "Usar MMAP: acceso a ficheros mapeados en memoria (menor uso de memoria)"
 
-#: src/muuli_wdr.cpp:1945
+#: src/muuli_wdr.cpp:1949
 msgid "Maps part files into memory instead of buffering them on the heap, lowering the process memory footprint. May reduce download speed on some disks; best for memory-constrained or upload-heavy hosts."
 msgstr "Mapea los ficheros de partes en memoria en vez de usar un buffer en la pila, reduciendo la huella de memoria del proceso. Puede reducir la velocidad de descarga en algunos discos; es mejor usarlo en entornos con poca memoria o nodos que principalmente suban datos."
 
-#: src/muuli_wdr.cpp:1947
+#: src/muuli_wdr.cpp:1951
 msgid "Upload Queue Size: 5000 clients"
 msgstr "Tamaño de cola de espera: 5000 clientes"
 
-#: src/muuli_wdr.cpp:1951
+#: src/muuli_wdr.cpp:1955
 msgid "Server connection refresh interval: Disable"
 msgstr "Intervalo de actualización de la conexión al servidor: desactivado"
 
-#: src/muuli_wdr.cpp:1955
+#: src/muuli_wdr.cpp:1959
 msgid "Disable computer's timed standby mode"
 msgstr "Deshabilitar el modo de reposo del ordenador"
 
-#: src/muuli_wdr.cpp:1974
+#: src/muuli_wdr.cpp:1978
 msgid "Skin to use: "
 msgstr "Tema a usar: "
 
-#: src/muuli_wdr.cpp:1983
+#: src/muuli_wdr.cpp:1987
 msgid "Show \"Fast eD2k Links Handler\" in every window."
 msgstr "Mostrar el \"Gestor rápido de enlaces eD2k\" en todas las ventanas."
 
-#: src/muuli_wdr.cpp:1986
+#: src/muuli_wdr.cpp:1990
 msgid "Show extended info on categories tabs"
 msgstr "Mostrar información adicional en las pestañas de las categorías"
 
-#: src/muuli_wdr.cpp:1989
+#: src/muuli_wdr.cpp:1993
 msgid "Show application version on title"
 msgstr "Mostrar la versión de la aplicación en el título"
 
-#: src/muuli_wdr.cpp:1991
+#: src/muuli_wdr.cpp:1995
 msgid "Show transfer rates on title"
 msgstr "Mostrar las tasas de transferencia en el título"
 
-#: src/muuli_wdr.cpp:1993
+#: src/muuli_wdr.cpp:1997
 msgid "Before application name"
 msgstr "Antes del nombre de la aplicación"
 
-#: src/muuli_wdr.cpp:1995
+#: src/muuli_wdr.cpp:1999
 msgid "After application name"
 msgstr "Después del nombre de la aplicación"
 
-#: src/muuli_wdr.cpp:1998
+#: src/muuli_wdr.cpp:2002
 msgid "Show overhead bandwidth"
 msgstr "Mostrar el ancho de banda adicional usado"
 
-#: src/muuli_wdr.cpp:2002
+#: src/muuli_wdr.cpp:2006
 msgid "Vertical toolbar orientation"
 msgstr "Orientación vertical de la barra de herramientas"
 
-#: src/muuli_wdr.cpp:2004
+#: src/muuli_wdr.cpp:2008
 msgid "Live column sorting (auto-reorder rows as their values change)"
 msgstr "Orden automático de columnas (reordena las filas según cambian sus valores)"
 
-#: src/muuli_wdr.cpp:2011
+#: src/muuli_wdr.cpp:2015
 msgid "Download Queue Files"
 msgstr "Archivos de la cola de descarga"
 
-#: src/muuli_wdr.cpp:2014
+#: src/muuli_wdr.cpp:2018
 msgid "Show progress percentage"
 msgstr "Mostrar el porcentaje de progreso"
 
-#: src/muuli_wdr.cpp:2020
+#: src/muuli_wdr.cpp:2024
 msgid "Show progress bar"
 msgstr "Mostrar la barra de progreso"
 
-#: src/muuli_wdr.cpp:2023
+#: src/muuli_wdr.cpp:2027
 msgid "Flat"
 msgstr "Plana"
 
-#: src/muuli_wdr.cpp:2027
+#: src/muuli_wdr.cpp:2031
 msgid "Round"
 msgstr "Redondeada"
 
-#: src/muuli_wdr.cpp:2045
+#: src/muuli_wdr.cpp:2049
 msgid "External Connection Parameters"
 msgstr "Parámetros de la conexión externa"
 
-#: src/muuli_wdr.cpp:2048
+#: src/muuli_wdr.cpp:2052
 msgid "Accept external connections"
 msgstr "Aceptar conexiones externas"
 
-#: src/muuli_wdr.cpp:2055 src/muuli_wdr.cpp:2114
+#: src/muuli_wdr.cpp:2059 src/muuli_wdr.cpp:2118
 msgid "IP of the listening interface:"
 msgstr "IP de la interfaz que está escuchando:"
 
-#: src/muuli_wdr.cpp:2058
+#: src/muuli_wdr.cpp:2062
 msgid "Enter here a valid ip in the a.b.c.d format for the listening EC interface. An empty field or 0.0.0.0 will mean any interface."
 msgstr "Introduzca aquí una IP válida en la forma a.b.c.d para la interfaz EC que está escuchando. Un campo vacío o 0.0.0.0 significará cualquier interfaz."
 
-#: src/muuli_wdr.cpp:2079 src/muuli_wdr.cpp:2163
+#: src/muuli_wdr.cpp:2083 src/muuli_wdr.cpp:2194
 msgid "TCP port:"
 msgstr "Puerto TCP:"
 
-#: src/muuli_wdr.cpp:2085
+#: src/muuli_wdr.cpp:2089
 msgid "Enable UPnP port forwarding on the EC port"
 msgstr "Habilitar la redirección de puertos UPnP en el puerto EC"
 
-#: src/muuli_wdr.cpp:2089 src/muuli_wdr.cpp:3048
+#: src/muuli_wdr.cpp:2093 src/muuli_wdr.cpp:3079
 #: src/utils/wxCas/src/wxcasprefs.cpp:167
 msgid "Password"
 msgstr "Contraseña"
 
-#: src/muuli_wdr.cpp:2095
+#: src/muuli_wdr.cpp:2099
 msgid "aMule API server parameters"
 msgstr "Parámetros del servidor aMule API"
 
-#: src/muuli_wdr.cpp:2098
+#: src/muuli_wdr.cpp:2102
 msgid "Run amuleapi (REST API) on startup"
 msgstr "Ejecutar amuleapi (API REST) al iniciar"
 
-#: src/muuli_wdr.cpp:2103
+#: src/muuli_wdr.cpp:2107
 msgid "HTTP port:"
 msgstr "Puerto HTTP:"
 
-#: src/muuli_wdr.cpp:2117
+#: src/muuli_wdr.cpp:2121
 msgid "The interface amuleapi's HTTP server listens on. 127.0.0.1 (default) accepts only local connections; use 0.0.0.0 or a specific IP to expose it to other hosts (set an admin password below)."
 msgstr "La interfaz en la que escucha el servidor HTTP de amuleapi es 127.0.0.1 (por defecto), que solo acepta conexiones locales; utilice 0.0.0.0 o una IP específica para exponerla a otros hosts (establezca una contraseña de administrador a continuación)."
 
-#: src/muuli_wdr.cpp:2120
+#: src/muuli_wdr.cpp:2126
+msgid "Type a password to set or change it. Stored passwords cannot be shown, so leaving this empty keeps the current one."
+msgstr ""
+
+#: src/muuli_wdr.cpp:2128
 msgid "Admin password"
 msgstr "Contraseña Admin"
 
-#: src/muuli_wdr.cpp:2125 src/muuli_wdr.cpp:2156
-msgid "Low rights password"
-msgstr "Contraseña del invitado"
+#: src/muuli_wdr.cpp:2140 src/muuli_wdr.cpp:2157 src/PrefsUnifiedDlg.cpp:1103
+#, fuzzy
+msgid "A password is set."
+msgstr "Contraseña Admin"
 
-#: src/muuli_wdr.cpp:2133
+#: src/muuli_wdr.cpp:2144
+#, fuzzy
+msgid "Enable guest access"
+msgstr "Denegar el acceso de invitado"
+
+#: src/muuli_wdr.cpp:2145
+msgid "Guest sessions may read status and listings but cannot change anything. Turning this off clears the stored guest password."
+msgstr ""
+
+#: src/muuli_wdr.cpp:2149
+#, fuzzy
+msgid "Guest password"
+msgstr "Contraseña de invitado para el servidor web"
+
+#: src/muuli_wdr.cpp:2164
 msgid "Web server parameters"
 msgstr "Parámetros del servidor web"
 
-#: src/muuli_wdr.cpp:2136
+#: src/muuli_wdr.cpp:2167
 msgid "Run webserver on startup (deprecated)"
 msgstr "Ejecutar webserver al iniciar (obsoleto)"
 
-#: src/muuli_wdr.cpp:2142
+#: src/muuli_wdr.cpp:2173
 msgid "Web template"
 msgstr "Plantilla web"
 
-#: src/muuli_wdr.cpp:2147
+#: src/muuli_wdr.cpp:2178
 msgid "Full rights password"
 msgstr "Contraseña de administrador"
 
-#: src/muuli_wdr.cpp:2151
+#: src/muuli_wdr.cpp:2182
 msgid "Enable Low rights User"
 msgstr "Permitir un invitado"
 
-#: src/muuli_wdr.cpp:2170
+#: src/muuli_wdr.cpp:2187
+msgid "Low rights password"
+msgstr "Contraseña del invitado"
+
+#: src/muuli_wdr.cpp:2201
 msgid "Enable UPnP port forwarding of the web server port"
 msgstr "Habilitar el reenvío de puertos UPnP en el puerto del servidor web"
 
-#: src/muuli_wdr.cpp:2175
+#: src/muuli_wdr.cpp:2206
 msgid "Web server UPnP TCP port (Optional)"
 msgstr "Puerto TCP del servidor web para UPnP (opcional)"
 
-#: src/muuli_wdr.cpp:2183
+#: src/muuli_wdr.cpp:2214
 msgid "Page Refresh Time (in secs)"
 msgstr "Intervalo de actualización de la página (en segundos)"
 
-#: src/muuli_wdr.cpp:2190
+#: src/muuli_wdr.cpp:2221
 msgid "Enable Gzip compression"
 msgstr "Activar la compresión gzip"
 
-#: src/muuli_wdr.cpp:2224
+#: src/muuli_wdr.cpp:2255
 msgid "Reset page to defaults"
 msgstr "Restablecer a los valores por defecto"
 
-#: src/muuli_wdr.cpp:2225
+#: src/muuli_wdr.cpp:2256
 msgid "Reset the settings on the current page to their default values."
 msgstr "Restablece los ajustes de la página actual a sus valores por defecto."
 
@@ -4525,308 +4553,308 @@ msgstr "Restablece los ajustes de la página actual a sus valores por defecto."
 # botón para cerrar el diálogo de Preferencias guardando los cambios. La
 # traducción sería distinta en cada caso, así que hay que dejar el OK
 # original.
-#: src/muuli_wdr.cpp:2227 src/muuli_wdr.cpp:2313 src/ServerWnd.cpp:274
+#: src/muuli_wdr.cpp:2258 src/muuli_wdr.cpp:2344 src/ServerWnd.cpp:274
 #: src/ServerWnd.cpp:282
 msgid "OK"
 msgstr "OK"
 
-#: src/muuli_wdr.cpp:2229
+#: src/muuli_wdr.cpp:2260
 msgid "Click here to apply any changes made to the preferences."
 msgstr "Haga clic aquí para aplicar los cambios hechos en las preferencias."
 
-#: src/muuli_wdr.cpp:2232
+#: src/muuli_wdr.cpp:2263
 msgid "Reset any changes made to the preferences."
 msgstr "Cancelar los cambios hechos en las preferencias."
 
-#: src/muuli_wdr.cpp:2261
+#: src/muuli_wdr.cpp:2292
 msgid "Comment :"
 msgstr "Comentario:"
 
-#: src/muuli_wdr.cpp:2268
+#: src/muuli_wdr.cpp:2299
 msgid "Incoming Dir :"
 msgstr "Directorio entrante:"
 
-#: src/muuli_wdr.cpp:2277
+#: src/muuli_wdr.cpp:2308
 msgid "Change priority for new assigned files :"
 msgstr "Cambiar la prioridad de los nuevos archivos asignados:"
 
-#: src/muuli_wdr.cpp:2281
+#: src/muuli_wdr.cpp:2312
 msgid "Don't change"
 msgstr "No cambiar"
 
-#: src/muuli_wdr.cpp:2293
+#: src/muuli_wdr.cpp:2324
 msgid "Select color for this Category (currently selected) :"
 msgstr "Seleccione el color para esta categoría (actualmente seleccionado):"
 
-#: src/muuli_wdr.cpp:2360 src/muuli_wdr.cpp:2379 src/muuli_wdr.cpp:2401
+#: src/muuli_wdr.cpp:2391 src/muuli_wdr.cpp:2410 src/muuli_wdr.cpp:2432
 msgid "Click this button to reset the log."
 msgstr "Pulse este botón para borrar el registro."
 
-#: src/muuli_wdr.cpp:2420
+#: src/muuli_wdr.cpp:2451
 msgid "Click on this button to update the servers list from URL ..."
 msgstr "Pulse este botón para actualizar la lista de servidores desde un URL..."
 
-#: src/muuli_wdr.cpp:2424
+#: src/muuli_wdr.cpp:2455
 msgid "Server list"
 msgstr "Lista de servidores"
 
-#: src/muuli_wdr.cpp:2428
+#: src/muuli_wdr.cpp:2459
 msgid "Enter the url to a server.met file here and press the button to the left to update the list of known servers."
 msgstr "Introduzca la URL de un archivo server.met y pulse el botón de la izquierda para actualizar la lista de servidores conocidos."
 
-#: src/muuli_wdr.cpp:2433
+#: src/muuli_wdr.cpp:2464
 msgid "Add server manually: Name"
 msgstr "Añadir servidor manualmente: Nombre"
 
-#: src/muuli_wdr.cpp:2436
+#: src/muuli_wdr.cpp:2467
 msgid "Enter the name of the new server here"
 msgstr "Introduzca aquí el nombre del nuevo servidor"
 
-#: src/muuli_wdr.cpp:2438 src/ServerWnd.cpp:206
+#: src/muuli_wdr.cpp:2469 src/ServerWnd.cpp:206
 msgid "IP:Port"
 msgstr "IP:Puerto"
 
-#: src/muuli_wdr.cpp:2441
+#: src/muuli_wdr.cpp:2472
 msgid "Enter the IP of the server here, using the x.x.x.x format."
 msgstr "Introduzca aquí la IP del servidor, usando el formato \"x.x.x.x\"."
 
-#: src/muuli_wdr.cpp:2447
+#: src/muuli_wdr.cpp:2478
 msgid "Enter the port of the server here."
 msgstr "Introduzca el puerto del servidor."
 
-#: src/muuli_wdr.cpp:2450
+#: src/muuli_wdr.cpp:2481
 msgid "Add manually a server (fill fields to the left before) ..."
 msgstr "Añadir manualmente un servidor (rellene antes los campos de la izquierda)..."
 
-#: src/muuli_wdr.cpp:2479
+#: src/muuli_wdr.cpp:2510
 msgid "aMule Log"
 msgstr "Registro de aMule"
 
-#: src/muuli_wdr.cpp:2487
+#: src/muuli_wdr.cpp:2518
 msgid "Server Info"
 msgstr "Información del servidor"
 
-#: src/muuli_wdr.cpp:2491
+#: src/muuli_wdr.cpp:2522
 msgid "ED2K Info"
 msgstr "Información sobre ED2K"
 
-#: src/muuli_wdr.cpp:2495
+#: src/muuli_wdr.cpp:2526
 msgid "Kad Info"
 msgstr "Información sobre Kad"
 
-#: src/muuli_wdr.cpp:2523
+#: src/muuli_wdr.cpp:2554
 msgid "Click on this button to update the nodes list from URL ..."
 msgstr "Pulse este botón para actualizar la lista de nodos desde el URL..."
 
-#: src/muuli_wdr.cpp:2527
+#: src/muuli_wdr.cpp:2558
 msgid "Nodes (0)"
 msgstr "Nodos (0)"
 
-#: src/muuli_wdr.cpp:2531
+#: src/muuli_wdr.cpp:2562
 msgid "Enter the url to a nodes.dat file here and press the button to the left to update the list of known nodes."
 msgstr "Introduzca la URL del archivo nodes.dat y pulse el botón de la izquierda para actualizar la lista de nodos conocidos."
 
-#: src/muuli_wdr.cpp:2534
+#: src/muuli_wdr.cpp:2565
 msgid "Nodes stats"
 msgstr "Estadísticas de nodos"
 
-#: src/muuli_wdr.cpp:2576
+#: src/muuli_wdr.cpp:2607
 msgid "Bootstrap"
 msgstr "Inicialización"
 
-#: src/muuli_wdr.cpp:2579
+#: src/muuli_wdr.cpp:2610
 msgid "New node"
 msgstr "Nuevo nodo"
 
-#: src/muuli_wdr.cpp:2584
+#: src/muuli_wdr.cpp:2615
 msgid "IP:"
 msgstr "IP:"
 
-#: src/muuli_wdr.cpp:2604
+#: src/muuli_wdr.cpp:2635
 msgid "Port:"
 msgstr "Puerto:"
 
-#: src/muuli_wdr.cpp:2617
+#: src/muuli_wdr.cpp:2648
 msgid "Bootstrap from known clients"
 msgstr "Inicializar desde clientes conocidos"
 
-#: src/muuli_wdr.cpp:2619
+#: src/muuli_wdr.cpp:2650
 msgid "Disconnect Kad"
 msgstr "Desconectar Kad"
 
-#: src/muuli_wdr.cpp:2653
+#: src/muuli_wdr.cpp:2684
 msgid "Use Secure User Identification"
 msgstr "Usar la Identificación Segura de Usuario (ISU)"
 
-#: src/muuli_wdr.cpp:2655
+#: src/muuli_wdr.cpp:2686
 msgid "It is recommended to enable this option. You will not receive credits if SUI is not enabled."
 msgstr "Se recomienda activar esta opción. No recibirá créditos si la ISU no está habilitada."
 
-#: src/muuli_wdr.cpp:2657
+#: src/muuli_wdr.cpp:2688
 msgid "Protocol Obfuscation"
 msgstr "Ofuscación de protocolo"
 
-#: src/muuli_wdr.cpp:2660
+#: src/muuli_wdr.cpp:2691
 msgid "Support Protocol Obfuscation"
 msgstr "Permitir la ofuscación de protocolo"
 
-#: src/muuli_wdr.cpp:2662
+#: src/muuli_wdr.cpp:2693
 msgid "This option enabled Protocol Obfuscation, and makes aMule accept obfuscated connections from other clients."
 msgstr "Esta opción activa la ofuscación de protocolo y hace que aMule acepte conexiones ofuscadas de otros clientes."
 
-#: src/muuli_wdr.cpp:2664
+#: src/muuli_wdr.cpp:2695
 msgid "Use obfuscation for outgoing connections"
 msgstr "Usar la ofuscación para las conexiones salientes"
 
-#: src/muuli_wdr.cpp:2666
+#: src/muuli_wdr.cpp:2697
 msgid "This option makes aMule use Protocol Obfuscation when connecting other clients/servers."
 msgstr "Esta opción hace que aMule use la ofuscación de protocolo cuando se conecta a otros clientes/servidores."
 
-#: src/muuli_wdr.cpp:2668
+#: src/muuli_wdr.cpp:2699
 msgid "Accept only obfuscated connections"
 msgstr "Aceptar sólo conexiones ofuscadas"
 
-#: src/muuli_wdr.cpp:2669
+#: src/muuli_wdr.cpp:2700
 msgid "This option makes aMule only accept obfuscated connections. You will have less sources, but all your traffic will be obfuscated"
 msgstr "Esta opción hace que aMule sólo acepte conexiones ofuscadas. Tendrá menos fuentes, pero todo su tráfico estará ofuscado"
 
-#: src/muuli_wdr.cpp:2674
+#: src/muuli_wdr.cpp:2705
 msgid "Everybody"
 msgstr "Todos"
 
-#: src/muuli_wdr.cpp:2676
+#: src/muuli_wdr.cpp:2707
 msgid "No one"
 msgstr "Nadie"
 
-#: src/muuli_wdr.cpp:2678
+#: src/muuli_wdr.cpp:2709
 msgid "Who can see my shared files:"
 msgstr "Quién puede ver mis archivos compartidos:"
 
-#: src/muuli_wdr.cpp:2679
+#: src/muuli_wdr.cpp:2710
 msgid "Select who can request to view a list of your shared files."
 msgstr "Seleccione quién puede solicitar ver la lista de sus archivos compartidos."
 
-#: src/muuli_wdr.cpp:2681
+#: src/muuli_wdr.cpp:2712
 msgid "IP-Filtering"
 msgstr "Filtrado de direcciones IP"
 
-#: src/muuli_wdr.cpp:2688
+#: src/muuli_wdr.cpp:2719
 msgid "Filter clients"
 msgstr "Filtrar los clientes"
 
-#: src/muuli_wdr.cpp:2690
+#: src/muuli_wdr.cpp:2721
 msgid "Enable filtering of the client IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "Habilitar el filtrado de las IP de clientes definidas en el archivo ~/.aMule/ipfilter.dat."
 
-#: src/muuli_wdr.cpp:2692
+#: src/muuli_wdr.cpp:2723
 msgid "Filter servers"
 msgstr "Filtrar los servidores"
 
-#: src/muuli_wdr.cpp:2694
+#: src/muuli_wdr.cpp:2725
 msgid "Enable filtering of the server IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "Habilitar el filtrado de las IP de servidores definidas en el archivo ~/.aMule/ipfilter.dat."
 
-#: src/muuli_wdr.cpp:2698
+#: src/muuli_wdr.cpp:2729
 msgid "Reload List"
 msgstr "Recargar la lista"
 
-#: src/muuli_wdr.cpp:2699
+#: src/muuli_wdr.cpp:2730
 msgid "Reload the list of IPs to filter from the file ~/.aMule/ipfilter.dat"
 msgstr "Recargar la lista de filtrado de IP desde el archivo ~/.aMule/ipfilter.dat"
 
-#: src/muuli_wdr.cpp:2705
+#: src/muuli_wdr.cpp:2736
 msgid "URL:"
 msgstr "URL:"
 
-#: src/muuli_wdr.cpp:2709 src/muuli_wdr.cpp:2902
+#: src/muuli_wdr.cpp:2740 src/muuli_wdr.cpp:2933
 msgid "Update now"
 msgstr "Actualizar ahora"
 
-#: src/muuli_wdr.cpp:2712
+#: src/muuli_wdr.cpp:2743
 msgid "Auto-update ipfilter at startup"
 msgstr "Autoactualizar el filtro de IP al inicio"
 
-#: src/muuli_wdr.cpp:2716
+#: src/muuli_wdr.cpp:2747
 msgid "Filtering Level:"
 msgstr "Nivel de filtrado:"
 
-#: src/muuli_wdr.cpp:2722
+#: src/muuli_wdr.cpp:2753
 msgid "Always filter LAN IPs"
 msgstr "Filtrar siempre las IP de LAN"
 
-#: src/muuli_wdr.cpp:2725
+#: src/muuli_wdr.cpp:2756
 msgid "Paranoid handling of non-matching IPs"
 msgstr "Gestión paranoica de las IP que no coincidan"
 
-#: src/muuli_wdr.cpp:2727
+#: src/muuli_wdr.cpp:2758
 msgid "Rejects a packet when its source IP differs from the IP the client claims (an anti-spoofing check). Disable only if it causes connection problems."
 msgstr "Rechaza un paquete cuando su IP de origen es diferente de la IP que el cliente dice tener (comprobación anti-suplantación). Desactivar sólo si causa problemas de conexión."
 
-#: src/muuli_wdr.cpp:2729
+#: src/muuli_wdr.cpp:2760
 msgid "Use system-wide ipfilter.dat if available"
 msgstr "Usar el ipfilter.dat del sistema si está disponible"
 
-#: src/muuli_wdr.cpp:2730
+#: src/muuli_wdr.cpp:2761
 msgid "If there's no local ipfilter.dat found, allow usage of a system-wide ipfilter file."
 msgstr "Si no hay un archivo ipfilter.dat local, permitir el uso de un archivo ipfilter del sistema."
 
-#: src/muuli_wdr.cpp:2747
+#: src/muuli_wdr.cpp:2778
 msgid "Enable Online-Signature"
 msgstr "Habilitar la firma digital"
 
-#: src/muuli_wdr.cpp:2749
+#: src/muuli_wdr.cpp:2780
 msgid "Enables the writing of the OS file, which can be used by external apps to create signatures and the like."
 msgstr "Habilita la escritura de archivos de firma digital, algo que puede ser usado por las aplicaciones externas para crear firmas y cosas parecidas."
 
-#: src/muuli_wdr.cpp:2753
+#: src/muuli_wdr.cpp:2784
 msgid "Update Frequency (Secs):"
 msgstr "Frecuencia de actualización (segundos):"
 
-#: src/muuli_wdr.cpp:2756
+#: src/muuli_wdr.cpp:2787
 msgid "Change the frequency (in seconds) of Online Signature updates."
 msgstr "Cambiar la frecuencia (en segundos) de actualización de la firma digital."
 
-#: src/muuli_wdr.cpp:2764
+#: src/muuli_wdr.cpp:2795
 msgid "Save online signature file in: "
 msgstr "Guardar el archivo de firma digital en: "
 
-#: src/muuli_wdr.cpp:2770
+#: src/muuli_wdr.cpp:2801
 msgid "Click here to select the directory containing the the Online Signature files."
 msgstr "Pulse aquí para seleccionar el directorio que contiene los archivos de firmas digitales."
 
-#: src/muuli_wdr.cpp:2803
+#: src/muuli_wdr.cpp:2834
 msgid "Show country flags for clients"
 msgstr "Mostrar las banderas de los países para los clientes"
 
-#: src/muuli_wdr.cpp:2804
+#: src/muuli_wdr.cpp:2835
 msgid "Render the country flag column in the transfers, queue and search views. Requires a valid MMDB GeoIP database (see below)."
 msgstr "Mostrar la columna de la bandera del país en las vistas de transferencias, cola y búsqueda. Requiere una base de datos MMDB GeoIP válida (ver más abajo)."
 
-#: src/muuli_wdr.cpp:2809
+#: src/muuli_wdr.cpp:2840
 msgid "Database"
 msgstr "Base de datos"
 
-#: src/muuli_wdr.cpp:2825
+#: src/muuli_wdr.cpp:2856
 msgid "Source:"
 msgstr "Fuente:"
 
-#: src/muuli_wdr.cpp:2828
+#: src/muuli_wdr.cpp:2859
 msgid "DB-IP (free, no account)"
 msgstr "DB-IP (gratis, sin crear una cuenta)"
 
-#: src/muuli_wdr.cpp:2829
+#: src/muuli_wdr.cpp:2860
 msgid "MaxMind GeoLite2 (free, account required)"
 msgstr "MaxMind GeoLite2 (gratuito, requiere crear una cuenta)"
 
-#: src/muuli_wdr.cpp:2830
+#: src/muuli_wdr.cpp:2861
 msgid "Custom URL"
 msgstr "URL personalizada"
 
-#: src/muuli_wdr.cpp:2833
+#: src/muuli_wdr.cpp:2864
 msgid "Choose which provider supplies the GeoIP MMDB database. DB-IP is the default - no account required. MaxMind requires a free account + license key. Use Custom URL to point at any other MMDB host (e.g. a local mirror)."
 msgstr "Elige qué proveedor ofrece la base de datos GeoIP MMDB. DB-IP es la opción predeterminada; no se necesita cuenta. MaxMind requiere una cuenta gratuita y una clave de licencia. Utiliza la opción 'URL personalizada' para indicar cualquier otro servidor MMDB (por ejemplo, un servidor espejo local)."
 
-#: src/muuli_wdr.cpp:2850
+#: src/muuli_wdr.cpp:2881
 msgid ""
 "No configuration required.\n"
 "\n"
@@ -4838,11 +4866,11 @@ msgstr ""
 "Datos IP-País de DB-IP.com - https://db-ip.com\n"
 "Licencia: Creative Commons BY 4.0 - https://creativecommons.org/licenses/by/4.0/"
 
-#: src/muuli_wdr.cpp:2863
+#: src/muuli_wdr.cpp:2894
 msgid "License key:"
 msgstr "Clave de licencia:"
 
-#: src/muuli_wdr.cpp:2869
+#: src/muuli_wdr.cpp:2900
 msgid ""
 "Sign up for a free MaxMind account, then generate a License Key:\n"
 "https://www.maxmind.com/en/geolite2/signup\n"
@@ -4858,11 +4886,11 @@ msgstr ""
 "Licencia: EULA de MaxMind GeoLite2 - https://www.maxmind.com/en/geolite2/eula\n"
 "Requiere la atribución de la fuente y el registro de una cuenta; actualizar al menos cada 30 días."
 
-#: src/muuli_wdr.cpp:2884
+#: src/muuli_wdr.cpp:2915
 msgid "Download URL:"
 msgstr "URL de descarga:"
 
-#: src/muuli_wdr.cpp:2890
+#: src/muuli_wdr.cpp:2921
 msgid ""
 "Must point to an .mmdb file or a .gz / .tar.gz containing one.\n"
 "URL may include credentials (https://user:pass@host/...).\n"
@@ -4872,211 +4900,211 @@ msgstr ""
 "La URL puede incluir credenciales (https://user:pass@host/...).\n"
 "Las condiciones de licencia y atribución dependen de la URL de descarga; la responsabilidad recae en ti."
 
-#: src/muuli_wdr.cpp:2903
+#: src/muuli_wdr.cpp:2934
 msgid "Download the GeoIP database from the selected source."
 msgstr "Descarga la base de datos GeoIP de la fuente seleccionada."
 
-#: src/muuli_wdr.cpp:2905
+#: src/muuli_wdr.cpp:2936
 msgid "Auto-update on startup"
 msgstr "Autoactualizar al inicio"
 
-#: src/muuli_wdr.cpp:2906
+#: src/muuli_wdr.cpp:2937
 msgid "Re-download the GeoIP database from the selected source every time aMule starts."
 msgstr "Vuelve a descargar la base de datos GeoIP desde la fuente seleccionada cada vez que se inicie aMule."
 
-#: src/muuli_wdr.cpp:2929
+#: src/muuli_wdr.cpp:2960
 msgid "Filter incoming messages (except current chat):"
 msgstr "Filtrar los mensajes entrantes (salvo la conversación actual):"
 
-#: src/muuli_wdr.cpp:2931
+#: src/muuli_wdr.cpp:2962
 msgid "Filter all messages"
 msgstr "Filtrar todos los mensajes"
 
-#: src/muuli_wdr.cpp:2933
+#: src/muuli_wdr.cpp:2964
 msgid "Filter messages from people not on your friend list"
 msgstr "Filtrar los mensajes de gente que no esté en su lista de amigos"
 
-#: src/muuli_wdr.cpp:2935
+#: src/muuli_wdr.cpp:2966
 msgid "Filter messages from unknown clients"
 msgstr "Filtrar los mensajes de clientes desconocidos"
 
-#: src/muuli_wdr.cpp:2937
+#: src/muuli_wdr.cpp:2968
 msgid "Filter messages containing (use ',' as separator):"
 msgstr "Filtrar los mensajes que contengan (use ',' como separador):"
 
-#: src/muuli_wdr.cpp:2940 src/muuli_wdr.cpp:2951
+#: src/muuli_wdr.cpp:2971 src/muuli_wdr.cpp:2982
 msgid "add here the words amule should filter and block messages including it"
 msgstr "añada aquí las palabras que amule debe filtrar para bloquear los mensajes que las incluyan"
 
-#: src/muuli_wdr.cpp:2942
+#: src/muuli_wdr.cpp:2973
 msgid "Show received messages in the log"
 msgstr "Mostrar los mensajes recibidos en el registro"
 
-#: src/muuli_wdr.cpp:2945
+#: src/muuli_wdr.cpp:2976
 msgid "Comments"
 msgstr "Comentarios"
 
-#: src/muuli_wdr.cpp:2948
+#: src/muuli_wdr.cpp:2979
 msgid "Filter comments containing (use ',' as separator):"
 msgstr "Filtrar los comentarios que contengan (use ',' como separador):"
 
-#: src/muuli_wdr.cpp:2973
+#: src/muuli_wdr.cpp:3004
 msgid "Enable Proxy"
 msgstr "Habilitar el proxy"
 
-#: src/muuli_wdr.cpp:2974
+#: src/muuli_wdr.cpp:3005
 msgid "Enable/disable proxy support"
 msgstr "Habilitar/deshabilitar el soporte para proxy"
 
-#: src/muuli_wdr.cpp:2977
+#: src/muuli_wdr.cpp:3008
 msgid "Proxy type:"
 msgstr "Tipo de proxy:"
 
-#: src/muuli_wdr.cpp:2988
+#: src/muuli_wdr.cpp:3019
 msgid "Proxy host:"
 msgstr "Servidor proxy:"
 
-#: src/muuli_wdr.cpp:2991
+#: src/muuli_wdr.cpp:3022
 msgid "The proxy host name"
 msgstr "Nombre del host del proxy"
 
-#: src/muuli_wdr.cpp:2993
+#: src/muuli_wdr.cpp:3024
 msgid "Proxy port:"
 msgstr "Puerto del proxy:"
 
-#: src/muuli_wdr.cpp:2996
+#: src/muuli_wdr.cpp:3027
 msgid "The proxy port"
 msgstr "El puerto del proxy"
 
-#: src/muuli_wdr.cpp:2998
+#: src/muuli_wdr.cpp:3029
 msgid "Enable authentication"
 msgstr "Habilitar la autentificación"
 
-#: src/muuli_wdr.cpp:2999
+#: src/muuli_wdr.cpp:3030
 msgid "Enable/disable username/password authentication"
 msgstr "Habilitar/deshabilitar la autenticación mediante usuario/contraseña"
 
-#: src/muuli_wdr.cpp:3002
+#: src/muuli_wdr.cpp:3033
 msgid "Username: "
 msgstr "Nombre de usuario: "
 
-#: src/muuli_wdr.cpp:3005
+#: src/muuli_wdr.cpp:3036
 msgid "The username to use to connect to the proxy"
 msgstr "El nombre de usuario a usar para conectar al proxy"
 
-#: src/muuli_wdr.cpp:3007
+#: src/muuli_wdr.cpp:3038
 msgid "Password:"
 msgstr "Contraseña:"
 
-#: src/muuli_wdr.cpp:3010
+#: src/muuli_wdr.cpp:3041
 msgid "The password to use to connect to the proxy"
 msgstr "La contraseña a usar para conectar al proxy"
 
-#: src/muuli_wdr.cpp:3029
+#: src/muuli_wdr.cpp:3060
 msgid "Connect to:"
 msgstr "Conectar a:"
 
-#: src/muuli_wdr.cpp:3038
+#: src/muuli_wdr.cpp:3069
 msgid "Login to remote amule"
 msgstr "Conexión a aMule remoto"
 
-#: src/muuli_wdr.cpp:3043
+#: src/muuli_wdr.cpp:3074
 msgid "User name"
 msgstr "Nombre de usuario"
 
-#: src/muuli_wdr.cpp:3054
+#: src/muuli_wdr.cpp:3085
 msgid "Remember those settings"
 msgstr "Recordar estas opciones"
 
-#: src/muuli_wdr.cpp:3057
+#: src/muuli_wdr.cpp:3088
 msgid "Force ZLIB compression"
 msgstr "Forzar compresión ZLIB"
 
-#: src/muuli_wdr.cpp:3081
+#: src/muuli_wdr.cpp:3112
 msgid "Enable Verbose Debug-Logging."
 msgstr "Habilitar el modo detallado de depuración."
 
-#: src/muuli_wdr.cpp:3083
+#: src/muuli_wdr.cpp:3114
 msgid "Only to Logfile"
 msgstr "Sólo al archivo de registro"
 
-#: src/muuli_wdr.cpp:3085
+#: src/muuli_wdr.cpp:3116
 msgid "Message Categories:"
 msgstr "Categorías de mensajes:"
 
-#: src/muuli_wdr.cpp:3109 src/PartFileConvertDlg.cpp:160
+#: src/muuli_wdr.cpp:3140 src/PartFileConvertDlg.cpp:160
 msgid "Waiting..."
 msgstr "Esperando..."
 
-#: src/muuli_wdr.cpp:3129
+#: src/muuli_wdr.cpp:3160
 msgid "Add imports"
 msgstr "Añadir lo importado"
 
-#: src/muuli_wdr.cpp:3132
+#: src/muuli_wdr.cpp:3163
 msgid "Retry selected"
 msgstr "Reintentar seleccionado"
 
-#: src/muuli_wdr.cpp:3134
+#: src/muuli_wdr.cpp:3165
 msgid "Remove selected"
 msgstr "Borrar seleccionado"
 
-#: src/muuli_wdr.cpp:3197
+#: src/muuli_wdr.cpp:3228
 msgid "Event Types"
 msgstr "Tipos de evento"
 
-#: src/muuli_wdr.cpp:3216
+#: src/muuli_wdr.cpp:3247
 msgid "Statistics and queued clients for selected file(s) : Session / All time"
 msgstr "Estadísticas y clientes en la cola para los archivos seleccionados: Sesión / Total"
 
-#: src/muuli_wdr.cpp:3240
+#: src/muuli_wdr.cpp:3271
 msgid "Active Uploads"
 msgstr "Subidas activas"
 
-#: src/muuli_wdr.cpp:3254
+#: src/muuli_wdr.cpp:3285
 msgid "Percent of total files"
 msgstr "Porcentaje del total de archivos"
 
-#: src/muuli_wdr.cpp:3306
+#: src/muuli_wdr.cpp:3337
 msgid "Show Clients for"
 msgstr "Mostrar los clientes para"
 
-#: src/muuli_wdr.cpp:3308
+#: src/muuli_wdr.cpp:3339
 msgid "All files"
 msgstr "Todos los archivos"
 
-#: src/muuli_wdr.cpp:3311
+#: src/muuli_wdr.cpp:3342
 msgid "Selected files"
 msgstr "Archivos seleccionados"
 
-#: src/muuli_wdr.cpp:3314
+#: src/muuli_wdr.cpp:3345
 msgid "Active uploads only"
 msgstr "Solo las subidas activas"
 
-#: src/muuli_wdr.cpp:3321
+#: src/muuli_wdr.cpp:3352
 msgid "Reload:"
 msgstr "Recargar:"
 
-#: src/muuli_wdr.cpp:3325
+#: src/muuli_wdr.cpp:3356
 msgid "Reload your shared files"
 msgstr "Recargar los archivos compartidos"
 
-#: src/muuli_wdr.cpp:3388
+#: src/muuli_wdr.cpp:3419
 msgid "Send"
 msgstr "Enviar"
 
-#: src/muuli_wdr.cpp:3389
+#: src/muuli_wdr.cpp:3420
 msgid "Sends the specified message."
 msgstr "Envía el mensaje especificado."
 
-#: src/muuli_wdr.cpp:3393
+#: src/muuli_wdr.cpp:3424
 msgid "Close this chat-session."
 msgstr "Cerrar esta sesión de chat."
 
-#: src/muuli_wdr.cpp:3416
+#: src/muuli_wdr.cpp:3447
 msgid "Connect to any server and/or Kad"
 msgstr "Conectar a cualquier servidor y/o a Kad"
 
-#: src/muuli_wdr.cpp:3422 src/SharedFilesCtrl.cpp:142 src/Statistics.cpp:941
+#: src/muuli_wdr.cpp:3453 src/SharedFilesCtrl.cpp:142 src/Statistics.cpp:941
 msgid "Shared Files"
 msgstr "Compartidos"
 
@@ -5436,248 +5464,248 @@ msgstr "Descargado"
 msgid "ERROR: Failed to open partfile '%s'"
 msgstr "ERROR: no se ha podido abrir el archivo de partes '%s'"
 
-#: src/Preferences.cpp:674
+#: src/Preferences.cpp:701
 msgid "System default"
 msgstr "Por defecto"
 
-#: src/Preferences.cpp:675
+#: src/Preferences.cpp:702
 msgid "Albanian"
 msgstr "Albanés"
 
-#: src/Preferences.cpp:676
+#: src/Preferences.cpp:703
 msgid "Arabic"
 msgstr "Árabe"
 
-#: src/Preferences.cpp:677
+#: src/Preferences.cpp:704
 msgid "Asturian"
 msgstr "Asturiano"
 
-#: src/Preferences.cpp:678
+#: src/Preferences.cpp:705
 msgid "Basque"
 msgstr "Euskera"
 
-#: src/Preferences.cpp:679
+#: src/Preferences.cpp:706
 msgid "Bulgarian"
 msgstr "Búlgaro"
 
-#: src/Preferences.cpp:680
+#: src/Preferences.cpp:707
 msgid "Catalan"
 msgstr "Catalán"
 
-#: src/Preferences.cpp:681
+#: src/Preferences.cpp:708
 msgid "Chinese (Simplified)"
 msgstr "Chino (simplificado)"
 
-#: src/Preferences.cpp:682
+#: src/Preferences.cpp:709
 msgid "Chinese (Traditional)"
 msgstr "Chino (tradicional)"
 
-#: src/Preferences.cpp:683
+#: src/Preferences.cpp:710
 msgid "Croatian"
 msgstr "Croata"
 
-#: src/Preferences.cpp:684
+#: src/Preferences.cpp:711
 msgid "Czech"
 msgstr "Checo"
 
-#: src/Preferences.cpp:685
+#: src/Preferences.cpp:712
 msgid "Danish"
 msgstr "Danés"
 
-#: src/Preferences.cpp:686
+#: src/Preferences.cpp:713
 msgid "Dutch"
 msgstr "Holandés"
 
-#: src/Preferences.cpp:687
+#: src/Preferences.cpp:714
 msgid "English (U.K.)"
 msgstr "Inglés (Reino Unido)"
 
-#: src/Preferences.cpp:688
+#: src/Preferences.cpp:715
 msgid "English (U.S.)"
 msgstr "Inglés (EE.UU.)"
 
-#: src/Preferences.cpp:689
+#: src/Preferences.cpp:716
 msgid "Estonian"
 msgstr "Estonio"
 
-#: src/Preferences.cpp:690
+#: src/Preferences.cpp:717
 msgid "Finnish"
 msgstr "Finés"
 
-#: src/Preferences.cpp:691
+#: src/Preferences.cpp:718
 msgid "French"
 msgstr "Francés"
 
-#: src/Preferences.cpp:692
+#: src/Preferences.cpp:719
 msgid "Galician"
 msgstr "Gallego"
 
-#: src/Preferences.cpp:693
+#: src/Preferences.cpp:720
 msgid "German"
 msgstr "Alemán"
 
-#: src/Preferences.cpp:694
+#: src/Preferences.cpp:721
 msgid "Greek"
 msgstr "Griego"
 
-#: src/Preferences.cpp:695
+#: src/Preferences.cpp:722
 msgid "Hebrew"
 msgstr "Hebreo"
 
-#: src/Preferences.cpp:696
+#: src/Preferences.cpp:723
 msgid "Hungarian"
 msgstr "Húngaro"
 
-#: src/Preferences.cpp:697
+#: src/Preferences.cpp:724
 msgid "Italian"
 msgstr "Italiano"
 
-#: src/Preferences.cpp:698
+#: src/Preferences.cpp:725
 msgid "Japanese"
 msgstr "Japonés"
 
-#: src/Preferences.cpp:699
+#: src/Preferences.cpp:726
 msgid "Korean"
 msgstr "Coreano"
 
-#: src/Preferences.cpp:700
+#: src/Preferences.cpp:727
 msgid "Latvian"
 msgstr "Letón"
 
-#: src/Preferences.cpp:701
+#: src/Preferences.cpp:728
 msgid "Lithuanian"
 msgstr "Lituano"
 
-#: src/Preferences.cpp:702
+#: src/Preferences.cpp:729
 msgid "Norwegian (Nynorsk)"
 msgstr "Noruego (Nynorsk)"
 
-#: src/Preferences.cpp:703
+#: src/Preferences.cpp:730
 msgid "Polish"
 msgstr "Polaco"
 
-#: src/Preferences.cpp:704
+#: src/Preferences.cpp:731
 msgid "Portuguese"
 msgstr "Portugués"
 
-#: src/Preferences.cpp:705
+#: src/Preferences.cpp:732
 msgid "Portuguese (Brazilian)"
 msgstr "Portugués (brasileño)"
 
-#: src/Preferences.cpp:706
+#: src/Preferences.cpp:733
 msgid "Romanian"
 msgstr "Rumano"
 
-#: src/Preferences.cpp:707
+#: src/Preferences.cpp:734
 msgid "Russian"
 msgstr "Ruso"
 
-#: src/Preferences.cpp:708
+#: src/Preferences.cpp:735
 msgid "Slovenian"
 msgstr "Esloveno"
 
-#: src/Preferences.cpp:709
+#: src/Preferences.cpp:736
 msgid "Spanish"
 msgstr "Español"
 
-#: src/Preferences.cpp:710
+#: src/Preferences.cpp:737
 msgid "Swedish"
 msgstr "Sueco"
 
-#: src/Preferences.cpp:711
+#: src/Preferences.cpp:738
 msgid "Turkish"
 msgstr "Turco"
 
-#: src/Preferences.cpp:712
+#: src/Preferences.cpp:739
 msgid "Ukrainian"
 msgstr "Ucraniano"
 
-#: src/Preferences.cpp:815
+#: src/Preferences.cpp:842
 msgid "Change Language"
 msgstr "Cambiar el idioma"
 
-#: src/Preferences.cpp:879
+#: src/Preferences.cpp:906
 msgid "There are no translations installed for aMule"
 msgstr "No hay traducciones instaladas para aMule"
 
-#: src/Preferences.cpp:880
+#: src/Preferences.cpp:907
 msgid "No languages available"
 msgstr "No hay idiomas disponibles"
 
-#: src/Preferences.cpp:1011
+#: src/Preferences.cpp:1038
 msgid "no options available"
 msgstr "no hay opciones disponibles"
 
-#: src/Preferences.cpp:2182
+#: src/Preferences.cpp:2227
 msgid "Invalid category found, skipping"
 msgstr "Categoría inválida encontrada, se omite"
 
-#: src/Preferences.cpp:2351
+#: src/Preferences.cpp:2396
 msgid "TCP port can't be higher than 65532 due to server UDP socket being TCP+3"
 msgstr "El puerto TCP no puede ser mayor que 65532 debido a que el socket del servidor UDP es TCP+3"
 
-#: src/Preferences.cpp:2352
+#: src/Preferences.cpp:2397
 #, c-format
 msgid "Default port will be used (%d)"
 msgstr "Puerto por defecto que será usado (%d)"
 
-#: src/PrefsUnifiedDlg.cpp:298 src/Statistics.cpp:866
+#: src/PrefsUnifiedDlg.cpp:300 src/Statistics.cpp:866
 msgid "Connection"
 msgstr "Conexión"
 
-#: src/PrefsUnifiedDlg.cpp:299 src/SearchListCtrl.cpp:117
+#: src/PrefsUnifiedDlg.cpp:301 src/SearchListCtrl.cpp:117
 msgid "Directories"
 msgstr "Directorios"
 
-#: src/PrefsUnifiedDlg.cpp:300 src/Statistics.cpp:917
+#: src/PrefsUnifiedDlg.cpp:302 src/Statistics.cpp:917
 msgid "Servers"
 msgstr "Servidores"
 
-#: src/PrefsUnifiedDlg.cpp:301 src/ServerListCtrl.cpp:96
+#: src/PrefsUnifiedDlg.cpp:303 src/ServerListCtrl.cpp:96
 msgid "Files"
 msgstr "Archivos"
 
-#: src/PrefsUnifiedDlg.cpp:302
+#: src/PrefsUnifiedDlg.cpp:304
 msgid "Security"
 msgstr "Seguridad"
 
-#: src/PrefsUnifiedDlg.cpp:303
+#: src/PrefsUnifiedDlg.cpp:305
 msgid "Interface"
 msgstr "Interfaz"
 
-#: src/PrefsUnifiedDlg.cpp:310
+#: src/PrefsUnifiedDlg.cpp:312
 msgid "IP2Country"
 msgstr "IP2Country"
 
-#: src/PrefsUnifiedDlg.cpp:313
+#: src/PrefsUnifiedDlg.cpp:315
 msgid "Proxy"
 msgstr "Proxy"
 
-#: src/PrefsUnifiedDlg.cpp:314
+#: src/PrefsUnifiedDlg.cpp:316
 msgid "Filters"
 msgstr "Filtros"
 
-#: src/PrefsUnifiedDlg.cpp:315
+#: src/PrefsUnifiedDlg.cpp:317
 msgid "Remote Controls"
 msgstr "Controles remotos"
 
-#: src/PrefsUnifiedDlg.cpp:316
+#: src/PrefsUnifiedDlg.cpp:318
 msgid "Online Signature"
 msgstr "Firma digital"
 
-#: src/PrefsUnifiedDlg.cpp:317
+#: src/PrefsUnifiedDlg.cpp:319
 msgid "Advanced"
 msgstr "Avanzado"
 
-#: src/PrefsUnifiedDlg.cpp:318
+#: src/PrefsUnifiedDlg.cpp:320
 msgid "Events"
 msgstr "Eventos"
 
-#: src/PrefsUnifiedDlg.cpp:321
+#: src/PrefsUnifiedDlg.cpp:323
 msgid "Debugging"
 msgstr "Depurando"
 
-#: src/PrefsUnifiedDlg.cpp:451
+#: src/PrefsUnifiedDlg.cpp:453
 msgid ""
 "The following variables will be substituted:\n"
 "    %PARTFILE - full path to the file\n"
@@ -5687,15 +5715,15 @@ msgstr ""
 "    %PARTFILE - ruta completa al archivo\n"
 "    %PARTNAME - nombre del archivo"
 
-#: src/PrefsUnifiedDlg.cpp:472
+#: src/PrefsUnifiedDlg.cpp:474
 msgid "Tray icon support requires libayatana-appindicator3 at compile time."
 msgstr "El icono de la bandeja requiere libayatana-appindicator3 en tiempo de compilación."
 
-#: src/PrefsUnifiedDlg.cpp:488
+#: src/PrefsUnifiedDlg.cpp:490
 msgid "Not available on Wayland: the protocol does not report when a window is minimized, so this option cannot intercept the system minimize button. Workaround: launch aMule with `GDK_BACKEND=x11` to use XWayland instead."
 msgstr "No disponible en Wayland: el protocolo no informa cuando una ventana es minimizada, por lo que esta opción no puede interceptar el botón de minimizar del sistema. Como alternativa: lanzar aMule con `GDK_BACKEND=x11` para usar XWayland."
 
-#: src/PrefsUnifiedDlg.cpp:534
+#: src/PrefsUnifiedDlg.cpp:536
 msgid ""
 "Do not change these setting unless you know\n"
 "what you are doing, otherwise you can easily\n"
@@ -5711,26 +5739,35 @@ msgstr ""
 "aMule funciona bien sin cambiar ninguno de\n"
 "estos parámetros."
 
-#: src/PrefsUnifiedDlg.cpp:645
+#: src/PrefsUnifiedDlg.cpp:647
 #, c-format
 msgid "Failed to connect Cfg to widget with the ID %d and key %s"
 msgstr "Error al conectar configuración con programa, con el ID %d y clave %s"
 
-#: src/PrefsUnifiedDlg.cpp:693
+#: src/PrefsUnifiedDlg.cpp:695
 #, c-format
 msgid "Failed to transfer data from Cfg to Widget with the ID %d and key %s"
 msgstr "Error al transferir datos desde la configuración al programa, con el ID %d y la clave %s"
 
-#: src/PrefsUnifiedDlg.cpp:799
+#: src/PrefsUnifiedDlg.cpp:801
 msgid "The type of proxy you are connecting to"
 msgstr "El tipo de proxy al que se está conectando"
 
-#: src/PrefsUnifiedDlg.cpp:1003
+#: src/PrefsUnifiedDlg.cpp:1020
 #, c-format
 msgid "Failed to transfer data from Widget to Cfg with the ID %d and key %s"
 msgstr "Error al transferir datos desde el programa a la configuración, con el ID %d y la clave %s"
 
 #: src/PrefsUnifiedDlg.cpp:1103
+#, fuzzy
+msgid "No password set."
+msgstr "Contraseña Admin"
+
+#: src/PrefsUnifiedDlg.cpp:1132
+msgid "Guest access needs a password. Type one in the guest password field, or untick Enable guest access."
+msgstr ""
+
+#: src/PrefsUnifiedDlg.cpp:1144
 msgid ""
 "aMule must be restarted to enable these changes:\n"
 "\n"
@@ -5738,39 +5775,39 @@ msgstr ""
 "aMule debe reiniciarse para aplicar los cambios:\n"
 "\n"
 
-#: src/PrefsUnifiedDlg.cpp:1110
+#: src/PrefsUnifiedDlg.cpp:1151
 msgid "- TCP port changed.\n"
 msgstr "- El puerto TCP ha cambiado.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1115
+#: src/PrefsUnifiedDlg.cpp:1156
 msgid "- UDP port changed.\n"
 msgstr "- El puerto UDP ha cambiado.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1120
+#: src/PrefsUnifiedDlg.cpp:1161
 msgid "- Network interface binding changed.\n"
 msgstr "- La interfaz de red vinculada ha cambiado.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1125
+#: src/PrefsUnifiedDlg.cpp:1166
 msgid "- External connect port changed.\n"
 msgstr "- El puerto para la conexión externa ha cambiado.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1129
+#: src/PrefsUnifiedDlg.cpp:1170
 msgid "- External connect acceptance changed.\n"
 msgstr "- La aceptación de conexión externa ha cambiado.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1133
+#: src/PrefsUnifiedDlg.cpp:1174
 msgid "- External connect interface changed.\n"
 msgstr "- La interfaz de conexión externa ha cambiado.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1137
+#: src/PrefsUnifiedDlg.cpp:1178
 msgid "- Protocol obfuscation support changed.\n"
 msgstr "- El soporte de ofuscación de protocolo ha cambiado.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1151
+#: src/PrefsUnifiedDlg.cpp:1193
 msgid "- amuleapi settings changed.\n"
 msgstr "- Ajustes de amuleapi modificados.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1160
+#: src/PrefsUnifiedDlg.cpp:1202
 msgid ""
 "Your Auto-update server list is empty.\n"
 "'Auto-update server list at startup' will be disabled."
@@ -5778,7 +5815,7 @@ msgstr ""
 "Su lista autoactualizable de servidores esta vacía.\n"
 "Se desactivará 'Autoactualizar la lista de servidores al inicio'."
 
-#: src/PrefsUnifiedDlg.cpp:1171
+#: src/PrefsUnifiedDlg.cpp:1213
 msgid ""
 "You have enabled external connections but have not specified a password.\n"
 "External connections cannot be enabled unless a valid password is specified."
@@ -5786,27 +5823,32 @@ msgstr ""
 "Tiene habilitadas las conexiones externas, pero no ha especificado ninguna contraseña.\n"
 "Las conexiones externas no pueden ser habilitadas a menos que especifique una contraseña válida."
 
-#: src/PrefsUnifiedDlg.cpp:1202
+#: src/PrefsUnifiedDlg.cpp:1246
+#, c-format
+msgid "The amuleapi password could not be saved: %s"
+msgstr ""
+
+#: src/PrefsUnifiedDlg.cpp:1276
 msgid "- Language changed.\n"
 msgstr "- Idioma cambiado.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1207
+#: src/PrefsUnifiedDlg.cpp:1281
 msgid "- Temp folder changed.\n"
 msgstr "- Carpeta temporal cambiada.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1212
+#: src/PrefsUnifiedDlg.cpp:1286
 msgid "- ED2K network enabled.\n"
 msgstr "- Red ED2K habilitada.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1245
+#: src/PrefsUnifiedDlg.cpp:1319
 msgid "The shared-file exclusion pattern is not a valid regular expression. The filter has been left disabled."
 msgstr "El patrón de exclusión de archivos compartidos no es una expresión regular válida. El filtro ha quedado deshabilitado."
 
-#: src/PrefsUnifiedDlg.cpp:1247 src/PrefsUnifiedDlg.cpp:1841
+#: src/PrefsUnifiedDlg.cpp:1321 src/PrefsUnifiedDlg.cpp:1921
 msgid "Invalid regular expression"
 msgstr "Expresión regular no válida"
 
-#: src/PrefsUnifiedDlg.cpp:1324
+#: src/PrefsUnifiedDlg.cpp:1398
 msgid ""
 "Both eD2k and Kad network are disabled.\n"
 "You won't be able to connect until you enable at least one of them."
@@ -5814,7 +5856,7 @@ msgstr ""
 "eD2k y Kad están desactivados.\n"
 "No podrá conectarse hasta que active al menos uno de ellos."
 
-#: src/PrefsUnifiedDlg.cpp:1329
+#: src/PrefsUnifiedDlg.cpp:1403
 msgid ""
 "Kad will not start if your UDP port is disabled.\n"
 "Enable UDP port or disable Kad."
@@ -5822,7 +5864,7 @@ msgstr ""
 "Kad no se inicia si el puerto UDP está deshabilitado.\n"
 "Habilite un puerto UDP o deshabilite Kad."
 
-#: src/PrefsUnifiedDlg.cpp:1385
+#: src/PrefsUnifiedDlg.cpp:1459
 msgid ""
 "\n"
 "You MUST restart aMule now.\n"
@@ -5832,68 +5874,68 @@ msgstr ""
 "DEBE reiniciar aMule ahora.\n"
 "Si no reinicia ahora, no se queje si sucede algo malo.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1450
+#: src/PrefsUnifiedDlg.cpp:1524
 msgid "Could not register aMule for autostart at login. The autostart store may be read-only."
 msgstr "No se pudo registrar aMule para arrancar automáticamente al iniciar sesión. El almacén de arranque automático podría ser de sólo lectura."
 
-#: src/PrefsUnifiedDlg.cpp:1452
+#: src/PrefsUnifiedDlg.cpp:1526
 msgid "Could not remove the autostart-at-login entry."
 msgstr "No se pudo eliminar la entrada de arranque automático."
 
-#: src/PrefsUnifiedDlg.cpp:1453
+#: src/PrefsUnifiedDlg.cpp:1527
 msgid "Autostart"
 msgstr "Arranque automático"
 
-#: src/PrefsUnifiedDlg.cpp:1468
+#: src/PrefsUnifiedDlg.cpp:1542
 msgid "Register file type"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1468
+#: src/PrefsUnifiedDlg.cpp:1542
 msgid "Register URL handler"
 msgstr "Registrar manejador de URL"
 
-#: src/PrefsUnifiedDlg.cpp:1476
+#: src/PrefsUnifiedDlg.cpp:1550
 #, c-format
 msgid "aMule only handles eD2k-compatible magnets. If you replace the current magnet handler (%s), BitTorrent magnet links will stop working - aMule cannot download BitTorrent content. Continue?"
 msgstr "aMule sólo maneja magnet:\\\\ compatibles con eD2k. Si reemplazas el manipulador de magnet:\\\\ actual (%s), los enlaces magnet de BitTorrent dejarán de funcionar: aMule no puede descargar contenido BitTorrent. ¿Continuar?"
 
-#: src/PrefsUnifiedDlg.cpp:1481
+#: src/PrefsUnifiedDlg.cpp:1555
 #, fuzzy, c-format
 msgid "Another application currently opens .emulecollection files (%s). Replace it with aMule?"
 msgstr "Otra aplicación es actualmente el controlador predeterminado para estos enlaces (%s). ¿Reemplazarlo por aMule?"
 
-#: src/PrefsUnifiedDlg.cpp:1486
+#: src/PrefsUnifiedDlg.cpp:1560
 #, c-format
 msgid "Another application is currently the default handler for these links (%s). Replace it with aMule?"
 msgstr "Otra aplicación es actualmente el controlador predeterminado para estos enlaces (%s). ¿Reemplazarlo por aMule?"
 
-#: src/PrefsUnifiedDlg.cpp:1511
+#: src/PrefsUnifiedDlg.cpp:1585
 #, fuzzy
 msgid "Could not register aMule for .emulecollection files. The registration store may be read-only."
 msgstr "No se pudo registrar aMule como el manejador de URL. El almacenamiento del registro podría ser de sólo lectura."
 
-#: src/PrefsUnifiedDlg.cpp:1513
+#: src/PrefsUnifiedDlg.cpp:1587
 #, fuzzy
 msgid "Could not remove the file type registration."
 msgstr "No se pudo retirar el manejador URL del registro."
 
-#: src/PrefsUnifiedDlg.cpp:1515
+#: src/PrefsUnifiedDlg.cpp:1589
 msgid "Could not register aMule as the URL handler. The registration store may be read-only."
 msgstr "No se pudo registrar aMule como el manejador de URL. El almacenamiento del registro podría ser de sólo lectura."
 
-#: src/PrefsUnifiedDlg.cpp:1517
+#: src/PrefsUnifiedDlg.cpp:1591
 msgid "Could not remove the URL handler registration."
 msgstr "No se pudo retirar el manejador URL del registro."
 
-#: src/PrefsUnifiedDlg.cpp:1587 src/PrefsUnifiedDlg.cpp:1614
+#: src/PrefsUnifiedDlg.cpp:1661 src/PrefsUnifiedDlg.cpp:1688
 msgid "The web server and aMule API require external connections to be enabled."
 msgstr "El servidor web y el API de aMule requieren que las conexiones externas estén habilitadas."
 
-#: src/PrefsUnifiedDlg.cpp:1597
+#: src/PrefsUnifiedDlg.cpp:1671
 msgid "The aMule web server is deprecated. Consider running the aMule API instead."
 msgstr "El servidor web aMule está obsoleto. Considere usar el API de aMule en su lugar."
 
-#: src/PrefsUnifiedDlg.cpp:1655
+#: src/PrefsUnifiedDlg.cpp:1735
 msgid ""
 "Your Auto-update servers list is in blank.\n"
 "Please fill in at least one URL to point to a valid server.met file.\n"
@@ -5903,64 +5945,64 @@ msgstr ""
 "Por favor, introduzca al menos un URL que apunte a un archivo server.met válido.\n"
 "Haga clic en el botón \"Lista\" junto a esta casilla para introducir un URL."
 
-#: src/PrefsUnifiedDlg.cpp:1796
+#: src/PrefsUnifiedDlg.cpp:1876
 msgid "Temporary files"
 msgstr "Archivos temporales"
 
-#: src/PrefsUnifiedDlg.cpp:1801
+#: src/PrefsUnifiedDlg.cpp:1881
 msgid "Incoming files"
 msgstr "Archivos entrantes"
 
-#: src/PrefsUnifiedDlg.cpp:1806
+#: src/PrefsUnifiedDlg.cpp:1886
 msgid "Online Signatures"
 msgstr "Firmas digitales"
 
-#: src/PrefsUnifiedDlg.cpp:1819
+#: src/PrefsUnifiedDlg.cpp:1899
 #, c-format
 msgid "Choose a folder for %s"
 msgstr "Elija una carpeta para %s"
 
-#: src/PrefsUnifiedDlg.cpp:1843
+#: src/PrefsUnifiedDlg.cpp:1923
 #, c-format
 msgid "Would exclude %u of %u shared file"
 msgid_plural "Would exclude %u of %u shared files"
 msgstr[0] "Excluiría %u de %u archivo compartido"
 msgstr[1] "Excluiría %u de %u archivos compartidos"
 
-#: src/PrefsUnifiedDlg.cpp:1860
+#: src/PrefsUnifiedDlg.cpp:1940
 msgid "Browse for videoplayer"
 msgstr "Buscar un reproductor de vídeo"
 
-#: src/PrefsUnifiedDlg.cpp:1864
+#: src/PrefsUnifiedDlg.cpp:1944
 msgid "Select browser"
 msgstr "Seleccione el navegador"
 
-#: src/PrefsUnifiedDlg.cpp:1868
+#: src/PrefsUnifiedDlg.cpp:1948
 msgid "Select ffprobe binary"
 msgstr "Seleccione el binario ffprobe"
 
-#: src/PrefsUnifiedDlg.cpp:1874
+#: src/PrefsUnifiedDlg.cpp:1954
 #, c-format
 msgid "Executable%s"
 msgstr "Ejecutable %s"
 
-#: src/PrefsUnifiedDlg.cpp:1908
+#: src/PrefsUnifiedDlg.cpp:1988
 msgid "ffprobe not found on PATH or in the standard install locations. Install ffmpeg (which ships ffprobe) or use Browse to pick a binary manually."
 msgstr "ffprobe no se encuentra en la ruta PATH o en las ubicaciones estándar de instalación. Instala ffmpeg (el cual provee ffprobe) o utiliza Examinar para elegir un binario manualmente."
 
-#: src/PrefsUnifiedDlg.cpp:1920
+#: src/PrefsUnifiedDlg.cpp:2000
 msgid "Reset the settings on this page to their default values?"
 msgstr "¿Desea restablecer los ajustes de esta página a sus valores por defecto?"
 
-#: src/PrefsUnifiedDlg.cpp:1921
+#: src/PrefsUnifiedDlg.cpp:2001
 msgid "Reset to defaults"
 msgstr "Restablecer a valores por defecto"
 
-#: src/PrefsUnifiedDlg.cpp:1948
+#: src/PrefsUnifiedDlg.cpp:2028
 msgid "Edit server list"
 msgstr "Editar la lista de servidores"
 
-#: src/PrefsUnifiedDlg.cpp:1949
+#: src/PrefsUnifiedDlg.cpp:2029
 msgid ""
 "Add here URL's to download server.met files.\n"
 "Only one url on each line."
@@ -5968,114 +6010,114 @@ msgstr ""
 "Añada aquí los URL para descargar los archivos server.met.\n"
 "Sólo un URL por línea."
 
-#: src/PrefsUnifiedDlg.cpp:2004
+#: src/PrefsUnifiedDlg.cpp:2084
 msgid "IP2Country update failed"
 msgstr "Error al actualizar IP2Country"
 
-#: src/PrefsUnifiedDlg.cpp:2149 src/PrefsUnifiedDlg.cpp:2180
+#: src/PrefsUnifiedDlg.cpp:2229 src/PrefsUnifiedDlg.cpp:2260
 msgid "Data by MaxMind GeoLite2"
 msgstr "Datos de MaxMind GeoLite2"
 
-#: src/PrefsUnifiedDlg.cpp:2151 src/PrefsUnifiedDlg.cpp:2182
+#: src/PrefsUnifiedDlg.cpp:2231 src/PrefsUnifiedDlg.cpp:2262
 msgid "Custom source"
 msgstr "Fuente personalizada"
 
-#: src/PrefsUnifiedDlg.cpp:2153 src/PrefsUnifiedDlg.cpp:2184
+#: src/PrefsUnifiedDlg.cpp:2233 src/PrefsUnifiedDlg.cpp:2264
 msgid "Data by DB-IP.com"
 msgstr "Datos de DB-IP.com"
 
-#: src/PrefsUnifiedDlg.cpp:2204
+#: src/PrefsUnifiedDlg.cpp:2284
 #, c-format
 msgid "Status: Loaded%s"
 msgstr "Estado: Cargado%s"
 
-#: src/PrefsUnifiedDlg.cpp:2206
+#: src/PrefsUnifiedDlg.cpp:2286
 #, c-format
 msgid "Status: Loaded%s - %s"
 msgstr "Estado: Cargado%s -%s"
 
-#: src/PrefsUnifiedDlg.cpp:2210
+#: src/PrefsUnifiedDlg.cpp:2290
 msgid "Status: Failed to load - click 'Update now' to refresh."
 msgstr "Estado: No se ha podido cargar. Haz clic en 'Actualizar ahora' para refrescar."
 
-#: src/PrefsUnifiedDlg.cpp:2212
+#: src/PrefsUnifiedDlg.cpp:2292
 msgid "Status: Not found - click 'Update now' to download."
 msgstr "Estado: No encontrado. Haz clic en 'Actualizar ahora' para descargarlo."
 
-#: src/PrefsUnifiedDlg.cpp:2270 src/PrefsUnifiedDlg.cpp:2294
+#: src/PrefsUnifiedDlg.cpp:2350 src/PrefsUnifiedDlg.cpp:2374
 #, c-format
 msgid "Update delay: %d second"
 msgid_plural "Update delay: %d seconds"
 msgstr[0] "Intervalo de actualización: %d segundo"
 msgstr[1] "Intervalo de actualización: %d segundos"
 
-#: src/PrefsUnifiedDlg.cpp:2278
+#: src/PrefsUnifiedDlg.cpp:2358
 #, c-format
 msgid "Time for average graph: %d minute"
 msgid_plural "Time for average graph: %d minutes"
 msgstr[0] "Tiempo medio del gráfico: %d minuto"
 msgstr[1] "Tiempo medio del gráfico: %d minutos"
 
-#: src/PrefsUnifiedDlg.cpp:2287
+#: src/PrefsUnifiedDlg.cpp:2367
 #, c-format
 msgid "Connections Graph Scale: %d"
 msgstr "Escala gráfica de conexiones: %d"
 
-#: src/PrefsUnifiedDlg.cpp:2302
+#: src/PrefsUnifiedDlg.cpp:2382
 #, c-format
 msgid "File Buffer Size: %d byte"
 msgid_plural "File Buffer Size: %d bytes"
 msgstr[0] "Tamaño del búfer de archivo: %d byte"
 msgstr[1] "Tamaño del búfer de archivo: %d bytes"
 
-#: src/PrefsUnifiedDlg.cpp:2312
+#: src/PrefsUnifiedDlg.cpp:2392
 #, c-format
 msgid "Upload Queue Size: %d client"
 msgid_plural "Upload Queue Size: %d clients"
 msgstr[0] "Tamaño de la cola de subida: %d cliente"
 msgstr[1] "Tamaño de la cola de subida: %d clientes"
 
-#: src/PrefsUnifiedDlg.cpp:2322
+#: src/PrefsUnifiedDlg.cpp:2402
 #, c-format
 msgid "Server connection refresh interval: %d minute"
 msgid_plural "Server connection refresh interval: %d minutes"
 msgstr[0] "Intervalo de actualización de la conexión al servidor: %d minuto"
 msgstr[1] "Intervalo de actualización de la conexión al servidor: %d minutos"
 
-#: src/PrefsUnifiedDlg.cpp:2327
+#: src/PrefsUnifiedDlg.cpp:2407
 msgid "Server connection refresh interval: Disabled"
 msgstr "Intervalo de actualización de la conexión al servidor: deshabilitado"
 
-#: src/PrefsUnifiedDlg.cpp:2371
+#: src/PrefsUnifiedDlg.cpp:2451
 msgid "disabled"
 msgstr "deshabilitado"
 
-#: src/PrefsUnifiedDlg.cpp:2397
+#: src/PrefsUnifiedDlg.cpp:2477
 #, c-format
 msgid "Execute command on '%s' event"
 msgstr "Ejecutar comando en el evento '%s'"
 
-#: src/PrefsUnifiedDlg.cpp:2404
+#: src/PrefsUnifiedDlg.cpp:2484
 msgid "Enable command execution on core"
 msgstr "Habilitar la ejecución de comandos en el núcleo"
 
-#: src/PrefsUnifiedDlg.cpp:2416
+#: src/PrefsUnifiedDlg.cpp:2496
 msgid "Core command:"
 msgstr "Comando del núcleo:"
 
-#: src/PrefsUnifiedDlg.cpp:2432
+#: src/PrefsUnifiedDlg.cpp:2512
 msgid "Enable command execution on GUI"
 msgstr "Habilitar la ejecución de comandos en la interfaz"
 
-#: src/PrefsUnifiedDlg.cpp:2444
+#: src/PrefsUnifiedDlg.cpp:2524
 msgid "GUI command:"
 msgstr "Comando de la interfaz:"
 
-#: src/PrefsUnifiedDlg.cpp:2460
+#: src/PrefsUnifiedDlg.cpp:2540
 msgid "The following variables will be replaced:"
 msgstr "Las siguientes variables serán sustituidas:"
 
-#: src/PrefsUnifiedDlg.cpp:2628
+#: src/PrefsUnifiedDlg.cpp:2708
 msgid ""
 "The following folders look like system or sensitive locations:\n"
 "\n"
@@ -6083,37 +6125,37 @@ msgstr ""
 "Estas carpetas parecen ubicaciones sensibles o de sistema:\n"
 "\n"
 
-#: src/PrefsUnifiedDlg.cpp:2633
+#: src/PrefsUnifiedDlg.cpp:2713
 msgid "Sharing them recursively will publish every file underneath on the eD2k/Kad networks. Do you really want to do this?"
 msgstr "Compartirlas recursivamente publicará todos los archivos en las redes eD2k/Kad. ¿Realmente quiere hacerlo?"
 
-#: src/PrefsUnifiedDlg.cpp:2636
+#: src/PrefsUnifiedDlg.cpp:2716
 msgid "Confirm shared folders"
 msgstr "Confirmar carpetas compartidas"
 
-#: src/PrefsUnifiedDlg.cpp:2664
+#: src/PrefsUnifiedDlg.cpp:2744
 msgid "Reloading shared files..."
 msgstr "Recargando los archivos compartidos..."
 
-#: src/PrefsUnifiedDlg.cpp:2665
+#: src/PrefsUnifiedDlg.cpp:2745
 msgid "Scanning for subdirectories..."
 msgstr "Escaneando por subcarpetas..."
 
-#: src/PrefsUnifiedDlg.cpp:2666
+#: src/PrefsUnifiedDlg.cpp:2746
 msgid "Updating shared folders"
 msgstr "Actualizando carpetas compartidas"
 
-#: src/PrefsUnifiedDlg.cpp:2693
+#: src/PrefsUnifiedDlg.cpp:2773
 #, c-format
 msgid "Scanned %u directories..."
 msgstr "Escaneadas %u carpetas..."
 
-#: src/PrefsUnifiedDlg.cpp:2743
+#: src/PrefsUnifiedDlg.cpp:2823
 #, c-format
 msgid "Reloading shared files: %u files scanned"
 msgstr "Recargando archivos compartidos: %u archivos escaneados"
 
-#: src/PrefsUnifiedDlg.cpp:2793
+#: src/PrefsUnifiedDlg.cpp:2873
 msgid "Shared folder"
 msgstr "Carpeta compartida"
 

--- a/po/es.po
+++ b/po/es.po
@@ -15,8 +15,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-28 12:12+0200\n"
-"PO-Revision-Date: 2026-07-27 10:19+0000\n"
+"POT-Creation-Date: 2026-07-28 08:06+0200\n"
+"PO-Revision-Date: 2026-07-27 11:36+0000\n"
 "Last-Translator: Diego Heras <ngosang@hotmail.es>\n"
 "Language-Team: Spanish <https://hosted.weblate.org/projects/amule/amule-application/es/>\n"
 "Language: es\n"
@@ -152,7 +152,7 @@ msgstr "Instalar"
 msgid "Not now"
 msgstr "Ahora no"
 
-#: src/AppImageIntegration.cpp:422 src/amuleDlg.cpp:665
+#: src/AppImageIntegration.cpp:422 src/amuleDlg.cpp:600
 msgid "Don't ask again"
 msgstr "No volver a preguntar"
 
@@ -214,83 +214,83 @@ msgstr "Error al abrir el archivo de enlaces ED2K."
 msgid "WARNING: You can't add yourself as a source for an eD2k link while having a lowid."
 msgstr "AVISO: no puede añadirse a sí mismo como fuente para un enlace eD2k teniendo Id Baja."
 
-#: src/amule.cpp:301
+#: src/amule.cpp:300
 msgid "Now, exiting main app..."
 msgstr "Ahora, saliendo de la aplicación principal..."
 
-#: src/amule.cpp:331
+#: src/amule.cpp:330
 #, c-format
 msgid "Terminating amuleweb instance with pid '%d' ... "
 msgstr "Cerrando la instancia de amuleweb con pid '%d'... "
 
-#: src/amule.cpp:335
+#: src/amule.cpp:334
 #, c-format
 msgid "Killing amuleweb instance with pid '%d' ... "
 msgstr "Matando la instancia de amuleweb con pid '%d'... "
 
-#: src/amule.cpp:337 src/amule.cpp:350 src/ClientRef.cpp:180
-#: src/SearchDlg.cpp:1041 src/ServerListCtrl.cpp:98
+#: src/amule.cpp:336 src/amule.cpp:349 src/ClientRef.cpp:180
+#: src/SearchDlg.cpp:880 src/ServerListCtrl.cpp:98
 msgid "Failed"
 msgstr "Falló"
 
-#: src/amule.cpp:344
+#: src/amule.cpp:343
 #, c-format
 msgid "Terminating amuleapi instance with pid '%d' ... "
 msgstr "Cerrando la instancia de amuleapi con pid '%d'... "
 
-#: src/amule.cpp:348
+#: src/amule.cpp:347
 #, c-format
 msgid "Killing amuleapi instance with pid '%d' ... "
 msgstr "Matando la instancia de amuleapi con pid '%d'... "
 
-#: src/amule.cpp:356
+#: src/amule.cpp:355
 msgid "aMule OnExit: Terminating core."
 msgstr "aMule OnExit: terminando el núcleo."
 
-#: src/amule.cpp:467
+#: src/amule.cpp:466
 msgid "aMule shutdown completed."
 msgstr "Cierre de aMule completado."
 
-#: src/amule.cpp:471
+#: src/amule.cpp:470
 msgid "Memory debug results for aMule exit:"
 msgstr "Resultados de depuración de memoria en la salida de aMule:"
 
-#: src/amule.cpp:652
+#: src/amule.cpp:651
 #, c-format
 msgid "Binding aMule's peer-to-peer traffic to interface: %s (HTTP updates use the default route)"
 msgstr "Vinculando el tráfico P2P de aMule a la interfaz: %s (las actualizaciones HTTP usan la ruta predeterminada)"
 
-#: src/amule.cpp:656
+#: src/amule.cpp:655
 #, c-format
 msgid "Binding all network traffic to interface: %s"
 msgstr "Vinculando todo el tráfico de red a la interfaz: %s"
 
-#: src/amule.cpp:660
+#: src/amule.cpp:659
 #, c-format
 msgid "WARNING: configured network interface '%s' was not found - traffic is NOT bound to it and may leave via the default route. Check the interface name in Preferences."
 msgstr "ADVERTENCIA: la interfaz de red configurada '%s' no se encontró; el tráfico NO está vinculado a ella y puede salir por la ruta predeterminada. Compruebe el nombre de la interfaz en Preferencias."
 
-#: src/amule.cpp:666
+#: src/amule.cpp:665
 #, c-format
 msgid "WARNING: binding to network interface '%s' requires elevated privileges and was NOT applied - traffic may leave via the default route. Grant the capability (e.g. 'sudo setcap cap_net_raw+ep' on the aMule binary) or run with sufficient privileges."
 msgstr "ADVERTENCIA: vincularse a la interfaz de red '%s' requiere privilegios elevados y NO se aplicó; el tráfico puede salir por la ruta predeterminada. Conceda la capacidad (por ejemplo, \"sudo setcap capnetraw+ep\" al binario de aMule) o ejecute con privilegios suficientes."
 
-#: src/amule.cpp:674
+#: src/amule.cpp:673
 #, c-format
 msgid "WARNING: could not bind to network interface '%s' - traffic may leave via the default route."
 msgstr "ADVERTENCIA: no se pudo vincular a la interfaz de red '%s'; el tráfico puede salir por la ruta predeterminada."
 
-#: src/amule.cpp:733
+#: src/amule.cpp:732
 msgid "Your locale has been changed to System Default due to a configuration change. Sorry."
 msgstr "Su configuración regional se ha cambiado a la predefinida del sistema debido a un cambio en la configuración. Disculpe."
 
-#: src/amule.cpp:735 src/amule.cpp:1589 src/CatDialog.cpp:128
+#: src/amule.cpp:734 src/amule.cpp:1581 src/CatDialog.cpp:128
 #: src/CatDialog.cpp:136 src/CatDialog.cpp:149 src/ServerList.cpp:366
 #: src/ServerListCtrl.cpp:152
 msgid "Info"
 msgstr "Información"
 
-#: src/amule.cpp:742
+#: src/amule.cpp:741
 msgid ""
 "\n"
 "EC configuration"
@@ -298,20 +298,20 @@ msgstr ""
 "\n"
 "Configuración de la EC"
 
-#: src/amule.cpp:745
+#: src/amule.cpp:744
 msgid "Password set and external connections enabled."
 msgstr "Contraseña fijada y conexiones externas habilitadas."
 
-#: src/amule.cpp:755 src/KadDlg.cpp:176 src/KadDlg.cpp:185
-#: src/PrefsUnifiedDlg.cpp:1461 src/SharedFilesCtrl.cpp:476
+#: src/amule.cpp:754 src/KadDlg.cpp:176 src/KadDlg.cpp:185
+#: src/PrefsUnifiedDlg.cpp:1387 src/SharedFilesCtrl.cpp:476
 msgid "WARNING"
 msgstr "AVISO"
 
-#: src/amule.cpp:992
+#: src/amule.cpp:991
 msgid "Network bootstrap"
 msgstr "Bootstrap de red"
 
-#: src/amule.cpp:997
+#: src/amule.cpp:996
 msgid ""
 "aMule has detected missing network bootstrap files.\n"
 "Select which ones to download:"
@@ -319,51 +319,51 @@ msgstr ""
 "aMule ha detectado archivos de bootstrap de red faltantes.\n"
 "Seleccione cuáles descargar:"
 
-#: src/amule.cpp:1006 src/FirstRunWizard.cpp:411
+#: src/amule.cpp:1005 src/FirstRunWizard.cpp:411
 msgid "eD2k server list (server.met)"
 msgstr "Lista de servidores eD2k (server.met)"
 
-#: src/amule.cpp:1013 src/FirstRunWizard.cpp:416
+#: src/amule.cpp:1012 src/FirstRunWizard.cpp:416
 msgid "Kad bootstrap nodes (nodes.dat)"
 msgstr "Nodos de bootstrap Kad (nodes.dat)"
 
-#: src/amule.cpp:1103
+#: src/amule.cpp:1102
 #, c-format
 msgid "web server running on pid %d"
 msgstr "servidor web corriendo con pid: %d"
 
-#: src/amule.cpp:1116
+#: src/amule.cpp:1115
 msgid "You requested to run web server on startup, but the amuleweb binary cannot be run. Please install the package containing aMule web server, or build aMule from source with -DBUILD_WEBSERVER=YES and install it."
 msgstr "Ha solicitado ejecutar el servidor web al inicio pero no se puede ejecutar el binario amuleweb. Por favor, instale el paquete que contiene el servidor web de aMule, o compile aMule desde el código fuente con -DBUILD_WEBSERVER=YES e instálelo."
 
-#: src/amule.cpp:1121 src/amule.cpp:1185 src/amule.cpp:1299 src/amule.cpp:1601
+#: src/amule.cpp:1120 src/amule.cpp:1177 src/amule.cpp:1291 src/amule.cpp:1593
 #: src/amule-remote-gui.cpp:603 src/amule-remote-gui.cpp:671
 #: src/amule-remote-gui.cpp:709 src/amule-remote-gui.cpp:1282
 #: src/amule-remote-gui.cpp:1345 src/amule-remote-gui.cpp:1372
-#: src/DownloadQueue.cpp:1481 src/PrefsUnifiedDlg.cpp:1247
+#: src/DownloadQueue.cpp:1481
 msgid "ERROR"
 msgstr "ERROR"
 
-#: src/amule.cpp:1174
+#: src/amule.cpp:1166
 #, c-format
 msgid "amuleapi running on pid %d"
 msgstr "amuleapi corriendo con pid %d"
 
-#: src/amule.cpp:1180
+#: src/amule.cpp:1172
 msgid "You requested to run amuleapi on startup, but the amuleapi binary cannot be run. Please install the package containing aMule's REST API server, or build aMule from source with -DBUILD_AMULEAPI=YES and install it."
 msgstr "Ha solicitado ejecutar amuleapi al inicio pero no se puede ejecutar el binario amuleapi. Por favor, instale el paquete que contiene el servidor API REST de aMule, o compile aMule desde el código fuente con -DBUILD_AMULEAPI=YES e instálelo."
 
-#: src/amule.cpp:1267
+#: src/amule.cpp:1259
 #, c-format
 msgid "Could not bind ports to the specified address: %s"
 msgstr "No se pueden asociar los puertos con la dirección especificada: %s"
 
-#: src/amule.cpp:1291
+#: src/amule.cpp:1283
 #, c-format
 msgid "Port %u is not available. You will be LOWID\n"
 msgstr "El puerto %u no está disponible. Tendrás Id Baja\n"
 
-#: src/amule.cpp:1296
+#: src/amule.cpp:1288
 #, c-format
 msgid ""
 "Port %u is not available!\n"
@@ -378,48 +378,48 @@ msgstr ""
 "\n"
 "Comprueba la red y asegúrate de que el puerto está abierto para salida y entrada."
 
-#: src/amule.cpp:1393
+#: src/amule.cpp:1385
 msgid "Failed to create OnlineSig File"
 msgstr "Error al crear el archivo de firma online"
 
-#: src/amule.cpp:1401
+#: src/amule.cpp:1393
 msgid "Failed to create aMule OnlineSig File"
 msgstr "Error al crear el archivo de firma online de aMule"
 
-#: src/amule.cpp:1564
+#: src/amule.cpp:1556
 msgid "The selected locale seems not to be installed on your box. (Note: I'll try to set it anyway)"
 msgstr "El idioma seleccionado no parece estar instalado en tu sistema. (Nota: intentaré configurarlo de todos modos)"
 
-#: src/amule.cpp:1574
+#: src/amule.cpp:1566
 #, c-format
 msgid "This is the first time you run aMule %s"
 msgstr "Es la primera vez que inicias aMule %s"
 
-#: src/amule.cpp:1577
+#: src/amule.cpp:1569
 msgid "This version is a testing version, updated daily, and\n"
 msgstr "Esta es una versión de prueba, actualizada diariamente, y\n"
 
-#: src/amule.cpp:1578
+#: src/amule.cpp:1570
 msgid "we give no warranty it won't break anything, burn your house,\n"
 msgstr "no garantizamos que no rompa nada, no queme su casa,\n"
 
-#: src/amule.cpp:1579
+#: src/amule.cpp:1571
 msgid "or kill your dog. But it *should* be safe to use anyway.\n"
 msgstr "o no mate a su perro. Pero *debería* ser seguro usarla de todas formas.\n"
 
-#: src/amule.cpp:1584
+#: src/amule.cpp:1576
 msgid "More information, support and new releases can found at our homepage,\n"
 msgstr "En nuestra web podrá encontrar más información, soporte y nuevas versiones,\n"
 
-#: src/amule.cpp:1585
+#: src/amule.cpp:1577
 msgid "at https://amule-org.github.io, or in our IRC channel #aMule at irc.libera.chat.\n"
 msgstr "en https://amule-org.github.io, o en nuestro canal de IRC #aMule en irc.libera.chat.\n"
 
-#: src/amule.cpp:1587
+#: src/amule.cpp:1579
 msgid "Feel free to report any bugs to https://github.com/amule-org/amule/issues"
 msgstr "Envíenos cualquier fallo a https://github.com/amule-org/amule/issues"
 
-#: src/amule.cpp:1599
+#: src/amule.cpp:1591
 msgid ""
 "The folder for Online Signature files you specified is INVALID!\n"
 " OnlineSignature will be DISABLED until you fix it on preferences."
@@ -427,137 +427,137 @@ msgstr ""
 "¡El directorio que ha especificado para archivos de firma digital no es válido!\n"
 "La firma digital se ha deshabilitado hasta que lo arregle en las preferencias."
 
-#: src/amule.cpp:1662
+#: src/amule.cpp:1654
 msgid "Server hostname notified"
 msgstr "Nombre de servidor notificado"
 
-#: src/amule.cpp:2039
+#: src/amule.cpp:2031
 #, c-format
 msgid "Disk space preallocation for file '%s' failed: %s"
 msgstr "La reserva del espacio en disco para el archivo '%s' ha fallado: %s"
 
-#: src/amule.cpp:2168
+#: src/amule.cpp:2160
 msgid "ERROR: can't open logfile"
 msgstr "ERROR: no se puede abrir el archivo de registro"
 
-#: src/amule.cpp:2172
+#: src/amule.cpp:2164
 msgid "WARNING: logfile is empty. Something is wrong."
 msgstr "AVISO: el archivo de registro está vacío. Algo está mal."
 
-#: src/amule.cpp:2189
+#: src/amule.cpp:2181
 msgid "Log has been reset"
 msgstr "El registro se ha borrado"
 
-#: src/amule.cpp:2213
+#: src/amule.cpp:2205
 #, c-format
 msgid "ServerMessage: %s"
 msgstr "Mensaje del servidor: %s"
 
-#: src/amule.cpp:2256 src/IP2Country.cpp:220 src/IPFilter.cpp:514
+#: src/amule.cpp:2248 src/IP2Country.cpp:220 src/IPFilter.cpp:514
 #: src/ServerList.cpp:875
 #, c-format
 msgid "Skipped download of %s, because requested file is not newer."
 msgstr "Se ha descartado la descarga de %s, porque el archivo solicitado no es más nuevo."
 
-#: src/amule.cpp:2259
+#: src/amule.cpp:2251
 msgid "Failed to download the nodes list."
 msgstr "Error al descargar la lista de nodos."
 
-#: src/amule.cpp:2322
+#: src/amule.cpp:2314
 msgid "Failed to open the downloaded version check file"
 msgstr "Error al abrir el archivo de comprobación de versión descargado"
 
-#: src/amule.cpp:2325 src/amule.cpp:2344
+#: src/amule.cpp:2317 src/amule.cpp:2336
 msgid "Corrupted version check file"
 msgstr "Archivo de comprobación de versión dañado"
 
-#: src/amule.cpp:2367
+#: src/amule.cpp:2359
 msgid "You are using an outdated version of aMule!"
 msgstr "¡Estás usando una versión desactualizada de aMule!"
 
-#: src/amule.cpp:2369
+#: src/amule.cpp:2361
 #, c-format
 msgid "Your aMule version is %i.%i.%i and the latest version is %li.%li.%li"
 msgstr "Su versión de aMule es %i.%i.%i y la última versión es %li.%li.%li"
 
-#: src/amule.cpp:2373
+#: src/amule.cpp:2365
 msgid "The latest version can always be found at https://github.com/amule-org/amule/releases/latest"
 msgstr "La última versión siempre se puede encontrar en https://github.com/amule-org/amule/releases/latest"
 
-#: src/amule.cpp:2376
+#: src/amule.cpp:2368
 #, c-format
 msgid "WARNING: Your aMuled version is outdated: %i.%i.%i < %li.%li.%li"
 msgstr "AVISO: su versión de aMuled está desactualizada: %i.%i.%i < %li.%li.%li"
 
-#: src/amule.cpp:2382
+#: src/amule.cpp:2374
 msgid "Your copy of aMule is up to date."
 msgstr "Su copia de aMule está actualizada."
 
-#: src/amule.cpp:2389
+#: src/amule.cpp:2381
 msgid "Failed to download the version check file"
 msgstr "Error al descargar el archivo de comprobación de la versión"
 
-#: src/amule.cpp:2558 src/amule-remote-gui.cpp:1133
+#: src/amule.cpp:2550 src/amule-remote-gui.cpp:1133
 #, c-format
 msgid "Users: %s | Files: %s"
 msgstr "Usuarios: %s | Archivos: %s"
 
-#: src/amule.cpp:2559 src/amule-remote-gui.cpp:1134
+#: src/amule.cpp:2551 src/amule-remote-gui.cpp:1134
 #, c-format
 msgid "Users: E: %s K: %s | Files: E: %s K: %s"
 msgstr "Usuarios: E: %s K: %s | Archivos: E: %s K: %s"
 
-#: src/amule.cpp:2573 src/amule-remote-gui.cpp:1147
+#: src/amule.cpp:2565 src/amule-remote-gui.cpp:1147
 msgid "No networks selected"
 msgstr "No hay redes seleccionadas"
 
-#: src/amule.cpp:2641 src/TextClient.cpp:903
+#: src/amule.cpp:2633 src/TextClient.cpp:903
 msgid "with LowID"
 msgstr "con Id Baja"
 
-#: src/amule.cpp:2641 src/TextClient.cpp:904
+#: src/amule.cpp:2633 src/TextClient.cpp:904
 msgid "with HighID"
 msgstr "con Id Alta"
 
-#: src/amule.cpp:2643
+#: src/amule.cpp:2635
 #, c-format
 msgid "Connected to %s %s"
 msgstr "Conectado a %s %s"
 
-#: src/amule.cpp:2648
+#: src/amule.cpp:2640
 #, c-format
 msgid "Connecting to %s"
 msgstr "Conectando a %s"
 
-#: src/amule.cpp:2650
+#: src/amule.cpp:2642
 msgid "Disconnected from eD2k"
 msgstr "Desconectado de eD2k"
 
-#: src/amule.cpp:2659
+#: src/amule.cpp:2651
 msgid "Kad started."
 msgstr "Kad iniciado."
 
-#: src/amule.cpp:2661
+#: src/amule.cpp:2653
 msgid "Kad stopped."
 msgstr "Kad detenido."
 
-#: src/amule.cpp:2669
+#: src/amule.cpp:2661
 msgid "Connected to Kad (ok)"
 msgstr "Conectado a Kad (correcto)"
 
-#: src/amule.cpp:2671
+#: src/amule.cpp:2663
 msgid "Connected to Kad (firewalled)"
 msgstr "Conectado a Kad (tras cortafuegos)"
 
-#: src/amule.cpp:2675
+#: src/amule.cpp:2667
 msgid "Disconnected from Kad"
 msgstr "Desconectado de Kad"
 
-#: src/amule.cpp:2707
+#: src/amule.cpp:2699
 msgid "Kad network cannot be used if UDP port is disabled on preferences, not starting."
 msgstr "La red Kad no se puede usar si el puerto UDP está deshabilitado en las preferencias, no se inicia."
 
-#: src/amule.cpp:2711
+#: src/amule.cpp:2703
 msgid "Kad network disabled on preferences, not connecting."
 msgstr "Red Kad deshabilitada en las preferencias, no se conecta."
 
@@ -582,67 +582,29 @@ msgstr "No se puede crear el archivo Pid"
 msgid "ERROR: %s"
 msgstr "ERROR: %s"
 
-#: src/amuleDlg.cpp:250
+#: src/amuleDlg.cpp:236
 #, c-format
 msgid "This is aMule %s based on eMule."
 msgstr "Esto es aMule %s basado en eMule."
 
-#: src/amuleDlg.cpp:251
+#: src/amuleDlg.cpp:237
 #, c-format
 msgid "Running on %s"
 msgstr "Ejecutándose en %s"
 
-#: src/amuleDlg.cpp:253
+#: src/amuleDlg.cpp:239
 msgid "Visit https://github.com/amule-org/amule/releases/latest to check if a new version is available."
 msgstr "Visite https://github.com/amule-org/amule/releases/latest para comprobar si hay una nueva versión disponible."
 
-#: src/amuleDlg.cpp:282
+#: src/amuleDlg.cpp:268
 msgid "FATAL ERROR: Failed to create Timer"
 msgstr "ERROR FATAL: no se ha podido crear el temporizador"
 
-#: src/amuleDlg.cpp:361 src/amuleDlg.cpp:1810 src/amuleDlg.cpp:2056
-#: src/muuli_wdr.cpp:1492 src/muuli_wdr.cpp:3439
-msgid "Networks"
-msgstr "Redes"
-
-#: src/amuleDlg.cpp:362 src/amuleDlg.cpp:1816 src/muuli_wdr.cpp:3440
-msgid "Searches"
-msgstr "Búsquedas"
-
-#: src/amuleDlg.cpp:363 src/amuleDlg.cpp:1822 src/DownloadListCtrl.cpp:740
-#: src/muuli_wdr.cpp:392 src/muuli_wdr.cpp:1585 src/muuli_wdr.cpp:3441
-#: src/Statistics.cpp:829
-msgid "Downloads"
-msgstr "Descargas"
-
-#: src/amuleDlg.cpp:364 src/amuleDlg.cpp:1828 src/muuli_wdr.cpp:3315
-msgid "Shared files"
-msgstr "Compartidos"
-
-#: src/amuleDlg.cpp:365 src/amuleDlg.cpp:1834 src/muuli_wdr.cpp:2947
-#: src/muuli_wdr.cpp:3397 src/muuli_wdr.cpp:3444
-msgid "Messages"
-msgstr "Mensajes"
-
-#: src/amuleDlg.cpp:366 src/amuleDlg.cpp:1840 src/muuli_wdr.cpp:3445
-#: src/PrefsUnifiedDlg.cpp:314 src/Statistics.cpp:779 src/Statistics.cpp:1235
-msgid "Statistics"
-msgstr "Estadísticas"
-
-#: src/amuleDlg.cpp:368 src/amuleDlg.cpp:1847 src/muuli_wdr.cpp:3447
-#: src/PrefsUnifiedDlg.cpp:330 src/utils/wxCas/src/wxcasprefs.cpp:39
-msgid "Preferences"
-msgstr "Preferencias"
-
-#: src/amuleDlg.cpp:371
-msgid "Navigate"
-msgstr ""
-
-#: src/amuleDlg.cpp:657
+#: src/amuleDlg.cpp:592
 msgid "New version available"
 msgstr "Nueva versión disponible"
 
-#: src/amuleDlg.cpp:661
+#: src/amuleDlg.cpp:596
 #, c-format
 msgid ""
 "A new version of aMule (%s) is available.\n"
@@ -657,184 +619,217 @@ msgstr ""
 "\n"
 "¿Le gustaría abrir la página de descarga?"
 
-#: src/amuleDlg.cpp:743
+#: src/amuleDlg.cpp:678
 msgid "aMule dialog destroyed"
 msgstr "Diálogo de aMule destruido"
 
-#: src/amuleDlg.cpp:766 src/DataToText.cpp:68 src/IPFilter.cpp:547
+#: src/amuleDlg.cpp:701 src/DataToText.cpp:68 src/IPFilter.cpp:547
 msgid "Connecting"
 msgstr "Conectando"
 
-#: src/amuleDlg.cpp:958
+#: src/amuleDlg.cpp:893
 msgid "eD2k: Connecting"
 msgstr "eD2k: Conectando"
 
-#: src/amuleDlg.cpp:962
+#: src/amuleDlg.cpp:897
 msgid "eD2k: Disconnected"
 msgstr "eD2k: Desconectado"
 
-#: src/amuleDlg.cpp:968
+#: src/amuleDlg.cpp:903
 msgid "Kad: Firewalled"
 msgstr "Kad: tras cortafuegos"
 
-#: src/amuleDlg.cpp:972
+#: src/amuleDlg.cpp:907
 msgid "Kad: Connected"
 msgstr "Kad: conectado"
 
-#: src/amuleDlg.cpp:977
+#: src/amuleDlg.cpp:912
 msgid "Kad: Connecting"
 msgstr "Kad: conectando"
 
-#: src/amuleDlg.cpp:981
+#: src/amuleDlg.cpp:916
 msgid "Kad: Off"
 msgstr "Kad: apagado"
 
-#: src/amuleDlg.cpp:1029 src/DownloadListCtrl.cpp:505
+#: src/amuleDlg.cpp:964 src/DownloadListCtrl.cpp:505
 #: src/DownloadListCtrl.cpp:749 src/FriendListCtrl.cpp:180
 #: src/muuli_wdr.cpp:731 src/muuli_wdr.cpp:782 src/muuli_wdr.cpp:846
-#: src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2252 src/muuli_wdr.cpp:2337
-#: src/muuli_wdr.cpp:3085 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
+#: src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2224 src/muuli_wdr.cpp:2309
+#: src/muuli_wdr.cpp:3057 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
 #: src/ServerListCtrl.cpp:606 src/TransferWnd.cpp:378
 #: src/utils/wxCas/src/wxcasprefs.cpp:235
 msgid "Cancel"
 msgstr "Cancelar"
 
-#: src/amuleDlg.cpp:1030
+#: src/amuleDlg.cpp:965
 msgid "Stop the current connection attempts"
 msgstr "Detener los intentos de conexión actuales"
 
-#: src/amuleDlg.cpp:1035 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976
-#: src/muuli_wdr.cpp:2475
+#: src/amuleDlg.cpp:970 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976
+#: src/muuli_wdr.cpp:2447
 msgid "Disconnect"
 msgstr "Desconectar"
 
-#: src/amuleDlg.cpp:1036
+#: src/amuleDlg.cpp:971
 msgid "Disconnect from the currently connected networks"
 msgstr "Desconectarse de las redes conectadas"
 
-#: src/amuleDlg.cpp:1041 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979
-#: src/muuli_wdr.cpp:2630 src/muuli_wdr.cpp:3082 src/muuli_wdr.cpp:3437
+#: src/amuleDlg.cpp:976 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979
+#: src/muuli_wdr.cpp:2602 src/muuli_wdr.cpp:3054 src/muuli_wdr.cpp:3409
 msgid "Connect"
 msgstr "Conectar"
 
-#: src/amuleDlg.cpp:1042
+#: src/amuleDlg.cpp:977
 msgid "Connect to the currently enabled networks"
 msgstr "Conectarse a las redes habilitadas"
 
-#: src/amuleDlg.cpp:1154
+#: src/amuleDlg.cpp:1089
 #, c-format
 msgid "Up: %.1f%s (%.1f) | Down: %.1f%s (%.1f)"
 msgstr "Su: %.1f%s (%.1f) | De: %.1f%s (%.1f)"
 
-#: src/amuleDlg.cpp:1156 src/amuleDlg.cpp:1158 src/amuleDlg.cpp:1162
-#: src/amuleDlg.cpp:1164 src/amuleDlg.cpp:1175 src/amuleDlg.cpp:1177
+#: src/amuleDlg.cpp:1091 src/amuleDlg.cpp:1093 src/amuleDlg.cpp:1097
+#: src/amuleDlg.cpp:1099 src/amuleDlg.cpp:1110 src/amuleDlg.cpp:1112
 #: src/MuleTrayIcon.cpp:796 src/MuleTrayIcon.cpp:799
 msgid " MB/s"
 msgstr " MB/s"
 
-#: src/amuleDlg.cpp:1156 src/amuleDlg.cpp:1158 src/amuleDlg.cpp:1162
-#: src/amuleDlg.cpp:1164 src/amuleDlg.cpp:1175 src/amuleDlg.cpp:1177
+#: src/amuleDlg.cpp:1091 src/amuleDlg.cpp:1093 src/amuleDlg.cpp:1097
+#: src/amuleDlg.cpp:1099 src/amuleDlg.cpp:1110 src/amuleDlg.cpp:1112
 #: src/MuleTrayIcon.cpp:796 src/MuleTrayIcon.cpp:799
 #: src/utils/wxCas/src/wxcasframe.cpp:1041
 msgid " kB/s"
 msgstr " kB/s"
 
-#: src/amuleDlg.cpp:1161
+#: src/amuleDlg.cpp:1096
 #, c-format
 msgid "Up: %.1f%s | Down: %.1f%s"
 msgstr "Su: %.1f%s | De: %.1f%s"
 
-#: src/amuleDlg.cpp:1193
+#: src/amuleDlg.cpp:1128
 #, c-format
 msgid "aMule (%s | Connected)"
 msgstr "aMule (%s | Conectado)"
 
-#: src/amuleDlg.cpp:1195
+#: src/amuleDlg.cpp:1130
 #, c-format
 msgid "aMule (%s | Disconnected)"
 msgstr "aMule (%s | Desconectado)"
 
-#: src/amuleDlg.cpp:1248
+#: src/amuleDlg.cpp:1183
 #, c-format
 msgid "Do you really want to exit %s?"
 msgstr "¿Realmente desea cerrar %s?"
 
-#: src/amuleDlg.cpp:1250
+#: src/amuleDlg.cpp:1185
 msgid "Exit confirmation"
 msgstr "Confirmación de salida"
 
-#: src/amuleDlg.cpp:1613
+#: src/amuleDlg.cpp:1548
 msgid "Launch Command: "
 msgstr "Ejecutar comando: "
 
-#: src/amuleDlg.cpp:1632 src/muuli_wdr.cpp:1972 src/Preferences.cpp:979
+#: src/amuleDlg.cpp:1567 src/muuli_wdr.cpp:1971 src/Preferences.cpp:951
 msgid "- default -"
 msgstr "- predeterminado -"
 
-#: src/amuleDlg.cpp:1660
+#: src/amuleDlg.cpp:1595
 #, c-format
 msgid "Skin directory '%s' does not exist"
 msgstr "El directorio de tema '%s' no existe"
 
-#: src/amuleDlg.cpp:1663
+#: src/amuleDlg.cpp:1598
 #, c-format
 msgid "WARNING: Unable to open skin file '%s' for read"
 msgstr "AVISO: no se puede abrir el archivo de tema '%s' para lectura"
 
-#: src/amuleDlg.cpp:1814 src/muuli_wdr.cpp:3439
+#: src/amuleDlg.cpp:1722 src/amuleDlg.cpp:1968 src/muuli_wdr.cpp:1485
+#: src/muuli_wdr.cpp:3411
+msgid "Networks"
+msgstr "Redes"
+
+#: src/amuleDlg.cpp:1726 src/muuli_wdr.cpp:3411
 msgid "Networks Window"
 msgstr "Ventana de redes"
 
-#: src/amuleDlg.cpp:1820 src/muuli_wdr.cpp:3440
+#: src/amuleDlg.cpp:1728 src/muuli_wdr.cpp:3412
+msgid "Searches"
+msgstr "Búsquedas"
+
+#: src/amuleDlg.cpp:1732 src/muuli_wdr.cpp:3412
 msgid "Searches Window"
 msgstr "Ventana de búsquedas"
 
-#: src/amuleDlg.cpp:1826 src/muuli_wdr.cpp:3441
+#: src/amuleDlg.cpp:1734 src/DownloadListCtrl.cpp:740 src/muuli_wdr.cpp:392
+#: src/muuli_wdr.cpp:1578 src/muuli_wdr.cpp:3413 src/Statistics.cpp:829
+msgid "Downloads"
+msgstr "Descargas"
+
+#: src/amuleDlg.cpp:1738 src/muuli_wdr.cpp:3413
 msgid "Downloads Window"
 msgstr "Ventana de descargas"
 
-#: src/amuleDlg.cpp:1832 src/muuli_wdr.cpp:3443
+#: src/amuleDlg.cpp:1740 src/muuli_wdr.cpp:3287
+msgid "Shared files"
+msgstr "Compartidos"
+
+#: src/amuleDlg.cpp:1744 src/muuli_wdr.cpp:3415
 msgid "Shared Files Window"
 msgstr "Ventana de archivos compartidos"
 
-#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3444
+#: src/amuleDlg.cpp:1746 src/muuli_wdr.cpp:2919 src/muuli_wdr.cpp:3369
+#: src/muuli_wdr.cpp:3416
+msgid "Messages"
+msgstr "Mensajes"
+
+#: src/amuleDlg.cpp:1750 src/muuli_wdr.cpp:3416
 msgid "Messages Window"
 msgstr "Ventana de mensajes"
 
-#: src/amuleDlg.cpp:1844 src/muuli_wdr.cpp:3445
+#: src/amuleDlg.cpp:1752 src/muuli_wdr.cpp:3417 src/PrefsUnifiedDlg.cpp:312
+#: src/Statistics.cpp:779 src/Statistics.cpp:1235
+msgid "Statistics"
+msgstr "Estadísticas"
+
+#: src/amuleDlg.cpp:1756 src/muuli_wdr.cpp:3417
 msgid "Statistics Graph Window"
 msgstr "Ventana de gráficos de estadísticas"
 
-#: src/amuleDlg.cpp:1851 src/muuli_wdr.cpp:3447
+#: src/amuleDlg.cpp:1759 src/muuli_wdr.cpp:3419 src/PrefsUnifiedDlg.cpp:328
+#: src/utils/wxCas/src/wxcasprefs.cpp:39
+msgid "Preferences"
+msgstr "Preferencias"
+
+#: src/amuleDlg.cpp:1763 src/muuli_wdr.cpp:3419
 msgid "Preferences Settings Window"
 msgstr "Ventana de preferencias de configuración"
 
-#: src/amuleDlg.cpp:1854 src/muuli_wdr.cpp:3448
+#: src/amuleDlg.cpp:1766 src/muuli_wdr.cpp:3420
 msgid "Import"
 msgstr "Importar"
 
-#: src/amuleDlg.cpp:1858 src/muuli_wdr.cpp:3448
+#: src/amuleDlg.cpp:1770 src/muuli_wdr.cpp:3420
 msgid "The partfile importer tool"
 msgstr "La herramienta para importar archivos de partes"
 
-#: src/amuleDlg.cpp:1861 src/muuli_wdr.cpp:3449
+#: src/amuleDlg.cpp:1773 src/muuli_wdr.cpp:3421
 #: src/utils/aLinkCreator/src/alcframe.cpp:262
 msgid "About"
 msgstr "Acerca de"
 
-#: src/amuleDlg.cpp:1861 src/muuli_wdr.cpp:3449
+#: src/amuleDlg.cpp:1773 src/muuli_wdr.cpp:3421
 msgid "About/Help"
 msgstr "Acerca de/Ayuda"
 
-#: src/amuleDlg.cpp:2059
+#: src/amuleDlg.cpp:1971
 msgid "eD2k network"
 msgstr "Red eD2k"
 
-#: src/amuleDlg.cpp:2062
+#: src/amuleDlg.cpp:1974
 msgid "Kad network"
 msgstr "Red Kad"
 
-#: src/amuleDlg.cpp:2062
+#: src/amuleDlg.cpp:1974
 msgid "No network"
 msgstr "No hay red"
 
@@ -965,7 +960,7 @@ msgstr "no encontrado"
 msgid "The core rejected these shared folders:%s"
 msgstr "El núcleo rechazó estas carpetas compartidas: %s"
 
-#: src/amule-remote-gui.cpp:1336 src/ExternalConn.cpp:2346
+#: src/amule-remote-gui.cpp:1336 src/ExternalConn.cpp:2345
 msgid "Invalid link or already on list."
 msgstr "El enlace no es válido o ya está en la lista."
 
@@ -981,7 +976,7 @@ msgstr "No se puede crear el directorio '%s' para la categoría '%s', se mantien
 #: src/ClientDetailDialog.cpp:123 src/DataToText.cpp:61 src/DataToText.cpp:86
 #: src/DataToText.cpp:101 src/DataToText.cpp:136 src/DataToText.cpp:165
 #: src/DownloadListCtrl.cpp:1172 src/DownloadListCtrl.cpp:1185
-#: src/DownloadListCtrl.cpp:1196 src/ExternalConn.cpp:609
+#: src/DownloadListCtrl.cpp:1196 src/ExternalConn.cpp:608
 #: src/FileDetailDialog.cpp:203 src/FileDetailDialog.cpp:235
 #: src/FileDetailDialog.cpp:242 src/GenericClientListCtrl.cpp:1171
 #: src/GenericClientListCtrl.cpp:1182 src/GenericClientListCtrl.cpp:1192
@@ -1367,19 +1362,19 @@ msgstr "Automática [Al]"
 msgid "Very low"
 msgstr "Muy baja"
 
-#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:743 src/muuli_wdr.cpp:2303
+#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:743 src/muuli_wdr.cpp:2275
 #: src/ServerListCtrl.cpp:263 src/ServerListCtrl.cpp:456
 #: src/SharedFilesCtrl.cpp:145
 msgid "Low"
 msgstr "Baja"
 
-#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:744 src/muuli_wdr.cpp:2304
+#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:744 src/muuli_wdr.cpp:2276
 #: src/ServerListCtrl.cpp:266 src/ServerListCtrl.cpp:457
 #: src/SharedFilesCtrl.cpp:146
 msgid "Normal"
 msgstr "Normal"
 
-#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:745 src/muuli_wdr.cpp:2305
+#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:745 src/muuli_wdr.cpp:2277
 #: src/ServerListCtrl.cpp:269 src/ServerListCtrl.cpp:458
 #: src/SharedFilesCtrl.cpp:147
 msgid "High"
@@ -1471,8 +1466,8 @@ msgstr "Servidor local"
 msgid "Remote Server"
 msgstr "Servidor remoto"
 
-#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3202
-#: src/SearchDlg.cpp:119 src/TextClient.cpp:911
+#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3174
+#: src/SearchDlg.cpp:111 src/TextClient.cpp:911
 msgid "Kad"
 msgstr "Kad"
 
@@ -1542,7 +1537,7 @@ msgstr "Parte"
 msgid "Size"
 msgstr "Tamaño"
 
-#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3269
+#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3241
 msgid "Transferred"
 msgstr "Transferido"
 
@@ -1600,7 +1595,7 @@ msgstr ""
 "Reacción desde: %s (%s)\n"
 "\n"
 
-#: src/DownloadListCtrl.cpp:746 src/muuli_wdr.cpp:2306
+#: src/DownloadListCtrl.cpp:746 src/muuli_wdr.cpp:2278
 #: src/SharedFilesCtrl.cpp:150
 msgid "Auto"
 msgstr "Automática"
@@ -1638,7 +1633,7 @@ msgid "Extended Options"
 msgstr "Opciones adicionales"
 
 #: src/DownloadListCtrl.cpp:770 src/DownloadListCtrl.cpp:822
-#: src/muuli_wdr.cpp:1790
+#: src/muuli_wdr.cpp:1789
 msgid "Preview"
 msgstr "Previsualizar"
 
@@ -1813,230 +1808,225 @@ msgstr[1] "No se pudieron añadir los enlaces %u (consulte el registro para más
 msgid "Invalid eD2k link! ERROR: %s"
 msgstr "¡Enlace eD2k inválido! ERROR: %s"
 
-#: src/ExternalConn.cpp:380
+#: src/ExternalConn.cpp:379
 msgid "Client sent packet after authentication failed."
 msgstr "El cliente ha enviado un paquete después de una autentificación fallida."
 
-#: src/ExternalConn.cpp:397
+#: src/ExternalConn.cpp:396
 msgid "External connection closed."
 msgstr "Conexión externa cerrada."
 
-#: src/ExternalConn.cpp:474
+#: src/ExternalConn.cpp:473
 msgid "External connections disabled due to empty password!"
 msgstr "¡Las conexiones externas están deshabilitadas por estar la contraseña en blanco!"
 
-#: src/ExternalConn.cpp:495
+#: src/ExternalConn.cpp:494
 msgid "External connections disabled in config file"
 msgstr "Conexiones externas deshabilitadas en el archivo de configuración"
 
-#: src/ExternalConn.cpp:576
+#: src/ExternalConn.cpp:575
 msgid "New external connection accepted"
 msgstr "Nueva conexión externa aceptada"
 
-#: src/ExternalConn.cpp:579
+#: src/ExternalConn.cpp:578
 msgid "ERROR: couldn't accept a new external connection"
 msgstr "ERROR: no se ha podido aceptar una nueva conexión externa"
 
-#: src/ExternalConn.cpp:596
+#: src/ExternalConn.cpp:595
 msgid "External connection refused due to empty password in preferences!"
 msgstr "¡Conexión externa rechazada por estar la contraseña en blanco en las preferencias!"
 
-#: src/ExternalConn.cpp:608
+#: src/ExternalConn.cpp:607
 #, c-format
 msgid "Connecting client: %s %s"
 msgstr "Conectando con el cliente: %s %s"
 
-#: src/ExternalConn.cpp:610
+#: src/ExternalConn.cpp:609
 msgid "Unknown version"
 msgstr "Versión desconocida"
 
-#: src/ExternalConn.cpp:623
+#: src/ExternalConn.cpp:622
 msgid "Incorrect EC version ID, there might be binary incompatibility. Use core and remote from same snapshot."
 msgstr "ID de versión de EC incorrecto, debe haber una incompatibilidad. Use núcleo y remoto de la misma versión."
 
-#: src/ExternalConn.cpp:631
+#: src/ExternalConn.cpp:630
 msgid "You cannot connect to a release version from an arbitrary development snapshot! *sigh* possible crash prevented"
 msgstr "¡No puede conectar a una versión final desde una versión de desarrollo cualquiera! *suspiro* posible error evitado"
 
-#: src/ExternalConn.cpp:714
+#: src/ExternalConn.cpp:713
 msgid "Invalid protocol version."
 msgstr "Versión de protocolo no válida."
 
-#: src/ExternalConn.cpp:720
+#: src/ExternalConn.cpp:719
 msgid "Missing protocol version tag."
 msgstr "Falta la etiqueta de versión de protocolo."
 
-#: src/ExternalConn.cpp:728
+#: src/ExternalConn.cpp:727
 msgid "Authentication failed: invalid hash specified as EC password."
 msgstr "Error de autentificación: se ha dado un hash inválido como contraseña de la EC."
 
-#: src/ExternalConn.cpp:776
+#: src/ExternalConn.cpp:775
 msgid "Authentication failed: wrong password."
 msgstr "Error de autentificación: contraseña incorrecta."
 
-#: src/ExternalConn.cpp:778
+#: src/ExternalConn.cpp:777
 msgid "Authentication failed: missing password."
 msgstr "Error de autentificación: falta la contraseña."
 
-#: src/ExternalConn.cpp:789
+#: src/ExternalConn.cpp:788
 msgid "Invalid request, please authenticate first."
 msgstr "Solicitud no válida, debe autentificarse primero."
 
-#: src/ExternalConn.cpp:794
+#: src/ExternalConn.cpp:793
 msgid "Access granted."
 msgstr "Acceso concedido."
 
-#: src/ExternalConn.cpp:802
+#: src/ExternalConn.cpp:801
 #, c-format
 msgid "Sent error message \"%s\" to client."
 msgstr "Enviar el mensaje de error \"%s\" al cliente."
 
-#: src/ExternalConn.cpp:807
+#: src/ExternalConn.cpp:806
 #, c-format
 msgid "Unauthorized access attempt from %s. Connection closed."
 msgstr "Intento de acceso no autorizado desde %s. Conexión cerrada."
 
-#: src/ExternalConn.cpp:1420
+#: src/ExternalConn.cpp:1419
 #, c-format
 msgid "Remote PartFile command failed: FileHash not found: %s"
 msgstr "Error en el comando del archivo de partes remoto: hash de archivo no encontrado: %s"
 
-#: src/ExternalConn.cpp:1424
+#: src/ExternalConn.cpp:1423
 #, c-format
 msgid "FileHash not found: %s"
 msgstr "Hash de archivo no encontrado: %s"
 
-#: src/ExternalConn.cpp:1471 src/ExternalConn.cpp:1559
-#: src/ExternalConn.cpp:1680
+#: src/ExternalConn.cpp:1470 src/ExternalConn.cpp:1558
+#: src/ExternalConn.cpp:1679
 msgid "OOPS! OpCode processing error!"
 msgstr "¡Huy! ¡Error procesando el código de operación!"
 
-#: src/ExternalConn.cpp:1502
+#: src/ExternalConn.cpp:1501
 msgid "Server not added"
 msgstr "Servidor no añadido"
 
-#: src/ExternalConn.cpp:1521
+#: src/ExternalConn.cpp:1520
 #, c-format
 msgid "server not found: %s"
 msgstr "servidor no encontrado: %s"
 
-#: src/ExternalConn.cpp:1538
+#: src/ExternalConn.cpp:1537
 msgid "need to define server to be removed"
 msgstr "necesita definir el servidor que va a borrar"
 
-#: src/ExternalConn.cpp:1553
+#: src/ExternalConn.cpp:1552
 msgid "eD2k is disabled in preferences."
 msgstr "eD2k está deshabilitado en las preferencias."
 
-#: src/ExternalConn.cpp:1658
+#: src/ExternalConn.cpp:1657
 msgid "Friend not found."
 msgstr "Amigo no encontrado."
 
-#: src/ExternalConn.cpp:1668
+#: src/ExternalConn.cpp:1667
 msgid "Client not found."
 msgstr "Cliente no encontrado."
 
-#: src/ExternalConn.cpp:1674
+#: src/ExternalConn.cpp:1673
 msgid "EC_TAG_FRIEND_SHARED requires EC_TAG_FRIEND or EC_TAG_CLIENT."
 msgstr "EC_TAG_FRIEND_SHARED requiere EC_TAG_FRIEND o EC_TAG_CLIENT."
 
-#: src/ExternalConn.cpp:1992
+#: src/ExternalConn.cpp:1991
 msgid "WebSearch from remote interface makes no sense."
 msgstr "La búsqueda web desde una interfaz remota no tiene sentido."
 
-#: src/ExternalConn.cpp:2027
+#: src/ExternalConn.cpp:2026
 msgid "Search in progress. Refetch results in a moment!"
 msgstr "Búsqueda en proceso. ¡Resultados obtenidos en breve!"
 
-#: src/ExternalConn.cpp:2266
+#: src/ExternalConn.cpp:2265
 msgid "No points for graph."
 msgstr "No hay puntos para el gráfico."
 
-#: src/ExternalConn.cpp:2276
+#: src/ExternalConn.cpp:2275
 msgid "Your client is not configured for this detail level."
 msgstr "Su cliente no está configurado para este nivel de detalle."
 
-#: src/ExternalConn.cpp:2303
+#: src/ExternalConn.cpp:2302
 msgid "External Connection: shutdown requested"
 msgstr "Conexión externa: apagado solicitado"
 
-#: src/ExternalConn.cpp:2315
+#: src/ExternalConn.cpp:2314
 msgid "Already shutting down."
 msgstr "Ya se está cerrando."
 
-#: src/ExternalConn.cpp:2333
+#: src/ExternalConn.cpp:2332
 #, c-format
 msgid "ExternalConn: adding link '%s'."
 msgstr "Conexión externa: añadiendo el enlace '%s'."
 
-#: src/ExternalConn.cpp:2351
+#: src/ExternalConn.cpp:2350
 #, c-format
 msgid "%d of %d links failed (invalid or already on list)."
 msgstr "%d de %d enlaces fallaron(no válidos o ya está en la lista)."
 
-#: src/ExternalConn.cpp:2374
+#: src/ExternalConn.cpp:2373
 msgid "Version check throttled; try again shortly."
 msgstr "La comprobación de versión se ha limitado; inténtelo de nuevo en breve."
 
-#: src/ExternalConn.cpp:2379
+#: src/ExternalConn.cpp:2378
 msgid "Version check is not available on this daemon."
 msgstr "La comprobación de versión no está disponible en este demonio."
 
-#: src/ExternalConn.cpp:2509
+#: src/ExternalConn.cpp:2508
 msgid "File not found."
 msgstr "Archivo no encontrado."
 
-#: src/ExternalConn.cpp:2514
+#: src/ExternalConn.cpp:2513
 msgid "Invalid file name."
 msgstr "Nombre de archivo incorrecto."
 
-#: src/ExternalConn.cpp:2522
+#: src/ExternalConn.cpp:2521
 msgid "Unable to rename file."
 msgstr "No se puede renombrar el archivo."
 
-#: src/ExternalConn.cpp:2839
-#, c-format
-msgid "Could not save the amuleapi password: %s"
-msgstr ""
-
-#: src/ExternalConn.cpp:3004 src/ExternalConn.cpp:3032
+#: src/ExternalConn.cpp:2992 src/ExternalConn.cpp:3020
 msgid "Kad is disabled in preferences."
 msgstr "Kad está deshabilitado en las preferencias."
 
-#: src/ExternalConn.cpp:3045
+#: src/ExternalConn.cpp:3033
 msgid "Already connected to eD2k."
 msgstr "Ya está conectado a eD2k."
 
-#: src/ExternalConn.cpp:3048
+#: src/ExternalConn.cpp:3036
 msgid "Connecting to eD2k..."
 msgstr "Conectado a eD2k..."
 
-#: src/ExternalConn.cpp:3057
+#: src/ExternalConn.cpp:3045
 msgid "Already connected to Kad."
 msgstr "Ya está conectado a Kad."
 
-#: src/ExternalConn.cpp:3060
+#: src/ExternalConn.cpp:3048
 msgid "Connecting to Kad..."
 msgstr "Conectando a Kad..."
 
-#: src/ExternalConn.cpp:3067
+#: src/ExternalConn.cpp:3055
 msgid "All networks are disabled."
 msgstr "Todas las redes están deshabilitadas."
 
-#: src/ExternalConn.cpp:3076
+#: src/ExternalConn.cpp:3064
 msgid "Disconnected from eD2k."
 msgstr "Desconectado de eD2k."
 
-#: src/ExternalConn.cpp:3081
+#: src/ExternalConn.cpp:3069
 msgid "Disconnected from Kad."
 msgstr "Desconectado de Kad."
 
-#: src/ExternalConn.cpp:3090
+#: src/ExternalConn.cpp:3078
 #, c-format
 msgid "External Connection: invalid opcode received: %#x"
 msgstr "Conexión externa: se ha recibido un código de operación inválido: %#x"
 
-#: src/ExternalConn.cpp:3095
+#: src/ExternalConn.cpp:3083
 msgid "Invalid opcode (wrong protocol version?)"
 msgstr "Código de operación no válido (¿versión de protocolo incorrecta?)"
 
@@ -2352,19 +2342,19 @@ msgstr ""
 msgid "eD2k"
 msgstr "eD2k"
 
-#: src/FirstRunWizard.cpp:349 src/muuli_wdr.cpp:1495
+#: src/FirstRunWizard.cpp:349 src/muuli_wdr.cpp:1488
 msgid "Kademlia"
 msgstr "Kademlia"
 
-#: src/FirstRunWizard.cpp:359 src/muuli_wdr.cpp:1423
+#: src/FirstRunWizard.cpp:359 src/muuli_wdr.cpp:1416
 msgid "Standard TCP Port "
 msgstr "Puerto TCP estándar "
 
-#: src/FirstRunWizard.cpp:365 src/muuli_wdr.cpp:1435
+#: src/FirstRunWizard.cpp:365 src/muuli_wdr.cpp:1428
 msgid "Extended UDP port (Kad / global search) "
 msgstr "Puerto UDP adicional (Kad / búsqueda global) "
 
-#: src/FirstRunWizard.cpp:377 src/muuli_wdr.cpp:1442
+#: src/FirstRunWizard.cpp:377 src/muuli_wdr.cpp:1435
 msgid "Enable UPnP for router port forwarding"
 msgstr "Habilitar UPnP para el reenvío del puerto del \"router\""
 
@@ -2391,7 +2381,7 @@ msgstr ""
 msgid "Your peer lists are already in place - nothing to download."
 msgstr "Ya está intentando descargar el archivo %s"
 
-#: src/FirstRunWizard.cpp:434 src/muuli_wdr.cpp:1540
+#: src/FirstRunWizard.cpp:434 src/muuli_wdr.cpp:1533
 msgid "Auto-update server list at startup"
 msgstr "Autoactualizar la lista de servidores al inicio"
 
@@ -2437,23 +2427,23 @@ msgid ""
 "want downloads on a different (e.g. larger) disk."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:549 src/FirstRunWizard.cpp:611 src/muuli_wdr.cpp:1702
+#: src/FirstRunWizard.cpp:549 src/FirstRunWizard.cpp:611 src/muuli_wdr.cpp:1701
 msgid "Destination folder for downloads"
 msgstr "Carpeta de destino para las descargas"
 
-#: src/FirstRunWizard.cpp:553 src/FirstRunWizard.cpp:569 src/muuli_wdr.cpp:1349
-#: src/muuli_wdr.cpp:1366 src/muuli_wdr.cpp:1677 src/muuli_wdr.cpp:1708
-#: src/muuli_wdr.cpp:1720 src/muuli_wdr.cpp:2790
+#: src/FirstRunWizard.cpp:553 src/FirstRunWizard.cpp:569 src/muuli_wdr.cpp:1342
+#: src/muuli_wdr.cpp:1359 src/muuli_wdr.cpp:1676 src/muuli_wdr.cpp:1707
+#: src/muuli_wdr.cpp:1719 src/muuli_wdr.cpp:2762
 #: src/utils/aLinkCreator/src/alcframe.cpp:135
 #: src/utils/wxCas/src/wxcasprefs.cpp:52 src/utils/wxCas/src/wxcasprefs.cpp:118
 msgid "Browse"
 msgstr "Examinar"
 
-#: src/FirstRunWizard.cpp:559 src/muuli_wdr.cpp:1713
+#: src/FirstRunWizard.cpp:559 src/muuli_wdr.cpp:1712
 msgid "(All files in this folder are shared with other peers)"
 msgstr "(Todos los archivos de esta carpeta se comparten con otros usuarios)"
 
-#: src/FirstRunWizard.cpp:565 src/FirstRunWizard.cpp:624 src/muuli_wdr.cpp:1715
+#: src/FirstRunWizard.cpp:565 src/FirstRunWizard.cpp:624 src/muuli_wdr.cpp:1714
 msgid "Folder for temporary download files"
 msgstr "Carpeta para los archivos temporales de las descargas"
 
@@ -2484,7 +2474,7 @@ msgstr "¡Error al abrir el archivo de amigos 'emfriends.met' para escritura!"
 msgid "CRITICAL - no client on StartChatSession"
 msgstr "CRÍTICO - no hay clientes en el inicio de sesión chat"
 
-#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2696 src/muuli_wdr.cpp:3373
+#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2668 src/muuli_wdr.cpp:3345
 msgid "Friends"
 msgstr "Amigos"
 
@@ -2594,8 +2584,8 @@ msgstr "Ninguno"
 msgid "No"
 msgstr "No"
 
-#: src/GenericClientListCtrl.cpp:1216 src/PrefsUnifiedDlg.cpp:2898
-#: src/PrefsUnifiedDlg.cpp:2948 src/ServerListCtrl.cpp:276
+#: src/GenericClientListCtrl.cpp:1216 src/PrefsUnifiedDlg.cpp:2818
+#: src/PrefsUnifiedDlg.cpp:2868 src/ServerListCtrl.cpp:276
 msgid "Yes"
 msgstr "Sí"
 
@@ -2764,10 +2754,10 @@ msgstr "Puerto no válido para la inicialización"
 msgid "Please fill all fields required"
 msgstr "Por favor, rellene todos los campos requeridos"
 
-#: src/KadDlg.cpp:192 src/PartFile.cpp:1031 src/PrefsUnifiedDlg.cpp:1134
-#: src/PrefsUnifiedDlg.cpp:1204 src/PrefsUnifiedDlg.cpp:1405
-#: src/PrefsUnifiedDlg.cpp:1663 src/PrefsUnifiedDlg.cpp:1673
-#: src/PrefsUnifiedDlg.cpp:1690 src/PrefsUnifiedDlg.cpp:1738
+#: src/KadDlg.cpp:192 src/PartFile.cpp:1031 src/PrefsUnifiedDlg.cpp:1162
+#: src/PrefsUnifiedDlg.cpp:1331 src/PrefsUnifiedDlg.cpp:1589
+#: src/PrefsUnifiedDlg.cpp:1599 src/PrefsUnifiedDlg.cpp:1616
+#: src/PrefsUnifiedDlg.cpp:1658
 msgid "Message"
 msgstr "Mensaje"
 
@@ -2868,7 +2858,7 @@ msgstr "Media de compartición"
 msgid "Uploaded"
 msgstr "Subido"
 
-#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3253
+#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3225
 msgid "Requested"
 msgstr "Pedido"
 
@@ -2991,7 +2981,7 @@ msgid "WARNING: "
 msgstr "AVISO: "
 
 #: src/MuleNotebook.cpp:179 src/muuli_wdr.cpp:817 src/muuli_wdr.cpp:1229
-#: src/muuli_wdr.cpp:3157 src/muuli_wdr.cpp:3413
+#: src/muuli_wdr.cpp:3129 src/muuli_wdr.cpp:3385
 msgid "Close"
 msgstr "Cerrar"
 
@@ -3004,12 +2994,12 @@ msgstr "Cortar"
 msgid "Copy"
 msgstr "Copiar"
 
-#: src/MuleTextCtrl.cpp:88 src/SearchDlg.cpp:261
+#: src/MuleTextCtrl.cpp:88
 msgid "Paste"
 msgstr "Pegar"
 
 #: src/MuleTextCtrl.cpp:89 src/muuli_wdr.cpp:358 src/muuli_wdr.cpp:757
-#: src/muuli_wdr.cpp:2380 src/muuli_wdr.cpp:2399 src/muuli_wdr.cpp:2421
+#: src/muuli_wdr.cpp:2352 src/muuli_wdr.cpp:2371 src/muuli_wdr.cpp:2393
 #: src/utils/aLinkCreator/src/alcframe.cpp:142
 msgid "Clear"
 msgstr "Limpiar"
@@ -3100,8 +3090,8 @@ msgid "Exit"
 msgstr "Salir"
 
 #: src/MuleTrayIcon.cpp:579 src/MuleTrayIcon.cpp:945 src/MuleTrayIcon.cpp:965
-#: src/muuli_wdr.cpp:1398 src/muuli_wdr.cpp:1406 src/muuli_wdr.cpp:1413
-#: src/muuli_wdr.cpp:1836 src/muuli_wdr.cpp:1842 src/OtherFunctions.cpp:91
+#: src/muuli_wdr.cpp:1391 src/muuli_wdr.cpp:1399 src/muuli_wdr.cpp:1406
+#: src/muuli_wdr.cpp:1835 src/muuli_wdr.cpp:1841 src/OtherFunctions.cpp:91
 #: src/StatisticsDlg.cpp:93 src/StatisticsDlg.cpp:95
 msgid "kB/s"
 msgstr "kB/s"
@@ -3270,7 +3260,7 @@ msgstr "Nombre:"
 msgid "Type"
 msgstr "Tipo"
 
-#: src/muuli_wdr.cpp:215 src/SearchDlg.cpp:118 src/SearchListCtrl.cpp:853
+#: src/muuli_wdr.cpp:215 src/SearchDlg.cpp:110 src/SearchListCtrl.cpp:853
 msgid "Local"
 msgstr "Local"
 
@@ -3341,7 +3331,7 @@ msgstr "Bytes"
 msgid "KB"
 msgstr "KB"
 
-#: src/muuli_wdr.cpp:274 src/muuli_wdr.cpp:293 src/muuli_wdr.cpp:1621
+#: src/muuli_wdr.cpp:274 src/muuli_wdr.cpp:293 src/muuli_wdr.cpp:1620
 #: src/OtherFunctions.cpp:64
 msgid "MB"
 msgstr "MB"
@@ -3358,7 +3348,7 @@ msgstr "Tamaño máximo"
 msgid "Availability"
 msgstr "Disponibilidad"
 
-#: src/muuli_wdr.cpp:312 src/muuli_wdr.cpp:398 src/muuli_wdr.cpp:3318
+#: src/muuli_wdr.cpp:312 src/muuli_wdr.cpp:398 src/muuli_wdr.cpp:3290
 msgid "Filter:"
 msgstr "Filtro:"
 
@@ -3390,7 +3380,7 @@ msgstr "Pide a los pares Kad que ya han respondido que amplíen la búsqueda. Ca
 msgid "Stop"
 msgstr "Parar"
 
-#: src/muuli_wdr.cpp:348 src/muuli_wdr.cpp:1392 src/SearchListCtrl.cpp:732
+#: src/muuli_wdr.cpp:348 src/muuli_wdr.cpp:1385 src/SearchListCtrl.cpp:732
 msgid "Download"
 msgstr "Descarga"
 
@@ -3421,12 +3411,12 @@ msgstr "Fuentes del archivo:"
 #: src/muuli_wdr.cpp:1160 src/muuli_wdr.cpp:1167 src/muuli_wdr.cpp:1172
 #: src/muuli_wdr.cpp:1179 src/muuli_wdr.cpp:1184 src/muuli_wdr.cpp:1191
 #: src/muuli_wdr.cpp:1205 src/muuli_wdr.cpp:1212 src/muuli_wdr.cpp:1217
-#: src/muuli_wdr.cpp:1224 src/muuli_wdr.cpp:3255 src/muuli_wdr.cpp:3263
-#: src/muuli_wdr.cpp:3271
+#: src/muuli_wdr.cpp:1224 src/muuli_wdr.cpp:3227 src/muuli_wdr.cpp:3235
+#: src/muuli_wdr.cpp:3243
 msgid "N/A"
 msgstr "N/D"
 
-#: src/muuli_wdr.cpp:508 src/muuli_wdr.cpp:1065 src/PrefsUnifiedDlg.cpp:299
+#: src/muuli_wdr.cpp:508 src/muuli_wdr.cpp:1065 src/PrefsUnifiedDlg.cpp:297
 msgid "General"
 msgstr "General"
 
@@ -3562,7 +3552,7 @@ msgstr "Artista :"
 msgid "Album :"
 msgstr "Álbum :"
 
-#: src/muuli_wdr.cpp:685 src/muuli_wdr.cpp:2275
+#: src/muuli_wdr.cpp:685 src/muuli_wdr.cpp:2247
 msgid "Title :"
 msgstr "Título:"
 
@@ -3670,7 +3660,7 @@ msgstr "Nombre del usuario:"
 msgid "Userhash :"
 msgstr "Hash del usuario:"
 
-#: src/muuli_wdr.cpp:895 src/muuli_wdr.cpp:1742 src/muuli_wdr.cpp:2470
+#: src/muuli_wdr.cpp:895 src/muuli_wdr.cpp:1741 src/muuli_wdr.cpp:2442
 #: src/utils/aLinkCreator/src/alcframe.cpp:137
 msgid "Add"
 msgstr "Añadir"
@@ -3679,15 +3669,15 @@ msgstr "Añadir"
 msgid "Download-Speed"
 msgstr "Velocidad de descarga"
 
-#: src/muuli_wdr.cpp:954 src/muuli_wdr.cpp:989 src/muuli_wdr.cpp:2574
+#: src/muuli_wdr.cpp:954 src/muuli_wdr.cpp:989 src/muuli_wdr.cpp:2546
 msgid "Current"
 msgstr "Actual"
 
-#: src/muuli_wdr.cpp:962 src/muuli_wdr.cpp:997 src/muuli_wdr.cpp:2582
+#: src/muuli_wdr.cpp:962 src/muuli_wdr.cpp:997 src/muuli_wdr.cpp:2554
 msgid "Running average"
 msgstr "Media de ejecución"
 
-#: src/muuli_wdr.cpp:970 src/muuli_wdr.cpp:1005 src/muuli_wdr.cpp:2590
+#: src/muuli_wdr.cpp:970 src/muuli_wdr.cpp:1005 src/muuli_wdr.cpp:2562
 msgid "Session average"
 msgstr "Media de la sesión"
 
@@ -3699,7 +3689,7 @@ msgstr "Velocidad de subida"
 msgid "Connections"
 msgstr "Conexiones"
 
-#: src/muuli_wdr.cpp:1024 src/muuli_wdr.cpp:1861
+#: src/muuli_wdr.cpp:1024 src/muuli_wdr.cpp:1860
 msgid "Active downloads"
 msgstr "Descargas activas"
 
@@ -3707,7 +3697,7 @@ msgstr "Descargas activas"
 msgid "Active connections (1:1)"
 msgstr "Conexiones activas (1:1)"
 
-#: src/muuli_wdr.cpp:1040 src/muuli_wdr.cpp:1862
+#: src/muuli_wdr.cpp:1040 src/muuli_wdr.cpp:1861
 msgid "Active uploads"
 msgstr "Subidas activas"
 
@@ -3823,8 +3813,8 @@ msgstr "Este es el nombre que ven los otros usuarios al conectarse con usted."
 msgid "Language: "
 msgstr "Idioma: "
 
-#: src/muuli_wdr.cpp:1257 src/muuli_wdr.cpp:1330 src/muuli_wdr.cpp:1334
-#: src/muuli_wdr.cpp:1337
+#: src/muuli_wdr.cpp:1257 src/muuli_wdr.cpp:1323 src/muuli_wdr.cpp:1327
+#: src/muuli_wdr.cpp:1330
 msgid "The delay before showing tool-tips."
 msgstr "El retardo antes de mostrar los mensajes emergentes."
 
@@ -3900,260 +3890,259 @@ msgstr "Mostrar notificaciones cuando acabe de descargar"
 msgid "Enabling this will make aMule to show notifications when finished downloading."
 msgstr "Si se activa, aMule mostrará notificaciones cuando acabe de descargar."
 
-#: src/muuli_wdr.cpp:1323
-#, fuzzy
-msgid "Remember search history"
-msgstr "Recordar estas opciones"
-
-#: src/muuli_wdr.cpp:1324
-msgid "Keeps a dropdown list of your past search terms in the Search tab's Name field. This remembers the queries you typed, not the results they returned."
-msgstr ""
-
-#: src/muuli_wdr.cpp:1329
+#: src/muuli_wdr.cpp:1322
 msgid "Tooltip delay time: "
 msgstr "Retardo de los mensajes emergentes: "
 
-#: src/muuli_wdr.cpp:1336
+#: src/muuli_wdr.cpp:1329
 msgid "seconds"
 msgstr "segundos"
 
-#: src/muuli_wdr.cpp:1340
+#: src/muuli_wdr.cpp:1333
 msgid "Browser Selection"
 msgstr "Selección del navegador"
 
-#: src/muuli_wdr.cpp:1346
+#: src/muuli_wdr.cpp:1339
 msgid "Enter your browser name here. Leave this field empty to use the system default browser."
 msgstr "Introduzca el nombre de su navegador. Déjelo en blanco si quiere usar el predefinido del sistema."
 
-#: src/muuli_wdr.cpp:1353
+#: src/muuli_wdr.cpp:1346
 msgid "Open in new tab if possible"
 msgstr "Abrir en una pestaña nueva si es posible"
 
-#: src/muuli_wdr.cpp:1355
+#: src/muuli_wdr.cpp:1348
 msgid "Open the web page in a new tab instead of in a new window when possible"
 msgstr "Cuando sea posible, abrir la página web en una nueva pestaña en lugar de en una nueva ventana"
 
-#: src/muuli_wdr.cpp:1359
+#: src/muuli_wdr.cpp:1352
 msgid "Video Player"
 msgstr "Reproductor de vídeo"
 
-#: src/muuli_wdr.cpp:1386
+#: src/muuli_wdr.cpp:1379
 msgid "Bandwidth limits"
 msgstr "Límites del ancho de banda"
 
-#: src/muuli_wdr.cpp:1400
+#: src/muuli_wdr.cpp:1393
 msgid "Upload"
 msgstr "Subida"
 
-#: src/muuli_wdr.cpp:1408
+#: src/muuli_wdr.cpp:1401
 msgid "Slot Allocation"
 msgstr "Asignación de puesto reservado"
 
-#: src/muuli_wdr.cpp:1417
+#: src/muuli_wdr.cpp:1410
 msgid "Ports"
 msgstr "Puertos"
 
-#: src/muuli_wdr.cpp:1427
+#: src/muuli_wdr.cpp:1420
 msgid "This is the standard eD2k port and cannot be disabled."
 msgstr "Este es el puerto eD2k estándar y no puede ser deshabilitado."
 
-#: src/muuli_wdr.cpp:1430
+#: src/muuli_wdr.cpp:1423
 msgid "UDP port for server requests (TCP+3):"
 msgstr "Puerto UDP para peticiones del servidor (TCP+3):"
 
-#: src/muuli_wdr.cpp:1432
+#: src/muuli_wdr.cpp:1425
 msgid "4665"
 msgstr "4665"
 
-#: src/muuli_wdr.cpp:1439
+#: src/muuli_wdr.cpp:1432
 msgid "This UDP port is used for extended eD2k requests and Kad network"
 msgstr "Este puerto UDP se usa para peticiones adicionales de eD2k y la red Kad"
 
-#: src/muuli_wdr.cpp:1446
+#: src/muuli_wdr.cpp:1439
 msgid "UPnP TCP Port (Optional):"
 msgstr "Puerto TCP para UPnP (opcional):"
 
-#: src/muuli_wdr.cpp:1456
+#: src/muuli_wdr.cpp:1449
 msgid "Bind local address to IP (empty for any):"
 msgstr "Dirección IP local de enlace (vacía para cualquiera):"
 
-#: src/muuli_wdr.cpp:1459
+#: src/muuli_wdr.cpp:1452
 msgid "Advanced users only: If you have multiple network interfaces, enter the address of the interface to which aMule should be bound."
 msgstr "Solo usuarios avanzados: si tiene varias tarjetas de red, introduzca la dirección de la tarjeta que debe usar aMule."
 
-#: src/muuli_wdr.cpp:1462 src/muuli_wdr.cpp:2055
+#: src/muuli_wdr.cpp:1455 src/muuli_wdr.cpp:2054
 msgid "Bind to network interface (empty for any):"
 msgstr "Vincular a interfaz de red (vacío para cualquiera):"
 
-#: src/muuli_wdr.cpp:1475
+#: src/muuli_wdr.cpp:1468
 msgid "Advanced users only: pin all of aMule's traffic to one network interface, chosen from the list or typed in by name (e.g. tun0, eth0, en0) or index. Unlike binding to an IP, this stops traffic leaking out via the default route - useful with a VPN. Requires no elevated privileges."
 msgstr "Solo para usuarios avanzados: fija todo el tráfico de aMule a una única interfaz de red, seleccionada de la lista o introducida por nombre (p. ej., tun0, eth0, en0) o por índice. A diferencia de vincularlo a una IP, esto evita que el tráfico se filtre por la ruta predeterminada, lo cual es útil con una VPN. No requiere privilegios elevados."
 
-#: src/muuli_wdr.cpp:1481
+#: src/muuli_wdr.cpp:1474
 msgid "Max sources per downloading file:"
 msgstr "Número máximo de fuentes descargando un archivo:"
 
-#: src/muuli_wdr.cpp:1485
+#: src/muuli_wdr.cpp:1478
 msgid "Max simultaneous connections:"
 msgstr "Número máximo de conexiones simultáneas:"
 
-#: src/muuli_wdr.cpp:1498 src/muuli_wdr.cpp:3197
+#: src/muuli_wdr.cpp:1491 src/muuli_wdr.cpp:3169
 msgid "ED2K"
 msgstr "ED2K"
 
-#: src/muuli_wdr.cpp:1505
+#: src/muuli_wdr.cpp:1498
 msgid "Autoconnect on startup"
 msgstr "Autoconectar al iniciar"
 
-#: src/muuli_wdr.cpp:1508
+#: src/muuli_wdr.cpp:1501
 msgid "Reconnect on loss"
 msgstr "Reconectar al perder la conexión"
 
-#: src/muuli_wdr.cpp:1530
+#: src/muuli_wdr.cpp:1523
 msgid "Remove dead server after"
 msgstr "Eliminar los servidores caídos tras"
 
-#: src/muuli_wdr.cpp:1531
+#: src/muuli_wdr.cpp:1524
 msgid "Static servers are never removed, even when unreachable."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1535
+#: src/muuli_wdr.cpp:1528
 msgid "retries"
 msgstr "reintentos"
 
-#: src/muuli_wdr.cpp:1543
+#: src/muuli_wdr.cpp:1536
 msgid "List"
 msgstr "Lista"
 
-#: src/muuli_wdr.cpp:1546
+#: src/muuli_wdr.cpp:1539
 msgid "Update server list when connecting to a server"
 msgstr "Actualizar la lista de servidores al conectar a un servidor"
 
-#: src/muuli_wdr.cpp:1549
+#: src/muuli_wdr.cpp:1542
 msgid "Update server list when a client connects"
 msgstr "Actualizar la lista de servidores cuando se conecte un cliente"
 
-#: src/muuli_wdr.cpp:1552
+#: src/muuli_wdr.cpp:1545
 msgid "Use priority system"
 msgstr "Usar el sistema de prioridades"
 
-#: src/muuli_wdr.cpp:1556
+#: src/muuli_wdr.cpp:1549
 msgid "Use smart LowID check on connect"
 msgstr "Usar el control inteligente de Id Baja al conectar"
 
-#: src/muuli_wdr.cpp:1560
+#: src/muuli_wdr.cpp:1553
 msgid "Safe connect"
 msgstr "Conexión segura"
 
-#: src/muuli_wdr.cpp:1564
+#: src/muuli_wdr.cpp:1557
 msgid "Autoconnect to servers in static list only"
 msgstr "Autoconectar sólo a servidores fijos"
 
-#: src/muuli_wdr.cpp:1567
+#: src/muuli_wdr.cpp:1560
 msgid "Set manually added servers to High Priority"
 msgstr "Asignar la prioridad alta a los servidores añadidos manualmente"
 
-#: src/muuli_wdr.cpp:1588
+#: src/muuli_wdr.cpp:1581
 msgid "Add files to download in pause mode"
 msgstr "Añadir los archivos a descargar en modo pausado"
 
-#: src/muuli_wdr.cpp:1590
+#: src/muuli_wdr.cpp:1583
 msgid "Add files to download with auto priority"
 msgstr "Añadir las nuevas descargas con prioridad automática"
 
-#: src/muuli_wdr.cpp:1593
+#: src/muuli_wdr.cpp:1586
 msgid "Try to download first and last chunks first"
 msgstr "Intentar descargar antes el primer y último trozo"
 
-#: src/muuli_wdr.cpp:1597
+#: src/muuli_wdr.cpp:1590
 msgid "Endgame mode: rotate to faster sources for the final blocks"
 msgstr "Modo endgame: cambiar a fuentes más rápidas para los bloques finales"
 
-#: src/muuli_wdr.cpp:1600
+#: src/muuli_wdr.cpp:1593
 msgid "Start next paused file when a file completes"
 msgstr "Descargar el siguiente archivo pausado cuando otro se complete"
 
-#: src/muuli_wdr.cpp:1603
+#: src/muuli_wdr.cpp:1596
 msgid "From the same category"
 msgstr "Solo de la misma categoría"
 
-#: src/muuli_wdr.cpp:1605
+#: src/muuli_wdr.cpp:1598
 msgid "In alphabetic order"
 msgstr "En orden alfabético"
 
-#: src/muuli_wdr.cpp:1607
+#: src/muuli_wdr.cpp:1600
 msgid "Preallocate disk space for new files"
 msgstr "Reservar el espacio en disco para los archivos nuevos"
 
-#: src/muuli_wdr.cpp:1608
+#: src/muuli_wdr.cpp:1601
 msgid "For new files preallocates disk space for the whole file, thus reduces fragmentation"
 msgstr "Reserva en disco el espacio para los archivos nuevos enteros, reduciendo asíla fragmentación"
 
-#: src/muuli_wdr.cpp:1613
+#: src/muuli_wdr.cpp:1606
+msgid "Create new files as sparse files"
+msgstr ""
+
+#: src/muuli_wdr.cpp:1607
+msgid "A sparse file reserves its full size on disk immediately without writing real data to it -- fast, but unsupported or slow on some filesystems, and free-space accounting stays optimistic while the download is in progress. Turn this off to grow the file only as data arrives."
+msgstr ""
+
+#: src/muuli_wdr.cpp:1612
 msgid "Stop downloads when free disk space reaches "
 msgstr "Detener las descargas cuando el espacio libre en disco alcance "
 
-#: src/muuli_wdr.cpp:1614
+#: src/muuli_wdr.cpp:1613
 msgid "Select this if you want aMule to check your disk space"
 msgstr "Seleccione esta opción si quiere que aMule compruebe el espacio en disco"
 
-#: src/muuli_wdr.cpp:1618
+#: src/muuli_wdr.cpp:1617
 msgid "Enter here the min disk space desired."
 msgstr "Introduzca el espacio mínimo de disco deseado."
 
-#: src/muuli_wdr.cpp:1624
+#: src/muuli_wdr.cpp:1623
 msgid "Save 10 sources on rare files (< 20 sources)"
 msgstr "Guardar 10 fuentes para archivos raros (< 20 fuentes)"
 
-#: src/muuli_wdr.cpp:1628 src/Statistics.cpp:790
+#: src/muuli_wdr.cpp:1627 src/Statistics.cpp:790
 msgid "Uploads"
 msgstr "Subidas"
 
-#: src/muuli_wdr.cpp:1631
+#: src/muuli_wdr.cpp:1630
 msgid "Add new shared files with auto priority"
 msgstr "Añadir los nuevos archivos compartidos con prioridad automática"
 
-#: src/muuli_wdr.cpp:1637
+#: src/muuli_wdr.cpp:1636
 msgid "Intelligent Corruption Handling (I.C.H.)"
 msgstr "Gestión inteligente de corrupción (I.C.H.)"
 
-#: src/muuli_wdr.cpp:1640
+#: src/muuli_wdr.cpp:1639
 msgid "Enable"
 msgstr "Habilitar"
 
-#: src/muuli_wdr.cpp:1643
+#: src/muuli_wdr.cpp:1642
 msgid "Advanced I.C.H. trusts every hash (not recommended)"
 msgstr "El I.C.H. avanzado confía en todos los hash (no recomendado)"
 
-#: src/muuli_wdr.cpp:1655 src/PrefsUnifiedDlg.cpp:1990
+#: src/muuli_wdr.cpp:1654 src/PrefsUnifiedDlg.cpp:1910
 msgid "Media metadata extraction"
 msgstr "Extracción de metadatos multimedia"
 
-#: src/muuli_wdr.cpp:1659
+#: src/muuli_wdr.cpp:1658
 msgid "Extract length / bitrate / codec from shared audio and video files"
 msgstr "Extraer la duración, el bitrate y el códec de los archivos multimedia compartidos"
 
-#: src/muuli_wdr.cpp:1661
+#: src/muuli_wdr.cpp:1660
 msgid "When enabled, aMule runs ffprobe on each shared media file to fill in the Length / Bitrate / Codec columns other clients see when they find the file in a search. Requires ffmpeg (the ffprobe binary) to be installed."
 msgstr "Cuando está activado, aMule ejecuta ffprobe en cada archivo multimedia compartido para rellenar las columnas de Duración / Bitrate / Códec que otros clientes ven cuando encuentran el archivo en una búsqueda. Requiere tener instalado ffmpeg (el binario ffprobe)."
 
-#: src/muuli_wdr.cpp:1668
+#: src/muuli_wdr.cpp:1667
 msgid "Path to ffprobe:"
 msgstr "Ruta a ffprobe:"
 
-#: src/muuli_wdr.cpp:1673
+#: src/muuli_wdr.cpp:1672
 msgid "Full path to the ffprobe binary. Leave empty to have aMule auto-detect it on startup."
 msgstr "Ruta completa al binario de ffprobe. Déjelo vacío para que aMule lo detecte automáticamente al iniciar."
 
-#: src/muuli_wdr.cpp:1681
+#: src/muuli_wdr.cpp:1680
 msgid "Detect"
 msgstr "Detectar"
 
-#: src/muuli_wdr.cpp:1682
+#: src/muuli_wdr.cpp:1681
 msgid "Search the standard install locations for an ffprobe binary and fill the path field."
 msgstr "Buscar los lugares de instalación estándar para un binario ffprobe y rellenar el campo de la ruta."
 
-#: src/muuli_wdr.cpp:1706
+#: src/muuli_wdr.cpp:1705
 msgid ""
 "Completed downloads are stored here. All files in this folder are automatically shared with other peers.\n"
 "If this folder also holds files you don't want to share, point it at an aMule-only sub-folder."
@@ -4161,383 +4150,360 @@ msgstr ""
 "Las descargas completadas se guardan aquí. Todos los archivos de esta carpeta se compartirán automáticamente con otros usuarios.\n"
 "Si esta carpeta contiene archivos que no quiere compartir, apúntelo a un sub-directorio exclusivo para aMule."
 
-#: src/muuli_wdr.cpp:1709
+#: src/muuli_wdr.cpp:1708
 msgid "Pick the folder where completed downloads will be stored. All files in that folder will be shared with other peers."
 msgstr "Elija la carpeta donde se guardarán las descargas terminadas. Todos los archivos de esa carpeta se compartirán con otros usuarios."
 
-#: src/muuli_wdr.cpp:1723
+#: src/muuli_wdr.cpp:1722
 msgid "Shared folders"
 msgstr "Carpetas compartidas"
 
-#: src/muuli_wdr.cpp:1729
+#: src/muuli_wdr.cpp:1728
 msgid "(Folders shared by the core. Enter a path to add one.)"
 msgstr "(Directorios compartidos por el núcleo. Introduzca una ruta para añadir uno.)"
 
-#: src/muuli_wdr.cpp:1737
+#: src/muuli_wdr.cpp:1736
 msgid "Absolute path of a folder on the core's machine, e.g. /home/user/shared"
 msgstr "Ruta absoluta de un directorio en la máquina del núcleo, p. ej. /home/user/compartido"
 
-#: src/muuli_wdr.cpp:1739 src/PrefsUnifiedDlg.cpp:2874
+#: src/muuli_wdr.cpp:1738 src/PrefsUnifiedDlg.cpp:2794
 msgid "Recursive"
 msgstr "Recursivo"
 
-#: src/muuli_wdr.cpp:1740
+#: src/muuli_wdr.cpp:1739
 msgid "Share every sub-folder underneath this one, including ones created later."
 msgstr "Compartir todos los subdirectorios bajo éste, incluyendo los creados en el futuro."
 
-#: src/muuli_wdr.cpp:1744 src/utils/aLinkCreator/src/alcframe.cpp:141
+#: src/muuli_wdr.cpp:1743 src/utils/aLinkCreator/src/alcframe.cpp:141
 msgid "Remove"
 msgstr "Borrar"
 
-#: src/muuli_wdr.cpp:1748
+#: src/muuli_wdr.cpp:1747
 msgid "(Right click on folder icon for recursive share)"
 msgstr "(Haga clic derecho en los iconos de carpetas para compartirlas recursivamente)"
 
-#: src/muuli_wdr.cpp:1755
+#: src/muuli_wdr.cpp:1754
 msgid "Share hidden files"
 msgstr "Compartir los archivos ocultos"
 
-#: src/muuli_wdr.cpp:1761
+#: src/muuli_wdr.cpp:1760
 msgid "Automatically rescan shared folders for changes"
 msgstr "Buscar cambios automáticamente en los directorios compartidos"
 
-#: src/muuli_wdr.cpp:1767
+#: src/muuli_wdr.cpp:1766
 msgid "Follow symbolic links in shared folders"
 msgstr "Seguir enlaces simbólicos en las carpetas compartidas"
 
-#: src/muuli_wdr.cpp:1773
+#: src/muuli_wdr.cpp:1772
 msgid "Exclude files matching:"
 msgstr "Excluir archivos coincidentes:"
 
-#: src/muuli_wdr.cpp:1776
+#: src/muuli_wdr.cpp:1775
 msgid "Wildcard patterns separated by '|', e.g. .DS_Store|Thumbs.db|*.tmp. Files whose name matches are not shared. Matching is case-insensitive."
 msgstr "Patrones comodines separados por '|', p.ej., .DS_Store|Thumbs.db|*.tmp. Los archivos cuyo nombre coincida no serán compartidos. No distingue mayúsculas/minúsculas."
 
-#: src/muuli_wdr.cpp:1780
+#: src/muuli_wdr.cpp:1779
 msgid "Patterns are regular expressions"
 msgstr "Los patrones son expresiones regulares"
 
-#: src/muuli_wdr.cpp:1781
+#: src/muuli_wdr.cpp:1780
 msgid "When set, the whole field is one regular expression ('|' is alternation). When unset, it is a list of '|'-separated wildcards."
 msgstr "Cuando se activa, el campo completo es una expresión regular ('|' es OR). Cuando no se activa, es un listado de comodines separados por '|'."
 
-#: src/muuli_wdr.cpp:1791
+#: src/muuli_wdr.cpp:1790
 msgid "Show how many shared files the current pattern would exclude."
 msgstr "Muestra cuántos archivos compartidos excluiría el patrón actual."
 
-#: src/muuli_wdr.cpp:1812
+#: src/muuli_wdr.cpp:1811
 msgid "Graphs"
 msgstr "Gráficos"
 
-#: src/muuli_wdr.cpp:1815 src/muuli_wdr.cpp:1877
+#: src/muuli_wdr.cpp:1814 src/muuli_wdr.cpp:1876
 msgid "Update delay : 5 secs"
 msgstr "Intervalo de actualización: 5 s"
 
-#: src/muuli_wdr.cpp:1819
+#: src/muuli_wdr.cpp:1818
 msgid "Time for average graph: 100 mins"
 msgstr "Tiempo de promedio del gráfico: 100 minutos"
 
-#: src/muuli_wdr.cpp:1823
+#: src/muuli_wdr.cpp:1822
 msgid "Connections Graph Scale: 100 "
 msgstr "Escala del gráfico de las conexiones: 100 "
 
-#: src/muuli_wdr.cpp:1830
+#: src/muuli_wdr.cpp:1829
 msgid "Download graph scale:"
 msgstr "Escala de la gráfica de descarga:"
 
-#: src/muuli_wdr.cpp:1838
+#: src/muuli_wdr.cpp:1837
 msgid "Upload graph scale:"
 msgstr "Escala de la gráfica de subida:"
 
-#: src/muuli_wdr.cpp:1848
+#: src/muuli_wdr.cpp:1847
 msgid "Colors: "
 msgstr "Colores: "
 
-#: src/muuli_wdr.cpp:1852
+#: src/muuli_wdr.cpp:1851
 msgid "Background"
 msgstr "Fondo"
 
-#: src/muuli_wdr.cpp:1853
+#: src/muuli_wdr.cpp:1852
 msgid "Grid"
 msgstr "Rejilla"
 
-#: src/muuli_wdr.cpp:1854
+#: src/muuli_wdr.cpp:1853
 msgid "Download current"
 msgstr "Descarga actual"
 
-#: src/muuli_wdr.cpp:1855
+#: src/muuli_wdr.cpp:1854
 msgid "Download running average"
 msgstr "Promedio de descarga en ejecución"
 
-#: src/muuli_wdr.cpp:1856
+#: src/muuli_wdr.cpp:1855
 msgid "Download session average"
 msgstr "Promedio de descarga en la sesión"
 
-#: src/muuli_wdr.cpp:1857
+#: src/muuli_wdr.cpp:1856
 msgid "Upload current"
 msgstr "Subida actual"
 
-#: src/muuli_wdr.cpp:1858
+#: src/muuli_wdr.cpp:1857
 msgid "Upload running average"
 msgstr "Promedio de subida en ejecución"
 
-#: src/muuli_wdr.cpp:1859
+#: src/muuli_wdr.cpp:1858
 msgid "Upload session average"
 msgstr "Promedio de subida en la sesión"
 
-#: src/muuli_wdr.cpp:1860
+#: src/muuli_wdr.cpp:1859
 msgid "Active connections"
 msgstr "Conexiones activas"
 
-#: src/muuli_wdr.cpp:1863
+#: src/muuli_wdr.cpp:1862
 msgid "Systray Icon Speed Bar"
 msgstr "Barra de velocidad en el icono de la bandeja del sistema"
 
-#: src/muuli_wdr.cpp:1864
+#: src/muuli_wdr.cpp:1863
 msgid "Kad-nodes current"
 msgstr "Nodos Kad actuales"
 
-#: src/muuli_wdr.cpp:1865
+#: src/muuli_wdr.cpp:1864
 msgid "Kad-nodes running"
 msgstr "Nodos Kad activos"
 
-#: src/muuli_wdr.cpp:1866
+#: src/muuli_wdr.cpp:1865
 msgid "Kad-nodes session"
 msgstr "Nodos Kad de la sesión"
 
-#: src/muuli_wdr.cpp:1870 src/muuli_wdr.cpp:2324
+#: src/muuli_wdr.cpp:1869 src/muuli_wdr.cpp:2296
 msgid "Select"
 msgstr "Seleccionar"
 
-#: src/muuli_wdr.cpp:1874
+#: src/muuli_wdr.cpp:1873
 msgid "Tree"
 msgstr "Árbol"
 
-#: src/muuli_wdr.cpp:1884
+#: src/muuli_wdr.cpp:1883
 msgid "Number of Client Versions shown (0=unlimited)"
 msgstr "Número de versiones de clientes a mostrar (0=sin límite)"
 
-#: src/muuli_wdr.cpp:1909
+#: src/muuli_wdr.cpp:1908
 msgid "!!! WARNING !!!"
 msgstr "¡¡¡ AVISO !!!"
 
-#: src/muuli_wdr.cpp:1924
+#: src/muuli_wdr.cpp:1923
 msgid "Max new connections / 5 secs"
 msgstr "Número máximo de nuevas conexiones cada 5 segundos"
 
-#: src/muuli_wdr.cpp:1926
+#: src/muuli_wdr.cpp:1925
 msgid "Concurrent Kad source lookups"
 msgstr "Búsquedas simultáneas de fuentes Kad"
 
-#: src/muuli_wdr.cpp:1928
+#: src/muuli_wdr.cpp:1927
 msgid "Kad source re-search interval (minutes)"
 msgstr "Intervalo de búsqueda de fuentes Kad (minutos)"
 
-#: src/muuli_wdr.cpp:1930
+#: src/muuli_wdr.cpp:1929
 msgid "Source re-ask interval (minutes)"
 msgstr "Intervalo re‐solicitud de fuentes (minutos)"
 
-#: src/muuli_wdr.cpp:1934
+#: src/muuli_wdr.cpp:1933
 msgid "File Buffer Size: 240000 bytes"
 msgstr "Tamaño del búfer de archivo: 240000 bytes"
 
-#: src/muuli_wdr.cpp:1938
+#: src/muuli_wdr.cpp:1937
 msgid "Use MMAP: memory-mapped file access (lower memory use)"
 msgstr "Usar MMAP: acceso a ficheros mapeados en memoria (menor uso de memoria)"
 
-#: src/muuli_wdr.cpp:1939
+#: src/muuli_wdr.cpp:1938
 msgid "Maps part files into memory instead of buffering them on the heap, lowering the process memory footprint. May reduce download speed on some disks; best for memory-constrained or upload-heavy hosts."
 msgstr "Mapea los ficheros de partes en memoria en vez de usar un buffer en la pila, reduciendo la huella de memoria del proceso. Puede reducir la velocidad de descarga en algunos discos; es mejor usarlo en entornos con poca memoria o nodos que principalmente suban datos."
 
-#: src/muuli_wdr.cpp:1941
+#: src/muuli_wdr.cpp:1940
 msgid "Upload Queue Size: 5000 clients"
 msgstr "Tamaño de cola de espera: 5000 clientes"
 
-#: src/muuli_wdr.cpp:1945
+#: src/muuli_wdr.cpp:1944
 msgid "Server connection refresh interval: Disable"
 msgstr "Intervalo de actualización de la conexión al servidor: desactivado"
 
-#: src/muuli_wdr.cpp:1949
+#: src/muuli_wdr.cpp:1948
 msgid "Disable computer's timed standby mode"
 msgstr "Deshabilitar el modo de reposo del ordenador"
 
-#: src/muuli_wdr.cpp:1968
+#: src/muuli_wdr.cpp:1967
 msgid "Skin to use: "
 msgstr "Tema a usar: "
 
-#: src/muuli_wdr.cpp:1977
+#: src/muuli_wdr.cpp:1976
 msgid "Show \"Fast eD2k Links Handler\" in every window."
 msgstr "Mostrar el \"Gestor rápido de enlaces eD2k\" en todas las ventanas."
 
-#: src/muuli_wdr.cpp:1980
+#: src/muuli_wdr.cpp:1979
 msgid "Show extended info on categories tabs"
 msgstr "Mostrar información adicional en las pestañas de las categorías"
 
-#: src/muuli_wdr.cpp:1983
+#: src/muuli_wdr.cpp:1982
 msgid "Show application version on title"
 msgstr "Mostrar la versión de la aplicación en el título"
 
-#: src/muuli_wdr.cpp:1985
+#: src/muuli_wdr.cpp:1984
 msgid "Show transfer rates on title"
 msgstr "Mostrar las tasas de transferencia en el título"
 
-#: src/muuli_wdr.cpp:1987
+#: src/muuli_wdr.cpp:1986
 msgid "Before application name"
 msgstr "Antes del nombre de la aplicación"
 
-#: src/muuli_wdr.cpp:1989
+#: src/muuli_wdr.cpp:1988
 msgid "After application name"
 msgstr "Después del nombre de la aplicación"
 
-#: src/muuli_wdr.cpp:1992
+#: src/muuli_wdr.cpp:1991
 msgid "Show overhead bandwidth"
 msgstr "Mostrar el ancho de banda adicional usado"
 
-#: src/muuli_wdr.cpp:1996
+#: src/muuli_wdr.cpp:1995
 msgid "Vertical toolbar orientation"
 msgstr "Orientación vertical de la barra de herramientas"
 
-#: src/muuli_wdr.cpp:1998
+#: src/muuli_wdr.cpp:1997
 msgid "Live column sorting (auto-reorder rows as their values change)"
 msgstr "Orden automático de columnas (reordena las filas según cambian sus valores)"
 
-#: src/muuli_wdr.cpp:2005
+#: src/muuli_wdr.cpp:2004
 msgid "Download Queue Files"
 msgstr "Archivos de la cola de descarga"
 
-#: src/muuli_wdr.cpp:2008
+#: src/muuli_wdr.cpp:2007
 msgid "Show progress percentage"
 msgstr "Mostrar el porcentaje de progreso"
 
-#: src/muuli_wdr.cpp:2014
+#: src/muuli_wdr.cpp:2013
 msgid "Show progress bar"
 msgstr "Mostrar la barra de progreso"
 
-#: src/muuli_wdr.cpp:2017
+#: src/muuli_wdr.cpp:2016
 msgid "Flat"
 msgstr "Plana"
 
-#: src/muuli_wdr.cpp:2021
+#: src/muuli_wdr.cpp:2020
 msgid "Round"
 msgstr "Redondeada"
 
-#: src/muuli_wdr.cpp:2039
+#: src/muuli_wdr.cpp:2038
 msgid "External Connection Parameters"
 msgstr "Parámetros de la conexión externa"
 
-#: src/muuli_wdr.cpp:2042
+#: src/muuli_wdr.cpp:2041
 msgid "Accept external connections"
 msgstr "Aceptar conexiones externas"
 
-#: src/muuli_wdr.cpp:2049 src/muuli_wdr.cpp:2108
+#: src/muuli_wdr.cpp:2048 src/muuli_wdr.cpp:2107
 msgid "IP of the listening interface:"
 msgstr "IP de la interfaz que está escuchando:"
 
-#: src/muuli_wdr.cpp:2052
+#: src/muuli_wdr.cpp:2051
 msgid "Enter here a valid ip in the a.b.c.d format for the listening EC interface. An empty field or 0.0.0.0 will mean any interface."
 msgstr "Introduzca aquí una IP válida en la forma a.b.c.d para la interfaz EC que está escuchando. Un campo vacío o 0.0.0.0 significará cualquier interfaz."
 
-#: src/muuli_wdr.cpp:2073 src/muuli_wdr.cpp:2184
+#: src/muuli_wdr.cpp:2072 src/muuli_wdr.cpp:2156
 msgid "TCP port:"
 msgstr "Puerto TCP:"
 
-#: src/muuli_wdr.cpp:2079
+#: src/muuli_wdr.cpp:2078
 msgid "Enable UPnP port forwarding on the EC port"
 msgstr "Habilitar la redirección de puertos UPnP en el puerto EC"
 
-#: src/muuli_wdr.cpp:2083 src/muuli_wdr.cpp:3069
+#: src/muuli_wdr.cpp:2082 src/muuli_wdr.cpp:3041
 #: src/utils/wxCas/src/wxcasprefs.cpp:167
 msgid "Password"
 msgstr "Contraseña"
 
-#: src/muuli_wdr.cpp:2089
+#: src/muuli_wdr.cpp:2088
 msgid "aMule API server parameters"
 msgstr "Parámetros del servidor aMule API"
 
-#: src/muuli_wdr.cpp:2092
+#: src/muuli_wdr.cpp:2091
 msgid "Run amuleapi (REST API) on startup"
 msgstr "Ejecutar amuleapi (API REST) al iniciar"
 
-#: src/muuli_wdr.cpp:2097
+#: src/muuli_wdr.cpp:2096
 msgid "HTTP port:"
 msgstr "Puerto HTTP:"
 
-#: src/muuli_wdr.cpp:2111
+#: src/muuli_wdr.cpp:2110
 msgid "The interface amuleapi's HTTP server listens on. 127.0.0.1 (default) accepts only local connections; use 0.0.0.0 or a specific IP to expose it to other hosts (set an admin password below)."
 msgstr "La interfaz en la que escucha el servidor HTTP de amuleapi es 127.0.0.1 (por defecto), que solo acepta conexiones locales; utilice 0.0.0.0 o una IP específica para exponerla a otros hosts (establezca una contraseña de administrador a continuación)."
 
-#: src/muuli_wdr.cpp:2116
-msgid "Type a password to set or change it. Stored passwords cannot be shown, so leaving this empty keeps the current one."
-msgstr ""
-
-#: src/muuli_wdr.cpp:2118
+#: src/muuli_wdr.cpp:2113
 msgid "Admin password"
 msgstr "Contraseña Admin"
 
-#: src/muuli_wdr.cpp:2130 src/muuli_wdr.cpp:2147 src/PrefsUnifiedDlg.cpp:1103
-#, fuzzy
-msgid "A password is set."
-msgstr "Contraseña Admin"
-
-#: src/muuli_wdr.cpp:2134
-#, fuzzy
-msgid "Enable guest access"
-msgstr "Denegar el acceso de invitado"
-
-#: src/muuli_wdr.cpp:2135
-msgid "Guest sessions may read status and listings but cannot change anything. Turning this off clears the stored guest password."
-msgstr ""
-
-#: src/muuli_wdr.cpp:2139
-#, fuzzy
-msgid "Guest password"
-msgstr "Contraseña de invitado para el servidor web"
-
-#: src/muuli_wdr.cpp:2154
-msgid "Web server parameters"
-msgstr "Parámetros del servidor web"
-
-#: src/muuli_wdr.cpp:2157
-msgid "Run webserver on startup (deprecated)"
-msgstr "Ejecutar webserver al iniciar (obsoleto)"
-
-#: src/muuli_wdr.cpp:2163
-msgid "Web template"
-msgstr "Plantilla web"
-
-#: src/muuli_wdr.cpp:2168
-msgid "Full rights password"
-msgstr "Contraseña de administrador"
-
-#: src/muuli_wdr.cpp:2172
-msgid "Enable Low rights User"
-msgstr "Permitir un invitado"
-
-#: src/muuli_wdr.cpp:2177
+#: src/muuli_wdr.cpp:2118 src/muuli_wdr.cpp:2149
 msgid "Low rights password"
 msgstr "Contraseña del invitado"
 
-#: src/muuli_wdr.cpp:2191
+#: src/muuli_wdr.cpp:2126
+msgid "Web server parameters"
+msgstr "Parámetros del servidor web"
+
+#: src/muuli_wdr.cpp:2129
+msgid "Run webserver on startup (deprecated)"
+msgstr "Ejecutar webserver al iniciar (obsoleto)"
+
+#: src/muuli_wdr.cpp:2135
+msgid "Web template"
+msgstr "Plantilla web"
+
+#: src/muuli_wdr.cpp:2140
+msgid "Full rights password"
+msgstr "Contraseña de administrador"
+
+#: src/muuli_wdr.cpp:2144
+msgid "Enable Low rights User"
+msgstr "Permitir un invitado"
+
+#: src/muuli_wdr.cpp:2163
 msgid "Enable UPnP port forwarding of the web server port"
 msgstr "Habilitar el reenvío de puertos UPnP en el puerto del servidor web"
 
-#: src/muuli_wdr.cpp:2196
+#: src/muuli_wdr.cpp:2168
 msgid "Web server UPnP TCP port (Optional)"
 msgstr "Puerto TCP del servidor web para UPnP (opcional)"
 
-#: src/muuli_wdr.cpp:2204
+#: src/muuli_wdr.cpp:2176
 msgid "Page Refresh Time (in secs)"
 msgstr "Intervalo de actualización de la página (en segundos)"
 
-#: src/muuli_wdr.cpp:2211
+#: src/muuli_wdr.cpp:2183
 msgid "Enable Gzip compression"
 msgstr "Activar la compresión gzip"
 
-#: src/muuli_wdr.cpp:2245
+#: src/muuli_wdr.cpp:2217
 msgid "Reset page to defaults"
 msgstr "Restablecer a los valores por defecto"
 
-#: src/muuli_wdr.cpp:2246
+#: src/muuli_wdr.cpp:2218
 msgid "Reset the settings on the current page to their default values."
 msgstr "Restablece los ajustes de la página actual a sus valores por defecto."
 
@@ -4545,308 +4511,308 @@ msgstr "Restablece los ajustes de la página actual a sus valores por defecto."
 # botón para cerrar el diálogo de Preferencias guardando los cambios. La
 # traducción sería distinta en cada caso, así que hay que dejar el OK
 # original.
-#: src/muuli_wdr.cpp:2248 src/muuli_wdr.cpp:2334 src/ServerWnd.cpp:274
+#: src/muuli_wdr.cpp:2220 src/muuli_wdr.cpp:2306 src/ServerWnd.cpp:274
 #: src/ServerWnd.cpp:282
 msgid "OK"
 msgstr "OK"
 
-#: src/muuli_wdr.cpp:2250
+#: src/muuli_wdr.cpp:2222
 msgid "Click here to apply any changes made to the preferences."
 msgstr "Haga clic aquí para aplicar los cambios hechos en las preferencias."
 
-#: src/muuli_wdr.cpp:2253
+#: src/muuli_wdr.cpp:2225
 msgid "Reset any changes made to the preferences."
 msgstr "Cancelar los cambios hechos en las preferencias."
 
-#: src/muuli_wdr.cpp:2282
+#: src/muuli_wdr.cpp:2254
 msgid "Comment :"
 msgstr "Comentario:"
 
-#: src/muuli_wdr.cpp:2289
+#: src/muuli_wdr.cpp:2261
 msgid "Incoming Dir :"
 msgstr "Directorio entrante:"
 
-#: src/muuli_wdr.cpp:2298
+#: src/muuli_wdr.cpp:2270
 msgid "Change priority for new assigned files :"
 msgstr "Cambiar la prioridad de los nuevos archivos asignados:"
 
-#: src/muuli_wdr.cpp:2302
+#: src/muuli_wdr.cpp:2274
 msgid "Don't change"
 msgstr "No cambiar"
 
-#: src/muuli_wdr.cpp:2314
+#: src/muuli_wdr.cpp:2286
 msgid "Select color for this Category (currently selected) :"
 msgstr "Seleccione el color para esta categoría (actualmente seleccionado):"
 
-#: src/muuli_wdr.cpp:2381 src/muuli_wdr.cpp:2400 src/muuli_wdr.cpp:2422
+#: src/muuli_wdr.cpp:2353 src/muuli_wdr.cpp:2372 src/muuli_wdr.cpp:2394
 msgid "Click this button to reset the log."
 msgstr "Pulse este botón para borrar el registro."
 
-#: src/muuli_wdr.cpp:2441
+#: src/muuli_wdr.cpp:2413
 msgid "Click on this button to update the servers list from URL ..."
 msgstr "Pulse este botón para actualizar la lista de servidores desde un URL..."
 
-#: src/muuli_wdr.cpp:2445
+#: src/muuli_wdr.cpp:2417
 msgid "Server list"
 msgstr "Lista de servidores"
 
-#: src/muuli_wdr.cpp:2449
+#: src/muuli_wdr.cpp:2421
 msgid "Enter the url to a server.met file here and press the button to the left to update the list of known servers."
 msgstr "Introduzca la URL de un archivo server.met y pulse el botón de la izquierda para actualizar la lista de servidores conocidos."
 
-#: src/muuli_wdr.cpp:2454
+#: src/muuli_wdr.cpp:2426
 msgid "Add server manually: Name"
 msgstr "Añadir servidor manualmente: Nombre"
 
-#: src/muuli_wdr.cpp:2457
+#: src/muuli_wdr.cpp:2429
 msgid "Enter the name of the new server here"
 msgstr "Introduzca aquí el nombre del nuevo servidor"
 
-#: src/muuli_wdr.cpp:2459 src/ServerWnd.cpp:206
+#: src/muuli_wdr.cpp:2431 src/ServerWnd.cpp:206
 msgid "IP:Port"
 msgstr "IP:Puerto"
 
-#: src/muuli_wdr.cpp:2462
+#: src/muuli_wdr.cpp:2434
 msgid "Enter the IP of the server here, using the x.x.x.x format."
 msgstr "Introduzca aquí la IP del servidor, usando el formato \"x.x.x.x\"."
 
-#: src/muuli_wdr.cpp:2468
+#: src/muuli_wdr.cpp:2440
 msgid "Enter the port of the server here."
 msgstr "Introduzca el puerto del servidor."
 
-#: src/muuli_wdr.cpp:2471
+#: src/muuli_wdr.cpp:2443
 msgid "Add manually a server (fill fields to the left before) ..."
 msgstr "Añadir manualmente un servidor (rellene antes los campos de la izquierda)..."
 
-#: src/muuli_wdr.cpp:2500
+#: src/muuli_wdr.cpp:2472
 msgid "aMule Log"
 msgstr "Registro de aMule"
 
-#: src/muuli_wdr.cpp:2508
+#: src/muuli_wdr.cpp:2480
 msgid "Server Info"
 msgstr "Información del servidor"
 
-#: src/muuli_wdr.cpp:2512
+#: src/muuli_wdr.cpp:2484
 msgid "ED2K Info"
 msgstr "Información sobre ED2K"
 
-#: src/muuli_wdr.cpp:2516
+#: src/muuli_wdr.cpp:2488
 msgid "Kad Info"
 msgstr "Información sobre Kad"
 
-#: src/muuli_wdr.cpp:2544
+#: src/muuli_wdr.cpp:2516
 msgid "Click on this button to update the nodes list from URL ..."
 msgstr "Pulse este botón para actualizar la lista de nodos desde el URL..."
 
-#: src/muuli_wdr.cpp:2548
+#: src/muuli_wdr.cpp:2520
 msgid "Nodes (0)"
 msgstr "Nodos (0)"
 
-#: src/muuli_wdr.cpp:2552
+#: src/muuli_wdr.cpp:2524
 msgid "Enter the url to a nodes.dat file here and press the button to the left to update the list of known nodes."
 msgstr "Introduzca la URL del archivo nodes.dat y pulse el botón de la izquierda para actualizar la lista de nodos conocidos."
 
-#: src/muuli_wdr.cpp:2555
+#: src/muuli_wdr.cpp:2527
 msgid "Nodes stats"
 msgstr "Estadísticas de nodos"
 
-#: src/muuli_wdr.cpp:2597
+#: src/muuli_wdr.cpp:2569
 msgid "Bootstrap"
 msgstr "Inicialización"
 
-#: src/muuli_wdr.cpp:2600
+#: src/muuli_wdr.cpp:2572
 msgid "New node"
 msgstr "Nuevo nodo"
 
-#: src/muuli_wdr.cpp:2605
+#: src/muuli_wdr.cpp:2577
 msgid "IP:"
 msgstr "IP:"
 
-#: src/muuli_wdr.cpp:2625
+#: src/muuli_wdr.cpp:2597
 msgid "Port:"
 msgstr "Puerto:"
 
-#: src/muuli_wdr.cpp:2638
+#: src/muuli_wdr.cpp:2610
 msgid "Bootstrap from known clients"
 msgstr "Inicializar desde clientes conocidos"
 
-#: src/muuli_wdr.cpp:2640
+#: src/muuli_wdr.cpp:2612
 msgid "Disconnect Kad"
 msgstr "Desconectar Kad"
 
-#: src/muuli_wdr.cpp:2674
+#: src/muuli_wdr.cpp:2646
 msgid "Use Secure User Identification"
 msgstr "Usar la Identificación Segura de Usuario (ISU)"
 
-#: src/muuli_wdr.cpp:2676
+#: src/muuli_wdr.cpp:2648
 msgid "It is recommended to enable this option. You will not receive credits if SUI is not enabled."
 msgstr "Se recomienda activar esta opción. No recibirá créditos si la ISU no está habilitada."
 
-#: src/muuli_wdr.cpp:2678
+#: src/muuli_wdr.cpp:2650
 msgid "Protocol Obfuscation"
 msgstr "Ofuscación de protocolo"
 
-#: src/muuli_wdr.cpp:2681
+#: src/muuli_wdr.cpp:2653
 msgid "Support Protocol Obfuscation"
 msgstr "Permitir la ofuscación de protocolo"
 
-#: src/muuli_wdr.cpp:2683
+#: src/muuli_wdr.cpp:2655
 msgid "This option enabled Protocol Obfuscation, and makes aMule accept obfuscated connections from other clients."
 msgstr "Esta opción activa la ofuscación de protocolo y hace que aMule acepte conexiones ofuscadas de otros clientes."
 
-#: src/muuli_wdr.cpp:2685
+#: src/muuli_wdr.cpp:2657
 msgid "Use obfuscation for outgoing connections"
 msgstr "Usar la ofuscación para las conexiones salientes"
 
-#: src/muuli_wdr.cpp:2687
+#: src/muuli_wdr.cpp:2659
 msgid "This option makes aMule use Protocol Obfuscation when connecting other clients/servers."
 msgstr "Esta opción hace que aMule use la ofuscación de protocolo cuando se conecta a otros clientes/servidores."
 
-#: src/muuli_wdr.cpp:2689
+#: src/muuli_wdr.cpp:2661
 msgid "Accept only obfuscated connections"
 msgstr "Aceptar sólo conexiones ofuscadas"
 
-#: src/muuli_wdr.cpp:2690
+#: src/muuli_wdr.cpp:2662
 msgid "This option makes aMule only accept obfuscated connections. You will have less sources, but all your traffic will be obfuscated"
 msgstr "Esta opción hace que aMule sólo acepte conexiones ofuscadas. Tendrá menos fuentes, pero todo su tráfico estará ofuscado"
 
-#: src/muuli_wdr.cpp:2695
+#: src/muuli_wdr.cpp:2667
 msgid "Everybody"
 msgstr "Todos"
 
-#: src/muuli_wdr.cpp:2697
+#: src/muuli_wdr.cpp:2669
 msgid "No one"
 msgstr "Nadie"
 
-#: src/muuli_wdr.cpp:2699
+#: src/muuli_wdr.cpp:2671
 msgid "Who can see my shared files:"
 msgstr "Quién puede ver mis archivos compartidos:"
 
-#: src/muuli_wdr.cpp:2700
+#: src/muuli_wdr.cpp:2672
 msgid "Select who can request to view a list of your shared files."
 msgstr "Seleccione quién puede solicitar ver la lista de sus archivos compartidos."
 
-#: src/muuli_wdr.cpp:2702
+#: src/muuli_wdr.cpp:2674
 msgid "IP-Filtering"
 msgstr "Filtrado de direcciones IP"
 
-#: src/muuli_wdr.cpp:2709
+#: src/muuli_wdr.cpp:2681
 msgid "Filter clients"
 msgstr "Filtrar los clientes"
 
-#: src/muuli_wdr.cpp:2711
+#: src/muuli_wdr.cpp:2683
 msgid "Enable filtering of the client IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "Habilitar el filtrado de las IP de clientes definidas en el archivo ~/.aMule/ipfilter.dat."
 
-#: src/muuli_wdr.cpp:2713
+#: src/muuli_wdr.cpp:2685
 msgid "Filter servers"
 msgstr "Filtrar los servidores"
 
-#: src/muuli_wdr.cpp:2715
+#: src/muuli_wdr.cpp:2687
 msgid "Enable filtering of the server IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "Habilitar el filtrado de las IP de servidores definidas en el archivo ~/.aMule/ipfilter.dat."
 
-#: src/muuli_wdr.cpp:2719
+#: src/muuli_wdr.cpp:2691
 msgid "Reload List"
 msgstr "Recargar la lista"
 
-#: src/muuli_wdr.cpp:2720
+#: src/muuli_wdr.cpp:2692
 msgid "Reload the list of IPs to filter from the file ~/.aMule/ipfilter.dat"
 msgstr "Recargar la lista de filtrado de IP desde el archivo ~/.aMule/ipfilter.dat"
 
-#: src/muuli_wdr.cpp:2726
+#: src/muuli_wdr.cpp:2698
 msgid "URL:"
 msgstr "URL:"
 
-#: src/muuli_wdr.cpp:2730 src/muuli_wdr.cpp:2923
+#: src/muuli_wdr.cpp:2702 src/muuli_wdr.cpp:2895
 msgid "Update now"
 msgstr "Actualizar ahora"
 
-#: src/muuli_wdr.cpp:2733
+#: src/muuli_wdr.cpp:2705
 msgid "Auto-update ipfilter at startup"
 msgstr "Autoactualizar el filtro de IP al inicio"
 
-#: src/muuli_wdr.cpp:2737
+#: src/muuli_wdr.cpp:2709
 msgid "Filtering Level:"
 msgstr "Nivel de filtrado:"
 
-#: src/muuli_wdr.cpp:2743
+#: src/muuli_wdr.cpp:2715
 msgid "Always filter LAN IPs"
 msgstr "Filtrar siempre las IP de LAN"
 
-#: src/muuli_wdr.cpp:2746
+#: src/muuli_wdr.cpp:2718
 msgid "Paranoid handling of non-matching IPs"
 msgstr "Gestión paranoica de las IP que no coincidan"
 
-#: src/muuli_wdr.cpp:2748
+#: src/muuli_wdr.cpp:2720
 msgid "Rejects a packet when its source IP differs from the IP the client claims (an anti-spoofing check). Disable only if it causes connection problems."
 msgstr "Rechaza un paquete cuando su IP de origen es diferente de la IP que el cliente dice tener (comprobación anti-suplantación). Desactivar sólo si causa problemas de conexión."
 
-#: src/muuli_wdr.cpp:2750
+#: src/muuli_wdr.cpp:2722
 msgid "Use system-wide ipfilter.dat if available"
 msgstr "Usar el ipfilter.dat del sistema si está disponible"
 
-#: src/muuli_wdr.cpp:2751
+#: src/muuli_wdr.cpp:2723
 msgid "If there's no local ipfilter.dat found, allow usage of a system-wide ipfilter file."
 msgstr "Si no hay un archivo ipfilter.dat local, permitir el uso de un archivo ipfilter del sistema."
 
-#: src/muuli_wdr.cpp:2768
+#: src/muuli_wdr.cpp:2740
 msgid "Enable Online-Signature"
 msgstr "Habilitar la firma digital"
 
-#: src/muuli_wdr.cpp:2770
+#: src/muuli_wdr.cpp:2742
 msgid "Enables the writing of the OS file, which can be used by external apps to create signatures and the like."
 msgstr "Habilita la escritura de archivos de firma digital, algo que puede ser usado por las aplicaciones externas para crear firmas y cosas parecidas."
 
-#: src/muuli_wdr.cpp:2774
+#: src/muuli_wdr.cpp:2746
 msgid "Update Frequency (Secs):"
 msgstr "Frecuencia de actualización (segundos):"
 
-#: src/muuli_wdr.cpp:2777
+#: src/muuli_wdr.cpp:2749
 msgid "Change the frequency (in seconds) of Online Signature updates."
 msgstr "Cambiar la frecuencia (en segundos) de actualización de la firma digital."
 
-#: src/muuli_wdr.cpp:2785
+#: src/muuli_wdr.cpp:2757
 msgid "Save online signature file in: "
 msgstr "Guardar el archivo de firma digital en: "
 
-#: src/muuli_wdr.cpp:2791
+#: src/muuli_wdr.cpp:2763
 msgid "Click here to select the directory containing the the Online Signature files."
 msgstr "Pulse aquí para seleccionar el directorio que contiene los archivos de firmas digitales."
 
-#: src/muuli_wdr.cpp:2824
+#: src/muuli_wdr.cpp:2796
 msgid "Show country flags for clients"
 msgstr "Mostrar las banderas de los países para los clientes"
 
-#: src/muuli_wdr.cpp:2825
+#: src/muuli_wdr.cpp:2797
 msgid "Render the country flag column in the transfers, queue and search views. Requires a valid MMDB GeoIP database (see below)."
 msgstr "Mostrar la columna de la bandera del país en las vistas de transferencias, cola y búsqueda. Requiere una base de datos MMDB GeoIP válida (ver más abajo)."
 
-#: src/muuli_wdr.cpp:2830
+#: src/muuli_wdr.cpp:2802
 msgid "Database"
 msgstr "Base de datos"
 
-#: src/muuli_wdr.cpp:2846
+#: src/muuli_wdr.cpp:2818
 msgid "Source:"
 msgstr "Fuente:"
 
-#: src/muuli_wdr.cpp:2849
+#: src/muuli_wdr.cpp:2821
 msgid "DB-IP (free, no account)"
 msgstr "DB-IP (gratis, sin crear una cuenta)"
 
-#: src/muuli_wdr.cpp:2850
+#: src/muuli_wdr.cpp:2822
 msgid "MaxMind GeoLite2 (free, account required)"
 msgstr "MaxMind GeoLite2 (gratuito, requiere crear una cuenta)"
 
-#: src/muuli_wdr.cpp:2851
+#: src/muuli_wdr.cpp:2823
 msgid "Custom URL"
 msgstr "URL personalizada"
 
-#: src/muuli_wdr.cpp:2854
+#: src/muuli_wdr.cpp:2826
 msgid "Choose which provider supplies the GeoIP MMDB database. DB-IP is the default - no account required. MaxMind requires a free account + license key. Use Custom URL to point at any other MMDB host (e.g. a local mirror)."
 msgstr "Elige qué proveedor ofrece la base de datos GeoIP MMDB. DB-IP es la opción predeterminada; no se necesita cuenta. MaxMind requiere una cuenta gratuita y una clave de licencia. Utiliza la opción 'URL personalizada' para indicar cualquier otro servidor MMDB (por ejemplo, un servidor espejo local)."
 
-#: src/muuli_wdr.cpp:2871
+#: src/muuli_wdr.cpp:2843
 msgid ""
 "No configuration required.\n"
 "\n"
@@ -4858,11 +4824,11 @@ msgstr ""
 "Datos IP-País de DB-IP.com - https://db-ip.com\n"
 "Licencia: Creative Commons BY 4.0 - https://creativecommons.org/licenses/by/4.0/"
 
-#: src/muuli_wdr.cpp:2884
+#: src/muuli_wdr.cpp:2856
 msgid "License key:"
 msgstr "Clave de licencia:"
 
-#: src/muuli_wdr.cpp:2890
+#: src/muuli_wdr.cpp:2862
 msgid ""
 "Sign up for a free MaxMind account, then generate a License Key:\n"
 "https://www.maxmind.com/en/geolite2/signup\n"
@@ -4878,11 +4844,11 @@ msgstr ""
 "Licencia: EULA de MaxMind GeoLite2 - https://www.maxmind.com/en/geolite2/eula\n"
 "Requiere la atribución de la fuente y el registro de una cuenta; actualizar al menos cada 30 días."
 
-#: src/muuli_wdr.cpp:2905
+#: src/muuli_wdr.cpp:2877
 msgid "Download URL:"
 msgstr "URL de descarga:"
 
-#: src/muuli_wdr.cpp:2911
+#: src/muuli_wdr.cpp:2883
 msgid ""
 "Must point to an .mmdb file or a .gz / .tar.gz containing one.\n"
 "URL may include credentials (https://user:pass@host/...).\n"
@@ -4892,211 +4858,211 @@ msgstr ""
 "La URL puede incluir credenciales (https://user:pass@host/...).\n"
 "Las condiciones de licencia y atribución dependen de la URL de descarga; la responsabilidad recae en ti."
 
-#: src/muuli_wdr.cpp:2924
+#: src/muuli_wdr.cpp:2896
 msgid "Download the GeoIP database from the selected source."
 msgstr "Descarga la base de datos GeoIP de la fuente seleccionada."
 
-#: src/muuli_wdr.cpp:2926
+#: src/muuli_wdr.cpp:2898
 msgid "Auto-update on startup"
 msgstr "Autoactualizar al inicio"
 
-#: src/muuli_wdr.cpp:2927
+#: src/muuli_wdr.cpp:2899
 msgid "Re-download the GeoIP database from the selected source every time aMule starts."
 msgstr "Vuelve a descargar la base de datos GeoIP desde la fuente seleccionada cada vez que se inicie aMule."
 
-#: src/muuli_wdr.cpp:2950
+#: src/muuli_wdr.cpp:2922
 msgid "Filter incoming messages (except current chat):"
 msgstr "Filtrar los mensajes entrantes (salvo la conversación actual):"
 
-#: src/muuli_wdr.cpp:2952
+#: src/muuli_wdr.cpp:2924
 msgid "Filter all messages"
 msgstr "Filtrar todos los mensajes"
 
-#: src/muuli_wdr.cpp:2954
+#: src/muuli_wdr.cpp:2926
 msgid "Filter messages from people not on your friend list"
 msgstr "Filtrar los mensajes de gente que no esté en su lista de amigos"
 
-#: src/muuli_wdr.cpp:2956
+#: src/muuli_wdr.cpp:2928
 msgid "Filter messages from unknown clients"
 msgstr "Filtrar los mensajes de clientes desconocidos"
 
-#: src/muuli_wdr.cpp:2958
+#: src/muuli_wdr.cpp:2930
 msgid "Filter messages containing (use ',' as separator):"
 msgstr "Filtrar los mensajes que contengan (use ',' como separador):"
 
-#: src/muuli_wdr.cpp:2961 src/muuli_wdr.cpp:2972
+#: src/muuli_wdr.cpp:2933 src/muuli_wdr.cpp:2944
 msgid "add here the words amule should filter and block messages including it"
 msgstr "añada aquí las palabras que amule debe filtrar para bloquear los mensajes que las incluyan"
 
-#: src/muuli_wdr.cpp:2963
+#: src/muuli_wdr.cpp:2935
 msgid "Show received messages in the log"
 msgstr "Mostrar los mensajes recibidos en el registro"
 
-#: src/muuli_wdr.cpp:2966
+#: src/muuli_wdr.cpp:2938
 msgid "Comments"
 msgstr "Comentarios"
 
-#: src/muuli_wdr.cpp:2969
+#: src/muuli_wdr.cpp:2941
 msgid "Filter comments containing (use ',' as separator):"
 msgstr "Filtrar los comentarios que contengan (use ',' como separador):"
 
-#: src/muuli_wdr.cpp:2994
+#: src/muuli_wdr.cpp:2966
 msgid "Enable Proxy"
 msgstr "Habilitar el proxy"
 
-#: src/muuli_wdr.cpp:2995
+#: src/muuli_wdr.cpp:2967
 msgid "Enable/disable proxy support"
 msgstr "Habilitar/deshabilitar el soporte para proxy"
 
-#: src/muuli_wdr.cpp:2998
+#: src/muuli_wdr.cpp:2970
 msgid "Proxy type:"
 msgstr "Tipo de proxy:"
 
-#: src/muuli_wdr.cpp:3009
+#: src/muuli_wdr.cpp:2981
 msgid "Proxy host:"
 msgstr "Servidor proxy:"
 
-#: src/muuli_wdr.cpp:3012
+#: src/muuli_wdr.cpp:2984
 msgid "The proxy host name"
 msgstr "Nombre del host del proxy"
 
-#: src/muuli_wdr.cpp:3014
+#: src/muuli_wdr.cpp:2986
 msgid "Proxy port:"
 msgstr "Puerto del proxy:"
 
-#: src/muuli_wdr.cpp:3017
+#: src/muuli_wdr.cpp:2989
 msgid "The proxy port"
 msgstr "El puerto del proxy"
 
-#: src/muuli_wdr.cpp:3019
+#: src/muuli_wdr.cpp:2991
 msgid "Enable authentication"
 msgstr "Habilitar la autentificación"
 
-#: src/muuli_wdr.cpp:3020
+#: src/muuli_wdr.cpp:2992
 msgid "Enable/disable username/password authentication"
 msgstr "Habilitar/deshabilitar la autenticación mediante usuario/contraseña"
 
-#: src/muuli_wdr.cpp:3023
+#: src/muuli_wdr.cpp:2995
 msgid "Username: "
 msgstr "Nombre de usuario: "
 
-#: src/muuli_wdr.cpp:3026
+#: src/muuli_wdr.cpp:2998
 msgid "The username to use to connect to the proxy"
 msgstr "El nombre de usuario a usar para conectar al proxy"
 
-#: src/muuli_wdr.cpp:3028
+#: src/muuli_wdr.cpp:3000
 msgid "Password:"
 msgstr "Contraseña:"
 
-#: src/muuli_wdr.cpp:3031
+#: src/muuli_wdr.cpp:3003
 msgid "The password to use to connect to the proxy"
 msgstr "La contraseña a usar para conectar al proxy"
 
-#: src/muuli_wdr.cpp:3050
+#: src/muuli_wdr.cpp:3022
 msgid "Connect to:"
 msgstr "Conectar a:"
 
-#: src/muuli_wdr.cpp:3059
+#: src/muuli_wdr.cpp:3031
 msgid "Login to remote amule"
 msgstr "Conexión a aMule remoto"
 
-#: src/muuli_wdr.cpp:3064
+#: src/muuli_wdr.cpp:3036
 msgid "User name"
 msgstr "Nombre de usuario"
 
-#: src/muuli_wdr.cpp:3075
+#: src/muuli_wdr.cpp:3047
 msgid "Remember those settings"
 msgstr "Recordar estas opciones"
 
-#: src/muuli_wdr.cpp:3078
+#: src/muuli_wdr.cpp:3050
 msgid "Force ZLIB compression"
 msgstr "Forzar compresión ZLIB"
 
-#: src/muuli_wdr.cpp:3102
+#: src/muuli_wdr.cpp:3074
 msgid "Enable Verbose Debug-Logging."
 msgstr "Habilitar el modo detallado de depuración."
 
-#: src/muuli_wdr.cpp:3104
+#: src/muuli_wdr.cpp:3076
 msgid "Only to Logfile"
 msgstr "Sólo al archivo de registro"
 
-#: src/muuli_wdr.cpp:3106
+#: src/muuli_wdr.cpp:3078
 msgid "Message Categories:"
 msgstr "Categorías de mensajes:"
 
-#: src/muuli_wdr.cpp:3130 src/PartFileConvertDlg.cpp:160
+#: src/muuli_wdr.cpp:3102 src/PartFileConvertDlg.cpp:160
 msgid "Waiting..."
 msgstr "Esperando..."
 
-#: src/muuli_wdr.cpp:3150
+#: src/muuli_wdr.cpp:3122
 msgid "Add imports"
 msgstr "Añadir lo importado"
 
-#: src/muuli_wdr.cpp:3153
+#: src/muuli_wdr.cpp:3125
 msgid "Retry selected"
 msgstr "Reintentar seleccionado"
 
-#: src/muuli_wdr.cpp:3155
+#: src/muuli_wdr.cpp:3127
 msgid "Remove selected"
 msgstr "Borrar seleccionado"
 
-#: src/muuli_wdr.cpp:3218
+#: src/muuli_wdr.cpp:3190
 msgid "Event Types"
 msgstr "Tipos de evento"
 
-#: src/muuli_wdr.cpp:3237
+#: src/muuli_wdr.cpp:3209
 msgid "Statistics and queued clients for selected file(s) : Session / All time"
 msgstr "Estadísticas y clientes en la cola para los archivos seleccionados: Sesión / Total"
 
-#: src/muuli_wdr.cpp:3261
+#: src/muuli_wdr.cpp:3233
 msgid "Active Uploads"
 msgstr "Subidas activas"
 
-#: src/muuli_wdr.cpp:3275
+#: src/muuli_wdr.cpp:3247
 msgid "Percent of total files"
 msgstr "Porcentaje del total de archivos"
 
-#: src/muuli_wdr.cpp:3327
+#: src/muuli_wdr.cpp:3299
 msgid "Show Clients for"
 msgstr "Mostrar los clientes para"
 
-#: src/muuli_wdr.cpp:3329
+#: src/muuli_wdr.cpp:3301
 msgid "All files"
 msgstr "Todos los archivos"
 
-#: src/muuli_wdr.cpp:3332
+#: src/muuli_wdr.cpp:3304
 msgid "Selected files"
 msgstr "Archivos seleccionados"
 
-#: src/muuli_wdr.cpp:3335
+#: src/muuli_wdr.cpp:3307
 msgid "Active uploads only"
 msgstr "Solo las subidas activas"
 
-#: src/muuli_wdr.cpp:3342
+#: src/muuli_wdr.cpp:3314
 msgid "Reload:"
 msgstr "Recargar:"
 
-#: src/muuli_wdr.cpp:3346
+#: src/muuli_wdr.cpp:3318
 msgid "Reload your shared files"
 msgstr "Recargar los archivos compartidos"
 
-#: src/muuli_wdr.cpp:3409
+#: src/muuli_wdr.cpp:3381
 msgid "Send"
 msgstr "Enviar"
 
-#: src/muuli_wdr.cpp:3410
+#: src/muuli_wdr.cpp:3382
 msgid "Sends the specified message."
 msgstr "Envía el mensaje especificado."
 
-#: src/muuli_wdr.cpp:3414
+#: src/muuli_wdr.cpp:3386
 msgid "Close this chat-session."
 msgstr "Cerrar esta sesión de chat."
 
-#: src/muuli_wdr.cpp:3437
+#: src/muuli_wdr.cpp:3409
 msgid "Connect to any server and/or Kad"
 msgstr "Conectar a cualquier servidor y/o a Kad"
 
-#: src/muuli_wdr.cpp:3443 src/SharedFilesCtrl.cpp:142 src/Statistics.cpp:941
+#: src/muuli_wdr.cpp:3415 src/SharedFilesCtrl.cpp:142 src/Statistics.cpp:941
 msgid "Shared Files"
 msgstr "Compartidos"
 
@@ -5456,248 +5422,248 @@ msgstr "Descargado"
 msgid "ERROR: Failed to open partfile '%s'"
 msgstr "ERROR: no se ha podido abrir el archivo de partes '%s'"
 
-#: src/Preferences.cpp:701
+#: src/Preferences.cpp:673
 msgid "System default"
 msgstr "Por defecto"
 
-#: src/Preferences.cpp:702
+#: src/Preferences.cpp:674
 msgid "Albanian"
 msgstr "Albanés"
 
-#: src/Preferences.cpp:703
+#: src/Preferences.cpp:675
 msgid "Arabic"
 msgstr "Árabe"
 
-#: src/Preferences.cpp:704
+#: src/Preferences.cpp:676
 msgid "Asturian"
 msgstr "Asturiano"
 
-#: src/Preferences.cpp:705
+#: src/Preferences.cpp:677
 msgid "Basque"
 msgstr "Euskera"
 
-#: src/Preferences.cpp:706
+#: src/Preferences.cpp:678
 msgid "Bulgarian"
 msgstr "Búlgaro"
 
-#: src/Preferences.cpp:707
+#: src/Preferences.cpp:679
 msgid "Catalan"
 msgstr "Catalán"
 
-#: src/Preferences.cpp:708
+#: src/Preferences.cpp:680
 msgid "Chinese (Simplified)"
 msgstr "Chino (simplificado)"
 
-#: src/Preferences.cpp:709
+#: src/Preferences.cpp:681
 msgid "Chinese (Traditional)"
 msgstr "Chino (tradicional)"
 
-#: src/Preferences.cpp:710
+#: src/Preferences.cpp:682
 msgid "Croatian"
 msgstr "Croata"
 
-#: src/Preferences.cpp:711
+#: src/Preferences.cpp:683
 msgid "Czech"
 msgstr "Checo"
 
-#: src/Preferences.cpp:712
+#: src/Preferences.cpp:684
 msgid "Danish"
 msgstr "Danés"
 
-#: src/Preferences.cpp:713
+#: src/Preferences.cpp:685
 msgid "Dutch"
 msgstr "Holandés"
 
-#: src/Preferences.cpp:714
+#: src/Preferences.cpp:686
 msgid "English (U.K.)"
 msgstr "Inglés (Reino Unido)"
 
-#: src/Preferences.cpp:715
+#: src/Preferences.cpp:687
 msgid "English (U.S.)"
 msgstr "Inglés (EE.UU.)"
 
-#: src/Preferences.cpp:716
+#: src/Preferences.cpp:688
 msgid "Estonian"
 msgstr "Estonio"
 
-#: src/Preferences.cpp:717
+#: src/Preferences.cpp:689
 msgid "Finnish"
 msgstr "Finés"
 
-#: src/Preferences.cpp:718
+#: src/Preferences.cpp:690
 msgid "French"
 msgstr "Francés"
 
-#: src/Preferences.cpp:719
+#: src/Preferences.cpp:691
 msgid "Galician"
 msgstr "Gallego"
 
-#: src/Preferences.cpp:720
+#: src/Preferences.cpp:692
 msgid "German"
 msgstr "Alemán"
 
-#: src/Preferences.cpp:721
+#: src/Preferences.cpp:693
 msgid "Greek"
 msgstr "Griego"
 
-#: src/Preferences.cpp:722
+#: src/Preferences.cpp:694
 msgid "Hebrew"
 msgstr "Hebreo"
 
-#: src/Preferences.cpp:723
+#: src/Preferences.cpp:695
 msgid "Hungarian"
 msgstr "Húngaro"
 
-#: src/Preferences.cpp:724
+#: src/Preferences.cpp:696
 msgid "Italian"
 msgstr "Italiano"
 
-#: src/Preferences.cpp:725
+#: src/Preferences.cpp:697
 msgid "Japanese"
 msgstr "Japonés"
 
-#: src/Preferences.cpp:726
+#: src/Preferences.cpp:698
 msgid "Korean"
 msgstr "Coreano"
 
-#: src/Preferences.cpp:727
+#: src/Preferences.cpp:699
 msgid "Latvian"
 msgstr "Letón"
 
-#: src/Preferences.cpp:728
+#: src/Preferences.cpp:700
 msgid "Lithuanian"
 msgstr "Lituano"
 
-#: src/Preferences.cpp:729
+#: src/Preferences.cpp:701
 msgid "Norwegian (Nynorsk)"
 msgstr "Noruego (Nynorsk)"
 
-#: src/Preferences.cpp:730
+#: src/Preferences.cpp:702
 msgid "Polish"
 msgstr "Polaco"
 
-#: src/Preferences.cpp:731
+#: src/Preferences.cpp:703
 msgid "Portuguese"
 msgstr "Portugués"
 
-#: src/Preferences.cpp:732
+#: src/Preferences.cpp:704
 msgid "Portuguese (Brazilian)"
 msgstr "Portugués (brasileño)"
 
-#: src/Preferences.cpp:733
+#: src/Preferences.cpp:705
 msgid "Romanian"
 msgstr "Rumano"
 
-#: src/Preferences.cpp:734
+#: src/Preferences.cpp:706
 msgid "Russian"
 msgstr "Ruso"
 
-#: src/Preferences.cpp:735
+#: src/Preferences.cpp:707
 msgid "Slovenian"
 msgstr "Esloveno"
 
-#: src/Preferences.cpp:736
+#: src/Preferences.cpp:708
 msgid "Spanish"
 msgstr "Español"
 
-#: src/Preferences.cpp:737
+#: src/Preferences.cpp:709
 msgid "Swedish"
 msgstr "Sueco"
 
-#: src/Preferences.cpp:738
+#: src/Preferences.cpp:710
 msgid "Turkish"
 msgstr "Turco"
 
-#: src/Preferences.cpp:739
+#: src/Preferences.cpp:711
 msgid "Ukrainian"
 msgstr "Ucraniano"
 
-#: src/Preferences.cpp:842
+#: src/Preferences.cpp:814
 msgid "Change Language"
 msgstr "Cambiar el idioma"
 
-#: src/Preferences.cpp:906
+#: src/Preferences.cpp:878
 msgid "There are no translations installed for aMule"
 msgstr "No hay traducciones instaladas para aMule"
 
-#: src/Preferences.cpp:907
+#: src/Preferences.cpp:879
 msgid "No languages available"
 msgstr "No hay idiomas disponibles"
 
-#: src/Preferences.cpp:1038
+#: src/Preferences.cpp:1010
 msgid "no options available"
 msgstr "no hay opciones disponibles"
 
-#: src/Preferences.cpp:2226
+#: src/Preferences.cpp:2179
 msgid "Invalid category found, skipping"
 msgstr "Categoría inválida encontrada, se omite"
 
-#: src/Preferences.cpp:2395
+#: src/Preferences.cpp:2348
 msgid "TCP port can't be higher than 65532 due to server UDP socket being TCP+3"
 msgstr "El puerto TCP no puede ser mayor que 65532 debido a que el socket del servidor UDP es TCP+3"
 
-#: src/Preferences.cpp:2396
+#: src/Preferences.cpp:2349
 #, c-format
 msgid "Default port will be used (%d)"
 msgstr "Puerto por defecto que será usado (%d)"
 
-#: src/PrefsUnifiedDlg.cpp:300 src/Statistics.cpp:866
+#: src/PrefsUnifiedDlg.cpp:298 src/Statistics.cpp:866
 msgid "Connection"
 msgstr "Conexión"
 
-#: src/PrefsUnifiedDlg.cpp:301 src/SearchListCtrl.cpp:117
+#: src/PrefsUnifiedDlg.cpp:299 src/SearchListCtrl.cpp:117
 msgid "Directories"
 msgstr "Directorios"
 
-#: src/PrefsUnifiedDlg.cpp:302 src/Statistics.cpp:917
+#: src/PrefsUnifiedDlg.cpp:300 src/Statistics.cpp:917
 msgid "Servers"
 msgstr "Servidores"
 
-#: src/PrefsUnifiedDlg.cpp:303 src/ServerListCtrl.cpp:96
+#: src/PrefsUnifiedDlg.cpp:301 src/ServerListCtrl.cpp:96
 msgid "Files"
 msgstr "Archivos"
 
-#: src/PrefsUnifiedDlg.cpp:304
+#: src/PrefsUnifiedDlg.cpp:302
 msgid "Security"
 msgstr "Seguridad"
 
-#: src/PrefsUnifiedDlg.cpp:305
+#: src/PrefsUnifiedDlg.cpp:303
 msgid "Interface"
 msgstr "Interfaz"
 
-#: src/PrefsUnifiedDlg.cpp:312
+#: src/PrefsUnifiedDlg.cpp:310
 msgid "IP2Country"
 msgstr "IP2Country"
 
-#: src/PrefsUnifiedDlg.cpp:315
+#: src/PrefsUnifiedDlg.cpp:313
 msgid "Proxy"
 msgstr "Proxy"
 
-#: src/PrefsUnifiedDlg.cpp:316
+#: src/PrefsUnifiedDlg.cpp:314
 msgid "Filters"
 msgstr "Filtros"
 
-#: src/PrefsUnifiedDlg.cpp:317
+#: src/PrefsUnifiedDlg.cpp:315
 msgid "Remote Controls"
 msgstr "Controles remotos"
 
-#: src/PrefsUnifiedDlg.cpp:318
+#: src/PrefsUnifiedDlg.cpp:316
 msgid "Online Signature"
 msgstr "Firma digital"
 
-#: src/PrefsUnifiedDlg.cpp:319
+#: src/PrefsUnifiedDlg.cpp:317
 msgid "Advanced"
 msgstr "Avanzado"
 
-#: src/PrefsUnifiedDlg.cpp:320
+#: src/PrefsUnifiedDlg.cpp:318
 msgid "Events"
 msgstr "Eventos"
 
-#: src/PrefsUnifiedDlg.cpp:323
+#: src/PrefsUnifiedDlg.cpp:321
 msgid "Debugging"
 msgstr "Depurando"
 
-#: src/PrefsUnifiedDlg.cpp:453
+#: src/PrefsUnifiedDlg.cpp:451
 msgid ""
 "The following variables will be substituted:\n"
 "    %PARTFILE - full path to the file\n"
@@ -5707,15 +5673,15 @@ msgstr ""
 "    %PARTFILE - ruta completa al archivo\n"
 "    %PARTNAME - nombre del archivo"
 
-#: src/PrefsUnifiedDlg.cpp:474
+#: src/PrefsUnifiedDlg.cpp:472
 msgid "Tray icon support requires libayatana-appindicator3 at compile time."
 msgstr "El icono de la bandeja requiere libayatana-appindicator3 en tiempo de compilación."
 
-#: src/PrefsUnifiedDlg.cpp:490
+#: src/PrefsUnifiedDlg.cpp:488
 msgid "Not available on Wayland: the protocol does not report when a window is minimized, so this option cannot intercept the system minimize button. Workaround: launch aMule with `GDK_BACKEND=x11` to use XWayland instead."
 msgstr "No disponible en Wayland: el protocolo no informa cuando una ventana es minimizada, por lo que esta opción no puede interceptar el botón de minimizar del sistema. Como alternativa: lanzar aMule con `GDK_BACKEND=x11` para usar XWayland."
 
-#: src/PrefsUnifiedDlg.cpp:536
+#: src/PrefsUnifiedDlg.cpp:534
 msgid ""
 "Do not change these setting unless you know\n"
 "what you are doing, otherwise you can easily\n"
@@ -5731,35 +5697,26 @@ msgstr ""
 "aMule funciona bien sin cambiar ninguno de\n"
 "estos parámetros."
 
-#: src/PrefsUnifiedDlg.cpp:647
+#: src/PrefsUnifiedDlg.cpp:645
 #, c-format
 msgid "Failed to connect Cfg to widget with the ID %d and key %s"
 msgstr "Error al conectar configuración con programa, con el ID %d y clave %s"
 
-#: src/PrefsUnifiedDlg.cpp:695
+#: src/PrefsUnifiedDlg.cpp:693
 #, c-format
 msgid "Failed to transfer data from Cfg to Widget with the ID %d and key %s"
 msgstr "Error al transferir datos desde la configuración al programa, con el ID %d y la clave %s"
 
-#: src/PrefsUnifiedDlg.cpp:801
+#: src/PrefsUnifiedDlg.cpp:799
 msgid "The type of proxy you are connecting to"
 msgstr "El tipo de proxy al que se está conectando"
 
-#: src/PrefsUnifiedDlg.cpp:1020
+#: src/PrefsUnifiedDlg.cpp:1003
 #, c-format
 msgid "Failed to transfer data from Widget to Cfg with the ID %d and key %s"
 msgstr "Error al transferir datos desde el programa a la configuración, con el ID %d y la clave %s"
 
 #: src/PrefsUnifiedDlg.cpp:1103
-#, fuzzy
-msgid "No password set."
-msgstr "Contraseña Admin"
-
-#: src/PrefsUnifiedDlg.cpp:1132
-msgid "Guest access needs a password. Type one in the guest password field, or untick Enable guest access."
-msgstr ""
-
-#: src/PrefsUnifiedDlg.cpp:1144
 msgid ""
 "aMule must be restarted to enable these changes:\n"
 "\n"
@@ -5767,39 +5724,39 @@ msgstr ""
 "aMule debe reiniciarse para aplicar los cambios:\n"
 "\n"
 
-#: src/PrefsUnifiedDlg.cpp:1151
+#: src/PrefsUnifiedDlg.cpp:1110
 msgid "- TCP port changed.\n"
 msgstr "- El puerto TCP ha cambiado.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1156
+#: src/PrefsUnifiedDlg.cpp:1115
 msgid "- UDP port changed.\n"
 msgstr "- El puerto UDP ha cambiado.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1161
+#: src/PrefsUnifiedDlg.cpp:1120
 msgid "- Network interface binding changed.\n"
 msgstr "- La interfaz de red vinculada ha cambiado.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1166
+#: src/PrefsUnifiedDlg.cpp:1125
 msgid "- External connect port changed.\n"
 msgstr "- El puerto para la conexión externa ha cambiado.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1170
+#: src/PrefsUnifiedDlg.cpp:1129
 msgid "- External connect acceptance changed.\n"
 msgstr "- La aceptación de conexión externa ha cambiado.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1174
+#: src/PrefsUnifiedDlg.cpp:1133
 msgid "- External connect interface changed.\n"
 msgstr "- La interfaz de conexión externa ha cambiado.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1178
+#: src/PrefsUnifiedDlg.cpp:1137
 msgid "- Protocol obfuscation support changed.\n"
 msgstr "- El soporte de ofuscación de protocolo ha cambiado.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1193
+#: src/PrefsUnifiedDlg.cpp:1151
 msgid "- amuleapi settings changed.\n"
 msgstr "- Ajustes de amuleapi modificados.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1202
+#: src/PrefsUnifiedDlg.cpp:1160
 msgid ""
 "Your Auto-update server list is empty.\n"
 "'Auto-update server list at startup' will be disabled."
@@ -5807,7 +5764,7 @@ msgstr ""
 "Su lista autoactualizable de servidores esta vacía.\n"
 "Se desactivará 'Autoactualizar la lista de servidores al inicio'."
 
-#: src/PrefsUnifiedDlg.cpp:1213
+#: src/PrefsUnifiedDlg.cpp:1171
 msgid ""
 "You have enabled external connections but have not specified a password.\n"
 "External connections cannot be enabled unless a valid password is specified."
@@ -5815,32 +5772,27 @@ msgstr ""
 "Tiene habilitadas las conexiones externas, pero no ha especificado ninguna contraseña.\n"
 "Las conexiones externas no pueden ser habilitadas a menos que especifique una contraseña válida."
 
-#: src/PrefsUnifiedDlg.cpp:1246
-#, c-format
-msgid "The amuleapi password could not be saved: %s"
-msgstr ""
-
-#: src/PrefsUnifiedDlg.cpp:1276
+#: src/PrefsUnifiedDlg.cpp:1202
 msgid "- Language changed.\n"
 msgstr "- Idioma cambiado.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1281
+#: src/PrefsUnifiedDlg.cpp:1207
 msgid "- Temp folder changed.\n"
 msgstr "- Carpeta temporal cambiada.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1286
+#: src/PrefsUnifiedDlg.cpp:1212
 msgid "- ED2K network enabled.\n"
 msgstr "- Red ED2K habilitada.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1319
+#: src/PrefsUnifiedDlg.cpp:1245
 msgid "The shared-file exclusion pattern is not a valid regular expression. The filter has been left disabled."
 msgstr "El patrón de exclusión de archivos compartidos no es una expresión regular válida. El filtro ha quedado deshabilitado."
 
-#: src/PrefsUnifiedDlg.cpp:1321 src/PrefsUnifiedDlg.cpp:1921
+#: src/PrefsUnifiedDlg.cpp:1247 src/PrefsUnifiedDlg.cpp:1841
 msgid "Invalid regular expression"
 msgstr "Expresión regular no válida"
 
-#: src/PrefsUnifiedDlg.cpp:1398
+#: src/PrefsUnifiedDlg.cpp:1324
 msgid ""
 "Both eD2k and Kad network are disabled.\n"
 "You won't be able to connect until you enable at least one of them."
@@ -5848,7 +5800,7 @@ msgstr ""
 "eD2k y Kad están desactivados.\n"
 "No podrá conectarse hasta que active al menos uno de ellos."
 
-#: src/PrefsUnifiedDlg.cpp:1403
+#: src/PrefsUnifiedDlg.cpp:1329
 msgid ""
 "Kad will not start if your UDP port is disabled.\n"
 "Enable UDP port or disable Kad."
@@ -5856,7 +5808,7 @@ msgstr ""
 "Kad no se inicia si el puerto UDP está deshabilitado.\n"
 "Habilite un puerto UDP o deshabilite Kad."
 
-#: src/PrefsUnifiedDlg.cpp:1459
+#: src/PrefsUnifiedDlg.cpp:1385
 msgid ""
 "\n"
 "You MUST restart aMule now.\n"
@@ -5866,68 +5818,68 @@ msgstr ""
 "DEBE reiniciar aMule ahora.\n"
 "Si no reinicia ahora, no se queje si sucede algo malo.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1524
+#: src/PrefsUnifiedDlg.cpp:1450
 msgid "Could not register aMule for autostart at login. The autostart store may be read-only."
 msgstr "No se pudo registrar aMule para arrancar automáticamente al iniciar sesión. El almacén de arranque automático podría ser de sólo lectura."
 
-#: src/PrefsUnifiedDlg.cpp:1526
+#: src/PrefsUnifiedDlg.cpp:1452
 msgid "Could not remove the autostart-at-login entry."
 msgstr "No se pudo eliminar la entrada de arranque automático."
 
-#: src/PrefsUnifiedDlg.cpp:1527
+#: src/PrefsUnifiedDlg.cpp:1453
 msgid "Autostart"
 msgstr "Arranque automático"
 
-#: src/PrefsUnifiedDlg.cpp:1542
+#: src/PrefsUnifiedDlg.cpp:1468
 msgid "Register file type"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1542
+#: src/PrefsUnifiedDlg.cpp:1468
 msgid "Register URL handler"
 msgstr "Registrar manejador de URL"
 
-#: src/PrefsUnifiedDlg.cpp:1550
+#: src/PrefsUnifiedDlg.cpp:1476
 #, c-format
 msgid "aMule only handles eD2k-compatible magnets. If you replace the current magnet handler (%s), BitTorrent magnet links will stop working - aMule cannot download BitTorrent content. Continue?"
 msgstr "aMule sólo maneja magnet:\\\\ compatibles con eD2k. Si reemplazas el manipulador de magnet:\\\\ actual (%s), los enlaces magnet de BitTorrent dejarán de funcionar: aMule no puede descargar contenido BitTorrent. ¿Continuar?"
 
-#: src/PrefsUnifiedDlg.cpp:1555
+#: src/PrefsUnifiedDlg.cpp:1481
 #, fuzzy, c-format
 msgid "Another application currently opens .emulecollection files (%s). Replace it with aMule?"
 msgstr "Otra aplicación es actualmente el controlador predeterminado para estos enlaces (%s). ¿Reemplazarlo por aMule?"
 
-#: src/PrefsUnifiedDlg.cpp:1560
+#: src/PrefsUnifiedDlg.cpp:1486
 #, c-format
 msgid "Another application is currently the default handler for these links (%s). Replace it with aMule?"
 msgstr "Otra aplicación es actualmente el controlador predeterminado para estos enlaces (%s). ¿Reemplazarlo por aMule?"
 
-#: src/PrefsUnifiedDlg.cpp:1585
+#: src/PrefsUnifiedDlg.cpp:1511
 #, fuzzy
 msgid "Could not register aMule for .emulecollection files. The registration store may be read-only."
 msgstr "No se pudo registrar aMule como el manejador de URL. El almacenamiento del registro podría ser de sólo lectura."
 
-#: src/PrefsUnifiedDlg.cpp:1587
+#: src/PrefsUnifiedDlg.cpp:1513
 #, fuzzy
 msgid "Could not remove the file type registration."
 msgstr "No se pudo retirar el manejador URL del registro."
 
-#: src/PrefsUnifiedDlg.cpp:1589
+#: src/PrefsUnifiedDlg.cpp:1515
 msgid "Could not register aMule as the URL handler. The registration store may be read-only."
 msgstr "No se pudo registrar aMule como el manejador de URL. El almacenamiento del registro podría ser de sólo lectura."
 
-#: src/PrefsUnifiedDlg.cpp:1591
+#: src/PrefsUnifiedDlg.cpp:1517
 msgid "Could not remove the URL handler registration."
 msgstr "No se pudo retirar el manejador URL del registro."
 
-#: src/PrefsUnifiedDlg.cpp:1661 src/PrefsUnifiedDlg.cpp:1688
+#: src/PrefsUnifiedDlg.cpp:1587 src/PrefsUnifiedDlg.cpp:1614
 msgid "The web server and aMule API require external connections to be enabled."
 msgstr "El servidor web y el API de aMule requieren que las conexiones externas estén habilitadas."
 
-#: src/PrefsUnifiedDlg.cpp:1671
+#: src/PrefsUnifiedDlg.cpp:1597
 msgid "The aMule web server is deprecated. Consider running the aMule API instead."
 msgstr "El servidor web aMule está obsoleto. Considere usar el API de aMule en su lugar."
 
-#: src/PrefsUnifiedDlg.cpp:1735
+#: src/PrefsUnifiedDlg.cpp:1655
 msgid ""
 "Your Auto-update servers list is in blank.\n"
 "Please fill in at least one URL to point to a valid server.met file.\n"
@@ -5937,64 +5889,64 @@ msgstr ""
 "Por favor, introduzca al menos un URL que apunte a un archivo server.met válido.\n"
 "Haga clic en el botón \"Lista\" junto a esta casilla para introducir un URL."
 
-#: src/PrefsUnifiedDlg.cpp:1876
+#: src/PrefsUnifiedDlg.cpp:1796
 msgid "Temporary files"
 msgstr "Archivos temporales"
 
-#: src/PrefsUnifiedDlg.cpp:1881
+#: src/PrefsUnifiedDlg.cpp:1801
 msgid "Incoming files"
 msgstr "Archivos entrantes"
 
-#: src/PrefsUnifiedDlg.cpp:1886
+#: src/PrefsUnifiedDlg.cpp:1806
 msgid "Online Signatures"
 msgstr "Firmas digitales"
 
-#: src/PrefsUnifiedDlg.cpp:1899
+#: src/PrefsUnifiedDlg.cpp:1819
 #, c-format
 msgid "Choose a folder for %s"
 msgstr "Elija una carpeta para %s"
 
-#: src/PrefsUnifiedDlg.cpp:1923
+#: src/PrefsUnifiedDlg.cpp:1843
 #, c-format
 msgid "Would exclude %u of %u shared file"
 msgid_plural "Would exclude %u of %u shared files"
 msgstr[0] "Excluiría %u de %u archivo compartido"
 msgstr[1] "Excluiría %u de %u archivos compartidos"
 
-#: src/PrefsUnifiedDlg.cpp:1940
+#: src/PrefsUnifiedDlg.cpp:1860
 msgid "Browse for videoplayer"
 msgstr "Buscar un reproductor de vídeo"
 
-#: src/PrefsUnifiedDlg.cpp:1944
+#: src/PrefsUnifiedDlg.cpp:1864
 msgid "Select browser"
 msgstr "Seleccione el navegador"
 
-#: src/PrefsUnifiedDlg.cpp:1948
+#: src/PrefsUnifiedDlg.cpp:1868
 msgid "Select ffprobe binary"
 msgstr "Seleccione el binario ffprobe"
 
-#: src/PrefsUnifiedDlg.cpp:1954
+#: src/PrefsUnifiedDlg.cpp:1874
 #, c-format
 msgid "Executable%s"
 msgstr "Ejecutable %s"
 
-#: src/PrefsUnifiedDlg.cpp:1988
+#: src/PrefsUnifiedDlg.cpp:1908
 msgid "ffprobe not found on PATH or in the standard install locations. Install ffmpeg (which ships ffprobe) or use Browse to pick a binary manually."
 msgstr "ffprobe no se encuentra en la ruta PATH o en las ubicaciones estándar de instalación. Instala ffmpeg (el cual provee ffprobe) o utiliza Examinar para elegir un binario manualmente."
 
-#: src/PrefsUnifiedDlg.cpp:2000
+#: src/PrefsUnifiedDlg.cpp:1920
 msgid "Reset the settings on this page to their default values?"
 msgstr "¿Desea restablecer los ajustes de esta página a sus valores por defecto?"
 
-#: src/PrefsUnifiedDlg.cpp:2001
+#: src/PrefsUnifiedDlg.cpp:1921
 msgid "Reset to defaults"
 msgstr "Restablecer a valores por defecto"
 
-#: src/PrefsUnifiedDlg.cpp:2028
+#: src/PrefsUnifiedDlg.cpp:1948
 msgid "Edit server list"
 msgstr "Editar la lista de servidores"
 
-#: src/PrefsUnifiedDlg.cpp:2029
+#: src/PrefsUnifiedDlg.cpp:1949
 msgid ""
 "Add here URL's to download server.met files.\n"
 "Only one url on each line."
@@ -6002,114 +5954,114 @@ msgstr ""
 "Añada aquí los URL para descargar los archivos server.met.\n"
 "Sólo un URL por línea."
 
-#: src/PrefsUnifiedDlg.cpp:2084
+#: src/PrefsUnifiedDlg.cpp:2004
 msgid "IP2Country update failed"
 msgstr "Error al actualizar IP2Country"
 
-#: src/PrefsUnifiedDlg.cpp:2229 src/PrefsUnifiedDlg.cpp:2260
+#: src/PrefsUnifiedDlg.cpp:2149 src/PrefsUnifiedDlg.cpp:2180
 msgid "Data by MaxMind GeoLite2"
 msgstr "Datos de MaxMind GeoLite2"
 
-#: src/PrefsUnifiedDlg.cpp:2231 src/PrefsUnifiedDlg.cpp:2262
+#: src/PrefsUnifiedDlg.cpp:2151 src/PrefsUnifiedDlg.cpp:2182
 msgid "Custom source"
 msgstr "Fuente personalizada"
 
-#: src/PrefsUnifiedDlg.cpp:2233 src/PrefsUnifiedDlg.cpp:2264
+#: src/PrefsUnifiedDlg.cpp:2153 src/PrefsUnifiedDlg.cpp:2184
 msgid "Data by DB-IP.com"
 msgstr "Datos de DB-IP.com"
 
-#: src/PrefsUnifiedDlg.cpp:2284
+#: src/PrefsUnifiedDlg.cpp:2204
 #, c-format
 msgid "Status: Loaded%s"
 msgstr "Estado: Cargado%s"
 
-#: src/PrefsUnifiedDlg.cpp:2286
+#: src/PrefsUnifiedDlg.cpp:2206
 #, c-format
 msgid "Status: Loaded%s - %s"
 msgstr "Estado: Cargado%s -%s"
 
-#: src/PrefsUnifiedDlg.cpp:2290
+#: src/PrefsUnifiedDlg.cpp:2210
 msgid "Status: Failed to load - click 'Update now' to refresh."
 msgstr "Estado: No se ha podido cargar. Haz clic en 'Actualizar ahora' para refrescar."
 
-#: src/PrefsUnifiedDlg.cpp:2292
+#: src/PrefsUnifiedDlg.cpp:2212
 msgid "Status: Not found - click 'Update now' to download."
 msgstr "Estado: No encontrado. Haz clic en 'Actualizar ahora' para descargarlo."
 
-#: src/PrefsUnifiedDlg.cpp:2350 src/PrefsUnifiedDlg.cpp:2374
+#: src/PrefsUnifiedDlg.cpp:2270 src/PrefsUnifiedDlg.cpp:2294
 #, c-format
 msgid "Update delay: %d second"
 msgid_plural "Update delay: %d seconds"
 msgstr[0] "Intervalo de actualización: %d segundo"
 msgstr[1] "Intervalo de actualización: %d segundos"
 
-#: src/PrefsUnifiedDlg.cpp:2358
+#: src/PrefsUnifiedDlg.cpp:2278
 #, c-format
 msgid "Time for average graph: %d minute"
 msgid_plural "Time for average graph: %d minutes"
 msgstr[0] "Tiempo medio del gráfico: %d minuto"
 msgstr[1] "Tiempo medio del gráfico: %d minutos"
 
-#: src/PrefsUnifiedDlg.cpp:2367
+#: src/PrefsUnifiedDlg.cpp:2287
 #, c-format
 msgid "Connections Graph Scale: %d"
 msgstr "Escala gráfica de conexiones: %d"
 
-#: src/PrefsUnifiedDlg.cpp:2382
+#: src/PrefsUnifiedDlg.cpp:2302
 #, c-format
 msgid "File Buffer Size: %d byte"
 msgid_plural "File Buffer Size: %d bytes"
 msgstr[0] "Tamaño del búfer de archivo: %d byte"
 msgstr[1] "Tamaño del búfer de archivo: %d bytes"
 
-#: src/PrefsUnifiedDlg.cpp:2392
+#: src/PrefsUnifiedDlg.cpp:2312
 #, c-format
 msgid "Upload Queue Size: %d client"
 msgid_plural "Upload Queue Size: %d clients"
 msgstr[0] "Tamaño de la cola de subida: %d cliente"
 msgstr[1] "Tamaño de la cola de subida: %d clientes"
 
-#: src/PrefsUnifiedDlg.cpp:2402
+#: src/PrefsUnifiedDlg.cpp:2322
 #, c-format
 msgid "Server connection refresh interval: %d minute"
 msgid_plural "Server connection refresh interval: %d minutes"
 msgstr[0] "Intervalo de actualización de la conexión al servidor: %d minuto"
 msgstr[1] "Intervalo de actualización de la conexión al servidor: %d minutos"
 
-#: src/PrefsUnifiedDlg.cpp:2407
+#: src/PrefsUnifiedDlg.cpp:2327
 msgid "Server connection refresh interval: Disabled"
 msgstr "Intervalo de actualización de la conexión al servidor: deshabilitado"
 
-#: src/PrefsUnifiedDlg.cpp:2451
+#: src/PrefsUnifiedDlg.cpp:2371
 msgid "disabled"
 msgstr "deshabilitado"
 
-#: src/PrefsUnifiedDlg.cpp:2477
+#: src/PrefsUnifiedDlg.cpp:2397
 #, c-format
 msgid "Execute command on '%s' event"
 msgstr "Ejecutar comando en el evento '%s'"
 
-#: src/PrefsUnifiedDlg.cpp:2484
+#: src/PrefsUnifiedDlg.cpp:2404
 msgid "Enable command execution on core"
 msgstr "Habilitar la ejecución de comandos en el núcleo"
 
-#: src/PrefsUnifiedDlg.cpp:2496
+#: src/PrefsUnifiedDlg.cpp:2416
 msgid "Core command:"
 msgstr "Comando del núcleo:"
 
-#: src/PrefsUnifiedDlg.cpp:2512
+#: src/PrefsUnifiedDlg.cpp:2432
 msgid "Enable command execution on GUI"
 msgstr "Habilitar la ejecución de comandos en la interfaz"
 
-#: src/PrefsUnifiedDlg.cpp:2524
+#: src/PrefsUnifiedDlg.cpp:2444
 msgid "GUI command:"
 msgstr "Comando de la interfaz:"
 
-#: src/PrefsUnifiedDlg.cpp:2540
+#: src/PrefsUnifiedDlg.cpp:2460
 msgid "The following variables will be replaced:"
 msgstr "Las siguientes variables serán sustituidas:"
 
-#: src/PrefsUnifiedDlg.cpp:2708
+#: src/PrefsUnifiedDlg.cpp:2628
 msgid ""
 "The following folders look like system or sensitive locations:\n"
 "\n"
@@ -6117,61 +6069,57 @@ msgstr ""
 "Estas carpetas parecen ubicaciones sensibles o de sistema:\n"
 "\n"
 
-#: src/PrefsUnifiedDlg.cpp:2713
+#: src/PrefsUnifiedDlg.cpp:2633
 msgid "Sharing them recursively will publish every file underneath on the eD2k/Kad networks. Do you really want to do this?"
 msgstr "Compartirlas recursivamente publicará todos los archivos en las redes eD2k/Kad. ¿Realmente quiere hacerlo?"
 
-#: src/PrefsUnifiedDlg.cpp:2716
+#: src/PrefsUnifiedDlg.cpp:2636
 msgid "Confirm shared folders"
 msgstr "Confirmar carpetas compartidas"
 
-#: src/PrefsUnifiedDlg.cpp:2744
+#: src/PrefsUnifiedDlg.cpp:2664
 msgid "Reloading shared files..."
 msgstr "Recargando los archivos compartidos..."
 
-#: src/PrefsUnifiedDlg.cpp:2745
+#: src/PrefsUnifiedDlg.cpp:2665
 msgid "Scanning for subdirectories..."
 msgstr "Escaneando por subcarpetas..."
 
-#: src/PrefsUnifiedDlg.cpp:2746
+#: src/PrefsUnifiedDlg.cpp:2666
 msgid "Updating shared folders"
 msgstr "Actualizando carpetas compartidas"
 
-#: src/PrefsUnifiedDlg.cpp:2773
+#: src/PrefsUnifiedDlg.cpp:2693
 #, c-format
 msgid "Scanned %u directories..."
 msgstr "Escaneadas %u carpetas..."
 
-#: src/PrefsUnifiedDlg.cpp:2823
+#: src/PrefsUnifiedDlg.cpp:2743
 #, c-format
 msgid "Reloading shared files: %u files scanned"
 msgstr "Recargando archivos compartidos: %u archivos escaneados"
 
-#: src/PrefsUnifiedDlg.cpp:2873
+#: src/PrefsUnifiedDlg.cpp:2793
 msgid "Shared folder"
 msgstr "Carpeta compartida"
 
-#: src/SearchDlg.cpp:280
-msgid "Clear search history"
-msgstr ""
-
-#: src/SearchDlg.cpp:584
+#: src/SearchDlg.cpp:425
 msgid "It's impossible to search when both eD2k and Kademlia are disabled."
 msgstr "No se puede buscar con eD2K y Kademlia deshabilitadas."
 
-#: src/SearchDlg.cpp:585 src/SearchListCtrl.cpp:858
+#: src/SearchDlg.cpp:426 src/SearchListCtrl.cpp:858
 msgid "Search error"
 msgstr "Error de búsqueda"
 
-#: src/SearchDlg.cpp:929
+#: src/SearchDlg.cpp:768
 msgid "Min size must be smaller than max size. Max size ignored."
 msgstr "El tamaño mínimo debe ser menor que el tamaño máximo. Tamaño máximo ignorado."
 
-#: src/SearchDlg.cpp:930 src/SearchDlg.cpp:1012
+#: src/SearchDlg.cpp:769 src/SearchDlg.cpp:851
 msgid "Search warning"
 msgstr "Aviso de búsqueda"
 
-#: src/SearchDlg.cpp:1092 src/SearchListCtrl.cpp:735
+#: src/SearchDlg.cpp:929 src/SearchListCtrl.cpp:735
 msgid "Main"
 msgstr "Principal"
 

--- a/po/es.po
+++ b/po/es.po
@@ -15,7 +15,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-28 12:17+0200\n"
+"POT-Creation-Date: 2026-07-28 13:09+0200\n"
 "PO-Revision-Date: 2026-07-27 11:36+0000\n"
 "Last-Translator: Diego Heras <ngosang@hotmail.es>\n"
 "Language-Team: Spanish <https://hosted.weblate.org/projects/amule/amule-application/es/>\n"
@@ -303,7 +303,7 @@ msgid "Password set and external connections enabled."
 msgstr "Contraseña fijada y conexiones externas habilitadas."
 
 #: src/amule.cpp:755 src/KadDlg.cpp:176 src/KadDlg.cpp:185
-#: src/PrefsUnifiedDlg.cpp:1461 src/SharedFilesCtrl.cpp:476
+#: src/PrefsUnifiedDlg.cpp:1470 src/SharedFilesCtrl.cpp:476
 msgid "WARNING"
 msgstr "AVISO"
 
@@ -340,7 +340,7 @@ msgstr "Ha solicitado ejecutar el servidor web al inicio pero no se puede ejecut
 #: src/amule-remote-gui.cpp:603 src/amule-remote-gui.cpp:671
 #: src/amule-remote-gui.cpp:709 src/amule-remote-gui.cpp:1282
 #: src/amule-remote-gui.cpp:1345 src/amule-remote-gui.cpp:1372
-#: src/DownloadQueue.cpp:1481 src/PrefsUnifiedDlg.cpp:1247
+#: src/DownloadQueue.cpp:1481 src/PrefsUnifiedDlg.cpp:1256
 msgid "ERROR"
 msgstr "ERROR"
 
@@ -600,36 +600,36 @@ msgstr "Visite https://github.com/amule-org/amule/releases/latest para comprobar
 msgid "FATAL ERROR: Failed to create Timer"
 msgstr "ERROR FATAL: no se ha podido crear el temporizador"
 
-#: src/amuleDlg.cpp:361 src/amuleDlg.cpp:1787 src/amuleDlg.cpp:2033
-#: src/muuli_wdr.cpp:1492 src/muuli_wdr.cpp:3449
+#: src/amuleDlg.cpp:361 src/amuleDlg.cpp:1810 src/amuleDlg.cpp:2056
+#: src/muuli_wdr.cpp:1492 src/muuli_wdr.cpp:3453
 msgid "Networks"
 msgstr "Redes"
 
-#: src/amuleDlg.cpp:362 src/amuleDlg.cpp:1793 src/muuli_wdr.cpp:3450
+#: src/amuleDlg.cpp:362 src/amuleDlg.cpp:1816 src/muuli_wdr.cpp:3454
 msgid "Searches"
 msgstr "Búsquedas"
 
-#: src/amuleDlg.cpp:363 src/amuleDlg.cpp:1799 src/DownloadListCtrl.cpp:740
-#: src/muuli_wdr.cpp:392 src/muuli_wdr.cpp:1585 src/muuli_wdr.cpp:3451
+#: src/amuleDlg.cpp:363 src/amuleDlg.cpp:1822 src/DownloadListCtrl.cpp:740
+#: src/muuli_wdr.cpp:392 src/muuli_wdr.cpp:1585 src/muuli_wdr.cpp:3455
 #: src/Statistics.cpp:829
 msgid "Downloads"
 msgstr "Descargas"
 
-#: src/amuleDlg.cpp:364 src/amuleDlg.cpp:1805 src/muuli_wdr.cpp:3325
+#: src/amuleDlg.cpp:364 src/amuleDlg.cpp:1828 src/muuli_wdr.cpp:3329
 msgid "Shared files"
 msgstr "Compartidos"
 
-#: src/amuleDlg.cpp:365 src/amuleDlg.cpp:1811 src/muuli_wdr.cpp:2957
-#: src/muuli_wdr.cpp:3407 src/muuli_wdr.cpp:3454
+#: src/amuleDlg.cpp:365 src/amuleDlg.cpp:1834 src/muuli_wdr.cpp:2961
+#: src/muuli_wdr.cpp:3411 src/muuli_wdr.cpp:3458
 msgid "Messages"
 msgstr "Mensajes"
 
-#: src/amuleDlg.cpp:366 src/amuleDlg.cpp:1817 src/muuli_wdr.cpp:3455
+#: src/amuleDlg.cpp:366 src/amuleDlg.cpp:1840 src/muuli_wdr.cpp:3459
 #: src/PrefsUnifiedDlg.cpp:314 src/Statistics.cpp:779 src/Statistics.cpp:1235
 msgid "Statistics"
 msgstr "Estadísticas"
 
-#: src/amuleDlg.cpp:368 src/amuleDlg.cpp:1824 src/muuli_wdr.cpp:3457
+#: src/amuleDlg.cpp:368 src/amuleDlg.cpp:1847 src/muuli_wdr.cpp:3461
 #: src/PrefsUnifiedDlg.cpp:330 src/utils/wxCas/src/wxcasprefs.cpp:39
 msgid "Preferences"
 msgstr "Preferencias"
@@ -692,8 +692,8 @@ msgstr "Kad: apagado"
 #: src/amuleDlg.cpp:1029 src/DownloadListCtrl.cpp:505
 #: src/DownloadListCtrl.cpp:749 src/FriendListCtrl.cpp:180
 #: src/muuli_wdr.cpp:731 src/muuli_wdr.cpp:782 src/muuli_wdr.cpp:846
-#: src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2262 src/muuli_wdr.cpp:2347
-#: src/muuli_wdr.cpp:3095 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
+#: src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2266 src/muuli_wdr.cpp:2351
+#: src/muuli_wdr.cpp:3099 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
 #: src/ServerListCtrl.cpp:606 src/TransferWnd.cpp:378
 #: src/utils/wxCas/src/wxcasprefs.cpp:235
 msgid "Cancel"
@@ -704,7 +704,7 @@ msgid "Stop the current connection attempts"
 msgstr "Detener los intentos de conexión actuales"
 
 #: src/amuleDlg.cpp:1035 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976
-#: src/muuli_wdr.cpp:2485
+#: src/muuli_wdr.cpp:2489
 msgid "Disconnect"
 msgstr "Desconectar"
 
@@ -713,7 +713,7 @@ msgid "Disconnect from the currently connected networks"
 msgstr "Desconectarse de las redes conectadas"
 
 #: src/amuleDlg.cpp:1041 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979
-#: src/muuli_wdr.cpp:2640 src/muuli_wdr.cpp:3092 src/muuli_wdr.cpp:3447
+#: src/muuli_wdr.cpp:2644 src/muuli_wdr.cpp:3096 src/muuli_wdr.cpp:3451
 msgid "Connect"
 msgstr "Conectar"
 
@@ -767,7 +767,7 @@ msgstr "Confirmación de salida"
 msgid "Launch Command: "
 msgstr "Ejecutar comando: "
 
-#: src/amuleDlg.cpp:1632 src/muuli_wdr.cpp:1982 src/Preferences.cpp:979
+#: src/amuleDlg.cpp:1632 src/muuli_wdr.cpp:1986 src/Preferences.cpp:979
 msgid "- default -"
 msgstr "- predeterminado -"
 
@@ -781,60 +781,60 @@ msgstr "El directorio de tema '%s' no existe"
 msgid "WARNING: Unable to open skin file '%s' for read"
 msgstr "AVISO: no se puede abrir el archivo de tema '%s' para lectura"
 
-#: src/amuleDlg.cpp:1791 src/muuli_wdr.cpp:3449
+#: src/amuleDlg.cpp:1814 src/muuli_wdr.cpp:3453
 msgid "Networks Window"
 msgstr "Ventana de redes"
 
-#: src/amuleDlg.cpp:1797 src/muuli_wdr.cpp:3450
+#: src/amuleDlg.cpp:1820 src/muuli_wdr.cpp:3454
 msgid "Searches Window"
 msgstr "Ventana de búsquedas"
 
-#: src/amuleDlg.cpp:1803 src/muuli_wdr.cpp:3451
+#: src/amuleDlg.cpp:1826 src/muuli_wdr.cpp:3455
 msgid "Downloads Window"
 msgstr "Ventana de descargas"
 
-#: src/amuleDlg.cpp:1809 src/muuli_wdr.cpp:3453
+#: src/amuleDlg.cpp:1832 src/muuli_wdr.cpp:3457
 msgid "Shared Files Window"
 msgstr "Ventana de archivos compartidos"
 
-#: src/amuleDlg.cpp:1815 src/muuli_wdr.cpp:3454
+#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3458
 msgid "Messages Window"
 msgstr "Ventana de mensajes"
 
-#: src/amuleDlg.cpp:1821 src/muuli_wdr.cpp:3455
+#: src/amuleDlg.cpp:1844 src/muuli_wdr.cpp:3459
 msgid "Statistics Graph Window"
 msgstr "Ventana de gráficos de estadísticas"
 
-#: src/amuleDlg.cpp:1828 src/muuli_wdr.cpp:3457
+#: src/amuleDlg.cpp:1851 src/muuli_wdr.cpp:3461
 msgid "Preferences Settings Window"
 msgstr "Ventana de preferencias de configuración"
 
-#: src/amuleDlg.cpp:1831 src/muuli_wdr.cpp:3458
+#: src/amuleDlg.cpp:1854 src/muuli_wdr.cpp:3462
 msgid "Import"
 msgstr "Importar"
 
-#: src/amuleDlg.cpp:1835 src/muuli_wdr.cpp:3458
+#: src/amuleDlg.cpp:1858 src/muuli_wdr.cpp:3462
 msgid "The partfile importer tool"
 msgstr "La herramienta para importar archivos de partes"
 
-#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3459
+#: src/amuleDlg.cpp:1861 src/muuli_wdr.cpp:3463
 #: src/utils/aLinkCreator/src/alcframe.cpp:262
 msgid "About"
 msgstr "Acerca de"
 
-#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3459
+#: src/amuleDlg.cpp:1861 src/muuli_wdr.cpp:3463
 msgid "About/Help"
 msgstr "Acerca de/Ayuda"
 
-#: src/amuleDlg.cpp:2036
+#: src/amuleDlg.cpp:2059
 msgid "eD2k network"
 msgstr "Red eD2k"
 
-#: src/amuleDlg.cpp:2039
+#: src/amuleDlg.cpp:2062
 msgid "Kad network"
 msgstr "Red Kad"
 
-#: src/amuleDlg.cpp:2039
+#: src/amuleDlg.cpp:2062
 msgid "No network"
 msgstr "No hay red"
 
@@ -1367,19 +1367,19 @@ msgstr "Automática [Al]"
 msgid "Very low"
 msgstr "Muy baja"
 
-#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:743 src/muuli_wdr.cpp:2313
+#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:743 src/muuli_wdr.cpp:2317
 #: src/ServerListCtrl.cpp:263 src/ServerListCtrl.cpp:456
 #: src/SharedFilesCtrl.cpp:145
 msgid "Low"
 msgstr "Baja"
 
-#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:744 src/muuli_wdr.cpp:2314
+#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:744 src/muuli_wdr.cpp:2318
 #: src/ServerListCtrl.cpp:266 src/ServerListCtrl.cpp:457
 #: src/SharedFilesCtrl.cpp:146
 msgid "Normal"
 msgstr "Normal"
 
-#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:745 src/muuli_wdr.cpp:2315
+#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:745 src/muuli_wdr.cpp:2319
 #: src/ServerListCtrl.cpp:269 src/ServerListCtrl.cpp:458
 #: src/SharedFilesCtrl.cpp:147
 msgid "High"
@@ -1471,7 +1471,7 @@ msgstr "Servidor local"
 msgid "Remote Server"
 msgstr "Servidor remoto"
 
-#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3212
+#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3216
 #: src/SearchDlg.cpp:119 src/TextClient.cpp:911
 msgid "Kad"
 msgstr "Kad"
@@ -1542,7 +1542,7 @@ msgstr "Parte"
 msgid "Size"
 msgstr "Tamaño"
 
-#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3279
+#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3283
 msgid "Transferred"
 msgstr "Transferido"
 
@@ -1600,7 +1600,7 @@ msgstr ""
 "Reacción desde: %s (%s)\n"
 "\n"
 
-#: src/DownloadListCtrl.cpp:746 src/muuli_wdr.cpp:2316
+#: src/DownloadListCtrl.cpp:746 src/muuli_wdr.cpp:2320
 #: src/SharedFilesCtrl.cpp:150
 msgid "Auto"
 msgstr "Automática"
@@ -1638,7 +1638,7 @@ msgid "Extended Options"
 msgstr "Opciones adicionales"
 
 #: src/DownloadListCtrl.cpp:770 src/DownloadListCtrl.cpp:822
-#: src/muuli_wdr.cpp:1800
+#: src/muuli_wdr.cpp:1804
 msgid "Preview"
 msgstr "Previsualizar"
 
@@ -2437,23 +2437,23 @@ msgid ""
 "want downloads on a different (e.g. larger) disk."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:549 src/FirstRunWizard.cpp:611 src/muuli_wdr.cpp:1712
+#: src/FirstRunWizard.cpp:549 src/FirstRunWizard.cpp:611 src/muuli_wdr.cpp:1716
 msgid "Destination folder for downloads"
 msgstr "Carpeta de destino para las descargas"
 
 #: src/FirstRunWizard.cpp:553 src/FirstRunWizard.cpp:569 src/muuli_wdr.cpp:1349
-#: src/muuli_wdr.cpp:1366 src/muuli_wdr.cpp:1687 src/muuli_wdr.cpp:1718
-#: src/muuli_wdr.cpp:1730 src/muuli_wdr.cpp:2800
+#: src/muuli_wdr.cpp:1366 src/muuli_wdr.cpp:1691 src/muuli_wdr.cpp:1722
+#: src/muuli_wdr.cpp:1734 src/muuli_wdr.cpp:2804
 #: src/utils/aLinkCreator/src/alcframe.cpp:135
 #: src/utils/wxCas/src/wxcasprefs.cpp:52 src/utils/wxCas/src/wxcasprefs.cpp:118
 msgid "Browse"
 msgstr "Examinar"
 
-#: src/FirstRunWizard.cpp:559 src/muuli_wdr.cpp:1723
+#: src/FirstRunWizard.cpp:559 src/muuli_wdr.cpp:1727
 msgid "(All files in this folder are shared with other peers)"
 msgstr "(Todos los archivos de esta carpeta se comparten con otros usuarios)"
 
-#: src/FirstRunWizard.cpp:565 src/FirstRunWizard.cpp:624 src/muuli_wdr.cpp:1725
+#: src/FirstRunWizard.cpp:565 src/FirstRunWizard.cpp:624 src/muuli_wdr.cpp:1729
 msgid "Folder for temporary download files"
 msgstr "Carpeta para los archivos temporales de las descargas"
 
@@ -2484,7 +2484,7 @@ msgstr "¡Error al abrir el archivo de amigos 'emfriends.met' para escritura!"
 msgid "CRITICAL - no client on StartChatSession"
 msgstr "CRÍTICO - no hay clientes en el inicio de sesión chat"
 
-#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2706 src/muuli_wdr.cpp:3383
+#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2710 src/muuli_wdr.cpp:3387
 msgid "Friends"
 msgstr "Amigos"
 
@@ -2594,8 +2594,8 @@ msgstr "Ninguno"
 msgid "No"
 msgstr "No"
 
-#: src/GenericClientListCtrl.cpp:1216 src/PrefsUnifiedDlg.cpp:2898
-#: src/PrefsUnifiedDlg.cpp:2948 src/ServerListCtrl.cpp:276
+#: src/GenericClientListCtrl.cpp:1216 src/PrefsUnifiedDlg.cpp:2907
+#: src/PrefsUnifiedDlg.cpp:2957 src/ServerListCtrl.cpp:276
 msgid "Yes"
 msgstr "Sí"
 
@@ -2764,10 +2764,10 @@ msgstr "Puerto no válido para la inicialización"
 msgid "Please fill all fields required"
 msgstr "Por favor, rellene todos los campos requeridos"
 
-#: src/KadDlg.cpp:192 src/PartFile.cpp:1031 src/PrefsUnifiedDlg.cpp:1134
-#: src/PrefsUnifiedDlg.cpp:1204 src/PrefsUnifiedDlg.cpp:1405
-#: src/PrefsUnifiedDlg.cpp:1663 src/PrefsUnifiedDlg.cpp:1673
-#: src/PrefsUnifiedDlg.cpp:1690 src/PrefsUnifiedDlg.cpp:1738
+#: src/KadDlg.cpp:192 src/PartFile.cpp:1031 src/PrefsUnifiedDlg.cpp:1143
+#: src/PrefsUnifiedDlg.cpp:1213 src/PrefsUnifiedDlg.cpp:1414
+#: src/PrefsUnifiedDlg.cpp:1672 src/PrefsUnifiedDlg.cpp:1682
+#: src/PrefsUnifiedDlg.cpp:1699 src/PrefsUnifiedDlg.cpp:1747
 msgid "Message"
 msgstr "Mensaje"
 
@@ -2868,7 +2868,7 @@ msgstr "Media de compartición"
 msgid "Uploaded"
 msgstr "Subido"
 
-#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3263
+#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3267
 msgid "Requested"
 msgstr "Pedido"
 
@@ -2991,7 +2991,7 @@ msgid "WARNING: "
 msgstr "AVISO: "
 
 #: src/MuleNotebook.cpp:179 src/muuli_wdr.cpp:817 src/muuli_wdr.cpp:1229
-#: src/muuli_wdr.cpp:3167 src/muuli_wdr.cpp:3423
+#: src/muuli_wdr.cpp:3171 src/muuli_wdr.cpp:3427
 msgid "Close"
 msgstr "Cerrar"
 
@@ -3009,7 +3009,7 @@ msgid "Paste"
 msgstr "Pegar"
 
 #: src/MuleTextCtrl.cpp:89 src/muuli_wdr.cpp:358 src/muuli_wdr.cpp:757
-#: src/muuli_wdr.cpp:2390 src/muuli_wdr.cpp:2409 src/muuli_wdr.cpp:2431
+#: src/muuli_wdr.cpp:2394 src/muuli_wdr.cpp:2413 src/muuli_wdr.cpp:2435
 #: src/utils/aLinkCreator/src/alcframe.cpp:142
 msgid "Clear"
 msgstr "Limpiar"
@@ -3101,7 +3101,7 @@ msgstr "Salir"
 
 #: src/MuleTrayIcon.cpp:579 src/MuleTrayIcon.cpp:945 src/MuleTrayIcon.cpp:965
 #: src/muuli_wdr.cpp:1398 src/muuli_wdr.cpp:1406 src/muuli_wdr.cpp:1413
-#: src/muuli_wdr.cpp:1846 src/muuli_wdr.cpp:1852 src/OtherFunctions.cpp:91
+#: src/muuli_wdr.cpp:1850 src/muuli_wdr.cpp:1856 src/OtherFunctions.cpp:91
 #: src/StatisticsDlg.cpp:93 src/StatisticsDlg.cpp:95
 msgid "kB/s"
 msgstr "kB/s"
@@ -3341,7 +3341,7 @@ msgstr "Bytes"
 msgid "KB"
 msgstr "KB"
 
-#: src/muuli_wdr.cpp:274 src/muuli_wdr.cpp:293 src/muuli_wdr.cpp:1631
+#: src/muuli_wdr.cpp:274 src/muuli_wdr.cpp:293 src/muuli_wdr.cpp:1635
 #: src/OtherFunctions.cpp:64
 msgid "MB"
 msgstr "MB"
@@ -3358,7 +3358,7 @@ msgstr "Tamaño máximo"
 msgid "Availability"
 msgstr "Disponibilidad"
 
-#: src/muuli_wdr.cpp:312 src/muuli_wdr.cpp:398 src/muuli_wdr.cpp:3328
+#: src/muuli_wdr.cpp:312 src/muuli_wdr.cpp:398 src/muuli_wdr.cpp:3332
 msgid "Filter:"
 msgstr "Filtro:"
 
@@ -3421,8 +3421,8 @@ msgstr "Fuentes del archivo:"
 #: src/muuli_wdr.cpp:1160 src/muuli_wdr.cpp:1167 src/muuli_wdr.cpp:1172
 #: src/muuli_wdr.cpp:1179 src/muuli_wdr.cpp:1184 src/muuli_wdr.cpp:1191
 #: src/muuli_wdr.cpp:1205 src/muuli_wdr.cpp:1212 src/muuli_wdr.cpp:1217
-#: src/muuli_wdr.cpp:1224 src/muuli_wdr.cpp:3265 src/muuli_wdr.cpp:3273
-#: src/muuli_wdr.cpp:3281
+#: src/muuli_wdr.cpp:1224 src/muuli_wdr.cpp:3269 src/muuli_wdr.cpp:3277
+#: src/muuli_wdr.cpp:3285
 msgid "N/A"
 msgstr "N/D"
 
@@ -3562,7 +3562,7 @@ msgstr "Artista :"
 msgid "Album :"
 msgstr "Álbum :"
 
-#: src/muuli_wdr.cpp:685 src/muuli_wdr.cpp:2285
+#: src/muuli_wdr.cpp:685 src/muuli_wdr.cpp:2289
 msgid "Title :"
 msgstr "Título:"
 
@@ -3670,7 +3670,7 @@ msgstr "Nombre del usuario:"
 msgid "Userhash :"
 msgstr "Hash del usuario:"
 
-#: src/muuli_wdr.cpp:895 src/muuli_wdr.cpp:1752 src/muuli_wdr.cpp:2480
+#: src/muuli_wdr.cpp:895 src/muuli_wdr.cpp:1756 src/muuli_wdr.cpp:2484
 #: src/utils/aLinkCreator/src/alcframe.cpp:137
 msgid "Add"
 msgstr "Añadir"
@@ -3679,15 +3679,15 @@ msgstr "Añadir"
 msgid "Download-Speed"
 msgstr "Velocidad de descarga"
 
-#: src/muuli_wdr.cpp:954 src/muuli_wdr.cpp:989 src/muuli_wdr.cpp:2584
+#: src/muuli_wdr.cpp:954 src/muuli_wdr.cpp:989 src/muuli_wdr.cpp:2588
 msgid "Current"
 msgstr "Actual"
 
-#: src/muuli_wdr.cpp:962 src/muuli_wdr.cpp:997 src/muuli_wdr.cpp:2592
+#: src/muuli_wdr.cpp:962 src/muuli_wdr.cpp:997 src/muuli_wdr.cpp:2596
 msgid "Running average"
 msgstr "Media de ejecución"
 
-#: src/muuli_wdr.cpp:970 src/muuli_wdr.cpp:1005 src/muuli_wdr.cpp:2600
+#: src/muuli_wdr.cpp:970 src/muuli_wdr.cpp:1005 src/muuli_wdr.cpp:2604
 msgid "Session average"
 msgstr "Media de la sesión"
 
@@ -3699,7 +3699,7 @@ msgstr "Velocidad de subida"
 msgid "Connections"
 msgstr "Conexiones"
 
-#: src/muuli_wdr.cpp:1024 src/muuli_wdr.cpp:1871
+#: src/muuli_wdr.cpp:1024 src/muuli_wdr.cpp:1875
 msgid "Active downloads"
 msgstr "Descargas activas"
 
@@ -3707,7 +3707,7 @@ msgstr "Descargas activas"
 msgid "Active connections (1:1)"
 msgstr "Conexiones activas (1:1)"
 
-#: src/muuli_wdr.cpp:1040 src/muuli_wdr.cpp:1872
+#: src/muuli_wdr.cpp:1040 src/muuli_wdr.cpp:1876
 msgid "Active uploads"
 msgstr "Subidas activas"
 
@@ -3981,7 +3981,7 @@ msgstr "Dirección IP local de enlace (vacía para cualquiera):"
 msgid "Advanced users only: If you have multiple network interfaces, enter the address of the interface to which aMule should be bound."
 msgstr "Solo usuarios avanzados: si tiene varias tarjetas de red, introduzca la dirección de la tarjeta que debe usar aMule."
 
-#: src/muuli_wdr.cpp:1462 src/muuli_wdr.cpp:2065
+#: src/muuli_wdr.cpp:1462 src/muuli_wdr.cpp:2069
 msgid "Bind to network interface (empty for any):"
 msgstr "Vincular a interfaz de red (vacío para cualquiera):"
 
@@ -3997,7 +3997,7 @@ msgstr "Número máximo de fuentes descargando un archivo:"
 msgid "Max simultaneous connections:"
 msgstr "Número máximo de conexiones simultáneas:"
 
-#: src/muuli_wdr.cpp:1498 src/muuli_wdr.cpp:3207
+#: src/muuli_wdr.cpp:1498 src/muuli_wdr.cpp:3211
 msgid "ED2K"
 msgstr "ED2K"
 
@@ -4089,79 +4089,79 @@ msgstr "Reservar el espacio en disco para los archivos nuevos"
 msgid "For new files preallocates disk space for the whole file, thus reduces fragmentation"
 msgstr "Reserva en disco el espacio para los archivos nuevos enteros, reduciendo asíla fragmentación"
 
-#: src/muuli_wdr.cpp:1617
+#: src/muuli_wdr.cpp:1621
 msgid "Create new files as sparse files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1618
+#: src/muuli_wdr.cpp:1622
 msgid "Sparse part files only occupy disk space for the parts already downloaded, so free space is used up gradually as the file fills in. Turn this off to use an ordinary file instead - useful where sparse files are unsupported or slow, or where backup/de-duplication tools handle them badly. Applies only when the core runs on Windows; on Linux and macOS part files are sparse anyway and this setting has no effect."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1623
+#: src/muuli_wdr.cpp:1627
 msgid "Stop downloads when free disk space reaches "
 msgstr "Detener las descargas cuando el espacio libre en disco alcance "
 
-#: src/muuli_wdr.cpp:1624
+#: src/muuli_wdr.cpp:1628
 msgid "Select this if you want aMule to check your disk space"
 msgstr "Seleccione esta opción si quiere que aMule compruebe el espacio en disco"
 
-#: src/muuli_wdr.cpp:1628
+#: src/muuli_wdr.cpp:1632
 msgid "Enter here the min disk space desired."
 msgstr "Introduzca el espacio mínimo de disco deseado."
 
-#: src/muuli_wdr.cpp:1634
+#: src/muuli_wdr.cpp:1638
 msgid "Save 10 sources on rare files (< 20 sources)"
 msgstr "Guardar 10 fuentes para archivos raros (< 20 fuentes)"
 
-#: src/muuli_wdr.cpp:1638 src/Statistics.cpp:790
+#: src/muuli_wdr.cpp:1642 src/Statistics.cpp:790
 msgid "Uploads"
 msgstr "Subidas"
 
-#: src/muuli_wdr.cpp:1641
+#: src/muuli_wdr.cpp:1645
 msgid "Add new shared files with auto priority"
 msgstr "Añadir los nuevos archivos compartidos con prioridad automática"
 
-#: src/muuli_wdr.cpp:1647
+#: src/muuli_wdr.cpp:1651
 msgid "Intelligent Corruption Handling (I.C.H.)"
 msgstr "Gestión inteligente de corrupción (I.C.H.)"
 
-#: src/muuli_wdr.cpp:1650
+#: src/muuli_wdr.cpp:1654
 msgid "Enable"
 msgstr "Habilitar"
 
-#: src/muuli_wdr.cpp:1653
+#: src/muuli_wdr.cpp:1657
 msgid "Advanced I.C.H. trusts every hash (not recommended)"
 msgstr "El I.C.H. avanzado confía en todos los hash (no recomendado)"
 
-#: src/muuli_wdr.cpp:1665 src/PrefsUnifiedDlg.cpp:1990
+#: src/muuli_wdr.cpp:1669 src/PrefsUnifiedDlg.cpp:1999
 msgid "Media metadata extraction"
 msgstr "Extracción de metadatos multimedia"
 
-#: src/muuli_wdr.cpp:1669
+#: src/muuli_wdr.cpp:1673
 msgid "Extract length / bitrate / codec from shared audio and video files"
 msgstr "Extraer la duración, el bitrate y el códec de los archivos multimedia compartidos"
 
-#: src/muuli_wdr.cpp:1671
+#: src/muuli_wdr.cpp:1675
 msgid "When enabled, aMule runs ffprobe on each shared media file to fill in the Length / Bitrate / Codec columns other clients see when they find the file in a search. Requires ffmpeg (the ffprobe binary) to be installed."
 msgstr "Cuando está activado, aMule ejecuta ffprobe en cada archivo multimedia compartido para rellenar las columnas de Duración / Bitrate / Códec que otros clientes ven cuando encuentran el archivo en una búsqueda. Requiere tener instalado ffmpeg (el binario ffprobe)."
 
-#: src/muuli_wdr.cpp:1678
+#: src/muuli_wdr.cpp:1682
 msgid "Path to ffprobe:"
 msgstr "Ruta a ffprobe:"
 
-#: src/muuli_wdr.cpp:1683
+#: src/muuli_wdr.cpp:1687
 msgid "Full path to the ffprobe binary. Leave empty to have aMule auto-detect it on startup."
 msgstr "Ruta completa al binario de ffprobe. Déjelo vacío para que aMule lo detecte automáticamente al iniciar."
 
-#: src/muuli_wdr.cpp:1691
+#: src/muuli_wdr.cpp:1695
 msgid "Detect"
 msgstr "Detectar"
 
-#: src/muuli_wdr.cpp:1692
+#: src/muuli_wdr.cpp:1696
 msgid "Search the standard install locations for an ffprobe binary and fill the path field."
 msgstr "Buscar los lugares de instalación estándar para un binario ffprobe y rellenar el campo de la ruta."
 
-#: src/muuli_wdr.cpp:1716
+#: src/muuli_wdr.cpp:1720
 msgid ""
 "Completed downloads are stored here. All files in this folder are automatically shared with other peers.\n"
 "If this folder also holds files you don't want to share, point it at an aMule-only sub-folder."
@@ -4169,383 +4169,383 @@ msgstr ""
 "Las descargas completadas se guardan aquí. Todos los archivos de esta carpeta se compartirán automáticamente con otros usuarios.\n"
 "Si esta carpeta contiene archivos que no quiere compartir, apúntelo a un sub-directorio exclusivo para aMule."
 
-#: src/muuli_wdr.cpp:1719
+#: src/muuli_wdr.cpp:1723
 msgid "Pick the folder where completed downloads will be stored. All files in that folder will be shared with other peers."
 msgstr "Elija la carpeta donde se guardarán las descargas terminadas. Todos los archivos de esa carpeta se compartirán con otros usuarios."
 
-#: src/muuli_wdr.cpp:1733
+#: src/muuli_wdr.cpp:1737
 msgid "Shared folders"
 msgstr "Carpetas compartidas"
 
-#: src/muuli_wdr.cpp:1739
+#: src/muuli_wdr.cpp:1743
 msgid "(Folders shared by the core. Enter a path to add one.)"
 msgstr "(Directorios compartidos por el núcleo. Introduzca una ruta para añadir uno.)"
 
-#: src/muuli_wdr.cpp:1747
+#: src/muuli_wdr.cpp:1751
 msgid "Absolute path of a folder on the core's machine, e.g. /home/user/shared"
 msgstr "Ruta absoluta de un directorio en la máquina del núcleo, p. ej. /home/user/compartido"
 
-#: src/muuli_wdr.cpp:1749 src/PrefsUnifiedDlg.cpp:2874
+#: src/muuli_wdr.cpp:1753 src/PrefsUnifiedDlg.cpp:2883
 msgid "Recursive"
 msgstr "Recursivo"
 
-#: src/muuli_wdr.cpp:1750
+#: src/muuli_wdr.cpp:1754
 msgid "Share every sub-folder underneath this one, including ones created later."
 msgstr "Compartir todos los subdirectorios bajo éste, incluyendo los creados en el futuro."
 
-#: src/muuli_wdr.cpp:1754 src/utils/aLinkCreator/src/alcframe.cpp:141
+#: src/muuli_wdr.cpp:1758 src/utils/aLinkCreator/src/alcframe.cpp:141
 msgid "Remove"
 msgstr "Borrar"
 
-#: src/muuli_wdr.cpp:1758
+#: src/muuli_wdr.cpp:1762
 msgid "(Right click on folder icon for recursive share)"
 msgstr "(Haga clic derecho en los iconos de carpetas para compartirlas recursivamente)"
 
-#: src/muuli_wdr.cpp:1765
+#: src/muuli_wdr.cpp:1769
 msgid "Share hidden files"
 msgstr "Compartir los archivos ocultos"
 
-#: src/muuli_wdr.cpp:1771
+#: src/muuli_wdr.cpp:1775
 msgid "Automatically rescan shared folders for changes"
 msgstr "Buscar cambios automáticamente en los directorios compartidos"
 
-#: src/muuli_wdr.cpp:1777
+#: src/muuli_wdr.cpp:1781
 msgid "Follow symbolic links in shared folders"
 msgstr "Seguir enlaces simbólicos en las carpetas compartidas"
 
-#: src/muuli_wdr.cpp:1783
+#: src/muuli_wdr.cpp:1787
 msgid "Exclude files matching:"
 msgstr "Excluir archivos coincidentes:"
 
-#: src/muuli_wdr.cpp:1786
+#: src/muuli_wdr.cpp:1790
 msgid "Wildcard patterns separated by '|', e.g. .DS_Store|Thumbs.db|*.tmp. Files whose name matches are not shared. Matching is case-insensitive."
 msgstr "Patrones comodines separados por '|', p.ej., .DS_Store|Thumbs.db|*.tmp. Los archivos cuyo nombre coincida no serán compartidos. No distingue mayúsculas/minúsculas."
 
-#: src/muuli_wdr.cpp:1790
+#: src/muuli_wdr.cpp:1794
 msgid "Patterns are regular expressions"
 msgstr "Los patrones son expresiones regulares"
 
-#: src/muuli_wdr.cpp:1791
+#: src/muuli_wdr.cpp:1795
 msgid "When set, the whole field is one regular expression ('|' is alternation). When unset, it is a list of '|'-separated wildcards."
 msgstr "Cuando se activa, el campo completo es una expresión regular ('|' es OR). Cuando no se activa, es un listado de comodines separados por '|'."
 
-#: src/muuli_wdr.cpp:1801
+#: src/muuli_wdr.cpp:1805
 msgid "Show how many shared files the current pattern would exclude."
 msgstr "Muestra cuántos archivos compartidos excluiría el patrón actual."
 
-#: src/muuli_wdr.cpp:1822
+#: src/muuli_wdr.cpp:1826
 msgid "Graphs"
 msgstr "Gráficos"
 
-#: src/muuli_wdr.cpp:1825 src/muuli_wdr.cpp:1887
+#: src/muuli_wdr.cpp:1829 src/muuli_wdr.cpp:1891
 msgid "Update delay : 5 secs"
 msgstr "Intervalo de actualización: 5 s"
 
-#: src/muuli_wdr.cpp:1829
+#: src/muuli_wdr.cpp:1833
 msgid "Time for average graph: 100 mins"
 msgstr "Tiempo de promedio del gráfico: 100 minutos"
 
-#: src/muuli_wdr.cpp:1833
+#: src/muuli_wdr.cpp:1837
 msgid "Connections Graph Scale: 100 "
 msgstr "Escala del gráfico de las conexiones: 100 "
 
-#: src/muuli_wdr.cpp:1840
+#: src/muuli_wdr.cpp:1844
 msgid "Download graph scale:"
 msgstr "Escala de la gráfica de descarga:"
 
-#: src/muuli_wdr.cpp:1848
+#: src/muuli_wdr.cpp:1852
 msgid "Upload graph scale:"
 msgstr "Escala de la gráfica de subida:"
 
-#: src/muuli_wdr.cpp:1858
+#: src/muuli_wdr.cpp:1862
 msgid "Colors: "
 msgstr "Colores: "
 
-#: src/muuli_wdr.cpp:1862
+#: src/muuli_wdr.cpp:1866
 msgid "Background"
 msgstr "Fondo"
 
-#: src/muuli_wdr.cpp:1863
+#: src/muuli_wdr.cpp:1867
 msgid "Grid"
 msgstr "Rejilla"
 
-#: src/muuli_wdr.cpp:1864
+#: src/muuli_wdr.cpp:1868
 msgid "Download current"
 msgstr "Descarga actual"
 
-#: src/muuli_wdr.cpp:1865
+#: src/muuli_wdr.cpp:1869
 msgid "Download running average"
 msgstr "Promedio de descarga en ejecución"
 
-#: src/muuli_wdr.cpp:1866
+#: src/muuli_wdr.cpp:1870
 msgid "Download session average"
 msgstr "Promedio de descarga en la sesión"
 
-#: src/muuli_wdr.cpp:1867
+#: src/muuli_wdr.cpp:1871
 msgid "Upload current"
 msgstr "Subida actual"
 
-#: src/muuli_wdr.cpp:1868
+#: src/muuli_wdr.cpp:1872
 msgid "Upload running average"
 msgstr "Promedio de subida en ejecución"
 
-#: src/muuli_wdr.cpp:1869
+#: src/muuli_wdr.cpp:1873
 msgid "Upload session average"
 msgstr "Promedio de subida en la sesión"
 
-#: src/muuli_wdr.cpp:1870
+#: src/muuli_wdr.cpp:1874
 msgid "Active connections"
 msgstr "Conexiones activas"
 
-#: src/muuli_wdr.cpp:1873
+#: src/muuli_wdr.cpp:1877
 msgid "Systray Icon Speed Bar"
 msgstr "Barra de velocidad en el icono de la bandeja del sistema"
 
-#: src/muuli_wdr.cpp:1874
+#: src/muuli_wdr.cpp:1878
 msgid "Kad-nodes current"
 msgstr "Nodos Kad actuales"
 
-#: src/muuli_wdr.cpp:1875
+#: src/muuli_wdr.cpp:1879
 msgid "Kad-nodes running"
 msgstr "Nodos Kad activos"
 
-#: src/muuli_wdr.cpp:1876
+#: src/muuli_wdr.cpp:1880
 msgid "Kad-nodes session"
 msgstr "Nodos Kad de la sesión"
 
-#: src/muuli_wdr.cpp:1880 src/muuli_wdr.cpp:2334
+#: src/muuli_wdr.cpp:1884 src/muuli_wdr.cpp:2338
 msgid "Select"
 msgstr "Seleccionar"
 
-#: src/muuli_wdr.cpp:1884
+#: src/muuli_wdr.cpp:1888
 msgid "Tree"
 msgstr "Árbol"
 
-#: src/muuli_wdr.cpp:1894
+#: src/muuli_wdr.cpp:1898
 msgid "Number of Client Versions shown (0=unlimited)"
 msgstr "Número de versiones de clientes a mostrar (0=sin límite)"
 
-#: src/muuli_wdr.cpp:1919
+#: src/muuli_wdr.cpp:1923
 msgid "!!! WARNING !!!"
 msgstr "¡¡¡ AVISO !!!"
 
-#: src/muuli_wdr.cpp:1934
+#: src/muuli_wdr.cpp:1938
 msgid "Max new connections / 5 secs"
 msgstr "Número máximo de nuevas conexiones cada 5 segundos"
 
-#: src/muuli_wdr.cpp:1936
+#: src/muuli_wdr.cpp:1940
 msgid "Concurrent Kad source lookups"
 msgstr "Búsquedas simultáneas de fuentes Kad"
 
-#: src/muuli_wdr.cpp:1938
+#: src/muuli_wdr.cpp:1942
 msgid "Kad source re-search interval (minutes)"
 msgstr "Intervalo de búsqueda de fuentes Kad (minutos)"
 
-#: src/muuli_wdr.cpp:1940
+#: src/muuli_wdr.cpp:1944
 msgid "Source re-ask interval (minutes)"
 msgstr "Intervalo re‐solicitud de fuentes (minutos)"
 
-#: src/muuli_wdr.cpp:1944
+#: src/muuli_wdr.cpp:1948
 msgid "File Buffer Size: 240000 bytes"
 msgstr "Tamaño del búfer de archivo: 240000 bytes"
 
-#: src/muuli_wdr.cpp:1948
+#: src/muuli_wdr.cpp:1952
 msgid "Use MMAP: memory-mapped file access (lower memory use)"
 msgstr "Usar MMAP: acceso a ficheros mapeados en memoria (menor uso de memoria)"
 
-#: src/muuli_wdr.cpp:1949
+#: src/muuli_wdr.cpp:1953
 msgid "Maps part files into memory instead of buffering them on the heap, lowering the process memory footprint. May reduce download speed on some disks; best for memory-constrained or upload-heavy hosts."
 msgstr "Mapea los ficheros de partes en memoria en vez de usar un buffer en la pila, reduciendo la huella de memoria del proceso. Puede reducir la velocidad de descarga en algunos discos; es mejor usarlo en entornos con poca memoria o nodos que principalmente suban datos."
 
-#: src/muuli_wdr.cpp:1951
+#: src/muuli_wdr.cpp:1955
 msgid "Upload Queue Size: 5000 clients"
 msgstr "Tamaño de cola de espera: 5000 clientes"
 
-#: src/muuli_wdr.cpp:1955
+#: src/muuli_wdr.cpp:1959
 msgid "Server connection refresh interval: Disable"
 msgstr "Intervalo de actualización de la conexión al servidor: desactivado"
 
-#: src/muuli_wdr.cpp:1959
+#: src/muuli_wdr.cpp:1963
 msgid "Disable computer's timed standby mode"
 msgstr "Deshabilitar el modo de reposo del ordenador"
 
-#: src/muuli_wdr.cpp:1978
+#: src/muuli_wdr.cpp:1982
 msgid "Skin to use: "
 msgstr "Tema a usar: "
 
-#: src/muuli_wdr.cpp:1987
+#: src/muuli_wdr.cpp:1991
 msgid "Show \"Fast eD2k Links Handler\" in every window."
 msgstr "Mostrar el \"Gestor rápido de enlaces eD2k\" en todas las ventanas."
 
-#: src/muuli_wdr.cpp:1990
+#: src/muuli_wdr.cpp:1994
 msgid "Show extended info on categories tabs"
 msgstr "Mostrar información adicional en las pestañas de las categorías"
 
-#: src/muuli_wdr.cpp:1993
+#: src/muuli_wdr.cpp:1997
 msgid "Show application version on title"
 msgstr "Mostrar la versión de la aplicación en el título"
 
-#: src/muuli_wdr.cpp:1995
+#: src/muuli_wdr.cpp:1999
 msgid "Show transfer rates on title"
 msgstr "Mostrar las tasas de transferencia en el título"
 
-#: src/muuli_wdr.cpp:1997
+#: src/muuli_wdr.cpp:2001
 msgid "Before application name"
 msgstr "Antes del nombre de la aplicación"
 
-#: src/muuli_wdr.cpp:1999
+#: src/muuli_wdr.cpp:2003
 msgid "After application name"
 msgstr "Después del nombre de la aplicación"
 
-#: src/muuli_wdr.cpp:2002
+#: src/muuli_wdr.cpp:2006
 msgid "Show overhead bandwidth"
 msgstr "Mostrar el ancho de banda adicional usado"
 
-#: src/muuli_wdr.cpp:2006
+#: src/muuli_wdr.cpp:2010
 msgid "Vertical toolbar orientation"
 msgstr "Orientación vertical de la barra de herramientas"
 
-#: src/muuli_wdr.cpp:2008
+#: src/muuli_wdr.cpp:2012
 msgid "Live column sorting (auto-reorder rows as their values change)"
 msgstr "Orden automático de columnas (reordena las filas según cambian sus valores)"
 
-#: src/muuli_wdr.cpp:2015
+#: src/muuli_wdr.cpp:2019
 msgid "Download Queue Files"
 msgstr "Archivos de la cola de descarga"
 
-#: src/muuli_wdr.cpp:2018
+#: src/muuli_wdr.cpp:2022
 msgid "Show progress percentage"
 msgstr "Mostrar el porcentaje de progreso"
 
-#: src/muuli_wdr.cpp:2024
+#: src/muuli_wdr.cpp:2028
 msgid "Show progress bar"
 msgstr "Mostrar la barra de progreso"
 
-#: src/muuli_wdr.cpp:2027
+#: src/muuli_wdr.cpp:2031
 msgid "Flat"
 msgstr "Plana"
 
-#: src/muuli_wdr.cpp:2031
+#: src/muuli_wdr.cpp:2035
 msgid "Round"
 msgstr "Redondeada"
 
-#: src/muuli_wdr.cpp:2049
+#: src/muuli_wdr.cpp:2053
 msgid "External Connection Parameters"
 msgstr "Parámetros de la conexión externa"
 
-#: src/muuli_wdr.cpp:2052
+#: src/muuli_wdr.cpp:2056
 msgid "Accept external connections"
 msgstr "Aceptar conexiones externas"
 
-#: src/muuli_wdr.cpp:2059 src/muuli_wdr.cpp:2118
+#: src/muuli_wdr.cpp:2063 src/muuli_wdr.cpp:2122
 msgid "IP of the listening interface:"
 msgstr "IP de la interfaz que está escuchando:"
 
-#: src/muuli_wdr.cpp:2062
+#: src/muuli_wdr.cpp:2066
 msgid "Enter here a valid ip in the a.b.c.d format for the listening EC interface. An empty field or 0.0.0.0 will mean any interface."
 msgstr "Introduzca aquí una IP válida en la forma a.b.c.d para la interfaz EC que está escuchando. Un campo vacío o 0.0.0.0 significará cualquier interfaz."
 
-#: src/muuli_wdr.cpp:2083 src/muuli_wdr.cpp:2194
+#: src/muuli_wdr.cpp:2087 src/muuli_wdr.cpp:2198
 msgid "TCP port:"
 msgstr "Puerto TCP:"
 
-#: src/muuli_wdr.cpp:2089
+#: src/muuli_wdr.cpp:2093
 msgid "Enable UPnP port forwarding on the EC port"
 msgstr "Habilitar la redirección de puertos UPnP en el puerto EC"
 
-#: src/muuli_wdr.cpp:2093 src/muuli_wdr.cpp:3079
+#: src/muuli_wdr.cpp:2097 src/muuli_wdr.cpp:3083
 #: src/utils/wxCas/src/wxcasprefs.cpp:167
 msgid "Password"
 msgstr "Contraseña"
 
-#: src/muuli_wdr.cpp:2099
+#: src/muuli_wdr.cpp:2103
 msgid "aMule API server parameters"
 msgstr "Parámetros del servidor aMule API"
 
-#: src/muuli_wdr.cpp:2102
+#: src/muuli_wdr.cpp:2106
 msgid "Run amuleapi (REST API) on startup"
 msgstr "Ejecutar amuleapi (API REST) al iniciar"
 
-#: src/muuli_wdr.cpp:2107
+#: src/muuli_wdr.cpp:2111
 msgid "HTTP port:"
 msgstr "Puerto HTTP:"
 
-#: src/muuli_wdr.cpp:2121
+#: src/muuli_wdr.cpp:2125
 msgid "The interface amuleapi's HTTP server listens on. 127.0.0.1 (default) accepts only local connections; use 0.0.0.0 or a specific IP to expose it to other hosts (set an admin password below)."
 msgstr "La interfaz en la que escucha el servidor HTTP de amuleapi es 127.0.0.1 (por defecto), que solo acepta conexiones locales; utilice 0.0.0.0 o una IP específica para exponerla a otros hosts (establezca una contraseña de administrador a continuación)."
 
-#: src/muuli_wdr.cpp:2126
+#: src/muuli_wdr.cpp:2130
 msgid "Type a password to set or change it. Stored passwords cannot be shown, so leaving this empty keeps the current one."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2128
+#: src/muuli_wdr.cpp:2132
 msgid "Admin password"
 msgstr "Contraseña Admin"
 
-#: src/muuli_wdr.cpp:2140 src/muuli_wdr.cpp:2157 src/PrefsUnifiedDlg.cpp:1103
+#: src/muuli_wdr.cpp:2144 src/muuli_wdr.cpp:2161 src/PrefsUnifiedDlg.cpp:1112
 #, fuzzy
 msgid "A password is set."
 msgstr "Contraseña Admin"
 
-#: src/muuli_wdr.cpp:2144
+#: src/muuli_wdr.cpp:2148
 #, fuzzy
 msgid "Enable guest access"
 msgstr "Denegar el acceso de invitado"
 
-#: src/muuli_wdr.cpp:2145
+#: src/muuli_wdr.cpp:2149
 msgid "Guest sessions may read status and listings but cannot change anything. Turning this off clears the stored guest password."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2149
+#: src/muuli_wdr.cpp:2153
 #, fuzzy
 msgid "Guest password"
 msgstr "Contraseña de invitado para el servidor web"
 
-#: src/muuli_wdr.cpp:2164
+#: src/muuli_wdr.cpp:2168
 msgid "Web server parameters"
 msgstr "Parámetros del servidor web"
 
-#: src/muuli_wdr.cpp:2167
+#: src/muuli_wdr.cpp:2171
 msgid "Run webserver on startup (deprecated)"
 msgstr "Ejecutar webserver al iniciar (obsoleto)"
 
-#: src/muuli_wdr.cpp:2173
+#: src/muuli_wdr.cpp:2177
 msgid "Web template"
 msgstr "Plantilla web"
 
-#: src/muuli_wdr.cpp:2178
+#: src/muuli_wdr.cpp:2182
 msgid "Full rights password"
 msgstr "Contraseña de administrador"
 
-#: src/muuli_wdr.cpp:2182
+#: src/muuli_wdr.cpp:2186
 msgid "Enable Low rights User"
 msgstr "Permitir un invitado"
 
-#: src/muuli_wdr.cpp:2187
+#: src/muuli_wdr.cpp:2191
 msgid "Low rights password"
 msgstr "Contraseña del invitado"
 
-#: src/muuli_wdr.cpp:2201
+#: src/muuli_wdr.cpp:2205
 msgid "Enable UPnP port forwarding of the web server port"
 msgstr "Habilitar el reenvío de puertos UPnP en el puerto del servidor web"
 
-#: src/muuli_wdr.cpp:2206
+#: src/muuli_wdr.cpp:2210
 msgid "Web server UPnP TCP port (Optional)"
 msgstr "Puerto TCP del servidor web para UPnP (opcional)"
 
-#: src/muuli_wdr.cpp:2214
+#: src/muuli_wdr.cpp:2218
 msgid "Page Refresh Time (in secs)"
 msgstr "Intervalo de actualización de la página (en segundos)"
 
-#: src/muuli_wdr.cpp:2221
+#: src/muuli_wdr.cpp:2225
 msgid "Enable Gzip compression"
 msgstr "Activar la compresión gzip"
 
-#: src/muuli_wdr.cpp:2255
+#: src/muuli_wdr.cpp:2259
 msgid "Reset page to defaults"
 msgstr "Restablecer a los valores por defecto"
 
-#: src/muuli_wdr.cpp:2256
+#: src/muuli_wdr.cpp:2260
 msgid "Reset the settings on the current page to their default values."
 msgstr "Restablece los ajustes de la página actual a sus valores por defecto."
 
@@ -4553,308 +4553,308 @@ msgstr "Restablece los ajustes de la página actual a sus valores por defecto."
 # botón para cerrar el diálogo de Preferencias guardando los cambios. La
 # traducción sería distinta en cada caso, así que hay que dejar el OK
 # original.
-#: src/muuli_wdr.cpp:2258 src/muuli_wdr.cpp:2344 src/ServerWnd.cpp:274
+#: src/muuli_wdr.cpp:2262 src/muuli_wdr.cpp:2348 src/ServerWnd.cpp:274
 #: src/ServerWnd.cpp:282
 msgid "OK"
 msgstr "OK"
 
-#: src/muuli_wdr.cpp:2260
+#: src/muuli_wdr.cpp:2264
 msgid "Click here to apply any changes made to the preferences."
 msgstr "Haga clic aquí para aplicar los cambios hechos en las preferencias."
 
-#: src/muuli_wdr.cpp:2263
+#: src/muuli_wdr.cpp:2267
 msgid "Reset any changes made to the preferences."
 msgstr "Cancelar los cambios hechos en las preferencias."
 
-#: src/muuli_wdr.cpp:2292
+#: src/muuli_wdr.cpp:2296
 msgid "Comment :"
 msgstr "Comentario:"
 
-#: src/muuli_wdr.cpp:2299
+#: src/muuli_wdr.cpp:2303
 msgid "Incoming Dir :"
 msgstr "Directorio entrante:"
 
-#: src/muuli_wdr.cpp:2308
+#: src/muuli_wdr.cpp:2312
 msgid "Change priority for new assigned files :"
 msgstr "Cambiar la prioridad de los nuevos archivos asignados:"
 
-#: src/muuli_wdr.cpp:2312
+#: src/muuli_wdr.cpp:2316
 msgid "Don't change"
 msgstr "No cambiar"
 
-#: src/muuli_wdr.cpp:2324
+#: src/muuli_wdr.cpp:2328
 msgid "Select color for this Category (currently selected) :"
 msgstr "Seleccione el color para esta categoría (actualmente seleccionado):"
 
-#: src/muuli_wdr.cpp:2391 src/muuli_wdr.cpp:2410 src/muuli_wdr.cpp:2432
+#: src/muuli_wdr.cpp:2395 src/muuli_wdr.cpp:2414 src/muuli_wdr.cpp:2436
 msgid "Click this button to reset the log."
 msgstr "Pulse este botón para borrar el registro."
 
-#: src/muuli_wdr.cpp:2451
+#: src/muuli_wdr.cpp:2455
 msgid "Click on this button to update the servers list from URL ..."
 msgstr "Pulse este botón para actualizar la lista de servidores desde un URL..."
 
-#: src/muuli_wdr.cpp:2455
+#: src/muuli_wdr.cpp:2459
 msgid "Server list"
 msgstr "Lista de servidores"
 
-#: src/muuli_wdr.cpp:2459
+#: src/muuli_wdr.cpp:2463
 msgid "Enter the url to a server.met file here and press the button to the left to update the list of known servers."
 msgstr "Introduzca la URL de un archivo server.met y pulse el botón de la izquierda para actualizar la lista de servidores conocidos."
 
-#: src/muuli_wdr.cpp:2464
+#: src/muuli_wdr.cpp:2468
 msgid "Add server manually: Name"
 msgstr "Añadir servidor manualmente: Nombre"
 
-#: src/muuli_wdr.cpp:2467
+#: src/muuli_wdr.cpp:2471
 msgid "Enter the name of the new server here"
 msgstr "Introduzca aquí el nombre del nuevo servidor"
 
-#: src/muuli_wdr.cpp:2469 src/ServerWnd.cpp:206
+#: src/muuli_wdr.cpp:2473 src/ServerWnd.cpp:206
 msgid "IP:Port"
 msgstr "IP:Puerto"
 
-#: src/muuli_wdr.cpp:2472
+#: src/muuli_wdr.cpp:2476
 msgid "Enter the IP of the server here, using the x.x.x.x format."
 msgstr "Introduzca aquí la IP del servidor, usando el formato \"x.x.x.x\"."
 
-#: src/muuli_wdr.cpp:2478
+#: src/muuli_wdr.cpp:2482
 msgid "Enter the port of the server here."
 msgstr "Introduzca el puerto del servidor."
 
-#: src/muuli_wdr.cpp:2481
+#: src/muuli_wdr.cpp:2485
 msgid "Add manually a server (fill fields to the left before) ..."
 msgstr "Añadir manualmente un servidor (rellene antes los campos de la izquierda)..."
 
-#: src/muuli_wdr.cpp:2510
+#: src/muuli_wdr.cpp:2514
 msgid "aMule Log"
 msgstr "Registro de aMule"
 
-#: src/muuli_wdr.cpp:2518
+#: src/muuli_wdr.cpp:2522
 msgid "Server Info"
 msgstr "Información del servidor"
 
-#: src/muuli_wdr.cpp:2522
+#: src/muuli_wdr.cpp:2526
 msgid "ED2K Info"
 msgstr "Información sobre ED2K"
 
-#: src/muuli_wdr.cpp:2526
+#: src/muuli_wdr.cpp:2530
 msgid "Kad Info"
 msgstr "Información sobre Kad"
 
-#: src/muuli_wdr.cpp:2554
+#: src/muuli_wdr.cpp:2558
 msgid "Click on this button to update the nodes list from URL ..."
 msgstr "Pulse este botón para actualizar la lista de nodos desde el URL..."
 
-#: src/muuli_wdr.cpp:2558
+#: src/muuli_wdr.cpp:2562
 msgid "Nodes (0)"
 msgstr "Nodos (0)"
 
-#: src/muuli_wdr.cpp:2562
+#: src/muuli_wdr.cpp:2566
 msgid "Enter the url to a nodes.dat file here and press the button to the left to update the list of known nodes."
 msgstr "Introduzca la URL del archivo nodes.dat y pulse el botón de la izquierda para actualizar la lista de nodos conocidos."
 
-#: src/muuli_wdr.cpp:2565
+#: src/muuli_wdr.cpp:2569
 msgid "Nodes stats"
 msgstr "Estadísticas de nodos"
 
-#: src/muuli_wdr.cpp:2607
+#: src/muuli_wdr.cpp:2611
 msgid "Bootstrap"
 msgstr "Inicialización"
 
-#: src/muuli_wdr.cpp:2610
+#: src/muuli_wdr.cpp:2614
 msgid "New node"
 msgstr "Nuevo nodo"
 
-#: src/muuli_wdr.cpp:2615
+#: src/muuli_wdr.cpp:2619
 msgid "IP:"
 msgstr "IP:"
 
-#: src/muuli_wdr.cpp:2635
+#: src/muuli_wdr.cpp:2639
 msgid "Port:"
 msgstr "Puerto:"
 
-#: src/muuli_wdr.cpp:2648
+#: src/muuli_wdr.cpp:2652
 msgid "Bootstrap from known clients"
 msgstr "Inicializar desde clientes conocidos"
 
-#: src/muuli_wdr.cpp:2650
+#: src/muuli_wdr.cpp:2654
 msgid "Disconnect Kad"
 msgstr "Desconectar Kad"
 
-#: src/muuli_wdr.cpp:2684
+#: src/muuli_wdr.cpp:2688
 msgid "Use Secure User Identification"
 msgstr "Usar la Identificación Segura de Usuario (ISU)"
 
-#: src/muuli_wdr.cpp:2686
+#: src/muuli_wdr.cpp:2690
 msgid "It is recommended to enable this option. You will not receive credits if SUI is not enabled."
 msgstr "Se recomienda activar esta opción. No recibirá créditos si la ISU no está habilitada."
 
-#: src/muuli_wdr.cpp:2688
+#: src/muuli_wdr.cpp:2692
 msgid "Protocol Obfuscation"
 msgstr "Ofuscación de protocolo"
 
-#: src/muuli_wdr.cpp:2691
+#: src/muuli_wdr.cpp:2695
 msgid "Support Protocol Obfuscation"
 msgstr "Permitir la ofuscación de protocolo"
 
-#: src/muuli_wdr.cpp:2693
+#: src/muuli_wdr.cpp:2697
 msgid "This option enabled Protocol Obfuscation, and makes aMule accept obfuscated connections from other clients."
 msgstr "Esta opción activa la ofuscación de protocolo y hace que aMule acepte conexiones ofuscadas de otros clientes."
 
-#: src/muuli_wdr.cpp:2695
+#: src/muuli_wdr.cpp:2699
 msgid "Use obfuscation for outgoing connections"
 msgstr "Usar la ofuscación para las conexiones salientes"
 
-#: src/muuli_wdr.cpp:2697
+#: src/muuli_wdr.cpp:2701
 msgid "This option makes aMule use Protocol Obfuscation when connecting other clients/servers."
 msgstr "Esta opción hace que aMule use la ofuscación de protocolo cuando se conecta a otros clientes/servidores."
 
-#: src/muuli_wdr.cpp:2699
+#: src/muuli_wdr.cpp:2703
 msgid "Accept only obfuscated connections"
 msgstr "Aceptar sólo conexiones ofuscadas"
 
-#: src/muuli_wdr.cpp:2700
+#: src/muuli_wdr.cpp:2704
 msgid "This option makes aMule only accept obfuscated connections. You will have less sources, but all your traffic will be obfuscated"
 msgstr "Esta opción hace que aMule sólo acepte conexiones ofuscadas. Tendrá menos fuentes, pero todo su tráfico estará ofuscado"
 
-#: src/muuli_wdr.cpp:2705
+#: src/muuli_wdr.cpp:2709
 msgid "Everybody"
 msgstr "Todos"
 
-#: src/muuli_wdr.cpp:2707
+#: src/muuli_wdr.cpp:2711
 msgid "No one"
 msgstr "Nadie"
 
-#: src/muuli_wdr.cpp:2709
+#: src/muuli_wdr.cpp:2713
 msgid "Who can see my shared files:"
 msgstr "Quién puede ver mis archivos compartidos:"
 
-#: src/muuli_wdr.cpp:2710
+#: src/muuli_wdr.cpp:2714
 msgid "Select who can request to view a list of your shared files."
 msgstr "Seleccione quién puede solicitar ver la lista de sus archivos compartidos."
 
-#: src/muuli_wdr.cpp:2712
+#: src/muuli_wdr.cpp:2716
 msgid "IP-Filtering"
 msgstr "Filtrado de direcciones IP"
 
-#: src/muuli_wdr.cpp:2719
+#: src/muuli_wdr.cpp:2723
 msgid "Filter clients"
 msgstr "Filtrar los clientes"
 
-#: src/muuli_wdr.cpp:2721
+#: src/muuli_wdr.cpp:2725
 msgid "Enable filtering of the client IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "Habilitar el filtrado de las IP de clientes definidas en el archivo ~/.aMule/ipfilter.dat."
 
-#: src/muuli_wdr.cpp:2723
+#: src/muuli_wdr.cpp:2727
 msgid "Filter servers"
 msgstr "Filtrar los servidores"
 
-#: src/muuli_wdr.cpp:2725
+#: src/muuli_wdr.cpp:2729
 msgid "Enable filtering of the server IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "Habilitar el filtrado de las IP de servidores definidas en el archivo ~/.aMule/ipfilter.dat."
 
-#: src/muuli_wdr.cpp:2729
+#: src/muuli_wdr.cpp:2733
 msgid "Reload List"
 msgstr "Recargar la lista"
 
-#: src/muuli_wdr.cpp:2730
+#: src/muuli_wdr.cpp:2734
 msgid "Reload the list of IPs to filter from the file ~/.aMule/ipfilter.dat"
 msgstr "Recargar la lista de filtrado de IP desde el archivo ~/.aMule/ipfilter.dat"
 
-#: src/muuli_wdr.cpp:2736
+#: src/muuli_wdr.cpp:2740
 msgid "URL:"
 msgstr "URL:"
 
-#: src/muuli_wdr.cpp:2740 src/muuli_wdr.cpp:2933
+#: src/muuli_wdr.cpp:2744 src/muuli_wdr.cpp:2937
 msgid "Update now"
 msgstr "Actualizar ahora"
 
-#: src/muuli_wdr.cpp:2743
+#: src/muuli_wdr.cpp:2747
 msgid "Auto-update ipfilter at startup"
 msgstr "Autoactualizar el filtro de IP al inicio"
 
-#: src/muuli_wdr.cpp:2747
+#: src/muuli_wdr.cpp:2751
 msgid "Filtering Level:"
 msgstr "Nivel de filtrado:"
 
-#: src/muuli_wdr.cpp:2753
+#: src/muuli_wdr.cpp:2757
 msgid "Always filter LAN IPs"
 msgstr "Filtrar siempre las IP de LAN"
 
-#: src/muuli_wdr.cpp:2756
+#: src/muuli_wdr.cpp:2760
 msgid "Paranoid handling of non-matching IPs"
 msgstr "Gestión paranoica de las IP que no coincidan"
 
-#: src/muuli_wdr.cpp:2758
+#: src/muuli_wdr.cpp:2762
 msgid "Rejects a packet when its source IP differs from the IP the client claims (an anti-spoofing check). Disable only if it causes connection problems."
 msgstr "Rechaza un paquete cuando su IP de origen es diferente de la IP que el cliente dice tener (comprobación anti-suplantación). Desactivar sólo si causa problemas de conexión."
 
-#: src/muuli_wdr.cpp:2760
+#: src/muuli_wdr.cpp:2764
 msgid "Use system-wide ipfilter.dat if available"
 msgstr "Usar el ipfilter.dat del sistema si está disponible"
 
-#: src/muuli_wdr.cpp:2761
+#: src/muuli_wdr.cpp:2765
 msgid "If there's no local ipfilter.dat found, allow usage of a system-wide ipfilter file."
 msgstr "Si no hay un archivo ipfilter.dat local, permitir el uso de un archivo ipfilter del sistema."
 
-#: src/muuli_wdr.cpp:2778
+#: src/muuli_wdr.cpp:2782
 msgid "Enable Online-Signature"
 msgstr "Habilitar la firma digital"
 
-#: src/muuli_wdr.cpp:2780
+#: src/muuli_wdr.cpp:2784
 msgid "Enables the writing of the OS file, which can be used by external apps to create signatures and the like."
 msgstr "Habilita la escritura de archivos de firma digital, algo que puede ser usado por las aplicaciones externas para crear firmas y cosas parecidas."
 
-#: src/muuli_wdr.cpp:2784
+#: src/muuli_wdr.cpp:2788
 msgid "Update Frequency (Secs):"
 msgstr "Frecuencia de actualización (segundos):"
 
-#: src/muuli_wdr.cpp:2787
+#: src/muuli_wdr.cpp:2791
 msgid "Change the frequency (in seconds) of Online Signature updates."
 msgstr "Cambiar la frecuencia (en segundos) de actualización de la firma digital."
 
-#: src/muuli_wdr.cpp:2795
+#: src/muuli_wdr.cpp:2799
 msgid "Save online signature file in: "
 msgstr "Guardar el archivo de firma digital en: "
 
-#: src/muuli_wdr.cpp:2801
+#: src/muuli_wdr.cpp:2805
 msgid "Click here to select the directory containing the the Online Signature files."
 msgstr "Pulse aquí para seleccionar el directorio que contiene los archivos de firmas digitales."
 
-#: src/muuli_wdr.cpp:2834
+#: src/muuli_wdr.cpp:2838
 msgid "Show country flags for clients"
 msgstr "Mostrar las banderas de los países para los clientes"
 
-#: src/muuli_wdr.cpp:2835
+#: src/muuli_wdr.cpp:2839
 msgid "Render the country flag column in the transfers, queue and search views. Requires a valid MMDB GeoIP database (see below)."
 msgstr "Mostrar la columna de la bandera del país en las vistas de transferencias, cola y búsqueda. Requiere una base de datos MMDB GeoIP válida (ver más abajo)."
 
-#: src/muuli_wdr.cpp:2840
+#: src/muuli_wdr.cpp:2844
 msgid "Database"
 msgstr "Base de datos"
 
-#: src/muuli_wdr.cpp:2856
+#: src/muuli_wdr.cpp:2860
 msgid "Source:"
 msgstr "Fuente:"
 
-#: src/muuli_wdr.cpp:2859
+#: src/muuli_wdr.cpp:2863
 msgid "DB-IP (free, no account)"
 msgstr "DB-IP (gratis, sin crear una cuenta)"
 
-#: src/muuli_wdr.cpp:2860
+#: src/muuli_wdr.cpp:2864
 msgid "MaxMind GeoLite2 (free, account required)"
 msgstr "MaxMind GeoLite2 (gratuito, requiere crear una cuenta)"
 
-#: src/muuli_wdr.cpp:2861
+#: src/muuli_wdr.cpp:2865
 msgid "Custom URL"
 msgstr "URL personalizada"
 
-#: src/muuli_wdr.cpp:2864
+#: src/muuli_wdr.cpp:2868
 msgid "Choose which provider supplies the GeoIP MMDB database. DB-IP is the default - no account required. MaxMind requires a free account + license key. Use Custom URL to point at any other MMDB host (e.g. a local mirror)."
 msgstr "Elige qué proveedor ofrece la base de datos GeoIP MMDB. DB-IP es la opción predeterminada; no se necesita cuenta. MaxMind requiere una cuenta gratuita y una clave de licencia. Utiliza la opción 'URL personalizada' para indicar cualquier otro servidor MMDB (por ejemplo, un servidor espejo local)."
 
-#: src/muuli_wdr.cpp:2881
+#: src/muuli_wdr.cpp:2885
 msgid ""
 "No configuration required.\n"
 "\n"
@@ -4866,11 +4866,11 @@ msgstr ""
 "Datos IP-País de DB-IP.com - https://db-ip.com\n"
 "Licencia: Creative Commons BY 4.0 - https://creativecommons.org/licenses/by/4.0/"
 
-#: src/muuli_wdr.cpp:2894
+#: src/muuli_wdr.cpp:2898
 msgid "License key:"
 msgstr "Clave de licencia:"
 
-#: src/muuli_wdr.cpp:2900
+#: src/muuli_wdr.cpp:2904
 msgid ""
 "Sign up for a free MaxMind account, then generate a License Key:\n"
 "https://www.maxmind.com/en/geolite2/signup\n"
@@ -4886,11 +4886,11 @@ msgstr ""
 "Licencia: EULA de MaxMind GeoLite2 - https://www.maxmind.com/en/geolite2/eula\n"
 "Requiere la atribución de la fuente y el registro de una cuenta; actualizar al menos cada 30 días."
 
-#: src/muuli_wdr.cpp:2915
+#: src/muuli_wdr.cpp:2919
 msgid "Download URL:"
 msgstr "URL de descarga:"
 
-#: src/muuli_wdr.cpp:2921
+#: src/muuli_wdr.cpp:2925
 msgid ""
 "Must point to an .mmdb file or a .gz / .tar.gz containing one.\n"
 "URL may include credentials (https://user:pass@host/...).\n"
@@ -4900,211 +4900,211 @@ msgstr ""
 "La URL puede incluir credenciales (https://user:pass@host/...).\n"
 "Las condiciones de licencia y atribución dependen de la URL de descarga; la responsabilidad recae en ti."
 
-#: src/muuli_wdr.cpp:2934
+#: src/muuli_wdr.cpp:2938
 msgid "Download the GeoIP database from the selected source."
 msgstr "Descarga la base de datos GeoIP de la fuente seleccionada."
 
-#: src/muuli_wdr.cpp:2936
+#: src/muuli_wdr.cpp:2940
 msgid "Auto-update on startup"
 msgstr "Autoactualizar al inicio"
 
-#: src/muuli_wdr.cpp:2937
+#: src/muuli_wdr.cpp:2941
 msgid "Re-download the GeoIP database from the selected source every time aMule starts."
 msgstr "Vuelve a descargar la base de datos GeoIP desde la fuente seleccionada cada vez que se inicie aMule."
 
-#: src/muuli_wdr.cpp:2960
+#: src/muuli_wdr.cpp:2964
 msgid "Filter incoming messages (except current chat):"
 msgstr "Filtrar los mensajes entrantes (salvo la conversación actual):"
 
-#: src/muuli_wdr.cpp:2962
+#: src/muuli_wdr.cpp:2966
 msgid "Filter all messages"
 msgstr "Filtrar todos los mensajes"
 
-#: src/muuli_wdr.cpp:2964
+#: src/muuli_wdr.cpp:2968
 msgid "Filter messages from people not on your friend list"
 msgstr "Filtrar los mensajes de gente que no esté en su lista de amigos"
 
-#: src/muuli_wdr.cpp:2966
+#: src/muuli_wdr.cpp:2970
 msgid "Filter messages from unknown clients"
 msgstr "Filtrar los mensajes de clientes desconocidos"
 
-#: src/muuli_wdr.cpp:2968
+#: src/muuli_wdr.cpp:2972
 msgid "Filter messages containing (use ',' as separator):"
 msgstr "Filtrar los mensajes que contengan (use ',' como separador):"
 
-#: src/muuli_wdr.cpp:2971 src/muuli_wdr.cpp:2982
+#: src/muuli_wdr.cpp:2975 src/muuli_wdr.cpp:2986
 msgid "add here the words amule should filter and block messages including it"
 msgstr "añada aquí las palabras que amule debe filtrar para bloquear los mensajes que las incluyan"
 
-#: src/muuli_wdr.cpp:2973
+#: src/muuli_wdr.cpp:2977
 msgid "Show received messages in the log"
 msgstr "Mostrar los mensajes recibidos en el registro"
 
-#: src/muuli_wdr.cpp:2976
+#: src/muuli_wdr.cpp:2980
 msgid "Comments"
 msgstr "Comentarios"
 
-#: src/muuli_wdr.cpp:2979
+#: src/muuli_wdr.cpp:2983
 msgid "Filter comments containing (use ',' as separator):"
 msgstr "Filtrar los comentarios que contengan (use ',' como separador):"
 
-#: src/muuli_wdr.cpp:3004
+#: src/muuli_wdr.cpp:3008
 msgid "Enable Proxy"
 msgstr "Habilitar el proxy"
 
-#: src/muuli_wdr.cpp:3005
+#: src/muuli_wdr.cpp:3009
 msgid "Enable/disable proxy support"
 msgstr "Habilitar/deshabilitar el soporte para proxy"
 
-#: src/muuli_wdr.cpp:3008
+#: src/muuli_wdr.cpp:3012
 msgid "Proxy type:"
 msgstr "Tipo de proxy:"
 
-#: src/muuli_wdr.cpp:3019
+#: src/muuli_wdr.cpp:3023
 msgid "Proxy host:"
 msgstr "Servidor proxy:"
 
-#: src/muuli_wdr.cpp:3022
+#: src/muuli_wdr.cpp:3026
 msgid "The proxy host name"
 msgstr "Nombre del host del proxy"
 
-#: src/muuli_wdr.cpp:3024
+#: src/muuli_wdr.cpp:3028
 msgid "Proxy port:"
 msgstr "Puerto del proxy:"
 
-#: src/muuli_wdr.cpp:3027
+#: src/muuli_wdr.cpp:3031
 msgid "The proxy port"
 msgstr "El puerto del proxy"
 
-#: src/muuli_wdr.cpp:3029
+#: src/muuli_wdr.cpp:3033
 msgid "Enable authentication"
 msgstr "Habilitar la autentificación"
 
-#: src/muuli_wdr.cpp:3030
+#: src/muuli_wdr.cpp:3034
 msgid "Enable/disable username/password authentication"
 msgstr "Habilitar/deshabilitar la autenticación mediante usuario/contraseña"
 
-#: src/muuli_wdr.cpp:3033
+#: src/muuli_wdr.cpp:3037
 msgid "Username: "
 msgstr "Nombre de usuario: "
 
-#: src/muuli_wdr.cpp:3036
+#: src/muuli_wdr.cpp:3040
 msgid "The username to use to connect to the proxy"
 msgstr "El nombre de usuario a usar para conectar al proxy"
 
-#: src/muuli_wdr.cpp:3038
+#: src/muuli_wdr.cpp:3042
 msgid "Password:"
 msgstr "Contraseña:"
 
-#: src/muuli_wdr.cpp:3041
+#: src/muuli_wdr.cpp:3045
 msgid "The password to use to connect to the proxy"
 msgstr "La contraseña a usar para conectar al proxy"
 
-#: src/muuli_wdr.cpp:3060
+#: src/muuli_wdr.cpp:3064
 msgid "Connect to:"
 msgstr "Conectar a:"
 
-#: src/muuli_wdr.cpp:3069
+#: src/muuli_wdr.cpp:3073
 msgid "Login to remote amule"
 msgstr "Conexión a aMule remoto"
 
-#: src/muuli_wdr.cpp:3074
+#: src/muuli_wdr.cpp:3078
 msgid "User name"
 msgstr "Nombre de usuario"
 
-#: src/muuli_wdr.cpp:3085
+#: src/muuli_wdr.cpp:3089
 msgid "Remember those settings"
 msgstr "Recordar estas opciones"
 
-#: src/muuli_wdr.cpp:3088
+#: src/muuli_wdr.cpp:3092
 msgid "Force ZLIB compression"
 msgstr "Forzar compresión ZLIB"
 
-#: src/muuli_wdr.cpp:3112
+#: src/muuli_wdr.cpp:3116
 msgid "Enable Verbose Debug-Logging."
 msgstr "Habilitar el modo detallado de depuración."
 
-#: src/muuli_wdr.cpp:3114
+#: src/muuli_wdr.cpp:3118
 msgid "Only to Logfile"
 msgstr "Sólo al archivo de registro"
 
-#: src/muuli_wdr.cpp:3116
+#: src/muuli_wdr.cpp:3120
 msgid "Message Categories:"
 msgstr "Categorías de mensajes:"
 
-#: src/muuli_wdr.cpp:3140 src/PartFileConvertDlg.cpp:160
+#: src/muuli_wdr.cpp:3144 src/PartFileConvertDlg.cpp:160
 msgid "Waiting..."
 msgstr "Esperando..."
 
-#: src/muuli_wdr.cpp:3160
+#: src/muuli_wdr.cpp:3164
 msgid "Add imports"
 msgstr "Añadir lo importado"
 
-#: src/muuli_wdr.cpp:3163
+#: src/muuli_wdr.cpp:3167
 msgid "Retry selected"
 msgstr "Reintentar seleccionado"
 
-#: src/muuli_wdr.cpp:3165
+#: src/muuli_wdr.cpp:3169
 msgid "Remove selected"
 msgstr "Borrar seleccionado"
 
-#: src/muuli_wdr.cpp:3228
+#: src/muuli_wdr.cpp:3232
 msgid "Event Types"
 msgstr "Tipos de evento"
 
-#: src/muuli_wdr.cpp:3247
+#: src/muuli_wdr.cpp:3251
 msgid "Statistics and queued clients for selected file(s) : Session / All time"
 msgstr "Estadísticas y clientes en la cola para los archivos seleccionados: Sesión / Total"
 
-#: src/muuli_wdr.cpp:3271
+#: src/muuli_wdr.cpp:3275
 msgid "Active Uploads"
 msgstr "Subidas activas"
 
-#: src/muuli_wdr.cpp:3285
+#: src/muuli_wdr.cpp:3289
 msgid "Percent of total files"
 msgstr "Porcentaje del total de archivos"
 
-#: src/muuli_wdr.cpp:3337
+#: src/muuli_wdr.cpp:3341
 msgid "Show Clients for"
 msgstr "Mostrar los clientes para"
 
-#: src/muuli_wdr.cpp:3339
+#: src/muuli_wdr.cpp:3343
 msgid "All files"
 msgstr "Todos los archivos"
 
-#: src/muuli_wdr.cpp:3342
+#: src/muuli_wdr.cpp:3346
 msgid "Selected files"
 msgstr "Archivos seleccionados"
 
-#: src/muuli_wdr.cpp:3345
+#: src/muuli_wdr.cpp:3349
 msgid "Active uploads only"
 msgstr "Solo las subidas activas"
 
-#: src/muuli_wdr.cpp:3352
+#: src/muuli_wdr.cpp:3356
 msgid "Reload:"
 msgstr "Recargar:"
 
-#: src/muuli_wdr.cpp:3356
+#: src/muuli_wdr.cpp:3360
 msgid "Reload your shared files"
 msgstr "Recargar los archivos compartidos"
 
-#: src/muuli_wdr.cpp:3419
+#: src/muuli_wdr.cpp:3423
 msgid "Send"
 msgstr "Enviar"
 
-#: src/muuli_wdr.cpp:3420
+#: src/muuli_wdr.cpp:3424
 msgid "Sends the specified message."
 msgstr "Envía el mensaje especificado."
 
-#: src/muuli_wdr.cpp:3424
+#: src/muuli_wdr.cpp:3428
 msgid "Close this chat-session."
 msgstr "Cerrar esta sesión de chat."
 
-#: src/muuli_wdr.cpp:3447
+#: src/muuli_wdr.cpp:3451
 msgid "Connect to any server and/or Kad"
 msgstr "Conectar a cualquier servidor y/o a Kad"
 
-#: src/muuli_wdr.cpp:3453 src/SharedFilesCtrl.cpp:142 src/Statistics.cpp:941
+#: src/muuli_wdr.cpp:3457 src/SharedFilesCtrl.cpp:142 src/Statistics.cpp:941
 msgid "Shared Files"
 msgstr "Compartidos"
 
@@ -5739,35 +5739,35 @@ msgstr ""
 "aMule funciona bien sin cambiar ninguno de\n"
 "estos parámetros."
 
-#: src/PrefsUnifiedDlg.cpp:647
+#: src/PrefsUnifiedDlg.cpp:656
 #, c-format
 msgid "Failed to connect Cfg to widget with the ID %d and key %s"
 msgstr "Error al conectar configuración con programa, con el ID %d y clave %s"
 
-#: src/PrefsUnifiedDlg.cpp:695
+#: src/PrefsUnifiedDlg.cpp:704
 #, c-format
 msgid "Failed to transfer data from Cfg to Widget with the ID %d and key %s"
 msgstr "Error al transferir datos desde la configuración al programa, con el ID %d y la clave %s"
 
-#: src/PrefsUnifiedDlg.cpp:801
+#: src/PrefsUnifiedDlg.cpp:810
 msgid "The type of proxy you are connecting to"
 msgstr "El tipo de proxy al que se está conectando"
 
-#: src/PrefsUnifiedDlg.cpp:1020
+#: src/PrefsUnifiedDlg.cpp:1029
 #, c-format
 msgid "Failed to transfer data from Widget to Cfg with the ID %d and key %s"
 msgstr "Error al transferir datos desde el programa a la configuración, con el ID %d y la clave %s"
 
-#: src/PrefsUnifiedDlg.cpp:1103
+#: src/PrefsUnifiedDlg.cpp:1112
 #, fuzzy
 msgid "No password set."
 msgstr "Contraseña Admin"
 
-#: src/PrefsUnifiedDlg.cpp:1132
+#: src/PrefsUnifiedDlg.cpp:1141
 msgid "Guest access needs a password. Type one in the guest password field, or untick Enable guest access."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1144
+#: src/PrefsUnifiedDlg.cpp:1153
 msgid ""
 "aMule must be restarted to enable these changes:\n"
 "\n"
@@ -5775,39 +5775,39 @@ msgstr ""
 "aMule debe reiniciarse para aplicar los cambios:\n"
 "\n"
 
-#: src/PrefsUnifiedDlg.cpp:1151
+#: src/PrefsUnifiedDlg.cpp:1160
 msgid "- TCP port changed.\n"
 msgstr "- El puerto TCP ha cambiado.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1156
+#: src/PrefsUnifiedDlg.cpp:1165
 msgid "- UDP port changed.\n"
 msgstr "- El puerto UDP ha cambiado.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1161
+#: src/PrefsUnifiedDlg.cpp:1170
 msgid "- Network interface binding changed.\n"
 msgstr "- La interfaz de red vinculada ha cambiado.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1166
+#: src/PrefsUnifiedDlg.cpp:1175
 msgid "- External connect port changed.\n"
 msgstr "- El puerto para la conexión externa ha cambiado.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1170
+#: src/PrefsUnifiedDlg.cpp:1179
 msgid "- External connect acceptance changed.\n"
 msgstr "- La aceptación de conexión externa ha cambiado.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1174
+#: src/PrefsUnifiedDlg.cpp:1183
 msgid "- External connect interface changed.\n"
 msgstr "- La interfaz de conexión externa ha cambiado.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1178
+#: src/PrefsUnifiedDlg.cpp:1187
 msgid "- Protocol obfuscation support changed.\n"
 msgstr "- El soporte de ofuscación de protocolo ha cambiado.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1193
+#: src/PrefsUnifiedDlg.cpp:1202
 msgid "- amuleapi settings changed.\n"
 msgstr "- Ajustes de amuleapi modificados.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1202
+#: src/PrefsUnifiedDlg.cpp:1211
 msgid ""
 "Your Auto-update server list is empty.\n"
 "'Auto-update server list at startup' will be disabled."
@@ -5815,7 +5815,7 @@ msgstr ""
 "Su lista autoactualizable de servidores esta vacía.\n"
 "Se desactivará 'Autoactualizar la lista de servidores al inicio'."
 
-#: src/PrefsUnifiedDlg.cpp:1213
+#: src/PrefsUnifiedDlg.cpp:1222
 msgid ""
 "You have enabled external connections but have not specified a password.\n"
 "External connections cannot be enabled unless a valid password is specified."
@@ -5823,32 +5823,32 @@ msgstr ""
 "Tiene habilitadas las conexiones externas, pero no ha especificado ninguna contraseña.\n"
 "Las conexiones externas no pueden ser habilitadas a menos que especifique una contraseña válida."
 
-#: src/PrefsUnifiedDlg.cpp:1246
+#: src/PrefsUnifiedDlg.cpp:1255
 #, c-format
 msgid "The amuleapi password could not be saved: %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1276
+#: src/PrefsUnifiedDlg.cpp:1285
 msgid "- Language changed.\n"
 msgstr "- Idioma cambiado.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1281
+#: src/PrefsUnifiedDlg.cpp:1290
 msgid "- Temp folder changed.\n"
 msgstr "- Carpeta temporal cambiada.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1286
+#: src/PrefsUnifiedDlg.cpp:1295
 msgid "- ED2K network enabled.\n"
 msgstr "- Red ED2K habilitada.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1319
+#: src/PrefsUnifiedDlg.cpp:1328
 msgid "The shared-file exclusion pattern is not a valid regular expression. The filter has been left disabled."
 msgstr "El patrón de exclusión de archivos compartidos no es una expresión regular válida. El filtro ha quedado deshabilitado."
 
-#: src/PrefsUnifiedDlg.cpp:1321 src/PrefsUnifiedDlg.cpp:1921
+#: src/PrefsUnifiedDlg.cpp:1330 src/PrefsUnifiedDlg.cpp:1930
 msgid "Invalid regular expression"
 msgstr "Expresión regular no válida"
 
-#: src/PrefsUnifiedDlg.cpp:1398
+#: src/PrefsUnifiedDlg.cpp:1407
 msgid ""
 "Both eD2k and Kad network are disabled.\n"
 "You won't be able to connect until you enable at least one of them."
@@ -5856,7 +5856,7 @@ msgstr ""
 "eD2k y Kad están desactivados.\n"
 "No podrá conectarse hasta que active al menos uno de ellos."
 
-#: src/PrefsUnifiedDlg.cpp:1403
+#: src/PrefsUnifiedDlg.cpp:1412
 msgid ""
 "Kad will not start if your UDP port is disabled.\n"
 "Enable UDP port or disable Kad."
@@ -5864,7 +5864,7 @@ msgstr ""
 "Kad no se inicia si el puerto UDP está deshabilitado.\n"
 "Habilite un puerto UDP o deshabilite Kad."
 
-#: src/PrefsUnifiedDlg.cpp:1459
+#: src/PrefsUnifiedDlg.cpp:1468
 msgid ""
 "\n"
 "You MUST restart aMule now.\n"
@@ -5874,68 +5874,68 @@ msgstr ""
 "DEBE reiniciar aMule ahora.\n"
 "Si no reinicia ahora, no se queje si sucede algo malo.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1524
+#: src/PrefsUnifiedDlg.cpp:1533
 msgid "Could not register aMule for autostart at login. The autostart store may be read-only."
 msgstr "No se pudo registrar aMule para arrancar automáticamente al iniciar sesión. El almacén de arranque automático podría ser de sólo lectura."
 
-#: src/PrefsUnifiedDlg.cpp:1526
+#: src/PrefsUnifiedDlg.cpp:1535
 msgid "Could not remove the autostart-at-login entry."
 msgstr "No se pudo eliminar la entrada de arranque automático."
 
-#: src/PrefsUnifiedDlg.cpp:1527
+#: src/PrefsUnifiedDlg.cpp:1536
 msgid "Autostart"
 msgstr "Arranque automático"
 
-#: src/PrefsUnifiedDlg.cpp:1542
+#: src/PrefsUnifiedDlg.cpp:1551
 msgid "Register file type"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1542
+#: src/PrefsUnifiedDlg.cpp:1551
 msgid "Register URL handler"
 msgstr "Registrar manejador de URL"
 
-#: src/PrefsUnifiedDlg.cpp:1550
+#: src/PrefsUnifiedDlg.cpp:1559
 #, c-format
 msgid "aMule only handles eD2k-compatible magnets. If you replace the current magnet handler (%s), BitTorrent magnet links will stop working - aMule cannot download BitTorrent content. Continue?"
 msgstr "aMule sólo maneja magnet:\\\\ compatibles con eD2k. Si reemplazas el manipulador de magnet:\\\\ actual (%s), los enlaces magnet de BitTorrent dejarán de funcionar: aMule no puede descargar contenido BitTorrent. ¿Continuar?"
 
-#: src/PrefsUnifiedDlg.cpp:1555
+#: src/PrefsUnifiedDlg.cpp:1564
 #, fuzzy, c-format
 msgid "Another application currently opens .emulecollection files (%s). Replace it with aMule?"
 msgstr "Otra aplicación es actualmente el controlador predeterminado para estos enlaces (%s). ¿Reemplazarlo por aMule?"
 
-#: src/PrefsUnifiedDlg.cpp:1560
+#: src/PrefsUnifiedDlg.cpp:1569
 #, c-format
 msgid "Another application is currently the default handler for these links (%s). Replace it with aMule?"
 msgstr "Otra aplicación es actualmente el controlador predeterminado para estos enlaces (%s). ¿Reemplazarlo por aMule?"
 
-#: src/PrefsUnifiedDlg.cpp:1585
+#: src/PrefsUnifiedDlg.cpp:1594
 #, fuzzy
 msgid "Could not register aMule for .emulecollection files. The registration store may be read-only."
 msgstr "No se pudo registrar aMule como el manejador de URL. El almacenamiento del registro podría ser de sólo lectura."
 
-#: src/PrefsUnifiedDlg.cpp:1587
+#: src/PrefsUnifiedDlg.cpp:1596
 #, fuzzy
 msgid "Could not remove the file type registration."
 msgstr "No se pudo retirar el manejador URL del registro."
 
-#: src/PrefsUnifiedDlg.cpp:1589
+#: src/PrefsUnifiedDlg.cpp:1598
 msgid "Could not register aMule as the URL handler. The registration store may be read-only."
 msgstr "No se pudo registrar aMule como el manejador de URL. El almacenamiento del registro podría ser de sólo lectura."
 
-#: src/PrefsUnifiedDlg.cpp:1591
+#: src/PrefsUnifiedDlg.cpp:1600
 msgid "Could not remove the URL handler registration."
 msgstr "No se pudo retirar el manejador URL del registro."
 
-#: src/PrefsUnifiedDlg.cpp:1661 src/PrefsUnifiedDlg.cpp:1688
+#: src/PrefsUnifiedDlg.cpp:1670 src/PrefsUnifiedDlg.cpp:1697
 msgid "The web server and aMule API require external connections to be enabled."
 msgstr "El servidor web y el API de aMule requieren que las conexiones externas estén habilitadas."
 
-#: src/PrefsUnifiedDlg.cpp:1671
+#: src/PrefsUnifiedDlg.cpp:1680
 msgid "The aMule web server is deprecated. Consider running the aMule API instead."
 msgstr "El servidor web aMule está obsoleto. Considere usar el API de aMule en su lugar."
 
-#: src/PrefsUnifiedDlg.cpp:1735
+#: src/PrefsUnifiedDlg.cpp:1744
 msgid ""
 "Your Auto-update servers list is in blank.\n"
 "Please fill in at least one URL to point to a valid server.met file.\n"
@@ -5945,64 +5945,64 @@ msgstr ""
 "Por favor, introduzca al menos un URL que apunte a un archivo server.met válido.\n"
 "Haga clic en el botón \"Lista\" junto a esta casilla para introducir un URL."
 
-#: src/PrefsUnifiedDlg.cpp:1876
+#: src/PrefsUnifiedDlg.cpp:1885
 msgid "Temporary files"
 msgstr "Archivos temporales"
 
-#: src/PrefsUnifiedDlg.cpp:1881
+#: src/PrefsUnifiedDlg.cpp:1890
 msgid "Incoming files"
 msgstr "Archivos entrantes"
 
-#: src/PrefsUnifiedDlg.cpp:1886
+#: src/PrefsUnifiedDlg.cpp:1895
 msgid "Online Signatures"
 msgstr "Firmas digitales"
 
-#: src/PrefsUnifiedDlg.cpp:1899
+#: src/PrefsUnifiedDlg.cpp:1908
 #, c-format
 msgid "Choose a folder for %s"
 msgstr "Elija una carpeta para %s"
 
-#: src/PrefsUnifiedDlg.cpp:1923
+#: src/PrefsUnifiedDlg.cpp:1932
 #, c-format
 msgid "Would exclude %u of %u shared file"
 msgid_plural "Would exclude %u of %u shared files"
 msgstr[0] "Excluiría %u de %u archivo compartido"
 msgstr[1] "Excluiría %u de %u archivos compartidos"
 
-#: src/PrefsUnifiedDlg.cpp:1940
+#: src/PrefsUnifiedDlg.cpp:1949
 msgid "Browse for videoplayer"
 msgstr "Buscar un reproductor de vídeo"
 
-#: src/PrefsUnifiedDlg.cpp:1944
+#: src/PrefsUnifiedDlg.cpp:1953
 msgid "Select browser"
 msgstr "Seleccione el navegador"
 
-#: src/PrefsUnifiedDlg.cpp:1948
+#: src/PrefsUnifiedDlg.cpp:1957
 msgid "Select ffprobe binary"
 msgstr "Seleccione el binario ffprobe"
 
-#: src/PrefsUnifiedDlg.cpp:1954
+#: src/PrefsUnifiedDlg.cpp:1963
 #, c-format
 msgid "Executable%s"
 msgstr "Ejecutable %s"
 
-#: src/PrefsUnifiedDlg.cpp:1988
+#: src/PrefsUnifiedDlg.cpp:1997
 msgid "ffprobe not found on PATH or in the standard install locations. Install ffmpeg (which ships ffprobe) or use Browse to pick a binary manually."
 msgstr "ffprobe no se encuentra en la ruta PATH o en las ubicaciones estándar de instalación. Instala ffmpeg (el cual provee ffprobe) o utiliza Examinar para elegir un binario manualmente."
 
-#: src/PrefsUnifiedDlg.cpp:2000
+#: src/PrefsUnifiedDlg.cpp:2009
 msgid "Reset the settings on this page to their default values?"
 msgstr "¿Desea restablecer los ajustes de esta página a sus valores por defecto?"
 
-#: src/PrefsUnifiedDlg.cpp:2001
+#: src/PrefsUnifiedDlg.cpp:2010
 msgid "Reset to defaults"
 msgstr "Restablecer a valores por defecto"
 
-#: src/PrefsUnifiedDlg.cpp:2028
+#: src/PrefsUnifiedDlg.cpp:2037
 msgid "Edit server list"
 msgstr "Editar la lista de servidores"
 
-#: src/PrefsUnifiedDlg.cpp:2029
+#: src/PrefsUnifiedDlg.cpp:2038
 msgid ""
 "Add here URL's to download server.met files.\n"
 "Only one url on each line."
@@ -6010,114 +6010,114 @@ msgstr ""
 "Añada aquí los URL para descargar los archivos server.met.\n"
 "Sólo un URL por línea."
 
-#: src/PrefsUnifiedDlg.cpp:2084
+#: src/PrefsUnifiedDlg.cpp:2093
 msgid "IP2Country update failed"
 msgstr "Error al actualizar IP2Country"
 
-#: src/PrefsUnifiedDlg.cpp:2229 src/PrefsUnifiedDlg.cpp:2260
+#: src/PrefsUnifiedDlg.cpp:2238 src/PrefsUnifiedDlg.cpp:2269
 msgid "Data by MaxMind GeoLite2"
 msgstr "Datos de MaxMind GeoLite2"
 
-#: src/PrefsUnifiedDlg.cpp:2231 src/PrefsUnifiedDlg.cpp:2262
+#: src/PrefsUnifiedDlg.cpp:2240 src/PrefsUnifiedDlg.cpp:2271
 msgid "Custom source"
 msgstr "Fuente personalizada"
 
-#: src/PrefsUnifiedDlg.cpp:2233 src/PrefsUnifiedDlg.cpp:2264
+#: src/PrefsUnifiedDlg.cpp:2242 src/PrefsUnifiedDlg.cpp:2273
 msgid "Data by DB-IP.com"
 msgstr "Datos de DB-IP.com"
 
-#: src/PrefsUnifiedDlg.cpp:2284
+#: src/PrefsUnifiedDlg.cpp:2293
 #, c-format
 msgid "Status: Loaded%s"
 msgstr "Estado: Cargado%s"
 
-#: src/PrefsUnifiedDlg.cpp:2286
+#: src/PrefsUnifiedDlg.cpp:2295
 #, c-format
 msgid "Status: Loaded%s - %s"
 msgstr "Estado: Cargado%s -%s"
 
-#: src/PrefsUnifiedDlg.cpp:2290
+#: src/PrefsUnifiedDlg.cpp:2299
 msgid "Status: Failed to load - click 'Update now' to refresh."
 msgstr "Estado: No se ha podido cargar. Haz clic en 'Actualizar ahora' para refrescar."
 
-#: src/PrefsUnifiedDlg.cpp:2292
+#: src/PrefsUnifiedDlg.cpp:2301
 msgid "Status: Not found - click 'Update now' to download."
 msgstr "Estado: No encontrado. Haz clic en 'Actualizar ahora' para descargarlo."
 
-#: src/PrefsUnifiedDlg.cpp:2350 src/PrefsUnifiedDlg.cpp:2374
+#: src/PrefsUnifiedDlg.cpp:2359 src/PrefsUnifiedDlg.cpp:2383
 #, c-format
 msgid "Update delay: %d second"
 msgid_plural "Update delay: %d seconds"
 msgstr[0] "Intervalo de actualización: %d segundo"
 msgstr[1] "Intervalo de actualización: %d segundos"
 
-#: src/PrefsUnifiedDlg.cpp:2358
+#: src/PrefsUnifiedDlg.cpp:2367
 #, c-format
 msgid "Time for average graph: %d minute"
 msgid_plural "Time for average graph: %d minutes"
 msgstr[0] "Tiempo medio del gráfico: %d minuto"
 msgstr[1] "Tiempo medio del gráfico: %d minutos"
 
-#: src/PrefsUnifiedDlg.cpp:2367
+#: src/PrefsUnifiedDlg.cpp:2376
 #, c-format
 msgid "Connections Graph Scale: %d"
 msgstr "Escala gráfica de conexiones: %d"
 
-#: src/PrefsUnifiedDlg.cpp:2382
+#: src/PrefsUnifiedDlg.cpp:2391
 #, c-format
 msgid "File Buffer Size: %d byte"
 msgid_plural "File Buffer Size: %d bytes"
 msgstr[0] "Tamaño del búfer de archivo: %d byte"
 msgstr[1] "Tamaño del búfer de archivo: %d bytes"
 
-#: src/PrefsUnifiedDlg.cpp:2392
+#: src/PrefsUnifiedDlg.cpp:2401
 #, c-format
 msgid "Upload Queue Size: %d client"
 msgid_plural "Upload Queue Size: %d clients"
 msgstr[0] "Tamaño de la cola de subida: %d cliente"
 msgstr[1] "Tamaño de la cola de subida: %d clientes"
 
-#: src/PrefsUnifiedDlg.cpp:2402
+#: src/PrefsUnifiedDlg.cpp:2411
 #, c-format
 msgid "Server connection refresh interval: %d minute"
 msgid_plural "Server connection refresh interval: %d minutes"
 msgstr[0] "Intervalo de actualización de la conexión al servidor: %d minuto"
 msgstr[1] "Intervalo de actualización de la conexión al servidor: %d minutos"
 
-#: src/PrefsUnifiedDlg.cpp:2407
+#: src/PrefsUnifiedDlg.cpp:2416
 msgid "Server connection refresh interval: Disabled"
 msgstr "Intervalo de actualización de la conexión al servidor: deshabilitado"
 
-#: src/PrefsUnifiedDlg.cpp:2451
+#: src/PrefsUnifiedDlg.cpp:2460
 msgid "disabled"
 msgstr "deshabilitado"
 
-#: src/PrefsUnifiedDlg.cpp:2477
+#: src/PrefsUnifiedDlg.cpp:2486
 #, c-format
 msgid "Execute command on '%s' event"
 msgstr "Ejecutar comando en el evento '%s'"
 
-#: src/PrefsUnifiedDlg.cpp:2484
+#: src/PrefsUnifiedDlg.cpp:2493
 msgid "Enable command execution on core"
 msgstr "Habilitar la ejecución de comandos en el núcleo"
 
-#: src/PrefsUnifiedDlg.cpp:2496
+#: src/PrefsUnifiedDlg.cpp:2505
 msgid "Core command:"
 msgstr "Comando del núcleo:"
 
-#: src/PrefsUnifiedDlg.cpp:2512
+#: src/PrefsUnifiedDlg.cpp:2521
 msgid "Enable command execution on GUI"
 msgstr "Habilitar la ejecución de comandos en la interfaz"
 
-#: src/PrefsUnifiedDlg.cpp:2524
+#: src/PrefsUnifiedDlg.cpp:2533
 msgid "GUI command:"
 msgstr "Comando de la interfaz:"
 
-#: src/PrefsUnifiedDlg.cpp:2540
+#: src/PrefsUnifiedDlg.cpp:2549
 msgid "The following variables will be replaced:"
 msgstr "Las siguientes variables serán sustituidas:"
 
-#: src/PrefsUnifiedDlg.cpp:2708
+#: src/PrefsUnifiedDlg.cpp:2717
 msgid ""
 "The following folders look like system or sensitive locations:\n"
 "\n"
@@ -6125,37 +6125,37 @@ msgstr ""
 "Estas carpetas parecen ubicaciones sensibles o de sistema:\n"
 "\n"
 
-#: src/PrefsUnifiedDlg.cpp:2713
+#: src/PrefsUnifiedDlg.cpp:2722
 msgid "Sharing them recursively will publish every file underneath on the eD2k/Kad networks. Do you really want to do this?"
 msgstr "Compartirlas recursivamente publicará todos los archivos en las redes eD2k/Kad. ¿Realmente quiere hacerlo?"
 
-#: src/PrefsUnifiedDlg.cpp:2716
+#: src/PrefsUnifiedDlg.cpp:2725
 msgid "Confirm shared folders"
 msgstr "Confirmar carpetas compartidas"
 
-#: src/PrefsUnifiedDlg.cpp:2744
+#: src/PrefsUnifiedDlg.cpp:2753
 msgid "Reloading shared files..."
 msgstr "Recargando los archivos compartidos..."
 
-#: src/PrefsUnifiedDlg.cpp:2745
+#: src/PrefsUnifiedDlg.cpp:2754
 msgid "Scanning for subdirectories..."
 msgstr "Escaneando por subcarpetas..."
 
-#: src/PrefsUnifiedDlg.cpp:2746
+#: src/PrefsUnifiedDlg.cpp:2755
 msgid "Updating shared folders"
 msgstr "Actualizando carpetas compartidas"
 
-#: src/PrefsUnifiedDlg.cpp:2773
+#: src/PrefsUnifiedDlg.cpp:2782
 #, c-format
 msgid "Scanned %u directories..."
 msgstr "Escaneadas %u carpetas..."
 
-#: src/PrefsUnifiedDlg.cpp:2823
+#: src/PrefsUnifiedDlg.cpp:2832
 #, c-format
 msgid "Reloading shared files: %u files scanned"
 msgstr "Recargando archivos compartidos: %u archivos escaneados"
 
-#: src/PrefsUnifiedDlg.cpp:2873
+#: src/PrefsUnifiedDlg.cpp:2882
 msgid "Shared folder"
 msgstr "Carpeta compartida"
 
@@ -7844,12 +7844,12 @@ msgstr "Eliminar la categoría"
 msgid "Hashset requested for unknown file: %s"
 msgstr "Solicitado hashset de un archivo desconocido: %s"
 
-#: src/UploadQueue.cpp:618
+#: src/UploadQueue.cpp:627
 #, c-format
 msgid "Resuming uploads of file: %s"
 msgstr "Reanudando las subidas del archivo: %s"
 
-#: src/UploadQueue.cpp:634
+#: src/UploadQueue.cpp:643
 #, c-format
 msgid "Suspending upload of file: %s"
 msgstr "Suspendiendo la subida del archivo: %s"

--- a/po/et_EE.po
+++ b/po/et_EE.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-28 12:17+0200\n"
+"POT-Creation-Date: 2026-07-28 13:09+0200\n"
 "PO-Revision-Date: 2026-07-27 11:36+0000\n"
 "Last-Translator: \n"
 "Language-Team: Estonian <kde-i18n-doc@kde.org>\n"
@@ -292,7 +292,7 @@ msgid "Password set and external connections enabled."
 msgstr "Parool on määratud ja välised ühendused võimalikud."
 
 #: src/amule.cpp:755 src/KadDlg.cpp:176 src/KadDlg.cpp:185
-#: src/PrefsUnifiedDlg.cpp:1461 src/SharedFilesCtrl.cpp:476
+#: src/PrefsUnifiedDlg.cpp:1470 src/SharedFilesCtrl.cpp:476
 msgid "WARNING"
 msgstr "HOIATUS"
 
@@ -330,7 +330,7 @@ msgstr "Soovisid et web server käivitataks käivitumisel, kuid amuleweb program
 #: src/amule-remote-gui.cpp:603 src/amule-remote-gui.cpp:671
 #: src/amule-remote-gui.cpp:709 src/amule-remote-gui.cpp:1282
 #: src/amule-remote-gui.cpp:1345 src/amule-remote-gui.cpp:1372
-#: src/DownloadQueue.cpp:1481 src/PrefsUnifiedDlg.cpp:1247
+#: src/DownloadQueue.cpp:1481 src/PrefsUnifiedDlg.cpp:1256
 msgid "ERROR"
 msgstr "VIGA"
 
@@ -592,36 +592,36 @@ msgstr "Külasta https://github.com/amule-org/amule/releases/latest ja vaata ehk
 msgid "FATAL ERROR: Failed to create Timer"
 msgstr "Fataalne VIGA: Ei suutnud luua stopperit."
 
-#: src/amuleDlg.cpp:361 src/amuleDlg.cpp:1787 src/amuleDlg.cpp:2033
-#: src/muuli_wdr.cpp:1492 src/muuli_wdr.cpp:3449
+#: src/amuleDlg.cpp:361 src/amuleDlg.cpp:1810 src/amuleDlg.cpp:2056
+#: src/muuli_wdr.cpp:1492 src/muuli_wdr.cpp:3453
 msgid "Networks"
 msgstr "Võrgud"
 
-#: src/amuleDlg.cpp:362 src/amuleDlg.cpp:1793 src/muuli_wdr.cpp:3450
+#: src/amuleDlg.cpp:362 src/amuleDlg.cpp:1816 src/muuli_wdr.cpp:3454
 msgid "Searches"
 msgstr "Otsingud"
 
-#: src/amuleDlg.cpp:363 src/amuleDlg.cpp:1799 src/DownloadListCtrl.cpp:740
-#: src/muuli_wdr.cpp:392 src/muuli_wdr.cpp:1585 src/muuli_wdr.cpp:3451
+#: src/amuleDlg.cpp:363 src/amuleDlg.cpp:1822 src/DownloadListCtrl.cpp:740
+#: src/muuli_wdr.cpp:392 src/muuli_wdr.cpp:1585 src/muuli_wdr.cpp:3455
 #: src/Statistics.cpp:829
 msgid "Downloads"
 msgstr "Tõmbamised"
 
-#: src/amuleDlg.cpp:364 src/amuleDlg.cpp:1805 src/muuli_wdr.cpp:3325
+#: src/amuleDlg.cpp:364 src/amuleDlg.cpp:1828 src/muuli_wdr.cpp:3329
 msgid "Shared files"
 msgstr "Jagatud failid"
 
-#: src/amuleDlg.cpp:365 src/amuleDlg.cpp:1811 src/muuli_wdr.cpp:2957
-#: src/muuli_wdr.cpp:3407 src/muuli_wdr.cpp:3454
+#: src/amuleDlg.cpp:365 src/amuleDlg.cpp:1834 src/muuli_wdr.cpp:2961
+#: src/muuli_wdr.cpp:3411 src/muuli_wdr.cpp:3458
 msgid "Messages"
 msgstr "Teated"
 
-#: src/amuleDlg.cpp:366 src/amuleDlg.cpp:1817 src/muuli_wdr.cpp:3455
+#: src/amuleDlg.cpp:366 src/amuleDlg.cpp:1840 src/muuli_wdr.cpp:3459
 #: src/PrefsUnifiedDlg.cpp:314 src/Statistics.cpp:779 src/Statistics.cpp:1235
 msgid "Statistics"
 msgstr "Statistika"
 
-#: src/amuleDlg.cpp:368 src/amuleDlg.cpp:1824 src/muuli_wdr.cpp:3457
+#: src/amuleDlg.cpp:368 src/amuleDlg.cpp:1847 src/muuli_wdr.cpp:3461
 #: src/PrefsUnifiedDlg.cpp:330 src/utils/wxCas/src/wxcasprefs.cpp:39
 msgid "Preferences"
 msgstr "Seaded"
@@ -680,8 +680,8 @@ msgstr "Kad: Väljas"
 #: src/amuleDlg.cpp:1029 src/DownloadListCtrl.cpp:505
 #: src/DownloadListCtrl.cpp:749 src/FriendListCtrl.cpp:180
 #: src/muuli_wdr.cpp:731 src/muuli_wdr.cpp:782 src/muuli_wdr.cpp:846
-#: src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2262 src/muuli_wdr.cpp:2347
-#: src/muuli_wdr.cpp:3095 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
+#: src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2266 src/muuli_wdr.cpp:2351
+#: src/muuli_wdr.cpp:3099 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
 #: src/ServerListCtrl.cpp:606 src/TransferWnd.cpp:378
 #: src/utils/wxCas/src/wxcasprefs.cpp:235
 msgid "Cancel"
@@ -692,7 +692,7 @@ msgid "Stop the current connection attempts"
 msgstr "Lõpeta käimasolevad ühenduskatsed"
 
 #: src/amuleDlg.cpp:1035 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976
-#: src/muuli_wdr.cpp:2485
+#: src/muuli_wdr.cpp:2489
 msgid "Disconnect"
 msgstr "Ühendu lahti"
 
@@ -701,7 +701,7 @@ msgid "Disconnect from the currently connected networks"
 msgstr "Lõpeta ühendus ühendatud võrkudega"
 
 #: src/amuleDlg.cpp:1041 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979
-#: src/muuli_wdr.cpp:2640 src/muuli_wdr.cpp:3092 src/muuli_wdr.cpp:3447
+#: src/muuli_wdr.cpp:2644 src/muuli_wdr.cpp:3096 src/muuli_wdr.cpp:3451
 msgid "Connect"
 msgstr "Ühenda"
 
@@ -756,7 +756,7 @@ msgstr "Kinnitan väljumise"
 msgid "Launch Command: "
 msgstr "Käivitamise korraldus: "
 
-#: src/amuleDlg.cpp:1632 src/muuli_wdr.cpp:1982 src/Preferences.cpp:979
+#: src/amuleDlg.cpp:1632 src/muuli_wdr.cpp:1986 src/Preferences.cpp:979
 msgid "- default -"
 msgstr "- vaikimisi -"
 
@@ -770,60 +770,60 @@ msgstr "Rüüde kataloogi  '%s' ei eksiteeri"
 msgid "WARNING: Unable to open skin file '%s' for read"
 msgstr "HOIATUS: Ei suuda rüüfaili '%s' lugemiseks avada"
 
-#: src/amuleDlg.cpp:1791 src/muuli_wdr.cpp:3449
+#: src/amuleDlg.cpp:1814 src/muuli_wdr.cpp:3453
 msgid "Networks Window"
 msgstr "Võrgud"
 
-#: src/amuleDlg.cpp:1797 src/muuli_wdr.cpp:3450
+#: src/amuleDlg.cpp:1820 src/muuli_wdr.cpp:3454
 msgid "Searches Window"
 msgstr "Otsingu aken"
 
-#: src/amuleDlg.cpp:1803 src/muuli_wdr.cpp:3451
+#: src/amuleDlg.cpp:1826 src/muuli_wdr.cpp:3455
 msgid "Downloads Window"
 msgstr "Tõmbamised"
 
-#: src/amuleDlg.cpp:1809 src/muuli_wdr.cpp:3453
+#: src/amuleDlg.cpp:1832 src/muuli_wdr.cpp:3457
 msgid "Shared Files Window"
 msgstr "Jagatud failide Aken"
 
-#: src/amuleDlg.cpp:1815 src/muuli_wdr.cpp:3454
+#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3458
 msgid "Messages Window"
 msgstr "Teadete Aken"
 
-#: src/amuleDlg.cpp:1821 src/muuli_wdr.cpp:3455
+#: src/amuleDlg.cpp:1844 src/muuli_wdr.cpp:3459
 msgid "Statistics Graph Window"
 msgstr "Statistiliste graafikute aken"
 
-#: src/amuleDlg.cpp:1828 src/muuli_wdr.cpp:3457
+#: src/amuleDlg.cpp:1851 src/muuli_wdr.cpp:3461
 msgid "Preferences Settings Window"
 msgstr "Seadete aken"
 
-#: src/amuleDlg.cpp:1831 src/muuli_wdr.cpp:3458
+#: src/amuleDlg.cpp:1854 src/muuli_wdr.cpp:3462
 msgid "Import"
 msgstr "Impordi"
 
-#: src/amuleDlg.cpp:1835 src/muuli_wdr.cpp:3458
+#: src/amuleDlg.cpp:1858 src/muuli_wdr.cpp:3462
 msgid "The partfile importer tool"
 msgstr "Osafailide importimise tööriist"
 
-#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3459
+#: src/amuleDlg.cpp:1861 src/muuli_wdr.cpp:3463
 #: src/utils/aLinkCreator/src/alcframe.cpp:262
 msgid "About"
 msgstr "Info"
 
-#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3459
+#: src/amuleDlg.cpp:1861 src/muuli_wdr.cpp:3463
 msgid "About/Help"
 msgstr "Info/Appi"
 
-#: src/amuleDlg.cpp:2036
+#: src/amuleDlg.cpp:2059
 msgid "eD2k network"
 msgstr "eD2k võrk"
 
-#: src/amuleDlg.cpp:2039
+#: src/amuleDlg.cpp:2062
 msgid "Kad network"
 msgstr "Kad võrk"
 
-#: src/amuleDlg.cpp:2039
+#: src/amuleDlg.cpp:2062
 msgid "No network"
 msgstr "Võrk puudub"
 
@@ -1356,19 +1356,19 @@ msgstr "Auto [Kõrge]"
 msgid "Very low"
 msgstr "Väga madal"
 
-#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:743 src/muuli_wdr.cpp:2313
+#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:743 src/muuli_wdr.cpp:2317
 #: src/ServerListCtrl.cpp:263 src/ServerListCtrl.cpp:456
 #: src/SharedFilesCtrl.cpp:145
 msgid "Low"
 msgstr "Madal"
 
-#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:744 src/muuli_wdr.cpp:2314
+#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:744 src/muuli_wdr.cpp:2318
 #: src/ServerListCtrl.cpp:266 src/ServerListCtrl.cpp:457
 #: src/SharedFilesCtrl.cpp:146
 msgid "Normal"
 msgstr "Keskmine"
 
-#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:745 src/muuli_wdr.cpp:2315
+#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:745 src/muuli_wdr.cpp:2319
 #: src/ServerListCtrl.cpp:269 src/ServerListCtrl.cpp:458
 #: src/SharedFilesCtrl.cpp:147
 msgid "High"
@@ -1460,7 +1460,7 @@ msgstr "Kohalik server"
 msgid "Remote Server"
 msgstr "Kaug server"
 
-#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3212
+#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3216
 #: src/SearchDlg.cpp:119 src/TextClient.cpp:911
 msgid "Kad"
 msgstr "Kad"
@@ -1532,7 +1532,7 @@ msgstr "Osa"
 msgid "Size"
 msgstr "Suurus"
 
-#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3279
+#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3283
 msgid "Transferred"
 msgstr "Siiratud"
 
@@ -1590,7 +1590,7 @@ msgstr ""
 "Tagasiside : %s (%s)\n"
 "\n"
 
-#: src/DownloadListCtrl.cpp:746 src/muuli_wdr.cpp:2316
+#: src/DownloadListCtrl.cpp:746 src/muuli_wdr.cpp:2320
 #: src/SharedFilesCtrl.cpp:150
 msgid "Auto"
 msgstr "Auto"
@@ -1628,7 +1628,7 @@ msgid "Extended Options"
 msgstr "Laiendatud valikud"
 
 #: src/DownloadListCtrl.cpp:770 src/DownloadListCtrl.cpp:822
-#: src/muuli_wdr.cpp:1800
+#: src/muuli_wdr.cpp:1804
 msgid "Preview"
 msgstr "Eelvaade"
 
@@ -2429,23 +2429,23 @@ msgid ""
 "want downloads on a different (e.g. larger) disk."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:549 src/FirstRunWizard.cpp:611 src/muuli_wdr.cpp:1712
+#: src/FirstRunWizard.cpp:549 src/FirstRunWizard.cpp:611 src/muuli_wdr.cpp:1716
 msgid "Destination folder for downloads"
 msgstr "Tõmmatavate failide kataloog"
 
 #: src/FirstRunWizard.cpp:553 src/FirstRunWizard.cpp:569 src/muuli_wdr.cpp:1349
-#: src/muuli_wdr.cpp:1366 src/muuli_wdr.cpp:1687 src/muuli_wdr.cpp:1718
-#: src/muuli_wdr.cpp:1730 src/muuli_wdr.cpp:2800
+#: src/muuli_wdr.cpp:1366 src/muuli_wdr.cpp:1691 src/muuli_wdr.cpp:1722
+#: src/muuli_wdr.cpp:1734 src/muuli_wdr.cpp:2804
 #: src/utils/aLinkCreator/src/alcframe.cpp:135
 #: src/utils/wxCas/src/wxcasprefs.cpp:52 src/utils/wxCas/src/wxcasprefs.cpp:118
 msgid "Browse"
 msgstr "Lehitse"
 
-#: src/FirstRunWizard.cpp:559 src/muuli_wdr.cpp:1723
+#: src/FirstRunWizard.cpp:559 src/muuli_wdr.cpp:1727
 msgid "(All files in this folder are shared with other peers)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:565 src/FirstRunWizard.cpp:624 src/muuli_wdr.cpp:1725
+#: src/FirstRunWizard.cpp:565 src/FirstRunWizard.cpp:624 src/muuli_wdr.cpp:1729
 msgid "Folder for temporary download files"
 msgstr "Ajutiste tõmmatavate failide kataloog"
 
@@ -2476,7 +2476,7 @@ msgstr "Sõprade faili 'emfriends.met' avamine kirjutamiseks ebaõnnestus!"
 msgid "CRITICAL - no client on StartChatSession"
 msgstr "KRIITILINE - StartChatSession puudub klient"
 
-#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2706 src/muuli_wdr.cpp:3383
+#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2710 src/muuli_wdr.cpp:3387
 msgid "Friends"
 msgstr "Sõbrad"
 
@@ -2587,8 +2587,8 @@ msgstr "Mitte keegi"
 msgid "No"
 msgstr "Ei"
 
-#: src/GenericClientListCtrl.cpp:1216 src/PrefsUnifiedDlg.cpp:2898
-#: src/PrefsUnifiedDlg.cpp:2948 src/ServerListCtrl.cpp:276
+#: src/GenericClientListCtrl.cpp:1216 src/PrefsUnifiedDlg.cpp:2907
+#: src/PrefsUnifiedDlg.cpp:2957 src/ServerListCtrl.cpp:276
 msgid "Yes"
 msgstr "Jah"
 
@@ -2757,10 +2757,10 @@ msgstr "Bootstrapil vigane port"
 msgid "Please fill all fields required"
 msgstr "Palun täida kõik nõutud väljad"
 
-#: src/KadDlg.cpp:192 src/PartFile.cpp:1031 src/PrefsUnifiedDlg.cpp:1134
-#: src/PrefsUnifiedDlg.cpp:1204 src/PrefsUnifiedDlg.cpp:1405
-#: src/PrefsUnifiedDlg.cpp:1663 src/PrefsUnifiedDlg.cpp:1673
-#: src/PrefsUnifiedDlg.cpp:1690 src/PrefsUnifiedDlg.cpp:1738
+#: src/KadDlg.cpp:192 src/PartFile.cpp:1031 src/PrefsUnifiedDlg.cpp:1143
+#: src/PrefsUnifiedDlg.cpp:1213 src/PrefsUnifiedDlg.cpp:1414
+#: src/PrefsUnifiedDlg.cpp:1672 src/PrefsUnifiedDlg.cpp:1682
+#: src/PrefsUnifiedDlg.cpp:1699 src/PrefsUnifiedDlg.cpp:1747
 msgid "Message"
 msgstr "Teade"
 
@@ -2862,7 +2862,7 @@ msgstr "Üles- ja allalaadimise suhe"
 msgid "Uploaded"
 msgstr "Üleslaaditud"
 
-#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3263
+#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3267
 msgid "Requested"
 msgstr "Küsitud"
 
@@ -2986,7 +2986,7 @@ msgid "WARNING: "
 msgstr "HOIATUS: "
 
 #: src/MuleNotebook.cpp:179 src/muuli_wdr.cpp:817 src/muuli_wdr.cpp:1229
-#: src/muuli_wdr.cpp:3167 src/muuli_wdr.cpp:3423
+#: src/muuli_wdr.cpp:3171 src/muuli_wdr.cpp:3427
 msgid "Close"
 msgstr "Sulge"
 
@@ -3004,7 +3004,7 @@ msgid "Paste"
 msgstr "Aseta"
 
 #: src/MuleTextCtrl.cpp:89 src/muuli_wdr.cpp:358 src/muuli_wdr.cpp:757
-#: src/muuli_wdr.cpp:2390 src/muuli_wdr.cpp:2409 src/muuli_wdr.cpp:2431
+#: src/muuli_wdr.cpp:2394 src/muuli_wdr.cpp:2413 src/muuli_wdr.cpp:2435
 #: src/utils/aLinkCreator/src/alcframe.cpp:142
 msgid "Clear"
 msgstr "Puhasta"
@@ -3103,7 +3103,7 @@ msgstr "Välju"
 
 #: src/MuleTrayIcon.cpp:579 src/MuleTrayIcon.cpp:945 src/MuleTrayIcon.cpp:965
 #: src/muuli_wdr.cpp:1398 src/muuli_wdr.cpp:1406 src/muuli_wdr.cpp:1413
-#: src/muuli_wdr.cpp:1846 src/muuli_wdr.cpp:1852 src/OtherFunctions.cpp:91
+#: src/muuli_wdr.cpp:1850 src/muuli_wdr.cpp:1856 src/OtherFunctions.cpp:91
 #: src/StatisticsDlg.cpp:93 src/StatisticsDlg.cpp:95
 msgid "kB/s"
 msgstr "kB/s"
@@ -3345,7 +3345,7 @@ msgstr "Baiti"
 msgid "KB"
 msgstr "KB"
 
-#: src/muuli_wdr.cpp:274 src/muuli_wdr.cpp:293 src/muuli_wdr.cpp:1631
+#: src/muuli_wdr.cpp:274 src/muuli_wdr.cpp:293 src/muuli_wdr.cpp:1635
 #: src/OtherFunctions.cpp:64
 msgid "MB"
 msgstr "MB"
@@ -3362,7 +3362,7 @@ msgstr "Suurim Suurus"
 msgid "Availability"
 msgstr "Saadavus"
 
-#: src/muuli_wdr.cpp:312 src/muuli_wdr.cpp:398 src/muuli_wdr.cpp:3328
+#: src/muuli_wdr.cpp:312 src/muuli_wdr.cpp:398 src/muuli_wdr.cpp:3332
 msgid "Filter:"
 msgstr "Filter:"
 
@@ -3425,8 +3425,8 @@ msgstr "Faili allikad:"
 #: src/muuli_wdr.cpp:1160 src/muuli_wdr.cpp:1167 src/muuli_wdr.cpp:1172
 #: src/muuli_wdr.cpp:1179 src/muuli_wdr.cpp:1184 src/muuli_wdr.cpp:1191
 #: src/muuli_wdr.cpp:1205 src/muuli_wdr.cpp:1212 src/muuli_wdr.cpp:1217
-#: src/muuli_wdr.cpp:1224 src/muuli_wdr.cpp:3265 src/muuli_wdr.cpp:3273
-#: src/muuli_wdr.cpp:3281
+#: src/muuli_wdr.cpp:1224 src/muuli_wdr.cpp:3269 src/muuli_wdr.cpp:3277
+#: src/muuli_wdr.cpp:3285
 msgid "N/A"
 msgstr "N/A"
 
@@ -3571,7 +3571,7 @@ msgstr ""
 msgid "Album :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:685 src/muuli_wdr.cpp:2285
+#: src/muuli_wdr.cpp:685 src/muuli_wdr.cpp:2289
 msgid "Title :"
 msgstr "Tiitel :"
 
@@ -3680,7 +3680,7 @@ msgstr "Kasutajanimi :"
 msgid "Userhash :"
 msgstr "Kasutaja kontrollsumma :"
 
-#: src/muuli_wdr.cpp:895 src/muuli_wdr.cpp:1752 src/muuli_wdr.cpp:2480
+#: src/muuli_wdr.cpp:895 src/muuli_wdr.cpp:1756 src/muuli_wdr.cpp:2484
 #: src/utils/aLinkCreator/src/alcframe.cpp:137
 msgid "Add"
 msgstr "Lisa"
@@ -3689,15 +3689,15 @@ msgstr "Lisa"
 msgid "Download-Speed"
 msgstr "Tõmbamise kiirus"
 
-#: src/muuli_wdr.cpp:954 src/muuli_wdr.cpp:989 src/muuli_wdr.cpp:2584
+#: src/muuli_wdr.cpp:954 src/muuli_wdr.cpp:989 src/muuli_wdr.cpp:2588
 msgid "Current"
 msgstr "Hetkel"
 
-#: src/muuli_wdr.cpp:962 src/muuli_wdr.cpp:997 src/muuli_wdr.cpp:2592
+#: src/muuli_wdr.cpp:962 src/muuli_wdr.cpp:997 src/muuli_wdr.cpp:2596
 msgid "Running average"
 msgstr "Hetke keskmine"
 
-#: src/muuli_wdr.cpp:970 src/muuli_wdr.cpp:1005 src/muuli_wdr.cpp:2600
+#: src/muuli_wdr.cpp:970 src/muuli_wdr.cpp:1005 src/muuli_wdr.cpp:2604
 msgid "Session average"
 msgstr "Seansi keskmine"
 
@@ -3709,7 +3709,7 @@ msgstr "Saatmise kiirus"
 msgid "Connections"
 msgstr "Ühendused"
 
-#: src/muuli_wdr.cpp:1024 src/muuli_wdr.cpp:1871
+#: src/muuli_wdr.cpp:1024 src/muuli_wdr.cpp:1875
 msgid "Active downloads"
 msgstr "Aktiivsed tõmbamised"
 
@@ -3717,7 +3717,7 @@ msgstr "Aktiivsed tõmbamised"
 msgid "Active connections (1:1)"
 msgstr "Aktiivseid ühendusi (1:1)"
 
-#: src/muuli_wdr.cpp:1040 src/muuli_wdr.cpp:1872
+#: src/muuli_wdr.cpp:1040 src/muuli_wdr.cpp:1876
 msgid "Active uploads"
 msgstr "Aktiivsed saatmised"
 
@@ -3993,7 +3993,7 @@ msgstr "Seo lokaalne aadress IP'ga (suvaliseks jäta tühjaks)"
 msgid "Advanced users only: If you have multiple network interfaces, enter the address of the interface to which aMule should be bound."
 msgstr "Ainult edasijõudnud kasutajatele: Kui sul on kasutada mitu võrguliidest, siis sisesta selle liidese aadress millega aMule võib ennast siduda."
 
-#: src/muuli_wdr.cpp:1462 src/muuli_wdr.cpp:2065
+#: src/muuli_wdr.cpp:1462 src/muuli_wdr.cpp:2069
 #, fuzzy
 msgid "Bind to network interface (empty for any):"
 msgstr "Seo lokaalne aadress IP'ga (suvaliseks jäta tühjaks)"
@@ -4010,7 +4010,7 @@ msgstr "Maksimaalseid allikaid tõmmatava faili kohta:"
 msgid "Max simultaneous connections:"
 msgstr "Maksimaalselt samaaegseid ühendusi:"
 
-#: src/muuli_wdr.cpp:1498 src/muuli_wdr.cpp:3207
+#: src/muuli_wdr.cpp:1498 src/muuli_wdr.cpp:3211
 msgid "ED2K"
 msgstr "ED2K"
 
@@ -4102,779 +4102,779 @@ msgstr "Eralda kettaruum uute failide jaoks"
 msgid "For new files preallocates disk space for the whole file, thus reduces fragmentation"
 msgstr "Eraldab uuet failide jaoks vajamineva kettaruumi, seeläbi väheneb faili fragmenteerumine"
 
-#: src/muuli_wdr.cpp:1617
+#: src/muuli_wdr.cpp:1621
 msgid "Create new files as sparse files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1618
+#: src/muuli_wdr.cpp:1622
 msgid "Sparse part files only occupy disk space for the parts already downloaded, so free space is used up gradually as the file fills in. Turn this off to use an ordinary file instead - useful where sparse files are unsupported or slow, or where backup/de-duplication tools handle them badly. Applies only when the core runs on Windows; on Linux and macOS part files are sparse anyway and this setting has no effect."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1623
+#: src/muuli_wdr.cpp:1627
 msgid "Stop downloads when free disk space reaches "
 msgstr "Lõpeta tõmbamine, kui vaba kettaruumi on jäänud "
 
-#: src/muuli_wdr.cpp:1624
+#: src/muuli_wdr.cpp:1628
 msgid "Select this if you want aMule to check your disk space"
 msgstr "Vali see kui soovid et aMule sinu kettaruumi kontrolliks"
 
-#: src/muuli_wdr.cpp:1628
+#: src/muuli_wdr.cpp:1632
 msgid "Enter here the min disk space desired."
 msgstr "Sisesta siia vähim soovitud kettaruum"
 
-#: src/muuli_wdr.cpp:1634
+#: src/muuli_wdr.cpp:1638
 msgid "Save 10 sources on rare files (< 20 sources)"
 msgstr "Salvesta haruldaste failide 10 allikat (< 20 allikat)"
 
-#: src/muuli_wdr.cpp:1638 src/Statistics.cpp:790
+#: src/muuli_wdr.cpp:1642 src/Statistics.cpp:790
 msgid "Uploads"
 msgstr "Saatmised"
 
-#: src/muuli_wdr.cpp:1641
+#: src/muuli_wdr.cpp:1645
 msgid "Add new shared files with auto priority"
 msgstr "Lisa uued jagatud failid automaatse prioriteediga"
 
-#: src/muuli_wdr.cpp:1647
+#: src/muuli_wdr.cpp:1651
 msgid "Intelligent Corruption Handling (I.C.H.)"
 msgstr "Intelligentne Riknemise Vältimine (I.C.H.)"
 
-#: src/muuli_wdr.cpp:1650
+#: src/muuli_wdr.cpp:1654
 msgid "Enable"
 msgstr "Luba"
 
-#: src/muuli_wdr.cpp:1653
+#: src/muuli_wdr.cpp:1657
 msgid "Advanced I.C.H. trusts every hash (not recommended)"
 msgstr "Laiendatud I.C.H. usaldab suvalist kontrollsummat (pole soovitatav valik)"
 
-#: src/muuli_wdr.cpp:1665 src/PrefsUnifiedDlg.cpp:1990
+#: src/muuli_wdr.cpp:1669 src/PrefsUnifiedDlg.cpp:1999
 msgid "Media metadata extraction"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1669
+#: src/muuli_wdr.cpp:1673
 msgid "Extract length / bitrate / codec from shared audio and video files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1671
+#: src/muuli_wdr.cpp:1675
 msgid "When enabled, aMule runs ffprobe on each shared media file to fill in the Length / Bitrate / Codec columns other clients see when they find the file in a search. Requires ffmpeg (the ffprobe binary) to be installed."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1678
+#: src/muuli_wdr.cpp:1682
 msgid "Path to ffprobe:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1683
+#: src/muuli_wdr.cpp:1687
 msgid "Full path to the ffprobe binary. Leave empty to have aMule auto-detect it on startup."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1691
+#: src/muuli_wdr.cpp:1695
 msgid "Detect"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1692
+#: src/muuli_wdr.cpp:1696
 msgid "Search the standard install locations for an ffprobe binary and fill the path field."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1716
+#: src/muuli_wdr.cpp:1720
 msgid ""
 "Completed downloads are stored here. All files in this folder are automatically shared with other peers.\n"
 "If this folder also holds files you don't want to share, point it at an aMule-only sub-folder."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1719
+#: src/muuli_wdr.cpp:1723
 msgid "Pick the folder where completed downloads will be stored. All files in that folder will be shared with other peers."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1733
+#: src/muuli_wdr.cpp:1737
 msgid "Shared folders"
 msgstr "Jagatud kataloogid"
 
-#: src/muuli_wdr.cpp:1739
+#: src/muuli_wdr.cpp:1743
 msgid "(Folders shared by the core. Enter a path to add one.)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1747
+#: src/muuli_wdr.cpp:1751
 msgid "Absolute path of a folder on the core's machine, e.g. /home/user/shared"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1749 src/PrefsUnifiedDlg.cpp:2874
+#: src/muuli_wdr.cpp:1753 src/PrefsUnifiedDlg.cpp:2883
 msgid "Recursive"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1750
+#: src/muuli_wdr.cpp:1754
 msgid "Share every sub-folder underneath this one, including ones created later."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1754 src/utils/aLinkCreator/src/alcframe.cpp:141
+#: src/muuli_wdr.cpp:1758 src/utils/aLinkCreator/src/alcframe.cpp:141
 msgid "Remove"
 msgstr "Eemalda"
 
-#: src/muuli_wdr.cpp:1758
+#: src/muuli_wdr.cpp:1762
 msgid "(Right click on folder icon for recursive share)"
 msgstr "(Rekursiivseks jagamiseks tee paremklikk kataloogi ikoonil)"
 
-#: src/muuli_wdr.cpp:1765
+#: src/muuli_wdr.cpp:1769
 msgid "Share hidden files"
 msgstr "Jaga peidetud failid"
 
-#: src/muuli_wdr.cpp:1771
+#: src/muuli_wdr.cpp:1775
 msgid "Automatically rescan shared folders for changes"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1777
+#: src/muuli_wdr.cpp:1781
 msgid "Follow symbolic links in shared folders"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1783
+#: src/muuli_wdr.cpp:1787
 msgid "Exclude files matching:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1786
+#: src/muuli_wdr.cpp:1790
 msgid "Wildcard patterns separated by '|', e.g. .DS_Store|Thumbs.db|*.tmp. Files whose name matches are not shared. Matching is case-insensitive."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1790
+#: src/muuli_wdr.cpp:1794
 msgid "Patterns are regular expressions"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1791
+#: src/muuli_wdr.cpp:1795
 msgid "When set, the whole field is one regular expression ('|' is alternation). When unset, it is a list of '|'-separated wildcards."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1801
+#: src/muuli_wdr.cpp:1805
 msgid "Show how many shared files the current pattern would exclude."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1822
+#: src/muuli_wdr.cpp:1826
 msgid "Graphs"
 msgstr "Graafikud"
 
-#: src/muuli_wdr.cpp:1825 src/muuli_wdr.cpp:1887
+#: src/muuli_wdr.cpp:1829 src/muuli_wdr.cpp:1891
 msgid "Update delay : 5 secs"
 msgstr "Värskenduste vahe : 5 sekundit"
 
-#: src/muuli_wdr.cpp:1829
+#: src/muuli_wdr.cpp:1833
 msgid "Time for average graph: 100 mins"
 msgstr "Keskmine graafiku aeg: 100 minutit"
 
-#: src/muuli_wdr.cpp:1833
+#: src/muuli_wdr.cpp:1837
 msgid "Connections Graph Scale: 100 "
 msgstr "Ühenduse graafiku skaala: 100"
 
-#: src/muuli_wdr.cpp:1840
+#: src/muuli_wdr.cpp:1844
 msgid "Download graph scale:"
 msgstr "Tõmbamise graafiku skaala:"
 
-#: src/muuli_wdr.cpp:1848
+#: src/muuli_wdr.cpp:1852
 msgid "Upload graph scale:"
 msgstr "Saatmise graafiku skaala:"
 
-#: src/muuli_wdr.cpp:1858
+#: src/muuli_wdr.cpp:1862
 #, fuzzy
 msgid "Colors: "
 msgstr "Värvid: "
 
-#: src/muuli_wdr.cpp:1862
+#: src/muuli_wdr.cpp:1866
 msgid "Background"
 msgstr "Taust"
 
-#: src/muuli_wdr.cpp:1863
+#: src/muuli_wdr.cpp:1867
 msgid "Grid"
 msgstr "Alusvõrk"
 
-#: src/muuli_wdr.cpp:1864
+#: src/muuli_wdr.cpp:1868
 msgid "Download current"
 msgstr "Allalaadimine, jooksev"
 
-#: src/muuli_wdr.cpp:1865
+#: src/muuli_wdr.cpp:1869
 msgid "Download running average"
 msgstr "Allalaadimine, jooksev keskmine"
 
-#: src/muuli_wdr.cpp:1866
+#: src/muuli_wdr.cpp:1870
 msgid "Download session average"
 msgstr "Allalaadimine, seansi keskmine"
 
-#: src/muuli_wdr.cpp:1867
+#: src/muuli_wdr.cpp:1871
 msgid "Upload current"
 msgstr "Saatmine hetkel"
 
-#: src/muuli_wdr.cpp:1868
+#: src/muuli_wdr.cpp:1872
 msgid "Upload running average"
 msgstr "Hetke saatmise keskmine"
 
-#: src/muuli_wdr.cpp:1869
+#: src/muuli_wdr.cpp:1873
 msgid "Upload session average"
 msgstr "Seansi keskmine saatmine"
 
-#: src/muuli_wdr.cpp:1870
+#: src/muuli_wdr.cpp:1874
 msgid "Active connections"
 msgstr "Aktiivseid ühendusi"
 
-#: src/muuli_wdr.cpp:1873
+#: src/muuli_wdr.cpp:1877
 #, fuzzy
 msgid "Systray Icon Speed Bar"
 msgstr "Süsteemiriba Kiirvaliku Ikoon"
 
-#: src/muuli_wdr.cpp:1874
+#: src/muuli_wdr.cpp:1878
 msgid "Kad-nodes current"
 msgstr "Kad-sõlmi hetkel"
 
-#: src/muuli_wdr.cpp:1875
+#: src/muuli_wdr.cpp:1879
 msgid "Kad-nodes running"
 msgstr "Kad-sõlmi jooksvalt"
 
-#: src/muuli_wdr.cpp:1876
+#: src/muuli_wdr.cpp:1880
 msgid "Kad-nodes session"
 msgstr "Kad-sõlmi seansis"
 
-#: src/muuli_wdr.cpp:1880 src/muuli_wdr.cpp:2334
+#: src/muuli_wdr.cpp:1884 src/muuli_wdr.cpp:2338
 msgid "Select"
 msgstr "Vali"
 
-#: src/muuli_wdr.cpp:1884
+#: src/muuli_wdr.cpp:1888
 msgid "Tree"
 msgstr "Puu"
 
-#: src/muuli_wdr.cpp:1894
+#: src/muuli_wdr.cpp:1898
 msgid "Number of Client Versions shown (0=unlimited)"
 msgstr "Kuvatavate Kliendi Versioonide arv (0=piiramatu)"
 
-#: src/muuli_wdr.cpp:1919
+#: src/muuli_wdr.cpp:1923
 msgid "!!! WARNING !!!"
 msgstr "!!! HOIATUS !!!"
 
-#: src/muuli_wdr.cpp:1934
+#: src/muuli_wdr.cpp:1938
 msgid "Max new connections / 5 secs"
 msgstr "Maksimaalne arv uusi ühendusi / 5 sek."
 
-#: src/muuli_wdr.cpp:1936
+#: src/muuli_wdr.cpp:1940
 msgid "Concurrent Kad source lookups"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1938
+#: src/muuli_wdr.cpp:1942
 #, fuzzy
 msgid "Kad source re-search interval (minutes)"
 msgstr "FTP värskendamise intervall minutites"
 
-#: src/muuli_wdr.cpp:1940
+#: src/muuli_wdr.cpp:1944
 #, fuzzy
 msgid "Source re-ask interval (minutes)"
 msgstr "FTP värskendamise intervall minutites"
 
-#: src/muuli_wdr.cpp:1944
+#: src/muuli_wdr.cpp:1948
 msgid "File Buffer Size: 240000 bytes"
 msgstr "Faili puhvri suurus: 240000 baiti"
 
-#: src/muuli_wdr.cpp:1948
+#: src/muuli_wdr.cpp:1952
 msgid "Use MMAP: memory-mapped file access (lower memory use)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1949
+#: src/muuli_wdr.cpp:1953
 msgid "Maps part files into memory instead of buffering them on the heap, lowering the process memory footprint. May reduce download speed on some disks; best for memory-constrained or upload-heavy hosts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1951
+#: src/muuli_wdr.cpp:1955
 msgid "Upload Queue Size: 5000 clients"
 msgstr "Saatmise saba suurus: 5000 klienti"
 
-#: src/muuli_wdr.cpp:1955
+#: src/muuli_wdr.cpp:1959
 msgid "Server connection refresh interval: Disable"
 msgstr "Serveriühenduse värskenadamise intervall: Ei kasuta"
 
-#: src/muuli_wdr.cpp:1959
+#: src/muuli_wdr.cpp:1963
 msgid "Disable computer's timed standby mode"
 msgstr "Keela arvuti ajastatud uinumine"
 
-#: src/muuli_wdr.cpp:1978
+#: src/muuli_wdr.cpp:1982
 msgid "Skin to use: "
 msgstr "Kasutatav rüü: "
 
-#: src/muuli_wdr.cpp:1987
+#: src/muuli_wdr.cpp:1991
 msgid "Show \"Fast eD2k Links Handler\" in every window."
 msgstr "Näita igas aknas \"Kiiret eD2k lingi käsitlejat\". "
 
-#: src/muuli_wdr.cpp:1990
+#: src/muuli_wdr.cpp:1994
 msgid "Show extended info on categories tabs"
 msgstr "Näita kategooria juures laiendatud infot"
 
-#: src/muuli_wdr.cpp:1993
+#: src/muuli_wdr.cpp:1997
 #, fuzzy
 msgid "Show application version on title"
 msgstr "Näita tiitelribal siirdamise kiirusi"
 
-#: src/muuli_wdr.cpp:1995
+#: src/muuli_wdr.cpp:1999
 msgid "Show transfer rates on title"
 msgstr "Näita tiitelribal siirdamise kiirusi"
 
-#: src/muuli_wdr.cpp:1997
+#: src/muuli_wdr.cpp:2001
 msgid "Before application name"
 msgstr "Eelmise rakenduse nimi"
 
-#: src/muuli_wdr.cpp:1999
+#: src/muuli_wdr.cpp:2003
 msgid "After application name"
 msgstr "Järgneva rakenduse nimi"
 
-#: src/muuli_wdr.cpp:2002
+#: src/muuli_wdr.cpp:2006
 msgid "Show overhead bandwidth"
 msgstr "Näita raisatud ribalaiust"
 
-#: src/muuli_wdr.cpp:2006
+#: src/muuli_wdr.cpp:2010
 msgid "Vertical toolbar orientation"
 msgstr "Vertikaalne tööriistariba paigutus"
 
-#: src/muuli_wdr.cpp:2008
+#: src/muuli_wdr.cpp:2012
 msgid "Live column sorting (auto-reorder rows as their values change)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2015
+#: src/muuli_wdr.cpp:2019
 msgid "Download Queue Files"
 msgstr "Tõmbamise Järjekorrafailid"
 
-#: src/muuli_wdr.cpp:2018
+#: src/muuli_wdr.cpp:2022
 msgid "Show progress percentage"
 msgstr "Näita edenemist protsentuaalselt"
 
-#: src/muuli_wdr.cpp:2024
+#: src/muuli_wdr.cpp:2028
 msgid "Show progress bar"
 msgstr "Näita edenemise riba"
 
-#: src/muuli_wdr.cpp:2027
+#: src/muuli_wdr.cpp:2031
 msgid "Flat"
 msgstr "Lame"
 
-#: src/muuli_wdr.cpp:2031
+#: src/muuli_wdr.cpp:2035
 msgid "Round"
 msgstr "Ümar"
 
-#: src/muuli_wdr.cpp:2049
+#: src/muuli_wdr.cpp:2053
 msgid "External Connection Parameters"
 msgstr "Välisühenduse parameetrid"
 
-#: src/muuli_wdr.cpp:2052
+#: src/muuli_wdr.cpp:2056
 msgid "Accept external connections"
 msgstr "Aksepteeri väliseid ühendusi"
 
-#: src/muuli_wdr.cpp:2059 src/muuli_wdr.cpp:2118
+#: src/muuli_wdr.cpp:2063 src/muuli_wdr.cpp:2122
 msgid "IP of the listening interface:"
 msgstr "Kuulava liidese IP aadress:"
 
-#: src/muuli_wdr.cpp:2062
+#: src/muuli_wdr.cpp:2066
 msgid "Enter here a valid ip in the a.b.c.d format for the listening EC interface. An empty field or 0.0.0.0 will mean any interface."
 msgstr "Sisesta siia välisühenduse liidese kehtiv ip aadress a.b.c.d formaadis. Tühi väli või 0.0.0.0 tähendab suvalist liidest."
 
-#: src/muuli_wdr.cpp:2083 src/muuli_wdr.cpp:2194
+#: src/muuli_wdr.cpp:2087 src/muuli_wdr.cpp:2198
 msgid "TCP port:"
 msgstr "TCP port:"
 
-#: src/muuli_wdr.cpp:2089
+#: src/muuli_wdr.cpp:2093
 msgid "Enable UPnP port forwarding on the EC port"
 msgstr "Luba UPnP pordisuunamist EC pordile"
 
-#: src/muuli_wdr.cpp:2093 src/muuli_wdr.cpp:3079
+#: src/muuli_wdr.cpp:2097 src/muuli_wdr.cpp:3083
 #: src/utils/wxCas/src/wxcasprefs.cpp:167
 msgid "Password"
 msgstr "Parool"
 
-#: src/muuli_wdr.cpp:2099
+#: src/muuli_wdr.cpp:2103
 #, fuzzy
 msgid "aMule API server parameters"
 msgstr "Web serveri seaded"
 
-#: src/muuli_wdr.cpp:2102
+#: src/muuli_wdr.cpp:2106
 msgid "Run amuleapi (REST API) on startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2107
+#: src/muuli_wdr.cpp:2111
 #, fuzzy
 msgid "HTTP port:"
 msgstr "TCP port:"
 
-#: src/muuli_wdr.cpp:2121
+#: src/muuli_wdr.cpp:2125
 msgid "The interface amuleapi's HTTP server listens on. 127.0.0.1 (default) accepts only local connections; use 0.0.0.0 or a specific IP to expose it to other hosts (set an admin password below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2126
+#: src/muuli_wdr.cpp:2130
 msgid "Type a password to set or change it. Stored passwords cannot be shown, so leaving this empty keeps the current one."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2128
+#: src/muuli_wdr.cpp:2132
 #, fuzzy
 msgid "Admin password"
 msgstr "Kontrollin parooli\n"
 
-#: src/muuli_wdr.cpp:2140 src/muuli_wdr.cpp:2157 src/PrefsUnifiedDlg.cpp:1103
+#: src/muuli_wdr.cpp:2144 src/muuli_wdr.cpp:2161 src/PrefsUnifiedDlg.cpp:1112
 #, fuzzy
 msgid "A password is set."
 msgstr "Kontrollin parooli\n"
 
-#: src/muuli_wdr.cpp:2144
+#: src/muuli_wdr.cpp:2148
 #, fuzzy
 msgid "Enable guest access"
 msgstr "Keela külalise (guest) ligipääs"
 
-#: src/muuli_wdr.cpp:2145
+#: src/muuli_wdr.cpp:2149
 msgid "Guest sessions may read status and listings but cannot change anything. Turning this off clears the stored guest password."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2149
+#: src/muuli_wdr.cpp:2153
 #, fuzzy
 msgid "Guest password"
 msgstr "Webserveri külalise (guest) parool"
 
-#: src/muuli_wdr.cpp:2164
+#: src/muuli_wdr.cpp:2168
 msgid "Web server parameters"
 msgstr "Web serveri seaded"
 
-#: src/muuli_wdr.cpp:2167
+#: src/muuli_wdr.cpp:2171
 #, fuzzy
 msgid "Run webserver on startup (deprecated)"
 msgstr "Käivita WEBserver koos aMulega"
 
-#: src/muuli_wdr.cpp:2173
+#: src/muuli_wdr.cpp:2177
 msgid "Web template"
 msgstr "WEB näidis/mall"
 
-#: src/muuli_wdr.cpp:2178
+#: src/muuli_wdr.cpp:2182
 msgid "Full rights password"
 msgstr "Täisõiguste parool"
 
-#: src/muuli_wdr.cpp:2182
+#: src/muuli_wdr.cpp:2186
 msgid "Enable Low rights User"
 msgstr "Luba madalate õigustega kasutaja"
 
-#: src/muuli_wdr.cpp:2187
+#: src/muuli_wdr.cpp:2191
 msgid "Low rights password"
 msgstr "Madalate õiguste parool"
 
-#: src/muuli_wdr.cpp:2201
+#: src/muuli_wdr.cpp:2205
 msgid "Enable UPnP port forwarding of the web server port"
 msgstr "Luba webservri portide UPnP pordisuunamist"
 
-#: src/muuli_wdr.cpp:2206
+#: src/muuli_wdr.cpp:2210
 msgid "Web server UPnP TCP port (Optional)"
 msgstr "Webserveri UPnP TCP port (Valikuline)"
 
-#: src/muuli_wdr.cpp:2214
+#: src/muuli_wdr.cpp:2218
 msgid "Page Refresh Time (in secs)"
 msgstr "Lehekülje värskendusaeg (sekundites)"
 
-#: src/muuli_wdr.cpp:2221
+#: src/muuli_wdr.cpp:2225
 msgid "Enable Gzip compression"
 msgstr "Luba Gzip pakkimine"
 
-#: src/muuli_wdr.cpp:2255
+#: src/muuli_wdr.cpp:2259
 #, fuzzy
 msgid "Reset page to defaults"
 msgstr "Süsteemi vaikeväärtus"
 
-#: src/muuli_wdr.cpp:2256
+#: src/muuli_wdr.cpp:2260
 msgid "Reset the settings on the current page to their default values."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2258 src/muuli_wdr.cpp:2344 src/ServerWnd.cpp:274
+#: src/muuli_wdr.cpp:2262 src/muuli_wdr.cpp:2348 src/ServerWnd.cpp:274
 #: src/ServerWnd.cpp:282
 msgid "OK"
 msgstr "Sobib"
 
-#: src/muuli_wdr.cpp:2260
+#: src/muuli_wdr.cpp:2264
 msgid "Click here to apply any changes made to the preferences."
 msgstr "Seadetes tehtud muudatuste jõustamiseks klikka siia."
 
-#: src/muuli_wdr.cpp:2263
+#: src/muuli_wdr.cpp:2267
 msgid "Reset any changes made to the preferences."
 msgstr "Tühista kõik seadetes tehtud muudatused."
 
-#: src/muuli_wdr.cpp:2292
+#: src/muuli_wdr.cpp:2296
 msgid "Comment :"
 msgstr "Kommentaar :"
 
-#: src/muuli_wdr.cpp:2299
+#: src/muuli_wdr.cpp:2303
 msgid "Incoming Dir :"
 msgstr "Tõmmatud failide kataloog :"
 
-#: src/muuli_wdr.cpp:2308
+#: src/muuli_wdr.cpp:2312
 msgid "Change priority for new assigned files :"
 msgstr "Muuda uute failide prioriteeti :"
 
-#: src/muuli_wdr.cpp:2312
+#: src/muuli_wdr.cpp:2316
 msgid "Don't change"
 msgstr "Ära muuda"
 
-#: src/muuli_wdr.cpp:2324
+#: src/muuli_wdr.cpp:2328
 msgid "Select color for this Category (currently selected) :"
 msgstr "Vali praegu valitud kategooriale värv :"
 
-#: src/muuli_wdr.cpp:2391 src/muuli_wdr.cpp:2410 src/muuli_wdr.cpp:2432
+#: src/muuli_wdr.cpp:2395 src/muuli_wdr.cpp:2414 src/muuli_wdr.cpp:2436
 msgid "Click this button to reset the log."
 msgstr "Klikates seda nuppu tühjendad logi."
 
-#: src/muuli_wdr.cpp:2451
+#: src/muuli_wdr.cpp:2455
 msgid "Click on this button to update the servers list from URL ..."
 msgstr "Sellele nupule klikates värskendad serverite loetelu URL ilt ..."
 
-#: src/muuli_wdr.cpp:2455
+#: src/muuli_wdr.cpp:2459
 msgid "Server list"
 msgstr "Serverite nimekiri"
 
-#: src/muuli_wdr.cpp:2459
+#: src/muuli_wdr.cpp:2463
 msgid "Enter the url to a server.met file here and press the button to the left to update the list of known servers."
 msgstr "Sisesta siia server.met faili asukoha URL ja pressi vasakul olevat nuppu tuntud serverite nimekirja värskendamiseks."
 
-#: src/muuli_wdr.cpp:2464
+#: src/muuli_wdr.cpp:2468
 msgid "Add server manually: Name"
 msgstr "Lisa server käsitsi: Nimi"
 
-#: src/muuli_wdr.cpp:2467
+#: src/muuli_wdr.cpp:2471
 msgid "Enter the name of the new server here"
 msgstr "Sisesta siia uue serveri nimi"
 
-#: src/muuli_wdr.cpp:2469 src/ServerWnd.cpp:206
+#: src/muuli_wdr.cpp:2473 src/ServerWnd.cpp:206
 msgid "IP:Port"
 msgstr "IP:Port"
 
-#: src/muuli_wdr.cpp:2472
+#: src/muuli_wdr.cpp:2476
 msgid "Enter the IP of the server here, using the x.x.x.x format."
 msgstr "Sisesta siia serveri IP aadrdess, kasutades x.x.x.x formaati."
 
-#: src/muuli_wdr.cpp:2478
+#: src/muuli_wdr.cpp:2482
 msgid "Enter the port of the server here."
 msgstr "Sisesta siia serveri port."
 
-#: src/muuli_wdr.cpp:2481
+#: src/muuli_wdr.cpp:2485
 msgid "Add manually a server (fill fields to the left before) ..."
 msgstr "Täites esiteks vasakul olevad väljad, lisa server käsitsi ..."
 
-#: src/muuli_wdr.cpp:2510
+#: src/muuli_wdr.cpp:2514
 msgid "aMule Log"
 msgstr "aMule Logi"
 
-#: src/muuli_wdr.cpp:2518
+#: src/muuli_wdr.cpp:2522
 msgid "Server Info"
 msgstr "Serveri info"
 
-#: src/muuli_wdr.cpp:2522
+#: src/muuli_wdr.cpp:2526
 msgid "ED2K Info"
 msgstr "ED2K Info"
 
-#: src/muuli_wdr.cpp:2526
+#: src/muuli_wdr.cpp:2530
 msgid "Kad Info"
 msgstr "Kad Info"
 
-#: src/muuli_wdr.cpp:2554
+#: src/muuli_wdr.cpp:2558
 msgid "Click on this button to update the nodes list from URL ..."
 msgstr "Klikates sellele nupule värskendad sõlmede loetelu URL'ilt ..."
 
-#: src/muuli_wdr.cpp:2558
+#: src/muuli_wdr.cpp:2562
 msgid "Nodes (0)"
 msgstr "Sõlmed (0)"
 
-#: src/muuli_wdr.cpp:2562
+#: src/muuli_wdr.cpp:2566
 msgid "Enter the url to a nodes.dat file here and press the button to the left to update the list of known nodes."
 msgstr "Sisesta siia nodes.dat faili url ja pressi vasakul olevat nuppu, et tuntud sõlmede loetelu täiendada."
 
-#: src/muuli_wdr.cpp:2565
+#: src/muuli_wdr.cpp:2569
 msgid "Nodes stats"
 msgstr "Sõlmede statistika"
 
-#: src/muuli_wdr.cpp:2607
+#: src/muuli_wdr.cpp:2611
 msgid "Bootstrap"
 msgstr "Bootstrap"
 
-#: src/muuli_wdr.cpp:2610
+#: src/muuli_wdr.cpp:2614
 msgid "New node"
 msgstr "Uus sõlm"
 
-#: src/muuli_wdr.cpp:2615
+#: src/muuli_wdr.cpp:2619
 msgid "IP:"
 msgstr "IP:"
 
-#: src/muuli_wdr.cpp:2635
+#: src/muuli_wdr.cpp:2639
 msgid "Port:"
 msgstr "Port:"
 
-#: src/muuli_wdr.cpp:2648
+#: src/muuli_wdr.cpp:2652
 msgid "Bootstrap from known clients"
 msgstr "Tuntud klientide Bootstrap"
 
-#: src/muuli_wdr.cpp:2650
+#: src/muuli_wdr.cpp:2654
 msgid "Disconnect Kad"
 msgstr "Lõpeta Kad ühendus"
 
-#: src/muuli_wdr.cpp:2684
+#: src/muuli_wdr.cpp:2688
 msgid "Use Secure User Identification"
 msgstr "Kasuta Turvalist Kasutaja tuvastamist"
 
-#: src/muuli_wdr.cpp:2686
+#: src/muuli_wdr.cpp:2690
 msgid "It is recommended to enable this option. You will not receive credits if SUI is not enabled."
 msgstr "On soovitatav see omadus lubada. Sa ei saa krediiti kui SUI on välja lülitatud."
 
-#: src/muuli_wdr.cpp:2688
+#: src/muuli_wdr.cpp:2692
 msgid "Protocol Obfuscation"
 msgstr "Protokolli Hämamine"
 
-#: src/muuli_wdr.cpp:2691
+#: src/muuli_wdr.cpp:2695
 msgid "Support Protocol Obfuscation"
 msgstr "Protokolli Hämamine lubatud"
 
-#: src/muuli_wdr.cpp:2693
+#: src/muuli_wdr.cpp:2697
 msgid "This option enabled Protocol Obfuscation, and makes aMule accept obfuscated connections from other clients."
 msgstr "See valik lülitab Protokolli Hämamise sisse ja sunnib aMule aksepteerima ainult teiste klientide hämatud ühendusi."
 
-#: src/muuli_wdr.cpp:2695
+#: src/muuli_wdr.cpp:2699
 msgid "Use obfuscation for outgoing connections"
 msgstr "Kasuta väljuvatel ühendustel hämamist"
 
-#: src/muuli_wdr.cpp:2697
+#: src/muuli_wdr.cpp:2701
 msgid "This option makes aMule use Protocol Obfuscation when connecting other clients/servers."
 msgstr "See valik sunnib aMule kasutama teiste serverite/klientidega ühendumisel Protokolli Hämamist."
 
-#: src/muuli_wdr.cpp:2699
+#: src/muuli_wdr.cpp:2703
 msgid "Accept only obfuscated connections"
 msgstr "Aksepteeri ainult hämatud ühendusi"
 
-#: src/muuli_wdr.cpp:2700
+#: src/muuli_wdr.cpp:2704
 msgid "This option makes aMule only accept obfuscated connections. You will have less sources, but all your traffic will be obfuscated"
 msgstr "See valik sunnib aMule aksepteerima ainult hämatud ühendusi. Sul on vähem allikaid aga kogu liiklus on hämatud."
 
-#: src/muuli_wdr.cpp:2705
+#: src/muuli_wdr.cpp:2709
 msgid "Everybody"
 msgstr "Igaüks"
 
-#: src/muuli_wdr.cpp:2707
+#: src/muuli_wdr.cpp:2711
 msgid "No one"
 msgstr "Mitte keegi"
 
-#: src/muuli_wdr.cpp:2709
+#: src/muuli_wdr.cpp:2713
 msgid "Who can see my shared files:"
 msgstr "Kes näeb minu jagatud faile:"
 
-#: src/muuli_wdr.cpp:2710
+#: src/muuli_wdr.cpp:2714
 msgid "Select who can request to view a list of your shared files."
 msgstr "Vali, kes võib vaatamiseks küsida sinu jagatud falide nimekira."
 
-#: src/muuli_wdr.cpp:2712
+#: src/muuli_wdr.cpp:2716
 msgid "IP-Filtering"
 msgstr "IP-Filtreerimine"
 
-#: src/muuli_wdr.cpp:2719
+#: src/muuli_wdr.cpp:2723
 msgid "Filter clients"
 msgstr "Filtreeri kliente"
 
-#: src/muuli_wdr.cpp:2721
+#: src/muuli_wdr.cpp:2725
 msgid "Enable filtering of the client IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "Rakenda klientide IP filtreerimine failis ~/.aMule/ipfilter.dat defineeritud aadressidele."
 
-#: src/muuli_wdr.cpp:2723
+#: src/muuli_wdr.cpp:2727
 msgid "Filter servers"
 msgstr "Filtreeri servereid"
 
-#: src/muuli_wdr.cpp:2725
+#: src/muuli_wdr.cpp:2729
 msgid "Enable filtering of the server IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "Rakenda serverite IP filtreerimine failis ~/.aMule/ipfilter.dat defineeritud aadressidele."
 
-#: src/muuli_wdr.cpp:2729
+#: src/muuli_wdr.cpp:2733
 msgid "Reload List"
 msgstr "Lae loetelu uuesti"
 
-#: src/muuli_wdr.cpp:2730
+#: src/muuli_wdr.cpp:2734
 msgid "Reload the list of IPs to filter from the file ~/.aMule/ipfilter.dat"
 msgstr "Taaslae filtreeritavad IP aadressid failist ~/.aMule/ipfilter.dat"
 
-#: src/muuli_wdr.cpp:2736
+#: src/muuli_wdr.cpp:2740
 msgid "URL:"
 msgstr "URL:"
 
-#: src/muuli_wdr.cpp:2740 src/muuli_wdr.cpp:2933
+#: src/muuli_wdr.cpp:2744 src/muuli_wdr.cpp:2937
 msgid "Update now"
 msgstr "Värskenda"
 
-#: src/muuli_wdr.cpp:2743
+#: src/muuli_wdr.cpp:2747
 msgid "Auto-update ipfilter at startup"
 msgstr "Käivitamisel värskenda automaatselt ipfiltrit"
 
-#: src/muuli_wdr.cpp:2747
+#: src/muuli_wdr.cpp:2751
 msgid "Filtering Level:"
 msgstr "Filtreerimise tase:"
 
-#: src/muuli_wdr.cpp:2753
+#: src/muuli_wdr.cpp:2757
 msgid "Always filter LAN IPs"
 msgstr "Filtreeri alati LAN IP aadresse"
 
-#: src/muuli_wdr.cpp:2756
+#: src/muuli_wdr.cpp:2760
 msgid "Paranoid handling of non-matching IPs"
 msgstr "Mitteklappivate IP aadresside paranoiline käitlemine"
 
-#: src/muuli_wdr.cpp:2758
+#: src/muuli_wdr.cpp:2762
 msgid "Rejects a packet when its source IP differs from the IP the client claims (an anti-spoofing check). Disable only if it causes connection problems."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2760
+#: src/muuli_wdr.cpp:2764
 msgid "Use system-wide ipfilter.dat if available"
 msgstr "Kasuta süsteemi ipfilter.dat kui see on saadaval"
 
-#: src/muuli_wdr.cpp:2761
+#: src/muuli_wdr.cpp:2765
 #, fuzzy
 msgid "If there's no local ipfilter.dat found, allow usage of a system-wide ipfilter file."
 msgstr "Kui kohalik ipfilter.dat fail puudub, kasuta süsteemi globaalset ipfilter faili."
 
-#: src/muuli_wdr.cpp:2778
+#: src/muuli_wdr.cpp:2782
 msgid "Enable Online-Signature"
 msgstr "Luba Online-Allkiri"
 
-#: src/muuli_wdr.cpp:2780
+#: src/muuli_wdr.cpp:2784
 msgid "Enables the writing of the OS file, which can be used by external apps to create signatures and the like."
 msgstr "Võimaldab kirjutada OS faile, mida saavad kasutada välised rakendused kasvõi allkirja loomiseks."
 
-#: src/muuli_wdr.cpp:2784
+#: src/muuli_wdr.cpp:2788
 msgid "Update Frequency (Secs):"
 msgstr "Värskenduse sagedus (Sek):"
 
-#: src/muuli_wdr.cpp:2787
+#: src/muuli_wdr.cpp:2791
 msgid "Change the frequency (in seconds) of Online Signature updates."
 msgstr "Muuda Online Allkirja värskendamise (sekundites) sagedust."
 
-#: src/muuli_wdr.cpp:2795
+#: src/muuli_wdr.cpp:2799
 msgid "Save online signature file in: "
 msgstr "Salvesta online ollkirja fail: "
 
-#: src/muuli_wdr.cpp:2801
+#: src/muuli_wdr.cpp:2805
 msgid "Click here to select the directory containing the the Online Signature files."
 msgstr "Siin saad valida kataloogi kus asub sinu Online Allkirja fail."
 
-#: src/muuli_wdr.cpp:2834
+#: src/muuli_wdr.cpp:2838
 msgid "Show country flags for clients"
 msgstr "Näita klientide riigi lippe"
 
-#: src/muuli_wdr.cpp:2835
+#: src/muuli_wdr.cpp:2839
 msgid "Render the country flag column in the transfers, queue and search views. Requires a valid MMDB GeoIP database (see below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2840
+#: src/muuli_wdr.cpp:2844
 #, fuzzy
 msgid "Database"
 msgstr "Andmekiirus :"
 
-#: src/muuli_wdr.cpp:2856
+#: src/muuli_wdr.cpp:2860
 #, fuzzy
 msgid "Source:"
 msgstr "Allikaid"
 
-#: src/muuli_wdr.cpp:2859
+#: src/muuli_wdr.cpp:2863
 msgid "DB-IP (free, no account)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2860
+#: src/muuli_wdr.cpp:2864
 msgid "MaxMind GeoLite2 (free, account required)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2861
+#: src/muuli_wdr.cpp:2865
 msgid "Custom URL"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2864
+#: src/muuli_wdr.cpp:2868
 msgid "Choose which provider supplies the GeoIP MMDB database. DB-IP is the default - no account required. MaxMind requires a free account + license key. Use Custom URL to point at any other MMDB host (e.g. a local mirror)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2881
+#: src/muuli_wdr.cpp:2885
 msgid ""
 "No configuration required.\n"
 "\n"
@@ -4882,11 +4882,11 @@ msgid ""
 "License: Creative Commons BY 4.0 - https://creativecommons.org/licenses/by/4.0/"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2894
+#: src/muuli_wdr.cpp:2898
 msgid "License key:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2900
+#: src/muuli_wdr.cpp:2904
 msgid ""
 "Sign up for a free MaxMind account, then generate a License Key:\n"
 "https://www.maxmind.com/en/geolite2/signup\n"
@@ -4896,226 +4896,226 @@ msgid ""
 "Requires attribution and account registration; refresh at least every 30 days."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2915
+#: src/muuli_wdr.cpp:2919
 #, fuzzy
 msgid "Download URL:"
 msgstr "Tõmbamine: "
 
-#: src/muuli_wdr.cpp:2921
+#: src/muuli_wdr.cpp:2925
 msgid ""
 "Must point to an .mmdb file or a .gz / .tar.gz containing one.\n"
 "URL may include credentials (https://user:pass@host/...).\n"
 "License and attribution terms are set by the upstream URL - you are responsible."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2934
+#: src/muuli_wdr.cpp:2938
 msgid "Download the GeoIP database from the selected source."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2936
+#: src/muuli_wdr.cpp:2940
 #, fuzzy
 msgid "Auto-update on startup"
 msgstr "Käivitamisel värskenda automaatselt ipfiltrit"
 
-#: src/muuli_wdr.cpp:2937
+#: src/muuli_wdr.cpp:2941
 msgid "Re-download the GeoIP database from the selected source every time aMule starts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2960
+#: src/muuli_wdr.cpp:2964
 msgid "Filter incoming messages (except current chat):"
 msgstr "Filtreeri saabuvaid teateid (va. käimasolev vestlus):"
 
-#: src/muuli_wdr.cpp:2962
+#: src/muuli_wdr.cpp:2966
 msgid "Filter all messages"
 msgstr "Filtreeri kõiki teateid"
 
-#: src/muuli_wdr.cpp:2964
+#: src/muuli_wdr.cpp:2968
 msgid "Filter messages from people not on your friend list"
 msgstr "Filtreeri sinu sõbralistiväliste kodanike teateid"
 
-#: src/muuli_wdr.cpp:2966
+#: src/muuli_wdr.cpp:2970
 msgid "Filter messages from unknown clients"
 msgstr "Filtreeri tundmatute klientide teateid"
 
-#: src/muuli_wdr.cpp:2968
+#: src/muuli_wdr.cpp:2972
 msgid "Filter messages containing (use ',' as separator):"
 msgstr "Filtreeri teateid, mis sisaldavad (loetelus kasuta eraldajana koma):"
 
-#: src/muuli_wdr.cpp:2971 src/muuli_wdr.cpp:2982
+#: src/muuli_wdr.cpp:2975 src/muuli_wdr.cpp:2986
 msgid "add here the words amule should filter and block messages including it"
 msgstr "lisa siia sõnad mille amule peab väljafiltreerima ja bloki teated mis seda sisaldavad"
 
-#: src/muuli_wdr.cpp:2973
+#: src/muuli_wdr.cpp:2977
 msgid "Show received messages in the log"
 msgstr "Näita logis saabunud teateid"
 
-#: src/muuli_wdr.cpp:2976
+#: src/muuli_wdr.cpp:2980
 msgid "Comments"
 msgstr "Kommentaarid"
 
-#: src/muuli_wdr.cpp:2979
+#: src/muuli_wdr.cpp:2983
 msgid "Filter comments containing (use ',' as separator):"
 msgstr "Filtreeri teateid, mis sisaldavad (loetelus kasuta eraldajana koma):"
 
-#: src/muuli_wdr.cpp:3004
+#: src/muuli_wdr.cpp:3008
 msgid "Enable Proxy"
 msgstr "Kasuta puhverserverit"
 
-#: src/muuli_wdr.cpp:3005
+#: src/muuli_wdr.cpp:3009
 msgid "Enable/disable proxy support"
 msgstr "Kasuta/ärakasuta puhverserveri tuge"
 
-#: src/muuli_wdr.cpp:3008
+#: src/muuli_wdr.cpp:3012
 msgid "Proxy type:"
 msgstr "Puhverserveri tüüp:"
 
-#: src/muuli_wdr.cpp:3019
+#: src/muuli_wdr.cpp:3023
 msgid "Proxy host:"
 msgstr "Puhverserveri nimi:"
 
-#: src/muuli_wdr.cpp:3022
+#: src/muuli_wdr.cpp:3026
 msgid "The proxy host name"
 msgstr "Selle puhverserveri/hosti nimi "
 
-#: src/muuli_wdr.cpp:3024
+#: src/muuli_wdr.cpp:3028
 msgid "Proxy port:"
 msgstr "Puhverserveri port:"
 
-#: src/muuli_wdr.cpp:3027
+#: src/muuli_wdr.cpp:3031
 msgid "The proxy port"
 msgstr "Selle puhverserveri pordi number"
 
-#: src/muuli_wdr.cpp:3029
+#: src/muuli_wdr.cpp:3033
 msgid "Enable authentication"
 msgstr "Nõua autoriseerimist"
 
-#: src/muuli_wdr.cpp:3030
+#: src/muuli_wdr.cpp:3034
 msgid "Enable/disable username/password authentication"
 msgstr "Autoriseerimisel Kasuta/Ära kasuta kasutajanime/parooli"
 
-#: src/muuli_wdr.cpp:3033
+#: src/muuli_wdr.cpp:3037
 msgid "Username: "
 msgstr "Kasutajanimi: "
 
-#: src/muuli_wdr.cpp:3036
+#: src/muuli_wdr.cpp:3040
 msgid "The username to use to connect to the proxy"
 msgstr "Puhverserveriga ühenduseks vajalik kasutajanimi"
 
-#: src/muuli_wdr.cpp:3038
+#: src/muuli_wdr.cpp:3042
 msgid "Password:"
 msgstr "Parool:"
 
-#: src/muuli_wdr.cpp:3041
+#: src/muuli_wdr.cpp:3045
 msgid "The password to use to connect to the proxy"
 msgstr "Puhverserveri kasutamiseks vajalik parool"
 
-#: src/muuli_wdr.cpp:3060
+#: src/muuli_wdr.cpp:3064
 msgid "Connect to:"
 msgstr "Ühendu :"
 
-#: src/muuli_wdr.cpp:3069
+#: src/muuli_wdr.cpp:3073
 msgid "Login to remote amule"
 msgstr "Logi sisse eemalasuvasse amuula"
 
-#: src/muuli_wdr.cpp:3074
+#: src/muuli_wdr.cpp:3078
 msgid "User name"
 msgstr "Kasutaja nimi"
 
-#: src/muuli_wdr.cpp:3085
+#: src/muuli_wdr.cpp:3089
 msgid "Remember those settings"
 msgstr "Pea need seaded meeles"
 
-#: src/muuli_wdr.cpp:3088
+#: src/muuli_wdr.cpp:3092
 #, fuzzy
 msgid "Force ZLIB compression"
 msgstr "Kasuta gzip pakkimist"
 
-#: src/muuli_wdr.cpp:3112
+#: src/muuli_wdr.cpp:3116
 msgid "Enable Verbose Debug-Logging."
 msgstr "Võimalda inimkieelne Veajälitus-Logimine"
 
-#: src/muuli_wdr.cpp:3114
+#: src/muuli_wdr.cpp:3118
 #, fuzzy
 msgid "Only to Logfile"
 msgstr "Ava Fail"
 
-#: src/muuli_wdr.cpp:3116
+#: src/muuli_wdr.cpp:3120
 msgid "Message Categories:"
 msgstr "Saadetav teade:"
 
-#: src/muuli_wdr.cpp:3140 src/PartFileConvertDlg.cpp:160
+#: src/muuli_wdr.cpp:3144 src/PartFileConvertDlg.cpp:160
 msgid "Waiting..."
 msgstr "Ootan..."
 
-#: src/muuli_wdr.cpp:3160
+#: src/muuli_wdr.cpp:3164
 msgid "Add imports"
 msgstr "Lisa imporditavad"
 
-#: src/muuli_wdr.cpp:3163
+#: src/muuli_wdr.cpp:3167
 msgid "Retry selected"
 msgstr "Proovi valitutega uuesti"
 
-#: src/muuli_wdr.cpp:3165
+#: src/muuli_wdr.cpp:3169
 msgid "Remove selected"
 msgstr "Eemalda valitud"
 
-#: src/muuli_wdr.cpp:3228
+#: src/muuli_wdr.cpp:3232
 msgid "Event Types"
 msgstr "Sündmuse tüübid"
 
-#: src/muuli_wdr.cpp:3247
+#: src/muuli_wdr.cpp:3251
 msgid "Statistics and queued clients for selected file(s) : Session / All time"
 msgstr "Statistika ja järjekorras kliendid valitud faili(de) kohta : Sessioon / Kokku"
 
-#: src/muuli_wdr.cpp:3271
+#: src/muuli_wdr.cpp:3275
 msgid "Active Uploads"
 msgstr "Aktiivsed saatmised"
 
-#: src/muuli_wdr.cpp:3285
+#: src/muuli_wdr.cpp:3289
 msgid "Percent of total files"
 msgstr "Protsenti kogufailidest"
 
-#: src/muuli_wdr.cpp:3337
+#: src/muuli_wdr.cpp:3341
 msgid "Show Clients for"
 msgstr "Näita Kliente"
 
-#: src/muuli_wdr.cpp:3339
+#: src/muuli_wdr.cpp:3343
 msgid "All files"
 msgstr "Kõik failid"
 
-#: src/muuli_wdr.cpp:3342
+#: src/muuli_wdr.cpp:3346
 msgid "Selected files"
 msgstr "Valitud failid"
 
-#: src/muuli_wdr.cpp:3345
+#: src/muuli_wdr.cpp:3349
 msgid "Active uploads only"
 msgstr "Ainult aktiivsed saatmised"
 
-#: src/muuli_wdr.cpp:3352
+#: src/muuli_wdr.cpp:3356
 msgid "Reload:"
 msgstr "Taaslae:"
 
-#: src/muuli_wdr.cpp:3356
+#: src/muuli_wdr.cpp:3360
 msgid "Reload your shared files"
 msgstr "Lae oma jagatud failid uuesti"
 
-#: src/muuli_wdr.cpp:3419
+#: src/muuli_wdr.cpp:3423
 msgid "Send"
 msgstr "Saada"
 
-#: src/muuli_wdr.cpp:3420
+#: src/muuli_wdr.cpp:3424
 msgid "Sends the specified message."
 msgstr "Saada määratud teade."
 
-#: src/muuli_wdr.cpp:3424
+#: src/muuli_wdr.cpp:3428
 msgid "Close this chat-session."
 msgstr "Sulge see vestlus-seanss."
 
-#: src/muuli_wdr.cpp:3447
+#: src/muuli_wdr.cpp:3451
 msgid "Connect to any server and/or Kad"
 msgstr "Ühendu suvalise serveri ja/või Kad võrguga"
 
-#: src/muuli_wdr.cpp:3453 src/SharedFilesCtrl.cpp:142 src/Statistics.cpp:941
+#: src/muuli_wdr.cpp:3457 src/SharedFilesCtrl.cpp:142 src/Statistics.cpp:941
 msgid "Shared Files"
 msgstr "Jagatud failid"
 
@@ -5751,35 +5751,35 @@ msgstr ""
 "aMule toimib ilusasti ilma siinolevaid seadeid muutmata\n"
 "You Are WARNED!!."
 
-#: src/PrefsUnifiedDlg.cpp:647
+#: src/PrefsUnifiedDlg.cpp:656
 #, c-format
 msgid "Failed to connect Cfg to widget with the ID %d and key %s"
 msgstr "Widgeti ühendamine Cfg'a, kasutades ID %d ja võtit %s, ebaõnnestus"
 
-#: src/PrefsUnifiedDlg.cpp:695
+#: src/PrefsUnifiedDlg.cpp:704
 #, c-format
 msgid "Failed to transfer data from Cfg to Widget with the ID %d and key %s"
 msgstr "Andmete ülekandmine Cfg'st Widget'isse, kasutades ID %d ja võtit %s, ebaõnnestus"
 
-#: src/PrefsUnifiedDlg.cpp:801
+#: src/PrefsUnifiedDlg.cpp:810
 msgid "The type of proxy you are connecting to"
 msgstr "Selle puhverserveri tüüp kuhu sa ühendud"
 
-#: src/PrefsUnifiedDlg.cpp:1020
+#: src/PrefsUnifiedDlg.cpp:1029
 #, c-format
 msgid "Failed to transfer data from Widget to Cfg with the ID %d and key %s"
 msgstr "Andmete ülekandmine Widgetist Cfg'sse, kasutades ID %d ja võtit %s, ebaõnnestus"
 
-#: src/PrefsUnifiedDlg.cpp:1103
+#: src/PrefsUnifiedDlg.cpp:1112
 #, fuzzy
 msgid "No password set."
 msgstr "Kontrollin parooli\n"
 
-#: src/PrefsUnifiedDlg.cpp:1132
+#: src/PrefsUnifiedDlg.cpp:1141
 msgid "Guest access needs a password. Type one in the guest password field, or untick Enable guest access."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1144
+#: src/PrefsUnifiedDlg.cpp:1153
 msgid ""
 "aMule must be restarted to enable these changes:\n"
 "\n"
@@ -5787,42 +5787,42 @@ msgstr ""
 "Nende muudatuste jõustamiseks pead aMUle taaskäivitama:\n"
 "\n"
 
-#: src/PrefsUnifiedDlg.cpp:1151
+#: src/PrefsUnifiedDlg.cpp:1160
 msgid "- TCP port changed.\n"
 msgstr "- TCP port muudetud.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1156
+#: src/PrefsUnifiedDlg.cpp:1165
 msgid "- UDP port changed.\n"
 msgstr "- UDP port muudetud.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1161
+#: src/PrefsUnifiedDlg.cpp:1170
 #, fuzzy
 msgid "- Network interface binding changed.\n"
 msgstr "- Välisühenduse liides muutunud.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1166
+#: src/PrefsUnifiedDlg.cpp:1175
 msgid "- External connect port changed.\n"
 msgstr "- Välisühenduse port on muutunud.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1170
+#: src/PrefsUnifiedDlg.cpp:1179
 msgid "- External connect acceptance changed.\n"
 msgstr "- Välisühenduse luba on muudetud.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1174
+#: src/PrefsUnifiedDlg.cpp:1183
 msgid "- External connect interface changed.\n"
 msgstr "- Välisühenduse liides muutunud.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1178
+#: src/PrefsUnifiedDlg.cpp:1187
 #, fuzzy
 msgid "- Protocol obfuscation support changed.\n"
 msgstr "Protokolli Hämamine"
 
-#: src/PrefsUnifiedDlg.cpp:1193
+#: src/PrefsUnifiedDlg.cpp:1202
 #, fuzzy
 msgid "- amuleapi settings changed.\n"
 msgstr "- Keel on muudetud.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1202
+#: src/PrefsUnifiedDlg.cpp:1211
 msgid ""
 "Your Auto-update server list is empty.\n"
 "'Auto-update server list at startup' will be disabled."
@@ -5830,7 +5830,7 @@ msgstr ""
 "Sinu automaane serverinimekirja värskendamise loetelu on tühi.\n"
 "Käivitamisel serverinimekirja automaatselt ei uuendata."
 
-#: src/PrefsUnifiedDlg.cpp:1213
+#: src/PrefsUnifiedDlg.cpp:1222
 msgid ""
 "You have enabled external connections but have not specified a password.\n"
 "External connections cannot be enabled unless a valid password is specified."
@@ -5838,33 +5838,33 @@ msgstr ""
 "Lülitasid sisse välised ühendused kuid ei määranud parooli.\n"
 "Väliseid ühendusi ei saa enne kehtiva parooli määramist kasutada."
 
-#: src/PrefsUnifiedDlg.cpp:1246
+#: src/PrefsUnifiedDlg.cpp:1255
 #, c-format
 msgid "The amuleapi password could not be saved: %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1276
+#: src/PrefsUnifiedDlg.cpp:1285
 msgid "- Language changed.\n"
 msgstr "- Keel on muudetud.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1281
+#: src/PrefsUnifiedDlg.cpp:1290
 msgid "- Temp folder changed.\n"
 msgstr "- Ajutiste failide kataloog on muudetud.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1286
+#: src/PrefsUnifiedDlg.cpp:1295
 msgid "- ED2K network enabled.\n"
 msgstr "- ED2K võrk on lubatud.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1319
+#: src/PrefsUnifiedDlg.cpp:1328
 msgid "The shared-file exclusion pattern is not a valid regular expression. The filter has been left disabled."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1321 src/PrefsUnifiedDlg.cpp:1921
+#: src/PrefsUnifiedDlg.cpp:1330 src/PrefsUnifiedDlg.cpp:1930
 #, fuzzy
 msgid "Invalid regular expression"
 msgstr "Vigane protokolli versioon."
 
-#: src/PrefsUnifiedDlg.cpp:1398
+#: src/PrefsUnifiedDlg.cpp:1407
 msgid ""
 "Both eD2k and Kad network are disabled.\n"
 "You won't be able to connect until you enable at least one of them."
@@ -5872,7 +5872,7 @@ msgstr ""
 "Mõlemad, nii eD2k kui ka Kad võrgud on mitteaktiivsed.\n"
 "Sa ei saa ühenduda enne, kui vähemalt üks neist on aktiivne."
 
-#: src/PrefsUnifiedDlg.cpp:1403
+#: src/PrefsUnifiedDlg.cpp:1412
 msgid ""
 "Kad will not start if your UDP port is disabled.\n"
 "Enable UDP port or disable Kad."
@@ -5880,7 +5880,7 @@ msgstr ""
 "Kad ei saa käivitada kuni UDP port on väljalülitatud.\n"
 "Lülita UDP port sisse, või Kad välja."
 
-#: src/PrefsUnifiedDlg.cpp:1459
+#: src/PrefsUnifiedDlg.cpp:1468
 msgid ""
 "\n"
 "You MUST restart aMule now.\n"
@@ -5890,69 +5890,69 @@ msgstr ""
 "Sa PEAD aMule nüüd taaskäivitama.\n"
 "Kui sa seda ei tee siis ära tänita kui midagi paha juhtub.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1524
+#: src/PrefsUnifiedDlg.cpp:1533
 msgid "Could not register aMule for autostart at login. The autostart store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1526
+#: src/PrefsUnifiedDlg.cpp:1535
 msgid "Could not remove the autostart-at-login entry."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1527
+#: src/PrefsUnifiedDlg.cpp:1536
 #, fuzzy
 msgid "Autostart"
 msgstr "Automaatne värskendamine on käivitatud"
 
-#: src/PrefsUnifiedDlg.cpp:1542
+#: src/PrefsUnifiedDlg.cpp:1551
 msgid "Register file type"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1542
+#: src/PrefsUnifiedDlg.cpp:1551
 msgid "Register URL handler"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1550
+#: src/PrefsUnifiedDlg.cpp:1559
 #, c-format
 msgid "aMule only handles eD2k-compatible magnets. If you replace the current magnet handler (%s), BitTorrent magnet links will stop working - aMule cannot download BitTorrent content. Continue?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1555
+#: src/PrefsUnifiedDlg.cpp:1564
 #, c-format
 msgid "Another application currently opens .emulecollection files (%s). Replace it with aMule?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1560
+#: src/PrefsUnifiedDlg.cpp:1569
 #, c-format
 msgid "Another application is currently the default handler for these links (%s). Replace it with aMule?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1585
+#: src/PrefsUnifiedDlg.cpp:1594
 msgid "Could not register aMule for .emulecollection files. The registration store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1587
+#: src/PrefsUnifiedDlg.cpp:1596
 #, fuzzy
 msgid "Could not remove the file type registration."
 msgstr "Ajutiste tõmmatavate failide kataloog"
 
-#: src/PrefsUnifiedDlg.cpp:1589
+#: src/PrefsUnifiedDlg.cpp:1598
 msgid "Could not register aMule as the URL handler. The registration store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1591
+#: src/PrefsUnifiedDlg.cpp:1600
 msgid "Could not remove the URL handler registration."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1661 src/PrefsUnifiedDlg.cpp:1688
+#: src/PrefsUnifiedDlg.cpp:1670 src/PrefsUnifiedDlg.cpp:1697
 #, fuzzy
 msgid "The web server and aMule API require external connections to be enabled."
 msgstr "Parool on määratud ja välised ühendused võimalikud."
 
-#: src/PrefsUnifiedDlg.cpp:1671
+#: src/PrefsUnifiedDlg.cpp:1680
 msgid "The aMule web server is deprecated. Consider running the aMule API instead."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1735
+#: src/PrefsUnifiedDlg.cpp:1744
 msgid ""
 "Your Auto-update servers list is in blank.\n"
 "Please fill in at least one URL to point to a valid server.met file.\n"
@@ -5962,66 +5962,66 @@ msgstr ""
 "Palun sisesta vähemalt üks server.met faili asukoha kehtiv URL.\n"
 "URL sisestamiseks kliki nupule 'Loend'."
 
-#: src/PrefsUnifiedDlg.cpp:1876
+#: src/PrefsUnifiedDlg.cpp:1885
 msgid "Temporary files"
 msgstr "Ajutised failid"
 
-#: src/PrefsUnifiedDlg.cpp:1881
+#: src/PrefsUnifiedDlg.cpp:1890
 msgid "Incoming files"
 msgstr "Saabuvad failid"
 
-#: src/PrefsUnifiedDlg.cpp:1886
+#: src/PrefsUnifiedDlg.cpp:1895
 msgid "Online Signatures"
 msgstr "Online Allkirjad"
 
-#: src/PrefsUnifiedDlg.cpp:1899
+#: src/PrefsUnifiedDlg.cpp:1908
 #, c-format
 msgid "Choose a folder for %s"
 msgstr "Vali %s kataloog"
 
-#: src/PrefsUnifiedDlg.cpp:1923
+#: src/PrefsUnifiedDlg.cpp:1932
 #, fuzzy, c-format
 msgid "Would exclude %u of %u shared file"
 msgid_plural "Would exclude %u of %u shared files"
 msgstr[0] "Leitud %i tuntud ja jagatud faili"
 msgstr[1] "Leitud %i tuntud ja jagatud faili."
 
-#: src/PrefsUnifiedDlg.cpp:1940
+#: src/PrefsUnifiedDlg.cpp:1949
 msgid "Browse for videoplayer"
 msgstr "Otsi filmi taasesitamise programmi"
 
-#: src/PrefsUnifiedDlg.cpp:1944
+#: src/PrefsUnifiedDlg.cpp:1953
 msgid "Select browser"
 msgstr "Vali lehitseja (browser)"
 
-#: src/PrefsUnifiedDlg.cpp:1948
+#: src/PrefsUnifiedDlg.cpp:1957
 #, fuzzy
 msgid "Select ffprobe binary"
 msgstr "Vali lehitseja (browser)"
 
-#: src/PrefsUnifiedDlg.cpp:1954
+#: src/PrefsUnifiedDlg.cpp:1963
 #, c-format
 msgid "Executable%s"
 msgstr "Käivitusprogramm%s"
 
-#: src/PrefsUnifiedDlg.cpp:1988
+#: src/PrefsUnifiedDlg.cpp:1997
 msgid "ffprobe not found on PATH or in the standard install locations. Install ffmpeg (which ships ffprobe) or use Browse to pick a binary manually."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2000
+#: src/PrefsUnifiedDlg.cpp:2009
 msgid "Reset the settings on this page to their default values?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2001
+#: src/PrefsUnifiedDlg.cpp:2010
 #, fuzzy
 msgid "Reset to defaults"
 msgstr "Süsteemi vaikeväärtus"
 
-#: src/PrefsUnifiedDlg.cpp:2028
+#: src/PrefsUnifiedDlg.cpp:2037
 msgid "Edit server list"
 msgstr "Muuda serverite nimekirja"
 
-#: src/PrefsUnifiedDlg.cpp:2029
+#: src/PrefsUnifiedDlg.cpp:2038
 msgid ""
 "Add here URL's to download server.met files.\n"
 "Only one url on each line."
@@ -6029,154 +6029,154 @@ msgstr ""
 "Lisa siia server.met faili(de) laadimise URL.\n"
 "Üks URL rea kohta."
 
-#: src/PrefsUnifiedDlg.cpp:2084
+#: src/PrefsUnifiedDlg.cpp:2093
 msgid "IP2Country update failed"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2229 src/PrefsUnifiedDlg.cpp:2260
+#: src/PrefsUnifiedDlg.cpp:2238 src/PrefsUnifiedDlg.cpp:2269
 msgid "Data by MaxMind GeoLite2"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2231 src/PrefsUnifiedDlg.cpp:2262
+#: src/PrefsUnifiedDlg.cpp:2240 src/PrefsUnifiedDlg.cpp:2271
 #, fuzzy
 msgid "Custom source"
 msgstr "Täielikke allikaid"
 
-#: src/PrefsUnifiedDlg.cpp:2233 src/PrefsUnifiedDlg.cpp:2264
+#: src/PrefsUnifiedDlg.cpp:2242 src/PrefsUnifiedDlg.cpp:2273
 msgid "Data by DB-IP.com"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2284
+#: src/PrefsUnifiedDlg.cpp:2293
 #, fuzzy, c-format
 msgid "Status: Loaded%s"
 msgstr "Olek:"
 
-#: src/PrefsUnifiedDlg.cpp:2286
+#: src/PrefsUnifiedDlg.cpp:2295
 #, fuzzy, c-format
 msgid "Status: Loaded%s - %s"
 msgstr "Olek:"
 
-#: src/PrefsUnifiedDlg.cpp:2290
+#: src/PrefsUnifiedDlg.cpp:2299
 msgid "Status: Failed to load - click 'Update now' to refresh."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2292
+#: src/PrefsUnifiedDlg.cpp:2301
 msgid "Status: Not found - click 'Update now' to download."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2350 src/PrefsUnifiedDlg.cpp:2374
+#: src/PrefsUnifiedDlg.cpp:2359 src/PrefsUnifiedDlg.cpp:2383
 #, c-format
 msgid "Update delay: %d second"
 msgid_plural "Update delay: %d seconds"
 msgstr[0] "Värskenduse viide: %d sekundit"
 msgstr[1] "Värskenduse viide: %d sekundit"
 
-#: src/PrefsUnifiedDlg.cpp:2358
+#: src/PrefsUnifiedDlg.cpp:2367
 #, c-format
 msgid "Time for average graph: %d minute"
 msgid_plural "Time for average graph: %d minutes"
 msgstr[0] "Keskmiste graafiku aeg: %d minutit"
 msgstr[1] "Keskmiste graafiku aeg: %d  minutit"
 
-#: src/PrefsUnifiedDlg.cpp:2367
+#: src/PrefsUnifiedDlg.cpp:2376
 #, c-format
 msgid "Connections Graph Scale: %d"
 msgstr "Ühenduse graafiku skaala: %d"
 
-#: src/PrefsUnifiedDlg.cpp:2382
+#: src/PrefsUnifiedDlg.cpp:2391
 #, c-format
 msgid "File Buffer Size: %d byte"
 msgid_plural "File Buffer Size: %d bytes"
 msgstr[0] "Failipuhvri suurus: %d baiti"
 msgstr[1] "Failipuhvri suurus: %d baiti"
 
-#: src/PrefsUnifiedDlg.cpp:2392
+#: src/PrefsUnifiedDlg.cpp:2401
 #, c-format
 msgid "Upload Queue Size: %d client"
 msgid_plural "Upload Queue Size: %d clients"
 msgstr[0] "Saatmise Saba suurus: %d klienti"
 msgstr[1] "Saatmise Saba suurus: %d klienti"
 
-#: src/PrefsUnifiedDlg.cpp:2402
+#: src/PrefsUnifiedDlg.cpp:2411
 #, c-format
 msgid "Server connection refresh interval: %d minute"
 msgid_plural "Server connection refresh interval: %d minutes"
 msgstr[0] "Serveri ühenduse värskendamise intervall: %d minutit"
 msgstr[1] "Serveri ühenduse värskendamise intervall: %d minutit"
 
-#: src/PrefsUnifiedDlg.cpp:2407
+#: src/PrefsUnifiedDlg.cpp:2416
 msgid "Server connection refresh interval: Disabled"
 msgstr "Serveri ühenduse värskendamise intervall: Ei kasuta"
 
-#: src/PrefsUnifiedDlg.cpp:2451
+#: src/PrefsUnifiedDlg.cpp:2460
 msgid "disabled"
 msgstr "keelatud"
 
-#: src/PrefsUnifiedDlg.cpp:2477
+#: src/PrefsUnifiedDlg.cpp:2486
 #, c-format
 msgid "Execute command on '%s' event"
 msgstr "Käivita käsk peale '%s' sündmust"
 
-#: src/PrefsUnifiedDlg.cpp:2484
+#: src/PrefsUnifiedDlg.cpp:2493
 msgid "Enable command execution on core"
 msgstr "Luba käskude käivitamine tuumas"
 
-#: src/PrefsUnifiedDlg.cpp:2496
+#: src/PrefsUnifiedDlg.cpp:2505
 msgid "Core command:"
 msgstr "Tuumkäsk:"
 
-#: src/PrefsUnifiedDlg.cpp:2512
+#: src/PrefsUnifiedDlg.cpp:2521
 msgid "Enable command execution on GUI"
 msgstr "Luba käskude käivitamine GUI's"
 
-#: src/PrefsUnifiedDlg.cpp:2524
+#: src/PrefsUnifiedDlg.cpp:2533
 msgid "GUI command:"
 msgstr "GUI Käsk:"
 
-#: src/PrefsUnifiedDlg.cpp:2540
+#: src/PrefsUnifiedDlg.cpp:2549
 msgid "The following variables will be replaced:"
 msgstr "Järgnevad muutujad asendatakse:"
 
-#: src/PrefsUnifiedDlg.cpp:2708
+#: src/PrefsUnifiedDlg.cpp:2717
 msgid ""
 "The following folders look like system or sensitive locations:\n"
 "\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2713
+#: src/PrefsUnifiedDlg.cpp:2722
 msgid "Sharing them recursively will publish every file underneath on the eD2k/Kad networks. Do you really want to do this?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2716
+#: src/PrefsUnifiedDlg.cpp:2725
 #, fuzzy
 msgid "Confirm shared folders"
 msgstr "Jagatud kataloogid"
 
-#: src/PrefsUnifiedDlg.cpp:2744
+#: src/PrefsUnifiedDlg.cpp:2753
 #, fuzzy
 msgid "Reloading shared files..."
 msgstr "Lae oma jagatud failid uuesti"
 
-#: src/PrefsUnifiedDlg.cpp:2745
+#: src/PrefsUnifiedDlg.cpp:2754
 msgid "Scanning for subdirectories..."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2746
+#: src/PrefsUnifiedDlg.cpp:2755
 #, fuzzy
 msgid "Updating shared folders"
 msgstr "Jagatud kataloogid"
 
-#: src/PrefsUnifiedDlg.cpp:2773
+#: src/PrefsUnifiedDlg.cpp:2782
 #, c-format
 msgid "Scanned %u directories..."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2823
+#: src/PrefsUnifiedDlg.cpp:2832
 #, fuzzy, c-format
 msgid "Reloading shared files: %u files scanned"
 msgstr "Jagatud failide loetelu taaslaadimine."
 
-#: src/PrefsUnifiedDlg.cpp:2873
+#: src/PrefsUnifiedDlg.cpp:2882
 #, fuzzy
 msgid "Shared folder"
 msgstr "Jagatud kataloogid"
@@ -7856,12 +7856,12 @@ msgstr "Eemalda kategooria"
 msgid "Hashset requested for unknown file: %s"
 msgstr "Tundmatu faili '%s' jaoks küsiti kontrollsummat."
 
-#: src/UploadQueue.cpp:618
+#: src/UploadQueue.cpp:627
 #, c-format
 msgid "Resuming uploads of file: %s"
 msgstr "Taastan faili '%s' saatmise"
 
-#: src/UploadQueue.cpp:634
+#: src/UploadQueue.cpp:643
 #, c-format
 msgid "Suspending upload of file: %s"
 msgstr "Peatan faili '%s' saatmise"

--- a/po/et_EE.po
+++ b/po/et_EE.po
@@ -10,8 +10,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-28 12:12+0200\n"
-"PO-Revision-Date: 2026-07-27 10:20+0000\n"
+"POT-Creation-Date: 2026-07-28 08:06+0200\n"
+"PO-Revision-Date: 2026-07-27 11:36+0000\n"
 "Last-Translator: \n"
 "Language-Team: Estonian <kde-i18n-doc@kde.org>\n"
 "Language: et_EE\n"
@@ -145,7 +145,7 @@ msgstr ""
 msgid "Not now"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:422 src/amuleDlg.cpp:665
+#: src/AppImageIntegration.cpp:422 src/amuleDlg.cpp:600
 msgid "Don't ask again"
 msgstr ""
 
@@ -203,83 +203,83 @@ msgstr "Ei suuda avada ED2KLinks faili."
 msgid "WARNING: You can't add yourself as a source for an eD2k link while having a lowid."
 msgstr "HOIATUS: Sa ei saa ennast eD2k lingi jaoks allikana lisada ajal kui omad lowid'd."
 
-#: src/amule.cpp:301
+#: src/amule.cpp:300
 msgid "Now, exiting main app..."
 msgstr "Ok, lahkun põhiprogrammist..."
 
-#: src/amule.cpp:331
+#: src/amule.cpp:330
 #, c-format
 msgid "Terminating amuleweb instance with pid '%d' ... "
 msgstr "Mõrvan amuleweb tegelase, protsessi id '%d' ... "
 
-#: src/amule.cpp:335
+#: src/amule.cpp:334
 #, c-format
 msgid "Killing amuleweb instance with pid '%d' ... "
 msgstr "Mõrvan amuleweb tegelase, protsessi id '%d' ... "
 
-#: src/amule.cpp:337 src/amule.cpp:350 src/ClientRef.cpp:180
-#: src/SearchDlg.cpp:1041 src/ServerListCtrl.cpp:98
+#: src/amule.cpp:336 src/amule.cpp:349 src/ClientRef.cpp:180
+#: src/SearchDlg.cpp:880 src/ServerListCtrl.cpp:98
 msgid "Failed"
 msgstr "Nurjunud"
 
-#: src/amule.cpp:344
+#: src/amule.cpp:343
 #, fuzzy, c-format
 msgid "Terminating amuleapi instance with pid '%d' ... "
 msgstr "Mõrvan amuleweb tegelase, protsessi id '%d' ... "
 
-#: src/amule.cpp:348
+#: src/amule.cpp:347
 #, fuzzy, c-format
 msgid "Killing amuleapi instance with pid '%d' ... "
 msgstr "Mõrvan amuleweb tegelase, protsessi id '%d' ... "
 
-#: src/amule.cpp:356
+#: src/amule.cpp:355
 msgid "aMule OnExit: Terminating core."
 msgstr "aMule OnExit: Peatan tuuma."
 
-#: src/amule.cpp:467
+#: src/amule.cpp:466
 msgid "aMule shutdown completed."
 msgstr "aMule seiskamine lõpetatud."
 
-#: src/amule.cpp:471
+#: src/amule.cpp:470
 msgid "Memory debug results for aMule exit:"
 msgstr "aMule väljumise mälu veajälituse tulemus:"
 
-#: src/amule.cpp:652
+#: src/amule.cpp:651
 #, c-format
 msgid "Binding aMule's peer-to-peer traffic to interface: %s (HTTP updates use the default route)"
 msgstr ""
 
-#: src/amule.cpp:656
+#: src/amule.cpp:655
 #, c-format
 msgid "Binding all network traffic to interface: %s"
 msgstr ""
 
-#: src/amule.cpp:660
+#: src/amule.cpp:659
 #, c-format
 msgid "WARNING: configured network interface '%s' was not found - traffic is NOT bound to it and may leave via the default route. Check the interface name in Preferences."
 msgstr ""
 
-#: src/amule.cpp:666
+#: src/amule.cpp:665
 #, c-format
 msgid "WARNING: binding to network interface '%s' requires elevated privileges and was NOT applied - traffic may leave via the default route. Grant the capability (e.g. 'sudo setcap cap_net_raw+ep' on the aMule binary) or run with sufficient privileges."
 msgstr ""
 
-#: src/amule.cpp:674
+#: src/amule.cpp:673
 #, c-format
 msgid "WARNING: could not bind to network interface '%s' - traffic may leave via the default route."
 msgstr ""
 
-#: src/amule.cpp:733
+#: src/amule.cpp:732
 msgid "Your locale has been changed to System Default due to a configuration change. Sorry."
 msgstr "Sinu keelelokaat muudeti süsteemi vaikeväärtuseks seoses konfiguratsiooni muudatustega. Sorry."
 
-#: src/amule.cpp:735 src/amule.cpp:1589 src/CatDialog.cpp:128
+#: src/amule.cpp:734 src/amule.cpp:1581 src/CatDialog.cpp:128
 #: src/CatDialog.cpp:136 src/CatDialog.cpp:149 src/ServerList.cpp:366
 #: src/ServerListCtrl.cpp:152
 msgid "Info"
 msgstr "Info"
 
-#: src/amule.cpp:742
+#: src/amule.cpp:741
 msgid ""
 "\n"
 "EC configuration"
@@ -287,74 +287,74 @@ msgstr ""
 "\n"
 "EC seadistused"
 
-#: src/amule.cpp:745
+#: src/amule.cpp:744
 msgid "Password set and external connections enabled."
 msgstr "Parool on määratud ja välised ühendused võimalikud."
 
-#: src/amule.cpp:755 src/KadDlg.cpp:176 src/KadDlg.cpp:185
-#: src/PrefsUnifiedDlg.cpp:1461 src/SharedFilesCtrl.cpp:476
+#: src/amule.cpp:754 src/KadDlg.cpp:176 src/KadDlg.cpp:185
+#: src/PrefsUnifiedDlg.cpp:1387 src/SharedFilesCtrl.cpp:476
 msgid "WARNING"
 msgstr "HOIATUS"
 
-#: src/amule.cpp:992
+#: src/amule.cpp:991
 #, fuzzy
 msgid "Network bootstrap"
 msgstr "Võrgud"
 
-#: src/amule.cpp:997
+#: src/amule.cpp:996
 msgid ""
 "aMule has detected missing network bootstrap files.\n"
 "Select which ones to download:"
 msgstr ""
 
-#: src/amule.cpp:1006 src/FirstRunWizard.cpp:411
+#: src/amule.cpp:1005 src/FirstRunWizard.cpp:411
 #, fuzzy
 msgid "eD2k server list (server.met)"
 msgstr "Failis server.met on %i serverit"
 
-#: src/amule.cpp:1013 src/FirstRunWizard.cpp:416
+#: src/amule.cpp:1012 src/FirstRunWizard.cpp:416
 msgid "Kad bootstrap nodes (nodes.dat)"
 msgstr ""
 
-#: src/amule.cpp:1103
+#: src/amule.cpp:1102
 #, c-format
 msgid "web server running on pid %d"
 msgstr "web server töötab protsessi id'ga %d"
 
-#: src/amule.cpp:1116
+#: src/amule.cpp:1115
 #, fuzzy
 msgid "You requested to run web server on startup, but the amuleweb binary cannot be run. Please install the package containing aMule web server, or build aMule from source with -DBUILD_WEBSERVER=YES and install it."
 msgstr "Soovisid et web server käivitataks käivitumisel, kuid amuleweb programm pole võimeline käivituma. Palun paigalada versioon mis sisaldab aMule web serverit või kompileeri aMule kasutades võtit --enable-webserver ja seejärel make install"
 
-#: src/amule.cpp:1121 src/amule.cpp:1185 src/amule.cpp:1299 src/amule.cpp:1601
+#: src/amule.cpp:1120 src/amule.cpp:1177 src/amule.cpp:1291 src/amule.cpp:1593
 #: src/amule-remote-gui.cpp:603 src/amule-remote-gui.cpp:671
 #: src/amule-remote-gui.cpp:709 src/amule-remote-gui.cpp:1282
 #: src/amule-remote-gui.cpp:1345 src/amule-remote-gui.cpp:1372
-#: src/DownloadQueue.cpp:1481 src/PrefsUnifiedDlg.cpp:1247
+#: src/DownloadQueue.cpp:1481
 msgid "ERROR"
 msgstr "VIGA"
 
-#: src/amule.cpp:1174
+#: src/amule.cpp:1166
 #, fuzzy, c-format
 msgid "amuleapi running on pid %d"
 msgstr "web server töötab protsessi id'ga %d"
 
-#: src/amule.cpp:1180
+#: src/amule.cpp:1172
 #, fuzzy
 msgid "You requested to run amuleapi on startup, but the amuleapi binary cannot be run. Please install the package containing aMule's REST API server, or build aMule from source with -DBUILD_AMULEAPI=YES and install it."
 msgstr "Soovisid et web server käivitataks käivitumisel, kuid amuleweb programm pole võimeline käivituma. Palun paigalada versioon mis sisaldab aMule web serverit või kompileeri aMule kasutades võtit --enable-webserver ja seejärel make install"
 
-#: src/amule.cpp:1267
+#: src/amule.cpp:1259
 #, c-format
 msgid "Could not bind ports to the specified address: %s"
 msgstr "Ei suuda siduda porti määratud aadressiga: %s"
 
-#: src/amule.cpp:1291
+#: src/amule.cpp:1283
 #, c-format
 msgid "Port %u is not available. You will be LOWID\n"
 msgstr "Port %u ei ole kasutatav. Sa saad LOWID\n"
 
-#: src/amule.cpp:1296
+#: src/amule.cpp:1288
 #, c-format
 msgid ""
 "Port %u is not available!\n"
@@ -369,48 +369,48 @@ msgstr ""
 "Kasuta netstat programmi kontrollimaks kuna port vabaneb\n"
 "ja proovi amule uuesti käivitada."
 
-#: src/amule.cpp:1393
+#: src/amule.cpp:1385
 msgid "Failed to create OnlineSig File"
 msgstr "Ei suutnud luua OnlineSig Faili"
 
-#: src/amule.cpp:1401
+#: src/amule.cpp:1393
 msgid "Failed to create aMule OnlineSig File"
 msgstr "Ei suutnud luua aMule OnlineSig Faili"
 
-#: src/amule.cpp:1564
+#: src/amule.cpp:1556
 msgid "The selected locale seems not to be installed on your box. (Note: I'll try to set it anyway)"
 msgstr "Tundub et valitud keelelokaat pole sinu karpi installeritud. (Märkus: Ma proovin seda seada sellest hoolimata)"
 
-#: src/amule.cpp:1574
+#: src/amule.cpp:1566
 #, c-format
 msgid "This is the first time you run aMule %s"
 msgstr "See on aMule %s käivitamise esimene kord"
 
-#: src/amule.cpp:1577
+#: src/amule.cpp:1569
 msgid "This version is a testing version, updated daily, and\n"
 msgstr "See on testversioon, mida igapäevaselt uuendatakse ja\n"
 
-#: src/amule.cpp:1578
+#: src/amule.cpp:1570
 msgid "we give no warranty it won't break anything, burn your house,\n"
 msgstr "me ei anna mingit garantiid, et see ei lõhu midagi, ei süüta sinu elamist\n"
 
-#: src/amule.cpp:1579
+#: src/amule.cpp:1571
 msgid "or kill your dog. But it *should* be safe to use anyway.\n"
 msgstr "ega tapa sinu koera. Sellest hoolimata peaks see olema *turvaline* kasutada.\n"
 
-#: src/amule.cpp:1584
+#: src/amule.cpp:1576
 msgid "More information, support and new releases can found at our homepage,\n"
 msgstr "Rohkem informatsiooni, tuge ja uusi programmi versioone leiad meie kodulehelt,\n"
 
-#: src/amule.cpp:1585
+#: src/amule.cpp:1577
 msgid "at https://amule-org.github.io, or in our IRC channel #aMule at irc.libera.chat.\n"
 msgstr "aadressil https://amule-org.github.io või meie IRC kanalis #aMule aadressil irc.libera.chat.\n"
 
-#: src/amule.cpp:1587
+#: src/amule.cpp:1579
 msgid "Feel free to report any bugs to https://github.com/amule-org/amule/issues"
 msgstr "Tunne ennast vabalt suvaliste vigade leidmisest teavitamisel aadressil https://github.com/amule-org/amule/issues"
 
-#: src/amule.cpp:1599
+#: src/amule.cpp:1591
 msgid ""
 "The folder for Online Signature files you specified is INVALID!\n"
 " OnlineSignature will be DISABLED until you fix it on preferences."
@@ -418,137 +418,137 @@ msgstr ""
 "Online Allkirja kataloog on VIGANE!\n"
 " Online Allkirja ei kasutata, kuni parandad vea seadetes."
 
-#: src/amule.cpp:1662
+#: src/amule.cpp:1654
 msgid "Server hostname notified"
 msgstr "Teatatud serveri nimi"
 
-#: src/amule.cpp:2039
+#: src/amule.cpp:2031
 #, c-format
 msgid "Disk space preallocation for file '%s' failed: %s"
 msgstr "Kettaruumi eraldamine faili '%s' jaoks ebaõnnestus: %s"
 
-#: src/amule.cpp:2168
+#: src/amule.cpp:2160
 msgid "ERROR: can't open logfile"
 msgstr "VIGA: Ei suutnud avada logifaili"
 
-#: src/amule.cpp:2172
+#: src/amule.cpp:2164
 msgid "WARNING: logfile is empty. Something is wrong."
 msgstr "HOIATUS: logifail on tühi, miskit on kapitaalselt viltu."
 
-#: src/amule.cpp:2189
+#: src/amule.cpp:2181
 msgid "Log has been reset"
 msgstr "Log on nullitud"
 
-#: src/amule.cpp:2213
+#: src/amule.cpp:2205
 #, c-format
 msgid "ServerMessage: %s"
 msgstr "Serveri teade: %s"
 
-#: src/amule.cpp:2256 src/IP2Country.cpp:220 src/IPFilter.cpp:514
+#: src/amule.cpp:2248 src/IP2Country.cpp:220 src/IPFilter.cpp:514
 #: src/ServerList.cpp:875
 #, c-format
 msgid "Skipped download of %s, because requested file is not newer."
 msgstr "Fail %s jäeti vahele, sest soovitud fail pole uuem."
 
-#: src/amule.cpp:2259
+#: src/amule.cpp:2251
 msgid "Failed to download the nodes list."
 msgstr "Ebaõnnestus sõlmede nimekirja tõmbamine."
 
-#: src/amule.cpp:2322
+#: src/amule.cpp:2314
 msgid "Failed to open the downloaded version check file"
 msgstr "Ebaõnnestus tõmmatud versiooni kotrollfaili avamine"
 
-#: src/amule.cpp:2325 src/amule.cpp:2344
+#: src/amule.cpp:2317 src/amule.cpp:2336
 msgid "Corrupted version check file"
 msgstr "Versiooni kontrollfail on korrumpeerunud"
 
-#: src/amule.cpp:2367
+#: src/amule.cpp:2359
 msgid "You are using an outdated version of aMule!"
 msgstr "Kasutad aegunud aMule versiooni!"
 
-#: src/amule.cpp:2369
+#: src/amule.cpp:2361
 #, c-format
 msgid "Your aMule version is %i.%i.%i and the latest version is %li.%li.%li"
 msgstr "Sinu aMule versioon on %i.%i.%i ja uusim versioon on %li.%li.%li"
 
-#: src/amule.cpp:2373
+#: src/amule.cpp:2365
 msgid "The latest version can always be found at https://github.com/amule-org/amule/releases/latest"
 msgstr "Uuema aMule versiooni saad alati aadressilt https://github.com/amule-org/amule/releases/latest"
 
-#: src/amule.cpp:2376
+#: src/amule.cpp:2368
 #, c-format
 msgid "WARNING: Your aMuled version is outdated: %i.%i.%i < %li.%li.%li"
 msgstr "HOAITUS: Sinu aMuled versioon on vananenud: %i.%i.%i < %li.%li.%li"
 
-#: src/amule.cpp:2382
+#: src/amule.cpp:2374
 msgid "Your copy of aMule is up to date."
 msgstr "Sinu aMule koopia on ajakohane."
 
-#: src/amule.cpp:2389
+#: src/amule.cpp:2381
 msgid "Failed to download the version check file"
 msgstr "Versiooni kontrollfaili tõmbamine ebaõnnestus"
 
-#: src/amule.cpp:2558 src/amule-remote-gui.cpp:1133
+#: src/amule.cpp:2550 src/amule-remote-gui.cpp:1133
 #, c-format
 msgid "Users: %s | Files: %s"
 msgstr "Kasutajaid: %s | Faile: %s"
 
-#: src/amule.cpp:2559 src/amule-remote-gui.cpp:1134
+#: src/amule.cpp:2551 src/amule-remote-gui.cpp:1134
 #, c-format
 msgid "Users: E: %s K: %s | Files: E: %s K: %s"
 msgstr "Kasutajaid: E: %s K: %s | Faile E: %s K: %s"
 
-#: src/amule.cpp:2573 src/amule-remote-gui.cpp:1147
+#: src/amule.cpp:2565 src/amule-remote-gui.cpp:1147
 msgid "No networks selected"
 msgstr "Ühtegi võrku pole valitud"
 
-#: src/amule.cpp:2641 src/TextClient.cpp:903
+#: src/amule.cpp:2633 src/TextClient.cpp:903
 msgid "with LowID"
 msgstr "koos LowID"
 
-#: src/amule.cpp:2641 src/TextClient.cpp:904
+#: src/amule.cpp:2633 src/TextClient.cpp:904
 msgid "with HighID"
 msgstr "koos HighID"
 
-#: src/amule.cpp:2643
+#: src/amule.cpp:2635
 #, c-format
 msgid "Connected to %s %s"
 msgstr "Ühendatud %s %s"
 
-#: src/amule.cpp:2648
+#: src/amule.cpp:2640
 #, c-format
 msgid "Connecting to %s"
 msgstr "Ühendun %s"
 
-#: src/amule.cpp:2650
+#: src/amule.cpp:2642
 msgid "Disconnected from eD2k"
 msgstr "eD2k ühendus katkestatud."
 
-#: src/amule.cpp:2659
+#: src/amule.cpp:2651
 msgid "Kad started."
 msgstr "Kad käivitatud."
 
-#: src/amule.cpp:2661
+#: src/amule.cpp:2653
 msgid "Kad stopped."
 msgstr "Kad peatatud."
 
-#: src/amule.cpp:2669
+#: src/amule.cpp:2661
 msgid "Connected to Kad (ok)"
 msgstr "Ühendus Kad võrk (ok)"
 
-#: src/amule.cpp:2671
+#: src/amule.cpp:2663
 msgid "Connected to Kad (firewalled)"
 msgstr "Ühendus Kad võrku (tulemüüriga)"
 
-#: src/amule.cpp:2675
+#: src/amule.cpp:2667
 msgid "Disconnected from Kad"
 msgstr "Ühendus Kad võrguga katkestatud"
 
-#: src/amule.cpp:2707
+#: src/amule.cpp:2699
 msgid "Kad network cannot be used if UDP port is disabled on preferences, not starting."
 msgstr "Kad võrku ei saa kasutada kui seadetes on UDP port väljalülitatud, ei ühendu."
 
-#: src/amule.cpp:2711
+#: src/amule.cpp:2703
 msgid "Kad network disabled on preferences, not connecting."
 msgstr "Kad on seadetes väljalülitatud, ei ühenda."
 
@@ -574,68 +574,30 @@ msgstr "Ei suuda luua PID faili"
 msgid "ERROR: %s"
 msgstr "VIGA: %s"
 
-#: src/amuleDlg.cpp:250
+#: src/amuleDlg.cpp:236
 #, c-format
 msgid "This is aMule %s based on eMule."
 msgstr "See on eMulel põhinev aMule %s."
 
-#: src/amuleDlg.cpp:251
+#: src/amuleDlg.cpp:237
 #, c-format
 msgid "Running on %s"
 msgstr "Jookseb %s peal"
 
-#: src/amuleDlg.cpp:253
+#: src/amuleDlg.cpp:239
 msgid "Visit https://github.com/amule-org/amule/releases/latest to check if a new version is available."
 msgstr "Külasta https://github.com/amule-org/amule/releases/latest ja vaata ehk on uuem versioon saadaval."
 
-#: src/amuleDlg.cpp:282
+#: src/amuleDlg.cpp:268
 msgid "FATAL ERROR: Failed to create Timer"
 msgstr "Fataalne VIGA: Ei suutnud luua stopperit."
 
-#: src/amuleDlg.cpp:361 src/amuleDlg.cpp:1810 src/amuleDlg.cpp:2056
-#: src/muuli_wdr.cpp:1492 src/muuli_wdr.cpp:3439
-msgid "Networks"
-msgstr "Võrgud"
-
-#: src/amuleDlg.cpp:362 src/amuleDlg.cpp:1816 src/muuli_wdr.cpp:3440
-msgid "Searches"
-msgstr "Otsingud"
-
-#: src/amuleDlg.cpp:363 src/amuleDlg.cpp:1822 src/DownloadListCtrl.cpp:740
-#: src/muuli_wdr.cpp:392 src/muuli_wdr.cpp:1585 src/muuli_wdr.cpp:3441
-#: src/Statistics.cpp:829
-msgid "Downloads"
-msgstr "Tõmbamised"
-
-#: src/amuleDlg.cpp:364 src/amuleDlg.cpp:1828 src/muuli_wdr.cpp:3315
-msgid "Shared files"
-msgstr "Jagatud failid"
-
-#: src/amuleDlg.cpp:365 src/amuleDlg.cpp:1834 src/muuli_wdr.cpp:2947
-#: src/muuli_wdr.cpp:3397 src/muuli_wdr.cpp:3444
-msgid "Messages"
-msgstr "Teated"
-
-#: src/amuleDlg.cpp:366 src/amuleDlg.cpp:1840 src/muuli_wdr.cpp:3445
-#: src/PrefsUnifiedDlg.cpp:314 src/Statistics.cpp:779 src/Statistics.cpp:1235
-msgid "Statistics"
-msgstr "Statistika"
-
-#: src/amuleDlg.cpp:368 src/amuleDlg.cpp:1847 src/muuli_wdr.cpp:3447
-#: src/PrefsUnifiedDlg.cpp:330 src/utils/wxCas/src/wxcasprefs.cpp:39
-msgid "Preferences"
-msgstr "Seaded"
-
-#: src/amuleDlg.cpp:371
-msgid "Navigate"
-msgstr ""
-
-#: src/amuleDlg.cpp:657
+#: src/amuleDlg.cpp:592
 #, fuzzy
 msgid "New version available"
 msgstr "Info puudub"
 
-#: src/amuleDlg.cpp:661
+#: src/amuleDlg.cpp:596
 #, fuzzy, c-format
 msgid ""
 "A new version of aMule (%s) is available.\n"
@@ -645,185 +607,218 @@ msgid ""
 "Would you like to open the download page?"
 msgstr "Uuema aMule versiooni saad alati aadressilt https://github.com/amule-org/amule/releases/latest"
 
-#: src/amuleDlg.cpp:743
+#: src/amuleDlg.cpp:678
 msgid "aMule dialog destroyed"
 msgstr "aMule dialoog hävitatud"
 
-#: src/amuleDlg.cpp:766 src/DataToText.cpp:68 src/IPFilter.cpp:547
+#: src/amuleDlg.cpp:701 src/DataToText.cpp:68 src/IPFilter.cpp:547
 msgid "Connecting"
 msgstr "Ühendun"
 
-#: src/amuleDlg.cpp:958
+#: src/amuleDlg.cpp:893
 msgid "eD2k: Connecting"
 msgstr "eD2k: Ühendun"
 
-#: src/amuleDlg.cpp:962
+#: src/amuleDlg.cpp:897
 msgid "eD2k: Disconnected"
 msgstr "eD2k: Lahutatud"
 
-#: src/amuleDlg.cpp:968
+#: src/amuleDlg.cpp:903
 msgid "Kad: Firewalled"
 msgstr "Kad: Tulemüüriga"
 
-#: src/amuleDlg.cpp:972
+#: src/amuleDlg.cpp:907
 msgid "Kad: Connected"
 msgstr "Kad: Ühendatud"
 
-#: src/amuleDlg.cpp:977
+#: src/amuleDlg.cpp:912
 msgid "Kad: Connecting"
 msgstr "Kad: Ühendun"
 
-#: src/amuleDlg.cpp:981
+#: src/amuleDlg.cpp:916
 msgid "Kad: Off"
 msgstr "Kad: Väljas"
 
-#: src/amuleDlg.cpp:1029 src/DownloadListCtrl.cpp:505
+#: src/amuleDlg.cpp:964 src/DownloadListCtrl.cpp:505
 #: src/DownloadListCtrl.cpp:749 src/FriendListCtrl.cpp:180
 #: src/muuli_wdr.cpp:731 src/muuli_wdr.cpp:782 src/muuli_wdr.cpp:846
-#: src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2252 src/muuli_wdr.cpp:2337
-#: src/muuli_wdr.cpp:3085 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
+#: src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2224 src/muuli_wdr.cpp:2309
+#: src/muuli_wdr.cpp:3057 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
 #: src/ServerListCtrl.cpp:606 src/TransferWnd.cpp:378
 #: src/utils/wxCas/src/wxcasprefs.cpp:235
 msgid "Cancel"
 msgstr "Loobu"
 
-#: src/amuleDlg.cpp:1030
+#: src/amuleDlg.cpp:965
 msgid "Stop the current connection attempts"
 msgstr "Lõpeta käimasolevad ühenduskatsed"
 
-#: src/amuleDlg.cpp:1035 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976
-#: src/muuli_wdr.cpp:2475
+#: src/amuleDlg.cpp:970 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976
+#: src/muuli_wdr.cpp:2447
 msgid "Disconnect"
 msgstr "Ühendu lahti"
 
-#: src/amuleDlg.cpp:1036
+#: src/amuleDlg.cpp:971
 msgid "Disconnect from the currently connected networks"
 msgstr "Lõpeta ühendus ühendatud võrkudega"
 
-#: src/amuleDlg.cpp:1041 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979
-#: src/muuli_wdr.cpp:2630 src/muuli_wdr.cpp:3082 src/muuli_wdr.cpp:3437
+#: src/amuleDlg.cpp:976 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979
+#: src/muuli_wdr.cpp:2602 src/muuli_wdr.cpp:3054 src/muuli_wdr.cpp:3409
 msgid "Connect"
 msgstr "Ühenda"
 
-#: src/amuleDlg.cpp:1042
+#: src/amuleDlg.cpp:977
 msgid "Connect to the currently enabled networks"
 msgstr "Ühendu olemasolevate, aktiivsete võrkudega"
 
-#: src/amuleDlg.cpp:1154
+#: src/amuleDlg.cpp:1089
 #, fuzzy, c-format
 msgid "Up: %.1f%s (%.1f) | Down: %.1f%s (%.1f)"
 msgstr "Üles: %.1f(%.1f) | Alla: %.1f(%.1f)"
 
-#: src/amuleDlg.cpp:1156 src/amuleDlg.cpp:1158 src/amuleDlg.cpp:1162
-#: src/amuleDlg.cpp:1164 src/amuleDlg.cpp:1175 src/amuleDlg.cpp:1177
+#: src/amuleDlg.cpp:1091 src/amuleDlg.cpp:1093 src/amuleDlg.cpp:1097
+#: src/amuleDlg.cpp:1099 src/amuleDlg.cpp:1110 src/amuleDlg.cpp:1112
 #: src/MuleTrayIcon.cpp:796 src/MuleTrayIcon.cpp:799
 #, fuzzy
 msgid " MB/s"
 msgstr "MB/s"
 
-#: src/amuleDlg.cpp:1156 src/amuleDlg.cpp:1158 src/amuleDlg.cpp:1162
-#: src/amuleDlg.cpp:1164 src/amuleDlg.cpp:1175 src/amuleDlg.cpp:1177
+#: src/amuleDlg.cpp:1091 src/amuleDlg.cpp:1093 src/amuleDlg.cpp:1097
+#: src/amuleDlg.cpp:1099 src/amuleDlg.cpp:1110 src/amuleDlg.cpp:1112
 #: src/MuleTrayIcon.cpp:796 src/MuleTrayIcon.cpp:799
 #: src/utils/wxCas/src/wxcasframe.cpp:1041
 msgid " kB/s"
 msgstr " kB/s"
 
-#: src/amuleDlg.cpp:1161
+#: src/amuleDlg.cpp:1096
 #, fuzzy, c-format
 msgid "Up: %.1f%s | Down: %.1f%s"
 msgstr "Üles: %.1f | Alla: %.1f"
 
-#: src/amuleDlg.cpp:1193
+#: src/amuleDlg.cpp:1128
 #, c-format
 msgid "aMule (%s | Connected)"
 msgstr "aMule (%s | Ühendatud)"
 
-#: src/amuleDlg.cpp:1195
+#: src/amuleDlg.cpp:1130
 #, c-format
 msgid "aMule (%s | Disconnected)"
 msgstr "aMule (%s | Ühenduseta)"
 
-#: src/amuleDlg.cpp:1248
+#: src/amuleDlg.cpp:1183
 #, c-format
 msgid "Do you really want to exit %s?"
 msgstr "Kas sa tõesti tahad %s'st väljuda?"
 
-#: src/amuleDlg.cpp:1250
+#: src/amuleDlg.cpp:1185
 msgid "Exit confirmation"
 msgstr "Kinnitan väljumise"
 
-#: src/amuleDlg.cpp:1613
+#: src/amuleDlg.cpp:1548
 msgid "Launch Command: "
 msgstr "Käivitamise korraldus: "
 
-#: src/amuleDlg.cpp:1632 src/muuli_wdr.cpp:1972 src/Preferences.cpp:979
+#: src/amuleDlg.cpp:1567 src/muuli_wdr.cpp:1971 src/Preferences.cpp:951
 msgid "- default -"
 msgstr "- vaikimisi -"
 
-#: src/amuleDlg.cpp:1660
+#: src/amuleDlg.cpp:1595
 #, c-format
 msgid "Skin directory '%s' does not exist"
 msgstr "Rüüde kataloogi  '%s' ei eksiteeri"
 
-#: src/amuleDlg.cpp:1663
+#: src/amuleDlg.cpp:1598
 #, c-format
 msgid "WARNING: Unable to open skin file '%s' for read"
 msgstr "HOIATUS: Ei suuda rüüfaili '%s' lugemiseks avada"
 
-#: src/amuleDlg.cpp:1814 src/muuli_wdr.cpp:3439
+#: src/amuleDlg.cpp:1722 src/amuleDlg.cpp:1968 src/muuli_wdr.cpp:1485
+#: src/muuli_wdr.cpp:3411
+msgid "Networks"
+msgstr "Võrgud"
+
+#: src/amuleDlg.cpp:1726 src/muuli_wdr.cpp:3411
 msgid "Networks Window"
 msgstr "Võrgud"
 
-#: src/amuleDlg.cpp:1820 src/muuli_wdr.cpp:3440
+#: src/amuleDlg.cpp:1728 src/muuli_wdr.cpp:3412
+msgid "Searches"
+msgstr "Otsingud"
+
+#: src/amuleDlg.cpp:1732 src/muuli_wdr.cpp:3412
 msgid "Searches Window"
 msgstr "Otsingu aken"
 
-#: src/amuleDlg.cpp:1826 src/muuli_wdr.cpp:3441
+#: src/amuleDlg.cpp:1734 src/DownloadListCtrl.cpp:740 src/muuli_wdr.cpp:392
+#: src/muuli_wdr.cpp:1578 src/muuli_wdr.cpp:3413 src/Statistics.cpp:829
+msgid "Downloads"
+msgstr "Tõmbamised"
+
+#: src/amuleDlg.cpp:1738 src/muuli_wdr.cpp:3413
 msgid "Downloads Window"
 msgstr "Tõmbamised"
 
-#: src/amuleDlg.cpp:1832 src/muuli_wdr.cpp:3443
+#: src/amuleDlg.cpp:1740 src/muuli_wdr.cpp:3287
+msgid "Shared files"
+msgstr "Jagatud failid"
+
+#: src/amuleDlg.cpp:1744 src/muuli_wdr.cpp:3415
 msgid "Shared Files Window"
 msgstr "Jagatud failide Aken"
 
-#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3444
+#: src/amuleDlg.cpp:1746 src/muuli_wdr.cpp:2919 src/muuli_wdr.cpp:3369
+#: src/muuli_wdr.cpp:3416
+msgid "Messages"
+msgstr "Teated"
+
+#: src/amuleDlg.cpp:1750 src/muuli_wdr.cpp:3416
 msgid "Messages Window"
 msgstr "Teadete Aken"
 
-#: src/amuleDlg.cpp:1844 src/muuli_wdr.cpp:3445
+#: src/amuleDlg.cpp:1752 src/muuli_wdr.cpp:3417 src/PrefsUnifiedDlg.cpp:312
+#: src/Statistics.cpp:779 src/Statistics.cpp:1235
+msgid "Statistics"
+msgstr "Statistika"
+
+#: src/amuleDlg.cpp:1756 src/muuli_wdr.cpp:3417
 msgid "Statistics Graph Window"
 msgstr "Statistiliste graafikute aken"
 
-#: src/amuleDlg.cpp:1851 src/muuli_wdr.cpp:3447
+#: src/amuleDlg.cpp:1759 src/muuli_wdr.cpp:3419 src/PrefsUnifiedDlg.cpp:328
+#: src/utils/wxCas/src/wxcasprefs.cpp:39
+msgid "Preferences"
+msgstr "Seaded"
+
+#: src/amuleDlg.cpp:1763 src/muuli_wdr.cpp:3419
 msgid "Preferences Settings Window"
 msgstr "Seadete aken"
 
-#: src/amuleDlg.cpp:1854 src/muuli_wdr.cpp:3448
+#: src/amuleDlg.cpp:1766 src/muuli_wdr.cpp:3420
 msgid "Import"
 msgstr "Impordi"
 
-#: src/amuleDlg.cpp:1858 src/muuli_wdr.cpp:3448
+#: src/amuleDlg.cpp:1770 src/muuli_wdr.cpp:3420
 msgid "The partfile importer tool"
 msgstr "Osafailide importimise tööriist"
 
-#: src/amuleDlg.cpp:1861 src/muuli_wdr.cpp:3449
+#: src/amuleDlg.cpp:1773 src/muuli_wdr.cpp:3421
 #: src/utils/aLinkCreator/src/alcframe.cpp:262
 msgid "About"
 msgstr "Info"
 
-#: src/amuleDlg.cpp:1861 src/muuli_wdr.cpp:3449
+#: src/amuleDlg.cpp:1773 src/muuli_wdr.cpp:3421
 msgid "About/Help"
 msgstr "Info/Appi"
 
-#: src/amuleDlg.cpp:2059
+#: src/amuleDlg.cpp:1971
 msgid "eD2k network"
 msgstr "eD2k võrk"
 
-#: src/amuleDlg.cpp:2062
+#: src/amuleDlg.cpp:1974
 msgid "Kad network"
 msgstr "Kad võrk"
 
-#: src/amuleDlg.cpp:2062
+#: src/amuleDlg.cpp:1974
 msgid "No network"
 msgstr "Võrk puudub"
 
@@ -953,7 +948,7 @@ msgstr "Faili ei leitud."
 msgid "The core rejected these shared folders:%s"
 msgstr ""
 
-#: src/amule-remote-gui.cpp:1336 src/ExternalConn.cpp:2346
+#: src/amule-remote-gui.cpp:1336 src/ExternalConn.cpp:2345
 msgid "Invalid link or already on list."
 msgstr "Vigane link või on juba loetelus."
 
@@ -969,7 +964,7 @@ msgstr "Ei suuda luua kataloogi '%s' '%s' kategooria jaoks, säilitan '%s' katal
 #: src/ClientDetailDialog.cpp:123 src/DataToText.cpp:61 src/DataToText.cpp:86
 #: src/DataToText.cpp:101 src/DataToText.cpp:136 src/DataToText.cpp:165
 #: src/DownloadListCtrl.cpp:1172 src/DownloadListCtrl.cpp:1185
-#: src/DownloadListCtrl.cpp:1196 src/ExternalConn.cpp:609
+#: src/DownloadListCtrl.cpp:1196 src/ExternalConn.cpp:608
 #: src/FileDetailDialog.cpp:203 src/FileDetailDialog.cpp:235
 #: src/FileDetailDialog.cpp:242 src/GenericClientListCtrl.cpp:1171
 #: src/GenericClientListCtrl.cpp:1182 src/GenericClientListCtrl.cpp:1192
@@ -1356,19 +1351,19 @@ msgstr "Auto [Kõrge]"
 msgid "Very low"
 msgstr "Väga madal"
 
-#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:743 src/muuli_wdr.cpp:2303
+#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:743 src/muuli_wdr.cpp:2275
 #: src/ServerListCtrl.cpp:263 src/ServerListCtrl.cpp:456
 #: src/SharedFilesCtrl.cpp:145
 msgid "Low"
 msgstr "Madal"
 
-#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:744 src/muuli_wdr.cpp:2304
+#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:744 src/muuli_wdr.cpp:2276
 #: src/ServerListCtrl.cpp:266 src/ServerListCtrl.cpp:457
 #: src/SharedFilesCtrl.cpp:146
 msgid "Normal"
 msgstr "Keskmine"
 
-#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:745 src/muuli_wdr.cpp:2305
+#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:745 src/muuli_wdr.cpp:2277
 #: src/ServerListCtrl.cpp:269 src/ServerListCtrl.cpp:458
 #: src/SharedFilesCtrl.cpp:147
 msgid "High"
@@ -1460,8 +1455,8 @@ msgstr "Kohalik server"
 msgid "Remote Server"
 msgstr "Kaug server"
 
-#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3202
-#: src/SearchDlg.cpp:119 src/TextClient.cpp:911
+#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3174
+#: src/SearchDlg.cpp:111 src/TextClient.cpp:911
 msgid "Kad"
 msgstr "Kad"
 
@@ -1532,7 +1527,7 @@ msgstr "Osa"
 msgid "Size"
 msgstr "Suurus"
 
-#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3269
+#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3241
 msgid "Transferred"
 msgstr "Siiratud"
 
@@ -1590,7 +1585,7 @@ msgstr ""
 "Tagasiside : %s (%s)\n"
 "\n"
 
-#: src/DownloadListCtrl.cpp:746 src/muuli_wdr.cpp:2306
+#: src/DownloadListCtrl.cpp:746 src/muuli_wdr.cpp:2278
 #: src/SharedFilesCtrl.cpp:150
 msgid "Auto"
 msgstr "Auto"
@@ -1628,7 +1623,7 @@ msgid "Extended Options"
 msgstr "Laiendatud valikud"
 
 #: src/DownloadListCtrl.cpp:770 src/DownloadListCtrl.cpp:822
-#: src/muuli_wdr.cpp:1790
+#: src/muuli_wdr.cpp:1789
 msgid "Preview"
 msgstr "Eelvaade"
 
@@ -1803,232 +1798,227 @@ msgstr[1] ""
 msgid "Invalid eD2k link! ERROR: %s"
 msgstr "Vigane eD2k link! VIGA: %s"
 
-#: src/ExternalConn.cpp:380
+#: src/ExternalConn.cpp:379
 msgid "Client sent packet after authentication failed."
 msgstr "Klient saatis paketi peale ebaõnnestunud autoriseerimist."
 
-#: src/ExternalConn.cpp:397
+#: src/ExternalConn.cpp:396
 msgid "External connection closed."
 msgstr "Välisühendus suleti"
 
-#: src/ExternalConn.cpp:474
+#: src/ExternalConn.cpp:473
 msgid "External connections disabled due to empty password!"
 msgstr "Välisühendused on tühja parooli tõttu mitteaktiivsed"
 
-#: src/ExternalConn.cpp:495
+#: src/ExternalConn.cpp:494
 msgid "External connections disabled in config file"
 msgstr "Välisühendused on konfiguratsioonifailis defineeritud mitteaktiivsena."
 
-#: src/ExternalConn.cpp:576
+#: src/ExternalConn.cpp:575
 msgid "New external connection accepted"
 msgstr "Kinnitati uus väline ühendus"
 
-#: src/ExternalConn.cpp:579
+#: src/ExternalConn.cpp:578
 msgid "ERROR: couldn't accept a new external connection"
 msgstr "VIGA: Ei suutnud uut välist ühendust aksepteerida"
 
-#: src/ExternalConn.cpp:596
+#: src/ExternalConn.cpp:595
 msgid "External connection refused due to empty password in preferences!"
 msgstr "Välisühendustest keelduti tühja parooli tõttu seadetes!"
 
-#: src/ExternalConn.cpp:608
+#: src/ExternalConn.cpp:607
 #, c-format
 msgid "Connecting client: %s %s"
 msgstr "Ühendan klienti: %s %s"
 
-#: src/ExternalConn.cpp:610
+#: src/ExternalConn.cpp:609
 msgid "Unknown version"
 msgstr "Versioon teadmata"
 
-#: src/ExternalConn.cpp:623
+#: src/ExternalConn.cpp:622
 msgid "Incorrect EC version ID, there might be binary incompatibility. Use core and remote from same snapshot."
 msgstr "Mittekorrektne Välisühenduste versiooni ID, siin võib olla binaarne kokkusobimatus.Kasuta sama versiooni tuuma ja kaugklienti."
 
-#: src/ExternalConn.cpp:631
+#: src/ExternalConn.cpp:630
 msgid "You cannot connect to a release version from an arbitrary development snapshot! *sigh* possible crash prevented"
 msgstr "Ajutise arendusversiooniga ei saa ühenduda reliisi versiooniga!!!! *RRRRRR* hoidsin ära võimaliku crässi"
 
-#: src/ExternalConn.cpp:714
+#: src/ExternalConn.cpp:713
 msgid "Invalid protocol version."
 msgstr "Vigane protokolli versioon."
 
-#: src/ExternalConn.cpp:720
+#: src/ExternalConn.cpp:719
 msgid "Missing protocol version tag."
 msgstr "Puudub protokolli versiooni märgis"
 
-#: src/ExternalConn.cpp:728
+#: src/ExternalConn.cpp:727
 msgid "Authentication failed: invalid hash specified as EC password."
 msgstr "Autoriseerimine ebaõnnestus: EC parooliks on määratud vigane räsi."
 
-#: src/ExternalConn.cpp:776
+#: src/ExternalConn.cpp:775
 msgid "Authentication failed: wrong password."
 msgstr "Autoriserimine ebaõnnestus: vale parool."
 
-#: src/ExternalConn.cpp:778
+#: src/ExternalConn.cpp:777
 msgid "Authentication failed: missing password."
 msgstr "Autoriserimine ebaõnnestus: parool puudub."
 
-#: src/ExternalConn.cpp:789
+#: src/ExternalConn.cpp:788
 msgid "Invalid request, please authenticate first."
 msgstr "Vigane päring, alustuseks pead ennast autoriseerima."
 
-#: src/ExternalConn.cpp:794
+#: src/ExternalConn.cpp:793
 msgid "Access granted."
 msgstr "Ligipääs Lubatud."
 
-#: src/ExternalConn.cpp:802
+#: src/ExternalConn.cpp:801
 #, c-format
 msgid "Sent error message \"%s\" to client."
 msgstr "Veateade \"%s\" kliendile saadetud."
 
-#: src/ExternalConn.cpp:807
+#: src/ExternalConn.cpp:806
 #, c-format
 msgid "Unauthorized access attempt from %s. Connection closed."
 msgstr "Autoriseerimata pääsukatse %s. Ühendus suletud."
 
-#: src/ExternalConn.cpp:1420
+#: src/ExternalConn.cpp:1419
 #, c-format
 msgid "Remote PartFile command failed: FileHash not found: %s"
 msgstr "Kaug OsaFaili käsk ebaõnnestus: Faili kontrollsummat ei leidnud: %s"
 
-#: src/ExternalConn.cpp:1424
+#: src/ExternalConn.cpp:1423
 #, c-format
 msgid "FileHash not found: %s"
 msgstr "Faili '%s' kontrollsummat ei leitud"
 
-#: src/ExternalConn.cpp:1471 src/ExternalConn.cpp:1559
-#: src/ExternalConn.cpp:1680
+#: src/ExternalConn.cpp:1470 src/ExternalConn.cpp:1558
+#: src/ExternalConn.cpp:1679
 msgid "OOPS! OpCode processing error!"
 msgstr "OOPS! OpCode töötlemise viga!"
 
-#: src/ExternalConn.cpp:1502
+#: src/ExternalConn.cpp:1501
 msgid "Server not added"
 msgstr "Serverit ei lisatud"
 
-#: src/ExternalConn.cpp:1521
+#: src/ExternalConn.cpp:1520
 #, c-format
 msgid "server not found: %s"
 msgstr "serverit ei leidnud: %s"
 
-#: src/ExternalConn.cpp:1538
+#: src/ExternalConn.cpp:1537
 msgid "need to define server to be removed"
 msgstr "eemaldatav server on vaja määrata"
 
-#: src/ExternalConn.cpp:1553
+#: src/ExternalConn.cpp:1552
 msgid "eD2k is disabled in preferences."
 msgstr "eD2k on seadetes väljalülitatud."
 
-#: src/ExternalConn.cpp:1658
+#: src/ExternalConn.cpp:1657
 #, fuzzy
 msgid "Friend not found."
 msgstr "Faili ei leitud."
 
-#: src/ExternalConn.cpp:1668
+#: src/ExternalConn.cpp:1667
 #, fuzzy
 msgid "Client not found."
 msgstr "Faili ei leitud."
 
-#: src/ExternalConn.cpp:1674
+#: src/ExternalConn.cpp:1673
 msgid "EC_TAG_FRIEND_SHARED requires EC_TAG_FRIEND or EC_TAG_CLIENT."
 msgstr ""
 
-#: src/ExternalConn.cpp:1992
+#: src/ExternalConn.cpp:1991
 msgid "WebSearch from remote interface makes no sense."
 msgstr "Web Otsing kaugtöökohast ei oma mõtet."
 
-#: src/ExternalConn.cpp:2027
+#: src/ExternalConn.cpp:2026
 msgid "Search in progress. Refetch results in a moment!"
 msgstr "Otsing on käimas. Varsti näed tulemusi!"
 
-#: src/ExternalConn.cpp:2266
+#: src/ExternalConn.cpp:2265
 msgid "No points for graph."
 msgstr "Graafiku jaoks pole punkte."
 
-#: src/ExternalConn.cpp:2276
+#: src/ExternalConn.cpp:2275
 msgid "Your client is not configured for this detail level."
 msgstr "Sinu klient pole seadistatud sellise detailsuse astme jaoks."
 
-#: src/ExternalConn.cpp:2303
+#: src/ExternalConn.cpp:2302
 msgid "External Connection: shutdown requested"
 msgstr "Väline Ühendus: nõutakse seiskamist"
 
-#: src/ExternalConn.cpp:2315
+#: src/ExternalConn.cpp:2314
 msgid "Already shutting down."
 msgstr "Juba sulgun..."
 
-#: src/ExternalConn.cpp:2333
+#: src/ExternalConn.cpp:2332
 #, c-format
 msgid "ExternalConn: adding link '%s'."
 msgstr "Väline ühendus: lisan lingi '%s'."
 
-#: src/ExternalConn.cpp:2351
+#: src/ExternalConn.cpp:2350
 #, fuzzy, c-format
 msgid "%d of %d links failed (invalid or already on list)."
 msgstr "Vigane link või on juba loetelus."
 
-#: src/ExternalConn.cpp:2374
+#: src/ExternalConn.cpp:2373
 msgid "Version check throttled; try again shortly."
 msgstr ""
 
-#: src/ExternalConn.cpp:2379
+#: src/ExternalConn.cpp:2378
 msgid "Version check is not available on this daemon."
 msgstr ""
 
-#: src/ExternalConn.cpp:2509
+#: src/ExternalConn.cpp:2508
 msgid "File not found."
 msgstr "Faili ei leitud."
 
-#: src/ExternalConn.cpp:2514
+#: src/ExternalConn.cpp:2513
 msgid "Invalid file name."
 msgstr "Vigane failinimi."
 
-#: src/ExternalConn.cpp:2522
+#: src/ExternalConn.cpp:2521
 msgid "Unable to rename file."
 msgstr "Ei suuda faili ringinimetada."
 
-#: src/ExternalConn.cpp:2839
-#, c-format
-msgid "Could not save the amuleapi password: %s"
-msgstr ""
-
-#: src/ExternalConn.cpp:3004 src/ExternalConn.cpp:3032
+#: src/ExternalConn.cpp:2992 src/ExternalConn.cpp:3020
 msgid "Kad is disabled in preferences."
 msgstr "Kad on seadetes väljalülitatud."
 
-#: src/ExternalConn.cpp:3045
+#: src/ExternalConn.cpp:3033
 msgid "Already connected to eD2k."
 msgstr "Juba ühendatud eD2k võrku."
 
-#: src/ExternalConn.cpp:3048
+#: src/ExternalConn.cpp:3036
 msgid "Connecting to eD2k..."
 msgstr "Ühendun eD2k..."
 
-#: src/ExternalConn.cpp:3057
+#: src/ExternalConn.cpp:3045
 msgid "Already connected to Kad."
 msgstr "Juba ühendatud Kad võrku."
 
-#: src/ExternalConn.cpp:3060
+#: src/ExternalConn.cpp:3048
 msgid "Connecting to Kad..."
 msgstr "Ühendun Kad..."
 
-#: src/ExternalConn.cpp:3067
+#: src/ExternalConn.cpp:3055
 msgid "All networks are disabled."
 msgstr "Kõik võrgud on väljalülitatud."
 
-#: src/ExternalConn.cpp:3076
+#: src/ExternalConn.cpp:3064
 msgid "Disconnected from eD2k."
 msgstr "eD2k ühendus katkestatud."
 
-#: src/ExternalConn.cpp:3081
+#: src/ExternalConn.cpp:3069
 msgid "Disconnected from Kad."
 msgstr "Kad ühendus katkestatud."
 
-#: src/ExternalConn.cpp:3090
+#: src/ExternalConn.cpp:3078
 #, c-format
 msgid "External Connection: invalid opcode received: %#x"
 msgstr "Väline Ühendus: sain vigase opkoodi: %#x"
 
-#: src/ExternalConn.cpp:3095
+#: src/ExternalConn.cpp:3083
 msgid "Invalid opcode (wrong protocol version?)"
 msgstr "Vigane opcode (vale protokolli versioon?)"
 
@@ -2344,19 +2334,19 @@ msgstr ""
 msgid "eD2k"
 msgstr "eD2k"
 
-#: src/FirstRunWizard.cpp:349 src/muuli_wdr.cpp:1495
+#: src/FirstRunWizard.cpp:349 src/muuli_wdr.cpp:1488
 msgid "Kademlia"
 msgstr "Kademlia"
 
-#: src/FirstRunWizard.cpp:359 src/muuli_wdr.cpp:1423
+#: src/FirstRunWizard.cpp:359 src/muuli_wdr.cpp:1416
 msgid "Standard TCP Port "
 msgstr "Vaikimisi TCP Port "
 
-#: src/FirstRunWizard.cpp:365 src/muuli_wdr.cpp:1435
+#: src/FirstRunWizard.cpp:365 src/muuli_wdr.cpp:1428
 msgid "Extended UDP port (Kad / global search) "
 msgstr "Laiendatud UDP port (Kad / globaalne otsing) "
 
-#: src/FirstRunWizard.cpp:377 src/muuli_wdr.cpp:1442
+#: src/FirstRunWizard.cpp:377 src/muuli_wdr.cpp:1435
 msgid "Enable UPnP for router port forwarding"
 msgstr "Luba UPnP ruuteri portide suunamiseks"
 
@@ -2383,7 +2373,7 @@ msgstr ""
 msgid "Your peer lists are already in place - nothing to download."
 msgstr "Sa juba proovid '%s' faili tõmmata"
 
-#: src/FirstRunWizard.cpp:434 src/muuli_wdr.cpp:1540
+#: src/FirstRunWizard.cpp:434 src/muuli_wdr.cpp:1533
 msgid "Auto-update server list at startup"
 msgstr "Käivitamisel värskenda automaatselt serverite nimekirja"
 
@@ -2429,23 +2419,23 @@ msgid ""
 "want downloads on a different (e.g. larger) disk."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:549 src/FirstRunWizard.cpp:611 src/muuli_wdr.cpp:1702
+#: src/FirstRunWizard.cpp:549 src/FirstRunWizard.cpp:611 src/muuli_wdr.cpp:1701
 msgid "Destination folder for downloads"
 msgstr "Tõmmatavate failide kataloog"
 
-#: src/FirstRunWizard.cpp:553 src/FirstRunWizard.cpp:569 src/muuli_wdr.cpp:1349
-#: src/muuli_wdr.cpp:1366 src/muuli_wdr.cpp:1677 src/muuli_wdr.cpp:1708
-#: src/muuli_wdr.cpp:1720 src/muuli_wdr.cpp:2790
+#: src/FirstRunWizard.cpp:553 src/FirstRunWizard.cpp:569 src/muuli_wdr.cpp:1342
+#: src/muuli_wdr.cpp:1359 src/muuli_wdr.cpp:1676 src/muuli_wdr.cpp:1707
+#: src/muuli_wdr.cpp:1719 src/muuli_wdr.cpp:2762
 #: src/utils/aLinkCreator/src/alcframe.cpp:135
 #: src/utils/wxCas/src/wxcasprefs.cpp:52 src/utils/wxCas/src/wxcasprefs.cpp:118
 msgid "Browse"
 msgstr "Lehitse"
 
-#: src/FirstRunWizard.cpp:559 src/muuli_wdr.cpp:1713
+#: src/FirstRunWizard.cpp:559 src/muuli_wdr.cpp:1712
 msgid "(All files in this folder are shared with other peers)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:565 src/FirstRunWizard.cpp:624 src/muuli_wdr.cpp:1715
+#: src/FirstRunWizard.cpp:565 src/FirstRunWizard.cpp:624 src/muuli_wdr.cpp:1714
 msgid "Folder for temporary download files"
 msgstr "Ajutiste tõmmatavate failide kataloog"
 
@@ -2476,7 +2466,7 @@ msgstr "Sõprade faili 'emfriends.met' avamine kirjutamiseks ebaõnnestus!"
 msgid "CRITICAL - no client on StartChatSession"
 msgstr "KRIITILINE - StartChatSession puudub klient"
 
-#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2696 src/muuli_wdr.cpp:3373
+#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2668 src/muuli_wdr.cpp:3345
 msgid "Friends"
 msgstr "Sõbrad"
 
@@ -2587,8 +2577,8 @@ msgstr "Mitte keegi"
 msgid "No"
 msgstr "Ei"
 
-#: src/GenericClientListCtrl.cpp:1216 src/PrefsUnifiedDlg.cpp:2898
-#: src/PrefsUnifiedDlg.cpp:2948 src/ServerListCtrl.cpp:276
+#: src/GenericClientListCtrl.cpp:1216 src/PrefsUnifiedDlg.cpp:2818
+#: src/PrefsUnifiedDlg.cpp:2868 src/ServerListCtrl.cpp:276
 msgid "Yes"
 msgstr "Jah"
 
@@ -2757,10 +2747,10 @@ msgstr "Bootstrapil vigane port"
 msgid "Please fill all fields required"
 msgstr "Palun täida kõik nõutud väljad"
 
-#: src/KadDlg.cpp:192 src/PartFile.cpp:1031 src/PrefsUnifiedDlg.cpp:1134
-#: src/PrefsUnifiedDlg.cpp:1204 src/PrefsUnifiedDlg.cpp:1405
-#: src/PrefsUnifiedDlg.cpp:1663 src/PrefsUnifiedDlg.cpp:1673
-#: src/PrefsUnifiedDlg.cpp:1690 src/PrefsUnifiedDlg.cpp:1738
+#: src/KadDlg.cpp:192 src/PartFile.cpp:1031 src/PrefsUnifiedDlg.cpp:1162
+#: src/PrefsUnifiedDlg.cpp:1331 src/PrefsUnifiedDlg.cpp:1589
+#: src/PrefsUnifiedDlg.cpp:1599 src/PrefsUnifiedDlg.cpp:1616
+#: src/PrefsUnifiedDlg.cpp:1658
 msgid "Message"
 msgstr "Teade"
 
@@ -2862,7 +2852,7 @@ msgstr "Üles- ja allalaadimise suhe"
 msgid "Uploaded"
 msgstr "Üleslaaditud"
 
-#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3253
+#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3225
 msgid "Requested"
 msgstr "Küsitud"
 
@@ -2986,7 +2976,7 @@ msgid "WARNING: "
 msgstr "HOIATUS: "
 
 #: src/MuleNotebook.cpp:179 src/muuli_wdr.cpp:817 src/muuli_wdr.cpp:1229
-#: src/muuli_wdr.cpp:3157 src/muuli_wdr.cpp:3413
+#: src/muuli_wdr.cpp:3129 src/muuli_wdr.cpp:3385
 msgid "Close"
 msgstr "Sulge"
 
@@ -2999,12 +2989,12 @@ msgstr "Lõika"
 msgid "Copy"
 msgstr "Kopeeri"
 
-#: src/MuleTextCtrl.cpp:88 src/SearchDlg.cpp:261
+#: src/MuleTextCtrl.cpp:88
 msgid "Paste"
 msgstr "Aseta"
 
 #: src/MuleTextCtrl.cpp:89 src/muuli_wdr.cpp:358 src/muuli_wdr.cpp:757
-#: src/muuli_wdr.cpp:2380 src/muuli_wdr.cpp:2399 src/muuli_wdr.cpp:2421
+#: src/muuli_wdr.cpp:2352 src/muuli_wdr.cpp:2371 src/muuli_wdr.cpp:2393
 #: src/utils/aLinkCreator/src/alcframe.cpp:142
 msgid "Clear"
 msgstr "Puhasta"
@@ -3102,8 +3092,8 @@ msgid "Exit"
 msgstr "Välju"
 
 #: src/MuleTrayIcon.cpp:579 src/MuleTrayIcon.cpp:945 src/MuleTrayIcon.cpp:965
-#: src/muuli_wdr.cpp:1398 src/muuli_wdr.cpp:1406 src/muuli_wdr.cpp:1413
-#: src/muuli_wdr.cpp:1836 src/muuli_wdr.cpp:1842 src/OtherFunctions.cpp:91
+#: src/muuli_wdr.cpp:1391 src/muuli_wdr.cpp:1399 src/muuli_wdr.cpp:1406
+#: src/muuli_wdr.cpp:1835 src/muuli_wdr.cpp:1841 src/OtherFunctions.cpp:91
 #: src/StatisticsDlg.cpp:93 src/StatisticsDlg.cpp:95
 msgid "kB/s"
 msgstr "kB/s"
@@ -3274,7 +3264,7 @@ msgstr "Nimi:"
 msgid "Type"
 msgstr "Tüüp"
 
-#: src/muuli_wdr.cpp:215 src/SearchDlg.cpp:118 src/SearchListCtrl.cpp:853
+#: src/muuli_wdr.cpp:215 src/SearchDlg.cpp:110 src/SearchListCtrl.cpp:853
 msgid "Local"
 msgstr "Kohalik"
 
@@ -3345,7 +3335,7 @@ msgstr "Baiti"
 msgid "KB"
 msgstr "KB"
 
-#: src/muuli_wdr.cpp:274 src/muuli_wdr.cpp:293 src/muuli_wdr.cpp:1621
+#: src/muuli_wdr.cpp:274 src/muuli_wdr.cpp:293 src/muuli_wdr.cpp:1620
 #: src/OtherFunctions.cpp:64
 msgid "MB"
 msgstr "MB"
@@ -3362,7 +3352,7 @@ msgstr "Suurim Suurus"
 msgid "Availability"
 msgstr "Saadavus"
 
-#: src/muuli_wdr.cpp:312 src/muuli_wdr.cpp:398 src/muuli_wdr.cpp:3318
+#: src/muuli_wdr.cpp:312 src/muuli_wdr.cpp:398 src/muuli_wdr.cpp:3290
 msgid "Filter:"
 msgstr "Filter:"
 
@@ -3394,7 +3384,7 @@ msgstr ""
 msgid "Stop"
 msgstr "Seiska"
 
-#: src/muuli_wdr.cpp:348 src/muuli_wdr.cpp:1392 src/SearchListCtrl.cpp:732
+#: src/muuli_wdr.cpp:348 src/muuli_wdr.cpp:1385 src/SearchListCtrl.cpp:732
 msgid "Download"
 msgstr "Tõmbamine"
 
@@ -3425,12 +3415,12 @@ msgstr "Faili allikad:"
 #: src/muuli_wdr.cpp:1160 src/muuli_wdr.cpp:1167 src/muuli_wdr.cpp:1172
 #: src/muuli_wdr.cpp:1179 src/muuli_wdr.cpp:1184 src/muuli_wdr.cpp:1191
 #: src/muuli_wdr.cpp:1205 src/muuli_wdr.cpp:1212 src/muuli_wdr.cpp:1217
-#: src/muuli_wdr.cpp:1224 src/muuli_wdr.cpp:3255 src/muuli_wdr.cpp:3263
-#: src/muuli_wdr.cpp:3271
+#: src/muuli_wdr.cpp:1224 src/muuli_wdr.cpp:3227 src/muuli_wdr.cpp:3235
+#: src/muuli_wdr.cpp:3243
 msgid "N/A"
 msgstr "N/A"
 
-#: src/muuli_wdr.cpp:508 src/muuli_wdr.cpp:1065 src/PrefsUnifiedDlg.cpp:299
+#: src/muuli_wdr.cpp:508 src/muuli_wdr.cpp:1065 src/PrefsUnifiedDlg.cpp:297
 msgid "General"
 msgstr "Üldine"
 
@@ -3571,7 +3561,7 @@ msgstr ""
 msgid "Album :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:685 src/muuli_wdr.cpp:2275
+#: src/muuli_wdr.cpp:685 src/muuli_wdr.cpp:2247
 msgid "Title :"
 msgstr "Tiitel :"
 
@@ -3680,7 +3670,7 @@ msgstr "Kasutajanimi :"
 msgid "Userhash :"
 msgstr "Kasutaja kontrollsumma :"
 
-#: src/muuli_wdr.cpp:895 src/muuli_wdr.cpp:1742 src/muuli_wdr.cpp:2470
+#: src/muuli_wdr.cpp:895 src/muuli_wdr.cpp:1741 src/muuli_wdr.cpp:2442
 #: src/utils/aLinkCreator/src/alcframe.cpp:137
 msgid "Add"
 msgstr "Lisa"
@@ -3689,15 +3679,15 @@ msgstr "Lisa"
 msgid "Download-Speed"
 msgstr "Tõmbamise kiirus"
 
-#: src/muuli_wdr.cpp:954 src/muuli_wdr.cpp:989 src/muuli_wdr.cpp:2574
+#: src/muuli_wdr.cpp:954 src/muuli_wdr.cpp:989 src/muuli_wdr.cpp:2546
 msgid "Current"
 msgstr "Hetkel"
 
-#: src/muuli_wdr.cpp:962 src/muuli_wdr.cpp:997 src/muuli_wdr.cpp:2582
+#: src/muuli_wdr.cpp:962 src/muuli_wdr.cpp:997 src/muuli_wdr.cpp:2554
 msgid "Running average"
 msgstr "Hetke keskmine"
 
-#: src/muuli_wdr.cpp:970 src/muuli_wdr.cpp:1005 src/muuli_wdr.cpp:2590
+#: src/muuli_wdr.cpp:970 src/muuli_wdr.cpp:1005 src/muuli_wdr.cpp:2562
 msgid "Session average"
 msgstr "Seansi keskmine"
 
@@ -3709,7 +3699,7 @@ msgstr "Saatmise kiirus"
 msgid "Connections"
 msgstr "Ühendused"
 
-#: src/muuli_wdr.cpp:1024 src/muuli_wdr.cpp:1861
+#: src/muuli_wdr.cpp:1024 src/muuli_wdr.cpp:1860
 msgid "Active downloads"
 msgstr "Aktiivsed tõmbamised"
 
@@ -3717,7 +3707,7 @@ msgstr "Aktiivsed tõmbamised"
 msgid "Active connections (1:1)"
 msgstr "Aktiivseid ühendusi (1:1)"
 
-#: src/muuli_wdr.cpp:1040 src/muuli_wdr.cpp:1862
+#: src/muuli_wdr.cpp:1040 src/muuli_wdr.cpp:1861
 msgid "Active uploads"
 msgstr "Aktiivsed saatmised"
 
@@ -3833,8 +3823,8 @@ msgstr "See on see nimi mida teised näevad kui sinuga ühenduvad."
 msgid "Language: "
 msgstr "Keel: "
 
-#: src/muuli_wdr.cpp:1257 src/muuli_wdr.cpp:1330 src/muuli_wdr.cpp:1334
-#: src/muuli_wdr.cpp:1337
+#: src/muuli_wdr.cpp:1257 src/muuli_wdr.cpp:1323 src/muuli_wdr.cpp:1327
+#: src/muuli_wdr.cpp:1330
 msgid "The delay before showing tool-tips."
 msgstr "Abitekstide kuvamise ajaline viide."
 
@@ -3912,961 +3902,937 @@ msgstr ""
 msgid "Enabling this will make aMule to show notifications when finished downloading."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1323
-#, fuzzy
-msgid "Remember search history"
-msgstr "Pea need seaded meeles"
-
-#: src/muuli_wdr.cpp:1324
-msgid "Keeps a dropdown list of your past search terms in the Search tab's Name field. This remembers the queries you typed, not the results they returned."
-msgstr ""
-
-#: src/muuli_wdr.cpp:1329
+#: src/muuli_wdr.cpp:1322
 msgid "Tooltip delay time: "
 msgstr "Abitekstide viide sekundites: "
 
-#: src/muuli_wdr.cpp:1336
+#: src/muuli_wdr.cpp:1329
 msgid "seconds"
 msgstr "sekundit"
 
-#: src/muuli_wdr.cpp:1340
+#: src/muuli_wdr.cpp:1333
 msgid "Browser Selection"
 msgstr "Lehitseja valik"
 
-#: src/muuli_wdr.cpp:1346
+#: src/muuli_wdr.cpp:1339
 msgid "Enter your browser name here. Leave this field empty to use the system default browser."
 msgstr "Sisesta siia lehitsejaprogrammi nimi. Jättes välja tühjaks, kasutab süsteem vaikimisi määratud lehitsejat."
 
-#: src/muuli_wdr.cpp:1353
+#: src/muuli_wdr.cpp:1346
 msgid "Open in new tab if possible"
 msgstr "Võimalusel ava uus sakk"
 
-#: src/muuli_wdr.cpp:1355
+#: src/muuli_wdr.cpp:1348
 msgid "Open the web page in a new tab instead of in a new window when possible"
 msgstr "Ava, kui võimalik, webileht uuel lehel selle asemel et avada uus aken"
 
-#: src/muuli_wdr.cpp:1359
+#: src/muuli_wdr.cpp:1352
 msgid "Video Player"
 msgstr "Video mängija"
 
-#: src/muuli_wdr.cpp:1386
+#: src/muuli_wdr.cpp:1379
 msgid "Bandwidth limits"
 msgstr "Ribalaiuse piirid"
 
-#: src/muuli_wdr.cpp:1400
+#: src/muuli_wdr.cpp:1393
 msgid "Upload"
 msgstr "Saatmine"
 
-#: src/muuli_wdr.cpp:1408
+#: src/muuli_wdr.cpp:1401
 msgid "Slot Allocation"
 msgstr "Määratud pesa"
 
-#: src/muuli_wdr.cpp:1417
+#: src/muuli_wdr.cpp:1410
 msgid "Ports"
 msgstr "Pordid"
 
-#: src/muuli_wdr.cpp:1427
+#: src/muuli_wdr.cpp:1420
 msgid "This is the standard eD2k port and cannot be disabled."
 msgstr "See on eD2k standard port ja seda ei saa välja lülitada."
 
-#: src/muuli_wdr.cpp:1430
+#: src/muuli_wdr.cpp:1423
 msgid "UDP port for server requests (TCP+3):"
 msgstr "UDP port serveri päringute jaoks (TCP+3):"
 
-#: src/muuli_wdr.cpp:1432
+#: src/muuli_wdr.cpp:1425
 msgid "4665"
 msgstr "4665"
 
-#: src/muuli_wdr.cpp:1439
+#: src/muuli_wdr.cpp:1432
 msgid "This UDP port is used for extended eD2k requests and Kad network"
 msgstr "Seda UDP porti kasutatkse laiendatud omadustega eD2k ja Kad võrgu puhul"
 
-#: src/muuli_wdr.cpp:1446
+#: src/muuli_wdr.cpp:1439
 msgid "UPnP TCP Port (Optional):"
 msgstr "UPnp TCP Port (Lisana):"
 
-#: src/muuli_wdr.cpp:1456
+#: src/muuli_wdr.cpp:1449
 msgid "Bind local address to IP (empty for any):"
 msgstr "Seo lokaalne aadress IP'ga (suvaliseks jäta tühjaks)"
 
-#: src/muuli_wdr.cpp:1459
+#: src/muuli_wdr.cpp:1452
 msgid "Advanced users only: If you have multiple network interfaces, enter the address of the interface to which aMule should be bound."
 msgstr "Ainult edasijõudnud kasutajatele: Kui sul on kasutada mitu võrguliidest, siis sisesta selle liidese aadress millega aMule võib ennast siduda."
 
-#: src/muuli_wdr.cpp:1462 src/muuli_wdr.cpp:2055
+#: src/muuli_wdr.cpp:1455 src/muuli_wdr.cpp:2054
 #, fuzzy
 msgid "Bind to network interface (empty for any):"
 msgstr "Seo lokaalne aadress IP'ga (suvaliseks jäta tühjaks)"
 
-#: src/muuli_wdr.cpp:1475
+#: src/muuli_wdr.cpp:1468
 msgid "Advanced users only: pin all of aMule's traffic to one network interface, chosen from the list or typed in by name (e.g. tun0, eth0, en0) or index. Unlike binding to an IP, this stops traffic leaking out via the default route - useful with a VPN. Requires no elevated privileges."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1481
+#: src/muuli_wdr.cpp:1474
 msgid "Max sources per downloading file:"
 msgstr "Maksimaalseid allikaid tõmmatava faili kohta:"
 
-#: src/muuli_wdr.cpp:1485
+#: src/muuli_wdr.cpp:1478
 msgid "Max simultaneous connections:"
 msgstr "Maksimaalselt samaaegseid ühendusi:"
 
-#: src/muuli_wdr.cpp:1498 src/muuli_wdr.cpp:3197
+#: src/muuli_wdr.cpp:1491 src/muuli_wdr.cpp:3169
 msgid "ED2K"
 msgstr "ED2K"
 
-#: src/muuli_wdr.cpp:1505
+#: src/muuli_wdr.cpp:1498
 msgid "Autoconnect on startup"
 msgstr "Automaatne ühendumine käivitumisel"
 
-#: src/muuli_wdr.cpp:1508
+#: src/muuli_wdr.cpp:1501
 msgid "Reconnect on loss"
 msgstr "Ühenduse kadumisel taasta ühendus"
 
-#: src/muuli_wdr.cpp:1530
+#: src/muuli_wdr.cpp:1523
 msgid "Remove dead server after"
 msgstr "Eemalda surnud server peale"
 
-#: src/muuli_wdr.cpp:1531
+#: src/muuli_wdr.cpp:1524
 msgid "Static servers are never removed, even when unreachable."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1535
+#: src/muuli_wdr.cpp:1528
 msgid "retries"
 msgstr "katset"
 
-#: src/muuli_wdr.cpp:1543
+#: src/muuli_wdr.cpp:1536
 msgid "List"
 msgstr "Loend"
 
-#: src/muuli_wdr.cpp:1546
+#: src/muuli_wdr.cpp:1539
 msgid "Update server list when connecting to a server"
 msgstr "Värskenda serverite nimekirja serveriga ühendumisel"
 
-#: src/muuli_wdr.cpp:1549
+#: src/muuli_wdr.cpp:1542
 msgid "Update server list when a client connects"
 msgstr "Värskenda serverite nimekirja kliendi ühendumisel"
 
-#: src/muuli_wdr.cpp:1552
+#: src/muuli_wdr.cpp:1545
 msgid "Use priority system"
 msgstr "Kasuta prioriteedisüsteemi"
 
-#: src/muuli_wdr.cpp:1556
+#: src/muuli_wdr.cpp:1549
 msgid "Use smart LowID check on connect"
 msgstr "Ühendumisel kasuta nutikat LowID kontrolli "
 
-#: src/muuli_wdr.cpp:1560
+#: src/muuli_wdr.cpp:1553
 msgid "Safe connect"
 msgstr "Ohutu ühendumine"
 
-#: src/muuli_wdr.cpp:1564
+#: src/muuli_wdr.cpp:1557
 msgid "Autoconnect to servers in static list only"
 msgstr "Automaatne ühendumine ainult staatilises serverinimekirjas olevate serveritega"
 
-#: src/muuli_wdr.cpp:1567
+#: src/muuli_wdr.cpp:1560
 msgid "Set manually added servers to High Priority"
 msgstr "Määra käsitsi lisatud serveritel Kõrge Prioriteet"
 
-#: src/muuli_wdr.cpp:1588
+#: src/muuli_wdr.cpp:1581
 msgid "Add files to download in pause mode"
 msgstr "Lisa failid tõmbamiseks peatatud olekus"
 
-#: src/muuli_wdr.cpp:1590
+#: src/muuli_wdr.cpp:1583
 msgid "Add files to download with auto priority"
 msgstr "Lisa failid tõmbamiseks automaatse prioriteediga"
 
-#: src/muuli_wdr.cpp:1593
+#: src/muuli_wdr.cpp:1586
 msgid "Try to download first and last chunks first"
 msgstr "Proovi alustuseks tõmmata esimene ja viimane tükk"
 
-#: src/muuli_wdr.cpp:1597
+#: src/muuli_wdr.cpp:1590
 msgid "Endgame mode: rotate to faster sources for the final blocks"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1600
+#: src/muuli_wdr.cpp:1593
 msgid "Start next paused file when a file completes"
 msgstr "Alusta järgmise peatatud failiga, kui fail lõpetab"
 
-#: src/muuli_wdr.cpp:1603
+#: src/muuli_wdr.cpp:1596
 msgid "From the same category"
 msgstr "Samast kategooriast"
 
-#: src/muuli_wdr.cpp:1605
+#: src/muuli_wdr.cpp:1598
 msgid "In alphabetic order"
 msgstr "Tähestikulises järjekorras"
 
-#: src/muuli_wdr.cpp:1607
+#: src/muuli_wdr.cpp:1600
 msgid "Preallocate disk space for new files"
 msgstr "Eralda kettaruum uute failide jaoks"
 
-#: src/muuli_wdr.cpp:1608
+#: src/muuli_wdr.cpp:1601
 msgid "For new files preallocates disk space for the whole file, thus reduces fragmentation"
 msgstr "Eraldab uuet failide jaoks vajamineva kettaruumi, seeläbi väheneb faili fragmenteerumine"
 
-#: src/muuli_wdr.cpp:1613
+#: src/muuli_wdr.cpp:1606
+msgid "Create new files as sparse files"
+msgstr ""
+
+#: src/muuli_wdr.cpp:1607
+msgid "A sparse file reserves its full size on disk immediately without writing real data to it -- fast, but unsupported or slow on some filesystems, and free-space accounting stays optimistic while the download is in progress. Turn this off to grow the file only as data arrives."
+msgstr ""
+
+#: src/muuli_wdr.cpp:1612
 msgid "Stop downloads when free disk space reaches "
 msgstr "Lõpeta tõmbamine, kui vaba kettaruumi on jäänud "
 
-#: src/muuli_wdr.cpp:1614
+#: src/muuli_wdr.cpp:1613
 msgid "Select this if you want aMule to check your disk space"
 msgstr "Vali see kui soovid et aMule sinu kettaruumi kontrolliks"
 
-#: src/muuli_wdr.cpp:1618
+#: src/muuli_wdr.cpp:1617
 msgid "Enter here the min disk space desired."
 msgstr "Sisesta siia vähim soovitud kettaruum"
 
-#: src/muuli_wdr.cpp:1624
+#: src/muuli_wdr.cpp:1623
 msgid "Save 10 sources on rare files (< 20 sources)"
 msgstr "Salvesta haruldaste failide 10 allikat (< 20 allikat)"
 
-#: src/muuli_wdr.cpp:1628 src/Statistics.cpp:790
+#: src/muuli_wdr.cpp:1627 src/Statistics.cpp:790
 msgid "Uploads"
 msgstr "Saatmised"
 
-#: src/muuli_wdr.cpp:1631
+#: src/muuli_wdr.cpp:1630
 msgid "Add new shared files with auto priority"
 msgstr "Lisa uued jagatud failid automaatse prioriteediga"
 
-#: src/muuli_wdr.cpp:1637
+#: src/muuli_wdr.cpp:1636
 msgid "Intelligent Corruption Handling (I.C.H.)"
 msgstr "Intelligentne Riknemise Vältimine (I.C.H.)"
 
-#: src/muuli_wdr.cpp:1640
+#: src/muuli_wdr.cpp:1639
 msgid "Enable"
 msgstr "Luba"
 
-#: src/muuli_wdr.cpp:1643
+#: src/muuli_wdr.cpp:1642
 msgid "Advanced I.C.H. trusts every hash (not recommended)"
 msgstr "Laiendatud I.C.H. usaldab suvalist kontrollsummat (pole soovitatav valik)"
 
-#: src/muuli_wdr.cpp:1655 src/PrefsUnifiedDlg.cpp:1990
+#: src/muuli_wdr.cpp:1654 src/PrefsUnifiedDlg.cpp:1910
 msgid "Media metadata extraction"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1659
+#: src/muuli_wdr.cpp:1658
 msgid "Extract length / bitrate / codec from shared audio and video files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1661
+#: src/muuli_wdr.cpp:1660
 msgid "When enabled, aMule runs ffprobe on each shared media file to fill in the Length / Bitrate / Codec columns other clients see when they find the file in a search. Requires ffmpeg (the ffprobe binary) to be installed."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1668
+#: src/muuli_wdr.cpp:1667
 msgid "Path to ffprobe:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1673
+#: src/muuli_wdr.cpp:1672
 msgid "Full path to the ffprobe binary. Leave empty to have aMule auto-detect it on startup."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1681
+#: src/muuli_wdr.cpp:1680
 msgid "Detect"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1682
+#: src/muuli_wdr.cpp:1681
 msgid "Search the standard install locations for an ffprobe binary and fill the path field."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1706
+#: src/muuli_wdr.cpp:1705
 msgid ""
 "Completed downloads are stored here. All files in this folder are automatically shared with other peers.\n"
 "If this folder also holds files you don't want to share, point it at an aMule-only sub-folder."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1709
+#: src/muuli_wdr.cpp:1708
 msgid "Pick the folder where completed downloads will be stored. All files in that folder will be shared with other peers."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1723
+#: src/muuli_wdr.cpp:1722
 msgid "Shared folders"
 msgstr "Jagatud kataloogid"
 
-#: src/muuli_wdr.cpp:1729
+#: src/muuli_wdr.cpp:1728
 msgid "(Folders shared by the core. Enter a path to add one.)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1737
+#: src/muuli_wdr.cpp:1736
 msgid "Absolute path of a folder on the core's machine, e.g. /home/user/shared"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1739 src/PrefsUnifiedDlg.cpp:2874
+#: src/muuli_wdr.cpp:1738 src/PrefsUnifiedDlg.cpp:2794
 msgid "Recursive"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1740
+#: src/muuli_wdr.cpp:1739
 msgid "Share every sub-folder underneath this one, including ones created later."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1744 src/utils/aLinkCreator/src/alcframe.cpp:141
+#: src/muuli_wdr.cpp:1743 src/utils/aLinkCreator/src/alcframe.cpp:141
 msgid "Remove"
 msgstr "Eemalda"
 
-#: src/muuli_wdr.cpp:1748
+#: src/muuli_wdr.cpp:1747
 msgid "(Right click on folder icon for recursive share)"
 msgstr "(Rekursiivseks jagamiseks tee paremklikk kataloogi ikoonil)"
 
-#: src/muuli_wdr.cpp:1755
+#: src/muuli_wdr.cpp:1754
 msgid "Share hidden files"
 msgstr "Jaga peidetud failid"
 
-#: src/muuli_wdr.cpp:1761
+#: src/muuli_wdr.cpp:1760
 msgid "Automatically rescan shared folders for changes"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1767
+#: src/muuli_wdr.cpp:1766
 msgid "Follow symbolic links in shared folders"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1773
+#: src/muuli_wdr.cpp:1772
 msgid "Exclude files matching:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1776
+#: src/muuli_wdr.cpp:1775
 msgid "Wildcard patterns separated by '|', e.g. .DS_Store|Thumbs.db|*.tmp. Files whose name matches are not shared. Matching is case-insensitive."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1780
+#: src/muuli_wdr.cpp:1779
 msgid "Patterns are regular expressions"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1781
+#: src/muuli_wdr.cpp:1780
 msgid "When set, the whole field is one regular expression ('|' is alternation). When unset, it is a list of '|'-separated wildcards."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1791
+#: src/muuli_wdr.cpp:1790
 msgid "Show how many shared files the current pattern would exclude."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1812
+#: src/muuli_wdr.cpp:1811
 msgid "Graphs"
 msgstr "Graafikud"
 
-#: src/muuli_wdr.cpp:1815 src/muuli_wdr.cpp:1877
+#: src/muuli_wdr.cpp:1814 src/muuli_wdr.cpp:1876
 msgid "Update delay : 5 secs"
 msgstr "Värskenduste vahe : 5 sekundit"
 
-#: src/muuli_wdr.cpp:1819
+#: src/muuli_wdr.cpp:1818
 msgid "Time for average graph: 100 mins"
 msgstr "Keskmine graafiku aeg: 100 minutit"
 
-#: src/muuli_wdr.cpp:1823
+#: src/muuli_wdr.cpp:1822
 msgid "Connections Graph Scale: 100 "
 msgstr "Ühenduse graafiku skaala: 100"
 
-#: src/muuli_wdr.cpp:1830
+#: src/muuli_wdr.cpp:1829
 msgid "Download graph scale:"
 msgstr "Tõmbamise graafiku skaala:"
 
-#: src/muuli_wdr.cpp:1838
+#: src/muuli_wdr.cpp:1837
 msgid "Upload graph scale:"
 msgstr "Saatmise graafiku skaala:"
 
-#: src/muuli_wdr.cpp:1848
+#: src/muuli_wdr.cpp:1847
 #, fuzzy
 msgid "Colors: "
 msgstr "Värvid: "
 
-#: src/muuli_wdr.cpp:1852
+#: src/muuli_wdr.cpp:1851
 msgid "Background"
 msgstr "Taust"
 
-#: src/muuli_wdr.cpp:1853
+#: src/muuli_wdr.cpp:1852
 msgid "Grid"
 msgstr "Alusvõrk"
 
-#: src/muuli_wdr.cpp:1854
+#: src/muuli_wdr.cpp:1853
 msgid "Download current"
 msgstr "Allalaadimine, jooksev"
 
-#: src/muuli_wdr.cpp:1855
+#: src/muuli_wdr.cpp:1854
 msgid "Download running average"
 msgstr "Allalaadimine, jooksev keskmine"
 
-#: src/muuli_wdr.cpp:1856
+#: src/muuli_wdr.cpp:1855
 msgid "Download session average"
 msgstr "Allalaadimine, seansi keskmine"
 
-#: src/muuli_wdr.cpp:1857
+#: src/muuli_wdr.cpp:1856
 msgid "Upload current"
 msgstr "Saatmine hetkel"
 
-#: src/muuli_wdr.cpp:1858
+#: src/muuli_wdr.cpp:1857
 msgid "Upload running average"
 msgstr "Hetke saatmise keskmine"
 
-#: src/muuli_wdr.cpp:1859
+#: src/muuli_wdr.cpp:1858
 msgid "Upload session average"
 msgstr "Seansi keskmine saatmine"
 
-#: src/muuli_wdr.cpp:1860
+#: src/muuli_wdr.cpp:1859
 msgid "Active connections"
 msgstr "Aktiivseid ühendusi"
 
-#: src/muuli_wdr.cpp:1863
+#: src/muuli_wdr.cpp:1862
 #, fuzzy
 msgid "Systray Icon Speed Bar"
 msgstr "Süsteemiriba Kiirvaliku Ikoon"
 
-#: src/muuli_wdr.cpp:1864
+#: src/muuli_wdr.cpp:1863
 msgid "Kad-nodes current"
 msgstr "Kad-sõlmi hetkel"
 
-#: src/muuli_wdr.cpp:1865
+#: src/muuli_wdr.cpp:1864
 msgid "Kad-nodes running"
 msgstr "Kad-sõlmi jooksvalt"
 
-#: src/muuli_wdr.cpp:1866
+#: src/muuli_wdr.cpp:1865
 msgid "Kad-nodes session"
 msgstr "Kad-sõlmi seansis"
 
-#: src/muuli_wdr.cpp:1870 src/muuli_wdr.cpp:2324
+#: src/muuli_wdr.cpp:1869 src/muuli_wdr.cpp:2296
 msgid "Select"
 msgstr "Vali"
 
-#: src/muuli_wdr.cpp:1874
+#: src/muuli_wdr.cpp:1873
 msgid "Tree"
 msgstr "Puu"
 
-#: src/muuli_wdr.cpp:1884
+#: src/muuli_wdr.cpp:1883
 msgid "Number of Client Versions shown (0=unlimited)"
 msgstr "Kuvatavate Kliendi Versioonide arv (0=piiramatu)"
 
-#: src/muuli_wdr.cpp:1909
+#: src/muuli_wdr.cpp:1908
 msgid "!!! WARNING !!!"
 msgstr "!!! HOIATUS !!!"
 
-#: src/muuli_wdr.cpp:1924
+#: src/muuli_wdr.cpp:1923
 msgid "Max new connections / 5 secs"
 msgstr "Maksimaalne arv uusi ühendusi / 5 sek."
 
-#: src/muuli_wdr.cpp:1926
+#: src/muuli_wdr.cpp:1925
 msgid "Concurrent Kad source lookups"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1928
+#: src/muuli_wdr.cpp:1927
 #, fuzzy
 msgid "Kad source re-search interval (minutes)"
 msgstr "FTP värskendamise intervall minutites"
 
-#: src/muuli_wdr.cpp:1930
+#: src/muuli_wdr.cpp:1929
 #, fuzzy
 msgid "Source re-ask interval (minutes)"
 msgstr "FTP värskendamise intervall minutites"
 
-#: src/muuli_wdr.cpp:1934
+#: src/muuli_wdr.cpp:1933
 msgid "File Buffer Size: 240000 bytes"
 msgstr "Faili puhvri suurus: 240000 baiti"
 
-#: src/muuli_wdr.cpp:1938
+#: src/muuli_wdr.cpp:1937
 msgid "Use MMAP: memory-mapped file access (lower memory use)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1939
+#: src/muuli_wdr.cpp:1938
 msgid "Maps part files into memory instead of buffering them on the heap, lowering the process memory footprint. May reduce download speed on some disks; best for memory-constrained or upload-heavy hosts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1941
+#: src/muuli_wdr.cpp:1940
 msgid "Upload Queue Size: 5000 clients"
 msgstr "Saatmise saba suurus: 5000 klienti"
 
-#: src/muuli_wdr.cpp:1945
+#: src/muuli_wdr.cpp:1944
 msgid "Server connection refresh interval: Disable"
 msgstr "Serveriühenduse värskenadamise intervall: Ei kasuta"
 
-#: src/muuli_wdr.cpp:1949
+#: src/muuli_wdr.cpp:1948
 msgid "Disable computer's timed standby mode"
 msgstr "Keela arvuti ajastatud uinumine"
 
-#: src/muuli_wdr.cpp:1968
+#: src/muuli_wdr.cpp:1967
 msgid "Skin to use: "
 msgstr "Kasutatav rüü: "
 
-#: src/muuli_wdr.cpp:1977
+#: src/muuli_wdr.cpp:1976
 msgid "Show \"Fast eD2k Links Handler\" in every window."
 msgstr "Näita igas aknas \"Kiiret eD2k lingi käsitlejat\". "
 
-#: src/muuli_wdr.cpp:1980
+#: src/muuli_wdr.cpp:1979
 msgid "Show extended info on categories tabs"
 msgstr "Näita kategooria juures laiendatud infot"
 
-#: src/muuli_wdr.cpp:1983
+#: src/muuli_wdr.cpp:1982
 #, fuzzy
 msgid "Show application version on title"
 msgstr "Näita tiitelribal siirdamise kiirusi"
 
-#: src/muuli_wdr.cpp:1985
+#: src/muuli_wdr.cpp:1984
 msgid "Show transfer rates on title"
 msgstr "Näita tiitelribal siirdamise kiirusi"
 
-#: src/muuli_wdr.cpp:1987
+#: src/muuli_wdr.cpp:1986
 msgid "Before application name"
 msgstr "Eelmise rakenduse nimi"
 
-#: src/muuli_wdr.cpp:1989
+#: src/muuli_wdr.cpp:1988
 msgid "After application name"
 msgstr "Järgneva rakenduse nimi"
 
-#: src/muuli_wdr.cpp:1992
+#: src/muuli_wdr.cpp:1991
 msgid "Show overhead bandwidth"
 msgstr "Näita raisatud ribalaiust"
 
-#: src/muuli_wdr.cpp:1996
+#: src/muuli_wdr.cpp:1995
 msgid "Vertical toolbar orientation"
 msgstr "Vertikaalne tööriistariba paigutus"
 
-#: src/muuli_wdr.cpp:1998
+#: src/muuli_wdr.cpp:1997
 msgid "Live column sorting (auto-reorder rows as their values change)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2005
+#: src/muuli_wdr.cpp:2004
 msgid "Download Queue Files"
 msgstr "Tõmbamise Järjekorrafailid"
 
-#: src/muuli_wdr.cpp:2008
+#: src/muuli_wdr.cpp:2007
 msgid "Show progress percentage"
 msgstr "Näita edenemist protsentuaalselt"
 
-#: src/muuli_wdr.cpp:2014
+#: src/muuli_wdr.cpp:2013
 msgid "Show progress bar"
 msgstr "Näita edenemise riba"
 
-#: src/muuli_wdr.cpp:2017
+#: src/muuli_wdr.cpp:2016
 msgid "Flat"
 msgstr "Lame"
 
-#: src/muuli_wdr.cpp:2021
+#: src/muuli_wdr.cpp:2020
 msgid "Round"
 msgstr "Ümar"
 
-#: src/muuli_wdr.cpp:2039
+#: src/muuli_wdr.cpp:2038
 msgid "External Connection Parameters"
 msgstr "Välisühenduse parameetrid"
 
-#: src/muuli_wdr.cpp:2042
+#: src/muuli_wdr.cpp:2041
 msgid "Accept external connections"
 msgstr "Aksepteeri väliseid ühendusi"
 
-#: src/muuli_wdr.cpp:2049 src/muuli_wdr.cpp:2108
+#: src/muuli_wdr.cpp:2048 src/muuli_wdr.cpp:2107
 msgid "IP of the listening interface:"
 msgstr "Kuulava liidese IP aadress:"
 
-#: src/muuli_wdr.cpp:2052
+#: src/muuli_wdr.cpp:2051
 msgid "Enter here a valid ip in the a.b.c.d format for the listening EC interface. An empty field or 0.0.0.0 will mean any interface."
 msgstr "Sisesta siia välisühenduse liidese kehtiv ip aadress a.b.c.d formaadis. Tühi väli või 0.0.0.0 tähendab suvalist liidest."
 
-#: src/muuli_wdr.cpp:2073 src/muuli_wdr.cpp:2184
+#: src/muuli_wdr.cpp:2072 src/muuli_wdr.cpp:2156
 msgid "TCP port:"
 msgstr "TCP port:"
 
-#: src/muuli_wdr.cpp:2079
+#: src/muuli_wdr.cpp:2078
 msgid "Enable UPnP port forwarding on the EC port"
 msgstr "Luba UPnP pordisuunamist EC pordile"
 
-#: src/muuli_wdr.cpp:2083 src/muuli_wdr.cpp:3069
+#: src/muuli_wdr.cpp:2082 src/muuli_wdr.cpp:3041
 #: src/utils/wxCas/src/wxcasprefs.cpp:167
 msgid "Password"
 msgstr "Parool"
 
-#: src/muuli_wdr.cpp:2089
+#: src/muuli_wdr.cpp:2088
 #, fuzzy
 msgid "aMule API server parameters"
 msgstr "Web serveri seaded"
 
-#: src/muuli_wdr.cpp:2092
+#: src/muuli_wdr.cpp:2091
 msgid "Run amuleapi (REST API) on startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2097
+#: src/muuli_wdr.cpp:2096
 #, fuzzy
 msgid "HTTP port:"
 msgstr "TCP port:"
 
-#: src/muuli_wdr.cpp:2111
+#: src/muuli_wdr.cpp:2110
 msgid "The interface amuleapi's HTTP server listens on. 127.0.0.1 (default) accepts only local connections; use 0.0.0.0 or a specific IP to expose it to other hosts (set an admin password below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2116
-msgid "Type a password to set or change it. Stored passwords cannot be shown, so leaving this empty keeps the current one."
-msgstr ""
-
-#: src/muuli_wdr.cpp:2118
+#: src/muuli_wdr.cpp:2113
 #, fuzzy
 msgid "Admin password"
 msgstr "Kontrollin parooli\n"
 
-#: src/muuli_wdr.cpp:2130 src/muuli_wdr.cpp:2147 src/PrefsUnifiedDlg.cpp:1103
-#, fuzzy
-msgid "A password is set."
-msgstr "Kontrollin parooli\n"
+#: src/muuli_wdr.cpp:2118 src/muuli_wdr.cpp:2149
+msgid "Low rights password"
+msgstr "Madalate õiguste parool"
 
-#: src/muuli_wdr.cpp:2134
-#, fuzzy
-msgid "Enable guest access"
-msgstr "Keela külalise (guest) ligipääs"
-
-#: src/muuli_wdr.cpp:2135
-msgid "Guest sessions may read status and listings but cannot change anything. Turning this off clears the stored guest password."
-msgstr ""
-
-#: src/muuli_wdr.cpp:2139
-#, fuzzy
-msgid "Guest password"
-msgstr "Webserveri külalise (guest) parool"
-
-#: src/muuli_wdr.cpp:2154
+#: src/muuli_wdr.cpp:2126
 msgid "Web server parameters"
 msgstr "Web serveri seaded"
 
-#: src/muuli_wdr.cpp:2157
+#: src/muuli_wdr.cpp:2129
 #, fuzzy
 msgid "Run webserver on startup (deprecated)"
 msgstr "Käivita WEBserver koos aMulega"
 
-#: src/muuli_wdr.cpp:2163
+#: src/muuli_wdr.cpp:2135
 msgid "Web template"
 msgstr "WEB näidis/mall"
 
-#: src/muuli_wdr.cpp:2168
+#: src/muuli_wdr.cpp:2140
 msgid "Full rights password"
 msgstr "Täisõiguste parool"
 
-#: src/muuli_wdr.cpp:2172
+#: src/muuli_wdr.cpp:2144
 msgid "Enable Low rights User"
 msgstr "Luba madalate õigustega kasutaja"
 
-#: src/muuli_wdr.cpp:2177
-msgid "Low rights password"
-msgstr "Madalate õiguste parool"
-
-#: src/muuli_wdr.cpp:2191
+#: src/muuli_wdr.cpp:2163
 msgid "Enable UPnP port forwarding of the web server port"
 msgstr "Luba webservri portide UPnP pordisuunamist"
 
-#: src/muuli_wdr.cpp:2196
+#: src/muuli_wdr.cpp:2168
 msgid "Web server UPnP TCP port (Optional)"
 msgstr "Webserveri UPnP TCP port (Valikuline)"
 
-#: src/muuli_wdr.cpp:2204
+#: src/muuli_wdr.cpp:2176
 msgid "Page Refresh Time (in secs)"
 msgstr "Lehekülje värskendusaeg (sekundites)"
 
-#: src/muuli_wdr.cpp:2211
+#: src/muuli_wdr.cpp:2183
 msgid "Enable Gzip compression"
 msgstr "Luba Gzip pakkimine"
 
-#: src/muuli_wdr.cpp:2245
+#: src/muuli_wdr.cpp:2217
 #, fuzzy
 msgid "Reset page to defaults"
 msgstr "Süsteemi vaikeväärtus"
 
-#: src/muuli_wdr.cpp:2246
+#: src/muuli_wdr.cpp:2218
 msgid "Reset the settings on the current page to their default values."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2248 src/muuli_wdr.cpp:2334 src/ServerWnd.cpp:274
+#: src/muuli_wdr.cpp:2220 src/muuli_wdr.cpp:2306 src/ServerWnd.cpp:274
 #: src/ServerWnd.cpp:282
 msgid "OK"
 msgstr "Sobib"
 
-#: src/muuli_wdr.cpp:2250
+#: src/muuli_wdr.cpp:2222
 msgid "Click here to apply any changes made to the preferences."
 msgstr "Seadetes tehtud muudatuste jõustamiseks klikka siia."
 
-#: src/muuli_wdr.cpp:2253
+#: src/muuli_wdr.cpp:2225
 msgid "Reset any changes made to the preferences."
 msgstr "Tühista kõik seadetes tehtud muudatused."
 
-#: src/muuli_wdr.cpp:2282
+#: src/muuli_wdr.cpp:2254
 msgid "Comment :"
 msgstr "Kommentaar :"
 
-#: src/muuli_wdr.cpp:2289
+#: src/muuli_wdr.cpp:2261
 msgid "Incoming Dir :"
 msgstr "Tõmmatud failide kataloog :"
 
-#: src/muuli_wdr.cpp:2298
+#: src/muuli_wdr.cpp:2270
 msgid "Change priority for new assigned files :"
 msgstr "Muuda uute failide prioriteeti :"
 
-#: src/muuli_wdr.cpp:2302
+#: src/muuli_wdr.cpp:2274
 msgid "Don't change"
 msgstr "Ära muuda"
 
-#: src/muuli_wdr.cpp:2314
+#: src/muuli_wdr.cpp:2286
 msgid "Select color for this Category (currently selected) :"
 msgstr "Vali praegu valitud kategooriale värv :"
 
-#: src/muuli_wdr.cpp:2381 src/muuli_wdr.cpp:2400 src/muuli_wdr.cpp:2422
+#: src/muuli_wdr.cpp:2353 src/muuli_wdr.cpp:2372 src/muuli_wdr.cpp:2394
 msgid "Click this button to reset the log."
 msgstr "Klikates seda nuppu tühjendad logi."
 
-#: src/muuli_wdr.cpp:2441
+#: src/muuli_wdr.cpp:2413
 msgid "Click on this button to update the servers list from URL ..."
 msgstr "Sellele nupule klikates värskendad serverite loetelu URL ilt ..."
 
-#: src/muuli_wdr.cpp:2445
+#: src/muuli_wdr.cpp:2417
 msgid "Server list"
 msgstr "Serverite nimekiri"
 
-#: src/muuli_wdr.cpp:2449
+#: src/muuli_wdr.cpp:2421
 msgid "Enter the url to a server.met file here and press the button to the left to update the list of known servers."
 msgstr "Sisesta siia server.met faili asukoha URL ja pressi vasakul olevat nuppu tuntud serverite nimekirja värskendamiseks."
 
-#: src/muuli_wdr.cpp:2454
+#: src/muuli_wdr.cpp:2426
 msgid "Add server manually: Name"
 msgstr "Lisa server käsitsi: Nimi"
 
-#: src/muuli_wdr.cpp:2457
+#: src/muuli_wdr.cpp:2429
 msgid "Enter the name of the new server here"
 msgstr "Sisesta siia uue serveri nimi"
 
-#: src/muuli_wdr.cpp:2459 src/ServerWnd.cpp:206
+#: src/muuli_wdr.cpp:2431 src/ServerWnd.cpp:206
 msgid "IP:Port"
 msgstr "IP:Port"
 
-#: src/muuli_wdr.cpp:2462
+#: src/muuli_wdr.cpp:2434
 msgid "Enter the IP of the server here, using the x.x.x.x format."
 msgstr "Sisesta siia serveri IP aadrdess, kasutades x.x.x.x formaati."
 
-#: src/muuli_wdr.cpp:2468
+#: src/muuli_wdr.cpp:2440
 msgid "Enter the port of the server here."
 msgstr "Sisesta siia serveri port."
 
-#: src/muuli_wdr.cpp:2471
+#: src/muuli_wdr.cpp:2443
 msgid "Add manually a server (fill fields to the left before) ..."
 msgstr "Täites esiteks vasakul olevad väljad, lisa server käsitsi ..."
 
-#: src/muuli_wdr.cpp:2500
+#: src/muuli_wdr.cpp:2472
 msgid "aMule Log"
 msgstr "aMule Logi"
 
-#: src/muuli_wdr.cpp:2508
+#: src/muuli_wdr.cpp:2480
 msgid "Server Info"
 msgstr "Serveri info"
 
-#: src/muuli_wdr.cpp:2512
+#: src/muuli_wdr.cpp:2484
 msgid "ED2K Info"
 msgstr "ED2K Info"
 
-#: src/muuli_wdr.cpp:2516
+#: src/muuli_wdr.cpp:2488
 msgid "Kad Info"
 msgstr "Kad Info"
 
-#: src/muuli_wdr.cpp:2544
+#: src/muuli_wdr.cpp:2516
 msgid "Click on this button to update the nodes list from URL ..."
 msgstr "Klikates sellele nupule värskendad sõlmede loetelu URL'ilt ..."
 
-#: src/muuli_wdr.cpp:2548
+#: src/muuli_wdr.cpp:2520
 msgid "Nodes (0)"
 msgstr "Sõlmed (0)"
 
-#: src/muuli_wdr.cpp:2552
+#: src/muuli_wdr.cpp:2524
 msgid "Enter the url to a nodes.dat file here and press the button to the left to update the list of known nodes."
 msgstr "Sisesta siia nodes.dat faili url ja pressi vasakul olevat nuppu, et tuntud sõlmede loetelu täiendada."
 
-#: src/muuli_wdr.cpp:2555
+#: src/muuli_wdr.cpp:2527
 msgid "Nodes stats"
 msgstr "Sõlmede statistika"
 
-#: src/muuli_wdr.cpp:2597
+#: src/muuli_wdr.cpp:2569
 msgid "Bootstrap"
 msgstr "Bootstrap"
 
-#: src/muuli_wdr.cpp:2600
+#: src/muuli_wdr.cpp:2572
 msgid "New node"
 msgstr "Uus sõlm"
 
-#: src/muuli_wdr.cpp:2605
+#: src/muuli_wdr.cpp:2577
 msgid "IP:"
 msgstr "IP:"
 
-#: src/muuli_wdr.cpp:2625
+#: src/muuli_wdr.cpp:2597
 msgid "Port:"
 msgstr "Port:"
 
-#: src/muuli_wdr.cpp:2638
+#: src/muuli_wdr.cpp:2610
 msgid "Bootstrap from known clients"
 msgstr "Tuntud klientide Bootstrap"
 
-#: src/muuli_wdr.cpp:2640
+#: src/muuli_wdr.cpp:2612
 msgid "Disconnect Kad"
 msgstr "Lõpeta Kad ühendus"
 
-#: src/muuli_wdr.cpp:2674
+#: src/muuli_wdr.cpp:2646
 msgid "Use Secure User Identification"
 msgstr "Kasuta Turvalist Kasutaja tuvastamist"
 
-#: src/muuli_wdr.cpp:2676
+#: src/muuli_wdr.cpp:2648
 msgid "It is recommended to enable this option. You will not receive credits if SUI is not enabled."
 msgstr "On soovitatav see omadus lubada. Sa ei saa krediiti kui SUI on välja lülitatud."
 
-#: src/muuli_wdr.cpp:2678
+#: src/muuli_wdr.cpp:2650
 msgid "Protocol Obfuscation"
 msgstr "Protokolli Hämamine"
 
-#: src/muuli_wdr.cpp:2681
+#: src/muuli_wdr.cpp:2653
 msgid "Support Protocol Obfuscation"
 msgstr "Protokolli Hämamine lubatud"
 
-#: src/muuli_wdr.cpp:2683
+#: src/muuli_wdr.cpp:2655
 msgid "This option enabled Protocol Obfuscation, and makes aMule accept obfuscated connections from other clients."
 msgstr "See valik lülitab Protokolli Hämamise sisse ja sunnib aMule aksepteerima ainult teiste klientide hämatud ühendusi."
 
-#: src/muuli_wdr.cpp:2685
+#: src/muuli_wdr.cpp:2657
 msgid "Use obfuscation for outgoing connections"
 msgstr "Kasuta väljuvatel ühendustel hämamist"
 
-#: src/muuli_wdr.cpp:2687
+#: src/muuli_wdr.cpp:2659
 msgid "This option makes aMule use Protocol Obfuscation when connecting other clients/servers."
 msgstr "See valik sunnib aMule kasutama teiste serverite/klientidega ühendumisel Protokolli Hämamist."
 
-#: src/muuli_wdr.cpp:2689
+#: src/muuli_wdr.cpp:2661
 msgid "Accept only obfuscated connections"
 msgstr "Aksepteeri ainult hämatud ühendusi"
 
-#: src/muuli_wdr.cpp:2690
+#: src/muuli_wdr.cpp:2662
 msgid "This option makes aMule only accept obfuscated connections. You will have less sources, but all your traffic will be obfuscated"
 msgstr "See valik sunnib aMule aksepteerima ainult hämatud ühendusi. Sul on vähem allikaid aga kogu liiklus on hämatud."
 
-#: src/muuli_wdr.cpp:2695
+#: src/muuli_wdr.cpp:2667
 msgid "Everybody"
 msgstr "Igaüks"
 
-#: src/muuli_wdr.cpp:2697
+#: src/muuli_wdr.cpp:2669
 msgid "No one"
 msgstr "Mitte keegi"
 
-#: src/muuli_wdr.cpp:2699
+#: src/muuli_wdr.cpp:2671
 msgid "Who can see my shared files:"
 msgstr "Kes näeb minu jagatud faile:"
 
-#: src/muuli_wdr.cpp:2700
+#: src/muuli_wdr.cpp:2672
 msgid "Select who can request to view a list of your shared files."
 msgstr "Vali, kes võib vaatamiseks küsida sinu jagatud falide nimekira."
 
-#: src/muuli_wdr.cpp:2702
+#: src/muuli_wdr.cpp:2674
 msgid "IP-Filtering"
 msgstr "IP-Filtreerimine"
 
-#: src/muuli_wdr.cpp:2709
+#: src/muuli_wdr.cpp:2681
 msgid "Filter clients"
 msgstr "Filtreeri kliente"
 
-#: src/muuli_wdr.cpp:2711
+#: src/muuli_wdr.cpp:2683
 msgid "Enable filtering of the client IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "Rakenda klientide IP filtreerimine failis ~/.aMule/ipfilter.dat defineeritud aadressidele."
 
-#: src/muuli_wdr.cpp:2713
+#: src/muuli_wdr.cpp:2685
 msgid "Filter servers"
 msgstr "Filtreeri servereid"
 
-#: src/muuli_wdr.cpp:2715
+#: src/muuli_wdr.cpp:2687
 msgid "Enable filtering of the server IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "Rakenda serverite IP filtreerimine failis ~/.aMule/ipfilter.dat defineeritud aadressidele."
 
-#: src/muuli_wdr.cpp:2719
+#: src/muuli_wdr.cpp:2691
 msgid "Reload List"
 msgstr "Lae loetelu uuesti"
 
-#: src/muuli_wdr.cpp:2720
+#: src/muuli_wdr.cpp:2692
 msgid "Reload the list of IPs to filter from the file ~/.aMule/ipfilter.dat"
 msgstr "Taaslae filtreeritavad IP aadressid failist ~/.aMule/ipfilter.dat"
 
-#: src/muuli_wdr.cpp:2726
+#: src/muuli_wdr.cpp:2698
 msgid "URL:"
 msgstr "URL:"
 
-#: src/muuli_wdr.cpp:2730 src/muuli_wdr.cpp:2923
+#: src/muuli_wdr.cpp:2702 src/muuli_wdr.cpp:2895
 msgid "Update now"
 msgstr "Värskenda"
 
-#: src/muuli_wdr.cpp:2733
+#: src/muuli_wdr.cpp:2705
 msgid "Auto-update ipfilter at startup"
 msgstr "Käivitamisel värskenda automaatselt ipfiltrit"
 
-#: src/muuli_wdr.cpp:2737
+#: src/muuli_wdr.cpp:2709
 msgid "Filtering Level:"
 msgstr "Filtreerimise tase:"
 
-#: src/muuli_wdr.cpp:2743
+#: src/muuli_wdr.cpp:2715
 msgid "Always filter LAN IPs"
 msgstr "Filtreeri alati LAN IP aadresse"
 
-#: src/muuli_wdr.cpp:2746
+#: src/muuli_wdr.cpp:2718
 msgid "Paranoid handling of non-matching IPs"
 msgstr "Mitteklappivate IP aadresside paranoiline käitlemine"
 
-#: src/muuli_wdr.cpp:2748
+#: src/muuli_wdr.cpp:2720
 msgid "Rejects a packet when its source IP differs from the IP the client claims (an anti-spoofing check). Disable only if it causes connection problems."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2750
+#: src/muuli_wdr.cpp:2722
 msgid "Use system-wide ipfilter.dat if available"
 msgstr "Kasuta süsteemi ipfilter.dat kui see on saadaval"
 
-#: src/muuli_wdr.cpp:2751
+#: src/muuli_wdr.cpp:2723
 #, fuzzy
 msgid "If there's no local ipfilter.dat found, allow usage of a system-wide ipfilter file."
 msgstr "Kui kohalik ipfilter.dat fail puudub, kasuta süsteemi globaalset ipfilter faili."
 
-#: src/muuli_wdr.cpp:2768
+#: src/muuli_wdr.cpp:2740
 msgid "Enable Online-Signature"
 msgstr "Luba Online-Allkiri"
 
-#: src/muuli_wdr.cpp:2770
+#: src/muuli_wdr.cpp:2742
 msgid "Enables the writing of the OS file, which can be used by external apps to create signatures and the like."
 msgstr "Võimaldab kirjutada OS faile, mida saavad kasutada välised rakendused kasvõi allkirja loomiseks."
 
-#: src/muuli_wdr.cpp:2774
+#: src/muuli_wdr.cpp:2746
 msgid "Update Frequency (Secs):"
 msgstr "Värskenduse sagedus (Sek):"
 
-#: src/muuli_wdr.cpp:2777
+#: src/muuli_wdr.cpp:2749
 msgid "Change the frequency (in seconds) of Online Signature updates."
 msgstr "Muuda Online Allkirja värskendamise (sekundites) sagedust."
 
-#: src/muuli_wdr.cpp:2785
+#: src/muuli_wdr.cpp:2757
 msgid "Save online signature file in: "
 msgstr "Salvesta online ollkirja fail: "
 
-#: src/muuli_wdr.cpp:2791
+#: src/muuli_wdr.cpp:2763
 msgid "Click here to select the directory containing the the Online Signature files."
 msgstr "Siin saad valida kataloogi kus asub sinu Online Allkirja fail."
 
-#: src/muuli_wdr.cpp:2824
+#: src/muuli_wdr.cpp:2796
 msgid "Show country flags for clients"
 msgstr "Näita klientide riigi lippe"
 
-#: src/muuli_wdr.cpp:2825
+#: src/muuli_wdr.cpp:2797
 msgid "Render the country flag column in the transfers, queue and search views. Requires a valid MMDB GeoIP database (see below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2830
+#: src/muuli_wdr.cpp:2802
 #, fuzzy
 msgid "Database"
 msgstr "Andmekiirus :"
 
-#: src/muuli_wdr.cpp:2846
+#: src/muuli_wdr.cpp:2818
 #, fuzzy
 msgid "Source:"
 msgstr "Allikaid"
 
-#: src/muuli_wdr.cpp:2849
+#: src/muuli_wdr.cpp:2821
 msgid "DB-IP (free, no account)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2850
+#: src/muuli_wdr.cpp:2822
 msgid "MaxMind GeoLite2 (free, account required)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2851
+#: src/muuli_wdr.cpp:2823
 msgid "Custom URL"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2854
+#: src/muuli_wdr.cpp:2826
 msgid "Choose which provider supplies the GeoIP MMDB database. DB-IP is the default - no account required. MaxMind requires a free account + license key. Use Custom URL to point at any other MMDB host (e.g. a local mirror)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2871
+#: src/muuli_wdr.cpp:2843
 msgid ""
 "No configuration required.\n"
 "\n"
@@ -4874,11 +4840,11 @@ msgid ""
 "License: Creative Commons BY 4.0 - https://creativecommons.org/licenses/by/4.0/"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2884
+#: src/muuli_wdr.cpp:2856
 msgid "License key:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2890
+#: src/muuli_wdr.cpp:2862
 msgid ""
 "Sign up for a free MaxMind account, then generate a License Key:\n"
 "https://www.maxmind.com/en/geolite2/signup\n"
@@ -4888,226 +4854,226 @@ msgid ""
 "Requires attribution and account registration; refresh at least every 30 days."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2905
+#: src/muuli_wdr.cpp:2877
 #, fuzzy
 msgid "Download URL:"
 msgstr "Tõmbamine: "
 
-#: src/muuli_wdr.cpp:2911
+#: src/muuli_wdr.cpp:2883
 msgid ""
 "Must point to an .mmdb file or a .gz / .tar.gz containing one.\n"
 "URL may include credentials (https://user:pass@host/...).\n"
 "License and attribution terms are set by the upstream URL - you are responsible."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2924
+#: src/muuli_wdr.cpp:2896
 msgid "Download the GeoIP database from the selected source."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2926
+#: src/muuli_wdr.cpp:2898
 #, fuzzy
 msgid "Auto-update on startup"
 msgstr "Käivitamisel värskenda automaatselt ipfiltrit"
 
-#: src/muuli_wdr.cpp:2927
+#: src/muuli_wdr.cpp:2899
 msgid "Re-download the GeoIP database from the selected source every time aMule starts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2950
+#: src/muuli_wdr.cpp:2922
 msgid "Filter incoming messages (except current chat):"
 msgstr "Filtreeri saabuvaid teateid (va. käimasolev vestlus):"
 
-#: src/muuli_wdr.cpp:2952
+#: src/muuli_wdr.cpp:2924
 msgid "Filter all messages"
 msgstr "Filtreeri kõiki teateid"
 
-#: src/muuli_wdr.cpp:2954
+#: src/muuli_wdr.cpp:2926
 msgid "Filter messages from people not on your friend list"
 msgstr "Filtreeri sinu sõbralistiväliste kodanike teateid"
 
-#: src/muuli_wdr.cpp:2956
+#: src/muuli_wdr.cpp:2928
 msgid "Filter messages from unknown clients"
 msgstr "Filtreeri tundmatute klientide teateid"
 
-#: src/muuli_wdr.cpp:2958
+#: src/muuli_wdr.cpp:2930
 msgid "Filter messages containing (use ',' as separator):"
 msgstr "Filtreeri teateid, mis sisaldavad (loetelus kasuta eraldajana koma):"
 
-#: src/muuli_wdr.cpp:2961 src/muuli_wdr.cpp:2972
+#: src/muuli_wdr.cpp:2933 src/muuli_wdr.cpp:2944
 msgid "add here the words amule should filter and block messages including it"
 msgstr "lisa siia sõnad mille amule peab väljafiltreerima ja bloki teated mis seda sisaldavad"
 
-#: src/muuli_wdr.cpp:2963
+#: src/muuli_wdr.cpp:2935
 msgid "Show received messages in the log"
 msgstr "Näita logis saabunud teateid"
 
-#: src/muuli_wdr.cpp:2966
+#: src/muuli_wdr.cpp:2938
 msgid "Comments"
 msgstr "Kommentaarid"
 
-#: src/muuli_wdr.cpp:2969
+#: src/muuli_wdr.cpp:2941
 msgid "Filter comments containing (use ',' as separator):"
 msgstr "Filtreeri teateid, mis sisaldavad (loetelus kasuta eraldajana koma):"
 
-#: src/muuli_wdr.cpp:2994
+#: src/muuli_wdr.cpp:2966
 msgid "Enable Proxy"
 msgstr "Kasuta puhverserverit"
 
-#: src/muuli_wdr.cpp:2995
+#: src/muuli_wdr.cpp:2967
 msgid "Enable/disable proxy support"
 msgstr "Kasuta/ärakasuta puhverserveri tuge"
 
-#: src/muuli_wdr.cpp:2998
+#: src/muuli_wdr.cpp:2970
 msgid "Proxy type:"
 msgstr "Puhverserveri tüüp:"
 
-#: src/muuli_wdr.cpp:3009
+#: src/muuli_wdr.cpp:2981
 msgid "Proxy host:"
 msgstr "Puhverserveri nimi:"
 
-#: src/muuli_wdr.cpp:3012
+#: src/muuli_wdr.cpp:2984
 msgid "The proxy host name"
 msgstr "Selle puhverserveri/hosti nimi "
 
-#: src/muuli_wdr.cpp:3014
+#: src/muuli_wdr.cpp:2986
 msgid "Proxy port:"
 msgstr "Puhverserveri port:"
 
-#: src/muuli_wdr.cpp:3017
+#: src/muuli_wdr.cpp:2989
 msgid "The proxy port"
 msgstr "Selle puhverserveri pordi number"
 
-#: src/muuli_wdr.cpp:3019
+#: src/muuli_wdr.cpp:2991
 msgid "Enable authentication"
 msgstr "Nõua autoriseerimist"
 
-#: src/muuli_wdr.cpp:3020
+#: src/muuli_wdr.cpp:2992
 msgid "Enable/disable username/password authentication"
 msgstr "Autoriseerimisel Kasuta/Ära kasuta kasutajanime/parooli"
 
-#: src/muuli_wdr.cpp:3023
+#: src/muuli_wdr.cpp:2995
 msgid "Username: "
 msgstr "Kasutajanimi: "
 
-#: src/muuli_wdr.cpp:3026
+#: src/muuli_wdr.cpp:2998
 msgid "The username to use to connect to the proxy"
 msgstr "Puhverserveriga ühenduseks vajalik kasutajanimi"
 
-#: src/muuli_wdr.cpp:3028
+#: src/muuli_wdr.cpp:3000
 msgid "Password:"
 msgstr "Parool:"
 
-#: src/muuli_wdr.cpp:3031
+#: src/muuli_wdr.cpp:3003
 msgid "The password to use to connect to the proxy"
 msgstr "Puhverserveri kasutamiseks vajalik parool"
 
-#: src/muuli_wdr.cpp:3050
+#: src/muuli_wdr.cpp:3022
 msgid "Connect to:"
 msgstr "Ühendu :"
 
-#: src/muuli_wdr.cpp:3059
+#: src/muuli_wdr.cpp:3031
 msgid "Login to remote amule"
 msgstr "Logi sisse eemalasuvasse amuula"
 
-#: src/muuli_wdr.cpp:3064
+#: src/muuli_wdr.cpp:3036
 msgid "User name"
 msgstr "Kasutaja nimi"
 
-#: src/muuli_wdr.cpp:3075
+#: src/muuli_wdr.cpp:3047
 msgid "Remember those settings"
 msgstr "Pea need seaded meeles"
 
-#: src/muuli_wdr.cpp:3078
+#: src/muuli_wdr.cpp:3050
 #, fuzzy
 msgid "Force ZLIB compression"
 msgstr "Kasuta gzip pakkimist"
 
-#: src/muuli_wdr.cpp:3102
+#: src/muuli_wdr.cpp:3074
 msgid "Enable Verbose Debug-Logging."
 msgstr "Võimalda inimkieelne Veajälitus-Logimine"
 
-#: src/muuli_wdr.cpp:3104
+#: src/muuli_wdr.cpp:3076
 #, fuzzy
 msgid "Only to Logfile"
 msgstr "Ava Fail"
 
-#: src/muuli_wdr.cpp:3106
+#: src/muuli_wdr.cpp:3078
 msgid "Message Categories:"
 msgstr "Saadetav teade:"
 
-#: src/muuli_wdr.cpp:3130 src/PartFileConvertDlg.cpp:160
+#: src/muuli_wdr.cpp:3102 src/PartFileConvertDlg.cpp:160
 msgid "Waiting..."
 msgstr "Ootan..."
 
-#: src/muuli_wdr.cpp:3150
+#: src/muuli_wdr.cpp:3122
 msgid "Add imports"
 msgstr "Lisa imporditavad"
 
-#: src/muuli_wdr.cpp:3153
+#: src/muuli_wdr.cpp:3125
 msgid "Retry selected"
 msgstr "Proovi valitutega uuesti"
 
-#: src/muuli_wdr.cpp:3155
+#: src/muuli_wdr.cpp:3127
 msgid "Remove selected"
 msgstr "Eemalda valitud"
 
-#: src/muuli_wdr.cpp:3218
+#: src/muuli_wdr.cpp:3190
 msgid "Event Types"
 msgstr "Sündmuse tüübid"
 
-#: src/muuli_wdr.cpp:3237
+#: src/muuli_wdr.cpp:3209
 msgid "Statistics and queued clients for selected file(s) : Session / All time"
 msgstr "Statistika ja järjekorras kliendid valitud faili(de) kohta : Sessioon / Kokku"
 
-#: src/muuli_wdr.cpp:3261
+#: src/muuli_wdr.cpp:3233
 msgid "Active Uploads"
 msgstr "Aktiivsed saatmised"
 
-#: src/muuli_wdr.cpp:3275
+#: src/muuli_wdr.cpp:3247
 msgid "Percent of total files"
 msgstr "Protsenti kogufailidest"
 
-#: src/muuli_wdr.cpp:3327
+#: src/muuli_wdr.cpp:3299
 msgid "Show Clients for"
 msgstr "Näita Kliente"
 
-#: src/muuli_wdr.cpp:3329
+#: src/muuli_wdr.cpp:3301
 msgid "All files"
 msgstr "Kõik failid"
 
-#: src/muuli_wdr.cpp:3332
+#: src/muuli_wdr.cpp:3304
 msgid "Selected files"
 msgstr "Valitud failid"
 
-#: src/muuli_wdr.cpp:3335
+#: src/muuli_wdr.cpp:3307
 msgid "Active uploads only"
 msgstr "Ainult aktiivsed saatmised"
 
-#: src/muuli_wdr.cpp:3342
+#: src/muuli_wdr.cpp:3314
 msgid "Reload:"
 msgstr "Taaslae:"
 
-#: src/muuli_wdr.cpp:3346
+#: src/muuli_wdr.cpp:3318
 msgid "Reload your shared files"
 msgstr "Lae oma jagatud failid uuesti"
 
-#: src/muuli_wdr.cpp:3409
+#: src/muuli_wdr.cpp:3381
 msgid "Send"
 msgstr "Saada"
 
-#: src/muuli_wdr.cpp:3410
+#: src/muuli_wdr.cpp:3382
 msgid "Sends the specified message."
 msgstr "Saada määratud teade."
 
-#: src/muuli_wdr.cpp:3414
+#: src/muuli_wdr.cpp:3386
 msgid "Close this chat-session."
 msgstr "Sulge see vestlus-seanss."
 
-#: src/muuli_wdr.cpp:3437
+#: src/muuli_wdr.cpp:3409
 msgid "Connect to any server and/or Kad"
 msgstr "Ühendu suvalise serveri ja/või Kad võrguga"
 
-#: src/muuli_wdr.cpp:3443 src/SharedFilesCtrl.cpp:142 src/Statistics.cpp:941
+#: src/muuli_wdr.cpp:3415 src/SharedFilesCtrl.cpp:142 src/Statistics.cpp:941
 msgid "Shared Files"
 msgstr "Jagatud failid"
 
@@ -5466,250 +5432,250 @@ msgstr "Allalaetud"
 msgid "ERROR: Failed to open partfile '%s'"
 msgstr "VIGA: Osafaili '%s' avamine ebaõnnestus"
 
-#: src/Preferences.cpp:701
+#: src/Preferences.cpp:673
 msgid "System default"
 msgstr "Süsteemi vaikeväärtus"
 
-#: src/Preferences.cpp:702
+#: src/Preferences.cpp:674
 msgid "Albanian"
 msgstr "Albaania"
 
-#: src/Preferences.cpp:703
+#: src/Preferences.cpp:675
 msgid "Arabic"
 msgstr "Araabia"
 
-#: src/Preferences.cpp:704
+#: src/Preferences.cpp:676
 msgid "Asturian"
 msgstr "Asturia"
 
-#: src/Preferences.cpp:705
+#: src/Preferences.cpp:677
 msgid "Basque"
 msgstr "Baski"
 
-#: src/Preferences.cpp:706
+#: src/Preferences.cpp:678
 msgid "Bulgarian"
 msgstr "Bulgaaria"
 
-#: src/Preferences.cpp:707
+#: src/Preferences.cpp:679
 msgid "Catalan"
 msgstr "Kataloonia"
 
-#: src/Preferences.cpp:708
+#: src/Preferences.cpp:680
 msgid "Chinese (Simplified)"
 msgstr "Hiina (Lihtsustatud)"
 
-#: src/Preferences.cpp:709
+#: src/Preferences.cpp:681
 msgid "Chinese (Traditional)"
 msgstr "Hiina (Traditsiooniline)"
 
-#: src/Preferences.cpp:710
+#: src/Preferences.cpp:682
 msgid "Croatian"
 msgstr "Kroaatia"
 
-#: src/Preferences.cpp:711
+#: src/Preferences.cpp:683
 msgid "Czech"
 msgstr "Tšehhi"
 
-#: src/Preferences.cpp:712
+#: src/Preferences.cpp:684
 msgid "Danish"
 msgstr "Taani"
 
-#: src/Preferences.cpp:713
+#: src/Preferences.cpp:685
 msgid "Dutch"
 msgstr "Hollandi"
 
-#: src/Preferences.cpp:714
+#: src/Preferences.cpp:686
 msgid "English (U.K.)"
 msgstr "Inglise (U.K.)"
 
-#: src/Preferences.cpp:715
+#: src/Preferences.cpp:687
 #, fuzzy
 msgid "English (U.S.)"
 msgstr "Inglise (U.K.)"
 
-#: src/Preferences.cpp:716
+#: src/Preferences.cpp:688
 msgid "Estonian"
 msgstr "Eesti"
 
-#: src/Preferences.cpp:717
+#: src/Preferences.cpp:689
 msgid "Finnish"
 msgstr "Soome"
 
-#: src/Preferences.cpp:718
+#: src/Preferences.cpp:690
 msgid "French"
 msgstr "Prantsuse"
 
-#: src/Preferences.cpp:719
+#: src/Preferences.cpp:691
 msgid "Galician"
 msgstr "Galiitsia"
 
-#: src/Preferences.cpp:720
+#: src/Preferences.cpp:692
 msgid "German"
 msgstr "Saksa"
 
-#: src/Preferences.cpp:721
+#: src/Preferences.cpp:693
 msgid "Greek"
 msgstr "Kreeka"
 
-#: src/Preferences.cpp:722
+#: src/Preferences.cpp:694
 msgid "Hebrew"
 msgstr "Heebrea"
 
-#: src/Preferences.cpp:723
+#: src/Preferences.cpp:695
 msgid "Hungarian"
 msgstr "Ungari"
 
-#: src/Preferences.cpp:724
+#: src/Preferences.cpp:696
 msgid "Italian"
 msgstr "Itaalia"
 
-#: src/Preferences.cpp:725
+#: src/Preferences.cpp:697
 msgid "Japanese"
 msgstr "Jaapani"
 
-#: src/Preferences.cpp:726
+#: src/Preferences.cpp:698
 msgid "Korean"
 msgstr "Korea"
 
-#: src/Preferences.cpp:727
+#: src/Preferences.cpp:699
 msgid "Latvian"
 msgstr ""
 
-#: src/Preferences.cpp:728
+#: src/Preferences.cpp:700
 msgid "Lithuanian"
 msgstr "Leedu"
 
-#: src/Preferences.cpp:729
+#: src/Preferences.cpp:701
 msgid "Norwegian (Nynorsk)"
 msgstr "Norra"
 
-#: src/Preferences.cpp:730
+#: src/Preferences.cpp:702
 msgid "Polish"
 msgstr "Poola"
 
-#: src/Preferences.cpp:731
+#: src/Preferences.cpp:703
 msgid "Portuguese"
 msgstr "Portugali"
 
-#: src/Preferences.cpp:732
+#: src/Preferences.cpp:704
 msgid "Portuguese (Brazilian)"
 msgstr "Portugali (Brasiilia)"
 
-#: src/Preferences.cpp:733
+#: src/Preferences.cpp:705
 msgid "Romanian"
 msgstr "Rumeenia"
 
-#: src/Preferences.cpp:734
+#: src/Preferences.cpp:706
 msgid "Russian"
 msgstr "Vene"
 
-#: src/Preferences.cpp:735
+#: src/Preferences.cpp:707
 msgid "Slovenian"
 msgstr "Sloveenia"
 
-#: src/Preferences.cpp:736
+#: src/Preferences.cpp:708
 msgid "Spanish"
 msgstr "Hispaania"
 
-#: src/Preferences.cpp:737
+#: src/Preferences.cpp:709
 msgid "Swedish"
 msgstr "Rootsi"
 
-#: src/Preferences.cpp:738
+#: src/Preferences.cpp:710
 msgid "Turkish"
 msgstr "Türgi"
 
-#: src/Preferences.cpp:739
+#: src/Preferences.cpp:711
 msgid "Ukrainian"
 msgstr "Ukraina"
 
-#: src/Preferences.cpp:842
+#: src/Preferences.cpp:814
 msgid "Change Language"
 msgstr "Muuda keel"
 
-#: src/Preferences.cpp:906
+#: src/Preferences.cpp:878
 msgid "There are no translations installed for aMule"
 msgstr ""
 
-#: src/Preferences.cpp:907
+#: src/Preferences.cpp:879
 #, fuzzy
 msgid "No languages available"
 msgstr "Info puudub"
 
-#: src/Preferences.cpp:1038
+#: src/Preferences.cpp:1010
 msgid "no options available"
 msgstr "valikud puuduvad"
 
-#: src/Preferences.cpp:2226
+#: src/Preferences.cpp:2179
 msgid "Invalid category found, skipping"
 msgstr "Leidsin vigase kategooria, ignoreerin"
 
-#: src/Preferences.cpp:2395
+#: src/Preferences.cpp:2348
 msgid "TCP port can't be higher than 65532 due to server UDP socket being TCP+3"
 msgstr "TCP port ei saa olla suuerm kui 65532, sest serveri UDP soket on TCP+3"
 
-#: src/Preferences.cpp:2396
+#: src/Preferences.cpp:2349
 #, c-format
 msgid "Default port will be used (%d)"
 msgstr "Kasutan vaikimisi porti (%d)"
 
-#: src/PrefsUnifiedDlg.cpp:300 src/Statistics.cpp:866
+#: src/PrefsUnifiedDlg.cpp:298 src/Statistics.cpp:866
 msgid "Connection"
 msgstr "Ühendus"
 
-#: src/PrefsUnifiedDlg.cpp:301 src/SearchListCtrl.cpp:117
+#: src/PrefsUnifiedDlg.cpp:299 src/SearchListCtrl.cpp:117
 msgid "Directories"
 msgstr "Kataloogid"
 
-#: src/PrefsUnifiedDlg.cpp:302 src/Statistics.cpp:917
+#: src/PrefsUnifiedDlg.cpp:300 src/Statistics.cpp:917
 msgid "Servers"
 msgstr "Serverid"
 
-#: src/PrefsUnifiedDlg.cpp:303 src/ServerListCtrl.cpp:96
+#: src/PrefsUnifiedDlg.cpp:301 src/ServerListCtrl.cpp:96
 msgid "Files"
 msgstr "Failid"
 
-#: src/PrefsUnifiedDlg.cpp:304
+#: src/PrefsUnifiedDlg.cpp:302
 msgid "Security"
 msgstr "Turvalisus"
 
-#: src/PrefsUnifiedDlg.cpp:305
+#: src/PrefsUnifiedDlg.cpp:303
 msgid "Interface"
 msgstr "Liides"
 
-#: src/PrefsUnifiedDlg.cpp:312
+#: src/PrefsUnifiedDlg.cpp:310
 msgid "IP2Country"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:315
+#: src/PrefsUnifiedDlg.cpp:313
 msgid "Proxy"
 msgstr "Puhverserver"
 
-#: src/PrefsUnifiedDlg.cpp:316
+#: src/PrefsUnifiedDlg.cpp:314
 msgid "Filters"
 msgstr "Filtrid"
 
-#: src/PrefsUnifiedDlg.cpp:317
+#: src/PrefsUnifiedDlg.cpp:315
 msgid "Remote Controls"
 msgstr "Kaugjuhtimine"
 
-#: src/PrefsUnifiedDlg.cpp:318
+#: src/PrefsUnifiedDlg.cpp:316
 msgid "Online Signature"
 msgstr "Online Allkiri"
 
-#: src/PrefsUnifiedDlg.cpp:319
+#: src/PrefsUnifiedDlg.cpp:317
 msgid "Advanced"
 msgstr "Muud"
 
-#: src/PrefsUnifiedDlg.cpp:320
+#: src/PrefsUnifiedDlg.cpp:318
 msgid "Events"
 msgstr "Sündmused"
 
-#: src/PrefsUnifiedDlg.cpp:323
+#: src/PrefsUnifiedDlg.cpp:321
 msgid "Debugging"
 msgstr "Veajälitus"
 
-#: src/PrefsUnifiedDlg.cpp:453
+#: src/PrefsUnifiedDlg.cpp:451
 msgid ""
 "The following variables will be substituted:\n"
 "    %PARTFILE - full path to the file\n"
@@ -5719,15 +5685,15 @@ msgstr ""
 "   %PARTFILE - fail täis rada\n"
 "   %PARTNAME - faili nimi"
 
-#: src/PrefsUnifiedDlg.cpp:474
+#: src/PrefsUnifiedDlg.cpp:472
 msgid "Tray icon support requires libayatana-appindicator3 at compile time."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:490
+#: src/PrefsUnifiedDlg.cpp:488
 msgid "Not available on Wayland: the protocol does not report when a window is minimized, so this option cannot intercept the system minimize button. Workaround: launch aMule with `GDK_BACKEND=x11` to use XWayland instead."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:536
+#: src/PrefsUnifiedDlg.cpp:534
 msgid ""
 "Do not change these setting unless you know\n"
 "what you are doing, otherwise you can easily\n"
@@ -5743,35 +5709,26 @@ msgstr ""
 "aMule toimib ilusasti ilma siinolevaid seadeid muutmata\n"
 "You Are WARNED!!."
 
-#: src/PrefsUnifiedDlg.cpp:647
+#: src/PrefsUnifiedDlg.cpp:645
 #, c-format
 msgid "Failed to connect Cfg to widget with the ID %d and key %s"
 msgstr "Widgeti ühendamine Cfg'a, kasutades ID %d ja võtit %s, ebaõnnestus"
 
-#: src/PrefsUnifiedDlg.cpp:695
+#: src/PrefsUnifiedDlg.cpp:693
 #, c-format
 msgid "Failed to transfer data from Cfg to Widget with the ID %d and key %s"
 msgstr "Andmete ülekandmine Cfg'st Widget'isse, kasutades ID %d ja võtit %s, ebaõnnestus"
 
-#: src/PrefsUnifiedDlg.cpp:801
+#: src/PrefsUnifiedDlg.cpp:799
 msgid "The type of proxy you are connecting to"
 msgstr "Selle puhverserveri tüüp kuhu sa ühendud"
 
-#: src/PrefsUnifiedDlg.cpp:1020
+#: src/PrefsUnifiedDlg.cpp:1003
 #, c-format
 msgid "Failed to transfer data from Widget to Cfg with the ID %d and key %s"
 msgstr "Andmete ülekandmine Widgetist Cfg'sse, kasutades ID %d ja võtit %s, ebaõnnestus"
 
 #: src/PrefsUnifiedDlg.cpp:1103
-#, fuzzy
-msgid "No password set."
-msgstr "Kontrollin parooli\n"
-
-#: src/PrefsUnifiedDlg.cpp:1132
-msgid "Guest access needs a password. Type one in the guest password field, or untick Enable guest access."
-msgstr ""
-
-#: src/PrefsUnifiedDlg.cpp:1144
 msgid ""
 "aMule must be restarted to enable these changes:\n"
 "\n"
@@ -5779,42 +5736,42 @@ msgstr ""
 "Nende muudatuste jõustamiseks pead aMUle taaskäivitama:\n"
 "\n"
 
-#: src/PrefsUnifiedDlg.cpp:1151
+#: src/PrefsUnifiedDlg.cpp:1110
 msgid "- TCP port changed.\n"
 msgstr "- TCP port muudetud.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1156
+#: src/PrefsUnifiedDlg.cpp:1115
 msgid "- UDP port changed.\n"
 msgstr "- UDP port muudetud.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1161
+#: src/PrefsUnifiedDlg.cpp:1120
 #, fuzzy
 msgid "- Network interface binding changed.\n"
 msgstr "- Välisühenduse liides muutunud.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1166
+#: src/PrefsUnifiedDlg.cpp:1125
 msgid "- External connect port changed.\n"
 msgstr "- Välisühenduse port on muutunud.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1170
+#: src/PrefsUnifiedDlg.cpp:1129
 msgid "- External connect acceptance changed.\n"
 msgstr "- Välisühenduse luba on muudetud.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1174
+#: src/PrefsUnifiedDlg.cpp:1133
 msgid "- External connect interface changed.\n"
 msgstr "- Välisühenduse liides muutunud.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1178
+#: src/PrefsUnifiedDlg.cpp:1137
 #, fuzzy
 msgid "- Protocol obfuscation support changed.\n"
 msgstr "Protokolli Hämamine"
 
-#: src/PrefsUnifiedDlg.cpp:1193
+#: src/PrefsUnifiedDlg.cpp:1151
 #, fuzzy
 msgid "- amuleapi settings changed.\n"
 msgstr "- Keel on muudetud.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1202
+#: src/PrefsUnifiedDlg.cpp:1160
 msgid ""
 "Your Auto-update server list is empty.\n"
 "'Auto-update server list at startup' will be disabled."
@@ -5822,7 +5779,7 @@ msgstr ""
 "Sinu automaane serverinimekirja värskendamise loetelu on tühi.\n"
 "Käivitamisel serverinimekirja automaatselt ei uuendata."
 
-#: src/PrefsUnifiedDlg.cpp:1213
+#: src/PrefsUnifiedDlg.cpp:1171
 msgid ""
 "You have enabled external connections but have not specified a password.\n"
 "External connections cannot be enabled unless a valid password is specified."
@@ -5830,33 +5787,28 @@ msgstr ""
 "Lülitasid sisse välised ühendused kuid ei määranud parooli.\n"
 "Väliseid ühendusi ei saa enne kehtiva parooli määramist kasutada."
 
-#: src/PrefsUnifiedDlg.cpp:1246
-#, c-format
-msgid "The amuleapi password could not be saved: %s"
-msgstr ""
-
-#: src/PrefsUnifiedDlg.cpp:1276
+#: src/PrefsUnifiedDlg.cpp:1202
 msgid "- Language changed.\n"
 msgstr "- Keel on muudetud.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1281
+#: src/PrefsUnifiedDlg.cpp:1207
 msgid "- Temp folder changed.\n"
 msgstr "- Ajutiste failide kataloog on muudetud.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1286
+#: src/PrefsUnifiedDlg.cpp:1212
 msgid "- ED2K network enabled.\n"
 msgstr "- ED2K võrk on lubatud.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1319
+#: src/PrefsUnifiedDlg.cpp:1245
 msgid "The shared-file exclusion pattern is not a valid regular expression. The filter has been left disabled."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1321 src/PrefsUnifiedDlg.cpp:1921
+#: src/PrefsUnifiedDlg.cpp:1247 src/PrefsUnifiedDlg.cpp:1841
 #, fuzzy
 msgid "Invalid regular expression"
 msgstr "Vigane protokolli versioon."
 
-#: src/PrefsUnifiedDlg.cpp:1398
+#: src/PrefsUnifiedDlg.cpp:1324
 msgid ""
 "Both eD2k and Kad network are disabled.\n"
 "You won't be able to connect until you enable at least one of them."
@@ -5864,7 +5816,7 @@ msgstr ""
 "Mõlemad, nii eD2k kui ka Kad võrgud on mitteaktiivsed.\n"
 "Sa ei saa ühenduda enne, kui vähemalt üks neist on aktiivne."
 
-#: src/PrefsUnifiedDlg.cpp:1403
+#: src/PrefsUnifiedDlg.cpp:1329
 msgid ""
 "Kad will not start if your UDP port is disabled.\n"
 "Enable UDP port or disable Kad."
@@ -5872,7 +5824,7 @@ msgstr ""
 "Kad ei saa käivitada kuni UDP port on väljalülitatud.\n"
 "Lülita UDP port sisse, või Kad välja."
 
-#: src/PrefsUnifiedDlg.cpp:1459
+#: src/PrefsUnifiedDlg.cpp:1385
 msgid ""
 "\n"
 "You MUST restart aMule now.\n"
@@ -5882,69 +5834,69 @@ msgstr ""
 "Sa PEAD aMule nüüd taaskäivitama.\n"
 "Kui sa seda ei tee siis ära tänita kui midagi paha juhtub.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1524
+#: src/PrefsUnifiedDlg.cpp:1450
 msgid "Could not register aMule for autostart at login. The autostart store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1526
+#: src/PrefsUnifiedDlg.cpp:1452
 msgid "Could not remove the autostart-at-login entry."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1527
+#: src/PrefsUnifiedDlg.cpp:1453
 #, fuzzy
 msgid "Autostart"
 msgstr "Automaatne värskendamine on käivitatud"
 
-#: src/PrefsUnifiedDlg.cpp:1542
+#: src/PrefsUnifiedDlg.cpp:1468
 msgid "Register file type"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1542
+#: src/PrefsUnifiedDlg.cpp:1468
 msgid "Register URL handler"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1550
+#: src/PrefsUnifiedDlg.cpp:1476
 #, c-format
 msgid "aMule only handles eD2k-compatible magnets. If you replace the current magnet handler (%s), BitTorrent magnet links will stop working - aMule cannot download BitTorrent content. Continue?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1555
+#: src/PrefsUnifiedDlg.cpp:1481
 #, c-format
 msgid "Another application currently opens .emulecollection files (%s). Replace it with aMule?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1560
+#: src/PrefsUnifiedDlg.cpp:1486
 #, c-format
 msgid "Another application is currently the default handler for these links (%s). Replace it with aMule?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1585
+#: src/PrefsUnifiedDlg.cpp:1511
 msgid "Could not register aMule for .emulecollection files. The registration store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1587
+#: src/PrefsUnifiedDlg.cpp:1513
 #, fuzzy
 msgid "Could not remove the file type registration."
 msgstr "Ajutiste tõmmatavate failide kataloog"
 
-#: src/PrefsUnifiedDlg.cpp:1589
+#: src/PrefsUnifiedDlg.cpp:1515
 msgid "Could not register aMule as the URL handler. The registration store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1591
+#: src/PrefsUnifiedDlg.cpp:1517
 msgid "Could not remove the URL handler registration."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1661 src/PrefsUnifiedDlg.cpp:1688
+#: src/PrefsUnifiedDlg.cpp:1587 src/PrefsUnifiedDlg.cpp:1614
 #, fuzzy
 msgid "The web server and aMule API require external connections to be enabled."
 msgstr "Parool on määratud ja välised ühendused võimalikud."
 
-#: src/PrefsUnifiedDlg.cpp:1671
+#: src/PrefsUnifiedDlg.cpp:1597
 msgid "The aMule web server is deprecated. Consider running the aMule API instead."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1735
+#: src/PrefsUnifiedDlg.cpp:1655
 msgid ""
 "Your Auto-update servers list is in blank.\n"
 "Please fill in at least one URL to point to a valid server.met file.\n"
@@ -5954,66 +5906,66 @@ msgstr ""
 "Palun sisesta vähemalt üks server.met faili asukoha kehtiv URL.\n"
 "URL sisestamiseks kliki nupule 'Loend'."
 
-#: src/PrefsUnifiedDlg.cpp:1876
+#: src/PrefsUnifiedDlg.cpp:1796
 msgid "Temporary files"
 msgstr "Ajutised failid"
 
-#: src/PrefsUnifiedDlg.cpp:1881
+#: src/PrefsUnifiedDlg.cpp:1801
 msgid "Incoming files"
 msgstr "Saabuvad failid"
 
-#: src/PrefsUnifiedDlg.cpp:1886
+#: src/PrefsUnifiedDlg.cpp:1806
 msgid "Online Signatures"
 msgstr "Online Allkirjad"
 
-#: src/PrefsUnifiedDlg.cpp:1899
+#: src/PrefsUnifiedDlg.cpp:1819
 #, c-format
 msgid "Choose a folder for %s"
 msgstr "Vali %s kataloog"
 
-#: src/PrefsUnifiedDlg.cpp:1923
+#: src/PrefsUnifiedDlg.cpp:1843
 #, fuzzy, c-format
 msgid "Would exclude %u of %u shared file"
 msgid_plural "Would exclude %u of %u shared files"
 msgstr[0] "Leitud %i tuntud ja jagatud faili"
 msgstr[1] "Leitud %i tuntud ja jagatud faili."
 
-#: src/PrefsUnifiedDlg.cpp:1940
+#: src/PrefsUnifiedDlg.cpp:1860
 msgid "Browse for videoplayer"
 msgstr "Otsi filmi taasesitamise programmi"
 
-#: src/PrefsUnifiedDlg.cpp:1944
+#: src/PrefsUnifiedDlg.cpp:1864
 msgid "Select browser"
 msgstr "Vali lehitseja (browser)"
 
-#: src/PrefsUnifiedDlg.cpp:1948
+#: src/PrefsUnifiedDlg.cpp:1868
 #, fuzzy
 msgid "Select ffprobe binary"
 msgstr "Vali lehitseja (browser)"
 
-#: src/PrefsUnifiedDlg.cpp:1954
+#: src/PrefsUnifiedDlg.cpp:1874
 #, c-format
 msgid "Executable%s"
 msgstr "Käivitusprogramm%s"
 
-#: src/PrefsUnifiedDlg.cpp:1988
+#: src/PrefsUnifiedDlg.cpp:1908
 msgid "ffprobe not found on PATH or in the standard install locations. Install ffmpeg (which ships ffprobe) or use Browse to pick a binary manually."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2000
+#: src/PrefsUnifiedDlg.cpp:1920
 msgid "Reset the settings on this page to their default values?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2001
+#: src/PrefsUnifiedDlg.cpp:1921
 #, fuzzy
 msgid "Reset to defaults"
 msgstr "Süsteemi vaikeväärtus"
 
-#: src/PrefsUnifiedDlg.cpp:2028
+#: src/PrefsUnifiedDlg.cpp:1948
 msgid "Edit server list"
 msgstr "Muuda serverite nimekirja"
 
-#: src/PrefsUnifiedDlg.cpp:2029
+#: src/PrefsUnifiedDlg.cpp:1949
 msgid ""
 "Add here URL's to download server.met files.\n"
 "Only one url on each line."
@@ -6021,180 +5973,176 @@ msgstr ""
 "Lisa siia server.met faili(de) laadimise URL.\n"
 "Üks URL rea kohta."
 
-#: src/PrefsUnifiedDlg.cpp:2084
+#: src/PrefsUnifiedDlg.cpp:2004
 msgid "IP2Country update failed"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2229 src/PrefsUnifiedDlg.cpp:2260
+#: src/PrefsUnifiedDlg.cpp:2149 src/PrefsUnifiedDlg.cpp:2180
 msgid "Data by MaxMind GeoLite2"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2231 src/PrefsUnifiedDlg.cpp:2262
+#: src/PrefsUnifiedDlg.cpp:2151 src/PrefsUnifiedDlg.cpp:2182
 #, fuzzy
 msgid "Custom source"
 msgstr "Täielikke allikaid"
 
-#: src/PrefsUnifiedDlg.cpp:2233 src/PrefsUnifiedDlg.cpp:2264
+#: src/PrefsUnifiedDlg.cpp:2153 src/PrefsUnifiedDlg.cpp:2184
 msgid "Data by DB-IP.com"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2284
+#: src/PrefsUnifiedDlg.cpp:2204
 #, fuzzy, c-format
 msgid "Status: Loaded%s"
 msgstr "Olek:"
 
-#: src/PrefsUnifiedDlg.cpp:2286
+#: src/PrefsUnifiedDlg.cpp:2206
 #, fuzzy, c-format
 msgid "Status: Loaded%s - %s"
 msgstr "Olek:"
 
-#: src/PrefsUnifiedDlg.cpp:2290
+#: src/PrefsUnifiedDlg.cpp:2210
 msgid "Status: Failed to load - click 'Update now' to refresh."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2292
+#: src/PrefsUnifiedDlg.cpp:2212
 msgid "Status: Not found - click 'Update now' to download."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2350 src/PrefsUnifiedDlg.cpp:2374
+#: src/PrefsUnifiedDlg.cpp:2270 src/PrefsUnifiedDlg.cpp:2294
 #, c-format
 msgid "Update delay: %d second"
 msgid_plural "Update delay: %d seconds"
 msgstr[0] "Värskenduse viide: %d sekundit"
 msgstr[1] "Värskenduse viide: %d sekundit"
 
-#: src/PrefsUnifiedDlg.cpp:2358
+#: src/PrefsUnifiedDlg.cpp:2278
 #, c-format
 msgid "Time for average graph: %d minute"
 msgid_plural "Time for average graph: %d minutes"
 msgstr[0] "Keskmiste graafiku aeg: %d minutit"
 msgstr[1] "Keskmiste graafiku aeg: %d  minutit"
 
-#: src/PrefsUnifiedDlg.cpp:2367
+#: src/PrefsUnifiedDlg.cpp:2287
 #, c-format
 msgid "Connections Graph Scale: %d"
 msgstr "Ühenduse graafiku skaala: %d"
 
-#: src/PrefsUnifiedDlg.cpp:2382
+#: src/PrefsUnifiedDlg.cpp:2302
 #, c-format
 msgid "File Buffer Size: %d byte"
 msgid_plural "File Buffer Size: %d bytes"
 msgstr[0] "Failipuhvri suurus: %d baiti"
 msgstr[1] "Failipuhvri suurus: %d baiti"
 
-#: src/PrefsUnifiedDlg.cpp:2392
+#: src/PrefsUnifiedDlg.cpp:2312
 #, c-format
 msgid "Upload Queue Size: %d client"
 msgid_plural "Upload Queue Size: %d clients"
 msgstr[0] "Saatmise Saba suurus: %d klienti"
 msgstr[1] "Saatmise Saba suurus: %d klienti"
 
-#: src/PrefsUnifiedDlg.cpp:2402
+#: src/PrefsUnifiedDlg.cpp:2322
 #, c-format
 msgid "Server connection refresh interval: %d minute"
 msgid_plural "Server connection refresh interval: %d minutes"
 msgstr[0] "Serveri ühenduse värskendamise intervall: %d minutit"
 msgstr[1] "Serveri ühenduse värskendamise intervall: %d minutit"
 
-#: src/PrefsUnifiedDlg.cpp:2407
+#: src/PrefsUnifiedDlg.cpp:2327
 msgid "Server connection refresh interval: Disabled"
 msgstr "Serveri ühenduse värskendamise intervall: Ei kasuta"
 
-#: src/PrefsUnifiedDlg.cpp:2451
+#: src/PrefsUnifiedDlg.cpp:2371
 msgid "disabled"
 msgstr "keelatud"
 
-#: src/PrefsUnifiedDlg.cpp:2477
+#: src/PrefsUnifiedDlg.cpp:2397
 #, c-format
 msgid "Execute command on '%s' event"
 msgstr "Käivita käsk peale '%s' sündmust"
 
-#: src/PrefsUnifiedDlg.cpp:2484
+#: src/PrefsUnifiedDlg.cpp:2404
 msgid "Enable command execution on core"
 msgstr "Luba käskude käivitamine tuumas"
 
-#: src/PrefsUnifiedDlg.cpp:2496
+#: src/PrefsUnifiedDlg.cpp:2416
 msgid "Core command:"
 msgstr "Tuumkäsk:"
 
-#: src/PrefsUnifiedDlg.cpp:2512
+#: src/PrefsUnifiedDlg.cpp:2432
 msgid "Enable command execution on GUI"
 msgstr "Luba käskude käivitamine GUI's"
 
-#: src/PrefsUnifiedDlg.cpp:2524
+#: src/PrefsUnifiedDlg.cpp:2444
 msgid "GUI command:"
 msgstr "GUI Käsk:"
 
-#: src/PrefsUnifiedDlg.cpp:2540
+#: src/PrefsUnifiedDlg.cpp:2460
 msgid "The following variables will be replaced:"
 msgstr "Järgnevad muutujad asendatakse:"
 
-#: src/PrefsUnifiedDlg.cpp:2708
+#: src/PrefsUnifiedDlg.cpp:2628
 msgid ""
 "The following folders look like system or sensitive locations:\n"
 "\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2713
+#: src/PrefsUnifiedDlg.cpp:2633
 msgid "Sharing them recursively will publish every file underneath on the eD2k/Kad networks. Do you really want to do this?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2716
+#: src/PrefsUnifiedDlg.cpp:2636
 #, fuzzy
 msgid "Confirm shared folders"
 msgstr "Jagatud kataloogid"
 
-#: src/PrefsUnifiedDlg.cpp:2744
+#: src/PrefsUnifiedDlg.cpp:2664
 #, fuzzy
 msgid "Reloading shared files..."
 msgstr "Lae oma jagatud failid uuesti"
 
-#: src/PrefsUnifiedDlg.cpp:2745
+#: src/PrefsUnifiedDlg.cpp:2665
 msgid "Scanning for subdirectories..."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2746
+#: src/PrefsUnifiedDlg.cpp:2666
 #, fuzzy
 msgid "Updating shared folders"
 msgstr "Jagatud kataloogid"
 
-#: src/PrefsUnifiedDlg.cpp:2773
+#: src/PrefsUnifiedDlg.cpp:2693
 #, c-format
 msgid "Scanned %u directories..."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2823
+#: src/PrefsUnifiedDlg.cpp:2743
 #, fuzzy, c-format
 msgid "Reloading shared files: %u files scanned"
 msgstr "Jagatud failide loetelu taaslaadimine."
 
-#: src/PrefsUnifiedDlg.cpp:2873
+#: src/PrefsUnifiedDlg.cpp:2793
 #, fuzzy
 msgid "Shared folder"
 msgstr "Jagatud kataloogid"
 
-#: src/SearchDlg.cpp:280
-msgid "Clear search history"
-msgstr ""
-
-#: src/SearchDlg.cpp:584
+#: src/SearchDlg.cpp:425
 msgid "It's impossible to search when both eD2k and Kademlia are disabled."
 msgstr ""
 
-#: src/SearchDlg.cpp:585 src/SearchListCtrl.cpp:858
+#: src/SearchDlg.cpp:426 src/SearchListCtrl.cpp:858
 #, fuzzy
 msgid "Search error"
 msgstr "Otsingud"
 
-#: src/SearchDlg.cpp:929
+#: src/SearchDlg.cpp:768
 msgid "Min size must be smaller than max size. Max size ignored."
 msgstr "Min suurus peab olema väiksem kui max suurus. Ignoreerin Max suurust."
 
-#: src/SearchDlg.cpp:930 src/SearchDlg.cpp:1012
+#: src/SearchDlg.cpp:769 src/SearchDlg.cpp:851
 msgid "Search warning"
 msgstr "Otsingu hoiatus"
 
-#: src/SearchDlg.cpp:1092 src/SearchListCtrl.cpp:735
+#: src/SearchDlg.cpp:929 src/SearchListCtrl.cpp:735
 msgid "Main"
 msgstr "Peamine"
 

--- a/po/et_EE.po
+++ b/po/et_EE.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-28 08:06+0200\n"
+"POT-Creation-Date: 2026-07-28 10:19+0200\n"
 "PO-Revision-Date: 2026-07-27 11:36+0000\n"
 "Last-Translator: \n"
 "Language-Team: Estonian <kde-i18n-doc@kde.org>\n"
@@ -145,7 +145,7 @@ msgstr ""
 msgid "Not now"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:422 src/amuleDlg.cpp:600
+#: src/AppImageIntegration.cpp:422 src/amuleDlg.cpp:665
 msgid "Don't ask again"
 msgstr ""
 
@@ -218,7 +218,7 @@ msgid "Killing amuleweb instance with pid '%d' ... "
 msgstr "Mõrvan amuleweb tegelase, protsessi id '%d' ... "
 
 #: src/amule.cpp:336 src/amule.cpp:349 src/ClientRef.cpp:180
-#: src/SearchDlg.cpp:880 src/ServerListCtrl.cpp:98
+#: src/SearchDlg.cpp:1041 src/ServerListCtrl.cpp:98
 msgid "Failed"
 msgstr "Nurjunud"
 
@@ -574,30 +574,68 @@ msgstr "Ei suuda luua PID faili"
 msgid "ERROR: %s"
 msgstr "VIGA: %s"
 
-#: src/amuleDlg.cpp:236
+#: src/amuleDlg.cpp:250
 #, c-format
 msgid "This is aMule %s based on eMule."
 msgstr "See on eMulel põhinev aMule %s."
 
-#: src/amuleDlg.cpp:237
+#: src/amuleDlg.cpp:251
 #, c-format
 msgid "Running on %s"
 msgstr "Jookseb %s peal"
 
-#: src/amuleDlg.cpp:239
+#: src/amuleDlg.cpp:253
 msgid "Visit https://github.com/amule-org/amule/releases/latest to check if a new version is available."
 msgstr "Külasta https://github.com/amule-org/amule/releases/latest ja vaata ehk on uuem versioon saadaval."
 
-#: src/amuleDlg.cpp:268
+#: src/amuleDlg.cpp:282
 msgid "FATAL ERROR: Failed to create Timer"
 msgstr "Fataalne VIGA: Ei suutnud luua stopperit."
 
-#: src/amuleDlg.cpp:592
+#: src/amuleDlg.cpp:361 src/amuleDlg.cpp:1787 src/amuleDlg.cpp:2033
+#: src/muuli_wdr.cpp:1492 src/muuli_wdr.cpp:3418
+msgid "Networks"
+msgstr "Võrgud"
+
+#: src/amuleDlg.cpp:362 src/amuleDlg.cpp:1793 src/muuli_wdr.cpp:3419
+msgid "Searches"
+msgstr "Otsingud"
+
+#: src/amuleDlg.cpp:363 src/amuleDlg.cpp:1799 src/DownloadListCtrl.cpp:740
+#: src/muuli_wdr.cpp:392 src/muuli_wdr.cpp:1585 src/muuli_wdr.cpp:3420
+#: src/Statistics.cpp:829
+msgid "Downloads"
+msgstr "Tõmbamised"
+
+#: src/amuleDlg.cpp:364 src/amuleDlg.cpp:1805 src/muuli_wdr.cpp:3294
+msgid "Shared files"
+msgstr "Jagatud failid"
+
+#: src/amuleDlg.cpp:365 src/amuleDlg.cpp:1811 src/muuli_wdr.cpp:2926
+#: src/muuli_wdr.cpp:3376 src/muuli_wdr.cpp:3423
+msgid "Messages"
+msgstr "Teated"
+
+#: src/amuleDlg.cpp:366 src/amuleDlg.cpp:1817 src/muuli_wdr.cpp:3424
+#: src/PrefsUnifiedDlg.cpp:312 src/Statistics.cpp:779 src/Statistics.cpp:1235
+msgid "Statistics"
+msgstr "Statistika"
+
+#: src/amuleDlg.cpp:368 src/amuleDlg.cpp:1824 src/muuli_wdr.cpp:3426
+#: src/PrefsUnifiedDlg.cpp:328 src/utils/wxCas/src/wxcasprefs.cpp:39
+msgid "Preferences"
+msgstr "Seaded"
+
+#: src/amuleDlg.cpp:371
+msgid "Navigate"
+msgstr ""
+
+#: src/amuleDlg.cpp:657
 #, fuzzy
 msgid "New version available"
 msgstr "Info puudub"
 
-#: src/amuleDlg.cpp:596
+#: src/amuleDlg.cpp:661
 #, fuzzy, c-format
 msgid ""
 "A new version of aMule (%s) is available.\n"
@@ -607,218 +645,185 @@ msgid ""
 "Would you like to open the download page?"
 msgstr "Uuema aMule versiooni saad alati aadressilt https://github.com/amule-org/amule/releases/latest"
 
-#: src/amuleDlg.cpp:678
+#: src/amuleDlg.cpp:743
 msgid "aMule dialog destroyed"
 msgstr "aMule dialoog hävitatud"
 
-#: src/amuleDlg.cpp:701 src/DataToText.cpp:68 src/IPFilter.cpp:547
+#: src/amuleDlg.cpp:766 src/DataToText.cpp:68 src/IPFilter.cpp:547
 msgid "Connecting"
 msgstr "Ühendun"
 
-#: src/amuleDlg.cpp:893
+#: src/amuleDlg.cpp:958
 msgid "eD2k: Connecting"
 msgstr "eD2k: Ühendun"
 
-#: src/amuleDlg.cpp:897
+#: src/amuleDlg.cpp:962
 msgid "eD2k: Disconnected"
 msgstr "eD2k: Lahutatud"
 
-#: src/amuleDlg.cpp:903
+#: src/amuleDlg.cpp:968
 msgid "Kad: Firewalled"
 msgstr "Kad: Tulemüüriga"
 
-#: src/amuleDlg.cpp:907
+#: src/amuleDlg.cpp:972
 msgid "Kad: Connected"
 msgstr "Kad: Ühendatud"
 
-#: src/amuleDlg.cpp:912
+#: src/amuleDlg.cpp:977
 msgid "Kad: Connecting"
 msgstr "Kad: Ühendun"
 
-#: src/amuleDlg.cpp:916
+#: src/amuleDlg.cpp:981
 msgid "Kad: Off"
 msgstr "Kad: Väljas"
 
-#: src/amuleDlg.cpp:964 src/DownloadListCtrl.cpp:505
+#: src/amuleDlg.cpp:1029 src/DownloadListCtrl.cpp:505
 #: src/DownloadListCtrl.cpp:749 src/FriendListCtrl.cpp:180
 #: src/muuli_wdr.cpp:731 src/muuli_wdr.cpp:782 src/muuli_wdr.cpp:846
-#: src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2224 src/muuli_wdr.cpp:2309
-#: src/muuli_wdr.cpp:3057 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
+#: src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2231 src/muuli_wdr.cpp:2316
+#: src/muuli_wdr.cpp:3064 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
 #: src/ServerListCtrl.cpp:606 src/TransferWnd.cpp:378
 #: src/utils/wxCas/src/wxcasprefs.cpp:235
 msgid "Cancel"
 msgstr "Loobu"
 
-#: src/amuleDlg.cpp:965
+#: src/amuleDlg.cpp:1030
 msgid "Stop the current connection attempts"
 msgstr "Lõpeta käimasolevad ühenduskatsed"
 
-#: src/amuleDlg.cpp:970 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976
-#: src/muuli_wdr.cpp:2447
+#: src/amuleDlg.cpp:1035 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976
+#: src/muuli_wdr.cpp:2454
 msgid "Disconnect"
 msgstr "Ühendu lahti"
 
-#: src/amuleDlg.cpp:971
+#: src/amuleDlg.cpp:1036
 msgid "Disconnect from the currently connected networks"
 msgstr "Lõpeta ühendus ühendatud võrkudega"
 
-#: src/amuleDlg.cpp:976 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979
-#: src/muuli_wdr.cpp:2602 src/muuli_wdr.cpp:3054 src/muuli_wdr.cpp:3409
+#: src/amuleDlg.cpp:1041 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979
+#: src/muuli_wdr.cpp:2609 src/muuli_wdr.cpp:3061 src/muuli_wdr.cpp:3416
 msgid "Connect"
 msgstr "Ühenda"
 
-#: src/amuleDlg.cpp:977
+#: src/amuleDlg.cpp:1042
 msgid "Connect to the currently enabled networks"
 msgstr "Ühendu olemasolevate, aktiivsete võrkudega"
 
-#: src/amuleDlg.cpp:1089
+#: src/amuleDlg.cpp:1154
 #, fuzzy, c-format
 msgid "Up: %.1f%s (%.1f) | Down: %.1f%s (%.1f)"
 msgstr "Üles: %.1f(%.1f) | Alla: %.1f(%.1f)"
 
-#: src/amuleDlg.cpp:1091 src/amuleDlg.cpp:1093 src/amuleDlg.cpp:1097
-#: src/amuleDlg.cpp:1099 src/amuleDlg.cpp:1110 src/amuleDlg.cpp:1112
+#: src/amuleDlg.cpp:1156 src/amuleDlg.cpp:1158 src/amuleDlg.cpp:1162
+#: src/amuleDlg.cpp:1164 src/amuleDlg.cpp:1175 src/amuleDlg.cpp:1177
 #: src/MuleTrayIcon.cpp:796 src/MuleTrayIcon.cpp:799
 #, fuzzy
 msgid " MB/s"
 msgstr "MB/s"
 
-#: src/amuleDlg.cpp:1091 src/amuleDlg.cpp:1093 src/amuleDlg.cpp:1097
-#: src/amuleDlg.cpp:1099 src/amuleDlg.cpp:1110 src/amuleDlg.cpp:1112
+#: src/amuleDlg.cpp:1156 src/amuleDlg.cpp:1158 src/amuleDlg.cpp:1162
+#: src/amuleDlg.cpp:1164 src/amuleDlg.cpp:1175 src/amuleDlg.cpp:1177
 #: src/MuleTrayIcon.cpp:796 src/MuleTrayIcon.cpp:799
 #: src/utils/wxCas/src/wxcasframe.cpp:1041
 msgid " kB/s"
 msgstr " kB/s"
 
-#: src/amuleDlg.cpp:1096
+#: src/amuleDlg.cpp:1161
 #, fuzzy, c-format
 msgid "Up: %.1f%s | Down: %.1f%s"
 msgstr "Üles: %.1f | Alla: %.1f"
 
-#: src/amuleDlg.cpp:1128
+#: src/amuleDlg.cpp:1193
 #, c-format
 msgid "aMule (%s | Connected)"
 msgstr "aMule (%s | Ühendatud)"
 
-#: src/amuleDlg.cpp:1130
+#: src/amuleDlg.cpp:1195
 #, c-format
 msgid "aMule (%s | Disconnected)"
 msgstr "aMule (%s | Ühenduseta)"
 
-#: src/amuleDlg.cpp:1183
+#: src/amuleDlg.cpp:1248
 #, c-format
 msgid "Do you really want to exit %s?"
 msgstr "Kas sa tõesti tahad %s'st väljuda?"
 
-#: src/amuleDlg.cpp:1185
+#: src/amuleDlg.cpp:1250
 msgid "Exit confirmation"
 msgstr "Kinnitan väljumise"
 
-#: src/amuleDlg.cpp:1548
+#: src/amuleDlg.cpp:1613
 msgid "Launch Command: "
 msgstr "Käivitamise korraldus: "
 
-#: src/amuleDlg.cpp:1567 src/muuli_wdr.cpp:1971 src/Preferences.cpp:951
+#: src/amuleDlg.cpp:1632 src/muuli_wdr.cpp:1978 src/Preferences.cpp:952
 msgid "- default -"
 msgstr "- vaikimisi -"
 
-#: src/amuleDlg.cpp:1595
+#: src/amuleDlg.cpp:1660
 #, c-format
 msgid "Skin directory '%s' does not exist"
 msgstr "Rüüde kataloogi  '%s' ei eksiteeri"
 
-#: src/amuleDlg.cpp:1598
+#: src/amuleDlg.cpp:1663
 #, c-format
 msgid "WARNING: Unable to open skin file '%s' for read"
 msgstr "HOIATUS: Ei suuda rüüfaili '%s' lugemiseks avada"
 
-#: src/amuleDlg.cpp:1722 src/amuleDlg.cpp:1968 src/muuli_wdr.cpp:1485
-#: src/muuli_wdr.cpp:3411
-msgid "Networks"
-msgstr "Võrgud"
-
-#: src/amuleDlg.cpp:1726 src/muuli_wdr.cpp:3411
+#: src/amuleDlg.cpp:1791 src/muuli_wdr.cpp:3418
 msgid "Networks Window"
 msgstr "Võrgud"
 
-#: src/amuleDlg.cpp:1728 src/muuli_wdr.cpp:3412
-msgid "Searches"
-msgstr "Otsingud"
-
-#: src/amuleDlg.cpp:1732 src/muuli_wdr.cpp:3412
+#: src/amuleDlg.cpp:1797 src/muuli_wdr.cpp:3419
 msgid "Searches Window"
 msgstr "Otsingu aken"
 
-#: src/amuleDlg.cpp:1734 src/DownloadListCtrl.cpp:740 src/muuli_wdr.cpp:392
-#: src/muuli_wdr.cpp:1578 src/muuli_wdr.cpp:3413 src/Statistics.cpp:829
-msgid "Downloads"
-msgstr "Tõmbamised"
-
-#: src/amuleDlg.cpp:1738 src/muuli_wdr.cpp:3413
+#: src/amuleDlg.cpp:1803 src/muuli_wdr.cpp:3420
 msgid "Downloads Window"
 msgstr "Tõmbamised"
 
-#: src/amuleDlg.cpp:1740 src/muuli_wdr.cpp:3287
-msgid "Shared files"
-msgstr "Jagatud failid"
-
-#: src/amuleDlg.cpp:1744 src/muuli_wdr.cpp:3415
+#: src/amuleDlg.cpp:1809 src/muuli_wdr.cpp:3422
 msgid "Shared Files Window"
 msgstr "Jagatud failide Aken"
 
-#: src/amuleDlg.cpp:1746 src/muuli_wdr.cpp:2919 src/muuli_wdr.cpp:3369
-#: src/muuli_wdr.cpp:3416
-msgid "Messages"
-msgstr "Teated"
-
-#: src/amuleDlg.cpp:1750 src/muuli_wdr.cpp:3416
+#: src/amuleDlg.cpp:1815 src/muuli_wdr.cpp:3423
 msgid "Messages Window"
 msgstr "Teadete Aken"
 
-#: src/amuleDlg.cpp:1752 src/muuli_wdr.cpp:3417 src/PrefsUnifiedDlg.cpp:312
-#: src/Statistics.cpp:779 src/Statistics.cpp:1235
-msgid "Statistics"
-msgstr "Statistika"
-
-#: src/amuleDlg.cpp:1756 src/muuli_wdr.cpp:3417
+#: src/amuleDlg.cpp:1821 src/muuli_wdr.cpp:3424
 msgid "Statistics Graph Window"
 msgstr "Statistiliste graafikute aken"
 
-#: src/amuleDlg.cpp:1759 src/muuli_wdr.cpp:3419 src/PrefsUnifiedDlg.cpp:328
-#: src/utils/wxCas/src/wxcasprefs.cpp:39
-msgid "Preferences"
-msgstr "Seaded"
-
-#: src/amuleDlg.cpp:1763 src/muuli_wdr.cpp:3419
+#: src/amuleDlg.cpp:1828 src/muuli_wdr.cpp:3426
 msgid "Preferences Settings Window"
 msgstr "Seadete aken"
 
-#: src/amuleDlg.cpp:1766 src/muuli_wdr.cpp:3420
+#: src/amuleDlg.cpp:1831 src/muuli_wdr.cpp:3427
 msgid "Import"
 msgstr "Impordi"
 
-#: src/amuleDlg.cpp:1770 src/muuli_wdr.cpp:3420
+#: src/amuleDlg.cpp:1835 src/muuli_wdr.cpp:3427
 msgid "The partfile importer tool"
 msgstr "Osafailide importimise tööriist"
 
-#: src/amuleDlg.cpp:1773 src/muuli_wdr.cpp:3421
+#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3428
 #: src/utils/aLinkCreator/src/alcframe.cpp:262
 msgid "About"
 msgstr "Info"
 
-#: src/amuleDlg.cpp:1773 src/muuli_wdr.cpp:3421
+#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3428
 msgid "About/Help"
 msgstr "Info/Appi"
 
-#: src/amuleDlg.cpp:1971
+#: src/amuleDlg.cpp:2036
 msgid "eD2k network"
 msgstr "eD2k võrk"
 
-#: src/amuleDlg.cpp:1974
+#: src/amuleDlg.cpp:2039
 msgid "Kad network"
 msgstr "Kad võrk"
 
-#: src/amuleDlg.cpp:1974
+#: src/amuleDlg.cpp:2039
 msgid "No network"
 msgstr "Võrk puudub"
 
@@ -1351,19 +1356,19 @@ msgstr "Auto [Kõrge]"
 msgid "Very low"
 msgstr "Väga madal"
 
-#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:743 src/muuli_wdr.cpp:2275
+#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:743 src/muuli_wdr.cpp:2282
 #: src/ServerListCtrl.cpp:263 src/ServerListCtrl.cpp:456
 #: src/SharedFilesCtrl.cpp:145
 msgid "Low"
 msgstr "Madal"
 
-#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:744 src/muuli_wdr.cpp:2276
+#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:744 src/muuli_wdr.cpp:2283
 #: src/ServerListCtrl.cpp:266 src/ServerListCtrl.cpp:457
 #: src/SharedFilesCtrl.cpp:146
 msgid "Normal"
 msgstr "Keskmine"
 
-#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:745 src/muuli_wdr.cpp:2277
+#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:745 src/muuli_wdr.cpp:2284
 #: src/ServerListCtrl.cpp:269 src/ServerListCtrl.cpp:458
 #: src/SharedFilesCtrl.cpp:147
 msgid "High"
@@ -1455,8 +1460,8 @@ msgstr "Kohalik server"
 msgid "Remote Server"
 msgstr "Kaug server"
 
-#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3174
-#: src/SearchDlg.cpp:111 src/TextClient.cpp:911
+#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3181
+#: src/SearchDlg.cpp:119 src/TextClient.cpp:911
 msgid "Kad"
 msgstr "Kad"
 
@@ -1527,7 +1532,7 @@ msgstr "Osa"
 msgid "Size"
 msgstr "Suurus"
 
-#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3241
+#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3248
 msgid "Transferred"
 msgstr "Siiratud"
 
@@ -1585,7 +1590,7 @@ msgstr ""
 "Tagasiside : %s (%s)\n"
 "\n"
 
-#: src/DownloadListCtrl.cpp:746 src/muuli_wdr.cpp:2278
+#: src/DownloadListCtrl.cpp:746 src/muuli_wdr.cpp:2285
 #: src/SharedFilesCtrl.cpp:150
 msgid "Auto"
 msgstr "Auto"
@@ -1623,7 +1628,7 @@ msgid "Extended Options"
 msgstr "Laiendatud valikud"
 
 #: src/DownloadListCtrl.cpp:770 src/DownloadListCtrl.cpp:822
-#: src/muuli_wdr.cpp:1789
+#: src/muuli_wdr.cpp:1796
 msgid "Preview"
 msgstr "Eelvaade"
 
@@ -2334,19 +2339,19 @@ msgstr ""
 msgid "eD2k"
 msgstr "eD2k"
 
-#: src/FirstRunWizard.cpp:349 src/muuli_wdr.cpp:1488
+#: src/FirstRunWizard.cpp:349 src/muuli_wdr.cpp:1495
 msgid "Kademlia"
 msgstr "Kademlia"
 
-#: src/FirstRunWizard.cpp:359 src/muuli_wdr.cpp:1416
+#: src/FirstRunWizard.cpp:359 src/muuli_wdr.cpp:1423
 msgid "Standard TCP Port "
 msgstr "Vaikimisi TCP Port "
 
-#: src/FirstRunWizard.cpp:365 src/muuli_wdr.cpp:1428
+#: src/FirstRunWizard.cpp:365 src/muuli_wdr.cpp:1435
 msgid "Extended UDP port (Kad / global search) "
 msgstr "Laiendatud UDP port (Kad / globaalne otsing) "
 
-#: src/FirstRunWizard.cpp:377 src/muuli_wdr.cpp:1435
+#: src/FirstRunWizard.cpp:377 src/muuli_wdr.cpp:1442
 msgid "Enable UPnP for router port forwarding"
 msgstr "Luba UPnP ruuteri portide suunamiseks"
 
@@ -2373,7 +2378,7 @@ msgstr ""
 msgid "Your peer lists are already in place - nothing to download."
 msgstr "Sa juba proovid '%s' faili tõmmata"
 
-#: src/FirstRunWizard.cpp:434 src/muuli_wdr.cpp:1533
+#: src/FirstRunWizard.cpp:434 src/muuli_wdr.cpp:1540
 msgid "Auto-update server list at startup"
 msgstr "Käivitamisel värskenda automaatselt serverite nimekirja"
 
@@ -2419,23 +2424,23 @@ msgid ""
 "want downloads on a different (e.g. larger) disk."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:549 src/FirstRunWizard.cpp:611 src/muuli_wdr.cpp:1701
+#: src/FirstRunWizard.cpp:549 src/FirstRunWizard.cpp:611 src/muuli_wdr.cpp:1708
 msgid "Destination folder for downloads"
 msgstr "Tõmmatavate failide kataloog"
 
-#: src/FirstRunWizard.cpp:553 src/FirstRunWizard.cpp:569 src/muuli_wdr.cpp:1342
-#: src/muuli_wdr.cpp:1359 src/muuli_wdr.cpp:1676 src/muuli_wdr.cpp:1707
-#: src/muuli_wdr.cpp:1719 src/muuli_wdr.cpp:2762
+#: src/FirstRunWizard.cpp:553 src/FirstRunWizard.cpp:569 src/muuli_wdr.cpp:1349
+#: src/muuli_wdr.cpp:1366 src/muuli_wdr.cpp:1683 src/muuli_wdr.cpp:1714
+#: src/muuli_wdr.cpp:1726 src/muuli_wdr.cpp:2769
 #: src/utils/aLinkCreator/src/alcframe.cpp:135
 #: src/utils/wxCas/src/wxcasprefs.cpp:52 src/utils/wxCas/src/wxcasprefs.cpp:118
 msgid "Browse"
 msgstr "Lehitse"
 
-#: src/FirstRunWizard.cpp:559 src/muuli_wdr.cpp:1712
+#: src/FirstRunWizard.cpp:559 src/muuli_wdr.cpp:1719
 msgid "(All files in this folder are shared with other peers)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:565 src/FirstRunWizard.cpp:624 src/muuli_wdr.cpp:1714
+#: src/FirstRunWizard.cpp:565 src/FirstRunWizard.cpp:624 src/muuli_wdr.cpp:1721
 msgid "Folder for temporary download files"
 msgstr "Ajutiste tõmmatavate failide kataloog"
 
@@ -2466,7 +2471,7 @@ msgstr "Sõprade faili 'emfriends.met' avamine kirjutamiseks ebaõnnestus!"
 msgid "CRITICAL - no client on StartChatSession"
 msgstr "KRIITILINE - StartChatSession puudub klient"
 
-#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2668 src/muuli_wdr.cpp:3345
+#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2675 src/muuli_wdr.cpp:3352
 msgid "Friends"
 msgstr "Sõbrad"
 
@@ -2852,7 +2857,7 @@ msgstr "Üles- ja allalaadimise suhe"
 msgid "Uploaded"
 msgstr "Üleslaaditud"
 
-#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3225
+#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3232
 msgid "Requested"
 msgstr "Küsitud"
 
@@ -2976,7 +2981,7 @@ msgid "WARNING: "
 msgstr "HOIATUS: "
 
 #: src/MuleNotebook.cpp:179 src/muuli_wdr.cpp:817 src/muuli_wdr.cpp:1229
-#: src/muuli_wdr.cpp:3129 src/muuli_wdr.cpp:3385
+#: src/muuli_wdr.cpp:3136 src/muuli_wdr.cpp:3392
 msgid "Close"
 msgstr "Sulge"
 
@@ -2989,12 +2994,12 @@ msgstr "Lõika"
 msgid "Copy"
 msgstr "Kopeeri"
 
-#: src/MuleTextCtrl.cpp:88
+#: src/MuleTextCtrl.cpp:88 src/SearchDlg.cpp:261
 msgid "Paste"
 msgstr "Aseta"
 
 #: src/MuleTextCtrl.cpp:89 src/muuli_wdr.cpp:358 src/muuli_wdr.cpp:757
-#: src/muuli_wdr.cpp:2352 src/muuli_wdr.cpp:2371 src/muuli_wdr.cpp:2393
+#: src/muuli_wdr.cpp:2359 src/muuli_wdr.cpp:2378 src/muuli_wdr.cpp:2400
 #: src/utils/aLinkCreator/src/alcframe.cpp:142
 msgid "Clear"
 msgstr "Puhasta"
@@ -3092,8 +3097,8 @@ msgid "Exit"
 msgstr "Välju"
 
 #: src/MuleTrayIcon.cpp:579 src/MuleTrayIcon.cpp:945 src/MuleTrayIcon.cpp:965
-#: src/muuli_wdr.cpp:1391 src/muuli_wdr.cpp:1399 src/muuli_wdr.cpp:1406
-#: src/muuli_wdr.cpp:1835 src/muuli_wdr.cpp:1841 src/OtherFunctions.cpp:91
+#: src/muuli_wdr.cpp:1398 src/muuli_wdr.cpp:1406 src/muuli_wdr.cpp:1413
+#: src/muuli_wdr.cpp:1842 src/muuli_wdr.cpp:1848 src/OtherFunctions.cpp:91
 #: src/StatisticsDlg.cpp:93 src/StatisticsDlg.cpp:95
 msgid "kB/s"
 msgstr "kB/s"
@@ -3264,7 +3269,7 @@ msgstr "Nimi:"
 msgid "Type"
 msgstr "Tüüp"
 
-#: src/muuli_wdr.cpp:215 src/SearchDlg.cpp:110 src/SearchListCtrl.cpp:853
+#: src/muuli_wdr.cpp:215 src/SearchDlg.cpp:118 src/SearchListCtrl.cpp:853
 msgid "Local"
 msgstr "Kohalik"
 
@@ -3335,7 +3340,7 @@ msgstr "Baiti"
 msgid "KB"
 msgstr "KB"
 
-#: src/muuli_wdr.cpp:274 src/muuli_wdr.cpp:293 src/muuli_wdr.cpp:1620
+#: src/muuli_wdr.cpp:274 src/muuli_wdr.cpp:293 src/muuli_wdr.cpp:1627
 #: src/OtherFunctions.cpp:64
 msgid "MB"
 msgstr "MB"
@@ -3352,7 +3357,7 @@ msgstr "Suurim Suurus"
 msgid "Availability"
 msgstr "Saadavus"
 
-#: src/muuli_wdr.cpp:312 src/muuli_wdr.cpp:398 src/muuli_wdr.cpp:3290
+#: src/muuli_wdr.cpp:312 src/muuli_wdr.cpp:398 src/muuli_wdr.cpp:3297
 msgid "Filter:"
 msgstr "Filter:"
 
@@ -3384,7 +3389,7 @@ msgstr ""
 msgid "Stop"
 msgstr "Seiska"
 
-#: src/muuli_wdr.cpp:348 src/muuli_wdr.cpp:1385 src/SearchListCtrl.cpp:732
+#: src/muuli_wdr.cpp:348 src/muuli_wdr.cpp:1392 src/SearchListCtrl.cpp:732
 msgid "Download"
 msgstr "Tõmbamine"
 
@@ -3415,8 +3420,8 @@ msgstr "Faili allikad:"
 #: src/muuli_wdr.cpp:1160 src/muuli_wdr.cpp:1167 src/muuli_wdr.cpp:1172
 #: src/muuli_wdr.cpp:1179 src/muuli_wdr.cpp:1184 src/muuli_wdr.cpp:1191
 #: src/muuli_wdr.cpp:1205 src/muuli_wdr.cpp:1212 src/muuli_wdr.cpp:1217
-#: src/muuli_wdr.cpp:1224 src/muuli_wdr.cpp:3227 src/muuli_wdr.cpp:3235
-#: src/muuli_wdr.cpp:3243
+#: src/muuli_wdr.cpp:1224 src/muuli_wdr.cpp:3234 src/muuli_wdr.cpp:3242
+#: src/muuli_wdr.cpp:3250
 msgid "N/A"
 msgstr "N/A"
 
@@ -3561,7 +3566,7 @@ msgstr ""
 msgid "Album :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:685 src/muuli_wdr.cpp:2247
+#: src/muuli_wdr.cpp:685 src/muuli_wdr.cpp:2254
 msgid "Title :"
 msgstr "Tiitel :"
 
@@ -3670,7 +3675,7 @@ msgstr "Kasutajanimi :"
 msgid "Userhash :"
 msgstr "Kasutaja kontrollsumma :"
 
-#: src/muuli_wdr.cpp:895 src/muuli_wdr.cpp:1741 src/muuli_wdr.cpp:2442
+#: src/muuli_wdr.cpp:895 src/muuli_wdr.cpp:1748 src/muuli_wdr.cpp:2449
 #: src/utils/aLinkCreator/src/alcframe.cpp:137
 msgid "Add"
 msgstr "Lisa"
@@ -3679,15 +3684,15 @@ msgstr "Lisa"
 msgid "Download-Speed"
 msgstr "Tõmbamise kiirus"
 
-#: src/muuli_wdr.cpp:954 src/muuli_wdr.cpp:989 src/muuli_wdr.cpp:2546
+#: src/muuli_wdr.cpp:954 src/muuli_wdr.cpp:989 src/muuli_wdr.cpp:2553
 msgid "Current"
 msgstr "Hetkel"
 
-#: src/muuli_wdr.cpp:962 src/muuli_wdr.cpp:997 src/muuli_wdr.cpp:2554
+#: src/muuli_wdr.cpp:962 src/muuli_wdr.cpp:997 src/muuli_wdr.cpp:2561
 msgid "Running average"
 msgstr "Hetke keskmine"
 
-#: src/muuli_wdr.cpp:970 src/muuli_wdr.cpp:1005 src/muuli_wdr.cpp:2562
+#: src/muuli_wdr.cpp:970 src/muuli_wdr.cpp:1005 src/muuli_wdr.cpp:2569
 msgid "Session average"
 msgstr "Seansi keskmine"
 
@@ -3699,7 +3704,7 @@ msgstr "Saatmise kiirus"
 msgid "Connections"
 msgstr "Ühendused"
 
-#: src/muuli_wdr.cpp:1024 src/muuli_wdr.cpp:1860
+#: src/muuli_wdr.cpp:1024 src/muuli_wdr.cpp:1867
 msgid "Active downloads"
 msgstr "Aktiivsed tõmbamised"
 
@@ -3707,7 +3712,7 @@ msgstr "Aktiivsed tõmbamised"
 msgid "Active connections (1:1)"
 msgstr "Aktiivseid ühendusi (1:1)"
 
-#: src/muuli_wdr.cpp:1040 src/muuli_wdr.cpp:1861
+#: src/muuli_wdr.cpp:1040 src/muuli_wdr.cpp:1868
 msgid "Active uploads"
 msgstr "Aktiivsed saatmised"
 
@@ -3823,8 +3828,8 @@ msgstr "See on see nimi mida teised näevad kui sinuga ühenduvad."
 msgid "Language: "
 msgstr "Keel: "
 
-#: src/muuli_wdr.cpp:1257 src/muuli_wdr.cpp:1323 src/muuli_wdr.cpp:1327
-#: src/muuli_wdr.cpp:1330
+#: src/muuli_wdr.cpp:1257 src/muuli_wdr.cpp:1330 src/muuli_wdr.cpp:1334
+#: src/muuli_wdr.cpp:1337
 msgid "The delay before showing tool-tips."
 msgstr "Abitekstide kuvamise ajaline viide."
 
@@ -3902,937 +3907,946 @@ msgstr ""
 msgid "Enabling this will make aMule to show notifications when finished downloading."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1322
+#: src/muuli_wdr.cpp:1323
+#, fuzzy
+msgid "Remember search history"
+msgstr "Pea need seaded meeles"
+
+#: src/muuli_wdr.cpp:1324
+msgid "Keeps a dropdown list of your past search terms in the Search tab's Name field. This remembers the queries you typed, not the results they returned."
+msgstr ""
+
+#: src/muuli_wdr.cpp:1329
 msgid "Tooltip delay time: "
 msgstr "Abitekstide viide sekundites: "
 
-#: src/muuli_wdr.cpp:1329
+#: src/muuli_wdr.cpp:1336
 msgid "seconds"
 msgstr "sekundit"
 
-#: src/muuli_wdr.cpp:1333
+#: src/muuli_wdr.cpp:1340
 msgid "Browser Selection"
 msgstr "Lehitseja valik"
 
-#: src/muuli_wdr.cpp:1339
+#: src/muuli_wdr.cpp:1346
 msgid "Enter your browser name here. Leave this field empty to use the system default browser."
 msgstr "Sisesta siia lehitsejaprogrammi nimi. Jättes välja tühjaks, kasutab süsteem vaikimisi määratud lehitsejat."
 
-#: src/muuli_wdr.cpp:1346
+#: src/muuli_wdr.cpp:1353
 msgid "Open in new tab if possible"
 msgstr "Võimalusel ava uus sakk"
 
-#: src/muuli_wdr.cpp:1348
+#: src/muuli_wdr.cpp:1355
 msgid "Open the web page in a new tab instead of in a new window when possible"
 msgstr "Ava, kui võimalik, webileht uuel lehel selle asemel et avada uus aken"
 
-#: src/muuli_wdr.cpp:1352
+#: src/muuli_wdr.cpp:1359
 msgid "Video Player"
 msgstr "Video mängija"
 
-#: src/muuli_wdr.cpp:1379
+#: src/muuli_wdr.cpp:1386
 msgid "Bandwidth limits"
 msgstr "Ribalaiuse piirid"
 
-#: src/muuli_wdr.cpp:1393
+#: src/muuli_wdr.cpp:1400
 msgid "Upload"
 msgstr "Saatmine"
 
-#: src/muuli_wdr.cpp:1401
+#: src/muuli_wdr.cpp:1408
 msgid "Slot Allocation"
 msgstr "Määratud pesa"
 
-#: src/muuli_wdr.cpp:1410
+#: src/muuli_wdr.cpp:1417
 msgid "Ports"
 msgstr "Pordid"
 
-#: src/muuli_wdr.cpp:1420
+#: src/muuli_wdr.cpp:1427
 msgid "This is the standard eD2k port and cannot be disabled."
 msgstr "See on eD2k standard port ja seda ei saa välja lülitada."
 
-#: src/muuli_wdr.cpp:1423
+#: src/muuli_wdr.cpp:1430
 msgid "UDP port for server requests (TCP+3):"
 msgstr "UDP port serveri päringute jaoks (TCP+3):"
 
-#: src/muuli_wdr.cpp:1425
+#: src/muuli_wdr.cpp:1432
 msgid "4665"
 msgstr "4665"
 
-#: src/muuli_wdr.cpp:1432
+#: src/muuli_wdr.cpp:1439
 msgid "This UDP port is used for extended eD2k requests and Kad network"
 msgstr "Seda UDP porti kasutatkse laiendatud omadustega eD2k ja Kad võrgu puhul"
 
-#: src/muuli_wdr.cpp:1439
+#: src/muuli_wdr.cpp:1446
 msgid "UPnP TCP Port (Optional):"
 msgstr "UPnp TCP Port (Lisana):"
 
-#: src/muuli_wdr.cpp:1449
+#: src/muuli_wdr.cpp:1456
 msgid "Bind local address to IP (empty for any):"
 msgstr "Seo lokaalne aadress IP'ga (suvaliseks jäta tühjaks)"
 
-#: src/muuli_wdr.cpp:1452
+#: src/muuli_wdr.cpp:1459
 msgid "Advanced users only: If you have multiple network interfaces, enter the address of the interface to which aMule should be bound."
 msgstr "Ainult edasijõudnud kasutajatele: Kui sul on kasutada mitu võrguliidest, siis sisesta selle liidese aadress millega aMule võib ennast siduda."
 
-#: src/muuli_wdr.cpp:1455 src/muuli_wdr.cpp:2054
+#: src/muuli_wdr.cpp:1462 src/muuli_wdr.cpp:2061
 #, fuzzy
 msgid "Bind to network interface (empty for any):"
 msgstr "Seo lokaalne aadress IP'ga (suvaliseks jäta tühjaks)"
 
-#: src/muuli_wdr.cpp:1468
+#: src/muuli_wdr.cpp:1475
 msgid "Advanced users only: pin all of aMule's traffic to one network interface, chosen from the list or typed in by name (e.g. tun0, eth0, en0) or index. Unlike binding to an IP, this stops traffic leaking out via the default route - useful with a VPN. Requires no elevated privileges."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1474
+#: src/muuli_wdr.cpp:1481
 msgid "Max sources per downloading file:"
 msgstr "Maksimaalseid allikaid tõmmatava faili kohta:"
 
-#: src/muuli_wdr.cpp:1478
+#: src/muuli_wdr.cpp:1485
 msgid "Max simultaneous connections:"
 msgstr "Maksimaalselt samaaegseid ühendusi:"
 
-#: src/muuli_wdr.cpp:1491 src/muuli_wdr.cpp:3169
+#: src/muuli_wdr.cpp:1498 src/muuli_wdr.cpp:3176
 msgid "ED2K"
 msgstr "ED2K"
 
-#: src/muuli_wdr.cpp:1498
+#: src/muuli_wdr.cpp:1505
 msgid "Autoconnect on startup"
 msgstr "Automaatne ühendumine käivitumisel"
 
-#: src/muuli_wdr.cpp:1501
+#: src/muuli_wdr.cpp:1508
 msgid "Reconnect on loss"
 msgstr "Ühenduse kadumisel taasta ühendus"
 
-#: src/muuli_wdr.cpp:1523
+#: src/muuli_wdr.cpp:1530
 msgid "Remove dead server after"
 msgstr "Eemalda surnud server peale"
 
-#: src/muuli_wdr.cpp:1524
+#: src/muuli_wdr.cpp:1531
 msgid "Static servers are never removed, even when unreachable."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1528
+#: src/muuli_wdr.cpp:1535
 msgid "retries"
 msgstr "katset"
 
-#: src/muuli_wdr.cpp:1536
+#: src/muuli_wdr.cpp:1543
 msgid "List"
 msgstr "Loend"
 
-#: src/muuli_wdr.cpp:1539
+#: src/muuli_wdr.cpp:1546
 msgid "Update server list when connecting to a server"
 msgstr "Värskenda serverite nimekirja serveriga ühendumisel"
 
-#: src/muuli_wdr.cpp:1542
+#: src/muuli_wdr.cpp:1549
 msgid "Update server list when a client connects"
 msgstr "Värskenda serverite nimekirja kliendi ühendumisel"
 
-#: src/muuli_wdr.cpp:1545
+#: src/muuli_wdr.cpp:1552
 msgid "Use priority system"
 msgstr "Kasuta prioriteedisüsteemi"
 
-#: src/muuli_wdr.cpp:1549
+#: src/muuli_wdr.cpp:1556
 msgid "Use smart LowID check on connect"
 msgstr "Ühendumisel kasuta nutikat LowID kontrolli "
 
-#: src/muuli_wdr.cpp:1553
+#: src/muuli_wdr.cpp:1560
 msgid "Safe connect"
 msgstr "Ohutu ühendumine"
 
-#: src/muuli_wdr.cpp:1557
+#: src/muuli_wdr.cpp:1564
 msgid "Autoconnect to servers in static list only"
 msgstr "Automaatne ühendumine ainult staatilises serverinimekirjas olevate serveritega"
 
-#: src/muuli_wdr.cpp:1560
+#: src/muuli_wdr.cpp:1567
 msgid "Set manually added servers to High Priority"
 msgstr "Määra käsitsi lisatud serveritel Kõrge Prioriteet"
 
-#: src/muuli_wdr.cpp:1581
+#: src/muuli_wdr.cpp:1588
 msgid "Add files to download in pause mode"
 msgstr "Lisa failid tõmbamiseks peatatud olekus"
 
-#: src/muuli_wdr.cpp:1583
+#: src/muuli_wdr.cpp:1590
 msgid "Add files to download with auto priority"
 msgstr "Lisa failid tõmbamiseks automaatse prioriteediga"
 
-#: src/muuli_wdr.cpp:1586
+#: src/muuli_wdr.cpp:1593
 msgid "Try to download first and last chunks first"
 msgstr "Proovi alustuseks tõmmata esimene ja viimane tükk"
 
-#: src/muuli_wdr.cpp:1590
+#: src/muuli_wdr.cpp:1597
 msgid "Endgame mode: rotate to faster sources for the final blocks"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1593
+#: src/muuli_wdr.cpp:1600
 msgid "Start next paused file when a file completes"
 msgstr "Alusta järgmise peatatud failiga, kui fail lõpetab"
 
-#: src/muuli_wdr.cpp:1596
+#: src/muuli_wdr.cpp:1603
 msgid "From the same category"
 msgstr "Samast kategooriast"
 
-#: src/muuli_wdr.cpp:1598
+#: src/muuli_wdr.cpp:1605
 msgid "In alphabetic order"
 msgstr "Tähestikulises järjekorras"
 
-#: src/muuli_wdr.cpp:1600
+#: src/muuli_wdr.cpp:1607
 msgid "Preallocate disk space for new files"
 msgstr "Eralda kettaruum uute failide jaoks"
 
-#: src/muuli_wdr.cpp:1601
+#: src/muuli_wdr.cpp:1608
 msgid "For new files preallocates disk space for the whole file, thus reduces fragmentation"
 msgstr "Eraldab uuet failide jaoks vajamineva kettaruumi, seeläbi väheneb faili fragmenteerumine"
 
-#: src/muuli_wdr.cpp:1606
+#: src/muuli_wdr.cpp:1613
 msgid "Create new files as sparse files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1607
+#: src/muuli_wdr.cpp:1614
 msgid "A sparse file reserves its full size on disk immediately without writing real data to it -- fast, but unsupported or slow on some filesystems, and free-space accounting stays optimistic while the download is in progress. Turn this off to grow the file only as data arrives."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1612
+#: src/muuli_wdr.cpp:1619
 msgid "Stop downloads when free disk space reaches "
 msgstr "Lõpeta tõmbamine, kui vaba kettaruumi on jäänud "
 
-#: src/muuli_wdr.cpp:1613
+#: src/muuli_wdr.cpp:1620
 msgid "Select this if you want aMule to check your disk space"
 msgstr "Vali see kui soovid et aMule sinu kettaruumi kontrolliks"
 
-#: src/muuli_wdr.cpp:1617
+#: src/muuli_wdr.cpp:1624
 msgid "Enter here the min disk space desired."
 msgstr "Sisesta siia vähim soovitud kettaruum"
 
-#: src/muuli_wdr.cpp:1623
+#: src/muuli_wdr.cpp:1630
 msgid "Save 10 sources on rare files (< 20 sources)"
 msgstr "Salvesta haruldaste failide 10 allikat (< 20 allikat)"
 
-#: src/muuli_wdr.cpp:1627 src/Statistics.cpp:790
+#: src/muuli_wdr.cpp:1634 src/Statistics.cpp:790
 msgid "Uploads"
 msgstr "Saatmised"
 
-#: src/muuli_wdr.cpp:1630
+#: src/muuli_wdr.cpp:1637
 msgid "Add new shared files with auto priority"
 msgstr "Lisa uued jagatud failid automaatse prioriteediga"
 
-#: src/muuli_wdr.cpp:1636
+#: src/muuli_wdr.cpp:1643
 msgid "Intelligent Corruption Handling (I.C.H.)"
 msgstr "Intelligentne Riknemise Vältimine (I.C.H.)"
 
-#: src/muuli_wdr.cpp:1639
+#: src/muuli_wdr.cpp:1646
 msgid "Enable"
 msgstr "Luba"
 
-#: src/muuli_wdr.cpp:1642
+#: src/muuli_wdr.cpp:1649
 msgid "Advanced I.C.H. trusts every hash (not recommended)"
 msgstr "Laiendatud I.C.H. usaldab suvalist kontrollsummat (pole soovitatav valik)"
 
-#: src/muuli_wdr.cpp:1654 src/PrefsUnifiedDlg.cpp:1910
+#: src/muuli_wdr.cpp:1661 src/PrefsUnifiedDlg.cpp:1910
 msgid "Media metadata extraction"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1658
+#: src/muuli_wdr.cpp:1665
 msgid "Extract length / bitrate / codec from shared audio and video files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1660
+#: src/muuli_wdr.cpp:1667
 msgid "When enabled, aMule runs ffprobe on each shared media file to fill in the Length / Bitrate / Codec columns other clients see when they find the file in a search. Requires ffmpeg (the ffprobe binary) to be installed."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1667
+#: src/muuli_wdr.cpp:1674
 msgid "Path to ffprobe:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1672
+#: src/muuli_wdr.cpp:1679
 msgid "Full path to the ffprobe binary. Leave empty to have aMule auto-detect it on startup."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1680
+#: src/muuli_wdr.cpp:1687
 msgid "Detect"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1681
+#: src/muuli_wdr.cpp:1688
 msgid "Search the standard install locations for an ffprobe binary and fill the path field."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1705
+#: src/muuli_wdr.cpp:1712
 msgid ""
 "Completed downloads are stored here. All files in this folder are automatically shared with other peers.\n"
 "If this folder also holds files you don't want to share, point it at an aMule-only sub-folder."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1708
+#: src/muuli_wdr.cpp:1715
 msgid "Pick the folder where completed downloads will be stored. All files in that folder will be shared with other peers."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1722
+#: src/muuli_wdr.cpp:1729
 msgid "Shared folders"
 msgstr "Jagatud kataloogid"
 
-#: src/muuli_wdr.cpp:1728
+#: src/muuli_wdr.cpp:1735
 msgid "(Folders shared by the core. Enter a path to add one.)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1736
+#: src/muuli_wdr.cpp:1743
 msgid "Absolute path of a folder on the core's machine, e.g. /home/user/shared"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1738 src/PrefsUnifiedDlg.cpp:2794
+#: src/muuli_wdr.cpp:1745 src/PrefsUnifiedDlg.cpp:2794
 msgid "Recursive"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1739
+#: src/muuli_wdr.cpp:1746
 msgid "Share every sub-folder underneath this one, including ones created later."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1743 src/utils/aLinkCreator/src/alcframe.cpp:141
+#: src/muuli_wdr.cpp:1750 src/utils/aLinkCreator/src/alcframe.cpp:141
 msgid "Remove"
 msgstr "Eemalda"
 
-#: src/muuli_wdr.cpp:1747
+#: src/muuli_wdr.cpp:1754
 msgid "(Right click on folder icon for recursive share)"
 msgstr "(Rekursiivseks jagamiseks tee paremklikk kataloogi ikoonil)"
 
-#: src/muuli_wdr.cpp:1754
+#: src/muuli_wdr.cpp:1761
 msgid "Share hidden files"
 msgstr "Jaga peidetud failid"
 
-#: src/muuli_wdr.cpp:1760
+#: src/muuli_wdr.cpp:1767
 msgid "Automatically rescan shared folders for changes"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1766
+#: src/muuli_wdr.cpp:1773
 msgid "Follow symbolic links in shared folders"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1772
+#: src/muuli_wdr.cpp:1779
 msgid "Exclude files matching:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1775
+#: src/muuli_wdr.cpp:1782
 msgid "Wildcard patterns separated by '|', e.g. .DS_Store|Thumbs.db|*.tmp. Files whose name matches are not shared. Matching is case-insensitive."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1779
+#: src/muuli_wdr.cpp:1786
 msgid "Patterns are regular expressions"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1780
+#: src/muuli_wdr.cpp:1787
 msgid "When set, the whole field is one regular expression ('|' is alternation). When unset, it is a list of '|'-separated wildcards."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1790
+#: src/muuli_wdr.cpp:1797
 msgid "Show how many shared files the current pattern would exclude."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1811
+#: src/muuli_wdr.cpp:1818
 msgid "Graphs"
 msgstr "Graafikud"
 
-#: src/muuli_wdr.cpp:1814 src/muuli_wdr.cpp:1876
+#: src/muuli_wdr.cpp:1821 src/muuli_wdr.cpp:1883
 msgid "Update delay : 5 secs"
 msgstr "Värskenduste vahe : 5 sekundit"
 
-#: src/muuli_wdr.cpp:1818
+#: src/muuli_wdr.cpp:1825
 msgid "Time for average graph: 100 mins"
 msgstr "Keskmine graafiku aeg: 100 minutit"
 
-#: src/muuli_wdr.cpp:1822
+#: src/muuli_wdr.cpp:1829
 msgid "Connections Graph Scale: 100 "
 msgstr "Ühenduse graafiku skaala: 100"
 
-#: src/muuli_wdr.cpp:1829
+#: src/muuli_wdr.cpp:1836
 msgid "Download graph scale:"
 msgstr "Tõmbamise graafiku skaala:"
 
-#: src/muuli_wdr.cpp:1837
+#: src/muuli_wdr.cpp:1844
 msgid "Upload graph scale:"
 msgstr "Saatmise graafiku skaala:"
 
-#: src/muuli_wdr.cpp:1847
+#: src/muuli_wdr.cpp:1854
 #, fuzzy
 msgid "Colors: "
 msgstr "Värvid: "
 
-#: src/muuli_wdr.cpp:1851
+#: src/muuli_wdr.cpp:1858
 msgid "Background"
 msgstr "Taust"
 
-#: src/muuli_wdr.cpp:1852
+#: src/muuli_wdr.cpp:1859
 msgid "Grid"
 msgstr "Alusvõrk"
 
-#: src/muuli_wdr.cpp:1853
+#: src/muuli_wdr.cpp:1860
 msgid "Download current"
 msgstr "Allalaadimine, jooksev"
 
-#: src/muuli_wdr.cpp:1854
+#: src/muuli_wdr.cpp:1861
 msgid "Download running average"
 msgstr "Allalaadimine, jooksev keskmine"
 
-#: src/muuli_wdr.cpp:1855
+#: src/muuli_wdr.cpp:1862
 msgid "Download session average"
 msgstr "Allalaadimine, seansi keskmine"
 
-#: src/muuli_wdr.cpp:1856
+#: src/muuli_wdr.cpp:1863
 msgid "Upload current"
 msgstr "Saatmine hetkel"
 
-#: src/muuli_wdr.cpp:1857
+#: src/muuli_wdr.cpp:1864
 msgid "Upload running average"
 msgstr "Hetke saatmise keskmine"
 
-#: src/muuli_wdr.cpp:1858
+#: src/muuli_wdr.cpp:1865
 msgid "Upload session average"
 msgstr "Seansi keskmine saatmine"
 
-#: src/muuli_wdr.cpp:1859
+#: src/muuli_wdr.cpp:1866
 msgid "Active connections"
 msgstr "Aktiivseid ühendusi"
 
-#: src/muuli_wdr.cpp:1862
+#: src/muuli_wdr.cpp:1869
 #, fuzzy
 msgid "Systray Icon Speed Bar"
 msgstr "Süsteemiriba Kiirvaliku Ikoon"
 
-#: src/muuli_wdr.cpp:1863
+#: src/muuli_wdr.cpp:1870
 msgid "Kad-nodes current"
 msgstr "Kad-sõlmi hetkel"
 
-#: src/muuli_wdr.cpp:1864
+#: src/muuli_wdr.cpp:1871
 msgid "Kad-nodes running"
 msgstr "Kad-sõlmi jooksvalt"
 
-#: src/muuli_wdr.cpp:1865
+#: src/muuli_wdr.cpp:1872
 msgid "Kad-nodes session"
 msgstr "Kad-sõlmi seansis"
 
-#: src/muuli_wdr.cpp:1869 src/muuli_wdr.cpp:2296
+#: src/muuli_wdr.cpp:1876 src/muuli_wdr.cpp:2303
 msgid "Select"
 msgstr "Vali"
 
-#: src/muuli_wdr.cpp:1873
+#: src/muuli_wdr.cpp:1880
 msgid "Tree"
 msgstr "Puu"
 
-#: src/muuli_wdr.cpp:1883
+#: src/muuli_wdr.cpp:1890
 msgid "Number of Client Versions shown (0=unlimited)"
 msgstr "Kuvatavate Kliendi Versioonide arv (0=piiramatu)"
 
-#: src/muuli_wdr.cpp:1908
+#: src/muuli_wdr.cpp:1915
 msgid "!!! WARNING !!!"
 msgstr "!!! HOIATUS !!!"
 
-#: src/muuli_wdr.cpp:1923
+#: src/muuli_wdr.cpp:1930
 msgid "Max new connections / 5 secs"
 msgstr "Maksimaalne arv uusi ühendusi / 5 sek."
 
-#: src/muuli_wdr.cpp:1925
+#: src/muuli_wdr.cpp:1932
 msgid "Concurrent Kad source lookups"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1927
+#: src/muuli_wdr.cpp:1934
 #, fuzzy
 msgid "Kad source re-search interval (minutes)"
 msgstr "FTP värskendamise intervall minutites"
 
-#: src/muuli_wdr.cpp:1929
+#: src/muuli_wdr.cpp:1936
 #, fuzzy
 msgid "Source re-ask interval (minutes)"
 msgstr "FTP värskendamise intervall minutites"
 
-#: src/muuli_wdr.cpp:1933
+#: src/muuli_wdr.cpp:1940
 msgid "File Buffer Size: 240000 bytes"
 msgstr "Faili puhvri suurus: 240000 baiti"
 
-#: src/muuli_wdr.cpp:1937
+#: src/muuli_wdr.cpp:1944
 msgid "Use MMAP: memory-mapped file access (lower memory use)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1938
+#: src/muuli_wdr.cpp:1945
 msgid "Maps part files into memory instead of buffering them on the heap, lowering the process memory footprint. May reduce download speed on some disks; best for memory-constrained or upload-heavy hosts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1940
+#: src/muuli_wdr.cpp:1947
 msgid "Upload Queue Size: 5000 clients"
 msgstr "Saatmise saba suurus: 5000 klienti"
 
-#: src/muuli_wdr.cpp:1944
+#: src/muuli_wdr.cpp:1951
 msgid "Server connection refresh interval: Disable"
 msgstr "Serveriühenduse värskenadamise intervall: Ei kasuta"
 
-#: src/muuli_wdr.cpp:1948
+#: src/muuli_wdr.cpp:1955
 msgid "Disable computer's timed standby mode"
 msgstr "Keela arvuti ajastatud uinumine"
 
-#: src/muuli_wdr.cpp:1967
+#: src/muuli_wdr.cpp:1974
 msgid "Skin to use: "
 msgstr "Kasutatav rüü: "
 
-#: src/muuli_wdr.cpp:1976
+#: src/muuli_wdr.cpp:1983
 msgid "Show \"Fast eD2k Links Handler\" in every window."
 msgstr "Näita igas aknas \"Kiiret eD2k lingi käsitlejat\". "
 
-#: src/muuli_wdr.cpp:1979
+#: src/muuli_wdr.cpp:1986
 msgid "Show extended info on categories tabs"
 msgstr "Näita kategooria juures laiendatud infot"
 
-#: src/muuli_wdr.cpp:1982
+#: src/muuli_wdr.cpp:1989
 #, fuzzy
 msgid "Show application version on title"
 msgstr "Näita tiitelribal siirdamise kiirusi"
 
-#: src/muuli_wdr.cpp:1984
+#: src/muuli_wdr.cpp:1991
 msgid "Show transfer rates on title"
 msgstr "Näita tiitelribal siirdamise kiirusi"
 
-#: src/muuli_wdr.cpp:1986
+#: src/muuli_wdr.cpp:1993
 msgid "Before application name"
 msgstr "Eelmise rakenduse nimi"
 
-#: src/muuli_wdr.cpp:1988
+#: src/muuli_wdr.cpp:1995
 msgid "After application name"
 msgstr "Järgneva rakenduse nimi"
 
-#: src/muuli_wdr.cpp:1991
+#: src/muuli_wdr.cpp:1998
 msgid "Show overhead bandwidth"
 msgstr "Näita raisatud ribalaiust"
 
-#: src/muuli_wdr.cpp:1995
+#: src/muuli_wdr.cpp:2002
 msgid "Vertical toolbar orientation"
 msgstr "Vertikaalne tööriistariba paigutus"
 
-#: src/muuli_wdr.cpp:1997
+#: src/muuli_wdr.cpp:2004
 msgid "Live column sorting (auto-reorder rows as their values change)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2004
+#: src/muuli_wdr.cpp:2011
 msgid "Download Queue Files"
 msgstr "Tõmbamise Järjekorrafailid"
 
-#: src/muuli_wdr.cpp:2007
+#: src/muuli_wdr.cpp:2014
 msgid "Show progress percentage"
 msgstr "Näita edenemist protsentuaalselt"
 
-#: src/muuli_wdr.cpp:2013
+#: src/muuli_wdr.cpp:2020
 msgid "Show progress bar"
 msgstr "Näita edenemise riba"
 
-#: src/muuli_wdr.cpp:2016
+#: src/muuli_wdr.cpp:2023
 msgid "Flat"
 msgstr "Lame"
 
-#: src/muuli_wdr.cpp:2020
+#: src/muuli_wdr.cpp:2027
 msgid "Round"
 msgstr "Ümar"
 
-#: src/muuli_wdr.cpp:2038
+#: src/muuli_wdr.cpp:2045
 msgid "External Connection Parameters"
 msgstr "Välisühenduse parameetrid"
 
-#: src/muuli_wdr.cpp:2041
+#: src/muuli_wdr.cpp:2048
 msgid "Accept external connections"
 msgstr "Aksepteeri väliseid ühendusi"
 
-#: src/muuli_wdr.cpp:2048 src/muuli_wdr.cpp:2107
+#: src/muuli_wdr.cpp:2055 src/muuli_wdr.cpp:2114
 msgid "IP of the listening interface:"
 msgstr "Kuulava liidese IP aadress:"
 
-#: src/muuli_wdr.cpp:2051
+#: src/muuli_wdr.cpp:2058
 msgid "Enter here a valid ip in the a.b.c.d format for the listening EC interface. An empty field or 0.0.0.0 will mean any interface."
 msgstr "Sisesta siia välisühenduse liidese kehtiv ip aadress a.b.c.d formaadis. Tühi väli või 0.0.0.0 tähendab suvalist liidest."
 
-#: src/muuli_wdr.cpp:2072 src/muuli_wdr.cpp:2156
+#: src/muuli_wdr.cpp:2079 src/muuli_wdr.cpp:2163
 msgid "TCP port:"
 msgstr "TCP port:"
 
-#: src/muuli_wdr.cpp:2078
+#: src/muuli_wdr.cpp:2085
 msgid "Enable UPnP port forwarding on the EC port"
 msgstr "Luba UPnP pordisuunamist EC pordile"
 
-#: src/muuli_wdr.cpp:2082 src/muuli_wdr.cpp:3041
+#: src/muuli_wdr.cpp:2089 src/muuli_wdr.cpp:3048
 #: src/utils/wxCas/src/wxcasprefs.cpp:167
 msgid "Password"
 msgstr "Parool"
 
-#: src/muuli_wdr.cpp:2088
+#: src/muuli_wdr.cpp:2095
 #, fuzzy
 msgid "aMule API server parameters"
 msgstr "Web serveri seaded"
 
-#: src/muuli_wdr.cpp:2091
+#: src/muuli_wdr.cpp:2098
 msgid "Run amuleapi (REST API) on startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2096
+#: src/muuli_wdr.cpp:2103
 #, fuzzy
 msgid "HTTP port:"
 msgstr "TCP port:"
 
-#: src/muuli_wdr.cpp:2110
+#: src/muuli_wdr.cpp:2117
 msgid "The interface amuleapi's HTTP server listens on. 127.0.0.1 (default) accepts only local connections; use 0.0.0.0 or a specific IP to expose it to other hosts (set an admin password below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2113
+#: src/muuli_wdr.cpp:2120
 #, fuzzy
 msgid "Admin password"
 msgstr "Kontrollin parooli\n"
 
-#: src/muuli_wdr.cpp:2118 src/muuli_wdr.cpp:2149
+#: src/muuli_wdr.cpp:2125 src/muuli_wdr.cpp:2156
 msgid "Low rights password"
 msgstr "Madalate õiguste parool"
 
-#: src/muuli_wdr.cpp:2126
+#: src/muuli_wdr.cpp:2133
 msgid "Web server parameters"
 msgstr "Web serveri seaded"
 
-#: src/muuli_wdr.cpp:2129
+#: src/muuli_wdr.cpp:2136
 #, fuzzy
 msgid "Run webserver on startup (deprecated)"
 msgstr "Käivita WEBserver koos aMulega"
 
-#: src/muuli_wdr.cpp:2135
+#: src/muuli_wdr.cpp:2142
 msgid "Web template"
 msgstr "WEB näidis/mall"
 
-#: src/muuli_wdr.cpp:2140
+#: src/muuli_wdr.cpp:2147
 msgid "Full rights password"
 msgstr "Täisõiguste parool"
 
-#: src/muuli_wdr.cpp:2144
+#: src/muuli_wdr.cpp:2151
 msgid "Enable Low rights User"
 msgstr "Luba madalate õigustega kasutaja"
 
-#: src/muuli_wdr.cpp:2163
+#: src/muuli_wdr.cpp:2170
 msgid "Enable UPnP port forwarding of the web server port"
 msgstr "Luba webservri portide UPnP pordisuunamist"
 
-#: src/muuli_wdr.cpp:2168
+#: src/muuli_wdr.cpp:2175
 msgid "Web server UPnP TCP port (Optional)"
 msgstr "Webserveri UPnP TCP port (Valikuline)"
 
-#: src/muuli_wdr.cpp:2176
+#: src/muuli_wdr.cpp:2183
 msgid "Page Refresh Time (in secs)"
 msgstr "Lehekülje värskendusaeg (sekundites)"
 
-#: src/muuli_wdr.cpp:2183
+#: src/muuli_wdr.cpp:2190
 msgid "Enable Gzip compression"
 msgstr "Luba Gzip pakkimine"
 
-#: src/muuli_wdr.cpp:2217
+#: src/muuli_wdr.cpp:2224
 #, fuzzy
 msgid "Reset page to defaults"
 msgstr "Süsteemi vaikeväärtus"
 
-#: src/muuli_wdr.cpp:2218
+#: src/muuli_wdr.cpp:2225
 msgid "Reset the settings on the current page to their default values."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2220 src/muuli_wdr.cpp:2306 src/ServerWnd.cpp:274
+#: src/muuli_wdr.cpp:2227 src/muuli_wdr.cpp:2313 src/ServerWnd.cpp:274
 #: src/ServerWnd.cpp:282
 msgid "OK"
 msgstr "Sobib"
 
-#: src/muuli_wdr.cpp:2222
+#: src/muuli_wdr.cpp:2229
 msgid "Click here to apply any changes made to the preferences."
 msgstr "Seadetes tehtud muudatuste jõustamiseks klikka siia."
 
-#: src/muuli_wdr.cpp:2225
+#: src/muuli_wdr.cpp:2232
 msgid "Reset any changes made to the preferences."
 msgstr "Tühista kõik seadetes tehtud muudatused."
 
-#: src/muuli_wdr.cpp:2254
+#: src/muuli_wdr.cpp:2261
 msgid "Comment :"
 msgstr "Kommentaar :"
 
-#: src/muuli_wdr.cpp:2261
+#: src/muuli_wdr.cpp:2268
 msgid "Incoming Dir :"
 msgstr "Tõmmatud failide kataloog :"
 
-#: src/muuli_wdr.cpp:2270
+#: src/muuli_wdr.cpp:2277
 msgid "Change priority for new assigned files :"
 msgstr "Muuda uute failide prioriteeti :"
 
-#: src/muuli_wdr.cpp:2274
+#: src/muuli_wdr.cpp:2281
 msgid "Don't change"
 msgstr "Ära muuda"
 
-#: src/muuli_wdr.cpp:2286
+#: src/muuli_wdr.cpp:2293
 msgid "Select color for this Category (currently selected) :"
 msgstr "Vali praegu valitud kategooriale värv :"
 
-#: src/muuli_wdr.cpp:2353 src/muuli_wdr.cpp:2372 src/muuli_wdr.cpp:2394
+#: src/muuli_wdr.cpp:2360 src/muuli_wdr.cpp:2379 src/muuli_wdr.cpp:2401
 msgid "Click this button to reset the log."
 msgstr "Klikates seda nuppu tühjendad logi."
 
-#: src/muuli_wdr.cpp:2413
+#: src/muuli_wdr.cpp:2420
 msgid "Click on this button to update the servers list from URL ..."
 msgstr "Sellele nupule klikates värskendad serverite loetelu URL ilt ..."
 
-#: src/muuli_wdr.cpp:2417
+#: src/muuli_wdr.cpp:2424
 msgid "Server list"
 msgstr "Serverite nimekiri"
 
-#: src/muuli_wdr.cpp:2421
+#: src/muuli_wdr.cpp:2428
 msgid "Enter the url to a server.met file here and press the button to the left to update the list of known servers."
 msgstr "Sisesta siia server.met faili asukoha URL ja pressi vasakul olevat nuppu tuntud serverite nimekirja värskendamiseks."
 
-#: src/muuli_wdr.cpp:2426
+#: src/muuli_wdr.cpp:2433
 msgid "Add server manually: Name"
 msgstr "Lisa server käsitsi: Nimi"
 
-#: src/muuli_wdr.cpp:2429
+#: src/muuli_wdr.cpp:2436
 msgid "Enter the name of the new server here"
 msgstr "Sisesta siia uue serveri nimi"
 
-#: src/muuli_wdr.cpp:2431 src/ServerWnd.cpp:206
+#: src/muuli_wdr.cpp:2438 src/ServerWnd.cpp:206
 msgid "IP:Port"
 msgstr "IP:Port"
 
-#: src/muuli_wdr.cpp:2434
+#: src/muuli_wdr.cpp:2441
 msgid "Enter the IP of the server here, using the x.x.x.x format."
 msgstr "Sisesta siia serveri IP aadrdess, kasutades x.x.x.x formaati."
 
-#: src/muuli_wdr.cpp:2440
+#: src/muuli_wdr.cpp:2447
 msgid "Enter the port of the server here."
 msgstr "Sisesta siia serveri port."
 
-#: src/muuli_wdr.cpp:2443
+#: src/muuli_wdr.cpp:2450
 msgid "Add manually a server (fill fields to the left before) ..."
 msgstr "Täites esiteks vasakul olevad väljad, lisa server käsitsi ..."
 
-#: src/muuli_wdr.cpp:2472
+#: src/muuli_wdr.cpp:2479
 msgid "aMule Log"
 msgstr "aMule Logi"
 
-#: src/muuli_wdr.cpp:2480
+#: src/muuli_wdr.cpp:2487
 msgid "Server Info"
 msgstr "Serveri info"
 
-#: src/muuli_wdr.cpp:2484
+#: src/muuli_wdr.cpp:2491
 msgid "ED2K Info"
 msgstr "ED2K Info"
 
-#: src/muuli_wdr.cpp:2488
+#: src/muuli_wdr.cpp:2495
 msgid "Kad Info"
 msgstr "Kad Info"
 
-#: src/muuli_wdr.cpp:2516
+#: src/muuli_wdr.cpp:2523
 msgid "Click on this button to update the nodes list from URL ..."
 msgstr "Klikates sellele nupule värskendad sõlmede loetelu URL'ilt ..."
 
-#: src/muuli_wdr.cpp:2520
+#: src/muuli_wdr.cpp:2527
 msgid "Nodes (0)"
 msgstr "Sõlmed (0)"
 
-#: src/muuli_wdr.cpp:2524
+#: src/muuli_wdr.cpp:2531
 msgid "Enter the url to a nodes.dat file here and press the button to the left to update the list of known nodes."
 msgstr "Sisesta siia nodes.dat faili url ja pressi vasakul olevat nuppu, et tuntud sõlmede loetelu täiendada."
 
-#: src/muuli_wdr.cpp:2527
+#: src/muuli_wdr.cpp:2534
 msgid "Nodes stats"
 msgstr "Sõlmede statistika"
 
-#: src/muuli_wdr.cpp:2569
+#: src/muuli_wdr.cpp:2576
 msgid "Bootstrap"
 msgstr "Bootstrap"
 
-#: src/muuli_wdr.cpp:2572
+#: src/muuli_wdr.cpp:2579
 msgid "New node"
 msgstr "Uus sõlm"
 
-#: src/muuli_wdr.cpp:2577
+#: src/muuli_wdr.cpp:2584
 msgid "IP:"
 msgstr "IP:"
 
-#: src/muuli_wdr.cpp:2597
+#: src/muuli_wdr.cpp:2604
 msgid "Port:"
 msgstr "Port:"
 
-#: src/muuli_wdr.cpp:2610
+#: src/muuli_wdr.cpp:2617
 msgid "Bootstrap from known clients"
 msgstr "Tuntud klientide Bootstrap"
 
-#: src/muuli_wdr.cpp:2612
+#: src/muuli_wdr.cpp:2619
 msgid "Disconnect Kad"
 msgstr "Lõpeta Kad ühendus"
 
-#: src/muuli_wdr.cpp:2646
+#: src/muuli_wdr.cpp:2653
 msgid "Use Secure User Identification"
 msgstr "Kasuta Turvalist Kasutaja tuvastamist"
 
-#: src/muuli_wdr.cpp:2648
+#: src/muuli_wdr.cpp:2655
 msgid "It is recommended to enable this option. You will not receive credits if SUI is not enabled."
 msgstr "On soovitatav see omadus lubada. Sa ei saa krediiti kui SUI on välja lülitatud."
 
-#: src/muuli_wdr.cpp:2650
+#: src/muuli_wdr.cpp:2657
 msgid "Protocol Obfuscation"
 msgstr "Protokolli Hämamine"
 
-#: src/muuli_wdr.cpp:2653
+#: src/muuli_wdr.cpp:2660
 msgid "Support Protocol Obfuscation"
 msgstr "Protokolli Hämamine lubatud"
 
-#: src/muuli_wdr.cpp:2655
+#: src/muuli_wdr.cpp:2662
 msgid "This option enabled Protocol Obfuscation, and makes aMule accept obfuscated connections from other clients."
 msgstr "See valik lülitab Protokolli Hämamise sisse ja sunnib aMule aksepteerima ainult teiste klientide hämatud ühendusi."
 
-#: src/muuli_wdr.cpp:2657
+#: src/muuli_wdr.cpp:2664
 msgid "Use obfuscation for outgoing connections"
 msgstr "Kasuta väljuvatel ühendustel hämamist"
 
-#: src/muuli_wdr.cpp:2659
+#: src/muuli_wdr.cpp:2666
 msgid "This option makes aMule use Protocol Obfuscation when connecting other clients/servers."
 msgstr "See valik sunnib aMule kasutama teiste serverite/klientidega ühendumisel Protokolli Hämamist."
 
-#: src/muuli_wdr.cpp:2661
+#: src/muuli_wdr.cpp:2668
 msgid "Accept only obfuscated connections"
 msgstr "Aksepteeri ainult hämatud ühendusi"
 
-#: src/muuli_wdr.cpp:2662
+#: src/muuli_wdr.cpp:2669
 msgid "This option makes aMule only accept obfuscated connections. You will have less sources, but all your traffic will be obfuscated"
 msgstr "See valik sunnib aMule aksepteerima ainult hämatud ühendusi. Sul on vähem allikaid aga kogu liiklus on hämatud."
 
-#: src/muuli_wdr.cpp:2667
+#: src/muuli_wdr.cpp:2674
 msgid "Everybody"
 msgstr "Igaüks"
 
-#: src/muuli_wdr.cpp:2669
+#: src/muuli_wdr.cpp:2676
 msgid "No one"
 msgstr "Mitte keegi"
 
-#: src/muuli_wdr.cpp:2671
+#: src/muuli_wdr.cpp:2678
 msgid "Who can see my shared files:"
 msgstr "Kes näeb minu jagatud faile:"
 
-#: src/muuli_wdr.cpp:2672
+#: src/muuli_wdr.cpp:2679
 msgid "Select who can request to view a list of your shared files."
 msgstr "Vali, kes võib vaatamiseks küsida sinu jagatud falide nimekira."
 
-#: src/muuli_wdr.cpp:2674
+#: src/muuli_wdr.cpp:2681
 msgid "IP-Filtering"
 msgstr "IP-Filtreerimine"
 
-#: src/muuli_wdr.cpp:2681
+#: src/muuli_wdr.cpp:2688
 msgid "Filter clients"
 msgstr "Filtreeri kliente"
 
-#: src/muuli_wdr.cpp:2683
+#: src/muuli_wdr.cpp:2690
 msgid "Enable filtering of the client IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "Rakenda klientide IP filtreerimine failis ~/.aMule/ipfilter.dat defineeritud aadressidele."
 
-#: src/muuli_wdr.cpp:2685
+#: src/muuli_wdr.cpp:2692
 msgid "Filter servers"
 msgstr "Filtreeri servereid"
 
-#: src/muuli_wdr.cpp:2687
+#: src/muuli_wdr.cpp:2694
 msgid "Enable filtering of the server IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "Rakenda serverite IP filtreerimine failis ~/.aMule/ipfilter.dat defineeritud aadressidele."
 
-#: src/muuli_wdr.cpp:2691
+#: src/muuli_wdr.cpp:2698
 msgid "Reload List"
 msgstr "Lae loetelu uuesti"
 
-#: src/muuli_wdr.cpp:2692
+#: src/muuli_wdr.cpp:2699
 msgid "Reload the list of IPs to filter from the file ~/.aMule/ipfilter.dat"
 msgstr "Taaslae filtreeritavad IP aadressid failist ~/.aMule/ipfilter.dat"
 
-#: src/muuli_wdr.cpp:2698
+#: src/muuli_wdr.cpp:2705
 msgid "URL:"
 msgstr "URL:"
 
-#: src/muuli_wdr.cpp:2702 src/muuli_wdr.cpp:2895
+#: src/muuli_wdr.cpp:2709 src/muuli_wdr.cpp:2902
 msgid "Update now"
 msgstr "Värskenda"
 
-#: src/muuli_wdr.cpp:2705
+#: src/muuli_wdr.cpp:2712
 msgid "Auto-update ipfilter at startup"
 msgstr "Käivitamisel värskenda automaatselt ipfiltrit"
 
-#: src/muuli_wdr.cpp:2709
+#: src/muuli_wdr.cpp:2716
 msgid "Filtering Level:"
 msgstr "Filtreerimise tase:"
 
-#: src/muuli_wdr.cpp:2715
+#: src/muuli_wdr.cpp:2722
 msgid "Always filter LAN IPs"
 msgstr "Filtreeri alati LAN IP aadresse"
 
-#: src/muuli_wdr.cpp:2718
+#: src/muuli_wdr.cpp:2725
 msgid "Paranoid handling of non-matching IPs"
 msgstr "Mitteklappivate IP aadresside paranoiline käitlemine"
 
-#: src/muuli_wdr.cpp:2720
+#: src/muuli_wdr.cpp:2727
 msgid "Rejects a packet when its source IP differs from the IP the client claims (an anti-spoofing check). Disable only if it causes connection problems."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2722
+#: src/muuli_wdr.cpp:2729
 msgid "Use system-wide ipfilter.dat if available"
 msgstr "Kasuta süsteemi ipfilter.dat kui see on saadaval"
 
-#: src/muuli_wdr.cpp:2723
+#: src/muuli_wdr.cpp:2730
 #, fuzzy
 msgid "If there's no local ipfilter.dat found, allow usage of a system-wide ipfilter file."
 msgstr "Kui kohalik ipfilter.dat fail puudub, kasuta süsteemi globaalset ipfilter faili."
 
-#: src/muuli_wdr.cpp:2740
+#: src/muuli_wdr.cpp:2747
 msgid "Enable Online-Signature"
 msgstr "Luba Online-Allkiri"
 
-#: src/muuli_wdr.cpp:2742
+#: src/muuli_wdr.cpp:2749
 msgid "Enables the writing of the OS file, which can be used by external apps to create signatures and the like."
 msgstr "Võimaldab kirjutada OS faile, mida saavad kasutada välised rakendused kasvõi allkirja loomiseks."
 
-#: src/muuli_wdr.cpp:2746
+#: src/muuli_wdr.cpp:2753
 msgid "Update Frequency (Secs):"
 msgstr "Värskenduse sagedus (Sek):"
 
-#: src/muuli_wdr.cpp:2749
+#: src/muuli_wdr.cpp:2756
 msgid "Change the frequency (in seconds) of Online Signature updates."
 msgstr "Muuda Online Allkirja värskendamise (sekundites) sagedust."
 
-#: src/muuli_wdr.cpp:2757
+#: src/muuli_wdr.cpp:2764
 msgid "Save online signature file in: "
 msgstr "Salvesta online ollkirja fail: "
 
-#: src/muuli_wdr.cpp:2763
+#: src/muuli_wdr.cpp:2770
 msgid "Click here to select the directory containing the the Online Signature files."
 msgstr "Siin saad valida kataloogi kus asub sinu Online Allkirja fail."
 
-#: src/muuli_wdr.cpp:2796
+#: src/muuli_wdr.cpp:2803
 msgid "Show country flags for clients"
 msgstr "Näita klientide riigi lippe"
 
-#: src/muuli_wdr.cpp:2797
+#: src/muuli_wdr.cpp:2804
 msgid "Render the country flag column in the transfers, queue and search views. Requires a valid MMDB GeoIP database (see below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2802
+#: src/muuli_wdr.cpp:2809
 #, fuzzy
 msgid "Database"
 msgstr "Andmekiirus :"
 
-#: src/muuli_wdr.cpp:2818
+#: src/muuli_wdr.cpp:2825
 #, fuzzy
 msgid "Source:"
 msgstr "Allikaid"
 
-#: src/muuli_wdr.cpp:2821
+#: src/muuli_wdr.cpp:2828
 msgid "DB-IP (free, no account)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2822
+#: src/muuli_wdr.cpp:2829
 msgid "MaxMind GeoLite2 (free, account required)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2823
+#: src/muuli_wdr.cpp:2830
 msgid "Custom URL"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2826
+#: src/muuli_wdr.cpp:2833
 msgid "Choose which provider supplies the GeoIP MMDB database. DB-IP is the default - no account required. MaxMind requires a free account + license key. Use Custom URL to point at any other MMDB host (e.g. a local mirror)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2843
+#: src/muuli_wdr.cpp:2850
 msgid ""
 "No configuration required.\n"
 "\n"
@@ -4840,11 +4854,11 @@ msgid ""
 "License: Creative Commons BY 4.0 - https://creativecommons.org/licenses/by/4.0/"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2856
+#: src/muuli_wdr.cpp:2863
 msgid "License key:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2862
+#: src/muuli_wdr.cpp:2869
 msgid ""
 "Sign up for a free MaxMind account, then generate a License Key:\n"
 "https://www.maxmind.com/en/geolite2/signup\n"
@@ -4854,226 +4868,226 @@ msgid ""
 "Requires attribution and account registration; refresh at least every 30 days."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2877
+#: src/muuli_wdr.cpp:2884
 #, fuzzy
 msgid "Download URL:"
 msgstr "Tõmbamine: "
 
-#: src/muuli_wdr.cpp:2883
+#: src/muuli_wdr.cpp:2890
 msgid ""
 "Must point to an .mmdb file or a .gz / .tar.gz containing one.\n"
 "URL may include credentials (https://user:pass@host/...).\n"
 "License and attribution terms are set by the upstream URL - you are responsible."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2896
+#: src/muuli_wdr.cpp:2903
 msgid "Download the GeoIP database from the selected source."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2898
+#: src/muuli_wdr.cpp:2905
 #, fuzzy
 msgid "Auto-update on startup"
 msgstr "Käivitamisel värskenda automaatselt ipfiltrit"
 
-#: src/muuli_wdr.cpp:2899
+#: src/muuli_wdr.cpp:2906
 msgid "Re-download the GeoIP database from the selected source every time aMule starts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2922
+#: src/muuli_wdr.cpp:2929
 msgid "Filter incoming messages (except current chat):"
 msgstr "Filtreeri saabuvaid teateid (va. käimasolev vestlus):"
 
-#: src/muuli_wdr.cpp:2924
+#: src/muuli_wdr.cpp:2931
 msgid "Filter all messages"
 msgstr "Filtreeri kõiki teateid"
 
-#: src/muuli_wdr.cpp:2926
+#: src/muuli_wdr.cpp:2933
 msgid "Filter messages from people not on your friend list"
 msgstr "Filtreeri sinu sõbralistiväliste kodanike teateid"
 
-#: src/muuli_wdr.cpp:2928
+#: src/muuli_wdr.cpp:2935
 msgid "Filter messages from unknown clients"
 msgstr "Filtreeri tundmatute klientide teateid"
 
-#: src/muuli_wdr.cpp:2930
+#: src/muuli_wdr.cpp:2937
 msgid "Filter messages containing (use ',' as separator):"
 msgstr "Filtreeri teateid, mis sisaldavad (loetelus kasuta eraldajana koma):"
 
-#: src/muuli_wdr.cpp:2933 src/muuli_wdr.cpp:2944
+#: src/muuli_wdr.cpp:2940 src/muuli_wdr.cpp:2951
 msgid "add here the words amule should filter and block messages including it"
 msgstr "lisa siia sõnad mille amule peab väljafiltreerima ja bloki teated mis seda sisaldavad"
 
-#: src/muuli_wdr.cpp:2935
+#: src/muuli_wdr.cpp:2942
 msgid "Show received messages in the log"
 msgstr "Näita logis saabunud teateid"
 
-#: src/muuli_wdr.cpp:2938
+#: src/muuli_wdr.cpp:2945
 msgid "Comments"
 msgstr "Kommentaarid"
 
-#: src/muuli_wdr.cpp:2941
+#: src/muuli_wdr.cpp:2948
 msgid "Filter comments containing (use ',' as separator):"
 msgstr "Filtreeri teateid, mis sisaldavad (loetelus kasuta eraldajana koma):"
 
-#: src/muuli_wdr.cpp:2966
+#: src/muuli_wdr.cpp:2973
 msgid "Enable Proxy"
 msgstr "Kasuta puhverserverit"
 
-#: src/muuli_wdr.cpp:2967
+#: src/muuli_wdr.cpp:2974
 msgid "Enable/disable proxy support"
 msgstr "Kasuta/ärakasuta puhverserveri tuge"
 
-#: src/muuli_wdr.cpp:2970
+#: src/muuli_wdr.cpp:2977
 msgid "Proxy type:"
 msgstr "Puhverserveri tüüp:"
 
-#: src/muuli_wdr.cpp:2981
+#: src/muuli_wdr.cpp:2988
 msgid "Proxy host:"
 msgstr "Puhverserveri nimi:"
 
-#: src/muuli_wdr.cpp:2984
+#: src/muuli_wdr.cpp:2991
 msgid "The proxy host name"
 msgstr "Selle puhverserveri/hosti nimi "
 
-#: src/muuli_wdr.cpp:2986
+#: src/muuli_wdr.cpp:2993
 msgid "Proxy port:"
 msgstr "Puhverserveri port:"
 
-#: src/muuli_wdr.cpp:2989
+#: src/muuli_wdr.cpp:2996
 msgid "The proxy port"
 msgstr "Selle puhverserveri pordi number"
 
-#: src/muuli_wdr.cpp:2991
+#: src/muuli_wdr.cpp:2998
 msgid "Enable authentication"
 msgstr "Nõua autoriseerimist"
 
-#: src/muuli_wdr.cpp:2992
+#: src/muuli_wdr.cpp:2999
 msgid "Enable/disable username/password authentication"
 msgstr "Autoriseerimisel Kasuta/Ära kasuta kasutajanime/parooli"
 
-#: src/muuli_wdr.cpp:2995
+#: src/muuli_wdr.cpp:3002
 msgid "Username: "
 msgstr "Kasutajanimi: "
 
-#: src/muuli_wdr.cpp:2998
+#: src/muuli_wdr.cpp:3005
 msgid "The username to use to connect to the proxy"
 msgstr "Puhverserveriga ühenduseks vajalik kasutajanimi"
 
-#: src/muuli_wdr.cpp:3000
+#: src/muuli_wdr.cpp:3007
 msgid "Password:"
 msgstr "Parool:"
 
-#: src/muuli_wdr.cpp:3003
+#: src/muuli_wdr.cpp:3010
 msgid "The password to use to connect to the proxy"
 msgstr "Puhverserveri kasutamiseks vajalik parool"
 
-#: src/muuli_wdr.cpp:3022
+#: src/muuli_wdr.cpp:3029
 msgid "Connect to:"
 msgstr "Ühendu :"
 
-#: src/muuli_wdr.cpp:3031
+#: src/muuli_wdr.cpp:3038
 msgid "Login to remote amule"
 msgstr "Logi sisse eemalasuvasse amuula"
 
-#: src/muuli_wdr.cpp:3036
+#: src/muuli_wdr.cpp:3043
 msgid "User name"
 msgstr "Kasutaja nimi"
 
-#: src/muuli_wdr.cpp:3047
+#: src/muuli_wdr.cpp:3054
 msgid "Remember those settings"
 msgstr "Pea need seaded meeles"
 
-#: src/muuli_wdr.cpp:3050
+#: src/muuli_wdr.cpp:3057
 #, fuzzy
 msgid "Force ZLIB compression"
 msgstr "Kasuta gzip pakkimist"
 
-#: src/muuli_wdr.cpp:3074
+#: src/muuli_wdr.cpp:3081
 msgid "Enable Verbose Debug-Logging."
 msgstr "Võimalda inimkieelne Veajälitus-Logimine"
 
-#: src/muuli_wdr.cpp:3076
+#: src/muuli_wdr.cpp:3083
 #, fuzzy
 msgid "Only to Logfile"
 msgstr "Ava Fail"
 
-#: src/muuli_wdr.cpp:3078
+#: src/muuli_wdr.cpp:3085
 msgid "Message Categories:"
 msgstr "Saadetav teade:"
 
-#: src/muuli_wdr.cpp:3102 src/PartFileConvertDlg.cpp:160
+#: src/muuli_wdr.cpp:3109 src/PartFileConvertDlg.cpp:160
 msgid "Waiting..."
 msgstr "Ootan..."
 
-#: src/muuli_wdr.cpp:3122
+#: src/muuli_wdr.cpp:3129
 msgid "Add imports"
 msgstr "Lisa imporditavad"
 
-#: src/muuli_wdr.cpp:3125
+#: src/muuli_wdr.cpp:3132
 msgid "Retry selected"
 msgstr "Proovi valitutega uuesti"
 
-#: src/muuli_wdr.cpp:3127
+#: src/muuli_wdr.cpp:3134
 msgid "Remove selected"
 msgstr "Eemalda valitud"
 
-#: src/muuli_wdr.cpp:3190
+#: src/muuli_wdr.cpp:3197
 msgid "Event Types"
 msgstr "Sündmuse tüübid"
 
-#: src/muuli_wdr.cpp:3209
+#: src/muuli_wdr.cpp:3216
 msgid "Statistics and queued clients for selected file(s) : Session / All time"
 msgstr "Statistika ja järjekorras kliendid valitud faili(de) kohta : Sessioon / Kokku"
 
-#: src/muuli_wdr.cpp:3233
+#: src/muuli_wdr.cpp:3240
 msgid "Active Uploads"
 msgstr "Aktiivsed saatmised"
 
-#: src/muuli_wdr.cpp:3247
+#: src/muuli_wdr.cpp:3254
 msgid "Percent of total files"
 msgstr "Protsenti kogufailidest"
 
-#: src/muuli_wdr.cpp:3299
+#: src/muuli_wdr.cpp:3306
 msgid "Show Clients for"
 msgstr "Näita Kliente"
 
-#: src/muuli_wdr.cpp:3301
+#: src/muuli_wdr.cpp:3308
 msgid "All files"
 msgstr "Kõik failid"
 
-#: src/muuli_wdr.cpp:3304
+#: src/muuli_wdr.cpp:3311
 msgid "Selected files"
 msgstr "Valitud failid"
 
-#: src/muuli_wdr.cpp:3307
+#: src/muuli_wdr.cpp:3314
 msgid "Active uploads only"
 msgstr "Ainult aktiivsed saatmised"
 
-#: src/muuli_wdr.cpp:3314
+#: src/muuli_wdr.cpp:3321
 msgid "Reload:"
 msgstr "Taaslae:"
 
-#: src/muuli_wdr.cpp:3318
+#: src/muuli_wdr.cpp:3325
 msgid "Reload your shared files"
 msgstr "Lae oma jagatud failid uuesti"
 
-#: src/muuli_wdr.cpp:3381
+#: src/muuli_wdr.cpp:3388
 msgid "Send"
 msgstr "Saada"
 
-#: src/muuli_wdr.cpp:3382
+#: src/muuli_wdr.cpp:3389
 msgid "Sends the specified message."
 msgstr "Saada määratud teade."
 
-#: src/muuli_wdr.cpp:3386
+#: src/muuli_wdr.cpp:3393
 msgid "Close this chat-session."
 msgstr "Sulge see vestlus-seanss."
 
-#: src/muuli_wdr.cpp:3409
+#: src/muuli_wdr.cpp:3416
 msgid "Connect to any server and/or Kad"
 msgstr "Ühendu suvalise serveri ja/või Kad võrguga"
 
-#: src/muuli_wdr.cpp:3415 src/SharedFilesCtrl.cpp:142 src/Statistics.cpp:941
+#: src/muuli_wdr.cpp:3422 src/SharedFilesCtrl.cpp:142 src/Statistics.cpp:941
 msgid "Shared Files"
 msgstr "Jagatud failid"
 
@@ -5432,189 +5446,189 @@ msgstr "Allalaetud"
 msgid "ERROR: Failed to open partfile '%s'"
 msgstr "VIGA: Osafaili '%s' avamine ebaõnnestus"
 
-#: src/Preferences.cpp:673
+#: src/Preferences.cpp:674
 msgid "System default"
 msgstr "Süsteemi vaikeväärtus"
 
-#: src/Preferences.cpp:674
+#: src/Preferences.cpp:675
 msgid "Albanian"
 msgstr "Albaania"
 
-#: src/Preferences.cpp:675
+#: src/Preferences.cpp:676
 msgid "Arabic"
 msgstr "Araabia"
 
-#: src/Preferences.cpp:676
+#: src/Preferences.cpp:677
 msgid "Asturian"
 msgstr "Asturia"
 
-#: src/Preferences.cpp:677
+#: src/Preferences.cpp:678
 msgid "Basque"
 msgstr "Baski"
 
-#: src/Preferences.cpp:678
+#: src/Preferences.cpp:679
 msgid "Bulgarian"
 msgstr "Bulgaaria"
 
-#: src/Preferences.cpp:679
+#: src/Preferences.cpp:680
 msgid "Catalan"
 msgstr "Kataloonia"
 
-#: src/Preferences.cpp:680
+#: src/Preferences.cpp:681
 msgid "Chinese (Simplified)"
 msgstr "Hiina (Lihtsustatud)"
 
-#: src/Preferences.cpp:681
+#: src/Preferences.cpp:682
 msgid "Chinese (Traditional)"
 msgstr "Hiina (Traditsiooniline)"
 
-#: src/Preferences.cpp:682
+#: src/Preferences.cpp:683
 msgid "Croatian"
 msgstr "Kroaatia"
 
-#: src/Preferences.cpp:683
+#: src/Preferences.cpp:684
 msgid "Czech"
 msgstr "Tšehhi"
 
-#: src/Preferences.cpp:684
+#: src/Preferences.cpp:685
 msgid "Danish"
 msgstr "Taani"
 
-#: src/Preferences.cpp:685
+#: src/Preferences.cpp:686
 msgid "Dutch"
 msgstr "Hollandi"
 
-#: src/Preferences.cpp:686
+#: src/Preferences.cpp:687
 msgid "English (U.K.)"
 msgstr "Inglise (U.K.)"
 
-#: src/Preferences.cpp:687
+#: src/Preferences.cpp:688
 #, fuzzy
 msgid "English (U.S.)"
 msgstr "Inglise (U.K.)"
 
-#: src/Preferences.cpp:688
+#: src/Preferences.cpp:689
 msgid "Estonian"
 msgstr "Eesti"
 
-#: src/Preferences.cpp:689
+#: src/Preferences.cpp:690
 msgid "Finnish"
 msgstr "Soome"
 
-#: src/Preferences.cpp:690
+#: src/Preferences.cpp:691
 msgid "French"
 msgstr "Prantsuse"
 
-#: src/Preferences.cpp:691
+#: src/Preferences.cpp:692
 msgid "Galician"
 msgstr "Galiitsia"
 
-#: src/Preferences.cpp:692
+#: src/Preferences.cpp:693
 msgid "German"
 msgstr "Saksa"
 
-#: src/Preferences.cpp:693
+#: src/Preferences.cpp:694
 msgid "Greek"
 msgstr "Kreeka"
 
-#: src/Preferences.cpp:694
+#: src/Preferences.cpp:695
 msgid "Hebrew"
 msgstr "Heebrea"
 
-#: src/Preferences.cpp:695
+#: src/Preferences.cpp:696
 msgid "Hungarian"
 msgstr "Ungari"
 
-#: src/Preferences.cpp:696
+#: src/Preferences.cpp:697
 msgid "Italian"
 msgstr "Itaalia"
 
-#: src/Preferences.cpp:697
+#: src/Preferences.cpp:698
 msgid "Japanese"
 msgstr "Jaapani"
 
-#: src/Preferences.cpp:698
+#: src/Preferences.cpp:699
 msgid "Korean"
 msgstr "Korea"
 
-#: src/Preferences.cpp:699
+#: src/Preferences.cpp:700
 msgid "Latvian"
 msgstr ""
 
-#: src/Preferences.cpp:700
+#: src/Preferences.cpp:701
 msgid "Lithuanian"
 msgstr "Leedu"
 
-#: src/Preferences.cpp:701
+#: src/Preferences.cpp:702
 msgid "Norwegian (Nynorsk)"
 msgstr "Norra"
 
-#: src/Preferences.cpp:702
+#: src/Preferences.cpp:703
 msgid "Polish"
 msgstr "Poola"
 
-#: src/Preferences.cpp:703
+#: src/Preferences.cpp:704
 msgid "Portuguese"
 msgstr "Portugali"
 
-#: src/Preferences.cpp:704
+#: src/Preferences.cpp:705
 msgid "Portuguese (Brazilian)"
 msgstr "Portugali (Brasiilia)"
 
-#: src/Preferences.cpp:705
+#: src/Preferences.cpp:706
 msgid "Romanian"
 msgstr "Rumeenia"
 
-#: src/Preferences.cpp:706
+#: src/Preferences.cpp:707
 msgid "Russian"
 msgstr "Vene"
 
-#: src/Preferences.cpp:707
+#: src/Preferences.cpp:708
 msgid "Slovenian"
 msgstr "Sloveenia"
 
-#: src/Preferences.cpp:708
+#: src/Preferences.cpp:709
 msgid "Spanish"
 msgstr "Hispaania"
 
-#: src/Preferences.cpp:709
+#: src/Preferences.cpp:710
 msgid "Swedish"
 msgstr "Rootsi"
 
-#: src/Preferences.cpp:710
+#: src/Preferences.cpp:711
 msgid "Turkish"
 msgstr "Türgi"
 
-#: src/Preferences.cpp:711
+#: src/Preferences.cpp:712
 msgid "Ukrainian"
 msgstr "Ukraina"
 
-#: src/Preferences.cpp:814
+#: src/Preferences.cpp:815
 msgid "Change Language"
 msgstr "Muuda keel"
 
-#: src/Preferences.cpp:878
+#: src/Preferences.cpp:879
 msgid "There are no translations installed for aMule"
 msgstr ""
 
-#: src/Preferences.cpp:879
+#: src/Preferences.cpp:880
 #, fuzzy
 msgid "No languages available"
 msgstr "Info puudub"
 
-#: src/Preferences.cpp:1010
+#: src/Preferences.cpp:1011
 msgid "no options available"
 msgstr "valikud puuduvad"
 
-#: src/Preferences.cpp:2179
+#: src/Preferences.cpp:2182
 msgid "Invalid category found, skipping"
 msgstr "Leidsin vigase kategooria, ignoreerin"
 
-#: src/Preferences.cpp:2348
+#: src/Preferences.cpp:2351
 msgid "TCP port can't be higher than 65532 due to server UDP socket being TCP+3"
 msgstr "TCP port ei saa olla suuerm kui 65532, sest serveri UDP soket on TCP+3"
 
-#: src/Preferences.cpp:2349
+#: src/Preferences.cpp:2352
 #, c-format
 msgid "Default port will be used (%d)"
 msgstr "Kasutan vaikimisi porti (%d)"
@@ -6125,24 +6139,28 @@ msgstr "Jagatud failide loetelu taaslaadimine."
 msgid "Shared folder"
 msgstr "Jagatud kataloogid"
 
-#: src/SearchDlg.cpp:425
+#: src/SearchDlg.cpp:280
+msgid "Clear search history"
+msgstr ""
+
+#: src/SearchDlg.cpp:584
 msgid "It's impossible to search when both eD2k and Kademlia are disabled."
 msgstr ""
 
-#: src/SearchDlg.cpp:426 src/SearchListCtrl.cpp:858
+#: src/SearchDlg.cpp:585 src/SearchListCtrl.cpp:858
 #, fuzzy
 msgid "Search error"
 msgstr "Otsingud"
 
-#: src/SearchDlg.cpp:768
+#: src/SearchDlg.cpp:929
 msgid "Min size must be smaller than max size. Max size ignored."
 msgstr "Min suurus peab olema väiksem kui max suurus. Ignoreerin Max suurust."
 
-#: src/SearchDlg.cpp:769 src/SearchDlg.cpp:851
+#: src/SearchDlg.cpp:930 src/SearchDlg.cpp:1012
 msgid "Search warning"
 msgstr "Otsingu hoiatus"
 
-#: src/SearchDlg.cpp:929 src/SearchListCtrl.cpp:735
+#: src/SearchDlg.cpp:1092 src/SearchListCtrl.cpp:735
 msgid "Main"
 msgstr "Peamine"
 

--- a/po/et_EE.po
+++ b/po/et_EE.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-28 10:19+0200\n"
+"POT-Creation-Date: 2026-07-28 12:17+0200\n"
 "PO-Revision-Date: 2026-07-27 11:36+0000\n"
 "Last-Translator: \n"
 "Language-Team: Estonian <kde-i18n-doc@kde.org>\n"
@@ -203,83 +203,83 @@ msgstr "Ei suuda avada ED2KLinks faili."
 msgid "WARNING: You can't add yourself as a source for an eD2k link while having a lowid."
 msgstr "HOIATUS: Sa ei saa ennast eD2k lingi jaoks allikana lisada ajal kui omad lowid'd."
 
-#: src/amule.cpp:300
+#: src/amule.cpp:301
 msgid "Now, exiting main app..."
 msgstr "Ok, lahkun põhiprogrammist..."
 
-#: src/amule.cpp:330
+#: src/amule.cpp:331
 #, c-format
 msgid "Terminating amuleweb instance with pid '%d' ... "
 msgstr "Mõrvan amuleweb tegelase, protsessi id '%d' ... "
 
-#: src/amule.cpp:334
+#: src/amule.cpp:335
 #, c-format
 msgid "Killing amuleweb instance with pid '%d' ... "
 msgstr "Mõrvan amuleweb tegelase, protsessi id '%d' ... "
 
-#: src/amule.cpp:336 src/amule.cpp:349 src/ClientRef.cpp:180
+#: src/amule.cpp:337 src/amule.cpp:350 src/ClientRef.cpp:180
 #: src/SearchDlg.cpp:1041 src/ServerListCtrl.cpp:98
 msgid "Failed"
 msgstr "Nurjunud"
 
-#: src/amule.cpp:343
+#: src/amule.cpp:344
 #, fuzzy, c-format
 msgid "Terminating amuleapi instance with pid '%d' ... "
 msgstr "Mõrvan amuleweb tegelase, protsessi id '%d' ... "
 
-#: src/amule.cpp:347
+#: src/amule.cpp:348
 #, fuzzy, c-format
 msgid "Killing amuleapi instance with pid '%d' ... "
 msgstr "Mõrvan amuleweb tegelase, protsessi id '%d' ... "
 
-#: src/amule.cpp:355
+#: src/amule.cpp:356
 msgid "aMule OnExit: Terminating core."
 msgstr "aMule OnExit: Peatan tuuma."
 
-#: src/amule.cpp:466
+#: src/amule.cpp:467
 msgid "aMule shutdown completed."
 msgstr "aMule seiskamine lõpetatud."
 
-#: src/amule.cpp:470
+#: src/amule.cpp:471
 msgid "Memory debug results for aMule exit:"
 msgstr "aMule väljumise mälu veajälituse tulemus:"
 
-#: src/amule.cpp:651
+#: src/amule.cpp:652
 #, c-format
 msgid "Binding aMule's peer-to-peer traffic to interface: %s (HTTP updates use the default route)"
 msgstr ""
 
-#: src/amule.cpp:655
+#: src/amule.cpp:656
 #, c-format
 msgid "Binding all network traffic to interface: %s"
 msgstr ""
 
-#: src/amule.cpp:659
+#: src/amule.cpp:660
 #, c-format
 msgid "WARNING: configured network interface '%s' was not found - traffic is NOT bound to it and may leave via the default route. Check the interface name in Preferences."
 msgstr ""
 
-#: src/amule.cpp:665
+#: src/amule.cpp:666
 #, c-format
 msgid "WARNING: binding to network interface '%s' requires elevated privileges and was NOT applied - traffic may leave via the default route. Grant the capability (e.g. 'sudo setcap cap_net_raw+ep' on the aMule binary) or run with sufficient privileges."
 msgstr ""
 
-#: src/amule.cpp:673
+#: src/amule.cpp:674
 #, c-format
 msgid "WARNING: could not bind to network interface '%s' - traffic may leave via the default route."
 msgstr ""
 
-#: src/amule.cpp:732
+#: src/amule.cpp:733
 msgid "Your locale has been changed to System Default due to a configuration change. Sorry."
 msgstr "Sinu keelelokaat muudeti süsteemi vaikeväärtuseks seoses konfiguratsiooni muudatustega. Sorry."
 
-#: src/amule.cpp:734 src/amule.cpp:1581 src/CatDialog.cpp:128
+#: src/amule.cpp:735 src/amule.cpp:1589 src/CatDialog.cpp:128
 #: src/CatDialog.cpp:136 src/CatDialog.cpp:149 src/ServerList.cpp:366
 #: src/ServerListCtrl.cpp:152
 msgid "Info"
 msgstr "Info"
 
-#: src/amule.cpp:741
+#: src/amule.cpp:742
 msgid ""
 "\n"
 "EC configuration"
@@ -287,74 +287,74 @@ msgstr ""
 "\n"
 "EC seadistused"
 
-#: src/amule.cpp:744
+#: src/amule.cpp:745
 msgid "Password set and external connections enabled."
 msgstr "Parool on määratud ja välised ühendused võimalikud."
 
-#: src/amule.cpp:754 src/KadDlg.cpp:176 src/KadDlg.cpp:185
-#: src/PrefsUnifiedDlg.cpp:1387 src/SharedFilesCtrl.cpp:476
+#: src/amule.cpp:755 src/KadDlg.cpp:176 src/KadDlg.cpp:185
+#: src/PrefsUnifiedDlg.cpp:1461 src/SharedFilesCtrl.cpp:476
 msgid "WARNING"
 msgstr "HOIATUS"
 
-#: src/amule.cpp:991
+#: src/amule.cpp:992
 #, fuzzy
 msgid "Network bootstrap"
 msgstr "Võrgud"
 
-#: src/amule.cpp:996
+#: src/amule.cpp:997
 msgid ""
 "aMule has detected missing network bootstrap files.\n"
 "Select which ones to download:"
 msgstr ""
 
-#: src/amule.cpp:1005 src/FirstRunWizard.cpp:411
+#: src/amule.cpp:1006 src/FirstRunWizard.cpp:411
 #, fuzzy
 msgid "eD2k server list (server.met)"
 msgstr "Failis server.met on %i serverit"
 
-#: src/amule.cpp:1012 src/FirstRunWizard.cpp:416
+#: src/amule.cpp:1013 src/FirstRunWizard.cpp:416
 msgid "Kad bootstrap nodes (nodes.dat)"
 msgstr ""
 
-#: src/amule.cpp:1102
+#: src/amule.cpp:1103
 #, c-format
 msgid "web server running on pid %d"
 msgstr "web server töötab protsessi id'ga %d"
 
-#: src/amule.cpp:1115
+#: src/amule.cpp:1116
 #, fuzzy
 msgid "You requested to run web server on startup, but the amuleweb binary cannot be run. Please install the package containing aMule web server, or build aMule from source with -DBUILD_WEBSERVER=YES and install it."
 msgstr "Soovisid et web server käivitataks käivitumisel, kuid amuleweb programm pole võimeline käivituma. Palun paigalada versioon mis sisaldab aMule web serverit või kompileeri aMule kasutades võtit --enable-webserver ja seejärel make install"
 
-#: src/amule.cpp:1120 src/amule.cpp:1177 src/amule.cpp:1291 src/amule.cpp:1593
+#: src/amule.cpp:1121 src/amule.cpp:1185 src/amule.cpp:1299 src/amule.cpp:1601
 #: src/amule-remote-gui.cpp:603 src/amule-remote-gui.cpp:671
 #: src/amule-remote-gui.cpp:709 src/amule-remote-gui.cpp:1282
 #: src/amule-remote-gui.cpp:1345 src/amule-remote-gui.cpp:1372
-#: src/DownloadQueue.cpp:1481
+#: src/DownloadQueue.cpp:1481 src/PrefsUnifiedDlg.cpp:1247
 msgid "ERROR"
 msgstr "VIGA"
 
-#: src/amule.cpp:1166
+#: src/amule.cpp:1174
 #, fuzzy, c-format
 msgid "amuleapi running on pid %d"
 msgstr "web server töötab protsessi id'ga %d"
 
-#: src/amule.cpp:1172
+#: src/amule.cpp:1180
 #, fuzzy
 msgid "You requested to run amuleapi on startup, but the amuleapi binary cannot be run. Please install the package containing aMule's REST API server, or build aMule from source with -DBUILD_AMULEAPI=YES and install it."
 msgstr "Soovisid et web server käivitataks käivitumisel, kuid amuleweb programm pole võimeline käivituma. Palun paigalada versioon mis sisaldab aMule web serverit või kompileeri aMule kasutades võtit --enable-webserver ja seejärel make install"
 
-#: src/amule.cpp:1259
+#: src/amule.cpp:1267
 #, c-format
 msgid "Could not bind ports to the specified address: %s"
 msgstr "Ei suuda siduda porti määratud aadressiga: %s"
 
-#: src/amule.cpp:1283
+#: src/amule.cpp:1291
 #, c-format
 msgid "Port %u is not available. You will be LOWID\n"
 msgstr "Port %u ei ole kasutatav. Sa saad LOWID\n"
 
-#: src/amule.cpp:1288
+#: src/amule.cpp:1296
 #, c-format
 msgid ""
 "Port %u is not available!\n"
@@ -369,48 +369,48 @@ msgstr ""
 "Kasuta netstat programmi kontrollimaks kuna port vabaneb\n"
 "ja proovi amule uuesti käivitada."
 
-#: src/amule.cpp:1385
+#: src/amule.cpp:1393
 msgid "Failed to create OnlineSig File"
 msgstr "Ei suutnud luua OnlineSig Faili"
 
-#: src/amule.cpp:1393
+#: src/amule.cpp:1401
 msgid "Failed to create aMule OnlineSig File"
 msgstr "Ei suutnud luua aMule OnlineSig Faili"
 
-#: src/amule.cpp:1556
+#: src/amule.cpp:1564
 msgid "The selected locale seems not to be installed on your box. (Note: I'll try to set it anyway)"
 msgstr "Tundub et valitud keelelokaat pole sinu karpi installeritud. (Märkus: Ma proovin seda seada sellest hoolimata)"
 
-#: src/amule.cpp:1566
+#: src/amule.cpp:1574
 #, c-format
 msgid "This is the first time you run aMule %s"
 msgstr "See on aMule %s käivitamise esimene kord"
 
-#: src/amule.cpp:1569
+#: src/amule.cpp:1577
 msgid "This version is a testing version, updated daily, and\n"
 msgstr "See on testversioon, mida igapäevaselt uuendatakse ja\n"
 
-#: src/amule.cpp:1570
+#: src/amule.cpp:1578
 msgid "we give no warranty it won't break anything, burn your house,\n"
 msgstr "me ei anna mingit garantiid, et see ei lõhu midagi, ei süüta sinu elamist\n"
 
-#: src/amule.cpp:1571
+#: src/amule.cpp:1579
 msgid "or kill your dog. But it *should* be safe to use anyway.\n"
 msgstr "ega tapa sinu koera. Sellest hoolimata peaks see olema *turvaline* kasutada.\n"
 
-#: src/amule.cpp:1576
+#: src/amule.cpp:1584
 msgid "More information, support and new releases can found at our homepage,\n"
 msgstr "Rohkem informatsiooni, tuge ja uusi programmi versioone leiad meie kodulehelt,\n"
 
-#: src/amule.cpp:1577
+#: src/amule.cpp:1585
 msgid "at https://amule-org.github.io, or in our IRC channel #aMule at irc.libera.chat.\n"
 msgstr "aadressil https://amule-org.github.io või meie IRC kanalis #aMule aadressil irc.libera.chat.\n"
 
-#: src/amule.cpp:1579
+#: src/amule.cpp:1587
 msgid "Feel free to report any bugs to https://github.com/amule-org/amule/issues"
 msgstr "Tunne ennast vabalt suvaliste vigade leidmisest teavitamisel aadressil https://github.com/amule-org/amule/issues"
 
-#: src/amule.cpp:1591
+#: src/amule.cpp:1599
 msgid ""
 "The folder for Online Signature files you specified is INVALID!\n"
 " OnlineSignature will be DISABLED until you fix it on preferences."
@@ -418,137 +418,137 @@ msgstr ""
 "Online Allkirja kataloog on VIGANE!\n"
 " Online Allkirja ei kasutata, kuni parandad vea seadetes."
 
-#: src/amule.cpp:1654
+#: src/amule.cpp:1662
 msgid "Server hostname notified"
 msgstr "Teatatud serveri nimi"
 
-#: src/amule.cpp:2031
+#: src/amule.cpp:2039
 #, c-format
 msgid "Disk space preallocation for file '%s' failed: %s"
 msgstr "Kettaruumi eraldamine faili '%s' jaoks ebaõnnestus: %s"
 
-#: src/amule.cpp:2160
+#: src/amule.cpp:2168
 msgid "ERROR: can't open logfile"
 msgstr "VIGA: Ei suutnud avada logifaili"
 
-#: src/amule.cpp:2164
+#: src/amule.cpp:2172
 msgid "WARNING: logfile is empty. Something is wrong."
 msgstr "HOIATUS: logifail on tühi, miskit on kapitaalselt viltu."
 
-#: src/amule.cpp:2181
+#: src/amule.cpp:2189
 msgid "Log has been reset"
 msgstr "Log on nullitud"
 
-#: src/amule.cpp:2205
+#: src/amule.cpp:2213
 #, c-format
 msgid "ServerMessage: %s"
 msgstr "Serveri teade: %s"
 
-#: src/amule.cpp:2248 src/IP2Country.cpp:220 src/IPFilter.cpp:514
+#: src/amule.cpp:2256 src/IP2Country.cpp:220 src/IPFilter.cpp:514
 #: src/ServerList.cpp:875
 #, c-format
 msgid "Skipped download of %s, because requested file is not newer."
 msgstr "Fail %s jäeti vahele, sest soovitud fail pole uuem."
 
-#: src/amule.cpp:2251
+#: src/amule.cpp:2259
 msgid "Failed to download the nodes list."
 msgstr "Ebaõnnestus sõlmede nimekirja tõmbamine."
 
-#: src/amule.cpp:2314
+#: src/amule.cpp:2322
 msgid "Failed to open the downloaded version check file"
 msgstr "Ebaõnnestus tõmmatud versiooni kotrollfaili avamine"
 
-#: src/amule.cpp:2317 src/amule.cpp:2336
+#: src/amule.cpp:2325 src/amule.cpp:2344
 msgid "Corrupted version check file"
 msgstr "Versiooni kontrollfail on korrumpeerunud"
 
-#: src/amule.cpp:2359
+#: src/amule.cpp:2367
 msgid "You are using an outdated version of aMule!"
 msgstr "Kasutad aegunud aMule versiooni!"
 
-#: src/amule.cpp:2361
+#: src/amule.cpp:2369
 #, c-format
 msgid "Your aMule version is %i.%i.%i and the latest version is %li.%li.%li"
 msgstr "Sinu aMule versioon on %i.%i.%i ja uusim versioon on %li.%li.%li"
 
-#: src/amule.cpp:2365
+#: src/amule.cpp:2373
 msgid "The latest version can always be found at https://github.com/amule-org/amule/releases/latest"
 msgstr "Uuema aMule versiooni saad alati aadressilt https://github.com/amule-org/amule/releases/latest"
 
-#: src/amule.cpp:2368
+#: src/amule.cpp:2376
 #, c-format
 msgid "WARNING: Your aMuled version is outdated: %i.%i.%i < %li.%li.%li"
 msgstr "HOAITUS: Sinu aMuled versioon on vananenud: %i.%i.%i < %li.%li.%li"
 
-#: src/amule.cpp:2374
+#: src/amule.cpp:2382
 msgid "Your copy of aMule is up to date."
 msgstr "Sinu aMule koopia on ajakohane."
 
-#: src/amule.cpp:2381
+#: src/amule.cpp:2389
 msgid "Failed to download the version check file"
 msgstr "Versiooni kontrollfaili tõmbamine ebaõnnestus"
 
-#: src/amule.cpp:2550 src/amule-remote-gui.cpp:1133
+#: src/amule.cpp:2558 src/amule-remote-gui.cpp:1133
 #, c-format
 msgid "Users: %s | Files: %s"
 msgstr "Kasutajaid: %s | Faile: %s"
 
-#: src/amule.cpp:2551 src/amule-remote-gui.cpp:1134
+#: src/amule.cpp:2559 src/amule-remote-gui.cpp:1134
 #, c-format
 msgid "Users: E: %s K: %s | Files: E: %s K: %s"
 msgstr "Kasutajaid: E: %s K: %s | Faile E: %s K: %s"
 
-#: src/amule.cpp:2565 src/amule-remote-gui.cpp:1147
+#: src/amule.cpp:2573 src/amule-remote-gui.cpp:1147
 msgid "No networks selected"
 msgstr "Ühtegi võrku pole valitud"
 
-#: src/amule.cpp:2633 src/TextClient.cpp:903
+#: src/amule.cpp:2641 src/TextClient.cpp:903
 msgid "with LowID"
 msgstr "koos LowID"
 
-#: src/amule.cpp:2633 src/TextClient.cpp:904
+#: src/amule.cpp:2641 src/TextClient.cpp:904
 msgid "with HighID"
 msgstr "koos HighID"
 
-#: src/amule.cpp:2635
+#: src/amule.cpp:2643
 #, c-format
 msgid "Connected to %s %s"
 msgstr "Ühendatud %s %s"
 
-#: src/amule.cpp:2640
+#: src/amule.cpp:2648
 #, c-format
 msgid "Connecting to %s"
 msgstr "Ühendun %s"
 
-#: src/amule.cpp:2642
+#: src/amule.cpp:2650
 msgid "Disconnected from eD2k"
 msgstr "eD2k ühendus katkestatud."
 
-#: src/amule.cpp:2651
+#: src/amule.cpp:2659
 msgid "Kad started."
 msgstr "Kad käivitatud."
 
-#: src/amule.cpp:2653
+#: src/amule.cpp:2661
 msgid "Kad stopped."
 msgstr "Kad peatatud."
 
-#: src/amule.cpp:2661
+#: src/amule.cpp:2669
 msgid "Connected to Kad (ok)"
 msgstr "Ühendus Kad võrk (ok)"
 
-#: src/amule.cpp:2663
+#: src/amule.cpp:2671
 msgid "Connected to Kad (firewalled)"
 msgstr "Ühendus Kad võrku (tulemüüriga)"
 
-#: src/amule.cpp:2667
+#: src/amule.cpp:2675
 msgid "Disconnected from Kad"
 msgstr "Ühendus Kad võrguga katkestatud"
 
-#: src/amule.cpp:2699
+#: src/amule.cpp:2707
 msgid "Kad network cannot be used if UDP port is disabled on preferences, not starting."
 msgstr "Kad võrku ei saa kasutada kui seadetes on UDP port väljalülitatud, ei ühendu."
 
-#: src/amule.cpp:2703
+#: src/amule.cpp:2711
 msgid "Kad network disabled on preferences, not connecting."
 msgstr "Kad on seadetes väljalülitatud, ei ühenda."
 
@@ -593,36 +593,36 @@ msgid "FATAL ERROR: Failed to create Timer"
 msgstr "Fataalne VIGA: Ei suutnud luua stopperit."
 
 #: src/amuleDlg.cpp:361 src/amuleDlg.cpp:1787 src/amuleDlg.cpp:2033
-#: src/muuli_wdr.cpp:1492 src/muuli_wdr.cpp:3418
+#: src/muuli_wdr.cpp:1492 src/muuli_wdr.cpp:3449
 msgid "Networks"
 msgstr "Võrgud"
 
-#: src/amuleDlg.cpp:362 src/amuleDlg.cpp:1793 src/muuli_wdr.cpp:3419
+#: src/amuleDlg.cpp:362 src/amuleDlg.cpp:1793 src/muuli_wdr.cpp:3450
 msgid "Searches"
 msgstr "Otsingud"
 
 #: src/amuleDlg.cpp:363 src/amuleDlg.cpp:1799 src/DownloadListCtrl.cpp:740
-#: src/muuli_wdr.cpp:392 src/muuli_wdr.cpp:1585 src/muuli_wdr.cpp:3420
+#: src/muuli_wdr.cpp:392 src/muuli_wdr.cpp:1585 src/muuli_wdr.cpp:3451
 #: src/Statistics.cpp:829
 msgid "Downloads"
 msgstr "Tõmbamised"
 
-#: src/amuleDlg.cpp:364 src/amuleDlg.cpp:1805 src/muuli_wdr.cpp:3294
+#: src/amuleDlg.cpp:364 src/amuleDlg.cpp:1805 src/muuli_wdr.cpp:3325
 msgid "Shared files"
 msgstr "Jagatud failid"
 
-#: src/amuleDlg.cpp:365 src/amuleDlg.cpp:1811 src/muuli_wdr.cpp:2926
-#: src/muuli_wdr.cpp:3376 src/muuli_wdr.cpp:3423
+#: src/amuleDlg.cpp:365 src/amuleDlg.cpp:1811 src/muuli_wdr.cpp:2957
+#: src/muuli_wdr.cpp:3407 src/muuli_wdr.cpp:3454
 msgid "Messages"
 msgstr "Teated"
 
-#: src/amuleDlg.cpp:366 src/amuleDlg.cpp:1817 src/muuli_wdr.cpp:3424
-#: src/PrefsUnifiedDlg.cpp:312 src/Statistics.cpp:779 src/Statistics.cpp:1235
+#: src/amuleDlg.cpp:366 src/amuleDlg.cpp:1817 src/muuli_wdr.cpp:3455
+#: src/PrefsUnifiedDlg.cpp:314 src/Statistics.cpp:779 src/Statistics.cpp:1235
 msgid "Statistics"
 msgstr "Statistika"
 
-#: src/amuleDlg.cpp:368 src/amuleDlg.cpp:1824 src/muuli_wdr.cpp:3426
-#: src/PrefsUnifiedDlg.cpp:328 src/utils/wxCas/src/wxcasprefs.cpp:39
+#: src/amuleDlg.cpp:368 src/amuleDlg.cpp:1824 src/muuli_wdr.cpp:3457
+#: src/PrefsUnifiedDlg.cpp:330 src/utils/wxCas/src/wxcasprefs.cpp:39
 msgid "Preferences"
 msgstr "Seaded"
 
@@ -680,8 +680,8 @@ msgstr "Kad: Väljas"
 #: src/amuleDlg.cpp:1029 src/DownloadListCtrl.cpp:505
 #: src/DownloadListCtrl.cpp:749 src/FriendListCtrl.cpp:180
 #: src/muuli_wdr.cpp:731 src/muuli_wdr.cpp:782 src/muuli_wdr.cpp:846
-#: src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2231 src/muuli_wdr.cpp:2316
-#: src/muuli_wdr.cpp:3064 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
+#: src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2262 src/muuli_wdr.cpp:2347
+#: src/muuli_wdr.cpp:3095 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
 #: src/ServerListCtrl.cpp:606 src/TransferWnd.cpp:378
 #: src/utils/wxCas/src/wxcasprefs.cpp:235
 msgid "Cancel"
@@ -692,7 +692,7 @@ msgid "Stop the current connection attempts"
 msgstr "Lõpeta käimasolevad ühenduskatsed"
 
 #: src/amuleDlg.cpp:1035 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976
-#: src/muuli_wdr.cpp:2454
+#: src/muuli_wdr.cpp:2485
 msgid "Disconnect"
 msgstr "Ühendu lahti"
 
@@ -701,7 +701,7 @@ msgid "Disconnect from the currently connected networks"
 msgstr "Lõpeta ühendus ühendatud võrkudega"
 
 #: src/amuleDlg.cpp:1041 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979
-#: src/muuli_wdr.cpp:2609 src/muuli_wdr.cpp:3061 src/muuli_wdr.cpp:3416
+#: src/muuli_wdr.cpp:2640 src/muuli_wdr.cpp:3092 src/muuli_wdr.cpp:3447
 msgid "Connect"
 msgstr "Ühenda"
 
@@ -756,7 +756,7 @@ msgstr "Kinnitan väljumise"
 msgid "Launch Command: "
 msgstr "Käivitamise korraldus: "
 
-#: src/amuleDlg.cpp:1632 src/muuli_wdr.cpp:1978 src/Preferences.cpp:952
+#: src/amuleDlg.cpp:1632 src/muuli_wdr.cpp:1982 src/Preferences.cpp:979
 msgid "- default -"
 msgstr "- vaikimisi -"
 
@@ -770,48 +770,48 @@ msgstr "Rüüde kataloogi  '%s' ei eksiteeri"
 msgid "WARNING: Unable to open skin file '%s' for read"
 msgstr "HOIATUS: Ei suuda rüüfaili '%s' lugemiseks avada"
 
-#: src/amuleDlg.cpp:1791 src/muuli_wdr.cpp:3418
+#: src/amuleDlg.cpp:1791 src/muuli_wdr.cpp:3449
 msgid "Networks Window"
 msgstr "Võrgud"
 
-#: src/amuleDlg.cpp:1797 src/muuli_wdr.cpp:3419
+#: src/amuleDlg.cpp:1797 src/muuli_wdr.cpp:3450
 msgid "Searches Window"
 msgstr "Otsingu aken"
 
-#: src/amuleDlg.cpp:1803 src/muuli_wdr.cpp:3420
+#: src/amuleDlg.cpp:1803 src/muuli_wdr.cpp:3451
 msgid "Downloads Window"
 msgstr "Tõmbamised"
 
-#: src/amuleDlg.cpp:1809 src/muuli_wdr.cpp:3422
+#: src/amuleDlg.cpp:1809 src/muuli_wdr.cpp:3453
 msgid "Shared Files Window"
 msgstr "Jagatud failide Aken"
 
-#: src/amuleDlg.cpp:1815 src/muuli_wdr.cpp:3423
+#: src/amuleDlg.cpp:1815 src/muuli_wdr.cpp:3454
 msgid "Messages Window"
 msgstr "Teadete Aken"
 
-#: src/amuleDlg.cpp:1821 src/muuli_wdr.cpp:3424
+#: src/amuleDlg.cpp:1821 src/muuli_wdr.cpp:3455
 msgid "Statistics Graph Window"
 msgstr "Statistiliste graafikute aken"
 
-#: src/amuleDlg.cpp:1828 src/muuli_wdr.cpp:3426
+#: src/amuleDlg.cpp:1828 src/muuli_wdr.cpp:3457
 msgid "Preferences Settings Window"
 msgstr "Seadete aken"
 
-#: src/amuleDlg.cpp:1831 src/muuli_wdr.cpp:3427
+#: src/amuleDlg.cpp:1831 src/muuli_wdr.cpp:3458
 msgid "Import"
 msgstr "Impordi"
 
-#: src/amuleDlg.cpp:1835 src/muuli_wdr.cpp:3427
+#: src/amuleDlg.cpp:1835 src/muuli_wdr.cpp:3458
 msgid "The partfile importer tool"
 msgstr "Osafailide importimise tööriist"
 
-#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3428
+#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3459
 #: src/utils/aLinkCreator/src/alcframe.cpp:262
 msgid "About"
 msgstr "Info"
 
-#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3428
+#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3459
 msgid "About/Help"
 msgstr "Info/Appi"
 
@@ -953,7 +953,7 @@ msgstr "Faili ei leitud."
 msgid "The core rejected these shared folders:%s"
 msgstr ""
 
-#: src/amule-remote-gui.cpp:1336 src/ExternalConn.cpp:2345
+#: src/amule-remote-gui.cpp:1336 src/ExternalConn.cpp:2346
 msgid "Invalid link or already on list."
 msgstr "Vigane link või on juba loetelus."
 
@@ -969,7 +969,7 @@ msgstr "Ei suuda luua kataloogi '%s' '%s' kategooria jaoks, säilitan '%s' katal
 #: src/ClientDetailDialog.cpp:123 src/DataToText.cpp:61 src/DataToText.cpp:86
 #: src/DataToText.cpp:101 src/DataToText.cpp:136 src/DataToText.cpp:165
 #: src/DownloadListCtrl.cpp:1172 src/DownloadListCtrl.cpp:1185
-#: src/DownloadListCtrl.cpp:1196 src/ExternalConn.cpp:608
+#: src/DownloadListCtrl.cpp:1196 src/ExternalConn.cpp:609
 #: src/FileDetailDialog.cpp:203 src/FileDetailDialog.cpp:235
 #: src/FileDetailDialog.cpp:242 src/GenericClientListCtrl.cpp:1171
 #: src/GenericClientListCtrl.cpp:1182 src/GenericClientListCtrl.cpp:1192
@@ -1356,19 +1356,19 @@ msgstr "Auto [Kõrge]"
 msgid "Very low"
 msgstr "Väga madal"
 
-#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:743 src/muuli_wdr.cpp:2282
+#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:743 src/muuli_wdr.cpp:2313
 #: src/ServerListCtrl.cpp:263 src/ServerListCtrl.cpp:456
 #: src/SharedFilesCtrl.cpp:145
 msgid "Low"
 msgstr "Madal"
 
-#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:744 src/muuli_wdr.cpp:2283
+#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:744 src/muuli_wdr.cpp:2314
 #: src/ServerListCtrl.cpp:266 src/ServerListCtrl.cpp:457
 #: src/SharedFilesCtrl.cpp:146
 msgid "Normal"
 msgstr "Keskmine"
 
-#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:745 src/muuli_wdr.cpp:2284
+#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:745 src/muuli_wdr.cpp:2315
 #: src/ServerListCtrl.cpp:269 src/ServerListCtrl.cpp:458
 #: src/SharedFilesCtrl.cpp:147
 msgid "High"
@@ -1460,7 +1460,7 @@ msgstr "Kohalik server"
 msgid "Remote Server"
 msgstr "Kaug server"
 
-#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3181
+#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3212
 #: src/SearchDlg.cpp:119 src/TextClient.cpp:911
 msgid "Kad"
 msgstr "Kad"
@@ -1532,7 +1532,7 @@ msgstr "Osa"
 msgid "Size"
 msgstr "Suurus"
 
-#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3248
+#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3279
 msgid "Transferred"
 msgstr "Siiratud"
 
@@ -1590,7 +1590,7 @@ msgstr ""
 "Tagasiside : %s (%s)\n"
 "\n"
 
-#: src/DownloadListCtrl.cpp:746 src/muuli_wdr.cpp:2285
+#: src/DownloadListCtrl.cpp:746 src/muuli_wdr.cpp:2316
 #: src/SharedFilesCtrl.cpp:150
 msgid "Auto"
 msgstr "Auto"
@@ -1628,7 +1628,7 @@ msgid "Extended Options"
 msgstr "Laiendatud valikud"
 
 #: src/DownloadListCtrl.cpp:770 src/DownloadListCtrl.cpp:822
-#: src/muuli_wdr.cpp:1796
+#: src/muuli_wdr.cpp:1800
 msgid "Preview"
 msgstr "Eelvaade"
 
@@ -1803,227 +1803,232 @@ msgstr[1] ""
 msgid "Invalid eD2k link! ERROR: %s"
 msgstr "Vigane eD2k link! VIGA: %s"
 
-#: src/ExternalConn.cpp:379
+#: src/ExternalConn.cpp:380
 msgid "Client sent packet after authentication failed."
 msgstr "Klient saatis paketi peale ebaõnnestunud autoriseerimist."
 
-#: src/ExternalConn.cpp:396
+#: src/ExternalConn.cpp:397
 msgid "External connection closed."
 msgstr "Välisühendus suleti"
 
-#: src/ExternalConn.cpp:473
+#: src/ExternalConn.cpp:474
 msgid "External connections disabled due to empty password!"
 msgstr "Välisühendused on tühja parooli tõttu mitteaktiivsed"
 
-#: src/ExternalConn.cpp:494
+#: src/ExternalConn.cpp:495
 msgid "External connections disabled in config file"
 msgstr "Välisühendused on konfiguratsioonifailis defineeritud mitteaktiivsena."
 
-#: src/ExternalConn.cpp:575
+#: src/ExternalConn.cpp:576
 msgid "New external connection accepted"
 msgstr "Kinnitati uus väline ühendus"
 
-#: src/ExternalConn.cpp:578
+#: src/ExternalConn.cpp:579
 msgid "ERROR: couldn't accept a new external connection"
 msgstr "VIGA: Ei suutnud uut välist ühendust aksepteerida"
 
-#: src/ExternalConn.cpp:595
+#: src/ExternalConn.cpp:596
 msgid "External connection refused due to empty password in preferences!"
 msgstr "Välisühendustest keelduti tühja parooli tõttu seadetes!"
 
-#: src/ExternalConn.cpp:607
+#: src/ExternalConn.cpp:608
 #, c-format
 msgid "Connecting client: %s %s"
 msgstr "Ühendan klienti: %s %s"
 
-#: src/ExternalConn.cpp:609
+#: src/ExternalConn.cpp:610
 msgid "Unknown version"
 msgstr "Versioon teadmata"
 
-#: src/ExternalConn.cpp:622
+#: src/ExternalConn.cpp:623
 msgid "Incorrect EC version ID, there might be binary incompatibility. Use core and remote from same snapshot."
 msgstr "Mittekorrektne Välisühenduste versiooni ID, siin võib olla binaarne kokkusobimatus.Kasuta sama versiooni tuuma ja kaugklienti."
 
-#: src/ExternalConn.cpp:630
+#: src/ExternalConn.cpp:631
 msgid "You cannot connect to a release version from an arbitrary development snapshot! *sigh* possible crash prevented"
 msgstr "Ajutise arendusversiooniga ei saa ühenduda reliisi versiooniga!!!! *RRRRRR* hoidsin ära võimaliku crässi"
 
-#: src/ExternalConn.cpp:713
+#: src/ExternalConn.cpp:714
 msgid "Invalid protocol version."
 msgstr "Vigane protokolli versioon."
 
-#: src/ExternalConn.cpp:719
+#: src/ExternalConn.cpp:720
 msgid "Missing protocol version tag."
 msgstr "Puudub protokolli versiooni märgis"
 
-#: src/ExternalConn.cpp:727
+#: src/ExternalConn.cpp:728
 msgid "Authentication failed: invalid hash specified as EC password."
 msgstr "Autoriseerimine ebaõnnestus: EC parooliks on määratud vigane räsi."
 
-#: src/ExternalConn.cpp:775
+#: src/ExternalConn.cpp:776
 msgid "Authentication failed: wrong password."
 msgstr "Autoriserimine ebaõnnestus: vale parool."
 
-#: src/ExternalConn.cpp:777
+#: src/ExternalConn.cpp:778
 msgid "Authentication failed: missing password."
 msgstr "Autoriserimine ebaõnnestus: parool puudub."
 
-#: src/ExternalConn.cpp:788
+#: src/ExternalConn.cpp:789
 msgid "Invalid request, please authenticate first."
 msgstr "Vigane päring, alustuseks pead ennast autoriseerima."
 
-#: src/ExternalConn.cpp:793
+#: src/ExternalConn.cpp:794
 msgid "Access granted."
 msgstr "Ligipääs Lubatud."
 
-#: src/ExternalConn.cpp:801
+#: src/ExternalConn.cpp:802
 #, c-format
 msgid "Sent error message \"%s\" to client."
 msgstr "Veateade \"%s\" kliendile saadetud."
 
-#: src/ExternalConn.cpp:806
+#: src/ExternalConn.cpp:807
 #, c-format
 msgid "Unauthorized access attempt from %s. Connection closed."
 msgstr "Autoriseerimata pääsukatse %s. Ühendus suletud."
 
-#: src/ExternalConn.cpp:1419
+#: src/ExternalConn.cpp:1420
 #, c-format
 msgid "Remote PartFile command failed: FileHash not found: %s"
 msgstr "Kaug OsaFaili käsk ebaõnnestus: Faili kontrollsummat ei leidnud: %s"
 
-#: src/ExternalConn.cpp:1423
+#: src/ExternalConn.cpp:1424
 #, c-format
 msgid "FileHash not found: %s"
 msgstr "Faili '%s' kontrollsummat ei leitud"
 
-#: src/ExternalConn.cpp:1470 src/ExternalConn.cpp:1558
-#: src/ExternalConn.cpp:1679
+#: src/ExternalConn.cpp:1471 src/ExternalConn.cpp:1559
+#: src/ExternalConn.cpp:1680
 msgid "OOPS! OpCode processing error!"
 msgstr "OOPS! OpCode töötlemise viga!"
 
-#: src/ExternalConn.cpp:1501
+#: src/ExternalConn.cpp:1502
 msgid "Server not added"
 msgstr "Serverit ei lisatud"
 
-#: src/ExternalConn.cpp:1520
+#: src/ExternalConn.cpp:1521
 #, c-format
 msgid "server not found: %s"
 msgstr "serverit ei leidnud: %s"
 
-#: src/ExternalConn.cpp:1537
+#: src/ExternalConn.cpp:1538
 msgid "need to define server to be removed"
 msgstr "eemaldatav server on vaja määrata"
 
-#: src/ExternalConn.cpp:1552
+#: src/ExternalConn.cpp:1553
 msgid "eD2k is disabled in preferences."
 msgstr "eD2k on seadetes väljalülitatud."
 
-#: src/ExternalConn.cpp:1657
+#: src/ExternalConn.cpp:1658
 #, fuzzy
 msgid "Friend not found."
 msgstr "Faili ei leitud."
 
-#: src/ExternalConn.cpp:1667
+#: src/ExternalConn.cpp:1668
 #, fuzzy
 msgid "Client not found."
 msgstr "Faili ei leitud."
 
-#: src/ExternalConn.cpp:1673
+#: src/ExternalConn.cpp:1674
 msgid "EC_TAG_FRIEND_SHARED requires EC_TAG_FRIEND or EC_TAG_CLIENT."
 msgstr ""
 
-#: src/ExternalConn.cpp:1991
+#: src/ExternalConn.cpp:1992
 msgid "WebSearch from remote interface makes no sense."
 msgstr "Web Otsing kaugtöökohast ei oma mõtet."
 
-#: src/ExternalConn.cpp:2026
+#: src/ExternalConn.cpp:2027
 msgid "Search in progress. Refetch results in a moment!"
 msgstr "Otsing on käimas. Varsti näed tulemusi!"
 
-#: src/ExternalConn.cpp:2265
+#: src/ExternalConn.cpp:2266
 msgid "No points for graph."
 msgstr "Graafiku jaoks pole punkte."
 
-#: src/ExternalConn.cpp:2275
+#: src/ExternalConn.cpp:2276
 msgid "Your client is not configured for this detail level."
 msgstr "Sinu klient pole seadistatud sellise detailsuse astme jaoks."
 
-#: src/ExternalConn.cpp:2302
+#: src/ExternalConn.cpp:2303
 msgid "External Connection: shutdown requested"
 msgstr "Väline Ühendus: nõutakse seiskamist"
 
-#: src/ExternalConn.cpp:2314
+#: src/ExternalConn.cpp:2315
 msgid "Already shutting down."
 msgstr "Juba sulgun..."
 
-#: src/ExternalConn.cpp:2332
+#: src/ExternalConn.cpp:2333
 #, c-format
 msgid "ExternalConn: adding link '%s'."
 msgstr "Väline ühendus: lisan lingi '%s'."
 
-#: src/ExternalConn.cpp:2350
+#: src/ExternalConn.cpp:2351
 #, fuzzy, c-format
 msgid "%d of %d links failed (invalid or already on list)."
 msgstr "Vigane link või on juba loetelus."
 
-#: src/ExternalConn.cpp:2373
+#: src/ExternalConn.cpp:2374
 msgid "Version check throttled; try again shortly."
 msgstr ""
 
-#: src/ExternalConn.cpp:2378
+#: src/ExternalConn.cpp:2379
 msgid "Version check is not available on this daemon."
 msgstr ""
 
-#: src/ExternalConn.cpp:2508
+#: src/ExternalConn.cpp:2509
 msgid "File not found."
 msgstr "Faili ei leitud."
 
-#: src/ExternalConn.cpp:2513
+#: src/ExternalConn.cpp:2514
 msgid "Invalid file name."
 msgstr "Vigane failinimi."
 
-#: src/ExternalConn.cpp:2521
+#: src/ExternalConn.cpp:2522
 msgid "Unable to rename file."
 msgstr "Ei suuda faili ringinimetada."
 
-#: src/ExternalConn.cpp:2992 src/ExternalConn.cpp:3020
+#: src/ExternalConn.cpp:2839
+#, c-format
+msgid "Could not save the amuleapi password: %s"
+msgstr ""
+
+#: src/ExternalConn.cpp:3004 src/ExternalConn.cpp:3032
 msgid "Kad is disabled in preferences."
 msgstr "Kad on seadetes väljalülitatud."
 
-#: src/ExternalConn.cpp:3033
+#: src/ExternalConn.cpp:3045
 msgid "Already connected to eD2k."
 msgstr "Juba ühendatud eD2k võrku."
 
-#: src/ExternalConn.cpp:3036
+#: src/ExternalConn.cpp:3048
 msgid "Connecting to eD2k..."
 msgstr "Ühendun eD2k..."
 
-#: src/ExternalConn.cpp:3045
+#: src/ExternalConn.cpp:3057
 msgid "Already connected to Kad."
 msgstr "Juba ühendatud Kad võrku."
 
-#: src/ExternalConn.cpp:3048
+#: src/ExternalConn.cpp:3060
 msgid "Connecting to Kad..."
 msgstr "Ühendun Kad..."
 
-#: src/ExternalConn.cpp:3055
+#: src/ExternalConn.cpp:3067
 msgid "All networks are disabled."
 msgstr "Kõik võrgud on väljalülitatud."
 
-#: src/ExternalConn.cpp:3064
+#: src/ExternalConn.cpp:3076
 msgid "Disconnected from eD2k."
 msgstr "eD2k ühendus katkestatud."
 
-#: src/ExternalConn.cpp:3069
+#: src/ExternalConn.cpp:3081
 msgid "Disconnected from Kad."
 msgstr "Kad ühendus katkestatud."
 
-#: src/ExternalConn.cpp:3078
+#: src/ExternalConn.cpp:3090
 #, c-format
 msgid "External Connection: invalid opcode received: %#x"
 msgstr "Väline Ühendus: sain vigase opkoodi: %#x"
 
-#: src/ExternalConn.cpp:3083
+#: src/ExternalConn.cpp:3095
 msgid "Invalid opcode (wrong protocol version?)"
 msgstr "Vigane opcode (vale protokolli versioon?)"
 
@@ -2424,23 +2429,23 @@ msgid ""
 "want downloads on a different (e.g. larger) disk."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:549 src/FirstRunWizard.cpp:611 src/muuli_wdr.cpp:1708
+#: src/FirstRunWizard.cpp:549 src/FirstRunWizard.cpp:611 src/muuli_wdr.cpp:1712
 msgid "Destination folder for downloads"
 msgstr "Tõmmatavate failide kataloog"
 
 #: src/FirstRunWizard.cpp:553 src/FirstRunWizard.cpp:569 src/muuli_wdr.cpp:1349
-#: src/muuli_wdr.cpp:1366 src/muuli_wdr.cpp:1683 src/muuli_wdr.cpp:1714
-#: src/muuli_wdr.cpp:1726 src/muuli_wdr.cpp:2769
+#: src/muuli_wdr.cpp:1366 src/muuli_wdr.cpp:1687 src/muuli_wdr.cpp:1718
+#: src/muuli_wdr.cpp:1730 src/muuli_wdr.cpp:2800
 #: src/utils/aLinkCreator/src/alcframe.cpp:135
 #: src/utils/wxCas/src/wxcasprefs.cpp:52 src/utils/wxCas/src/wxcasprefs.cpp:118
 msgid "Browse"
 msgstr "Lehitse"
 
-#: src/FirstRunWizard.cpp:559 src/muuli_wdr.cpp:1719
+#: src/FirstRunWizard.cpp:559 src/muuli_wdr.cpp:1723
 msgid "(All files in this folder are shared with other peers)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:565 src/FirstRunWizard.cpp:624 src/muuli_wdr.cpp:1721
+#: src/FirstRunWizard.cpp:565 src/FirstRunWizard.cpp:624 src/muuli_wdr.cpp:1725
 msgid "Folder for temporary download files"
 msgstr "Ajutiste tõmmatavate failide kataloog"
 
@@ -2471,7 +2476,7 @@ msgstr "Sõprade faili 'emfriends.met' avamine kirjutamiseks ebaõnnestus!"
 msgid "CRITICAL - no client on StartChatSession"
 msgstr "KRIITILINE - StartChatSession puudub klient"
 
-#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2675 src/muuli_wdr.cpp:3352
+#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2706 src/muuli_wdr.cpp:3383
 msgid "Friends"
 msgstr "Sõbrad"
 
@@ -2582,8 +2587,8 @@ msgstr "Mitte keegi"
 msgid "No"
 msgstr "Ei"
 
-#: src/GenericClientListCtrl.cpp:1216 src/PrefsUnifiedDlg.cpp:2818
-#: src/PrefsUnifiedDlg.cpp:2868 src/ServerListCtrl.cpp:276
+#: src/GenericClientListCtrl.cpp:1216 src/PrefsUnifiedDlg.cpp:2898
+#: src/PrefsUnifiedDlg.cpp:2948 src/ServerListCtrl.cpp:276
 msgid "Yes"
 msgstr "Jah"
 
@@ -2752,10 +2757,10 @@ msgstr "Bootstrapil vigane port"
 msgid "Please fill all fields required"
 msgstr "Palun täida kõik nõutud väljad"
 
-#: src/KadDlg.cpp:192 src/PartFile.cpp:1031 src/PrefsUnifiedDlg.cpp:1162
-#: src/PrefsUnifiedDlg.cpp:1331 src/PrefsUnifiedDlg.cpp:1589
-#: src/PrefsUnifiedDlg.cpp:1599 src/PrefsUnifiedDlg.cpp:1616
-#: src/PrefsUnifiedDlg.cpp:1658
+#: src/KadDlg.cpp:192 src/PartFile.cpp:1031 src/PrefsUnifiedDlg.cpp:1134
+#: src/PrefsUnifiedDlg.cpp:1204 src/PrefsUnifiedDlg.cpp:1405
+#: src/PrefsUnifiedDlg.cpp:1663 src/PrefsUnifiedDlg.cpp:1673
+#: src/PrefsUnifiedDlg.cpp:1690 src/PrefsUnifiedDlg.cpp:1738
 msgid "Message"
 msgstr "Teade"
 
@@ -2857,7 +2862,7 @@ msgstr "Üles- ja allalaadimise suhe"
 msgid "Uploaded"
 msgstr "Üleslaaditud"
 
-#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3232
+#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3263
 msgid "Requested"
 msgstr "Küsitud"
 
@@ -2981,7 +2986,7 @@ msgid "WARNING: "
 msgstr "HOIATUS: "
 
 #: src/MuleNotebook.cpp:179 src/muuli_wdr.cpp:817 src/muuli_wdr.cpp:1229
-#: src/muuli_wdr.cpp:3136 src/muuli_wdr.cpp:3392
+#: src/muuli_wdr.cpp:3167 src/muuli_wdr.cpp:3423
 msgid "Close"
 msgstr "Sulge"
 
@@ -2999,7 +3004,7 @@ msgid "Paste"
 msgstr "Aseta"
 
 #: src/MuleTextCtrl.cpp:89 src/muuli_wdr.cpp:358 src/muuli_wdr.cpp:757
-#: src/muuli_wdr.cpp:2359 src/muuli_wdr.cpp:2378 src/muuli_wdr.cpp:2400
+#: src/muuli_wdr.cpp:2390 src/muuli_wdr.cpp:2409 src/muuli_wdr.cpp:2431
 #: src/utils/aLinkCreator/src/alcframe.cpp:142
 msgid "Clear"
 msgstr "Puhasta"
@@ -3098,7 +3103,7 @@ msgstr "Välju"
 
 #: src/MuleTrayIcon.cpp:579 src/MuleTrayIcon.cpp:945 src/MuleTrayIcon.cpp:965
 #: src/muuli_wdr.cpp:1398 src/muuli_wdr.cpp:1406 src/muuli_wdr.cpp:1413
-#: src/muuli_wdr.cpp:1842 src/muuli_wdr.cpp:1848 src/OtherFunctions.cpp:91
+#: src/muuli_wdr.cpp:1846 src/muuli_wdr.cpp:1852 src/OtherFunctions.cpp:91
 #: src/StatisticsDlg.cpp:93 src/StatisticsDlg.cpp:95
 msgid "kB/s"
 msgstr "kB/s"
@@ -3340,7 +3345,7 @@ msgstr "Baiti"
 msgid "KB"
 msgstr "KB"
 
-#: src/muuli_wdr.cpp:274 src/muuli_wdr.cpp:293 src/muuli_wdr.cpp:1627
+#: src/muuli_wdr.cpp:274 src/muuli_wdr.cpp:293 src/muuli_wdr.cpp:1631
 #: src/OtherFunctions.cpp:64
 msgid "MB"
 msgstr "MB"
@@ -3357,7 +3362,7 @@ msgstr "Suurim Suurus"
 msgid "Availability"
 msgstr "Saadavus"
 
-#: src/muuli_wdr.cpp:312 src/muuli_wdr.cpp:398 src/muuli_wdr.cpp:3297
+#: src/muuli_wdr.cpp:312 src/muuli_wdr.cpp:398 src/muuli_wdr.cpp:3328
 msgid "Filter:"
 msgstr "Filter:"
 
@@ -3420,12 +3425,12 @@ msgstr "Faili allikad:"
 #: src/muuli_wdr.cpp:1160 src/muuli_wdr.cpp:1167 src/muuli_wdr.cpp:1172
 #: src/muuli_wdr.cpp:1179 src/muuli_wdr.cpp:1184 src/muuli_wdr.cpp:1191
 #: src/muuli_wdr.cpp:1205 src/muuli_wdr.cpp:1212 src/muuli_wdr.cpp:1217
-#: src/muuli_wdr.cpp:1224 src/muuli_wdr.cpp:3234 src/muuli_wdr.cpp:3242
-#: src/muuli_wdr.cpp:3250
+#: src/muuli_wdr.cpp:1224 src/muuli_wdr.cpp:3265 src/muuli_wdr.cpp:3273
+#: src/muuli_wdr.cpp:3281
 msgid "N/A"
 msgstr "N/A"
 
-#: src/muuli_wdr.cpp:508 src/muuli_wdr.cpp:1065 src/PrefsUnifiedDlg.cpp:297
+#: src/muuli_wdr.cpp:508 src/muuli_wdr.cpp:1065 src/PrefsUnifiedDlg.cpp:299
 msgid "General"
 msgstr "Üldine"
 
@@ -3566,7 +3571,7 @@ msgstr ""
 msgid "Album :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:685 src/muuli_wdr.cpp:2254
+#: src/muuli_wdr.cpp:685 src/muuli_wdr.cpp:2285
 msgid "Title :"
 msgstr "Tiitel :"
 
@@ -3675,7 +3680,7 @@ msgstr "Kasutajanimi :"
 msgid "Userhash :"
 msgstr "Kasutaja kontrollsumma :"
 
-#: src/muuli_wdr.cpp:895 src/muuli_wdr.cpp:1748 src/muuli_wdr.cpp:2449
+#: src/muuli_wdr.cpp:895 src/muuli_wdr.cpp:1752 src/muuli_wdr.cpp:2480
 #: src/utils/aLinkCreator/src/alcframe.cpp:137
 msgid "Add"
 msgstr "Lisa"
@@ -3684,15 +3689,15 @@ msgstr "Lisa"
 msgid "Download-Speed"
 msgstr "Tõmbamise kiirus"
 
-#: src/muuli_wdr.cpp:954 src/muuli_wdr.cpp:989 src/muuli_wdr.cpp:2553
+#: src/muuli_wdr.cpp:954 src/muuli_wdr.cpp:989 src/muuli_wdr.cpp:2584
 msgid "Current"
 msgstr "Hetkel"
 
-#: src/muuli_wdr.cpp:962 src/muuli_wdr.cpp:997 src/muuli_wdr.cpp:2561
+#: src/muuli_wdr.cpp:962 src/muuli_wdr.cpp:997 src/muuli_wdr.cpp:2592
 msgid "Running average"
 msgstr "Hetke keskmine"
 
-#: src/muuli_wdr.cpp:970 src/muuli_wdr.cpp:1005 src/muuli_wdr.cpp:2569
+#: src/muuli_wdr.cpp:970 src/muuli_wdr.cpp:1005 src/muuli_wdr.cpp:2600
 msgid "Session average"
 msgstr "Seansi keskmine"
 
@@ -3704,7 +3709,7 @@ msgstr "Saatmise kiirus"
 msgid "Connections"
 msgstr "Ühendused"
 
-#: src/muuli_wdr.cpp:1024 src/muuli_wdr.cpp:1867
+#: src/muuli_wdr.cpp:1024 src/muuli_wdr.cpp:1871
 msgid "Active downloads"
 msgstr "Aktiivsed tõmbamised"
 
@@ -3712,7 +3717,7 @@ msgstr "Aktiivsed tõmbamised"
 msgid "Active connections (1:1)"
 msgstr "Aktiivseid ühendusi (1:1)"
 
-#: src/muuli_wdr.cpp:1040 src/muuli_wdr.cpp:1868
+#: src/muuli_wdr.cpp:1040 src/muuli_wdr.cpp:1872
 msgid "Active uploads"
 msgstr "Aktiivsed saatmised"
 
@@ -3988,7 +3993,7 @@ msgstr "Seo lokaalne aadress IP'ga (suvaliseks jäta tühjaks)"
 msgid "Advanced users only: If you have multiple network interfaces, enter the address of the interface to which aMule should be bound."
 msgstr "Ainult edasijõudnud kasutajatele: Kui sul on kasutada mitu võrguliidest, siis sisesta selle liidese aadress millega aMule võib ennast siduda."
 
-#: src/muuli_wdr.cpp:1462 src/muuli_wdr.cpp:2061
+#: src/muuli_wdr.cpp:1462 src/muuli_wdr.cpp:2065
 #, fuzzy
 msgid "Bind to network interface (empty for any):"
 msgstr "Seo lokaalne aadress IP'ga (suvaliseks jäta tühjaks)"
@@ -4005,7 +4010,7 @@ msgstr "Maksimaalseid allikaid tõmmatava faili kohta:"
 msgid "Max simultaneous connections:"
 msgstr "Maksimaalselt samaaegseid ühendusi:"
 
-#: src/muuli_wdr.cpp:1498 src/muuli_wdr.cpp:3176
+#: src/muuli_wdr.cpp:1498 src/muuli_wdr.cpp:3207
 msgid "ED2K"
 msgstr "ED2K"
 
@@ -4097,756 +4102,779 @@ msgstr "Eralda kettaruum uute failide jaoks"
 msgid "For new files preallocates disk space for the whole file, thus reduces fragmentation"
 msgstr "Eraldab uuet failide jaoks vajamineva kettaruumi, seeläbi väheneb faili fragmenteerumine"
 
-#: src/muuli_wdr.cpp:1613
+#: src/muuli_wdr.cpp:1617
 msgid "Create new files as sparse files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1614
-msgid "A sparse file reserves its full size on disk immediately without writing real data to it -- fast, but unsupported or slow on some filesystems, and free-space accounting stays optimistic while the download is in progress. Turn this off to grow the file only as data arrives."
+#: src/muuli_wdr.cpp:1618
+msgid "Sparse part files only occupy disk space for the parts already downloaded, so free space is used up gradually as the file fills in. Turn this off to use an ordinary file instead - useful where sparse files are unsupported or slow, or where backup/de-duplication tools handle them badly. Applies only when the core runs on Windows; on Linux and macOS part files are sparse anyway and this setting has no effect."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1619
+#: src/muuli_wdr.cpp:1623
 msgid "Stop downloads when free disk space reaches "
 msgstr "Lõpeta tõmbamine, kui vaba kettaruumi on jäänud "
 
-#: src/muuli_wdr.cpp:1620
+#: src/muuli_wdr.cpp:1624
 msgid "Select this if you want aMule to check your disk space"
 msgstr "Vali see kui soovid et aMule sinu kettaruumi kontrolliks"
 
-#: src/muuli_wdr.cpp:1624
+#: src/muuli_wdr.cpp:1628
 msgid "Enter here the min disk space desired."
 msgstr "Sisesta siia vähim soovitud kettaruum"
 
-#: src/muuli_wdr.cpp:1630
+#: src/muuli_wdr.cpp:1634
 msgid "Save 10 sources on rare files (< 20 sources)"
 msgstr "Salvesta haruldaste failide 10 allikat (< 20 allikat)"
 
-#: src/muuli_wdr.cpp:1634 src/Statistics.cpp:790
+#: src/muuli_wdr.cpp:1638 src/Statistics.cpp:790
 msgid "Uploads"
 msgstr "Saatmised"
 
-#: src/muuli_wdr.cpp:1637
+#: src/muuli_wdr.cpp:1641
 msgid "Add new shared files with auto priority"
 msgstr "Lisa uued jagatud failid automaatse prioriteediga"
 
-#: src/muuli_wdr.cpp:1643
+#: src/muuli_wdr.cpp:1647
 msgid "Intelligent Corruption Handling (I.C.H.)"
 msgstr "Intelligentne Riknemise Vältimine (I.C.H.)"
 
-#: src/muuli_wdr.cpp:1646
+#: src/muuli_wdr.cpp:1650
 msgid "Enable"
 msgstr "Luba"
 
-#: src/muuli_wdr.cpp:1649
+#: src/muuli_wdr.cpp:1653
 msgid "Advanced I.C.H. trusts every hash (not recommended)"
 msgstr "Laiendatud I.C.H. usaldab suvalist kontrollsummat (pole soovitatav valik)"
 
-#: src/muuli_wdr.cpp:1661 src/PrefsUnifiedDlg.cpp:1910
+#: src/muuli_wdr.cpp:1665 src/PrefsUnifiedDlg.cpp:1990
 msgid "Media metadata extraction"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1665
+#: src/muuli_wdr.cpp:1669
 msgid "Extract length / bitrate / codec from shared audio and video files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1667
+#: src/muuli_wdr.cpp:1671
 msgid "When enabled, aMule runs ffprobe on each shared media file to fill in the Length / Bitrate / Codec columns other clients see when they find the file in a search. Requires ffmpeg (the ffprobe binary) to be installed."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1674
+#: src/muuli_wdr.cpp:1678
 msgid "Path to ffprobe:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1679
+#: src/muuli_wdr.cpp:1683
 msgid "Full path to the ffprobe binary. Leave empty to have aMule auto-detect it on startup."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1687
+#: src/muuli_wdr.cpp:1691
 msgid "Detect"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1688
+#: src/muuli_wdr.cpp:1692
 msgid "Search the standard install locations for an ffprobe binary and fill the path field."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1712
+#: src/muuli_wdr.cpp:1716
 msgid ""
 "Completed downloads are stored here. All files in this folder are automatically shared with other peers.\n"
 "If this folder also holds files you don't want to share, point it at an aMule-only sub-folder."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1715
+#: src/muuli_wdr.cpp:1719
 msgid "Pick the folder where completed downloads will be stored. All files in that folder will be shared with other peers."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1729
+#: src/muuli_wdr.cpp:1733
 msgid "Shared folders"
 msgstr "Jagatud kataloogid"
 
-#: src/muuli_wdr.cpp:1735
+#: src/muuli_wdr.cpp:1739
 msgid "(Folders shared by the core. Enter a path to add one.)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1743
+#: src/muuli_wdr.cpp:1747
 msgid "Absolute path of a folder on the core's machine, e.g. /home/user/shared"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1745 src/PrefsUnifiedDlg.cpp:2794
+#: src/muuli_wdr.cpp:1749 src/PrefsUnifiedDlg.cpp:2874
 msgid "Recursive"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1746
+#: src/muuli_wdr.cpp:1750
 msgid "Share every sub-folder underneath this one, including ones created later."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1750 src/utils/aLinkCreator/src/alcframe.cpp:141
+#: src/muuli_wdr.cpp:1754 src/utils/aLinkCreator/src/alcframe.cpp:141
 msgid "Remove"
 msgstr "Eemalda"
 
-#: src/muuli_wdr.cpp:1754
+#: src/muuli_wdr.cpp:1758
 msgid "(Right click on folder icon for recursive share)"
 msgstr "(Rekursiivseks jagamiseks tee paremklikk kataloogi ikoonil)"
 
-#: src/muuli_wdr.cpp:1761
+#: src/muuli_wdr.cpp:1765
 msgid "Share hidden files"
 msgstr "Jaga peidetud failid"
 
-#: src/muuli_wdr.cpp:1767
+#: src/muuli_wdr.cpp:1771
 msgid "Automatically rescan shared folders for changes"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1773
+#: src/muuli_wdr.cpp:1777
 msgid "Follow symbolic links in shared folders"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1779
+#: src/muuli_wdr.cpp:1783
 msgid "Exclude files matching:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1782
+#: src/muuli_wdr.cpp:1786
 msgid "Wildcard patterns separated by '|', e.g. .DS_Store|Thumbs.db|*.tmp. Files whose name matches are not shared. Matching is case-insensitive."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1786
+#: src/muuli_wdr.cpp:1790
 msgid "Patterns are regular expressions"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1787
+#: src/muuli_wdr.cpp:1791
 msgid "When set, the whole field is one regular expression ('|' is alternation). When unset, it is a list of '|'-separated wildcards."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1797
+#: src/muuli_wdr.cpp:1801
 msgid "Show how many shared files the current pattern would exclude."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1818
+#: src/muuli_wdr.cpp:1822
 msgid "Graphs"
 msgstr "Graafikud"
 
-#: src/muuli_wdr.cpp:1821 src/muuli_wdr.cpp:1883
+#: src/muuli_wdr.cpp:1825 src/muuli_wdr.cpp:1887
 msgid "Update delay : 5 secs"
 msgstr "Värskenduste vahe : 5 sekundit"
 
-#: src/muuli_wdr.cpp:1825
+#: src/muuli_wdr.cpp:1829
 msgid "Time for average graph: 100 mins"
 msgstr "Keskmine graafiku aeg: 100 minutit"
 
-#: src/muuli_wdr.cpp:1829
+#: src/muuli_wdr.cpp:1833
 msgid "Connections Graph Scale: 100 "
 msgstr "Ühenduse graafiku skaala: 100"
 
-#: src/muuli_wdr.cpp:1836
+#: src/muuli_wdr.cpp:1840
 msgid "Download graph scale:"
 msgstr "Tõmbamise graafiku skaala:"
 
-#: src/muuli_wdr.cpp:1844
+#: src/muuli_wdr.cpp:1848
 msgid "Upload graph scale:"
 msgstr "Saatmise graafiku skaala:"
 
-#: src/muuli_wdr.cpp:1854
+#: src/muuli_wdr.cpp:1858
 #, fuzzy
 msgid "Colors: "
 msgstr "Värvid: "
 
-#: src/muuli_wdr.cpp:1858
+#: src/muuli_wdr.cpp:1862
 msgid "Background"
 msgstr "Taust"
 
-#: src/muuli_wdr.cpp:1859
+#: src/muuli_wdr.cpp:1863
 msgid "Grid"
 msgstr "Alusvõrk"
 
-#: src/muuli_wdr.cpp:1860
+#: src/muuli_wdr.cpp:1864
 msgid "Download current"
 msgstr "Allalaadimine, jooksev"
 
-#: src/muuli_wdr.cpp:1861
+#: src/muuli_wdr.cpp:1865
 msgid "Download running average"
 msgstr "Allalaadimine, jooksev keskmine"
 
-#: src/muuli_wdr.cpp:1862
+#: src/muuli_wdr.cpp:1866
 msgid "Download session average"
 msgstr "Allalaadimine, seansi keskmine"
 
-#: src/muuli_wdr.cpp:1863
+#: src/muuli_wdr.cpp:1867
 msgid "Upload current"
 msgstr "Saatmine hetkel"
 
-#: src/muuli_wdr.cpp:1864
+#: src/muuli_wdr.cpp:1868
 msgid "Upload running average"
 msgstr "Hetke saatmise keskmine"
 
-#: src/muuli_wdr.cpp:1865
+#: src/muuli_wdr.cpp:1869
 msgid "Upload session average"
 msgstr "Seansi keskmine saatmine"
 
-#: src/muuli_wdr.cpp:1866
+#: src/muuli_wdr.cpp:1870
 msgid "Active connections"
 msgstr "Aktiivseid ühendusi"
 
-#: src/muuli_wdr.cpp:1869
+#: src/muuli_wdr.cpp:1873
 #, fuzzy
 msgid "Systray Icon Speed Bar"
 msgstr "Süsteemiriba Kiirvaliku Ikoon"
 
-#: src/muuli_wdr.cpp:1870
+#: src/muuli_wdr.cpp:1874
 msgid "Kad-nodes current"
 msgstr "Kad-sõlmi hetkel"
 
-#: src/muuli_wdr.cpp:1871
+#: src/muuli_wdr.cpp:1875
 msgid "Kad-nodes running"
 msgstr "Kad-sõlmi jooksvalt"
 
-#: src/muuli_wdr.cpp:1872
+#: src/muuli_wdr.cpp:1876
 msgid "Kad-nodes session"
 msgstr "Kad-sõlmi seansis"
 
-#: src/muuli_wdr.cpp:1876 src/muuli_wdr.cpp:2303
+#: src/muuli_wdr.cpp:1880 src/muuli_wdr.cpp:2334
 msgid "Select"
 msgstr "Vali"
 
-#: src/muuli_wdr.cpp:1880
+#: src/muuli_wdr.cpp:1884
 msgid "Tree"
 msgstr "Puu"
 
-#: src/muuli_wdr.cpp:1890
+#: src/muuli_wdr.cpp:1894
 msgid "Number of Client Versions shown (0=unlimited)"
 msgstr "Kuvatavate Kliendi Versioonide arv (0=piiramatu)"
 
-#: src/muuli_wdr.cpp:1915
+#: src/muuli_wdr.cpp:1919
 msgid "!!! WARNING !!!"
 msgstr "!!! HOIATUS !!!"
 
-#: src/muuli_wdr.cpp:1930
+#: src/muuli_wdr.cpp:1934
 msgid "Max new connections / 5 secs"
 msgstr "Maksimaalne arv uusi ühendusi / 5 sek."
 
-#: src/muuli_wdr.cpp:1932
+#: src/muuli_wdr.cpp:1936
 msgid "Concurrent Kad source lookups"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1934
+#: src/muuli_wdr.cpp:1938
 #, fuzzy
 msgid "Kad source re-search interval (minutes)"
 msgstr "FTP värskendamise intervall minutites"
 
-#: src/muuli_wdr.cpp:1936
+#: src/muuli_wdr.cpp:1940
 #, fuzzy
 msgid "Source re-ask interval (minutes)"
 msgstr "FTP värskendamise intervall minutites"
 
-#: src/muuli_wdr.cpp:1940
+#: src/muuli_wdr.cpp:1944
 msgid "File Buffer Size: 240000 bytes"
 msgstr "Faili puhvri suurus: 240000 baiti"
 
-#: src/muuli_wdr.cpp:1944
+#: src/muuli_wdr.cpp:1948
 msgid "Use MMAP: memory-mapped file access (lower memory use)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1945
+#: src/muuli_wdr.cpp:1949
 msgid "Maps part files into memory instead of buffering them on the heap, lowering the process memory footprint. May reduce download speed on some disks; best for memory-constrained or upload-heavy hosts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1947
+#: src/muuli_wdr.cpp:1951
 msgid "Upload Queue Size: 5000 clients"
 msgstr "Saatmise saba suurus: 5000 klienti"
 
-#: src/muuli_wdr.cpp:1951
+#: src/muuli_wdr.cpp:1955
 msgid "Server connection refresh interval: Disable"
 msgstr "Serveriühenduse värskenadamise intervall: Ei kasuta"
 
-#: src/muuli_wdr.cpp:1955
+#: src/muuli_wdr.cpp:1959
 msgid "Disable computer's timed standby mode"
 msgstr "Keela arvuti ajastatud uinumine"
 
-#: src/muuli_wdr.cpp:1974
+#: src/muuli_wdr.cpp:1978
 msgid "Skin to use: "
 msgstr "Kasutatav rüü: "
 
-#: src/muuli_wdr.cpp:1983
+#: src/muuli_wdr.cpp:1987
 msgid "Show \"Fast eD2k Links Handler\" in every window."
 msgstr "Näita igas aknas \"Kiiret eD2k lingi käsitlejat\". "
 
-#: src/muuli_wdr.cpp:1986
+#: src/muuli_wdr.cpp:1990
 msgid "Show extended info on categories tabs"
 msgstr "Näita kategooria juures laiendatud infot"
 
-#: src/muuli_wdr.cpp:1989
+#: src/muuli_wdr.cpp:1993
 #, fuzzy
 msgid "Show application version on title"
 msgstr "Näita tiitelribal siirdamise kiirusi"
 
-#: src/muuli_wdr.cpp:1991
+#: src/muuli_wdr.cpp:1995
 msgid "Show transfer rates on title"
 msgstr "Näita tiitelribal siirdamise kiirusi"
 
-#: src/muuli_wdr.cpp:1993
+#: src/muuli_wdr.cpp:1997
 msgid "Before application name"
 msgstr "Eelmise rakenduse nimi"
 
-#: src/muuli_wdr.cpp:1995
+#: src/muuli_wdr.cpp:1999
 msgid "After application name"
 msgstr "Järgneva rakenduse nimi"
 
-#: src/muuli_wdr.cpp:1998
+#: src/muuli_wdr.cpp:2002
 msgid "Show overhead bandwidth"
 msgstr "Näita raisatud ribalaiust"
 
-#: src/muuli_wdr.cpp:2002
+#: src/muuli_wdr.cpp:2006
 msgid "Vertical toolbar orientation"
 msgstr "Vertikaalne tööriistariba paigutus"
 
-#: src/muuli_wdr.cpp:2004
+#: src/muuli_wdr.cpp:2008
 msgid "Live column sorting (auto-reorder rows as their values change)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2011
+#: src/muuli_wdr.cpp:2015
 msgid "Download Queue Files"
 msgstr "Tõmbamise Järjekorrafailid"
 
-#: src/muuli_wdr.cpp:2014
+#: src/muuli_wdr.cpp:2018
 msgid "Show progress percentage"
 msgstr "Näita edenemist protsentuaalselt"
 
-#: src/muuli_wdr.cpp:2020
+#: src/muuli_wdr.cpp:2024
 msgid "Show progress bar"
 msgstr "Näita edenemise riba"
 
-#: src/muuli_wdr.cpp:2023
+#: src/muuli_wdr.cpp:2027
 msgid "Flat"
 msgstr "Lame"
 
-#: src/muuli_wdr.cpp:2027
+#: src/muuli_wdr.cpp:2031
 msgid "Round"
 msgstr "Ümar"
 
-#: src/muuli_wdr.cpp:2045
+#: src/muuli_wdr.cpp:2049
 msgid "External Connection Parameters"
 msgstr "Välisühenduse parameetrid"
 
-#: src/muuli_wdr.cpp:2048
+#: src/muuli_wdr.cpp:2052
 msgid "Accept external connections"
 msgstr "Aksepteeri väliseid ühendusi"
 
-#: src/muuli_wdr.cpp:2055 src/muuli_wdr.cpp:2114
+#: src/muuli_wdr.cpp:2059 src/muuli_wdr.cpp:2118
 msgid "IP of the listening interface:"
 msgstr "Kuulava liidese IP aadress:"
 
-#: src/muuli_wdr.cpp:2058
+#: src/muuli_wdr.cpp:2062
 msgid "Enter here a valid ip in the a.b.c.d format for the listening EC interface. An empty field or 0.0.0.0 will mean any interface."
 msgstr "Sisesta siia välisühenduse liidese kehtiv ip aadress a.b.c.d formaadis. Tühi väli või 0.0.0.0 tähendab suvalist liidest."
 
-#: src/muuli_wdr.cpp:2079 src/muuli_wdr.cpp:2163
+#: src/muuli_wdr.cpp:2083 src/muuli_wdr.cpp:2194
 msgid "TCP port:"
 msgstr "TCP port:"
 
-#: src/muuli_wdr.cpp:2085
+#: src/muuli_wdr.cpp:2089
 msgid "Enable UPnP port forwarding on the EC port"
 msgstr "Luba UPnP pordisuunamist EC pordile"
 
-#: src/muuli_wdr.cpp:2089 src/muuli_wdr.cpp:3048
+#: src/muuli_wdr.cpp:2093 src/muuli_wdr.cpp:3079
 #: src/utils/wxCas/src/wxcasprefs.cpp:167
 msgid "Password"
 msgstr "Parool"
 
-#: src/muuli_wdr.cpp:2095
+#: src/muuli_wdr.cpp:2099
 #, fuzzy
 msgid "aMule API server parameters"
 msgstr "Web serveri seaded"
 
-#: src/muuli_wdr.cpp:2098
+#: src/muuli_wdr.cpp:2102
 msgid "Run amuleapi (REST API) on startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2103
+#: src/muuli_wdr.cpp:2107
 #, fuzzy
 msgid "HTTP port:"
 msgstr "TCP port:"
 
-#: src/muuli_wdr.cpp:2117
+#: src/muuli_wdr.cpp:2121
 msgid "The interface amuleapi's HTTP server listens on. 127.0.0.1 (default) accepts only local connections; use 0.0.0.0 or a specific IP to expose it to other hosts (set an admin password below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2120
+#: src/muuli_wdr.cpp:2126
+msgid "Type a password to set or change it. Stored passwords cannot be shown, so leaving this empty keeps the current one."
+msgstr ""
+
+#: src/muuli_wdr.cpp:2128
 #, fuzzy
 msgid "Admin password"
 msgstr "Kontrollin parooli\n"
 
-#: src/muuli_wdr.cpp:2125 src/muuli_wdr.cpp:2156
-msgid "Low rights password"
-msgstr "Madalate õiguste parool"
+#: src/muuli_wdr.cpp:2140 src/muuli_wdr.cpp:2157 src/PrefsUnifiedDlg.cpp:1103
+#, fuzzy
+msgid "A password is set."
+msgstr "Kontrollin parooli\n"
 
-#: src/muuli_wdr.cpp:2133
+#: src/muuli_wdr.cpp:2144
+#, fuzzy
+msgid "Enable guest access"
+msgstr "Keela külalise (guest) ligipääs"
+
+#: src/muuli_wdr.cpp:2145
+msgid "Guest sessions may read status and listings but cannot change anything. Turning this off clears the stored guest password."
+msgstr ""
+
+#: src/muuli_wdr.cpp:2149
+#, fuzzy
+msgid "Guest password"
+msgstr "Webserveri külalise (guest) parool"
+
+#: src/muuli_wdr.cpp:2164
 msgid "Web server parameters"
 msgstr "Web serveri seaded"
 
-#: src/muuli_wdr.cpp:2136
+#: src/muuli_wdr.cpp:2167
 #, fuzzy
 msgid "Run webserver on startup (deprecated)"
 msgstr "Käivita WEBserver koos aMulega"
 
-#: src/muuli_wdr.cpp:2142
+#: src/muuli_wdr.cpp:2173
 msgid "Web template"
 msgstr "WEB näidis/mall"
 
-#: src/muuli_wdr.cpp:2147
+#: src/muuli_wdr.cpp:2178
 msgid "Full rights password"
 msgstr "Täisõiguste parool"
 
-#: src/muuli_wdr.cpp:2151
+#: src/muuli_wdr.cpp:2182
 msgid "Enable Low rights User"
 msgstr "Luba madalate õigustega kasutaja"
 
-#: src/muuli_wdr.cpp:2170
+#: src/muuli_wdr.cpp:2187
+msgid "Low rights password"
+msgstr "Madalate õiguste parool"
+
+#: src/muuli_wdr.cpp:2201
 msgid "Enable UPnP port forwarding of the web server port"
 msgstr "Luba webservri portide UPnP pordisuunamist"
 
-#: src/muuli_wdr.cpp:2175
+#: src/muuli_wdr.cpp:2206
 msgid "Web server UPnP TCP port (Optional)"
 msgstr "Webserveri UPnP TCP port (Valikuline)"
 
-#: src/muuli_wdr.cpp:2183
+#: src/muuli_wdr.cpp:2214
 msgid "Page Refresh Time (in secs)"
 msgstr "Lehekülje värskendusaeg (sekundites)"
 
-#: src/muuli_wdr.cpp:2190
+#: src/muuli_wdr.cpp:2221
 msgid "Enable Gzip compression"
 msgstr "Luba Gzip pakkimine"
 
-#: src/muuli_wdr.cpp:2224
+#: src/muuli_wdr.cpp:2255
 #, fuzzy
 msgid "Reset page to defaults"
 msgstr "Süsteemi vaikeväärtus"
 
-#: src/muuli_wdr.cpp:2225
+#: src/muuli_wdr.cpp:2256
 msgid "Reset the settings on the current page to their default values."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2227 src/muuli_wdr.cpp:2313 src/ServerWnd.cpp:274
+#: src/muuli_wdr.cpp:2258 src/muuli_wdr.cpp:2344 src/ServerWnd.cpp:274
 #: src/ServerWnd.cpp:282
 msgid "OK"
 msgstr "Sobib"
 
-#: src/muuli_wdr.cpp:2229
+#: src/muuli_wdr.cpp:2260
 msgid "Click here to apply any changes made to the preferences."
 msgstr "Seadetes tehtud muudatuste jõustamiseks klikka siia."
 
-#: src/muuli_wdr.cpp:2232
+#: src/muuli_wdr.cpp:2263
 msgid "Reset any changes made to the preferences."
 msgstr "Tühista kõik seadetes tehtud muudatused."
 
-#: src/muuli_wdr.cpp:2261
+#: src/muuli_wdr.cpp:2292
 msgid "Comment :"
 msgstr "Kommentaar :"
 
-#: src/muuli_wdr.cpp:2268
+#: src/muuli_wdr.cpp:2299
 msgid "Incoming Dir :"
 msgstr "Tõmmatud failide kataloog :"
 
-#: src/muuli_wdr.cpp:2277
+#: src/muuli_wdr.cpp:2308
 msgid "Change priority for new assigned files :"
 msgstr "Muuda uute failide prioriteeti :"
 
-#: src/muuli_wdr.cpp:2281
+#: src/muuli_wdr.cpp:2312
 msgid "Don't change"
 msgstr "Ära muuda"
 
-#: src/muuli_wdr.cpp:2293
+#: src/muuli_wdr.cpp:2324
 msgid "Select color for this Category (currently selected) :"
 msgstr "Vali praegu valitud kategooriale värv :"
 
-#: src/muuli_wdr.cpp:2360 src/muuli_wdr.cpp:2379 src/muuli_wdr.cpp:2401
+#: src/muuli_wdr.cpp:2391 src/muuli_wdr.cpp:2410 src/muuli_wdr.cpp:2432
 msgid "Click this button to reset the log."
 msgstr "Klikates seda nuppu tühjendad logi."
 
-#: src/muuli_wdr.cpp:2420
+#: src/muuli_wdr.cpp:2451
 msgid "Click on this button to update the servers list from URL ..."
 msgstr "Sellele nupule klikates värskendad serverite loetelu URL ilt ..."
 
-#: src/muuli_wdr.cpp:2424
+#: src/muuli_wdr.cpp:2455
 msgid "Server list"
 msgstr "Serverite nimekiri"
 
-#: src/muuli_wdr.cpp:2428
+#: src/muuli_wdr.cpp:2459
 msgid "Enter the url to a server.met file here and press the button to the left to update the list of known servers."
 msgstr "Sisesta siia server.met faili asukoha URL ja pressi vasakul olevat nuppu tuntud serverite nimekirja värskendamiseks."
 
-#: src/muuli_wdr.cpp:2433
+#: src/muuli_wdr.cpp:2464
 msgid "Add server manually: Name"
 msgstr "Lisa server käsitsi: Nimi"
 
-#: src/muuli_wdr.cpp:2436
+#: src/muuli_wdr.cpp:2467
 msgid "Enter the name of the new server here"
 msgstr "Sisesta siia uue serveri nimi"
 
-#: src/muuli_wdr.cpp:2438 src/ServerWnd.cpp:206
+#: src/muuli_wdr.cpp:2469 src/ServerWnd.cpp:206
 msgid "IP:Port"
 msgstr "IP:Port"
 
-#: src/muuli_wdr.cpp:2441
+#: src/muuli_wdr.cpp:2472
 msgid "Enter the IP of the server here, using the x.x.x.x format."
 msgstr "Sisesta siia serveri IP aadrdess, kasutades x.x.x.x formaati."
 
-#: src/muuli_wdr.cpp:2447
+#: src/muuli_wdr.cpp:2478
 msgid "Enter the port of the server here."
 msgstr "Sisesta siia serveri port."
 
-#: src/muuli_wdr.cpp:2450
+#: src/muuli_wdr.cpp:2481
 msgid "Add manually a server (fill fields to the left before) ..."
 msgstr "Täites esiteks vasakul olevad väljad, lisa server käsitsi ..."
 
-#: src/muuli_wdr.cpp:2479
+#: src/muuli_wdr.cpp:2510
 msgid "aMule Log"
 msgstr "aMule Logi"
 
-#: src/muuli_wdr.cpp:2487
+#: src/muuli_wdr.cpp:2518
 msgid "Server Info"
 msgstr "Serveri info"
 
-#: src/muuli_wdr.cpp:2491
+#: src/muuli_wdr.cpp:2522
 msgid "ED2K Info"
 msgstr "ED2K Info"
 
-#: src/muuli_wdr.cpp:2495
+#: src/muuli_wdr.cpp:2526
 msgid "Kad Info"
 msgstr "Kad Info"
 
-#: src/muuli_wdr.cpp:2523
+#: src/muuli_wdr.cpp:2554
 msgid "Click on this button to update the nodes list from URL ..."
 msgstr "Klikates sellele nupule värskendad sõlmede loetelu URL'ilt ..."
 
-#: src/muuli_wdr.cpp:2527
+#: src/muuli_wdr.cpp:2558
 msgid "Nodes (0)"
 msgstr "Sõlmed (0)"
 
-#: src/muuli_wdr.cpp:2531
+#: src/muuli_wdr.cpp:2562
 msgid "Enter the url to a nodes.dat file here and press the button to the left to update the list of known nodes."
 msgstr "Sisesta siia nodes.dat faili url ja pressi vasakul olevat nuppu, et tuntud sõlmede loetelu täiendada."
 
-#: src/muuli_wdr.cpp:2534
+#: src/muuli_wdr.cpp:2565
 msgid "Nodes stats"
 msgstr "Sõlmede statistika"
 
-#: src/muuli_wdr.cpp:2576
+#: src/muuli_wdr.cpp:2607
 msgid "Bootstrap"
 msgstr "Bootstrap"
 
-#: src/muuli_wdr.cpp:2579
+#: src/muuli_wdr.cpp:2610
 msgid "New node"
 msgstr "Uus sõlm"
 
-#: src/muuli_wdr.cpp:2584
+#: src/muuli_wdr.cpp:2615
 msgid "IP:"
 msgstr "IP:"
 
-#: src/muuli_wdr.cpp:2604
+#: src/muuli_wdr.cpp:2635
 msgid "Port:"
 msgstr "Port:"
 
-#: src/muuli_wdr.cpp:2617
+#: src/muuli_wdr.cpp:2648
 msgid "Bootstrap from known clients"
 msgstr "Tuntud klientide Bootstrap"
 
-#: src/muuli_wdr.cpp:2619
+#: src/muuli_wdr.cpp:2650
 msgid "Disconnect Kad"
 msgstr "Lõpeta Kad ühendus"
 
-#: src/muuli_wdr.cpp:2653
+#: src/muuli_wdr.cpp:2684
 msgid "Use Secure User Identification"
 msgstr "Kasuta Turvalist Kasutaja tuvastamist"
 
-#: src/muuli_wdr.cpp:2655
+#: src/muuli_wdr.cpp:2686
 msgid "It is recommended to enable this option. You will not receive credits if SUI is not enabled."
 msgstr "On soovitatav see omadus lubada. Sa ei saa krediiti kui SUI on välja lülitatud."
 
-#: src/muuli_wdr.cpp:2657
+#: src/muuli_wdr.cpp:2688
 msgid "Protocol Obfuscation"
 msgstr "Protokolli Hämamine"
 
-#: src/muuli_wdr.cpp:2660
+#: src/muuli_wdr.cpp:2691
 msgid "Support Protocol Obfuscation"
 msgstr "Protokolli Hämamine lubatud"
 
-#: src/muuli_wdr.cpp:2662
+#: src/muuli_wdr.cpp:2693
 msgid "This option enabled Protocol Obfuscation, and makes aMule accept obfuscated connections from other clients."
 msgstr "See valik lülitab Protokolli Hämamise sisse ja sunnib aMule aksepteerima ainult teiste klientide hämatud ühendusi."
 
-#: src/muuli_wdr.cpp:2664
+#: src/muuli_wdr.cpp:2695
 msgid "Use obfuscation for outgoing connections"
 msgstr "Kasuta väljuvatel ühendustel hämamist"
 
-#: src/muuli_wdr.cpp:2666
+#: src/muuli_wdr.cpp:2697
 msgid "This option makes aMule use Protocol Obfuscation when connecting other clients/servers."
 msgstr "See valik sunnib aMule kasutama teiste serverite/klientidega ühendumisel Protokolli Hämamist."
 
-#: src/muuli_wdr.cpp:2668
+#: src/muuli_wdr.cpp:2699
 msgid "Accept only obfuscated connections"
 msgstr "Aksepteeri ainult hämatud ühendusi"
 
-#: src/muuli_wdr.cpp:2669
+#: src/muuli_wdr.cpp:2700
 msgid "This option makes aMule only accept obfuscated connections. You will have less sources, but all your traffic will be obfuscated"
 msgstr "See valik sunnib aMule aksepteerima ainult hämatud ühendusi. Sul on vähem allikaid aga kogu liiklus on hämatud."
 
-#: src/muuli_wdr.cpp:2674
+#: src/muuli_wdr.cpp:2705
 msgid "Everybody"
 msgstr "Igaüks"
 
-#: src/muuli_wdr.cpp:2676
+#: src/muuli_wdr.cpp:2707
 msgid "No one"
 msgstr "Mitte keegi"
 
-#: src/muuli_wdr.cpp:2678
+#: src/muuli_wdr.cpp:2709
 msgid "Who can see my shared files:"
 msgstr "Kes näeb minu jagatud faile:"
 
-#: src/muuli_wdr.cpp:2679
+#: src/muuli_wdr.cpp:2710
 msgid "Select who can request to view a list of your shared files."
 msgstr "Vali, kes võib vaatamiseks küsida sinu jagatud falide nimekira."
 
-#: src/muuli_wdr.cpp:2681
+#: src/muuli_wdr.cpp:2712
 msgid "IP-Filtering"
 msgstr "IP-Filtreerimine"
 
-#: src/muuli_wdr.cpp:2688
+#: src/muuli_wdr.cpp:2719
 msgid "Filter clients"
 msgstr "Filtreeri kliente"
 
-#: src/muuli_wdr.cpp:2690
+#: src/muuli_wdr.cpp:2721
 msgid "Enable filtering of the client IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "Rakenda klientide IP filtreerimine failis ~/.aMule/ipfilter.dat defineeritud aadressidele."
 
-#: src/muuli_wdr.cpp:2692
+#: src/muuli_wdr.cpp:2723
 msgid "Filter servers"
 msgstr "Filtreeri servereid"
 
-#: src/muuli_wdr.cpp:2694
+#: src/muuli_wdr.cpp:2725
 msgid "Enable filtering of the server IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "Rakenda serverite IP filtreerimine failis ~/.aMule/ipfilter.dat defineeritud aadressidele."
 
-#: src/muuli_wdr.cpp:2698
+#: src/muuli_wdr.cpp:2729
 msgid "Reload List"
 msgstr "Lae loetelu uuesti"
 
-#: src/muuli_wdr.cpp:2699
+#: src/muuli_wdr.cpp:2730
 msgid "Reload the list of IPs to filter from the file ~/.aMule/ipfilter.dat"
 msgstr "Taaslae filtreeritavad IP aadressid failist ~/.aMule/ipfilter.dat"
 
-#: src/muuli_wdr.cpp:2705
+#: src/muuli_wdr.cpp:2736
 msgid "URL:"
 msgstr "URL:"
 
-#: src/muuli_wdr.cpp:2709 src/muuli_wdr.cpp:2902
+#: src/muuli_wdr.cpp:2740 src/muuli_wdr.cpp:2933
 msgid "Update now"
 msgstr "Värskenda"
 
-#: src/muuli_wdr.cpp:2712
+#: src/muuli_wdr.cpp:2743
 msgid "Auto-update ipfilter at startup"
 msgstr "Käivitamisel värskenda automaatselt ipfiltrit"
 
-#: src/muuli_wdr.cpp:2716
+#: src/muuli_wdr.cpp:2747
 msgid "Filtering Level:"
 msgstr "Filtreerimise tase:"
 
-#: src/muuli_wdr.cpp:2722
+#: src/muuli_wdr.cpp:2753
 msgid "Always filter LAN IPs"
 msgstr "Filtreeri alati LAN IP aadresse"
 
-#: src/muuli_wdr.cpp:2725
+#: src/muuli_wdr.cpp:2756
 msgid "Paranoid handling of non-matching IPs"
 msgstr "Mitteklappivate IP aadresside paranoiline käitlemine"
 
-#: src/muuli_wdr.cpp:2727
+#: src/muuli_wdr.cpp:2758
 msgid "Rejects a packet when its source IP differs from the IP the client claims (an anti-spoofing check). Disable only if it causes connection problems."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2729
+#: src/muuli_wdr.cpp:2760
 msgid "Use system-wide ipfilter.dat if available"
 msgstr "Kasuta süsteemi ipfilter.dat kui see on saadaval"
 
-#: src/muuli_wdr.cpp:2730
+#: src/muuli_wdr.cpp:2761
 #, fuzzy
 msgid "If there's no local ipfilter.dat found, allow usage of a system-wide ipfilter file."
 msgstr "Kui kohalik ipfilter.dat fail puudub, kasuta süsteemi globaalset ipfilter faili."
 
-#: src/muuli_wdr.cpp:2747
+#: src/muuli_wdr.cpp:2778
 msgid "Enable Online-Signature"
 msgstr "Luba Online-Allkiri"
 
-#: src/muuli_wdr.cpp:2749
+#: src/muuli_wdr.cpp:2780
 msgid "Enables the writing of the OS file, which can be used by external apps to create signatures and the like."
 msgstr "Võimaldab kirjutada OS faile, mida saavad kasutada välised rakendused kasvõi allkirja loomiseks."
 
-#: src/muuli_wdr.cpp:2753
+#: src/muuli_wdr.cpp:2784
 msgid "Update Frequency (Secs):"
 msgstr "Värskenduse sagedus (Sek):"
 
-#: src/muuli_wdr.cpp:2756
+#: src/muuli_wdr.cpp:2787
 msgid "Change the frequency (in seconds) of Online Signature updates."
 msgstr "Muuda Online Allkirja värskendamise (sekundites) sagedust."
 
-#: src/muuli_wdr.cpp:2764
+#: src/muuli_wdr.cpp:2795
 msgid "Save online signature file in: "
 msgstr "Salvesta online ollkirja fail: "
 
-#: src/muuli_wdr.cpp:2770
+#: src/muuli_wdr.cpp:2801
 msgid "Click here to select the directory containing the the Online Signature files."
 msgstr "Siin saad valida kataloogi kus asub sinu Online Allkirja fail."
 
-#: src/muuli_wdr.cpp:2803
+#: src/muuli_wdr.cpp:2834
 msgid "Show country flags for clients"
 msgstr "Näita klientide riigi lippe"
 
-#: src/muuli_wdr.cpp:2804
+#: src/muuli_wdr.cpp:2835
 msgid "Render the country flag column in the transfers, queue and search views. Requires a valid MMDB GeoIP database (see below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2809
+#: src/muuli_wdr.cpp:2840
 #, fuzzy
 msgid "Database"
 msgstr "Andmekiirus :"
 
-#: src/muuli_wdr.cpp:2825
+#: src/muuli_wdr.cpp:2856
 #, fuzzy
 msgid "Source:"
 msgstr "Allikaid"
 
-#: src/muuli_wdr.cpp:2828
+#: src/muuli_wdr.cpp:2859
 msgid "DB-IP (free, no account)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2829
+#: src/muuli_wdr.cpp:2860
 msgid "MaxMind GeoLite2 (free, account required)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2830
+#: src/muuli_wdr.cpp:2861
 msgid "Custom URL"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2833
+#: src/muuli_wdr.cpp:2864
 msgid "Choose which provider supplies the GeoIP MMDB database. DB-IP is the default - no account required. MaxMind requires a free account + license key. Use Custom URL to point at any other MMDB host (e.g. a local mirror)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2850
+#: src/muuli_wdr.cpp:2881
 msgid ""
 "No configuration required.\n"
 "\n"
@@ -4854,11 +4882,11 @@ msgid ""
 "License: Creative Commons BY 4.0 - https://creativecommons.org/licenses/by/4.0/"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2863
+#: src/muuli_wdr.cpp:2894
 msgid "License key:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2869
+#: src/muuli_wdr.cpp:2900
 msgid ""
 "Sign up for a free MaxMind account, then generate a License Key:\n"
 "https://www.maxmind.com/en/geolite2/signup\n"
@@ -4868,226 +4896,226 @@ msgid ""
 "Requires attribution and account registration; refresh at least every 30 days."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2884
+#: src/muuli_wdr.cpp:2915
 #, fuzzy
 msgid "Download URL:"
 msgstr "Tõmbamine: "
 
-#: src/muuli_wdr.cpp:2890
+#: src/muuli_wdr.cpp:2921
 msgid ""
 "Must point to an .mmdb file or a .gz / .tar.gz containing one.\n"
 "URL may include credentials (https://user:pass@host/...).\n"
 "License and attribution terms are set by the upstream URL - you are responsible."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2903
+#: src/muuli_wdr.cpp:2934
 msgid "Download the GeoIP database from the selected source."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2905
+#: src/muuli_wdr.cpp:2936
 #, fuzzy
 msgid "Auto-update on startup"
 msgstr "Käivitamisel värskenda automaatselt ipfiltrit"
 
-#: src/muuli_wdr.cpp:2906
+#: src/muuli_wdr.cpp:2937
 msgid "Re-download the GeoIP database from the selected source every time aMule starts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2929
+#: src/muuli_wdr.cpp:2960
 msgid "Filter incoming messages (except current chat):"
 msgstr "Filtreeri saabuvaid teateid (va. käimasolev vestlus):"
 
-#: src/muuli_wdr.cpp:2931
+#: src/muuli_wdr.cpp:2962
 msgid "Filter all messages"
 msgstr "Filtreeri kõiki teateid"
 
-#: src/muuli_wdr.cpp:2933
+#: src/muuli_wdr.cpp:2964
 msgid "Filter messages from people not on your friend list"
 msgstr "Filtreeri sinu sõbralistiväliste kodanike teateid"
 
-#: src/muuli_wdr.cpp:2935
+#: src/muuli_wdr.cpp:2966
 msgid "Filter messages from unknown clients"
 msgstr "Filtreeri tundmatute klientide teateid"
 
-#: src/muuli_wdr.cpp:2937
+#: src/muuli_wdr.cpp:2968
 msgid "Filter messages containing (use ',' as separator):"
 msgstr "Filtreeri teateid, mis sisaldavad (loetelus kasuta eraldajana koma):"
 
-#: src/muuli_wdr.cpp:2940 src/muuli_wdr.cpp:2951
+#: src/muuli_wdr.cpp:2971 src/muuli_wdr.cpp:2982
 msgid "add here the words amule should filter and block messages including it"
 msgstr "lisa siia sõnad mille amule peab väljafiltreerima ja bloki teated mis seda sisaldavad"
 
-#: src/muuli_wdr.cpp:2942
+#: src/muuli_wdr.cpp:2973
 msgid "Show received messages in the log"
 msgstr "Näita logis saabunud teateid"
 
-#: src/muuli_wdr.cpp:2945
+#: src/muuli_wdr.cpp:2976
 msgid "Comments"
 msgstr "Kommentaarid"
 
-#: src/muuli_wdr.cpp:2948
+#: src/muuli_wdr.cpp:2979
 msgid "Filter comments containing (use ',' as separator):"
 msgstr "Filtreeri teateid, mis sisaldavad (loetelus kasuta eraldajana koma):"
 
-#: src/muuli_wdr.cpp:2973
+#: src/muuli_wdr.cpp:3004
 msgid "Enable Proxy"
 msgstr "Kasuta puhverserverit"
 
-#: src/muuli_wdr.cpp:2974
+#: src/muuli_wdr.cpp:3005
 msgid "Enable/disable proxy support"
 msgstr "Kasuta/ärakasuta puhverserveri tuge"
 
-#: src/muuli_wdr.cpp:2977
+#: src/muuli_wdr.cpp:3008
 msgid "Proxy type:"
 msgstr "Puhverserveri tüüp:"
 
-#: src/muuli_wdr.cpp:2988
+#: src/muuli_wdr.cpp:3019
 msgid "Proxy host:"
 msgstr "Puhverserveri nimi:"
 
-#: src/muuli_wdr.cpp:2991
+#: src/muuli_wdr.cpp:3022
 msgid "The proxy host name"
 msgstr "Selle puhverserveri/hosti nimi "
 
-#: src/muuli_wdr.cpp:2993
+#: src/muuli_wdr.cpp:3024
 msgid "Proxy port:"
 msgstr "Puhverserveri port:"
 
-#: src/muuli_wdr.cpp:2996
+#: src/muuli_wdr.cpp:3027
 msgid "The proxy port"
 msgstr "Selle puhverserveri pordi number"
 
-#: src/muuli_wdr.cpp:2998
+#: src/muuli_wdr.cpp:3029
 msgid "Enable authentication"
 msgstr "Nõua autoriseerimist"
 
-#: src/muuli_wdr.cpp:2999
+#: src/muuli_wdr.cpp:3030
 msgid "Enable/disable username/password authentication"
 msgstr "Autoriseerimisel Kasuta/Ära kasuta kasutajanime/parooli"
 
-#: src/muuli_wdr.cpp:3002
+#: src/muuli_wdr.cpp:3033
 msgid "Username: "
 msgstr "Kasutajanimi: "
 
-#: src/muuli_wdr.cpp:3005
+#: src/muuli_wdr.cpp:3036
 msgid "The username to use to connect to the proxy"
 msgstr "Puhverserveriga ühenduseks vajalik kasutajanimi"
 
-#: src/muuli_wdr.cpp:3007
+#: src/muuli_wdr.cpp:3038
 msgid "Password:"
 msgstr "Parool:"
 
-#: src/muuli_wdr.cpp:3010
+#: src/muuli_wdr.cpp:3041
 msgid "The password to use to connect to the proxy"
 msgstr "Puhverserveri kasutamiseks vajalik parool"
 
-#: src/muuli_wdr.cpp:3029
+#: src/muuli_wdr.cpp:3060
 msgid "Connect to:"
 msgstr "Ühendu :"
 
-#: src/muuli_wdr.cpp:3038
+#: src/muuli_wdr.cpp:3069
 msgid "Login to remote amule"
 msgstr "Logi sisse eemalasuvasse amuula"
 
-#: src/muuli_wdr.cpp:3043
+#: src/muuli_wdr.cpp:3074
 msgid "User name"
 msgstr "Kasutaja nimi"
 
-#: src/muuli_wdr.cpp:3054
+#: src/muuli_wdr.cpp:3085
 msgid "Remember those settings"
 msgstr "Pea need seaded meeles"
 
-#: src/muuli_wdr.cpp:3057
+#: src/muuli_wdr.cpp:3088
 #, fuzzy
 msgid "Force ZLIB compression"
 msgstr "Kasuta gzip pakkimist"
 
-#: src/muuli_wdr.cpp:3081
+#: src/muuli_wdr.cpp:3112
 msgid "Enable Verbose Debug-Logging."
 msgstr "Võimalda inimkieelne Veajälitus-Logimine"
 
-#: src/muuli_wdr.cpp:3083
+#: src/muuli_wdr.cpp:3114
 #, fuzzy
 msgid "Only to Logfile"
 msgstr "Ava Fail"
 
-#: src/muuli_wdr.cpp:3085
+#: src/muuli_wdr.cpp:3116
 msgid "Message Categories:"
 msgstr "Saadetav teade:"
 
-#: src/muuli_wdr.cpp:3109 src/PartFileConvertDlg.cpp:160
+#: src/muuli_wdr.cpp:3140 src/PartFileConvertDlg.cpp:160
 msgid "Waiting..."
 msgstr "Ootan..."
 
-#: src/muuli_wdr.cpp:3129
+#: src/muuli_wdr.cpp:3160
 msgid "Add imports"
 msgstr "Lisa imporditavad"
 
-#: src/muuli_wdr.cpp:3132
+#: src/muuli_wdr.cpp:3163
 msgid "Retry selected"
 msgstr "Proovi valitutega uuesti"
 
-#: src/muuli_wdr.cpp:3134
+#: src/muuli_wdr.cpp:3165
 msgid "Remove selected"
 msgstr "Eemalda valitud"
 
-#: src/muuli_wdr.cpp:3197
+#: src/muuli_wdr.cpp:3228
 msgid "Event Types"
 msgstr "Sündmuse tüübid"
 
-#: src/muuli_wdr.cpp:3216
+#: src/muuli_wdr.cpp:3247
 msgid "Statistics and queued clients for selected file(s) : Session / All time"
 msgstr "Statistika ja järjekorras kliendid valitud faili(de) kohta : Sessioon / Kokku"
 
-#: src/muuli_wdr.cpp:3240
+#: src/muuli_wdr.cpp:3271
 msgid "Active Uploads"
 msgstr "Aktiivsed saatmised"
 
-#: src/muuli_wdr.cpp:3254
+#: src/muuli_wdr.cpp:3285
 msgid "Percent of total files"
 msgstr "Protsenti kogufailidest"
 
-#: src/muuli_wdr.cpp:3306
+#: src/muuli_wdr.cpp:3337
 msgid "Show Clients for"
 msgstr "Näita Kliente"
 
-#: src/muuli_wdr.cpp:3308
+#: src/muuli_wdr.cpp:3339
 msgid "All files"
 msgstr "Kõik failid"
 
-#: src/muuli_wdr.cpp:3311
+#: src/muuli_wdr.cpp:3342
 msgid "Selected files"
 msgstr "Valitud failid"
 
-#: src/muuli_wdr.cpp:3314
+#: src/muuli_wdr.cpp:3345
 msgid "Active uploads only"
 msgstr "Ainult aktiivsed saatmised"
 
-#: src/muuli_wdr.cpp:3321
+#: src/muuli_wdr.cpp:3352
 msgid "Reload:"
 msgstr "Taaslae:"
 
-#: src/muuli_wdr.cpp:3325
+#: src/muuli_wdr.cpp:3356
 msgid "Reload your shared files"
 msgstr "Lae oma jagatud failid uuesti"
 
-#: src/muuli_wdr.cpp:3388
+#: src/muuli_wdr.cpp:3419
 msgid "Send"
 msgstr "Saada"
 
-#: src/muuli_wdr.cpp:3389
+#: src/muuli_wdr.cpp:3420
 msgid "Sends the specified message."
 msgstr "Saada määratud teade."
 
-#: src/muuli_wdr.cpp:3393
+#: src/muuli_wdr.cpp:3424
 msgid "Close this chat-session."
 msgstr "Sulge see vestlus-seanss."
 
-#: src/muuli_wdr.cpp:3416
+#: src/muuli_wdr.cpp:3447
 msgid "Connect to any server and/or Kad"
 msgstr "Ühendu suvalise serveri ja/või Kad võrguga"
 
-#: src/muuli_wdr.cpp:3422 src/SharedFilesCtrl.cpp:142 src/Statistics.cpp:941
+#: src/muuli_wdr.cpp:3453 src/SharedFilesCtrl.cpp:142 src/Statistics.cpp:941
 msgid "Shared Files"
 msgstr "Jagatud failid"
 
@@ -5446,250 +5474,250 @@ msgstr "Allalaetud"
 msgid "ERROR: Failed to open partfile '%s'"
 msgstr "VIGA: Osafaili '%s' avamine ebaõnnestus"
 
-#: src/Preferences.cpp:674
+#: src/Preferences.cpp:701
 msgid "System default"
 msgstr "Süsteemi vaikeväärtus"
 
-#: src/Preferences.cpp:675
+#: src/Preferences.cpp:702
 msgid "Albanian"
 msgstr "Albaania"
 
-#: src/Preferences.cpp:676
+#: src/Preferences.cpp:703
 msgid "Arabic"
 msgstr "Araabia"
 
-#: src/Preferences.cpp:677
+#: src/Preferences.cpp:704
 msgid "Asturian"
 msgstr "Asturia"
 
-#: src/Preferences.cpp:678
+#: src/Preferences.cpp:705
 msgid "Basque"
 msgstr "Baski"
 
-#: src/Preferences.cpp:679
+#: src/Preferences.cpp:706
 msgid "Bulgarian"
 msgstr "Bulgaaria"
 
-#: src/Preferences.cpp:680
+#: src/Preferences.cpp:707
 msgid "Catalan"
 msgstr "Kataloonia"
 
-#: src/Preferences.cpp:681
+#: src/Preferences.cpp:708
 msgid "Chinese (Simplified)"
 msgstr "Hiina (Lihtsustatud)"
 
-#: src/Preferences.cpp:682
+#: src/Preferences.cpp:709
 msgid "Chinese (Traditional)"
 msgstr "Hiina (Traditsiooniline)"
 
-#: src/Preferences.cpp:683
+#: src/Preferences.cpp:710
 msgid "Croatian"
 msgstr "Kroaatia"
 
-#: src/Preferences.cpp:684
+#: src/Preferences.cpp:711
 msgid "Czech"
 msgstr "Tšehhi"
 
-#: src/Preferences.cpp:685
+#: src/Preferences.cpp:712
 msgid "Danish"
 msgstr "Taani"
 
-#: src/Preferences.cpp:686
+#: src/Preferences.cpp:713
 msgid "Dutch"
 msgstr "Hollandi"
 
-#: src/Preferences.cpp:687
+#: src/Preferences.cpp:714
 msgid "English (U.K.)"
 msgstr "Inglise (U.K.)"
 
-#: src/Preferences.cpp:688
+#: src/Preferences.cpp:715
 #, fuzzy
 msgid "English (U.S.)"
 msgstr "Inglise (U.K.)"
 
-#: src/Preferences.cpp:689
+#: src/Preferences.cpp:716
 msgid "Estonian"
 msgstr "Eesti"
 
-#: src/Preferences.cpp:690
+#: src/Preferences.cpp:717
 msgid "Finnish"
 msgstr "Soome"
 
-#: src/Preferences.cpp:691
+#: src/Preferences.cpp:718
 msgid "French"
 msgstr "Prantsuse"
 
-#: src/Preferences.cpp:692
+#: src/Preferences.cpp:719
 msgid "Galician"
 msgstr "Galiitsia"
 
-#: src/Preferences.cpp:693
+#: src/Preferences.cpp:720
 msgid "German"
 msgstr "Saksa"
 
-#: src/Preferences.cpp:694
+#: src/Preferences.cpp:721
 msgid "Greek"
 msgstr "Kreeka"
 
-#: src/Preferences.cpp:695
+#: src/Preferences.cpp:722
 msgid "Hebrew"
 msgstr "Heebrea"
 
-#: src/Preferences.cpp:696
+#: src/Preferences.cpp:723
 msgid "Hungarian"
 msgstr "Ungari"
 
-#: src/Preferences.cpp:697
+#: src/Preferences.cpp:724
 msgid "Italian"
 msgstr "Itaalia"
 
-#: src/Preferences.cpp:698
+#: src/Preferences.cpp:725
 msgid "Japanese"
 msgstr "Jaapani"
 
-#: src/Preferences.cpp:699
+#: src/Preferences.cpp:726
 msgid "Korean"
 msgstr "Korea"
 
-#: src/Preferences.cpp:700
+#: src/Preferences.cpp:727
 msgid "Latvian"
 msgstr ""
 
-#: src/Preferences.cpp:701
+#: src/Preferences.cpp:728
 msgid "Lithuanian"
 msgstr "Leedu"
 
-#: src/Preferences.cpp:702
+#: src/Preferences.cpp:729
 msgid "Norwegian (Nynorsk)"
 msgstr "Norra"
 
-#: src/Preferences.cpp:703
+#: src/Preferences.cpp:730
 msgid "Polish"
 msgstr "Poola"
 
-#: src/Preferences.cpp:704
+#: src/Preferences.cpp:731
 msgid "Portuguese"
 msgstr "Portugali"
 
-#: src/Preferences.cpp:705
+#: src/Preferences.cpp:732
 msgid "Portuguese (Brazilian)"
 msgstr "Portugali (Brasiilia)"
 
-#: src/Preferences.cpp:706
+#: src/Preferences.cpp:733
 msgid "Romanian"
 msgstr "Rumeenia"
 
-#: src/Preferences.cpp:707
+#: src/Preferences.cpp:734
 msgid "Russian"
 msgstr "Vene"
 
-#: src/Preferences.cpp:708
+#: src/Preferences.cpp:735
 msgid "Slovenian"
 msgstr "Sloveenia"
 
-#: src/Preferences.cpp:709
+#: src/Preferences.cpp:736
 msgid "Spanish"
 msgstr "Hispaania"
 
-#: src/Preferences.cpp:710
+#: src/Preferences.cpp:737
 msgid "Swedish"
 msgstr "Rootsi"
 
-#: src/Preferences.cpp:711
+#: src/Preferences.cpp:738
 msgid "Turkish"
 msgstr "Türgi"
 
-#: src/Preferences.cpp:712
+#: src/Preferences.cpp:739
 msgid "Ukrainian"
 msgstr "Ukraina"
 
-#: src/Preferences.cpp:815
+#: src/Preferences.cpp:842
 msgid "Change Language"
 msgstr "Muuda keel"
 
-#: src/Preferences.cpp:879
+#: src/Preferences.cpp:906
 msgid "There are no translations installed for aMule"
 msgstr ""
 
-#: src/Preferences.cpp:880
+#: src/Preferences.cpp:907
 #, fuzzy
 msgid "No languages available"
 msgstr "Info puudub"
 
-#: src/Preferences.cpp:1011
+#: src/Preferences.cpp:1038
 msgid "no options available"
 msgstr "valikud puuduvad"
 
-#: src/Preferences.cpp:2182
+#: src/Preferences.cpp:2227
 msgid "Invalid category found, skipping"
 msgstr "Leidsin vigase kategooria, ignoreerin"
 
-#: src/Preferences.cpp:2351
+#: src/Preferences.cpp:2396
 msgid "TCP port can't be higher than 65532 due to server UDP socket being TCP+3"
 msgstr "TCP port ei saa olla suuerm kui 65532, sest serveri UDP soket on TCP+3"
 
-#: src/Preferences.cpp:2352
+#: src/Preferences.cpp:2397
 #, c-format
 msgid "Default port will be used (%d)"
 msgstr "Kasutan vaikimisi porti (%d)"
 
-#: src/PrefsUnifiedDlg.cpp:298 src/Statistics.cpp:866
+#: src/PrefsUnifiedDlg.cpp:300 src/Statistics.cpp:866
 msgid "Connection"
 msgstr "Ühendus"
 
-#: src/PrefsUnifiedDlg.cpp:299 src/SearchListCtrl.cpp:117
+#: src/PrefsUnifiedDlg.cpp:301 src/SearchListCtrl.cpp:117
 msgid "Directories"
 msgstr "Kataloogid"
 
-#: src/PrefsUnifiedDlg.cpp:300 src/Statistics.cpp:917
+#: src/PrefsUnifiedDlg.cpp:302 src/Statistics.cpp:917
 msgid "Servers"
 msgstr "Serverid"
 
-#: src/PrefsUnifiedDlg.cpp:301 src/ServerListCtrl.cpp:96
+#: src/PrefsUnifiedDlg.cpp:303 src/ServerListCtrl.cpp:96
 msgid "Files"
 msgstr "Failid"
 
-#: src/PrefsUnifiedDlg.cpp:302
+#: src/PrefsUnifiedDlg.cpp:304
 msgid "Security"
 msgstr "Turvalisus"
 
-#: src/PrefsUnifiedDlg.cpp:303
+#: src/PrefsUnifiedDlg.cpp:305
 msgid "Interface"
 msgstr "Liides"
 
-#: src/PrefsUnifiedDlg.cpp:310
+#: src/PrefsUnifiedDlg.cpp:312
 msgid "IP2Country"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:313
+#: src/PrefsUnifiedDlg.cpp:315
 msgid "Proxy"
 msgstr "Puhverserver"
 
-#: src/PrefsUnifiedDlg.cpp:314
+#: src/PrefsUnifiedDlg.cpp:316
 msgid "Filters"
 msgstr "Filtrid"
 
-#: src/PrefsUnifiedDlg.cpp:315
+#: src/PrefsUnifiedDlg.cpp:317
 msgid "Remote Controls"
 msgstr "Kaugjuhtimine"
 
-#: src/PrefsUnifiedDlg.cpp:316
+#: src/PrefsUnifiedDlg.cpp:318
 msgid "Online Signature"
 msgstr "Online Allkiri"
 
-#: src/PrefsUnifiedDlg.cpp:317
+#: src/PrefsUnifiedDlg.cpp:319
 msgid "Advanced"
 msgstr "Muud"
 
-#: src/PrefsUnifiedDlg.cpp:318
+#: src/PrefsUnifiedDlg.cpp:320
 msgid "Events"
 msgstr "Sündmused"
 
-#: src/PrefsUnifiedDlg.cpp:321
+#: src/PrefsUnifiedDlg.cpp:323
 msgid "Debugging"
 msgstr "Veajälitus"
 
-#: src/PrefsUnifiedDlg.cpp:451
+#: src/PrefsUnifiedDlg.cpp:453
 msgid ""
 "The following variables will be substituted:\n"
 "    %PARTFILE - full path to the file\n"
@@ -5699,15 +5727,15 @@ msgstr ""
 "   %PARTFILE - fail täis rada\n"
 "   %PARTNAME - faili nimi"
 
-#: src/PrefsUnifiedDlg.cpp:472
+#: src/PrefsUnifiedDlg.cpp:474
 msgid "Tray icon support requires libayatana-appindicator3 at compile time."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:488
+#: src/PrefsUnifiedDlg.cpp:490
 msgid "Not available on Wayland: the protocol does not report when a window is minimized, so this option cannot intercept the system minimize button. Workaround: launch aMule with `GDK_BACKEND=x11` to use XWayland instead."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:534
+#: src/PrefsUnifiedDlg.cpp:536
 msgid ""
 "Do not change these setting unless you know\n"
 "what you are doing, otherwise you can easily\n"
@@ -5723,26 +5751,35 @@ msgstr ""
 "aMule toimib ilusasti ilma siinolevaid seadeid muutmata\n"
 "You Are WARNED!!."
 
-#: src/PrefsUnifiedDlg.cpp:645
+#: src/PrefsUnifiedDlg.cpp:647
 #, c-format
 msgid "Failed to connect Cfg to widget with the ID %d and key %s"
 msgstr "Widgeti ühendamine Cfg'a, kasutades ID %d ja võtit %s, ebaõnnestus"
 
-#: src/PrefsUnifiedDlg.cpp:693
+#: src/PrefsUnifiedDlg.cpp:695
 #, c-format
 msgid "Failed to transfer data from Cfg to Widget with the ID %d and key %s"
 msgstr "Andmete ülekandmine Cfg'st Widget'isse, kasutades ID %d ja võtit %s, ebaõnnestus"
 
-#: src/PrefsUnifiedDlg.cpp:799
+#: src/PrefsUnifiedDlg.cpp:801
 msgid "The type of proxy you are connecting to"
 msgstr "Selle puhverserveri tüüp kuhu sa ühendud"
 
-#: src/PrefsUnifiedDlg.cpp:1003
+#: src/PrefsUnifiedDlg.cpp:1020
 #, c-format
 msgid "Failed to transfer data from Widget to Cfg with the ID %d and key %s"
 msgstr "Andmete ülekandmine Widgetist Cfg'sse, kasutades ID %d ja võtit %s, ebaõnnestus"
 
 #: src/PrefsUnifiedDlg.cpp:1103
+#, fuzzy
+msgid "No password set."
+msgstr "Kontrollin parooli\n"
+
+#: src/PrefsUnifiedDlg.cpp:1132
+msgid "Guest access needs a password. Type one in the guest password field, or untick Enable guest access."
+msgstr ""
+
+#: src/PrefsUnifiedDlg.cpp:1144
 msgid ""
 "aMule must be restarted to enable these changes:\n"
 "\n"
@@ -5750,42 +5787,42 @@ msgstr ""
 "Nende muudatuste jõustamiseks pead aMUle taaskäivitama:\n"
 "\n"
 
-#: src/PrefsUnifiedDlg.cpp:1110
+#: src/PrefsUnifiedDlg.cpp:1151
 msgid "- TCP port changed.\n"
 msgstr "- TCP port muudetud.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1115
+#: src/PrefsUnifiedDlg.cpp:1156
 msgid "- UDP port changed.\n"
 msgstr "- UDP port muudetud.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1120
+#: src/PrefsUnifiedDlg.cpp:1161
 #, fuzzy
 msgid "- Network interface binding changed.\n"
 msgstr "- Välisühenduse liides muutunud.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1125
+#: src/PrefsUnifiedDlg.cpp:1166
 msgid "- External connect port changed.\n"
 msgstr "- Välisühenduse port on muutunud.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1129
+#: src/PrefsUnifiedDlg.cpp:1170
 msgid "- External connect acceptance changed.\n"
 msgstr "- Välisühenduse luba on muudetud.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1133
+#: src/PrefsUnifiedDlg.cpp:1174
 msgid "- External connect interface changed.\n"
 msgstr "- Välisühenduse liides muutunud.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1137
+#: src/PrefsUnifiedDlg.cpp:1178
 #, fuzzy
 msgid "- Protocol obfuscation support changed.\n"
 msgstr "Protokolli Hämamine"
 
-#: src/PrefsUnifiedDlg.cpp:1151
+#: src/PrefsUnifiedDlg.cpp:1193
 #, fuzzy
 msgid "- amuleapi settings changed.\n"
 msgstr "- Keel on muudetud.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1160
+#: src/PrefsUnifiedDlg.cpp:1202
 msgid ""
 "Your Auto-update server list is empty.\n"
 "'Auto-update server list at startup' will be disabled."
@@ -5793,7 +5830,7 @@ msgstr ""
 "Sinu automaane serverinimekirja värskendamise loetelu on tühi.\n"
 "Käivitamisel serverinimekirja automaatselt ei uuendata."
 
-#: src/PrefsUnifiedDlg.cpp:1171
+#: src/PrefsUnifiedDlg.cpp:1213
 msgid ""
 "You have enabled external connections but have not specified a password.\n"
 "External connections cannot be enabled unless a valid password is specified."
@@ -5801,28 +5838,33 @@ msgstr ""
 "Lülitasid sisse välised ühendused kuid ei määranud parooli.\n"
 "Väliseid ühendusi ei saa enne kehtiva parooli määramist kasutada."
 
-#: src/PrefsUnifiedDlg.cpp:1202
+#: src/PrefsUnifiedDlg.cpp:1246
+#, c-format
+msgid "The amuleapi password could not be saved: %s"
+msgstr ""
+
+#: src/PrefsUnifiedDlg.cpp:1276
 msgid "- Language changed.\n"
 msgstr "- Keel on muudetud.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1207
+#: src/PrefsUnifiedDlg.cpp:1281
 msgid "- Temp folder changed.\n"
 msgstr "- Ajutiste failide kataloog on muudetud.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1212
+#: src/PrefsUnifiedDlg.cpp:1286
 msgid "- ED2K network enabled.\n"
 msgstr "- ED2K võrk on lubatud.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1245
+#: src/PrefsUnifiedDlg.cpp:1319
 msgid "The shared-file exclusion pattern is not a valid regular expression. The filter has been left disabled."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1247 src/PrefsUnifiedDlg.cpp:1841
+#: src/PrefsUnifiedDlg.cpp:1321 src/PrefsUnifiedDlg.cpp:1921
 #, fuzzy
 msgid "Invalid regular expression"
 msgstr "Vigane protokolli versioon."
 
-#: src/PrefsUnifiedDlg.cpp:1324
+#: src/PrefsUnifiedDlg.cpp:1398
 msgid ""
 "Both eD2k and Kad network are disabled.\n"
 "You won't be able to connect until you enable at least one of them."
@@ -5830,7 +5872,7 @@ msgstr ""
 "Mõlemad, nii eD2k kui ka Kad võrgud on mitteaktiivsed.\n"
 "Sa ei saa ühenduda enne, kui vähemalt üks neist on aktiivne."
 
-#: src/PrefsUnifiedDlg.cpp:1329
+#: src/PrefsUnifiedDlg.cpp:1403
 msgid ""
 "Kad will not start if your UDP port is disabled.\n"
 "Enable UDP port or disable Kad."
@@ -5838,7 +5880,7 @@ msgstr ""
 "Kad ei saa käivitada kuni UDP port on väljalülitatud.\n"
 "Lülita UDP port sisse, või Kad välja."
 
-#: src/PrefsUnifiedDlg.cpp:1385
+#: src/PrefsUnifiedDlg.cpp:1459
 msgid ""
 "\n"
 "You MUST restart aMule now.\n"
@@ -5848,69 +5890,69 @@ msgstr ""
 "Sa PEAD aMule nüüd taaskäivitama.\n"
 "Kui sa seda ei tee siis ära tänita kui midagi paha juhtub.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1450
+#: src/PrefsUnifiedDlg.cpp:1524
 msgid "Could not register aMule for autostart at login. The autostart store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1452
+#: src/PrefsUnifiedDlg.cpp:1526
 msgid "Could not remove the autostart-at-login entry."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1453
+#: src/PrefsUnifiedDlg.cpp:1527
 #, fuzzy
 msgid "Autostart"
 msgstr "Automaatne värskendamine on käivitatud"
 
-#: src/PrefsUnifiedDlg.cpp:1468
+#: src/PrefsUnifiedDlg.cpp:1542
 msgid "Register file type"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1468
+#: src/PrefsUnifiedDlg.cpp:1542
 msgid "Register URL handler"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1476
+#: src/PrefsUnifiedDlg.cpp:1550
 #, c-format
 msgid "aMule only handles eD2k-compatible magnets. If you replace the current magnet handler (%s), BitTorrent magnet links will stop working - aMule cannot download BitTorrent content. Continue?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1481
+#: src/PrefsUnifiedDlg.cpp:1555
 #, c-format
 msgid "Another application currently opens .emulecollection files (%s). Replace it with aMule?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1486
+#: src/PrefsUnifiedDlg.cpp:1560
 #, c-format
 msgid "Another application is currently the default handler for these links (%s). Replace it with aMule?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1511
+#: src/PrefsUnifiedDlg.cpp:1585
 msgid "Could not register aMule for .emulecollection files. The registration store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1513
+#: src/PrefsUnifiedDlg.cpp:1587
 #, fuzzy
 msgid "Could not remove the file type registration."
 msgstr "Ajutiste tõmmatavate failide kataloog"
 
-#: src/PrefsUnifiedDlg.cpp:1515
+#: src/PrefsUnifiedDlg.cpp:1589
 msgid "Could not register aMule as the URL handler. The registration store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1517
+#: src/PrefsUnifiedDlg.cpp:1591
 msgid "Could not remove the URL handler registration."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1587 src/PrefsUnifiedDlg.cpp:1614
+#: src/PrefsUnifiedDlg.cpp:1661 src/PrefsUnifiedDlg.cpp:1688
 #, fuzzy
 msgid "The web server and aMule API require external connections to be enabled."
 msgstr "Parool on määratud ja välised ühendused võimalikud."
 
-#: src/PrefsUnifiedDlg.cpp:1597
+#: src/PrefsUnifiedDlg.cpp:1671
 msgid "The aMule web server is deprecated. Consider running the aMule API instead."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1655
+#: src/PrefsUnifiedDlg.cpp:1735
 msgid ""
 "Your Auto-update servers list is in blank.\n"
 "Please fill in at least one URL to point to a valid server.met file.\n"
@@ -5920,66 +5962,66 @@ msgstr ""
 "Palun sisesta vähemalt üks server.met faili asukoha kehtiv URL.\n"
 "URL sisestamiseks kliki nupule 'Loend'."
 
-#: src/PrefsUnifiedDlg.cpp:1796
+#: src/PrefsUnifiedDlg.cpp:1876
 msgid "Temporary files"
 msgstr "Ajutised failid"
 
-#: src/PrefsUnifiedDlg.cpp:1801
+#: src/PrefsUnifiedDlg.cpp:1881
 msgid "Incoming files"
 msgstr "Saabuvad failid"
 
-#: src/PrefsUnifiedDlg.cpp:1806
+#: src/PrefsUnifiedDlg.cpp:1886
 msgid "Online Signatures"
 msgstr "Online Allkirjad"
 
-#: src/PrefsUnifiedDlg.cpp:1819
+#: src/PrefsUnifiedDlg.cpp:1899
 #, c-format
 msgid "Choose a folder for %s"
 msgstr "Vali %s kataloog"
 
-#: src/PrefsUnifiedDlg.cpp:1843
+#: src/PrefsUnifiedDlg.cpp:1923
 #, fuzzy, c-format
 msgid "Would exclude %u of %u shared file"
 msgid_plural "Would exclude %u of %u shared files"
 msgstr[0] "Leitud %i tuntud ja jagatud faili"
 msgstr[1] "Leitud %i tuntud ja jagatud faili."
 
-#: src/PrefsUnifiedDlg.cpp:1860
+#: src/PrefsUnifiedDlg.cpp:1940
 msgid "Browse for videoplayer"
 msgstr "Otsi filmi taasesitamise programmi"
 
-#: src/PrefsUnifiedDlg.cpp:1864
+#: src/PrefsUnifiedDlg.cpp:1944
 msgid "Select browser"
 msgstr "Vali lehitseja (browser)"
 
-#: src/PrefsUnifiedDlg.cpp:1868
+#: src/PrefsUnifiedDlg.cpp:1948
 #, fuzzy
 msgid "Select ffprobe binary"
 msgstr "Vali lehitseja (browser)"
 
-#: src/PrefsUnifiedDlg.cpp:1874
+#: src/PrefsUnifiedDlg.cpp:1954
 #, c-format
 msgid "Executable%s"
 msgstr "Käivitusprogramm%s"
 
-#: src/PrefsUnifiedDlg.cpp:1908
+#: src/PrefsUnifiedDlg.cpp:1988
 msgid "ffprobe not found on PATH or in the standard install locations. Install ffmpeg (which ships ffprobe) or use Browse to pick a binary manually."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1920
+#: src/PrefsUnifiedDlg.cpp:2000
 msgid "Reset the settings on this page to their default values?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1921
+#: src/PrefsUnifiedDlg.cpp:2001
 #, fuzzy
 msgid "Reset to defaults"
 msgstr "Süsteemi vaikeväärtus"
 
-#: src/PrefsUnifiedDlg.cpp:1948
+#: src/PrefsUnifiedDlg.cpp:2028
 msgid "Edit server list"
 msgstr "Muuda serverite nimekirja"
 
-#: src/PrefsUnifiedDlg.cpp:1949
+#: src/PrefsUnifiedDlg.cpp:2029
 msgid ""
 "Add here URL's to download server.met files.\n"
 "Only one url on each line."
@@ -5987,154 +6029,154 @@ msgstr ""
 "Lisa siia server.met faili(de) laadimise URL.\n"
 "Üks URL rea kohta."
 
-#: src/PrefsUnifiedDlg.cpp:2004
+#: src/PrefsUnifiedDlg.cpp:2084
 msgid "IP2Country update failed"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2149 src/PrefsUnifiedDlg.cpp:2180
+#: src/PrefsUnifiedDlg.cpp:2229 src/PrefsUnifiedDlg.cpp:2260
 msgid "Data by MaxMind GeoLite2"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2151 src/PrefsUnifiedDlg.cpp:2182
+#: src/PrefsUnifiedDlg.cpp:2231 src/PrefsUnifiedDlg.cpp:2262
 #, fuzzy
 msgid "Custom source"
 msgstr "Täielikke allikaid"
 
-#: src/PrefsUnifiedDlg.cpp:2153 src/PrefsUnifiedDlg.cpp:2184
+#: src/PrefsUnifiedDlg.cpp:2233 src/PrefsUnifiedDlg.cpp:2264
 msgid "Data by DB-IP.com"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2204
+#: src/PrefsUnifiedDlg.cpp:2284
 #, fuzzy, c-format
 msgid "Status: Loaded%s"
 msgstr "Olek:"
 
-#: src/PrefsUnifiedDlg.cpp:2206
+#: src/PrefsUnifiedDlg.cpp:2286
 #, fuzzy, c-format
 msgid "Status: Loaded%s - %s"
 msgstr "Olek:"
 
-#: src/PrefsUnifiedDlg.cpp:2210
+#: src/PrefsUnifiedDlg.cpp:2290
 msgid "Status: Failed to load - click 'Update now' to refresh."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2212
+#: src/PrefsUnifiedDlg.cpp:2292
 msgid "Status: Not found - click 'Update now' to download."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2270 src/PrefsUnifiedDlg.cpp:2294
+#: src/PrefsUnifiedDlg.cpp:2350 src/PrefsUnifiedDlg.cpp:2374
 #, c-format
 msgid "Update delay: %d second"
 msgid_plural "Update delay: %d seconds"
 msgstr[0] "Värskenduse viide: %d sekundit"
 msgstr[1] "Värskenduse viide: %d sekundit"
 
-#: src/PrefsUnifiedDlg.cpp:2278
+#: src/PrefsUnifiedDlg.cpp:2358
 #, c-format
 msgid "Time for average graph: %d minute"
 msgid_plural "Time for average graph: %d minutes"
 msgstr[0] "Keskmiste graafiku aeg: %d minutit"
 msgstr[1] "Keskmiste graafiku aeg: %d  minutit"
 
-#: src/PrefsUnifiedDlg.cpp:2287
+#: src/PrefsUnifiedDlg.cpp:2367
 #, c-format
 msgid "Connections Graph Scale: %d"
 msgstr "Ühenduse graafiku skaala: %d"
 
-#: src/PrefsUnifiedDlg.cpp:2302
+#: src/PrefsUnifiedDlg.cpp:2382
 #, c-format
 msgid "File Buffer Size: %d byte"
 msgid_plural "File Buffer Size: %d bytes"
 msgstr[0] "Failipuhvri suurus: %d baiti"
 msgstr[1] "Failipuhvri suurus: %d baiti"
 
-#: src/PrefsUnifiedDlg.cpp:2312
+#: src/PrefsUnifiedDlg.cpp:2392
 #, c-format
 msgid "Upload Queue Size: %d client"
 msgid_plural "Upload Queue Size: %d clients"
 msgstr[0] "Saatmise Saba suurus: %d klienti"
 msgstr[1] "Saatmise Saba suurus: %d klienti"
 
-#: src/PrefsUnifiedDlg.cpp:2322
+#: src/PrefsUnifiedDlg.cpp:2402
 #, c-format
 msgid "Server connection refresh interval: %d minute"
 msgid_plural "Server connection refresh interval: %d minutes"
 msgstr[0] "Serveri ühenduse värskendamise intervall: %d minutit"
 msgstr[1] "Serveri ühenduse värskendamise intervall: %d minutit"
 
-#: src/PrefsUnifiedDlg.cpp:2327
+#: src/PrefsUnifiedDlg.cpp:2407
 msgid "Server connection refresh interval: Disabled"
 msgstr "Serveri ühenduse värskendamise intervall: Ei kasuta"
 
-#: src/PrefsUnifiedDlg.cpp:2371
+#: src/PrefsUnifiedDlg.cpp:2451
 msgid "disabled"
 msgstr "keelatud"
 
-#: src/PrefsUnifiedDlg.cpp:2397
+#: src/PrefsUnifiedDlg.cpp:2477
 #, c-format
 msgid "Execute command on '%s' event"
 msgstr "Käivita käsk peale '%s' sündmust"
 
-#: src/PrefsUnifiedDlg.cpp:2404
+#: src/PrefsUnifiedDlg.cpp:2484
 msgid "Enable command execution on core"
 msgstr "Luba käskude käivitamine tuumas"
 
-#: src/PrefsUnifiedDlg.cpp:2416
+#: src/PrefsUnifiedDlg.cpp:2496
 msgid "Core command:"
 msgstr "Tuumkäsk:"
 
-#: src/PrefsUnifiedDlg.cpp:2432
+#: src/PrefsUnifiedDlg.cpp:2512
 msgid "Enable command execution on GUI"
 msgstr "Luba käskude käivitamine GUI's"
 
-#: src/PrefsUnifiedDlg.cpp:2444
+#: src/PrefsUnifiedDlg.cpp:2524
 msgid "GUI command:"
 msgstr "GUI Käsk:"
 
-#: src/PrefsUnifiedDlg.cpp:2460
+#: src/PrefsUnifiedDlg.cpp:2540
 msgid "The following variables will be replaced:"
 msgstr "Järgnevad muutujad asendatakse:"
 
-#: src/PrefsUnifiedDlg.cpp:2628
+#: src/PrefsUnifiedDlg.cpp:2708
 msgid ""
 "The following folders look like system or sensitive locations:\n"
 "\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2633
+#: src/PrefsUnifiedDlg.cpp:2713
 msgid "Sharing them recursively will publish every file underneath on the eD2k/Kad networks. Do you really want to do this?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2636
+#: src/PrefsUnifiedDlg.cpp:2716
 #, fuzzy
 msgid "Confirm shared folders"
 msgstr "Jagatud kataloogid"
 
-#: src/PrefsUnifiedDlg.cpp:2664
+#: src/PrefsUnifiedDlg.cpp:2744
 #, fuzzy
 msgid "Reloading shared files..."
 msgstr "Lae oma jagatud failid uuesti"
 
-#: src/PrefsUnifiedDlg.cpp:2665
+#: src/PrefsUnifiedDlg.cpp:2745
 msgid "Scanning for subdirectories..."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2666
+#: src/PrefsUnifiedDlg.cpp:2746
 #, fuzzy
 msgid "Updating shared folders"
 msgstr "Jagatud kataloogid"
 
-#: src/PrefsUnifiedDlg.cpp:2693
+#: src/PrefsUnifiedDlg.cpp:2773
 #, c-format
 msgid "Scanned %u directories..."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2743
+#: src/PrefsUnifiedDlg.cpp:2823
 #, fuzzy, c-format
 msgid "Reloading shared files: %u files scanned"
 msgstr "Jagatud failide loetelu taaslaadimine."
 
-#: src/PrefsUnifiedDlg.cpp:2793
+#: src/PrefsUnifiedDlg.cpp:2873
 #, fuzzy
 msgid "Shared folder"
 msgstr "Jagatud kataloogid"

--- a/po/eu.po
+++ b/po/eu.po
@@ -10,8 +10,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-28 12:12+0200\n"
-"PO-Revision-Date: 2026-07-27 10:20+0000\n"
+"POT-Creation-Date: 2026-07-28 08:06+0200\n"
+"PO-Revision-Date: 2026-07-27 11:37+0000\n"
 "Last-Translator: Piarres Beobide <pi@beobide.net>\n"
 "Language-Team: Euskara <librezale@librezale.org>\n"
 "Language: eu\n"
@@ -146,7 +146,7 @@ msgstr ""
 msgid "Not now"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:422 src/amuleDlg.cpp:665
+#: src/AppImageIntegration.cpp:422 src/amuleDlg.cpp:600
 msgid "Don't ask again"
 msgstr ""
 
@@ -204,83 +204,83 @@ msgstr "Huts ED2KLinks fitxategia irekitzerakoan."
 msgid "WARNING: You can't add yourself as a source for an eD2k link while having a lowid."
 msgstr "KONTUZ: Ezin duzu zure burua ezarri eD2k lotura batean Id baxua duzunean."
 
-#: src/amule.cpp:301
+#: src/amule.cpp:300
 msgid "Now, exiting main app..."
 msgstr "Orain, aplikazio nagusia ixten..."
 
-#: src/amule.cpp:331
+#: src/amule.cpp:330
 #, c-format
 msgid "Terminating amuleweb instance with pid '%d' ... "
 msgstr "'%d' pid-a duen amuleweb instantzia amaitzen ... "
 
-#: src/amule.cpp:335
+#: src/amule.cpp:334
 #, c-format
 msgid "Killing amuleweb instance with pid '%d' ... "
 msgstr "'%d' pid-a duen amuleweb instantzia hiltzen ... "
 
-#: src/amule.cpp:337 src/amule.cpp:350 src/ClientRef.cpp:180
-#: src/SearchDlg.cpp:1041 src/ServerListCtrl.cpp:98
+#: src/amule.cpp:336 src/amule.cpp:349 src/ClientRef.cpp:180
+#: src/SearchDlg.cpp:880 src/ServerListCtrl.cpp:98
 msgid "Failed"
 msgstr "Huts egin du"
 
-#: src/amule.cpp:344
+#: src/amule.cpp:343
 #, fuzzy, c-format
 msgid "Terminating amuleapi instance with pid '%d' ... "
 msgstr "'%d' pid-a duen amuleweb instantzia amaitzen ... "
 
-#: src/amule.cpp:348
+#: src/amule.cpp:347
 #, fuzzy, c-format
 msgid "Killing amuleapi instance with pid '%d' ... "
 msgstr "'%d' pid-a duen amuleweb instantzia hiltzen ... "
 
-#: src/amule.cpp:356
+#: src/amule.cpp:355
 msgid "aMule OnExit: Terminating core."
 msgstr "aMule irteten: Muina ixten."
 
-#: src/amule.cpp:467
+#: src/amule.cpp:466
 msgid "aMule shutdown completed."
 msgstr "aMule itzaltzea osaturik."
 
-#: src/amule.cpp:471
+#: src/amule.cpp:470
 msgid "Memory debug results for aMule exit:"
 msgstr "aMule ixtearen memoria arazte irteera:"
 
-#: src/amule.cpp:652
+#: src/amule.cpp:651
 #, c-format
 msgid "Binding aMule's peer-to-peer traffic to interface: %s (HTTP updates use the default route)"
 msgstr ""
 
-#: src/amule.cpp:656
+#: src/amule.cpp:655
 #, c-format
 msgid "Binding all network traffic to interface: %s"
 msgstr ""
 
-#: src/amule.cpp:660
+#: src/amule.cpp:659
 #, c-format
 msgid "WARNING: configured network interface '%s' was not found - traffic is NOT bound to it and may leave via the default route. Check the interface name in Preferences."
 msgstr ""
 
-#: src/amule.cpp:666
+#: src/amule.cpp:665
 #, c-format
 msgid "WARNING: binding to network interface '%s' requires elevated privileges and was NOT applied - traffic may leave via the default route. Grant the capability (e.g. 'sudo setcap cap_net_raw+ep' on the aMule binary) or run with sufficient privileges."
 msgstr ""
 
-#: src/amule.cpp:674
+#: src/amule.cpp:673
 #, c-format
 msgid "WARNING: could not bind to network interface '%s' - traffic may leave via the default route."
 msgstr ""
 
-#: src/amule.cpp:733
+#: src/amule.cpp:732
 msgid "Your locale has been changed to System Default due to a configuration change. Sorry."
 msgstr "Zure lokalak sistemako lehenetsira aldatu dira konfigurazio aldaketa bat dela eta. Barkatu."
 
-#: src/amule.cpp:735 src/amule.cpp:1589 src/CatDialog.cpp:128
+#: src/amule.cpp:734 src/amule.cpp:1581 src/CatDialog.cpp:128
 #: src/CatDialog.cpp:136 src/CatDialog.cpp:149 src/ServerList.cpp:366
 #: src/ServerListCtrl.cpp:152
 msgid "Info"
 msgstr "Argb"
 
-#: src/amule.cpp:742
+#: src/amule.cpp:741
 msgid ""
 "\n"
 "EC configuration"
@@ -288,74 +288,74 @@ msgstr ""
 "\n"
 "EC konfigurazioa"
 
-#: src/amule.cpp:745
+#: src/amule.cpp:744
 msgid "Password set and external connections enabled."
 msgstr "Pasahitza ezarria eta kanpo konexioak gaiturik."
 
-#: src/amule.cpp:755 src/KadDlg.cpp:176 src/KadDlg.cpp:185
-#: src/PrefsUnifiedDlg.cpp:1461 src/SharedFilesCtrl.cpp:476
+#: src/amule.cpp:754 src/KadDlg.cpp:176 src/KadDlg.cpp:185
+#: src/PrefsUnifiedDlg.cpp:1387 src/SharedFilesCtrl.cpp:476
 msgid "WARNING"
 msgstr "OHARRA"
 
-#: src/amule.cpp:992
+#: src/amule.cpp:991
 #, fuzzy
 msgid "Network bootstrap"
 msgstr "Sareak"
 
-#: src/amule.cpp:997
+#: src/amule.cpp:996
 msgid ""
 "aMule has detected missing network bootstrap files.\n"
 "Select which ones to download:"
 msgstr ""
 
-#: src/amule.cpp:1006 src/FirstRunWizard.cpp:411
+#: src/amule.cpp:1005 src/FirstRunWizard.cpp:411
 #, fuzzy
 msgid "eD2k server list (server.met)"
 msgstr "zerbitzari %i aurkiturik server.met fitxategian"
 
-#: src/amule.cpp:1013 src/FirstRunWizard.cpp:416
+#: src/amule.cpp:1012 src/FirstRunWizard.cpp:416
 msgid "Kad bootstrap nodes (nodes.dat)"
 msgstr ""
 
-#: src/amule.cpp:1103
+#: src/amule.cpp:1102
 #, c-format
 msgid "web server running on pid %d"
 msgstr "web zerbitzaria abiarazirik %d pid-arekin"
 
-#: src/amule.cpp:1116
+#: src/amule.cpp:1115
 #, fuzzy
 msgid "You requested to run web server on startup, but the amuleweb binary cannot be run. Please install the package containing aMule web server, or build aMule from source with -DBUILD_WEBSERVER=YES and install it."
 msgstr "Abioan web-zerbitzaria exekutatzea eskatu duzu, baina amuleweb bitarra ezin da exekutatu. Mesedez instalatu amule web zerbitzaria duen paketea edo konpilatu ezazu amule --enable-webserver erabilian eta make install egin"
 
-#: src/amule.cpp:1121 src/amule.cpp:1185 src/amule.cpp:1299 src/amule.cpp:1601
+#: src/amule.cpp:1120 src/amule.cpp:1177 src/amule.cpp:1291 src/amule.cpp:1593
 #: src/amule-remote-gui.cpp:603 src/amule-remote-gui.cpp:671
 #: src/amule-remote-gui.cpp:709 src/amule-remote-gui.cpp:1282
 #: src/amule-remote-gui.cpp:1345 src/amule-remote-gui.cpp:1372
-#: src/DownloadQueue.cpp:1481 src/PrefsUnifiedDlg.cpp:1247
+#: src/DownloadQueue.cpp:1481
 msgid "ERROR"
 msgstr "ERROREA"
 
-#: src/amule.cpp:1174
+#: src/amule.cpp:1166
 #, fuzzy, c-format
 msgid "amuleapi running on pid %d"
 msgstr "web zerbitzaria abiarazirik %d pid-arekin"
 
-#: src/amule.cpp:1180
+#: src/amule.cpp:1172
 #, fuzzy
 msgid "You requested to run amuleapi on startup, but the amuleapi binary cannot be run. Please install the package containing aMule's REST API server, or build aMule from source with -DBUILD_AMULEAPI=YES and install it."
 msgstr "Abioan web-zerbitzaria exekutatzea eskatu duzu, baina amuleweb bitarra ezin da exekutatu. Mesedez instalatu amule web zerbitzaria duen paketea edo konpilatu ezazu amule --enable-webserver erabilian eta make install egin"
 
-#: src/amule.cpp:1267
+#: src/amule.cpp:1259
 #, c-format
 msgid "Could not bind ports to the specified address: %s"
 msgstr "Ezin da atakak ezarritako helbidean ireki: %s"
 
-#: src/amule.cpp:1291
+#: src/amule.cpp:1283
 #, c-format
 msgid "Port %u is not available. You will be LOWID\n"
 msgstr "%u ataka ez dago eskuragarri. IDBaxua izango duzu\n"
 
-#: src/amule.cpp:1296
+#: src/amule.cpp:1288
 #, c-format
 msgid ""
 "Port %u is not available!\n"
@@ -370,48 +370,48 @@ msgstr ""
 "\n"
 "Egiaztatu zure sarea ataka sarrera eta irteerarako irekirik dagoela ziurtatzeko."
 
-#: src/amule.cpp:1393
+#: src/amule.cpp:1385
 msgid "Failed to create OnlineSig File"
 msgstr "Huts online sinadura fitxategia sortzerakoan"
 
-#: src/amule.cpp:1401
+#: src/amule.cpp:1393
 msgid "Failed to create aMule OnlineSig File"
 msgstr "Huts aMule online sinadura fitxategia sortzerakoan"
 
-#: src/amule.cpp:1564
+#: src/amule.cpp:1556
 msgid "The selected locale seems not to be installed on your box. (Note: I'll try to set it anyway)"
 msgstr "Aukeratutako lokalak ez dirudi zure sisteman instalaturik. (Oharra: Hala ere erabiltzen saiatuko da)"
 
-#: src/amule.cpp:1574
+#: src/amule.cpp:1566
 #, c-format
 msgid "This is the first time you run aMule %s"
 msgstr "aMule %s abiarazten duzun lehen aldia da"
 
-#: src/amule.cpp:1577
+#: src/amule.cpp:1569
 msgid "This version is a testing version, updated daily, and\n"
 msgstr "Bertsioa hau beta bertsio bat da, egunero eguneratzen da, eta\n"
 
-#: src/amule.cpp:1578
+#: src/amule.cpp:1570
 msgid "we give no warranty it won't break anything, burn your house,\n"
 msgstr "ez gara ezer apurtu, zure etxea erre, edo zure zakurra akatzen\n"
 
-#: src/amule.cpp:1579
+#: src/amule.cpp:1571
 msgid "or kill your dog. But it *should* be safe to use anyway.\n"
 msgstr "badu ere kargu egingo. Baina erabiltzeko ziurra izan *beharko* litzateke.\n"
 
-#: src/amule.cpp:1584
+#: src/amule.cpp:1576
 msgid "More information, support and new releases can found at our homepage,\n"
 msgstr "Argibide gehiago, laguntza eta bertsio berriak gure webgunean aurki ditzakezu,\n"
 
-#: src/amule.cpp:1585
+#: src/amule.cpp:1577
 msgid "at https://amule-org.github.io, or in our IRC channel #aMule at irc.libera.chat.\n"
 msgstr "https://amule-org.github.io -en, edo irc.libera.chat IRC sareko #aMule kanalean.\n"
 
-#: src/amule.cpp:1587
+#: src/amule.cpp:1579
 msgid "Feel free to report any bugs to https://github.com/amule-org/amule/issues"
 msgstr "Edozein akatsen berri emateko:https://github.com/amule-org/amule/issues"
 
-#: src/amule.cpp:1599
+#: src/amule.cpp:1591
 msgid ""
 "The folder for Online Signature files you specified is INVALID!\n"
 " OnlineSignature will be DISABLED until you fix it on preferences."
@@ -419,137 +419,137 @@ msgstr ""
 "Zuk aukeratutako sinadura karpeta BALIOGABEA da!\n"
 " Lehenespenak konpondu artean lineako sinadura EZGAITU egingo da."
 
-#: src/amule.cpp:1662
+#: src/amule.cpp:1654
 msgid "Server hostname notified"
 msgstr "Zerbitzari ostalari-izena notifikatua"
 
-#: src/amule.cpp:2039
+#: src/amule.cpp:2031
 #, c-format
 msgid "Disk space preallocation for file '%s' failed: %s"
 msgstr "Disko aurresleipenak huts egin du '%s' fitxategiarentzat: %s"
 
-#: src/amule.cpp:2168
+#: src/amule.cpp:2160
 msgid "ERROR: can't open logfile"
 msgstr "ERROREA: ezin da erregistro fitxategia ireki"
 
-#: src/amule.cpp:2172
+#: src/amule.cpp:2164
 msgid "WARNING: logfile is empty. Something is wrong."
 msgstr "ABISUA: erregistro fitxategia hutsik dago. Zerbait oker dago."
 
-#: src/amule.cpp:2189
+#: src/amule.cpp:2181
 msgid "Log has been reset"
 msgstr "Erregistroa berrezarri egin da"
 
-#: src/amule.cpp:2213
+#: src/amule.cpp:2205
 #, c-format
 msgid "ServerMessage: %s"
 msgstr "ZerbitzariMezua: %s"
 
-#: src/amule.cpp:2256 src/IP2Country.cpp:220 src/IPFilter.cpp:514
+#: src/amule.cpp:2248 src/IP2Country.cpp:220 src/IPFilter.cpp:514
 #: src/ServerList.cpp:875
 #, c-format
 msgid "Skipped download of %s, because requested file is not newer."
 msgstr "%s-ren deskarga baztertua, eskatutako fitxategia ez da berria eta."
 
-#: src/amule.cpp:2259
+#: src/amule.cpp:2251
 msgid "Failed to download the nodes list."
 msgstr "Huts egin du nodo zerrenda deskargatzerakoan."
 
-#: src/amule.cpp:2322
+#: src/amule.cpp:2314
 msgid "Failed to open the downloaded version check file"
 msgstr "Huts egin du"
 
-#: src/amule.cpp:2325 src/amule.cpp:2344
+#: src/amule.cpp:2317 src/amule.cpp:2336
 msgid "Corrupted version check file"
 msgstr "Hondaturiko bertsio arakatze fitxategia"
 
-#: src/amule.cpp:2367
+#: src/amule.cpp:2359
 msgid "You are using an outdated version of aMule!"
 msgstr "Zaharkiturik dagoen aMule bertsio bat erabiltzen ari zara!"
 
-#: src/amule.cpp:2369
+#: src/amule.cpp:2361
 #, c-format
 msgid "Your aMule version is %i.%i.%i and the latest version is %li.%li.%li"
 msgstr "Zure aMule bertsioa %i.%i.%i da eta azken bertsioa %li.%li.%li da"
 
-#: src/amule.cpp:2373
+#: src/amule.cpp:2365
 msgid "The latest version can always be found at https://github.com/amule-org/amule/releases/latest"
 msgstr "Azken bertsioa beti https://github.com/amule-org/amule/releases/latest webgunean aurki daiteke"
 
-#: src/amule.cpp:2376
+#: src/amule.cpp:2368
 #, c-format
 msgid "WARNING: Your aMuled version is outdated: %i.%i.%i < %li.%li.%li"
 msgstr "OHARRA: Zure aMuled bertsioa zaharkiturik dago: %i.%i.%i < %li.%li.%li"
 
-#: src/amule.cpp:2382
+#: src/amule.cpp:2374
 msgid "Your copy of aMule is up to date."
 msgstr "Zure aMule kopia zaharkiturik dago."
 
-#: src/amule.cpp:2389
+#: src/amule.cpp:2381
 msgid "Failed to download the version check file"
 msgstr "Huts bertsio arakatze fitxategia deskargatzerakoan"
 
-#: src/amule.cpp:2558 src/amule-remote-gui.cpp:1133
+#: src/amule.cpp:2550 src/amule-remote-gui.cpp:1133
 #, c-format
 msgid "Users: %s | Files: %s"
 msgstr "Erab: %s | Fitx: %s"
 
-#: src/amule.cpp:2559 src/amule-remote-gui.cpp:1134
+#: src/amule.cpp:2551 src/amule-remote-gui.cpp:1134
 #, c-format
 msgid "Users: E: %s K: %s | Files: E: %s K: %s"
 msgstr "Erab: E: %s K: %s | Fitx: E: %s K: %s"
 
-#: src/amule.cpp:2573 src/amule-remote-gui.cpp:1147
+#: src/amule.cpp:2565 src/amule-remote-gui.cpp:1147
 msgid "No networks selected"
 msgstr "Ez dago sarerik hautatuta"
 
-#: src/amule.cpp:2641 src/TextClient.cpp:903
+#: src/amule.cpp:2633 src/TextClient.cpp:903
 msgid "with LowID"
 msgstr "IDBaxuarekin"
 
-#: src/amule.cpp:2641 src/TextClient.cpp:904
+#: src/amule.cpp:2633 src/TextClient.cpp:904
 msgid "with HighID"
 msgstr "IDAltuarekin"
 
-#: src/amule.cpp:2643
+#: src/amule.cpp:2635
 #, c-format
 msgid "Connected to %s %s"
 msgstr "%s %s-ra konektaturik"
 
-#: src/amule.cpp:2648
+#: src/amule.cpp:2640
 #, c-format
 msgid "Connecting to %s"
 msgstr "%s-ra konektatzen"
 
-#: src/amule.cpp:2650
+#: src/amule.cpp:2642
 msgid "Disconnected from eD2k"
 msgstr "eD2k-tik deskonektatua"
 
-#: src/amule.cpp:2659
+#: src/amule.cpp:2651
 msgid "Kad started."
 msgstr "Kad abiarazirik."
 
-#: src/amule.cpp:2661
+#: src/amule.cpp:2653
 msgid "Kad stopped."
 msgstr "Kad gelditurik."
 
-#: src/amule.cpp:2669
+#: src/amule.cpp:2661
 msgid "Connected to Kad (ok)"
 msgstr "Kad-era Konektatuta (ondo)"
 
-#: src/amule.cpp:2671
+#: src/amule.cpp:2663
 msgid "Connected to Kad (firewalled)"
 msgstr "Kad-era Konektatuta (suebakirik)"
 
-#: src/amule.cpp:2675
+#: src/amule.cpp:2667
 msgid "Disconnected from Kad"
 msgstr "Kad-etik deskonektatua"
 
-#: src/amule.cpp:2707
+#: src/amule.cpp:2699
 msgid "Kad network cannot be used if UDP port is disabled on preferences, not starting."
 msgstr "Kad sarea ezin da erabili hobespenetan UDP ataka ezgaiturik badago, ez da abiaraziko."
 
-#: src/amule.cpp:2711
+#: src/amule.cpp:2703
 msgid "Kad network disabled on preferences, not connecting."
 msgstr "Kad sarea hobespenetan ezgaiturik, ez da konektatuko."
 
@@ -575,68 +575,30 @@ msgstr "Ezin da Pid fitxategia sortu"
 msgid "ERROR: %s"
 msgstr "ERROREA: %s"
 
-#: src/amuleDlg.cpp:250
+#: src/amuleDlg.cpp:236
 #, c-format
 msgid "This is aMule %s based on eMule."
 msgstr "Hau eMulen oinarrituriko aMule %s da."
 
-#: src/amuleDlg.cpp:251
+#: src/amuleDlg.cpp:237
 #, c-format
 msgid "Running on %s"
 msgstr "%s-n abiarazirik"
 
-#: src/amuleDlg.cpp:253
+#: src/amuleDlg.cpp:239
 msgid "Visit https://github.com/amule-org/amule/releases/latest to check if a new version is available."
 msgstr "Bisitatu https://github.com/amule-org/amule/releases/latest gunea bertsio berriagorik eskuragarri dagoen jakiteko."
 
-#: src/amuleDlg.cpp:282
+#: src/amuleDlg.cpp:268
 msgid "FATAL ERROR: Failed to create Timer"
 msgstr "ERRORE KONPONEZINA: Huts kronometroa sortzean"
 
-#: src/amuleDlg.cpp:361 src/amuleDlg.cpp:1810 src/amuleDlg.cpp:2056
-#: src/muuli_wdr.cpp:1492 src/muuli_wdr.cpp:3439
-msgid "Networks"
-msgstr "Sareak"
-
-#: src/amuleDlg.cpp:362 src/amuleDlg.cpp:1816 src/muuli_wdr.cpp:3440
-msgid "Searches"
-msgstr "Bilaketak"
-
-#: src/amuleDlg.cpp:363 src/amuleDlg.cpp:1822 src/DownloadListCtrl.cpp:740
-#: src/muuli_wdr.cpp:392 src/muuli_wdr.cpp:1585 src/muuli_wdr.cpp:3441
-#: src/Statistics.cpp:829
-msgid "Downloads"
-msgstr "Deskargak"
-
-#: src/amuleDlg.cpp:364 src/amuleDlg.cpp:1828 src/muuli_wdr.cpp:3315
-msgid "Shared files"
-msgstr "Partekatutako fitxategiak"
-
-#: src/amuleDlg.cpp:365 src/amuleDlg.cpp:1834 src/muuli_wdr.cpp:2947
-#: src/muuli_wdr.cpp:3397 src/muuli_wdr.cpp:3444
-msgid "Messages"
-msgstr "Mezuak"
-
-#: src/amuleDlg.cpp:366 src/amuleDlg.cpp:1840 src/muuli_wdr.cpp:3445
-#: src/PrefsUnifiedDlg.cpp:314 src/Statistics.cpp:779 src/Statistics.cpp:1235
-msgid "Statistics"
-msgstr "Estatistikak"
-
-#: src/amuleDlg.cpp:368 src/amuleDlg.cpp:1847 src/muuli_wdr.cpp:3447
-#: src/PrefsUnifiedDlg.cpp:330 src/utils/wxCas/src/wxcasprefs.cpp:39
-msgid "Preferences"
-msgstr "Hobespenak"
-
-#: src/amuleDlg.cpp:371
-msgid "Navigate"
-msgstr ""
-
-#: src/amuleDlg.cpp:657
+#: src/amuleDlg.cpp:592
 #, fuzzy
 msgid "New version available"
 msgstr "Ez dago erabilgarri"
 
-#: src/amuleDlg.cpp:661
+#: src/amuleDlg.cpp:596
 #, fuzzy, c-format
 msgid ""
 "A new version of aMule (%s) is available.\n"
@@ -646,185 +608,218 @@ msgid ""
 "Would you like to open the download page?"
 msgstr "Azken bertsioa beti https://github.com/amule-org/amule/releases/latest webgunean aurki daiteke"
 
-#: src/amuleDlg.cpp:743
+#: src/amuleDlg.cpp:678
 msgid "aMule dialog destroyed"
 msgstr "aMule elkarrizketa suntsitua"
 
-#: src/amuleDlg.cpp:766 src/DataToText.cpp:68 src/IPFilter.cpp:547
+#: src/amuleDlg.cpp:701 src/DataToText.cpp:68 src/IPFilter.cpp:547
 msgid "Connecting"
 msgstr "Konektatzen"
 
-#: src/amuleDlg.cpp:958
+#: src/amuleDlg.cpp:893
 msgid "eD2k: Connecting"
 msgstr "eD2k: Konektatzen"
 
-#: src/amuleDlg.cpp:962
+#: src/amuleDlg.cpp:897
 msgid "eD2k: Disconnected"
 msgstr "eD2k: Deskonektatua"
 
-#: src/amuleDlg.cpp:968
+#: src/amuleDlg.cpp:903
 msgid "Kad: Firewalled"
 msgstr "Kad: Suebakirik"
 
-#: src/amuleDlg.cpp:972
+#: src/amuleDlg.cpp:907
 msgid "Kad: Connected"
 msgstr "Kad: Konektaturik"
 
-#: src/amuleDlg.cpp:977
+#: src/amuleDlg.cpp:912
 msgid "Kad: Connecting"
 msgstr "Kad: Konektatzen"
 
-#: src/amuleDlg.cpp:981
+#: src/amuleDlg.cpp:916
 msgid "Kad: Off"
 msgstr "Kad: Itzalia"
 
-#: src/amuleDlg.cpp:1029 src/DownloadListCtrl.cpp:505
+#: src/amuleDlg.cpp:964 src/DownloadListCtrl.cpp:505
 #: src/DownloadListCtrl.cpp:749 src/FriendListCtrl.cpp:180
 #: src/muuli_wdr.cpp:731 src/muuli_wdr.cpp:782 src/muuli_wdr.cpp:846
-#: src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2252 src/muuli_wdr.cpp:2337
-#: src/muuli_wdr.cpp:3085 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
+#: src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2224 src/muuli_wdr.cpp:2309
+#: src/muuli_wdr.cpp:3057 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
 #: src/ServerListCtrl.cpp:606 src/TransferWnd.cpp:378
 #: src/utils/wxCas/src/wxcasprefs.cpp:235
 msgid "Cancel"
 msgstr "Utzi"
 
-#: src/amuleDlg.cpp:1030
+#: src/amuleDlg.cpp:965
 msgid "Stop the current connection attempts"
 msgstr "Geratu uneko konexio saiakerak"
 
-#: src/amuleDlg.cpp:1035 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976
-#: src/muuli_wdr.cpp:2475
+#: src/amuleDlg.cpp:970 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976
+#: src/muuli_wdr.cpp:2447
 msgid "Disconnect"
 msgstr "Deskonektatu"
 
-#: src/amuleDlg.cpp:1036
+#: src/amuleDlg.cpp:971
 msgid "Disconnect from the currently connected networks"
 msgstr "Deskonektatu konektatutako sareetatik"
 
-#: src/amuleDlg.cpp:1041 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979
-#: src/muuli_wdr.cpp:2630 src/muuli_wdr.cpp:3082 src/muuli_wdr.cpp:3437
+#: src/amuleDlg.cpp:976 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979
+#: src/muuli_wdr.cpp:2602 src/muuli_wdr.cpp:3054 src/muuli_wdr.cpp:3409
 msgid "Connect"
 msgstr "Konektatu"
 
-#: src/amuleDlg.cpp:1042
+#: src/amuleDlg.cpp:977
 msgid "Connect to the currently enabled networks"
 msgstr "Konektatu gaituriko sareetara"
 
-#: src/amuleDlg.cpp:1154
+#: src/amuleDlg.cpp:1089
 #, fuzzy, c-format
 msgid "Up: %.1f%s (%.1f) | Down: %.1f%s (%.1f)"
 msgstr "Gora: %.1f(%.1f) | Behera: %.1f(%.1f)"
 
-#: src/amuleDlg.cpp:1156 src/amuleDlg.cpp:1158 src/amuleDlg.cpp:1162
-#: src/amuleDlg.cpp:1164 src/amuleDlg.cpp:1175 src/amuleDlg.cpp:1177
+#: src/amuleDlg.cpp:1091 src/amuleDlg.cpp:1093 src/amuleDlg.cpp:1097
+#: src/amuleDlg.cpp:1099 src/amuleDlg.cpp:1110 src/amuleDlg.cpp:1112
 #: src/MuleTrayIcon.cpp:796 src/MuleTrayIcon.cpp:799
 #, fuzzy
 msgid " MB/s"
 msgstr "MB/s"
 
-#: src/amuleDlg.cpp:1156 src/amuleDlg.cpp:1158 src/amuleDlg.cpp:1162
-#: src/amuleDlg.cpp:1164 src/amuleDlg.cpp:1175 src/amuleDlg.cpp:1177
+#: src/amuleDlg.cpp:1091 src/amuleDlg.cpp:1093 src/amuleDlg.cpp:1097
+#: src/amuleDlg.cpp:1099 src/amuleDlg.cpp:1110 src/amuleDlg.cpp:1112
 #: src/MuleTrayIcon.cpp:796 src/MuleTrayIcon.cpp:799
 #: src/utils/wxCas/src/wxcasframe.cpp:1041
 msgid " kB/s"
 msgstr " kB/s"
 
-#: src/amuleDlg.cpp:1161
+#: src/amuleDlg.cpp:1096
 #, fuzzy, c-format
 msgid "Up: %.1f%s | Down: %.1f%s"
 msgstr "Gora: %.1f | Behera: %.1f"
 
-#: src/amuleDlg.cpp:1193
+#: src/amuleDlg.cpp:1128
 #, c-format
 msgid "aMule (%s | Connected)"
 msgstr "aMule (%s | Konektaturik)"
 
-#: src/amuleDlg.cpp:1195
+#: src/amuleDlg.cpp:1130
 #, c-format
 msgid "aMule (%s | Disconnected)"
 msgstr "aMule (%s | Ez konektaturik)"
 
-#: src/amuleDlg.cpp:1248
+#: src/amuleDlg.cpp:1183
 #, c-format
 msgid "Do you really want to exit %s?"
 msgstr "Benetan %s utzi egin nahi duzu?"
 
-#: src/amuleDlg.cpp:1250
+#: src/amuleDlg.cpp:1185
 msgid "Exit confirmation"
 msgstr "Irteera berrespena"
 
-#: src/amuleDlg.cpp:1613
+#: src/amuleDlg.cpp:1548
 msgid "Launch Command: "
 msgstr "Abiarazi komandoa: "
 
-#: src/amuleDlg.cpp:1632 src/muuli_wdr.cpp:1972 src/Preferences.cpp:979
+#: src/amuleDlg.cpp:1567 src/muuli_wdr.cpp:1971 src/Preferences.cpp:951
 msgid "- default -"
 msgstr "- lehenetsia -"
 
-#: src/amuleDlg.cpp:1660
+#: src/amuleDlg.cpp:1595
 #, c-format
 msgid "Skin directory '%s' does not exist"
 msgstr "Ez dago '%s' itxura direktorioa"
 
-#: src/amuleDlg.cpp:1663
+#: src/amuleDlg.cpp:1598
 #, c-format
 msgid "WARNING: Unable to open skin file '%s' for read"
 msgstr "ABISUA: Ezin da '%s' azal fitxategia irakurri"
 
-#: src/amuleDlg.cpp:1814 src/muuli_wdr.cpp:3439
+#: src/amuleDlg.cpp:1722 src/amuleDlg.cpp:1968 src/muuli_wdr.cpp:1485
+#: src/muuli_wdr.cpp:3411
+msgid "Networks"
+msgstr "Sareak"
+
+#: src/amuleDlg.cpp:1726 src/muuli_wdr.cpp:3411
 msgid "Networks Window"
 msgstr "Sare leihoa"
 
-#: src/amuleDlg.cpp:1820 src/muuli_wdr.cpp:3440
+#: src/amuleDlg.cpp:1728 src/muuli_wdr.cpp:3412
+msgid "Searches"
+msgstr "Bilaketak"
+
+#: src/amuleDlg.cpp:1732 src/muuli_wdr.cpp:3412
 msgid "Searches Window"
 msgstr "Bilaketa leihoa"
 
-#: src/amuleDlg.cpp:1826 src/muuli_wdr.cpp:3441
+#: src/amuleDlg.cpp:1734 src/DownloadListCtrl.cpp:740 src/muuli_wdr.cpp:392
+#: src/muuli_wdr.cpp:1578 src/muuli_wdr.cpp:3413 src/Statistics.cpp:829
+msgid "Downloads"
+msgstr "Deskargak"
+
+#: src/amuleDlg.cpp:1738 src/muuli_wdr.cpp:3413
 msgid "Downloads Window"
 msgstr "Deskargak leihoa"
 
-#: src/amuleDlg.cpp:1832 src/muuli_wdr.cpp:3443
+#: src/amuleDlg.cpp:1740 src/muuli_wdr.cpp:3287
+msgid "Shared files"
+msgstr "Partekatutako fitxategiak"
+
+#: src/amuleDlg.cpp:1744 src/muuli_wdr.cpp:3415
 msgid "Shared Files Window"
 msgstr "Partekatutako fitxategi leihoa"
 
-#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3444
+#: src/amuleDlg.cpp:1746 src/muuli_wdr.cpp:2919 src/muuli_wdr.cpp:3369
+#: src/muuli_wdr.cpp:3416
+msgid "Messages"
+msgstr "Mezuak"
+
+#: src/amuleDlg.cpp:1750 src/muuli_wdr.cpp:3416
 msgid "Messages Window"
 msgstr "Mezu leihoa"
 
-#: src/amuleDlg.cpp:1844 src/muuli_wdr.cpp:3445
+#: src/amuleDlg.cpp:1752 src/muuli_wdr.cpp:3417 src/PrefsUnifiedDlg.cpp:312
+#: src/Statistics.cpp:779 src/Statistics.cpp:1235
+msgid "Statistics"
+msgstr "Estatistikak"
+
+#: src/amuleDlg.cpp:1756 src/muuli_wdr.cpp:3417
 msgid "Statistics Graph Window"
 msgstr "Estatistika grafiko leihoa"
 
-#: src/amuleDlg.cpp:1851 src/muuli_wdr.cpp:3447
+#: src/amuleDlg.cpp:1759 src/muuli_wdr.cpp:3419 src/PrefsUnifiedDlg.cpp:328
+#: src/utils/wxCas/src/wxcasprefs.cpp:39
+msgid "Preferences"
+msgstr "Hobespenak"
+
+#: src/amuleDlg.cpp:1763 src/muuli_wdr.cpp:3419
 msgid "Preferences Settings Window"
 msgstr "Hobespen ezarpen leihoa"
 
-#: src/amuleDlg.cpp:1854 src/muuli_wdr.cpp:3448
+#: src/amuleDlg.cpp:1766 src/muuli_wdr.cpp:3420
 msgid "Import"
 msgstr "Inportatu"
 
-#: src/amuleDlg.cpp:1858 src/muuli_wdr.cpp:3448
+#: src/amuleDlg.cpp:1770 src/muuli_wdr.cpp:3420
 msgid "The partfile importer tool"
 msgstr "Zati fitxategi inportazio tresna"
 
-#: src/amuleDlg.cpp:1861 src/muuli_wdr.cpp:3449
+#: src/amuleDlg.cpp:1773 src/muuli_wdr.cpp:3421
 #: src/utils/aLinkCreator/src/alcframe.cpp:262
 msgid "About"
 msgstr "Honi buruz"
 
-#: src/amuleDlg.cpp:1861 src/muuli_wdr.cpp:3449
+#: src/amuleDlg.cpp:1773 src/muuli_wdr.cpp:3421
 msgid "About/Help"
 msgstr "Honi buruz/Laguntza"
 
-#: src/amuleDlg.cpp:2059
+#: src/amuleDlg.cpp:1971
 msgid "eD2k network"
 msgstr "eD2k sarea"
 
-#: src/amuleDlg.cpp:2062
+#: src/amuleDlg.cpp:1974
 msgid "Kad network"
 msgstr "Kad sarea"
 
-#: src/amuleDlg.cpp:2062
+#: src/amuleDlg.cpp:1974
 msgid "No network"
 msgstr "Sarerik ez"
 
@@ -954,7 +949,7 @@ msgstr "Fitxategia ez da aurkitu."
 msgid "The core rejected these shared folders:%s"
 msgstr ""
 
-#: src/amule-remote-gui.cpp:1336 src/ExternalConn.cpp:2346
+#: src/amule-remote-gui.cpp:1336 src/ExternalConn.cpp:2345
 msgid "Invalid link or already on list."
 msgstr "Lotura baliogabea edo zerrendan dagoeneko."
 
@@ -970,7 +965,7 @@ msgstr "Ezin da '%s' direktorioa sortu '%s' kategoriarentzat, '%s' direktorioa m
 #: src/ClientDetailDialog.cpp:123 src/DataToText.cpp:61 src/DataToText.cpp:86
 #: src/DataToText.cpp:101 src/DataToText.cpp:136 src/DataToText.cpp:165
 #: src/DownloadListCtrl.cpp:1172 src/DownloadListCtrl.cpp:1185
-#: src/DownloadListCtrl.cpp:1196 src/ExternalConn.cpp:609
+#: src/DownloadListCtrl.cpp:1196 src/ExternalConn.cpp:608
 #: src/FileDetailDialog.cpp:203 src/FileDetailDialog.cpp:235
 #: src/FileDetailDialog.cpp:242 src/GenericClientListCtrl.cpp:1171
 #: src/GenericClientListCtrl.cpp:1182 src/GenericClientListCtrl.cpp:1192
@@ -1357,19 +1352,19 @@ msgstr "Auto[Alt]"
 msgid "Very low"
 msgstr "Oso txikia"
 
-#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:743 src/muuli_wdr.cpp:2303
+#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:743 src/muuli_wdr.cpp:2275
 #: src/ServerListCtrl.cpp:263 src/ServerListCtrl.cpp:456
 #: src/SharedFilesCtrl.cpp:145
 msgid "Low"
 msgstr "Baxua"
 
-#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:744 src/muuli_wdr.cpp:2304
+#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:744 src/muuli_wdr.cpp:2276
 #: src/ServerListCtrl.cpp:266 src/ServerListCtrl.cpp:457
 #: src/SharedFilesCtrl.cpp:146
 msgid "Normal"
 msgstr "Normala"
 
-#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:745 src/muuli_wdr.cpp:2305
+#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:745 src/muuli_wdr.cpp:2277
 #: src/ServerListCtrl.cpp:269 src/ServerListCtrl.cpp:458
 #: src/SharedFilesCtrl.cpp:147
 msgid "High"
@@ -1461,8 +1456,8 @@ msgstr "Zerbitzari lokala"
 msgid "Remote Server"
 msgstr "Urruneko zerbitzaria"
 
-#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3202
-#: src/SearchDlg.cpp:119 src/TextClient.cpp:911
+#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3174
+#: src/SearchDlg.cpp:111 src/TextClient.cpp:911
 msgid "Kad"
 msgstr "Kad"
 
@@ -1533,7 +1528,7 @@ msgstr "Zatia"
 msgid "Size"
 msgstr "Tamaina"
 
-#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3269
+#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3241
 msgid "Transferred"
 msgstr "Transferituta"
 
@@ -1591,7 +1586,7 @@ msgstr ""
 "Erantzuna hemendik: %s (%s)\n"
 "\n"
 
-#: src/DownloadListCtrl.cpp:746 src/muuli_wdr.cpp:2306
+#: src/DownloadListCtrl.cpp:746 src/muuli_wdr.cpp:2278
 #: src/SharedFilesCtrl.cpp:150
 msgid "Auto"
 msgstr "Auto"
@@ -1629,7 +1624,7 @@ msgid "Extended Options"
 msgstr "Hedatutako aukerak"
 
 #: src/DownloadListCtrl.cpp:770 src/DownloadListCtrl.cpp:822
-#: src/muuli_wdr.cpp:1790
+#: src/muuli_wdr.cpp:1789
 msgid "Preview"
 msgstr "Aurrebista"
 
@@ -1804,232 +1799,227 @@ msgstr[1] ""
 msgid "Invalid eD2k link! ERROR: %s"
 msgstr "Okerreko eD2k lotura! ERROREA: %s"
 
-#: src/ExternalConn.cpp:380
+#: src/ExternalConn.cpp:379
 msgid "Client sent packet after authentication failed."
 msgstr "Bezeroak pakete bat bidali du egiaztapenak huts egin ondoren."
 
-#: src/ExternalConn.cpp:397
+#: src/ExternalConn.cpp:396
 msgid "External connection closed."
 msgstr "Kanpo konexioa ukaturik."
 
-#: src/ExternalConn.cpp:474
+#: src/ExternalConn.cpp:473
 msgid "External connections disabled due to empty password!"
 msgstr "Pasahitz zuria dela eta kanpo konexioak ezgaiturik!"
 
-#: src/ExternalConn.cpp:495
+#: src/ExternalConn.cpp:494
 msgid "External connections disabled in config file"
 msgstr "Kanpo konexioak ezgaiturik konfigurazio fitxategian"
 
-#: src/ExternalConn.cpp:576
+#: src/ExternalConn.cpp:575
 msgid "New external connection accepted"
 msgstr "Kanpo konexio berri bat onartu da"
 
-#: src/ExternalConn.cpp:579
+#: src/ExternalConn.cpp:578
 msgid "ERROR: couldn't accept a new external connection"
 msgstr "ERROREA: ezin da kanpo konexio berria onartu"
 
-#: src/ExternalConn.cpp:596
+#: src/ExternalConn.cpp:595
 msgid "External connection refused due to empty password in preferences!"
 msgstr "Hobespenetan pasahitza zurian dela eta kanpo konexioak ukaturik!"
 
-#: src/ExternalConn.cpp:608
+#: src/ExternalConn.cpp:607
 #, c-format
 msgid "Connecting client: %s %s"
 msgstr "Bezerora konektatzen: %s %s"
 
-#: src/ExternalConn.cpp:610
+#: src/ExternalConn.cpp:609
 msgid "Unknown version"
 msgstr "Bertsio ezezaguna"
 
-#: src/ExternalConn.cpp:623
+#: src/ExternalConn.cpp:622
 msgid "Incorrect EC version ID, there might be binary incompatibility. Use core and remote from same snapshot."
 msgstr "Okerreko bertsio ID-a, bitar bateratze ezintasuna dago. Erabili urruneko eta nagusi bertsio berdina."
 
-#: src/ExternalConn.cpp:631
+#: src/ExternalConn.cpp:630
 msgid "You cannot connect to a release version from an arbitrary development snapshot! *sigh* possible crash prevented"
 msgstr "Ezin zara argitaratutako bertsio batetara konektatu edozein garapen bertsiotik! *ikusi* apurketa aukera saihestua"
 
-#: src/ExternalConn.cpp:714
+#: src/ExternalConn.cpp:713
 msgid "Invalid protocol version."
 msgstr "Protokolo bertsio baliogabea."
 
-#: src/ExternalConn.cpp:720
+#: src/ExternalConn.cpp:719
 msgid "Missing protocol version tag."
 msgstr "Protokolo bertsio marka falta da."
 
-#: src/ExternalConn.cpp:728
+#: src/ExternalConn.cpp:727
 msgid "Authentication failed: invalid hash specified as EC password."
 msgstr "Autentifikazio errorea: okerreko egiaztapena ezarri da EC pasahitz gisa."
 
-#: src/ExternalConn.cpp:776
+#: src/ExternalConn.cpp:775
 msgid "Authentication failed: wrong password."
 msgstr "Egiaztapenak huts egin du: okerreko pasahitza."
 
-#: src/ExternalConn.cpp:778
+#: src/ExternalConn.cpp:777
 msgid "Authentication failed: missing password."
 msgstr "Egiaztapenak huts egin du: pasahitza falta da."
 
-#: src/ExternalConn.cpp:789
+#: src/ExternalConn.cpp:788
 msgid "Invalid request, please authenticate first."
 msgstr "Eskakizun baliogabea, mesedez identifikatu aurretik."
 
-#: src/ExternalConn.cpp:794
+#: src/ExternalConn.cpp:793
 msgid "Access granted."
 msgstr "Sarrera onartua."
 
-#: src/ExternalConn.cpp:802
+#: src/ExternalConn.cpp:801
 #, c-format
 msgid "Sent error message \"%s\" to client."
 msgstr "\"%s\" errore mezua bezerora bidalia."
 
-#: src/ExternalConn.cpp:807
+#: src/ExternalConn.cpp:806
 #, c-format
 msgid "Unauthorized access attempt from %s. Connection closed."
 msgstr "Baimendu gabeko sarrera saiakera %s-tik. Konexioa itxia."
 
-#: src/ExternalConn.cpp:1420
+#: src/ExternalConn.cpp:1419
 #, c-format
 msgid "Remote PartFile command failed: FileHash not found: %s"
 msgstr "Urruneko ZatiFitxategi komandoak huts egin du: Ez da %s fitxategi egiaztapena aurkitu"
 
-#: src/ExternalConn.cpp:1424
+#: src/ExternalConn.cpp:1423
 #, c-format
 msgid "FileHash not found: %s"
 msgstr "Ez da %s fitxategi egiaztapena aurkitu"
 
-#: src/ExternalConn.cpp:1471 src/ExternalConn.cpp:1559
-#: src/ExternalConn.cpp:1680
+#: src/ExternalConn.cpp:1470 src/ExternalConn.cpp:1558
+#: src/ExternalConn.cpp:1679
 msgid "OOPS! OpCode processing error!"
 msgstr "OOPS! OpCode prozesu errorea!"
 
-#: src/ExternalConn.cpp:1502
+#: src/ExternalConn.cpp:1501
 msgid "Server not added"
 msgstr "Zerbitzaria ez da gehitu"
 
-#: src/ExternalConn.cpp:1521
+#: src/ExternalConn.cpp:1520
 #, c-format
 msgid "server not found: %s"
 msgstr "ez da zerbitzaria aurkitu: %s"
 
-#: src/ExternalConn.cpp:1538
+#: src/ExternalConn.cpp:1537
 msgid "need to define server to be removed"
 msgstr "ezabatzeko zerbitzaria ezarri behar da"
 
-#: src/ExternalConn.cpp:1553
+#: src/ExternalConn.cpp:1552
 msgid "eD2k is disabled in preferences."
 msgstr "eD2k ezgaiturik dago hobespenetan."
 
-#: src/ExternalConn.cpp:1658
+#: src/ExternalConn.cpp:1657
 #, fuzzy
 msgid "Friend not found."
 msgstr "Fitxategia ez da aurkitu."
 
-#: src/ExternalConn.cpp:1668
+#: src/ExternalConn.cpp:1667
 #, fuzzy
 msgid "Client not found."
 msgstr "Fitxategia ez da aurkitu."
 
-#: src/ExternalConn.cpp:1674
+#: src/ExternalConn.cpp:1673
 msgid "EC_TAG_FRIEND_SHARED requires EC_TAG_FRIEND or EC_TAG_CLIENT."
 msgstr ""
 
-#: src/ExternalConn.cpp:1992
+#: src/ExternalConn.cpp:1991
 msgid "WebSearch from remote interface makes no sense."
 msgstr "Urruneko interfazeko Web bilaketak ez du zentzurik."
 
-#: src/ExternalConn.cpp:2027
+#: src/ExternalConn.cpp:2026
 msgid "Search in progress. Refetch results in a moment!"
 msgstr "Bilaketa bidean. Emaitzak emango une batean!"
 
-#: src/ExternalConn.cpp:2266
+#: src/ExternalConn.cpp:2265
 msgid "No points for graph."
 msgstr "Ez dago punturik grafikoarentzat."
 
-#: src/ExternalConn.cpp:2276
+#: src/ExternalConn.cpp:2275
 msgid "Your client is not configured for this detail level."
 msgstr "Zure bezeroa ez dago xehetasun maila honetarako konfiguraturik."
 
-#: src/ExternalConn.cpp:2303
+#: src/ExternalConn.cpp:2302
 msgid "External Connection: shutdown requested"
 msgstr "Kanpo konexioa: itzaltzea eskatuta"
 
-#: src/ExternalConn.cpp:2315
+#: src/ExternalConn.cpp:2314
 msgid "Already shutting down."
 msgstr "Dagoeneko irteten."
 
-#: src/ExternalConn.cpp:2333
+#: src/ExternalConn.cpp:2332
 #, c-format
 msgid "ExternalConn: adding link '%s'."
 msgstr "KanpoKonexioa: '%s' lotura gehitzen."
 
-#: src/ExternalConn.cpp:2351
+#: src/ExternalConn.cpp:2350
 #, fuzzy, c-format
 msgid "%d of %d links failed (invalid or already on list)."
 msgstr "Lotura baliogabea edo zerrendan dagoeneko."
 
-#: src/ExternalConn.cpp:2374
+#: src/ExternalConn.cpp:2373
 msgid "Version check throttled; try again shortly."
 msgstr ""
 
-#: src/ExternalConn.cpp:2379
+#: src/ExternalConn.cpp:2378
 msgid "Version check is not available on this daemon."
 msgstr ""
 
-#: src/ExternalConn.cpp:2509
+#: src/ExternalConn.cpp:2508
 msgid "File not found."
 msgstr "Fitxategia ez da aurkitu."
 
-#: src/ExternalConn.cpp:2514
+#: src/ExternalConn.cpp:2513
 msgid "Invalid file name."
 msgstr "Fitxategi izen baliogabea."
 
-#: src/ExternalConn.cpp:2522
+#: src/ExternalConn.cpp:2521
 msgid "Unable to rename file."
 msgstr "Ezinda fitxategia berrizendatu."
 
-#: src/ExternalConn.cpp:2839
-#, c-format
-msgid "Could not save the amuleapi password: %s"
-msgstr ""
-
-#: src/ExternalConn.cpp:3004 src/ExternalConn.cpp:3032
+#: src/ExternalConn.cpp:2992 src/ExternalConn.cpp:3020
 msgid "Kad is disabled in preferences."
 msgstr "Kad ezgaiturik dago hobespenetan."
 
-#: src/ExternalConn.cpp:3045
+#: src/ExternalConn.cpp:3033
 msgid "Already connected to eD2k."
 msgstr "Dagoeneko eD2k-ra konektaturik."
 
-#: src/ExternalConn.cpp:3048
+#: src/ExternalConn.cpp:3036
 msgid "Connecting to eD2k..."
 msgstr "ed2k-era konektatzen..."
 
-#: src/ExternalConn.cpp:3057
+#: src/ExternalConn.cpp:3045
 msgid "Already connected to Kad."
 msgstr "Dagoeneko Kad-era konektaturik."
 
-#: src/ExternalConn.cpp:3060
+#: src/ExternalConn.cpp:3048
 msgid "Connecting to Kad..."
 msgstr "Kad-era konektatzen..."
 
-#: src/ExternalConn.cpp:3067
+#: src/ExternalConn.cpp:3055
 msgid "All networks are disabled."
 msgstr "Sare guztiak ezgaiturik daude."
 
-#: src/ExternalConn.cpp:3076
+#: src/ExternalConn.cpp:3064
 msgid "Disconnected from eD2k."
 msgstr "eD2k-tik deskonektatua."
 
-#: src/ExternalConn.cpp:3081
+#: src/ExternalConn.cpp:3069
 msgid "Disconnected from Kad."
 msgstr "Kad-etik deskonektaturik."
 
-#: src/ExternalConn.cpp:3090
+#: src/ExternalConn.cpp:3078
 #, c-format
 msgid "External Connection: invalid opcode received: %#x"
 msgstr "Kanpo Konexioa: okerreko opcode-a jasoa: %#x"
 
-#: src/ExternalConn.cpp:3095
+#: src/ExternalConn.cpp:3083
 msgid "Invalid opcode (wrong protocol version?)"
 msgstr "Opcode baliogabea (okerreko protokolo bertsioa?)"
 
@@ -2345,19 +2335,19 @@ msgstr ""
 msgid "eD2k"
 msgstr "eD2k"
 
-#: src/FirstRunWizard.cpp:349 src/muuli_wdr.cpp:1495
+#: src/FirstRunWizard.cpp:349 src/muuli_wdr.cpp:1488
 msgid "Kademlia"
 msgstr "Kademlia"
 
-#: src/FirstRunWizard.cpp:359 src/muuli_wdr.cpp:1423
+#: src/FirstRunWizard.cpp:359 src/muuli_wdr.cpp:1416
 msgid "Standard TCP Port "
 msgstr "TCP ataka estandarra "
 
-#: src/FirstRunWizard.cpp:365 src/muuli_wdr.cpp:1435
+#: src/FirstRunWizard.cpp:365 src/muuli_wdr.cpp:1428
 msgid "Extended UDP port (Kad / global search) "
 msgstr "Hedatutako UDP ataka (Kad / bilaketa orokorra) "
 
-#: src/FirstRunWizard.cpp:377 src/muuli_wdr.cpp:1442
+#: src/FirstRunWizard.cpp:377 src/muuli_wdr.cpp:1435
 msgid "Enable UPnP for router port forwarding"
 msgstr "Gaitu UPnP router ataka berbideraketarako"
 
@@ -2384,7 +2374,7 @@ msgstr ""
 msgid "Your peer lists are already in place - nothing to download."
 msgstr "Dagoeneko %s fitxategia deskargatzen ari zara"
 
-#: src/FirstRunWizard.cpp:434 src/muuli_wdr.cpp:1540
+#: src/FirstRunWizard.cpp:434 src/muuli_wdr.cpp:1533
 msgid "Auto-update server list at startup"
 msgstr "Auto-eguneratu zerbitzari zerrenda abioan"
 
@@ -2430,23 +2420,23 @@ msgid ""
 "want downloads on a different (e.g. larger) disk."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:549 src/FirstRunWizard.cpp:611 src/muuli_wdr.cpp:1702
+#: src/FirstRunWizard.cpp:549 src/FirstRunWizard.cpp:611 src/muuli_wdr.cpp:1701
 msgid "Destination folder for downloads"
 msgstr "Deskargentzat helburu karpeta"
 
-#: src/FirstRunWizard.cpp:553 src/FirstRunWizard.cpp:569 src/muuli_wdr.cpp:1349
-#: src/muuli_wdr.cpp:1366 src/muuli_wdr.cpp:1677 src/muuli_wdr.cpp:1708
-#: src/muuli_wdr.cpp:1720 src/muuli_wdr.cpp:2790
+#: src/FirstRunWizard.cpp:553 src/FirstRunWizard.cpp:569 src/muuli_wdr.cpp:1342
+#: src/muuli_wdr.cpp:1359 src/muuli_wdr.cpp:1676 src/muuli_wdr.cpp:1707
+#: src/muuli_wdr.cpp:1719 src/muuli_wdr.cpp:2762
 #: src/utils/aLinkCreator/src/alcframe.cpp:135
 #: src/utils/wxCas/src/wxcasprefs.cpp:52 src/utils/wxCas/src/wxcasprefs.cpp:118
 msgid "Browse"
 msgstr "Arakatu"
 
-#: src/FirstRunWizard.cpp:559 src/muuli_wdr.cpp:1713
+#: src/FirstRunWizard.cpp:559 src/muuli_wdr.cpp:1712
 msgid "(All files in this folder are shared with other peers)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:565 src/FirstRunWizard.cpp:624 src/muuli_wdr.cpp:1715
+#: src/FirstRunWizard.cpp:565 src/FirstRunWizard.cpp:624 src/muuli_wdr.cpp:1714
 msgid "Folder for temporary download files"
 msgstr "Aldiroko deskarga fitxategientzat karpeta"
 
@@ -2477,7 +2467,7 @@ msgstr "Huts 'emfriends.met' lagun zerrenda fitxategia idazteko irekitzean!"
 msgid "CRITICAL - no client on StartChatSession"
 msgstr "KRITIKOA - ez dago bezerorik StartChatSession-en"
 
-#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2696 src/muuli_wdr.cpp:3373
+#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2668 src/muuli_wdr.cpp:3345
 msgid "Friends"
 msgstr "Lagunak"
 
@@ -2588,8 +2578,8 @@ msgstr "Batez"
 msgid "No"
 msgstr "Ez"
 
-#: src/GenericClientListCtrl.cpp:1216 src/PrefsUnifiedDlg.cpp:2898
-#: src/PrefsUnifiedDlg.cpp:2948 src/ServerListCtrl.cpp:276
+#: src/GenericClientListCtrl.cpp:1216 src/PrefsUnifiedDlg.cpp:2818
+#: src/PrefsUnifiedDlg.cpp:2868 src/ServerListCtrl.cpp:276
 msgid "Yes"
 msgstr "Bai"
 
@@ -2758,10 +2748,10 @@ msgstr "Abiarazteko ataka baliogabea"
 msgid "Please fill all fields required"
 msgstr "Beharrezko eremu guztiak bete"
 
-#: src/KadDlg.cpp:192 src/PartFile.cpp:1031 src/PrefsUnifiedDlg.cpp:1134
-#: src/PrefsUnifiedDlg.cpp:1204 src/PrefsUnifiedDlg.cpp:1405
-#: src/PrefsUnifiedDlg.cpp:1663 src/PrefsUnifiedDlg.cpp:1673
-#: src/PrefsUnifiedDlg.cpp:1690 src/PrefsUnifiedDlg.cpp:1738
+#: src/KadDlg.cpp:192 src/PartFile.cpp:1031 src/PrefsUnifiedDlg.cpp:1162
+#: src/PrefsUnifiedDlg.cpp:1331 src/PrefsUnifiedDlg.cpp:1589
+#: src/PrefsUnifiedDlg.cpp:1599 src/PrefsUnifiedDlg.cpp:1616
+#: src/PrefsUnifiedDlg.cpp:1658
 msgid "Message"
 msgstr "Mezua"
 
@@ -2863,7 +2853,7 @@ msgstr "Partekatze erlazioa"
 msgid "Uploaded"
 msgstr "Igoa"
 
-#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3253
+#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3225
 msgid "Requested"
 msgstr "Eskatutakoa"
 
@@ -2987,7 +2977,7 @@ msgid "WARNING: "
 msgstr "OHARRA: "
 
 #: src/MuleNotebook.cpp:179 src/muuli_wdr.cpp:817 src/muuli_wdr.cpp:1229
-#: src/muuli_wdr.cpp:3157 src/muuli_wdr.cpp:3413
+#: src/muuli_wdr.cpp:3129 src/muuli_wdr.cpp:3385
 msgid "Close"
 msgstr "Itxi"
 
@@ -3000,12 +2990,12 @@ msgstr "Ebaki"
 msgid "Copy"
 msgstr "Kopiatu"
 
-#: src/MuleTextCtrl.cpp:88 src/SearchDlg.cpp:261
+#: src/MuleTextCtrl.cpp:88
 msgid "Paste"
 msgstr "Itsatsi"
 
 #: src/MuleTextCtrl.cpp:89 src/muuli_wdr.cpp:358 src/muuli_wdr.cpp:757
-#: src/muuli_wdr.cpp:2380 src/muuli_wdr.cpp:2399 src/muuli_wdr.cpp:2421
+#: src/muuli_wdr.cpp:2352 src/muuli_wdr.cpp:2371 src/muuli_wdr.cpp:2393
 #: src/utils/aLinkCreator/src/alcframe.cpp:142
 msgid "Clear"
 msgstr "Garbitu"
@@ -3103,8 +3093,8 @@ msgid "Exit"
 msgstr "Irten"
 
 #: src/MuleTrayIcon.cpp:579 src/MuleTrayIcon.cpp:945 src/MuleTrayIcon.cpp:965
-#: src/muuli_wdr.cpp:1398 src/muuli_wdr.cpp:1406 src/muuli_wdr.cpp:1413
-#: src/muuli_wdr.cpp:1836 src/muuli_wdr.cpp:1842 src/OtherFunctions.cpp:91
+#: src/muuli_wdr.cpp:1391 src/muuli_wdr.cpp:1399 src/muuli_wdr.cpp:1406
+#: src/muuli_wdr.cpp:1835 src/muuli_wdr.cpp:1841 src/OtherFunctions.cpp:91
 #: src/StatisticsDlg.cpp:93 src/StatisticsDlg.cpp:95
 msgid "kB/s"
 msgstr "kB/s"
@@ -3275,7 +3265,7 @@ msgstr "Izena:"
 msgid "Type"
 msgstr "Mota"
 
-#: src/muuli_wdr.cpp:215 src/SearchDlg.cpp:118 src/SearchListCtrl.cpp:853
+#: src/muuli_wdr.cpp:215 src/SearchDlg.cpp:110 src/SearchListCtrl.cpp:853
 msgid "Local"
 msgstr "Lokala"
 
@@ -3346,7 +3336,7 @@ msgstr "Byte"
 msgid "KB"
 msgstr "KB"
 
-#: src/muuli_wdr.cpp:274 src/muuli_wdr.cpp:293 src/muuli_wdr.cpp:1621
+#: src/muuli_wdr.cpp:274 src/muuli_wdr.cpp:293 src/muuli_wdr.cpp:1620
 #: src/OtherFunctions.cpp:64
 msgid "MB"
 msgstr "MB"
@@ -3363,7 +3353,7 @@ msgstr "Gehi. tamaina"
 msgid "Availability"
 msgstr "Eskuragarritasuna"
 
-#: src/muuli_wdr.cpp:312 src/muuli_wdr.cpp:398 src/muuli_wdr.cpp:3318
+#: src/muuli_wdr.cpp:312 src/muuli_wdr.cpp:398 src/muuli_wdr.cpp:3290
 msgid "Filter:"
 msgstr "Iragazkia:"
 
@@ -3395,7 +3385,7 @@ msgstr ""
 msgid "Stop"
 msgstr "Gelditu"
 
-#: src/muuli_wdr.cpp:348 src/muuli_wdr.cpp:1392 src/SearchListCtrl.cpp:732
+#: src/muuli_wdr.cpp:348 src/muuli_wdr.cpp:1385 src/SearchListCtrl.cpp:732
 msgid "Download"
 msgstr "Deskargatu"
 
@@ -3426,12 +3416,12 @@ msgstr "Fitxategiaren iturburua:"
 #: src/muuli_wdr.cpp:1160 src/muuli_wdr.cpp:1167 src/muuli_wdr.cpp:1172
 #: src/muuli_wdr.cpp:1179 src/muuli_wdr.cpp:1184 src/muuli_wdr.cpp:1191
 #: src/muuli_wdr.cpp:1205 src/muuli_wdr.cpp:1212 src/muuli_wdr.cpp:1217
-#: src/muuli_wdr.cpp:1224 src/muuli_wdr.cpp:3255 src/muuli_wdr.cpp:3263
-#: src/muuli_wdr.cpp:3271
+#: src/muuli_wdr.cpp:1224 src/muuli_wdr.cpp:3227 src/muuli_wdr.cpp:3235
+#: src/muuli_wdr.cpp:3243
 msgid "N/A"
 msgstr "E/G"
 
-#: src/muuli_wdr.cpp:508 src/muuli_wdr.cpp:1065 src/PrefsUnifiedDlg.cpp:299
+#: src/muuli_wdr.cpp:508 src/muuli_wdr.cpp:1065 src/PrefsUnifiedDlg.cpp:297
 msgid "General"
 msgstr "Orokorra"
 
@@ -3572,7 +3562,7 @@ msgstr ""
 msgid "Album :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:685 src/muuli_wdr.cpp:2275
+#: src/muuli_wdr.cpp:685 src/muuli_wdr.cpp:2247
 msgid "Title :"
 msgstr "Titulua :"
 
@@ -3681,7 +3671,7 @@ msgstr "Erabiltzaile-izena :"
 msgid "Userhash :"
 msgstr "Erabiltzaile aztertze zenbakia :"
 
-#: src/muuli_wdr.cpp:895 src/muuli_wdr.cpp:1742 src/muuli_wdr.cpp:2470
+#: src/muuli_wdr.cpp:895 src/muuli_wdr.cpp:1741 src/muuli_wdr.cpp:2442
 #: src/utils/aLinkCreator/src/alcframe.cpp:137
 msgid "Add"
 msgstr "Gehitu"
@@ -3690,15 +3680,15 @@ msgstr "Gehitu"
 msgid "Download-Speed"
 msgstr "Deskarga abiadura"
 
-#: src/muuli_wdr.cpp:954 src/muuli_wdr.cpp:989 src/muuli_wdr.cpp:2574
+#: src/muuli_wdr.cpp:954 src/muuli_wdr.cpp:989 src/muuli_wdr.cpp:2546
 msgid "Current"
 msgstr "Unekoa"
 
-#: src/muuli_wdr.cpp:962 src/muuli_wdr.cpp:997 src/muuli_wdr.cpp:2582
+#: src/muuli_wdr.cpp:962 src/muuli_wdr.cpp:997 src/muuli_wdr.cpp:2554
 msgid "Running average"
 msgstr "Funtzionamendu bataz bestekoa"
 
-#: src/muuli_wdr.cpp:970 src/muuli_wdr.cpp:1005 src/muuli_wdr.cpp:2590
+#: src/muuli_wdr.cpp:970 src/muuli_wdr.cpp:1005 src/muuli_wdr.cpp:2562
 msgid "Session average"
 msgstr "saio batez bestekoa"
 
@@ -3710,7 +3700,7 @@ msgstr "Igoera abiadura"
 msgid "Connections"
 msgstr "Konexioak"
 
-#: src/muuli_wdr.cpp:1024 src/muuli_wdr.cpp:1861
+#: src/muuli_wdr.cpp:1024 src/muuli_wdr.cpp:1860
 msgid "Active downloads"
 msgstr "Deskarga aktiboak"
 
@@ -3718,7 +3708,7 @@ msgstr "Deskarga aktiboak"
 msgid "Active connections (1:1)"
 msgstr "konexio aktiboak (1:1)"
 
-#: src/muuli_wdr.cpp:1040 src/muuli_wdr.cpp:1862
+#: src/muuli_wdr.cpp:1040 src/muuli_wdr.cpp:1861
 msgid "Active uploads"
 msgstr "Igoera aktiboak"
 
@@ -3834,8 +3824,8 @@ msgstr "Hau beste erabiltzaileek zuri konektatzerakoan ikusiko duten izena da."
 msgid "Language: "
 msgstr "Hizkuntza: "
 
-#: src/muuli_wdr.cpp:1257 src/muuli_wdr.cpp:1330 src/muuli_wdr.cpp:1334
-#: src/muuli_wdr.cpp:1337
+#: src/muuli_wdr.cpp:1257 src/muuli_wdr.cpp:1323 src/muuli_wdr.cpp:1327
+#: src/muuli_wdr.cpp:1330
 msgid "The delay before showing tool-tips."
 msgstr "Argibideak bistarazi aurreko denbora."
 
@@ -3913,960 +3903,936 @@ msgstr ""
 msgid "Enabling this will make aMule to show notifications when finished downloading."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1323
-#, fuzzy
-msgid "Remember search history"
-msgstr "Ezarpen hauek gogoratu"
-
-#: src/muuli_wdr.cpp:1324
-msgid "Keeps a dropdown list of your past search terms in the Search tab's Name field. This remembers the queries you typed, not the results they returned."
-msgstr ""
-
-#: src/muuli_wdr.cpp:1329
+#: src/muuli_wdr.cpp:1322
 msgid "Tooltip delay time: "
 msgstr "Gomendio atzerapena: "
 
-#: src/muuli_wdr.cpp:1336
+#: src/muuli_wdr.cpp:1329
 msgid "seconds"
 msgstr "segundo"
 
-#: src/muuli_wdr.cpp:1340
+#: src/muuli_wdr.cpp:1333
 msgid "Browser Selection"
 msgstr "Nabigatzaile hautaketa"
 
-#: src/muuli_wdr.cpp:1346
+#: src/muuli_wdr.cpp:1339
 msgid "Enter your browser name here. Leave this field empty to use the system default browser."
 msgstr "Idatzi zure nabigatzaile izena hemen. Zurian utzi sisteman lehenetsitako nabigatzailea erabiltzeko."
 
-#: src/muuli_wdr.cpp:1353
+#: src/muuli_wdr.cpp:1346
 msgid "Open in new tab if possible"
 msgstr "Ireki fitxa berrian aukera dagoenenean"
 
-#: src/muuli_wdr.cpp:1355
+#: src/muuli_wdr.cpp:1348
 msgid "Open the web page in a new tab instead of in a new window when possible"
 msgstr "Ireki web orria fitxa berrian leiho berrian ordez aukera dagoenenean"
 
-#: src/muuli_wdr.cpp:1359
+#: src/muuli_wdr.cpp:1352
 msgid "Video Player"
 msgstr "Bideo-erreproduzigailua"
 
-#: src/muuli_wdr.cpp:1386
+#: src/muuli_wdr.cpp:1379
 msgid "Bandwidth limits"
 msgstr "Konexio mugak"
 
-#: src/muuli_wdr.cpp:1400
+#: src/muuli_wdr.cpp:1393
 msgid "Upload"
 msgstr "Igo"
 
-#: src/muuli_wdr.cpp:1408
+#: src/muuli_wdr.cpp:1401
 msgid "Slot Allocation"
 msgstr "Ataka ezarpena"
 
-#: src/muuli_wdr.cpp:1417
+#: src/muuli_wdr.cpp:1410
 msgid "Ports"
 msgstr "Atakak"
 
-#: src/muuli_wdr.cpp:1427
+#: src/muuli_wdr.cpp:1420
 msgid "This is the standard eD2k port and cannot be disabled."
 msgstr "Hau eD2k ataka estandarra da eta ezin da ezgaitu."
 
-#: src/muuli_wdr.cpp:1430
+#: src/muuli_wdr.cpp:1423
 msgid "UDP port for server requests (TCP+3):"
 msgstr "UDP ataka zerbitzari eskakizunetarako (TCP+3):"
 
-#: src/muuli_wdr.cpp:1432
+#: src/muuli_wdr.cpp:1425
 msgid "4665"
 msgstr "4665"
 
-#: src/muuli_wdr.cpp:1439
+#: src/muuli_wdr.cpp:1432
 msgid "This UDP port is used for extended eD2k requests and Kad network"
 msgstr "UDP ataka hau hedaturiko eD2k eskakizun eta Kad sarerako erabiltzen da"
 
-#: src/muuli_wdr.cpp:1446
+#: src/muuli_wdr.cpp:1439
 msgid "UPnP TCP Port (Optional):"
 msgstr "UPnP TCP ataka (aukerakoa):"
 
-#: src/muuli_wdr.cpp:1456
+#: src/muuli_wdr.cpp:1449
 msgid "Bind local address to IP (empty for any):"
 msgstr "Lotu helbide lokala IP batetara (zurian edozeinentzat):"
 
-#: src/muuli_wdr.cpp:1459
+#: src/muuli_wdr.cpp:1452
 msgid "Advanced users only: If you have multiple network interfaces, enter the address of the interface to which aMule should be bound."
 msgstr "Erabiltzaile aurreratuak bakarrik: Sare interfaze anitz badituzu idatzi amulek erabili behar duen sare interfazearen helbidea."
 
-#: src/muuli_wdr.cpp:1462 src/muuli_wdr.cpp:2055
+#: src/muuli_wdr.cpp:1455 src/muuli_wdr.cpp:2054
 #, fuzzy
 msgid "Bind to network interface (empty for any):"
 msgstr "Lotu helbide lokala IP batetara (zurian edozeinentzat):"
 
-#: src/muuli_wdr.cpp:1475
+#: src/muuli_wdr.cpp:1468
 msgid "Advanced users only: pin all of aMule's traffic to one network interface, chosen from the list or typed in by name (e.g. tun0, eth0, en0) or index. Unlike binding to an IP, this stops traffic leaking out via the default route - useful with a VPN. Requires no elevated privileges."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1481
+#: src/muuli_wdr.cpp:1474
 msgid "Max sources per downloading file:"
 msgstr "Jatorri muga deskarga bakoitzerako:"
 
-#: src/muuli_wdr.cpp:1485
+#: src/muuli_wdr.cpp:1478
 msgid "Max simultaneous connections:"
 msgstr "Aldibereko konexioa muga:"
 
-#: src/muuli_wdr.cpp:1498 src/muuli_wdr.cpp:3197
+#: src/muuli_wdr.cpp:1491 src/muuli_wdr.cpp:3169
 msgid "ED2K"
 msgstr "ED2K"
 
-#: src/muuli_wdr.cpp:1505
+#: src/muuli_wdr.cpp:1498
 msgid "Autoconnect on startup"
 msgstr "Konektatu abiaraztekoan"
 
-#: src/muuli_wdr.cpp:1508
+#: src/muuli_wdr.cpp:1501
 msgid "Reconnect on loss"
 msgstr "birkonektatu konexioa galtzean"
 
-#: src/muuli_wdr.cpp:1530
+#: src/muuli_wdr.cpp:1523
 msgid "Remove dead server after"
 msgstr "Ezabatu hildako zerbitzaria geroago"
 
-#: src/muuli_wdr.cpp:1531
+#: src/muuli_wdr.cpp:1524
 msgid "Static servers are never removed, even when unreachable."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1535
+#: src/muuli_wdr.cpp:1528
 msgid "retries"
 msgstr "saiakerak"
 
-#: src/muuli_wdr.cpp:1543
+#: src/muuli_wdr.cpp:1536
 msgid "List"
 msgstr "Zerrenda"
 
-#: src/muuli_wdr.cpp:1546
+#: src/muuli_wdr.cpp:1539
 msgid "Update server list when connecting to a server"
 msgstr "Eguneratu zerbitzari zerrenda zerbitzari batetara konektatzean"
 
-#: src/muuli_wdr.cpp:1549
+#: src/muuli_wdr.cpp:1542
 msgid "Update server list when a client connects"
 msgstr "Eguneratu zerbitzari zerrenda bezero bat konektatzean"
 
-#: src/muuli_wdr.cpp:1552
+#: src/muuli_wdr.cpp:1545
 msgid "Use priority system"
 msgstr "Erabili lehentasun sistema"
 
-#: src/muuli_wdr.cpp:1556
+#: src/muuli_wdr.cpp:1549
 msgid "Use smart LowID check on connect"
 msgstr "Erabili IDbaxu egiaztapena konektatzerakoan"
 
-#: src/muuli_wdr.cpp:1560
+#: src/muuli_wdr.cpp:1553
 msgid "Safe connect"
 msgstr "Konexio ziurra"
 
-#: src/muuli_wdr.cpp:1564
+#: src/muuli_wdr.cpp:1557
 msgid "Autoconnect to servers in static list only"
 msgstr "Estatiko zerbitzarietara bakarrik auto-konektatu"
 
-#: src/muuli_wdr.cpp:1567
+#: src/muuli_wdr.cpp:1560
 msgid "Set manually added servers to High Priority"
 msgstr "Ezarri eskuz gehitutako zerbitzariak lehentasun altuan"
 
-#: src/muuli_wdr.cpp:1588
+#: src/muuli_wdr.cpp:1581
 msgid "Add files to download in pause mode"
 msgstr "Gehitu fitxategiak deskargetara geldirik"
 
-#: src/muuli_wdr.cpp:1590
+#: src/muuli_wdr.cpp:1583
 msgid "Add files to download with auto priority"
 msgstr "Gehitu fitxategiak deskarga zerrendara auto-lehentasunarekin"
 
-#: src/muuli_wdr.cpp:1593
+#: src/muuli_wdr.cpp:1586
 msgid "Try to download first and last chunks first"
 msgstr "Saiatu lehen eta azken zatiak hasieran deskargatzen"
 
-#: src/muuli_wdr.cpp:1597
+#: src/muuli_wdr.cpp:1590
 msgid "Endgame mode: rotate to faster sources for the final blocks"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1600
+#: src/muuli_wdr.cpp:1593
 msgid "Start next paused file when a file completes"
 msgstr "Abiarazi lehen pausaturiko fitxategia fitxategi bat osatzean"
 
-#: src/muuli_wdr.cpp:1603
+#: src/muuli_wdr.cpp:1596
 msgid "From the same category"
 msgstr "Kategoria berdinekoa"
 
-#: src/muuli_wdr.cpp:1605
+#: src/muuli_wdr.cpp:1598
 msgid "In alphabetic order"
 msgstr "Orden alfabetikoan"
 
-#: src/muuli_wdr.cpp:1607
+#: src/muuli_wdr.cpp:1600
 msgid "Preallocate disk space for new files"
 msgstr "Aurresleitu disko lekua fitxategi berrientzat"
 
-#: src/muuli_wdr.cpp:1608
+#: src/muuli_wdr.cpp:1601
 msgid "For new files preallocates disk space for the whole file, thus reduces fragmentation"
 msgstr "Fitxategi berrientzat fitxategi bakoitzarentzat disko leku osoa aurresleitzen du, honek fragmentazioa murrizten du"
 
-#: src/muuli_wdr.cpp:1613
+#: src/muuli_wdr.cpp:1606
+msgid "Create new files as sparse files"
+msgstr ""
+
+#: src/muuli_wdr.cpp:1607
+msgid "A sparse file reserves its full size on disk immediately without writing real data to it -- fast, but unsupported or slow on some filesystems, and free-space accounting stays optimistic while the download is in progress. Turn this off to grow the file only as data arrives."
+msgstr ""
+
+#: src/muuli_wdr.cpp:1612
 msgid "Stop downloads when free disk space reaches "
 msgstr "Gelditu deskargak disko-leku librea hona iristean "
 
-#: src/muuli_wdr.cpp:1614
+#: src/muuli_wdr.cpp:1613
 msgid "Select this if you want aMule to check your disk space"
 msgstr "Aukera hau hautatu aMulek zure disko-lekua egiaztatzea nahi baduzu"
 
-#: src/muuli_wdr.cpp:1618
+#: src/muuli_wdr.cpp:1617
 msgid "Enter here the min disk space desired."
 msgstr "Ezarri hemen nahi duzu disko toki txikiena."
 
-#: src/muuli_wdr.cpp:1624
+#: src/muuli_wdr.cpp:1623
 msgid "Save 10 sources on rare files (< 20 sources)"
 msgstr "10 jatorri gorde fitxategi arraroentzat (< 20 jatorri)"
 
-#: src/muuli_wdr.cpp:1628 src/Statistics.cpp:790
+#: src/muuli_wdr.cpp:1627 src/Statistics.cpp:790
 msgid "Uploads"
 msgstr "Igoerak"
 
-#: src/muuli_wdr.cpp:1631
+#: src/muuli_wdr.cpp:1630
 msgid "Add new shared files with auto priority"
 msgstr "Gehitu partekatutako fitxategi berriak auto-lehentasunarekin"
 
-#: src/muuli_wdr.cpp:1637
+#: src/muuli_wdr.cpp:1636
 msgid "Intelligent Corruption Handling (I.C.H.)"
 msgstr "Hondatze kudeaketa adimentsua (I.C.H)"
 
-#: src/muuli_wdr.cpp:1640
+#: src/muuli_wdr.cpp:1639
 msgid "Enable"
 msgstr "Gaitu"
 
-#: src/muuli_wdr.cpp:1643
+#: src/muuli_wdr.cpp:1642
 msgid "Advanced I.C.H. trusts every hash (not recommended)"
 msgstr "I.C.H aurreratuak, egiaztapen bakoitza egiaztatzen du (ez da gomendatzen)"
 
-#: src/muuli_wdr.cpp:1655 src/PrefsUnifiedDlg.cpp:1990
+#: src/muuli_wdr.cpp:1654 src/PrefsUnifiedDlg.cpp:1910
 msgid "Media metadata extraction"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1659
+#: src/muuli_wdr.cpp:1658
 msgid "Extract length / bitrate / codec from shared audio and video files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1661
+#: src/muuli_wdr.cpp:1660
 msgid "When enabled, aMule runs ffprobe on each shared media file to fill in the Length / Bitrate / Codec columns other clients see when they find the file in a search. Requires ffmpeg (the ffprobe binary) to be installed."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1668
+#: src/muuli_wdr.cpp:1667
 msgid "Path to ffprobe:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1673
+#: src/muuli_wdr.cpp:1672
 msgid "Full path to the ffprobe binary. Leave empty to have aMule auto-detect it on startup."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1681
+#: src/muuli_wdr.cpp:1680
 msgid "Detect"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1682
+#: src/muuli_wdr.cpp:1681
 msgid "Search the standard install locations for an ffprobe binary and fill the path field."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1706
+#: src/muuli_wdr.cpp:1705
 msgid ""
 "Completed downloads are stored here. All files in this folder are automatically shared with other peers.\n"
 "If this folder also holds files you don't want to share, point it at an aMule-only sub-folder."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1709
+#: src/muuli_wdr.cpp:1708
 msgid "Pick the folder where completed downloads will be stored. All files in that folder will be shared with other peers."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1723
+#: src/muuli_wdr.cpp:1722
 msgid "Shared folders"
 msgstr "Partekatutako karpetak"
 
-#: src/muuli_wdr.cpp:1729
+#: src/muuli_wdr.cpp:1728
 msgid "(Folders shared by the core. Enter a path to add one.)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1737
+#: src/muuli_wdr.cpp:1736
 msgid "Absolute path of a folder on the core's machine, e.g. /home/user/shared"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1739 src/PrefsUnifiedDlg.cpp:2874
+#: src/muuli_wdr.cpp:1738 src/PrefsUnifiedDlg.cpp:2794
 msgid "Recursive"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1740
+#: src/muuli_wdr.cpp:1739
 msgid "Share every sub-folder underneath this one, including ones created later."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1744 src/utils/aLinkCreator/src/alcframe.cpp:141
+#: src/muuli_wdr.cpp:1743 src/utils/aLinkCreator/src/alcframe.cpp:141
 msgid "Remove"
 msgstr "Ezabatu"
 
-#: src/muuli_wdr.cpp:1748
+#: src/muuli_wdr.cpp:1747
 msgid "(Right click on folder icon for recursive share)"
 msgstr "(Egin klik eskuineko botoiaz karpeta ikono batean barnekoak ere partekatzeko)"
 
-#: src/muuli_wdr.cpp:1755
+#: src/muuli_wdr.cpp:1754
 msgid "Share hidden files"
 msgstr "Partekatu ezkutatutako fitxategiak"
 
-#: src/muuli_wdr.cpp:1761
+#: src/muuli_wdr.cpp:1760
 msgid "Automatically rescan shared folders for changes"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1767
+#: src/muuli_wdr.cpp:1766
 msgid "Follow symbolic links in shared folders"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1773
+#: src/muuli_wdr.cpp:1772
 msgid "Exclude files matching:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1776
+#: src/muuli_wdr.cpp:1775
 msgid "Wildcard patterns separated by '|', e.g. .DS_Store|Thumbs.db|*.tmp. Files whose name matches are not shared. Matching is case-insensitive."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1780
+#: src/muuli_wdr.cpp:1779
 msgid "Patterns are regular expressions"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1781
+#: src/muuli_wdr.cpp:1780
 msgid "When set, the whole field is one regular expression ('|' is alternation). When unset, it is a list of '|'-separated wildcards."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1791
+#: src/muuli_wdr.cpp:1790
 msgid "Show how many shared files the current pattern would exclude."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1812
+#: src/muuli_wdr.cpp:1811
 msgid "Graphs"
 msgstr "Grafikak"
 
-#: src/muuli_wdr.cpp:1815 src/muuli_wdr.cpp:1877
+#: src/muuli_wdr.cpp:1814 src/muuli_wdr.cpp:1876
 msgid "Update delay : 5 secs"
 msgstr "Eguneratze atzerapena : 5 seg"
 
-#: src/muuli_wdr.cpp:1819
+#: src/muuli_wdr.cpp:1818
 msgid "Time for average graph: 100 mins"
 msgstr "Bataz besteko grafiko denbora : 100 min"
 
-#: src/muuli_wdr.cpp:1823
+#: src/muuli_wdr.cpp:1822
 msgid "Connections Graph Scale: 100 "
 msgstr "Konexio graf eskala: 100 "
 
-#: src/muuli_wdr.cpp:1830
+#: src/muuli_wdr.cpp:1829
 msgid "Download graph scale:"
 msgstr "Deskarga grafiko eskala:"
 
-#: src/muuli_wdr.cpp:1838
+#: src/muuli_wdr.cpp:1837
 msgid "Upload graph scale:"
 msgstr "Igoera grafiko eskala:"
 
-#: src/muuli_wdr.cpp:1848
+#: src/muuli_wdr.cpp:1847
 #, fuzzy
 msgid "Colors: "
 msgstr "Koloreak: "
 
-#: src/muuli_wdr.cpp:1852
+#: src/muuli_wdr.cpp:1851
 msgid "Background"
 msgstr "Atzeko planoa"
 
-#: src/muuli_wdr.cpp:1853
+#: src/muuli_wdr.cpp:1852
 msgid "Grid"
 msgstr "Sareta"
 
-#: src/muuli_wdr.cpp:1854
+#: src/muuli_wdr.cpp:1853
 msgid "Download current"
 msgstr "Uneko deskargak"
 
-#: src/muuli_wdr.cpp:1855
+#: src/muuli_wdr.cpp:1854
 msgid "Download running average"
 msgstr "Martxan deskargak bataz bestean"
 
-#: src/muuli_wdr.cpp:1856
+#: src/muuli_wdr.cpp:1855
 msgid "Download session average"
 msgstr "Saioaren bataz besteko deskargak"
 
-#: src/muuli_wdr.cpp:1857
+#: src/muuli_wdr.cpp:1856
 msgid "Upload current"
 msgstr "Uneko igoerak"
 
-#: src/muuli_wdr.cpp:1858
+#: src/muuli_wdr.cpp:1857
 msgid "Upload running average"
 msgstr "Martxan igoerak bataz bestean"
 
-#: src/muuli_wdr.cpp:1859
+#: src/muuli_wdr.cpp:1858
 msgid "Upload session average"
 msgstr "Saioaren bataz besteko igoerak"
 
-#: src/muuli_wdr.cpp:1860
+#: src/muuli_wdr.cpp:1859
 msgid "Active connections"
 msgstr "Konexio aktiboak"
 
-#: src/muuli_wdr.cpp:1863
+#: src/muuli_wdr.cpp:1862
 #, fuzzy
 msgid "Systray Icon Speed Bar"
 msgstr "Sistema-barra abiadura-barra ikonoa"
 
-#: src/muuli_wdr.cpp:1864
+#: src/muuli_wdr.cpp:1863
 msgid "Kad-nodes current"
 msgstr "Uneko Kad-nodoak"
 
-#: src/muuli_wdr.cpp:1865
+#: src/muuli_wdr.cpp:1864
 msgid "Kad-nodes running"
 msgstr "Kad-nodoak martxan"
 
-#: src/muuli_wdr.cpp:1866
+#: src/muuli_wdr.cpp:1865
 msgid "Kad-nodes session"
 msgstr "Kad-nodo saioa"
 
-#: src/muuli_wdr.cpp:1870 src/muuli_wdr.cpp:2324
+#: src/muuli_wdr.cpp:1869 src/muuli_wdr.cpp:2296
 msgid "Select"
 msgstr "Hautatu"
 
-#: src/muuli_wdr.cpp:1874
+#: src/muuli_wdr.cpp:1873
 msgid "Tree"
 msgstr "Zuhaitza"
 
-#: src/muuli_wdr.cpp:1884
+#: src/muuli_wdr.cpp:1883
 msgid "Number of Client Versions shown (0=unlimited)"
 msgstr "Erakutsiko diren bezero kopurua (0=mugagabea)"
 
-#: src/muuli_wdr.cpp:1909
+#: src/muuli_wdr.cpp:1908
 msgid "!!! WARNING !!!"
 msgstr "!!! KONTUZ !!!"
 
-#: src/muuli_wdr.cpp:1924
+#: src/muuli_wdr.cpp:1923
 msgid "Max new connections / 5 secs"
 msgstr "Gehienezko konexio berri / 5 seg"
 
-#: src/muuli_wdr.cpp:1926
+#: src/muuli_wdr.cpp:1925
 msgid "Concurrent Kad source lookups"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1928
+#: src/muuli_wdr.cpp:1927
 #, fuzzy
 msgid "Kad source re-search interval (minutes)"
 msgstr "FTP igoera aldia minututan"
 
-#: src/muuli_wdr.cpp:1930
+#: src/muuli_wdr.cpp:1929
 #, fuzzy
 msgid "Source re-ask interval (minutes)"
 msgstr "FTP igoera aldia minututan"
 
-#: src/muuli_wdr.cpp:1934
+#: src/muuli_wdr.cpp:1933
 msgid "File Buffer Size: 240000 bytes"
 msgstr "Fitxategia buffer tamaina: 240000 byte"
 
-#: src/muuli_wdr.cpp:1938
+#: src/muuli_wdr.cpp:1937
 msgid "Use MMAP: memory-mapped file access (lower memory use)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1939
+#: src/muuli_wdr.cpp:1938
 msgid "Maps part files into memory instead of buffering them on the heap, lowering the process memory footprint. May reduce download speed on some disks; best for memory-constrained or upload-heavy hosts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1941
+#: src/muuli_wdr.cpp:1940
 msgid "Upload Queue Size: 5000 clients"
 msgstr "Igoera ilara tamaina: 5000 bezero"
 
-#: src/muuli_wdr.cpp:1945
+#: src/muuli_wdr.cpp:1944
 msgid "Server connection refresh interval: Disable"
 msgstr "Zerbitzari konexio berritze aldia: Ezgaiturik"
 
-#: src/muuli_wdr.cpp:1949
+#: src/muuli_wdr.cpp:1948
 msgid "Disable computer's timed standby mode"
 msgstr "Ezgaitu ordenagailu ordulariaren bigarren planoko modua"
 
-#: src/muuli_wdr.cpp:1968
+#: src/muuli_wdr.cpp:1967
 msgid "Skin to use: "
 msgstr "Erabiltzeko azala: "
 
-#: src/muuli_wdr.cpp:1977
+#: src/muuli_wdr.cpp:1976
 msgid "Show \"Fast eD2k Links Handler\" in every window."
 msgstr "Erakutsi \"eD2k lotura kudeatzaile azkarra\" leiho bakoitzean."
 
-#: src/muuli_wdr.cpp:1980
+#: src/muuli_wdr.cpp:1979
 msgid "Show extended info on categories tabs"
 msgstr "Erakutsi argibide hedatuak kategoria fitxetan"
 
-#: src/muuli_wdr.cpp:1983
+#: src/muuli_wdr.cpp:1982
 msgid "Show application version on title"
 msgstr "Erakutsi aplikazio bertsioa izenburuan"
 
-#: src/muuli_wdr.cpp:1985
+#: src/muuli_wdr.cpp:1984
 msgid "Show transfer rates on title"
 msgstr "Erakutsi transferentziak izenburuan"
 
-#: src/muuli_wdr.cpp:1987
+#: src/muuli_wdr.cpp:1986
 msgid "Before application name"
 msgstr "Aplikazio izenaren aurretik"
 
-#: src/muuli_wdr.cpp:1989
+#: src/muuli_wdr.cpp:1988
 msgid "After application name"
 msgstr "Aplikazio izenaren ondoren"
 
-#: src/muuli_wdr.cpp:1992
+#: src/muuli_wdr.cpp:1991
 msgid "Show overhead bandwidth"
 msgstr "Erakutsi goiburu erabilpena"
 
-#: src/muuli_wdr.cpp:1996
+#: src/muuli_wdr.cpp:1995
 msgid "Vertical toolbar orientation"
 msgstr "Tresna-barra bertikal orientazioa"
 
-#: src/muuli_wdr.cpp:1998
+#: src/muuli_wdr.cpp:1997
 msgid "Live column sorting (auto-reorder rows as their values change)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2005
+#: src/muuli_wdr.cpp:2004
 msgid "Download Queue Files"
 msgstr "Deskargatu ilara fitxategiak"
 
-#: src/muuli_wdr.cpp:2008
+#: src/muuli_wdr.cpp:2007
 msgid "Show progress percentage"
 msgstr "Erakutsi aurrerapen ehunekoa"
 
-#: src/muuli_wdr.cpp:2014
+#: src/muuli_wdr.cpp:2013
 msgid "Show progress bar"
 msgstr "Erakutsi aurrerapen barra"
 
-#: src/muuli_wdr.cpp:2017
+#: src/muuli_wdr.cpp:2016
 msgid "Flat"
 msgstr "Laua"
 
-#: src/muuli_wdr.cpp:2021
+#: src/muuli_wdr.cpp:2020
 msgid "Round"
 msgstr "Biribildu"
 
-#: src/muuli_wdr.cpp:2039
+#: src/muuli_wdr.cpp:2038
 msgid "External Connection Parameters"
 msgstr "Urruneko konexio ezarpenak"
 
-#: src/muuli_wdr.cpp:2042
+#: src/muuli_wdr.cpp:2041
 msgid "Accept external connections"
 msgstr "Onartu urruneko konexioak"
 
-#: src/muuli_wdr.cpp:2049 src/muuli_wdr.cpp:2108
+#: src/muuli_wdr.cpp:2048 src/muuli_wdr.cpp:2107
 msgid "IP of the listening interface:"
 msgstr "Entzunean dagoen interfazearen IPa:"
 
-#: src/muuli_wdr.cpp:2052
+#: src/muuli_wdr.cpp:2051
 msgid "Enter here a valid ip in the a.b.c.d format for the listening EC interface. An empty field or 0.0.0.0 will mean any interface."
 msgstr "Idatzi hemen a.b.c.d formatuan entzun behar den interfazearen baliozko ip helbidea. Eremu huts batek edo 0.0.0.0 ezartzeak edozein interfazetan entzutea eragingo du."
 
-#: src/muuli_wdr.cpp:2073 src/muuli_wdr.cpp:2184
+#: src/muuli_wdr.cpp:2072 src/muuli_wdr.cpp:2156
 msgid "TCP port:"
 msgstr "TCP ataka:"
 
-#: src/muuli_wdr.cpp:2079
+#: src/muuli_wdr.cpp:2078
 msgid "Enable UPnP port forwarding on the EC port"
 msgstr "UPnP berbideraketa gaitu EC atakan"
 
-#: src/muuli_wdr.cpp:2083 src/muuli_wdr.cpp:3069
+#: src/muuli_wdr.cpp:2082 src/muuli_wdr.cpp:3041
 #: src/utils/wxCas/src/wxcasprefs.cpp:167
 msgid "Password"
 msgstr "Pasahitza"
 
-#: src/muuli_wdr.cpp:2089
+#: src/muuli_wdr.cpp:2088
 #, fuzzy
 msgid "aMule API server parameters"
 msgstr "Web zerbitzari parametroak"
 
-#: src/muuli_wdr.cpp:2092
+#: src/muuli_wdr.cpp:2091
 msgid "Run amuleapi (REST API) on startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2097
+#: src/muuli_wdr.cpp:2096
 #, fuzzy
 msgid "HTTP port:"
 msgstr "TCP ataka:"
 
-#: src/muuli_wdr.cpp:2111
+#: src/muuli_wdr.cpp:2110
 msgid "The interface amuleapi's HTTP server listens on. 127.0.0.1 (default) accepts only local connections; use 0.0.0.0 or a specific IP to expose it to other hosts (set an admin password below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2116
-msgid "Type a password to set or change it. Stored passwords cannot be shown, so leaving this empty keeps the current one."
-msgstr ""
-
-#: src/muuli_wdr.cpp:2118
+#: src/muuli_wdr.cpp:2113
 #, fuzzy
 msgid "Admin password"
 msgstr "Pasahitz egiaztatzen\n"
 
-#: src/muuli_wdr.cpp:2130 src/muuli_wdr.cpp:2147 src/PrefsUnifiedDlg.cpp:1103
-#, fuzzy
-msgid "A password is set."
-msgstr "Pasahitz egiaztatzen\n"
+#: src/muuli_wdr.cpp:2118 src/muuli_wdr.cpp:2149
+msgid "Low rights password"
+msgstr "Baimen baxuko pasahitza"
 
-#: src/muuli_wdr.cpp:2134
-#, fuzzy
-msgid "Enable guest access"
-msgstr "Gonbidatu sarrera ezgaitu"
-
-#: src/muuli_wdr.cpp:2135
-msgid "Guest sessions may read status and listings but cannot change anything. Turning this off clears the stored guest password."
-msgstr ""
-
-#: src/muuli_wdr.cpp:2139
-#, fuzzy
-msgid "Guest password"
-msgstr "Gonbidatu pasahitza web zerbitzarirako"
-
-#: src/muuli_wdr.cpp:2154
+#: src/muuli_wdr.cpp:2126
 msgid "Web server parameters"
 msgstr "Web zerbitzari parametroak"
 
-#: src/muuli_wdr.cpp:2157
+#: src/muuli_wdr.cpp:2129
 #, fuzzy
 msgid "Run webserver on startup (deprecated)"
 msgstr "Exekutatu web-zerbitzaria abioan"
 
-#: src/muuli_wdr.cpp:2163
+#: src/muuli_wdr.cpp:2135
 msgid "Web template"
 msgstr "Web txantiloia"
 
-#: src/muuli_wdr.cpp:2168
+#: src/muuli_wdr.cpp:2140
 msgid "Full rights password"
 msgstr "Baimen osorako pasahitza"
 
-#: src/muuli_wdr.cpp:2172
+#: src/muuli_wdr.cpp:2144
 msgid "Enable Low rights User"
 msgstr "Gaitu baimen gutxiko erabiltzailea"
 
-#: src/muuli_wdr.cpp:2177
-msgid "Low rights password"
-msgstr "Baimen baxuko pasahitza"
-
-#: src/muuli_wdr.cpp:2191
+#: src/muuli_wdr.cpp:2163
 msgid "Enable UPnP port forwarding of the web server port"
 msgstr "Gaitu web zerbitzari atakaren UPnP ataka birbidalketa"
 
-#: src/muuli_wdr.cpp:2196
+#: src/muuli_wdr.cpp:2168
 msgid "Web server UPnP TCP port (Optional)"
 msgstr "Web zerbitzari UPnP ataka (aukerakoa)"
 
-#: src/muuli_wdr.cpp:2204
+#: src/muuli_wdr.cpp:2176
 msgid "Page Refresh Time (in secs)"
 msgstr "Orrialdea berritzeko denbora (segundotan)"
 
-#: src/muuli_wdr.cpp:2211
+#: src/muuli_wdr.cpp:2183
 msgid "Enable Gzip compression"
 msgstr "Gaitu Gzip konpresioa"
 
-#: src/muuli_wdr.cpp:2245
+#: src/muuli_wdr.cpp:2217
 #, fuzzy
 msgid "Reset page to defaults"
 msgstr "Sistema lehenetsia"
 
-#: src/muuli_wdr.cpp:2246
+#: src/muuli_wdr.cpp:2218
 msgid "Reset the settings on the current page to their default values."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2248 src/muuli_wdr.cpp:2334 src/ServerWnd.cpp:274
+#: src/muuli_wdr.cpp:2220 src/muuli_wdr.cpp:2306 src/ServerWnd.cpp:274
 #: src/ServerWnd.cpp:282
 msgid "OK"
 msgstr "Ados"
 
-#: src/muuli_wdr.cpp:2250
+#: src/muuli_wdr.cpp:2222
 msgid "Click here to apply any changes made to the preferences."
 msgstr "Hemen klik egin hobespenetan eginiko edozein aldaketa ezartzeko."
 
-#: src/muuli_wdr.cpp:2253
+#: src/muuli_wdr.cpp:2225
 msgid "Reset any changes made to the preferences."
 msgstr "Berrezarri hobespenetan eginiko edozein aldaketa."
 
-#: src/muuli_wdr.cpp:2282
+#: src/muuli_wdr.cpp:2254
 msgid "Comment :"
 msgstr "Iruzkina :"
 
-#: src/muuli_wdr.cpp:2289
+#: src/muuli_wdr.cpp:2261
 msgid "Incoming Dir :"
 msgstr "Deskarga direktorioa :"
 
-#: src/muuli_wdr.cpp:2298
+#: src/muuli_wdr.cpp:2270
 msgid "Change priority for new assigned files :"
 msgstr "Aldatu lehentasuna fitxategi berrientzat :"
 
-#: src/muuli_wdr.cpp:2302
+#: src/muuli_wdr.cpp:2274
 msgid "Don't change"
 msgstr "Ez aldatu"
 
-#: src/muuli_wdr.cpp:2314
+#: src/muuli_wdr.cpp:2286
 msgid "Select color for this Category (currently selected) :"
 msgstr "Hautatu kolorea kategoria honentzat (unean aukeratutakoa) :"
 
-#: src/muuli_wdr.cpp:2381 src/muuli_wdr.cpp:2400 src/muuli_wdr.cpp:2422
+#: src/muuli_wdr.cpp:2353 src/muuli_wdr.cpp:2372 src/muuli_wdr.cpp:2394
 msgid "Click this button to reset the log."
 msgstr "Botoi hau klikatu erregistroa garbitzeko."
 
-#: src/muuli_wdr.cpp:2441
+#: src/muuli_wdr.cpp:2413
 msgid "Click on this button to update the servers list from URL ..."
 msgstr "Klik egin botoi honetan zerbitzari zerrenda URL-tik eguneratzeko ..."
 
-#: src/muuli_wdr.cpp:2445
+#: src/muuli_wdr.cpp:2417
 msgid "Server list"
 msgstr "Zerbitzari zerrenda"
 
-#: src/muuli_wdr.cpp:2449
+#: src/muuli_wdr.cpp:2421
 msgid "Enter the url to a server.met file here and press the button to the left to update the list of known servers."
 msgstr "Idatzi server.met fitxategiaren URL bat hemen eta gero ezkerreko botoia sakatu zerbitzari ezagunen zerrenda eguneratzeko."
 
-#: src/muuli_wdr.cpp:2454
+#: src/muuli_wdr.cpp:2426
 msgid "Add server manually: Name"
 msgstr "Gehitu zerbitzaria eskuz: Izena"
 
-#: src/muuli_wdr.cpp:2457
+#: src/muuli_wdr.cpp:2429
 msgid "Enter the name of the new server here"
 msgstr "Idatzi zerbitzari berriaren izen hemen"
 
-#: src/muuli_wdr.cpp:2459 src/ServerWnd.cpp:206
+#: src/muuli_wdr.cpp:2431 src/ServerWnd.cpp:206
 msgid "IP:Port"
 msgstr "IP ataka"
 
-#: src/muuli_wdr.cpp:2462
+#: src/muuli_wdr.cpp:2434
 msgid "Enter the IP of the server here, using the x.x.x.x format."
 msgstr "Idatzi x.x.x.x formatua erabiliaz zerbitzariaren ip helbidea."
 
-#: src/muuli_wdr.cpp:2468
+#: src/muuli_wdr.cpp:2440
 msgid "Enter the port of the server here."
 msgstr "Idatzi zerbitzariaren ataka hemen."
 
-#: src/muuli_wdr.cpp:2471
+#: src/muuli_wdr.cpp:2443
 msgid "Add manually a server (fill fields to the left before) ..."
 msgstr "Gehitu zerbitzari bat eskuz (sar datuak ezkerrean lehenik) ..."
 
-#: src/muuli_wdr.cpp:2500
+#: src/muuli_wdr.cpp:2472
 msgid "aMule Log"
 msgstr "aMule erregistroa"
 
-#: src/muuli_wdr.cpp:2508
+#: src/muuli_wdr.cpp:2480
 msgid "Server Info"
 msgstr "Zerbitzari argibideak"
 
-#: src/muuli_wdr.cpp:2512
+#: src/muuli_wdr.cpp:2484
 msgid "ED2K Info"
 msgstr "Argb"
 
-#: src/muuli_wdr.cpp:2516
+#: src/muuli_wdr.cpp:2488
 msgid "Kad Info"
 msgstr "Kad Argb"
 
-#: src/muuli_wdr.cpp:2544
+#: src/muuli_wdr.cpp:2516
 msgid "Click on this button to update the nodes list from URL ..."
 msgstr "Klikatu botoi honetan nodo zerrenda URL honetatik eguneratzeko ..."
 
-#: src/muuli_wdr.cpp:2548
+#: src/muuli_wdr.cpp:2520
 msgid "Nodes (0)"
 msgstr "Nodoak (0)"
 
-#: src/muuli_wdr.cpp:2552
+#: src/muuli_wdr.cpp:2524
 msgid "Enter the url to a nodes.dat file here and press the button to the left to update the list of known nodes."
 msgstr "nodes.dat fitxategi baten URL-a idatzi eta ezkerreko botoia sakatu nodo ezagunen zerrenda eguneratzeko."
 
-#: src/muuli_wdr.cpp:2555
+#: src/muuli_wdr.cpp:2527
 msgid "Nodes stats"
 msgstr "Nodo estatistikak"
 
-#: src/muuli_wdr.cpp:2597
+#: src/muuli_wdr.cpp:2569
 msgid "Bootstrap"
 msgstr "Autoabioa"
 
-#: src/muuli_wdr.cpp:2600
+#: src/muuli_wdr.cpp:2572
 msgid "New node"
 msgstr "Nodo berria"
 
-#: src/muuli_wdr.cpp:2605
+#: src/muuli_wdr.cpp:2577
 msgid "IP:"
 msgstr "IP:"
 
-#: src/muuli_wdr.cpp:2625
+#: src/muuli_wdr.cpp:2597
 msgid "Port:"
 msgstr "Ataka:"
 
-#: src/muuli_wdr.cpp:2638
+#: src/muuli_wdr.cpp:2610
 msgid "Bootstrap from known clients"
 msgstr "Bezero ezagunetarik abiarazi"
 
-#: src/muuli_wdr.cpp:2640
+#: src/muuli_wdr.cpp:2612
 msgid "Disconnect Kad"
 msgstr "Kad deskonektatu"
 
-#: src/muuli_wdr.cpp:2674
+#: src/muuli_wdr.cpp:2646
 msgid "Use Secure User Identification"
 msgstr "Erabili erabiltzaile identifikazio segurua"
 
-#: src/muuli_wdr.cpp:2676
+#: src/muuli_wdr.cpp:2648
 msgid "It is recommended to enable this option. You will not receive credits if SUI is not enabled."
 msgstr "Gomendagarri da aukera hau gaitzea. Ez duzu krediturik jasoko EIS erabiltzen ez baduzu."
 
-#: src/muuli_wdr.cpp:2678
+#: src/muuli_wdr.cpp:2650
 msgid "Protocol Obfuscation"
 msgstr "Protokolo nahastea"
 
-#: src/muuli_wdr.cpp:2681
+#: src/muuli_wdr.cpp:2653
 msgid "Support Protocol Obfuscation"
 msgstr "Gaitu protokolo nahastea"
 
-#: src/muuli_wdr.cpp:2683
+#: src/muuli_wdr.cpp:2655
 msgid "This option enabled Protocol Obfuscation, and makes aMule accept obfuscated connections from other clients."
 msgstr "Aukera honek protokolo nahastea gaitzen du eta aMule-k beste bezeroetako konexio nahastuak onartzea eragite du."
 
-#: src/muuli_wdr.cpp:2685
+#: src/muuli_wdr.cpp:2657
 msgid "Use obfuscation for outgoing connections"
 msgstr "Erabili nahastea kanporako konexioetan"
 
-#: src/muuli_wdr.cpp:2687
+#: src/muuli_wdr.cpp:2659
 msgid "This option makes aMule use Protocol Obfuscation when connecting other clients/servers."
 msgstr "Aukera honek Amulek beste bezero/zerbitzarietara konektatzerakoan protokolo nahastea erabiltzea eragiten du."
 
-#: src/muuli_wdr.cpp:2689
+#: src/muuli_wdr.cpp:2661
 msgid "Accept only obfuscated connections"
 msgstr "Onartu nahasitako konexioak bakarrik"
 
-#: src/muuli_wdr.cpp:2690
+#: src/muuli_wdr.cpp:2662
 msgid "This option makes aMule only accept obfuscated connections. You will have less sources, but all your traffic will be obfuscated"
 msgstr "Aukera honek Amulek nahasitako konexioak bakarrik onartzea eragiten du. Jatorri gutxiago izango dituzu baina zure trafiko guztia nahasia egongo da"
 
-#: src/muuli_wdr.cpp:2695
+#: src/muuli_wdr.cpp:2667
 msgid "Everybody"
 msgstr "Edozeini"
 
-#: src/muuli_wdr.cpp:2697
+#: src/muuli_wdr.cpp:2669
 msgid "No one"
 msgstr "Bat ere ez"
 
-#: src/muuli_wdr.cpp:2699
+#: src/muuli_wdr.cpp:2671
 msgid "Who can see my shared files:"
 msgstr "Nork ikusi ditzaken nire partekatutako fitxategiak:"
 
-#: src/muuli_wdr.cpp:2700
+#: src/muuli_wdr.cpp:2672
 msgid "Select who can request to view a list of your shared files."
 msgstr "Hautatu zure partekatutako fitxategiak nork ikus ditzakeen."
 
-#: src/muuli_wdr.cpp:2702
+#: src/muuli_wdr.cpp:2674
 msgid "IP-Filtering"
 msgstr "IP-Iragazkia"
 
-#: src/muuli_wdr.cpp:2709
+#: src/muuli_wdr.cpp:2681
 msgid "Filter clients"
 msgstr "Bezeroak iragazi"
 
-#: src/muuli_wdr.cpp:2711
+#: src/muuli_wdr.cpp:2683
 msgid "Enable filtering of the client IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "~/.aMule/ipfilter.dat fitxategian ezarritako bezero IP iragazketa gaitu."
 
-#: src/muuli_wdr.cpp:2713
+#: src/muuli_wdr.cpp:2685
 msgid "Filter servers"
 msgstr "Zerbitzariak iragazi"
 
-#: src/muuli_wdr.cpp:2715
+#: src/muuli_wdr.cpp:2687
 msgid "Enable filtering of the server IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "~/.aMule/ipfilter.dat fitxategian ezarritako zerbitzari IP iragazketa gaitu."
 
-#: src/muuli_wdr.cpp:2719
+#: src/muuli_wdr.cpp:2691
 msgid "Reload List"
 msgstr "Berritu zerrenda"
 
-#: src/muuli_wdr.cpp:2720
+#: src/muuli_wdr.cpp:2692
 msgid "Reload the list of IPs to filter from the file ~/.aMule/ipfilter.dat"
 msgstr "Berritu ~/.aMule/ipfilter.dat fitxategian ezarritako IP helbideen iragazkia"
 
-#: src/muuli_wdr.cpp:2726
+#: src/muuli_wdr.cpp:2698
 msgid "URL:"
 msgstr "URL-a:"
 
-#: src/muuli_wdr.cpp:2730 src/muuli_wdr.cpp:2923
+#: src/muuli_wdr.cpp:2702 src/muuli_wdr.cpp:2895
 msgid "Update now"
 msgstr "Eguneratu orain"
 
-#: src/muuli_wdr.cpp:2733
+#: src/muuli_wdr.cpp:2705
 msgid "Auto-update ipfilter at startup"
 msgstr "Automatikoki eguneratu ip iragazkia abioan"
 
-#: src/muuli_wdr.cpp:2737
+#: src/muuli_wdr.cpp:2709
 msgid "Filtering Level:"
 msgstr "Iragazki maila:"
 
-#: src/muuli_wdr.cpp:2743
+#: src/muuli_wdr.cpp:2715
 msgid "Always filter LAN IPs"
 msgstr "Beti iragazi LAN IP-ak"
 
-#: src/muuli_wdr.cpp:2746
+#: src/muuli_wdr.cpp:2718
 msgid "Paranoid handling of non-matching IPs"
 msgstr "Paranoia kudeaketa pareko ez diren IP helbideentzat"
 
-#: src/muuli_wdr.cpp:2748
+#: src/muuli_wdr.cpp:2720
 msgid "Rejects a packet when its source IP differs from the IP the client claims (an anti-spoofing check). Disable only if it causes connection problems."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2750
+#: src/muuli_wdr.cpp:2722
 msgid "Use system-wide ipfilter.dat if available"
 msgstr "Erabili sistemako ipfilter.dat eskuragarri badago"
 
-#: src/muuli_wdr.cpp:2751
+#: src/muuli_wdr.cpp:2723
 #, fuzzy
 msgid "If there's no local ipfilter.dat found, allow usage of a system-wide ipfilter file."
 msgstr "Ez bada ipfilter.dat fitxategi lokalik aurkitu, orduan onartu sistema ipfilter fitxategia erabiltzea."
 
-#: src/muuli_wdr.cpp:2768
+#: src/muuli_wdr.cpp:2740
 msgid "Enable Online-Signature"
 msgstr "Gaitu sinadura linean"
 
-#: src/muuli_wdr.cpp:2770
+#: src/muuli_wdr.cpp:2742
 msgid "Enables the writing of the OS file, which can be used by external apps to create signatures and the like."
 msgstr "Gaitu sistemak fitxategiak idaztea, kanpo programek sinadurak sortu ahal izateko egiten da."
 
-#: src/muuli_wdr.cpp:2774
+#: src/muuli_wdr.cpp:2746
 msgid "Update Frequency (Secs):"
 msgstr "Eguneratu maiztasuna (Seg):"
 
-#: src/muuli_wdr.cpp:2777
+#: src/muuli_wdr.cpp:2749
 msgid "Change the frequency (in seconds) of Online Signature updates."
 msgstr "Aldatu linean sinadura eguneraketa aldia (segundotan)."
 
-#: src/muuli_wdr.cpp:2785
+#: src/muuli_wdr.cpp:2757
 msgid "Save online signature file in: "
 msgstr "Gorde sare sinadura fitxategia hemen: "
 
-#: src/muuli_wdr.cpp:2791
+#: src/muuli_wdr.cpp:2763
 msgid "Click here to select the directory containing the the Online Signature files."
 msgstr "Klikatu hemen linean sinadurak dituen karpeta aukeratzeko."
 
-#: src/muuli_wdr.cpp:2824
+#: src/muuli_wdr.cpp:2796
 msgid "Show country flags for clients"
 msgstr "Bistarazi estatu banderak bezeroentzat"
 
-#: src/muuli_wdr.cpp:2825
+#: src/muuli_wdr.cpp:2797
 msgid "Render the country flag column in the transfers, queue and search views. Requires a valid MMDB GeoIP database (see below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2830
+#: src/muuli_wdr.cpp:2802
 #, fuzzy
 msgid "Database"
 msgstr "Data abiadura :"
 
-#: src/muuli_wdr.cpp:2846
+#: src/muuli_wdr.cpp:2818
 #, fuzzy
 msgid "Source:"
 msgstr "Jatorriak"
 
-#: src/muuli_wdr.cpp:2849
+#: src/muuli_wdr.cpp:2821
 msgid "DB-IP (free, no account)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2850
+#: src/muuli_wdr.cpp:2822
 msgid "MaxMind GeoLite2 (free, account required)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2851
+#: src/muuli_wdr.cpp:2823
 msgid "Custom URL"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2854
+#: src/muuli_wdr.cpp:2826
 msgid "Choose which provider supplies the GeoIP MMDB database. DB-IP is the default - no account required. MaxMind requires a free account + license key. Use Custom URL to point at any other MMDB host (e.g. a local mirror)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2871
+#: src/muuli_wdr.cpp:2843
 msgid ""
 "No configuration required.\n"
 "\n"
@@ -4874,11 +4840,11 @@ msgid ""
 "License: Creative Commons BY 4.0 - https://creativecommons.org/licenses/by/4.0/"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2884
+#: src/muuli_wdr.cpp:2856
 msgid "License key:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2890
+#: src/muuli_wdr.cpp:2862
 msgid ""
 "Sign up for a free MaxMind account, then generate a License Key:\n"
 "https://www.maxmind.com/en/geolite2/signup\n"
@@ -4888,226 +4854,226 @@ msgid ""
 "Requires attribution and account registration; refresh at least every 30 days."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2905
+#: src/muuli_wdr.cpp:2877
 #, fuzzy
 msgid "Download URL:"
 msgstr "Deskargak: "
 
-#: src/muuli_wdr.cpp:2911
+#: src/muuli_wdr.cpp:2883
 msgid ""
 "Must point to an .mmdb file or a .gz / .tar.gz containing one.\n"
 "URL may include credentials (https://user:pass@host/...).\n"
 "License and attribution terms are set by the upstream URL - you are responsible."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2924
+#: src/muuli_wdr.cpp:2896
 msgid "Download the GeoIP database from the selected source."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2926
+#: src/muuli_wdr.cpp:2898
 #, fuzzy
 msgid "Auto-update on startup"
 msgstr "Automatikoki eguneratu ip iragazkia abioan"
 
-#: src/muuli_wdr.cpp:2927
+#: src/muuli_wdr.cpp:2899
 msgid "Re-download the GeoIP database from the selected source every time aMule starts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2950
+#: src/muuli_wdr.cpp:2922
 msgid "Filter incoming messages (except current chat):"
 msgstr "sarrera mezu iragazkia (txat honetan ezik):"
 
-#: src/muuli_wdr.cpp:2952
+#: src/muuli_wdr.cpp:2924
 msgid "Filter all messages"
 msgstr "Mezu guztiak iragazi"
 
-#: src/muuli_wdr.cpp:2954
+#: src/muuli_wdr.cpp:2926
 msgid "Filter messages from people not on your friend list"
 msgstr "Lagun zerrendan ez daudenen mezuak iragazi"
 
-#: src/muuli_wdr.cpp:2956
+#: src/muuli_wdr.cpp:2928
 msgid "Filter messages from unknown clients"
 msgstr "Bezero ezezagunen mezuak iragazi"
 
-#: src/muuli_wdr.cpp:2958
+#: src/muuli_wdr.cpp:2930
 msgid "Filter messages containing (use ',' as separator):"
 msgstr "Hau duten mezuak iragazi (erabili ',' bereizle bezala):"
 
-#: src/muuli_wdr.cpp:2961 src/muuli_wdr.cpp:2972
+#: src/muuli_wdr.cpp:2933 src/muuli_wdr.cpp:2944
 msgid "add here the words amule should filter and block messages including it"
 msgstr "Gehitu amulek mezuetan blokeatzea nahi dituzun hitzak"
 
-#: src/muuli_wdr.cpp:2963
+#: src/muuli_wdr.cpp:2935
 msgid "Show received messages in the log"
 msgstr "Ikusi jasotako mezuak erregistroan"
 
-#: src/muuli_wdr.cpp:2966
+#: src/muuli_wdr.cpp:2938
 msgid "Comments"
 msgstr "Iruzkinak"
 
-#: src/muuli_wdr.cpp:2969
+#: src/muuli_wdr.cpp:2941
 msgid "Filter comments containing (use ',' as separator):"
 msgstr "Fitxategi iruzkinak hau du (',' erabili bereizle gisa):"
 
-#: src/muuli_wdr.cpp:2994
+#: src/muuli_wdr.cpp:2966
 msgid "Enable Proxy"
 msgstr "Proxy-a gaitu"
 
-#: src/muuli_wdr.cpp:2995
+#: src/muuli_wdr.cpp:2967
 msgid "Enable/disable proxy support"
 msgstr "Proxy onarpena gaitu/ezgaitu"
 
-#: src/muuli_wdr.cpp:2998
+#: src/muuli_wdr.cpp:2970
 msgid "Proxy type:"
 msgstr "Proxy mota:"
 
-#: src/muuli_wdr.cpp:3009
+#: src/muuli_wdr.cpp:2981
 msgid "Proxy host:"
 msgstr "Proxy ostalaria:"
 
-#: src/muuli_wdr.cpp:3012
+#: src/muuli_wdr.cpp:2984
 msgid "The proxy host name"
 msgstr "Proxy ostalari izena"
 
-#: src/muuli_wdr.cpp:3014
+#: src/muuli_wdr.cpp:2986
 msgid "Proxy port:"
 msgstr "Proxy ataka:"
 
-#: src/muuli_wdr.cpp:3017
+#: src/muuli_wdr.cpp:2989
 msgid "The proxy port"
 msgstr "Proxy ataka"
 
-#: src/muuli_wdr.cpp:3019
+#: src/muuli_wdr.cpp:2991
 msgid "Enable authentication"
 msgstr "Gaitu autentifikazioa"
 
-#: src/muuli_wdr.cpp:3020
+#: src/muuli_wdr.cpp:2992
 msgid "Enable/disable username/password authentication"
 msgstr "erabiltzaile/pasahitz autentifikazioa gaitu/ezgaitu"
 
-#: src/muuli_wdr.cpp:3023
+#: src/muuli_wdr.cpp:2995
 msgid "Username: "
 msgstr "Erabiltzaile izena: "
 
-#: src/muuli_wdr.cpp:3026
+#: src/muuli_wdr.cpp:2998
 msgid "The username to use to connect to the proxy"
 msgstr "Proxy-ra konektatzeko erabiliko den erabiltzaile izena"
 
-#: src/muuli_wdr.cpp:3028
+#: src/muuli_wdr.cpp:3000
 msgid "Password:"
 msgstr "Pasahitza:"
 
-#: src/muuli_wdr.cpp:3031
+#: src/muuli_wdr.cpp:3003
 msgid "The password to use to connect to the proxy"
 msgstr "Proxy-ra konektatzeko erabiliko den pasahitza"
 
-#: src/muuli_wdr.cpp:3050
+#: src/muuli_wdr.cpp:3022
 msgid "Connect to:"
 msgstr "Hona konektaturik:"
 
-#: src/muuli_wdr.cpp:3059
+#: src/muuli_wdr.cpp:3031
 msgid "Login to remote amule"
 msgstr "Urruneko aMulen saioa hasi"
 
-#: src/muuli_wdr.cpp:3064
+#: src/muuli_wdr.cpp:3036
 msgid "User name"
 msgstr "Erabiltzaile izena"
 
-#: src/muuli_wdr.cpp:3075
+#: src/muuli_wdr.cpp:3047
 msgid "Remember those settings"
 msgstr "Ezarpen hauek gogoratu"
 
-#: src/muuli_wdr.cpp:3078
+#: src/muuli_wdr.cpp:3050
 #, fuzzy
 msgid "Force ZLIB compression"
 msgstr "Erabili gzip konpresioa"
 
-#: src/muuli_wdr.cpp:3102
+#: src/muuli_wdr.cpp:3074
 msgid "Enable Verbose Debug-Logging."
 msgstr "Gaitu arazten luzeko saio hasiera."
 
-#: src/muuli_wdr.cpp:3104
+#: src/muuli_wdr.cpp:3076
 #, fuzzy
 msgid "Only to Logfile"
 msgstr "&Ireki fitxategia"
 
-#: src/muuli_wdr.cpp:3106
+#: src/muuli_wdr.cpp:3078
 msgid "Message Categories:"
 msgstr "Mezu kategoriak:"
 
-#: src/muuli_wdr.cpp:3130 src/PartFileConvertDlg.cpp:160
+#: src/muuli_wdr.cpp:3102 src/PartFileConvertDlg.cpp:160
 msgid "Waiting..."
 msgstr "Zain..."
 
-#: src/muuli_wdr.cpp:3150
+#: src/muuli_wdr.cpp:3122
 msgid "Add imports"
 msgstr "Gehitu"
 
-#: src/muuli_wdr.cpp:3153
+#: src/muuli_wdr.cpp:3125
 msgid "Retry selected"
 msgstr "Berriz saiatu hautaturikoak"
 
-#: src/muuli_wdr.cpp:3155
+#: src/muuli_wdr.cpp:3127
 msgid "Remove selected"
 msgstr "Ezabatu hautaturikoak"
 
-#: src/muuli_wdr.cpp:3218
+#: src/muuli_wdr.cpp:3190
 msgid "Event Types"
 msgstr "Gertaera motak"
 
-#: src/muuli_wdr.cpp:3237
+#: src/muuli_wdr.cpp:3209
 msgid "Statistics and queued clients for selected file(s) : Session / All time"
 msgstr "Hautako fitxategientzat estatistika eta bezero ilara: Saioa / osotara"
 
-#: src/muuli_wdr.cpp:3261
+#: src/muuli_wdr.cpp:3233
 msgid "Active Uploads"
 msgstr "Igoera aktiboak"
 
-#: src/muuli_wdr.cpp:3275
+#: src/muuli_wdr.cpp:3247
 msgid "Percent of total files"
 msgstr "fitxategi guztien ehunekoa"
 
-#: src/muuli_wdr.cpp:3327
+#: src/muuli_wdr.cpp:3299
 msgid "Show Clients for"
 msgstr "Erakutsi bezeroak:"
 
-#: src/muuli_wdr.cpp:3329
+#: src/muuli_wdr.cpp:3301
 msgid "All files"
 msgstr "Fitxategi guztiak"
 
-#: src/muuli_wdr.cpp:3332
+#: src/muuli_wdr.cpp:3304
 msgid "Selected files"
 msgstr "Hautatutako fitxategiak"
 
-#: src/muuli_wdr.cpp:3335
+#: src/muuli_wdr.cpp:3307
 msgid "Active uploads only"
 msgstr "Igoera aktiboak bakarrik"
 
-#: src/muuli_wdr.cpp:3342
+#: src/muuli_wdr.cpp:3314
 msgid "Reload:"
 msgstr "Berritu:"
 
-#: src/muuli_wdr.cpp:3346
+#: src/muuli_wdr.cpp:3318
 msgid "Reload your shared files"
 msgstr "Berritu zure partekatutako fitxategiak"
 
-#: src/muuli_wdr.cpp:3409
+#: src/muuli_wdr.cpp:3381
 msgid "Send"
 msgstr "Bidali"
 
-#: src/muuli_wdr.cpp:3410
+#: src/muuli_wdr.cpp:3382
 msgid "Sends the specified message."
 msgstr "Zehaztutako mezua bidali."
 
-#: src/muuli_wdr.cpp:3414
+#: src/muuli_wdr.cpp:3386
 msgid "Close this chat-session."
 msgstr "Itxi elkarrizketa saio hau."
 
-#: src/muuli_wdr.cpp:3437
+#: src/muuli_wdr.cpp:3409
 msgid "Connect to any server and/or Kad"
 msgstr "Konektatu edozein zerbitzari eta/edo Kad"
 
-#: src/muuli_wdr.cpp:3443 src/SharedFilesCtrl.cpp:142 src/Statistics.cpp:941
+#: src/muuli_wdr.cpp:3415 src/SharedFilesCtrl.cpp:142 src/Statistics.cpp:941
 msgid "Shared Files"
 msgstr "Partekatutako fitxategiak"
 
@@ -5466,249 +5432,249 @@ msgstr "Deskargatua"
 msgid "ERROR: Failed to open partfile '%s'"
 msgstr "ERROREA: Huts '%s' zati fitxategia irekitzean"
 
-#: src/Preferences.cpp:701
+#: src/Preferences.cpp:673
 msgid "System default"
 msgstr "Sistema lehenetsia"
 
-#: src/Preferences.cpp:702
+#: src/Preferences.cpp:674
 msgid "Albanian"
 msgstr "Albaniera"
 
-#: src/Preferences.cpp:703
+#: src/Preferences.cpp:675
 msgid "Arabic"
 msgstr "Arabiera"
 
-#: src/Preferences.cpp:704
+#: src/Preferences.cpp:676
 msgid "Asturian"
 msgstr "Bablea"
 
-#: src/Preferences.cpp:705
+#: src/Preferences.cpp:677
 msgid "Basque"
 msgstr "Euskara"
 
-#: src/Preferences.cpp:706
+#: src/Preferences.cpp:678
 msgid "Bulgarian"
 msgstr "Bulgariera"
 
-#: src/Preferences.cpp:707
+#: src/Preferences.cpp:679
 msgid "Catalan"
 msgstr "Katalana"
 
-#: src/Preferences.cpp:708
+#: src/Preferences.cpp:680
 msgid "Chinese (Simplified)"
 msgstr "Txinatarra (Sinplea)"
 
-#: src/Preferences.cpp:709
+#: src/Preferences.cpp:681
 msgid "Chinese (Traditional)"
 msgstr "Txinatarra (ohizkoa)"
 
-#: src/Preferences.cpp:710
+#: src/Preferences.cpp:682
 msgid "Croatian"
 msgstr "Kroaziera"
 
-#: src/Preferences.cpp:711
+#: src/Preferences.cpp:683
 msgid "Czech"
 msgstr "Txekiera"
 
-#: src/Preferences.cpp:712
+#: src/Preferences.cpp:684
 msgid "Danish"
 msgstr "Daniera"
 
-#: src/Preferences.cpp:713
+#: src/Preferences.cpp:685
 msgid "Dutch"
 msgstr "Nederlandera"
 
-#: src/Preferences.cpp:714
+#: src/Preferences.cpp:686
 msgid "English (U.K.)"
 msgstr "Ingelesa (E.B.)"
 
-#: src/Preferences.cpp:715
+#: src/Preferences.cpp:687
 #, fuzzy
 msgid "English (U.S.)"
 msgstr "Ingelesa (E.B.)"
 
-#: src/Preferences.cpp:716
+#: src/Preferences.cpp:688
 msgid "Estonian"
 msgstr "Estoniera"
 
-#: src/Preferences.cpp:717
+#: src/Preferences.cpp:689
 msgid "Finnish"
 msgstr "Finlandiera"
 
-#: src/Preferences.cpp:718
+#: src/Preferences.cpp:690
 msgid "French"
 msgstr "Frantsesa"
 
-#: src/Preferences.cpp:719
+#: src/Preferences.cpp:691
 msgid "Galician"
 msgstr "Galiziera"
 
-#: src/Preferences.cpp:720
+#: src/Preferences.cpp:692
 msgid "German"
 msgstr "Alemana"
 
-#: src/Preferences.cpp:721
+#: src/Preferences.cpp:693
 msgid "Greek"
 msgstr "Grekoa"
 
-#: src/Preferences.cpp:722
+#: src/Preferences.cpp:694
 msgid "Hebrew"
 msgstr "Hebreera"
 
-#: src/Preferences.cpp:723
+#: src/Preferences.cpp:695
 msgid "Hungarian"
 msgstr "Hungariera"
 
-#: src/Preferences.cpp:724
+#: src/Preferences.cpp:696
 msgid "Italian"
 msgstr "Italiera"
 
-#: src/Preferences.cpp:725
+#: src/Preferences.cpp:697
 msgid "Japanese"
 msgstr "Japoniera"
 
-#: src/Preferences.cpp:726
+#: src/Preferences.cpp:698
 msgid "Korean"
 msgstr "Koreera"
 
-#: src/Preferences.cpp:727
+#: src/Preferences.cpp:699
 msgid "Latvian"
 msgstr ""
 
-#: src/Preferences.cpp:728
+#: src/Preferences.cpp:700
 msgid "Lithuanian"
 msgstr "Lituaniera"
 
-#: src/Preferences.cpp:729
+#: src/Preferences.cpp:701
 msgid "Norwegian (Nynorsk)"
 msgstr "Norvegiera (Nynorsk)"
 
-#: src/Preferences.cpp:730
+#: src/Preferences.cpp:702
 msgid "Polish"
 msgstr "Poloniera"
 
-#: src/Preferences.cpp:731
+#: src/Preferences.cpp:703
 msgid "Portuguese"
 msgstr "Portugesa"
 
-#: src/Preferences.cpp:732
+#: src/Preferences.cpp:704
 msgid "Portuguese (Brazilian)"
 msgstr "Portugesa (Brasildarra)"
 
-#: src/Preferences.cpp:733
+#: src/Preferences.cpp:705
 msgid "Romanian"
 msgstr "Errumaniera"
 
-#: src/Preferences.cpp:734
+#: src/Preferences.cpp:706
 msgid "Russian"
 msgstr "Errusiera"
 
-#: src/Preferences.cpp:735
+#: src/Preferences.cpp:707
 msgid "Slovenian"
 msgstr "Esloveniera"
 
-#: src/Preferences.cpp:736
+#: src/Preferences.cpp:708
 msgid "Spanish"
 msgstr "Gaztelera"
 
-#: src/Preferences.cpp:737
+#: src/Preferences.cpp:709
 msgid "Swedish"
 msgstr "Suediera"
 
-#: src/Preferences.cpp:738
+#: src/Preferences.cpp:710
 msgid "Turkish"
 msgstr "Turkiera"
 
-#: src/Preferences.cpp:739
+#: src/Preferences.cpp:711
 msgid "Ukrainian"
 msgstr "Ukraniera"
 
-#: src/Preferences.cpp:842
+#: src/Preferences.cpp:814
 msgid "Change Language"
 msgstr "Aldatu hizkuntza"
 
-#: src/Preferences.cpp:906
+#: src/Preferences.cpp:878
 msgid "There are no translations installed for aMule"
 msgstr "Ez dago aMulerentzat itzulpen instalaturik"
 
-#: src/Preferences.cpp:907
+#: src/Preferences.cpp:879
 msgid "No languages available"
 msgstr "Ez dago hizkuntza erabilgarririk"
 
-#: src/Preferences.cpp:1038
+#: src/Preferences.cpp:1010
 msgid "no options available"
 msgstr "ez dago aukera erabilgarririk"
 
-#: src/Preferences.cpp:2226
+#: src/Preferences.cpp:2179
 msgid "Invalid category found, skipping"
 msgstr "Kategoria baliogabe aurkitua, baztertzen"
 
-#: src/Preferences.cpp:2395
+#: src/Preferences.cpp:2348
 msgid "TCP port can't be higher than 65532 due to server UDP socket being TCP+3"
 msgstr "TCP ataka ezin da 65532 baino altuagoa izan UDP socket-a TCP+3 bait da"
 
-#: src/Preferences.cpp:2396
+#: src/Preferences.cpp:2349
 #, c-format
 msgid "Default port will be used (%d)"
 msgstr "Lehenetsiriko ataka erabiliko da (%d)"
 
-#: src/PrefsUnifiedDlg.cpp:300 src/Statistics.cpp:866
+#: src/PrefsUnifiedDlg.cpp:298 src/Statistics.cpp:866
 msgid "Connection"
 msgstr "Konexioa"
 
-#: src/PrefsUnifiedDlg.cpp:301 src/SearchListCtrl.cpp:117
+#: src/PrefsUnifiedDlg.cpp:299 src/SearchListCtrl.cpp:117
 msgid "Directories"
 msgstr "Direktorioak"
 
-#: src/PrefsUnifiedDlg.cpp:302 src/Statistics.cpp:917
+#: src/PrefsUnifiedDlg.cpp:300 src/Statistics.cpp:917
 msgid "Servers"
 msgstr "Zerbitzariak"
 
-#: src/PrefsUnifiedDlg.cpp:303 src/ServerListCtrl.cpp:96
+#: src/PrefsUnifiedDlg.cpp:301 src/ServerListCtrl.cpp:96
 msgid "Files"
 msgstr "Fitxategiak"
 
-#: src/PrefsUnifiedDlg.cpp:304
+#: src/PrefsUnifiedDlg.cpp:302
 msgid "Security"
 msgstr "Segurtasuna"
 
-#: src/PrefsUnifiedDlg.cpp:305
+#: src/PrefsUnifiedDlg.cpp:303
 msgid "Interface"
 msgstr "Interfazea"
 
-#: src/PrefsUnifiedDlg.cpp:312
+#: src/PrefsUnifiedDlg.cpp:310
 msgid "IP2Country"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:315
+#: src/PrefsUnifiedDlg.cpp:313
 msgid "Proxy"
 msgstr "Proxy-a"
 
-#: src/PrefsUnifiedDlg.cpp:316
+#: src/PrefsUnifiedDlg.cpp:314
 msgid "Filters"
 msgstr "Iragazkiak"
 
-#: src/PrefsUnifiedDlg.cpp:317
+#: src/PrefsUnifiedDlg.cpp:315
 msgid "Remote Controls"
 msgstr "Urruneko kontrolak"
 
-#: src/PrefsUnifiedDlg.cpp:318
+#: src/PrefsUnifiedDlg.cpp:316
 msgid "Online Signature"
 msgstr "Sinadura linean"
 
-#: src/PrefsUnifiedDlg.cpp:319
+#: src/PrefsUnifiedDlg.cpp:317
 msgid "Advanced"
 msgstr "Aurreratua"
 
-#: src/PrefsUnifiedDlg.cpp:320
+#: src/PrefsUnifiedDlg.cpp:318
 msgid "Events"
 msgstr "Gertaerak"
 
-#: src/PrefsUnifiedDlg.cpp:323
+#: src/PrefsUnifiedDlg.cpp:321
 msgid "Debugging"
 msgstr "Araztena"
 
-#: src/PrefsUnifiedDlg.cpp:453
+#: src/PrefsUnifiedDlg.cpp:451
 msgid ""
 "The following variables will be substituted:\n"
 "    %PARTFILE - full path to the file\n"
@@ -5718,15 +5684,15 @@ msgstr ""
 "    %PARTFILE - fitxategiaren bide osoa\n"
 "    %PARTNAME - fitxategi-izena soilik"
 
-#: src/PrefsUnifiedDlg.cpp:474
+#: src/PrefsUnifiedDlg.cpp:472
 msgid "Tray icon support requires libayatana-appindicator3 at compile time."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:490
+#: src/PrefsUnifiedDlg.cpp:488
 msgid "Not available on Wayland: the protocol does not report when a window is minimized, so this option cannot intercept the system minimize button. Workaround: launch aMule with `GDK_BACKEND=x11` to use XWayland instead."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:536
+#: src/PrefsUnifiedDlg.cpp:534
 msgid ""
 "Do not change these setting unless you know\n"
 "what you are doing, otherwise you can easily\n"
@@ -5742,35 +5708,26 @@ msgstr ""
 "Amulek ondo funtzionatu beharko luke ezarpen\n"
 "hauek aldatu gabe."
 
-#: src/PrefsUnifiedDlg.cpp:647
+#: src/PrefsUnifiedDlg.cpp:645
 #, c-format
 msgid "Failed to connect Cfg to widget with the ID %d and key %s"
 msgstr "Huts %d IDa eta %s gakoaz konfiguraziotik programara konektatzean"
 
-#: src/PrefsUnifiedDlg.cpp:695
+#: src/PrefsUnifiedDlg.cpp:693
 #, c-format
 msgid "Failed to transfer data from Cfg to Widget with the ID %d and key %s"
 msgstr "Huts %d IDa eta %s gakoaz konfiguraziotik programara datuak bidaltzean"
 
-#: src/PrefsUnifiedDlg.cpp:801
+#: src/PrefsUnifiedDlg.cpp:799
 msgid "The type of proxy you are connecting to"
 msgstr "Konektatzen ari zaren Proxy-aren mota"
 
-#: src/PrefsUnifiedDlg.cpp:1020
+#: src/PrefsUnifiedDlg.cpp:1003
 #, c-format
 msgid "Failed to transfer data from Widget to Cfg with the ID %d and key %s"
 msgstr "Huts %d IDa eta %s gakoaz programatik konfiguraziora datuak bidaltzean"
 
 #: src/PrefsUnifiedDlg.cpp:1103
-#, fuzzy
-msgid "No password set."
-msgstr "Pasahitz egiaztatzen\n"
-
-#: src/PrefsUnifiedDlg.cpp:1132
-msgid "Guest access needs a password. Type one in the guest password field, or untick Enable guest access."
-msgstr ""
-
-#: src/PrefsUnifiedDlg.cpp:1144
 msgid ""
 "aMule must be restarted to enable these changes:\n"
 "\n"
@@ -5778,42 +5735,42 @@ msgstr ""
 "aMule berrabiarazi egin behar da aldaketa hauek gaitu ahal izateko:\n"
 "\n"
 
-#: src/PrefsUnifiedDlg.cpp:1151
+#: src/PrefsUnifiedDlg.cpp:1110
 msgid "- TCP port changed.\n"
 msgstr "- TCP ataka aldaturik.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1156
+#: src/PrefsUnifiedDlg.cpp:1115
 msgid "- UDP port changed.\n"
 msgstr "- UDP - ataka aldaturik.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1161
+#: src/PrefsUnifiedDlg.cpp:1120
 #, fuzzy
 msgid "- Network interface binding changed.\n"
 msgstr "- Kanpo konexio interfazea aldatua.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1166
+#: src/PrefsUnifiedDlg.cpp:1125
 msgid "- External connect port changed.\n"
 msgstr "- Kanpo konexio ataka aldatua.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1170
+#: src/PrefsUnifiedDlg.cpp:1129
 msgid "- External connect acceptance changed.\n"
 msgstr "- Lanpo konexio onarpena aldatua.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1174
+#: src/PrefsUnifiedDlg.cpp:1133
 msgid "- External connect interface changed.\n"
 msgstr "- Kanpo konexio interfazea aldatua.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1178
+#: src/PrefsUnifiedDlg.cpp:1137
 #, fuzzy
 msgid "- Protocol obfuscation support changed.\n"
 msgstr "Protokolo nahastea"
 
-#: src/PrefsUnifiedDlg.cpp:1193
+#: src/PrefsUnifiedDlg.cpp:1151
 #, fuzzy
 msgid "- amuleapi settings changed.\n"
 msgstr "- Hizkuntza aldaturik.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1202
+#: src/PrefsUnifiedDlg.cpp:1160
 msgid ""
 "Your Auto-update server list is empty.\n"
 "'Auto-update server list at startup' will be disabled."
@@ -5821,7 +5778,7 @@ msgstr ""
 "Auto-eguneraketa zerbitzari zerrenda hutsa dago.\n"
 "'Auto-eguneratu zerbitzari zerrenda abioan' ezgaitu egingo da."
 
-#: src/PrefsUnifiedDlg.cpp:1213
+#: src/PrefsUnifiedDlg.cpp:1171
 msgid ""
 "You have enabled external connections but have not specified a password.\n"
 "External connections cannot be enabled unless a valid password is specified."
@@ -5829,33 +5786,28 @@ msgstr ""
 "Kanpo konexioak gaiturik dituzu baina ez duzu pasahitzik ezarri.\n"
 "Kanpo konexiorik ezin da onartu baliozko pasahitza ezarri arte."
 
-#: src/PrefsUnifiedDlg.cpp:1246
-#, c-format
-msgid "The amuleapi password could not be saved: %s"
-msgstr ""
-
-#: src/PrefsUnifiedDlg.cpp:1276
+#: src/PrefsUnifiedDlg.cpp:1202
 msgid "- Language changed.\n"
 msgstr "- Hizkuntza aldaturik.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1281
+#: src/PrefsUnifiedDlg.cpp:1207
 msgid "- Temp folder changed.\n"
 msgstr "- Aldiroko karpeta aldaturik.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1286
+#: src/PrefsUnifiedDlg.cpp:1212
 msgid "- ED2K network enabled.\n"
 msgstr "- ED2K sarea gaiturik.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1319
+#: src/PrefsUnifiedDlg.cpp:1245
 msgid "The shared-file exclusion pattern is not a valid regular expression. The filter has been left disabled."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1321 src/PrefsUnifiedDlg.cpp:1921
+#: src/PrefsUnifiedDlg.cpp:1247 src/PrefsUnifiedDlg.cpp:1841
 #, fuzzy
 msgid "Invalid regular expression"
 msgstr "Protokolo bertsio baliogabea."
 
-#: src/PrefsUnifiedDlg.cpp:1398
+#: src/PrefsUnifiedDlg.cpp:1324
 msgid ""
 "Both eD2k and Kad network are disabled.\n"
 "You won't be able to connect until you enable at least one of them."
@@ -5863,7 +5815,7 @@ msgstr ""
 "Bai eD2k eta bai Kad sareak ezgaiturik daude.\n"
 "Ezingo zara konektatu behintzat bietako bat gaitu arte."
 
-#: src/PrefsUnifiedDlg.cpp:1403
+#: src/PrefsUnifiedDlg.cpp:1329
 msgid ""
 "Kad will not start if your UDP port is disabled.\n"
 "Enable UDP port or disable Kad."
@@ -5871,7 +5823,7 @@ msgstr ""
 "Kad ezin da abiarazi zure UDP ataka ezgaiturik badago.\n"
 "UDP ataka gaitu edo Kad ezgaitu."
 
-#: src/PrefsUnifiedDlg.cpp:1459
+#: src/PrefsUnifiedDlg.cpp:1385
 msgid ""
 "\n"
 "You MUST restart aMule now.\n"
@@ -5881,69 +5833,69 @@ msgstr ""
 "aMule orain berrabiarazi BEHAR duzu.\n"
 "Orain ez berrabiaraziaz gero ez kexatu ezer txarra gertatzen bada.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1524
+#: src/PrefsUnifiedDlg.cpp:1450
 msgid "Could not register aMule for autostart at login. The autostart store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1526
+#: src/PrefsUnifiedDlg.cpp:1452
 msgid "Could not remove the autostart-at-login entry."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1527
+#: src/PrefsUnifiedDlg.cpp:1453
 #, fuzzy
 msgid "Autostart"
 msgstr "Auto berritzea abiarazirik"
 
-#: src/PrefsUnifiedDlg.cpp:1542
+#: src/PrefsUnifiedDlg.cpp:1468
 msgid "Register file type"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1542
+#: src/PrefsUnifiedDlg.cpp:1468
 msgid "Register URL handler"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1550
+#: src/PrefsUnifiedDlg.cpp:1476
 #, c-format
 msgid "aMule only handles eD2k-compatible magnets. If you replace the current magnet handler (%s), BitTorrent magnet links will stop working - aMule cannot download BitTorrent content. Continue?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1555
+#: src/PrefsUnifiedDlg.cpp:1481
 #, c-format
 msgid "Another application currently opens .emulecollection files (%s). Replace it with aMule?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1560
+#: src/PrefsUnifiedDlg.cpp:1486
 #, c-format
 msgid "Another application is currently the default handler for these links (%s). Replace it with aMule?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1585
+#: src/PrefsUnifiedDlg.cpp:1511
 msgid "Could not register aMule for .emulecollection files. The registration store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1587
+#: src/PrefsUnifiedDlg.cpp:1513
 #, fuzzy
 msgid "Could not remove the file type registration."
 msgstr "Aldiroko deskarga fitxategientzat karpeta"
 
-#: src/PrefsUnifiedDlg.cpp:1589
+#: src/PrefsUnifiedDlg.cpp:1515
 msgid "Could not register aMule as the URL handler. The registration store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1591
+#: src/PrefsUnifiedDlg.cpp:1517
 msgid "Could not remove the URL handler registration."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1661 src/PrefsUnifiedDlg.cpp:1688
+#: src/PrefsUnifiedDlg.cpp:1587 src/PrefsUnifiedDlg.cpp:1614
 #, fuzzy
 msgid "The web server and aMule API require external connections to be enabled."
 msgstr "Pasahitza ezarria eta kanpo konexioak gaiturik."
 
-#: src/PrefsUnifiedDlg.cpp:1671
+#: src/PrefsUnifiedDlg.cpp:1597
 msgid "The aMule web server is deprecated. Consider running the aMule API instead."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1735
+#: src/PrefsUnifiedDlg.cpp:1655
 msgid ""
 "Your Auto-update servers list is in blank.\n"
 "Please fill in at least one URL to point to a valid server.met file.\n"
@@ -5953,66 +5905,66 @@ msgstr ""
 "Mesedez bete behintzat baliozko server.met fitxategi batetara zuzenduaz.\n"
 "Klikatu \"zerrenda\" botoia URL-a sartzeko."
 
-#: src/PrefsUnifiedDlg.cpp:1876
+#: src/PrefsUnifiedDlg.cpp:1796
 msgid "Temporary files"
 msgstr "Aldi baterako fitxategiak"
 
-#: src/PrefsUnifiedDlg.cpp:1881
+#: src/PrefsUnifiedDlg.cpp:1801
 msgid "Incoming files"
 msgstr "Sarrera fitxategiak"
 
-#: src/PrefsUnifiedDlg.cpp:1886
+#: src/PrefsUnifiedDlg.cpp:1806
 msgid "Online Signatures"
 msgstr "Linean sinadurak"
 
-#: src/PrefsUnifiedDlg.cpp:1899
+#: src/PrefsUnifiedDlg.cpp:1819
 #, c-format
 msgid "Choose a folder for %s"
 msgstr "Aukeratu karpeta bat %s-rentzat"
 
-#: src/PrefsUnifiedDlg.cpp:1923
+#: src/PrefsUnifiedDlg.cpp:1843
 #, fuzzy, c-format
 msgid "Would exclude %u of %u shared file"
 msgid_plural "Would exclude %u of %u shared files"
 msgstr[0] "Ezagututako partekatutako fitxategi %i aurkiturik"
 msgstr[1] "%i ezagututako partekatutako fitxategi aurkiturik"
 
-#: src/PrefsUnifiedDlg.cpp:1940
+#: src/PrefsUnifiedDlg.cpp:1860
 msgid "Browse for videoplayer"
 msgstr "Arakatu bideo erreproduzigailua"
 
-#: src/PrefsUnifiedDlg.cpp:1944
+#: src/PrefsUnifiedDlg.cpp:1864
 msgid "Select browser"
 msgstr "Hautatu nabigatzailea"
 
-#: src/PrefsUnifiedDlg.cpp:1948
+#: src/PrefsUnifiedDlg.cpp:1868
 #, fuzzy
 msgid "Select ffprobe binary"
 msgstr "Hautatu nabigatzailea"
 
-#: src/PrefsUnifiedDlg.cpp:1954
+#: src/PrefsUnifiedDlg.cpp:1874
 #, c-format
 msgid "Executable%s"
 msgstr "Abiarazgarria%s"
 
-#: src/PrefsUnifiedDlg.cpp:1988
+#: src/PrefsUnifiedDlg.cpp:1908
 msgid "ffprobe not found on PATH or in the standard install locations. Install ffmpeg (which ships ffprobe) or use Browse to pick a binary manually."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2000
+#: src/PrefsUnifiedDlg.cpp:1920
 msgid "Reset the settings on this page to their default values?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2001
+#: src/PrefsUnifiedDlg.cpp:1921
 #, fuzzy
 msgid "Reset to defaults"
 msgstr "Sistema lehenetsia"
 
-#: src/PrefsUnifiedDlg.cpp:2028
+#: src/PrefsUnifiedDlg.cpp:1948
 msgid "Edit server list"
 msgstr "Editatu zerbitzari zerrenda"
 
-#: src/PrefsUnifiedDlg.cpp:2029
+#: src/PrefsUnifiedDlg.cpp:1949
 msgid ""
 "Add here URL's to download server.met files.\n"
 "Only one url on each line."
@@ -6020,180 +5972,176 @@ msgstr ""
 "Gehitu hemen server.met deskargatzeko URL-a.\n"
 "URL helbide bat lerro bakoitzean."
 
-#: src/PrefsUnifiedDlg.cpp:2084
+#: src/PrefsUnifiedDlg.cpp:2004
 msgid "IP2Country update failed"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2229 src/PrefsUnifiedDlg.cpp:2260
+#: src/PrefsUnifiedDlg.cpp:2149 src/PrefsUnifiedDlg.cpp:2180
 msgid "Data by MaxMind GeoLite2"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2231 src/PrefsUnifiedDlg.cpp:2262
+#: src/PrefsUnifiedDlg.cpp:2151 src/PrefsUnifiedDlg.cpp:2182
 #, fuzzy
 msgid "Custom source"
 msgstr "Jatorri osoak"
 
-#: src/PrefsUnifiedDlg.cpp:2233 src/PrefsUnifiedDlg.cpp:2264
+#: src/PrefsUnifiedDlg.cpp:2153 src/PrefsUnifiedDlg.cpp:2184
 msgid "Data by DB-IP.com"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2284
+#: src/PrefsUnifiedDlg.cpp:2204
 #, fuzzy, c-format
 msgid "Status: Loaded%s"
 msgstr "Egoera:"
 
-#: src/PrefsUnifiedDlg.cpp:2286
+#: src/PrefsUnifiedDlg.cpp:2206
 #, fuzzy, c-format
 msgid "Status: Loaded%s - %s"
 msgstr "Egoera:"
 
-#: src/PrefsUnifiedDlg.cpp:2290
+#: src/PrefsUnifiedDlg.cpp:2210
 msgid "Status: Failed to load - click 'Update now' to refresh."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2292
+#: src/PrefsUnifiedDlg.cpp:2212
 msgid "Status: Not found - click 'Update now' to download."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2350 src/PrefsUnifiedDlg.cpp:2374
+#: src/PrefsUnifiedDlg.cpp:2270 src/PrefsUnifiedDlg.cpp:2294
 #, c-format
 msgid "Update delay: %d second"
 msgid_plural "Update delay: %d seconds"
 msgstr[0] "Eguneratze maiztasuna: seg %d"
 msgstr[1] "Eguneratze maiztasuna: %d seg"
 
-#: src/PrefsUnifiedDlg.cpp:2358
+#: src/PrefsUnifiedDlg.cpp:2278
 #, c-format
 msgid "Time for average graph: %d minute"
 msgid_plural "Time for average graph: %d minutes"
 msgstr[0] "Batez besteko grafiko denbora: minutu %d"
 msgstr[1] "Batez besteko grafiko denbora: %d minutu"
 
-#: src/PrefsUnifiedDlg.cpp:2367
+#: src/PrefsUnifiedDlg.cpp:2287
 #, c-format
 msgid "Connections Graph Scale: %d"
 msgstr "Konexio grafiko eskala: %d"
 
-#: src/PrefsUnifiedDlg.cpp:2382
+#: src/PrefsUnifiedDlg.cpp:2302
 #, c-format
 msgid "File Buffer Size: %d byte"
 msgid_plural "File Buffer Size: %d bytes"
 msgstr[0] "Fitxategi buffer tamaina: byte %d"
 msgstr[1] "Fitxategi buffer tamaina: %d byte"
 
-#: src/PrefsUnifiedDlg.cpp:2392
+#: src/PrefsUnifiedDlg.cpp:2312
 #, c-format
 msgid "Upload Queue Size: %d client"
 msgid_plural "Upload Queue Size: %d clients"
 msgstr[0] "Igoera ilara tamaina: bezero %d"
 msgstr[1] "Igoera ilara tamaina: %d bezero"
 
-#: src/PrefsUnifiedDlg.cpp:2402
+#: src/PrefsUnifiedDlg.cpp:2322
 #, c-format
 msgid "Server connection refresh interval: %d minute"
 msgid_plural "Server connection refresh interval: %d minutes"
 msgstr[0] "Zerbitzari konexio berritze maiztasuna: minutu %d"
 msgstr[1] "Zerbitzari konexio berritze maiztasuna: %d minutu"
 
-#: src/PrefsUnifiedDlg.cpp:2407
+#: src/PrefsUnifiedDlg.cpp:2327
 msgid "Server connection refresh interval: Disabled"
 msgstr "Zerbitzarira konexio berritze maiztasuna: Ezgaiturik"
 
-#: src/PrefsUnifiedDlg.cpp:2451
+#: src/PrefsUnifiedDlg.cpp:2371
 msgid "disabled"
 msgstr "ezgaiturik"
 
-#: src/PrefsUnifiedDlg.cpp:2477
+#: src/PrefsUnifiedDlg.cpp:2397
 #, c-format
 msgid "Execute command on '%s' event"
 msgstr "Gertaeran'%s' komandoa exekutatu"
 
-#: src/PrefsUnifiedDlg.cpp:2484
+#: src/PrefsUnifiedDlg.cpp:2404
 msgid "Enable command execution on core"
 msgstr "Gaitu komando exekuzioa muinean"
 
-#: src/PrefsUnifiedDlg.cpp:2496
+#: src/PrefsUnifiedDlg.cpp:2416
 msgid "Core command:"
 msgstr "Muin komandoa:"
 
-#: src/PrefsUnifiedDlg.cpp:2512
+#: src/PrefsUnifiedDlg.cpp:2432
 msgid "Enable command execution on GUI"
 msgstr "Gaitu komando exekuzioa urruneko interfazean"
 
-#: src/PrefsUnifiedDlg.cpp:2524
+#: src/PrefsUnifiedDlg.cpp:2444
 msgid "GUI command:"
 msgstr "Urruneko interfaze komandoa:"
 
-#: src/PrefsUnifiedDlg.cpp:2540
+#: src/PrefsUnifiedDlg.cpp:2460
 msgid "The following variables will be replaced:"
 msgstr "Hurrengo aldagaiak aldatuko dira:"
 
-#: src/PrefsUnifiedDlg.cpp:2708
+#: src/PrefsUnifiedDlg.cpp:2628
 msgid ""
 "The following folders look like system or sensitive locations:\n"
 "\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2713
+#: src/PrefsUnifiedDlg.cpp:2633
 msgid "Sharing them recursively will publish every file underneath on the eD2k/Kad networks. Do you really want to do this?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2716
+#: src/PrefsUnifiedDlg.cpp:2636
 #, fuzzy
 msgid "Confirm shared folders"
 msgstr "Partekatutako karpetak"
 
-#: src/PrefsUnifiedDlg.cpp:2744
+#: src/PrefsUnifiedDlg.cpp:2664
 #, fuzzy
 msgid "Reloading shared files..."
 msgstr "Berritu zure partekatutako fitxategiak"
 
-#: src/PrefsUnifiedDlg.cpp:2745
+#: src/PrefsUnifiedDlg.cpp:2665
 msgid "Scanning for subdirectories..."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2746
+#: src/PrefsUnifiedDlg.cpp:2666
 #, fuzzy
 msgid "Updating shared folders"
 msgstr "Partekatutako karpetak"
 
-#: src/PrefsUnifiedDlg.cpp:2773
+#: src/PrefsUnifiedDlg.cpp:2693
 #, c-format
 msgid "Scanned %u directories..."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2823
+#: src/PrefsUnifiedDlg.cpp:2743
 #, fuzzy, c-format
 msgid "Reloading shared files: %u files scanned"
 msgstr "Partekatutako fitxategi zerrenda birkargatu."
 
-#: src/PrefsUnifiedDlg.cpp:2873
+#: src/PrefsUnifiedDlg.cpp:2793
 #, fuzzy
 msgid "Shared folder"
 msgstr "Partekatutako karpetak"
 
-#: src/SearchDlg.cpp:280
-msgid "Clear search history"
-msgstr ""
-
-#: src/SearchDlg.cpp:584
+#: src/SearchDlg.cpp:425
 msgid "It's impossible to search when both eD2k and Kademlia are disabled."
 msgstr ""
 
-#: src/SearchDlg.cpp:585 src/SearchListCtrl.cpp:858
+#: src/SearchDlg.cpp:426 src/SearchListCtrl.cpp:858
 #, fuzzy
 msgid "Search error"
 msgstr "Bilaketak"
 
-#: src/SearchDlg.cpp:929
+#: src/SearchDlg.cpp:768
 msgid "Min size must be smaller than max size. Max size ignored."
 msgstr "Gutxienezko tamaina gehienezkoa baino txikiagoa izan behar da. Gehienezkoa alde batetara utziko da."
 
-#: src/SearchDlg.cpp:930 src/SearchDlg.cpp:1012
+#: src/SearchDlg.cpp:769 src/SearchDlg.cpp:851
 msgid "Search warning"
 msgstr "Bilaketa oharra"
 
-#: src/SearchDlg.cpp:1092 src/SearchListCtrl.cpp:735
+#: src/SearchDlg.cpp:929 src/SearchListCtrl.cpp:735
 msgid "Main"
 msgstr "Nagusia"
 

--- a/po/eu.po
+++ b/po/eu.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-28 12:17+0200\n"
+"POT-Creation-Date: 2026-07-28 13:09+0200\n"
 "PO-Revision-Date: 2026-07-27 11:37+0000\n"
 "Last-Translator: Piarres Beobide <pi@beobide.net>\n"
 "Language-Team: Euskara <librezale@librezale.org>\n"
@@ -293,7 +293,7 @@ msgid "Password set and external connections enabled."
 msgstr "Pasahitza ezarria eta kanpo konexioak gaiturik."
 
 #: src/amule.cpp:755 src/KadDlg.cpp:176 src/KadDlg.cpp:185
-#: src/PrefsUnifiedDlg.cpp:1461 src/SharedFilesCtrl.cpp:476
+#: src/PrefsUnifiedDlg.cpp:1470 src/SharedFilesCtrl.cpp:476
 msgid "WARNING"
 msgstr "OHARRA"
 
@@ -331,7 +331,7 @@ msgstr "Abioan web-zerbitzaria exekutatzea eskatu duzu, baina amuleweb bitarra e
 #: src/amule-remote-gui.cpp:603 src/amule-remote-gui.cpp:671
 #: src/amule-remote-gui.cpp:709 src/amule-remote-gui.cpp:1282
 #: src/amule-remote-gui.cpp:1345 src/amule-remote-gui.cpp:1372
-#: src/DownloadQueue.cpp:1481 src/PrefsUnifiedDlg.cpp:1247
+#: src/DownloadQueue.cpp:1481 src/PrefsUnifiedDlg.cpp:1256
 msgid "ERROR"
 msgstr "ERROREA"
 
@@ -593,36 +593,36 @@ msgstr "Bisitatu https://github.com/amule-org/amule/releases/latest gunea bertsi
 msgid "FATAL ERROR: Failed to create Timer"
 msgstr "ERRORE KONPONEZINA: Huts kronometroa sortzean"
 
-#: src/amuleDlg.cpp:361 src/amuleDlg.cpp:1787 src/amuleDlg.cpp:2033
-#: src/muuli_wdr.cpp:1492 src/muuli_wdr.cpp:3449
+#: src/amuleDlg.cpp:361 src/amuleDlg.cpp:1810 src/amuleDlg.cpp:2056
+#: src/muuli_wdr.cpp:1492 src/muuli_wdr.cpp:3453
 msgid "Networks"
 msgstr "Sareak"
 
-#: src/amuleDlg.cpp:362 src/amuleDlg.cpp:1793 src/muuli_wdr.cpp:3450
+#: src/amuleDlg.cpp:362 src/amuleDlg.cpp:1816 src/muuli_wdr.cpp:3454
 msgid "Searches"
 msgstr "Bilaketak"
 
-#: src/amuleDlg.cpp:363 src/amuleDlg.cpp:1799 src/DownloadListCtrl.cpp:740
-#: src/muuli_wdr.cpp:392 src/muuli_wdr.cpp:1585 src/muuli_wdr.cpp:3451
+#: src/amuleDlg.cpp:363 src/amuleDlg.cpp:1822 src/DownloadListCtrl.cpp:740
+#: src/muuli_wdr.cpp:392 src/muuli_wdr.cpp:1585 src/muuli_wdr.cpp:3455
 #: src/Statistics.cpp:829
 msgid "Downloads"
 msgstr "Deskargak"
 
-#: src/amuleDlg.cpp:364 src/amuleDlg.cpp:1805 src/muuli_wdr.cpp:3325
+#: src/amuleDlg.cpp:364 src/amuleDlg.cpp:1828 src/muuli_wdr.cpp:3329
 msgid "Shared files"
 msgstr "Partekatutako fitxategiak"
 
-#: src/amuleDlg.cpp:365 src/amuleDlg.cpp:1811 src/muuli_wdr.cpp:2957
-#: src/muuli_wdr.cpp:3407 src/muuli_wdr.cpp:3454
+#: src/amuleDlg.cpp:365 src/amuleDlg.cpp:1834 src/muuli_wdr.cpp:2961
+#: src/muuli_wdr.cpp:3411 src/muuli_wdr.cpp:3458
 msgid "Messages"
 msgstr "Mezuak"
 
-#: src/amuleDlg.cpp:366 src/amuleDlg.cpp:1817 src/muuli_wdr.cpp:3455
+#: src/amuleDlg.cpp:366 src/amuleDlg.cpp:1840 src/muuli_wdr.cpp:3459
 #: src/PrefsUnifiedDlg.cpp:314 src/Statistics.cpp:779 src/Statistics.cpp:1235
 msgid "Statistics"
 msgstr "Estatistikak"
 
-#: src/amuleDlg.cpp:368 src/amuleDlg.cpp:1824 src/muuli_wdr.cpp:3457
+#: src/amuleDlg.cpp:368 src/amuleDlg.cpp:1847 src/muuli_wdr.cpp:3461
 #: src/PrefsUnifiedDlg.cpp:330 src/utils/wxCas/src/wxcasprefs.cpp:39
 msgid "Preferences"
 msgstr "Hobespenak"
@@ -681,8 +681,8 @@ msgstr "Kad: Itzalia"
 #: src/amuleDlg.cpp:1029 src/DownloadListCtrl.cpp:505
 #: src/DownloadListCtrl.cpp:749 src/FriendListCtrl.cpp:180
 #: src/muuli_wdr.cpp:731 src/muuli_wdr.cpp:782 src/muuli_wdr.cpp:846
-#: src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2262 src/muuli_wdr.cpp:2347
-#: src/muuli_wdr.cpp:3095 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
+#: src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2266 src/muuli_wdr.cpp:2351
+#: src/muuli_wdr.cpp:3099 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
 #: src/ServerListCtrl.cpp:606 src/TransferWnd.cpp:378
 #: src/utils/wxCas/src/wxcasprefs.cpp:235
 msgid "Cancel"
@@ -693,7 +693,7 @@ msgid "Stop the current connection attempts"
 msgstr "Geratu uneko konexio saiakerak"
 
 #: src/amuleDlg.cpp:1035 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976
-#: src/muuli_wdr.cpp:2485
+#: src/muuli_wdr.cpp:2489
 msgid "Disconnect"
 msgstr "Deskonektatu"
 
@@ -702,7 +702,7 @@ msgid "Disconnect from the currently connected networks"
 msgstr "Deskonektatu konektatutako sareetatik"
 
 #: src/amuleDlg.cpp:1041 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979
-#: src/muuli_wdr.cpp:2640 src/muuli_wdr.cpp:3092 src/muuli_wdr.cpp:3447
+#: src/muuli_wdr.cpp:2644 src/muuli_wdr.cpp:3096 src/muuli_wdr.cpp:3451
 msgid "Connect"
 msgstr "Konektatu"
 
@@ -757,7 +757,7 @@ msgstr "Irteera berrespena"
 msgid "Launch Command: "
 msgstr "Abiarazi komandoa: "
 
-#: src/amuleDlg.cpp:1632 src/muuli_wdr.cpp:1982 src/Preferences.cpp:979
+#: src/amuleDlg.cpp:1632 src/muuli_wdr.cpp:1986 src/Preferences.cpp:979
 msgid "- default -"
 msgstr "- lehenetsia -"
 
@@ -771,60 +771,60 @@ msgstr "Ez dago '%s' itxura direktorioa"
 msgid "WARNING: Unable to open skin file '%s' for read"
 msgstr "ABISUA: Ezin da '%s' azal fitxategia irakurri"
 
-#: src/amuleDlg.cpp:1791 src/muuli_wdr.cpp:3449
+#: src/amuleDlg.cpp:1814 src/muuli_wdr.cpp:3453
 msgid "Networks Window"
 msgstr "Sare leihoa"
 
-#: src/amuleDlg.cpp:1797 src/muuli_wdr.cpp:3450
+#: src/amuleDlg.cpp:1820 src/muuli_wdr.cpp:3454
 msgid "Searches Window"
 msgstr "Bilaketa leihoa"
 
-#: src/amuleDlg.cpp:1803 src/muuli_wdr.cpp:3451
+#: src/amuleDlg.cpp:1826 src/muuli_wdr.cpp:3455
 msgid "Downloads Window"
 msgstr "Deskargak leihoa"
 
-#: src/amuleDlg.cpp:1809 src/muuli_wdr.cpp:3453
+#: src/amuleDlg.cpp:1832 src/muuli_wdr.cpp:3457
 msgid "Shared Files Window"
 msgstr "Partekatutako fitxategi leihoa"
 
-#: src/amuleDlg.cpp:1815 src/muuli_wdr.cpp:3454
+#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3458
 msgid "Messages Window"
 msgstr "Mezu leihoa"
 
-#: src/amuleDlg.cpp:1821 src/muuli_wdr.cpp:3455
+#: src/amuleDlg.cpp:1844 src/muuli_wdr.cpp:3459
 msgid "Statistics Graph Window"
 msgstr "Estatistika grafiko leihoa"
 
-#: src/amuleDlg.cpp:1828 src/muuli_wdr.cpp:3457
+#: src/amuleDlg.cpp:1851 src/muuli_wdr.cpp:3461
 msgid "Preferences Settings Window"
 msgstr "Hobespen ezarpen leihoa"
 
-#: src/amuleDlg.cpp:1831 src/muuli_wdr.cpp:3458
+#: src/amuleDlg.cpp:1854 src/muuli_wdr.cpp:3462
 msgid "Import"
 msgstr "Inportatu"
 
-#: src/amuleDlg.cpp:1835 src/muuli_wdr.cpp:3458
+#: src/amuleDlg.cpp:1858 src/muuli_wdr.cpp:3462
 msgid "The partfile importer tool"
 msgstr "Zati fitxategi inportazio tresna"
 
-#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3459
+#: src/amuleDlg.cpp:1861 src/muuli_wdr.cpp:3463
 #: src/utils/aLinkCreator/src/alcframe.cpp:262
 msgid "About"
 msgstr "Honi buruz"
 
-#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3459
+#: src/amuleDlg.cpp:1861 src/muuli_wdr.cpp:3463
 msgid "About/Help"
 msgstr "Honi buruz/Laguntza"
 
-#: src/amuleDlg.cpp:2036
+#: src/amuleDlg.cpp:2059
 msgid "eD2k network"
 msgstr "eD2k sarea"
 
-#: src/amuleDlg.cpp:2039
+#: src/amuleDlg.cpp:2062
 msgid "Kad network"
 msgstr "Kad sarea"
 
-#: src/amuleDlg.cpp:2039
+#: src/amuleDlg.cpp:2062
 msgid "No network"
 msgstr "Sarerik ez"
 
@@ -1357,19 +1357,19 @@ msgstr "Auto[Alt]"
 msgid "Very low"
 msgstr "Oso txikia"
 
-#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:743 src/muuli_wdr.cpp:2313
+#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:743 src/muuli_wdr.cpp:2317
 #: src/ServerListCtrl.cpp:263 src/ServerListCtrl.cpp:456
 #: src/SharedFilesCtrl.cpp:145
 msgid "Low"
 msgstr "Baxua"
 
-#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:744 src/muuli_wdr.cpp:2314
+#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:744 src/muuli_wdr.cpp:2318
 #: src/ServerListCtrl.cpp:266 src/ServerListCtrl.cpp:457
 #: src/SharedFilesCtrl.cpp:146
 msgid "Normal"
 msgstr "Normala"
 
-#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:745 src/muuli_wdr.cpp:2315
+#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:745 src/muuli_wdr.cpp:2319
 #: src/ServerListCtrl.cpp:269 src/ServerListCtrl.cpp:458
 #: src/SharedFilesCtrl.cpp:147
 msgid "High"
@@ -1461,7 +1461,7 @@ msgstr "Zerbitzari lokala"
 msgid "Remote Server"
 msgstr "Urruneko zerbitzaria"
 
-#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3212
+#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3216
 #: src/SearchDlg.cpp:119 src/TextClient.cpp:911
 msgid "Kad"
 msgstr "Kad"
@@ -1533,7 +1533,7 @@ msgstr "Zatia"
 msgid "Size"
 msgstr "Tamaina"
 
-#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3279
+#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3283
 msgid "Transferred"
 msgstr "Transferituta"
 
@@ -1591,7 +1591,7 @@ msgstr ""
 "Erantzuna hemendik: %s (%s)\n"
 "\n"
 
-#: src/DownloadListCtrl.cpp:746 src/muuli_wdr.cpp:2316
+#: src/DownloadListCtrl.cpp:746 src/muuli_wdr.cpp:2320
 #: src/SharedFilesCtrl.cpp:150
 msgid "Auto"
 msgstr "Auto"
@@ -1629,7 +1629,7 @@ msgid "Extended Options"
 msgstr "Hedatutako aukerak"
 
 #: src/DownloadListCtrl.cpp:770 src/DownloadListCtrl.cpp:822
-#: src/muuli_wdr.cpp:1800
+#: src/muuli_wdr.cpp:1804
 msgid "Preview"
 msgstr "Aurrebista"
 
@@ -2430,23 +2430,23 @@ msgid ""
 "want downloads on a different (e.g. larger) disk."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:549 src/FirstRunWizard.cpp:611 src/muuli_wdr.cpp:1712
+#: src/FirstRunWizard.cpp:549 src/FirstRunWizard.cpp:611 src/muuli_wdr.cpp:1716
 msgid "Destination folder for downloads"
 msgstr "Deskargentzat helburu karpeta"
 
 #: src/FirstRunWizard.cpp:553 src/FirstRunWizard.cpp:569 src/muuli_wdr.cpp:1349
-#: src/muuli_wdr.cpp:1366 src/muuli_wdr.cpp:1687 src/muuli_wdr.cpp:1718
-#: src/muuli_wdr.cpp:1730 src/muuli_wdr.cpp:2800
+#: src/muuli_wdr.cpp:1366 src/muuli_wdr.cpp:1691 src/muuli_wdr.cpp:1722
+#: src/muuli_wdr.cpp:1734 src/muuli_wdr.cpp:2804
 #: src/utils/aLinkCreator/src/alcframe.cpp:135
 #: src/utils/wxCas/src/wxcasprefs.cpp:52 src/utils/wxCas/src/wxcasprefs.cpp:118
 msgid "Browse"
 msgstr "Arakatu"
 
-#: src/FirstRunWizard.cpp:559 src/muuli_wdr.cpp:1723
+#: src/FirstRunWizard.cpp:559 src/muuli_wdr.cpp:1727
 msgid "(All files in this folder are shared with other peers)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:565 src/FirstRunWizard.cpp:624 src/muuli_wdr.cpp:1725
+#: src/FirstRunWizard.cpp:565 src/FirstRunWizard.cpp:624 src/muuli_wdr.cpp:1729
 msgid "Folder for temporary download files"
 msgstr "Aldiroko deskarga fitxategientzat karpeta"
 
@@ -2477,7 +2477,7 @@ msgstr "Huts 'emfriends.met' lagun zerrenda fitxategia idazteko irekitzean!"
 msgid "CRITICAL - no client on StartChatSession"
 msgstr "KRITIKOA - ez dago bezerorik StartChatSession-en"
 
-#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2706 src/muuli_wdr.cpp:3383
+#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2710 src/muuli_wdr.cpp:3387
 msgid "Friends"
 msgstr "Lagunak"
 
@@ -2588,8 +2588,8 @@ msgstr "Batez"
 msgid "No"
 msgstr "Ez"
 
-#: src/GenericClientListCtrl.cpp:1216 src/PrefsUnifiedDlg.cpp:2898
-#: src/PrefsUnifiedDlg.cpp:2948 src/ServerListCtrl.cpp:276
+#: src/GenericClientListCtrl.cpp:1216 src/PrefsUnifiedDlg.cpp:2907
+#: src/PrefsUnifiedDlg.cpp:2957 src/ServerListCtrl.cpp:276
 msgid "Yes"
 msgstr "Bai"
 
@@ -2758,10 +2758,10 @@ msgstr "Abiarazteko ataka baliogabea"
 msgid "Please fill all fields required"
 msgstr "Beharrezko eremu guztiak bete"
 
-#: src/KadDlg.cpp:192 src/PartFile.cpp:1031 src/PrefsUnifiedDlg.cpp:1134
-#: src/PrefsUnifiedDlg.cpp:1204 src/PrefsUnifiedDlg.cpp:1405
-#: src/PrefsUnifiedDlg.cpp:1663 src/PrefsUnifiedDlg.cpp:1673
-#: src/PrefsUnifiedDlg.cpp:1690 src/PrefsUnifiedDlg.cpp:1738
+#: src/KadDlg.cpp:192 src/PartFile.cpp:1031 src/PrefsUnifiedDlg.cpp:1143
+#: src/PrefsUnifiedDlg.cpp:1213 src/PrefsUnifiedDlg.cpp:1414
+#: src/PrefsUnifiedDlg.cpp:1672 src/PrefsUnifiedDlg.cpp:1682
+#: src/PrefsUnifiedDlg.cpp:1699 src/PrefsUnifiedDlg.cpp:1747
 msgid "Message"
 msgstr "Mezua"
 
@@ -2863,7 +2863,7 @@ msgstr "Partekatze erlazioa"
 msgid "Uploaded"
 msgstr "Igoa"
 
-#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3263
+#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3267
 msgid "Requested"
 msgstr "Eskatutakoa"
 
@@ -2987,7 +2987,7 @@ msgid "WARNING: "
 msgstr "OHARRA: "
 
 #: src/MuleNotebook.cpp:179 src/muuli_wdr.cpp:817 src/muuli_wdr.cpp:1229
-#: src/muuli_wdr.cpp:3167 src/muuli_wdr.cpp:3423
+#: src/muuli_wdr.cpp:3171 src/muuli_wdr.cpp:3427
 msgid "Close"
 msgstr "Itxi"
 
@@ -3005,7 +3005,7 @@ msgid "Paste"
 msgstr "Itsatsi"
 
 #: src/MuleTextCtrl.cpp:89 src/muuli_wdr.cpp:358 src/muuli_wdr.cpp:757
-#: src/muuli_wdr.cpp:2390 src/muuli_wdr.cpp:2409 src/muuli_wdr.cpp:2431
+#: src/muuli_wdr.cpp:2394 src/muuli_wdr.cpp:2413 src/muuli_wdr.cpp:2435
 #: src/utils/aLinkCreator/src/alcframe.cpp:142
 msgid "Clear"
 msgstr "Garbitu"
@@ -3104,7 +3104,7 @@ msgstr "Irten"
 
 #: src/MuleTrayIcon.cpp:579 src/MuleTrayIcon.cpp:945 src/MuleTrayIcon.cpp:965
 #: src/muuli_wdr.cpp:1398 src/muuli_wdr.cpp:1406 src/muuli_wdr.cpp:1413
-#: src/muuli_wdr.cpp:1846 src/muuli_wdr.cpp:1852 src/OtherFunctions.cpp:91
+#: src/muuli_wdr.cpp:1850 src/muuli_wdr.cpp:1856 src/OtherFunctions.cpp:91
 #: src/StatisticsDlg.cpp:93 src/StatisticsDlg.cpp:95
 msgid "kB/s"
 msgstr "kB/s"
@@ -3346,7 +3346,7 @@ msgstr "Byte"
 msgid "KB"
 msgstr "KB"
 
-#: src/muuli_wdr.cpp:274 src/muuli_wdr.cpp:293 src/muuli_wdr.cpp:1631
+#: src/muuli_wdr.cpp:274 src/muuli_wdr.cpp:293 src/muuli_wdr.cpp:1635
 #: src/OtherFunctions.cpp:64
 msgid "MB"
 msgstr "MB"
@@ -3363,7 +3363,7 @@ msgstr "Gehi. tamaina"
 msgid "Availability"
 msgstr "Eskuragarritasuna"
 
-#: src/muuli_wdr.cpp:312 src/muuli_wdr.cpp:398 src/muuli_wdr.cpp:3328
+#: src/muuli_wdr.cpp:312 src/muuli_wdr.cpp:398 src/muuli_wdr.cpp:3332
 msgid "Filter:"
 msgstr "Iragazkia:"
 
@@ -3426,8 +3426,8 @@ msgstr "Fitxategiaren iturburua:"
 #: src/muuli_wdr.cpp:1160 src/muuli_wdr.cpp:1167 src/muuli_wdr.cpp:1172
 #: src/muuli_wdr.cpp:1179 src/muuli_wdr.cpp:1184 src/muuli_wdr.cpp:1191
 #: src/muuli_wdr.cpp:1205 src/muuli_wdr.cpp:1212 src/muuli_wdr.cpp:1217
-#: src/muuli_wdr.cpp:1224 src/muuli_wdr.cpp:3265 src/muuli_wdr.cpp:3273
-#: src/muuli_wdr.cpp:3281
+#: src/muuli_wdr.cpp:1224 src/muuli_wdr.cpp:3269 src/muuli_wdr.cpp:3277
+#: src/muuli_wdr.cpp:3285
 msgid "N/A"
 msgstr "E/G"
 
@@ -3572,7 +3572,7 @@ msgstr ""
 msgid "Album :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:685 src/muuli_wdr.cpp:2285
+#: src/muuli_wdr.cpp:685 src/muuli_wdr.cpp:2289
 msgid "Title :"
 msgstr "Titulua :"
 
@@ -3681,7 +3681,7 @@ msgstr "Erabiltzaile-izena :"
 msgid "Userhash :"
 msgstr "Erabiltzaile aztertze zenbakia :"
 
-#: src/muuli_wdr.cpp:895 src/muuli_wdr.cpp:1752 src/muuli_wdr.cpp:2480
+#: src/muuli_wdr.cpp:895 src/muuli_wdr.cpp:1756 src/muuli_wdr.cpp:2484
 #: src/utils/aLinkCreator/src/alcframe.cpp:137
 msgid "Add"
 msgstr "Gehitu"
@@ -3690,15 +3690,15 @@ msgstr "Gehitu"
 msgid "Download-Speed"
 msgstr "Deskarga abiadura"
 
-#: src/muuli_wdr.cpp:954 src/muuli_wdr.cpp:989 src/muuli_wdr.cpp:2584
+#: src/muuli_wdr.cpp:954 src/muuli_wdr.cpp:989 src/muuli_wdr.cpp:2588
 msgid "Current"
 msgstr "Unekoa"
 
-#: src/muuli_wdr.cpp:962 src/muuli_wdr.cpp:997 src/muuli_wdr.cpp:2592
+#: src/muuli_wdr.cpp:962 src/muuli_wdr.cpp:997 src/muuli_wdr.cpp:2596
 msgid "Running average"
 msgstr "Funtzionamendu bataz bestekoa"
 
-#: src/muuli_wdr.cpp:970 src/muuli_wdr.cpp:1005 src/muuli_wdr.cpp:2600
+#: src/muuli_wdr.cpp:970 src/muuli_wdr.cpp:1005 src/muuli_wdr.cpp:2604
 msgid "Session average"
 msgstr "saio batez bestekoa"
 
@@ -3710,7 +3710,7 @@ msgstr "Igoera abiadura"
 msgid "Connections"
 msgstr "Konexioak"
 
-#: src/muuli_wdr.cpp:1024 src/muuli_wdr.cpp:1871
+#: src/muuli_wdr.cpp:1024 src/muuli_wdr.cpp:1875
 msgid "Active downloads"
 msgstr "Deskarga aktiboak"
 
@@ -3718,7 +3718,7 @@ msgstr "Deskarga aktiboak"
 msgid "Active connections (1:1)"
 msgstr "konexio aktiboak (1:1)"
 
-#: src/muuli_wdr.cpp:1040 src/muuli_wdr.cpp:1872
+#: src/muuli_wdr.cpp:1040 src/muuli_wdr.cpp:1876
 msgid "Active uploads"
 msgstr "Igoera aktiboak"
 
@@ -3994,7 +3994,7 @@ msgstr "Lotu helbide lokala IP batetara (zurian edozeinentzat):"
 msgid "Advanced users only: If you have multiple network interfaces, enter the address of the interface to which aMule should be bound."
 msgstr "Erabiltzaile aurreratuak bakarrik: Sare interfaze anitz badituzu idatzi amulek erabili behar duen sare interfazearen helbidea."
 
-#: src/muuli_wdr.cpp:1462 src/muuli_wdr.cpp:2065
+#: src/muuli_wdr.cpp:1462 src/muuli_wdr.cpp:2069
 #, fuzzy
 msgid "Bind to network interface (empty for any):"
 msgstr "Lotu helbide lokala IP batetara (zurian edozeinentzat):"
@@ -4011,7 +4011,7 @@ msgstr "Jatorri muga deskarga bakoitzerako:"
 msgid "Max simultaneous connections:"
 msgstr "Aldibereko konexioa muga:"
 
-#: src/muuli_wdr.cpp:1498 src/muuli_wdr.cpp:3207
+#: src/muuli_wdr.cpp:1498 src/muuli_wdr.cpp:3211
 msgid "ED2K"
 msgstr "ED2K"
 
@@ -4103,778 +4103,778 @@ msgstr "Aurresleitu disko lekua fitxategi berrientzat"
 msgid "For new files preallocates disk space for the whole file, thus reduces fragmentation"
 msgstr "Fitxategi berrientzat fitxategi bakoitzarentzat disko leku osoa aurresleitzen du, honek fragmentazioa murrizten du"
 
-#: src/muuli_wdr.cpp:1617
+#: src/muuli_wdr.cpp:1621
 msgid "Create new files as sparse files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1618
+#: src/muuli_wdr.cpp:1622
 msgid "Sparse part files only occupy disk space for the parts already downloaded, so free space is used up gradually as the file fills in. Turn this off to use an ordinary file instead - useful where sparse files are unsupported or slow, or where backup/de-duplication tools handle them badly. Applies only when the core runs on Windows; on Linux and macOS part files are sparse anyway and this setting has no effect."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1623
+#: src/muuli_wdr.cpp:1627
 msgid "Stop downloads when free disk space reaches "
 msgstr "Gelditu deskargak disko-leku librea hona iristean "
 
-#: src/muuli_wdr.cpp:1624
+#: src/muuli_wdr.cpp:1628
 msgid "Select this if you want aMule to check your disk space"
 msgstr "Aukera hau hautatu aMulek zure disko-lekua egiaztatzea nahi baduzu"
 
-#: src/muuli_wdr.cpp:1628
+#: src/muuli_wdr.cpp:1632
 msgid "Enter here the min disk space desired."
 msgstr "Ezarri hemen nahi duzu disko toki txikiena."
 
-#: src/muuli_wdr.cpp:1634
+#: src/muuli_wdr.cpp:1638
 msgid "Save 10 sources on rare files (< 20 sources)"
 msgstr "10 jatorri gorde fitxategi arraroentzat (< 20 jatorri)"
 
-#: src/muuli_wdr.cpp:1638 src/Statistics.cpp:790
+#: src/muuli_wdr.cpp:1642 src/Statistics.cpp:790
 msgid "Uploads"
 msgstr "Igoerak"
 
-#: src/muuli_wdr.cpp:1641
+#: src/muuli_wdr.cpp:1645
 msgid "Add new shared files with auto priority"
 msgstr "Gehitu partekatutako fitxategi berriak auto-lehentasunarekin"
 
-#: src/muuli_wdr.cpp:1647
+#: src/muuli_wdr.cpp:1651
 msgid "Intelligent Corruption Handling (I.C.H.)"
 msgstr "Hondatze kudeaketa adimentsua (I.C.H)"
 
-#: src/muuli_wdr.cpp:1650
+#: src/muuli_wdr.cpp:1654
 msgid "Enable"
 msgstr "Gaitu"
 
-#: src/muuli_wdr.cpp:1653
+#: src/muuli_wdr.cpp:1657
 msgid "Advanced I.C.H. trusts every hash (not recommended)"
 msgstr "I.C.H aurreratuak, egiaztapen bakoitza egiaztatzen du (ez da gomendatzen)"
 
-#: src/muuli_wdr.cpp:1665 src/PrefsUnifiedDlg.cpp:1990
+#: src/muuli_wdr.cpp:1669 src/PrefsUnifiedDlg.cpp:1999
 msgid "Media metadata extraction"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1669
+#: src/muuli_wdr.cpp:1673
 msgid "Extract length / bitrate / codec from shared audio and video files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1671
+#: src/muuli_wdr.cpp:1675
 msgid "When enabled, aMule runs ffprobe on each shared media file to fill in the Length / Bitrate / Codec columns other clients see when they find the file in a search. Requires ffmpeg (the ffprobe binary) to be installed."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1678
+#: src/muuli_wdr.cpp:1682
 msgid "Path to ffprobe:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1683
+#: src/muuli_wdr.cpp:1687
 msgid "Full path to the ffprobe binary. Leave empty to have aMule auto-detect it on startup."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1691
+#: src/muuli_wdr.cpp:1695
 msgid "Detect"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1692
+#: src/muuli_wdr.cpp:1696
 msgid "Search the standard install locations for an ffprobe binary and fill the path field."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1716
+#: src/muuli_wdr.cpp:1720
 msgid ""
 "Completed downloads are stored here. All files in this folder are automatically shared with other peers.\n"
 "If this folder also holds files you don't want to share, point it at an aMule-only sub-folder."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1719
+#: src/muuli_wdr.cpp:1723
 msgid "Pick the folder where completed downloads will be stored. All files in that folder will be shared with other peers."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1733
+#: src/muuli_wdr.cpp:1737
 msgid "Shared folders"
 msgstr "Partekatutako karpetak"
 
-#: src/muuli_wdr.cpp:1739
+#: src/muuli_wdr.cpp:1743
 msgid "(Folders shared by the core. Enter a path to add one.)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1747
+#: src/muuli_wdr.cpp:1751
 msgid "Absolute path of a folder on the core's machine, e.g. /home/user/shared"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1749 src/PrefsUnifiedDlg.cpp:2874
+#: src/muuli_wdr.cpp:1753 src/PrefsUnifiedDlg.cpp:2883
 msgid "Recursive"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1750
+#: src/muuli_wdr.cpp:1754
 msgid "Share every sub-folder underneath this one, including ones created later."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1754 src/utils/aLinkCreator/src/alcframe.cpp:141
+#: src/muuli_wdr.cpp:1758 src/utils/aLinkCreator/src/alcframe.cpp:141
 msgid "Remove"
 msgstr "Ezabatu"
 
-#: src/muuli_wdr.cpp:1758
+#: src/muuli_wdr.cpp:1762
 msgid "(Right click on folder icon for recursive share)"
 msgstr "(Egin klik eskuineko botoiaz karpeta ikono batean barnekoak ere partekatzeko)"
 
-#: src/muuli_wdr.cpp:1765
+#: src/muuli_wdr.cpp:1769
 msgid "Share hidden files"
 msgstr "Partekatu ezkutatutako fitxategiak"
 
-#: src/muuli_wdr.cpp:1771
+#: src/muuli_wdr.cpp:1775
 msgid "Automatically rescan shared folders for changes"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1777
+#: src/muuli_wdr.cpp:1781
 msgid "Follow symbolic links in shared folders"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1783
+#: src/muuli_wdr.cpp:1787
 msgid "Exclude files matching:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1786
+#: src/muuli_wdr.cpp:1790
 msgid "Wildcard patterns separated by '|', e.g. .DS_Store|Thumbs.db|*.tmp. Files whose name matches are not shared. Matching is case-insensitive."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1790
+#: src/muuli_wdr.cpp:1794
 msgid "Patterns are regular expressions"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1791
+#: src/muuli_wdr.cpp:1795
 msgid "When set, the whole field is one regular expression ('|' is alternation). When unset, it is a list of '|'-separated wildcards."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1801
+#: src/muuli_wdr.cpp:1805
 msgid "Show how many shared files the current pattern would exclude."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1822
+#: src/muuli_wdr.cpp:1826
 msgid "Graphs"
 msgstr "Grafikak"
 
-#: src/muuli_wdr.cpp:1825 src/muuli_wdr.cpp:1887
+#: src/muuli_wdr.cpp:1829 src/muuli_wdr.cpp:1891
 msgid "Update delay : 5 secs"
 msgstr "Eguneratze atzerapena : 5 seg"
 
-#: src/muuli_wdr.cpp:1829
+#: src/muuli_wdr.cpp:1833
 msgid "Time for average graph: 100 mins"
 msgstr "Bataz besteko grafiko denbora : 100 min"
 
-#: src/muuli_wdr.cpp:1833
+#: src/muuli_wdr.cpp:1837
 msgid "Connections Graph Scale: 100 "
 msgstr "Konexio graf eskala: 100 "
 
-#: src/muuli_wdr.cpp:1840
+#: src/muuli_wdr.cpp:1844
 msgid "Download graph scale:"
 msgstr "Deskarga grafiko eskala:"
 
-#: src/muuli_wdr.cpp:1848
+#: src/muuli_wdr.cpp:1852
 msgid "Upload graph scale:"
 msgstr "Igoera grafiko eskala:"
 
-#: src/muuli_wdr.cpp:1858
+#: src/muuli_wdr.cpp:1862
 #, fuzzy
 msgid "Colors: "
 msgstr "Koloreak: "
 
-#: src/muuli_wdr.cpp:1862
+#: src/muuli_wdr.cpp:1866
 msgid "Background"
 msgstr "Atzeko planoa"
 
-#: src/muuli_wdr.cpp:1863
+#: src/muuli_wdr.cpp:1867
 msgid "Grid"
 msgstr "Sareta"
 
-#: src/muuli_wdr.cpp:1864
+#: src/muuli_wdr.cpp:1868
 msgid "Download current"
 msgstr "Uneko deskargak"
 
-#: src/muuli_wdr.cpp:1865
+#: src/muuli_wdr.cpp:1869
 msgid "Download running average"
 msgstr "Martxan deskargak bataz bestean"
 
-#: src/muuli_wdr.cpp:1866
+#: src/muuli_wdr.cpp:1870
 msgid "Download session average"
 msgstr "Saioaren bataz besteko deskargak"
 
-#: src/muuli_wdr.cpp:1867
+#: src/muuli_wdr.cpp:1871
 msgid "Upload current"
 msgstr "Uneko igoerak"
 
-#: src/muuli_wdr.cpp:1868
+#: src/muuli_wdr.cpp:1872
 msgid "Upload running average"
 msgstr "Martxan igoerak bataz bestean"
 
-#: src/muuli_wdr.cpp:1869
+#: src/muuli_wdr.cpp:1873
 msgid "Upload session average"
 msgstr "Saioaren bataz besteko igoerak"
 
-#: src/muuli_wdr.cpp:1870
+#: src/muuli_wdr.cpp:1874
 msgid "Active connections"
 msgstr "Konexio aktiboak"
 
-#: src/muuli_wdr.cpp:1873
+#: src/muuli_wdr.cpp:1877
 #, fuzzy
 msgid "Systray Icon Speed Bar"
 msgstr "Sistema-barra abiadura-barra ikonoa"
 
-#: src/muuli_wdr.cpp:1874
+#: src/muuli_wdr.cpp:1878
 msgid "Kad-nodes current"
 msgstr "Uneko Kad-nodoak"
 
-#: src/muuli_wdr.cpp:1875
+#: src/muuli_wdr.cpp:1879
 msgid "Kad-nodes running"
 msgstr "Kad-nodoak martxan"
 
-#: src/muuli_wdr.cpp:1876
+#: src/muuli_wdr.cpp:1880
 msgid "Kad-nodes session"
 msgstr "Kad-nodo saioa"
 
-#: src/muuli_wdr.cpp:1880 src/muuli_wdr.cpp:2334
+#: src/muuli_wdr.cpp:1884 src/muuli_wdr.cpp:2338
 msgid "Select"
 msgstr "Hautatu"
 
-#: src/muuli_wdr.cpp:1884
+#: src/muuli_wdr.cpp:1888
 msgid "Tree"
 msgstr "Zuhaitza"
 
-#: src/muuli_wdr.cpp:1894
+#: src/muuli_wdr.cpp:1898
 msgid "Number of Client Versions shown (0=unlimited)"
 msgstr "Erakutsiko diren bezero kopurua (0=mugagabea)"
 
-#: src/muuli_wdr.cpp:1919
+#: src/muuli_wdr.cpp:1923
 msgid "!!! WARNING !!!"
 msgstr "!!! KONTUZ !!!"
 
-#: src/muuli_wdr.cpp:1934
+#: src/muuli_wdr.cpp:1938
 msgid "Max new connections / 5 secs"
 msgstr "Gehienezko konexio berri / 5 seg"
 
-#: src/muuli_wdr.cpp:1936
+#: src/muuli_wdr.cpp:1940
 msgid "Concurrent Kad source lookups"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1938
+#: src/muuli_wdr.cpp:1942
 #, fuzzy
 msgid "Kad source re-search interval (minutes)"
 msgstr "FTP igoera aldia minututan"
 
-#: src/muuli_wdr.cpp:1940
+#: src/muuli_wdr.cpp:1944
 #, fuzzy
 msgid "Source re-ask interval (minutes)"
 msgstr "FTP igoera aldia minututan"
 
-#: src/muuli_wdr.cpp:1944
+#: src/muuli_wdr.cpp:1948
 msgid "File Buffer Size: 240000 bytes"
 msgstr "Fitxategia buffer tamaina: 240000 byte"
 
-#: src/muuli_wdr.cpp:1948
+#: src/muuli_wdr.cpp:1952
 msgid "Use MMAP: memory-mapped file access (lower memory use)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1949
+#: src/muuli_wdr.cpp:1953
 msgid "Maps part files into memory instead of buffering them on the heap, lowering the process memory footprint. May reduce download speed on some disks; best for memory-constrained or upload-heavy hosts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1951
+#: src/muuli_wdr.cpp:1955
 msgid "Upload Queue Size: 5000 clients"
 msgstr "Igoera ilara tamaina: 5000 bezero"
 
-#: src/muuli_wdr.cpp:1955
+#: src/muuli_wdr.cpp:1959
 msgid "Server connection refresh interval: Disable"
 msgstr "Zerbitzari konexio berritze aldia: Ezgaiturik"
 
-#: src/muuli_wdr.cpp:1959
+#: src/muuli_wdr.cpp:1963
 msgid "Disable computer's timed standby mode"
 msgstr "Ezgaitu ordenagailu ordulariaren bigarren planoko modua"
 
-#: src/muuli_wdr.cpp:1978
+#: src/muuli_wdr.cpp:1982
 msgid "Skin to use: "
 msgstr "Erabiltzeko azala: "
 
-#: src/muuli_wdr.cpp:1987
+#: src/muuli_wdr.cpp:1991
 msgid "Show \"Fast eD2k Links Handler\" in every window."
 msgstr "Erakutsi \"eD2k lotura kudeatzaile azkarra\" leiho bakoitzean."
 
-#: src/muuli_wdr.cpp:1990
+#: src/muuli_wdr.cpp:1994
 msgid "Show extended info on categories tabs"
 msgstr "Erakutsi argibide hedatuak kategoria fitxetan"
 
-#: src/muuli_wdr.cpp:1993
+#: src/muuli_wdr.cpp:1997
 msgid "Show application version on title"
 msgstr "Erakutsi aplikazio bertsioa izenburuan"
 
-#: src/muuli_wdr.cpp:1995
+#: src/muuli_wdr.cpp:1999
 msgid "Show transfer rates on title"
 msgstr "Erakutsi transferentziak izenburuan"
 
-#: src/muuli_wdr.cpp:1997
+#: src/muuli_wdr.cpp:2001
 msgid "Before application name"
 msgstr "Aplikazio izenaren aurretik"
 
-#: src/muuli_wdr.cpp:1999
+#: src/muuli_wdr.cpp:2003
 msgid "After application name"
 msgstr "Aplikazio izenaren ondoren"
 
-#: src/muuli_wdr.cpp:2002
+#: src/muuli_wdr.cpp:2006
 msgid "Show overhead bandwidth"
 msgstr "Erakutsi goiburu erabilpena"
 
-#: src/muuli_wdr.cpp:2006
+#: src/muuli_wdr.cpp:2010
 msgid "Vertical toolbar orientation"
 msgstr "Tresna-barra bertikal orientazioa"
 
-#: src/muuli_wdr.cpp:2008
+#: src/muuli_wdr.cpp:2012
 msgid "Live column sorting (auto-reorder rows as their values change)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2015
+#: src/muuli_wdr.cpp:2019
 msgid "Download Queue Files"
 msgstr "Deskargatu ilara fitxategiak"
 
-#: src/muuli_wdr.cpp:2018
+#: src/muuli_wdr.cpp:2022
 msgid "Show progress percentage"
 msgstr "Erakutsi aurrerapen ehunekoa"
 
-#: src/muuli_wdr.cpp:2024
+#: src/muuli_wdr.cpp:2028
 msgid "Show progress bar"
 msgstr "Erakutsi aurrerapen barra"
 
-#: src/muuli_wdr.cpp:2027
+#: src/muuli_wdr.cpp:2031
 msgid "Flat"
 msgstr "Laua"
 
-#: src/muuli_wdr.cpp:2031
+#: src/muuli_wdr.cpp:2035
 msgid "Round"
 msgstr "Biribildu"
 
-#: src/muuli_wdr.cpp:2049
+#: src/muuli_wdr.cpp:2053
 msgid "External Connection Parameters"
 msgstr "Urruneko konexio ezarpenak"
 
-#: src/muuli_wdr.cpp:2052
+#: src/muuli_wdr.cpp:2056
 msgid "Accept external connections"
 msgstr "Onartu urruneko konexioak"
 
-#: src/muuli_wdr.cpp:2059 src/muuli_wdr.cpp:2118
+#: src/muuli_wdr.cpp:2063 src/muuli_wdr.cpp:2122
 msgid "IP of the listening interface:"
 msgstr "Entzunean dagoen interfazearen IPa:"
 
-#: src/muuli_wdr.cpp:2062
+#: src/muuli_wdr.cpp:2066
 msgid "Enter here a valid ip in the a.b.c.d format for the listening EC interface. An empty field or 0.0.0.0 will mean any interface."
 msgstr "Idatzi hemen a.b.c.d formatuan entzun behar den interfazearen baliozko ip helbidea. Eremu huts batek edo 0.0.0.0 ezartzeak edozein interfazetan entzutea eragingo du."
 
-#: src/muuli_wdr.cpp:2083 src/muuli_wdr.cpp:2194
+#: src/muuli_wdr.cpp:2087 src/muuli_wdr.cpp:2198
 msgid "TCP port:"
 msgstr "TCP ataka:"
 
-#: src/muuli_wdr.cpp:2089
+#: src/muuli_wdr.cpp:2093
 msgid "Enable UPnP port forwarding on the EC port"
 msgstr "UPnP berbideraketa gaitu EC atakan"
 
-#: src/muuli_wdr.cpp:2093 src/muuli_wdr.cpp:3079
+#: src/muuli_wdr.cpp:2097 src/muuli_wdr.cpp:3083
 #: src/utils/wxCas/src/wxcasprefs.cpp:167
 msgid "Password"
 msgstr "Pasahitza"
 
-#: src/muuli_wdr.cpp:2099
+#: src/muuli_wdr.cpp:2103
 #, fuzzy
 msgid "aMule API server parameters"
 msgstr "Web zerbitzari parametroak"
 
-#: src/muuli_wdr.cpp:2102
+#: src/muuli_wdr.cpp:2106
 msgid "Run amuleapi (REST API) on startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2107
+#: src/muuli_wdr.cpp:2111
 #, fuzzy
 msgid "HTTP port:"
 msgstr "TCP ataka:"
 
-#: src/muuli_wdr.cpp:2121
+#: src/muuli_wdr.cpp:2125
 msgid "The interface amuleapi's HTTP server listens on. 127.0.0.1 (default) accepts only local connections; use 0.0.0.0 or a specific IP to expose it to other hosts (set an admin password below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2126
+#: src/muuli_wdr.cpp:2130
 msgid "Type a password to set or change it. Stored passwords cannot be shown, so leaving this empty keeps the current one."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2128
+#: src/muuli_wdr.cpp:2132
 #, fuzzy
 msgid "Admin password"
 msgstr "Pasahitz egiaztatzen\n"
 
-#: src/muuli_wdr.cpp:2140 src/muuli_wdr.cpp:2157 src/PrefsUnifiedDlg.cpp:1103
+#: src/muuli_wdr.cpp:2144 src/muuli_wdr.cpp:2161 src/PrefsUnifiedDlg.cpp:1112
 #, fuzzy
 msgid "A password is set."
 msgstr "Pasahitz egiaztatzen\n"
 
-#: src/muuli_wdr.cpp:2144
+#: src/muuli_wdr.cpp:2148
 #, fuzzy
 msgid "Enable guest access"
 msgstr "Gonbidatu sarrera ezgaitu"
 
-#: src/muuli_wdr.cpp:2145
+#: src/muuli_wdr.cpp:2149
 msgid "Guest sessions may read status and listings but cannot change anything. Turning this off clears the stored guest password."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2149
+#: src/muuli_wdr.cpp:2153
 #, fuzzy
 msgid "Guest password"
 msgstr "Gonbidatu pasahitza web zerbitzarirako"
 
-#: src/muuli_wdr.cpp:2164
+#: src/muuli_wdr.cpp:2168
 msgid "Web server parameters"
 msgstr "Web zerbitzari parametroak"
 
-#: src/muuli_wdr.cpp:2167
+#: src/muuli_wdr.cpp:2171
 #, fuzzy
 msgid "Run webserver on startup (deprecated)"
 msgstr "Exekutatu web-zerbitzaria abioan"
 
-#: src/muuli_wdr.cpp:2173
+#: src/muuli_wdr.cpp:2177
 msgid "Web template"
 msgstr "Web txantiloia"
 
-#: src/muuli_wdr.cpp:2178
+#: src/muuli_wdr.cpp:2182
 msgid "Full rights password"
 msgstr "Baimen osorako pasahitza"
 
-#: src/muuli_wdr.cpp:2182
+#: src/muuli_wdr.cpp:2186
 msgid "Enable Low rights User"
 msgstr "Gaitu baimen gutxiko erabiltzailea"
 
-#: src/muuli_wdr.cpp:2187
+#: src/muuli_wdr.cpp:2191
 msgid "Low rights password"
 msgstr "Baimen baxuko pasahitza"
 
-#: src/muuli_wdr.cpp:2201
+#: src/muuli_wdr.cpp:2205
 msgid "Enable UPnP port forwarding of the web server port"
 msgstr "Gaitu web zerbitzari atakaren UPnP ataka birbidalketa"
 
-#: src/muuli_wdr.cpp:2206
+#: src/muuli_wdr.cpp:2210
 msgid "Web server UPnP TCP port (Optional)"
 msgstr "Web zerbitzari UPnP ataka (aukerakoa)"
 
-#: src/muuli_wdr.cpp:2214
+#: src/muuli_wdr.cpp:2218
 msgid "Page Refresh Time (in secs)"
 msgstr "Orrialdea berritzeko denbora (segundotan)"
 
-#: src/muuli_wdr.cpp:2221
+#: src/muuli_wdr.cpp:2225
 msgid "Enable Gzip compression"
 msgstr "Gaitu Gzip konpresioa"
 
-#: src/muuli_wdr.cpp:2255
+#: src/muuli_wdr.cpp:2259
 #, fuzzy
 msgid "Reset page to defaults"
 msgstr "Sistema lehenetsia"
 
-#: src/muuli_wdr.cpp:2256
+#: src/muuli_wdr.cpp:2260
 msgid "Reset the settings on the current page to their default values."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2258 src/muuli_wdr.cpp:2344 src/ServerWnd.cpp:274
+#: src/muuli_wdr.cpp:2262 src/muuli_wdr.cpp:2348 src/ServerWnd.cpp:274
 #: src/ServerWnd.cpp:282
 msgid "OK"
 msgstr "Ados"
 
-#: src/muuli_wdr.cpp:2260
+#: src/muuli_wdr.cpp:2264
 msgid "Click here to apply any changes made to the preferences."
 msgstr "Hemen klik egin hobespenetan eginiko edozein aldaketa ezartzeko."
 
-#: src/muuli_wdr.cpp:2263
+#: src/muuli_wdr.cpp:2267
 msgid "Reset any changes made to the preferences."
 msgstr "Berrezarri hobespenetan eginiko edozein aldaketa."
 
-#: src/muuli_wdr.cpp:2292
+#: src/muuli_wdr.cpp:2296
 msgid "Comment :"
 msgstr "Iruzkina :"
 
-#: src/muuli_wdr.cpp:2299
+#: src/muuli_wdr.cpp:2303
 msgid "Incoming Dir :"
 msgstr "Deskarga direktorioa :"
 
-#: src/muuli_wdr.cpp:2308
+#: src/muuli_wdr.cpp:2312
 msgid "Change priority for new assigned files :"
 msgstr "Aldatu lehentasuna fitxategi berrientzat :"
 
-#: src/muuli_wdr.cpp:2312
+#: src/muuli_wdr.cpp:2316
 msgid "Don't change"
 msgstr "Ez aldatu"
 
-#: src/muuli_wdr.cpp:2324
+#: src/muuli_wdr.cpp:2328
 msgid "Select color for this Category (currently selected) :"
 msgstr "Hautatu kolorea kategoria honentzat (unean aukeratutakoa) :"
 
-#: src/muuli_wdr.cpp:2391 src/muuli_wdr.cpp:2410 src/muuli_wdr.cpp:2432
+#: src/muuli_wdr.cpp:2395 src/muuli_wdr.cpp:2414 src/muuli_wdr.cpp:2436
 msgid "Click this button to reset the log."
 msgstr "Botoi hau klikatu erregistroa garbitzeko."
 
-#: src/muuli_wdr.cpp:2451
+#: src/muuli_wdr.cpp:2455
 msgid "Click on this button to update the servers list from URL ..."
 msgstr "Klik egin botoi honetan zerbitzari zerrenda URL-tik eguneratzeko ..."
 
-#: src/muuli_wdr.cpp:2455
+#: src/muuli_wdr.cpp:2459
 msgid "Server list"
 msgstr "Zerbitzari zerrenda"
 
-#: src/muuli_wdr.cpp:2459
+#: src/muuli_wdr.cpp:2463
 msgid "Enter the url to a server.met file here and press the button to the left to update the list of known servers."
 msgstr "Idatzi server.met fitxategiaren URL bat hemen eta gero ezkerreko botoia sakatu zerbitzari ezagunen zerrenda eguneratzeko."
 
-#: src/muuli_wdr.cpp:2464
+#: src/muuli_wdr.cpp:2468
 msgid "Add server manually: Name"
 msgstr "Gehitu zerbitzaria eskuz: Izena"
 
-#: src/muuli_wdr.cpp:2467
+#: src/muuli_wdr.cpp:2471
 msgid "Enter the name of the new server here"
 msgstr "Idatzi zerbitzari berriaren izen hemen"
 
-#: src/muuli_wdr.cpp:2469 src/ServerWnd.cpp:206
+#: src/muuli_wdr.cpp:2473 src/ServerWnd.cpp:206
 msgid "IP:Port"
 msgstr "IP ataka"
 
-#: src/muuli_wdr.cpp:2472
+#: src/muuli_wdr.cpp:2476
 msgid "Enter the IP of the server here, using the x.x.x.x format."
 msgstr "Idatzi x.x.x.x formatua erabiliaz zerbitzariaren ip helbidea."
 
-#: src/muuli_wdr.cpp:2478
+#: src/muuli_wdr.cpp:2482
 msgid "Enter the port of the server here."
 msgstr "Idatzi zerbitzariaren ataka hemen."
 
-#: src/muuli_wdr.cpp:2481
+#: src/muuli_wdr.cpp:2485
 msgid "Add manually a server (fill fields to the left before) ..."
 msgstr "Gehitu zerbitzari bat eskuz (sar datuak ezkerrean lehenik) ..."
 
-#: src/muuli_wdr.cpp:2510
+#: src/muuli_wdr.cpp:2514
 msgid "aMule Log"
 msgstr "aMule erregistroa"
 
-#: src/muuli_wdr.cpp:2518
+#: src/muuli_wdr.cpp:2522
 msgid "Server Info"
 msgstr "Zerbitzari argibideak"
 
-#: src/muuli_wdr.cpp:2522
+#: src/muuli_wdr.cpp:2526
 msgid "ED2K Info"
 msgstr "Argb"
 
-#: src/muuli_wdr.cpp:2526
+#: src/muuli_wdr.cpp:2530
 msgid "Kad Info"
 msgstr "Kad Argb"
 
-#: src/muuli_wdr.cpp:2554
+#: src/muuli_wdr.cpp:2558
 msgid "Click on this button to update the nodes list from URL ..."
 msgstr "Klikatu botoi honetan nodo zerrenda URL honetatik eguneratzeko ..."
 
-#: src/muuli_wdr.cpp:2558
+#: src/muuli_wdr.cpp:2562
 msgid "Nodes (0)"
 msgstr "Nodoak (0)"
 
-#: src/muuli_wdr.cpp:2562
+#: src/muuli_wdr.cpp:2566
 msgid "Enter the url to a nodes.dat file here and press the button to the left to update the list of known nodes."
 msgstr "nodes.dat fitxategi baten URL-a idatzi eta ezkerreko botoia sakatu nodo ezagunen zerrenda eguneratzeko."
 
-#: src/muuli_wdr.cpp:2565
+#: src/muuli_wdr.cpp:2569
 msgid "Nodes stats"
 msgstr "Nodo estatistikak"
 
-#: src/muuli_wdr.cpp:2607
+#: src/muuli_wdr.cpp:2611
 msgid "Bootstrap"
 msgstr "Autoabioa"
 
-#: src/muuli_wdr.cpp:2610
+#: src/muuli_wdr.cpp:2614
 msgid "New node"
 msgstr "Nodo berria"
 
-#: src/muuli_wdr.cpp:2615
+#: src/muuli_wdr.cpp:2619
 msgid "IP:"
 msgstr "IP:"
 
-#: src/muuli_wdr.cpp:2635
+#: src/muuli_wdr.cpp:2639
 msgid "Port:"
 msgstr "Ataka:"
 
-#: src/muuli_wdr.cpp:2648
+#: src/muuli_wdr.cpp:2652
 msgid "Bootstrap from known clients"
 msgstr "Bezero ezagunetarik abiarazi"
 
-#: src/muuli_wdr.cpp:2650
+#: src/muuli_wdr.cpp:2654
 msgid "Disconnect Kad"
 msgstr "Kad deskonektatu"
 
-#: src/muuli_wdr.cpp:2684
+#: src/muuli_wdr.cpp:2688
 msgid "Use Secure User Identification"
 msgstr "Erabili erabiltzaile identifikazio segurua"
 
-#: src/muuli_wdr.cpp:2686
+#: src/muuli_wdr.cpp:2690
 msgid "It is recommended to enable this option. You will not receive credits if SUI is not enabled."
 msgstr "Gomendagarri da aukera hau gaitzea. Ez duzu krediturik jasoko EIS erabiltzen ez baduzu."
 
-#: src/muuli_wdr.cpp:2688
+#: src/muuli_wdr.cpp:2692
 msgid "Protocol Obfuscation"
 msgstr "Protokolo nahastea"
 
-#: src/muuli_wdr.cpp:2691
+#: src/muuli_wdr.cpp:2695
 msgid "Support Protocol Obfuscation"
 msgstr "Gaitu protokolo nahastea"
 
-#: src/muuli_wdr.cpp:2693
+#: src/muuli_wdr.cpp:2697
 msgid "This option enabled Protocol Obfuscation, and makes aMule accept obfuscated connections from other clients."
 msgstr "Aukera honek protokolo nahastea gaitzen du eta aMule-k beste bezeroetako konexio nahastuak onartzea eragite du."
 
-#: src/muuli_wdr.cpp:2695
+#: src/muuli_wdr.cpp:2699
 msgid "Use obfuscation for outgoing connections"
 msgstr "Erabili nahastea kanporako konexioetan"
 
-#: src/muuli_wdr.cpp:2697
+#: src/muuli_wdr.cpp:2701
 msgid "This option makes aMule use Protocol Obfuscation when connecting other clients/servers."
 msgstr "Aukera honek Amulek beste bezero/zerbitzarietara konektatzerakoan protokolo nahastea erabiltzea eragiten du."
 
-#: src/muuli_wdr.cpp:2699
+#: src/muuli_wdr.cpp:2703
 msgid "Accept only obfuscated connections"
 msgstr "Onartu nahasitako konexioak bakarrik"
 
-#: src/muuli_wdr.cpp:2700
+#: src/muuli_wdr.cpp:2704
 msgid "This option makes aMule only accept obfuscated connections. You will have less sources, but all your traffic will be obfuscated"
 msgstr "Aukera honek Amulek nahasitako konexioak bakarrik onartzea eragiten du. Jatorri gutxiago izango dituzu baina zure trafiko guztia nahasia egongo da"
 
-#: src/muuli_wdr.cpp:2705
+#: src/muuli_wdr.cpp:2709
 msgid "Everybody"
 msgstr "Edozeini"
 
-#: src/muuli_wdr.cpp:2707
+#: src/muuli_wdr.cpp:2711
 msgid "No one"
 msgstr "Bat ere ez"
 
-#: src/muuli_wdr.cpp:2709
+#: src/muuli_wdr.cpp:2713
 msgid "Who can see my shared files:"
 msgstr "Nork ikusi ditzaken nire partekatutako fitxategiak:"
 
-#: src/muuli_wdr.cpp:2710
+#: src/muuli_wdr.cpp:2714
 msgid "Select who can request to view a list of your shared files."
 msgstr "Hautatu zure partekatutako fitxategiak nork ikus ditzakeen."
 
-#: src/muuli_wdr.cpp:2712
+#: src/muuli_wdr.cpp:2716
 msgid "IP-Filtering"
 msgstr "IP-Iragazkia"
 
-#: src/muuli_wdr.cpp:2719
+#: src/muuli_wdr.cpp:2723
 msgid "Filter clients"
 msgstr "Bezeroak iragazi"
 
-#: src/muuli_wdr.cpp:2721
+#: src/muuli_wdr.cpp:2725
 msgid "Enable filtering of the client IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "~/.aMule/ipfilter.dat fitxategian ezarritako bezero IP iragazketa gaitu."
 
-#: src/muuli_wdr.cpp:2723
+#: src/muuli_wdr.cpp:2727
 msgid "Filter servers"
 msgstr "Zerbitzariak iragazi"
 
-#: src/muuli_wdr.cpp:2725
+#: src/muuli_wdr.cpp:2729
 msgid "Enable filtering of the server IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "~/.aMule/ipfilter.dat fitxategian ezarritako zerbitzari IP iragazketa gaitu."
 
-#: src/muuli_wdr.cpp:2729
+#: src/muuli_wdr.cpp:2733
 msgid "Reload List"
 msgstr "Berritu zerrenda"
 
-#: src/muuli_wdr.cpp:2730
+#: src/muuli_wdr.cpp:2734
 msgid "Reload the list of IPs to filter from the file ~/.aMule/ipfilter.dat"
 msgstr "Berritu ~/.aMule/ipfilter.dat fitxategian ezarritako IP helbideen iragazkia"
 
-#: src/muuli_wdr.cpp:2736
+#: src/muuli_wdr.cpp:2740
 msgid "URL:"
 msgstr "URL-a:"
 
-#: src/muuli_wdr.cpp:2740 src/muuli_wdr.cpp:2933
+#: src/muuli_wdr.cpp:2744 src/muuli_wdr.cpp:2937
 msgid "Update now"
 msgstr "Eguneratu orain"
 
-#: src/muuli_wdr.cpp:2743
+#: src/muuli_wdr.cpp:2747
 msgid "Auto-update ipfilter at startup"
 msgstr "Automatikoki eguneratu ip iragazkia abioan"
 
-#: src/muuli_wdr.cpp:2747
+#: src/muuli_wdr.cpp:2751
 msgid "Filtering Level:"
 msgstr "Iragazki maila:"
 
-#: src/muuli_wdr.cpp:2753
+#: src/muuli_wdr.cpp:2757
 msgid "Always filter LAN IPs"
 msgstr "Beti iragazi LAN IP-ak"
 
-#: src/muuli_wdr.cpp:2756
+#: src/muuli_wdr.cpp:2760
 msgid "Paranoid handling of non-matching IPs"
 msgstr "Paranoia kudeaketa pareko ez diren IP helbideentzat"
 
-#: src/muuli_wdr.cpp:2758
+#: src/muuli_wdr.cpp:2762
 msgid "Rejects a packet when its source IP differs from the IP the client claims (an anti-spoofing check). Disable only if it causes connection problems."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2760
+#: src/muuli_wdr.cpp:2764
 msgid "Use system-wide ipfilter.dat if available"
 msgstr "Erabili sistemako ipfilter.dat eskuragarri badago"
 
-#: src/muuli_wdr.cpp:2761
+#: src/muuli_wdr.cpp:2765
 #, fuzzy
 msgid "If there's no local ipfilter.dat found, allow usage of a system-wide ipfilter file."
 msgstr "Ez bada ipfilter.dat fitxategi lokalik aurkitu, orduan onartu sistema ipfilter fitxategia erabiltzea."
 
-#: src/muuli_wdr.cpp:2778
+#: src/muuli_wdr.cpp:2782
 msgid "Enable Online-Signature"
 msgstr "Gaitu sinadura linean"
 
-#: src/muuli_wdr.cpp:2780
+#: src/muuli_wdr.cpp:2784
 msgid "Enables the writing of the OS file, which can be used by external apps to create signatures and the like."
 msgstr "Gaitu sistemak fitxategiak idaztea, kanpo programek sinadurak sortu ahal izateko egiten da."
 
-#: src/muuli_wdr.cpp:2784
+#: src/muuli_wdr.cpp:2788
 msgid "Update Frequency (Secs):"
 msgstr "Eguneratu maiztasuna (Seg):"
 
-#: src/muuli_wdr.cpp:2787
+#: src/muuli_wdr.cpp:2791
 msgid "Change the frequency (in seconds) of Online Signature updates."
 msgstr "Aldatu linean sinadura eguneraketa aldia (segundotan)."
 
-#: src/muuli_wdr.cpp:2795
+#: src/muuli_wdr.cpp:2799
 msgid "Save online signature file in: "
 msgstr "Gorde sare sinadura fitxategia hemen: "
 
-#: src/muuli_wdr.cpp:2801
+#: src/muuli_wdr.cpp:2805
 msgid "Click here to select the directory containing the the Online Signature files."
 msgstr "Klikatu hemen linean sinadurak dituen karpeta aukeratzeko."
 
-#: src/muuli_wdr.cpp:2834
+#: src/muuli_wdr.cpp:2838
 msgid "Show country flags for clients"
 msgstr "Bistarazi estatu banderak bezeroentzat"
 
-#: src/muuli_wdr.cpp:2835
+#: src/muuli_wdr.cpp:2839
 msgid "Render the country flag column in the transfers, queue and search views. Requires a valid MMDB GeoIP database (see below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2840
+#: src/muuli_wdr.cpp:2844
 #, fuzzy
 msgid "Database"
 msgstr "Data abiadura :"
 
-#: src/muuli_wdr.cpp:2856
+#: src/muuli_wdr.cpp:2860
 #, fuzzy
 msgid "Source:"
 msgstr "Jatorriak"
 
-#: src/muuli_wdr.cpp:2859
+#: src/muuli_wdr.cpp:2863
 msgid "DB-IP (free, no account)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2860
+#: src/muuli_wdr.cpp:2864
 msgid "MaxMind GeoLite2 (free, account required)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2861
+#: src/muuli_wdr.cpp:2865
 msgid "Custom URL"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2864
+#: src/muuli_wdr.cpp:2868
 msgid "Choose which provider supplies the GeoIP MMDB database. DB-IP is the default - no account required. MaxMind requires a free account + license key. Use Custom URL to point at any other MMDB host (e.g. a local mirror)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2881
+#: src/muuli_wdr.cpp:2885
 msgid ""
 "No configuration required.\n"
 "\n"
@@ -4882,11 +4882,11 @@ msgid ""
 "License: Creative Commons BY 4.0 - https://creativecommons.org/licenses/by/4.0/"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2894
+#: src/muuli_wdr.cpp:2898
 msgid "License key:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2900
+#: src/muuli_wdr.cpp:2904
 msgid ""
 "Sign up for a free MaxMind account, then generate a License Key:\n"
 "https://www.maxmind.com/en/geolite2/signup\n"
@@ -4896,226 +4896,226 @@ msgid ""
 "Requires attribution and account registration; refresh at least every 30 days."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2915
+#: src/muuli_wdr.cpp:2919
 #, fuzzy
 msgid "Download URL:"
 msgstr "Deskargak: "
 
-#: src/muuli_wdr.cpp:2921
+#: src/muuli_wdr.cpp:2925
 msgid ""
 "Must point to an .mmdb file or a .gz / .tar.gz containing one.\n"
 "URL may include credentials (https://user:pass@host/...).\n"
 "License and attribution terms are set by the upstream URL - you are responsible."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2934
+#: src/muuli_wdr.cpp:2938
 msgid "Download the GeoIP database from the selected source."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2936
+#: src/muuli_wdr.cpp:2940
 #, fuzzy
 msgid "Auto-update on startup"
 msgstr "Automatikoki eguneratu ip iragazkia abioan"
 
-#: src/muuli_wdr.cpp:2937
+#: src/muuli_wdr.cpp:2941
 msgid "Re-download the GeoIP database from the selected source every time aMule starts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2960
+#: src/muuli_wdr.cpp:2964
 msgid "Filter incoming messages (except current chat):"
 msgstr "sarrera mezu iragazkia (txat honetan ezik):"
 
-#: src/muuli_wdr.cpp:2962
+#: src/muuli_wdr.cpp:2966
 msgid "Filter all messages"
 msgstr "Mezu guztiak iragazi"
 
-#: src/muuli_wdr.cpp:2964
+#: src/muuli_wdr.cpp:2968
 msgid "Filter messages from people not on your friend list"
 msgstr "Lagun zerrendan ez daudenen mezuak iragazi"
 
-#: src/muuli_wdr.cpp:2966
+#: src/muuli_wdr.cpp:2970
 msgid "Filter messages from unknown clients"
 msgstr "Bezero ezezagunen mezuak iragazi"
 
-#: src/muuli_wdr.cpp:2968
+#: src/muuli_wdr.cpp:2972
 msgid "Filter messages containing (use ',' as separator):"
 msgstr "Hau duten mezuak iragazi (erabili ',' bereizle bezala):"
 
-#: src/muuli_wdr.cpp:2971 src/muuli_wdr.cpp:2982
+#: src/muuli_wdr.cpp:2975 src/muuli_wdr.cpp:2986
 msgid "add here the words amule should filter and block messages including it"
 msgstr "Gehitu amulek mezuetan blokeatzea nahi dituzun hitzak"
 
-#: src/muuli_wdr.cpp:2973
+#: src/muuli_wdr.cpp:2977
 msgid "Show received messages in the log"
 msgstr "Ikusi jasotako mezuak erregistroan"
 
-#: src/muuli_wdr.cpp:2976
+#: src/muuli_wdr.cpp:2980
 msgid "Comments"
 msgstr "Iruzkinak"
 
-#: src/muuli_wdr.cpp:2979
+#: src/muuli_wdr.cpp:2983
 msgid "Filter comments containing (use ',' as separator):"
 msgstr "Fitxategi iruzkinak hau du (',' erabili bereizle gisa):"
 
-#: src/muuli_wdr.cpp:3004
+#: src/muuli_wdr.cpp:3008
 msgid "Enable Proxy"
 msgstr "Proxy-a gaitu"
 
-#: src/muuli_wdr.cpp:3005
+#: src/muuli_wdr.cpp:3009
 msgid "Enable/disable proxy support"
 msgstr "Proxy onarpena gaitu/ezgaitu"
 
-#: src/muuli_wdr.cpp:3008
+#: src/muuli_wdr.cpp:3012
 msgid "Proxy type:"
 msgstr "Proxy mota:"
 
-#: src/muuli_wdr.cpp:3019
+#: src/muuli_wdr.cpp:3023
 msgid "Proxy host:"
 msgstr "Proxy ostalaria:"
 
-#: src/muuli_wdr.cpp:3022
+#: src/muuli_wdr.cpp:3026
 msgid "The proxy host name"
 msgstr "Proxy ostalari izena"
 
-#: src/muuli_wdr.cpp:3024
+#: src/muuli_wdr.cpp:3028
 msgid "Proxy port:"
 msgstr "Proxy ataka:"
 
-#: src/muuli_wdr.cpp:3027
+#: src/muuli_wdr.cpp:3031
 msgid "The proxy port"
 msgstr "Proxy ataka"
 
-#: src/muuli_wdr.cpp:3029
+#: src/muuli_wdr.cpp:3033
 msgid "Enable authentication"
 msgstr "Gaitu autentifikazioa"
 
-#: src/muuli_wdr.cpp:3030
+#: src/muuli_wdr.cpp:3034
 msgid "Enable/disable username/password authentication"
 msgstr "erabiltzaile/pasahitz autentifikazioa gaitu/ezgaitu"
 
-#: src/muuli_wdr.cpp:3033
+#: src/muuli_wdr.cpp:3037
 msgid "Username: "
 msgstr "Erabiltzaile izena: "
 
-#: src/muuli_wdr.cpp:3036
+#: src/muuli_wdr.cpp:3040
 msgid "The username to use to connect to the proxy"
 msgstr "Proxy-ra konektatzeko erabiliko den erabiltzaile izena"
 
-#: src/muuli_wdr.cpp:3038
+#: src/muuli_wdr.cpp:3042
 msgid "Password:"
 msgstr "Pasahitza:"
 
-#: src/muuli_wdr.cpp:3041
+#: src/muuli_wdr.cpp:3045
 msgid "The password to use to connect to the proxy"
 msgstr "Proxy-ra konektatzeko erabiliko den pasahitza"
 
-#: src/muuli_wdr.cpp:3060
+#: src/muuli_wdr.cpp:3064
 msgid "Connect to:"
 msgstr "Hona konektaturik:"
 
-#: src/muuli_wdr.cpp:3069
+#: src/muuli_wdr.cpp:3073
 msgid "Login to remote amule"
 msgstr "Urruneko aMulen saioa hasi"
 
-#: src/muuli_wdr.cpp:3074
+#: src/muuli_wdr.cpp:3078
 msgid "User name"
 msgstr "Erabiltzaile izena"
 
-#: src/muuli_wdr.cpp:3085
+#: src/muuli_wdr.cpp:3089
 msgid "Remember those settings"
 msgstr "Ezarpen hauek gogoratu"
 
-#: src/muuli_wdr.cpp:3088
+#: src/muuli_wdr.cpp:3092
 #, fuzzy
 msgid "Force ZLIB compression"
 msgstr "Erabili gzip konpresioa"
 
-#: src/muuli_wdr.cpp:3112
+#: src/muuli_wdr.cpp:3116
 msgid "Enable Verbose Debug-Logging."
 msgstr "Gaitu arazten luzeko saio hasiera."
 
-#: src/muuli_wdr.cpp:3114
+#: src/muuli_wdr.cpp:3118
 #, fuzzy
 msgid "Only to Logfile"
 msgstr "&Ireki fitxategia"
 
-#: src/muuli_wdr.cpp:3116
+#: src/muuli_wdr.cpp:3120
 msgid "Message Categories:"
 msgstr "Mezu kategoriak:"
 
-#: src/muuli_wdr.cpp:3140 src/PartFileConvertDlg.cpp:160
+#: src/muuli_wdr.cpp:3144 src/PartFileConvertDlg.cpp:160
 msgid "Waiting..."
 msgstr "Zain..."
 
-#: src/muuli_wdr.cpp:3160
+#: src/muuli_wdr.cpp:3164
 msgid "Add imports"
 msgstr "Gehitu"
 
-#: src/muuli_wdr.cpp:3163
+#: src/muuli_wdr.cpp:3167
 msgid "Retry selected"
 msgstr "Berriz saiatu hautaturikoak"
 
-#: src/muuli_wdr.cpp:3165
+#: src/muuli_wdr.cpp:3169
 msgid "Remove selected"
 msgstr "Ezabatu hautaturikoak"
 
-#: src/muuli_wdr.cpp:3228
+#: src/muuli_wdr.cpp:3232
 msgid "Event Types"
 msgstr "Gertaera motak"
 
-#: src/muuli_wdr.cpp:3247
+#: src/muuli_wdr.cpp:3251
 msgid "Statistics and queued clients for selected file(s) : Session / All time"
 msgstr "Hautako fitxategientzat estatistika eta bezero ilara: Saioa / osotara"
 
-#: src/muuli_wdr.cpp:3271
+#: src/muuli_wdr.cpp:3275
 msgid "Active Uploads"
 msgstr "Igoera aktiboak"
 
-#: src/muuli_wdr.cpp:3285
+#: src/muuli_wdr.cpp:3289
 msgid "Percent of total files"
 msgstr "fitxategi guztien ehunekoa"
 
-#: src/muuli_wdr.cpp:3337
+#: src/muuli_wdr.cpp:3341
 msgid "Show Clients for"
 msgstr "Erakutsi bezeroak:"
 
-#: src/muuli_wdr.cpp:3339
+#: src/muuli_wdr.cpp:3343
 msgid "All files"
 msgstr "Fitxategi guztiak"
 
-#: src/muuli_wdr.cpp:3342
+#: src/muuli_wdr.cpp:3346
 msgid "Selected files"
 msgstr "Hautatutako fitxategiak"
 
-#: src/muuli_wdr.cpp:3345
+#: src/muuli_wdr.cpp:3349
 msgid "Active uploads only"
 msgstr "Igoera aktiboak bakarrik"
 
-#: src/muuli_wdr.cpp:3352
+#: src/muuli_wdr.cpp:3356
 msgid "Reload:"
 msgstr "Berritu:"
 
-#: src/muuli_wdr.cpp:3356
+#: src/muuli_wdr.cpp:3360
 msgid "Reload your shared files"
 msgstr "Berritu zure partekatutako fitxategiak"
 
-#: src/muuli_wdr.cpp:3419
+#: src/muuli_wdr.cpp:3423
 msgid "Send"
 msgstr "Bidali"
 
-#: src/muuli_wdr.cpp:3420
+#: src/muuli_wdr.cpp:3424
 msgid "Sends the specified message."
 msgstr "Zehaztutako mezua bidali."
 
-#: src/muuli_wdr.cpp:3424
+#: src/muuli_wdr.cpp:3428
 msgid "Close this chat-session."
 msgstr "Itxi elkarrizketa saio hau."
 
-#: src/muuli_wdr.cpp:3447
+#: src/muuli_wdr.cpp:3451
 msgid "Connect to any server and/or Kad"
 msgstr "Konektatu edozein zerbitzari eta/edo Kad"
 
-#: src/muuli_wdr.cpp:3453 src/SharedFilesCtrl.cpp:142 src/Statistics.cpp:941
+#: src/muuli_wdr.cpp:3457 src/SharedFilesCtrl.cpp:142 src/Statistics.cpp:941
 msgid "Shared Files"
 msgstr "Partekatutako fitxategiak"
 
@@ -5750,35 +5750,35 @@ msgstr ""
 "Amulek ondo funtzionatu beharko luke ezarpen\n"
 "hauek aldatu gabe."
 
-#: src/PrefsUnifiedDlg.cpp:647
+#: src/PrefsUnifiedDlg.cpp:656
 #, c-format
 msgid "Failed to connect Cfg to widget with the ID %d and key %s"
 msgstr "Huts %d IDa eta %s gakoaz konfiguraziotik programara konektatzean"
 
-#: src/PrefsUnifiedDlg.cpp:695
+#: src/PrefsUnifiedDlg.cpp:704
 #, c-format
 msgid "Failed to transfer data from Cfg to Widget with the ID %d and key %s"
 msgstr "Huts %d IDa eta %s gakoaz konfiguraziotik programara datuak bidaltzean"
 
-#: src/PrefsUnifiedDlg.cpp:801
+#: src/PrefsUnifiedDlg.cpp:810
 msgid "The type of proxy you are connecting to"
 msgstr "Konektatzen ari zaren Proxy-aren mota"
 
-#: src/PrefsUnifiedDlg.cpp:1020
+#: src/PrefsUnifiedDlg.cpp:1029
 #, c-format
 msgid "Failed to transfer data from Widget to Cfg with the ID %d and key %s"
 msgstr "Huts %d IDa eta %s gakoaz programatik konfiguraziora datuak bidaltzean"
 
-#: src/PrefsUnifiedDlg.cpp:1103
+#: src/PrefsUnifiedDlg.cpp:1112
 #, fuzzy
 msgid "No password set."
 msgstr "Pasahitz egiaztatzen\n"
 
-#: src/PrefsUnifiedDlg.cpp:1132
+#: src/PrefsUnifiedDlg.cpp:1141
 msgid "Guest access needs a password. Type one in the guest password field, or untick Enable guest access."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1144
+#: src/PrefsUnifiedDlg.cpp:1153
 msgid ""
 "aMule must be restarted to enable these changes:\n"
 "\n"
@@ -5786,42 +5786,42 @@ msgstr ""
 "aMule berrabiarazi egin behar da aldaketa hauek gaitu ahal izateko:\n"
 "\n"
 
-#: src/PrefsUnifiedDlg.cpp:1151
+#: src/PrefsUnifiedDlg.cpp:1160
 msgid "- TCP port changed.\n"
 msgstr "- TCP ataka aldaturik.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1156
+#: src/PrefsUnifiedDlg.cpp:1165
 msgid "- UDP port changed.\n"
 msgstr "- UDP - ataka aldaturik.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1161
+#: src/PrefsUnifiedDlg.cpp:1170
 #, fuzzy
 msgid "- Network interface binding changed.\n"
 msgstr "- Kanpo konexio interfazea aldatua.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1166
+#: src/PrefsUnifiedDlg.cpp:1175
 msgid "- External connect port changed.\n"
 msgstr "- Kanpo konexio ataka aldatua.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1170
+#: src/PrefsUnifiedDlg.cpp:1179
 msgid "- External connect acceptance changed.\n"
 msgstr "- Lanpo konexio onarpena aldatua.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1174
+#: src/PrefsUnifiedDlg.cpp:1183
 msgid "- External connect interface changed.\n"
 msgstr "- Kanpo konexio interfazea aldatua.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1178
+#: src/PrefsUnifiedDlg.cpp:1187
 #, fuzzy
 msgid "- Protocol obfuscation support changed.\n"
 msgstr "Protokolo nahastea"
 
-#: src/PrefsUnifiedDlg.cpp:1193
+#: src/PrefsUnifiedDlg.cpp:1202
 #, fuzzy
 msgid "- amuleapi settings changed.\n"
 msgstr "- Hizkuntza aldaturik.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1202
+#: src/PrefsUnifiedDlg.cpp:1211
 msgid ""
 "Your Auto-update server list is empty.\n"
 "'Auto-update server list at startup' will be disabled."
@@ -5829,7 +5829,7 @@ msgstr ""
 "Auto-eguneraketa zerbitzari zerrenda hutsa dago.\n"
 "'Auto-eguneratu zerbitzari zerrenda abioan' ezgaitu egingo da."
 
-#: src/PrefsUnifiedDlg.cpp:1213
+#: src/PrefsUnifiedDlg.cpp:1222
 msgid ""
 "You have enabled external connections but have not specified a password.\n"
 "External connections cannot be enabled unless a valid password is specified."
@@ -5837,33 +5837,33 @@ msgstr ""
 "Kanpo konexioak gaiturik dituzu baina ez duzu pasahitzik ezarri.\n"
 "Kanpo konexiorik ezin da onartu baliozko pasahitza ezarri arte."
 
-#: src/PrefsUnifiedDlg.cpp:1246
+#: src/PrefsUnifiedDlg.cpp:1255
 #, c-format
 msgid "The amuleapi password could not be saved: %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1276
+#: src/PrefsUnifiedDlg.cpp:1285
 msgid "- Language changed.\n"
 msgstr "- Hizkuntza aldaturik.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1281
+#: src/PrefsUnifiedDlg.cpp:1290
 msgid "- Temp folder changed.\n"
 msgstr "- Aldiroko karpeta aldaturik.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1286
+#: src/PrefsUnifiedDlg.cpp:1295
 msgid "- ED2K network enabled.\n"
 msgstr "- ED2K sarea gaiturik.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1319
+#: src/PrefsUnifiedDlg.cpp:1328
 msgid "The shared-file exclusion pattern is not a valid regular expression. The filter has been left disabled."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1321 src/PrefsUnifiedDlg.cpp:1921
+#: src/PrefsUnifiedDlg.cpp:1330 src/PrefsUnifiedDlg.cpp:1930
 #, fuzzy
 msgid "Invalid regular expression"
 msgstr "Protokolo bertsio baliogabea."
 
-#: src/PrefsUnifiedDlg.cpp:1398
+#: src/PrefsUnifiedDlg.cpp:1407
 msgid ""
 "Both eD2k and Kad network are disabled.\n"
 "You won't be able to connect until you enable at least one of them."
@@ -5871,7 +5871,7 @@ msgstr ""
 "Bai eD2k eta bai Kad sareak ezgaiturik daude.\n"
 "Ezingo zara konektatu behintzat bietako bat gaitu arte."
 
-#: src/PrefsUnifiedDlg.cpp:1403
+#: src/PrefsUnifiedDlg.cpp:1412
 msgid ""
 "Kad will not start if your UDP port is disabled.\n"
 "Enable UDP port or disable Kad."
@@ -5879,7 +5879,7 @@ msgstr ""
 "Kad ezin da abiarazi zure UDP ataka ezgaiturik badago.\n"
 "UDP ataka gaitu edo Kad ezgaitu."
 
-#: src/PrefsUnifiedDlg.cpp:1459
+#: src/PrefsUnifiedDlg.cpp:1468
 msgid ""
 "\n"
 "You MUST restart aMule now.\n"
@@ -5889,69 +5889,69 @@ msgstr ""
 "aMule orain berrabiarazi BEHAR duzu.\n"
 "Orain ez berrabiaraziaz gero ez kexatu ezer txarra gertatzen bada.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1524
+#: src/PrefsUnifiedDlg.cpp:1533
 msgid "Could not register aMule for autostart at login. The autostart store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1526
+#: src/PrefsUnifiedDlg.cpp:1535
 msgid "Could not remove the autostart-at-login entry."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1527
+#: src/PrefsUnifiedDlg.cpp:1536
 #, fuzzy
 msgid "Autostart"
 msgstr "Auto berritzea abiarazirik"
 
-#: src/PrefsUnifiedDlg.cpp:1542
+#: src/PrefsUnifiedDlg.cpp:1551
 msgid "Register file type"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1542
+#: src/PrefsUnifiedDlg.cpp:1551
 msgid "Register URL handler"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1550
+#: src/PrefsUnifiedDlg.cpp:1559
 #, c-format
 msgid "aMule only handles eD2k-compatible magnets. If you replace the current magnet handler (%s), BitTorrent magnet links will stop working - aMule cannot download BitTorrent content. Continue?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1555
+#: src/PrefsUnifiedDlg.cpp:1564
 #, c-format
 msgid "Another application currently opens .emulecollection files (%s). Replace it with aMule?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1560
+#: src/PrefsUnifiedDlg.cpp:1569
 #, c-format
 msgid "Another application is currently the default handler for these links (%s). Replace it with aMule?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1585
+#: src/PrefsUnifiedDlg.cpp:1594
 msgid "Could not register aMule for .emulecollection files. The registration store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1587
+#: src/PrefsUnifiedDlg.cpp:1596
 #, fuzzy
 msgid "Could not remove the file type registration."
 msgstr "Aldiroko deskarga fitxategientzat karpeta"
 
-#: src/PrefsUnifiedDlg.cpp:1589
+#: src/PrefsUnifiedDlg.cpp:1598
 msgid "Could not register aMule as the URL handler. The registration store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1591
+#: src/PrefsUnifiedDlg.cpp:1600
 msgid "Could not remove the URL handler registration."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1661 src/PrefsUnifiedDlg.cpp:1688
+#: src/PrefsUnifiedDlg.cpp:1670 src/PrefsUnifiedDlg.cpp:1697
 #, fuzzy
 msgid "The web server and aMule API require external connections to be enabled."
 msgstr "Pasahitza ezarria eta kanpo konexioak gaiturik."
 
-#: src/PrefsUnifiedDlg.cpp:1671
+#: src/PrefsUnifiedDlg.cpp:1680
 msgid "The aMule web server is deprecated. Consider running the aMule API instead."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1735
+#: src/PrefsUnifiedDlg.cpp:1744
 msgid ""
 "Your Auto-update servers list is in blank.\n"
 "Please fill in at least one URL to point to a valid server.met file.\n"
@@ -5961,66 +5961,66 @@ msgstr ""
 "Mesedez bete behintzat baliozko server.met fitxategi batetara zuzenduaz.\n"
 "Klikatu \"zerrenda\" botoia URL-a sartzeko."
 
-#: src/PrefsUnifiedDlg.cpp:1876
+#: src/PrefsUnifiedDlg.cpp:1885
 msgid "Temporary files"
 msgstr "Aldi baterako fitxategiak"
 
-#: src/PrefsUnifiedDlg.cpp:1881
+#: src/PrefsUnifiedDlg.cpp:1890
 msgid "Incoming files"
 msgstr "Sarrera fitxategiak"
 
-#: src/PrefsUnifiedDlg.cpp:1886
+#: src/PrefsUnifiedDlg.cpp:1895
 msgid "Online Signatures"
 msgstr "Linean sinadurak"
 
-#: src/PrefsUnifiedDlg.cpp:1899
+#: src/PrefsUnifiedDlg.cpp:1908
 #, c-format
 msgid "Choose a folder for %s"
 msgstr "Aukeratu karpeta bat %s-rentzat"
 
-#: src/PrefsUnifiedDlg.cpp:1923
+#: src/PrefsUnifiedDlg.cpp:1932
 #, fuzzy, c-format
 msgid "Would exclude %u of %u shared file"
 msgid_plural "Would exclude %u of %u shared files"
 msgstr[0] "Ezagututako partekatutako fitxategi %i aurkiturik"
 msgstr[1] "%i ezagututako partekatutako fitxategi aurkiturik"
 
-#: src/PrefsUnifiedDlg.cpp:1940
+#: src/PrefsUnifiedDlg.cpp:1949
 msgid "Browse for videoplayer"
 msgstr "Arakatu bideo erreproduzigailua"
 
-#: src/PrefsUnifiedDlg.cpp:1944
+#: src/PrefsUnifiedDlg.cpp:1953
 msgid "Select browser"
 msgstr "Hautatu nabigatzailea"
 
-#: src/PrefsUnifiedDlg.cpp:1948
+#: src/PrefsUnifiedDlg.cpp:1957
 #, fuzzy
 msgid "Select ffprobe binary"
 msgstr "Hautatu nabigatzailea"
 
-#: src/PrefsUnifiedDlg.cpp:1954
+#: src/PrefsUnifiedDlg.cpp:1963
 #, c-format
 msgid "Executable%s"
 msgstr "Abiarazgarria%s"
 
-#: src/PrefsUnifiedDlg.cpp:1988
+#: src/PrefsUnifiedDlg.cpp:1997
 msgid "ffprobe not found on PATH or in the standard install locations. Install ffmpeg (which ships ffprobe) or use Browse to pick a binary manually."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2000
+#: src/PrefsUnifiedDlg.cpp:2009
 msgid "Reset the settings on this page to their default values?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2001
+#: src/PrefsUnifiedDlg.cpp:2010
 #, fuzzy
 msgid "Reset to defaults"
 msgstr "Sistema lehenetsia"
 
-#: src/PrefsUnifiedDlg.cpp:2028
+#: src/PrefsUnifiedDlg.cpp:2037
 msgid "Edit server list"
 msgstr "Editatu zerbitzari zerrenda"
 
-#: src/PrefsUnifiedDlg.cpp:2029
+#: src/PrefsUnifiedDlg.cpp:2038
 msgid ""
 "Add here URL's to download server.met files.\n"
 "Only one url on each line."
@@ -6028,154 +6028,154 @@ msgstr ""
 "Gehitu hemen server.met deskargatzeko URL-a.\n"
 "URL helbide bat lerro bakoitzean."
 
-#: src/PrefsUnifiedDlg.cpp:2084
+#: src/PrefsUnifiedDlg.cpp:2093
 msgid "IP2Country update failed"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2229 src/PrefsUnifiedDlg.cpp:2260
+#: src/PrefsUnifiedDlg.cpp:2238 src/PrefsUnifiedDlg.cpp:2269
 msgid "Data by MaxMind GeoLite2"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2231 src/PrefsUnifiedDlg.cpp:2262
+#: src/PrefsUnifiedDlg.cpp:2240 src/PrefsUnifiedDlg.cpp:2271
 #, fuzzy
 msgid "Custom source"
 msgstr "Jatorri osoak"
 
-#: src/PrefsUnifiedDlg.cpp:2233 src/PrefsUnifiedDlg.cpp:2264
+#: src/PrefsUnifiedDlg.cpp:2242 src/PrefsUnifiedDlg.cpp:2273
 msgid "Data by DB-IP.com"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2284
+#: src/PrefsUnifiedDlg.cpp:2293
 #, fuzzy, c-format
 msgid "Status: Loaded%s"
 msgstr "Egoera:"
 
-#: src/PrefsUnifiedDlg.cpp:2286
+#: src/PrefsUnifiedDlg.cpp:2295
 #, fuzzy, c-format
 msgid "Status: Loaded%s - %s"
 msgstr "Egoera:"
 
-#: src/PrefsUnifiedDlg.cpp:2290
+#: src/PrefsUnifiedDlg.cpp:2299
 msgid "Status: Failed to load - click 'Update now' to refresh."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2292
+#: src/PrefsUnifiedDlg.cpp:2301
 msgid "Status: Not found - click 'Update now' to download."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2350 src/PrefsUnifiedDlg.cpp:2374
+#: src/PrefsUnifiedDlg.cpp:2359 src/PrefsUnifiedDlg.cpp:2383
 #, c-format
 msgid "Update delay: %d second"
 msgid_plural "Update delay: %d seconds"
 msgstr[0] "Eguneratze maiztasuna: seg %d"
 msgstr[1] "Eguneratze maiztasuna: %d seg"
 
-#: src/PrefsUnifiedDlg.cpp:2358
+#: src/PrefsUnifiedDlg.cpp:2367
 #, c-format
 msgid "Time for average graph: %d minute"
 msgid_plural "Time for average graph: %d minutes"
 msgstr[0] "Batez besteko grafiko denbora: minutu %d"
 msgstr[1] "Batez besteko grafiko denbora: %d minutu"
 
-#: src/PrefsUnifiedDlg.cpp:2367
+#: src/PrefsUnifiedDlg.cpp:2376
 #, c-format
 msgid "Connections Graph Scale: %d"
 msgstr "Konexio grafiko eskala: %d"
 
-#: src/PrefsUnifiedDlg.cpp:2382
+#: src/PrefsUnifiedDlg.cpp:2391
 #, c-format
 msgid "File Buffer Size: %d byte"
 msgid_plural "File Buffer Size: %d bytes"
 msgstr[0] "Fitxategi buffer tamaina: byte %d"
 msgstr[1] "Fitxategi buffer tamaina: %d byte"
 
-#: src/PrefsUnifiedDlg.cpp:2392
+#: src/PrefsUnifiedDlg.cpp:2401
 #, c-format
 msgid "Upload Queue Size: %d client"
 msgid_plural "Upload Queue Size: %d clients"
 msgstr[0] "Igoera ilara tamaina: bezero %d"
 msgstr[1] "Igoera ilara tamaina: %d bezero"
 
-#: src/PrefsUnifiedDlg.cpp:2402
+#: src/PrefsUnifiedDlg.cpp:2411
 #, c-format
 msgid "Server connection refresh interval: %d minute"
 msgid_plural "Server connection refresh interval: %d minutes"
 msgstr[0] "Zerbitzari konexio berritze maiztasuna: minutu %d"
 msgstr[1] "Zerbitzari konexio berritze maiztasuna: %d minutu"
 
-#: src/PrefsUnifiedDlg.cpp:2407
+#: src/PrefsUnifiedDlg.cpp:2416
 msgid "Server connection refresh interval: Disabled"
 msgstr "Zerbitzarira konexio berritze maiztasuna: Ezgaiturik"
 
-#: src/PrefsUnifiedDlg.cpp:2451
+#: src/PrefsUnifiedDlg.cpp:2460
 msgid "disabled"
 msgstr "ezgaiturik"
 
-#: src/PrefsUnifiedDlg.cpp:2477
+#: src/PrefsUnifiedDlg.cpp:2486
 #, c-format
 msgid "Execute command on '%s' event"
 msgstr "Gertaeran'%s' komandoa exekutatu"
 
-#: src/PrefsUnifiedDlg.cpp:2484
+#: src/PrefsUnifiedDlg.cpp:2493
 msgid "Enable command execution on core"
 msgstr "Gaitu komando exekuzioa muinean"
 
-#: src/PrefsUnifiedDlg.cpp:2496
+#: src/PrefsUnifiedDlg.cpp:2505
 msgid "Core command:"
 msgstr "Muin komandoa:"
 
-#: src/PrefsUnifiedDlg.cpp:2512
+#: src/PrefsUnifiedDlg.cpp:2521
 msgid "Enable command execution on GUI"
 msgstr "Gaitu komando exekuzioa urruneko interfazean"
 
-#: src/PrefsUnifiedDlg.cpp:2524
+#: src/PrefsUnifiedDlg.cpp:2533
 msgid "GUI command:"
 msgstr "Urruneko interfaze komandoa:"
 
-#: src/PrefsUnifiedDlg.cpp:2540
+#: src/PrefsUnifiedDlg.cpp:2549
 msgid "The following variables will be replaced:"
 msgstr "Hurrengo aldagaiak aldatuko dira:"
 
-#: src/PrefsUnifiedDlg.cpp:2708
+#: src/PrefsUnifiedDlg.cpp:2717
 msgid ""
 "The following folders look like system or sensitive locations:\n"
 "\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2713
+#: src/PrefsUnifiedDlg.cpp:2722
 msgid "Sharing them recursively will publish every file underneath on the eD2k/Kad networks. Do you really want to do this?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2716
+#: src/PrefsUnifiedDlg.cpp:2725
 #, fuzzy
 msgid "Confirm shared folders"
 msgstr "Partekatutako karpetak"
 
-#: src/PrefsUnifiedDlg.cpp:2744
+#: src/PrefsUnifiedDlg.cpp:2753
 #, fuzzy
 msgid "Reloading shared files..."
 msgstr "Berritu zure partekatutako fitxategiak"
 
-#: src/PrefsUnifiedDlg.cpp:2745
+#: src/PrefsUnifiedDlg.cpp:2754
 msgid "Scanning for subdirectories..."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2746
+#: src/PrefsUnifiedDlg.cpp:2755
 #, fuzzy
 msgid "Updating shared folders"
 msgstr "Partekatutako karpetak"
 
-#: src/PrefsUnifiedDlg.cpp:2773
+#: src/PrefsUnifiedDlg.cpp:2782
 #, c-format
 msgid "Scanned %u directories..."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2823
+#: src/PrefsUnifiedDlg.cpp:2832
 #, fuzzy, c-format
 msgid "Reloading shared files: %u files scanned"
 msgstr "Partekatutako fitxategi zerrenda birkargatu."
 
-#: src/PrefsUnifiedDlg.cpp:2873
+#: src/PrefsUnifiedDlg.cpp:2882
 #, fuzzy
 msgid "Shared folder"
 msgstr "Partekatutako karpetak"
@@ -7856,12 +7856,12 @@ msgstr "Ezabatu kategoria"
 msgid "Hashset requested for unknown file: %s"
 msgstr "Egiaztapena eskaturik fitxategi ezezagunarentzat: %s"
 
-#: src/UploadQueue.cpp:618
+#: src/UploadQueue.cpp:627
 #, c-format
 msgid "Resuming uploads of file: %s"
 msgstr "Fitxategiaren igoerak berriarazten: %s"
 
-#: src/UploadQueue.cpp:634
+#: src/UploadQueue.cpp:643
 #, c-format
 msgid "Suspending upload of file: %s"
 msgstr "Fitxategiaren igoerak gelditzen: %s"

--- a/po/eu.po
+++ b/po/eu.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-28 08:06+0200\n"
+"POT-Creation-Date: 2026-07-28 10:19+0200\n"
 "PO-Revision-Date: 2026-07-27 11:37+0000\n"
 "Last-Translator: Piarres Beobide <pi@beobide.net>\n"
 "Language-Team: Euskara <librezale@librezale.org>\n"
@@ -146,7 +146,7 @@ msgstr ""
 msgid "Not now"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:422 src/amuleDlg.cpp:600
+#: src/AppImageIntegration.cpp:422 src/amuleDlg.cpp:665
 msgid "Don't ask again"
 msgstr ""
 
@@ -219,7 +219,7 @@ msgid "Killing amuleweb instance with pid '%d' ... "
 msgstr "'%d' pid-a duen amuleweb instantzia hiltzen ... "
 
 #: src/amule.cpp:336 src/amule.cpp:349 src/ClientRef.cpp:180
-#: src/SearchDlg.cpp:880 src/ServerListCtrl.cpp:98
+#: src/SearchDlg.cpp:1041 src/ServerListCtrl.cpp:98
 msgid "Failed"
 msgstr "Huts egin du"
 
@@ -575,30 +575,68 @@ msgstr "Ezin da Pid fitxategia sortu"
 msgid "ERROR: %s"
 msgstr "ERROREA: %s"
 
-#: src/amuleDlg.cpp:236
+#: src/amuleDlg.cpp:250
 #, c-format
 msgid "This is aMule %s based on eMule."
 msgstr "Hau eMulen oinarrituriko aMule %s da."
 
-#: src/amuleDlg.cpp:237
+#: src/amuleDlg.cpp:251
 #, c-format
 msgid "Running on %s"
 msgstr "%s-n abiarazirik"
 
-#: src/amuleDlg.cpp:239
+#: src/amuleDlg.cpp:253
 msgid "Visit https://github.com/amule-org/amule/releases/latest to check if a new version is available."
 msgstr "Bisitatu https://github.com/amule-org/amule/releases/latest gunea bertsio berriagorik eskuragarri dagoen jakiteko."
 
-#: src/amuleDlg.cpp:268
+#: src/amuleDlg.cpp:282
 msgid "FATAL ERROR: Failed to create Timer"
 msgstr "ERRORE KONPONEZINA: Huts kronometroa sortzean"
 
-#: src/amuleDlg.cpp:592
+#: src/amuleDlg.cpp:361 src/amuleDlg.cpp:1787 src/amuleDlg.cpp:2033
+#: src/muuli_wdr.cpp:1492 src/muuli_wdr.cpp:3418
+msgid "Networks"
+msgstr "Sareak"
+
+#: src/amuleDlg.cpp:362 src/amuleDlg.cpp:1793 src/muuli_wdr.cpp:3419
+msgid "Searches"
+msgstr "Bilaketak"
+
+#: src/amuleDlg.cpp:363 src/amuleDlg.cpp:1799 src/DownloadListCtrl.cpp:740
+#: src/muuli_wdr.cpp:392 src/muuli_wdr.cpp:1585 src/muuli_wdr.cpp:3420
+#: src/Statistics.cpp:829
+msgid "Downloads"
+msgstr "Deskargak"
+
+#: src/amuleDlg.cpp:364 src/amuleDlg.cpp:1805 src/muuli_wdr.cpp:3294
+msgid "Shared files"
+msgstr "Partekatutako fitxategiak"
+
+#: src/amuleDlg.cpp:365 src/amuleDlg.cpp:1811 src/muuli_wdr.cpp:2926
+#: src/muuli_wdr.cpp:3376 src/muuli_wdr.cpp:3423
+msgid "Messages"
+msgstr "Mezuak"
+
+#: src/amuleDlg.cpp:366 src/amuleDlg.cpp:1817 src/muuli_wdr.cpp:3424
+#: src/PrefsUnifiedDlg.cpp:312 src/Statistics.cpp:779 src/Statistics.cpp:1235
+msgid "Statistics"
+msgstr "Estatistikak"
+
+#: src/amuleDlg.cpp:368 src/amuleDlg.cpp:1824 src/muuli_wdr.cpp:3426
+#: src/PrefsUnifiedDlg.cpp:328 src/utils/wxCas/src/wxcasprefs.cpp:39
+msgid "Preferences"
+msgstr "Hobespenak"
+
+#: src/amuleDlg.cpp:371
+msgid "Navigate"
+msgstr ""
+
+#: src/amuleDlg.cpp:657
 #, fuzzy
 msgid "New version available"
 msgstr "Ez dago erabilgarri"
 
-#: src/amuleDlg.cpp:596
+#: src/amuleDlg.cpp:661
 #, fuzzy, c-format
 msgid ""
 "A new version of aMule (%s) is available.\n"
@@ -608,218 +646,185 @@ msgid ""
 "Would you like to open the download page?"
 msgstr "Azken bertsioa beti https://github.com/amule-org/amule/releases/latest webgunean aurki daiteke"
 
-#: src/amuleDlg.cpp:678
+#: src/amuleDlg.cpp:743
 msgid "aMule dialog destroyed"
 msgstr "aMule elkarrizketa suntsitua"
 
-#: src/amuleDlg.cpp:701 src/DataToText.cpp:68 src/IPFilter.cpp:547
+#: src/amuleDlg.cpp:766 src/DataToText.cpp:68 src/IPFilter.cpp:547
 msgid "Connecting"
 msgstr "Konektatzen"
 
-#: src/amuleDlg.cpp:893
+#: src/amuleDlg.cpp:958
 msgid "eD2k: Connecting"
 msgstr "eD2k: Konektatzen"
 
-#: src/amuleDlg.cpp:897
+#: src/amuleDlg.cpp:962
 msgid "eD2k: Disconnected"
 msgstr "eD2k: Deskonektatua"
 
-#: src/amuleDlg.cpp:903
+#: src/amuleDlg.cpp:968
 msgid "Kad: Firewalled"
 msgstr "Kad: Suebakirik"
 
-#: src/amuleDlg.cpp:907
+#: src/amuleDlg.cpp:972
 msgid "Kad: Connected"
 msgstr "Kad: Konektaturik"
 
-#: src/amuleDlg.cpp:912
+#: src/amuleDlg.cpp:977
 msgid "Kad: Connecting"
 msgstr "Kad: Konektatzen"
 
-#: src/amuleDlg.cpp:916
+#: src/amuleDlg.cpp:981
 msgid "Kad: Off"
 msgstr "Kad: Itzalia"
 
-#: src/amuleDlg.cpp:964 src/DownloadListCtrl.cpp:505
+#: src/amuleDlg.cpp:1029 src/DownloadListCtrl.cpp:505
 #: src/DownloadListCtrl.cpp:749 src/FriendListCtrl.cpp:180
 #: src/muuli_wdr.cpp:731 src/muuli_wdr.cpp:782 src/muuli_wdr.cpp:846
-#: src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2224 src/muuli_wdr.cpp:2309
-#: src/muuli_wdr.cpp:3057 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
+#: src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2231 src/muuli_wdr.cpp:2316
+#: src/muuli_wdr.cpp:3064 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
 #: src/ServerListCtrl.cpp:606 src/TransferWnd.cpp:378
 #: src/utils/wxCas/src/wxcasprefs.cpp:235
 msgid "Cancel"
 msgstr "Utzi"
 
-#: src/amuleDlg.cpp:965
+#: src/amuleDlg.cpp:1030
 msgid "Stop the current connection attempts"
 msgstr "Geratu uneko konexio saiakerak"
 
-#: src/amuleDlg.cpp:970 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976
-#: src/muuli_wdr.cpp:2447
+#: src/amuleDlg.cpp:1035 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976
+#: src/muuli_wdr.cpp:2454
 msgid "Disconnect"
 msgstr "Deskonektatu"
 
-#: src/amuleDlg.cpp:971
+#: src/amuleDlg.cpp:1036
 msgid "Disconnect from the currently connected networks"
 msgstr "Deskonektatu konektatutako sareetatik"
 
-#: src/amuleDlg.cpp:976 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979
-#: src/muuli_wdr.cpp:2602 src/muuli_wdr.cpp:3054 src/muuli_wdr.cpp:3409
+#: src/amuleDlg.cpp:1041 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979
+#: src/muuli_wdr.cpp:2609 src/muuli_wdr.cpp:3061 src/muuli_wdr.cpp:3416
 msgid "Connect"
 msgstr "Konektatu"
 
-#: src/amuleDlg.cpp:977
+#: src/amuleDlg.cpp:1042
 msgid "Connect to the currently enabled networks"
 msgstr "Konektatu gaituriko sareetara"
 
-#: src/amuleDlg.cpp:1089
+#: src/amuleDlg.cpp:1154
 #, fuzzy, c-format
 msgid "Up: %.1f%s (%.1f) | Down: %.1f%s (%.1f)"
 msgstr "Gora: %.1f(%.1f) | Behera: %.1f(%.1f)"
 
-#: src/amuleDlg.cpp:1091 src/amuleDlg.cpp:1093 src/amuleDlg.cpp:1097
-#: src/amuleDlg.cpp:1099 src/amuleDlg.cpp:1110 src/amuleDlg.cpp:1112
+#: src/amuleDlg.cpp:1156 src/amuleDlg.cpp:1158 src/amuleDlg.cpp:1162
+#: src/amuleDlg.cpp:1164 src/amuleDlg.cpp:1175 src/amuleDlg.cpp:1177
 #: src/MuleTrayIcon.cpp:796 src/MuleTrayIcon.cpp:799
 #, fuzzy
 msgid " MB/s"
 msgstr "MB/s"
 
-#: src/amuleDlg.cpp:1091 src/amuleDlg.cpp:1093 src/amuleDlg.cpp:1097
-#: src/amuleDlg.cpp:1099 src/amuleDlg.cpp:1110 src/amuleDlg.cpp:1112
+#: src/amuleDlg.cpp:1156 src/amuleDlg.cpp:1158 src/amuleDlg.cpp:1162
+#: src/amuleDlg.cpp:1164 src/amuleDlg.cpp:1175 src/amuleDlg.cpp:1177
 #: src/MuleTrayIcon.cpp:796 src/MuleTrayIcon.cpp:799
 #: src/utils/wxCas/src/wxcasframe.cpp:1041
 msgid " kB/s"
 msgstr " kB/s"
 
-#: src/amuleDlg.cpp:1096
+#: src/amuleDlg.cpp:1161
 #, fuzzy, c-format
 msgid "Up: %.1f%s | Down: %.1f%s"
 msgstr "Gora: %.1f | Behera: %.1f"
 
-#: src/amuleDlg.cpp:1128
+#: src/amuleDlg.cpp:1193
 #, c-format
 msgid "aMule (%s | Connected)"
 msgstr "aMule (%s | Konektaturik)"
 
-#: src/amuleDlg.cpp:1130
+#: src/amuleDlg.cpp:1195
 #, c-format
 msgid "aMule (%s | Disconnected)"
 msgstr "aMule (%s | Ez konektaturik)"
 
-#: src/amuleDlg.cpp:1183
+#: src/amuleDlg.cpp:1248
 #, c-format
 msgid "Do you really want to exit %s?"
 msgstr "Benetan %s utzi egin nahi duzu?"
 
-#: src/amuleDlg.cpp:1185
+#: src/amuleDlg.cpp:1250
 msgid "Exit confirmation"
 msgstr "Irteera berrespena"
 
-#: src/amuleDlg.cpp:1548
+#: src/amuleDlg.cpp:1613
 msgid "Launch Command: "
 msgstr "Abiarazi komandoa: "
 
-#: src/amuleDlg.cpp:1567 src/muuli_wdr.cpp:1971 src/Preferences.cpp:951
+#: src/amuleDlg.cpp:1632 src/muuli_wdr.cpp:1978 src/Preferences.cpp:952
 msgid "- default -"
 msgstr "- lehenetsia -"
 
-#: src/amuleDlg.cpp:1595
+#: src/amuleDlg.cpp:1660
 #, c-format
 msgid "Skin directory '%s' does not exist"
 msgstr "Ez dago '%s' itxura direktorioa"
 
-#: src/amuleDlg.cpp:1598
+#: src/amuleDlg.cpp:1663
 #, c-format
 msgid "WARNING: Unable to open skin file '%s' for read"
 msgstr "ABISUA: Ezin da '%s' azal fitxategia irakurri"
 
-#: src/amuleDlg.cpp:1722 src/amuleDlg.cpp:1968 src/muuli_wdr.cpp:1485
-#: src/muuli_wdr.cpp:3411
-msgid "Networks"
-msgstr "Sareak"
-
-#: src/amuleDlg.cpp:1726 src/muuli_wdr.cpp:3411
+#: src/amuleDlg.cpp:1791 src/muuli_wdr.cpp:3418
 msgid "Networks Window"
 msgstr "Sare leihoa"
 
-#: src/amuleDlg.cpp:1728 src/muuli_wdr.cpp:3412
-msgid "Searches"
-msgstr "Bilaketak"
-
-#: src/amuleDlg.cpp:1732 src/muuli_wdr.cpp:3412
+#: src/amuleDlg.cpp:1797 src/muuli_wdr.cpp:3419
 msgid "Searches Window"
 msgstr "Bilaketa leihoa"
 
-#: src/amuleDlg.cpp:1734 src/DownloadListCtrl.cpp:740 src/muuli_wdr.cpp:392
-#: src/muuli_wdr.cpp:1578 src/muuli_wdr.cpp:3413 src/Statistics.cpp:829
-msgid "Downloads"
-msgstr "Deskargak"
-
-#: src/amuleDlg.cpp:1738 src/muuli_wdr.cpp:3413
+#: src/amuleDlg.cpp:1803 src/muuli_wdr.cpp:3420
 msgid "Downloads Window"
 msgstr "Deskargak leihoa"
 
-#: src/amuleDlg.cpp:1740 src/muuli_wdr.cpp:3287
-msgid "Shared files"
-msgstr "Partekatutako fitxategiak"
-
-#: src/amuleDlg.cpp:1744 src/muuli_wdr.cpp:3415
+#: src/amuleDlg.cpp:1809 src/muuli_wdr.cpp:3422
 msgid "Shared Files Window"
 msgstr "Partekatutako fitxategi leihoa"
 
-#: src/amuleDlg.cpp:1746 src/muuli_wdr.cpp:2919 src/muuli_wdr.cpp:3369
-#: src/muuli_wdr.cpp:3416
-msgid "Messages"
-msgstr "Mezuak"
-
-#: src/amuleDlg.cpp:1750 src/muuli_wdr.cpp:3416
+#: src/amuleDlg.cpp:1815 src/muuli_wdr.cpp:3423
 msgid "Messages Window"
 msgstr "Mezu leihoa"
 
-#: src/amuleDlg.cpp:1752 src/muuli_wdr.cpp:3417 src/PrefsUnifiedDlg.cpp:312
-#: src/Statistics.cpp:779 src/Statistics.cpp:1235
-msgid "Statistics"
-msgstr "Estatistikak"
-
-#: src/amuleDlg.cpp:1756 src/muuli_wdr.cpp:3417
+#: src/amuleDlg.cpp:1821 src/muuli_wdr.cpp:3424
 msgid "Statistics Graph Window"
 msgstr "Estatistika grafiko leihoa"
 
-#: src/amuleDlg.cpp:1759 src/muuli_wdr.cpp:3419 src/PrefsUnifiedDlg.cpp:328
-#: src/utils/wxCas/src/wxcasprefs.cpp:39
-msgid "Preferences"
-msgstr "Hobespenak"
-
-#: src/amuleDlg.cpp:1763 src/muuli_wdr.cpp:3419
+#: src/amuleDlg.cpp:1828 src/muuli_wdr.cpp:3426
 msgid "Preferences Settings Window"
 msgstr "Hobespen ezarpen leihoa"
 
-#: src/amuleDlg.cpp:1766 src/muuli_wdr.cpp:3420
+#: src/amuleDlg.cpp:1831 src/muuli_wdr.cpp:3427
 msgid "Import"
 msgstr "Inportatu"
 
-#: src/amuleDlg.cpp:1770 src/muuli_wdr.cpp:3420
+#: src/amuleDlg.cpp:1835 src/muuli_wdr.cpp:3427
 msgid "The partfile importer tool"
 msgstr "Zati fitxategi inportazio tresna"
 
-#: src/amuleDlg.cpp:1773 src/muuli_wdr.cpp:3421
+#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3428
 #: src/utils/aLinkCreator/src/alcframe.cpp:262
 msgid "About"
 msgstr "Honi buruz"
 
-#: src/amuleDlg.cpp:1773 src/muuli_wdr.cpp:3421
+#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3428
 msgid "About/Help"
 msgstr "Honi buruz/Laguntza"
 
-#: src/amuleDlg.cpp:1971
+#: src/amuleDlg.cpp:2036
 msgid "eD2k network"
 msgstr "eD2k sarea"
 
-#: src/amuleDlg.cpp:1974
+#: src/amuleDlg.cpp:2039
 msgid "Kad network"
 msgstr "Kad sarea"
 
-#: src/amuleDlg.cpp:1974
+#: src/amuleDlg.cpp:2039
 msgid "No network"
 msgstr "Sarerik ez"
 
@@ -1352,19 +1357,19 @@ msgstr "Auto[Alt]"
 msgid "Very low"
 msgstr "Oso txikia"
 
-#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:743 src/muuli_wdr.cpp:2275
+#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:743 src/muuli_wdr.cpp:2282
 #: src/ServerListCtrl.cpp:263 src/ServerListCtrl.cpp:456
 #: src/SharedFilesCtrl.cpp:145
 msgid "Low"
 msgstr "Baxua"
 
-#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:744 src/muuli_wdr.cpp:2276
+#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:744 src/muuli_wdr.cpp:2283
 #: src/ServerListCtrl.cpp:266 src/ServerListCtrl.cpp:457
 #: src/SharedFilesCtrl.cpp:146
 msgid "Normal"
 msgstr "Normala"
 
-#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:745 src/muuli_wdr.cpp:2277
+#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:745 src/muuli_wdr.cpp:2284
 #: src/ServerListCtrl.cpp:269 src/ServerListCtrl.cpp:458
 #: src/SharedFilesCtrl.cpp:147
 msgid "High"
@@ -1456,8 +1461,8 @@ msgstr "Zerbitzari lokala"
 msgid "Remote Server"
 msgstr "Urruneko zerbitzaria"
 
-#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3174
-#: src/SearchDlg.cpp:111 src/TextClient.cpp:911
+#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3181
+#: src/SearchDlg.cpp:119 src/TextClient.cpp:911
 msgid "Kad"
 msgstr "Kad"
 
@@ -1528,7 +1533,7 @@ msgstr "Zatia"
 msgid "Size"
 msgstr "Tamaina"
 
-#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3241
+#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3248
 msgid "Transferred"
 msgstr "Transferituta"
 
@@ -1586,7 +1591,7 @@ msgstr ""
 "Erantzuna hemendik: %s (%s)\n"
 "\n"
 
-#: src/DownloadListCtrl.cpp:746 src/muuli_wdr.cpp:2278
+#: src/DownloadListCtrl.cpp:746 src/muuli_wdr.cpp:2285
 #: src/SharedFilesCtrl.cpp:150
 msgid "Auto"
 msgstr "Auto"
@@ -1624,7 +1629,7 @@ msgid "Extended Options"
 msgstr "Hedatutako aukerak"
 
 #: src/DownloadListCtrl.cpp:770 src/DownloadListCtrl.cpp:822
-#: src/muuli_wdr.cpp:1789
+#: src/muuli_wdr.cpp:1796
 msgid "Preview"
 msgstr "Aurrebista"
 
@@ -2335,19 +2340,19 @@ msgstr ""
 msgid "eD2k"
 msgstr "eD2k"
 
-#: src/FirstRunWizard.cpp:349 src/muuli_wdr.cpp:1488
+#: src/FirstRunWizard.cpp:349 src/muuli_wdr.cpp:1495
 msgid "Kademlia"
 msgstr "Kademlia"
 
-#: src/FirstRunWizard.cpp:359 src/muuli_wdr.cpp:1416
+#: src/FirstRunWizard.cpp:359 src/muuli_wdr.cpp:1423
 msgid "Standard TCP Port "
 msgstr "TCP ataka estandarra "
 
-#: src/FirstRunWizard.cpp:365 src/muuli_wdr.cpp:1428
+#: src/FirstRunWizard.cpp:365 src/muuli_wdr.cpp:1435
 msgid "Extended UDP port (Kad / global search) "
 msgstr "Hedatutako UDP ataka (Kad / bilaketa orokorra) "
 
-#: src/FirstRunWizard.cpp:377 src/muuli_wdr.cpp:1435
+#: src/FirstRunWizard.cpp:377 src/muuli_wdr.cpp:1442
 msgid "Enable UPnP for router port forwarding"
 msgstr "Gaitu UPnP router ataka berbideraketarako"
 
@@ -2374,7 +2379,7 @@ msgstr ""
 msgid "Your peer lists are already in place - nothing to download."
 msgstr "Dagoeneko %s fitxategia deskargatzen ari zara"
 
-#: src/FirstRunWizard.cpp:434 src/muuli_wdr.cpp:1533
+#: src/FirstRunWizard.cpp:434 src/muuli_wdr.cpp:1540
 msgid "Auto-update server list at startup"
 msgstr "Auto-eguneratu zerbitzari zerrenda abioan"
 
@@ -2420,23 +2425,23 @@ msgid ""
 "want downloads on a different (e.g. larger) disk."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:549 src/FirstRunWizard.cpp:611 src/muuli_wdr.cpp:1701
+#: src/FirstRunWizard.cpp:549 src/FirstRunWizard.cpp:611 src/muuli_wdr.cpp:1708
 msgid "Destination folder for downloads"
 msgstr "Deskargentzat helburu karpeta"
 
-#: src/FirstRunWizard.cpp:553 src/FirstRunWizard.cpp:569 src/muuli_wdr.cpp:1342
-#: src/muuli_wdr.cpp:1359 src/muuli_wdr.cpp:1676 src/muuli_wdr.cpp:1707
-#: src/muuli_wdr.cpp:1719 src/muuli_wdr.cpp:2762
+#: src/FirstRunWizard.cpp:553 src/FirstRunWizard.cpp:569 src/muuli_wdr.cpp:1349
+#: src/muuli_wdr.cpp:1366 src/muuli_wdr.cpp:1683 src/muuli_wdr.cpp:1714
+#: src/muuli_wdr.cpp:1726 src/muuli_wdr.cpp:2769
 #: src/utils/aLinkCreator/src/alcframe.cpp:135
 #: src/utils/wxCas/src/wxcasprefs.cpp:52 src/utils/wxCas/src/wxcasprefs.cpp:118
 msgid "Browse"
 msgstr "Arakatu"
 
-#: src/FirstRunWizard.cpp:559 src/muuli_wdr.cpp:1712
+#: src/FirstRunWizard.cpp:559 src/muuli_wdr.cpp:1719
 msgid "(All files in this folder are shared with other peers)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:565 src/FirstRunWizard.cpp:624 src/muuli_wdr.cpp:1714
+#: src/FirstRunWizard.cpp:565 src/FirstRunWizard.cpp:624 src/muuli_wdr.cpp:1721
 msgid "Folder for temporary download files"
 msgstr "Aldiroko deskarga fitxategientzat karpeta"
 
@@ -2467,7 +2472,7 @@ msgstr "Huts 'emfriends.met' lagun zerrenda fitxategia idazteko irekitzean!"
 msgid "CRITICAL - no client on StartChatSession"
 msgstr "KRITIKOA - ez dago bezerorik StartChatSession-en"
 
-#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2668 src/muuli_wdr.cpp:3345
+#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2675 src/muuli_wdr.cpp:3352
 msgid "Friends"
 msgstr "Lagunak"
 
@@ -2853,7 +2858,7 @@ msgstr "Partekatze erlazioa"
 msgid "Uploaded"
 msgstr "Igoa"
 
-#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3225
+#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3232
 msgid "Requested"
 msgstr "Eskatutakoa"
 
@@ -2977,7 +2982,7 @@ msgid "WARNING: "
 msgstr "OHARRA: "
 
 #: src/MuleNotebook.cpp:179 src/muuli_wdr.cpp:817 src/muuli_wdr.cpp:1229
-#: src/muuli_wdr.cpp:3129 src/muuli_wdr.cpp:3385
+#: src/muuli_wdr.cpp:3136 src/muuli_wdr.cpp:3392
 msgid "Close"
 msgstr "Itxi"
 
@@ -2990,12 +2995,12 @@ msgstr "Ebaki"
 msgid "Copy"
 msgstr "Kopiatu"
 
-#: src/MuleTextCtrl.cpp:88
+#: src/MuleTextCtrl.cpp:88 src/SearchDlg.cpp:261
 msgid "Paste"
 msgstr "Itsatsi"
 
 #: src/MuleTextCtrl.cpp:89 src/muuli_wdr.cpp:358 src/muuli_wdr.cpp:757
-#: src/muuli_wdr.cpp:2352 src/muuli_wdr.cpp:2371 src/muuli_wdr.cpp:2393
+#: src/muuli_wdr.cpp:2359 src/muuli_wdr.cpp:2378 src/muuli_wdr.cpp:2400
 #: src/utils/aLinkCreator/src/alcframe.cpp:142
 msgid "Clear"
 msgstr "Garbitu"
@@ -3093,8 +3098,8 @@ msgid "Exit"
 msgstr "Irten"
 
 #: src/MuleTrayIcon.cpp:579 src/MuleTrayIcon.cpp:945 src/MuleTrayIcon.cpp:965
-#: src/muuli_wdr.cpp:1391 src/muuli_wdr.cpp:1399 src/muuli_wdr.cpp:1406
-#: src/muuli_wdr.cpp:1835 src/muuli_wdr.cpp:1841 src/OtherFunctions.cpp:91
+#: src/muuli_wdr.cpp:1398 src/muuli_wdr.cpp:1406 src/muuli_wdr.cpp:1413
+#: src/muuli_wdr.cpp:1842 src/muuli_wdr.cpp:1848 src/OtherFunctions.cpp:91
 #: src/StatisticsDlg.cpp:93 src/StatisticsDlg.cpp:95
 msgid "kB/s"
 msgstr "kB/s"
@@ -3265,7 +3270,7 @@ msgstr "Izena:"
 msgid "Type"
 msgstr "Mota"
 
-#: src/muuli_wdr.cpp:215 src/SearchDlg.cpp:110 src/SearchListCtrl.cpp:853
+#: src/muuli_wdr.cpp:215 src/SearchDlg.cpp:118 src/SearchListCtrl.cpp:853
 msgid "Local"
 msgstr "Lokala"
 
@@ -3336,7 +3341,7 @@ msgstr "Byte"
 msgid "KB"
 msgstr "KB"
 
-#: src/muuli_wdr.cpp:274 src/muuli_wdr.cpp:293 src/muuli_wdr.cpp:1620
+#: src/muuli_wdr.cpp:274 src/muuli_wdr.cpp:293 src/muuli_wdr.cpp:1627
 #: src/OtherFunctions.cpp:64
 msgid "MB"
 msgstr "MB"
@@ -3353,7 +3358,7 @@ msgstr "Gehi. tamaina"
 msgid "Availability"
 msgstr "Eskuragarritasuna"
 
-#: src/muuli_wdr.cpp:312 src/muuli_wdr.cpp:398 src/muuli_wdr.cpp:3290
+#: src/muuli_wdr.cpp:312 src/muuli_wdr.cpp:398 src/muuli_wdr.cpp:3297
 msgid "Filter:"
 msgstr "Iragazkia:"
 
@@ -3385,7 +3390,7 @@ msgstr ""
 msgid "Stop"
 msgstr "Gelditu"
 
-#: src/muuli_wdr.cpp:348 src/muuli_wdr.cpp:1385 src/SearchListCtrl.cpp:732
+#: src/muuli_wdr.cpp:348 src/muuli_wdr.cpp:1392 src/SearchListCtrl.cpp:732
 msgid "Download"
 msgstr "Deskargatu"
 
@@ -3416,8 +3421,8 @@ msgstr "Fitxategiaren iturburua:"
 #: src/muuli_wdr.cpp:1160 src/muuli_wdr.cpp:1167 src/muuli_wdr.cpp:1172
 #: src/muuli_wdr.cpp:1179 src/muuli_wdr.cpp:1184 src/muuli_wdr.cpp:1191
 #: src/muuli_wdr.cpp:1205 src/muuli_wdr.cpp:1212 src/muuli_wdr.cpp:1217
-#: src/muuli_wdr.cpp:1224 src/muuli_wdr.cpp:3227 src/muuli_wdr.cpp:3235
-#: src/muuli_wdr.cpp:3243
+#: src/muuli_wdr.cpp:1224 src/muuli_wdr.cpp:3234 src/muuli_wdr.cpp:3242
+#: src/muuli_wdr.cpp:3250
 msgid "N/A"
 msgstr "E/G"
 
@@ -3562,7 +3567,7 @@ msgstr ""
 msgid "Album :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:685 src/muuli_wdr.cpp:2247
+#: src/muuli_wdr.cpp:685 src/muuli_wdr.cpp:2254
 msgid "Title :"
 msgstr "Titulua :"
 
@@ -3671,7 +3676,7 @@ msgstr "Erabiltzaile-izena :"
 msgid "Userhash :"
 msgstr "Erabiltzaile aztertze zenbakia :"
 
-#: src/muuli_wdr.cpp:895 src/muuli_wdr.cpp:1741 src/muuli_wdr.cpp:2442
+#: src/muuli_wdr.cpp:895 src/muuli_wdr.cpp:1748 src/muuli_wdr.cpp:2449
 #: src/utils/aLinkCreator/src/alcframe.cpp:137
 msgid "Add"
 msgstr "Gehitu"
@@ -3680,15 +3685,15 @@ msgstr "Gehitu"
 msgid "Download-Speed"
 msgstr "Deskarga abiadura"
 
-#: src/muuli_wdr.cpp:954 src/muuli_wdr.cpp:989 src/muuli_wdr.cpp:2546
+#: src/muuli_wdr.cpp:954 src/muuli_wdr.cpp:989 src/muuli_wdr.cpp:2553
 msgid "Current"
 msgstr "Unekoa"
 
-#: src/muuli_wdr.cpp:962 src/muuli_wdr.cpp:997 src/muuli_wdr.cpp:2554
+#: src/muuli_wdr.cpp:962 src/muuli_wdr.cpp:997 src/muuli_wdr.cpp:2561
 msgid "Running average"
 msgstr "Funtzionamendu bataz bestekoa"
 
-#: src/muuli_wdr.cpp:970 src/muuli_wdr.cpp:1005 src/muuli_wdr.cpp:2562
+#: src/muuli_wdr.cpp:970 src/muuli_wdr.cpp:1005 src/muuli_wdr.cpp:2569
 msgid "Session average"
 msgstr "saio batez bestekoa"
 
@@ -3700,7 +3705,7 @@ msgstr "Igoera abiadura"
 msgid "Connections"
 msgstr "Konexioak"
 
-#: src/muuli_wdr.cpp:1024 src/muuli_wdr.cpp:1860
+#: src/muuli_wdr.cpp:1024 src/muuli_wdr.cpp:1867
 msgid "Active downloads"
 msgstr "Deskarga aktiboak"
 
@@ -3708,7 +3713,7 @@ msgstr "Deskarga aktiboak"
 msgid "Active connections (1:1)"
 msgstr "konexio aktiboak (1:1)"
 
-#: src/muuli_wdr.cpp:1040 src/muuli_wdr.cpp:1861
+#: src/muuli_wdr.cpp:1040 src/muuli_wdr.cpp:1868
 msgid "Active uploads"
 msgstr "Igoera aktiboak"
 
@@ -3824,8 +3829,8 @@ msgstr "Hau beste erabiltzaileek zuri konektatzerakoan ikusiko duten izena da."
 msgid "Language: "
 msgstr "Hizkuntza: "
 
-#: src/muuli_wdr.cpp:1257 src/muuli_wdr.cpp:1323 src/muuli_wdr.cpp:1327
-#: src/muuli_wdr.cpp:1330
+#: src/muuli_wdr.cpp:1257 src/muuli_wdr.cpp:1330 src/muuli_wdr.cpp:1334
+#: src/muuli_wdr.cpp:1337
 msgid "The delay before showing tool-tips."
 msgstr "Argibideak bistarazi aurreko denbora."
 
@@ -3903,936 +3908,945 @@ msgstr ""
 msgid "Enabling this will make aMule to show notifications when finished downloading."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1322
+#: src/muuli_wdr.cpp:1323
+#, fuzzy
+msgid "Remember search history"
+msgstr "Ezarpen hauek gogoratu"
+
+#: src/muuli_wdr.cpp:1324
+msgid "Keeps a dropdown list of your past search terms in the Search tab's Name field. This remembers the queries you typed, not the results they returned."
+msgstr ""
+
+#: src/muuli_wdr.cpp:1329
 msgid "Tooltip delay time: "
 msgstr "Gomendio atzerapena: "
 
-#: src/muuli_wdr.cpp:1329
+#: src/muuli_wdr.cpp:1336
 msgid "seconds"
 msgstr "segundo"
 
-#: src/muuli_wdr.cpp:1333
+#: src/muuli_wdr.cpp:1340
 msgid "Browser Selection"
 msgstr "Nabigatzaile hautaketa"
 
-#: src/muuli_wdr.cpp:1339
+#: src/muuli_wdr.cpp:1346
 msgid "Enter your browser name here. Leave this field empty to use the system default browser."
 msgstr "Idatzi zure nabigatzaile izena hemen. Zurian utzi sisteman lehenetsitako nabigatzailea erabiltzeko."
 
-#: src/muuli_wdr.cpp:1346
+#: src/muuli_wdr.cpp:1353
 msgid "Open in new tab if possible"
 msgstr "Ireki fitxa berrian aukera dagoenenean"
 
-#: src/muuli_wdr.cpp:1348
+#: src/muuli_wdr.cpp:1355
 msgid "Open the web page in a new tab instead of in a new window when possible"
 msgstr "Ireki web orria fitxa berrian leiho berrian ordez aukera dagoenenean"
 
-#: src/muuli_wdr.cpp:1352
+#: src/muuli_wdr.cpp:1359
 msgid "Video Player"
 msgstr "Bideo-erreproduzigailua"
 
-#: src/muuli_wdr.cpp:1379
+#: src/muuli_wdr.cpp:1386
 msgid "Bandwidth limits"
 msgstr "Konexio mugak"
 
-#: src/muuli_wdr.cpp:1393
+#: src/muuli_wdr.cpp:1400
 msgid "Upload"
 msgstr "Igo"
 
-#: src/muuli_wdr.cpp:1401
+#: src/muuli_wdr.cpp:1408
 msgid "Slot Allocation"
 msgstr "Ataka ezarpena"
 
-#: src/muuli_wdr.cpp:1410
+#: src/muuli_wdr.cpp:1417
 msgid "Ports"
 msgstr "Atakak"
 
-#: src/muuli_wdr.cpp:1420
+#: src/muuli_wdr.cpp:1427
 msgid "This is the standard eD2k port and cannot be disabled."
 msgstr "Hau eD2k ataka estandarra da eta ezin da ezgaitu."
 
-#: src/muuli_wdr.cpp:1423
+#: src/muuli_wdr.cpp:1430
 msgid "UDP port for server requests (TCP+3):"
 msgstr "UDP ataka zerbitzari eskakizunetarako (TCP+3):"
 
-#: src/muuli_wdr.cpp:1425
+#: src/muuli_wdr.cpp:1432
 msgid "4665"
 msgstr "4665"
 
-#: src/muuli_wdr.cpp:1432
+#: src/muuli_wdr.cpp:1439
 msgid "This UDP port is used for extended eD2k requests and Kad network"
 msgstr "UDP ataka hau hedaturiko eD2k eskakizun eta Kad sarerako erabiltzen da"
 
-#: src/muuli_wdr.cpp:1439
+#: src/muuli_wdr.cpp:1446
 msgid "UPnP TCP Port (Optional):"
 msgstr "UPnP TCP ataka (aukerakoa):"
 
-#: src/muuli_wdr.cpp:1449
+#: src/muuli_wdr.cpp:1456
 msgid "Bind local address to IP (empty for any):"
 msgstr "Lotu helbide lokala IP batetara (zurian edozeinentzat):"
 
-#: src/muuli_wdr.cpp:1452
+#: src/muuli_wdr.cpp:1459
 msgid "Advanced users only: If you have multiple network interfaces, enter the address of the interface to which aMule should be bound."
 msgstr "Erabiltzaile aurreratuak bakarrik: Sare interfaze anitz badituzu idatzi amulek erabili behar duen sare interfazearen helbidea."
 
-#: src/muuli_wdr.cpp:1455 src/muuli_wdr.cpp:2054
+#: src/muuli_wdr.cpp:1462 src/muuli_wdr.cpp:2061
 #, fuzzy
 msgid "Bind to network interface (empty for any):"
 msgstr "Lotu helbide lokala IP batetara (zurian edozeinentzat):"
 
-#: src/muuli_wdr.cpp:1468
+#: src/muuli_wdr.cpp:1475
 msgid "Advanced users only: pin all of aMule's traffic to one network interface, chosen from the list or typed in by name (e.g. tun0, eth0, en0) or index. Unlike binding to an IP, this stops traffic leaking out via the default route - useful with a VPN. Requires no elevated privileges."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1474
+#: src/muuli_wdr.cpp:1481
 msgid "Max sources per downloading file:"
 msgstr "Jatorri muga deskarga bakoitzerako:"
 
-#: src/muuli_wdr.cpp:1478
+#: src/muuli_wdr.cpp:1485
 msgid "Max simultaneous connections:"
 msgstr "Aldibereko konexioa muga:"
 
-#: src/muuli_wdr.cpp:1491 src/muuli_wdr.cpp:3169
+#: src/muuli_wdr.cpp:1498 src/muuli_wdr.cpp:3176
 msgid "ED2K"
 msgstr "ED2K"
 
-#: src/muuli_wdr.cpp:1498
+#: src/muuli_wdr.cpp:1505
 msgid "Autoconnect on startup"
 msgstr "Konektatu abiaraztekoan"
 
-#: src/muuli_wdr.cpp:1501
+#: src/muuli_wdr.cpp:1508
 msgid "Reconnect on loss"
 msgstr "birkonektatu konexioa galtzean"
 
-#: src/muuli_wdr.cpp:1523
+#: src/muuli_wdr.cpp:1530
 msgid "Remove dead server after"
 msgstr "Ezabatu hildako zerbitzaria geroago"
 
-#: src/muuli_wdr.cpp:1524
+#: src/muuli_wdr.cpp:1531
 msgid "Static servers are never removed, even when unreachable."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1528
+#: src/muuli_wdr.cpp:1535
 msgid "retries"
 msgstr "saiakerak"
 
-#: src/muuli_wdr.cpp:1536
+#: src/muuli_wdr.cpp:1543
 msgid "List"
 msgstr "Zerrenda"
 
-#: src/muuli_wdr.cpp:1539
+#: src/muuli_wdr.cpp:1546
 msgid "Update server list when connecting to a server"
 msgstr "Eguneratu zerbitzari zerrenda zerbitzari batetara konektatzean"
 
-#: src/muuli_wdr.cpp:1542
+#: src/muuli_wdr.cpp:1549
 msgid "Update server list when a client connects"
 msgstr "Eguneratu zerbitzari zerrenda bezero bat konektatzean"
 
-#: src/muuli_wdr.cpp:1545
+#: src/muuli_wdr.cpp:1552
 msgid "Use priority system"
 msgstr "Erabili lehentasun sistema"
 
-#: src/muuli_wdr.cpp:1549
+#: src/muuli_wdr.cpp:1556
 msgid "Use smart LowID check on connect"
 msgstr "Erabili IDbaxu egiaztapena konektatzerakoan"
 
-#: src/muuli_wdr.cpp:1553
+#: src/muuli_wdr.cpp:1560
 msgid "Safe connect"
 msgstr "Konexio ziurra"
 
-#: src/muuli_wdr.cpp:1557
+#: src/muuli_wdr.cpp:1564
 msgid "Autoconnect to servers in static list only"
 msgstr "Estatiko zerbitzarietara bakarrik auto-konektatu"
 
-#: src/muuli_wdr.cpp:1560
+#: src/muuli_wdr.cpp:1567
 msgid "Set manually added servers to High Priority"
 msgstr "Ezarri eskuz gehitutako zerbitzariak lehentasun altuan"
 
-#: src/muuli_wdr.cpp:1581
+#: src/muuli_wdr.cpp:1588
 msgid "Add files to download in pause mode"
 msgstr "Gehitu fitxategiak deskargetara geldirik"
 
-#: src/muuli_wdr.cpp:1583
+#: src/muuli_wdr.cpp:1590
 msgid "Add files to download with auto priority"
 msgstr "Gehitu fitxategiak deskarga zerrendara auto-lehentasunarekin"
 
-#: src/muuli_wdr.cpp:1586
+#: src/muuli_wdr.cpp:1593
 msgid "Try to download first and last chunks first"
 msgstr "Saiatu lehen eta azken zatiak hasieran deskargatzen"
 
-#: src/muuli_wdr.cpp:1590
+#: src/muuli_wdr.cpp:1597
 msgid "Endgame mode: rotate to faster sources for the final blocks"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1593
+#: src/muuli_wdr.cpp:1600
 msgid "Start next paused file when a file completes"
 msgstr "Abiarazi lehen pausaturiko fitxategia fitxategi bat osatzean"
 
-#: src/muuli_wdr.cpp:1596
+#: src/muuli_wdr.cpp:1603
 msgid "From the same category"
 msgstr "Kategoria berdinekoa"
 
-#: src/muuli_wdr.cpp:1598
+#: src/muuli_wdr.cpp:1605
 msgid "In alphabetic order"
 msgstr "Orden alfabetikoan"
 
-#: src/muuli_wdr.cpp:1600
+#: src/muuli_wdr.cpp:1607
 msgid "Preallocate disk space for new files"
 msgstr "Aurresleitu disko lekua fitxategi berrientzat"
 
-#: src/muuli_wdr.cpp:1601
+#: src/muuli_wdr.cpp:1608
 msgid "For new files preallocates disk space for the whole file, thus reduces fragmentation"
 msgstr "Fitxategi berrientzat fitxategi bakoitzarentzat disko leku osoa aurresleitzen du, honek fragmentazioa murrizten du"
 
-#: src/muuli_wdr.cpp:1606
+#: src/muuli_wdr.cpp:1613
 msgid "Create new files as sparse files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1607
+#: src/muuli_wdr.cpp:1614
 msgid "A sparse file reserves its full size on disk immediately without writing real data to it -- fast, but unsupported or slow on some filesystems, and free-space accounting stays optimistic while the download is in progress. Turn this off to grow the file only as data arrives."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1612
+#: src/muuli_wdr.cpp:1619
 msgid "Stop downloads when free disk space reaches "
 msgstr "Gelditu deskargak disko-leku librea hona iristean "
 
-#: src/muuli_wdr.cpp:1613
+#: src/muuli_wdr.cpp:1620
 msgid "Select this if you want aMule to check your disk space"
 msgstr "Aukera hau hautatu aMulek zure disko-lekua egiaztatzea nahi baduzu"
 
-#: src/muuli_wdr.cpp:1617
+#: src/muuli_wdr.cpp:1624
 msgid "Enter here the min disk space desired."
 msgstr "Ezarri hemen nahi duzu disko toki txikiena."
 
-#: src/muuli_wdr.cpp:1623
+#: src/muuli_wdr.cpp:1630
 msgid "Save 10 sources on rare files (< 20 sources)"
 msgstr "10 jatorri gorde fitxategi arraroentzat (< 20 jatorri)"
 
-#: src/muuli_wdr.cpp:1627 src/Statistics.cpp:790
+#: src/muuli_wdr.cpp:1634 src/Statistics.cpp:790
 msgid "Uploads"
 msgstr "Igoerak"
 
-#: src/muuli_wdr.cpp:1630
+#: src/muuli_wdr.cpp:1637
 msgid "Add new shared files with auto priority"
 msgstr "Gehitu partekatutako fitxategi berriak auto-lehentasunarekin"
 
-#: src/muuli_wdr.cpp:1636
+#: src/muuli_wdr.cpp:1643
 msgid "Intelligent Corruption Handling (I.C.H.)"
 msgstr "Hondatze kudeaketa adimentsua (I.C.H)"
 
-#: src/muuli_wdr.cpp:1639
+#: src/muuli_wdr.cpp:1646
 msgid "Enable"
 msgstr "Gaitu"
 
-#: src/muuli_wdr.cpp:1642
+#: src/muuli_wdr.cpp:1649
 msgid "Advanced I.C.H. trusts every hash (not recommended)"
 msgstr "I.C.H aurreratuak, egiaztapen bakoitza egiaztatzen du (ez da gomendatzen)"
 
-#: src/muuli_wdr.cpp:1654 src/PrefsUnifiedDlg.cpp:1910
+#: src/muuli_wdr.cpp:1661 src/PrefsUnifiedDlg.cpp:1910
 msgid "Media metadata extraction"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1658
+#: src/muuli_wdr.cpp:1665
 msgid "Extract length / bitrate / codec from shared audio and video files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1660
+#: src/muuli_wdr.cpp:1667
 msgid "When enabled, aMule runs ffprobe on each shared media file to fill in the Length / Bitrate / Codec columns other clients see when they find the file in a search. Requires ffmpeg (the ffprobe binary) to be installed."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1667
+#: src/muuli_wdr.cpp:1674
 msgid "Path to ffprobe:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1672
+#: src/muuli_wdr.cpp:1679
 msgid "Full path to the ffprobe binary. Leave empty to have aMule auto-detect it on startup."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1680
+#: src/muuli_wdr.cpp:1687
 msgid "Detect"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1681
+#: src/muuli_wdr.cpp:1688
 msgid "Search the standard install locations for an ffprobe binary and fill the path field."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1705
+#: src/muuli_wdr.cpp:1712
 msgid ""
 "Completed downloads are stored here. All files in this folder are automatically shared with other peers.\n"
 "If this folder also holds files you don't want to share, point it at an aMule-only sub-folder."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1708
+#: src/muuli_wdr.cpp:1715
 msgid "Pick the folder where completed downloads will be stored. All files in that folder will be shared with other peers."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1722
+#: src/muuli_wdr.cpp:1729
 msgid "Shared folders"
 msgstr "Partekatutako karpetak"
 
-#: src/muuli_wdr.cpp:1728
+#: src/muuli_wdr.cpp:1735
 msgid "(Folders shared by the core. Enter a path to add one.)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1736
+#: src/muuli_wdr.cpp:1743
 msgid "Absolute path of a folder on the core's machine, e.g. /home/user/shared"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1738 src/PrefsUnifiedDlg.cpp:2794
+#: src/muuli_wdr.cpp:1745 src/PrefsUnifiedDlg.cpp:2794
 msgid "Recursive"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1739
+#: src/muuli_wdr.cpp:1746
 msgid "Share every sub-folder underneath this one, including ones created later."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1743 src/utils/aLinkCreator/src/alcframe.cpp:141
+#: src/muuli_wdr.cpp:1750 src/utils/aLinkCreator/src/alcframe.cpp:141
 msgid "Remove"
 msgstr "Ezabatu"
 
-#: src/muuli_wdr.cpp:1747
+#: src/muuli_wdr.cpp:1754
 msgid "(Right click on folder icon for recursive share)"
 msgstr "(Egin klik eskuineko botoiaz karpeta ikono batean barnekoak ere partekatzeko)"
 
-#: src/muuli_wdr.cpp:1754
+#: src/muuli_wdr.cpp:1761
 msgid "Share hidden files"
 msgstr "Partekatu ezkutatutako fitxategiak"
 
-#: src/muuli_wdr.cpp:1760
+#: src/muuli_wdr.cpp:1767
 msgid "Automatically rescan shared folders for changes"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1766
+#: src/muuli_wdr.cpp:1773
 msgid "Follow symbolic links in shared folders"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1772
+#: src/muuli_wdr.cpp:1779
 msgid "Exclude files matching:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1775
+#: src/muuli_wdr.cpp:1782
 msgid "Wildcard patterns separated by '|', e.g. .DS_Store|Thumbs.db|*.tmp. Files whose name matches are not shared. Matching is case-insensitive."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1779
+#: src/muuli_wdr.cpp:1786
 msgid "Patterns are regular expressions"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1780
+#: src/muuli_wdr.cpp:1787
 msgid "When set, the whole field is one regular expression ('|' is alternation). When unset, it is a list of '|'-separated wildcards."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1790
+#: src/muuli_wdr.cpp:1797
 msgid "Show how many shared files the current pattern would exclude."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1811
+#: src/muuli_wdr.cpp:1818
 msgid "Graphs"
 msgstr "Grafikak"
 
-#: src/muuli_wdr.cpp:1814 src/muuli_wdr.cpp:1876
+#: src/muuli_wdr.cpp:1821 src/muuli_wdr.cpp:1883
 msgid "Update delay : 5 secs"
 msgstr "Eguneratze atzerapena : 5 seg"
 
-#: src/muuli_wdr.cpp:1818
+#: src/muuli_wdr.cpp:1825
 msgid "Time for average graph: 100 mins"
 msgstr "Bataz besteko grafiko denbora : 100 min"
 
-#: src/muuli_wdr.cpp:1822
+#: src/muuli_wdr.cpp:1829
 msgid "Connections Graph Scale: 100 "
 msgstr "Konexio graf eskala: 100 "
 
-#: src/muuli_wdr.cpp:1829
+#: src/muuli_wdr.cpp:1836
 msgid "Download graph scale:"
 msgstr "Deskarga grafiko eskala:"
 
-#: src/muuli_wdr.cpp:1837
+#: src/muuli_wdr.cpp:1844
 msgid "Upload graph scale:"
 msgstr "Igoera grafiko eskala:"
 
-#: src/muuli_wdr.cpp:1847
+#: src/muuli_wdr.cpp:1854
 #, fuzzy
 msgid "Colors: "
 msgstr "Koloreak: "
 
-#: src/muuli_wdr.cpp:1851
+#: src/muuli_wdr.cpp:1858
 msgid "Background"
 msgstr "Atzeko planoa"
 
-#: src/muuli_wdr.cpp:1852
+#: src/muuli_wdr.cpp:1859
 msgid "Grid"
 msgstr "Sareta"
 
-#: src/muuli_wdr.cpp:1853
+#: src/muuli_wdr.cpp:1860
 msgid "Download current"
 msgstr "Uneko deskargak"
 
-#: src/muuli_wdr.cpp:1854
+#: src/muuli_wdr.cpp:1861
 msgid "Download running average"
 msgstr "Martxan deskargak bataz bestean"
 
-#: src/muuli_wdr.cpp:1855
+#: src/muuli_wdr.cpp:1862
 msgid "Download session average"
 msgstr "Saioaren bataz besteko deskargak"
 
-#: src/muuli_wdr.cpp:1856
+#: src/muuli_wdr.cpp:1863
 msgid "Upload current"
 msgstr "Uneko igoerak"
 
-#: src/muuli_wdr.cpp:1857
+#: src/muuli_wdr.cpp:1864
 msgid "Upload running average"
 msgstr "Martxan igoerak bataz bestean"
 
-#: src/muuli_wdr.cpp:1858
+#: src/muuli_wdr.cpp:1865
 msgid "Upload session average"
 msgstr "Saioaren bataz besteko igoerak"
 
-#: src/muuli_wdr.cpp:1859
+#: src/muuli_wdr.cpp:1866
 msgid "Active connections"
 msgstr "Konexio aktiboak"
 
-#: src/muuli_wdr.cpp:1862
+#: src/muuli_wdr.cpp:1869
 #, fuzzy
 msgid "Systray Icon Speed Bar"
 msgstr "Sistema-barra abiadura-barra ikonoa"
 
-#: src/muuli_wdr.cpp:1863
+#: src/muuli_wdr.cpp:1870
 msgid "Kad-nodes current"
 msgstr "Uneko Kad-nodoak"
 
-#: src/muuli_wdr.cpp:1864
+#: src/muuli_wdr.cpp:1871
 msgid "Kad-nodes running"
 msgstr "Kad-nodoak martxan"
 
-#: src/muuli_wdr.cpp:1865
+#: src/muuli_wdr.cpp:1872
 msgid "Kad-nodes session"
 msgstr "Kad-nodo saioa"
 
-#: src/muuli_wdr.cpp:1869 src/muuli_wdr.cpp:2296
+#: src/muuli_wdr.cpp:1876 src/muuli_wdr.cpp:2303
 msgid "Select"
 msgstr "Hautatu"
 
-#: src/muuli_wdr.cpp:1873
+#: src/muuli_wdr.cpp:1880
 msgid "Tree"
 msgstr "Zuhaitza"
 
-#: src/muuli_wdr.cpp:1883
+#: src/muuli_wdr.cpp:1890
 msgid "Number of Client Versions shown (0=unlimited)"
 msgstr "Erakutsiko diren bezero kopurua (0=mugagabea)"
 
-#: src/muuli_wdr.cpp:1908
+#: src/muuli_wdr.cpp:1915
 msgid "!!! WARNING !!!"
 msgstr "!!! KONTUZ !!!"
 
-#: src/muuli_wdr.cpp:1923
+#: src/muuli_wdr.cpp:1930
 msgid "Max new connections / 5 secs"
 msgstr "Gehienezko konexio berri / 5 seg"
 
-#: src/muuli_wdr.cpp:1925
+#: src/muuli_wdr.cpp:1932
 msgid "Concurrent Kad source lookups"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1927
+#: src/muuli_wdr.cpp:1934
 #, fuzzy
 msgid "Kad source re-search interval (minutes)"
 msgstr "FTP igoera aldia minututan"
 
-#: src/muuli_wdr.cpp:1929
+#: src/muuli_wdr.cpp:1936
 #, fuzzy
 msgid "Source re-ask interval (minutes)"
 msgstr "FTP igoera aldia minututan"
 
-#: src/muuli_wdr.cpp:1933
+#: src/muuli_wdr.cpp:1940
 msgid "File Buffer Size: 240000 bytes"
 msgstr "Fitxategia buffer tamaina: 240000 byte"
 
-#: src/muuli_wdr.cpp:1937
+#: src/muuli_wdr.cpp:1944
 msgid "Use MMAP: memory-mapped file access (lower memory use)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1938
+#: src/muuli_wdr.cpp:1945
 msgid "Maps part files into memory instead of buffering them on the heap, lowering the process memory footprint. May reduce download speed on some disks; best for memory-constrained or upload-heavy hosts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1940
+#: src/muuli_wdr.cpp:1947
 msgid "Upload Queue Size: 5000 clients"
 msgstr "Igoera ilara tamaina: 5000 bezero"
 
-#: src/muuli_wdr.cpp:1944
+#: src/muuli_wdr.cpp:1951
 msgid "Server connection refresh interval: Disable"
 msgstr "Zerbitzari konexio berritze aldia: Ezgaiturik"
 
-#: src/muuli_wdr.cpp:1948
+#: src/muuli_wdr.cpp:1955
 msgid "Disable computer's timed standby mode"
 msgstr "Ezgaitu ordenagailu ordulariaren bigarren planoko modua"
 
-#: src/muuli_wdr.cpp:1967
+#: src/muuli_wdr.cpp:1974
 msgid "Skin to use: "
 msgstr "Erabiltzeko azala: "
 
-#: src/muuli_wdr.cpp:1976
+#: src/muuli_wdr.cpp:1983
 msgid "Show \"Fast eD2k Links Handler\" in every window."
 msgstr "Erakutsi \"eD2k lotura kudeatzaile azkarra\" leiho bakoitzean."
 
-#: src/muuli_wdr.cpp:1979
+#: src/muuli_wdr.cpp:1986
 msgid "Show extended info on categories tabs"
 msgstr "Erakutsi argibide hedatuak kategoria fitxetan"
 
-#: src/muuli_wdr.cpp:1982
+#: src/muuli_wdr.cpp:1989
 msgid "Show application version on title"
 msgstr "Erakutsi aplikazio bertsioa izenburuan"
 
-#: src/muuli_wdr.cpp:1984
+#: src/muuli_wdr.cpp:1991
 msgid "Show transfer rates on title"
 msgstr "Erakutsi transferentziak izenburuan"
 
-#: src/muuli_wdr.cpp:1986
+#: src/muuli_wdr.cpp:1993
 msgid "Before application name"
 msgstr "Aplikazio izenaren aurretik"
 
-#: src/muuli_wdr.cpp:1988
+#: src/muuli_wdr.cpp:1995
 msgid "After application name"
 msgstr "Aplikazio izenaren ondoren"
 
-#: src/muuli_wdr.cpp:1991
+#: src/muuli_wdr.cpp:1998
 msgid "Show overhead bandwidth"
 msgstr "Erakutsi goiburu erabilpena"
 
-#: src/muuli_wdr.cpp:1995
+#: src/muuli_wdr.cpp:2002
 msgid "Vertical toolbar orientation"
 msgstr "Tresna-barra bertikal orientazioa"
 
-#: src/muuli_wdr.cpp:1997
+#: src/muuli_wdr.cpp:2004
 msgid "Live column sorting (auto-reorder rows as their values change)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2004
+#: src/muuli_wdr.cpp:2011
 msgid "Download Queue Files"
 msgstr "Deskargatu ilara fitxategiak"
 
-#: src/muuli_wdr.cpp:2007
+#: src/muuli_wdr.cpp:2014
 msgid "Show progress percentage"
 msgstr "Erakutsi aurrerapen ehunekoa"
 
-#: src/muuli_wdr.cpp:2013
+#: src/muuli_wdr.cpp:2020
 msgid "Show progress bar"
 msgstr "Erakutsi aurrerapen barra"
 
-#: src/muuli_wdr.cpp:2016
+#: src/muuli_wdr.cpp:2023
 msgid "Flat"
 msgstr "Laua"
 
-#: src/muuli_wdr.cpp:2020
+#: src/muuli_wdr.cpp:2027
 msgid "Round"
 msgstr "Biribildu"
 
-#: src/muuli_wdr.cpp:2038
+#: src/muuli_wdr.cpp:2045
 msgid "External Connection Parameters"
 msgstr "Urruneko konexio ezarpenak"
 
-#: src/muuli_wdr.cpp:2041
+#: src/muuli_wdr.cpp:2048
 msgid "Accept external connections"
 msgstr "Onartu urruneko konexioak"
 
-#: src/muuli_wdr.cpp:2048 src/muuli_wdr.cpp:2107
+#: src/muuli_wdr.cpp:2055 src/muuli_wdr.cpp:2114
 msgid "IP of the listening interface:"
 msgstr "Entzunean dagoen interfazearen IPa:"
 
-#: src/muuli_wdr.cpp:2051
+#: src/muuli_wdr.cpp:2058
 msgid "Enter here a valid ip in the a.b.c.d format for the listening EC interface. An empty field or 0.0.0.0 will mean any interface."
 msgstr "Idatzi hemen a.b.c.d formatuan entzun behar den interfazearen baliozko ip helbidea. Eremu huts batek edo 0.0.0.0 ezartzeak edozein interfazetan entzutea eragingo du."
 
-#: src/muuli_wdr.cpp:2072 src/muuli_wdr.cpp:2156
+#: src/muuli_wdr.cpp:2079 src/muuli_wdr.cpp:2163
 msgid "TCP port:"
 msgstr "TCP ataka:"
 
-#: src/muuli_wdr.cpp:2078
+#: src/muuli_wdr.cpp:2085
 msgid "Enable UPnP port forwarding on the EC port"
 msgstr "UPnP berbideraketa gaitu EC atakan"
 
-#: src/muuli_wdr.cpp:2082 src/muuli_wdr.cpp:3041
+#: src/muuli_wdr.cpp:2089 src/muuli_wdr.cpp:3048
 #: src/utils/wxCas/src/wxcasprefs.cpp:167
 msgid "Password"
 msgstr "Pasahitza"
 
-#: src/muuli_wdr.cpp:2088
+#: src/muuli_wdr.cpp:2095
 #, fuzzy
 msgid "aMule API server parameters"
 msgstr "Web zerbitzari parametroak"
 
-#: src/muuli_wdr.cpp:2091
+#: src/muuli_wdr.cpp:2098
 msgid "Run amuleapi (REST API) on startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2096
+#: src/muuli_wdr.cpp:2103
 #, fuzzy
 msgid "HTTP port:"
 msgstr "TCP ataka:"
 
-#: src/muuli_wdr.cpp:2110
+#: src/muuli_wdr.cpp:2117
 msgid "The interface amuleapi's HTTP server listens on. 127.0.0.1 (default) accepts only local connections; use 0.0.0.0 or a specific IP to expose it to other hosts (set an admin password below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2113
+#: src/muuli_wdr.cpp:2120
 #, fuzzy
 msgid "Admin password"
 msgstr "Pasahitz egiaztatzen\n"
 
-#: src/muuli_wdr.cpp:2118 src/muuli_wdr.cpp:2149
+#: src/muuli_wdr.cpp:2125 src/muuli_wdr.cpp:2156
 msgid "Low rights password"
 msgstr "Baimen baxuko pasahitza"
 
-#: src/muuli_wdr.cpp:2126
+#: src/muuli_wdr.cpp:2133
 msgid "Web server parameters"
 msgstr "Web zerbitzari parametroak"
 
-#: src/muuli_wdr.cpp:2129
+#: src/muuli_wdr.cpp:2136
 #, fuzzy
 msgid "Run webserver on startup (deprecated)"
 msgstr "Exekutatu web-zerbitzaria abioan"
 
-#: src/muuli_wdr.cpp:2135
+#: src/muuli_wdr.cpp:2142
 msgid "Web template"
 msgstr "Web txantiloia"
 
-#: src/muuli_wdr.cpp:2140
+#: src/muuli_wdr.cpp:2147
 msgid "Full rights password"
 msgstr "Baimen osorako pasahitza"
 
-#: src/muuli_wdr.cpp:2144
+#: src/muuli_wdr.cpp:2151
 msgid "Enable Low rights User"
 msgstr "Gaitu baimen gutxiko erabiltzailea"
 
-#: src/muuli_wdr.cpp:2163
+#: src/muuli_wdr.cpp:2170
 msgid "Enable UPnP port forwarding of the web server port"
 msgstr "Gaitu web zerbitzari atakaren UPnP ataka birbidalketa"
 
-#: src/muuli_wdr.cpp:2168
+#: src/muuli_wdr.cpp:2175
 msgid "Web server UPnP TCP port (Optional)"
 msgstr "Web zerbitzari UPnP ataka (aukerakoa)"
 
-#: src/muuli_wdr.cpp:2176
+#: src/muuli_wdr.cpp:2183
 msgid "Page Refresh Time (in secs)"
 msgstr "Orrialdea berritzeko denbora (segundotan)"
 
-#: src/muuli_wdr.cpp:2183
+#: src/muuli_wdr.cpp:2190
 msgid "Enable Gzip compression"
 msgstr "Gaitu Gzip konpresioa"
 
-#: src/muuli_wdr.cpp:2217
+#: src/muuli_wdr.cpp:2224
 #, fuzzy
 msgid "Reset page to defaults"
 msgstr "Sistema lehenetsia"
 
-#: src/muuli_wdr.cpp:2218
+#: src/muuli_wdr.cpp:2225
 msgid "Reset the settings on the current page to their default values."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2220 src/muuli_wdr.cpp:2306 src/ServerWnd.cpp:274
+#: src/muuli_wdr.cpp:2227 src/muuli_wdr.cpp:2313 src/ServerWnd.cpp:274
 #: src/ServerWnd.cpp:282
 msgid "OK"
 msgstr "Ados"
 
-#: src/muuli_wdr.cpp:2222
+#: src/muuli_wdr.cpp:2229
 msgid "Click here to apply any changes made to the preferences."
 msgstr "Hemen klik egin hobespenetan eginiko edozein aldaketa ezartzeko."
 
-#: src/muuli_wdr.cpp:2225
+#: src/muuli_wdr.cpp:2232
 msgid "Reset any changes made to the preferences."
 msgstr "Berrezarri hobespenetan eginiko edozein aldaketa."
 
-#: src/muuli_wdr.cpp:2254
+#: src/muuli_wdr.cpp:2261
 msgid "Comment :"
 msgstr "Iruzkina :"
 
-#: src/muuli_wdr.cpp:2261
+#: src/muuli_wdr.cpp:2268
 msgid "Incoming Dir :"
 msgstr "Deskarga direktorioa :"
 
-#: src/muuli_wdr.cpp:2270
+#: src/muuli_wdr.cpp:2277
 msgid "Change priority for new assigned files :"
 msgstr "Aldatu lehentasuna fitxategi berrientzat :"
 
-#: src/muuli_wdr.cpp:2274
+#: src/muuli_wdr.cpp:2281
 msgid "Don't change"
 msgstr "Ez aldatu"
 
-#: src/muuli_wdr.cpp:2286
+#: src/muuli_wdr.cpp:2293
 msgid "Select color for this Category (currently selected) :"
 msgstr "Hautatu kolorea kategoria honentzat (unean aukeratutakoa) :"
 
-#: src/muuli_wdr.cpp:2353 src/muuli_wdr.cpp:2372 src/muuli_wdr.cpp:2394
+#: src/muuli_wdr.cpp:2360 src/muuli_wdr.cpp:2379 src/muuli_wdr.cpp:2401
 msgid "Click this button to reset the log."
 msgstr "Botoi hau klikatu erregistroa garbitzeko."
 
-#: src/muuli_wdr.cpp:2413
+#: src/muuli_wdr.cpp:2420
 msgid "Click on this button to update the servers list from URL ..."
 msgstr "Klik egin botoi honetan zerbitzari zerrenda URL-tik eguneratzeko ..."
 
-#: src/muuli_wdr.cpp:2417
+#: src/muuli_wdr.cpp:2424
 msgid "Server list"
 msgstr "Zerbitzari zerrenda"
 
-#: src/muuli_wdr.cpp:2421
+#: src/muuli_wdr.cpp:2428
 msgid "Enter the url to a server.met file here and press the button to the left to update the list of known servers."
 msgstr "Idatzi server.met fitxategiaren URL bat hemen eta gero ezkerreko botoia sakatu zerbitzari ezagunen zerrenda eguneratzeko."
 
-#: src/muuli_wdr.cpp:2426
+#: src/muuli_wdr.cpp:2433
 msgid "Add server manually: Name"
 msgstr "Gehitu zerbitzaria eskuz: Izena"
 
-#: src/muuli_wdr.cpp:2429
+#: src/muuli_wdr.cpp:2436
 msgid "Enter the name of the new server here"
 msgstr "Idatzi zerbitzari berriaren izen hemen"
 
-#: src/muuli_wdr.cpp:2431 src/ServerWnd.cpp:206
+#: src/muuli_wdr.cpp:2438 src/ServerWnd.cpp:206
 msgid "IP:Port"
 msgstr "IP ataka"
 
-#: src/muuli_wdr.cpp:2434
+#: src/muuli_wdr.cpp:2441
 msgid "Enter the IP of the server here, using the x.x.x.x format."
 msgstr "Idatzi x.x.x.x formatua erabiliaz zerbitzariaren ip helbidea."
 
-#: src/muuli_wdr.cpp:2440
+#: src/muuli_wdr.cpp:2447
 msgid "Enter the port of the server here."
 msgstr "Idatzi zerbitzariaren ataka hemen."
 
-#: src/muuli_wdr.cpp:2443
+#: src/muuli_wdr.cpp:2450
 msgid "Add manually a server (fill fields to the left before) ..."
 msgstr "Gehitu zerbitzari bat eskuz (sar datuak ezkerrean lehenik) ..."
 
-#: src/muuli_wdr.cpp:2472
+#: src/muuli_wdr.cpp:2479
 msgid "aMule Log"
 msgstr "aMule erregistroa"
 
-#: src/muuli_wdr.cpp:2480
+#: src/muuli_wdr.cpp:2487
 msgid "Server Info"
 msgstr "Zerbitzari argibideak"
 
-#: src/muuli_wdr.cpp:2484
+#: src/muuli_wdr.cpp:2491
 msgid "ED2K Info"
 msgstr "Argb"
 
-#: src/muuli_wdr.cpp:2488
+#: src/muuli_wdr.cpp:2495
 msgid "Kad Info"
 msgstr "Kad Argb"
 
-#: src/muuli_wdr.cpp:2516
+#: src/muuli_wdr.cpp:2523
 msgid "Click on this button to update the nodes list from URL ..."
 msgstr "Klikatu botoi honetan nodo zerrenda URL honetatik eguneratzeko ..."
 
-#: src/muuli_wdr.cpp:2520
+#: src/muuli_wdr.cpp:2527
 msgid "Nodes (0)"
 msgstr "Nodoak (0)"
 
-#: src/muuli_wdr.cpp:2524
+#: src/muuli_wdr.cpp:2531
 msgid "Enter the url to a nodes.dat file here and press the button to the left to update the list of known nodes."
 msgstr "nodes.dat fitxategi baten URL-a idatzi eta ezkerreko botoia sakatu nodo ezagunen zerrenda eguneratzeko."
 
-#: src/muuli_wdr.cpp:2527
+#: src/muuli_wdr.cpp:2534
 msgid "Nodes stats"
 msgstr "Nodo estatistikak"
 
-#: src/muuli_wdr.cpp:2569
+#: src/muuli_wdr.cpp:2576
 msgid "Bootstrap"
 msgstr "Autoabioa"
 
-#: src/muuli_wdr.cpp:2572
+#: src/muuli_wdr.cpp:2579
 msgid "New node"
 msgstr "Nodo berria"
 
-#: src/muuli_wdr.cpp:2577
+#: src/muuli_wdr.cpp:2584
 msgid "IP:"
 msgstr "IP:"
 
-#: src/muuli_wdr.cpp:2597
+#: src/muuli_wdr.cpp:2604
 msgid "Port:"
 msgstr "Ataka:"
 
-#: src/muuli_wdr.cpp:2610
+#: src/muuli_wdr.cpp:2617
 msgid "Bootstrap from known clients"
 msgstr "Bezero ezagunetarik abiarazi"
 
-#: src/muuli_wdr.cpp:2612
+#: src/muuli_wdr.cpp:2619
 msgid "Disconnect Kad"
 msgstr "Kad deskonektatu"
 
-#: src/muuli_wdr.cpp:2646
+#: src/muuli_wdr.cpp:2653
 msgid "Use Secure User Identification"
 msgstr "Erabili erabiltzaile identifikazio segurua"
 
-#: src/muuli_wdr.cpp:2648
+#: src/muuli_wdr.cpp:2655
 msgid "It is recommended to enable this option. You will not receive credits if SUI is not enabled."
 msgstr "Gomendagarri da aukera hau gaitzea. Ez duzu krediturik jasoko EIS erabiltzen ez baduzu."
 
-#: src/muuli_wdr.cpp:2650
+#: src/muuli_wdr.cpp:2657
 msgid "Protocol Obfuscation"
 msgstr "Protokolo nahastea"
 
-#: src/muuli_wdr.cpp:2653
+#: src/muuli_wdr.cpp:2660
 msgid "Support Protocol Obfuscation"
 msgstr "Gaitu protokolo nahastea"
 
-#: src/muuli_wdr.cpp:2655
+#: src/muuli_wdr.cpp:2662
 msgid "This option enabled Protocol Obfuscation, and makes aMule accept obfuscated connections from other clients."
 msgstr "Aukera honek protokolo nahastea gaitzen du eta aMule-k beste bezeroetako konexio nahastuak onartzea eragite du."
 
-#: src/muuli_wdr.cpp:2657
+#: src/muuli_wdr.cpp:2664
 msgid "Use obfuscation for outgoing connections"
 msgstr "Erabili nahastea kanporako konexioetan"
 
-#: src/muuli_wdr.cpp:2659
+#: src/muuli_wdr.cpp:2666
 msgid "This option makes aMule use Protocol Obfuscation when connecting other clients/servers."
 msgstr "Aukera honek Amulek beste bezero/zerbitzarietara konektatzerakoan protokolo nahastea erabiltzea eragiten du."
 
-#: src/muuli_wdr.cpp:2661
+#: src/muuli_wdr.cpp:2668
 msgid "Accept only obfuscated connections"
 msgstr "Onartu nahasitako konexioak bakarrik"
 
-#: src/muuli_wdr.cpp:2662
+#: src/muuli_wdr.cpp:2669
 msgid "This option makes aMule only accept obfuscated connections. You will have less sources, but all your traffic will be obfuscated"
 msgstr "Aukera honek Amulek nahasitako konexioak bakarrik onartzea eragiten du. Jatorri gutxiago izango dituzu baina zure trafiko guztia nahasia egongo da"
 
-#: src/muuli_wdr.cpp:2667
+#: src/muuli_wdr.cpp:2674
 msgid "Everybody"
 msgstr "Edozeini"
 
-#: src/muuli_wdr.cpp:2669
+#: src/muuli_wdr.cpp:2676
 msgid "No one"
 msgstr "Bat ere ez"
 
-#: src/muuli_wdr.cpp:2671
+#: src/muuli_wdr.cpp:2678
 msgid "Who can see my shared files:"
 msgstr "Nork ikusi ditzaken nire partekatutako fitxategiak:"
 
-#: src/muuli_wdr.cpp:2672
+#: src/muuli_wdr.cpp:2679
 msgid "Select who can request to view a list of your shared files."
 msgstr "Hautatu zure partekatutako fitxategiak nork ikus ditzakeen."
 
-#: src/muuli_wdr.cpp:2674
+#: src/muuli_wdr.cpp:2681
 msgid "IP-Filtering"
 msgstr "IP-Iragazkia"
 
-#: src/muuli_wdr.cpp:2681
+#: src/muuli_wdr.cpp:2688
 msgid "Filter clients"
 msgstr "Bezeroak iragazi"
 
-#: src/muuli_wdr.cpp:2683
+#: src/muuli_wdr.cpp:2690
 msgid "Enable filtering of the client IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "~/.aMule/ipfilter.dat fitxategian ezarritako bezero IP iragazketa gaitu."
 
-#: src/muuli_wdr.cpp:2685
+#: src/muuli_wdr.cpp:2692
 msgid "Filter servers"
 msgstr "Zerbitzariak iragazi"
 
-#: src/muuli_wdr.cpp:2687
+#: src/muuli_wdr.cpp:2694
 msgid "Enable filtering of the server IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "~/.aMule/ipfilter.dat fitxategian ezarritako zerbitzari IP iragazketa gaitu."
 
-#: src/muuli_wdr.cpp:2691
+#: src/muuli_wdr.cpp:2698
 msgid "Reload List"
 msgstr "Berritu zerrenda"
 
-#: src/muuli_wdr.cpp:2692
+#: src/muuli_wdr.cpp:2699
 msgid "Reload the list of IPs to filter from the file ~/.aMule/ipfilter.dat"
 msgstr "Berritu ~/.aMule/ipfilter.dat fitxategian ezarritako IP helbideen iragazkia"
 
-#: src/muuli_wdr.cpp:2698
+#: src/muuli_wdr.cpp:2705
 msgid "URL:"
 msgstr "URL-a:"
 
-#: src/muuli_wdr.cpp:2702 src/muuli_wdr.cpp:2895
+#: src/muuli_wdr.cpp:2709 src/muuli_wdr.cpp:2902
 msgid "Update now"
 msgstr "Eguneratu orain"
 
-#: src/muuli_wdr.cpp:2705
+#: src/muuli_wdr.cpp:2712
 msgid "Auto-update ipfilter at startup"
 msgstr "Automatikoki eguneratu ip iragazkia abioan"
 
-#: src/muuli_wdr.cpp:2709
+#: src/muuli_wdr.cpp:2716
 msgid "Filtering Level:"
 msgstr "Iragazki maila:"
 
-#: src/muuli_wdr.cpp:2715
+#: src/muuli_wdr.cpp:2722
 msgid "Always filter LAN IPs"
 msgstr "Beti iragazi LAN IP-ak"
 
-#: src/muuli_wdr.cpp:2718
+#: src/muuli_wdr.cpp:2725
 msgid "Paranoid handling of non-matching IPs"
 msgstr "Paranoia kudeaketa pareko ez diren IP helbideentzat"
 
-#: src/muuli_wdr.cpp:2720
+#: src/muuli_wdr.cpp:2727
 msgid "Rejects a packet when its source IP differs from the IP the client claims (an anti-spoofing check). Disable only if it causes connection problems."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2722
+#: src/muuli_wdr.cpp:2729
 msgid "Use system-wide ipfilter.dat if available"
 msgstr "Erabili sistemako ipfilter.dat eskuragarri badago"
 
-#: src/muuli_wdr.cpp:2723
+#: src/muuli_wdr.cpp:2730
 #, fuzzy
 msgid "If there's no local ipfilter.dat found, allow usage of a system-wide ipfilter file."
 msgstr "Ez bada ipfilter.dat fitxategi lokalik aurkitu, orduan onartu sistema ipfilter fitxategia erabiltzea."
 
-#: src/muuli_wdr.cpp:2740
+#: src/muuli_wdr.cpp:2747
 msgid "Enable Online-Signature"
 msgstr "Gaitu sinadura linean"
 
-#: src/muuli_wdr.cpp:2742
+#: src/muuli_wdr.cpp:2749
 msgid "Enables the writing of the OS file, which can be used by external apps to create signatures and the like."
 msgstr "Gaitu sistemak fitxategiak idaztea, kanpo programek sinadurak sortu ahal izateko egiten da."
 
-#: src/muuli_wdr.cpp:2746
+#: src/muuli_wdr.cpp:2753
 msgid "Update Frequency (Secs):"
 msgstr "Eguneratu maiztasuna (Seg):"
 
-#: src/muuli_wdr.cpp:2749
+#: src/muuli_wdr.cpp:2756
 msgid "Change the frequency (in seconds) of Online Signature updates."
 msgstr "Aldatu linean sinadura eguneraketa aldia (segundotan)."
 
-#: src/muuli_wdr.cpp:2757
+#: src/muuli_wdr.cpp:2764
 msgid "Save online signature file in: "
 msgstr "Gorde sare sinadura fitxategia hemen: "
 
-#: src/muuli_wdr.cpp:2763
+#: src/muuli_wdr.cpp:2770
 msgid "Click here to select the directory containing the the Online Signature files."
 msgstr "Klikatu hemen linean sinadurak dituen karpeta aukeratzeko."
 
-#: src/muuli_wdr.cpp:2796
+#: src/muuli_wdr.cpp:2803
 msgid "Show country flags for clients"
 msgstr "Bistarazi estatu banderak bezeroentzat"
 
-#: src/muuli_wdr.cpp:2797
+#: src/muuli_wdr.cpp:2804
 msgid "Render the country flag column in the transfers, queue and search views. Requires a valid MMDB GeoIP database (see below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2802
+#: src/muuli_wdr.cpp:2809
 #, fuzzy
 msgid "Database"
 msgstr "Data abiadura :"
 
-#: src/muuli_wdr.cpp:2818
+#: src/muuli_wdr.cpp:2825
 #, fuzzy
 msgid "Source:"
 msgstr "Jatorriak"
 
-#: src/muuli_wdr.cpp:2821
+#: src/muuli_wdr.cpp:2828
 msgid "DB-IP (free, no account)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2822
+#: src/muuli_wdr.cpp:2829
 msgid "MaxMind GeoLite2 (free, account required)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2823
+#: src/muuli_wdr.cpp:2830
 msgid "Custom URL"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2826
+#: src/muuli_wdr.cpp:2833
 msgid "Choose which provider supplies the GeoIP MMDB database. DB-IP is the default - no account required. MaxMind requires a free account + license key. Use Custom URL to point at any other MMDB host (e.g. a local mirror)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2843
+#: src/muuli_wdr.cpp:2850
 msgid ""
 "No configuration required.\n"
 "\n"
@@ -4840,11 +4854,11 @@ msgid ""
 "License: Creative Commons BY 4.0 - https://creativecommons.org/licenses/by/4.0/"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2856
+#: src/muuli_wdr.cpp:2863
 msgid "License key:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2862
+#: src/muuli_wdr.cpp:2869
 msgid ""
 "Sign up for a free MaxMind account, then generate a License Key:\n"
 "https://www.maxmind.com/en/geolite2/signup\n"
@@ -4854,226 +4868,226 @@ msgid ""
 "Requires attribution and account registration; refresh at least every 30 days."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2877
+#: src/muuli_wdr.cpp:2884
 #, fuzzy
 msgid "Download URL:"
 msgstr "Deskargak: "
 
-#: src/muuli_wdr.cpp:2883
+#: src/muuli_wdr.cpp:2890
 msgid ""
 "Must point to an .mmdb file or a .gz / .tar.gz containing one.\n"
 "URL may include credentials (https://user:pass@host/...).\n"
 "License and attribution terms are set by the upstream URL - you are responsible."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2896
+#: src/muuli_wdr.cpp:2903
 msgid "Download the GeoIP database from the selected source."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2898
+#: src/muuli_wdr.cpp:2905
 #, fuzzy
 msgid "Auto-update on startup"
 msgstr "Automatikoki eguneratu ip iragazkia abioan"
 
-#: src/muuli_wdr.cpp:2899
+#: src/muuli_wdr.cpp:2906
 msgid "Re-download the GeoIP database from the selected source every time aMule starts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2922
+#: src/muuli_wdr.cpp:2929
 msgid "Filter incoming messages (except current chat):"
 msgstr "sarrera mezu iragazkia (txat honetan ezik):"
 
-#: src/muuli_wdr.cpp:2924
+#: src/muuli_wdr.cpp:2931
 msgid "Filter all messages"
 msgstr "Mezu guztiak iragazi"
 
-#: src/muuli_wdr.cpp:2926
+#: src/muuli_wdr.cpp:2933
 msgid "Filter messages from people not on your friend list"
 msgstr "Lagun zerrendan ez daudenen mezuak iragazi"
 
-#: src/muuli_wdr.cpp:2928
+#: src/muuli_wdr.cpp:2935
 msgid "Filter messages from unknown clients"
 msgstr "Bezero ezezagunen mezuak iragazi"
 
-#: src/muuli_wdr.cpp:2930
+#: src/muuli_wdr.cpp:2937
 msgid "Filter messages containing (use ',' as separator):"
 msgstr "Hau duten mezuak iragazi (erabili ',' bereizle bezala):"
 
-#: src/muuli_wdr.cpp:2933 src/muuli_wdr.cpp:2944
+#: src/muuli_wdr.cpp:2940 src/muuli_wdr.cpp:2951
 msgid "add here the words amule should filter and block messages including it"
 msgstr "Gehitu amulek mezuetan blokeatzea nahi dituzun hitzak"
 
-#: src/muuli_wdr.cpp:2935
+#: src/muuli_wdr.cpp:2942
 msgid "Show received messages in the log"
 msgstr "Ikusi jasotako mezuak erregistroan"
 
-#: src/muuli_wdr.cpp:2938
+#: src/muuli_wdr.cpp:2945
 msgid "Comments"
 msgstr "Iruzkinak"
 
-#: src/muuli_wdr.cpp:2941
+#: src/muuli_wdr.cpp:2948
 msgid "Filter comments containing (use ',' as separator):"
 msgstr "Fitxategi iruzkinak hau du (',' erabili bereizle gisa):"
 
-#: src/muuli_wdr.cpp:2966
+#: src/muuli_wdr.cpp:2973
 msgid "Enable Proxy"
 msgstr "Proxy-a gaitu"
 
-#: src/muuli_wdr.cpp:2967
+#: src/muuli_wdr.cpp:2974
 msgid "Enable/disable proxy support"
 msgstr "Proxy onarpena gaitu/ezgaitu"
 
-#: src/muuli_wdr.cpp:2970
+#: src/muuli_wdr.cpp:2977
 msgid "Proxy type:"
 msgstr "Proxy mota:"
 
-#: src/muuli_wdr.cpp:2981
+#: src/muuli_wdr.cpp:2988
 msgid "Proxy host:"
 msgstr "Proxy ostalaria:"
 
-#: src/muuli_wdr.cpp:2984
+#: src/muuli_wdr.cpp:2991
 msgid "The proxy host name"
 msgstr "Proxy ostalari izena"
 
-#: src/muuli_wdr.cpp:2986
+#: src/muuli_wdr.cpp:2993
 msgid "Proxy port:"
 msgstr "Proxy ataka:"
 
-#: src/muuli_wdr.cpp:2989
+#: src/muuli_wdr.cpp:2996
 msgid "The proxy port"
 msgstr "Proxy ataka"
 
-#: src/muuli_wdr.cpp:2991
+#: src/muuli_wdr.cpp:2998
 msgid "Enable authentication"
 msgstr "Gaitu autentifikazioa"
 
-#: src/muuli_wdr.cpp:2992
+#: src/muuli_wdr.cpp:2999
 msgid "Enable/disable username/password authentication"
 msgstr "erabiltzaile/pasahitz autentifikazioa gaitu/ezgaitu"
 
-#: src/muuli_wdr.cpp:2995
+#: src/muuli_wdr.cpp:3002
 msgid "Username: "
 msgstr "Erabiltzaile izena: "
 
-#: src/muuli_wdr.cpp:2998
+#: src/muuli_wdr.cpp:3005
 msgid "The username to use to connect to the proxy"
 msgstr "Proxy-ra konektatzeko erabiliko den erabiltzaile izena"
 
-#: src/muuli_wdr.cpp:3000
+#: src/muuli_wdr.cpp:3007
 msgid "Password:"
 msgstr "Pasahitza:"
 
-#: src/muuli_wdr.cpp:3003
+#: src/muuli_wdr.cpp:3010
 msgid "The password to use to connect to the proxy"
 msgstr "Proxy-ra konektatzeko erabiliko den pasahitza"
 
-#: src/muuli_wdr.cpp:3022
+#: src/muuli_wdr.cpp:3029
 msgid "Connect to:"
 msgstr "Hona konektaturik:"
 
-#: src/muuli_wdr.cpp:3031
+#: src/muuli_wdr.cpp:3038
 msgid "Login to remote amule"
 msgstr "Urruneko aMulen saioa hasi"
 
-#: src/muuli_wdr.cpp:3036
+#: src/muuli_wdr.cpp:3043
 msgid "User name"
 msgstr "Erabiltzaile izena"
 
-#: src/muuli_wdr.cpp:3047
+#: src/muuli_wdr.cpp:3054
 msgid "Remember those settings"
 msgstr "Ezarpen hauek gogoratu"
 
-#: src/muuli_wdr.cpp:3050
+#: src/muuli_wdr.cpp:3057
 #, fuzzy
 msgid "Force ZLIB compression"
 msgstr "Erabili gzip konpresioa"
 
-#: src/muuli_wdr.cpp:3074
+#: src/muuli_wdr.cpp:3081
 msgid "Enable Verbose Debug-Logging."
 msgstr "Gaitu arazten luzeko saio hasiera."
 
-#: src/muuli_wdr.cpp:3076
+#: src/muuli_wdr.cpp:3083
 #, fuzzy
 msgid "Only to Logfile"
 msgstr "&Ireki fitxategia"
 
-#: src/muuli_wdr.cpp:3078
+#: src/muuli_wdr.cpp:3085
 msgid "Message Categories:"
 msgstr "Mezu kategoriak:"
 
-#: src/muuli_wdr.cpp:3102 src/PartFileConvertDlg.cpp:160
+#: src/muuli_wdr.cpp:3109 src/PartFileConvertDlg.cpp:160
 msgid "Waiting..."
 msgstr "Zain..."
 
-#: src/muuli_wdr.cpp:3122
+#: src/muuli_wdr.cpp:3129
 msgid "Add imports"
 msgstr "Gehitu"
 
-#: src/muuli_wdr.cpp:3125
+#: src/muuli_wdr.cpp:3132
 msgid "Retry selected"
 msgstr "Berriz saiatu hautaturikoak"
 
-#: src/muuli_wdr.cpp:3127
+#: src/muuli_wdr.cpp:3134
 msgid "Remove selected"
 msgstr "Ezabatu hautaturikoak"
 
-#: src/muuli_wdr.cpp:3190
+#: src/muuli_wdr.cpp:3197
 msgid "Event Types"
 msgstr "Gertaera motak"
 
-#: src/muuli_wdr.cpp:3209
+#: src/muuli_wdr.cpp:3216
 msgid "Statistics and queued clients for selected file(s) : Session / All time"
 msgstr "Hautako fitxategientzat estatistika eta bezero ilara: Saioa / osotara"
 
-#: src/muuli_wdr.cpp:3233
+#: src/muuli_wdr.cpp:3240
 msgid "Active Uploads"
 msgstr "Igoera aktiboak"
 
-#: src/muuli_wdr.cpp:3247
+#: src/muuli_wdr.cpp:3254
 msgid "Percent of total files"
 msgstr "fitxategi guztien ehunekoa"
 
-#: src/muuli_wdr.cpp:3299
+#: src/muuli_wdr.cpp:3306
 msgid "Show Clients for"
 msgstr "Erakutsi bezeroak:"
 
-#: src/muuli_wdr.cpp:3301
+#: src/muuli_wdr.cpp:3308
 msgid "All files"
 msgstr "Fitxategi guztiak"
 
-#: src/muuli_wdr.cpp:3304
+#: src/muuli_wdr.cpp:3311
 msgid "Selected files"
 msgstr "Hautatutako fitxategiak"
 
-#: src/muuli_wdr.cpp:3307
+#: src/muuli_wdr.cpp:3314
 msgid "Active uploads only"
 msgstr "Igoera aktiboak bakarrik"
 
-#: src/muuli_wdr.cpp:3314
+#: src/muuli_wdr.cpp:3321
 msgid "Reload:"
 msgstr "Berritu:"
 
-#: src/muuli_wdr.cpp:3318
+#: src/muuli_wdr.cpp:3325
 msgid "Reload your shared files"
 msgstr "Berritu zure partekatutako fitxategiak"
 
-#: src/muuli_wdr.cpp:3381
+#: src/muuli_wdr.cpp:3388
 msgid "Send"
 msgstr "Bidali"
 
-#: src/muuli_wdr.cpp:3382
+#: src/muuli_wdr.cpp:3389
 msgid "Sends the specified message."
 msgstr "Zehaztutako mezua bidali."
 
-#: src/muuli_wdr.cpp:3386
+#: src/muuli_wdr.cpp:3393
 msgid "Close this chat-session."
 msgstr "Itxi elkarrizketa saio hau."
 
-#: src/muuli_wdr.cpp:3409
+#: src/muuli_wdr.cpp:3416
 msgid "Connect to any server and/or Kad"
 msgstr "Konektatu edozein zerbitzari eta/edo Kad"
 
-#: src/muuli_wdr.cpp:3415 src/SharedFilesCtrl.cpp:142 src/Statistics.cpp:941
+#: src/muuli_wdr.cpp:3422 src/SharedFilesCtrl.cpp:142 src/Statistics.cpp:941
 msgid "Shared Files"
 msgstr "Partekatutako fitxategiak"
 
@@ -5432,188 +5446,188 @@ msgstr "Deskargatua"
 msgid "ERROR: Failed to open partfile '%s'"
 msgstr "ERROREA: Huts '%s' zati fitxategia irekitzean"
 
-#: src/Preferences.cpp:673
+#: src/Preferences.cpp:674
 msgid "System default"
 msgstr "Sistema lehenetsia"
 
-#: src/Preferences.cpp:674
+#: src/Preferences.cpp:675
 msgid "Albanian"
 msgstr "Albaniera"
 
-#: src/Preferences.cpp:675
+#: src/Preferences.cpp:676
 msgid "Arabic"
 msgstr "Arabiera"
 
-#: src/Preferences.cpp:676
+#: src/Preferences.cpp:677
 msgid "Asturian"
 msgstr "Bablea"
 
-#: src/Preferences.cpp:677
+#: src/Preferences.cpp:678
 msgid "Basque"
 msgstr "Euskara"
 
-#: src/Preferences.cpp:678
+#: src/Preferences.cpp:679
 msgid "Bulgarian"
 msgstr "Bulgariera"
 
-#: src/Preferences.cpp:679
+#: src/Preferences.cpp:680
 msgid "Catalan"
 msgstr "Katalana"
 
-#: src/Preferences.cpp:680
+#: src/Preferences.cpp:681
 msgid "Chinese (Simplified)"
 msgstr "Txinatarra (Sinplea)"
 
-#: src/Preferences.cpp:681
+#: src/Preferences.cpp:682
 msgid "Chinese (Traditional)"
 msgstr "Txinatarra (ohizkoa)"
 
-#: src/Preferences.cpp:682
+#: src/Preferences.cpp:683
 msgid "Croatian"
 msgstr "Kroaziera"
 
-#: src/Preferences.cpp:683
+#: src/Preferences.cpp:684
 msgid "Czech"
 msgstr "Txekiera"
 
-#: src/Preferences.cpp:684
+#: src/Preferences.cpp:685
 msgid "Danish"
 msgstr "Daniera"
 
-#: src/Preferences.cpp:685
+#: src/Preferences.cpp:686
 msgid "Dutch"
 msgstr "Nederlandera"
 
-#: src/Preferences.cpp:686
+#: src/Preferences.cpp:687
 msgid "English (U.K.)"
 msgstr "Ingelesa (E.B.)"
 
-#: src/Preferences.cpp:687
+#: src/Preferences.cpp:688
 #, fuzzy
 msgid "English (U.S.)"
 msgstr "Ingelesa (E.B.)"
 
-#: src/Preferences.cpp:688
+#: src/Preferences.cpp:689
 msgid "Estonian"
 msgstr "Estoniera"
 
-#: src/Preferences.cpp:689
+#: src/Preferences.cpp:690
 msgid "Finnish"
 msgstr "Finlandiera"
 
-#: src/Preferences.cpp:690
+#: src/Preferences.cpp:691
 msgid "French"
 msgstr "Frantsesa"
 
-#: src/Preferences.cpp:691
+#: src/Preferences.cpp:692
 msgid "Galician"
 msgstr "Galiziera"
 
-#: src/Preferences.cpp:692
+#: src/Preferences.cpp:693
 msgid "German"
 msgstr "Alemana"
 
-#: src/Preferences.cpp:693
+#: src/Preferences.cpp:694
 msgid "Greek"
 msgstr "Grekoa"
 
-#: src/Preferences.cpp:694
+#: src/Preferences.cpp:695
 msgid "Hebrew"
 msgstr "Hebreera"
 
-#: src/Preferences.cpp:695
+#: src/Preferences.cpp:696
 msgid "Hungarian"
 msgstr "Hungariera"
 
-#: src/Preferences.cpp:696
+#: src/Preferences.cpp:697
 msgid "Italian"
 msgstr "Italiera"
 
-#: src/Preferences.cpp:697
+#: src/Preferences.cpp:698
 msgid "Japanese"
 msgstr "Japoniera"
 
-#: src/Preferences.cpp:698
+#: src/Preferences.cpp:699
 msgid "Korean"
 msgstr "Koreera"
 
-#: src/Preferences.cpp:699
+#: src/Preferences.cpp:700
 msgid "Latvian"
 msgstr ""
 
-#: src/Preferences.cpp:700
+#: src/Preferences.cpp:701
 msgid "Lithuanian"
 msgstr "Lituaniera"
 
-#: src/Preferences.cpp:701
+#: src/Preferences.cpp:702
 msgid "Norwegian (Nynorsk)"
 msgstr "Norvegiera (Nynorsk)"
 
-#: src/Preferences.cpp:702
+#: src/Preferences.cpp:703
 msgid "Polish"
 msgstr "Poloniera"
 
-#: src/Preferences.cpp:703
+#: src/Preferences.cpp:704
 msgid "Portuguese"
 msgstr "Portugesa"
 
-#: src/Preferences.cpp:704
+#: src/Preferences.cpp:705
 msgid "Portuguese (Brazilian)"
 msgstr "Portugesa (Brasildarra)"
 
-#: src/Preferences.cpp:705
+#: src/Preferences.cpp:706
 msgid "Romanian"
 msgstr "Errumaniera"
 
-#: src/Preferences.cpp:706
+#: src/Preferences.cpp:707
 msgid "Russian"
 msgstr "Errusiera"
 
-#: src/Preferences.cpp:707
+#: src/Preferences.cpp:708
 msgid "Slovenian"
 msgstr "Esloveniera"
 
-#: src/Preferences.cpp:708
+#: src/Preferences.cpp:709
 msgid "Spanish"
 msgstr "Gaztelera"
 
-#: src/Preferences.cpp:709
+#: src/Preferences.cpp:710
 msgid "Swedish"
 msgstr "Suediera"
 
-#: src/Preferences.cpp:710
+#: src/Preferences.cpp:711
 msgid "Turkish"
 msgstr "Turkiera"
 
-#: src/Preferences.cpp:711
+#: src/Preferences.cpp:712
 msgid "Ukrainian"
 msgstr "Ukraniera"
 
-#: src/Preferences.cpp:814
+#: src/Preferences.cpp:815
 msgid "Change Language"
 msgstr "Aldatu hizkuntza"
 
-#: src/Preferences.cpp:878
+#: src/Preferences.cpp:879
 msgid "There are no translations installed for aMule"
 msgstr "Ez dago aMulerentzat itzulpen instalaturik"
 
-#: src/Preferences.cpp:879
+#: src/Preferences.cpp:880
 msgid "No languages available"
 msgstr "Ez dago hizkuntza erabilgarririk"
 
-#: src/Preferences.cpp:1010
+#: src/Preferences.cpp:1011
 msgid "no options available"
 msgstr "ez dago aukera erabilgarririk"
 
-#: src/Preferences.cpp:2179
+#: src/Preferences.cpp:2182
 msgid "Invalid category found, skipping"
 msgstr "Kategoria baliogabe aurkitua, baztertzen"
 
-#: src/Preferences.cpp:2348
+#: src/Preferences.cpp:2351
 msgid "TCP port can't be higher than 65532 due to server UDP socket being TCP+3"
 msgstr "TCP ataka ezin da 65532 baino altuagoa izan UDP socket-a TCP+3 bait da"
 
-#: src/Preferences.cpp:2349
+#: src/Preferences.cpp:2352
 #, c-format
 msgid "Default port will be used (%d)"
 msgstr "Lehenetsiriko ataka erabiliko da (%d)"
@@ -6124,24 +6138,28 @@ msgstr "Partekatutako fitxategi zerrenda birkargatu."
 msgid "Shared folder"
 msgstr "Partekatutako karpetak"
 
-#: src/SearchDlg.cpp:425
+#: src/SearchDlg.cpp:280
+msgid "Clear search history"
+msgstr ""
+
+#: src/SearchDlg.cpp:584
 msgid "It's impossible to search when both eD2k and Kademlia are disabled."
 msgstr ""
 
-#: src/SearchDlg.cpp:426 src/SearchListCtrl.cpp:858
+#: src/SearchDlg.cpp:585 src/SearchListCtrl.cpp:858
 #, fuzzy
 msgid "Search error"
 msgstr "Bilaketak"
 
-#: src/SearchDlg.cpp:768
+#: src/SearchDlg.cpp:929
 msgid "Min size must be smaller than max size. Max size ignored."
 msgstr "Gutxienezko tamaina gehienezkoa baino txikiagoa izan behar da. Gehienezkoa alde batetara utziko da."
 
-#: src/SearchDlg.cpp:769 src/SearchDlg.cpp:851
+#: src/SearchDlg.cpp:930 src/SearchDlg.cpp:1012
 msgid "Search warning"
 msgstr "Bilaketa oharra"
 
-#: src/SearchDlg.cpp:929 src/SearchListCtrl.cpp:735
+#: src/SearchDlg.cpp:1092 src/SearchListCtrl.cpp:735
 msgid "Main"
 msgstr "Nagusia"
 

--- a/po/eu.po
+++ b/po/eu.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-28 10:19+0200\n"
+"POT-Creation-Date: 2026-07-28 12:17+0200\n"
 "PO-Revision-Date: 2026-07-27 11:37+0000\n"
 "Last-Translator: Piarres Beobide <pi@beobide.net>\n"
 "Language-Team: Euskara <librezale@librezale.org>\n"
@@ -204,83 +204,83 @@ msgstr "Huts ED2KLinks fitxategia irekitzerakoan."
 msgid "WARNING: You can't add yourself as a source for an eD2k link while having a lowid."
 msgstr "KONTUZ: Ezin duzu zure burua ezarri eD2k lotura batean Id baxua duzunean."
 
-#: src/amule.cpp:300
+#: src/amule.cpp:301
 msgid "Now, exiting main app..."
 msgstr "Orain, aplikazio nagusia ixten..."
 
-#: src/amule.cpp:330
+#: src/amule.cpp:331
 #, c-format
 msgid "Terminating amuleweb instance with pid '%d' ... "
 msgstr "'%d' pid-a duen amuleweb instantzia amaitzen ... "
 
-#: src/amule.cpp:334
+#: src/amule.cpp:335
 #, c-format
 msgid "Killing amuleweb instance with pid '%d' ... "
 msgstr "'%d' pid-a duen amuleweb instantzia hiltzen ... "
 
-#: src/amule.cpp:336 src/amule.cpp:349 src/ClientRef.cpp:180
+#: src/amule.cpp:337 src/amule.cpp:350 src/ClientRef.cpp:180
 #: src/SearchDlg.cpp:1041 src/ServerListCtrl.cpp:98
 msgid "Failed"
 msgstr "Huts egin du"
 
-#: src/amule.cpp:343
+#: src/amule.cpp:344
 #, fuzzy, c-format
 msgid "Terminating amuleapi instance with pid '%d' ... "
 msgstr "'%d' pid-a duen amuleweb instantzia amaitzen ... "
 
-#: src/amule.cpp:347
+#: src/amule.cpp:348
 #, fuzzy, c-format
 msgid "Killing amuleapi instance with pid '%d' ... "
 msgstr "'%d' pid-a duen amuleweb instantzia hiltzen ... "
 
-#: src/amule.cpp:355
+#: src/amule.cpp:356
 msgid "aMule OnExit: Terminating core."
 msgstr "aMule irteten: Muina ixten."
 
-#: src/amule.cpp:466
+#: src/amule.cpp:467
 msgid "aMule shutdown completed."
 msgstr "aMule itzaltzea osaturik."
 
-#: src/amule.cpp:470
+#: src/amule.cpp:471
 msgid "Memory debug results for aMule exit:"
 msgstr "aMule ixtearen memoria arazte irteera:"
 
-#: src/amule.cpp:651
+#: src/amule.cpp:652
 #, c-format
 msgid "Binding aMule's peer-to-peer traffic to interface: %s (HTTP updates use the default route)"
 msgstr ""
 
-#: src/amule.cpp:655
+#: src/amule.cpp:656
 #, c-format
 msgid "Binding all network traffic to interface: %s"
 msgstr ""
 
-#: src/amule.cpp:659
+#: src/amule.cpp:660
 #, c-format
 msgid "WARNING: configured network interface '%s' was not found - traffic is NOT bound to it and may leave via the default route. Check the interface name in Preferences."
 msgstr ""
 
-#: src/amule.cpp:665
+#: src/amule.cpp:666
 #, c-format
 msgid "WARNING: binding to network interface '%s' requires elevated privileges and was NOT applied - traffic may leave via the default route. Grant the capability (e.g. 'sudo setcap cap_net_raw+ep' on the aMule binary) or run with sufficient privileges."
 msgstr ""
 
-#: src/amule.cpp:673
+#: src/amule.cpp:674
 #, c-format
 msgid "WARNING: could not bind to network interface '%s' - traffic may leave via the default route."
 msgstr ""
 
-#: src/amule.cpp:732
+#: src/amule.cpp:733
 msgid "Your locale has been changed to System Default due to a configuration change. Sorry."
 msgstr "Zure lokalak sistemako lehenetsira aldatu dira konfigurazio aldaketa bat dela eta. Barkatu."
 
-#: src/amule.cpp:734 src/amule.cpp:1581 src/CatDialog.cpp:128
+#: src/amule.cpp:735 src/amule.cpp:1589 src/CatDialog.cpp:128
 #: src/CatDialog.cpp:136 src/CatDialog.cpp:149 src/ServerList.cpp:366
 #: src/ServerListCtrl.cpp:152
 msgid "Info"
 msgstr "Argb"
 
-#: src/amule.cpp:741
+#: src/amule.cpp:742
 msgid ""
 "\n"
 "EC configuration"
@@ -288,74 +288,74 @@ msgstr ""
 "\n"
 "EC konfigurazioa"
 
-#: src/amule.cpp:744
+#: src/amule.cpp:745
 msgid "Password set and external connections enabled."
 msgstr "Pasahitza ezarria eta kanpo konexioak gaiturik."
 
-#: src/amule.cpp:754 src/KadDlg.cpp:176 src/KadDlg.cpp:185
-#: src/PrefsUnifiedDlg.cpp:1387 src/SharedFilesCtrl.cpp:476
+#: src/amule.cpp:755 src/KadDlg.cpp:176 src/KadDlg.cpp:185
+#: src/PrefsUnifiedDlg.cpp:1461 src/SharedFilesCtrl.cpp:476
 msgid "WARNING"
 msgstr "OHARRA"
 
-#: src/amule.cpp:991
+#: src/amule.cpp:992
 #, fuzzy
 msgid "Network bootstrap"
 msgstr "Sareak"
 
-#: src/amule.cpp:996
+#: src/amule.cpp:997
 msgid ""
 "aMule has detected missing network bootstrap files.\n"
 "Select which ones to download:"
 msgstr ""
 
-#: src/amule.cpp:1005 src/FirstRunWizard.cpp:411
+#: src/amule.cpp:1006 src/FirstRunWizard.cpp:411
 #, fuzzy
 msgid "eD2k server list (server.met)"
 msgstr "zerbitzari %i aurkiturik server.met fitxategian"
 
-#: src/amule.cpp:1012 src/FirstRunWizard.cpp:416
+#: src/amule.cpp:1013 src/FirstRunWizard.cpp:416
 msgid "Kad bootstrap nodes (nodes.dat)"
 msgstr ""
 
-#: src/amule.cpp:1102
+#: src/amule.cpp:1103
 #, c-format
 msgid "web server running on pid %d"
 msgstr "web zerbitzaria abiarazirik %d pid-arekin"
 
-#: src/amule.cpp:1115
+#: src/amule.cpp:1116
 #, fuzzy
 msgid "You requested to run web server on startup, but the amuleweb binary cannot be run. Please install the package containing aMule web server, or build aMule from source with -DBUILD_WEBSERVER=YES and install it."
 msgstr "Abioan web-zerbitzaria exekutatzea eskatu duzu, baina amuleweb bitarra ezin da exekutatu. Mesedez instalatu amule web zerbitzaria duen paketea edo konpilatu ezazu amule --enable-webserver erabilian eta make install egin"
 
-#: src/amule.cpp:1120 src/amule.cpp:1177 src/amule.cpp:1291 src/amule.cpp:1593
+#: src/amule.cpp:1121 src/amule.cpp:1185 src/amule.cpp:1299 src/amule.cpp:1601
 #: src/amule-remote-gui.cpp:603 src/amule-remote-gui.cpp:671
 #: src/amule-remote-gui.cpp:709 src/amule-remote-gui.cpp:1282
 #: src/amule-remote-gui.cpp:1345 src/amule-remote-gui.cpp:1372
-#: src/DownloadQueue.cpp:1481
+#: src/DownloadQueue.cpp:1481 src/PrefsUnifiedDlg.cpp:1247
 msgid "ERROR"
 msgstr "ERROREA"
 
-#: src/amule.cpp:1166
+#: src/amule.cpp:1174
 #, fuzzy, c-format
 msgid "amuleapi running on pid %d"
 msgstr "web zerbitzaria abiarazirik %d pid-arekin"
 
-#: src/amule.cpp:1172
+#: src/amule.cpp:1180
 #, fuzzy
 msgid "You requested to run amuleapi on startup, but the amuleapi binary cannot be run. Please install the package containing aMule's REST API server, or build aMule from source with -DBUILD_AMULEAPI=YES and install it."
 msgstr "Abioan web-zerbitzaria exekutatzea eskatu duzu, baina amuleweb bitarra ezin da exekutatu. Mesedez instalatu amule web zerbitzaria duen paketea edo konpilatu ezazu amule --enable-webserver erabilian eta make install egin"
 
-#: src/amule.cpp:1259
+#: src/amule.cpp:1267
 #, c-format
 msgid "Could not bind ports to the specified address: %s"
 msgstr "Ezin da atakak ezarritako helbidean ireki: %s"
 
-#: src/amule.cpp:1283
+#: src/amule.cpp:1291
 #, c-format
 msgid "Port %u is not available. You will be LOWID\n"
 msgstr "%u ataka ez dago eskuragarri. IDBaxua izango duzu\n"
 
-#: src/amule.cpp:1288
+#: src/amule.cpp:1296
 #, c-format
 msgid ""
 "Port %u is not available!\n"
@@ -370,48 +370,48 @@ msgstr ""
 "\n"
 "Egiaztatu zure sarea ataka sarrera eta irteerarako irekirik dagoela ziurtatzeko."
 
-#: src/amule.cpp:1385
+#: src/amule.cpp:1393
 msgid "Failed to create OnlineSig File"
 msgstr "Huts online sinadura fitxategia sortzerakoan"
 
-#: src/amule.cpp:1393
+#: src/amule.cpp:1401
 msgid "Failed to create aMule OnlineSig File"
 msgstr "Huts aMule online sinadura fitxategia sortzerakoan"
 
-#: src/amule.cpp:1556
+#: src/amule.cpp:1564
 msgid "The selected locale seems not to be installed on your box. (Note: I'll try to set it anyway)"
 msgstr "Aukeratutako lokalak ez dirudi zure sisteman instalaturik. (Oharra: Hala ere erabiltzen saiatuko da)"
 
-#: src/amule.cpp:1566
+#: src/amule.cpp:1574
 #, c-format
 msgid "This is the first time you run aMule %s"
 msgstr "aMule %s abiarazten duzun lehen aldia da"
 
-#: src/amule.cpp:1569
+#: src/amule.cpp:1577
 msgid "This version is a testing version, updated daily, and\n"
 msgstr "Bertsioa hau beta bertsio bat da, egunero eguneratzen da, eta\n"
 
-#: src/amule.cpp:1570
+#: src/amule.cpp:1578
 msgid "we give no warranty it won't break anything, burn your house,\n"
 msgstr "ez gara ezer apurtu, zure etxea erre, edo zure zakurra akatzen\n"
 
-#: src/amule.cpp:1571
+#: src/amule.cpp:1579
 msgid "or kill your dog. But it *should* be safe to use anyway.\n"
 msgstr "badu ere kargu egingo. Baina erabiltzeko ziurra izan *beharko* litzateke.\n"
 
-#: src/amule.cpp:1576
+#: src/amule.cpp:1584
 msgid "More information, support and new releases can found at our homepage,\n"
 msgstr "Argibide gehiago, laguntza eta bertsio berriak gure webgunean aurki ditzakezu,\n"
 
-#: src/amule.cpp:1577
+#: src/amule.cpp:1585
 msgid "at https://amule-org.github.io, or in our IRC channel #aMule at irc.libera.chat.\n"
 msgstr "https://amule-org.github.io -en, edo irc.libera.chat IRC sareko #aMule kanalean.\n"
 
-#: src/amule.cpp:1579
+#: src/amule.cpp:1587
 msgid "Feel free to report any bugs to https://github.com/amule-org/amule/issues"
 msgstr "Edozein akatsen berri emateko:https://github.com/amule-org/amule/issues"
 
-#: src/amule.cpp:1591
+#: src/amule.cpp:1599
 msgid ""
 "The folder for Online Signature files you specified is INVALID!\n"
 " OnlineSignature will be DISABLED until you fix it on preferences."
@@ -419,137 +419,137 @@ msgstr ""
 "Zuk aukeratutako sinadura karpeta BALIOGABEA da!\n"
 " Lehenespenak konpondu artean lineako sinadura EZGAITU egingo da."
 
-#: src/amule.cpp:1654
+#: src/amule.cpp:1662
 msgid "Server hostname notified"
 msgstr "Zerbitzari ostalari-izena notifikatua"
 
-#: src/amule.cpp:2031
+#: src/amule.cpp:2039
 #, c-format
 msgid "Disk space preallocation for file '%s' failed: %s"
 msgstr "Disko aurresleipenak huts egin du '%s' fitxategiarentzat: %s"
 
-#: src/amule.cpp:2160
+#: src/amule.cpp:2168
 msgid "ERROR: can't open logfile"
 msgstr "ERROREA: ezin da erregistro fitxategia ireki"
 
-#: src/amule.cpp:2164
+#: src/amule.cpp:2172
 msgid "WARNING: logfile is empty. Something is wrong."
 msgstr "ABISUA: erregistro fitxategia hutsik dago. Zerbait oker dago."
 
-#: src/amule.cpp:2181
+#: src/amule.cpp:2189
 msgid "Log has been reset"
 msgstr "Erregistroa berrezarri egin da"
 
-#: src/amule.cpp:2205
+#: src/amule.cpp:2213
 #, c-format
 msgid "ServerMessage: %s"
 msgstr "ZerbitzariMezua: %s"
 
-#: src/amule.cpp:2248 src/IP2Country.cpp:220 src/IPFilter.cpp:514
+#: src/amule.cpp:2256 src/IP2Country.cpp:220 src/IPFilter.cpp:514
 #: src/ServerList.cpp:875
 #, c-format
 msgid "Skipped download of %s, because requested file is not newer."
 msgstr "%s-ren deskarga baztertua, eskatutako fitxategia ez da berria eta."
 
-#: src/amule.cpp:2251
+#: src/amule.cpp:2259
 msgid "Failed to download the nodes list."
 msgstr "Huts egin du nodo zerrenda deskargatzerakoan."
 
-#: src/amule.cpp:2314
+#: src/amule.cpp:2322
 msgid "Failed to open the downloaded version check file"
 msgstr "Huts egin du"
 
-#: src/amule.cpp:2317 src/amule.cpp:2336
+#: src/amule.cpp:2325 src/amule.cpp:2344
 msgid "Corrupted version check file"
 msgstr "Hondaturiko bertsio arakatze fitxategia"
 
-#: src/amule.cpp:2359
+#: src/amule.cpp:2367
 msgid "You are using an outdated version of aMule!"
 msgstr "Zaharkiturik dagoen aMule bertsio bat erabiltzen ari zara!"
 
-#: src/amule.cpp:2361
+#: src/amule.cpp:2369
 #, c-format
 msgid "Your aMule version is %i.%i.%i and the latest version is %li.%li.%li"
 msgstr "Zure aMule bertsioa %i.%i.%i da eta azken bertsioa %li.%li.%li da"
 
-#: src/amule.cpp:2365
+#: src/amule.cpp:2373
 msgid "The latest version can always be found at https://github.com/amule-org/amule/releases/latest"
 msgstr "Azken bertsioa beti https://github.com/amule-org/amule/releases/latest webgunean aurki daiteke"
 
-#: src/amule.cpp:2368
+#: src/amule.cpp:2376
 #, c-format
 msgid "WARNING: Your aMuled version is outdated: %i.%i.%i < %li.%li.%li"
 msgstr "OHARRA: Zure aMuled bertsioa zaharkiturik dago: %i.%i.%i < %li.%li.%li"
 
-#: src/amule.cpp:2374
+#: src/amule.cpp:2382
 msgid "Your copy of aMule is up to date."
 msgstr "Zure aMule kopia zaharkiturik dago."
 
-#: src/amule.cpp:2381
+#: src/amule.cpp:2389
 msgid "Failed to download the version check file"
 msgstr "Huts bertsio arakatze fitxategia deskargatzerakoan"
 
-#: src/amule.cpp:2550 src/amule-remote-gui.cpp:1133
+#: src/amule.cpp:2558 src/amule-remote-gui.cpp:1133
 #, c-format
 msgid "Users: %s | Files: %s"
 msgstr "Erab: %s | Fitx: %s"
 
-#: src/amule.cpp:2551 src/amule-remote-gui.cpp:1134
+#: src/amule.cpp:2559 src/amule-remote-gui.cpp:1134
 #, c-format
 msgid "Users: E: %s K: %s | Files: E: %s K: %s"
 msgstr "Erab: E: %s K: %s | Fitx: E: %s K: %s"
 
-#: src/amule.cpp:2565 src/amule-remote-gui.cpp:1147
+#: src/amule.cpp:2573 src/amule-remote-gui.cpp:1147
 msgid "No networks selected"
 msgstr "Ez dago sarerik hautatuta"
 
-#: src/amule.cpp:2633 src/TextClient.cpp:903
+#: src/amule.cpp:2641 src/TextClient.cpp:903
 msgid "with LowID"
 msgstr "IDBaxuarekin"
 
-#: src/amule.cpp:2633 src/TextClient.cpp:904
+#: src/amule.cpp:2641 src/TextClient.cpp:904
 msgid "with HighID"
 msgstr "IDAltuarekin"
 
-#: src/amule.cpp:2635
+#: src/amule.cpp:2643
 #, c-format
 msgid "Connected to %s %s"
 msgstr "%s %s-ra konektaturik"
 
-#: src/amule.cpp:2640
+#: src/amule.cpp:2648
 #, c-format
 msgid "Connecting to %s"
 msgstr "%s-ra konektatzen"
 
-#: src/amule.cpp:2642
+#: src/amule.cpp:2650
 msgid "Disconnected from eD2k"
 msgstr "eD2k-tik deskonektatua"
 
-#: src/amule.cpp:2651
+#: src/amule.cpp:2659
 msgid "Kad started."
 msgstr "Kad abiarazirik."
 
-#: src/amule.cpp:2653
+#: src/amule.cpp:2661
 msgid "Kad stopped."
 msgstr "Kad gelditurik."
 
-#: src/amule.cpp:2661
+#: src/amule.cpp:2669
 msgid "Connected to Kad (ok)"
 msgstr "Kad-era Konektatuta (ondo)"
 
-#: src/amule.cpp:2663
+#: src/amule.cpp:2671
 msgid "Connected to Kad (firewalled)"
 msgstr "Kad-era Konektatuta (suebakirik)"
 
-#: src/amule.cpp:2667
+#: src/amule.cpp:2675
 msgid "Disconnected from Kad"
 msgstr "Kad-etik deskonektatua"
 
-#: src/amule.cpp:2699
+#: src/amule.cpp:2707
 msgid "Kad network cannot be used if UDP port is disabled on preferences, not starting."
 msgstr "Kad sarea ezin da erabili hobespenetan UDP ataka ezgaiturik badago, ez da abiaraziko."
 
-#: src/amule.cpp:2703
+#: src/amule.cpp:2711
 msgid "Kad network disabled on preferences, not connecting."
 msgstr "Kad sarea hobespenetan ezgaiturik, ez da konektatuko."
 
@@ -594,36 +594,36 @@ msgid "FATAL ERROR: Failed to create Timer"
 msgstr "ERRORE KONPONEZINA: Huts kronometroa sortzean"
 
 #: src/amuleDlg.cpp:361 src/amuleDlg.cpp:1787 src/amuleDlg.cpp:2033
-#: src/muuli_wdr.cpp:1492 src/muuli_wdr.cpp:3418
+#: src/muuli_wdr.cpp:1492 src/muuli_wdr.cpp:3449
 msgid "Networks"
 msgstr "Sareak"
 
-#: src/amuleDlg.cpp:362 src/amuleDlg.cpp:1793 src/muuli_wdr.cpp:3419
+#: src/amuleDlg.cpp:362 src/amuleDlg.cpp:1793 src/muuli_wdr.cpp:3450
 msgid "Searches"
 msgstr "Bilaketak"
 
 #: src/amuleDlg.cpp:363 src/amuleDlg.cpp:1799 src/DownloadListCtrl.cpp:740
-#: src/muuli_wdr.cpp:392 src/muuli_wdr.cpp:1585 src/muuli_wdr.cpp:3420
+#: src/muuli_wdr.cpp:392 src/muuli_wdr.cpp:1585 src/muuli_wdr.cpp:3451
 #: src/Statistics.cpp:829
 msgid "Downloads"
 msgstr "Deskargak"
 
-#: src/amuleDlg.cpp:364 src/amuleDlg.cpp:1805 src/muuli_wdr.cpp:3294
+#: src/amuleDlg.cpp:364 src/amuleDlg.cpp:1805 src/muuli_wdr.cpp:3325
 msgid "Shared files"
 msgstr "Partekatutako fitxategiak"
 
-#: src/amuleDlg.cpp:365 src/amuleDlg.cpp:1811 src/muuli_wdr.cpp:2926
-#: src/muuli_wdr.cpp:3376 src/muuli_wdr.cpp:3423
+#: src/amuleDlg.cpp:365 src/amuleDlg.cpp:1811 src/muuli_wdr.cpp:2957
+#: src/muuli_wdr.cpp:3407 src/muuli_wdr.cpp:3454
 msgid "Messages"
 msgstr "Mezuak"
 
-#: src/amuleDlg.cpp:366 src/amuleDlg.cpp:1817 src/muuli_wdr.cpp:3424
-#: src/PrefsUnifiedDlg.cpp:312 src/Statistics.cpp:779 src/Statistics.cpp:1235
+#: src/amuleDlg.cpp:366 src/amuleDlg.cpp:1817 src/muuli_wdr.cpp:3455
+#: src/PrefsUnifiedDlg.cpp:314 src/Statistics.cpp:779 src/Statistics.cpp:1235
 msgid "Statistics"
 msgstr "Estatistikak"
 
-#: src/amuleDlg.cpp:368 src/amuleDlg.cpp:1824 src/muuli_wdr.cpp:3426
-#: src/PrefsUnifiedDlg.cpp:328 src/utils/wxCas/src/wxcasprefs.cpp:39
+#: src/amuleDlg.cpp:368 src/amuleDlg.cpp:1824 src/muuli_wdr.cpp:3457
+#: src/PrefsUnifiedDlg.cpp:330 src/utils/wxCas/src/wxcasprefs.cpp:39
 msgid "Preferences"
 msgstr "Hobespenak"
 
@@ -681,8 +681,8 @@ msgstr "Kad: Itzalia"
 #: src/amuleDlg.cpp:1029 src/DownloadListCtrl.cpp:505
 #: src/DownloadListCtrl.cpp:749 src/FriendListCtrl.cpp:180
 #: src/muuli_wdr.cpp:731 src/muuli_wdr.cpp:782 src/muuli_wdr.cpp:846
-#: src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2231 src/muuli_wdr.cpp:2316
-#: src/muuli_wdr.cpp:3064 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
+#: src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2262 src/muuli_wdr.cpp:2347
+#: src/muuli_wdr.cpp:3095 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
 #: src/ServerListCtrl.cpp:606 src/TransferWnd.cpp:378
 #: src/utils/wxCas/src/wxcasprefs.cpp:235
 msgid "Cancel"
@@ -693,7 +693,7 @@ msgid "Stop the current connection attempts"
 msgstr "Geratu uneko konexio saiakerak"
 
 #: src/amuleDlg.cpp:1035 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976
-#: src/muuli_wdr.cpp:2454
+#: src/muuli_wdr.cpp:2485
 msgid "Disconnect"
 msgstr "Deskonektatu"
 
@@ -702,7 +702,7 @@ msgid "Disconnect from the currently connected networks"
 msgstr "Deskonektatu konektatutako sareetatik"
 
 #: src/amuleDlg.cpp:1041 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979
-#: src/muuli_wdr.cpp:2609 src/muuli_wdr.cpp:3061 src/muuli_wdr.cpp:3416
+#: src/muuli_wdr.cpp:2640 src/muuli_wdr.cpp:3092 src/muuli_wdr.cpp:3447
 msgid "Connect"
 msgstr "Konektatu"
 
@@ -757,7 +757,7 @@ msgstr "Irteera berrespena"
 msgid "Launch Command: "
 msgstr "Abiarazi komandoa: "
 
-#: src/amuleDlg.cpp:1632 src/muuli_wdr.cpp:1978 src/Preferences.cpp:952
+#: src/amuleDlg.cpp:1632 src/muuli_wdr.cpp:1982 src/Preferences.cpp:979
 msgid "- default -"
 msgstr "- lehenetsia -"
 
@@ -771,48 +771,48 @@ msgstr "Ez dago '%s' itxura direktorioa"
 msgid "WARNING: Unable to open skin file '%s' for read"
 msgstr "ABISUA: Ezin da '%s' azal fitxategia irakurri"
 
-#: src/amuleDlg.cpp:1791 src/muuli_wdr.cpp:3418
+#: src/amuleDlg.cpp:1791 src/muuli_wdr.cpp:3449
 msgid "Networks Window"
 msgstr "Sare leihoa"
 
-#: src/amuleDlg.cpp:1797 src/muuli_wdr.cpp:3419
+#: src/amuleDlg.cpp:1797 src/muuli_wdr.cpp:3450
 msgid "Searches Window"
 msgstr "Bilaketa leihoa"
 
-#: src/amuleDlg.cpp:1803 src/muuli_wdr.cpp:3420
+#: src/amuleDlg.cpp:1803 src/muuli_wdr.cpp:3451
 msgid "Downloads Window"
 msgstr "Deskargak leihoa"
 
-#: src/amuleDlg.cpp:1809 src/muuli_wdr.cpp:3422
+#: src/amuleDlg.cpp:1809 src/muuli_wdr.cpp:3453
 msgid "Shared Files Window"
 msgstr "Partekatutako fitxategi leihoa"
 
-#: src/amuleDlg.cpp:1815 src/muuli_wdr.cpp:3423
+#: src/amuleDlg.cpp:1815 src/muuli_wdr.cpp:3454
 msgid "Messages Window"
 msgstr "Mezu leihoa"
 
-#: src/amuleDlg.cpp:1821 src/muuli_wdr.cpp:3424
+#: src/amuleDlg.cpp:1821 src/muuli_wdr.cpp:3455
 msgid "Statistics Graph Window"
 msgstr "Estatistika grafiko leihoa"
 
-#: src/amuleDlg.cpp:1828 src/muuli_wdr.cpp:3426
+#: src/amuleDlg.cpp:1828 src/muuli_wdr.cpp:3457
 msgid "Preferences Settings Window"
 msgstr "Hobespen ezarpen leihoa"
 
-#: src/amuleDlg.cpp:1831 src/muuli_wdr.cpp:3427
+#: src/amuleDlg.cpp:1831 src/muuli_wdr.cpp:3458
 msgid "Import"
 msgstr "Inportatu"
 
-#: src/amuleDlg.cpp:1835 src/muuli_wdr.cpp:3427
+#: src/amuleDlg.cpp:1835 src/muuli_wdr.cpp:3458
 msgid "The partfile importer tool"
 msgstr "Zati fitxategi inportazio tresna"
 
-#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3428
+#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3459
 #: src/utils/aLinkCreator/src/alcframe.cpp:262
 msgid "About"
 msgstr "Honi buruz"
 
-#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3428
+#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3459
 msgid "About/Help"
 msgstr "Honi buruz/Laguntza"
 
@@ -954,7 +954,7 @@ msgstr "Fitxategia ez da aurkitu."
 msgid "The core rejected these shared folders:%s"
 msgstr ""
 
-#: src/amule-remote-gui.cpp:1336 src/ExternalConn.cpp:2345
+#: src/amule-remote-gui.cpp:1336 src/ExternalConn.cpp:2346
 msgid "Invalid link or already on list."
 msgstr "Lotura baliogabea edo zerrendan dagoeneko."
 
@@ -970,7 +970,7 @@ msgstr "Ezin da '%s' direktorioa sortu '%s' kategoriarentzat, '%s' direktorioa m
 #: src/ClientDetailDialog.cpp:123 src/DataToText.cpp:61 src/DataToText.cpp:86
 #: src/DataToText.cpp:101 src/DataToText.cpp:136 src/DataToText.cpp:165
 #: src/DownloadListCtrl.cpp:1172 src/DownloadListCtrl.cpp:1185
-#: src/DownloadListCtrl.cpp:1196 src/ExternalConn.cpp:608
+#: src/DownloadListCtrl.cpp:1196 src/ExternalConn.cpp:609
 #: src/FileDetailDialog.cpp:203 src/FileDetailDialog.cpp:235
 #: src/FileDetailDialog.cpp:242 src/GenericClientListCtrl.cpp:1171
 #: src/GenericClientListCtrl.cpp:1182 src/GenericClientListCtrl.cpp:1192
@@ -1357,19 +1357,19 @@ msgstr "Auto[Alt]"
 msgid "Very low"
 msgstr "Oso txikia"
 
-#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:743 src/muuli_wdr.cpp:2282
+#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:743 src/muuli_wdr.cpp:2313
 #: src/ServerListCtrl.cpp:263 src/ServerListCtrl.cpp:456
 #: src/SharedFilesCtrl.cpp:145
 msgid "Low"
 msgstr "Baxua"
 
-#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:744 src/muuli_wdr.cpp:2283
+#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:744 src/muuli_wdr.cpp:2314
 #: src/ServerListCtrl.cpp:266 src/ServerListCtrl.cpp:457
 #: src/SharedFilesCtrl.cpp:146
 msgid "Normal"
 msgstr "Normala"
 
-#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:745 src/muuli_wdr.cpp:2284
+#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:745 src/muuli_wdr.cpp:2315
 #: src/ServerListCtrl.cpp:269 src/ServerListCtrl.cpp:458
 #: src/SharedFilesCtrl.cpp:147
 msgid "High"
@@ -1461,7 +1461,7 @@ msgstr "Zerbitzari lokala"
 msgid "Remote Server"
 msgstr "Urruneko zerbitzaria"
 
-#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3181
+#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3212
 #: src/SearchDlg.cpp:119 src/TextClient.cpp:911
 msgid "Kad"
 msgstr "Kad"
@@ -1533,7 +1533,7 @@ msgstr "Zatia"
 msgid "Size"
 msgstr "Tamaina"
 
-#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3248
+#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3279
 msgid "Transferred"
 msgstr "Transferituta"
 
@@ -1591,7 +1591,7 @@ msgstr ""
 "Erantzuna hemendik: %s (%s)\n"
 "\n"
 
-#: src/DownloadListCtrl.cpp:746 src/muuli_wdr.cpp:2285
+#: src/DownloadListCtrl.cpp:746 src/muuli_wdr.cpp:2316
 #: src/SharedFilesCtrl.cpp:150
 msgid "Auto"
 msgstr "Auto"
@@ -1629,7 +1629,7 @@ msgid "Extended Options"
 msgstr "Hedatutako aukerak"
 
 #: src/DownloadListCtrl.cpp:770 src/DownloadListCtrl.cpp:822
-#: src/muuli_wdr.cpp:1796
+#: src/muuli_wdr.cpp:1800
 msgid "Preview"
 msgstr "Aurrebista"
 
@@ -1804,227 +1804,232 @@ msgstr[1] ""
 msgid "Invalid eD2k link! ERROR: %s"
 msgstr "Okerreko eD2k lotura! ERROREA: %s"
 
-#: src/ExternalConn.cpp:379
+#: src/ExternalConn.cpp:380
 msgid "Client sent packet after authentication failed."
 msgstr "Bezeroak pakete bat bidali du egiaztapenak huts egin ondoren."
 
-#: src/ExternalConn.cpp:396
+#: src/ExternalConn.cpp:397
 msgid "External connection closed."
 msgstr "Kanpo konexioa ukaturik."
 
-#: src/ExternalConn.cpp:473
+#: src/ExternalConn.cpp:474
 msgid "External connections disabled due to empty password!"
 msgstr "Pasahitz zuria dela eta kanpo konexioak ezgaiturik!"
 
-#: src/ExternalConn.cpp:494
+#: src/ExternalConn.cpp:495
 msgid "External connections disabled in config file"
 msgstr "Kanpo konexioak ezgaiturik konfigurazio fitxategian"
 
-#: src/ExternalConn.cpp:575
+#: src/ExternalConn.cpp:576
 msgid "New external connection accepted"
 msgstr "Kanpo konexio berri bat onartu da"
 
-#: src/ExternalConn.cpp:578
+#: src/ExternalConn.cpp:579
 msgid "ERROR: couldn't accept a new external connection"
 msgstr "ERROREA: ezin da kanpo konexio berria onartu"
 
-#: src/ExternalConn.cpp:595
+#: src/ExternalConn.cpp:596
 msgid "External connection refused due to empty password in preferences!"
 msgstr "Hobespenetan pasahitza zurian dela eta kanpo konexioak ukaturik!"
 
-#: src/ExternalConn.cpp:607
+#: src/ExternalConn.cpp:608
 #, c-format
 msgid "Connecting client: %s %s"
 msgstr "Bezerora konektatzen: %s %s"
 
-#: src/ExternalConn.cpp:609
+#: src/ExternalConn.cpp:610
 msgid "Unknown version"
 msgstr "Bertsio ezezaguna"
 
-#: src/ExternalConn.cpp:622
+#: src/ExternalConn.cpp:623
 msgid "Incorrect EC version ID, there might be binary incompatibility. Use core and remote from same snapshot."
 msgstr "Okerreko bertsio ID-a, bitar bateratze ezintasuna dago. Erabili urruneko eta nagusi bertsio berdina."
 
-#: src/ExternalConn.cpp:630
+#: src/ExternalConn.cpp:631
 msgid "You cannot connect to a release version from an arbitrary development snapshot! *sigh* possible crash prevented"
 msgstr "Ezin zara argitaratutako bertsio batetara konektatu edozein garapen bertsiotik! *ikusi* apurketa aukera saihestua"
 
-#: src/ExternalConn.cpp:713
+#: src/ExternalConn.cpp:714
 msgid "Invalid protocol version."
 msgstr "Protokolo bertsio baliogabea."
 
-#: src/ExternalConn.cpp:719
+#: src/ExternalConn.cpp:720
 msgid "Missing protocol version tag."
 msgstr "Protokolo bertsio marka falta da."
 
-#: src/ExternalConn.cpp:727
+#: src/ExternalConn.cpp:728
 msgid "Authentication failed: invalid hash specified as EC password."
 msgstr "Autentifikazio errorea: okerreko egiaztapena ezarri da EC pasahitz gisa."
 
-#: src/ExternalConn.cpp:775
+#: src/ExternalConn.cpp:776
 msgid "Authentication failed: wrong password."
 msgstr "Egiaztapenak huts egin du: okerreko pasahitza."
 
-#: src/ExternalConn.cpp:777
+#: src/ExternalConn.cpp:778
 msgid "Authentication failed: missing password."
 msgstr "Egiaztapenak huts egin du: pasahitza falta da."
 
-#: src/ExternalConn.cpp:788
+#: src/ExternalConn.cpp:789
 msgid "Invalid request, please authenticate first."
 msgstr "Eskakizun baliogabea, mesedez identifikatu aurretik."
 
-#: src/ExternalConn.cpp:793
+#: src/ExternalConn.cpp:794
 msgid "Access granted."
 msgstr "Sarrera onartua."
 
-#: src/ExternalConn.cpp:801
+#: src/ExternalConn.cpp:802
 #, c-format
 msgid "Sent error message \"%s\" to client."
 msgstr "\"%s\" errore mezua bezerora bidalia."
 
-#: src/ExternalConn.cpp:806
+#: src/ExternalConn.cpp:807
 #, c-format
 msgid "Unauthorized access attempt from %s. Connection closed."
 msgstr "Baimendu gabeko sarrera saiakera %s-tik. Konexioa itxia."
 
-#: src/ExternalConn.cpp:1419
+#: src/ExternalConn.cpp:1420
 #, c-format
 msgid "Remote PartFile command failed: FileHash not found: %s"
 msgstr "Urruneko ZatiFitxategi komandoak huts egin du: Ez da %s fitxategi egiaztapena aurkitu"
 
-#: src/ExternalConn.cpp:1423
+#: src/ExternalConn.cpp:1424
 #, c-format
 msgid "FileHash not found: %s"
 msgstr "Ez da %s fitxategi egiaztapena aurkitu"
 
-#: src/ExternalConn.cpp:1470 src/ExternalConn.cpp:1558
-#: src/ExternalConn.cpp:1679
+#: src/ExternalConn.cpp:1471 src/ExternalConn.cpp:1559
+#: src/ExternalConn.cpp:1680
 msgid "OOPS! OpCode processing error!"
 msgstr "OOPS! OpCode prozesu errorea!"
 
-#: src/ExternalConn.cpp:1501
+#: src/ExternalConn.cpp:1502
 msgid "Server not added"
 msgstr "Zerbitzaria ez da gehitu"
 
-#: src/ExternalConn.cpp:1520
+#: src/ExternalConn.cpp:1521
 #, c-format
 msgid "server not found: %s"
 msgstr "ez da zerbitzaria aurkitu: %s"
 
-#: src/ExternalConn.cpp:1537
+#: src/ExternalConn.cpp:1538
 msgid "need to define server to be removed"
 msgstr "ezabatzeko zerbitzaria ezarri behar da"
 
-#: src/ExternalConn.cpp:1552
+#: src/ExternalConn.cpp:1553
 msgid "eD2k is disabled in preferences."
 msgstr "eD2k ezgaiturik dago hobespenetan."
 
-#: src/ExternalConn.cpp:1657
+#: src/ExternalConn.cpp:1658
 #, fuzzy
 msgid "Friend not found."
 msgstr "Fitxategia ez da aurkitu."
 
-#: src/ExternalConn.cpp:1667
+#: src/ExternalConn.cpp:1668
 #, fuzzy
 msgid "Client not found."
 msgstr "Fitxategia ez da aurkitu."
 
-#: src/ExternalConn.cpp:1673
+#: src/ExternalConn.cpp:1674
 msgid "EC_TAG_FRIEND_SHARED requires EC_TAG_FRIEND or EC_TAG_CLIENT."
 msgstr ""
 
-#: src/ExternalConn.cpp:1991
+#: src/ExternalConn.cpp:1992
 msgid "WebSearch from remote interface makes no sense."
 msgstr "Urruneko interfazeko Web bilaketak ez du zentzurik."
 
-#: src/ExternalConn.cpp:2026
+#: src/ExternalConn.cpp:2027
 msgid "Search in progress. Refetch results in a moment!"
 msgstr "Bilaketa bidean. Emaitzak emango une batean!"
 
-#: src/ExternalConn.cpp:2265
+#: src/ExternalConn.cpp:2266
 msgid "No points for graph."
 msgstr "Ez dago punturik grafikoarentzat."
 
-#: src/ExternalConn.cpp:2275
+#: src/ExternalConn.cpp:2276
 msgid "Your client is not configured for this detail level."
 msgstr "Zure bezeroa ez dago xehetasun maila honetarako konfiguraturik."
 
-#: src/ExternalConn.cpp:2302
+#: src/ExternalConn.cpp:2303
 msgid "External Connection: shutdown requested"
 msgstr "Kanpo konexioa: itzaltzea eskatuta"
 
-#: src/ExternalConn.cpp:2314
+#: src/ExternalConn.cpp:2315
 msgid "Already shutting down."
 msgstr "Dagoeneko irteten."
 
-#: src/ExternalConn.cpp:2332
+#: src/ExternalConn.cpp:2333
 #, c-format
 msgid "ExternalConn: adding link '%s'."
 msgstr "KanpoKonexioa: '%s' lotura gehitzen."
 
-#: src/ExternalConn.cpp:2350
+#: src/ExternalConn.cpp:2351
 #, fuzzy, c-format
 msgid "%d of %d links failed (invalid or already on list)."
 msgstr "Lotura baliogabea edo zerrendan dagoeneko."
 
-#: src/ExternalConn.cpp:2373
+#: src/ExternalConn.cpp:2374
 msgid "Version check throttled; try again shortly."
 msgstr ""
 
-#: src/ExternalConn.cpp:2378
+#: src/ExternalConn.cpp:2379
 msgid "Version check is not available on this daemon."
 msgstr ""
 
-#: src/ExternalConn.cpp:2508
+#: src/ExternalConn.cpp:2509
 msgid "File not found."
 msgstr "Fitxategia ez da aurkitu."
 
-#: src/ExternalConn.cpp:2513
+#: src/ExternalConn.cpp:2514
 msgid "Invalid file name."
 msgstr "Fitxategi izen baliogabea."
 
-#: src/ExternalConn.cpp:2521
+#: src/ExternalConn.cpp:2522
 msgid "Unable to rename file."
 msgstr "Ezinda fitxategia berrizendatu."
 
-#: src/ExternalConn.cpp:2992 src/ExternalConn.cpp:3020
+#: src/ExternalConn.cpp:2839
+#, c-format
+msgid "Could not save the amuleapi password: %s"
+msgstr ""
+
+#: src/ExternalConn.cpp:3004 src/ExternalConn.cpp:3032
 msgid "Kad is disabled in preferences."
 msgstr "Kad ezgaiturik dago hobespenetan."
 
-#: src/ExternalConn.cpp:3033
+#: src/ExternalConn.cpp:3045
 msgid "Already connected to eD2k."
 msgstr "Dagoeneko eD2k-ra konektaturik."
 
-#: src/ExternalConn.cpp:3036
+#: src/ExternalConn.cpp:3048
 msgid "Connecting to eD2k..."
 msgstr "ed2k-era konektatzen..."
 
-#: src/ExternalConn.cpp:3045
+#: src/ExternalConn.cpp:3057
 msgid "Already connected to Kad."
 msgstr "Dagoeneko Kad-era konektaturik."
 
-#: src/ExternalConn.cpp:3048
+#: src/ExternalConn.cpp:3060
 msgid "Connecting to Kad..."
 msgstr "Kad-era konektatzen..."
 
-#: src/ExternalConn.cpp:3055
+#: src/ExternalConn.cpp:3067
 msgid "All networks are disabled."
 msgstr "Sare guztiak ezgaiturik daude."
 
-#: src/ExternalConn.cpp:3064
+#: src/ExternalConn.cpp:3076
 msgid "Disconnected from eD2k."
 msgstr "eD2k-tik deskonektatua."
 
-#: src/ExternalConn.cpp:3069
+#: src/ExternalConn.cpp:3081
 msgid "Disconnected from Kad."
 msgstr "Kad-etik deskonektaturik."
 
-#: src/ExternalConn.cpp:3078
+#: src/ExternalConn.cpp:3090
 #, c-format
 msgid "External Connection: invalid opcode received: %#x"
 msgstr "Kanpo Konexioa: okerreko opcode-a jasoa: %#x"
 
-#: src/ExternalConn.cpp:3083
+#: src/ExternalConn.cpp:3095
 msgid "Invalid opcode (wrong protocol version?)"
 msgstr "Opcode baliogabea (okerreko protokolo bertsioa?)"
 
@@ -2425,23 +2430,23 @@ msgid ""
 "want downloads on a different (e.g. larger) disk."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:549 src/FirstRunWizard.cpp:611 src/muuli_wdr.cpp:1708
+#: src/FirstRunWizard.cpp:549 src/FirstRunWizard.cpp:611 src/muuli_wdr.cpp:1712
 msgid "Destination folder for downloads"
 msgstr "Deskargentzat helburu karpeta"
 
 #: src/FirstRunWizard.cpp:553 src/FirstRunWizard.cpp:569 src/muuli_wdr.cpp:1349
-#: src/muuli_wdr.cpp:1366 src/muuli_wdr.cpp:1683 src/muuli_wdr.cpp:1714
-#: src/muuli_wdr.cpp:1726 src/muuli_wdr.cpp:2769
+#: src/muuli_wdr.cpp:1366 src/muuli_wdr.cpp:1687 src/muuli_wdr.cpp:1718
+#: src/muuli_wdr.cpp:1730 src/muuli_wdr.cpp:2800
 #: src/utils/aLinkCreator/src/alcframe.cpp:135
 #: src/utils/wxCas/src/wxcasprefs.cpp:52 src/utils/wxCas/src/wxcasprefs.cpp:118
 msgid "Browse"
 msgstr "Arakatu"
 
-#: src/FirstRunWizard.cpp:559 src/muuli_wdr.cpp:1719
+#: src/FirstRunWizard.cpp:559 src/muuli_wdr.cpp:1723
 msgid "(All files in this folder are shared with other peers)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:565 src/FirstRunWizard.cpp:624 src/muuli_wdr.cpp:1721
+#: src/FirstRunWizard.cpp:565 src/FirstRunWizard.cpp:624 src/muuli_wdr.cpp:1725
 msgid "Folder for temporary download files"
 msgstr "Aldiroko deskarga fitxategientzat karpeta"
 
@@ -2472,7 +2477,7 @@ msgstr "Huts 'emfriends.met' lagun zerrenda fitxategia idazteko irekitzean!"
 msgid "CRITICAL - no client on StartChatSession"
 msgstr "KRITIKOA - ez dago bezerorik StartChatSession-en"
 
-#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2675 src/muuli_wdr.cpp:3352
+#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2706 src/muuli_wdr.cpp:3383
 msgid "Friends"
 msgstr "Lagunak"
 
@@ -2583,8 +2588,8 @@ msgstr "Batez"
 msgid "No"
 msgstr "Ez"
 
-#: src/GenericClientListCtrl.cpp:1216 src/PrefsUnifiedDlg.cpp:2818
-#: src/PrefsUnifiedDlg.cpp:2868 src/ServerListCtrl.cpp:276
+#: src/GenericClientListCtrl.cpp:1216 src/PrefsUnifiedDlg.cpp:2898
+#: src/PrefsUnifiedDlg.cpp:2948 src/ServerListCtrl.cpp:276
 msgid "Yes"
 msgstr "Bai"
 
@@ -2753,10 +2758,10 @@ msgstr "Abiarazteko ataka baliogabea"
 msgid "Please fill all fields required"
 msgstr "Beharrezko eremu guztiak bete"
 
-#: src/KadDlg.cpp:192 src/PartFile.cpp:1031 src/PrefsUnifiedDlg.cpp:1162
-#: src/PrefsUnifiedDlg.cpp:1331 src/PrefsUnifiedDlg.cpp:1589
-#: src/PrefsUnifiedDlg.cpp:1599 src/PrefsUnifiedDlg.cpp:1616
-#: src/PrefsUnifiedDlg.cpp:1658
+#: src/KadDlg.cpp:192 src/PartFile.cpp:1031 src/PrefsUnifiedDlg.cpp:1134
+#: src/PrefsUnifiedDlg.cpp:1204 src/PrefsUnifiedDlg.cpp:1405
+#: src/PrefsUnifiedDlg.cpp:1663 src/PrefsUnifiedDlg.cpp:1673
+#: src/PrefsUnifiedDlg.cpp:1690 src/PrefsUnifiedDlg.cpp:1738
 msgid "Message"
 msgstr "Mezua"
 
@@ -2858,7 +2863,7 @@ msgstr "Partekatze erlazioa"
 msgid "Uploaded"
 msgstr "Igoa"
 
-#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3232
+#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3263
 msgid "Requested"
 msgstr "Eskatutakoa"
 
@@ -2982,7 +2987,7 @@ msgid "WARNING: "
 msgstr "OHARRA: "
 
 #: src/MuleNotebook.cpp:179 src/muuli_wdr.cpp:817 src/muuli_wdr.cpp:1229
-#: src/muuli_wdr.cpp:3136 src/muuli_wdr.cpp:3392
+#: src/muuli_wdr.cpp:3167 src/muuli_wdr.cpp:3423
 msgid "Close"
 msgstr "Itxi"
 
@@ -3000,7 +3005,7 @@ msgid "Paste"
 msgstr "Itsatsi"
 
 #: src/MuleTextCtrl.cpp:89 src/muuli_wdr.cpp:358 src/muuli_wdr.cpp:757
-#: src/muuli_wdr.cpp:2359 src/muuli_wdr.cpp:2378 src/muuli_wdr.cpp:2400
+#: src/muuli_wdr.cpp:2390 src/muuli_wdr.cpp:2409 src/muuli_wdr.cpp:2431
 #: src/utils/aLinkCreator/src/alcframe.cpp:142
 msgid "Clear"
 msgstr "Garbitu"
@@ -3099,7 +3104,7 @@ msgstr "Irten"
 
 #: src/MuleTrayIcon.cpp:579 src/MuleTrayIcon.cpp:945 src/MuleTrayIcon.cpp:965
 #: src/muuli_wdr.cpp:1398 src/muuli_wdr.cpp:1406 src/muuli_wdr.cpp:1413
-#: src/muuli_wdr.cpp:1842 src/muuli_wdr.cpp:1848 src/OtherFunctions.cpp:91
+#: src/muuli_wdr.cpp:1846 src/muuli_wdr.cpp:1852 src/OtherFunctions.cpp:91
 #: src/StatisticsDlg.cpp:93 src/StatisticsDlg.cpp:95
 msgid "kB/s"
 msgstr "kB/s"
@@ -3341,7 +3346,7 @@ msgstr "Byte"
 msgid "KB"
 msgstr "KB"
 
-#: src/muuli_wdr.cpp:274 src/muuli_wdr.cpp:293 src/muuli_wdr.cpp:1627
+#: src/muuli_wdr.cpp:274 src/muuli_wdr.cpp:293 src/muuli_wdr.cpp:1631
 #: src/OtherFunctions.cpp:64
 msgid "MB"
 msgstr "MB"
@@ -3358,7 +3363,7 @@ msgstr "Gehi. tamaina"
 msgid "Availability"
 msgstr "Eskuragarritasuna"
 
-#: src/muuli_wdr.cpp:312 src/muuli_wdr.cpp:398 src/muuli_wdr.cpp:3297
+#: src/muuli_wdr.cpp:312 src/muuli_wdr.cpp:398 src/muuli_wdr.cpp:3328
 msgid "Filter:"
 msgstr "Iragazkia:"
 
@@ -3421,12 +3426,12 @@ msgstr "Fitxategiaren iturburua:"
 #: src/muuli_wdr.cpp:1160 src/muuli_wdr.cpp:1167 src/muuli_wdr.cpp:1172
 #: src/muuli_wdr.cpp:1179 src/muuli_wdr.cpp:1184 src/muuli_wdr.cpp:1191
 #: src/muuli_wdr.cpp:1205 src/muuli_wdr.cpp:1212 src/muuli_wdr.cpp:1217
-#: src/muuli_wdr.cpp:1224 src/muuli_wdr.cpp:3234 src/muuli_wdr.cpp:3242
-#: src/muuli_wdr.cpp:3250
+#: src/muuli_wdr.cpp:1224 src/muuli_wdr.cpp:3265 src/muuli_wdr.cpp:3273
+#: src/muuli_wdr.cpp:3281
 msgid "N/A"
 msgstr "E/G"
 
-#: src/muuli_wdr.cpp:508 src/muuli_wdr.cpp:1065 src/PrefsUnifiedDlg.cpp:297
+#: src/muuli_wdr.cpp:508 src/muuli_wdr.cpp:1065 src/PrefsUnifiedDlg.cpp:299
 msgid "General"
 msgstr "Orokorra"
 
@@ -3567,7 +3572,7 @@ msgstr ""
 msgid "Album :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:685 src/muuli_wdr.cpp:2254
+#: src/muuli_wdr.cpp:685 src/muuli_wdr.cpp:2285
 msgid "Title :"
 msgstr "Titulua :"
 
@@ -3676,7 +3681,7 @@ msgstr "Erabiltzaile-izena :"
 msgid "Userhash :"
 msgstr "Erabiltzaile aztertze zenbakia :"
 
-#: src/muuli_wdr.cpp:895 src/muuli_wdr.cpp:1748 src/muuli_wdr.cpp:2449
+#: src/muuli_wdr.cpp:895 src/muuli_wdr.cpp:1752 src/muuli_wdr.cpp:2480
 #: src/utils/aLinkCreator/src/alcframe.cpp:137
 msgid "Add"
 msgstr "Gehitu"
@@ -3685,15 +3690,15 @@ msgstr "Gehitu"
 msgid "Download-Speed"
 msgstr "Deskarga abiadura"
 
-#: src/muuli_wdr.cpp:954 src/muuli_wdr.cpp:989 src/muuli_wdr.cpp:2553
+#: src/muuli_wdr.cpp:954 src/muuli_wdr.cpp:989 src/muuli_wdr.cpp:2584
 msgid "Current"
 msgstr "Unekoa"
 
-#: src/muuli_wdr.cpp:962 src/muuli_wdr.cpp:997 src/muuli_wdr.cpp:2561
+#: src/muuli_wdr.cpp:962 src/muuli_wdr.cpp:997 src/muuli_wdr.cpp:2592
 msgid "Running average"
 msgstr "Funtzionamendu bataz bestekoa"
 
-#: src/muuli_wdr.cpp:970 src/muuli_wdr.cpp:1005 src/muuli_wdr.cpp:2569
+#: src/muuli_wdr.cpp:970 src/muuli_wdr.cpp:1005 src/muuli_wdr.cpp:2600
 msgid "Session average"
 msgstr "saio batez bestekoa"
 
@@ -3705,7 +3710,7 @@ msgstr "Igoera abiadura"
 msgid "Connections"
 msgstr "Konexioak"
 
-#: src/muuli_wdr.cpp:1024 src/muuli_wdr.cpp:1867
+#: src/muuli_wdr.cpp:1024 src/muuli_wdr.cpp:1871
 msgid "Active downloads"
 msgstr "Deskarga aktiboak"
 
@@ -3713,7 +3718,7 @@ msgstr "Deskarga aktiboak"
 msgid "Active connections (1:1)"
 msgstr "konexio aktiboak (1:1)"
 
-#: src/muuli_wdr.cpp:1040 src/muuli_wdr.cpp:1868
+#: src/muuli_wdr.cpp:1040 src/muuli_wdr.cpp:1872
 msgid "Active uploads"
 msgstr "Igoera aktiboak"
 
@@ -3989,7 +3994,7 @@ msgstr "Lotu helbide lokala IP batetara (zurian edozeinentzat):"
 msgid "Advanced users only: If you have multiple network interfaces, enter the address of the interface to which aMule should be bound."
 msgstr "Erabiltzaile aurreratuak bakarrik: Sare interfaze anitz badituzu idatzi amulek erabili behar duen sare interfazearen helbidea."
 
-#: src/muuli_wdr.cpp:1462 src/muuli_wdr.cpp:2061
+#: src/muuli_wdr.cpp:1462 src/muuli_wdr.cpp:2065
 #, fuzzy
 msgid "Bind to network interface (empty for any):"
 msgstr "Lotu helbide lokala IP batetara (zurian edozeinentzat):"
@@ -4006,7 +4011,7 @@ msgstr "Jatorri muga deskarga bakoitzerako:"
 msgid "Max simultaneous connections:"
 msgstr "Aldibereko konexioa muga:"
 
-#: src/muuli_wdr.cpp:1498 src/muuli_wdr.cpp:3176
+#: src/muuli_wdr.cpp:1498 src/muuli_wdr.cpp:3207
 msgid "ED2K"
 msgstr "ED2K"
 
@@ -4098,755 +4103,778 @@ msgstr "Aurresleitu disko lekua fitxategi berrientzat"
 msgid "For new files preallocates disk space for the whole file, thus reduces fragmentation"
 msgstr "Fitxategi berrientzat fitxategi bakoitzarentzat disko leku osoa aurresleitzen du, honek fragmentazioa murrizten du"
 
-#: src/muuli_wdr.cpp:1613
+#: src/muuli_wdr.cpp:1617
 msgid "Create new files as sparse files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1614
-msgid "A sparse file reserves its full size on disk immediately without writing real data to it -- fast, but unsupported or slow on some filesystems, and free-space accounting stays optimistic while the download is in progress. Turn this off to grow the file only as data arrives."
+#: src/muuli_wdr.cpp:1618
+msgid "Sparse part files only occupy disk space for the parts already downloaded, so free space is used up gradually as the file fills in. Turn this off to use an ordinary file instead - useful where sparse files are unsupported or slow, or where backup/de-duplication tools handle them badly. Applies only when the core runs on Windows; on Linux and macOS part files are sparse anyway and this setting has no effect."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1619
+#: src/muuli_wdr.cpp:1623
 msgid "Stop downloads when free disk space reaches "
 msgstr "Gelditu deskargak disko-leku librea hona iristean "
 
-#: src/muuli_wdr.cpp:1620
+#: src/muuli_wdr.cpp:1624
 msgid "Select this if you want aMule to check your disk space"
 msgstr "Aukera hau hautatu aMulek zure disko-lekua egiaztatzea nahi baduzu"
 
-#: src/muuli_wdr.cpp:1624
+#: src/muuli_wdr.cpp:1628
 msgid "Enter here the min disk space desired."
 msgstr "Ezarri hemen nahi duzu disko toki txikiena."
 
-#: src/muuli_wdr.cpp:1630
+#: src/muuli_wdr.cpp:1634
 msgid "Save 10 sources on rare files (< 20 sources)"
 msgstr "10 jatorri gorde fitxategi arraroentzat (< 20 jatorri)"
 
-#: src/muuli_wdr.cpp:1634 src/Statistics.cpp:790
+#: src/muuli_wdr.cpp:1638 src/Statistics.cpp:790
 msgid "Uploads"
 msgstr "Igoerak"
 
-#: src/muuli_wdr.cpp:1637
+#: src/muuli_wdr.cpp:1641
 msgid "Add new shared files with auto priority"
 msgstr "Gehitu partekatutako fitxategi berriak auto-lehentasunarekin"
 
-#: src/muuli_wdr.cpp:1643
+#: src/muuli_wdr.cpp:1647
 msgid "Intelligent Corruption Handling (I.C.H.)"
 msgstr "Hondatze kudeaketa adimentsua (I.C.H)"
 
-#: src/muuli_wdr.cpp:1646
+#: src/muuli_wdr.cpp:1650
 msgid "Enable"
 msgstr "Gaitu"
 
-#: src/muuli_wdr.cpp:1649
+#: src/muuli_wdr.cpp:1653
 msgid "Advanced I.C.H. trusts every hash (not recommended)"
 msgstr "I.C.H aurreratuak, egiaztapen bakoitza egiaztatzen du (ez da gomendatzen)"
 
-#: src/muuli_wdr.cpp:1661 src/PrefsUnifiedDlg.cpp:1910
+#: src/muuli_wdr.cpp:1665 src/PrefsUnifiedDlg.cpp:1990
 msgid "Media metadata extraction"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1665
+#: src/muuli_wdr.cpp:1669
 msgid "Extract length / bitrate / codec from shared audio and video files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1667
+#: src/muuli_wdr.cpp:1671
 msgid "When enabled, aMule runs ffprobe on each shared media file to fill in the Length / Bitrate / Codec columns other clients see when they find the file in a search. Requires ffmpeg (the ffprobe binary) to be installed."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1674
+#: src/muuli_wdr.cpp:1678
 msgid "Path to ffprobe:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1679
+#: src/muuli_wdr.cpp:1683
 msgid "Full path to the ffprobe binary. Leave empty to have aMule auto-detect it on startup."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1687
+#: src/muuli_wdr.cpp:1691
 msgid "Detect"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1688
+#: src/muuli_wdr.cpp:1692
 msgid "Search the standard install locations for an ffprobe binary and fill the path field."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1712
+#: src/muuli_wdr.cpp:1716
 msgid ""
 "Completed downloads are stored here. All files in this folder are automatically shared with other peers.\n"
 "If this folder also holds files you don't want to share, point it at an aMule-only sub-folder."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1715
+#: src/muuli_wdr.cpp:1719
 msgid "Pick the folder where completed downloads will be stored. All files in that folder will be shared with other peers."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1729
+#: src/muuli_wdr.cpp:1733
 msgid "Shared folders"
 msgstr "Partekatutako karpetak"
 
-#: src/muuli_wdr.cpp:1735
+#: src/muuli_wdr.cpp:1739
 msgid "(Folders shared by the core. Enter a path to add one.)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1743
+#: src/muuli_wdr.cpp:1747
 msgid "Absolute path of a folder on the core's machine, e.g. /home/user/shared"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1745 src/PrefsUnifiedDlg.cpp:2794
+#: src/muuli_wdr.cpp:1749 src/PrefsUnifiedDlg.cpp:2874
 msgid "Recursive"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1746
+#: src/muuli_wdr.cpp:1750
 msgid "Share every sub-folder underneath this one, including ones created later."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1750 src/utils/aLinkCreator/src/alcframe.cpp:141
+#: src/muuli_wdr.cpp:1754 src/utils/aLinkCreator/src/alcframe.cpp:141
 msgid "Remove"
 msgstr "Ezabatu"
 
-#: src/muuli_wdr.cpp:1754
+#: src/muuli_wdr.cpp:1758
 msgid "(Right click on folder icon for recursive share)"
 msgstr "(Egin klik eskuineko botoiaz karpeta ikono batean barnekoak ere partekatzeko)"
 
-#: src/muuli_wdr.cpp:1761
+#: src/muuli_wdr.cpp:1765
 msgid "Share hidden files"
 msgstr "Partekatu ezkutatutako fitxategiak"
 
-#: src/muuli_wdr.cpp:1767
+#: src/muuli_wdr.cpp:1771
 msgid "Automatically rescan shared folders for changes"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1773
+#: src/muuli_wdr.cpp:1777
 msgid "Follow symbolic links in shared folders"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1779
+#: src/muuli_wdr.cpp:1783
 msgid "Exclude files matching:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1782
+#: src/muuli_wdr.cpp:1786
 msgid "Wildcard patterns separated by '|', e.g. .DS_Store|Thumbs.db|*.tmp. Files whose name matches are not shared. Matching is case-insensitive."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1786
+#: src/muuli_wdr.cpp:1790
 msgid "Patterns are regular expressions"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1787
+#: src/muuli_wdr.cpp:1791
 msgid "When set, the whole field is one regular expression ('|' is alternation). When unset, it is a list of '|'-separated wildcards."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1797
+#: src/muuli_wdr.cpp:1801
 msgid "Show how many shared files the current pattern would exclude."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1818
+#: src/muuli_wdr.cpp:1822
 msgid "Graphs"
 msgstr "Grafikak"
 
-#: src/muuli_wdr.cpp:1821 src/muuli_wdr.cpp:1883
+#: src/muuli_wdr.cpp:1825 src/muuli_wdr.cpp:1887
 msgid "Update delay : 5 secs"
 msgstr "Eguneratze atzerapena : 5 seg"
 
-#: src/muuli_wdr.cpp:1825
+#: src/muuli_wdr.cpp:1829
 msgid "Time for average graph: 100 mins"
 msgstr "Bataz besteko grafiko denbora : 100 min"
 
-#: src/muuli_wdr.cpp:1829
+#: src/muuli_wdr.cpp:1833
 msgid "Connections Graph Scale: 100 "
 msgstr "Konexio graf eskala: 100 "
 
-#: src/muuli_wdr.cpp:1836
+#: src/muuli_wdr.cpp:1840
 msgid "Download graph scale:"
 msgstr "Deskarga grafiko eskala:"
 
-#: src/muuli_wdr.cpp:1844
+#: src/muuli_wdr.cpp:1848
 msgid "Upload graph scale:"
 msgstr "Igoera grafiko eskala:"
 
-#: src/muuli_wdr.cpp:1854
+#: src/muuli_wdr.cpp:1858
 #, fuzzy
 msgid "Colors: "
 msgstr "Koloreak: "
 
-#: src/muuli_wdr.cpp:1858
+#: src/muuli_wdr.cpp:1862
 msgid "Background"
 msgstr "Atzeko planoa"
 
-#: src/muuli_wdr.cpp:1859
+#: src/muuli_wdr.cpp:1863
 msgid "Grid"
 msgstr "Sareta"
 
-#: src/muuli_wdr.cpp:1860
+#: src/muuli_wdr.cpp:1864
 msgid "Download current"
 msgstr "Uneko deskargak"
 
-#: src/muuli_wdr.cpp:1861
+#: src/muuli_wdr.cpp:1865
 msgid "Download running average"
 msgstr "Martxan deskargak bataz bestean"
 
-#: src/muuli_wdr.cpp:1862
+#: src/muuli_wdr.cpp:1866
 msgid "Download session average"
 msgstr "Saioaren bataz besteko deskargak"
 
-#: src/muuli_wdr.cpp:1863
+#: src/muuli_wdr.cpp:1867
 msgid "Upload current"
 msgstr "Uneko igoerak"
 
-#: src/muuli_wdr.cpp:1864
+#: src/muuli_wdr.cpp:1868
 msgid "Upload running average"
 msgstr "Martxan igoerak bataz bestean"
 
-#: src/muuli_wdr.cpp:1865
+#: src/muuli_wdr.cpp:1869
 msgid "Upload session average"
 msgstr "Saioaren bataz besteko igoerak"
 
-#: src/muuli_wdr.cpp:1866
+#: src/muuli_wdr.cpp:1870
 msgid "Active connections"
 msgstr "Konexio aktiboak"
 
-#: src/muuli_wdr.cpp:1869
+#: src/muuli_wdr.cpp:1873
 #, fuzzy
 msgid "Systray Icon Speed Bar"
 msgstr "Sistema-barra abiadura-barra ikonoa"
 
-#: src/muuli_wdr.cpp:1870
+#: src/muuli_wdr.cpp:1874
 msgid "Kad-nodes current"
 msgstr "Uneko Kad-nodoak"
 
-#: src/muuli_wdr.cpp:1871
+#: src/muuli_wdr.cpp:1875
 msgid "Kad-nodes running"
 msgstr "Kad-nodoak martxan"
 
-#: src/muuli_wdr.cpp:1872
+#: src/muuli_wdr.cpp:1876
 msgid "Kad-nodes session"
 msgstr "Kad-nodo saioa"
 
-#: src/muuli_wdr.cpp:1876 src/muuli_wdr.cpp:2303
+#: src/muuli_wdr.cpp:1880 src/muuli_wdr.cpp:2334
 msgid "Select"
 msgstr "Hautatu"
 
-#: src/muuli_wdr.cpp:1880
+#: src/muuli_wdr.cpp:1884
 msgid "Tree"
 msgstr "Zuhaitza"
 
-#: src/muuli_wdr.cpp:1890
+#: src/muuli_wdr.cpp:1894
 msgid "Number of Client Versions shown (0=unlimited)"
 msgstr "Erakutsiko diren bezero kopurua (0=mugagabea)"
 
-#: src/muuli_wdr.cpp:1915
+#: src/muuli_wdr.cpp:1919
 msgid "!!! WARNING !!!"
 msgstr "!!! KONTUZ !!!"
 
-#: src/muuli_wdr.cpp:1930
+#: src/muuli_wdr.cpp:1934
 msgid "Max new connections / 5 secs"
 msgstr "Gehienezko konexio berri / 5 seg"
 
-#: src/muuli_wdr.cpp:1932
+#: src/muuli_wdr.cpp:1936
 msgid "Concurrent Kad source lookups"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1934
+#: src/muuli_wdr.cpp:1938
 #, fuzzy
 msgid "Kad source re-search interval (minutes)"
 msgstr "FTP igoera aldia minututan"
 
-#: src/muuli_wdr.cpp:1936
+#: src/muuli_wdr.cpp:1940
 #, fuzzy
 msgid "Source re-ask interval (minutes)"
 msgstr "FTP igoera aldia minututan"
 
-#: src/muuli_wdr.cpp:1940
+#: src/muuli_wdr.cpp:1944
 msgid "File Buffer Size: 240000 bytes"
 msgstr "Fitxategia buffer tamaina: 240000 byte"
 
-#: src/muuli_wdr.cpp:1944
+#: src/muuli_wdr.cpp:1948
 msgid "Use MMAP: memory-mapped file access (lower memory use)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1945
+#: src/muuli_wdr.cpp:1949
 msgid "Maps part files into memory instead of buffering them on the heap, lowering the process memory footprint. May reduce download speed on some disks; best for memory-constrained or upload-heavy hosts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1947
+#: src/muuli_wdr.cpp:1951
 msgid "Upload Queue Size: 5000 clients"
 msgstr "Igoera ilara tamaina: 5000 bezero"
 
-#: src/muuli_wdr.cpp:1951
+#: src/muuli_wdr.cpp:1955
 msgid "Server connection refresh interval: Disable"
 msgstr "Zerbitzari konexio berritze aldia: Ezgaiturik"
 
-#: src/muuli_wdr.cpp:1955
+#: src/muuli_wdr.cpp:1959
 msgid "Disable computer's timed standby mode"
 msgstr "Ezgaitu ordenagailu ordulariaren bigarren planoko modua"
 
-#: src/muuli_wdr.cpp:1974
+#: src/muuli_wdr.cpp:1978
 msgid "Skin to use: "
 msgstr "Erabiltzeko azala: "
 
-#: src/muuli_wdr.cpp:1983
+#: src/muuli_wdr.cpp:1987
 msgid "Show \"Fast eD2k Links Handler\" in every window."
 msgstr "Erakutsi \"eD2k lotura kudeatzaile azkarra\" leiho bakoitzean."
 
-#: src/muuli_wdr.cpp:1986
+#: src/muuli_wdr.cpp:1990
 msgid "Show extended info on categories tabs"
 msgstr "Erakutsi argibide hedatuak kategoria fitxetan"
 
-#: src/muuli_wdr.cpp:1989
+#: src/muuli_wdr.cpp:1993
 msgid "Show application version on title"
 msgstr "Erakutsi aplikazio bertsioa izenburuan"
 
-#: src/muuli_wdr.cpp:1991
+#: src/muuli_wdr.cpp:1995
 msgid "Show transfer rates on title"
 msgstr "Erakutsi transferentziak izenburuan"
 
-#: src/muuli_wdr.cpp:1993
+#: src/muuli_wdr.cpp:1997
 msgid "Before application name"
 msgstr "Aplikazio izenaren aurretik"
 
-#: src/muuli_wdr.cpp:1995
+#: src/muuli_wdr.cpp:1999
 msgid "After application name"
 msgstr "Aplikazio izenaren ondoren"
 
-#: src/muuli_wdr.cpp:1998
+#: src/muuli_wdr.cpp:2002
 msgid "Show overhead bandwidth"
 msgstr "Erakutsi goiburu erabilpena"
 
-#: src/muuli_wdr.cpp:2002
+#: src/muuli_wdr.cpp:2006
 msgid "Vertical toolbar orientation"
 msgstr "Tresna-barra bertikal orientazioa"
 
-#: src/muuli_wdr.cpp:2004
+#: src/muuli_wdr.cpp:2008
 msgid "Live column sorting (auto-reorder rows as their values change)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2011
+#: src/muuli_wdr.cpp:2015
 msgid "Download Queue Files"
 msgstr "Deskargatu ilara fitxategiak"
 
-#: src/muuli_wdr.cpp:2014
+#: src/muuli_wdr.cpp:2018
 msgid "Show progress percentage"
 msgstr "Erakutsi aurrerapen ehunekoa"
 
-#: src/muuli_wdr.cpp:2020
+#: src/muuli_wdr.cpp:2024
 msgid "Show progress bar"
 msgstr "Erakutsi aurrerapen barra"
 
-#: src/muuli_wdr.cpp:2023
+#: src/muuli_wdr.cpp:2027
 msgid "Flat"
 msgstr "Laua"
 
-#: src/muuli_wdr.cpp:2027
+#: src/muuli_wdr.cpp:2031
 msgid "Round"
 msgstr "Biribildu"
 
-#: src/muuli_wdr.cpp:2045
+#: src/muuli_wdr.cpp:2049
 msgid "External Connection Parameters"
 msgstr "Urruneko konexio ezarpenak"
 
-#: src/muuli_wdr.cpp:2048
+#: src/muuli_wdr.cpp:2052
 msgid "Accept external connections"
 msgstr "Onartu urruneko konexioak"
 
-#: src/muuli_wdr.cpp:2055 src/muuli_wdr.cpp:2114
+#: src/muuli_wdr.cpp:2059 src/muuli_wdr.cpp:2118
 msgid "IP of the listening interface:"
 msgstr "Entzunean dagoen interfazearen IPa:"
 
-#: src/muuli_wdr.cpp:2058
+#: src/muuli_wdr.cpp:2062
 msgid "Enter here a valid ip in the a.b.c.d format for the listening EC interface. An empty field or 0.0.0.0 will mean any interface."
 msgstr "Idatzi hemen a.b.c.d formatuan entzun behar den interfazearen baliozko ip helbidea. Eremu huts batek edo 0.0.0.0 ezartzeak edozein interfazetan entzutea eragingo du."
 
-#: src/muuli_wdr.cpp:2079 src/muuli_wdr.cpp:2163
+#: src/muuli_wdr.cpp:2083 src/muuli_wdr.cpp:2194
 msgid "TCP port:"
 msgstr "TCP ataka:"
 
-#: src/muuli_wdr.cpp:2085
+#: src/muuli_wdr.cpp:2089
 msgid "Enable UPnP port forwarding on the EC port"
 msgstr "UPnP berbideraketa gaitu EC atakan"
 
-#: src/muuli_wdr.cpp:2089 src/muuli_wdr.cpp:3048
+#: src/muuli_wdr.cpp:2093 src/muuli_wdr.cpp:3079
 #: src/utils/wxCas/src/wxcasprefs.cpp:167
 msgid "Password"
 msgstr "Pasahitza"
 
-#: src/muuli_wdr.cpp:2095
+#: src/muuli_wdr.cpp:2099
 #, fuzzy
 msgid "aMule API server parameters"
 msgstr "Web zerbitzari parametroak"
 
-#: src/muuli_wdr.cpp:2098
+#: src/muuli_wdr.cpp:2102
 msgid "Run amuleapi (REST API) on startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2103
+#: src/muuli_wdr.cpp:2107
 #, fuzzy
 msgid "HTTP port:"
 msgstr "TCP ataka:"
 
-#: src/muuli_wdr.cpp:2117
+#: src/muuli_wdr.cpp:2121
 msgid "The interface amuleapi's HTTP server listens on. 127.0.0.1 (default) accepts only local connections; use 0.0.0.0 or a specific IP to expose it to other hosts (set an admin password below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2120
+#: src/muuli_wdr.cpp:2126
+msgid "Type a password to set or change it. Stored passwords cannot be shown, so leaving this empty keeps the current one."
+msgstr ""
+
+#: src/muuli_wdr.cpp:2128
 #, fuzzy
 msgid "Admin password"
 msgstr "Pasahitz egiaztatzen\n"
 
-#: src/muuli_wdr.cpp:2125 src/muuli_wdr.cpp:2156
-msgid "Low rights password"
-msgstr "Baimen baxuko pasahitza"
+#: src/muuli_wdr.cpp:2140 src/muuli_wdr.cpp:2157 src/PrefsUnifiedDlg.cpp:1103
+#, fuzzy
+msgid "A password is set."
+msgstr "Pasahitz egiaztatzen\n"
 
-#: src/muuli_wdr.cpp:2133
+#: src/muuli_wdr.cpp:2144
+#, fuzzy
+msgid "Enable guest access"
+msgstr "Gonbidatu sarrera ezgaitu"
+
+#: src/muuli_wdr.cpp:2145
+msgid "Guest sessions may read status and listings but cannot change anything. Turning this off clears the stored guest password."
+msgstr ""
+
+#: src/muuli_wdr.cpp:2149
+#, fuzzy
+msgid "Guest password"
+msgstr "Gonbidatu pasahitza web zerbitzarirako"
+
+#: src/muuli_wdr.cpp:2164
 msgid "Web server parameters"
 msgstr "Web zerbitzari parametroak"
 
-#: src/muuli_wdr.cpp:2136
+#: src/muuli_wdr.cpp:2167
 #, fuzzy
 msgid "Run webserver on startup (deprecated)"
 msgstr "Exekutatu web-zerbitzaria abioan"
 
-#: src/muuli_wdr.cpp:2142
+#: src/muuli_wdr.cpp:2173
 msgid "Web template"
 msgstr "Web txantiloia"
 
-#: src/muuli_wdr.cpp:2147
+#: src/muuli_wdr.cpp:2178
 msgid "Full rights password"
 msgstr "Baimen osorako pasahitza"
 
-#: src/muuli_wdr.cpp:2151
+#: src/muuli_wdr.cpp:2182
 msgid "Enable Low rights User"
 msgstr "Gaitu baimen gutxiko erabiltzailea"
 
-#: src/muuli_wdr.cpp:2170
+#: src/muuli_wdr.cpp:2187
+msgid "Low rights password"
+msgstr "Baimen baxuko pasahitza"
+
+#: src/muuli_wdr.cpp:2201
 msgid "Enable UPnP port forwarding of the web server port"
 msgstr "Gaitu web zerbitzari atakaren UPnP ataka birbidalketa"
 
-#: src/muuli_wdr.cpp:2175
+#: src/muuli_wdr.cpp:2206
 msgid "Web server UPnP TCP port (Optional)"
 msgstr "Web zerbitzari UPnP ataka (aukerakoa)"
 
-#: src/muuli_wdr.cpp:2183
+#: src/muuli_wdr.cpp:2214
 msgid "Page Refresh Time (in secs)"
 msgstr "Orrialdea berritzeko denbora (segundotan)"
 
-#: src/muuli_wdr.cpp:2190
+#: src/muuli_wdr.cpp:2221
 msgid "Enable Gzip compression"
 msgstr "Gaitu Gzip konpresioa"
 
-#: src/muuli_wdr.cpp:2224
+#: src/muuli_wdr.cpp:2255
 #, fuzzy
 msgid "Reset page to defaults"
 msgstr "Sistema lehenetsia"
 
-#: src/muuli_wdr.cpp:2225
+#: src/muuli_wdr.cpp:2256
 msgid "Reset the settings on the current page to their default values."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2227 src/muuli_wdr.cpp:2313 src/ServerWnd.cpp:274
+#: src/muuli_wdr.cpp:2258 src/muuli_wdr.cpp:2344 src/ServerWnd.cpp:274
 #: src/ServerWnd.cpp:282
 msgid "OK"
 msgstr "Ados"
 
-#: src/muuli_wdr.cpp:2229
+#: src/muuli_wdr.cpp:2260
 msgid "Click here to apply any changes made to the preferences."
 msgstr "Hemen klik egin hobespenetan eginiko edozein aldaketa ezartzeko."
 
-#: src/muuli_wdr.cpp:2232
+#: src/muuli_wdr.cpp:2263
 msgid "Reset any changes made to the preferences."
 msgstr "Berrezarri hobespenetan eginiko edozein aldaketa."
 
-#: src/muuli_wdr.cpp:2261
+#: src/muuli_wdr.cpp:2292
 msgid "Comment :"
 msgstr "Iruzkina :"
 
-#: src/muuli_wdr.cpp:2268
+#: src/muuli_wdr.cpp:2299
 msgid "Incoming Dir :"
 msgstr "Deskarga direktorioa :"
 
-#: src/muuli_wdr.cpp:2277
+#: src/muuli_wdr.cpp:2308
 msgid "Change priority for new assigned files :"
 msgstr "Aldatu lehentasuna fitxategi berrientzat :"
 
-#: src/muuli_wdr.cpp:2281
+#: src/muuli_wdr.cpp:2312
 msgid "Don't change"
 msgstr "Ez aldatu"
 
-#: src/muuli_wdr.cpp:2293
+#: src/muuli_wdr.cpp:2324
 msgid "Select color for this Category (currently selected) :"
 msgstr "Hautatu kolorea kategoria honentzat (unean aukeratutakoa) :"
 
-#: src/muuli_wdr.cpp:2360 src/muuli_wdr.cpp:2379 src/muuli_wdr.cpp:2401
+#: src/muuli_wdr.cpp:2391 src/muuli_wdr.cpp:2410 src/muuli_wdr.cpp:2432
 msgid "Click this button to reset the log."
 msgstr "Botoi hau klikatu erregistroa garbitzeko."
 
-#: src/muuli_wdr.cpp:2420
+#: src/muuli_wdr.cpp:2451
 msgid "Click on this button to update the servers list from URL ..."
 msgstr "Klik egin botoi honetan zerbitzari zerrenda URL-tik eguneratzeko ..."
 
-#: src/muuli_wdr.cpp:2424
+#: src/muuli_wdr.cpp:2455
 msgid "Server list"
 msgstr "Zerbitzari zerrenda"
 
-#: src/muuli_wdr.cpp:2428
+#: src/muuli_wdr.cpp:2459
 msgid "Enter the url to a server.met file here and press the button to the left to update the list of known servers."
 msgstr "Idatzi server.met fitxategiaren URL bat hemen eta gero ezkerreko botoia sakatu zerbitzari ezagunen zerrenda eguneratzeko."
 
-#: src/muuli_wdr.cpp:2433
+#: src/muuli_wdr.cpp:2464
 msgid "Add server manually: Name"
 msgstr "Gehitu zerbitzaria eskuz: Izena"
 
-#: src/muuli_wdr.cpp:2436
+#: src/muuli_wdr.cpp:2467
 msgid "Enter the name of the new server here"
 msgstr "Idatzi zerbitzari berriaren izen hemen"
 
-#: src/muuli_wdr.cpp:2438 src/ServerWnd.cpp:206
+#: src/muuli_wdr.cpp:2469 src/ServerWnd.cpp:206
 msgid "IP:Port"
 msgstr "IP ataka"
 
-#: src/muuli_wdr.cpp:2441
+#: src/muuli_wdr.cpp:2472
 msgid "Enter the IP of the server here, using the x.x.x.x format."
 msgstr "Idatzi x.x.x.x formatua erabiliaz zerbitzariaren ip helbidea."
 
-#: src/muuli_wdr.cpp:2447
+#: src/muuli_wdr.cpp:2478
 msgid "Enter the port of the server here."
 msgstr "Idatzi zerbitzariaren ataka hemen."
 
-#: src/muuli_wdr.cpp:2450
+#: src/muuli_wdr.cpp:2481
 msgid "Add manually a server (fill fields to the left before) ..."
 msgstr "Gehitu zerbitzari bat eskuz (sar datuak ezkerrean lehenik) ..."
 
-#: src/muuli_wdr.cpp:2479
+#: src/muuli_wdr.cpp:2510
 msgid "aMule Log"
 msgstr "aMule erregistroa"
 
-#: src/muuli_wdr.cpp:2487
+#: src/muuli_wdr.cpp:2518
 msgid "Server Info"
 msgstr "Zerbitzari argibideak"
 
-#: src/muuli_wdr.cpp:2491
+#: src/muuli_wdr.cpp:2522
 msgid "ED2K Info"
 msgstr "Argb"
 
-#: src/muuli_wdr.cpp:2495
+#: src/muuli_wdr.cpp:2526
 msgid "Kad Info"
 msgstr "Kad Argb"
 
-#: src/muuli_wdr.cpp:2523
+#: src/muuli_wdr.cpp:2554
 msgid "Click on this button to update the nodes list from URL ..."
 msgstr "Klikatu botoi honetan nodo zerrenda URL honetatik eguneratzeko ..."
 
-#: src/muuli_wdr.cpp:2527
+#: src/muuli_wdr.cpp:2558
 msgid "Nodes (0)"
 msgstr "Nodoak (0)"
 
-#: src/muuli_wdr.cpp:2531
+#: src/muuli_wdr.cpp:2562
 msgid "Enter the url to a nodes.dat file here and press the button to the left to update the list of known nodes."
 msgstr "nodes.dat fitxategi baten URL-a idatzi eta ezkerreko botoia sakatu nodo ezagunen zerrenda eguneratzeko."
 
-#: src/muuli_wdr.cpp:2534
+#: src/muuli_wdr.cpp:2565
 msgid "Nodes stats"
 msgstr "Nodo estatistikak"
 
-#: src/muuli_wdr.cpp:2576
+#: src/muuli_wdr.cpp:2607
 msgid "Bootstrap"
 msgstr "Autoabioa"
 
-#: src/muuli_wdr.cpp:2579
+#: src/muuli_wdr.cpp:2610
 msgid "New node"
 msgstr "Nodo berria"
 
-#: src/muuli_wdr.cpp:2584
+#: src/muuli_wdr.cpp:2615
 msgid "IP:"
 msgstr "IP:"
 
-#: src/muuli_wdr.cpp:2604
+#: src/muuli_wdr.cpp:2635
 msgid "Port:"
 msgstr "Ataka:"
 
-#: src/muuli_wdr.cpp:2617
+#: src/muuli_wdr.cpp:2648
 msgid "Bootstrap from known clients"
 msgstr "Bezero ezagunetarik abiarazi"
 
-#: src/muuli_wdr.cpp:2619
+#: src/muuli_wdr.cpp:2650
 msgid "Disconnect Kad"
 msgstr "Kad deskonektatu"
 
-#: src/muuli_wdr.cpp:2653
+#: src/muuli_wdr.cpp:2684
 msgid "Use Secure User Identification"
 msgstr "Erabili erabiltzaile identifikazio segurua"
 
-#: src/muuli_wdr.cpp:2655
+#: src/muuli_wdr.cpp:2686
 msgid "It is recommended to enable this option. You will not receive credits if SUI is not enabled."
 msgstr "Gomendagarri da aukera hau gaitzea. Ez duzu krediturik jasoko EIS erabiltzen ez baduzu."
 
-#: src/muuli_wdr.cpp:2657
+#: src/muuli_wdr.cpp:2688
 msgid "Protocol Obfuscation"
 msgstr "Protokolo nahastea"
 
-#: src/muuli_wdr.cpp:2660
+#: src/muuli_wdr.cpp:2691
 msgid "Support Protocol Obfuscation"
 msgstr "Gaitu protokolo nahastea"
 
-#: src/muuli_wdr.cpp:2662
+#: src/muuli_wdr.cpp:2693
 msgid "This option enabled Protocol Obfuscation, and makes aMule accept obfuscated connections from other clients."
 msgstr "Aukera honek protokolo nahastea gaitzen du eta aMule-k beste bezeroetako konexio nahastuak onartzea eragite du."
 
-#: src/muuli_wdr.cpp:2664
+#: src/muuli_wdr.cpp:2695
 msgid "Use obfuscation for outgoing connections"
 msgstr "Erabili nahastea kanporako konexioetan"
 
-#: src/muuli_wdr.cpp:2666
+#: src/muuli_wdr.cpp:2697
 msgid "This option makes aMule use Protocol Obfuscation when connecting other clients/servers."
 msgstr "Aukera honek Amulek beste bezero/zerbitzarietara konektatzerakoan protokolo nahastea erabiltzea eragiten du."
 
-#: src/muuli_wdr.cpp:2668
+#: src/muuli_wdr.cpp:2699
 msgid "Accept only obfuscated connections"
 msgstr "Onartu nahasitako konexioak bakarrik"
 
-#: src/muuli_wdr.cpp:2669
+#: src/muuli_wdr.cpp:2700
 msgid "This option makes aMule only accept obfuscated connections. You will have less sources, but all your traffic will be obfuscated"
 msgstr "Aukera honek Amulek nahasitako konexioak bakarrik onartzea eragiten du. Jatorri gutxiago izango dituzu baina zure trafiko guztia nahasia egongo da"
 
-#: src/muuli_wdr.cpp:2674
+#: src/muuli_wdr.cpp:2705
 msgid "Everybody"
 msgstr "Edozeini"
 
-#: src/muuli_wdr.cpp:2676
+#: src/muuli_wdr.cpp:2707
 msgid "No one"
 msgstr "Bat ere ez"
 
-#: src/muuli_wdr.cpp:2678
+#: src/muuli_wdr.cpp:2709
 msgid "Who can see my shared files:"
 msgstr "Nork ikusi ditzaken nire partekatutako fitxategiak:"
 
-#: src/muuli_wdr.cpp:2679
+#: src/muuli_wdr.cpp:2710
 msgid "Select who can request to view a list of your shared files."
 msgstr "Hautatu zure partekatutako fitxategiak nork ikus ditzakeen."
 
-#: src/muuli_wdr.cpp:2681
+#: src/muuli_wdr.cpp:2712
 msgid "IP-Filtering"
 msgstr "IP-Iragazkia"
 
-#: src/muuli_wdr.cpp:2688
+#: src/muuli_wdr.cpp:2719
 msgid "Filter clients"
 msgstr "Bezeroak iragazi"
 
-#: src/muuli_wdr.cpp:2690
+#: src/muuli_wdr.cpp:2721
 msgid "Enable filtering of the client IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "~/.aMule/ipfilter.dat fitxategian ezarritako bezero IP iragazketa gaitu."
 
-#: src/muuli_wdr.cpp:2692
+#: src/muuli_wdr.cpp:2723
 msgid "Filter servers"
 msgstr "Zerbitzariak iragazi"
 
-#: src/muuli_wdr.cpp:2694
+#: src/muuli_wdr.cpp:2725
 msgid "Enable filtering of the server IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "~/.aMule/ipfilter.dat fitxategian ezarritako zerbitzari IP iragazketa gaitu."
 
-#: src/muuli_wdr.cpp:2698
+#: src/muuli_wdr.cpp:2729
 msgid "Reload List"
 msgstr "Berritu zerrenda"
 
-#: src/muuli_wdr.cpp:2699
+#: src/muuli_wdr.cpp:2730
 msgid "Reload the list of IPs to filter from the file ~/.aMule/ipfilter.dat"
 msgstr "Berritu ~/.aMule/ipfilter.dat fitxategian ezarritako IP helbideen iragazkia"
 
-#: src/muuli_wdr.cpp:2705
+#: src/muuli_wdr.cpp:2736
 msgid "URL:"
 msgstr "URL-a:"
 
-#: src/muuli_wdr.cpp:2709 src/muuli_wdr.cpp:2902
+#: src/muuli_wdr.cpp:2740 src/muuli_wdr.cpp:2933
 msgid "Update now"
 msgstr "Eguneratu orain"
 
-#: src/muuli_wdr.cpp:2712
+#: src/muuli_wdr.cpp:2743
 msgid "Auto-update ipfilter at startup"
 msgstr "Automatikoki eguneratu ip iragazkia abioan"
 
-#: src/muuli_wdr.cpp:2716
+#: src/muuli_wdr.cpp:2747
 msgid "Filtering Level:"
 msgstr "Iragazki maila:"
 
-#: src/muuli_wdr.cpp:2722
+#: src/muuli_wdr.cpp:2753
 msgid "Always filter LAN IPs"
 msgstr "Beti iragazi LAN IP-ak"
 
-#: src/muuli_wdr.cpp:2725
+#: src/muuli_wdr.cpp:2756
 msgid "Paranoid handling of non-matching IPs"
 msgstr "Paranoia kudeaketa pareko ez diren IP helbideentzat"
 
-#: src/muuli_wdr.cpp:2727
+#: src/muuli_wdr.cpp:2758
 msgid "Rejects a packet when its source IP differs from the IP the client claims (an anti-spoofing check). Disable only if it causes connection problems."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2729
+#: src/muuli_wdr.cpp:2760
 msgid "Use system-wide ipfilter.dat if available"
 msgstr "Erabili sistemako ipfilter.dat eskuragarri badago"
 
-#: src/muuli_wdr.cpp:2730
+#: src/muuli_wdr.cpp:2761
 #, fuzzy
 msgid "If there's no local ipfilter.dat found, allow usage of a system-wide ipfilter file."
 msgstr "Ez bada ipfilter.dat fitxategi lokalik aurkitu, orduan onartu sistema ipfilter fitxategia erabiltzea."
 
-#: src/muuli_wdr.cpp:2747
+#: src/muuli_wdr.cpp:2778
 msgid "Enable Online-Signature"
 msgstr "Gaitu sinadura linean"
 
-#: src/muuli_wdr.cpp:2749
+#: src/muuli_wdr.cpp:2780
 msgid "Enables the writing of the OS file, which can be used by external apps to create signatures and the like."
 msgstr "Gaitu sistemak fitxategiak idaztea, kanpo programek sinadurak sortu ahal izateko egiten da."
 
-#: src/muuli_wdr.cpp:2753
+#: src/muuli_wdr.cpp:2784
 msgid "Update Frequency (Secs):"
 msgstr "Eguneratu maiztasuna (Seg):"
 
-#: src/muuli_wdr.cpp:2756
+#: src/muuli_wdr.cpp:2787
 msgid "Change the frequency (in seconds) of Online Signature updates."
 msgstr "Aldatu linean sinadura eguneraketa aldia (segundotan)."
 
-#: src/muuli_wdr.cpp:2764
+#: src/muuli_wdr.cpp:2795
 msgid "Save online signature file in: "
 msgstr "Gorde sare sinadura fitxategia hemen: "
 
-#: src/muuli_wdr.cpp:2770
+#: src/muuli_wdr.cpp:2801
 msgid "Click here to select the directory containing the the Online Signature files."
 msgstr "Klikatu hemen linean sinadurak dituen karpeta aukeratzeko."
 
-#: src/muuli_wdr.cpp:2803
+#: src/muuli_wdr.cpp:2834
 msgid "Show country flags for clients"
 msgstr "Bistarazi estatu banderak bezeroentzat"
 
-#: src/muuli_wdr.cpp:2804
+#: src/muuli_wdr.cpp:2835
 msgid "Render the country flag column in the transfers, queue and search views. Requires a valid MMDB GeoIP database (see below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2809
+#: src/muuli_wdr.cpp:2840
 #, fuzzy
 msgid "Database"
 msgstr "Data abiadura :"
 
-#: src/muuli_wdr.cpp:2825
+#: src/muuli_wdr.cpp:2856
 #, fuzzy
 msgid "Source:"
 msgstr "Jatorriak"
 
-#: src/muuli_wdr.cpp:2828
+#: src/muuli_wdr.cpp:2859
 msgid "DB-IP (free, no account)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2829
+#: src/muuli_wdr.cpp:2860
 msgid "MaxMind GeoLite2 (free, account required)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2830
+#: src/muuli_wdr.cpp:2861
 msgid "Custom URL"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2833
+#: src/muuli_wdr.cpp:2864
 msgid "Choose which provider supplies the GeoIP MMDB database. DB-IP is the default - no account required. MaxMind requires a free account + license key. Use Custom URL to point at any other MMDB host (e.g. a local mirror)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2850
+#: src/muuli_wdr.cpp:2881
 msgid ""
 "No configuration required.\n"
 "\n"
@@ -4854,11 +4882,11 @@ msgid ""
 "License: Creative Commons BY 4.0 - https://creativecommons.org/licenses/by/4.0/"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2863
+#: src/muuli_wdr.cpp:2894
 msgid "License key:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2869
+#: src/muuli_wdr.cpp:2900
 msgid ""
 "Sign up for a free MaxMind account, then generate a License Key:\n"
 "https://www.maxmind.com/en/geolite2/signup\n"
@@ -4868,226 +4896,226 @@ msgid ""
 "Requires attribution and account registration; refresh at least every 30 days."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2884
+#: src/muuli_wdr.cpp:2915
 #, fuzzy
 msgid "Download URL:"
 msgstr "Deskargak: "
 
-#: src/muuli_wdr.cpp:2890
+#: src/muuli_wdr.cpp:2921
 msgid ""
 "Must point to an .mmdb file or a .gz / .tar.gz containing one.\n"
 "URL may include credentials (https://user:pass@host/...).\n"
 "License and attribution terms are set by the upstream URL - you are responsible."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2903
+#: src/muuli_wdr.cpp:2934
 msgid "Download the GeoIP database from the selected source."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2905
+#: src/muuli_wdr.cpp:2936
 #, fuzzy
 msgid "Auto-update on startup"
 msgstr "Automatikoki eguneratu ip iragazkia abioan"
 
-#: src/muuli_wdr.cpp:2906
+#: src/muuli_wdr.cpp:2937
 msgid "Re-download the GeoIP database from the selected source every time aMule starts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2929
+#: src/muuli_wdr.cpp:2960
 msgid "Filter incoming messages (except current chat):"
 msgstr "sarrera mezu iragazkia (txat honetan ezik):"
 
-#: src/muuli_wdr.cpp:2931
+#: src/muuli_wdr.cpp:2962
 msgid "Filter all messages"
 msgstr "Mezu guztiak iragazi"
 
-#: src/muuli_wdr.cpp:2933
+#: src/muuli_wdr.cpp:2964
 msgid "Filter messages from people not on your friend list"
 msgstr "Lagun zerrendan ez daudenen mezuak iragazi"
 
-#: src/muuli_wdr.cpp:2935
+#: src/muuli_wdr.cpp:2966
 msgid "Filter messages from unknown clients"
 msgstr "Bezero ezezagunen mezuak iragazi"
 
-#: src/muuli_wdr.cpp:2937
+#: src/muuli_wdr.cpp:2968
 msgid "Filter messages containing (use ',' as separator):"
 msgstr "Hau duten mezuak iragazi (erabili ',' bereizle bezala):"
 
-#: src/muuli_wdr.cpp:2940 src/muuli_wdr.cpp:2951
+#: src/muuli_wdr.cpp:2971 src/muuli_wdr.cpp:2982
 msgid "add here the words amule should filter and block messages including it"
 msgstr "Gehitu amulek mezuetan blokeatzea nahi dituzun hitzak"
 
-#: src/muuli_wdr.cpp:2942
+#: src/muuli_wdr.cpp:2973
 msgid "Show received messages in the log"
 msgstr "Ikusi jasotako mezuak erregistroan"
 
-#: src/muuli_wdr.cpp:2945
+#: src/muuli_wdr.cpp:2976
 msgid "Comments"
 msgstr "Iruzkinak"
 
-#: src/muuli_wdr.cpp:2948
+#: src/muuli_wdr.cpp:2979
 msgid "Filter comments containing (use ',' as separator):"
 msgstr "Fitxategi iruzkinak hau du (',' erabili bereizle gisa):"
 
-#: src/muuli_wdr.cpp:2973
+#: src/muuli_wdr.cpp:3004
 msgid "Enable Proxy"
 msgstr "Proxy-a gaitu"
 
-#: src/muuli_wdr.cpp:2974
+#: src/muuli_wdr.cpp:3005
 msgid "Enable/disable proxy support"
 msgstr "Proxy onarpena gaitu/ezgaitu"
 
-#: src/muuli_wdr.cpp:2977
+#: src/muuli_wdr.cpp:3008
 msgid "Proxy type:"
 msgstr "Proxy mota:"
 
-#: src/muuli_wdr.cpp:2988
+#: src/muuli_wdr.cpp:3019
 msgid "Proxy host:"
 msgstr "Proxy ostalaria:"
 
-#: src/muuli_wdr.cpp:2991
+#: src/muuli_wdr.cpp:3022
 msgid "The proxy host name"
 msgstr "Proxy ostalari izena"
 
-#: src/muuli_wdr.cpp:2993
+#: src/muuli_wdr.cpp:3024
 msgid "Proxy port:"
 msgstr "Proxy ataka:"
 
-#: src/muuli_wdr.cpp:2996
+#: src/muuli_wdr.cpp:3027
 msgid "The proxy port"
 msgstr "Proxy ataka"
 
-#: src/muuli_wdr.cpp:2998
+#: src/muuli_wdr.cpp:3029
 msgid "Enable authentication"
 msgstr "Gaitu autentifikazioa"
 
-#: src/muuli_wdr.cpp:2999
+#: src/muuli_wdr.cpp:3030
 msgid "Enable/disable username/password authentication"
 msgstr "erabiltzaile/pasahitz autentifikazioa gaitu/ezgaitu"
 
-#: src/muuli_wdr.cpp:3002
+#: src/muuli_wdr.cpp:3033
 msgid "Username: "
 msgstr "Erabiltzaile izena: "
 
-#: src/muuli_wdr.cpp:3005
+#: src/muuli_wdr.cpp:3036
 msgid "The username to use to connect to the proxy"
 msgstr "Proxy-ra konektatzeko erabiliko den erabiltzaile izena"
 
-#: src/muuli_wdr.cpp:3007
+#: src/muuli_wdr.cpp:3038
 msgid "Password:"
 msgstr "Pasahitza:"
 
-#: src/muuli_wdr.cpp:3010
+#: src/muuli_wdr.cpp:3041
 msgid "The password to use to connect to the proxy"
 msgstr "Proxy-ra konektatzeko erabiliko den pasahitza"
 
-#: src/muuli_wdr.cpp:3029
+#: src/muuli_wdr.cpp:3060
 msgid "Connect to:"
 msgstr "Hona konektaturik:"
 
-#: src/muuli_wdr.cpp:3038
+#: src/muuli_wdr.cpp:3069
 msgid "Login to remote amule"
 msgstr "Urruneko aMulen saioa hasi"
 
-#: src/muuli_wdr.cpp:3043
+#: src/muuli_wdr.cpp:3074
 msgid "User name"
 msgstr "Erabiltzaile izena"
 
-#: src/muuli_wdr.cpp:3054
+#: src/muuli_wdr.cpp:3085
 msgid "Remember those settings"
 msgstr "Ezarpen hauek gogoratu"
 
-#: src/muuli_wdr.cpp:3057
+#: src/muuli_wdr.cpp:3088
 #, fuzzy
 msgid "Force ZLIB compression"
 msgstr "Erabili gzip konpresioa"
 
-#: src/muuli_wdr.cpp:3081
+#: src/muuli_wdr.cpp:3112
 msgid "Enable Verbose Debug-Logging."
 msgstr "Gaitu arazten luzeko saio hasiera."
 
-#: src/muuli_wdr.cpp:3083
+#: src/muuli_wdr.cpp:3114
 #, fuzzy
 msgid "Only to Logfile"
 msgstr "&Ireki fitxategia"
 
-#: src/muuli_wdr.cpp:3085
+#: src/muuli_wdr.cpp:3116
 msgid "Message Categories:"
 msgstr "Mezu kategoriak:"
 
-#: src/muuli_wdr.cpp:3109 src/PartFileConvertDlg.cpp:160
+#: src/muuli_wdr.cpp:3140 src/PartFileConvertDlg.cpp:160
 msgid "Waiting..."
 msgstr "Zain..."
 
-#: src/muuli_wdr.cpp:3129
+#: src/muuli_wdr.cpp:3160
 msgid "Add imports"
 msgstr "Gehitu"
 
-#: src/muuli_wdr.cpp:3132
+#: src/muuli_wdr.cpp:3163
 msgid "Retry selected"
 msgstr "Berriz saiatu hautaturikoak"
 
-#: src/muuli_wdr.cpp:3134
+#: src/muuli_wdr.cpp:3165
 msgid "Remove selected"
 msgstr "Ezabatu hautaturikoak"
 
-#: src/muuli_wdr.cpp:3197
+#: src/muuli_wdr.cpp:3228
 msgid "Event Types"
 msgstr "Gertaera motak"
 
-#: src/muuli_wdr.cpp:3216
+#: src/muuli_wdr.cpp:3247
 msgid "Statistics and queued clients for selected file(s) : Session / All time"
 msgstr "Hautako fitxategientzat estatistika eta bezero ilara: Saioa / osotara"
 
-#: src/muuli_wdr.cpp:3240
+#: src/muuli_wdr.cpp:3271
 msgid "Active Uploads"
 msgstr "Igoera aktiboak"
 
-#: src/muuli_wdr.cpp:3254
+#: src/muuli_wdr.cpp:3285
 msgid "Percent of total files"
 msgstr "fitxategi guztien ehunekoa"
 
-#: src/muuli_wdr.cpp:3306
+#: src/muuli_wdr.cpp:3337
 msgid "Show Clients for"
 msgstr "Erakutsi bezeroak:"
 
-#: src/muuli_wdr.cpp:3308
+#: src/muuli_wdr.cpp:3339
 msgid "All files"
 msgstr "Fitxategi guztiak"
 
-#: src/muuli_wdr.cpp:3311
+#: src/muuli_wdr.cpp:3342
 msgid "Selected files"
 msgstr "Hautatutako fitxategiak"
 
-#: src/muuli_wdr.cpp:3314
+#: src/muuli_wdr.cpp:3345
 msgid "Active uploads only"
 msgstr "Igoera aktiboak bakarrik"
 
-#: src/muuli_wdr.cpp:3321
+#: src/muuli_wdr.cpp:3352
 msgid "Reload:"
 msgstr "Berritu:"
 
-#: src/muuli_wdr.cpp:3325
+#: src/muuli_wdr.cpp:3356
 msgid "Reload your shared files"
 msgstr "Berritu zure partekatutako fitxategiak"
 
-#: src/muuli_wdr.cpp:3388
+#: src/muuli_wdr.cpp:3419
 msgid "Send"
 msgstr "Bidali"
 
-#: src/muuli_wdr.cpp:3389
+#: src/muuli_wdr.cpp:3420
 msgid "Sends the specified message."
 msgstr "Zehaztutako mezua bidali."
 
-#: src/muuli_wdr.cpp:3393
+#: src/muuli_wdr.cpp:3424
 msgid "Close this chat-session."
 msgstr "Itxi elkarrizketa saio hau."
 
-#: src/muuli_wdr.cpp:3416
+#: src/muuli_wdr.cpp:3447
 msgid "Connect to any server and/or Kad"
 msgstr "Konektatu edozein zerbitzari eta/edo Kad"
 
-#: src/muuli_wdr.cpp:3422 src/SharedFilesCtrl.cpp:142 src/Statistics.cpp:941
+#: src/muuli_wdr.cpp:3453 src/SharedFilesCtrl.cpp:142 src/Statistics.cpp:941
 msgid "Shared Files"
 msgstr "Partekatutako fitxategiak"
 
@@ -5446,249 +5474,249 @@ msgstr "Deskargatua"
 msgid "ERROR: Failed to open partfile '%s'"
 msgstr "ERROREA: Huts '%s' zati fitxategia irekitzean"
 
-#: src/Preferences.cpp:674
+#: src/Preferences.cpp:701
 msgid "System default"
 msgstr "Sistema lehenetsia"
 
-#: src/Preferences.cpp:675
+#: src/Preferences.cpp:702
 msgid "Albanian"
 msgstr "Albaniera"
 
-#: src/Preferences.cpp:676
+#: src/Preferences.cpp:703
 msgid "Arabic"
 msgstr "Arabiera"
 
-#: src/Preferences.cpp:677
+#: src/Preferences.cpp:704
 msgid "Asturian"
 msgstr "Bablea"
 
-#: src/Preferences.cpp:678
+#: src/Preferences.cpp:705
 msgid "Basque"
 msgstr "Euskara"
 
-#: src/Preferences.cpp:679
+#: src/Preferences.cpp:706
 msgid "Bulgarian"
 msgstr "Bulgariera"
 
-#: src/Preferences.cpp:680
+#: src/Preferences.cpp:707
 msgid "Catalan"
 msgstr "Katalana"
 
-#: src/Preferences.cpp:681
+#: src/Preferences.cpp:708
 msgid "Chinese (Simplified)"
 msgstr "Txinatarra (Sinplea)"
 
-#: src/Preferences.cpp:682
+#: src/Preferences.cpp:709
 msgid "Chinese (Traditional)"
 msgstr "Txinatarra (ohizkoa)"
 
-#: src/Preferences.cpp:683
+#: src/Preferences.cpp:710
 msgid "Croatian"
 msgstr "Kroaziera"
 
-#: src/Preferences.cpp:684
+#: src/Preferences.cpp:711
 msgid "Czech"
 msgstr "Txekiera"
 
-#: src/Preferences.cpp:685
+#: src/Preferences.cpp:712
 msgid "Danish"
 msgstr "Daniera"
 
-#: src/Preferences.cpp:686
+#: src/Preferences.cpp:713
 msgid "Dutch"
 msgstr "Nederlandera"
 
-#: src/Preferences.cpp:687
+#: src/Preferences.cpp:714
 msgid "English (U.K.)"
 msgstr "Ingelesa (E.B.)"
 
-#: src/Preferences.cpp:688
+#: src/Preferences.cpp:715
 #, fuzzy
 msgid "English (U.S.)"
 msgstr "Ingelesa (E.B.)"
 
-#: src/Preferences.cpp:689
+#: src/Preferences.cpp:716
 msgid "Estonian"
 msgstr "Estoniera"
 
-#: src/Preferences.cpp:690
+#: src/Preferences.cpp:717
 msgid "Finnish"
 msgstr "Finlandiera"
 
-#: src/Preferences.cpp:691
+#: src/Preferences.cpp:718
 msgid "French"
 msgstr "Frantsesa"
 
-#: src/Preferences.cpp:692
+#: src/Preferences.cpp:719
 msgid "Galician"
 msgstr "Galiziera"
 
-#: src/Preferences.cpp:693
+#: src/Preferences.cpp:720
 msgid "German"
 msgstr "Alemana"
 
-#: src/Preferences.cpp:694
+#: src/Preferences.cpp:721
 msgid "Greek"
 msgstr "Grekoa"
 
-#: src/Preferences.cpp:695
+#: src/Preferences.cpp:722
 msgid "Hebrew"
 msgstr "Hebreera"
 
-#: src/Preferences.cpp:696
+#: src/Preferences.cpp:723
 msgid "Hungarian"
 msgstr "Hungariera"
 
-#: src/Preferences.cpp:697
+#: src/Preferences.cpp:724
 msgid "Italian"
 msgstr "Italiera"
 
-#: src/Preferences.cpp:698
+#: src/Preferences.cpp:725
 msgid "Japanese"
 msgstr "Japoniera"
 
-#: src/Preferences.cpp:699
+#: src/Preferences.cpp:726
 msgid "Korean"
 msgstr "Koreera"
 
-#: src/Preferences.cpp:700
+#: src/Preferences.cpp:727
 msgid "Latvian"
 msgstr ""
 
-#: src/Preferences.cpp:701
+#: src/Preferences.cpp:728
 msgid "Lithuanian"
 msgstr "Lituaniera"
 
-#: src/Preferences.cpp:702
+#: src/Preferences.cpp:729
 msgid "Norwegian (Nynorsk)"
 msgstr "Norvegiera (Nynorsk)"
 
-#: src/Preferences.cpp:703
+#: src/Preferences.cpp:730
 msgid "Polish"
 msgstr "Poloniera"
 
-#: src/Preferences.cpp:704
+#: src/Preferences.cpp:731
 msgid "Portuguese"
 msgstr "Portugesa"
 
-#: src/Preferences.cpp:705
+#: src/Preferences.cpp:732
 msgid "Portuguese (Brazilian)"
 msgstr "Portugesa (Brasildarra)"
 
-#: src/Preferences.cpp:706
+#: src/Preferences.cpp:733
 msgid "Romanian"
 msgstr "Errumaniera"
 
-#: src/Preferences.cpp:707
+#: src/Preferences.cpp:734
 msgid "Russian"
 msgstr "Errusiera"
 
-#: src/Preferences.cpp:708
+#: src/Preferences.cpp:735
 msgid "Slovenian"
 msgstr "Esloveniera"
 
-#: src/Preferences.cpp:709
+#: src/Preferences.cpp:736
 msgid "Spanish"
 msgstr "Gaztelera"
 
-#: src/Preferences.cpp:710
+#: src/Preferences.cpp:737
 msgid "Swedish"
 msgstr "Suediera"
 
-#: src/Preferences.cpp:711
+#: src/Preferences.cpp:738
 msgid "Turkish"
 msgstr "Turkiera"
 
-#: src/Preferences.cpp:712
+#: src/Preferences.cpp:739
 msgid "Ukrainian"
 msgstr "Ukraniera"
 
-#: src/Preferences.cpp:815
+#: src/Preferences.cpp:842
 msgid "Change Language"
 msgstr "Aldatu hizkuntza"
 
-#: src/Preferences.cpp:879
+#: src/Preferences.cpp:906
 msgid "There are no translations installed for aMule"
 msgstr "Ez dago aMulerentzat itzulpen instalaturik"
 
-#: src/Preferences.cpp:880
+#: src/Preferences.cpp:907
 msgid "No languages available"
 msgstr "Ez dago hizkuntza erabilgarririk"
 
-#: src/Preferences.cpp:1011
+#: src/Preferences.cpp:1038
 msgid "no options available"
 msgstr "ez dago aukera erabilgarririk"
 
-#: src/Preferences.cpp:2182
+#: src/Preferences.cpp:2227
 msgid "Invalid category found, skipping"
 msgstr "Kategoria baliogabe aurkitua, baztertzen"
 
-#: src/Preferences.cpp:2351
+#: src/Preferences.cpp:2396
 msgid "TCP port can't be higher than 65532 due to server UDP socket being TCP+3"
 msgstr "TCP ataka ezin da 65532 baino altuagoa izan UDP socket-a TCP+3 bait da"
 
-#: src/Preferences.cpp:2352
+#: src/Preferences.cpp:2397
 #, c-format
 msgid "Default port will be used (%d)"
 msgstr "Lehenetsiriko ataka erabiliko da (%d)"
 
-#: src/PrefsUnifiedDlg.cpp:298 src/Statistics.cpp:866
+#: src/PrefsUnifiedDlg.cpp:300 src/Statistics.cpp:866
 msgid "Connection"
 msgstr "Konexioa"
 
-#: src/PrefsUnifiedDlg.cpp:299 src/SearchListCtrl.cpp:117
+#: src/PrefsUnifiedDlg.cpp:301 src/SearchListCtrl.cpp:117
 msgid "Directories"
 msgstr "Direktorioak"
 
-#: src/PrefsUnifiedDlg.cpp:300 src/Statistics.cpp:917
+#: src/PrefsUnifiedDlg.cpp:302 src/Statistics.cpp:917
 msgid "Servers"
 msgstr "Zerbitzariak"
 
-#: src/PrefsUnifiedDlg.cpp:301 src/ServerListCtrl.cpp:96
+#: src/PrefsUnifiedDlg.cpp:303 src/ServerListCtrl.cpp:96
 msgid "Files"
 msgstr "Fitxategiak"
 
-#: src/PrefsUnifiedDlg.cpp:302
+#: src/PrefsUnifiedDlg.cpp:304
 msgid "Security"
 msgstr "Segurtasuna"
 
-#: src/PrefsUnifiedDlg.cpp:303
+#: src/PrefsUnifiedDlg.cpp:305
 msgid "Interface"
 msgstr "Interfazea"
 
-#: src/PrefsUnifiedDlg.cpp:310
+#: src/PrefsUnifiedDlg.cpp:312
 msgid "IP2Country"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:313
+#: src/PrefsUnifiedDlg.cpp:315
 msgid "Proxy"
 msgstr "Proxy-a"
 
-#: src/PrefsUnifiedDlg.cpp:314
+#: src/PrefsUnifiedDlg.cpp:316
 msgid "Filters"
 msgstr "Iragazkiak"
 
-#: src/PrefsUnifiedDlg.cpp:315
+#: src/PrefsUnifiedDlg.cpp:317
 msgid "Remote Controls"
 msgstr "Urruneko kontrolak"
 
-#: src/PrefsUnifiedDlg.cpp:316
+#: src/PrefsUnifiedDlg.cpp:318
 msgid "Online Signature"
 msgstr "Sinadura linean"
 
-#: src/PrefsUnifiedDlg.cpp:317
+#: src/PrefsUnifiedDlg.cpp:319
 msgid "Advanced"
 msgstr "Aurreratua"
 
-#: src/PrefsUnifiedDlg.cpp:318
+#: src/PrefsUnifiedDlg.cpp:320
 msgid "Events"
 msgstr "Gertaerak"
 
-#: src/PrefsUnifiedDlg.cpp:321
+#: src/PrefsUnifiedDlg.cpp:323
 msgid "Debugging"
 msgstr "Araztena"
 
-#: src/PrefsUnifiedDlg.cpp:451
+#: src/PrefsUnifiedDlg.cpp:453
 msgid ""
 "The following variables will be substituted:\n"
 "    %PARTFILE - full path to the file\n"
@@ -5698,15 +5726,15 @@ msgstr ""
 "    %PARTFILE - fitxategiaren bide osoa\n"
 "    %PARTNAME - fitxategi-izena soilik"
 
-#: src/PrefsUnifiedDlg.cpp:472
+#: src/PrefsUnifiedDlg.cpp:474
 msgid "Tray icon support requires libayatana-appindicator3 at compile time."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:488
+#: src/PrefsUnifiedDlg.cpp:490
 msgid "Not available on Wayland: the protocol does not report when a window is minimized, so this option cannot intercept the system minimize button. Workaround: launch aMule with `GDK_BACKEND=x11` to use XWayland instead."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:534
+#: src/PrefsUnifiedDlg.cpp:536
 msgid ""
 "Do not change these setting unless you know\n"
 "what you are doing, otherwise you can easily\n"
@@ -5722,26 +5750,35 @@ msgstr ""
 "Amulek ondo funtzionatu beharko luke ezarpen\n"
 "hauek aldatu gabe."
 
-#: src/PrefsUnifiedDlg.cpp:645
+#: src/PrefsUnifiedDlg.cpp:647
 #, c-format
 msgid "Failed to connect Cfg to widget with the ID %d and key %s"
 msgstr "Huts %d IDa eta %s gakoaz konfiguraziotik programara konektatzean"
 
-#: src/PrefsUnifiedDlg.cpp:693
+#: src/PrefsUnifiedDlg.cpp:695
 #, c-format
 msgid "Failed to transfer data from Cfg to Widget with the ID %d and key %s"
 msgstr "Huts %d IDa eta %s gakoaz konfiguraziotik programara datuak bidaltzean"
 
-#: src/PrefsUnifiedDlg.cpp:799
+#: src/PrefsUnifiedDlg.cpp:801
 msgid "The type of proxy you are connecting to"
 msgstr "Konektatzen ari zaren Proxy-aren mota"
 
-#: src/PrefsUnifiedDlg.cpp:1003
+#: src/PrefsUnifiedDlg.cpp:1020
 #, c-format
 msgid "Failed to transfer data from Widget to Cfg with the ID %d and key %s"
 msgstr "Huts %d IDa eta %s gakoaz programatik konfiguraziora datuak bidaltzean"
 
 #: src/PrefsUnifiedDlg.cpp:1103
+#, fuzzy
+msgid "No password set."
+msgstr "Pasahitz egiaztatzen\n"
+
+#: src/PrefsUnifiedDlg.cpp:1132
+msgid "Guest access needs a password. Type one in the guest password field, or untick Enable guest access."
+msgstr ""
+
+#: src/PrefsUnifiedDlg.cpp:1144
 msgid ""
 "aMule must be restarted to enable these changes:\n"
 "\n"
@@ -5749,42 +5786,42 @@ msgstr ""
 "aMule berrabiarazi egin behar da aldaketa hauek gaitu ahal izateko:\n"
 "\n"
 
-#: src/PrefsUnifiedDlg.cpp:1110
+#: src/PrefsUnifiedDlg.cpp:1151
 msgid "- TCP port changed.\n"
 msgstr "- TCP ataka aldaturik.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1115
+#: src/PrefsUnifiedDlg.cpp:1156
 msgid "- UDP port changed.\n"
 msgstr "- UDP - ataka aldaturik.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1120
+#: src/PrefsUnifiedDlg.cpp:1161
 #, fuzzy
 msgid "- Network interface binding changed.\n"
 msgstr "- Kanpo konexio interfazea aldatua.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1125
+#: src/PrefsUnifiedDlg.cpp:1166
 msgid "- External connect port changed.\n"
 msgstr "- Kanpo konexio ataka aldatua.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1129
+#: src/PrefsUnifiedDlg.cpp:1170
 msgid "- External connect acceptance changed.\n"
 msgstr "- Lanpo konexio onarpena aldatua.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1133
+#: src/PrefsUnifiedDlg.cpp:1174
 msgid "- External connect interface changed.\n"
 msgstr "- Kanpo konexio interfazea aldatua.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1137
+#: src/PrefsUnifiedDlg.cpp:1178
 #, fuzzy
 msgid "- Protocol obfuscation support changed.\n"
 msgstr "Protokolo nahastea"
 
-#: src/PrefsUnifiedDlg.cpp:1151
+#: src/PrefsUnifiedDlg.cpp:1193
 #, fuzzy
 msgid "- amuleapi settings changed.\n"
 msgstr "- Hizkuntza aldaturik.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1160
+#: src/PrefsUnifiedDlg.cpp:1202
 msgid ""
 "Your Auto-update server list is empty.\n"
 "'Auto-update server list at startup' will be disabled."
@@ -5792,7 +5829,7 @@ msgstr ""
 "Auto-eguneraketa zerbitzari zerrenda hutsa dago.\n"
 "'Auto-eguneratu zerbitzari zerrenda abioan' ezgaitu egingo da."
 
-#: src/PrefsUnifiedDlg.cpp:1171
+#: src/PrefsUnifiedDlg.cpp:1213
 msgid ""
 "You have enabled external connections but have not specified a password.\n"
 "External connections cannot be enabled unless a valid password is specified."
@@ -5800,28 +5837,33 @@ msgstr ""
 "Kanpo konexioak gaiturik dituzu baina ez duzu pasahitzik ezarri.\n"
 "Kanpo konexiorik ezin da onartu baliozko pasahitza ezarri arte."
 
-#: src/PrefsUnifiedDlg.cpp:1202
+#: src/PrefsUnifiedDlg.cpp:1246
+#, c-format
+msgid "The amuleapi password could not be saved: %s"
+msgstr ""
+
+#: src/PrefsUnifiedDlg.cpp:1276
 msgid "- Language changed.\n"
 msgstr "- Hizkuntza aldaturik.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1207
+#: src/PrefsUnifiedDlg.cpp:1281
 msgid "- Temp folder changed.\n"
 msgstr "- Aldiroko karpeta aldaturik.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1212
+#: src/PrefsUnifiedDlg.cpp:1286
 msgid "- ED2K network enabled.\n"
 msgstr "- ED2K sarea gaiturik.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1245
+#: src/PrefsUnifiedDlg.cpp:1319
 msgid "The shared-file exclusion pattern is not a valid regular expression. The filter has been left disabled."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1247 src/PrefsUnifiedDlg.cpp:1841
+#: src/PrefsUnifiedDlg.cpp:1321 src/PrefsUnifiedDlg.cpp:1921
 #, fuzzy
 msgid "Invalid regular expression"
 msgstr "Protokolo bertsio baliogabea."
 
-#: src/PrefsUnifiedDlg.cpp:1324
+#: src/PrefsUnifiedDlg.cpp:1398
 msgid ""
 "Both eD2k and Kad network are disabled.\n"
 "You won't be able to connect until you enable at least one of them."
@@ -5829,7 +5871,7 @@ msgstr ""
 "Bai eD2k eta bai Kad sareak ezgaiturik daude.\n"
 "Ezingo zara konektatu behintzat bietako bat gaitu arte."
 
-#: src/PrefsUnifiedDlg.cpp:1329
+#: src/PrefsUnifiedDlg.cpp:1403
 msgid ""
 "Kad will not start if your UDP port is disabled.\n"
 "Enable UDP port or disable Kad."
@@ -5837,7 +5879,7 @@ msgstr ""
 "Kad ezin da abiarazi zure UDP ataka ezgaiturik badago.\n"
 "UDP ataka gaitu edo Kad ezgaitu."
 
-#: src/PrefsUnifiedDlg.cpp:1385
+#: src/PrefsUnifiedDlg.cpp:1459
 msgid ""
 "\n"
 "You MUST restart aMule now.\n"
@@ -5847,69 +5889,69 @@ msgstr ""
 "aMule orain berrabiarazi BEHAR duzu.\n"
 "Orain ez berrabiaraziaz gero ez kexatu ezer txarra gertatzen bada.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1450
+#: src/PrefsUnifiedDlg.cpp:1524
 msgid "Could not register aMule for autostart at login. The autostart store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1452
+#: src/PrefsUnifiedDlg.cpp:1526
 msgid "Could not remove the autostart-at-login entry."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1453
+#: src/PrefsUnifiedDlg.cpp:1527
 #, fuzzy
 msgid "Autostart"
 msgstr "Auto berritzea abiarazirik"
 
-#: src/PrefsUnifiedDlg.cpp:1468
+#: src/PrefsUnifiedDlg.cpp:1542
 msgid "Register file type"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1468
+#: src/PrefsUnifiedDlg.cpp:1542
 msgid "Register URL handler"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1476
+#: src/PrefsUnifiedDlg.cpp:1550
 #, c-format
 msgid "aMule only handles eD2k-compatible magnets. If you replace the current magnet handler (%s), BitTorrent magnet links will stop working - aMule cannot download BitTorrent content. Continue?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1481
+#: src/PrefsUnifiedDlg.cpp:1555
 #, c-format
 msgid "Another application currently opens .emulecollection files (%s). Replace it with aMule?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1486
+#: src/PrefsUnifiedDlg.cpp:1560
 #, c-format
 msgid "Another application is currently the default handler for these links (%s). Replace it with aMule?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1511
+#: src/PrefsUnifiedDlg.cpp:1585
 msgid "Could not register aMule for .emulecollection files. The registration store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1513
+#: src/PrefsUnifiedDlg.cpp:1587
 #, fuzzy
 msgid "Could not remove the file type registration."
 msgstr "Aldiroko deskarga fitxategientzat karpeta"
 
-#: src/PrefsUnifiedDlg.cpp:1515
+#: src/PrefsUnifiedDlg.cpp:1589
 msgid "Could not register aMule as the URL handler. The registration store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1517
+#: src/PrefsUnifiedDlg.cpp:1591
 msgid "Could not remove the URL handler registration."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1587 src/PrefsUnifiedDlg.cpp:1614
+#: src/PrefsUnifiedDlg.cpp:1661 src/PrefsUnifiedDlg.cpp:1688
 #, fuzzy
 msgid "The web server and aMule API require external connections to be enabled."
 msgstr "Pasahitza ezarria eta kanpo konexioak gaiturik."
 
-#: src/PrefsUnifiedDlg.cpp:1597
+#: src/PrefsUnifiedDlg.cpp:1671
 msgid "The aMule web server is deprecated. Consider running the aMule API instead."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1655
+#: src/PrefsUnifiedDlg.cpp:1735
 msgid ""
 "Your Auto-update servers list is in blank.\n"
 "Please fill in at least one URL to point to a valid server.met file.\n"
@@ -5919,66 +5961,66 @@ msgstr ""
 "Mesedez bete behintzat baliozko server.met fitxategi batetara zuzenduaz.\n"
 "Klikatu \"zerrenda\" botoia URL-a sartzeko."
 
-#: src/PrefsUnifiedDlg.cpp:1796
+#: src/PrefsUnifiedDlg.cpp:1876
 msgid "Temporary files"
 msgstr "Aldi baterako fitxategiak"
 
-#: src/PrefsUnifiedDlg.cpp:1801
+#: src/PrefsUnifiedDlg.cpp:1881
 msgid "Incoming files"
 msgstr "Sarrera fitxategiak"
 
-#: src/PrefsUnifiedDlg.cpp:1806
+#: src/PrefsUnifiedDlg.cpp:1886
 msgid "Online Signatures"
 msgstr "Linean sinadurak"
 
-#: src/PrefsUnifiedDlg.cpp:1819
+#: src/PrefsUnifiedDlg.cpp:1899
 #, c-format
 msgid "Choose a folder for %s"
 msgstr "Aukeratu karpeta bat %s-rentzat"
 
-#: src/PrefsUnifiedDlg.cpp:1843
+#: src/PrefsUnifiedDlg.cpp:1923
 #, fuzzy, c-format
 msgid "Would exclude %u of %u shared file"
 msgid_plural "Would exclude %u of %u shared files"
 msgstr[0] "Ezagututako partekatutako fitxategi %i aurkiturik"
 msgstr[1] "%i ezagututako partekatutako fitxategi aurkiturik"
 
-#: src/PrefsUnifiedDlg.cpp:1860
+#: src/PrefsUnifiedDlg.cpp:1940
 msgid "Browse for videoplayer"
 msgstr "Arakatu bideo erreproduzigailua"
 
-#: src/PrefsUnifiedDlg.cpp:1864
+#: src/PrefsUnifiedDlg.cpp:1944
 msgid "Select browser"
 msgstr "Hautatu nabigatzailea"
 
-#: src/PrefsUnifiedDlg.cpp:1868
+#: src/PrefsUnifiedDlg.cpp:1948
 #, fuzzy
 msgid "Select ffprobe binary"
 msgstr "Hautatu nabigatzailea"
 
-#: src/PrefsUnifiedDlg.cpp:1874
+#: src/PrefsUnifiedDlg.cpp:1954
 #, c-format
 msgid "Executable%s"
 msgstr "Abiarazgarria%s"
 
-#: src/PrefsUnifiedDlg.cpp:1908
+#: src/PrefsUnifiedDlg.cpp:1988
 msgid "ffprobe not found on PATH or in the standard install locations. Install ffmpeg (which ships ffprobe) or use Browse to pick a binary manually."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1920
+#: src/PrefsUnifiedDlg.cpp:2000
 msgid "Reset the settings on this page to their default values?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1921
+#: src/PrefsUnifiedDlg.cpp:2001
 #, fuzzy
 msgid "Reset to defaults"
 msgstr "Sistema lehenetsia"
 
-#: src/PrefsUnifiedDlg.cpp:1948
+#: src/PrefsUnifiedDlg.cpp:2028
 msgid "Edit server list"
 msgstr "Editatu zerbitzari zerrenda"
 
-#: src/PrefsUnifiedDlg.cpp:1949
+#: src/PrefsUnifiedDlg.cpp:2029
 msgid ""
 "Add here URL's to download server.met files.\n"
 "Only one url on each line."
@@ -5986,154 +6028,154 @@ msgstr ""
 "Gehitu hemen server.met deskargatzeko URL-a.\n"
 "URL helbide bat lerro bakoitzean."
 
-#: src/PrefsUnifiedDlg.cpp:2004
+#: src/PrefsUnifiedDlg.cpp:2084
 msgid "IP2Country update failed"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2149 src/PrefsUnifiedDlg.cpp:2180
+#: src/PrefsUnifiedDlg.cpp:2229 src/PrefsUnifiedDlg.cpp:2260
 msgid "Data by MaxMind GeoLite2"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2151 src/PrefsUnifiedDlg.cpp:2182
+#: src/PrefsUnifiedDlg.cpp:2231 src/PrefsUnifiedDlg.cpp:2262
 #, fuzzy
 msgid "Custom source"
 msgstr "Jatorri osoak"
 
-#: src/PrefsUnifiedDlg.cpp:2153 src/PrefsUnifiedDlg.cpp:2184
+#: src/PrefsUnifiedDlg.cpp:2233 src/PrefsUnifiedDlg.cpp:2264
 msgid "Data by DB-IP.com"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2204
+#: src/PrefsUnifiedDlg.cpp:2284
 #, fuzzy, c-format
 msgid "Status: Loaded%s"
 msgstr "Egoera:"
 
-#: src/PrefsUnifiedDlg.cpp:2206
+#: src/PrefsUnifiedDlg.cpp:2286
 #, fuzzy, c-format
 msgid "Status: Loaded%s - %s"
 msgstr "Egoera:"
 
-#: src/PrefsUnifiedDlg.cpp:2210
+#: src/PrefsUnifiedDlg.cpp:2290
 msgid "Status: Failed to load - click 'Update now' to refresh."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2212
+#: src/PrefsUnifiedDlg.cpp:2292
 msgid "Status: Not found - click 'Update now' to download."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2270 src/PrefsUnifiedDlg.cpp:2294
+#: src/PrefsUnifiedDlg.cpp:2350 src/PrefsUnifiedDlg.cpp:2374
 #, c-format
 msgid "Update delay: %d second"
 msgid_plural "Update delay: %d seconds"
 msgstr[0] "Eguneratze maiztasuna: seg %d"
 msgstr[1] "Eguneratze maiztasuna: %d seg"
 
-#: src/PrefsUnifiedDlg.cpp:2278
+#: src/PrefsUnifiedDlg.cpp:2358
 #, c-format
 msgid "Time for average graph: %d minute"
 msgid_plural "Time for average graph: %d minutes"
 msgstr[0] "Batez besteko grafiko denbora: minutu %d"
 msgstr[1] "Batez besteko grafiko denbora: %d minutu"
 
-#: src/PrefsUnifiedDlg.cpp:2287
+#: src/PrefsUnifiedDlg.cpp:2367
 #, c-format
 msgid "Connections Graph Scale: %d"
 msgstr "Konexio grafiko eskala: %d"
 
-#: src/PrefsUnifiedDlg.cpp:2302
+#: src/PrefsUnifiedDlg.cpp:2382
 #, c-format
 msgid "File Buffer Size: %d byte"
 msgid_plural "File Buffer Size: %d bytes"
 msgstr[0] "Fitxategi buffer tamaina: byte %d"
 msgstr[1] "Fitxategi buffer tamaina: %d byte"
 
-#: src/PrefsUnifiedDlg.cpp:2312
+#: src/PrefsUnifiedDlg.cpp:2392
 #, c-format
 msgid "Upload Queue Size: %d client"
 msgid_plural "Upload Queue Size: %d clients"
 msgstr[0] "Igoera ilara tamaina: bezero %d"
 msgstr[1] "Igoera ilara tamaina: %d bezero"
 
-#: src/PrefsUnifiedDlg.cpp:2322
+#: src/PrefsUnifiedDlg.cpp:2402
 #, c-format
 msgid "Server connection refresh interval: %d minute"
 msgid_plural "Server connection refresh interval: %d minutes"
 msgstr[0] "Zerbitzari konexio berritze maiztasuna: minutu %d"
 msgstr[1] "Zerbitzari konexio berritze maiztasuna: %d minutu"
 
-#: src/PrefsUnifiedDlg.cpp:2327
+#: src/PrefsUnifiedDlg.cpp:2407
 msgid "Server connection refresh interval: Disabled"
 msgstr "Zerbitzarira konexio berritze maiztasuna: Ezgaiturik"
 
-#: src/PrefsUnifiedDlg.cpp:2371
+#: src/PrefsUnifiedDlg.cpp:2451
 msgid "disabled"
 msgstr "ezgaiturik"
 
-#: src/PrefsUnifiedDlg.cpp:2397
+#: src/PrefsUnifiedDlg.cpp:2477
 #, c-format
 msgid "Execute command on '%s' event"
 msgstr "Gertaeran'%s' komandoa exekutatu"
 
-#: src/PrefsUnifiedDlg.cpp:2404
+#: src/PrefsUnifiedDlg.cpp:2484
 msgid "Enable command execution on core"
 msgstr "Gaitu komando exekuzioa muinean"
 
-#: src/PrefsUnifiedDlg.cpp:2416
+#: src/PrefsUnifiedDlg.cpp:2496
 msgid "Core command:"
 msgstr "Muin komandoa:"
 
-#: src/PrefsUnifiedDlg.cpp:2432
+#: src/PrefsUnifiedDlg.cpp:2512
 msgid "Enable command execution on GUI"
 msgstr "Gaitu komando exekuzioa urruneko interfazean"
 
-#: src/PrefsUnifiedDlg.cpp:2444
+#: src/PrefsUnifiedDlg.cpp:2524
 msgid "GUI command:"
 msgstr "Urruneko interfaze komandoa:"
 
-#: src/PrefsUnifiedDlg.cpp:2460
+#: src/PrefsUnifiedDlg.cpp:2540
 msgid "The following variables will be replaced:"
 msgstr "Hurrengo aldagaiak aldatuko dira:"
 
-#: src/PrefsUnifiedDlg.cpp:2628
+#: src/PrefsUnifiedDlg.cpp:2708
 msgid ""
 "The following folders look like system or sensitive locations:\n"
 "\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2633
+#: src/PrefsUnifiedDlg.cpp:2713
 msgid "Sharing them recursively will publish every file underneath on the eD2k/Kad networks. Do you really want to do this?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2636
+#: src/PrefsUnifiedDlg.cpp:2716
 #, fuzzy
 msgid "Confirm shared folders"
 msgstr "Partekatutako karpetak"
 
-#: src/PrefsUnifiedDlg.cpp:2664
+#: src/PrefsUnifiedDlg.cpp:2744
 #, fuzzy
 msgid "Reloading shared files..."
 msgstr "Berritu zure partekatutako fitxategiak"
 
-#: src/PrefsUnifiedDlg.cpp:2665
+#: src/PrefsUnifiedDlg.cpp:2745
 msgid "Scanning for subdirectories..."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2666
+#: src/PrefsUnifiedDlg.cpp:2746
 #, fuzzy
 msgid "Updating shared folders"
 msgstr "Partekatutako karpetak"
 
-#: src/PrefsUnifiedDlg.cpp:2693
+#: src/PrefsUnifiedDlg.cpp:2773
 #, c-format
 msgid "Scanned %u directories..."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2743
+#: src/PrefsUnifiedDlg.cpp:2823
 #, fuzzy, c-format
 msgid "Reloading shared files: %u files scanned"
 msgstr "Partekatutako fitxategi zerrenda birkargatu."
 
-#: src/PrefsUnifiedDlg.cpp:2793
+#: src/PrefsUnifiedDlg.cpp:2873
 #, fuzzy
 msgid "Shared folder"
 msgstr "Partekatutako karpetak"

--- a/po/fi.po
+++ b/po/fi.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-28 12:17+0200\n"
+"POT-Creation-Date: 2026-07-28 13:09+0200\n"
 "PO-Revision-Date: 2026-07-27 11:37+0000\n"
 "Last-Translator: Tapio Rantala <tapio.rantala@iki.fi>\n"
 "Language-Team: aMule Team <https://github.com/amule-org/amule>\n"
@@ -293,7 +293,7 @@ msgid "Password set and external connections enabled."
 msgstr "Salasana asetettu ja etäyhteydet sallittu."
 
 #: src/amule.cpp:755 src/KadDlg.cpp:176 src/KadDlg.cpp:185
-#: src/PrefsUnifiedDlg.cpp:1461 src/SharedFilesCtrl.cpp:476
+#: src/PrefsUnifiedDlg.cpp:1470 src/SharedFilesCtrl.cpp:476
 msgid "WARNING"
 msgstr "VAROITUS"
 
@@ -331,7 +331,7 @@ msgstr "Olet asettanut web-palvelimen ajettavaksi käynnistettäessä, mutta amu
 #: src/amule-remote-gui.cpp:603 src/amule-remote-gui.cpp:671
 #: src/amule-remote-gui.cpp:709 src/amule-remote-gui.cpp:1282
 #: src/amule-remote-gui.cpp:1345 src/amule-remote-gui.cpp:1372
-#: src/DownloadQueue.cpp:1481 src/PrefsUnifiedDlg.cpp:1247
+#: src/DownloadQueue.cpp:1481 src/PrefsUnifiedDlg.cpp:1256
 msgid "ERROR"
 msgstr "VIRHE"
 
@@ -593,36 +593,36 @@ msgstr "Vieraile nettisivulla https://github.com/amule-org/amule/releases/latest
 msgid "FATAL ERROR: Failed to create Timer"
 msgstr "KRIITTINEN VIRHE: Ajastimen luominen epäonnistui"
 
-#: src/amuleDlg.cpp:361 src/amuleDlg.cpp:1787 src/amuleDlg.cpp:2033
-#: src/muuli_wdr.cpp:1492 src/muuli_wdr.cpp:3449
+#: src/amuleDlg.cpp:361 src/amuleDlg.cpp:1810 src/amuleDlg.cpp:2056
+#: src/muuli_wdr.cpp:1492 src/muuli_wdr.cpp:3453
 msgid "Networks"
 msgstr "Verkot"
 
-#: src/amuleDlg.cpp:362 src/amuleDlg.cpp:1793 src/muuli_wdr.cpp:3450
+#: src/amuleDlg.cpp:362 src/amuleDlg.cpp:1816 src/muuli_wdr.cpp:3454
 msgid "Searches"
 msgstr "Haut"
 
-#: src/amuleDlg.cpp:363 src/amuleDlg.cpp:1799 src/DownloadListCtrl.cpp:740
-#: src/muuli_wdr.cpp:392 src/muuli_wdr.cpp:1585 src/muuli_wdr.cpp:3451
+#: src/amuleDlg.cpp:363 src/amuleDlg.cpp:1822 src/DownloadListCtrl.cpp:740
+#: src/muuli_wdr.cpp:392 src/muuli_wdr.cpp:1585 src/muuli_wdr.cpp:3455
 #: src/Statistics.cpp:829
 msgid "Downloads"
 msgstr "Lataukset"
 
-#: src/amuleDlg.cpp:364 src/amuleDlg.cpp:1805 src/muuli_wdr.cpp:3325
+#: src/amuleDlg.cpp:364 src/amuleDlg.cpp:1828 src/muuli_wdr.cpp:3329
 msgid "Shared files"
 msgstr "Jaetut tiedostot"
 
-#: src/amuleDlg.cpp:365 src/amuleDlg.cpp:1811 src/muuli_wdr.cpp:2957
-#: src/muuli_wdr.cpp:3407 src/muuli_wdr.cpp:3454
+#: src/amuleDlg.cpp:365 src/amuleDlg.cpp:1834 src/muuli_wdr.cpp:2961
+#: src/muuli_wdr.cpp:3411 src/muuli_wdr.cpp:3458
 msgid "Messages"
 msgstr "Viestit"
 
-#: src/amuleDlg.cpp:366 src/amuleDlg.cpp:1817 src/muuli_wdr.cpp:3455
+#: src/amuleDlg.cpp:366 src/amuleDlg.cpp:1840 src/muuli_wdr.cpp:3459
 #: src/PrefsUnifiedDlg.cpp:314 src/Statistics.cpp:779 src/Statistics.cpp:1235
 msgid "Statistics"
 msgstr "Tilastot"
 
-#: src/amuleDlg.cpp:368 src/amuleDlg.cpp:1824 src/muuli_wdr.cpp:3457
+#: src/amuleDlg.cpp:368 src/amuleDlg.cpp:1847 src/muuli_wdr.cpp:3461
 #: src/PrefsUnifiedDlg.cpp:330 src/utils/wxCas/src/wxcasprefs.cpp:39
 msgid "Preferences"
 msgstr "Asetukset"
@@ -681,8 +681,8 @@ msgstr "Kad: Pois päältä"
 #: src/amuleDlg.cpp:1029 src/DownloadListCtrl.cpp:505
 #: src/DownloadListCtrl.cpp:749 src/FriendListCtrl.cpp:180
 #: src/muuli_wdr.cpp:731 src/muuli_wdr.cpp:782 src/muuli_wdr.cpp:846
-#: src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2262 src/muuli_wdr.cpp:2347
-#: src/muuli_wdr.cpp:3095 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
+#: src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2266 src/muuli_wdr.cpp:2351
+#: src/muuli_wdr.cpp:3099 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
 #: src/ServerListCtrl.cpp:606 src/TransferWnd.cpp:378
 #: src/utils/wxCas/src/wxcasprefs.cpp:235
 msgid "Cancel"
@@ -693,7 +693,7 @@ msgid "Stop the current connection attempts"
 msgstr "Pysäytä nykyiset yhteysyritykset"
 
 #: src/amuleDlg.cpp:1035 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976
-#: src/muuli_wdr.cpp:2485
+#: src/muuli_wdr.cpp:2489
 msgid "Disconnect"
 msgstr "Katkaise yhteys"
 
@@ -702,7 +702,7 @@ msgid "Disconnect from the currently connected networks"
 msgstr "Katkaise yhteys yhdistettyihin verkkoihin"
 
 #: src/amuleDlg.cpp:1041 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979
-#: src/muuli_wdr.cpp:2640 src/muuli_wdr.cpp:3092 src/muuli_wdr.cpp:3447
+#: src/muuli_wdr.cpp:2644 src/muuli_wdr.cpp:3096 src/muuli_wdr.cpp:3451
 msgid "Connect"
 msgstr "Yhdistä"
 
@@ -757,7 +757,7 @@ msgstr "Lopettamisen varmistus"
 msgid "Launch Command: "
 msgstr "Suorita komento: "
 
-#: src/amuleDlg.cpp:1632 src/muuli_wdr.cpp:1982 src/Preferences.cpp:979
+#: src/amuleDlg.cpp:1632 src/muuli_wdr.cpp:1986 src/Preferences.cpp:979
 msgid "- default -"
 msgstr "- oletus -"
 
@@ -771,60 +771,60 @@ msgstr "Teemakansiota '%s' ei ole olemassa"
 msgid "WARNING: Unable to open skin file '%s' for read"
 msgstr "VAROITUS: Ei voida avata teematiedostoa '%s' luettavaksi"
 
-#: src/amuleDlg.cpp:1791 src/muuli_wdr.cpp:3449
+#: src/amuleDlg.cpp:1814 src/muuli_wdr.cpp:3453
 msgid "Networks Window"
 msgstr "Verkkoikkuna"
 
-#: src/amuleDlg.cpp:1797 src/muuli_wdr.cpp:3450
+#: src/amuleDlg.cpp:1820 src/muuli_wdr.cpp:3454
 msgid "Searches Window"
 msgstr "Hakujen ikkuna"
 
-#: src/amuleDlg.cpp:1803 src/muuli_wdr.cpp:3451
+#: src/amuleDlg.cpp:1826 src/muuli_wdr.cpp:3455
 msgid "Downloads Window"
 msgstr "Latausten ikkuna"
 
-#: src/amuleDlg.cpp:1809 src/muuli_wdr.cpp:3453
+#: src/amuleDlg.cpp:1832 src/muuli_wdr.cpp:3457
 msgid "Shared Files Window"
 msgstr "Jaettujen tiedostojen ikkuna"
 
-#: src/amuleDlg.cpp:1815 src/muuli_wdr.cpp:3454
+#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3458
 msgid "Messages Window"
 msgstr "Viestien ikkuna"
 
-#: src/amuleDlg.cpp:1821 src/muuli_wdr.cpp:3455
+#: src/amuleDlg.cpp:1844 src/muuli_wdr.cpp:3459
 msgid "Statistics Graph Window"
 msgstr "Tilastokuvaajien ikkuna"
 
-#: src/amuleDlg.cpp:1828 src/muuli_wdr.cpp:3457
+#: src/amuleDlg.cpp:1851 src/muuli_wdr.cpp:3461
 msgid "Preferences Settings Window"
 msgstr "Asetuksien säätöikkuna"
 
-#: src/amuleDlg.cpp:1831 src/muuli_wdr.cpp:3458
+#: src/amuleDlg.cpp:1854 src/muuli_wdr.cpp:3462
 msgid "Import"
 msgstr "Tuonti"
 
-#: src/amuleDlg.cpp:1835 src/muuli_wdr.cpp:3458
+#: src/amuleDlg.cpp:1858 src/muuli_wdr.cpp:3462
 msgid "The partfile importer tool"
 msgstr "Osatiedostojen tuontityökalu"
 
-#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3459
+#: src/amuleDlg.cpp:1861 src/muuli_wdr.cpp:3463
 #: src/utils/aLinkCreator/src/alcframe.cpp:262
 msgid "About"
 msgstr "Tietoja"
 
-#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3459
+#: src/amuleDlg.cpp:1861 src/muuli_wdr.cpp:3463
 msgid "About/Help"
 msgstr "Tietoja/Ohje"
 
-#: src/amuleDlg.cpp:2036
+#: src/amuleDlg.cpp:2059
 msgid "eD2k network"
 msgstr "eD2k-verkko"
 
-#: src/amuleDlg.cpp:2039
+#: src/amuleDlg.cpp:2062
 msgid "Kad network"
 msgstr "Kad-verkko"
 
-#: src/amuleDlg.cpp:2039
+#: src/amuleDlg.cpp:2062
 msgid "No network"
 msgstr "Ei verkkoa"
 
@@ -1357,19 +1357,19 @@ msgstr "Auto [Ko]"
 msgid "Very low"
 msgstr "Erittäin matala"
 
-#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:743 src/muuli_wdr.cpp:2313
+#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:743 src/muuli_wdr.cpp:2317
 #: src/ServerListCtrl.cpp:263 src/ServerListCtrl.cpp:456
 #: src/SharedFilesCtrl.cpp:145
 msgid "Low"
 msgstr "Matala"
 
-#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:744 src/muuli_wdr.cpp:2314
+#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:744 src/muuli_wdr.cpp:2318
 #: src/ServerListCtrl.cpp:266 src/ServerListCtrl.cpp:457
 #: src/SharedFilesCtrl.cpp:146
 msgid "Normal"
 msgstr "Normaali"
 
-#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:745 src/muuli_wdr.cpp:2315
+#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:745 src/muuli_wdr.cpp:2319
 #: src/ServerListCtrl.cpp:269 src/ServerListCtrl.cpp:458
 #: src/SharedFilesCtrl.cpp:147
 msgid "High"
@@ -1461,7 +1461,7 @@ msgstr "Paikallinen Palvelin"
 msgid "Remote Server"
 msgstr "Etäpalvelin"
 
-#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3212
+#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3216
 #: src/SearchDlg.cpp:119 src/TextClient.cpp:911
 msgid "Kad"
 msgstr "Kad"
@@ -1533,7 +1533,7 @@ msgstr "Osa"
 msgid "Size"
 msgstr "Koko"
 
-#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3279
+#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3283
 msgid "Transferred"
 msgstr "Siirretty"
 
@@ -1591,7 +1591,7 @@ msgstr ""
 "Palaute tullut: %s (%s)\n"
 "\n"
 
-#: src/DownloadListCtrl.cpp:746 src/muuli_wdr.cpp:2316
+#: src/DownloadListCtrl.cpp:746 src/muuli_wdr.cpp:2320
 #: src/SharedFilesCtrl.cpp:150
 msgid "Auto"
 msgstr "Automaattinen"
@@ -1629,7 +1629,7 @@ msgid "Extended Options"
 msgstr "Laajat asetukset"
 
 #: src/DownloadListCtrl.cpp:770 src/DownloadListCtrl.cpp:822
-#: src/muuli_wdr.cpp:1800
+#: src/muuli_wdr.cpp:1804
 msgid "Preview"
 msgstr "Esikatsele"
 
@@ -2430,23 +2430,23 @@ msgid ""
 "want downloads on a different (e.g. larger) disk."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:549 src/FirstRunWizard.cpp:611 src/muuli_wdr.cpp:1712
+#: src/FirstRunWizard.cpp:549 src/FirstRunWizard.cpp:611 src/muuli_wdr.cpp:1716
 msgid "Destination folder for downloads"
 msgstr "Kansio ladatuille tiedostoille"
 
 #: src/FirstRunWizard.cpp:553 src/FirstRunWizard.cpp:569 src/muuli_wdr.cpp:1349
-#: src/muuli_wdr.cpp:1366 src/muuli_wdr.cpp:1687 src/muuli_wdr.cpp:1718
-#: src/muuli_wdr.cpp:1730 src/muuli_wdr.cpp:2800
+#: src/muuli_wdr.cpp:1366 src/muuli_wdr.cpp:1691 src/muuli_wdr.cpp:1722
+#: src/muuli_wdr.cpp:1734 src/muuli_wdr.cpp:2804
 #: src/utils/aLinkCreator/src/alcframe.cpp:135
 #: src/utils/wxCas/src/wxcasprefs.cpp:52 src/utils/wxCas/src/wxcasprefs.cpp:118
 msgid "Browse"
 msgstr "Selaa"
 
-#: src/FirstRunWizard.cpp:559 src/muuli_wdr.cpp:1723
+#: src/FirstRunWizard.cpp:559 src/muuli_wdr.cpp:1727
 msgid "(All files in this folder are shared with other peers)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:565 src/FirstRunWizard.cpp:624 src/muuli_wdr.cpp:1725
+#: src/FirstRunWizard.cpp:565 src/FirstRunWizard.cpp:624 src/muuli_wdr.cpp:1729
 msgid "Folder for temporary download files"
 msgstr "Kansio latauksen väliaikaisille tiedostoille"
 
@@ -2477,7 +2477,7 @@ msgstr "Kaverilistatiedostoa 'emfriends.met' ei saatu avattua kirjoitettavaksi!"
 msgid "CRITICAL - no client on StartChatSession"
 msgstr "KRIITTINEN - ei asiakasta keskustelun aloituksessa"
 
-#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2706 src/muuli_wdr.cpp:3383
+#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2710 src/muuli_wdr.cpp:3387
 msgid "Friends"
 msgstr "Kaverit"
 
@@ -2588,8 +2588,8 @@ msgstr "Ei yhtään"
 msgid "No"
 msgstr "Ei"
 
-#: src/GenericClientListCtrl.cpp:1216 src/PrefsUnifiedDlg.cpp:2898
-#: src/PrefsUnifiedDlg.cpp:2948 src/ServerListCtrl.cpp:276
+#: src/GenericClientListCtrl.cpp:1216 src/PrefsUnifiedDlg.cpp:2907
+#: src/PrefsUnifiedDlg.cpp:2957 src/ServerListCtrl.cpp:276
 msgid "Yes"
 msgstr "Kyllä"
 
@@ -2758,10 +2758,10 @@ msgstr "Portti ei kelpaa yhdistämisavuksi"
 msgid "Please fill all fields required"
 msgstr "Ole hyvä ja täytä kaikki vaaditut kentät"
 
-#: src/KadDlg.cpp:192 src/PartFile.cpp:1031 src/PrefsUnifiedDlg.cpp:1134
-#: src/PrefsUnifiedDlg.cpp:1204 src/PrefsUnifiedDlg.cpp:1405
-#: src/PrefsUnifiedDlg.cpp:1663 src/PrefsUnifiedDlg.cpp:1673
-#: src/PrefsUnifiedDlg.cpp:1690 src/PrefsUnifiedDlg.cpp:1738
+#: src/KadDlg.cpp:192 src/PartFile.cpp:1031 src/PrefsUnifiedDlg.cpp:1143
+#: src/PrefsUnifiedDlg.cpp:1213 src/PrefsUnifiedDlg.cpp:1414
+#: src/PrefsUnifiedDlg.cpp:1672 src/PrefsUnifiedDlg.cpp:1682
+#: src/PrefsUnifiedDlg.cpp:1699 src/PrefsUnifiedDlg.cpp:1747
 msgid "Message"
 msgstr "Viesti"
 
@@ -2863,7 +2863,7 @@ msgstr "Jakosuhde"
 msgid "Uploaded"
 msgstr "Lähetetty"
 
-#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3263
+#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3267
 msgid "Requested"
 msgstr "Pyydetty"
 
@@ -2987,7 +2987,7 @@ msgid "WARNING: "
 msgstr "VAROITUS: "
 
 #: src/MuleNotebook.cpp:179 src/muuli_wdr.cpp:817 src/muuli_wdr.cpp:1229
-#: src/muuli_wdr.cpp:3167 src/muuli_wdr.cpp:3423
+#: src/muuli_wdr.cpp:3171 src/muuli_wdr.cpp:3427
 msgid "Close"
 msgstr "Sulje"
 
@@ -3005,7 +3005,7 @@ msgid "Paste"
 msgstr "Liitä"
 
 #: src/MuleTextCtrl.cpp:89 src/muuli_wdr.cpp:358 src/muuli_wdr.cpp:757
-#: src/muuli_wdr.cpp:2390 src/muuli_wdr.cpp:2409 src/muuli_wdr.cpp:2431
+#: src/muuli_wdr.cpp:2394 src/muuli_wdr.cpp:2413 src/muuli_wdr.cpp:2435
 #: src/utils/aLinkCreator/src/alcframe.cpp:142
 msgid "Clear"
 msgstr "Pyyhi"
@@ -3104,7 +3104,7 @@ msgstr "Sulje"
 
 #: src/MuleTrayIcon.cpp:579 src/MuleTrayIcon.cpp:945 src/MuleTrayIcon.cpp:965
 #: src/muuli_wdr.cpp:1398 src/muuli_wdr.cpp:1406 src/muuli_wdr.cpp:1413
-#: src/muuli_wdr.cpp:1846 src/muuli_wdr.cpp:1852 src/OtherFunctions.cpp:91
+#: src/muuli_wdr.cpp:1850 src/muuli_wdr.cpp:1856 src/OtherFunctions.cpp:91
 #: src/StatisticsDlg.cpp:93 src/StatisticsDlg.cpp:95
 msgid "kB/s"
 msgstr "KB/s"
@@ -3346,7 +3346,7 @@ msgstr "Tavua"
 msgid "KB"
 msgstr "KB"
 
-#: src/muuli_wdr.cpp:274 src/muuli_wdr.cpp:293 src/muuli_wdr.cpp:1631
+#: src/muuli_wdr.cpp:274 src/muuli_wdr.cpp:293 src/muuli_wdr.cpp:1635
 #: src/OtherFunctions.cpp:64
 msgid "MB"
 msgstr "MB"
@@ -3363,7 +3363,7 @@ msgstr "Enimmäiskoko"
 msgid "Availability"
 msgstr "Saatavuus"
 
-#: src/muuli_wdr.cpp:312 src/muuli_wdr.cpp:398 src/muuli_wdr.cpp:3328
+#: src/muuli_wdr.cpp:312 src/muuli_wdr.cpp:398 src/muuli_wdr.cpp:3332
 msgid "Filter:"
 msgstr "Suodatin:"
 
@@ -3426,8 +3426,8 @@ msgstr "Tiedostolähteet:"
 #: src/muuli_wdr.cpp:1160 src/muuli_wdr.cpp:1167 src/muuli_wdr.cpp:1172
 #: src/muuli_wdr.cpp:1179 src/muuli_wdr.cpp:1184 src/muuli_wdr.cpp:1191
 #: src/muuli_wdr.cpp:1205 src/muuli_wdr.cpp:1212 src/muuli_wdr.cpp:1217
-#: src/muuli_wdr.cpp:1224 src/muuli_wdr.cpp:3265 src/muuli_wdr.cpp:3273
-#: src/muuli_wdr.cpp:3281
+#: src/muuli_wdr.cpp:1224 src/muuli_wdr.cpp:3269 src/muuli_wdr.cpp:3277
+#: src/muuli_wdr.cpp:3285
 msgid "N/A"
 msgstr "Ei saatavilla"
 
@@ -3572,7 +3572,7 @@ msgstr ""
 msgid "Album :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:685 src/muuli_wdr.cpp:2285
+#: src/muuli_wdr.cpp:685 src/muuli_wdr.cpp:2289
 msgid "Title :"
 msgstr "Otsikko :"
 
@@ -3681,7 +3681,7 @@ msgstr "Käyttäjänimi :"
 msgid "Userhash :"
 msgstr "Käyttäjätarkiste :"
 
-#: src/muuli_wdr.cpp:895 src/muuli_wdr.cpp:1752 src/muuli_wdr.cpp:2480
+#: src/muuli_wdr.cpp:895 src/muuli_wdr.cpp:1756 src/muuli_wdr.cpp:2484
 #: src/utils/aLinkCreator/src/alcframe.cpp:137
 msgid "Add"
 msgstr "Lisää"
@@ -3690,15 +3690,15 @@ msgstr "Lisää"
 msgid "Download-Speed"
 msgstr "Latausnopeus"
 
-#: src/muuli_wdr.cpp:954 src/muuli_wdr.cpp:989 src/muuli_wdr.cpp:2584
+#: src/muuli_wdr.cpp:954 src/muuli_wdr.cpp:989 src/muuli_wdr.cpp:2588
 msgid "Current"
 msgstr "Nykyinen"
 
-#: src/muuli_wdr.cpp:962 src/muuli_wdr.cpp:997 src/muuli_wdr.cpp:2592
+#: src/muuli_wdr.cpp:962 src/muuli_wdr.cpp:997 src/muuli_wdr.cpp:2596
 msgid "Running average"
 msgstr "Yhtäjaksoinen keskiarvo"
 
-#: src/muuli_wdr.cpp:970 src/muuli_wdr.cpp:1005 src/muuli_wdr.cpp:2600
+#: src/muuli_wdr.cpp:970 src/muuli_wdr.cpp:1005 src/muuli_wdr.cpp:2604
 msgid "Session average"
 msgstr "Session keskiarvo"
 
@@ -3710,7 +3710,7 @@ msgstr "Lähetysnopeus"
 msgid "Connections"
 msgstr "Yhteydet"
 
-#: src/muuli_wdr.cpp:1024 src/muuli_wdr.cpp:1871
+#: src/muuli_wdr.cpp:1024 src/muuli_wdr.cpp:1875
 msgid "Active downloads"
 msgstr "Aktiiviset lataukset"
 
@@ -3718,7 +3718,7 @@ msgstr "Aktiiviset lataukset"
 msgid "Active connections (1:1)"
 msgstr "Aktiiviset yhteydet (1:1)"
 
-#: src/muuli_wdr.cpp:1040 src/muuli_wdr.cpp:1872
+#: src/muuli_wdr.cpp:1040 src/muuli_wdr.cpp:1876
 msgid "Active uploads"
 msgstr "Aktiiviset lähetykset"
 
@@ -3994,7 +3994,7 @@ msgstr "Sido paikallinen osoite IP:hen (tyhjä sallii mihin tahansa):"
 msgid "Advanced users only: If you have multiple network interfaces, enter the address of the interface to which aMule should be bound."
 msgstr "Vain edistyneille käyttäjille: mikäli sinulla on useampia verkkoliitäntöjä, syötä sen liitännän osoite johon haluat aMulen sidottavan."
 
-#: src/muuli_wdr.cpp:1462 src/muuli_wdr.cpp:2065
+#: src/muuli_wdr.cpp:1462 src/muuli_wdr.cpp:2069
 #, fuzzy
 msgid "Bind to network interface (empty for any):"
 msgstr "Sido paikallinen osoite IP:hen (tyhjä sallii mihin tahansa):"
@@ -4011,7 +4011,7 @@ msgstr "Lähteitä enintään tiedostoa kohden:"
 msgid "Max simultaneous connections:"
 msgstr "Yhtäaikaisten yhteyksien enimmäismäärä:"
 
-#: src/muuli_wdr.cpp:1498 src/muuli_wdr.cpp:3207
+#: src/muuli_wdr.cpp:1498 src/muuli_wdr.cpp:3211
 msgid "ED2K"
 msgstr "ED2K"
 
@@ -4103,778 +4103,778 @@ msgstr "Esivaraa levytila uusille tiedostoille"
 msgid "For new files preallocates disk space for the whole file, thus reduces fragmentation"
 msgstr "Uusia tiedostoja lisätessä varaa levytilaa koko tiedostolle, vähentää pirstaloitumista"
 
-#: src/muuli_wdr.cpp:1617
+#: src/muuli_wdr.cpp:1621
 msgid "Create new files as sparse files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1618
+#: src/muuli_wdr.cpp:1622
 msgid "Sparse part files only occupy disk space for the parts already downloaded, so free space is used up gradually as the file fills in. Turn this off to use an ordinary file instead - useful where sparse files are unsupported or slow, or where backup/de-duplication tools handle them badly. Applies only when the core runs on Windows; on Linux and macOS part files are sparse anyway and this setting has no effect."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1623
+#: src/muuli_wdr.cpp:1627
 msgid "Stop downloads when free disk space reaches "
 msgstr "Pysäytä lataukset kun tyhjän levytilan määrä saavuttaa "
 
-#: src/muuli_wdr.cpp:1624
+#: src/muuli_wdr.cpp:1628
 msgid "Select this if you want aMule to check your disk space"
 msgstr "Valitse tämä mikäli haluat aMulen tarkistavan vapaan levytilan määrän"
 
-#: src/muuli_wdr.cpp:1628
+#: src/muuli_wdr.cpp:1632
 msgid "Enter here the min disk space desired."
 msgstr "Syötä tähän levytila jonka haluat jättää vapaaksi."
 
-#: src/muuli_wdr.cpp:1634
+#: src/muuli_wdr.cpp:1638
 msgid "Save 10 sources on rare files (< 20 sources)"
 msgstr "Tallenna 10 lähdettä harvinaisille tiedostoille (< 20 lähdettä)"
 
-#: src/muuli_wdr.cpp:1638 src/Statistics.cpp:790
+#: src/muuli_wdr.cpp:1642 src/Statistics.cpp:790
 msgid "Uploads"
 msgstr "Lähetykset"
 
-#: src/muuli_wdr.cpp:1641
+#: src/muuli_wdr.cpp:1645
 msgid "Add new shared files with auto priority"
 msgstr "Lisää uudet jaetut tiedostot tärkeys automaattisella"
 
-#: src/muuli_wdr.cpp:1647
+#: src/muuli_wdr.cpp:1651
 msgid "Intelligent Corruption Handling (I.C.H.)"
 msgstr "Älykäs turmeltumien käsittely (I.C.H.)"
 
-#: src/muuli_wdr.cpp:1650
+#: src/muuli_wdr.cpp:1654
 msgid "Enable"
 msgstr "Käytä"
 
-#: src/muuli_wdr.cpp:1653
+#: src/muuli_wdr.cpp:1657
 msgid "Advanced I.C.H. trusts every hash (not recommended)"
 msgstr "Kehittynyt I.C.H. luottaa kaikkiin tarkisteisiin (ei suositella)"
 
-#: src/muuli_wdr.cpp:1665 src/PrefsUnifiedDlg.cpp:1990
+#: src/muuli_wdr.cpp:1669 src/PrefsUnifiedDlg.cpp:1999
 msgid "Media metadata extraction"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1669
+#: src/muuli_wdr.cpp:1673
 msgid "Extract length / bitrate / codec from shared audio and video files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1671
+#: src/muuli_wdr.cpp:1675
 msgid "When enabled, aMule runs ffprobe on each shared media file to fill in the Length / Bitrate / Codec columns other clients see when they find the file in a search. Requires ffmpeg (the ffprobe binary) to be installed."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1678
+#: src/muuli_wdr.cpp:1682
 msgid "Path to ffprobe:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1683
+#: src/muuli_wdr.cpp:1687
 msgid "Full path to the ffprobe binary. Leave empty to have aMule auto-detect it on startup."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1691
+#: src/muuli_wdr.cpp:1695
 msgid "Detect"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1692
+#: src/muuli_wdr.cpp:1696
 msgid "Search the standard install locations for an ffprobe binary and fill the path field."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1716
+#: src/muuli_wdr.cpp:1720
 msgid ""
 "Completed downloads are stored here. All files in this folder are automatically shared with other peers.\n"
 "If this folder also holds files you don't want to share, point it at an aMule-only sub-folder."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1719
+#: src/muuli_wdr.cpp:1723
 msgid "Pick the folder where completed downloads will be stored. All files in that folder will be shared with other peers."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1733
+#: src/muuli_wdr.cpp:1737
 msgid "Shared folders"
 msgstr "Jaetut kansiot"
 
-#: src/muuli_wdr.cpp:1739
+#: src/muuli_wdr.cpp:1743
 msgid "(Folders shared by the core. Enter a path to add one.)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1747
+#: src/muuli_wdr.cpp:1751
 msgid "Absolute path of a folder on the core's machine, e.g. /home/user/shared"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1749 src/PrefsUnifiedDlg.cpp:2874
+#: src/muuli_wdr.cpp:1753 src/PrefsUnifiedDlg.cpp:2883
 msgid "Recursive"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1750
+#: src/muuli_wdr.cpp:1754
 msgid "Share every sub-folder underneath this one, including ones created later."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1754 src/utils/aLinkCreator/src/alcframe.cpp:141
+#: src/muuli_wdr.cpp:1758 src/utils/aLinkCreator/src/alcframe.cpp:141
 msgid "Remove"
 msgstr "Poista"
 
-#: src/muuli_wdr.cpp:1758
+#: src/muuli_wdr.cpp:1762
 msgid "(Right click on folder icon for recursive share)"
 msgstr "(Klikkaa oikealla painikkeella kansion kuvaketta jakaaksesi rekursiivisesti)"
 
-#: src/muuli_wdr.cpp:1765
+#: src/muuli_wdr.cpp:1769
 msgid "Share hidden files"
 msgstr "Jaa piilotiedostot"
 
-#: src/muuli_wdr.cpp:1771
+#: src/muuli_wdr.cpp:1775
 msgid "Automatically rescan shared folders for changes"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1777
+#: src/muuli_wdr.cpp:1781
 msgid "Follow symbolic links in shared folders"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1783
+#: src/muuli_wdr.cpp:1787
 msgid "Exclude files matching:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1786
+#: src/muuli_wdr.cpp:1790
 msgid "Wildcard patterns separated by '|', e.g. .DS_Store|Thumbs.db|*.tmp. Files whose name matches are not shared. Matching is case-insensitive."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1790
+#: src/muuli_wdr.cpp:1794
 msgid "Patterns are regular expressions"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1791
+#: src/muuli_wdr.cpp:1795
 msgid "When set, the whole field is one regular expression ('|' is alternation). When unset, it is a list of '|'-separated wildcards."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1801
+#: src/muuli_wdr.cpp:1805
 msgid "Show how many shared files the current pattern would exclude."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1822
+#: src/muuli_wdr.cpp:1826
 msgid "Graphs"
 msgstr "Kuvaajat"
 
-#: src/muuli_wdr.cpp:1825 src/muuli_wdr.cpp:1887
+#: src/muuli_wdr.cpp:1829 src/muuli_wdr.cpp:1891
 msgid "Update delay : 5 secs"
 msgstr "Päivitysväli : 5 sekuntia"
 
-#: src/muuli_wdr.cpp:1829
+#: src/muuli_wdr.cpp:1833
 msgid "Time for average graph: 100 mins"
 msgstr "Keskimääräiskuvaajan aika: 100 minuuttia"
 
-#: src/muuli_wdr.cpp:1833
+#: src/muuli_wdr.cpp:1837
 msgid "Connections Graph Scale: 100 "
 msgstr "Yhteyskuvaajan Skaala: 100 "
 
-#: src/muuli_wdr.cpp:1840
+#: src/muuli_wdr.cpp:1844
 msgid "Download graph scale:"
 msgstr "Latauskuvaajan skaala:"
 
-#: src/muuli_wdr.cpp:1848
+#: src/muuli_wdr.cpp:1852
 msgid "Upload graph scale:"
 msgstr "Lähetyskuvaajan skaala:"
 
-#: src/muuli_wdr.cpp:1858
+#: src/muuli_wdr.cpp:1862
 #, fuzzy
 msgid "Colors: "
 msgstr "Värit: "
 
-#: src/muuli_wdr.cpp:1862
+#: src/muuli_wdr.cpp:1866
 msgid "Background"
 msgstr "Taustaväri"
 
-#: src/muuli_wdr.cpp:1863
+#: src/muuli_wdr.cpp:1867
 msgid "Grid"
 msgstr "Ruudukko"
 
-#: src/muuli_wdr.cpp:1864
+#: src/muuli_wdr.cpp:1868
 msgid "Download current"
 msgstr "Hetkittäinen lataus"
 
-#: src/muuli_wdr.cpp:1865
+#: src/muuli_wdr.cpp:1869
 msgid "Download running average"
 msgstr "Latauksen yhtäjaksoinen keskiarvo"
 
-#: src/muuli_wdr.cpp:1866
+#: src/muuli_wdr.cpp:1870
 msgid "Download session average"
 msgstr "Latauksen keskiarvo sessiossa"
 
-#: src/muuli_wdr.cpp:1867
+#: src/muuli_wdr.cpp:1871
 msgid "Upload current"
 msgstr "Hetkittäinen lähetys"
 
-#: src/muuli_wdr.cpp:1868
+#: src/muuli_wdr.cpp:1872
 msgid "Upload running average"
 msgstr "Lähetyksen yhtäjaksoinen keskiarvo"
 
-#: src/muuli_wdr.cpp:1869
+#: src/muuli_wdr.cpp:1873
 msgid "Upload session average"
 msgstr "Lähetyksen keskiarvo sessiossa"
 
-#: src/muuli_wdr.cpp:1870
+#: src/muuli_wdr.cpp:1874
 msgid "Active connections"
 msgstr "Aktiiviset yhteydet"
 
-#: src/muuli_wdr.cpp:1873
+#: src/muuli_wdr.cpp:1877
 #, fuzzy
 msgid "Systray Icon Speed Bar"
 msgstr "Järjestelmäpalkin nopeusnäyttö"
 
-#: src/muuli_wdr.cpp:1874
+#: src/muuli_wdr.cpp:1878
 msgid "Kad-nodes current"
 msgstr "Kad-yhteyksiä tällä hetkellä"
 
-#: src/muuli_wdr.cpp:1875
+#: src/muuli_wdr.cpp:1879
 msgid "Kad-nodes running"
 msgstr "Kad-yhteyksiä aktiivisena"
 
-#: src/muuli_wdr.cpp:1876
+#: src/muuli_wdr.cpp:1880
 msgid "Kad-nodes session"
 msgstr "Kad-yhteyksiä sessiossa"
 
-#: src/muuli_wdr.cpp:1880 src/muuli_wdr.cpp:2334
+#: src/muuli_wdr.cpp:1884 src/muuli_wdr.cpp:2338
 msgid "Select"
 msgstr "Valitse"
 
-#: src/muuli_wdr.cpp:1884
+#: src/muuli_wdr.cpp:1888
 msgid "Tree"
 msgstr "Puu"
 
-#: src/muuli_wdr.cpp:1894
+#: src/muuli_wdr.cpp:1898
 msgid "Number of Client Versions shown (0=unlimited)"
 msgstr "Näytettävien asiakasversioiden määrä (0=rajoittamattomasti)"
 
-#: src/muuli_wdr.cpp:1919
+#: src/muuli_wdr.cpp:1923
 msgid "!!! WARNING !!!"
 msgstr "!!! VAROITUS !!!"
 
-#: src/muuli_wdr.cpp:1934
+#: src/muuli_wdr.cpp:1938
 msgid "Max new connections / 5 secs"
 msgstr "Enimmäismäärä uusia yhteyksiä / 5 s"
 
-#: src/muuli_wdr.cpp:1936
+#: src/muuli_wdr.cpp:1940
 msgid "Concurrent Kad source lookups"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1938
+#: src/muuli_wdr.cpp:1942
 #, fuzzy
 msgid "Kad source re-search interval (minutes)"
 msgstr "FTP-päivityksien väli minuuteissa"
 
-#: src/muuli_wdr.cpp:1940
+#: src/muuli_wdr.cpp:1944
 #, fuzzy
 msgid "Source re-ask interval (minutes)"
 msgstr "FTP-päivityksien väli minuuteissa"
 
-#: src/muuli_wdr.cpp:1944
+#: src/muuli_wdr.cpp:1948
 msgid "File Buffer Size: 240000 bytes"
 msgstr "Tiedostopuskurin koko: 240000 tavua"
 
-#: src/muuli_wdr.cpp:1948
+#: src/muuli_wdr.cpp:1952
 msgid "Use MMAP: memory-mapped file access (lower memory use)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1949
+#: src/muuli_wdr.cpp:1953
 msgid "Maps part files into memory instead of buffering them on the heap, lowering the process memory footprint. May reduce download speed on some disks; best for memory-constrained or upload-heavy hosts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1951
+#: src/muuli_wdr.cpp:1955
 msgid "Upload Queue Size: 5000 clients"
 msgstr "Lähetysjonon koko: 5000 asiakasta"
 
-#: src/muuli_wdr.cpp:1955
+#: src/muuli_wdr.cpp:1959
 msgid "Server connection refresh interval: Disable"
 msgstr "Palvelinyhteyden päivitysväli: Poissa käytöstä"
 
-#: src/muuli_wdr.cpp:1959
+#: src/muuli_wdr.cpp:1963
 msgid "Disable computer's timed standby mode"
 msgstr "Poista käytöstä tietokoneen ajastettu siirtyminen valmiustilaan"
 
-#: src/muuli_wdr.cpp:1978
+#: src/muuli_wdr.cpp:1982
 msgid "Skin to use: "
 msgstr "Käytettävä teema: "
 
-#: src/muuli_wdr.cpp:1987
+#: src/muuli_wdr.cpp:1991
 msgid "Show \"Fast eD2k Links Handler\" in every window."
 msgstr "Näytä \"Nopea eD2k-linkkien käsittelijä\" jokaisessa ikkunassa."
 
-#: src/muuli_wdr.cpp:1990
+#: src/muuli_wdr.cpp:1994
 msgid "Show extended info on categories tabs"
 msgstr "Näytä laajennetut tiedot luokitteluvälilehdillä"
 
-#: src/muuli_wdr.cpp:1993
+#: src/muuli_wdr.cpp:1997
 msgid "Show application version on title"
 msgstr "Näytä sovelluksen versio otsikossa"
 
-#: src/muuli_wdr.cpp:1995
+#: src/muuli_wdr.cpp:1999
 msgid "Show transfer rates on title"
 msgstr "Näytä siirtonopeudet otsikossa"
 
-#: src/muuli_wdr.cpp:1997
+#: src/muuli_wdr.cpp:2001
 msgid "Before application name"
 msgstr "Ennen sovelluksen nimeä"
 
-#: src/muuli_wdr.cpp:1999
+#: src/muuli_wdr.cpp:2003
 msgid "After application name"
 msgstr "Sovelluksen nimen perässä"
 
-#: src/muuli_wdr.cpp:2002
+#: src/muuli_wdr.cpp:2006
 msgid "Show overhead bandwidth"
 msgstr "Näytä otsikkotietoihin kuluva kaista"
 
-#: src/muuli_wdr.cpp:2006
+#: src/muuli_wdr.cpp:2010
 msgid "Vertical toolbar orientation"
 msgstr "Pystysuuntainen työkalupalkki"
 
-#: src/muuli_wdr.cpp:2008
+#: src/muuli_wdr.cpp:2012
 msgid "Live column sorting (auto-reorder rows as their values change)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2015
+#: src/muuli_wdr.cpp:2019
 msgid "Download Queue Files"
 msgstr "Latausjonon tiedostot"
 
-#: src/muuli_wdr.cpp:2018
+#: src/muuli_wdr.cpp:2022
 msgid "Show progress percentage"
 msgstr "Näytä edistyminen prosentteina"
 
-#: src/muuli_wdr.cpp:2024
+#: src/muuli_wdr.cpp:2028
 msgid "Show progress bar"
 msgstr "Näytä edistymispalkki"
 
-#: src/muuli_wdr.cpp:2027
+#: src/muuli_wdr.cpp:2031
 msgid "Flat"
 msgstr "Tasainen"
 
-#: src/muuli_wdr.cpp:2031
+#: src/muuli_wdr.cpp:2035
 msgid "Round"
 msgstr "Pyöreä"
 
-#: src/muuli_wdr.cpp:2049
+#: src/muuli_wdr.cpp:2053
 msgid "External Connection Parameters"
 msgstr "Etäyhteyksien asetukset"
 
-#: src/muuli_wdr.cpp:2052
+#: src/muuli_wdr.cpp:2056
 msgid "Accept external connections"
 msgstr "Hyväksy etäyhteydet"
 
-#: src/muuli_wdr.cpp:2059 src/muuli_wdr.cpp:2118
+#: src/muuli_wdr.cpp:2063 src/muuli_wdr.cpp:2122
 msgid "IP of the listening interface:"
 msgstr "Kuunneltavan verkkoliitännän IP:"
 
-#: src/muuli_wdr.cpp:2062
+#: src/muuli_wdr.cpp:2066
 msgid "Enter here a valid ip in the a.b.c.d format for the listening EC interface. An empty field or 0.0.0.0 will mean any interface."
 msgstr "Syötä tähän sen verkkoliitännän ip jota kuunnellaan etäyhteyksiä varten. Tyhjä tai 0.0.0.0 tarkoittaa kaikkia verkkoliitäntöjä."
 
-#: src/muuli_wdr.cpp:2083 src/muuli_wdr.cpp:2194
+#: src/muuli_wdr.cpp:2087 src/muuli_wdr.cpp:2198
 msgid "TCP port:"
 msgstr "TCP-portti:"
 
-#: src/muuli_wdr.cpp:2089
+#: src/muuli_wdr.cpp:2093
 msgid "Enable UPnP port forwarding on the EC port"
 msgstr "Kytke päälle UPnP-portinohjaus etäyhteysportissa"
 
-#: src/muuli_wdr.cpp:2093 src/muuli_wdr.cpp:3079
+#: src/muuli_wdr.cpp:2097 src/muuli_wdr.cpp:3083
 #: src/utils/wxCas/src/wxcasprefs.cpp:167
 msgid "Password"
 msgstr "Salasana"
 
-#: src/muuli_wdr.cpp:2099
+#: src/muuli_wdr.cpp:2103
 #, fuzzy
 msgid "aMule API server parameters"
 msgstr "Web-palvelimen asetukset"
 
-#: src/muuli_wdr.cpp:2102
+#: src/muuli_wdr.cpp:2106
 msgid "Run amuleapi (REST API) on startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2107
+#: src/muuli_wdr.cpp:2111
 #, fuzzy
 msgid "HTTP port:"
 msgstr "TCP-portti:"
 
-#: src/muuli_wdr.cpp:2121
+#: src/muuli_wdr.cpp:2125
 msgid "The interface amuleapi's HTTP server listens on. 127.0.0.1 (default) accepts only local connections; use 0.0.0.0 or a specific IP to expose it to other hosts (set an admin password below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2126
+#: src/muuli_wdr.cpp:2130
 msgid "Type a password to set or change it. Stored passwords cannot be shown, so leaving this empty keeps the current one."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2128
+#: src/muuli_wdr.cpp:2132
 #, fuzzy
 msgid "Admin password"
 msgstr "Tarkistaa salasanaa\n"
 
-#: src/muuli_wdr.cpp:2140 src/muuli_wdr.cpp:2157 src/PrefsUnifiedDlg.cpp:1103
+#: src/muuli_wdr.cpp:2144 src/muuli_wdr.cpp:2161 src/PrefsUnifiedDlg.cpp:1112
 #, fuzzy
 msgid "A password is set."
 msgstr "Tarkistaa salasanaa\n"
 
-#: src/muuli_wdr.cpp:2144
+#: src/muuli_wdr.cpp:2148
 #, fuzzy
 msgid "Enable guest access"
 msgstr "Estä vieraskäyttö"
 
-#: src/muuli_wdr.cpp:2145
+#: src/muuli_wdr.cpp:2149
 msgid "Guest sessions may read status and listings but cannot change anything. Turning this off clears the stored guest password."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2149
+#: src/muuli_wdr.cpp:2153
 #, fuzzy
 msgid "Guest password"
 msgstr "Vieraan salasana web-palvelimelle"
 
-#: src/muuli_wdr.cpp:2164
+#: src/muuli_wdr.cpp:2168
 msgid "Web server parameters"
 msgstr "Web-palvelimen asetukset"
 
-#: src/muuli_wdr.cpp:2167
+#: src/muuli_wdr.cpp:2171
 #, fuzzy
 msgid "Run webserver on startup (deprecated)"
 msgstr "Käynnistä web-palvelin käynnistettäessä"
 
-#: src/muuli_wdr.cpp:2173
+#: src/muuli_wdr.cpp:2177
 msgid "Web template"
 msgstr "Web-sapluuna"
 
-#: src/muuli_wdr.cpp:2178
+#: src/muuli_wdr.cpp:2182
 msgid "Full rights password"
 msgstr "Täysien oikeuksien salasana"
 
-#: src/muuli_wdr.cpp:2182
+#: src/muuli_wdr.cpp:2186
 msgid "Enable Low rights User"
 msgstr "Salli rajoitettujen oikeuksien käyttäjä"
 
-#: src/muuli_wdr.cpp:2187
+#: src/muuli_wdr.cpp:2191
 msgid "Low rights password"
 msgstr "Rajoitettujen oikeuksien salasana"
 
-#: src/muuli_wdr.cpp:2201
+#: src/muuli_wdr.cpp:2205
 msgid "Enable UPnP port forwarding of the web server port"
 msgstr "Käytä UPnP-portinohjausta web-palvelimen portissa"
 
-#: src/muuli_wdr.cpp:2206
+#: src/muuli_wdr.cpp:2210
 msgid "Web server UPnP TCP port (Optional)"
 msgstr "Web-palvelimen UPnP TCP-portti (Valinnainen)"
 
-#: src/muuli_wdr.cpp:2214
+#: src/muuli_wdr.cpp:2218
 msgid "Page Refresh Time (in secs)"
 msgstr "Sivun päivitysväli (sekunneissa)"
 
-#: src/muuli_wdr.cpp:2221
+#: src/muuli_wdr.cpp:2225
 msgid "Enable Gzip compression"
 msgstr "Salli gzip-pakkaus"
 
-#: src/muuli_wdr.cpp:2255
+#: src/muuli_wdr.cpp:2259
 #, fuzzy
 msgid "Reset page to defaults"
 msgstr "Järjestelmän vakio"
 
-#: src/muuli_wdr.cpp:2256
+#: src/muuli_wdr.cpp:2260
 msgid "Reset the settings on the current page to their default values."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2258 src/muuli_wdr.cpp:2344 src/ServerWnd.cpp:274
+#: src/muuli_wdr.cpp:2262 src/muuli_wdr.cpp:2348 src/ServerWnd.cpp:274
 #: src/ServerWnd.cpp:282
 msgid "OK"
 msgstr "OK"
 
-#: src/muuli_wdr.cpp:2260
+#: src/muuli_wdr.cpp:2264
 msgid "Click here to apply any changes made to the preferences."
 msgstr "Napsauta tästä saattaaksesi voimaan asetuksiin tehdyt muutokset."
 
-#: src/muuli_wdr.cpp:2263
+#: src/muuli_wdr.cpp:2267
 msgid "Reset any changes made to the preferences."
 msgstr "Nollaa asetuksiin tekemäsi muutokset."
 
-#: src/muuli_wdr.cpp:2292
+#: src/muuli_wdr.cpp:2296
 msgid "Comment :"
 msgstr "Kommentti :"
 
-#: src/muuli_wdr.cpp:2299
+#: src/muuli_wdr.cpp:2303
 msgid "Incoming Dir :"
 msgstr "Saapuvien kansio :"
 
-#: src/muuli_wdr.cpp:2308
+#: src/muuli_wdr.cpp:2312
 msgid "Change priority for new assigned files :"
 msgstr "Vaihda tärkeyttä uusille sijoitetuille tiedostoille :"
 
-#: src/muuli_wdr.cpp:2312
+#: src/muuli_wdr.cpp:2316
 msgid "Don't change"
 msgstr "Älä vaihda"
 
-#: src/muuli_wdr.cpp:2324
+#: src/muuli_wdr.cpp:2328
 msgid "Select color for this Category (currently selected) :"
 msgstr "Valitse väri tälle luokalle (valittuna) :"
 
-#: src/muuli_wdr.cpp:2391 src/muuli_wdr.cpp:2410 src/muuli_wdr.cpp:2432
+#: src/muuli_wdr.cpp:2395 src/muuli_wdr.cpp:2414 src/muuli_wdr.cpp:2436
 msgid "Click this button to reset the log."
 msgstr "Napsauta tätä painiketta nollataksesi lokin."
 
-#: src/muuli_wdr.cpp:2451
+#: src/muuli_wdr.cpp:2455
 msgid "Click on this button to update the servers list from URL ..."
 msgstr "Napsauta tätä nappia päivittääksesi palvelinlistan osoitteesta ..."
 
-#: src/muuli_wdr.cpp:2455
+#: src/muuli_wdr.cpp:2459
 msgid "Server list"
 msgstr "Palvelinlista"
 
-#: src/muuli_wdr.cpp:2459
+#: src/muuli_wdr.cpp:2463
 msgid "Enter the url to a server.met file here and press the button to the left to update the list of known servers."
 msgstr "Syötä tähän server.met-tiedostoon osoittava url ja paina nappia vasemmalla päivittääksesi tunnettujen palvelimien listan."
 
-#: src/muuli_wdr.cpp:2464
+#: src/muuli_wdr.cpp:2468
 msgid "Add server manually: Name"
 msgstr "Palvelimen lisäys käsin: Nimi"
 
-#: src/muuli_wdr.cpp:2467
+#: src/muuli_wdr.cpp:2471
 msgid "Enter the name of the new server here"
 msgstr "Syötä uuden palvelimen nimi tähän"
 
-#: src/muuli_wdr.cpp:2469 src/ServerWnd.cpp:206
+#: src/muuli_wdr.cpp:2473 src/ServerWnd.cpp:206
 msgid "IP:Port"
 msgstr "IP:Portti"
 
-#: src/muuli_wdr.cpp:2472
+#: src/muuli_wdr.cpp:2476
 msgid "Enter the IP of the server here, using the x.x.x.x format."
 msgstr "Syötä uuden palvelimen IP tähän, muodossa x.x.x.x."
 
-#: src/muuli_wdr.cpp:2478
+#: src/muuli_wdr.cpp:2482
 msgid "Enter the port of the server here."
 msgstr "Syötä palvelimen portti tähän."
 
-#: src/muuli_wdr.cpp:2481
+#: src/muuli_wdr.cpp:2485
 msgid "Add manually a server (fill fields to the left before) ..."
 msgstr "Lisää palvelin käsin (täytä vasemmalla olevat kentät) ..."
 
-#: src/muuli_wdr.cpp:2510
+#: src/muuli_wdr.cpp:2514
 msgid "aMule Log"
 msgstr "aMule loki"
 
-#: src/muuli_wdr.cpp:2518
+#: src/muuli_wdr.cpp:2522
 msgid "Server Info"
 msgstr "Palvelimen tiedot"
 
-#: src/muuli_wdr.cpp:2522
+#: src/muuli_wdr.cpp:2526
 msgid "ED2K Info"
 msgstr "ED2K Info"
 
-#: src/muuli_wdr.cpp:2526
+#: src/muuli_wdr.cpp:2530
 msgid "Kad Info"
 msgstr "Kad Info"
 
-#: src/muuli_wdr.cpp:2554
+#: src/muuli_wdr.cpp:2558
 msgid "Click on this button to update the nodes list from URL ..."
 msgstr "Napsauta tätä nappia päivittääksesi yhteyspisteiden listan osoitteesta ..."
 
-#: src/muuli_wdr.cpp:2558
+#: src/muuli_wdr.cpp:2562
 msgid "Nodes (0)"
 msgstr "Yhteyspisteitä (0)"
 
-#: src/muuli_wdr.cpp:2562
+#: src/muuli_wdr.cpp:2566
 msgid "Enter the url to a nodes.dat file here and press the button to the left to update the list of known nodes."
 msgstr "Syötä tähän nodes.dat-tiedostoon osoittava url ja paina nappia vasemmalla päivittääksesi tunnettujen yhteyspisteiden listan."
 
-#: src/muuli_wdr.cpp:2565
+#: src/muuli_wdr.cpp:2569
 msgid "Nodes stats"
 msgstr "Yhteyspisteiden tilastot"
 
-#: src/muuli_wdr.cpp:2607
+#: src/muuli_wdr.cpp:2611
 msgid "Bootstrap"
 msgstr "Yhdistämisapu"
 
-#: src/muuli_wdr.cpp:2610
+#: src/muuli_wdr.cpp:2614
 msgid "New node"
 msgstr "Uusi yhteyspiste"
 
-#: src/muuli_wdr.cpp:2615
+#: src/muuli_wdr.cpp:2619
 msgid "IP:"
 msgstr "IP:"
 
-#: src/muuli_wdr.cpp:2635
+#: src/muuli_wdr.cpp:2639
 msgid "Port:"
 msgstr "Portti:"
 
-#: src/muuli_wdr.cpp:2648
+#: src/muuli_wdr.cpp:2652
 msgid "Bootstrap from known clients"
 msgstr "Käytä tunnettuja asiakkaita yhdistämisapuna"
 
-#: src/muuli_wdr.cpp:2650
+#: src/muuli_wdr.cpp:2654
 msgid "Disconnect Kad"
 msgstr "Katkaise Kad-yhteys"
 
-#: src/muuli_wdr.cpp:2684
+#: src/muuli_wdr.cpp:2688
 msgid "Use Secure User Identification"
 msgstr "Käytä turvattua käyttäjän tunnistusta"
 
-#: src/muuli_wdr.cpp:2686
+#: src/muuli_wdr.cpp:2690
 msgid "It is recommended to enable this option. You will not receive credits if SUI is not enabled."
 msgstr "Tunnistuksen käyttö on suositeltavaa. Muuten et hyödy pistejärjestelmästä."
 
-#: src/muuli_wdr.cpp:2688
+#: src/muuli_wdr.cpp:2692
 msgid "Protocol Obfuscation"
 msgstr "Protokollan kätkeminen"
 
-#: src/muuli_wdr.cpp:2691
+#: src/muuli_wdr.cpp:2695
 msgid "Support Protocol Obfuscation"
 msgstr "Tuki protokollan kätkemiselle"
 
-#: src/muuli_wdr.cpp:2693
+#: src/muuli_wdr.cpp:2697
 msgid "This option enabled Protocol Obfuscation, and makes aMule accept obfuscated connections from other clients."
 msgstr "Tämä valinta sallii aMulen ottaa vastaan kätketyn protokollan yhteyksiä muilta asiakkailta."
 
-#: src/muuli_wdr.cpp:2695
+#: src/muuli_wdr.cpp:2699
 msgid "Use obfuscation for outgoing connections"
 msgstr "Käytä kätkemistä lähtevissä yhteyksissä"
 
-#: src/muuli_wdr.cpp:2697
+#: src/muuli_wdr.cpp:2701
 msgid "This option makes aMule use Protocol Obfuscation when connecting other clients/servers."
 msgstr "Tämä valittuna aMule käyttää protokollan kätkemistä ottaessaan yhteyttä muihin asiakkaisiin/palvelimiin."
 
-#: src/muuli_wdr.cpp:2699
+#: src/muuli_wdr.cpp:2703
 msgid "Accept only obfuscated connections"
 msgstr "Vastaanota vain kätkettyjä yhteyksiä"
 
-#: src/muuli_wdr.cpp:2700
+#: src/muuli_wdr.cpp:2704
 msgid "This option makes aMule only accept obfuscated connections. You will have less sources, but all your traffic will be obfuscated"
 msgstr "Tämä valittuna aMule hyväksyy vain kätketyt yhteydet. Lähteitä on vähemmän saatavilla mutta kaikki liikenteesi on kätketyllä protokollalla."
 
-#: src/muuli_wdr.cpp:2705
+#: src/muuli_wdr.cpp:2709
 msgid "Everybody"
 msgstr "Kaikki"
 
-#: src/muuli_wdr.cpp:2707
+#: src/muuli_wdr.cpp:2711
 msgid "No one"
 msgstr "Ei kukaan"
 
-#: src/muuli_wdr.cpp:2709
+#: src/muuli_wdr.cpp:2713
 msgid "Who can see my shared files:"
 msgstr "Ketkä voivat nähdä jaetut tiedostoni:"
 
-#: src/muuli_wdr.cpp:2710
+#: src/muuli_wdr.cpp:2714
 msgid "Select who can request to view a list of your shared files."
 msgstr "Valitse ketkä voivat pyytää nähtäville sinun jaettujen tiedostojen listaasi."
 
-#: src/muuli_wdr.cpp:2712
+#: src/muuli_wdr.cpp:2716
 msgid "IP-Filtering"
 msgstr "IP-suodatus"
 
-#: src/muuli_wdr.cpp:2719
+#: src/muuli_wdr.cpp:2723
 msgid "Filter clients"
 msgstr "Suodata asiakkaat"
 
-#: src/muuli_wdr.cpp:2721
+#: src/muuli_wdr.cpp:2725
 msgid "Enable filtering of the client IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "Salli asiakas-IP:den suodatus kuten määritelty tiedostossa ~/.aMule/ipfilter.dat."
 
-#: src/muuli_wdr.cpp:2723
+#: src/muuli_wdr.cpp:2727
 msgid "Filter servers"
 msgstr "Suodata palvelimet"
 
-#: src/muuli_wdr.cpp:2725
+#: src/muuli_wdr.cpp:2729
 msgid "Enable filtering of the server IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "Salli palvelin-IP:den suodatus kuten määritelty tiedostossa ~/.aMule/ipfilter.dat."
 
-#: src/muuli_wdr.cpp:2729
+#: src/muuli_wdr.cpp:2733
 msgid "Reload List"
 msgstr "Uudelleenlataa lista"
 
-#: src/muuli_wdr.cpp:2730
+#: src/muuli_wdr.cpp:2734
 msgid "Reload the list of IPs to filter from the file ~/.aMule/ipfilter.dat"
 msgstr "Uudelleenlataa suodatettavien IP:den lista tiedostosta ~/.aMule/ipfilter.dat."
 
-#: src/muuli_wdr.cpp:2736
+#: src/muuli_wdr.cpp:2740
 msgid "URL:"
 msgstr "URL:"
 
-#: src/muuli_wdr.cpp:2740 src/muuli_wdr.cpp:2933
+#: src/muuli_wdr.cpp:2744 src/muuli_wdr.cpp:2937
 msgid "Update now"
 msgstr "Päivitä nyt"
 
-#: src/muuli_wdr.cpp:2743
+#: src/muuli_wdr.cpp:2747
 msgid "Auto-update ipfilter at startup"
 msgstr "Päivitä ip-suodatus automaattisesti käynnistettäessä"
 
-#: src/muuli_wdr.cpp:2747
+#: src/muuli_wdr.cpp:2751
 msgid "Filtering Level:"
 msgstr "Suodatustaso:"
 
-#: src/muuli_wdr.cpp:2753
+#: src/muuli_wdr.cpp:2757
 msgid "Always filter LAN IPs"
 msgstr "Suodata aina lähiverkon IP:t"
 
-#: src/muuli_wdr.cpp:2756
+#: src/muuli_wdr.cpp:2760
 msgid "Paranoid handling of non-matching IPs"
 msgstr "Käsittele muut IP:t vainoharhaisesti"
 
-#: src/muuli_wdr.cpp:2758
+#: src/muuli_wdr.cpp:2762
 msgid "Rejects a packet when its source IP differs from the IP the client claims (an anti-spoofing check). Disable only if it causes connection problems."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2760
+#: src/muuli_wdr.cpp:2764
 msgid "Use system-wide ipfilter.dat if available"
 msgstr "Käytä järjestelmänlaajuista ipfilter.dat-tiedostoa mikäli saatavilla"
 
-#: src/muuli_wdr.cpp:2761
+#: src/muuli_wdr.cpp:2765
 #, fuzzy
 msgid "If there's no local ipfilter.dat found, allow usage of a system-wide ipfilter file."
 msgstr "Mikäli paikallista ipfilter.dat:ia ei löydy, käytetään järjestelmänlaajuista ipfilter.dat-tiedostoa."
 
-#: src/muuli_wdr.cpp:2778
+#: src/muuli_wdr.cpp:2782
 msgid "Enable Online-Signature"
 msgstr "Kytke Online-Signeeraus päälle"
 
-#: src/muuli_wdr.cpp:2780
+#: src/muuli_wdr.cpp:2784
 msgid "Enables the writing of the OS file, which can be used by external apps to create signatures and the like."
 msgstr "Kytkee päälle Online-Signeeraustiedoston kirjoittamisen, jota muut ohjelmat voivat käyttää esimerkiksi signeerauksissa."
 
-#: src/muuli_wdr.cpp:2784
+#: src/muuli_wdr.cpp:2788
 msgid "Update Frequency (Secs):"
 msgstr "Päivitysväli (sekuntia):"
 
-#: src/muuli_wdr.cpp:2787
+#: src/muuli_wdr.cpp:2791
 msgid "Change the frequency (in seconds) of Online Signature updates."
 msgstr "Muuttaa Online-Signeerauksen päivitysväliä, annetaan sekunteina."
 
-#: src/muuli_wdr.cpp:2795
+#: src/muuli_wdr.cpp:2799
 msgid "Save online signature file in: "
 msgstr "Online-signeeraus-tiedoston tallennuspaikka:"
 
-#: src/muuli_wdr.cpp:2801
+#: src/muuli_wdr.cpp:2805
 msgid "Click here to select the directory containing the the Online Signature files."
 msgstr "Napsauta tästä valitaksesi kansio Online-Signeerauksen tiedostoille."
 
-#: src/muuli_wdr.cpp:2834
+#: src/muuli_wdr.cpp:2838
 msgid "Show country flags for clients"
 msgstr "Näytä asiakkaiden valtioiden liput"
 
-#: src/muuli_wdr.cpp:2835
+#: src/muuli_wdr.cpp:2839
 msgid "Render the country flag column in the transfers, queue and search views. Requires a valid MMDB GeoIP database (see below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2840
+#: src/muuli_wdr.cpp:2844
 #, fuzzy
 msgid "Database"
 msgstr "Siirtonopeus :"
 
-#: src/muuli_wdr.cpp:2856
+#: src/muuli_wdr.cpp:2860
 #, fuzzy
 msgid "Source:"
 msgstr "Lähteet"
 
-#: src/muuli_wdr.cpp:2859
+#: src/muuli_wdr.cpp:2863
 msgid "DB-IP (free, no account)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2860
+#: src/muuli_wdr.cpp:2864
 msgid "MaxMind GeoLite2 (free, account required)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2861
+#: src/muuli_wdr.cpp:2865
 msgid "Custom URL"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2864
+#: src/muuli_wdr.cpp:2868
 msgid "Choose which provider supplies the GeoIP MMDB database. DB-IP is the default - no account required. MaxMind requires a free account + license key. Use Custom URL to point at any other MMDB host (e.g. a local mirror)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2881
+#: src/muuli_wdr.cpp:2885
 msgid ""
 "No configuration required.\n"
 "\n"
@@ -4882,11 +4882,11 @@ msgid ""
 "License: Creative Commons BY 4.0 - https://creativecommons.org/licenses/by/4.0/"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2894
+#: src/muuli_wdr.cpp:2898
 msgid "License key:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2900
+#: src/muuli_wdr.cpp:2904
 msgid ""
 "Sign up for a free MaxMind account, then generate a License Key:\n"
 "https://www.maxmind.com/en/geolite2/signup\n"
@@ -4896,226 +4896,226 @@ msgid ""
 "Requires attribution and account registration; refresh at least every 30 days."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2915
+#: src/muuli_wdr.cpp:2919
 #, fuzzy
 msgid "Download URL:"
 msgstr "Lataus: "
 
-#: src/muuli_wdr.cpp:2921
+#: src/muuli_wdr.cpp:2925
 msgid ""
 "Must point to an .mmdb file or a .gz / .tar.gz containing one.\n"
 "URL may include credentials (https://user:pass@host/...).\n"
 "License and attribution terms are set by the upstream URL - you are responsible."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2934
+#: src/muuli_wdr.cpp:2938
 msgid "Download the GeoIP database from the selected source."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2936
+#: src/muuli_wdr.cpp:2940
 #, fuzzy
 msgid "Auto-update on startup"
 msgstr "Päivitä ip-suodatus automaattisesti käynnistettäessä"
 
-#: src/muuli_wdr.cpp:2937
+#: src/muuli_wdr.cpp:2941
 msgid "Re-download the GeoIP database from the selected source every time aMule starts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2960
+#: src/muuli_wdr.cpp:2964
 msgid "Filter incoming messages (except current chat):"
 msgstr "Suodata saapuvat viestit (ei koske keskusteluja):"
 
-#: src/muuli_wdr.cpp:2962
+#: src/muuli_wdr.cpp:2966
 msgid "Filter all messages"
 msgstr "Suodata kaikki viestit"
 
-#: src/muuli_wdr.cpp:2964
+#: src/muuli_wdr.cpp:2968
 msgid "Filter messages from people not on your friend list"
 msgstr "Suodata viestit ihmisiltä jotka eivät ole kaverilistallasi"
 
-#: src/muuli_wdr.cpp:2966
+#: src/muuli_wdr.cpp:2970
 msgid "Filter messages from unknown clients"
 msgstr "Suodata viestit tuntemattomilta asiakkailta"
 
-#: src/muuli_wdr.cpp:2968
+#: src/muuli_wdr.cpp:2972
 msgid "Filter messages containing (use ',' as separator):"
 msgstr "Suodata viestit jotka sisältävät (käytä merkkiä ',' erottimena):"
 
-#: src/muuli_wdr.cpp:2971 src/muuli_wdr.cpp:2982
+#: src/muuli_wdr.cpp:2975 src/muuli_wdr.cpp:2986
 msgid "add here the words amule should filter and block messages including it"
 msgstr "Syötä tähän suodatettavat sanat ja aMule estää viestit jotka sisältävät sellaisen"
 
-#: src/muuli_wdr.cpp:2973
+#: src/muuli_wdr.cpp:2977
 msgid "Show received messages in the log"
 msgstr "Näytä vastaanotetut viestit lokissa"
 
-#: src/muuli_wdr.cpp:2976
+#: src/muuli_wdr.cpp:2980
 msgid "Comments"
 msgstr "Kommentit"
 
-#: src/muuli_wdr.cpp:2979
+#: src/muuli_wdr.cpp:2983
 msgid "Filter comments containing (use ',' as separator):"
 msgstr "Suodata kommentit jotka sisältävät (käytä merkkiä ',' erottimena):"
 
-#: src/muuli_wdr.cpp:3004
+#: src/muuli_wdr.cpp:3008
 msgid "Enable Proxy"
 msgstr "Käytä välityspalvelinta"
 
-#: src/muuli_wdr.cpp:3005
+#: src/muuli_wdr.cpp:3009
 msgid "Enable/disable proxy support"
 msgstr "Kytke päälle/pois välityspalvelimen tuki"
 
-#: src/muuli_wdr.cpp:3008
+#: src/muuli_wdr.cpp:3012
 msgid "Proxy type:"
 msgstr "Tyyppi:"
 
-#: src/muuli_wdr.cpp:3019
+#: src/muuli_wdr.cpp:3023
 msgid "Proxy host:"
 msgstr "Välityspalvelin:"
 
-#: src/muuli_wdr.cpp:3022
+#: src/muuli_wdr.cpp:3026
 msgid "The proxy host name"
 msgstr "Välityspalvelimen verkkonimi"
 
-#: src/muuli_wdr.cpp:3024
+#: src/muuli_wdr.cpp:3028
 msgid "Proxy port:"
 msgstr "Portti:"
 
-#: src/muuli_wdr.cpp:3027
+#: src/muuli_wdr.cpp:3031
 msgid "The proxy port"
 msgstr "Välityspalvelimen portti"
 
-#: src/muuli_wdr.cpp:3029
+#: src/muuli_wdr.cpp:3033
 msgid "Enable authentication"
 msgstr "Käytä tunnistautumista"
 
-#: src/muuli_wdr.cpp:3030
+#: src/muuli_wdr.cpp:3034
 msgid "Enable/disable username/password authentication"
 msgstr "Kytkee päälle/pois käyttäjänimellä/salasanalla tunnistautumisen"
 
-#: src/muuli_wdr.cpp:3033
+#: src/muuli_wdr.cpp:3037
 msgid "Username: "
 msgstr "Käyttäjänimi: "
 
-#: src/muuli_wdr.cpp:3036
+#: src/muuli_wdr.cpp:3040
 msgid "The username to use to connect to the proxy"
 msgstr "Käyttäjänimi tunnistautuessa välityspalvelimelle"
 
-#: src/muuli_wdr.cpp:3038
+#: src/muuli_wdr.cpp:3042
 msgid "Password:"
 msgstr "Salasana:"
 
-#: src/muuli_wdr.cpp:3041
+#: src/muuli_wdr.cpp:3045
 msgid "The password to use to connect to the proxy"
 msgstr "Salasana tunnistautuessa välityspalvelimelle"
 
-#: src/muuli_wdr.cpp:3060
+#: src/muuli_wdr.cpp:3064
 msgid "Connect to:"
 msgstr "Yhdistä:"
 
-#: src/muuli_wdr.cpp:3069
+#: src/muuli_wdr.cpp:3073
 msgid "Login to remote amule"
 msgstr "Kirjaudu etä-aMuleen"
 
-#: src/muuli_wdr.cpp:3074
+#: src/muuli_wdr.cpp:3078
 msgid "User name"
 msgstr "Käyttäjänimi"
 
-#: src/muuli_wdr.cpp:3085
+#: src/muuli_wdr.cpp:3089
 msgid "Remember those settings"
 msgstr "Muista nämä asetukset"
 
-#: src/muuli_wdr.cpp:3088
+#: src/muuli_wdr.cpp:3092
 #, fuzzy
 msgid "Force ZLIB compression"
 msgstr "Käytä gzip-pakkausta"
 
-#: src/muuli_wdr.cpp:3112
+#: src/muuli_wdr.cpp:3116
 msgid "Enable Verbose Debug-Logging."
 msgstr "Käytä monisanaista lokiin kirjausta."
 
-#: src/muuli_wdr.cpp:3114
+#: src/muuli_wdr.cpp:3118
 #, fuzzy
 msgid "Only to Logfile"
 msgstr "Avaa tied&osto"
 
-#: src/muuli_wdr.cpp:3116
+#: src/muuli_wdr.cpp:3120
 msgid "Message Categories:"
 msgstr "Viestien luokittelut:"
 
-#: src/muuli_wdr.cpp:3140 src/PartFileConvertDlg.cpp:160
+#: src/muuli_wdr.cpp:3144 src/PartFileConvertDlg.cpp:160
 msgid "Waiting..."
 msgstr "Odottaa..."
 
-#: src/muuli_wdr.cpp:3160
+#: src/muuli_wdr.cpp:3164
 msgid "Add imports"
 msgstr "Lisää tuonteja"
 
-#: src/muuli_wdr.cpp:3163
+#: src/muuli_wdr.cpp:3167
 msgid "Retry selected"
 msgstr "Yritä uudelleen valittuja"
 
-#: src/muuli_wdr.cpp:3165
+#: src/muuli_wdr.cpp:3169
 msgid "Remove selected"
 msgstr "Poista valitut"
 
-#: src/muuli_wdr.cpp:3228
+#: src/muuli_wdr.cpp:3232
 msgid "Event Types"
 msgstr "Tapahtumatyypit"
 
-#: src/muuli_wdr.cpp:3247
+#: src/muuli_wdr.cpp:3251
 msgid "Statistics and queued clients for selected file(s) : Session / All time"
 msgstr "Tilastot ja jonottavat asiakkaat valitu(i)lle tiedosto(i)lle: Sessiossa / Yhteensä"
 
-#: src/muuli_wdr.cpp:3271
+#: src/muuli_wdr.cpp:3275
 msgid "Active Uploads"
 msgstr "Aktiiviset lähetykset"
 
-#: src/muuli_wdr.cpp:3285
+#: src/muuli_wdr.cpp:3289
 msgid "Percent of total files"
 msgstr "Prosenttia kaikista tiedostoista"
 
-#: src/muuli_wdr.cpp:3337
+#: src/muuli_wdr.cpp:3341
 msgid "Show Clients for"
 msgstr "Näytä asiakkaat"
 
-#: src/muuli_wdr.cpp:3339
+#: src/muuli_wdr.cpp:3343
 msgid "All files"
 msgstr "Kaikki tiedostot"
 
-#: src/muuli_wdr.cpp:3342
+#: src/muuli_wdr.cpp:3346
 msgid "Selected files"
 msgstr "Valitut tiedostot"
 
-#: src/muuli_wdr.cpp:3345
+#: src/muuli_wdr.cpp:3349
 msgid "Active uploads only"
 msgstr "Vain aktiiviset lähetykset"
 
-#: src/muuli_wdr.cpp:3352
+#: src/muuli_wdr.cpp:3356
 msgid "Reload:"
 msgstr "Uudelleenlataa:"
 
-#: src/muuli_wdr.cpp:3356
+#: src/muuli_wdr.cpp:3360
 msgid "Reload your shared files"
 msgstr "Uudelleenlataa jaetut tiedostot"
 
-#: src/muuli_wdr.cpp:3419
+#: src/muuli_wdr.cpp:3423
 msgid "Send"
 msgstr "Lähetä"
 
-#: src/muuli_wdr.cpp:3420
+#: src/muuli_wdr.cpp:3424
 msgid "Sends the specified message."
 msgstr "Lähettää annetun viestin."
 
-#: src/muuli_wdr.cpp:3424
+#: src/muuli_wdr.cpp:3428
 msgid "Close this chat-session."
 msgstr "Sulje tämä keskustelu."
 
-#: src/muuli_wdr.cpp:3447
+#: src/muuli_wdr.cpp:3451
 msgid "Connect to any server and/or Kad"
 msgstr "Yhdistä mihin tahansa palvelimeen ja/tai Kadiin"
 
-#: src/muuli_wdr.cpp:3453 src/SharedFilesCtrl.cpp:142 src/Statistics.cpp:941
+#: src/muuli_wdr.cpp:3457 src/SharedFilesCtrl.cpp:142 src/Statistics.cpp:941
 msgid "Shared Files"
 msgstr "Jaetut tiedostot"
 
@@ -5750,35 +5750,35 @@ msgstr ""
 "aMule toimii hyvin vaikka näitä ei\n"
 "säädettäisikään."
 
-#: src/PrefsUnifiedDlg.cpp:647
+#: src/PrefsUnifiedDlg.cpp:656
 #, c-format
 msgid "Failed to connect Cfg to widget with the ID %d and key %s"
 msgstr "Asetuksen kytkeminen widgettiin epäonnistui ID:llä %d ja avaimella %s"
 
-#: src/PrefsUnifiedDlg.cpp:695
+#: src/PrefsUnifiedDlg.cpp:704
 #, c-format
 msgid "Failed to transfer data from Cfg to Widget with the ID %d and key %s"
 msgstr "Datan siirtäminen asetuksesta widgettiin epäonnistui ID:llä %d ja avaimella %s"
 
-#: src/PrefsUnifiedDlg.cpp:801
+#: src/PrefsUnifiedDlg.cpp:810
 msgid "The type of proxy you are connecting to"
 msgstr "Yhdistettävän välityspalvelimen tyyppi"
 
-#: src/PrefsUnifiedDlg.cpp:1020
+#: src/PrefsUnifiedDlg.cpp:1029
 #, c-format
 msgid "Failed to transfer data from Widget to Cfg with the ID %d and key %s"
 msgstr "Datan siirtäminen widgetistä asetukseen epäonnistui ID:llä %d ja avaimella %s"
 
-#: src/PrefsUnifiedDlg.cpp:1103
+#: src/PrefsUnifiedDlg.cpp:1112
 #, fuzzy
 msgid "No password set."
 msgstr "Tarkistaa salasanaa\n"
 
-#: src/PrefsUnifiedDlg.cpp:1132
+#: src/PrefsUnifiedDlg.cpp:1141
 msgid "Guest access needs a password. Type one in the guest password field, or untick Enable guest access."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1144
+#: src/PrefsUnifiedDlg.cpp:1153
 msgid ""
 "aMule must be restarted to enable these changes:\n"
 "\n"
@@ -5786,42 +5786,42 @@ msgstr ""
 "aMule on käynnistettävä uudelleen näiden muutosten voimaansaattamiseksi:\n"
 "\n"
 
-#: src/PrefsUnifiedDlg.cpp:1151
+#: src/PrefsUnifiedDlg.cpp:1160
 msgid "- TCP port changed.\n"
 msgstr "- TCP-portti muuttui.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1156
+#: src/PrefsUnifiedDlg.cpp:1165
 msgid "- UDP port changed.\n"
 msgstr "- UDP-portti muuttui.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1161
+#: src/PrefsUnifiedDlg.cpp:1170
 #, fuzzy
 msgid "- Network interface binding changed.\n"
 msgstr "- Etäyhteyden sovitin muuttui.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1166
+#: src/PrefsUnifiedDlg.cpp:1175
 msgid "- External connect port changed.\n"
 msgstr "- Etäyhteyden portti vaihtui.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1170
+#: src/PrefsUnifiedDlg.cpp:1179
 msgid "- External connect acceptance changed.\n"
 msgstr "- Etäyhteyden vastaanotto muuttui.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1174
+#: src/PrefsUnifiedDlg.cpp:1183
 msgid "- External connect interface changed.\n"
 msgstr "- Etäyhteyden sovitin muuttui.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1178
+#: src/PrefsUnifiedDlg.cpp:1187
 #, fuzzy
 msgid "- Protocol obfuscation support changed.\n"
 msgstr "Protokollan kätkeminen"
 
-#: src/PrefsUnifiedDlg.cpp:1193
+#: src/PrefsUnifiedDlg.cpp:1202
 #, fuzzy
 msgid "- amuleapi settings changed.\n"
 msgstr "- Kieli vaihtui.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1202
+#: src/PrefsUnifiedDlg.cpp:1211
 msgid ""
 "Your Auto-update server list is empty.\n"
 "'Auto-update server list at startup' will be disabled."
@@ -5829,7 +5829,7 @@ msgstr ""
 "Palvelinlistan automaattisen päivityksen lista on tyhjä.\n"
 "'Päivitä palvelinlista käynnistettäessä' kytketään pois päältä."
 
-#: src/PrefsUnifiedDlg.cpp:1213
+#: src/PrefsUnifiedDlg.cpp:1222
 msgid ""
 "You have enabled external connections but have not specified a password.\n"
 "External connections cannot be enabled unless a valid password is specified."
@@ -5837,33 +5837,33 @@ msgstr ""
 "Olet sallinut etäyhteydet mutta et ole antanut salasanaa.\n"
 "Etäyhteydet eivät ole mahdollisia ellei salasanaa ole annettu."
 
-#: src/PrefsUnifiedDlg.cpp:1246
+#: src/PrefsUnifiedDlg.cpp:1255
 #, c-format
 msgid "The amuleapi password could not be saved: %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1276
+#: src/PrefsUnifiedDlg.cpp:1285
 msgid "- Language changed.\n"
 msgstr "- Kieli vaihtui.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1281
+#: src/PrefsUnifiedDlg.cpp:1290
 msgid "- Temp folder changed.\n"
 msgstr "- Väliaikaiskansio muuttui.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1286
+#: src/PrefsUnifiedDlg.cpp:1295
 msgid "- ED2K network enabled.\n"
 msgstr "- ED2K-verkko käytössä.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1319
+#: src/PrefsUnifiedDlg.cpp:1328
 msgid "The shared-file exclusion pattern is not a valid regular expression. The filter has been left disabled."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1321 src/PrefsUnifiedDlg.cpp:1921
+#: src/PrefsUnifiedDlg.cpp:1330 src/PrefsUnifiedDlg.cpp:1930
 #, fuzzy
 msgid "Invalid regular expression"
 msgstr "Väärä protokollaversio."
 
-#: src/PrefsUnifiedDlg.cpp:1398
+#: src/PrefsUnifiedDlg.cpp:1407
 msgid ""
 "Both eD2k and Kad network are disabled.\n"
 "You won't be able to connect until you enable at least one of them."
@@ -5871,7 +5871,7 @@ msgstr ""
 "Sekä eD2k- että Kad-verkko on pois päältä.\n"
 "Et voi yhdistää ennen kuin ainakin toinen niistä on sallittu."
 
-#: src/PrefsUnifiedDlg.cpp:1403
+#: src/PrefsUnifiedDlg.cpp:1412
 msgid ""
 "Kad will not start if your UDP port is disabled.\n"
 "Enable UDP port or disable Kad."
@@ -5879,7 +5879,7 @@ msgstr ""
 "Kad ei käynnisty mikäli UDP-portti on pois päältä.\n"
 "Salli UDP-portti tai kytke Kad pois päältä."
 
-#: src/PrefsUnifiedDlg.cpp:1459
+#: src/PrefsUnifiedDlg.cpp:1468
 msgid ""
 "\n"
 "You MUST restart aMule now.\n"
@@ -5889,69 +5889,69 @@ msgstr ""
 "Sinun on uudelleenkäynnistettävä aMule nyt.\n"
 "Mikäli et uudelleenkäynnistä nyt, älä valita mikäli jotain pahaa tapahtuu.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1524
+#: src/PrefsUnifiedDlg.cpp:1533
 msgid "Could not register aMule for autostart at login. The autostart store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1526
+#: src/PrefsUnifiedDlg.cpp:1535
 msgid "Could not remove the autostart-at-login entry."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1527
+#: src/PrefsUnifiedDlg.cpp:1536
 #, fuzzy
 msgid "Autostart"
 msgstr "Automaattinen Päivitys aloitettu"
 
-#: src/PrefsUnifiedDlg.cpp:1542
+#: src/PrefsUnifiedDlg.cpp:1551
 msgid "Register file type"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1542
+#: src/PrefsUnifiedDlg.cpp:1551
 msgid "Register URL handler"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1550
+#: src/PrefsUnifiedDlg.cpp:1559
 #, c-format
 msgid "aMule only handles eD2k-compatible magnets. If you replace the current magnet handler (%s), BitTorrent magnet links will stop working - aMule cannot download BitTorrent content. Continue?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1555
+#: src/PrefsUnifiedDlg.cpp:1564
 #, c-format
 msgid "Another application currently opens .emulecollection files (%s). Replace it with aMule?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1560
+#: src/PrefsUnifiedDlg.cpp:1569
 #, c-format
 msgid "Another application is currently the default handler for these links (%s). Replace it with aMule?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1585
+#: src/PrefsUnifiedDlg.cpp:1594
 msgid "Could not register aMule for .emulecollection files. The registration store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1587
+#: src/PrefsUnifiedDlg.cpp:1596
 #, fuzzy
 msgid "Could not remove the file type registration."
 msgstr "Kansio latauksen väliaikaisille tiedostoille"
 
-#: src/PrefsUnifiedDlg.cpp:1589
+#: src/PrefsUnifiedDlg.cpp:1598
 msgid "Could not register aMule as the URL handler. The registration store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1591
+#: src/PrefsUnifiedDlg.cpp:1600
 msgid "Could not remove the URL handler registration."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1661 src/PrefsUnifiedDlg.cpp:1688
+#: src/PrefsUnifiedDlg.cpp:1670 src/PrefsUnifiedDlg.cpp:1697
 #, fuzzy
 msgid "The web server and aMule API require external connections to be enabled."
 msgstr "Salasana asetettu ja etäyhteydet sallittu."
 
-#: src/PrefsUnifiedDlg.cpp:1671
+#: src/PrefsUnifiedDlg.cpp:1680
 msgid "The aMule web server is deprecated. Consider running the aMule API instead."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1735
+#: src/PrefsUnifiedDlg.cpp:1744
 msgid ""
 "Your Auto-update servers list is in blank.\n"
 "Please fill in at least one URL to point to a valid server.met file.\n"
@@ -5961,66 +5961,66 @@ msgstr ""
 "Ole hyvä ja syötä ainakin yksi URL joka osoittaa käypään server.met-tiedostoon.\n"
 "Klikkaa nappia \"Lista\" tämän valintaruudun vierestä syöttääksesi URLin."
 
-#: src/PrefsUnifiedDlg.cpp:1876
+#: src/PrefsUnifiedDlg.cpp:1885
 msgid "Temporary files"
 msgstr "Väliaikaiset tiedostot"
 
-#: src/PrefsUnifiedDlg.cpp:1881
+#: src/PrefsUnifiedDlg.cpp:1890
 msgid "Incoming files"
 msgstr "Saapuvat tiedostot"
 
-#: src/PrefsUnifiedDlg.cpp:1886
+#: src/PrefsUnifiedDlg.cpp:1895
 msgid "Online Signatures"
 msgstr "Online-Signeeraukset"
 
-#: src/PrefsUnifiedDlg.cpp:1899
+#: src/PrefsUnifiedDlg.cpp:1908
 #, c-format
 msgid "Choose a folder for %s"
 msgstr "Valitse kansio kohteelle %s"
 
-#: src/PrefsUnifiedDlg.cpp:1923
+#: src/PrefsUnifiedDlg.cpp:1932
 #, fuzzy, c-format
 msgid "Would exclude %u of %u shared file"
 msgid_plural "Would exclude %u of %u shared files"
 msgstr[0] "Löydetty %i tunnettu jaettu tiedosto"
 msgstr[1] "Löydetty %i tunnettua jaettua tiedostoa"
 
-#: src/PrefsUnifiedDlg.cpp:1940
+#: src/PrefsUnifiedDlg.cpp:1949
 msgid "Browse for videoplayer"
 msgstr "Etsi videosoitin"
 
-#: src/PrefsUnifiedDlg.cpp:1944
+#: src/PrefsUnifiedDlg.cpp:1953
 msgid "Select browser"
 msgstr "Valitse selain"
 
-#: src/PrefsUnifiedDlg.cpp:1948
+#: src/PrefsUnifiedDlg.cpp:1957
 #, fuzzy
 msgid "Select ffprobe binary"
 msgstr "Valitse selain"
 
-#: src/PrefsUnifiedDlg.cpp:1954
+#: src/PrefsUnifiedDlg.cpp:1963
 #, c-format
 msgid "Executable%s"
 msgstr "Suoritettava tiedosto%s"
 
-#: src/PrefsUnifiedDlg.cpp:1988
+#: src/PrefsUnifiedDlg.cpp:1997
 msgid "ffprobe not found on PATH or in the standard install locations. Install ffmpeg (which ships ffprobe) or use Browse to pick a binary manually."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2000
+#: src/PrefsUnifiedDlg.cpp:2009
 msgid "Reset the settings on this page to their default values?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2001
+#: src/PrefsUnifiedDlg.cpp:2010
 #, fuzzy
 msgid "Reset to defaults"
 msgstr "Järjestelmän vakio"
 
-#: src/PrefsUnifiedDlg.cpp:2028
+#: src/PrefsUnifiedDlg.cpp:2037
 msgid "Edit server list"
 msgstr "Muokkaa palvelinlistaa"
 
-#: src/PrefsUnifiedDlg.cpp:2029
+#: src/PrefsUnifiedDlg.cpp:2038
 msgid ""
 "Add here URL's to download server.met files.\n"
 "Only one url on each line."
@@ -6028,154 +6028,154 @@ msgstr ""
 "Syötä tähän URLit joista server.met-tiedostot haetaan.\n"
 "Vain yksi urli riville."
 
-#: src/PrefsUnifiedDlg.cpp:2084
+#: src/PrefsUnifiedDlg.cpp:2093
 msgid "IP2Country update failed"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2229 src/PrefsUnifiedDlg.cpp:2260
+#: src/PrefsUnifiedDlg.cpp:2238 src/PrefsUnifiedDlg.cpp:2269
 msgid "Data by MaxMind GeoLite2"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2231 src/PrefsUnifiedDlg.cpp:2262
+#: src/PrefsUnifiedDlg.cpp:2240 src/PrefsUnifiedDlg.cpp:2271
 #, fuzzy
 msgid "Custom source"
 msgstr "Täysiä lähteitä"
 
-#: src/PrefsUnifiedDlg.cpp:2233 src/PrefsUnifiedDlg.cpp:2264
+#: src/PrefsUnifiedDlg.cpp:2242 src/PrefsUnifiedDlg.cpp:2273
 msgid "Data by DB-IP.com"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2284
+#: src/PrefsUnifiedDlg.cpp:2293
 #, fuzzy, c-format
 msgid "Status: Loaded%s"
 msgstr "Tila:"
 
-#: src/PrefsUnifiedDlg.cpp:2286
+#: src/PrefsUnifiedDlg.cpp:2295
 #, fuzzy, c-format
 msgid "Status: Loaded%s - %s"
 msgstr "Tila:"
 
-#: src/PrefsUnifiedDlg.cpp:2290
+#: src/PrefsUnifiedDlg.cpp:2299
 msgid "Status: Failed to load - click 'Update now' to refresh."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2292
+#: src/PrefsUnifiedDlg.cpp:2301
 msgid "Status: Not found - click 'Update now' to download."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2350 src/PrefsUnifiedDlg.cpp:2374
+#: src/PrefsUnifiedDlg.cpp:2359 src/PrefsUnifiedDlg.cpp:2383
 #, c-format
 msgid "Update delay: %d second"
 msgid_plural "Update delay: %d seconds"
 msgstr[0] "Päivitysväli: %d sekunti"
 msgstr[1] "Päivitysväli: %d sekuntia"
 
-#: src/PrefsUnifiedDlg.cpp:2358
+#: src/PrefsUnifiedDlg.cpp:2367
 #, c-format
 msgid "Time for average graph: %d minute"
 msgid_plural "Time for average graph: %d minutes"
 msgstr[0] "Keskimääräiskuvaajan aika: %d minuutti"
 msgstr[1] "Keskimääräiskuvaajan aika: %d minuuttia"
 
-#: src/PrefsUnifiedDlg.cpp:2367
+#: src/PrefsUnifiedDlg.cpp:2376
 #, c-format
 msgid "Connections Graph Scale: %d"
 msgstr "Yhteyskuvaajan skaala: %d"
 
-#: src/PrefsUnifiedDlg.cpp:2382
+#: src/PrefsUnifiedDlg.cpp:2391
 #, c-format
 msgid "File Buffer Size: %d byte"
 msgid_plural "File Buffer Size: %d bytes"
 msgstr[0] "Tiedostopuskurin koko: %d tavu"
 msgstr[1] "Tiedostopuskurin koko: %d tavua"
 
-#: src/PrefsUnifiedDlg.cpp:2392
+#: src/PrefsUnifiedDlg.cpp:2401
 #, c-format
 msgid "Upload Queue Size: %d client"
 msgid_plural "Upload Queue Size: %d clients"
 msgstr[0] "Lähetysjonon koko: %d asiakas"
 msgstr[1] "Lähetysjonon koko: %d asiakasta"
 
-#: src/PrefsUnifiedDlg.cpp:2402
+#: src/PrefsUnifiedDlg.cpp:2411
 #, c-format
 msgid "Server connection refresh interval: %d minute"
 msgid_plural "Server connection refresh interval: %d minutes"
 msgstr[0] "Palvelinyhteyden päivitysväli: %d minuutti"
 msgstr[1] "Palvelinyhteyden päivitysväli: %d minuuttia"
 
-#: src/PrefsUnifiedDlg.cpp:2407
+#: src/PrefsUnifiedDlg.cpp:2416
 msgid "Server connection refresh interval: Disabled"
 msgstr "Palvelinyhteyden päivitysväli: Ei käytössä"
 
-#: src/PrefsUnifiedDlg.cpp:2451
+#: src/PrefsUnifiedDlg.cpp:2460
 msgid "disabled"
 msgstr "poissa käytöstä"
 
-#: src/PrefsUnifiedDlg.cpp:2477
+#: src/PrefsUnifiedDlg.cpp:2486
 #, c-format
 msgid "Execute command on '%s' event"
 msgstr "Suorita komento tapahtuman '%s' yhteydessä"
 
-#: src/PrefsUnifiedDlg.cpp:2484
+#: src/PrefsUnifiedDlg.cpp:2493
 msgid "Enable command execution on core"
 msgstr "Mahdollista komentojen suorittaminen ytimestä"
 
-#: src/PrefsUnifiedDlg.cpp:2496
+#: src/PrefsUnifiedDlg.cpp:2505
 msgid "Core command:"
 msgstr "Ytimen komento:"
 
-#: src/PrefsUnifiedDlg.cpp:2512
+#: src/PrefsUnifiedDlg.cpp:2521
 msgid "Enable command execution on GUI"
 msgstr "Mahdollista komentojen suorittaminen graafisesta käyttöliittymästä"
 
-#: src/PrefsUnifiedDlg.cpp:2524
+#: src/PrefsUnifiedDlg.cpp:2533
 msgid "GUI command:"
 msgstr "Graafisen käyttöliittymän komento:"
 
-#: src/PrefsUnifiedDlg.cpp:2540
+#: src/PrefsUnifiedDlg.cpp:2549
 msgid "The following variables will be replaced:"
 msgstr "Seuraavat muuttujat korvataan:"
 
-#: src/PrefsUnifiedDlg.cpp:2708
+#: src/PrefsUnifiedDlg.cpp:2717
 msgid ""
 "The following folders look like system or sensitive locations:\n"
 "\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2713
+#: src/PrefsUnifiedDlg.cpp:2722
 msgid "Sharing them recursively will publish every file underneath on the eD2k/Kad networks. Do you really want to do this?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2716
+#: src/PrefsUnifiedDlg.cpp:2725
 #, fuzzy
 msgid "Confirm shared folders"
 msgstr "Jaetut kansiot"
 
-#: src/PrefsUnifiedDlg.cpp:2744
+#: src/PrefsUnifiedDlg.cpp:2753
 #, fuzzy
 msgid "Reloading shared files..."
 msgstr "Uudelleenlataa jaetut tiedostot"
 
-#: src/PrefsUnifiedDlg.cpp:2745
+#: src/PrefsUnifiedDlg.cpp:2754
 msgid "Scanning for subdirectories..."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2746
+#: src/PrefsUnifiedDlg.cpp:2755
 #, fuzzy
 msgid "Updating shared folders"
 msgstr "Jaetut kansiot"
 
-#: src/PrefsUnifiedDlg.cpp:2773
+#: src/PrefsUnifiedDlg.cpp:2782
 #, c-format
 msgid "Scanned %u directories..."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2823
+#: src/PrefsUnifiedDlg.cpp:2832
 #, fuzzy, c-format
 msgid "Reloading shared files: %u files scanned"
 msgstr "Lataa uudelleen lista jaetuista tiedostoista."
 
-#: src/PrefsUnifiedDlg.cpp:2873
+#: src/PrefsUnifiedDlg.cpp:2882
 #, fuzzy
 msgid "Shared folder"
 msgstr "Jaetut kansiot"
@@ -7856,12 +7856,12 @@ msgstr "Poista luokka"
 msgid "Hashset requested for unknown file: %s"
 msgstr "Tarkistejoukkoa pyydettiin tuntemattomalle tiedostolle: %s"
 
-#: src/UploadQueue.cpp:618
+#: src/UploadQueue.cpp:627
 #, c-format
 msgid "Resuming uploads of file: %s"
 msgstr "Jatketaan tiedoston %s lähetyksiä"
 
-#: src/UploadQueue.cpp:634
+#: src/UploadQueue.cpp:643
 #, c-format
 msgid "Suspending upload of file: %s"
 msgstr "Keskeytetään tiedoston %s lähetys"

--- a/po/fi.po
+++ b/po/fi.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-28 10:19+0200\n"
+"POT-Creation-Date: 2026-07-28 12:17+0200\n"
 "PO-Revision-Date: 2026-07-27 11:37+0000\n"
 "Last-Translator: Tapio Rantala <tapio.rantala@iki.fi>\n"
 "Language-Team: aMule Team <https://github.com/amule-org/amule>\n"
@@ -204,83 +204,83 @@ msgstr "ED2KLinks-tiedoston avaus epäonnistui."
 msgid "WARNING: You can't add yourself as a source for an eD2k link while having a lowid."
 msgstr "VAROITUS: Et voi lisätä itseäsi lähteeksi eD2k-linkkiin kun sinulla on LowID."
 
-#: src/amule.cpp:300
+#: src/amule.cpp:301
 msgid "Now, exiting main app..."
 msgstr "Pääohjelmaa suljetaan..."
 
-#: src/amule.cpp:330
+#: src/amule.cpp:331
 #, c-format
 msgid "Terminating amuleweb instance with pid '%d' ... "
 msgstr "Lopetetaan amulewebin instanssi prosessinumerolla '%d' ... "
 
-#: src/amule.cpp:334
+#: src/amule.cpp:335
 #, c-format
 msgid "Killing amuleweb instance with pid '%d' ... "
 msgstr "Tuhotaan amulewebin instanssi prosessinumerolla '%d' ... "
 
-#: src/amule.cpp:336 src/amule.cpp:349 src/ClientRef.cpp:180
+#: src/amule.cpp:337 src/amule.cpp:350 src/ClientRef.cpp:180
 #: src/SearchDlg.cpp:1041 src/ServerListCtrl.cpp:98
 msgid "Failed"
 msgstr "Epäonnistunut"
 
-#: src/amule.cpp:343
+#: src/amule.cpp:344
 #, fuzzy, c-format
 msgid "Terminating amuleapi instance with pid '%d' ... "
 msgstr "Lopetetaan amulewebin instanssi prosessinumerolla '%d' ... "
 
-#: src/amule.cpp:347
+#: src/amule.cpp:348
 #, fuzzy, c-format
 msgid "Killing amuleapi instance with pid '%d' ... "
 msgstr "Tuhotaan amulewebin instanssi prosessinumerolla '%d' ... "
 
-#: src/amule.cpp:355
+#: src/amule.cpp:356
 msgid "aMule OnExit: Terminating core."
 msgstr "aMulen poistuessa: Lopetetaan ydin."
 
-#: src/amule.cpp:466
+#: src/amule.cpp:467
 msgid "aMule shutdown completed."
 msgstr "aMule sammutettu."
 
-#: src/amule.cpp:470
+#: src/amule.cpp:471
 msgid "Memory debug results for aMule exit:"
 msgstr "Muistin virheiden etsinnän tulokset aMulen sulkeutuessa:"
 
-#: src/amule.cpp:651
+#: src/amule.cpp:652
 #, c-format
 msgid "Binding aMule's peer-to-peer traffic to interface: %s (HTTP updates use the default route)"
 msgstr ""
 
-#: src/amule.cpp:655
+#: src/amule.cpp:656
 #, c-format
 msgid "Binding all network traffic to interface: %s"
 msgstr ""
 
-#: src/amule.cpp:659
+#: src/amule.cpp:660
 #, c-format
 msgid "WARNING: configured network interface '%s' was not found - traffic is NOT bound to it and may leave via the default route. Check the interface name in Preferences."
 msgstr ""
 
-#: src/amule.cpp:665
+#: src/amule.cpp:666
 #, c-format
 msgid "WARNING: binding to network interface '%s' requires elevated privileges and was NOT applied - traffic may leave via the default route. Grant the capability (e.g. 'sudo setcap cap_net_raw+ep' on the aMule binary) or run with sufficient privileges."
 msgstr ""
 
-#: src/amule.cpp:673
+#: src/amule.cpp:674
 #, c-format
 msgid "WARNING: could not bind to network interface '%s' - traffic may leave via the default route."
 msgstr ""
 
-#: src/amule.cpp:732
+#: src/amule.cpp:733
 msgid "Your locale has been changed to System Default due to a configuration change. Sorry."
 msgstr "Maa-asetuksesi vaihdettiin järjestelmän oletuksiksi asetusmuutoksen takia. Pahoittelen."
 
-#: src/amule.cpp:734 src/amule.cpp:1581 src/CatDialog.cpp:128
+#: src/amule.cpp:735 src/amule.cpp:1589 src/CatDialog.cpp:128
 #: src/CatDialog.cpp:136 src/CatDialog.cpp:149 src/ServerList.cpp:366
 #: src/ServerListCtrl.cpp:152
 msgid "Info"
 msgstr "Info"
 
-#: src/amule.cpp:741
+#: src/amule.cpp:742
 msgid ""
 "\n"
 "EC configuration"
@@ -288,74 +288,74 @@ msgstr ""
 "\n"
 "Etäyhteyksien asetukset"
 
-#: src/amule.cpp:744
+#: src/amule.cpp:745
 msgid "Password set and external connections enabled."
 msgstr "Salasana asetettu ja etäyhteydet sallittu."
 
-#: src/amule.cpp:754 src/KadDlg.cpp:176 src/KadDlg.cpp:185
-#: src/PrefsUnifiedDlg.cpp:1387 src/SharedFilesCtrl.cpp:476
+#: src/amule.cpp:755 src/KadDlg.cpp:176 src/KadDlg.cpp:185
+#: src/PrefsUnifiedDlg.cpp:1461 src/SharedFilesCtrl.cpp:476
 msgid "WARNING"
 msgstr "VAROITUS"
 
-#: src/amule.cpp:991
+#: src/amule.cpp:992
 #, fuzzy
 msgid "Network bootstrap"
 msgstr "Verkot"
 
-#: src/amule.cpp:996
+#: src/amule.cpp:997
 msgid ""
 "aMule has detected missing network bootstrap files.\n"
 "Select which ones to download:"
 msgstr ""
 
-#: src/amule.cpp:1005 src/FirstRunWizard.cpp:411
+#: src/amule.cpp:1006 src/FirstRunWizard.cpp:411
 #, fuzzy
 msgid "eD2k server list (server.met)"
 msgstr "%i palvelin tiedostossa server.met"
 
-#: src/amule.cpp:1012 src/FirstRunWizard.cpp:416
+#: src/amule.cpp:1013 src/FirstRunWizard.cpp:416
 msgid "Kad bootstrap nodes (nodes.dat)"
 msgstr ""
 
-#: src/amule.cpp:1102
+#: src/amule.cpp:1103
 #, c-format
 msgid "web server running on pid %d"
 msgstr "web-palvelin käynnissä prosessinumerolla %d"
 
-#: src/amule.cpp:1115
+#: src/amule.cpp:1116
 #, fuzzy
 msgid "You requested to run web server on startup, but the amuleweb binary cannot be run. Please install the package containing aMule web server, or build aMule from source with -DBUILD_WEBSERVER=YES and install it."
 msgstr "Olet asettanut web-palvelimen ajettavaksi käynnistettäessä, mutta amuleweb-ohjelmaa ei voida ajaa. Ole hyvä ja asenna aMule web-palvelimen sisältävä paketti tai käännä aMule käyttäen parametria --enable-webserver ja suorita make install"
 
-#: src/amule.cpp:1120 src/amule.cpp:1177 src/amule.cpp:1291 src/amule.cpp:1593
+#: src/amule.cpp:1121 src/amule.cpp:1185 src/amule.cpp:1299 src/amule.cpp:1601
 #: src/amule-remote-gui.cpp:603 src/amule-remote-gui.cpp:671
 #: src/amule-remote-gui.cpp:709 src/amule-remote-gui.cpp:1282
 #: src/amule-remote-gui.cpp:1345 src/amule-remote-gui.cpp:1372
-#: src/DownloadQueue.cpp:1481
+#: src/DownloadQueue.cpp:1481 src/PrefsUnifiedDlg.cpp:1247
 msgid "ERROR"
 msgstr "VIRHE"
 
-#: src/amule.cpp:1166
+#: src/amule.cpp:1174
 #, fuzzy, c-format
 msgid "amuleapi running on pid %d"
 msgstr "web-palvelin käynnissä prosessinumerolla %d"
 
-#: src/amule.cpp:1172
+#: src/amule.cpp:1180
 #, fuzzy
 msgid "You requested to run amuleapi on startup, but the amuleapi binary cannot be run. Please install the package containing aMule's REST API server, or build aMule from source with -DBUILD_AMULEAPI=YES and install it."
 msgstr "Olet asettanut web-palvelimen ajettavaksi käynnistettäessä, mutta amuleweb-ohjelmaa ei voida ajaa. Ole hyvä ja asenna aMule web-palvelimen sisältävä paketti tai käännä aMule käyttäen parametria --enable-webserver ja suorita make install"
 
-#: src/amule.cpp:1259
+#: src/amule.cpp:1267
 #, c-format
 msgid "Could not bind ports to the specified address: %s"
 msgstr "Ei voitu sitoa portteja annettuun osoitteeseen: %s"
 
-#: src/amule.cpp:1283
+#: src/amule.cpp:1291
 #, c-format
 msgid "Port %u is not available. You will be LOWID\n"
 msgstr "Portti %u ei ole saatavilla. Sinulle annetaan LowID\n"
 
-#: src/amule.cpp:1288
+#: src/amule.cpp:1296
 #, c-format
 msgid ""
 "Port %u is not available!\n"
@@ -370,48 +370,48 @@ msgstr ""
 "\n"
 "Tarkista yhteytesi varmistaaksesi että portti on avoinna sekä ulos että sisään."
 
-#: src/amule.cpp:1385
+#: src/amule.cpp:1393
 msgid "Failed to create OnlineSig File"
 msgstr "Online-Signeeraustiedoston luonti epäonnistui"
 
-#: src/amule.cpp:1393
+#: src/amule.cpp:1401
 msgid "Failed to create aMule OnlineSig File"
 msgstr "aMulen Online-Signeeraustiedoston luonti epäonnistui"
 
-#: src/amule.cpp:1556
+#: src/amule.cpp:1564
 msgid "The selected locale seems not to be installed on your box. (Note: I'll try to set it anyway)"
 msgstr "Valittu maa-asetus ei näytä olevan asennettuna järjestelmääsi. (Huom: Yritän asettaa sen kuitenkin)"
 
-#: src/amule.cpp:1566
+#: src/amule.cpp:1574
 #, c-format
 msgid "This is the first time you run aMule %s"
 msgstr "Tämä on ensimmäinen kerta kun käynnistät aMulen version %s"
 
-#: src/amule.cpp:1569
+#: src/amule.cpp:1577
 msgid "This version is a testing version, updated daily, and\n"
 msgstr "Tämä versio on testiversio jota päivitetään päivittäin,\n"
 
-#: src/amule.cpp:1570
+#: src/amule.cpp:1578
 msgid "we give no warranty it won't break anything, burn your house,\n"
 msgstr "emmekä me anna takuuta ettei se riko mitään, polta taloasi,\n"
 
-#: src/amule.cpp:1571
+#: src/amule.cpp:1579
 msgid "or kill your dog. But it *should* be safe to use anyway.\n"
 msgstr "tai tapa koiraasi. Mutta sen *pitäisi* olla silti turvallinen käyttää.\n"
 
-#: src/amule.cpp:1576
+#: src/amule.cpp:1584
 msgid "More information, support and new releases can found at our homepage,\n"
 msgstr "Lisätietoa, tukea ja uudet julkaisut löytyvät kotisivuiltamme osoitteessa\n"
 
-#: src/amule.cpp:1577
+#: src/amule.cpp:1585
 msgid "at https://amule-org.github.io, or in our IRC channel #aMule at irc.libera.chat.\n"
 msgstr "https://amule-org.github.io tai IRC-kanavaltamme #aMule palvelimella irc.libera.chat (englanniksi).\n"
 
-#: src/amule.cpp:1579
+#: src/amule.cpp:1587
 msgid "Feel free to report any bugs to https://github.com/amule-org/amule/issues"
 msgstr "Voit vapaasti raportoida bugeista osoitteessa https://github.com/amule-org/amule/issues"
 
-#: src/amule.cpp:1591
+#: src/amule.cpp:1599
 msgid ""
 "The folder for Online Signature files you specified is INVALID!\n"
 " OnlineSignature will be DISABLED until you fix it on preferences."
@@ -419,137 +419,137 @@ msgstr ""
 "Online-Signeeraukselle asettamasi kansio ei ole kelvollinen!\n"
 " Online-Signeeraus kytketään pois päältä kunnes korjaat asian asetuksista."
 
-#: src/amule.cpp:1654
+#: src/amule.cpp:1662
 msgid "Server hostname notified"
 msgstr "Palvelimen verkkonimi ilmoitettu"
 
-#: src/amule.cpp:2031
+#: src/amule.cpp:2039
 #, c-format
 msgid "Disk space preallocation for file '%s' failed: %s"
 msgstr "Levytilan esivaraus tiedostolle '%s' epäonnistui: %s"
 
-#: src/amule.cpp:2160
+#: src/amule.cpp:2168
 msgid "ERROR: can't open logfile"
 msgstr "VIRHE: Lokitiedostoa ei voida avata"
 
-#: src/amule.cpp:2164
+#: src/amule.cpp:2172
 msgid "WARNING: logfile is empty. Something is wrong."
 msgstr "VAROITUS: Lokitiedosto on tyhjä. Jotain on pielessä."
 
-#: src/amule.cpp:2181
+#: src/amule.cpp:2189
 msgid "Log has been reset"
 msgstr "Loki nollattiin"
 
-#: src/amule.cpp:2205
+#: src/amule.cpp:2213
 #, c-format
 msgid "ServerMessage: %s"
 msgstr "Palvelimen viesti: %s"
 
-#: src/amule.cpp:2248 src/IP2Country.cpp:220 src/IPFilter.cpp:514
+#: src/amule.cpp:2256 src/IP2Country.cpp:220 src/IPFilter.cpp:514
 #: src/ServerList.cpp:875
 #, c-format
 msgid "Skipped download of %s, because requested file is not newer."
 msgstr "Hypättiin yli latauksesta %s, koska pyydetty tiedosto ei ole uudempi."
 
-#: src/amule.cpp:2251
+#: src/amule.cpp:2259
 msgid "Failed to download the nodes list."
 msgstr "Yhteyspisteiden listan lataus epäonnistui."
 
-#: src/amule.cpp:2314
+#: src/amule.cpp:2322
 msgid "Failed to open the downloaded version check file"
 msgstr "Ladatun versiotarkistustiedoston avaus epäonnistui"
 
-#: src/amule.cpp:2317 src/amule.cpp:2336
+#: src/amule.cpp:2325 src/amule.cpp:2344
 msgid "Corrupted version check file"
 msgstr "Turmeltunut versiotarkistustiedosto"
 
-#: src/amule.cpp:2359
+#: src/amule.cpp:2367
 msgid "You are using an outdated version of aMule!"
 msgstr "Käytät vanhentunutta versiota aMulesta!"
 
-#: src/amule.cpp:2361
+#: src/amule.cpp:2369
 #, c-format
 msgid "Your aMule version is %i.%i.%i and the latest version is %li.%li.%li"
 msgstr "Tämän aMulen versio on %i.%i.%i ja uusin versio on %li.%li.%li"
 
-#: src/amule.cpp:2365
+#: src/amule.cpp:2373
 msgid "The latest version can always be found at https://github.com/amule-org/amule/releases/latest"
 msgstr "Uusin version löytyy aina osoitteesta https://github.com/amule-org/amule/releases/latest"
 
-#: src/amule.cpp:2368
+#: src/amule.cpp:2376
 #, c-format
 msgid "WARNING: Your aMuled version is outdated: %i.%i.%i < %li.%li.%li"
 msgstr "VAROITUS: aMulesi versio on vanhentunut: %i.%i.%i < %li.%li.%li"
 
-#: src/amule.cpp:2374
+#: src/amule.cpp:2382
 msgid "Your copy of aMule is up to date."
 msgstr "aMulesi on uusinta versiota."
 
-#: src/amule.cpp:2381
+#: src/amule.cpp:2389
 msgid "Failed to download the version check file"
 msgstr "Versiotarkistustiedoston lataus epäonnistui"
 
-#: src/amule.cpp:2550 src/amule-remote-gui.cpp:1133
+#: src/amule.cpp:2558 src/amule-remote-gui.cpp:1133
 #, c-format
 msgid "Users: %s | Files: %s"
 msgstr "Käyttäjiä: %s | Tiedostoja: %s"
 
-#: src/amule.cpp:2551 src/amule-remote-gui.cpp:1134
+#: src/amule.cpp:2559 src/amule-remote-gui.cpp:1134
 #, c-format
 msgid "Users: E: %s K: %s | Files: E: %s K: %s"
 msgstr "Käyttäjiä: E: %s K: %s | Tiedostoja: E: %s K: %s"
 
-#: src/amule.cpp:2565 src/amule-remote-gui.cpp:1147
+#: src/amule.cpp:2573 src/amule-remote-gui.cpp:1147
 msgid "No networks selected"
 msgstr "Ei valittuja verkkoja"
 
-#: src/amule.cpp:2633 src/TextClient.cpp:903
+#: src/amule.cpp:2641 src/TextClient.cpp:903
 msgid "with LowID"
 msgstr "LowID:llä"
 
-#: src/amule.cpp:2633 src/TextClient.cpp:904
+#: src/amule.cpp:2641 src/TextClient.cpp:904
 msgid "with HighID"
 msgstr "HighID:llä"
 
-#: src/amule.cpp:2635
+#: src/amule.cpp:2643
 #, c-format
 msgid "Connected to %s %s"
 msgstr "Yhdistetty %s %s"
 
-#: src/amule.cpp:2640
+#: src/amule.cpp:2648
 #, c-format
 msgid "Connecting to %s"
 msgstr "Yhdistän %s"
 
-#: src/amule.cpp:2642
+#: src/amule.cpp:2650
 msgid "Disconnected from eD2k"
 msgstr "eD2k-yhteys katkaistu"
 
-#: src/amule.cpp:2651
+#: src/amule.cpp:2659
 msgid "Kad started."
 msgstr "Käynnistettiin Kad."
 
-#: src/amule.cpp:2653
+#: src/amule.cpp:2661
 msgid "Kad stopped."
 msgstr "Pysäytettiin Kad."
 
-#: src/amule.cpp:2661
+#: src/amule.cpp:2669
 msgid "Connected to Kad (ok)"
 msgstr "Yhdistetty Kadiin (ok)"
 
-#: src/amule.cpp:2663
+#: src/amule.cpp:2671
 msgid "Connected to Kad (firewalled)"
 msgstr "Yhdistetty Kadiin (palomuurattu)"
 
-#: src/amule.cpp:2667
+#: src/amule.cpp:2675
 msgid "Disconnected from Kad"
 msgstr "Yhteys Kadiin katkaistu"
 
-#: src/amule.cpp:2699
+#: src/amule.cpp:2707
 msgid "Kad network cannot be used if UDP port is disabled on preferences, not starting."
 msgstr "Kad-verkkoa ei voida käyttää mikäli UDP-portti on estetty asetuksissa, ei käynnistetä."
 
-#: src/amule.cpp:2703
+#: src/amule.cpp:2711
 msgid "Kad network disabled on preferences, not connecting."
 msgstr "Kad-verkko estetty asetuksissa, ei yhdistetä."
 
@@ -594,36 +594,36 @@ msgid "FATAL ERROR: Failed to create Timer"
 msgstr "KRIITTINEN VIRHE: Ajastimen luominen epäonnistui"
 
 #: src/amuleDlg.cpp:361 src/amuleDlg.cpp:1787 src/amuleDlg.cpp:2033
-#: src/muuli_wdr.cpp:1492 src/muuli_wdr.cpp:3418
+#: src/muuli_wdr.cpp:1492 src/muuli_wdr.cpp:3449
 msgid "Networks"
 msgstr "Verkot"
 
-#: src/amuleDlg.cpp:362 src/amuleDlg.cpp:1793 src/muuli_wdr.cpp:3419
+#: src/amuleDlg.cpp:362 src/amuleDlg.cpp:1793 src/muuli_wdr.cpp:3450
 msgid "Searches"
 msgstr "Haut"
 
 #: src/amuleDlg.cpp:363 src/amuleDlg.cpp:1799 src/DownloadListCtrl.cpp:740
-#: src/muuli_wdr.cpp:392 src/muuli_wdr.cpp:1585 src/muuli_wdr.cpp:3420
+#: src/muuli_wdr.cpp:392 src/muuli_wdr.cpp:1585 src/muuli_wdr.cpp:3451
 #: src/Statistics.cpp:829
 msgid "Downloads"
 msgstr "Lataukset"
 
-#: src/amuleDlg.cpp:364 src/amuleDlg.cpp:1805 src/muuli_wdr.cpp:3294
+#: src/amuleDlg.cpp:364 src/amuleDlg.cpp:1805 src/muuli_wdr.cpp:3325
 msgid "Shared files"
 msgstr "Jaetut tiedostot"
 
-#: src/amuleDlg.cpp:365 src/amuleDlg.cpp:1811 src/muuli_wdr.cpp:2926
-#: src/muuli_wdr.cpp:3376 src/muuli_wdr.cpp:3423
+#: src/amuleDlg.cpp:365 src/amuleDlg.cpp:1811 src/muuli_wdr.cpp:2957
+#: src/muuli_wdr.cpp:3407 src/muuli_wdr.cpp:3454
 msgid "Messages"
 msgstr "Viestit"
 
-#: src/amuleDlg.cpp:366 src/amuleDlg.cpp:1817 src/muuli_wdr.cpp:3424
-#: src/PrefsUnifiedDlg.cpp:312 src/Statistics.cpp:779 src/Statistics.cpp:1235
+#: src/amuleDlg.cpp:366 src/amuleDlg.cpp:1817 src/muuli_wdr.cpp:3455
+#: src/PrefsUnifiedDlg.cpp:314 src/Statistics.cpp:779 src/Statistics.cpp:1235
 msgid "Statistics"
 msgstr "Tilastot"
 
-#: src/amuleDlg.cpp:368 src/amuleDlg.cpp:1824 src/muuli_wdr.cpp:3426
-#: src/PrefsUnifiedDlg.cpp:328 src/utils/wxCas/src/wxcasprefs.cpp:39
+#: src/amuleDlg.cpp:368 src/amuleDlg.cpp:1824 src/muuli_wdr.cpp:3457
+#: src/PrefsUnifiedDlg.cpp:330 src/utils/wxCas/src/wxcasprefs.cpp:39
 msgid "Preferences"
 msgstr "Asetukset"
 
@@ -681,8 +681,8 @@ msgstr "Kad: Pois päältä"
 #: src/amuleDlg.cpp:1029 src/DownloadListCtrl.cpp:505
 #: src/DownloadListCtrl.cpp:749 src/FriendListCtrl.cpp:180
 #: src/muuli_wdr.cpp:731 src/muuli_wdr.cpp:782 src/muuli_wdr.cpp:846
-#: src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2231 src/muuli_wdr.cpp:2316
-#: src/muuli_wdr.cpp:3064 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
+#: src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2262 src/muuli_wdr.cpp:2347
+#: src/muuli_wdr.cpp:3095 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
 #: src/ServerListCtrl.cpp:606 src/TransferWnd.cpp:378
 #: src/utils/wxCas/src/wxcasprefs.cpp:235
 msgid "Cancel"
@@ -693,7 +693,7 @@ msgid "Stop the current connection attempts"
 msgstr "Pysäytä nykyiset yhteysyritykset"
 
 #: src/amuleDlg.cpp:1035 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976
-#: src/muuli_wdr.cpp:2454
+#: src/muuli_wdr.cpp:2485
 msgid "Disconnect"
 msgstr "Katkaise yhteys"
 
@@ -702,7 +702,7 @@ msgid "Disconnect from the currently connected networks"
 msgstr "Katkaise yhteys yhdistettyihin verkkoihin"
 
 #: src/amuleDlg.cpp:1041 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979
-#: src/muuli_wdr.cpp:2609 src/muuli_wdr.cpp:3061 src/muuli_wdr.cpp:3416
+#: src/muuli_wdr.cpp:2640 src/muuli_wdr.cpp:3092 src/muuli_wdr.cpp:3447
 msgid "Connect"
 msgstr "Yhdistä"
 
@@ -757,7 +757,7 @@ msgstr "Lopettamisen varmistus"
 msgid "Launch Command: "
 msgstr "Suorita komento: "
 
-#: src/amuleDlg.cpp:1632 src/muuli_wdr.cpp:1978 src/Preferences.cpp:952
+#: src/amuleDlg.cpp:1632 src/muuli_wdr.cpp:1982 src/Preferences.cpp:979
 msgid "- default -"
 msgstr "- oletus -"
 
@@ -771,48 +771,48 @@ msgstr "Teemakansiota '%s' ei ole olemassa"
 msgid "WARNING: Unable to open skin file '%s' for read"
 msgstr "VAROITUS: Ei voida avata teematiedostoa '%s' luettavaksi"
 
-#: src/amuleDlg.cpp:1791 src/muuli_wdr.cpp:3418
+#: src/amuleDlg.cpp:1791 src/muuli_wdr.cpp:3449
 msgid "Networks Window"
 msgstr "Verkkoikkuna"
 
-#: src/amuleDlg.cpp:1797 src/muuli_wdr.cpp:3419
+#: src/amuleDlg.cpp:1797 src/muuli_wdr.cpp:3450
 msgid "Searches Window"
 msgstr "Hakujen ikkuna"
 
-#: src/amuleDlg.cpp:1803 src/muuli_wdr.cpp:3420
+#: src/amuleDlg.cpp:1803 src/muuli_wdr.cpp:3451
 msgid "Downloads Window"
 msgstr "Latausten ikkuna"
 
-#: src/amuleDlg.cpp:1809 src/muuli_wdr.cpp:3422
+#: src/amuleDlg.cpp:1809 src/muuli_wdr.cpp:3453
 msgid "Shared Files Window"
 msgstr "Jaettujen tiedostojen ikkuna"
 
-#: src/amuleDlg.cpp:1815 src/muuli_wdr.cpp:3423
+#: src/amuleDlg.cpp:1815 src/muuli_wdr.cpp:3454
 msgid "Messages Window"
 msgstr "Viestien ikkuna"
 
-#: src/amuleDlg.cpp:1821 src/muuli_wdr.cpp:3424
+#: src/amuleDlg.cpp:1821 src/muuli_wdr.cpp:3455
 msgid "Statistics Graph Window"
 msgstr "Tilastokuvaajien ikkuna"
 
-#: src/amuleDlg.cpp:1828 src/muuli_wdr.cpp:3426
+#: src/amuleDlg.cpp:1828 src/muuli_wdr.cpp:3457
 msgid "Preferences Settings Window"
 msgstr "Asetuksien säätöikkuna"
 
-#: src/amuleDlg.cpp:1831 src/muuli_wdr.cpp:3427
+#: src/amuleDlg.cpp:1831 src/muuli_wdr.cpp:3458
 msgid "Import"
 msgstr "Tuonti"
 
-#: src/amuleDlg.cpp:1835 src/muuli_wdr.cpp:3427
+#: src/amuleDlg.cpp:1835 src/muuli_wdr.cpp:3458
 msgid "The partfile importer tool"
 msgstr "Osatiedostojen tuontityökalu"
 
-#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3428
+#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3459
 #: src/utils/aLinkCreator/src/alcframe.cpp:262
 msgid "About"
 msgstr "Tietoja"
 
-#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3428
+#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3459
 msgid "About/Help"
 msgstr "Tietoja/Ohje"
 
@@ -954,7 +954,7 @@ msgstr "Tiedostoa ei löytynyt."
 msgid "The core rejected these shared folders:%s"
 msgstr ""
 
-#: src/amule-remote-gui.cpp:1336 src/ExternalConn.cpp:2345
+#: src/amule-remote-gui.cpp:1336 src/ExternalConn.cpp:2346
 msgid "Invalid link or already on list."
 msgstr "Virheellinen linkki tai se on jo listalla."
 
@@ -970,7 +970,7 @@ msgstr "Ei voida luoda kansiota '%s' luokalle '%s', pidän kansion '%s'."
 #: src/ClientDetailDialog.cpp:123 src/DataToText.cpp:61 src/DataToText.cpp:86
 #: src/DataToText.cpp:101 src/DataToText.cpp:136 src/DataToText.cpp:165
 #: src/DownloadListCtrl.cpp:1172 src/DownloadListCtrl.cpp:1185
-#: src/DownloadListCtrl.cpp:1196 src/ExternalConn.cpp:608
+#: src/DownloadListCtrl.cpp:1196 src/ExternalConn.cpp:609
 #: src/FileDetailDialog.cpp:203 src/FileDetailDialog.cpp:235
 #: src/FileDetailDialog.cpp:242 src/GenericClientListCtrl.cpp:1171
 #: src/GenericClientListCtrl.cpp:1182 src/GenericClientListCtrl.cpp:1192
@@ -1357,19 +1357,19 @@ msgstr "Auto [Ko]"
 msgid "Very low"
 msgstr "Erittäin matala"
 
-#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:743 src/muuli_wdr.cpp:2282
+#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:743 src/muuli_wdr.cpp:2313
 #: src/ServerListCtrl.cpp:263 src/ServerListCtrl.cpp:456
 #: src/SharedFilesCtrl.cpp:145
 msgid "Low"
 msgstr "Matala"
 
-#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:744 src/muuli_wdr.cpp:2283
+#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:744 src/muuli_wdr.cpp:2314
 #: src/ServerListCtrl.cpp:266 src/ServerListCtrl.cpp:457
 #: src/SharedFilesCtrl.cpp:146
 msgid "Normal"
 msgstr "Normaali"
 
-#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:745 src/muuli_wdr.cpp:2284
+#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:745 src/muuli_wdr.cpp:2315
 #: src/ServerListCtrl.cpp:269 src/ServerListCtrl.cpp:458
 #: src/SharedFilesCtrl.cpp:147
 msgid "High"
@@ -1461,7 +1461,7 @@ msgstr "Paikallinen Palvelin"
 msgid "Remote Server"
 msgstr "Etäpalvelin"
 
-#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3181
+#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3212
 #: src/SearchDlg.cpp:119 src/TextClient.cpp:911
 msgid "Kad"
 msgstr "Kad"
@@ -1533,7 +1533,7 @@ msgstr "Osa"
 msgid "Size"
 msgstr "Koko"
 
-#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3248
+#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3279
 msgid "Transferred"
 msgstr "Siirretty"
 
@@ -1591,7 +1591,7 @@ msgstr ""
 "Palaute tullut: %s (%s)\n"
 "\n"
 
-#: src/DownloadListCtrl.cpp:746 src/muuli_wdr.cpp:2285
+#: src/DownloadListCtrl.cpp:746 src/muuli_wdr.cpp:2316
 #: src/SharedFilesCtrl.cpp:150
 msgid "Auto"
 msgstr "Automaattinen"
@@ -1629,7 +1629,7 @@ msgid "Extended Options"
 msgstr "Laajat asetukset"
 
 #: src/DownloadListCtrl.cpp:770 src/DownloadListCtrl.cpp:822
-#: src/muuli_wdr.cpp:1796
+#: src/muuli_wdr.cpp:1800
 msgid "Preview"
 msgstr "Esikatsele"
 
@@ -1804,227 +1804,232 @@ msgstr[1] ""
 msgid "Invalid eD2k link! ERROR: %s"
 msgstr "Virheellinen eD2k-linkki! VIRHE: %s"
 
-#: src/ExternalConn.cpp:379
+#: src/ExternalConn.cpp:380
 msgid "Client sent packet after authentication failed."
 msgstr "Asiakas lähetti paketin tunnistautumisen epäonnistumisen jälkeen."
 
-#: src/ExternalConn.cpp:396
+#: src/ExternalConn.cpp:397
 msgid "External connection closed."
 msgstr "Etäyhteys suljettu."
 
-#: src/ExternalConn.cpp:473
+#: src/ExternalConn.cpp:474
 msgid "External connections disabled due to empty password!"
 msgstr "Etäyhteydet kielletty sillä salasana on tyhjä!"
 
-#: src/ExternalConn.cpp:494
+#: src/ExternalConn.cpp:495
 msgid "External connections disabled in config file"
 msgstr "Etäyhteydet estetty asetustiedostossa"
 
-#: src/ExternalConn.cpp:575
+#: src/ExternalConn.cpp:576
 msgid "New external connection accepted"
 msgstr "Uusi etäyhteys hyväksytty"
 
-#: src/ExternalConn.cpp:578
+#: src/ExternalConn.cpp:579
 msgid "ERROR: couldn't accept a new external connection"
 msgstr "VIRHE: uutta etäyhteyttä ei voitu ottaa vastaan"
 
-#: src/ExternalConn.cpp:595
+#: src/ExternalConn.cpp:596
 msgid "External connection refused due to empty password in preferences!"
 msgstr "Etäyhteys torjuttu koska salasana on tyhjä asetuksissa!"
 
-#: src/ExternalConn.cpp:607
+#: src/ExternalConn.cpp:608
 #, c-format
 msgid "Connecting client: %s %s"
 msgstr "Yhdistän asiakkaaseen: %s %s"
 
-#: src/ExternalConn.cpp:609
+#: src/ExternalConn.cpp:610
 msgid "Unknown version"
 msgstr "Tuntematon versio"
 
-#: src/ExternalConn.cpp:622
+#: src/ExternalConn.cpp:623
 msgid "Incorrect EC version ID, there might be binary incompatibility. Use core and remote from same snapshot."
 msgstr "Epäkelpo etäversiotunniste, binäärinen epäyhteensopivuus on mahdollinen. Käytä ydintä ja etäpäätettä samasta vedoksesta."
 
-#: src/ExternalConn.cpp:630
+#: src/ExternalConn.cpp:631
 msgid "You cannot connect to a release version from an arbitrary development snapshot! *sigh* possible crash prevented"
 msgstr "Et voi yhdistää julkaisuversioon mielivaltaisella kehitysversiolla! *huoh* mahdollinen kaatuminen estetty"
 
-#: src/ExternalConn.cpp:713
+#: src/ExternalConn.cpp:714
 msgid "Invalid protocol version."
 msgstr "Väärä protokollaversio."
 
-#: src/ExternalConn.cpp:719
+#: src/ExternalConn.cpp:720
 msgid "Missing protocol version tag."
 msgstr "Puuttuva protokollan versiomerkintä."
 
-#: src/ExternalConn.cpp:727
+#: src/ExternalConn.cpp:728
 msgid "Authentication failed: invalid hash specified as EC password."
 msgstr "Tunnistautuminen epäonnistui: etäyhteyssalasanan tarkiste on väärin."
 
-#: src/ExternalConn.cpp:775
+#: src/ExternalConn.cpp:776
 msgid "Authentication failed: wrong password."
 msgstr "Tunnistautuminen epäonnistui: väärä salasana."
 
-#: src/ExternalConn.cpp:777
+#: src/ExternalConn.cpp:778
 msgid "Authentication failed: missing password."
 msgstr "Tunnistautuminen epäonnistui: salasana puuttui."
 
-#: src/ExternalConn.cpp:788
+#: src/ExternalConn.cpp:789
 msgid "Invalid request, please authenticate first."
 msgstr "Epäkelpo pyyntö, tunnistaudu ensin."
 
-#: src/ExternalConn.cpp:793
+#: src/ExternalConn.cpp:794
 msgid "Access granted."
 msgstr "Pääsy myönnetty."
 
-#: src/ExternalConn.cpp:801
+#: src/ExternalConn.cpp:802
 #, c-format
 msgid "Sent error message \"%s\" to client."
 msgstr "Virheilmoitus \"%s\" lähetetty asiakkaalle."
 
-#: src/ExternalConn.cpp:806
+#: src/ExternalConn.cpp:807
 #, c-format
 msgid "Unauthorized access attempt from %s. Connection closed."
 msgstr "Luvaton yhteysyritys osoitteesta %s. Yhteys suljettu."
 
-#: src/ExternalConn.cpp:1419
+#: src/ExternalConn.cpp:1420
 #, c-format
 msgid "Remote PartFile command failed: FileHash not found: %s"
 msgstr "Etäosatiedoston komento epäonnistui: Tiedostotarkistetta ei löytynyt: %s"
 
-#: src/ExternalConn.cpp:1423
+#: src/ExternalConn.cpp:1424
 #, c-format
 msgid "FileHash not found: %s"
 msgstr "Tiedostotarkistetta ei löytynyt: %s"
 
-#: src/ExternalConn.cpp:1470 src/ExternalConn.cpp:1558
-#: src/ExternalConn.cpp:1679
+#: src/ExternalConn.cpp:1471 src/ExternalConn.cpp:1559
+#: src/ExternalConn.cpp:1680
 msgid "OOPS! OpCode processing error!"
 msgstr "Hupsis! Komentosanan käsittelyvirhe!"
 
-#: src/ExternalConn.cpp:1501
+#: src/ExternalConn.cpp:1502
 msgid "Server not added"
 msgstr "Palvelinta ei lisätty"
 
-#: src/ExternalConn.cpp:1520
+#: src/ExternalConn.cpp:1521
 #, c-format
 msgid "server not found: %s"
 msgstr "palvelinta ei löytynyt: %s"
 
-#: src/ExternalConn.cpp:1537
+#: src/ExternalConn.cpp:1538
 msgid "need to define server to be removed"
 msgstr "poistettava palvelin on määriteltävä"
 
-#: src/ExternalConn.cpp:1552
+#: src/ExternalConn.cpp:1553
 msgid "eD2k is disabled in preferences."
 msgstr "eD2k on poistettu käytöstä asetuksissa."
 
-#: src/ExternalConn.cpp:1657
+#: src/ExternalConn.cpp:1658
 #, fuzzy
 msgid "Friend not found."
 msgstr "Tiedostoa ei löytynyt."
 
-#: src/ExternalConn.cpp:1667
+#: src/ExternalConn.cpp:1668
 #, fuzzy
 msgid "Client not found."
 msgstr "Tiedostoa ei löytynyt."
 
-#: src/ExternalConn.cpp:1673
+#: src/ExternalConn.cpp:1674
 msgid "EC_TAG_FRIEND_SHARED requires EC_TAG_FRIEND or EC_TAG_CLIENT."
 msgstr ""
 
-#: src/ExternalConn.cpp:1991
+#: src/ExternalConn.cpp:1992
 msgid "WebSearch from remote interface makes no sense."
 msgstr "Verkkohaku etäliittymästä ei ole mielekästä."
 
-#: src/ExternalConn.cpp:2026
+#: src/ExternalConn.cpp:2027
 msgid "Search in progress. Refetch results in a moment!"
 msgstr "Haku on käynnissä. Nouda tuloksia kohta uudelleen!"
 
-#: src/ExternalConn.cpp:2265
+#: src/ExternalConn.cpp:2266
 msgid "No points for graph."
 msgstr "Ei pisteitä kaavioon."
 
-#: src/ExternalConn.cpp:2275
+#: src/ExternalConn.cpp:2276
 msgid "Your client is not configured for this detail level."
 msgstr "Asiakasohjelmaasi ei ole asetettu tälle tarkkuustasolle."
 
-#: src/ExternalConn.cpp:2302
+#: src/ExternalConn.cpp:2303
 msgid "External Connection: shutdown requested"
 msgstr "Etäyhteys: sulkemista pyydetty"
 
-#: src/ExternalConn.cpp:2314
+#: src/ExternalConn.cpp:2315
 msgid "Already shutting down."
 msgstr "Sulkeminen on jo käynnissä."
 
-#: src/ExternalConn.cpp:2332
+#: src/ExternalConn.cpp:2333
 #, c-format
 msgid "ExternalConn: adding link '%s'."
 msgstr "Etäyhteys: lisään linkkiä '%s'."
 
-#: src/ExternalConn.cpp:2350
+#: src/ExternalConn.cpp:2351
 #, fuzzy, c-format
 msgid "%d of %d links failed (invalid or already on list)."
 msgstr "Virheellinen linkki tai se on jo listalla."
 
-#: src/ExternalConn.cpp:2373
+#: src/ExternalConn.cpp:2374
 msgid "Version check throttled; try again shortly."
 msgstr ""
 
-#: src/ExternalConn.cpp:2378
+#: src/ExternalConn.cpp:2379
 msgid "Version check is not available on this daemon."
 msgstr ""
 
-#: src/ExternalConn.cpp:2508
+#: src/ExternalConn.cpp:2509
 msgid "File not found."
 msgstr "Tiedostoa ei löytynyt."
 
-#: src/ExternalConn.cpp:2513
+#: src/ExternalConn.cpp:2514
 msgid "Invalid file name."
 msgstr "Epäkelpo tiedostonimi."
 
-#: src/ExternalConn.cpp:2521
+#: src/ExternalConn.cpp:2522
 msgid "Unable to rename file."
 msgstr "Tiedostoa ei voitu uudelleennimetä."
 
-#: src/ExternalConn.cpp:2992 src/ExternalConn.cpp:3020
+#: src/ExternalConn.cpp:2839
+#, c-format
+msgid "Could not save the amuleapi password: %s"
+msgstr ""
+
+#: src/ExternalConn.cpp:3004 src/ExternalConn.cpp:3032
 msgid "Kad is disabled in preferences."
 msgstr "Kad on poistettu päältä asetuksissa."
 
-#: src/ExternalConn.cpp:3033
+#: src/ExternalConn.cpp:3045
 msgid "Already connected to eD2k."
 msgstr "eD2k on jo yhdistetty."
 
-#: src/ExternalConn.cpp:3036
+#: src/ExternalConn.cpp:3048
 msgid "Connecting to eD2k..."
 msgstr "Yhdistetään eD2k..."
 
-#: src/ExternalConn.cpp:3045
+#: src/ExternalConn.cpp:3057
 msgid "Already connected to Kad."
 msgstr "Kad on jo yhdistetty."
 
-#: src/ExternalConn.cpp:3048
+#: src/ExternalConn.cpp:3060
 msgid "Connecting to Kad..."
 msgstr "Yhdistetään Kadiin..."
 
-#: src/ExternalConn.cpp:3055
+#: src/ExternalConn.cpp:3067
 msgid "All networks are disabled."
 msgstr "Kaikki verkot ovat pois päältä."
 
-#: src/ExternalConn.cpp:3064
+#: src/ExternalConn.cpp:3076
 msgid "Disconnected from eD2k."
 msgstr "eD2k-yhteys katkaistu"
 
-#: src/ExternalConn.cpp:3069
+#: src/ExternalConn.cpp:3081
 msgid "Disconnected from Kad."
 msgstr "Kad-yhteys katkaistu."
 
-#: src/ExternalConn.cpp:3078
+#: src/ExternalConn.cpp:3090
 #, c-format
 msgid "External Connection: invalid opcode received: %#x"
 msgstr "Etäyhteys: vastaanotettiin epäkelpo komentosana: %#x"
 
-#: src/ExternalConn.cpp:3083
+#: src/ExternalConn.cpp:3095
 msgid "Invalid opcode (wrong protocol version?)"
 msgstr "Epäkelpo komentosana (väärä protokollaversio?)"
 
@@ -2425,23 +2430,23 @@ msgid ""
 "want downloads on a different (e.g. larger) disk."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:549 src/FirstRunWizard.cpp:611 src/muuli_wdr.cpp:1708
+#: src/FirstRunWizard.cpp:549 src/FirstRunWizard.cpp:611 src/muuli_wdr.cpp:1712
 msgid "Destination folder for downloads"
 msgstr "Kansio ladatuille tiedostoille"
 
 #: src/FirstRunWizard.cpp:553 src/FirstRunWizard.cpp:569 src/muuli_wdr.cpp:1349
-#: src/muuli_wdr.cpp:1366 src/muuli_wdr.cpp:1683 src/muuli_wdr.cpp:1714
-#: src/muuli_wdr.cpp:1726 src/muuli_wdr.cpp:2769
+#: src/muuli_wdr.cpp:1366 src/muuli_wdr.cpp:1687 src/muuli_wdr.cpp:1718
+#: src/muuli_wdr.cpp:1730 src/muuli_wdr.cpp:2800
 #: src/utils/aLinkCreator/src/alcframe.cpp:135
 #: src/utils/wxCas/src/wxcasprefs.cpp:52 src/utils/wxCas/src/wxcasprefs.cpp:118
 msgid "Browse"
 msgstr "Selaa"
 
-#: src/FirstRunWizard.cpp:559 src/muuli_wdr.cpp:1719
+#: src/FirstRunWizard.cpp:559 src/muuli_wdr.cpp:1723
 msgid "(All files in this folder are shared with other peers)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:565 src/FirstRunWizard.cpp:624 src/muuli_wdr.cpp:1721
+#: src/FirstRunWizard.cpp:565 src/FirstRunWizard.cpp:624 src/muuli_wdr.cpp:1725
 msgid "Folder for temporary download files"
 msgstr "Kansio latauksen väliaikaisille tiedostoille"
 
@@ -2472,7 +2477,7 @@ msgstr "Kaverilistatiedostoa 'emfriends.met' ei saatu avattua kirjoitettavaksi!"
 msgid "CRITICAL - no client on StartChatSession"
 msgstr "KRIITTINEN - ei asiakasta keskustelun aloituksessa"
 
-#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2675 src/muuli_wdr.cpp:3352
+#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2706 src/muuli_wdr.cpp:3383
 msgid "Friends"
 msgstr "Kaverit"
 
@@ -2583,8 +2588,8 @@ msgstr "Ei yhtään"
 msgid "No"
 msgstr "Ei"
 
-#: src/GenericClientListCtrl.cpp:1216 src/PrefsUnifiedDlg.cpp:2818
-#: src/PrefsUnifiedDlg.cpp:2868 src/ServerListCtrl.cpp:276
+#: src/GenericClientListCtrl.cpp:1216 src/PrefsUnifiedDlg.cpp:2898
+#: src/PrefsUnifiedDlg.cpp:2948 src/ServerListCtrl.cpp:276
 msgid "Yes"
 msgstr "Kyllä"
 
@@ -2753,10 +2758,10 @@ msgstr "Portti ei kelpaa yhdistämisavuksi"
 msgid "Please fill all fields required"
 msgstr "Ole hyvä ja täytä kaikki vaaditut kentät"
 
-#: src/KadDlg.cpp:192 src/PartFile.cpp:1031 src/PrefsUnifiedDlg.cpp:1162
-#: src/PrefsUnifiedDlg.cpp:1331 src/PrefsUnifiedDlg.cpp:1589
-#: src/PrefsUnifiedDlg.cpp:1599 src/PrefsUnifiedDlg.cpp:1616
-#: src/PrefsUnifiedDlg.cpp:1658
+#: src/KadDlg.cpp:192 src/PartFile.cpp:1031 src/PrefsUnifiedDlg.cpp:1134
+#: src/PrefsUnifiedDlg.cpp:1204 src/PrefsUnifiedDlg.cpp:1405
+#: src/PrefsUnifiedDlg.cpp:1663 src/PrefsUnifiedDlg.cpp:1673
+#: src/PrefsUnifiedDlg.cpp:1690 src/PrefsUnifiedDlg.cpp:1738
 msgid "Message"
 msgstr "Viesti"
 
@@ -2858,7 +2863,7 @@ msgstr "Jakosuhde"
 msgid "Uploaded"
 msgstr "Lähetetty"
 
-#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3232
+#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3263
 msgid "Requested"
 msgstr "Pyydetty"
 
@@ -2982,7 +2987,7 @@ msgid "WARNING: "
 msgstr "VAROITUS: "
 
 #: src/MuleNotebook.cpp:179 src/muuli_wdr.cpp:817 src/muuli_wdr.cpp:1229
-#: src/muuli_wdr.cpp:3136 src/muuli_wdr.cpp:3392
+#: src/muuli_wdr.cpp:3167 src/muuli_wdr.cpp:3423
 msgid "Close"
 msgstr "Sulje"
 
@@ -3000,7 +3005,7 @@ msgid "Paste"
 msgstr "Liitä"
 
 #: src/MuleTextCtrl.cpp:89 src/muuli_wdr.cpp:358 src/muuli_wdr.cpp:757
-#: src/muuli_wdr.cpp:2359 src/muuli_wdr.cpp:2378 src/muuli_wdr.cpp:2400
+#: src/muuli_wdr.cpp:2390 src/muuli_wdr.cpp:2409 src/muuli_wdr.cpp:2431
 #: src/utils/aLinkCreator/src/alcframe.cpp:142
 msgid "Clear"
 msgstr "Pyyhi"
@@ -3099,7 +3104,7 @@ msgstr "Sulje"
 
 #: src/MuleTrayIcon.cpp:579 src/MuleTrayIcon.cpp:945 src/MuleTrayIcon.cpp:965
 #: src/muuli_wdr.cpp:1398 src/muuli_wdr.cpp:1406 src/muuli_wdr.cpp:1413
-#: src/muuli_wdr.cpp:1842 src/muuli_wdr.cpp:1848 src/OtherFunctions.cpp:91
+#: src/muuli_wdr.cpp:1846 src/muuli_wdr.cpp:1852 src/OtherFunctions.cpp:91
 #: src/StatisticsDlg.cpp:93 src/StatisticsDlg.cpp:95
 msgid "kB/s"
 msgstr "KB/s"
@@ -3341,7 +3346,7 @@ msgstr "Tavua"
 msgid "KB"
 msgstr "KB"
 
-#: src/muuli_wdr.cpp:274 src/muuli_wdr.cpp:293 src/muuli_wdr.cpp:1627
+#: src/muuli_wdr.cpp:274 src/muuli_wdr.cpp:293 src/muuli_wdr.cpp:1631
 #: src/OtherFunctions.cpp:64
 msgid "MB"
 msgstr "MB"
@@ -3358,7 +3363,7 @@ msgstr "Enimmäiskoko"
 msgid "Availability"
 msgstr "Saatavuus"
 
-#: src/muuli_wdr.cpp:312 src/muuli_wdr.cpp:398 src/muuli_wdr.cpp:3297
+#: src/muuli_wdr.cpp:312 src/muuli_wdr.cpp:398 src/muuli_wdr.cpp:3328
 msgid "Filter:"
 msgstr "Suodatin:"
 
@@ -3421,12 +3426,12 @@ msgstr "Tiedostolähteet:"
 #: src/muuli_wdr.cpp:1160 src/muuli_wdr.cpp:1167 src/muuli_wdr.cpp:1172
 #: src/muuli_wdr.cpp:1179 src/muuli_wdr.cpp:1184 src/muuli_wdr.cpp:1191
 #: src/muuli_wdr.cpp:1205 src/muuli_wdr.cpp:1212 src/muuli_wdr.cpp:1217
-#: src/muuli_wdr.cpp:1224 src/muuli_wdr.cpp:3234 src/muuli_wdr.cpp:3242
-#: src/muuli_wdr.cpp:3250
+#: src/muuli_wdr.cpp:1224 src/muuli_wdr.cpp:3265 src/muuli_wdr.cpp:3273
+#: src/muuli_wdr.cpp:3281
 msgid "N/A"
 msgstr "Ei saatavilla"
 
-#: src/muuli_wdr.cpp:508 src/muuli_wdr.cpp:1065 src/PrefsUnifiedDlg.cpp:297
+#: src/muuli_wdr.cpp:508 src/muuli_wdr.cpp:1065 src/PrefsUnifiedDlg.cpp:299
 msgid "General"
 msgstr "Yleiset"
 
@@ -3567,7 +3572,7 @@ msgstr ""
 msgid "Album :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:685 src/muuli_wdr.cpp:2254
+#: src/muuli_wdr.cpp:685 src/muuli_wdr.cpp:2285
 msgid "Title :"
 msgstr "Otsikko :"
 
@@ -3676,7 +3681,7 @@ msgstr "Käyttäjänimi :"
 msgid "Userhash :"
 msgstr "Käyttäjätarkiste :"
 
-#: src/muuli_wdr.cpp:895 src/muuli_wdr.cpp:1748 src/muuli_wdr.cpp:2449
+#: src/muuli_wdr.cpp:895 src/muuli_wdr.cpp:1752 src/muuli_wdr.cpp:2480
 #: src/utils/aLinkCreator/src/alcframe.cpp:137
 msgid "Add"
 msgstr "Lisää"
@@ -3685,15 +3690,15 @@ msgstr "Lisää"
 msgid "Download-Speed"
 msgstr "Latausnopeus"
 
-#: src/muuli_wdr.cpp:954 src/muuli_wdr.cpp:989 src/muuli_wdr.cpp:2553
+#: src/muuli_wdr.cpp:954 src/muuli_wdr.cpp:989 src/muuli_wdr.cpp:2584
 msgid "Current"
 msgstr "Nykyinen"
 
-#: src/muuli_wdr.cpp:962 src/muuli_wdr.cpp:997 src/muuli_wdr.cpp:2561
+#: src/muuli_wdr.cpp:962 src/muuli_wdr.cpp:997 src/muuli_wdr.cpp:2592
 msgid "Running average"
 msgstr "Yhtäjaksoinen keskiarvo"
 
-#: src/muuli_wdr.cpp:970 src/muuli_wdr.cpp:1005 src/muuli_wdr.cpp:2569
+#: src/muuli_wdr.cpp:970 src/muuli_wdr.cpp:1005 src/muuli_wdr.cpp:2600
 msgid "Session average"
 msgstr "Session keskiarvo"
 
@@ -3705,7 +3710,7 @@ msgstr "Lähetysnopeus"
 msgid "Connections"
 msgstr "Yhteydet"
 
-#: src/muuli_wdr.cpp:1024 src/muuli_wdr.cpp:1867
+#: src/muuli_wdr.cpp:1024 src/muuli_wdr.cpp:1871
 msgid "Active downloads"
 msgstr "Aktiiviset lataukset"
 
@@ -3713,7 +3718,7 @@ msgstr "Aktiiviset lataukset"
 msgid "Active connections (1:1)"
 msgstr "Aktiiviset yhteydet (1:1)"
 
-#: src/muuli_wdr.cpp:1040 src/muuli_wdr.cpp:1868
+#: src/muuli_wdr.cpp:1040 src/muuli_wdr.cpp:1872
 msgid "Active uploads"
 msgstr "Aktiiviset lähetykset"
 
@@ -3989,7 +3994,7 @@ msgstr "Sido paikallinen osoite IP:hen (tyhjä sallii mihin tahansa):"
 msgid "Advanced users only: If you have multiple network interfaces, enter the address of the interface to which aMule should be bound."
 msgstr "Vain edistyneille käyttäjille: mikäli sinulla on useampia verkkoliitäntöjä, syötä sen liitännän osoite johon haluat aMulen sidottavan."
 
-#: src/muuli_wdr.cpp:1462 src/muuli_wdr.cpp:2061
+#: src/muuli_wdr.cpp:1462 src/muuli_wdr.cpp:2065
 #, fuzzy
 msgid "Bind to network interface (empty for any):"
 msgstr "Sido paikallinen osoite IP:hen (tyhjä sallii mihin tahansa):"
@@ -4006,7 +4011,7 @@ msgstr "Lähteitä enintään tiedostoa kohden:"
 msgid "Max simultaneous connections:"
 msgstr "Yhtäaikaisten yhteyksien enimmäismäärä:"
 
-#: src/muuli_wdr.cpp:1498 src/muuli_wdr.cpp:3176
+#: src/muuli_wdr.cpp:1498 src/muuli_wdr.cpp:3207
 msgid "ED2K"
 msgstr "ED2K"
 
@@ -4098,755 +4103,778 @@ msgstr "Esivaraa levytila uusille tiedostoille"
 msgid "For new files preallocates disk space for the whole file, thus reduces fragmentation"
 msgstr "Uusia tiedostoja lisätessä varaa levytilaa koko tiedostolle, vähentää pirstaloitumista"
 
-#: src/muuli_wdr.cpp:1613
+#: src/muuli_wdr.cpp:1617
 msgid "Create new files as sparse files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1614
-msgid "A sparse file reserves its full size on disk immediately without writing real data to it -- fast, but unsupported or slow on some filesystems, and free-space accounting stays optimistic while the download is in progress. Turn this off to grow the file only as data arrives."
+#: src/muuli_wdr.cpp:1618
+msgid "Sparse part files only occupy disk space for the parts already downloaded, so free space is used up gradually as the file fills in. Turn this off to use an ordinary file instead - useful where sparse files are unsupported or slow, or where backup/de-duplication tools handle them badly. Applies only when the core runs on Windows; on Linux and macOS part files are sparse anyway and this setting has no effect."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1619
+#: src/muuli_wdr.cpp:1623
 msgid "Stop downloads when free disk space reaches "
 msgstr "Pysäytä lataukset kun tyhjän levytilan määrä saavuttaa "
 
-#: src/muuli_wdr.cpp:1620
+#: src/muuli_wdr.cpp:1624
 msgid "Select this if you want aMule to check your disk space"
 msgstr "Valitse tämä mikäli haluat aMulen tarkistavan vapaan levytilan määrän"
 
-#: src/muuli_wdr.cpp:1624
+#: src/muuli_wdr.cpp:1628
 msgid "Enter here the min disk space desired."
 msgstr "Syötä tähän levytila jonka haluat jättää vapaaksi."
 
-#: src/muuli_wdr.cpp:1630
+#: src/muuli_wdr.cpp:1634
 msgid "Save 10 sources on rare files (< 20 sources)"
 msgstr "Tallenna 10 lähdettä harvinaisille tiedostoille (< 20 lähdettä)"
 
-#: src/muuli_wdr.cpp:1634 src/Statistics.cpp:790
+#: src/muuli_wdr.cpp:1638 src/Statistics.cpp:790
 msgid "Uploads"
 msgstr "Lähetykset"
 
-#: src/muuli_wdr.cpp:1637
+#: src/muuli_wdr.cpp:1641
 msgid "Add new shared files with auto priority"
 msgstr "Lisää uudet jaetut tiedostot tärkeys automaattisella"
 
-#: src/muuli_wdr.cpp:1643
+#: src/muuli_wdr.cpp:1647
 msgid "Intelligent Corruption Handling (I.C.H.)"
 msgstr "Älykäs turmeltumien käsittely (I.C.H.)"
 
-#: src/muuli_wdr.cpp:1646
+#: src/muuli_wdr.cpp:1650
 msgid "Enable"
 msgstr "Käytä"
 
-#: src/muuli_wdr.cpp:1649
+#: src/muuli_wdr.cpp:1653
 msgid "Advanced I.C.H. trusts every hash (not recommended)"
 msgstr "Kehittynyt I.C.H. luottaa kaikkiin tarkisteisiin (ei suositella)"
 
-#: src/muuli_wdr.cpp:1661 src/PrefsUnifiedDlg.cpp:1910
+#: src/muuli_wdr.cpp:1665 src/PrefsUnifiedDlg.cpp:1990
 msgid "Media metadata extraction"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1665
+#: src/muuli_wdr.cpp:1669
 msgid "Extract length / bitrate / codec from shared audio and video files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1667
+#: src/muuli_wdr.cpp:1671
 msgid "When enabled, aMule runs ffprobe on each shared media file to fill in the Length / Bitrate / Codec columns other clients see when they find the file in a search. Requires ffmpeg (the ffprobe binary) to be installed."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1674
+#: src/muuli_wdr.cpp:1678
 msgid "Path to ffprobe:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1679
+#: src/muuli_wdr.cpp:1683
 msgid "Full path to the ffprobe binary. Leave empty to have aMule auto-detect it on startup."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1687
+#: src/muuli_wdr.cpp:1691
 msgid "Detect"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1688
+#: src/muuli_wdr.cpp:1692
 msgid "Search the standard install locations for an ffprobe binary and fill the path field."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1712
+#: src/muuli_wdr.cpp:1716
 msgid ""
 "Completed downloads are stored here. All files in this folder are automatically shared with other peers.\n"
 "If this folder also holds files you don't want to share, point it at an aMule-only sub-folder."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1715
+#: src/muuli_wdr.cpp:1719
 msgid "Pick the folder where completed downloads will be stored. All files in that folder will be shared with other peers."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1729
+#: src/muuli_wdr.cpp:1733
 msgid "Shared folders"
 msgstr "Jaetut kansiot"
 
-#: src/muuli_wdr.cpp:1735
+#: src/muuli_wdr.cpp:1739
 msgid "(Folders shared by the core. Enter a path to add one.)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1743
+#: src/muuli_wdr.cpp:1747
 msgid "Absolute path of a folder on the core's machine, e.g. /home/user/shared"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1745 src/PrefsUnifiedDlg.cpp:2794
+#: src/muuli_wdr.cpp:1749 src/PrefsUnifiedDlg.cpp:2874
 msgid "Recursive"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1746
+#: src/muuli_wdr.cpp:1750
 msgid "Share every sub-folder underneath this one, including ones created later."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1750 src/utils/aLinkCreator/src/alcframe.cpp:141
+#: src/muuli_wdr.cpp:1754 src/utils/aLinkCreator/src/alcframe.cpp:141
 msgid "Remove"
 msgstr "Poista"
 
-#: src/muuli_wdr.cpp:1754
+#: src/muuli_wdr.cpp:1758
 msgid "(Right click on folder icon for recursive share)"
 msgstr "(Klikkaa oikealla painikkeella kansion kuvaketta jakaaksesi rekursiivisesti)"
 
-#: src/muuli_wdr.cpp:1761
+#: src/muuli_wdr.cpp:1765
 msgid "Share hidden files"
 msgstr "Jaa piilotiedostot"
 
-#: src/muuli_wdr.cpp:1767
+#: src/muuli_wdr.cpp:1771
 msgid "Automatically rescan shared folders for changes"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1773
+#: src/muuli_wdr.cpp:1777
 msgid "Follow symbolic links in shared folders"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1779
+#: src/muuli_wdr.cpp:1783
 msgid "Exclude files matching:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1782
+#: src/muuli_wdr.cpp:1786
 msgid "Wildcard patterns separated by '|', e.g. .DS_Store|Thumbs.db|*.tmp. Files whose name matches are not shared. Matching is case-insensitive."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1786
+#: src/muuli_wdr.cpp:1790
 msgid "Patterns are regular expressions"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1787
+#: src/muuli_wdr.cpp:1791
 msgid "When set, the whole field is one regular expression ('|' is alternation). When unset, it is a list of '|'-separated wildcards."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1797
+#: src/muuli_wdr.cpp:1801
 msgid "Show how many shared files the current pattern would exclude."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1818
+#: src/muuli_wdr.cpp:1822
 msgid "Graphs"
 msgstr "Kuvaajat"
 
-#: src/muuli_wdr.cpp:1821 src/muuli_wdr.cpp:1883
+#: src/muuli_wdr.cpp:1825 src/muuli_wdr.cpp:1887
 msgid "Update delay : 5 secs"
 msgstr "Päivitysväli : 5 sekuntia"
 
-#: src/muuli_wdr.cpp:1825
+#: src/muuli_wdr.cpp:1829
 msgid "Time for average graph: 100 mins"
 msgstr "Keskimääräiskuvaajan aika: 100 minuuttia"
 
-#: src/muuli_wdr.cpp:1829
+#: src/muuli_wdr.cpp:1833
 msgid "Connections Graph Scale: 100 "
 msgstr "Yhteyskuvaajan Skaala: 100 "
 
-#: src/muuli_wdr.cpp:1836
+#: src/muuli_wdr.cpp:1840
 msgid "Download graph scale:"
 msgstr "Latauskuvaajan skaala:"
 
-#: src/muuli_wdr.cpp:1844
+#: src/muuli_wdr.cpp:1848
 msgid "Upload graph scale:"
 msgstr "Lähetyskuvaajan skaala:"
 
-#: src/muuli_wdr.cpp:1854
+#: src/muuli_wdr.cpp:1858
 #, fuzzy
 msgid "Colors: "
 msgstr "Värit: "
 
-#: src/muuli_wdr.cpp:1858
+#: src/muuli_wdr.cpp:1862
 msgid "Background"
 msgstr "Taustaväri"
 
-#: src/muuli_wdr.cpp:1859
+#: src/muuli_wdr.cpp:1863
 msgid "Grid"
 msgstr "Ruudukko"
 
-#: src/muuli_wdr.cpp:1860
+#: src/muuli_wdr.cpp:1864
 msgid "Download current"
 msgstr "Hetkittäinen lataus"
 
-#: src/muuli_wdr.cpp:1861
+#: src/muuli_wdr.cpp:1865
 msgid "Download running average"
 msgstr "Latauksen yhtäjaksoinen keskiarvo"
 
-#: src/muuli_wdr.cpp:1862
+#: src/muuli_wdr.cpp:1866
 msgid "Download session average"
 msgstr "Latauksen keskiarvo sessiossa"
 
-#: src/muuli_wdr.cpp:1863
+#: src/muuli_wdr.cpp:1867
 msgid "Upload current"
 msgstr "Hetkittäinen lähetys"
 
-#: src/muuli_wdr.cpp:1864
+#: src/muuli_wdr.cpp:1868
 msgid "Upload running average"
 msgstr "Lähetyksen yhtäjaksoinen keskiarvo"
 
-#: src/muuli_wdr.cpp:1865
+#: src/muuli_wdr.cpp:1869
 msgid "Upload session average"
 msgstr "Lähetyksen keskiarvo sessiossa"
 
-#: src/muuli_wdr.cpp:1866
+#: src/muuli_wdr.cpp:1870
 msgid "Active connections"
 msgstr "Aktiiviset yhteydet"
 
-#: src/muuli_wdr.cpp:1869
+#: src/muuli_wdr.cpp:1873
 #, fuzzy
 msgid "Systray Icon Speed Bar"
 msgstr "Järjestelmäpalkin nopeusnäyttö"
 
-#: src/muuli_wdr.cpp:1870
+#: src/muuli_wdr.cpp:1874
 msgid "Kad-nodes current"
 msgstr "Kad-yhteyksiä tällä hetkellä"
 
-#: src/muuli_wdr.cpp:1871
+#: src/muuli_wdr.cpp:1875
 msgid "Kad-nodes running"
 msgstr "Kad-yhteyksiä aktiivisena"
 
-#: src/muuli_wdr.cpp:1872
+#: src/muuli_wdr.cpp:1876
 msgid "Kad-nodes session"
 msgstr "Kad-yhteyksiä sessiossa"
 
-#: src/muuli_wdr.cpp:1876 src/muuli_wdr.cpp:2303
+#: src/muuli_wdr.cpp:1880 src/muuli_wdr.cpp:2334
 msgid "Select"
 msgstr "Valitse"
 
-#: src/muuli_wdr.cpp:1880
+#: src/muuli_wdr.cpp:1884
 msgid "Tree"
 msgstr "Puu"
 
-#: src/muuli_wdr.cpp:1890
+#: src/muuli_wdr.cpp:1894
 msgid "Number of Client Versions shown (0=unlimited)"
 msgstr "Näytettävien asiakasversioiden määrä (0=rajoittamattomasti)"
 
-#: src/muuli_wdr.cpp:1915
+#: src/muuli_wdr.cpp:1919
 msgid "!!! WARNING !!!"
 msgstr "!!! VAROITUS !!!"
 
-#: src/muuli_wdr.cpp:1930
+#: src/muuli_wdr.cpp:1934
 msgid "Max new connections / 5 secs"
 msgstr "Enimmäismäärä uusia yhteyksiä / 5 s"
 
-#: src/muuli_wdr.cpp:1932
+#: src/muuli_wdr.cpp:1936
 msgid "Concurrent Kad source lookups"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1934
+#: src/muuli_wdr.cpp:1938
 #, fuzzy
 msgid "Kad source re-search interval (minutes)"
 msgstr "FTP-päivityksien väli minuuteissa"
 
-#: src/muuli_wdr.cpp:1936
+#: src/muuli_wdr.cpp:1940
 #, fuzzy
 msgid "Source re-ask interval (minutes)"
 msgstr "FTP-päivityksien väli minuuteissa"
 
-#: src/muuli_wdr.cpp:1940
+#: src/muuli_wdr.cpp:1944
 msgid "File Buffer Size: 240000 bytes"
 msgstr "Tiedostopuskurin koko: 240000 tavua"
 
-#: src/muuli_wdr.cpp:1944
+#: src/muuli_wdr.cpp:1948
 msgid "Use MMAP: memory-mapped file access (lower memory use)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1945
+#: src/muuli_wdr.cpp:1949
 msgid "Maps part files into memory instead of buffering them on the heap, lowering the process memory footprint. May reduce download speed on some disks; best for memory-constrained or upload-heavy hosts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1947
+#: src/muuli_wdr.cpp:1951
 msgid "Upload Queue Size: 5000 clients"
 msgstr "Lähetysjonon koko: 5000 asiakasta"
 
-#: src/muuli_wdr.cpp:1951
+#: src/muuli_wdr.cpp:1955
 msgid "Server connection refresh interval: Disable"
 msgstr "Palvelinyhteyden päivitysväli: Poissa käytöstä"
 
-#: src/muuli_wdr.cpp:1955
+#: src/muuli_wdr.cpp:1959
 msgid "Disable computer's timed standby mode"
 msgstr "Poista käytöstä tietokoneen ajastettu siirtyminen valmiustilaan"
 
-#: src/muuli_wdr.cpp:1974
+#: src/muuli_wdr.cpp:1978
 msgid "Skin to use: "
 msgstr "Käytettävä teema: "
 
-#: src/muuli_wdr.cpp:1983
+#: src/muuli_wdr.cpp:1987
 msgid "Show \"Fast eD2k Links Handler\" in every window."
 msgstr "Näytä \"Nopea eD2k-linkkien käsittelijä\" jokaisessa ikkunassa."
 
-#: src/muuli_wdr.cpp:1986
+#: src/muuli_wdr.cpp:1990
 msgid "Show extended info on categories tabs"
 msgstr "Näytä laajennetut tiedot luokitteluvälilehdillä"
 
-#: src/muuli_wdr.cpp:1989
+#: src/muuli_wdr.cpp:1993
 msgid "Show application version on title"
 msgstr "Näytä sovelluksen versio otsikossa"
 
-#: src/muuli_wdr.cpp:1991
+#: src/muuli_wdr.cpp:1995
 msgid "Show transfer rates on title"
 msgstr "Näytä siirtonopeudet otsikossa"
 
-#: src/muuli_wdr.cpp:1993
+#: src/muuli_wdr.cpp:1997
 msgid "Before application name"
 msgstr "Ennen sovelluksen nimeä"
 
-#: src/muuli_wdr.cpp:1995
+#: src/muuli_wdr.cpp:1999
 msgid "After application name"
 msgstr "Sovelluksen nimen perässä"
 
-#: src/muuli_wdr.cpp:1998
+#: src/muuli_wdr.cpp:2002
 msgid "Show overhead bandwidth"
 msgstr "Näytä otsikkotietoihin kuluva kaista"
 
-#: src/muuli_wdr.cpp:2002
+#: src/muuli_wdr.cpp:2006
 msgid "Vertical toolbar orientation"
 msgstr "Pystysuuntainen työkalupalkki"
 
-#: src/muuli_wdr.cpp:2004
+#: src/muuli_wdr.cpp:2008
 msgid "Live column sorting (auto-reorder rows as their values change)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2011
+#: src/muuli_wdr.cpp:2015
 msgid "Download Queue Files"
 msgstr "Latausjonon tiedostot"
 
-#: src/muuli_wdr.cpp:2014
+#: src/muuli_wdr.cpp:2018
 msgid "Show progress percentage"
 msgstr "Näytä edistyminen prosentteina"
 
-#: src/muuli_wdr.cpp:2020
+#: src/muuli_wdr.cpp:2024
 msgid "Show progress bar"
 msgstr "Näytä edistymispalkki"
 
-#: src/muuli_wdr.cpp:2023
+#: src/muuli_wdr.cpp:2027
 msgid "Flat"
 msgstr "Tasainen"
 
-#: src/muuli_wdr.cpp:2027
+#: src/muuli_wdr.cpp:2031
 msgid "Round"
 msgstr "Pyöreä"
 
-#: src/muuli_wdr.cpp:2045
+#: src/muuli_wdr.cpp:2049
 msgid "External Connection Parameters"
 msgstr "Etäyhteyksien asetukset"
 
-#: src/muuli_wdr.cpp:2048
+#: src/muuli_wdr.cpp:2052
 msgid "Accept external connections"
 msgstr "Hyväksy etäyhteydet"
 
-#: src/muuli_wdr.cpp:2055 src/muuli_wdr.cpp:2114
+#: src/muuli_wdr.cpp:2059 src/muuli_wdr.cpp:2118
 msgid "IP of the listening interface:"
 msgstr "Kuunneltavan verkkoliitännän IP:"
 
-#: src/muuli_wdr.cpp:2058
+#: src/muuli_wdr.cpp:2062
 msgid "Enter here a valid ip in the a.b.c.d format for the listening EC interface. An empty field or 0.0.0.0 will mean any interface."
 msgstr "Syötä tähän sen verkkoliitännän ip jota kuunnellaan etäyhteyksiä varten. Tyhjä tai 0.0.0.0 tarkoittaa kaikkia verkkoliitäntöjä."
 
-#: src/muuli_wdr.cpp:2079 src/muuli_wdr.cpp:2163
+#: src/muuli_wdr.cpp:2083 src/muuli_wdr.cpp:2194
 msgid "TCP port:"
 msgstr "TCP-portti:"
 
-#: src/muuli_wdr.cpp:2085
+#: src/muuli_wdr.cpp:2089
 msgid "Enable UPnP port forwarding on the EC port"
 msgstr "Kytke päälle UPnP-portinohjaus etäyhteysportissa"
 
-#: src/muuli_wdr.cpp:2089 src/muuli_wdr.cpp:3048
+#: src/muuli_wdr.cpp:2093 src/muuli_wdr.cpp:3079
 #: src/utils/wxCas/src/wxcasprefs.cpp:167
 msgid "Password"
 msgstr "Salasana"
 
-#: src/muuli_wdr.cpp:2095
+#: src/muuli_wdr.cpp:2099
 #, fuzzy
 msgid "aMule API server parameters"
 msgstr "Web-palvelimen asetukset"
 
-#: src/muuli_wdr.cpp:2098
+#: src/muuli_wdr.cpp:2102
 msgid "Run amuleapi (REST API) on startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2103
+#: src/muuli_wdr.cpp:2107
 #, fuzzy
 msgid "HTTP port:"
 msgstr "TCP-portti:"
 
-#: src/muuli_wdr.cpp:2117
+#: src/muuli_wdr.cpp:2121
 msgid "The interface amuleapi's HTTP server listens on. 127.0.0.1 (default) accepts only local connections; use 0.0.0.0 or a specific IP to expose it to other hosts (set an admin password below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2120
+#: src/muuli_wdr.cpp:2126
+msgid "Type a password to set or change it. Stored passwords cannot be shown, so leaving this empty keeps the current one."
+msgstr ""
+
+#: src/muuli_wdr.cpp:2128
 #, fuzzy
 msgid "Admin password"
 msgstr "Tarkistaa salasanaa\n"
 
-#: src/muuli_wdr.cpp:2125 src/muuli_wdr.cpp:2156
-msgid "Low rights password"
-msgstr "Rajoitettujen oikeuksien salasana"
+#: src/muuli_wdr.cpp:2140 src/muuli_wdr.cpp:2157 src/PrefsUnifiedDlg.cpp:1103
+#, fuzzy
+msgid "A password is set."
+msgstr "Tarkistaa salasanaa\n"
 
-#: src/muuli_wdr.cpp:2133
+#: src/muuli_wdr.cpp:2144
+#, fuzzy
+msgid "Enable guest access"
+msgstr "Estä vieraskäyttö"
+
+#: src/muuli_wdr.cpp:2145
+msgid "Guest sessions may read status and listings but cannot change anything. Turning this off clears the stored guest password."
+msgstr ""
+
+#: src/muuli_wdr.cpp:2149
+#, fuzzy
+msgid "Guest password"
+msgstr "Vieraan salasana web-palvelimelle"
+
+#: src/muuli_wdr.cpp:2164
 msgid "Web server parameters"
 msgstr "Web-palvelimen asetukset"
 
-#: src/muuli_wdr.cpp:2136
+#: src/muuli_wdr.cpp:2167
 #, fuzzy
 msgid "Run webserver on startup (deprecated)"
 msgstr "Käynnistä web-palvelin käynnistettäessä"
 
-#: src/muuli_wdr.cpp:2142
+#: src/muuli_wdr.cpp:2173
 msgid "Web template"
 msgstr "Web-sapluuna"
 
-#: src/muuli_wdr.cpp:2147
+#: src/muuli_wdr.cpp:2178
 msgid "Full rights password"
 msgstr "Täysien oikeuksien salasana"
 
-#: src/muuli_wdr.cpp:2151
+#: src/muuli_wdr.cpp:2182
 msgid "Enable Low rights User"
 msgstr "Salli rajoitettujen oikeuksien käyttäjä"
 
-#: src/muuli_wdr.cpp:2170
+#: src/muuli_wdr.cpp:2187
+msgid "Low rights password"
+msgstr "Rajoitettujen oikeuksien salasana"
+
+#: src/muuli_wdr.cpp:2201
 msgid "Enable UPnP port forwarding of the web server port"
 msgstr "Käytä UPnP-portinohjausta web-palvelimen portissa"
 
-#: src/muuli_wdr.cpp:2175
+#: src/muuli_wdr.cpp:2206
 msgid "Web server UPnP TCP port (Optional)"
 msgstr "Web-palvelimen UPnP TCP-portti (Valinnainen)"
 
-#: src/muuli_wdr.cpp:2183
+#: src/muuli_wdr.cpp:2214
 msgid "Page Refresh Time (in secs)"
 msgstr "Sivun päivitysväli (sekunneissa)"
 
-#: src/muuli_wdr.cpp:2190
+#: src/muuli_wdr.cpp:2221
 msgid "Enable Gzip compression"
 msgstr "Salli gzip-pakkaus"
 
-#: src/muuli_wdr.cpp:2224
+#: src/muuli_wdr.cpp:2255
 #, fuzzy
 msgid "Reset page to defaults"
 msgstr "Järjestelmän vakio"
 
-#: src/muuli_wdr.cpp:2225
+#: src/muuli_wdr.cpp:2256
 msgid "Reset the settings on the current page to their default values."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2227 src/muuli_wdr.cpp:2313 src/ServerWnd.cpp:274
+#: src/muuli_wdr.cpp:2258 src/muuli_wdr.cpp:2344 src/ServerWnd.cpp:274
 #: src/ServerWnd.cpp:282
 msgid "OK"
 msgstr "OK"
 
-#: src/muuli_wdr.cpp:2229
+#: src/muuli_wdr.cpp:2260
 msgid "Click here to apply any changes made to the preferences."
 msgstr "Napsauta tästä saattaaksesi voimaan asetuksiin tehdyt muutokset."
 
-#: src/muuli_wdr.cpp:2232
+#: src/muuli_wdr.cpp:2263
 msgid "Reset any changes made to the preferences."
 msgstr "Nollaa asetuksiin tekemäsi muutokset."
 
-#: src/muuli_wdr.cpp:2261
+#: src/muuli_wdr.cpp:2292
 msgid "Comment :"
 msgstr "Kommentti :"
 
-#: src/muuli_wdr.cpp:2268
+#: src/muuli_wdr.cpp:2299
 msgid "Incoming Dir :"
 msgstr "Saapuvien kansio :"
 
-#: src/muuli_wdr.cpp:2277
+#: src/muuli_wdr.cpp:2308
 msgid "Change priority for new assigned files :"
 msgstr "Vaihda tärkeyttä uusille sijoitetuille tiedostoille :"
 
-#: src/muuli_wdr.cpp:2281
+#: src/muuli_wdr.cpp:2312
 msgid "Don't change"
 msgstr "Älä vaihda"
 
-#: src/muuli_wdr.cpp:2293
+#: src/muuli_wdr.cpp:2324
 msgid "Select color for this Category (currently selected) :"
 msgstr "Valitse väri tälle luokalle (valittuna) :"
 
-#: src/muuli_wdr.cpp:2360 src/muuli_wdr.cpp:2379 src/muuli_wdr.cpp:2401
+#: src/muuli_wdr.cpp:2391 src/muuli_wdr.cpp:2410 src/muuli_wdr.cpp:2432
 msgid "Click this button to reset the log."
 msgstr "Napsauta tätä painiketta nollataksesi lokin."
 
-#: src/muuli_wdr.cpp:2420
+#: src/muuli_wdr.cpp:2451
 msgid "Click on this button to update the servers list from URL ..."
 msgstr "Napsauta tätä nappia päivittääksesi palvelinlistan osoitteesta ..."
 
-#: src/muuli_wdr.cpp:2424
+#: src/muuli_wdr.cpp:2455
 msgid "Server list"
 msgstr "Palvelinlista"
 
-#: src/muuli_wdr.cpp:2428
+#: src/muuli_wdr.cpp:2459
 msgid "Enter the url to a server.met file here and press the button to the left to update the list of known servers."
 msgstr "Syötä tähän server.met-tiedostoon osoittava url ja paina nappia vasemmalla päivittääksesi tunnettujen palvelimien listan."
 
-#: src/muuli_wdr.cpp:2433
+#: src/muuli_wdr.cpp:2464
 msgid "Add server manually: Name"
 msgstr "Palvelimen lisäys käsin: Nimi"
 
-#: src/muuli_wdr.cpp:2436
+#: src/muuli_wdr.cpp:2467
 msgid "Enter the name of the new server here"
 msgstr "Syötä uuden palvelimen nimi tähän"
 
-#: src/muuli_wdr.cpp:2438 src/ServerWnd.cpp:206
+#: src/muuli_wdr.cpp:2469 src/ServerWnd.cpp:206
 msgid "IP:Port"
 msgstr "IP:Portti"
 
-#: src/muuli_wdr.cpp:2441
+#: src/muuli_wdr.cpp:2472
 msgid "Enter the IP of the server here, using the x.x.x.x format."
 msgstr "Syötä uuden palvelimen IP tähän, muodossa x.x.x.x."
 
-#: src/muuli_wdr.cpp:2447
+#: src/muuli_wdr.cpp:2478
 msgid "Enter the port of the server here."
 msgstr "Syötä palvelimen portti tähän."
 
-#: src/muuli_wdr.cpp:2450
+#: src/muuli_wdr.cpp:2481
 msgid "Add manually a server (fill fields to the left before) ..."
 msgstr "Lisää palvelin käsin (täytä vasemmalla olevat kentät) ..."
 
-#: src/muuli_wdr.cpp:2479
+#: src/muuli_wdr.cpp:2510
 msgid "aMule Log"
 msgstr "aMule loki"
 
-#: src/muuli_wdr.cpp:2487
+#: src/muuli_wdr.cpp:2518
 msgid "Server Info"
 msgstr "Palvelimen tiedot"
 
-#: src/muuli_wdr.cpp:2491
+#: src/muuli_wdr.cpp:2522
 msgid "ED2K Info"
 msgstr "ED2K Info"
 
-#: src/muuli_wdr.cpp:2495
+#: src/muuli_wdr.cpp:2526
 msgid "Kad Info"
 msgstr "Kad Info"
 
-#: src/muuli_wdr.cpp:2523
+#: src/muuli_wdr.cpp:2554
 msgid "Click on this button to update the nodes list from URL ..."
 msgstr "Napsauta tätä nappia päivittääksesi yhteyspisteiden listan osoitteesta ..."
 
-#: src/muuli_wdr.cpp:2527
+#: src/muuli_wdr.cpp:2558
 msgid "Nodes (0)"
 msgstr "Yhteyspisteitä (0)"
 
-#: src/muuli_wdr.cpp:2531
+#: src/muuli_wdr.cpp:2562
 msgid "Enter the url to a nodes.dat file here and press the button to the left to update the list of known nodes."
 msgstr "Syötä tähän nodes.dat-tiedostoon osoittava url ja paina nappia vasemmalla päivittääksesi tunnettujen yhteyspisteiden listan."
 
-#: src/muuli_wdr.cpp:2534
+#: src/muuli_wdr.cpp:2565
 msgid "Nodes stats"
 msgstr "Yhteyspisteiden tilastot"
 
-#: src/muuli_wdr.cpp:2576
+#: src/muuli_wdr.cpp:2607
 msgid "Bootstrap"
 msgstr "Yhdistämisapu"
 
-#: src/muuli_wdr.cpp:2579
+#: src/muuli_wdr.cpp:2610
 msgid "New node"
 msgstr "Uusi yhteyspiste"
 
-#: src/muuli_wdr.cpp:2584
+#: src/muuli_wdr.cpp:2615
 msgid "IP:"
 msgstr "IP:"
 
-#: src/muuli_wdr.cpp:2604
+#: src/muuli_wdr.cpp:2635
 msgid "Port:"
 msgstr "Portti:"
 
-#: src/muuli_wdr.cpp:2617
+#: src/muuli_wdr.cpp:2648
 msgid "Bootstrap from known clients"
 msgstr "Käytä tunnettuja asiakkaita yhdistämisapuna"
 
-#: src/muuli_wdr.cpp:2619
+#: src/muuli_wdr.cpp:2650
 msgid "Disconnect Kad"
 msgstr "Katkaise Kad-yhteys"
 
-#: src/muuli_wdr.cpp:2653
+#: src/muuli_wdr.cpp:2684
 msgid "Use Secure User Identification"
 msgstr "Käytä turvattua käyttäjän tunnistusta"
 
-#: src/muuli_wdr.cpp:2655
+#: src/muuli_wdr.cpp:2686
 msgid "It is recommended to enable this option. You will not receive credits if SUI is not enabled."
 msgstr "Tunnistuksen käyttö on suositeltavaa. Muuten et hyödy pistejärjestelmästä."
 
-#: src/muuli_wdr.cpp:2657
+#: src/muuli_wdr.cpp:2688
 msgid "Protocol Obfuscation"
 msgstr "Protokollan kätkeminen"
 
-#: src/muuli_wdr.cpp:2660
+#: src/muuli_wdr.cpp:2691
 msgid "Support Protocol Obfuscation"
 msgstr "Tuki protokollan kätkemiselle"
 
-#: src/muuli_wdr.cpp:2662
+#: src/muuli_wdr.cpp:2693
 msgid "This option enabled Protocol Obfuscation, and makes aMule accept obfuscated connections from other clients."
 msgstr "Tämä valinta sallii aMulen ottaa vastaan kätketyn protokollan yhteyksiä muilta asiakkailta."
 
-#: src/muuli_wdr.cpp:2664
+#: src/muuli_wdr.cpp:2695
 msgid "Use obfuscation for outgoing connections"
 msgstr "Käytä kätkemistä lähtevissä yhteyksissä"
 
-#: src/muuli_wdr.cpp:2666
+#: src/muuli_wdr.cpp:2697
 msgid "This option makes aMule use Protocol Obfuscation when connecting other clients/servers."
 msgstr "Tämä valittuna aMule käyttää protokollan kätkemistä ottaessaan yhteyttä muihin asiakkaisiin/palvelimiin."
 
-#: src/muuli_wdr.cpp:2668
+#: src/muuli_wdr.cpp:2699
 msgid "Accept only obfuscated connections"
 msgstr "Vastaanota vain kätkettyjä yhteyksiä"
 
-#: src/muuli_wdr.cpp:2669
+#: src/muuli_wdr.cpp:2700
 msgid "This option makes aMule only accept obfuscated connections. You will have less sources, but all your traffic will be obfuscated"
 msgstr "Tämä valittuna aMule hyväksyy vain kätketyt yhteydet. Lähteitä on vähemmän saatavilla mutta kaikki liikenteesi on kätketyllä protokollalla."
 
-#: src/muuli_wdr.cpp:2674
+#: src/muuli_wdr.cpp:2705
 msgid "Everybody"
 msgstr "Kaikki"
 
-#: src/muuli_wdr.cpp:2676
+#: src/muuli_wdr.cpp:2707
 msgid "No one"
 msgstr "Ei kukaan"
 
-#: src/muuli_wdr.cpp:2678
+#: src/muuli_wdr.cpp:2709
 msgid "Who can see my shared files:"
 msgstr "Ketkä voivat nähdä jaetut tiedostoni:"
 
-#: src/muuli_wdr.cpp:2679
+#: src/muuli_wdr.cpp:2710
 msgid "Select who can request to view a list of your shared files."
 msgstr "Valitse ketkä voivat pyytää nähtäville sinun jaettujen tiedostojen listaasi."
 
-#: src/muuli_wdr.cpp:2681
+#: src/muuli_wdr.cpp:2712
 msgid "IP-Filtering"
 msgstr "IP-suodatus"
 
-#: src/muuli_wdr.cpp:2688
+#: src/muuli_wdr.cpp:2719
 msgid "Filter clients"
 msgstr "Suodata asiakkaat"
 
-#: src/muuli_wdr.cpp:2690
+#: src/muuli_wdr.cpp:2721
 msgid "Enable filtering of the client IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "Salli asiakas-IP:den suodatus kuten määritelty tiedostossa ~/.aMule/ipfilter.dat."
 
-#: src/muuli_wdr.cpp:2692
+#: src/muuli_wdr.cpp:2723
 msgid "Filter servers"
 msgstr "Suodata palvelimet"
 
-#: src/muuli_wdr.cpp:2694
+#: src/muuli_wdr.cpp:2725
 msgid "Enable filtering of the server IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "Salli palvelin-IP:den suodatus kuten määritelty tiedostossa ~/.aMule/ipfilter.dat."
 
-#: src/muuli_wdr.cpp:2698
+#: src/muuli_wdr.cpp:2729
 msgid "Reload List"
 msgstr "Uudelleenlataa lista"
 
-#: src/muuli_wdr.cpp:2699
+#: src/muuli_wdr.cpp:2730
 msgid "Reload the list of IPs to filter from the file ~/.aMule/ipfilter.dat"
 msgstr "Uudelleenlataa suodatettavien IP:den lista tiedostosta ~/.aMule/ipfilter.dat."
 
-#: src/muuli_wdr.cpp:2705
+#: src/muuli_wdr.cpp:2736
 msgid "URL:"
 msgstr "URL:"
 
-#: src/muuli_wdr.cpp:2709 src/muuli_wdr.cpp:2902
+#: src/muuli_wdr.cpp:2740 src/muuli_wdr.cpp:2933
 msgid "Update now"
 msgstr "Päivitä nyt"
 
-#: src/muuli_wdr.cpp:2712
+#: src/muuli_wdr.cpp:2743
 msgid "Auto-update ipfilter at startup"
 msgstr "Päivitä ip-suodatus automaattisesti käynnistettäessä"
 
-#: src/muuli_wdr.cpp:2716
+#: src/muuli_wdr.cpp:2747
 msgid "Filtering Level:"
 msgstr "Suodatustaso:"
 
-#: src/muuli_wdr.cpp:2722
+#: src/muuli_wdr.cpp:2753
 msgid "Always filter LAN IPs"
 msgstr "Suodata aina lähiverkon IP:t"
 
-#: src/muuli_wdr.cpp:2725
+#: src/muuli_wdr.cpp:2756
 msgid "Paranoid handling of non-matching IPs"
 msgstr "Käsittele muut IP:t vainoharhaisesti"
 
-#: src/muuli_wdr.cpp:2727
+#: src/muuli_wdr.cpp:2758
 msgid "Rejects a packet when its source IP differs from the IP the client claims (an anti-spoofing check). Disable only if it causes connection problems."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2729
+#: src/muuli_wdr.cpp:2760
 msgid "Use system-wide ipfilter.dat if available"
 msgstr "Käytä järjestelmänlaajuista ipfilter.dat-tiedostoa mikäli saatavilla"
 
-#: src/muuli_wdr.cpp:2730
+#: src/muuli_wdr.cpp:2761
 #, fuzzy
 msgid "If there's no local ipfilter.dat found, allow usage of a system-wide ipfilter file."
 msgstr "Mikäli paikallista ipfilter.dat:ia ei löydy, käytetään järjestelmänlaajuista ipfilter.dat-tiedostoa."
 
-#: src/muuli_wdr.cpp:2747
+#: src/muuli_wdr.cpp:2778
 msgid "Enable Online-Signature"
 msgstr "Kytke Online-Signeeraus päälle"
 
-#: src/muuli_wdr.cpp:2749
+#: src/muuli_wdr.cpp:2780
 msgid "Enables the writing of the OS file, which can be used by external apps to create signatures and the like."
 msgstr "Kytkee päälle Online-Signeeraustiedoston kirjoittamisen, jota muut ohjelmat voivat käyttää esimerkiksi signeerauksissa."
 
-#: src/muuli_wdr.cpp:2753
+#: src/muuli_wdr.cpp:2784
 msgid "Update Frequency (Secs):"
 msgstr "Päivitysväli (sekuntia):"
 
-#: src/muuli_wdr.cpp:2756
+#: src/muuli_wdr.cpp:2787
 msgid "Change the frequency (in seconds) of Online Signature updates."
 msgstr "Muuttaa Online-Signeerauksen päivitysväliä, annetaan sekunteina."
 
-#: src/muuli_wdr.cpp:2764
+#: src/muuli_wdr.cpp:2795
 msgid "Save online signature file in: "
 msgstr "Online-signeeraus-tiedoston tallennuspaikka:"
 
-#: src/muuli_wdr.cpp:2770
+#: src/muuli_wdr.cpp:2801
 msgid "Click here to select the directory containing the the Online Signature files."
 msgstr "Napsauta tästä valitaksesi kansio Online-Signeerauksen tiedostoille."
 
-#: src/muuli_wdr.cpp:2803
+#: src/muuli_wdr.cpp:2834
 msgid "Show country flags for clients"
 msgstr "Näytä asiakkaiden valtioiden liput"
 
-#: src/muuli_wdr.cpp:2804
+#: src/muuli_wdr.cpp:2835
 msgid "Render the country flag column in the transfers, queue and search views. Requires a valid MMDB GeoIP database (see below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2809
+#: src/muuli_wdr.cpp:2840
 #, fuzzy
 msgid "Database"
 msgstr "Siirtonopeus :"
 
-#: src/muuli_wdr.cpp:2825
+#: src/muuli_wdr.cpp:2856
 #, fuzzy
 msgid "Source:"
 msgstr "Lähteet"
 
-#: src/muuli_wdr.cpp:2828
+#: src/muuli_wdr.cpp:2859
 msgid "DB-IP (free, no account)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2829
+#: src/muuli_wdr.cpp:2860
 msgid "MaxMind GeoLite2 (free, account required)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2830
+#: src/muuli_wdr.cpp:2861
 msgid "Custom URL"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2833
+#: src/muuli_wdr.cpp:2864
 msgid "Choose which provider supplies the GeoIP MMDB database. DB-IP is the default - no account required. MaxMind requires a free account + license key. Use Custom URL to point at any other MMDB host (e.g. a local mirror)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2850
+#: src/muuli_wdr.cpp:2881
 msgid ""
 "No configuration required.\n"
 "\n"
@@ -4854,11 +4882,11 @@ msgid ""
 "License: Creative Commons BY 4.0 - https://creativecommons.org/licenses/by/4.0/"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2863
+#: src/muuli_wdr.cpp:2894
 msgid "License key:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2869
+#: src/muuli_wdr.cpp:2900
 msgid ""
 "Sign up for a free MaxMind account, then generate a License Key:\n"
 "https://www.maxmind.com/en/geolite2/signup\n"
@@ -4868,226 +4896,226 @@ msgid ""
 "Requires attribution and account registration; refresh at least every 30 days."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2884
+#: src/muuli_wdr.cpp:2915
 #, fuzzy
 msgid "Download URL:"
 msgstr "Lataus: "
 
-#: src/muuli_wdr.cpp:2890
+#: src/muuli_wdr.cpp:2921
 msgid ""
 "Must point to an .mmdb file or a .gz / .tar.gz containing one.\n"
 "URL may include credentials (https://user:pass@host/...).\n"
 "License and attribution terms are set by the upstream URL - you are responsible."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2903
+#: src/muuli_wdr.cpp:2934
 msgid "Download the GeoIP database from the selected source."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2905
+#: src/muuli_wdr.cpp:2936
 #, fuzzy
 msgid "Auto-update on startup"
 msgstr "Päivitä ip-suodatus automaattisesti käynnistettäessä"
 
-#: src/muuli_wdr.cpp:2906
+#: src/muuli_wdr.cpp:2937
 msgid "Re-download the GeoIP database from the selected source every time aMule starts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2929
+#: src/muuli_wdr.cpp:2960
 msgid "Filter incoming messages (except current chat):"
 msgstr "Suodata saapuvat viestit (ei koske keskusteluja):"
 
-#: src/muuli_wdr.cpp:2931
+#: src/muuli_wdr.cpp:2962
 msgid "Filter all messages"
 msgstr "Suodata kaikki viestit"
 
-#: src/muuli_wdr.cpp:2933
+#: src/muuli_wdr.cpp:2964
 msgid "Filter messages from people not on your friend list"
 msgstr "Suodata viestit ihmisiltä jotka eivät ole kaverilistallasi"
 
-#: src/muuli_wdr.cpp:2935
+#: src/muuli_wdr.cpp:2966
 msgid "Filter messages from unknown clients"
 msgstr "Suodata viestit tuntemattomilta asiakkailta"
 
-#: src/muuli_wdr.cpp:2937
+#: src/muuli_wdr.cpp:2968
 msgid "Filter messages containing (use ',' as separator):"
 msgstr "Suodata viestit jotka sisältävät (käytä merkkiä ',' erottimena):"
 
-#: src/muuli_wdr.cpp:2940 src/muuli_wdr.cpp:2951
+#: src/muuli_wdr.cpp:2971 src/muuli_wdr.cpp:2982
 msgid "add here the words amule should filter and block messages including it"
 msgstr "Syötä tähän suodatettavat sanat ja aMule estää viestit jotka sisältävät sellaisen"
 
-#: src/muuli_wdr.cpp:2942
+#: src/muuli_wdr.cpp:2973
 msgid "Show received messages in the log"
 msgstr "Näytä vastaanotetut viestit lokissa"
 
-#: src/muuli_wdr.cpp:2945
+#: src/muuli_wdr.cpp:2976
 msgid "Comments"
 msgstr "Kommentit"
 
-#: src/muuli_wdr.cpp:2948
+#: src/muuli_wdr.cpp:2979
 msgid "Filter comments containing (use ',' as separator):"
 msgstr "Suodata kommentit jotka sisältävät (käytä merkkiä ',' erottimena):"
 
-#: src/muuli_wdr.cpp:2973
+#: src/muuli_wdr.cpp:3004
 msgid "Enable Proxy"
 msgstr "Käytä välityspalvelinta"
 
-#: src/muuli_wdr.cpp:2974
+#: src/muuli_wdr.cpp:3005
 msgid "Enable/disable proxy support"
 msgstr "Kytke päälle/pois välityspalvelimen tuki"
 
-#: src/muuli_wdr.cpp:2977
+#: src/muuli_wdr.cpp:3008
 msgid "Proxy type:"
 msgstr "Tyyppi:"
 
-#: src/muuli_wdr.cpp:2988
+#: src/muuli_wdr.cpp:3019
 msgid "Proxy host:"
 msgstr "Välityspalvelin:"
 
-#: src/muuli_wdr.cpp:2991
+#: src/muuli_wdr.cpp:3022
 msgid "The proxy host name"
 msgstr "Välityspalvelimen verkkonimi"
 
-#: src/muuli_wdr.cpp:2993
+#: src/muuli_wdr.cpp:3024
 msgid "Proxy port:"
 msgstr "Portti:"
 
-#: src/muuli_wdr.cpp:2996
+#: src/muuli_wdr.cpp:3027
 msgid "The proxy port"
 msgstr "Välityspalvelimen portti"
 
-#: src/muuli_wdr.cpp:2998
+#: src/muuli_wdr.cpp:3029
 msgid "Enable authentication"
 msgstr "Käytä tunnistautumista"
 
-#: src/muuli_wdr.cpp:2999
+#: src/muuli_wdr.cpp:3030
 msgid "Enable/disable username/password authentication"
 msgstr "Kytkee päälle/pois käyttäjänimellä/salasanalla tunnistautumisen"
 
-#: src/muuli_wdr.cpp:3002
+#: src/muuli_wdr.cpp:3033
 msgid "Username: "
 msgstr "Käyttäjänimi: "
 
-#: src/muuli_wdr.cpp:3005
+#: src/muuli_wdr.cpp:3036
 msgid "The username to use to connect to the proxy"
 msgstr "Käyttäjänimi tunnistautuessa välityspalvelimelle"
 
-#: src/muuli_wdr.cpp:3007
+#: src/muuli_wdr.cpp:3038
 msgid "Password:"
 msgstr "Salasana:"
 
-#: src/muuli_wdr.cpp:3010
+#: src/muuli_wdr.cpp:3041
 msgid "The password to use to connect to the proxy"
 msgstr "Salasana tunnistautuessa välityspalvelimelle"
 
-#: src/muuli_wdr.cpp:3029
+#: src/muuli_wdr.cpp:3060
 msgid "Connect to:"
 msgstr "Yhdistä:"
 
-#: src/muuli_wdr.cpp:3038
+#: src/muuli_wdr.cpp:3069
 msgid "Login to remote amule"
 msgstr "Kirjaudu etä-aMuleen"
 
-#: src/muuli_wdr.cpp:3043
+#: src/muuli_wdr.cpp:3074
 msgid "User name"
 msgstr "Käyttäjänimi"
 
-#: src/muuli_wdr.cpp:3054
+#: src/muuli_wdr.cpp:3085
 msgid "Remember those settings"
 msgstr "Muista nämä asetukset"
 
-#: src/muuli_wdr.cpp:3057
+#: src/muuli_wdr.cpp:3088
 #, fuzzy
 msgid "Force ZLIB compression"
 msgstr "Käytä gzip-pakkausta"
 
-#: src/muuli_wdr.cpp:3081
+#: src/muuli_wdr.cpp:3112
 msgid "Enable Verbose Debug-Logging."
 msgstr "Käytä monisanaista lokiin kirjausta."
 
-#: src/muuli_wdr.cpp:3083
+#: src/muuli_wdr.cpp:3114
 #, fuzzy
 msgid "Only to Logfile"
 msgstr "Avaa tied&osto"
 
-#: src/muuli_wdr.cpp:3085
+#: src/muuli_wdr.cpp:3116
 msgid "Message Categories:"
 msgstr "Viestien luokittelut:"
 
-#: src/muuli_wdr.cpp:3109 src/PartFileConvertDlg.cpp:160
+#: src/muuli_wdr.cpp:3140 src/PartFileConvertDlg.cpp:160
 msgid "Waiting..."
 msgstr "Odottaa..."
 
-#: src/muuli_wdr.cpp:3129
+#: src/muuli_wdr.cpp:3160
 msgid "Add imports"
 msgstr "Lisää tuonteja"
 
-#: src/muuli_wdr.cpp:3132
+#: src/muuli_wdr.cpp:3163
 msgid "Retry selected"
 msgstr "Yritä uudelleen valittuja"
 
-#: src/muuli_wdr.cpp:3134
+#: src/muuli_wdr.cpp:3165
 msgid "Remove selected"
 msgstr "Poista valitut"
 
-#: src/muuli_wdr.cpp:3197
+#: src/muuli_wdr.cpp:3228
 msgid "Event Types"
 msgstr "Tapahtumatyypit"
 
-#: src/muuli_wdr.cpp:3216
+#: src/muuli_wdr.cpp:3247
 msgid "Statistics and queued clients for selected file(s) : Session / All time"
 msgstr "Tilastot ja jonottavat asiakkaat valitu(i)lle tiedosto(i)lle: Sessiossa / Yhteensä"
 
-#: src/muuli_wdr.cpp:3240
+#: src/muuli_wdr.cpp:3271
 msgid "Active Uploads"
 msgstr "Aktiiviset lähetykset"
 
-#: src/muuli_wdr.cpp:3254
+#: src/muuli_wdr.cpp:3285
 msgid "Percent of total files"
 msgstr "Prosenttia kaikista tiedostoista"
 
-#: src/muuli_wdr.cpp:3306
+#: src/muuli_wdr.cpp:3337
 msgid "Show Clients for"
 msgstr "Näytä asiakkaat"
 
-#: src/muuli_wdr.cpp:3308
+#: src/muuli_wdr.cpp:3339
 msgid "All files"
 msgstr "Kaikki tiedostot"
 
-#: src/muuli_wdr.cpp:3311
+#: src/muuli_wdr.cpp:3342
 msgid "Selected files"
 msgstr "Valitut tiedostot"
 
-#: src/muuli_wdr.cpp:3314
+#: src/muuli_wdr.cpp:3345
 msgid "Active uploads only"
 msgstr "Vain aktiiviset lähetykset"
 
-#: src/muuli_wdr.cpp:3321
+#: src/muuli_wdr.cpp:3352
 msgid "Reload:"
 msgstr "Uudelleenlataa:"
 
-#: src/muuli_wdr.cpp:3325
+#: src/muuli_wdr.cpp:3356
 msgid "Reload your shared files"
 msgstr "Uudelleenlataa jaetut tiedostot"
 
-#: src/muuli_wdr.cpp:3388
+#: src/muuli_wdr.cpp:3419
 msgid "Send"
 msgstr "Lähetä"
 
-#: src/muuli_wdr.cpp:3389
+#: src/muuli_wdr.cpp:3420
 msgid "Sends the specified message."
 msgstr "Lähettää annetun viestin."
 
-#: src/muuli_wdr.cpp:3393
+#: src/muuli_wdr.cpp:3424
 msgid "Close this chat-session."
 msgstr "Sulje tämä keskustelu."
 
-#: src/muuli_wdr.cpp:3416
+#: src/muuli_wdr.cpp:3447
 msgid "Connect to any server and/or Kad"
 msgstr "Yhdistä mihin tahansa palvelimeen ja/tai Kadiin"
 
-#: src/muuli_wdr.cpp:3422 src/SharedFilesCtrl.cpp:142 src/Statistics.cpp:941
+#: src/muuli_wdr.cpp:3453 src/SharedFilesCtrl.cpp:142 src/Statistics.cpp:941
 msgid "Shared Files"
 msgstr "Jaetut tiedostot"
 
@@ -5446,249 +5474,249 @@ msgstr "Ladattu"
 msgid "ERROR: Failed to open partfile '%s'"
 msgstr "VIRHE: Ei voida avata osatiedostoa '%s'"
 
-#: src/Preferences.cpp:674
+#: src/Preferences.cpp:701
 msgid "System default"
 msgstr "Järjestelmän vakio"
 
-#: src/Preferences.cpp:675
+#: src/Preferences.cpp:702
 msgid "Albanian"
 msgstr "Albania"
 
-#: src/Preferences.cpp:676
+#: src/Preferences.cpp:703
 msgid "Arabic"
 msgstr "Arabia"
 
-#: src/Preferences.cpp:677
+#: src/Preferences.cpp:704
 msgid "Asturian"
 msgstr "Asturia"
 
-#: src/Preferences.cpp:678
+#: src/Preferences.cpp:705
 msgid "Basque"
 msgstr "Baski"
 
-#: src/Preferences.cpp:679
+#: src/Preferences.cpp:706
 msgid "Bulgarian"
 msgstr "Bulgaria"
 
-#: src/Preferences.cpp:680
+#: src/Preferences.cpp:707
 msgid "Catalan"
 msgstr "Katalaani"
 
-#: src/Preferences.cpp:681
+#: src/Preferences.cpp:708
 msgid "Chinese (Simplified)"
 msgstr "Kiina (Yksinkertaistettu)"
 
-#: src/Preferences.cpp:682
+#: src/Preferences.cpp:709
 msgid "Chinese (Traditional)"
 msgstr "Kiina (Perinteinen)"
 
-#: src/Preferences.cpp:683
+#: src/Preferences.cpp:710
 msgid "Croatian"
 msgstr "Kroatia"
 
-#: src/Preferences.cpp:684
+#: src/Preferences.cpp:711
 msgid "Czech"
 msgstr "Tsekki"
 
-#: src/Preferences.cpp:685
+#: src/Preferences.cpp:712
 msgid "Danish"
 msgstr "Tanska"
 
-#: src/Preferences.cpp:686
+#: src/Preferences.cpp:713
 msgid "Dutch"
 msgstr "Hollanti"
 
-#: src/Preferences.cpp:687
+#: src/Preferences.cpp:714
 msgid "English (U.K.)"
 msgstr "Englanti (U.K.)"
 
-#: src/Preferences.cpp:688
+#: src/Preferences.cpp:715
 #, fuzzy
 msgid "English (U.S.)"
 msgstr "Englanti (U.K.)"
 
-#: src/Preferences.cpp:689
+#: src/Preferences.cpp:716
 msgid "Estonian"
 msgstr "Viro"
 
-#: src/Preferences.cpp:690
+#: src/Preferences.cpp:717
 msgid "Finnish"
 msgstr "Suomi"
 
-#: src/Preferences.cpp:691
+#: src/Preferences.cpp:718
 msgid "French"
 msgstr "Ranska"
 
-#: src/Preferences.cpp:692
+#: src/Preferences.cpp:719
 msgid "Galician"
 msgstr "Galicia (Galego)"
 
-#: src/Preferences.cpp:693
+#: src/Preferences.cpp:720
 msgid "German"
 msgstr "Saksa"
 
-#: src/Preferences.cpp:694
+#: src/Preferences.cpp:721
 msgid "Greek"
 msgstr "Kreikka"
 
-#: src/Preferences.cpp:695
+#: src/Preferences.cpp:722
 msgid "Hebrew"
 msgstr "Heprea"
 
-#: src/Preferences.cpp:696
+#: src/Preferences.cpp:723
 msgid "Hungarian"
 msgstr "Unkari"
 
-#: src/Preferences.cpp:697
+#: src/Preferences.cpp:724
 msgid "Italian"
 msgstr "Italia"
 
-#: src/Preferences.cpp:698
+#: src/Preferences.cpp:725
 msgid "Japanese"
 msgstr "Japani"
 
-#: src/Preferences.cpp:699
+#: src/Preferences.cpp:726
 msgid "Korean"
 msgstr "Korea"
 
-#: src/Preferences.cpp:700
+#: src/Preferences.cpp:727
 msgid "Latvian"
 msgstr ""
 
-#: src/Preferences.cpp:701
+#: src/Preferences.cpp:728
 msgid "Lithuanian"
 msgstr "Liettua"
 
-#: src/Preferences.cpp:702
+#: src/Preferences.cpp:729
 msgid "Norwegian (Nynorsk)"
 msgstr "Norja (Nynorsk)"
 
-#: src/Preferences.cpp:703
+#: src/Preferences.cpp:730
 msgid "Polish"
 msgstr "Puola"
 
-#: src/Preferences.cpp:704
+#: src/Preferences.cpp:731
 msgid "Portuguese"
 msgstr "Portugali"
 
-#: src/Preferences.cpp:705
+#: src/Preferences.cpp:732
 msgid "Portuguese (Brazilian)"
 msgstr "Portugali (Brazilia)"
 
-#: src/Preferences.cpp:706
+#: src/Preferences.cpp:733
 msgid "Romanian"
 msgstr "Romanian"
 
-#: src/Preferences.cpp:707
+#: src/Preferences.cpp:734
 msgid "Russian"
 msgstr "Venäjä"
 
-#: src/Preferences.cpp:708
+#: src/Preferences.cpp:735
 msgid "Slovenian"
 msgstr "Slovenia"
 
-#: src/Preferences.cpp:709
+#: src/Preferences.cpp:736
 msgid "Spanish"
 msgstr "Espanja"
 
-#: src/Preferences.cpp:710
+#: src/Preferences.cpp:737
 msgid "Swedish"
 msgstr "Ruotsi"
 
-#: src/Preferences.cpp:711
+#: src/Preferences.cpp:738
 msgid "Turkish"
 msgstr "Turkki"
 
-#: src/Preferences.cpp:712
+#: src/Preferences.cpp:739
 msgid "Ukrainian"
 msgstr "Ukraina"
 
-#: src/Preferences.cpp:815
+#: src/Preferences.cpp:842
 msgid "Change Language"
 msgstr "Vaihda kieli"
 
-#: src/Preferences.cpp:879
+#: src/Preferences.cpp:906
 msgid "There are no translations installed for aMule"
 msgstr "Käännöksiä ei ole asennettuna aMulelle"
 
-#: src/Preferences.cpp:880
+#: src/Preferences.cpp:907
 msgid "No languages available"
 msgstr "Kieliä ei saatavilla"
 
-#: src/Preferences.cpp:1011
+#: src/Preferences.cpp:1038
 msgid "no options available"
 msgstr "vaihtoehtoja ei saatavilla"
 
-#: src/Preferences.cpp:2182
+#: src/Preferences.cpp:2227
 msgid "Invalid category found, skipping"
 msgstr "Löytyi epäkelpo luokka, hypätään yli"
 
-#: src/Preferences.cpp:2351
+#: src/Preferences.cpp:2396
 msgid "TCP port can't be higher than 65532 due to server UDP socket being TCP+3"
 msgstr "TCP-portti ei voi olla korkeampi kuin 65532 koska serverin käyttämä UDP-pistukka on TCP+3"
 
-#: src/Preferences.cpp:2352
+#: src/Preferences.cpp:2397
 #, c-format
 msgid "Default port will be used (%d)"
 msgstr "Käytetään oletusporttia (%d)"
 
-#: src/PrefsUnifiedDlg.cpp:298 src/Statistics.cpp:866
+#: src/PrefsUnifiedDlg.cpp:300 src/Statistics.cpp:866
 msgid "Connection"
 msgstr "Yhteys"
 
-#: src/PrefsUnifiedDlg.cpp:299 src/SearchListCtrl.cpp:117
+#: src/PrefsUnifiedDlg.cpp:301 src/SearchListCtrl.cpp:117
 msgid "Directories"
 msgstr "Kansiot"
 
-#: src/PrefsUnifiedDlg.cpp:300 src/Statistics.cpp:917
+#: src/PrefsUnifiedDlg.cpp:302 src/Statistics.cpp:917
 msgid "Servers"
 msgstr "Palvelimet"
 
-#: src/PrefsUnifiedDlg.cpp:301 src/ServerListCtrl.cpp:96
+#: src/PrefsUnifiedDlg.cpp:303 src/ServerListCtrl.cpp:96
 msgid "Files"
 msgstr "Tiedostot"
 
-#: src/PrefsUnifiedDlg.cpp:302
+#: src/PrefsUnifiedDlg.cpp:304
 msgid "Security"
 msgstr "Turvallisuus"
 
-#: src/PrefsUnifiedDlg.cpp:303
+#: src/PrefsUnifiedDlg.cpp:305
 msgid "Interface"
 msgstr "Käyttöliittymä"
 
-#: src/PrefsUnifiedDlg.cpp:310
+#: src/PrefsUnifiedDlg.cpp:312
 msgid "IP2Country"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:313
+#: src/PrefsUnifiedDlg.cpp:315
 msgid "Proxy"
 msgstr "Välityspalvelin"
 
-#: src/PrefsUnifiedDlg.cpp:314
+#: src/PrefsUnifiedDlg.cpp:316
 msgid "Filters"
 msgstr "Suodattimet"
 
-#: src/PrefsUnifiedDlg.cpp:315
+#: src/PrefsUnifiedDlg.cpp:317
 msgid "Remote Controls"
 msgstr "Etähallinta"
 
-#: src/PrefsUnifiedDlg.cpp:316
+#: src/PrefsUnifiedDlg.cpp:318
 msgid "Online Signature"
 msgstr "Online-Signeeraus"
 
-#: src/PrefsUnifiedDlg.cpp:317
+#: src/PrefsUnifiedDlg.cpp:319
 msgid "Advanced"
 msgstr "Laajennetut"
 
-#: src/PrefsUnifiedDlg.cpp:318
+#: src/PrefsUnifiedDlg.cpp:320
 msgid "Events"
 msgstr "Tapahtumat"
 
-#: src/PrefsUnifiedDlg.cpp:321
+#: src/PrefsUnifiedDlg.cpp:323
 msgid "Debugging"
 msgstr "Debuggaus"
 
-#: src/PrefsUnifiedDlg.cpp:451
+#: src/PrefsUnifiedDlg.cpp:453
 msgid ""
 "The following variables will be substituted:\n"
 "    %PARTFILE - full path to the file\n"
@@ -5698,15 +5726,15 @@ msgstr ""
 "    %PARTFILE - koko polku tiedostoon\n"
 "    %PARTNAME - pelkästään tiedoston nimi"
 
-#: src/PrefsUnifiedDlg.cpp:472
+#: src/PrefsUnifiedDlg.cpp:474
 msgid "Tray icon support requires libayatana-appindicator3 at compile time."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:488
+#: src/PrefsUnifiedDlg.cpp:490
 msgid "Not available on Wayland: the protocol does not report when a window is minimized, so this option cannot intercept the system minimize button. Workaround: launch aMule with `GDK_BACKEND=x11` to use XWayland instead."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:534
+#: src/PrefsUnifiedDlg.cpp:536
 msgid ""
 "Do not change these setting unless you know\n"
 "what you are doing, otherwise you can easily\n"
@@ -5722,26 +5750,35 @@ msgstr ""
 "aMule toimii hyvin vaikka näitä ei\n"
 "säädettäisikään."
 
-#: src/PrefsUnifiedDlg.cpp:645
+#: src/PrefsUnifiedDlg.cpp:647
 #, c-format
 msgid "Failed to connect Cfg to widget with the ID %d and key %s"
 msgstr "Asetuksen kytkeminen widgettiin epäonnistui ID:llä %d ja avaimella %s"
 
-#: src/PrefsUnifiedDlg.cpp:693
+#: src/PrefsUnifiedDlg.cpp:695
 #, c-format
 msgid "Failed to transfer data from Cfg to Widget with the ID %d and key %s"
 msgstr "Datan siirtäminen asetuksesta widgettiin epäonnistui ID:llä %d ja avaimella %s"
 
-#: src/PrefsUnifiedDlg.cpp:799
+#: src/PrefsUnifiedDlg.cpp:801
 msgid "The type of proxy you are connecting to"
 msgstr "Yhdistettävän välityspalvelimen tyyppi"
 
-#: src/PrefsUnifiedDlg.cpp:1003
+#: src/PrefsUnifiedDlg.cpp:1020
 #, c-format
 msgid "Failed to transfer data from Widget to Cfg with the ID %d and key %s"
 msgstr "Datan siirtäminen widgetistä asetukseen epäonnistui ID:llä %d ja avaimella %s"
 
 #: src/PrefsUnifiedDlg.cpp:1103
+#, fuzzy
+msgid "No password set."
+msgstr "Tarkistaa salasanaa\n"
+
+#: src/PrefsUnifiedDlg.cpp:1132
+msgid "Guest access needs a password. Type one in the guest password field, or untick Enable guest access."
+msgstr ""
+
+#: src/PrefsUnifiedDlg.cpp:1144
 msgid ""
 "aMule must be restarted to enable these changes:\n"
 "\n"
@@ -5749,42 +5786,42 @@ msgstr ""
 "aMule on käynnistettävä uudelleen näiden muutosten voimaansaattamiseksi:\n"
 "\n"
 
-#: src/PrefsUnifiedDlg.cpp:1110
+#: src/PrefsUnifiedDlg.cpp:1151
 msgid "- TCP port changed.\n"
 msgstr "- TCP-portti muuttui.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1115
+#: src/PrefsUnifiedDlg.cpp:1156
 msgid "- UDP port changed.\n"
 msgstr "- UDP-portti muuttui.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1120
+#: src/PrefsUnifiedDlg.cpp:1161
 #, fuzzy
 msgid "- Network interface binding changed.\n"
 msgstr "- Etäyhteyden sovitin muuttui.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1125
+#: src/PrefsUnifiedDlg.cpp:1166
 msgid "- External connect port changed.\n"
 msgstr "- Etäyhteyden portti vaihtui.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1129
+#: src/PrefsUnifiedDlg.cpp:1170
 msgid "- External connect acceptance changed.\n"
 msgstr "- Etäyhteyden vastaanotto muuttui.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1133
+#: src/PrefsUnifiedDlg.cpp:1174
 msgid "- External connect interface changed.\n"
 msgstr "- Etäyhteyden sovitin muuttui.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1137
+#: src/PrefsUnifiedDlg.cpp:1178
 #, fuzzy
 msgid "- Protocol obfuscation support changed.\n"
 msgstr "Protokollan kätkeminen"
 
-#: src/PrefsUnifiedDlg.cpp:1151
+#: src/PrefsUnifiedDlg.cpp:1193
 #, fuzzy
 msgid "- amuleapi settings changed.\n"
 msgstr "- Kieli vaihtui.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1160
+#: src/PrefsUnifiedDlg.cpp:1202
 msgid ""
 "Your Auto-update server list is empty.\n"
 "'Auto-update server list at startup' will be disabled."
@@ -5792,7 +5829,7 @@ msgstr ""
 "Palvelinlistan automaattisen päivityksen lista on tyhjä.\n"
 "'Päivitä palvelinlista käynnistettäessä' kytketään pois päältä."
 
-#: src/PrefsUnifiedDlg.cpp:1171
+#: src/PrefsUnifiedDlg.cpp:1213
 msgid ""
 "You have enabled external connections but have not specified a password.\n"
 "External connections cannot be enabled unless a valid password is specified."
@@ -5800,28 +5837,33 @@ msgstr ""
 "Olet sallinut etäyhteydet mutta et ole antanut salasanaa.\n"
 "Etäyhteydet eivät ole mahdollisia ellei salasanaa ole annettu."
 
-#: src/PrefsUnifiedDlg.cpp:1202
+#: src/PrefsUnifiedDlg.cpp:1246
+#, c-format
+msgid "The amuleapi password could not be saved: %s"
+msgstr ""
+
+#: src/PrefsUnifiedDlg.cpp:1276
 msgid "- Language changed.\n"
 msgstr "- Kieli vaihtui.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1207
+#: src/PrefsUnifiedDlg.cpp:1281
 msgid "- Temp folder changed.\n"
 msgstr "- Väliaikaiskansio muuttui.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1212
+#: src/PrefsUnifiedDlg.cpp:1286
 msgid "- ED2K network enabled.\n"
 msgstr "- ED2K-verkko käytössä.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1245
+#: src/PrefsUnifiedDlg.cpp:1319
 msgid "The shared-file exclusion pattern is not a valid regular expression. The filter has been left disabled."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1247 src/PrefsUnifiedDlg.cpp:1841
+#: src/PrefsUnifiedDlg.cpp:1321 src/PrefsUnifiedDlg.cpp:1921
 #, fuzzy
 msgid "Invalid regular expression"
 msgstr "Väärä protokollaversio."
 
-#: src/PrefsUnifiedDlg.cpp:1324
+#: src/PrefsUnifiedDlg.cpp:1398
 msgid ""
 "Both eD2k and Kad network are disabled.\n"
 "You won't be able to connect until you enable at least one of them."
@@ -5829,7 +5871,7 @@ msgstr ""
 "Sekä eD2k- että Kad-verkko on pois päältä.\n"
 "Et voi yhdistää ennen kuin ainakin toinen niistä on sallittu."
 
-#: src/PrefsUnifiedDlg.cpp:1329
+#: src/PrefsUnifiedDlg.cpp:1403
 msgid ""
 "Kad will not start if your UDP port is disabled.\n"
 "Enable UDP port or disable Kad."
@@ -5837,7 +5879,7 @@ msgstr ""
 "Kad ei käynnisty mikäli UDP-portti on pois päältä.\n"
 "Salli UDP-portti tai kytke Kad pois päältä."
 
-#: src/PrefsUnifiedDlg.cpp:1385
+#: src/PrefsUnifiedDlg.cpp:1459
 msgid ""
 "\n"
 "You MUST restart aMule now.\n"
@@ -5847,69 +5889,69 @@ msgstr ""
 "Sinun on uudelleenkäynnistettävä aMule nyt.\n"
 "Mikäli et uudelleenkäynnistä nyt, älä valita mikäli jotain pahaa tapahtuu.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1450
+#: src/PrefsUnifiedDlg.cpp:1524
 msgid "Could not register aMule for autostart at login. The autostart store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1452
+#: src/PrefsUnifiedDlg.cpp:1526
 msgid "Could not remove the autostart-at-login entry."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1453
+#: src/PrefsUnifiedDlg.cpp:1527
 #, fuzzy
 msgid "Autostart"
 msgstr "Automaattinen Päivitys aloitettu"
 
-#: src/PrefsUnifiedDlg.cpp:1468
+#: src/PrefsUnifiedDlg.cpp:1542
 msgid "Register file type"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1468
+#: src/PrefsUnifiedDlg.cpp:1542
 msgid "Register URL handler"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1476
+#: src/PrefsUnifiedDlg.cpp:1550
 #, c-format
 msgid "aMule only handles eD2k-compatible magnets. If you replace the current magnet handler (%s), BitTorrent magnet links will stop working - aMule cannot download BitTorrent content. Continue?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1481
+#: src/PrefsUnifiedDlg.cpp:1555
 #, c-format
 msgid "Another application currently opens .emulecollection files (%s). Replace it with aMule?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1486
+#: src/PrefsUnifiedDlg.cpp:1560
 #, c-format
 msgid "Another application is currently the default handler for these links (%s). Replace it with aMule?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1511
+#: src/PrefsUnifiedDlg.cpp:1585
 msgid "Could not register aMule for .emulecollection files. The registration store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1513
+#: src/PrefsUnifiedDlg.cpp:1587
 #, fuzzy
 msgid "Could not remove the file type registration."
 msgstr "Kansio latauksen väliaikaisille tiedostoille"
 
-#: src/PrefsUnifiedDlg.cpp:1515
+#: src/PrefsUnifiedDlg.cpp:1589
 msgid "Could not register aMule as the URL handler. The registration store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1517
+#: src/PrefsUnifiedDlg.cpp:1591
 msgid "Could not remove the URL handler registration."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1587 src/PrefsUnifiedDlg.cpp:1614
+#: src/PrefsUnifiedDlg.cpp:1661 src/PrefsUnifiedDlg.cpp:1688
 #, fuzzy
 msgid "The web server and aMule API require external connections to be enabled."
 msgstr "Salasana asetettu ja etäyhteydet sallittu."
 
-#: src/PrefsUnifiedDlg.cpp:1597
+#: src/PrefsUnifiedDlg.cpp:1671
 msgid "The aMule web server is deprecated. Consider running the aMule API instead."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1655
+#: src/PrefsUnifiedDlg.cpp:1735
 msgid ""
 "Your Auto-update servers list is in blank.\n"
 "Please fill in at least one URL to point to a valid server.met file.\n"
@@ -5919,66 +5961,66 @@ msgstr ""
 "Ole hyvä ja syötä ainakin yksi URL joka osoittaa käypään server.met-tiedostoon.\n"
 "Klikkaa nappia \"Lista\" tämän valintaruudun vierestä syöttääksesi URLin."
 
-#: src/PrefsUnifiedDlg.cpp:1796
+#: src/PrefsUnifiedDlg.cpp:1876
 msgid "Temporary files"
 msgstr "Väliaikaiset tiedostot"
 
-#: src/PrefsUnifiedDlg.cpp:1801
+#: src/PrefsUnifiedDlg.cpp:1881
 msgid "Incoming files"
 msgstr "Saapuvat tiedostot"
 
-#: src/PrefsUnifiedDlg.cpp:1806
+#: src/PrefsUnifiedDlg.cpp:1886
 msgid "Online Signatures"
 msgstr "Online-Signeeraukset"
 
-#: src/PrefsUnifiedDlg.cpp:1819
+#: src/PrefsUnifiedDlg.cpp:1899
 #, c-format
 msgid "Choose a folder for %s"
 msgstr "Valitse kansio kohteelle %s"
 
-#: src/PrefsUnifiedDlg.cpp:1843
+#: src/PrefsUnifiedDlg.cpp:1923
 #, fuzzy, c-format
 msgid "Would exclude %u of %u shared file"
 msgid_plural "Would exclude %u of %u shared files"
 msgstr[0] "Löydetty %i tunnettu jaettu tiedosto"
 msgstr[1] "Löydetty %i tunnettua jaettua tiedostoa"
 
-#: src/PrefsUnifiedDlg.cpp:1860
+#: src/PrefsUnifiedDlg.cpp:1940
 msgid "Browse for videoplayer"
 msgstr "Etsi videosoitin"
 
-#: src/PrefsUnifiedDlg.cpp:1864
+#: src/PrefsUnifiedDlg.cpp:1944
 msgid "Select browser"
 msgstr "Valitse selain"
 
-#: src/PrefsUnifiedDlg.cpp:1868
+#: src/PrefsUnifiedDlg.cpp:1948
 #, fuzzy
 msgid "Select ffprobe binary"
 msgstr "Valitse selain"
 
-#: src/PrefsUnifiedDlg.cpp:1874
+#: src/PrefsUnifiedDlg.cpp:1954
 #, c-format
 msgid "Executable%s"
 msgstr "Suoritettava tiedosto%s"
 
-#: src/PrefsUnifiedDlg.cpp:1908
+#: src/PrefsUnifiedDlg.cpp:1988
 msgid "ffprobe not found on PATH or in the standard install locations. Install ffmpeg (which ships ffprobe) or use Browse to pick a binary manually."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1920
+#: src/PrefsUnifiedDlg.cpp:2000
 msgid "Reset the settings on this page to their default values?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1921
+#: src/PrefsUnifiedDlg.cpp:2001
 #, fuzzy
 msgid "Reset to defaults"
 msgstr "Järjestelmän vakio"
 
-#: src/PrefsUnifiedDlg.cpp:1948
+#: src/PrefsUnifiedDlg.cpp:2028
 msgid "Edit server list"
 msgstr "Muokkaa palvelinlistaa"
 
-#: src/PrefsUnifiedDlg.cpp:1949
+#: src/PrefsUnifiedDlg.cpp:2029
 msgid ""
 "Add here URL's to download server.met files.\n"
 "Only one url on each line."
@@ -5986,154 +6028,154 @@ msgstr ""
 "Syötä tähän URLit joista server.met-tiedostot haetaan.\n"
 "Vain yksi urli riville."
 
-#: src/PrefsUnifiedDlg.cpp:2004
+#: src/PrefsUnifiedDlg.cpp:2084
 msgid "IP2Country update failed"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2149 src/PrefsUnifiedDlg.cpp:2180
+#: src/PrefsUnifiedDlg.cpp:2229 src/PrefsUnifiedDlg.cpp:2260
 msgid "Data by MaxMind GeoLite2"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2151 src/PrefsUnifiedDlg.cpp:2182
+#: src/PrefsUnifiedDlg.cpp:2231 src/PrefsUnifiedDlg.cpp:2262
 #, fuzzy
 msgid "Custom source"
 msgstr "Täysiä lähteitä"
 
-#: src/PrefsUnifiedDlg.cpp:2153 src/PrefsUnifiedDlg.cpp:2184
+#: src/PrefsUnifiedDlg.cpp:2233 src/PrefsUnifiedDlg.cpp:2264
 msgid "Data by DB-IP.com"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2204
+#: src/PrefsUnifiedDlg.cpp:2284
 #, fuzzy, c-format
 msgid "Status: Loaded%s"
 msgstr "Tila:"
 
-#: src/PrefsUnifiedDlg.cpp:2206
+#: src/PrefsUnifiedDlg.cpp:2286
 #, fuzzy, c-format
 msgid "Status: Loaded%s - %s"
 msgstr "Tila:"
 
-#: src/PrefsUnifiedDlg.cpp:2210
+#: src/PrefsUnifiedDlg.cpp:2290
 msgid "Status: Failed to load - click 'Update now' to refresh."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2212
+#: src/PrefsUnifiedDlg.cpp:2292
 msgid "Status: Not found - click 'Update now' to download."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2270 src/PrefsUnifiedDlg.cpp:2294
+#: src/PrefsUnifiedDlg.cpp:2350 src/PrefsUnifiedDlg.cpp:2374
 #, c-format
 msgid "Update delay: %d second"
 msgid_plural "Update delay: %d seconds"
 msgstr[0] "Päivitysväli: %d sekunti"
 msgstr[1] "Päivitysväli: %d sekuntia"
 
-#: src/PrefsUnifiedDlg.cpp:2278
+#: src/PrefsUnifiedDlg.cpp:2358
 #, c-format
 msgid "Time for average graph: %d minute"
 msgid_plural "Time for average graph: %d minutes"
 msgstr[0] "Keskimääräiskuvaajan aika: %d minuutti"
 msgstr[1] "Keskimääräiskuvaajan aika: %d minuuttia"
 
-#: src/PrefsUnifiedDlg.cpp:2287
+#: src/PrefsUnifiedDlg.cpp:2367
 #, c-format
 msgid "Connections Graph Scale: %d"
 msgstr "Yhteyskuvaajan skaala: %d"
 
-#: src/PrefsUnifiedDlg.cpp:2302
+#: src/PrefsUnifiedDlg.cpp:2382
 #, c-format
 msgid "File Buffer Size: %d byte"
 msgid_plural "File Buffer Size: %d bytes"
 msgstr[0] "Tiedostopuskurin koko: %d tavu"
 msgstr[1] "Tiedostopuskurin koko: %d tavua"
 
-#: src/PrefsUnifiedDlg.cpp:2312
+#: src/PrefsUnifiedDlg.cpp:2392
 #, c-format
 msgid "Upload Queue Size: %d client"
 msgid_plural "Upload Queue Size: %d clients"
 msgstr[0] "Lähetysjonon koko: %d asiakas"
 msgstr[1] "Lähetysjonon koko: %d asiakasta"
 
-#: src/PrefsUnifiedDlg.cpp:2322
+#: src/PrefsUnifiedDlg.cpp:2402
 #, c-format
 msgid "Server connection refresh interval: %d minute"
 msgid_plural "Server connection refresh interval: %d minutes"
 msgstr[0] "Palvelinyhteyden päivitysväli: %d minuutti"
 msgstr[1] "Palvelinyhteyden päivitysväli: %d minuuttia"
 
-#: src/PrefsUnifiedDlg.cpp:2327
+#: src/PrefsUnifiedDlg.cpp:2407
 msgid "Server connection refresh interval: Disabled"
 msgstr "Palvelinyhteyden päivitysväli: Ei käytössä"
 
-#: src/PrefsUnifiedDlg.cpp:2371
+#: src/PrefsUnifiedDlg.cpp:2451
 msgid "disabled"
 msgstr "poissa käytöstä"
 
-#: src/PrefsUnifiedDlg.cpp:2397
+#: src/PrefsUnifiedDlg.cpp:2477
 #, c-format
 msgid "Execute command on '%s' event"
 msgstr "Suorita komento tapahtuman '%s' yhteydessä"
 
-#: src/PrefsUnifiedDlg.cpp:2404
+#: src/PrefsUnifiedDlg.cpp:2484
 msgid "Enable command execution on core"
 msgstr "Mahdollista komentojen suorittaminen ytimestä"
 
-#: src/PrefsUnifiedDlg.cpp:2416
+#: src/PrefsUnifiedDlg.cpp:2496
 msgid "Core command:"
 msgstr "Ytimen komento:"
 
-#: src/PrefsUnifiedDlg.cpp:2432
+#: src/PrefsUnifiedDlg.cpp:2512
 msgid "Enable command execution on GUI"
 msgstr "Mahdollista komentojen suorittaminen graafisesta käyttöliittymästä"
 
-#: src/PrefsUnifiedDlg.cpp:2444
+#: src/PrefsUnifiedDlg.cpp:2524
 msgid "GUI command:"
 msgstr "Graafisen käyttöliittymän komento:"
 
-#: src/PrefsUnifiedDlg.cpp:2460
+#: src/PrefsUnifiedDlg.cpp:2540
 msgid "The following variables will be replaced:"
 msgstr "Seuraavat muuttujat korvataan:"
 
-#: src/PrefsUnifiedDlg.cpp:2628
+#: src/PrefsUnifiedDlg.cpp:2708
 msgid ""
 "The following folders look like system or sensitive locations:\n"
 "\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2633
+#: src/PrefsUnifiedDlg.cpp:2713
 msgid "Sharing them recursively will publish every file underneath on the eD2k/Kad networks. Do you really want to do this?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2636
+#: src/PrefsUnifiedDlg.cpp:2716
 #, fuzzy
 msgid "Confirm shared folders"
 msgstr "Jaetut kansiot"
 
-#: src/PrefsUnifiedDlg.cpp:2664
+#: src/PrefsUnifiedDlg.cpp:2744
 #, fuzzy
 msgid "Reloading shared files..."
 msgstr "Uudelleenlataa jaetut tiedostot"
 
-#: src/PrefsUnifiedDlg.cpp:2665
+#: src/PrefsUnifiedDlg.cpp:2745
 msgid "Scanning for subdirectories..."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2666
+#: src/PrefsUnifiedDlg.cpp:2746
 #, fuzzy
 msgid "Updating shared folders"
 msgstr "Jaetut kansiot"
 
-#: src/PrefsUnifiedDlg.cpp:2693
+#: src/PrefsUnifiedDlg.cpp:2773
 #, c-format
 msgid "Scanned %u directories..."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2743
+#: src/PrefsUnifiedDlg.cpp:2823
 #, fuzzy, c-format
 msgid "Reloading shared files: %u files scanned"
 msgstr "Lataa uudelleen lista jaetuista tiedostoista."
 
-#: src/PrefsUnifiedDlg.cpp:2793
+#: src/PrefsUnifiedDlg.cpp:2873
 #, fuzzy
 msgid "Shared folder"
 msgstr "Jaetut kansiot"

--- a/po/fi.po
+++ b/po/fi.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-28 08:06+0200\n"
+"POT-Creation-Date: 2026-07-28 10:19+0200\n"
 "PO-Revision-Date: 2026-07-27 11:37+0000\n"
 "Last-Translator: Tapio Rantala <tapio.rantala@iki.fi>\n"
 "Language-Team: aMule Team <https://github.com/amule-org/amule>\n"
@@ -146,7 +146,7 @@ msgstr ""
 msgid "Not now"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:422 src/amuleDlg.cpp:600
+#: src/AppImageIntegration.cpp:422 src/amuleDlg.cpp:665
 msgid "Don't ask again"
 msgstr ""
 
@@ -219,7 +219,7 @@ msgid "Killing amuleweb instance with pid '%d' ... "
 msgstr "Tuhotaan amulewebin instanssi prosessinumerolla '%d' ... "
 
 #: src/amule.cpp:336 src/amule.cpp:349 src/ClientRef.cpp:180
-#: src/SearchDlg.cpp:880 src/ServerListCtrl.cpp:98
+#: src/SearchDlg.cpp:1041 src/ServerListCtrl.cpp:98
 msgid "Failed"
 msgstr "Epäonnistunut"
 
@@ -575,30 +575,68 @@ msgstr "Ei voitu luoda prosessinumerotiedostoa"
 msgid "ERROR: %s"
 msgstr "VIRHE: %s"
 
-#: src/amuleDlg.cpp:236
+#: src/amuleDlg.cpp:250
 #, c-format
 msgid "This is aMule %s based on eMule."
 msgstr "Tämä on aMule %s ja pohjautuu eMuleen."
 
-#: src/amuleDlg.cpp:237
+#: src/amuleDlg.cpp:251
 #, c-format
 msgid "Running on %s"
 msgstr "Käynnissä %s"
 
-#: src/amuleDlg.cpp:239
+#: src/amuleDlg.cpp:253
 msgid "Visit https://github.com/amule-org/amule/releases/latest to check if a new version is available."
 msgstr "Vieraile nettisivulla https://github.com/amule-org/amule/releases/latest tarkistaaksi uuden version saatavuuden."
 
-#: src/amuleDlg.cpp:268
+#: src/amuleDlg.cpp:282
 msgid "FATAL ERROR: Failed to create Timer"
 msgstr "KRIITTINEN VIRHE: Ajastimen luominen epäonnistui"
 
-#: src/amuleDlg.cpp:592
+#: src/amuleDlg.cpp:361 src/amuleDlg.cpp:1787 src/amuleDlg.cpp:2033
+#: src/muuli_wdr.cpp:1492 src/muuli_wdr.cpp:3418
+msgid "Networks"
+msgstr "Verkot"
+
+#: src/amuleDlg.cpp:362 src/amuleDlg.cpp:1793 src/muuli_wdr.cpp:3419
+msgid "Searches"
+msgstr "Haut"
+
+#: src/amuleDlg.cpp:363 src/amuleDlg.cpp:1799 src/DownloadListCtrl.cpp:740
+#: src/muuli_wdr.cpp:392 src/muuli_wdr.cpp:1585 src/muuli_wdr.cpp:3420
+#: src/Statistics.cpp:829
+msgid "Downloads"
+msgstr "Lataukset"
+
+#: src/amuleDlg.cpp:364 src/amuleDlg.cpp:1805 src/muuli_wdr.cpp:3294
+msgid "Shared files"
+msgstr "Jaetut tiedostot"
+
+#: src/amuleDlg.cpp:365 src/amuleDlg.cpp:1811 src/muuli_wdr.cpp:2926
+#: src/muuli_wdr.cpp:3376 src/muuli_wdr.cpp:3423
+msgid "Messages"
+msgstr "Viestit"
+
+#: src/amuleDlg.cpp:366 src/amuleDlg.cpp:1817 src/muuli_wdr.cpp:3424
+#: src/PrefsUnifiedDlg.cpp:312 src/Statistics.cpp:779 src/Statistics.cpp:1235
+msgid "Statistics"
+msgstr "Tilastot"
+
+#: src/amuleDlg.cpp:368 src/amuleDlg.cpp:1824 src/muuli_wdr.cpp:3426
+#: src/PrefsUnifiedDlg.cpp:328 src/utils/wxCas/src/wxcasprefs.cpp:39
+msgid "Preferences"
+msgstr "Asetukset"
+
+#: src/amuleDlg.cpp:371
+msgid "Navigate"
+msgstr ""
+
+#: src/amuleDlg.cpp:657
 #, fuzzy
 msgid "New version available"
 msgstr "Ei saatavissa"
 
-#: src/amuleDlg.cpp:596
+#: src/amuleDlg.cpp:661
 #, fuzzy, c-format
 msgid ""
 "A new version of aMule (%s) is available.\n"
@@ -608,218 +646,185 @@ msgid ""
 "Would you like to open the download page?"
 msgstr "Uusin version löytyy aina osoitteesta https://github.com/amule-org/amule/releases/latest"
 
-#: src/amuleDlg.cpp:678
+#: src/amuleDlg.cpp:743
 msgid "aMule dialog destroyed"
 msgstr "aMulen dialogi tuhottu"
 
-#: src/amuleDlg.cpp:701 src/DataToText.cpp:68 src/IPFilter.cpp:547
+#: src/amuleDlg.cpp:766 src/DataToText.cpp:68 src/IPFilter.cpp:547
 msgid "Connecting"
 msgstr "Yhdistetään"
 
-#: src/amuleDlg.cpp:893
+#: src/amuleDlg.cpp:958
 msgid "eD2k: Connecting"
 msgstr "eD2k: Yhdistetään"
 
-#: src/amuleDlg.cpp:897
+#: src/amuleDlg.cpp:962
 msgid "eD2k: Disconnected"
 msgstr "eD2k: Ei yhdistetty"
 
-#: src/amuleDlg.cpp:903
+#: src/amuleDlg.cpp:968
 msgid "Kad: Firewalled"
 msgstr "Kad: Palomuurattu"
 
-#: src/amuleDlg.cpp:907
+#: src/amuleDlg.cpp:972
 msgid "Kad: Connected"
 msgstr "Kad: Yhdistety"
 
-#: src/amuleDlg.cpp:912
+#: src/amuleDlg.cpp:977
 msgid "Kad: Connecting"
 msgstr "Kad: Yhdistetään"
 
-#: src/amuleDlg.cpp:916
+#: src/amuleDlg.cpp:981
 msgid "Kad: Off"
 msgstr "Kad: Pois päältä"
 
-#: src/amuleDlg.cpp:964 src/DownloadListCtrl.cpp:505
+#: src/amuleDlg.cpp:1029 src/DownloadListCtrl.cpp:505
 #: src/DownloadListCtrl.cpp:749 src/FriendListCtrl.cpp:180
 #: src/muuli_wdr.cpp:731 src/muuli_wdr.cpp:782 src/muuli_wdr.cpp:846
-#: src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2224 src/muuli_wdr.cpp:2309
-#: src/muuli_wdr.cpp:3057 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
+#: src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2231 src/muuli_wdr.cpp:2316
+#: src/muuli_wdr.cpp:3064 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
 #: src/ServerListCtrl.cpp:606 src/TransferWnd.cpp:378
 #: src/utils/wxCas/src/wxcasprefs.cpp:235
 msgid "Cancel"
 msgstr "Peruuta"
 
-#: src/amuleDlg.cpp:965
+#: src/amuleDlg.cpp:1030
 msgid "Stop the current connection attempts"
 msgstr "Pysäytä nykyiset yhteysyritykset"
 
-#: src/amuleDlg.cpp:970 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976
-#: src/muuli_wdr.cpp:2447
+#: src/amuleDlg.cpp:1035 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976
+#: src/muuli_wdr.cpp:2454
 msgid "Disconnect"
 msgstr "Katkaise yhteys"
 
-#: src/amuleDlg.cpp:971
+#: src/amuleDlg.cpp:1036
 msgid "Disconnect from the currently connected networks"
 msgstr "Katkaise yhteys yhdistettyihin verkkoihin"
 
-#: src/amuleDlg.cpp:976 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979
-#: src/muuli_wdr.cpp:2602 src/muuli_wdr.cpp:3054 src/muuli_wdr.cpp:3409
+#: src/amuleDlg.cpp:1041 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979
+#: src/muuli_wdr.cpp:2609 src/muuli_wdr.cpp:3061 src/muuli_wdr.cpp:3416
 msgid "Connect"
 msgstr "Yhdistä"
 
-#: src/amuleDlg.cpp:977
+#: src/amuleDlg.cpp:1042
 msgid "Connect to the currently enabled networks"
 msgstr "Yhdistä sallittuihin verkkoihin"
 
-#: src/amuleDlg.cpp:1089
+#: src/amuleDlg.cpp:1154
 #, fuzzy, c-format
 msgid "Up: %.1f%s (%.1f) | Down: %.1f%s (%.1f)"
 msgstr "Ylös: %.1f(%.1f) | Alas: %.1f(%.1f)"
 
-#: src/amuleDlg.cpp:1091 src/amuleDlg.cpp:1093 src/amuleDlg.cpp:1097
-#: src/amuleDlg.cpp:1099 src/amuleDlg.cpp:1110 src/amuleDlg.cpp:1112
+#: src/amuleDlg.cpp:1156 src/amuleDlg.cpp:1158 src/amuleDlg.cpp:1162
+#: src/amuleDlg.cpp:1164 src/amuleDlg.cpp:1175 src/amuleDlg.cpp:1177
 #: src/MuleTrayIcon.cpp:796 src/MuleTrayIcon.cpp:799
 #, fuzzy
 msgid " MB/s"
 msgstr "MB/s"
 
-#: src/amuleDlg.cpp:1091 src/amuleDlg.cpp:1093 src/amuleDlg.cpp:1097
-#: src/amuleDlg.cpp:1099 src/amuleDlg.cpp:1110 src/amuleDlg.cpp:1112
+#: src/amuleDlg.cpp:1156 src/amuleDlg.cpp:1158 src/amuleDlg.cpp:1162
+#: src/amuleDlg.cpp:1164 src/amuleDlg.cpp:1175 src/amuleDlg.cpp:1177
 #: src/MuleTrayIcon.cpp:796 src/MuleTrayIcon.cpp:799
 #: src/utils/wxCas/src/wxcasframe.cpp:1041
 msgid " kB/s"
 msgstr " KB/s"
 
-#: src/amuleDlg.cpp:1096
+#: src/amuleDlg.cpp:1161
 #, fuzzy, c-format
 msgid "Up: %.1f%s | Down: %.1f%s"
 msgstr "Ylös: %.1f | Alas: %.1f"
 
-#: src/amuleDlg.cpp:1128
+#: src/amuleDlg.cpp:1193
 #, c-format
 msgid "aMule (%s | Connected)"
 msgstr "aMule (%s | Yhdistetty)"
 
-#: src/amuleDlg.cpp:1130
+#: src/amuleDlg.cpp:1195
 #, c-format
 msgid "aMule (%s | Disconnected)"
 msgstr "aMule (%s | Ei yhdistetty)"
 
-#: src/amuleDlg.cpp:1183
+#: src/amuleDlg.cpp:1248
 #, c-format
 msgid "Do you really want to exit %s?"
 msgstr "Haluatko varmasti sulkea %sn?"
 
-#: src/amuleDlg.cpp:1185
+#: src/amuleDlg.cpp:1250
 msgid "Exit confirmation"
 msgstr "Lopettamisen varmistus"
 
-#: src/amuleDlg.cpp:1548
+#: src/amuleDlg.cpp:1613
 msgid "Launch Command: "
 msgstr "Suorita komento: "
 
-#: src/amuleDlg.cpp:1567 src/muuli_wdr.cpp:1971 src/Preferences.cpp:951
+#: src/amuleDlg.cpp:1632 src/muuli_wdr.cpp:1978 src/Preferences.cpp:952
 msgid "- default -"
 msgstr "- oletus -"
 
-#: src/amuleDlg.cpp:1595
+#: src/amuleDlg.cpp:1660
 #, c-format
 msgid "Skin directory '%s' does not exist"
 msgstr "Teemakansiota '%s' ei ole olemassa"
 
-#: src/amuleDlg.cpp:1598
+#: src/amuleDlg.cpp:1663
 #, c-format
 msgid "WARNING: Unable to open skin file '%s' for read"
 msgstr "VAROITUS: Ei voida avata teematiedostoa '%s' luettavaksi"
 
-#: src/amuleDlg.cpp:1722 src/amuleDlg.cpp:1968 src/muuli_wdr.cpp:1485
-#: src/muuli_wdr.cpp:3411
-msgid "Networks"
-msgstr "Verkot"
-
-#: src/amuleDlg.cpp:1726 src/muuli_wdr.cpp:3411
+#: src/amuleDlg.cpp:1791 src/muuli_wdr.cpp:3418
 msgid "Networks Window"
 msgstr "Verkkoikkuna"
 
-#: src/amuleDlg.cpp:1728 src/muuli_wdr.cpp:3412
-msgid "Searches"
-msgstr "Haut"
-
-#: src/amuleDlg.cpp:1732 src/muuli_wdr.cpp:3412
+#: src/amuleDlg.cpp:1797 src/muuli_wdr.cpp:3419
 msgid "Searches Window"
 msgstr "Hakujen ikkuna"
 
-#: src/amuleDlg.cpp:1734 src/DownloadListCtrl.cpp:740 src/muuli_wdr.cpp:392
-#: src/muuli_wdr.cpp:1578 src/muuli_wdr.cpp:3413 src/Statistics.cpp:829
-msgid "Downloads"
-msgstr "Lataukset"
-
-#: src/amuleDlg.cpp:1738 src/muuli_wdr.cpp:3413
+#: src/amuleDlg.cpp:1803 src/muuli_wdr.cpp:3420
 msgid "Downloads Window"
 msgstr "Latausten ikkuna"
 
-#: src/amuleDlg.cpp:1740 src/muuli_wdr.cpp:3287
-msgid "Shared files"
-msgstr "Jaetut tiedostot"
-
-#: src/amuleDlg.cpp:1744 src/muuli_wdr.cpp:3415
+#: src/amuleDlg.cpp:1809 src/muuli_wdr.cpp:3422
 msgid "Shared Files Window"
 msgstr "Jaettujen tiedostojen ikkuna"
 
-#: src/amuleDlg.cpp:1746 src/muuli_wdr.cpp:2919 src/muuli_wdr.cpp:3369
-#: src/muuli_wdr.cpp:3416
-msgid "Messages"
-msgstr "Viestit"
-
-#: src/amuleDlg.cpp:1750 src/muuli_wdr.cpp:3416
+#: src/amuleDlg.cpp:1815 src/muuli_wdr.cpp:3423
 msgid "Messages Window"
 msgstr "Viestien ikkuna"
 
-#: src/amuleDlg.cpp:1752 src/muuli_wdr.cpp:3417 src/PrefsUnifiedDlg.cpp:312
-#: src/Statistics.cpp:779 src/Statistics.cpp:1235
-msgid "Statistics"
-msgstr "Tilastot"
-
-#: src/amuleDlg.cpp:1756 src/muuli_wdr.cpp:3417
+#: src/amuleDlg.cpp:1821 src/muuli_wdr.cpp:3424
 msgid "Statistics Graph Window"
 msgstr "Tilastokuvaajien ikkuna"
 
-#: src/amuleDlg.cpp:1759 src/muuli_wdr.cpp:3419 src/PrefsUnifiedDlg.cpp:328
-#: src/utils/wxCas/src/wxcasprefs.cpp:39
-msgid "Preferences"
-msgstr "Asetukset"
-
-#: src/amuleDlg.cpp:1763 src/muuli_wdr.cpp:3419
+#: src/amuleDlg.cpp:1828 src/muuli_wdr.cpp:3426
 msgid "Preferences Settings Window"
 msgstr "Asetuksien säätöikkuna"
 
-#: src/amuleDlg.cpp:1766 src/muuli_wdr.cpp:3420
+#: src/amuleDlg.cpp:1831 src/muuli_wdr.cpp:3427
 msgid "Import"
 msgstr "Tuonti"
 
-#: src/amuleDlg.cpp:1770 src/muuli_wdr.cpp:3420
+#: src/amuleDlg.cpp:1835 src/muuli_wdr.cpp:3427
 msgid "The partfile importer tool"
 msgstr "Osatiedostojen tuontityökalu"
 
-#: src/amuleDlg.cpp:1773 src/muuli_wdr.cpp:3421
+#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3428
 #: src/utils/aLinkCreator/src/alcframe.cpp:262
 msgid "About"
 msgstr "Tietoja"
 
-#: src/amuleDlg.cpp:1773 src/muuli_wdr.cpp:3421
+#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3428
 msgid "About/Help"
 msgstr "Tietoja/Ohje"
 
-#: src/amuleDlg.cpp:1971
+#: src/amuleDlg.cpp:2036
 msgid "eD2k network"
 msgstr "eD2k-verkko"
 
-#: src/amuleDlg.cpp:1974
+#: src/amuleDlg.cpp:2039
 msgid "Kad network"
 msgstr "Kad-verkko"
 
-#: src/amuleDlg.cpp:1974
+#: src/amuleDlg.cpp:2039
 msgid "No network"
 msgstr "Ei verkkoa"
 
@@ -1352,19 +1357,19 @@ msgstr "Auto [Ko]"
 msgid "Very low"
 msgstr "Erittäin matala"
 
-#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:743 src/muuli_wdr.cpp:2275
+#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:743 src/muuli_wdr.cpp:2282
 #: src/ServerListCtrl.cpp:263 src/ServerListCtrl.cpp:456
 #: src/SharedFilesCtrl.cpp:145
 msgid "Low"
 msgstr "Matala"
 
-#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:744 src/muuli_wdr.cpp:2276
+#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:744 src/muuli_wdr.cpp:2283
 #: src/ServerListCtrl.cpp:266 src/ServerListCtrl.cpp:457
 #: src/SharedFilesCtrl.cpp:146
 msgid "Normal"
 msgstr "Normaali"
 
-#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:745 src/muuli_wdr.cpp:2277
+#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:745 src/muuli_wdr.cpp:2284
 #: src/ServerListCtrl.cpp:269 src/ServerListCtrl.cpp:458
 #: src/SharedFilesCtrl.cpp:147
 msgid "High"
@@ -1456,8 +1461,8 @@ msgstr "Paikallinen Palvelin"
 msgid "Remote Server"
 msgstr "Etäpalvelin"
 
-#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3174
-#: src/SearchDlg.cpp:111 src/TextClient.cpp:911
+#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3181
+#: src/SearchDlg.cpp:119 src/TextClient.cpp:911
 msgid "Kad"
 msgstr "Kad"
 
@@ -1528,7 +1533,7 @@ msgstr "Osa"
 msgid "Size"
 msgstr "Koko"
 
-#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3241
+#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3248
 msgid "Transferred"
 msgstr "Siirretty"
 
@@ -1586,7 +1591,7 @@ msgstr ""
 "Palaute tullut: %s (%s)\n"
 "\n"
 
-#: src/DownloadListCtrl.cpp:746 src/muuli_wdr.cpp:2278
+#: src/DownloadListCtrl.cpp:746 src/muuli_wdr.cpp:2285
 #: src/SharedFilesCtrl.cpp:150
 msgid "Auto"
 msgstr "Automaattinen"
@@ -1624,7 +1629,7 @@ msgid "Extended Options"
 msgstr "Laajat asetukset"
 
 #: src/DownloadListCtrl.cpp:770 src/DownloadListCtrl.cpp:822
-#: src/muuli_wdr.cpp:1789
+#: src/muuli_wdr.cpp:1796
 msgid "Preview"
 msgstr "Esikatsele"
 
@@ -2335,19 +2340,19 @@ msgstr ""
 msgid "eD2k"
 msgstr "eD2k"
 
-#: src/FirstRunWizard.cpp:349 src/muuli_wdr.cpp:1488
+#: src/FirstRunWizard.cpp:349 src/muuli_wdr.cpp:1495
 msgid "Kademlia"
 msgstr "Kademlia"
 
-#: src/FirstRunWizard.cpp:359 src/muuli_wdr.cpp:1416
+#: src/FirstRunWizard.cpp:359 src/muuli_wdr.cpp:1423
 msgid "Standard TCP Port "
 msgstr "Vakio TCP-portti"
 
-#: src/FirstRunWizard.cpp:365 src/muuli_wdr.cpp:1428
+#: src/FirstRunWizard.cpp:365 src/muuli_wdr.cpp:1435
 msgid "Extended UDP port (Kad / global search) "
 msgstr "Laajennettu UDP-portti (Kad / haku kaikkialta)."
 
-#: src/FirstRunWizard.cpp:377 src/muuli_wdr.cpp:1435
+#: src/FirstRunWizard.cpp:377 src/muuli_wdr.cpp:1442
 msgid "Enable UPnP for router port forwarding"
 msgstr "Käytä UPnP:tä reitittimen portinohjauksessa"
 
@@ -2374,7 +2379,7 @@ msgstr ""
 msgid "Your peer lists are already in place - nothing to download."
 msgstr "Lataat jo tiedostoa %s"
 
-#: src/FirstRunWizard.cpp:434 src/muuli_wdr.cpp:1533
+#: src/FirstRunWizard.cpp:434 src/muuli_wdr.cpp:1540
 msgid "Auto-update server list at startup"
 msgstr "Päivitä palvelinlista käynnistettäessä"
 
@@ -2420,23 +2425,23 @@ msgid ""
 "want downloads on a different (e.g. larger) disk."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:549 src/FirstRunWizard.cpp:611 src/muuli_wdr.cpp:1701
+#: src/FirstRunWizard.cpp:549 src/FirstRunWizard.cpp:611 src/muuli_wdr.cpp:1708
 msgid "Destination folder for downloads"
 msgstr "Kansio ladatuille tiedostoille"
 
-#: src/FirstRunWizard.cpp:553 src/FirstRunWizard.cpp:569 src/muuli_wdr.cpp:1342
-#: src/muuli_wdr.cpp:1359 src/muuli_wdr.cpp:1676 src/muuli_wdr.cpp:1707
-#: src/muuli_wdr.cpp:1719 src/muuli_wdr.cpp:2762
+#: src/FirstRunWizard.cpp:553 src/FirstRunWizard.cpp:569 src/muuli_wdr.cpp:1349
+#: src/muuli_wdr.cpp:1366 src/muuli_wdr.cpp:1683 src/muuli_wdr.cpp:1714
+#: src/muuli_wdr.cpp:1726 src/muuli_wdr.cpp:2769
 #: src/utils/aLinkCreator/src/alcframe.cpp:135
 #: src/utils/wxCas/src/wxcasprefs.cpp:52 src/utils/wxCas/src/wxcasprefs.cpp:118
 msgid "Browse"
 msgstr "Selaa"
 
-#: src/FirstRunWizard.cpp:559 src/muuli_wdr.cpp:1712
+#: src/FirstRunWizard.cpp:559 src/muuli_wdr.cpp:1719
 msgid "(All files in this folder are shared with other peers)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:565 src/FirstRunWizard.cpp:624 src/muuli_wdr.cpp:1714
+#: src/FirstRunWizard.cpp:565 src/FirstRunWizard.cpp:624 src/muuli_wdr.cpp:1721
 msgid "Folder for temporary download files"
 msgstr "Kansio latauksen väliaikaisille tiedostoille"
 
@@ -2467,7 +2472,7 @@ msgstr "Kaverilistatiedostoa 'emfriends.met' ei saatu avattua kirjoitettavaksi!"
 msgid "CRITICAL - no client on StartChatSession"
 msgstr "KRIITTINEN - ei asiakasta keskustelun aloituksessa"
 
-#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2668 src/muuli_wdr.cpp:3345
+#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2675 src/muuli_wdr.cpp:3352
 msgid "Friends"
 msgstr "Kaverit"
 
@@ -2853,7 +2858,7 @@ msgstr "Jakosuhde"
 msgid "Uploaded"
 msgstr "Lähetetty"
 
-#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3225
+#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3232
 msgid "Requested"
 msgstr "Pyydetty"
 
@@ -2977,7 +2982,7 @@ msgid "WARNING: "
 msgstr "VAROITUS: "
 
 #: src/MuleNotebook.cpp:179 src/muuli_wdr.cpp:817 src/muuli_wdr.cpp:1229
-#: src/muuli_wdr.cpp:3129 src/muuli_wdr.cpp:3385
+#: src/muuli_wdr.cpp:3136 src/muuli_wdr.cpp:3392
 msgid "Close"
 msgstr "Sulje"
 
@@ -2990,12 +2995,12 @@ msgstr "Leikkaa"
 msgid "Copy"
 msgstr "Kopioi"
 
-#: src/MuleTextCtrl.cpp:88
+#: src/MuleTextCtrl.cpp:88 src/SearchDlg.cpp:261
 msgid "Paste"
 msgstr "Liitä"
 
 #: src/MuleTextCtrl.cpp:89 src/muuli_wdr.cpp:358 src/muuli_wdr.cpp:757
-#: src/muuli_wdr.cpp:2352 src/muuli_wdr.cpp:2371 src/muuli_wdr.cpp:2393
+#: src/muuli_wdr.cpp:2359 src/muuli_wdr.cpp:2378 src/muuli_wdr.cpp:2400
 #: src/utils/aLinkCreator/src/alcframe.cpp:142
 msgid "Clear"
 msgstr "Pyyhi"
@@ -3093,8 +3098,8 @@ msgid "Exit"
 msgstr "Sulje"
 
 #: src/MuleTrayIcon.cpp:579 src/MuleTrayIcon.cpp:945 src/MuleTrayIcon.cpp:965
-#: src/muuli_wdr.cpp:1391 src/muuli_wdr.cpp:1399 src/muuli_wdr.cpp:1406
-#: src/muuli_wdr.cpp:1835 src/muuli_wdr.cpp:1841 src/OtherFunctions.cpp:91
+#: src/muuli_wdr.cpp:1398 src/muuli_wdr.cpp:1406 src/muuli_wdr.cpp:1413
+#: src/muuli_wdr.cpp:1842 src/muuli_wdr.cpp:1848 src/OtherFunctions.cpp:91
 #: src/StatisticsDlg.cpp:93 src/StatisticsDlg.cpp:95
 msgid "kB/s"
 msgstr "KB/s"
@@ -3265,7 +3270,7 @@ msgstr "Nimi:"
 msgid "Type"
 msgstr "Tyyppi"
 
-#: src/muuli_wdr.cpp:215 src/SearchDlg.cpp:110 src/SearchListCtrl.cpp:853
+#: src/muuli_wdr.cpp:215 src/SearchDlg.cpp:118 src/SearchListCtrl.cpp:853
 msgid "Local"
 msgstr "Paikallinen"
 
@@ -3336,7 +3341,7 @@ msgstr "Tavua"
 msgid "KB"
 msgstr "KB"
 
-#: src/muuli_wdr.cpp:274 src/muuli_wdr.cpp:293 src/muuli_wdr.cpp:1620
+#: src/muuli_wdr.cpp:274 src/muuli_wdr.cpp:293 src/muuli_wdr.cpp:1627
 #: src/OtherFunctions.cpp:64
 msgid "MB"
 msgstr "MB"
@@ -3353,7 +3358,7 @@ msgstr "Enimmäiskoko"
 msgid "Availability"
 msgstr "Saatavuus"
 
-#: src/muuli_wdr.cpp:312 src/muuli_wdr.cpp:398 src/muuli_wdr.cpp:3290
+#: src/muuli_wdr.cpp:312 src/muuli_wdr.cpp:398 src/muuli_wdr.cpp:3297
 msgid "Filter:"
 msgstr "Suodatin:"
 
@@ -3385,7 +3390,7 @@ msgstr ""
 msgid "Stop"
 msgstr "Pysäytä"
 
-#: src/muuli_wdr.cpp:348 src/muuli_wdr.cpp:1385 src/SearchListCtrl.cpp:732
+#: src/muuli_wdr.cpp:348 src/muuli_wdr.cpp:1392 src/SearchListCtrl.cpp:732
 msgid "Download"
 msgstr "Lataa"
 
@@ -3416,8 +3421,8 @@ msgstr "Tiedostolähteet:"
 #: src/muuli_wdr.cpp:1160 src/muuli_wdr.cpp:1167 src/muuli_wdr.cpp:1172
 #: src/muuli_wdr.cpp:1179 src/muuli_wdr.cpp:1184 src/muuli_wdr.cpp:1191
 #: src/muuli_wdr.cpp:1205 src/muuli_wdr.cpp:1212 src/muuli_wdr.cpp:1217
-#: src/muuli_wdr.cpp:1224 src/muuli_wdr.cpp:3227 src/muuli_wdr.cpp:3235
-#: src/muuli_wdr.cpp:3243
+#: src/muuli_wdr.cpp:1224 src/muuli_wdr.cpp:3234 src/muuli_wdr.cpp:3242
+#: src/muuli_wdr.cpp:3250
 msgid "N/A"
 msgstr "Ei saatavilla"
 
@@ -3562,7 +3567,7 @@ msgstr ""
 msgid "Album :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:685 src/muuli_wdr.cpp:2247
+#: src/muuli_wdr.cpp:685 src/muuli_wdr.cpp:2254
 msgid "Title :"
 msgstr "Otsikko :"
 
@@ -3671,7 +3676,7 @@ msgstr "Käyttäjänimi :"
 msgid "Userhash :"
 msgstr "Käyttäjätarkiste :"
 
-#: src/muuli_wdr.cpp:895 src/muuli_wdr.cpp:1741 src/muuli_wdr.cpp:2442
+#: src/muuli_wdr.cpp:895 src/muuli_wdr.cpp:1748 src/muuli_wdr.cpp:2449
 #: src/utils/aLinkCreator/src/alcframe.cpp:137
 msgid "Add"
 msgstr "Lisää"
@@ -3680,15 +3685,15 @@ msgstr "Lisää"
 msgid "Download-Speed"
 msgstr "Latausnopeus"
 
-#: src/muuli_wdr.cpp:954 src/muuli_wdr.cpp:989 src/muuli_wdr.cpp:2546
+#: src/muuli_wdr.cpp:954 src/muuli_wdr.cpp:989 src/muuli_wdr.cpp:2553
 msgid "Current"
 msgstr "Nykyinen"
 
-#: src/muuli_wdr.cpp:962 src/muuli_wdr.cpp:997 src/muuli_wdr.cpp:2554
+#: src/muuli_wdr.cpp:962 src/muuli_wdr.cpp:997 src/muuli_wdr.cpp:2561
 msgid "Running average"
 msgstr "Yhtäjaksoinen keskiarvo"
 
-#: src/muuli_wdr.cpp:970 src/muuli_wdr.cpp:1005 src/muuli_wdr.cpp:2562
+#: src/muuli_wdr.cpp:970 src/muuli_wdr.cpp:1005 src/muuli_wdr.cpp:2569
 msgid "Session average"
 msgstr "Session keskiarvo"
 
@@ -3700,7 +3705,7 @@ msgstr "Lähetysnopeus"
 msgid "Connections"
 msgstr "Yhteydet"
 
-#: src/muuli_wdr.cpp:1024 src/muuli_wdr.cpp:1860
+#: src/muuli_wdr.cpp:1024 src/muuli_wdr.cpp:1867
 msgid "Active downloads"
 msgstr "Aktiiviset lataukset"
 
@@ -3708,7 +3713,7 @@ msgstr "Aktiiviset lataukset"
 msgid "Active connections (1:1)"
 msgstr "Aktiiviset yhteydet (1:1)"
 
-#: src/muuli_wdr.cpp:1040 src/muuli_wdr.cpp:1861
+#: src/muuli_wdr.cpp:1040 src/muuli_wdr.cpp:1868
 msgid "Active uploads"
 msgstr "Aktiiviset lähetykset"
 
@@ -3824,8 +3829,8 @@ msgstr "Tämä on nimi jonka muut käyttäjät näkevät yhdistäessään sinuun
 msgid "Language: "
 msgstr "Kieli: "
 
-#: src/muuli_wdr.cpp:1257 src/muuli_wdr.cpp:1323 src/muuli_wdr.cpp:1327
-#: src/muuli_wdr.cpp:1330
+#: src/muuli_wdr.cpp:1257 src/muuli_wdr.cpp:1330 src/muuli_wdr.cpp:1334
+#: src/muuli_wdr.cpp:1337
 msgid "The delay before showing tool-tips."
 msgstr "Viive työkaluvihjeiden näyttämiseen."
 
@@ -3903,936 +3908,945 @@ msgstr ""
 msgid "Enabling this will make aMule to show notifications when finished downloading."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1322
+#: src/muuli_wdr.cpp:1323
+#, fuzzy
+msgid "Remember search history"
+msgstr "Muista nämä asetukset"
+
+#: src/muuli_wdr.cpp:1324
+msgid "Keeps a dropdown list of your past search terms in the Search tab's Name field. This remembers the queries you typed, not the results they returned."
+msgstr ""
+
+#: src/muuli_wdr.cpp:1329
 msgid "Tooltip delay time: "
 msgstr "Työkaluvihjeiden viive:"
 
-#: src/muuli_wdr.cpp:1329
+#: src/muuli_wdr.cpp:1336
 msgid "seconds"
 msgstr "sekuntia"
 
-#: src/muuli_wdr.cpp:1333
+#: src/muuli_wdr.cpp:1340
 msgid "Browser Selection"
 msgstr "Selaimen valinta"
 
-#: src/muuli_wdr.cpp:1339
+#: src/muuli_wdr.cpp:1346
 msgid "Enter your browser name here. Leave this field empty to use the system default browser."
 msgstr "Syötä tähän selaimesi nimi. Jätä tyhjäksi jos haluat käyttää järjestelmän oletusselainta."
 
-#: src/muuli_wdr.cpp:1346
+#: src/muuli_wdr.cpp:1353
 msgid "Open in new tab if possible"
 msgstr "Avaa uuteen välilehteen mikäli mahdollista"
 
-#: src/muuli_wdr.cpp:1348
+#: src/muuli_wdr.cpp:1355
 msgid "Open the web page in a new tab instead of in a new window when possible"
 msgstr "Avaa verkkosivun uuteen välilehteen uuden ikkunan sijaan kun se on mahdollista"
 
-#: src/muuli_wdr.cpp:1352
+#: src/muuli_wdr.cpp:1359
 msgid "Video Player"
 msgstr "Videotoistin"
 
-#: src/muuli_wdr.cpp:1379
+#: src/muuli_wdr.cpp:1386
 msgid "Bandwidth limits"
 msgstr "Kaistankäytön rajoitukset"
 
-#: src/muuli_wdr.cpp:1393
+#: src/muuli_wdr.cpp:1400
 msgid "Upload"
 msgstr "Lähetys"
 
-#: src/muuli_wdr.cpp:1401
+#: src/muuli_wdr.cpp:1408
 msgid "Slot Allocation"
 msgstr "Paikkavaraus"
 
-#: src/muuli_wdr.cpp:1410
+#: src/muuli_wdr.cpp:1417
 msgid "Ports"
 msgstr "Portit"
 
-#: src/muuli_wdr.cpp:1420
+#: src/muuli_wdr.cpp:1427
 msgid "This is the standard eD2k port and cannot be disabled."
 msgstr "Tämä on vakio eD2k-portti eikä sitä voi kytkeä pois päältä."
 
-#: src/muuli_wdr.cpp:1423
+#: src/muuli_wdr.cpp:1430
 msgid "UDP port for server requests (TCP+3):"
 msgstr "UDP-portti palvelinpyyntöihin (TCP+3):"
 
-#: src/muuli_wdr.cpp:1425
+#: src/muuli_wdr.cpp:1432
 msgid "4665"
 msgstr "4665"
 
-#: src/muuli_wdr.cpp:1432
+#: src/muuli_wdr.cpp:1439
 msgid "This UDP port is used for extended eD2k requests and Kad network"
 msgstr "Tätä UDP-porttia käytetään laajennettuihin eD2k-hakuihin sekä Kad-verkossa"
 
-#: src/muuli_wdr.cpp:1439
+#: src/muuli_wdr.cpp:1446
 msgid "UPnP TCP Port (Optional):"
 msgstr "UPnP:n TCP-portti (Valinnainen):"
 
-#: src/muuli_wdr.cpp:1449
+#: src/muuli_wdr.cpp:1456
 msgid "Bind local address to IP (empty for any):"
 msgstr "Sido paikallinen osoite IP:hen (tyhjä sallii mihin tahansa):"
 
-#: src/muuli_wdr.cpp:1452
+#: src/muuli_wdr.cpp:1459
 msgid "Advanced users only: If you have multiple network interfaces, enter the address of the interface to which aMule should be bound."
 msgstr "Vain edistyneille käyttäjille: mikäli sinulla on useampia verkkoliitäntöjä, syötä sen liitännän osoite johon haluat aMulen sidottavan."
 
-#: src/muuli_wdr.cpp:1455 src/muuli_wdr.cpp:2054
+#: src/muuli_wdr.cpp:1462 src/muuli_wdr.cpp:2061
 #, fuzzy
 msgid "Bind to network interface (empty for any):"
 msgstr "Sido paikallinen osoite IP:hen (tyhjä sallii mihin tahansa):"
 
-#: src/muuli_wdr.cpp:1468
+#: src/muuli_wdr.cpp:1475
 msgid "Advanced users only: pin all of aMule's traffic to one network interface, chosen from the list or typed in by name (e.g. tun0, eth0, en0) or index. Unlike binding to an IP, this stops traffic leaking out via the default route - useful with a VPN. Requires no elevated privileges."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1474
+#: src/muuli_wdr.cpp:1481
 msgid "Max sources per downloading file:"
 msgstr "Lähteitä enintään tiedostoa kohden:"
 
-#: src/muuli_wdr.cpp:1478
+#: src/muuli_wdr.cpp:1485
 msgid "Max simultaneous connections:"
 msgstr "Yhtäaikaisten yhteyksien enimmäismäärä:"
 
-#: src/muuli_wdr.cpp:1491 src/muuli_wdr.cpp:3169
+#: src/muuli_wdr.cpp:1498 src/muuli_wdr.cpp:3176
 msgid "ED2K"
 msgstr "ED2K"
 
-#: src/muuli_wdr.cpp:1498
+#: src/muuli_wdr.cpp:1505
 msgid "Autoconnect on startup"
 msgstr "Yhdistä automaattisesti käynnistettäessä"
 
-#: src/muuli_wdr.cpp:1501
+#: src/muuli_wdr.cpp:1508
 msgid "Reconnect on loss"
 msgstr "Yhdistä uudelleen yhteyden katketessa"
 
-#: src/muuli_wdr.cpp:1523
+#: src/muuli_wdr.cpp:1530
 msgid "Remove dead server after"
 msgstr "Poista toimimattomat palvelimet"
 
-#: src/muuli_wdr.cpp:1524
+#: src/muuli_wdr.cpp:1531
 msgid "Static servers are never removed, even when unreachable."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1528
+#: src/muuli_wdr.cpp:1535
 msgid "retries"
 msgstr "yrityksen jälkeen"
 
-#: src/muuli_wdr.cpp:1536
+#: src/muuli_wdr.cpp:1543
 msgid "List"
 msgstr "Lista"
 
-#: src/muuli_wdr.cpp:1539
+#: src/muuli_wdr.cpp:1546
 msgid "Update server list when connecting to a server"
 msgstr "Päivitä palvelinlista yhdistettäessä palvelimelle"
 
-#: src/muuli_wdr.cpp:1542
+#: src/muuli_wdr.cpp:1549
 msgid "Update server list when a client connects"
 msgstr "Päivitä palvelinlista asiakkaan yhdistäessä"
 
-#: src/muuli_wdr.cpp:1545
+#: src/muuli_wdr.cpp:1552
 msgid "Use priority system"
 msgstr "Käytä tärkeysjärjestystä"
 
-#: src/muuli_wdr.cpp:1549
+#: src/muuli_wdr.cpp:1556
 msgid "Use smart LowID check on connect"
 msgstr "Käytä älykästä LowID-tarkistusta yhdistettäessä"
 
-#: src/muuli_wdr.cpp:1553
+#: src/muuli_wdr.cpp:1560
 msgid "Safe connect"
 msgstr "Turvallinen yhdistäminen"
 
-#: src/muuli_wdr.cpp:1557
+#: src/muuli_wdr.cpp:1564
 msgid "Autoconnect to servers in static list only"
 msgstr "Yhdistä automaattisesti vain pysyville palvelimille"
 
-#: src/muuli_wdr.cpp:1560
+#: src/muuli_wdr.cpp:1567
 msgid "Set manually added servers to High Priority"
 msgstr "Aseta käsin syötetyt palvelimet korkealle tärkeydelle"
 
-#: src/muuli_wdr.cpp:1581
+#: src/muuli_wdr.cpp:1588
 msgid "Add files to download in pause mode"
 msgstr "Lisää tiedostot lataukseen tauotettuna"
 
-#: src/muuli_wdr.cpp:1583
+#: src/muuli_wdr.cpp:1590
 msgid "Add files to download with auto priority"
 msgstr "Lisää tiedostot lataukseen tärkeys automaattisella"
 
-#: src/muuli_wdr.cpp:1586
+#: src/muuli_wdr.cpp:1593
 msgid "Try to download first and last chunks first"
 msgstr "Yritä ladata ensimmäiset ja viimeiset palat ensin"
 
-#: src/muuli_wdr.cpp:1590
+#: src/muuli_wdr.cpp:1597
 msgid "Endgame mode: rotate to faster sources for the final blocks"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1593
+#: src/muuli_wdr.cpp:1600
 msgid "Start next paused file when a file completes"
 msgstr "Käynnistä seuraava tauotetty tiedosto kun tiedosto valmistuu"
 
-#: src/muuli_wdr.cpp:1596
+#: src/muuli_wdr.cpp:1603
 msgid "From the same category"
 msgstr "Samasta luokasta"
 
-#: src/muuli_wdr.cpp:1598
+#: src/muuli_wdr.cpp:1605
 msgid "In alphabetic order"
 msgstr "Aakkosellisessa järjestyksessä"
 
-#: src/muuli_wdr.cpp:1600
+#: src/muuli_wdr.cpp:1607
 msgid "Preallocate disk space for new files"
 msgstr "Esivaraa levytila uusille tiedostoille"
 
-#: src/muuli_wdr.cpp:1601
+#: src/muuli_wdr.cpp:1608
 msgid "For new files preallocates disk space for the whole file, thus reduces fragmentation"
 msgstr "Uusia tiedostoja lisätessä varaa levytilaa koko tiedostolle, vähentää pirstaloitumista"
 
-#: src/muuli_wdr.cpp:1606
+#: src/muuli_wdr.cpp:1613
 msgid "Create new files as sparse files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1607
+#: src/muuli_wdr.cpp:1614
 msgid "A sparse file reserves its full size on disk immediately without writing real data to it -- fast, but unsupported or slow on some filesystems, and free-space accounting stays optimistic while the download is in progress. Turn this off to grow the file only as data arrives."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1612
+#: src/muuli_wdr.cpp:1619
 msgid "Stop downloads when free disk space reaches "
 msgstr "Pysäytä lataukset kun tyhjän levytilan määrä saavuttaa "
 
-#: src/muuli_wdr.cpp:1613
+#: src/muuli_wdr.cpp:1620
 msgid "Select this if you want aMule to check your disk space"
 msgstr "Valitse tämä mikäli haluat aMulen tarkistavan vapaan levytilan määrän"
 
-#: src/muuli_wdr.cpp:1617
+#: src/muuli_wdr.cpp:1624
 msgid "Enter here the min disk space desired."
 msgstr "Syötä tähän levytila jonka haluat jättää vapaaksi."
 
-#: src/muuli_wdr.cpp:1623
+#: src/muuli_wdr.cpp:1630
 msgid "Save 10 sources on rare files (< 20 sources)"
 msgstr "Tallenna 10 lähdettä harvinaisille tiedostoille (< 20 lähdettä)"
 
-#: src/muuli_wdr.cpp:1627 src/Statistics.cpp:790
+#: src/muuli_wdr.cpp:1634 src/Statistics.cpp:790
 msgid "Uploads"
 msgstr "Lähetykset"
 
-#: src/muuli_wdr.cpp:1630
+#: src/muuli_wdr.cpp:1637
 msgid "Add new shared files with auto priority"
 msgstr "Lisää uudet jaetut tiedostot tärkeys automaattisella"
 
-#: src/muuli_wdr.cpp:1636
+#: src/muuli_wdr.cpp:1643
 msgid "Intelligent Corruption Handling (I.C.H.)"
 msgstr "Älykäs turmeltumien käsittely (I.C.H.)"
 
-#: src/muuli_wdr.cpp:1639
+#: src/muuli_wdr.cpp:1646
 msgid "Enable"
 msgstr "Käytä"
 
-#: src/muuli_wdr.cpp:1642
+#: src/muuli_wdr.cpp:1649
 msgid "Advanced I.C.H. trusts every hash (not recommended)"
 msgstr "Kehittynyt I.C.H. luottaa kaikkiin tarkisteisiin (ei suositella)"
 
-#: src/muuli_wdr.cpp:1654 src/PrefsUnifiedDlg.cpp:1910
+#: src/muuli_wdr.cpp:1661 src/PrefsUnifiedDlg.cpp:1910
 msgid "Media metadata extraction"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1658
+#: src/muuli_wdr.cpp:1665
 msgid "Extract length / bitrate / codec from shared audio and video files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1660
+#: src/muuli_wdr.cpp:1667
 msgid "When enabled, aMule runs ffprobe on each shared media file to fill in the Length / Bitrate / Codec columns other clients see when they find the file in a search. Requires ffmpeg (the ffprobe binary) to be installed."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1667
+#: src/muuli_wdr.cpp:1674
 msgid "Path to ffprobe:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1672
+#: src/muuli_wdr.cpp:1679
 msgid "Full path to the ffprobe binary. Leave empty to have aMule auto-detect it on startup."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1680
+#: src/muuli_wdr.cpp:1687
 msgid "Detect"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1681
+#: src/muuli_wdr.cpp:1688
 msgid "Search the standard install locations for an ffprobe binary and fill the path field."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1705
+#: src/muuli_wdr.cpp:1712
 msgid ""
 "Completed downloads are stored here. All files in this folder are automatically shared with other peers.\n"
 "If this folder also holds files you don't want to share, point it at an aMule-only sub-folder."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1708
+#: src/muuli_wdr.cpp:1715
 msgid "Pick the folder where completed downloads will be stored. All files in that folder will be shared with other peers."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1722
+#: src/muuli_wdr.cpp:1729
 msgid "Shared folders"
 msgstr "Jaetut kansiot"
 
-#: src/muuli_wdr.cpp:1728
+#: src/muuli_wdr.cpp:1735
 msgid "(Folders shared by the core. Enter a path to add one.)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1736
+#: src/muuli_wdr.cpp:1743
 msgid "Absolute path of a folder on the core's machine, e.g. /home/user/shared"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1738 src/PrefsUnifiedDlg.cpp:2794
+#: src/muuli_wdr.cpp:1745 src/PrefsUnifiedDlg.cpp:2794
 msgid "Recursive"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1739
+#: src/muuli_wdr.cpp:1746
 msgid "Share every sub-folder underneath this one, including ones created later."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1743 src/utils/aLinkCreator/src/alcframe.cpp:141
+#: src/muuli_wdr.cpp:1750 src/utils/aLinkCreator/src/alcframe.cpp:141
 msgid "Remove"
 msgstr "Poista"
 
-#: src/muuli_wdr.cpp:1747
+#: src/muuli_wdr.cpp:1754
 msgid "(Right click on folder icon for recursive share)"
 msgstr "(Klikkaa oikealla painikkeella kansion kuvaketta jakaaksesi rekursiivisesti)"
 
-#: src/muuli_wdr.cpp:1754
+#: src/muuli_wdr.cpp:1761
 msgid "Share hidden files"
 msgstr "Jaa piilotiedostot"
 
-#: src/muuli_wdr.cpp:1760
+#: src/muuli_wdr.cpp:1767
 msgid "Automatically rescan shared folders for changes"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1766
+#: src/muuli_wdr.cpp:1773
 msgid "Follow symbolic links in shared folders"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1772
+#: src/muuli_wdr.cpp:1779
 msgid "Exclude files matching:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1775
+#: src/muuli_wdr.cpp:1782
 msgid "Wildcard patterns separated by '|', e.g. .DS_Store|Thumbs.db|*.tmp. Files whose name matches are not shared. Matching is case-insensitive."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1779
+#: src/muuli_wdr.cpp:1786
 msgid "Patterns are regular expressions"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1780
+#: src/muuli_wdr.cpp:1787
 msgid "When set, the whole field is one regular expression ('|' is alternation). When unset, it is a list of '|'-separated wildcards."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1790
+#: src/muuli_wdr.cpp:1797
 msgid "Show how many shared files the current pattern would exclude."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1811
+#: src/muuli_wdr.cpp:1818
 msgid "Graphs"
 msgstr "Kuvaajat"
 
-#: src/muuli_wdr.cpp:1814 src/muuli_wdr.cpp:1876
+#: src/muuli_wdr.cpp:1821 src/muuli_wdr.cpp:1883
 msgid "Update delay : 5 secs"
 msgstr "Päivitysväli : 5 sekuntia"
 
-#: src/muuli_wdr.cpp:1818
+#: src/muuli_wdr.cpp:1825
 msgid "Time for average graph: 100 mins"
 msgstr "Keskimääräiskuvaajan aika: 100 minuuttia"
 
-#: src/muuli_wdr.cpp:1822
+#: src/muuli_wdr.cpp:1829
 msgid "Connections Graph Scale: 100 "
 msgstr "Yhteyskuvaajan Skaala: 100 "
 
-#: src/muuli_wdr.cpp:1829
+#: src/muuli_wdr.cpp:1836
 msgid "Download graph scale:"
 msgstr "Latauskuvaajan skaala:"
 
-#: src/muuli_wdr.cpp:1837
+#: src/muuli_wdr.cpp:1844
 msgid "Upload graph scale:"
 msgstr "Lähetyskuvaajan skaala:"
 
-#: src/muuli_wdr.cpp:1847
+#: src/muuli_wdr.cpp:1854
 #, fuzzy
 msgid "Colors: "
 msgstr "Värit: "
 
-#: src/muuli_wdr.cpp:1851
+#: src/muuli_wdr.cpp:1858
 msgid "Background"
 msgstr "Taustaväri"
 
-#: src/muuli_wdr.cpp:1852
+#: src/muuli_wdr.cpp:1859
 msgid "Grid"
 msgstr "Ruudukko"
 
-#: src/muuli_wdr.cpp:1853
+#: src/muuli_wdr.cpp:1860
 msgid "Download current"
 msgstr "Hetkittäinen lataus"
 
-#: src/muuli_wdr.cpp:1854
+#: src/muuli_wdr.cpp:1861
 msgid "Download running average"
 msgstr "Latauksen yhtäjaksoinen keskiarvo"
 
-#: src/muuli_wdr.cpp:1855
+#: src/muuli_wdr.cpp:1862
 msgid "Download session average"
 msgstr "Latauksen keskiarvo sessiossa"
 
-#: src/muuli_wdr.cpp:1856
+#: src/muuli_wdr.cpp:1863
 msgid "Upload current"
 msgstr "Hetkittäinen lähetys"
 
-#: src/muuli_wdr.cpp:1857
+#: src/muuli_wdr.cpp:1864
 msgid "Upload running average"
 msgstr "Lähetyksen yhtäjaksoinen keskiarvo"
 
-#: src/muuli_wdr.cpp:1858
+#: src/muuli_wdr.cpp:1865
 msgid "Upload session average"
 msgstr "Lähetyksen keskiarvo sessiossa"
 
-#: src/muuli_wdr.cpp:1859
+#: src/muuli_wdr.cpp:1866
 msgid "Active connections"
 msgstr "Aktiiviset yhteydet"
 
-#: src/muuli_wdr.cpp:1862
+#: src/muuli_wdr.cpp:1869
 #, fuzzy
 msgid "Systray Icon Speed Bar"
 msgstr "Järjestelmäpalkin nopeusnäyttö"
 
-#: src/muuli_wdr.cpp:1863
+#: src/muuli_wdr.cpp:1870
 msgid "Kad-nodes current"
 msgstr "Kad-yhteyksiä tällä hetkellä"
 
-#: src/muuli_wdr.cpp:1864
+#: src/muuli_wdr.cpp:1871
 msgid "Kad-nodes running"
 msgstr "Kad-yhteyksiä aktiivisena"
 
-#: src/muuli_wdr.cpp:1865
+#: src/muuli_wdr.cpp:1872
 msgid "Kad-nodes session"
 msgstr "Kad-yhteyksiä sessiossa"
 
-#: src/muuli_wdr.cpp:1869 src/muuli_wdr.cpp:2296
+#: src/muuli_wdr.cpp:1876 src/muuli_wdr.cpp:2303
 msgid "Select"
 msgstr "Valitse"
 
-#: src/muuli_wdr.cpp:1873
+#: src/muuli_wdr.cpp:1880
 msgid "Tree"
 msgstr "Puu"
 
-#: src/muuli_wdr.cpp:1883
+#: src/muuli_wdr.cpp:1890
 msgid "Number of Client Versions shown (0=unlimited)"
 msgstr "Näytettävien asiakasversioiden määrä (0=rajoittamattomasti)"
 
-#: src/muuli_wdr.cpp:1908
+#: src/muuli_wdr.cpp:1915
 msgid "!!! WARNING !!!"
 msgstr "!!! VAROITUS !!!"
 
-#: src/muuli_wdr.cpp:1923
+#: src/muuli_wdr.cpp:1930
 msgid "Max new connections / 5 secs"
 msgstr "Enimmäismäärä uusia yhteyksiä / 5 s"
 
-#: src/muuli_wdr.cpp:1925
+#: src/muuli_wdr.cpp:1932
 msgid "Concurrent Kad source lookups"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1927
+#: src/muuli_wdr.cpp:1934
 #, fuzzy
 msgid "Kad source re-search interval (minutes)"
 msgstr "FTP-päivityksien väli minuuteissa"
 
-#: src/muuli_wdr.cpp:1929
+#: src/muuli_wdr.cpp:1936
 #, fuzzy
 msgid "Source re-ask interval (minutes)"
 msgstr "FTP-päivityksien väli minuuteissa"
 
-#: src/muuli_wdr.cpp:1933
+#: src/muuli_wdr.cpp:1940
 msgid "File Buffer Size: 240000 bytes"
 msgstr "Tiedostopuskurin koko: 240000 tavua"
 
-#: src/muuli_wdr.cpp:1937
+#: src/muuli_wdr.cpp:1944
 msgid "Use MMAP: memory-mapped file access (lower memory use)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1938
+#: src/muuli_wdr.cpp:1945
 msgid "Maps part files into memory instead of buffering them on the heap, lowering the process memory footprint. May reduce download speed on some disks; best for memory-constrained or upload-heavy hosts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1940
+#: src/muuli_wdr.cpp:1947
 msgid "Upload Queue Size: 5000 clients"
 msgstr "Lähetysjonon koko: 5000 asiakasta"
 
-#: src/muuli_wdr.cpp:1944
+#: src/muuli_wdr.cpp:1951
 msgid "Server connection refresh interval: Disable"
 msgstr "Palvelinyhteyden päivitysväli: Poissa käytöstä"
 
-#: src/muuli_wdr.cpp:1948
+#: src/muuli_wdr.cpp:1955
 msgid "Disable computer's timed standby mode"
 msgstr "Poista käytöstä tietokoneen ajastettu siirtyminen valmiustilaan"
 
-#: src/muuli_wdr.cpp:1967
+#: src/muuli_wdr.cpp:1974
 msgid "Skin to use: "
 msgstr "Käytettävä teema: "
 
-#: src/muuli_wdr.cpp:1976
+#: src/muuli_wdr.cpp:1983
 msgid "Show \"Fast eD2k Links Handler\" in every window."
 msgstr "Näytä \"Nopea eD2k-linkkien käsittelijä\" jokaisessa ikkunassa."
 
-#: src/muuli_wdr.cpp:1979
+#: src/muuli_wdr.cpp:1986
 msgid "Show extended info on categories tabs"
 msgstr "Näytä laajennetut tiedot luokitteluvälilehdillä"
 
-#: src/muuli_wdr.cpp:1982
+#: src/muuli_wdr.cpp:1989
 msgid "Show application version on title"
 msgstr "Näytä sovelluksen versio otsikossa"
 
-#: src/muuli_wdr.cpp:1984
+#: src/muuli_wdr.cpp:1991
 msgid "Show transfer rates on title"
 msgstr "Näytä siirtonopeudet otsikossa"
 
-#: src/muuli_wdr.cpp:1986
+#: src/muuli_wdr.cpp:1993
 msgid "Before application name"
 msgstr "Ennen sovelluksen nimeä"
 
-#: src/muuli_wdr.cpp:1988
+#: src/muuli_wdr.cpp:1995
 msgid "After application name"
 msgstr "Sovelluksen nimen perässä"
 
-#: src/muuli_wdr.cpp:1991
+#: src/muuli_wdr.cpp:1998
 msgid "Show overhead bandwidth"
 msgstr "Näytä otsikkotietoihin kuluva kaista"
 
-#: src/muuli_wdr.cpp:1995
+#: src/muuli_wdr.cpp:2002
 msgid "Vertical toolbar orientation"
 msgstr "Pystysuuntainen työkalupalkki"
 
-#: src/muuli_wdr.cpp:1997
+#: src/muuli_wdr.cpp:2004
 msgid "Live column sorting (auto-reorder rows as their values change)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2004
+#: src/muuli_wdr.cpp:2011
 msgid "Download Queue Files"
 msgstr "Latausjonon tiedostot"
 
-#: src/muuli_wdr.cpp:2007
+#: src/muuli_wdr.cpp:2014
 msgid "Show progress percentage"
 msgstr "Näytä edistyminen prosentteina"
 
-#: src/muuli_wdr.cpp:2013
+#: src/muuli_wdr.cpp:2020
 msgid "Show progress bar"
 msgstr "Näytä edistymispalkki"
 
-#: src/muuli_wdr.cpp:2016
+#: src/muuli_wdr.cpp:2023
 msgid "Flat"
 msgstr "Tasainen"
 
-#: src/muuli_wdr.cpp:2020
+#: src/muuli_wdr.cpp:2027
 msgid "Round"
 msgstr "Pyöreä"
 
-#: src/muuli_wdr.cpp:2038
+#: src/muuli_wdr.cpp:2045
 msgid "External Connection Parameters"
 msgstr "Etäyhteyksien asetukset"
 
-#: src/muuli_wdr.cpp:2041
+#: src/muuli_wdr.cpp:2048
 msgid "Accept external connections"
 msgstr "Hyväksy etäyhteydet"
 
-#: src/muuli_wdr.cpp:2048 src/muuli_wdr.cpp:2107
+#: src/muuli_wdr.cpp:2055 src/muuli_wdr.cpp:2114
 msgid "IP of the listening interface:"
 msgstr "Kuunneltavan verkkoliitännän IP:"
 
-#: src/muuli_wdr.cpp:2051
+#: src/muuli_wdr.cpp:2058
 msgid "Enter here a valid ip in the a.b.c.d format for the listening EC interface. An empty field or 0.0.0.0 will mean any interface."
 msgstr "Syötä tähän sen verkkoliitännän ip jota kuunnellaan etäyhteyksiä varten. Tyhjä tai 0.0.0.0 tarkoittaa kaikkia verkkoliitäntöjä."
 
-#: src/muuli_wdr.cpp:2072 src/muuli_wdr.cpp:2156
+#: src/muuli_wdr.cpp:2079 src/muuli_wdr.cpp:2163
 msgid "TCP port:"
 msgstr "TCP-portti:"
 
-#: src/muuli_wdr.cpp:2078
+#: src/muuli_wdr.cpp:2085
 msgid "Enable UPnP port forwarding on the EC port"
 msgstr "Kytke päälle UPnP-portinohjaus etäyhteysportissa"
 
-#: src/muuli_wdr.cpp:2082 src/muuli_wdr.cpp:3041
+#: src/muuli_wdr.cpp:2089 src/muuli_wdr.cpp:3048
 #: src/utils/wxCas/src/wxcasprefs.cpp:167
 msgid "Password"
 msgstr "Salasana"
 
-#: src/muuli_wdr.cpp:2088
+#: src/muuli_wdr.cpp:2095
 #, fuzzy
 msgid "aMule API server parameters"
 msgstr "Web-palvelimen asetukset"
 
-#: src/muuli_wdr.cpp:2091
+#: src/muuli_wdr.cpp:2098
 msgid "Run amuleapi (REST API) on startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2096
+#: src/muuli_wdr.cpp:2103
 #, fuzzy
 msgid "HTTP port:"
 msgstr "TCP-portti:"
 
-#: src/muuli_wdr.cpp:2110
+#: src/muuli_wdr.cpp:2117
 msgid "The interface amuleapi's HTTP server listens on. 127.0.0.1 (default) accepts only local connections; use 0.0.0.0 or a specific IP to expose it to other hosts (set an admin password below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2113
+#: src/muuli_wdr.cpp:2120
 #, fuzzy
 msgid "Admin password"
 msgstr "Tarkistaa salasanaa\n"
 
-#: src/muuli_wdr.cpp:2118 src/muuli_wdr.cpp:2149
+#: src/muuli_wdr.cpp:2125 src/muuli_wdr.cpp:2156
 msgid "Low rights password"
 msgstr "Rajoitettujen oikeuksien salasana"
 
-#: src/muuli_wdr.cpp:2126
+#: src/muuli_wdr.cpp:2133
 msgid "Web server parameters"
 msgstr "Web-palvelimen asetukset"
 
-#: src/muuli_wdr.cpp:2129
+#: src/muuli_wdr.cpp:2136
 #, fuzzy
 msgid "Run webserver on startup (deprecated)"
 msgstr "Käynnistä web-palvelin käynnistettäessä"
 
-#: src/muuli_wdr.cpp:2135
+#: src/muuli_wdr.cpp:2142
 msgid "Web template"
 msgstr "Web-sapluuna"
 
-#: src/muuli_wdr.cpp:2140
+#: src/muuli_wdr.cpp:2147
 msgid "Full rights password"
 msgstr "Täysien oikeuksien salasana"
 
-#: src/muuli_wdr.cpp:2144
+#: src/muuli_wdr.cpp:2151
 msgid "Enable Low rights User"
 msgstr "Salli rajoitettujen oikeuksien käyttäjä"
 
-#: src/muuli_wdr.cpp:2163
+#: src/muuli_wdr.cpp:2170
 msgid "Enable UPnP port forwarding of the web server port"
 msgstr "Käytä UPnP-portinohjausta web-palvelimen portissa"
 
-#: src/muuli_wdr.cpp:2168
+#: src/muuli_wdr.cpp:2175
 msgid "Web server UPnP TCP port (Optional)"
 msgstr "Web-palvelimen UPnP TCP-portti (Valinnainen)"
 
-#: src/muuli_wdr.cpp:2176
+#: src/muuli_wdr.cpp:2183
 msgid "Page Refresh Time (in secs)"
 msgstr "Sivun päivitysväli (sekunneissa)"
 
-#: src/muuli_wdr.cpp:2183
+#: src/muuli_wdr.cpp:2190
 msgid "Enable Gzip compression"
 msgstr "Salli gzip-pakkaus"
 
-#: src/muuli_wdr.cpp:2217
+#: src/muuli_wdr.cpp:2224
 #, fuzzy
 msgid "Reset page to defaults"
 msgstr "Järjestelmän vakio"
 
-#: src/muuli_wdr.cpp:2218
+#: src/muuli_wdr.cpp:2225
 msgid "Reset the settings on the current page to their default values."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2220 src/muuli_wdr.cpp:2306 src/ServerWnd.cpp:274
+#: src/muuli_wdr.cpp:2227 src/muuli_wdr.cpp:2313 src/ServerWnd.cpp:274
 #: src/ServerWnd.cpp:282
 msgid "OK"
 msgstr "OK"
 
-#: src/muuli_wdr.cpp:2222
+#: src/muuli_wdr.cpp:2229
 msgid "Click here to apply any changes made to the preferences."
 msgstr "Napsauta tästä saattaaksesi voimaan asetuksiin tehdyt muutokset."
 
-#: src/muuli_wdr.cpp:2225
+#: src/muuli_wdr.cpp:2232
 msgid "Reset any changes made to the preferences."
 msgstr "Nollaa asetuksiin tekemäsi muutokset."
 
-#: src/muuli_wdr.cpp:2254
+#: src/muuli_wdr.cpp:2261
 msgid "Comment :"
 msgstr "Kommentti :"
 
-#: src/muuli_wdr.cpp:2261
+#: src/muuli_wdr.cpp:2268
 msgid "Incoming Dir :"
 msgstr "Saapuvien kansio :"
 
-#: src/muuli_wdr.cpp:2270
+#: src/muuli_wdr.cpp:2277
 msgid "Change priority for new assigned files :"
 msgstr "Vaihda tärkeyttä uusille sijoitetuille tiedostoille :"
 
-#: src/muuli_wdr.cpp:2274
+#: src/muuli_wdr.cpp:2281
 msgid "Don't change"
 msgstr "Älä vaihda"
 
-#: src/muuli_wdr.cpp:2286
+#: src/muuli_wdr.cpp:2293
 msgid "Select color for this Category (currently selected) :"
 msgstr "Valitse väri tälle luokalle (valittuna) :"
 
-#: src/muuli_wdr.cpp:2353 src/muuli_wdr.cpp:2372 src/muuli_wdr.cpp:2394
+#: src/muuli_wdr.cpp:2360 src/muuli_wdr.cpp:2379 src/muuli_wdr.cpp:2401
 msgid "Click this button to reset the log."
 msgstr "Napsauta tätä painiketta nollataksesi lokin."
 
-#: src/muuli_wdr.cpp:2413
+#: src/muuli_wdr.cpp:2420
 msgid "Click on this button to update the servers list from URL ..."
 msgstr "Napsauta tätä nappia päivittääksesi palvelinlistan osoitteesta ..."
 
-#: src/muuli_wdr.cpp:2417
+#: src/muuli_wdr.cpp:2424
 msgid "Server list"
 msgstr "Palvelinlista"
 
-#: src/muuli_wdr.cpp:2421
+#: src/muuli_wdr.cpp:2428
 msgid "Enter the url to a server.met file here and press the button to the left to update the list of known servers."
 msgstr "Syötä tähän server.met-tiedostoon osoittava url ja paina nappia vasemmalla päivittääksesi tunnettujen palvelimien listan."
 
-#: src/muuli_wdr.cpp:2426
+#: src/muuli_wdr.cpp:2433
 msgid "Add server manually: Name"
 msgstr "Palvelimen lisäys käsin: Nimi"
 
-#: src/muuli_wdr.cpp:2429
+#: src/muuli_wdr.cpp:2436
 msgid "Enter the name of the new server here"
 msgstr "Syötä uuden palvelimen nimi tähän"
 
-#: src/muuli_wdr.cpp:2431 src/ServerWnd.cpp:206
+#: src/muuli_wdr.cpp:2438 src/ServerWnd.cpp:206
 msgid "IP:Port"
 msgstr "IP:Portti"
 
-#: src/muuli_wdr.cpp:2434
+#: src/muuli_wdr.cpp:2441
 msgid "Enter the IP of the server here, using the x.x.x.x format."
 msgstr "Syötä uuden palvelimen IP tähän, muodossa x.x.x.x."
 
-#: src/muuli_wdr.cpp:2440
+#: src/muuli_wdr.cpp:2447
 msgid "Enter the port of the server here."
 msgstr "Syötä palvelimen portti tähän."
 
-#: src/muuli_wdr.cpp:2443
+#: src/muuli_wdr.cpp:2450
 msgid "Add manually a server (fill fields to the left before) ..."
 msgstr "Lisää palvelin käsin (täytä vasemmalla olevat kentät) ..."
 
-#: src/muuli_wdr.cpp:2472
+#: src/muuli_wdr.cpp:2479
 msgid "aMule Log"
 msgstr "aMule loki"
 
-#: src/muuli_wdr.cpp:2480
+#: src/muuli_wdr.cpp:2487
 msgid "Server Info"
 msgstr "Palvelimen tiedot"
 
-#: src/muuli_wdr.cpp:2484
+#: src/muuli_wdr.cpp:2491
 msgid "ED2K Info"
 msgstr "ED2K Info"
 
-#: src/muuli_wdr.cpp:2488
+#: src/muuli_wdr.cpp:2495
 msgid "Kad Info"
 msgstr "Kad Info"
 
-#: src/muuli_wdr.cpp:2516
+#: src/muuli_wdr.cpp:2523
 msgid "Click on this button to update the nodes list from URL ..."
 msgstr "Napsauta tätä nappia päivittääksesi yhteyspisteiden listan osoitteesta ..."
 
-#: src/muuli_wdr.cpp:2520
+#: src/muuli_wdr.cpp:2527
 msgid "Nodes (0)"
 msgstr "Yhteyspisteitä (0)"
 
-#: src/muuli_wdr.cpp:2524
+#: src/muuli_wdr.cpp:2531
 msgid "Enter the url to a nodes.dat file here and press the button to the left to update the list of known nodes."
 msgstr "Syötä tähän nodes.dat-tiedostoon osoittava url ja paina nappia vasemmalla päivittääksesi tunnettujen yhteyspisteiden listan."
 
-#: src/muuli_wdr.cpp:2527
+#: src/muuli_wdr.cpp:2534
 msgid "Nodes stats"
 msgstr "Yhteyspisteiden tilastot"
 
-#: src/muuli_wdr.cpp:2569
+#: src/muuli_wdr.cpp:2576
 msgid "Bootstrap"
 msgstr "Yhdistämisapu"
 
-#: src/muuli_wdr.cpp:2572
+#: src/muuli_wdr.cpp:2579
 msgid "New node"
 msgstr "Uusi yhteyspiste"
 
-#: src/muuli_wdr.cpp:2577
+#: src/muuli_wdr.cpp:2584
 msgid "IP:"
 msgstr "IP:"
 
-#: src/muuli_wdr.cpp:2597
+#: src/muuli_wdr.cpp:2604
 msgid "Port:"
 msgstr "Portti:"
 
-#: src/muuli_wdr.cpp:2610
+#: src/muuli_wdr.cpp:2617
 msgid "Bootstrap from known clients"
 msgstr "Käytä tunnettuja asiakkaita yhdistämisapuna"
 
-#: src/muuli_wdr.cpp:2612
+#: src/muuli_wdr.cpp:2619
 msgid "Disconnect Kad"
 msgstr "Katkaise Kad-yhteys"
 
-#: src/muuli_wdr.cpp:2646
+#: src/muuli_wdr.cpp:2653
 msgid "Use Secure User Identification"
 msgstr "Käytä turvattua käyttäjän tunnistusta"
 
-#: src/muuli_wdr.cpp:2648
+#: src/muuli_wdr.cpp:2655
 msgid "It is recommended to enable this option. You will not receive credits if SUI is not enabled."
 msgstr "Tunnistuksen käyttö on suositeltavaa. Muuten et hyödy pistejärjestelmästä."
 
-#: src/muuli_wdr.cpp:2650
+#: src/muuli_wdr.cpp:2657
 msgid "Protocol Obfuscation"
 msgstr "Protokollan kätkeminen"
 
-#: src/muuli_wdr.cpp:2653
+#: src/muuli_wdr.cpp:2660
 msgid "Support Protocol Obfuscation"
 msgstr "Tuki protokollan kätkemiselle"
 
-#: src/muuli_wdr.cpp:2655
+#: src/muuli_wdr.cpp:2662
 msgid "This option enabled Protocol Obfuscation, and makes aMule accept obfuscated connections from other clients."
 msgstr "Tämä valinta sallii aMulen ottaa vastaan kätketyn protokollan yhteyksiä muilta asiakkailta."
 
-#: src/muuli_wdr.cpp:2657
+#: src/muuli_wdr.cpp:2664
 msgid "Use obfuscation for outgoing connections"
 msgstr "Käytä kätkemistä lähtevissä yhteyksissä"
 
-#: src/muuli_wdr.cpp:2659
+#: src/muuli_wdr.cpp:2666
 msgid "This option makes aMule use Protocol Obfuscation when connecting other clients/servers."
 msgstr "Tämä valittuna aMule käyttää protokollan kätkemistä ottaessaan yhteyttä muihin asiakkaisiin/palvelimiin."
 
-#: src/muuli_wdr.cpp:2661
+#: src/muuli_wdr.cpp:2668
 msgid "Accept only obfuscated connections"
 msgstr "Vastaanota vain kätkettyjä yhteyksiä"
 
-#: src/muuli_wdr.cpp:2662
+#: src/muuli_wdr.cpp:2669
 msgid "This option makes aMule only accept obfuscated connections. You will have less sources, but all your traffic will be obfuscated"
 msgstr "Tämä valittuna aMule hyväksyy vain kätketyt yhteydet. Lähteitä on vähemmän saatavilla mutta kaikki liikenteesi on kätketyllä protokollalla."
 
-#: src/muuli_wdr.cpp:2667
+#: src/muuli_wdr.cpp:2674
 msgid "Everybody"
 msgstr "Kaikki"
 
-#: src/muuli_wdr.cpp:2669
+#: src/muuli_wdr.cpp:2676
 msgid "No one"
 msgstr "Ei kukaan"
 
-#: src/muuli_wdr.cpp:2671
+#: src/muuli_wdr.cpp:2678
 msgid "Who can see my shared files:"
 msgstr "Ketkä voivat nähdä jaetut tiedostoni:"
 
-#: src/muuli_wdr.cpp:2672
+#: src/muuli_wdr.cpp:2679
 msgid "Select who can request to view a list of your shared files."
 msgstr "Valitse ketkä voivat pyytää nähtäville sinun jaettujen tiedostojen listaasi."
 
-#: src/muuli_wdr.cpp:2674
+#: src/muuli_wdr.cpp:2681
 msgid "IP-Filtering"
 msgstr "IP-suodatus"
 
-#: src/muuli_wdr.cpp:2681
+#: src/muuli_wdr.cpp:2688
 msgid "Filter clients"
 msgstr "Suodata asiakkaat"
 
-#: src/muuli_wdr.cpp:2683
+#: src/muuli_wdr.cpp:2690
 msgid "Enable filtering of the client IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "Salli asiakas-IP:den suodatus kuten määritelty tiedostossa ~/.aMule/ipfilter.dat."
 
-#: src/muuli_wdr.cpp:2685
+#: src/muuli_wdr.cpp:2692
 msgid "Filter servers"
 msgstr "Suodata palvelimet"
 
-#: src/muuli_wdr.cpp:2687
+#: src/muuli_wdr.cpp:2694
 msgid "Enable filtering of the server IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "Salli palvelin-IP:den suodatus kuten määritelty tiedostossa ~/.aMule/ipfilter.dat."
 
-#: src/muuli_wdr.cpp:2691
+#: src/muuli_wdr.cpp:2698
 msgid "Reload List"
 msgstr "Uudelleenlataa lista"
 
-#: src/muuli_wdr.cpp:2692
+#: src/muuli_wdr.cpp:2699
 msgid "Reload the list of IPs to filter from the file ~/.aMule/ipfilter.dat"
 msgstr "Uudelleenlataa suodatettavien IP:den lista tiedostosta ~/.aMule/ipfilter.dat."
 
-#: src/muuli_wdr.cpp:2698
+#: src/muuli_wdr.cpp:2705
 msgid "URL:"
 msgstr "URL:"
 
-#: src/muuli_wdr.cpp:2702 src/muuli_wdr.cpp:2895
+#: src/muuli_wdr.cpp:2709 src/muuli_wdr.cpp:2902
 msgid "Update now"
 msgstr "Päivitä nyt"
 
-#: src/muuli_wdr.cpp:2705
+#: src/muuli_wdr.cpp:2712
 msgid "Auto-update ipfilter at startup"
 msgstr "Päivitä ip-suodatus automaattisesti käynnistettäessä"
 
-#: src/muuli_wdr.cpp:2709
+#: src/muuli_wdr.cpp:2716
 msgid "Filtering Level:"
 msgstr "Suodatustaso:"
 
-#: src/muuli_wdr.cpp:2715
+#: src/muuli_wdr.cpp:2722
 msgid "Always filter LAN IPs"
 msgstr "Suodata aina lähiverkon IP:t"
 
-#: src/muuli_wdr.cpp:2718
+#: src/muuli_wdr.cpp:2725
 msgid "Paranoid handling of non-matching IPs"
 msgstr "Käsittele muut IP:t vainoharhaisesti"
 
-#: src/muuli_wdr.cpp:2720
+#: src/muuli_wdr.cpp:2727
 msgid "Rejects a packet when its source IP differs from the IP the client claims (an anti-spoofing check). Disable only if it causes connection problems."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2722
+#: src/muuli_wdr.cpp:2729
 msgid "Use system-wide ipfilter.dat if available"
 msgstr "Käytä järjestelmänlaajuista ipfilter.dat-tiedostoa mikäli saatavilla"
 
-#: src/muuli_wdr.cpp:2723
+#: src/muuli_wdr.cpp:2730
 #, fuzzy
 msgid "If there's no local ipfilter.dat found, allow usage of a system-wide ipfilter file."
 msgstr "Mikäli paikallista ipfilter.dat:ia ei löydy, käytetään järjestelmänlaajuista ipfilter.dat-tiedostoa."
 
-#: src/muuli_wdr.cpp:2740
+#: src/muuli_wdr.cpp:2747
 msgid "Enable Online-Signature"
 msgstr "Kytke Online-Signeeraus päälle"
 
-#: src/muuli_wdr.cpp:2742
+#: src/muuli_wdr.cpp:2749
 msgid "Enables the writing of the OS file, which can be used by external apps to create signatures and the like."
 msgstr "Kytkee päälle Online-Signeeraustiedoston kirjoittamisen, jota muut ohjelmat voivat käyttää esimerkiksi signeerauksissa."
 
-#: src/muuli_wdr.cpp:2746
+#: src/muuli_wdr.cpp:2753
 msgid "Update Frequency (Secs):"
 msgstr "Päivitysväli (sekuntia):"
 
-#: src/muuli_wdr.cpp:2749
+#: src/muuli_wdr.cpp:2756
 msgid "Change the frequency (in seconds) of Online Signature updates."
 msgstr "Muuttaa Online-Signeerauksen päivitysväliä, annetaan sekunteina."
 
-#: src/muuli_wdr.cpp:2757
+#: src/muuli_wdr.cpp:2764
 msgid "Save online signature file in: "
 msgstr "Online-signeeraus-tiedoston tallennuspaikka:"
 
-#: src/muuli_wdr.cpp:2763
+#: src/muuli_wdr.cpp:2770
 msgid "Click here to select the directory containing the the Online Signature files."
 msgstr "Napsauta tästä valitaksesi kansio Online-Signeerauksen tiedostoille."
 
-#: src/muuli_wdr.cpp:2796
+#: src/muuli_wdr.cpp:2803
 msgid "Show country flags for clients"
 msgstr "Näytä asiakkaiden valtioiden liput"
 
-#: src/muuli_wdr.cpp:2797
+#: src/muuli_wdr.cpp:2804
 msgid "Render the country flag column in the transfers, queue and search views. Requires a valid MMDB GeoIP database (see below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2802
+#: src/muuli_wdr.cpp:2809
 #, fuzzy
 msgid "Database"
 msgstr "Siirtonopeus :"
 
-#: src/muuli_wdr.cpp:2818
+#: src/muuli_wdr.cpp:2825
 #, fuzzy
 msgid "Source:"
 msgstr "Lähteet"
 
-#: src/muuli_wdr.cpp:2821
+#: src/muuli_wdr.cpp:2828
 msgid "DB-IP (free, no account)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2822
+#: src/muuli_wdr.cpp:2829
 msgid "MaxMind GeoLite2 (free, account required)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2823
+#: src/muuli_wdr.cpp:2830
 msgid "Custom URL"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2826
+#: src/muuli_wdr.cpp:2833
 msgid "Choose which provider supplies the GeoIP MMDB database. DB-IP is the default - no account required. MaxMind requires a free account + license key. Use Custom URL to point at any other MMDB host (e.g. a local mirror)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2843
+#: src/muuli_wdr.cpp:2850
 msgid ""
 "No configuration required.\n"
 "\n"
@@ -4840,11 +4854,11 @@ msgid ""
 "License: Creative Commons BY 4.0 - https://creativecommons.org/licenses/by/4.0/"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2856
+#: src/muuli_wdr.cpp:2863
 msgid "License key:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2862
+#: src/muuli_wdr.cpp:2869
 msgid ""
 "Sign up for a free MaxMind account, then generate a License Key:\n"
 "https://www.maxmind.com/en/geolite2/signup\n"
@@ -4854,226 +4868,226 @@ msgid ""
 "Requires attribution and account registration; refresh at least every 30 days."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2877
+#: src/muuli_wdr.cpp:2884
 #, fuzzy
 msgid "Download URL:"
 msgstr "Lataus: "
 
-#: src/muuli_wdr.cpp:2883
+#: src/muuli_wdr.cpp:2890
 msgid ""
 "Must point to an .mmdb file or a .gz / .tar.gz containing one.\n"
 "URL may include credentials (https://user:pass@host/...).\n"
 "License and attribution terms are set by the upstream URL - you are responsible."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2896
+#: src/muuli_wdr.cpp:2903
 msgid "Download the GeoIP database from the selected source."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2898
+#: src/muuli_wdr.cpp:2905
 #, fuzzy
 msgid "Auto-update on startup"
 msgstr "Päivitä ip-suodatus automaattisesti käynnistettäessä"
 
-#: src/muuli_wdr.cpp:2899
+#: src/muuli_wdr.cpp:2906
 msgid "Re-download the GeoIP database from the selected source every time aMule starts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2922
+#: src/muuli_wdr.cpp:2929
 msgid "Filter incoming messages (except current chat):"
 msgstr "Suodata saapuvat viestit (ei koske keskusteluja):"
 
-#: src/muuli_wdr.cpp:2924
+#: src/muuli_wdr.cpp:2931
 msgid "Filter all messages"
 msgstr "Suodata kaikki viestit"
 
-#: src/muuli_wdr.cpp:2926
+#: src/muuli_wdr.cpp:2933
 msgid "Filter messages from people not on your friend list"
 msgstr "Suodata viestit ihmisiltä jotka eivät ole kaverilistallasi"
 
-#: src/muuli_wdr.cpp:2928
+#: src/muuli_wdr.cpp:2935
 msgid "Filter messages from unknown clients"
 msgstr "Suodata viestit tuntemattomilta asiakkailta"
 
-#: src/muuli_wdr.cpp:2930
+#: src/muuli_wdr.cpp:2937
 msgid "Filter messages containing (use ',' as separator):"
 msgstr "Suodata viestit jotka sisältävät (käytä merkkiä ',' erottimena):"
 
-#: src/muuli_wdr.cpp:2933 src/muuli_wdr.cpp:2944
+#: src/muuli_wdr.cpp:2940 src/muuli_wdr.cpp:2951
 msgid "add here the words amule should filter and block messages including it"
 msgstr "Syötä tähän suodatettavat sanat ja aMule estää viestit jotka sisältävät sellaisen"
 
-#: src/muuli_wdr.cpp:2935
+#: src/muuli_wdr.cpp:2942
 msgid "Show received messages in the log"
 msgstr "Näytä vastaanotetut viestit lokissa"
 
-#: src/muuli_wdr.cpp:2938
+#: src/muuli_wdr.cpp:2945
 msgid "Comments"
 msgstr "Kommentit"
 
-#: src/muuli_wdr.cpp:2941
+#: src/muuli_wdr.cpp:2948
 msgid "Filter comments containing (use ',' as separator):"
 msgstr "Suodata kommentit jotka sisältävät (käytä merkkiä ',' erottimena):"
 
-#: src/muuli_wdr.cpp:2966
+#: src/muuli_wdr.cpp:2973
 msgid "Enable Proxy"
 msgstr "Käytä välityspalvelinta"
 
-#: src/muuli_wdr.cpp:2967
+#: src/muuli_wdr.cpp:2974
 msgid "Enable/disable proxy support"
 msgstr "Kytke päälle/pois välityspalvelimen tuki"
 
-#: src/muuli_wdr.cpp:2970
+#: src/muuli_wdr.cpp:2977
 msgid "Proxy type:"
 msgstr "Tyyppi:"
 
-#: src/muuli_wdr.cpp:2981
+#: src/muuli_wdr.cpp:2988
 msgid "Proxy host:"
 msgstr "Välityspalvelin:"
 
-#: src/muuli_wdr.cpp:2984
+#: src/muuli_wdr.cpp:2991
 msgid "The proxy host name"
 msgstr "Välityspalvelimen verkkonimi"
 
-#: src/muuli_wdr.cpp:2986
+#: src/muuli_wdr.cpp:2993
 msgid "Proxy port:"
 msgstr "Portti:"
 
-#: src/muuli_wdr.cpp:2989
+#: src/muuli_wdr.cpp:2996
 msgid "The proxy port"
 msgstr "Välityspalvelimen portti"
 
-#: src/muuli_wdr.cpp:2991
+#: src/muuli_wdr.cpp:2998
 msgid "Enable authentication"
 msgstr "Käytä tunnistautumista"
 
-#: src/muuli_wdr.cpp:2992
+#: src/muuli_wdr.cpp:2999
 msgid "Enable/disable username/password authentication"
 msgstr "Kytkee päälle/pois käyttäjänimellä/salasanalla tunnistautumisen"
 
-#: src/muuli_wdr.cpp:2995
+#: src/muuli_wdr.cpp:3002
 msgid "Username: "
 msgstr "Käyttäjänimi: "
 
-#: src/muuli_wdr.cpp:2998
+#: src/muuli_wdr.cpp:3005
 msgid "The username to use to connect to the proxy"
 msgstr "Käyttäjänimi tunnistautuessa välityspalvelimelle"
 
-#: src/muuli_wdr.cpp:3000
+#: src/muuli_wdr.cpp:3007
 msgid "Password:"
 msgstr "Salasana:"
 
-#: src/muuli_wdr.cpp:3003
+#: src/muuli_wdr.cpp:3010
 msgid "The password to use to connect to the proxy"
 msgstr "Salasana tunnistautuessa välityspalvelimelle"
 
-#: src/muuli_wdr.cpp:3022
+#: src/muuli_wdr.cpp:3029
 msgid "Connect to:"
 msgstr "Yhdistä:"
 
-#: src/muuli_wdr.cpp:3031
+#: src/muuli_wdr.cpp:3038
 msgid "Login to remote amule"
 msgstr "Kirjaudu etä-aMuleen"
 
-#: src/muuli_wdr.cpp:3036
+#: src/muuli_wdr.cpp:3043
 msgid "User name"
 msgstr "Käyttäjänimi"
 
-#: src/muuli_wdr.cpp:3047
+#: src/muuli_wdr.cpp:3054
 msgid "Remember those settings"
 msgstr "Muista nämä asetukset"
 
-#: src/muuli_wdr.cpp:3050
+#: src/muuli_wdr.cpp:3057
 #, fuzzy
 msgid "Force ZLIB compression"
 msgstr "Käytä gzip-pakkausta"
 
-#: src/muuli_wdr.cpp:3074
+#: src/muuli_wdr.cpp:3081
 msgid "Enable Verbose Debug-Logging."
 msgstr "Käytä monisanaista lokiin kirjausta."
 
-#: src/muuli_wdr.cpp:3076
+#: src/muuli_wdr.cpp:3083
 #, fuzzy
 msgid "Only to Logfile"
 msgstr "Avaa tied&osto"
 
-#: src/muuli_wdr.cpp:3078
+#: src/muuli_wdr.cpp:3085
 msgid "Message Categories:"
 msgstr "Viestien luokittelut:"
 
-#: src/muuli_wdr.cpp:3102 src/PartFileConvertDlg.cpp:160
+#: src/muuli_wdr.cpp:3109 src/PartFileConvertDlg.cpp:160
 msgid "Waiting..."
 msgstr "Odottaa..."
 
-#: src/muuli_wdr.cpp:3122
+#: src/muuli_wdr.cpp:3129
 msgid "Add imports"
 msgstr "Lisää tuonteja"
 
-#: src/muuli_wdr.cpp:3125
+#: src/muuli_wdr.cpp:3132
 msgid "Retry selected"
 msgstr "Yritä uudelleen valittuja"
 
-#: src/muuli_wdr.cpp:3127
+#: src/muuli_wdr.cpp:3134
 msgid "Remove selected"
 msgstr "Poista valitut"
 
-#: src/muuli_wdr.cpp:3190
+#: src/muuli_wdr.cpp:3197
 msgid "Event Types"
 msgstr "Tapahtumatyypit"
 
-#: src/muuli_wdr.cpp:3209
+#: src/muuli_wdr.cpp:3216
 msgid "Statistics and queued clients for selected file(s) : Session / All time"
 msgstr "Tilastot ja jonottavat asiakkaat valitu(i)lle tiedosto(i)lle: Sessiossa / Yhteensä"
 
-#: src/muuli_wdr.cpp:3233
+#: src/muuli_wdr.cpp:3240
 msgid "Active Uploads"
 msgstr "Aktiiviset lähetykset"
 
-#: src/muuli_wdr.cpp:3247
+#: src/muuli_wdr.cpp:3254
 msgid "Percent of total files"
 msgstr "Prosenttia kaikista tiedostoista"
 
-#: src/muuli_wdr.cpp:3299
+#: src/muuli_wdr.cpp:3306
 msgid "Show Clients for"
 msgstr "Näytä asiakkaat"
 
-#: src/muuli_wdr.cpp:3301
+#: src/muuli_wdr.cpp:3308
 msgid "All files"
 msgstr "Kaikki tiedostot"
 
-#: src/muuli_wdr.cpp:3304
+#: src/muuli_wdr.cpp:3311
 msgid "Selected files"
 msgstr "Valitut tiedostot"
 
-#: src/muuli_wdr.cpp:3307
+#: src/muuli_wdr.cpp:3314
 msgid "Active uploads only"
 msgstr "Vain aktiiviset lähetykset"
 
-#: src/muuli_wdr.cpp:3314
+#: src/muuli_wdr.cpp:3321
 msgid "Reload:"
 msgstr "Uudelleenlataa:"
 
-#: src/muuli_wdr.cpp:3318
+#: src/muuli_wdr.cpp:3325
 msgid "Reload your shared files"
 msgstr "Uudelleenlataa jaetut tiedostot"
 
-#: src/muuli_wdr.cpp:3381
+#: src/muuli_wdr.cpp:3388
 msgid "Send"
 msgstr "Lähetä"
 
-#: src/muuli_wdr.cpp:3382
+#: src/muuli_wdr.cpp:3389
 msgid "Sends the specified message."
 msgstr "Lähettää annetun viestin."
 
-#: src/muuli_wdr.cpp:3386
+#: src/muuli_wdr.cpp:3393
 msgid "Close this chat-session."
 msgstr "Sulje tämä keskustelu."
 
-#: src/muuli_wdr.cpp:3409
+#: src/muuli_wdr.cpp:3416
 msgid "Connect to any server and/or Kad"
 msgstr "Yhdistä mihin tahansa palvelimeen ja/tai Kadiin"
 
-#: src/muuli_wdr.cpp:3415 src/SharedFilesCtrl.cpp:142 src/Statistics.cpp:941
+#: src/muuli_wdr.cpp:3422 src/SharedFilesCtrl.cpp:142 src/Statistics.cpp:941
 msgid "Shared Files"
 msgstr "Jaetut tiedostot"
 
@@ -5432,188 +5446,188 @@ msgstr "Ladattu"
 msgid "ERROR: Failed to open partfile '%s'"
 msgstr "VIRHE: Ei voida avata osatiedostoa '%s'"
 
-#: src/Preferences.cpp:673
+#: src/Preferences.cpp:674
 msgid "System default"
 msgstr "Järjestelmän vakio"
 
-#: src/Preferences.cpp:674
+#: src/Preferences.cpp:675
 msgid "Albanian"
 msgstr "Albania"
 
-#: src/Preferences.cpp:675
+#: src/Preferences.cpp:676
 msgid "Arabic"
 msgstr "Arabia"
 
-#: src/Preferences.cpp:676
+#: src/Preferences.cpp:677
 msgid "Asturian"
 msgstr "Asturia"
 
-#: src/Preferences.cpp:677
+#: src/Preferences.cpp:678
 msgid "Basque"
 msgstr "Baski"
 
-#: src/Preferences.cpp:678
+#: src/Preferences.cpp:679
 msgid "Bulgarian"
 msgstr "Bulgaria"
 
-#: src/Preferences.cpp:679
+#: src/Preferences.cpp:680
 msgid "Catalan"
 msgstr "Katalaani"
 
-#: src/Preferences.cpp:680
+#: src/Preferences.cpp:681
 msgid "Chinese (Simplified)"
 msgstr "Kiina (Yksinkertaistettu)"
 
-#: src/Preferences.cpp:681
+#: src/Preferences.cpp:682
 msgid "Chinese (Traditional)"
 msgstr "Kiina (Perinteinen)"
 
-#: src/Preferences.cpp:682
+#: src/Preferences.cpp:683
 msgid "Croatian"
 msgstr "Kroatia"
 
-#: src/Preferences.cpp:683
+#: src/Preferences.cpp:684
 msgid "Czech"
 msgstr "Tsekki"
 
-#: src/Preferences.cpp:684
+#: src/Preferences.cpp:685
 msgid "Danish"
 msgstr "Tanska"
 
-#: src/Preferences.cpp:685
+#: src/Preferences.cpp:686
 msgid "Dutch"
 msgstr "Hollanti"
 
-#: src/Preferences.cpp:686
+#: src/Preferences.cpp:687
 msgid "English (U.K.)"
 msgstr "Englanti (U.K.)"
 
-#: src/Preferences.cpp:687
+#: src/Preferences.cpp:688
 #, fuzzy
 msgid "English (U.S.)"
 msgstr "Englanti (U.K.)"
 
-#: src/Preferences.cpp:688
+#: src/Preferences.cpp:689
 msgid "Estonian"
 msgstr "Viro"
 
-#: src/Preferences.cpp:689
+#: src/Preferences.cpp:690
 msgid "Finnish"
 msgstr "Suomi"
 
-#: src/Preferences.cpp:690
+#: src/Preferences.cpp:691
 msgid "French"
 msgstr "Ranska"
 
-#: src/Preferences.cpp:691
+#: src/Preferences.cpp:692
 msgid "Galician"
 msgstr "Galicia (Galego)"
 
-#: src/Preferences.cpp:692
+#: src/Preferences.cpp:693
 msgid "German"
 msgstr "Saksa"
 
-#: src/Preferences.cpp:693
+#: src/Preferences.cpp:694
 msgid "Greek"
 msgstr "Kreikka"
 
-#: src/Preferences.cpp:694
+#: src/Preferences.cpp:695
 msgid "Hebrew"
 msgstr "Heprea"
 
-#: src/Preferences.cpp:695
+#: src/Preferences.cpp:696
 msgid "Hungarian"
 msgstr "Unkari"
 
-#: src/Preferences.cpp:696
+#: src/Preferences.cpp:697
 msgid "Italian"
 msgstr "Italia"
 
-#: src/Preferences.cpp:697
+#: src/Preferences.cpp:698
 msgid "Japanese"
 msgstr "Japani"
 
-#: src/Preferences.cpp:698
+#: src/Preferences.cpp:699
 msgid "Korean"
 msgstr "Korea"
 
-#: src/Preferences.cpp:699
+#: src/Preferences.cpp:700
 msgid "Latvian"
 msgstr ""
 
-#: src/Preferences.cpp:700
+#: src/Preferences.cpp:701
 msgid "Lithuanian"
 msgstr "Liettua"
 
-#: src/Preferences.cpp:701
+#: src/Preferences.cpp:702
 msgid "Norwegian (Nynorsk)"
 msgstr "Norja (Nynorsk)"
 
-#: src/Preferences.cpp:702
+#: src/Preferences.cpp:703
 msgid "Polish"
 msgstr "Puola"
 
-#: src/Preferences.cpp:703
+#: src/Preferences.cpp:704
 msgid "Portuguese"
 msgstr "Portugali"
 
-#: src/Preferences.cpp:704
+#: src/Preferences.cpp:705
 msgid "Portuguese (Brazilian)"
 msgstr "Portugali (Brazilia)"
 
-#: src/Preferences.cpp:705
+#: src/Preferences.cpp:706
 msgid "Romanian"
 msgstr "Romanian"
 
-#: src/Preferences.cpp:706
+#: src/Preferences.cpp:707
 msgid "Russian"
 msgstr "Venäjä"
 
-#: src/Preferences.cpp:707
+#: src/Preferences.cpp:708
 msgid "Slovenian"
 msgstr "Slovenia"
 
-#: src/Preferences.cpp:708
+#: src/Preferences.cpp:709
 msgid "Spanish"
 msgstr "Espanja"
 
-#: src/Preferences.cpp:709
+#: src/Preferences.cpp:710
 msgid "Swedish"
 msgstr "Ruotsi"
 
-#: src/Preferences.cpp:710
+#: src/Preferences.cpp:711
 msgid "Turkish"
 msgstr "Turkki"
 
-#: src/Preferences.cpp:711
+#: src/Preferences.cpp:712
 msgid "Ukrainian"
 msgstr "Ukraina"
 
-#: src/Preferences.cpp:814
+#: src/Preferences.cpp:815
 msgid "Change Language"
 msgstr "Vaihda kieli"
 
-#: src/Preferences.cpp:878
+#: src/Preferences.cpp:879
 msgid "There are no translations installed for aMule"
 msgstr "Käännöksiä ei ole asennettuna aMulelle"
 
-#: src/Preferences.cpp:879
+#: src/Preferences.cpp:880
 msgid "No languages available"
 msgstr "Kieliä ei saatavilla"
 
-#: src/Preferences.cpp:1010
+#: src/Preferences.cpp:1011
 msgid "no options available"
 msgstr "vaihtoehtoja ei saatavilla"
 
-#: src/Preferences.cpp:2179
+#: src/Preferences.cpp:2182
 msgid "Invalid category found, skipping"
 msgstr "Löytyi epäkelpo luokka, hypätään yli"
 
-#: src/Preferences.cpp:2348
+#: src/Preferences.cpp:2351
 msgid "TCP port can't be higher than 65532 due to server UDP socket being TCP+3"
 msgstr "TCP-portti ei voi olla korkeampi kuin 65532 koska serverin käyttämä UDP-pistukka on TCP+3"
 
-#: src/Preferences.cpp:2349
+#: src/Preferences.cpp:2352
 #, c-format
 msgid "Default port will be used (%d)"
 msgstr "Käytetään oletusporttia (%d)"
@@ -6124,24 +6138,28 @@ msgstr "Lataa uudelleen lista jaetuista tiedostoista."
 msgid "Shared folder"
 msgstr "Jaetut kansiot"
 
-#: src/SearchDlg.cpp:425
+#: src/SearchDlg.cpp:280
+msgid "Clear search history"
+msgstr ""
+
+#: src/SearchDlg.cpp:584
 msgid "It's impossible to search when both eD2k and Kademlia are disabled."
 msgstr ""
 
-#: src/SearchDlg.cpp:426 src/SearchListCtrl.cpp:858
+#: src/SearchDlg.cpp:585 src/SearchListCtrl.cpp:858
 #, fuzzy
 msgid "Search error"
 msgstr "Haut"
 
-#: src/SearchDlg.cpp:768
+#: src/SearchDlg.cpp:929
 msgid "Min size must be smaller than max size. Max size ignored."
 msgstr "Vähimmäiskoon pitää olla pienempi kuin enimmäiskoon. Enimmäiskokoa ei huomioida."
 
-#: src/SearchDlg.cpp:769 src/SearchDlg.cpp:851
+#: src/SearchDlg.cpp:930 src/SearchDlg.cpp:1012
 msgid "Search warning"
 msgstr "Hakuvaroitus"
 
-#: src/SearchDlg.cpp:929 src/SearchListCtrl.cpp:735
+#: src/SearchDlg.cpp:1092 src/SearchListCtrl.cpp:735
 msgid "Main"
 msgstr "Kaikki"
 

--- a/po/fi.po
+++ b/po/fi.po
@@ -11,8 +11,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-28 12:12+0200\n"
-"PO-Revision-Date: 2026-07-27 10:21+0000\n"
+"POT-Creation-Date: 2026-07-28 08:06+0200\n"
+"PO-Revision-Date: 2026-07-27 11:37+0000\n"
 "Last-Translator: Tapio Rantala <tapio.rantala@iki.fi>\n"
 "Language-Team: aMule Team <https://github.com/amule-org/amule>\n"
 "Language: fi\n"
@@ -146,7 +146,7 @@ msgstr ""
 msgid "Not now"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:422 src/amuleDlg.cpp:665
+#: src/AppImageIntegration.cpp:422 src/amuleDlg.cpp:600
 msgid "Don't ask again"
 msgstr ""
 
@@ -204,83 +204,83 @@ msgstr "ED2KLinks-tiedoston avaus epäonnistui."
 msgid "WARNING: You can't add yourself as a source for an eD2k link while having a lowid."
 msgstr "VAROITUS: Et voi lisätä itseäsi lähteeksi eD2k-linkkiin kun sinulla on LowID."
 
-#: src/amule.cpp:301
+#: src/amule.cpp:300
 msgid "Now, exiting main app..."
 msgstr "Pääohjelmaa suljetaan..."
 
-#: src/amule.cpp:331
+#: src/amule.cpp:330
 #, c-format
 msgid "Terminating amuleweb instance with pid '%d' ... "
 msgstr "Lopetetaan amulewebin instanssi prosessinumerolla '%d' ... "
 
-#: src/amule.cpp:335
+#: src/amule.cpp:334
 #, c-format
 msgid "Killing amuleweb instance with pid '%d' ... "
 msgstr "Tuhotaan amulewebin instanssi prosessinumerolla '%d' ... "
 
-#: src/amule.cpp:337 src/amule.cpp:350 src/ClientRef.cpp:180
-#: src/SearchDlg.cpp:1041 src/ServerListCtrl.cpp:98
+#: src/amule.cpp:336 src/amule.cpp:349 src/ClientRef.cpp:180
+#: src/SearchDlg.cpp:880 src/ServerListCtrl.cpp:98
 msgid "Failed"
 msgstr "Epäonnistunut"
 
-#: src/amule.cpp:344
+#: src/amule.cpp:343
 #, fuzzy, c-format
 msgid "Terminating amuleapi instance with pid '%d' ... "
 msgstr "Lopetetaan amulewebin instanssi prosessinumerolla '%d' ... "
 
-#: src/amule.cpp:348
+#: src/amule.cpp:347
 #, fuzzy, c-format
 msgid "Killing amuleapi instance with pid '%d' ... "
 msgstr "Tuhotaan amulewebin instanssi prosessinumerolla '%d' ... "
 
-#: src/amule.cpp:356
+#: src/amule.cpp:355
 msgid "aMule OnExit: Terminating core."
 msgstr "aMulen poistuessa: Lopetetaan ydin."
 
-#: src/amule.cpp:467
+#: src/amule.cpp:466
 msgid "aMule shutdown completed."
 msgstr "aMule sammutettu."
 
-#: src/amule.cpp:471
+#: src/amule.cpp:470
 msgid "Memory debug results for aMule exit:"
 msgstr "Muistin virheiden etsinnän tulokset aMulen sulkeutuessa:"
 
-#: src/amule.cpp:652
+#: src/amule.cpp:651
 #, c-format
 msgid "Binding aMule's peer-to-peer traffic to interface: %s (HTTP updates use the default route)"
 msgstr ""
 
-#: src/amule.cpp:656
+#: src/amule.cpp:655
 #, c-format
 msgid "Binding all network traffic to interface: %s"
 msgstr ""
 
-#: src/amule.cpp:660
+#: src/amule.cpp:659
 #, c-format
 msgid "WARNING: configured network interface '%s' was not found - traffic is NOT bound to it and may leave via the default route. Check the interface name in Preferences."
 msgstr ""
 
-#: src/amule.cpp:666
+#: src/amule.cpp:665
 #, c-format
 msgid "WARNING: binding to network interface '%s' requires elevated privileges and was NOT applied - traffic may leave via the default route. Grant the capability (e.g. 'sudo setcap cap_net_raw+ep' on the aMule binary) or run with sufficient privileges."
 msgstr ""
 
-#: src/amule.cpp:674
+#: src/amule.cpp:673
 #, c-format
 msgid "WARNING: could not bind to network interface '%s' - traffic may leave via the default route."
 msgstr ""
 
-#: src/amule.cpp:733
+#: src/amule.cpp:732
 msgid "Your locale has been changed to System Default due to a configuration change. Sorry."
 msgstr "Maa-asetuksesi vaihdettiin järjestelmän oletuksiksi asetusmuutoksen takia. Pahoittelen."
 
-#: src/amule.cpp:735 src/amule.cpp:1589 src/CatDialog.cpp:128
+#: src/amule.cpp:734 src/amule.cpp:1581 src/CatDialog.cpp:128
 #: src/CatDialog.cpp:136 src/CatDialog.cpp:149 src/ServerList.cpp:366
 #: src/ServerListCtrl.cpp:152
 msgid "Info"
 msgstr "Info"
 
-#: src/amule.cpp:742
+#: src/amule.cpp:741
 msgid ""
 "\n"
 "EC configuration"
@@ -288,74 +288,74 @@ msgstr ""
 "\n"
 "Etäyhteyksien asetukset"
 
-#: src/amule.cpp:745
+#: src/amule.cpp:744
 msgid "Password set and external connections enabled."
 msgstr "Salasana asetettu ja etäyhteydet sallittu."
 
-#: src/amule.cpp:755 src/KadDlg.cpp:176 src/KadDlg.cpp:185
-#: src/PrefsUnifiedDlg.cpp:1461 src/SharedFilesCtrl.cpp:476
+#: src/amule.cpp:754 src/KadDlg.cpp:176 src/KadDlg.cpp:185
+#: src/PrefsUnifiedDlg.cpp:1387 src/SharedFilesCtrl.cpp:476
 msgid "WARNING"
 msgstr "VAROITUS"
 
-#: src/amule.cpp:992
+#: src/amule.cpp:991
 #, fuzzy
 msgid "Network bootstrap"
 msgstr "Verkot"
 
-#: src/amule.cpp:997
+#: src/amule.cpp:996
 msgid ""
 "aMule has detected missing network bootstrap files.\n"
 "Select which ones to download:"
 msgstr ""
 
-#: src/amule.cpp:1006 src/FirstRunWizard.cpp:411
+#: src/amule.cpp:1005 src/FirstRunWizard.cpp:411
 #, fuzzy
 msgid "eD2k server list (server.met)"
 msgstr "%i palvelin tiedostossa server.met"
 
-#: src/amule.cpp:1013 src/FirstRunWizard.cpp:416
+#: src/amule.cpp:1012 src/FirstRunWizard.cpp:416
 msgid "Kad bootstrap nodes (nodes.dat)"
 msgstr ""
 
-#: src/amule.cpp:1103
+#: src/amule.cpp:1102
 #, c-format
 msgid "web server running on pid %d"
 msgstr "web-palvelin käynnissä prosessinumerolla %d"
 
-#: src/amule.cpp:1116
+#: src/amule.cpp:1115
 #, fuzzy
 msgid "You requested to run web server on startup, but the amuleweb binary cannot be run. Please install the package containing aMule web server, or build aMule from source with -DBUILD_WEBSERVER=YES and install it."
 msgstr "Olet asettanut web-palvelimen ajettavaksi käynnistettäessä, mutta amuleweb-ohjelmaa ei voida ajaa. Ole hyvä ja asenna aMule web-palvelimen sisältävä paketti tai käännä aMule käyttäen parametria --enable-webserver ja suorita make install"
 
-#: src/amule.cpp:1121 src/amule.cpp:1185 src/amule.cpp:1299 src/amule.cpp:1601
+#: src/amule.cpp:1120 src/amule.cpp:1177 src/amule.cpp:1291 src/amule.cpp:1593
 #: src/amule-remote-gui.cpp:603 src/amule-remote-gui.cpp:671
 #: src/amule-remote-gui.cpp:709 src/amule-remote-gui.cpp:1282
 #: src/amule-remote-gui.cpp:1345 src/amule-remote-gui.cpp:1372
-#: src/DownloadQueue.cpp:1481 src/PrefsUnifiedDlg.cpp:1247
+#: src/DownloadQueue.cpp:1481
 msgid "ERROR"
 msgstr "VIRHE"
 
-#: src/amule.cpp:1174
+#: src/amule.cpp:1166
 #, fuzzy, c-format
 msgid "amuleapi running on pid %d"
 msgstr "web-palvelin käynnissä prosessinumerolla %d"
 
-#: src/amule.cpp:1180
+#: src/amule.cpp:1172
 #, fuzzy
 msgid "You requested to run amuleapi on startup, but the amuleapi binary cannot be run. Please install the package containing aMule's REST API server, or build aMule from source with -DBUILD_AMULEAPI=YES and install it."
 msgstr "Olet asettanut web-palvelimen ajettavaksi käynnistettäessä, mutta amuleweb-ohjelmaa ei voida ajaa. Ole hyvä ja asenna aMule web-palvelimen sisältävä paketti tai käännä aMule käyttäen parametria --enable-webserver ja suorita make install"
 
-#: src/amule.cpp:1267
+#: src/amule.cpp:1259
 #, c-format
 msgid "Could not bind ports to the specified address: %s"
 msgstr "Ei voitu sitoa portteja annettuun osoitteeseen: %s"
 
-#: src/amule.cpp:1291
+#: src/amule.cpp:1283
 #, c-format
 msgid "Port %u is not available. You will be LOWID\n"
 msgstr "Portti %u ei ole saatavilla. Sinulle annetaan LowID\n"
 
-#: src/amule.cpp:1296
+#: src/amule.cpp:1288
 #, c-format
 msgid ""
 "Port %u is not available!\n"
@@ -370,48 +370,48 @@ msgstr ""
 "\n"
 "Tarkista yhteytesi varmistaaksesi että portti on avoinna sekä ulos että sisään."
 
-#: src/amule.cpp:1393
+#: src/amule.cpp:1385
 msgid "Failed to create OnlineSig File"
 msgstr "Online-Signeeraustiedoston luonti epäonnistui"
 
-#: src/amule.cpp:1401
+#: src/amule.cpp:1393
 msgid "Failed to create aMule OnlineSig File"
 msgstr "aMulen Online-Signeeraustiedoston luonti epäonnistui"
 
-#: src/amule.cpp:1564
+#: src/amule.cpp:1556
 msgid "The selected locale seems not to be installed on your box. (Note: I'll try to set it anyway)"
 msgstr "Valittu maa-asetus ei näytä olevan asennettuna järjestelmääsi. (Huom: Yritän asettaa sen kuitenkin)"
 
-#: src/amule.cpp:1574
+#: src/amule.cpp:1566
 #, c-format
 msgid "This is the first time you run aMule %s"
 msgstr "Tämä on ensimmäinen kerta kun käynnistät aMulen version %s"
 
-#: src/amule.cpp:1577
+#: src/amule.cpp:1569
 msgid "This version is a testing version, updated daily, and\n"
 msgstr "Tämä versio on testiversio jota päivitetään päivittäin,\n"
 
-#: src/amule.cpp:1578
+#: src/amule.cpp:1570
 msgid "we give no warranty it won't break anything, burn your house,\n"
 msgstr "emmekä me anna takuuta ettei se riko mitään, polta taloasi,\n"
 
-#: src/amule.cpp:1579
+#: src/amule.cpp:1571
 msgid "or kill your dog. But it *should* be safe to use anyway.\n"
 msgstr "tai tapa koiraasi. Mutta sen *pitäisi* olla silti turvallinen käyttää.\n"
 
-#: src/amule.cpp:1584
+#: src/amule.cpp:1576
 msgid "More information, support and new releases can found at our homepage,\n"
 msgstr "Lisätietoa, tukea ja uudet julkaisut löytyvät kotisivuiltamme osoitteessa\n"
 
-#: src/amule.cpp:1585
+#: src/amule.cpp:1577
 msgid "at https://amule-org.github.io, or in our IRC channel #aMule at irc.libera.chat.\n"
 msgstr "https://amule-org.github.io tai IRC-kanavaltamme #aMule palvelimella irc.libera.chat (englanniksi).\n"
 
-#: src/amule.cpp:1587
+#: src/amule.cpp:1579
 msgid "Feel free to report any bugs to https://github.com/amule-org/amule/issues"
 msgstr "Voit vapaasti raportoida bugeista osoitteessa https://github.com/amule-org/amule/issues"
 
-#: src/amule.cpp:1599
+#: src/amule.cpp:1591
 msgid ""
 "The folder for Online Signature files you specified is INVALID!\n"
 " OnlineSignature will be DISABLED until you fix it on preferences."
@@ -419,137 +419,137 @@ msgstr ""
 "Online-Signeeraukselle asettamasi kansio ei ole kelvollinen!\n"
 " Online-Signeeraus kytketään pois päältä kunnes korjaat asian asetuksista."
 
-#: src/amule.cpp:1662
+#: src/amule.cpp:1654
 msgid "Server hostname notified"
 msgstr "Palvelimen verkkonimi ilmoitettu"
 
-#: src/amule.cpp:2039
+#: src/amule.cpp:2031
 #, c-format
 msgid "Disk space preallocation for file '%s' failed: %s"
 msgstr "Levytilan esivaraus tiedostolle '%s' epäonnistui: %s"
 
-#: src/amule.cpp:2168
+#: src/amule.cpp:2160
 msgid "ERROR: can't open logfile"
 msgstr "VIRHE: Lokitiedostoa ei voida avata"
 
-#: src/amule.cpp:2172
+#: src/amule.cpp:2164
 msgid "WARNING: logfile is empty. Something is wrong."
 msgstr "VAROITUS: Lokitiedosto on tyhjä. Jotain on pielessä."
 
-#: src/amule.cpp:2189
+#: src/amule.cpp:2181
 msgid "Log has been reset"
 msgstr "Loki nollattiin"
 
-#: src/amule.cpp:2213
+#: src/amule.cpp:2205
 #, c-format
 msgid "ServerMessage: %s"
 msgstr "Palvelimen viesti: %s"
 
-#: src/amule.cpp:2256 src/IP2Country.cpp:220 src/IPFilter.cpp:514
+#: src/amule.cpp:2248 src/IP2Country.cpp:220 src/IPFilter.cpp:514
 #: src/ServerList.cpp:875
 #, c-format
 msgid "Skipped download of %s, because requested file is not newer."
 msgstr "Hypättiin yli latauksesta %s, koska pyydetty tiedosto ei ole uudempi."
 
-#: src/amule.cpp:2259
+#: src/amule.cpp:2251
 msgid "Failed to download the nodes list."
 msgstr "Yhteyspisteiden listan lataus epäonnistui."
 
-#: src/amule.cpp:2322
+#: src/amule.cpp:2314
 msgid "Failed to open the downloaded version check file"
 msgstr "Ladatun versiotarkistustiedoston avaus epäonnistui"
 
-#: src/amule.cpp:2325 src/amule.cpp:2344
+#: src/amule.cpp:2317 src/amule.cpp:2336
 msgid "Corrupted version check file"
 msgstr "Turmeltunut versiotarkistustiedosto"
 
-#: src/amule.cpp:2367
+#: src/amule.cpp:2359
 msgid "You are using an outdated version of aMule!"
 msgstr "Käytät vanhentunutta versiota aMulesta!"
 
-#: src/amule.cpp:2369
+#: src/amule.cpp:2361
 #, c-format
 msgid "Your aMule version is %i.%i.%i and the latest version is %li.%li.%li"
 msgstr "Tämän aMulen versio on %i.%i.%i ja uusin versio on %li.%li.%li"
 
-#: src/amule.cpp:2373
+#: src/amule.cpp:2365
 msgid "The latest version can always be found at https://github.com/amule-org/amule/releases/latest"
 msgstr "Uusin version löytyy aina osoitteesta https://github.com/amule-org/amule/releases/latest"
 
-#: src/amule.cpp:2376
+#: src/amule.cpp:2368
 #, c-format
 msgid "WARNING: Your aMuled version is outdated: %i.%i.%i < %li.%li.%li"
 msgstr "VAROITUS: aMulesi versio on vanhentunut: %i.%i.%i < %li.%li.%li"
 
-#: src/amule.cpp:2382
+#: src/amule.cpp:2374
 msgid "Your copy of aMule is up to date."
 msgstr "aMulesi on uusinta versiota."
 
-#: src/amule.cpp:2389
+#: src/amule.cpp:2381
 msgid "Failed to download the version check file"
 msgstr "Versiotarkistustiedoston lataus epäonnistui"
 
-#: src/amule.cpp:2558 src/amule-remote-gui.cpp:1133
+#: src/amule.cpp:2550 src/amule-remote-gui.cpp:1133
 #, c-format
 msgid "Users: %s | Files: %s"
 msgstr "Käyttäjiä: %s | Tiedostoja: %s"
 
-#: src/amule.cpp:2559 src/amule-remote-gui.cpp:1134
+#: src/amule.cpp:2551 src/amule-remote-gui.cpp:1134
 #, c-format
 msgid "Users: E: %s K: %s | Files: E: %s K: %s"
 msgstr "Käyttäjiä: E: %s K: %s | Tiedostoja: E: %s K: %s"
 
-#: src/amule.cpp:2573 src/amule-remote-gui.cpp:1147
+#: src/amule.cpp:2565 src/amule-remote-gui.cpp:1147
 msgid "No networks selected"
 msgstr "Ei valittuja verkkoja"
 
-#: src/amule.cpp:2641 src/TextClient.cpp:903
+#: src/amule.cpp:2633 src/TextClient.cpp:903
 msgid "with LowID"
 msgstr "LowID:llä"
 
-#: src/amule.cpp:2641 src/TextClient.cpp:904
+#: src/amule.cpp:2633 src/TextClient.cpp:904
 msgid "with HighID"
 msgstr "HighID:llä"
 
-#: src/amule.cpp:2643
+#: src/amule.cpp:2635
 #, c-format
 msgid "Connected to %s %s"
 msgstr "Yhdistetty %s %s"
 
-#: src/amule.cpp:2648
+#: src/amule.cpp:2640
 #, c-format
 msgid "Connecting to %s"
 msgstr "Yhdistän %s"
 
-#: src/amule.cpp:2650
+#: src/amule.cpp:2642
 msgid "Disconnected from eD2k"
 msgstr "eD2k-yhteys katkaistu"
 
-#: src/amule.cpp:2659
+#: src/amule.cpp:2651
 msgid "Kad started."
 msgstr "Käynnistettiin Kad."
 
-#: src/amule.cpp:2661
+#: src/amule.cpp:2653
 msgid "Kad stopped."
 msgstr "Pysäytettiin Kad."
 
-#: src/amule.cpp:2669
+#: src/amule.cpp:2661
 msgid "Connected to Kad (ok)"
 msgstr "Yhdistetty Kadiin (ok)"
 
-#: src/amule.cpp:2671
+#: src/amule.cpp:2663
 msgid "Connected to Kad (firewalled)"
 msgstr "Yhdistetty Kadiin (palomuurattu)"
 
-#: src/amule.cpp:2675
+#: src/amule.cpp:2667
 msgid "Disconnected from Kad"
 msgstr "Yhteys Kadiin katkaistu"
 
-#: src/amule.cpp:2707
+#: src/amule.cpp:2699
 msgid "Kad network cannot be used if UDP port is disabled on preferences, not starting."
 msgstr "Kad-verkkoa ei voida käyttää mikäli UDP-portti on estetty asetuksissa, ei käynnistetä."
 
-#: src/amule.cpp:2711
+#: src/amule.cpp:2703
 msgid "Kad network disabled on preferences, not connecting."
 msgstr "Kad-verkko estetty asetuksissa, ei yhdistetä."
 
@@ -575,68 +575,30 @@ msgstr "Ei voitu luoda prosessinumerotiedostoa"
 msgid "ERROR: %s"
 msgstr "VIRHE: %s"
 
-#: src/amuleDlg.cpp:250
+#: src/amuleDlg.cpp:236
 #, c-format
 msgid "This is aMule %s based on eMule."
 msgstr "Tämä on aMule %s ja pohjautuu eMuleen."
 
-#: src/amuleDlg.cpp:251
+#: src/amuleDlg.cpp:237
 #, c-format
 msgid "Running on %s"
 msgstr "Käynnissä %s"
 
-#: src/amuleDlg.cpp:253
+#: src/amuleDlg.cpp:239
 msgid "Visit https://github.com/amule-org/amule/releases/latest to check if a new version is available."
 msgstr "Vieraile nettisivulla https://github.com/amule-org/amule/releases/latest tarkistaaksi uuden version saatavuuden."
 
-#: src/amuleDlg.cpp:282
+#: src/amuleDlg.cpp:268
 msgid "FATAL ERROR: Failed to create Timer"
 msgstr "KRIITTINEN VIRHE: Ajastimen luominen epäonnistui"
 
-#: src/amuleDlg.cpp:361 src/amuleDlg.cpp:1810 src/amuleDlg.cpp:2056
-#: src/muuli_wdr.cpp:1492 src/muuli_wdr.cpp:3439
-msgid "Networks"
-msgstr "Verkot"
-
-#: src/amuleDlg.cpp:362 src/amuleDlg.cpp:1816 src/muuli_wdr.cpp:3440
-msgid "Searches"
-msgstr "Haut"
-
-#: src/amuleDlg.cpp:363 src/amuleDlg.cpp:1822 src/DownloadListCtrl.cpp:740
-#: src/muuli_wdr.cpp:392 src/muuli_wdr.cpp:1585 src/muuli_wdr.cpp:3441
-#: src/Statistics.cpp:829
-msgid "Downloads"
-msgstr "Lataukset"
-
-#: src/amuleDlg.cpp:364 src/amuleDlg.cpp:1828 src/muuli_wdr.cpp:3315
-msgid "Shared files"
-msgstr "Jaetut tiedostot"
-
-#: src/amuleDlg.cpp:365 src/amuleDlg.cpp:1834 src/muuli_wdr.cpp:2947
-#: src/muuli_wdr.cpp:3397 src/muuli_wdr.cpp:3444
-msgid "Messages"
-msgstr "Viestit"
-
-#: src/amuleDlg.cpp:366 src/amuleDlg.cpp:1840 src/muuli_wdr.cpp:3445
-#: src/PrefsUnifiedDlg.cpp:314 src/Statistics.cpp:779 src/Statistics.cpp:1235
-msgid "Statistics"
-msgstr "Tilastot"
-
-#: src/amuleDlg.cpp:368 src/amuleDlg.cpp:1847 src/muuli_wdr.cpp:3447
-#: src/PrefsUnifiedDlg.cpp:330 src/utils/wxCas/src/wxcasprefs.cpp:39
-msgid "Preferences"
-msgstr "Asetukset"
-
-#: src/amuleDlg.cpp:371
-msgid "Navigate"
-msgstr ""
-
-#: src/amuleDlg.cpp:657
+#: src/amuleDlg.cpp:592
 #, fuzzy
 msgid "New version available"
 msgstr "Ei saatavissa"
 
-#: src/amuleDlg.cpp:661
+#: src/amuleDlg.cpp:596
 #, fuzzy, c-format
 msgid ""
 "A new version of aMule (%s) is available.\n"
@@ -646,185 +608,218 @@ msgid ""
 "Would you like to open the download page?"
 msgstr "Uusin version löytyy aina osoitteesta https://github.com/amule-org/amule/releases/latest"
 
-#: src/amuleDlg.cpp:743
+#: src/amuleDlg.cpp:678
 msgid "aMule dialog destroyed"
 msgstr "aMulen dialogi tuhottu"
 
-#: src/amuleDlg.cpp:766 src/DataToText.cpp:68 src/IPFilter.cpp:547
+#: src/amuleDlg.cpp:701 src/DataToText.cpp:68 src/IPFilter.cpp:547
 msgid "Connecting"
 msgstr "Yhdistetään"
 
-#: src/amuleDlg.cpp:958
+#: src/amuleDlg.cpp:893
 msgid "eD2k: Connecting"
 msgstr "eD2k: Yhdistetään"
 
-#: src/amuleDlg.cpp:962
+#: src/amuleDlg.cpp:897
 msgid "eD2k: Disconnected"
 msgstr "eD2k: Ei yhdistetty"
 
-#: src/amuleDlg.cpp:968
+#: src/amuleDlg.cpp:903
 msgid "Kad: Firewalled"
 msgstr "Kad: Palomuurattu"
 
-#: src/amuleDlg.cpp:972
+#: src/amuleDlg.cpp:907
 msgid "Kad: Connected"
 msgstr "Kad: Yhdistety"
 
-#: src/amuleDlg.cpp:977
+#: src/amuleDlg.cpp:912
 msgid "Kad: Connecting"
 msgstr "Kad: Yhdistetään"
 
-#: src/amuleDlg.cpp:981
+#: src/amuleDlg.cpp:916
 msgid "Kad: Off"
 msgstr "Kad: Pois päältä"
 
-#: src/amuleDlg.cpp:1029 src/DownloadListCtrl.cpp:505
+#: src/amuleDlg.cpp:964 src/DownloadListCtrl.cpp:505
 #: src/DownloadListCtrl.cpp:749 src/FriendListCtrl.cpp:180
 #: src/muuli_wdr.cpp:731 src/muuli_wdr.cpp:782 src/muuli_wdr.cpp:846
-#: src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2252 src/muuli_wdr.cpp:2337
-#: src/muuli_wdr.cpp:3085 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
+#: src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2224 src/muuli_wdr.cpp:2309
+#: src/muuli_wdr.cpp:3057 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
 #: src/ServerListCtrl.cpp:606 src/TransferWnd.cpp:378
 #: src/utils/wxCas/src/wxcasprefs.cpp:235
 msgid "Cancel"
 msgstr "Peruuta"
 
-#: src/amuleDlg.cpp:1030
+#: src/amuleDlg.cpp:965
 msgid "Stop the current connection attempts"
 msgstr "Pysäytä nykyiset yhteysyritykset"
 
-#: src/amuleDlg.cpp:1035 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976
-#: src/muuli_wdr.cpp:2475
+#: src/amuleDlg.cpp:970 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976
+#: src/muuli_wdr.cpp:2447
 msgid "Disconnect"
 msgstr "Katkaise yhteys"
 
-#: src/amuleDlg.cpp:1036
+#: src/amuleDlg.cpp:971
 msgid "Disconnect from the currently connected networks"
 msgstr "Katkaise yhteys yhdistettyihin verkkoihin"
 
-#: src/amuleDlg.cpp:1041 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979
-#: src/muuli_wdr.cpp:2630 src/muuli_wdr.cpp:3082 src/muuli_wdr.cpp:3437
+#: src/amuleDlg.cpp:976 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979
+#: src/muuli_wdr.cpp:2602 src/muuli_wdr.cpp:3054 src/muuli_wdr.cpp:3409
 msgid "Connect"
 msgstr "Yhdistä"
 
-#: src/amuleDlg.cpp:1042
+#: src/amuleDlg.cpp:977
 msgid "Connect to the currently enabled networks"
 msgstr "Yhdistä sallittuihin verkkoihin"
 
-#: src/amuleDlg.cpp:1154
+#: src/amuleDlg.cpp:1089
 #, fuzzy, c-format
 msgid "Up: %.1f%s (%.1f) | Down: %.1f%s (%.1f)"
 msgstr "Ylös: %.1f(%.1f) | Alas: %.1f(%.1f)"
 
-#: src/amuleDlg.cpp:1156 src/amuleDlg.cpp:1158 src/amuleDlg.cpp:1162
-#: src/amuleDlg.cpp:1164 src/amuleDlg.cpp:1175 src/amuleDlg.cpp:1177
+#: src/amuleDlg.cpp:1091 src/amuleDlg.cpp:1093 src/amuleDlg.cpp:1097
+#: src/amuleDlg.cpp:1099 src/amuleDlg.cpp:1110 src/amuleDlg.cpp:1112
 #: src/MuleTrayIcon.cpp:796 src/MuleTrayIcon.cpp:799
 #, fuzzy
 msgid " MB/s"
 msgstr "MB/s"
 
-#: src/amuleDlg.cpp:1156 src/amuleDlg.cpp:1158 src/amuleDlg.cpp:1162
-#: src/amuleDlg.cpp:1164 src/amuleDlg.cpp:1175 src/amuleDlg.cpp:1177
+#: src/amuleDlg.cpp:1091 src/amuleDlg.cpp:1093 src/amuleDlg.cpp:1097
+#: src/amuleDlg.cpp:1099 src/amuleDlg.cpp:1110 src/amuleDlg.cpp:1112
 #: src/MuleTrayIcon.cpp:796 src/MuleTrayIcon.cpp:799
 #: src/utils/wxCas/src/wxcasframe.cpp:1041
 msgid " kB/s"
 msgstr " KB/s"
 
-#: src/amuleDlg.cpp:1161
+#: src/amuleDlg.cpp:1096
 #, fuzzy, c-format
 msgid "Up: %.1f%s | Down: %.1f%s"
 msgstr "Ylös: %.1f | Alas: %.1f"
 
-#: src/amuleDlg.cpp:1193
+#: src/amuleDlg.cpp:1128
 #, c-format
 msgid "aMule (%s | Connected)"
 msgstr "aMule (%s | Yhdistetty)"
 
-#: src/amuleDlg.cpp:1195
+#: src/amuleDlg.cpp:1130
 #, c-format
 msgid "aMule (%s | Disconnected)"
 msgstr "aMule (%s | Ei yhdistetty)"
 
-#: src/amuleDlg.cpp:1248
+#: src/amuleDlg.cpp:1183
 #, c-format
 msgid "Do you really want to exit %s?"
 msgstr "Haluatko varmasti sulkea %sn?"
 
-#: src/amuleDlg.cpp:1250
+#: src/amuleDlg.cpp:1185
 msgid "Exit confirmation"
 msgstr "Lopettamisen varmistus"
 
-#: src/amuleDlg.cpp:1613
+#: src/amuleDlg.cpp:1548
 msgid "Launch Command: "
 msgstr "Suorita komento: "
 
-#: src/amuleDlg.cpp:1632 src/muuli_wdr.cpp:1972 src/Preferences.cpp:979
+#: src/amuleDlg.cpp:1567 src/muuli_wdr.cpp:1971 src/Preferences.cpp:951
 msgid "- default -"
 msgstr "- oletus -"
 
-#: src/amuleDlg.cpp:1660
+#: src/amuleDlg.cpp:1595
 #, c-format
 msgid "Skin directory '%s' does not exist"
 msgstr "Teemakansiota '%s' ei ole olemassa"
 
-#: src/amuleDlg.cpp:1663
+#: src/amuleDlg.cpp:1598
 #, c-format
 msgid "WARNING: Unable to open skin file '%s' for read"
 msgstr "VAROITUS: Ei voida avata teematiedostoa '%s' luettavaksi"
 
-#: src/amuleDlg.cpp:1814 src/muuli_wdr.cpp:3439
+#: src/amuleDlg.cpp:1722 src/amuleDlg.cpp:1968 src/muuli_wdr.cpp:1485
+#: src/muuli_wdr.cpp:3411
+msgid "Networks"
+msgstr "Verkot"
+
+#: src/amuleDlg.cpp:1726 src/muuli_wdr.cpp:3411
 msgid "Networks Window"
 msgstr "Verkkoikkuna"
 
-#: src/amuleDlg.cpp:1820 src/muuli_wdr.cpp:3440
+#: src/amuleDlg.cpp:1728 src/muuli_wdr.cpp:3412
+msgid "Searches"
+msgstr "Haut"
+
+#: src/amuleDlg.cpp:1732 src/muuli_wdr.cpp:3412
 msgid "Searches Window"
 msgstr "Hakujen ikkuna"
 
-#: src/amuleDlg.cpp:1826 src/muuli_wdr.cpp:3441
+#: src/amuleDlg.cpp:1734 src/DownloadListCtrl.cpp:740 src/muuli_wdr.cpp:392
+#: src/muuli_wdr.cpp:1578 src/muuli_wdr.cpp:3413 src/Statistics.cpp:829
+msgid "Downloads"
+msgstr "Lataukset"
+
+#: src/amuleDlg.cpp:1738 src/muuli_wdr.cpp:3413
 msgid "Downloads Window"
 msgstr "Latausten ikkuna"
 
-#: src/amuleDlg.cpp:1832 src/muuli_wdr.cpp:3443
+#: src/amuleDlg.cpp:1740 src/muuli_wdr.cpp:3287
+msgid "Shared files"
+msgstr "Jaetut tiedostot"
+
+#: src/amuleDlg.cpp:1744 src/muuli_wdr.cpp:3415
 msgid "Shared Files Window"
 msgstr "Jaettujen tiedostojen ikkuna"
 
-#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3444
+#: src/amuleDlg.cpp:1746 src/muuli_wdr.cpp:2919 src/muuli_wdr.cpp:3369
+#: src/muuli_wdr.cpp:3416
+msgid "Messages"
+msgstr "Viestit"
+
+#: src/amuleDlg.cpp:1750 src/muuli_wdr.cpp:3416
 msgid "Messages Window"
 msgstr "Viestien ikkuna"
 
-#: src/amuleDlg.cpp:1844 src/muuli_wdr.cpp:3445
+#: src/amuleDlg.cpp:1752 src/muuli_wdr.cpp:3417 src/PrefsUnifiedDlg.cpp:312
+#: src/Statistics.cpp:779 src/Statistics.cpp:1235
+msgid "Statistics"
+msgstr "Tilastot"
+
+#: src/amuleDlg.cpp:1756 src/muuli_wdr.cpp:3417
 msgid "Statistics Graph Window"
 msgstr "Tilastokuvaajien ikkuna"
 
-#: src/amuleDlg.cpp:1851 src/muuli_wdr.cpp:3447
+#: src/amuleDlg.cpp:1759 src/muuli_wdr.cpp:3419 src/PrefsUnifiedDlg.cpp:328
+#: src/utils/wxCas/src/wxcasprefs.cpp:39
+msgid "Preferences"
+msgstr "Asetukset"
+
+#: src/amuleDlg.cpp:1763 src/muuli_wdr.cpp:3419
 msgid "Preferences Settings Window"
 msgstr "Asetuksien säätöikkuna"
 
-#: src/amuleDlg.cpp:1854 src/muuli_wdr.cpp:3448
+#: src/amuleDlg.cpp:1766 src/muuli_wdr.cpp:3420
 msgid "Import"
 msgstr "Tuonti"
 
-#: src/amuleDlg.cpp:1858 src/muuli_wdr.cpp:3448
+#: src/amuleDlg.cpp:1770 src/muuli_wdr.cpp:3420
 msgid "The partfile importer tool"
 msgstr "Osatiedostojen tuontityökalu"
 
-#: src/amuleDlg.cpp:1861 src/muuli_wdr.cpp:3449
+#: src/amuleDlg.cpp:1773 src/muuli_wdr.cpp:3421
 #: src/utils/aLinkCreator/src/alcframe.cpp:262
 msgid "About"
 msgstr "Tietoja"
 
-#: src/amuleDlg.cpp:1861 src/muuli_wdr.cpp:3449
+#: src/amuleDlg.cpp:1773 src/muuli_wdr.cpp:3421
 msgid "About/Help"
 msgstr "Tietoja/Ohje"
 
-#: src/amuleDlg.cpp:2059
+#: src/amuleDlg.cpp:1971
 msgid "eD2k network"
 msgstr "eD2k-verkko"
 
-#: src/amuleDlg.cpp:2062
+#: src/amuleDlg.cpp:1974
 msgid "Kad network"
 msgstr "Kad-verkko"
 
-#: src/amuleDlg.cpp:2062
+#: src/amuleDlg.cpp:1974
 msgid "No network"
 msgstr "Ei verkkoa"
 
@@ -954,7 +949,7 @@ msgstr "Tiedostoa ei löytynyt."
 msgid "The core rejected these shared folders:%s"
 msgstr ""
 
-#: src/amule-remote-gui.cpp:1336 src/ExternalConn.cpp:2346
+#: src/amule-remote-gui.cpp:1336 src/ExternalConn.cpp:2345
 msgid "Invalid link or already on list."
 msgstr "Virheellinen linkki tai se on jo listalla."
 
@@ -970,7 +965,7 @@ msgstr "Ei voida luoda kansiota '%s' luokalle '%s', pidän kansion '%s'."
 #: src/ClientDetailDialog.cpp:123 src/DataToText.cpp:61 src/DataToText.cpp:86
 #: src/DataToText.cpp:101 src/DataToText.cpp:136 src/DataToText.cpp:165
 #: src/DownloadListCtrl.cpp:1172 src/DownloadListCtrl.cpp:1185
-#: src/DownloadListCtrl.cpp:1196 src/ExternalConn.cpp:609
+#: src/DownloadListCtrl.cpp:1196 src/ExternalConn.cpp:608
 #: src/FileDetailDialog.cpp:203 src/FileDetailDialog.cpp:235
 #: src/FileDetailDialog.cpp:242 src/GenericClientListCtrl.cpp:1171
 #: src/GenericClientListCtrl.cpp:1182 src/GenericClientListCtrl.cpp:1192
@@ -1357,19 +1352,19 @@ msgstr "Auto [Ko]"
 msgid "Very low"
 msgstr "Erittäin matala"
 
-#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:743 src/muuli_wdr.cpp:2303
+#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:743 src/muuli_wdr.cpp:2275
 #: src/ServerListCtrl.cpp:263 src/ServerListCtrl.cpp:456
 #: src/SharedFilesCtrl.cpp:145
 msgid "Low"
 msgstr "Matala"
 
-#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:744 src/muuli_wdr.cpp:2304
+#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:744 src/muuli_wdr.cpp:2276
 #: src/ServerListCtrl.cpp:266 src/ServerListCtrl.cpp:457
 #: src/SharedFilesCtrl.cpp:146
 msgid "Normal"
 msgstr "Normaali"
 
-#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:745 src/muuli_wdr.cpp:2305
+#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:745 src/muuli_wdr.cpp:2277
 #: src/ServerListCtrl.cpp:269 src/ServerListCtrl.cpp:458
 #: src/SharedFilesCtrl.cpp:147
 msgid "High"
@@ -1461,8 +1456,8 @@ msgstr "Paikallinen Palvelin"
 msgid "Remote Server"
 msgstr "Etäpalvelin"
 
-#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3202
-#: src/SearchDlg.cpp:119 src/TextClient.cpp:911
+#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3174
+#: src/SearchDlg.cpp:111 src/TextClient.cpp:911
 msgid "Kad"
 msgstr "Kad"
 
@@ -1533,7 +1528,7 @@ msgstr "Osa"
 msgid "Size"
 msgstr "Koko"
 
-#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3269
+#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3241
 msgid "Transferred"
 msgstr "Siirretty"
 
@@ -1591,7 +1586,7 @@ msgstr ""
 "Palaute tullut: %s (%s)\n"
 "\n"
 
-#: src/DownloadListCtrl.cpp:746 src/muuli_wdr.cpp:2306
+#: src/DownloadListCtrl.cpp:746 src/muuli_wdr.cpp:2278
 #: src/SharedFilesCtrl.cpp:150
 msgid "Auto"
 msgstr "Automaattinen"
@@ -1629,7 +1624,7 @@ msgid "Extended Options"
 msgstr "Laajat asetukset"
 
 #: src/DownloadListCtrl.cpp:770 src/DownloadListCtrl.cpp:822
-#: src/muuli_wdr.cpp:1790
+#: src/muuli_wdr.cpp:1789
 msgid "Preview"
 msgstr "Esikatsele"
 
@@ -1804,232 +1799,227 @@ msgstr[1] ""
 msgid "Invalid eD2k link! ERROR: %s"
 msgstr "Virheellinen eD2k-linkki! VIRHE: %s"
 
-#: src/ExternalConn.cpp:380
+#: src/ExternalConn.cpp:379
 msgid "Client sent packet after authentication failed."
 msgstr "Asiakas lähetti paketin tunnistautumisen epäonnistumisen jälkeen."
 
-#: src/ExternalConn.cpp:397
+#: src/ExternalConn.cpp:396
 msgid "External connection closed."
 msgstr "Etäyhteys suljettu."
 
-#: src/ExternalConn.cpp:474
+#: src/ExternalConn.cpp:473
 msgid "External connections disabled due to empty password!"
 msgstr "Etäyhteydet kielletty sillä salasana on tyhjä!"
 
-#: src/ExternalConn.cpp:495
+#: src/ExternalConn.cpp:494
 msgid "External connections disabled in config file"
 msgstr "Etäyhteydet estetty asetustiedostossa"
 
-#: src/ExternalConn.cpp:576
+#: src/ExternalConn.cpp:575
 msgid "New external connection accepted"
 msgstr "Uusi etäyhteys hyväksytty"
 
-#: src/ExternalConn.cpp:579
+#: src/ExternalConn.cpp:578
 msgid "ERROR: couldn't accept a new external connection"
 msgstr "VIRHE: uutta etäyhteyttä ei voitu ottaa vastaan"
 
-#: src/ExternalConn.cpp:596
+#: src/ExternalConn.cpp:595
 msgid "External connection refused due to empty password in preferences!"
 msgstr "Etäyhteys torjuttu koska salasana on tyhjä asetuksissa!"
 
-#: src/ExternalConn.cpp:608
+#: src/ExternalConn.cpp:607
 #, c-format
 msgid "Connecting client: %s %s"
 msgstr "Yhdistän asiakkaaseen: %s %s"
 
-#: src/ExternalConn.cpp:610
+#: src/ExternalConn.cpp:609
 msgid "Unknown version"
 msgstr "Tuntematon versio"
 
-#: src/ExternalConn.cpp:623
+#: src/ExternalConn.cpp:622
 msgid "Incorrect EC version ID, there might be binary incompatibility. Use core and remote from same snapshot."
 msgstr "Epäkelpo etäversiotunniste, binäärinen epäyhteensopivuus on mahdollinen. Käytä ydintä ja etäpäätettä samasta vedoksesta."
 
-#: src/ExternalConn.cpp:631
+#: src/ExternalConn.cpp:630
 msgid "You cannot connect to a release version from an arbitrary development snapshot! *sigh* possible crash prevented"
 msgstr "Et voi yhdistää julkaisuversioon mielivaltaisella kehitysversiolla! *huoh* mahdollinen kaatuminen estetty"
 
-#: src/ExternalConn.cpp:714
+#: src/ExternalConn.cpp:713
 msgid "Invalid protocol version."
 msgstr "Väärä protokollaversio."
 
-#: src/ExternalConn.cpp:720
+#: src/ExternalConn.cpp:719
 msgid "Missing protocol version tag."
 msgstr "Puuttuva protokollan versiomerkintä."
 
-#: src/ExternalConn.cpp:728
+#: src/ExternalConn.cpp:727
 msgid "Authentication failed: invalid hash specified as EC password."
 msgstr "Tunnistautuminen epäonnistui: etäyhteyssalasanan tarkiste on väärin."
 
-#: src/ExternalConn.cpp:776
+#: src/ExternalConn.cpp:775
 msgid "Authentication failed: wrong password."
 msgstr "Tunnistautuminen epäonnistui: väärä salasana."
 
-#: src/ExternalConn.cpp:778
+#: src/ExternalConn.cpp:777
 msgid "Authentication failed: missing password."
 msgstr "Tunnistautuminen epäonnistui: salasana puuttui."
 
-#: src/ExternalConn.cpp:789
+#: src/ExternalConn.cpp:788
 msgid "Invalid request, please authenticate first."
 msgstr "Epäkelpo pyyntö, tunnistaudu ensin."
 
-#: src/ExternalConn.cpp:794
+#: src/ExternalConn.cpp:793
 msgid "Access granted."
 msgstr "Pääsy myönnetty."
 
-#: src/ExternalConn.cpp:802
+#: src/ExternalConn.cpp:801
 #, c-format
 msgid "Sent error message \"%s\" to client."
 msgstr "Virheilmoitus \"%s\" lähetetty asiakkaalle."
 
-#: src/ExternalConn.cpp:807
+#: src/ExternalConn.cpp:806
 #, c-format
 msgid "Unauthorized access attempt from %s. Connection closed."
 msgstr "Luvaton yhteysyritys osoitteesta %s. Yhteys suljettu."
 
-#: src/ExternalConn.cpp:1420
+#: src/ExternalConn.cpp:1419
 #, c-format
 msgid "Remote PartFile command failed: FileHash not found: %s"
 msgstr "Etäosatiedoston komento epäonnistui: Tiedostotarkistetta ei löytynyt: %s"
 
-#: src/ExternalConn.cpp:1424
+#: src/ExternalConn.cpp:1423
 #, c-format
 msgid "FileHash not found: %s"
 msgstr "Tiedostotarkistetta ei löytynyt: %s"
 
-#: src/ExternalConn.cpp:1471 src/ExternalConn.cpp:1559
-#: src/ExternalConn.cpp:1680
+#: src/ExternalConn.cpp:1470 src/ExternalConn.cpp:1558
+#: src/ExternalConn.cpp:1679
 msgid "OOPS! OpCode processing error!"
 msgstr "Hupsis! Komentosanan käsittelyvirhe!"
 
-#: src/ExternalConn.cpp:1502
+#: src/ExternalConn.cpp:1501
 msgid "Server not added"
 msgstr "Palvelinta ei lisätty"
 
-#: src/ExternalConn.cpp:1521
+#: src/ExternalConn.cpp:1520
 #, c-format
 msgid "server not found: %s"
 msgstr "palvelinta ei löytynyt: %s"
 
-#: src/ExternalConn.cpp:1538
+#: src/ExternalConn.cpp:1537
 msgid "need to define server to be removed"
 msgstr "poistettava palvelin on määriteltävä"
 
-#: src/ExternalConn.cpp:1553
+#: src/ExternalConn.cpp:1552
 msgid "eD2k is disabled in preferences."
 msgstr "eD2k on poistettu käytöstä asetuksissa."
 
-#: src/ExternalConn.cpp:1658
+#: src/ExternalConn.cpp:1657
 #, fuzzy
 msgid "Friend not found."
 msgstr "Tiedostoa ei löytynyt."
 
-#: src/ExternalConn.cpp:1668
+#: src/ExternalConn.cpp:1667
 #, fuzzy
 msgid "Client not found."
 msgstr "Tiedostoa ei löytynyt."
 
-#: src/ExternalConn.cpp:1674
+#: src/ExternalConn.cpp:1673
 msgid "EC_TAG_FRIEND_SHARED requires EC_TAG_FRIEND or EC_TAG_CLIENT."
 msgstr ""
 
-#: src/ExternalConn.cpp:1992
+#: src/ExternalConn.cpp:1991
 msgid "WebSearch from remote interface makes no sense."
 msgstr "Verkkohaku etäliittymästä ei ole mielekästä."
 
-#: src/ExternalConn.cpp:2027
+#: src/ExternalConn.cpp:2026
 msgid "Search in progress. Refetch results in a moment!"
 msgstr "Haku on käynnissä. Nouda tuloksia kohta uudelleen!"
 
-#: src/ExternalConn.cpp:2266
+#: src/ExternalConn.cpp:2265
 msgid "No points for graph."
 msgstr "Ei pisteitä kaavioon."
 
-#: src/ExternalConn.cpp:2276
+#: src/ExternalConn.cpp:2275
 msgid "Your client is not configured for this detail level."
 msgstr "Asiakasohjelmaasi ei ole asetettu tälle tarkkuustasolle."
 
-#: src/ExternalConn.cpp:2303
+#: src/ExternalConn.cpp:2302
 msgid "External Connection: shutdown requested"
 msgstr "Etäyhteys: sulkemista pyydetty"
 
-#: src/ExternalConn.cpp:2315
+#: src/ExternalConn.cpp:2314
 msgid "Already shutting down."
 msgstr "Sulkeminen on jo käynnissä."
 
-#: src/ExternalConn.cpp:2333
+#: src/ExternalConn.cpp:2332
 #, c-format
 msgid "ExternalConn: adding link '%s'."
 msgstr "Etäyhteys: lisään linkkiä '%s'."
 
-#: src/ExternalConn.cpp:2351
+#: src/ExternalConn.cpp:2350
 #, fuzzy, c-format
 msgid "%d of %d links failed (invalid or already on list)."
 msgstr "Virheellinen linkki tai se on jo listalla."
 
-#: src/ExternalConn.cpp:2374
+#: src/ExternalConn.cpp:2373
 msgid "Version check throttled; try again shortly."
 msgstr ""
 
-#: src/ExternalConn.cpp:2379
+#: src/ExternalConn.cpp:2378
 msgid "Version check is not available on this daemon."
 msgstr ""
 
-#: src/ExternalConn.cpp:2509
+#: src/ExternalConn.cpp:2508
 msgid "File not found."
 msgstr "Tiedostoa ei löytynyt."
 
-#: src/ExternalConn.cpp:2514
+#: src/ExternalConn.cpp:2513
 msgid "Invalid file name."
 msgstr "Epäkelpo tiedostonimi."
 
-#: src/ExternalConn.cpp:2522
+#: src/ExternalConn.cpp:2521
 msgid "Unable to rename file."
 msgstr "Tiedostoa ei voitu uudelleennimetä."
 
-#: src/ExternalConn.cpp:2839
-#, c-format
-msgid "Could not save the amuleapi password: %s"
-msgstr ""
-
-#: src/ExternalConn.cpp:3004 src/ExternalConn.cpp:3032
+#: src/ExternalConn.cpp:2992 src/ExternalConn.cpp:3020
 msgid "Kad is disabled in preferences."
 msgstr "Kad on poistettu päältä asetuksissa."
 
-#: src/ExternalConn.cpp:3045
+#: src/ExternalConn.cpp:3033
 msgid "Already connected to eD2k."
 msgstr "eD2k on jo yhdistetty."
 
-#: src/ExternalConn.cpp:3048
+#: src/ExternalConn.cpp:3036
 msgid "Connecting to eD2k..."
 msgstr "Yhdistetään eD2k..."
 
-#: src/ExternalConn.cpp:3057
+#: src/ExternalConn.cpp:3045
 msgid "Already connected to Kad."
 msgstr "Kad on jo yhdistetty."
 
-#: src/ExternalConn.cpp:3060
+#: src/ExternalConn.cpp:3048
 msgid "Connecting to Kad..."
 msgstr "Yhdistetään Kadiin..."
 
-#: src/ExternalConn.cpp:3067
+#: src/ExternalConn.cpp:3055
 msgid "All networks are disabled."
 msgstr "Kaikki verkot ovat pois päältä."
 
-#: src/ExternalConn.cpp:3076
+#: src/ExternalConn.cpp:3064
 msgid "Disconnected from eD2k."
 msgstr "eD2k-yhteys katkaistu"
 
-#: src/ExternalConn.cpp:3081
+#: src/ExternalConn.cpp:3069
 msgid "Disconnected from Kad."
 msgstr "Kad-yhteys katkaistu."
 
-#: src/ExternalConn.cpp:3090
+#: src/ExternalConn.cpp:3078
 #, c-format
 msgid "External Connection: invalid opcode received: %#x"
 msgstr "Etäyhteys: vastaanotettiin epäkelpo komentosana: %#x"
 
-#: src/ExternalConn.cpp:3095
+#: src/ExternalConn.cpp:3083
 msgid "Invalid opcode (wrong protocol version?)"
 msgstr "Epäkelpo komentosana (väärä protokollaversio?)"
 
@@ -2345,19 +2335,19 @@ msgstr ""
 msgid "eD2k"
 msgstr "eD2k"
 
-#: src/FirstRunWizard.cpp:349 src/muuli_wdr.cpp:1495
+#: src/FirstRunWizard.cpp:349 src/muuli_wdr.cpp:1488
 msgid "Kademlia"
 msgstr "Kademlia"
 
-#: src/FirstRunWizard.cpp:359 src/muuli_wdr.cpp:1423
+#: src/FirstRunWizard.cpp:359 src/muuli_wdr.cpp:1416
 msgid "Standard TCP Port "
 msgstr "Vakio TCP-portti"
 
-#: src/FirstRunWizard.cpp:365 src/muuli_wdr.cpp:1435
+#: src/FirstRunWizard.cpp:365 src/muuli_wdr.cpp:1428
 msgid "Extended UDP port (Kad / global search) "
 msgstr "Laajennettu UDP-portti (Kad / haku kaikkialta)."
 
-#: src/FirstRunWizard.cpp:377 src/muuli_wdr.cpp:1442
+#: src/FirstRunWizard.cpp:377 src/muuli_wdr.cpp:1435
 msgid "Enable UPnP for router port forwarding"
 msgstr "Käytä UPnP:tä reitittimen portinohjauksessa"
 
@@ -2384,7 +2374,7 @@ msgstr ""
 msgid "Your peer lists are already in place - nothing to download."
 msgstr "Lataat jo tiedostoa %s"
 
-#: src/FirstRunWizard.cpp:434 src/muuli_wdr.cpp:1540
+#: src/FirstRunWizard.cpp:434 src/muuli_wdr.cpp:1533
 msgid "Auto-update server list at startup"
 msgstr "Päivitä palvelinlista käynnistettäessä"
 
@@ -2430,23 +2420,23 @@ msgid ""
 "want downloads on a different (e.g. larger) disk."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:549 src/FirstRunWizard.cpp:611 src/muuli_wdr.cpp:1702
+#: src/FirstRunWizard.cpp:549 src/FirstRunWizard.cpp:611 src/muuli_wdr.cpp:1701
 msgid "Destination folder for downloads"
 msgstr "Kansio ladatuille tiedostoille"
 
-#: src/FirstRunWizard.cpp:553 src/FirstRunWizard.cpp:569 src/muuli_wdr.cpp:1349
-#: src/muuli_wdr.cpp:1366 src/muuli_wdr.cpp:1677 src/muuli_wdr.cpp:1708
-#: src/muuli_wdr.cpp:1720 src/muuli_wdr.cpp:2790
+#: src/FirstRunWizard.cpp:553 src/FirstRunWizard.cpp:569 src/muuli_wdr.cpp:1342
+#: src/muuli_wdr.cpp:1359 src/muuli_wdr.cpp:1676 src/muuli_wdr.cpp:1707
+#: src/muuli_wdr.cpp:1719 src/muuli_wdr.cpp:2762
 #: src/utils/aLinkCreator/src/alcframe.cpp:135
 #: src/utils/wxCas/src/wxcasprefs.cpp:52 src/utils/wxCas/src/wxcasprefs.cpp:118
 msgid "Browse"
 msgstr "Selaa"
 
-#: src/FirstRunWizard.cpp:559 src/muuli_wdr.cpp:1713
+#: src/FirstRunWizard.cpp:559 src/muuli_wdr.cpp:1712
 msgid "(All files in this folder are shared with other peers)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:565 src/FirstRunWizard.cpp:624 src/muuli_wdr.cpp:1715
+#: src/FirstRunWizard.cpp:565 src/FirstRunWizard.cpp:624 src/muuli_wdr.cpp:1714
 msgid "Folder for temporary download files"
 msgstr "Kansio latauksen väliaikaisille tiedostoille"
 
@@ -2477,7 +2467,7 @@ msgstr "Kaverilistatiedostoa 'emfriends.met' ei saatu avattua kirjoitettavaksi!"
 msgid "CRITICAL - no client on StartChatSession"
 msgstr "KRIITTINEN - ei asiakasta keskustelun aloituksessa"
 
-#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2696 src/muuli_wdr.cpp:3373
+#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2668 src/muuli_wdr.cpp:3345
 msgid "Friends"
 msgstr "Kaverit"
 
@@ -2588,8 +2578,8 @@ msgstr "Ei yhtään"
 msgid "No"
 msgstr "Ei"
 
-#: src/GenericClientListCtrl.cpp:1216 src/PrefsUnifiedDlg.cpp:2898
-#: src/PrefsUnifiedDlg.cpp:2948 src/ServerListCtrl.cpp:276
+#: src/GenericClientListCtrl.cpp:1216 src/PrefsUnifiedDlg.cpp:2818
+#: src/PrefsUnifiedDlg.cpp:2868 src/ServerListCtrl.cpp:276
 msgid "Yes"
 msgstr "Kyllä"
 
@@ -2758,10 +2748,10 @@ msgstr "Portti ei kelpaa yhdistämisavuksi"
 msgid "Please fill all fields required"
 msgstr "Ole hyvä ja täytä kaikki vaaditut kentät"
 
-#: src/KadDlg.cpp:192 src/PartFile.cpp:1031 src/PrefsUnifiedDlg.cpp:1134
-#: src/PrefsUnifiedDlg.cpp:1204 src/PrefsUnifiedDlg.cpp:1405
-#: src/PrefsUnifiedDlg.cpp:1663 src/PrefsUnifiedDlg.cpp:1673
-#: src/PrefsUnifiedDlg.cpp:1690 src/PrefsUnifiedDlg.cpp:1738
+#: src/KadDlg.cpp:192 src/PartFile.cpp:1031 src/PrefsUnifiedDlg.cpp:1162
+#: src/PrefsUnifiedDlg.cpp:1331 src/PrefsUnifiedDlg.cpp:1589
+#: src/PrefsUnifiedDlg.cpp:1599 src/PrefsUnifiedDlg.cpp:1616
+#: src/PrefsUnifiedDlg.cpp:1658
 msgid "Message"
 msgstr "Viesti"
 
@@ -2863,7 +2853,7 @@ msgstr "Jakosuhde"
 msgid "Uploaded"
 msgstr "Lähetetty"
 
-#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3253
+#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3225
 msgid "Requested"
 msgstr "Pyydetty"
 
@@ -2987,7 +2977,7 @@ msgid "WARNING: "
 msgstr "VAROITUS: "
 
 #: src/MuleNotebook.cpp:179 src/muuli_wdr.cpp:817 src/muuli_wdr.cpp:1229
-#: src/muuli_wdr.cpp:3157 src/muuli_wdr.cpp:3413
+#: src/muuli_wdr.cpp:3129 src/muuli_wdr.cpp:3385
 msgid "Close"
 msgstr "Sulje"
 
@@ -3000,12 +2990,12 @@ msgstr "Leikkaa"
 msgid "Copy"
 msgstr "Kopioi"
 
-#: src/MuleTextCtrl.cpp:88 src/SearchDlg.cpp:261
+#: src/MuleTextCtrl.cpp:88
 msgid "Paste"
 msgstr "Liitä"
 
 #: src/MuleTextCtrl.cpp:89 src/muuli_wdr.cpp:358 src/muuli_wdr.cpp:757
-#: src/muuli_wdr.cpp:2380 src/muuli_wdr.cpp:2399 src/muuli_wdr.cpp:2421
+#: src/muuli_wdr.cpp:2352 src/muuli_wdr.cpp:2371 src/muuli_wdr.cpp:2393
 #: src/utils/aLinkCreator/src/alcframe.cpp:142
 msgid "Clear"
 msgstr "Pyyhi"
@@ -3103,8 +3093,8 @@ msgid "Exit"
 msgstr "Sulje"
 
 #: src/MuleTrayIcon.cpp:579 src/MuleTrayIcon.cpp:945 src/MuleTrayIcon.cpp:965
-#: src/muuli_wdr.cpp:1398 src/muuli_wdr.cpp:1406 src/muuli_wdr.cpp:1413
-#: src/muuli_wdr.cpp:1836 src/muuli_wdr.cpp:1842 src/OtherFunctions.cpp:91
+#: src/muuli_wdr.cpp:1391 src/muuli_wdr.cpp:1399 src/muuli_wdr.cpp:1406
+#: src/muuli_wdr.cpp:1835 src/muuli_wdr.cpp:1841 src/OtherFunctions.cpp:91
 #: src/StatisticsDlg.cpp:93 src/StatisticsDlg.cpp:95
 msgid "kB/s"
 msgstr "KB/s"
@@ -3275,7 +3265,7 @@ msgstr "Nimi:"
 msgid "Type"
 msgstr "Tyyppi"
 
-#: src/muuli_wdr.cpp:215 src/SearchDlg.cpp:118 src/SearchListCtrl.cpp:853
+#: src/muuli_wdr.cpp:215 src/SearchDlg.cpp:110 src/SearchListCtrl.cpp:853
 msgid "Local"
 msgstr "Paikallinen"
 
@@ -3346,7 +3336,7 @@ msgstr "Tavua"
 msgid "KB"
 msgstr "KB"
 
-#: src/muuli_wdr.cpp:274 src/muuli_wdr.cpp:293 src/muuli_wdr.cpp:1621
+#: src/muuli_wdr.cpp:274 src/muuli_wdr.cpp:293 src/muuli_wdr.cpp:1620
 #: src/OtherFunctions.cpp:64
 msgid "MB"
 msgstr "MB"
@@ -3363,7 +3353,7 @@ msgstr "Enimmäiskoko"
 msgid "Availability"
 msgstr "Saatavuus"
 
-#: src/muuli_wdr.cpp:312 src/muuli_wdr.cpp:398 src/muuli_wdr.cpp:3318
+#: src/muuli_wdr.cpp:312 src/muuli_wdr.cpp:398 src/muuli_wdr.cpp:3290
 msgid "Filter:"
 msgstr "Suodatin:"
 
@@ -3395,7 +3385,7 @@ msgstr ""
 msgid "Stop"
 msgstr "Pysäytä"
 
-#: src/muuli_wdr.cpp:348 src/muuli_wdr.cpp:1392 src/SearchListCtrl.cpp:732
+#: src/muuli_wdr.cpp:348 src/muuli_wdr.cpp:1385 src/SearchListCtrl.cpp:732
 msgid "Download"
 msgstr "Lataa"
 
@@ -3426,12 +3416,12 @@ msgstr "Tiedostolähteet:"
 #: src/muuli_wdr.cpp:1160 src/muuli_wdr.cpp:1167 src/muuli_wdr.cpp:1172
 #: src/muuli_wdr.cpp:1179 src/muuli_wdr.cpp:1184 src/muuli_wdr.cpp:1191
 #: src/muuli_wdr.cpp:1205 src/muuli_wdr.cpp:1212 src/muuli_wdr.cpp:1217
-#: src/muuli_wdr.cpp:1224 src/muuli_wdr.cpp:3255 src/muuli_wdr.cpp:3263
-#: src/muuli_wdr.cpp:3271
+#: src/muuli_wdr.cpp:1224 src/muuli_wdr.cpp:3227 src/muuli_wdr.cpp:3235
+#: src/muuli_wdr.cpp:3243
 msgid "N/A"
 msgstr "Ei saatavilla"
 
-#: src/muuli_wdr.cpp:508 src/muuli_wdr.cpp:1065 src/PrefsUnifiedDlg.cpp:299
+#: src/muuli_wdr.cpp:508 src/muuli_wdr.cpp:1065 src/PrefsUnifiedDlg.cpp:297
 msgid "General"
 msgstr "Yleiset"
 
@@ -3572,7 +3562,7 @@ msgstr ""
 msgid "Album :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:685 src/muuli_wdr.cpp:2275
+#: src/muuli_wdr.cpp:685 src/muuli_wdr.cpp:2247
 msgid "Title :"
 msgstr "Otsikko :"
 
@@ -3681,7 +3671,7 @@ msgstr "Käyttäjänimi :"
 msgid "Userhash :"
 msgstr "Käyttäjätarkiste :"
 
-#: src/muuli_wdr.cpp:895 src/muuli_wdr.cpp:1742 src/muuli_wdr.cpp:2470
+#: src/muuli_wdr.cpp:895 src/muuli_wdr.cpp:1741 src/muuli_wdr.cpp:2442
 #: src/utils/aLinkCreator/src/alcframe.cpp:137
 msgid "Add"
 msgstr "Lisää"
@@ -3690,15 +3680,15 @@ msgstr "Lisää"
 msgid "Download-Speed"
 msgstr "Latausnopeus"
 
-#: src/muuli_wdr.cpp:954 src/muuli_wdr.cpp:989 src/muuli_wdr.cpp:2574
+#: src/muuli_wdr.cpp:954 src/muuli_wdr.cpp:989 src/muuli_wdr.cpp:2546
 msgid "Current"
 msgstr "Nykyinen"
 
-#: src/muuli_wdr.cpp:962 src/muuli_wdr.cpp:997 src/muuli_wdr.cpp:2582
+#: src/muuli_wdr.cpp:962 src/muuli_wdr.cpp:997 src/muuli_wdr.cpp:2554
 msgid "Running average"
 msgstr "Yhtäjaksoinen keskiarvo"
 
-#: src/muuli_wdr.cpp:970 src/muuli_wdr.cpp:1005 src/muuli_wdr.cpp:2590
+#: src/muuli_wdr.cpp:970 src/muuli_wdr.cpp:1005 src/muuli_wdr.cpp:2562
 msgid "Session average"
 msgstr "Session keskiarvo"
 
@@ -3710,7 +3700,7 @@ msgstr "Lähetysnopeus"
 msgid "Connections"
 msgstr "Yhteydet"
 
-#: src/muuli_wdr.cpp:1024 src/muuli_wdr.cpp:1861
+#: src/muuli_wdr.cpp:1024 src/muuli_wdr.cpp:1860
 msgid "Active downloads"
 msgstr "Aktiiviset lataukset"
 
@@ -3718,7 +3708,7 @@ msgstr "Aktiiviset lataukset"
 msgid "Active connections (1:1)"
 msgstr "Aktiiviset yhteydet (1:1)"
 
-#: src/muuli_wdr.cpp:1040 src/muuli_wdr.cpp:1862
+#: src/muuli_wdr.cpp:1040 src/muuli_wdr.cpp:1861
 msgid "Active uploads"
 msgstr "Aktiiviset lähetykset"
 
@@ -3834,8 +3824,8 @@ msgstr "Tämä on nimi jonka muut käyttäjät näkevät yhdistäessään sinuun
 msgid "Language: "
 msgstr "Kieli: "
 
-#: src/muuli_wdr.cpp:1257 src/muuli_wdr.cpp:1330 src/muuli_wdr.cpp:1334
-#: src/muuli_wdr.cpp:1337
+#: src/muuli_wdr.cpp:1257 src/muuli_wdr.cpp:1323 src/muuli_wdr.cpp:1327
+#: src/muuli_wdr.cpp:1330
 msgid "The delay before showing tool-tips."
 msgstr "Viive työkaluvihjeiden näyttämiseen."
 
@@ -3913,960 +3903,936 @@ msgstr ""
 msgid "Enabling this will make aMule to show notifications when finished downloading."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1323
-#, fuzzy
-msgid "Remember search history"
-msgstr "Muista nämä asetukset"
-
-#: src/muuli_wdr.cpp:1324
-msgid "Keeps a dropdown list of your past search terms in the Search tab's Name field. This remembers the queries you typed, not the results they returned."
-msgstr ""
-
-#: src/muuli_wdr.cpp:1329
+#: src/muuli_wdr.cpp:1322
 msgid "Tooltip delay time: "
 msgstr "Työkaluvihjeiden viive:"
 
-#: src/muuli_wdr.cpp:1336
+#: src/muuli_wdr.cpp:1329
 msgid "seconds"
 msgstr "sekuntia"
 
-#: src/muuli_wdr.cpp:1340
+#: src/muuli_wdr.cpp:1333
 msgid "Browser Selection"
 msgstr "Selaimen valinta"
 
-#: src/muuli_wdr.cpp:1346
+#: src/muuli_wdr.cpp:1339
 msgid "Enter your browser name here. Leave this field empty to use the system default browser."
 msgstr "Syötä tähän selaimesi nimi. Jätä tyhjäksi jos haluat käyttää järjestelmän oletusselainta."
 
-#: src/muuli_wdr.cpp:1353
+#: src/muuli_wdr.cpp:1346
 msgid "Open in new tab if possible"
 msgstr "Avaa uuteen välilehteen mikäli mahdollista"
 
-#: src/muuli_wdr.cpp:1355
+#: src/muuli_wdr.cpp:1348
 msgid "Open the web page in a new tab instead of in a new window when possible"
 msgstr "Avaa verkkosivun uuteen välilehteen uuden ikkunan sijaan kun se on mahdollista"
 
-#: src/muuli_wdr.cpp:1359
+#: src/muuli_wdr.cpp:1352
 msgid "Video Player"
 msgstr "Videotoistin"
 
-#: src/muuli_wdr.cpp:1386
+#: src/muuli_wdr.cpp:1379
 msgid "Bandwidth limits"
 msgstr "Kaistankäytön rajoitukset"
 
-#: src/muuli_wdr.cpp:1400
+#: src/muuli_wdr.cpp:1393
 msgid "Upload"
 msgstr "Lähetys"
 
-#: src/muuli_wdr.cpp:1408
+#: src/muuli_wdr.cpp:1401
 msgid "Slot Allocation"
 msgstr "Paikkavaraus"
 
-#: src/muuli_wdr.cpp:1417
+#: src/muuli_wdr.cpp:1410
 msgid "Ports"
 msgstr "Portit"
 
-#: src/muuli_wdr.cpp:1427
+#: src/muuli_wdr.cpp:1420
 msgid "This is the standard eD2k port and cannot be disabled."
 msgstr "Tämä on vakio eD2k-portti eikä sitä voi kytkeä pois päältä."
 
-#: src/muuli_wdr.cpp:1430
+#: src/muuli_wdr.cpp:1423
 msgid "UDP port for server requests (TCP+3):"
 msgstr "UDP-portti palvelinpyyntöihin (TCP+3):"
 
-#: src/muuli_wdr.cpp:1432
+#: src/muuli_wdr.cpp:1425
 msgid "4665"
 msgstr "4665"
 
-#: src/muuli_wdr.cpp:1439
+#: src/muuli_wdr.cpp:1432
 msgid "This UDP port is used for extended eD2k requests and Kad network"
 msgstr "Tätä UDP-porttia käytetään laajennettuihin eD2k-hakuihin sekä Kad-verkossa"
 
-#: src/muuli_wdr.cpp:1446
+#: src/muuli_wdr.cpp:1439
 msgid "UPnP TCP Port (Optional):"
 msgstr "UPnP:n TCP-portti (Valinnainen):"
 
-#: src/muuli_wdr.cpp:1456
+#: src/muuli_wdr.cpp:1449
 msgid "Bind local address to IP (empty for any):"
 msgstr "Sido paikallinen osoite IP:hen (tyhjä sallii mihin tahansa):"
 
-#: src/muuli_wdr.cpp:1459
+#: src/muuli_wdr.cpp:1452
 msgid "Advanced users only: If you have multiple network interfaces, enter the address of the interface to which aMule should be bound."
 msgstr "Vain edistyneille käyttäjille: mikäli sinulla on useampia verkkoliitäntöjä, syötä sen liitännän osoite johon haluat aMulen sidottavan."
 
-#: src/muuli_wdr.cpp:1462 src/muuli_wdr.cpp:2055
+#: src/muuli_wdr.cpp:1455 src/muuli_wdr.cpp:2054
 #, fuzzy
 msgid "Bind to network interface (empty for any):"
 msgstr "Sido paikallinen osoite IP:hen (tyhjä sallii mihin tahansa):"
 
-#: src/muuli_wdr.cpp:1475
+#: src/muuli_wdr.cpp:1468
 msgid "Advanced users only: pin all of aMule's traffic to one network interface, chosen from the list or typed in by name (e.g. tun0, eth0, en0) or index. Unlike binding to an IP, this stops traffic leaking out via the default route - useful with a VPN. Requires no elevated privileges."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1481
+#: src/muuli_wdr.cpp:1474
 msgid "Max sources per downloading file:"
 msgstr "Lähteitä enintään tiedostoa kohden:"
 
-#: src/muuli_wdr.cpp:1485
+#: src/muuli_wdr.cpp:1478
 msgid "Max simultaneous connections:"
 msgstr "Yhtäaikaisten yhteyksien enimmäismäärä:"
 
-#: src/muuli_wdr.cpp:1498 src/muuli_wdr.cpp:3197
+#: src/muuli_wdr.cpp:1491 src/muuli_wdr.cpp:3169
 msgid "ED2K"
 msgstr "ED2K"
 
-#: src/muuli_wdr.cpp:1505
+#: src/muuli_wdr.cpp:1498
 msgid "Autoconnect on startup"
 msgstr "Yhdistä automaattisesti käynnistettäessä"
 
-#: src/muuli_wdr.cpp:1508
+#: src/muuli_wdr.cpp:1501
 msgid "Reconnect on loss"
 msgstr "Yhdistä uudelleen yhteyden katketessa"
 
-#: src/muuli_wdr.cpp:1530
+#: src/muuli_wdr.cpp:1523
 msgid "Remove dead server after"
 msgstr "Poista toimimattomat palvelimet"
 
-#: src/muuli_wdr.cpp:1531
+#: src/muuli_wdr.cpp:1524
 msgid "Static servers are never removed, even when unreachable."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1535
+#: src/muuli_wdr.cpp:1528
 msgid "retries"
 msgstr "yrityksen jälkeen"
 
-#: src/muuli_wdr.cpp:1543
+#: src/muuli_wdr.cpp:1536
 msgid "List"
 msgstr "Lista"
 
-#: src/muuli_wdr.cpp:1546
+#: src/muuli_wdr.cpp:1539
 msgid "Update server list when connecting to a server"
 msgstr "Päivitä palvelinlista yhdistettäessä palvelimelle"
 
-#: src/muuli_wdr.cpp:1549
+#: src/muuli_wdr.cpp:1542
 msgid "Update server list when a client connects"
 msgstr "Päivitä palvelinlista asiakkaan yhdistäessä"
 
-#: src/muuli_wdr.cpp:1552
+#: src/muuli_wdr.cpp:1545
 msgid "Use priority system"
 msgstr "Käytä tärkeysjärjestystä"
 
-#: src/muuli_wdr.cpp:1556
+#: src/muuli_wdr.cpp:1549
 msgid "Use smart LowID check on connect"
 msgstr "Käytä älykästä LowID-tarkistusta yhdistettäessä"
 
-#: src/muuli_wdr.cpp:1560
+#: src/muuli_wdr.cpp:1553
 msgid "Safe connect"
 msgstr "Turvallinen yhdistäminen"
 
-#: src/muuli_wdr.cpp:1564
+#: src/muuli_wdr.cpp:1557
 msgid "Autoconnect to servers in static list only"
 msgstr "Yhdistä automaattisesti vain pysyville palvelimille"
 
-#: src/muuli_wdr.cpp:1567
+#: src/muuli_wdr.cpp:1560
 msgid "Set manually added servers to High Priority"
 msgstr "Aseta käsin syötetyt palvelimet korkealle tärkeydelle"
 
-#: src/muuli_wdr.cpp:1588
+#: src/muuli_wdr.cpp:1581
 msgid "Add files to download in pause mode"
 msgstr "Lisää tiedostot lataukseen tauotettuna"
 
-#: src/muuli_wdr.cpp:1590
+#: src/muuli_wdr.cpp:1583
 msgid "Add files to download with auto priority"
 msgstr "Lisää tiedostot lataukseen tärkeys automaattisella"
 
-#: src/muuli_wdr.cpp:1593
+#: src/muuli_wdr.cpp:1586
 msgid "Try to download first and last chunks first"
 msgstr "Yritä ladata ensimmäiset ja viimeiset palat ensin"
 
-#: src/muuli_wdr.cpp:1597
+#: src/muuli_wdr.cpp:1590
 msgid "Endgame mode: rotate to faster sources for the final blocks"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1600
+#: src/muuli_wdr.cpp:1593
 msgid "Start next paused file when a file completes"
 msgstr "Käynnistä seuraava tauotetty tiedosto kun tiedosto valmistuu"
 
-#: src/muuli_wdr.cpp:1603
+#: src/muuli_wdr.cpp:1596
 msgid "From the same category"
 msgstr "Samasta luokasta"
 
-#: src/muuli_wdr.cpp:1605
+#: src/muuli_wdr.cpp:1598
 msgid "In alphabetic order"
 msgstr "Aakkosellisessa järjestyksessä"
 
-#: src/muuli_wdr.cpp:1607
+#: src/muuli_wdr.cpp:1600
 msgid "Preallocate disk space for new files"
 msgstr "Esivaraa levytila uusille tiedostoille"
 
-#: src/muuli_wdr.cpp:1608
+#: src/muuli_wdr.cpp:1601
 msgid "For new files preallocates disk space for the whole file, thus reduces fragmentation"
 msgstr "Uusia tiedostoja lisätessä varaa levytilaa koko tiedostolle, vähentää pirstaloitumista"
 
-#: src/muuli_wdr.cpp:1613
+#: src/muuli_wdr.cpp:1606
+msgid "Create new files as sparse files"
+msgstr ""
+
+#: src/muuli_wdr.cpp:1607
+msgid "A sparse file reserves its full size on disk immediately without writing real data to it -- fast, but unsupported or slow on some filesystems, and free-space accounting stays optimistic while the download is in progress. Turn this off to grow the file only as data arrives."
+msgstr ""
+
+#: src/muuli_wdr.cpp:1612
 msgid "Stop downloads when free disk space reaches "
 msgstr "Pysäytä lataukset kun tyhjän levytilan määrä saavuttaa "
 
-#: src/muuli_wdr.cpp:1614
+#: src/muuli_wdr.cpp:1613
 msgid "Select this if you want aMule to check your disk space"
 msgstr "Valitse tämä mikäli haluat aMulen tarkistavan vapaan levytilan määrän"
 
-#: src/muuli_wdr.cpp:1618
+#: src/muuli_wdr.cpp:1617
 msgid "Enter here the min disk space desired."
 msgstr "Syötä tähän levytila jonka haluat jättää vapaaksi."
 
-#: src/muuli_wdr.cpp:1624
+#: src/muuli_wdr.cpp:1623
 msgid "Save 10 sources on rare files (< 20 sources)"
 msgstr "Tallenna 10 lähdettä harvinaisille tiedostoille (< 20 lähdettä)"
 
-#: src/muuli_wdr.cpp:1628 src/Statistics.cpp:790
+#: src/muuli_wdr.cpp:1627 src/Statistics.cpp:790
 msgid "Uploads"
 msgstr "Lähetykset"
 
-#: src/muuli_wdr.cpp:1631
+#: src/muuli_wdr.cpp:1630
 msgid "Add new shared files with auto priority"
 msgstr "Lisää uudet jaetut tiedostot tärkeys automaattisella"
 
-#: src/muuli_wdr.cpp:1637
+#: src/muuli_wdr.cpp:1636
 msgid "Intelligent Corruption Handling (I.C.H.)"
 msgstr "Älykäs turmeltumien käsittely (I.C.H.)"
 
-#: src/muuli_wdr.cpp:1640
+#: src/muuli_wdr.cpp:1639
 msgid "Enable"
 msgstr "Käytä"
 
-#: src/muuli_wdr.cpp:1643
+#: src/muuli_wdr.cpp:1642
 msgid "Advanced I.C.H. trusts every hash (not recommended)"
 msgstr "Kehittynyt I.C.H. luottaa kaikkiin tarkisteisiin (ei suositella)"
 
-#: src/muuli_wdr.cpp:1655 src/PrefsUnifiedDlg.cpp:1990
+#: src/muuli_wdr.cpp:1654 src/PrefsUnifiedDlg.cpp:1910
 msgid "Media metadata extraction"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1659
+#: src/muuli_wdr.cpp:1658
 msgid "Extract length / bitrate / codec from shared audio and video files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1661
+#: src/muuli_wdr.cpp:1660
 msgid "When enabled, aMule runs ffprobe on each shared media file to fill in the Length / Bitrate / Codec columns other clients see when they find the file in a search. Requires ffmpeg (the ffprobe binary) to be installed."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1668
+#: src/muuli_wdr.cpp:1667
 msgid "Path to ffprobe:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1673
+#: src/muuli_wdr.cpp:1672
 msgid "Full path to the ffprobe binary. Leave empty to have aMule auto-detect it on startup."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1681
+#: src/muuli_wdr.cpp:1680
 msgid "Detect"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1682
+#: src/muuli_wdr.cpp:1681
 msgid "Search the standard install locations for an ffprobe binary and fill the path field."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1706
+#: src/muuli_wdr.cpp:1705
 msgid ""
 "Completed downloads are stored here. All files in this folder are automatically shared with other peers.\n"
 "If this folder also holds files you don't want to share, point it at an aMule-only sub-folder."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1709
+#: src/muuli_wdr.cpp:1708
 msgid "Pick the folder where completed downloads will be stored. All files in that folder will be shared with other peers."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1723
+#: src/muuli_wdr.cpp:1722
 msgid "Shared folders"
 msgstr "Jaetut kansiot"
 
-#: src/muuli_wdr.cpp:1729
+#: src/muuli_wdr.cpp:1728
 msgid "(Folders shared by the core. Enter a path to add one.)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1737
+#: src/muuli_wdr.cpp:1736
 msgid "Absolute path of a folder on the core's machine, e.g. /home/user/shared"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1739 src/PrefsUnifiedDlg.cpp:2874
+#: src/muuli_wdr.cpp:1738 src/PrefsUnifiedDlg.cpp:2794
 msgid "Recursive"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1740
+#: src/muuli_wdr.cpp:1739
 msgid "Share every sub-folder underneath this one, including ones created later."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1744 src/utils/aLinkCreator/src/alcframe.cpp:141
+#: src/muuli_wdr.cpp:1743 src/utils/aLinkCreator/src/alcframe.cpp:141
 msgid "Remove"
 msgstr "Poista"
 
-#: src/muuli_wdr.cpp:1748
+#: src/muuli_wdr.cpp:1747
 msgid "(Right click on folder icon for recursive share)"
 msgstr "(Klikkaa oikealla painikkeella kansion kuvaketta jakaaksesi rekursiivisesti)"
 
-#: src/muuli_wdr.cpp:1755
+#: src/muuli_wdr.cpp:1754
 msgid "Share hidden files"
 msgstr "Jaa piilotiedostot"
 
-#: src/muuli_wdr.cpp:1761
+#: src/muuli_wdr.cpp:1760
 msgid "Automatically rescan shared folders for changes"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1767
+#: src/muuli_wdr.cpp:1766
 msgid "Follow symbolic links in shared folders"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1773
+#: src/muuli_wdr.cpp:1772
 msgid "Exclude files matching:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1776
+#: src/muuli_wdr.cpp:1775
 msgid "Wildcard patterns separated by '|', e.g. .DS_Store|Thumbs.db|*.tmp. Files whose name matches are not shared. Matching is case-insensitive."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1780
+#: src/muuli_wdr.cpp:1779
 msgid "Patterns are regular expressions"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1781
+#: src/muuli_wdr.cpp:1780
 msgid "When set, the whole field is one regular expression ('|' is alternation). When unset, it is a list of '|'-separated wildcards."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1791
+#: src/muuli_wdr.cpp:1790
 msgid "Show how many shared files the current pattern would exclude."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1812
+#: src/muuli_wdr.cpp:1811
 msgid "Graphs"
 msgstr "Kuvaajat"
 
-#: src/muuli_wdr.cpp:1815 src/muuli_wdr.cpp:1877
+#: src/muuli_wdr.cpp:1814 src/muuli_wdr.cpp:1876
 msgid "Update delay : 5 secs"
 msgstr "Päivitysväli : 5 sekuntia"
 
-#: src/muuli_wdr.cpp:1819
+#: src/muuli_wdr.cpp:1818
 msgid "Time for average graph: 100 mins"
 msgstr "Keskimääräiskuvaajan aika: 100 minuuttia"
 
-#: src/muuli_wdr.cpp:1823
+#: src/muuli_wdr.cpp:1822
 msgid "Connections Graph Scale: 100 "
 msgstr "Yhteyskuvaajan Skaala: 100 "
 
-#: src/muuli_wdr.cpp:1830
+#: src/muuli_wdr.cpp:1829
 msgid "Download graph scale:"
 msgstr "Latauskuvaajan skaala:"
 
-#: src/muuli_wdr.cpp:1838
+#: src/muuli_wdr.cpp:1837
 msgid "Upload graph scale:"
 msgstr "Lähetyskuvaajan skaala:"
 
-#: src/muuli_wdr.cpp:1848
+#: src/muuli_wdr.cpp:1847
 #, fuzzy
 msgid "Colors: "
 msgstr "Värit: "
 
-#: src/muuli_wdr.cpp:1852
+#: src/muuli_wdr.cpp:1851
 msgid "Background"
 msgstr "Taustaväri"
 
-#: src/muuli_wdr.cpp:1853
+#: src/muuli_wdr.cpp:1852
 msgid "Grid"
 msgstr "Ruudukko"
 
-#: src/muuli_wdr.cpp:1854
+#: src/muuli_wdr.cpp:1853
 msgid "Download current"
 msgstr "Hetkittäinen lataus"
 
-#: src/muuli_wdr.cpp:1855
+#: src/muuli_wdr.cpp:1854
 msgid "Download running average"
 msgstr "Latauksen yhtäjaksoinen keskiarvo"
 
-#: src/muuli_wdr.cpp:1856
+#: src/muuli_wdr.cpp:1855
 msgid "Download session average"
 msgstr "Latauksen keskiarvo sessiossa"
 
-#: src/muuli_wdr.cpp:1857
+#: src/muuli_wdr.cpp:1856
 msgid "Upload current"
 msgstr "Hetkittäinen lähetys"
 
-#: src/muuli_wdr.cpp:1858
+#: src/muuli_wdr.cpp:1857
 msgid "Upload running average"
 msgstr "Lähetyksen yhtäjaksoinen keskiarvo"
 
-#: src/muuli_wdr.cpp:1859
+#: src/muuli_wdr.cpp:1858
 msgid "Upload session average"
 msgstr "Lähetyksen keskiarvo sessiossa"
 
-#: src/muuli_wdr.cpp:1860
+#: src/muuli_wdr.cpp:1859
 msgid "Active connections"
 msgstr "Aktiiviset yhteydet"
 
-#: src/muuli_wdr.cpp:1863
+#: src/muuli_wdr.cpp:1862
 #, fuzzy
 msgid "Systray Icon Speed Bar"
 msgstr "Järjestelmäpalkin nopeusnäyttö"
 
-#: src/muuli_wdr.cpp:1864
+#: src/muuli_wdr.cpp:1863
 msgid "Kad-nodes current"
 msgstr "Kad-yhteyksiä tällä hetkellä"
 
-#: src/muuli_wdr.cpp:1865
+#: src/muuli_wdr.cpp:1864
 msgid "Kad-nodes running"
 msgstr "Kad-yhteyksiä aktiivisena"
 
-#: src/muuli_wdr.cpp:1866
+#: src/muuli_wdr.cpp:1865
 msgid "Kad-nodes session"
 msgstr "Kad-yhteyksiä sessiossa"
 
-#: src/muuli_wdr.cpp:1870 src/muuli_wdr.cpp:2324
+#: src/muuli_wdr.cpp:1869 src/muuli_wdr.cpp:2296
 msgid "Select"
 msgstr "Valitse"
 
-#: src/muuli_wdr.cpp:1874
+#: src/muuli_wdr.cpp:1873
 msgid "Tree"
 msgstr "Puu"
 
-#: src/muuli_wdr.cpp:1884
+#: src/muuli_wdr.cpp:1883
 msgid "Number of Client Versions shown (0=unlimited)"
 msgstr "Näytettävien asiakasversioiden määrä (0=rajoittamattomasti)"
 
-#: src/muuli_wdr.cpp:1909
+#: src/muuli_wdr.cpp:1908
 msgid "!!! WARNING !!!"
 msgstr "!!! VAROITUS !!!"
 
-#: src/muuli_wdr.cpp:1924
+#: src/muuli_wdr.cpp:1923
 msgid "Max new connections / 5 secs"
 msgstr "Enimmäismäärä uusia yhteyksiä / 5 s"
 
-#: src/muuli_wdr.cpp:1926
+#: src/muuli_wdr.cpp:1925
 msgid "Concurrent Kad source lookups"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1928
+#: src/muuli_wdr.cpp:1927
 #, fuzzy
 msgid "Kad source re-search interval (minutes)"
 msgstr "FTP-päivityksien väli minuuteissa"
 
-#: src/muuli_wdr.cpp:1930
+#: src/muuli_wdr.cpp:1929
 #, fuzzy
 msgid "Source re-ask interval (minutes)"
 msgstr "FTP-päivityksien väli minuuteissa"
 
-#: src/muuli_wdr.cpp:1934
+#: src/muuli_wdr.cpp:1933
 msgid "File Buffer Size: 240000 bytes"
 msgstr "Tiedostopuskurin koko: 240000 tavua"
 
-#: src/muuli_wdr.cpp:1938
+#: src/muuli_wdr.cpp:1937
 msgid "Use MMAP: memory-mapped file access (lower memory use)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1939
+#: src/muuli_wdr.cpp:1938
 msgid "Maps part files into memory instead of buffering them on the heap, lowering the process memory footprint. May reduce download speed on some disks; best for memory-constrained or upload-heavy hosts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1941
+#: src/muuli_wdr.cpp:1940
 msgid "Upload Queue Size: 5000 clients"
 msgstr "Lähetysjonon koko: 5000 asiakasta"
 
-#: src/muuli_wdr.cpp:1945
+#: src/muuli_wdr.cpp:1944
 msgid "Server connection refresh interval: Disable"
 msgstr "Palvelinyhteyden päivitysväli: Poissa käytöstä"
 
-#: src/muuli_wdr.cpp:1949
+#: src/muuli_wdr.cpp:1948
 msgid "Disable computer's timed standby mode"
 msgstr "Poista käytöstä tietokoneen ajastettu siirtyminen valmiustilaan"
 
-#: src/muuli_wdr.cpp:1968
+#: src/muuli_wdr.cpp:1967
 msgid "Skin to use: "
 msgstr "Käytettävä teema: "
 
-#: src/muuli_wdr.cpp:1977
+#: src/muuli_wdr.cpp:1976
 msgid "Show \"Fast eD2k Links Handler\" in every window."
 msgstr "Näytä \"Nopea eD2k-linkkien käsittelijä\" jokaisessa ikkunassa."
 
-#: src/muuli_wdr.cpp:1980
+#: src/muuli_wdr.cpp:1979
 msgid "Show extended info on categories tabs"
 msgstr "Näytä laajennetut tiedot luokitteluvälilehdillä"
 
-#: src/muuli_wdr.cpp:1983
+#: src/muuli_wdr.cpp:1982
 msgid "Show application version on title"
 msgstr "Näytä sovelluksen versio otsikossa"
 
-#: src/muuli_wdr.cpp:1985
+#: src/muuli_wdr.cpp:1984
 msgid "Show transfer rates on title"
 msgstr "Näytä siirtonopeudet otsikossa"
 
-#: src/muuli_wdr.cpp:1987
+#: src/muuli_wdr.cpp:1986
 msgid "Before application name"
 msgstr "Ennen sovelluksen nimeä"
 
-#: src/muuli_wdr.cpp:1989
+#: src/muuli_wdr.cpp:1988
 msgid "After application name"
 msgstr "Sovelluksen nimen perässä"
 
-#: src/muuli_wdr.cpp:1992
+#: src/muuli_wdr.cpp:1991
 msgid "Show overhead bandwidth"
 msgstr "Näytä otsikkotietoihin kuluva kaista"
 
-#: src/muuli_wdr.cpp:1996
+#: src/muuli_wdr.cpp:1995
 msgid "Vertical toolbar orientation"
 msgstr "Pystysuuntainen työkalupalkki"
 
-#: src/muuli_wdr.cpp:1998
+#: src/muuli_wdr.cpp:1997
 msgid "Live column sorting (auto-reorder rows as their values change)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2005
+#: src/muuli_wdr.cpp:2004
 msgid "Download Queue Files"
 msgstr "Latausjonon tiedostot"
 
-#: src/muuli_wdr.cpp:2008
+#: src/muuli_wdr.cpp:2007
 msgid "Show progress percentage"
 msgstr "Näytä edistyminen prosentteina"
 
-#: src/muuli_wdr.cpp:2014
+#: src/muuli_wdr.cpp:2013
 msgid "Show progress bar"
 msgstr "Näytä edistymispalkki"
 
-#: src/muuli_wdr.cpp:2017
+#: src/muuli_wdr.cpp:2016
 msgid "Flat"
 msgstr "Tasainen"
 
-#: src/muuli_wdr.cpp:2021
+#: src/muuli_wdr.cpp:2020
 msgid "Round"
 msgstr "Pyöreä"
 
-#: src/muuli_wdr.cpp:2039
+#: src/muuli_wdr.cpp:2038
 msgid "External Connection Parameters"
 msgstr "Etäyhteyksien asetukset"
 
-#: src/muuli_wdr.cpp:2042
+#: src/muuli_wdr.cpp:2041
 msgid "Accept external connections"
 msgstr "Hyväksy etäyhteydet"
 
-#: src/muuli_wdr.cpp:2049 src/muuli_wdr.cpp:2108
+#: src/muuli_wdr.cpp:2048 src/muuli_wdr.cpp:2107
 msgid "IP of the listening interface:"
 msgstr "Kuunneltavan verkkoliitännän IP:"
 
-#: src/muuli_wdr.cpp:2052
+#: src/muuli_wdr.cpp:2051
 msgid "Enter here a valid ip in the a.b.c.d format for the listening EC interface. An empty field or 0.0.0.0 will mean any interface."
 msgstr "Syötä tähän sen verkkoliitännän ip jota kuunnellaan etäyhteyksiä varten. Tyhjä tai 0.0.0.0 tarkoittaa kaikkia verkkoliitäntöjä."
 
-#: src/muuli_wdr.cpp:2073 src/muuli_wdr.cpp:2184
+#: src/muuli_wdr.cpp:2072 src/muuli_wdr.cpp:2156
 msgid "TCP port:"
 msgstr "TCP-portti:"
 
-#: src/muuli_wdr.cpp:2079
+#: src/muuli_wdr.cpp:2078
 msgid "Enable UPnP port forwarding on the EC port"
 msgstr "Kytke päälle UPnP-portinohjaus etäyhteysportissa"
 
-#: src/muuli_wdr.cpp:2083 src/muuli_wdr.cpp:3069
+#: src/muuli_wdr.cpp:2082 src/muuli_wdr.cpp:3041
 #: src/utils/wxCas/src/wxcasprefs.cpp:167
 msgid "Password"
 msgstr "Salasana"
 
-#: src/muuli_wdr.cpp:2089
+#: src/muuli_wdr.cpp:2088
 #, fuzzy
 msgid "aMule API server parameters"
 msgstr "Web-palvelimen asetukset"
 
-#: src/muuli_wdr.cpp:2092
+#: src/muuli_wdr.cpp:2091
 msgid "Run amuleapi (REST API) on startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2097
+#: src/muuli_wdr.cpp:2096
 #, fuzzy
 msgid "HTTP port:"
 msgstr "TCP-portti:"
 
-#: src/muuli_wdr.cpp:2111
+#: src/muuli_wdr.cpp:2110
 msgid "The interface amuleapi's HTTP server listens on. 127.0.0.1 (default) accepts only local connections; use 0.0.0.0 or a specific IP to expose it to other hosts (set an admin password below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2116
-msgid "Type a password to set or change it. Stored passwords cannot be shown, so leaving this empty keeps the current one."
-msgstr ""
-
-#: src/muuli_wdr.cpp:2118
+#: src/muuli_wdr.cpp:2113
 #, fuzzy
 msgid "Admin password"
 msgstr "Tarkistaa salasanaa\n"
 
-#: src/muuli_wdr.cpp:2130 src/muuli_wdr.cpp:2147 src/PrefsUnifiedDlg.cpp:1103
-#, fuzzy
-msgid "A password is set."
-msgstr "Tarkistaa salasanaa\n"
+#: src/muuli_wdr.cpp:2118 src/muuli_wdr.cpp:2149
+msgid "Low rights password"
+msgstr "Rajoitettujen oikeuksien salasana"
 
-#: src/muuli_wdr.cpp:2134
-#, fuzzy
-msgid "Enable guest access"
-msgstr "Estä vieraskäyttö"
-
-#: src/muuli_wdr.cpp:2135
-msgid "Guest sessions may read status and listings but cannot change anything. Turning this off clears the stored guest password."
-msgstr ""
-
-#: src/muuli_wdr.cpp:2139
-#, fuzzy
-msgid "Guest password"
-msgstr "Vieraan salasana web-palvelimelle"
-
-#: src/muuli_wdr.cpp:2154
+#: src/muuli_wdr.cpp:2126
 msgid "Web server parameters"
 msgstr "Web-palvelimen asetukset"
 
-#: src/muuli_wdr.cpp:2157
+#: src/muuli_wdr.cpp:2129
 #, fuzzy
 msgid "Run webserver on startup (deprecated)"
 msgstr "Käynnistä web-palvelin käynnistettäessä"
 
-#: src/muuli_wdr.cpp:2163
+#: src/muuli_wdr.cpp:2135
 msgid "Web template"
 msgstr "Web-sapluuna"
 
-#: src/muuli_wdr.cpp:2168
+#: src/muuli_wdr.cpp:2140
 msgid "Full rights password"
 msgstr "Täysien oikeuksien salasana"
 
-#: src/muuli_wdr.cpp:2172
+#: src/muuli_wdr.cpp:2144
 msgid "Enable Low rights User"
 msgstr "Salli rajoitettujen oikeuksien käyttäjä"
 
-#: src/muuli_wdr.cpp:2177
-msgid "Low rights password"
-msgstr "Rajoitettujen oikeuksien salasana"
-
-#: src/muuli_wdr.cpp:2191
+#: src/muuli_wdr.cpp:2163
 msgid "Enable UPnP port forwarding of the web server port"
 msgstr "Käytä UPnP-portinohjausta web-palvelimen portissa"
 
-#: src/muuli_wdr.cpp:2196
+#: src/muuli_wdr.cpp:2168
 msgid "Web server UPnP TCP port (Optional)"
 msgstr "Web-palvelimen UPnP TCP-portti (Valinnainen)"
 
-#: src/muuli_wdr.cpp:2204
+#: src/muuli_wdr.cpp:2176
 msgid "Page Refresh Time (in secs)"
 msgstr "Sivun päivitysväli (sekunneissa)"
 
-#: src/muuli_wdr.cpp:2211
+#: src/muuli_wdr.cpp:2183
 msgid "Enable Gzip compression"
 msgstr "Salli gzip-pakkaus"
 
-#: src/muuli_wdr.cpp:2245
+#: src/muuli_wdr.cpp:2217
 #, fuzzy
 msgid "Reset page to defaults"
 msgstr "Järjestelmän vakio"
 
-#: src/muuli_wdr.cpp:2246
+#: src/muuli_wdr.cpp:2218
 msgid "Reset the settings on the current page to their default values."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2248 src/muuli_wdr.cpp:2334 src/ServerWnd.cpp:274
+#: src/muuli_wdr.cpp:2220 src/muuli_wdr.cpp:2306 src/ServerWnd.cpp:274
 #: src/ServerWnd.cpp:282
 msgid "OK"
 msgstr "OK"
 
-#: src/muuli_wdr.cpp:2250
+#: src/muuli_wdr.cpp:2222
 msgid "Click here to apply any changes made to the preferences."
 msgstr "Napsauta tästä saattaaksesi voimaan asetuksiin tehdyt muutokset."
 
-#: src/muuli_wdr.cpp:2253
+#: src/muuli_wdr.cpp:2225
 msgid "Reset any changes made to the preferences."
 msgstr "Nollaa asetuksiin tekemäsi muutokset."
 
-#: src/muuli_wdr.cpp:2282
+#: src/muuli_wdr.cpp:2254
 msgid "Comment :"
 msgstr "Kommentti :"
 
-#: src/muuli_wdr.cpp:2289
+#: src/muuli_wdr.cpp:2261
 msgid "Incoming Dir :"
 msgstr "Saapuvien kansio :"
 
-#: src/muuli_wdr.cpp:2298
+#: src/muuli_wdr.cpp:2270
 msgid "Change priority for new assigned files :"
 msgstr "Vaihda tärkeyttä uusille sijoitetuille tiedostoille :"
 
-#: src/muuli_wdr.cpp:2302
+#: src/muuli_wdr.cpp:2274
 msgid "Don't change"
 msgstr "Älä vaihda"
 
-#: src/muuli_wdr.cpp:2314
+#: src/muuli_wdr.cpp:2286
 msgid "Select color for this Category (currently selected) :"
 msgstr "Valitse väri tälle luokalle (valittuna) :"
 
-#: src/muuli_wdr.cpp:2381 src/muuli_wdr.cpp:2400 src/muuli_wdr.cpp:2422
+#: src/muuli_wdr.cpp:2353 src/muuli_wdr.cpp:2372 src/muuli_wdr.cpp:2394
 msgid "Click this button to reset the log."
 msgstr "Napsauta tätä painiketta nollataksesi lokin."
 
-#: src/muuli_wdr.cpp:2441
+#: src/muuli_wdr.cpp:2413
 msgid "Click on this button to update the servers list from URL ..."
 msgstr "Napsauta tätä nappia päivittääksesi palvelinlistan osoitteesta ..."
 
-#: src/muuli_wdr.cpp:2445
+#: src/muuli_wdr.cpp:2417
 msgid "Server list"
 msgstr "Palvelinlista"
 
-#: src/muuli_wdr.cpp:2449
+#: src/muuli_wdr.cpp:2421
 msgid "Enter the url to a server.met file here and press the button to the left to update the list of known servers."
 msgstr "Syötä tähän server.met-tiedostoon osoittava url ja paina nappia vasemmalla päivittääksesi tunnettujen palvelimien listan."
 
-#: src/muuli_wdr.cpp:2454
+#: src/muuli_wdr.cpp:2426
 msgid "Add server manually: Name"
 msgstr "Palvelimen lisäys käsin: Nimi"
 
-#: src/muuli_wdr.cpp:2457
+#: src/muuli_wdr.cpp:2429
 msgid "Enter the name of the new server here"
 msgstr "Syötä uuden palvelimen nimi tähän"
 
-#: src/muuli_wdr.cpp:2459 src/ServerWnd.cpp:206
+#: src/muuli_wdr.cpp:2431 src/ServerWnd.cpp:206
 msgid "IP:Port"
 msgstr "IP:Portti"
 
-#: src/muuli_wdr.cpp:2462
+#: src/muuli_wdr.cpp:2434
 msgid "Enter the IP of the server here, using the x.x.x.x format."
 msgstr "Syötä uuden palvelimen IP tähän, muodossa x.x.x.x."
 
-#: src/muuli_wdr.cpp:2468
+#: src/muuli_wdr.cpp:2440
 msgid "Enter the port of the server here."
 msgstr "Syötä palvelimen portti tähän."
 
-#: src/muuli_wdr.cpp:2471
+#: src/muuli_wdr.cpp:2443
 msgid "Add manually a server (fill fields to the left before) ..."
 msgstr "Lisää palvelin käsin (täytä vasemmalla olevat kentät) ..."
 
-#: src/muuli_wdr.cpp:2500
+#: src/muuli_wdr.cpp:2472
 msgid "aMule Log"
 msgstr "aMule loki"
 
-#: src/muuli_wdr.cpp:2508
+#: src/muuli_wdr.cpp:2480
 msgid "Server Info"
 msgstr "Palvelimen tiedot"
 
-#: src/muuli_wdr.cpp:2512
+#: src/muuli_wdr.cpp:2484
 msgid "ED2K Info"
 msgstr "ED2K Info"
 
-#: src/muuli_wdr.cpp:2516
+#: src/muuli_wdr.cpp:2488
 msgid "Kad Info"
 msgstr "Kad Info"
 
-#: src/muuli_wdr.cpp:2544
+#: src/muuli_wdr.cpp:2516
 msgid "Click on this button to update the nodes list from URL ..."
 msgstr "Napsauta tätä nappia päivittääksesi yhteyspisteiden listan osoitteesta ..."
 
-#: src/muuli_wdr.cpp:2548
+#: src/muuli_wdr.cpp:2520
 msgid "Nodes (0)"
 msgstr "Yhteyspisteitä (0)"
 
-#: src/muuli_wdr.cpp:2552
+#: src/muuli_wdr.cpp:2524
 msgid "Enter the url to a nodes.dat file here and press the button to the left to update the list of known nodes."
 msgstr "Syötä tähän nodes.dat-tiedostoon osoittava url ja paina nappia vasemmalla päivittääksesi tunnettujen yhteyspisteiden listan."
 
-#: src/muuli_wdr.cpp:2555
+#: src/muuli_wdr.cpp:2527
 msgid "Nodes stats"
 msgstr "Yhteyspisteiden tilastot"
 
-#: src/muuli_wdr.cpp:2597
+#: src/muuli_wdr.cpp:2569
 msgid "Bootstrap"
 msgstr "Yhdistämisapu"
 
-#: src/muuli_wdr.cpp:2600
+#: src/muuli_wdr.cpp:2572
 msgid "New node"
 msgstr "Uusi yhteyspiste"
 
-#: src/muuli_wdr.cpp:2605
+#: src/muuli_wdr.cpp:2577
 msgid "IP:"
 msgstr "IP:"
 
-#: src/muuli_wdr.cpp:2625
+#: src/muuli_wdr.cpp:2597
 msgid "Port:"
 msgstr "Portti:"
 
-#: src/muuli_wdr.cpp:2638
+#: src/muuli_wdr.cpp:2610
 msgid "Bootstrap from known clients"
 msgstr "Käytä tunnettuja asiakkaita yhdistämisapuna"
 
-#: src/muuli_wdr.cpp:2640
+#: src/muuli_wdr.cpp:2612
 msgid "Disconnect Kad"
 msgstr "Katkaise Kad-yhteys"
 
-#: src/muuli_wdr.cpp:2674
+#: src/muuli_wdr.cpp:2646
 msgid "Use Secure User Identification"
 msgstr "Käytä turvattua käyttäjän tunnistusta"
 
-#: src/muuli_wdr.cpp:2676
+#: src/muuli_wdr.cpp:2648
 msgid "It is recommended to enable this option. You will not receive credits if SUI is not enabled."
 msgstr "Tunnistuksen käyttö on suositeltavaa. Muuten et hyödy pistejärjestelmästä."
 
-#: src/muuli_wdr.cpp:2678
+#: src/muuli_wdr.cpp:2650
 msgid "Protocol Obfuscation"
 msgstr "Protokollan kätkeminen"
 
-#: src/muuli_wdr.cpp:2681
+#: src/muuli_wdr.cpp:2653
 msgid "Support Protocol Obfuscation"
 msgstr "Tuki protokollan kätkemiselle"
 
-#: src/muuli_wdr.cpp:2683
+#: src/muuli_wdr.cpp:2655
 msgid "This option enabled Protocol Obfuscation, and makes aMule accept obfuscated connections from other clients."
 msgstr "Tämä valinta sallii aMulen ottaa vastaan kätketyn protokollan yhteyksiä muilta asiakkailta."
 
-#: src/muuli_wdr.cpp:2685
+#: src/muuli_wdr.cpp:2657
 msgid "Use obfuscation for outgoing connections"
 msgstr "Käytä kätkemistä lähtevissä yhteyksissä"
 
-#: src/muuli_wdr.cpp:2687
+#: src/muuli_wdr.cpp:2659
 msgid "This option makes aMule use Protocol Obfuscation when connecting other clients/servers."
 msgstr "Tämä valittuna aMule käyttää protokollan kätkemistä ottaessaan yhteyttä muihin asiakkaisiin/palvelimiin."
 
-#: src/muuli_wdr.cpp:2689
+#: src/muuli_wdr.cpp:2661
 msgid "Accept only obfuscated connections"
 msgstr "Vastaanota vain kätkettyjä yhteyksiä"
 
-#: src/muuli_wdr.cpp:2690
+#: src/muuli_wdr.cpp:2662
 msgid "This option makes aMule only accept obfuscated connections. You will have less sources, but all your traffic will be obfuscated"
 msgstr "Tämä valittuna aMule hyväksyy vain kätketyt yhteydet. Lähteitä on vähemmän saatavilla mutta kaikki liikenteesi on kätketyllä protokollalla."
 
-#: src/muuli_wdr.cpp:2695
+#: src/muuli_wdr.cpp:2667
 msgid "Everybody"
 msgstr "Kaikki"
 
-#: src/muuli_wdr.cpp:2697
+#: src/muuli_wdr.cpp:2669
 msgid "No one"
 msgstr "Ei kukaan"
 
-#: src/muuli_wdr.cpp:2699
+#: src/muuli_wdr.cpp:2671
 msgid "Who can see my shared files:"
 msgstr "Ketkä voivat nähdä jaetut tiedostoni:"
 
-#: src/muuli_wdr.cpp:2700
+#: src/muuli_wdr.cpp:2672
 msgid "Select who can request to view a list of your shared files."
 msgstr "Valitse ketkä voivat pyytää nähtäville sinun jaettujen tiedostojen listaasi."
 
-#: src/muuli_wdr.cpp:2702
+#: src/muuli_wdr.cpp:2674
 msgid "IP-Filtering"
 msgstr "IP-suodatus"
 
-#: src/muuli_wdr.cpp:2709
+#: src/muuli_wdr.cpp:2681
 msgid "Filter clients"
 msgstr "Suodata asiakkaat"
 
-#: src/muuli_wdr.cpp:2711
+#: src/muuli_wdr.cpp:2683
 msgid "Enable filtering of the client IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "Salli asiakas-IP:den suodatus kuten määritelty tiedostossa ~/.aMule/ipfilter.dat."
 
-#: src/muuli_wdr.cpp:2713
+#: src/muuli_wdr.cpp:2685
 msgid "Filter servers"
 msgstr "Suodata palvelimet"
 
-#: src/muuli_wdr.cpp:2715
+#: src/muuli_wdr.cpp:2687
 msgid "Enable filtering of the server IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "Salli palvelin-IP:den suodatus kuten määritelty tiedostossa ~/.aMule/ipfilter.dat."
 
-#: src/muuli_wdr.cpp:2719
+#: src/muuli_wdr.cpp:2691
 msgid "Reload List"
 msgstr "Uudelleenlataa lista"
 
-#: src/muuli_wdr.cpp:2720
+#: src/muuli_wdr.cpp:2692
 msgid "Reload the list of IPs to filter from the file ~/.aMule/ipfilter.dat"
 msgstr "Uudelleenlataa suodatettavien IP:den lista tiedostosta ~/.aMule/ipfilter.dat."
 
-#: src/muuli_wdr.cpp:2726
+#: src/muuli_wdr.cpp:2698
 msgid "URL:"
 msgstr "URL:"
 
-#: src/muuli_wdr.cpp:2730 src/muuli_wdr.cpp:2923
+#: src/muuli_wdr.cpp:2702 src/muuli_wdr.cpp:2895
 msgid "Update now"
 msgstr "Päivitä nyt"
 
-#: src/muuli_wdr.cpp:2733
+#: src/muuli_wdr.cpp:2705
 msgid "Auto-update ipfilter at startup"
 msgstr "Päivitä ip-suodatus automaattisesti käynnistettäessä"
 
-#: src/muuli_wdr.cpp:2737
+#: src/muuli_wdr.cpp:2709
 msgid "Filtering Level:"
 msgstr "Suodatustaso:"
 
-#: src/muuli_wdr.cpp:2743
+#: src/muuli_wdr.cpp:2715
 msgid "Always filter LAN IPs"
 msgstr "Suodata aina lähiverkon IP:t"
 
-#: src/muuli_wdr.cpp:2746
+#: src/muuli_wdr.cpp:2718
 msgid "Paranoid handling of non-matching IPs"
 msgstr "Käsittele muut IP:t vainoharhaisesti"
 
-#: src/muuli_wdr.cpp:2748
+#: src/muuli_wdr.cpp:2720
 msgid "Rejects a packet when its source IP differs from the IP the client claims (an anti-spoofing check). Disable only if it causes connection problems."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2750
+#: src/muuli_wdr.cpp:2722
 msgid "Use system-wide ipfilter.dat if available"
 msgstr "Käytä järjestelmänlaajuista ipfilter.dat-tiedostoa mikäli saatavilla"
 
-#: src/muuli_wdr.cpp:2751
+#: src/muuli_wdr.cpp:2723
 #, fuzzy
 msgid "If there's no local ipfilter.dat found, allow usage of a system-wide ipfilter file."
 msgstr "Mikäli paikallista ipfilter.dat:ia ei löydy, käytetään järjestelmänlaajuista ipfilter.dat-tiedostoa."
 
-#: src/muuli_wdr.cpp:2768
+#: src/muuli_wdr.cpp:2740
 msgid "Enable Online-Signature"
 msgstr "Kytke Online-Signeeraus päälle"
 
-#: src/muuli_wdr.cpp:2770
+#: src/muuli_wdr.cpp:2742
 msgid "Enables the writing of the OS file, which can be used by external apps to create signatures and the like."
 msgstr "Kytkee päälle Online-Signeeraustiedoston kirjoittamisen, jota muut ohjelmat voivat käyttää esimerkiksi signeerauksissa."
 
-#: src/muuli_wdr.cpp:2774
+#: src/muuli_wdr.cpp:2746
 msgid "Update Frequency (Secs):"
 msgstr "Päivitysväli (sekuntia):"
 
-#: src/muuli_wdr.cpp:2777
+#: src/muuli_wdr.cpp:2749
 msgid "Change the frequency (in seconds) of Online Signature updates."
 msgstr "Muuttaa Online-Signeerauksen päivitysväliä, annetaan sekunteina."
 
-#: src/muuli_wdr.cpp:2785
+#: src/muuli_wdr.cpp:2757
 msgid "Save online signature file in: "
 msgstr "Online-signeeraus-tiedoston tallennuspaikka:"
 
-#: src/muuli_wdr.cpp:2791
+#: src/muuli_wdr.cpp:2763
 msgid "Click here to select the directory containing the the Online Signature files."
 msgstr "Napsauta tästä valitaksesi kansio Online-Signeerauksen tiedostoille."
 
-#: src/muuli_wdr.cpp:2824
+#: src/muuli_wdr.cpp:2796
 msgid "Show country flags for clients"
 msgstr "Näytä asiakkaiden valtioiden liput"
 
-#: src/muuli_wdr.cpp:2825
+#: src/muuli_wdr.cpp:2797
 msgid "Render the country flag column in the transfers, queue and search views. Requires a valid MMDB GeoIP database (see below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2830
+#: src/muuli_wdr.cpp:2802
 #, fuzzy
 msgid "Database"
 msgstr "Siirtonopeus :"
 
-#: src/muuli_wdr.cpp:2846
+#: src/muuli_wdr.cpp:2818
 #, fuzzy
 msgid "Source:"
 msgstr "Lähteet"
 
-#: src/muuli_wdr.cpp:2849
+#: src/muuli_wdr.cpp:2821
 msgid "DB-IP (free, no account)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2850
+#: src/muuli_wdr.cpp:2822
 msgid "MaxMind GeoLite2 (free, account required)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2851
+#: src/muuli_wdr.cpp:2823
 msgid "Custom URL"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2854
+#: src/muuli_wdr.cpp:2826
 msgid "Choose which provider supplies the GeoIP MMDB database. DB-IP is the default - no account required. MaxMind requires a free account + license key. Use Custom URL to point at any other MMDB host (e.g. a local mirror)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2871
+#: src/muuli_wdr.cpp:2843
 msgid ""
 "No configuration required.\n"
 "\n"
@@ -4874,11 +4840,11 @@ msgid ""
 "License: Creative Commons BY 4.0 - https://creativecommons.org/licenses/by/4.0/"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2884
+#: src/muuli_wdr.cpp:2856
 msgid "License key:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2890
+#: src/muuli_wdr.cpp:2862
 msgid ""
 "Sign up for a free MaxMind account, then generate a License Key:\n"
 "https://www.maxmind.com/en/geolite2/signup\n"
@@ -4888,226 +4854,226 @@ msgid ""
 "Requires attribution and account registration; refresh at least every 30 days."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2905
+#: src/muuli_wdr.cpp:2877
 #, fuzzy
 msgid "Download URL:"
 msgstr "Lataus: "
 
-#: src/muuli_wdr.cpp:2911
+#: src/muuli_wdr.cpp:2883
 msgid ""
 "Must point to an .mmdb file or a .gz / .tar.gz containing one.\n"
 "URL may include credentials (https://user:pass@host/...).\n"
 "License and attribution terms are set by the upstream URL - you are responsible."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2924
+#: src/muuli_wdr.cpp:2896
 msgid "Download the GeoIP database from the selected source."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2926
+#: src/muuli_wdr.cpp:2898
 #, fuzzy
 msgid "Auto-update on startup"
 msgstr "Päivitä ip-suodatus automaattisesti käynnistettäessä"
 
-#: src/muuli_wdr.cpp:2927
+#: src/muuli_wdr.cpp:2899
 msgid "Re-download the GeoIP database from the selected source every time aMule starts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2950
+#: src/muuli_wdr.cpp:2922
 msgid "Filter incoming messages (except current chat):"
 msgstr "Suodata saapuvat viestit (ei koske keskusteluja):"
 
-#: src/muuli_wdr.cpp:2952
+#: src/muuli_wdr.cpp:2924
 msgid "Filter all messages"
 msgstr "Suodata kaikki viestit"
 
-#: src/muuli_wdr.cpp:2954
+#: src/muuli_wdr.cpp:2926
 msgid "Filter messages from people not on your friend list"
 msgstr "Suodata viestit ihmisiltä jotka eivät ole kaverilistallasi"
 
-#: src/muuli_wdr.cpp:2956
+#: src/muuli_wdr.cpp:2928
 msgid "Filter messages from unknown clients"
 msgstr "Suodata viestit tuntemattomilta asiakkailta"
 
-#: src/muuli_wdr.cpp:2958
+#: src/muuli_wdr.cpp:2930
 msgid "Filter messages containing (use ',' as separator):"
 msgstr "Suodata viestit jotka sisältävät (käytä merkkiä ',' erottimena):"
 
-#: src/muuli_wdr.cpp:2961 src/muuli_wdr.cpp:2972
+#: src/muuli_wdr.cpp:2933 src/muuli_wdr.cpp:2944
 msgid "add here the words amule should filter and block messages including it"
 msgstr "Syötä tähän suodatettavat sanat ja aMule estää viestit jotka sisältävät sellaisen"
 
-#: src/muuli_wdr.cpp:2963
+#: src/muuli_wdr.cpp:2935
 msgid "Show received messages in the log"
 msgstr "Näytä vastaanotetut viestit lokissa"
 
-#: src/muuli_wdr.cpp:2966
+#: src/muuli_wdr.cpp:2938
 msgid "Comments"
 msgstr "Kommentit"
 
-#: src/muuli_wdr.cpp:2969
+#: src/muuli_wdr.cpp:2941
 msgid "Filter comments containing (use ',' as separator):"
 msgstr "Suodata kommentit jotka sisältävät (käytä merkkiä ',' erottimena):"
 
-#: src/muuli_wdr.cpp:2994
+#: src/muuli_wdr.cpp:2966
 msgid "Enable Proxy"
 msgstr "Käytä välityspalvelinta"
 
-#: src/muuli_wdr.cpp:2995
+#: src/muuli_wdr.cpp:2967
 msgid "Enable/disable proxy support"
 msgstr "Kytke päälle/pois välityspalvelimen tuki"
 
-#: src/muuli_wdr.cpp:2998
+#: src/muuli_wdr.cpp:2970
 msgid "Proxy type:"
 msgstr "Tyyppi:"
 
-#: src/muuli_wdr.cpp:3009
+#: src/muuli_wdr.cpp:2981
 msgid "Proxy host:"
 msgstr "Välityspalvelin:"
 
-#: src/muuli_wdr.cpp:3012
+#: src/muuli_wdr.cpp:2984
 msgid "The proxy host name"
 msgstr "Välityspalvelimen verkkonimi"
 
-#: src/muuli_wdr.cpp:3014
+#: src/muuli_wdr.cpp:2986
 msgid "Proxy port:"
 msgstr "Portti:"
 
-#: src/muuli_wdr.cpp:3017
+#: src/muuli_wdr.cpp:2989
 msgid "The proxy port"
 msgstr "Välityspalvelimen portti"
 
-#: src/muuli_wdr.cpp:3019
+#: src/muuli_wdr.cpp:2991
 msgid "Enable authentication"
 msgstr "Käytä tunnistautumista"
 
-#: src/muuli_wdr.cpp:3020
+#: src/muuli_wdr.cpp:2992
 msgid "Enable/disable username/password authentication"
 msgstr "Kytkee päälle/pois käyttäjänimellä/salasanalla tunnistautumisen"
 
-#: src/muuli_wdr.cpp:3023
+#: src/muuli_wdr.cpp:2995
 msgid "Username: "
 msgstr "Käyttäjänimi: "
 
-#: src/muuli_wdr.cpp:3026
+#: src/muuli_wdr.cpp:2998
 msgid "The username to use to connect to the proxy"
 msgstr "Käyttäjänimi tunnistautuessa välityspalvelimelle"
 
-#: src/muuli_wdr.cpp:3028
+#: src/muuli_wdr.cpp:3000
 msgid "Password:"
 msgstr "Salasana:"
 
-#: src/muuli_wdr.cpp:3031
+#: src/muuli_wdr.cpp:3003
 msgid "The password to use to connect to the proxy"
 msgstr "Salasana tunnistautuessa välityspalvelimelle"
 
-#: src/muuli_wdr.cpp:3050
+#: src/muuli_wdr.cpp:3022
 msgid "Connect to:"
 msgstr "Yhdistä:"
 
-#: src/muuli_wdr.cpp:3059
+#: src/muuli_wdr.cpp:3031
 msgid "Login to remote amule"
 msgstr "Kirjaudu etä-aMuleen"
 
-#: src/muuli_wdr.cpp:3064
+#: src/muuli_wdr.cpp:3036
 msgid "User name"
 msgstr "Käyttäjänimi"
 
-#: src/muuli_wdr.cpp:3075
+#: src/muuli_wdr.cpp:3047
 msgid "Remember those settings"
 msgstr "Muista nämä asetukset"
 
-#: src/muuli_wdr.cpp:3078
+#: src/muuli_wdr.cpp:3050
 #, fuzzy
 msgid "Force ZLIB compression"
 msgstr "Käytä gzip-pakkausta"
 
-#: src/muuli_wdr.cpp:3102
+#: src/muuli_wdr.cpp:3074
 msgid "Enable Verbose Debug-Logging."
 msgstr "Käytä monisanaista lokiin kirjausta."
 
-#: src/muuli_wdr.cpp:3104
+#: src/muuli_wdr.cpp:3076
 #, fuzzy
 msgid "Only to Logfile"
 msgstr "Avaa tied&osto"
 
-#: src/muuli_wdr.cpp:3106
+#: src/muuli_wdr.cpp:3078
 msgid "Message Categories:"
 msgstr "Viestien luokittelut:"
 
-#: src/muuli_wdr.cpp:3130 src/PartFileConvertDlg.cpp:160
+#: src/muuli_wdr.cpp:3102 src/PartFileConvertDlg.cpp:160
 msgid "Waiting..."
 msgstr "Odottaa..."
 
-#: src/muuli_wdr.cpp:3150
+#: src/muuli_wdr.cpp:3122
 msgid "Add imports"
 msgstr "Lisää tuonteja"
 
-#: src/muuli_wdr.cpp:3153
+#: src/muuli_wdr.cpp:3125
 msgid "Retry selected"
 msgstr "Yritä uudelleen valittuja"
 
-#: src/muuli_wdr.cpp:3155
+#: src/muuli_wdr.cpp:3127
 msgid "Remove selected"
 msgstr "Poista valitut"
 
-#: src/muuli_wdr.cpp:3218
+#: src/muuli_wdr.cpp:3190
 msgid "Event Types"
 msgstr "Tapahtumatyypit"
 
-#: src/muuli_wdr.cpp:3237
+#: src/muuli_wdr.cpp:3209
 msgid "Statistics and queued clients for selected file(s) : Session / All time"
 msgstr "Tilastot ja jonottavat asiakkaat valitu(i)lle tiedosto(i)lle: Sessiossa / Yhteensä"
 
-#: src/muuli_wdr.cpp:3261
+#: src/muuli_wdr.cpp:3233
 msgid "Active Uploads"
 msgstr "Aktiiviset lähetykset"
 
-#: src/muuli_wdr.cpp:3275
+#: src/muuli_wdr.cpp:3247
 msgid "Percent of total files"
 msgstr "Prosenttia kaikista tiedostoista"
 
-#: src/muuli_wdr.cpp:3327
+#: src/muuli_wdr.cpp:3299
 msgid "Show Clients for"
 msgstr "Näytä asiakkaat"
 
-#: src/muuli_wdr.cpp:3329
+#: src/muuli_wdr.cpp:3301
 msgid "All files"
 msgstr "Kaikki tiedostot"
 
-#: src/muuli_wdr.cpp:3332
+#: src/muuli_wdr.cpp:3304
 msgid "Selected files"
 msgstr "Valitut tiedostot"
 
-#: src/muuli_wdr.cpp:3335
+#: src/muuli_wdr.cpp:3307
 msgid "Active uploads only"
 msgstr "Vain aktiiviset lähetykset"
 
-#: src/muuli_wdr.cpp:3342
+#: src/muuli_wdr.cpp:3314
 msgid "Reload:"
 msgstr "Uudelleenlataa:"
 
-#: src/muuli_wdr.cpp:3346
+#: src/muuli_wdr.cpp:3318
 msgid "Reload your shared files"
 msgstr "Uudelleenlataa jaetut tiedostot"
 
-#: src/muuli_wdr.cpp:3409
+#: src/muuli_wdr.cpp:3381
 msgid "Send"
 msgstr "Lähetä"
 
-#: src/muuli_wdr.cpp:3410
+#: src/muuli_wdr.cpp:3382
 msgid "Sends the specified message."
 msgstr "Lähettää annetun viestin."
 
-#: src/muuli_wdr.cpp:3414
+#: src/muuli_wdr.cpp:3386
 msgid "Close this chat-session."
 msgstr "Sulje tämä keskustelu."
 
-#: src/muuli_wdr.cpp:3437
+#: src/muuli_wdr.cpp:3409
 msgid "Connect to any server and/or Kad"
 msgstr "Yhdistä mihin tahansa palvelimeen ja/tai Kadiin"
 
-#: src/muuli_wdr.cpp:3443 src/SharedFilesCtrl.cpp:142 src/Statistics.cpp:941
+#: src/muuli_wdr.cpp:3415 src/SharedFilesCtrl.cpp:142 src/Statistics.cpp:941
 msgid "Shared Files"
 msgstr "Jaetut tiedostot"
 
@@ -5466,249 +5432,249 @@ msgstr "Ladattu"
 msgid "ERROR: Failed to open partfile '%s'"
 msgstr "VIRHE: Ei voida avata osatiedostoa '%s'"
 
-#: src/Preferences.cpp:701
+#: src/Preferences.cpp:673
 msgid "System default"
 msgstr "Järjestelmän vakio"
 
-#: src/Preferences.cpp:702
+#: src/Preferences.cpp:674
 msgid "Albanian"
 msgstr "Albania"
 
-#: src/Preferences.cpp:703
+#: src/Preferences.cpp:675
 msgid "Arabic"
 msgstr "Arabia"
 
-#: src/Preferences.cpp:704
+#: src/Preferences.cpp:676
 msgid "Asturian"
 msgstr "Asturia"
 
-#: src/Preferences.cpp:705
+#: src/Preferences.cpp:677
 msgid "Basque"
 msgstr "Baski"
 
-#: src/Preferences.cpp:706
+#: src/Preferences.cpp:678
 msgid "Bulgarian"
 msgstr "Bulgaria"
 
-#: src/Preferences.cpp:707
+#: src/Preferences.cpp:679
 msgid "Catalan"
 msgstr "Katalaani"
 
-#: src/Preferences.cpp:708
+#: src/Preferences.cpp:680
 msgid "Chinese (Simplified)"
 msgstr "Kiina (Yksinkertaistettu)"
 
-#: src/Preferences.cpp:709
+#: src/Preferences.cpp:681
 msgid "Chinese (Traditional)"
 msgstr "Kiina (Perinteinen)"
 
-#: src/Preferences.cpp:710
+#: src/Preferences.cpp:682
 msgid "Croatian"
 msgstr "Kroatia"
 
-#: src/Preferences.cpp:711
+#: src/Preferences.cpp:683
 msgid "Czech"
 msgstr "Tsekki"
 
-#: src/Preferences.cpp:712
+#: src/Preferences.cpp:684
 msgid "Danish"
 msgstr "Tanska"
 
-#: src/Preferences.cpp:713
+#: src/Preferences.cpp:685
 msgid "Dutch"
 msgstr "Hollanti"
 
-#: src/Preferences.cpp:714
+#: src/Preferences.cpp:686
 msgid "English (U.K.)"
 msgstr "Englanti (U.K.)"
 
-#: src/Preferences.cpp:715
+#: src/Preferences.cpp:687
 #, fuzzy
 msgid "English (U.S.)"
 msgstr "Englanti (U.K.)"
 
-#: src/Preferences.cpp:716
+#: src/Preferences.cpp:688
 msgid "Estonian"
 msgstr "Viro"
 
-#: src/Preferences.cpp:717
+#: src/Preferences.cpp:689
 msgid "Finnish"
 msgstr "Suomi"
 
-#: src/Preferences.cpp:718
+#: src/Preferences.cpp:690
 msgid "French"
 msgstr "Ranska"
 
-#: src/Preferences.cpp:719
+#: src/Preferences.cpp:691
 msgid "Galician"
 msgstr "Galicia (Galego)"
 
-#: src/Preferences.cpp:720
+#: src/Preferences.cpp:692
 msgid "German"
 msgstr "Saksa"
 
-#: src/Preferences.cpp:721
+#: src/Preferences.cpp:693
 msgid "Greek"
 msgstr "Kreikka"
 
-#: src/Preferences.cpp:722
+#: src/Preferences.cpp:694
 msgid "Hebrew"
 msgstr "Heprea"
 
-#: src/Preferences.cpp:723
+#: src/Preferences.cpp:695
 msgid "Hungarian"
 msgstr "Unkari"
 
-#: src/Preferences.cpp:724
+#: src/Preferences.cpp:696
 msgid "Italian"
 msgstr "Italia"
 
-#: src/Preferences.cpp:725
+#: src/Preferences.cpp:697
 msgid "Japanese"
 msgstr "Japani"
 
-#: src/Preferences.cpp:726
+#: src/Preferences.cpp:698
 msgid "Korean"
 msgstr "Korea"
 
-#: src/Preferences.cpp:727
+#: src/Preferences.cpp:699
 msgid "Latvian"
 msgstr ""
 
-#: src/Preferences.cpp:728
+#: src/Preferences.cpp:700
 msgid "Lithuanian"
 msgstr "Liettua"
 
-#: src/Preferences.cpp:729
+#: src/Preferences.cpp:701
 msgid "Norwegian (Nynorsk)"
 msgstr "Norja (Nynorsk)"
 
-#: src/Preferences.cpp:730
+#: src/Preferences.cpp:702
 msgid "Polish"
 msgstr "Puola"
 
-#: src/Preferences.cpp:731
+#: src/Preferences.cpp:703
 msgid "Portuguese"
 msgstr "Portugali"
 
-#: src/Preferences.cpp:732
+#: src/Preferences.cpp:704
 msgid "Portuguese (Brazilian)"
 msgstr "Portugali (Brazilia)"
 
-#: src/Preferences.cpp:733
+#: src/Preferences.cpp:705
 msgid "Romanian"
 msgstr "Romanian"
 
-#: src/Preferences.cpp:734
+#: src/Preferences.cpp:706
 msgid "Russian"
 msgstr "Venäjä"
 
-#: src/Preferences.cpp:735
+#: src/Preferences.cpp:707
 msgid "Slovenian"
 msgstr "Slovenia"
 
-#: src/Preferences.cpp:736
+#: src/Preferences.cpp:708
 msgid "Spanish"
 msgstr "Espanja"
 
-#: src/Preferences.cpp:737
+#: src/Preferences.cpp:709
 msgid "Swedish"
 msgstr "Ruotsi"
 
-#: src/Preferences.cpp:738
+#: src/Preferences.cpp:710
 msgid "Turkish"
 msgstr "Turkki"
 
-#: src/Preferences.cpp:739
+#: src/Preferences.cpp:711
 msgid "Ukrainian"
 msgstr "Ukraina"
 
-#: src/Preferences.cpp:842
+#: src/Preferences.cpp:814
 msgid "Change Language"
 msgstr "Vaihda kieli"
 
-#: src/Preferences.cpp:906
+#: src/Preferences.cpp:878
 msgid "There are no translations installed for aMule"
 msgstr "Käännöksiä ei ole asennettuna aMulelle"
 
-#: src/Preferences.cpp:907
+#: src/Preferences.cpp:879
 msgid "No languages available"
 msgstr "Kieliä ei saatavilla"
 
-#: src/Preferences.cpp:1038
+#: src/Preferences.cpp:1010
 msgid "no options available"
 msgstr "vaihtoehtoja ei saatavilla"
 
-#: src/Preferences.cpp:2226
+#: src/Preferences.cpp:2179
 msgid "Invalid category found, skipping"
 msgstr "Löytyi epäkelpo luokka, hypätään yli"
 
-#: src/Preferences.cpp:2395
+#: src/Preferences.cpp:2348
 msgid "TCP port can't be higher than 65532 due to server UDP socket being TCP+3"
 msgstr "TCP-portti ei voi olla korkeampi kuin 65532 koska serverin käyttämä UDP-pistukka on TCP+3"
 
-#: src/Preferences.cpp:2396
+#: src/Preferences.cpp:2349
 #, c-format
 msgid "Default port will be used (%d)"
 msgstr "Käytetään oletusporttia (%d)"
 
-#: src/PrefsUnifiedDlg.cpp:300 src/Statistics.cpp:866
+#: src/PrefsUnifiedDlg.cpp:298 src/Statistics.cpp:866
 msgid "Connection"
 msgstr "Yhteys"
 
-#: src/PrefsUnifiedDlg.cpp:301 src/SearchListCtrl.cpp:117
+#: src/PrefsUnifiedDlg.cpp:299 src/SearchListCtrl.cpp:117
 msgid "Directories"
 msgstr "Kansiot"
 
-#: src/PrefsUnifiedDlg.cpp:302 src/Statistics.cpp:917
+#: src/PrefsUnifiedDlg.cpp:300 src/Statistics.cpp:917
 msgid "Servers"
 msgstr "Palvelimet"
 
-#: src/PrefsUnifiedDlg.cpp:303 src/ServerListCtrl.cpp:96
+#: src/PrefsUnifiedDlg.cpp:301 src/ServerListCtrl.cpp:96
 msgid "Files"
 msgstr "Tiedostot"
 
-#: src/PrefsUnifiedDlg.cpp:304
+#: src/PrefsUnifiedDlg.cpp:302
 msgid "Security"
 msgstr "Turvallisuus"
 
-#: src/PrefsUnifiedDlg.cpp:305
+#: src/PrefsUnifiedDlg.cpp:303
 msgid "Interface"
 msgstr "Käyttöliittymä"
 
-#: src/PrefsUnifiedDlg.cpp:312
+#: src/PrefsUnifiedDlg.cpp:310
 msgid "IP2Country"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:315
+#: src/PrefsUnifiedDlg.cpp:313
 msgid "Proxy"
 msgstr "Välityspalvelin"
 
-#: src/PrefsUnifiedDlg.cpp:316
+#: src/PrefsUnifiedDlg.cpp:314
 msgid "Filters"
 msgstr "Suodattimet"
 
-#: src/PrefsUnifiedDlg.cpp:317
+#: src/PrefsUnifiedDlg.cpp:315
 msgid "Remote Controls"
 msgstr "Etähallinta"
 
-#: src/PrefsUnifiedDlg.cpp:318
+#: src/PrefsUnifiedDlg.cpp:316
 msgid "Online Signature"
 msgstr "Online-Signeeraus"
 
-#: src/PrefsUnifiedDlg.cpp:319
+#: src/PrefsUnifiedDlg.cpp:317
 msgid "Advanced"
 msgstr "Laajennetut"
 
-#: src/PrefsUnifiedDlg.cpp:320
+#: src/PrefsUnifiedDlg.cpp:318
 msgid "Events"
 msgstr "Tapahtumat"
 
-#: src/PrefsUnifiedDlg.cpp:323
+#: src/PrefsUnifiedDlg.cpp:321
 msgid "Debugging"
 msgstr "Debuggaus"
 
-#: src/PrefsUnifiedDlg.cpp:453
+#: src/PrefsUnifiedDlg.cpp:451
 msgid ""
 "The following variables will be substituted:\n"
 "    %PARTFILE - full path to the file\n"
@@ -5718,15 +5684,15 @@ msgstr ""
 "    %PARTFILE - koko polku tiedostoon\n"
 "    %PARTNAME - pelkästään tiedoston nimi"
 
-#: src/PrefsUnifiedDlg.cpp:474
+#: src/PrefsUnifiedDlg.cpp:472
 msgid "Tray icon support requires libayatana-appindicator3 at compile time."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:490
+#: src/PrefsUnifiedDlg.cpp:488
 msgid "Not available on Wayland: the protocol does not report when a window is minimized, so this option cannot intercept the system minimize button. Workaround: launch aMule with `GDK_BACKEND=x11` to use XWayland instead."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:536
+#: src/PrefsUnifiedDlg.cpp:534
 msgid ""
 "Do not change these setting unless you know\n"
 "what you are doing, otherwise you can easily\n"
@@ -5742,35 +5708,26 @@ msgstr ""
 "aMule toimii hyvin vaikka näitä ei\n"
 "säädettäisikään."
 
-#: src/PrefsUnifiedDlg.cpp:647
+#: src/PrefsUnifiedDlg.cpp:645
 #, c-format
 msgid "Failed to connect Cfg to widget with the ID %d and key %s"
 msgstr "Asetuksen kytkeminen widgettiin epäonnistui ID:llä %d ja avaimella %s"
 
-#: src/PrefsUnifiedDlg.cpp:695
+#: src/PrefsUnifiedDlg.cpp:693
 #, c-format
 msgid "Failed to transfer data from Cfg to Widget with the ID %d and key %s"
 msgstr "Datan siirtäminen asetuksesta widgettiin epäonnistui ID:llä %d ja avaimella %s"
 
-#: src/PrefsUnifiedDlg.cpp:801
+#: src/PrefsUnifiedDlg.cpp:799
 msgid "The type of proxy you are connecting to"
 msgstr "Yhdistettävän välityspalvelimen tyyppi"
 
-#: src/PrefsUnifiedDlg.cpp:1020
+#: src/PrefsUnifiedDlg.cpp:1003
 #, c-format
 msgid "Failed to transfer data from Widget to Cfg with the ID %d and key %s"
 msgstr "Datan siirtäminen widgetistä asetukseen epäonnistui ID:llä %d ja avaimella %s"
 
 #: src/PrefsUnifiedDlg.cpp:1103
-#, fuzzy
-msgid "No password set."
-msgstr "Tarkistaa salasanaa\n"
-
-#: src/PrefsUnifiedDlg.cpp:1132
-msgid "Guest access needs a password. Type one in the guest password field, or untick Enable guest access."
-msgstr ""
-
-#: src/PrefsUnifiedDlg.cpp:1144
 msgid ""
 "aMule must be restarted to enable these changes:\n"
 "\n"
@@ -5778,42 +5735,42 @@ msgstr ""
 "aMule on käynnistettävä uudelleen näiden muutosten voimaansaattamiseksi:\n"
 "\n"
 
-#: src/PrefsUnifiedDlg.cpp:1151
+#: src/PrefsUnifiedDlg.cpp:1110
 msgid "- TCP port changed.\n"
 msgstr "- TCP-portti muuttui.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1156
+#: src/PrefsUnifiedDlg.cpp:1115
 msgid "- UDP port changed.\n"
 msgstr "- UDP-portti muuttui.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1161
+#: src/PrefsUnifiedDlg.cpp:1120
 #, fuzzy
 msgid "- Network interface binding changed.\n"
 msgstr "- Etäyhteyden sovitin muuttui.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1166
+#: src/PrefsUnifiedDlg.cpp:1125
 msgid "- External connect port changed.\n"
 msgstr "- Etäyhteyden portti vaihtui.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1170
+#: src/PrefsUnifiedDlg.cpp:1129
 msgid "- External connect acceptance changed.\n"
 msgstr "- Etäyhteyden vastaanotto muuttui.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1174
+#: src/PrefsUnifiedDlg.cpp:1133
 msgid "- External connect interface changed.\n"
 msgstr "- Etäyhteyden sovitin muuttui.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1178
+#: src/PrefsUnifiedDlg.cpp:1137
 #, fuzzy
 msgid "- Protocol obfuscation support changed.\n"
 msgstr "Protokollan kätkeminen"
 
-#: src/PrefsUnifiedDlg.cpp:1193
+#: src/PrefsUnifiedDlg.cpp:1151
 #, fuzzy
 msgid "- amuleapi settings changed.\n"
 msgstr "- Kieli vaihtui.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1202
+#: src/PrefsUnifiedDlg.cpp:1160
 msgid ""
 "Your Auto-update server list is empty.\n"
 "'Auto-update server list at startup' will be disabled."
@@ -5821,7 +5778,7 @@ msgstr ""
 "Palvelinlistan automaattisen päivityksen lista on tyhjä.\n"
 "'Päivitä palvelinlista käynnistettäessä' kytketään pois päältä."
 
-#: src/PrefsUnifiedDlg.cpp:1213
+#: src/PrefsUnifiedDlg.cpp:1171
 msgid ""
 "You have enabled external connections but have not specified a password.\n"
 "External connections cannot be enabled unless a valid password is specified."
@@ -5829,33 +5786,28 @@ msgstr ""
 "Olet sallinut etäyhteydet mutta et ole antanut salasanaa.\n"
 "Etäyhteydet eivät ole mahdollisia ellei salasanaa ole annettu."
 
-#: src/PrefsUnifiedDlg.cpp:1246
-#, c-format
-msgid "The amuleapi password could not be saved: %s"
-msgstr ""
-
-#: src/PrefsUnifiedDlg.cpp:1276
+#: src/PrefsUnifiedDlg.cpp:1202
 msgid "- Language changed.\n"
 msgstr "- Kieli vaihtui.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1281
+#: src/PrefsUnifiedDlg.cpp:1207
 msgid "- Temp folder changed.\n"
 msgstr "- Väliaikaiskansio muuttui.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1286
+#: src/PrefsUnifiedDlg.cpp:1212
 msgid "- ED2K network enabled.\n"
 msgstr "- ED2K-verkko käytössä.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1319
+#: src/PrefsUnifiedDlg.cpp:1245
 msgid "The shared-file exclusion pattern is not a valid regular expression. The filter has been left disabled."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1321 src/PrefsUnifiedDlg.cpp:1921
+#: src/PrefsUnifiedDlg.cpp:1247 src/PrefsUnifiedDlg.cpp:1841
 #, fuzzy
 msgid "Invalid regular expression"
 msgstr "Väärä protokollaversio."
 
-#: src/PrefsUnifiedDlg.cpp:1398
+#: src/PrefsUnifiedDlg.cpp:1324
 msgid ""
 "Both eD2k and Kad network are disabled.\n"
 "You won't be able to connect until you enable at least one of them."
@@ -5863,7 +5815,7 @@ msgstr ""
 "Sekä eD2k- että Kad-verkko on pois päältä.\n"
 "Et voi yhdistää ennen kuin ainakin toinen niistä on sallittu."
 
-#: src/PrefsUnifiedDlg.cpp:1403
+#: src/PrefsUnifiedDlg.cpp:1329
 msgid ""
 "Kad will not start if your UDP port is disabled.\n"
 "Enable UDP port or disable Kad."
@@ -5871,7 +5823,7 @@ msgstr ""
 "Kad ei käynnisty mikäli UDP-portti on pois päältä.\n"
 "Salli UDP-portti tai kytke Kad pois päältä."
 
-#: src/PrefsUnifiedDlg.cpp:1459
+#: src/PrefsUnifiedDlg.cpp:1385
 msgid ""
 "\n"
 "You MUST restart aMule now.\n"
@@ -5881,69 +5833,69 @@ msgstr ""
 "Sinun on uudelleenkäynnistettävä aMule nyt.\n"
 "Mikäli et uudelleenkäynnistä nyt, älä valita mikäli jotain pahaa tapahtuu.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1524
+#: src/PrefsUnifiedDlg.cpp:1450
 msgid "Could not register aMule for autostart at login. The autostart store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1526
+#: src/PrefsUnifiedDlg.cpp:1452
 msgid "Could not remove the autostart-at-login entry."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1527
+#: src/PrefsUnifiedDlg.cpp:1453
 #, fuzzy
 msgid "Autostart"
 msgstr "Automaattinen Päivitys aloitettu"
 
-#: src/PrefsUnifiedDlg.cpp:1542
+#: src/PrefsUnifiedDlg.cpp:1468
 msgid "Register file type"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1542
+#: src/PrefsUnifiedDlg.cpp:1468
 msgid "Register URL handler"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1550
+#: src/PrefsUnifiedDlg.cpp:1476
 #, c-format
 msgid "aMule only handles eD2k-compatible magnets. If you replace the current magnet handler (%s), BitTorrent magnet links will stop working - aMule cannot download BitTorrent content. Continue?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1555
+#: src/PrefsUnifiedDlg.cpp:1481
 #, c-format
 msgid "Another application currently opens .emulecollection files (%s). Replace it with aMule?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1560
+#: src/PrefsUnifiedDlg.cpp:1486
 #, c-format
 msgid "Another application is currently the default handler for these links (%s). Replace it with aMule?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1585
+#: src/PrefsUnifiedDlg.cpp:1511
 msgid "Could not register aMule for .emulecollection files. The registration store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1587
+#: src/PrefsUnifiedDlg.cpp:1513
 #, fuzzy
 msgid "Could not remove the file type registration."
 msgstr "Kansio latauksen väliaikaisille tiedostoille"
 
-#: src/PrefsUnifiedDlg.cpp:1589
+#: src/PrefsUnifiedDlg.cpp:1515
 msgid "Could not register aMule as the URL handler. The registration store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1591
+#: src/PrefsUnifiedDlg.cpp:1517
 msgid "Could not remove the URL handler registration."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1661 src/PrefsUnifiedDlg.cpp:1688
+#: src/PrefsUnifiedDlg.cpp:1587 src/PrefsUnifiedDlg.cpp:1614
 #, fuzzy
 msgid "The web server and aMule API require external connections to be enabled."
 msgstr "Salasana asetettu ja etäyhteydet sallittu."
 
-#: src/PrefsUnifiedDlg.cpp:1671
+#: src/PrefsUnifiedDlg.cpp:1597
 msgid "The aMule web server is deprecated. Consider running the aMule API instead."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1735
+#: src/PrefsUnifiedDlg.cpp:1655
 msgid ""
 "Your Auto-update servers list is in blank.\n"
 "Please fill in at least one URL to point to a valid server.met file.\n"
@@ -5953,66 +5905,66 @@ msgstr ""
 "Ole hyvä ja syötä ainakin yksi URL joka osoittaa käypään server.met-tiedostoon.\n"
 "Klikkaa nappia \"Lista\" tämän valintaruudun vierestä syöttääksesi URLin."
 
-#: src/PrefsUnifiedDlg.cpp:1876
+#: src/PrefsUnifiedDlg.cpp:1796
 msgid "Temporary files"
 msgstr "Väliaikaiset tiedostot"
 
-#: src/PrefsUnifiedDlg.cpp:1881
+#: src/PrefsUnifiedDlg.cpp:1801
 msgid "Incoming files"
 msgstr "Saapuvat tiedostot"
 
-#: src/PrefsUnifiedDlg.cpp:1886
+#: src/PrefsUnifiedDlg.cpp:1806
 msgid "Online Signatures"
 msgstr "Online-Signeeraukset"
 
-#: src/PrefsUnifiedDlg.cpp:1899
+#: src/PrefsUnifiedDlg.cpp:1819
 #, c-format
 msgid "Choose a folder for %s"
 msgstr "Valitse kansio kohteelle %s"
 
-#: src/PrefsUnifiedDlg.cpp:1923
+#: src/PrefsUnifiedDlg.cpp:1843
 #, fuzzy, c-format
 msgid "Would exclude %u of %u shared file"
 msgid_plural "Would exclude %u of %u shared files"
 msgstr[0] "Löydetty %i tunnettu jaettu tiedosto"
 msgstr[1] "Löydetty %i tunnettua jaettua tiedostoa"
 
-#: src/PrefsUnifiedDlg.cpp:1940
+#: src/PrefsUnifiedDlg.cpp:1860
 msgid "Browse for videoplayer"
 msgstr "Etsi videosoitin"
 
-#: src/PrefsUnifiedDlg.cpp:1944
+#: src/PrefsUnifiedDlg.cpp:1864
 msgid "Select browser"
 msgstr "Valitse selain"
 
-#: src/PrefsUnifiedDlg.cpp:1948
+#: src/PrefsUnifiedDlg.cpp:1868
 #, fuzzy
 msgid "Select ffprobe binary"
 msgstr "Valitse selain"
 
-#: src/PrefsUnifiedDlg.cpp:1954
+#: src/PrefsUnifiedDlg.cpp:1874
 #, c-format
 msgid "Executable%s"
 msgstr "Suoritettava tiedosto%s"
 
-#: src/PrefsUnifiedDlg.cpp:1988
+#: src/PrefsUnifiedDlg.cpp:1908
 msgid "ffprobe not found on PATH or in the standard install locations. Install ffmpeg (which ships ffprobe) or use Browse to pick a binary manually."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2000
+#: src/PrefsUnifiedDlg.cpp:1920
 msgid "Reset the settings on this page to their default values?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2001
+#: src/PrefsUnifiedDlg.cpp:1921
 #, fuzzy
 msgid "Reset to defaults"
 msgstr "Järjestelmän vakio"
 
-#: src/PrefsUnifiedDlg.cpp:2028
+#: src/PrefsUnifiedDlg.cpp:1948
 msgid "Edit server list"
 msgstr "Muokkaa palvelinlistaa"
 
-#: src/PrefsUnifiedDlg.cpp:2029
+#: src/PrefsUnifiedDlg.cpp:1949
 msgid ""
 "Add here URL's to download server.met files.\n"
 "Only one url on each line."
@@ -6020,180 +5972,176 @@ msgstr ""
 "Syötä tähän URLit joista server.met-tiedostot haetaan.\n"
 "Vain yksi urli riville."
 
-#: src/PrefsUnifiedDlg.cpp:2084
+#: src/PrefsUnifiedDlg.cpp:2004
 msgid "IP2Country update failed"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2229 src/PrefsUnifiedDlg.cpp:2260
+#: src/PrefsUnifiedDlg.cpp:2149 src/PrefsUnifiedDlg.cpp:2180
 msgid "Data by MaxMind GeoLite2"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2231 src/PrefsUnifiedDlg.cpp:2262
+#: src/PrefsUnifiedDlg.cpp:2151 src/PrefsUnifiedDlg.cpp:2182
 #, fuzzy
 msgid "Custom source"
 msgstr "Täysiä lähteitä"
 
-#: src/PrefsUnifiedDlg.cpp:2233 src/PrefsUnifiedDlg.cpp:2264
+#: src/PrefsUnifiedDlg.cpp:2153 src/PrefsUnifiedDlg.cpp:2184
 msgid "Data by DB-IP.com"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2284
+#: src/PrefsUnifiedDlg.cpp:2204
 #, fuzzy, c-format
 msgid "Status: Loaded%s"
 msgstr "Tila:"
 
-#: src/PrefsUnifiedDlg.cpp:2286
+#: src/PrefsUnifiedDlg.cpp:2206
 #, fuzzy, c-format
 msgid "Status: Loaded%s - %s"
 msgstr "Tila:"
 
-#: src/PrefsUnifiedDlg.cpp:2290
+#: src/PrefsUnifiedDlg.cpp:2210
 msgid "Status: Failed to load - click 'Update now' to refresh."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2292
+#: src/PrefsUnifiedDlg.cpp:2212
 msgid "Status: Not found - click 'Update now' to download."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2350 src/PrefsUnifiedDlg.cpp:2374
+#: src/PrefsUnifiedDlg.cpp:2270 src/PrefsUnifiedDlg.cpp:2294
 #, c-format
 msgid "Update delay: %d second"
 msgid_plural "Update delay: %d seconds"
 msgstr[0] "Päivitysväli: %d sekunti"
 msgstr[1] "Päivitysväli: %d sekuntia"
 
-#: src/PrefsUnifiedDlg.cpp:2358
+#: src/PrefsUnifiedDlg.cpp:2278
 #, c-format
 msgid "Time for average graph: %d minute"
 msgid_plural "Time for average graph: %d minutes"
 msgstr[0] "Keskimääräiskuvaajan aika: %d minuutti"
 msgstr[1] "Keskimääräiskuvaajan aika: %d minuuttia"
 
-#: src/PrefsUnifiedDlg.cpp:2367
+#: src/PrefsUnifiedDlg.cpp:2287
 #, c-format
 msgid "Connections Graph Scale: %d"
 msgstr "Yhteyskuvaajan skaala: %d"
 
-#: src/PrefsUnifiedDlg.cpp:2382
+#: src/PrefsUnifiedDlg.cpp:2302
 #, c-format
 msgid "File Buffer Size: %d byte"
 msgid_plural "File Buffer Size: %d bytes"
 msgstr[0] "Tiedostopuskurin koko: %d tavu"
 msgstr[1] "Tiedostopuskurin koko: %d tavua"
 
-#: src/PrefsUnifiedDlg.cpp:2392
+#: src/PrefsUnifiedDlg.cpp:2312
 #, c-format
 msgid "Upload Queue Size: %d client"
 msgid_plural "Upload Queue Size: %d clients"
 msgstr[0] "Lähetysjonon koko: %d asiakas"
 msgstr[1] "Lähetysjonon koko: %d asiakasta"
 
-#: src/PrefsUnifiedDlg.cpp:2402
+#: src/PrefsUnifiedDlg.cpp:2322
 #, c-format
 msgid "Server connection refresh interval: %d minute"
 msgid_plural "Server connection refresh interval: %d minutes"
 msgstr[0] "Palvelinyhteyden päivitysväli: %d minuutti"
 msgstr[1] "Palvelinyhteyden päivitysväli: %d minuuttia"
 
-#: src/PrefsUnifiedDlg.cpp:2407
+#: src/PrefsUnifiedDlg.cpp:2327
 msgid "Server connection refresh interval: Disabled"
 msgstr "Palvelinyhteyden päivitysväli: Ei käytössä"
 
-#: src/PrefsUnifiedDlg.cpp:2451
+#: src/PrefsUnifiedDlg.cpp:2371
 msgid "disabled"
 msgstr "poissa käytöstä"
 
-#: src/PrefsUnifiedDlg.cpp:2477
+#: src/PrefsUnifiedDlg.cpp:2397
 #, c-format
 msgid "Execute command on '%s' event"
 msgstr "Suorita komento tapahtuman '%s' yhteydessä"
 
-#: src/PrefsUnifiedDlg.cpp:2484
+#: src/PrefsUnifiedDlg.cpp:2404
 msgid "Enable command execution on core"
 msgstr "Mahdollista komentojen suorittaminen ytimestä"
 
-#: src/PrefsUnifiedDlg.cpp:2496
+#: src/PrefsUnifiedDlg.cpp:2416
 msgid "Core command:"
 msgstr "Ytimen komento:"
 
-#: src/PrefsUnifiedDlg.cpp:2512
+#: src/PrefsUnifiedDlg.cpp:2432
 msgid "Enable command execution on GUI"
 msgstr "Mahdollista komentojen suorittaminen graafisesta käyttöliittymästä"
 
-#: src/PrefsUnifiedDlg.cpp:2524
+#: src/PrefsUnifiedDlg.cpp:2444
 msgid "GUI command:"
 msgstr "Graafisen käyttöliittymän komento:"
 
-#: src/PrefsUnifiedDlg.cpp:2540
+#: src/PrefsUnifiedDlg.cpp:2460
 msgid "The following variables will be replaced:"
 msgstr "Seuraavat muuttujat korvataan:"
 
-#: src/PrefsUnifiedDlg.cpp:2708
+#: src/PrefsUnifiedDlg.cpp:2628
 msgid ""
 "The following folders look like system or sensitive locations:\n"
 "\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2713
+#: src/PrefsUnifiedDlg.cpp:2633
 msgid "Sharing them recursively will publish every file underneath on the eD2k/Kad networks. Do you really want to do this?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2716
+#: src/PrefsUnifiedDlg.cpp:2636
 #, fuzzy
 msgid "Confirm shared folders"
 msgstr "Jaetut kansiot"
 
-#: src/PrefsUnifiedDlg.cpp:2744
+#: src/PrefsUnifiedDlg.cpp:2664
 #, fuzzy
 msgid "Reloading shared files..."
 msgstr "Uudelleenlataa jaetut tiedostot"
 
-#: src/PrefsUnifiedDlg.cpp:2745
+#: src/PrefsUnifiedDlg.cpp:2665
 msgid "Scanning for subdirectories..."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2746
+#: src/PrefsUnifiedDlg.cpp:2666
 #, fuzzy
 msgid "Updating shared folders"
 msgstr "Jaetut kansiot"
 
-#: src/PrefsUnifiedDlg.cpp:2773
+#: src/PrefsUnifiedDlg.cpp:2693
 #, c-format
 msgid "Scanned %u directories..."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2823
+#: src/PrefsUnifiedDlg.cpp:2743
 #, fuzzy, c-format
 msgid "Reloading shared files: %u files scanned"
 msgstr "Lataa uudelleen lista jaetuista tiedostoista."
 
-#: src/PrefsUnifiedDlg.cpp:2873
+#: src/PrefsUnifiedDlg.cpp:2793
 #, fuzzy
 msgid "Shared folder"
 msgstr "Jaetut kansiot"
 
-#: src/SearchDlg.cpp:280
-msgid "Clear search history"
-msgstr ""
-
-#: src/SearchDlg.cpp:584
+#: src/SearchDlg.cpp:425
 msgid "It's impossible to search when both eD2k and Kademlia are disabled."
 msgstr ""
 
-#: src/SearchDlg.cpp:585 src/SearchListCtrl.cpp:858
+#: src/SearchDlg.cpp:426 src/SearchListCtrl.cpp:858
 #, fuzzy
 msgid "Search error"
 msgstr "Haut"
 
-#: src/SearchDlg.cpp:929
+#: src/SearchDlg.cpp:768
 msgid "Min size must be smaller than max size. Max size ignored."
 msgstr "Vähimmäiskoon pitää olla pienempi kuin enimmäiskoon. Enimmäiskokoa ei huomioida."
 
-#: src/SearchDlg.cpp:930 src/SearchDlg.cpp:1012
+#: src/SearchDlg.cpp:769 src/SearchDlg.cpp:851
 msgid "Search warning"
 msgstr "Hakuvaroitus"
 
-#: src/SearchDlg.cpp:1092 src/SearchListCtrl.cpp:735
+#: src/SearchDlg.cpp:929 src/SearchListCtrl.cpp:735
 msgid "Main"
 msgstr "Kaikki"
 

--- a/po/fr.po
+++ b/po/fr.po
@@ -15,7 +15,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-28 08:06+0200\n"
+"POT-Creation-Date: 2026-07-28 10:19+0200\n"
 "PO-Revision-Date: 2026-07-27 11:38+0000\n"
 "Last-Translator: Dylan Aïssi <bob.dybian@gmail.com>\n"
 "Language-Team: Français\n"
@@ -149,7 +149,7 @@ msgstr "Installer"
 msgid "Not now"
 msgstr "Pas maintenant"
 
-#: src/AppImageIntegration.cpp:422 src/amuleDlg.cpp:600
+#: src/AppImageIntegration.cpp:422 src/amuleDlg.cpp:665
 msgid "Don't ask again"
 msgstr "Ne plus me demander"
 
@@ -226,7 +226,7 @@ msgid "Killing amuleweb instance with pid '%d' ... "
 msgstr "Mise à mort de l'instance amuleweb avec le pid '%d' … "
 
 #: src/amule.cpp:336 src/amule.cpp:349 src/ClientRef.cpp:180
-#: src/SearchDlg.cpp:880 src/ServerListCtrl.cpp:98
+#: src/SearchDlg.cpp:1041 src/ServerListCtrl.cpp:98
 msgid "Failed"
 msgstr "Échec"
 
@@ -580,29 +580,67 @@ msgstr "Impossible de créer le fichier Pid"
 msgid "ERROR: %s"
 msgstr "Erreur : %s"
 
-#: src/amuleDlg.cpp:236
+#: src/amuleDlg.cpp:250
 #, c-format
 msgid "This is aMule %s based on eMule."
 msgstr "Ceci est aMule %s basé sur eMule."
 
-#: src/amuleDlg.cpp:237
+#: src/amuleDlg.cpp:251
 #, c-format
 msgid "Running on %s"
 msgstr "Tourne sur %s"
 
-#: src/amuleDlg.cpp:239
+#: src/amuleDlg.cpp:253
 msgid "Visit https://github.com/amule-org/amule/releases/latest to check if a new version is available."
 msgstr "Visitez https://github.com/amule-org/amule/releases/latest pour vérifier si une nouvelle version est disponible."
 
-#: src/amuleDlg.cpp:268
+#: src/amuleDlg.cpp:282
 msgid "FATAL ERROR: Failed to create Timer"
 msgstr "ERREUR FATALE : Échec de la création du minuteur"
 
-#: src/amuleDlg.cpp:592
+#: src/amuleDlg.cpp:361 src/amuleDlg.cpp:1787 src/amuleDlg.cpp:2033
+#: src/muuli_wdr.cpp:1492 src/muuli_wdr.cpp:3418
+msgid "Networks"
+msgstr "Réseaux"
+
+#: src/amuleDlg.cpp:362 src/amuleDlg.cpp:1793 src/muuli_wdr.cpp:3419
+msgid "Searches"
+msgstr "Recherches"
+
+#: src/amuleDlg.cpp:363 src/amuleDlg.cpp:1799 src/DownloadListCtrl.cpp:740
+#: src/muuli_wdr.cpp:392 src/muuli_wdr.cpp:1585 src/muuli_wdr.cpp:3420
+#: src/Statistics.cpp:829
+msgid "Downloads"
+msgstr "Téléchargements"
+
+#: src/amuleDlg.cpp:364 src/amuleDlg.cpp:1805 src/muuli_wdr.cpp:3294
+msgid "Shared files"
+msgstr "Fichiers partagés"
+
+#: src/amuleDlg.cpp:365 src/amuleDlg.cpp:1811 src/muuli_wdr.cpp:2926
+#: src/muuli_wdr.cpp:3376 src/muuli_wdr.cpp:3423
+msgid "Messages"
+msgstr "Messages"
+
+#: src/amuleDlg.cpp:366 src/amuleDlg.cpp:1817 src/muuli_wdr.cpp:3424
+#: src/PrefsUnifiedDlg.cpp:312 src/Statistics.cpp:779 src/Statistics.cpp:1235
+msgid "Statistics"
+msgstr "Statistiques"
+
+#: src/amuleDlg.cpp:368 src/amuleDlg.cpp:1824 src/muuli_wdr.cpp:3426
+#: src/PrefsUnifiedDlg.cpp:328 src/utils/wxCas/src/wxcasprefs.cpp:39
+msgid "Preferences"
+msgstr "Préférences"
+
+#: src/amuleDlg.cpp:371
+msgid "Navigate"
+msgstr ""
+
+#: src/amuleDlg.cpp:657
 msgid "New version available"
 msgstr "Une nouvelle version est disponible"
 
-#: src/amuleDlg.cpp:596
+#: src/amuleDlg.cpp:661
 #, c-format
 msgid ""
 "A new version of aMule (%s) is available.\n"
@@ -617,217 +655,184 @@ msgstr ""
 "\n"
 "Souhaiteriez-vous ouvrir la page de téléchargement ?"
 
-#: src/amuleDlg.cpp:678
+#: src/amuleDlg.cpp:743
 msgid "aMule dialog destroyed"
 msgstr "boîte de dialogue aMule détruite"
 
-#: src/amuleDlg.cpp:701 src/DataToText.cpp:68 src/IPFilter.cpp:547
+#: src/amuleDlg.cpp:766 src/DataToText.cpp:68 src/IPFilter.cpp:547
 msgid "Connecting"
 msgstr "Connexion en cours"
 
-#: src/amuleDlg.cpp:893
+#: src/amuleDlg.cpp:958
 msgid "eD2k: Connecting"
 msgstr "eD2k : Connexion en cours"
 
-#: src/amuleDlg.cpp:897
+#: src/amuleDlg.cpp:962
 msgid "eD2k: Disconnected"
 msgstr "eD2k : Déconnecté"
 
-#: src/amuleDlg.cpp:903
+#: src/amuleDlg.cpp:968
 msgid "Kad: Firewalled"
 msgstr "Kad : Derrière un pare-feu"
 
-#: src/amuleDlg.cpp:907
+#: src/amuleDlg.cpp:972
 msgid "Kad: Connected"
 msgstr "Kad : Connecté"
 
-#: src/amuleDlg.cpp:912
+#: src/amuleDlg.cpp:977
 msgid "Kad: Connecting"
 msgstr "Kad : Connexion en cours"
 
-#: src/amuleDlg.cpp:916
+#: src/amuleDlg.cpp:981
 msgid "Kad: Off"
 msgstr "Kad : Coupé"
 
-#: src/amuleDlg.cpp:964 src/DownloadListCtrl.cpp:505
+#: src/amuleDlg.cpp:1029 src/DownloadListCtrl.cpp:505
 #: src/DownloadListCtrl.cpp:749 src/FriendListCtrl.cpp:180
 #: src/muuli_wdr.cpp:731 src/muuli_wdr.cpp:782 src/muuli_wdr.cpp:846
-#: src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2224 src/muuli_wdr.cpp:2309
-#: src/muuli_wdr.cpp:3057 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
+#: src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2231 src/muuli_wdr.cpp:2316
+#: src/muuli_wdr.cpp:3064 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
 #: src/ServerListCtrl.cpp:606 src/TransferWnd.cpp:378
 #: src/utils/wxCas/src/wxcasprefs.cpp:235
 msgid "Cancel"
 msgstr "Annuler"
 
-#: src/amuleDlg.cpp:965
+#: src/amuleDlg.cpp:1030
 msgid "Stop the current connection attempts"
 msgstr "Stopper les essais de connexions en cours"
 
-#: src/amuleDlg.cpp:970 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976
-#: src/muuli_wdr.cpp:2447
+#: src/amuleDlg.cpp:1035 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976
+#: src/muuli_wdr.cpp:2454
 msgid "Disconnect"
 msgstr "Déconnecter"
 
-#: src/amuleDlg.cpp:971
+#: src/amuleDlg.cpp:1036
 msgid "Disconnect from the currently connected networks"
 msgstr "Se déconnecter des réseaux actuellement connectés"
 
-#: src/amuleDlg.cpp:976 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979
-#: src/muuli_wdr.cpp:2602 src/muuli_wdr.cpp:3054 src/muuli_wdr.cpp:3409
+#: src/amuleDlg.cpp:1041 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979
+#: src/muuli_wdr.cpp:2609 src/muuli_wdr.cpp:3061 src/muuli_wdr.cpp:3416
 msgid "Connect"
 msgstr "Se connecter"
 
-#: src/amuleDlg.cpp:977
+#: src/amuleDlg.cpp:1042
 msgid "Connect to the currently enabled networks"
 msgstr "Se connecter aux réseaux actuellement activés"
 
-#: src/amuleDlg.cpp:1089
+#: src/amuleDlg.cpp:1154
 #, c-format
 msgid "Up: %.1f%s (%.1f) | Down: %.1f%s (%.1f)"
 msgstr "E : %.1f%s (%.1f) | R : %.1f%s (%.1f)"
 
-#: src/amuleDlg.cpp:1091 src/amuleDlg.cpp:1093 src/amuleDlg.cpp:1097
-#: src/amuleDlg.cpp:1099 src/amuleDlg.cpp:1110 src/amuleDlg.cpp:1112
+#: src/amuleDlg.cpp:1156 src/amuleDlg.cpp:1158 src/amuleDlg.cpp:1162
+#: src/amuleDlg.cpp:1164 src/amuleDlg.cpp:1175 src/amuleDlg.cpp:1177
 #: src/MuleTrayIcon.cpp:796 src/MuleTrayIcon.cpp:799
 msgid " MB/s"
 msgstr " Mo/s"
 
-#: src/amuleDlg.cpp:1091 src/amuleDlg.cpp:1093 src/amuleDlg.cpp:1097
-#: src/amuleDlg.cpp:1099 src/amuleDlg.cpp:1110 src/amuleDlg.cpp:1112
+#: src/amuleDlg.cpp:1156 src/amuleDlg.cpp:1158 src/amuleDlg.cpp:1162
+#: src/amuleDlg.cpp:1164 src/amuleDlg.cpp:1175 src/amuleDlg.cpp:1177
 #: src/MuleTrayIcon.cpp:796 src/MuleTrayIcon.cpp:799
 #: src/utils/wxCas/src/wxcasframe.cpp:1041
 msgid " kB/s"
 msgstr " Ko/s"
 
-#: src/amuleDlg.cpp:1096
+#: src/amuleDlg.cpp:1161
 #, c-format
 msgid "Up: %.1f%s | Down: %.1f%s"
 msgstr "E : %.1f%s | R : %.1f%s"
 
-#: src/amuleDlg.cpp:1128
+#: src/amuleDlg.cpp:1193
 #, c-format
 msgid "aMule (%s | Connected)"
 msgstr "aMule (%s | Connecté)"
 
-#: src/amuleDlg.cpp:1130
+#: src/amuleDlg.cpp:1195
 #, c-format
 msgid "aMule (%s | Disconnected)"
 msgstr "aMule (%s | Déconnecté)"
 
-#: src/amuleDlg.cpp:1183
+#: src/amuleDlg.cpp:1248
 #, c-format
 msgid "Do you really want to exit %s?"
 msgstr "Voulez-vous vraiment quitter %s ?"
 
-#: src/amuleDlg.cpp:1185
+#: src/amuleDlg.cpp:1250
 msgid "Exit confirmation"
 msgstr "Confirmation de sortie"
 
-#: src/amuleDlg.cpp:1548
+#: src/amuleDlg.cpp:1613
 msgid "Launch Command: "
 msgstr "Commande de lancement : "
 
-#: src/amuleDlg.cpp:1567 src/muuli_wdr.cpp:1971 src/Preferences.cpp:951
+#: src/amuleDlg.cpp:1632 src/muuli_wdr.cpp:1978 src/Preferences.cpp:952
 msgid "- default -"
 msgstr "- défaut -"
 
-#: src/amuleDlg.cpp:1595
+#: src/amuleDlg.cpp:1660
 #, c-format
 msgid "Skin directory '%s' does not exist"
 msgstr "Le répertoire de thèmes '%s' n'existe pas"
 
-#: src/amuleDlg.cpp:1598
+#: src/amuleDlg.cpp:1663
 #, c-format
 msgid "WARNING: Unable to open skin file '%s' for read"
 msgstr "AVERTISSEMENT : Impossible d'ouvrir le fichier thème '%s' pour la lecture"
 
-#: src/amuleDlg.cpp:1722 src/amuleDlg.cpp:1968 src/muuli_wdr.cpp:1485
-#: src/muuli_wdr.cpp:3411
-msgid "Networks"
-msgstr "Réseaux"
-
-#: src/amuleDlg.cpp:1726 src/muuli_wdr.cpp:3411
+#: src/amuleDlg.cpp:1791 src/muuli_wdr.cpp:3418
 msgid "Networks Window"
 msgstr "Fenêtre des réseaux"
 
-#: src/amuleDlg.cpp:1728 src/muuli_wdr.cpp:3412
-msgid "Searches"
-msgstr "Recherches"
-
-#: src/amuleDlg.cpp:1732 src/muuli_wdr.cpp:3412
+#: src/amuleDlg.cpp:1797 src/muuli_wdr.cpp:3419
 msgid "Searches Window"
 msgstr "Fenêtre de Recherche"
 
-#: src/amuleDlg.cpp:1734 src/DownloadListCtrl.cpp:740 src/muuli_wdr.cpp:392
-#: src/muuli_wdr.cpp:1578 src/muuli_wdr.cpp:3413 src/Statistics.cpp:829
-msgid "Downloads"
-msgstr "Téléchargements"
-
-#: src/amuleDlg.cpp:1738 src/muuli_wdr.cpp:3413
+#: src/amuleDlg.cpp:1803 src/muuli_wdr.cpp:3420
 msgid "Downloads Window"
 msgstr "Fenêtre des Téléchargements"
 
-#: src/amuleDlg.cpp:1740 src/muuli_wdr.cpp:3287
-msgid "Shared files"
-msgstr "Fichiers partagés"
-
-#: src/amuleDlg.cpp:1744 src/muuli_wdr.cpp:3415
+#: src/amuleDlg.cpp:1809 src/muuli_wdr.cpp:3422
 msgid "Shared Files Window"
 msgstr "Fenêtre des Fichiers Partagés"
 
-#: src/amuleDlg.cpp:1746 src/muuli_wdr.cpp:2919 src/muuli_wdr.cpp:3369
-#: src/muuli_wdr.cpp:3416
-msgid "Messages"
-msgstr "Messages"
-
-#: src/amuleDlg.cpp:1750 src/muuli_wdr.cpp:3416
+#: src/amuleDlg.cpp:1815 src/muuli_wdr.cpp:3423
 msgid "Messages Window"
 msgstr "Fenêtre des Messages"
 
-#: src/amuleDlg.cpp:1752 src/muuli_wdr.cpp:3417 src/PrefsUnifiedDlg.cpp:312
-#: src/Statistics.cpp:779 src/Statistics.cpp:1235
-msgid "Statistics"
-msgstr "Statistiques"
-
-#: src/amuleDlg.cpp:1756 src/muuli_wdr.cpp:3417
+#: src/amuleDlg.cpp:1821 src/muuli_wdr.cpp:3424
 msgid "Statistics Graph Window"
 msgstr "Fenêtre des Statistiques"
 
-#: src/amuleDlg.cpp:1759 src/muuli_wdr.cpp:3419 src/PrefsUnifiedDlg.cpp:328
-#: src/utils/wxCas/src/wxcasprefs.cpp:39
-msgid "Preferences"
-msgstr "Préférences"
-
-#: src/amuleDlg.cpp:1763 src/muuli_wdr.cpp:3419
+#: src/amuleDlg.cpp:1828 src/muuli_wdr.cpp:3426
 msgid "Preferences Settings Window"
 msgstr "Fenêtre des Préférences"
 
-#: src/amuleDlg.cpp:1766 src/muuli_wdr.cpp:3420
+#: src/amuleDlg.cpp:1831 src/muuli_wdr.cpp:3427
 msgid "Import"
 msgstr "Importer"
 
-#: src/amuleDlg.cpp:1770 src/muuli_wdr.cpp:3420
+#: src/amuleDlg.cpp:1835 src/muuli_wdr.cpp:3427
 msgid "The partfile importer tool"
 msgstr "L'outil d'importation de fichier .part"
 
-#: src/amuleDlg.cpp:1773 src/muuli_wdr.cpp:3421
+#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3428
 #: src/utils/aLinkCreator/src/alcframe.cpp:262
 msgid "About"
 msgstr "À propos"
 
-#: src/amuleDlg.cpp:1773 src/muuli_wdr.cpp:3421
+#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3428
 msgid "About/Help"
 msgstr "À propos/Aide"
 
-#: src/amuleDlg.cpp:1971
+#: src/amuleDlg.cpp:2036
 msgid "eD2k network"
 msgstr "Réseau eD2k"
 
-#: src/amuleDlg.cpp:1974
+#: src/amuleDlg.cpp:2039
 msgid "Kad network"
 msgstr "Réseau Kad"
 
-#: src/amuleDlg.cpp:1974
+#: src/amuleDlg.cpp:2039
 msgid "No network"
 msgstr "Pas de réseau"
 
@@ -1360,19 +1365,19 @@ msgstr "Auto [Haute]"
 msgid "Very low"
 msgstr "Très basse"
 
-#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:743 src/muuli_wdr.cpp:2275
+#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:743 src/muuli_wdr.cpp:2282
 #: src/ServerListCtrl.cpp:263 src/ServerListCtrl.cpp:456
 #: src/SharedFilesCtrl.cpp:145
 msgid "Low"
 msgstr "Basse"
 
-#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:744 src/muuli_wdr.cpp:2276
+#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:744 src/muuli_wdr.cpp:2283
 #: src/ServerListCtrl.cpp:266 src/ServerListCtrl.cpp:457
 #: src/SharedFilesCtrl.cpp:146
 msgid "Normal"
 msgstr "Normale"
 
-#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:745 src/muuli_wdr.cpp:2277
+#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:745 src/muuli_wdr.cpp:2284
 #: src/ServerListCtrl.cpp:269 src/ServerListCtrl.cpp:458
 #: src/SharedFilesCtrl.cpp:147
 msgid "High"
@@ -1464,8 +1469,8 @@ msgstr "Serveur Local"
 msgid "Remote Server"
 msgstr "Serveur Distant"
 
-#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3174
-#: src/SearchDlg.cpp:111 src/TextClient.cpp:911
+#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3181
+#: src/SearchDlg.cpp:119 src/TextClient.cpp:911
 msgid "Kad"
 msgstr "Kad"
 
@@ -1535,7 +1540,7 @@ msgstr "Partie"
 msgid "Size"
 msgstr "Taille"
 
-#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3241
+#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3248
 msgid "Transferred"
 msgstr "Reçu"
 
@@ -1593,7 +1598,7 @@ msgstr ""
 "Retour de : %s (%s)\n"
 "\n"
 
-#: src/DownloadListCtrl.cpp:746 src/muuli_wdr.cpp:2278
+#: src/DownloadListCtrl.cpp:746 src/muuli_wdr.cpp:2285
 #: src/SharedFilesCtrl.cpp:150
 msgid "Auto"
 msgstr "Auto"
@@ -1631,7 +1636,7 @@ msgid "Extended Options"
 msgstr "Options avancées"
 
 #: src/DownloadListCtrl.cpp:770 src/DownloadListCtrl.cpp:822
-#: src/muuli_wdr.cpp:1789
+#: src/muuli_wdr.cpp:1796
 msgid "Preview"
 msgstr "Prévisualisation"
 
@@ -2340,19 +2345,19 @@ msgstr ""
 msgid "eD2k"
 msgstr "eD2k"
 
-#: src/FirstRunWizard.cpp:349 src/muuli_wdr.cpp:1488
+#: src/FirstRunWizard.cpp:349 src/muuli_wdr.cpp:1495
 msgid "Kademlia"
 msgstr "Kademlia"
 
-#: src/FirstRunWizard.cpp:359 src/muuli_wdr.cpp:1416
+#: src/FirstRunWizard.cpp:359 src/muuli_wdr.cpp:1423
 msgid "Standard TCP Port "
 msgstr "Port TCP standard "
 
-#: src/FirstRunWizard.cpp:365 src/muuli_wdr.cpp:1428
+#: src/FirstRunWizard.cpp:365 src/muuli_wdr.cpp:1435
 msgid "Extended UDP port (Kad / global search) "
 msgstr "Port UDP étendu (recherche Kad / globale) "
 
-#: src/FirstRunWizard.cpp:377 src/muuli_wdr.cpp:1435
+#: src/FirstRunWizard.cpp:377 src/muuli_wdr.cpp:1442
 msgid "Enable UPnP for router port forwarding"
 msgstr "Activer UPnP pour la redirection de port du routeur"
 
@@ -2379,7 +2384,7 @@ msgstr ""
 msgid "Your peer lists are already in place - nothing to download."
 msgstr "Vous êtes déjà en train de télécharger le fichier %s"
 
-#: src/FirstRunWizard.cpp:434 src/muuli_wdr.cpp:1533
+#: src/FirstRunWizard.cpp:434 src/muuli_wdr.cpp:1540
 msgid "Auto-update server list at startup"
 msgstr "Mise à jour automatique de la liste des serveurs au démarrage"
 
@@ -2425,23 +2430,23 @@ msgid ""
 "want downloads on a different (e.g. larger) disk."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:549 src/FirstRunWizard.cpp:611 src/muuli_wdr.cpp:1701
+#: src/FirstRunWizard.cpp:549 src/FirstRunWizard.cpp:611 src/muuli_wdr.cpp:1708
 msgid "Destination folder for downloads"
 msgstr "Dossier de destination des téléchargements"
 
-#: src/FirstRunWizard.cpp:553 src/FirstRunWizard.cpp:569 src/muuli_wdr.cpp:1342
-#: src/muuli_wdr.cpp:1359 src/muuli_wdr.cpp:1676 src/muuli_wdr.cpp:1707
-#: src/muuli_wdr.cpp:1719 src/muuli_wdr.cpp:2762
+#: src/FirstRunWizard.cpp:553 src/FirstRunWizard.cpp:569 src/muuli_wdr.cpp:1349
+#: src/muuli_wdr.cpp:1366 src/muuli_wdr.cpp:1683 src/muuli_wdr.cpp:1714
+#: src/muuli_wdr.cpp:1726 src/muuli_wdr.cpp:2769
 #: src/utils/aLinkCreator/src/alcframe.cpp:135
 #: src/utils/wxCas/src/wxcasprefs.cpp:52 src/utils/wxCas/src/wxcasprefs.cpp:118
 msgid "Browse"
 msgstr "Parcourir"
 
-#: src/FirstRunWizard.cpp:559 src/muuli_wdr.cpp:1712
+#: src/FirstRunWizard.cpp:559 src/muuli_wdr.cpp:1719
 msgid "(All files in this folder are shared with other peers)"
 msgstr "(Tous les fichiers de ce répertoire sont partagés avec les autres pairs)"
 
-#: src/FirstRunWizard.cpp:565 src/FirstRunWizard.cpp:624 src/muuli_wdr.cpp:1714
+#: src/FirstRunWizard.cpp:565 src/FirstRunWizard.cpp:624 src/muuli_wdr.cpp:1721
 msgid "Folder for temporary download files"
 msgstr "Dossier des fichiers de téléchargements temporaires"
 
@@ -2472,7 +2477,7 @@ msgstr "Échec de l'ouverture du fichier de la liste d'amis 'emfriends.met' pour
 msgid "CRITICAL - no client on StartChatSession"
 msgstr "CRITIQUE - Pas de client dans StartChatSession"
 
-#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2668 src/muuli_wdr.cpp:3345
+#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2675 src/muuli_wdr.cpp:3352
 msgid "Friends"
 msgstr "Amis"
 
@@ -2856,7 +2861,7 @@ msgstr "Ratio de partage"
 msgid "Uploaded"
 msgstr "Émis"
 
-#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3225
+#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3232
 msgid "Requested"
 msgstr "Demandé"
 
@@ -2979,7 +2984,7 @@ msgid "WARNING: "
 msgstr "AVERTISSEMENT : "
 
 #: src/MuleNotebook.cpp:179 src/muuli_wdr.cpp:817 src/muuli_wdr.cpp:1229
-#: src/muuli_wdr.cpp:3129 src/muuli_wdr.cpp:3385
+#: src/muuli_wdr.cpp:3136 src/muuli_wdr.cpp:3392
 msgid "Close"
 msgstr "Fermer"
 
@@ -2992,12 +2997,12 @@ msgstr "Couper"
 msgid "Copy"
 msgstr "Copier"
 
-#: src/MuleTextCtrl.cpp:88
+#: src/MuleTextCtrl.cpp:88 src/SearchDlg.cpp:261
 msgid "Paste"
 msgstr "Coller"
 
 #: src/MuleTextCtrl.cpp:89 src/muuli_wdr.cpp:358 src/muuli_wdr.cpp:757
-#: src/muuli_wdr.cpp:2352 src/muuli_wdr.cpp:2371 src/muuli_wdr.cpp:2393
+#: src/muuli_wdr.cpp:2359 src/muuli_wdr.cpp:2378 src/muuli_wdr.cpp:2400
 #: src/utils/aLinkCreator/src/alcframe.cpp:142
 msgid "Clear"
 msgstr "Effacer"
@@ -3088,8 +3093,8 @@ msgid "Exit"
 msgstr "Quitter"
 
 #: src/MuleTrayIcon.cpp:579 src/MuleTrayIcon.cpp:945 src/MuleTrayIcon.cpp:965
-#: src/muuli_wdr.cpp:1391 src/muuli_wdr.cpp:1399 src/muuli_wdr.cpp:1406
-#: src/muuli_wdr.cpp:1835 src/muuli_wdr.cpp:1841 src/OtherFunctions.cpp:91
+#: src/muuli_wdr.cpp:1398 src/muuli_wdr.cpp:1406 src/muuli_wdr.cpp:1413
+#: src/muuli_wdr.cpp:1842 src/muuli_wdr.cpp:1848 src/OtherFunctions.cpp:91
 #: src/StatisticsDlg.cpp:93 src/StatisticsDlg.cpp:95
 msgid "kB/s"
 msgstr "Ko/s"
@@ -3258,7 +3263,7 @@ msgstr "Nom :"
 msgid "Type"
 msgstr "Type"
 
-#: src/muuli_wdr.cpp:215 src/SearchDlg.cpp:110 src/SearchListCtrl.cpp:853
+#: src/muuli_wdr.cpp:215 src/SearchDlg.cpp:118 src/SearchListCtrl.cpp:853
 msgid "Local"
 msgstr "Local"
 
@@ -3329,7 +3334,7 @@ msgstr "Octets"
 msgid "KB"
 msgstr "Ko"
 
-#: src/muuli_wdr.cpp:274 src/muuli_wdr.cpp:293 src/muuli_wdr.cpp:1620
+#: src/muuli_wdr.cpp:274 src/muuli_wdr.cpp:293 src/muuli_wdr.cpp:1627
 #: src/OtherFunctions.cpp:64
 msgid "MB"
 msgstr "Mo"
@@ -3346,7 +3351,7 @@ msgstr "Taille Maximum"
 msgid "Availability"
 msgstr "Disponibilité"
 
-#: src/muuli_wdr.cpp:312 src/muuli_wdr.cpp:398 src/muuli_wdr.cpp:3290
+#: src/muuli_wdr.cpp:312 src/muuli_wdr.cpp:398 src/muuli_wdr.cpp:3297
 msgid "Filter:"
 msgstr "Filtre :"
 
@@ -3378,7 +3383,7 @@ msgstr "Demande aux pairs Kad ayant déjà répondu d'élargir la recherche. Cha
 msgid "Stop"
 msgstr "Arrêter"
 
-#: src/muuli_wdr.cpp:348 src/muuli_wdr.cpp:1385 src/SearchListCtrl.cpp:732
+#: src/muuli_wdr.cpp:348 src/muuli_wdr.cpp:1392 src/SearchListCtrl.cpp:732
 msgid "Download"
 msgstr "Réception"
 
@@ -3409,8 +3414,8 @@ msgstr "Sources du fichier :"
 #: src/muuli_wdr.cpp:1160 src/muuli_wdr.cpp:1167 src/muuli_wdr.cpp:1172
 #: src/muuli_wdr.cpp:1179 src/muuli_wdr.cpp:1184 src/muuli_wdr.cpp:1191
 #: src/muuli_wdr.cpp:1205 src/muuli_wdr.cpp:1212 src/muuli_wdr.cpp:1217
-#: src/muuli_wdr.cpp:1224 src/muuli_wdr.cpp:3227 src/muuli_wdr.cpp:3235
-#: src/muuli_wdr.cpp:3243
+#: src/muuli_wdr.cpp:1224 src/muuli_wdr.cpp:3234 src/muuli_wdr.cpp:3242
+#: src/muuli_wdr.cpp:3250
 msgid "N/A"
 msgstr "N/A"
 
@@ -3550,7 +3555,7 @@ msgstr "Artiste :"
 msgid "Album :"
 msgstr "Album :"
 
-#: src/muuli_wdr.cpp:685 src/muuli_wdr.cpp:2247
+#: src/muuli_wdr.cpp:685 src/muuli_wdr.cpp:2254
 msgid "Title :"
 msgstr "Titre :"
 
@@ -3658,7 +3663,7 @@ msgstr "Nom d'utilisateur :"
 msgid "Userhash :"
 msgstr "Hachage de l'utilisateur :"
 
-#: src/muuli_wdr.cpp:895 src/muuli_wdr.cpp:1741 src/muuli_wdr.cpp:2442
+#: src/muuli_wdr.cpp:895 src/muuli_wdr.cpp:1748 src/muuli_wdr.cpp:2449
 #: src/utils/aLinkCreator/src/alcframe.cpp:137
 msgid "Add"
 msgstr "Ajouter"
@@ -3667,15 +3672,15 @@ msgstr "Ajouter"
 msgid "Download-Speed"
 msgstr "Vitesse de réception"
 
-#: src/muuli_wdr.cpp:954 src/muuli_wdr.cpp:989 src/muuli_wdr.cpp:2546
+#: src/muuli_wdr.cpp:954 src/muuli_wdr.cpp:989 src/muuli_wdr.cpp:2553
 msgid "Current"
 msgstr "Actuelle"
 
-#: src/muuli_wdr.cpp:962 src/muuli_wdr.cpp:997 src/muuli_wdr.cpp:2554
+#: src/muuli_wdr.cpp:962 src/muuli_wdr.cpp:997 src/muuli_wdr.cpp:2561
 msgid "Running average"
 msgstr "Moyenne totale"
 
-#: src/muuli_wdr.cpp:970 src/muuli_wdr.cpp:1005 src/muuli_wdr.cpp:2562
+#: src/muuli_wdr.cpp:970 src/muuli_wdr.cpp:1005 src/muuli_wdr.cpp:2569
 msgid "Session average"
 msgstr "Moyenne de la session"
 
@@ -3687,7 +3692,7 @@ msgstr "Vitesse d'émission"
 msgid "Connections"
 msgstr "Connexions"
 
-#: src/muuli_wdr.cpp:1024 src/muuli_wdr.cpp:1860
+#: src/muuli_wdr.cpp:1024 src/muuli_wdr.cpp:1867
 msgid "Active downloads"
 msgstr "Téléchargements actifs"
 
@@ -3695,7 +3700,7 @@ msgstr "Téléchargements actifs"
 msgid "Active connections (1:1)"
 msgstr "Connexions actives (1:1)"
 
-#: src/muuli_wdr.cpp:1040 src/muuli_wdr.cpp:1861
+#: src/muuli_wdr.cpp:1040 src/muuli_wdr.cpp:1868
 msgid "Active uploads"
 msgstr "Envois actifs"
 
@@ -3811,8 +3816,8 @@ msgstr "Ceci est le nom que verront les autres utilisateurs lorsqu'ils se connec
 msgid "Language: "
 msgstr "Langue : "
 
-#: src/muuli_wdr.cpp:1257 src/muuli_wdr.cpp:1323 src/muuli_wdr.cpp:1327
-#: src/muuli_wdr.cpp:1330
+#: src/muuli_wdr.cpp:1257 src/muuli_wdr.cpp:1330 src/muuli_wdr.cpp:1334
+#: src/muuli_wdr.cpp:1337
 msgid "The delay before showing tool-tips."
 msgstr "Délai avant l'apparition des infobulles."
 
@@ -3888,259 +3893,268 @@ msgstr "Afficher des notifications lorsque le téléchargement est terminé"
 msgid "Enabling this will make aMule to show notifications when finished downloading."
 msgstr "Si vous activez cette option, aMule affichera des notifications une fois le téléchargement terminé."
 
-#: src/muuli_wdr.cpp:1322
+#: src/muuli_wdr.cpp:1323
+#, fuzzy
+msgid "Remember search history"
+msgstr "Se rappeler de ces réglages"
+
+#: src/muuli_wdr.cpp:1324
+msgid "Keeps a dropdown list of your past search terms in the Search tab's Name field. This remembers the queries you typed, not the results they returned."
+msgstr ""
+
+#: src/muuli_wdr.cpp:1329
 msgid "Tooltip delay time: "
 msgstr "Délai d'affichage des info-bulles : "
 
-#: src/muuli_wdr.cpp:1329
+#: src/muuli_wdr.cpp:1336
 msgid "seconds"
 msgstr "secondes"
 
-#: src/muuli_wdr.cpp:1333
+#: src/muuli_wdr.cpp:1340
 msgid "Browser Selection"
 msgstr "Sélection du navigateur"
 
-#: src/muuli_wdr.cpp:1339
+#: src/muuli_wdr.cpp:1346
 msgid "Enter your browser name here. Leave this field empty to use the system default browser."
 msgstr "Indiquez le nom de votre navigateur ici. Laissez ce champ vide pour utiliser le navigateur par défaut du système."
 
-#: src/muuli_wdr.cpp:1346
+#: src/muuli_wdr.cpp:1353
 msgid "Open in new tab if possible"
 msgstr "Ouvrir si possible dans un nouvel onglet"
 
-#: src/muuli_wdr.cpp:1348
+#: src/muuli_wdr.cpp:1355
 msgid "Open the web page in a new tab instead of in a new window when possible"
 msgstr "Ouvrir, lorsque c'est possible, la page Web dans un nouvel onglet plutôt que dans une nouvelle page"
 
-#: src/muuli_wdr.cpp:1352
+#: src/muuli_wdr.cpp:1359
 msgid "Video Player"
 msgstr "Lecteur vidéo"
 
-#: src/muuli_wdr.cpp:1379
+#: src/muuli_wdr.cpp:1386
 msgid "Bandwidth limits"
 msgstr "Limites de la bande passante"
 
-#: src/muuli_wdr.cpp:1393
+#: src/muuli_wdr.cpp:1400
 msgid "Upload"
 msgstr "Émission"
 
-#: src/muuli_wdr.cpp:1401
+#: src/muuli_wdr.cpp:1408
 msgid "Slot Allocation"
 msgstr "Attribution de slot"
 
-#: src/muuli_wdr.cpp:1410
+#: src/muuli_wdr.cpp:1417
 msgid "Ports"
 msgstr "Ports"
 
-#: src/muuli_wdr.cpp:1420
+#: src/muuli_wdr.cpp:1427
 msgid "This is the standard eD2k port and cannot be disabled."
 msgstr "Ceci est le port eD2k standard et ne peut pas être activé."
 
-#: src/muuli_wdr.cpp:1423
+#: src/muuli_wdr.cpp:1430
 msgid "UDP port for server requests (TCP+3):"
 msgstr "Port UDP pour les requêtes des serveurs (TCP+3) :"
 
-#: src/muuli_wdr.cpp:1425
+#: src/muuli_wdr.cpp:1432
 msgid "4665"
 msgstr "4665"
 
-#: src/muuli_wdr.cpp:1432
+#: src/muuli_wdr.cpp:1439
 msgid "This UDP port is used for extended eD2k requests and Kad network"
 msgstr "Ce port UDP est utilisé pour les requêtes eD2k étendues et pour le réseau Kad"
 
-#: src/muuli_wdr.cpp:1439
+#: src/muuli_wdr.cpp:1446
 msgid "UPnP TCP Port (Optional):"
 msgstr "Port TCP UPnP (Facultatif) :"
 
-#: src/muuli_wdr.cpp:1449
+#: src/muuli_wdr.cpp:1456
 msgid "Bind local address to IP (empty for any):"
 msgstr "Lier l'adresse locale à une IP (vide pour toutes) :"
 
-#: src/muuli_wdr.cpp:1452
+#: src/muuli_wdr.cpp:1459
 msgid "Advanced users only: If you have multiple network interfaces, enter the address of the interface to which aMule should be bound."
 msgstr "Utilisateurs avancés uniquement : Si vous avez plusieurs interfaces réseau, entrez l'adresse de l'interface à laquelle aMule doit être lié."
 
-#: src/muuli_wdr.cpp:1455 src/muuli_wdr.cpp:2054
+#: src/muuli_wdr.cpp:1462 src/muuli_wdr.cpp:2061
 msgid "Bind to network interface (empty for any):"
 msgstr "Lier à une interface réseau (vide pour toutes) :"
 
-#: src/muuli_wdr.cpp:1468
+#: src/muuli_wdr.cpp:1475
 msgid "Advanced users only: pin all of aMule's traffic to one network interface, chosen from the list or typed in by name (e.g. tun0, eth0, en0) or index. Unlike binding to an IP, this stops traffic leaking out via the default route - useful with a VPN. Requires no elevated privileges."
 msgstr "Utilisateurs avancé uniquement : affecter tout le trafic d'aMule à une interface réseau unique, choisie depuis la liste ou bien par la saisie de son nom (par exemple tun0, eth0, en0) ou son index. Contrairement à la liaison à une adresse IP, cela empêche le trafic de fuiter par la route par défaut - utile avec un VPN. Ne nécessite pas de privilèges élevés."
 
-#: src/muuli_wdr.cpp:1474
+#: src/muuli_wdr.cpp:1481
 msgid "Max sources per downloading file:"
 msgstr "Sources maximales par fichier téléchargé :"
 
-#: src/muuli_wdr.cpp:1478
+#: src/muuli_wdr.cpp:1485
 msgid "Max simultaneous connections:"
 msgstr "Connexions simultanées maximales :"
 
-#: src/muuli_wdr.cpp:1491 src/muuli_wdr.cpp:3169
+#: src/muuli_wdr.cpp:1498 src/muuli_wdr.cpp:3176
 msgid "ED2K"
 msgstr "ED2K"
 
-#: src/muuli_wdr.cpp:1498
+#: src/muuli_wdr.cpp:1505
 msgid "Autoconnect on startup"
 msgstr "Se connecter automatiquement au démarrage"
 
-#: src/muuli_wdr.cpp:1501
+#: src/muuli_wdr.cpp:1508
 msgid "Reconnect on loss"
 msgstr "Reconnecter en cas de déconnexion"
 
-#: src/muuli_wdr.cpp:1523
+#: src/muuli_wdr.cpp:1530
 msgid "Remove dead server after"
 msgstr "Supprimer les serveurs inactifs après"
 
-#: src/muuli_wdr.cpp:1524
+#: src/muuli_wdr.cpp:1531
 msgid "Static servers are never removed, even when unreachable."
 msgstr "Les serveurs statiques ne sont jamais enlevés, même lorsqu'ils sont injoignables."
 
-#: src/muuli_wdr.cpp:1528
+#: src/muuli_wdr.cpp:1535
 msgid "retries"
 msgstr "essais"
 
-#: src/muuli_wdr.cpp:1536
+#: src/muuli_wdr.cpp:1543
 msgid "List"
 msgstr "Liste"
 
-#: src/muuli_wdr.cpp:1539
+#: src/muuli_wdr.cpp:1546
 msgid "Update server list when connecting to a server"
 msgstr "Mise à jour de la liste des serveurs dès la connexion à un serveur"
 
-#: src/muuli_wdr.cpp:1542
+#: src/muuli_wdr.cpp:1549
 msgid "Update server list when a client connects"
 msgstr "Mise à jour de la liste des serveurs dès la connexion d'un client"
 
-#: src/muuli_wdr.cpp:1545
+#: src/muuli_wdr.cpp:1552
 msgid "Use priority system"
 msgstr "Utiliser le système de priorité"
 
-#: src/muuli_wdr.cpp:1549
+#: src/muuli_wdr.cpp:1556
 msgid "Use smart LowID check on connect"
 msgstr "Utiliser la vérification du LowID à la connexion"
 
-#: src/muuli_wdr.cpp:1553
+#: src/muuli_wdr.cpp:1560
 msgid "Safe connect"
 msgstr "Connexion sûre"
 
-#: src/muuli_wdr.cpp:1557
+#: src/muuli_wdr.cpp:1564
 msgid "Autoconnect to servers in static list only"
 msgstr "Se connecter automatiquement seulement sur les serveurs statiques"
 
-#: src/muuli_wdr.cpp:1560
+#: src/muuli_wdr.cpp:1567
 msgid "Set manually added servers to High Priority"
 msgstr "Mettre les serveurs ajoutés manuellement en priorité haute"
 
-#: src/muuli_wdr.cpp:1581
+#: src/muuli_wdr.cpp:1588
 msgid "Add files to download in pause mode"
 msgstr "Ajouter les fichiers à télécharger en mode Pause"
 
-#: src/muuli_wdr.cpp:1583
+#: src/muuli_wdr.cpp:1590
 msgid "Add files to download with auto priority"
 msgstr "Ajouter les fichiers à télécharger en priorité automatique"
 
-#: src/muuli_wdr.cpp:1586
+#: src/muuli_wdr.cpp:1593
 msgid "Try to download first and last chunks first"
 msgstr "Essayer de télécharger la première et la dernière partie en premier"
 
-#: src/muuli_wdr.cpp:1590
+#: src/muuli_wdr.cpp:1597
 msgid "Endgame mode: rotate to faster sources for the final blocks"
 msgstr "Mode « endgame » : basculer vers les sources plus rapides pour les blocs finaux"
 
-#: src/muuli_wdr.cpp:1593
+#: src/muuli_wdr.cpp:1600
 msgid "Start next paused file when a file completes"
 msgstr "Démarrer le prochain fichier en pause lorsqu'un fichier se termine"
 
-#: src/muuli_wdr.cpp:1596
+#: src/muuli_wdr.cpp:1603
 msgid "From the same category"
 msgstr "De la même catégorie"
 
-#: src/muuli_wdr.cpp:1598
+#: src/muuli_wdr.cpp:1605
 msgid "In alphabetic order"
 msgstr "Dans l'ordre alphabétique"
 
-#: src/muuli_wdr.cpp:1600
+#: src/muuli_wdr.cpp:1607
 msgid "Preallocate disk space for new files"
 msgstr "Réserver de l'espace disque pour les nouveaux fichiers"
 
-#: src/muuli_wdr.cpp:1601
+#: src/muuli_wdr.cpp:1608
 msgid "For new files preallocates disk space for the whole file, thus reduces fragmentation"
 msgstr "Réserve de l'espace du disque pour les nouveaux fichiers, réduisant ainsi la fragmentation"
 
-#: src/muuli_wdr.cpp:1606
+#: src/muuli_wdr.cpp:1613
 msgid "Create new files as sparse files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1607
+#: src/muuli_wdr.cpp:1614
 msgid "A sparse file reserves its full size on disk immediately without writing real data to it -- fast, but unsupported or slow on some filesystems, and free-space accounting stays optimistic while the download is in progress. Turn this off to grow the file only as data arrives."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1612
+#: src/muuli_wdr.cpp:1619
 msgid "Stop downloads when free disk space reaches "
 msgstr "Stoppe les téléchargements lorsque l'espace disponible est atteint "
 
-#: src/muuli_wdr.cpp:1613
+#: src/muuli_wdr.cpp:1620
 msgid "Select this if you want aMule to check your disk space"
 msgstr "Sélectionnez ceci si vous souhaitez qu'aMule vérifie votre espace disque"
 
-#: src/muuli_wdr.cpp:1617
+#: src/muuli_wdr.cpp:1624
 msgid "Enter here the min disk space desired."
 msgstr "Entrez ici l'espace disque minimum désiré."
 
-#: src/muuli_wdr.cpp:1623
+#: src/muuli_wdr.cpp:1630
 msgid "Save 10 sources on rare files (< 20 sources)"
 msgstr "Sauver 10 sources pour les fichiers rares (< 20 sources)"
 
-#: src/muuli_wdr.cpp:1627 src/Statistics.cpp:790
+#: src/muuli_wdr.cpp:1634 src/Statistics.cpp:790
 msgid "Uploads"
 msgstr "Émission"
 
-#: src/muuli_wdr.cpp:1630
+#: src/muuli_wdr.cpp:1637
 msgid "Add new shared files with auto priority"
 msgstr "Ajouter les nouveaux fichiers partagés en priorité automatique"
 
-#: src/muuli_wdr.cpp:1636
+#: src/muuli_wdr.cpp:1643
 msgid "Intelligent Corruption Handling (I.C.H.)"
 msgstr "Gestion Intelligente de la Corruption (I.C.H.)"
 
-#: src/muuli_wdr.cpp:1639
+#: src/muuli_wdr.cpp:1646
 msgid "Enable"
 msgstr "Activer"
 
-#: src/muuli_wdr.cpp:1642
+#: src/muuli_wdr.cpp:1649
 msgid "Advanced I.C.H. trusts every hash (not recommended)"
 msgstr "I.C.H. avancée se fie aux hachages (non recommandé)"
 
-#: src/muuli_wdr.cpp:1654 src/PrefsUnifiedDlg.cpp:1910
+#: src/muuli_wdr.cpp:1661 src/PrefsUnifiedDlg.cpp:1910
 msgid "Media metadata extraction"
 msgstr "Extraction de métadonnées de média"
 
-#: src/muuli_wdr.cpp:1658
+#: src/muuli_wdr.cpp:1665
 msgid "Extract length / bitrate / codec from shared audio and video files"
 msgstr "Extraire la durée / le débit binaire / le codec depuis les fichiers audio et vidéo partagés"
 
-#: src/muuli_wdr.cpp:1660
+#: src/muuli_wdr.cpp:1667
 msgid "When enabled, aMule runs ffprobe on each shared media file to fill in the Length / Bitrate / Codec columns other clients see when they find the file in a search. Requires ffmpeg (the ffprobe binary) to be installed."
 msgstr "Lorsque cette option est activée, aMule exécute ffprobe sur chaque fichier média partagé pour remplir les colonnes Durée / Débit binaire / Codec que les autres clients voient quand ils trouvent le fichier lors d'une recherche. Nécessite que ffmpeg (le binaire ffprobe) soit installé."
 
-#: src/muuli_wdr.cpp:1667
+#: src/muuli_wdr.cpp:1674
 msgid "Path to ffprobe:"
 msgstr "Emplacement de ffprobe :"
 
-#: src/muuli_wdr.cpp:1672
+#: src/muuli_wdr.cpp:1679
 msgid "Full path to the ffprobe binary. Leave empty to have aMule auto-detect it on startup."
 msgstr "Chemin complet vers le binaire ffprobe. Laisser vide pour qu'aMule le détecte automatiquement au démarrage."
 
-#: src/muuli_wdr.cpp:1680
+#: src/muuli_wdr.cpp:1687
 msgid "Detect"
 msgstr "Détecter"
 
-#: src/muuli_wdr.cpp:1681
+#: src/muuli_wdr.cpp:1688
 msgid "Search the standard install locations for an ffprobe binary and fill the path field."
 msgstr "Rechercher les binaires de ffprobe aux emplacements par défaut et compléter le champ emplacement."
 
-#: src/muuli_wdr.cpp:1705
+#: src/muuli_wdr.cpp:1712
 msgid ""
 "Completed downloads are stored here. All files in this folder are automatically shared with other peers.\n"
 "If this folder also holds files you don't want to share, point it at an aMule-only sub-folder."
@@ -4148,665 +4162,665 @@ msgstr ""
 "Les téléchargements terminés sont stockés ici. Tous les fichiers de ce répertoire sont automatiquement partagés avec les autres pairs.\n"
 "Si ce répertoire contient également des fichiers que vous ne souhaitez pas partager, indiquez un sous-répertoire réservé à aMule."
 
-#: src/muuli_wdr.cpp:1708
+#: src/muuli_wdr.cpp:1715
 msgid "Pick the folder where completed downloads will be stored. All files in that folder will be shared with other peers."
 msgstr "Choisissez le répertoire où les téléchargements terminés seront enregistrés. Tous les fichiers de ce répertoire seront partagés avec les autres pairs."
 
-#: src/muuli_wdr.cpp:1722
+#: src/muuli_wdr.cpp:1729
 msgid "Shared folders"
 msgstr "Dossiers partagés"
 
-#: src/muuli_wdr.cpp:1728
+#: src/muuli_wdr.cpp:1735
 msgid "(Folders shared by the core. Enter a path to add one.)"
 msgstr "(Les répertoires partagés par le noyau. Entrer un chemin pour en ajouter un.)"
 
-#: src/muuli_wdr.cpp:1736
+#: src/muuli_wdr.cpp:1743
 msgid "Absolute path of a folder on the core's machine, e.g. /home/user/shared"
 msgstr "Le chemin absolu d'un répertoire sur la machine du noyau, par exemple /home/utilisateur/shared"
 
-#: src/muuli_wdr.cpp:1738 src/PrefsUnifiedDlg.cpp:2794
+#: src/muuli_wdr.cpp:1745 src/PrefsUnifiedDlg.cpp:2794
 msgid "Recursive"
 msgstr "Récursif"
 
-#: src/muuli_wdr.cpp:1739
+#: src/muuli_wdr.cpp:1746
 msgid "Share every sub-folder underneath this one, including ones created later."
 msgstr "Partager chaque sous-répertoire sous celui-ci, y compris ceux qui seront créés ultérieurement."
 
-#: src/muuli_wdr.cpp:1743 src/utils/aLinkCreator/src/alcframe.cpp:141
+#: src/muuli_wdr.cpp:1750 src/utils/aLinkCreator/src/alcframe.cpp:141
 msgid "Remove"
 msgstr "Enlever"
 
-#: src/muuli_wdr.cpp:1747
+#: src/muuli_wdr.cpp:1754
 msgid "(Right click on folder icon for recursive share)"
 msgstr "(Clic droit sur l'icône du répertoire pour un partage récursif)"
 
-#: src/muuli_wdr.cpp:1754
+#: src/muuli_wdr.cpp:1761
 msgid "Share hidden files"
 msgstr "Partager les fichiers cachés"
 
-#: src/muuli_wdr.cpp:1760
+#: src/muuli_wdr.cpp:1767
 msgid "Automatically rescan shared folders for changes"
 msgstr "Analyser automatiquement à nouveau les répertoires partagés pour rechercher des modifications"
 
-#: src/muuli_wdr.cpp:1766
+#: src/muuli_wdr.cpp:1773
 msgid "Follow symbolic links in shared folders"
 msgstr "Suivre les liens symboliques dans les répertoires partagés"
 
-#: src/muuli_wdr.cpp:1772
+#: src/muuli_wdr.cpp:1779
 msgid "Exclude files matching:"
 msgstr "Exclure les fichiers correspondant à :"
 
-#: src/muuli_wdr.cpp:1775
+#: src/muuli_wdr.cpp:1782
 msgid "Wildcard patterns separated by '|', e.g. .DS_Store|Thumbs.db|*.tmp. Files whose name matches are not shared. Matching is case-insensitive."
 msgstr "Motifs de caractères génériques séparés par '|', par exemple .DS_Store|Thumbs.db|*.tmp. Les fichiers dont le nom correspond ne seront pas partagés. La correspondance est insensible à la casse."
 
-#: src/muuli_wdr.cpp:1779
+#: src/muuli_wdr.cpp:1786
 msgid "Patterns are regular expressions"
 msgstr "Les motifs sont des expressions régulières"
 
-#: src/muuli_wdr.cpp:1780
+#: src/muuli_wdr.cpp:1787
 msgid "When set, the whole field is one regular expression ('|' is alternation). When unset, it is a list of '|'-separated wildcards."
 msgstr "Lorsque l'option est activée, la totalité du champ est une expression régulière ('|' indique une alternative). Lorsque l'option est désactivée, il s'agit d'une liste de caractères génériques séparés par des '|'."
 
-#: src/muuli_wdr.cpp:1790
+#: src/muuli_wdr.cpp:1797
 msgid "Show how many shared files the current pattern would exclude."
 msgstr "Afficher combien de fichiers partagés le motif actuel exclurait."
 
-#: src/muuli_wdr.cpp:1811
+#: src/muuli_wdr.cpp:1818
 msgid "Graphs"
 msgstr "Graphiques"
 
-#: src/muuli_wdr.cpp:1814 src/muuli_wdr.cpp:1876
+#: src/muuli_wdr.cpp:1821 src/muuli_wdr.cpp:1883
 msgid "Update delay : 5 secs"
 msgstr "Délais de rafraîchissement : 5 s"
 
-#: src/muuli_wdr.cpp:1818
+#: src/muuli_wdr.cpp:1825
 msgid "Time for average graph: 100 mins"
 msgstr "Temps pour la courbe de la moyenne : 100 min"
 
-#: src/muuli_wdr.cpp:1822
+#: src/muuli_wdr.cpp:1829
 msgid "Connections Graph Scale: 100 "
 msgstr "Échelle du graphique des connexions : 100 "
 
-#: src/muuli_wdr.cpp:1829
+#: src/muuli_wdr.cpp:1836
 msgid "Download graph scale:"
 msgstr "Échelle des graphiques de réception :"
 
-#: src/muuli_wdr.cpp:1837
+#: src/muuli_wdr.cpp:1844
 msgid "Upload graph scale:"
 msgstr "Échelle des graphiques d'envoi :"
 
-#: src/muuli_wdr.cpp:1847
+#: src/muuli_wdr.cpp:1854
 msgid "Colors: "
 msgstr "Couleurs : "
 
-#: src/muuli_wdr.cpp:1851
+#: src/muuli_wdr.cpp:1858
 msgid "Background"
 msgstr "Fond"
 
-#: src/muuli_wdr.cpp:1852
+#: src/muuli_wdr.cpp:1859
 msgid "Grid"
 msgstr "Quadrillage"
 
-#: src/muuli_wdr.cpp:1853
+#: src/muuli_wdr.cpp:1860
 msgid "Download current"
 msgstr "Téléchargement actuel"
 
-#: src/muuli_wdr.cpp:1854
+#: src/muuli_wdr.cpp:1861
 msgid "Download running average"
 msgstr "Téléchargement moyen total"
 
-#: src/muuli_wdr.cpp:1855
+#: src/muuli_wdr.cpp:1862
 msgid "Download session average"
 msgstr "Téléchargement moyen sur la session"
 
-#: src/muuli_wdr.cpp:1856
+#: src/muuli_wdr.cpp:1863
 msgid "Upload current"
 msgstr "Envoi actuel"
 
-#: src/muuli_wdr.cpp:1857
+#: src/muuli_wdr.cpp:1864
 msgid "Upload running average"
 msgstr "Envoi moyen total"
 
-#: src/muuli_wdr.cpp:1858
+#: src/muuli_wdr.cpp:1865
 msgid "Upload session average"
 msgstr "Envoi moyen sur la session"
 
-#: src/muuli_wdr.cpp:1859
+#: src/muuli_wdr.cpp:1866
 msgid "Active connections"
 msgstr "Connexions actives"
 
-#: src/muuli_wdr.cpp:1862
+#: src/muuli_wdr.cpp:1869
 msgid "Systray Icon Speed Bar"
 msgstr "Barre de vitesse dans l'icône de barre des tâches"
 
-#: src/muuli_wdr.cpp:1863
+#: src/muuli_wdr.cpp:1870
 msgid "Kad-nodes current"
 msgstr "Nœuds Kad actuels"
 
-#: src/muuli_wdr.cpp:1864
+#: src/muuli_wdr.cpp:1871
 msgid "Kad-nodes running"
 msgstr "Nœuds Kad total"
 
-#: src/muuli_wdr.cpp:1865
+#: src/muuli_wdr.cpp:1872
 msgid "Kad-nodes session"
 msgstr "Nœuds Kad pour la session"
 
-#: src/muuli_wdr.cpp:1869 src/muuli_wdr.cpp:2296
+#: src/muuli_wdr.cpp:1876 src/muuli_wdr.cpp:2303
 msgid "Select"
 msgstr "Sélectionner"
 
-#: src/muuli_wdr.cpp:1873
+#: src/muuli_wdr.cpp:1880
 msgid "Tree"
 msgstr "Arbre"
 
-#: src/muuli_wdr.cpp:1883
+#: src/muuli_wdr.cpp:1890
 msgid "Number of Client Versions shown (0=unlimited)"
 msgstr "Nombre de versions client affichées (0=illimité)"
 
-#: src/muuli_wdr.cpp:1908
+#: src/muuli_wdr.cpp:1915
 msgid "!!! WARNING !!!"
 msgstr "!!! AVERTISSEMENT !!!"
 
-#: src/muuli_wdr.cpp:1923
+#: src/muuli_wdr.cpp:1930
 msgid "Max new connections / 5 secs"
 msgstr "Nombre maximum de nouvelles connexions / 5 secs"
 
-#: src/muuli_wdr.cpp:1925
+#: src/muuli_wdr.cpp:1932
 msgid "Concurrent Kad source lookups"
 msgstr "Recherche concurrentes de sources Kad"
 
-#: src/muuli_wdr.cpp:1927
+#: src/muuli_wdr.cpp:1934
 msgid "Kad source re-search interval (minutes)"
 msgstr "Intervalle entre les nouvelles recherches de sources Kad (en minutes)"
 
-#: src/muuli_wdr.cpp:1929
+#: src/muuli_wdr.cpp:1936
 msgid "Source re-ask interval (minutes)"
 msgstr "Intervalle entre les nouvelles demandes de sources Kad (en minutes)"
 
-#: src/muuli_wdr.cpp:1933
+#: src/muuli_wdr.cpp:1940
 msgid "File Buffer Size: 240000 bytes"
 msgstr "Taille du fichier de tampon : 240000 octets"
 
-#: src/muuli_wdr.cpp:1937
+#: src/muuli_wdr.cpp:1944
 msgid "Use MMAP: memory-mapped file access (lower memory use)"
 msgstr "Utiliser MMAP : « memory-mapped file access », c'est-à-dire accès aux fichiers mappés dans la mémoire (utilise moins de mémoire)"
 
-#: src/muuli_wdr.cpp:1938
+#: src/muuli_wdr.cpp:1945
 msgid "Maps part files into memory instead of buffering them on the heap, lowering the process memory footprint. May reduce download speed on some disks; best for memory-constrained or upload-heavy hosts."
 msgstr "Fait correspondre les fichiers partiels dans la mémoire au lieu de les mettre en tampon sur la pile, baissant l'empreinte mémoire du processus. Peut réduire la vitesse de téléchargement sur certains disques ; idéal pour les hôtes disposant de peu de mémoire ou pour ceux qui téléversent beaucoup."
 
-#: src/muuli_wdr.cpp:1940
+#: src/muuli_wdr.cpp:1947
 msgid "Upload Queue Size: 5000 clients"
 msgstr "Taille de la file d'attente d'envoi : 5000 clients"
 
-#: src/muuli_wdr.cpp:1944
+#: src/muuli_wdr.cpp:1951
 msgid "Server connection refresh interval: Disable"
 msgstr "Intervalle de rafraîchissement de la connexion serveur : Désactivé"
 
-#: src/muuli_wdr.cpp:1948
+#: src/muuli_wdr.cpp:1955
 msgid "Disable computer's timed standby mode"
 msgstr "Désactiver la mise en veille programmé de l'ordinateur"
 
-#: src/muuli_wdr.cpp:1967
+#: src/muuli_wdr.cpp:1974
 msgid "Skin to use: "
 msgstr "Thème à utiliser : "
 
-#: src/muuli_wdr.cpp:1976
+#: src/muuli_wdr.cpp:1983
 msgid "Show \"Fast eD2k Links Handler\" in every window."
 msgstr "Afficher le \"Gestionnaire rapide de liens eD2k \" dans chaque fenêtre."
 
-#: src/muuli_wdr.cpp:1979
+#: src/muuli_wdr.cpp:1986
 msgid "Show extended info on categories tabs"
 msgstr "Afficher des infos supplémentaires sur les onglets des catégories"
 
-#: src/muuli_wdr.cpp:1982
+#: src/muuli_wdr.cpp:1989
 msgid "Show application version on title"
 msgstr "Afficher la version de l'application dans le titre"
 
-#: src/muuli_wdr.cpp:1984
+#: src/muuli_wdr.cpp:1991
 msgid "Show transfer rates on title"
 msgstr "Afficher les taux de transfert dans la barre de titre"
 
-#: src/muuli_wdr.cpp:1986
+#: src/muuli_wdr.cpp:1993
 msgid "Before application name"
 msgstr "Avant le nom de l'application"
 
-#: src/muuli_wdr.cpp:1988
+#: src/muuli_wdr.cpp:1995
 msgid "After application name"
 msgstr "Après le nom de l'application"
 
-#: src/muuli_wdr.cpp:1991
+#: src/muuli_wdr.cpp:1998
 msgid "Show overhead bandwidth"
 msgstr "Afficher la surcharge de la bande passante"
 
-#: src/muuli_wdr.cpp:1995
+#: src/muuli_wdr.cpp:2002
 msgid "Vertical toolbar orientation"
 msgstr "Orientation de la barre d'outils verticale"
 
-#: src/muuli_wdr.cpp:1997
+#: src/muuli_wdr.cpp:2004
 msgid "Live column sorting (auto-reorder rows as their values change)"
 msgstr "Tri des colonnes en temps réel (réorganisation automatique des lignes à mesure que leurs valeurs changent)"
 
-#: src/muuli_wdr.cpp:2004
+#: src/muuli_wdr.cpp:2011
 msgid "Download Queue Files"
 msgstr "Fichiers à télécharger en file d'attente"
 
-#: src/muuli_wdr.cpp:2007
+#: src/muuli_wdr.cpp:2014
 msgid "Show progress percentage"
 msgstr "Afficher le pourcentage de progression"
 
-#: src/muuli_wdr.cpp:2013
+#: src/muuli_wdr.cpp:2020
 msgid "Show progress bar"
 msgstr "Afficher la barre de progression"
 
-#: src/muuli_wdr.cpp:2016
+#: src/muuli_wdr.cpp:2023
 msgid "Flat"
 msgstr "Plat"
 
-#: src/muuli_wdr.cpp:2020
+#: src/muuli_wdr.cpp:2027
 msgid "Round"
 msgstr "Relief"
 
-#: src/muuli_wdr.cpp:2038
+#: src/muuli_wdr.cpp:2045
 msgid "External Connection Parameters"
 msgstr "Paramètres de Connexion Externe"
 
-#: src/muuli_wdr.cpp:2041
+#: src/muuli_wdr.cpp:2048
 msgid "Accept external connections"
 msgstr "Accepter les connexions externes"
 
-#: src/muuli_wdr.cpp:2048 src/muuli_wdr.cpp:2107
+#: src/muuli_wdr.cpp:2055 src/muuli_wdr.cpp:2114
 msgid "IP of the listening interface:"
 msgstr "IP de l'interface d'écoute :"
 
-#: src/muuli_wdr.cpp:2051
+#: src/muuli_wdr.cpp:2058
 msgid "Enter here a valid ip in the a.b.c.d format for the listening EC interface. An empty field or 0.0.0.0 will mean any interface."
 msgstr "Entrer ici une adresse IP valide dans le format a.b.c.d pour l'interface d'écoute EC. Un champ vide ou 0.0.0.0 signifiera toutes les interfaces."
 
-#: src/muuli_wdr.cpp:2072 src/muuli_wdr.cpp:2156
+#: src/muuli_wdr.cpp:2079 src/muuli_wdr.cpp:2163
 msgid "TCP port:"
 msgstr "Port TCP :"
 
-#: src/muuli_wdr.cpp:2078
+#: src/muuli_wdr.cpp:2085
 msgid "Enable UPnP port forwarding on the EC port"
 msgstr "Activer la redirection de ports en UPnP sur le port EC"
 
-#: src/muuli_wdr.cpp:2082 src/muuli_wdr.cpp:3041
+#: src/muuli_wdr.cpp:2089 src/muuli_wdr.cpp:3048
 #: src/utils/wxCas/src/wxcasprefs.cpp:167
 msgid "Password"
 msgstr "Mot de passe"
 
-#: src/muuli_wdr.cpp:2088
+#: src/muuli_wdr.cpp:2095
 msgid "aMule API server parameters"
 msgstr "Paramètres du serveur aMule API"
 
-#: src/muuli_wdr.cpp:2091
+#: src/muuli_wdr.cpp:2098
 msgid "Run amuleapi (REST API) on startup"
 msgstr "Exécuter amuleapi (API REST) au démarrage"
 
-#: src/muuli_wdr.cpp:2096
+#: src/muuli_wdr.cpp:2103
 msgid "HTTP port:"
 msgstr "Port HTTP :"
 
-#: src/muuli_wdr.cpp:2110
+#: src/muuli_wdr.cpp:2117
 msgid "The interface amuleapi's HTTP server listens on. 127.0.0.1 (default) accepts only local connections; use 0.0.0.0 or a specific IP to expose it to other hosts (set an admin password below)."
 msgstr "L'interface sur laquelle le serveur HTTP d'amuleapi écoute. 127.0.0.1 (par défaut) n'accepte que les connexions locales  ; utilisez 0.0.0.0 ou bien une adresse IP spécifique pour l'exposer à d'autres hôtes (définissez un mot de passe administrateur ci-dessous)."
 
-#: src/muuli_wdr.cpp:2113
+#: src/muuli_wdr.cpp:2120
 msgid "Admin password"
 msgstr "Mot de passe administrateur"
 
-#: src/muuli_wdr.cpp:2118 src/muuli_wdr.cpp:2149
+#: src/muuli_wdr.cpp:2125 src/muuli_wdr.cpp:2156
 msgid "Low rights password"
 msgstr "Mot de passe sans privilèges"
 
-#: src/muuli_wdr.cpp:2126
+#: src/muuli_wdr.cpp:2133
 msgid "Web server parameters"
 msgstr "Paramètres du serveur Web"
 
-#: src/muuli_wdr.cpp:2129
+#: src/muuli_wdr.cpp:2136
 msgid "Run webserver on startup (deprecated)"
 msgstr "Démarrer le serveur web au démarrage (obsolète)"
 
-#: src/muuli_wdr.cpp:2135
+#: src/muuli_wdr.cpp:2142
 msgid "Web template"
 msgstr "Template web"
 
-#: src/muuli_wdr.cpp:2140
+#: src/muuli_wdr.cpp:2147
 msgid "Full rights password"
 msgstr "Mot de passe administrateur"
 
-#: src/muuli_wdr.cpp:2144
+#: src/muuli_wdr.cpp:2151
 msgid "Enable Low rights User"
 msgstr "Activer l'accès utilisateur sans privilèges"
 
-#: src/muuli_wdr.cpp:2163
+#: src/muuli_wdr.cpp:2170
 msgid "Enable UPnP port forwarding of the web server port"
 msgstr "Activer la redirection de port UPnP sur le port du serveur web"
 
-#: src/muuli_wdr.cpp:2168
+#: src/muuli_wdr.cpp:2175
 msgid "Web server UPnP TCP port (Optional)"
 msgstr "Port TCP UPnP du serveur web (Facultatif)"
 
-#: src/muuli_wdr.cpp:2176
+#: src/muuli_wdr.cpp:2183
 msgid "Page Refresh Time (in secs)"
 msgstr "Intervalle de rafraîchissement (en secondes)"
 
-#: src/muuli_wdr.cpp:2183
+#: src/muuli_wdr.cpp:2190
 msgid "Enable Gzip compression"
 msgstr "Activer la compression Gzip"
 
-#: src/muuli_wdr.cpp:2217
+#: src/muuli_wdr.cpp:2224
 msgid "Reset page to defaults"
 msgstr "Réinitialiser la page aux valeurs par défaut"
 
-#: src/muuli_wdr.cpp:2218
+#: src/muuli_wdr.cpp:2225
 msgid "Reset the settings on the current page to their default values."
 msgstr "Réinitialiser les réglages sur la page actuelle à leurs valeurs par défaut."
 
-#: src/muuli_wdr.cpp:2220 src/muuli_wdr.cpp:2306 src/ServerWnd.cpp:274
+#: src/muuli_wdr.cpp:2227 src/muuli_wdr.cpp:2313 src/ServerWnd.cpp:274
 #: src/ServerWnd.cpp:282
 msgid "OK"
 msgstr "OK"
 
-#: src/muuli_wdr.cpp:2222
+#: src/muuli_wdr.cpp:2229
 msgid "Click here to apply any changes made to the preferences."
 msgstr "Cliquer ici pour appliquer tous les changements effectués dans les Préférences."
 
-#: src/muuli_wdr.cpp:2225
+#: src/muuli_wdr.cpp:2232
 msgid "Reset any changes made to the preferences."
 msgstr "Annule tous les changements effectués dans les Préférences."
 
-#: src/muuli_wdr.cpp:2254
+#: src/muuli_wdr.cpp:2261
 msgid "Comment :"
 msgstr "Commentaire :"
 
-#: src/muuli_wdr.cpp:2261
+#: src/muuli_wdr.cpp:2268
 msgid "Incoming Dir :"
 msgstr "Répertoire entrant :"
 
-#: src/muuli_wdr.cpp:2270
+#: src/muuli_wdr.cpp:2277
 msgid "Change priority for new assigned files :"
 msgstr "Changer la priorité des nouveaux fichiers assignés :"
 
-#: src/muuli_wdr.cpp:2274
+#: src/muuli_wdr.cpp:2281
 msgid "Don't change"
 msgstr "Ne rien changer"
 
-#: src/muuli_wdr.cpp:2286
+#: src/muuli_wdr.cpp:2293
 msgid "Select color for this Category (currently selected) :"
 msgstr "Choisir la couleur pour cette Catégorie (actuellement sélectionnée) :"
 
-#: src/muuli_wdr.cpp:2353 src/muuli_wdr.cpp:2372 src/muuli_wdr.cpp:2394
+#: src/muuli_wdr.cpp:2360 src/muuli_wdr.cpp:2379 src/muuli_wdr.cpp:2401
 msgid "Click this button to reset the log."
 msgstr "Cliquer ici pour effacer le journal."
 
-#: src/muuli_wdr.cpp:2413
+#: src/muuli_wdr.cpp:2420
 msgid "Click on this button to update the servers list from URL ..."
 msgstr "Cliquer ici pour mettre à jour la liste des serveurs à partir de l'URL…"
 
-#: src/muuli_wdr.cpp:2417
+#: src/muuli_wdr.cpp:2424
 msgid "Server list"
 msgstr "Liste des serveurs"
 
-#: src/muuli_wdr.cpp:2421
+#: src/muuli_wdr.cpp:2428
 msgid "Enter the url to a server.met file here and press the button to the left to update the list of known servers."
 msgstr "Entrer l'URL d'un fichier server.met et presser le bouton à gauche pour rafraîchir la liste des serveurs connus."
 
-#: src/muuli_wdr.cpp:2426
+#: src/muuli_wdr.cpp:2433
 msgid "Add server manually: Name"
 msgstr "Ajouter un serveur manuellement : Nom"
 
-#: src/muuli_wdr.cpp:2429
+#: src/muuli_wdr.cpp:2436
 msgid "Enter the name of the new server here"
 msgstr "Entrer ici le nom du nouveau serveur"
 
-#: src/muuli_wdr.cpp:2431 src/ServerWnd.cpp:206
+#: src/muuli_wdr.cpp:2438 src/ServerWnd.cpp:206
 msgid "IP:Port"
 msgstr "IP : Port"
 
-#: src/muuli_wdr.cpp:2434
+#: src/muuli_wdr.cpp:2441
 msgid "Enter the IP of the server here, using the x.x.x.x format."
 msgstr "Entrer ici l'adresse IP du serveur, avec le format x.x.x.x."
 
-#: src/muuli_wdr.cpp:2440
+#: src/muuli_wdr.cpp:2447
 msgid "Enter the port of the server here."
 msgstr "Entrer ici le port du serveur."
 
-#: src/muuli_wdr.cpp:2443
+#: src/muuli_wdr.cpp:2450
 msgid "Add manually a server (fill fields to the left before) ..."
 msgstr "Ajouter manuellement un serveur (remplir les champs à gauche avant)…"
 
-#: src/muuli_wdr.cpp:2472
+#: src/muuli_wdr.cpp:2479
 msgid "aMule Log"
 msgstr "Journal d'aMule"
 
-#: src/muuli_wdr.cpp:2480
+#: src/muuli_wdr.cpp:2487
 msgid "Server Info"
 msgstr "Infos Serveur"
 
-#: src/muuli_wdr.cpp:2484
+#: src/muuli_wdr.cpp:2491
 msgid "ED2K Info"
 msgstr "Infos ED2K"
 
-#: src/muuli_wdr.cpp:2488
+#: src/muuli_wdr.cpp:2495
 msgid "Kad Info"
 msgstr "Infos Kad"
 
-#: src/muuli_wdr.cpp:2516
+#: src/muuli_wdr.cpp:2523
 msgid "Click on this button to update the nodes list from URL ..."
 msgstr "Cliquer sur le bouton pour mettre à jour la liste des nœuds depuis l'URL…"
 
-#: src/muuli_wdr.cpp:2520
+#: src/muuli_wdr.cpp:2527
 msgid "Nodes (0)"
 msgstr "Nœuds (0)"
 
-#: src/muuli_wdr.cpp:2524
+#: src/muuli_wdr.cpp:2531
 msgid "Enter the url to a nodes.dat file here and press the button to the left to update the list of known nodes."
 msgstr "Entrer l'URL d'un fichier nodes.dat ici et presser le bouton à gauche pour mettre à jour la liste des nœuds connus."
 
-#: src/muuli_wdr.cpp:2527
+#: src/muuli_wdr.cpp:2534
 msgid "Nodes stats"
 msgstr "Statistiques des nœuds"
 
-#: src/muuli_wdr.cpp:2569
+#: src/muuli_wdr.cpp:2576
 msgid "Bootstrap"
 msgstr "Amorçage"
 
-#: src/muuli_wdr.cpp:2572
+#: src/muuli_wdr.cpp:2579
 msgid "New node"
 msgstr "Nouveau nœud"
 
-#: src/muuli_wdr.cpp:2577
+#: src/muuli_wdr.cpp:2584
 msgid "IP:"
 msgstr "IP :"
 
-#: src/muuli_wdr.cpp:2597
+#: src/muuli_wdr.cpp:2604
 msgid "Port:"
 msgstr "Port :"
 
-#: src/muuli_wdr.cpp:2610
+#: src/muuli_wdr.cpp:2617
 msgid "Bootstrap from known clients"
 msgstr "Amorçage depuis les clients connus"
 
-#: src/muuli_wdr.cpp:2612
+#: src/muuli_wdr.cpp:2619
 msgid "Disconnect Kad"
 msgstr "Déconnecter Kad"
 
-#: src/muuli_wdr.cpp:2646
+#: src/muuli_wdr.cpp:2653
 msgid "Use Secure User Identification"
 msgstr "Utiliser l'Identification Utilisateur Sécurisée (SUI)"
 
-#: src/muuli_wdr.cpp:2648
+#: src/muuli_wdr.cpp:2655
 msgid "It is recommended to enable this option. You will not receive credits if SUI is not enabled."
 msgstr "Il est recommandé d'activer cette option. Vous ne recevrez pas de crédits si SUI n'est pas activé."
 
-#: src/muuli_wdr.cpp:2650
+#: src/muuli_wdr.cpp:2657
 msgid "Protocol Obfuscation"
 msgstr "Brouillage de protocole"
 
-#: src/muuli_wdr.cpp:2653
+#: src/muuli_wdr.cpp:2660
 msgid "Support Protocol Obfuscation"
 msgstr "Supporter le brouillage de protocole"
 
-#: src/muuli_wdr.cpp:2655
+#: src/muuli_wdr.cpp:2662
 msgid "This option enabled Protocol Obfuscation, and makes aMule accept obfuscated connections from other clients."
 msgstr "Cette option active le brouillage de protocole, cela permet à aMule d'accepter les connexions brouillées des autres clients."
 
-#: src/muuli_wdr.cpp:2657
+#: src/muuli_wdr.cpp:2664
 msgid "Use obfuscation for outgoing connections"
 msgstr "Utiliser le brouillage pour les connexions sortantes"
 
-#: src/muuli_wdr.cpp:2659
+#: src/muuli_wdr.cpp:2666
 msgid "This option makes aMule use Protocol Obfuscation when connecting other clients/servers."
 msgstr "Avec cette option, aMule utilise le brouillage de protocole lors des connexions aux autres clients/serveurs."
 
-#: src/muuli_wdr.cpp:2661
+#: src/muuli_wdr.cpp:2668
 msgid "Accept only obfuscated connections"
 msgstr "Accepter seulement les connexions brouillées"
 
-#: src/muuli_wdr.cpp:2662
+#: src/muuli_wdr.cpp:2669
 msgid "This option makes aMule only accept obfuscated connections. You will have less sources, but all your traffic will be obfuscated"
 msgstr "Avec cette option, aMule n'accepte que les connexions brouillées. Vous aurez moins de sources, mais tout votre trafic sera brouillé"
 
-#: src/muuli_wdr.cpp:2667
+#: src/muuli_wdr.cpp:2674
 msgid "Everybody"
 msgstr "Tout le monde"
 
-#: src/muuli_wdr.cpp:2669
+#: src/muuli_wdr.cpp:2676
 msgid "No one"
 msgstr "Personne"
 
-#: src/muuli_wdr.cpp:2671
+#: src/muuli_wdr.cpp:2678
 msgid "Who can see my shared files:"
 msgstr "Qui peut voir mes fichiers partagés :"
 
-#: src/muuli_wdr.cpp:2672
+#: src/muuli_wdr.cpp:2679
 msgid "Select who can request to view a list of your shared files."
 msgstr "Indique qui peut voir votre liste de fichiers partagés."
 
-#: src/muuli_wdr.cpp:2674
+#: src/muuli_wdr.cpp:2681
 msgid "IP-Filtering"
 msgstr "Filtrage des IP"
 
-#: src/muuli_wdr.cpp:2681
+#: src/muuli_wdr.cpp:2688
 msgid "Filter clients"
 msgstr "Filtrage des clients"
 
-#: src/muuli_wdr.cpp:2683
+#: src/muuli_wdr.cpp:2690
 msgid "Enable filtering of the client IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "Activer le filtrage des clients selon les IP contenues dans le fichier ~/.aMule/ipfilter.dat."
 
-#: src/muuli_wdr.cpp:2685
+#: src/muuli_wdr.cpp:2692
 msgid "Filter servers"
 msgstr "Filtrage des serveurs"
 
-#: src/muuli_wdr.cpp:2687
+#: src/muuli_wdr.cpp:2694
 msgid "Enable filtering of the server IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "Active le filtrage des serveurs selon les IP contenues dans le fichier ~/.aMule/ipfilter.dat."
 
-#: src/muuli_wdr.cpp:2691
+#: src/muuli_wdr.cpp:2698
 msgid "Reload List"
 msgstr "Recharger la liste"
 
-#: src/muuli_wdr.cpp:2692
+#: src/muuli_wdr.cpp:2699
 msgid "Reload the list of IPs to filter from the file ~/.aMule/ipfilter.dat"
 msgstr "Recharge la liste des IP à filtrer à partir du fichier ~/.aMule/ipfilter.dat"
 
-#: src/muuli_wdr.cpp:2698
+#: src/muuli_wdr.cpp:2705
 msgid "URL:"
 msgstr "URL :"
 
-#: src/muuli_wdr.cpp:2702 src/muuli_wdr.cpp:2895
+#: src/muuli_wdr.cpp:2709 src/muuli_wdr.cpp:2902
 msgid "Update now"
 msgstr "Mettre à jour maintenant"
 
-#: src/muuli_wdr.cpp:2705
+#: src/muuli_wdr.cpp:2712
 msgid "Auto-update ipfilter at startup"
 msgstr "Mise à jour d' IPFilter au démarrage"
 
-#: src/muuli_wdr.cpp:2709
+#: src/muuli_wdr.cpp:2716
 msgid "Filtering Level:"
 msgstr "Niveau de filtrage :"
 
-#: src/muuli_wdr.cpp:2715
+#: src/muuli_wdr.cpp:2722
 msgid "Always filter LAN IPs"
 msgstr "Toujours filtrer les IPs LAN"
 
-#: src/muuli_wdr.cpp:2718
+#: src/muuli_wdr.cpp:2725
 msgid "Paranoid handling of non-matching IPs"
 msgstr "Prise en charge paranoïaque des IPs qui ne se correspondent pas"
 
-#: src/muuli_wdr.cpp:2720
+#: src/muuli_wdr.cpp:2727
 msgid "Rejects a packet when its source IP differs from the IP the client claims (an anti-spoofing check). Disable only if it causes connection problems."
 msgstr "Rejette un paquet lorsque son IP source diffère de l'IP que le client prétend avoir (vérification anti-usurpation). Désactivez seulement si cela provoque des problèmes de connexion."
 
-#: src/muuli_wdr.cpp:2722
+#: src/muuli_wdr.cpp:2729
 msgid "Use system-wide ipfilter.dat if available"
 msgstr "Utiliser un ipfilter.dat système si disponible"
 
-#: src/muuli_wdr.cpp:2723
+#: src/muuli_wdr.cpp:2730
 msgid "If there's no local ipfilter.dat found, allow usage of a system-wide ipfilter file."
 msgstr "S'il n'y a pas de fichier ipfilter.dat local, autoriser l'utilisation d'un fichier ipfilter système."
 
-#: src/muuli_wdr.cpp:2740
+#: src/muuli_wdr.cpp:2747
 msgid "Enable Online-Signature"
 msgstr "Activer la Signature En Ligne"
 
-#: src/muuli_wdr.cpp:2742
+#: src/muuli_wdr.cpp:2749
 msgid "Enables the writing of the OS file, which can be used by external apps to create signatures and the like."
 msgstr "Active l'écriture du fichier de signature en ligne, qui peut-être utilisé par des applications extérieures pour créer des signatures, etc."
 
-#: src/muuli_wdr.cpp:2746
+#: src/muuli_wdr.cpp:2753
 msgid "Update Frequency (Secs):"
 msgstr "Fréquence de mise à jour (Secondes) :"
 
-#: src/muuli_wdr.cpp:2749
+#: src/muuli_wdr.cpp:2756
 msgid "Change the frequency (in seconds) of Online Signature updates."
 msgstr "Change la fréquence des mises à jour de la signature en ligne (en secondes)."
 
-#: src/muuli_wdr.cpp:2757
+#: src/muuli_wdr.cpp:2764
 msgid "Save online signature file in: "
 msgstr "Sauver le fichier de signature en ligne dans : "
 
-#: src/muuli_wdr.cpp:2763
+#: src/muuli_wdr.cpp:2770
 msgid "Click here to select the directory containing the the Online Signature files."
 msgstr "Cliquer ici pour sélectionner le répertoire contenant le fichier de signature en ligne."
 
-#: src/muuli_wdr.cpp:2796
+#: src/muuli_wdr.cpp:2803
 msgid "Show country flags for clients"
 msgstr "Voir les drapeaux des pays pour les clients"
 
-#: src/muuli_wdr.cpp:2797
+#: src/muuli_wdr.cpp:2804
 msgid "Render the country flag column in the transfers, queue and search views. Requires a valid MMDB GeoIP database (see below)."
 msgstr "Afficher la colonne des drapeaux des pays dans les vues des transferts, des files d'attente et de recherche. Nécessite une base de données MMDB GeoIP valide (cf. ci-dessous)."
 
-#: src/muuli_wdr.cpp:2802
+#: src/muuli_wdr.cpp:2809
 msgid "Database"
 msgstr "Base de données"
 
-#: src/muuli_wdr.cpp:2818
+#: src/muuli_wdr.cpp:2825
 msgid "Source:"
 msgstr "Source :"
 
-#: src/muuli_wdr.cpp:2821
+#: src/muuli_wdr.cpp:2828
 msgid "DB-IP (free, no account)"
 msgstr "DB-IP (gratuit, pas de compte)"
 
-#: src/muuli_wdr.cpp:2822
+#: src/muuli_wdr.cpp:2829
 msgid "MaxMind GeoLite2 (free, account required)"
 msgstr "MaxMind GeoLite2 (gratuit, compte nécessaire)"
 
-#: src/muuli_wdr.cpp:2823
+#: src/muuli_wdr.cpp:2830
 msgid "Custom URL"
 msgstr "URL personnalisé"
 
-#: src/muuli_wdr.cpp:2826
+#: src/muuli_wdr.cpp:2833
 msgid "Choose which provider supplies the GeoIP MMDB database. DB-IP is the default - no account required. MaxMind requires a free account + license key. Use Custom URL to point at any other MMDB host (e.g. a local mirror)."
 msgstr "Choisissez quel fournisseur procure la base de données GeoIP MMDB. DB-IP est la valeur par défaut - ne nécessite pas de compte. MaxMind nécessite un compte gratuit + une clef de licence. Utilisez un URL personnalisé pour pointer vers tout autre hôte MMDB (par exemple un miroir local)."
 
-#: src/muuli_wdr.cpp:2843
+#: src/muuli_wdr.cpp:2850
 msgid ""
 "No configuration required.\n"
 "\n"
@@ -4818,11 +4832,11 @@ msgstr ""
 "Les données IP vers pays par DB-IP.com - https://db-ip.com\n"
 "Licence : Creative Commons Attribution 4.0 - https://creativecommons.org/licenses/by/4.0/deed.fr"
 
-#: src/muuli_wdr.cpp:2856
+#: src/muuli_wdr.cpp:2863
 msgid "License key:"
 msgstr "Clef de licence :"
 
-#: src/muuli_wdr.cpp:2862
+#: src/muuli_wdr.cpp:2869
 msgid ""
 "Sign up for a free MaxMind account, then generate a License Key:\n"
 "https://www.maxmind.com/en/geolite2/signup\n"
@@ -4838,11 +4852,11 @@ msgstr ""
 "Licence : CLUF MaxMind GeoLite2 - https://www.maxmind.com/en/geolite2/eula\n"
 "Nécessite une attribution et la création d'un compte ; actualisez au moins tous les 30 jours."
 
-#: src/muuli_wdr.cpp:2877
+#: src/muuli_wdr.cpp:2884
 msgid "Download URL:"
 msgstr "URL de téléchargement :"
 
-#: src/muuli_wdr.cpp:2883
+#: src/muuli_wdr.cpp:2890
 msgid ""
 "Must point to an .mmdb file or a .gz / .tar.gz containing one.\n"
 "URL may include credentials (https://user:pass@host/...).\n"
@@ -4852,211 +4866,211 @@ msgstr ""
 "L'URL peut contenir un identifiant et mot de passe (https://utilisateur:motdepasse@hôte/...) \n"
 "La licence et les conditions d'attribution sont définies par l'URL d'origine - vous en êtes responsable."
 
-#: src/muuli_wdr.cpp:2896
+#: src/muuli_wdr.cpp:2903
 msgid "Download the GeoIP database from the selected source."
 msgstr "Télécharger la base de données GeoIP depuis la source sélectionnée."
 
-#: src/muuli_wdr.cpp:2898
+#: src/muuli_wdr.cpp:2905
 msgid "Auto-update on startup"
 msgstr "Mise à jour automatique au démarrage"
 
-#: src/muuli_wdr.cpp:2899
+#: src/muuli_wdr.cpp:2906
 msgid "Re-download the GeoIP database from the selected source every time aMule starts."
 msgstr "Télécharger à nouveau la base de données GeoIP depuis la source sélectionnée chaque fois qu'aMule démarre."
 
-#: src/muuli_wdr.cpp:2922
+#: src/muuli_wdr.cpp:2929
 msgid "Filter incoming messages (except current chat):"
 msgstr "Filtrer les messages entrant (sauf la discussion en cours) :"
 
-#: src/muuli_wdr.cpp:2924
+#: src/muuli_wdr.cpp:2931
 msgid "Filter all messages"
 msgstr "Filtrer tous les messages"
 
-#: src/muuli_wdr.cpp:2926
+#: src/muuli_wdr.cpp:2933
 msgid "Filter messages from people not on your friend list"
 msgstr "Filtrer les messages des gens qui ne sont pas sur votre liste d'amis"
 
-#: src/muuli_wdr.cpp:2928
+#: src/muuli_wdr.cpp:2935
 msgid "Filter messages from unknown clients"
 msgstr "Filtrer les messages des clients inconnus"
 
-#: src/muuli_wdr.cpp:2930
+#: src/muuli_wdr.cpp:2937
 msgid "Filter messages containing (use ',' as separator):"
 msgstr "Filtrer les messages contenant (utiliser ',' comme séparateur) :"
 
-#: src/muuli_wdr.cpp:2933 src/muuli_wdr.cpp:2944
+#: src/muuli_wdr.cpp:2940 src/muuli_wdr.cpp:2951
 msgid "add here the words amule should filter and block messages including it"
 msgstr "ajouter ici les mots qu'aMule doit filtrer : blocage des messages les contenant"
 
-#: src/muuli_wdr.cpp:2935
+#: src/muuli_wdr.cpp:2942
 msgid "Show received messages in the log"
 msgstr "Afficher les messages reçus dans le journal"
 
-#: src/muuli_wdr.cpp:2938
+#: src/muuli_wdr.cpp:2945
 msgid "Comments"
 msgstr "Commentaires"
 
-#: src/muuli_wdr.cpp:2941
+#: src/muuli_wdr.cpp:2948
 msgid "Filter comments containing (use ',' as separator):"
 msgstr "Filtrer les commentaires contenant (utiliser ',' comme séparateur) :"
 
-#: src/muuli_wdr.cpp:2966
+#: src/muuli_wdr.cpp:2973
 msgid "Enable Proxy"
 msgstr "Activer le Proxy"
 
-#: src/muuli_wdr.cpp:2967
+#: src/muuli_wdr.cpp:2974
 msgid "Enable/disable proxy support"
 msgstr "Active/Désactive le support proxy"
 
-#: src/muuli_wdr.cpp:2970
+#: src/muuli_wdr.cpp:2977
 msgid "Proxy type:"
 msgstr "Type de proxy :"
 
-#: src/muuli_wdr.cpp:2981
+#: src/muuli_wdr.cpp:2988
 msgid "Proxy host:"
 msgstr "Hôte du proxy :"
 
-#: src/muuli_wdr.cpp:2984
+#: src/muuli_wdr.cpp:2991
 msgid "The proxy host name"
 msgstr "Nom de l'hôte du proxy"
 
-#: src/muuli_wdr.cpp:2986
+#: src/muuli_wdr.cpp:2993
 msgid "Proxy port:"
 msgstr "Port du proxy :"
 
-#: src/muuli_wdr.cpp:2989
+#: src/muuli_wdr.cpp:2996
 msgid "The proxy port"
 msgstr "Numéro du port du proxy"
 
-#: src/muuli_wdr.cpp:2991
+#: src/muuli_wdr.cpp:2998
 msgid "Enable authentication"
 msgstr "Activer l'authentification"
 
-#: src/muuli_wdr.cpp:2992
+#: src/muuli_wdr.cpp:2999
 msgid "Enable/disable username/password authentication"
 msgstr "Active/Désactive l'authentification par nom d'utilisateur/mot de passe"
 
-#: src/muuli_wdr.cpp:2995
+#: src/muuli_wdr.cpp:3002
 msgid "Username: "
 msgstr "Nom d'utilisateur : "
 
-#: src/muuli_wdr.cpp:2998
+#: src/muuli_wdr.cpp:3005
 msgid "The username to use to connect to the proxy"
 msgstr "Nom d'utilisateur pour se connecter au proxy"
 
-#: src/muuli_wdr.cpp:3000
+#: src/muuli_wdr.cpp:3007
 msgid "Password:"
 msgstr "Mot de passe :"
 
-#: src/muuli_wdr.cpp:3003
+#: src/muuli_wdr.cpp:3010
 msgid "The password to use to connect to the proxy"
 msgstr "Mot de passe pour se connecter au proxy"
 
-#: src/muuli_wdr.cpp:3022
+#: src/muuli_wdr.cpp:3029
 msgid "Connect to:"
 msgstr "Se connecter à :"
 
-#: src/muuli_wdr.cpp:3031
+#: src/muuli_wdr.cpp:3038
 msgid "Login to remote amule"
 msgstr "Connexion distante à aMule"
 
-#: src/muuli_wdr.cpp:3036
+#: src/muuli_wdr.cpp:3043
 msgid "User name"
 msgstr "Nom d'utilisateur"
 
-#: src/muuli_wdr.cpp:3047
+#: src/muuli_wdr.cpp:3054
 msgid "Remember those settings"
 msgstr "Se rappeler de ces réglages"
 
-#: src/muuli_wdr.cpp:3050
+#: src/muuli_wdr.cpp:3057
 msgid "Force ZLIB compression"
 msgstr "Forcer la compression ZLIB"
 
-#: src/muuli_wdr.cpp:3074
+#: src/muuli_wdr.cpp:3081
 msgid "Enable Verbose Debug-Logging."
 msgstr "Activer l'historique du mode de débogage bavard."
 
-#: src/muuli_wdr.cpp:3076
+#: src/muuli_wdr.cpp:3083
 msgid "Only to Logfile"
 msgstr "Seulement vers le fichier journal"
 
-#: src/muuli_wdr.cpp:3078
+#: src/muuli_wdr.cpp:3085
 msgid "Message Categories:"
 msgstr "Catégories des messages :"
 
-#: src/muuli_wdr.cpp:3102 src/PartFileConvertDlg.cpp:160
+#: src/muuli_wdr.cpp:3109 src/PartFileConvertDlg.cpp:160
 msgid "Waiting..."
 msgstr "En attente…"
 
-#: src/muuli_wdr.cpp:3122
+#: src/muuli_wdr.cpp:3129
 msgid "Add imports"
 msgstr "Ajouter des fichiers à importer"
 
-#: src/muuli_wdr.cpp:3125
+#: src/muuli_wdr.cpp:3132
 msgid "Retry selected"
 msgstr "Réessayer avec la sélection"
 
-#: src/muuli_wdr.cpp:3127
+#: src/muuli_wdr.cpp:3134
 msgid "Remove selected"
 msgstr "Supprimer la sélection"
 
-#: src/muuli_wdr.cpp:3190
+#: src/muuli_wdr.cpp:3197
 msgid "Event Types"
 msgstr "Types d'événements"
 
-#: src/muuli_wdr.cpp:3209
+#: src/muuli_wdr.cpp:3216
 msgid "Statistics and queued clients for selected file(s) : Session / All time"
 msgstr "Statistiques et clients en attente pour le(s) fichier(s) sélectionné(s) : Session / Tous les temps"
 
-#: src/muuli_wdr.cpp:3233
+#: src/muuli_wdr.cpp:3240
 msgid "Active Uploads"
 msgstr "Envois Actifs"
 
-#: src/muuli_wdr.cpp:3247
+#: src/muuli_wdr.cpp:3254
 msgid "Percent of total files"
 msgstr "Pourcentage du total de fichiers"
 
-#: src/muuli_wdr.cpp:3299
+#: src/muuli_wdr.cpp:3306
 msgid "Show Clients for"
 msgstr "Afficher les clients pour"
 
-#: src/muuli_wdr.cpp:3301
+#: src/muuli_wdr.cpp:3308
 msgid "All files"
 msgstr "Tous les fichiers"
 
-#: src/muuli_wdr.cpp:3304
+#: src/muuli_wdr.cpp:3311
 msgid "Selected files"
 msgstr "Fichiers sélectionnés"
 
-#: src/muuli_wdr.cpp:3307
+#: src/muuli_wdr.cpp:3314
 msgid "Active uploads only"
 msgstr "Envois actifs seulement"
 
-#: src/muuli_wdr.cpp:3314
+#: src/muuli_wdr.cpp:3321
 msgid "Reload:"
 msgstr "Recharger :"
 
-#: src/muuli_wdr.cpp:3318
+#: src/muuli_wdr.cpp:3325
 msgid "Reload your shared files"
 msgstr "Recharge vos fichiers partagés"
 
-#: src/muuli_wdr.cpp:3381
+#: src/muuli_wdr.cpp:3388
 msgid "Send"
 msgstr "Envoyer"
 
-#: src/muuli_wdr.cpp:3382
+#: src/muuli_wdr.cpp:3389
 msgid "Sends the specified message."
 msgstr "Envoie le message spécifié."
 
-#: src/muuli_wdr.cpp:3386
+#: src/muuli_wdr.cpp:3393
 msgid "Close this chat-session."
 msgstr "Ferme cette session de discussion."
 
-#: src/muuli_wdr.cpp:3409
+#: src/muuli_wdr.cpp:3416
 msgid "Connect to any server and/or Kad"
 msgstr "Se connecter à n'importe quel serveur et/ou Kad"
 
-#: src/muuli_wdr.cpp:3415 src/SharedFilesCtrl.cpp:142 src/Statistics.cpp:941
+#: src/muuli_wdr.cpp:3422 src/SharedFilesCtrl.cpp:142 src/Statistics.cpp:941
 msgid "Shared Files"
 msgstr "Fichiers partagés"
 
@@ -5416,187 +5430,187 @@ msgstr "Téléchargé"
 msgid "ERROR: Failed to open partfile '%s'"
 msgstr "ERREUR : Impossible d'ouvrir fichier .part : '%s'"
 
-#: src/Preferences.cpp:673
+#: src/Preferences.cpp:674
 msgid "System default"
 msgstr "Système par défaut"
 
-#: src/Preferences.cpp:674
+#: src/Preferences.cpp:675
 msgid "Albanian"
 msgstr "Albanais"
 
-#: src/Preferences.cpp:675
+#: src/Preferences.cpp:676
 msgid "Arabic"
 msgstr "Arabe"
 
-#: src/Preferences.cpp:676
+#: src/Preferences.cpp:677
 msgid "Asturian"
 msgstr "Asturien"
 
-#: src/Preferences.cpp:677
+#: src/Preferences.cpp:678
 msgid "Basque"
 msgstr "Basque"
 
-#: src/Preferences.cpp:678
+#: src/Preferences.cpp:679
 msgid "Bulgarian"
 msgstr "Bulgare"
 
-#: src/Preferences.cpp:679
+#: src/Preferences.cpp:680
 msgid "Catalan"
 msgstr "Catalan"
 
-#: src/Preferences.cpp:680
+#: src/Preferences.cpp:681
 msgid "Chinese (Simplified)"
 msgstr "Chinois (Simplifié)"
 
-#: src/Preferences.cpp:681
+#: src/Preferences.cpp:682
 msgid "Chinese (Traditional)"
 msgstr "Chinois (Traditionnel)"
 
-#: src/Preferences.cpp:682
+#: src/Preferences.cpp:683
 msgid "Croatian"
 msgstr "Croate"
 
-#: src/Preferences.cpp:683
+#: src/Preferences.cpp:684
 msgid "Czech"
 msgstr "Tchèque"
 
-#: src/Preferences.cpp:684
+#: src/Preferences.cpp:685
 msgid "Danish"
 msgstr "Danois"
 
-#: src/Preferences.cpp:685
+#: src/Preferences.cpp:686
 msgid "Dutch"
 msgstr "Hollandais"
 
-#: src/Preferences.cpp:686
+#: src/Preferences.cpp:687
 msgid "English (U.K.)"
 msgstr "Anglais (U.K.)"
 
-#: src/Preferences.cpp:687
+#: src/Preferences.cpp:688
 msgid "English (U.S.)"
 msgstr "Anglais (É-U)"
 
-#: src/Preferences.cpp:688
+#: src/Preferences.cpp:689
 msgid "Estonian"
 msgstr "Estonien"
 
-#: src/Preferences.cpp:689
+#: src/Preferences.cpp:690
 msgid "Finnish"
 msgstr "Finlandais"
 
-#: src/Preferences.cpp:690
+#: src/Preferences.cpp:691
 msgid "French"
 msgstr "Français"
 
-#: src/Preferences.cpp:691
+#: src/Preferences.cpp:692
 msgid "Galician"
 msgstr "Galicien"
 
-#: src/Preferences.cpp:692
+#: src/Preferences.cpp:693
 msgid "German"
 msgstr "Allemand"
 
-#: src/Preferences.cpp:693
+#: src/Preferences.cpp:694
 msgid "Greek"
 msgstr "Grec"
 
-#: src/Preferences.cpp:694
+#: src/Preferences.cpp:695
 msgid "Hebrew"
 msgstr "Hébreux"
 
-#: src/Preferences.cpp:695
+#: src/Preferences.cpp:696
 msgid "Hungarian"
 msgstr "Hongrois"
 
-#: src/Preferences.cpp:696
+#: src/Preferences.cpp:697
 msgid "Italian"
 msgstr "Italien"
 
-#: src/Preferences.cpp:697
+#: src/Preferences.cpp:698
 msgid "Japanese"
 msgstr "Japonais"
 
-#: src/Preferences.cpp:698
+#: src/Preferences.cpp:699
 msgid "Korean"
 msgstr "Coréen"
 
-#: src/Preferences.cpp:699
+#: src/Preferences.cpp:700
 msgid "Latvian"
 msgstr "Letton"
 
-#: src/Preferences.cpp:700
+#: src/Preferences.cpp:701
 msgid "Lithuanian"
 msgstr "Lituanien"
 
-#: src/Preferences.cpp:701
+#: src/Preferences.cpp:702
 msgid "Norwegian (Nynorsk)"
 msgstr "Norvégien (Nynorsk)"
 
-#: src/Preferences.cpp:702
+#: src/Preferences.cpp:703
 msgid "Polish"
 msgstr "Polonais"
 
-#: src/Preferences.cpp:703
+#: src/Preferences.cpp:704
 msgid "Portuguese"
 msgstr "Portugais"
 
-#: src/Preferences.cpp:704
+#: src/Preferences.cpp:705
 msgid "Portuguese (Brazilian)"
 msgstr "Portugais (Brésilien)"
 
-#: src/Preferences.cpp:705
+#: src/Preferences.cpp:706
 msgid "Romanian"
 msgstr "Roumain"
 
-#: src/Preferences.cpp:706
+#: src/Preferences.cpp:707
 msgid "Russian"
 msgstr "Russe"
 
-#: src/Preferences.cpp:707
+#: src/Preferences.cpp:708
 msgid "Slovenian"
 msgstr "Slovène"
 
-#: src/Preferences.cpp:708
+#: src/Preferences.cpp:709
 msgid "Spanish"
 msgstr "Espagnol"
 
-#: src/Preferences.cpp:709
+#: src/Preferences.cpp:710
 msgid "Swedish"
 msgstr "Suédois"
 
-#: src/Preferences.cpp:710
+#: src/Preferences.cpp:711
 msgid "Turkish"
 msgstr "Turc"
 
-#: src/Preferences.cpp:711
+#: src/Preferences.cpp:712
 msgid "Ukrainian"
 msgstr "Ukrainien"
 
-#: src/Preferences.cpp:814
+#: src/Preferences.cpp:815
 msgid "Change Language"
 msgstr "Changer de langue"
 
-#: src/Preferences.cpp:878
+#: src/Preferences.cpp:879
 msgid "There are no translations installed for aMule"
 msgstr "Il n'y a pas de traductions installées pour aMule"
 
-#: src/Preferences.cpp:879
+#: src/Preferences.cpp:880
 msgid "No languages available"
 msgstr "Pas de langues disponibles"
 
-#: src/Preferences.cpp:1010
+#: src/Preferences.cpp:1011
 msgid "no options available"
 msgstr "pas d'option disponible"
 
-#: src/Preferences.cpp:2179
+#: src/Preferences.cpp:2182
 msgid "Invalid category found, skipping"
 msgstr "Catégorie invalide trouvée, on passe"
 
-#: src/Preferences.cpp:2348
+#: src/Preferences.cpp:2351
 msgid "TCP port can't be higher than 65532 due to server UDP socket being TCP+3"
 msgstr "Le port TCP ne peut pas dépasser 65532 car le socket UDP du serveur sera à TCP+3"
 
-#: src/Preferences.cpp:2349
+#: src/Preferences.cpp:2352
 #, c-format
 msgid "Default port will be used (%d)"
 msgstr "Le port par défaut sera utilisé (%d)"
@@ -6097,23 +6111,27 @@ msgstr "Rechargement des fichiers partagés : %u fichiers analysés"
 msgid "Shared folder"
 msgstr "Dossier partagé"
 
-#: src/SearchDlg.cpp:425
+#: src/SearchDlg.cpp:280
+msgid "Clear search history"
+msgstr ""
+
+#: src/SearchDlg.cpp:584
 msgid "It's impossible to search when both eD2k and Kademlia are disabled."
 msgstr "Lorsque eD2k et Kademlia sont désactivés tous les deux, il est impossible d'effectuer une recherche."
 
-#: src/SearchDlg.cpp:426 src/SearchListCtrl.cpp:858
+#: src/SearchDlg.cpp:585 src/SearchListCtrl.cpp:858
 msgid "Search error"
 msgstr "Erreur de recherche"
 
-#: src/SearchDlg.cpp:768
+#: src/SearchDlg.cpp:929
 msgid "Min size must be smaller than max size. Max size ignored."
 msgstr "La taille minimum doit être inférieur à la taille maximum. Taille maximum ignorée."
 
-#: src/SearchDlg.cpp:769 src/SearchDlg.cpp:851
+#: src/SearchDlg.cpp:930 src/SearchDlg.cpp:1012
 msgid "Search warning"
 msgstr "Avertissement dans la recherche"
 
-#: src/SearchDlg.cpp:929 src/SearchListCtrl.cpp:735
+#: src/SearchDlg.cpp:1092 src/SearchListCtrl.cpp:735
 msgid "Main"
 msgstr "Principal"
 

--- a/po/fr.po
+++ b/po/fr.po
@@ -15,8 +15,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-28 12:12+0200\n"
-"PO-Revision-Date: 2026-07-27 10:22+0000\n"
+"POT-Creation-Date: 2026-07-28 08:06+0200\n"
+"PO-Revision-Date: 2026-07-27 11:38+0000\n"
 "Last-Translator: Dylan Aïssi <bob.dybian@gmail.com>\n"
 "Language-Team: Français\n"
 "Language: fr\n"
@@ -149,7 +149,7 @@ msgstr "Installer"
 msgid "Not now"
 msgstr "Pas maintenant"
 
-#: src/AppImageIntegration.cpp:422 src/amuleDlg.cpp:665
+#: src/AppImageIntegration.cpp:422 src/amuleDlg.cpp:600
 msgid "Don't ask again"
 msgstr "Ne plus me demander"
 
@@ -211,83 +211,83 @@ msgstr "Échec de l'ouverture du fichier ED2KLinks."
 msgid "WARNING: You can't add yourself as a source for an eD2k link while having a lowid."
 msgstr "AVERTISSEMENT : Vous ne pouvez pas vous ajouter vous-même en tant que source pour un lien eD2k alors que vous avez un LowID."
 
-#: src/amule.cpp:301
+#: src/amule.cpp:300
 msgid "Now, exiting main app..."
 msgstr "Et maintenant on quitte l'application principale…"
 
-#: src/amule.cpp:331
+#: src/amule.cpp:330
 #, c-format
 msgid "Terminating amuleweb instance with pid '%d' ... "
 msgstr "Interruption de l'instance amuleweb avec le pid '%d' … "
 
-#: src/amule.cpp:335
+#: src/amule.cpp:334
 #, c-format
 msgid "Killing amuleweb instance with pid '%d' ... "
 msgstr "Mise à mort de l'instance amuleweb avec le pid '%d' … "
 
-#: src/amule.cpp:337 src/amule.cpp:350 src/ClientRef.cpp:180
-#: src/SearchDlg.cpp:1041 src/ServerListCtrl.cpp:98
+#: src/amule.cpp:336 src/amule.cpp:349 src/ClientRef.cpp:180
+#: src/SearchDlg.cpp:880 src/ServerListCtrl.cpp:98
 msgid "Failed"
 msgstr "Échec"
 
-#: src/amule.cpp:344
+#: src/amule.cpp:343
 #, c-format
 msgid "Terminating amuleapi instance with pid '%d' ... "
 msgstr "Interruption de l'instance amuleapi avec le pid '%d'… "
 
-#: src/amule.cpp:348
+#: src/amule.cpp:347
 #, c-format
 msgid "Killing amuleapi instance with pid '%d' ... "
 msgstr "Arrêt de l'instance amuleapi avec le pid '%d'… "
 
-#: src/amule.cpp:356
+#: src/amule.cpp:355
 msgid "aMule OnExit: Terminating core."
 msgstr "aMule OnExit : Arrêt du noyau."
 
-#: src/amule.cpp:467
+#: src/amule.cpp:466
 msgid "aMule shutdown completed."
 msgstr "Fermeture d'aMule terminée."
 
-#: src/amule.cpp:471
+#: src/amule.cpp:470
 msgid "Memory debug results for aMule exit:"
 msgstr "Résultats du débogage de la mémoire pour la sortie d'aMule :"
 
-#: src/amule.cpp:652
+#: src/amule.cpp:651
 #, c-format
 msgid "Binding aMule's peer-to-peer traffic to interface: %s (HTTP updates use the default route)"
 msgstr "Liaison du trafic pair à pair d'aMule à l'interface : %s (les mises à jour HTTP utilisent le chemin par défaut)"
 
-#: src/amule.cpp:656
+#: src/amule.cpp:655
 #, c-format
 msgid "Binding all network traffic to interface: %s"
 msgstr "Rattacher tout le trafic réseau à l'interface : %s"
 
-#: src/amule.cpp:660
+#: src/amule.cpp:659
 #, c-format
 msgid "WARNING: configured network interface '%s' was not found - traffic is NOT bound to it and may leave via the default route. Check the interface name in Preferences."
 msgstr "AVERTISSEMENT : l'interface réseau configurée '%s' n'a pu être trouvé - le trafic ne lui est PAS lié et peut partir sur le chemin par défaut. Vérifiez le nom de l'interface dans les Préférences."
 
-#: src/amule.cpp:666
+#: src/amule.cpp:665
 #, c-format
 msgid "WARNING: binding to network interface '%s' requires elevated privileges and was NOT applied - traffic may leave via the default route. Grant the capability (e.g. 'sudo setcap cap_net_raw+ep' on the aMule binary) or run with sufficient privileges."
 msgstr "AVERTISSEMENT : la liaison à l'interface réseau '%s' nécessite des privilèges élevés et n'a PAS été appliquée - le trafic peut emprunter le chemin par défaut. Attribuez la capacité (par exemple 'sudo setcap cap_net_raw+ep' sur le binaire aMule) ou exécutez avec des privilèges suffisants."
 
-#: src/amule.cpp:674
+#: src/amule.cpp:673
 #, c-format
 msgid "WARNING: could not bind to network interface '%s' - traffic may leave via the default route."
 msgstr "AVERTISSEMENT : impossible de lier à l'interface réseau '%s' - le trafic peut emprunter le chemin par défaut."
 
-#: src/amule.cpp:733
+#: src/amule.cpp:732
 msgid "Your locale has been changed to System Default due to a configuration change. Sorry."
 msgstr "Votre localisation a été remise à la valeur par défaut à cause d'un changement dans la configuration. Désolé."
 
-#: src/amule.cpp:735 src/amule.cpp:1589 src/CatDialog.cpp:128
+#: src/amule.cpp:734 src/amule.cpp:1581 src/CatDialog.cpp:128
 #: src/CatDialog.cpp:136 src/CatDialog.cpp:149 src/ServerList.cpp:366
 #: src/ServerListCtrl.cpp:152
 msgid "Info"
 msgstr "Infos"
 
-#: src/amule.cpp:742
+#: src/amule.cpp:741
 msgid ""
 "\n"
 "EC configuration"
@@ -295,21 +295,21 @@ msgstr ""
 "\n"
 "Configuration EC"
 
-#: src/amule.cpp:745
+#: src/amule.cpp:744
 msgid "Password set and external connections enabled."
 msgstr "Mot de passe renseigné et connexions externes activées."
 
-#: src/amule.cpp:755 src/KadDlg.cpp:176 src/KadDlg.cpp:185
-#: src/PrefsUnifiedDlg.cpp:1461 src/SharedFilesCtrl.cpp:476
+#: src/amule.cpp:754 src/KadDlg.cpp:176 src/KadDlg.cpp:185
+#: src/PrefsUnifiedDlg.cpp:1387 src/SharedFilesCtrl.cpp:476
 msgid "WARNING"
 msgstr "AVERTISSEMENT"
 
 # AI-GENERATED — please review.
-#: src/amule.cpp:992
+#: src/amule.cpp:991
 msgid "Network bootstrap"
 msgstr "Amorçage de réseau"
 
-#: src/amule.cpp:997
+#: src/amule.cpp:996
 msgid ""
 "aMule has detected missing network bootstrap files.\n"
 "Select which ones to download:"
@@ -317,51 +317,51 @@ msgstr ""
 "aMule a détecté des fichiers d'amorçage de réseau manquants.\n"
 "Sélectionnez ceux à télécharger :"
 
-#: src/amule.cpp:1006 src/FirstRunWizard.cpp:411
+#: src/amule.cpp:1005 src/FirstRunWizard.cpp:411
 msgid "eD2k server list (server.met)"
 msgstr "Liste de serveurs eD2k (server.met)"
 
-#: src/amule.cpp:1013 src/FirstRunWizard.cpp:416
+#: src/amule.cpp:1012 src/FirstRunWizard.cpp:416
 msgid "Kad bootstrap nodes (nodes.dat)"
 msgstr "Nœuds d'amorçage Kad (nodes.dat)"
 
-#: src/amule.cpp:1103
+#: src/amule.cpp:1102
 #, c-format
 msgid "web server running on pid %d"
 msgstr "serveur web s'exécutant avec le pid %d"
 
-#: src/amule.cpp:1116
+#: src/amule.cpp:1115
 msgid "You requested to run web server on startup, but the amuleweb binary cannot be run. Please install the package containing aMule web server, or build aMule from source with -DBUILD_WEBSERVER=YES and install it."
 msgstr "Vous avez demandé à exécuter le serveur web au démarrage, mais le binaire amuleweb ne peut être exécuté. Veuillez installer le paquet contenant le serveur web aMule, ou compilez aMule depuis le code source avec -DBUILD_WEBSERVER=YES et installez-le."
 
-#: src/amule.cpp:1121 src/amule.cpp:1185 src/amule.cpp:1299 src/amule.cpp:1601
+#: src/amule.cpp:1120 src/amule.cpp:1177 src/amule.cpp:1291 src/amule.cpp:1593
 #: src/amule-remote-gui.cpp:603 src/amule-remote-gui.cpp:671
 #: src/amule-remote-gui.cpp:709 src/amule-remote-gui.cpp:1282
 #: src/amule-remote-gui.cpp:1345 src/amule-remote-gui.cpp:1372
-#: src/DownloadQueue.cpp:1481 src/PrefsUnifiedDlg.cpp:1247
+#: src/DownloadQueue.cpp:1481
 msgid "ERROR"
 msgstr "ERREUR"
 
-#: src/amule.cpp:1174
+#: src/amule.cpp:1166
 #, c-format
 msgid "amuleapi running on pid %d"
 msgstr "amuleapi s'exécutant avec le pid %d"
 
-#: src/amule.cpp:1180
+#: src/amule.cpp:1172
 msgid "You requested to run amuleapi on startup, but the amuleapi binary cannot be run. Please install the package containing aMule's REST API server, or build aMule from source with -DBUILD_AMULEAPI=YES and install it."
 msgstr "Vous avez demandé à exécuter amuleapi au démarrage, mais le binaire amuleapi ne peut être exécuté. Veuillez installer le paquet contenant le serveur API RESTd'aMule, ou compilez aMule depuis le code source avec -DBUILD_AMULEAPI=YES et installez-le."
 
-#: src/amule.cpp:1267
+#: src/amule.cpp:1259
 #, c-format
 msgid "Could not bind ports to the specified address: %s"
 msgstr "Impossible de lier les ports à l'adresse spécifiée : %s"
 
-#: src/amule.cpp:1291
+#: src/amule.cpp:1283
 #, c-format
 msgid "Port %u is not available. You will be LOWID\n"
 msgstr "Le port %u n'est pas disponible. Vous serez LowID\n"
 
-#: src/amule.cpp:1296
+#: src/amule.cpp:1288
 #, c-format
 msgid ""
 "Port %u is not available!\n"
@@ -376,48 +376,48 @@ msgstr ""
 "\n"
 "Vérifiez votre réseau pour être sûr que le port est ouvert en sortie et en entrée."
 
-#: src/amule.cpp:1393
+#: src/amule.cpp:1385
 msgid "Failed to create OnlineSig File"
 msgstr "Échec de la création du fichier OnlineSig"
 
-#: src/amule.cpp:1401
+#: src/amule.cpp:1393
 msgid "Failed to create aMule OnlineSig File"
 msgstr "Échec de la création du fichier aMule OnlineSig"
 
-#: src/amule.cpp:1564
+#: src/amule.cpp:1556
 msgid "The selected locale seems not to be installed on your box. (Note: I'll try to set it anyway)"
 msgstr "La localisation choisie semble ne pas être installée sur votre machine. (Note : Je tente de la forcer quand même)"
 
-#: src/amule.cpp:1574
+#: src/amule.cpp:1566
 #, c-format
 msgid "This is the first time you run aMule %s"
 msgstr "C'est la première fois que vous lancez aMule %s"
 
-#: src/amule.cpp:1577
+#: src/amule.cpp:1569
 msgid "This version is a testing version, updated daily, and\n"
 msgstr "Cette version est une version de test, mise à jour quotidiennement, et\n"
 
-#: src/amule.cpp:1578
+#: src/amule.cpp:1570
 msgid "we give no warranty it won't break anything, burn your house,\n"
 msgstr "nous ne fournissons aucune garantie que cela n'endommagera rien, brûlera votre maison,\n"
 
-#: src/amule.cpp:1579
+#: src/amule.cpp:1571
 msgid "or kill your dog. But it *should* be safe to use anyway.\n"
 msgstr "ou tuera votre chien. Mais ça *devrait* être à peu près sûr quand-même.\n"
 
-#: src/amule.cpp:1584
+#: src/amule.cpp:1576
 msgid "More information, support and new releases can found at our homepage,\n"
 msgstr "Plus d'informations, de l'aide et de nouvelles versions peuvent être trouvées sur notre page web,\n"
 
-#: src/amule.cpp:1585
+#: src/amule.cpp:1577
 msgid "at https://amule-org.github.io, or in our IRC channel #aMule at irc.libera.chat.\n"
 msgstr "https://amule-org.github.io, ou sur notre canal IRC : #aMule sur irc.libera.chat.\n"
 
-#: src/amule.cpp:1587
+#: src/amule.cpp:1579
 msgid "Feel free to report any bugs to https://github.com/amule-org/amule/issues"
 msgstr "Ne vous gênez pas pour reporter tout bogue sur https://github.com/amule-org/amule/issues"
 
-#: src/amule.cpp:1599
+#: src/amule.cpp:1591
 msgid ""
 "The folder for Online Signature files you specified is INVALID!\n"
 " OnlineSignature will be DISABLED until you fix it on preferences."
@@ -425,137 +425,137 @@ msgstr ""
 "Le répertoire choisi pour les fichiers de signature en ligne est INVALIDE !\n"
 "La signature en ligne sera DÉSACTIVÉE jusqu'à ce que cela soit corrigé dans les préférences."
 
-#: src/amule.cpp:1662
+#: src/amule.cpp:1654
 msgid "Server hostname notified"
 msgstr "Nom du serveur signalé"
 
-#: src/amule.cpp:2039
+#: src/amule.cpp:2031
 #, c-format
 msgid "Disk space preallocation for file '%s' failed: %s"
 msgstr "Erreur lors de la réserve d'espace pour le fichier '%s' : %s"
 
-#: src/amule.cpp:2168
+#: src/amule.cpp:2160
 msgid "ERROR: can't open logfile"
 msgstr "ERREUR : impossible d'ouvrir le fichier journal"
 
-#: src/amule.cpp:2172
+#: src/amule.cpp:2164
 msgid "WARNING: logfile is empty. Something is wrong."
 msgstr "AVERTISSEMENT : le fichier journal est vide. Quelque chose ne va pas."
 
-#: src/amule.cpp:2189
+#: src/amule.cpp:2181
 msgid "Log has been reset"
 msgstr "Le journal a été effacé"
 
-#: src/amule.cpp:2213
+#: src/amule.cpp:2205
 #, c-format
 msgid "ServerMessage: %s"
 msgstr "ServerMessage : %s"
 
-#: src/amule.cpp:2256 src/IP2Country.cpp:220 src/IPFilter.cpp:514
+#: src/amule.cpp:2248 src/IP2Country.cpp:220 src/IPFilter.cpp:514
 #: src/ServerList.cpp:875
 #, c-format
 msgid "Skipped download of %s, because requested file is not newer."
 msgstr "Saut du téléchargement de %s, car le fichier demandé n'est pas récent."
 
-#: src/amule.cpp:2259
+#: src/amule.cpp:2251
 msgid "Failed to download the nodes list."
 msgstr "Échec du téléchargement de la liste des nœuds."
 
-#: src/amule.cpp:2322
+#: src/amule.cpp:2314
 msgid "Failed to open the downloaded version check file"
 msgstr "Échec de l'ouverture du fichier de vérification de version téléchargé"
 
-#: src/amule.cpp:2325 src/amule.cpp:2344
+#: src/amule.cpp:2317 src/amule.cpp:2336
 msgid "Corrupted version check file"
 msgstr "Fichier de vérification de version corrompu"
 
-#: src/amule.cpp:2367
+#: src/amule.cpp:2359
 msgid "You are using an outdated version of aMule!"
 msgstr "Vous utilisez une version obsolète d'aMule !"
 
-#: src/amule.cpp:2369
+#: src/amule.cpp:2361
 #, c-format
 msgid "Your aMule version is %i.%i.%i and the latest version is %li.%li.%li"
 msgstr "Votre version d'aMule est %i.%i.%i et la dernière version est %li.%li.%li"
 
-#: src/amule.cpp:2373
+#: src/amule.cpp:2365
 msgid "The latest version can always be found at https://github.com/amule-org/amule/releases/latest"
 msgstr "La dernière version peut toujours être trouvée sur https://github.com/amule-org/amule/releases/latest"
 
-#: src/amule.cpp:2376
+#: src/amule.cpp:2368
 #, c-format
 msgid "WARNING: Your aMuled version is outdated: %i.%i.%i < %li.%li.%li"
 msgstr "AVERTISSEMENT : votre version d'aMuled est obsolète : %i.%i.%i < %li.%li.%li"
 
-#: src/amule.cpp:2382
+#: src/amule.cpp:2374
 msgid "Your copy of aMule is up to date."
 msgstr "Votre version d'aMule est à jour."
 
-#: src/amule.cpp:2389
+#: src/amule.cpp:2381
 msgid "Failed to download the version check file"
 msgstr "Échec du téléchargement du fichier de vérification de version"
 
-#: src/amule.cpp:2558 src/amule-remote-gui.cpp:1133
+#: src/amule.cpp:2550 src/amule-remote-gui.cpp:1133
 #, c-format
 msgid "Users: %s | Files: %s"
 msgstr "Utilisateurs : %s | Fichiers : %s"
 
-#: src/amule.cpp:2559 src/amule-remote-gui.cpp:1134
+#: src/amule.cpp:2551 src/amule-remote-gui.cpp:1134
 #, c-format
 msgid "Users: E: %s K: %s | Files: E: %s K: %s"
 msgstr "Utilisateurs : E : %s K : %s | Fichiers : E : %s K : %s"
 
-#: src/amule.cpp:2573 src/amule-remote-gui.cpp:1147
+#: src/amule.cpp:2565 src/amule-remote-gui.cpp:1147
 msgid "No networks selected"
 msgstr "Aucun réseau sélectionné"
 
-#: src/amule.cpp:2641 src/TextClient.cpp:903
+#: src/amule.cpp:2633 src/TextClient.cpp:903
 msgid "with LowID"
 msgstr "avec un LowID"
 
-#: src/amule.cpp:2641 src/TextClient.cpp:904
+#: src/amule.cpp:2633 src/TextClient.cpp:904
 msgid "with HighID"
 msgstr "avec un HighID"
 
-#: src/amule.cpp:2643
+#: src/amule.cpp:2635
 #, c-format
 msgid "Connected to %s %s"
 msgstr "Connecté à %s %s"
 
-#: src/amule.cpp:2648
+#: src/amule.cpp:2640
 #, c-format
 msgid "Connecting to %s"
 msgstr "Connexion à %s"
 
-#: src/amule.cpp:2650
+#: src/amule.cpp:2642
 msgid "Disconnected from eD2k"
 msgstr "Déconnecté de eD2k"
 
-#: src/amule.cpp:2659
+#: src/amule.cpp:2651
 msgid "Kad started."
 msgstr "Kad démarré."
 
-#: src/amule.cpp:2661
+#: src/amule.cpp:2653
 msgid "Kad stopped."
 msgstr "Kad arrêté."
 
-#: src/amule.cpp:2669
+#: src/amule.cpp:2661
 msgid "Connected to Kad (ok)"
 msgstr "Connecté à Kad (OK)"
 
-#: src/amule.cpp:2671
+#: src/amule.cpp:2663
 msgid "Connected to Kad (firewalled)"
 msgstr "Connecté à Kad (pare-feu)"
 
-#: src/amule.cpp:2675
+#: src/amule.cpp:2667
 msgid "Disconnected from Kad"
 msgstr "Déconnecté de Kad"
 
-#: src/amule.cpp:2707
+#: src/amule.cpp:2699
 msgid "Kad network cannot be used if UDP port is disabled on preferences, not starting."
 msgstr "Le réseau Kad ne peut être utilisé si le port UDP est désactivé dans les préférences, pas de démarrage."
 
-#: src/amule.cpp:2711
+#: src/amule.cpp:2703
 msgid "Kad network disabled on preferences, not connecting."
 msgstr "Le réseau Kad est désactivé dans les préférences, pas de connexion."
 
@@ -580,67 +580,29 @@ msgstr "Impossible de créer le fichier Pid"
 msgid "ERROR: %s"
 msgstr "Erreur : %s"
 
-#: src/amuleDlg.cpp:250
+#: src/amuleDlg.cpp:236
 #, c-format
 msgid "This is aMule %s based on eMule."
 msgstr "Ceci est aMule %s basé sur eMule."
 
-#: src/amuleDlg.cpp:251
+#: src/amuleDlg.cpp:237
 #, c-format
 msgid "Running on %s"
 msgstr "Tourne sur %s"
 
-#: src/amuleDlg.cpp:253
+#: src/amuleDlg.cpp:239
 msgid "Visit https://github.com/amule-org/amule/releases/latest to check if a new version is available."
 msgstr "Visitez https://github.com/amule-org/amule/releases/latest pour vérifier si une nouvelle version est disponible."
 
-#: src/amuleDlg.cpp:282
+#: src/amuleDlg.cpp:268
 msgid "FATAL ERROR: Failed to create Timer"
 msgstr "ERREUR FATALE : Échec de la création du minuteur"
 
-#: src/amuleDlg.cpp:361 src/amuleDlg.cpp:1810 src/amuleDlg.cpp:2056
-#: src/muuli_wdr.cpp:1492 src/muuli_wdr.cpp:3439
-msgid "Networks"
-msgstr "Réseaux"
-
-#: src/amuleDlg.cpp:362 src/amuleDlg.cpp:1816 src/muuli_wdr.cpp:3440
-msgid "Searches"
-msgstr "Recherches"
-
-#: src/amuleDlg.cpp:363 src/amuleDlg.cpp:1822 src/DownloadListCtrl.cpp:740
-#: src/muuli_wdr.cpp:392 src/muuli_wdr.cpp:1585 src/muuli_wdr.cpp:3441
-#: src/Statistics.cpp:829
-msgid "Downloads"
-msgstr "Téléchargements"
-
-#: src/amuleDlg.cpp:364 src/amuleDlg.cpp:1828 src/muuli_wdr.cpp:3315
-msgid "Shared files"
-msgstr "Fichiers partagés"
-
-#: src/amuleDlg.cpp:365 src/amuleDlg.cpp:1834 src/muuli_wdr.cpp:2947
-#: src/muuli_wdr.cpp:3397 src/muuli_wdr.cpp:3444
-msgid "Messages"
-msgstr "Messages"
-
-#: src/amuleDlg.cpp:366 src/amuleDlg.cpp:1840 src/muuli_wdr.cpp:3445
-#: src/PrefsUnifiedDlg.cpp:314 src/Statistics.cpp:779 src/Statistics.cpp:1235
-msgid "Statistics"
-msgstr "Statistiques"
-
-#: src/amuleDlg.cpp:368 src/amuleDlg.cpp:1847 src/muuli_wdr.cpp:3447
-#: src/PrefsUnifiedDlg.cpp:330 src/utils/wxCas/src/wxcasprefs.cpp:39
-msgid "Preferences"
-msgstr "Préférences"
-
-#: src/amuleDlg.cpp:371
-msgid "Navigate"
-msgstr ""
-
-#: src/amuleDlg.cpp:657
+#: src/amuleDlg.cpp:592
 msgid "New version available"
 msgstr "Une nouvelle version est disponible"
 
-#: src/amuleDlg.cpp:661
+#: src/amuleDlg.cpp:596
 #, c-format
 msgid ""
 "A new version of aMule (%s) is available.\n"
@@ -655,184 +617,217 @@ msgstr ""
 "\n"
 "Souhaiteriez-vous ouvrir la page de téléchargement ?"
 
-#: src/amuleDlg.cpp:743
+#: src/amuleDlg.cpp:678
 msgid "aMule dialog destroyed"
 msgstr "boîte de dialogue aMule détruite"
 
-#: src/amuleDlg.cpp:766 src/DataToText.cpp:68 src/IPFilter.cpp:547
+#: src/amuleDlg.cpp:701 src/DataToText.cpp:68 src/IPFilter.cpp:547
 msgid "Connecting"
 msgstr "Connexion en cours"
 
-#: src/amuleDlg.cpp:958
+#: src/amuleDlg.cpp:893
 msgid "eD2k: Connecting"
 msgstr "eD2k : Connexion en cours"
 
-#: src/amuleDlg.cpp:962
+#: src/amuleDlg.cpp:897
 msgid "eD2k: Disconnected"
 msgstr "eD2k : Déconnecté"
 
-#: src/amuleDlg.cpp:968
+#: src/amuleDlg.cpp:903
 msgid "Kad: Firewalled"
 msgstr "Kad : Derrière un pare-feu"
 
-#: src/amuleDlg.cpp:972
+#: src/amuleDlg.cpp:907
 msgid "Kad: Connected"
 msgstr "Kad : Connecté"
 
-#: src/amuleDlg.cpp:977
+#: src/amuleDlg.cpp:912
 msgid "Kad: Connecting"
 msgstr "Kad : Connexion en cours"
 
-#: src/amuleDlg.cpp:981
+#: src/amuleDlg.cpp:916
 msgid "Kad: Off"
 msgstr "Kad : Coupé"
 
-#: src/amuleDlg.cpp:1029 src/DownloadListCtrl.cpp:505
+#: src/amuleDlg.cpp:964 src/DownloadListCtrl.cpp:505
 #: src/DownloadListCtrl.cpp:749 src/FriendListCtrl.cpp:180
 #: src/muuli_wdr.cpp:731 src/muuli_wdr.cpp:782 src/muuli_wdr.cpp:846
-#: src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2252 src/muuli_wdr.cpp:2337
-#: src/muuli_wdr.cpp:3085 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
+#: src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2224 src/muuli_wdr.cpp:2309
+#: src/muuli_wdr.cpp:3057 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
 #: src/ServerListCtrl.cpp:606 src/TransferWnd.cpp:378
 #: src/utils/wxCas/src/wxcasprefs.cpp:235
 msgid "Cancel"
 msgstr "Annuler"
 
-#: src/amuleDlg.cpp:1030
+#: src/amuleDlg.cpp:965
 msgid "Stop the current connection attempts"
 msgstr "Stopper les essais de connexions en cours"
 
-#: src/amuleDlg.cpp:1035 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976
-#: src/muuli_wdr.cpp:2475
+#: src/amuleDlg.cpp:970 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976
+#: src/muuli_wdr.cpp:2447
 msgid "Disconnect"
 msgstr "Déconnecter"
 
-#: src/amuleDlg.cpp:1036
+#: src/amuleDlg.cpp:971
 msgid "Disconnect from the currently connected networks"
 msgstr "Se déconnecter des réseaux actuellement connectés"
 
-#: src/amuleDlg.cpp:1041 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979
-#: src/muuli_wdr.cpp:2630 src/muuli_wdr.cpp:3082 src/muuli_wdr.cpp:3437
+#: src/amuleDlg.cpp:976 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979
+#: src/muuli_wdr.cpp:2602 src/muuli_wdr.cpp:3054 src/muuli_wdr.cpp:3409
 msgid "Connect"
 msgstr "Se connecter"
 
-#: src/amuleDlg.cpp:1042
+#: src/amuleDlg.cpp:977
 msgid "Connect to the currently enabled networks"
 msgstr "Se connecter aux réseaux actuellement activés"
 
-#: src/amuleDlg.cpp:1154
+#: src/amuleDlg.cpp:1089
 #, c-format
 msgid "Up: %.1f%s (%.1f) | Down: %.1f%s (%.1f)"
 msgstr "E : %.1f%s (%.1f) | R : %.1f%s (%.1f)"
 
-#: src/amuleDlg.cpp:1156 src/amuleDlg.cpp:1158 src/amuleDlg.cpp:1162
-#: src/amuleDlg.cpp:1164 src/amuleDlg.cpp:1175 src/amuleDlg.cpp:1177
+#: src/amuleDlg.cpp:1091 src/amuleDlg.cpp:1093 src/amuleDlg.cpp:1097
+#: src/amuleDlg.cpp:1099 src/amuleDlg.cpp:1110 src/amuleDlg.cpp:1112
 #: src/MuleTrayIcon.cpp:796 src/MuleTrayIcon.cpp:799
 msgid " MB/s"
 msgstr " Mo/s"
 
-#: src/amuleDlg.cpp:1156 src/amuleDlg.cpp:1158 src/amuleDlg.cpp:1162
-#: src/amuleDlg.cpp:1164 src/amuleDlg.cpp:1175 src/amuleDlg.cpp:1177
+#: src/amuleDlg.cpp:1091 src/amuleDlg.cpp:1093 src/amuleDlg.cpp:1097
+#: src/amuleDlg.cpp:1099 src/amuleDlg.cpp:1110 src/amuleDlg.cpp:1112
 #: src/MuleTrayIcon.cpp:796 src/MuleTrayIcon.cpp:799
 #: src/utils/wxCas/src/wxcasframe.cpp:1041
 msgid " kB/s"
 msgstr " Ko/s"
 
-#: src/amuleDlg.cpp:1161
+#: src/amuleDlg.cpp:1096
 #, c-format
 msgid "Up: %.1f%s | Down: %.1f%s"
 msgstr "E : %.1f%s | R : %.1f%s"
 
-#: src/amuleDlg.cpp:1193
+#: src/amuleDlg.cpp:1128
 #, c-format
 msgid "aMule (%s | Connected)"
 msgstr "aMule (%s | Connecté)"
 
-#: src/amuleDlg.cpp:1195
+#: src/amuleDlg.cpp:1130
 #, c-format
 msgid "aMule (%s | Disconnected)"
 msgstr "aMule (%s | Déconnecté)"
 
-#: src/amuleDlg.cpp:1248
+#: src/amuleDlg.cpp:1183
 #, c-format
 msgid "Do you really want to exit %s?"
 msgstr "Voulez-vous vraiment quitter %s ?"
 
-#: src/amuleDlg.cpp:1250
+#: src/amuleDlg.cpp:1185
 msgid "Exit confirmation"
 msgstr "Confirmation de sortie"
 
-#: src/amuleDlg.cpp:1613
+#: src/amuleDlg.cpp:1548
 msgid "Launch Command: "
 msgstr "Commande de lancement : "
 
-#: src/amuleDlg.cpp:1632 src/muuli_wdr.cpp:1972 src/Preferences.cpp:979
+#: src/amuleDlg.cpp:1567 src/muuli_wdr.cpp:1971 src/Preferences.cpp:951
 msgid "- default -"
 msgstr "- défaut -"
 
-#: src/amuleDlg.cpp:1660
+#: src/amuleDlg.cpp:1595
 #, c-format
 msgid "Skin directory '%s' does not exist"
 msgstr "Le répertoire de thèmes '%s' n'existe pas"
 
-#: src/amuleDlg.cpp:1663
+#: src/amuleDlg.cpp:1598
 #, c-format
 msgid "WARNING: Unable to open skin file '%s' for read"
 msgstr "AVERTISSEMENT : Impossible d'ouvrir le fichier thème '%s' pour la lecture"
 
-#: src/amuleDlg.cpp:1814 src/muuli_wdr.cpp:3439
+#: src/amuleDlg.cpp:1722 src/amuleDlg.cpp:1968 src/muuli_wdr.cpp:1485
+#: src/muuli_wdr.cpp:3411
+msgid "Networks"
+msgstr "Réseaux"
+
+#: src/amuleDlg.cpp:1726 src/muuli_wdr.cpp:3411
 msgid "Networks Window"
 msgstr "Fenêtre des réseaux"
 
-#: src/amuleDlg.cpp:1820 src/muuli_wdr.cpp:3440
+#: src/amuleDlg.cpp:1728 src/muuli_wdr.cpp:3412
+msgid "Searches"
+msgstr "Recherches"
+
+#: src/amuleDlg.cpp:1732 src/muuli_wdr.cpp:3412
 msgid "Searches Window"
 msgstr "Fenêtre de Recherche"
 
-#: src/amuleDlg.cpp:1826 src/muuli_wdr.cpp:3441
+#: src/amuleDlg.cpp:1734 src/DownloadListCtrl.cpp:740 src/muuli_wdr.cpp:392
+#: src/muuli_wdr.cpp:1578 src/muuli_wdr.cpp:3413 src/Statistics.cpp:829
+msgid "Downloads"
+msgstr "Téléchargements"
+
+#: src/amuleDlg.cpp:1738 src/muuli_wdr.cpp:3413
 msgid "Downloads Window"
 msgstr "Fenêtre des Téléchargements"
 
-#: src/amuleDlg.cpp:1832 src/muuli_wdr.cpp:3443
+#: src/amuleDlg.cpp:1740 src/muuli_wdr.cpp:3287
+msgid "Shared files"
+msgstr "Fichiers partagés"
+
+#: src/amuleDlg.cpp:1744 src/muuli_wdr.cpp:3415
 msgid "Shared Files Window"
 msgstr "Fenêtre des Fichiers Partagés"
 
-#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3444
+#: src/amuleDlg.cpp:1746 src/muuli_wdr.cpp:2919 src/muuli_wdr.cpp:3369
+#: src/muuli_wdr.cpp:3416
+msgid "Messages"
+msgstr "Messages"
+
+#: src/amuleDlg.cpp:1750 src/muuli_wdr.cpp:3416
 msgid "Messages Window"
 msgstr "Fenêtre des Messages"
 
-#: src/amuleDlg.cpp:1844 src/muuli_wdr.cpp:3445
+#: src/amuleDlg.cpp:1752 src/muuli_wdr.cpp:3417 src/PrefsUnifiedDlg.cpp:312
+#: src/Statistics.cpp:779 src/Statistics.cpp:1235
+msgid "Statistics"
+msgstr "Statistiques"
+
+#: src/amuleDlg.cpp:1756 src/muuli_wdr.cpp:3417
 msgid "Statistics Graph Window"
 msgstr "Fenêtre des Statistiques"
 
-#: src/amuleDlg.cpp:1851 src/muuli_wdr.cpp:3447
+#: src/amuleDlg.cpp:1759 src/muuli_wdr.cpp:3419 src/PrefsUnifiedDlg.cpp:328
+#: src/utils/wxCas/src/wxcasprefs.cpp:39
+msgid "Preferences"
+msgstr "Préférences"
+
+#: src/amuleDlg.cpp:1763 src/muuli_wdr.cpp:3419
 msgid "Preferences Settings Window"
 msgstr "Fenêtre des Préférences"
 
-#: src/amuleDlg.cpp:1854 src/muuli_wdr.cpp:3448
+#: src/amuleDlg.cpp:1766 src/muuli_wdr.cpp:3420
 msgid "Import"
 msgstr "Importer"
 
-#: src/amuleDlg.cpp:1858 src/muuli_wdr.cpp:3448
+#: src/amuleDlg.cpp:1770 src/muuli_wdr.cpp:3420
 msgid "The partfile importer tool"
 msgstr "L'outil d'importation de fichier .part"
 
-#: src/amuleDlg.cpp:1861 src/muuli_wdr.cpp:3449
+#: src/amuleDlg.cpp:1773 src/muuli_wdr.cpp:3421
 #: src/utils/aLinkCreator/src/alcframe.cpp:262
 msgid "About"
 msgstr "À propos"
 
-#: src/amuleDlg.cpp:1861 src/muuli_wdr.cpp:3449
+#: src/amuleDlg.cpp:1773 src/muuli_wdr.cpp:3421
 msgid "About/Help"
 msgstr "À propos/Aide"
 
-#: src/amuleDlg.cpp:2059
+#: src/amuleDlg.cpp:1971
 msgid "eD2k network"
 msgstr "Réseau eD2k"
 
-#: src/amuleDlg.cpp:2062
+#: src/amuleDlg.cpp:1974
 msgid "Kad network"
 msgstr "Réseau Kad"
 
-#: src/amuleDlg.cpp:2062
+#: src/amuleDlg.cpp:1974
 msgid "No network"
 msgstr "Pas de réseau"
 
@@ -963,7 +958,7 @@ msgstr "introuvable"
 msgid "The core rejected these shared folders:%s"
 msgstr "Le noyau a rejeté ces répertoires partagés : %s"
 
-#: src/amule-remote-gui.cpp:1336 src/ExternalConn.cpp:2346
+#: src/amule-remote-gui.cpp:1336 src/ExternalConn.cpp:2345
 msgid "Invalid link or already on list."
 msgstr "Lien invalide ou déjà dans la liste."
 
@@ -979,7 +974,7 @@ msgstr "Impossible de créer le répertoire '%s' pour la catégorie '%s', on gar
 #: src/ClientDetailDialog.cpp:123 src/DataToText.cpp:61 src/DataToText.cpp:86
 #: src/DataToText.cpp:101 src/DataToText.cpp:136 src/DataToText.cpp:165
 #: src/DownloadListCtrl.cpp:1172 src/DownloadListCtrl.cpp:1185
-#: src/DownloadListCtrl.cpp:1196 src/ExternalConn.cpp:609
+#: src/DownloadListCtrl.cpp:1196 src/ExternalConn.cpp:608
 #: src/FileDetailDialog.cpp:203 src/FileDetailDialog.cpp:235
 #: src/FileDetailDialog.cpp:242 src/GenericClientListCtrl.cpp:1171
 #: src/GenericClientListCtrl.cpp:1182 src/GenericClientListCtrl.cpp:1192
@@ -1365,19 +1360,19 @@ msgstr "Auto [Haute]"
 msgid "Very low"
 msgstr "Très basse"
 
-#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:743 src/muuli_wdr.cpp:2303
+#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:743 src/muuli_wdr.cpp:2275
 #: src/ServerListCtrl.cpp:263 src/ServerListCtrl.cpp:456
 #: src/SharedFilesCtrl.cpp:145
 msgid "Low"
 msgstr "Basse"
 
-#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:744 src/muuli_wdr.cpp:2304
+#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:744 src/muuli_wdr.cpp:2276
 #: src/ServerListCtrl.cpp:266 src/ServerListCtrl.cpp:457
 #: src/SharedFilesCtrl.cpp:146
 msgid "Normal"
 msgstr "Normale"
 
-#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:745 src/muuli_wdr.cpp:2305
+#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:745 src/muuli_wdr.cpp:2277
 #: src/ServerListCtrl.cpp:269 src/ServerListCtrl.cpp:458
 #: src/SharedFilesCtrl.cpp:147
 msgid "High"
@@ -1469,8 +1464,8 @@ msgstr "Serveur Local"
 msgid "Remote Server"
 msgstr "Serveur Distant"
 
-#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3202
-#: src/SearchDlg.cpp:119 src/TextClient.cpp:911
+#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3174
+#: src/SearchDlg.cpp:111 src/TextClient.cpp:911
 msgid "Kad"
 msgstr "Kad"
 
@@ -1540,7 +1535,7 @@ msgstr "Partie"
 msgid "Size"
 msgstr "Taille"
 
-#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3269
+#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3241
 msgid "Transferred"
 msgstr "Reçu"
 
@@ -1598,7 +1593,7 @@ msgstr ""
 "Retour de : %s (%s)\n"
 "\n"
 
-#: src/DownloadListCtrl.cpp:746 src/muuli_wdr.cpp:2306
+#: src/DownloadListCtrl.cpp:746 src/muuli_wdr.cpp:2278
 #: src/SharedFilesCtrl.cpp:150
 msgid "Auto"
 msgstr "Auto"
@@ -1636,7 +1631,7 @@ msgid "Extended Options"
 msgstr "Options avancées"
 
 #: src/DownloadListCtrl.cpp:770 src/DownloadListCtrl.cpp:822
-#: src/muuli_wdr.cpp:1790
+#: src/muuli_wdr.cpp:1789
 msgid "Preview"
 msgstr "Prévisualisation"
 
@@ -1811,230 +1806,225 @@ msgstr[1] "Impossible d'ajouter %u liens (cf. le journal pour les détails)."
 msgid "Invalid eD2k link! ERROR: %s"
 msgstr "Lien eD2k invalide ! ERREUR : %s"
 
-#: src/ExternalConn.cpp:380
+#: src/ExternalConn.cpp:379
 msgid "Client sent packet after authentication failed."
 msgstr "Le client a envoyé un paquet après l'échec d'authentification."
 
-#: src/ExternalConn.cpp:397
+#: src/ExternalConn.cpp:396
 msgid "External connection closed."
 msgstr "Connexion externe fermée."
 
-#: src/ExternalConn.cpp:474
+#: src/ExternalConn.cpp:473
 msgid "External connections disabled due to empty password!"
 msgstr "Les connexions externes sont désactivées car le mot de passe est vide !"
 
-#: src/ExternalConn.cpp:495
+#: src/ExternalConn.cpp:494
 msgid "External connections disabled in config file"
 msgstr "Les connexions externes sont désactivées dans le fichier de configuration"
 
-#: src/ExternalConn.cpp:576
+#: src/ExternalConn.cpp:575
 msgid "New external connection accepted"
 msgstr "Nouvelle connexion externe acceptée"
 
-#: src/ExternalConn.cpp:579
+#: src/ExternalConn.cpp:578
 msgid "ERROR: couldn't accept a new external connection"
 msgstr "ERREUR : impossible d'accepter une nouvelle connexion externe"
 
-#: src/ExternalConn.cpp:596
+#: src/ExternalConn.cpp:595
 msgid "External connection refused due to empty password in preferences!"
 msgstr "Connexion externe refusée car le mot de passe est vide dans les préférences !"
 
-#: src/ExternalConn.cpp:608
+#: src/ExternalConn.cpp:607
 #, c-format
 msgid "Connecting client: %s %s"
 msgstr "Connexion au client : %s %s"
 
-#: src/ExternalConn.cpp:610
+#: src/ExternalConn.cpp:609
 msgid "Unknown version"
 msgstr "Version inconnue"
 
-#: src/ExternalConn.cpp:623
+#: src/ExternalConn.cpp:622
 msgid "Incorrect EC version ID, there might be binary incompatibility. Use core and remote from same snapshot."
 msgstr "ID de version de EC incorrecte, Il peut y avoir des incompatibilités entre les binaires. Utilisez un noyau et un client distant de la même version."
 
-#: src/ExternalConn.cpp:631
+#: src/ExternalConn.cpp:630
 msgid "You cannot connect to a release version from an arbitrary development snapshot! *sigh* possible crash prevented"
 msgstr "Vous ne pouvez pas connecter une version stable depuis une version de développement ! *pfff* un crash potentiel a été évité"
 
-#: src/ExternalConn.cpp:714
+#: src/ExternalConn.cpp:713
 msgid "Invalid protocol version."
 msgstr "Version du protocole invalide."
 
-#: src/ExternalConn.cpp:720
+#: src/ExternalConn.cpp:719
 msgid "Missing protocol version tag."
 msgstr "L'étiquette de la version du protocole est manquante."
 
-#: src/ExternalConn.cpp:728
+#: src/ExternalConn.cpp:727
 msgid "Authentication failed: invalid hash specified as EC password."
 msgstr "Authentification échouée : hachage spécifié comme mot de passe invalide."
 
-#: src/ExternalConn.cpp:776
+#: src/ExternalConn.cpp:775
 msgid "Authentication failed: wrong password."
 msgstr "Authentification échouée : mot de passe erroné."
 
-#: src/ExternalConn.cpp:778
+#: src/ExternalConn.cpp:777
 msgid "Authentication failed: missing password."
 msgstr "Authentification échouée : mot de passe manquant."
 
-#: src/ExternalConn.cpp:789
+#: src/ExternalConn.cpp:788
 msgid "Invalid request, please authenticate first."
 msgstr "Requête invalide, veuillez vous authentifier d'abord."
 
-#: src/ExternalConn.cpp:794
+#: src/ExternalConn.cpp:793
 msgid "Access granted."
 msgstr "Accès autorisé."
 
-#: src/ExternalConn.cpp:802
+#: src/ExternalConn.cpp:801
 #, c-format
 msgid "Sent error message \"%s\" to client."
 msgstr "Envoi du message d'erreur \"%s\" au client."
 
-#: src/ExternalConn.cpp:807
+#: src/ExternalConn.cpp:806
 #, c-format
 msgid "Unauthorized access attempt from %s. Connection closed."
 msgstr "Tentative d'accès non autorisé de %s. Connexion fermée."
 
-#: src/ExternalConn.cpp:1420
+#: src/ExternalConn.cpp:1419
 #, c-format
 msgid "Remote PartFile command failed: FileHash not found: %s"
 msgstr "Échec de la commande du fichier .part à distance : hachage du fichier non trouvé : %s"
 
-#: src/ExternalConn.cpp:1424
+#: src/ExternalConn.cpp:1423
 #, c-format
 msgid "FileHash not found: %s"
 msgstr "Hachage du fichier non trouvé : %s"
 
-#: src/ExternalConn.cpp:1471 src/ExternalConn.cpp:1559
-#: src/ExternalConn.cpp:1680
+#: src/ExternalConn.cpp:1470 src/ExternalConn.cpp:1558
+#: src/ExternalConn.cpp:1679
 msgid "OOPS! OpCode processing error!"
 msgstr "ARGH ! Erreur de traitement de l'OpCode !"
 
-#: src/ExternalConn.cpp:1502
+#: src/ExternalConn.cpp:1501
 msgid "Server not added"
 msgstr "Serveur non ajouté"
 
-#: src/ExternalConn.cpp:1521
+#: src/ExternalConn.cpp:1520
 #, c-format
 msgid "server not found: %s"
 msgstr "serveur non trouvé : %s"
 
-#: src/ExternalConn.cpp:1538
+#: src/ExternalConn.cpp:1537
 msgid "need to define server to be removed"
 msgstr "il faut définir le serveur à supprimer"
 
-#: src/ExternalConn.cpp:1553
+#: src/ExternalConn.cpp:1552
 msgid "eD2k is disabled in preferences."
 msgstr "eD2k est désactivé dans les préférences."
 
-#: src/ExternalConn.cpp:1658
+#: src/ExternalConn.cpp:1657
 msgid "Friend not found."
 msgstr "Ami introuvable."
 
-#: src/ExternalConn.cpp:1668
+#: src/ExternalConn.cpp:1667
 msgid "Client not found."
 msgstr "Client introuvable."
 
-#: src/ExternalConn.cpp:1674
+#: src/ExternalConn.cpp:1673
 msgid "EC_TAG_FRIEND_SHARED requires EC_TAG_FRIEND or EC_TAG_CLIENT."
 msgstr "EC_TAG_FRIEND_SHARED nécessite EC_TAG_FRIEND ou bien EC_TAG_CLIENT."
 
-#: src/ExternalConn.cpp:1992
+#: src/ExternalConn.cpp:1991
 msgid "WebSearch from remote interface makes no sense."
 msgstr "Une recherche Web par une interface distante n'a aucun sens."
 
-#: src/ExternalConn.cpp:2027
+#: src/ExternalConn.cpp:2026
 msgid "Search in progress. Refetch results in a moment!"
 msgstr "Recherche en cours. Résultats dans un moment !"
 
-#: src/ExternalConn.cpp:2266
+#: src/ExternalConn.cpp:2265
 msgid "No points for graph."
 msgstr "Pas de points pour le graphique."
 
-#: src/ExternalConn.cpp:2276
+#: src/ExternalConn.cpp:2275
 msgid "Your client is not configured for this detail level."
 msgstr "Votre client n'est pas configuré pour ce niveau de détails."
 
-#: src/ExternalConn.cpp:2303
+#: src/ExternalConn.cpp:2302
 msgid "External Connection: shutdown requested"
 msgstr "Connexion externe : fermeture demandée"
 
-#: src/ExternalConn.cpp:2315
+#: src/ExternalConn.cpp:2314
 msgid "Already shutting down."
 msgstr "Arrêt déjà en cours."
 
-#: src/ExternalConn.cpp:2333
+#: src/ExternalConn.cpp:2332
 #, c-format
 msgid "ExternalConn: adding link '%s'."
 msgstr "ConnExt : ajout du lien '%s'."
 
-#: src/ExternalConn.cpp:2351
+#: src/ExternalConn.cpp:2350
 #, c-format
 msgid "%d of %d links failed (invalid or already on list)."
 msgstr "Échec de %d liens sur %d (invalides ou déjà sur la liste)."
 
-#: src/ExternalConn.cpp:2374
+#: src/ExternalConn.cpp:2373
 msgid "Version check throttled; try again shortly."
 msgstr "Vérification d'une nouvelle version a été empêchée ; veuillez réessayer sous peu."
 
-#: src/ExternalConn.cpp:2379
+#: src/ExternalConn.cpp:2378
 msgid "Version check is not available on this daemon."
 msgstr "La vérification de la version est indisponible sur ce démon."
 
-#: src/ExternalConn.cpp:2509
+#: src/ExternalConn.cpp:2508
 msgid "File not found."
 msgstr "Fichier non trouvé."
 
-#: src/ExternalConn.cpp:2514
+#: src/ExternalConn.cpp:2513
 msgid "Invalid file name."
 msgstr "Nom de fichier invalide."
 
-#: src/ExternalConn.cpp:2522
+#: src/ExternalConn.cpp:2521
 msgid "Unable to rename file."
 msgstr "Impossible de renommer le fichier."
 
-#: src/ExternalConn.cpp:2839
-#, c-format
-msgid "Could not save the amuleapi password: %s"
-msgstr ""
-
-#: src/ExternalConn.cpp:3004 src/ExternalConn.cpp:3032
+#: src/ExternalConn.cpp:2992 src/ExternalConn.cpp:3020
 msgid "Kad is disabled in preferences."
 msgstr "Kad est désactivé dans les préférences."
 
-#: src/ExternalConn.cpp:3045
+#: src/ExternalConn.cpp:3033
 msgid "Already connected to eD2k."
 msgstr "Déjà connecté à eD2k."
 
-#: src/ExternalConn.cpp:3048
+#: src/ExternalConn.cpp:3036
 msgid "Connecting to eD2k..."
 msgstr "Connexion à eD2k…"
 
-#: src/ExternalConn.cpp:3057
+#: src/ExternalConn.cpp:3045
 msgid "Already connected to Kad."
 msgstr "Déjà connecté à Kad."
 
-#: src/ExternalConn.cpp:3060
+#: src/ExternalConn.cpp:3048
 msgid "Connecting to Kad..."
 msgstr "Connexion à Kad…"
 
-#: src/ExternalConn.cpp:3067
+#: src/ExternalConn.cpp:3055
 msgid "All networks are disabled."
 msgstr "Tous les réseaux sont désactivés."
 
-#: src/ExternalConn.cpp:3076
+#: src/ExternalConn.cpp:3064
 msgid "Disconnected from eD2k."
 msgstr "Déconnecté de eD2k."
 
-#: src/ExternalConn.cpp:3081
+#: src/ExternalConn.cpp:3069
 msgid "Disconnected from Kad."
 msgstr "Déconnecté de Kad."
 
-#: src/ExternalConn.cpp:3090
+#: src/ExternalConn.cpp:3078
 #, c-format
 msgid "External Connection: invalid opcode received: %#x"
 msgstr "Connexion externe : opcode reçu invalide : %#x"
 
-#: src/ExternalConn.cpp:3095
+#: src/ExternalConn.cpp:3083
 msgid "Invalid opcode (wrong protocol version?)"
 msgstr "opcode invalide (mauvaise version de protocole ?)"
 
@@ -2350,19 +2340,19 @@ msgstr ""
 msgid "eD2k"
 msgstr "eD2k"
 
-#: src/FirstRunWizard.cpp:349 src/muuli_wdr.cpp:1495
+#: src/FirstRunWizard.cpp:349 src/muuli_wdr.cpp:1488
 msgid "Kademlia"
 msgstr "Kademlia"
 
-#: src/FirstRunWizard.cpp:359 src/muuli_wdr.cpp:1423
+#: src/FirstRunWizard.cpp:359 src/muuli_wdr.cpp:1416
 msgid "Standard TCP Port "
 msgstr "Port TCP standard "
 
-#: src/FirstRunWizard.cpp:365 src/muuli_wdr.cpp:1435
+#: src/FirstRunWizard.cpp:365 src/muuli_wdr.cpp:1428
 msgid "Extended UDP port (Kad / global search) "
 msgstr "Port UDP étendu (recherche Kad / globale) "
 
-#: src/FirstRunWizard.cpp:377 src/muuli_wdr.cpp:1442
+#: src/FirstRunWizard.cpp:377 src/muuli_wdr.cpp:1435
 msgid "Enable UPnP for router port forwarding"
 msgstr "Activer UPnP pour la redirection de port du routeur"
 
@@ -2389,7 +2379,7 @@ msgstr ""
 msgid "Your peer lists are already in place - nothing to download."
 msgstr "Vous êtes déjà en train de télécharger le fichier %s"
 
-#: src/FirstRunWizard.cpp:434 src/muuli_wdr.cpp:1540
+#: src/FirstRunWizard.cpp:434 src/muuli_wdr.cpp:1533
 msgid "Auto-update server list at startup"
 msgstr "Mise à jour automatique de la liste des serveurs au démarrage"
 
@@ -2435,23 +2425,23 @@ msgid ""
 "want downloads on a different (e.g. larger) disk."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:549 src/FirstRunWizard.cpp:611 src/muuli_wdr.cpp:1702
+#: src/FirstRunWizard.cpp:549 src/FirstRunWizard.cpp:611 src/muuli_wdr.cpp:1701
 msgid "Destination folder for downloads"
 msgstr "Dossier de destination des téléchargements"
 
-#: src/FirstRunWizard.cpp:553 src/FirstRunWizard.cpp:569 src/muuli_wdr.cpp:1349
-#: src/muuli_wdr.cpp:1366 src/muuli_wdr.cpp:1677 src/muuli_wdr.cpp:1708
-#: src/muuli_wdr.cpp:1720 src/muuli_wdr.cpp:2790
+#: src/FirstRunWizard.cpp:553 src/FirstRunWizard.cpp:569 src/muuli_wdr.cpp:1342
+#: src/muuli_wdr.cpp:1359 src/muuli_wdr.cpp:1676 src/muuli_wdr.cpp:1707
+#: src/muuli_wdr.cpp:1719 src/muuli_wdr.cpp:2762
 #: src/utils/aLinkCreator/src/alcframe.cpp:135
 #: src/utils/wxCas/src/wxcasprefs.cpp:52 src/utils/wxCas/src/wxcasprefs.cpp:118
 msgid "Browse"
 msgstr "Parcourir"
 
-#: src/FirstRunWizard.cpp:559 src/muuli_wdr.cpp:1713
+#: src/FirstRunWizard.cpp:559 src/muuli_wdr.cpp:1712
 msgid "(All files in this folder are shared with other peers)"
 msgstr "(Tous les fichiers de ce répertoire sont partagés avec les autres pairs)"
 
-#: src/FirstRunWizard.cpp:565 src/FirstRunWizard.cpp:624 src/muuli_wdr.cpp:1715
+#: src/FirstRunWizard.cpp:565 src/FirstRunWizard.cpp:624 src/muuli_wdr.cpp:1714
 msgid "Folder for temporary download files"
 msgstr "Dossier des fichiers de téléchargements temporaires"
 
@@ -2482,7 +2472,7 @@ msgstr "Échec de l'ouverture du fichier de la liste d'amis 'emfriends.met' pour
 msgid "CRITICAL - no client on StartChatSession"
 msgstr "CRITIQUE - Pas de client dans StartChatSession"
 
-#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2696 src/muuli_wdr.cpp:3373
+#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2668 src/muuli_wdr.cpp:3345
 msgid "Friends"
 msgstr "Amis"
 
@@ -2592,8 +2582,8 @@ msgstr "Aucun"
 msgid "No"
 msgstr "Non"
 
-#: src/GenericClientListCtrl.cpp:1216 src/PrefsUnifiedDlg.cpp:2898
-#: src/PrefsUnifiedDlg.cpp:2948 src/ServerListCtrl.cpp:276
+#: src/GenericClientListCtrl.cpp:1216 src/PrefsUnifiedDlg.cpp:2818
+#: src/PrefsUnifiedDlg.cpp:2868 src/ServerListCtrl.cpp:276
 msgid "Yes"
 msgstr "Oui"
 
@@ -2762,10 +2752,10 @@ msgstr "Port invalide pour l'amorçage"
 msgid "Please fill all fields required"
 msgstr "Veuillez remplir tous les champs requis"
 
-#: src/KadDlg.cpp:192 src/PartFile.cpp:1031 src/PrefsUnifiedDlg.cpp:1134
-#: src/PrefsUnifiedDlg.cpp:1204 src/PrefsUnifiedDlg.cpp:1405
-#: src/PrefsUnifiedDlg.cpp:1663 src/PrefsUnifiedDlg.cpp:1673
-#: src/PrefsUnifiedDlg.cpp:1690 src/PrefsUnifiedDlg.cpp:1738
+#: src/KadDlg.cpp:192 src/PartFile.cpp:1031 src/PrefsUnifiedDlg.cpp:1162
+#: src/PrefsUnifiedDlg.cpp:1331 src/PrefsUnifiedDlg.cpp:1589
+#: src/PrefsUnifiedDlg.cpp:1599 src/PrefsUnifiedDlg.cpp:1616
+#: src/PrefsUnifiedDlg.cpp:1658
 msgid "Message"
 msgstr "Message"
 
@@ -2866,7 +2856,7 @@ msgstr "Ratio de partage"
 msgid "Uploaded"
 msgstr "Émis"
 
-#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3253
+#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3225
 msgid "Requested"
 msgstr "Demandé"
 
@@ -2989,7 +2979,7 @@ msgid "WARNING: "
 msgstr "AVERTISSEMENT : "
 
 #: src/MuleNotebook.cpp:179 src/muuli_wdr.cpp:817 src/muuli_wdr.cpp:1229
-#: src/muuli_wdr.cpp:3157 src/muuli_wdr.cpp:3413
+#: src/muuli_wdr.cpp:3129 src/muuli_wdr.cpp:3385
 msgid "Close"
 msgstr "Fermer"
 
@@ -3002,12 +2992,12 @@ msgstr "Couper"
 msgid "Copy"
 msgstr "Copier"
 
-#: src/MuleTextCtrl.cpp:88 src/SearchDlg.cpp:261
+#: src/MuleTextCtrl.cpp:88
 msgid "Paste"
 msgstr "Coller"
 
 #: src/MuleTextCtrl.cpp:89 src/muuli_wdr.cpp:358 src/muuli_wdr.cpp:757
-#: src/muuli_wdr.cpp:2380 src/muuli_wdr.cpp:2399 src/muuli_wdr.cpp:2421
+#: src/muuli_wdr.cpp:2352 src/muuli_wdr.cpp:2371 src/muuli_wdr.cpp:2393
 #: src/utils/aLinkCreator/src/alcframe.cpp:142
 msgid "Clear"
 msgstr "Effacer"
@@ -3098,8 +3088,8 @@ msgid "Exit"
 msgstr "Quitter"
 
 #: src/MuleTrayIcon.cpp:579 src/MuleTrayIcon.cpp:945 src/MuleTrayIcon.cpp:965
-#: src/muuli_wdr.cpp:1398 src/muuli_wdr.cpp:1406 src/muuli_wdr.cpp:1413
-#: src/muuli_wdr.cpp:1836 src/muuli_wdr.cpp:1842 src/OtherFunctions.cpp:91
+#: src/muuli_wdr.cpp:1391 src/muuli_wdr.cpp:1399 src/muuli_wdr.cpp:1406
+#: src/muuli_wdr.cpp:1835 src/muuli_wdr.cpp:1841 src/OtherFunctions.cpp:91
 #: src/StatisticsDlg.cpp:93 src/StatisticsDlg.cpp:95
 msgid "kB/s"
 msgstr "Ko/s"
@@ -3268,7 +3258,7 @@ msgstr "Nom :"
 msgid "Type"
 msgstr "Type"
 
-#: src/muuli_wdr.cpp:215 src/SearchDlg.cpp:118 src/SearchListCtrl.cpp:853
+#: src/muuli_wdr.cpp:215 src/SearchDlg.cpp:110 src/SearchListCtrl.cpp:853
 msgid "Local"
 msgstr "Local"
 
@@ -3339,7 +3329,7 @@ msgstr "Octets"
 msgid "KB"
 msgstr "Ko"
 
-#: src/muuli_wdr.cpp:274 src/muuli_wdr.cpp:293 src/muuli_wdr.cpp:1621
+#: src/muuli_wdr.cpp:274 src/muuli_wdr.cpp:293 src/muuli_wdr.cpp:1620
 #: src/OtherFunctions.cpp:64
 msgid "MB"
 msgstr "Mo"
@@ -3356,7 +3346,7 @@ msgstr "Taille Maximum"
 msgid "Availability"
 msgstr "Disponibilité"
 
-#: src/muuli_wdr.cpp:312 src/muuli_wdr.cpp:398 src/muuli_wdr.cpp:3318
+#: src/muuli_wdr.cpp:312 src/muuli_wdr.cpp:398 src/muuli_wdr.cpp:3290
 msgid "Filter:"
 msgstr "Filtre :"
 
@@ -3388,7 +3378,7 @@ msgstr "Demande aux pairs Kad ayant déjà répondu d'élargir la recherche. Cha
 msgid "Stop"
 msgstr "Arrêter"
 
-#: src/muuli_wdr.cpp:348 src/muuli_wdr.cpp:1392 src/SearchListCtrl.cpp:732
+#: src/muuli_wdr.cpp:348 src/muuli_wdr.cpp:1385 src/SearchListCtrl.cpp:732
 msgid "Download"
 msgstr "Réception"
 
@@ -3419,12 +3409,12 @@ msgstr "Sources du fichier :"
 #: src/muuli_wdr.cpp:1160 src/muuli_wdr.cpp:1167 src/muuli_wdr.cpp:1172
 #: src/muuli_wdr.cpp:1179 src/muuli_wdr.cpp:1184 src/muuli_wdr.cpp:1191
 #: src/muuli_wdr.cpp:1205 src/muuli_wdr.cpp:1212 src/muuli_wdr.cpp:1217
-#: src/muuli_wdr.cpp:1224 src/muuli_wdr.cpp:3255 src/muuli_wdr.cpp:3263
-#: src/muuli_wdr.cpp:3271
+#: src/muuli_wdr.cpp:1224 src/muuli_wdr.cpp:3227 src/muuli_wdr.cpp:3235
+#: src/muuli_wdr.cpp:3243
 msgid "N/A"
 msgstr "N/A"
 
-#: src/muuli_wdr.cpp:508 src/muuli_wdr.cpp:1065 src/PrefsUnifiedDlg.cpp:299
+#: src/muuli_wdr.cpp:508 src/muuli_wdr.cpp:1065 src/PrefsUnifiedDlg.cpp:297
 msgid "General"
 msgstr "Général"
 
@@ -3560,7 +3550,7 @@ msgstr "Artiste :"
 msgid "Album :"
 msgstr "Album :"
 
-#: src/muuli_wdr.cpp:685 src/muuli_wdr.cpp:2275
+#: src/muuli_wdr.cpp:685 src/muuli_wdr.cpp:2247
 msgid "Title :"
 msgstr "Titre :"
 
@@ -3668,7 +3658,7 @@ msgstr "Nom d'utilisateur :"
 msgid "Userhash :"
 msgstr "Hachage de l'utilisateur :"
 
-#: src/muuli_wdr.cpp:895 src/muuli_wdr.cpp:1742 src/muuli_wdr.cpp:2470
+#: src/muuli_wdr.cpp:895 src/muuli_wdr.cpp:1741 src/muuli_wdr.cpp:2442
 #: src/utils/aLinkCreator/src/alcframe.cpp:137
 msgid "Add"
 msgstr "Ajouter"
@@ -3677,15 +3667,15 @@ msgstr "Ajouter"
 msgid "Download-Speed"
 msgstr "Vitesse de réception"
 
-#: src/muuli_wdr.cpp:954 src/muuli_wdr.cpp:989 src/muuli_wdr.cpp:2574
+#: src/muuli_wdr.cpp:954 src/muuli_wdr.cpp:989 src/muuli_wdr.cpp:2546
 msgid "Current"
 msgstr "Actuelle"
 
-#: src/muuli_wdr.cpp:962 src/muuli_wdr.cpp:997 src/muuli_wdr.cpp:2582
+#: src/muuli_wdr.cpp:962 src/muuli_wdr.cpp:997 src/muuli_wdr.cpp:2554
 msgid "Running average"
 msgstr "Moyenne totale"
 
-#: src/muuli_wdr.cpp:970 src/muuli_wdr.cpp:1005 src/muuli_wdr.cpp:2590
+#: src/muuli_wdr.cpp:970 src/muuli_wdr.cpp:1005 src/muuli_wdr.cpp:2562
 msgid "Session average"
 msgstr "Moyenne de la session"
 
@@ -3697,7 +3687,7 @@ msgstr "Vitesse d'émission"
 msgid "Connections"
 msgstr "Connexions"
 
-#: src/muuli_wdr.cpp:1024 src/muuli_wdr.cpp:1861
+#: src/muuli_wdr.cpp:1024 src/muuli_wdr.cpp:1860
 msgid "Active downloads"
 msgstr "Téléchargements actifs"
 
@@ -3705,7 +3695,7 @@ msgstr "Téléchargements actifs"
 msgid "Active connections (1:1)"
 msgstr "Connexions actives (1:1)"
 
-#: src/muuli_wdr.cpp:1040 src/muuli_wdr.cpp:1862
+#: src/muuli_wdr.cpp:1040 src/muuli_wdr.cpp:1861
 msgid "Active uploads"
 msgstr "Envois actifs"
 
@@ -3821,8 +3811,8 @@ msgstr "Ceci est le nom que verront les autres utilisateurs lorsqu'ils se connec
 msgid "Language: "
 msgstr "Langue : "
 
-#: src/muuli_wdr.cpp:1257 src/muuli_wdr.cpp:1330 src/muuli_wdr.cpp:1334
-#: src/muuli_wdr.cpp:1337
+#: src/muuli_wdr.cpp:1257 src/muuli_wdr.cpp:1323 src/muuli_wdr.cpp:1327
+#: src/muuli_wdr.cpp:1330
 msgid "The delay before showing tool-tips."
 msgstr "Délai avant l'apparition des infobulles."
 
@@ -3898,260 +3888,259 @@ msgstr "Afficher des notifications lorsque le téléchargement est terminé"
 msgid "Enabling this will make aMule to show notifications when finished downloading."
 msgstr "Si vous activez cette option, aMule affichera des notifications une fois le téléchargement terminé."
 
-#: src/muuli_wdr.cpp:1323
-#, fuzzy
-msgid "Remember search history"
-msgstr "Se rappeler de ces réglages"
-
-#: src/muuli_wdr.cpp:1324
-msgid "Keeps a dropdown list of your past search terms in the Search tab's Name field. This remembers the queries you typed, not the results they returned."
-msgstr ""
-
-#: src/muuli_wdr.cpp:1329
+#: src/muuli_wdr.cpp:1322
 msgid "Tooltip delay time: "
 msgstr "Délai d'affichage des info-bulles : "
 
-#: src/muuli_wdr.cpp:1336
+#: src/muuli_wdr.cpp:1329
 msgid "seconds"
 msgstr "secondes"
 
-#: src/muuli_wdr.cpp:1340
+#: src/muuli_wdr.cpp:1333
 msgid "Browser Selection"
 msgstr "Sélection du navigateur"
 
-#: src/muuli_wdr.cpp:1346
+#: src/muuli_wdr.cpp:1339
 msgid "Enter your browser name here. Leave this field empty to use the system default browser."
 msgstr "Indiquez le nom de votre navigateur ici. Laissez ce champ vide pour utiliser le navigateur par défaut du système."
 
-#: src/muuli_wdr.cpp:1353
+#: src/muuli_wdr.cpp:1346
 msgid "Open in new tab if possible"
 msgstr "Ouvrir si possible dans un nouvel onglet"
 
-#: src/muuli_wdr.cpp:1355
+#: src/muuli_wdr.cpp:1348
 msgid "Open the web page in a new tab instead of in a new window when possible"
 msgstr "Ouvrir, lorsque c'est possible, la page Web dans un nouvel onglet plutôt que dans une nouvelle page"
 
-#: src/muuli_wdr.cpp:1359
+#: src/muuli_wdr.cpp:1352
 msgid "Video Player"
 msgstr "Lecteur vidéo"
 
-#: src/muuli_wdr.cpp:1386
+#: src/muuli_wdr.cpp:1379
 msgid "Bandwidth limits"
 msgstr "Limites de la bande passante"
 
-#: src/muuli_wdr.cpp:1400
+#: src/muuli_wdr.cpp:1393
 msgid "Upload"
 msgstr "Émission"
 
-#: src/muuli_wdr.cpp:1408
+#: src/muuli_wdr.cpp:1401
 msgid "Slot Allocation"
 msgstr "Attribution de slot"
 
-#: src/muuli_wdr.cpp:1417
+#: src/muuli_wdr.cpp:1410
 msgid "Ports"
 msgstr "Ports"
 
-#: src/muuli_wdr.cpp:1427
+#: src/muuli_wdr.cpp:1420
 msgid "This is the standard eD2k port and cannot be disabled."
 msgstr "Ceci est le port eD2k standard et ne peut pas être activé."
 
-#: src/muuli_wdr.cpp:1430
+#: src/muuli_wdr.cpp:1423
 msgid "UDP port for server requests (TCP+3):"
 msgstr "Port UDP pour les requêtes des serveurs (TCP+3) :"
 
-#: src/muuli_wdr.cpp:1432
+#: src/muuli_wdr.cpp:1425
 msgid "4665"
 msgstr "4665"
 
-#: src/muuli_wdr.cpp:1439
+#: src/muuli_wdr.cpp:1432
 msgid "This UDP port is used for extended eD2k requests and Kad network"
 msgstr "Ce port UDP est utilisé pour les requêtes eD2k étendues et pour le réseau Kad"
 
-#: src/muuli_wdr.cpp:1446
+#: src/muuli_wdr.cpp:1439
 msgid "UPnP TCP Port (Optional):"
 msgstr "Port TCP UPnP (Facultatif) :"
 
-#: src/muuli_wdr.cpp:1456
+#: src/muuli_wdr.cpp:1449
 msgid "Bind local address to IP (empty for any):"
 msgstr "Lier l'adresse locale à une IP (vide pour toutes) :"
 
-#: src/muuli_wdr.cpp:1459
+#: src/muuli_wdr.cpp:1452
 msgid "Advanced users only: If you have multiple network interfaces, enter the address of the interface to which aMule should be bound."
 msgstr "Utilisateurs avancés uniquement : Si vous avez plusieurs interfaces réseau, entrez l'adresse de l'interface à laquelle aMule doit être lié."
 
-#: src/muuli_wdr.cpp:1462 src/muuli_wdr.cpp:2055
+#: src/muuli_wdr.cpp:1455 src/muuli_wdr.cpp:2054
 msgid "Bind to network interface (empty for any):"
 msgstr "Lier à une interface réseau (vide pour toutes) :"
 
-#: src/muuli_wdr.cpp:1475
+#: src/muuli_wdr.cpp:1468
 msgid "Advanced users only: pin all of aMule's traffic to one network interface, chosen from the list or typed in by name (e.g. tun0, eth0, en0) or index. Unlike binding to an IP, this stops traffic leaking out via the default route - useful with a VPN. Requires no elevated privileges."
 msgstr "Utilisateurs avancé uniquement : affecter tout le trafic d'aMule à une interface réseau unique, choisie depuis la liste ou bien par la saisie de son nom (par exemple tun0, eth0, en0) ou son index. Contrairement à la liaison à une adresse IP, cela empêche le trafic de fuiter par la route par défaut - utile avec un VPN. Ne nécessite pas de privilèges élevés."
 
-#: src/muuli_wdr.cpp:1481
+#: src/muuli_wdr.cpp:1474
 msgid "Max sources per downloading file:"
 msgstr "Sources maximales par fichier téléchargé :"
 
-#: src/muuli_wdr.cpp:1485
+#: src/muuli_wdr.cpp:1478
 msgid "Max simultaneous connections:"
 msgstr "Connexions simultanées maximales :"
 
-#: src/muuli_wdr.cpp:1498 src/muuli_wdr.cpp:3197
+#: src/muuli_wdr.cpp:1491 src/muuli_wdr.cpp:3169
 msgid "ED2K"
 msgstr "ED2K"
 
-#: src/muuli_wdr.cpp:1505
+#: src/muuli_wdr.cpp:1498
 msgid "Autoconnect on startup"
 msgstr "Se connecter automatiquement au démarrage"
 
-#: src/muuli_wdr.cpp:1508
+#: src/muuli_wdr.cpp:1501
 msgid "Reconnect on loss"
 msgstr "Reconnecter en cas de déconnexion"
 
-#: src/muuli_wdr.cpp:1530
+#: src/muuli_wdr.cpp:1523
 msgid "Remove dead server after"
 msgstr "Supprimer les serveurs inactifs après"
 
-#: src/muuli_wdr.cpp:1531
+#: src/muuli_wdr.cpp:1524
 msgid "Static servers are never removed, even when unreachable."
 msgstr "Les serveurs statiques ne sont jamais enlevés, même lorsqu'ils sont injoignables."
 
-#: src/muuli_wdr.cpp:1535
+#: src/muuli_wdr.cpp:1528
 msgid "retries"
 msgstr "essais"
 
-#: src/muuli_wdr.cpp:1543
+#: src/muuli_wdr.cpp:1536
 msgid "List"
 msgstr "Liste"
 
-#: src/muuli_wdr.cpp:1546
+#: src/muuli_wdr.cpp:1539
 msgid "Update server list when connecting to a server"
 msgstr "Mise à jour de la liste des serveurs dès la connexion à un serveur"
 
-#: src/muuli_wdr.cpp:1549
+#: src/muuli_wdr.cpp:1542
 msgid "Update server list when a client connects"
 msgstr "Mise à jour de la liste des serveurs dès la connexion d'un client"
 
-#: src/muuli_wdr.cpp:1552
+#: src/muuli_wdr.cpp:1545
 msgid "Use priority system"
 msgstr "Utiliser le système de priorité"
 
-#: src/muuli_wdr.cpp:1556
+#: src/muuli_wdr.cpp:1549
 msgid "Use smart LowID check on connect"
 msgstr "Utiliser la vérification du LowID à la connexion"
 
-#: src/muuli_wdr.cpp:1560
+#: src/muuli_wdr.cpp:1553
 msgid "Safe connect"
 msgstr "Connexion sûre"
 
-#: src/muuli_wdr.cpp:1564
+#: src/muuli_wdr.cpp:1557
 msgid "Autoconnect to servers in static list only"
 msgstr "Se connecter automatiquement seulement sur les serveurs statiques"
 
-#: src/muuli_wdr.cpp:1567
+#: src/muuli_wdr.cpp:1560
 msgid "Set manually added servers to High Priority"
 msgstr "Mettre les serveurs ajoutés manuellement en priorité haute"
 
-#: src/muuli_wdr.cpp:1588
+#: src/muuli_wdr.cpp:1581
 msgid "Add files to download in pause mode"
 msgstr "Ajouter les fichiers à télécharger en mode Pause"
 
-#: src/muuli_wdr.cpp:1590
+#: src/muuli_wdr.cpp:1583
 msgid "Add files to download with auto priority"
 msgstr "Ajouter les fichiers à télécharger en priorité automatique"
 
-#: src/muuli_wdr.cpp:1593
+#: src/muuli_wdr.cpp:1586
 msgid "Try to download first and last chunks first"
 msgstr "Essayer de télécharger la première et la dernière partie en premier"
 
-#: src/muuli_wdr.cpp:1597
+#: src/muuli_wdr.cpp:1590
 msgid "Endgame mode: rotate to faster sources for the final blocks"
 msgstr "Mode « endgame » : basculer vers les sources plus rapides pour les blocs finaux"
 
-#: src/muuli_wdr.cpp:1600
+#: src/muuli_wdr.cpp:1593
 msgid "Start next paused file when a file completes"
 msgstr "Démarrer le prochain fichier en pause lorsqu'un fichier se termine"
 
-#: src/muuli_wdr.cpp:1603
+#: src/muuli_wdr.cpp:1596
 msgid "From the same category"
 msgstr "De la même catégorie"
 
-#: src/muuli_wdr.cpp:1605
+#: src/muuli_wdr.cpp:1598
 msgid "In alphabetic order"
 msgstr "Dans l'ordre alphabétique"
 
-#: src/muuli_wdr.cpp:1607
+#: src/muuli_wdr.cpp:1600
 msgid "Preallocate disk space for new files"
 msgstr "Réserver de l'espace disque pour les nouveaux fichiers"
 
-#: src/muuli_wdr.cpp:1608
+#: src/muuli_wdr.cpp:1601
 msgid "For new files preallocates disk space for the whole file, thus reduces fragmentation"
 msgstr "Réserve de l'espace du disque pour les nouveaux fichiers, réduisant ainsi la fragmentation"
 
-#: src/muuli_wdr.cpp:1613
+#: src/muuli_wdr.cpp:1606
+msgid "Create new files as sparse files"
+msgstr ""
+
+#: src/muuli_wdr.cpp:1607
+msgid "A sparse file reserves its full size on disk immediately without writing real data to it -- fast, but unsupported or slow on some filesystems, and free-space accounting stays optimistic while the download is in progress. Turn this off to grow the file only as data arrives."
+msgstr ""
+
+#: src/muuli_wdr.cpp:1612
 msgid "Stop downloads when free disk space reaches "
 msgstr "Stoppe les téléchargements lorsque l'espace disponible est atteint "
 
-#: src/muuli_wdr.cpp:1614
+#: src/muuli_wdr.cpp:1613
 msgid "Select this if you want aMule to check your disk space"
 msgstr "Sélectionnez ceci si vous souhaitez qu'aMule vérifie votre espace disque"
 
-#: src/muuli_wdr.cpp:1618
+#: src/muuli_wdr.cpp:1617
 msgid "Enter here the min disk space desired."
 msgstr "Entrez ici l'espace disque minimum désiré."
 
-#: src/muuli_wdr.cpp:1624
+#: src/muuli_wdr.cpp:1623
 msgid "Save 10 sources on rare files (< 20 sources)"
 msgstr "Sauver 10 sources pour les fichiers rares (< 20 sources)"
 
-#: src/muuli_wdr.cpp:1628 src/Statistics.cpp:790
+#: src/muuli_wdr.cpp:1627 src/Statistics.cpp:790
 msgid "Uploads"
 msgstr "Émission"
 
-#: src/muuli_wdr.cpp:1631
+#: src/muuli_wdr.cpp:1630
 msgid "Add new shared files with auto priority"
 msgstr "Ajouter les nouveaux fichiers partagés en priorité automatique"
 
-#: src/muuli_wdr.cpp:1637
+#: src/muuli_wdr.cpp:1636
 msgid "Intelligent Corruption Handling (I.C.H.)"
 msgstr "Gestion Intelligente de la Corruption (I.C.H.)"
 
-#: src/muuli_wdr.cpp:1640
+#: src/muuli_wdr.cpp:1639
 msgid "Enable"
 msgstr "Activer"
 
-#: src/muuli_wdr.cpp:1643
+#: src/muuli_wdr.cpp:1642
 msgid "Advanced I.C.H. trusts every hash (not recommended)"
 msgstr "I.C.H. avancée se fie aux hachages (non recommandé)"
 
-#: src/muuli_wdr.cpp:1655 src/PrefsUnifiedDlg.cpp:1990
+#: src/muuli_wdr.cpp:1654 src/PrefsUnifiedDlg.cpp:1910
 msgid "Media metadata extraction"
 msgstr "Extraction de métadonnées de média"
 
-#: src/muuli_wdr.cpp:1659
+#: src/muuli_wdr.cpp:1658
 msgid "Extract length / bitrate / codec from shared audio and video files"
 msgstr "Extraire la durée / le débit binaire / le codec depuis les fichiers audio et vidéo partagés"
 
-#: src/muuli_wdr.cpp:1661
+#: src/muuli_wdr.cpp:1660
 msgid "When enabled, aMule runs ffprobe on each shared media file to fill in the Length / Bitrate / Codec columns other clients see when they find the file in a search. Requires ffmpeg (the ffprobe binary) to be installed."
 msgstr "Lorsque cette option est activée, aMule exécute ffprobe sur chaque fichier média partagé pour remplir les colonnes Durée / Débit binaire / Codec que les autres clients voient quand ils trouvent le fichier lors d'une recherche. Nécessite que ffmpeg (le binaire ffprobe) soit installé."
 
-#: src/muuli_wdr.cpp:1668
+#: src/muuli_wdr.cpp:1667
 msgid "Path to ffprobe:"
 msgstr "Emplacement de ffprobe :"
 
-#: src/muuli_wdr.cpp:1673
+#: src/muuli_wdr.cpp:1672
 msgid "Full path to the ffprobe binary. Leave empty to have aMule auto-detect it on startup."
 msgstr "Chemin complet vers le binaire ffprobe. Laisser vide pour qu'aMule le détecte automatiquement au démarrage."
 
-#: src/muuli_wdr.cpp:1681
+#: src/muuli_wdr.cpp:1680
 msgid "Detect"
 msgstr "Détecter"
 
-#: src/muuli_wdr.cpp:1682
+#: src/muuli_wdr.cpp:1681
 msgid "Search the standard install locations for an ffprobe binary and fill the path field."
 msgstr "Rechercher les binaires de ffprobe aux emplacements par défaut et compléter le champ emplacement."
 
-#: src/muuli_wdr.cpp:1706
+#: src/muuli_wdr.cpp:1705
 msgid ""
 "Completed downloads are stored here. All files in this folder are automatically shared with other peers.\n"
 "If this folder also holds files you don't want to share, point it at an aMule-only sub-folder."
@@ -4159,688 +4148,665 @@ msgstr ""
 "Les téléchargements terminés sont stockés ici. Tous les fichiers de ce répertoire sont automatiquement partagés avec les autres pairs.\n"
 "Si ce répertoire contient également des fichiers que vous ne souhaitez pas partager, indiquez un sous-répertoire réservé à aMule."
 
-#: src/muuli_wdr.cpp:1709
+#: src/muuli_wdr.cpp:1708
 msgid "Pick the folder where completed downloads will be stored. All files in that folder will be shared with other peers."
 msgstr "Choisissez le répertoire où les téléchargements terminés seront enregistrés. Tous les fichiers de ce répertoire seront partagés avec les autres pairs."
 
-#: src/muuli_wdr.cpp:1723
+#: src/muuli_wdr.cpp:1722
 msgid "Shared folders"
 msgstr "Dossiers partagés"
 
-#: src/muuli_wdr.cpp:1729
+#: src/muuli_wdr.cpp:1728
 msgid "(Folders shared by the core. Enter a path to add one.)"
 msgstr "(Les répertoires partagés par le noyau. Entrer un chemin pour en ajouter un.)"
 
-#: src/muuli_wdr.cpp:1737
+#: src/muuli_wdr.cpp:1736
 msgid "Absolute path of a folder on the core's machine, e.g. /home/user/shared"
 msgstr "Le chemin absolu d'un répertoire sur la machine du noyau, par exemple /home/utilisateur/shared"
 
-#: src/muuli_wdr.cpp:1739 src/PrefsUnifiedDlg.cpp:2874
+#: src/muuli_wdr.cpp:1738 src/PrefsUnifiedDlg.cpp:2794
 msgid "Recursive"
 msgstr "Récursif"
 
-#: src/muuli_wdr.cpp:1740
+#: src/muuli_wdr.cpp:1739
 msgid "Share every sub-folder underneath this one, including ones created later."
 msgstr "Partager chaque sous-répertoire sous celui-ci, y compris ceux qui seront créés ultérieurement."
 
-#: src/muuli_wdr.cpp:1744 src/utils/aLinkCreator/src/alcframe.cpp:141
+#: src/muuli_wdr.cpp:1743 src/utils/aLinkCreator/src/alcframe.cpp:141
 msgid "Remove"
 msgstr "Enlever"
 
-#: src/muuli_wdr.cpp:1748
+#: src/muuli_wdr.cpp:1747
 msgid "(Right click on folder icon for recursive share)"
 msgstr "(Clic droit sur l'icône du répertoire pour un partage récursif)"
 
-#: src/muuli_wdr.cpp:1755
+#: src/muuli_wdr.cpp:1754
 msgid "Share hidden files"
 msgstr "Partager les fichiers cachés"
 
-#: src/muuli_wdr.cpp:1761
+#: src/muuli_wdr.cpp:1760
 msgid "Automatically rescan shared folders for changes"
 msgstr "Analyser automatiquement à nouveau les répertoires partagés pour rechercher des modifications"
 
-#: src/muuli_wdr.cpp:1767
+#: src/muuli_wdr.cpp:1766
 msgid "Follow symbolic links in shared folders"
 msgstr "Suivre les liens symboliques dans les répertoires partagés"
 
-#: src/muuli_wdr.cpp:1773
+#: src/muuli_wdr.cpp:1772
 msgid "Exclude files matching:"
 msgstr "Exclure les fichiers correspondant à :"
 
-#: src/muuli_wdr.cpp:1776
+#: src/muuli_wdr.cpp:1775
 msgid "Wildcard patterns separated by '|', e.g. .DS_Store|Thumbs.db|*.tmp. Files whose name matches are not shared. Matching is case-insensitive."
 msgstr "Motifs de caractères génériques séparés par '|', par exemple .DS_Store|Thumbs.db|*.tmp. Les fichiers dont le nom correspond ne seront pas partagés. La correspondance est insensible à la casse."
 
-#: src/muuli_wdr.cpp:1780
+#: src/muuli_wdr.cpp:1779
 msgid "Patterns are regular expressions"
 msgstr "Les motifs sont des expressions régulières"
 
-#: src/muuli_wdr.cpp:1781
+#: src/muuli_wdr.cpp:1780
 msgid "When set, the whole field is one regular expression ('|' is alternation). When unset, it is a list of '|'-separated wildcards."
 msgstr "Lorsque l'option est activée, la totalité du champ est une expression régulière ('|' indique une alternative). Lorsque l'option est désactivée, il s'agit d'une liste de caractères génériques séparés par des '|'."
 
-#: src/muuli_wdr.cpp:1791
+#: src/muuli_wdr.cpp:1790
 msgid "Show how many shared files the current pattern would exclude."
 msgstr "Afficher combien de fichiers partagés le motif actuel exclurait."
 
-#: src/muuli_wdr.cpp:1812
+#: src/muuli_wdr.cpp:1811
 msgid "Graphs"
 msgstr "Graphiques"
 
-#: src/muuli_wdr.cpp:1815 src/muuli_wdr.cpp:1877
+#: src/muuli_wdr.cpp:1814 src/muuli_wdr.cpp:1876
 msgid "Update delay : 5 secs"
 msgstr "Délais de rafraîchissement : 5 s"
 
-#: src/muuli_wdr.cpp:1819
+#: src/muuli_wdr.cpp:1818
 msgid "Time for average graph: 100 mins"
 msgstr "Temps pour la courbe de la moyenne : 100 min"
 
-#: src/muuli_wdr.cpp:1823
+#: src/muuli_wdr.cpp:1822
 msgid "Connections Graph Scale: 100 "
 msgstr "Échelle du graphique des connexions : 100 "
 
-#: src/muuli_wdr.cpp:1830
+#: src/muuli_wdr.cpp:1829
 msgid "Download graph scale:"
 msgstr "Échelle des graphiques de réception :"
 
-#: src/muuli_wdr.cpp:1838
+#: src/muuli_wdr.cpp:1837
 msgid "Upload graph scale:"
 msgstr "Échelle des graphiques d'envoi :"
 
-#: src/muuli_wdr.cpp:1848
+#: src/muuli_wdr.cpp:1847
 msgid "Colors: "
 msgstr "Couleurs : "
 
-#: src/muuli_wdr.cpp:1852
+#: src/muuli_wdr.cpp:1851
 msgid "Background"
 msgstr "Fond"
 
-#: src/muuli_wdr.cpp:1853
+#: src/muuli_wdr.cpp:1852
 msgid "Grid"
 msgstr "Quadrillage"
 
-#: src/muuli_wdr.cpp:1854
+#: src/muuli_wdr.cpp:1853
 msgid "Download current"
 msgstr "Téléchargement actuel"
 
-#: src/muuli_wdr.cpp:1855
+#: src/muuli_wdr.cpp:1854
 msgid "Download running average"
 msgstr "Téléchargement moyen total"
 
-#: src/muuli_wdr.cpp:1856
+#: src/muuli_wdr.cpp:1855
 msgid "Download session average"
 msgstr "Téléchargement moyen sur la session"
 
-#: src/muuli_wdr.cpp:1857
+#: src/muuli_wdr.cpp:1856
 msgid "Upload current"
 msgstr "Envoi actuel"
 
-#: src/muuli_wdr.cpp:1858
+#: src/muuli_wdr.cpp:1857
 msgid "Upload running average"
 msgstr "Envoi moyen total"
 
-#: src/muuli_wdr.cpp:1859
+#: src/muuli_wdr.cpp:1858
 msgid "Upload session average"
 msgstr "Envoi moyen sur la session"
 
-#: src/muuli_wdr.cpp:1860
+#: src/muuli_wdr.cpp:1859
 msgid "Active connections"
 msgstr "Connexions actives"
 
-#: src/muuli_wdr.cpp:1863
+#: src/muuli_wdr.cpp:1862
 msgid "Systray Icon Speed Bar"
 msgstr "Barre de vitesse dans l'icône de barre des tâches"
 
-#: src/muuli_wdr.cpp:1864
+#: src/muuli_wdr.cpp:1863
 msgid "Kad-nodes current"
 msgstr "Nœuds Kad actuels"
 
-#: src/muuli_wdr.cpp:1865
+#: src/muuli_wdr.cpp:1864
 msgid "Kad-nodes running"
 msgstr "Nœuds Kad total"
 
-#: src/muuli_wdr.cpp:1866
+#: src/muuli_wdr.cpp:1865
 msgid "Kad-nodes session"
 msgstr "Nœuds Kad pour la session"
 
-#: src/muuli_wdr.cpp:1870 src/muuli_wdr.cpp:2324
+#: src/muuli_wdr.cpp:1869 src/muuli_wdr.cpp:2296
 msgid "Select"
 msgstr "Sélectionner"
 
-#: src/muuli_wdr.cpp:1874
+#: src/muuli_wdr.cpp:1873
 msgid "Tree"
 msgstr "Arbre"
 
-#: src/muuli_wdr.cpp:1884
+#: src/muuli_wdr.cpp:1883
 msgid "Number of Client Versions shown (0=unlimited)"
 msgstr "Nombre de versions client affichées (0=illimité)"
 
-#: src/muuli_wdr.cpp:1909
+#: src/muuli_wdr.cpp:1908
 msgid "!!! WARNING !!!"
 msgstr "!!! AVERTISSEMENT !!!"
 
-#: src/muuli_wdr.cpp:1924
+#: src/muuli_wdr.cpp:1923
 msgid "Max new connections / 5 secs"
 msgstr "Nombre maximum de nouvelles connexions / 5 secs"
 
-#: src/muuli_wdr.cpp:1926
+#: src/muuli_wdr.cpp:1925
 msgid "Concurrent Kad source lookups"
 msgstr "Recherche concurrentes de sources Kad"
 
-#: src/muuli_wdr.cpp:1928
+#: src/muuli_wdr.cpp:1927
 msgid "Kad source re-search interval (minutes)"
 msgstr "Intervalle entre les nouvelles recherches de sources Kad (en minutes)"
 
-#: src/muuli_wdr.cpp:1930
+#: src/muuli_wdr.cpp:1929
 msgid "Source re-ask interval (minutes)"
 msgstr "Intervalle entre les nouvelles demandes de sources Kad (en minutes)"
 
-#: src/muuli_wdr.cpp:1934
+#: src/muuli_wdr.cpp:1933
 msgid "File Buffer Size: 240000 bytes"
 msgstr "Taille du fichier de tampon : 240000 octets"
 
-#: src/muuli_wdr.cpp:1938
+#: src/muuli_wdr.cpp:1937
 msgid "Use MMAP: memory-mapped file access (lower memory use)"
 msgstr "Utiliser MMAP : « memory-mapped file access », c'est-à-dire accès aux fichiers mappés dans la mémoire (utilise moins de mémoire)"
 
-#: src/muuli_wdr.cpp:1939
+#: src/muuli_wdr.cpp:1938
 msgid "Maps part files into memory instead of buffering them on the heap, lowering the process memory footprint. May reduce download speed on some disks; best for memory-constrained or upload-heavy hosts."
 msgstr "Fait correspondre les fichiers partiels dans la mémoire au lieu de les mettre en tampon sur la pile, baissant l'empreinte mémoire du processus. Peut réduire la vitesse de téléchargement sur certains disques ; idéal pour les hôtes disposant de peu de mémoire ou pour ceux qui téléversent beaucoup."
 
-#: src/muuli_wdr.cpp:1941
+#: src/muuli_wdr.cpp:1940
 msgid "Upload Queue Size: 5000 clients"
 msgstr "Taille de la file d'attente d'envoi : 5000 clients"
 
-#: src/muuli_wdr.cpp:1945
+#: src/muuli_wdr.cpp:1944
 msgid "Server connection refresh interval: Disable"
 msgstr "Intervalle de rafraîchissement de la connexion serveur : Désactivé"
 
-#: src/muuli_wdr.cpp:1949
+#: src/muuli_wdr.cpp:1948
 msgid "Disable computer's timed standby mode"
 msgstr "Désactiver la mise en veille programmé de l'ordinateur"
 
-#: src/muuli_wdr.cpp:1968
+#: src/muuli_wdr.cpp:1967
 msgid "Skin to use: "
 msgstr "Thème à utiliser : "
 
-#: src/muuli_wdr.cpp:1977
+#: src/muuli_wdr.cpp:1976
 msgid "Show \"Fast eD2k Links Handler\" in every window."
 msgstr "Afficher le \"Gestionnaire rapide de liens eD2k \" dans chaque fenêtre."
 
-#: src/muuli_wdr.cpp:1980
+#: src/muuli_wdr.cpp:1979
 msgid "Show extended info on categories tabs"
 msgstr "Afficher des infos supplémentaires sur les onglets des catégories"
 
-#: src/muuli_wdr.cpp:1983
+#: src/muuli_wdr.cpp:1982
 msgid "Show application version on title"
 msgstr "Afficher la version de l'application dans le titre"
 
-#: src/muuli_wdr.cpp:1985
+#: src/muuli_wdr.cpp:1984
 msgid "Show transfer rates on title"
 msgstr "Afficher les taux de transfert dans la barre de titre"
 
-#: src/muuli_wdr.cpp:1987
+#: src/muuli_wdr.cpp:1986
 msgid "Before application name"
 msgstr "Avant le nom de l'application"
 
-#: src/muuli_wdr.cpp:1989
+#: src/muuli_wdr.cpp:1988
 msgid "After application name"
 msgstr "Après le nom de l'application"
 
-#: src/muuli_wdr.cpp:1992
+#: src/muuli_wdr.cpp:1991
 msgid "Show overhead bandwidth"
 msgstr "Afficher la surcharge de la bande passante"
 
-#: src/muuli_wdr.cpp:1996
+#: src/muuli_wdr.cpp:1995
 msgid "Vertical toolbar orientation"
 msgstr "Orientation de la barre d'outils verticale"
 
-#: src/muuli_wdr.cpp:1998
+#: src/muuli_wdr.cpp:1997
 msgid "Live column sorting (auto-reorder rows as their values change)"
 msgstr "Tri des colonnes en temps réel (réorganisation automatique des lignes à mesure que leurs valeurs changent)"
 
-#: src/muuli_wdr.cpp:2005
+#: src/muuli_wdr.cpp:2004
 msgid "Download Queue Files"
 msgstr "Fichiers à télécharger en file d'attente"
 
-#: src/muuli_wdr.cpp:2008
+#: src/muuli_wdr.cpp:2007
 msgid "Show progress percentage"
 msgstr "Afficher le pourcentage de progression"
 
-#: src/muuli_wdr.cpp:2014
+#: src/muuli_wdr.cpp:2013
 msgid "Show progress bar"
 msgstr "Afficher la barre de progression"
 
-#: src/muuli_wdr.cpp:2017
+#: src/muuli_wdr.cpp:2016
 msgid "Flat"
 msgstr "Plat"
 
-#: src/muuli_wdr.cpp:2021
+#: src/muuli_wdr.cpp:2020
 msgid "Round"
 msgstr "Relief"
 
-#: src/muuli_wdr.cpp:2039
+#: src/muuli_wdr.cpp:2038
 msgid "External Connection Parameters"
 msgstr "Paramètres de Connexion Externe"
 
-#: src/muuli_wdr.cpp:2042
+#: src/muuli_wdr.cpp:2041
 msgid "Accept external connections"
 msgstr "Accepter les connexions externes"
 
-#: src/muuli_wdr.cpp:2049 src/muuli_wdr.cpp:2108
+#: src/muuli_wdr.cpp:2048 src/muuli_wdr.cpp:2107
 msgid "IP of the listening interface:"
 msgstr "IP de l'interface d'écoute :"
 
-#: src/muuli_wdr.cpp:2052
+#: src/muuli_wdr.cpp:2051
 msgid "Enter here a valid ip in the a.b.c.d format for the listening EC interface. An empty field or 0.0.0.0 will mean any interface."
 msgstr "Entrer ici une adresse IP valide dans le format a.b.c.d pour l'interface d'écoute EC. Un champ vide ou 0.0.0.0 signifiera toutes les interfaces."
 
-#: src/muuli_wdr.cpp:2073 src/muuli_wdr.cpp:2184
+#: src/muuli_wdr.cpp:2072 src/muuli_wdr.cpp:2156
 msgid "TCP port:"
 msgstr "Port TCP :"
 
-#: src/muuli_wdr.cpp:2079
+#: src/muuli_wdr.cpp:2078
 msgid "Enable UPnP port forwarding on the EC port"
 msgstr "Activer la redirection de ports en UPnP sur le port EC"
 
-#: src/muuli_wdr.cpp:2083 src/muuli_wdr.cpp:3069
+#: src/muuli_wdr.cpp:2082 src/muuli_wdr.cpp:3041
 #: src/utils/wxCas/src/wxcasprefs.cpp:167
 msgid "Password"
 msgstr "Mot de passe"
 
-#: src/muuli_wdr.cpp:2089
+#: src/muuli_wdr.cpp:2088
 msgid "aMule API server parameters"
 msgstr "Paramètres du serveur aMule API"
 
-#: src/muuli_wdr.cpp:2092
+#: src/muuli_wdr.cpp:2091
 msgid "Run amuleapi (REST API) on startup"
 msgstr "Exécuter amuleapi (API REST) au démarrage"
 
-#: src/muuli_wdr.cpp:2097
+#: src/muuli_wdr.cpp:2096
 msgid "HTTP port:"
 msgstr "Port HTTP :"
 
-#: src/muuli_wdr.cpp:2111
+#: src/muuli_wdr.cpp:2110
 msgid "The interface amuleapi's HTTP server listens on. 127.0.0.1 (default) accepts only local connections; use 0.0.0.0 or a specific IP to expose it to other hosts (set an admin password below)."
 msgstr "L'interface sur laquelle le serveur HTTP d'amuleapi écoute. 127.0.0.1 (par défaut) n'accepte que les connexions locales  ; utilisez 0.0.0.0 ou bien une adresse IP spécifique pour l'exposer à d'autres hôtes (définissez un mot de passe administrateur ci-dessous)."
 
-#: src/muuli_wdr.cpp:2116
-msgid "Type a password to set or change it. Stored passwords cannot be shown, so leaving this empty keeps the current one."
-msgstr ""
-
-#: src/muuli_wdr.cpp:2118
+#: src/muuli_wdr.cpp:2113
 msgid "Admin password"
 msgstr "Mot de passe administrateur"
 
-#: src/muuli_wdr.cpp:2130 src/muuli_wdr.cpp:2147 src/PrefsUnifiedDlg.cpp:1103
-#, fuzzy
-msgid "A password is set."
-msgstr "Mot de passe administrateur"
-
-#: src/muuli_wdr.cpp:2134
-#, fuzzy
-msgid "Enable guest access"
-msgstr "Interdire l'accès invité"
-
-#: src/muuli_wdr.cpp:2135
-msgid "Guest sessions may read status and listings but cannot change anything. Turning this off clears the stored guest password."
-msgstr ""
-
-#: src/muuli_wdr.cpp:2139
-#, fuzzy
-msgid "Guest password"
-msgstr "Mot de passe invité pour le serveur web"
-
-#: src/muuli_wdr.cpp:2154
-msgid "Web server parameters"
-msgstr "Paramètres du serveur Web"
-
-#: src/muuli_wdr.cpp:2157
-msgid "Run webserver on startup (deprecated)"
-msgstr "Démarrer le serveur web au démarrage (obsolète)"
-
-#: src/muuli_wdr.cpp:2163
-msgid "Web template"
-msgstr "Template web"
-
-#: src/muuli_wdr.cpp:2168
-msgid "Full rights password"
-msgstr "Mot de passe administrateur"
-
-#: src/muuli_wdr.cpp:2172
-msgid "Enable Low rights User"
-msgstr "Activer l'accès utilisateur sans privilèges"
-
-#: src/muuli_wdr.cpp:2177
+#: src/muuli_wdr.cpp:2118 src/muuli_wdr.cpp:2149
 msgid "Low rights password"
 msgstr "Mot de passe sans privilèges"
 
-#: src/muuli_wdr.cpp:2191
+#: src/muuli_wdr.cpp:2126
+msgid "Web server parameters"
+msgstr "Paramètres du serveur Web"
+
+#: src/muuli_wdr.cpp:2129
+msgid "Run webserver on startup (deprecated)"
+msgstr "Démarrer le serveur web au démarrage (obsolète)"
+
+#: src/muuli_wdr.cpp:2135
+msgid "Web template"
+msgstr "Template web"
+
+#: src/muuli_wdr.cpp:2140
+msgid "Full rights password"
+msgstr "Mot de passe administrateur"
+
+#: src/muuli_wdr.cpp:2144
+msgid "Enable Low rights User"
+msgstr "Activer l'accès utilisateur sans privilèges"
+
+#: src/muuli_wdr.cpp:2163
 msgid "Enable UPnP port forwarding of the web server port"
 msgstr "Activer la redirection de port UPnP sur le port du serveur web"
 
-#: src/muuli_wdr.cpp:2196
+#: src/muuli_wdr.cpp:2168
 msgid "Web server UPnP TCP port (Optional)"
 msgstr "Port TCP UPnP du serveur web (Facultatif)"
 
-#: src/muuli_wdr.cpp:2204
+#: src/muuli_wdr.cpp:2176
 msgid "Page Refresh Time (in secs)"
 msgstr "Intervalle de rafraîchissement (en secondes)"
 
-#: src/muuli_wdr.cpp:2211
+#: src/muuli_wdr.cpp:2183
 msgid "Enable Gzip compression"
 msgstr "Activer la compression Gzip"
 
-#: src/muuli_wdr.cpp:2245
+#: src/muuli_wdr.cpp:2217
 msgid "Reset page to defaults"
 msgstr "Réinitialiser la page aux valeurs par défaut"
 
-#: src/muuli_wdr.cpp:2246
+#: src/muuli_wdr.cpp:2218
 msgid "Reset the settings on the current page to their default values."
 msgstr "Réinitialiser les réglages sur la page actuelle à leurs valeurs par défaut."
 
-#: src/muuli_wdr.cpp:2248 src/muuli_wdr.cpp:2334 src/ServerWnd.cpp:274
+#: src/muuli_wdr.cpp:2220 src/muuli_wdr.cpp:2306 src/ServerWnd.cpp:274
 #: src/ServerWnd.cpp:282
 msgid "OK"
 msgstr "OK"
 
-#: src/muuli_wdr.cpp:2250
+#: src/muuli_wdr.cpp:2222
 msgid "Click here to apply any changes made to the preferences."
 msgstr "Cliquer ici pour appliquer tous les changements effectués dans les Préférences."
 
-#: src/muuli_wdr.cpp:2253
+#: src/muuli_wdr.cpp:2225
 msgid "Reset any changes made to the preferences."
 msgstr "Annule tous les changements effectués dans les Préférences."
 
-#: src/muuli_wdr.cpp:2282
+#: src/muuli_wdr.cpp:2254
 msgid "Comment :"
 msgstr "Commentaire :"
 
-#: src/muuli_wdr.cpp:2289
+#: src/muuli_wdr.cpp:2261
 msgid "Incoming Dir :"
 msgstr "Répertoire entrant :"
 
-#: src/muuli_wdr.cpp:2298
+#: src/muuli_wdr.cpp:2270
 msgid "Change priority for new assigned files :"
 msgstr "Changer la priorité des nouveaux fichiers assignés :"
 
-#: src/muuli_wdr.cpp:2302
+#: src/muuli_wdr.cpp:2274
 msgid "Don't change"
 msgstr "Ne rien changer"
 
-#: src/muuli_wdr.cpp:2314
+#: src/muuli_wdr.cpp:2286
 msgid "Select color for this Category (currently selected) :"
 msgstr "Choisir la couleur pour cette Catégorie (actuellement sélectionnée) :"
 
-#: src/muuli_wdr.cpp:2381 src/muuli_wdr.cpp:2400 src/muuli_wdr.cpp:2422
+#: src/muuli_wdr.cpp:2353 src/muuli_wdr.cpp:2372 src/muuli_wdr.cpp:2394
 msgid "Click this button to reset the log."
 msgstr "Cliquer ici pour effacer le journal."
 
-#: src/muuli_wdr.cpp:2441
+#: src/muuli_wdr.cpp:2413
 msgid "Click on this button to update the servers list from URL ..."
 msgstr "Cliquer ici pour mettre à jour la liste des serveurs à partir de l'URL…"
 
-#: src/muuli_wdr.cpp:2445
+#: src/muuli_wdr.cpp:2417
 msgid "Server list"
 msgstr "Liste des serveurs"
 
-#: src/muuli_wdr.cpp:2449
+#: src/muuli_wdr.cpp:2421
 msgid "Enter the url to a server.met file here and press the button to the left to update the list of known servers."
 msgstr "Entrer l'URL d'un fichier server.met et presser le bouton à gauche pour rafraîchir la liste des serveurs connus."
 
-#: src/muuli_wdr.cpp:2454
+#: src/muuli_wdr.cpp:2426
 msgid "Add server manually: Name"
 msgstr "Ajouter un serveur manuellement : Nom"
 
-#: src/muuli_wdr.cpp:2457
+#: src/muuli_wdr.cpp:2429
 msgid "Enter the name of the new server here"
 msgstr "Entrer ici le nom du nouveau serveur"
 
-#: src/muuli_wdr.cpp:2459 src/ServerWnd.cpp:206
+#: src/muuli_wdr.cpp:2431 src/ServerWnd.cpp:206
 msgid "IP:Port"
 msgstr "IP : Port"
 
-#: src/muuli_wdr.cpp:2462
+#: src/muuli_wdr.cpp:2434
 msgid "Enter the IP of the server here, using the x.x.x.x format."
 msgstr "Entrer ici l'adresse IP du serveur, avec le format x.x.x.x."
 
-#: src/muuli_wdr.cpp:2468
+#: src/muuli_wdr.cpp:2440
 msgid "Enter the port of the server here."
 msgstr "Entrer ici le port du serveur."
 
-#: src/muuli_wdr.cpp:2471
+#: src/muuli_wdr.cpp:2443
 msgid "Add manually a server (fill fields to the left before) ..."
 msgstr "Ajouter manuellement un serveur (remplir les champs à gauche avant)…"
 
-#: src/muuli_wdr.cpp:2500
+#: src/muuli_wdr.cpp:2472
 msgid "aMule Log"
 msgstr "Journal d'aMule"
 
-#: src/muuli_wdr.cpp:2508
+#: src/muuli_wdr.cpp:2480
 msgid "Server Info"
 msgstr "Infos Serveur"
 
-#: src/muuli_wdr.cpp:2512
+#: src/muuli_wdr.cpp:2484
 msgid "ED2K Info"
 msgstr "Infos ED2K"
 
-#: src/muuli_wdr.cpp:2516
+#: src/muuli_wdr.cpp:2488
 msgid "Kad Info"
 msgstr "Infos Kad"
 
-#: src/muuli_wdr.cpp:2544
+#: src/muuli_wdr.cpp:2516
 msgid "Click on this button to update the nodes list from URL ..."
 msgstr "Cliquer sur le bouton pour mettre à jour la liste des nœuds depuis l'URL…"
 
-#: src/muuli_wdr.cpp:2548
+#: src/muuli_wdr.cpp:2520
 msgid "Nodes (0)"
 msgstr "Nœuds (0)"
 
-#: src/muuli_wdr.cpp:2552
+#: src/muuli_wdr.cpp:2524
 msgid "Enter the url to a nodes.dat file here and press the button to the left to update the list of known nodes."
 msgstr "Entrer l'URL d'un fichier nodes.dat ici et presser le bouton à gauche pour mettre à jour la liste des nœuds connus."
 
-#: src/muuli_wdr.cpp:2555
+#: src/muuli_wdr.cpp:2527
 msgid "Nodes stats"
 msgstr "Statistiques des nœuds"
 
-#: src/muuli_wdr.cpp:2597
+#: src/muuli_wdr.cpp:2569
 msgid "Bootstrap"
 msgstr "Amorçage"
 
-#: src/muuli_wdr.cpp:2600
+#: src/muuli_wdr.cpp:2572
 msgid "New node"
 msgstr "Nouveau nœud"
 
-#: src/muuli_wdr.cpp:2605
+#: src/muuli_wdr.cpp:2577
 msgid "IP:"
 msgstr "IP :"
 
-#: src/muuli_wdr.cpp:2625
+#: src/muuli_wdr.cpp:2597
 msgid "Port:"
 msgstr "Port :"
 
-#: src/muuli_wdr.cpp:2638
+#: src/muuli_wdr.cpp:2610
 msgid "Bootstrap from known clients"
 msgstr "Amorçage depuis les clients connus"
 
-#: src/muuli_wdr.cpp:2640
+#: src/muuli_wdr.cpp:2612
 msgid "Disconnect Kad"
 msgstr "Déconnecter Kad"
 
-#: src/muuli_wdr.cpp:2674
+#: src/muuli_wdr.cpp:2646
 msgid "Use Secure User Identification"
 msgstr "Utiliser l'Identification Utilisateur Sécurisée (SUI)"
 
-#: src/muuli_wdr.cpp:2676
+#: src/muuli_wdr.cpp:2648
 msgid "It is recommended to enable this option. You will not receive credits if SUI is not enabled."
 msgstr "Il est recommandé d'activer cette option. Vous ne recevrez pas de crédits si SUI n'est pas activé."
 
-#: src/muuli_wdr.cpp:2678
+#: src/muuli_wdr.cpp:2650
 msgid "Protocol Obfuscation"
 msgstr "Brouillage de protocole"
 
-#: src/muuli_wdr.cpp:2681
+#: src/muuli_wdr.cpp:2653
 msgid "Support Protocol Obfuscation"
 msgstr "Supporter le brouillage de protocole"
 
-#: src/muuli_wdr.cpp:2683
+#: src/muuli_wdr.cpp:2655
 msgid "This option enabled Protocol Obfuscation, and makes aMule accept obfuscated connections from other clients."
 msgstr "Cette option active le brouillage de protocole, cela permet à aMule d'accepter les connexions brouillées des autres clients."
 
-#: src/muuli_wdr.cpp:2685
+#: src/muuli_wdr.cpp:2657
 msgid "Use obfuscation for outgoing connections"
 msgstr "Utiliser le brouillage pour les connexions sortantes"
 
-#: src/muuli_wdr.cpp:2687
+#: src/muuli_wdr.cpp:2659
 msgid "This option makes aMule use Protocol Obfuscation when connecting other clients/servers."
 msgstr "Avec cette option, aMule utilise le brouillage de protocole lors des connexions aux autres clients/serveurs."
 
-#: src/muuli_wdr.cpp:2689
+#: src/muuli_wdr.cpp:2661
 msgid "Accept only obfuscated connections"
 msgstr "Accepter seulement les connexions brouillées"
 
-#: src/muuli_wdr.cpp:2690
+#: src/muuli_wdr.cpp:2662
 msgid "This option makes aMule only accept obfuscated connections. You will have less sources, but all your traffic will be obfuscated"
 msgstr "Avec cette option, aMule n'accepte que les connexions brouillées. Vous aurez moins de sources, mais tout votre trafic sera brouillé"
 
-#: src/muuli_wdr.cpp:2695
+#: src/muuli_wdr.cpp:2667
 msgid "Everybody"
 msgstr "Tout le monde"
 
-#: src/muuli_wdr.cpp:2697
+#: src/muuli_wdr.cpp:2669
 msgid "No one"
 msgstr "Personne"
 
-#: src/muuli_wdr.cpp:2699
+#: src/muuli_wdr.cpp:2671
 msgid "Who can see my shared files:"
 msgstr "Qui peut voir mes fichiers partagés :"
 
-#: src/muuli_wdr.cpp:2700
+#: src/muuli_wdr.cpp:2672
 msgid "Select who can request to view a list of your shared files."
 msgstr "Indique qui peut voir votre liste de fichiers partagés."
 
-#: src/muuli_wdr.cpp:2702
+#: src/muuli_wdr.cpp:2674
 msgid "IP-Filtering"
 msgstr "Filtrage des IP"
 
-#: src/muuli_wdr.cpp:2709
+#: src/muuli_wdr.cpp:2681
 msgid "Filter clients"
 msgstr "Filtrage des clients"
 
-#: src/muuli_wdr.cpp:2711
+#: src/muuli_wdr.cpp:2683
 msgid "Enable filtering of the client IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "Activer le filtrage des clients selon les IP contenues dans le fichier ~/.aMule/ipfilter.dat."
 
-#: src/muuli_wdr.cpp:2713
+#: src/muuli_wdr.cpp:2685
 msgid "Filter servers"
 msgstr "Filtrage des serveurs"
 
-#: src/muuli_wdr.cpp:2715
+#: src/muuli_wdr.cpp:2687
 msgid "Enable filtering of the server IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "Active le filtrage des serveurs selon les IP contenues dans le fichier ~/.aMule/ipfilter.dat."
 
-#: src/muuli_wdr.cpp:2719
+#: src/muuli_wdr.cpp:2691
 msgid "Reload List"
 msgstr "Recharger la liste"
 
-#: src/muuli_wdr.cpp:2720
+#: src/muuli_wdr.cpp:2692
 msgid "Reload the list of IPs to filter from the file ~/.aMule/ipfilter.dat"
 msgstr "Recharge la liste des IP à filtrer à partir du fichier ~/.aMule/ipfilter.dat"
 
-#: src/muuli_wdr.cpp:2726
+#: src/muuli_wdr.cpp:2698
 msgid "URL:"
 msgstr "URL :"
 
-#: src/muuli_wdr.cpp:2730 src/muuli_wdr.cpp:2923
+#: src/muuli_wdr.cpp:2702 src/muuli_wdr.cpp:2895
 msgid "Update now"
 msgstr "Mettre à jour maintenant"
 
-#: src/muuli_wdr.cpp:2733
+#: src/muuli_wdr.cpp:2705
 msgid "Auto-update ipfilter at startup"
 msgstr "Mise à jour d' IPFilter au démarrage"
 
-#: src/muuli_wdr.cpp:2737
+#: src/muuli_wdr.cpp:2709
 msgid "Filtering Level:"
 msgstr "Niveau de filtrage :"
 
-#: src/muuli_wdr.cpp:2743
+#: src/muuli_wdr.cpp:2715
 msgid "Always filter LAN IPs"
 msgstr "Toujours filtrer les IPs LAN"
 
-#: src/muuli_wdr.cpp:2746
+#: src/muuli_wdr.cpp:2718
 msgid "Paranoid handling of non-matching IPs"
 msgstr "Prise en charge paranoïaque des IPs qui ne se correspondent pas"
 
-#: src/muuli_wdr.cpp:2748
+#: src/muuli_wdr.cpp:2720
 msgid "Rejects a packet when its source IP differs from the IP the client claims (an anti-spoofing check). Disable only if it causes connection problems."
 msgstr "Rejette un paquet lorsque son IP source diffère de l'IP que le client prétend avoir (vérification anti-usurpation). Désactivez seulement si cela provoque des problèmes de connexion."
 
-#: src/muuli_wdr.cpp:2750
+#: src/muuli_wdr.cpp:2722
 msgid "Use system-wide ipfilter.dat if available"
 msgstr "Utiliser un ipfilter.dat système si disponible"
 
-#: src/muuli_wdr.cpp:2751
+#: src/muuli_wdr.cpp:2723
 msgid "If there's no local ipfilter.dat found, allow usage of a system-wide ipfilter file."
 msgstr "S'il n'y a pas de fichier ipfilter.dat local, autoriser l'utilisation d'un fichier ipfilter système."
 
-#: src/muuli_wdr.cpp:2768
+#: src/muuli_wdr.cpp:2740
 msgid "Enable Online-Signature"
 msgstr "Activer la Signature En Ligne"
 
-#: src/muuli_wdr.cpp:2770
+#: src/muuli_wdr.cpp:2742
 msgid "Enables the writing of the OS file, which can be used by external apps to create signatures and the like."
 msgstr "Active l'écriture du fichier de signature en ligne, qui peut-être utilisé par des applications extérieures pour créer des signatures, etc."
 
-#: src/muuli_wdr.cpp:2774
+#: src/muuli_wdr.cpp:2746
 msgid "Update Frequency (Secs):"
 msgstr "Fréquence de mise à jour (Secondes) :"
 
-#: src/muuli_wdr.cpp:2777
+#: src/muuli_wdr.cpp:2749
 msgid "Change the frequency (in seconds) of Online Signature updates."
 msgstr "Change la fréquence des mises à jour de la signature en ligne (en secondes)."
 
-#: src/muuli_wdr.cpp:2785
+#: src/muuli_wdr.cpp:2757
 msgid "Save online signature file in: "
 msgstr "Sauver le fichier de signature en ligne dans : "
 
-#: src/muuli_wdr.cpp:2791
+#: src/muuli_wdr.cpp:2763
 msgid "Click here to select the directory containing the the Online Signature files."
 msgstr "Cliquer ici pour sélectionner le répertoire contenant le fichier de signature en ligne."
 
-#: src/muuli_wdr.cpp:2824
+#: src/muuli_wdr.cpp:2796
 msgid "Show country flags for clients"
 msgstr "Voir les drapeaux des pays pour les clients"
 
-#: src/muuli_wdr.cpp:2825
+#: src/muuli_wdr.cpp:2797
 msgid "Render the country flag column in the transfers, queue and search views. Requires a valid MMDB GeoIP database (see below)."
 msgstr "Afficher la colonne des drapeaux des pays dans les vues des transferts, des files d'attente et de recherche. Nécessite une base de données MMDB GeoIP valide (cf. ci-dessous)."
 
-#: src/muuli_wdr.cpp:2830
+#: src/muuli_wdr.cpp:2802
 msgid "Database"
 msgstr "Base de données"
 
-#: src/muuli_wdr.cpp:2846
+#: src/muuli_wdr.cpp:2818
 msgid "Source:"
 msgstr "Source :"
 
-#: src/muuli_wdr.cpp:2849
+#: src/muuli_wdr.cpp:2821
 msgid "DB-IP (free, no account)"
 msgstr "DB-IP (gratuit, pas de compte)"
 
-#: src/muuli_wdr.cpp:2850
+#: src/muuli_wdr.cpp:2822
 msgid "MaxMind GeoLite2 (free, account required)"
 msgstr "MaxMind GeoLite2 (gratuit, compte nécessaire)"
 
-#: src/muuli_wdr.cpp:2851
+#: src/muuli_wdr.cpp:2823
 msgid "Custom URL"
 msgstr "URL personnalisé"
 
-#: src/muuli_wdr.cpp:2854
+#: src/muuli_wdr.cpp:2826
 msgid "Choose which provider supplies the GeoIP MMDB database. DB-IP is the default - no account required. MaxMind requires a free account + license key. Use Custom URL to point at any other MMDB host (e.g. a local mirror)."
 msgstr "Choisissez quel fournisseur procure la base de données GeoIP MMDB. DB-IP est la valeur par défaut - ne nécessite pas de compte. MaxMind nécessite un compte gratuit + une clef de licence. Utilisez un URL personnalisé pour pointer vers tout autre hôte MMDB (par exemple un miroir local)."
 
-#: src/muuli_wdr.cpp:2871
+#: src/muuli_wdr.cpp:2843
 msgid ""
 "No configuration required.\n"
 "\n"
@@ -4852,11 +4818,11 @@ msgstr ""
 "Les données IP vers pays par DB-IP.com - https://db-ip.com\n"
 "Licence : Creative Commons Attribution 4.0 - https://creativecommons.org/licenses/by/4.0/deed.fr"
 
-#: src/muuli_wdr.cpp:2884
+#: src/muuli_wdr.cpp:2856
 msgid "License key:"
 msgstr "Clef de licence :"
 
-#: src/muuli_wdr.cpp:2890
+#: src/muuli_wdr.cpp:2862
 msgid ""
 "Sign up for a free MaxMind account, then generate a License Key:\n"
 "https://www.maxmind.com/en/geolite2/signup\n"
@@ -4872,11 +4838,11 @@ msgstr ""
 "Licence : CLUF MaxMind GeoLite2 - https://www.maxmind.com/en/geolite2/eula\n"
 "Nécessite une attribution et la création d'un compte ; actualisez au moins tous les 30 jours."
 
-#: src/muuli_wdr.cpp:2905
+#: src/muuli_wdr.cpp:2877
 msgid "Download URL:"
 msgstr "URL de téléchargement :"
 
-#: src/muuli_wdr.cpp:2911
+#: src/muuli_wdr.cpp:2883
 msgid ""
 "Must point to an .mmdb file or a .gz / .tar.gz containing one.\n"
 "URL may include credentials (https://user:pass@host/...).\n"
@@ -4886,211 +4852,211 @@ msgstr ""
 "L'URL peut contenir un identifiant et mot de passe (https://utilisateur:motdepasse@hôte/...) \n"
 "La licence et les conditions d'attribution sont définies par l'URL d'origine - vous en êtes responsable."
 
-#: src/muuli_wdr.cpp:2924
+#: src/muuli_wdr.cpp:2896
 msgid "Download the GeoIP database from the selected source."
 msgstr "Télécharger la base de données GeoIP depuis la source sélectionnée."
 
-#: src/muuli_wdr.cpp:2926
+#: src/muuli_wdr.cpp:2898
 msgid "Auto-update on startup"
 msgstr "Mise à jour automatique au démarrage"
 
-#: src/muuli_wdr.cpp:2927
+#: src/muuli_wdr.cpp:2899
 msgid "Re-download the GeoIP database from the selected source every time aMule starts."
 msgstr "Télécharger à nouveau la base de données GeoIP depuis la source sélectionnée chaque fois qu'aMule démarre."
 
-#: src/muuli_wdr.cpp:2950
+#: src/muuli_wdr.cpp:2922
 msgid "Filter incoming messages (except current chat):"
 msgstr "Filtrer les messages entrant (sauf la discussion en cours) :"
 
-#: src/muuli_wdr.cpp:2952
+#: src/muuli_wdr.cpp:2924
 msgid "Filter all messages"
 msgstr "Filtrer tous les messages"
 
-#: src/muuli_wdr.cpp:2954
+#: src/muuli_wdr.cpp:2926
 msgid "Filter messages from people not on your friend list"
 msgstr "Filtrer les messages des gens qui ne sont pas sur votre liste d'amis"
 
-#: src/muuli_wdr.cpp:2956
+#: src/muuli_wdr.cpp:2928
 msgid "Filter messages from unknown clients"
 msgstr "Filtrer les messages des clients inconnus"
 
-#: src/muuli_wdr.cpp:2958
+#: src/muuli_wdr.cpp:2930
 msgid "Filter messages containing (use ',' as separator):"
 msgstr "Filtrer les messages contenant (utiliser ',' comme séparateur) :"
 
-#: src/muuli_wdr.cpp:2961 src/muuli_wdr.cpp:2972
+#: src/muuli_wdr.cpp:2933 src/muuli_wdr.cpp:2944
 msgid "add here the words amule should filter and block messages including it"
 msgstr "ajouter ici les mots qu'aMule doit filtrer : blocage des messages les contenant"
 
-#: src/muuli_wdr.cpp:2963
+#: src/muuli_wdr.cpp:2935
 msgid "Show received messages in the log"
 msgstr "Afficher les messages reçus dans le journal"
 
-#: src/muuli_wdr.cpp:2966
+#: src/muuli_wdr.cpp:2938
 msgid "Comments"
 msgstr "Commentaires"
 
-#: src/muuli_wdr.cpp:2969
+#: src/muuli_wdr.cpp:2941
 msgid "Filter comments containing (use ',' as separator):"
 msgstr "Filtrer les commentaires contenant (utiliser ',' comme séparateur) :"
 
-#: src/muuli_wdr.cpp:2994
+#: src/muuli_wdr.cpp:2966
 msgid "Enable Proxy"
 msgstr "Activer le Proxy"
 
-#: src/muuli_wdr.cpp:2995
+#: src/muuli_wdr.cpp:2967
 msgid "Enable/disable proxy support"
 msgstr "Active/Désactive le support proxy"
 
-#: src/muuli_wdr.cpp:2998
+#: src/muuli_wdr.cpp:2970
 msgid "Proxy type:"
 msgstr "Type de proxy :"
 
-#: src/muuli_wdr.cpp:3009
+#: src/muuli_wdr.cpp:2981
 msgid "Proxy host:"
 msgstr "Hôte du proxy :"
 
-#: src/muuli_wdr.cpp:3012
+#: src/muuli_wdr.cpp:2984
 msgid "The proxy host name"
 msgstr "Nom de l'hôte du proxy"
 
-#: src/muuli_wdr.cpp:3014
+#: src/muuli_wdr.cpp:2986
 msgid "Proxy port:"
 msgstr "Port du proxy :"
 
-#: src/muuli_wdr.cpp:3017
+#: src/muuli_wdr.cpp:2989
 msgid "The proxy port"
 msgstr "Numéro du port du proxy"
 
-#: src/muuli_wdr.cpp:3019
+#: src/muuli_wdr.cpp:2991
 msgid "Enable authentication"
 msgstr "Activer l'authentification"
 
-#: src/muuli_wdr.cpp:3020
+#: src/muuli_wdr.cpp:2992
 msgid "Enable/disable username/password authentication"
 msgstr "Active/Désactive l'authentification par nom d'utilisateur/mot de passe"
 
-#: src/muuli_wdr.cpp:3023
+#: src/muuli_wdr.cpp:2995
 msgid "Username: "
 msgstr "Nom d'utilisateur : "
 
-#: src/muuli_wdr.cpp:3026
+#: src/muuli_wdr.cpp:2998
 msgid "The username to use to connect to the proxy"
 msgstr "Nom d'utilisateur pour se connecter au proxy"
 
-#: src/muuli_wdr.cpp:3028
+#: src/muuli_wdr.cpp:3000
 msgid "Password:"
 msgstr "Mot de passe :"
 
-#: src/muuli_wdr.cpp:3031
+#: src/muuli_wdr.cpp:3003
 msgid "The password to use to connect to the proxy"
 msgstr "Mot de passe pour se connecter au proxy"
 
-#: src/muuli_wdr.cpp:3050
+#: src/muuli_wdr.cpp:3022
 msgid "Connect to:"
 msgstr "Se connecter à :"
 
-#: src/muuli_wdr.cpp:3059
+#: src/muuli_wdr.cpp:3031
 msgid "Login to remote amule"
 msgstr "Connexion distante à aMule"
 
-#: src/muuli_wdr.cpp:3064
+#: src/muuli_wdr.cpp:3036
 msgid "User name"
 msgstr "Nom d'utilisateur"
 
-#: src/muuli_wdr.cpp:3075
+#: src/muuli_wdr.cpp:3047
 msgid "Remember those settings"
 msgstr "Se rappeler de ces réglages"
 
-#: src/muuli_wdr.cpp:3078
+#: src/muuli_wdr.cpp:3050
 msgid "Force ZLIB compression"
 msgstr "Forcer la compression ZLIB"
 
-#: src/muuli_wdr.cpp:3102
+#: src/muuli_wdr.cpp:3074
 msgid "Enable Verbose Debug-Logging."
 msgstr "Activer l'historique du mode de débogage bavard."
 
-#: src/muuli_wdr.cpp:3104
+#: src/muuli_wdr.cpp:3076
 msgid "Only to Logfile"
 msgstr "Seulement vers le fichier journal"
 
-#: src/muuli_wdr.cpp:3106
+#: src/muuli_wdr.cpp:3078
 msgid "Message Categories:"
 msgstr "Catégories des messages :"
 
-#: src/muuli_wdr.cpp:3130 src/PartFileConvertDlg.cpp:160
+#: src/muuli_wdr.cpp:3102 src/PartFileConvertDlg.cpp:160
 msgid "Waiting..."
 msgstr "En attente…"
 
-#: src/muuli_wdr.cpp:3150
+#: src/muuli_wdr.cpp:3122
 msgid "Add imports"
 msgstr "Ajouter des fichiers à importer"
 
-#: src/muuli_wdr.cpp:3153
+#: src/muuli_wdr.cpp:3125
 msgid "Retry selected"
 msgstr "Réessayer avec la sélection"
 
-#: src/muuli_wdr.cpp:3155
+#: src/muuli_wdr.cpp:3127
 msgid "Remove selected"
 msgstr "Supprimer la sélection"
 
-#: src/muuli_wdr.cpp:3218
+#: src/muuli_wdr.cpp:3190
 msgid "Event Types"
 msgstr "Types d'événements"
 
-#: src/muuli_wdr.cpp:3237
+#: src/muuli_wdr.cpp:3209
 msgid "Statistics and queued clients for selected file(s) : Session / All time"
 msgstr "Statistiques et clients en attente pour le(s) fichier(s) sélectionné(s) : Session / Tous les temps"
 
-#: src/muuli_wdr.cpp:3261
+#: src/muuli_wdr.cpp:3233
 msgid "Active Uploads"
 msgstr "Envois Actifs"
 
-#: src/muuli_wdr.cpp:3275
+#: src/muuli_wdr.cpp:3247
 msgid "Percent of total files"
 msgstr "Pourcentage du total de fichiers"
 
-#: src/muuli_wdr.cpp:3327
+#: src/muuli_wdr.cpp:3299
 msgid "Show Clients for"
 msgstr "Afficher les clients pour"
 
-#: src/muuli_wdr.cpp:3329
+#: src/muuli_wdr.cpp:3301
 msgid "All files"
 msgstr "Tous les fichiers"
 
-#: src/muuli_wdr.cpp:3332
+#: src/muuli_wdr.cpp:3304
 msgid "Selected files"
 msgstr "Fichiers sélectionnés"
 
-#: src/muuli_wdr.cpp:3335
+#: src/muuli_wdr.cpp:3307
 msgid "Active uploads only"
 msgstr "Envois actifs seulement"
 
-#: src/muuli_wdr.cpp:3342
+#: src/muuli_wdr.cpp:3314
 msgid "Reload:"
 msgstr "Recharger :"
 
-#: src/muuli_wdr.cpp:3346
+#: src/muuli_wdr.cpp:3318
 msgid "Reload your shared files"
 msgstr "Recharge vos fichiers partagés"
 
-#: src/muuli_wdr.cpp:3409
+#: src/muuli_wdr.cpp:3381
 msgid "Send"
 msgstr "Envoyer"
 
-#: src/muuli_wdr.cpp:3410
+#: src/muuli_wdr.cpp:3382
 msgid "Sends the specified message."
 msgstr "Envoie le message spécifié."
 
-#: src/muuli_wdr.cpp:3414
+#: src/muuli_wdr.cpp:3386
 msgid "Close this chat-session."
 msgstr "Ferme cette session de discussion."
 
-#: src/muuli_wdr.cpp:3437
+#: src/muuli_wdr.cpp:3409
 msgid "Connect to any server and/or Kad"
 msgstr "Se connecter à n'importe quel serveur et/ou Kad"
 
-#: src/muuli_wdr.cpp:3443 src/SharedFilesCtrl.cpp:142 src/Statistics.cpp:941
+#: src/muuli_wdr.cpp:3415 src/SharedFilesCtrl.cpp:142 src/Statistics.cpp:941
 msgid "Shared Files"
 msgstr "Fichiers partagés"
 
@@ -5450,248 +5416,248 @@ msgstr "Téléchargé"
 msgid "ERROR: Failed to open partfile '%s'"
 msgstr "ERREUR : Impossible d'ouvrir fichier .part : '%s'"
 
-#: src/Preferences.cpp:701
+#: src/Preferences.cpp:673
 msgid "System default"
 msgstr "Système par défaut"
 
-#: src/Preferences.cpp:702
+#: src/Preferences.cpp:674
 msgid "Albanian"
 msgstr "Albanais"
 
-#: src/Preferences.cpp:703
+#: src/Preferences.cpp:675
 msgid "Arabic"
 msgstr "Arabe"
 
-#: src/Preferences.cpp:704
+#: src/Preferences.cpp:676
 msgid "Asturian"
 msgstr "Asturien"
 
-#: src/Preferences.cpp:705
+#: src/Preferences.cpp:677
 msgid "Basque"
 msgstr "Basque"
 
-#: src/Preferences.cpp:706
+#: src/Preferences.cpp:678
 msgid "Bulgarian"
 msgstr "Bulgare"
 
-#: src/Preferences.cpp:707
+#: src/Preferences.cpp:679
 msgid "Catalan"
 msgstr "Catalan"
 
-#: src/Preferences.cpp:708
+#: src/Preferences.cpp:680
 msgid "Chinese (Simplified)"
 msgstr "Chinois (Simplifié)"
 
-#: src/Preferences.cpp:709
+#: src/Preferences.cpp:681
 msgid "Chinese (Traditional)"
 msgstr "Chinois (Traditionnel)"
 
-#: src/Preferences.cpp:710
+#: src/Preferences.cpp:682
 msgid "Croatian"
 msgstr "Croate"
 
-#: src/Preferences.cpp:711
+#: src/Preferences.cpp:683
 msgid "Czech"
 msgstr "Tchèque"
 
-#: src/Preferences.cpp:712
+#: src/Preferences.cpp:684
 msgid "Danish"
 msgstr "Danois"
 
-#: src/Preferences.cpp:713
+#: src/Preferences.cpp:685
 msgid "Dutch"
 msgstr "Hollandais"
 
-#: src/Preferences.cpp:714
+#: src/Preferences.cpp:686
 msgid "English (U.K.)"
 msgstr "Anglais (U.K.)"
 
-#: src/Preferences.cpp:715
+#: src/Preferences.cpp:687
 msgid "English (U.S.)"
 msgstr "Anglais (É-U)"
 
-#: src/Preferences.cpp:716
+#: src/Preferences.cpp:688
 msgid "Estonian"
 msgstr "Estonien"
 
-#: src/Preferences.cpp:717
+#: src/Preferences.cpp:689
 msgid "Finnish"
 msgstr "Finlandais"
 
-#: src/Preferences.cpp:718
+#: src/Preferences.cpp:690
 msgid "French"
 msgstr "Français"
 
-#: src/Preferences.cpp:719
+#: src/Preferences.cpp:691
 msgid "Galician"
 msgstr "Galicien"
 
-#: src/Preferences.cpp:720
+#: src/Preferences.cpp:692
 msgid "German"
 msgstr "Allemand"
 
-#: src/Preferences.cpp:721
+#: src/Preferences.cpp:693
 msgid "Greek"
 msgstr "Grec"
 
-#: src/Preferences.cpp:722
+#: src/Preferences.cpp:694
 msgid "Hebrew"
 msgstr "Hébreux"
 
-#: src/Preferences.cpp:723
+#: src/Preferences.cpp:695
 msgid "Hungarian"
 msgstr "Hongrois"
 
-#: src/Preferences.cpp:724
+#: src/Preferences.cpp:696
 msgid "Italian"
 msgstr "Italien"
 
-#: src/Preferences.cpp:725
+#: src/Preferences.cpp:697
 msgid "Japanese"
 msgstr "Japonais"
 
-#: src/Preferences.cpp:726
+#: src/Preferences.cpp:698
 msgid "Korean"
 msgstr "Coréen"
 
-#: src/Preferences.cpp:727
+#: src/Preferences.cpp:699
 msgid "Latvian"
 msgstr "Letton"
 
-#: src/Preferences.cpp:728
+#: src/Preferences.cpp:700
 msgid "Lithuanian"
 msgstr "Lituanien"
 
-#: src/Preferences.cpp:729
+#: src/Preferences.cpp:701
 msgid "Norwegian (Nynorsk)"
 msgstr "Norvégien (Nynorsk)"
 
-#: src/Preferences.cpp:730
+#: src/Preferences.cpp:702
 msgid "Polish"
 msgstr "Polonais"
 
-#: src/Preferences.cpp:731
+#: src/Preferences.cpp:703
 msgid "Portuguese"
 msgstr "Portugais"
 
-#: src/Preferences.cpp:732
+#: src/Preferences.cpp:704
 msgid "Portuguese (Brazilian)"
 msgstr "Portugais (Brésilien)"
 
-#: src/Preferences.cpp:733
+#: src/Preferences.cpp:705
 msgid "Romanian"
 msgstr "Roumain"
 
-#: src/Preferences.cpp:734
+#: src/Preferences.cpp:706
 msgid "Russian"
 msgstr "Russe"
 
-#: src/Preferences.cpp:735
+#: src/Preferences.cpp:707
 msgid "Slovenian"
 msgstr "Slovène"
 
-#: src/Preferences.cpp:736
+#: src/Preferences.cpp:708
 msgid "Spanish"
 msgstr "Espagnol"
 
-#: src/Preferences.cpp:737
+#: src/Preferences.cpp:709
 msgid "Swedish"
 msgstr "Suédois"
 
-#: src/Preferences.cpp:738
+#: src/Preferences.cpp:710
 msgid "Turkish"
 msgstr "Turc"
 
-#: src/Preferences.cpp:739
+#: src/Preferences.cpp:711
 msgid "Ukrainian"
 msgstr "Ukrainien"
 
-#: src/Preferences.cpp:842
+#: src/Preferences.cpp:814
 msgid "Change Language"
 msgstr "Changer de langue"
 
-#: src/Preferences.cpp:906
+#: src/Preferences.cpp:878
 msgid "There are no translations installed for aMule"
 msgstr "Il n'y a pas de traductions installées pour aMule"
 
-#: src/Preferences.cpp:907
+#: src/Preferences.cpp:879
 msgid "No languages available"
 msgstr "Pas de langues disponibles"
 
-#: src/Preferences.cpp:1038
+#: src/Preferences.cpp:1010
 msgid "no options available"
 msgstr "pas d'option disponible"
 
-#: src/Preferences.cpp:2226
+#: src/Preferences.cpp:2179
 msgid "Invalid category found, skipping"
 msgstr "Catégorie invalide trouvée, on passe"
 
-#: src/Preferences.cpp:2395
+#: src/Preferences.cpp:2348
 msgid "TCP port can't be higher than 65532 due to server UDP socket being TCP+3"
 msgstr "Le port TCP ne peut pas dépasser 65532 car le socket UDP du serveur sera à TCP+3"
 
-#: src/Preferences.cpp:2396
+#: src/Preferences.cpp:2349
 #, c-format
 msgid "Default port will be used (%d)"
 msgstr "Le port par défaut sera utilisé (%d)"
 
-#: src/PrefsUnifiedDlg.cpp:300 src/Statistics.cpp:866
+#: src/PrefsUnifiedDlg.cpp:298 src/Statistics.cpp:866
 msgid "Connection"
 msgstr "Connexion"
 
-#: src/PrefsUnifiedDlg.cpp:301 src/SearchListCtrl.cpp:117
+#: src/PrefsUnifiedDlg.cpp:299 src/SearchListCtrl.cpp:117
 msgid "Directories"
 msgstr "Répertoires"
 
-#: src/PrefsUnifiedDlg.cpp:302 src/Statistics.cpp:917
+#: src/PrefsUnifiedDlg.cpp:300 src/Statistics.cpp:917
 msgid "Servers"
 msgstr "Serveurs"
 
-#: src/PrefsUnifiedDlg.cpp:303 src/ServerListCtrl.cpp:96
+#: src/PrefsUnifiedDlg.cpp:301 src/ServerListCtrl.cpp:96
 msgid "Files"
 msgstr "Fichiers"
 
-#: src/PrefsUnifiedDlg.cpp:304
+#: src/PrefsUnifiedDlg.cpp:302
 msgid "Security"
 msgstr "Sécurité"
 
-#: src/PrefsUnifiedDlg.cpp:305
+#: src/PrefsUnifiedDlg.cpp:303
 msgid "Interface"
 msgstr "Interface"
 
-#: src/PrefsUnifiedDlg.cpp:312
+#: src/PrefsUnifiedDlg.cpp:310
 msgid "IP2Country"
 msgstr "IP2Country"
 
-#: src/PrefsUnifiedDlg.cpp:315
+#: src/PrefsUnifiedDlg.cpp:313
 msgid "Proxy"
 msgstr "Proxy"
 
-#: src/PrefsUnifiedDlg.cpp:316
+#: src/PrefsUnifiedDlg.cpp:314
 msgid "Filters"
 msgstr "Filtres"
 
-#: src/PrefsUnifiedDlg.cpp:317
+#: src/PrefsUnifiedDlg.cpp:315
 msgid "Remote Controls"
 msgstr "Contrôles à distance"
 
-#: src/PrefsUnifiedDlg.cpp:318
+#: src/PrefsUnifiedDlg.cpp:316
 msgid "Online Signature"
 msgstr "Signature en ligne"
 
-#: src/PrefsUnifiedDlg.cpp:319
+#: src/PrefsUnifiedDlg.cpp:317
 msgid "Advanced"
 msgstr "Avancé"
 
-#: src/PrefsUnifiedDlg.cpp:320
+#: src/PrefsUnifiedDlg.cpp:318
 msgid "Events"
 msgstr "Événements"
 
-#: src/PrefsUnifiedDlg.cpp:323
+#: src/PrefsUnifiedDlg.cpp:321
 msgid "Debugging"
 msgstr "Débogage"
 
-#: src/PrefsUnifiedDlg.cpp:453
+#: src/PrefsUnifiedDlg.cpp:451
 msgid ""
 "The following variables will be substituted:\n"
 "    %PARTFILE - full path to the file\n"
@@ -5701,15 +5667,15 @@ msgstr ""
 "    %PARTFILE - chemin complet vers le fichier\n"
 "    %PARTNAME - nom du fichier seulement"
 
-#: src/PrefsUnifiedDlg.cpp:474
+#: src/PrefsUnifiedDlg.cpp:472
 msgid "Tray icon support requires libayatana-appindicator3 at compile time."
 msgstr "L'icône de la barre système nécessite libayatana-appindicator3 au moment de la compilation."
 
-#: src/PrefsUnifiedDlg.cpp:490
+#: src/PrefsUnifiedDlg.cpp:488
 msgid "Not available on Wayland: the protocol does not report when a window is minimized, so this option cannot intercept the system minimize button. Workaround: launch aMule with `GDK_BACKEND=x11` to use XWayland instead."
 msgstr "Non disponible sous Wayland : le protocole n'informe pas lorsqu'une fenêtre est minimisée, cette option ne peut donc intercepter le bouton de minimisation du système. Solution de contournement : lancez aMule avec `GDK_BACKEND=x11` pour utiliser XWayland à la place."
 
-#: src/PrefsUnifiedDlg.cpp:536
+#: src/PrefsUnifiedDlg.cpp:534
 msgid ""
 "Do not change these setting unless you know\n"
 "what you are doing, otherwise you can easily\n"
@@ -5725,35 +5691,26 @@ msgstr ""
 "aMule fonctionnera bien en ne modifiant pas\n"
 "ces réglages."
 
-#: src/PrefsUnifiedDlg.cpp:647
+#: src/PrefsUnifiedDlg.cpp:645
 #, c-format
 msgid "Failed to connect Cfg to widget with the ID %d and key %s"
 msgstr "Échec à la connexion de Cfg au widget avec l'ID %d et la clé %s"
 
-#: src/PrefsUnifiedDlg.cpp:695
+#: src/PrefsUnifiedDlg.cpp:693
 #, c-format
 msgid "Failed to transfer data from Cfg to Widget with the ID %d and key %s"
 msgstr "Échec du transfert de données depuis Cfg vers le widget avec l'ID %d et la clé %s"
 
-#: src/PrefsUnifiedDlg.cpp:801
+#: src/PrefsUnifiedDlg.cpp:799
 msgid "The type of proxy you are connecting to"
 msgstr "Type de proxy auquel vous êtes connecté"
 
-#: src/PrefsUnifiedDlg.cpp:1020
+#: src/PrefsUnifiedDlg.cpp:1003
 #, c-format
 msgid "Failed to transfer data from Widget to Cfg with the ID %d and key %s"
 msgstr "Échec du transfert de données depuis le widget vers Cfg avec l'ID %d et la clé %s"
 
 #: src/PrefsUnifiedDlg.cpp:1103
-#, fuzzy
-msgid "No password set."
-msgstr "Mot de passe administrateur"
-
-#: src/PrefsUnifiedDlg.cpp:1132
-msgid "Guest access needs a password. Type one in the guest password field, or untick Enable guest access."
-msgstr ""
-
-#: src/PrefsUnifiedDlg.cpp:1144
 msgid ""
 "aMule must be restarted to enable these changes:\n"
 "\n"
@@ -5761,39 +5718,39 @@ msgstr ""
 "aMule doit être redémarré pour activer ces changements : \n"
 "\n"
 
-#: src/PrefsUnifiedDlg.cpp:1151
+#: src/PrefsUnifiedDlg.cpp:1110
 msgid "- TCP port changed.\n"
 msgstr "- Port TCP changé.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1156
+#: src/PrefsUnifiedDlg.cpp:1115
 msgid "- UDP port changed.\n"
 msgstr "- Port UDP changé.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1161
+#: src/PrefsUnifiedDlg.cpp:1120
 msgid "- Network interface binding changed.\n"
 msgstr "- La liaison de Interface réseau modifiée.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1166
+#: src/PrefsUnifiedDlg.cpp:1125
 msgid "- External connect port changed.\n"
 msgstr "- Port de connexion externe changé.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1170
+#: src/PrefsUnifiedDlg.cpp:1129
 msgid "- External connect acceptance changed.\n"
 msgstr "- Consentement de connexion externe changé.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1174
+#: src/PrefsUnifiedDlg.cpp:1133
 msgid "- External connect interface changed.\n"
 msgstr "- Interface de connexion externe changé.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1178
+#: src/PrefsUnifiedDlg.cpp:1137
 msgid "- Protocol obfuscation support changed.\n"
 msgstr "- Support du brouillage de protocole changé.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1193
+#: src/PrefsUnifiedDlg.cpp:1151
 msgid "- amuleapi settings changed.\n"
 msgstr "- les réglages amuleapi modifiés.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1202
+#: src/PrefsUnifiedDlg.cpp:1160
 msgid ""
 "Your Auto-update server list is empty.\n"
 "'Auto-update server list at startup' will be disabled."
@@ -5801,7 +5758,7 @@ msgstr ""
 "Votre liste de serveur pour la mise à jour automatique est vide.\n"
 "'Mise à jour automatique au démarrage de la liste des serveurs' va être désactivée."
 
-#: src/PrefsUnifiedDlg.cpp:1213
+#: src/PrefsUnifiedDlg.cpp:1171
 msgid ""
 "You have enabled external connections but have not specified a password.\n"
 "External connections cannot be enabled unless a valid password is specified."
@@ -5809,32 +5766,27 @@ msgstr ""
 "Vous avez activé les connexions externes mais vous n'avez pas spécifié de mot de passe valide.\n"
 "Les connexions externes ne pourront pas être activées tant qu'un mot de passe valide n'est pas spécifié."
 
-#: src/PrefsUnifiedDlg.cpp:1246
-#, c-format
-msgid "The amuleapi password could not be saved: %s"
-msgstr ""
-
-#: src/PrefsUnifiedDlg.cpp:1276
+#: src/PrefsUnifiedDlg.cpp:1202
 msgid "- Language changed.\n"
 msgstr "- Langue changée.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1281
+#: src/PrefsUnifiedDlg.cpp:1207
 msgid "- Temp folder changed.\n"
 msgstr "- Dossier temporaire changé.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1286
+#: src/PrefsUnifiedDlg.cpp:1212
 msgid "- ED2K network enabled.\n"
 msgstr "- Réseau ED2K activé.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1319
+#: src/PrefsUnifiedDlg.cpp:1245
 msgid "The shared-file exclusion pattern is not a valid regular expression. The filter has been left disabled."
 msgstr "Le motif d'exclusion de fichiers partagés n'est pas une expression régulière valide. Le filtre a été laissé désactivé."
 
-#: src/PrefsUnifiedDlg.cpp:1321 src/PrefsUnifiedDlg.cpp:1921
+#: src/PrefsUnifiedDlg.cpp:1247 src/PrefsUnifiedDlg.cpp:1841
 msgid "Invalid regular expression"
 msgstr "Expression régulière invalide"
 
-#: src/PrefsUnifiedDlg.cpp:1398
+#: src/PrefsUnifiedDlg.cpp:1324
 msgid ""
 "Both eD2k and Kad network are disabled.\n"
 "You won't be able to connect until you enable at least one of them."
@@ -5842,7 +5794,7 @@ msgstr ""
 "Les réseaux eD2k et Kad sont désactivés.\n"
 "Vous ne pourrez pas vous connecter tant que vous n'activerez pas au moins l'un des deux."
 
-#: src/PrefsUnifiedDlg.cpp:1403
+#: src/PrefsUnifiedDlg.cpp:1329
 msgid ""
 "Kad will not start if your UDP port is disabled.\n"
 "Enable UDP port or disable Kad."
@@ -5850,7 +5802,7 @@ msgstr ""
 "Kad ne démarrera pas si votre port UDP est désactivé.\n"
 "Activez le port UDP ou désactivez Kad."
 
-#: src/PrefsUnifiedDlg.cpp:1459
+#: src/PrefsUnifiedDlg.cpp:1385
 msgid ""
 "\n"
 "You MUST restart aMule now.\n"
@@ -5860,68 +5812,68 @@ msgstr ""
 "Vous DEVEZ redémarrer aMule maintenant.\n"
 "Si vous ne le faites pas, ne vous plaignez pas si des bogues surviennent.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1524
+#: src/PrefsUnifiedDlg.cpp:1450
 msgid "Could not register aMule for autostart at login. The autostart store may be read-only."
 msgstr "Échec de l'enregistrement d'aMule pour un lancement automatique à l'ouverture d'une session. Le dépôt de lancement automatique est peut-être en lecture seule."
 
-#: src/PrefsUnifiedDlg.cpp:1526
+#: src/PrefsUnifiedDlg.cpp:1452
 msgid "Could not remove the autostart-at-login entry."
 msgstr "Échec de l'effacement de l'entrée du lancement automatique à l'ouverture d'une session."
 
-#: src/PrefsUnifiedDlg.cpp:1527
+#: src/PrefsUnifiedDlg.cpp:1453
 msgid "Autostart"
 msgstr "Lancement automatique"
 
-#: src/PrefsUnifiedDlg.cpp:1542
+#: src/PrefsUnifiedDlg.cpp:1468
 msgid "Register file type"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1542
+#: src/PrefsUnifiedDlg.cpp:1468
 msgid "Register URL handler"
 msgstr "Enregistrer le gestionnaire d'URL"
 
-#: src/PrefsUnifiedDlg.cpp:1550
+#: src/PrefsUnifiedDlg.cpp:1476
 #, c-format
 msgid "aMule only handles eD2k-compatible magnets. If you replace the current magnet handler (%s), BitTorrent magnet links will stop working - aMule cannot download BitTorrent content. Continue?"
 msgstr "aMule ne gère que les magnet compatibles avec eD2k. Si vous remplacez le gestionnaire de magnet actuel (%s), les liens magnet BitTorrent cesseront de fonctionner - aMule ne peut télécharger du contenu BitTorrent. Continuer ?"
 
-#: src/PrefsUnifiedDlg.cpp:1555
+#: src/PrefsUnifiedDlg.cpp:1481
 #, fuzzy, c-format
 msgid "Another application currently opens .emulecollection files (%s). Replace it with aMule?"
 msgstr "Une autre application gère les liens (%s) par défaut. La remplacer par aMule ?"
 
-#: src/PrefsUnifiedDlg.cpp:1560
+#: src/PrefsUnifiedDlg.cpp:1486
 #, c-format
 msgid "Another application is currently the default handler for these links (%s). Replace it with aMule?"
 msgstr "Une autre application gère les liens (%s) par défaut. La remplacer par aMule ?"
 
-#: src/PrefsUnifiedDlg.cpp:1585
+#: src/PrefsUnifiedDlg.cpp:1511
 #, fuzzy
 msgid "Could not register aMule for .emulecollection files. The registration store may be read-only."
 msgstr "Échec de l'enregistrement d'aMule en tant que gestionnaire des URL. Le dépôt d'enregistrement est peut-être en lecture seule."
 
-#: src/PrefsUnifiedDlg.cpp:1587
+#: src/PrefsUnifiedDlg.cpp:1513
 #, fuzzy
 msgid "Could not remove the file type registration."
 msgstr "Impossible de supprimer l'enregistrement du gestionnaire d'URL."
 
-#: src/PrefsUnifiedDlg.cpp:1589
+#: src/PrefsUnifiedDlg.cpp:1515
 msgid "Could not register aMule as the URL handler. The registration store may be read-only."
 msgstr "Échec de l'enregistrement d'aMule en tant que gestionnaire des URL. Le dépôt d'enregistrement est peut-être en lecture seule."
 
-#: src/PrefsUnifiedDlg.cpp:1591
+#: src/PrefsUnifiedDlg.cpp:1517
 msgid "Could not remove the URL handler registration."
 msgstr "Impossible de supprimer l'enregistrement du gestionnaire d'URL."
 
-#: src/PrefsUnifiedDlg.cpp:1661 src/PrefsUnifiedDlg.cpp:1688
+#: src/PrefsUnifiedDlg.cpp:1587 src/PrefsUnifiedDlg.cpp:1614
 msgid "The web server and aMule API require external connections to be enabled."
 msgstr "Le serveur web et aMule API nécessitent l'activation des connexions externes."
 
-#: src/PrefsUnifiedDlg.cpp:1671
+#: src/PrefsUnifiedDlg.cpp:1597
 msgid "The aMule web server is deprecated. Consider running the aMule API instead."
 msgstr "Le serveur web d'aMule est obsolète. Envisagez d'utiliser aMule API à sa place."
 
-#: src/PrefsUnifiedDlg.cpp:1735
+#: src/PrefsUnifiedDlg.cpp:1655
 msgid ""
 "Your Auto-update servers list is in blank.\n"
 "Please fill in at least one URL to point to a valid server.met file.\n"
@@ -5931,64 +5883,64 @@ msgstr ""
 "Entrez s'il vous plaît au moins une URL qui pointe sur un fichier server.met valide.\n"
 "Cliquez sur le bouton \"Liste\" à coté de cette case pour entrer une URL."
 
-#: src/PrefsUnifiedDlg.cpp:1876
+#: src/PrefsUnifiedDlg.cpp:1796
 msgid "Temporary files"
 msgstr "Fichiers temporaires"
 
-#: src/PrefsUnifiedDlg.cpp:1881
+#: src/PrefsUnifiedDlg.cpp:1801
 msgid "Incoming files"
 msgstr "Fichiers réceptionnés"
 
-#: src/PrefsUnifiedDlg.cpp:1886
+#: src/PrefsUnifiedDlg.cpp:1806
 msgid "Online Signatures"
 msgstr "Signatures En Ligne"
 
-#: src/PrefsUnifiedDlg.cpp:1899
+#: src/PrefsUnifiedDlg.cpp:1819
 #, c-format
 msgid "Choose a folder for %s"
 msgstr "Choisir un dossier pour %s"
 
-#: src/PrefsUnifiedDlg.cpp:1923
+#: src/PrefsUnifiedDlg.cpp:1843
 #, c-format
 msgid "Would exclude %u of %u shared file"
 msgid_plural "Would exclude %u of %u shared files"
 msgstr[0] "Exclurait %u fichier sur %u fichier partagé"
 msgstr[1] "Exclurait %u fichiers sur %u fichiers partagés"
 
-#: src/PrefsUnifiedDlg.cpp:1940
+#: src/PrefsUnifiedDlg.cpp:1860
 msgid "Browse for videoplayer"
 msgstr "Chercher un lecteur vidéo"
 
-#: src/PrefsUnifiedDlg.cpp:1944
+#: src/PrefsUnifiedDlg.cpp:1864
 msgid "Select browser"
 msgstr "Choisir un navigateur"
 
-#: src/PrefsUnifiedDlg.cpp:1948
+#: src/PrefsUnifiedDlg.cpp:1868
 msgid "Select ffprobe binary"
 msgstr "Sélectionner le binaire ffprobe"
 
-#: src/PrefsUnifiedDlg.cpp:1954
+#: src/PrefsUnifiedDlg.cpp:1874
 #, c-format
 msgid "Executable%s"
 msgstr "Exécutable%s"
 
-#: src/PrefsUnifiedDlg.cpp:1988
+#: src/PrefsUnifiedDlg.cpp:1908
 msgid "ffprobe not found on PATH or in the standard install locations. Install ffmpeg (which ships ffprobe) or use Browse to pick a binary manually."
 msgstr "ffprobe n'a pas été trouvé sur PATH ou dans les emplacement standards d'installation. Installez ffmpeg (qui fournit ffprobe) ou bien utilisez Parcourir pour choisir un binaire manuellement."
 
-#: src/PrefsUnifiedDlg.cpp:2000
+#: src/PrefsUnifiedDlg.cpp:1920
 msgid "Reset the settings on this page to their default values?"
 msgstr "Réinitialiser les réglages sur cette page à leurs valeurs par défaut ?"
 
-#: src/PrefsUnifiedDlg.cpp:2001
+#: src/PrefsUnifiedDlg.cpp:1921
 msgid "Reset to defaults"
 msgstr "Réinitialiser aux valeurs par défaut"
 
-#: src/PrefsUnifiedDlg.cpp:2028
+#: src/PrefsUnifiedDlg.cpp:1948
 msgid "Edit server list"
 msgstr "Éditer la liste des serveurs"
 
-#: src/PrefsUnifiedDlg.cpp:2029
+#: src/PrefsUnifiedDlg.cpp:1949
 msgid ""
 "Add here URL's to download server.met files.\n"
 "Only one url on each line."
@@ -5996,114 +5948,114 @@ msgstr ""
 "Ajoutez ci-dessous des URL pour télécharger des fichiers server.met.\n"
 "Seulement une URL par ligne."
 
-#: src/PrefsUnifiedDlg.cpp:2084
+#: src/PrefsUnifiedDlg.cpp:2004
 msgid "IP2Country update failed"
 msgstr "Échec de la mise à jour IP2Country"
 
-#: src/PrefsUnifiedDlg.cpp:2229 src/PrefsUnifiedDlg.cpp:2260
+#: src/PrefsUnifiedDlg.cpp:2149 src/PrefsUnifiedDlg.cpp:2180
 msgid "Data by MaxMind GeoLite2"
 msgstr "Données fournies par MaxMind GeoLite2"
 
-#: src/PrefsUnifiedDlg.cpp:2231 src/PrefsUnifiedDlg.cpp:2262
+#: src/PrefsUnifiedDlg.cpp:2151 src/PrefsUnifiedDlg.cpp:2182
 msgid "Custom source"
 msgstr "Source personnalisée"
 
-#: src/PrefsUnifiedDlg.cpp:2233 src/PrefsUnifiedDlg.cpp:2264
+#: src/PrefsUnifiedDlg.cpp:2153 src/PrefsUnifiedDlg.cpp:2184
 msgid "Data by DB-IP.com"
 msgstr "Données fournies par DB-IP.com"
 
-#: src/PrefsUnifiedDlg.cpp:2284
+#: src/PrefsUnifiedDlg.cpp:2204
 #, c-format
 msgid "Status: Loaded%s"
 msgstr "État : %s chargé"
 
-#: src/PrefsUnifiedDlg.cpp:2286
+#: src/PrefsUnifiedDlg.cpp:2206
 #, c-format
 msgid "Status: Loaded%s - %s"
 msgstr "État : %s - %s chargé"
 
-#: src/PrefsUnifiedDlg.cpp:2290
+#: src/PrefsUnifiedDlg.cpp:2210
 msgid "Status: Failed to load - click 'Update now' to refresh."
 msgstr "État : échec du chargement - cliquez sur « Mettre à jour maintenant » pour actualiser."
 
-#: src/PrefsUnifiedDlg.cpp:2292
+#: src/PrefsUnifiedDlg.cpp:2212
 msgid "Status: Not found - click 'Update now' to download."
 msgstr "État : introuvable - cliquez sur « Mettre à jour maintenant » pour télécharger."
 
-#: src/PrefsUnifiedDlg.cpp:2350 src/PrefsUnifiedDlg.cpp:2374
+#: src/PrefsUnifiedDlg.cpp:2270 src/PrefsUnifiedDlg.cpp:2294
 #, c-format
 msgid "Update delay: %d second"
 msgid_plural "Update delay: %d seconds"
 msgstr[0] "Délais de rafraîchissement : %d seconde"
 msgstr[1] "Délais de rafraîchissement : %d secondes"
 
-#: src/PrefsUnifiedDlg.cpp:2358
+#: src/PrefsUnifiedDlg.cpp:2278
 #, c-format
 msgid "Time for average graph: %d minute"
 msgid_plural "Time for average graph: %d minutes"
 msgstr[0] "Temps pour le graphe des moyennes : %d minute"
 msgstr[1] "Temps pour le graphe des moyennes : %d minutes"
 
-#: src/PrefsUnifiedDlg.cpp:2367
+#: src/PrefsUnifiedDlg.cpp:2287
 #, c-format
 msgid "Connections Graph Scale: %d"
 msgstr "Échelle du graphique des connexions : %d"
 
-#: src/PrefsUnifiedDlg.cpp:2382
+#: src/PrefsUnifiedDlg.cpp:2302
 #, c-format
 msgid "File Buffer Size: %d byte"
 msgid_plural "File Buffer Size: %d bytes"
 msgstr[0] "Taille du tampon de fichiers : %d octet"
 msgstr[1] "Taille du tampon de fichiers : %d octets"
 
-#: src/PrefsUnifiedDlg.cpp:2392
+#: src/PrefsUnifiedDlg.cpp:2312
 #, c-format
 msgid "Upload Queue Size: %d client"
 msgid_plural "Upload Queue Size: %d clients"
 msgstr[0] "Taille de la fille d'attente d'émission : %d client"
 msgstr[1] "Taille de la fille d'attente d'émission : %d clients"
 
-#: src/PrefsUnifiedDlg.cpp:2402
+#: src/PrefsUnifiedDlg.cpp:2322
 #, c-format
 msgid "Server connection refresh interval: %d minute"
 msgid_plural "Server connection refresh interval: %d minutes"
 msgstr[0] "Intervalle de rafraîchissement de la connexion serveur : %d minute"
 msgstr[1] "Intervalle de rafraîchissement de la connexion serveur : %d minutes"
 
-#: src/PrefsUnifiedDlg.cpp:2407
+#: src/PrefsUnifiedDlg.cpp:2327
 msgid "Server connection refresh interval: Disabled"
 msgstr "Intervalle de rafraîchissement de la connexion serveur : Désactivé"
 
-#: src/PrefsUnifiedDlg.cpp:2451
+#: src/PrefsUnifiedDlg.cpp:2371
 msgid "disabled"
 msgstr "désactivé"
 
-#: src/PrefsUnifiedDlg.cpp:2477
+#: src/PrefsUnifiedDlg.cpp:2397
 #, c-format
 msgid "Execute command on '%s' event"
 msgstr "Exécuter la commande lors de l'événement '%s'"
 
-#: src/PrefsUnifiedDlg.cpp:2484
+#: src/PrefsUnifiedDlg.cpp:2404
 msgid "Enable command execution on core"
 msgstr "Activer l'exécution de la commande sur le noyau"
 
-#: src/PrefsUnifiedDlg.cpp:2496
+#: src/PrefsUnifiedDlg.cpp:2416
 msgid "Core command:"
 msgstr "Commande du noyau :"
 
-#: src/PrefsUnifiedDlg.cpp:2512
+#: src/PrefsUnifiedDlg.cpp:2432
 msgid "Enable command execution on GUI"
 msgstr "Activer l'exécution de la commande sur l'interface graphique"
 
-#: src/PrefsUnifiedDlg.cpp:2524
+#: src/PrefsUnifiedDlg.cpp:2444
 msgid "GUI command:"
 msgstr "Commande de l'interface graphique :"
 
-#: src/PrefsUnifiedDlg.cpp:2540
+#: src/PrefsUnifiedDlg.cpp:2460
 msgid "The following variables will be replaced:"
 msgstr "Les variables suivantes seront remplacées :"
 
-#: src/PrefsUnifiedDlg.cpp:2708
+#: src/PrefsUnifiedDlg.cpp:2628
 msgid ""
 "The following folders look like system or sensitive locations:\n"
 "\n"
@@ -6111,61 +6063,57 @@ msgstr ""
 "Les répertoires suivants semblent être des répertoires système ou des emplacements sensibles.\n"
 "\n"
 
-#: src/PrefsUnifiedDlg.cpp:2713
+#: src/PrefsUnifiedDlg.cpp:2633
 msgid "Sharing them recursively will publish every file underneath on the eD2k/Kad networks. Do you really want to do this?"
 msgstr "Les partager récursivement publiera chaque fichier contenu dans les sous répertoires sur les réseaux eD2k/Kad. Êtes-vous sûr de vouloir faire cela ?"
 
-#: src/PrefsUnifiedDlg.cpp:2716
+#: src/PrefsUnifiedDlg.cpp:2636
 msgid "Confirm shared folders"
 msgstr "Confirmer les dossiers partagés"
 
-#: src/PrefsUnifiedDlg.cpp:2744
+#: src/PrefsUnifiedDlg.cpp:2664
 msgid "Reloading shared files..."
 msgstr "Rechargement des fichiers partagés…"
 
-#: src/PrefsUnifiedDlg.cpp:2745
+#: src/PrefsUnifiedDlg.cpp:2665
 msgid "Scanning for subdirectories..."
 msgstr "Analyse des sous-répertoires…"
 
-#: src/PrefsUnifiedDlg.cpp:2746
+#: src/PrefsUnifiedDlg.cpp:2666
 msgid "Updating shared folders"
 msgstr "Mise à jour des dossiers partagés"
 
-#: src/PrefsUnifiedDlg.cpp:2773
+#: src/PrefsUnifiedDlg.cpp:2693
 #, c-format
 msgid "Scanned %u directories..."
 msgstr "%u répertoires analysés…"
 
-#: src/PrefsUnifiedDlg.cpp:2823
+#: src/PrefsUnifiedDlg.cpp:2743
 #, c-format
 msgid "Reloading shared files: %u files scanned"
 msgstr "Rechargement des fichiers partagés : %u fichiers analysés"
 
-#: src/PrefsUnifiedDlg.cpp:2873
+#: src/PrefsUnifiedDlg.cpp:2793
 msgid "Shared folder"
 msgstr "Dossier partagé"
 
-#: src/SearchDlg.cpp:280
-msgid "Clear search history"
-msgstr ""
-
-#: src/SearchDlg.cpp:584
+#: src/SearchDlg.cpp:425
 msgid "It's impossible to search when both eD2k and Kademlia are disabled."
 msgstr "Lorsque eD2k et Kademlia sont désactivés tous les deux, il est impossible d'effectuer une recherche."
 
-#: src/SearchDlg.cpp:585 src/SearchListCtrl.cpp:858
+#: src/SearchDlg.cpp:426 src/SearchListCtrl.cpp:858
 msgid "Search error"
 msgstr "Erreur de recherche"
 
-#: src/SearchDlg.cpp:929
+#: src/SearchDlg.cpp:768
 msgid "Min size must be smaller than max size. Max size ignored."
 msgstr "La taille minimum doit être inférieur à la taille maximum. Taille maximum ignorée."
 
-#: src/SearchDlg.cpp:930 src/SearchDlg.cpp:1012
+#: src/SearchDlg.cpp:769 src/SearchDlg.cpp:851
 msgid "Search warning"
 msgstr "Avertissement dans la recherche"
 
-#: src/SearchDlg.cpp:1092 src/SearchListCtrl.cpp:735
+#: src/SearchDlg.cpp:929 src/SearchListCtrl.cpp:735
 msgid "Main"
 msgstr "Principal"
 

--- a/po/fr.po
+++ b/po/fr.po
@@ -15,7 +15,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-28 10:19+0200\n"
+"POT-Creation-Date: 2026-07-28 12:17+0200\n"
 "PO-Revision-Date: 2026-07-27 11:38+0000\n"
 "Last-Translator: Dylan Aïssi <bob.dybian@gmail.com>\n"
 "Language-Team: Français\n"
@@ -211,83 +211,83 @@ msgstr "Échec de l'ouverture du fichier ED2KLinks."
 msgid "WARNING: You can't add yourself as a source for an eD2k link while having a lowid."
 msgstr "AVERTISSEMENT : Vous ne pouvez pas vous ajouter vous-même en tant que source pour un lien eD2k alors que vous avez un LowID."
 
-#: src/amule.cpp:300
+#: src/amule.cpp:301
 msgid "Now, exiting main app..."
 msgstr "Et maintenant on quitte l'application principale…"
 
-#: src/amule.cpp:330
+#: src/amule.cpp:331
 #, c-format
 msgid "Terminating amuleweb instance with pid '%d' ... "
 msgstr "Interruption de l'instance amuleweb avec le pid '%d' … "
 
-#: src/amule.cpp:334
+#: src/amule.cpp:335
 #, c-format
 msgid "Killing amuleweb instance with pid '%d' ... "
 msgstr "Mise à mort de l'instance amuleweb avec le pid '%d' … "
 
-#: src/amule.cpp:336 src/amule.cpp:349 src/ClientRef.cpp:180
+#: src/amule.cpp:337 src/amule.cpp:350 src/ClientRef.cpp:180
 #: src/SearchDlg.cpp:1041 src/ServerListCtrl.cpp:98
 msgid "Failed"
 msgstr "Échec"
 
-#: src/amule.cpp:343
+#: src/amule.cpp:344
 #, c-format
 msgid "Terminating amuleapi instance with pid '%d' ... "
 msgstr "Interruption de l'instance amuleapi avec le pid '%d'… "
 
-#: src/amule.cpp:347
+#: src/amule.cpp:348
 #, c-format
 msgid "Killing amuleapi instance with pid '%d' ... "
 msgstr "Arrêt de l'instance amuleapi avec le pid '%d'… "
 
-#: src/amule.cpp:355
+#: src/amule.cpp:356
 msgid "aMule OnExit: Terminating core."
 msgstr "aMule OnExit : Arrêt du noyau."
 
-#: src/amule.cpp:466
+#: src/amule.cpp:467
 msgid "aMule shutdown completed."
 msgstr "Fermeture d'aMule terminée."
 
-#: src/amule.cpp:470
+#: src/amule.cpp:471
 msgid "Memory debug results for aMule exit:"
 msgstr "Résultats du débogage de la mémoire pour la sortie d'aMule :"
 
-#: src/amule.cpp:651
+#: src/amule.cpp:652
 #, c-format
 msgid "Binding aMule's peer-to-peer traffic to interface: %s (HTTP updates use the default route)"
 msgstr "Liaison du trafic pair à pair d'aMule à l'interface : %s (les mises à jour HTTP utilisent le chemin par défaut)"
 
-#: src/amule.cpp:655
+#: src/amule.cpp:656
 #, c-format
 msgid "Binding all network traffic to interface: %s"
 msgstr "Rattacher tout le trafic réseau à l'interface : %s"
 
-#: src/amule.cpp:659
+#: src/amule.cpp:660
 #, c-format
 msgid "WARNING: configured network interface '%s' was not found - traffic is NOT bound to it and may leave via the default route. Check the interface name in Preferences."
 msgstr "AVERTISSEMENT : l'interface réseau configurée '%s' n'a pu être trouvé - le trafic ne lui est PAS lié et peut partir sur le chemin par défaut. Vérifiez le nom de l'interface dans les Préférences."
 
-#: src/amule.cpp:665
+#: src/amule.cpp:666
 #, c-format
 msgid "WARNING: binding to network interface '%s' requires elevated privileges and was NOT applied - traffic may leave via the default route. Grant the capability (e.g. 'sudo setcap cap_net_raw+ep' on the aMule binary) or run with sufficient privileges."
 msgstr "AVERTISSEMENT : la liaison à l'interface réseau '%s' nécessite des privilèges élevés et n'a PAS été appliquée - le trafic peut emprunter le chemin par défaut. Attribuez la capacité (par exemple 'sudo setcap cap_net_raw+ep' sur le binaire aMule) ou exécutez avec des privilèges suffisants."
 
-#: src/amule.cpp:673
+#: src/amule.cpp:674
 #, c-format
 msgid "WARNING: could not bind to network interface '%s' - traffic may leave via the default route."
 msgstr "AVERTISSEMENT : impossible de lier à l'interface réseau '%s' - le trafic peut emprunter le chemin par défaut."
 
-#: src/amule.cpp:732
+#: src/amule.cpp:733
 msgid "Your locale has been changed to System Default due to a configuration change. Sorry."
 msgstr "Votre localisation a été remise à la valeur par défaut à cause d'un changement dans la configuration. Désolé."
 
-#: src/amule.cpp:734 src/amule.cpp:1581 src/CatDialog.cpp:128
+#: src/amule.cpp:735 src/amule.cpp:1589 src/CatDialog.cpp:128
 #: src/CatDialog.cpp:136 src/CatDialog.cpp:149 src/ServerList.cpp:366
 #: src/ServerListCtrl.cpp:152
 msgid "Info"
 msgstr "Infos"
 
-#: src/amule.cpp:741
+#: src/amule.cpp:742
 msgid ""
 "\n"
 "EC configuration"
@@ -295,21 +295,21 @@ msgstr ""
 "\n"
 "Configuration EC"
 
-#: src/amule.cpp:744
+#: src/amule.cpp:745
 msgid "Password set and external connections enabled."
 msgstr "Mot de passe renseigné et connexions externes activées."
 
-#: src/amule.cpp:754 src/KadDlg.cpp:176 src/KadDlg.cpp:185
-#: src/PrefsUnifiedDlg.cpp:1387 src/SharedFilesCtrl.cpp:476
+#: src/amule.cpp:755 src/KadDlg.cpp:176 src/KadDlg.cpp:185
+#: src/PrefsUnifiedDlg.cpp:1461 src/SharedFilesCtrl.cpp:476
 msgid "WARNING"
 msgstr "AVERTISSEMENT"
 
 # AI-GENERATED — please review.
-#: src/amule.cpp:991
+#: src/amule.cpp:992
 msgid "Network bootstrap"
 msgstr "Amorçage de réseau"
 
-#: src/amule.cpp:996
+#: src/amule.cpp:997
 msgid ""
 "aMule has detected missing network bootstrap files.\n"
 "Select which ones to download:"
@@ -317,51 +317,51 @@ msgstr ""
 "aMule a détecté des fichiers d'amorçage de réseau manquants.\n"
 "Sélectionnez ceux à télécharger :"
 
-#: src/amule.cpp:1005 src/FirstRunWizard.cpp:411
+#: src/amule.cpp:1006 src/FirstRunWizard.cpp:411
 msgid "eD2k server list (server.met)"
 msgstr "Liste de serveurs eD2k (server.met)"
 
-#: src/amule.cpp:1012 src/FirstRunWizard.cpp:416
+#: src/amule.cpp:1013 src/FirstRunWizard.cpp:416
 msgid "Kad bootstrap nodes (nodes.dat)"
 msgstr "Nœuds d'amorçage Kad (nodes.dat)"
 
-#: src/amule.cpp:1102
+#: src/amule.cpp:1103
 #, c-format
 msgid "web server running on pid %d"
 msgstr "serveur web s'exécutant avec le pid %d"
 
-#: src/amule.cpp:1115
+#: src/amule.cpp:1116
 msgid "You requested to run web server on startup, but the amuleweb binary cannot be run. Please install the package containing aMule web server, or build aMule from source with -DBUILD_WEBSERVER=YES and install it."
 msgstr "Vous avez demandé à exécuter le serveur web au démarrage, mais le binaire amuleweb ne peut être exécuté. Veuillez installer le paquet contenant le serveur web aMule, ou compilez aMule depuis le code source avec -DBUILD_WEBSERVER=YES et installez-le."
 
-#: src/amule.cpp:1120 src/amule.cpp:1177 src/amule.cpp:1291 src/amule.cpp:1593
+#: src/amule.cpp:1121 src/amule.cpp:1185 src/amule.cpp:1299 src/amule.cpp:1601
 #: src/amule-remote-gui.cpp:603 src/amule-remote-gui.cpp:671
 #: src/amule-remote-gui.cpp:709 src/amule-remote-gui.cpp:1282
 #: src/amule-remote-gui.cpp:1345 src/amule-remote-gui.cpp:1372
-#: src/DownloadQueue.cpp:1481
+#: src/DownloadQueue.cpp:1481 src/PrefsUnifiedDlg.cpp:1247
 msgid "ERROR"
 msgstr "ERREUR"
 
-#: src/amule.cpp:1166
+#: src/amule.cpp:1174
 #, c-format
 msgid "amuleapi running on pid %d"
 msgstr "amuleapi s'exécutant avec le pid %d"
 
-#: src/amule.cpp:1172
+#: src/amule.cpp:1180
 msgid "You requested to run amuleapi on startup, but the amuleapi binary cannot be run. Please install the package containing aMule's REST API server, or build aMule from source with -DBUILD_AMULEAPI=YES and install it."
 msgstr "Vous avez demandé à exécuter amuleapi au démarrage, mais le binaire amuleapi ne peut être exécuté. Veuillez installer le paquet contenant le serveur API RESTd'aMule, ou compilez aMule depuis le code source avec -DBUILD_AMULEAPI=YES et installez-le."
 
-#: src/amule.cpp:1259
+#: src/amule.cpp:1267
 #, c-format
 msgid "Could not bind ports to the specified address: %s"
 msgstr "Impossible de lier les ports à l'adresse spécifiée : %s"
 
-#: src/amule.cpp:1283
+#: src/amule.cpp:1291
 #, c-format
 msgid "Port %u is not available. You will be LOWID\n"
 msgstr "Le port %u n'est pas disponible. Vous serez LowID\n"
 
-#: src/amule.cpp:1288
+#: src/amule.cpp:1296
 #, c-format
 msgid ""
 "Port %u is not available!\n"
@@ -376,48 +376,48 @@ msgstr ""
 "\n"
 "Vérifiez votre réseau pour être sûr que le port est ouvert en sortie et en entrée."
 
-#: src/amule.cpp:1385
+#: src/amule.cpp:1393
 msgid "Failed to create OnlineSig File"
 msgstr "Échec de la création du fichier OnlineSig"
 
-#: src/amule.cpp:1393
+#: src/amule.cpp:1401
 msgid "Failed to create aMule OnlineSig File"
 msgstr "Échec de la création du fichier aMule OnlineSig"
 
-#: src/amule.cpp:1556
+#: src/amule.cpp:1564
 msgid "The selected locale seems not to be installed on your box. (Note: I'll try to set it anyway)"
 msgstr "La localisation choisie semble ne pas être installée sur votre machine. (Note : Je tente de la forcer quand même)"
 
-#: src/amule.cpp:1566
+#: src/amule.cpp:1574
 #, c-format
 msgid "This is the first time you run aMule %s"
 msgstr "C'est la première fois que vous lancez aMule %s"
 
-#: src/amule.cpp:1569
+#: src/amule.cpp:1577
 msgid "This version is a testing version, updated daily, and\n"
 msgstr "Cette version est une version de test, mise à jour quotidiennement, et\n"
 
-#: src/amule.cpp:1570
+#: src/amule.cpp:1578
 msgid "we give no warranty it won't break anything, burn your house,\n"
 msgstr "nous ne fournissons aucune garantie que cela n'endommagera rien, brûlera votre maison,\n"
 
-#: src/amule.cpp:1571
+#: src/amule.cpp:1579
 msgid "or kill your dog. But it *should* be safe to use anyway.\n"
 msgstr "ou tuera votre chien. Mais ça *devrait* être à peu près sûr quand-même.\n"
 
-#: src/amule.cpp:1576
+#: src/amule.cpp:1584
 msgid "More information, support and new releases can found at our homepage,\n"
 msgstr "Plus d'informations, de l'aide et de nouvelles versions peuvent être trouvées sur notre page web,\n"
 
-#: src/amule.cpp:1577
+#: src/amule.cpp:1585
 msgid "at https://amule-org.github.io, or in our IRC channel #aMule at irc.libera.chat.\n"
 msgstr "https://amule-org.github.io, ou sur notre canal IRC : #aMule sur irc.libera.chat.\n"
 
-#: src/amule.cpp:1579
+#: src/amule.cpp:1587
 msgid "Feel free to report any bugs to https://github.com/amule-org/amule/issues"
 msgstr "Ne vous gênez pas pour reporter tout bogue sur https://github.com/amule-org/amule/issues"
 
-#: src/amule.cpp:1591
+#: src/amule.cpp:1599
 msgid ""
 "The folder for Online Signature files you specified is INVALID!\n"
 " OnlineSignature will be DISABLED until you fix it on preferences."
@@ -425,137 +425,137 @@ msgstr ""
 "Le répertoire choisi pour les fichiers de signature en ligne est INVALIDE !\n"
 "La signature en ligne sera DÉSACTIVÉE jusqu'à ce que cela soit corrigé dans les préférences."
 
-#: src/amule.cpp:1654
+#: src/amule.cpp:1662
 msgid "Server hostname notified"
 msgstr "Nom du serveur signalé"
 
-#: src/amule.cpp:2031
+#: src/amule.cpp:2039
 #, c-format
 msgid "Disk space preallocation for file '%s' failed: %s"
 msgstr "Erreur lors de la réserve d'espace pour le fichier '%s' : %s"
 
-#: src/amule.cpp:2160
+#: src/amule.cpp:2168
 msgid "ERROR: can't open logfile"
 msgstr "ERREUR : impossible d'ouvrir le fichier journal"
 
-#: src/amule.cpp:2164
+#: src/amule.cpp:2172
 msgid "WARNING: logfile is empty. Something is wrong."
 msgstr "AVERTISSEMENT : le fichier journal est vide. Quelque chose ne va pas."
 
-#: src/amule.cpp:2181
+#: src/amule.cpp:2189
 msgid "Log has been reset"
 msgstr "Le journal a été effacé"
 
-#: src/amule.cpp:2205
+#: src/amule.cpp:2213
 #, c-format
 msgid "ServerMessage: %s"
 msgstr "ServerMessage : %s"
 
-#: src/amule.cpp:2248 src/IP2Country.cpp:220 src/IPFilter.cpp:514
+#: src/amule.cpp:2256 src/IP2Country.cpp:220 src/IPFilter.cpp:514
 #: src/ServerList.cpp:875
 #, c-format
 msgid "Skipped download of %s, because requested file is not newer."
 msgstr "Saut du téléchargement de %s, car le fichier demandé n'est pas récent."
 
-#: src/amule.cpp:2251
+#: src/amule.cpp:2259
 msgid "Failed to download the nodes list."
 msgstr "Échec du téléchargement de la liste des nœuds."
 
-#: src/amule.cpp:2314
+#: src/amule.cpp:2322
 msgid "Failed to open the downloaded version check file"
 msgstr "Échec de l'ouverture du fichier de vérification de version téléchargé"
 
-#: src/amule.cpp:2317 src/amule.cpp:2336
+#: src/amule.cpp:2325 src/amule.cpp:2344
 msgid "Corrupted version check file"
 msgstr "Fichier de vérification de version corrompu"
 
-#: src/amule.cpp:2359
+#: src/amule.cpp:2367
 msgid "You are using an outdated version of aMule!"
 msgstr "Vous utilisez une version obsolète d'aMule !"
 
-#: src/amule.cpp:2361
+#: src/amule.cpp:2369
 #, c-format
 msgid "Your aMule version is %i.%i.%i and the latest version is %li.%li.%li"
 msgstr "Votre version d'aMule est %i.%i.%i et la dernière version est %li.%li.%li"
 
-#: src/amule.cpp:2365
+#: src/amule.cpp:2373
 msgid "The latest version can always be found at https://github.com/amule-org/amule/releases/latest"
 msgstr "La dernière version peut toujours être trouvée sur https://github.com/amule-org/amule/releases/latest"
 
-#: src/amule.cpp:2368
+#: src/amule.cpp:2376
 #, c-format
 msgid "WARNING: Your aMuled version is outdated: %i.%i.%i < %li.%li.%li"
 msgstr "AVERTISSEMENT : votre version d'aMuled est obsolète : %i.%i.%i < %li.%li.%li"
 
-#: src/amule.cpp:2374
+#: src/amule.cpp:2382
 msgid "Your copy of aMule is up to date."
 msgstr "Votre version d'aMule est à jour."
 
-#: src/amule.cpp:2381
+#: src/amule.cpp:2389
 msgid "Failed to download the version check file"
 msgstr "Échec du téléchargement du fichier de vérification de version"
 
-#: src/amule.cpp:2550 src/amule-remote-gui.cpp:1133
+#: src/amule.cpp:2558 src/amule-remote-gui.cpp:1133
 #, c-format
 msgid "Users: %s | Files: %s"
 msgstr "Utilisateurs : %s | Fichiers : %s"
 
-#: src/amule.cpp:2551 src/amule-remote-gui.cpp:1134
+#: src/amule.cpp:2559 src/amule-remote-gui.cpp:1134
 #, c-format
 msgid "Users: E: %s K: %s | Files: E: %s K: %s"
 msgstr "Utilisateurs : E : %s K : %s | Fichiers : E : %s K : %s"
 
-#: src/amule.cpp:2565 src/amule-remote-gui.cpp:1147
+#: src/amule.cpp:2573 src/amule-remote-gui.cpp:1147
 msgid "No networks selected"
 msgstr "Aucun réseau sélectionné"
 
-#: src/amule.cpp:2633 src/TextClient.cpp:903
+#: src/amule.cpp:2641 src/TextClient.cpp:903
 msgid "with LowID"
 msgstr "avec un LowID"
 
-#: src/amule.cpp:2633 src/TextClient.cpp:904
+#: src/amule.cpp:2641 src/TextClient.cpp:904
 msgid "with HighID"
 msgstr "avec un HighID"
 
-#: src/amule.cpp:2635
+#: src/amule.cpp:2643
 #, c-format
 msgid "Connected to %s %s"
 msgstr "Connecté à %s %s"
 
-#: src/amule.cpp:2640
+#: src/amule.cpp:2648
 #, c-format
 msgid "Connecting to %s"
 msgstr "Connexion à %s"
 
-#: src/amule.cpp:2642
+#: src/amule.cpp:2650
 msgid "Disconnected from eD2k"
 msgstr "Déconnecté de eD2k"
 
-#: src/amule.cpp:2651
+#: src/amule.cpp:2659
 msgid "Kad started."
 msgstr "Kad démarré."
 
-#: src/amule.cpp:2653
+#: src/amule.cpp:2661
 msgid "Kad stopped."
 msgstr "Kad arrêté."
 
-#: src/amule.cpp:2661
+#: src/amule.cpp:2669
 msgid "Connected to Kad (ok)"
 msgstr "Connecté à Kad (OK)"
 
-#: src/amule.cpp:2663
+#: src/amule.cpp:2671
 msgid "Connected to Kad (firewalled)"
 msgstr "Connecté à Kad (pare-feu)"
 
-#: src/amule.cpp:2667
+#: src/amule.cpp:2675
 msgid "Disconnected from Kad"
 msgstr "Déconnecté de Kad"
 
-#: src/amule.cpp:2699
+#: src/amule.cpp:2707
 msgid "Kad network cannot be used if UDP port is disabled on preferences, not starting."
 msgstr "Le réseau Kad ne peut être utilisé si le port UDP est désactivé dans les préférences, pas de démarrage."
 
-#: src/amule.cpp:2703
+#: src/amule.cpp:2711
 msgid "Kad network disabled on preferences, not connecting."
 msgstr "Le réseau Kad est désactivé dans les préférences, pas de connexion."
 
@@ -599,36 +599,36 @@ msgid "FATAL ERROR: Failed to create Timer"
 msgstr "ERREUR FATALE : Échec de la création du minuteur"
 
 #: src/amuleDlg.cpp:361 src/amuleDlg.cpp:1787 src/amuleDlg.cpp:2033
-#: src/muuli_wdr.cpp:1492 src/muuli_wdr.cpp:3418
+#: src/muuli_wdr.cpp:1492 src/muuli_wdr.cpp:3449
 msgid "Networks"
 msgstr "Réseaux"
 
-#: src/amuleDlg.cpp:362 src/amuleDlg.cpp:1793 src/muuli_wdr.cpp:3419
+#: src/amuleDlg.cpp:362 src/amuleDlg.cpp:1793 src/muuli_wdr.cpp:3450
 msgid "Searches"
 msgstr "Recherches"
 
 #: src/amuleDlg.cpp:363 src/amuleDlg.cpp:1799 src/DownloadListCtrl.cpp:740
-#: src/muuli_wdr.cpp:392 src/muuli_wdr.cpp:1585 src/muuli_wdr.cpp:3420
+#: src/muuli_wdr.cpp:392 src/muuli_wdr.cpp:1585 src/muuli_wdr.cpp:3451
 #: src/Statistics.cpp:829
 msgid "Downloads"
 msgstr "Téléchargements"
 
-#: src/amuleDlg.cpp:364 src/amuleDlg.cpp:1805 src/muuli_wdr.cpp:3294
+#: src/amuleDlg.cpp:364 src/amuleDlg.cpp:1805 src/muuli_wdr.cpp:3325
 msgid "Shared files"
 msgstr "Fichiers partagés"
 
-#: src/amuleDlg.cpp:365 src/amuleDlg.cpp:1811 src/muuli_wdr.cpp:2926
-#: src/muuli_wdr.cpp:3376 src/muuli_wdr.cpp:3423
+#: src/amuleDlg.cpp:365 src/amuleDlg.cpp:1811 src/muuli_wdr.cpp:2957
+#: src/muuli_wdr.cpp:3407 src/muuli_wdr.cpp:3454
 msgid "Messages"
 msgstr "Messages"
 
-#: src/amuleDlg.cpp:366 src/amuleDlg.cpp:1817 src/muuli_wdr.cpp:3424
-#: src/PrefsUnifiedDlg.cpp:312 src/Statistics.cpp:779 src/Statistics.cpp:1235
+#: src/amuleDlg.cpp:366 src/amuleDlg.cpp:1817 src/muuli_wdr.cpp:3455
+#: src/PrefsUnifiedDlg.cpp:314 src/Statistics.cpp:779 src/Statistics.cpp:1235
 msgid "Statistics"
 msgstr "Statistiques"
 
-#: src/amuleDlg.cpp:368 src/amuleDlg.cpp:1824 src/muuli_wdr.cpp:3426
-#: src/PrefsUnifiedDlg.cpp:328 src/utils/wxCas/src/wxcasprefs.cpp:39
+#: src/amuleDlg.cpp:368 src/amuleDlg.cpp:1824 src/muuli_wdr.cpp:3457
+#: src/PrefsUnifiedDlg.cpp:330 src/utils/wxCas/src/wxcasprefs.cpp:39
 msgid "Preferences"
 msgstr "Préférences"
 
@@ -690,8 +690,8 @@ msgstr "Kad : Coupé"
 #: src/amuleDlg.cpp:1029 src/DownloadListCtrl.cpp:505
 #: src/DownloadListCtrl.cpp:749 src/FriendListCtrl.cpp:180
 #: src/muuli_wdr.cpp:731 src/muuli_wdr.cpp:782 src/muuli_wdr.cpp:846
-#: src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2231 src/muuli_wdr.cpp:2316
-#: src/muuli_wdr.cpp:3064 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
+#: src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2262 src/muuli_wdr.cpp:2347
+#: src/muuli_wdr.cpp:3095 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
 #: src/ServerListCtrl.cpp:606 src/TransferWnd.cpp:378
 #: src/utils/wxCas/src/wxcasprefs.cpp:235
 msgid "Cancel"
@@ -702,7 +702,7 @@ msgid "Stop the current connection attempts"
 msgstr "Stopper les essais de connexions en cours"
 
 #: src/amuleDlg.cpp:1035 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976
-#: src/muuli_wdr.cpp:2454
+#: src/muuli_wdr.cpp:2485
 msgid "Disconnect"
 msgstr "Déconnecter"
 
@@ -711,7 +711,7 @@ msgid "Disconnect from the currently connected networks"
 msgstr "Se déconnecter des réseaux actuellement connectés"
 
 #: src/amuleDlg.cpp:1041 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979
-#: src/muuli_wdr.cpp:2609 src/muuli_wdr.cpp:3061 src/muuli_wdr.cpp:3416
+#: src/muuli_wdr.cpp:2640 src/muuli_wdr.cpp:3092 src/muuli_wdr.cpp:3447
 msgid "Connect"
 msgstr "Se connecter"
 
@@ -765,7 +765,7 @@ msgstr "Confirmation de sortie"
 msgid "Launch Command: "
 msgstr "Commande de lancement : "
 
-#: src/amuleDlg.cpp:1632 src/muuli_wdr.cpp:1978 src/Preferences.cpp:952
+#: src/amuleDlg.cpp:1632 src/muuli_wdr.cpp:1982 src/Preferences.cpp:979
 msgid "- default -"
 msgstr "- défaut -"
 
@@ -779,48 +779,48 @@ msgstr "Le répertoire de thèmes '%s' n'existe pas"
 msgid "WARNING: Unable to open skin file '%s' for read"
 msgstr "AVERTISSEMENT : Impossible d'ouvrir le fichier thème '%s' pour la lecture"
 
-#: src/amuleDlg.cpp:1791 src/muuli_wdr.cpp:3418
+#: src/amuleDlg.cpp:1791 src/muuli_wdr.cpp:3449
 msgid "Networks Window"
 msgstr "Fenêtre des réseaux"
 
-#: src/amuleDlg.cpp:1797 src/muuli_wdr.cpp:3419
+#: src/amuleDlg.cpp:1797 src/muuli_wdr.cpp:3450
 msgid "Searches Window"
 msgstr "Fenêtre de Recherche"
 
-#: src/amuleDlg.cpp:1803 src/muuli_wdr.cpp:3420
+#: src/amuleDlg.cpp:1803 src/muuli_wdr.cpp:3451
 msgid "Downloads Window"
 msgstr "Fenêtre des Téléchargements"
 
-#: src/amuleDlg.cpp:1809 src/muuli_wdr.cpp:3422
+#: src/amuleDlg.cpp:1809 src/muuli_wdr.cpp:3453
 msgid "Shared Files Window"
 msgstr "Fenêtre des Fichiers Partagés"
 
-#: src/amuleDlg.cpp:1815 src/muuli_wdr.cpp:3423
+#: src/amuleDlg.cpp:1815 src/muuli_wdr.cpp:3454
 msgid "Messages Window"
 msgstr "Fenêtre des Messages"
 
-#: src/amuleDlg.cpp:1821 src/muuli_wdr.cpp:3424
+#: src/amuleDlg.cpp:1821 src/muuli_wdr.cpp:3455
 msgid "Statistics Graph Window"
 msgstr "Fenêtre des Statistiques"
 
-#: src/amuleDlg.cpp:1828 src/muuli_wdr.cpp:3426
+#: src/amuleDlg.cpp:1828 src/muuli_wdr.cpp:3457
 msgid "Preferences Settings Window"
 msgstr "Fenêtre des Préférences"
 
-#: src/amuleDlg.cpp:1831 src/muuli_wdr.cpp:3427
+#: src/amuleDlg.cpp:1831 src/muuli_wdr.cpp:3458
 msgid "Import"
 msgstr "Importer"
 
-#: src/amuleDlg.cpp:1835 src/muuli_wdr.cpp:3427
+#: src/amuleDlg.cpp:1835 src/muuli_wdr.cpp:3458
 msgid "The partfile importer tool"
 msgstr "L'outil d'importation de fichier .part"
 
-#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3428
+#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3459
 #: src/utils/aLinkCreator/src/alcframe.cpp:262
 msgid "About"
 msgstr "À propos"
 
-#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3428
+#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3459
 msgid "About/Help"
 msgstr "À propos/Aide"
 
@@ -963,7 +963,7 @@ msgstr "introuvable"
 msgid "The core rejected these shared folders:%s"
 msgstr "Le noyau a rejeté ces répertoires partagés : %s"
 
-#: src/amule-remote-gui.cpp:1336 src/ExternalConn.cpp:2345
+#: src/amule-remote-gui.cpp:1336 src/ExternalConn.cpp:2346
 msgid "Invalid link or already on list."
 msgstr "Lien invalide ou déjà dans la liste."
 
@@ -979,7 +979,7 @@ msgstr "Impossible de créer le répertoire '%s' pour la catégorie '%s', on gar
 #: src/ClientDetailDialog.cpp:123 src/DataToText.cpp:61 src/DataToText.cpp:86
 #: src/DataToText.cpp:101 src/DataToText.cpp:136 src/DataToText.cpp:165
 #: src/DownloadListCtrl.cpp:1172 src/DownloadListCtrl.cpp:1185
-#: src/DownloadListCtrl.cpp:1196 src/ExternalConn.cpp:608
+#: src/DownloadListCtrl.cpp:1196 src/ExternalConn.cpp:609
 #: src/FileDetailDialog.cpp:203 src/FileDetailDialog.cpp:235
 #: src/FileDetailDialog.cpp:242 src/GenericClientListCtrl.cpp:1171
 #: src/GenericClientListCtrl.cpp:1182 src/GenericClientListCtrl.cpp:1192
@@ -1365,19 +1365,19 @@ msgstr "Auto [Haute]"
 msgid "Very low"
 msgstr "Très basse"
 
-#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:743 src/muuli_wdr.cpp:2282
+#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:743 src/muuli_wdr.cpp:2313
 #: src/ServerListCtrl.cpp:263 src/ServerListCtrl.cpp:456
 #: src/SharedFilesCtrl.cpp:145
 msgid "Low"
 msgstr "Basse"
 
-#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:744 src/muuli_wdr.cpp:2283
+#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:744 src/muuli_wdr.cpp:2314
 #: src/ServerListCtrl.cpp:266 src/ServerListCtrl.cpp:457
 #: src/SharedFilesCtrl.cpp:146
 msgid "Normal"
 msgstr "Normale"
 
-#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:745 src/muuli_wdr.cpp:2284
+#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:745 src/muuli_wdr.cpp:2315
 #: src/ServerListCtrl.cpp:269 src/ServerListCtrl.cpp:458
 #: src/SharedFilesCtrl.cpp:147
 msgid "High"
@@ -1469,7 +1469,7 @@ msgstr "Serveur Local"
 msgid "Remote Server"
 msgstr "Serveur Distant"
 
-#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3181
+#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3212
 #: src/SearchDlg.cpp:119 src/TextClient.cpp:911
 msgid "Kad"
 msgstr "Kad"
@@ -1540,7 +1540,7 @@ msgstr "Partie"
 msgid "Size"
 msgstr "Taille"
 
-#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3248
+#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3279
 msgid "Transferred"
 msgstr "Reçu"
 
@@ -1598,7 +1598,7 @@ msgstr ""
 "Retour de : %s (%s)\n"
 "\n"
 
-#: src/DownloadListCtrl.cpp:746 src/muuli_wdr.cpp:2285
+#: src/DownloadListCtrl.cpp:746 src/muuli_wdr.cpp:2316
 #: src/SharedFilesCtrl.cpp:150
 msgid "Auto"
 msgstr "Auto"
@@ -1636,7 +1636,7 @@ msgid "Extended Options"
 msgstr "Options avancées"
 
 #: src/DownloadListCtrl.cpp:770 src/DownloadListCtrl.cpp:822
-#: src/muuli_wdr.cpp:1796
+#: src/muuli_wdr.cpp:1800
 msgid "Preview"
 msgstr "Prévisualisation"
 
@@ -1811,225 +1811,230 @@ msgstr[1] "Impossible d'ajouter %u liens (cf. le journal pour les détails)."
 msgid "Invalid eD2k link! ERROR: %s"
 msgstr "Lien eD2k invalide ! ERREUR : %s"
 
-#: src/ExternalConn.cpp:379
+#: src/ExternalConn.cpp:380
 msgid "Client sent packet after authentication failed."
 msgstr "Le client a envoyé un paquet après l'échec d'authentification."
 
-#: src/ExternalConn.cpp:396
+#: src/ExternalConn.cpp:397
 msgid "External connection closed."
 msgstr "Connexion externe fermée."
 
-#: src/ExternalConn.cpp:473
+#: src/ExternalConn.cpp:474
 msgid "External connections disabled due to empty password!"
 msgstr "Les connexions externes sont désactivées car le mot de passe est vide !"
 
-#: src/ExternalConn.cpp:494
+#: src/ExternalConn.cpp:495
 msgid "External connections disabled in config file"
 msgstr "Les connexions externes sont désactivées dans le fichier de configuration"
 
-#: src/ExternalConn.cpp:575
+#: src/ExternalConn.cpp:576
 msgid "New external connection accepted"
 msgstr "Nouvelle connexion externe acceptée"
 
-#: src/ExternalConn.cpp:578
+#: src/ExternalConn.cpp:579
 msgid "ERROR: couldn't accept a new external connection"
 msgstr "ERREUR : impossible d'accepter une nouvelle connexion externe"
 
-#: src/ExternalConn.cpp:595
+#: src/ExternalConn.cpp:596
 msgid "External connection refused due to empty password in preferences!"
 msgstr "Connexion externe refusée car le mot de passe est vide dans les préférences !"
 
-#: src/ExternalConn.cpp:607
+#: src/ExternalConn.cpp:608
 #, c-format
 msgid "Connecting client: %s %s"
 msgstr "Connexion au client : %s %s"
 
-#: src/ExternalConn.cpp:609
+#: src/ExternalConn.cpp:610
 msgid "Unknown version"
 msgstr "Version inconnue"
 
-#: src/ExternalConn.cpp:622
+#: src/ExternalConn.cpp:623
 msgid "Incorrect EC version ID, there might be binary incompatibility. Use core and remote from same snapshot."
 msgstr "ID de version de EC incorrecte, Il peut y avoir des incompatibilités entre les binaires. Utilisez un noyau et un client distant de la même version."
 
-#: src/ExternalConn.cpp:630
+#: src/ExternalConn.cpp:631
 msgid "You cannot connect to a release version from an arbitrary development snapshot! *sigh* possible crash prevented"
 msgstr "Vous ne pouvez pas connecter une version stable depuis une version de développement ! *pfff* un crash potentiel a été évité"
 
-#: src/ExternalConn.cpp:713
+#: src/ExternalConn.cpp:714
 msgid "Invalid protocol version."
 msgstr "Version du protocole invalide."
 
-#: src/ExternalConn.cpp:719
+#: src/ExternalConn.cpp:720
 msgid "Missing protocol version tag."
 msgstr "L'étiquette de la version du protocole est manquante."
 
-#: src/ExternalConn.cpp:727
+#: src/ExternalConn.cpp:728
 msgid "Authentication failed: invalid hash specified as EC password."
 msgstr "Authentification échouée : hachage spécifié comme mot de passe invalide."
 
-#: src/ExternalConn.cpp:775
+#: src/ExternalConn.cpp:776
 msgid "Authentication failed: wrong password."
 msgstr "Authentification échouée : mot de passe erroné."
 
-#: src/ExternalConn.cpp:777
+#: src/ExternalConn.cpp:778
 msgid "Authentication failed: missing password."
 msgstr "Authentification échouée : mot de passe manquant."
 
-#: src/ExternalConn.cpp:788
+#: src/ExternalConn.cpp:789
 msgid "Invalid request, please authenticate first."
 msgstr "Requête invalide, veuillez vous authentifier d'abord."
 
-#: src/ExternalConn.cpp:793
+#: src/ExternalConn.cpp:794
 msgid "Access granted."
 msgstr "Accès autorisé."
 
-#: src/ExternalConn.cpp:801
+#: src/ExternalConn.cpp:802
 #, c-format
 msgid "Sent error message \"%s\" to client."
 msgstr "Envoi du message d'erreur \"%s\" au client."
 
-#: src/ExternalConn.cpp:806
+#: src/ExternalConn.cpp:807
 #, c-format
 msgid "Unauthorized access attempt from %s. Connection closed."
 msgstr "Tentative d'accès non autorisé de %s. Connexion fermée."
 
-#: src/ExternalConn.cpp:1419
+#: src/ExternalConn.cpp:1420
 #, c-format
 msgid "Remote PartFile command failed: FileHash not found: %s"
 msgstr "Échec de la commande du fichier .part à distance : hachage du fichier non trouvé : %s"
 
-#: src/ExternalConn.cpp:1423
+#: src/ExternalConn.cpp:1424
 #, c-format
 msgid "FileHash not found: %s"
 msgstr "Hachage du fichier non trouvé : %s"
 
-#: src/ExternalConn.cpp:1470 src/ExternalConn.cpp:1558
-#: src/ExternalConn.cpp:1679
+#: src/ExternalConn.cpp:1471 src/ExternalConn.cpp:1559
+#: src/ExternalConn.cpp:1680
 msgid "OOPS! OpCode processing error!"
 msgstr "ARGH ! Erreur de traitement de l'OpCode !"
 
-#: src/ExternalConn.cpp:1501
+#: src/ExternalConn.cpp:1502
 msgid "Server not added"
 msgstr "Serveur non ajouté"
 
-#: src/ExternalConn.cpp:1520
+#: src/ExternalConn.cpp:1521
 #, c-format
 msgid "server not found: %s"
 msgstr "serveur non trouvé : %s"
 
-#: src/ExternalConn.cpp:1537
+#: src/ExternalConn.cpp:1538
 msgid "need to define server to be removed"
 msgstr "il faut définir le serveur à supprimer"
 
-#: src/ExternalConn.cpp:1552
+#: src/ExternalConn.cpp:1553
 msgid "eD2k is disabled in preferences."
 msgstr "eD2k est désactivé dans les préférences."
 
-#: src/ExternalConn.cpp:1657
+#: src/ExternalConn.cpp:1658
 msgid "Friend not found."
 msgstr "Ami introuvable."
 
-#: src/ExternalConn.cpp:1667
+#: src/ExternalConn.cpp:1668
 msgid "Client not found."
 msgstr "Client introuvable."
 
-#: src/ExternalConn.cpp:1673
+#: src/ExternalConn.cpp:1674
 msgid "EC_TAG_FRIEND_SHARED requires EC_TAG_FRIEND or EC_TAG_CLIENT."
 msgstr "EC_TAG_FRIEND_SHARED nécessite EC_TAG_FRIEND ou bien EC_TAG_CLIENT."
 
-#: src/ExternalConn.cpp:1991
+#: src/ExternalConn.cpp:1992
 msgid "WebSearch from remote interface makes no sense."
 msgstr "Une recherche Web par une interface distante n'a aucun sens."
 
-#: src/ExternalConn.cpp:2026
+#: src/ExternalConn.cpp:2027
 msgid "Search in progress. Refetch results in a moment!"
 msgstr "Recherche en cours. Résultats dans un moment !"
 
-#: src/ExternalConn.cpp:2265
+#: src/ExternalConn.cpp:2266
 msgid "No points for graph."
 msgstr "Pas de points pour le graphique."
 
-#: src/ExternalConn.cpp:2275
+#: src/ExternalConn.cpp:2276
 msgid "Your client is not configured for this detail level."
 msgstr "Votre client n'est pas configuré pour ce niveau de détails."
 
-#: src/ExternalConn.cpp:2302
+#: src/ExternalConn.cpp:2303
 msgid "External Connection: shutdown requested"
 msgstr "Connexion externe : fermeture demandée"
 
-#: src/ExternalConn.cpp:2314
+#: src/ExternalConn.cpp:2315
 msgid "Already shutting down."
 msgstr "Arrêt déjà en cours."
 
-#: src/ExternalConn.cpp:2332
+#: src/ExternalConn.cpp:2333
 #, c-format
 msgid "ExternalConn: adding link '%s'."
 msgstr "ConnExt : ajout du lien '%s'."
 
-#: src/ExternalConn.cpp:2350
+#: src/ExternalConn.cpp:2351
 #, c-format
 msgid "%d of %d links failed (invalid or already on list)."
 msgstr "Échec de %d liens sur %d (invalides ou déjà sur la liste)."
 
-#: src/ExternalConn.cpp:2373
+#: src/ExternalConn.cpp:2374
 msgid "Version check throttled; try again shortly."
 msgstr "Vérification d'une nouvelle version a été empêchée ; veuillez réessayer sous peu."
 
-#: src/ExternalConn.cpp:2378
+#: src/ExternalConn.cpp:2379
 msgid "Version check is not available on this daemon."
 msgstr "La vérification de la version est indisponible sur ce démon."
 
-#: src/ExternalConn.cpp:2508
+#: src/ExternalConn.cpp:2509
 msgid "File not found."
 msgstr "Fichier non trouvé."
 
-#: src/ExternalConn.cpp:2513
+#: src/ExternalConn.cpp:2514
 msgid "Invalid file name."
 msgstr "Nom de fichier invalide."
 
-#: src/ExternalConn.cpp:2521
+#: src/ExternalConn.cpp:2522
 msgid "Unable to rename file."
 msgstr "Impossible de renommer le fichier."
 
-#: src/ExternalConn.cpp:2992 src/ExternalConn.cpp:3020
+#: src/ExternalConn.cpp:2839
+#, c-format
+msgid "Could not save the amuleapi password: %s"
+msgstr ""
+
+#: src/ExternalConn.cpp:3004 src/ExternalConn.cpp:3032
 msgid "Kad is disabled in preferences."
 msgstr "Kad est désactivé dans les préférences."
 
-#: src/ExternalConn.cpp:3033
+#: src/ExternalConn.cpp:3045
 msgid "Already connected to eD2k."
 msgstr "Déjà connecté à eD2k."
 
-#: src/ExternalConn.cpp:3036
+#: src/ExternalConn.cpp:3048
 msgid "Connecting to eD2k..."
 msgstr "Connexion à eD2k…"
 
-#: src/ExternalConn.cpp:3045
+#: src/ExternalConn.cpp:3057
 msgid "Already connected to Kad."
 msgstr "Déjà connecté à Kad."
 
-#: src/ExternalConn.cpp:3048
+#: src/ExternalConn.cpp:3060
 msgid "Connecting to Kad..."
 msgstr "Connexion à Kad…"
 
-#: src/ExternalConn.cpp:3055
+#: src/ExternalConn.cpp:3067
 msgid "All networks are disabled."
 msgstr "Tous les réseaux sont désactivés."
 
-#: src/ExternalConn.cpp:3064
+#: src/ExternalConn.cpp:3076
 msgid "Disconnected from eD2k."
 msgstr "Déconnecté de eD2k."
 
-#: src/ExternalConn.cpp:3069
+#: src/ExternalConn.cpp:3081
 msgid "Disconnected from Kad."
 msgstr "Déconnecté de Kad."
 
-#: src/ExternalConn.cpp:3078
+#: src/ExternalConn.cpp:3090
 #, c-format
 msgid "External Connection: invalid opcode received: %#x"
 msgstr "Connexion externe : opcode reçu invalide : %#x"
 
-#: src/ExternalConn.cpp:3083
+#: src/ExternalConn.cpp:3095
 msgid "Invalid opcode (wrong protocol version?)"
 msgstr "opcode invalide (mauvaise version de protocole ?)"
 
@@ -2430,23 +2435,23 @@ msgid ""
 "want downloads on a different (e.g. larger) disk."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:549 src/FirstRunWizard.cpp:611 src/muuli_wdr.cpp:1708
+#: src/FirstRunWizard.cpp:549 src/FirstRunWizard.cpp:611 src/muuli_wdr.cpp:1712
 msgid "Destination folder for downloads"
 msgstr "Dossier de destination des téléchargements"
 
 #: src/FirstRunWizard.cpp:553 src/FirstRunWizard.cpp:569 src/muuli_wdr.cpp:1349
-#: src/muuli_wdr.cpp:1366 src/muuli_wdr.cpp:1683 src/muuli_wdr.cpp:1714
-#: src/muuli_wdr.cpp:1726 src/muuli_wdr.cpp:2769
+#: src/muuli_wdr.cpp:1366 src/muuli_wdr.cpp:1687 src/muuli_wdr.cpp:1718
+#: src/muuli_wdr.cpp:1730 src/muuli_wdr.cpp:2800
 #: src/utils/aLinkCreator/src/alcframe.cpp:135
 #: src/utils/wxCas/src/wxcasprefs.cpp:52 src/utils/wxCas/src/wxcasprefs.cpp:118
 msgid "Browse"
 msgstr "Parcourir"
 
-#: src/FirstRunWizard.cpp:559 src/muuli_wdr.cpp:1719
+#: src/FirstRunWizard.cpp:559 src/muuli_wdr.cpp:1723
 msgid "(All files in this folder are shared with other peers)"
 msgstr "(Tous les fichiers de ce répertoire sont partagés avec les autres pairs)"
 
-#: src/FirstRunWizard.cpp:565 src/FirstRunWizard.cpp:624 src/muuli_wdr.cpp:1721
+#: src/FirstRunWizard.cpp:565 src/FirstRunWizard.cpp:624 src/muuli_wdr.cpp:1725
 msgid "Folder for temporary download files"
 msgstr "Dossier des fichiers de téléchargements temporaires"
 
@@ -2477,7 +2482,7 @@ msgstr "Échec de l'ouverture du fichier de la liste d'amis 'emfriends.met' pour
 msgid "CRITICAL - no client on StartChatSession"
 msgstr "CRITIQUE - Pas de client dans StartChatSession"
 
-#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2675 src/muuli_wdr.cpp:3352
+#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2706 src/muuli_wdr.cpp:3383
 msgid "Friends"
 msgstr "Amis"
 
@@ -2587,8 +2592,8 @@ msgstr "Aucun"
 msgid "No"
 msgstr "Non"
 
-#: src/GenericClientListCtrl.cpp:1216 src/PrefsUnifiedDlg.cpp:2818
-#: src/PrefsUnifiedDlg.cpp:2868 src/ServerListCtrl.cpp:276
+#: src/GenericClientListCtrl.cpp:1216 src/PrefsUnifiedDlg.cpp:2898
+#: src/PrefsUnifiedDlg.cpp:2948 src/ServerListCtrl.cpp:276
 msgid "Yes"
 msgstr "Oui"
 
@@ -2757,10 +2762,10 @@ msgstr "Port invalide pour l'amorçage"
 msgid "Please fill all fields required"
 msgstr "Veuillez remplir tous les champs requis"
 
-#: src/KadDlg.cpp:192 src/PartFile.cpp:1031 src/PrefsUnifiedDlg.cpp:1162
-#: src/PrefsUnifiedDlg.cpp:1331 src/PrefsUnifiedDlg.cpp:1589
-#: src/PrefsUnifiedDlg.cpp:1599 src/PrefsUnifiedDlg.cpp:1616
-#: src/PrefsUnifiedDlg.cpp:1658
+#: src/KadDlg.cpp:192 src/PartFile.cpp:1031 src/PrefsUnifiedDlg.cpp:1134
+#: src/PrefsUnifiedDlg.cpp:1204 src/PrefsUnifiedDlg.cpp:1405
+#: src/PrefsUnifiedDlg.cpp:1663 src/PrefsUnifiedDlg.cpp:1673
+#: src/PrefsUnifiedDlg.cpp:1690 src/PrefsUnifiedDlg.cpp:1738
 msgid "Message"
 msgstr "Message"
 
@@ -2861,7 +2866,7 @@ msgstr "Ratio de partage"
 msgid "Uploaded"
 msgstr "Émis"
 
-#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3232
+#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3263
 msgid "Requested"
 msgstr "Demandé"
 
@@ -2984,7 +2989,7 @@ msgid "WARNING: "
 msgstr "AVERTISSEMENT : "
 
 #: src/MuleNotebook.cpp:179 src/muuli_wdr.cpp:817 src/muuli_wdr.cpp:1229
-#: src/muuli_wdr.cpp:3136 src/muuli_wdr.cpp:3392
+#: src/muuli_wdr.cpp:3167 src/muuli_wdr.cpp:3423
 msgid "Close"
 msgstr "Fermer"
 
@@ -3002,7 +3007,7 @@ msgid "Paste"
 msgstr "Coller"
 
 #: src/MuleTextCtrl.cpp:89 src/muuli_wdr.cpp:358 src/muuli_wdr.cpp:757
-#: src/muuli_wdr.cpp:2359 src/muuli_wdr.cpp:2378 src/muuli_wdr.cpp:2400
+#: src/muuli_wdr.cpp:2390 src/muuli_wdr.cpp:2409 src/muuli_wdr.cpp:2431
 #: src/utils/aLinkCreator/src/alcframe.cpp:142
 msgid "Clear"
 msgstr "Effacer"
@@ -3094,7 +3099,7 @@ msgstr "Quitter"
 
 #: src/MuleTrayIcon.cpp:579 src/MuleTrayIcon.cpp:945 src/MuleTrayIcon.cpp:965
 #: src/muuli_wdr.cpp:1398 src/muuli_wdr.cpp:1406 src/muuli_wdr.cpp:1413
-#: src/muuli_wdr.cpp:1842 src/muuli_wdr.cpp:1848 src/OtherFunctions.cpp:91
+#: src/muuli_wdr.cpp:1846 src/muuli_wdr.cpp:1852 src/OtherFunctions.cpp:91
 #: src/StatisticsDlg.cpp:93 src/StatisticsDlg.cpp:95
 msgid "kB/s"
 msgstr "Ko/s"
@@ -3334,7 +3339,7 @@ msgstr "Octets"
 msgid "KB"
 msgstr "Ko"
 
-#: src/muuli_wdr.cpp:274 src/muuli_wdr.cpp:293 src/muuli_wdr.cpp:1627
+#: src/muuli_wdr.cpp:274 src/muuli_wdr.cpp:293 src/muuli_wdr.cpp:1631
 #: src/OtherFunctions.cpp:64
 msgid "MB"
 msgstr "Mo"
@@ -3351,7 +3356,7 @@ msgstr "Taille Maximum"
 msgid "Availability"
 msgstr "Disponibilité"
 
-#: src/muuli_wdr.cpp:312 src/muuli_wdr.cpp:398 src/muuli_wdr.cpp:3297
+#: src/muuli_wdr.cpp:312 src/muuli_wdr.cpp:398 src/muuli_wdr.cpp:3328
 msgid "Filter:"
 msgstr "Filtre :"
 
@@ -3414,12 +3419,12 @@ msgstr "Sources du fichier :"
 #: src/muuli_wdr.cpp:1160 src/muuli_wdr.cpp:1167 src/muuli_wdr.cpp:1172
 #: src/muuli_wdr.cpp:1179 src/muuli_wdr.cpp:1184 src/muuli_wdr.cpp:1191
 #: src/muuli_wdr.cpp:1205 src/muuli_wdr.cpp:1212 src/muuli_wdr.cpp:1217
-#: src/muuli_wdr.cpp:1224 src/muuli_wdr.cpp:3234 src/muuli_wdr.cpp:3242
-#: src/muuli_wdr.cpp:3250
+#: src/muuli_wdr.cpp:1224 src/muuli_wdr.cpp:3265 src/muuli_wdr.cpp:3273
+#: src/muuli_wdr.cpp:3281
 msgid "N/A"
 msgstr "N/A"
 
-#: src/muuli_wdr.cpp:508 src/muuli_wdr.cpp:1065 src/PrefsUnifiedDlg.cpp:297
+#: src/muuli_wdr.cpp:508 src/muuli_wdr.cpp:1065 src/PrefsUnifiedDlg.cpp:299
 msgid "General"
 msgstr "Général"
 
@@ -3555,7 +3560,7 @@ msgstr "Artiste :"
 msgid "Album :"
 msgstr "Album :"
 
-#: src/muuli_wdr.cpp:685 src/muuli_wdr.cpp:2254
+#: src/muuli_wdr.cpp:685 src/muuli_wdr.cpp:2285
 msgid "Title :"
 msgstr "Titre :"
 
@@ -3663,7 +3668,7 @@ msgstr "Nom d'utilisateur :"
 msgid "Userhash :"
 msgstr "Hachage de l'utilisateur :"
 
-#: src/muuli_wdr.cpp:895 src/muuli_wdr.cpp:1748 src/muuli_wdr.cpp:2449
+#: src/muuli_wdr.cpp:895 src/muuli_wdr.cpp:1752 src/muuli_wdr.cpp:2480
 #: src/utils/aLinkCreator/src/alcframe.cpp:137
 msgid "Add"
 msgstr "Ajouter"
@@ -3672,15 +3677,15 @@ msgstr "Ajouter"
 msgid "Download-Speed"
 msgstr "Vitesse de réception"
 
-#: src/muuli_wdr.cpp:954 src/muuli_wdr.cpp:989 src/muuli_wdr.cpp:2553
+#: src/muuli_wdr.cpp:954 src/muuli_wdr.cpp:989 src/muuli_wdr.cpp:2584
 msgid "Current"
 msgstr "Actuelle"
 
-#: src/muuli_wdr.cpp:962 src/muuli_wdr.cpp:997 src/muuli_wdr.cpp:2561
+#: src/muuli_wdr.cpp:962 src/muuli_wdr.cpp:997 src/muuli_wdr.cpp:2592
 msgid "Running average"
 msgstr "Moyenne totale"
 
-#: src/muuli_wdr.cpp:970 src/muuli_wdr.cpp:1005 src/muuli_wdr.cpp:2569
+#: src/muuli_wdr.cpp:970 src/muuli_wdr.cpp:1005 src/muuli_wdr.cpp:2600
 msgid "Session average"
 msgstr "Moyenne de la session"
 
@@ -3692,7 +3697,7 @@ msgstr "Vitesse d'émission"
 msgid "Connections"
 msgstr "Connexions"
 
-#: src/muuli_wdr.cpp:1024 src/muuli_wdr.cpp:1867
+#: src/muuli_wdr.cpp:1024 src/muuli_wdr.cpp:1871
 msgid "Active downloads"
 msgstr "Téléchargements actifs"
 
@@ -3700,7 +3705,7 @@ msgstr "Téléchargements actifs"
 msgid "Active connections (1:1)"
 msgstr "Connexions actives (1:1)"
 
-#: src/muuli_wdr.cpp:1040 src/muuli_wdr.cpp:1868
+#: src/muuli_wdr.cpp:1040 src/muuli_wdr.cpp:1872
 msgid "Active uploads"
 msgstr "Envois actifs"
 
@@ -3974,7 +3979,7 @@ msgstr "Lier l'adresse locale à une IP (vide pour toutes) :"
 msgid "Advanced users only: If you have multiple network interfaces, enter the address of the interface to which aMule should be bound."
 msgstr "Utilisateurs avancés uniquement : Si vous avez plusieurs interfaces réseau, entrez l'adresse de l'interface à laquelle aMule doit être lié."
 
-#: src/muuli_wdr.cpp:1462 src/muuli_wdr.cpp:2061
+#: src/muuli_wdr.cpp:1462 src/muuli_wdr.cpp:2065
 msgid "Bind to network interface (empty for any):"
 msgstr "Lier à une interface réseau (vide pour toutes) :"
 
@@ -3990,7 +3995,7 @@ msgstr "Sources maximales par fichier téléchargé :"
 msgid "Max simultaneous connections:"
 msgstr "Connexions simultanées maximales :"
 
-#: src/muuli_wdr.cpp:1498 src/muuli_wdr.cpp:3176
+#: src/muuli_wdr.cpp:1498 src/muuli_wdr.cpp:3207
 msgid "ED2K"
 msgstr "ED2K"
 
@@ -4082,79 +4087,79 @@ msgstr "Réserver de l'espace disque pour les nouveaux fichiers"
 msgid "For new files preallocates disk space for the whole file, thus reduces fragmentation"
 msgstr "Réserve de l'espace du disque pour les nouveaux fichiers, réduisant ainsi la fragmentation"
 
-#: src/muuli_wdr.cpp:1613
+#: src/muuli_wdr.cpp:1617
 msgid "Create new files as sparse files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1614
-msgid "A sparse file reserves its full size on disk immediately without writing real data to it -- fast, but unsupported or slow on some filesystems, and free-space accounting stays optimistic while the download is in progress. Turn this off to grow the file only as data arrives."
+#: src/muuli_wdr.cpp:1618
+msgid "Sparse part files only occupy disk space for the parts already downloaded, so free space is used up gradually as the file fills in. Turn this off to use an ordinary file instead - useful where sparse files are unsupported or slow, or where backup/de-duplication tools handle them badly. Applies only when the core runs on Windows; on Linux and macOS part files are sparse anyway and this setting has no effect."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1619
+#: src/muuli_wdr.cpp:1623
 msgid "Stop downloads when free disk space reaches "
 msgstr "Stoppe les téléchargements lorsque l'espace disponible est atteint "
 
-#: src/muuli_wdr.cpp:1620
+#: src/muuli_wdr.cpp:1624
 msgid "Select this if you want aMule to check your disk space"
 msgstr "Sélectionnez ceci si vous souhaitez qu'aMule vérifie votre espace disque"
 
-#: src/muuli_wdr.cpp:1624
+#: src/muuli_wdr.cpp:1628
 msgid "Enter here the min disk space desired."
 msgstr "Entrez ici l'espace disque minimum désiré."
 
-#: src/muuli_wdr.cpp:1630
+#: src/muuli_wdr.cpp:1634
 msgid "Save 10 sources on rare files (< 20 sources)"
 msgstr "Sauver 10 sources pour les fichiers rares (< 20 sources)"
 
-#: src/muuli_wdr.cpp:1634 src/Statistics.cpp:790
+#: src/muuli_wdr.cpp:1638 src/Statistics.cpp:790
 msgid "Uploads"
 msgstr "Émission"
 
-#: src/muuli_wdr.cpp:1637
+#: src/muuli_wdr.cpp:1641
 msgid "Add new shared files with auto priority"
 msgstr "Ajouter les nouveaux fichiers partagés en priorité automatique"
 
-#: src/muuli_wdr.cpp:1643
+#: src/muuli_wdr.cpp:1647
 msgid "Intelligent Corruption Handling (I.C.H.)"
 msgstr "Gestion Intelligente de la Corruption (I.C.H.)"
 
-#: src/muuli_wdr.cpp:1646
+#: src/muuli_wdr.cpp:1650
 msgid "Enable"
 msgstr "Activer"
 
-#: src/muuli_wdr.cpp:1649
+#: src/muuli_wdr.cpp:1653
 msgid "Advanced I.C.H. trusts every hash (not recommended)"
 msgstr "I.C.H. avancée se fie aux hachages (non recommandé)"
 
-#: src/muuli_wdr.cpp:1661 src/PrefsUnifiedDlg.cpp:1910
+#: src/muuli_wdr.cpp:1665 src/PrefsUnifiedDlg.cpp:1990
 msgid "Media metadata extraction"
 msgstr "Extraction de métadonnées de média"
 
-#: src/muuli_wdr.cpp:1665
+#: src/muuli_wdr.cpp:1669
 msgid "Extract length / bitrate / codec from shared audio and video files"
 msgstr "Extraire la durée / le débit binaire / le codec depuis les fichiers audio et vidéo partagés"
 
-#: src/muuli_wdr.cpp:1667
+#: src/muuli_wdr.cpp:1671
 msgid "When enabled, aMule runs ffprobe on each shared media file to fill in the Length / Bitrate / Codec columns other clients see when they find the file in a search. Requires ffmpeg (the ffprobe binary) to be installed."
 msgstr "Lorsque cette option est activée, aMule exécute ffprobe sur chaque fichier média partagé pour remplir les colonnes Durée / Débit binaire / Codec que les autres clients voient quand ils trouvent le fichier lors d'une recherche. Nécessite que ffmpeg (le binaire ffprobe) soit installé."
 
-#: src/muuli_wdr.cpp:1674
+#: src/muuli_wdr.cpp:1678
 msgid "Path to ffprobe:"
 msgstr "Emplacement de ffprobe :"
 
-#: src/muuli_wdr.cpp:1679
+#: src/muuli_wdr.cpp:1683
 msgid "Full path to the ffprobe binary. Leave empty to have aMule auto-detect it on startup."
 msgstr "Chemin complet vers le binaire ffprobe. Laisser vide pour qu'aMule le détecte automatiquement au démarrage."
 
-#: src/muuli_wdr.cpp:1687
+#: src/muuli_wdr.cpp:1691
 msgid "Detect"
 msgstr "Détecter"
 
-#: src/muuli_wdr.cpp:1688
+#: src/muuli_wdr.cpp:1692
 msgid "Search the standard install locations for an ffprobe binary and fill the path field."
 msgstr "Rechercher les binaires de ffprobe aux emplacements par défaut et compléter le champ emplacement."
 
-#: src/muuli_wdr.cpp:1712
+#: src/muuli_wdr.cpp:1716
 msgid ""
 "Completed downloads are stored here. All files in this folder are automatically shared with other peers.\n"
 "If this folder also holds files you don't want to share, point it at an aMule-only sub-folder."
@@ -4162,665 +4167,688 @@ msgstr ""
 "Les téléchargements terminés sont stockés ici. Tous les fichiers de ce répertoire sont automatiquement partagés avec les autres pairs.\n"
 "Si ce répertoire contient également des fichiers que vous ne souhaitez pas partager, indiquez un sous-répertoire réservé à aMule."
 
-#: src/muuli_wdr.cpp:1715
+#: src/muuli_wdr.cpp:1719
 msgid "Pick the folder where completed downloads will be stored. All files in that folder will be shared with other peers."
 msgstr "Choisissez le répertoire où les téléchargements terminés seront enregistrés. Tous les fichiers de ce répertoire seront partagés avec les autres pairs."
 
-#: src/muuli_wdr.cpp:1729
+#: src/muuli_wdr.cpp:1733
 msgid "Shared folders"
 msgstr "Dossiers partagés"
 
-#: src/muuli_wdr.cpp:1735
+#: src/muuli_wdr.cpp:1739
 msgid "(Folders shared by the core. Enter a path to add one.)"
 msgstr "(Les répertoires partagés par le noyau. Entrer un chemin pour en ajouter un.)"
 
-#: src/muuli_wdr.cpp:1743
+#: src/muuli_wdr.cpp:1747
 msgid "Absolute path of a folder on the core's machine, e.g. /home/user/shared"
 msgstr "Le chemin absolu d'un répertoire sur la machine du noyau, par exemple /home/utilisateur/shared"
 
-#: src/muuli_wdr.cpp:1745 src/PrefsUnifiedDlg.cpp:2794
+#: src/muuli_wdr.cpp:1749 src/PrefsUnifiedDlg.cpp:2874
 msgid "Recursive"
 msgstr "Récursif"
 
-#: src/muuli_wdr.cpp:1746
+#: src/muuli_wdr.cpp:1750
 msgid "Share every sub-folder underneath this one, including ones created later."
 msgstr "Partager chaque sous-répertoire sous celui-ci, y compris ceux qui seront créés ultérieurement."
 
-#: src/muuli_wdr.cpp:1750 src/utils/aLinkCreator/src/alcframe.cpp:141
+#: src/muuli_wdr.cpp:1754 src/utils/aLinkCreator/src/alcframe.cpp:141
 msgid "Remove"
 msgstr "Enlever"
 
-#: src/muuli_wdr.cpp:1754
+#: src/muuli_wdr.cpp:1758
 msgid "(Right click on folder icon for recursive share)"
 msgstr "(Clic droit sur l'icône du répertoire pour un partage récursif)"
 
-#: src/muuli_wdr.cpp:1761
+#: src/muuli_wdr.cpp:1765
 msgid "Share hidden files"
 msgstr "Partager les fichiers cachés"
 
-#: src/muuli_wdr.cpp:1767
+#: src/muuli_wdr.cpp:1771
 msgid "Automatically rescan shared folders for changes"
 msgstr "Analyser automatiquement à nouveau les répertoires partagés pour rechercher des modifications"
 
-#: src/muuli_wdr.cpp:1773
+#: src/muuli_wdr.cpp:1777
 msgid "Follow symbolic links in shared folders"
 msgstr "Suivre les liens symboliques dans les répertoires partagés"
 
-#: src/muuli_wdr.cpp:1779
+#: src/muuli_wdr.cpp:1783
 msgid "Exclude files matching:"
 msgstr "Exclure les fichiers correspondant à :"
 
-#: src/muuli_wdr.cpp:1782
+#: src/muuli_wdr.cpp:1786
 msgid "Wildcard patterns separated by '|', e.g. .DS_Store|Thumbs.db|*.tmp. Files whose name matches are not shared. Matching is case-insensitive."
 msgstr "Motifs de caractères génériques séparés par '|', par exemple .DS_Store|Thumbs.db|*.tmp. Les fichiers dont le nom correspond ne seront pas partagés. La correspondance est insensible à la casse."
 
-#: src/muuli_wdr.cpp:1786
+#: src/muuli_wdr.cpp:1790
 msgid "Patterns are regular expressions"
 msgstr "Les motifs sont des expressions régulières"
 
-#: src/muuli_wdr.cpp:1787
+#: src/muuli_wdr.cpp:1791
 msgid "When set, the whole field is one regular expression ('|' is alternation). When unset, it is a list of '|'-separated wildcards."
 msgstr "Lorsque l'option est activée, la totalité du champ est une expression régulière ('|' indique une alternative). Lorsque l'option est désactivée, il s'agit d'une liste de caractères génériques séparés par des '|'."
 
-#: src/muuli_wdr.cpp:1797
+#: src/muuli_wdr.cpp:1801
 msgid "Show how many shared files the current pattern would exclude."
 msgstr "Afficher combien de fichiers partagés le motif actuel exclurait."
 
-#: src/muuli_wdr.cpp:1818
+#: src/muuli_wdr.cpp:1822
 msgid "Graphs"
 msgstr "Graphiques"
 
-#: src/muuli_wdr.cpp:1821 src/muuli_wdr.cpp:1883
+#: src/muuli_wdr.cpp:1825 src/muuli_wdr.cpp:1887
 msgid "Update delay : 5 secs"
 msgstr "Délais de rafraîchissement : 5 s"
 
-#: src/muuli_wdr.cpp:1825
+#: src/muuli_wdr.cpp:1829
 msgid "Time for average graph: 100 mins"
 msgstr "Temps pour la courbe de la moyenne : 100 min"
 
-#: src/muuli_wdr.cpp:1829
+#: src/muuli_wdr.cpp:1833
 msgid "Connections Graph Scale: 100 "
 msgstr "Échelle du graphique des connexions : 100 "
 
-#: src/muuli_wdr.cpp:1836
+#: src/muuli_wdr.cpp:1840
 msgid "Download graph scale:"
 msgstr "Échelle des graphiques de réception :"
 
-#: src/muuli_wdr.cpp:1844
+#: src/muuli_wdr.cpp:1848
 msgid "Upload graph scale:"
 msgstr "Échelle des graphiques d'envoi :"
 
-#: src/muuli_wdr.cpp:1854
+#: src/muuli_wdr.cpp:1858
 msgid "Colors: "
 msgstr "Couleurs : "
 
-#: src/muuli_wdr.cpp:1858
+#: src/muuli_wdr.cpp:1862
 msgid "Background"
 msgstr "Fond"
 
-#: src/muuli_wdr.cpp:1859
+#: src/muuli_wdr.cpp:1863
 msgid "Grid"
 msgstr "Quadrillage"
 
-#: src/muuli_wdr.cpp:1860
+#: src/muuli_wdr.cpp:1864
 msgid "Download current"
 msgstr "Téléchargement actuel"
 
-#: src/muuli_wdr.cpp:1861
+#: src/muuli_wdr.cpp:1865
 msgid "Download running average"
 msgstr "Téléchargement moyen total"
 
-#: src/muuli_wdr.cpp:1862
+#: src/muuli_wdr.cpp:1866
 msgid "Download session average"
 msgstr "Téléchargement moyen sur la session"
 
-#: src/muuli_wdr.cpp:1863
+#: src/muuli_wdr.cpp:1867
 msgid "Upload current"
 msgstr "Envoi actuel"
 
-#: src/muuli_wdr.cpp:1864
+#: src/muuli_wdr.cpp:1868
 msgid "Upload running average"
 msgstr "Envoi moyen total"
 
-#: src/muuli_wdr.cpp:1865
+#: src/muuli_wdr.cpp:1869
 msgid "Upload session average"
 msgstr "Envoi moyen sur la session"
 
-#: src/muuli_wdr.cpp:1866
+#: src/muuli_wdr.cpp:1870
 msgid "Active connections"
 msgstr "Connexions actives"
 
-#: src/muuli_wdr.cpp:1869
+#: src/muuli_wdr.cpp:1873
 msgid "Systray Icon Speed Bar"
 msgstr "Barre de vitesse dans l'icône de barre des tâches"
 
-#: src/muuli_wdr.cpp:1870
+#: src/muuli_wdr.cpp:1874
 msgid "Kad-nodes current"
 msgstr "Nœuds Kad actuels"
 
-#: src/muuli_wdr.cpp:1871
+#: src/muuli_wdr.cpp:1875
 msgid "Kad-nodes running"
 msgstr "Nœuds Kad total"
 
-#: src/muuli_wdr.cpp:1872
+#: src/muuli_wdr.cpp:1876
 msgid "Kad-nodes session"
 msgstr "Nœuds Kad pour la session"
 
-#: src/muuli_wdr.cpp:1876 src/muuli_wdr.cpp:2303
+#: src/muuli_wdr.cpp:1880 src/muuli_wdr.cpp:2334
 msgid "Select"
 msgstr "Sélectionner"
 
-#: src/muuli_wdr.cpp:1880
+#: src/muuli_wdr.cpp:1884
 msgid "Tree"
 msgstr "Arbre"
 
-#: src/muuli_wdr.cpp:1890
+#: src/muuli_wdr.cpp:1894
 msgid "Number of Client Versions shown (0=unlimited)"
 msgstr "Nombre de versions client affichées (0=illimité)"
 
-#: src/muuli_wdr.cpp:1915
+#: src/muuli_wdr.cpp:1919
 msgid "!!! WARNING !!!"
 msgstr "!!! AVERTISSEMENT !!!"
 
-#: src/muuli_wdr.cpp:1930
+#: src/muuli_wdr.cpp:1934
 msgid "Max new connections / 5 secs"
 msgstr "Nombre maximum de nouvelles connexions / 5 secs"
 
-#: src/muuli_wdr.cpp:1932
+#: src/muuli_wdr.cpp:1936
 msgid "Concurrent Kad source lookups"
 msgstr "Recherche concurrentes de sources Kad"
 
-#: src/muuli_wdr.cpp:1934
+#: src/muuli_wdr.cpp:1938
 msgid "Kad source re-search interval (minutes)"
 msgstr "Intervalle entre les nouvelles recherches de sources Kad (en minutes)"
 
-#: src/muuli_wdr.cpp:1936
+#: src/muuli_wdr.cpp:1940
 msgid "Source re-ask interval (minutes)"
 msgstr "Intervalle entre les nouvelles demandes de sources Kad (en minutes)"
 
-#: src/muuli_wdr.cpp:1940
+#: src/muuli_wdr.cpp:1944
 msgid "File Buffer Size: 240000 bytes"
 msgstr "Taille du fichier de tampon : 240000 octets"
 
-#: src/muuli_wdr.cpp:1944
+#: src/muuli_wdr.cpp:1948
 msgid "Use MMAP: memory-mapped file access (lower memory use)"
 msgstr "Utiliser MMAP : « memory-mapped file access », c'est-à-dire accès aux fichiers mappés dans la mémoire (utilise moins de mémoire)"
 
-#: src/muuli_wdr.cpp:1945
+#: src/muuli_wdr.cpp:1949
 msgid "Maps part files into memory instead of buffering them on the heap, lowering the process memory footprint. May reduce download speed on some disks; best for memory-constrained or upload-heavy hosts."
 msgstr "Fait correspondre les fichiers partiels dans la mémoire au lieu de les mettre en tampon sur la pile, baissant l'empreinte mémoire du processus. Peut réduire la vitesse de téléchargement sur certains disques ; idéal pour les hôtes disposant de peu de mémoire ou pour ceux qui téléversent beaucoup."
 
-#: src/muuli_wdr.cpp:1947
+#: src/muuli_wdr.cpp:1951
 msgid "Upload Queue Size: 5000 clients"
 msgstr "Taille de la file d'attente d'envoi : 5000 clients"
 
-#: src/muuli_wdr.cpp:1951
+#: src/muuli_wdr.cpp:1955
 msgid "Server connection refresh interval: Disable"
 msgstr "Intervalle de rafraîchissement de la connexion serveur : Désactivé"
 
-#: src/muuli_wdr.cpp:1955
+#: src/muuli_wdr.cpp:1959
 msgid "Disable computer's timed standby mode"
 msgstr "Désactiver la mise en veille programmé de l'ordinateur"
 
-#: src/muuli_wdr.cpp:1974
+#: src/muuli_wdr.cpp:1978
 msgid "Skin to use: "
 msgstr "Thème à utiliser : "
 
-#: src/muuli_wdr.cpp:1983
+#: src/muuli_wdr.cpp:1987
 msgid "Show \"Fast eD2k Links Handler\" in every window."
 msgstr "Afficher le \"Gestionnaire rapide de liens eD2k \" dans chaque fenêtre."
 
-#: src/muuli_wdr.cpp:1986
+#: src/muuli_wdr.cpp:1990
 msgid "Show extended info on categories tabs"
 msgstr "Afficher des infos supplémentaires sur les onglets des catégories"
 
-#: src/muuli_wdr.cpp:1989
+#: src/muuli_wdr.cpp:1993
 msgid "Show application version on title"
 msgstr "Afficher la version de l'application dans le titre"
 
-#: src/muuli_wdr.cpp:1991
+#: src/muuli_wdr.cpp:1995
 msgid "Show transfer rates on title"
 msgstr "Afficher les taux de transfert dans la barre de titre"
 
-#: src/muuli_wdr.cpp:1993
+#: src/muuli_wdr.cpp:1997
 msgid "Before application name"
 msgstr "Avant le nom de l'application"
 
-#: src/muuli_wdr.cpp:1995
+#: src/muuli_wdr.cpp:1999
 msgid "After application name"
 msgstr "Après le nom de l'application"
 
-#: src/muuli_wdr.cpp:1998
+#: src/muuli_wdr.cpp:2002
 msgid "Show overhead bandwidth"
 msgstr "Afficher la surcharge de la bande passante"
 
-#: src/muuli_wdr.cpp:2002
+#: src/muuli_wdr.cpp:2006
 msgid "Vertical toolbar orientation"
 msgstr "Orientation de la barre d'outils verticale"
 
-#: src/muuli_wdr.cpp:2004
+#: src/muuli_wdr.cpp:2008
 msgid "Live column sorting (auto-reorder rows as their values change)"
 msgstr "Tri des colonnes en temps réel (réorganisation automatique des lignes à mesure que leurs valeurs changent)"
 
-#: src/muuli_wdr.cpp:2011
+#: src/muuli_wdr.cpp:2015
 msgid "Download Queue Files"
 msgstr "Fichiers à télécharger en file d'attente"
 
-#: src/muuli_wdr.cpp:2014
+#: src/muuli_wdr.cpp:2018
 msgid "Show progress percentage"
 msgstr "Afficher le pourcentage de progression"
 
-#: src/muuli_wdr.cpp:2020
+#: src/muuli_wdr.cpp:2024
 msgid "Show progress bar"
 msgstr "Afficher la barre de progression"
 
-#: src/muuli_wdr.cpp:2023
+#: src/muuli_wdr.cpp:2027
 msgid "Flat"
 msgstr "Plat"
 
-#: src/muuli_wdr.cpp:2027
+#: src/muuli_wdr.cpp:2031
 msgid "Round"
 msgstr "Relief"
 
-#: src/muuli_wdr.cpp:2045
+#: src/muuli_wdr.cpp:2049
 msgid "External Connection Parameters"
 msgstr "Paramètres de Connexion Externe"
 
-#: src/muuli_wdr.cpp:2048
+#: src/muuli_wdr.cpp:2052
 msgid "Accept external connections"
 msgstr "Accepter les connexions externes"
 
-#: src/muuli_wdr.cpp:2055 src/muuli_wdr.cpp:2114
+#: src/muuli_wdr.cpp:2059 src/muuli_wdr.cpp:2118
 msgid "IP of the listening interface:"
 msgstr "IP de l'interface d'écoute :"
 
-#: src/muuli_wdr.cpp:2058
+#: src/muuli_wdr.cpp:2062
 msgid "Enter here a valid ip in the a.b.c.d format for the listening EC interface. An empty field or 0.0.0.0 will mean any interface."
 msgstr "Entrer ici une adresse IP valide dans le format a.b.c.d pour l'interface d'écoute EC. Un champ vide ou 0.0.0.0 signifiera toutes les interfaces."
 
-#: src/muuli_wdr.cpp:2079 src/muuli_wdr.cpp:2163
+#: src/muuli_wdr.cpp:2083 src/muuli_wdr.cpp:2194
 msgid "TCP port:"
 msgstr "Port TCP :"
 
-#: src/muuli_wdr.cpp:2085
+#: src/muuli_wdr.cpp:2089
 msgid "Enable UPnP port forwarding on the EC port"
 msgstr "Activer la redirection de ports en UPnP sur le port EC"
 
-#: src/muuli_wdr.cpp:2089 src/muuli_wdr.cpp:3048
+#: src/muuli_wdr.cpp:2093 src/muuli_wdr.cpp:3079
 #: src/utils/wxCas/src/wxcasprefs.cpp:167
 msgid "Password"
 msgstr "Mot de passe"
 
-#: src/muuli_wdr.cpp:2095
+#: src/muuli_wdr.cpp:2099
 msgid "aMule API server parameters"
 msgstr "Paramètres du serveur aMule API"
 
-#: src/muuli_wdr.cpp:2098
+#: src/muuli_wdr.cpp:2102
 msgid "Run amuleapi (REST API) on startup"
 msgstr "Exécuter amuleapi (API REST) au démarrage"
 
-#: src/muuli_wdr.cpp:2103
+#: src/muuli_wdr.cpp:2107
 msgid "HTTP port:"
 msgstr "Port HTTP :"
 
-#: src/muuli_wdr.cpp:2117
+#: src/muuli_wdr.cpp:2121
 msgid "The interface amuleapi's HTTP server listens on. 127.0.0.1 (default) accepts only local connections; use 0.0.0.0 or a specific IP to expose it to other hosts (set an admin password below)."
 msgstr "L'interface sur laquelle le serveur HTTP d'amuleapi écoute. 127.0.0.1 (par défaut) n'accepte que les connexions locales  ; utilisez 0.0.0.0 ou bien une adresse IP spécifique pour l'exposer à d'autres hôtes (définissez un mot de passe administrateur ci-dessous)."
 
-#: src/muuli_wdr.cpp:2120
+#: src/muuli_wdr.cpp:2126
+msgid "Type a password to set or change it. Stored passwords cannot be shown, so leaving this empty keeps the current one."
+msgstr ""
+
+#: src/muuli_wdr.cpp:2128
 msgid "Admin password"
 msgstr "Mot de passe administrateur"
 
-#: src/muuli_wdr.cpp:2125 src/muuli_wdr.cpp:2156
-msgid "Low rights password"
-msgstr "Mot de passe sans privilèges"
+#: src/muuli_wdr.cpp:2140 src/muuli_wdr.cpp:2157 src/PrefsUnifiedDlg.cpp:1103
+#, fuzzy
+msgid "A password is set."
+msgstr "Mot de passe administrateur"
 
-#: src/muuli_wdr.cpp:2133
+#: src/muuli_wdr.cpp:2144
+#, fuzzy
+msgid "Enable guest access"
+msgstr "Interdire l'accès invité"
+
+#: src/muuli_wdr.cpp:2145
+msgid "Guest sessions may read status and listings but cannot change anything. Turning this off clears the stored guest password."
+msgstr ""
+
+#: src/muuli_wdr.cpp:2149
+#, fuzzy
+msgid "Guest password"
+msgstr "Mot de passe invité pour le serveur web"
+
+#: src/muuli_wdr.cpp:2164
 msgid "Web server parameters"
 msgstr "Paramètres du serveur Web"
 
-#: src/muuli_wdr.cpp:2136
+#: src/muuli_wdr.cpp:2167
 msgid "Run webserver on startup (deprecated)"
 msgstr "Démarrer le serveur web au démarrage (obsolète)"
 
-#: src/muuli_wdr.cpp:2142
+#: src/muuli_wdr.cpp:2173
 msgid "Web template"
 msgstr "Template web"
 
-#: src/muuli_wdr.cpp:2147
+#: src/muuli_wdr.cpp:2178
 msgid "Full rights password"
 msgstr "Mot de passe administrateur"
 
-#: src/muuli_wdr.cpp:2151
+#: src/muuli_wdr.cpp:2182
 msgid "Enable Low rights User"
 msgstr "Activer l'accès utilisateur sans privilèges"
 
-#: src/muuli_wdr.cpp:2170
+#: src/muuli_wdr.cpp:2187
+msgid "Low rights password"
+msgstr "Mot de passe sans privilèges"
+
+#: src/muuli_wdr.cpp:2201
 msgid "Enable UPnP port forwarding of the web server port"
 msgstr "Activer la redirection de port UPnP sur le port du serveur web"
 
-#: src/muuli_wdr.cpp:2175
+#: src/muuli_wdr.cpp:2206
 msgid "Web server UPnP TCP port (Optional)"
 msgstr "Port TCP UPnP du serveur web (Facultatif)"
 
-#: src/muuli_wdr.cpp:2183
+#: src/muuli_wdr.cpp:2214
 msgid "Page Refresh Time (in secs)"
 msgstr "Intervalle de rafraîchissement (en secondes)"
 
-#: src/muuli_wdr.cpp:2190
+#: src/muuli_wdr.cpp:2221
 msgid "Enable Gzip compression"
 msgstr "Activer la compression Gzip"
 
-#: src/muuli_wdr.cpp:2224
+#: src/muuli_wdr.cpp:2255
 msgid "Reset page to defaults"
 msgstr "Réinitialiser la page aux valeurs par défaut"
 
-#: src/muuli_wdr.cpp:2225
+#: src/muuli_wdr.cpp:2256
 msgid "Reset the settings on the current page to their default values."
 msgstr "Réinitialiser les réglages sur la page actuelle à leurs valeurs par défaut."
 
-#: src/muuli_wdr.cpp:2227 src/muuli_wdr.cpp:2313 src/ServerWnd.cpp:274
+#: src/muuli_wdr.cpp:2258 src/muuli_wdr.cpp:2344 src/ServerWnd.cpp:274
 #: src/ServerWnd.cpp:282
 msgid "OK"
 msgstr "OK"
 
-#: src/muuli_wdr.cpp:2229
+#: src/muuli_wdr.cpp:2260
 msgid "Click here to apply any changes made to the preferences."
 msgstr "Cliquer ici pour appliquer tous les changements effectués dans les Préférences."
 
-#: src/muuli_wdr.cpp:2232
+#: src/muuli_wdr.cpp:2263
 msgid "Reset any changes made to the preferences."
 msgstr "Annule tous les changements effectués dans les Préférences."
 
-#: src/muuli_wdr.cpp:2261
+#: src/muuli_wdr.cpp:2292
 msgid "Comment :"
 msgstr "Commentaire :"
 
-#: src/muuli_wdr.cpp:2268
+#: src/muuli_wdr.cpp:2299
 msgid "Incoming Dir :"
 msgstr "Répertoire entrant :"
 
-#: src/muuli_wdr.cpp:2277
+#: src/muuli_wdr.cpp:2308
 msgid "Change priority for new assigned files :"
 msgstr "Changer la priorité des nouveaux fichiers assignés :"
 
-#: src/muuli_wdr.cpp:2281
+#: src/muuli_wdr.cpp:2312
 msgid "Don't change"
 msgstr "Ne rien changer"
 
-#: src/muuli_wdr.cpp:2293
+#: src/muuli_wdr.cpp:2324
 msgid "Select color for this Category (currently selected) :"
 msgstr "Choisir la couleur pour cette Catégorie (actuellement sélectionnée) :"
 
-#: src/muuli_wdr.cpp:2360 src/muuli_wdr.cpp:2379 src/muuli_wdr.cpp:2401
+#: src/muuli_wdr.cpp:2391 src/muuli_wdr.cpp:2410 src/muuli_wdr.cpp:2432
 msgid "Click this button to reset the log."
 msgstr "Cliquer ici pour effacer le journal."
 
-#: src/muuli_wdr.cpp:2420
+#: src/muuli_wdr.cpp:2451
 msgid "Click on this button to update the servers list from URL ..."
 msgstr "Cliquer ici pour mettre à jour la liste des serveurs à partir de l'URL…"
 
-#: src/muuli_wdr.cpp:2424
+#: src/muuli_wdr.cpp:2455
 msgid "Server list"
 msgstr "Liste des serveurs"
 
-#: src/muuli_wdr.cpp:2428
+#: src/muuli_wdr.cpp:2459
 msgid "Enter the url to a server.met file here and press the button to the left to update the list of known servers."
 msgstr "Entrer l'URL d'un fichier server.met et presser le bouton à gauche pour rafraîchir la liste des serveurs connus."
 
-#: src/muuli_wdr.cpp:2433
+#: src/muuli_wdr.cpp:2464
 msgid "Add server manually: Name"
 msgstr "Ajouter un serveur manuellement : Nom"
 
-#: src/muuli_wdr.cpp:2436
+#: src/muuli_wdr.cpp:2467
 msgid "Enter the name of the new server here"
 msgstr "Entrer ici le nom du nouveau serveur"
 
-#: src/muuli_wdr.cpp:2438 src/ServerWnd.cpp:206
+#: src/muuli_wdr.cpp:2469 src/ServerWnd.cpp:206
 msgid "IP:Port"
 msgstr "IP : Port"
 
-#: src/muuli_wdr.cpp:2441
+#: src/muuli_wdr.cpp:2472
 msgid "Enter the IP of the server here, using the x.x.x.x format."
 msgstr "Entrer ici l'adresse IP du serveur, avec le format x.x.x.x."
 
-#: src/muuli_wdr.cpp:2447
+#: src/muuli_wdr.cpp:2478
 msgid "Enter the port of the server here."
 msgstr "Entrer ici le port du serveur."
 
-#: src/muuli_wdr.cpp:2450
+#: src/muuli_wdr.cpp:2481
 msgid "Add manually a server (fill fields to the left before) ..."
 msgstr "Ajouter manuellement un serveur (remplir les champs à gauche avant)…"
 
-#: src/muuli_wdr.cpp:2479
+#: src/muuli_wdr.cpp:2510
 msgid "aMule Log"
 msgstr "Journal d'aMule"
 
-#: src/muuli_wdr.cpp:2487
+#: src/muuli_wdr.cpp:2518
 msgid "Server Info"
 msgstr "Infos Serveur"
 
-#: src/muuli_wdr.cpp:2491
+#: src/muuli_wdr.cpp:2522
 msgid "ED2K Info"
 msgstr "Infos ED2K"
 
-#: src/muuli_wdr.cpp:2495
+#: src/muuli_wdr.cpp:2526
 msgid "Kad Info"
 msgstr "Infos Kad"
 
-#: src/muuli_wdr.cpp:2523
+#: src/muuli_wdr.cpp:2554
 msgid "Click on this button to update the nodes list from URL ..."
 msgstr "Cliquer sur le bouton pour mettre à jour la liste des nœuds depuis l'URL…"
 
-#: src/muuli_wdr.cpp:2527
+#: src/muuli_wdr.cpp:2558
 msgid "Nodes (0)"
 msgstr "Nœuds (0)"
 
-#: src/muuli_wdr.cpp:2531
+#: src/muuli_wdr.cpp:2562
 msgid "Enter the url to a nodes.dat file here and press the button to the left to update the list of known nodes."
 msgstr "Entrer l'URL d'un fichier nodes.dat ici et presser le bouton à gauche pour mettre à jour la liste des nœuds connus."
 
-#: src/muuli_wdr.cpp:2534
+#: src/muuli_wdr.cpp:2565
 msgid "Nodes stats"
 msgstr "Statistiques des nœuds"
 
-#: src/muuli_wdr.cpp:2576
+#: src/muuli_wdr.cpp:2607
 msgid "Bootstrap"
 msgstr "Amorçage"
 
-#: src/muuli_wdr.cpp:2579
+#: src/muuli_wdr.cpp:2610
 msgid "New node"
 msgstr "Nouveau nœud"
 
-#: src/muuli_wdr.cpp:2584
+#: src/muuli_wdr.cpp:2615
 msgid "IP:"
 msgstr "IP :"
 
-#: src/muuli_wdr.cpp:2604
+#: src/muuli_wdr.cpp:2635
 msgid "Port:"
 msgstr "Port :"
 
-#: src/muuli_wdr.cpp:2617
+#: src/muuli_wdr.cpp:2648
 msgid "Bootstrap from known clients"
 msgstr "Amorçage depuis les clients connus"
 
-#: src/muuli_wdr.cpp:2619
+#: src/muuli_wdr.cpp:2650
 msgid "Disconnect Kad"
 msgstr "Déconnecter Kad"
 
-#: src/muuli_wdr.cpp:2653
+#: src/muuli_wdr.cpp:2684
 msgid "Use Secure User Identification"
 msgstr "Utiliser l'Identification Utilisateur Sécurisée (SUI)"
 
-#: src/muuli_wdr.cpp:2655
+#: src/muuli_wdr.cpp:2686
 msgid "It is recommended to enable this option. You will not receive credits if SUI is not enabled."
 msgstr "Il est recommandé d'activer cette option. Vous ne recevrez pas de crédits si SUI n'est pas activé."
 
-#: src/muuli_wdr.cpp:2657
+#: src/muuli_wdr.cpp:2688
 msgid "Protocol Obfuscation"
 msgstr "Brouillage de protocole"
 
-#: src/muuli_wdr.cpp:2660
+#: src/muuli_wdr.cpp:2691
 msgid "Support Protocol Obfuscation"
 msgstr "Supporter le brouillage de protocole"
 
-#: src/muuli_wdr.cpp:2662
+#: src/muuli_wdr.cpp:2693
 msgid "This option enabled Protocol Obfuscation, and makes aMule accept obfuscated connections from other clients."
 msgstr "Cette option active le brouillage de protocole, cela permet à aMule d'accepter les connexions brouillées des autres clients."
 
-#: src/muuli_wdr.cpp:2664
+#: src/muuli_wdr.cpp:2695
 msgid "Use obfuscation for outgoing connections"
 msgstr "Utiliser le brouillage pour les connexions sortantes"
 
-#: src/muuli_wdr.cpp:2666
+#: src/muuli_wdr.cpp:2697
 msgid "This option makes aMule use Protocol Obfuscation when connecting other clients/servers."
 msgstr "Avec cette option, aMule utilise le brouillage de protocole lors des connexions aux autres clients/serveurs."
 
-#: src/muuli_wdr.cpp:2668
+#: src/muuli_wdr.cpp:2699
 msgid "Accept only obfuscated connections"
 msgstr "Accepter seulement les connexions brouillées"
 
-#: src/muuli_wdr.cpp:2669
+#: src/muuli_wdr.cpp:2700
 msgid "This option makes aMule only accept obfuscated connections. You will have less sources, but all your traffic will be obfuscated"
 msgstr "Avec cette option, aMule n'accepte que les connexions brouillées. Vous aurez moins de sources, mais tout votre trafic sera brouillé"
 
-#: src/muuli_wdr.cpp:2674
+#: src/muuli_wdr.cpp:2705
 msgid "Everybody"
 msgstr "Tout le monde"
 
-#: src/muuli_wdr.cpp:2676
+#: src/muuli_wdr.cpp:2707
 msgid "No one"
 msgstr "Personne"
 
-#: src/muuli_wdr.cpp:2678
+#: src/muuli_wdr.cpp:2709
 msgid "Who can see my shared files:"
 msgstr "Qui peut voir mes fichiers partagés :"
 
-#: src/muuli_wdr.cpp:2679
+#: src/muuli_wdr.cpp:2710
 msgid "Select who can request to view a list of your shared files."
 msgstr "Indique qui peut voir votre liste de fichiers partagés."
 
-#: src/muuli_wdr.cpp:2681
+#: src/muuli_wdr.cpp:2712
 msgid "IP-Filtering"
 msgstr "Filtrage des IP"
 
-#: src/muuli_wdr.cpp:2688
+#: src/muuli_wdr.cpp:2719
 msgid "Filter clients"
 msgstr "Filtrage des clients"
 
-#: src/muuli_wdr.cpp:2690
+#: src/muuli_wdr.cpp:2721
 msgid "Enable filtering of the client IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "Activer le filtrage des clients selon les IP contenues dans le fichier ~/.aMule/ipfilter.dat."
 
-#: src/muuli_wdr.cpp:2692
+#: src/muuli_wdr.cpp:2723
 msgid "Filter servers"
 msgstr "Filtrage des serveurs"
 
-#: src/muuli_wdr.cpp:2694
+#: src/muuli_wdr.cpp:2725
 msgid "Enable filtering of the server IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "Active le filtrage des serveurs selon les IP contenues dans le fichier ~/.aMule/ipfilter.dat."
 
-#: src/muuli_wdr.cpp:2698
+#: src/muuli_wdr.cpp:2729
 msgid "Reload List"
 msgstr "Recharger la liste"
 
-#: src/muuli_wdr.cpp:2699
+#: src/muuli_wdr.cpp:2730
 msgid "Reload the list of IPs to filter from the file ~/.aMule/ipfilter.dat"
 msgstr "Recharge la liste des IP à filtrer à partir du fichier ~/.aMule/ipfilter.dat"
 
-#: src/muuli_wdr.cpp:2705
+#: src/muuli_wdr.cpp:2736
 msgid "URL:"
 msgstr "URL :"
 
-#: src/muuli_wdr.cpp:2709 src/muuli_wdr.cpp:2902
+#: src/muuli_wdr.cpp:2740 src/muuli_wdr.cpp:2933
 msgid "Update now"
 msgstr "Mettre à jour maintenant"
 
-#: src/muuli_wdr.cpp:2712
+#: src/muuli_wdr.cpp:2743
 msgid "Auto-update ipfilter at startup"
 msgstr "Mise à jour d' IPFilter au démarrage"
 
-#: src/muuli_wdr.cpp:2716
+#: src/muuli_wdr.cpp:2747
 msgid "Filtering Level:"
 msgstr "Niveau de filtrage :"
 
-#: src/muuli_wdr.cpp:2722
+#: src/muuli_wdr.cpp:2753
 msgid "Always filter LAN IPs"
 msgstr "Toujours filtrer les IPs LAN"
 
-#: src/muuli_wdr.cpp:2725
+#: src/muuli_wdr.cpp:2756
 msgid "Paranoid handling of non-matching IPs"
 msgstr "Prise en charge paranoïaque des IPs qui ne se correspondent pas"
 
-#: src/muuli_wdr.cpp:2727
+#: src/muuli_wdr.cpp:2758
 msgid "Rejects a packet when its source IP differs from the IP the client claims (an anti-spoofing check). Disable only if it causes connection problems."
 msgstr "Rejette un paquet lorsque son IP source diffère de l'IP que le client prétend avoir (vérification anti-usurpation). Désactivez seulement si cela provoque des problèmes de connexion."
 
-#: src/muuli_wdr.cpp:2729
+#: src/muuli_wdr.cpp:2760
 msgid "Use system-wide ipfilter.dat if available"
 msgstr "Utiliser un ipfilter.dat système si disponible"
 
-#: src/muuli_wdr.cpp:2730
+#: src/muuli_wdr.cpp:2761
 msgid "If there's no local ipfilter.dat found, allow usage of a system-wide ipfilter file."
 msgstr "S'il n'y a pas de fichier ipfilter.dat local, autoriser l'utilisation d'un fichier ipfilter système."
 
-#: src/muuli_wdr.cpp:2747
+#: src/muuli_wdr.cpp:2778
 msgid "Enable Online-Signature"
 msgstr "Activer la Signature En Ligne"
 
-#: src/muuli_wdr.cpp:2749
+#: src/muuli_wdr.cpp:2780
 msgid "Enables the writing of the OS file, which can be used by external apps to create signatures and the like."
 msgstr "Active l'écriture du fichier de signature en ligne, qui peut-être utilisé par des applications extérieures pour créer des signatures, etc."
 
-#: src/muuli_wdr.cpp:2753
+#: src/muuli_wdr.cpp:2784
 msgid "Update Frequency (Secs):"
 msgstr "Fréquence de mise à jour (Secondes) :"
 
-#: src/muuli_wdr.cpp:2756
+#: src/muuli_wdr.cpp:2787
 msgid "Change the frequency (in seconds) of Online Signature updates."
 msgstr "Change la fréquence des mises à jour de la signature en ligne (en secondes)."
 
-#: src/muuli_wdr.cpp:2764
+#: src/muuli_wdr.cpp:2795
 msgid "Save online signature file in: "
 msgstr "Sauver le fichier de signature en ligne dans : "
 
-#: src/muuli_wdr.cpp:2770
+#: src/muuli_wdr.cpp:2801
 msgid "Click here to select the directory containing the the Online Signature files."
 msgstr "Cliquer ici pour sélectionner le répertoire contenant le fichier de signature en ligne."
 
-#: src/muuli_wdr.cpp:2803
+#: src/muuli_wdr.cpp:2834
 msgid "Show country flags for clients"
 msgstr "Voir les drapeaux des pays pour les clients"
 
-#: src/muuli_wdr.cpp:2804
+#: src/muuli_wdr.cpp:2835
 msgid "Render the country flag column in the transfers, queue and search views. Requires a valid MMDB GeoIP database (see below)."
 msgstr "Afficher la colonne des drapeaux des pays dans les vues des transferts, des files d'attente et de recherche. Nécessite une base de données MMDB GeoIP valide (cf. ci-dessous)."
 
-#: src/muuli_wdr.cpp:2809
+#: src/muuli_wdr.cpp:2840
 msgid "Database"
 msgstr "Base de données"
 
-#: src/muuli_wdr.cpp:2825
+#: src/muuli_wdr.cpp:2856
 msgid "Source:"
 msgstr "Source :"
 
-#: src/muuli_wdr.cpp:2828
+#: src/muuli_wdr.cpp:2859
 msgid "DB-IP (free, no account)"
 msgstr "DB-IP (gratuit, pas de compte)"
 
-#: src/muuli_wdr.cpp:2829
+#: src/muuli_wdr.cpp:2860
 msgid "MaxMind GeoLite2 (free, account required)"
 msgstr "MaxMind GeoLite2 (gratuit, compte nécessaire)"
 
-#: src/muuli_wdr.cpp:2830
+#: src/muuli_wdr.cpp:2861
 msgid "Custom URL"
 msgstr "URL personnalisé"
 
-#: src/muuli_wdr.cpp:2833
+#: src/muuli_wdr.cpp:2864
 msgid "Choose which provider supplies the GeoIP MMDB database. DB-IP is the default - no account required. MaxMind requires a free account + license key. Use Custom URL to point at any other MMDB host (e.g. a local mirror)."
 msgstr "Choisissez quel fournisseur procure la base de données GeoIP MMDB. DB-IP est la valeur par défaut - ne nécessite pas de compte. MaxMind nécessite un compte gratuit + une clef de licence. Utilisez un URL personnalisé pour pointer vers tout autre hôte MMDB (par exemple un miroir local)."
 
-#: src/muuli_wdr.cpp:2850
+#: src/muuli_wdr.cpp:2881
 msgid ""
 "No configuration required.\n"
 "\n"
@@ -4832,11 +4860,11 @@ msgstr ""
 "Les données IP vers pays par DB-IP.com - https://db-ip.com\n"
 "Licence : Creative Commons Attribution 4.0 - https://creativecommons.org/licenses/by/4.0/deed.fr"
 
-#: src/muuli_wdr.cpp:2863
+#: src/muuli_wdr.cpp:2894
 msgid "License key:"
 msgstr "Clef de licence :"
 
-#: src/muuli_wdr.cpp:2869
+#: src/muuli_wdr.cpp:2900
 msgid ""
 "Sign up for a free MaxMind account, then generate a License Key:\n"
 "https://www.maxmind.com/en/geolite2/signup\n"
@@ -4852,11 +4880,11 @@ msgstr ""
 "Licence : CLUF MaxMind GeoLite2 - https://www.maxmind.com/en/geolite2/eula\n"
 "Nécessite une attribution et la création d'un compte ; actualisez au moins tous les 30 jours."
 
-#: src/muuli_wdr.cpp:2884
+#: src/muuli_wdr.cpp:2915
 msgid "Download URL:"
 msgstr "URL de téléchargement :"
 
-#: src/muuli_wdr.cpp:2890
+#: src/muuli_wdr.cpp:2921
 msgid ""
 "Must point to an .mmdb file or a .gz / .tar.gz containing one.\n"
 "URL may include credentials (https://user:pass@host/...).\n"
@@ -4866,211 +4894,211 @@ msgstr ""
 "L'URL peut contenir un identifiant et mot de passe (https://utilisateur:motdepasse@hôte/...) \n"
 "La licence et les conditions d'attribution sont définies par l'URL d'origine - vous en êtes responsable."
 
-#: src/muuli_wdr.cpp:2903
+#: src/muuli_wdr.cpp:2934
 msgid "Download the GeoIP database from the selected source."
 msgstr "Télécharger la base de données GeoIP depuis la source sélectionnée."
 
-#: src/muuli_wdr.cpp:2905
+#: src/muuli_wdr.cpp:2936
 msgid "Auto-update on startup"
 msgstr "Mise à jour automatique au démarrage"
 
-#: src/muuli_wdr.cpp:2906
+#: src/muuli_wdr.cpp:2937
 msgid "Re-download the GeoIP database from the selected source every time aMule starts."
 msgstr "Télécharger à nouveau la base de données GeoIP depuis la source sélectionnée chaque fois qu'aMule démarre."
 
-#: src/muuli_wdr.cpp:2929
+#: src/muuli_wdr.cpp:2960
 msgid "Filter incoming messages (except current chat):"
 msgstr "Filtrer les messages entrant (sauf la discussion en cours) :"
 
-#: src/muuli_wdr.cpp:2931
+#: src/muuli_wdr.cpp:2962
 msgid "Filter all messages"
 msgstr "Filtrer tous les messages"
 
-#: src/muuli_wdr.cpp:2933
+#: src/muuli_wdr.cpp:2964
 msgid "Filter messages from people not on your friend list"
 msgstr "Filtrer les messages des gens qui ne sont pas sur votre liste d'amis"
 
-#: src/muuli_wdr.cpp:2935
+#: src/muuli_wdr.cpp:2966
 msgid "Filter messages from unknown clients"
 msgstr "Filtrer les messages des clients inconnus"
 
-#: src/muuli_wdr.cpp:2937
+#: src/muuli_wdr.cpp:2968
 msgid "Filter messages containing (use ',' as separator):"
 msgstr "Filtrer les messages contenant (utiliser ',' comme séparateur) :"
 
-#: src/muuli_wdr.cpp:2940 src/muuli_wdr.cpp:2951
+#: src/muuli_wdr.cpp:2971 src/muuli_wdr.cpp:2982
 msgid "add here the words amule should filter and block messages including it"
 msgstr "ajouter ici les mots qu'aMule doit filtrer : blocage des messages les contenant"
 
-#: src/muuli_wdr.cpp:2942
+#: src/muuli_wdr.cpp:2973
 msgid "Show received messages in the log"
 msgstr "Afficher les messages reçus dans le journal"
 
-#: src/muuli_wdr.cpp:2945
+#: src/muuli_wdr.cpp:2976
 msgid "Comments"
 msgstr "Commentaires"
 
-#: src/muuli_wdr.cpp:2948
+#: src/muuli_wdr.cpp:2979
 msgid "Filter comments containing (use ',' as separator):"
 msgstr "Filtrer les commentaires contenant (utiliser ',' comme séparateur) :"
 
-#: src/muuli_wdr.cpp:2973
+#: src/muuli_wdr.cpp:3004
 msgid "Enable Proxy"
 msgstr "Activer le Proxy"
 
-#: src/muuli_wdr.cpp:2974
+#: src/muuli_wdr.cpp:3005
 msgid "Enable/disable proxy support"
 msgstr "Active/Désactive le support proxy"
 
-#: src/muuli_wdr.cpp:2977
+#: src/muuli_wdr.cpp:3008
 msgid "Proxy type:"
 msgstr "Type de proxy :"
 
-#: src/muuli_wdr.cpp:2988
+#: src/muuli_wdr.cpp:3019
 msgid "Proxy host:"
 msgstr "Hôte du proxy :"
 
-#: src/muuli_wdr.cpp:2991
+#: src/muuli_wdr.cpp:3022
 msgid "The proxy host name"
 msgstr "Nom de l'hôte du proxy"
 
-#: src/muuli_wdr.cpp:2993
+#: src/muuli_wdr.cpp:3024
 msgid "Proxy port:"
 msgstr "Port du proxy :"
 
-#: src/muuli_wdr.cpp:2996
+#: src/muuli_wdr.cpp:3027
 msgid "The proxy port"
 msgstr "Numéro du port du proxy"
 
-#: src/muuli_wdr.cpp:2998
+#: src/muuli_wdr.cpp:3029
 msgid "Enable authentication"
 msgstr "Activer l'authentification"
 
-#: src/muuli_wdr.cpp:2999
+#: src/muuli_wdr.cpp:3030
 msgid "Enable/disable username/password authentication"
 msgstr "Active/Désactive l'authentification par nom d'utilisateur/mot de passe"
 
-#: src/muuli_wdr.cpp:3002
+#: src/muuli_wdr.cpp:3033
 msgid "Username: "
 msgstr "Nom d'utilisateur : "
 
-#: src/muuli_wdr.cpp:3005
+#: src/muuli_wdr.cpp:3036
 msgid "The username to use to connect to the proxy"
 msgstr "Nom d'utilisateur pour se connecter au proxy"
 
-#: src/muuli_wdr.cpp:3007
+#: src/muuli_wdr.cpp:3038
 msgid "Password:"
 msgstr "Mot de passe :"
 
-#: src/muuli_wdr.cpp:3010
+#: src/muuli_wdr.cpp:3041
 msgid "The password to use to connect to the proxy"
 msgstr "Mot de passe pour se connecter au proxy"
 
-#: src/muuli_wdr.cpp:3029
+#: src/muuli_wdr.cpp:3060
 msgid "Connect to:"
 msgstr "Se connecter à :"
 
-#: src/muuli_wdr.cpp:3038
+#: src/muuli_wdr.cpp:3069
 msgid "Login to remote amule"
 msgstr "Connexion distante à aMule"
 
-#: src/muuli_wdr.cpp:3043
+#: src/muuli_wdr.cpp:3074
 msgid "User name"
 msgstr "Nom d'utilisateur"
 
-#: src/muuli_wdr.cpp:3054
+#: src/muuli_wdr.cpp:3085
 msgid "Remember those settings"
 msgstr "Se rappeler de ces réglages"
 
-#: src/muuli_wdr.cpp:3057
+#: src/muuli_wdr.cpp:3088
 msgid "Force ZLIB compression"
 msgstr "Forcer la compression ZLIB"
 
-#: src/muuli_wdr.cpp:3081
+#: src/muuli_wdr.cpp:3112
 msgid "Enable Verbose Debug-Logging."
 msgstr "Activer l'historique du mode de débogage bavard."
 
-#: src/muuli_wdr.cpp:3083
+#: src/muuli_wdr.cpp:3114
 msgid "Only to Logfile"
 msgstr "Seulement vers le fichier journal"
 
-#: src/muuli_wdr.cpp:3085
+#: src/muuli_wdr.cpp:3116
 msgid "Message Categories:"
 msgstr "Catégories des messages :"
 
-#: src/muuli_wdr.cpp:3109 src/PartFileConvertDlg.cpp:160
+#: src/muuli_wdr.cpp:3140 src/PartFileConvertDlg.cpp:160
 msgid "Waiting..."
 msgstr "En attente…"
 
-#: src/muuli_wdr.cpp:3129
+#: src/muuli_wdr.cpp:3160
 msgid "Add imports"
 msgstr "Ajouter des fichiers à importer"
 
-#: src/muuli_wdr.cpp:3132
+#: src/muuli_wdr.cpp:3163
 msgid "Retry selected"
 msgstr "Réessayer avec la sélection"
 
-#: src/muuli_wdr.cpp:3134
+#: src/muuli_wdr.cpp:3165
 msgid "Remove selected"
 msgstr "Supprimer la sélection"
 
-#: src/muuli_wdr.cpp:3197
+#: src/muuli_wdr.cpp:3228
 msgid "Event Types"
 msgstr "Types d'événements"
 
-#: src/muuli_wdr.cpp:3216
+#: src/muuli_wdr.cpp:3247
 msgid "Statistics and queued clients for selected file(s) : Session / All time"
 msgstr "Statistiques et clients en attente pour le(s) fichier(s) sélectionné(s) : Session / Tous les temps"
 
-#: src/muuli_wdr.cpp:3240
+#: src/muuli_wdr.cpp:3271
 msgid "Active Uploads"
 msgstr "Envois Actifs"
 
-#: src/muuli_wdr.cpp:3254
+#: src/muuli_wdr.cpp:3285
 msgid "Percent of total files"
 msgstr "Pourcentage du total de fichiers"
 
-#: src/muuli_wdr.cpp:3306
+#: src/muuli_wdr.cpp:3337
 msgid "Show Clients for"
 msgstr "Afficher les clients pour"
 
-#: src/muuli_wdr.cpp:3308
+#: src/muuli_wdr.cpp:3339
 msgid "All files"
 msgstr "Tous les fichiers"
 
-#: src/muuli_wdr.cpp:3311
+#: src/muuli_wdr.cpp:3342
 msgid "Selected files"
 msgstr "Fichiers sélectionnés"
 
-#: src/muuli_wdr.cpp:3314
+#: src/muuli_wdr.cpp:3345
 msgid "Active uploads only"
 msgstr "Envois actifs seulement"
 
-#: src/muuli_wdr.cpp:3321
+#: src/muuli_wdr.cpp:3352
 msgid "Reload:"
 msgstr "Recharger :"
 
-#: src/muuli_wdr.cpp:3325
+#: src/muuli_wdr.cpp:3356
 msgid "Reload your shared files"
 msgstr "Recharge vos fichiers partagés"
 
-#: src/muuli_wdr.cpp:3388
+#: src/muuli_wdr.cpp:3419
 msgid "Send"
 msgstr "Envoyer"
 
-#: src/muuli_wdr.cpp:3389
+#: src/muuli_wdr.cpp:3420
 msgid "Sends the specified message."
 msgstr "Envoie le message spécifié."
 
-#: src/muuli_wdr.cpp:3393
+#: src/muuli_wdr.cpp:3424
 msgid "Close this chat-session."
 msgstr "Ferme cette session de discussion."
 
-#: src/muuli_wdr.cpp:3416
+#: src/muuli_wdr.cpp:3447
 msgid "Connect to any server and/or Kad"
 msgstr "Se connecter à n'importe quel serveur et/ou Kad"
 
-#: src/muuli_wdr.cpp:3422 src/SharedFilesCtrl.cpp:142 src/Statistics.cpp:941
+#: src/muuli_wdr.cpp:3453 src/SharedFilesCtrl.cpp:142 src/Statistics.cpp:941
 msgid "Shared Files"
 msgstr "Fichiers partagés"
 
@@ -5430,248 +5458,248 @@ msgstr "Téléchargé"
 msgid "ERROR: Failed to open partfile '%s'"
 msgstr "ERREUR : Impossible d'ouvrir fichier .part : '%s'"
 
-#: src/Preferences.cpp:674
+#: src/Preferences.cpp:701
 msgid "System default"
 msgstr "Système par défaut"
 
-#: src/Preferences.cpp:675
+#: src/Preferences.cpp:702
 msgid "Albanian"
 msgstr "Albanais"
 
-#: src/Preferences.cpp:676
+#: src/Preferences.cpp:703
 msgid "Arabic"
 msgstr "Arabe"
 
-#: src/Preferences.cpp:677
+#: src/Preferences.cpp:704
 msgid "Asturian"
 msgstr "Asturien"
 
-#: src/Preferences.cpp:678
+#: src/Preferences.cpp:705
 msgid "Basque"
 msgstr "Basque"
 
-#: src/Preferences.cpp:679
+#: src/Preferences.cpp:706
 msgid "Bulgarian"
 msgstr "Bulgare"
 
-#: src/Preferences.cpp:680
+#: src/Preferences.cpp:707
 msgid "Catalan"
 msgstr "Catalan"
 
-#: src/Preferences.cpp:681
+#: src/Preferences.cpp:708
 msgid "Chinese (Simplified)"
 msgstr "Chinois (Simplifié)"
 
-#: src/Preferences.cpp:682
+#: src/Preferences.cpp:709
 msgid "Chinese (Traditional)"
 msgstr "Chinois (Traditionnel)"
 
-#: src/Preferences.cpp:683
+#: src/Preferences.cpp:710
 msgid "Croatian"
 msgstr "Croate"
 
-#: src/Preferences.cpp:684
+#: src/Preferences.cpp:711
 msgid "Czech"
 msgstr "Tchèque"
 
-#: src/Preferences.cpp:685
+#: src/Preferences.cpp:712
 msgid "Danish"
 msgstr "Danois"
 
-#: src/Preferences.cpp:686
+#: src/Preferences.cpp:713
 msgid "Dutch"
 msgstr "Hollandais"
 
-#: src/Preferences.cpp:687
+#: src/Preferences.cpp:714
 msgid "English (U.K.)"
 msgstr "Anglais (U.K.)"
 
-#: src/Preferences.cpp:688
+#: src/Preferences.cpp:715
 msgid "English (U.S.)"
 msgstr "Anglais (É-U)"
 
-#: src/Preferences.cpp:689
+#: src/Preferences.cpp:716
 msgid "Estonian"
 msgstr "Estonien"
 
-#: src/Preferences.cpp:690
+#: src/Preferences.cpp:717
 msgid "Finnish"
 msgstr "Finlandais"
 
-#: src/Preferences.cpp:691
+#: src/Preferences.cpp:718
 msgid "French"
 msgstr "Français"
 
-#: src/Preferences.cpp:692
+#: src/Preferences.cpp:719
 msgid "Galician"
 msgstr "Galicien"
 
-#: src/Preferences.cpp:693
+#: src/Preferences.cpp:720
 msgid "German"
 msgstr "Allemand"
 
-#: src/Preferences.cpp:694
+#: src/Preferences.cpp:721
 msgid "Greek"
 msgstr "Grec"
 
-#: src/Preferences.cpp:695
+#: src/Preferences.cpp:722
 msgid "Hebrew"
 msgstr "Hébreux"
 
-#: src/Preferences.cpp:696
+#: src/Preferences.cpp:723
 msgid "Hungarian"
 msgstr "Hongrois"
 
-#: src/Preferences.cpp:697
+#: src/Preferences.cpp:724
 msgid "Italian"
 msgstr "Italien"
 
-#: src/Preferences.cpp:698
+#: src/Preferences.cpp:725
 msgid "Japanese"
 msgstr "Japonais"
 
-#: src/Preferences.cpp:699
+#: src/Preferences.cpp:726
 msgid "Korean"
 msgstr "Coréen"
 
-#: src/Preferences.cpp:700
+#: src/Preferences.cpp:727
 msgid "Latvian"
 msgstr "Letton"
 
-#: src/Preferences.cpp:701
+#: src/Preferences.cpp:728
 msgid "Lithuanian"
 msgstr "Lituanien"
 
-#: src/Preferences.cpp:702
+#: src/Preferences.cpp:729
 msgid "Norwegian (Nynorsk)"
 msgstr "Norvégien (Nynorsk)"
 
-#: src/Preferences.cpp:703
+#: src/Preferences.cpp:730
 msgid "Polish"
 msgstr "Polonais"
 
-#: src/Preferences.cpp:704
+#: src/Preferences.cpp:731
 msgid "Portuguese"
 msgstr "Portugais"
 
-#: src/Preferences.cpp:705
+#: src/Preferences.cpp:732
 msgid "Portuguese (Brazilian)"
 msgstr "Portugais (Brésilien)"
 
-#: src/Preferences.cpp:706
+#: src/Preferences.cpp:733
 msgid "Romanian"
 msgstr "Roumain"
 
-#: src/Preferences.cpp:707
+#: src/Preferences.cpp:734
 msgid "Russian"
 msgstr "Russe"
 
-#: src/Preferences.cpp:708
+#: src/Preferences.cpp:735
 msgid "Slovenian"
 msgstr "Slovène"
 
-#: src/Preferences.cpp:709
+#: src/Preferences.cpp:736
 msgid "Spanish"
 msgstr "Espagnol"
 
-#: src/Preferences.cpp:710
+#: src/Preferences.cpp:737
 msgid "Swedish"
 msgstr "Suédois"
 
-#: src/Preferences.cpp:711
+#: src/Preferences.cpp:738
 msgid "Turkish"
 msgstr "Turc"
 
-#: src/Preferences.cpp:712
+#: src/Preferences.cpp:739
 msgid "Ukrainian"
 msgstr "Ukrainien"
 
-#: src/Preferences.cpp:815
+#: src/Preferences.cpp:842
 msgid "Change Language"
 msgstr "Changer de langue"
 
-#: src/Preferences.cpp:879
+#: src/Preferences.cpp:906
 msgid "There are no translations installed for aMule"
 msgstr "Il n'y a pas de traductions installées pour aMule"
 
-#: src/Preferences.cpp:880
+#: src/Preferences.cpp:907
 msgid "No languages available"
 msgstr "Pas de langues disponibles"
 
-#: src/Preferences.cpp:1011
+#: src/Preferences.cpp:1038
 msgid "no options available"
 msgstr "pas d'option disponible"
 
-#: src/Preferences.cpp:2182
+#: src/Preferences.cpp:2227
 msgid "Invalid category found, skipping"
 msgstr "Catégorie invalide trouvée, on passe"
 
-#: src/Preferences.cpp:2351
+#: src/Preferences.cpp:2396
 msgid "TCP port can't be higher than 65532 due to server UDP socket being TCP+3"
 msgstr "Le port TCP ne peut pas dépasser 65532 car le socket UDP du serveur sera à TCP+3"
 
-#: src/Preferences.cpp:2352
+#: src/Preferences.cpp:2397
 #, c-format
 msgid "Default port will be used (%d)"
 msgstr "Le port par défaut sera utilisé (%d)"
 
-#: src/PrefsUnifiedDlg.cpp:298 src/Statistics.cpp:866
+#: src/PrefsUnifiedDlg.cpp:300 src/Statistics.cpp:866
 msgid "Connection"
 msgstr "Connexion"
 
-#: src/PrefsUnifiedDlg.cpp:299 src/SearchListCtrl.cpp:117
+#: src/PrefsUnifiedDlg.cpp:301 src/SearchListCtrl.cpp:117
 msgid "Directories"
 msgstr "Répertoires"
 
-#: src/PrefsUnifiedDlg.cpp:300 src/Statistics.cpp:917
+#: src/PrefsUnifiedDlg.cpp:302 src/Statistics.cpp:917
 msgid "Servers"
 msgstr "Serveurs"
 
-#: src/PrefsUnifiedDlg.cpp:301 src/ServerListCtrl.cpp:96
+#: src/PrefsUnifiedDlg.cpp:303 src/ServerListCtrl.cpp:96
 msgid "Files"
 msgstr "Fichiers"
 
-#: src/PrefsUnifiedDlg.cpp:302
+#: src/PrefsUnifiedDlg.cpp:304
 msgid "Security"
 msgstr "Sécurité"
 
-#: src/PrefsUnifiedDlg.cpp:303
+#: src/PrefsUnifiedDlg.cpp:305
 msgid "Interface"
 msgstr "Interface"
 
-#: src/PrefsUnifiedDlg.cpp:310
+#: src/PrefsUnifiedDlg.cpp:312
 msgid "IP2Country"
 msgstr "IP2Country"
 
-#: src/PrefsUnifiedDlg.cpp:313
+#: src/PrefsUnifiedDlg.cpp:315
 msgid "Proxy"
 msgstr "Proxy"
 
-#: src/PrefsUnifiedDlg.cpp:314
+#: src/PrefsUnifiedDlg.cpp:316
 msgid "Filters"
 msgstr "Filtres"
 
-#: src/PrefsUnifiedDlg.cpp:315
+#: src/PrefsUnifiedDlg.cpp:317
 msgid "Remote Controls"
 msgstr "Contrôles à distance"
 
-#: src/PrefsUnifiedDlg.cpp:316
+#: src/PrefsUnifiedDlg.cpp:318
 msgid "Online Signature"
 msgstr "Signature en ligne"
 
-#: src/PrefsUnifiedDlg.cpp:317
+#: src/PrefsUnifiedDlg.cpp:319
 msgid "Advanced"
 msgstr "Avancé"
 
-#: src/PrefsUnifiedDlg.cpp:318
+#: src/PrefsUnifiedDlg.cpp:320
 msgid "Events"
 msgstr "Événements"
 
-#: src/PrefsUnifiedDlg.cpp:321
+#: src/PrefsUnifiedDlg.cpp:323
 msgid "Debugging"
 msgstr "Débogage"
 
-#: src/PrefsUnifiedDlg.cpp:451
+#: src/PrefsUnifiedDlg.cpp:453
 msgid ""
 "The following variables will be substituted:\n"
 "    %PARTFILE - full path to the file\n"
@@ -5681,15 +5709,15 @@ msgstr ""
 "    %PARTFILE - chemin complet vers le fichier\n"
 "    %PARTNAME - nom du fichier seulement"
 
-#: src/PrefsUnifiedDlg.cpp:472
+#: src/PrefsUnifiedDlg.cpp:474
 msgid "Tray icon support requires libayatana-appindicator3 at compile time."
 msgstr "L'icône de la barre système nécessite libayatana-appindicator3 au moment de la compilation."
 
-#: src/PrefsUnifiedDlg.cpp:488
+#: src/PrefsUnifiedDlg.cpp:490
 msgid "Not available on Wayland: the protocol does not report when a window is minimized, so this option cannot intercept the system minimize button. Workaround: launch aMule with `GDK_BACKEND=x11` to use XWayland instead."
 msgstr "Non disponible sous Wayland : le protocole n'informe pas lorsqu'une fenêtre est minimisée, cette option ne peut donc intercepter le bouton de minimisation du système. Solution de contournement : lancez aMule avec `GDK_BACKEND=x11` pour utiliser XWayland à la place."
 
-#: src/PrefsUnifiedDlg.cpp:534
+#: src/PrefsUnifiedDlg.cpp:536
 msgid ""
 "Do not change these setting unless you know\n"
 "what you are doing, otherwise you can easily\n"
@@ -5705,26 +5733,35 @@ msgstr ""
 "aMule fonctionnera bien en ne modifiant pas\n"
 "ces réglages."
 
-#: src/PrefsUnifiedDlg.cpp:645
+#: src/PrefsUnifiedDlg.cpp:647
 #, c-format
 msgid "Failed to connect Cfg to widget with the ID %d and key %s"
 msgstr "Échec à la connexion de Cfg au widget avec l'ID %d et la clé %s"
 
-#: src/PrefsUnifiedDlg.cpp:693
+#: src/PrefsUnifiedDlg.cpp:695
 #, c-format
 msgid "Failed to transfer data from Cfg to Widget with the ID %d and key %s"
 msgstr "Échec du transfert de données depuis Cfg vers le widget avec l'ID %d et la clé %s"
 
-#: src/PrefsUnifiedDlg.cpp:799
+#: src/PrefsUnifiedDlg.cpp:801
 msgid "The type of proxy you are connecting to"
 msgstr "Type de proxy auquel vous êtes connecté"
 
-#: src/PrefsUnifiedDlg.cpp:1003
+#: src/PrefsUnifiedDlg.cpp:1020
 #, c-format
 msgid "Failed to transfer data from Widget to Cfg with the ID %d and key %s"
 msgstr "Échec du transfert de données depuis le widget vers Cfg avec l'ID %d et la clé %s"
 
 #: src/PrefsUnifiedDlg.cpp:1103
+#, fuzzy
+msgid "No password set."
+msgstr "Mot de passe administrateur"
+
+#: src/PrefsUnifiedDlg.cpp:1132
+msgid "Guest access needs a password. Type one in the guest password field, or untick Enable guest access."
+msgstr ""
+
+#: src/PrefsUnifiedDlg.cpp:1144
 msgid ""
 "aMule must be restarted to enable these changes:\n"
 "\n"
@@ -5732,39 +5769,39 @@ msgstr ""
 "aMule doit être redémarré pour activer ces changements : \n"
 "\n"
 
-#: src/PrefsUnifiedDlg.cpp:1110
+#: src/PrefsUnifiedDlg.cpp:1151
 msgid "- TCP port changed.\n"
 msgstr "- Port TCP changé.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1115
+#: src/PrefsUnifiedDlg.cpp:1156
 msgid "- UDP port changed.\n"
 msgstr "- Port UDP changé.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1120
+#: src/PrefsUnifiedDlg.cpp:1161
 msgid "- Network interface binding changed.\n"
 msgstr "- La liaison de Interface réseau modifiée.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1125
+#: src/PrefsUnifiedDlg.cpp:1166
 msgid "- External connect port changed.\n"
 msgstr "- Port de connexion externe changé.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1129
+#: src/PrefsUnifiedDlg.cpp:1170
 msgid "- External connect acceptance changed.\n"
 msgstr "- Consentement de connexion externe changé.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1133
+#: src/PrefsUnifiedDlg.cpp:1174
 msgid "- External connect interface changed.\n"
 msgstr "- Interface de connexion externe changé.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1137
+#: src/PrefsUnifiedDlg.cpp:1178
 msgid "- Protocol obfuscation support changed.\n"
 msgstr "- Support du brouillage de protocole changé.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1151
+#: src/PrefsUnifiedDlg.cpp:1193
 msgid "- amuleapi settings changed.\n"
 msgstr "- les réglages amuleapi modifiés.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1160
+#: src/PrefsUnifiedDlg.cpp:1202
 msgid ""
 "Your Auto-update server list is empty.\n"
 "'Auto-update server list at startup' will be disabled."
@@ -5772,7 +5809,7 @@ msgstr ""
 "Votre liste de serveur pour la mise à jour automatique est vide.\n"
 "'Mise à jour automatique au démarrage de la liste des serveurs' va être désactivée."
 
-#: src/PrefsUnifiedDlg.cpp:1171
+#: src/PrefsUnifiedDlg.cpp:1213
 msgid ""
 "You have enabled external connections but have not specified a password.\n"
 "External connections cannot be enabled unless a valid password is specified."
@@ -5780,27 +5817,32 @@ msgstr ""
 "Vous avez activé les connexions externes mais vous n'avez pas spécifié de mot de passe valide.\n"
 "Les connexions externes ne pourront pas être activées tant qu'un mot de passe valide n'est pas spécifié."
 
-#: src/PrefsUnifiedDlg.cpp:1202
+#: src/PrefsUnifiedDlg.cpp:1246
+#, c-format
+msgid "The amuleapi password could not be saved: %s"
+msgstr ""
+
+#: src/PrefsUnifiedDlg.cpp:1276
 msgid "- Language changed.\n"
 msgstr "- Langue changée.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1207
+#: src/PrefsUnifiedDlg.cpp:1281
 msgid "- Temp folder changed.\n"
 msgstr "- Dossier temporaire changé.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1212
+#: src/PrefsUnifiedDlg.cpp:1286
 msgid "- ED2K network enabled.\n"
 msgstr "- Réseau ED2K activé.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1245
+#: src/PrefsUnifiedDlg.cpp:1319
 msgid "The shared-file exclusion pattern is not a valid regular expression. The filter has been left disabled."
 msgstr "Le motif d'exclusion de fichiers partagés n'est pas une expression régulière valide. Le filtre a été laissé désactivé."
 
-#: src/PrefsUnifiedDlg.cpp:1247 src/PrefsUnifiedDlg.cpp:1841
+#: src/PrefsUnifiedDlg.cpp:1321 src/PrefsUnifiedDlg.cpp:1921
 msgid "Invalid regular expression"
 msgstr "Expression régulière invalide"
 
-#: src/PrefsUnifiedDlg.cpp:1324
+#: src/PrefsUnifiedDlg.cpp:1398
 msgid ""
 "Both eD2k and Kad network are disabled.\n"
 "You won't be able to connect until you enable at least one of them."
@@ -5808,7 +5850,7 @@ msgstr ""
 "Les réseaux eD2k et Kad sont désactivés.\n"
 "Vous ne pourrez pas vous connecter tant que vous n'activerez pas au moins l'un des deux."
 
-#: src/PrefsUnifiedDlg.cpp:1329
+#: src/PrefsUnifiedDlg.cpp:1403
 msgid ""
 "Kad will not start if your UDP port is disabled.\n"
 "Enable UDP port or disable Kad."
@@ -5816,7 +5858,7 @@ msgstr ""
 "Kad ne démarrera pas si votre port UDP est désactivé.\n"
 "Activez le port UDP ou désactivez Kad."
 
-#: src/PrefsUnifiedDlg.cpp:1385
+#: src/PrefsUnifiedDlg.cpp:1459
 msgid ""
 "\n"
 "You MUST restart aMule now.\n"
@@ -5826,68 +5868,68 @@ msgstr ""
 "Vous DEVEZ redémarrer aMule maintenant.\n"
 "Si vous ne le faites pas, ne vous plaignez pas si des bogues surviennent.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1450
+#: src/PrefsUnifiedDlg.cpp:1524
 msgid "Could not register aMule for autostart at login. The autostart store may be read-only."
 msgstr "Échec de l'enregistrement d'aMule pour un lancement automatique à l'ouverture d'une session. Le dépôt de lancement automatique est peut-être en lecture seule."
 
-#: src/PrefsUnifiedDlg.cpp:1452
+#: src/PrefsUnifiedDlg.cpp:1526
 msgid "Could not remove the autostart-at-login entry."
 msgstr "Échec de l'effacement de l'entrée du lancement automatique à l'ouverture d'une session."
 
-#: src/PrefsUnifiedDlg.cpp:1453
+#: src/PrefsUnifiedDlg.cpp:1527
 msgid "Autostart"
 msgstr "Lancement automatique"
 
-#: src/PrefsUnifiedDlg.cpp:1468
+#: src/PrefsUnifiedDlg.cpp:1542
 msgid "Register file type"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1468
+#: src/PrefsUnifiedDlg.cpp:1542
 msgid "Register URL handler"
 msgstr "Enregistrer le gestionnaire d'URL"
 
-#: src/PrefsUnifiedDlg.cpp:1476
+#: src/PrefsUnifiedDlg.cpp:1550
 #, c-format
 msgid "aMule only handles eD2k-compatible magnets. If you replace the current magnet handler (%s), BitTorrent magnet links will stop working - aMule cannot download BitTorrent content. Continue?"
 msgstr "aMule ne gère que les magnet compatibles avec eD2k. Si vous remplacez le gestionnaire de magnet actuel (%s), les liens magnet BitTorrent cesseront de fonctionner - aMule ne peut télécharger du contenu BitTorrent. Continuer ?"
 
-#: src/PrefsUnifiedDlg.cpp:1481
+#: src/PrefsUnifiedDlg.cpp:1555
 #, fuzzy, c-format
 msgid "Another application currently opens .emulecollection files (%s). Replace it with aMule?"
 msgstr "Une autre application gère les liens (%s) par défaut. La remplacer par aMule ?"
 
-#: src/PrefsUnifiedDlg.cpp:1486
+#: src/PrefsUnifiedDlg.cpp:1560
 #, c-format
 msgid "Another application is currently the default handler for these links (%s). Replace it with aMule?"
 msgstr "Une autre application gère les liens (%s) par défaut. La remplacer par aMule ?"
 
-#: src/PrefsUnifiedDlg.cpp:1511
+#: src/PrefsUnifiedDlg.cpp:1585
 #, fuzzy
 msgid "Could not register aMule for .emulecollection files. The registration store may be read-only."
 msgstr "Échec de l'enregistrement d'aMule en tant que gestionnaire des URL. Le dépôt d'enregistrement est peut-être en lecture seule."
 
-#: src/PrefsUnifiedDlg.cpp:1513
+#: src/PrefsUnifiedDlg.cpp:1587
 #, fuzzy
 msgid "Could not remove the file type registration."
 msgstr "Impossible de supprimer l'enregistrement du gestionnaire d'URL."
 
-#: src/PrefsUnifiedDlg.cpp:1515
+#: src/PrefsUnifiedDlg.cpp:1589
 msgid "Could not register aMule as the URL handler. The registration store may be read-only."
 msgstr "Échec de l'enregistrement d'aMule en tant que gestionnaire des URL. Le dépôt d'enregistrement est peut-être en lecture seule."
 
-#: src/PrefsUnifiedDlg.cpp:1517
+#: src/PrefsUnifiedDlg.cpp:1591
 msgid "Could not remove the URL handler registration."
 msgstr "Impossible de supprimer l'enregistrement du gestionnaire d'URL."
 
-#: src/PrefsUnifiedDlg.cpp:1587 src/PrefsUnifiedDlg.cpp:1614
+#: src/PrefsUnifiedDlg.cpp:1661 src/PrefsUnifiedDlg.cpp:1688
 msgid "The web server and aMule API require external connections to be enabled."
 msgstr "Le serveur web et aMule API nécessitent l'activation des connexions externes."
 
-#: src/PrefsUnifiedDlg.cpp:1597
+#: src/PrefsUnifiedDlg.cpp:1671
 msgid "The aMule web server is deprecated. Consider running the aMule API instead."
 msgstr "Le serveur web d'aMule est obsolète. Envisagez d'utiliser aMule API à sa place."
 
-#: src/PrefsUnifiedDlg.cpp:1655
+#: src/PrefsUnifiedDlg.cpp:1735
 msgid ""
 "Your Auto-update servers list is in blank.\n"
 "Please fill in at least one URL to point to a valid server.met file.\n"
@@ -5897,64 +5939,64 @@ msgstr ""
 "Entrez s'il vous plaît au moins une URL qui pointe sur un fichier server.met valide.\n"
 "Cliquez sur le bouton \"Liste\" à coté de cette case pour entrer une URL."
 
-#: src/PrefsUnifiedDlg.cpp:1796
+#: src/PrefsUnifiedDlg.cpp:1876
 msgid "Temporary files"
 msgstr "Fichiers temporaires"
 
-#: src/PrefsUnifiedDlg.cpp:1801
+#: src/PrefsUnifiedDlg.cpp:1881
 msgid "Incoming files"
 msgstr "Fichiers réceptionnés"
 
-#: src/PrefsUnifiedDlg.cpp:1806
+#: src/PrefsUnifiedDlg.cpp:1886
 msgid "Online Signatures"
 msgstr "Signatures En Ligne"
 
-#: src/PrefsUnifiedDlg.cpp:1819
+#: src/PrefsUnifiedDlg.cpp:1899
 #, c-format
 msgid "Choose a folder for %s"
 msgstr "Choisir un dossier pour %s"
 
-#: src/PrefsUnifiedDlg.cpp:1843
+#: src/PrefsUnifiedDlg.cpp:1923
 #, c-format
 msgid "Would exclude %u of %u shared file"
 msgid_plural "Would exclude %u of %u shared files"
 msgstr[0] "Exclurait %u fichier sur %u fichier partagé"
 msgstr[1] "Exclurait %u fichiers sur %u fichiers partagés"
 
-#: src/PrefsUnifiedDlg.cpp:1860
+#: src/PrefsUnifiedDlg.cpp:1940
 msgid "Browse for videoplayer"
 msgstr "Chercher un lecteur vidéo"
 
-#: src/PrefsUnifiedDlg.cpp:1864
+#: src/PrefsUnifiedDlg.cpp:1944
 msgid "Select browser"
 msgstr "Choisir un navigateur"
 
-#: src/PrefsUnifiedDlg.cpp:1868
+#: src/PrefsUnifiedDlg.cpp:1948
 msgid "Select ffprobe binary"
 msgstr "Sélectionner le binaire ffprobe"
 
-#: src/PrefsUnifiedDlg.cpp:1874
+#: src/PrefsUnifiedDlg.cpp:1954
 #, c-format
 msgid "Executable%s"
 msgstr "Exécutable%s"
 
-#: src/PrefsUnifiedDlg.cpp:1908
+#: src/PrefsUnifiedDlg.cpp:1988
 msgid "ffprobe not found on PATH or in the standard install locations. Install ffmpeg (which ships ffprobe) or use Browse to pick a binary manually."
 msgstr "ffprobe n'a pas été trouvé sur PATH ou dans les emplacement standards d'installation. Installez ffmpeg (qui fournit ffprobe) ou bien utilisez Parcourir pour choisir un binaire manuellement."
 
-#: src/PrefsUnifiedDlg.cpp:1920
+#: src/PrefsUnifiedDlg.cpp:2000
 msgid "Reset the settings on this page to their default values?"
 msgstr "Réinitialiser les réglages sur cette page à leurs valeurs par défaut ?"
 
-#: src/PrefsUnifiedDlg.cpp:1921
+#: src/PrefsUnifiedDlg.cpp:2001
 msgid "Reset to defaults"
 msgstr "Réinitialiser aux valeurs par défaut"
 
-#: src/PrefsUnifiedDlg.cpp:1948
+#: src/PrefsUnifiedDlg.cpp:2028
 msgid "Edit server list"
 msgstr "Éditer la liste des serveurs"
 
-#: src/PrefsUnifiedDlg.cpp:1949
+#: src/PrefsUnifiedDlg.cpp:2029
 msgid ""
 "Add here URL's to download server.met files.\n"
 "Only one url on each line."
@@ -5962,114 +6004,114 @@ msgstr ""
 "Ajoutez ci-dessous des URL pour télécharger des fichiers server.met.\n"
 "Seulement une URL par ligne."
 
-#: src/PrefsUnifiedDlg.cpp:2004
+#: src/PrefsUnifiedDlg.cpp:2084
 msgid "IP2Country update failed"
 msgstr "Échec de la mise à jour IP2Country"
 
-#: src/PrefsUnifiedDlg.cpp:2149 src/PrefsUnifiedDlg.cpp:2180
+#: src/PrefsUnifiedDlg.cpp:2229 src/PrefsUnifiedDlg.cpp:2260
 msgid "Data by MaxMind GeoLite2"
 msgstr "Données fournies par MaxMind GeoLite2"
 
-#: src/PrefsUnifiedDlg.cpp:2151 src/PrefsUnifiedDlg.cpp:2182
+#: src/PrefsUnifiedDlg.cpp:2231 src/PrefsUnifiedDlg.cpp:2262
 msgid "Custom source"
 msgstr "Source personnalisée"
 
-#: src/PrefsUnifiedDlg.cpp:2153 src/PrefsUnifiedDlg.cpp:2184
+#: src/PrefsUnifiedDlg.cpp:2233 src/PrefsUnifiedDlg.cpp:2264
 msgid "Data by DB-IP.com"
 msgstr "Données fournies par DB-IP.com"
 
-#: src/PrefsUnifiedDlg.cpp:2204
+#: src/PrefsUnifiedDlg.cpp:2284
 #, c-format
 msgid "Status: Loaded%s"
 msgstr "État : %s chargé"
 
-#: src/PrefsUnifiedDlg.cpp:2206
+#: src/PrefsUnifiedDlg.cpp:2286
 #, c-format
 msgid "Status: Loaded%s - %s"
 msgstr "État : %s - %s chargé"
 
-#: src/PrefsUnifiedDlg.cpp:2210
+#: src/PrefsUnifiedDlg.cpp:2290
 msgid "Status: Failed to load - click 'Update now' to refresh."
 msgstr "État : échec du chargement - cliquez sur « Mettre à jour maintenant » pour actualiser."
 
-#: src/PrefsUnifiedDlg.cpp:2212
+#: src/PrefsUnifiedDlg.cpp:2292
 msgid "Status: Not found - click 'Update now' to download."
 msgstr "État : introuvable - cliquez sur « Mettre à jour maintenant » pour télécharger."
 
-#: src/PrefsUnifiedDlg.cpp:2270 src/PrefsUnifiedDlg.cpp:2294
+#: src/PrefsUnifiedDlg.cpp:2350 src/PrefsUnifiedDlg.cpp:2374
 #, c-format
 msgid "Update delay: %d second"
 msgid_plural "Update delay: %d seconds"
 msgstr[0] "Délais de rafraîchissement : %d seconde"
 msgstr[1] "Délais de rafraîchissement : %d secondes"
 
-#: src/PrefsUnifiedDlg.cpp:2278
+#: src/PrefsUnifiedDlg.cpp:2358
 #, c-format
 msgid "Time for average graph: %d minute"
 msgid_plural "Time for average graph: %d minutes"
 msgstr[0] "Temps pour le graphe des moyennes : %d minute"
 msgstr[1] "Temps pour le graphe des moyennes : %d minutes"
 
-#: src/PrefsUnifiedDlg.cpp:2287
+#: src/PrefsUnifiedDlg.cpp:2367
 #, c-format
 msgid "Connections Graph Scale: %d"
 msgstr "Échelle du graphique des connexions : %d"
 
-#: src/PrefsUnifiedDlg.cpp:2302
+#: src/PrefsUnifiedDlg.cpp:2382
 #, c-format
 msgid "File Buffer Size: %d byte"
 msgid_plural "File Buffer Size: %d bytes"
 msgstr[0] "Taille du tampon de fichiers : %d octet"
 msgstr[1] "Taille du tampon de fichiers : %d octets"
 
-#: src/PrefsUnifiedDlg.cpp:2312
+#: src/PrefsUnifiedDlg.cpp:2392
 #, c-format
 msgid "Upload Queue Size: %d client"
 msgid_plural "Upload Queue Size: %d clients"
 msgstr[0] "Taille de la fille d'attente d'émission : %d client"
 msgstr[1] "Taille de la fille d'attente d'émission : %d clients"
 
-#: src/PrefsUnifiedDlg.cpp:2322
+#: src/PrefsUnifiedDlg.cpp:2402
 #, c-format
 msgid "Server connection refresh interval: %d minute"
 msgid_plural "Server connection refresh interval: %d minutes"
 msgstr[0] "Intervalle de rafraîchissement de la connexion serveur : %d minute"
 msgstr[1] "Intervalle de rafraîchissement de la connexion serveur : %d minutes"
 
-#: src/PrefsUnifiedDlg.cpp:2327
+#: src/PrefsUnifiedDlg.cpp:2407
 msgid "Server connection refresh interval: Disabled"
 msgstr "Intervalle de rafraîchissement de la connexion serveur : Désactivé"
 
-#: src/PrefsUnifiedDlg.cpp:2371
+#: src/PrefsUnifiedDlg.cpp:2451
 msgid "disabled"
 msgstr "désactivé"
 
-#: src/PrefsUnifiedDlg.cpp:2397
+#: src/PrefsUnifiedDlg.cpp:2477
 #, c-format
 msgid "Execute command on '%s' event"
 msgstr "Exécuter la commande lors de l'événement '%s'"
 
-#: src/PrefsUnifiedDlg.cpp:2404
+#: src/PrefsUnifiedDlg.cpp:2484
 msgid "Enable command execution on core"
 msgstr "Activer l'exécution de la commande sur le noyau"
 
-#: src/PrefsUnifiedDlg.cpp:2416
+#: src/PrefsUnifiedDlg.cpp:2496
 msgid "Core command:"
 msgstr "Commande du noyau :"
 
-#: src/PrefsUnifiedDlg.cpp:2432
+#: src/PrefsUnifiedDlg.cpp:2512
 msgid "Enable command execution on GUI"
 msgstr "Activer l'exécution de la commande sur l'interface graphique"
 
-#: src/PrefsUnifiedDlg.cpp:2444
+#: src/PrefsUnifiedDlg.cpp:2524
 msgid "GUI command:"
 msgstr "Commande de l'interface graphique :"
 
-#: src/PrefsUnifiedDlg.cpp:2460
+#: src/PrefsUnifiedDlg.cpp:2540
 msgid "The following variables will be replaced:"
 msgstr "Les variables suivantes seront remplacées :"
 
-#: src/PrefsUnifiedDlg.cpp:2628
+#: src/PrefsUnifiedDlg.cpp:2708
 msgid ""
 "The following folders look like system or sensitive locations:\n"
 "\n"
@@ -6077,37 +6119,37 @@ msgstr ""
 "Les répertoires suivants semblent être des répertoires système ou des emplacements sensibles.\n"
 "\n"
 
-#: src/PrefsUnifiedDlg.cpp:2633
+#: src/PrefsUnifiedDlg.cpp:2713
 msgid "Sharing them recursively will publish every file underneath on the eD2k/Kad networks. Do you really want to do this?"
 msgstr "Les partager récursivement publiera chaque fichier contenu dans les sous répertoires sur les réseaux eD2k/Kad. Êtes-vous sûr de vouloir faire cela ?"
 
-#: src/PrefsUnifiedDlg.cpp:2636
+#: src/PrefsUnifiedDlg.cpp:2716
 msgid "Confirm shared folders"
 msgstr "Confirmer les dossiers partagés"
 
-#: src/PrefsUnifiedDlg.cpp:2664
+#: src/PrefsUnifiedDlg.cpp:2744
 msgid "Reloading shared files..."
 msgstr "Rechargement des fichiers partagés…"
 
-#: src/PrefsUnifiedDlg.cpp:2665
+#: src/PrefsUnifiedDlg.cpp:2745
 msgid "Scanning for subdirectories..."
 msgstr "Analyse des sous-répertoires…"
 
-#: src/PrefsUnifiedDlg.cpp:2666
+#: src/PrefsUnifiedDlg.cpp:2746
 msgid "Updating shared folders"
 msgstr "Mise à jour des dossiers partagés"
 
-#: src/PrefsUnifiedDlg.cpp:2693
+#: src/PrefsUnifiedDlg.cpp:2773
 #, c-format
 msgid "Scanned %u directories..."
 msgstr "%u répertoires analysés…"
 
-#: src/PrefsUnifiedDlg.cpp:2743
+#: src/PrefsUnifiedDlg.cpp:2823
 #, c-format
 msgid "Reloading shared files: %u files scanned"
 msgstr "Rechargement des fichiers partagés : %u fichiers analysés"
 
-#: src/PrefsUnifiedDlg.cpp:2793
+#: src/PrefsUnifiedDlg.cpp:2873
 msgid "Shared folder"
 msgstr "Dossier partagé"
 

--- a/po/fr.po
+++ b/po/fr.po
@@ -15,7 +15,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-28 12:17+0200\n"
+"POT-Creation-Date: 2026-07-28 13:09+0200\n"
 "PO-Revision-Date: 2026-07-27 11:38+0000\n"
 "Last-Translator: Dylan Aïssi <bob.dybian@gmail.com>\n"
 "Language-Team: Français\n"
@@ -300,7 +300,7 @@ msgid "Password set and external connections enabled."
 msgstr "Mot de passe renseigné et connexions externes activées."
 
 #: src/amule.cpp:755 src/KadDlg.cpp:176 src/KadDlg.cpp:185
-#: src/PrefsUnifiedDlg.cpp:1461 src/SharedFilesCtrl.cpp:476
+#: src/PrefsUnifiedDlg.cpp:1470 src/SharedFilesCtrl.cpp:476
 msgid "WARNING"
 msgstr "AVERTISSEMENT"
 
@@ -338,7 +338,7 @@ msgstr "Vous avez demandé à exécuter le serveur web au démarrage, mais le bi
 #: src/amule-remote-gui.cpp:603 src/amule-remote-gui.cpp:671
 #: src/amule-remote-gui.cpp:709 src/amule-remote-gui.cpp:1282
 #: src/amule-remote-gui.cpp:1345 src/amule-remote-gui.cpp:1372
-#: src/DownloadQueue.cpp:1481 src/PrefsUnifiedDlg.cpp:1247
+#: src/DownloadQueue.cpp:1481 src/PrefsUnifiedDlg.cpp:1256
 msgid "ERROR"
 msgstr "ERREUR"
 
@@ -598,36 +598,36 @@ msgstr "Visitez https://github.com/amule-org/amule/releases/latest pour vérifie
 msgid "FATAL ERROR: Failed to create Timer"
 msgstr "ERREUR FATALE : Échec de la création du minuteur"
 
-#: src/amuleDlg.cpp:361 src/amuleDlg.cpp:1787 src/amuleDlg.cpp:2033
-#: src/muuli_wdr.cpp:1492 src/muuli_wdr.cpp:3449
+#: src/amuleDlg.cpp:361 src/amuleDlg.cpp:1810 src/amuleDlg.cpp:2056
+#: src/muuli_wdr.cpp:1492 src/muuli_wdr.cpp:3453
 msgid "Networks"
 msgstr "Réseaux"
 
-#: src/amuleDlg.cpp:362 src/amuleDlg.cpp:1793 src/muuli_wdr.cpp:3450
+#: src/amuleDlg.cpp:362 src/amuleDlg.cpp:1816 src/muuli_wdr.cpp:3454
 msgid "Searches"
 msgstr "Recherches"
 
-#: src/amuleDlg.cpp:363 src/amuleDlg.cpp:1799 src/DownloadListCtrl.cpp:740
-#: src/muuli_wdr.cpp:392 src/muuli_wdr.cpp:1585 src/muuli_wdr.cpp:3451
+#: src/amuleDlg.cpp:363 src/amuleDlg.cpp:1822 src/DownloadListCtrl.cpp:740
+#: src/muuli_wdr.cpp:392 src/muuli_wdr.cpp:1585 src/muuli_wdr.cpp:3455
 #: src/Statistics.cpp:829
 msgid "Downloads"
 msgstr "Téléchargements"
 
-#: src/amuleDlg.cpp:364 src/amuleDlg.cpp:1805 src/muuli_wdr.cpp:3325
+#: src/amuleDlg.cpp:364 src/amuleDlg.cpp:1828 src/muuli_wdr.cpp:3329
 msgid "Shared files"
 msgstr "Fichiers partagés"
 
-#: src/amuleDlg.cpp:365 src/amuleDlg.cpp:1811 src/muuli_wdr.cpp:2957
-#: src/muuli_wdr.cpp:3407 src/muuli_wdr.cpp:3454
+#: src/amuleDlg.cpp:365 src/amuleDlg.cpp:1834 src/muuli_wdr.cpp:2961
+#: src/muuli_wdr.cpp:3411 src/muuli_wdr.cpp:3458
 msgid "Messages"
 msgstr "Messages"
 
-#: src/amuleDlg.cpp:366 src/amuleDlg.cpp:1817 src/muuli_wdr.cpp:3455
+#: src/amuleDlg.cpp:366 src/amuleDlg.cpp:1840 src/muuli_wdr.cpp:3459
 #: src/PrefsUnifiedDlg.cpp:314 src/Statistics.cpp:779 src/Statistics.cpp:1235
 msgid "Statistics"
 msgstr "Statistiques"
 
-#: src/amuleDlg.cpp:368 src/amuleDlg.cpp:1824 src/muuli_wdr.cpp:3457
+#: src/amuleDlg.cpp:368 src/amuleDlg.cpp:1847 src/muuli_wdr.cpp:3461
 #: src/PrefsUnifiedDlg.cpp:330 src/utils/wxCas/src/wxcasprefs.cpp:39
 msgid "Preferences"
 msgstr "Préférences"
@@ -690,8 +690,8 @@ msgstr "Kad : Coupé"
 #: src/amuleDlg.cpp:1029 src/DownloadListCtrl.cpp:505
 #: src/DownloadListCtrl.cpp:749 src/FriendListCtrl.cpp:180
 #: src/muuli_wdr.cpp:731 src/muuli_wdr.cpp:782 src/muuli_wdr.cpp:846
-#: src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2262 src/muuli_wdr.cpp:2347
-#: src/muuli_wdr.cpp:3095 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
+#: src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2266 src/muuli_wdr.cpp:2351
+#: src/muuli_wdr.cpp:3099 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
 #: src/ServerListCtrl.cpp:606 src/TransferWnd.cpp:378
 #: src/utils/wxCas/src/wxcasprefs.cpp:235
 msgid "Cancel"
@@ -702,7 +702,7 @@ msgid "Stop the current connection attempts"
 msgstr "Stopper les essais de connexions en cours"
 
 #: src/amuleDlg.cpp:1035 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976
-#: src/muuli_wdr.cpp:2485
+#: src/muuli_wdr.cpp:2489
 msgid "Disconnect"
 msgstr "Déconnecter"
 
@@ -711,7 +711,7 @@ msgid "Disconnect from the currently connected networks"
 msgstr "Se déconnecter des réseaux actuellement connectés"
 
 #: src/amuleDlg.cpp:1041 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979
-#: src/muuli_wdr.cpp:2640 src/muuli_wdr.cpp:3092 src/muuli_wdr.cpp:3447
+#: src/muuli_wdr.cpp:2644 src/muuli_wdr.cpp:3096 src/muuli_wdr.cpp:3451
 msgid "Connect"
 msgstr "Se connecter"
 
@@ -765,7 +765,7 @@ msgstr "Confirmation de sortie"
 msgid "Launch Command: "
 msgstr "Commande de lancement : "
 
-#: src/amuleDlg.cpp:1632 src/muuli_wdr.cpp:1982 src/Preferences.cpp:979
+#: src/amuleDlg.cpp:1632 src/muuli_wdr.cpp:1986 src/Preferences.cpp:979
 msgid "- default -"
 msgstr "- défaut -"
 
@@ -779,60 +779,60 @@ msgstr "Le répertoire de thèmes '%s' n'existe pas"
 msgid "WARNING: Unable to open skin file '%s' for read"
 msgstr "AVERTISSEMENT : Impossible d'ouvrir le fichier thème '%s' pour la lecture"
 
-#: src/amuleDlg.cpp:1791 src/muuli_wdr.cpp:3449
+#: src/amuleDlg.cpp:1814 src/muuli_wdr.cpp:3453
 msgid "Networks Window"
 msgstr "Fenêtre des réseaux"
 
-#: src/amuleDlg.cpp:1797 src/muuli_wdr.cpp:3450
+#: src/amuleDlg.cpp:1820 src/muuli_wdr.cpp:3454
 msgid "Searches Window"
 msgstr "Fenêtre de Recherche"
 
-#: src/amuleDlg.cpp:1803 src/muuli_wdr.cpp:3451
+#: src/amuleDlg.cpp:1826 src/muuli_wdr.cpp:3455
 msgid "Downloads Window"
 msgstr "Fenêtre des Téléchargements"
 
-#: src/amuleDlg.cpp:1809 src/muuli_wdr.cpp:3453
+#: src/amuleDlg.cpp:1832 src/muuli_wdr.cpp:3457
 msgid "Shared Files Window"
 msgstr "Fenêtre des Fichiers Partagés"
 
-#: src/amuleDlg.cpp:1815 src/muuli_wdr.cpp:3454
+#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3458
 msgid "Messages Window"
 msgstr "Fenêtre des Messages"
 
-#: src/amuleDlg.cpp:1821 src/muuli_wdr.cpp:3455
+#: src/amuleDlg.cpp:1844 src/muuli_wdr.cpp:3459
 msgid "Statistics Graph Window"
 msgstr "Fenêtre des Statistiques"
 
-#: src/amuleDlg.cpp:1828 src/muuli_wdr.cpp:3457
+#: src/amuleDlg.cpp:1851 src/muuli_wdr.cpp:3461
 msgid "Preferences Settings Window"
 msgstr "Fenêtre des Préférences"
 
-#: src/amuleDlg.cpp:1831 src/muuli_wdr.cpp:3458
+#: src/amuleDlg.cpp:1854 src/muuli_wdr.cpp:3462
 msgid "Import"
 msgstr "Importer"
 
-#: src/amuleDlg.cpp:1835 src/muuli_wdr.cpp:3458
+#: src/amuleDlg.cpp:1858 src/muuli_wdr.cpp:3462
 msgid "The partfile importer tool"
 msgstr "L'outil d'importation de fichier .part"
 
-#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3459
+#: src/amuleDlg.cpp:1861 src/muuli_wdr.cpp:3463
 #: src/utils/aLinkCreator/src/alcframe.cpp:262
 msgid "About"
 msgstr "À propos"
 
-#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3459
+#: src/amuleDlg.cpp:1861 src/muuli_wdr.cpp:3463
 msgid "About/Help"
 msgstr "À propos/Aide"
 
-#: src/amuleDlg.cpp:2036
+#: src/amuleDlg.cpp:2059
 msgid "eD2k network"
 msgstr "Réseau eD2k"
 
-#: src/amuleDlg.cpp:2039
+#: src/amuleDlg.cpp:2062
 msgid "Kad network"
 msgstr "Réseau Kad"
 
-#: src/amuleDlg.cpp:2039
+#: src/amuleDlg.cpp:2062
 msgid "No network"
 msgstr "Pas de réseau"
 
@@ -1365,19 +1365,19 @@ msgstr "Auto [Haute]"
 msgid "Very low"
 msgstr "Très basse"
 
-#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:743 src/muuli_wdr.cpp:2313
+#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:743 src/muuli_wdr.cpp:2317
 #: src/ServerListCtrl.cpp:263 src/ServerListCtrl.cpp:456
 #: src/SharedFilesCtrl.cpp:145
 msgid "Low"
 msgstr "Basse"
 
-#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:744 src/muuli_wdr.cpp:2314
+#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:744 src/muuli_wdr.cpp:2318
 #: src/ServerListCtrl.cpp:266 src/ServerListCtrl.cpp:457
 #: src/SharedFilesCtrl.cpp:146
 msgid "Normal"
 msgstr "Normale"
 
-#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:745 src/muuli_wdr.cpp:2315
+#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:745 src/muuli_wdr.cpp:2319
 #: src/ServerListCtrl.cpp:269 src/ServerListCtrl.cpp:458
 #: src/SharedFilesCtrl.cpp:147
 msgid "High"
@@ -1469,7 +1469,7 @@ msgstr "Serveur Local"
 msgid "Remote Server"
 msgstr "Serveur Distant"
 
-#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3212
+#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3216
 #: src/SearchDlg.cpp:119 src/TextClient.cpp:911
 msgid "Kad"
 msgstr "Kad"
@@ -1540,7 +1540,7 @@ msgstr "Partie"
 msgid "Size"
 msgstr "Taille"
 
-#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3279
+#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3283
 msgid "Transferred"
 msgstr "Reçu"
 
@@ -1598,7 +1598,7 @@ msgstr ""
 "Retour de : %s (%s)\n"
 "\n"
 
-#: src/DownloadListCtrl.cpp:746 src/muuli_wdr.cpp:2316
+#: src/DownloadListCtrl.cpp:746 src/muuli_wdr.cpp:2320
 #: src/SharedFilesCtrl.cpp:150
 msgid "Auto"
 msgstr "Auto"
@@ -1636,7 +1636,7 @@ msgid "Extended Options"
 msgstr "Options avancées"
 
 #: src/DownloadListCtrl.cpp:770 src/DownloadListCtrl.cpp:822
-#: src/muuli_wdr.cpp:1800
+#: src/muuli_wdr.cpp:1804
 msgid "Preview"
 msgstr "Prévisualisation"
 
@@ -2435,23 +2435,23 @@ msgid ""
 "want downloads on a different (e.g. larger) disk."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:549 src/FirstRunWizard.cpp:611 src/muuli_wdr.cpp:1712
+#: src/FirstRunWizard.cpp:549 src/FirstRunWizard.cpp:611 src/muuli_wdr.cpp:1716
 msgid "Destination folder for downloads"
 msgstr "Dossier de destination des téléchargements"
 
 #: src/FirstRunWizard.cpp:553 src/FirstRunWizard.cpp:569 src/muuli_wdr.cpp:1349
-#: src/muuli_wdr.cpp:1366 src/muuli_wdr.cpp:1687 src/muuli_wdr.cpp:1718
-#: src/muuli_wdr.cpp:1730 src/muuli_wdr.cpp:2800
+#: src/muuli_wdr.cpp:1366 src/muuli_wdr.cpp:1691 src/muuli_wdr.cpp:1722
+#: src/muuli_wdr.cpp:1734 src/muuli_wdr.cpp:2804
 #: src/utils/aLinkCreator/src/alcframe.cpp:135
 #: src/utils/wxCas/src/wxcasprefs.cpp:52 src/utils/wxCas/src/wxcasprefs.cpp:118
 msgid "Browse"
 msgstr "Parcourir"
 
-#: src/FirstRunWizard.cpp:559 src/muuli_wdr.cpp:1723
+#: src/FirstRunWizard.cpp:559 src/muuli_wdr.cpp:1727
 msgid "(All files in this folder are shared with other peers)"
 msgstr "(Tous les fichiers de ce répertoire sont partagés avec les autres pairs)"
 
-#: src/FirstRunWizard.cpp:565 src/FirstRunWizard.cpp:624 src/muuli_wdr.cpp:1725
+#: src/FirstRunWizard.cpp:565 src/FirstRunWizard.cpp:624 src/muuli_wdr.cpp:1729
 msgid "Folder for temporary download files"
 msgstr "Dossier des fichiers de téléchargements temporaires"
 
@@ -2482,7 +2482,7 @@ msgstr "Échec de l'ouverture du fichier de la liste d'amis 'emfriends.met' pour
 msgid "CRITICAL - no client on StartChatSession"
 msgstr "CRITIQUE - Pas de client dans StartChatSession"
 
-#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2706 src/muuli_wdr.cpp:3383
+#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2710 src/muuli_wdr.cpp:3387
 msgid "Friends"
 msgstr "Amis"
 
@@ -2592,8 +2592,8 @@ msgstr "Aucun"
 msgid "No"
 msgstr "Non"
 
-#: src/GenericClientListCtrl.cpp:1216 src/PrefsUnifiedDlg.cpp:2898
-#: src/PrefsUnifiedDlg.cpp:2948 src/ServerListCtrl.cpp:276
+#: src/GenericClientListCtrl.cpp:1216 src/PrefsUnifiedDlg.cpp:2907
+#: src/PrefsUnifiedDlg.cpp:2957 src/ServerListCtrl.cpp:276
 msgid "Yes"
 msgstr "Oui"
 
@@ -2762,10 +2762,10 @@ msgstr "Port invalide pour l'amorçage"
 msgid "Please fill all fields required"
 msgstr "Veuillez remplir tous les champs requis"
 
-#: src/KadDlg.cpp:192 src/PartFile.cpp:1031 src/PrefsUnifiedDlg.cpp:1134
-#: src/PrefsUnifiedDlg.cpp:1204 src/PrefsUnifiedDlg.cpp:1405
-#: src/PrefsUnifiedDlg.cpp:1663 src/PrefsUnifiedDlg.cpp:1673
-#: src/PrefsUnifiedDlg.cpp:1690 src/PrefsUnifiedDlg.cpp:1738
+#: src/KadDlg.cpp:192 src/PartFile.cpp:1031 src/PrefsUnifiedDlg.cpp:1143
+#: src/PrefsUnifiedDlg.cpp:1213 src/PrefsUnifiedDlg.cpp:1414
+#: src/PrefsUnifiedDlg.cpp:1672 src/PrefsUnifiedDlg.cpp:1682
+#: src/PrefsUnifiedDlg.cpp:1699 src/PrefsUnifiedDlg.cpp:1747
 msgid "Message"
 msgstr "Message"
 
@@ -2866,7 +2866,7 @@ msgstr "Ratio de partage"
 msgid "Uploaded"
 msgstr "Émis"
 
-#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3263
+#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3267
 msgid "Requested"
 msgstr "Demandé"
 
@@ -2989,7 +2989,7 @@ msgid "WARNING: "
 msgstr "AVERTISSEMENT : "
 
 #: src/MuleNotebook.cpp:179 src/muuli_wdr.cpp:817 src/muuli_wdr.cpp:1229
-#: src/muuli_wdr.cpp:3167 src/muuli_wdr.cpp:3423
+#: src/muuli_wdr.cpp:3171 src/muuli_wdr.cpp:3427
 msgid "Close"
 msgstr "Fermer"
 
@@ -3007,7 +3007,7 @@ msgid "Paste"
 msgstr "Coller"
 
 #: src/MuleTextCtrl.cpp:89 src/muuli_wdr.cpp:358 src/muuli_wdr.cpp:757
-#: src/muuli_wdr.cpp:2390 src/muuli_wdr.cpp:2409 src/muuli_wdr.cpp:2431
+#: src/muuli_wdr.cpp:2394 src/muuli_wdr.cpp:2413 src/muuli_wdr.cpp:2435
 #: src/utils/aLinkCreator/src/alcframe.cpp:142
 msgid "Clear"
 msgstr "Effacer"
@@ -3099,7 +3099,7 @@ msgstr "Quitter"
 
 #: src/MuleTrayIcon.cpp:579 src/MuleTrayIcon.cpp:945 src/MuleTrayIcon.cpp:965
 #: src/muuli_wdr.cpp:1398 src/muuli_wdr.cpp:1406 src/muuli_wdr.cpp:1413
-#: src/muuli_wdr.cpp:1846 src/muuli_wdr.cpp:1852 src/OtherFunctions.cpp:91
+#: src/muuli_wdr.cpp:1850 src/muuli_wdr.cpp:1856 src/OtherFunctions.cpp:91
 #: src/StatisticsDlg.cpp:93 src/StatisticsDlg.cpp:95
 msgid "kB/s"
 msgstr "Ko/s"
@@ -3339,7 +3339,7 @@ msgstr "Octets"
 msgid "KB"
 msgstr "Ko"
 
-#: src/muuli_wdr.cpp:274 src/muuli_wdr.cpp:293 src/muuli_wdr.cpp:1631
+#: src/muuli_wdr.cpp:274 src/muuli_wdr.cpp:293 src/muuli_wdr.cpp:1635
 #: src/OtherFunctions.cpp:64
 msgid "MB"
 msgstr "Mo"
@@ -3356,7 +3356,7 @@ msgstr "Taille Maximum"
 msgid "Availability"
 msgstr "Disponibilité"
 
-#: src/muuli_wdr.cpp:312 src/muuli_wdr.cpp:398 src/muuli_wdr.cpp:3328
+#: src/muuli_wdr.cpp:312 src/muuli_wdr.cpp:398 src/muuli_wdr.cpp:3332
 msgid "Filter:"
 msgstr "Filtre :"
 
@@ -3419,8 +3419,8 @@ msgstr "Sources du fichier :"
 #: src/muuli_wdr.cpp:1160 src/muuli_wdr.cpp:1167 src/muuli_wdr.cpp:1172
 #: src/muuli_wdr.cpp:1179 src/muuli_wdr.cpp:1184 src/muuli_wdr.cpp:1191
 #: src/muuli_wdr.cpp:1205 src/muuli_wdr.cpp:1212 src/muuli_wdr.cpp:1217
-#: src/muuli_wdr.cpp:1224 src/muuli_wdr.cpp:3265 src/muuli_wdr.cpp:3273
-#: src/muuli_wdr.cpp:3281
+#: src/muuli_wdr.cpp:1224 src/muuli_wdr.cpp:3269 src/muuli_wdr.cpp:3277
+#: src/muuli_wdr.cpp:3285
 msgid "N/A"
 msgstr "N/A"
 
@@ -3560,7 +3560,7 @@ msgstr "Artiste :"
 msgid "Album :"
 msgstr "Album :"
 
-#: src/muuli_wdr.cpp:685 src/muuli_wdr.cpp:2285
+#: src/muuli_wdr.cpp:685 src/muuli_wdr.cpp:2289
 msgid "Title :"
 msgstr "Titre :"
 
@@ -3668,7 +3668,7 @@ msgstr "Nom d'utilisateur :"
 msgid "Userhash :"
 msgstr "Hachage de l'utilisateur :"
 
-#: src/muuli_wdr.cpp:895 src/muuli_wdr.cpp:1752 src/muuli_wdr.cpp:2480
+#: src/muuli_wdr.cpp:895 src/muuli_wdr.cpp:1756 src/muuli_wdr.cpp:2484
 #: src/utils/aLinkCreator/src/alcframe.cpp:137
 msgid "Add"
 msgstr "Ajouter"
@@ -3677,15 +3677,15 @@ msgstr "Ajouter"
 msgid "Download-Speed"
 msgstr "Vitesse de réception"
 
-#: src/muuli_wdr.cpp:954 src/muuli_wdr.cpp:989 src/muuli_wdr.cpp:2584
+#: src/muuli_wdr.cpp:954 src/muuli_wdr.cpp:989 src/muuli_wdr.cpp:2588
 msgid "Current"
 msgstr "Actuelle"
 
-#: src/muuli_wdr.cpp:962 src/muuli_wdr.cpp:997 src/muuli_wdr.cpp:2592
+#: src/muuli_wdr.cpp:962 src/muuli_wdr.cpp:997 src/muuli_wdr.cpp:2596
 msgid "Running average"
 msgstr "Moyenne totale"
 
-#: src/muuli_wdr.cpp:970 src/muuli_wdr.cpp:1005 src/muuli_wdr.cpp:2600
+#: src/muuli_wdr.cpp:970 src/muuli_wdr.cpp:1005 src/muuli_wdr.cpp:2604
 msgid "Session average"
 msgstr "Moyenne de la session"
 
@@ -3697,7 +3697,7 @@ msgstr "Vitesse d'émission"
 msgid "Connections"
 msgstr "Connexions"
 
-#: src/muuli_wdr.cpp:1024 src/muuli_wdr.cpp:1871
+#: src/muuli_wdr.cpp:1024 src/muuli_wdr.cpp:1875
 msgid "Active downloads"
 msgstr "Téléchargements actifs"
 
@@ -3705,7 +3705,7 @@ msgstr "Téléchargements actifs"
 msgid "Active connections (1:1)"
 msgstr "Connexions actives (1:1)"
 
-#: src/muuli_wdr.cpp:1040 src/muuli_wdr.cpp:1872
+#: src/muuli_wdr.cpp:1040 src/muuli_wdr.cpp:1876
 msgid "Active uploads"
 msgstr "Envois actifs"
 
@@ -3979,7 +3979,7 @@ msgstr "Lier l'adresse locale à une IP (vide pour toutes) :"
 msgid "Advanced users only: If you have multiple network interfaces, enter the address of the interface to which aMule should be bound."
 msgstr "Utilisateurs avancés uniquement : Si vous avez plusieurs interfaces réseau, entrez l'adresse de l'interface à laquelle aMule doit être lié."
 
-#: src/muuli_wdr.cpp:1462 src/muuli_wdr.cpp:2065
+#: src/muuli_wdr.cpp:1462 src/muuli_wdr.cpp:2069
 msgid "Bind to network interface (empty for any):"
 msgstr "Lier à une interface réseau (vide pour toutes) :"
 
@@ -3995,7 +3995,7 @@ msgstr "Sources maximales par fichier téléchargé :"
 msgid "Max simultaneous connections:"
 msgstr "Connexions simultanées maximales :"
 
-#: src/muuli_wdr.cpp:1498 src/muuli_wdr.cpp:3207
+#: src/muuli_wdr.cpp:1498 src/muuli_wdr.cpp:3211
 msgid "ED2K"
 msgstr "ED2K"
 
@@ -4087,79 +4087,79 @@ msgstr "Réserver de l'espace disque pour les nouveaux fichiers"
 msgid "For new files preallocates disk space for the whole file, thus reduces fragmentation"
 msgstr "Réserve de l'espace du disque pour les nouveaux fichiers, réduisant ainsi la fragmentation"
 
-#: src/muuli_wdr.cpp:1617
+#: src/muuli_wdr.cpp:1621
 msgid "Create new files as sparse files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1618
+#: src/muuli_wdr.cpp:1622
 msgid "Sparse part files only occupy disk space for the parts already downloaded, so free space is used up gradually as the file fills in. Turn this off to use an ordinary file instead - useful where sparse files are unsupported or slow, or where backup/de-duplication tools handle them badly. Applies only when the core runs on Windows; on Linux and macOS part files are sparse anyway and this setting has no effect."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1623
+#: src/muuli_wdr.cpp:1627
 msgid "Stop downloads when free disk space reaches "
 msgstr "Stoppe les téléchargements lorsque l'espace disponible est atteint "
 
-#: src/muuli_wdr.cpp:1624
+#: src/muuli_wdr.cpp:1628
 msgid "Select this if you want aMule to check your disk space"
 msgstr "Sélectionnez ceci si vous souhaitez qu'aMule vérifie votre espace disque"
 
-#: src/muuli_wdr.cpp:1628
+#: src/muuli_wdr.cpp:1632
 msgid "Enter here the min disk space desired."
 msgstr "Entrez ici l'espace disque minimum désiré."
 
-#: src/muuli_wdr.cpp:1634
+#: src/muuli_wdr.cpp:1638
 msgid "Save 10 sources on rare files (< 20 sources)"
 msgstr "Sauver 10 sources pour les fichiers rares (< 20 sources)"
 
-#: src/muuli_wdr.cpp:1638 src/Statistics.cpp:790
+#: src/muuli_wdr.cpp:1642 src/Statistics.cpp:790
 msgid "Uploads"
 msgstr "Émission"
 
-#: src/muuli_wdr.cpp:1641
+#: src/muuli_wdr.cpp:1645
 msgid "Add new shared files with auto priority"
 msgstr "Ajouter les nouveaux fichiers partagés en priorité automatique"
 
-#: src/muuli_wdr.cpp:1647
+#: src/muuli_wdr.cpp:1651
 msgid "Intelligent Corruption Handling (I.C.H.)"
 msgstr "Gestion Intelligente de la Corruption (I.C.H.)"
 
-#: src/muuli_wdr.cpp:1650
+#: src/muuli_wdr.cpp:1654
 msgid "Enable"
 msgstr "Activer"
 
-#: src/muuli_wdr.cpp:1653
+#: src/muuli_wdr.cpp:1657
 msgid "Advanced I.C.H. trusts every hash (not recommended)"
 msgstr "I.C.H. avancée se fie aux hachages (non recommandé)"
 
-#: src/muuli_wdr.cpp:1665 src/PrefsUnifiedDlg.cpp:1990
+#: src/muuli_wdr.cpp:1669 src/PrefsUnifiedDlg.cpp:1999
 msgid "Media metadata extraction"
 msgstr "Extraction de métadonnées de média"
 
-#: src/muuli_wdr.cpp:1669
+#: src/muuli_wdr.cpp:1673
 msgid "Extract length / bitrate / codec from shared audio and video files"
 msgstr "Extraire la durée / le débit binaire / le codec depuis les fichiers audio et vidéo partagés"
 
-#: src/muuli_wdr.cpp:1671
+#: src/muuli_wdr.cpp:1675
 msgid "When enabled, aMule runs ffprobe on each shared media file to fill in the Length / Bitrate / Codec columns other clients see when they find the file in a search. Requires ffmpeg (the ffprobe binary) to be installed."
 msgstr "Lorsque cette option est activée, aMule exécute ffprobe sur chaque fichier média partagé pour remplir les colonnes Durée / Débit binaire / Codec que les autres clients voient quand ils trouvent le fichier lors d'une recherche. Nécessite que ffmpeg (le binaire ffprobe) soit installé."
 
-#: src/muuli_wdr.cpp:1678
+#: src/muuli_wdr.cpp:1682
 msgid "Path to ffprobe:"
 msgstr "Emplacement de ffprobe :"
 
-#: src/muuli_wdr.cpp:1683
+#: src/muuli_wdr.cpp:1687
 msgid "Full path to the ffprobe binary. Leave empty to have aMule auto-detect it on startup."
 msgstr "Chemin complet vers le binaire ffprobe. Laisser vide pour qu'aMule le détecte automatiquement au démarrage."
 
-#: src/muuli_wdr.cpp:1691
+#: src/muuli_wdr.cpp:1695
 msgid "Detect"
 msgstr "Détecter"
 
-#: src/muuli_wdr.cpp:1692
+#: src/muuli_wdr.cpp:1696
 msgid "Search the standard install locations for an ffprobe binary and fill the path field."
 msgstr "Rechercher les binaires de ffprobe aux emplacements par défaut et compléter le champ emplacement."
 
-#: src/muuli_wdr.cpp:1716
+#: src/muuli_wdr.cpp:1720
 msgid ""
 "Completed downloads are stored here. All files in this folder are automatically shared with other peers.\n"
 "If this folder also holds files you don't want to share, point it at an aMule-only sub-folder."
@@ -4167,688 +4167,688 @@ msgstr ""
 "Les téléchargements terminés sont stockés ici. Tous les fichiers de ce répertoire sont automatiquement partagés avec les autres pairs.\n"
 "Si ce répertoire contient également des fichiers que vous ne souhaitez pas partager, indiquez un sous-répertoire réservé à aMule."
 
-#: src/muuli_wdr.cpp:1719
+#: src/muuli_wdr.cpp:1723
 msgid "Pick the folder where completed downloads will be stored. All files in that folder will be shared with other peers."
 msgstr "Choisissez le répertoire où les téléchargements terminés seront enregistrés. Tous les fichiers de ce répertoire seront partagés avec les autres pairs."
 
-#: src/muuli_wdr.cpp:1733
+#: src/muuli_wdr.cpp:1737
 msgid "Shared folders"
 msgstr "Dossiers partagés"
 
-#: src/muuli_wdr.cpp:1739
+#: src/muuli_wdr.cpp:1743
 msgid "(Folders shared by the core. Enter a path to add one.)"
 msgstr "(Les répertoires partagés par le noyau. Entrer un chemin pour en ajouter un.)"
 
-#: src/muuli_wdr.cpp:1747
+#: src/muuli_wdr.cpp:1751
 msgid "Absolute path of a folder on the core's machine, e.g. /home/user/shared"
 msgstr "Le chemin absolu d'un répertoire sur la machine du noyau, par exemple /home/utilisateur/shared"
 
-#: src/muuli_wdr.cpp:1749 src/PrefsUnifiedDlg.cpp:2874
+#: src/muuli_wdr.cpp:1753 src/PrefsUnifiedDlg.cpp:2883
 msgid "Recursive"
 msgstr "Récursif"
 
-#: src/muuli_wdr.cpp:1750
+#: src/muuli_wdr.cpp:1754
 msgid "Share every sub-folder underneath this one, including ones created later."
 msgstr "Partager chaque sous-répertoire sous celui-ci, y compris ceux qui seront créés ultérieurement."
 
-#: src/muuli_wdr.cpp:1754 src/utils/aLinkCreator/src/alcframe.cpp:141
+#: src/muuli_wdr.cpp:1758 src/utils/aLinkCreator/src/alcframe.cpp:141
 msgid "Remove"
 msgstr "Enlever"
 
-#: src/muuli_wdr.cpp:1758
+#: src/muuli_wdr.cpp:1762
 msgid "(Right click on folder icon for recursive share)"
 msgstr "(Clic droit sur l'icône du répertoire pour un partage récursif)"
 
-#: src/muuli_wdr.cpp:1765
+#: src/muuli_wdr.cpp:1769
 msgid "Share hidden files"
 msgstr "Partager les fichiers cachés"
 
-#: src/muuli_wdr.cpp:1771
+#: src/muuli_wdr.cpp:1775
 msgid "Automatically rescan shared folders for changes"
 msgstr "Analyser automatiquement à nouveau les répertoires partagés pour rechercher des modifications"
 
-#: src/muuli_wdr.cpp:1777
+#: src/muuli_wdr.cpp:1781
 msgid "Follow symbolic links in shared folders"
 msgstr "Suivre les liens symboliques dans les répertoires partagés"
 
-#: src/muuli_wdr.cpp:1783
+#: src/muuli_wdr.cpp:1787
 msgid "Exclude files matching:"
 msgstr "Exclure les fichiers correspondant à :"
 
-#: src/muuli_wdr.cpp:1786
+#: src/muuli_wdr.cpp:1790
 msgid "Wildcard patterns separated by '|', e.g. .DS_Store|Thumbs.db|*.tmp. Files whose name matches are not shared. Matching is case-insensitive."
 msgstr "Motifs de caractères génériques séparés par '|', par exemple .DS_Store|Thumbs.db|*.tmp. Les fichiers dont le nom correspond ne seront pas partagés. La correspondance est insensible à la casse."
 
-#: src/muuli_wdr.cpp:1790
+#: src/muuli_wdr.cpp:1794
 msgid "Patterns are regular expressions"
 msgstr "Les motifs sont des expressions régulières"
 
-#: src/muuli_wdr.cpp:1791
+#: src/muuli_wdr.cpp:1795
 msgid "When set, the whole field is one regular expression ('|' is alternation). When unset, it is a list of '|'-separated wildcards."
 msgstr "Lorsque l'option est activée, la totalité du champ est une expression régulière ('|' indique une alternative). Lorsque l'option est désactivée, il s'agit d'une liste de caractères génériques séparés par des '|'."
 
-#: src/muuli_wdr.cpp:1801
+#: src/muuli_wdr.cpp:1805
 msgid "Show how many shared files the current pattern would exclude."
 msgstr "Afficher combien de fichiers partagés le motif actuel exclurait."
 
-#: src/muuli_wdr.cpp:1822
+#: src/muuli_wdr.cpp:1826
 msgid "Graphs"
 msgstr "Graphiques"
 
-#: src/muuli_wdr.cpp:1825 src/muuli_wdr.cpp:1887
+#: src/muuli_wdr.cpp:1829 src/muuli_wdr.cpp:1891
 msgid "Update delay : 5 secs"
 msgstr "Délais de rafraîchissement : 5 s"
 
-#: src/muuli_wdr.cpp:1829
+#: src/muuli_wdr.cpp:1833
 msgid "Time for average graph: 100 mins"
 msgstr "Temps pour la courbe de la moyenne : 100 min"
 
-#: src/muuli_wdr.cpp:1833
+#: src/muuli_wdr.cpp:1837
 msgid "Connections Graph Scale: 100 "
 msgstr "Échelle du graphique des connexions : 100 "
 
-#: src/muuli_wdr.cpp:1840
+#: src/muuli_wdr.cpp:1844
 msgid "Download graph scale:"
 msgstr "Échelle des graphiques de réception :"
 
-#: src/muuli_wdr.cpp:1848
+#: src/muuli_wdr.cpp:1852
 msgid "Upload graph scale:"
 msgstr "Échelle des graphiques d'envoi :"
 
-#: src/muuli_wdr.cpp:1858
+#: src/muuli_wdr.cpp:1862
 msgid "Colors: "
 msgstr "Couleurs : "
 
-#: src/muuli_wdr.cpp:1862
+#: src/muuli_wdr.cpp:1866
 msgid "Background"
 msgstr "Fond"
 
-#: src/muuli_wdr.cpp:1863
+#: src/muuli_wdr.cpp:1867
 msgid "Grid"
 msgstr "Quadrillage"
 
-#: src/muuli_wdr.cpp:1864
+#: src/muuli_wdr.cpp:1868
 msgid "Download current"
 msgstr "Téléchargement actuel"
 
-#: src/muuli_wdr.cpp:1865
+#: src/muuli_wdr.cpp:1869
 msgid "Download running average"
 msgstr "Téléchargement moyen total"
 
-#: src/muuli_wdr.cpp:1866
+#: src/muuli_wdr.cpp:1870
 msgid "Download session average"
 msgstr "Téléchargement moyen sur la session"
 
-#: src/muuli_wdr.cpp:1867
+#: src/muuli_wdr.cpp:1871
 msgid "Upload current"
 msgstr "Envoi actuel"
 
-#: src/muuli_wdr.cpp:1868
+#: src/muuli_wdr.cpp:1872
 msgid "Upload running average"
 msgstr "Envoi moyen total"
 
-#: src/muuli_wdr.cpp:1869
+#: src/muuli_wdr.cpp:1873
 msgid "Upload session average"
 msgstr "Envoi moyen sur la session"
 
-#: src/muuli_wdr.cpp:1870
+#: src/muuli_wdr.cpp:1874
 msgid "Active connections"
 msgstr "Connexions actives"
 
-#: src/muuli_wdr.cpp:1873
+#: src/muuli_wdr.cpp:1877
 msgid "Systray Icon Speed Bar"
 msgstr "Barre de vitesse dans l'icône de barre des tâches"
 
-#: src/muuli_wdr.cpp:1874
+#: src/muuli_wdr.cpp:1878
 msgid "Kad-nodes current"
 msgstr "Nœuds Kad actuels"
 
-#: src/muuli_wdr.cpp:1875
+#: src/muuli_wdr.cpp:1879
 msgid "Kad-nodes running"
 msgstr "Nœuds Kad total"
 
-#: src/muuli_wdr.cpp:1876
+#: src/muuli_wdr.cpp:1880
 msgid "Kad-nodes session"
 msgstr "Nœuds Kad pour la session"
 
-#: src/muuli_wdr.cpp:1880 src/muuli_wdr.cpp:2334
+#: src/muuli_wdr.cpp:1884 src/muuli_wdr.cpp:2338
 msgid "Select"
 msgstr "Sélectionner"
 
-#: src/muuli_wdr.cpp:1884
+#: src/muuli_wdr.cpp:1888
 msgid "Tree"
 msgstr "Arbre"
 
-#: src/muuli_wdr.cpp:1894
+#: src/muuli_wdr.cpp:1898
 msgid "Number of Client Versions shown (0=unlimited)"
 msgstr "Nombre de versions client affichées (0=illimité)"
 
-#: src/muuli_wdr.cpp:1919
+#: src/muuli_wdr.cpp:1923
 msgid "!!! WARNING !!!"
 msgstr "!!! AVERTISSEMENT !!!"
 
-#: src/muuli_wdr.cpp:1934
+#: src/muuli_wdr.cpp:1938
 msgid "Max new connections / 5 secs"
 msgstr "Nombre maximum de nouvelles connexions / 5 secs"
 
-#: src/muuli_wdr.cpp:1936
+#: src/muuli_wdr.cpp:1940
 msgid "Concurrent Kad source lookups"
 msgstr "Recherche concurrentes de sources Kad"
 
-#: src/muuli_wdr.cpp:1938
+#: src/muuli_wdr.cpp:1942
 msgid "Kad source re-search interval (minutes)"
 msgstr "Intervalle entre les nouvelles recherches de sources Kad (en minutes)"
 
-#: src/muuli_wdr.cpp:1940
+#: src/muuli_wdr.cpp:1944
 msgid "Source re-ask interval (minutes)"
 msgstr "Intervalle entre les nouvelles demandes de sources Kad (en minutes)"
 
-#: src/muuli_wdr.cpp:1944
+#: src/muuli_wdr.cpp:1948
 msgid "File Buffer Size: 240000 bytes"
 msgstr "Taille du fichier de tampon : 240000 octets"
 
-#: src/muuli_wdr.cpp:1948
+#: src/muuli_wdr.cpp:1952
 msgid "Use MMAP: memory-mapped file access (lower memory use)"
 msgstr "Utiliser MMAP : « memory-mapped file access », c'est-à-dire accès aux fichiers mappés dans la mémoire (utilise moins de mémoire)"
 
-#: src/muuli_wdr.cpp:1949
+#: src/muuli_wdr.cpp:1953
 msgid "Maps part files into memory instead of buffering them on the heap, lowering the process memory footprint. May reduce download speed on some disks; best for memory-constrained or upload-heavy hosts."
 msgstr "Fait correspondre les fichiers partiels dans la mémoire au lieu de les mettre en tampon sur la pile, baissant l'empreinte mémoire du processus. Peut réduire la vitesse de téléchargement sur certains disques ; idéal pour les hôtes disposant de peu de mémoire ou pour ceux qui téléversent beaucoup."
 
-#: src/muuli_wdr.cpp:1951
+#: src/muuli_wdr.cpp:1955
 msgid "Upload Queue Size: 5000 clients"
 msgstr "Taille de la file d'attente d'envoi : 5000 clients"
 
-#: src/muuli_wdr.cpp:1955
+#: src/muuli_wdr.cpp:1959
 msgid "Server connection refresh interval: Disable"
 msgstr "Intervalle de rafraîchissement de la connexion serveur : Désactivé"
 
-#: src/muuli_wdr.cpp:1959
+#: src/muuli_wdr.cpp:1963
 msgid "Disable computer's timed standby mode"
 msgstr "Désactiver la mise en veille programmé de l'ordinateur"
 
-#: src/muuli_wdr.cpp:1978
+#: src/muuli_wdr.cpp:1982
 msgid "Skin to use: "
 msgstr "Thème à utiliser : "
 
-#: src/muuli_wdr.cpp:1987
+#: src/muuli_wdr.cpp:1991
 msgid "Show \"Fast eD2k Links Handler\" in every window."
 msgstr "Afficher le \"Gestionnaire rapide de liens eD2k \" dans chaque fenêtre."
 
-#: src/muuli_wdr.cpp:1990
+#: src/muuli_wdr.cpp:1994
 msgid "Show extended info on categories tabs"
 msgstr "Afficher des infos supplémentaires sur les onglets des catégories"
 
-#: src/muuli_wdr.cpp:1993
+#: src/muuli_wdr.cpp:1997
 msgid "Show application version on title"
 msgstr "Afficher la version de l'application dans le titre"
 
-#: src/muuli_wdr.cpp:1995
+#: src/muuli_wdr.cpp:1999
 msgid "Show transfer rates on title"
 msgstr "Afficher les taux de transfert dans la barre de titre"
 
-#: src/muuli_wdr.cpp:1997
+#: src/muuli_wdr.cpp:2001
 msgid "Before application name"
 msgstr "Avant le nom de l'application"
 
-#: src/muuli_wdr.cpp:1999
+#: src/muuli_wdr.cpp:2003
 msgid "After application name"
 msgstr "Après le nom de l'application"
 
-#: src/muuli_wdr.cpp:2002
+#: src/muuli_wdr.cpp:2006
 msgid "Show overhead bandwidth"
 msgstr "Afficher la surcharge de la bande passante"
 
-#: src/muuli_wdr.cpp:2006
+#: src/muuli_wdr.cpp:2010
 msgid "Vertical toolbar orientation"
 msgstr "Orientation de la barre d'outils verticale"
 
-#: src/muuli_wdr.cpp:2008
+#: src/muuli_wdr.cpp:2012
 msgid "Live column sorting (auto-reorder rows as their values change)"
 msgstr "Tri des colonnes en temps réel (réorganisation automatique des lignes à mesure que leurs valeurs changent)"
 
-#: src/muuli_wdr.cpp:2015
+#: src/muuli_wdr.cpp:2019
 msgid "Download Queue Files"
 msgstr "Fichiers à télécharger en file d'attente"
 
-#: src/muuli_wdr.cpp:2018
+#: src/muuli_wdr.cpp:2022
 msgid "Show progress percentage"
 msgstr "Afficher le pourcentage de progression"
 
-#: src/muuli_wdr.cpp:2024
+#: src/muuli_wdr.cpp:2028
 msgid "Show progress bar"
 msgstr "Afficher la barre de progression"
 
-#: src/muuli_wdr.cpp:2027
+#: src/muuli_wdr.cpp:2031
 msgid "Flat"
 msgstr "Plat"
 
-#: src/muuli_wdr.cpp:2031
+#: src/muuli_wdr.cpp:2035
 msgid "Round"
 msgstr "Relief"
 
-#: src/muuli_wdr.cpp:2049
+#: src/muuli_wdr.cpp:2053
 msgid "External Connection Parameters"
 msgstr "Paramètres de Connexion Externe"
 
-#: src/muuli_wdr.cpp:2052
+#: src/muuli_wdr.cpp:2056
 msgid "Accept external connections"
 msgstr "Accepter les connexions externes"
 
-#: src/muuli_wdr.cpp:2059 src/muuli_wdr.cpp:2118
+#: src/muuli_wdr.cpp:2063 src/muuli_wdr.cpp:2122
 msgid "IP of the listening interface:"
 msgstr "IP de l'interface d'écoute :"
 
-#: src/muuli_wdr.cpp:2062
+#: src/muuli_wdr.cpp:2066
 msgid "Enter here a valid ip in the a.b.c.d format for the listening EC interface. An empty field or 0.0.0.0 will mean any interface."
 msgstr "Entrer ici une adresse IP valide dans le format a.b.c.d pour l'interface d'écoute EC. Un champ vide ou 0.0.0.0 signifiera toutes les interfaces."
 
-#: src/muuli_wdr.cpp:2083 src/muuli_wdr.cpp:2194
+#: src/muuli_wdr.cpp:2087 src/muuli_wdr.cpp:2198
 msgid "TCP port:"
 msgstr "Port TCP :"
 
-#: src/muuli_wdr.cpp:2089
+#: src/muuli_wdr.cpp:2093
 msgid "Enable UPnP port forwarding on the EC port"
 msgstr "Activer la redirection de ports en UPnP sur le port EC"
 
-#: src/muuli_wdr.cpp:2093 src/muuli_wdr.cpp:3079
+#: src/muuli_wdr.cpp:2097 src/muuli_wdr.cpp:3083
 #: src/utils/wxCas/src/wxcasprefs.cpp:167
 msgid "Password"
 msgstr "Mot de passe"
 
-#: src/muuli_wdr.cpp:2099
+#: src/muuli_wdr.cpp:2103
 msgid "aMule API server parameters"
 msgstr "Paramètres du serveur aMule API"
 
-#: src/muuli_wdr.cpp:2102
+#: src/muuli_wdr.cpp:2106
 msgid "Run amuleapi (REST API) on startup"
 msgstr "Exécuter amuleapi (API REST) au démarrage"
 
-#: src/muuli_wdr.cpp:2107
+#: src/muuli_wdr.cpp:2111
 msgid "HTTP port:"
 msgstr "Port HTTP :"
 
-#: src/muuli_wdr.cpp:2121
+#: src/muuli_wdr.cpp:2125
 msgid "The interface amuleapi's HTTP server listens on. 127.0.0.1 (default) accepts only local connections; use 0.0.0.0 or a specific IP to expose it to other hosts (set an admin password below)."
 msgstr "L'interface sur laquelle le serveur HTTP d'amuleapi écoute. 127.0.0.1 (par défaut) n'accepte que les connexions locales  ; utilisez 0.0.0.0 ou bien une adresse IP spécifique pour l'exposer à d'autres hôtes (définissez un mot de passe administrateur ci-dessous)."
 
-#: src/muuli_wdr.cpp:2126
+#: src/muuli_wdr.cpp:2130
 msgid "Type a password to set or change it. Stored passwords cannot be shown, so leaving this empty keeps the current one."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2128
+#: src/muuli_wdr.cpp:2132
 msgid "Admin password"
 msgstr "Mot de passe administrateur"
 
-#: src/muuli_wdr.cpp:2140 src/muuli_wdr.cpp:2157 src/PrefsUnifiedDlg.cpp:1103
+#: src/muuli_wdr.cpp:2144 src/muuli_wdr.cpp:2161 src/PrefsUnifiedDlg.cpp:1112
 #, fuzzy
 msgid "A password is set."
 msgstr "Mot de passe administrateur"
 
-#: src/muuli_wdr.cpp:2144
+#: src/muuli_wdr.cpp:2148
 #, fuzzy
 msgid "Enable guest access"
 msgstr "Interdire l'accès invité"
 
-#: src/muuli_wdr.cpp:2145
+#: src/muuli_wdr.cpp:2149
 msgid "Guest sessions may read status and listings but cannot change anything. Turning this off clears the stored guest password."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2149
+#: src/muuli_wdr.cpp:2153
 #, fuzzy
 msgid "Guest password"
 msgstr "Mot de passe invité pour le serveur web"
 
-#: src/muuli_wdr.cpp:2164
+#: src/muuli_wdr.cpp:2168
 msgid "Web server parameters"
 msgstr "Paramètres du serveur Web"
 
-#: src/muuli_wdr.cpp:2167
+#: src/muuli_wdr.cpp:2171
 msgid "Run webserver on startup (deprecated)"
 msgstr "Démarrer le serveur web au démarrage (obsolète)"
 
-#: src/muuli_wdr.cpp:2173
+#: src/muuli_wdr.cpp:2177
 msgid "Web template"
 msgstr "Template web"
 
-#: src/muuli_wdr.cpp:2178
+#: src/muuli_wdr.cpp:2182
 msgid "Full rights password"
 msgstr "Mot de passe administrateur"
 
-#: src/muuli_wdr.cpp:2182
+#: src/muuli_wdr.cpp:2186
 msgid "Enable Low rights User"
 msgstr "Activer l'accès utilisateur sans privilèges"
 
-#: src/muuli_wdr.cpp:2187
+#: src/muuli_wdr.cpp:2191
 msgid "Low rights password"
 msgstr "Mot de passe sans privilèges"
 
-#: src/muuli_wdr.cpp:2201
+#: src/muuli_wdr.cpp:2205
 msgid "Enable UPnP port forwarding of the web server port"
 msgstr "Activer la redirection de port UPnP sur le port du serveur web"
 
-#: src/muuli_wdr.cpp:2206
+#: src/muuli_wdr.cpp:2210
 msgid "Web server UPnP TCP port (Optional)"
 msgstr "Port TCP UPnP du serveur web (Facultatif)"
 
-#: src/muuli_wdr.cpp:2214
+#: src/muuli_wdr.cpp:2218
 msgid "Page Refresh Time (in secs)"
 msgstr "Intervalle de rafraîchissement (en secondes)"
 
-#: src/muuli_wdr.cpp:2221
+#: src/muuli_wdr.cpp:2225
 msgid "Enable Gzip compression"
 msgstr "Activer la compression Gzip"
 
-#: src/muuli_wdr.cpp:2255
+#: src/muuli_wdr.cpp:2259
 msgid "Reset page to defaults"
 msgstr "Réinitialiser la page aux valeurs par défaut"
 
-#: src/muuli_wdr.cpp:2256
+#: src/muuli_wdr.cpp:2260
 msgid "Reset the settings on the current page to their default values."
 msgstr "Réinitialiser les réglages sur la page actuelle à leurs valeurs par défaut."
 
-#: src/muuli_wdr.cpp:2258 src/muuli_wdr.cpp:2344 src/ServerWnd.cpp:274
+#: src/muuli_wdr.cpp:2262 src/muuli_wdr.cpp:2348 src/ServerWnd.cpp:274
 #: src/ServerWnd.cpp:282
 msgid "OK"
 msgstr "OK"
 
-#: src/muuli_wdr.cpp:2260
+#: src/muuli_wdr.cpp:2264
 msgid "Click here to apply any changes made to the preferences."
 msgstr "Cliquer ici pour appliquer tous les changements effectués dans les Préférences."
 
-#: src/muuli_wdr.cpp:2263
+#: src/muuli_wdr.cpp:2267
 msgid "Reset any changes made to the preferences."
 msgstr "Annule tous les changements effectués dans les Préférences."
 
-#: src/muuli_wdr.cpp:2292
+#: src/muuli_wdr.cpp:2296
 msgid "Comment :"
 msgstr "Commentaire :"
 
-#: src/muuli_wdr.cpp:2299
+#: src/muuli_wdr.cpp:2303
 msgid "Incoming Dir :"
 msgstr "Répertoire entrant :"
 
-#: src/muuli_wdr.cpp:2308
+#: src/muuli_wdr.cpp:2312
 msgid "Change priority for new assigned files :"
 msgstr "Changer la priorité des nouveaux fichiers assignés :"
 
-#: src/muuli_wdr.cpp:2312
+#: src/muuli_wdr.cpp:2316
 msgid "Don't change"
 msgstr "Ne rien changer"
 
-#: src/muuli_wdr.cpp:2324
+#: src/muuli_wdr.cpp:2328
 msgid "Select color for this Category (currently selected) :"
 msgstr "Choisir la couleur pour cette Catégorie (actuellement sélectionnée) :"
 
-#: src/muuli_wdr.cpp:2391 src/muuli_wdr.cpp:2410 src/muuli_wdr.cpp:2432
+#: src/muuli_wdr.cpp:2395 src/muuli_wdr.cpp:2414 src/muuli_wdr.cpp:2436
 msgid "Click this button to reset the log."
 msgstr "Cliquer ici pour effacer le journal."
 
-#: src/muuli_wdr.cpp:2451
+#: src/muuli_wdr.cpp:2455
 msgid "Click on this button to update the servers list from URL ..."
 msgstr "Cliquer ici pour mettre à jour la liste des serveurs à partir de l'URL…"
 
-#: src/muuli_wdr.cpp:2455
+#: src/muuli_wdr.cpp:2459
 msgid "Server list"
 msgstr "Liste des serveurs"
 
-#: src/muuli_wdr.cpp:2459
+#: src/muuli_wdr.cpp:2463
 msgid "Enter the url to a server.met file here and press the button to the left to update the list of known servers."
 msgstr "Entrer l'URL d'un fichier server.met et presser le bouton à gauche pour rafraîchir la liste des serveurs connus."
 
-#: src/muuli_wdr.cpp:2464
+#: src/muuli_wdr.cpp:2468
 msgid "Add server manually: Name"
 msgstr "Ajouter un serveur manuellement : Nom"
 
-#: src/muuli_wdr.cpp:2467
+#: src/muuli_wdr.cpp:2471
 msgid "Enter the name of the new server here"
 msgstr "Entrer ici le nom du nouveau serveur"
 
-#: src/muuli_wdr.cpp:2469 src/ServerWnd.cpp:206
+#: src/muuli_wdr.cpp:2473 src/ServerWnd.cpp:206
 msgid "IP:Port"
 msgstr "IP : Port"
 
-#: src/muuli_wdr.cpp:2472
+#: src/muuli_wdr.cpp:2476
 msgid "Enter the IP of the server here, using the x.x.x.x format."
 msgstr "Entrer ici l'adresse IP du serveur, avec le format x.x.x.x."
 
-#: src/muuli_wdr.cpp:2478
+#: src/muuli_wdr.cpp:2482
 msgid "Enter the port of the server here."
 msgstr "Entrer ici le port du serveur."
 
-#: src/muuli_wdr.cpp:2481
+#: src/muuli_wdr.cpp:2485
 msgid "Add manually a server (fill fields to the left before) ..."
 msgstr "Ajouter manuellement un serveur (remplir les champs à gauche avant)…"
 
-#: src/muuli_wdr.cpp:2510
+#: src/muuli_wdr.cpp:2514
 msgid "aMule Log"
 msgstr "Journal d'aMule"
 
-#: src/muuli_wdr.cpp:2518
+#: src/muuli_wdr.cpp:2522
 msgid "Server Info"
 msgstr "Infos Serveur"
 
-#: src/muuli_wdr.cpp:2522
+#: src/muuli_wdr.cpp:2526
 msgid "ED2K Info"
 msgstr "Infos ED2K"
 
-#: src/muuli_wdr.cpp:2526
+#: src/muuli_wdr.cpp:2530
 msgid "Kad Info"
 msgstr "Infos Kad"
 
-#: src/muuli_wdr.cpp:2554
+#: src/muuli_wdr.cpp:2558
 msgid "Click on this button to update the nodes list from URL ..."
 msgstr "Cliquer sur le bouton pour mettre à jour la liste des nœuds depuis l'URL…"
 
-#: src/muuli_wdr.cpp:2558
+#: src/muuli_wdr.cpp:2562
 msgid "Nodes (0)"
 msgstr "Nœuds (0)"
 
-#: src/muuli_wdr.cpp:2562
+#: src/muuli_wdr.cpp:2566
 msgid "Enter the url to a nodes.dat file here and press the button to the left to update the list of known nodes."
 msgstr "Entrer l'URL d'un fichier nodes.dat ici et presser le bouton à gauche pour mettre à jour la liste des nœuds connus."
 
-#: src/muuli_wdr.cpp:2565
+#: src/muuli_wdr.cpp:2569
 msgid "Nodes stats"
 msgstr "Statistiques des nœuds"
 
-#: src/muuli_wdr.cpp:2607
+#: src/muuli_wdr.cpp:2611
 msgid "Bootstrap"
 msgstr "Amorçage"
 
-#: src/muuli_wdr.cpp:2610
+#: src/muuli_wdr.cpp:2614
 msgid "New node"
 msgstr "Nouveau nœud"
 
-#: src/muuli_wdr.cpp:2615
+#: src/muuli_wdr.cpp:2619
 msgid "IP:"
 msgstr "IP :"
 
-#: src/muuli_wdr.cpp:2635
+#: src/muuli_wdr.cpp:2639
 msgid "Port:"
 msgstr "Port :"
 
-#: src/muuli_wdr.cpp:2648
+#: src/muuli_wdr.cpp:2652
 msgid "Bootstrap from known clients"
 msgstr "Amorçage depuis les clients connus"
 
-#: src/muuli_wdr.cpp:2650
+#: src/muuli_wdr.cpp:2654
 msgid "Disconnect Kad"
 msgstr "Déconnecter Kad"
 
-#: src/muuli_wdr.cpp:2684
+#: src/muuli_wdr.cpp:2688
 msgid "Use Secure User Identification"
 msgstr "Utiliser l'Identification Utilisateur Sécurisée (SUI)"
 
-#: src/muuli_wdr.cpp:2686
+#: src/muuli_wdr.cpp:2690
 msgid "It is recommended to enable this option. You will not receive credits if SUI is not enabled."
 msgstr "Il est recommandé d'activer cette option. Vous ne recevrez pas de crédits si SUI n'est pas activé."
 
-#: src/muuli_wdr.cpp:2688
+#: src/muuli_wdr.cpp:2692
 msgid "Protocol Obfuscation"
 msgstr "Brouillage de protocole"
 
-#: src/muuli_wdr.cpp:2691
+#: src/muuli_wdr.cpp:2695
 msgid "Support Protocol Obfuscation"
 msgstr "Supporter le brouillage de protocole"
 
-#: src/muuli_wdr.cpp:2693
+#: src/muuli_wdr.cpp:2697
 msgid "This option enabled Protocol Obfuscation, and makes aMule accept obfuscated connections from other clients."
 msgstr "Cette option active le brouillage de protocole, cela permet à aMule d'accepter les connexions brouillées des autres clients."
 
-#: src/muuli_wdr.cpp:2695
+#: src/muuli_wdr.cpp:2699
 msgid "Use obfuscation for outgoing connections"
 msgstr "Utiliser le brouillage pour les connexions sortantes"
 
-#: src/muuli_wdr.cpp:2697
+#: src/muuli_wdr.cpp:2701
 msgid "This option makes aMule use Protocol Obfuscation when connecting other clients/servers."
 msgstr "Avec cette option, aMule utilise le brouillage de protocole lors des connexions aux autres clients/serveurs."
 
-#: src/muuli_wdr.cpp:2699
+#: src/muuli_wdr.cpp:2703
 msgid "Accept only obfuscated connections"
 msgstr "Accepter seulement les connexions brouillées"
 
-#: src/muuli_wdr.cpp:2700
+#: src/muuli_wdr.cpp:2704
 msgid "This option makes aMule only accept obfuscated connections. You will have less sources, but all your traffic will be obfuscated"
 msgstr "Avec cette option, aMule n'accepte que les connexions brouillées. Vous aurez moins de sources, mais tout votre trafic sera brouillé"
 
-#: src/muuli_wdr.cpp:2705
+#: src/muuli_wdr.cpp:2709
 msgid "Everybody"
 msgstr "Tout le monde"
 
-#: src/muuli_wdr.cpp:2707
+#: src/muuli_wdr.cpp:2711
 msgid "No one"
 msgstr "Personne"
 
-#: src/muuli_wdr.cpp:2709
+#: src/muuli_wdr.cpp:2713
 msgid "Who can see my shared files:"
 msgstr "Qui peut voir mes fichiers partagés :"
 
-#: src/muuli_wdr.cpp:2710
+#: src/muuli_wdr.cpp:2714
 msgid "Select who can request to view a list of your shared files."
 msgstr "Indique qui peut voir votre liste de fichiers partagés."
 
-#: src/muuli_wdr.cpp:2712
+#: src/muuli_wdr.cpp:2716
 msgid "IP-Filtering"
 msgstr "Filtrage des IP"
 
-#: src/muuli_wdr.cpp:2719
+#: src/muuli_wdr.cpp:2723
 msgid "Filter clients"
 msgstr "Filtrage des clients"
 
-#: src/muuli_wdr.cpp:2721
+#: src/muuli_wdr.cpp:2725
 msgid "Enable filtering of the client IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "Activer le filtrage des clients selon les IP contenues dans le fichier ~/.aMule/ipfilter.dat."
 
-#: src/muuli_wdr.cpp:2723
+#: src/muuli_wdr.cpp:2727
 msgid "Filter servers"
 msgstr "Filtrage des serveurs"
 
-#: src/muuli_wdr.cpp:2725
+#: src/muuli_wdr.cpp:2729
 msgid "Enable filtering of the server IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "Active le filtrage des serveurs selon les IP contenues dans le fichier ~/.aMule/ipfilter.dat."
 
-#: src/muuli_wdr.cpp:2729
+#: src/muuli_wdr.cpp:2733
 msgid "Reload List"
 msgstr "Recharger la liste"
 
-#: src/muuli_wdr.cpp:2730
+#: src/muuli_wdr.cpp:2734
 msgid "Reload the list of IPs to filter from the file ~/.aMule/ipfilter.dat"
 msgstr "Recharge la liste des IP à filtrer à partir du fichier ~/.aMule/ipfilter.dat"
 
-#: src/muuli_wdr.cpp:2736
+#: src/muuli_wdr.cpp:2740
 msgid "URL:"
 msgstr "URL :"
 
-#: src/muuli_wdr.cpp:2740 src/muuli_wdr.cpp:2933
+#: src/muuli_wdr.cpp:2744 src/muuli_wdr.cpp:2937
 msgid "Update now"
 msgstr "Mettre à jour maintenant"
 
-#: src/muuli_wdr.cpp:2743
+#: src/muuli_wdr.cpp:2747
 msgid "Auto-update ipfilter at startup"
 msgstr "Mise à jour d' IPFilter au démarrage"
 
-#: src/muuli_wdr.cpp:2747
+#: src/muuli_wdr.cpp:2751
 msgid "Filtering Level:"
 msgstr "Niveau de filtrage :"
 
-#: src/muuli_wdr.cpp:2753
+#: src/muuli_wdr.cpp:2757
 msgid "Always filter LAN IPs"
 msgstr "Toujours filtrer les IPs LAN"
 
-#: src/muuli_wdr.cpp:2756
+#: src/muuli_wdr.cpp:2760
 msgid "Paranoid handling of non-matching IPs"
 msgstr "Prise en charge paranoïaque des IPs qui ne se correspondent pas"
 
-#: src/muuli_wdr.cpp:2758
+#: src/muuli_wdr.cpp:2762
 msgid "Rejects a packet when its source IP differs from the IP the client claims (an anti-spoofing check). Disable only if it causes connection problems."
 msgstr "Rejette un paquet lorsque son IP source diffère de l'IP que le client prétend avoir (vérification anti-usurpation). Désactivez seulement si cela provoque des problèmes de connexion."
 
-#: src/muuli_wdr.cpp:2760
+#: src/muuli_wdr.cpp:2764
 msgid "Use system-wide ipfilter.dat if available"
 msgstr "Utiliser un ipfilter.dat système si disponible"
 
-#: src/muuli_wdr.cpp:2761
+#: src/muuli_wdr.cpp:2765
 msgid "If there's no local ipfilter.dat found, allow usage of a system-wide ipfilter file."
 msgstr "S'il n'y a pas de fichier ipfilter.dat local, autoriser l'utilisation d'un fichier ipfilter système."
 
-#: src/muuli_wdr.cpp:2778
+#: src/muuli_wdr.cpp:2782
 msgid "Enable Online-Signature"
 msgstr "Activer la Signature En Ligne"
 
-#: src/muuli_wdr.cpp:2780
+#: src/muuli_wdr.cpp:2784
 msgid "Enables the writing of the OS file, which can be used by external apps to create signatures and the like."
 msgstr "Active l'écriture du fichier de signature en ligne, qui peut-être utilisé par des applications extérieures pour créer des signatures, etc."
 
-#: src/muuli_wdr.cpp:2784
+#: src/muuli_wdr.cpp:2788
 msgid "Update Frequency (Secs):"
 msgstr "Fréquence de mise à jour (Secondes) :"
 
-#: src/muuli_wdr.cpp:2787
+#: src/muuli_wdr.cpp:2791
 msgid "Change the frequency (in seconds) of Online Signature updates."
 msgstr "Change la fréquence des mises à jour de la signature en ligne (en secondes)."
 
-#: src/muuli_wdr.cpp:2795
+#: src/muuli_wdr.cpp:2799
 msgid "Save online signature file in: "
 msgstr "Sauver le fichier de signature en ligne dans : "
 
-#: src/muuli_wdr.cpp:2801
+#: src/muuli_wdr.cpp:2805
 msgid "Click here to select the directory containing the the Online Signature files."
 msgstr "Cliquer ici pour sélectionner le répertoire contenant le fichier de signature en ligne."
 
-#: src/muuli_wdr.cpp:2834
+#: src/muuli_wdr.cpp:2838
 msgid "Show country flags for clients"
 msgstr "Voir les drapeaux des pays pour les clients"
 
-#: src/muuli_wdr.cpp:2835
+#: src/muuli_wdr.cpp:2839
 msgid "Render the country flag column in the transfers, queue and search views. Requires a valid MMDB GeoIP database (see below)."
 msgstr "Afficher la colonne des drapeaux des pays dans les vues des transferts, des files d'attente et de recherche. Nécessite une base de données MMDB GeoIP valide (cf. ci-dessous)."
 
-#: src/muuli_wdr.cpp:2840
+#: src/muuli_wdr.cpp:2844
 msgid "Database"
 msgstr "Base de données"
 
-#: src/muuli_wdr.cpp:2856
+#: src/muuli_wdr.cpp:2860
 msgid "Source:"
 msgstr "Source :"
 
-#: src/muuli_wdr.cpp:2859
+#: src/muuli_wdr.cpp:2863
 msgid "DB-IP (free, no account)"
 msgstr "DB-IP (gratuit, pas de compte)"
 
-#: src/muuli_wdr.cpp:2860
+#: src/muuli_wdr.cpp:2864
 msgid "MaxMind GeoLite2 (free, account required)"
 msgstr "MaxMind GeoLite2 (gratuit, compte nécessaire)"
 
-#: src/muuli_wdr.cpp:2861
+#: src/muuli_wdr.cpp:2865
 msgid "Custom URL"
 msgstr "URL personnalisé"
 
-#: src/muuli_wdr.cpp:2864
+#: src/muuli_wdr.cpp:2868
 msgid "Choose which provider supplies the GeoIP MMDB database. DB-IP is the default - no account required. MaxMind requires a free account + license key. Use Custom URL to point at any other MMDB host (e.g. a local mirror)."
 msgstr "Choisissez quel fournisseur procure la base de données GeoIP MMDB. DB-IP est la valeur par défaut - ne nécessite pas de compte. MaxMind nécessite un compte gratuit + une clef de licence. Utilisez un URL personnalisé pour pointer vers tout autre hôte MMDB (par exemple un miroir local)."
 
-#: src/muuli_wdr.cpp:2881
+#: src/muuli_wdr.cpp:2885
 msgid ""
 "No configuration required.\n"
 "\n"
@@ -4860,11 +4860,11 @@ msgstr ""
 "Les données IP vers pays par DB-IP.com - https://db-ip.com\n"
 "Licence : Creative Commons Attribution 4.0 - https://creativecommons.org/licenses/by/4.0/deed.fr"
 
-#: src/muuli_wdr.cpp:2894
+#: src/muuli_wdr.cpp:2898
 msgid "License key:"
 msgstr "Clef de licence :"
 
-#: src/muuli_wdr.cpp:2900
+#: src/muuli_wdr.cpp:2904
 msgid ""
 "Sign up for a free MaxMind account, then generate a License Key:\n"
 "https://www.maxmind.com/en/geolite2/signup\n"
@@ -4880,11 +4880,11 @@ msgstr ""
 "Licence : CLUF MaxMind GeoLite2 - https://www.maxmind.com/en/geolite2/eula\n"
 "Nécessite une attribution et la création d'un compte ; actualisez au moins tous les 30 jours."
 
-#: src/muuli_wdr.cpp:2915
+#: src/muuli_wdr.cpp:2919
 msgid "Download URL:"
 msgstr "URL de téléchargement :"
 
-#: src/muuli_wdr.cpp:2921
+#: src/muuli_wdr.cpp:2925
 msgid ""
 "Must point to an .mmdb file or a .gz / .tar.gz containing one.\n"
 "URL may include credentials (https://user:pass@host/...).\n"
@@ -4894,211 +4894,211 @@ msgstr ""
 "L'URL peut contenir un identifiant et mot de passe (https://utilisateur:motdepasse@hôte/...) \n"
 "La licence et les conditions d'attribution sont définies par l'URL d'origine - vous en êtes responsable."
 
-#: src/muuli_wdr.cpp:2934
+#: src/muuli_wdr.cpp:2938
 msgid "Download the GeoIP database from the selected source."
 msgstr "Télécharger la base de données GeoIP depuis la source sélectionnée."
 
-#: src/muuli_wdr.cpp:2936
+#: src/muuli_wdr.cpp:2940
 msgid "Auto-update on startup"
 msgstr "Mise à jour automatique au démarrage"
 
-#: src/muuli_wdr.cpp:2937
+#: src/muuli_wdr.cpp:2941
 msgid "Re-download the GeoIP database from the selected source every time aMule starts."
 msgstr "Télécharger à nouveau la base de données GeoIP depuis la source sélectionnée chaque fois qu'aMule démarre."
 
-#: src/muuli_wdr.cpp:2960
+#: src/muuli_wdr.cpp:2964
 msgid "Filter incoming messages (except current chat):"
 msgstr "Filtrer les messages entrant (sauf la discussion en cours) :"
 
-#: src/muuli_wdr.cpp:2962
+#: src/muuli_wdr.cpp:2966
 msgid "Filter all messages"
 msgstr "Filtrer tous les messages"
 
-#: src/muuli_wdr.cpp:2964
+#: src/muuli_wdr.cpp:2968
 msgid "Filter messages from people not on your friend list"
 msgstr "Filtrer les messages des gens qui ne sont pas sur votre liste d'amis"
 
-#: src/muuli_wdr.cpp:2966
+#: src/muuli_wdr.cpp:2970
 msgid "Filter messages from unknown clients"
 msgstr "Filtrer les messages des clients inconnus"
 
-#: src/muuli_wdr.cpp:2968
+#: src/muuli_wdr.cpp:2972
 msgid "Filter messages containing (use ',' as separator):"
 msgstr "Filtrer les messages contenant (utiliser ',' comme séparateur) :"
 
-#: src/muuli_wdr.cpp:2971 src/muuli_wdr.cpp:2982
+#: src/muuli_wdr.cpp:2975 src/muuli_wdr.cpp:2986
 msgid "add here the words amule should filter and block messages including it"
 msgstr "ajouter ici les mots qu'aMule doit filtrer : blocage des messages les contenant"
 
-#: src/muuli_wdr.cpp:2973
+#: src/muuli_wdr.cpp:2977
 msgid "Show received messages in the log"
 msgstr "Afficher les messages reçus dans le journal"
 
-#: src/muuli_wdr.cpp:2976
+#: src/muuli_wdr.cpp:2980
 msgid "Comments"
 msgstr "Commentaires"
 
-#: src/muuli_wdr.cpp:2979
+#: src/muuli_wdr.cpp:2983
 msgid "Filter comments containing (use ',' as separator):"
 msgstr "Filtrer les commentaires contenant (utiliser ',' comme séparateur) :"
 
-#: src/muuli_wdr.cpp:3004
+#: src/muuli_wdr.cpp:3008
 msgid "Enable Proxy"
 msgstr "Activer le Proxy"
 
-#: src/muuli_wdr.cpp:3005
+#: src/muuli_wdr.cpp:3009
 msgid "Enable/disable proxy support"
 msgstr "Active/Désactive le support proxy"
 
-#: src/muuli_wdr.cpp:3008
+#: src/muuli_wdr.cpp:3012
 msgid "Proxy type:"
 msgstr "Type de proxy :"
 
-#: src/muuli_wdr.cpp:3019
+#: src/muuli_wdr.cpp:3023
 msgid "Proxy host:"
 msgstr "Hôte du proxy :"
 
-#: src/muuli_wdr.cpp:3022
+#: src/muuli_wdr.cpp:3026
 msgid "The proxy host name"
 msgstr "Nom de l'hôte du proxy"
 
-#: src/muuli_wdr.cpp:3024
+#: src/muuli_wdr.cpp:3028
 msgid "Proxy port:"
 msgstr "Port du proxy :"
 
-#: src/muuli_wdr.cpp:3027
+#: src/muuli_wdr.cpp:3031
 msgid "The proxy port"
 msgstr "Numéro du port du proxy"
 
-#: src/muuli_wdr.cpp:3029
+#: src/muuli_wdr.cpp:3033
 msgid "Enable authentication"
 msgstr "Activer l'authentification"
 
-#: src/muuli_wdr.cpp:3030
+#: src/muuli_wdr.cpp:3034
 msgid "Enable/disable username/password authentication"
 msgstr "Active/Désactive l'authentification par nom d'utilisateur/mot de passe"
 
-#: src/muuli_wdr.cpp:3033
+#: src/muuli_wdr.cpp:3037
 msgid "Username: "
 msgstr "Nom d'utilisateur : "
 
-#: src/muuli_wdr.cpp:3036
+#: src/muuli_wdr.cpp:3040
 msgid "The username to use to connect to the proxy"
 msgstr "Nom d'utilisateur pour se connecter au proxy"
 
-#: src/muuli_wdr.cpp:3038
+#: src/muuli_wdr.cpp:3042
 msgid "Password:"
 msgstr "Mot de passe :"
 
-#: src/muuli_wdr.cpp:3041
+#: src/muuli_wdr.cpp:3045
 msgid "The password to use to connect to the proxy"
 msgstr "Mot de passe pour se connecter au proxy"
 
-#: src/muuli_wdr.cpp:3060
+#: src/muuli_wdr.cpp:3064
 msgid "Connect to:"
 msgstr "Se connecter à :"
 
-#: src/muuli_wdr.cpp:3069
+#: src/muuli_wdr.cpp:3073
 msgid "Login to remote amule"
 msgstr "Connexion distante à aMule"
 
-#: src/muuli_wdr.cpp:3074
+#: src/muuli_wdr.cpp:3078
 msgid "User name"
 msgstr "Nom d'utilisateur"
 
-#: src/muuli_wdr.cpp:3085
+#: src/muuli_wdr.cpp:3089
 msgid "Remember those settings"
 msgstr "Se rappeler de ces réglages"
 
-#: src/muuli_wdr.cpp:3088
+#: src/muuli_wdr.cpp:3092
 msgid "Force ZLIB compression"
 msgstr "Forcer la compression ZLIB"
 
-#: src/muuli_wdr.cpp:3112
+#: src/muuli_wdr.cpp:3116
 msgid "Enable Verbose Debug-Logging."
 msgstr "Activer l'historique du mode de débogage bavard."
 
-#: src/muuli_wdr.cpp:3114
+#: src/muuli_wdr.cpp:3118
 msgid "Only to Logfile"
 msgstr "Seulement vers le fichier journal"
 
-#: src/muuli_wdr.cpp:3116
+#: src/muuli_wdr.cpp:3120
 msgid "Message Categories:"
 msgstr "Catégories des messages :"
 
-#: src/muuli_wdr.cpp:3140 src/PartFileConvertDlg.cpp:160
+#: src/muuli_wdr.cpp:3144 src/PartFileConvertDlg.cpp:160
 msgid "Waiting..."
 msgstr "En attente…"
 
-#: src/muuli_wdr.cpp:3160
+#: src/muuli_wdr.cpp:3164
 msgid "Add imports"
 msgstr "Ajouter des fichiers à importer"
 
-#: src/muuli_wdr.cpp:3163
+#: src/muuli_wdr.cpp:3167
 msgid "Retry selected"
 msgstr "Réessayer avec la sélection"
 
-#: src/muuli_wdr.cpp:3165
+#: src/muuli_wdr.cpp:3169
 msgid "Remove selected"
 msgstr "Supprimer la sélection"
 
-#: src/muuli_wdr.cpp:3228
+#: src/muuli_wdr.cpp:3232
 msgid "Event Types"
 msgstr "Types d'événements"
 
-#: src/muuli_wdr.cpp:3247
+#: src/muuli_wdr.cpp:3251
 msgid "Statistics and queued clients for selected file(s) : Session / All time"
 msgstr "Statistiques et clients en attente pour le(s) fichier(s) sélectionné(s) : Session / Tous les temps"
 
-#: src/muuli_wdr.cpp:3271
+#: src/muuli_wdr.cpp:3275
 msgid "Active Uploads"
 msgstr "Envois Actifs"
 
-#: src/muuli_wdr.cpp:3285
+#: src/muuli_wdr.cpp:3289
 msgid "Percent of total files"
 msgstr "Pourcentage du total de fichiers"
 
-#: src/muuli_wdr.cpp:3337
+#: src/muuli_wdr.cpp:3341
 msgid "Show Clients for"
 msgstr "Afficher les clients pour"
 
-#: src/muuli_wdr.cpp:3339
+#: src/muuli_wdr.cpp:3343
 msgid "All files"
 msgstr "Tous les fichiers"
 
-#: src/muuli_wdr.cpp:3342
+#: src/muuli_wdr.cpp:3346
 msgid "Selected files"
 msgstr "Fichiers sélectionnés"
 
-#: src/muuli_wdr.cpp:3345
+#: src/muuli_wdr.cpp:3349
 msgid "Active uploads only"
 msgstr "Envois actifs seulement"
 
-#: src/muuli_wdr.cpp:3352
+#: src/muuli_wdr.cpp:3356
 msgid "Reload:"
 msgstr "Recharger :"
 
-#: src/muuli_wdr.cpp:3356
+#: src/muuli_wdr.cpp:3360
 msgid "Reload your shared files"
 msgstr "Recharge vos fichiers partagés"
 
-#: src/muuli_wdr.cpp:3419
+#: src/muuli_wdr.cpp:3423
 msgid "Send"
 msgstr "Envoyer"
 
-#: src/muuli_wdr.cpp:3420
+#: src/muuli_wdr.cpp:3424
 msgid "Sends the specified message."
 msgstr "Envoie le message spécifié."
 
-#: src/muuli_wdr.cpp:3424
+#: src/muuli_wdr.cpp:3428
 msgid "Close this chat-session."
 msgstr "Ferme cette session de discussion."
 
-#: src/muuli_wdr.cpp:3447
+#: src/muuli_wdr.cpp:3451
 msgid "Connect to any server and/or Kad"
 msgstr "Se connecter à n'importe quel serveur et/ou Kad"
 
-#: src/muuli_wdr.cpp:3453 src/SharedFilesCtrl.cpp:142 src/Statistics.cpp:941
+#: src/muuli_wdr.cpp:3457 src/SharedFilesCtrl.cpp:142 src/Statistics.cpp:941
 msgid "Shared Files"
 msgstr "Fichiers partagés"
 
@@ -5733,35 +5733,35 @@ msgstr ""
 "aMule fonctionnera bien en ne modifiant pas\n"
 "ces réglages."
 
-#: src/PrefsUnifiedDlg.cpp:647
+#: src/PrefsUnifiedDlg.cpp:656
 #, c-format
 msgid "Failed to connect Cfg to widget with the ID %d and key %s"
 msgstr "Échec à la connexion de Cfg au widget avec l'ID %d et la clé %s"
 
-#: src/PrefsUnifiedDlg.cpp:695
+#: src/PrefsUnifiedDlg.cpp:704
 #, c-format
 msgid "Failed to transfer data from Cfg to Widget with the ID %d and key %s"
 msgstr "Échec du transfert de données depuis Cfg vers le widget avec l'ID %d et la clé %s"
 
-#: src/PrefsUnifiedDlg.cpp:801
+#: src/PrefsUnifiedDlg.cpp:810
 msgid "The type of proxy you are connecting to"
 msgstr "Type de proxy auquel vous êtes connecté"
 
-#: src/PrefsUnifiedDlg.cpp:1020
+#: src/PrefsUnifiedDlg.cpp:1029
 #, c-format
 msgid "Failed to transfer data from Widget to Cfg with the ID %d and key %s"
 msgstr "Échec du transfert de données depuis le widget vers Cfg avec l'ID %d et la clé %s"
 
-#: src/PrefsUnifiedDlg.cpp:1103
+#: src/PrefsUnifiedDlg.cpp:1112
 #, fuzzy
 msgid "No password set."
 msgstr "Mot de passe administrateur"
 
-#: src/PrefsUnifiedDlg.cpp:1132
+#: src/PrefsUnifiedDlg.cpp:1141
 msgid "Guest access needs a password. Type one in the guest password field, or untick Enable guest access."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1144
+#: src/PrefsUnifiedDlg.cpp:1153
 msgid ""
 "aMule must be restarted to enable these changes:\n"
 "\n"
@@ -5769,39 +5769,39 @@ msgstr ""
 "aMule doit être redémarré pour activer ces changements : \n"
 "\n"
 
-#: src/PrefsUnifiedDlg.cpp:1151
+#: src/PrefsUnifiedDlg.cpp:1160
 msgid "- TCP port changed.\n"
 msgstr "- Port TCP changé.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1156
+#: src/PrefsUnifiedDlg.cpp:1165
 msgid "- UDP port changed.\n"
 msgstr "- Port UDP changé.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1161
+#: src/PrefsUnifiedDlg.cpp:1170
 msgid "- Network interface binding changed.\n"
 msgstr "- La liaison de Interface réseau modifiée.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1166
+#: src/PrefsUnifiedDlg.cpp:1175
 msgid "- External connect port changed.\n"
 msgstr "- Port de connexion externe changé.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1170
+#: src/PrefsUnifiedDlg.cpp:1179
 msgid "- External connect acceptance changed.\n"
 msgstr "- Consentement de connexion externe changé.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1174
+#: src/PrefsUnifiedDlg.cpp:1183
 msgid "- External connect interface changed.\n"
 msgstr "- Interface de connexion externe changé.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1178
+#: src/PrefsUnifiedDlg.cpp:1187
 msgid "- Protocol obfuscation support changed.\n"
 msgstr "- Support du brouillage de protocole changé.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1193
+#: src/PrefsUnifiedDlg.cpp:1202
 msgid "- amuleapi settings changed.\n"
 msgstr "- les réglages amuleapi modifiés.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1202
+#: src/PrefsUnifiedDlg.cpp:1211
 msgid ""
 "Your Auto-update server list is empty.\n"
 "'Auto-update server list at startup' will be disabled."
@@ -5809,7 +5809,7 @@ msgstr ""
 "Votre liste de serveur pour la mise à jour automatique est vide.\n"
 "'Mise à jour automatique au démarrage de la liste des serveurs' va être désactivée."
 
-#: src/PrefsUnifiedDlg.cpp:1213
+#: src/PrefsUnifiedDlg.cpp:1222
 msgid ""
 "You have enabled external connections but have not specified a password.\n"
 "External connections cannot be enabled unless a valid password is specified."
@@ -5817,32 +5817,32 @@ msgstr ""
 "Vous avez activé les connexions externes mais vous n'avez pas spécifié de mot de passe valide.\n"
 "Les connexions externes ne pourront pas être activées tant qu'un mot de passe valide n'est pas spécifié."
 
-#: src/PrefsUnifiedDlg.cpp:1246
+#: src/PrefsUnifiedDlg.cpp:1255
 #, c-format
 msgid "The amuleapi password could not be saved: %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1276
+#: src/PrefsUnifiedDlg.cpp:1285
 msgid "- Language changed.\n"
 msgstr "- Langue changée.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1281
+#: src/PrefsUnifiedDlg.cpp:1290
 msgid "- Temp folder changed.\n"
 msgstr "- Dossier temporaire changé.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1286
+#: src/PrefsUnifiedDlg.cpp:1295
 msgid "- ED2K network enabled.\n"
 msgstr "- Réseau ED2K activé.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1319
+#: src/PrefsUnifiedDlg.cpp:1328
 msgid "The shared-file exclusion pattern is not a valid regular expression. The filter has been left disabled."
 msgstr "Le motif d'exclusion de fichiers partagés n'est pas une expression régulière valide. Le filtre a été laissé désactivé."
 
-#: src/PrefsUnifiedDlg.cpp:1321 src/PrefsUnifiedDlg.cpp:1921
+#: src/PrefsUnifiedDlg.cpp:1330 src/PrefsUnifiedDlg.cpp:1930
 msgid "Invalid regular expression"
 msgstr "Expression régulière invalide"
 
-#: src/PrefsUnifiedDlg.cpp:1398
+#: src/PrefsUnifiedDlg.cpp:1407
 msgid ""
 "Both eD2k and Kad network are disabled.\n"
 "You won't be able to connect until you enable at least one of them."
@@ -5850,7 +5850,7 @@ msgstr ""
 "Les réseaux eD2k et Kad sont désactivés.\n"
 "Vous ne pourrez pas vous connecter tant que vous n'activerez pas au moins l'un des deux."
 
-#: src/PrefsUnifiedDlg.cpp:1403
+#: src/PrefsUnifiedDlg.cpp:1412
 msgid ""
 "Kad will not start if your UDP port is disabled.\n"
 "Enable UDP port or disable Kad."
@@ -5858,7 +5858,7 @@ msgstr ""
 "Kad ne démarrera pas si votre port UDP est désactivé.\n"
 "Activez le port UDP ou désactivez Kad."
 
-#: src/PrefsUnifiedDlg.cpp:1459
+#: src/PrefsUnifiedDlg.cpp:1468
 msgid ""
 "\n"
 "You MUST restart aMule now.\n"
@@ -5868,68 +5868,68 @@ msgstr ""
 "Vous DEVEZ redémarrer aMule maintenant.\n"
 "Si vous ne le faites pas, ne vous plaignez pas si des bogues surviennent.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1524
+#: src/PrefsUnifiedDlg.cpp:1533
 msgid "Could not register aMule for autostart at login. The autostart store may be read-only."
 msgstr "Échec de l'enregistrement d'aMule pour un lancement automatique à l'ouverture d'une session. Le dépôt de lancement automatique est peut-être en lecture seule."
 
-#: src/PrefsUnifiedDlg.cpp:1526
+#: src/PrefsUnifiedDlg.cpp:1535
 msgid "Could not remove the autostart-at-login entry."
 msgstr "Échec de l'effacement de l'entrée du lancement automatique à l'ouverture d'une session."
 
-#: src/PrefsUnifiedDlg.cpp:1527
+#: src/PrefsUnifiedDlg.cpp:1536
 msgid "Autostart"
 msgstr "Lancement automatique"
 
-#: src/PrefsUnifiedDlg.cpp:1542
+#: src/PrefsUnifiedDlg.cpp:1551
 msgid "Register file type"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1542
+#: src/PrefsUnifiedDlg.cpp:1551
 msgid "Register URL handler"
 msgstr "Enregistrer le gestionnaire d'URL"
 
-#: src/PrefsUnifiedDlg.cpp:1550
+#: src/PrefsUnifiedDlg.cpp:1559
 #, c-format
 msgid "aMule only handles eD2k-compatible magnets. If you replace the current magnet handler (%s), BitTorrent magnet links will stop working - aMule cannot download BitTorrent content. Continue?"
 msgstr "aMule ne gère que les magnet compatibles avec eD2k. Si vous remplacez le gestionnaire de magnet actuel (%s), les liens magnet BitTorrent cesseront de fonctionner - aMule ne peut télécharger du contenu BitTorrent. Continuer ?"
 
-#: src/PrefsUnifiedDlg.cpp:1555
+#: src/PrefsUnifiedDlg.cpp:1564
 #, fuzzy, c-format
 msgid "Another application currently opens .emulecollection files (%s). Replace it with aMule?"
 msgstr "Une autre application gère les liens (%s) par défaut. La remplacer par aMule ?"
 
-#: src/PrefsUnifiedDlg.cpp:1560
+#: src/PrefsUnifiedDlg.cpp:1569
 #, c-format
 msgid "Another application is currently the default handler for these links (%s). Replace it with aMule?"
 msgstr "Une autre application gère les liens (%s) par défaut. La remplacer par aMule ?"
 
-#: src/PrefsUnifiedDlg.cpp:1585
+#: src/PrefsUnifiedDlg.cpp:1594
 #, fuzzy
 msgid "Could not register aMule for .emulecollection files. The registration store may be read-only."
 msgstr "Échec de l'enregistrement d'aMule en tant que gestionnaire des URL. Le dépôt d'enregistrement est peut-être en lecture seule."
 
-#: src/PrefsUnifiedDlg.cpp:1587
+#: src/PrefsUnifiedDlg.cpp:1596
 #, fuzzy
 msgid "Could not remove the file type registration."
 msgstr "Impossible de supprimer l'enregistrement du gestionnaire d'URL."
 
-#: src/PrefsUnifiedDlg.cpp:1589
+#: src/PrefsUnifiedDlg.cpp:1598
 msgid "Could not register aMule as the URL handler. The registration store may be read-only."
 msgstr "Échec de l'enregistrement d'aMule en tant que gestionnaire des URL. Le dépôt d'enregistrement est peut-être en lecture seule."
 
-#: src/PrefsUnifiedDlg.cpp:1591
+#: src/PrefsUnifiedDlg.cpp:1600
 msgid "Could not remove the URL handler registration."
 msgstr "Impossible de supprimer l'enregistrement du gestionnaire d'URL."
 
-#: src/PrefsUnifiedDlg.cpp:1661 src/PrefsUnifiedDlg.cpp:1688
+#: src/PrefsUnifiedDlg.cpp:1670 src/PrefsUnifiedDlg.cpp:1697
 msgid "The web server and aMule API require external connections to be enabled."
 msgstr "Le serveur web et aMule API nécessitent l'activation des connexions externes."
 
-#: src/PrefsUnifiedDlg.cpp:1671
+#: src/PrefsUnifiedDlg.cpp:1680
 msgid "The aMule web server is deprecated. Consider running the aMule API instead."
 msgstr "Le serveur web d'aMule est obsolète. Envisagez d'utiliser aMule API à sa place."
 
-#: src/PrefsUnifiedDlg.cpp:1735
+#: src/PrefsUnifiedDlg.cpp:1744
 msgid ""
 "Your Auto-update servers list is in blank.\n"
 "Please fill in at least one URL to point to a valid server.met file.\n"
@@ -5939,64 +5939,64 @@ msgstr ""
 "Entrez s'il vous plaît au moins une URL qui pointe sur un fichier server.met valide.\n"
 "Cliquez sur le bouton \"Liste\" à coté de cette case pour entrer une URL."
 
-#: src/PrefsUnifiedDlg.cpp:1876
+#: src/PrefsUnifiedDlg.cpp:1885
 msgid "Temporary files"
 msgstr "Fichiers temporaires"
 
-#: src/PrefsUnifiedDlg.cpp:1881
+#: src/PrefsUnifiedDlg.cpp:1890
 msgid "Incoming files"
 msgstr "Fichiers réceptionnés"
 
-#: src/PrefsUnifiedDlg.cpp:1886
+#: src/PrefsUnifiedDlg.cpp:1895
 msgid "Online Signatures"
 msgstr "Signatures En Ligne"
 
-#: src/PrefsUnifiedDlg.cpp:1899
+#: src/PrefsUnifiedDlg.cpp:1908
 #, c-format
 msgid "Choose a folder for %s"
 msgstr "Choisir un dossier pour %s"
 
-#: src/PrefsUnifiedDlg.cpp:1923
+#: src/PrefsUnifiedDlg.cpp:1932
 #, c-format
 msgid "Would exclude %u of %u shared file"
 msgid_plural "Would exclude %u of %u shared files"
 msgstr[0] "Exclurait %u fichier sur %u fichier partagé"
 msgstr[1] "Exclurait %u fichiers sur %u fichiers partagés"
 
-#: src/PrefsUnifiedDlg.cpp:1940
+#: src/PrefsUnifiedDlg.cpp:1949
 msgid "Browse for videoplayer"
 msgstr "Chercher un lecteur vidéo"
 
-#: src/PrefsUnifiedDlg.cpp:1944
+#: src/PrefsUnifiedDlg.cpp:1953
 msgid "Select browser"
 msgstr "Choisir un navigateur"
 
-#: src/PrefsUnifiedDlg.cpp:1948
+#: src/PrefsUnifiedDlg.cpp:1957
 msgid "Select ffprobe binary"
 msgstr "Sélectionner le binaire ffprobe"
 
-#: src/PrefsUnifiedDlg.cpp:1954
+#: src/PrefsUnifiedDlg.cpp:1963
 #, c-format
 msgid "Executable%s"
 msgstr "Exécutable%s"
 
-#: src/PrefsUnifiedDlg.cpp:1988
+#: src/PrefsUnifiedDlg.cpp:1997
 msgid "ffprobe not found on PATH or in the standard install locations. Install ffmpeg (which ships ffprobe) or use Browse to pick a binary manually."
 msgstr "ffprobe n'a pas été trouvé sur PATH ou dans les emplacement standards d'installation. Installez ffmpeg (qui fournit ffprobe) ou bien utilisez Parcourir pour choisir un binaire manuellement."
 
-#: src/PrefsUnifiedDlg.cpp:2000
+#: src/PrefsUnifiedDlg.cpp:2009
 msgid "Reset the settings on this page to their default values?"
 msgstr "Réinitialiser les réglages sur cette page à leurs valeurs par défaut ?"
 
-#: src/PrefsUnifiedDlg.cpp:2001
+#: src/PrefsUnifiedDlg.cpp:2010
 msgid "Reset to defaults"
 msgstr "Réinitialiser aux valeurs par défaut"
 
-#: src/PrefsUnifiedDlg.cpp:2028
+#: src/PrefsUnifiedDlg.cpp:2037
 msgid "Edit server list"
 msgstr "Éditer la liste des serveurs"
 
-#: src/PrefsUnifiedDlg.cpp:2029
+#: src/PrefsUnifiedDlg.cpp:2038
 msgid ""
 "Add here URL's to download server.met files.\n"
 "Only one url on each line."
@@ -6004,114 +6004,114 @@ msgstr ""
 "Ajoutez ci-dessous des URL pour télécharger des fichiers server.met.\n"
 "Seulement une URL par ligne."
 
-#: src/PrefsUnifiedDlg.cpp:2084
+#: src/PrefsUnifiedDlg.cpp:2093
 msgid "IP2Country update failed"
 msgstr "Échec de la mise à jour IP2Country"
 
-#: src/PrefsUnifiedDlg.cpp:2229 src/PrefsUnifiedDlg.cpp:2260
+#: src/PrefsUnifiedDlg.cpp:2238 src/PrefsUnifiedDlg.cpp:2269
 msgid "Data by MaxMind GeoLite2"
 msgstr "Données fournies par MaxMind GeoLite2"
 
-#: src/PrefsUnifiedDlg.cpp:2231 src/PrefsUnifiedDlg.cpp:2262
+#: src/PrefsUnifiedDlg.cpp:2240 src/PrefsUnifiedDlg.cpp:2271
 msgid "Custom source"
 msgstr "Source personnalisée"
 
-#: src/PrefsUnifiedDlg.cpp:2233 src/PrefsUnifiedDlg.cpp:2264
+#: src/PrefsUnifiedDlg.cpp:2242 src/PrefsUnifiedDlg.cpp:2273
 msgid "Data by DB-IP.com"
 msgstr "Données fournies par DB-IP.com"
 
-#: src/PrefsUnifiedDlg.cpp:2284
+#: src/PrefsUnifiedDlg.cpp:2293
 #, c-format
 msgid "Status: Loaded%s"
 msgstr "État : %s chargé"
 
-#: src/PrefsUnifiedDlg.cpp:2286
+#: src/PrefsUnifiedDlg.cpp:2295
 #, c-format
 msgid "Status: Loaded%s - %s"
 msgstr "État : %s - %s chargé"
 
-#: src/PrefsUnifiedDlg.cpp:2290
+#: src/PrefsUnifiedDlg.cpp:2299
 msgid "Status: Failed to load - click 'Update now' to refresh."
 msgstr "État : échec du chargement - cliquez sur « Mettre à jour maintenant » pour actualiser."
 
-#: src/PrefsUnifiedDlg.cpp:2292
+#: src/PrefsUnifiedDlg.cpp:2301
 msgid "Status: Not found - click 'Update now' to download."
 msgstr "État : introuvable - cliquez sur « Mettre à jour maintenant » pour télécharger."
 
-#: src/PrefsUnifiedDlg.cpp:2350 src/PrefsUnifiedDlg.cpp:2374
+#: src/PrefsUnifiedDlg.cpp:2359 src/PrefsUnifiedDlg.cpp:2383
 #, c-format
 msgid "Update delay: %d second"
 msgid_plural "Update delay: %d seconds"
 msgstr[0] "Délais de rafraîchissement : %d seconde"
 msgstr[1] "Délais de rafraîchissement : %d secondes"
 
-#: src/PrefsUnifiedDlg.cpp:2358
+#: src/PrefsUnifiedDlg.cpp:2367
 #, c-format
 msgid "Time for average graph: %d minute"
 msgid_plural "Time for average graph: %d minutes"
 msgstr[0] "Temps pour le graphe des moyennes : %d minute"
 msgstr[1] "Temps pour le graphe des moyennes : %d minutes"
 
-#: src/PrefsUnifiedDlg.cpp:2367
+#: src/PrefsUnifiedDlg.cpp:2376
 #, c-format
 msgid "Connections Graph Scale: %d"
 msgstr "Échelle du graphique des connexions : %d"
 
-#: src/PrefsUnifiedDlg.cpp:2382
+#: src/PrefsUnifiedDlg.cpp:2391
 #, c-format
 msgid "File Buffer Size: %d byte"
 msgid_plural "File Buffer Size: %d bytes"
 msgstr[0] "Taille du tampon de fichiers : %d octet"
 msgstr[1] "Taille du tampon de fichiers : %d octets"
 
-#: src/PrefsUnifiedDlg.cpp:2392
+#: src/PrefsUnifiedDlg.cpp:2401
 #, c-format
 msgid "Upload Queue Size: %d client"
 msgid_plural "Upload Queue Size: %d clients"
 msgstr[0] "Taille de la fille d'attente d'émission : %d client"
 msgstr[1] "Taille de la fille d'attente d'émission : %d clients"
 
-#: src/PrefsUnifiedDlg.cpp:2402
+#: src/PrefsUnifiedDlg.cpp:2411
 #, c-format
 msgid "Server connection refresh interval: %d minute"
 msgid_plural "Server connection refresh interval: %d minutes"
 msgstr[0] "Intervalle de rafraîchissement de la connexion serveur : %d minute"
 msgstr[1] "Intervalle de rafraîchissement de la connexion serveur : %d minutes"
 
-#: src/PrefsUnifiedDlg.cpp:2407
+#: src/PrefsUnifiedDlg.cpp:2416
 msgid "Server connection refresh interval: Disabled"
 msgstr "Intervalle de rafraîchissement de la connexion serveur : Désactivé"
 
-#: src/PrefsUnifiedDlg.cpp:2451
+#: src/PrefsUnifiedDlg.cpp:2460
 msgid "disabled"
 msgstr "désactivé"
 
-#: src/PrefsUnifiedDlg.cpp:2477
+#: src/PrefsUnifiedDlg.cpp:2486
 #, c-format
 msgid "Execute command on '%s' event"
 msgstr "Exécuter la commande lors de l'événement '%s'"
 
-#: src/PrefsUnifiedDlg.cpp:2484
+#: src/PrefsUnifiedDlg.cpp:2493
 msgid "Enable command execution on core"
 msgstr "Activer l'exécution de la commande sur le noyau"
 
-#: src/PrefsUnifiedDlg.cpp:2496
+#: src/PrefsUnifiedDlg.cpp:2505
 msgid "Core command:"
 msgstr "Commande du noyau :"
 
-#: src/PrefsUnifiedDlg.cpp:2512
+#: src/PrefsUnifiedDlg.cpp:2521
 msgid "Enable command execution on GUI"
 msgstr "Activer l'exécution de la commande sur l'interface graphique"
 
-#: src/PrefsUnifiedDlg.cpp:2524
+#: src/PrefsUnifiedDlg.cpp:2533
 msgid "GUI command:"
 msgstr "Commande de l'interface graphique :"
 
-#: src/PrefsUnifiedDlg.cpp:2540
+#: src/PrefsUnifiedDlg.cpp:2549
 msgid "The following variables will be replaced:"
 msgstr "Les variables suivantes seront remplacées :"
 
-#: src/PrefsUnifiedDlg.cpp:2708
+#: src/PrefsUnifiedDlg.cpp:2717
 msgid ""
 "The following folders look like system or sensitive locations:\n"
 "\n"
@@ -6119,37 +6119,37 @@ msgstr ""
 "Les répertoires suivants semblent être des répertoires système ou des emplacements sensibles.\n"
 "\n"
 
-#: src/PrefsUnifiedDlg.cpp:2713
+#: src/PrefsUnifiedDlg.cpp:2722
 msgid "Sharing them recursively will publish every file underneath on the eD2k/Kad networks. Do you really want to do this?"
 msgstr "Les partager récursivement publiera chaque fichier contenu dans les sous répertoires sur les réseaux eD2k/Kad. Êtes-vous sûr de vouloir faire cela ?"
 
-#: src/PrefsUnifiedDlg.cpp:2716
+#: src/PrefsUnifiedDlg.cpp:2725
 msgid "Confirm shared folders"
 msgstr "Confirmer les dossiers partagés"
 
-#: src/PrefsUnifiedDlg.cpp:2744
+#: src/PrefsUnifiedDlg.cpp:2753
 msgid "Reloading shared files..."
 msgstr "Rechargement des fichiers partagés…"
 
-#: src/PrefsUnifiedDlg.cpp:2745
+#: src/PrefsUnifiedDlg.cpp:2754
 msgid "Scanning for subdirectories..."
 msgstr "Analyse des sous-répertoires…"
 
-#: src/PrefsUnifiedDlg.cpp:2746
+#: src/PrefsUnifiedDlg.cpp:2755
 msgid "Updating shared folders"
 msgstr "Mise à jour des dossiers partagés"
 
-#: src/PrefsUnifiedDlg.cpp:2773
+#: src/PrefsUnifiedDlg.cpp:2782
 #, c-format
 msgid "Scanned %u directories..."
 msgstr "%u répertoires analysés…"
 
-#: src/PrefsUnifiedDlg.cpp:2823
+#: src/PrefsUnifiedDlg.cpp:2832
 #, c-format
 msgid "Reloading shared files: %u files scanned"
 msgstr "Rechargement des fichiers partagés : %u fichiers analysés"
 
-#: src/PrefsUnifiedDlg.cpp:2873
+#: src/PrefsUnifiedDlg.cpp:2882
 msgid "Shared folder"
 msgstr "Dossier partagé"
 
@@ -7836,12 +7836,12 @@ msgstr "Supprimer une catégorie"
 msgid "Hashset requested for unknown file: %s"
 msgstr "Requête d'un hashset pour le fichier inconnu : %s"
 
-#: src/UploadQueue.cpp:618
+#: src/UploadQueue.cpp:627
 #, c-format
 msgid "Resuming uploads of file: %s"
 msgstr "Reprise des envois du fichier : %s"
 
-#: src/UploadQueue.cpp:634
+#: src/UploadQueue.cpp:643
 #, c-format
 msgid "Suspending upload of file: %s"
 msgstr "Pause des envois du fichier : %s"

--- a/po/gl.po
+++ b/po/gl.po
@@ -24,8 +24,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-28 12:12+0200\n"
-"PO-Revision-Date: 2026-07-27 10:22+0000\n"
+"POT-Creation-Date: 2026-07-28 08:06+0200\n"
+"PO-Revision-Date: 2026-07-27 11:38+0000\n"
 "Last-Translator: Pablo <parodper@gmail.com>\n"
 "Language-Team: http://forum.amule.org/index.php?topic=13883\n"
 "Language: gl\n"
@@ -162,7 +162,7 @@ msgstr "Continuar"
 msgid "Not now"
 msgstr "Agora non"
 
-#: src/AppImageIntegration.cpp:422 src/amuleDlg.cpp:665
+#: src/AppImageIntegration.cpp:422 src/amuleDlg.cpp:600
 msgid "Don't ask again"
 msgstr "Non preguntar de novo"
 
@@ -224,83 +224,83 @@ msgstr "Non se puido abrir o ficheiro con ligazóns eD2k."
 msgid "WARNING: You can't add yourself as a source for an eD2k link while having a lowid."
 msgstr "AVISO: Non podes engadirte a ti mesmo como unha fonte para un enlace eD2k tendo ID baixa."
 
-#: src/amule.cpp:301
+#: src/amule.cpp:300
 msgid "Now, exiting main app..."
 msgstr "Saíndo da aplicación principal..."
 
-#: src/amule.cpp:331
+#: src/amule.cpp:330
 #, c-format
 msgid "Terminating amuleweb instance with pid '%d' ... "
 msgstr "Rematando o proceso de amuleweb co pid «%d» ... "
 
-#: src/amule.cpp:335
+#: src/amule.cpp:334
 #, c-format
 msgid "Killing amuleweb instance with pid '%d' ... "
 msgstr "Obrigando ao proceso de amuleweb con pid «%d» a pecharse ... "
 
-#: src/amule.cpp:337 src/amule.cpp:350 src/ClientRef.cpp:180
-#: src/SearchDlg.cpp:1041 src/ServerListCtrl.cpp:98
+#: src/amule.cpp:336 src/amule.cpp:349 src/ClientRef.cpp:180
+#: src/SearchDlg.cpp:880 src/ServerListCtrl.cpp:98
 msgid "Failed"
 msgstr "Erro"
 
-#: src/amule.cpp:344
+#: src/amule.cpp:343
 #, fuzzy, c-format
 msgid "Terminating amuleapi instance with pid '%d' ... "
 msgstr "Rematando o proceso de amuleweb co pid «%d» ... "
 
-#: src/amule.cpp:348
+#: src/amule.cpp:347
 #, fuzzy, c-format
 msgid "Killing amuleapi instance with pid '%d' ... "
 msgstr "Obrigando ao proceso de amuleweb con pid «%d» a pecharse ... "
 
-#: src/amule.cpp:356
+#: src/amule.cpp:355
 msgid "aMule OnExit: Terminating core."
 msgstr "aMule Ao Sairen(OnExit): Apagando o núcleo."
 
-#: src/amule.cpp:467
+#: src/amule.cpp:466
 msgid "aMule shutdown completed."
 msgstr "Apagado completado."
 
-#: src/amule.cpp:471
+#: src/amule.cpp:470
 msgid "Memory debug results for aMule exit:"
 msgstr "Resultados da depuración da memoria ao sair de aMule:"
 
-#: src/amule.cpp:652
+#: src/amule.cpp:651
 #, c-format
 msgid "Binding aMule's peer-to-peer traffic to interface: %s (HTTP updates use the default route)"
 msgstr ""
 
-#: src/amule.cpp:656
+#: src/amule.cpp:655
 #, c-format
 msgid "Binding all network traffic to interface: %s"
 msgstr ""
 
-#: src/amule.cpp:660
+#: src/amule.cpp:659
 #, c-format
 msgid "WARNING: configured network interface '%s' was not found - traffic is NOT bound to it and may leave via the default route. Check the interface name in Preferences."
 msgstr ""
 
-#: src/amule.cpp:666
+#: src/amule.cpp:665
 #, c-format
 msgid "WARNING: binding to network interface '%s' requires elevated privileges and was NOT applied - traffic may leave via the default route. Grant the capability (e.g. 'sudo setcap cap_net_raw+ep' on the aMule binary) or run with sufficient privileges."
 msgstr ""
 
-#: src/amule.cpp:674
+#: src/amule.cpp:673
 #, c-format
 msgid "WARNING: could not bind to network interface '%s' - traffic may leave via the default route."
 msgstr ""
 
-#: src/amule.cpp:733
+#: src/amule.cpp:732
 msgid "Your locale has been changed to System Default due to a configuration change. Sorry."
 msgstr "O idioma cambiouse ao predeterminado do sistema debido a un troco na configuración."
 
-#: src/amule.cpp:735 src/amule.cpp:1589 src/CatDialog.cpp:128
+#: src/amule.cpp:734 src/amule.cpp:1581 src/CatDialog.cpp:128
 #: src/CatDialog.cpp:136 src/CatDialog.cpp:149 src/ServerList.cpp:366
 #: src/ServerListCtrl.cpp:152
 msgid "Info"
 msgstr "Información"
 
-#: src/amule.cpp:742
+#: src/amule.cpp:741
 msgid ""
 "\n"
 "EC configuration"
@@ -308,20 +308,20 @@ msgstr ""
 "\n"
 "Configuración CE"
 
-#: src/amule.cpp:745
+#: src/amule.cpp:744
 msgid "Password set and external connections enabled."
 msgstr "Establecido o contrasinal e habilitadas conexións externas."
 
-#: src/amule.cpp:755 src/KadDlg.cpp:176 src/KadDlg.cpp:185
-#: src/PrefsUnifiedDlg.cpp:1461 src/SharedFilesCtrl.cpp:476
+#: src/amule.cpp:754 src/KadDlg.cpp:176 src/KadDlg.cpp:185
+#: src/PrefsUnifiedDlg.cpp:1387 src/SharedFilesCtrl.cpp:476
 msgid "WARNING"
 msgstr "AVISO"
 
-#: src/amule.cpp:992
+#: src/amule.cpp:991
 msgid "Network bootstrap"
 msgstr "Arranque da rede"
 
-#: src/amule.cpp:997
+#: src/amule.cpp:996
 msgid ""
 "aMule has detected missing network bootstrap files.\n"
 "Select which ones to download:"
@@ -329,53 +329,53 @@ msgstr ""
 "aMule detectou que faltan ficheiros necesarios para arrancar a rede.\n"
 "Escolla os que queira descargar:"
 
-#: src/amule.cpp:1006 src/FirstRunWizard.cpp:411
+#: src/amule.cpp:1005 src/FirstRunWizard.cpp:411
 msgid "eD2k server list (server.met)"
 msgstr "Lista de servidores eD2k (server.met)"
 
-#: src/amule.cpp:1013 src/FirstRunWizard.cpp:416
+#: src/amule.cpp:1012 src/FirstRunWizard.cpp:416
 msgid "Kad bootstrap nodes (nodes.dat)"
 msgstr "Nodos de inicio de Kad (nodes.dat)"
 
-#: src/amule.cpp:1103
+#: src/amule.cpp:1102
 #, c-format
 msgid "web server running on pid %d"
 msgstr "servidor web executándose co pid %d"
 
-#: src/amule.cpp:1116
+#: src/amule.cpp:1115
 #, fuzzy
 msgid "You requested to run web server on startup, but the amuleweb binary cannot be run. Please install the package containing aMule web server, or build aMule from source with -DBUILD_WEBSERVER=YES and install it."
 msgstr "Solicitou executar o servidor web ó inicio pero non se puido executar o programa amuleweb. Instale o paquete que conteña o servidor web do aMule ou compile o aMule empregando o parámetro --enable-webserver e logo execute make install"
 
-#: src/amule.cpp:1121 src/amule.cpp:1185 src/amule.cpp:1299 src/amule.cpp:1601
+#: src/amule.cpp:1120 src/amule.cpp:1177 src/amule.cpp:1291 src/amule.cpp:1593
 #: src/amule-remote-gui.cpp:603 src/amule-remote-gui.cpp:671
 #: src/amule-remote-gui.cpp:709 src/amule-remote-gui.cpp:1282
 #: src/amule-remote-gui.cpp:1345 src/amule-remote-gui.cpp:1372
-#: src/DownloadQueue.cpp:1481 src/PrefsUnifiedDlg.cpp:1247
+#: src/DownloadQueue.cpp:1481
 msgid "ERROR"
 msgstr "ERRO"
 
-#: src/amule.cpp:1174
+#: src/amule.cpp:1166
 #, fuzzy, c-format
 msgid "amuleapi running on pid %d"
 msgstr "servidor web executándose co pid %d"
 
-#: src/amule.cpp:1180
+#: src/amule.cpp:1172
 #, fuzzy
 msgid "You requested to run amuleapi on startup, but the amuleapi binary cannot be run. Please install the package containing aMule's REST API server, or build aMule from source with -DBUILD_AMULEAPI=YES and install it."
 msgstr "Solicitou executar o servidor web ó inicio pero non se puido executar o programa amuleweb. Instale o paquete que conteña o servidor web do aMule ou compile o aMule empregando o parámetro --enable-webserver e logo execute make install"
 
-#: src/amule.cpp:1267
+#: src/amule.cpp:1259
 #, c-format
 msgid "Could not bind ports to the specified address: %s"
 msgstr "No se puideron vincular os portos á dirección especificada: %s"
 
-#: src/amule.cpp:1291
+#: src/amule.cpp:1283
 #, c-format
 msgid "Port %u is not available. You will be LOWID\n"
 msgstr "O porto %u non está dispoñible . Terá IDBAIXA\n"
 
-#: src/amule.cpp:1296
+#: src/amule.cpp:1288
 #, c-format
 msgid ""
 "Port %u is not available!\n"
@@ -390,48 +390,48 @@ msgstr ""
 "\n"
 "Comprobe a súa rede para asegurarse de que o porto está aberto para a entrada e saída."
 
-#: src/amule.cpp:1393
+#: src/amule.cpp:1385
 msgid "Failed to create OnlineSig File"
 msgstr "Non se puido crear o ficheiro OnlineSig"
 
-#: src/amule.cpp:1401
+#: src/amule.cpp:1393
 msgid "Failed to create aMule OnlineSig File"
 msgstr "Non se puido crear o ficheiro OnlineSig de aMule"
 
-#: src/amule.cpp:1564
+#: src/amule.cpp:1556
 msgid "The selected locale seems not to be installed on your box. (Note: I'll try to set it anyway)"
 msgstr "O idioma seleccionado semella non estar instalado. (Nota: Intentarase usalo a pesar diso)"
 
-#: src/amule.cpp:1574
+#: src/amule.cpp:1566
 #, c-format
 msgid "This is the first time you run aMule %s"
 msgstr "Esta é a primeira vez que iniciou aMule %s"
 
-#: src/amule.cpp:1577
+#: src/amule.cpp:1569
 msgid "This version is a testing version, updated daily, and\n"
 msgstr "Esta versión é unha versión en proba, actualizada diariamente, e\n"
 
-#: src/amule.cpp:1578
+#: src/amule.cpp:1570
 msgid "we give no warranty it won't break anything, burn your house,\n"
 msgstr "non lle aseguramos que non se rompa algo, lle prenda lume a súa casa,\n"
 
-#: src/amule.cpp:1579
+#: src/amule.cpp:1571
 msgid "or kill your dog. But it *should* be safe to use anyway.\n"
 msgstr "ou mate ao seu can. Pero non debería pasar nada.\n"
 
-#: src/amule.cpp:1584
+#: src/amule.cpp:1576
 msgid "More information, support and new releases can found at our homepage,\n"
 msgstr "Pode atopar máis información, axuda e novas actualizacións na nosa páxina,\n"
 
-#: src/amule.cpp:1585
+#: src/amule.cpp:1577
 msgid "at https://amule-org.github.io, or in our IRC channel #aMule at irc.libera.chat.\n"
 msgstr "en https://amule-org.github.io, ou na nosa canle IRC #aMule en irc.libera.chat.\n"
 
-#: src/amule.cpp:1587
+#: src/amule.cpp:1579
 msgid "Feel free to report any bugs to https://github.com/amule-org/amule/issues"
 msgstr "Pode avisar de calquera problema en https://github.com/amule-org/amule/issues"
 
-#: src/amule.cpp:1599
+#: src/amule.cpp:1591
 msgid ""
 "The folder for Online Signature files you specified is INVALID!\n"
 " OnlineSignature will be DISABLED until you fix it on preferences."
@@ -439,137 +439,137 @@ msgstr ""
 "O cartafol que especificou para as Sinaturas En Liña non é válido!\n"
 "A Sinatura En Liña permanecerá desactivada ata que se arranxe a configuración."
 
-#: src/amule.cpp:1662
+#: src/amule.cpp:1654
 msgid "Server hostname notified"
 msgstr "Nome do servidor avisado"
 
-#: src/amule.cpp:2039
+#: src/amule.cpp:2031
 #, c-format
 msgid "Disk space preallocation for file '%s' failed: %s"
 msgstr "Fallou a reserva do espazo no disco duro para o ficheiro «%s»: %s"
 
-#: src/amule.cpp:2168
+#: src/amule.cpp:2160
 msgid "ERROR: can't open logfile"
 msgstr "ERRO: non se pode abrir o ficheiro do rexistro"
 
-#: src/amule.cpp:2172
+#: src/amule.cpp:2164
 msgid "WARNING: logfile is empty. Something is wrong."
 msgstr "AVISO: o ficheiro de rexistro está baleiro. Algo está mal."
 
-#: src/amule.cpp:2189
+#: src/amule.cpp:2181
 msgid "Log has been reset"
 msgstr "O rexistro foi borrado"
 
-#: src/amule.cpp:2213
+#: src/amule.cpp:2205
 #, c-format
 msgid "ServerMessage: %s"
 msgstr "Mensaxe do servidor: %s"
 
-#: src/amule.cpp:2256 src/IP2Country.cpp:220 src/IPFilter.cpp:514
+#: src/amule.cpp:2248 src/IP2Country.cpp:220 src/IPFilter.cpp:514
 #: src/ServerList.cpp:875
 #, c-format
 msgid "Skipped download of %s, because requested file is not newer."
 msgstr "Saltouse a descarga de %s, por que o ficheiro pedido é máis antigo."
 
-#: src/amule.cpp:2259
+#: src/amule.cpp:2251
 msgid "Failed to download the nodes list."
 msgstr "Non se puido descargar a lista de nodos."
 
-#: src/amule.cpp:2322
+#: src/amule.cpp:2314
 msgid "Failed to open the downloaded version check file"
 msgstr "Non se puido abrir o ficheiro de comprobación da versión descargado"
 
-#: src/amule.cpp:2325 src/amule.cpp:2344
+#: src/amule.cpp:2317 src/amule.cpp:2336
 msgid "Corrupted version check file"
 msgstr "Ficheiro de comprobación da versión corrupto"
 
-#: src/amule.cpp:2367
+#: src/amule.cpp:2359
 msgid "You are using an outdated version of aMule!"
 msgstr "Está usando unha versión de aMule desactualizada!"
 
-#: src/amule.cpp:2369
+#: src/amule.cpp:2361
 #, c-format
 msgid "Your aMule version is %i.%i.%i and the latest version is %li.%li.%li"
 msgstr "A súa versión de aMule é %i.%i.%i e a última versión é %li.%li.%li"
 
-#: src/amule.cpp:2373
+#: src/amule.cpp:2365
 msgid "The latest version can always be found at https://github.com/amule-org/amule/releases/latest"
 msgstr "Pode obter a última versión de aMule en https://github.com/amule-org/amule/releases/latest"
 
-#: src/amule.cpp:2376
+#: src/amule.cpp:2368
 #, c-format
 msgid "WARNING: Your aMuled version is outdated: %i.%i.%i < %li.%li.%li"
 msgstr "AVISO: A súa versión de aMule está desactualizada: %i.%i.%i < %li.%li.%li"
 
-#: src/amule.cpp:2382
+#: src/amule.cpp:2374
 msgid "Your copy of aMule is up to date."
 msgstr "A súa copia de aMule está actualizada."
 
-#: src/amule.cpp:2389
+#: src/amule.cpp:2381
 msgid "Failed to download the version check file"
 msgstr "Non se puido descargar o ficheiro de comprobación de versión"
 
-#: src/amule.cpp:2558 src/amule-remote-gui.cpp:1133
+#: src/amule.cpp:2550 src/amule-remote-gui.cpp:1133
 #, c-format
 msgid "Users: %s | Files: %s"
 msgstr "Usuarios: %s | Ficheiros: %s"
 
-#: src/amule.cpp:2559 src/amule-remote-gui.cpp:1134
+#: src/amule.cpp:2551 src/amule-remote-gui.cpp:1134
 #, c-format
 msgid "Users: E: %s K: %s | Files: E: %s K: %s"
 msgstr "Usuarios: E: %s K: %s | Ficheiros: E: %s K: %s"
 
-#: src/amule.cpp:2573 src/amule-remote-gui.cpp:1147
+#: src/amule.cpp:2565 src/amule-remote-gui.cpp:1147
 msgid "No networks selected"
 msgstr "Sen redes seleccionadas"
 
-#: src/amule.cpp:2641 src/TextClient.cpp:903
+#: src/amule.cpp:2633 src/TextClient.cpp:903
 msgid "with LowID"
 msgstr "con IDBaixa"
 
-#: src/amule.cpp:2641 src/TextClient.cpp:904
+#: src/amule.cpp:2633 src/TextClient.cpp:904
 msgid "with HighID"
 msgstr "con IDAlta"
 
-#: src/amule.cpp:2643
+#: src/amule.cpp:2635
 #, c-format
 msgid "Connected to %s %s"
 msgstr "Conectado a %s %s"
 
-#: src/amule.cpp:2648
+#: src/amule.cpp:2640
 #, c-format
 msgid "Connecting to %s"
 msgstr "Conectando a %s"
 
-#: src/amule.cpp:2650
+#: src/amule.cpp:2642
 msgid "Disconnected from eD2k"
 msgstr "Desconectouse do eD2k"
 
-#: src/amule.cpp:2659
+#: src/amule.cpp:2651
 msgid "Kad started."
 msgstr "Iniciado Kad."
 
-#: src/amule.cpp:2661
+#: src/amule.cpp:2653
 msgid "Kad stopped."
 msgstr "Parado Kad."
 
-#: src/amule.cpp:2669
+#: src/amule.cpp:2661
 msgid "Connected to Kad (ok)"
 msgstr "Conectado a Kad (ok)"
 
-#: src/amule.cpp:2671
+#: src/amule.cpp:2663
 msgid "Connected to Kad (firewalled)"
 msgstr "Conectado a Kad (devasa)"
 
-#: src/amule.cpp:2675
+#: src/amule.cpp:2667
 msgid "Disconnected from Kad"
 msgstr "Desconectado de Kad"
 
-#: src/amule.cpp:2707
+#: src/amule.cpp:2699
 msgid "Kad network cannot be used if UDP port is disabled on preferences, not starting."
 msgstr "Non se pode usar a rede Kad se o porto UDP está desactivado nas preferencias. Non se iniciou."
 
-#: src/amule.cpp:2711
+#: src/amule.cpp:2703
 msgid "Kad network disabled on preferences, not connecting."
 msgstr "A rede Kad está desactivada nas preferencias. Non se iniciou."
 
@@ -594,68 +594,30 @@ msgstr "Non se puido crear o ficheiro Pid"
 msgid "ERROR: %s"
 msgstr "ERRO: %s"
 
-#: src/amuleDlg.cpp:250
+#: src/amuleDlg.cpp:236
 #, c-format
 msgid "This is aMule %s based on eMule."
 msgstr "Este é aMule %s baseado en eMule."
 
-#: src/amuleDlg.cpp:251
+#: src/amuleDlg.cpp:237
 #, c-format
 msgid "Running on %s"
 msgstr "Executando en %s"
 
-#: src/amuleDlg.cpp:253
+#: src/amuleDlg.cpp:239
 msgid "Visit https://github.com/amule-org/amule/releases/latest to check if a new version is available."
 msgstr "Visite https://github.com/amule-org/amule/releases/latest para obter actualizacións."
 
-#: src/amuleDlg.cpp:282
+#: src/amuleDlg.cpp:268
 msgid "FATAL ERROR: Failed to create Timer"
 msgstr "ERRO GRAVE: Non se puido crear o temporizador"
 
-#: src/amuleDlg.cpp:361 src/amuleDlg.cpp:1810 src/amuleDlg.cpp:2056
-#: src/muuli_wdr.cpp:1492 src/muuli_wdr.cpp:3439
-msgid "Networks"
-msgstr "Redes"
-
-#: src/amuleDlg.cpp:362 src/amuleDlg.cpp:1816 src/muuli_wdr.cpp:3440
-msgid "Searches"
-msgstr "Buscas"
-
-#: src/amuleDlg.cpp:363 src/amuleDlg.cpp:1822 src/DownloadListCtrl.cpp:740
-#: src/muuli_wdr.cpp:392 src/muuli_wdr.cpp:1585 src/muuli_wdr.cpp:3441
-#: src/Statistics.cpp:829
-msgid "Downloads"
-msgstr "Descargas"
-
-#: src/amuleDlg.cpp:364 src/amuleDlg.cpp:1828 src/muuli_wdr.cpp:3315
-msgid "Shared files"
-msgstr "Ficheiros compartidos"
-
-#: src/amuleDlg.cpp:365 src/amuleDlg.cpp:1834 src/muuli_wdr.cpp:2947
-#: src/muuli_wdr.cpp:3397 src/muuli_wdr.cpp:3444
-msgid "Messages"
-msgstr "Mensaxes"
-
-#: src/amuleDlg.cpp:366 src/amuleDlg.cpp:1840 src/muuli_wdr.cpp:3445
-#: src/PrefsUnifiedDlg.cpp:314 src/Statistics.cpp:779 src/Statistics.cpp:1235
-msgid "Statistics"
-msgstr "Estadísticas"
-
-#: src/amuleDlg.cpp:368 src/amuleDlg.cpp:1847 src/muuli_wdr.cpp:3447
-#: src/PrefsUnifiedDlg.cpp:330 src/utils/wxCas/src/wxcasprefs.cpp:39
-msgid "Preferences"
-msgstr "Preferencias"
-
-#: src/amuleDlg.cpp:371
-msgid "Navigate"
-msgstr ""
-
-#: src/amuleDlg.cpp:657
+#: src/amuleDlg.cpp:592
 #, fuzzy
 msgid "New version available"
 msgstr "Non dispoñible"
 
-#: src/amuleDlg.cpp:661
+#: src/amuleDlg.cpp:596
 #, fuzzy, c-format
 msgid ""
 "A new version of aMule (%s) is available.\n"
@@ -665,184 +627,217 @@ msgid ""
 "Would you like to open the download page?"
 msgstr "Pode obter a última versión de aMule en https://github.com/amule-org/amule/releases/latest"
 
-#: src/amuleDlg.cpp:743
+#: src/amuleDlg.cpp:678
 msgid "aMule dialog destroyed"
 msgstr "Destruído o cadro de diálogo de aMule"
 
-#: src/amuleDlg.cpp:766 src/DataToText.cpp:68 src/IPFilter.cpp:547
+#: src/amuleDlg.cpp:701 src/DataToText.cpp:68 src/IPFilter.cpp:547
 msgid "Connecting"
 msgstr "Conectando"
 
-#: src/amuleDlg.cpp:958
+#: src/amuleDlg.cpp:893
 msgid "eD2k: Connecting"
 msgstr "eD2k: Conectando"
 
-#: src/amuleDlg.cpp:962
+#: src/amuleDlg.cpp:897
 msgid "eD2k: Disconnected"
 msgstr "eD2k: Desconectado"
 
-#: src/amuleDlg.cpp:968
+#: src/amuleDlg.cpp:903
 msgid "Kad: Firewalled"
 msgstr "Kad: Tras devasa"
 
-#: src/amuleDlg.cpp:972
+#: src/amuleDlg.cpp:907
 msgid "Kad: Connected"
 msgstr "Kad: Conectado"
 
-#: src/amuleDlg.cpp:977
+#: src/amuleDlg.cpp:912
 msgid "Kad: Connecting"
 msgstr "Kad: Conectando"
 
-#: src/amuleDlg.cpp:981
+#: src/amuleDlg.cpp:916
 msgid "Kad: Off"
 msgstr "Kad: Apagado"
 
-#: src/amuleDlg.cpp:1029 src/DownloadListCtrl.cpp:505
+#: src/amuleDlg.cpp:964 src/DownloadListCtrl.cpp:505
 #: src/DownloadListCtrl.cpp:749 src/FriendListCtrl.cpp:180
 #: src/muuli_wdr.cpp:731 src/muuli_wdr.cpp:782 src/muuli_wdr.cpp:846
-#: src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2252 src/muuli_wdr.cpp:2337
-#: src/muuli_wdr.cpp:3085 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
+#: src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2224 src/muuli_wdr.cpp:2309
+#: src/muuli_wdr.cpp:3057 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
 #: src/ServerListCtrl.cpp:606 src/TransferWnd.cpp:378
 #: src/utils/wxCas/src/wxcasprefs.cpp:235
 msgid "Cancel"
 msgstr "Cancelar"
 
-#: src/amuleDlg.cpp:1030
+#: src/amuleDlg.cpp:965
 msgid "Stop the current connection attempts"
 msgstr "Deter a tentativa actual de conexión"
 
-#: src/amuleDlg.cpp:1035 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976
-#: src/muuli_wdr.cpp:2475
+#: src/amuleDlg.cpp:970 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976
+#: src/muuli_wdr.cpp:2447
 msgid "Disconnect"
 msgstr "Desconectar"
 
-#: src/amuleDlg.cpp:1036
+#: src/amuleDlg.cpp:971
 msgid "Disconnect from the currently connected networks"
 msgstr "Desconectar das redes conectadas"
 
-#: src/amuleDlg.cpp:1041 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979
-#: src/muuli_wdr.cpp:2630 src/muuli_wdr.cpp:3082 src/muuli_wdr.cpp:3437
+#: src/amuleDlg.cpp:976 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979
+#: src/muuli_wdr.cpp:2602 src/muuli_wdr.cpp:3054 src/muuli_wdr.cpp:3409
 msgid "Connect"
 msgstr "Conectar"
 
-#: src/amuleDlg.cpp:1042
+#: src/amuleDlg.cpp:977
 msgid "Connect to the currently enabled networks"
 msgstr "Conectar ás redes activas"
 
-#: src/amuleDlg.cpp:1154
+#: src/amuleDlg.cpp:1089
 #, c-format
 msgid "Up: %.1f%s (%.1f) | Down: %.1f%s (%.1f)"
 msgstr "Enviado: %.1f%s (%.1f) | Descargado: %.1f%s (%.1f)"
 
-#: src/amuleDlg.cpp:1156 src/amuleDlg.cpp:1158 src/amuleDlg.cpp:1162
-#: src/amuleDlg.cpp:1164 src/amuleDlg.cpp:1175 src/amuleDlg.cpp:1177
+#: src/amuleDlg.cpp:1091 src/amuleDlg.cpp:1093 src/amuleDlg.cpp:1097
+#: src/amuleDlg.cpp:1099 src/amuleDlg.cpp:1110 src/amuleDlg.cpp:1112
 #: src/MuleTrayIcon.cpp:796 src/MuleTrayIcon.cpp:799
 msgid " MB/s"
 msgstr " MB/s"
 
-#: src/amuleDlg.cpp:1156 src/amuleDlg.cpp:1158 src/amuleDlg.cpp:1162
-#: src/amuleDlg.cpp:1164 src/amuleDlg.cpp:1175 src/amuleDlg.cpp:1177
+#: src/amuleDlg.cpp:1091 src/amuleDlg.cpp:1093 src/amuleDlg.cpp:1097
+#: src/amuleDlg.cpp:1099 src/amuleDlg.cpp:1110 src/amuleDlg.cpp:1112
 #: src/MuleTrayIcon.cpp:796 src/MuleTrayIcon.cpp:799
 #: src/utils/wxCas/src/wxcasframe.cpp:1041
 msgid " kB/s"
 msgstr " kB/s"
 
-#: src/amuleDlg.cpp:1161
+#: src/amuleDlg.cpp:1096
 #, c-format
 msgid "Up: %.1f%s | Down: %.1f%s"
 msgstr "Enviado: %.1f%s | Descargado: %.1f%s"
 
-#: src/amuleDlg.cpp:1193
+#: src/amuleDlg.cpp:1128
 #, c-format
 msgid "aMule (%s | Connected)"
 msgstr "aMule (%s | Conectado)"
 
-#: src/amuleDlg.cpp:1195
+#: src/amuleDlg.cpp:1130
 #, c-format
 msgid "aMule (%s | Disconnected)"
 msgstr "aMule (%s | Desconectado)"
 
-#: src/amuleDlg.cpp:1248
+#: src/amuleDlg.cpp:1183
 #, c-format
 msgid "Do you really want to exit %s?"
 msgstr "Desexar saír de %s?"
 
-#: src/amuleDlg.cpp:1250
+#: src/amuleDlg.cpp:1185
 msgid "Exit confirmation"
 msgstr "Confirmación da saída"
 
-#: src/amuleDlg.cpp:1613
+#: src/amuleDlg.cpp:1548
 msgid "Launch Command: "
 msgstr "Ordes de Arranque: "
 
-#: src/amuleDlg.cpp:1632 src/muuli_wdr.cpp:1972 src/Preferences.cpp:979
+#: src/amuleDlg.cpp:1567 src/muuli_wdr.cpp:1971 src/Preferences.cpp:951
 msgid "- default -"
 msgstr "- por omisión -"
 
-#: src/amuleDlg.cpp:1660
+#: src/amuleDlg.cpp:1595
 #, c-format
 msgid "Skin directory '%s' does not exist"
 msgstr "Non existe o directorio de temas «%s»"
 
-#: src/amuleDlg.cpp:1663
+#: src/amuleDlg.cpp:1598
 #, c-format
 msgid "WARNING: Unable to open skin file '%s' for read"
 msgstr "AVISO: Non se puido abrir o ficheiro de temas «%s» en modo lectura"
 
-#: src/amuleDlg.cpp:1814 src/muuli_wdr.cpp:3439
+#: src/amuleDlg.cpp:1722 src/amuleDlg.cpp:1968 src/muuli_wdr.cpp:1485
+#: src/muuli_wdr.cpp:3411
+msgid "Networks"
+msgstr "Redes"
+
+#: src/amuleDlg.cpp:1726 src/muuli_wdr.cpp:3411
 msgid "Networks Window"
 msgstr "Xanela de Redes"
 
-#: src/amuleDlg.cpp:1820 src/muuli_wdr.cpp:3440
+#: src/amuleDlg.cpp:1728 src/muuli_wdr.cpp:3412
+msgid "Searches"
+msgstr "Buscas"
+
+#: src/amuleDlg.cpp:1732 src/muuli_wdr.cpp:3412
 msgid "Searches Window"
 msgstr "Xanela de buscas"
 
-#: src/amuleDlg.cpp:1826 src/muuli_wdr.cpp:3441
+#: src/amuleDlg.cpp:1734 src/DownloadListCtrl.cpp:740 src/muuli_wdr.cpp:392
+#: src/muuli_wdr.cpp:1578 src/muuli_wdr.cpp:3413 src/Statistics.cpp:829
+msgid "Downloads"
+msgstr "Descargas"
+
+#: src/amuleDlg.cpp:1738 src/muuli_wdr.cpp:3413
 msgid "Downloads Window"
 msgstr "Xanela de descargas"
 
-#: src/amuleDlg.cpp:1832 src/muuli_wdr.cpp:3443
+#: src/amuleDlg.cpp:1740 src/muuli_wdr.cpp:3287
+msgid "Shared files"
+msgstr "Ficheiros compartidos"
+
+#: src/amuleDlg.cpp:1744 src/muuli_wdr.cpp:3415
 msgid "Shared Files Window"
 msgstr "Xanela de ficheiros compartidos"
 
-#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3444
+#: src/amuleDlg.cpp:1746 src/muuli_wdr.cpp:2919 src/muuli_wdr.cpp:3369
+#: src/muuli_wdr.cpp:3416
+msgid "Messages"
+msgstr "Mensaxes"
+
+#: src/amuleDlg.cpp:1750 src/muuli_wdr.cpp:3416
 msgid "Messages Window"
 msgstr "Xanela de mensaxes"
 
-#: src/amuleDlg.cpp:1844 src/muuli_wdr.cpp:3445
+#: src/amuleDlg.cpp:1752 src/muuli_wdr.cpp:3417 src/PrefsUnifiedDlg.cpp:312
+#: src/Statistics.cpp:779 src/Statistics.cpp:1235
+msgid "Statistics"
+msgstr "Estadísticas"
+
+#: src/amuleDlg.cpp:1756 src/muuli_wdr.cpp:3417
 msgid "Statistics Graph Window"
 msgstr "Xanela de gráficos de estadísticas"
 
-#: src/amuleDlg.cpp:1851 src/muuli_wdr.cpp:3447
+#: src/amuleDlg.cpp:1759 src/muuli_wdr.cpp:3419 src/PrefsUnifiedDlg.cpp:328
+#: src/utils/wxCas/src/wxcasprefs.cpp:39
+msgid "Preferences"
+msgstr "Preferencias"
+
+#: src/amuleDlg.cpp:1763 src/muuli_wdr.cpp:3419
 msgid "Preferences Settings Window"
 msgstr "Xanela de Preferencias"
 
-#: src/amuleDlg.cpp:1854 src/muuli_wdr.cpp:3448
+#: src/amuleDlg.cpp:1766 src/muuli_wdr.cpp:3420
 msgid "Import"
 msgstr "Importar"
 
-#: src/amuleDlg.cpp:1858 src/muuli_wdr.cpp:3448
+#: src/amuleDlg.cpp:1770 src/muuli_wdr.cpp:3420
 msgid "The partfile importer tool"
 msgstr "A ferramenta para importar ficheiros «part»"
 
-#: src/amuleDlg.cpp:1861 src/muuli_wdr.cpp:3449
+#: src/amuleDlg.cpp:1773 src/muuli_wdr.cpp:3421
 #: src/utils/aLinkCreator/src/alcframe.cpp:262
 msgid "About"
 msgstr "Sobre"
 
-#: src/amuleDlg.cpp:1861 src/muuli_wdr.cpp:3449
+#: src/amuleDlg.cpp:1773 src/muuli_wdr.cpp:3421
 msgid "About/Help"
 msgstr "Sobre/Axuda"
 
-#: src/amuleDlg.cpp:2059
+#: src/amuleDlg.cpp:1971
 msgid "eD2k network"
 msgstr "Rede eD2k"
 
-#: src/amuleDlg.cpp:2062
+#: src/amuleDlg.cpp:1974
 msgid "Kad network"
 msgstr "Red Kad"
 
-#: src/amuleDlg.cpp:2062
+#: src/amuleDlg.cpp:1974
 msgid "No network"
 msgstr "Sen rede"
 
@@ -974,7 +969,7 @@ msgstr "Ficheiro non atopado."
 msgid "The core rejected these shared folders:%s"
 msgstr ""
 
-#: src/amule-remote-gui.cpp:1336 src/ExternalConn.cpp:2346
+#: src/amule-remote-gui.cpp:1336 src/ExternalConn.cpp:2345
 msgid "Invalid link or already on list."
 msgstr "Ligazón inválida ou xa presente na lista."
 
@@ -990,7 +985,7 @@ msgstr "Non se puido crear o directorio «%s» para a categoría «%s», mantend
 #: src/ClientDetailDialog.cpp:123 src/DataToText.cpp:61 src/DataToText.cpp:86
 #: src/DataToText.cpp:101 src/DataToText.cpp:136 src/DataToText.cpp:165
 #: src/DownloadListCtrl.cpp:1172 src/DownloadListCtrl.cpp:1185
-#: src/DownloadListCtrl.cpp:1196 src/ExternalConn.cpp:609
+#: src/DownloadListCtrl.cpp:1196 src/ExternalConn.cpp:608
 #: src/FileDetailDialog.cpp:203 src/FileDetailDialog.cpp:235
 #: src/FileDetailDialog.cpp:242 src/GenericClientListCtrl.cpp:1171
 #: src/GenericClientListCtrl.cpp:1182 src/GenericClientListCtrl.cpp:1192
@@ -1377,19 +1372,19 @@ msgstr "Auto [Al]"
 msgid "Very low"
 msgstr "Moi baixa"
 
-#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:743 src/muuli_wdr.cpp:2303
+#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:743 src/muuli_wdr.cpp:2275
 #: src/ServerListCtrl.cpp:263 src/ServerListCtrl.cpp:456
 #: src/SharedFilesCtrl.cpp:145
 msgid "Low"
 msgstr "Baixa"
 
-#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:744 src/muuli_wdr.cpp:2304
+#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:744 src/muuli_wdr.cpp:2276
 #: src/ServerListCtrl.cpp:266 src/ServerListCtrl.cpp:457
 #: src/SharedFilesCtrl.cpp:146
 msgid "Normal"
 msgstr "Normal"
 
-#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:745 src/muuli_wdr.cpp:2305
+#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:745 src/muuli_wdr.cpp:2277
 #: src/ServerListCtrl.cpp:269 src/ServerListCtrl.cpp:458
 #: src/SharedFilesCtrl.cpp:147
 msgid "High"
@@ -1481,8 +1476,8 @@ msgstr "Servidor local"
 msgid "Remote Server"
 msgstr "Servidor remoto"
 
-#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3202
-#: src/SearchDlg.cpp:119 src/TextClient.cpp:911
+#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3174
+#: src/SearchDlg.cpp:111 src/TextClient.cpp:911
 msgid "Kad"
 msgstr "Kad"
 
@@ -1552,7 +1547,7 @@ msgstr "Parte"
 msgid "Size"
 msgstr "Tamaño"
 
-#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3269
+#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3241
 msgid "Transferred"
 msgstr "Transferido"
 
@@ -1610,7 +1605,7 @@ msgstr ""
 "Comentarios de : %s (%s)\n"
 "\n"
 
-#: src/DownloadListCtrl.cpp:746 src/muuli_wdr.cpp:2306
+#: src/DownloadListCtrl.cpp:746 src/muuli_wdr.cpp:2278
 #: src/SharedFilesCtrl.cpp:150
 msgid "Auto"
 msgstr "Automático"
@@ -1648,7 +1643,7 @@ msgid "Extended Options"
 msgstr "Opcións extendidas"
 
 #: src/DownloadListCtrl.cpp:770 src/DownloadListCtrl.cpp:822
-#: src/muuli_wdr.cpp:1790
+#: src/muuli_wdr.cpp:1789
 msgid "Preview"
 msgstr "Previsualizar"
 
@@ -1823,230 +1818,225 @@ msgstr[1] "Non se puideron engadir as ligazóns %u (consulte o rexistro)."
 msgid "Invalid eD2k link! ERROR: %s"
 msgstr "Ligazón eD2k inválida! ERRO: %s"
 
-#: src/ExternalConn.cpp:380
+#: src/ExternalConn.cpp:379
 msgid "Client sent packet after authentication failed."
 msgstr "O cliente enviou un paquete despois de que fallara a identificación."
 
-#: src/ExternalConn.cpp:397
+#: src/ExternalConn.cpp:396
 msgid "External connection closed."
 msgstr "Conexión externa pechada."
 
-#: src/ExternalConn.cpp:474
+#: src/ExternalConn.cpp:473
 msgid "External connections disabled due to empty password!"
 msgstr "Conexións externas desactivadas por mor dun contrasinal baleiro!"
 
-#: src/ExternalConn.cpp:495
+#: src/ExternalConn.cpp:494
 msgid "External connections disabled in config file"
 msgstr "Conexións externas desactivadas no ficheiro de configuración"
 
-#: src/ExternalConn.cpp:576
+#: src/ExternalConn.cpp:575
 msgid "New external connection accepted"
 msgstr "Nova conexión externa aceptada"
 
-#: src/ExternalConn.cpp:579
+#: src/ExternalConn.cpp:578
 msgid "ERROR: couldn't accept a new external connection"
 msgstr "ERRO: non se puido aceptar unha nova conexión externa"
 
-#: src/ExternalConn.cpp:596
+#: src/ExternalConn.cpp:595
 msgid "External connection refused due to empty password in preferences!"
 msgstr "Conexións externas desactivadas por mor dun contrasinal baleiro nas preferencias!"
 
-#: src/ExternalConn.cpp:608
+#: src/ExternalConn.cpp:607
 #, c-format
 msgid "Connecting client: %s %s"
 msgstr "Conectando ao cliente: %s %s"
 
-#: src/ExternalConn.cpp:610
+#: src/ExternalConn.cpp:609
 msgid "Unknown version"
 msgstr "Versión descoñecida"
 
-#: src/ExternalConn.cpp:623
+#: src/ExternalConn.cpp:622
 msgid "Incorrect EC version ID, there might be binary incompatibility. Use core and remote from same snapshot."
 msgstr "CE incorrecto na ID de versión, os programas non son compatibles. Use a mesma versión para o núcleo e para o remoto."
 
-#: src/ExternalConn.cpp:631
+#: src/ExternalConn.cpp:630
 msgid "You cannot connect to a release version from an arbitrary development snapshot! *sigh* possible crash prevented"
 msgstr "Non se pode conectar a una versión estable dende una versión de desenvolvemento calquera! Evitada posible fallo do programa"
 
-#: src/ExternalConn.cpp:714
+#: src/ExternalConn.cpp:713
 msgid "Invalid protocol version."
 msgstr "Versión do protocolo inválida."
 
-#: src/ExternalConn.cpp:720
+#: src/ExternalConn.cpp:719
 msgid "Missing protocol version tag."
 msgstr "Marcador da versión do protocolo inexistente."
 
-#: src/ExternalConn.cpp:728
+#: src/ExternalConn.cpp:727
 msgid "Authentication failed: invalid hash specified as EC password."
 msgstr "Fallou a identificación: o resumo criptográfico (hash) usado coma contrasinal CE é inválido."
 
-#: src/ExternalConn.cpp:776
+#: src/ExternalConn.cpp:775
 msgid "Authentication failed: wrong password."
 msgstr "Fallou a identificación: contrasinal erróneo."
 
-#: src/ExternalConn.cpp:778
+#: src/ExternalConn.cpp:777
 msgid "Authentication failed: missing password."
 msgstr "Fallou a identificación: falta o contrasinal."
 
-#: src/ExternalConn.cpp:789
+#: src/ExternalConn.cpp:788
 msgid "Invalid request, please authenticate first."
 msgstr "Petición inválida, primeiro identifíquese."
 
-#: src/ExternalConn.cpp:794
+#: src/ExternalConn.cpp:793
 msgid "Access granted."
 msgstr "Acceso concedido."
 
-#: src/ExternalConn.cpp:802
+#: src/ExternalConn.cpp:801
 #, c-format
 msgid "Sent error message \"%s\" to client."
 msgstr "Enviando mensaxe «%s» ao cliente."
 
-#: src/ExternalConn.cpp:807
+#: src/ExternalConn.cpp:806
 #, c-format
 msgid "Unauthorized access attempt from %s. Connection closed."
 msgstr "Intento de acceso non autorizado dende %s. Conexión pechada."
 
-#: src/ExternalConn.cpp:1420
+#: src/ExternalConn.cpp:1419
 #, c-format
 msgid "Remote PartFile command failed: FileHash not found: %s"
 msgstr "Fallou a orde PartFile remota: FileHash non atopado: %s"
 
-#: src/ExternalConn.cpp:1424
+#: src/ExternalConn.cpp:1423
 #, c-format
 msgid "FileHash not found: %s"
 msgstr "FileHash non atopado: %s"
 
-#: src/ExternalConn.cpp:1471 src/ExternalConn.cpp:1559
-#: src/ExternalConn.cpp:1680
+#: src/ExternalConn.cpp:1470 src/ExternalConn.cpp:1558
+#: src/ExternalConn.cpp:1679
 msgid "OOPS! OpCode processing error!"
 msgstr "OOPS! Erro ao procesar o OpCode!"
 
-#: src/ExternalConn.cpp:1502
+#: src/ExternalConn.cpp:1501
 msgid "Server not added"
 msgstr "Servidor non engadido"
 
-#: src/ExternalConn.cpp:1521
+#: src/ExternalConn.cpp:1520
 #, c-format
 msgid "server not found: %s"
 msgstr "servidor non atopado: %s"
 
-#: src/ExternalConn.cpp:1538
+#: src/ExternalConn.cpp:1537
 msgid "need to define server to be removed"
 msgstr "necesita definir o servidor que quere eliminar"
 
-#: src/ExternalConn.cpp:1553
+#: src/ExternalConn.cpp:1552
 msgid "eD2k is disabled in preferences."
 msgstr "eD2k está desactivado nas preferencias."
 
-#: src/ExternalConn.cpp:1658
+#: src/ExternalConn.cpp:1657
 msgid "Friend not found."
 msgstr "Non se atopou o amigo."
 
-#: src/ExternalConn.cpp:1668
+#: src/ExternalConn.cpp:1667
 msgid "Client not found."
 msgstr "Non se atopou o ficheiro."
 
-#: src/ExternalConn.cpp:1674
+#: src/ExternalConn.cpp:1673
 msgid "EC_TAG_FRIEND_SHARED requires EC_TAG_FRIEND or EC_TAG_CLIENT."
 msgstr "EC_TAG_FRIEND_SHARED precisa de EC_TAG_FRIEND ou EC_TAG_CLIENT."
 
-#: src/ExternalConn.cpp:1992
+#: src/ExternalConn.cpp:1991
 msgid "WebSearch from remote interface makes no sense."
 msgstr "Non ten sentido usar WebSearch dende unha interface remota."
 
-#: src/ExternalConn.cpp:2027
+#: src/ExternalConn.cpp:2026
 msgid "Search in progress. Refetch results in a moment!"
 msgstr "Busca en progreso. Obterá os resultado nun intre!"
 
-#: src/ExternalConn.cpp:2266
+#: src/ExternalConn.cpp:2265
 msgid "No points for graph."
 msgstr "Sen puntos para a gráfica."
 
-#: src/ExternalConn.cpp:2276
+#: src/ExternalConn.cpp:2275
 msgid "Your client is not configured for this detail level."
 msgstr "O seu cliente non está configurado para este nivel de detalle."
 
-#: src/ExternalConn.cpp:2303
+#: src/ExternalConn.cpp:2302
 msgid "External Connection: shutdown requested"
 msgstr "Conexión externa: apagado solicitado"
 
-#: src/ExternalConn.cpp:2315
+#: src/ExternalConn.cpp:2314
 msgid "Already shutting down."
 msgstr "Xa se está apagando."
 
-#: src/ExternalConn.cpp:2333
+#: src/ExternalConn.cpp:2332
 #, c-format
 msgid "ExternalConn: adding link '%s'."
 msgstr "Conexión externa: engadinda ligazón «%s»."
 
-#: src/ExternalConn.cpp:2351
+#: src/ExternalConn.cpp:2350
 #, c-format
 msgid "%d of %d links failed (invalid or already on list)."
 msgstr "Fallaron %d de %d ligazóns (por non valer ou xa estar na lista)."
 
-#: src/ExternalConn.cpp:2374
+#: src/ExternalConn.cpp:2373
 msgid "Version check throttled; try again shortly."
 msgstr ""
 
-#: src/ExternalConn.cpp:2379
+#: src/ExternalConn.cpp:2378
 msgid "Version check is not available on this daemon."
 msgstr ""
 
-#: src/ExternalConn.cpp:2509
+#: src/ExternalConn.cpp:2508
 msgid "File not found."
 msgstr "Ficheiro non atopado."
 
-#: src/ExternalConn.cpp:2514
+#: src/ExternalConn.cpp:2513
 msgid "Invalid file name."
 msgstr "Nome de ficheiro inválido."
 
-#: src/ExternalConn.cpp:2522
+#: src/ExternalConn.cpp:2521
 msgid "Unable to rename file."
 msgstr "Imposible cambiarlle o nome ao ficheiro."
 
-#: src/ExternalConn.cpp:2839
-#, c-format
-msgid "Could not save the amuleapi password: %s"
-msgstr ""
-
-#: src/ExternalConn.cpp:3004 src/ExternalConn.cpp:3032
+#: src/ExternalConn.cpp:2992 src/ExternalConn.cpp:3020
 msgid "Kad is disabled in preferences."
 msgstr "Kad está desactivado nas preferencias."
 
-#: src/ExternalConn.cpp:3045
+#: src/ExternalConn.cpp:3033
 msgid "Already connected to eD2k."
 msgstr "Xa está conectado ao eD2k."
 
-#: src/ExternalConn.cpp:3048
+#: src/ExternalConn.cpp:3036
 msgid "Connecting to eD2k..."
 msgstr "Conectando ao eD2k..."
 
-#: src/ExternalConn.cpp:3057
+#: src/ExternalConn.cpp:3045
 msgid "Already connected to Kad."
 msgstr "Xa está conectado a Kad."
 
-#: src/ExternalConn.cpp:3060
+#: src/ExternalConn.cpp:3048
 msgid "Connecting to Kad..."
 msgstr "Conectando a Kad..."
 
-#: src/ExternalConn.cpp:3067
+#: src/ExternalConn.cpp:3055
 msgid "All networks are disabled."
 msgstr "Tódalas redes están desactivadas."
 
-#: src/ExternalConn.cpp:3076
+#: src/ExternalConn.cpp:3064
 msgid "Disconnected from eD2k."
 msgstr "Desconectado do eD2k."
 
-#: src/ExternalConn.cpp:3081
+#: src/ExternalConn.cpp:3069
 msgid "Disconnected from Kad."
 msgstr "Desconectado de Kad."
 
-#: src/ExternalConn.cpp:3090
+#: src/ExternalConn.cpp:3078
 #, c-format
 msgid "External Connection: invalid opcode received: %#x"
 msgstr "Conexión externa: recibido código de operación inválido: %#x"
 
-#: src/ExternalConn.cpp:3095
+#: src/ExternalConn.cpp:3083
 msgid "Invalid opcode (wrong protocol version?)"
 msgstr "Opcode inválido (versión do protocolo inválida?)"
 
@@ -2362,19 +2352,19 @@ msgstr ""
 msgid "eD2k"
 msgstr "eD2k"
 
-#: src/FirstRunWizard.cpp:349 src/muuli_wdr.cpp:1495
+#: src/FirstRunWizard.cpp:349 src/muuli_wdr.cpp:1488
 msgid "Kademlia"
 msgstr "Kademlia"
 
-#: src/FirstRunWizard.cpp:359 src/muuli_wdr.cpp:1423
+#: src/FirstRunWizard.cpp:359 src/muuli_wdr.cpp:1416
 msgid "Standard TCP Port "
 msgstr "Porto TCP normativizado "
 
-#: src/FirstRunWizard.cpp:365 src/muuli_wdr.cpp:1435
+#: src/FirstRunWizard.cpp:365 src/muuli_wdr.cpp:1428
 msgid "Extended UDP port (Kad / global search) "
 msgstr "Porto UDP ampliado (Kad / busca global) "
 
-#: src/FirstRunWizard.cpp:377 src/muuli_wdr.cpp:1442
+#: src/FirstRunWizard.cpp:377 src/muuli_wdr.cpp:1435
 msgid "Enable UPnP for router port forwarding"
 msgstr "Activar UPnP para configurar os portos no encamiñador"
 
@@ -2401,7 +2391,7 @@ msgstr ""
 msgid "Your peer lists are already in place - nothing to download."
 msgstr "O ficheiro %s xa se está descargando"
 
-#: src/FirstRunWizard.cpp:434 src/muuli_wdr.cpp:1540
+#: src/FirstRunWizard.cpp:434 src/muuli_wdr.cpp:1533
 msgid "Auto-update server list at startup"
 msgstr "Actualizar automáticamente a lista de servidores no arranque"
 
@@ -2447,23 +2437,23 @@ msgid ""
 "want downloads on a different (e.g. larger) disk."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:549 src/FirstRunWizard.cpp:611 src/muuli_wdr.cpp:1702
+#: src/FirstRunWizard.cpp:549 src/FirstRunWizard.cpp:611 src/muuli_wdr.cpp:1701
 msgid "Destination folder for downloads"
 msgstr "Cartafol de destino para descargas"
 
-#: src/FirstRunWizard.cpp:553 src/FirstRunWizard.cpp:569 src/muuli_wdr.cpp:1349
-#: src/muuli_wdr.cpp:1366 src/muuli_wdr.cpp:1677 src/muuli_wdr.cpp:1708
-#: src/muuli_wdr.cpp:1720 src/muuli_wdr.cpp:2790
+#: src/FirstRunWizard.cpp:553 src/FirstRunWizard.cpp:569 src/muuli_wdr.cpp:1342
+#: src/muuli_wdr.cpp:1359 src/muuli_wdr.cpp:1676 src/muuli_wdr.cpp:1707
+#: src/muuli_wdr.cpp:1719 src/muuli_wdr.cpp:2762
 #: src/utils/aLinkCreator/src/alcframe.cpp:135
 #: src/utils/wxCas/src/wxcasprefs.cpp:52 src/utils/wxCas/src/wxcasprefs.cpp:118
 msgid "Browse"
 msgstr "Navegador"
 
-#: src/FirstRunWizard.cpp:559 src/muuli_wdr.cpp:1713
+#: src/FirstRunWizard.cpp:559 src/muuli_wdr.cpp:1712
 msgid "(All files in this folder are shared with other peers)"
 msgstr "(Compartiranse todos os ficheiros do cartafol co resto de parceiros)"
 
-#: src/FirstRunWizard.cpp:565 src/FirstRunWizard.cpp:624 src/muuli_wdr.cpp:1715
+#: src/FirstRunWizard.cpp:565 src/FirstRunWizard.cpp:624 src/muuli_wdr.cpp:1714
 msgid "Folder for temporary download files"
 msgstr "Cartafol para ficheiros de descarga temporais"
 
@@ -2494,7 +2484,7 @@ msgstr "Non se puido escribir a lista de amigos ao ficheiro «emfriends.met»!"
 msgid "CRITICAL - no client on StartChatSession"
 msgstr "CRÍTICO - non hai cliente en StartChatSession"
 
-#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2696 src/muuli_wdr.cpp:3373
+#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2668 src/muuli_wdr.cpp:3345
 msgid "Friends"
 msgstr "Amigos"
 
@@ -2604,8 +2594,8 @@ msgstr "Ningún"
 msgid "No"
 msgstr "Non"
 
-#: src/GenericClientListCtrl.cpp:1216 src/PrefsUnifiedDlg.cpp:2898
-#: src/PrefsUnifiedDlg.cpp:2948 src/ServerListCtrl.cpp:276
+#: src/GenericClientListCtrl.cpp:1216 src/PrefsUnifiedDlg.cpp:2818
+#: src/PrefsUnifiedDlg.cpp:2868 src/ServerListCtrl.cpp:276
 msgid "Yes"
 msgstr "Si"
 
@@ -2774,10 +2764,10 @@ msgstr "Porto inválido para o arranque"
 msgid "Please fill all fields required"
 msgstr "Enche todos os campos requiridos"
 
-#: src/KadDlg.cpp:192 src/PartFile.cpp:1031 src/PrefsUnifiedDlg.cpp:1134
-#: src/PrefsUnifiedDlg.cpp:1204 src/PrefsUnifiedDlg.cpp:1405
-#: src/PrefsUnifiedDlg.cpp:1663 src/PrefsUnifiedDlg.cpp:1673
-#: src/PrefsUnifiedDlg.cpp:1690 src/PrefsUnifiedDlg.cpp:1738
+#: src/KadDlg.cpp:192 src/PartFile.cpp:1031 src/PrefsUnifiedDlg.cpp:1162
+#: src/PrefsUnifiedDlg.cpp:1331 src/PrefsUnifiedDlg.cpp:1589
+#: src/PrefsUnifiedDlg.cpp:1599 src/PrefsUnifiedDlg.cpp:1616
+#: src/PrefsUnifiedDlg.cpp:1658
 msgid "Message"
 msgstr "Mensaxe"
 
@@ -2879,7 +2869,7 @@ msgstr "Relación enviado/descargado"
 msgid "Uploaded"
 msgstr "Enviado"
 
-#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3253
+#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3225
 msgid "Requested"
 msgstr "Solicitado"
 
@@ -3003,7 +2993,7 @@ msgid "WARNING: "
 msgstr "AVISO: "
 
 #: src/MuleNotebook.cpp:179 src/muuli_wdr.cpp:817 src/muuli_wdr.cpp:1229
-#: src/muuli_wdr.cpp:3157 src/muuli_wdr.cpp:3413
+#: src/muuli_wdr.cpp:3129 src/muuli_wdr.cpp:3385
 msgid "Close"
 msgstr "Pechar"
 
@@ -3016,12 +3006,12 @@ msgstr "Cortar"
 msgid "Copy"
 msgstr "Copiar"
 
-#: src/MuleTextCtrl.cpp:88 src/SearchDlg.cpp:261
+#: src/MuleTextCtrl.cpp:88
 msgid "Paste"
 msgstr "Pegar"
 
 #: src/MuleTextCtrl.cpp:89 src/muuli_wdr.cpp:358 src/muuli_wdr.cpp:757
-#: src/muuli_wdr.cpp:2380 src/muuli_wdr.cpp:2399 src/muuli_wdr.cpp:2421
+#: src/muuli_wdr.cpp:2352 src/muuli_wdr.cpp:2371 src/muuli_wdr.cpp:2393
 #: src/utils/aLinkCreator/src/alcframe.cpp:142
 msgid "Clear"
 msgstr "Limpar"
@@ -3112,8 +3102,8 @@ msgid "Exit"
 msgstr "Saír"
 
 #: src/MuleTrayIcon.cpp:579 src/MuleTrayIcon.cpp:945 src/MuleTrayIcon.cpp:965
-#: src/muuli_wdr.cpp:1398 src/muuli_wdr.cpp:1406 src/muuli_wdr.cpp:1413
-#: src/muuli_wdr.cpp:1836 src/muuli_wdr.cpp:1842 src/OtherFunctions.cpp:91
+#: src/muuli_wdr.cpp:1391 src/muuli_wdr.cpp:1399 src/muuli_wdr.cpp:1406
+#: src/muuli_wdr.cpp:1835 src/muuli_wdr.cpp:1841 src/OtherFunctions.cpp:91
 #: src/StatisticsDlg.cpp:93 src/StatisticsDlg.cpp:95
 msgid "kB/s"
 msgstr "kB/s"
@@ -3284,7 +3274,7 @@ msgstr "Nome:"
 msgid "Type"
 msgstr "Tipo"
 
-#: src/muuli_wdr.cpp:215 src/SearchDlg.cpp:118 src/SearchListCtrl.cpp:853
+#: src/muuli_wdr.cpp:215 src/SearchDlg.cpp:110 src/SearchListCtrl.cpp:853
 msgid "Local"
 msgstr "Local"
 
@@ -3355,7 +3345,7 @@ msgstr "Octetos"
 msgid "KB"
 msgstr "KB"
 
-#: src/muuli_wdr.cpp:274 src/muuli_wdr.cpp:293 src/muuli_wdr.cpp:1621
+#: src/muuli_wdr.cpp:274 src/muuli_wdr.cpp:293 src/muuli_wdr.cpp:1620
 #: src/OtherFunctions.cpp:64
 msgid "MB"
 msgstr "MB"
@@ -3372,7 +3362,7 @@ msgstr "Tamaño máximo"
 msgid "Availability"
 msgstr "Dispoñibilidade"
 
-#: src/muuli_wdr.cpp:312 src/muuli_wdr.cpp:398 src/muuli_wdr.cpp:3318
+#: src/muuli_wdr.cpp:312 src/muuli_wdr.cpp:398 src/muuli_wdr.cpp:3290
 msgid "Filter:"
 msgstr "Filtrado:"
 
@@ -3404,7 +3394,7 @@ msgstr "Solicitar que os clientes Kad contactados estendan a busca. Cada pulsaci
 msgid "Stop"
 msgstr "Deter"
 
-#: src/muuli_wdr.cpp:348 src/muuli_wdr.cpp:1392 src/SearchListCtrl.cpp:732
+#: src/muuli_wdr.cpp:348 src/muuli_wdr.cpp:1385 src/SearchListCtrl.cpp:732
 msgid "Download"
 msgstr "Descargar"
 
@@ -3435,12 +3425,12 @@ msgstr "Fontes do ficheiro:"
 #: src/muuli_wdr.cpp:1160 src/muuli_wdr.cpp:1167 src/muuli_wdr.cpp:1172
 #: src/muuli_wdr.cpp:1179 src/muuli_wdr.cpp:1184 src/muuli_wdr.cpp:1191
 #: src/muuli_wdr.cpp:1205 src/muuli_wdr.cpp:1212 src/muuli_wdr.cpp:1217
-#: src/muuli_wdr.cpp:1224 src/muuli_wdr.cpp:3255 src/muuli_wdr.cpp:3263
-#: src/muuli_wdr.cpp:3271
+#: src/muuli_wdr.cpp:1224 src/muuli_wdr.cpp:3227 src/muuli_wdr.cpp:3235
+#: src/muuli_wdr.cpp:3243
 msgid "N/A"
 msgstr "N/A"
 
-#: src/muuli_wdr.cpp:508 src/muuli_wdr.cpp:1065 src/PrefsUnifiedDlg.cpp:299
+#: src/muuli_wdr.cpp:508 src/muuli_wdr.cpp:1065 src/PrefsUnifiedDlg.cpp:297
 msgid "General"
 msgstr "Xeral"
 
@@ -3581,7 +3571,7 @@ msgstr ""
 msgid "Album :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:685 src/muuli_wdr.cpp:2275
+#: src/muuli_wdr.cpp:685 src/muuli_wdr.cpp:2247
 msgid "Title :"
 msgstr "Título :"
 
@@ -3690,7 +3680,7 @@ msgstr "Nome de usuario :"
 msgid "Userhash :"
 msgstr "Hash do usuario :"
 
-#: src/muuli_wdr.cpp:895 src/muuli_wdr.cpp:1742 src/muuli_wdr.cpp:2470
+#: src/muuli_wdr.cpp:895 src/muuli_wdr.cpp:1741 src/muuli_wdr.cpp:2442
 #: src/utils/aLinkCreator/src/alcframe.cpp:137
 msgid "Add"
 msgstr "Engadir"
@@ -3699,15 +3689,15 @@ msgstr "Engadir"
 msgid "Download-Speed"
 msgstr "Velocidade de descarga"
 
-#: src/muuli_wdr.cpp:954 src/muuli_wdr.cpp:989 src/muuli_wdr.cpp:2574
+#: src/muuli_wdr.cpp:954 src/muuli_wdr.cpp:989 src/muuli_wdr.cpp:2546
 msgid "Current"
 msgstr "Actual"
 
-#: src/muuli_wdr.cpp:962 src/muuli_wdr.cpp:997 src/muuli_wdr.cpp:2582
+#: src/muuli_wdr.cpp:962 src/muuli_wdr.cpp:997 src/muuli_wdr.cpp:2554
 msgid "Running average"
 msgstr "Media de execución"
 
-#: src/muuli_wdr.cpp:970 src/muuli_wdr.cpp:1005 src/muuli_wdr.cpp:2590
+#: src/muuli_wdr.cpp:970 src/muuli_wdr.cpp:1005 src/muuli_wdr.cpp:2562
 msgid "Session average"
 msgstr "Media de sesión"
 
@@ -3719,7 +3709,7 @@ msgstr "Velocidade de envío"
 msgid "Connections"
 msgstr "Conexións"
 
-#: src/muuli_wdr.cpp:1024 src/muuli_wdr.cpp:1861
+#: src/muuli_wdr.cpp:1024 src/muuli_wdr.cpp:1860
 msgid "Active downloads"
 msgstr "Descargas activas"
 
@@ -3727,7 +3717,7 @@ msgstr "Descargas activas"
 msgid "Active connections (1:1)"
 msgstr "Conexións activas (1:1)"
 
-#: src/muuli_wdr.cpp:1040 src/muuli_wdr.cpp:1862
+#: src/muuli_wdr.cpp:1040 src/muuli_wdr.cpp:1861
 msgid "Active uploads"
 msgstr "Envíos activos"
 
@@ -3843,8 +3833,8 @@ msgstr "Este é o nome que os outros usuarios verán cando se conecten a vostede
 msgid "Language: "
 msgstr "Idioma: "
 
-#: src/muuli_wdr.cpp:1257 src/muuli_wdr.cpp:1330 src/muuli_wdr.cpp:1334
-#: src/muuli_wdr.cpp:1337
+#: src/muuli_wdr.cpp:1257 src/muuli_wdr.cpp:1323 src/muuli_wdr.cpp:1327
+#: src/muuli_wdr.cpp:1330
 msgid "The delay before showing tool-tips."
 msgstr "O retardo antes de mostrar as mensaxes emerxentes."
 
@@ -3922,261 +3912,260 @@ msgstr "Amosar unha notificación ao rematar a descarga"
 msgid "Enabling this will make aMule to show notifications when finished downloading."
 msgstr "Activando isto aMule avisaralle cando remate a descarga."
 
-#: src/muuli_wdr.cpp:1323
-#, fuzzy
-msgid "Remember search history"
-msgstr "Recordar esas opcións"
-
-#: src/muuli_wdr.cpp:1324
-msgid "Keeps a dropdown list of your past search terms in the Search tab's Name field. This remembers the queries you typed, not the results they returned."
-msgstr ""
-
-#: src/muuli_wdr.cpp:1329
+#: src/muuli_wdr.cpp:1322
 msgid "Tooltip delay time: "
 msgstr "Retardo da información sobre as ferramentas: "
 
-#: src/muuli_wdr.cpp:1336
+#: src/muuli_wdr.cpp:1329
 msgid "seconds"
 msgstr "segundos"
 
-#: src/muuli_wdr.cpp:1340
+#: src/muuli_wdr.cpp:1333
 msgid "Browser Selection"
 msgstr "Selección de navegador"
 
-#: src/muuli_wdr.cpp:1346
+#: src/muuli_wdr.cpp:1339
 msgid "Enter your browser name here. Leave this field empty to use the system default browser."
 msgstr "Introduza o nome do seu navegador aquí. Deixe o campo baleiro para empregar o navegador predeterminado do sistema."
 
-#: src/muuli_wdr.cpp:1353
+#: src/muuli_wdr.cpp:1346
 msgid "Open in new tab if possible"
 msgstr "Abrir nunha nova lapela se é posible"
 
-#: src/muuli_wdr.cpp:1355
+#: src/muuli_wdr.cpp:1348
 msgid "Open the web page in a new tab instead of in a new window when possible"
 msgstr "Abrir as páxinas web nunha nova solapa, en lugar de nunha nova xanela"
 
-#: src/muuli_wdr.cpp:1359
+#: src/muuli_wdr.cpp:1352
 msgid "Video Player"
 msgstr "Reprodutor de vídeo"
 
-#: src/muuli_wdr.cpp:1386
+#: src/muuli_wdr.cpp:1379
 msgid "Bandwidth limits"
 msgstr "Límites de ancho de banda"
 
-#: src/muuli_wdr.cpp:1400
+#: src/muuli_wdr.cpp:1393
 msgid "Upload"
 msgstr "Enviar"
 
-#: src/muuli_wdr.cpp:1408
+#: src/muuli_wdr.cpp:1401
 msgid "Slot Allocation"
 msgstr "Asignación de ocos"
 
-#: src/muuli_wdr.cpp:1417
+#: src/muuli_wdr.cpp:1410
 msgid "Ports"
 msgstr "Portos"
 
-#: src/muuli_wdr.cpp:1427
+#: src/muuli_wdr.cpp:1420
 msgid "This is the standard eD2k port and cannot be disabled."
 msgstr "Este é o porto eD2k normativizado e non se pode desactivar."
 
-#: src/muuli_wdr.cpp:1430
+#: src/muuli_wdr.cpp:1423
 msgid "UDP port for server requests (TCP+3):"
 msgstr "Porto UDP para peticións do servidor (TCP+3)"
 
-#: src/muuli_wdr.cpp:1432
+#: src/muuli_wdr.cpp:1425
 msgid "4665"
 msgstr "4665"
 
-#: src/muuli_wdr.cpp:1439
+#: src/muuli_wdr.cpp:1432
 msgid "This UDP port is used for extended eD2k requests and Kad network"
 msgstr "Este porto UDP úsase para peticións eD2k ampliadas e para a rede Kad"
 
-#: src/muuli_wdr.cpp:1446
+#: src/muuli_wdr.cpp:1439
 msgid "UPnP TCP Port (Optional):"
 msgstr "Porto TCP para UPnP (Opcional):"
 
-#: src/muuli_wdr.cpp:1456
+#: src/muuli_wdr.cpp:1449
 msgid "Bind local address to IP (empty for any):"
 msgstr "Ligar dirección local á IP (deixe baleiro para calquera):"
 
-#: src/muuli_wdr.cpp:1459
+#: src/muuli_wdr.cpp:1452
 msgid "Advanced users only: If you have multiple network interfaces, enter the address of the interface to which aMule should be bound."
 msgstr "Só usuarios experimentados: Se ten varias interfaces de rede, introduza a dirección da interface que quere que aMule use."
 
-#: src/muuli_wdr.cpp:1462 src/muuli_wdr.cpp:2055
+#: src/muuli_wdr.cpp:1455 src/muuli_wdr.cpp:2054
 #, fuzzy
 msgid "Bind to network interface (empty for any):"
 msgstr "Ligar dirección local á IP (deixe baleiro para calquera):"
 
-#: src/muuli_wdr.cpp:1475
+#: src/muuli_wdr.cpp:1468
 msgid "Advanced users only: pin all of aMule's traffic to one network interface, chosen from the list or typed in by name (e.g. tun0, eth0, en0) or index. Unlike binding to an IP, this stops traffic leaking out via the default route - useful with a VPN. Requires no elevated privileges."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1481
+#: src/muuli_wdr.cpp:1474
 msgid "Max sources per downloading file:"
 msgstr "Límite de fontes por ficheiro descargado:"
 
-#: src/muuli_wdr.cpp:1485
+#: src/muuli_wdr.cpp:1478
 msgid "Max simultaneous connections:"
 msgstr "Conexións simultáneas máximas:"
 
-#: src/muuli_wdr.cpp:1498 src/muuli_wdr.cpp:3197
+#: src/muuli_wdr.cpp:1491 src/muuli_wdr.cpp:3169
 msgid "ED2K"
 msgstr "ED2K"
 
-#: src/muuli_wdr.cpp:1505
+#: src/muuli_wdr.cpp:1498
 msgid "Autoconnect on startup"
 msgstr "Conectar automaticamente ao iniciarse"
 
-#: src/muuli_wdr.cpp:1508
+#: src/muuli_wdr.cpp:1501
 msgid "Reconnect on loss"
 msgstr "Volver a conectarse ao perder a conexión"
 
-#: src/muuli_wdr.cpp:1530
+#: src/muuli_wdr.cpp:1523
 msgid "Remove dead server after"
 msgstr "Eliminar servidores caídos tras"
 
-#: src/muuli_wdr.cpp:1531
+#: src/muuli_wdr.cpp:1524
 msgid "Static servers are never removed, even when unreachable."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1535
+#: src/muuli_wdr.cpp:1528
 msgid "retries"
 msgstr "intentos"
 
-#: src/muuli_wdr.cpp:1543
+#: src/muuli_wdr.cpp:1536
 msgid "List"
 msgstr "Lista"
 
-#: src/muuli_wdr.cpp:1546
+#: src/muuli_wdr.cpp:1539
 msgid "Update server list when connecting to a server"
 msgstr "Actualizar a lista de servidores ao conectarse a un servidor"
 
-#: src/muuli_wdr.cpp:1549
+#: src/muuli_wdr.cpp:1542
 msgid "Update server list when a client connects"
 msgstr "Actualizar a lista de servidores cando un cliente se conecte"
 
-#: src/muuli_wdr.cpp:1552
+#: src/muuli_wdr.cpp:1545
 msgid "Use priority system"
 msgstr "Usar sistema de prioridades"
 
-#: src/muuli_wdr.cpp:1556
+#: src/muuli_wdr.cpp:1549
 msgid "Use smart LowID check on connect"
 msgstr "Control intelixente da IDBaixa ao conectar"
 
-#: src/muuli_wdr.cpp:1560
+#: src/muuli_wdr.cpp:1553
 msgid "Safe connect"
 msgstr "Conexión segura"
 
-#: src/muuli_wdr.cpp:1564
+#: src/muuli_wdr.cpp:1557
 msgid "Autoconnect to servers in static list only"
 msgstr "Conectar automaticamente só a servidores fixos"
 
-#: src/muuli_wdr.cpp:1567
+#: src/muuli_wdr.cpp:1560
 msgid "Set manually added servers to High Priority"
 msgstr "Asignar alta prioridade aos servidores engadidos manualmente"
 
-#: src/muuli_wdr.cpp:1588
+#: src/muuli_wdr.cpp:1581
 msgid "Add files to download in pause mode"
 msgstr "Poñer en pausa os ficheiros engadidos á lista de descargas"
 
-#: src/muuli_wdr.cpp:1590
+#: src/muuli_wdr.cpp:1583
 msgid "Add files to download with auto priority"
 msgstr "Engadir os novos ficheiros compartidos con prioridade Automática"
 
-#: src/muuli_wdr.cpp:1593
+#: src/muuli_wdr.cpp:1586
 msgid "Try to download first and last chunks first"
 msgstr "Tentar descargar antes o primeiro e último anaco do ficheiro"
 
-#: src/muuli_wdr.cpp:1597
+#: src/muuli_wdr.cpp:1590
 msgid "Endgame mode: rotate to faster sources for the final blocks"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1600
+#: src/muuli_wdr.cpp:1593
 msgid "Start next paused file when a file completes"
 msgstr "Comezar co seguinte ficheiro que estea pausado cando remate o ficheiro actual"
 
-#: src/muuli_wdr.cpp:1603
+#: src/muuli_wdr.cpp:1596
 msgid "From the same category"
 msgstr "Da mesma categoría"
 
-#: src/muuli_wdr.cpp:1605
+#: src/muuli_wdr.cpp:1598
 msgid "In alphabetic order"
 msgstr "En orde alfabética"
 
-#: src/muuli_wdr.cpp:1607
+#: src/muuli_wdr.cpp:1600
 msgid "Preallocate disk space for new files"
 msgstr "Reservar espazo no disco para os novos ficheiros"
 
-#: src/muuli_wdr.cpp:1608
+#: src/muuli_wdr.cpp:1601
 msgid "For new files preallocates disk space for the whole file, thus reduces fragmentation"
 msgstr "Reserva o tamaño do ficheiro no disco para reducir a fragmentación"
 
-#: src/muuli_wdr.cpp:1613
+#: src/muuli_wdr.cpp:1606
+msgid "Create new files as sparse files"
+msgstr ""
+
+#: src/muuli_wdr.cpp:1607
+msgid "A sparse file reserves its full size on disk immediately without writing real data to it -- fast, but unsupported or slow on some filesystems, and free-space accounting stays optimistic while the download is in progress. Turn this off to grow the file only as data arrives."
+msgstr ""
+
+#: src/muuli_wdr.cpp:1612
 msgid "Stop downloads when free disk space reaches "
 msgstr "Parar descargas canto o espazo libre no disco acade "
 
-#: src/muuli_wdr.cpp:1614
+#: src/muuli_wdr.cpp:1613
 msgid "Select this if you want aMule to check your disk space"
 msgstr "Seleccione esta opción se quere que aMule comprobe o espazo libre no disco"
 
-#: src/muuli_wdr.cpp:1618
+#: src/muuli_wdr.cpp:1617
 msgid "Enter here the min disk space desired."
 msgstr "Introduza o espazo mínimo de disco desexado."
 
-#: src/muuli_wdr.cpp:1624
+#: src/muuli_wdr.cpp:1623
 msgid "Save 10 sources on rare files (< 20 sources)"
 msgstr "Gardar 10 fontes en ficheiros raros (< 20 fontes)"
 
-#: src/muuli_wdr.cpp:1628 src/Statistics.cpp:790
+#: src/muuli_wdr.cpp:1627 src/Statistics.cpp:790
 msgid "Uploads"
 msgstr "Enviado"
 
-#: src/muuli_wdr.cpp:1631
+#: src/muuli_wdr.cpp:1630
 msgid "Add new shared files with auto priority"
 msgstr "Engadir novas descargas con prioridade Automática"
 
-#: src/muuli_wdr.cpp:1637
+#: src/muuli_wdr.cpp:1636
 msgid "Intelligent Corruption Handling (I.C.H.)"
 msgstr "Xestión Intelixente de Corrupcións (X.I.C, I.C.H en inglés)"
 
-#: src/muuli_wdr.cpp:1640
+#: src/muuli_wdr.cpp:1639
 msgid "Enable"
 msgstr "Activada"
 
-#: src/muuli_wdr.cpp:1643
+#: src/muuli_wdr.cpp:1642
 msgid "Advanced I.C.H. trusts every hash (not recommended)"
 msgstr "O X.I.C. avanzado confía en cada hash (non recomendado)"
 
-#: src/muuli_wdr.cpp:1655 src/PrefsUnifiedDlg.cpp:1990
+#: src/muuli_wdr.cpp:1654 src/PrefsUnifiedDlg.cpp:1910
 msgid "Media metadata extraction"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1659
+#: src/muuli_wdr.cpp:1658
 msgid "Extract length / bitrate / codec from shared audio and video files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1661
+#: src/muuli_wdr.cpp:1660
 msgid "When enabled, aMule runs ffprobe on each shared media file to fill in the Length / Bitrate / Codec columns other clients see when they find the file in a search. Requires ffmpeg (the ffprobe binary) to be installed."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1668
+#: src/muuli_wdr.cpp:1667
 msgid "Path to ffprobe:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1673
+#: src/muuli_wdr.cpp:1672
 msgid "Full path to the ffprobe binary. Leave empty to have aMule auto-detect it on startup."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1681
+#: src/muuli_wdr.cpp:1680
 msgid "Detect"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1682
+#: src/muuli_wdr.cpp:1681
 msgid "Search the standard install locations for an ffprobe binary and fill the path field."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1706
+#: src/muuli_wdr.cpp:1705
 msgid ""
 "Completed downloads are stored here. All files in this folder are automatically shared with other peers.\n"
 "If this folder also holds files you don't want to share, point it at an aMule-only sub-folder."
@@ -4184,697 +4173,674 @@ msgstr ""
 "Aquí gárdanse as descargas completas. Automaticamente compartiranse todos os ficheiros do cartafol co resto de parceiros.\n"
 "Se o cartafol tamén conten ficheiros privados, apunte a ruta a un cartafol só para aMule."
 
-#: src/muuli_wdr.cpp:1709
+#: src/muuli_wdr.cpp:1708
 msgid "Pick the folder where completed downloads will be stored. All files in that folder will be shared with other peers."
 msgstr "Escolla o cartafol onde gardar as descargas completas. Compartiranse todos os ficheiros do cartafol co resto de parceiros."
 
-#: src/muuli_wdr.cpp:1723
+#: src/muuli_wdr.cpp:1722
 msgid "Shared folders"
 msgstr "Cartafoles compartidos"
 
-#: src/muuli_wdr.cpp:1729
+#: src/muuli_wdr.cpp:1728
 msgid "(Folders shared by the core. Enter a path to add one.)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1737
+#: src/muuli_wdr.cpp:1736
 msgid "Absolute path of a folder on the core's machine, e.g. /home/user/shared"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1739 src/PrefsUnifiedDlg.cpp:2874
+#: src/muuli_wdr.cpp:1738 src/PrefsUnifiedDlg.cpp:2794
 msgid "Recursive"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1740
+#: src/muuli_wdr.cpp:1739
 msgid "Share every sub-folder underneath this one, including ones created later."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1744 src/utils/aLinkCreator/src/alcframe.cpp:141
+#: src/muuli_wdr.cpp:1743 src/utils/aLinkCreator/src/alcframe.cpp:141
 msgid "Remove"
 msgstr "Eliminar"
 
-#: src/muuli_wdr.cpp:1748
+#: src/muuli_wdr.cpp:1747
 msgid "(Right click on folder icon for recursive share)"
 msgstr "(Preme co botón dereito na icona do cartafol para compartir recursivamente)"
 
-#: src/muuli_wdr.cpp:1755
+#: src/muuli_wdr.cpp:1754
 msgid "Share hidden files"
 msgstr "Compartir ficheiros ocultos"
 
-#: src/muuli_wdr.cpp:1761
+#: src/muuli_wdr.cpp:1760
 msgid "Automatically rescan shared folders for changes"
 msgstr "Revisar automaticamente se hai cambios nos cartafoles compartidos"
 
-#: src/muuli_wdr.cpp:1767
+#: src/muuli_wdr.cpp:1766
 msgid "Follow symbolic links in shared folders"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1773
+#: src/muuli_wdr.cpp:1772
 msgid "Exclude files matching:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1776
+#: src/muuli_wdr.cpp:1775
 msgid "Wildcard patterns separated by '|', e.g. .DS_Store|Thumbs.db|*.tmp. Files whose name matches are not shared. Matching is case-insensitive."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1780
+#: src/muuli_wdr.cpp:1779
 msgid "Patterns are regular expressions"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1781
+#: src/muuli_wdr.cpp:1780
 msgid "When set, the whole field is one regular expression ('|' is alternation). When unset, it is a list of '|'-separated wildcards."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1791
+#: src/muuli_wdr.cpp:1790
 msgid "Show how many shared files the current pattern would exclude."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1812
+#: src/muuli_wdr.cpp:1811
 msgid "Graphs"
 msgstr "Gráficas"
 
-#: src/muuli_wdr.cpp:1815 src/muuli_wdr.cpp:1877
+#: src/muuli_wdr.cpp:1814 src/muuli_wdr.cpp:1876
 msgid "Update delay : 5 secs"
 msgstr "Intervalo de actualización: 5 segs"
 
-#: src/muuli_wdr.cpp:1819
+#: src/muuli_wdr.cpp:1818
 msgid "Time for average graph: 100 mins"
 msgstr "Tempo de media do gráfico: 100 minutos"
 
-#: src/muuli_wdr.cpp:1823
+#: src/muuli_wdr.cpp:1822
 msgid "Connections Graph Scale: 100 "
 msgstr "Escala do gráfico das conexións: 100 "
 
-#: src/muuli_wdr.cpp:1830
+#: src/muuli_wdr.cpp:1829
 msgid "Download graph scale:"
 msgstr "Escala do gráfico de descargas:"
 
-#: src/muuli_wdr.cpp:1838
+#: src/muuli_wdr.cpp:1837
 msgid "Upload graph scale:"
 msgstr "Escala do gráfico de envíos:"
 
-#: src/muuli_wdr.cpp:1848
+#: src/muuli_wdr.cpp:1847
 msgid "Colors: "
 msgstr "Cores: "
 
-#: src/muuli_wdr.cpp:1852
+#: src/muuli_wdr.cpp:1851
 msgid "Background"
 msgstr "Fondo"
 
-#: src/muuli_wdr.cpp:1853
+#: src/muuli_wdr.cpp:1852
 msgid "Grid"
 msgstr "Enreixado"
 
-#: src/muuli_wdr.cpp:1854
+#: src/muuli_wdr.cpp:1853
 msgid "Download current"
 msgstr "Descarga actual"
 
-#: src/muuli_wdr.cpp:1855
+#: src/muuli_wdr.cpp:1854
 msgid "Download running average"
 msgstr "Media das descargas en execución"
 
-#: src/muuli_wdr.cpp:1856
+#: src/muuli_wdr.cpp:1855
 msgid "Download session average"
 msgstr "Media de descargas na sesión"
 
-#: src/muuli_wdr.cpp:1857
+#: src/muuli_wdr.cpp:1856
 msgid "Upload current"
 msgstr "Subida actual"
 
-#: src/muuli_wdr.cpp:1858
+#: src/muuli_wdr.cpp:1857
 msgid "Upload running average"
 msgstr "Media de subida en execución"
 
-#: src/muuli_wdr.cpp:1859
+#: src/muuli_wdr.cpp:1858
 msgid "Upload session average"
 msgstr "Media de subida na sesión"
 
-#: src/muuli_wdr.cpp:1860
+#: src/muuli_wdr.cpp:1859
 msgid "Active connections"
 msgstr "Conexións activas"
 
-#: src/muuli_wdr.cpp:1863
+#: src/muuli_wdr.cpp:1862
 msgid "Systray Icon Speed Bar"
 msgstr "Barra de velocidade na bandexa do sistema"
 
-#: src/muuli_wdr.cpp:1864
+#: src/muuli_wdr.cpp:1863
 msgid "Kad-nodes current"
 msgstr "Nodos Kad actuais"
 
-#: src/muuli_wdr.cpp:1865
+#: src/muuli_wdr.cpp:1864
 msgid "Kad-nodes running"
 msgstr "Nodo Kad executándose"
 
-#: src/muuli_wdr.cpp:1866
+#: src/muuli_wdr.cpp:1865
 msgid "Kad-nodes session"
 msgstr "Nodos Kad na sesión"
 
-#: src/muuli_wdr.cpp:1870 src/muuli_wdr.cpp:2324
+#: src/muuli_wdr.cpp:1869 src/muuli_wdr.cpp:2296
 msgid "Select"
 msgstr "Seleccionar"
 
-#: src/muuli_wdr.cpp:1874
+#: src/muuli_wdr.cpp:1873
 msgid "Tree"
 msgstr "Árbore"
 
-#: src/muuli_wdr.cpp:1884
+#: src/muuli_wdr.cpp:1883
 msgid "Number of Client Versions shown (0=unlimited)"
 msgstr "Cantas versións do cliente a amosar (0=ilimitado)"
 
-#: src/muuli_wdr.cpp:1909
+#: src/muuli_wdr.cpp:1908
 msgid "!!! WARNING !!!"
 msgstr "ADVERTENCIA !!!"
 
-#: src/muuli_wdr.cpp:1924
+#: src/muuli_wdr.cpp:1923
 msgid "Max new connections / 5 secs"
 msgstr "Novas conexións máx. / 5 segs"
 
-#: src/muuli_wdr.cpp:1926
+#: src/muuli_wdr.cpp:1925
 msgid "Concurrent Kad source lookups"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1928
+#: src/muuli_wdr.cpp:1927
 #, fuzzy
 msgid "Kad source re-search interval (minutes)"
 msgstr "Intervalo de actualización do FTP en minutos"
 
-#: src/muuli_wdr.cpp:1930
+#: src/muuli_wdr.cpp:1929
 #, fuzzy
 msgid "Source re-ask interval (minutes)"
 msgstr "Intervalo de actualización do FTP en minutos"
 
-#: src/muuli_wdr.cpp:1934
+#: src/muuli_wdr.cpp:1933
 msgid "File Buffer Size: 240000 bytes"
 msgstr "Tamaño do búfer de ficheiro: 240 000 octetos"
 
-#: src/muuli_wdr.cpp:1938
+#: src/muuli_wdr.cpp:1937
 msgid "Use MMAP: memory-mapped file access (lower memory use)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1939
+#: src/muuli_wdr.cpp:1938
 msgid "Maps part files into memory instead of buffering them on the heap, lowering the process memory footprint. May reduce download speed on some disks; best for memory-constrained or upload-heavy hosts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1941
+#: src/muuli_wdr.cpp:1940
 msgid "Upload Queue Size: 5000 clients"
 msgstr "Tamaño cola de espera: 5000 clientes"
 
-#: src/muuli_wdr.cpp:1945
+#: src/muuli_wdr.cpp:1944
 msgid "Server connection refresh interval: Disable"
 msgstr "Intervalo de actualización de conexión ao servidor: Desactivado"
 
-#: src/muuli_wdr.cpp:1949
+#: src/muuli_wdr.cpp:1948
 msgid "Disable computer's timed standby mode"
 msgstr "Impedir que o ordenador entre en modo espera"
 
-#: src/muuli_wdr.cpp:1968
+#: src/muuli_wdr.cpp:1967
 msgid "Skin to use: "
 msgstr "Tema a usar: "
 
-#: src/muuli_wdr.cpp:1977
+#: src/muuli_wdr.cpp:1976
 msgid "Show \"Fast eD2k Links Handler\" in every window."
 msgstr "Amosar «Xestor rápido de ligazóns eD2k» en cada xanela."
 
-#: src/muuli_wdr.cpp:1980
+#: src/muuli_wdr.cpp:1979
 msgid "Show extended info on categories tabs"
 msgstr "Mostrar información engadida nas lapelas das categorías"
 
-#: src/muuli_wdr.cpp:1983
+#: src/muuli_wdr.cpp:1982
 msgid "Show application version on title"
 msgstr "Amosar a versión da aplicación no título"
 
-#: src/muuli_wdr.cpp:1985
+#: src/muuli_wdr.cpp:1984
 msgid "Show transfer rates on title"
 msgstr "Mostrar velocidades de transferencia no título"
 
-#: src/muuli_wdr.cpp:1987
+#: src/muuli_wdr.cpp:1986
 msgid "Before application name"
 msgstr "Antes do nome da aplicación"
 
-#: src/muuli_wdr.cpp:1989
+#: src/muuli_wdr.cpp:1988
 msgid "After application name"
 msgstr "Despois do nome da aplicación"
 
-#: src/muuli_wdr.cpp:1992
+#: src/muuli_wdr.cpp:1991
 msgid "Show overhead bandwidth"
 msgstr "Amosar ancho de banda malgastado"
 
-#: src/muuli_wdr.cpp:1996
+#: src/muuli_wdr.cpp:1995
 msgid "Vertical toolbar orientation"
 msgstr "Barra de ferramentas en orientación vertical"
 
-#: src/muuli_wdr.cpp:1998
+#: src/muuli_wdr.cpp:1997
 msgid "Live column sorting (auto-reorder rows as their values change)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2005
+#: src/muuli_wdr.cpp:2004
 msgid "Download Queue Files"
 msgstr "Cola de Descargas"
 
-#: src/muuli_wdr.cpp:2008
+#: src/muuli_wdr.cpp:2007
 msgid "Show progress percentage"
 msgstr "Amosar porcentaxe de progreso"
 
-#: src/muuli_wdr.cpp:2014
+#: src/muuli_wdr.cpp:2013
 msgid "Show progress bar"
 msgstr "Amosar barra de progreso"
 
-#: src/muuli_wdr.cpp:2017
+#: src/muuli_wdr.cpp:2016
 msgid "Flat"
 msgstr "Plana"
 
-#: src/muuli_wdr.cpp:2021
+#: src/muuli_wdr.cpp:2020
 msgid "Round"
 msgstr "3D"
 
-#: src/muuli_wdr.cpp:2039
+#: src/muuli_wdr.cpp:2038
 msgid "External Connection Parameters"
 msgstr "Parámetros da Conexión Externa (CE)"
 
-#: src/muuli_wdr.cpp:2042
+#: src/muuli_wdr.cpp:2041
 msgid "Accept external connections"
 msgstr "Aceptar conexións externas"
 
-#: src/muuli_wdr.cpp:2049 src/muuli_wdr.cpp:2108
+#: src/muuli_wdr.cpp:2048 src/muuli_wdr.cpp:2107
 msgid "IP of the listening interface:"
 msgstr "IP da interface na que escoitar:"
 
-#: src/muuli_wdr.cpp:2052
+#: src/muuli_wdr.cpp:2051
 msgid "Enter here a valid ip in the a.b.c.d format for the listening EC interface. An empty field or 0.0.0.0 will mean any interface."
 msgstr "Introduza aquí a IP (válida, no formato a.b.c.d) da interface para a CE. Un campo baleiro ou 0.0.0.0 significa calquera interface."
 
-#: src/muuli_wdr.cpp:2073 src/muuli_wdr.cpp:2184
+#: src/muuli_wdr.cpp:2072 src/muuli_wdr.cpp:2156
 msgid "TCP port:"
 msgstr "Porto TCP:"
 
-#: src/muuli_wdr.cpp:2079
+#: src/muuli_wdr.cpp:2078
 msgid "Enable UPnP port forwarding on the EC port"
 msgstr "Activar a configuración de portos por UPnP para o porto de CE"
 
-#: src/muuli_wdr.cpp:2083 src/muuli_wdr.cpp:3069
+#: src/muuli_wdr.cpp:2082 src/muuli_wdr.cpp:3041
 #: src/utils/wxCas/src/wxcasprefs.cpp:167
 msgid "Password"
 msgstr "Contrasinal"
 
-#: src/muuli_wdr.cpp:2089
+#: src/muuli_wdr.cpp:2088
 #, fuzzy
 msgid "aMule API server parameters"
 msgstr "Parámetros do servidor Web"
 
-#: src/muuli_wdr.cpp:2092
+#: src/muuli_wdr.cpp:2091
 msgid "Run amuleapi (REST API) on startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2097
+#: src/muuli_wdr.cpp:2096
 #, fuzzy
 msgid "HTTP port:"
 msgstr "Porto TCP:"
 
-#: src/muuli_wdr.cpp:2111
+#: src/muuli_wdr.cpp:2110
 msgid "The interface amuleapi's HTTP server listens on. 127.0.0.1 (default) accepts only local connections; use 0.0.0.0 or a specific IP to expose it to other hosts (set an admin password below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2116
-msgid "Type a password to set or change it. Stored passwords cannot be shown, so leaving this empty keeps the current one."
-msgstr ""
-
-#: src/muuli_wdr.cpp:2118
+#: src/muuli_wdr.cpp:2113
 #, fuzzy
 msgid "Admin password"
 msgstr "Comprobando contrasinal\n"
 
-#: src/muuli_wdr.cpp:2130 src/muuli_wdr.cpp:2147 src/PrefsUnifiedDlg.cpp:1103
-#, fuzzy
-msgid "A password is set."
-msgstr "Comprobando contrasinal\n"
+#: src/muuli_wdr.cpp:2118 src/muuli_wdr.cpp:2149
+msgid "Low rights password"
+msgstr "Contrasinal para o invitado"
 
-#: src/muuli_wdr.cpp:2134
-#, fuzzy
-msgid "Enable guest access"
-msgstr "Denegar acceso de invitado"
-
-#: src/muuli_wdr.cpp:2135
-msgid "Guest sessions may read status and listings but cannot change anything. Turning this off clears the stored guest password."
-msgstr ""
-
-#: src/muuli_wdr.cpp:2139
-#, fuzzy
-msgid "Guest password"
-msgstr "Contrasinal de invitado para o servidor web"
-
-#: src/muuli_wdr.cpp:2154
+#: src/muuli_wdr.cpp:2126
 msgid "Web server parameters"
 msgstr "Parámetros do servidor Web"
 
-#: src/muuli_wdr.cpp:2157
+#: src/muuli_wdr.cpp:2129
 #, fuzzy
 msgid "Run webserver on startup (deprecated)"
 msgstr "Arrancar o servidor web ao iniciar"
 
-#: src/muuli_wdr.cpp:2163
+#: src/muuli_wdr.cpp:2135
 msgid "Web template"
 msgstr "Modelo Web"
 
-#: src/muuli_wdr.cpp:2168
+#: src/muuli_wdr.cpp:2140
 msgid "Full rights password"
 msgstr "Contrasinal para o administrador"
 
-#: src/muuli_wdr.cpp:2172
+#: src/muuli_wdr.cpp:2144
 msgid "Enable Low rights User"
 msgstr "Activar invitado"
 
-#: src/muuli_wdr.cpp:2177
-msgid "Low rights password"
-msgstr "Contrasinal para o invitado"
-
-#: src/muuli_wdr.cpp:2191
+#: src/muuli_wdr.cpp:2163
 msgid "Enable UPnP port forwarding of the web server port"
 msgstr "Configurar o porto do servidor web mediante UPnP"
 
-#: src/muuli_wdr.cpp:2196
+#: src/muuli_wdr.cpp:2168
 msgid "Web server UPnP TCP port (Optional)"
 msgstr "Porto TCP para o UPnP do servidor web (Opcional)"
 
-#: src/muuli_wdr.cpp:2204
+#: src/muuli_wdr.cpp:2176
 msgid "Page Refresh Time (in secs)"
 msgstr "Tempo de actualización da páxina (en segs)"
 
-#: src/muuli_wdr.cpp:2211
+#: src/muuli_wdr.cpp:2183
 msgid "Enable Gzip compression"
 msgstr "Activar compresión Gzip"
 
-#: src/muuli_wdr.cpp:2245
+#: src/muuli_wdr.cpp:2217
 #, fuzzy
 msgid "Reset page to defaults"
 msgstr "Predeterminado"
 
-#: src/muuli_wdr.cpp:2246
+#: src/muuli_wdr.cpp:2218
 msgid "Reset the settings on the current page to their default values."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2248 src/muuli_wdr.cpp:2334 src/ServerWnd.cpp:274
+#: src/muuli_wdr.cpp:2220 src/muuli_wdr.cpp:2306 src/ServerWnd.cpp:274
 #: src/ServerWnd.cpp:282
 msgid "OK"
 msgstr "Vale"
 
-#: src/muuli_wdr.cpp:2250
+#: src/muuli_wdr.cpp:2222
 msgid "Click here to apply any changes made to the preferences."
 msgstr "Aplicar calquera troco feito nas preferencias."
 
-#: src/muuli_wdr.cpp:2253
+#: src/muuli_wdr.cpp:2225
 msgid "Reset any changes made to the preferences."
 msgstr "Restablecer calquera troco feito nas preferencias."
 
-#: src/muuli_wdr.cpp:2282
+#: src/muuli_wdr.cpp:2254
 msgid "Comment :"
 msgstr "Comentario :"
 
-#: src/muuli_wdr.cpp:2289
+#: src/muuli_wdr.cpp:2261
 msgid "Incoming Dir :"
 msgstr "Cartafol de descargas :"
 
-#: src/muuli_wdr.cpp:2298
+#: src/muuli_wdr.cpp:2270
 msgid "Change priority for new assigned files :"
 msgstr "Cambiar prioridade para os novos ficheiros asignados :"
 
-#: src/muuli_wdr.cpp:2302
+#: src/muuli_wdr.cpp:2274
 msgid "Don't change"
 msgstr "Non cambiar"
 
-#: src/muuli_wdr.cpp:2314
+#: src/muuli_wdr.cpp:2286
 msgid "Select color for this Category (currently selected) :"
 msgstr "Seleccionar cor para esta categoría (a seleccionada) :"
 
-#: src/muuli_wdr.cpp:2381 src/muuli_wdr.cpp:2400 src/muuli_wdr.cpp:2422
+#: src/muuli_wdr.cpp:2353 src/muuli_wdr.cpp:2372 src/muuli_wdr.cpp:2394
 msgid "Click this button to reset the log."
 msgstr "Premer este botón para reiniciar o rexistro."
 
-#: src/muuli_wdr.cpp:2441
+#: src/muuli_wdr.cpp:2413
 msgid "Click on this button to update the servers list from URL ..."
 msgstr "Premer neste botón para actualizar a lista de servidores desde a URL ..."
 
-#: src/muuli_wdr.cpp:2445
+#: src/muuli_wdr.cpp:2417
 msgid "Server list"
 msgstr "Lista de servidores"
 
-#: src/muuli_wdr.cpp:2449
+#: src/muuli_wdr.cpp:2421
 msgid "Enter the url to a server.met file here and press the button to the left to update the list of known servers."
 msgstr "Introduza a URL dun ficheiro server.met e prema o botón da esquerda para actualizar a lista de servidores coñecidos."
 
-#: src/muuli_wdr.cpp:2454
+#: src/muuli_wdr.cpp:2426
 msgid "Add server manually: Name"
 msgstr "Engadir servidor manualmente: Nome"
 
-#: src/muuli_wdr.cpp:2457
+#: src/muuli_wdr.cpp:2429
 msgid "Enter the name of the new server here"
 msgstr "Introduza o nome do novo servidor aquí"
 
-#: src/muuli_wdr.cpp:2459 src/ServerWnd.cpp:206
+#: src/muuli_wdr.cpp:2431 src/ServerWnd.cpp:206
 msgid "IP:Port"
 msgstr "IP:Porto"
 
-#: src/muuli_wdr.cpp:2462
+#: src/muuli_wdr.cpp:2434
 msgid "Enter the IP of the server here, using the x.x.x.x format."
 msgstr "Introduza a IP do servidor aquí, usando o formato x.x.x.x ."
 
-#: src/muuli_wdr.cpp:2468
+#: src/muuli_wdr.cpp:2440
 msgid "Enter the port of the server here."
 msgstr "Introduza o porto do servidor aquí."
 
-#: src/muuli_wdr.cpp:2471
+#: src/muuli_wdr.cpp:2443
 msgid "Add manually a server (fill fields to the left before) ..."
 msgstr "Engadir servidor manualmente (antes enche os campos á esquerda) ..."
 
-#: src/muuli_wdr.cpp:2500
+#: src/muuli_wdr.cpp:2472
 msgid "aMule Log"
 msgstr "Rexistro de aMule"
 
-#: src/muuli_wdr.cpp:2508
+#: src/muuli_wdr.cpp:2480
 msgid "Server Info"
 msgstr "Info. do servidor"
 
-#: src/muuli_wdr.cpp:2512
+#: src/muuli_wdr.cpp:2484
 msgid "ED2K Info"
 msgstr "Info. ED2K"
 
-#: src/muuli_wdr.cpp:2516
+#: src/muuli_wdr.cpp:2488
 msgid "Kad Info"
 msgstr "Info. Kad"
 
-#: src/muuli_wdr.cpp:2544
+#: src/muuli_wdr.cpp:2516
 msgid "Click on this button to update the nodes list from URL ..."
 msgstr "Prema neste botón para actualizar a lista de nodos dende a URL ..."
 
-#: src/muuli_wdr.cpp:2548
+#: src/muuli_wdr.cpp:2520
 msgid "Nodes (0)"
 msgstr "Nodos (0)"
 
-#: src/muuli_wdr.cpp:2552
+#: src/muuli_wdr.cpp:2524
 msgid "Enter the url to a nodes.dat file here and press the button to the left to update the list of known nodes."
 msgstr "Introduza aquí a URL ao ficheiro nodes.dat e prema o botón da esquerda, para actualizar a lista de nodos coñecidos."
 
-#: src/muuli_wdr.cpp:2555
+#: src/muuli_wdr.cpp:2527
 msgid "Nodes stats"
 msgstr "Estatísticas de nodos"
 
-#: src/muuli_wdr.cpp:2597
+#: src/muuli_wdr.cpp:2569
 msgid "Bootstrap"
 msgstr "Arranque autónomo (dende cero)"
 
-#: src/muuli_wdr.cpp:2600
+#: src/muuli_wdr.cpp:2572
 msgid "New node"
 msgstr "Novo nodo"
 
-#: src/muuli_wdr.cpp:2605
+#: src/muuli_wdr.cpp:2577
 msgid "IP:"
 msgstr "IP:"
 
-#: src/muuli_wdr.cpp:2625
+#: src/muuli_wdr.cpp:2597
 msgid "Port:"
 msgstr "Porto:"
 
-#: src/muuli_wdr.cpp:2638
+#: src/muuli_wdr.cpp:2610
 msgid "Bootstrap from known clients"
 msgstr "Arrancar a partir de clientes coñecidos"
 
-#: src/muuli_wdr.cpp:2640
+#: src/muuli_wdr.cpp:2612
 msgid "Disconnect Kad"
 msgstr "Desconectar Kad"
 
-#: src/muuli_wdr.cpp:2674
+#: src/muuli_wdr.cpp:2646
 msgid "Use Secure User Identification"
 msgstr "Empregar a Identificación Segura do Usuario"
 
-#: src/muuli_wdr.cpp:2676
+#: src/muuli_wdr.cpp:2648
 msgid "It is recommended to enable this option. You will not receive credits if SUI is not enabled."
 msgstr "Aconséllase habilitar esta opción. Non recibirá créditos se a ISU non se habilitou."
 
-#: src/muuli_wdr.cpp:2678
+#: src/muuli_wdr.cpp:2650
 msgid "Protocol Obfuscation"
 msgstr "Ofuscación do protocolo"
 
-#: src/muuli_wdr.cpp:2681
+#: src/muuli_wdr.cpp:2653
 msgid "Support Protocol Obfuscation"
 msgstr "Aceptar a ofuscación do protocolo"
 
-#: src/muuli_wdr.cpp:2683
+#: src/muuli_wdr.cpp:2655
 msgid "This option enabled Protocol Obfuscation, and makes aMule accept obfuscated connections from other clients."
 msgstr "Esta opción activa a ofuscación do protocolo, e permite que aMule acepte conexións ofuscadas doutros clientes."
 
-#: src/muuli_wdr.cpp:2685
+#: src/muuli_wdr.cpp:2657
 msgid "Use obfuscation for outgoing connections"
 msgstr "Usar ofuscación para as conexións saíntes"
 
-#: src/muuli_wdr.cpp:2687
+#: src/muuli_wdr.cpp:2659
 msgid "This option makes aMule use Protocol Obfuscation when connecting other clients/servers."
 msgstr "Esta opción fai que aMule use a ofuscación de protocolo cando se conectan outros clientes/servidores."
 
-#: src/muuli_wdr.cpp:2689
+#: src/muuli_wdr.cpp:2661
 msgid "Accept only obfuscated connections"
 msgstr "Aceptar só conexións ofuscadas"
 
-#: src/muuli_wdr.cpp:2690
+#: src/muuli_wdr.cpp:2662
 msgid "This option makes aMule only accept obfuscated connections. You will have less sources, but all your traffic will be obfuscated"
 msgstr "Esta opción fai que aMule só acepte conexións ofuscadas. Terá menos fontes, pero todo o tráfico estará ofuscado"
 
-#: src/muuli_wdr.cpp:2695
+#: src/muuli_wdr.cpp:2667
 msgid "Everybody"
 msgstr "Todos"
 
-#: src/muuli_wdr.cpp:2697
+#: src/muuli_wdr.cpp:2669
 msgid "No one"
 msgstr "Ninguén"
 
-#: src/muuli_wdr.cpp:2699
+#: src/muuli_wdr.cpp:2671
 msgid "Who can see my shared files:"
 msgstr "Quen pode ver os meus ficheiros compartidos:"
 
-#: src/muuli_wdr.cpp:2700
+#: src/muuli_wdr.cpp:2672
 msgid "Select who can request to view a list of your shared files."
 msgstr "Seleccione quen pode solicitar ver a lista de ficheiros compartidos."
 
-#: src/muuli_wdr.cpp:2702
+#: src/muuli_wdr.cpp:2674
 msgid "IP-Filtering"
 msgstr "Filtrado de IPs"
 
-#: src/muuli_wdr.cpp:2709
+#: src/muuli_wdr.cpp:2681
 msgid "Filter clients"
 msgstr "Filtrar clientes"
 
-#: src/muuli_wdr.cpp:2711
+#: src/muuli_wdr.cpp:2683
 msgid "Enable filtering of the client IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "Activar filtrado das IPs dos clientes definidas no ficheiro ~/.aMule/ipfilter.dat."
 
-#: src/muuli_wdr.cpp:2713
+#: src/muuli_wdr.cpp:2685
 msgid "Filter servers"
 msgstr "Filtrar servidores"
 
-#: src/muuli_wdr.cpp:2715
+#: src/muuli_wdr.cpp:2687
 msgid "Enable filtering of the server IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "Activar filtrado das IPs dos servidores definidas no ficheiro ~/.aMule/ipfilter.dat."
 
-#: src/muuli_wdr.cpp:2719
+#: src/muuli_wdr.cpp:2691
 msgid "Reload List"
 msgstr "Recargar lista"
 
-#: src/muuli_wdr.cpp:2720
+#: src/muuli_wdr.cpp:2692
 msgid "Reload the list of IPs to filter from the file ~/.aMule/ipfilter.dat"
 msgstr "Recargar a lista de filtrado de IPs desde o ficheiro ~/.aMule/ipfilter.dat"
 
-#: src/muuli_wdr.cpp:2726
+#: src/muuli_wdr.cpp:2698
 msgid "URL:"
 msgstr "URL:"
 
-#: src/muuli_wdr.cpp:2730 src/muuli_wdr.cpp:2923
+#: src/muuli_wdr.cpp:2702 src/muuli_wdr.cpp:2895
 msgid "Update now"
 msgstr "Actualizar agora"
 
-#: src/muuli_wdr.cpp:2733
+#: src/muuli_wdr.cpp:2705
 msgid "Auto-update ipfilter at startup"
 msgstr "Auto-actualizar o filtrado de IPs ao iniciarse"
 
-#: src/muuli_wdr.cpp:2737
+#: src/muuli_wdr.cpp:2709
 msgid "Filtering Level:"
 msgstr "Nivel de filtrado:"
 
-#: src/muuli_wdr.cpp:2743
+#: src/muuli_wdr.cpp:2715
 msgid "Always filter LAN IPs"
 msgstr "Filtrar sempre IPs LAN"
 
-#: src/muuli_wdr.cpp:2746
+#: src/muuli_wdr.cpp:2718
 msgid "Paranoid handling of non-matching IPs"
 msgstr "Xestión paranoica de IPs non coincidintes"
 
-#: src/muuli_wdr.cpp:2748
+#: src/muuli_wdr.cpp:2720
 msgid "Rejects a packet when its source IP differs from the IP the client claims (an anti-spoofing check). Disable only if it causes connection problems."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2750
+#: src/muuli_wdr.cpp:2722
 msgid "Use system-wide ipfilter.dat if available"
 msgstr "Empregar un ipfilter.dat global se está dispoñible"
 
-#: src/muuli_wdr.cpp:2751
+#: src/muuli_wdr.cpp:2723
 msgid "If there's no local ipfilter.dat found, allow usage of a system-wide ipfilter file."
 msgstr "De non atopar o ipfilter.dat local, permitir o emprego dun ipfilter global."
 
-#: src/muuli_wdr.cpp:2768
+#: src/muuli_wdr.cpp:2740
 msgid "Enable Online-Signature"
 msgstr "Activar Sinatura En liña"
 
-#: src/muuli_wdr.cpp:2770
+#: src/muuli_wdr.cpp:2742
 msgid "Enables the writing of the OS file, which can be used by external apps to create signatures and the like."
 msgstr "Habilitar a escritura de ficheiros do SE. Sóese usar para crear sinaturas para aplicacións externas."
 
-#: src/muuli_wdr.cpp:2774
+#: src/muuli_wdr.cpp:2746
 msgid "Update Frequency (Secs):"
 msgstr "Frecuencia de actualización (segs):"
 
-#: src/muuli_wdr.cpp:2777
+#: src/muuli_wdr.cpp:2749
 msgid "Change the frequency (in seconds) of Online Signature updates."
 msgstr "Cambiar a frecuencia (en segundos) da actualización da sinatura en liña."
 
-#: src/muuli_wdr.cpp:2785
+#: src/muuli_wdr.cpp:2757
 msgid "Save online signature file in: "
 msgstr "Gardar o ficheiro de sinaturas en liña en: "
 
-#: src/muuli_wdr.cpp:2791
+#: src/muuli_wdr.cpp:2763
 msgid "Click here to select the directory containing the the Online Signature files."
 msgstr "Prema aquí para seleccionar o directorio que contén os ficheiros de sinaturas en liña."
 
-#: src/muuli_wdr.cpp:2824
+#: src/muuli_wdr.cpp:2796
 msgid "Show country flags for clients"
 msgstr "Amosar as bandeiras do país de orixe dos clientes"
 
-#: src/muuli_wdr.cpp:2825
+#: src/muuli_wdr.cpp:2797
 msgid "Render the country flag column in the transfers, queue and search views. Requires a valid MMDB GeoIP database (see below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2830
+#: src/muuli_wdr.cpp:2802
 #, fuzzy
 msgid "Database"
 msgstr "Fluxo de datos :"
 
-#: src/muuli_wdr.cpp:2846
+#: src/muuli_wdr.cpp:2818
 #, fuzzy
 msgid "Source:"
 msgstr "Fontes"
 
-#: src/muuli_wdr.cpp:2849
+#: src/muuli_wdr.cpp:2821
 msgid "DB-IP (free, no account)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2850
+#: src/muuli_wdr.cpp:2822
 msgid "MaxMind GeoLite2 (free, account required)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2851
+#: src/muuli_wdr.cpp:2823
 msgid "Custom URL"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2854
+#: src/muuli_wdr.cpp:2826
 msgid "Choose which provider supplies the GeoIP MMDB database. DB-IP is the default - no account required. MaxMind requires a free account + license key. Use Custom URL to point at any other MMDB host (e.g. a local mirror)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2871
+#: src/muuli_wdr.cpp:2843
 msgid ""
 "No configuration required.\n"
 "\n"
@@ -4882,11 +4848,11 @@ msgid ""
 "License: Creative Commons BY 4.0 - https://creativecommons.org/licenses/by/4.0/"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2884
+#: src/muuli_wdr.cpp:2856
 msgid "License key:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2890
+#: src/muuli_wdr.cpp:2862
 msgid ""
 "Sign up for a free MaxMind account, then generate a License Key:\n"
 "https://www.maxmind.com/en/geolite2/signup\n"
@@ -4896,225 +4862,225 @@ msgid ""
 "Requires attribution and account registration; refresh at least every 30 days."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2905
+#: src/muuli_wdr.cpp:2877
 #, fuzzy
 msgid "Download URL:"
 msgstr "Descargado: "
 
-#: src/muuli_wdr.cpp:2911
+#: src/muuli_wdr.cpp:2883
 msgid ""
 "Must point to an .mmdb file or a .gz / .tar.gz containing one.\n"
 "URL may include credentials (https://user:pass@host/...).\n"
 "License and attribution terms are set by the upstream URL - you are responsible."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2924
+#: src/muuli_wdr.cpp:2896
 msgid "Download the GeoIP database from the selected source."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2926
+#: src/muuli_wdr.cpp:2898
 #, fuzzy
 msgid "Auto-update on startup"
 msgstr "Auto-actualizar o filtrado de IPs ao iniciarse"
 
-#: src/muuli_wdr.cpp:2927
+#: src/muuli_wdr.cpp:2899
 msgid "Re-download the GeoIP database from the selected source every time aMule starts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2950
+#: src/muuli_wdr.cpp:2922
 msgid "Filter incoming messages (except current chat):"
 msgstr "Filtrar mensaxes entrantes (excepto as da conversación actual):"
 
-#: src/muuli_wdr.cpp:2952
+#: src/muuli_wdr.cpp:2924
 msgid "Filter all messages"
 msgstr "Filtrar todas as mensaxes"
 
-#: src/muuli_wdr.cpp:2954
+#: src/muuli_wdr.cpp:2926
 msgid "Filter messages from people not on your friend list"
 msgstr "Filtrar mensaxes de xente que non estea na lista de amigos"
 
-#: src/muuli_wdr.cpp:2956
+#: src/muuli_wdr.cpp:2928
 msgid "Filter messages from unknown clients"
 msgstr "Filtrar mensaxes de clientes descoñecidos"
 
-#: src/muuli_wdr.cpp:2958
+#: src/muuli_wdr.cpp:2930
 msgid "Filter messages containing (use ',' as separator):"
 msgstr "Filtrar mensaxes que conteñan (use «,» como separador):"
 
-#: src/muuli_wdr.cpp:2961 src/muuli_wdr.cpp:2972
+#: src/muuli_wdr.cpp:2933 src/muuli_wdr.cpp:2944
 msgid "add here the words amule should filter and block messages including it"
 msgstr "engada aquí palabras para filtrar e bloquear as mensaxes que coincidan"
 
-#: src/muuli_wdr.cpp:2963
+#: src/muuli_wdr.cpp:2935
 msgid "Show received messages in the log"
 msgstr "Amosar as mensaxes recibidas no rexistro"
 
-#: src/muuli_wdr.cpp:2966
+#: src/muuli_wdr.cpp:2938
 msgid "Comments"
 msgstr "Comentarios"
 
-#: src/muuli_wdr.cpp:2969
+#: src/muuli_wdr.cpp:2941
 msgid "Filter comments containing (use ',' as separator):"
 msgstr "Filtrar comentarios que conteñan (empregue «,» coma separador):"
 
-#: src/muuli_wdr.cpp:2994
+#: src/muuli_wdr.cpp:2966
 msgid "Enable Proxy"
 msgstr "Activar proxy"
 
-#: src/muuli_wdr.cpp:2995
+#: src/muuli_wdr.cpp:2967
 msgid "Enable/disable proxy support"
 msgstr "Activar/desactivar o tipo de proxy"
 
-#: src/muuli_wdr.cpp:2998
+#: src/muuli_wdr.cpp:2970
 msgid "Proxy type:"
 msgstr "Tipo de proxy:"
 
-#: src/muuli_wdr.cpp:3009
+#: src/muuli_wdr.cpp:2981
 msgid "Proxy host:"
 msgstr "Anfitrión do proxy:"
 
-#: src/muuli_wdr.cpp:3012
+#: src/muuli_wdr.cpp:2984
 msgid "The proxy host name"
 msgstr "O nome do anfitrión do proxy"
 
-#: src/muuli_wdr.cpp:3014
+#: src/muuli_wdr.cpp:2986
 msgid "Proxy port:"
 msgstr "Porto do proxy:"
 
-#: src/muuli_wdr.cpp:3017
+#: src/muuli_wdr.cpp:2989
 msgid "The proxy port"
 msgstr "O porto do proxy"
 
-#: src/muuli_wdr.cpp:3019
+#: src/muuli_wdr.cpp:2991
 msgid "Enable authentication"
 msgstr "Activar identificación"
 
-#: src/muuli_wdr.cpp:3020
+#: src/muuli_wdr.cpp:2992
 msgid "Enable/disable username/password authentication"
 msgstr "Activar/desactivar a identificación mediante nome de usuario e contrasinal"
 
-#: src/muuli_wdr.cpp:3023
+#: src/muuli_wdr.cpp:2995
 msgid "Username: "
 msgstr "Nome de usuario: "
 
-#: src/muuli_wdr.cpp:3026
+#: src/muuli_wdr.cpp:2998
 msgid "The username to use to connect to the proxy"
 msgstr "O nome de usuario a usar para conectarse ao proxy"
 
-#: src/muuli_wdr.cpp:3028
+#: src/muuli_wdr.cpp:3000
 msgid "Password:"
 msgstr "Contrasinal:"
 
-#: src/muuli_wdr.cpp:3031
+#: src/muuli_wdr.cpp:3003
 msgid "The password to use to connect to the proxy"
 msgstr "O contrasinal a empregar para conectarse ao proxy"
 
-#: src/muuli_wdr.cpp:3050
+#: src/muuli_wdr.cpp:3022
 msgid "Connect to:"
 msgstr "Conectar a:"
 
-#: src/muuli_wdr.cpp:3059
+#: src/muuli_wdr.cpp:3031
 msgid "Login to remote amule"
 msgstr "Conectar a amule remoto"
 
-#: src/muuli_wdr.cpp:3064
+#: src/muuli_wdr.cpp:3036
 msgid "User name"
 msgstr "Nome de usuario"
 
-#: src/muuli_wdr.cpp:3075
+#: src/muuli_wdr.cpp:3047
 msgid "Remember those settings"
 msgstr "Recordar esas opcións"
 
-#: src/muuli_wdr.cpp:3078
+#: src/muuli_wdr.cpp:3050
 #, fuzzy
 msgid "Force ZLIB compression"
 msgstr "Usar compresión gzip"
 
-#: src/muuli_wdr.cpp:3102
+#: src/muuli_wdr.cpp:3074
 msgid "Enable Verbose Debug-Logging."
 msgstr "Activar Rexistro de Depuración Estendido."
 
-#: src/muuli_wdr.cpp:3104
+#: src/muuli_wdr.cpp:3076
 msgid "Only to Logfile"
 msgstr "Só ao ficheiro do rexistro"
 
-#: src/muuli_wdr.cpp:3106
+#: src/muuli_wdr.cpp:3078
 msgid "Message Categories:"
 msgstr "Categorías das mensaxes:"
 
-#: src/muuli_wdr.cpp:3130 src/PartFileConvertDlg.cpp:160
+#: src/muuli_wdr.cpp:3102 src/PartFileConvertDlg.cpp:160
 msgid "Waiting..."
 msgstr "Agardando..."
 
-#: src/muuli_wdr.cpp:3150
+#: src/muuli_wdr.cpp:3122
 msgid "Add imports"
 msgstr "Engadir importados"
 
-#: src/muuli_wdr.cpp:3153
+#: src/muuli_wdr.cpp:3125
 msgid "Retry selected"
 msgstr "Tentar de novo o seleccionado"
 
-#: src/muuli_wdr.cpp:3155
+#: src/muuli_wdr.cpp:3127
 msgid "Remove selected"
 msgstr "Borrar seleccionados"
 
-#: src/muuli_wdr.cpp:3218
+#: src/muuli_wdr.cpp:3190
 msgid "Event Types"
 msgstr "Tipos de eventos"
 
-#: src/muuli_wdr.cpp:3237
+#: src/muuli_wdr.cpp:3209
 msgid "Statistics and queued clients for selected file(s) : Session / All time"
 msgstr "Estadísticas e clientes esperando para os ficheiros seleccionados: Sesión / Total"
 
-#: src/muuli_wdr.cpp:3261
+#: src/muuli_wdr.cpp:3233
 msgid "Active Uploads"
 msgstr "Envíos activos"
 
-#: src/muuli_wdr.cpp:3275
+#: src/muuli_wdr.cpp:3247
 msgid "Percent of total files"
 msgstr "Porcentaxe de todos os ficheiros"
 
-#: src/muuli_wdr.cpp:3327
+#: src/muuli_wdr.cpp:3299
 msgid "Show Clients for"
 msgstr "Amosar clientes para"
 
-#: src/muuli_wdr.cpp:3329
+#: src/muuli_wdr.cpp:3301
 msgid "All files"
 msgstr "Todos os ficheiros"
 
-#: src/muuli_wdr.cpp:3332
+#: src/muuli_wdr.cpp:3304
 msgid "Selected files"
 msgstr "Ficheiros selecionados"
 
-#: src/muuli_wdr.cpp:3335
+#: src/muuli_wdr.cpp:3307
 msgid "Active uploads only"
 msgstr "Só subidas activas"
 
-#: src/muuli_wdr.cpp:3342
+#: src/muuli_wdr.cpp:3314
 msgid "Reload:"
 msgstr "Recargar:"
 
-#: src/muuli_wdr.cpp:3346
+#: src/muuli_wdr.cpp:3318
 msgid "Reload your shared files"
 msgstr "Recargar os seus ficheiros compartidos"
 
-#: src/muuli_wdr.cpp:3409
+#: src/muuli_wdr.cpp:3381
 msgid "Send"
 msgstr "Enviar"
 
-#: src/muuli_wdr.cpp:3410
+#: src/muuli_wdr.cpp:3382
 msgid "Sends the specified message."
 msgstr "Enviar a mensaxe especificada."
 
-#: src/muuli_wdr.cpp:3414
+#: src/muuli_wdr.cpp:3386
 msgid "Close this chat-session."
 msgstr "Pechar esta conversa."
 
-#: src/muuli_wdr.cpp:3437
+#: src/muuli_wdr.cpp:3409
 msgid "Connect to any server and/or Kad"
 msgstr "Conectar a calquera servidor e/ou Kad"
 
-#: src/muuli_wdr.cpp:3443 src/SharedFilesCtrl.cpp:142 src/Statistics.cpp:941
+#: src/muuli_wdr.cpp:3415 src/SharedFilesCtrl.cpp:142 src/Statistics.cpp:941
 msgid "Shared Files"
 msgstr "Ficheiros compartidos"
 
@@ -5474,249 +5440,249 @@ msgstr "Descargado"
 msgid "ERROR: Failed to open partfile '%s'"
 msgstr "ERRO: Non se puido abrir o partfile «%s»"
 
-#: src/Preferences.cpp:701
+#: src/Preferences.cpp:673
 msgid "System default"
 msgstr "Predeterminado"
 
-#: src/Preferences.cpp:702
+#: src/Preferences.cpp:674
 msgid "Albanian"
 msgstr "Albanés"
 
-#: src/Preferences.cpp:703
+#: src/Preferences.cpp:675
 msgid "Arabic"
 msgstr "Árabe"
 
-#: src/Preferences.cpp:704
+#: src/Preferences.cpp:676
 msgid "Asturian"
 msgstr "Asturiano"
 
-#: src/Preferences.cpp:705
+#: src/Preferences.cpp:677
 msgid "Basque"
 msgstr "Euskera"
 
-#: src/Preferences.cpp:706
+#: src/Preferences.cpp:678
 msgid "Bulgarian"
 msgstr "Búlgaro"
 
-#: src/Preferences.cpp:707
+#: src/Preferences.cpp:679
 msgid "Catalan"
 msgstr "Catalán"
 
-#: src/Preferences.cpp:708
+#: src/Preferences.cpp:680
 msgid "Chinese (Simplified)"
 msgstr "Chinés (Simplificado)"
 
-#: src/Preferences.cpp:709
+#: src/Preferences.cpp:681
 msgid "Chinese (Traditional)"
 msgstr "Chinés (Tradicional)"
 
-#: src/Preferences.cpp:710
+#: src/Preferences.cpp:682
 msgid "Croatian"
 msgstr "Croata"
 
-#: src/Preferences.cpp:711
+#: src/Preferences.cpp:683
 msgid "Czech"
 msgstr "Checo"
 
-#: src/Preferences.cpp:712
+#: src/Preferences.cpp:684
 msgid "Danish"
 msgstr "Danés"
 
-#: src/Preferences.cpp:713
+#: src/Preferences.cpp:685
 msgid "Dutch"
 msgstr "Holandés"
 
-#: src/Preferences.cpp:714
+#: src/Preferences.cpp:686
 msgid "English (U.K.)"
 msgstr "Inglés (R. U.)"
 
-#: src/Preferences.cpp:715
+#: src/Preferences.cpp:687
 #, fuzzy
 msgid "English (U.S.)"
 msgstr "Inglés (R. U.)"
 
-#: src/Preferences.cpp:716
+#: src/Preferences.cpp:688
 msgid "Estonian"
 msgstr "Estonio"
 
-#: src/Preferences.cpp:717
+#: src/Preferences.cpp:689
 msgid "Finnish"
 msgstr "Finlandés"
 
-#: src/Preferences.cpp:718
+#: src/Preferences.cpp:690
 msgid "French"
 msgstr "Francés"
 
-#: src/Preferences.cpp:719
+#: src/Preferences.cpp:691
 msgid "Galician"
 msgstr "Galego"
 
-#: src/Preferences.cpp:720
+#: src/Preferences.cpp:692
 msgid "German"
 msgstr "Alemán"
 
-#: src/Preferences.cpp:721
+#: src/Preferences.cpp:693
 msgid "Greek"
 msgstr "Grego"
 
-#: src/Preferences.cpp:722
+#: src/Preferences.cpp:694
 msgid "Hebrew"
 msgstr "Hebreo"
 
-#: src/Preferences.cpp:723
+#: src/Preferences.cpp:695
 msgid "Hungarian"
 msgstr "Húngaro"
 
-#: src/Preferences.cpp:724
+#: src/Preferences.cpp:696
 msgid "Italian"
 msgstr "Italiano"
 
-#: src/Preferences.cpp:725
+#: src/Preferences.cpp:697
 msgid "Japanese"
 msgstr "Xaponés"
 
-#: src/Preferences.cpp:726
+#: src/Preferences.cpp:698
 msgid "Korean"
 msgstr "Coreano"
 
-#: src/Preferences.cpp:727
+#: src/Preferences.cpp:699
 msgid "Latvian"
 msgstr ""
 
-#: src/Preferences.cpp:728
+#: src/Preferences.cpp:700
 msgid "Lithuanian"
 msgstr "Lituano"
 
-#: src/Preferences.cpp:729
+#: src/Preferences.cpp:701
 msgid "Norwegian (Nynorsk)"
 msgstr "Noruegués (Nynorsk)"
 
-#: src/Preferences.cpp:730
+#: src/Preferences.cpp:702
 msgid "Polish"
 msgstr "Polaco"
 
-#: src/Preferences.cpp:731
+#: src/Preferences.cpp:703
 msgid "Portuguese"
 msgstr "Portugués"
 
-#: src/Preferences.cpp:732
+#: src/Preferences.cpp:704
 msgid "Portuguese (Brazilian)"
 msgstr "Portugués (Brasileiro)"
 
-#: src/Preferences.cpp:733
+#: src/Preferences.cpp:705
 msgid "Romanian"
 msgstr "Rumano"
 
-#: src/Preferences.cpp:734
+#: src/Preferences.cpp:706
 msgid "Russian"
 msgstr "Ruso"
 
-#: src/Preferences.cpp:735
+#: src/Preferences.cpp:707
 msgid "Slovenian"
 msgstr "Esloveno"
 
-#: src/Preferences.cpp:736
+#: src/Preferences.cpp:708
 msgid "Spanish"
 msgstr "Castelán"
 
-#: src/Preferences.cpp:737
+#: src/Preferences.cpp:709
 msgid "Swedish"
 msgstr "Sueco"
 
-#: src/Preferences.cpp:738
+#: src/Preferences.cpp:710
 msgid "Turkish"
 msgstr "Turco"
 
-#: src/Preferences.cpp:739
+#: src/Preferences.cpp:711
 msgid "Ukrainian"
 msgstr "Ucraniano"
 
-#: src/Preferences.cpp:842
+#: src/Preferences.cpp:814
 msgid "Change Language"
 msgstr "Cambiar idioma"
 
-#: src/Preferences.cpp:906
+#: src/Preferences.cpp:878
 msgid "There are no translations installed for aMule"
 msgstr "Non hai traducións instaladas para aMule"
 
-#: src/Preferences.cpp:907
+#: src/Preferences.cpp:879
 msgid "No languages available"
 msgstr "Ningunha lingua dispoñible"
 
-#: src/Preferences.cpp:1038
+#: src/Preferences.cpp:1010
 msgid "no options available"
 msgstr "non hai opcións disponibles"
 
-#: src/Preferences.cpp:2226
+#: src/Preferences.cpp:2179
 msgid "Invalid category found, skipping"
 msgstr "Categoría inválida atopada, saltandoa"
 
-#: src/Preferences.cpp:2395
+#: src/Preferences.cpp:2348
 msgid "TCP port can't be higher than 65532 due to server UDP socket being TCP+3"
 msgstr "O porto TCP non pode ser máis alto que 65532 debido a que o socket do servidor UDP é TCP+3"
 
-#: src/Preferences.cpp:2396
+#: src/Preferences.cpp:2349
 #, c-format
 msgid "Default port will be used (%d)"
 msgstr "Empregarase o porto predeterminado (%d)"
 
-#: src/PrefsUnifiedDlg.cpp:300 src/Statistics.cpp:866
+#: src/PrefsUnifiedDlg.cpp:298 src/Statistics.cpp:866
 msgid "Connection"
 msgstr "Conexión"
 
-#: src/PrefsUnifiedDlg.cpp:301 src/SearchListCtrl.cpp:117
+#: src/PrefsUnifiedDlg.cpp:299 src/SearchListCtrl.cpp:117
 msgid "Directories"
 msgstr "Cartafoles"
 
-#: src/PrefsUnifiedDlg.cpp:302 src/Statistics.cpp:917
+#: src/PrefsUnifiedDlg.cpp:300 src/Statistics.cpp:917
 msgid "Servers"
 msgstr "Servidores"
 
-#: src/PrefsUnifiedDlg.cpp:303 src/ServerListCtrl.cpp:96
+#: src/PrefsUnifiedDlg.cpp:301 src/ServerListCtrl.cpp:96
 msgid "Files"
 msgstr "Ficheiros"
 
-#: src/PrefsUnifiedDlg.cpp:304
+#: src/PrefsUnifiedDlg.cpp:302
 msgid "Security"
 msgstr "Seguranza"
 
-#: src/PrefsUnifiedDlg.cpp:305
+#: src/PrefsUnifiedDlg.cpp:303
 msgid "Interface"
 msgstr "Interface"
 
-#: src/PrefsUnifiedDlg.cpp:312
+#: src/PrefsUnifiedDlg.cpp:310
 msgid "IP2Country"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:315
+#: src/PrefsUnifiedDlg.cpp:313
 msgid "Proxy"
 msgstr "Proxy"
 
-#: src/PrefsUnifiedDlg.cpp:316
+#: src/PrefsUnifiedDlg.cpp:314
 msgid "Filters"
 msgstr "Filtros"
 
-#: src/PrefsUnifiedDlg.cpp:317
+#: src/PrefsUnifiedDlg.cpp:315
 msgid "Remote Controls"
 msgstr "Controles remotos"
 
-#: src/PrefsUnifiedDlg.cpp:318
+#: src/PrefsUnifiedDlg.cpp:316
 msgid "Online Signature"
 msgstr "Sinatura En liña"
 
-#: src/PrefsUnifiedDlg.cpp:319
+#: src/PrefsUnifiedDlg.cpp:317
 msgid "Advanced"
 msgstr "Avanzado"
 
-#: src/PrefsUnifiedDlg.cpp:320
+#: src/PrefsUnifiedDlg.cpp:318
 msgid "Events"
 msgstr "Eventos"
 
-#: src/PrefsUnifiedDlg.cpp:323
+#: src/PrefsUnifiedDlg.cpp:321
 msgid "Debugging"
 msgstr "Depuración"
 
-#: src/PrefsUnifiedDlg.cpp:453
+#: src/PrefsUnifiedDlg.cpp:451
 msgid ""
 "The following variables will be substituted:\n"
 "    %PARTFILE - full path to the file\n"
@@ -5726,15 +5692,15 @@ msgstr ""
 "    %PARTFILE - ruta completa do ficheiro\n"
 "    %PARTNAME - nome do ficheiro"
 
-#: src/PrefsUnifiedDlg.cpp:474
+#: src/PrefsUnifiedDlg.cpp:472
 msgid "Tray icon support requires libayatana-appindicator3 at compile time."
 msgstr "Para poder engadir unha icona precisa ter libayatana-appindicator3 durante a compilación."
 
-#: src/PrefsUnifiedDlg.cpp:490
+#: src/PrefsUnifiedDlg.cpp:488
 msgid "Not available on Wayland: the protocol does not report when a window is minimized, so this option cannot intercept the system minimize button. Workaround: launch aMule with `GDK_BACKEND=x11` to use XWayland instead."
 msgstr "Non dispoñible en Wayland: o protocolo non pode avisar se se minimiza unha xanela, polo que non se pode interceptar o botón de minimizar. Como alternativa, execute aMule con «GDK_BACKEND=x11» para usar XWayland."
 
-#: src/PrefsUnifiedDlg.cpp:536
+#: src/PrefsUnifiedDlg.cpp:534
 msgid ""
 "Do not change these setting unless you know\n"
 "what you are doing, otherwise you can easily\n"
@@ -5750,35 +5716,26 @@ msgstr ""
 "aMule funcionará ben sen que cambie ningún\n"
 "destes parámetros."
 
-#: src/PrefsUnifiedDlg.cpp:647
+#: src/PrefsUnifiedDlg.cpp:645
 #, c-format
 msgid "Failed to connect Cfg to widget with the ID %d and key %s"
 msgstr "Non se puido conectar a configuración ao compoñente coa ID %d e chave %s"
 
-#: src/PrefsUnifiedDlg.cpp:695
+#: src/PrefsUnifiedDlg.cpp:693
 #, c-format
 msgid "Failed to transfer data from Cfg to Widget with the ID %d and key %s"
 msgstr "Non se puido transferir información dende a configuración ao compoñente con ID %d e chave %s"
 
-#: src/PrefsUnifiedDlg.cpp:801
+#: src/PrefsUnifiedDlg.cpp:799
 msgid "The type of proxy you are connecting to"
 msgstr "O tipo de proxy ao que se está a conectar"
 
-#: src/PrefsUnifiedDlg.cpp:1020
+#: src/PrefsUnifiedDlg.cpp:1003
 #, c-format
 msgid "Failed to transfer data from Widget to Cfg with the ID %d and key %s"
 msgstr "Non se puido transferir información entre o compoñente e a configuración con ID %d e chave %s"
 
 #: src/PrefsUnifiedDlg.cpp:1103
-#, fuzzy
-msgid "No password set."
-msgstr "Comprobando contrasinal\n"
-
-#: src/PrefsUnifiedDlg.cpp:1132
-msgid "Guest access needs a password. Type one in the guest password field, or untick Enable guest access."
-msgstr ""
-
-#: src/PrefsUnifiedDlg.cpp:1144
 msgid ""
 "aMule must be restarted to enable these changes:\n"
 "\n"
@@ -5786,41 +5743,41 @@ msgstr ""
 "aMule debe ser reiniciado para activar estes trocos:\n"
 "\n"
 
-#: src/PrefsUnifiedDlg.cpp:1151
+#: src/PrefsUnifiedDlg.cpp:1110
 msgid "- TCP port changed.\n"
 msgstr "- Porto TCP cambiado.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1156
+#: src/PrefsUnifiedDlg.cpp:1115
 msgid "- UDP port changed.\n"
 msgstr "- Porto UDP cambiado.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1161
+#: src/PrefsUnifiedDlg.cpp:1120
 #, fuzzy
 msgid "- Network interface binding changed.\n"
 msgstr "- Cambiada interface da conexión externa.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1166
+#: src/PrefsUnifiedDlg.cpp:1125
 msgid "- External connect port changed.\n"
 msgstr "- Cambiado o porto da conexión externa.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1170
+#: src/PrefsUnifiedDlg.cpp:1129
 msgid "- External connect acceptance changed.\n"
 msgstr "- Cambiada a aceptación da conexión externa.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1174
+#: src/PrefsUnifiedDlg.cpp:1133
 msgid "- External connect interface changed.\n"
 msgstr "- Cambiada interface da conexión externa.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1178
+#: src/PrefsUnifiedDlg.cpp:1137
 msgid "- Protocol obfuscation support changed.\n"
 msgstr "- Cambiada opción da ofuscación do protocolo.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1193
+#: src/PrefsUnifiedDlg.cpp:1151
 #, fuzzy
 msgid "- amuleapi settings changed.\n"
 msgstr "- Idioma cambiado.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1202
+#: src/PrefsUnifiedDlg.cpp:1160
 msgid ""
 "Your Auto-update server list is empty.\n"
 "'Auto-update server list at startup' will be disabled."
@@ -5828,7 +5785,7 @@ msgstr ""
 "A túa lista de servidores para auto-actualizar está baleira.\n"
 "Desactivarase a actualización no inicio."
 
-#: src/PrefsUnifiedDlg.cpp:1213
+#: src/PrefsUnifiedDlg.cpp:1171
 msgid ""
 "You have enabled external connections but have not specified a password.\n"
 "External connections cannot be enabled unless a valid password is specified."
@@ -5836,33 +5793,28 @@ msgstr ""
 "Permítense conexións externas pero non se especificou un contrasinal.\n"
 "As conexións externas non poden ser activadas ate que se especifique un contrasinal válido."
 
-#: src/PrefsUnifiedDlg.cpp:1246
-#, c-format
-msgid "The amuleapi password could not be saved: %s"
-msgstr ""
-
-#: src/PrefsUnifiedDlg.cpp:1276
+#: src/PrefsUnifiedDlg.cpp:1202
 msgid "- Language changed.\n"
 msgstr "- Idioma cambiado.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1281
+#: src/PrefsUnifiedDlg.cpp:1207
 msgid "- Temp folder changed.\n"
 msgstr "- Cartafol temporal cambiado.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1286
+#: src/PrefsUnifiedDlg.cpp:1212
 msgid "- ED2K network enabled.\n"
 msgstr "- Rede eD2K activada.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1319
+#: src/PrefsUnifiedDlg.cpp:1245
 msgid "The shared-file exclusion pattern is not a valid regular expression. The filter has been left disabled."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1321 src/PrefsUnifiedDlg.cpp:1921
+#: src/PrefsUnifiedDlg.cpp:1247 src/PrefsUnifiedDlg.cpp:1841
 #, fuzzy
 msgid "Invalid regular expression"
 msgstr "Versión do protocolo inválida."
 
-#: src/PrefsUnifiedDlg.cpp:1398
+#: src/PrefsUnifiedDlg.cpp:1324
 msgid ""
 "Both eD2k and Kad network are disabled.\n"
 "You won't be able to connect until you enable at least one of them."
@@ -5870,7 +5822,7 @@ msgstr ""
 "Tanto eD2k e Kad están desactivados.\n"
 "Non poderás conectarte ate activar algún dous."
 
-#: src/PrefsUnifiedDlg.cpp:1403
+#: src/PrefsUnifiedDlg.cpp:1329
 msgid ""
 "Kad will not start if your UDP port is disabled.\n"
 "Enable UDP port or disable Kad."
@@ -5878,7 +5830,7 @@ msgstr ""
 "Kad non se iniciará se non está activado o porto UDP.\n"
 "Active o porto UDP ou desactive Kad."
 
-#: src/PrefsUnifiedDlg.cpp:1459
+#: src/PrefsUnifiedDlg.cpp:1385
 msgid ""
 "\n"
 "You MUST restart aMule now.\n"
@@ -5888,71 +5840,71 @@ msgstr ""
 "Debe reiniciar o aMule agora.\n"
 "Se non o reinicia agora, ature coas consecuencias.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1524
+#: src/PrefsUnifiedDlg.cpp:1450
 msgid "Could not register aMule for autostart at login. The autostart store may be read-only."
 msgstr "Non se puido configurar para que aMule arranque ao iniciar sesión. Pode ser que a configuración non permita modificacións."
 
-#: src/PrefsUnifiedDlg.cpp:1526
+#: src/PrefsUnifiedDlg.cpp:1452
 msgid "Could not remove the autostart-at-login entry."
 msgstr "Non se puido quitar o arranque ao inicio da configuración."
 
-#: src/PrefsUnifiedDlg.cpp:1527
+#: src/PrefsUnifiedDlg.cpp:1453
 msgid "Autostart"
 msgstr "Arrancar ao inicio"
 
-#: src/PrefsUnifiedDlg.cpp:1542
+#: src/PrefsUnifiedDlg.cpp:1468
 msgid "Register file type"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1542
+#: src/PrefsUnifiedDlg.cpp:1468
 msgid "Register URL handler"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1550
+#: src/PrefsUnifiedDlg.cpp:1476
 #, c-format
 msgid "aMule only handles eD2k-compatible magnets. If you replace the current magnet handler (%s), BitTorrent magnet links will stop working - aMule cannot download BitTorrent content. Continue?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1555
+#: src/PrefsUnifiedDlg.cpp:1481
 #, c-format
 msgid "Another application currently opens .emulecollection files (%s). Replace it with aMule?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1560
+#: src/PrefsUnifiedDlg.cpp:1486
 #, c-format
 msgid "Another application is currently the default handler for these links (%s). Replace it with aMule?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1585
+#: src/PrefsUnifiedDlg.cpp:1511
 #, fuzzy
 msgid "Could not register aMule for .emulecollection files. The registration store may be read-only."
 msgstr "Non se puido configurar para que aMule arranque ao iniciar sesión. Pode ser que a configuración non permita modificacións."
 
-#: src/PrefsUnifiedDlg.cpp:1587
+#: src/PrefsUnifiedDlg.cpp:1513
 #, fuzzy
 msgid "Could not remove the file type registration."
 msgstr "Non se puido quitar o arranque ao inicio da configuración."
 
-#: src/PrefsUnifiedDlg.cpp:1589
+#: src/PrefsUnifiedDlg.cpp:1515
 #, fuzzy
 msgid "Could not register aMule as the URL handler. The registration store may be read-only."
 msgstr "Non se puido configurar para que aMule arranque ao iniciar sesión. Pode ser que a configuración non permita modificacións."
 
-#: src/PrefsUnifiedDlg.cpp:1591
+#: src/PrefsUnifiedDlg.cpp:1517
 #, fuzzy
 msgid "Could not remove the URL handler registration."
 msgstr "Non se puido quitar o arranque ao inicio da configuración."
 
-#: src/PrefsUnifiedDlg.cpp:1661 src/PrefsUnifiedDlg.cpp:1688
+#: src/PrefsUnifiedDlg.cpp:1587 src/PrefsUnifiedDlg.cpp:1614
 #, fuzzy
 msgid "The web server and aMule API require external connections to be enabled."
 msgstr "Establecido o contrasinal e habilitadas conexións externas."
 
-#: src/PrefsUnifiedDlg.cpp:1671
+#: src/PrefsUnifiedDlg.cpp:1597
 msgid "The aMule web server is deprecated. Consider running the aMule API instead."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1735
+#: src/PrefsUnifiedDlg.cpp:1655
 msgid ""
 "Your Auto-update servers list is in blank.\n"
 "Please fill in at least one URL to point to a valid server.met file.\n"
@@ -5962,66 +5914,66 @@ msgstr ""
 "Introduza polo menos unha URL dun ficheiro server.met.\n"
 "Prema no botón «Listar» para introducir unha URL."
 
-#: src/PrefsUnifiedDlg.cpp:1876
+#: src/PrefsUnifiedDlg.cpp:1796
 msgid "Temporary files"
 msgstr "Ficheiros temporais"
 
-#: src/PrefsUnifiedDlg.cpp:1881
+#: src/PrefsUnifiedDlg.cpp:1801
 msgid "Incoming files"
 msgstr "Ficheiros entrantes"
 
-#: src/PrefsUnifiedDlg.cpp:1886
+#: src/PrefsUnifiedDlg.cpp:1806
 msgid "Online Signatures"
 msgstr "Sinaturas En Liña"
 
-#: src/PrefsUnifiedDlg.cpp:1899
+#: src/PrefsUnifiedDlg.cpp:1819
 #, c-format
 msgid "Choose a folder for %s"
 msgstr "Escolla un cartafol para %s"
 
-#: src/PrefsUnifiedDlg.cpp:1923
+#: src/PrefsUnifiedDlg.cpp:1843
 #, fuzzy, c-format
 msgid "Would exclude %u of %u shared file"
 msgid_plural "Would exclude %u of %u shared files"
 msgstr[0] "Atopado %i ficheiro compartido"
 msgstr[1] "Atopados %i ficheiros compartidos"
 
-#: src/PrefsUnifiedDlg.cpp:1940
+#: src/PrefsUnifiedDlg.cpp:1860
 msgid "Browse for videoplayer"
 msgstr "Atopar o reprodutor de vídeo"
 
-#: src/PrefsUnifiedDlg.cpp:1944
+#: src/PrefsUnifiedDlg.cpp:1864
 msgid "Select browser"
 msgstr "Seleccione o navegador"
 
-#: src/PrefsUnifiedDlg.cpp:1948
+#: src/PrefsUnifiedDlg.cpp:1868
 #, fuzzy
 msgid "Select ffprobe binary"
 msgstr "Seleccione o navegador"
 
-#: src/PrefsUnifiedDlg.cpp:1954
+#: src/PrefsUnifiedDlg.cpp:1874
 #, c-format
 msgid "Executable%s"
 msgstr "Executable%s"
 
-#: src/PrefsUnifiedDlg.cpp:1988
+#: src/PrefsUnifiedDlg.cpp:1908
 msgid "ffprobe not found on PATH or in the standard install locations. Install ffmpeg (which ships ffprobe) or use Browse to pick a binary manually."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2000
+#: src/PrefsUnifiedDlg.cpp:1920
 msgid "Reset the settings on this page to their default values?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2001
+#: src/PrefsUnifiedDlg.cpp:1921
 #, fuzzy
 msgid "Reset to defaults"
 msgstr "Predeterminado"
 
-#: src/PrefsUnifiedDlg.cpp:2028
+#: src/PrefsUnifiedDlg.cpp:1948
 msgid "Edit server list"
 msgstr "Editar a lista dos servidores"
 
-#: src/PrefsUnifiedDlg.cpp:2029
+#: src/PrefsUnifiedDlg.cpp:1949
 msgid ""
 "Add here URL's to download server.met files.\n"
 "Only one url on each line."
@@ -6029,115 +5981,115 @@ msgstr ""
 "Engadir aquí unha URL para descargar unha lista server.met.\n"
 "Só unha url nesta liña."
 
-#: src/PrefsUnifiedDlg.cpp:2084
+#: src/PrefsUnifiedDlg.cpp:2004
 msgid "IP2Country update failed"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2229 src/PrefsUnifiedDlg.cpp:2260
+#: src/PrefsUnifiedDlg.cpp:2149 src/PrefsUnifiedDlg.cpp:2180
 msgid "Data by MaxMind GeoLite2"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2231 src/PrefsUnifiedDlg.cpp:2262
+#: src/PrefsUnifiedDlg.cpp:2151 src/PrefsUnifiedDlg.cpp:2182
 #, fuzzy
 msgid "Custom source"
 msgstr "Fontes completas"
 
-#: src/PrefsUnifiedDlg.cpp:2233 src/PrefsUnifiedDlg.cpp:2264
+#: src/PrefsUnifiedDlg.cpp:2153 src/PrefsUnifiedDlg.cpp:2184
 msgid "Data by DB-IP.com"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2284
+#: src/PrefsUnifiedDlg.cpp:2204
 #, fuzzy, c-format
 msgid "Status: Loaded%s"
 msgstr "Estado:"
 
-#: src/PrefsUnifiedDlg.cpp:2286
+#: src/PrefsUnifiedDlg.cpp:2206
 #, fuzzy, c-format
 msgid "Status: Loaded%s - %s"
 msgstr "Estado:"
 
-#: src/PrefsUnifiedDlg.cpp:2290
+#: src/PrefsUnifiedDlg.cpp:2210
 msgid "Status: Failed to load - click 'Update now' to refresh."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2292
+#: src/PrefsUnifiedDlg.cpp:2212
 msgid "Status: Not found - click 'Update now' to download."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2350 src/PrefsUnifiedDlg.cpp:2374
+#: src/PrefsUnifiedDlg.cpp:2270 src/PrefsUnifiedDlg.cpp:2294
 #, c-format
 msgid "Update delay: %d second"
 msgid_plural "Update delay: %d seconds"
 msgstr[0] "Período de actualización: %d segundo"
 msgstr[1] "Período de actualización: %d segundos"
 
-#: src/PrefsUnifiedDlg.cpp:2358
+#: src/PrefsUnifiedDlg.cpp:2278
 #, c-format
 msgid "Time for average graph: %d minute"
 msgid_plural "Time for average graph: %d minutes"
 msgstr[0] "Tempo medio de gráfico: %d min"
 msgstr[1] "Tempo medio de gráfico: %d min"
 
-#: src/PrefsUnifiedDlg.cpp:2367
+#: src/PrefsUnifiedDlg.cpp:2287
 #, c-format
 msgid "Connections Graph Scale: %d"
 msgstr "Escala gráfica das conexións: %d"
 
-#: src/PrefsUnifiedDlg.cpp:2382
+#: src/PrefsUnifiedDlg.cpp:2302
 #, c-format
 msgid "File Buffer Size: %d byte"
 msgid_plural "File Buffer Size: %d bytes"
 msgstr[0] "Tamaño do búfer dos ficheiros: %d octeto"
 msgstr[1] "Tamaño do búfer dos ficheiros: %d octetos"
 
-#: src/PrefsUnifiedDlg.cpp:2392
+#: src/PrefsUnifiedDlg.cpp:2312
 #, c-format
 msgid "Upload Queue Size: %d client"
 msgid_plural "Upload Queue Size: %d clients"
 msgstr[0] "Tamaño da cola de subida: %d cliente"
 msgstr[1] "Tamaño da cola de subida: %d clientes"
 
-#: src/PrefsUnifiedDlg.cpp:2402
+#: src/PrefsUnifiedDlg.cpp:2322
 #, c-format
 msgid "Server connection refresh interval: %d minute"
 msgid_plural "Server connection refresh interval: %d minutes"
 msgstr[0] "Intervalo de actualización da conexión ao servidor: %d minuto"
 msgstr[1] "Intervalo de actualización da conexión ao servidor: %d minutos"
 
-#: src/PrefsUnifiedDlg.cpp:2407
+#: src/PrefsUnifiedDlg.cpp:2327
 msgid "Server connection refresh interval: Disabled"
 msgstr "Intervalo de actualización da conexión ao servidor. Desactivada"
 
-#: src/PrefsUnifiedDlg.cpp:2451
+#: src/PrefsUnifiedDlg.cpp:2371
 msgid "disabled"
 msgstr "desactivado"
 
-#: src/PrefsUnifiedDlg.cpp:2477
+#: src/PrefsUnifiedDlg.cpp:2397
 #, c-format
 msgid "Execute command on '%s' event"
 msgstr "Executar unha orde no evento «%s»"
 
-#: src/PrefsUnifiedDlg.cpp:2484
+#: src/PrefsUnifiedDlg.cpp:2404
 msgid "Enable command execution on core"
 msgstr "Activar execución de ordes no núcleo"
 
-#: src/PrefsUnifiedDlg.cpp:2496
+#: src/PrefsUnifiedDlg.cpp:2416
 msgid "Core command:"
 msgstr "Orde do núcleo:"
 
-#: src/PrefsUnifiedDlg.cpp:2512
+#: src/PrefsUnifiedDlg.cpp:2432
 msgid "Enable command execution on GUI"
 msgstr "Activar execución de ordes na interface gráfica"
 
-#: src/PrefsUnifiedDlg.cpp:2524
+#: src/PrefsUnifiedDlg.cpp:2444
 msgid "GUI command:"
 msgstr "Orde da interface gráfica:"
 
-#: src/PrefsUnifiedDlg.cpp:2540
+#: src/PrefsUnifiedDlg.cpp:2460
 msgid "The following variables will be replaced:"
 msgstr "As seguintes variables serán substituídas:"
 
-#: src/PrefsUnifiedDlg.cpp:2708
+#: src/PrefsUnifiedDlg.cpp:2628
 msgid ""
 "The following folders look like system or sensitive locations:\n"
 "\n"
@@ -6145,62 +6097,58 @@ msgstr ""
 "Estas carpetas semellan parte do sistema, ou que poden ser confidenciais:\n"
 "\n"
 
-#: src/PrefsUnifiedDlg.cpp:2713
+#: src/PrefsUnifiedDlg.cpp:2633
 msgid "Sharing them recursively will publish every file underneath on the eD2k/Kad networks. Do you really want to do this?"
 msgstr "Compartir de xeito recursivo publicará calquera ficheiro que teñan debaixo nas redes eD2k e Kad. Comprobe todo ben antes de continuar."
 
-#: src/PrefsUnifiedDlg.cpp:2716
+#: src/PrefsUnifiedDlg.cpp:2636
 msgid "Confirm shared folders"
 msgstr "Confirmar e compartir cartafoles"
 
-#: src/PrefsUnifiedDlg.cpp:2744
+#: src/PrefsUnifiedDlg.cpp:2664
 msgid "Reloading shared files..."
 msgstr "Recargando os ficheiros compartidos..."
 
-#: src/PrefsUnifiedDlg.cpp:2745
+#: src/PrefsUnifiedDlg.cpp:2665
 msgid "Scanning for subdirectories..."
 msgstr "Buscando subdirectorios..."
 
-#: src/PrefsUnifiedDlg.cpp:2746
+#: src/PrefsUnifiedDlg.cpp:2666
 msgid "Updating shared folders"
 msgstr "Actualizando os cartafoles compartidos"
 
-#: src/PrefsUnifiedDlg.cpp:2773
+#: src/PrefsUnifiedDlg.cpp:2693
 #, c-format
 msgid "Scanned %u directories..."
 msgstr "Buscáronse %u directorios..."
 
-#: src/PrefsUnifiedDlg.cpp:2823
+#: src/PrefsUnifiedDlg.cpp:2743
 #, c-format
 msgid "Reloading shared files: %u files scanned"
 msgstr "Recargouse a lista de ficheiros compartidos: atopáronse %u ficheiros"
 
-#: src/PrefsUnifiedDlg.cpp:2873
+#: src/PrefsUnifiedDlg.cpp:2793
 #, fuzzy
 msgid "Shared folder"
 msgstr "Cartafoles compartidos"
 
-#: src/SearchDlg.cpp:280
-msgid "Clear search history"
-msgstr ""
-
-#: src/SearchDlg.cpp:584
+#: src/SearchDlg.cpp:425
 msgid "It's impossible to search when both eD2k and Kademlia are disabled."
 msgstr "Non se pode buscar se tanto eD2k coma Kademlia están desactivados."
 
-#: src/SearchDlg.cpp:585 src/SearchListCtrl.cpp:858
+#: src/SearchDlg.cpp:426 src/SearchListCtrl.cpp:858
 msgid "Search error"
 msgstr "Erro na busca"
 
-#: src/SearchDlg.cpp:929
+#: src/SearchDlg.cpp:768
 msgid "Min size must be smaller than max size. Max size ignored."
 msgstr "O tamaño mínimo debe ser máis pequeno que o máximo. Tamaño máximo ignorado."
 
-#: src/SearchDlg.cpp:930 src/SearchDlg.cpp:1012
+#: src/SearchDlg.cpp:769 src/SearchDlg.cpp:851
 msgid "Search warning"
 msgstr "Aviso na busca"
 
-#: src/SearchDlg.cpp:1092 src/SearchListCtrl.cpp:735
+#: src/SearchDlg.cpp:929 src/SearchListCtrl.cpp:735
 msgid "Main"
 msgstr "Principal"
 

--- a/po/gl.po
+++ b/po/gl.po
@@ -24,7 +24,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-28 12:17+0200\n"
+"POT-Creation-Date: 2026-07-28 13:09+0200\n"
 "PO-Revision-Date: 2026-07-27 11:38+0000\n"
 "Last-Translator: Pablo <parodper@gmail.com>\n"
 "Language-Team: http://forum.amule.org/index.php?topic=13883\n"
@@ -313,7 +313,7 @@ msgid "Password set and external connections enabled."
 msgstr "Establecido o contrasinal e habilitadas conexións externas."
 
 #: src/amule.cpp:755 src/KadDlg.cpp:176 src/KadDlg.cpp:185
-#: src/PrefsUnifiedDlg.cpp:1461 src/SharedFilesCtrl.cpp:476
+#: src/PrefsUnifiedDlg.cpp:1470 src/SharedFilesCtrl.cpp:476
 msgid "WARNING"
 msgstr "AVISO"
 
@@ -351,7 +351,7 @@ msgstr "Solicitou executar o servidor web ó inicio pero non se puido executar o
 #: src/amule-remote-gui.cpp:603 src/amule-remote-gui.cpp:671
 #: src/amule-remote-gui.cpp:709 src/amule-remote-gui.cpp:1282
 #: src/amule-remote-gui.cpp:1345 src/amule-remote-gui.cpp:1372
-#: src/DownloadQueue.cpp:1481 src/PrefsUnifiedDlg.cpp:1247
+#: src/DownloadQueue.cpp:1481 src/PrefsUnifiedDlg.cpp:1256
 msgid "ERROR"
 msgstr "ERRO"
 
@@ -612,36 +612,36 @@ msgstr "Visite https://github.com/amule-org/amule/releases/latest para obter act
 msgid "FATAL ERROR: Failed to create Timer"
 msgstr "ERRO GRAVE: Non se puido crear o temporizador"
 
-#: src/amuleDlg.cpp:361 src/amuleDlg.cpp:1787 src/amuleDlg.cpp:2033
-#: src/muuli_wdr.cpp:1492 src/muuli_wdr.cpp:3449
+#: src/amuleDlg.cpp:361 src/amuleDlg.cpp:1810 src/amuleDlg.cpp:2056
+#: src/muuli_wdr.cpp:1492 src/muuli_wdr.cpp:3453
 msgid "Networks"
 msgstr "Redes"
 
-#: src/amuleDlg.cpp:362 src/amuleDlg.cpp:1793 src/muuli_wdr.cpp:3450
+#: src/amuleDlg.cpp:362 src/amuleDlg.cpp:1816 src/muuli_wdr.cpp:3454
 msgid "Searches"
 msgstr "Buscas"
 
-#: src/amuleDlg.cpp:363 src/amuleDlg.cpp:1799 src/DownloadListCtrl.cpp:740
-#: src/muuli_wdr.cpp:392 src/muuli_wdr.cpp:1585 src/muuli_wdr.cpp:3451
+#: src/amuleDlg.cpp:363 src/amuleDlg.cpp:1822 src/DownloadListCtrl.cpp:740
+#: src/muuli_wdr.cpp:392 src/muuli_wdr.cpp:1585 src/muuli_wdr.cpp:3455
 #: src/Statistics.cpp:829
 msgid "Downloads"
 msgstr "Descargas"
 
-#: src/amuleDlg.cpp:364 src/amuleDlg.cpp:1805 src/muuli_wdr.cpp:3325
+#: src/amuleDlg.cpp:364 src/amuleDlg.cpp:1828 src/muuli_wdr.cpp:3329
 msgid "Shared files"
 msgstr "Ficheiros compartidos"
 
-#: src/amuleDlg.cpp:365 src/amuleDlg.cpp:1811 src/muuli_wdr.cpp:2957
-#: src/muuli_wdr.cpp:3407 src/muuli_wdr.cpp:3454
+#: src/amuleDlg.cpp:365 src/amuleDlg.cpp:1834 src/muuli_wdr.cpp:2961
+#: src/muuli_wdr.cpp:3411 src/muuli_wdr.cpp:3458
 msgid "Messages"
 msgstr "Mensaxes"
 
-#: src/amuleDlg.cpp:366 src/amuleDlg.cpp:1817 src/muuli_wdr.cpp:3455
+#: src/amuleDlg.cpp:366 src/amuleDlg.cpp:1840 src/muuli_wdr.cpp:3459
 #: src/PrefsUnifiedDlg.cpp:314 src/Statistics.cpp:779 src/Statistics.cpp:1235
 msgid "Statistics"
 msgstr "Estadísticas"
 
-#: src/amuleDlg.cpp:368 src/amuleDlg.cpp:1824 src/muuli_wdr.cpp:3457
+#: src/amuleDlg.cpp:368 src/amuleDlg.cpp:1847 src/muuli_wdr.cpp:3461
 #: src/PrefsUnifiedDlg.cpp:330 src/utils/wxCas/src/wxcasprefs.cpp:39
 msgid "Preferences"
 msgstr "Preferencias"
@@ -700,8 +700,8 @@ msgstr "Kad: Apagado"
 #: src/amuleDlg.cpp:1029 src/DownloadListCtrl.cpp:505
 #: src/DownloadListCtrl.cpp:749 src/FriendListCtrl.cpp:180
 #: src/muuli_wdr.cpp:731 src/muuli_wdr.cpp:782 src/muuli_wdr.cpp:846
-#: src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2262 src/muuli_wdr.cpp:2347
-#: src/muuli_wdr.cpp:3095 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
+#: src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2266 src/muuli_wdr.cpp:2351
+#: src/muuli_wdr.cpp:3099 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
 #: src/ServerListCtrl.cpp:606 src/TransferWnd.cpp:378
 #: src/utils/wxCas/src/wxcasprefs.cpp:235
 msgid "Cancel"
@@ -712,7 +712,7 @@ msgid "Stop the current connection attempts"
 msgstr "Deter a tentativa actual de conexión"
 
 #: src/amuleDlg.cpp:1035 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976
-#: src/muuli_wdr.cpp:2485
+#: src/muuli_wdr.cpp:2489
 msgid "Disconnect"
 msgstr "Desconectar"
 
@@ -721,7 +721,7 @@ msgid "Disconnect from the currently connected networks"
 msgstr "Desconectar das redes conectadas"
 
 #: src/amuleDlg.cpp:1041 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979
-#: src/muuli_wdr.cpp:2640 src/muuli_wdr.cpp:3092 src/muuli_wdr.cpp:3447
+#: src/muuli_wdr.cpp:2644 src/muuli_wdr.cpp:3096 src/muuli_wdr.cpp:3451
 msgid "Connect"
 msgstr "Conectar"
 
@@ -775,7 +775,7 @@ msgstr "Confirmación da saída"
 msgid "Launch Command: "
 msgstr "Ordes de Arranque: "
 
-#: src/amuleDlg.cpp:1632 src/muuli_wdr.cpp:1982 src/Preferences.cpp:979
+#: src/amuleDlg.cpp:1632 src/muuli_wdr.cpp:1986 src/Preferences.cpp:979
 msgid "- default -"
 msgstr "- por omisión -"
 
@@ -789,60 +789,60 @@ msgstr "Non existe o directorio de temas «%s»"
 msgid "WARNING: Unable to open skin file '%s' for read"
 msgstr "AVISO: Non se puido abrir o ficheiro de temas «%s» en modo lectura"
 
-#: src/amuleDlg.cpp:1791 src/muuli_wdr.cpp:3449
+#: src/amuleDlg.cpp:1814 src/muuli_wdr.cpp:3453
 msgid "Networks Window"
 msgstr "Xanela de Redes"
 
-#: src/amuleDlg.cpp:1797 src/muuli_wdr.cpp:3450
+#: src/amuleDlg.cpp:1820 src/muuli_wdr.cpp:3454
 msgid "Searches Window"
 msgstr "Xanela de buscas"
 
-#: src/amuleDlg.cpp:1803 src/muuli_wdr.cpp:3451
+#: src/amuleDlg.cpp:1826 src/muuli_wdr.cpp:3455
 msgid "Downloads Window"
 msgstr "Xanela de descargas"
 
-#: src/amuleDlg.cpp:1809 src/muuli_wdr.cpp:3453
+#: src/amuleDlg.cpp:1832 src/muuli_wdr.cpp:3457
 msgid "Shared Files Window"
 msgstr "Xanela de ficheiros compartidos"
 
-#: src/amuleDlg.cpp:1815 src/muuli_wdr.cpp:3454
+#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3458
 msgid "Messages Window"
 msgstr "Xanela de mensaxes"
 
-#: src/amuleDlg.cpp:1821 src/muuli_wdr.cpp:3455
+#: src/amuleDlg.cpp:1844 src/muuli_wdr.cpp:3459
 msgid "Statistics Graph Window"
 msgstr "Xanela de gráficos de estadísticas"
 
-#: src/amuleDlg.cpp:1828 src/muuli_wdr.cpp:3457
+#: src/amuleDlg.cpp:1851 src/muuli_wdr.cpp:3461
 msgid "Preferences Settings Window"
 msgstr "Xanela de Preferencias"
 
-#: src/amuleDlg.cpp:1831 src/muuli_wdr.cpp:3458
+#: src/amuleDlg.cpp:1854 src/muuli_wdr.cpp:3462
 msgid "Import"
 msgstr "Importar"
 
-#: src/amuleDlg.cpp:1835 src/muuli_wdr.cpp:3458
+#: src/amuleDlg.cpp:1858 src/muuli_wdr.cpp:3462
 msgid "The partfile importer tool"
 msgstr "A ferramenta para importar ficheiros «part»"
 
-#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3459
+#: src/amuleDlg.cpp:1861 src/muuli_wdr.cpp:3463
 #: src/utils/aLinkCreator/src/alcframe.cpp:262
 msgid "About"
 msgstr "Sobre"
 
-#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3459
+#: src/amuleDlg.cpp:1861 src/muuli_wdr.cpp:3463
 msgid "About/Help"
 msgstr "Sobre/Axuda"
 
-#: src/amuleDlg.cpp:2036
+#: src/amuleDlg.cpp:2059
 msgid "eD2k network"
 msgstr "Rede eD2k"
 
-#: src/amuleDlg.cpp:2039
+#: src/amuleDlg.cpp:2062
 msgid "Kad network"
 msgstr "Red Kad"
 
-#: src/amuleDlg.cpp:2039
+#: src/amuleDlg.cpp:2062
 msgid "No network"
 msgstr "Sen rede"
 
@@ -1377,19 +1377,19 @@ msgstr "Auto [Al]"
 msgid "Very low"
 msgstr "Moi baixa"
 
-#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:743 src/muuli_wdr.cpp:2313
+#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:743 src/muuli_wdr.cpp:2317
 #: src/ServerListCtrl.cpp:263 src/ServerListCtrl.cpp:456
 #: src/SharedFilesCtrl.cpp:145
 msgid "Low"
 msgstr "Baixa"
 
-#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:744 src/muuli_wdr.cpp:2314
+#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:744 src/muuli_wdr.cpp:2318
 #: src/ServerListCtrl.cpp:266 src/ServerListCtrl.cpp:457
 #: src/SharedFilesCtrl.cpp:146
 msgid "Normal"
 msgstr "Normal"
 
-#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:745 src/muuli_wdr.cpp:2315
+#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:745 src/muuli_wdr.cpp:2319
 #: src/ServerListCtrl.cpp:269 src/ServerListCtrl.cpp:458
 #: src/SharedFilesCtrl.cpp:147
 msgid "High"
@@ -1481,7 +1481,7 @@ msgstr "Servidor local"
 msgid "Remote Server"
 msgstr "Servidor remoto"
 
-#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3212
+#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3216
 #: src/SearchDlg.cpp:119 src/TextClient.cpp:911
 msgid "Kad"
 msgstr "Kad"
@@ -1552,7 +1552,7 @@ msgstr "Parte"
 msgid "Size"
 msgstr "Tamaño"
 
-#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3279
+#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3283
 msgid "Transferred"
 msgstr "Transferido"
 
@@ -1610,7 +1610,7 @@ msgstr ""
 "Comentarios de : %s (%s)\n"
 "\n"
 
-#: src/DownloadListCtrl.cpp:746 src/muuli_wdr.cpp:2316
+#: src/DownloadListCtrl.cpp:746 src/muuli_wdr.cpp:2320
 #: src/SharedFilesCtrl.cpp:150
 msgid "Auto"
 msgstr "Automático"
@@ -1648,7 +1648,7 @@ msgid "Extended Options"
 msgstr "Opcións extendidas"
 
 #: src/DownloadListCtrl.cpp:770 src/DownloadListCtrl.cpp:822
-#: src/muuli_wdr.cpp:1800
+#: src/muuli_wdr.cpp:1804
 msgid "Preview"
 msgstr "Previsualizar"
 
@@ -2447,23 +2447,23 @@ msgid ""
 "want downloads on a different (e.g. larger) disk."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:549 src/FirstRunWizard.cpp:611 src/muuli_wdr.cpp:1712
+#: src/FirstRunWizard.cpp:549 src/FirstRunWizard.cpp:611 src/muuli_wdr.cpp:1716
 msgid "Destination folder for downloads"
 msgstr "Cartafol de destino para descargas"
 
 #: src/FirstRunWizard.cpp:553 src/FirstRunWizard.cpp:569 src/muuli_wdr.cpp:1349
-#: src/muuli_wdr.cpp:1366 src/muuli_wdr.cpp:1687 src/muuli_wdr.cpp:1718
-#: src/muuli_wdr.cpp:1730 src/muuli_wdr.cpp:2800
+#: src/muuli_wdr.cpp:1366 src/muuli_wdr.cpp:1691 src/muuli_wdr.cpp:1722
+#: src/muuli_wdr.cpp:1734 src/muuli_wdr.cpp:2804
 #: src/utils/aLinkCreator/src/alcframe.cpp:135
 #: src/utils/wxCas/src/wxcasprefs.cpp:52 src/utils/wxCas/src/wxcasprefs.cpp:118
 msgid "Browse"
 msgstr "Navegador"
 
-#: src/FirstRunWizard.cpp:559 src/muuli_wdr.cpp:1723
+#: src/FirstRunWizard.cpp:559 src/muuli_wdr.cpp:1727
 msgid "(All files in this folder are shared with other peers)"
 msgstr "(Compartiranse todos os ficheiros do cartafol co resto de parceiros)"
 
-#: src/FirstRunWizard.cpp:565 src/FirstRunWizard.cpp:624 src/muuli_wdr.cpp:1725
+#: src/FirstRunWizard.cpp:565 src/FirstRunWizard.cpp:624 src/muuli_wdr.cpp:1729
 msgid "Folder for temporary download files"
 msgstr "Cartafol para ficheiros de descarga temporais"
 
@@ -2494,7 +2494,7 @@ msgstr "Non se puido escribir a lista de amigos ao ficheiro «emfriends.met»!"
 msgid "CRITICAL - no client on StartChatSession"
 msgstr "CRÍTICO - non hai cliente en StartChatSession"
 
-#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2706 src/muuli_wdr.cpp:3383
+#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2710 src/muuli_wdr.cpp:3387
 msgid "Friends"
 msgstr "Amigos"
 
@@ -2604,8 +2604,8 @@ msgstr "Ningún"
 msgid "No"
 msgstr "Non"
 
-#: src/GenericClientListCtrl.cpp:1216 src/PrefsUnifiedDlg.cpp:2898
-#: src/PrefsUnifiedDlg.cpp:2948 src/ServerListCtrl.cpp:276
+#: src/GenericClientListCtrl.cpp:1216 src/PrefsUnifiedDlg.cpp:2907
+#: src/PrefsUnifiedDlg.cpp:2957 src/ServerListCtrl.cpp:276
 msgid "Yes"
 msgstr "Si"
 
@@ -2774,10 +2774,10 @@ msgstr "Porto inválido para o arranque"
 msgid "Please fill all fields required"
 msgstr "Enche todos os campos requiridos"
 
-#: src/KadDlg.cpp:192 src/PartFile.cpp:1031 src/PrefsUnifiedDlg.cpp:1134
-#: src/PrefsUnifiedDlg.cpp:1204 src/PrefsUnifiedDlg.cpp:1405
-#: src/PrefsUnifiedDlg.cpp:1663 src/PrefsUnifiedDlg.cpp:1673
-#: src/PrefsUnifiedDlg.cpp:1690 src/PrefsUnifiedDlg.cpp:1738
+#: src/KadDlg.cpp:192 src/PartFile.cpp:1031 src/PrefsUnifiedDlg.cpp:1143
+#: src/PrefsUnifiedDlg.cpp:1213 src/PrefsUnifiedDlg.cpp:1414
+#: src/PrefsUnifiedDlg.cpp:1672 src/PrefsUnifiedDlg.cpp:1682
+#: src/PrefsUnifiedDlg.cpp:1699 src/PrefsUnifiedDlg.cpp:1747
 msgid "Message"
 msgstr "Mensaxe"
 
@@ -2879,7 +2879,7 @@ msgstr "Relación enviado/descargado"
 msgid "Uploaded"
 msgstr "Enviado"
 
-#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3263
+#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3267
 msgid "Requested"
 msgstr "Solicitado"
 
@@ -3003,7 +3003,7 @@ msgid "WARNING: "
 msgstr "AVISO: "
 
 #: src/MuleNotebook.cpp:179 src/muuli_wdr.cpp:817 src/muuli_wdr.cpp:1229
-#: src/muuli_wdr.cpp:3167 src/muuli_wdr.cpp:3423
+#: src/muuli_wdr.cpp:3171 src/muuli_wdr.cpp:3427
 msgid "Close"
 msgstr "Pechar"
 
@@ -3021,7 +3021,7 @@ msgid "Paste"
 msgstr "Pegar"
 
 #: src/MuleTextCtrl.cpp:89 src/muuli_wdr.cpp:358 src/muuli_wdr.cpp:757
-#: src/muuli_wdr.cpp:2390 src/muuli_wdr.cpp:2409 src/muuli_wdr.cpp:2431
+#: src/muuli_wdr.cpp:2394 src/muuli_wdr.cpp:2413 src/muuli_wdr.cpp:2435
 #: src/utils/aLinkCreator/src/alcframe.cpp:142
 msgid "Clear"
 msgstr "Limpar"
@@ -3113,7 +3113,7 @@ msgstr "Saír"
 
 #: src/MuleTrayIcon.cpp:579 src/MuleTrayIcon.cpp:945 src/MuleTrayIcon.cpp:965
 #: src/muuli_wdr.cpp:1398 src/muuli_wdr.cpp:1406 src/muuli_wdr.cpp:1413
-#: src/muuli_wdr.cpp:1846 src/muuli_wdr.cpp:1852 src/OtherFunctions.cpp:91
+#: src/muuli_wdr.cpp:1850 src/muuli_wdr.cpp:1856 src/OtherFunctions.cpp:91
 #: src/StatisticsDlg.cpp:93 src/StatisticsDlg.cpp:95
 msgid "kB/s"
 msgstr "kB/s"
@@ -3355,7 +3355,7 @@ msgstr "Octetos"
 msgid "KB"
 msgstr "KB"
 
-#: src/muuli_wdr.cpp:274 src/muuli_wdr.cpp:293 src/muuli_wdr.cpp:1631
+#: src/muuli_wdr.cpp:274 src/muuli_wdr.cpp:293 src/muuli_wdr.cpp:1635
 #: src/OtherFunctions.cpp:64
 msgid "MB"
 msgstr "MB"
@@ -3372,7 +3372,7 @@ msgstr "Tamaño máximo"
 msgid "Availability"
 msgstr "Dispoñibilidade"
 
-#: src/muuli_wdr.cpp:312 src/muuli_wdr.cpp:398 src/muuli_wdr.cpp:3328
+#: src/muuli_wdr.cpp:312 src/muuli_wdr.cpp:398 src/muuli_wdr.cpp:3332
 msgid "Filter:"
 msgstr "Filtrado:"
 
@@ -3435,8 +3435,8 @@ msgstr "Fontes do ficheiro:"
 #: src/muuli_wdr.cpp:1160 src/muuli_wdr.cpp:1167 src/muuli_wdr.cpp:1172
 #: src/muuli_wdr.cpp:1179 src/muuli_wdr.cpp:1184 src/muuli_wdr.cpp:1191
 #: src/muuli_wdr.cpp:1205 src/muuli_wdr.cpp:1212 src/muuli_wdr.cpp:1217
-#: src/muuli_wdr.cpp:1224 src/muuli_wdr.cpp:3265 src/muuli_wdr.cpp:3273
-#: src/muuli_wdr.cpp:3281
+#: src/muuli_wdr.cpp:1224 src/muuli_wdr.cpp:3269 src/muuli_wdr.cpp:3277
+#: src/muuli_wdr.cpp:3285
 msgid "N/A"
 msgstr "N/A"
 
@@ -3581,7 +3581,7 @@ msgstr ""
 msgid "Album :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:685 src/muuli_wdr.cpp:2285
+#: src/muuli_wdr.cpp:685 src/muuli_wdr.cpp:2289
 msgid "Title :"
 msgstr "Título :"
 
@@ -3690,7 +3690,7 @@ msgstr "Nome de usuario :"
 msgid "Userhash :"
 msgstr "Hash do usuario :"
 
-#: src/muuli_wdr.cpp:895 src/muuli_wdr.cpp:1752 src/muuli_wdr.cpp:2480
+#: src/muuli_wdr.cpp:895 src/muuli_wdr.cpp:1756 src/muuli_wdr.cpp:2484
 #: src/utils/aLinkCreator/src/alcframe.cpp:137
 msgid "Add"
 msgstr "Engadir"
@@ -3699,15 +3699,15 @@ msgstr "Engadir"
 msgid "Download-Speed"
 msgstr "Velocidade de descarga"
 
-#: src/muuli_wdr.cpp:954 src/muuli_wdr.cpp:989 src/muuli_wdr.cpp:2584
+#: src/muuli_wdr.cpp:954 src/muuli_wdr.cpp:989 src/muuli_wdr.cpp:2588
 msgid "Current"
 msgstr "Actual"
 
-#: src/muuli_wdr.cpp:962 src/muuli_wdr.cpp:997 src/muuli_wdr.cpp:2592
+#: src/muuli_wdr.cpp:962 src/muuli_wdr.cpp:997 src/muuli_wdr.cpp:2596
 msgid "Running average"
 msgstr "Media de execución"
 
-#: src/muuli_wdr.cpp:970 src/muuli_wdr.cpp:1005 src/muuli_wdr.cpp:2600
+#: src/muuli_wdr.cpp:970 src/muuli_wdr.cpp:1005 src/muuli_wdr.cpp:2604
 msgid "Session average"
 msgstr "Media de sesión"
 
@@ -3719,7 +3719,7 @@ msgstr "Velocidade de envío"
 msgid "Connections"
 msgstr "Conexións"
 
-#: src/muuli_wdr.cpp:1024 src/muuli_wdr.cpp:1871
+#: src/muuli_wdr.cpp:1024 src/muuli_wdr.cpp:1875
 msgid "Active downloads"
 msgstr "Descargas activas"
 
@@ -3727,7 +3727,7 @@ msgstr "Descargas activas"
 msgid "Active connections (1:1)"
 msgstr "Conexións activas (1:1)"
 
-#: src/muuli_wdr.cpp:1040 src/muuli_wdr.cpp:1872
+#: src/muuli_wdr.cpp:1040 src/muuli_wdr.cpp:1876
 msgid "Active uploads"
 msgstr "Envíos activos"
 
@@ -4003,7 +4003,7 @@ msgstr "Ligar dirección local á IP (deixe baleiro para calquera):"
 msgid "Advanced users only: If you have multiple network interfaces, enter the address of the interface to which aMule should be bound."
 msgstr "Só usuarios experimentados: Se ten varias interfaces de rede, introduza a dirección da interface que quere que aMule use."
 
-#: src/muuli_wdr.cpp:1462 src/muuli_wdr.cpp:2065
+#: src/muuli_wdr.cpp:1462 src/muuli_wdr.cpp:2069
 #, fuzzy
 msgid "Bind to network interface (empty for any):"
 msgstr "Ligar dirección local á IP (deixe baleiro para calquera):"
@@ -4020,7 +4020,7 @@ msgstr "Límite de fontes por ficheiro descargado:"
 msgid "Max simultaneous connections:"
 msgstr "Conexións simultáneas máximas:"
 
-#: src/muuli_wdr.cpp:1498 src/muuli_wdr.cpp:3207
+#: src/muuli_wdr.cpp:1498 src/muuli_wdr.cpp:3211
 msgid "ED2K"
 msgstr "ED2K"
 
@@ -4112,79 +4112,79 @@ msgstr "Reservar espazo no disco para os novos ficheiros"
 msgid "For new files preallocates disk space for the whole file, thus reduces fragmentation"
 msgstr "Reserva o tamaño do ficheiro no disco para reducir a fragmentación"
 
-#: src/muuli_wdr.cpp:1617
+#: src/muuli_wdr.cpp:1621
 msgid "Create new files as sparse files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1618
+#: src/muuli_wdr.cpp:1622
 msgid "Sparse part files only occupy disk space for the parts already downloaded, so free space is used up gradually as the file fills in. Turn this off to use an ordinary file instead - useful where sparse files are unsupported or slow, or where backup/de-duplication tools handle them badly. Applies only when the core runs on Windows; on Linux and macOS part files are sparse anyway and this setting has no effect."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1623
+#: src/muuli_wdr.cpp:1627
 msgid "Stop downloads when free disk space reaches "
 msgstr "Parar descargas canto o espazo libre no disco acade "
 
-#: src/muuli_wdr.cpp:1624
+#: src/muuli_wdr.cpp:1628
 msgid "Select this if you want aMule to check your disk space"
 msgstr "Seleccione esta opción se quere que aMule comprobe o espazo libre no disco"
 
-#: src/muuli_wdr.cpp:1628
+#: src/muuli_wdr.cpp:1632
 msgid "Enter here the min disk space desired."
 msgstr "Introduza o espazo mínimo de disco desexado."
 
-#: src/muuli_wdr.cpp:1634
+#: src/muuli_wdr.cpp:1638
 msgid "Save 10 sources on rare files (< 20 sources)"
 msgstr "Gardar 10 fontes en ficheiros raros (< 20 fontes)"
 
-#: src/muuli_wdr.cpp:1638 src/Statistics.cpp:790
+#: src/muuli_wdr.cpp:1642 src/Statistics.cpp:790
 msgid "Uploads"
 msgstr "Enviado"
 
-#: src/muuli_wdr.cpp:1641
+#: src/muuli_wdr.cpp:1645
 msgid "Add new shared files with auto priority"
 msgstr "Engadir novas descargas con prioridade Automática"
 
-#: src/muuli_wdr.cpp:1647
+#: src/muuli_wdr.cpp:1651
 msgid "Intelligent Corruption Handling (I.C.H.)"
 msgstr "Xestión Intelixente de Corrupcións (X.I.C, I.C.H en inglés)"
 
-#: src/muuli_wdr.cpp:1650
+#: src/muuli_wdr.cpp:1654
 msgid "Enable"
 msgstr "Activada"
 
-#: src/muuli_wdr.cpp:1653
+#: src/muuli_wdr.cpp:1657
 msgid "Advanced I.C.H. trusts every hash (not recommended)"
 msgstr "O X.I.C. avanzado confía en cada hash (non recomendado)"
 
-#: src/muuli_wdr.cpp:1665 src/PrefsUnifiedDlg.cpp:1990
+#: src/muuli_wdr.cpp:1669 src/PrefsUnifiedDlg.cpp:1999
 msgid "Media metadata extraction"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1669
+#: src/muuli_wdr.cpp:1673
 msgid "Extract length / bitrate / codec from shared audio and video files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1671
+#: src/muuli_wdr.cpp:1675
 msgid "When enabled, aMule runs ffprobe on each shared media file to fill in the Length / Bitrate / Codec columns other clients see when they find the file in a search. Requires ffmpeg (the ffprobe binary) to be installed."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1678
+#: src/muuli_wdr.cpp:1682
 msgid "Path to ffprobe:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1683
+#: src/muuli_wdr.cpp:1687
 msgid "Full path to the ffprobe binary. Leave empty to have aMule auto-detect it on startup."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1691
+#: src/muuli_wdr.cpp:1695
 msgid "Detect"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1692
+#: src/muuli_wdr.cpp:1696
 msgid "Search the standard install locations for an ffprobe binary and fill the path field."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1716
+#: src/muuli_wdr.cpp:1720
 msgid ""
 "Completed downloads are stored here. All files in this folder are automatically shared with other peers.\n"
 "If this folder also holds files you don't want to share, point it at an aMule-only sub-folder."
@@ -4192,697 +4192,697 @@ msgstr ""
 "Aquí gárdanse as descargas completas. Automaticamente compartiranse todos os ficheiros do cartafol co resto de parceiros.\n"
 "Se o cartafol tamén conten ficheiros privados, apunte a ruta a un cartafol só para aMule."
 
-#: src/muuli_wdr.cpp:1719
+#: src/muuli_wdr.cpp:1723
 msgid "Pick the folder where completed downloads will be stored. All files in that folder will be shared with other peers."
 msgstr "Escolla o cartafol onde gardar as descargas completas. Compartiranse todos os ficheiros do cartafol co resto de parceiros."
 
-#: src/muuli_wdr.cpp:1733
+#: src/muuli_wdr.cpp:1737
 msgid "Shared folders"
 msgstr "Cartafoles compartidos"
 
-#: src/muuli_wdr.cpp:1739
+#: src/muuli_wdr.cpp:1743
 msgid "(Folders shared by the core. Enter a path to add one.)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1747
+#: src/muuli_wdr.cpp:1751
 msgid "Absolute path of a folder on the core's machine, e.g. /home/user/shared"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1749 src/PrefsUnifiedDlg.cpp:2874
+#: src/muuli_wdr.cpp:1753 src/PrefsUnifiedDlg.cpp:2883
 msgid "Recursive"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1750
+#: src/muuli_wdr.cpp:1754
 msgid "Share every sub-folder underneath this one, including ones created later."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1754 src/utils/aLinkCreator/src/alcframe.cpp:141
+#: src/muuli_wdr.cpp:1758 src/utils/aLinkCreator/src/alcframe.cpp:141
 msgid "Remove"
 msgstr "Eliminar"
 
-#: src/muuli_wdr.cpp:1758
+#: src/muuli_wdr.cpp:1762
 msgid "(Right click on folder icon for recursive share)"
 msgstr "(Preme co botón dereito na icona do cartafol para compartir recursivamente)"
 
-#: src/muuli_wdr.cpp:1765
+#: src/muuli_wdr.cpp:1769
 msgid "Share hidden files"
 msgstr "Compartir ficheiros ocultos"
 
-#: src/muuli_wdr.cpp:1771
+#: src/muuli_wdr.cpp:1775
 msgid "Automatically rescan shared folders for changes"
 msgstr "Revisar automaticamente se hai cambios nos cartafoles compartidos"
 
-#: src/muuli_wdr.cpp:1777
+#: src/muuli_wdr.cpp:1781
 msgid "Follow symbolic links in shared folders"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1783
+#: src/muuli_wdr.cpp:1787
 msgid "Exclude files matching:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1786
+#: src/muuli_wdr.cpp:1790
 msgid "Wildcard patterns separated by '|', e.g. .DS_Store|Thumbs.db|*.tmp. Files whose name matches are not shared. Matching is case-insensitive."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1790
+#: src/muuli_wdr.cpp:1794
 msgid "Patterns are regular expressions"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1791
+#: src/muuli_wdr.cpp:1795
 msgid "When set, the whole field is one regular expression ('|' is alternation). When unset, it is a list of '|'-separated wildcards."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1801
+#: src/muuli_wdr.cpp:1805
 msgid "Show how many shared files the current pattern would exclude."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1822
+#: src/muuli_wdr.cpp:1826
 msgid "Graphs"
 msgstr "Gráficas"
 
-#: src/muuli_wdr.cpp:1825 src/muuli_wdr.cpp:1887
+#: src/muuli_wdr.cpp:1829 src/muuli_wdr.cpp:1891
 msgid "Update delay : 5 secs"
 msgstr "Intervalo de actualización: 5 segs"
 
-#: src/muuli_wdr.cpp:1829
+#: src/muuli_wdr.cpp:1833
 msgid "Time for average graph: 100 mins"
 msgstr "Tempo de media do gráfico: 100 minutos"
 
-#: src/muuli_wdr.cpp:1833
+#: src/muuli_wdr.cpp:1837
 msgid "Connections Graph Scale: 100 "
 msgstr "Escala do gráfico das conexións: 100 "
 
-#: src/muuli_wdr.cpp:1840
+#: src/muuli_wdr.cpp:1844
 msgid "Download graph scale:"
 msgstr "Escala do gráfico de descargas:"
 
-#: src/muuli_wdr.cpp:1848
+#: src/muuli_wdr.cpp:1852
 msgid "Upload graph scale:"
 msgstr "Escala do gráfico de envíos:"
 
-#: src/muuli_wdr.cpp:1858
+#: src/muuli_wdr.cpp:1862
 msgid "Colors: "
 msgstr "Cores: "
 
-#: src/muuli_wdr.cpp:1862
+#: src/muuli_wdr.cpp:1866
 msgid "Background"
 msgstr "Fondo"
 
-#: src/muuli_wdr.cpp:1863
+#: src/muuli_wdr.cpp:1867
 msgid "Grid"
 msgstr "Enreixado"
 
-#: src/muuli_wdr.cpp:1864
+#: src/muuli_wdr.cpp:1868
 msgid "Download current"
 msgstr "Descarga actual"
 
-#: src/muuli_wdr.cpp:1865
+#: src/muuli_wdr.cpp:1869
 msgid "Download running average"
 msgstr "Media das descargas en execución"
 
-#: src/muuli_wdr.cpp:1866
+#: src/muuli_wdr.cpp:1870
 msgid "Download session average"
 msgstr "Media de descargas na sesión"
 
-#: src/muuli_wdr.cpp:1867
+#: src/muuli_wdr.cpp:1871
 msgid "Upload current"
 msgstr "Subida actual"
 
-#: src/muuli_wdr.cpp:1868
+#: src/muuli_wdr.cpp:1872
 msgid "Upload running average"
 msgstr "Media de subida en execución"
 
-#: src/muuli_wdr.cpp:1869
+#: src/muuli_wdr.cpp:1873
 msgid "Upload session average"
 msgstr "Media de subida na sesión"
 
-#: src/muuli_wdr.cpp:1870
+#: src/muuli_wdr.cpp:1874
 msgid "Active connections"
 msgstr "Conexións activas"
 
-#: src/muuli_wdr.cpp:1873
+#: src/muuli_wdr.cpp:1877
 msgid "Systray Icon Speed Bar"
 msgstr "Barra de velocidade na bandexa do sistema"
 
-#: src/muuli_wdr.cpp:1874
+#: src/muuli_wdr.cpp:1878
 msgid "Kad-nodes current"
 msgstr "Nodos Kad actuais"
 
-#: src/muuli_wdr.cpp:1875
+#: src/muuli_wdr.cpp:1879
 msgid "Kad-nodes running"
 msgstr "Nodo Kad executándose"
 
-#: src/muuli_wdr.cpp:1876
+#: src/muuli_wdr.cpp:1880
 msgid "Kad-nodes session"
 msgstr "Nodos Kad na sesión"
 
-#: src/muuli_wdr.cpp:1880 src/muuli_wdr.cpp:2334
+#: src/muuli_wdr.cpp:1884 src/muuli_wdr.cpp:2338
 msgid "Select"
 msgstr "Seleccionar"
 
-#: src/muuli_wdr.cpp:1884
+#: src/muuli_wdr.cpp:1888
 msgid "Tree"
 msgstr "Árbore"
 
-#: src/muuli_wdr.cpp:1894
+#: src/muuli_wdr.cpp:1898
 msgid "Number of Client Versions shown (0=unlimited)"
 msgstr "Cantas versións do cliente a amosar (0=ilimitado)"
 
-#: src/muuli_wdr.cpp:1919
+#: src/muuli_wdr.cpp:1923
 msgid "!!! WARNING !!!"
 msgstr "ADVERTENCIA !!!"
 
-#: src/muuli_wdr.cpp:1934
+#: src/muuli_wdr.cpp:1938
 msgid "Max new connections / 5 secs"
 msgstr "Novas conexións máx. / 5 segs"
 
-#: src/muuli_wdr.cpp:1936
+#: src/muuli_wdr.cpp:1940
 msgid "Concurrent Kad source lookups"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1938
+#: src/muuli_wdr.cpp:1942
 #, fuzzy
 msgid "Kad source re-search interval (minutes)"
 msgstr "Intervalo de actualización do FTP en minutos"
 
-#: src/muuli_wdr.cpp:1940
+#: src/muuli_wdr.cpp:1944
 #, fuzzy
 msgid "Source re-ask interval (minutes)"
 msgstr "Intervalo de actualización do FTP en minutos"
 
-#: src/muuli_wdr.cpp:1944
+#: src/muuli_wdr.cpp:1948
 msgid "File Buffer Size: 240000 bytes"
 msgstr "Tamaño do búfer de ficheiro: 240 000 octetos"
 
-#: src/muuli_wdr.cpp:1948
+#: src/muuli_wdr.cpp:1952
 msgid "Use MMAP: memory-mapped file access (lower memory use)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1949
+#: src/muuli_wdr.cpp:1953
 msgid "Maps part files into memory instead of buffering them on the heap, lowering the process memory footprint. May reduce download speed on some disks; best for memory-constrained or upload-heavy hosts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1951
+#: src/muuli_wdr.cpp:1955
 msgid "Upload Queue Size: 5000 clients"
 msgstr "Tamaño cola de espera: 5000 clientes"
 
-#: src/muuli_wdr.cpp:1955
+#: src/muuli_wdr.cpp:1959
 msgid "Server connection refresh interval: Disable"
 msgstr "Intervalo de actualización de conexión ao servidor: Desactivado"
 
-#: src/muuli_wdr.cpp:1959
+#: src/muuli_wdr.cpp:1963
 msgid "Disable computer's timed standby mode"
 msgstr "Impedir que o ordenador entre en modo espera"
 
-#: src/muuli_wdr.cpp:1978
+#: src/muuli_wdr.cpp:1982
 msgid "Skin to use: "
 msgstr "Tema a usar: "
 
-#: src/muuli_wdr.cpp:1987
+#: src/muuli_wdr.cpp:1991
 msgid "Show \"Fast eD2k Links Handler\" in every window."
 msgstr "Amosar «Xestor rápido de ligazóns eD2k» en cada xanela."
 
-#: src/muuli_wdr.cpp:1990
+#: src/muuli_wdr.cpp:1994
 msgid "Show extended info on categories tabs"
 msgstr "Mostrar información engadida nas lapelas das categorías"
 
-#: src/muuli_wdr.cpp:1993
+#: src/muuli_wdr.cpp:1997
 msgid "Show application version on title"
 msgstr "Amosar a versión da aplicación no título"
 
-#: src/muuli_wdr.cpp:1995
+#: src/muuli_wdr.cpp:1999
 msgid "Show transfer rates on title"
 msgstr "Mostrar velocidades de transferencia no título"
 
-#: src/muuli_wdr.cpp:1997
+#: src/muuli_wdr.cpp:2001
 msgid "Before application name"
 msgstr "Antes do nome da aplicación"
 
-#: src/muuli_wdr.cpp:1999
+#: src/muuli_wdr.cpp:2003
 msgid "After application name"
 msgstr "Despois do nome da aplicación"
 
-#: src/muuli_wdr.cpp:2002
+#: src/muuli_wdr.cpp:2006
 msgid "Show overhead bandwidth"
 msgstr "Amosar ancho de banda malgastado"
 
-#: src/muuli_wdr.cpp:2006
+#: src/muuli_wdr.cpp:2010
 msgid "Vertical toolbar orientation"
 msgstr "Barra de ferramentas en orientación vertical"
 
-#: src/muuli_wdr.cpp:2008
+#: src/muuli_wdr.cpp:2012
 msgid "Live column sorting (auto-reorder rows as their values change)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2015
+#: src/muuli_wdr.cpp:2019
 msgid "Download Queue Files"
 msgstr "Cola de Descargas"
 
-#: src/muuli_wdr.cpp:2018
+#: src/muuli_wdr.cpp:2022
 msgid "Show progress percentage"
 msgstr "Amosar porcentaxe de progreso"
 
-#: src/muuli_wdr.cpp:2024
+#: src/muuli_wdr.cpp:2028
 msgid "Show progress bar"
 msgstr "Amosar barra de progreso"
 
-#: src/muuli_wdr.cpp:2027
+#: src/muuli_wdr.cpp:2031
 msgid "Flat"
 msgstr "Plana"
 
-#: src/muuli_wdr.cpp:2031
+#: src/muuli_wdr.cpp:2035
 msgid "Round"
 msgstr "3D"
 
-#: src/muuli_wdr.cpp:2049
+#: src/muuli_wdr.cpp:2053
 msgid "External Connection Parameters"
 msgstr "Parámetros da Conexión Externa (CE)"
 
-#: src/muuli_wdr.cpp:2052
+#: src/muuli_wdr.cpp:2056
 msgid "Accept external connections"
 msgstr "Aceptar conexións externas"
 
-#: src/muuli_wdr.cpp:2059 src/muuli_wdr.cpp:2118
+#: src/muuli_wdr.cpp:2063 src/muuli_wdr.cpp:2122
 msgid "IP of the listening interface:"
 msgstr "IP da interface na que escoitar:"
 
-#: src/muuli_wdr.cpp:2062
+#: src/muuli_wdr.cpp:2066
 msgid "Enter here a valid ip in the a.b.c.d format for the listening EC interface. An empty field or 0.0.0.0 will mean any interface."
 msgstr "Introduza aquí a IP (válida, no formato a.b.c.d) da interface para a CE. Un campo baleiro ou 0.0.0.0 significa calquera interface."
 
-#: src/muuli_wdr.cpp:2083 src/muuli_wdr.cpp:2194
+#: src/muuli_wdr.cpp:2087 src/muuli_wdr.cpp:2198
 msgid "TCP port:"
 msgstr "Porto TCP:"
 
-#: src/muuli_wdr.cpp:2089
+#: src/muuli_wdr.cpp:2093
 msgid "Enable UPnP port forwarding on the EC port"
 msgstr "Activar a configuración de portos por UPnP para o porto de CE"
 
-#: src/muuli_wdr.cpp:2093 src/muuli_wdr.cpp:3079
+#: src/muuli_wdr.cpp:2097 src/muuli_wdr.cpp:3083
 #: src/utils/wxCas/src/wxcasprefs.cpp:167
 msgid "Password"
 msgstr "Contrasinal"
 
-#: src/muuli_wdr.cpp:2099
+#: src/muuli_wdr.cpp:2103
 #, fuzzy
 msgid "aMule API server parameters"
 msgstr "Parámetros do servidor Web"
 
-#: src/muuli_wdr.cpp:2102
+#: src/muuli_wdr.cpp:2106
 msgid "Run amuleapi (REST API) on startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2107
+#: src/muuli_wdr.cpp:2111
 #, fuzzy
 msgid "HTTP port:"
 msgstr "Porto TCP:"
 
-#: src/muuli_wdr.cpp:2121
+#: src/muuli_wdr.cpp:2125
 msgid "The interface amuleapi's HTTP server listens on. 127.0.0.1 (default) accepts only local connections; use 0.0.0.0 or a specific IP to expose it to other hosts (set an admin password below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2126
+#: src/muuli_wdr.cpp:2130
 msgid "Type a password to set or change it. Stored passwords cannot be shown, so leaving this empty keeps the current one."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2128
+#: src/muuli_wdr.cpp:2132
 #, fuzzy
 msgid "Admin password"
 msgstr "Comprobando contrasinal\n"
 
-#: src/muuli_wdr.cpp:2140 src/muuli_wdr.cpp:2157 src/PrefsUnifiedDlg.cpp:1103
+#: src/muuli_wdr.cpp:2144 src/muuli_wdr.cpp:2161 src/PrefsUnifiedDlg.cpp:1112
 #, fuzzy
 msgid "A password is set."
 msgstr "Comprobando contrasinal\n"
 
-#: src/muuli_wdr.cpp:2144
+#: src/muuli_wdr.cpp:2148
 #, fuzzy
 msgid "Enable guest access"
 msgstr "Denegar acceso de invitado"
 
-#: src/muuli_wdr.cpp:2145
+#: src/muuli_wdr.cpp:2149
 msgid "Guest sessions may read status and listings but cannot change anything. Turning this off clears the stored guest password."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2149
+#: src/muuli_wdr.cpp:2153
 #, fuzzy
 msgid "Guest password"
 msgstr "Contrasinal de invitado para o servidor web"
 
-#: src/muuli_wdr.cpp:2164
+#: src/muuli_wdr.cpp:2168
 msgid "Web server parameters"
 msgstr "Parámetros do servidor Web"
 
-#: src/muuli_wdr.cpp:2167
+#: src/muuli_wdr.cpp:2171
 #, fuzzy
 msgid "Run webserver on startup (deprecated)"
 msgstr "Arrancar o servidor web ao iniciar"
 
-#: src/muuli_wdr.cpp:2173
+#: src/muuli_wdr.cpp:2177
 msgid "Web template"
 msgstr "Modelo Web"
 
-#: src/muuli_wdr.cpp:2178
+#: src/muuli_wdr.cpp:2182
 msgid "Full rights password"
 msgstr "Contrasinal para o administrador"
 
-#: src/muuli_wdr.cpp:2182
+#: src/muuli_wdr.cpp:2186
 msgid "Enable Low rights User"
 msgstr "Activar invitado"
 
-#: src/muuli_wdr.cpp:2187
+#: src/muuli_wdr.cpp:2191
 msgid "Low rights password"
 msgstr "Contrasinal para o invitado"
 
-#: src/muuli_wdr.cpp:2201
+#: src/muuli_wdr.cpp:2205
 msgid "Enable UPnP port forwarding of the web server port"
 msgstr "Configurar o porto do servidor web mediante UPnP"
 
-#: src/muuli_wdr.cpp:2206
+#: src/muuli_wdr.cpp:2210
 msgid "Web server UPnP TCP port (Optional)"
 msgstr "Porto TCP para o UPnP do servidor web (Opcional)"
 
-#: src/muuli_wdr.cpp:2214
+#: src/muuli_wdr.cpp:2218
 msgid "Page Refresh Time (in secs)"
 msgstr "Tempo de actualización da páxina (en segs)"
 
-#: src/muuli_wdr.cpp:2221
+#: src/muuli_wdr.cpp:2225
 msgid "Enable Gzip compression"
 msgstr "Activar compresión Gzip"
 
-#: src/muuli_wdr.cpp:2255
+#: src/muuli_wdr.cpp:2259
 #, fuzzy
 msgid "Reset page to defaults"
 msgstr "Predeterminado"
 
-#: src/muuli_wdr.cpp:2256
+#: src/muuli_wdr.cpp:2260
 msgid "Reset the settings on the current page to their default values."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2258 src/muuli_wdr.cpp:2344 src/ServerWnd.cpp:274
+#: src/muuli_wdr.cpp:2262 src/muuli_wdr.cpp:2348 src/ServerWnd.cpp:274
 #: src/ServerWnd.cpp:282
 msgid "OK"
 msgstr "Vale"
 
-#: src/muuli_wdr.cpp:2260
+#: src/muuli_wdr.cpp:2264
 msgid "Click here to apply any changes made to the preferences."
 msgstr "Aplicar calquera troco feito nas preferencias."
 
-#: src/muuli_wdr.cpp:2263
+#: src/muuli_wdr.cpp:2267
 msgid "Reset any changes made to the preferences."
 msgstr "Restablecer calquera troco feito nas preferencias."
 
-#: src/muuli_wdr.cpp:2292
+#: src/muuli_wdr.cpp:2296
 msgid "Comment :"
 msgstr "Comentario :"
 
-#: src/muuli_wdr.cpp:2299
+#: src/muuli_wdr.cpp:2303
 msgid "Incoming Dir :"
 msgstr "Cartafol de descargas :"
 
-#: src/muuli_wdr.cpp:2308
+#: src/muuli_wdr.cpp:2312
 msgid "Change priority for new assigned files :"
 msgstr "Cambiar prioridade para os novos ficheiros asignados :"
 
-#: src/muuli_wdr.cpp:2312
+#: src/muuli_wdr.cpp:2316
 msgid "Don't change"
 msgstr "Non cambiar"
 
-#: src/muuli_wdr.cpp:2324
+#: src/muuli_wdr.cpp:2328
 msgid "Select color for this Category (currently selected) :"
 msgstr "Seleccionar cor para esta categoría (a seleccionada) :"
 
-#: src/muuli_wdr.cpp:2391 src/muuli_wdr.cpp:2410 src/muuli_wdr.cpp:2432
+#: src/muuli_wdr.cpp:2395 src/muuli_wdr.cpp:2414 src/muuli_wdr.cpp:2436
 msgid "Click this button to reset the log."
 msgstr "Premer este botón para reiniciar o rexistro."
 
-#: src/muuli_wdr.cpp:2451
+#: src/muuli_wdr.cpp:2455
 msgid "Click on this button to update the servers list from URL ..."
 msgstr "Premer neste botón para actualizar a lista de servidores desde a URL ..."
 
-#: src/muuli_wdr.cpp:2455
+#: src/muuli_wdr.cpp:2459
 msgid "Server list"
 msgstr "Lista de servidores"
 
-#: src/muuli_wdr.cpp:2459
+#: src/muuli_wdr.cpp:2463
 msgid "Enter the url to a server.met file here and press the button to the left to update the list of known servers."
 msgstr "Introduza a URL dun ficheiro server.met e prema o botón da esquerda para actualizar a lista de servidores coñecidos."
 
-#: src/muuli_wdr.cpp:2464
+#: src/muuli_wdr.cpp:2468
 msgid "Add server manually: Name"
 msgstr "Engadir servidor manualmente: Nome"
 
-#: src/muuli_wdr.cpp:2467
+#: src/muuli_wdr.cpp:2471
 msgid "Enter the name of the new server here"
 msgstr "Introduza o nome do novo servidor aquí"
 
-#: src/muuli_wdr.cpp:2469 src/ServerWnd.cpp:206
+#: src/muuli_wdr.cpp:2473 src/ServerWnd.cpp:206
 msgid "IP:Port"
 msgstr "IP:Porto"
 
-#: src/muuli_wdr.cpp:2472
+#: src/muuli_wdr.cpp:2476
 msgid "Enter the IP of the server here, using the x.x.x.x format."
 msgstr "Introduza a IP do servidor aquí, usando o formato x.x.x.x ."
 
-#: src/muuli_wdr.cpp:2478
+#: src/muuli_wdr.cpp:2482
 msgid "Enter the port of the server here."
 msgstr "Introduza o porto do servidor aquí."
 
-#: src/muuli_wdr.cpp:2481
+#: src/muuli_wdr.cpp:2485
 msgid "Add manually a server (fill fields to the left before) ..."
 msgstr "Engadir servidor manualmente (antes enche os campos á esquerda) ..."
 
-#: src/muuli_wdr.cpp:2510
+#: src/muuli_wdr.cpp:2514
 msgid "aMule Log"
 msgstr "Rexistro de aMule"
 
-#: src/muuli_wdr.cpp:2518
+#: src/muuli_wdr.cpp:2522
 msgid "Server Info"
 msgstr "Info. do servidor"
 
-#: src/muuli_wdr.cpp:2522
+#: src/muuli_wdr.cpp:2526
 msgid "ED2K Info"
 msgstr "Info. ED2K"
 
-#: src/muuli_wdr.cpp:2526
+#: src/muuli_wdr.cpp:2530
 msgid "Kad Info"
 msgstr "Info. Kad"
 
-#: src/muuli_wdr.cpp:2554
+#: src/muuli_wdr.cpp:2558
 msgid "Click on this button to update the nodes list from URL ..."
 msgstr "Prema neste botón para actualizar a lista de nodos dende a URL ..."
 
-#: src/muuli_wdr.cpp:2558
+#: src/muuli_wdr.cpp:2562
 msgid "Nodes (0)"
 msgstr "Nodos (0)"
 
-#: src/muuli_wdr.cpp:2562
+#: src/muuli_wdr.cpp:2566
 msgid "Enter the url to a nodes.dat file here and press the button to the left to update the list of known nodes."
 msgstr "Introduza aquí a URL ao ficheiro nodes.dat e prema o botón da esquerda, para actualizar a lista de nodos coñecidos."
 
-#: src/muuli_wdr.cpp:2565
+#: src/muuli_wdr.cpp:2569
 msgid "Nodes stats"
 msgstr "Estatísticas de nodos"
 
-#: src/muuli_wdr.cpp:2607
+#: src/muuli_wdr.cpp:2611
 msgid "Bootstrap"
 msgstr "Arranque autónomo (dende cero)"
 
-#: src/muuli_wdr.cpp:2610
+#: src/muuli_wdr.cpp:2614
 msgid "New node"
 msgstr "Novo nodo"
 
-#: src/muuli_wdr.cpp:2615
+#: src/muuli_wdr.cpp:2619
 msgid "IP:"
 msgstr "IP:"
 
-#: src/muuli_wdr.cpp:2635
+#: src/muuli_wdr.cpp:2639
 msgid "Port:"
 msgstr "Porto:"
 
-#: src/muuli_wdr.cpp:2648
+#: src/muuli_wdr.cpp:2652
 msgid "Bootstrap from known clients"
 msgstr "Arrancar a partir de clientes coñecidos"
 
-#: src/muuli_wdr.cpp:2650
+#: src/muuli_wdr.cpp:2654
 msgid "Disconnect Kad"
 msgstr "Desconectar Kad"
 
-#: src/muuli_wdr.cpp:2684
+#: src/muuli_wdr.cpp:2688
 msgid "Use Secure User Identification"
 msgstr "Empregar a Identificación Segura do Usuario"
 
-#: src/muuli_wdr.cpp:2686
+#: src/muuli_wdr.cpp:2690
 msgid "It is recommended to enable this option. You will not receive credits if SUI is not enabled."
 msgstr "Aconséllase habilitar esta opción. Non recibirá créditos se a ISU non se habilitou."
 
-#: src/muuli_wdr.cpp:2688
+#: src/muuli_wdr.cpp:2692
 msgid "Protocol Obfuscation"
 msgstr "Ofuscación do protocolo"
 
-#: src/muuli_wdr.cpp:2691
+#: src/muuli_wdr.cpp:2695
 msgid "Support Protocol Obfuscation"
 msgstr "Aceptar a ofuscación do protocolo"
 
-#: src/muuli_wdr.cpp:2693
+#: src/muuli_wdr.cpp:2697
 msgid "This option enabled Protocol Obfuscation, and makes aMule accept obfuscated connections from other clients."
 msgstr "Esta opción activa a ofuscación do protocolo, e permite que aMule acepte conexións ofuscadas doutros clientes."
 
-#: src/muuli_wdr.cpp:2695
+#: src/muuli_wdr.cpp:2699
 msgid "Use obfuscation for outgoing connections"
 msgstr "Usar ofuscación para as conexións saíntes"
 
-#: src/muuli_wdr.cpp:2697
+#: src/muuli_wdr.cpp:2701
 msgid "This option makes aMule use Protocol Obfuscation when connecting other clients/servers."
 msgstr "Esta opción fai que aMule use a ofuscación de protocolo cando se conectan outros clientes/servidores."
 
-#: src/muuli_wdr.cpp:2699
+#: src/muuli_wdr.cpp:2703
 msgid "Accept only obfuscated connections"
 msgstr "Aceptar só conexións ofuscadas"
 
-#: src/muuli_wdr.cpp:2700
+#: src/muuli_wdr.cpp:2704
 msgid "This option makes aMule only accept obfuscated connections. You will have less sources, but all your traffic will be obfuscated"
 msgstr "Esta opción fai que aMule só acepte conexións ofuscadas. Terá menos fontes, pero todo o tráfico estará ofuscado"
 
-#: src/muuli_wdr.cpp:2705
+#: src/muuli_wdr.cpp:2709
 msgid "Everybody"
 msgstr "Todos"
 
-#: src/muuli_wdr.cpp:2707
+#: src/muuli_wdr.cpp:2711
 msgid "No one"
 msgstr "Ninguén"
 
-#: src/muuli_wdr.cpp:2709
+#: src/muuli_wdr.cpp:2713
 msgid "Who can see my shared files:"
 msgstr "Quen pode ver os meus ficheiros compartidos:"
 
-#: src/muuli_wdr.cpp:2710
+#: src/muuli_wdr.cpp:2714
 msgid "Select who can request to view a list of your shared files."
 msgstr "Seleccione quen pode solicitar ver a lista de ficheiros compartidos."
 
-#: src/muuli_wdr.cpp:2712
+#: src/muuli_wdr.cpp:2716
 msgid "IP-Filtering"
 msgstr "Filtrado de IPs"
 
-#: src/muuli_wdr.cpp:2719
+#: src/muuli_wdr.cpp:2723
 msgid "Filter clients"
 msgstr "Filtrar clientes"
 
-#: src/muuli_wdr.cpp:2721
+#: src/muuli_wdr.cpp:2725
 msgid "Enable filtering of the client IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "Activar filtrado das IPs dos clientes definidas no ficheiro ~/.aMule/ipfilter.dat."
 
-#: src/muuli_wdr.cpp:2723
+#: src/muuli_wdr.cpp:2727
 msgid "Filter servers"
 msgstr "Filtrar servidores"
 
-#: src/muuli_wdr.cpp:2725
+#: src/muuli_wdr.cpp:2729
 msgid "Enable filtering of the server IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "Activar filtrado das IPs dos servidores definidas no ficheiro ~/.aMule/ipfilter.dat."
 
-#: src/muuli_wdr.cpp:2729
+#: src/muuli_wdr.cpp:2733
 msgid "Reload List"
 msgstr "Recargar lista"
 
-#: src/muuli_wdr.cpp:2730
+#: src/muuli_wdr.cpp:2734
 msgid "Reload the list of IPs to filter from the file ~/.aMule/ipfilter.dat"
 msgstr "Recargar a lista de filtrado de IPs desde o ficheiro ~/.aMule/ipfilter.dat"
 
-#: src/muuli_wdr.cpp:2736
+#: src/muuli_wdr.cpp:2740
 msgid "URL:"
 msgstr "URL:"
 
-#: src/muuli_wdr.cpp:2740 src/muuli_wdr.cpp:2933
+#: src/muuli_wdr.cpp:2744 src/muuli_wdr.cpp:2937
 msgid "Update now"
 msgstr "Actualizar agora"
 
-#: src/muuli_wdr.cpp:2743
+#: src/muuli_wdr.cpp:2747
 msgid "Auto-update ipfilter at startup"
 msgstr "Auto-actualizar o filtrado de IPs ao iniciarse"
 
-#: src/muuli_wdr.cpp:2747
+#: src/muuli_wdr.cpp:2751
 msgid "Filtering Level:"
 msgstr "Nivel de filtrado:"
 
-#: src/muuli_wdr.cpp:2753
+#: src/muuli_wdr.cpp:2757
 msgid "Always filter LAN IPs"
 msgstr "Filtrar sempre IPs LAN"
 
-#: src/muuli_wdr.cpp:2756
+#: src/muuli_wdr.cpp:2760
 msgid "Paranoid handling of non-matching IPs"
 msgstr "Xestión paranoica de IPs non coincidintes"
 
-#: src/muuli_wdr.cpp:2758
+#: src/muuli_wdr.cpp:2762
 msgid "Rejects a packet when its source IP differs from the IP the client claims (an anti-spoofing check). Disable only if it causes connection problems."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2760
+#: src/muuli_wdr.cpp:2764
 msgid "Use system-wide ipfilter.dat if available"
 msgstr "Empregar un ipfilter.dat global se está dispoñible"
 
-#: src/muuli_wdr.cpp:2761
+#: src/muuli_wdr.cpp:2765
 msgid "If there's no local ipfilter.dat found, allow usage of a system-wide ipfilter file."
 msgstr "De non atopar o ipfilter.dat local, permitir o emprego dun ipfilter global."
 
-#: src/muuli_wdr.cpp:2778
+#: src/muuli_wdr.cpp:2782
 msgid "Enable Online-Signature"
 msgstr "Activar Sinatura En liña"
 
-#: src/muuli_wdr.cpp:2780
+#: src/muuli_wdr.cpp:2784
 msgid "Enables the writing of the OS file, which can be used by external apps to create signatures and the like."
 msgstr "Habilitar a escritura de ficheiros do SE. Sóese usar para crear sinaturas para aplicacións externas."
 
-#: src/muuli_wdr.cpp:2784
+#: src/muuli_wdr.cpp:2788
 msgid "Update Frequency (Secs):"
 msgstr "Frecuencia de actualización (segs):"
 
-#: src/muuli_wdr.cpp:2787
+#: src/muuli_wdr.cpp:2791
 msgid "Change the frequency (in seconds) of Online Signature updates."
 msgstr "Cambiar a frecuencia (en segundos) da actualización da sinatura en liña."
 
-#: src/muuli_wdr.cpp:2795
+#: src/muuli_wdr.cpp:2799
 msgid "Save online signature file in: "
 msgstr "Gardar o ficheiro de sinaturas en liña en: "
 
-#: src/muuli_wdr.cpp:2801
+#: src/muuli_wdr.cpp:2805
 msgid "Click here to select the directory containing the the Online Signature files."
 msgstr "Prema aquí para seleccionar o directorio que contén os ficheiros de sinaturas en liña."
 
-#: src/muuli_wdr.cpp:2834
+#: src/muuli_wdr.cpp:2838
 msgid "Show country flags for clients"
 msgstr "Amosar as bandeiras do país de orixe dos clientes"
 
-#: src/muuli_wdr.cpp:2835
+#: src/muuli_wdr.cpp:2839
 msgid "Render the country flag column in the transfers, queue and search views. Requires a valid MMDB GeoIP database (see below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2840
+#: src/muuli_wdr.cpp:2844
 #, fuzzy
 msgid "Database"
 msgstr "Fluxo de datos :"
 
-#: src/muuli_wdr.cpp:2856
+#: src/muuli_wdr.cpp:2860
 #, fuzzy
 msgid "Source:"
 msgstr "Fontes"
 
-#: src/muuli_wdr.cpp:2859
+#: src/muuli_wdr.cpp:2863
 msgid "DB-IP (free, no account)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2860
+#: src/muuli_wdr.cpp:2864
 msgid "MaxMind GeoLite2 (free, account required)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2861
+#: src/muuli_wdr.cpp:2865
 msgid "Custom URL"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2864
+#: src/muuli_wdr.cpp:2868
 msgid "Choose which provider supplies the GeoIP MMDB database. DB-IP is the default - no account required. MaxMind requires a free account + license key. Use Custom URL to point at any other MMDB host (e.g. a local mirror)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2881
+#: src/muuli_wdr.cpp:2885
 msgid ""
 "No configuration required.\n"
 "\n"
@@ -4890,11 +4890,11 @@ msgid ""
 "License: Creative Commons BY 4.0 - https://creativecommons.org/licenses/by/4.0/"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2894
+#: src/muuli_wdr.cpp:2898
 msgid "License key:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2900
+#: src/muuli_wdr.cpp:2904
 msgid ""
 "Sign up for a free MaxMind account, then generate a License Key:\n"
 "https://www.maxmind.com/en/geolite2/signup\n"
@@ -4904,225 +4904,225 @@ msgid ""
 "Requires attribution and account registration; refresh at least every 30 days."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2915
+#: src/muuli_wdr.cpp:2919
 #, fuzzy
 msgid "Download URL:"
 msgstr "Descargado: "
 
-#: src/muuli_wdr.cpp:2921
+#: src/muuli_wdr.cpp:2925
 msgid ""
 "Must point to an .mmdb file or a .gz / .tar.gz containing one.\n"
 "URL may include credentials (https://user:pass@host/...).\n"
 "License and attribution terms are set by the upstream URL - you are responsible."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2934
+#: src/muuli_wdr.cpp:2938
 msgid "Download the GeoIP database from the selected source."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2936
+#: src/muuli_wdr.cpp:2940
 #, fuzzy
 msgid "Auto-update on startup"
 msgstr "Auto-actualizar o filtrado de IPs ao iniciarse"
 
-#: src/muuli_wdr.cpp:2937
+#: src/muuli_wdr.cpp:2941
 msgid "Re-download the GeoIP database from the selected source every time aMule starts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2960
+#: src/muuli_wdr.cpp:2964
 msgid "Filter incoming messages (except current chat):"
 msgstr "Filtrar mensaxes entrantes (excepto as da conversación actual):"
 
-#: src/muuli_wdr.cpp:2962
+#: src/muuli_wdr.cpp:2966
 msgid "Filter all messages"
 msgstr "Filtrar todas as mensaxes"
 
-#: src/muuli_wdr.cpp:2964
+#: src/muuli_wdr.cpp:2968
 msgid "Filter messages from people not on your friend list"
 msgstr "Filtrar mensaxes de xente que non estea na lista de amigos"
 
-#: src/muuli_wdr.cpp:2966
+#: src/muuli_wdr.cpp:2970
 msgid "Filter messages from unknown clients"
 msgstr "Filtrar mensaxes de clientes descoñecidos"
 
-#: src/muuli_wdr.cpp:2968
+#: src/muuli_wdr.cpp:2972
 msgid "Filter messages containing (use ',' as separator):"
 msgstr "Filtrar mensaxes que conteñan (use «,» como separador):"
 
-#: src/muuli_wdr.cpp:2971 src/muuli_wdr.cpp:2982
+#: src/muuli_wdr.cpp:2975 src/muuli_wdr.cpp:2986
 msgid "add here the words amule should filter and block messages including it"
 msgstr "engada aquí palabras para filtrar e bloquear as mensaxes que coincidan"
 
-#: src/muuli_wdr.cpp:2973
+#: src/muuli_wdr.cpp:2977
 msgid "Show received messages in the log"
 msgstr "Amosar as mensaxes recibidas no rexistro"
 
-#: src/muuli_wdr.cpp:2976
+#: src/muuli_wdr.cpp:2980
 msgid "Comments"
 msgstr "Comentarios"
 
-#: src/muuli_wdr.cpp:2979
+#: src/muuli_wdr.cpp:2983
 msgid "Filter comments containing (use ',' as separator):"
 msgstr "Filtrar comentarios que conteñan (empregue «,» coma separador):"
 
-#: src/muuli_wdr.cpp:3004
+#: src/muuli_wdr.cpp:3008
 msgid "Enable Proxy"
 msgstr "Activar proxy"
 
-#: src/muuli_wdr.cpp:3005
+#: src/muuli_wdr.cpp:3009
 msgid "Enable/disable proxy support"
 msgstr "Activar/desactivar o tipo de proxy"
 
-#: src/muuli_wdr.cpp:3008
+#: src/muuli_wdr.cpp:3012
 msgid "Proxy type:"
 msgstr "Tipo de proxy:"
 
-#: src/muuli_wdr.cpp:3019
+#: src/muuli_wdr.cpp:3023
 msgid "Proxy host:"
 msgstr "Anfitrión do proxy:"
 
-#: src/muuli_wdr.cpp:3022
+#: src/muuli_wdr.cpp:3026
 msgid "The proxy host name"
 msgstr "O nome do anfitrión do proxy"
 
-#: src/muuli_wdr.cpp:3024
+#: src/muuli_wdr.cpp:3028
 msgid "Proxy port:"
 msgstr "Porto do proxy:"
 
-#: src/muuli_wdr.cpp:3027
+#: src/muuli_wdr.cpp:3031
 msgid "The proxy port"
 msgstr "O porto do proxy"
 
-#: src/muuli_wdr.cpp:3029
+#: src/muuli_wdr.cpp:3033
 msgid "Enable authentication"
 msgstr "Activar identificación"
 
-#: src/muuli_wdr.cpp:3030
+#: src/muuli_wdr.cpp:3034
 msgid "Enable/disable username/password authentication"
 msgstr "Activar/desactivar a identificación mediante nome de usuario e contrasinal"
 
-#: src/muuli_wdr.cpp:3033
+#: src/muuli_wdr.cpp:3037
 msgid "Username: "
 msgstr "Nome de usuario: "
 
-#: src/muuli_wdr.cpp:3036
+#: src/muuli_wdr.cpp:3040
 msgid "The username to use to connect to the proxy"
 msgstr "O nome de usuario a usar para conectarse ao proxy"
 
-#: src/muuli_wdr.cpp:3038
+#: src/muuli_wdr.cpp:3042
 msgid "Password:"
 msgstr "Contrasinal:"
 
-#: src/muuli_wdr.cpp:3041
+#: src/muuli_wdr.cpp:3045
 msgid "The password to use to connect to the proxy"
 msgstr "O contrasinal a empregar para conectarse ao proxy"
 
-#: src/muuli_wdr.cpp:3060
+#: src/muuli_wdr.cpp:3064
 msgid "Connect to:"
 msgstr "Conectar a:"
 
-#: src/muuli_wdr.cpp:3069
+#: src/muuli_wdr.cpp:3073
 msgid "Login to remote amule"
 msgstr "Conectar a amule remoto"
 
-#: src/muuli_wdr.cpp:3074
+#: src/muuli_wdr.cpp:3078
 msgid "User name"
 msgstr "Nome de usuario"
 
-#: src/muuli_wdr.cpp:3085
+#: src/muuli_wdr.cpp:3089
 msgid "Remember those settings"
 msgstr "Recordar esas opcións"
 
-#: src/muuli_wdr.cpp:3088
+#: src/muuli_wdr.cpp:3092
 #, fuzzy
 msgid "Force ZLIB compression"
 msgstr "Usar compresión gzip"
 
-#: src/muuli_wdr.cpp:3112
+#: src/muuli_wdr.cpp:3116
 msgid "Enable Verbose Debug-Logging."
 msgstr "Activar Rexistro de Depuración Estendido."
 
-#: src/muuli_wdr.cpp:3114
+#: src/muuli_wdr.cpp:3118
 msgid "Only to Logfile"
 msgstr "Só ao ficheiro do rexistro"
 
-#: src/muuli_wdr.cpp:3116
+#: src/muuli_wdr.cpp:3120
 msgid "Message Categories:"
 msgstr "Categorías das mensaxes:"
 
-#: src/muuli_wdr.cpp:3140 src/PartFileConvertDlg.cpp:160
+#: src/muuli_wdr.cpp:3144 src/PartFileConvertDlg.cpp:160
 msgid "Waiting..."
 msgstr "Agardando..."
 
-#: src/muuli_wdr.cpp:3160
+#: src/muuli_wdr.cpp:3164
 msgid "Add imports"
 msgstr "Engadir importados"
 
-#: src/muuli_wdr.cpp:3163
+#: src/muuli_wdr.cpp:3167
 msgid "Retry selected"
 msgstr "Tentar de novo o seleccionado"
 
-#: src/muuli_wdr.cpp:3165
+#: src/muuli_wdr.cpp:3169
 msgid "Remove selected"
 msgstr "Borrar seleccionados"
 
-#: src/muuli_wdr.cpp:3228
+#: src/muuli_wdr.cpp:3232
 msgid "Event Types"
 msgstr "Tipos de eventos"
 
-#: src/muuli_wdr.cpp:3247
+#: src/muuli_wdr.cpp:3251
 msgid "Statistics and queued clients for selected file(s) : Session / All time"
 msgstr "Estadísticas e clientes esperando para os ficheiros seleccionados: Sesión / Total"
 
-#: src/muuli_wdr.cpp:3271
+#: src/muuli_wdr.cpp:3275
 msgid "Active Uploads"
 msgstr "Envíos activos"
 
-#: src/muuli_wdr.cpp:3285
+#: src/muuli_wdr.cpp:3289
 msgid "Percent of total files"
 msgstr "Porcentaxe de todos os ficheiros"
 
-#: src/muuli_wdr.cpp:3337
+#: src/muuli_wdr.cpp:3341
 msgid "Show Clients for"
 msgstr "Amosar clientes para"
 
-#: src/muuli_wdr.cpp:3339
+#: src/muuli_wdr.cpp:3343
 msgid "All files"
 msgstr "Todos os ficheiros"
 
-#: src/muuli_wdr.cpp:3342
+#: src/muuli_wdr.cpp:3346
 msgid "Selected files"
 msgstr "Ficheiros selecionados"
 
-#: src/muuli_wdr.cpp:3345
+#: src/muuli_wdr.cpp:3349
 msgid "Active uploads only"
 msgstr "Só subidas activas"
 
-#: src/muuli_wdr.cpp:3352
+#: src/muuli_wdr.cpp:3356
 msgid "Reload:"
 msgstr "Recargar:"
 
-#: src/muuli_wdr.cpp:3356
+#: src/muuli_wdr.cpp:3360
 msgid "Reload your shared files"
 msgstr "Recargar os seus ficheiros compartidos"
 
-#: src/muuli_wdr.cpp:3419
+#: src/muuli_wdr.cpp:3423
 msgid "Send"
 msgstr "Enviar"
 
-#: src/muuli_wdr.cpp:3420
+#: src/muuli_wdr.cpp:3424
 msgid "Sends the specified message."
 msgstr "Enviar a mensaxe especificada."
 
-#: src/muuli_wdr.cpp:3424
+#: src/muuli_wdr.cpp:3428
 msgid "Close this chat-session."
 msgstr "Pechar esta conversa."
 
-#: src/muuli_wdr.cpp:3447
+#: src/muuli_wdr.cpp:3451
 msgid "Connect to any server and/or Kad"
 msgstr "Conectar a calquera servidor e/ou Kad"
 
-#: src/muuli_wdr.cpp:3453 src/SharedFilesCtrl.cpp:142 src/Statistics.cpp:941
+#: src/muuli_wdr.cpp:3457 src/SharedFilesCtrl.cpp:142 src/Statistics.cpp:941
 msgid "Shared Files"
 msgstr "Ficheiros compartidos"
 
@@ -5758,35 +5758,35 @@ msgstr ""
 "aMule funcionará ben sen que cambie ningún\n"
 "destes parámetros."
 
-#: src/PrefsUnifiedDlg.cpp:647
+#: src/PrefsUnifiedDlg.cpp:656
 #, c-format
 msgid "Failed to connect Cfg to widget with the ID %d and key %s"
 msgstr "Non se puido conectar a configuración ao compoñente coa ID %d e chave %s"
 
-#: src/PrefsUnifiedDlg.cpp:695
+#: src/PrefsUnifiedDlg.cpp:704
 #, c-format
 msgid "Failed to transfer data from Cfg to Widget with the ID %d and key %s"
 msgstr "Non se puido transferir información dende a configuración ao compoñente con ID %d e chave %s"
 
-#: src/PrefsUnifiedDlg.cpp:801
+#: src/PrefsUnifiedDlg.cpp:810
 msgid "The type of proxy you are connecting to"
 msgstr "O tipo de proxy ao que se está a conectar"
 
-#: src/PrefsUnifiedDlg.cpp:1020
+#: src/PrefsUnifiedDlg.cpp:1029
 #, c-format
 msgid "Failed to transfer data from Widget to Cfg with the ID %d and key %s"
 msgstr "Non se puido transferir información entre o compoñente e a configuración con ID %d e chave %s"
 
-#: src/PrefsUnifiedDlg.cpp:1103
+#: src/PrefsUnifiedDlg.cpp:1112
 #, fuzzy
 msgid "No password set."
 msgstr "Comprobando contrasinal\n"
 
-#: src/PrefsUnifiedDlg.cpp:1132
+#: src/PrefsUnifiedDlg.cpp:1141
 msgid "Guest access needs a password. Type one in the guest password field, or untick Enable guest access."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1144
+#: src/PrefsUnifiedDlg.cpp:1153
 msgid ""
 "aMule must be restarted to enable these changes:\n"
 "\n"
@@ -5794,41 +5794,41 @@ msgstr ""
 "aMule debe ser reiniciado para activar estes trocos:\n"
 "\n"
 
-#: src/PrefsUnifiedDlg.cpp:1151
+#: src/PrefsUnifiedDlg.cpp:1160
 msgid "- TCP port changed.\n"
 msgstr "- Porto TCP cambiado.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1156
+#: src/PrefsUnifiedDlg.cpp:1165
 msgid "- UDP port changed.\n"
 msgstr "- Porto UDP cambiado.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1161
+#: src/PrefsUnifiedDlg.cpp:1170
 #, fuzzy
 msgid "- Network interface binding changed.\n"
 msgstr "- Cambiada interface da conexión externa.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1166
+#: src/PrefsUnifiedDlg.cpp:1175
 msgid "- External connect port changed.\n"
 msgstr "- Cambiado o porto da conexión externa.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1170
+#: src/PrefsUnifiedDlg.cpp:1179
 msgid "- External connect acceptance changed.\n"
 msgstr "- Cambiada a aceptación da conexión externa.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1174
+#: src/PrefsUnifiedDlg.cpp:1183
 msgid "- External connect interface changed.\n"
 msgstr "- Cambiada interface da conexión externa.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1178
+#: src/PrefsUnifiedDlg.cpp:1187
 msgid "- Protocol obfuscation support changed.\n"
 msgstr "- Cambiada opción da ofuscación do protocolo.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1193
+#: src/PrefsUnifiedDlg.cpp:1202
 #, fuzzy
 msgid "- amuleapi settings changed.\n"
 msgstr "- Idioma cambiado.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1202
+#: src/PrefsUnifiedDlg.cpp:1211
 msgid ""
 "Your Auto-update server list is empty.\n"
 "'Auto-update server list at startup' will be disabled."
@@ -5836,7 +5836,7 @@ msgstr ""
 "A túa lista de servidores para auto-actualizar está baleira.\n"
 "Desactivarase a actualización no inicio."
 
-#: src/PrefsUnifiedDlg.cpp:1213
+#: src/PrefsUnifiedDlg.cpp:1222
 msgid ""
 "You have enabled external connections but have not specified a password.\n"
 "External connections cannot be enabled unless a valid password is specified."
@@ -5844,33 +5844,33 @@ msgstr ""
 "Permítense conexións externas pero non se especificou un contrasinal.\n"
 "As conexións externas non poden ser activadas ate que se especifique un contrasinal válido."
 
-#: src/PrefsUnifiedDlg.cpp:1246
+#: src/PrefsUnifiedDlg.cpp:1255
 #, c-format
 msgid "The amuleapi password could not be saved: %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1276
+#: src/PrefsUnifiedDlg.cpp:1285
 msgid "- Language changed.\n"
 msgstr "- Idioma cambiado.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1281
+#: src/PrefsUnifiedDlg.cpp:1290
 msgid "- Temp folder changed.\n"
 msgstr "- Cartafol temporal cambiado.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1286
+#: src/PrefsUnifiedDlg.cpp:1295
 msgid "- ED2K network enabled.\n"
 msgstr "- Rede eD2K activada.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1319
+#: src/PrefsUnifiedDlg.cpp:1328
 msgid "The shared-file exclusion pattern is not a valid regular expression. The filter has been left disabled."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1321 src/PrefsUnifiedDlg.cpp:1921
+#: src/PrefsUnifiedDlg.cpp:1330 src/PrefsUnifiedDlg.cpp:1930
 #, fuzzy
 msgid "Invalid regular expression"
 msgstr "Versión do protocolo inválida."
 
-#: src/PrefsUnifiedDlg.cpp:1398
+#: src/PrefsUnifiedDlg.cpp:1407
 msgid ""
 "Both eD2k and Kad network are disabled.\n"
 "You won't be able to connect until you enable at least one of them."
@@ -5878,7 +5878,7 @@ msgstr ""
 "Tanto eD2k e Kad están desactivados.\n"
 "Non poderás conectarte ate activar algún dous."
 
-#: src/PrefsUnifiedDlg.cpp:1403
+#: src/PrefsUnifiedDlg.cpp:1412
 msgid ""
 "Kad will not start if your UDP port is disabled.\n"
 "Enable UDP port or disable Kad."
@@ -5886,7 +5886,7 @@ msgstr ""
 "Kad non se iniciará se non está activado o porto UDP.\n"
 "Active o porto UDP ou desactive Kad."
 
-#: src/PrefsUnifiedDlg.cpp:1459
+#: src/PrefsUnifiedDlg.cpp:1468
 msgid ""
 "\n"
 "You MUST restart aMule now.\n"
@@ -5896,71 +5896,71 @@ msgstr ""
 "Debe reiniciar o aMule agora.\n"
 "Se non o reinicia agora, ature coas consecuencias.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1524
+#: src/PrefsUnifiedDlg.cpp:1533
 msgid "Could not register aMule for autostart at login. The autostart store may be read-only."
 msgstr "Non se puido configurar para que aMule arranque ao iniciar sesión. Pode ser que a configuración non permita modificacións."
 
-#: src/PrefsUnifiedDlg.cpp:1526
+#: src/PrefsUnifiedDlg.cpp:1535
 msgid "Could not remove the autostart-at-login entry."
 msgstr "Non se puido quitar o arranque ao inicio da configuración."
 
-#: src/PrefsUnifiedDlg.cpp:1527
+#: src/PrefsUnifiedDlg.cpp:1536
 msgid "Autostart"
 msgstr "Arrancar ao inicio"
 
-#: src/PrefsUnifiedDlg.cpp:1542
+#: src/PrefsUnifiedDlg.cpp:1551
 msgid "Register file type"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1542
+#: src/PrefsUnifiedDlg.cpp:1551
 msgid "Register URL handler"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1550
+#: src/PrefsUnifiedDlg.cpp:1559
 #, c-format
 msgid "aMule only handles eD2k-compatible magnets. If you replace the current magnet handler (%s), BitTorrent magnet links will stop working - aMule cannot download BitTorrent content. Continue?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1555
+#: src/PrefsUnifiedDlg.cpp:1564
 #, c-format
 msgid "Another application currently opens .emulecollection files (%s). Replace it with aMule?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1560
+#: src/PrefsUnifiedDlg.cpp:1569
 #, c-format
 msgid "Another application is currently the default handler for these links (%s). Replace it with aMule?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1585
+#: src/PrefsUnifiedDlg.cpp:1594
 #, fuzzy
 msgid "Could not register aMule for .emulecollection files. The registration store may be read-only."
 msgstr "Non se puido configurar para que aMule arranque ao iniciar sesión. Pode ser que a configuración non permita modificacións."
 
-#: src/PrefsUnifiedDlg.cpp:1587
+#: src/PrefsUnifiedDlg.cpp:1596
 #, fuzzy
 msgid "Could not remove the file type registration."
 msgstr "Non se puido quitar o arranque ao inicio da configuración."
 
-#: src/PrefsUnifiedDlg.cpp:1589
+#: src/PrefsUnifiedDlg.cpp:1598
 #, fuzzy
 msgid "Could not register aMule as the URL handler. The registration store may be read-only."
 msgstr "Non se puido configurar para que aMule arranque ao iniciar sesión. Pode ser que a configuración non permita modificacións."
 
-#: src/PrefsUnifiedDlg.cpp:1591
+#: src/PrefsUnifiedDlg.cpp:1600
 #, fuzzy
 msgid "Could not remove the URL handler registration."
 msgstr "Non se puido quitar o arranque ao inicio da configuración."
 
-#: src/PrefsUnifiedDlg.cpp:1661 src/PrefsUnifiedDlg.cpp:1688
+#: src/PrefsUnifiedDlg.cpp:1670 src/PrefsUnifiedDlg.cpp:1697
 #, fuzzy
 msgid "The web server and aMule API require external connections to be enabled."
 msgstr "Establecido o contrasinal e habilitadas conexións externas."
 
-#: src/PrefsUnifiedDlg.cpp:1671
+#: src/PrefsUnifiedDlg.cpp:1680
 msgid "The aMule web server is deprecated. Consider running the aMule API instead."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1735
+#: src/PrefsUnifiedDlg.cpp:1744
 msgid ""
 "Your Auto-update servers list is in blank.\n"
 "Please fill in at least one URL to point to a valid server.met file.\n"
@@ -5970,66 +5970,66 @@ msgstr ""
 "Introduza polo menos unha URL dun ficheiro server.met.\n"
 "Prema no botón «Listar» para introducir unha URL."
 
-#: src/PrefsUnifiedDlg.cpp:1876
+#: src/PrefsUnifiedDlg.cpp:1885
 msgid "Temporary files"
 msgstr "Ficheiros temporais"
 
-#: src/PrefsUnifiedDlg.cpp:1881
+#: src/PrefsUnifiedDlg.cpp:1890
 msgid "Incoming files"
 msgstr "Ficheiros entrantes"
 
-#: src/PrefsUnifiedDlg.cpp:1886
+#: src/PrefsUnifiedDlg.cpp:1895
 msgid "Online Signatures"
 msgstr "Sinaturas En Liña"
 
-#: src/PrefsUnifiedDlg.cpp:1899
+#: src/PrefsUnifiedDlg.cpp:1908
 #, c-format
 msgid "Choose a folder for %s"
 msgstr "Escolla un cartafol para %s"
 
-#: src/PrefsUnifiedDlg.cpp:1923
+#: src/PrefsUnifiedDlg.cpp:1932
 #, fuzzy, c-format
 msgid "Would exclude %u of %u shared file"
 msgid_plural "Would exclude %u of %u shared files"
 msgstr[0] "Atopado %i ficheiro compartido"
 msgstr[1] "Atopados %i ficheiros compartidos"
 
-#: src/PrefsUnifiedDlg.cpp:1940
+#: src/PrefsUnifiedDlg.cpp:1949
 msgid "Browse for videoplayer"
 msgstr "Atopar o reprodutor de vídeo"
 
-#: src/PrefsUnifiedDlg.cpp:1944
+#: src/PrefsUnifiedDlg.cpp:1953
 msgid "Select browser"
 msgstr "Seleccione o navegador"
 
-#: src/PrefsUnifiedDlg.cpp:1948
+#: src/PrefsUnifiedDlg.cpp:1957
 #, fuzzy
 msgid "Select ffprobe binary"
 msgstr "Seleccione o navegador"
 
-#: src/PrefsUnifiedDlg.cpp:1954
+#: src/PrefsUnifiedDlg.cpp:1963
 #, c-format
 msgid "Executable%s"
 msgstr "Executable%s"
 
-#: src/PrefsUnifiedDlg.cpp:1988
+#: src/PrefsUnifiedDlg.cpp:1997
 msgid "ffprobe not found on PATH or in the standard install locations. Install ffmpeg (which ships ffprobe) or use Browse to pick a binary manually."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2000
+#: src/PrefsUnifiedDlg.cpp:2009
 msgid "Reset the settings on this page to their default values?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2001
+#: src/PrefsUnifiedDlg.cpp:2010
 #, fuzzy
 msgid "Reset to defaults"
 msgstr "Predeterminado"
 
-#: src/PrefsUnifiedDlg.cpp:2028
+#: src/PrefsUnifiedDlg.cpp:2037
 msgid "Edit server list"
 msgstr "Editar a lista dos servidores"
 
-#: src/PrefsUnifiedDlg.cpp:2029
+#: src/PrefsUnifiedDlg.cpp:2038
 msgid ""
 "Add here URL's to download server.met files.\n"
 "Only one url on each line."
@@ -6037,115 +6037,115 @@ msgstr ""
 "Engadir aquí unha URL para descargar unha lista server.met.\n"
 "Só unha url nesta liña."
 
-#: src/PrefsUnifiedDlg.cpp:2084
+#: src/PrefsUnifiedDlg.cpp:2093
 msgid "IP2Country update failed"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2229 src/PrefsUnifiedDlg.cpp:2260
+#: src/PrefsUnifiedDlg.cpp:2238 src/PrefsUnifiedDlg.cpp:2269
 msgid "Data by MaxMind GeoLite2"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2231 src/PrefsUnifiedDlg.cpp:2262
+#: src/PrefsUnifiedDlg.cpp:2240 src/PrefsUnifiedDlg.cpp:2271
 #, fuzzy
 msgid "Custom source"
 msgstr "Fontes completas"
 
-#: src/PrefsUnifiedDlg.cpp:2233 src/PrefsUnifiedDlg.cpp:2264
+#: src/PrefsUnifiedDlg.cpp:2242 src/PrefsUnifiedDlg.cpp:2273
 msgid "Data by DB-IP.com"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2284
+#: src/PrefsUnifiedDlg.cpp:2293
 #, fuzzy, c-format
 msgid "Status: Loaded%s"
 msgstr "Estado:"
 
-#: src/PrefsUnifiedDlg.cpp:2286
+#: src/PrefsUnifiedDlg.cpp:2295
 #, fuzzy, c-format
 msgid "Status: Loaded%s - %s"
 msgstr "Estado:"
 
-#: src/PrefsUnifiedDlg.cpp:2290
+#: src/PrefsUnifiedDlg.cpp:2299
 msgid "Status: Failed to load - click 'Update now' to refresh."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2292
+#: src/PrefsUnifiedDlg.cpp:2301
 msgid "Status: Not found - click 'Update now' to download."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2350 src/PrefsUnifiedDlg.cpp:2374
+#: src/PrefsUnifiedDlg.cpp:2359 src/PrefsUnifiedDlg.cpp:2383
 #, c-format
 msgid "Update delay: %d second"
 msgid_plural "Update delay: %d seconds"
 msgstr[0] "Período de actualización: %d segundo"
 msgstr[1] "Período de actualización: %d segundos"
 
-#: src/PrefsUnifiedDlg.cpp:2358
+#: src/PrefsUnifiedDlg.cpp:2367
 #, c-format
 msgid "Time for average graph: %d minute"
 msgid_plural "Time for average graph: %d minutes"
 msgstr[0] "Tempo medio de gráfico: %d min"
 msgstr[1] "Tempo medio de gráfico: %d min"
 
-#: src/PrefsUnifiedDlg.cpp:2367
+#: src/PrefsUnifiedDlg.cpp:2376
 #, c-format
 msgid "Connections Graph Scale: %d"
 msgstr "Escala gráfica das conexións: %d"
 
-#: src/PrefsUnifiedDlg.cpp:2382
+#: src/PrefsUnifiedDlg.cpp:2391
 #, c-format
 msgid "File Buffer Size: %d byte"
 msgid_plural "File Buffer Size: %d bytes"
 msgstr[0] "Tamaño do búfer dos ficheiros: %d octeto"
 msgstr[1] "Tamaño do búfer dos ficheiros: %d octetos"
 
-#: src/PrefsUnifiedDlg.cpp:2392
+#: src/PrefsUnifiedDlg.cpp:2401
 #, c-format
 msgid "Upload Queue Size: %d client"
 msgid_plural "Upload Queue Size: %d clients"
 msgstr[0] "Tamaño da cola de subida: %d cliente"
 msgstr[1] "Tamaño da cola de subida: %d clientes"
 
-#: src/PrefsUnifiedDlg.cpp:2402
+#: src/PrefsUnifiedDlg.cpp:2411
 #, c-format
 msgid "Server connection refresh interval: %d minute"
 msgid_plural "Server connection refresh interval: %d minutes"
 msgstr[0] "Intervalo de actualización da conexión ao servidor: %d minuto"
 msgstr[1] "Intervalo de actualización da conexión ao servidor: %d minutos"
 
-#: src/PrefsUnifiedDlg.cpp:2407
+#: src/PrefsUnifiedDlg.cpp:2416
 msgid "Server connection refresh interval: Disabled"
 msgstr "Intervalo de actualización da conexión ao servidor. Desactivada"
 
-#: src/PrefsUnifiedDlg.cpp:2451
+#: src/PrefsUnifiedDlg.cpp:2460
 msgid "disabled"
 msgstr "desactivado"
 
-#: src/PrefsUnifiedDlg.cpp:2477
+#: src/PrefsUnifiedDlg.cpp:2486
 #, c-format
 msgid "Execute command on '%s' event"
 msgstr "Executar unha orde no evento «%s»"
 
-#: src/PrefsUnifiedDlg.cpp:2484
+#: src/PrefsUnifiedDlg.cpp:2493
 msgid "Enable command execution on core"
 msgstr "Activar execución de ordes no núcleo"
 
-#: src/PrefsUnifiedDlg.cpp:2496
+#: src/PrefsUnifiedDlg.cpp:2505
 msgid "Core command:"
 msgstr "Orde do núcleo:"
 
-#: src/PrefsUnifiedDlg.cpp:2512
+#: src/PrefsUnifiedDlg.cpp:2521
 msgid "Enable command execution on GUI"
 msgstr "Activar execución de ordes na interface gráfica"
 
-#: src/PrefsUnifiedDlg.cpp:2524
+#: src/PrefsUnifiedDlg.cpp:2533
 msgid "GUI command:"
 msgstr "Orde da interface gráfica:"
 
-#: src/PrefsUnifiedDlg.cpp:2540
+#: src/PrefsUnifiedDlg.cpp:2549
 msgid "The following variables will be replaced:"
 msgstr "As seguintes variables serán substituídas:"
 
-#: src/PrefsUnifiedDlg.cpp:2708
+#: src/PrefsUnifiedDlg.cpp:2717
 msgid ""
 "The following folders look like system or sensitive locations:\n"
 "\n"
@@ -6153,37 +6153,37 @@ msgstr ""
 "Estas carpetas semellan parte do sistema, ou que poden ser confidenciais:\n"
 "\n"
 
-#: src/PrefsUnifiedDlg.cpp:2713
+#: src/PrefsUnifiedDlg.cpp:2722
 msgid "Sharing them recursively will publish every file underneath on the eD2k/Kad networks. Do you really want to do this?"
 msgstr "Compartir de xeito recursivo publicará calquera ficheiro que teñan debaixo nas redes eD2k e Kad. Comprobe todo ben antes de continuar."
 
-#: src/PrefsUnifiedDlg.cpp:2716
+#: src/PrefsUnifiedDlg.cpp:2725
 msgid "Confirm shared folders"
 msgstr "Confirmar e compartir cartafoles"
 
-#: src/PrefsUnifiedDlg.cpp:2744
+#: src/PrefsUnifiedDlg.cpp:2753
 msgid "Reloading shared files..."
 msgstr "Recargando os ficheiros compartidos..."
 
-#: src/PrefsUnifiedDlg.cpp:2745
+#: src/PrefsUnifiedDlg.cpp:2754
 msgid "Scanning for subdirectories..."
 msgstr "Buscando subdirectorios..."
 
-#: src/PrefsUnifiedDlg.cpp:2746
+#: src/PrefsUnifiedDlg.cpp:2755
 msgid "Updating shared folders"
 msgstr "Actualizando os cartafoles compartidos"
 
-#: src/PrefsUnifiedDlg.cpp:2773
+#: src/PrefsUnifiedDlg.cpp:2782
 #, c-format
 msgid "Scanned %u directories..."
 msgstr "Buscáronse %u directorios..."
 
-#: src/PrefsUnifiedDlg.cpp:2823
+#: src/PrefsUnifiedDlg.cpp:2832
 #, c-format
 msgid "Reloading shared files: %u files scanned"
 msgstr "Recargouse a lista de ficheiros compartidos: atopáronse %u ficheiros"
 
-#: src/PrefsUnifiedDlg.cpp:2873
+#: src/PrefsUnifiedDlg.cpp:2882
 #, fuzzy
 msgid "Shared folder"
 msgstr "Cartafoles compartidos"
@@ -7876,12 +7876,12 @@ msgstr "Borrar categoría"
 msgid "Hashset requested for unknown file: %s"
 msgstr "Pediuse un hashset para un ficheiro descoñecido: %s"
 
-#: src/UploadQueue.cpp:618
+#: src/UploadQueue.cpp:627
 #, c-format
 msgid "Resuming uploads of file: %s"
 msgstr "Continuando enviando o ficheiro: %s"
 
-#: src/UploadQueue.cpp:634
+#: src/UploadQueue.cpp:643
 #, c-format
 msgid "Suspending upload of file: %s"
 msgstr "Interrompendo o envío do ficheiro: %s"

--- a/po/gl.po
+++ b/po/gl.po
@@ -24,7 +24,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-28 08:06+0200\n"
+"POT-Creation-Date: 2026-07-28 10:19+0200\n"
 "PO-Revision-Date: 2026-07-27 11:38+0000\n"
 "Last-Translator: Pablo <parodper@gmail.com>\n"
 "Language-Team: http://forum.amule.org/index.php?topic=13883\n"
@@ -162,7 +162,7 @@ msgstr "Continuar"
 msgid "Not now"
 msgstr "Agora non"
 
-#: src/AppImageIntegration.cpp:422 src/amuleDlg.cpp:600
+#: src/AppImageIntegration.cpp:422 src/amuleDlg.cpp:665
 msgid "Don't ask again"
 msgstr "Non preguntar de novo"
 
@@ -239,7 +239,7 @@ msgid "Killing amuleweb instance with pid '%d' ... "
 msgstr "Obrigando ao proceso de amuleweb con pid «%d» a pecharse ... "
 
 #: src/amule.cpp:336 src/amule.cpp:349 src/ClientRef.cpp:180
-#: src/SearchDlg.cpp:880 src/ServerListCtrl.cpp:98
+#: src/SearchDlg.cpp:1041 src/ServerListCtrl.cpp:98
 msgid "Failed"
 msgstr "Erro"
 
@@ -594,30 +594,68 @@ msgstr "Non se puido crear o ficheiro Pid"
 msgid "ERROR: %s"
 msgstr "ERRO: %s"
 
-#: src/amuleDlg.cpp:236
+#: src/amuleDlg.cpp:250
 #, c-format
 msgid "This is aMule %s based on eMule."
 msgstr "Este é aMule %s baseado en eMule."
 
-#: src/amuleDlg.cpp:237
+#: src/amuleDlg.cpp:251
 #, c-format
 msgid "Running on %s"
 msgstr "Executando en %s"
 
-#: src/amuleDlg.cpp:239
+#: src/amuleDlg.cpp:253
 msgid "Visit https://github.com/amule-org/amule/releases/latest to check if a new version is available."
 msgstr "Visite https://github.com/amule-org/amule/releases/latest para obter actualizacións."
 
-#: src/amuleDlg.cpp:268
+#: src/amuleDlg.cpp:282
 msgid "FATAL ERROR: Failed to create Timer"
 msgstr "ERRO GRAVE: Non se puido crear o temporizador"
 
-#: src/amuleDlg.cpp:592
+#: src/amuleDlg.cpp:361 src/amuleDlg.cpp:1787 src/amuleDlg.cpp:2033
+#: src/muuli_wdr.cpp:1492 src/muuli_wdr.cpp:3418
+msgid "Networks"
+msgstr "Redes"
+
+#: src/amuleDlg.cpp:362 src/amuleDlg.cpp:1793 src/muuli_wdr.cpp:3419
+msgid "Searches"
+msgstr "Buscas"
+
+#: src/amuleDlg.cpp:363 src/amuleDlg.cpp:1799 src/DownloadListCtrl.cpp:740
+#: src/muuli_wdr.cpp:392 src/muuli_wdr.cpp:1585 src/muuli_wdr.cpp:3420
+#: src/Statistics.cpp:829
+msgid "Downloads"
+msgstr "Descargas"
+
+#: src/amuleDlg.cpp:364 src/amuleDlg.cpp:1805 src/muuli_wdr.cpp:3294
+msgid "Shared files"
+msgstr "Ficheiros compartidos"
+
+#: src/amuleDlg.cpp:365 src/amuleDlg.cpp:1811 src/muuli_wdr.cpp:2926
+#: src/muuli_wdr.cpp:3376 src/muuli_wdr.cpp:3423
+msgid "Messages"
+msgstr "Mensaxes"
+
+#: src/amuleDlg.cpp:366 src/amuleDlg.cpp:1817 src/muuli_wdr.cpp:3424
+#: src/PrefsUnifiedDlg.cpp:312 src/Statistics.cpp:779 src/Statistics.cpp:1235
+msgid "Statistics"
+msgstr "Estadísticas"
+
+#: src/amuleDlg.cpp:368 src/amuleDlg.cpp:1824 src/muuli_wdr.cpp:3426
+#: src/PrefsUnifiedDlg.cpp:328 src/utils/wxCas/src/wxcasprefs.cpp:39
+msgid "Preferences"
+msgstr "Preferencias"
+
+#: src/amuleDlg.cpp:371
+msgid "Navigate"
+msgstr ""
+
+#: src/amuleDlg.cpp:657
 #, fuzzy
 msgid "New version available"
 msgstr "Non dispoñible"
 
-#: src/amuleDlg.cpp:596
+#: src/amuleDlg.cpp:661
 #, fuzzy, c-format
 msgid ""
 "A new version of aMule (%s) is available.\n"
@@ -627,217 +665,184 @@ msgid ""
 "Would you like to open the download page?"
 msgstr "Pode obter a última versión de aMule en https://github.com/amule-org/amule/releases/latest"
 
-#: src/amuleDlg.cpp:678
+#: src/amuleDlg.cpp:743
 msgid "aMule dialog destroyed"
 msgstr "Destruído o cadro de diálogo de aMule"
 
-#: src/amuleDlg.cpp:701 src/DataToText.cpp:68 src/IPFilter.cpp:547
+#: src/amuleDlg.cpp:766 src/DataToText.cpp:68 src/IPFilter.cpp:547
 msgid "Connecting"
 msgstr "Conectando"
 
-#: src/amuleDlg.cpp:893
+#: src/amuleDlg.cpp:958
 msgid "eD2k: Connecting"
 msgstr "eD2k: Conectando"
 
-#: src/amuleDlg.cpp:897
+#: src/amuleDlg.cpp:962
 msgid "eD2k: Disconnected"
 msgstr "eD2k: Desconectado"
 
-#: src/amuleDlg.cpp:903
+#: src/amuleDlg.cpp:968
 msgid "Kad: Firewalled"
 msgstr "Kad: Tras devasa"
 
-#: src/amuleDlg.cpp:907
+#: src/amuleDlg.cpp:972
 msgid "Kad: Connected"
 msgstr "Kad: Conectado"
 
-#: src/amuleDlg.cpp:912
+#: src/amuleDlg.cpp:977
 msgid "Kad: Connecting"
 msgstr "Kad: Conectando"
 
-#: src/amuleDlg.cpp:916
+#: src/amuleDlg.cpp:981
 msgid "Kad: Off"
 msgstr "Kad: Apagado"
 
-#: src/amuleDlg.cpp:964 src/DownloadListCtrl.cpp:505
+#: src/amuleDlg.cpp:1029 src/DownloadListCtrl.cpp:505
 #: src/DownloadListCtrl.cpp:749 src/FriendListCtrl.cpp:180
 #: src/muuli_wdr.cpp:731 src/muuli_wdr.cpp:782 src/muuli_wdr.cpp:846
-#: src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2224 src/muuli_wdr.cpp:2309
-#: src/muuli_wdr.cpp:3057 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
+#: src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2231 src/muuli_wdr.cpp:2316
+#: src/muuli_wdr.cpp:3064 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
 #: src/ServerListCtrl.cpp:606 src/TransferWnd.cpp:378
 #: src/utils/wxCas/src/wxcasprefs.cpp:235
 msgid "Cancel"
 msgstr "Cancelar"
 
-#: src/amuleDlg.cpp:965
+#: src/amuleDlg.cpp:1030
 msgid "Stop the current connection attempts"
 msgstr "Deter a tentativa actual de conexión"
 
-#: src/amuleDlg.cpp:970 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976
-#: src/muuli_wdr.cpp:2447
+#: src/amuleDlg.cpp:1035 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976
+#: src/muuli_wdr.cpp:2454
 msgid "Disconnect"
 msgstr "Desconectar"
 
-#: src/amuleDlg.cpp:971
+#: src/amuleDlg.cpp:1036
 msgid "Disconnect from the currently connected networks"
 msgstr "Desconectar das redes conectadas"
 
-#: src/amuleDlg.cpp:976 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979
-#: src/muuli_wdr.cpp:2602 src/muuli_wdr.cpp:3054 src/muuli_wdr.cpp:3409
+#: src/amuleDlg.cpp:1041 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979
+#: src/muuli_wdr.cpp:2609 src/muuli_wdr.cpp:3061 src/muuli_wdr.cpp:3416
 msgid "Connect"
 msgstr "Conectar"
 
-#: src/amuleDlg.cpp:977
+#: src/amuleDlg.cpp:1042
 msgid "Connect to the currently enabled networks"
 msgstr "Conectar ás redes activas"
 
-#: src/amuleDlg.cpp:1089
+#: src/amuleDlg.cpp:1154
 #, c-format
 msgid "Up: %.1f%s (%.1f) | Down: %.1f%s (%.1f)"
 msgstr "Enviado: %.1f%s (%.1f) | Descargado: %.1f%s (%.1f)"
 
-#: src/amuleDlg.cpp:1091 src/amuleDlg.cpp:1093 src/amuleDlg.cpp:1097
-#: src/amuleDlg.cpp:1099 src/amuleDlg.cpp:1110 src/amuleDlg.cpp:1112
+#: src/amuleDlg.cpp:1156 src/amuleDlg.cpp:1158 src/amuleDlg.cpp:1162
+#: src/amuleDlg.cpp:1164 src/amuleDlg.cpp:1175 src/amuleDlg.cpp:1177
 #: src/MuleTrayIcon.cpp:796 src/MuleTrayIcon.cpp:799
 msgid " MB/s"
 msgstr " MB/s"
 
-#: src/amuleDlg.cpp:1091 src/amuleDlg.cpp:1093 src/amuleDlg.cpp:1097
-#: src/amuleDlg.cpp:1099 src/amuleDlg.cpp:1110 src/amuleDlg.cpp:1112
+#: src/amuleDlg.cpp:1156 src/amuleDlg.cpp:1158 src/amuleDlg.cpp:1162
+#: src/amuleDlg.cpp:1164 src/amuleDlg.cpp:1175 src/amuleDlg.cpp:1177
 #: src/MuleTrayIcon.cpp:796 src/MuleTrayIcon.cpp:799
 #: src/utils/wxCas/src/wxcasframe.cpp:1041
 msgid " kB/s"
 msgstr " kB/s"
 
-#: src/amuleDlg.cpp:1096
+#: src/amuleDlg.cpp:1161
 #, c-format
 msgid "Up: %.1f%s | Down: %.1f%s"
 msgstr "Enviado: %.1f%s | Descargado: %.1f%s"
 
-#: src/amuleDlg.cpp:1128
+#: src/amuleDlg.cpp:1193
 #, c-format
 msgid "aMule (%s | Connected)"
 msgstr "aMule (%s | Conectado)"
 
-#: src/amuleDlg.cpp:1130
+#: src/amuleDlg.cpp:1195
 #, c-format
 msgid "aMule (%s | Disconnected)"
 msgstr "aMule (%s | Desconectado)"
 
-#: src/amuleDlg.cpp:1183
+#: src/amuleDlg.cpp:1248
 #, c-format
 msgid "Do you really want to exit %s?"
 msgstr "Desexar saír de %s?"
 
-#: src/amuleDlg.cpp:1185
+#: src/amuleDlg.cpp:1250
 msgid "Exit confirmation"
 msgstr "Confirmación da saída"
 
-#: src/amuleDlg.cpp:1548
+#: src/amuleDlg.cpp:1613
 msgid "Launch Command: "
 msgstr "Ordes de Arranque: "
 
-#: src/amuleDlg.cpp:1567 src/muuli_wdr.cpp:1971 src/Preferences.cpp:951
+#: src/amuleDlg.cpp:1632 src/muuli_wdr.cpp:1978 src/Preferences.cpp:952
 msgid "- default -"
 msgstr "- por omisión -"
 
-#: src/amuleDlg.cpp:1595
+#: src/amuleDlg.cpp:1660
 #, c-format
 msgid "Skin directory '%s' does not exist"
 msgstr "Non existe o directorio de temas «%s»"
 
-#: src/amuleDlg.cpp:1598
+#: src/amuleDlg.cpp:1663
 #, c-format
 msgid "WARNING: Unable to open skin file '%s' for read"
 msgstr "AVISO: Non se puido abrir o ficheiro de temas «%s» en modo lectura"
 
-#: src/amuleDlg.cpp:1722 src/amuleDlg.cpp:1968 src/muuli_wdr.cpp:1485
-#: src/muuli_wdr.cpp:3411
-msgid "Networks"
-msgstr "Redes"
-
-#: src/amuleDlg.cpp:1726 src/muuli_wdr.cpp:3411
+#: src/amuleDlg.cpp:1791 src/muuli_wdr.cpp:3418
 msgid "Networks Window"
 msgstr "Xanela de Redes"
 
-#: src/amuleDlg.cpp:1728 src/muuli_wdr.cpp:3412
-msgid "Searches"
-msgstr "Buscas"
-
-#: src/amuleDlg.cpp:1732 src/muuli_wdr.cpp:3412
+#: src/amuleDlg.cpp:1797 src/muuli_wdr.cpp:3419
 msgid "Searches Window"
 msgstr "Xanela de buscas"
 
-#: src/amuleDlg.cpp:1734 src/DownloadListCtrl.cpp:740 src/muuli_wdr.cpp:392
-#: src/muuli_wdr.cpp:1578 src/muuli_wdr.cpp:3413 src/Statistics.cpp:829
-msgid "Downloads"
-msgstr "Descargas"
-
-#: src/amuleDlg.cpp:1738 src/muuli_wdr.cpp:3413
+#: src/amuleDlg.cpp:1803 src/muuli_wdr.cpp:3420
 msgid "Downloads Window"
 msgstr "Xanela de descargas"
 
-#: src/amuleDlg.cpp:1740 src/muuli_wdr.cpp:3287
-msgid "Shared files"
-msgstr "Ficheiros compartidos"
-
-#: src/amuleDlg.cpp:1744 src/muuli_wdr.cpp:3415
+#: src/amuleDlg.cpp:1809 src/muuli_wdr.cpp:3422
 msgid "Shared Files Window"
 msgstr "Xanela de ficheiros compartidos"
 
-#: src/amuleDlg.cpp:1746 src/muuli_wdr.cpp:2919 src/muuli_wdr.cpp:3369
-#: src/muuli_wdr.cpp:3416
-msgid "Messages"
-msgstr "Mensaxes"
-
-#: src/amuleDlg.cpp:1750 src/muuli_wdr.cpp:3416
+#: src/amuleDlg.cpp:1815 src/muuli_wdr.cpp:3423
 msgid "Messages Window"
 msgstr "Xanela de mensaxes"
 
-#: src/amuleDlg.cpp:1752 src/muuli_wdr.cpp:3417 src/PrefsUnifiedDlg.cpp:312
-#: src/Statistics.cpp:779 src/Statistics.cpp:1235
-msgid "Statistics"
-msgstr "Estadísticas"
-
-#: src/amuleDlg.cpp:1756 src/muuli_wdr.cpp:3417
+#: src/amuleDlg.cpp:1821 src/muuli_wdr.cpp:3424
 msgid "Statistics Graph Window"
 msgstr "Xanela de gráficos de estadísticas"
 
-#: src/amuleDlg.cpp:1759 src/muuli_wdr.cpp:3419 src/PrefsUnifiedDlg.cpp:328
-#: src/utils/wxCas/src/wxcasprefs.cpp:39
-msgid "Preferences"
-msgstr "Preferencias"
-
-#: src/amuleDlg.cpp:1763 src/muuli_wdr.cpp:3419
+#: src/amuleDlg.cpp:1828 src/muuli_wdr.cpp:3426
 msgid "Preferences Settings Window"
 msgstr "Xanela de Preferencias"
 
-#: src/amuleDlg.cpp:1766 src/muuli_wdr.cpp:3420
+#: src/amuleDlg.cpp:1831 src/muuli_wdr.cpp:3427
 msgid "Import"
 msgstr "Importar"
 
-#: src/amuleDlg.cpp:1770 src/muuli_wdr.cpp:3420
+#: src/amuleDlg.cpp:1835 src/muuli_wdr.cpp:3427
 msgid "The partfile importer tool"
 msgstr "A ferramenta para importar ficheiros «part»"
 
-#: src/amuleDlg.cpp:1773 src/muuli_wdr.cpp:3421
+#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3428
 #: src/utils/aLinkCreator/src/alcframe.cpp:262
 msgid "About"
 msgstr "Sobre"
 
-#: src/amuleDlg.cpp:1773 src/muuli_wdr.cpp:3421
+#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3428
 msgid "About/Help"
 msgstr "Sobre/Axuda"
 
-#: src/amuleDlg.cpp:1971
+#: src/amuleDlg.cpp:2036
 msgid "eD2k network"
 msgstr "Rede eD2k"
 
-#: src/amuleDlg.cpp:1974
+#: src/amuleDlg.cpp:2039
 msgid "Kad network"
 msgstr "Red Kad"
 
-#: src/amuleDlg.cpp:1974
+#: src/amuleDlg.cpp:2039
 msgid "No network"
 msgstr "Sen rede"
 
@@ -1372,19 +1377,19 @@ msgstr "Auto [Al]"
 msgid "Very low"
 msgstr "Moi baixa"
 
-#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:743 src/muuli_wdr.cpp:2275
+#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:743 src/muuli_wdr.cpp:2282
 #: src/ServerListCtrl.cpp:263 src/ServerListCtrl.cpp:456
 #: src/SharedFilesCtrl.cpp:145
 msgid "Low"
 msgstr "Baixa"
 
-#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:744 src/muuli_wdr.cpp:2276
+#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:744 src/muuli_wdr.cpp:2283
 #: src/ServerListCtrl.cpp:266 src/ServerListCtrl.cpp:457
 #: src/SharedFilesCtrl.cpp:146
 msgid "Normal"
 msgstr "Normal"
 
-#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:745 src/muuli_wdr.cpp:2277
+#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:745 src/muuli_wdr.cpp:2284
 #: src/ServerListCtrl.cpp:269 src/ServerListCtrl.cpp:458
 #: src/SharedFilesCtrl.cpp:147
 msgid "High"
@@ -1476,8 +1481,8 @@ msgstr "Servidor local"
 msgid "Remote Server"
 msgstr "Servidor remoto"
 
-#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3174
-#: src/SearchDlg.cpp:111 src/TextClient.cpp:911
+#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3181
+#: src/SearchDlg.cpp:119 src/TextClient.cpp:911
 msgid "Kad"
 msgstr "Kad"
 
@@ -1547,7 +1552,7 @@ msgstr "Parte"
 msgid "Size"
 msgstr "Tamaño"
 
-#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3241
+#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3248
 msgid "Transferred"
 msgstr "Transferido"
 
@@ -1605,7 +1610,7 @@ msgstr ""
 "Comentarios de : %s (%s)\n"
 "\n"
 
-#: src/DownloadListCtrl.cpp:746 src/muuli_wdr.cpp:2278
+#: src/DownloadListCtrl.cpp:746 src/muuli_wdr.cpp:2285
 #: src/SharedFilesCtrl.cpp:150
 msgid "Auto"
 msgstr "Automático"
@@ -1643,7 +1648,7 @@ msgid "Extended Options"
 msgstr "Opcións extendidas"
 
 #: src/DownloadListCtrl.cpp:770 src/DownloadListCtrl.cpp:822
-#: src/muuli_wdr.cpp:1789
+#: src/muuli_wdr.cpp:1796
 msgid "Preview"
 msgstr "Previsualizar"
 
@@ -2352,19 +2357,19 @@ msgstr ""
 msgid "eD2k"
 msgstr "eD2k"
 
-#: src/FirstRunWizard.cpp:349 src/muuli_wdr.cpp:1488
+#: src/FirstRunWizard.cpp:349 src/muuli_wdr.cpp:1495
 msgid "Kademlia"
 msgstr "Kademlia"
 
-#: src/FirstRunWizard.cpp:359 src/muuli_wdr.cpp:1416
+#: src/FirstRunWizard.cpp:359 src/muuli_wdr.cpp:1423
 msgid "Standard TCP Port "
 msgstr "Porto TCP normativizado "
 
-#: src/FirstRunWizard.cpp:365 src/muuli_wdr.cpp:1428
+#: src/FirstRunWizard.cpp:365 src/muuli_wdr.cpp:1435
 msgid "Extended UDP port (Kad / global search) "
 msgstr "Porto UDP ampliado (Kad / busca global) "
 
-#: src/FirstRunWizard.cpp:377 src/muuli_wdr.cpp:1435
+#: src/FirstRunWizard.cpp:377 src/muuli_wdr.cpp:1442
 msgid "Enable UPnP for router port forwarding"
 msgstr "Activar UPnP para configurar os portos no encamiñador"
 
@@ -2391,7 +2396,7 @@ msgstr ""
 msgid "Your peer lists are already in place - nothing to download."
 msgstr "O ficheiro %s xa se está descargando"
 
-#: src/FirstRunWizard.cpp:434 src/muuli_wdr.cpp:1533
+#: src/FirstRunWizard.cpp:434 src/muuli_wdr.cpp:1540
 msgid "Auto-update server list at startup"
 msgstr "Actualizar automáticamente a lista de servidores no arranque"
 
@@ -2437,23 +2442,23 @@ msgid ""
 "want downloads on a different (e.g. larger) disk."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:549 src/FirstRunWizard.cpp:611 src/muuli_wdr.cpp:1701
+#: src/FirstRunWizard.cpp:549 src/FirstRunWizard.cpp:611 src/muuli_wdr.cpp:1708
 msgid "Destination folder for downloads"
 msgstr "Cartafol de destino para descargas"
 
-#: src/FirstRunWizard.cpp:553 src/FirstRunWizard.cpp:569 src/muuli_wdr.cpp:1342
-#: src/muuli_wdr.cpp:1359 src/muuli_wdr.cpp:1676 src/muuli_wdr.cpp:1707
-#: src/muuli_wdr.cpp:1719 src/muuli_wdr.cpp:2762
+#: src/FirstRunWizard.cpp:553 src/FirstRunWizard.cpp:569 src/muuli_wdr.cpp:1349
+#: src/muuli_wdr.cpp:1366 src/muuli_wdr.cpp:1683 src/muuli_wdr.cpp:1714
+#: src/muuli_wdr.cpp:1726 src/muuli_wdr.cpp:2769
 #: src/utils/aLinkCreator/src/alcframe.cpp:135
 #: src/utils/wxCas/src/wxcasprefs.cpp:52 src/utils/wxCas/src/wxcasprefs.cpp:118
 msgid "Browse"
 msgstr "Navegador"
 
-#: src/FirstRunWizard.cpp:559 src/muuli_wdr.cpp:1712
+#: src/FirstRunWizard.cpp:559 src/muuli_wdr.cpp:1719
 msgid "(All files in this folder are shared with other peers)"
 msgstr "(Compartiranse todos os ficheiros do cartafol co resto de parceiros)"
 
-#: src/FirstRunWizard.cpp:565 src/FirstRunWizard.cpp:624 src/muuli_wdr.cpp:1714
+#: src/FirstRunWizard.cpp:565 src/FirstRunWizard.cpp:624 src/muuli_wdr.cpp:1721
 msgid "Folder for temporary download files"
 msgstr "Cartafol para ficheiros de descarga temporais"
 
@@ -2484,7 +2489,7 @@ msgstr "Non se puido escribir a lista de amigos ao ficheiro «emfriends.met»!"
 msgid "CRITICAL - no client on StartChatSession"
 msgstr "CRÍTICO - non hai cliente en StartChatSession"
 
-#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2668 src/muuli_wdr.cpp:3345
+#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2675 src/muuli_wdr.cpp:3352
 msgid "Friends"
 msgstr "Amigos"
 
@@ -2869,7 +2874,7 @@ msgstr "Relación enviado/descargado"
 msgid "Uploaded"
 msgstr "Enviado"
 
-#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3225
+#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3232
 msgid "Requested"
 msgstr "Solicitado"
 
@@ -2993,7 +2998,7 @@ msgid "WARNING: "
 msgstr "AVISO: "
 
 #: src/MuleNotebook.cpp:179 src/muuli_wdr.cpp:817 src/muuli_wdr.cpp:1229
-#: src/muuli_wdr.cpp:3129 src/muuli_wdr.cpp:3385
+#: src/muuli_wdr.cpp:3136 src/muuli_wdr.cpp:3392
 msgid "Close"
 msgstr "Pechar"
 
@@ -3006,12 +3011,12 @@ msgstr "Cortar"
 msgid "Copy"
 msgstr "Copiar"
 
-#: src/MuleTextCtrl.cpp:88
+#: src/MuleTextCtrl.cpp:88 src/SearchDlg.cpp:261
 msgid "Paste"
 msgstr "Pegar"
 
 #: src/MuleTextCtrl.cpp:89 src/muuli_wdr.cpp:358 src/muuli_wdr.cpp:757
-#: src/muuli_wdr.cpp:2352 src/muuli_wdr.cpp:2371 src/muuli_wdr.cpp:2393
+#: src/muuli_wdr.cpp:2359 src/muuli_wdr.cpp:2378 src/muuli_wdr.cpp:2400
 #: src/utils/aLinkCreator/src/alcframe.cpp:142
 msgid "Clear"
 msgstr "Limpar"
@@ -3102,8 +3107,8 @@ msgid "Exit"
 msgstr "Saír"
 
 #: src/MuleTrayIcon.cpp:579 src/MuleTrayIcon.cpp:945 src/MuleTrayIcon.cpp:965
-#: src/muuli_wdr.cpp:1391 src/muuli_wdr.cpp:1399 src/muuli_wdr.cpp:1406
-#: src/muuli_wdr.cpp:1835 src/muuli_wdr.cpp:1841 src/OtherFunctions.cpp:91
+#: src/muuli_wdr.cpp:1398 src/muuli_wdr.cpp:1406 src/muuli_wdr.cpp:1413
+#: src/muuli_wdr.cpp:1842 src/muuli_wdr.cpp:1848 src/OtherFunctions.cpp:91
 #: src/StatisticsDlg.cpp:93 src/StatisticsDlg.cpp:95
 msgid "kB/s"
 msgstr "kB/s"
@@ -3274,7 +3279,7 @@ msgstr "Nome:"
 msgid "Type"
 msgstr "Tipo"
 
-#: src/muuli_wdr.cpp:215 src/SearchDlg.cpp:110 src/SearchListCtrl.cpp:853
+#: src/muuli_wdr.cpp:215 src/SearchDlg.cpp:118 src/SearchListCtrl.cpp:853
 msgid "Local"
 msgstr "Local"
 
@@ -3345,7 +3350,7 @@ msgstr "Octetos"
 msgid "KB"
 msgstr "KB"
 
-#: src/muuli_wdr.cpp:274 src/muuli_wdr.cpp:293 src/muuli_wdr.cpp:1620
+#: src/muuli_wdr.cpp:274 src/muuli_wdr.cpp:293 src/muuli_wdr.cpp:1627
 #: src/OtherFunctions.cpp:64
 msgid "MB"
 msgstr "MB"
@@ -3362,7 +3367,7 @@ msgstr "Tamaño máximo"
 msgid "Availability"
 msgstr "Dispoñibilidade"
 
-#: src/muuli_wdr.cpp:312 src/muuli_wdr.cpp:398 src/muuli_wdr.cpp:3290
+#: src/muuli_wdr.cpp:312 src/muuli_wdr.cpp:398 src/muuli_wdr.cpp:3297
 msgid "Filter:"
 msgstr "Filtrado:"
 
@@ -3394,7 +3399,7 @@ msgstr "Solicitar que os clientes Kad contactados estendan a busca. Cada pulsaci
 msgid "Stop"
 msgstr "Deter"
 
-#: src/muuli_wdr.cpp:348 src/muuli_wdr.cpp:1385 src/SearchListCtrl.cpp:732
+#: src/muuli_wdr.cpp:348 src/muuli_wdr.cpp:1392 src/SearchListCtrl.cpp:732
 msgid "Download"
 msgstr "Descargar"
 
@@ -3425,8 +3430,8 @@ msgstr "Fontes do ficheiro:"
 #: src/muuli_wdr.cpp:1160 src/muuli_wdr.cpp:1167 src/muuli_wdr.cpp:1172
 #: src/muuli_wdr.cpp:1179 src/muuli_wdr.cpp:1184 src/muuli_wdr.cpp:1191
 #: src/muuli_wdr.cpp:1205 src/muuli_wdr.cpp:1212 src/muuli_wdr.cpp:1217
-#: src/muuli_wdr.cpp:1224 src/muuli_wdr.cpp:3227 src/muuli_wdr.cpp:3235
-#: src/muuli_wdr.cpp:3243
+#: src/muuli_wdr.cpp:1224 src/muuli_wdr.cpp:3234 src/muuli_wdr.cpp:3242
+#: src/muuli_wdr.cpp:3250
 msgid "N/A"
 msgstr "N/A"
 
@@ -3571,7 +3576,7 @@ msgstr ""
 msgid "Album :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:685 src/muuli_wdr.cpp:2247
+#: src/muuli_wdr.cpp:685 src/muuli_wdr.cpp:2254
 msgid "Title :"
 msgstr "Título :"
 
@@ -3680,7 +3685,7 @@ msgstr "Nome de usuario :"
 msgid "Userhash :"
 msgstr "Hash do usuario :"
 
-#: src/muuli_wdr.cpp:895 src/muuli_wdr.cpp:1741 src/muuli_wdr.cpp:2442
+#: src/muuli_wdr.cpp:895 src/muuli_wdr.cpp:1748 src/muuli_wdr.cpp:2449
 #: src/utils/aLinkCreator/src/alcframe.cpp:137
 msgid "Add"
 msgstr "Engadir"
@@ -3689,15 +3694,15 @@ msgstr "Engadir"
 msgid "Download-Speed"
 msgstr "Velocidade de descarga"
 
-#: src/muuli_wdr.cpp:954 src/muuli_wdr.cpp:989 src/muuli_wdr.cpp:2546
+#: src/muuli_wdr.cpp:954 src/muuli_wdr.cpp:989 src/muuli_wdr.cpp:2553
 msgid "Current"
 msgstr "Actual"
 
-#: src/muuli_wdr.cpp:962 src/muuli_wdr.cpp:997 src/muuli_wdr.cpp:2554
+#: src/muuli_wdr.cpp:962 src/muuli_wdr.cpp:997 src/muuli_wdr.cpp:2561
 msgid "Running average"
 msgstr "Media de execución"
 
-#: src/muuli_wdr.cpp:970 src/muuli_wdr.cpp:1005 src/muuli_wdr.cpp:2562
+#: src/muuli_wdr.cpp:970 src/muuli_wdr.cpp:1005 src/muuli_wdr.cpp:2569
 msgid "Session average"
 msgstr "Media de sesión"
 
@@ -3709,7 +3714,7 @@ msgstr "Velocidade de envío"
 msgid "Connections"
 msgstr "Conexións"
 
-#: src/muuli_wdr.cpp:1024 src/muuli_wdr.cpp:1860
+#: src/muuli_wdr.cpp:1024 src/muuli_wdr.cpp:1867
 msgid "Active downloads"
 msgstr "Descargas activas"
 
@@ -3717,7 +3722,7 @@ msgstr "Descargas activas"
 msgid "Active connections (1:1)"
 msgstr "Conexións activas (1:1)"
 
-#: src/muuli_wdr.cpp:1040 src/muuli_wdr.cpp:1861
+#: src/muuli_wdr.cpp:1040 src/muuli_wdr.cpp:1868
 msgid "Active uploads"
 msgstr "Envíos activos"
 
@@ -3833,8 +3838,8 @@ msgstr "Este é o nome que os outros usuarios verán cando se conecten a vostede
 msgid "Language: "
 msgstr "Idioma: "
 
-#: src/muuli_wdr.cpp:1257 src/muuli_wdr.cpp:1323 src/muuli_wdr.cpp:1327
-#: src/muuli_wdr.cpp:1330
+#: src/muuli_wdr.cpp:1257 src/muuli_wdr.cpp:1330 src/muuli_wdr.cpp:1334
+#: src/muuli_wdr.cpp:1337
 msgid "The delay before showing tool-tips."
 msgstr "O retardo antes de mostrar as mensaxes emerxentes."
 
@@ -3912,260 +3917,269 @@ msgstr "Amosar unha notificación ao rematar a descarga"
 msgid "Enabling this will make aMule to show notifications when finished downloading."
 msgstr "Activando isto aMule avisaralle cando remate a descarga."
 
-#: src/muuli_wdr.cpp:1322
+#: src/muuli_wdr.cpp:1323
+#, fuzzy
+msgid "Remember search history"
+msgstr "Recordar esas opcións"
+
+#: src/muuli_wdr.cpp:1324
+msgid "Keeps a dropdown list of your past search terms in the Search tab's Name field. This remembers the queries you typed, not the results they returned."
+msgstr ""
+
+#: src/muuli_wdr.cpp:1329
 msgid "Tooltip delay time: "
 msgstr "Retardo da información sobre as ferramentas: "
 
-#: src/muuli_wdr.cpp:1329
+#: src/muuli_wdr.cpp:1336
 msgid "seconds"
 msgstr "segundos"
 
-#: src/muuli_wdr.cpp:1333
+#: src/muuli_wdr.cpp:1340
 msgid "Browser Selection"
 msgstr "Selección de navegador"
 
-#: src/muuli_wdr.cpp:1339
+#: src/muuli_wdr.cpp:1346
 msgid "Enter your browser name here. Leave this field empty to use the system default browser."
 msgstr "Introduza o nome do seu navegador aquí. Deixe o campo baleiro para empregar o navegador predeterminado do sistema."
 
-#: src/muuli_wdr.cpp:1346
+#: src/muuli_wdr.cpp:1353
 msgid "Open in new tab if possible"
 msgstr "Abrir nunha nova lapela se é posible"
 
-#: src/muuli_wdr.cpp:1348
+#: src/muuli_wdr.cpp:1355
 msgid "Open the web page in a new tab instead of in a new window when possible"
 msgstr "Abrir as páxinas web nunha nova solapa, en lugar de nunha nova xanela"
 
-#: src/muuli_wdr.cpp:1352
+#: src/muuli_wdr.cpp:1359
 msgid "Video Player"
 msgstr "Reprodutor de vídeo"
 
-#: src/muuli_wdr.cpp:1379
+#: src/muuli_wdr.cpp:1386
 msgid "Bandwidth limits"
 msgstr "Límites de ancho de banda"
 
-#: src/muuli_wdr.cpp:1393
+#: src/muuli_wdr.cpp:1400
 msgid "Upload"
 msgstr "Enviar"
 
-#: src/muuli_wdr.cpp:1401
+#: src/muuli_wdr.cpp:1408
 msgid "Slot Allocation"
 msgstr "Asignación de ocos"
 
-#: src/muuli_wdr.cpp:1410
+#: src/muuli_wdr.cpp:1417
 msgid "Ports"
 msgstr "Portos"
 
-#: src/muuli_wdr.cpp:1420
+#: src/muuli_wdr.cpp:1427
 msgid "This is the standard eD2k port and cannot be disabled."
 msgstr "Este é o porto eD2k normativizado e non se pode desactivar."
 
-#: src/muuli_wdr.cpp:1423
+#: src/muuli_wdr.cpp:1430
 msgid "UDP port for server requests (TCP+3):"
 msgstr "Porto UDP para peticións do servidor (TCP+3)"
 
-#: src/muuli_wdr.cpp:1425
+#: src/muuli_wdr.cpp:1432
 msgid "4665"
 msgstr "4665"
 
-#: src/muuli_wdr.cpp:1432
+#: src/muuli_wdr.cpp:1439
 msgid "This UDP port is used for extended eD2k requests and Kad network"
 msgstr "Este porto UDP úsase para peticións eD2k ampliadas e para a rede Kad"
 
-#: src/muuli_wdr.cpp:1439
+#: src/muuli_wdr.cpp:1446
 msgid "UPnP TCP Port (Optional):"
 msgstr "Porto TCP para UPnP (Opcional):"
 
-#: src/muuli_wdr.cpp:1449
+#: src/muuli_wdr.cpp:1456
 msgid "Bind local address to IP (empty for any):"
 msgstr "Ligar dirección local á IP (deixe baleiro para calquera):"
 
-#: src/muuli_wdr.cpp:1452
+#: src/muuli_wdr.cpp:1459
 msgid "Advanced users only: If you have multiple network interfaces, enter the address of the interface to which aMule should be bound."
 msgstr "Só usuarios experimentados: Se ten varias interfaces de rede, introduza a dirección da interface que quere que aMule use."
 
-#: src/muuli_wdr.cpp:1455 src/muuli_wdr.cpp:2054
+#: src/muuli_wdr.cpp:1462 src/muuli_wdr.cpp:2061
 #, fuzzy
 msgid "Bind to network interface (empty for any):"
 msgstr "Ligar dirección local á IP (deixe baleiro para calquera):"
 
-#: src/muuli_wdr.cpp:1468
+#: src/muuli_wdr.cpp:1475
 msgid "Advanced users only: pin all of aMule's traffic to one network interface, chosen from the list or typed in by name (e.g. tun0, eth0, en0) or index. Unlike binding to an IP, this stops traffic leaking out via the default route - useful with a VPN. Requires no elevated privileges."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1474
+#: src/muuli_wdr.cpp:1481
 msgid "Max sources per downloading file:"
 msgstr "Límite de fontes por ficheiro descargado:"
 
-#: src/muuli_wdr.cpp:1478
+#: src/muuli_wdr.cpp:1485
 msgid "Max simultaneous connections:"
 msgstr "Conexións simultáneas máximas:"
 
-#: src/muuli_wdr.cpp:1491 src/muuli_wdr.cpp:3169
+#: src/muuli_wdr.cpp:1498 src/muuli_wdr.cpp:3176
 msgid "ED2K"
 msgstr "ED2K"
 
-#: src/muuli_wdr.cpp:1498
+#: src/muuli_wdr.cpp:1505
 msgid "Autoconnect on startup"
 msgstr "Conectar automaticamente ao iniciarse"
 
-#: src/muuli_wdr.cpp:1501
+#: src/muuli_wdr.cpp:1508
 msgid "Reconnect on loss"
 msgstr "Volver a conectarse ao perder a conexión"
 
-#: src/muuli_wdr.cpp:1523
+#: src/muuli_wdr.cpp:1530
 msgid "Remove dead server after"
 msgstr "Eliminar servidores caídos tras"
 
-#: src/muuli_wdr.cpp:1524
+#: src/muuli_wdr.cpp:1531
 msgid "Static servers are never removed, even when unreachable."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1528
+#: src/muuli_wdr.cpp:1535
 msgid "retries"
 msgstr "intentos"
 
-#: src/muuli_wdr.cpp:1536
+#: src/muuli_wdr.cpp:1543
 msgid "List"
 msgstr "Lista"
 
-#: src/muuli_wdr.cpp:1539
+#: src/muuli_wdr.cpp:1546
 msgid "Update server list when connecting to a server"
 msgstr "Actualizar a lista de servidores ao conectarse a un servidor"
 
-#: src/muuli_wdr.cpp:1542
+#: src/muuli_wdr.cpp:1549
 msgid "Update server list when a client connects"
 msgstr "Actualizar a lista de servidores cando un cliente se conecte"
 
-#: src/muuli_wdr.cpp:1545
+#: src/muuli_wdr.cpp:1552
 msgid "Use priority system"
 msgstr "Usar sistema de prioridades"
 
-#: src/muuli_wdr.cpp:1549
+#: src/muuli_wdr.cpp:1556
 msgid "Use smart LowID check on connect"
 msgstr "Control intelixente da IDBaixa ao conectar"
 
-#: src/muuli_wdr.cpp:1553
+#: src/muuli_wdr.cpp:1560
 msgid "Safe connect"
 msgstr "Conexión segura"
 
-#: src/muuli_wdr.cpp:1557
+#: src/muuli_wdr.cpp:1564
 msgid "Autoconnect to servers in static list only"
 msgstr "Conectar automaticamente só a servidores fixos"
 
-#: src/muuli_wdr.cpp:1560
+#: src/muuli_wdr.cpp:1567
 msgid "Set manually added servers to High Priority"
 msgstr "Asignar alta prioridade aos servidores engadidos manualmente"
 
-#: src/muuli_wdr.cpp:1581
+#: src/muuli_wdr.cpp:1588
 msgid "Add files to download in pause mode"
 msgstr "Poñer en pausa os ficheiros engadidos á lista de descargas"
 
-#: src/muuli_wdr.cpp:1583
+#: src/muuli_wdr.cpp:1590
 msgid "Add files to download with auto priority"
 msgstr "Engadir os novos ficheiros compartidos con prioridade Automática"
 
-#: src/muuli_wdr.cpp:1586
+#: src/muuli_wdr.cpp:1593
 msgid "Try to download first and last chunks first"
 msgstr "Tentar descargar antes o primeiro e último anaco do ficheiro"
 
-#: src/muuli_wdr.cpp:1590
+#: src/muuli_wdr.cpp:1597
 msgid "Endgame mode: rotate to faster sources for the final blocks"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1593
+#: src/muuli_wdr.cpp:1600
 msgid "Start next paused file when a file completes"
 msgstr "Comezar co seguinte ficheiro que estea pausado cando remate o ficheiro actual"
 
-#: src/muuli_wdr.cpp:1596
+#: src/muuli_wdr.cpp:1603
 msgid "From the same category"
 msgstr "Da mesma categoría"
 
-#: src/muuli_wdr.cpp:1598
+#: src/muuli_wdr.cpp:1605
 msgid "In alphabetic order"
 msgstr "En orde alfabética"
 
-#: src/muuli_wdr.cpp:1600
+#: src/muuli_wdr.cpp:1607
 msgid "Preallocate disk space for new files"
 msgstr "Reservar espazo no disco para os novos ficheiros"
 
-#: src/muuli_wdr.cpp:1601
+#: src/muuli_wdr.cpp:1608
 msgid "For new files preallocates disk space for the whole file, thus reduces fragmentation"
 msgstr "Reserva o tamaño do ficheiro no disco para reducir a fragmentación"
 
-#: src/muuli_wdr.cpp:1606
+#: src/muuli_wdr.cpp:1613
 msgid "Create new files as sparse files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1607
+#: src/muuli_wdr.cpp:1614
 msgid "A sparse file reserves its full size on disk immediately without writing real data to it -- fast, but unsupported or slow on some filesystems, and free-space accounting stays optimistic while the download is in progress. Turn this off to grow the file only as data arrives."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1612
+#: src/muuli_wdr.cpp:1619
 msgid "Stop downloads when free disk space reaches "
 msgstr "Parar descargas canto o espazo libre no disco acade "
 
-#: src/muuli_wdr.cpp:1613
+#: src/muuli_wdr.cpp:1620
 msgid "Select this if you want aMule to check your disk space"
 msgstr "Seleccione esta opción se quere que aMule comprobe o espazo libre no disco"
 
-#: src/muuli_wdr.cpp:1617
+#: src/muuli_wdr.cpp:1624
 msgid "Enter here the min disk space desired."
 msgstr "Introduza o espazo mínimo de disco desexado."
 
-#: src/muuli_wdr.cpp:1623
+#: src/muuli_wdr.cpp:1630
 msgid "Save 10 sources on rare files (< 20 sources)"
 msgstr "Gardar 10 fontes en ficheiros raros (< 20 fontes)"
 
-#: src/muuli_wdr.cpp:1627 src/Statistics.cpp:790
+#: src/muuli_wdr.cpp:1634 src/Statistics.cpp:790
 msgid "Uploads"
 msgstr "Enviado"
 
-#: src/muuli_wdr.cpp:1630
+#: src/muuli_wdr.cpp:1637
 msgid "Add new shared files with auto priority"
 msgstr "Engadir novas descargas con prioridade Automática"
 
-#: src/muuli_wdr.cpp:1636
+#: src/muuli_wdr.cpp:1643
 msgid "Intelligent Corruption Handling (I.C.H.)"
 msgstr "Xestión Intelixente de Corrupcións (X.I.C, I.C.H en inglés)"
 
-#: src/muuli_wdr.cpp:1639
+#: src/muuli_wdr.cpp:1646
 msgid "Enable"
 msgstr "Activada"
 
-#: src/muuli_wdr.cpp:1642
+#: src/muuli_wdr.cpp:1649
 msgid "Advanced I.C.H. trusts every hash (not recommended)"
 msgstr "O X.I.C. avanzado confía en cada hash (non recomendado)"
 
-#: src/muuli_wdr.cpp:1654 src/PrefsUnifiedDlg.cpp:1910
+#: src/muuli_wdr.cpp:1661 src/PrefsUnifiedDlg.cpp:1910
 msgid "Media metadata extraction"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1658
+#: src/muuli_wdr.cpp:1665
 msgid "Extract length / bitrate / codec from shared audio and video files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1660
+#: src/muuli_wdr.cpp:1667
 msgid "When enabled, aMule runs ffprobe on each shared media file to fill in the Length / Bitrate / Codec columns other clients see when they find the file in a search. Requires ffmpeg (the ffprobe binary) to be installed."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1667
+#: src/muuli_wdr.cpp:1674
 msgid "Path to ffprobe:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1672
+#: src/muuli_wdr.cpp:1679
 msgid "Full path to the ffprobe binary. Leave empty to have aMule auto-detect it on startup."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1680
+#: src/muuli_wdr.cpp:1687
 msgid "Detect"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1681
+#: src/muuli_wdr.cpp:1688
 msgid "Search the standard install locations for an ffprobe binary and fill the path field."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1705
+#: src/muuli_wdr.cpp:1712
 msgid ""
 "Completed downloads are stored here. All files in this folder are automatically shared with other peers.\n"
 "If this folder also holds files you don't want to share, point it at an aMule-only sub-folder."
@@ -4173,674 +4187,674 @@ msgstr ""
 "Aquí gárdanse as descargas completas. Automaticamente compartiranse todos os ficheiros do cartafol co resto de parceiros.\n"
 "Se o cartafol tamén conten ficheiros privados, apunte a ruta a un cartafol só para aMule."
 
-#: src/muuli_wdr.cpp:1708
+#: src/muuli_wdr.cpp:1715
 msgid "Pick the folder where completed downloads will be stored. All files in that folder will be shared with other peers."
 msgstr "Escolla o cartafol onde gardar as descargas completas. Compartiranse todos os ficheiros do cartafol co resto de parceiros."
 
-#: src/muuli_wdr.cpp:1722
+#: src/muuli_wdr.cpp:1729
 msgid "Shared folders"
 msgstr "Cartafoles compartidos"
 
-#: src/muuli_wdr.cpp:1728
+#: src/muuli_wdr.cpp:1735
 msgid "(Folders shared by the core. Enter a path to add one.)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1736
+#: src/muuli_wdr.cpp:1743
 msgid "Absolute path of a folder on the core's machine, e.g. /home/user/shared"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1738 src/PrefsUnifiedDlg.cpp:2794
+#: src/muuli_wdr.cpp:1745 src/PrefsUnifiedDlg.cpp:2794
 msgid "Recursive"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1739
+#: src/muuli_wdr.cpp:1746
 msgid "Share every sub-folder underneath this one, including ones created later."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1743 src/utils/aLinkCreator/src/alcframe.cpp:141
+#: src/muuli_wdr.cpp:1750 src/utils/aLinkCreator/src/alcframe.cpp:141
 msgid "Remove"
 msgstr "Eliminar"
 
-#: src/muuli_wdr.cpp:1747
+#: src/muuli_wdr.cpp:1754
 msgid "(Right click on folder icon for recursive share)"
 msgstr "(Preme co botón dereito na icona do cartafol para compartir recursivamente)"
 
-#: src/muuli_wdr.cpp:1754
+#: src/muuli_wdr.cpp:1761
 msgid "Share hidden files"
 msgstr "Compartir ficheiros ocultos"
 
-#: src/muuli_wdr.cpp:1760
+#: src/muuli_wdr.cpp:1767
 msgid "Automatically rescan shared folders for changes"
 msgstr "Revisar automaticamente se hai cambios nos cartafoles compartidos"
 
-#: src/muuli_wdr.cpp:1766
+#: src/muuli_wdr.cpp:1773
 msgid "Follow symbolic links in shared folders"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1772
+#: src/muuli_wdr.cpp:1779
 msgid "Exclude files matching:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1775
+#: src/muuli_wdr.cpp:1782
 msgid "Wildcard patterns separated by '|', e.g. .DS_Store|Thumbs.db|*.tmp. Files whose name matches are not shared. Matching is case-insensitive."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1779
+#: src/muuli_wdr.cpp:1786
 msgid "Patterns are regular expressions"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1780
+#: src/muuli_wdr.cpp:1787
 msgid "When set, the whole field is one regular expression ('|' is alternation). When unset, it is a list of '|'-separated wildcards."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1790
+#: src/muuli_wdr.cpp:1797
 msgid "Show how many shared files the current pattern would exclude."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1811
+#: src/muuli_wdr.cpp:1818
 msgid "Graphs"
 msgstr "Gráficas"
 
-#: src/muuli_wdr.cpp:1814 src/muuli_wdr.cpp:1876
+#: src/muuli_wdr.cpp:1821 src/muuli_wdr.cpp:1883
 msgid "Update delay : 5 secs"
 msgstr "Intervalo de actualización: 5 segs"
 
-#: src/muuli_wdr.cpp:1818
+#: src/muuli_wdr.cpp:1825
 msgid "Time for average graph: 100 mins"
 msgstr "Tempo de media do gráfico: 100 minutos"
 
-#: src/muuli_wdr.cpp:1822
+#: src/muuli_wdr.cpp:1829
 msgid "Connections Graph Scale: 100 "
 msgstr "Escala do gráfico das conexións: 100 "
 
-#: src/muuli_wdr.cpp:1829
+#: src/muuli_wdr.cpp:1836
 msgid "Download graph scale:"
 msgstr "Escala do gráfico de descargas:"
 
-#: src/muuli_wdr.cpp:1837
+#: src/muuli_wdr.cpp:1844
 msgid "Upload graph scale:"
 msgstr "Escala do gráfico de envíos:"
 
-#: src/muuli_wdr.cpp:1847
+#: src/muuli_wdr.cpp:1854
 msgid "Colors: "
 msgstr "Cores: "
 
-#: src/muuli_wdr.cpp:1851
+#: src/muuli_wdr.cpp:1858
 msgid "Background"
 msgstr "Fondo"
 
-#: src/muuli_wdr.cpp:1852
+#: src/muuli_wdr.cpp:1859
 msgid "Grid"
 msgstr "Enreixado"
 
-#: src/muuli_wdr.cpp:1853
+#: src/muuli_wdr.cpp:1860
 msgid "Download current"
 msgstr "Descarga actual"
 
-#: src/muuli_wdr.cpp:1854
+#: src/muuli_wdr.cpp:1861
 msgid "Download running average"
 msgstr "Media das descargas en execución"
 
-#: src/muuli_wdr.cpp:1855
+#: src/muuli_wdr.cpp:1862
 msgid "Download session average"
 msgstr "Media de descargas na sesión"
 
-#: src/muuli_wdr.cpp:1856
+#: src/muuli_wdr.cpp:1863
 msgid "Upload current"
 msgstr "Subida actual"
 
-#: src/muuli_wdr.cpp:1857
+#: src/muuli_wdr.cpp:1864
 msgid "Upload running average"
 msgstr "Media de subida en execución"
 
-#: src/muuli_wdr.cpp:1858
+#: src/muuli_wdr.cpp:1865
 msgid "Upload session average"
 msgstr "Media de subida na sesión"
 
-#: src/muuli_wdr.cpp:1859
+#: src/muuli_wdr.cpp:1866
 msgid "Active connections"
 msgstr "Conexións activas"
 
-#: src/muuli_wdr.cpp:1862
+#: src/muuli_wdr.cpp:1869
 msgid "Systray Icon Speed Bar"
 msgstr "Barra de velocidade na bandexa do sistema"
 
-#: src/muuli_wdr.cpp:1863
+#: src/muuli_wdr.cpp:1870
 msgid "Kad-nodes current"
 msgstr "Nodos Kad actuais"
 
-#: src/muuli_wdr.cpp:1864
+#: src/muuli_wdr.cpp:1871
 msgid "Kad-nodes running"
 msgstr "Nodo Kad executándose"
 
-#: src/muuli_wdr.cpp:1865
+#: src/muuli_wdr.cpp:1872
 msgid "Kad-nodes session"
 msgstr "Nodos Kad na sesión"
 
-#: src/muuli_wdr.cpp:1869 src/muuli_wdr.cpp:2296
+#: src/muuli_wdr.cpp:1876 src/muuli_wdr.cpp:2303
 msgid "Select"
 msgstr "Seleccionar"
 
-#: src/muuli_wdr.cpp:1873
+#: src/muuli_wdr.cpp:1880
 msgid "Tree"
 msgstr "Árbore"
 
-#: src/muuli_wdr.cpp:1883
+#: src/muuli_wdr.cpp:1890
 msgid "Number of Client Versions shown (0=unlimited)"
 msgstr "Cantas versións do cliente a amosar (0=ilimitado)"
 
-#: src/muuli_wdr.cpp:1908
+#: src/muuli_wdr.cpp:1915
 msgid "!!! WARNING !!!"
 msgstr "ADVERTENCIA !!!"
 
-#: src/muuli_wdr.cpp:1923
+#: src/muuli_wdr.cpp:1930
 msgid "Max new connections / 5 secs"
 msgstr "Novas conexións máx. / 5 segs"
 
-#: src/muuli_wdr.cpp:1925
+#: src/muuli_wdr.cpp:1932
 msgid "Concurrent Kad source lookups"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1927
+#: src/muuli_wdr.cpp:1934
 #, fuzzy
 msgid "Kad source re-search interval (minutes)"
 msgstr "Intervalo de actualización do FTP en minutos"
 
-#: src/muuli_wdr.cpp:1929
+#: src/muuli_wdr.cpp:1936
 #, fuzzy
 msgid "Source re-ask interval (minutes)"
 msgstr "Intervalo de actualización do FTP en minutos"
 
-#: src/muuli_wdr.cpp:1933
+#: src/muuli_wdr.cpp:1940
 msgid "File Buffer Size: 240000 bytes"
 msgstr "Tamaño do búfer de ficheiro: 240 000 octetos"
 
-#: src/muuli_wdr.cpp:1937
+#: src/muuli_wdr.cpp:1944
 msgid "Use MMAP: memory-mapped file access (lower memory use)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1938
+#: src/muuli_wdr.cpp:1945
 msgid "Maps part files into memory instead of buffering them on the heap, lowering the process memory footprint. May reduce download speed on some disks; best for memory-constrained or upload-heavy hosts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1940
+#: src/muuli_wdr.cpp:1947
 msgid "Upload Queue Size: 5000 clients"
 msgstr "Tamaño cola de espera: 5000 clientes"
 
-#: src/muuli_wdr.cpp:1944
+#: src/muuli_wdr.cpp:1951
 msgid "Server connection refresh interval: Disable"
 msgstr "Intervalo de actualización de conexión ao servidor: Desactivado"
 
-#: src/muuli_wdr.cpp:1948
+#: src/muuli_wdr.cpp:1955
 msgid "Disable computer's timed standby mode"
 msgstr "Impedir que o ordenador entre en modo espera"
 
-#: src/muuli_wdr.cpp:1967
+#: src/muuli_wdr.cpp:1974
 msgid "Skin to use: "
 msgstr "Tema a usar: "
 
-#: src/muuli_wdr.cpp:1976
+#: src/muuli_wdr.cpp:1983
 msgid "Show \"Fast eD2k Links Handler\" in every window."
 msgstr "Amosar «Xestor rápido de ligazóns eD2k» en cada xanela."
 
-#: src/muuli_wdr.cpp:1979
+#: src/muuli_wdr.cpp:1986
 msgid "Show extended info on categories tabs"
 msgstr "Mostrar información engadida nas lapelas das categorías"
 
-#: src/muuli_wdr.cpp:1982
+#: src/muuli_wdr.cpp:1989
 msgid "Show application version on title"
 msgstr "Amosar a versión da aplicación no título"
 
-#: src/muuli_wdr.cpp:1984
+#: src/muuli_wdr.cpp:1991
 msgid "Show transfer rates on title"
 msgstr "Mostrar velocidades de transferencia no título"
 
-#: src/muuli_wdr.cpp:1986
+#: src/muuli_wdr.cpp:1993
 msgid "Before application name"
 msgstr "Antes do nome da aplicación"
 
-#: src/muuli_wdr.cpp:1988
+#: src/muuli_wdr.cpp:1995
 msgid "After application name"
 msgstr "Despois do nome da aplicación"
 
-#: src/muuli_wdr.cpp:1991
+#: src/muuli_wdr.cpp:1998
 msgid "Show overhead bandwidth"
 msgstr "Amosar ancho de banda malgastado"
 
-#: src/muuli_wdr.cpp:1995
+#: src/muuli_wdr.cpp:2002
 msgid "Vertical toolbar orientation"
 msgstr "Barra de ferramentas en orientación vertical"
 
-#: src/muuli_wdr.cpp:1997
+#: src/muuli_wdr.cpp:2004
 msgid "Live column sorting (auto-reorder rows as their values change)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2004
+#: src/muuli_wdr.cpp:2011
 msgid "Download Queue Files"
 msgstr "Cola de Descargas"
 
-#: src/muuli_wdr.cpp:2007
+#: src/muuli_wdr.cpp:2014
 msgid "Show progress percentage"
 msgstr "Amosar porcentaxe de progreso"
 
-#: src/muuli_wdr.cpp:2013
+#: src/muuli_wdr.cpp:2020
 msgid "Show progress bar"
 msgstr "Amosar barra de progreso"
 
-#: src/muuli_wdr.cpp:2016
+#: src/muuli_wdr.cpp:2023
 msgid "Flat"
 msgstr "Plana"
 
-#: src/muuli_wdr.cpp:2020
+#: src/muuli_wdr.cpp:2027
 msgid "Round"
 msgstr "3D"
 
-#: src/muuli_wdr.cpp:2038
+#: src/muuli_wdr.cpp:2045
 msgid "External Connection Parameters"
 msgstr "Parámetros da Conexión Externa (CE)"
 
-#: src/muuli_wdr.cpp:2041
+#: src/muuli_wdr.cpp:2048
 msgid "Accept external connections"
 msgstr "Aceptar conexións externas"
 
-#: src/muuli_wdr.cpp:2048 src/muuli_wdr.cpp:2107
+#: src/muuli_wdr.cpp:2055 src/muuli_wdr.cpp:2114
 msgid "IP of the listening interface:"
 msgstr "IP da interface na que escoitar:"
 
-#: src/muuli_wdr.cpp:2051
+#: src/muuli_wdr.cpp:2058
 msgid "Enter here a valid ip in the a.b.c.d format for the listening EC interface. An empty field or 0.0.0.0 will mean any interface."
 msgstr "Introduza aquí a IP (válida, no formato a.b.c.d) da interface para a CE. Un campo baleiro ou 0.0.0.0 significa calquera interface."
 
-#: src/muuli_wdr.cpp:2072 src/muuli_wdr.cpp:2156
+#: src/muuli_wdr.cpp:2079 src/muuli_wdr.cpp:2163
 msgid "TCP port:"
 msgstr "Porto TCP:"
 
-#: src/muuli_wdr.cpp:2078
+#: src/muuli_wdr.cpp:2085
 msgid "Enable UPnP port forwarding on the EC port"
 msgstr "Activar a configuración de portos por UPnP para o porto de CE"
 
-#: src/muuli_wdr.cpp:2082 src/muuli_wdr.cpp:3041
+#: src/muuli_wdr.cpp:2089 src/muuli_wdr.cpp:3048
 #: src/utils/wxCas/src/wxcasprefs.cpp:167
 msgid "Password"
 msgstr "Contrasinal"
 
-#: src/muuli_wdr.cpp:2088
+#: src/muuli_wdr.cpp:2095
 #, fuzzy
 msgid "aMule API server parameters"
 msgstr "Parámetros do servidor Web"
 
-#: src/muuli_wdr.cpp:2091
+#: src/muuli_wdr.cpp:2098
 msgid "Run amuleapi (REST API) on startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2096
+#: src/muuli_wdr.cpp:2103
 #, fuzzy
 msgid "HTTP port:"
 msgstr "Porto TCP:"
 
-#: src/muuli_wdr.cpp:2110
+#: src/muuli_wdr.cpp:2117
 msgid "The interface amuleapi's HTTP server listens on. 127.0.0.1 (default) accepts only local connections; use 0.0.0.0 or a specific IP to expose it to other hosts (set an admin password below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2113
+#: src/muuli_wdr.cpp:2120
 #, fuzzy
 msgid "Admin password"
 msgstr "Comprobando contrasinal\n"
 
-#: src/muuli_wdr.cpp:2118 src/muuli_wdr.cpp:2149
+#: src/muuli_wdr.cpp:2125 src/muuli_wdr.cpp:2156
 msgid "Low rights password"
 msgstr "Contrasinal para o invitado"
 
-#: src/muuli_wdr.cpp:2126
+#: src/muuli_wdr.cpp:2133
 msgid "Web server parameters"
 msgstr "Parámetros do servidor Web"
 
-#: src/muuli_wdr.cpp:2129
+#: src/muuli_wdr.cpp:2136
 #, fuzzy
 msgid "Run webserver on startup (deprecated)"
 msgstr "Arrancar o servidor web ao iniciar"
 
-#: src/muuli_wdr.cpp:2135
+#: src/muuli_wdr.cpp:2142
 msgid "Web template"
 msgstr "Modelo Web"
 
-#: src/muuli_wdr.cpp:2140
+#: src/muuli_wdr.cpp:2147
 msgid "Full rights password"
 msgstr "Contrasinal para o administrador"
 
-#: src/muuli_wdr.cpp:2144
+#: src/muuli_wdr.cpp:2151
 msgid "Enable Low rights User"
 msgstr "Activar invitado"
 
-#: src/muuli_wdr.cpp:2163
+#: src/muuli_wdr.cpp:2170
 msgid "Enable UPnP port forwarding of the web server port"
 msgstr "Configurar o porto do servidor web mediante UPnP"
 
-#: src/muuli_wdr.cpp:2168
+#: src/muuli_wdr.cpp:2175
 msgid "Web server UPnP TCP port (Optional)"
 msgstr "Porto TCP para o UPnP do servidor web (Opcional)"
 
-#: src/muuli_wdr.cpp:2176
+#: src/muuli_wdr.cpp:2183
 msgid "Page Refresh Time (in secs)"
 msgstr "Tempo de actualización da páxina (en segs)"
 
-#: src/muuli_wdr.cpp:2183
+#: src/muuli_wdr.cpp:2190
 msgid "Enable Gzip compression"
 msgstr "Activar compresión Gzip"
 
-#: src/muuli_wdr.cpp:2217
+#: src/muuli_wdr.cpp:2224
 #, fuzzy
 msgid "Reset page to defaults"
 msgstr "Predeterminado"
 
-#: src/muuli_wdr.cpp:2218
+#: src/muuli_wdr.cpp:2225
 msgid "Reset the settings on the current page to their default values."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2220 src/muuli_wdr.cpp:2306 src/ServerWnd.cpp:274
+#: src/muuli_wdr.cpp:2227 src/muuli_wdr.cpp:2313 src/ServerWnd.cpp:274
 #: src/ServerWnd.cpp:282
 msgid "OK"
 msgstr "Vale"
 
-#: src/muuli_wdr.cpp:2222
+#: src/muuli_wdr.cpp:2229
 msgid "Click here to apply any changes made to the preferences."
 msgstr "Aplicar calquera troco feito nas preferencias."
 
-#: src/muuli_wdr.cpp:2225
+#: src/muuli_wdr.cpp:2232
 msgid "Reset any changes made to the preferences."
 msgstr "Restablecer calquera troco feito nas preferencias."
 
-#: src/muuli_wdr.cpp:2254
+#: src/muuli_wdr.cpp:2261
 msgid "Comment :"
 msgstr "Comentario :"
 
-#: src/muuli_wdr.cpp:2261
+#: src/muuli_wdr.cpp:2268
 msgid "Incoming Dir :"
 msgstr "Cartafol de descargas :"
 
-#: src/muuli_wdr.cpp:2270
+#: src/muuli_wdr.cpp:2277
 msgid "Change priority for new assigned files :"
 msgstr "Cambiar prioridade para os novos ficheiros asignados :"
 
-#: src/muuli_wdr.cpp:2274
+#: src/muuli_wdr.cpp:2281
 msgid "Don't change"
 msgstr "Non cambiar"
 
-#: src/muuli_wdr.cpp:2286
+#: src/muuli_wdr.cpp:2293
 msgid "Select color for this Category (currently selected) :"
 msgstr "Seleccionar cor para esta categoría (a seleccionada) :"
 
-#: src/muuli_wdr.cpp:2353 src/muuli_wdr.cpp:2372 src/muuli_wdr.cpp:2394
+#: src/muuli_wdr.cpp:2360 src/muuli_wdr.cpp:2379 src/muuli_wdr.cpp:2401
 msgid "Click this button to reset the log."
 msgstr "Premer este botón para reiniciar o rexistro."
 
-#: src/muuli_wdr.cpp:2413
+#: src/muuli_wdr.cpp:2420
 msgid "Click on this button to update the servers list from URL ..."
 msgstr "Premer neste botón para actualizar a lista de servidores desde a URL ..."
 
-#: src/muuli_wdr.cpp:2417
+#: src/muuli_wdr.cpp:2424
 msgid "Server list"
 msgstr "Lista de servidores"
 
-#: src/muuli_wdr.cpp:2421
+#: src/muuli_wdr.cpp:2428
 msgid "Enter the url to a server.met file here and press the button to the left to update the list of known servers."
 msgstr "Introduza a URL dun ficheiro server.met e prema o botón da esquerda para actualizar a lista de servidores coñecidos."
 
-#: src/muuli_wdr.cpp:2426
+#: src/muuli_wdr.cpp:2433
 msgid "Add server manually: Name"
 msgstr "Engadir servidor manualmente: Nome"
 
-#: src/muuli_wdr.cpp:2429
+#: src/muuli_wdr.cpp:2436
 msgid "Enter the name of the new server here"
 msgstr "Introduza o nome do novo servidor aquí"
 
-#: src/muuli_wdr.cpp:2431 src/ServerWnd.cpp:206
+#: src/muuli_wdr.cpp:2438 src/ServerWnd.cpp:206
 msgid "IP:Port"
 msgstr "IP:Porto"
 
-#: src/muuli_wdr.cpp:2434
+#: src/muuli_wdr.cpp:2441
 msgid "Enter the IP of the server here, using the x.x.x.x format."
 msgstr "Introduza a IP do servidor aquí, usando o formato x.x.x.x ."
 
-#: src/muuli_wdr.cpp:2440
+#: src/muuli_wdr.cpp:2447
 msgid "Enter the port of the server here."
 msgstr "Introduza o porto do servidor aquí."
 
-#: src/muuli_wdr.cpp:2443
+#: src/muuli_wdr.cpp:2450
 msgid "Add manually a server (fill fields to the left before) ..."
 msgstr "Engadir servidor manualmente (antes enche os campos á esquerda) ..."
 
-#: src/muuli_wdr.cpp:2472
+#: src/muuli_wdr.cpp:2479
 msgid "aMule Log"
 msgstr "Rexistro de aMule"
 
-#: src/muuli_wdr.cpp:2480
+#: src/muuli_wdr.cpp:2487
 msgid "Server Info"
 msgstr "Info. do servidor"
 
-#: src/muuli_wdr.cpp:2484
+#: src/muuli_wdr.cpp:2491
 msgid "ED2K Info"
 msgstr "Info. ED2K"
 
-#: src/muuli_wdr.cpp:2488
+#: src/muuli_wdr.cpp:2495
 msgid "Kad Info"
 msgstr "Info. Kad"
 
-#: src/muuli_wdr.cpp:2516
+#: src/muuli_wdr.cpp:2523
 msgid "Click on this button to update the nodes list from URL ..."
 msgstr "Prema neste botón para actualizar a lista de nodos dende a URL ..."
 
-#: src/muuli_wdr.cpp:2520
+#: src/muuli_wdr.cpp:2527
 msgid "Nodes (0)"
 msgstr "Nodos (0)"
 
-#: src/muuli_wdr.cpp:2524
+#: src/muuli_wdr.cpp:2531
 msgid "Enter the url to a nodes.dat file here and press the button to the left to update the list of known nodes."
 msgstr "Introduza aquí a URL ao ficheiro nodes.dat e prema o botón da esquerda, para actualizar a lista de nodos coñecidos."
 
-#: src/muuli_wdr.cpp:2527
+#: src/muuli_wdr.cpp:2534
 msgid "Nodes stats"
 msgstr "Estatísticas de nodos"
 
-#: src/muuli_wdr.cpp:2569
+#: src/muuli_wdr.cpp:2576
 msgid "Bootstrap"
 msgstr "Arranque autónomo (dende cero)"
 
-#: src/muuli_wdr.cpp:2572
+#: src/muuli_wdr.cpp:2579
 msgid "New node"
 msgstr "Novo nodo"
 
-#: src/muuli_wdr.cpp:2577
+#: src/muuli_wdr.cpp:2584
 msgid "IP:"
 msgstr "IP:"
 
-#: src/muuli_wdr.cpp:2597
+#: src/muuli_wdr.cpp:2604
 msgid "Port:"
 msgstr "Porto:"
 
-#: src/muuli_wdr.cpp:2610
+#: src/muuli_wdr.cpp:2617
 msgid "Bootstrap from known clients"
 msgstr "Arrancar a partir de clientes coñecidos"
 
-#: src/muuli_wdr.cpp:2612
+#: src/muuli_wdr.cpp:2619
 msgid "Disconnect Kad"
 msgstr "Desconectar Kad"
 
-#: src/muuli_wdr.cpp:2646
+#: src/muuli_wdr.cpp:2653
 msgid "Use Secure User Identification"
 msgstr "Empregar a Identificación Segura do Usuario"
 
-#: src/muuli_wdr.cpp:2648
+#: src/muuli_wdr.cpp:2655
 msgid "It is recommended to enable this option. You will not receive credits if SUI is not enabled."
 msgstr "Aconséllase habilitar esta opción. Non recibirá créditos se a ISU non se habilitou."
 
-#: src/muuli_wdr.cpp:2650
+#: src/muuli_wdr.cpp:2657
 msgid "Protocol Obfuscation"
 msgstr "Ofuscación do protocolo"
 
-#: src/muuli_wdr.cpp:2653
+#: src/muuli_wdr.cpp:2660
 msgid "Support Protocol Obfuscation"
 msgstr "Aceptar a ofuscación do protocolo"
 
-#: src/muuli_wdr.cpp:2655
+#: src/muuli_wdr.cpp:2662
 msgid "This option enabled Protocol Obfuscation, and makes aMule accept obfuscated connections from other clients."
 msgstr "Esta opción activa a ofuscación do protocolo, e permite que aMule acepte conexións ofuscadas doutros clientes."
 
-#: src/muuli_wdr.cpp:2657
+#: src/muuli_wdr.cpp:2664
 msgid "Use obfuscation for outgoing connections"
 msgstr "Usar ofuscación para as conexións saíntes"
 
-#: src/muuli_wdr.cpp:2659
+#: src/muuli_wdr.cpp:2666
 msgid "This option makes aMule use Protocol Obfuscation when connecting other clients/servers."
 msgstr "Esta opción fai que aMule use a ofuscación de protocolo cando se conectan outros clientes/servidores."
 
-#: src/muuli_wdr.cpp:2661
+#: src/muuli_wdr.cpp:2668
 msgid "Accept only obfuscated connections"
 msgstr "Aceptar só conexións ofuscadas"
 
-#: src/muuli_wdr.cpp:2662
+#: src/muuli_wdr.cpp:2669
 msgid "This option makes aMule only accept obfuscated connections. You will have less sources, but all your traffic will be obfuscated"
 msgstr "Esta opción fai que aMule só acepte conexións ofuscadas. Terá menos fontes, pero todo o tráfico estará ofuscado"
 
-#: src/muuli_wdr.cpp:2667
+#: src/muuli_wdr.cpp:2674
 msgid "Everybody"
 msgstr "Todos"
 
-#: src/muuli_wdr.cpp:2669
+#: src/muuli_wdr.cpp:2676
 msgid "No one"
 msgstr "Ninguén"
 
-#: src/muuli_wdr.cpp:2671
+#: src/muuli_wdr.cpp:2678
 msgid "Who can see my shared files:"
 msgstr "Quen pode ver os meus ficheiros compartidos:"
 
-#: src/muuli_wdr.cpp:2672
+#: src/muuli_wdr.cpp:2679
 msgid "Select who can request to view a list of your shared files."
 msgstr "Seleccione quen pode solicitar ver a lista de ficheiros compartidos."
 
-#: src/muuli_wdr.cpp:2674
+#: src/muuli_wdr.cpp:2681
 msgid "IP-Filtering"
 msgstr "Filtrado de IPs"
 
-#: src/muuli_wdr.cpp:2681
+#: src/muuli_wdr.cpp:2688
 msgid "Filter clients"
 msgstr "Filtrar clientes"
 
-#: src/muuli_wdr.cpp:2683
+#: src/muuli_wdr.cpp:2690
 msgid "Enable filtering of the client IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "Activar filtrado das IPs dos clientes definidas no ficheiro ~/.aMule/ipfilter.dat."
 
-#: src/muuli_wdr.cpp:2685
+#: src/muuli_wdr.cpp:2692
 msgid "Filter servers"
 msgstr "Filtrar servidores"
 
-#: src/muuli_wdr.cpp:2687
+#: src/muuli_wdr.cpp:2694
 msgid "Enable filtering of the server IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "Activar filtrado das IPs dos servidores definidas no ficheiro ~/.aMule/ipfilter.dat."
 
-#: src/muuli_wdr.cpp:2691
+#: src/muuli_wdr.cpp:2698
 msgid "Reload List"
 msgstr "Recargar lista"
 
-#: src/muuli_wdr.cpp:2692
+#: src/muuli_wdr.cpp:2699
 msgid "Reload the list of IPs to filter from the file ~/.aMule/ipfilter.dat"
 msgstr "Recargar a lista de filtrado de IPs desde o ficheiro ~/.aMule/ipfilter.dat"
 
-#: src/muuli_wdr.cpp:2698
+#: src/muuli_wdr.cpp:2705
 msgid "URL:"
 msgstr "URL:"
 
-#: src/muuli_wdr.cpp:2702 src/muuli_wdr.cpp:2895
+#: src/muuli_wdr.cpp:2709 src/muuli_wdr.cpp:2902
 msgid "Update now"
 msgstr "Actualizar agora"
 
-#: src/muuli_wdr.cpp:2705
+#: src/muuli_wdr.cpp:2712
 msgid "Auto-update ipfilter at startup"
 msgstr "Auto-actualizar o filtrado de IPs ao iniciarse"
 
-#: src/muuli_wdr.cpp:2709
+#: src/muuli_wdr.cpp:2716
 msgid "Filtering Level:"
 msgstr "Nivel de filtrado:"
 
-#: src/muuli_wdr.cpp:2715
+#: src/muuli_wdr.cpp:2722
 msgid "Always filter LAN IPs"
 msgstr "Filtrar sempre IPs LAN"
 
-#: src/muuli_wdr.cpp:2718
+#: src/muuli_wdr.cpp:2725
 msgid "Paranoid handling of non-matching IPs"
 msgstr "Xestión paranoica de IPs non coincidintes"
 
-#: src/muuli_wdr.cpp:2720
+#: src/muuli_wdr.cpp:2727
 msgid "Rejects a packet when its source IP differs from the IP the client claims (an anti-spoofing check). Disable only if it causes connection problems."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2722
+#: src/muuli_wdr.cpp:2729
 msgid "Use system-wide ipfilter.dat if available"
 msgstr "Empregar un ipfilter.dat global se está dispoñible"
 
-#: src/muuli_wdr.cpp:2723
+#: src/muuli_wdr.cpp:2730
 msgid "If there's no local ipfilter.dat found, allow usage of a system-wide ipfilter file."
 msgstr "De non atopar o ipfilter.dat local, permitir o emprego dun ipfilter global."
 
-#: src/muuli_wdr.cpp:2740
+#: src/muuli_wdr.cpp:2747
 msgid "Enable Online-Signature"
 msgstr "Activar Sinatura En liña"
 
-#: src/muuli_wdr.cpp:2742
+#: src/muuli_wdr.cpp:2749
 msgid "Enables the writing of the OS file, which can be used by external apps to create signatures and the like."
 msgstr "Habilitar a escritura de ficheiros do SE. Sóese usar para crear sinaturas para aplicacións externas."
 
-#: src/muuli_wdr.cpp:2746
+#: src/muuli_wdr.cpp:2753
 msgid "Update Frequency (Secs):"
 msgstr "Frecuencia de actualización (segs):"
 
-#: src/muuli_wdr.cpp:2749
+#: src/muuli_wdr.cpp:2756
 msgid "Change the frequency (in seconds) of Online Signature updates."
 msgstr "Cambiar a frecuencia (en segundos) da actualización da sinatura en liña."
 
-#: src/muuli_wdr.cpp:2757
+#: src/muuli_wdr.cpp:2764
 msgid "Save online signature file in: "
 msgstr "Gardar o ficheiro de sinaturas en liña en: "
 
-#: src/muuli_wdr.cpp:2763
+#: src/muuli_wdr.cpp:2770
 msgid "Click here to select the directory containing the the Online Signature files."
 msgstr "Prema aquí para seleccionar o directorio que contén os ficheiros de sinaturas en liña."
 
-#: src/muuli_wdr.cpp:2796
+#: src/muuli_wdr.cpp:2803
 msgid "Show country flags for clients"
 msgstr "Amosar as bandeiras do país de orixe dos clientes"
 
-#: src/muuli_wdr.cpp:2797
+#: src/muuli_wdr.cpp:2804
 msgid "Render the country flag column in the transfers, queue and search views. Requires a valid MMDB GeoIP database (see below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2802
+#: src/muuli_wdr.cpp:2809
 #, fuzzy
 msgid "Database"
 msgstr "Fluxo de datos :"
 
-#: src/muuli_wdr.cpp:2818
+#: src/muuli_wdr.cpp:2825
 #, fuzzy
 msgid "Source:"
 msgstr "Fontes"
 
-#: src/muuli_wdr.cpp:2821
+#: src/muuli_wdr.cpp:2828
 msgid "DB-IP (free, no account)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2822
+#: src/muuli_wdr.cpp:2829
 msgid "MaxMind GeoLite2 (free, account required)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2823
+#: src/muuli_wdr.cpp:2830
 msgid "Custom URL"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2826
+#: src/muuli_wdr.cpp:2833
 msgid "Choose which provider supplies the GeoIP MMDB database. DB-IP is the default - no account required. MaxMind requires a free account + license key. Use Custom URL to point at any other MMDB host (e.g. a local mirror)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2843
+#: src/muuli_wdr.cpp:2850
 msgid ""
 "No configuration required.\n"
 "\n"
@@ -4848,11 +4862,11 @@ msgid ""
 "License: Creative Commons BY 4.0 - https://creativecommons.org/licenses/by/4.0/"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2856
+#: src/muuli_wdr.cpp:2863
 msgid "License key:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2862
+#: src/muuli_wdr.cpp:2869
 msgid ""
 "Sign up for a free MaxMind account, then generate a License Key:\n"
 "https://www.maxmind.com/en/geolite2/signup\n"
@@ -4862,225 +4876,225 @@ msgid ""
 "Requires attribution and account registration; refresh at least every 30 days."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2877
+#: src/muuli_wdr.cpp:2884
 #, fuzzy
 msgid "Download URL:"
 msgstr "Descargado: "
 
-#: src/muuli_wdr.cpp:2883
+#: src/muuli_wdr.cpp:2890
 msgid ""
 "Must point to an .mmdb file or a .gz / .tar.gz containing one.\n"
 "URL may include credentials (https://user:pass@host/...).\n"
 "License and attribution terms are set by the upstream URL - you are responsible."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2896
+#: src/muuli_wdr.cpp:2903
 msgid "Download the GeoIP database from the selected source."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2898
+#: src/muuli_wdr.cpp:2905
 #, fuzzy
 msgid "Auto-update on startup"
 msgstr "Auto-actualizar o filtrado de IPs ao iniciarse"
 
-#: src/muuli_wdr.cpp:2899
+#: src/muuli_wdr.cpp:2906
 msgid "Re-download the GeoIP database from the selected source every time aMule starts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2922
+#: src/muuli_wdr.cpp:2929
 msgid "Filter incoming messages (except current chat):"
 msgstr "Filtrar mensaxes entrantes (excepto as da conversación actual):"
 
-#: src/muuli_wdr.cpp:2924
+#: src/muuli_wdr.cpp:2931
 msgid "Filter all messages"
 msgstr "Filtrar todas as mensaxes"
 
-#: src/muuli_wdr.cpp:2926
+#: src/muuli_wdr.cpp:2933
 msgid "Filter messages from people not on your friend list"
 msgstr "Filtrar mensaxes de xente que non estea na lista de amigos"
 
-#: src/muuli_wdr.cpp:2928
+#: src/muuli_wdr.cpp:2935
 msgid "Filter messages from unknown clients"
 msgstr "Filtrar mensaxes de clientes descoñecidos"
 
-#: src/muuli_wdr.cpp:2930
+#: src/muuli_wdr.cpp:2937
 msgid "Filter messages containing (use ',' as separator):"
 msgstr "Filtrar mensaxes que conteñan (use «,» como separador):"
 
-#: src/muuli_wdr.cpp:2933 src/muuli_wdr.cpp:2944
+#: src/muuli_wdr.cpp:2940 src/muuli_wdr.cpp:2951
 msgid "add here the words amule should filter and block messages including it"
 msgstr "engada aquí palabras para filtrar e bloquear as mensaxes que coincidan"
 
-#: src/muuli_wdr.cpp:2935
+#: src/muuli_wdr.cpp:2942
 msgid "Show received messages in the log"
 msgstr "Amosar as mensaxes recibidas no rexistro"
 
-#: src/muuli_wdr.cpp:2938
+#: src/muuli_wdr.cpp:2945
 msgid "Comments"
 msgstr "Comentarios"
 
-#: src/muuli_wdr.cpp:2941
+#: src/muuli_wdr.cpp:2948
 msgid "Filter comments containing (use ',' as separator):"
 msgstr "Filtrar comentarios que conteñan (empregue «,» coma separador):"
 
-#: src/muuli_wdr.cpp:2966
+#: src/muuli_wdr.cpp:2973
 msgid "Enable Proxy"
 msgstr "Activar proxy"
 
-#: src/muuli_wdr.cpp:2967
+#: src/muuli_wdr.cpp:2974
 msgid "Enable/disable proxy support"
 msgstr "Activar/desactivar o tipo de proxy"
 
-#: src/muuli_wdr.cpp:2970
+#: src/muuli_wdr.cpp:2977
 msgid "Proxy type:"
 msgstr "Tipo de proxy:"
 
-#: src/muuli_wdr.cpp:2981
+#: src/muuli_wdr.cpp:2988
 msgid "Proxy host:"
 msgstr "Anfitrión do proxy:"
 
-#: src/muuli_wdr.cpp:2984
+#: src/muuli_wdr.cpp:2991
 msgid "The proxy host name"
 msgstr "O nome do anfitrión do proxy"
 
-#: src/muuli_wdr.cpp:2986
+#: src/muuli_wdr.cpp:2993
 msgid "Proxy port:"
 msgstr "Porto do proxy:"
 
-#: src/muuli_wdr.cpp:2989
+#: src/muuli_wdr.cpp:2996
 msgid "The proxy port"
 msgstr "O porto do proxy"
 
-#: src/muuli_wdr.cpp:2991
+#: src/muuli_wdr.cpp:2998
 msgid "Enable authentication"
 msgstr "Activar identificación"
 
-#: src/muuli_wdr.cpp:2992
+#: src/muuli_wdr.cpp:2999
 msgid "Enable/disable username/password authentication"
 msgstr "Activar/desactivar a identificación mediante nome de usuario e contrasinal"
 
-#: src/muuli_wdr.cpp:2995
+#: src/muuli_wdr.cpp:3002
 msgid "Username: "
 msgstr "Nome de usuario: "
 
-#: src/muuli_wdr.cpp:2998
+#: src/muuli_wdr.cpp:3005
 msgid "The username to use to connect to the proxy"
 msgstr "O nome de usuario a usar para conectarse ao proxy"
 
-#: src/muuli_wdr.cpp:3000
+#: src/muuli_wdr.cpp:3007
 msgid "Password:"
 msgstr "Contrasinal:"
 
-#: src/muuli_wdr.cpp:3003
+#: src/muuli_wdr.cpp:3010
 msgid "The password to use to connect to the proxy"
 msgstr "O contrasinal a empregar para conectarse ao proxy"
 
-#: src/muuli_wdr.cpp:3022
+#: src/muuli_wdr.cpp:3029
 msgid "Connect to:"
 msgstr "Conectar a:"
 
-#: src/muuli_wdr.cpp:3031
+#: src/muuli_wdr.cpp:3038
 msgid "Login to remote amule"
 msgstr "Conectar a amule remoto"
 
-#: src/muuli_wdr.cpp:3036
+#: src/muuli_wdr.cpp:3043
 msgid "User name"
 msgstr "Nome de usuario"
 
-#: src/muuli_wdr.cpp:3047
+#: src/muuli_wdr.cpp:3054
 msgid "Remember those settings"
 msgstr "Recordar esas opcións"
 
-#: src/muuli_wdr.cpp:3050
+#: src/muuli_wdr.cpp:3057
 #, fuzzy
 msgid "Force ZLIB compression"
 msgstr "Usar compresión gzip"
 
-#: src/muuli_wdr.cpp:3074
+#: src/muuli_wdr.cpp:3081
 msgid "Enable Verbose Debug-Logging."
 msgstr "Activar Rexistro de Depuración Estendido."
 
-#: src/muuli_wdr.cpp:3076
+#: src/muuli_wdr.cpp:3083
 msgid "Only to Logfile"
 msgstr "Só ao ficheiro do rexistro"
 
-#: src/muuli_wdr.cpp:3078
+#: src/muuli_wdr.cpp:3085
 msgid "Message Categories:"
 msgstr "Categorías das mensaxes:"
 
-#: src/muuli_wdr.cpp:3102 src/PartFileConvertDlg.cpp:160
+#: src/muuli_wdr.cpp:3109 src/PartFileConvertDlg.cpp:160
 msgid "Waiting..."
 msgstr "Agardando..."
 
-#: src/muuli_wdr.cpp:3122
+#: src/muuli_wdr.cpp:3129
 msgid "Add imports"
 msgstr "Engadir importados"
 
-#: src/muuli_wdr.cpp:3125
+#: src/muuli_wdr.cpp:3132
 msgid "Retry selected"
 msgstr "Tentar de novo o seleccionado"
 
-#: src/muuli_wdr.cpp:3127
+#: src/muuli_wdr.cpp:3134
 msgid "Remove selected"
 msgstr "Borrar seleccionados"
 
-#: src/muuli_wdr.cpp:3190
+#: src/muuli_wdr.cpp:3197
 msgid "Event Types"
 msgstr "Tipos de eventos"
 
-#: src/muuli_wdr.cpp:3209
+#: src/muuli_wdr.cpp:3216
 msgid "Statistics and queued clients for selected file(s) : Session / All time"
 msgstr "Estadísticas e clientes esperando para os ficheiros seleccionados: Sesión / Total"
 
-#: src/muuli_wdr.cpp:3233
+#: src/muuli_wdr.cpp:3240
 msgid "Active Uploads"
 msgstr "Envíos activos"
 
-#: src/muuli_wdr.cpp:3247
+#: src/muuli_wdr.cpp:3254
 msgid "Percent of total files"
 msgstr "Porcentaxe de todos os ficheiros"
 
-#: src/muuli_wdr.cpp:3299
+#: src/muuli_wdr.cpp:3306
 msgid "Show Clients for"
 msgstr "Amosar clientes para"
 
-#: src/muuli_wdr.cpp:3301
+#: src/muuli_wdr.cpp:3308
 msgid "All files"
 msgstr "Todos os ficheiros"
 
-#: src/muuli_wdr.cpp:3304
+#: src/muuli_wdr.cpp:3311
 msgid "Selected files"
 msgstr "Ficheiros selecionados"
 
-#: src/muuli_wdr.cpp:3307
+#: src/muuli_wdr.cpp:3314
 msgid "Active uploads only"
 msgstr "Só subidas activas"
 
-#: src/muuli_wdr.cpp:3314
+#: src/muuli_wdr.cpp:3321
 msgid "Reload:"
 msgstr "Recargar:"
 
-#: src/muuli_wdr.cpp:3318
+#: src/muuli_wdr.cpp:3325
 msgid "Reload your shared files"
 msgstr "Recargar os seus ficheiros compartidos"
 
-#: src/muuli_wdr.cpp:3381
+#: src/muuli_wdr.cpp:3388
 msgid "Send"
 msgstr "Enviar"
 
-#: src/muuli_wdr.cpp:3382
+#: src/muuli_wdr.cpp:3389
 msgid "Sends the specified message."
 msgstr "Enviar a mensaxe especificada."
 
-#: src/muuli_wdr.cpp:3386
+#: src/muuli_wdr.cpp:3393
 msgid "Close this chat-session."
 msgstr "Pechar esta conversa."
 
-#: src/muuli_wdr.cpp:3409
+#: src/muuli_wdr.cpp:3416
 msgid "Connect to any server and/or Kad"
 msgstr "Conectar a calquera servidor e/ou Kad"
 
-#: src/muuli_wdr.cpp:3415 src/SharedFilesCtrl.cpp:142 src/Statistics.cpp:941
+#: src/muuli_wdr.cpp:3422 src/SharedFilesCtrl.cpp:142 src/Statistics.cpp:941
 msgid "Shared Files"
 msgstr "Ficheiros compartidos"
 
@@ -5440,188 +5454,188 @@ msgstr "Descargado"
 msgid "ERROR: Failed to open partfile '%s'"
 msgstr "ERRO: Non se puido abrir o partfile «%s»"
 
-#: src/Preferences.cpp:673
+#: src/Preferences.cpp:674
 msgid "System default"
 msgstr "Predeterminado"
 
-#: src/Preferences.cpp:674
+#: src/Preferences.cpp:675
 msgid "Albanian"
 msgstr "Albanés"
 
-#: src/Preferences.cpp:675
+#: src/Preferences.cpp:676
 msgid "Arabic"
 msgstr "Árabe"
 
-#: src/Preferences.cpp:676
+#: src/Preferences.cpp:677
 msgid "Asturian"
 msgstr "Asturiano"
 
-#: src/Preferences.cpp:677
+#: src/Preferences.cpp:678
 msgid "Basque"
 msgstr "Euskera"
 
-#: src/Preferences.cpp:678
+#: src/Preferences.cpp:679
 msgid "Bulgarian"
 msgstr "Búlgaro"
 
-#: src/Preferences.cpp:679
+#: src/Preferences.cpp:680
 msgid "Catalan"
 msgstr "Catalán"
 
-#: src/Preferences.cpp:680
+#: src/Preferences.cpp:681
 msgid "Chinese (Simplified)"
 msgstr "Chinés (Simplificado)"
 
-#: src/Preferences.cpp:681
+#: src/Preferences.cpp:682
 msgid "Chinese (Traditional)"
 msgstr "Chinés (Tradicional)"
 
-#: src/Preferences.cpp:682
+#: src/Preferences.cpp:683
 msgid "Croatian"
 msgstr "Croata"
 
-#: src/Preferences.cpp:683
+#: src/Preferences.cpp:684
 msgid "Czech"
 msgstr "Checo"
 
-#: src/Preferences.cpp:684
+#: src/Preferences.cpp:685
 msgid "Danish"
 msgstr "Danés"
 
-#: src/Preferences.cpp:685
+#: src/Preferences.cpp:686
 msgid "Dutch"
 msgstr "Holandés"
 
-#: src/Preferences.cpp:686
+#: src/Preferences.cpp:687
 msgid "English (U.K.)"
 msgstr "Inglés (R. U.)"
 
-#: src/Preferences.cpp:687
+#: src/Preferences.cpp:688
 #, fuzzy
 msgid "English (U.S.)"
 msgstr "Inglés (R. U.)"
 
-#: src/Preferences.cpp:688
+#: src/Preferences.cpp:689
 msgid "Estonian"
 msgstr "Estonio"
 
-#: src/Preferences.cpp:689
+#: src/Preferences.cpp:690
 msgid "Finnish"
 msgstr "Finlandés"
 
-#: src/Preferences.cpp:690
+#: src/Preferences.cpp:691
 msgid "French"
 msgstr "Francés"
 
-#: src/Preferences.cpp:691
+#: src/Preferences.cpp:692
 msgid "Galician"
 msgstr "Galego"
 
-#: src/Preferences.cpp:692
+#: src/Preferences.cpp:693
 msgid "German"
 msgstr "Alemán"
 
-#: src/Preferences.cpp:693
+#: src/Preferences.cpp:694
 msgid "Greek"
 msgstr "Grego"
 
-#: src/Preferences.cpp:694
+#: src/Preferences.cpp:695
 msgid "Hebrew"
 msgstr "Hebreo"
 
-#: src/Preferences.cpp:695
+#: src/Preferences.cpp:696
 msgid "Hungarian"
 msgstr "Húngaro"
 
-#: src/Preferences.cpp:696
+#: src/Preferences.cpp:697
 msgid "Italian"
 msgstr "Italiano"
 
-#: src/Preferences.cpp:697
+#: src/Preferences.cpp:698
 msgid "Japanese"
 msgstr "Xaponés"
 
-#: src/Preferences.cpp:698
+#: src/Preferences.cpp:699
 msgid "Korean"
 msgstr "Coreano"
 
-#: src/Preferences.cpp:699
+#: src/Preferences.cpp:700
 msgid "Latvian"
 msgstr ""
 
-#: src/Preferences.cpp:700
+#: src/Preferences.cpp:701
 msgid "Lithuanian"
 msgstr "Lituano"
 
-#: src/Preferences.cpp:701
+#: src/Preferences.cpp:702
 msgid "Norwegian (Nynorsk)"
 msgstr "Noruegués (Nynorsk)"
 
-#: src/Preferences.cpp:702
+#: src/Preferences.cpp:703
 msgid "Polish"
 msgstr "Polaco"
 
-#: src/Preferences.cpp:703
+#: src/Preferences.cpp:704
 msgid "Portuguese"
 msgstr "Portugués"
 
-#: src/Preferences.cpp:704
+#: src/Preferences.cpp:705
 msgid "Portuguese (Brazilian)"
 msgstr "Portugués (Brasileiro)"
 
-#: src/Preferences.cpp:705
+#: src/Preferences.cpp:706
 msgid "Romanian"
 msgstr "Rumano"
 
-#: src/Preferences.cpp:706
+#: src/Preferences.cpp:707
 msgid "Russian"
 msgstr "Ruso"
 
-#: src/Preferences.cpp:707
+#: src/Preferences.cpp:708
 msgid "Slovenian"
 msgstr "Esloveno"
 
-#: src/Preferences.cpp:708
+#: src/Preferences.cpp:709
 msgid "Spanish"
 msgstr "Castelán"
 
-#: src/Preferences.cpp:709
+#: src/Preferences.cpp:710
 msgid "Swedish"
 msgstr "Sueco"
 
-#: src/Preferences.cpp:710
+#: src/Preferences.cpp:711
 msgid "Turkish"
 msgstr "Turco"
 
-#: src/Preferences.cpp:711
+#: src/Preferences.cpp:712
 msgid "Ukrainian"
 msgstr "Ucraniano"
 
-#: src/Preferences.cpp:814
+#: src/Preferences.cpp:815
 msgid "Change Language"
 msgstr "Cambiar idioma"
 
-#: src/Preferences.cpp:878
+#: src/Preferences.cpp:879
 msgid "There are no translations installed for aMule"
 msgstr "Non hai traducións instaladas para aMule"
 
-#: src/Preferences.cpp:879
+#: src/Preferences.cpp:880
 msgid "No languages available"
 msgstr "Ningunha lingua dispoñible"
 
-#: src/Preferences.cpp:1010
+#: src/Preferences.cpp:1011
 msgid "no options available"
 msgstr "non hai opcións disponibles"
 
-#: src/Preferences.cpp:2179
+#: src/Preferences.cpp:2182
 msgid "Invalid category found, skipping"
 msgstr "Categoría inválida atopada, saltandoa"
 
-#: src/Preferences.cpp:2348
+#: src/Preferences.cpp:2351
 msgid "TCP port can't be higher than 65532 due to server UDP socket being TCP+3"
 msgstr "O porto TCP non pode ser máis alto que 65532 debido a que o socket do servidor UDP é TCP+3"
 
-#: src/Preferences.cpp:2349
+#: src/Preferences.cpp:2352
 #, c-format
 msgid "Default port will be used (%d)"
 msgstr "Empregarase o porto predeterminado (%d)"
@@ -6132,23 +6146,27 @@ msgstr "Recargouse a lista de ficheiros compartidos: atopáronse %u ficheiros"
 msgid "Shared folder"
 msgstr "Cartafoles compartidos"
 
-#: src/SearchDlg.cpp:425
+#: src/SearchDlg.cpp:280
+msgid "Clear search history"
+msgstr ""
+
+#: src/SearchDlg.cpp:584
 msgid "It's impossible to search when both eD2k and Kademlia are disabled."
 msgstr "Non se pode buscar se tanto eD2k coma Kademlia están desactivados."
 
-#: src/SearchDlg.cpp:426 src/SearchListCtrl.cpp:858
+#: src/SearchDlg.cpp:585 src/SearchListCtrl.cpp:858
 msgid "Search error"
 msgstr "Erro na busca"
 
-#: src/SearchDlg.cpp:768
+#: src/SearchDlg.cpp:929
 msgid "Min size must be smaller than max size. Max size ignored."
 msgstr "O tamaño mínimo debe ser máis pequeno que o máximo. Tamaño máximo ignorado."
 
-#: src/SearchDlg.cpp:769 src/SearchDlg.cpp:851
+#: src/SearchDlg.cpp:930 src/SearchDlg.cpp:1012
 msgid "Search warning"
 msgstr "Aviso na busca"
 
-#: src/SearchDlg.cpp:929 src/SearchListCtrl.cpp:735
+#: src/SearchDlg.cpp:1092 src/SearchListCtrl.cpp:735
 msgid "Main"
 msgstr "Principal"
 

--- a/po/gl.po
+++ b/po/gl.po
@@ -24,7 +24,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-28 10:19+0200\n"
+"POT-Creation-Date: 2026-07-28 12:17+0200\n"
 "PO-Revision-Date: 2026-07-27 11:38+0000\n"
 "Last-Translator: Pablo <parodper@gmail.com>\n"
 "Language-Team: http://forum.amule.org/index.php?topic=13883\n"
@@ -224,83 +224,83 @@ msgstr "Non se puido abrir o ficheiro con ligazóns eD2k."
 msgid "WARNING: You can't add yourself as a source for an eD2k link while having a lowid."
 msgstr "AVISO: Non podes engadirte a ti mesmo como unha fonte para un enlace eD2k tendo ID baixa."
 
-#: src/amule.cpp:300
+#: src/amule.cpp:301
 msgid "Now, exiting main app..."
 msgstr "Saíndo da aplicación principal..."
 
-#: src/amule.cpp:330
+#: src/amule.cpp:331
 #, c-format
 msgid "Terminating amuleweb instance with pid '%d' ... "
 msgstr "Rematando o proceso de amuleweb co pid «%d» ... "
 
-#: src/amule.cpp:334
+#: src/amule.cpp:335
 #, c-format
 msgid "Killing amuleweb instance with pid '%d' ... "
 msgstr "Obrigando ao proceso de amuleweb con pid «%d» a pecharse ... "
 
-#: src/amule.cpp:336 src/amule.cpp:349 src/ClientRef.cpp:180
+#: src/amule.cpp:337 src/amule.cpp:350 src/ClientRef.cpp:180
 #: src/SearchDlg.cpp:1041 src/ServerListCtrl.cpp:98
 msgid "Failed"
 msgstr "Erro"
 
-#: src/amule.cpp:343
+#: src/amule.cpp:344
 #, fuzzy, c-format
 msgid "Terminating amuleapi instance with pid '%d' ... "
 msgstr "Rematando o proceso de amuleweb co pid «%d» ... "
 
-#: src/amule.cpp:347
+#: src/amule.cpp:348
 #, fuzzy, c-format
 msgid "Killing amuleapi instance with pid '%d' ... "
 msgstr "Obrigando ao proceso de amuleweb con pid «%d» a pecharse ... "
 
-#: src/amule.cpp:355
+#: src/amule.cpp:356
 msgid "aMule OnExit: Terminating core."
 msgstr "aMule Ao Sairen(OnExit): Apagando o núcleo."
 
-#: src/amule.cpp:466
+#: src/amule.cpp:467
 msgid "aMule shutdown completed."
 msgstr "Apagado completado."
 
-#: src/amule.cpp:470
+#: src/amule.cpp:471
 msgid "Memory debug results for aMule exit:"
 msgstr "Resultados da depuración da memoria ao sair de aMule:"
 
-#: src/amule.cpp:651
+#: src/amule.cpp:652
 #, c-format
 msgid "Binding aMule's peer-to-peer traffic to interface: %s (HTTP updates use the default route)"
 msgstr ""
 
-#: src/amule.cpp:655
+#: src/amule.cpp:656
 #, c-format
 msgid "Binding all network traffic to interface: %s"
 msgstr ""
 
-#: src/amule.cpp:659
+#: src/amule.cpp:660
 #, c-format
 msgid "WARNING: configured network interface '%s' was not found - traffic is NOT bound to it and may leave via the default route. Check the interface name in Preferences."
 msgstr ""
 
-#: src/amule.cpp:665
+#: src/amule.cpp:666
 #, c-format
 msgid "WARNING: binding to network interface '%s' requires elevated privileges and was NOT applied - traffic may leave via the default route. Grant the capability (e.g. 'sudo setcap cap_net_raw+ep' on the aMule binary) or run with sufficient privileges."
 msgstr ""
 
-#: src/amule.cpp:673
+#: src/amule.cpp:674
 #, c-format
 msgid "WARNING: could not bind to network interface '%s' - traffic may leave via the default route."
 msgstr ""
 
-#: src/amule.cpp:732
+#: src/amule.cpp:733
 msgid "Your locale has been changed to System Default due to a configuration change. Sorry."
 msgstr "O idioma cambiouse ao predeterminado do sistema debido a un troco na configuración."
 
-#: src/amule.cpp:734 src/amule.cpp:1581 src/CatDialog.cpp:128
+#: src/amule.cpp:735 src/amule.cpp:1589 src/CatDialog.cpp:128
 #: src/CatDialog.cpp:136 src/CatDialog.cpp:149 src/ServerList.cpp:366
 #: src/ServerListCtrl.cpp:152
 msgid "Info"
 msgstr "Información"
 
-#: src/amule.cpp:741
+#: src/amule.cpp:742
 msgid ""
 "\n"
 "EC configuration"
@@ -308,20 +308,20 @@ msgstr ""
 "\n"
 "Configuración CE"
 
-#: src/amule.cpp:744
+#: src/amule.cpp:745
 msgid "Password set and external connections enabled."
 msgstr "Establecido o contrasinal e habilitadas conexións externas."
 
-#: src/amule.cpp:754 src/KadDlg.cpp:176 src/KadDlg.cpp:185
-#: src/PrefsUnifiedDlg.cpp:1387 src/SharedFilesCtrl.cpp:476
+#: src/amule.cpp:755 src/KadDlg.cpp:176 src/KadDlg.cpp:185
+#: src/PrefsUnifiedDlg.cpp:1461 src/SharedFilesCtrl.cpp:476
 msgid "WARNING"
 msgstr "AVISO"
 
-#: src/amule.cpp:991
+#: src/amule.cpp:992
 msgid "Network bootstrap"
 msgstr "Arranque da rede"
 
-#: src/amule.cpp:996
+#: src/amule.cpp:997
 msgid ""
 "aMule has detected missing network bootstrap files.\n"
 "Select which ones to download:"
@@ -329,53 +329,53 @@ msgstr ""
 "aMule detectou que faltan ficheiros necesarios para arrancar a rede.\n"
 "Escolla os que queira descargar:"
 
-#: src/amule.cpp:1005 src/FirstRunWizard.cpp:411
+#: src/amule.cpp:1006 src/FirstRunWizard.cpp:411
 msgid "eD2k server list (server.met)"
 msgstr "Lista de servidores eD2k (server.met)"
 
-#: src/amule.cpp:1012 src/FirstRunWizard.cpp:416
+#: src/amule.cpp:1013 src/FirstRunWizard.cpp:416
 msgid "Kad bootstrap nodes (nodes.dat)"
 msgstr "Nodos de inicio de Kad (nodes.dat)"
 
-#: src/amule.cpp:1102
+#: src/amule.cpp:1103
 #, c-format
 msgid "web server running on pid %d"
 msgstr "servidor web executándose co pid %d"
 
-#: src/amule.cpp:1115
+#: src/amule.cpp:1116
 #, fuzzy
 msgid "You requested to run web server on startup, but the amuleweb binary cannot be run. Please install the package containing aMule web server, or build aMule from source with -DBUILD_WEBSERVER=YES and install it."
 msgstr "Solicitou executar o servidor web ó inicio pero non se puido executar o programa amuleweb. Instale o paquete que conteña o servidor web do aMule ou compile o aMule empregando o parámetro --enable-webserver e logo execute make install"
 
-#: src/amule.cpp:1120 src/amule.cpp:1177 src/amule.cpp:1291 src/amule.cpp:1593
+#: src/amule.cpp:1121 src/amule.cpp:1185 src/amule.cpp:1299 src/amule.cpp:1601
 #: src/amule-remote-gui.cpp:603 src/amule-remote-gui.cpp:671
 #: src/amule-remote-gui.cpp:709 src/amule-remote-gui.cpp:1282
 #: src/amule-remote-gui.cpp:1345 src/amule-remote-gui.cpp:1372
-#: src/DownloadQueue.cpp:1481
+#: src/DownloadQueue.cpp:1481 src/PrefsUnifiedDlg.cpp:1247
 msgid "ERROR"
 msgstr "ERRO"
 
-#: src/amule.cpp:1166
+#: src/amule.cpp:1174
 #, fuzzy, c-format
 msgid "amuleapi running on pid %d"
 msgstr "servidor web executándose co pid %d"
 
-#: src/amule.cpp:1172
+#: src/amule.cpp:1180
 #, fuzzy
 msgid "You requested to run amuleapi on startup, but the amuleapi binary cannot be run. Please install the package containing aMule's REST API server, or build aMule from source with -DBUILD_AMULEAPI=YES and install it."
 msgstr "Solicitou executar o servidor web ó inicio pero non se puido executar o programa amuleweb. Instale o paquete que conteña o servidor web do aMule ou compile o aMule empregando o parámetro --enable-webserver e logo execute make install"
 
-#: src/amule.cpp:1259
+#: src/amule.cpp:1267
 #, c-format
 msgid "Could not bind ports to the specified address: %s"
 msgstr "No se puideron vincular os portos á dirección especificada: %s"
 
-#: src/amule.cpp:1283
+#: src/amule.cpp:1291
 #, c-format
 msgid "Port %u is not available. You will be LOWID\n"
 msgstr "O porto %u non está dispoñible . Terá IDBAIXA\n"
 
-#: src/amule.cpp:1288
+#: src/amule.cpp:1296
 #, c-format
 msgid ""
 "Port %u is not available!\n"
@@ -390,48 +390,48 @@ msgstr ""
 "\n"
 "Comprobe a súa rede para asegurarse de que o porto está aberto para a entrada e saída."
 
-#: src/amule.cpp:1385
+#: src/amule.cpp:1393
 msgid "Failed to create OnlineSig File"
 msgstr "Non se puido crear o ficheiro OnlineSig"
 
-#: src/amule.cpp:1393
+#: src/amule.cpp:1401
 msgid "Failed to create aMule OnlineSig File"
 msgstr "Non se puido crear o ficheiro OnlineSig de aMule"
 
-#: src/amule.cpp:1556
+#: src/amule.cpp:1564
 msgid "The selected locale seems not to be installed on your box. (Note: I'll try to set it anyway)"
 msgstr "O idioma seleccionado semella non estar instalado. (Nota: Intentarase usalo a pesar diso)"
 
-#: src/amule.cpp:1566
+#: src/amule.cpp:1574
 #, c-format
 msgid "This is the first time you run aMule %s"
 msgstr "Esta é a primeira vez que iniciou aMule %s"
 
-#: src/amule.cpp:1569
+#: src/amule.cpp:1577
 msgid "This version is a testing version, updated daily, and\n"
 msgstr "Esta versión é unha versión en proba, actualizada diariamente, e\n"
 
-#: src/amule.cpp:1570
+#: src/amule.cpp:1578
 msgid "we give no warranty it won't break anything, burn your house,\n"
 msgstr "non lle aseguramos que non se rompa algo, lle prenda lume a súa casa,\n"
 
-#: src/amule.cpp:1571
+#: src/amule.cpp:1579
 msgid "or kill your dog. But it *should* be safe to use anyway.\n"
 msgstr "ou mate ao seu can. Pero non debería pasar nada.\n"
 
-#: src/amule.cpp:1576
+#: src/amule.cpp:1584
 msgid "More information, support and new releases can found at our homepage,\n"
 msgstr "Pode atopar máis información, axuda e novas actualizacións na nosa páxina,\n"
 
-#: src/amule.cpp:1577
+#: src/amule.cpp:1585
 msgid "at https://amule-org.github.io, or in our IRC channel #aMule at irc.libera.chat.\n"
 msgstr "en https://amule-org.github.io, ou na nosa canle IRC #aMule en irc.libera.chat.\n"
 
-#: src/amule.cpp:1579
+#: src/amule.cpp:1587
 msgid "Feel free to report any bugs to https://github.com/amule-org/amule/issues"
 msgstr "Pode avisar de calquera problema en https://github.com/amule-org/amule/issues"
 
-#: src/amule.cpp:1591
+#: src/amule.cpp:1599
 msgid ""
 "The folder for Online Signature files you specified is INVALID!\n"
 " OnlineSignature will be DISABLED until you fix it on preferences."
@@ -439,137 +439,137 @@ msgstr ""
 "O cartafol que especificou para as Sinaturas En Liña non é válido!\n"
 "A Sinatura En Liña permanecerá desactivada ata que se arranxe a configuración."
 
-#: src/amule.cpp:1654
+#: src/amule.cpp:1662
 msgid "Server hostname notified"
 msgstr "Nome do servidor avisado"
 
-#: src/amule.cpp:2031
+#: src/amule.cpp:2039
 #, c-format
 msgid "Disk space preallocation for file '%s' failed: %s"
 msgstr "Fallou a reserva do espazo no disco duro para o ficheiro «%s»: %s"
 
-#: src/amule.cpp:2160
+#: src/amule.cpp:2168
 msgid "ERROR: can't open logfile"
 msgstr "ERRO: non se pode abrir o ficheiro do rexistro"
 
-#: src/amule.cpp:2164
+#: src/amule.cpp:2172
 msgid "WARNING: logfile is empty. Something is wrong."
 msgstr "AVISO: o ficheiro de rexistro está baleiro. Algo está mal."
 
-#: src/amule.cpp:2181
+#: src/amule.cpp:2189
 msgid "Log has been reset"
 msgstr "O rexistro foi borrado"
 
-#: src/amule.cpp:2205
+#: src/amule.cpp:2213
 #, c-format
 msgid "ServerMessage: %s"
 msgstr "Mensaxe do servidor: %s"
 
-#: src/amule.cpp:2248 src/IP2Country.cpp:220 src/IPFilter.cpp:514
+#: src/amule.cpp:2256 src/IP2Country.cpp:220 src/IPFilter.cpp:514
 #: src/ServerList.cpp:875
 #, c-format
 msgid "Skipped download of %s, because requested file is not newer."
 msgstr "Saltouse a descarga de %s, por que o ficheiro pedido é máis antigo."
 
-#: src/amule.cpp:2251
+#: src/amule.cpp:2259
 msgid "Failed to download the nodes list."
 msgstr "Non se puido descargar a lista de nodos."
 
-#: src/amule.cpp:2314
+#: src/amule.cpp:2322
 msgid "Failed to open the downloaded version check file"
 msgstr "Non se puido abrir o ficheiro de comprobación da versión descargado"
 
-#: src/amule.cpp:2317 src/amule.cpp:2336
+#: src/amule.cpp:2325 src/amule.cpp:2344
 msgid "Corrupted version check file"
 msgstr "Ficheiro de comprobación da versión corrupto"
 
-#: src/amule.cpp:2359
+#: src/amule.cpp:2367
 msgid "You are using an outdated version of aMule!"
 msgstr "Está usando unha versión de aMule desactualizada!"
 
-#: src/amule.cpp:2361
+#: src/amule.cpp:2369
 #, c-format
 msgid "Your aMule version is %i.%i.%i and the latest version is %li.%li.%li"
 msgstr "A súa versión de aMule é %i.%i.%i e a última versión é %li.%li.%li"
 
-#: src/amule.cpp:2365
+#: src/amule.cpp:2373
 msgid "The latest version can always be found at https://github.com/amule-org/amule/releases/latest"
 msgstr "Pode obter a última versión de aMule en https://github.com/amule-org/amule/releases/latest"
 
-#: src/amule.cpp:2368
+#: src/amule.cpp:2376
 #, c-format
 msgid "WARNING: Your aMuled version is outdated: %i.%i.%i < %li.%li.%li"
 msgstr "AVISO: A súa versión de aMule está desactualizada: %i.%i.%i < %li.%li.%li"
 
-#: src/amule.cpp:2374
+#: src/amule.cpp:2382
 msgid "Your copy of aMule is up to date."
 msgstr "A súa copia de aMule está actualizada."
 
-#: src/amule.cpp:2381
+#: src/amule.cpp:2389
 msgid "Failed to download the version check file"
 msgstr "Non se puido descargar o ficheiro de comprobación de versión"
 
-#: src/amule.cpp:2550 src/amule-remote-gui.cpp:1133
+#: src/amule.cpp:2558 src/amule-remote-gui.cpp:1133
 #, c-format
 msgid "Users: %s | Files: %s"
 msgstr "Usuarios: %s | Ficheiros: %s"
 
-#: src/amule.cpp:2551 src/amule-remote-gui.cpp:1134
+#: src/amule.cpp:2559 src/amule-remote-gui.cpp:1134
 #, c-format
 msgid "Users: E: %s K: %s | Files: E: %s K: %s"
 msgstr "Usuarios: E: %s K: %s | Ficheiros: E: %s K: %s"
 
-#: src/amule.cpp:2565 src/amule-remote-gui.cpp:1147
+#: src/amule.cpp:2573 src/amule-remote-gui.cpp:1147
 msgid "No networks selected"
 msgstr "Sen redes seleccionadas"
 
-#: src/amule.cpp:2633 src/TextClient.cpp:903
+#: src/amule.cpp:2641 src/TextClient.cpp:903
 msgid "with LowID"
 msgstr "con IDBaixa"
 
-#: src/amule.cpp:2633 src/TextClient.cpp:904
+#: src/amule.cpp:2641 src/TextClient.cpp:904
 msgid "with HighID"
 msgstr "con IDAlta"
 
-#: src/amule.cpp:2635
+#: src/amule.cpp:2643
 #, c-format
 msgid "Connected to %s %s"
 msgstr "Conectado a %s %s"
 
-#: src/amule.cpp:2640
+#: src/amule.cpp:2648
 #, c-format
 msgid "Connecting to %s"
 msgstr "Conectando a %s"
 
-#: src/amule.cpp:2642
+#: src/amule.cpp:2650
 msgid "Disconnected from eD2k"
 msgstr "Desconectouse do eD2k"
 
-#: src/amule.cpp:2651
+#: src/amule.cpp:2659
 msgid "Kad started."
 msgstr "Iniciado Kad."
 
-#: src/amule.cpp:2653
+#: src/amule.cpp:2661
 msgid "Kad stopped."
 msgstr "Parado Kad."
 
-#: src/amule.cpp:2661
+#: src/amule.cpp:2669
 msgid "Connected to Kad (ok)"
 msgstr "Conectado a Kad (ok)"
 
-#: src/amule.cpp:2663
+#: src/amule.cpp:2671
 msgid "Connected to Kad (firewalled)"
 msgstr "Conectado a Kad (devasa)"
 
-#: src/amule.cpp:2667
+#: src/amule.cpp:2675
 msgid "Disconnected from Kad"
 msgstr "Desconectado de Kad"
 
-#: src/amule.cpp:2699
+#: src/amule.cpp:2707
 msgid "Kad network cannot be used if UDP port is disabled on preferences, not starting."
 msgstr "Non se pode usar a rede Kad se o porto UDP está desactivado nas preferencias. Non se iniciou."
 
-#: src/amule.cpp:2703
+#: src/amule.cpp:2711
 msgid "Kad network disabled on preferences, not connecting."
 msgstr "A rede Kad está desactivada nas preferencias. Non se iniciou."
 
@@ -613,36 +613,36 @@ msgid "FATAL ERROR: Failed to create Timer"
 msgstr "ERRO GRAVE: Non se puido crear o temporizador"
 
 #: src/amuleDlg.cpp:361 src/amuleDlg.cpp:1787 src/amuleDlg.cpp:2033
-#: src/muuli_wdr.cpp:1492 src/muuli_wdr.cpp:3418
+#: src/muuli_wdr.cpp:1492 src/muuli_wdr.cpp:3449
 msgid "Networks"
 msgstr "Redes"
 
-#: src/amuleDlg.cpp:362 src/amuleDlg.cpp:1793 src/muuli_wdr.cpp:3419
+#: src/amuleDlg.cpp:362 src/amuleDlg.cpp:1793 src/muuli_wdr.cpp:3450
 msgid "Searches"
 msgstr "Buscas"
 
 #: src/amuleDlg.cpp:363 src/amuleDlg.cpp:1799 src/DownloadListCtrl.cpp:740
-#: src/muuli_wdr.cpp:392 src/muuli_wdr.cpp:1585 src/muuli_wdr.cpp:3420
+#: src/muuli_wdr.cpp:392 src/muuli_wdr.cpp:1585 src/muuli_wdr.cpp:3451
 #: src/Statistics.cpp:829
 msgid "Downloads"
 msgstr "Descargas"
 
-#: src/amuleDlg.cpp:364 src/amuleDlg.cpp:1805 src/muuli_wdr.cpp:3294
+#: src/amuleDlg.cpp:364 src/amuleDlg.cpp:1805 src/muuli_wdr.cpp:3325
 msgid "Shared files"
 msgstr "Ficheiros compartidos"
 
-#: src/amuleDlg.cpp:365 src/amuleDlg.cpp:1811 src/muuli_wdr.cpp:2926
-#: src/muuli_wdr.cpp:3376 src/muuli_wdr.cpp:3423
+#: src/amuleDlg.cpp:365 src/amuleDlg.cpp:1811 src/muuli_wdr.cpp:2957
+#: src/muuli_wdr.cpp:3407 src/muuli_wdr.cpp:3454
 msgid "Messages"
 msgstr "Mensaxes"
 
-#: src/amuleDlg.cpp:366 src/amuleDlg.cpp:1817 src/muuli_wdr.cpp:3424
-#: src/PrefsUnifiedDlg.cpp:312 src/Statistics.cpp:779 src/Statistics.cpp:1235
+#: src/amuleDlg.cpp:366 src/amuleDlg.cpp:1817 src/muuli_wdr.cpp:3455
+#: src/PrefsUnifiedDlg.cpp:314 src/Statistics.cpp:779 src/Statistics.cpp:1235
 msgid "Statistics"
 msgstr "Estadísticas"
 
-#: src/amuleDlg.cpp:368 src/amuleDlg.cpp:1824 src/muuli_wdr.cpp:3426
-#: src/PrefsUnifiedDlg.cpp:328 src/utils/wxCas/src/wxcasprefs.cpp:39
+#: src/amuleDlg.cpp:368 src/amuleDlg.cpp:1824 src/muuli_wdr.cpp:3457
+#: src/PrefsUnifiedDlg.cpp:330 src/utils/wxCas/src/wxcasprefs.cpp:39
 msgid "Preferences"
 msgstr "Preferencias"
 
@@ -700,8 +700,8 @@ msgstr "Kad: Apagado"
 #: src/amuleDlg.cpp:1029 src/DownloadListCtrl.cpp:505
 #: src/DownloadListCtrl.cpp:749 src/FriendListCtrl.cpp:180
 #: src/muuli_wdr.cpp:731 src/muuli_wdr.cpp:782 src/muuli_wdr.cpp:846
-#: src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2231 src/muuli_wdr.cpp:2316
-#: src/muuli_wdr.cpp:3064 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
+#: src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2262 src/muuli_wdr.cpp:2347
+#: src/muuli_wdr.cpp:3095 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
 #: src/ServerListCtrl.cpp:606 src/TransferWnd.cpp:378
 #: src/utils/wxCas/src/wxcasprefs.cpp:235
 msgid "Cancel"
@@ -712,7 +712,7 @@ msgid "Stop the current connection attempts"
 msgstr "Deter a tentativa actual de conexión"
 
 #: src/amuleDlg.cpp:1035 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976
-#: src/muuli_wdr.cpp:2454
+#: src/muuli_wdr.cpp:2485
 msgid "Disconnect"
 msgstr "Desconectar"
 
@@ -721,7 +721,7 @@ msgid "Disconnect from the currently connected networks"
 msgstr "Desconectar das redes conectadas"
 
 #: src/amuleDlg.cpp:1041 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979
-#: src/muuli_wdr.cpp:2609 src/muuli_wdr.cpp:3061 src/muuli_wdr.cpp:3416
+#: src/muuli_wdr.cpp:2640 src/muuli_wdr.cpp:3092 src/muuli_wdr.cpp:3447
 msgid "Connect"
 msgstr "Conectar"
 
@@ -775,7 +775,7 @@ msgstr "Confirmación da saída"
 msgid "Launch Command: "
 msgstr "Ordes de Arranque: "
 
-#: src/amuleDlg.cpp:1632 src/muuli_wdr.cpp:1978 src/Preferences.cpp:952
+#: src/amuleDlg.cpp:1632 src/muuli_wdr.cpp:1982 src/Preferences.cpp:979
 msgid "- default -"
 msgstr "- por omisión -"
 
@@ -789,48 +789,48 @@ msgstr "Non existe o directorio de temas «%s»"
 msgid "WARNING: Unable to open skin file '%s' for read"
 msgstr "AVISO: Non se puido abrir o ficheiro de temas «%s» en modo lectura"
 
-#: src/amuleDlg.cpp:1791 src/muuli_wdr.cpp:3418
+#: src/amuleDlg.cpp:1791 src/muuli_wdr.cpp:3449
 msgid "Networks Window"
 msgstr "Xanela de Redes"
 
-#: src/amuleDlg.cpp:1797 src/muuli_wdr.cpp:3419
+#: src/amuleDlg.cpp:1797 src/muuli_wdr.cpp:3450
 msgid "Searches Window"
 msgstr "Xanela de buscas"
 
-#: src/amuleDlg.cpp:1803 src/muuli_wdr.cpp:3420
+#: src/amuleDlg.cpp:1803 src/muuli_wdr.cpp:3451
 msgid "Downloads Window"
 msgstr "Xanela de descargas"
 
-#: src/amuleDlg.cpp:1809 src/muuli_wdr.cpp:3422
+#: src/amuleDlg.cpp:1809 src/muuli_wdr.cpp:3453
 msgid "Shared Files Window"
 msgstr "Xanela de ficheiros compartidos"
 
-#: src/amuleDlg.cpp:1815 src/muuli_wdr.cpp:3423
+#: src/amuleDlg.cpp:1815 src/muuli_wdr.cpp:3454
 msgid "Messages Window"
 msgstr "Xanela de mensaxes"
 
-#: src/amuleDlg.cpp:1821 src/muuli_wdr.cpp:3424
+#: src/amuleDlg.cpp:1821 src/muuli_wdr.cpp:3455
 msgid "Statistics Graph Window"
 msgstr "Xanela de gráficos de estadísticas"
 
-#: src/amuleDlg.cpp:1828 src/muuli_wdr.cpp:3426
+#: src/amuleDlg.cpp:1828 src/muuli_wdr.cpp:3457
 msgid "Preferences Settings Window"
 msgstr "Xanela de Preferencias"
 
-#: src/amuleDlg.cpp:1831 src/muuli_wdr.cpp:3427
+#: src/amuleDlg.cpp:1831 src/muuli_wdr.cpp:3458
 msgid "Import"
 msgstr "Importar"
 
-#: src/amuleDlg.cpp:1835 src/muuli_wdr.cpp:3427
+#: src/amuleDlg.cpp:1835 src/muuli_wdr.cpp:3458
 msgid "The partfile importer tool"
 msgstr "A ferramenta para importar ficheiros «part»"
 
-#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3428
+#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3459
 #: src/utils/aLinkCreator/src/alcframe.cpp:262
 msgid "About"
 msgstr "Sobre"
 
-#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3428
+#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3459
 msgid "About/Help"
 msgstr "Sobre/Axuda"
 
@@ -974,7 +974,7 @@ msgstr "Ficheiro non atopado."
 msgid "The core rejected these shared folders:%s"
 msgstr ""
 
-#: src/amule-remote-gui.cpp:1336 src/ExternalConn.cpp:2345
+#: src/amule-remote-gui.cpp:1336 src/ExternalConn.cpp:2346
 msgid "Invalid link or already on list."
 msgstr "Ligazón inválida ou xa presente na lista."
 
@@ -990,7 +990,7 @@ msgstr "Non se puido crear o directorio «%s» para a categoría «%s», mantend
 #: src/ClientDetailDialog.cpp:123 src/DataToText.cpp:61 src/DataToText.cpp:86
 #: src/DataToText.cpp:101 src/DataToText.cpp:136 src/DataToText.cpp:165
 #: src/DownloadListCtrl.cpp:1172 src/DownloadListCtrl.cpp:1185
-#: src/DownloadListCtrl.cpp:1196 src/ExternalConn.cpp:608
+#: src/DownloadListCtrl.cpp:1196 src/ExternalConn.cpp:609
 #: src/FileDetailDialog.cpp:203 src/FileDetailDialog.cpp:235
 #: src/FileDetailDialog.cpp:242 src/GenericClientListCtrl.cpp:1171
 #: src/GenericClientListCtrl.cpp:1182 src/GenericClientListCtrl.cpp:1192
@@ -1377,19 +1377,19 @@ msgstr "Auto [Al]"
 msgid "Very low"
 msgstr "Moi baixa"
 
-#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:743 src/muuli_wdr.cpp:2282
+#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:743 src/muuli_wdr.cpp:2313
 #: src/ServerListCtrl.cpp:263 src/ServerListCtrl.cpp:456
 #: src/SharedFilesCtrl.cpp:145
 msgid "Low"
 msgstr "Baixa"
 
-#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:744 src/muuli_wdr.cpp:2283
+#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:744 src/muuli_wdr.cpp:2314
 #: src/ServerListCtrl.cpp:266 src/ServerListCtrl.cpp:457
 #: src/SharedFilesCtrl.cpp:146
 msgid "Normal"
 msgstr "Normal"
 
-#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:745 src/muuli_wdr.cpp:2284
+#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:745 src/muuli_wdr.cpp:2315
 #: src/ServerListCtrl.cpp:269 src/ServerListCtrl.cpp:458
 #: src/SharedFilesCtrl.cpp:147
 msgid "High"
@@ -1481,7 +1481,7 @@ msgstr "Servidor local"
 msgid "Remote Server"
 msgstr "Servidor remoto"
 
-#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3181
+#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3212
 #: src/SearchDlg.cpp:119 src/TextClient.cpp:911
 msgid "Kad"
 msgstr "Kad"
@@ -1552,7 +1552,7 @@ msgstr "Parte"
 msgid "Size"
 msgstr "Tamaño"
 
-#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3248
+#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3279
 msgid "Transferred"
 msgstr "Transferido"
 
@@ -1610,7 +1610,7 @@ msgstr ""
 "Comentarios de : %s (%s)\n"
 "\n"
 
-#: src/DownloadListCtrl.cpp:746 src/muuli_wdr.cpp:2285
+#: src/DownloadListCtrl.cpp:746 src/muuli_wdr.cpp:2316
 #: src/SharedFilesCtrl.cpp:150
 msgid "Auto"
 msgstr "Automático"
@@ -1648,7 +1648,7 @@ msgid "Extended Options"
 msgstr "Opcións extendidas"
 
 #: src/DownloadListCtrl.cpp:770 src/DownloadListCtrl.cpp:822
-#: src/muuli_wdr.cpp:1796
+#: src/muuli_wdr.cpp:1800
 msgid "Preview"
 msgstr "Previsualizar"
 
@@ -1823,225 +1823,230 @@ msgstr[1] "Non se puideron engadir as ligazóns %u (consulte o rexistro)."
 msgid "Invalid eD2k link! ERROR: %s"
 msgstr "Ligazón eD2k inválida! ERRO: %s"
 
-#: src/ExternalConn.cpp:379
+#: src/ExternalConn.cpp:380
 msgid "Client sent packet after authentication failed."
 msgstr "O cliente enviou un paquete despois de que fallara a identificación."
 
-#: src/ExternalConn.cpp:396
+#: src/ExternalConn.cpp:397
 msgid "External connection closed."
 msgstr "Conexión externa pechada."
 
-#: src/ExternalConn.cpp:473
+#: src/ExternalConn.cpp:474
 msgid "External connections disabled due to empty password!"
 msgstr "Conexións externas desactivadas por mor dun contrasinal baleiro!"
 
-#: src/ExternalConn.cpp:494
+#: src/ExternalConn.cpp:495
 msgid "External connections disabled in config file"
 msgstr "Conexións externas desactivadas no ficheiro de configuración"
 
-#: src/ExternalConn.cpp:575
+#: src/ExternalConn.cpp:576
 msgid "New external connection accepted"
 msgstr "Nova conexión externa aceptada"
 
-#: src/ExternalConn.cpp:578
+#: src/ExternalConn.cpp:579
 msgid "ERROR: couldn't accept a new external connection"
 msgstr "ERRO: non se puido aceptar unha nova conexión externa"
 
-#: src/ExternalConn.cpp:595
+#: src/ExternalConn.cpp:596
 msgid "External connection refused due to empty password in preferences!"
 msgstr "Conexións externas desactivadas por mor dun contrasinal baleiro nas preferencias!"
 
-#: src/ExternalConn.cpp:607
+#: src/ExternalConn.cpp:608
 #, c-format
 msgid "Connecting client: %s %s"
 msgstr "Conectando ao cliente: %s %s"
 
-#: src/ExternalConn.cpp:609
+#: src/ExternalConn.cpp:610
 msgid "Unknown version"
 msgstr "Versión descoñecida"
 
-#: src/ExternalConn.cpp:622
+#: src/ExternalConn.cpp:623
 msgid "Incorrect EC version ID, there might be binary incompatibility. Use core and remote from same snapshot."
 msgstr "CE incorrecto na ID de versión, os programas non son compatibles. Use a mesma versión para o núcleo e para o remoto."
 
-#: src/ExternalConn.cpp:630
+#: src/ExternalConn.cpp:631
 msgid "You cannot connect to a release version from an arbitrary development snapshot! *sigh* possible crash prevented"
 msgstr "Non se pode conectar a una versión estable dende una versión de desenvolvemento calquera! Evitada posible fallo do programa"
 
-#: src/ExternalConn.cpp:713
+#: src/ExternalConn.cpp:714
 msgid "Invalid protocol version."
 msgstr "Versión do protocolo inválida."
 
-#: src/ExternalConn.cpp:719
+#: src/ExternalConn.cpp:720
 msgid "Missing protocol version tag."
 msgstr "Marcador da versión do protocolo inexistente."
 
-#: src/ExternalConn.cpp:727
+#: src/ExternalConn.cpp:728
 msgid "Authentication failed: invalid hash specified as EC password."
 msgstr "Fallou a identificación: o resumo criptográfico (hash) usado coma contrasinal CE é inválido."
 
-#: src/ExternalConn.cpp:775
+#: src/ExternalConn.cpp:776
 msgid "Authentication failed: wrong password."
 msgstr "Fallou a identificación: contrasinal erróneo."
 
-#: src/ExternalConn.cpp:777
+#: src/ExternalConn.cpp:778
 msgid "Authentication failed: missing password."
 msgstr "Fallou a identificación: falta o contrasinal."
 
-#: src/ExternalConn.cpp:788
+#: src/ExternalConn.cpp:789
 msgid "Invalid request, please authenticate first."
 msgstr "Petición inválida, primeiro identifíquese."
 
-#: src/ExternalConn.cpp:793
+#: src/ExternalConn.cpp:794
 msgid "Access granted."
 msgstr "Acceso concedido."
 
-#: src/ExternalConn.cpp:801
+#: src/ExternalConn.cpp:802
 #, c-format
 msgid "Sent error message \"%s\" to client."
 msgstr "Enviando mensaxe «%s» ao cliente."
 
-#: src/ExternalConn.cpp:806
+#: src/ExternalConn.cpp:807
 #, c-format
 msgid "Unauthorized access attempt from %s. Connection closed."
 msgstr "Intento de acceso non autorizado dende %s. Conexión pechada."
 
-#: src/ExternalConn.cpp:1419
+#: src/ExternalConn.cpp:1420
 #, c-format
 msgid "Remote PartFile command failed: FileHash not found: %s"
 msgstr "Fallou a orde PartFile remota: FileHash non atopado: %s"
 
-#: src/ExternalConn.cpp:1423
+#: src/ExternalConn.cpp:1424
 #, c-format
 msgid "FileHash not found: %s"
 msgstr "FileHash non atopado: %s"
 
-#: src/ExternalConn.cpp:1470 src/ExternalConn.cpp:1558
-#: src/ExternalConn.cpp:1679
+#: src/ExternalConn.cpp:1471 src/ExternalConn.cpp:1559
+#: src/ExternalConn.cpp:1680
 msgid "OOPS! OpCode processing error!"
 msgstr "OOPS! Erro ao procesar o OpCode!"
 
-#: src/ExternalConn.cpp:1501
+#: src/ExternalConn.cpp:1502
 msgid "Server not added"
 msgstr "Servidor non engadido"
 
-#: src/ExternalConn.cpp:1520
+#: src/ExternalConn.cpp:1521
 #, c-format
 msgid "server not found: %s"
 msgstr "servidor non atopado: %s"
 
-#: src/ExternalConn.cpp:1537
+#: src/ExternalConn.cpp:1538
 msgid "need to define server to be removed"
 msgstr "necesita definir o servidor que quere eliminar"
 
-#: src/ExternalConn.cpp:1552
+#: src/ExternalConn.cpp:1553
 msgid "eD2k is disabled in preferences."
 msgstr "eD2k está desactivado nas preferencias."
 
-#: src/ExternalConn.cpp:1657
+#: src/ExternalConn.cpp:1658
 msgid "Friend not found."
 msgstr "Non se atopou o amigo."
 
-#: src/ExternalConn.cpp:1667
+#: src/ExternalConn.cpp:1668
 msgid "Client not found."
 msgstr "Non se atopou o ficheiro."
 
-#: src/ExternalConn.cpp:1673
+#: src/ExternalConn.cpp:1674
 msgid "EC_TAG_FRIEND_SHARED requires EC_TAG_FRIEND or EC_TAG_CLIENT."
 msgstr "EC_TAG_FRIEND_SHARED precisa de EC_TAG_FRIEND ou EC_TAG_CLIENT."
 
-#: src/ExternalConn.cpp:1991
+#: src/ExternalConn.cpp:1992
 msgid "WebSearch from remote interface makes no sense."
 msgstr "Non ten sentido usar WebSearch dende unha interface remota."
 
-#: src/ExternalConn.cpp:2026
+#: src/ExternalConn.cpp:2027
 msgid "Search in progress. Refetch results in a moment!"
 msgstr "Busca en progreso. Obterá os resultado nun intre!"
 
-#: src/ExternalConn.cpp:2265
+#: src/ExternalConn.cpp:2266
 msgid "No points for graph."
 msgstr "Sen puntos para a gráfica."
 
-#: src/ExternalConn.cpp:2275
+#: src/ExternalConn.cpp:2276
 msgid "Your client is not configured for this detail level."
 msgstr "O seu cliente non está configurado para este nivel de detalle."
 
-#: src/ExternalConn.cpp:2302
+#: src/ExternalConn.cpp:2303
 msgid "External Connection: shutdown requested"
 msgstr "Conexión externa: apagado solicitado"
 
-#: src/ExternalConn.cpp:2314
+#: src/ExternalConn.cpp:2315
 msgid "Already shutting down."
 msgstr "Xa se está apagando."
 
-#: src/ExternalConn.cpp:2332
+#: src/ExternalConn.cpp:2333
 #, c-format
 msgid "ExternalConn: adding link '%s'."
 msgstr "Conexión externa: engadinda ligazón «%s»."
 
-#: src/ExternalConn.cpp:2350
+#: src/ExternalConn.cpp:2351
 #, c-format
 msgid "%d of %d links failed (invalid or already on list)."
 msgstr "Fallaron %d de %d ligazóns (por non valer ou xa estar na lista)."
 
-#: src/ExternalConn.cpp:2373
+#: src/ExternalConn.cpp:2374
 msgid "Version check throttled; try again shortly."
 msgstr ""
 
-#: src/ExternalConn.cpp:2378
+#: src/ExternalConn.cpp:2379
 msgid "Version check is not available on this daemon."
 msgstr ""
 
-#: src/ExternalConn.cpp:2508
+#: src/ExternalConn.cpp:2509
 msgid "File not found."
 msgstr "Ficheiro non atopado."
 
-#: src/ExternalConn.cpp:2513
+#: src/ExternalConn.cpp:2514
 msgid "Invalid file name."
 msgstr "Nome de ficheiro inválido."
 
-#: src/ExternalConn.cpp:2521
+#: src/ExternalConn.cpp:2522
 msgid "Unable to rename file."
 msgstr "Imposible cambiarlle o nome ao ficheiro."
 
-#: src/ExternalConn.cpp:2992 src/ExternalConn.cpp:3020
+#: src/ExternalConn.cpp:2839
+#, c-format
+msgid "Could not save the amuleapi password: %s"
+msgstr ""
+
+#: src/ExternalConn.cpp:3004 src/ExternalConn.cpp:3032
 msgid "Kad is disabled in preferences."
 msgstr "Kad está desactivado nas preferencias."
 
-#: src/ExternalConn.cpp:3033
+#: src/ExternalConn.cpp:3045
 msgid "Already connected to eD2k."
 msgstr "Xa está conectado ao eD2k."
 
-#: src/ExternalConn.cpp:3036
+#: src/ExternalConn.cpp:3048
 msgid "Connecting to eD2k..."
 msgstr "Conectando ao eD2k..."
 
-#: src/ExternalConn.cpp:3045
+#: src/ExternalConn.cpp:3057
 msgid "Already connected to Kad."
 msgstr "Xa está conectado a Kad."
 
-#: src/ExternalConn.cpp:3048
+#: src/ExternalConn.cpp:3060
 msgid "Connecting to Kad..."
 msgstr "Conectando a Kad..."
 
-#: src/ExternalConn.cpp:3055
+#: src/ExternalConn.cpp:3067
 msgid "All networks are disabled."
 msgstr "Tódalas redes están desactivadas."
 
-#: src/ExternalConn.cpp:3064
+#: src/ExternalConn.cpp:3076
 msgid "Disconnected from eD2k."
 msgstr "Desconectado do eD2k."
 
-#: src/ExternalConn.cpp:3069
+#: src/ExternalConn.cpp:3081
 msgid "Disconnected from Kad."
 msgstr "Desconectado de Kad."
 
-#: src/ExternalConn.cpp:3078
+#: src/ExternalConn.cpp:3090
 #, c-format
 msgid "External Connection: invalid opcode received: %#x"
 msgstr "Conexión externa: recibido código de operación inválido: %#x"
 
-#: src/ExternalConn.cpp:3083
+#: src/ExternalConn.cpp:3095
 msgid "Invalid opcode (wrong protocol version?)"
 msgstr "Opcode inválido (versión do protocolo inválida?)"
 
@@ -2442,23 +2447,23 @@ msgid ""
 "want downloads on a different (e.g. larger) disk."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:549 src/FirstRunWizard.cpp:611 src/muuli_wdr.cpp:1708
+#: src/FirstRunWizard.cpp:549 src/FirstRunWizard.cpp:611 src/muuli_wdr.cpp:1712
 msgid "Destination folder for downloads"
 msgstr "Cartafol de destino para descargas"
 
 #: src/FirstRunWizard.cpp:553 src/FirstRunWizard.cpp:569 src/muuli_wdr.cpp:1349
-#: src/muuli_wdr.cpp:1366 src/muuli_wdr.cpp:1683 src/muuli_wdr.cpp:1714
-#: src/muuli_wdr.cpp:1726 src/muuli_wdr.cpp:2769
+#: src/muuli_wdr.cpp:1366 src/muuli_wdr.cpp:1687 src/muuli_wdr.cpp:1718
+#: src/muuli_wdr.cpp:1730 src/muuli_wdr.cpp:2800
 #: src/utils/aLinkCreator/src/alcframe.cpp:135
 #: src/utils/wxCas/src/wxcasprefs.cpp:52 src/utils/wxCas/src/wxcasprefs.cpp:118
 msgid "Browse"
 msgstr "Navegador"
 
-#: src/FirstRunWizard.cpp:559 src/muuli_wdr.cpp:1719
+#: src/FirstRunWizard.cpp:559 src/muuli_wdr.cpp:1723
 msgid "(All files in this folder are shared with other peers)"
 msgstr "(Compartiranse todos os ficheiros do cartafol co resto de parceiros)"
 
-#: src/FirstRunWizard.cpp:565 src/FirstRunWizard.cpp:624 src/muuli_wdr.cpp:1721
+#: src/FirstRunWizard.cpp:565 src/FirstRunWizard.cpp:624 src/muuli_wdr.cpp:1725
 msgid "Folder for temporary download files"
 msgstr "Cartafol para ficheiros de descarga temporais"
 
@@ -2489,7 +2494,7 @@ msgstr "Non se puido escribir a lista de amigos ao ficheiro «emfriends.met»!"
 msgid "CRITICAL - no client on StartChatSession"
 msgstr "CRÍTICO - non hai cliente en StartChatSession"
 
-#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2675 src/muuli_wdr.cpp:3352
+#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2706 src/muuli_wdr.cpp:3383
 msgid "Friends"
 msgstr "Amigos"
 
@@ -2599,8 +2604,8 @@ msgstr "Ningún"
 msgid "No"
 msgstr "Non"
 
-#: src/GenericClientListCtrl.cpp:1216 src/PrefsUnifiedDlg.cpp:2818
-#: src/PrefsUnifiedDlg.cpp:2868 src/ServerListCtrl.cpp:276
+#: src/GenericClientListCtrl.cpp:1216 src/PrefsUnifiedDlg.cpp:2898
+#: src/PrefsUnifiedDlg.cpp:2948 src/ServerListCtrl.cpp:276
 msgid "Yes"
 msgstr "Si"
 
@@ -2769,10 +2774,10 @@ msgstr "Porto inválido para o arranque"
 msgid "Please fill all fields required"
 msgstr "Enche todos os campos requiridos"
 
-#: src/KadDlg.cpp:192 src/PartFile.cpp:1031 src/PrefsUnifiedDlg.cpp:1162
-#: src/PrefsUnifiedDlg.cpp:1331 src/PrefsUnifiedDlg.cpp:1589
-#: src/PrefsUnifiedDlg.cpp:1599 src/PrefsUnifiedDlg.cpp:1616
-#: src/PrefsUnifiedDlg.cpp:1658
+#: src/KadDlg.cpp:192 src/PartFile.cpp:1031 src/PrefsUnifiedDlg.cpp:1134
+#: src/PrefsUnifiedDlg.cpp:1204 src/PrefsUnifiedDlg.cpp:1405
+#: src/PrefsUnifiedDlg.cpp:1663 src/PrefsUnifiedDlg.cpp:1673
+#: src/PrefsUnifiedDlg.cpp:1690 src/PrefsUnifiedDlg.cpp:1738
 msgid "Message"
 msgstr "Mensaxe"
 
@@ -2874,7 +2879,7 @@ msgstr "Relación enviado/descargado"
 msgid "Uploaded"
 msgstr "Enviado"
 
-#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3232
+#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3263
 msgid "Requested"
 msgstr "Solicitado"
 
@@ -2998,7 +3003,7 @@ msgid "WARNING: "
 msgstr "AVISO: "
 
 #: src/MuleNotebook.cpp:179 src/muuli_wdr.cpp:817 src/muuli_wdr.cpp:1229
-#: src/muuli_wdr.cpp:3136 src/muuli_wdr.cpp:3392
+#: src/muuli_wdr.cpp:3167 src/muuli_wdr.cpp:3423
 msgid "Close"
 msgstr "Pechar"
 
@@ -3016,7 +3021,7 @@ msgid "Paste"
 msgstr "Pegar"
 
 #: src/MuleTextCtrl.cpp:89 src/muuli_wdr.cpp:358 src/muuli_wdr.cpp:757
-#: src/muuli_wdr.cpp:2359 src/muuli_wdr.cpp:2378 src/muuli_wdr.cpp:2400
+#: src/muuli_wdr.cpp:2390 src/muuli_wdr.cpp:2409 src/muuli_wdr.cpp:2431
 #: src/utils/aLinkCreator/src/alcframe.cpp:142
 msgid "Clear"
 msgstr "Limpar"
@@ -3108,7 +3113,7 @@ msgstr "Saír"
 
 #: src/MuleTrayIcon.cpp:579 src/MuleTrayIcon.cpp:945 src/MuleTrayIcon.cpp:965
 #: src/muuli_wdr.cpp:1398 src/muuli_wdr.cpp:1406 src/muuli_wdr.cpp:1413
-#: src/muuli_wdr.cpp:1842 src/muuli_wdr.cpp:1848 src/OtherFunctions.cpp:91
+#: src/muuli_wdr.cpp:1846 src/muuli_wdr.cpp:1852 src/OtherFunctions.cpp:91
 #: src/StatisticsDlg.cpp:93 src/StatisticsDlg.cpp:95
 msgid "kB/s"
 msgstr "kB/s"
@@ -3350,7 +3355,7 @@ msgstr "Octetos"
 msgid "KB"
 msgstr "KB"
 
-#: src/muuli_wdr.cpp:274 src/muuli_wdr.cpp:293 src/muuli_wdr.cpp:1627
+#: src/muuli_wdr.cpp:274 src/muuli_wdr.cpp:293 src/muuli_wdr.cpp:1631
 #: src/OtherFunctions.cpp:64
 msgid "MB"
 msgstr "MB"
@@ -3367,7 +3372,7 @@ msgstr "Tamaño máximo"
 msgid "Availability"
 msgstr "Dispoñibilidade"
 
-#: src/muuli_wdr.cpp:312 src/muuli_wdr.cpp:398 src/muuli_wdr.cpp:3297
+#: src/muuli_wdr.cpp:312 src/muuli_wdr.cpp:398 src/muuli_wdr.cpp:3328
 msgid "Filter:"
 msgstr "Filtrado:"
 
@@ -3430,12 +3435,12 @@ msgstr "Fontes do ficheiro:"
 #: src/muuli_wdr.cpp:1160 src/muuli_wdr.cpp:1167 src/muuli_wdr.cpp:1172
 #: src/muuli_wdr.cpp:1179 src/muuli_wdr.cpp:1184 src/muuli_wdr.cpp:1191
 #: src/muuli_wdr.cpp:1205 src/muuli_wdr.cpp:1212 src/muuli_wdr.cpp:1217
-#: src/muuli_wdr.cpp:1224 src/muuli_wdr.cpp:3234 src/muuli_wdr.cpp:3242
-#: src/muuli_wdr.cpp:3250
+#: src/muuli_wdr.cpp:1224 src/muuli_wdr.cpp:3265 src/muuli_wdr.cpp:3273
+#: src/muuli_wdr.cpp:3281
 msgid "N/A"
 msgstr "N/A"
 
-#: src/muuli_wdr.cpp:508 src/muuli_wdr.cpp:1065 src/PrefsUnifiedDlg.cpp:297
+#: src/muuli_wdr.cpp:508 src/muuli_wdr.cpp:1065 src/PrefsUnifiedDlg.cpp:299
 msgid "General"
 msgstr "Xeral"
 
@@ -3576,7 +3581,7 @@ msgstr ""
 msgid "Album :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:685 src/muuli_wdr.cpp:2254
+#: src/muuli_wdr.cpp:685 src/muuli_wdr.cpp:2285
 msgid "Title :"
 msgstr "Título :"
 
@@ -3685,7 +3690,7 @@ msgstr "Nome de usuario :"
 msgid "Userhash :"
 msgstr "Hash do usuario :"
 
-#: src/muuli_wdr.cpp:895 src/muuli_wdr.cpp:1748 src/muuli_wdr.cpp:2449
+#: src/muuli_wdr.cpp:895 src/muuli_wdr.cpp:1752 src/muuli_wdr.cpp:2480
 #: src/utils/aLinkCreator/src/alcframe.cpp:137
 msgid "Add"
 msgstr "Engadir"
@@ -3694,15 +3699,15 @@ msgstr "Engadir"
 msgid "Download-Speed"
 msgstr "Velocidade de descarga"
 
-#: src/muuli_wdr.cpp:954 src/muuli_wdr.cpp:989 src/muuli_wdr.cpp:2553
+#: src/muuli_wdr.cpp:954 src/muuli_wdr.cpp:989 src/muuli_wdr.cpp:2584
 msgid "Current"
 msgstr "Actual"
 
-#: src/muuli_wdr.cpp:962 src/muuli_wdr.cpp:997 src/muuli_wdr.cpp:2561
+#: src/muuli_wdr.cpp:962 src/muuli_wdr.cpp:997 src/muuli_wdr.cpp:2592
 msgid "Running average"
 msgstr "Media de execución"
 
-#: src/muuli_wdr.cpp:970 src/muuli_wdr.cpp:1005 src/muuli_wdr.cpp:2569
+#: src/muuli_wdr.cpp:970 src/muuli_wdr.cpp:1005 src/muuli_wdr.cpp:2600
 msgid "Session average"
 msgstr "Media de sesión"
 
@@ -3714,7 +3719,7 @@ msgstr "Velocidade de envío"
 msgid "Connections"
 msgstr "Conexións"
 
-#: src/muuli_wdr.cpp:1024 src/muuli_wdr.cpp:1867
+#: src/muuli_wdr.cpp:1024 src/muuli_wdr.cpp:1871
 msgid "Active downloads"
 msgstr "Descargas activas"
 
@@ -3722,7 +3727,7 @@ msgstr "Descargas activas"
 msgid "Active connections (1:1)"
 msgstr "Conexións activas (1:1)"
 
-#: src/muuli_wdr.cpp:1040 src/muuli_wdr.cpp:1868
+#: src/muuli_wdr.cpp:1040 src/muuli_wdr.cpp:1872
 msgid "Active uploads"
 msgstr "Envíos activos"
 
@@ -3998,7 +4003,7 @@ msgstr "Ligar dirección local á IP (deixe baleiro para calquera):"
 msgid "Advanced users only: If you have multiple network interfaces, enter the address of the interface to which aMule should be bound."
 msgstr "Só usuarios experimentados: Se ten varias interfaces de rede, introduza a dirección da interface que quere que aMule use."
 
-#: src/muuli_wdr.cpp:1462 src/muuli_wdr.cpp:2061
+#: src/muuli_wdr.cpp:1462 src/muuli_wdr.cpp:2065
 #, fuzzy
 msgid "Bind to network interface (empty for any):"
 msgstr "Ligar dirección local á IP (deixe baleiro para calquera):"
@@ -4015,7 +4020,7 @@ msgstr "Límite de fontes por ficheiro descargado:"
 msgid "Max simultaneous connections:"
 msgstr "Conexións simultáneas máximas:"
 
-#: src/muuli_wdr.cpp:1498 src/muuli_wdr.cpp:3176
+#: src/muuli_wdr.cpp:1498 src/muuli_wdr.cpp:3207
 msgid "ED2K"
 msgstr "ED2K"
 
@@ -4107,79 +4112,79 @@ msgstr "Reservar espazo no disco para os novos ficheiros"
 msgid "For new files preallocates disk space for the whole file, thus reduces fragmentation"
 msgstr "Reserva o tamaño do ficheiro no disco para reducir a fragmentación"
 
-#: src/muuli_wdr.cpp:1613
+#: src/muuli_wdr.cpp:1617
 msgid "Create new files as sparse files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1614
-msgid "A sparse file reserves its full size on disk immediately without writing real data to it -- fast, but unsupported or slow on some filesystems, and free-space accounting stays optimistic while the download is in progress. Turn this off to grow the file only as data arrives."
+#: src/muuli_wdr.cpp:1618
+msgid "Sparse part files only occupy disk space for the parts already downloaded, so free space is used up gradually as the file fills in. Turn this off to use an ordinary file instead - useful where sparse files are unsupported or slow, or where backup/de-duplication tools handle them badly. Applies only when the core runs on Windows; on Linux and macOS part files are sparse anyway and this setting has no effect."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1619
+#: src/muuli_wdr.cpp:1623
 msgid "Stop downloads when free disk space reaches "
 msgstr "Parar descargas canto o espazo libre no disco acade "
 
-#: src/muuli_wdr.cpp:1620
+#: src/muuli_wdr.cpp:1624
 msgid "Select this if you want aMule to check your disk space"
 msgstr "Seleccione esta opción se quere que aMule comprobe o espazo libre no disco"
 
-#: src/muuli_wdr.cpp:1624
+#: src/muuli_wdr.cpp:1628
 msgid "Enter here the min disk space desired."
 msgstr "Introduza o espazo mínimo de disco desexado."
 
-#: src/muuli_wdr.cpp:1630
+#: src/muuli_wdr.cpp:1634
 msgid "Save 10 sources on rare files (< 20 sources)"
 msgstr "Gardar 10 fontes en ficheiros raros (< 20 fontes)"
 
-#: src/muuli_wdr.cpp:1634 src/Statistics.cpp:790
+#: src/muuli_wdr.cpp:1638 src/Statistics.cpp:790
 msgid "Uploads"
 msgstr "Enviado"
 
-#: src/muuli_wdr.cpp:1637
+#: src/muuli_wdr.cpp:1641
 msgid "Add new shared files with auto priority"
 msgstr "Engadir novas descargas con prioridade Automática"
 
-#: src/muuli_wdr.cpp:1643
+#: src/muuli_wdr.cpp:1647
 msgid "Intelligent Corruption Handling (I.C.H.)"
 msgstr "Xestión Intelixente de Corrupcións (X.I.C, I.C.H en inglés)"
 
-#: src/muuli_wdr.cpp:1646
+#: src/muuli_wdr.cpp:1650
 msgid "Enable"
 msgstr "Activada"
 
-#: src/muuli_wdr.cpp:1649
+#: src/muuli_wdr.cpp:1653
 msgid "Advanced I.C.H. trusts every hash (not recommended)"
 msgstr "O X.I.C. avanzado confía en cada hash (non recomendado)"
 
-#: src/muuli_wdr.cpp:1661 src/PrefsUnifiedDlg.cpp:1910
+#: src/muuli_wdr.cpp:1665 src/PrefsUnifiedDlg.cpp:1990
 msgid "Media metadata extraction"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1665
+#: src/muuli_wdr.cpp:1669
 msgid "Extract length / bitrate / codec from shared audio and video files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1667
+#: src/muuli_wdr.cpp:1671
 msgid "When enabled, aMule runs ffprobe on each shared media file to fill in the Length / Bitrate / Codec columns other clients see when they find the file in a search. Requires ffmpeg (the ffprobe binary) to be installed."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1674
+#: src/muuli_wdr.cpp:1678
 msgid "Path to ffprobe:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1679
+#: src/muuli_wdr.cpp:1683
 msgid "Full path to the ffprobe binary. Leave empty to have aMule auto-detect it on startup."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1687
+#: src/muuli_wdr.cpp:1691
 msgid "Detect"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1688
+#: src/muuli_wdr.cpp:1692
 msgid "Search the standard install locations for an ffprobe binary and fill the path field."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1712
+#: src/muuli_wdr.cpp:1716
 msgid ""
 "Completed downloads are stored here. All files in this folder are automatically shared with other peers.\n"
 "If this folder also holds files you don't want to share, point it at an aMule-only sub-folder."
@@ -4187,674 +4192,697 @@ msgstr ""
 "Aquí gárdanse as descargas completas. Automaticamente compartiranse todos os ficheiros do cartafol co resto de parceiros.\n"
 "Se o cartafol tamén conten ficheiros privados, apunte a ruta a un cartafol só para aMule."
 
-#: src/muuli_wdr.cpp:1715
+#: src/muuli_wdr.cpp:1719
 msgid "Pick the folder where completed downloads will be stored. All files in that folder will be shared with other peers."
 msgstr "Escolla o cartafol onde gardar as descargas completas. Compartiranse todos os ficheiros do cartafol co resto de parceiros."
 
-#: src/muuli_wdr.cpp:1729
+#: src/muuli_wdr.cpp:1733
 msgid "Shared folders"
 msgstr "Cartafoles compartidos"
 
-#: src/muuli_wdr.cpp:1735
+#: src/muuli_wdr.cpp:1739
 msgid "(Folders shared by the core. Enter a path to add one.)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1743
+#: src/muuli_wdr.cpp:1747
 msgid "Absolute path of a folder on the core's machine, e.g. /home/user/shared"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1745 src/PrefsUnifiedDlg.cpp:2794
+#: src/muuli_wdr.cpp:1749 src/PrefsUnifiedDlg.cpp:2874
 msgid "Recursive"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1746
+#: src/muuli_wdr.cpp:1750
 msgid "Share every sub-folder underneath this one, including ones created later."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1750 src/utils/aLinkCreator/src/alcframe.cpp:141
+#: src/muuli_wdr.cpp:1754 src/utils/aLinkCreator/src/alcframe.cpp:141
 msgid "Remove"
 msgstr "Eliminar"
 
-#: src/muuli_wdr.cpp:1754
+#: src/muuli_wdr.cpp:1758
 msgid "(Right click on folder icon for recursive share)"
 msgstr "(Preme co botón dereito na icona do cartafol para compartir recursivamente)"
 
-#: src/muuli_wdr.cpp:1761
+#: src/muuli_wdr.cpp:1765
 msgid "Share hidden files"
 msgstr "Compartir ficheiros ocultos"
 
-#: src/muuli_wdr.cpp:1767
+#: src/muuli_wdr.cpp:1771
 msgid "Automatically rescan shared folders for changes"
 msgstr "Revisar automaticamente se hai cambios nos cartafoles compartidos"
 
-#: src/muuli_wdr.cpp:1773
+#: src/muuli_wdr.cpp:1777
 msgid "Follow symbolic links in shared folders"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1779
+#: src/muuli_wdr.cpp:1783
 msgid "Exclude files matching:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1782
+#: src/muuli_wdr.cpp:1786
 msgid "Wildcard patterns separated by '|', e.g. .DS_Store|Thumbs.db|*.tmp. Files whose name matches are not shared. Matching is case-insensitive."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1786
+#: src/muuli_wdr.cpp:1790
 msgid "Patterns are regular expressions"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1787
+#: src/muuli_wdr.cpp:1791
 msgid "When set, the whole field is one regular expression ('|' is alternation). When unset, it is a list of '|'-separated wildcards."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1797
+#: src/muuli_wdr.cpp:1801
 msgid "Show how many shared files the current pattern would exclude."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1818
+#: src/muuli_wdr.cpp:1822
 msgid "Graphs"
 msgstr "Gráficas"
 
-#: src/muuli_wdr.cpp:1821 src/muuli_wdr.cpp:1883
+#: src/muuli_wdr.cpp:1825 src/muuli_wdr.cpp:1887
 msgid "Update delay : 5 secs"
 msgstr "Intervalo de actualización: 5 segs"
 
-#: src/muuli_wdr.cpp:1825
+#: src/muuli_wdr.cpp:1829
 msgid "Time for average graph: 100 mins"
 msgstr "Tempo de media do gráfico: 100 minutos"
 
-#: src/muuli_wdr.cpp:1829
+#: src/muuli_wdr.cpp:1833
 msgid "Connections Graph Scale: 100 "
 msgstr "Escala do gráfico das conexións: 100 "
 
-#: src/muuli_wdr.cpp:1836
+#: src/muuli_wdr.cpp:1840
 msgid "Download graph scale:"
 msgstr "Escala do gráfico de descargas:"
 
-#: src/muuli_wdr.cpp:1844
+#: src/muuli_wdr.cpp:1848
 msgid "Upload graph scale:"
 msgstr "Escala do gráfico de envíos:"
 
-#: src/muuli_wdr.cpp:1854
+#: src/muuli_wdr.cpp:1858
 msgid "Colors: "
 msgstr "Cores: "
 
-#: src/muuli_wdr.cpp:1858
+#: src/muuli_wdr.cpp:1862
 msgid "Background"
 msgstr "Fondo"
 
-#: src/muuli_wdr.cpp:1859
+#: src/muuli_wdr.cpp:1863
 msgid "Grid"
 msgstr "Enreixado"
 
-#: src/muuli_wdr.cpp:1860
+#: src/muuli_wdr.cpp:1864
 msgid "Download current"
 msgstr "Descarga actual"
 
-#: src/muuli_wdr.cpp:1861
+#: src/muuli_wdr.cpp:1865
 msgid "Download running average"
 msgstr "Media das descargas en execución"
 
-#: src/muuli_wdr.cpp:1862
+#: src/muuli_wdr.cpp:1866
 msgid "Download session average"
 msgstr "Media de descargas na sesión"
 
-#: src/muuli_wdr.cpp:1863
+#: src/muuli_wdr.cpp:1867
 msgid "Upload current"
 msgstr "Subida actual"
 
-#: src/muuli_wdr.cpp:1864
+#: src/muuli_wdr.cpp:1868
 msgid "Upload running average"
 msgstr "Media de subida en execución"
 
-#: src/muuli_wdr.cpp:1865
+#: src/muuli_wdr.cpp:1869
 msgid "Upload session average"
 msgstr "Media de subida na sesión"
 
-#: src/muuli_wdr.cpp:1866
+#: src/muuli_wdr.cpp:1870
 msgid "Active connections"
 msgstr "Conexións activas"
 
-#: src/muuli_wdr.cpp:1869
+#: src/muuli_wdr.cpp:1873
 msgid "Systray Icon Speed Bar"
 msgstr "Barra de velocidade na bandexa do sistema"
 
-#: src/muuli_wdr.cpp:1870
+#: src/muuli_wdr.cpp:1874
 msgid "Kad-nodes current"
 msgstr "Nodos Kad actuais"
 
-#: src/muuli_wdr.cpp:1871
+#: src/muuli_wdr.cpp:1875
 msgid "Kad-nodes running"
 msgstr "Nodo Kad executándose"
 
-#: src/muuli_wdr.cpp:1872
+#: src/muuli_wdr.cpp:1876
 msgid "Kad-nodes session"
 msgstr "Nodos Kad na sesión"
 
-#: src/muuli_wdr.cpp:1876 src/muuli_wdr.cpp:2303
+#: src/muuli_wdr.cpp:1880 src/muuli_wdr.cpp:2334
 msgid "Select"
 msgstr "Seleccionar"
 
-#: src/muuli_wdr.cpp:1880
+#: src/muuli_wdr.cpp:1884
 msgid "Tree"
 msgstr "Árbore"
 
-#: src/muuli_wdr.cpp:1890
+#: src/muuli_wdr.cpp:1894
 msgid "Number of Client Versions shown (0=unlimited)"
 msgstr "Cantas versións do cliente a amosar (0=ilimitado)"
 
-#: src/muuli_wdr.cpp:1915
+#: src/muuli_wdr.cpp:1919
 msgid "!!! WARNING !!!"
 msgstr "ADVERTENCIA !!!"
 
-#: src/muuli_wdr.cpp:1930
+#: src/muuli_wdr.cpp:1934
 msgid "Max new connections / 5 secs"
 msgstr "Novas conexións máx. / 5 segs"
 
-#: src/muuli_wdr.cpp:1932
+#: src/muuli_wdr.cpp:1936
 msgid "Concurrent Kad source lookups"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1934
+#: src/muuli_wdr.cpp:1938
 #, fuzzy
 msgid "Kad source re-search interval (minutes)"
 msgstr "Intervalo de actualización do FTP en minutos"
 
-#: src/muuli_wdr.cpp:1936
+#: src/muuli_wdr.cpp:1940
 #, fuzzy
 msgid "Source re-ask interval (minutes)"
 msgstr "Intervalo de actualización do FTP en minutos"
 
-#: src/muuli_wdr.cpp:1940
+#: src/muuli_wdr.cpp:1944
 msgid "File Buffer Size: 240000 bytes"
 msgstr "Tamaño do búfer de ficheiro: 240 000 octetos"
 
-#: src/muuli_wdr.cpp:1944
+#: src/muuli_wdr.cpp:1948
 msgid "Use MMAP: memory-mapped file access (lower memory use)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1945
+#: src/muuli_wdr.cpp:1949
 msgid "Maps part files into memory instead of buffering them on the heap, lowering the process memory footprint. May reduce download speed on some disks; best for memory-constrained or upload-heavy hosts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1947
+#: src/muuli_wdr.cpp:1951
 msgid "Upload Queue Size: 5000 clients"
 msgstr "Tamaño cola de espera: 5000 clientes"
 
-#: src/muuli_wdr.cpp:1951
+#: src/muuli_wdr.cpp:1955
 msgid "Server connection refresh interval: Disable"
 msgstr "Intervalo de actualización de conexión ao servidor: Desactivado"
 
-#: src/muuli_wdr.cpp:1955
+#: src/muuli_wdr.cpp:1959
 msgid "Disable computer's timed standby mode"
 msgstr "Impedir que o ordenador entre en modo espera"
 
-#: src/muuli_wdr.cpp:1974
+#: src/muuli_wdr.cpp:1978
 msgid "Skin to use: "
 msgstr "Tema a usar: "
 
-#: src/muuli_wdr.cpp:1983
+#: src/muuli_wdr.cpp:1987
 msgid "Show \"Fast eD2k Links Handler\" in every window."
 msgstr "Amosar «Xestor rápido de ligazóns eD2k» en cada xanela."
 
-#: src/muuli_wdr.cpp:1986
+#: src/muuli_wdr.cpp:1990
 msgid "Show extended info on categories tabs"
 msgstr "Mostrar información engadida nas lapelas das categorías"
 
-#: src/muuli_wdr.cpp:1989
+#: src/muuli_wdr.cpp:1993
 msgid "Show application version on title"
 msgstr "Amosar a versión da aplicación no título"
 
-#: src/muuli_wdr.cpp:1991
+#: src/muuli_wdr.cpp:1995
 msgid "Show transfer rates on title"
 msgstr "Mostrar velocidades de transferencia no título"
 
-#: src/muuli_wdr.cpp:1993
+#: src/muuli_wdr.cpp:1997
 msgid "Before application name"
 msgstr "Antes do nome da aplicación"
 
-#: src/muuli_wdr.cpp:1995
+#: src/muuli_wdr.cpp:1999
 msgid "After application name"
 msgstr "Despois do nome da aplicación"
 
-#: src/muuli_wdr.cpp:1998
+#: src/muuli_wdr.cpp:2002
 msgid "Show overhead bandwidth"
 msgstr "Amosar ancho de banda malgastado"
 
-#: src/muuli_wdr.cpp:2002
+#: src/muuli_wdr.cpp:2006
 msgid "Vertical toolbar orientation"
 msgstr "Barra de ferramentas en orientación vertical"
 
-#: src/muuli_wdr.cpp:2004
+#: src/muuli_wdr.cpp:2008
 msgid "Live column sorting (auto-reorder rows as their values change)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2011
+#: src/muuli_wdr.cpp:2015
 msgid "Download Queue Files"
 msgstr "Cola de Descargas"
 
-#: src/muuli_wdr.cpp:2014
+#: src/muuli_wdr.cpp:2018
 msgid "Show progress percentage"
 msgstr "Amosar porcentaxe de progreso"
 
-#: src/muuli_wdr.cpp:2020
+#: src/muuli_wdr.cpp:2024
 msgid "Show progress bar"
 msgstr "Amosar barra de progreso"
 
-#: src/muuli_wdr.cpp:2023
+#: src/muuli_wdr.cpp:2027
 msgid "Flat"
 msgstr "Plana"
 
-#: src/muuli_wdr.cpp:2027
+#: src/muuli_wdr.cpp:2031
 msgid "Round"
 msgstr "3D"
 
-#: src/muuli_wdr.cpp:2045
+#: src/muuli_wdr.cpp:2049
 msgid "External Connection Parameters"
 msgstr "Parámetros da Conexión Externa (CE)"
 
-#: src/muuli_wdr.cpp:2048
+#: src/muuli_wdr.cpp:2052
 msgid "Accept external connections"
 msgstr "Aceptar conexións externas"
 
-#: src/muuli_wdr.cpp:2055 src/muuli_wdr.cpp:2114
+#: src/muuli_wdr.cpp:2059 src/muuli_wdr.cpp:2118
 msgid "IP of the listening interface:"
 msgstr "IP da interface na que escoitar:"
 
-#: src/muuli_wdr.cpp:2058
+#: src/muuli_wdr.cpp:2062
 msgid "Enter here a valid ip in the a.b.c.d format for the listening EC interface. An empty field or 0.0.0.0 will mean any interface."
 msgstr "Introduza aquí a IP (válida, no formato a.b.c.d) da interface para a CE. Un campo baleiro ou 0.0.0.0 significa calquera interface."
 
-#: src/muuli_wdr.cpp:2079 src/muuli_wdr.cpp:2163
+#: src/muuli_wdr.cpp:2083 src/muuli_wdr.cpp:2194
 msgid "TCP port:"
 msgstr "Porto TCP:"
 
-#: src/muuli_wdr.cpp:2085
+#: src/muuli_wdr.cpp:2089
 msgid "Enable UPnP port forwarding on the EC port"
 msgstr "Activar a configuración de portos por UPnP para o porto de CE"
 
-#: src/muuli_wdr.cpp:2089 src/muuli_wdr.cpp:3048
+#: src/muuli_wdr.cpp:2093 src/muuli_wdr.cpp:3079
 #: src/utils/wxCas/src/wxcasprefs.cpp:167
 msgid "Password"
 msgstr "Contrasinal"
 
-#: src/muuli_wdr.cpp:2095
+#: src/muuli_wdr.cpp:2099
 #, fuzzy
 msgid "aMule API server parameters"
 msgstr "Parámetros do servidor Web"
 
-#: src/muuli_wdr.cpp:2098
+#: src/muuli_wdr.cpp:2102
 msgid "Run amuleapi (REST API) on startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2103
+#: src/muuli_wdr.cpp:2107
 #, fuzzy
 msgid "HTTP port:"
 msgstr "Porto TCP:"
 
-#: src/muuli_wdr.cpp:2117
+#: src/muuli_wdr.cpp:2121
 msgid "The interface amuleapi's HTTP server listens on. 127.0.0.1 (default) accepts only local connections; use 0.0.0.0 or a specific IP to expose it to other hosts (set an admin password below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2120
+#: src/muuli_wdr.cpp:2126
+msgid "Type a password to set or change it. Stored passwords cannot be shown, so leaving this empty keeps the current one."
+msgstr ""
+
+#: src/muuli_wdr.cpp:2128
 #, fuzzy
 msgid "Admin password"
 msgstr "Comprobando contrasinal\n"
 
-#: src/muuli_wdr.cpp:2125 src/muuli_wdr.cpp:2156
-msgid "Low rights password"
-msgstr "Contrasinal para o invitado"
+#: src/muuli_wdr.cpp:2140 src/muuli_wdr.cpp:2157 src/PrefsUnifiedDlg.cpp:1103
+#, fuzzy
+msgid "A password is set."
+msgstr "Comprobando contrasinal\n"
 
-#: src/muuli_wdr.cpp:2133
+#: src/muuli_wdr.cpp:2144
+#, fuzzy
+msgid "Enable guest access"
+msgstr "Denegar acceso de invitado"
+
+#: src/muuli_wdr.cpp:2145
+msgid "Guest sessions may read status and listings but cannot change anything. Turning this off clears the stored guest password."
+msgstr ""
+
+#: src/muuli_wdr.cpp:2149
+#, fuzzy
+msgid "Guest password"
+msgstr "Contrasinal de invitado para o servidor web"
+
+#: src/muuli_wdr.cpp:2164
 msgid "Web server parameters"
 msgstr "Parámetros do servidor Web"
 
-#: src/muuli_wdr.cpp:2136
+#: src/muuli_wdr.cpp:2167
 #, fuzzy
 msgid "Run webserver on startup (deprecated)"
 msgstr "Arrancar o servidor web ao iniciar"
 
-#: src/muuli_wdr.cpp:2142
+#: src/muuli_wdr.cpp:2173
 msgid "Web template"
 msgstr "Modelo Web"
 
-#: src/muuli_wdr.cpp:2147
+#: src/muuli_wdr.cpp:2178
 msgid "Full rights password"
 msgstr "Contrasinal para o administrador"
 
-#: src/muuli_wdr.cpp:2151
+#: src/muuli_wdr.cpp:2182
 msgid "Enable Low rights User"
 msgstr "Activar invitado"
 
-#: src/muuli_wdr.cpp:2170
+#: src/muuli_wdr.cpp:2187
+msgid "Low rights password"
+msgstr "Contrasinal para o invitado"
+
+#: src/muuli_wdr.cpp:2201
 msgid "Enable UPnP port forwarding of the web server port"
 msgstr "Configurar o porto do servidor web mediante UPnP"
 
-#: src/muuli_wdr.cpp:2175
+#: src/muuli_wdr.cpp:2206
 msgid "Web server UPnP TCP port (Optional)"
 msgstr "Porto TCP para o UPnP do servidor web (Opcional)"
 
-#: src/muuli_wdr.cpp:2183
+#: src/muuli_wdr.cpp:2214
 msgid "Page Refresh Time (in secs)"
 msgstr "Tempo de actualización da páxina (en segs)"
 
-#: src/muuli_wdr.cpp:2190
+#: src/muuli_wdr.cpp:2221
 msgid "Enable Gzip compression"
 msgstr "Activar compresión Gzip"
 
-#: src/muuli_wdr.cpp:2224
+#: src/muuli_wdr.cpp:2255
 #, fuzzy
 msgid "Reset page to defaults"
 msgstr "Predeterminado"
 
-#: src/muuli_wdr.cpp:2225
+#: src/muuli_wdr.cpp:2256
 msgid "Reset the settings on the current page to their default values."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2227 src/muuli_wdr.cpp:2313 src/ServerWnd.cpp:274
+#: src/muuli_wdr.cpp:2258 src/muuli_wdr.cpp:2344 src/ServerWnd.cpp:274
 #: src/ServerWnd.cpp:282
 msgid "OK"
 msgstr "Vale"
 
-#: src/muuli_wdr.cpp:2229
+#: src/muuli_wdr.cpp:2260
 msgid "Click here to apply any changes made to the preferences."
 msgstr "Aplicar calquera troco feito nas preferencias."
 
-#: src/muuli_wdr.cpp:2232
+#: src/muuli_wdr.cpp:2263
 msgid "Reset any changes made to the preferences."
 msgstr "Restablecer calquera troco feito nas preferencias."
 
-#: src/muuli_wdr.cpp:2261
+#: src/muuli_wdr.cpp:2292
 msgid "Comment :"
 msgstr "Comentario :"
 
-#: src/muuli_wdr.cpp:2268
+#: src/muuli_wdr.cpp:2299
 msgid "Incoming Dir :"
 msgstr "Cartafol de descargas :"
 
-#: src/muuli_wdr.cpp:2277
+#: src/muuli_wdr.cpp:2308
 msgid "Change priority for new assigned files :"
 msgstr "Cambiar prioridade para os novos ficheiros asignados :"
 
-#: src/muuli_wdr.cpp:2281
+#: src/muuli_wdr.cpp:2312
 msgid "Don't change"
 msgstr "Non cambiar"
 
-#: src/muuli_wdr.cpp:2293
+#: src/muuli_wdr.cpp:2324
 msgid "Select color for this Category (currently selected) :"
 msgstr "Seleccionar cor para esta categoría (a seleccionada) :"
 
-#: src/muuli_wdr.cpp:2360 src/muuli_wdr.cpp:2379 src/muuli_wdr.cpp:2401
+#: src/muuli_wdr.cpp:2391 src/muuli_wdr.cpp:2410 src/muuli_wdr.cpp:2432
 msgid "Click this button to reset the log."
 msgstr "Premer este botón para reiniciar o rexistro."
 
-#: src/muuli_wdr.cpp:2420
+#: src/muuli_wdr.cpp:2451
 msgid "Click on this button to update the servers list from URL ..."
 msgstr "Premer neste botón para actualizar a lista de servidores desde a URL ..."
 
-#: src/muuli_wdr.cpp:2424
+#: src/muuli_wdr.cpp:2455
 msgid "Server list"
 msgstr "Lista de servidores"
 
-#: src/muuli_wdr.cpp:2428
+#: src/muuli_wdr.cpp:2459
 msgid "Enter the url to a server.met file here and press the button to the left to update the list of known servers."
 msgstr "Introduza a URL dun ficheiro server.met e prema o botón da esquerda para actualizar a lista de servidores coñecidos."
 
-#: src/muuli_wdr.cpp:2433
+#: src/muuli_wdr.cpp:2464
 msgid "Add server manually: Name"
 msgstr "Engadir servidor manualmente: Nome"
 
-#: src/muuli_wdr.cpp:2436
+#: src/muuli_wdr.cpp:2467
 msgid "Enter the name of the new server here"
 msgstr "Introduza o nome do novo servidor aquí"
 
-#: src/muuli_wdr.cpp:2438 src/ServerWnd.cpp:206
+#: src/muuli_wdr.cpp:2469 src/ServerWnd.cpp:206
 msgid "IP:Port"
 msgstr "IP:Porto"
 
-#: src/muuli_wdr.cpp:2441
+#: src/muuli_wdr.cpp:2472
 msgid "Enter the IP of the server here, using the x.x.x.x format."
 msgstr "Introduza a IP do servidor aquí, usando o formato x.x.x.x ."
 
-#: src/muuli_wdr.cpp:2447
+#: src/muuli_wdr.cpp:2478
 msgid "Enter the port of the server here."
 msgstr "Introduza o porto do servidor aquí."
 
-#: src/muuli_wdr.cpp:2450
+#: src/muuli_wdr.cpp:2481
 msgid "Add manually a server (fill fields to the left before) ..."
 msgstr "Engadir servidor manualmente (antes enche os campos á esquerda) ..."
 
-#: src/muuli_wdr.cpp:2479
+#: src/muuli_wdr.cpp:2510
 msgid "aMule Log"
 msgstr "Rexistro de aMule"
 
-#: src/muuli_wdr.cpp:2487
+#: src/muuli_wdr.cpp:2518
 msgid "Server Info"
 msgstr "Info. do servidor"
 
-#: src/muuli_wdr.cpp:2491
+#: src/muuli_wdr.cpp:2522
 msgid "ED2K Info"
 msgstr "Info. ED2K"
 
-#: src/muuli_wdr.cpp:2495
+#: src/muuli_wdr.cpp:2526
 msgid "Kad Info"
 msgstr "Info. Kad"
 
-#: src/muuli_wdr.cpp:2523
+#: src/muuli_wdr.cpp:2554
 msgid "Click on this button to update the nodes list from URL ..."
 msgstr "Prema neste botón para actualizar a lista de nodos dende a URL ..."
 
-#: src/muuli_wdr.cpp:2527
+#: src/muuli_wdr.cpp:2558
 msgid "Nodes (0)"
 msgstr "Nodos (0)"
 
-#: src/muuli_wdr.cpp:2531
+#: src/muuli_wdr.cpp:2562
 msgid "Enter the url to a nodes.dat file here and press the button to the left to update the list of known nodes."
 msgstr "Introduza aquí a URL ao ficheiro nodes.dat e prema o botón da esquerda, para actualizar a lista de nodos coñecidos."
 
-#: src/muuli_wdr.cpp:2534
+#: src/muuli_wdr.cpp:2565
 msgid "Nodes stats"
 msgstr "Estatísticas de nodos"
 
-#: src/muuli_wdr.cpp:2576
+#: src/muuli_wdr.cpp:2607
 msgid "Bootstrap"
 msgstr "Arranque autónomo (dende cero)"
 
-#: src/muuli_wdr.cpp:2579
+#: src/muuli_wdr.cpp:2610
 msgid "New node"
 msgstr "Novo nodo"
 
-#: src/muuli_wdr.cpp:2584
+#: src/muuli_wdr.cpp:2615
 msgid "IP:"
 msgstr "IP:"
 
-#: src/muuli_wdr.cpp:2604
+#: src/muuli_wdr.cpp:2635
 msgid "Port:"
 msgstr "Porto:"
 
-#: src/muuli_wdr.cpp:2617
+#: src/muuli_wdr.cpp:2648
 msgid "Bootstrap from known clients"
 msgstr "Arrancar a partir de clientes coñecidos"
 
-#: src/muuli_wdr.cpp:2619
+#: src/muuli_wdr.cpp:2650
 msgid "Disconnect Kad"
 msgstr "Desconectar Kad"
 
-#: src/muuli_wdr.cpp:2653
+#: src/muuli_wdr.cpp:2684
 msgid "Use Secure User Identification"
 msgstr "Empregar a Identificación Segura do Usuario"
 
-#: src/muuli_wdr.cpp:2655
+#: src/muuli_wdr.cpp:2686
 msgid "It is recommended to enable this option. You will not receive credits if SUI is not enabled."
 msgstr "Aconséllase habilitar esta opción. Non recibirá créditos se a ISU non se habilitou."
 
-#: src/muuli_wdr.cpp:2657
+#: src/muuli_wdr.cpp:2688
 msgid "Protocol Obfuscation"
 msgstr "Ofuscación do protocolo"
 
-#: src/muuli_wdr.cpp:2660
+#: src/muuli_wdr.cpp:2691
 msgid "Support Protocol Obfuscation"
 msgstr "Aceptar a ofuscación do protocolo"
 
-#: src/muuli_wdr.cpp:2662
+#: src/muuli_wdr.cpp:2693
 msgid "This option enabled Protocol Obfuscation, and makes aMule accept obfuscated connections from other clients."
 msgstr "Esta opción activa a ofuscación do protocolo, e permite que aMule acepte conexións ofuscadas doutros clientes."
 
-#: src/muuli_wdr.cpp:2664
+#: src/muuli_wdr.cpp:2695
 msgid "Use obfuscation for outgoing connections"
 msgstr "Usar ofuscación para as conexións saíntes"
 
-#: src/muuli_wdr.cpp:2666
+#: src/muuli_wdr.cpp:2697
 msgid "This option makes aMule use Protocol Obfuscation when connecting other clients/servers."
 msgstr "Esta opción fai que aMule use a ofuscación de protocolo cando se conectan outros clientes/servidores."
 
-#: src/muuli_wdr.cpp:2668
+#: src/muuli_wdr.cpp:2699
 msgid "Accept only obfuscated connections"
 msgstr "Aceptar só conexións ofuscadas"
 
-#: src/muuli_wdr.cpp:2669
+#: src/muuli_wdr.cpp:2700
 msgid "This option makes aMule only accept obfuscated connections. You will have less sources, but all your traffic will be obfuscated"
 msgstr "Esta opción fai que aMule só acepte conexións ofuscadas. Terá menos fontes, pero todo o tráfico estará ofuscado"
 
-#: src/muuli_wdr.cpp:2674
+#: src/muuli_wdr.cpp:2705
 msgid "Everybody"
 msgstr "Todos"
 
-#: src/muuli_wdr.cpp:2676
+#: src/muuli_wdr.cpp:2707
 msgid "No one"
 msgstr "Ninguén"
 
-#: src/muuli_wdr.cpp:2678
+#: src/muuli_wdr.cpp:2709
 msgid "Who can see my shared files:"
 msgstr "Quen pode ver os meus ficheiros compartidos:"
 
-#: src/muuli_wdr.cpp:2679
+#: src/muuli_wdr.cpp:2710
 msgid "Select who can request to view a list of your shared files."
 msgstr "Seleccione quen pode solicitar ver a lista de ficheiros compartidos."
 
-#: src/muuli_wdr.cpp:2681
+#: src/muuli_wdr.cpp:2712
 msgid "IP-Filtering"
 msgstr "Filtrado de IPs"
 
-#: src/muuli_wdr.cpp:2688
+#: src/muuli_wdr.cpp:2719
 msgid "Filter clients"
 msgstr "Filtrar clientes"
 
-#: src/muuli_wdr.cpp:2690
+#: src/muuli_wdr.cpp:2721
 msgid "Enable filtering of the client IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "Activar filtrado das IPs dos clientes definidas no ficheiro ~/.aMule/ipfilter.dat."
 
-#: src/muuli_wdr.cpp:2692
+#: src/muuli_wdr.cpp:2723
 msgid "Filter servers"
 msgstr "Filtrar servidores"
 
-#: src/muuli_wdr.cpp:2694
+#: src/muuli_wdr.cpp:2725
 msgid "Enable filtering of the server IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "Activar filtrado das IPs dos servidores definidas no ficheiro ~/.aMule/ipfilter.dat."
 
-#: src/muuli_wdr.cpp:2698
+#: src/muuli_wdr.cpp:2729
 msgid "Reload List"
 msgstr "Recargar lista"
 
-#: src/muuli_wdr.cpp:2699
+#: src/muuli_wdr.cpp:2730
 msgid "Reload the list of IPs to filter from the file ~/.aMule/ipfilter.dat"
 msgstr "Recargar a lista de filtrado de IPs desde o ficheiro ~/.aMule/ipfilter.dat"
 
-#: src/muuli_wdr.cpp:2705
+#: src/muuli_wdr.cpp:2736
 msgid "URL:"
 msgstr "URL:"
 
-#: src/muuli_wdr.cpp:2709 src/muuli_wdr.cpp:2902
+#: src/muuli_wdr.cpp:2740 src/muuli_wdr.cpp:2933
 msgid "Update now"
 msgstr "Actualizar agora"
 
-#: src/muuli_wdr.cpp:2712
+#: src/muuli_wdr.cpp:2743
 msgid "Auto-update ipfilter at startup"
 msgstr "Auto-actualizar o filtrado de IPs ao iniciarse"
 
-#: src/muuli_wdr.cpp:2716
+#: src/muuli_wdr.cpp:2747
 msgid "Filtering Level:"
 msgstr "Nivel de filtrado:"
 
-#: src/muuli_wdr.cpp:2722
+#: src/muuli_wdr.cpp:2753
 msgid "Always filter LAN IPs"
 msgstr "Filtrar sempre IPs LAN"
 
-#: src/muuli_wdr.cpp:2725
+#: src/muuli_wdr.cpp:2756
 msgid "Paranoid handling of non-matching IPs"
 msgstr "Xestión paranoica de IPs non coincidintes"
 
-#: src/muuli_wdr.cpp:2727
+#: src/muuli_wdr.cpp:2758
 msgid "Rejects a packet when its source IP differs from the IP the client claims (an anti-spoofing check). Disable only if it causes connection problems."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2729
+#: src/muuli_wdr.cpp:2760
 msgid "Use system-wide ipfilter.dat if available"
 msgstr "Empregar un ipfilter.dat global se está dispoñible"
 
-#: src/muuli_wdr.cpp:2730
+#: src/muuli_wdr.cpp:2761
 msgid "If there's no local ipfilter.dat found, allow usage of a system-wide ipfilter file."
 msgstr "De non atopar o ipfilter.dat local, permitir o emprego dun ipfilter global."
 
-#: src/muuli_wdr.cpp:2747
+#: src/muuli_wdr.cpp:2778
 msgid "Enable Online-Signature"
 msgstr "Activar Sinatura En liña"
 
-#: src/muuli_wdr.cpp:2749
+#: src/muuli_wdr.cpp:2780
 msgid "Enables the writing of the OS file, which can be used by external apps to create signatures and the like."
 msgstr "Habilitar a escritura de ficheiros do SE. Sóese usar para crear sinaturas para aplicacións externas."
 
-#: src/muuli_wdr.cpp:2753
+#: src/muuli_wdr.cpp:2784
 msgid "Update Frequency (Secs):"
 msgstr "Frecuencia de actualización (segs):"
 
-#: src/muuli_wdr.cpp:2756
+#: src/muuli_wdr.cpp:2787
 msgid "Change the frequency (in seconds) of Online Signature updates."
 msgstr "Cambiar a frecuencia (en segundos) da actualización da sinatura en liña."
 
-#: src/muuli_wdr.cpp:2764
+#: src/muuli_wdr.cpp:2795
 msgid "Save online signature file in: "
 msgstr "Gardar o ficheiro de sinaturas en liña en: "
 
-#: src/muuli_wdr.cpp:2770
+#: src/muuli_wdr.cpp:2801
 msgid "Click here to select the directory containing the the Online Signature files."
 msgstr "Prema aquí para seleccionar o directorio que contén os ficheiros de sinaturas en liña."
 
-#: src/muuli_wdr.cpp:2803
+#: src/muuli_wdr.cpp:2834
 msgid "Show country flags for clients"
 msgstr "Amosar as bandeiras do país de orixe dos clientes"
 
-#: src/muuli_wdr.cpp:2804
+#: src/muuli_wdr.cpp:2835
 msgid "Render the country flag column in the transfers, queue and search views. Requires a valid MMDB GeoIP database (see below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2809
+#: src/muuli_wdr.cpp:2840
 #, fuzzy
 msgid "Database"
 msgstr "Fluxo de datos :"
 
-#: src/muuli_wdr.cpp:2825
+#: src/muuli_wdr.cpp:2856
 #, fuzzy
 msgid "Source:"
 msgstr "Fontes"
 
-#: src/muuli_wdr.cpp:2828
+#: src/muuli_wdr.cpp:2859
 msgid "DB-IP (free, no account)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2829
+#: src/muuli_wdr.cpp:2860
 msgid "MaxMind GeoLite2 (free, account required)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2830
+#: src/muuli_wdr.cpp:2861
 msgid "Custom URL"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2833
+#: src/muuli_wdr.cpp:2864
 msgid "Choose which provider supplies the GeoIP MMDB database. DB-IP is the default - no account required. MaxMind requires a free account + license key. Use Custom URL to point at any other MMDB host (e.g. a local mirror)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2850
+#: src/muuli_wdr.cpp:2881
 msgid ""
 "No configuration required.\n"
 "\n"
@@ -4862,11 +4890,11 @@ msgid ""
 "License: Creative Commons BY 4.0 - https://creativecommons.org/licenses/by/4.0/"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2863
+#: src/muuli_wdr.cpp:2894
 msgid "License key:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2869
+#: src/muuli_wdr.cpp:2900
 msgid ""
 "Sign up for a free MaxMind account, then generate a License Key:\n"
 "https://www.maxmind.com/en/geolite2/signup\n"
@@ -4876,225 +4904,225 @@ msgid ""
 "Requires attribution and account registration; refresh at least every 30 days."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2884
+#: src/muuli_wdr.cpp:2915
 #, fuzzy
 msgid "Download URL:"
 msgstr "Descargado: "
 
-#: src/muuli_wdr.cpp:2890
+#: src/muuli_wdr.cpp:2921
 msgid ""
 "Must point to an .mmdb file or a .gz / .tar.gz containing one.\n"
 "URL may include credentials (https://user:pass@host/...).\n"
 "License and attribution terms are set by the upstream URL - you are responsible."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2903
+#: src/muuli_wdr.cpp:2934
 msgid "Download the GeoIP database from the selected source."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2905
+#: src/muuli_wdr.cpp:2936
 #, fuzzy
 msgid "Auto-update on startup"
 msgstr "Auto-actualizar o filtrado de IPs ao iniciarse"
 
-#: src/muuli_wdr.cpp:2906
+#: src/muuli_wdr.cpp:2937
 msgid "Re-download the GeoIP database from the selected source every time aMule starts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2929
+#: src/muuli_wdr.cpp:2960
 msgid "Filter incoming messages (except current chat):"
 msgstr "Filtrar mensaxes entrantes (excepto as da conversación actual):"
 
-#: src/muuli_wdr.cpp:2931
+#: src/muuli_wdr.cpp:2962
 msgid "Filter all messages"
 msgstr "Filtrar todas as mensaxes"
 
-#: src/muuli_wdr.cpp:2933
+#: src/muuli_wdr.cpp:2964
 msgid "Filter messages from people not on your friend list"
 msgstr "Filtrar mensaxes de xente que non estea na lista de amigos"
 
-#: src/muuli_wdr.cpp:2935
+#: src/muuli_wdr.cpp:2966
 msgid "Filter messages from unknown clients"
 msgstr "Filtrar mensaxes de clientes descoñecidos"
 
-#: src/muuli_wdr.cpp:2937
+#: src/muuli_wdr.cpp:2968
 msgid "Filter messages containing (use ',' as separator):"
 msgstr "Filtrar mensaxes que conteñan (use «,» como separador):"
 
-#: src/muuli_wdr.cpp:2940 src/muuli_wdr.cpp:2951
+#: src/muuli_wdr.cpp:2971 src/muuli_wdr.cpp:2982
 msgid "add here the words amule should filter and block messages including it"
 msgstr "engada aquí palabras para filtrar e bloquear as mensaxes que coincidan"
 
-#: src/muuli_wdr.cpp:2942
+#: src/muuli_wdr.cpp:2973
 msgid "Show received messages in the log"
 msgstr "Amosar as mensaxes recibidas no rexistro"
 
-#: src/muuli_wdr.cpp:2945
+#: src/muuli_wdr.cpp:2976
 msgid "Comments"
 msgstr "Comentarios"
 
-#: src/muuli_wdr.cpp:2948
+#: src/muuli_wdr.cpp:2979
 msgid "Filter comments containing (use ',' as separator):"
 msgstr "Filtrar comentarios que conteñan (empregue «,» coma separador):"
 
-#: src/muuli_wdr.cpp:2973
+#: src/muuli_wdr.cpp:3004
 msgid "Enable Proxy"
 msgstr "Activar proxy"
 
-#: src/muuli_wdr.cpp:2974
+#: src/muuli_wdr.cpp:3005
 msgid "Enable/disable proxy support"
 msgstr "Activar/desactivar o tipo de proxy"
 
-#: src/muuli_wdr.cpp:2977
+#: src/muuli_wdr.cpp:3008
 msgid "Proxy type:"
 msgstr "Tipo de proxy:"
 
-#: src/muuli_wdr.cpp:2988
+#: src/muuli_wdr.cpp:3019
 msgid "Proxy host:"
 msgstr "Anfitrión do proxy:"
 
-#: src/muuli_wdr.cpp:2991
+#: src/muuli_wdr.cpp:3022
 msgid "The proxy host name"
 msgstr "O nome do anfitrión do proxy"
 
-#: src/muuli_wdr.cpp:2993
+#: src/muuli_wdr.cpp:3024
 msgid "Proxy port:"
 msgstr "Porto do proxy:"
 
-#: src/muuli_wdr.cpp:2996
+#: src/muuli_wdr.cpp:3027
 msgid "The proxy port"
 msgstr "O porto do proxy"
 
-#: src/muuli_wdr.cpp:2998
+#: src/muuli_wdr.cpp:3029
 msgid "Enable authentication"
 msgstr "Activar identificación"
 
-#: src/muuli_wdr.cpp:2999
+#: src/muuli_wdr.cpp:3030
 msgid "Enable/disable username/password authentication"
 msgstr "Activar/desactivar a identificación mediante nome de usuario e contrasinal"
 
-#: src/muuli_wdr.cpp:3002
+#: src/muuli_wdr.cpp:3033
 msgid "Username: "
 msgstr "Nome de usuario: "
 
-#: src/muuli_wdr.cpp:3005
+#: src/muuli_wdr.cpp:3036
 msgid "The username to use to connect to the proxy"
 msgstr "O nome de usuario a usar para conectarse ao proxy"
 
-#: src/muuli_wdr.cpp:3007
+#: src/muuli_wdr.cpp:3038
 msgid "Password:"
 msgstr "Contrasinal:"
 
-#: src/muuli_wdr.cpp:3010
+#: src/muuli_wdr.cpp:3041
 msgid "The password to use to connect to the proxy"
 msgstr "O contrasinal a empregar para conectarse ao proxy"
 
-#: src/muuli_wdr.cpp:3029
+#: src/muuli_wdr.cpp:3060
 msgid "Connect to:"
 msgstr "Conectar a:"
 
-#: src/muuli_wdr.cpp:3038
+#: src/muuli_wdr.cpp:3069
 msgid "Login to remote amule"
 msgstr "Conectar a amule remoto"
 
-#: src/muuli_wdr.cpp:3043
+#: src/muuli_wdr.cpp:3074
 msgid "User name"
 msgstr "Nome de usuario"
 
-#: src/muuli_wdr.cpp:3054
+#: src/muuli_wdr.cpp:3085
 msgid "Remember those settings"
 msgstr "Recordar esas opcións"
 
-#: src/muuli_wdr.cpp:3057
+#: src/muuli_wdr.cpp:3088
 #, fuzzy
 msgid "Force ZLIB compression"
 msgstr "Usar compresión gzip"
 
-#: src/muuli_wdr.cpp:3081
+#: src/muuli_wdr.cpp:3112
 msgid "Enable Verbose Debug-Logging."
 msgstr "Activar Rexistro de Depuración Estendido."
 
-#: src/muuli_wdr.cpp:3083
+#: src/muuli_wdr.cpp:3114
 msgid "Only to Logfile"
 msgstr "Só ao ficheiro do rexistro"
 
-#: src/muuli_wdr.cpp:3085
+#: src/muuli_wdr.cpp:3116
 msgid "Message Categories:"
 msgstr "Categorías das mensaxes:"
 
-#: src/muuli_wdr.cpp:3109 src/PartFileConvertDlg.cpp:160
+#: src/muuli_wdr.cpp:3140 src/PartFileConvertDlg.cpp:160
 msgid "Waiting..."
 msgstr "Agardando..."
 
-#: src/muuli_wdr.cpp:3129
+#: src/muuli_wdr.cpp:3160
 msgid "Add imports"
 msgstr "Engadir importados"
 
-#: src/muuli_wdr.cpp:3132
+#: src/muuli_wdr.cpp:3163
 msgid "Retry selected"
 msgstr "Tentar de novo o seleccionado"
 
-#: src/muuli_wdr.cpp:3134
+#: src/muuli_wdr.cpp:3165
 msgid "Remove selected"
 msgstr "Borrar seleccionados"
 
-#: src/muuli_wdr.cpp:3197
+#: src/muuli_wdr.cpp:3228
 msgid "Event Types"
 msgstr "Tipos de eventos"
 
-#: src/muuli_wdr.cpp:3216
+#: src/muuli_wdr.cpp:3247
 msgid "Statistics and queued clients for selected file(s) : Session / All time"
 msgstr "Estadísticas e clientes esperando para os ficheiros seleccionados: Sesión / Total"
 
-#: src/muuli_wdr.cpp:3240
+#: src/muuli_wdr.cpp:3271
 msgid "Active Uploads"
 msgstr "Envíos activos"
 
-#: src/muuli_wdr.cpp:3254
+#: src/muuli_wdr.cpp:3285
 msgid "Percent of total files"
 msgstr "Porcentaxe de todos os ficheiros"
 
-#: src/muuli_wdr.cpp:3306
+#: src/muuli_wdr.cpp:3337
 msgid "Show Clients for"
 msgstr "Amosar clientes para"
 
-#: src/muuli_wdr.cpp:3308
+#: src/muuli_wdr.cpp:3339
 msgid "All files"
 msgstr "Todos os ficheiros"
 
-#: src/muuli_wdr.cpp:3311
+#: src/muuli_wdr.cpp:3342
 msgid "Selected files"
 msgstr "Ficheiros selecionados"
 
-#: src/muuli_wdr.cpp:3314
+#: src/muuli_wdr.cpp:3345
 msgid "Active uploads only"
 msgstr "Só subidas activas"
 
-#: src/muuli_wdr.cpp:3321
+#: src/muuli_wdr.cpp:3352
 msgid "Reload:"
 msgstr "Recargar:"
 
-#: src/muuli_wdr.cpp:3325
+#: src/muuli_wdr.cpp:3356
 msgid "Reload your shared files"
 msgstr "Recargar os seus ficheiros compartidos"
 
-#: src/muuli_wdr.cpp:3388
+#: src/muuli_wdr.cpp:3419
 msgid "Send"
 msgstr "Enviar"
 
-#: src/muuli_wdr.cpp:3389
+#: src/muuli_wdr.cpp:3420
 msgid "Sends the specified message."
 msgstr "Enviar a mensaxe especificada."
 
-#: src/muuli_wdr.cpp:3393
+#: src/muuli_wdr.cpp:3424
 msgid "Close this chat-session."
 msgstr "Pechar esta conversa."
 
-#: src/muuli_wdr.cpp:3416
+#: src/muuli_wdr.cpp:3447
 msgid "Connect to any server and/or Kad"
 msgstr "Conectar a calquera servidor e/ou Kad"
 
-#: src/muuli_wdr.cpp:3422 src/SharedFilesCtrl.cpp:142 src/Statistics.cpp:941
+#: src/muuli_wdr.cpp:3453 src/SharedFilesCtrl.cpp:142 src/Statistics.cpp:941
 msgid "Shared Files"
 msgstr "Ficheiros compartidos"
 
@@ -5454,249 +5482,249 @@ msgstr "Descargado"
 msgid "ERROR: Failed to open partfile '%s'"
 msgstr "ERRO: Non se puido abrir o partfile «%s»"
 
-#: src/Preferences.cpp:674
+#: src/Preferences.cpp:701
 msgid "System default"
 msgstr "Predeterminado"
 
-#: src/Preferences.cpp:675
+#: src/Preferences.cpp:702
 msgid "Albanian"
 msgstr "Albanés"
 
-#: src/Preferences.cpp:676
+#: src/Preferences.cpp:703
 msgid "Arabic"
 msgstr "Árabe"
 
-#: src/Preferences.cpp:677
+#: src/Preferences.cpp:704
 msgid "Asturian"
 msgstr "Asturiano"
 
-#: src/Preferences.cpp:678
+#: src/Preferences.cpp:705
 msgid "Basque"
 msgstr "Euskera"
 
-#: src/Preferences.cpp:679
+#: src/Preferences.cpp:706
 msgid "Bulgarian"
 msgstr "Búlgaro"
 
-#: src/Preferences.cpp:680
+#: src/Preferences.cpp:707
 msgid "Catalan"
 msgstr "Catalán"
 
-#: src/Preferences.cpp:681
+#: src/Preferences.cpp:708
 msgid "Chinese (Simplified)"
 msgstr "Chinés (Simplificado)"
 
-#: src/Preferences.cpp:682
+#: src/Preferences.cpp:709
 msgid "Chinese (Traditional)"
 msgstr "Chinés (Tradicional)"
 
-#: src/Preferences.cpp:683
+#: src/Preferences.cpp:710
 msgid "Croatian"
 msgstr "Croata"
 
-#: src/Preferences.cpp:684
+#: src/Preferences.cpp:711
 msgid "Czech"
 msgstr "Checo"
 
-#: src/Preferences.cpp:685
+#: src/Preferences.cpp:712
 msgid "Danish"
 msgstr "Danés"
 
-#: src/Preferences.cpp:686
+#: src/Preferences.cpp:713
 msgid "Dutch"
 msgstr "Holandés"
 
-#: src/Preferences.cpp:687
+#: src/Preferences.cpp:714
 msgid "English (U.K.)"
 msgstr "Inglés (R. U.)"
 
-#: src/Preferences.cpp:688
+#: src/Preferences.cpp:715
 #, fuzzy
 msgid "English (U.S.)"
 msgstr "Inglés (R. U.)"
 
-#: src/Preferences.cpp:689
+#: src/Preferences.cpp:716
 msgid "Estonian"
 msgstr "Estonio"
 
-#: src/Preferences.cpp:690
+#: src/Preferences.cpp:717
 msgid "Finnish"
 msgstr "Finlandés"
 
-#: src/Preferences.cpp:691
+#: src/Preferences.cpp:718
 msgid "French"
 msgstr "Francés"
 
-#: src/Preferences.cpp:692
+#: src/Preferences.cpp:719
 msgid "Galician"
 msgstr "Galego"
 
-#: src/Preferences.cpp:693
+#: src/Preferences.cpp:720
 msgid "German"
 msgstr "Alemán"
 
-#: src/Preferences.cpp:694
+#: src/Preferences.cpp:721
 msgid "Greek"
 msgstr "Grego"
 
-#: src/Preferences.cpp:695
+#: src/Preferences.cpp:722
 msgid "Hebrew"
 msgstr "Hebreo"
 
-#: src/Preferences.cpp:696
+#: src/Preferences.cpp:723
 msgid "Hungarian"
 msgstr "Húngaro"
 
-#: src/Preferences.cpp:697
+#: src/Preferences.cpp:724
 msgid "Italian"
 msgstr "Italiano"
 
-#: src/Preferences.cpp:698
+#: src/Preferences.cpp:725
 msgid "Japanese"
 msgstr "Xaponés"
 
-#: src/Preferences.cpp:699
+#: src/Preferences.cpp:726
 msgid "Korean"
 msgstr "Coreano"
 
-#: src/Preferences.cpp:700
+#: src/Preferences.cpp:727
 msgid "Latvian"
 msgstr ""
 
-#: src/Preferences.cpp:701
+#: src/Preferences.cpp:728
 msgid "Lithuanian"
 msgstr "Lituano"
 
-#: src/Preferences.cpp:702
+#: src/Preferences.cpp:729
 msgid "Norwegian (Nynorsk)"
 msgstr "Noruegués (Nynorsk)"
 
-#: src/Preferences.cpp:703
+#: src/Preferences.cpp:730
 msgid "Polish"
 msgstr "Polaco"
 
-#: src/Preferences.cpp:704
+#: src/Preferences.cpp:731
 msgid "Portuguese"
 msgstr "Portugués"
 
-#: src/Preferences.cpp:705
+#: src/Preferences.cpp:732
 msgid "Portuguese (Brazilian)"
 msgstr "Portugués (Brasileiro)"
 
-#: src/Preferences.cpp:706
+#: src/Preferences.cpp:733
 msgid "Romanian"
 msgstr "Rumano"
 
-#: src/Preferences.cpp:707
+#: src/Preferences.cpp:734
 msgid "Russian"
 msgstr "Ruso"
 
-#: src/Preferences.cpp:708
+#: src/Preferences.cpp:735
 msgid "Slovenian"
 msgstr "Esloveno"
 
-#: src/Preferences.cpp:709
+#: src/Preferences.cpp:736
 msgid "Spanish"
 msgstr "Castelán"
 
-#: src/Preferences.cpp:710
+#: src/Preferences.cpp:737
 msgid "Swedish"
 msgstr "Sueco"
 
-#: src/Preferences.cpp:711
+#: src/Preferences.cpp:738
 msgid "Turkish"
 msgstr "Turco"
 
-#: src/Preferences.cpp:712
+#: src/Preferences.cpp:739
 msgid "Ukrainian"
 msgstr "Ucraniano"
 
-#: src/Preferences.cpp:815
+#: src/Preferences.cpp:842
 msgid "Change Language"
 msgstr "Cambiar idioma"
 
-#: src/Preferences.cpp:879
+#: src/Preferences.cpp:906
 msgid "There are no translations installed for aMule"
 msgstr "Non hai traducións instaladas para aMule"
 
-#: src/Preferences.cpp:880
+#: src/Preferences.cpp:907
 msgid "No languages available"
 msgstr "Ningunha lingua dispoñible"
 
-#: src/Preferences.cpp:1011
+#: src/Preferences.cpp:1038
 msgid "no options available"
 msgstr "non hai opcións disponibles"
 
-#: src/Preferences.cpp:2182
+#: src/Preferences.cpp:2227
 msgid "Invalid category found, skipping"
 msgstr "Categoría inválida atopada, saltandoa"
 
-#: src/Preferences.cpp:2351
+#: src/Preferences.cpp:2396
 msgid "TCP port can't be higher than 65532 due to server UDP socket being TCP+3"
 msgstr "O porto TCP non pode ser máis alto que 65532 debido a que o socket do servidor UDP é TCP+3"
 
-#: src/Preferences.cpp:2352
+#: src/Preferences.cpp:2397
 #, c-format
 msgid "Default port will be used (%d)"
 msgstr "Empregarase o porto predeterminado (%d)"
 
-#: src/PrefsUnifiedDlg.cpp:298 src/Statistics.cpp:866
+#: src/PrefsUnifiedDlg.cpp:300 src/Statistics.cpp:866
 msgid "Connection"
 msgstr "Conexión"
 
-#: src/PrefsUnifiedDlg.cpp:299 src/SearchListCtrl.cpp:117
+#: src/PrefsUnifiedDlg.cpp:301 src/SearchListCtrl.cpp:117
 msgid "Directories"
 msgstr "Cartafoles"
 
-#: src/PrefsUnifiedDlg.cpp:300 src/Statistics.cpp:917
+#: src/PrefsUnifiedDlg.cpp:302 src/Statistics.cpp:917
 msgid "Servers"
 msgstr "Servidores"
 
-#: src/PrefsUnifiedDlg.cpp:301 src/ServerListCtrl.cpp:96
+#: src/PrefsUnifiedDlg.cpp:303 src/ServerListCtrl.cpp:96
 msgid "Files"
 msgstr "Ficheiros"
 
-#: src/PrefsUnifiedDlg.cpp:302
+#: src/PrefsUnifiedDlg.cpp:304
 msgid "Security"
 msgstr "Seguranza"
 
-#: src/PrefsUnifiedDlg.cpp:303
+#: src/PrefsUnifiedDlg.cpp:305
 msgid "Interface"
 msgstr "Interface"
 
-#: src/PrefsUnifiedDlg.cpp:310
+#: src/PrefsUnifiedDlg.cpp:312
 msgid "IP2Country"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:313
+#: src/PrefsUnifiedDlg.cpp:315
 msgid "Proxy"
 msgstr "Proxy"
 
-#: src/PrefsUnifiedDlg.cpp:314
+#: src/PrefsUnifiedDlg.cpp:316
 msgid "Filters"
 msgstr "Filtros"
 
-#: src/PrefsUnifiedDlg.cpp:315
+#: src/PrefsUnifiedDlg.cpp:317
 msgid "Remote Controls"
 msgstr "Controles remotos"
 
-#: src/PrefsUnifiedDlg.cpp:316
+#: src/PrefsUnifiedDlg.cpp:318
 msgid "Online Signature"
 msgstr "Sinatura En liña"
 
-#: src/PrefsUnifiedDlg.cpp:317
+#: src/PrefsUnifiedDlg.cpp:319
 msgid "Advanced"
 msgstr "Avanzado"
 
-#: src/PrefsUnifiedDlg.cpp:318
+#: src/PrefsUnifiedDlg.cpp:320
 msgid "Events"
 msgstr "Eventos"
 
-#: src/PrefsUnifiedDlg.cpp:321
+#: src/PrefsUnifiedDlg.cpp:323
 msgid "Debugging"
 msgstr "Depuración"
 
-#: src/PrefsUnifiedDlg.cpp:451
+#: src/PrefsUnifiedDlg.cpp:453
 msgid ""
 "The following variables will be substituted:\n"
 "    %PARTFILE - full path to the file\n"
@@ -5706,15 +5734,15 @@ msgstr ""
 "    %PARTFILE - ruta completa do ficheiro\n"
 "    %PARTNAME - nome do ficheiro"
 
-#: src/PrefsUnifiedDlg.cpp:472
+#: src/PrefsUnifiedDlg.cpp:474
 msgid "Tray icon support requires libayatana-appindicator3 at compile time."
 msgstr "Para poder engadir unha icona precisa ter libayatana-appindicator3 durante a compilación."
 
-#: src/PrefsUnifiedDlg.cpp:488
+#: src/PrefsUnifiedDlg.cpp:490
 msgid "Not available on Wayland: the protocol does not report when a window is minimized, so this option cannot intercept the system minimize button. Workaround: launch aMule with `GDK_BACKEND=x11` to use XWayland instead."
 msgstr "Non dispoñible en Wayland: o protocolo non pode avisar se se minimiza unha xanela, polo que non se pode interceptar o botón de minimizar. Como alternativa, execute aMule con «GDK_BACKEND=x11» para usar XWayland."
 
-#: src/PrefsUnifiedDlg.cpp:534
+#: src/PrefsUnifiedDlg.cpp:536
 msgid ""
 "Do not change these setting unless you know\n"
 "what you are doing, otherwise you can easily\n"
@@ -5730,26 +5758,35 @@ msgstr ""
 "aMule funcionará ben sen que cambie ningún\n"
 "destes parámetros."
 
-#: src/PrefsUnifiedDlg.cpp:645
+#: src/PrefsUnifiedDlg.cpp:647
 #, c-format
 msgid "Failed to connect Cfg to widget with the ID %d and key %s"
 msgstr "Non se puido conectar a configuración ao compoñente coa ID %d e chave %s"
 
-#: src/PrefsUnifiedDlg.cpp:693
+#: src/PrefsUnifiedDlg.cpp:695
 #, c-format
 msgid "Failed to transfer data from Cfg to Widget with the ID %d and key %s"
 msgstr "Non se puido transferir información dende a configuración ao compoñente con ID %d e chave %s"
 
-#: src/PrefsUnifiedDlg.cpp:799
+#: src/PrefsUnifiedDlg.cpp:801
 msgid "The type of proxy you are connecting to"
 msgstr "O tipo de proxy ao que se está a conectar"
 
-#: src/PrefsUnifiedDlg.cpp:1003
+#: src/PrefsUnifiedDlg.cpp:1020
 #, c-format
 msgid "Failed to transfer data from Widget to Cfg with the ID %d and key %s"
 msgstr "Non se puido transferir información entre o compoñente e a configuración con ID %d e chave %s"
 
 #: src/PrefsUnifiedDlg.cpp:1103
+#, fuzzy
+msgid "No password set."
+msgstr "Comprobando contrasinal\n"
+
+#: src/PrefsUnifiedDlg.cpp:1132
+msgid "Guest access needs a password. Type one in the guest password field, or untick Enable guest access."
+msgstr ""
+
+#: src/PrefsUnifiedDlg.cpp:1144
 msgid ""
 "aMule must be restarted to enable these changes:\n"
 "\n"
@@ -5757,41 +5794,41 @@ msgstr ""
 "aMule debe ser reiniciado para activar estes trocos:\n"
 "\n"
 
-#: src/PrefsUnifiedDlg.cpp:1110
+#: src/PrefsUnifiedDlg.cpp:1151
 msgid "- TCP port changed.\n"
 msgstr "- Porto TCP cambiado.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1115
+#: src/PrefsUnifiedDlg.cpp:1156
 msgid "- UDP port changed.\n"
 msgstr "- Porto UDP cambiado.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1120
+#: src/PrefsUnifiedDlg.cpp:1161
 #, fuzzy
 msgid "- Network interface binding changed.\n"
 msgstr "- Cambiada interface da conexión externa.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1125
+#: src/PrefsUnifiedDlg.cpp:1166
 msgid "- External connect port changed.\n"
 msgstr "- Cambiado o porto da conexión externa.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1129
+#: src/PrefsUnifiedDlg.cpp:1170
 msgid "- External connect acceptance changed.\n"
 msgstr "- Cambiada a aceptación da conexión externa.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1133
+#: src/PrefsUnifiedDlg.cpp:1174
 msgid "- External connect interface changed.\n"
 msgstr "- Cambiada interface da conexión externa.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1137
+#: src/PrefsUnifiedDlg.cpp:1178
 msgid "- Protocol obfuscation support changed.\n"
 msgstr "- Cambiada opción da ofuscación do protocolo.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1151
+#: src/PrefsUnifiedDlg.cpp:1193
 #, fuzzy
 msgid "- amuleapi settings changed.\n"
 msgstr "- Idioma cambiado.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1160
+#: src/PrefsUnifiedDlg.cpp:1202
 msgid ""
 "Your Auto-update server list is empty.\n"
 "'Auto-update server list at startup' will be disabled."
@@ -5799,7 +5836,7 @@ msgstr ""
 "A túa lista de servidores para auto-actualizar está baleira.\n"
 "Desactivarase a actualización no inicio."
 
-#: src/PrefsUnifiedDlg.cpp:1171
+#: src/PrefsUnifiedDlg.cpp:1213
 msgid ""
 "You have enabled external connections but have not specified a password.\n"
 "External connections cannot be enabled unless a valid password is specified."
@@ -5807,28 +5844,33 @@ msgstr ""
 "Permítense conexións externas pero non se especificou un contrasinal.\n"
 "As conexións externas non poden ser activadas ate que se especifique un contrasinal válido."
 
-#: src/PrefsUnifiedDlg.cpp:1202
+#: src/PrefsUnifiedDlg.cpp:1246
+#, c-format
+msgid "The amuleapi password could not be saved: %s"
+msgstr ""
+
+#: src/PrefsUnifiedDlg.cpp:1276
 msgid "- Language changed.\n"
 msgstr "- Idioma cambiado.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1207
+#: src/PrefsUnifiedDlg.cpp:1281
 msgid "- Temp folder changed.\n"
 msgstr "- Cartafol temporal cambiado.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1212
+#: src/PrefsUnifiedDlg.cpp:1286
 msgid "- ED2K network enabled.\n"
 msgstr "- Rede eD2K activada.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1245
+#: src/PrefsUnifiedDlg.cpp:1319
 msgid "The shared-file exclusion pattern is not a valid regular expression. The filter has been left disabled."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1247 src/PrefsUnifiedDlg.cpp:1841
+#: src/PrefsUnifiedDlg.cpp:1321 src/PrefsUnifiedDlg.cpp:1921
 #, fuzzy
 msgid "Invalid regular expression"
 msgstr "Versión do protocolo inválida."
 
-#: src/PrefsUnifiedDlg.cpp:1324
+#: src/PrefsUnifiedDlg.cpp:1398
 msgid ""
 "Both eD2k and Kad network are disabled.\n"
 "You won't be able to connect until you enable at least one of them."
@@ -5836,7 +5878,7 @@ msgstr ""
 "Tanto eD2k e Kad están desactivados.\n"
 "Non poderás conectarte ate activar algún dous."
 
-#: src/PrefsUnifiedDlg.cpp:1329
+#: src/PrefsUnifiedDlg.cpp:1403
 msgid ""
 "Kad will not start if your UDP port is disabled.\n"
 "Enable UDP port or disable Kad."
@@ -5844,7 +5886,7 @@ msgstr ""
 "Kad non se iniciará se non está activado o porto UDP.\n"
 "Active o porto UDP ou desactive Kad."
 
-#: src/PrefsUnifiedDlg.cpp:1385
+#: src/PrefsUnifiedDlg.cpp:1459
 msgid ""
 "\n"
 "You MUST restart aMule now.\n"
@@ -5854,71 +5896,71 @@ msgstr ""
 "Debe reiniciar o aMule agora.\n"
 "Se non o reinicia agora, ature coas consecuencias.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1450
+#: src/PrefsUnifiedDlg.cpp:1524
 msgid "Could not register aMule for autostart at login. The autostart store may be read-only."
 msgstr "Non se puido configurar para que aMule arranque ao iniciar sesión. Pode ser que a configuración non permita modificacións."
 
-#: src/PrefsUnifiedDlg.cpp:1452
+#: src/PrefsUnifiedDlg.cpp:1526
 msgid "Could not remove the autostart-at-login entry."
 msgstr "Non se puido quitar o arranque ao inicio da configuración."
 
-#: src/PrefsUnifiedDlg.cpp:1453
+#: src/PrefsUnifiedDlg.cpp:1527
 msgid "Autostart"
 msgstr "Arrancar ao inicio"
 
-#: src/PrefsUnifiedDlg.cpp:1468
+#: src/PrefsUnifiedDlg.cpp:1542
 msgid "Register file type"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1468
+#: src/PrefsUnifiedDlg.cpp:1542
 msgid "Register URL handler"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1476
+#: src/PrefsUnifiedDlg.cpp:1550
 #, c-format
 msgid "aMule only handles eD2k-compatible magnets. If you replace the current magnet handler (%s), BitTorrent magnet links will stop working - aMule cannot download BitTorrent content. Continue?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1481
+#: src/PrefsUnifiedDlg.cpp:1555
 #, c-format
 msgid "Another application currently opens .emulecollection files (%s). Replace it with aMule?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1486
+#: src/PrefsUnifiedDlg.cpp:1560
 #, c-format
 msgid "Another application is currently the default handler for these links (%s). Replace it with aMule?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1511
+#: src/PrefsUnifiedDlg.cpp:1585
 #, fuzzy
 msgid "Could not register aMule for .emulecollection files. The registration store may be read-only."
 msgstr "Non se puido configurar para que aMule arranque ao iniciar sesión. Pode ser que a configuración non permita modificacións."
 
-#: src/PrefsUnifiedDlg.cpp:1513
+#: src/PrefsUnifiedDlg.cpp:1587
 #, fuzzy
 msgid "Could not remove the file type registration."
 msgstr "Non se puido quitar o arranque ao inicio da configuración."
 
-#: src/PrefsUnifiedDlg.cpp:1515
+#: src/PrefsUnifiedDlg.cpp:1589
 #, fuzzy
 msgid "Could not register aMule as the URL handler. The registration store may be read-only."
 msgstr "Non se puido configurar para que aMule arranque ao iniciar sesión. Pode ser que a configuración non permita modificacións."
 
-#: src/PrefsUnifiedDlg.cpp:1517
+#: src/PrefsUnifiedDlg.cpp:1591
 #, fuzzy
 msgid "Could not remove the URL handler registration."
 msgstr "Non se puido quitar o arranque ao inicio da configuración."
 
-#: src/PrefsUnifiedDlg.cpp:1587 src/PrefsUnifiedDlg.cpp:1614
+#: src/PrefsUnifiedDlg.cpp:1661 src/PrefsUnifiedDlg.cpp:1688
 #, fuzzy
 msgid "The web server and aMule API require external connections to be enabled."
 msgstr "Establecido o contrasinal e habilitadas conexións externas."
 
-#: src/PrefsUnifiedDlg.cpp:1597
+#: src/PrefsUnifiedDlg.cpp:1671
 msgid "The aMule web server is deprecated. Consider running the aMule API instead."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1655
+#: src/PrefsUnifiedDlg.cpp:1735
 msgid ""
 "Your Auto-update servers list is in blank.\n"
 "Please fill in at least one URL to point to a valid server.met file.\n"
@@ -5928,66 +5970,66 @@ msgstr ""
 "Introduza polo menos unha URL dun ficheiro server.met.\n"
 "Prema no botón «Listar» para introducir unha URL."
 
-#: src/PrefsUnifiedDlg.cpp:1796
+#: src/PrefsUnifiedDlg.cpp:1876
 msgid "Temporary files"
 msgstr "Ficheiros temporais"
 
-#: src/PrefsUnifiedDlg.cpp:1801
+#: src/PrefsUnifiedDlg.cpp:1881
 msgid "Incoming files"
 msgstr "Ficheiros entrantes"
 
-#: src/PrefsUnifiedDlg.cpp:1806
+#: src/PrefsUnifiedDlg.cpp:1886
 msgid "Online Signatures"
 msgstr "Sinaturas En Liña"
 
-#: src/PrefsUnifiedDlg.cpp:1819
+#: src/PrefsUnifiedDlg.cpp:1899
 #, c-format
 msgid "Choose a folder for %s"
 msgstr "Escolla un cartafol para %s"
 
-#: src/PrefsUnifiedDlg.cpp:1843
+#: src/PrefsUnifiedDlg.cpp:1923
 #, fuzzy, c-format
 msgid "Would exclude %u of %u shared file"
 msgid_plural "Would exclude %u of %u shared files"
 msgstr[0] "Atopado %i ficheiro compartido"
 msgstr[1] "Atopados %i ficheiros compartidos"
 
-#: src/PrefsUnifiedDlg.cpp:1860
+#: src/PrefsUnifiedDlg.cpp:1940
 msgid "Browse for videoplayer"
 msgstr "Atopar o reprodutor de vídeo"
 
-#: src/PrefsUnifiedDlg.cpp:1864
+#: src/PrefsUnifiedDlg.cpp:1944
 msgid "Select browser"
 msgstr "Seleccione o navegador"
 
-#: src/PrefsUnifiedDlg.cpp:1868
+#: src/PrefsUnifiedDlg.cpp:1948
 #, fuzzy
 msgid "Select ffprobe binary"
 msgstr "Seleccione o navegador"
 
-#: src/PrefsUnifiedDlg.cpp:1874
+#: src/PrefsUnifiedDlg.cpp:1954
 #, c-format
 msgid "Executable%s"
 msgstr "Executable%s"
 
-#: src/PrefsUnifiedDlg.cpp:1908
+#: src/PrefsUnifiedDlg.cpp:1988
 msgid "ffprobe not found on PATH or in the standard install locations. Install ffmpeg (which ships ffprobe) or use Browse to pick a binary manually."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1920
+#: src/PrefsUnifiedDlg.cpp:2000
 msgid "Reset the settings on this page to their default values?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1921
+#: src/PrefsUnifiedDlg.cpp:2001
 #, fuzzy
 msgid "Reset to defaults"
 msgstr "Predeterminado"
 
-#: src/PrefsUnifiedDlg.cpp:1948
+#: src/PrefsUnifiedDlg.cpp:2028
 msgid "Edit server list"
 msgstr "Editar a lista dos servidores"
 
-#: src/PrefsUnifiedDlg.cpp:1949
+#: src/PrefsUnifiedDlg.cpp:2029
 msgid ""
 "Add here URL's to download server.met files.\n"
 "Only one url on each line."
@@ -5995,115 +6037,115 @@ msgstr ""
 "Engadir aquí unha URL para descargar unha lista server.met.\n"
 "Só unha url nesta liña."
 
-#: src/PrefsUnifiedDlg.cpp:2004
+#: src/PrefsUnifiedDlg.cpp:2084
 msgid "IP2Country update failed"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2149 src/PrefsUnifiedDlg.cpp:2180
+#: src/PrefsUnifiedDlg.cpp:2229 src/PrefsUnifiedDlg.cpp:2260
 msgid "Data by MaxMind GeoLite2"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2151 src/PrefsUnifiedDlg.cpp:2182
+#: src/PrefsUnifiedDlg.cpp:2231 src/PrefsUnifiedDlg.cpp:2262
 #, fuzzy
 msgid "Custom source"
 msgstr "Fontes completas"
 
-#: src/PrefsUnifiedDlg.cpp:2153 src/PrefsUnifiedDlg.cpp:2184
+#: src/PrefsUnifiedDlg.cpp:2233 src/PrefsUnifiedDlg.cpp:2264
 msgid "Data by DB-IP.com"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2204
+#: src/PrefsUnifiedDlg.cpp:2284
 #, fuzzy, c-format
 msgid "Status: Loaded%s"
 msgstr "Estado:"
 
-#: src/PrefsUnifiedDlg.cpp:2206
+#: src/PrefsUnifiedDlg.cpp:2286
 #, fuzzy, c-format
 msgid "Status: Loaded%s - %s"
 msgstr "Estado:"
 
-#: src/PrefsUnifiedDlg.cpp:2210
+#: src/PrefsUnifiedDlg.cpp:2290
 msgid "Status: Failed to load - click 'Update now' to refresh."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2212
+#: src/PrefsUnifiedDlg.cpp:2292
 msgid "Status: Not found - click 'Update now' to download."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2270 src/PrefsUnifiedDlg.cpp:2294
+#: src/PrefsUnifiedDlg.cpp:2350 src/PrefsUnifiedDlg.cpp:2374
 #, c-format
 msgid "Update delay: %d second"
 msgid_plural "Update delay: %d seconds"
 msgstr[0] "Período de actualización: %d segundo"
 msgstr[1] "Período de actualización: %d segundos"
 
-#: src/PrefsUnifiedDlg.cpp:2278
+#: src/PrefsUnifiedDlg.cpp:2358
 #, c-format
 msgid "Time for average graph: %d minute"
 msgid_plural "Time for average graph: %d minutes"
 msgstr[0] "Tempo medio de gráfico: %d min"
 msgstr[1] "Tempo medio de gráfico: %d min"
 
-#: src/PrefsUnifiedDlg.cpp:2287
+#: src/PrefsUnifiedDlg.cpp:2367
 #, c-format
 msgid "Connections Graph Scale: %d"
 msgstr "Escala gráfica das conexións: %d"
 
-#: src/PrefsUnifiedDlg.cpp:2302
+#: src/PrefsUnifiedDlg.cpp:2382
 #, c-format
 msgid "File Buffer Size: %d byte"
 msgid_plural "File Buffer Size: %d bytes"
 msgstr[0] "Tamaño do búfer dos ficheiros: %d octeto"
 msgstr[1] "Tamaño do búfer dos ficheiros: %d octetos"
 
-#: src/PrefsUnifiedDlg.cpp:2312
+#: src/PrefsUnifiedDlg.cpp:2392
 #, c-format
 msgid "Upload Queue Size: %d client"
 msgid_plural "Upload Queue Size: %d clients"
 msgstr[0] "Tamaño da cola de subida: %d cliente"
 msgstr[1] "Tamaño da cola de subida: %d clientes"
 
-#: src/PrefsUnifiedDlg.cpp:2322
+#: src/PrefsUnifiedDlg.cpp:2402
 #, c-format
 msgid "Server connection refresh interval: %d minute"
 msgid_plural "Server connection refresh interval: %d minutes"
 msgstr[0] "Intervalo de actualización da conexión ao servidor: %d minuto"
 msgstr[1] "Intervalo de actualización da conexión ao servidor: %d minutos"
 
-#: src/PrefsUnifiedDlg.cpp:2327
+#: src/PrefsUnifiedDlg.cpp:2407
 msgid "Server connection refresh interval: Disabled"
 msgstr "Intervalo de actualización da conexión ao servidor. Desactivada"
 
-#: src/PrefsUnifiedDlg.cpp:2371
+#: src/PrefsUnifiedDlg.cpp:2451
 msgid "disabled"
 msgstr "desactivado"
 
-#: src/PrefsUnifiedDlg.cpp:2397
+#: src/PrefsUnifiedDlg.cpp:2477
 #, c-format
 msgid "Execute command on '%s' event"
 msgstr "Executar unha orde no evento «%s»"
 
-#: src/PrefsUnifiedDlg.cpp:2404
+#: src/PrefsUnifiedDlg.cpp:2484
 msgid "Enable command execution on core"
 msgstr "Activar execución de ordes no núcleo"
 
-#: src/PrefsUnifiedDlg.cpp:2416
+#: src/PrefsUnifiedDlg.cpp:2496
 msgid "Core command:"
 msgstr "Orde do núcleo:"
 
-#: src/PrefsUnifiedDlg.cpp:2432
+#: src/PrefsUnifiedDlg.cpp:2512
 msgid "Enable command execution on GUI"
 msgstr "Activar execución de ordes na interface gráfica"
 
-#: src/PrefsUnifiedDlg.cpp:2444
+#: src/PrefsUnifiedDlg.cpp:2524
 msgid "GUI command:"
 msgstr "Orde da interface gráfica:"
 
-#: src/PrefsUnifiedDlg.cpp:2460
+#: src/PrefsUnifiedDlg.cpp:2540
 msgid "The following variables will be replaced:"
 msgstr "As seguintes variables serán substituídas:"
 
-#: src/PrefsUnifiedDlg.cpp:2628
+#: src/PrefsUnifiedDlg.cpp:2708
 msgid ""
 "The following folders look like system or sensitive locations:\n"
 "\n"
@@ -6111,37 +6153,37 @@ msgstr ""
 "Estas carpetas semellan parte do sistema, ou que poden ser confidenciais:\n"
 "\n"
 
-#: src/PrefsUnifiedDlg.cpp:2633
+#: src/PrefsUnifiedDlg.cpp:2713
 msgid "Sharing them recursively will publish every file underneath on the eD2k/Kad networks. Do you really want to do this?"
 msgstr "Compartir de xeito recursivo publicará calquera ficheiro que teñan debaixo nas redes eD2k e Kad. Comprobe todo ben antes de continuar."
 
-#: src/PrefsUnifiedDlg.cpp:2636
+#: src/PrefsUnifiedDlg.cpp:2716
 msgid "Confirm shared folders"
 msgstr "Confirmar e compartir cartafoles"
 
-#: src/PrefsUnifiedDlg.cpp:2664
+#: src/PrefsUnifiedDlg.cpp:2744
 msgid "Reloading shared files..."
 msgstr "Recargando os ficheiros compartidos..."
 
-#: src/PrefsUnifiedDlg.cpp:2665
+#: src/PrefsUnifiedDlg.cpp:2745
 msgid "Scanning for subdirectories..."
 msgstr "Buscando subdirectorios..."
 
-#: src/PrefsUnifiedDlg.cpp:2666
+#: src/PrefsUnifiedDlg.cpp:2746
 msgid "Updating shared folders"
 msgstr "Actualizando os cartafoles compartidos"
 
-#: src/PrefsUnifiedDlg.cpp:2693
+#: src/PrefsUnifiedDlg.cpp:2773
 #, c-format
 msgid "Scanned %u directories..."
 msgstr "Buscáronse %u directorios..."
 
-#: src/PrefsUnifiedDlg.cpp:2743
+#: src/PrefsUnifiedDlg.cpp:2823
 #, c-format
 msgid "Reloading shared files: %u files scanned"
 msgstr "Recargouse a lista de ficheiros compartidos: atopáronse %u ficheiros"
 
-#: src/PrefsUnifiedDlg.cpp:2793
+#: src/PrefsUnifiedDlg.cpp:2873
 #, fuzzy
 msgid "Shared folder"
 msgstr "Cartafoles compartidos"

--- a/po/he.po
+++ b/po/he.po
@@ -9,8 +9,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-28 12:12+0200\n"
-"PO-Revision-Date: 2026-07-27 10:23+0000\n"
+"POT-Creation-Date: 2026-07-28 08:06+0200\n"
+"PO-Revision-Date: 2026-07-27 11:39+0000\n"
 "Last-Translator: Peace Kramer <kpeace1@gmail.com>\n"
 "Language-Team: Hebrew\n"
 "Language: he\n"
@@ -140,7 +140,7 @@ msgstr ""
 msgid "Not now"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:422 src/amuleDlg.cpp:665
+#: src/AppImageIntegration.cpp:422 src/amuleDlg.cpp:600
 msgid "Don't ask again"
 msgstr ""
 
@@ -199,156 +199,156 @@ msgstr "פתיחת הקובץ %s·(%s נכשלה"
 msgid "WARNING: You can't add yourself as a source for an eD2k link while having a lowid."
 msgstr ""
 
-#: src/amule.cpp:301
+#: src/amule.cpp:300
 msgid "Now, exiting main app..."
 msgstr ""
 
-#: src/amule.cpp:331
+#: src/amule.cpp:330
 #, c-format
 msgid "Terminating amuleweb instance with pid '%d' ... "
 msgstr ""
 
-#: src/amule.cpp:335
+#: src/amule.cpp:334
 #, c-format
 msgid "Killing amuleweb instance with pid '%d' ... "
 msgstr ""
 
-#: src/amule.cpp:337 src/amule.cpp:350 src/ClientRef.cpp:180
-#: src/SearchDlg.cpp:1041 src/ServerListCtrl.cpp:98
+#: src/amule.cpp:336 src/amule.cpp:349 src/ClientRef.cpp:180
+#: src/SearchDlg.cpp:880 src/ServerListCtrl.cpp:98
 msgid "Failed"
 msgstr "נכשל"
 
-#: src/amule.cpp:344
+#: src/amule.cpp:343
 #, c-format
 msgid "Terminating amuleapi instance with pid '%d' ... "
 msgstr ""
 
-#: src/amule.cpp:348
+#: src/amule.cpp:347
 #, c-format
 msgid "Killing amuleapi instance with pid '%d' ... "
 msgstr ""
 
-#: src/amule.cpp:356
+#: src/amule.cpp:355
 msgid "aMule OnExit: Terminating core."
 msgstr ""
 
-#: src/amule.cpp:467
+#: src/amule.cpp:466
 #, fuzzy
 msgid "aMule shutdown completed."
 msgstr "הורדה הסתיימה"
 
-#: src/amule.cpp:471
+#: src/amule.cpp:470
 msgid "Memory debug results for aMule exit:"
 msgstr ""
 
-#: src/amule.cpp:652
+#: src/amule.cpp:651
 #, c-format
 msgid "Binding aMule's peer-to-peer traffic to interface: %s (HTTP updates use the default route)"
 msgstr ""
 
-#: src/amule.cpp:656
+#: src/amule.cpp:655
 #, c-format
 msgid "Binding all network traffic to interface: %s"
 msgstr ""
 
-#: src/amule.cpp:660
+#: src/amule.cpp:659
 #, c-format
 msgid "WARNING: configured network interface '%s' was not found - traffic is NOT bound to it and may leave via the default route. Check the interface name in Preferences."
 msgstr ""
 
-#: src/amule.cpp:666
+#: src/amule.cpp:665
 #, c-format
 msgid "WARNING: binding to network interface '%s' requires elevated privileges and was NOT applied - traffic may leave via the default route. Grant the capability (e.g. 'sudo setcap cap_net_raw+ep' on the aMule binary) or run with sufficient privileges."
 msgstr ""
 
-#: src/amule.cpp:674
+#: src/amule.cpp:673
 #, c-format
 msgid "WARNING: could not bind to network interface '%s' - traffic may leave via the default route."
 msgstr ""
 
-#: src/amule.cpp:733
+#: src/amule.cpp:732
 msgid "Your locale has been changed to System Default due to a configuration change. Sorry."
 msgstr ""
 
-#: src/amule.cpp:735 src/amule.cpp:1589 src/CatDialog.cpp:128
+#: src/amule.cpp:734 src/amule.cpp:1581 src/CatDialog.cpp:128
 #: src/CatDialog.cpp:136 src/CatDialog.cpp:149 src/ServerList.cpp:366
 #: src/ServerListCtrl.cpp:152
 msgid "Info"
 msgstr "מידע"
 
-#: src/amule.cpp:742
+#: src/amule.cpp:741
 #, fuzzy
 msgid ""
 "\n"
 "EC configuration"
 msgstr "אישרור יצאיה"
 
-#: src/amule.cpp:745
+#: src/amule.cpp:744
 #, fuzzy
 msgid "Password set and external connections enabled."
 msgstr "גישה חיצונית חדשה התקבלה"
 
-#: src/amule.cpp:755 src/KadDlg.cpp:176 src/KadDlg.cpp:185
-#: src/PrefsUnifiedDlg.cpp:1461 src/SharedFilesCtrl.cpp:476
+#: src/amule.cpp:754 src/KadDlg.cpp:176 src/KadDlg.cpp:185
+#: src/PrefsUnifiedDlg.cpp:1387 src/SharedFilesCtrl.cpp:476
 msgid "WARNING"
 msgstr "אזהרה"
 
-#: src/amule.cpp:992
+#: src/amule.cpp:991
 #, fuzzy
 msgid "Network bootstrap"
 msgstr "רשתות"
 
-#: src/amule.cpp:997
+#: src/amule.cpp:996
 msgid ""
 "aMule has detected missing network bootstrap files.\n"
 "Select which ones to download:"
 msgstr ""
 
-#: src/amule.cpp:1006 src/FirstRunWizard.cpp:411
+#: src/amule.cpp:1005 src/FirstRunWizard.cpp:411
 msgid "eD2k server list (server.met)"
 msgstr ""
 
-#: src/amule.cpp:1013 src/FirstRunWizard.cpp:416
+#: src/amule.cpp:1012 src/FirstRunWizard.cpp:416
 msgid "Kad bootstrap nodes (nodes.dat)"
 msgstr ""
 
-#: src/amule.cpp:1103
+#: src/amule.cpp:1102
 #, c-format
 msgid "web server running on pid %d"
 msgstr ""
 
-#: src/amule.cpp:1116
+#: src/amule.cpp:1115
 msgid "You requested to run web server on startup, but the amuleweb binary cannot be run. Please install the package containing aMule web server, or build aMule from source with -DBUILD_WEBSERVER=YES and install it."
 msgstr ""
 
-#: src/amule.cpp:1121 src/amule.cpp:1185 src/amule.cpp:1299 src/amule.cpp:1601
+#: src/amule.cpp:1120 src/amule.cpp:1177 src/amule.cpp:1291 src/amule.cpp:1593
 #: src/amule-remote-gui.cpp:603 src/amule-remote-gui.cpp:671
 #: src/amule-remote-gui.cpp:709 src/amule-remote-gui.cpp:1282
 #: src/amule-remote-gui.cpp:1345 src/amule-remote-gui.cpp:1372
-#: src/DownloadQueue.cpp:1481 src/PrefsUnifiedDlg.cpp:1247
+#: src/DownloadQueue.cpp:1481
 msgid "ERROR"
 msgstr ""
 
-#: src/amule.cpp:1174
+#: src/amule.cpp:1166
 #, fuzzy, c-format
 msgid "amuleapi running on pid %d"
 msgstr "אימיול פועל"
 
-#: src/amule.cpp:1180
+#: src/amule.cpp:1172
 msgid "You requested to run amuleapi on startup, but the amuleapi binary cannot be run. Please install the package containing aMule's REST API server, or build aMule from source with -DBUILD_AMULEAPI=YES and install it."
 msgstr ""
 
-#: src/amule.cpp:1267
+#: src/amule.cpp:1259
 #, c-format
 msgid "Could not bind ports to the specified address: %s"
 msgstr ""
 
-#: src/amule.cpp:1291
+#: src/amule.cpp:1283
 #, c-format
 msgid "Port %u is not available. You will be LOWID\n"
 msgstr ""
 
-#: src/amule.cpp:1296
+#: src/amule.cpp:1288
 #, c-format
 msgid ""
 "Port %u is not available!\n"
@@ -358,185 +358,185 @@ msgid ""
 "Check your network to make sure the port is open for output and input."
 msgstr ""
 
-#: src/amule.cpp:1393
+#: src/amule.cpp:1385
 msgid "Failed to create OnlineSig File"
 msgstr ""
 
-#: src/amule.cpp:1401
+#: src/amule.cpp:1393
 msgid "Failed to create aMule OnlineSig File"
 msgstr ""
 
-#: src/amule.cpp:1564
+#: src/amule.cpp:1556
 msgid "The selected locale seems not to be installed on your box. (Note: I'll try to set it anyway)"
 msgstr ""
 
-#: src/amule.cpp:1574
+#: src/amule.cpp:1566
 #, c-format
 msgid "This is the first time you run aMule %s"
 msgstr ""
 
-#: src/amule.cpp:1577
+#: src/amule.cpp:1569
 msgid "This version is a testing version, updated daily, and\n"
 msgstr ""
 
-#: src/amule.cpp:1578
+#: src/amule.cpp:1570
 msgid "we give no warranty it won't break anything, burn your house,\n"
 msgstr ""
 
-#: src/amule.cpp:1579
+#: src/amule.cpp:1571
 msgid "or kill your dog. But it *should* be safe to use anyway.\n"
 msgstr ""
 
-#: src/amule.cpp:1584
+#: src/amule.cpp:1576
 msgid "More information, support and new releases can found at our homepage,\n"
 msgstr ""
 
-#: src/amule.cpp:1585
+#: src/amule.cpp:1577
 msgid "at https://amule-org.github.io, or in our IRC channel #aMule at irc.libera.chat.\n"
 msgstr ""
 
-#: src/amule.cpp:1587
+#: src/amule.cpp:1579
 msgid "Feel free to report any bugs to https://github.com/amule-org/amule/issues"
 msgstr "תרגיש חופשי לדוואח על כל שגיאה ל https://github.com/amule-org/amule/issues"
 
-#: src/amule.cpp:1599
+#: src/amule.cpp:1591
 msgid ""
 "The folder for Online Signature files you specified is INVALID!\n"
 " OnlineSignature will be DISABLED until you fix it on preferences."
 msgstr ""
 
-#: src/amule.cpp:1662
+#: src/amule.cpp:1654
 #, fuzzy
 msgid "Server hostname notified"
 msgstr "שם שרת:"
 
-#: src/amule.cpp:2039
+#: src/amule.cpp:2031
 #, c-format
 msgid "Disk space preallocation for file '%s' failed: %s"
 msgstr ""
 
-#: src/amule.cpp:2168
+#: src/amule.cpp:2160
 msgid "ERROR: can't open logfile"
 msgstr "שגיאה: לא יכול לפתוח קובץ יומן."
 
-#: src/amule.cpp:2172
+#: src/amule.cpp:2164
 msgid "WARNING: logfile is empty. Something is wrong."
 msgstr ""
 
-#: src/amule.cpp:2189
+#: src/amule.cpp:2181
 msgid "Log has been reset"
 msgstr "היומן אופס."
 
-#: src/amule.cpp:2213
+#: src/amule.cpp:2205
 #, c-format
 msgid "ServerMessage: %s"
 msgstr ""
 
-#: src/amule.cpp:2256 src/IP2Country.cpp:220 src/IPFilter.cpp:514
+#: src/amule.cpp:2248 src/IP2Country.cpp:220 src/IPFilter.cpp:514
 #: src/ServerList.cpp:875
 #, c-format
 msgid "Skipped download of %s, because requested file is not newer."
 msgstr ""
 
-#: src/amule.cpp:2259
+#: src/amule.cpp:2251
 msgid "Failed to download the nodes list."
 msgstr ""
 
-#: src/amule.cpp:2322
+#: src/amule.cpp:2314
 msgid "Failed to open the downloaded version check file"
 msgstr ""
 
-#: src/amule.cpp:2325 src/amule.cpp:2344
+#: src/amule.cpp:2317 src/amule.cpp:2336
 msgid "Corrupted version check file"
 msgstr ""
 
-#: src/amule.cpp:2367
+#: src/amule.cpp:2359
 msgid "You are using an outdated version of aMule!"
 msgstr ""
 
-#: src/amule.cpp:2369
+#: src/amule.cpp:2361
 #, c-format
 msgid "Your aMule version is %i.%i.%i and the latest version is %li.%li.%li"
 msgstr ""
 
-#: src/amule.cpp:2373
+#: src/amule.cpp:2365
 msgid "The latest version can always be found at https://github.com/amule-org/amule/releases/latest"
 msgstr ""
 
-#: src/amule.cpp:2376
+#: src/amule.cpp:2368
 #, c-format
 msgid "WARNING: Your aMuled version is outdated: %i.%i.%i < %li.%li.%li"
 msgstr ""
 
-#: src/amule.cpp:2382
+#: src/amule.cpp:2374
 msgid "Your copy of aMule is up to date."
 msgstr ""
 
-#: src/amule.cpp:2389
+#: src/amule.cpp:2381
 msgid "Failed to download the version check file"
 msgstr ""
 
-#: src/amule.cpp:2558 src/amule-remote-gui.cpp:1133
+#: src/amule.cpp:2550 src/amule-remote-gui.cpp:1133
 #, c-format
 msgid "Users: %s | Files: %s"
 msgstr ""
 
-#: src/amule.cpp:2559 src/amule-remote-gui.cpp:1134
+#: src/amule.cpp:2551 src/amule-remote-gui.cpp:1134
 #, c-format
 msgid "Users: E: %s K: %s | Files: E: %s K: %s"
 msgstr ""
 
-#: src/amule.cpp:2573 src/amule-remote-gui.cpp:1147
+#: src/amule.cpp:2565 src/amule-remote-gui.cpp:1147
 msgid "No networks selected"
 msgstr ""
 
-#: src/amule.cpp:2641 src/TextClient.cpp:903
+#: src/amule.cpp:2633 src/TextClient.cpp:903
 msgid "with LowID"
 msgstr "עם מ\"ז נמוך (LowID)"
 
-#: src/amule.cpp:2641 src/TextClient.cpp:904
+#: src/amule.cpp:2633 src/TextClient.cpp:904
 msgid "with HighID"
 msgstr "עם מ\"ז גבוהה (HighID)"
 
-#: src/amule.cpp:2643
+#: src/amule.cpp:2635
 #, c-format
 msgid "Connected to %s %s"
 msgstr ""
 
-#: src/amule.cpp:2648
+#: src/amule.cpp:2640
 #, c-format
 msgid "Connecting to %s"
 msgstr ""
 
-#: src/amule.cpp:2650
+#: src/amule.cpp:2642
 msgid "Disconnected from eD2k"
 msgstr ""
 
-#: src/amule.cpp:2659
+#: src/amule.cpp:2651
 msgid "Kad started."
 msgstr "קאד התחיל."
 
-#: src/amule.cpp:2661
+#: src/amule.cpp:2653
 msgid "Kad stopped."
 msgstr "קאד נעצר."
 
-#: src/amule.cpp:2669
+#: src/amule.cpp:2661
 msgid "Connected to Kad (ok)"
 msgstr "קאד מחובר (בסדר)"
 
-#: src/amule.cpp:2671
+#: src/amule.cpp:2663
 msgid "Connected to Kad (firewalled)"
 msgstr "קאד מחובר (מאחורי חומת אש)"
 
-#: src/amule.cpp:2675
+#: src/amule.cpp:2667
 msgid "Disconnected from Kad"
 msgstr "מנותק מקאד."
 
-#: src/amule.cpp:2707
+#: src/amule.cpp:2699
 msgid "Kad network cannot be used if UDP port is disabled on preferences, not starting."
 msgstr "אי אפשר להשתמש ברשת הקאד אם מוואת UDP מבוטלת בהעדפות, לא התחיל."
 
-#: src/amule.cpp:2711
+#: src/amule.cpp:2703
 msgid "Kad network disabled on preferences, not connecting."
 msgstr "קאד מבוטל בהעדפות, לא מתחבר."
 
@@ -561,68 +561,30 @@ msgstr ""
 msgid "ERROR: %s"
 msgstr "אירעה שגיאה: %s"
 
-#: src/amuleDlg.cpp:250
+#: src/amuleDlg.cpp:236
 #, c-format
 msgid "This is aMule %s based on eMule."
 msgstr "זהו אֵימיול %s המבוסס על אִמיול"
 
-#: src/amuleDlg.cpp:251
+#: src/amuleDlg.cpp:237
 #, c-format
 msgid "Running on %s"
 msgstr "פועל על %s"
 
-#: src/amuleDlg.cpp:253
+#: src/amuleDlg.cpp:239
 msgid "Visit https://github.com/amule-org/amule/releases/latest to check if a new version is available."
 msgstr "בקר ב https://github.com/amule-org/amule/releases/latest כדי לבדוק האם ישנה גירסה חדישה זמינה."
 
-#: src/amuleDlg.cpp:282
+#: src/amuleDlg.cpp:268
 msgid "FATAL ERROR: Failed to create Timer"
 msgstr ""
 
-#: src/amuleDlg.cpp:361 src/amuleDlg.cpp:1810 src/amuleDlg.cpp:2056
-#: src/muuli_wdr.cpp:1492 src/muuli_wdr.cpp:3439
-msgid "Networks"
-msgstr "רשתות"
-
-#: src/amuleDlg.cpp:362 src/amuleDlg.cpp:1816 src/muuli_wdr.cpp:3440
-msgid "Searches"
-msgstr "חיפושים"
-
-#: src/amuleDlg.cpp:363 src/amuleDlg.cpp:1822 src/DownloadListCtrl.cpp:740
-#: src/muuli_wdr.cpp:392 src/muuli_wdr.cpp:1585 src/muuli_wdr.cpp:3441
-#: src/Statistics.cpp:829
-msgid "Downloads"
-msgstr "הורדות"
-
-#: src/amuleDlg.cpp:364 src/amuleDlg.cpp:1828 src/muuli_wdr.cpp:3315
-msgid "Shared files"
-msgstr ""
-
-#: src/amuleDlg.cpp:365 src/amuleDlg.cpp:1834 src/muuli_wdr.cpp:2947
-#: src/muuli_wdr.cpp:3397 src/muuli_wdr.cpp:3444
-msgid "Messages"
-msgstr "הודעות"
-
-#: src/amuleDlg.cpp:366 src/amuleDlg.cpp:1840 src/muuli_wdr.cpp:3445
-#: src/PrefsUnifiedDlg.cpp:314 src/Statistics.cpp:779 src/Statistics.cpp:1235
-msgid "Statistics"
-msgstr "סטטיסטיקות"
-
-#: src/amuleDlg.cpp:368 src/amuleDlg.cpp:1847 src/muuli_wdr.cpp:3447
-#: src/PrefsUnifiedDlg.cpp:330 src/utils/wxCas/src/wxcasprefs.cpp:39
-msgid "Preferences"
-msgstr "העדפות"
-
-#: src/amuleDlg.cpp:371
-msgid "Navigate"
-msgstr ""
-
-#: src/amuleDlg.cpp:657
+#: src/amuleDlg.cpp:592
 #, fuzzy
 msgid "New version available"
 msgstr "לא זמין"
 
-#: src/amuleDlg.cpp:661
+#: src/amuleDlg.cpp:596
 #, c-format
 msgid ""
 "A new version of aMule (%s) is available.\n"
@@ -632,186 +594,219 @@ msgid ""
 "Would you like to open the download page?"
 msgstr ""
 
-#: src/amuleDlg.cpp:743
+#: src/amuleDlg.cpp:678
 msgid "aMule dialog destroyed"
 msgstr ""
 
-#: src/amuleDlg.cpp:766 src/DataToText.cpp:68 src/IPFilter.cpp:547
+#: src/amuleDlg.cpp:701 src/DataToText.cpp:68 src/IPFilter.cpp:547
 msgid "Connecting"
 msgstr "מתחבר"
 
-#: src/amuleDlg.cpp:958
+#: src/amuleDlg.cpp:893
 msgid "eD2k: Connecting"
 msgstr ""
 
-#: src/amuleDlg.cpp:962
+#: src/amuleDlg.cpp:897
 msgid "eD2k: Disconnected"
 msgstr ""
 
-#: src/amuleDlg.cpp:968
+#: src/amuleDlg.cpp:903
 msgid "Kad: Firewalled"
 msgstr "קאד: חסום חומתאש"
 
-#: src/amuleDlg.cpp:972
+#: src/amuleDlg.cpp:907
 msgid "Kad: Connected"
 msgstr "קאד: מחובר"
 
-#: src/amuleDlg.cpp:977
+#: src/amuleDlg.cpp:912
 msgid "Kad: Connecting"
 msgstr "קאד: מתחבר"
 
-#: src/amuleDlg.cpp:981
+#: src/amuleDlg.cpp:916
 msgid "Kad: Off"
 msgstr "קאד: מכובה"
 
-#: src/amuleDlg.cpp:1029 src/DownloadListCtrl.cpp:505
+#: src/amuleDlg.cpp:964 src/DownloadListCtrl.cpp:505
 #: src/DownloadListCtrl.cpp:749 src/FriendListCtrl.cpp:180
 #: src/muuli_wdr.cpp:731 src/muuli_wdr.cpp:782 src/muuli_wdr.cpp:846
-#: src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2252 src/muuli_wdr.cpp:2337
-#: src/muuli_wdr.cpp:3085 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
+#: src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2224 src/muuli_wdr.cpp:2309
+#: src/muuli_wdr.cpp:3057 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
 #: src/ServerListCtrl.cpp:606 src/TransferWnd.cpp:378
 #: src/utils/wxCas/src/wxcasprefs.cpp:235
 msgid "Cancel"
 msgstr "ביטול"
 
-#: src/amuleDlg.cpp:1030
+#: src/amuleDlg.cpp:965
 msgid "Stop the current connection attempts"
 msgstr "הפסק את ניסיונות ההתחברות הנוכחיים"
 
-#: src/amuleDlg.cpp:1035 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976
-#: src/muuli_wdr.cpp:2475
+#: src/amuleDlg.cpp:970 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976
+#: src/muuli_wdr.cpp:2447
 msgid "Disconnect"
 msgstr "מנותק"
 
-#: src/amuleDlg.cpp:1036
+#: src/amuleDlg.cpp:971
 msgid "Disconnect from the currently connected networks"
 msgstr "התנתק מהרשתות שאליהם אתה מחובר כעת"
 
-#: src/amuleDlg.cpp:1041 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979
-#: src/muuli_wdr.cpp:2630 src/muuli_wdr.cpp:3082 src/muuli_wdr.cpp:3437
+#: src/amuleDlg.cpp:976 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979
+#: src/muuli_wdr.cpp:2602 src/muuli_wdr.cpp:3054 src/muuli_wdr.cpp:3409
 msgid "Connect"
 msgstr "התחבר"
 
-#: src/amuleDlg.cpp:1042
+#: src/amuleDlg.cpp:977
 msgid "Connect to the currently enabled networks"
 msgstr "התחבר לרשתות שמאופשרות כרגע"
 
-#: src/amuleDlg.cpp:1154
+#: src/amuleDlg.cpp:1089
 #, fuzzy, c-format
 msgid "Up: %.1f%s (%.1f) | Down: %.1f%s (%.1f)"
 msgstr "מעלה: %.1f(%.1f) | מוריד: %.1f(%.1f)"
 
-#: src/amuleDlg.cpp:1156 src/amuleDlg.cpp:1158 src/amuleDlg.cpp:1162
-#: src/amuleDlg.cpp:1164 src/amuleDlg.cpp:1175 src/amuleDlg.cpp:1177
+#: src/amuleDlg.cpp:1091 src/amuleDlg.cpp:1093 src/amuleDlg.cpp:1097
+#: src/amuleDlg.cpp:1099 src/amuleDlg.cpp:1110 src/amuleDlg.cpp:1112
 #: src/MuleTrayIcon.cpp:796 src/MuleTrayIcon.cpp:799
 #, fuzzy
 msgid " MB/s"
 msgstr "מ\"ב/ש"
 
-#: src/amuleDlg.cpp:1156 src/amuleDlg.cpp:1158 src/amuleDlg.cpp:1162
-#: src/amuleDlg.cpp:1164 src/amuleDlg.cpp:1175 src/amuleDlg.cpp:1177
+#: src/amuleDlg.cpp:1091 src/amuleDlg.cpp:1093 src/amuleDlg.cpp:1097
+#: src/amuleDlg.cpp:1099 src/amuleDlg.cpp:1110 src/amuleDlg.cpp:1112
 #: src/MuleTrayIcon.cpp:796 src/MuleTrayIcon.cpp:799
 #: src/utils/wxCas/src/wxcasframe.cpp:1041
 msgid " kB/s"
 msgstr " ק\"ב/ש"
 
-#: src/amuleDlg.cpp:1161
+#: src/amuleDlg.cpp:1096
 #, fuzzy, c-format
 msgid "Up: %.1f%s | Down: %.1f%s"
 msgstr "מעלה: %.1f | מוריד: %.1f"
 
-#: src/amuleDlg.cpp:1193
+#: src/amuleDlg.cpp:1128
 #, c-format
 msgid "aMule (%s | Connected)"
 msgstr "אימיול (%s | מחובר)"
 
-#: src/amuleDlg.cpp:1195
+#: src/amuleDlg.cpp:1130
 #, c-format
 msgid "aMule (%s | Disconnected)"
 msgstr "אימיול (%s | מנותק)"
 
-#: src/amuleDlg.cpp:1248
+#: src/amuleDlg.cpp:1183
 #, fuzzy, c-format
 msgid "Do you really want to exit %s?"
 msgstr "האם אתה באמת רוצה לצאת מאימיול?"
 
-#: src/amuleDlg.cpp:1250
+#: src/amuleDlg.cpp:1185
 msgid "Exit confirmation"
 msgstr "אישרור יצאיה"
 
-#: src/amuleDlg.cpp:1613
+#: src/amuleDlg.cpp:1548
 msgid "Launch Command: "
 msgstr ""
 
-#: src/amuleDlg.cpp:1632 src/muuli_wdr.cpp:1972 src/Preferences.cpp:979
+#: src/amuleDlg.cpp:1567 src/muuli_wdr.cpp:1971 src/Preferences.cpp:951
 msgid "- default -"
 msgstr ""
 
-#: src/amuleDlg.cpp:1660
+#: src/amuleDlg.cpp:1595
 #, c-format
 msgid "Skin directory '%s' does not exist"
 msgstr "ספריית הסקינים '%s' לא קיימת"
 
-#: src/amuleDlg.cpp:1663
+#: src/amuleDlg.cpp:1598
 #, c-format
 msgid "WARNING: Unable to open skin file '%s' for read"
 msgstr ""
 
-#: src/amuleDlg.cpp:1814 src/muuli_wdr.cpp:3439
+#: src/amuleDlg.cpp:1722 src/amuleDlg.cpp:1968 src/muuli_wdr.cpp:1485
+#: src/muuli_wdr.cpp:3411
+msgid "Networks"
+msgstr "רשתות"
+
+#: src/amuleDlg.cpp:1726 src/muuli_wdr.cpp:3411
 msgid "Networks Window"
 msgstr "חלון הרשתות"
 
-#: src/amuleDlg.cpp:1820 src/muuli_wdr.cpp:3440
+#: src/amuleDlg.cpp:1728 src/muuli_wdr.cpp:3412
+msgid "Searches"
+msgstr "חיפושים"
+
+#: src/amuleDlg.cpp:1732 src/muuli_wdr.cpp:3412
 msgid "Searches Window"
 msgstr "חלון החיפושים"
 
-#: src/amuleDlg.cpp:1826 src/muuli_wdr.cpp:3441
+#: src/amuleDlg.cpp:1734 src/DownloadListCtrl.cpp:740 src/muuli_wdr.cpp:392
+#: src/muuli_wdr.cpp:1578 src/muuli_wdr.cpp:3413 src/Statistics.cpp:829
+msgid "Downloads"
+msgstr "הורדות"
+
+#: src/amuleDlg.cpp:1738 src/muuli_wdr.cpp:3413
 #, fuzzy
 msgid "Downloads Window"
 msgstr "מוריד מהרשת"
 
-#: src/amuleDlg.cpp:1832 src/muuli_wdr.cpp:3443
+#: src/amuleDlg.cpp:1740 src/muuli_wdr.cpp:3287
+msgid "Shared files"
+msgstr ""
+
+#: src/amuleDlg.cpp:1744 src/muuli_wdr.cpp:3415
 msgid "Shared Files Window"
 msgstr "חלון הקבצים המשותפים"
 
-#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3444
+#: src/amuleDlg.cpp:1746 src/muuli_wdr.cpp:2919 src/muuli_wdr.cpp:3369
+#: src/muuli_wdr.cpp:3416
+msgid "Messages"
+msgstr "הודעות"
+
+#: src/amuleDlg.cpp:1750 src/muuli_wdr.cpp:3416
 msgid "Messages Window"
 msgstr "חלון ההודעות"
 
-#: src/amuleDlg.cpp:1844 src/muuli_wdr.cpp:3445
+#: src/amuleDlg.cpp:1752 src/muuli_wdr.cpp:3417 src/PrefsUnifiedDlg.cpp:312
+#: src/Statistics.cpp:779 src/Statistics.cpp:1235
+msgid "Statistics"
+msgstr "סטטיסטיקות"
+
+#: src/amuleDlg.cpp:1756 src/muuli_wdr.cpp:3417
 msgid "Statistics Graph Window"
 msgstr "חלון גרפי הסטטיסטיקה"
 
-#: src/amuleDlg.cpp:1851 src/muuli_wdr.cpp:3447
+#: src/amuleDlg.cpp:1759 src/muuli_wdr.cpp:3419 src/PrefsUnifiedDlg.cpp:328
+#: src/utils/wxCas/src/wxcasprefs.cpp:39
+msgid "Preferences"
+msgstr "העדפות"
+
+#: src/amuleDlg.cpp:1763 src/muuli_wdr.cpp:3419
 msgid "Preferences Settings Window"
 msgstr "חלון הגדרת ההעדפות"
 
-#: src/amuleDlg.cpp:1854 src/muuli_wdr.cpp:3448
+#: src/amuleDlg.cpp:1766 src/muuli_wdr.cpp:3420
 msgid "Import"
 msgstr "ייבא"
 
-#: src/amuleDlg.cpp:1858 src/muuli_wdr.cpp:3448
+#: src/amuleDlg.cpp:1770 src/muuli_wdr.cpp:3420
 msgid "The partfile importer tool"
 msgstr "כלי הייבא עבור קובץ-החלקים"
 
-#: src/amuleDlg.cpp:1861 src/muuli_wdr.cpp:3449
+#: src/amuleDlg.cpp:1773 src/muuli_wdr.cpp:3421
 #: src/utils/aLinkCreator/src/alcframe.cpp:262
 msgid "About"
 msgstr "אודות"
 
-#: src/amuleDlg.cpp:1861 src/muuli_wdr.cpp:3449
+#: src/amuleDlg.cpp:1773 src/muuli_wdr.cpp:3421
 msgid "About/Help"
 msgstr "אודות/עזרה"
 
-#: src/amuleDlg.cpp:2059
+#: src/amuleDlg.cpp:1971
 msgid "eD2k network"
 msgstr ""
 
-#: src/amuleDlg.cpp:2062
+#: src/amuleDlg.cpp:1974
 msgid "Kad network"
 msgstr ""
 
-#: src/amuleDlg.cpp:2062
+#: src/amuleDlg.cpp:1974
 msgid "No network"
 msgstr ""
 
@@ -944,7 +939,7 @@ msgstr "קובץ לא נמצא."
 msgid "The core rejected these shared folders:%s"
 msgstr ""
 
-#: src/amule-remote-gui.cpp:1336 src/ExternalConn.cpp:2346
+#: src/amule-remote-gui.cpp:1336 src/ExternalConn.cpp:2345
 msgid "Invalid link or already on list."
 msgstr "קישור לא תקף או שכבר נמצא ברשימה."
 
@@ -960,7 +955,7 @@ msgstr ""
 #: src/ClientDetailDialog.cpp:123 src/DataToText.cpp:61 src/DataToText.cpp:86
 #: src/DataToText.cpp:101 src/DataToText.cpp:136 src/DataToText.cpp:165
 #: src/DownloadListCtrl.cpp:1172 src/DownloadListCtrl.cpp:1185
-#: src/DownloadListCtrl.cpp:1196 src/ExternalConn.cpp:609
+#: src/DownloadListCtrl.cpp:1196 src/ExternalConn.cpp:608
 #: src/FileDetailDialog.cpp:203 src/FileDetailDialog.cpp:235
 #: src/FileDetailDialog.cpp:242 src/GenericClientListCtrl.cpp:1171
 #: src/GenericClientListCtrl.cpp:1182 src/GenericClientListCtrl.cpp:1192
@@ -1347,19 +1342,19 @@ msgstr "אוטומטי [גבוה]"
 msgid "Very low"
 msgstr "מאוד נמוך"
 
-#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:743 src/muuli_wdr.cpp:2303
+#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:743 src/muuli_wdr.cpp:2275
 #: src/ServerListCtrl.cpp:263 src/ServerListCtrl.cpp:456
 #: src/SharedFilesCtrl.cpp:145
 msgid "Low"
 msgstr "נמוך"
 
-#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:744 src/muuli_wdr.cpp:2304
+#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:744 src/muuli_wdr.cpp:2276
 #: src/ServerListCtrl.cpp:266 src/ServerListCtrl.cpp:457
 #: src/SharedFilesCtrl.cpp:146
 msgid "Normal"
 msgstr "רגיל"
 
-#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:745 src/muuli_wdr.cpp:2305
+#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:745 src/muuli_wdr.cpp:2277
 #: src/ServerListCtrl.cpp:269 src/ServerListCtrl.cpp:458
 #: src/SharedFilesCtrl.cpp:147
 msgid "High"
@@ -1451,8 +1446,8 @@ msgstr "שרת מקומי"
 msgid "Remote Server"
 msgstr "שרת מרוחק"
 
-#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3202
-#: src/SearchDlg.cpp:119 src/TextClient.cpp:911
+#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3174
+#: src/SearchDlg.cpp:111 src/TextClient.cpp:911
 msgid "Kad"
 msgstr "קאד"
 
@@ -1523,7 +1518,7 @@ msgstr ""
 msgid "Size"
 msgstr "גודל"
 
-#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3269
+#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3241
 msgid "Transferred"
 msgstr "הועברו"
 
@@ -1579,7 +1574,7 @@ msgid ""
 "\n"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:746 src/muuli_wdr.cpp:2306
+#: src/DownloadListCtrl.cpp:746 src/muuli_wdr.cpp:2278
 #: src/SharedFilesCtrl.cpp:150
 msgid "Auto"
 msgstr "אוטמטי"
@@ -1617,7 +1612,7 @@ msgid "Extended Options"
 msgstr "אפשרויות מורחבות"
 
 #: src/DownloadListCtrl.cpp:770 src/DownloadListCtrl.cpp:822
-#: src/muuli_wdr.cpp:1790
+#: src/muuli_wdr.cpp:1789
 msgid "Preview"
 msgstr "תקדימון"
 
@@ -1790,237 +1785,232 @@ msgstr[1] ""
 msgid "Invalid eD2k link! ERROR: %s"
 msgstr ""
 
-#: src/ExternalConn.cpp:380
+#: src/ExternalConn.cpp:379
 #, fuzzy
 msgid "Client sent packet after authentication failed."
 msgstr "זיהוי נכשל"
 
-#: src/ExternalConn.cpp:397
+#: src/ExternalConn.cpp:396
 msgid "External connection closed."
 msgstr "חיבור חיצוני נסגר."
 
-#: src/ExternalConn.cpp:474
+#: src/ExternalConn.cpp:473
 msgid "External connections disabled due to empty password!"
 msgstr "גישה חיצונית מנוטרלת מאחר שהסיסמא ריקה!"
 
-#: src/ExternalConn.cpp:495
+#: src/ExternalConn.cpp:494
 msgid "External connections disabled in config file"
 msgstr "גישה מרוחקת מנוטרלת בקובץ ההגדרות"
 
-#: src/ExternalConn.cpp:576
+#: src/ExternalConn.cpp:575
 msgid "New external connection accepted"
 msgstr "גישה חיצונית חדשה התקבלה"
 
-#: src/ExternalConn.cpp:579
+#: src/ExternalConn.cpp:578
 msgid "ERROR: couldn't accept a new external connection"
 msgstr ""
 
-#: src/ExternalConn.cpp:596
+#: src/ExternalConn.cpp:595
 msgid "External connection refused due to empty password in preferences!"
 msgstr "גישה מרחוק נכשלה עקב סיסמא ריקה בהעדפות!"
 
-#: src/ExternalConn.cpp:608
+#: src/ExternalConn.cpp:607
 #, c-format
 msgid "Connecting client: %s %s"
 msgstr "מחבר לקוח:%s %s"
 
-#: src/ExternalConn.cpp:610
+#: src/ExternalConn.cpp:609
 msgid "Unknown version"
 msgstr "גירסה לא ידועה"
 
-#: src/ExternalConn.cpp:623
+#: src/ExternalConn.cpp:622
 msgid "Incorrect EC version ID, there might be binary incompatibility. Use core and remote from same snapshot."
 msgstr "גירסת EC לא נכונה, יתכן ויש אי התאמה בינארית. השתמש בליבה ובלקוח חיצוני מאותו תצלום (גירסה)."
 
-#: src/ExternalConn.cpp:631
+#: src/ExternalConn.cpp:630
 #, fuzzy
 msgid "You cannot connect to a release version from an arbitrary development snapshot! *sigh* possible crash prevented"
 msgstr "אתה לא להתחבר לגרסה ששוחררה מSVN (כלי לניהול גרסאות תוכנה) ! *נאנח* ייתכן והתרסקות של התוכנה נמנעה"
 
-#: src/ExternalConn.cpp:714
+#: src/ExternalConn.cpp:713
 msgid "Invalid protocol version."
 msgstr "גרסת פרוטוקל לא תקפה."
 
-#: src/ExternalConn.cpp:720
+#: src/ExternalConn.cpp:719
 msgid "Missing protocol version tag."
 msgstr "חסר התווית של גרסת הפרוטוקול."
 
-#: src/ExternalConn.cpp:728
+#: src/ExternalConn.cpp:727
 msgid "Authentication failed: invalid hash specified as EC password."
 msgstr ""
 
-#: src/ExternalConn.cpp:776
+#: src/ExternalConn.cpp:775
 #, fuzzy
 msgid "Authentication failed: wrong password."
 msgstr "זיהוי נכשל"
 
-#: src/ExternalConn.cpp:778
+#: src/ExternalConn.cpp:777
 #, fuzzy
 msgid "Authentication failed: missing password."
 msgstr "זיהוי נכשל"
 
-#: src/ExternalConn.cpp:789
+#: src/ExternalConn.cpp:788
 #, fuzzy
 msgid "Invalid request, please authenticate first."
 msgstr "בקשה לא תקפה, כדאי שקודם תאמת."
 
-#: src/ExternalConn.cpp:794
+#: src/ExternalConn.cpp:793
 msgid "Access granted."
 msgstr "גישה אושרה."
 
-#: src/ExternalConn.cpp:802
+#: src/ExternalConn.cpp:801
 #, c-format
 msgid "Sent error message \"%s\" to client."
 msgstr ""
 
-#: src/ExternalConn.cpp:807
+#: src/ExternalConn.cpp:806
 #, fuzzy, c-format
 msgid "Unauthorized access attempt from %s. Connection closed."
 msgstr "ניסיון גישה שאינו מורשה. החיבור נסגר."
 
-#: src/ExternalConn.cpp:1420
+#: src/ExternalConn.cpp:1419
 #, c-format
 msgid "Remote PartFile command failed: FileHash not found: %s"
 msgstr "פקודת קובץ-חלקים מרוחקת מכשלה: גיבוב הקובץ לא נמצא: %s"
 
-#: src/ExternalConn.cpp:1424
+#: src/ExternalConn.cpp:1423
 #, c-format
 msgid "FileHash not found: %s"
 msgstr "גיבוב הקובץ לא מצא: %s"
 
-#: src/ExternalConn.cpp:1471 src/ExternalConn.cpp:1559
-#: src/ExternalConn.cpp:1680
+#: src/ExternalConn.cpp:1470 src/ExternalConn.cpp:1558
+#: src/ExternalConn.cpp:1679
 msgid "OOPS! OpCode processing error!"
 msgstr "אופס! שגיאה בעיבוד קוד-פעולה!"
 
-#: src/ExternalConn.cpp:1502
+#: src/ExternalConn.cpp:1501
 msgid "Server not added"
 msgstr "השרת לא התווסף"
 
-#: src/ExternalConn.cpp:1521
+#: src/ExternalConn.cpp:1520
 #, c-format
 msgid "server not found: %s"
 msgstr "לא נמצא השרת: %s"
 
-#: src/ExternalConn.cpp:1538
+#: src/ExternalConn.cpp:1537
 msgid "need to define server to be removed"
 msgstr "צריך להגדיר שרת כדי להסירו"
 
-#: src/ExternalConn.cpp:1553
+#: src/ExternalConn.cpp:1552
 msgid "eD2k is disabled in preferences."
 msgstr ""
 
-#: src/ExternalConn.cpp:1658
+#: src/ExternalConn.cpp:1657
 #, fuzzy
 msgid "Friend not found."
 msgstr "קובץ לא נמצא."
 
-#: src/ExternalConn.cpp:1668
+#: src/ExternalConn.cpp:1667
 #, fuzzy
 msgid "Client not found."
 msgstr "קובץ לא נמצא."
 
-#: src/ExternalConn.cpp:1674
+#: src/ExternalConn.cpp:1673
 msgid "EC_TAG_FRIEND_SHARED requires EC_TAG_FRIEND or EC_TAG_CLIENT."
 msgstr ""
 
-#: src/ExternalConn.cpp:1992
+#: src/ExternalConn.cpp:1991
 msgid "WebSearch from remote interface makes no sense."
 msgstr "לא הגיוני לבצע חיפוש-רשתי מתוך ממשק מרוחק."
 
-#: src/ExternalConn.cpp:2027
+#: src/ExternalConn.cpp:2026
 msgid "Search in progress. Refetch results in a moment!"
 msgstr "חיפוש פועל כרגע. ייבא מחדש תוצאות בעוד רגע!"
 
-#: src/ExternalConn.cpp:2266
+#: src/ExternalConn.cpp:2265
 msgid "No points for graph."
 msgstr "אין נקודות עבור הגרף."
 
-#: src/ExternalConn.cpp:2276
+#: src/ExternalConn.cpp:2275
 msgid "Your client is not configured for this detail level."
 msgstr "הלקוח שלך אינו מוגדר עבור הרמה הזאת של פרטים."
 
-#: src/ExternalConn.cpp:2303
+#: src/ExternalConn.cpp:2302
 msgid "External Connection: shutdown requested"
 msgstr ""
 
-#: src/ExternalConn.cpp:2315
+#: src/ExternalConn.cpp:2314
 msgid "Already shutting down."
 msgstr "כבר בתהליך כיבוי."
 
-#: src/ExternalConn.cpp:2333
+#: src/ExternalConn.cpp:2332
 #, c-format
 msgid "ExternalConn: adding link '%s'."
 msgstr "חיבור-חיצוני: מוסיף קישור '%s'."
 
-#: src/ExternalConn.cpp:2351
+#: src/ExternalConn.cpp:2350
 #, fuzzy, c-format
 msgid "%d of %d links failed (invalid or already on list)."
 msgstr "קישור לא תקף או שכבר נמצא ברשימה."
 
-#: src/ExternalConn.cpp:2374
+#: src/ExternalConn.cpp:2373
 msgid "Version check throttled; try again shortly."
 msgstr ""
 
-#: src/ExternalConn.cpp:2379
+#: src/ExternalConn.cpp:2378
 msgid "Version check is not available on this daemon."
 msgstr ""
 
-#: src/ExternalConn.cpp:2509
+#: src/ExternalConn.cpp:2508
 msgid "File not found."
 msgstr "קובץ לא נמצא."
 
-#: src/ExternalConn.cpp:2514
+#: src/ExternalConn.cpp:2513
 msgid "Invalid file name."
 msgstr "שם קובץ לא תכף."
 
-#: src/ExternalConn.cpp:2522
+#: src/ExternalConn.cpp:2521
 msgid "Unable to rename file."
 msgstr "לא מצליח לשנות את השם של הקובץ."
 
-#: src/ExternalConn.cpp:2839
-#, c-format
-msgid "Could not save the amuleapi password: %s"
-msgstr ""
-
-#: src/ExternalConn.cpp:3004 src/ExternalConn.cpp:3032
+#: src/ExternalConn.cpp:2992 src/ExternalConn.cpp:3020
 msgid "Kad is disabled in preferences."
 msgstr "קאד מנוטרל בתוך ההעדפות."
 
-#: src/ExternalConn.cpp:3045
+#: src/ExternalConn.cpp:3033
 msgid "Already connected to eD2k."
 msgstr ""
 
-#: src/ExternalConn.cpp:3048
+#: src/ExternalConn.cpp:3036
 msgid "Connecting to eD2k..."
 msgstr ""
 
-#: src/ExternalConn.cpp:3057
+#: src/ExternalConn.cpp:3045
 msgid "Already connected to Kad."
 msgstr "כבר מחובר לקאד."
 
-#: src/ExternalConn.cpp:3060
+#: src/ExternalConn.cpp:3048
 msgid "Connecting to Kad..."
 msgstr "מתחבר לקאד..."
 
-#: src/ExternalConn.cpp:3067
+#: src/ExternalConn.cpp:3055
 msgid "All networks are disabled."
 msgstr "כל הרשתות מנוטרלות."
 
-#: src/ExternalConn.cpp:3076
+#: src/ExternalConn.cpp:3064
 msgid "Disconnected from eD2k."
 msgstr ""
 
-#: src/ExternalConn.cpp:3081
+#: src/ExternalConn.cpp:3069
 msgid "Disconnected from Kad."
 msgstr "מתנתק מקאד."
 
-#: src/ExternalConn.cpp:3090
+#: src/ExternalConn.cpp:3078
 #, c-format
 msgid "External Connection: invalid opcode received: %#x"
 msgstr ""
 
-#: src/ExternalConn.cpp:3095
+#: src/ExternalConn.cpp:3083
 msgid "Invalid opcode (wrong protocol version?)"
 msgstr "קוד-פעולה לא תקף (גרסת פרוטקול שגויה?)"
 
@@ -2311,19 +2301,19 @@ msgstr ""
 msgid "eD2k"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:349 src/muuli_wdr.cpp:1495
+#: src/FirstRunWizard.cpp:349 src/muuli_wdr.cpp:1488
 msgid "Kademlia"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:359 src/muuli_wdr.cpp:1423
+#: src/FirstRunWizard.cpp:359 src/muuli_wdr.cpp:1416
 msgid "Standard TCP Port "
 msgstr ""
 
-#: src/FirstRunWizard.cpp:365 src/muuli_wdr.cpp:1435
+#: src/FirstRunWizard.cpp:365 src/muuli_wdr.cpp:1428
 msgid "Extended UDP port (Kad / global search) "
 msgstr ""
 
-#: src/FirstRunWizard.cpp:377 src/muuli_wdr.cpp:1442
+#: src/FirstRunWizard.cpp:377 src/muuli_wdr.cpp:1435
 msgid "Enable UPnP for router port forwarding"
 msgstr ""
 
@@ -2350,7 +2340,7 @@ msgstr ""
 msgid "Your peer lists are already in place - nothing to download."
 msgstr "אתה כבר מנסה להוריד את הקובץ %s"
 
-#: src/FirstRunWizard.cpp:434 src/muuli_wdr.cpp:1540
+#: src/FirstRunWizard.cpp:434 src/muuli_wdr.cpp:1533
 msgid "Auto-update server list at startup"
 msgstr ""
 
@@ -2396,23 +2386,23 @@ msgid ""
 "want downloads on a different (e.g. larger) disk."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:549 src/FirstRunWizard.cpp:611 src/muuli_wdr.cpp:1702
+#: src/FirstRunWizard.cpp:549 src/FirstRunWizard.cpp:611 src/muuli_wdr.cpp:1701
 msgid "Destination folder for downloads"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:553 src/FirstRunWizard.cpp:569 src/muuli_wdr.cpp:1349
-#: src/muuli_wdr.cpp:1366 src/muuli_wdr.cpp:1677 src/muuli_wdr.cpp:1708
-#: src/muuli_wdr.cpp:1720 src/muuli_wdr.cpp:2790
+#: src/FirstRunWizard.cpp:553 src/FirstRunWizard.cpp:569 src/muuli_wdr.cpp:1342
+#: src/muuli_wdr.cpp:1359 src/muuli_wdr.cpp:1676 src/muuli_wdr.cpp:1707
+#: src/muuli_wdr.cpp:1719 src/muuli_wdr.cpp:2762
 #: src/utils/aLinkCreator/src/alcframe.cpp:135
 #: src/utils/wxCas/src/wxcasprefs.cpp:52 src/utils/wxCas/src/wxcasprefs.cpp:118
 msgid "Browse"
 msgstr "דפדף"
 
-#: src/FirstRunWizard.cpp:559 src/muuli_wdr.cpp:1713
+#: src/FirstRunWizard.cpp:559 src/muuli_wdr.cpp:1712
 msgid "(All files in this folder are shared with other peers)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:565 src/FirstRunWizard.cpp:624 src/muuli_wdr.cpp:1715
+#: src/FirstRunWizard.cpp:565 src/FirstRunWizard.cpp:624 src/muuli_wdr.cpp:1714
 msgid "Folder for temporary download files"
 msgstr ""
 
@@ -2443,7 +2433,7 @@ msgstr ""
 msgid "CRITICAL - no client on StartChatSession"
 msgstr ""
 
-#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2696 src/muuli_wdr.cpp:3373
+#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2668 src/muuli_wdr.cpp:3345
 msgid "Friends"
 msgstr "חברים"
 
@@ -2557,8 +2547,8 @@ msgstr "לא"
 msgid "No"
 msgstr "לא"
 
-#: src/GenericClientListCtrl.cpp:1216 src/PrefsUnifiedDlg.cpp:2898
-#: src/PrefsUnifiedDlg.cpp:2948 src/ServerListCtrl.cpp:276
+#: src/GenericClientListCtrl.cpp:1216 src/PrefsUnifiedDlg.cpp:2818
+#: src/PrefsUnifiedDlg.cpp:2868 src/ServerListCtrl.cpp:276
 msgid "Yes"
 msgstr "כן"
 
@@ -2726,10 +2716,10 @@ msgstr "מבואה לא תקפה על מנת לבצע אתחול"
 msgid "Please fill all fields required"
 msgstr "אנא מלא את כל השדות כפי שנדרש"
 
-#: src/KadDlg.cpp:192 src/PartFile.cpp:1031 src/PrefsUnifiedDlg.cpp:1134
-#: src/PrefsUnifiedDlg.cpp:1204 src/PrefsUnifiedDlg.cpp:1405
-#: src/PrefsUnifiedDlg.cpp:1663 src/PrefsUnifiedDlg.cpp:1673
-#: src/PrefsUnifiedDlg.cpp:1690 src/PrefsUnifiedDlg.cpp:1738
+#: src/KadDlg.cpp:192 src/PartFile.cpp:1031 src/PrefsUnifiedDlg.cpp:1162
+#: src/PrefsUnifiedDlg.cpp:1331 src/PrefsUnifiedDlg.cpp:1589
+#: src/PrefsUnifiedDlg.cpp:1599 src/PrefsUnifiedDlg.cpp:1616
+#: src/PrefsUnifiedDlg.cpp:1658
 msgid "Message"
 msgstr "הודעה"
 
@@ -2831,7 +2821,7 @@ msgstr ""
 msgid "Uploaded"
 msgstr ""
 
-#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3253
+#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3225
 msgid "Requested"
 msgstr ""
 
@@ -2957,7 +2947,7 @@ msgid "WARNING: "
 msgstr ""
 
 #: src/MuleNotebook.cpp:179 src/muuli_wdr.cpp:817 src/muuli_wdr.cpp:1229
-#: src/muuli_wdr.cpp:3157 src/muuli_wdr.cpp:3413
+#: src/muuli_wdr.cpp:3129 src/muuli_wdr.cpp:3385
 msgid "Close"
 msgstr "סגור"
 
@@ -2970,12 +2960,12 @@ msgstr "גזור"
 msgid "Copy"
 msgstr "העתק"
 
-#: src/MuleTextCtrl.cpp:88 src/SearchDlg.cpp:261
+#: src/MuleTextCtrl.cpp:88
 msgid "Paste"
 msgstr "הדבק"
 
 #: src/MuleTextCtrl.cpp:89 src/muuli_wdr.cpp:358 src/muuli_wdr.cpp:757
-#: src/muuli_wdr.cpp:2380 src/muuli_wdr.cpp:2399 src/muuli_wdr.cpp:2421
+#: src/muuli_wdr.cpp:2352 src/muuli_wdr.cpp:2371 src/muuli_wdr.cpp:2393
 #: src/utils/aLinkCreator/src/alcframe.cpp:142
 msgid "Clear"
 msgstr "נקה"
@@ -3072,8 +3062,8 @@ msgid "Exit"
 msgstr "יציאה"
 
 #: src/MuleTrayIcon.cpp:579 src/MuleTrayIcon.cpp:945 src/MuleTrayIcon.cpp:965
-#: src/muuli_wdr.cpp:1398 src/muuli_wdr.cpp:1406 src/muuli_wdr.cpp:1413
-#: src/muuli_wdr.cpp:1836 src/muuli_wdr.cpp:1842 src/OtherFunctions.cpp:91
+#: src/muuli_wdr.cpp:1391 src/muuli_wdr.cpp:1399 src/muuli_wdr.cpp:1406
+#: src/muuli_wdr.cpp:1835 src/muuli_wdr.cpp:1841 src/OtherFunctions.cpp:91
 #: src/StatisticsDlg.cpp:93 src/StatisticsDlg.cpp:95
 msgid "kB/s"
 msgstr "ק\"ב/ש"
@@ -3244,7 +3234,7 @@ msgstr "שם:"
 msgid "Type"
 msgstr "סוג/טיפוס"
 
-#: src/muuli_wdr.cpp:215 src/SearchDlg.cpp:118 src/SearchListCtrl.cpp:853
+#: src/muuli_wdr.cpp:215 src/SearchDlg.cpp:110 src/SearchListCtrl.cpp:853
 msgid "Local"
 msgstr "מקומי"
 
@@ -3315,7 +3305,7 @@ msgstr "בתים"
 msgid "KB"
 msgstr "ק\"ב"
 
-#: src/muuli_wdr.cpp:274 src/muuli_wdr.cpp:293 src/muuli_wdr.cpp:1621
+#: src/muuli_wdr.cpp:274 src/muuli_wdr.cpp:293 src/muuli_wdr.cpp:1620
 #: src/OtherFunctions.cpp:64
 msgid "MB"
 msgstr "מ\"ב"
@@ -3332,7 +3322,7 @@ msgstr "גודל מקסימלי"
 msgid "Availability"
 msgstr "זמינות"
 
-#: src/muuli_wdr.cpp:312 src/muuli_wdr.cpp:398 src/muuli_wdr.cpp:3318
+#: src/muuli_wdr.cpp:312 src/muuli_wdr.cpp:398 src/muuli_wdr.cpp:3290
 msgid "Filter:"
 msgstr "מסנן:"
 
@@ -3364,7 +3354,7 @@ msgstr ""
 msgid "Stop"
 msgstr "עצור"
 
-#: src/muuli_wdr.cpp:348 src/muuli_wdr.cpp:1392 src/SearchListCtrl.cpp:732
+#: src/muuli_wdr.cpp:348 src/muuli_wdr.cpp:1385 src/SearchListCtrl.cpp:732
 msgid "Download"
 msgstr "הורדה"
 
@@ -3396,12 +3386,12 @@ msgstr "מקורות שנמצאו :"
 #: src/muuli_wdr.cpp:1160 src/muuli_wdr.cpp:1167 src/muuli_wdr.cpp:1172
 #: src/muuli_wdr.cpp:1179 src/muuli_wdr.cpp:1184 src/muuli_wdr.cpp:1191
 #: src/muuli_wdr.cpp:1205 src/muuli_wdr.cpp:1212 src/muuli_wdr.cpp:1217
-#: src/muuli_wdr.cpp:1224 src/muuli_wdr.cpp:3255 src/muuli_wdr.cpp:3263
-#: src/muuli_wdr.cpp:3271
+#: src/muuli_wdr.cpp:1224 src/muuli_wdr.cpp:3227 src/muuli_wdr.cpp:3235
+#: src/muuli_wdr.cpp:3243
 msgid "N/A"
 msgstr "ל\"ת"
 
-#: src/muuli_wdr.cpp:508 src/muuli_wdr.cpp:1065 src/PrefsUnifiedDlg.cpp:299
+#: src/muuli_wdr.cpp:508 src/muuli_wdr.cpp:1065 src/PrefsUnifiedDlg.cpp:297
 msgid "General"
 msgstr "כללי"
 
@@ -3541,7 +3531,7 @@ msgstr ""
 msgid "Album :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:685 src/muuli_wdr.cpp:2275
+#: src/muuli_wdr.cpp:685 src/muuli_wdr.cpp:2247
 msgid "Title :"
 msgstr ""
 
@@ -3648,7 +3638,7 @@ msgstr "שם משתמש :"
 msgid "Userhash :"
 msgstr "גיבוב משתשמ :"
 
-#: src/muuli_wdr.cpp:895 src/muuli_wdr.cpp:1742 src/muuli_wdr.cpp:2470
+#: src/muuli_wdr.cpp:895 src/muuli_wdr.cpp:1741 src/muuli_wdr.cpp:2442
 #: src/utils/aLinkCreator/src/alcframe.cpp:137
 msgid "Add"
 msgstr "הוסף"
@@ -3657,15 +3647,15 @@ msgstr "הוסף"
 msgid "Download-Speed"
 msgstr "מהירות הורדה"
 
-#: src/muuli_wdr.cpp:954 src/muuli_wdr.cpp:989 src/muuli_wdr.cpp:2574
+#: src/muuli_wdr.cpp:954 src/muuli_wdr.cpp:989 src/muuli_wdr.cpp:2546
 msgid "Current"
 msgstr "נוכחיים"
 
-#: src/muuli_wdr.cpp:962 src/muuli_wdr.cpp:997 src/muuli_wdr.cpp:2582
+#: src/muuli_wdr.cpp:962 src/muuli_wdr.cpp:997 src/muuli_wdr.cpp:2554
 msgid "Running average"
 msgstr "ממוצע רץ"
 
-#: src/muuli_wdr.cpp:970 src/muuli_wdr.cpp:1005 src/muuli_wdr.cpp:2590
+#: src/muuli_wdr.cpp:970 src/muuli_wdr.cpp:1005 src/muuli_wdr.cpp:2562
 msgid "Session average"
 msgstr "ממוצע ההרצה הנוכחית"
 
@@ -3677,7 +3667,7 @@ msgstr "מהירות-העלאה"
 msgid "Connections"
 msgstr "חיבורים"
 
-#: src/muuli_wdr.cpp:1024 src/muuli_wdr.cpp:1861
+#: src/muuli_wdr.cpp:1024 src/muuli_wdr.cpp:1860
 msgid "Active downloads"
 msgstr "הורדות פעילות"
 
@@ -3685,7 +3675,7 @@ msgstr "הורדות פעילות"
 msgid "Active connections (1:1)"
 msgstr "חיבורים פעילים (1:1)"
 
-#: src/muuli_wdr.cpp:1040 src/muuli_wdr.cpp:1862
+#: src/muuli_wdr.cpp:1040 src/muuli_wdr.cpp:1861
 msgid "Active uploads"
 msgstr "העלאות פעילים"
 
@@ -3802,8 +3792,8 @@ msgstr ""
 msgid "Language: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1257 src/muuli_wdr.cpp:1330 src/muuli_wdr.cpp:1334
-#: src/muuli_wdr.cpp:1337
+#: src/muuli_wdr.cpp:1257 src/muuli_wdr.cpp:1323 src/muuli_wdr.cpp:1327
+#: src/muuli_wdr.cpp:1330
 msgid "The delay before showing tool-tips."
 msgstr ""
 
@@ -3879,954 +3869,931 @@ msgstr ""
 msgid "Enabling this will make aMule to show notifications when finished downloading."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1323
-msgid "Remember search history"
-msgstr ""
-
-#: src/muuli_wdr.cpp:1324
-msgid "Keeps a dropdown list of your past search terms in the Search tab's Name field. This remembers the queries you typed, not the results they returned."
-msgstr ""
-
-#: src/muuli_wdr.cpp:1329
+#: src/muuli_wdr.cpp:1322
 msgid "Tooltip delay time: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1336
+#: src/muuli_wdr.cpp:1329
 msgid "seconds"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1340
+#: src/muuli_wdr.cpp:1333
 msgid "Browser Selection"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1346
+#: src/muuli_wdr.cpp:1339
 msgid "Enter your browser name here. Leave this field empty to use the system default browser."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1353
+#: src/muuli_wdr.cpp:1346
 msgid "Open in new tab if possible"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1355
+#: src/muuli_wdr.cpp:1348
 msgid "Open the web page in a new tab instead of in a new window when possible"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1359
+#: src/muuli_wdr.cpp:1352
 msgid "Video Player"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1386
+#: src/muuli_wdr.cpp:1379
 msgid "Bandwidth limits"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1400
+#: src/muuli_wdr.cpp:1393
 msgid "Upload"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1408
+#: src/muuli_wdr.cpp:1401
 msgid "Slot Allocation"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1417
+#: src/muuli_wdr.cpp:1410
 msgid "Ports"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1427
+#: src/muuli_wdr.cpp:1420
 msgid "This is the standard eD2k port and cannot be disabled."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1430
+#: src/muuli_wdr.cpp:1423
 msgid "UDP port for server requests (TCP+3):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1432
+#: src/muuli_wdr.cpp:1425
 msgid "4665"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1439
+#: src/muuli_wdr.cpp:1432
 msgid "This UDP port is used for extended eD2k requests and Kad network"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1446
+#: src/muuli_wdr.cpp:1439
 msgid "UPnP TCP Port (Optional):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1456
+#: src/muuli_wdr.cpp:1449
 msgid "Bind local address to IP (empty for any):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1459
+#: src/muuli_wdr.cpp:1452
 msgid "Advanced users only: If you have multiple network interfaces, enter the address of the interface to which aMule should be bound."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1462 src/muuli_wdr.cpp:2055
+#: src/muuli_wdr.cpp:1455 src/muuli_wdr.cpp:2054
 msgid "Bind to network interface (empty for any):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1475
+#: src/muuli_wdr.cpp:1468
 msgid "Advanced users only: pin all of aMule's traffic to one network interface, chosen from the list or typed in by name (e.g. tun0, eth0, en0) or index. Unlike binding to an IP, this stops traffic leaking out via the default route - useful with a VPN. Requires no elevated privileges."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1481
+#: src/muuli_wdr.cpp:1474
 msgid "Max sources per downloading file:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1485
+#: src/muuli_wdr.cpp:1478
 msgid "Max simultaneous connections:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1498 src/muuli_wdr.cpp:3197
+#: src/muuli_wdr.cpp:1491 src/muuli_wdr.cpp:3169
 msgid "ED2K"
 msgstr "ED2K"
 
-#: src/muuli_wdr.cpp:1505
+#: src/muuli_wdr.cpp:1498
 msgid "Autoconnect on startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1508
+#: src/muuli_wdr.cpp:1501
 msgid "Reconnect on loss"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1530
+#: src/muuli_wdr.cpp:1523
 msgid "Remove dead server after"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1531
+#: src/muuli_wdr.cpp:1524
 msgid "Static servers are never removed, even when unreachable."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1535
+#: src/muuli_wdr.cpp:1528
 msgid "retries"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1543
+#: src/muuli_wdr.cpp:1536
 msgid "List"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1546
+#: src/muuli_wdr.cpp:1539
 msgid "Update server list when connecting to a server"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1549
+#: src/muuli_wdr.cpp:1542
 msgid "Update server list when a client connects"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1552
+#: src/muuli_wdr.cpp:1545
 msgid "Use priority system"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1556
+#: src/muuli_wdr.cpp:1549
 msgid "Use smart LowID check on connect"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1560
+#: src/muuli_wdr.cpp:1553
 msgid "Safe connect"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1564
+#: src/muuli_wdr.cpp:1557
 msgid "Autoconnect to servers in static list only"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1567
+#: src/muuli_wdr.cpp:1560
 msgid "Set manually added servers to High Priority"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1588
+#: src/muuli_wdr.cpp:1581
 msgid "Add files to download in pause mode"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1590
+#: src/muuli_wdr.cpp:1583
 msgid "Add files to download with auto priority"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1593
+#: src/muuli_wdr.cpp:1586
 msgid "Try to download first and last chunks first"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1597
+#: src/muuli_wdr.cpp:1590
 msgid "Endgame mode: rotate to faster sources for the final blocks"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1600
+#: src/muuli_wdr.cpp:1593
 msgid "Start next paused file when a file completes"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1603
+#: src/muuli_wdr.cpp:1596
 msgid "From the same category"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1605
+#: src/muuli_wdr.cpp:1598
 msgid "In alphabetic order"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1607
+#: src/muuli_wdr.cpp:1600
 msgid "Preallocate disk space for new files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1608
+#: src/muuli_wdr.cpp:1601
 msgid "For new files preallocates disk space for the whole file, thus reduces fragmentation"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1613
+#: src/muuli_wdr.cpp:1606
+msgid "Create new files as sparse files"
+msgstr ""
+
+#: src/muuli_wdr.cpp:1607
+msgid "A sparse file reserves its full size on disk immediately without writing real data to it -- fast, but unsupported or slow on some filesystems, and free-space accounting stays optimistic while the download is in progress. Turn this off to grow the file only as data arrives."
+msgstr ""
+
+#: src/muuli_wdr.cpp:1612
 msgid "Stop downloads when free disk space reaches "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1614
+#: src/muuli_wdr.cpp:1613
 msgid "Select this if you want aMule to check your disk space"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1618
+#: src/muuli_wdr.cpp:1617
 msgid "Enter here the min disk space desired."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1624
+#: src/muuli_wdr.cpp:1623
 msgid "Save 10 sources on rare files (< 20 sources)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1628 src/Statistics.cpp:790
+#: src/muuli_wdr.cpp:1627 src/Statistics.cpp:790
 msgid "Uploads"
 msgstr "ההעלאות"
 
-#: src/muuli_wdr.cpp:1631
+#: src/muuli_wdr.cpp:1630
 msgid "Add new shared files with auto priority"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1637
+#: src/muuli_wdr.cpp:1636
 msgid "Intelligent Corruption Handling (I.C.H.)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1640
+#: src/muuli_wdr.cpp:1639
 msgid "Enable"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1643
+#: src/muuli_wdr.cpp:1642
 msgid "Advanced I.C.H. trusts every hash (not recommended)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1655 src/PrefsUnifiedDlg.cpp:1990
+#: src/muuli_wdr.cpp:1654 src/PrefsUnifiedDlg.cpp:1910
 msgid "Media metadata extraction"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1659
+#: src/muuli_wdr.cpp:1658
 msgid "Extract length / bitrate / codec from shared audio and video files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1661
+#: src/muuli_wdr.cpp:1660
 msgid "When enabled, aMule runs ffprobe on each shared media file to fill in the Length / Bitrate / Codec columns other clients see when they find the file in a search. Requires ffmpeg (the ffprobe binary) to be installed."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1668
+#: src/muuli_wdr.cpp:1667
 msgid "Path to ffprobe:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1673
+#: src/muuli_wdr.cpp:1672
 msgid "Full path to the ffprobe binary. Leave empty to have aMule auto-detect it on startup."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1681
+#: src/muuli_wdr.cpp:1680
 msgid "Detect"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1682
+#: src/muuli_wdr.cpp:1681
 msgid "Search the standard install locations for an ffprobe binary and fill the path field."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1706
+#: src/muuli_wdr.cpp:1705
 msgid ""
 "Completed downloads are stored here. All files in this folder are automatically shared with other peers.\n"
 "If this folder also holds files you don't want to share, point it at an aMule-only sub-folder."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1709
+#: src/muuli_wdr.cpp:1708
 msgid "Pick the folder where completed downloads will be stored. All files in that folder will be shared with other peers."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1723
+#: src/muuli_wdr.cpp:1722
 msgid "Shared folders"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1729
+#: src/muuli_wdr.cpp:1728
 msgid "(Folders shared by the core. Enter a path to add one.)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1737
+#: src/muuli_wdr.cpp:1736
 msgid "Absolute path of a folder on the core's machine, e.g. /home/user/shared"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1739 src/PrefsUnifiedDlg.cpp:2874
+#: src/muuli_wdr.cpp:1738 src/PrefsUnifiedDlg.cpp:2794
 msgid "Recursive"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1740
+#: src/muuli_wdr.cpp:1739
 msgid "Share every sub-folder underneath this one, including ones created later."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1744 src/utils/aLinkCreator/src/alcframe.cpp:141
+#: src/muuli_wdr.cpp:1743 src/utils/aLinkCreator/src/alcframe.cpp:141
 msgid "Remove"
 msgstr "הסר"
 
-#: src/muuli_wdr.cpp:1748
+#: src/muuli_wdr.cpp:1747
 msgid "(Right click on folder icon for recursive share)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1755
+#: src/muuli_wdr.cpp:1754
 msgid "Share hidden files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1761
+#: src/muuli_wdr.cpp:1760
 msgid "Automatically rescan shared folders for changes"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1767
+#: src/muuli_wdr.cpp:1766
 msgid "Follow symbolic links in shared folders"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1773
+#: src/muuli_wdr.cpp:1772
 msgid "Exclude files matching:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1776
+#: src/muuli_wdr.cpp:1775
 msgid "Wildcard patterns separated by '|', e.g. .DS_Store|Thumbs.db|*.tmp. Files whose name matches are not shared. Matching is case-insensitive."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1780
+#: src/muuli_wdr.cpp:1779
 msgid "Patterns are regular expressions"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1781
+#: src/muuli_wdr.cpp:1780
 msgid "When set, the whole field is one regular expression ('|' is alternation). When unset, it is a list of '|'-separated wildcards."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1791
+#: src/muuli_wdr.cpp:1790
 msgid "Show how many shared files the current pattern would exclude."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1812
+#: src/muuli_wdr.cpp:1811
 msgid "Graphs"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1815 src/muuli_wdr.cpp:1877
+#: src/muuli_wdr.cpp:1814 src/muuli_wdr.cpp:1876
 msgid "Update delay : 5 secs"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1819
+#: src/muuli_wdr.cpp:1818
 msgid "Time for average graph: 100 mins"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1823
+#: src/muuli_wdr.cpp:1822
 msgid "Connections Graph Scale: 100 "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1830
+#: src/muuli_wdr.cpp:1829
 msgid "Download graph scale:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1838
+#: src/muuli_wdr.cpp:1837
 msgid "Upload graph scale:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1848
+#: src/muuli_wdr.cpp:1847
 msgid "Colors: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1852
+#: src/muuli_wdr.cpp:1851
 msgid "Background"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1853
+#: src/muuli_wdr.cpp:1852
 msgid "Grid"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1854
+#: src/muuli_wdr.cpp:1853
 msgid "Download current"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1855
+#: src/muuli_wdr.cpp:1854
 msgid "Download running average"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1856
+#: src/muuli_wdr.cpp:1855
 msgid "Download session average"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1857
+#: src/muuli_wdr.cpp:1856
 msgid "Upload current"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1858
+#: src/muuli_wdr.cpp:1857
 msgid "Upload running average"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1859
+#: src/muuli_wdr.cpp:1858
 msgid "Upload session average"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1860
+#: src/muuli_wdr.cpp:1859
 msgid "Active connections"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1863
+#: src/muuli_wdr.cpp:1862
 msgid "Systray Icon Speed Bar"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1864
+#: src/muuli_wdr.cpp:1863
 msgid "Kad-nodes current"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1865
+#: src/muuli_wdr.cpp:1864
 msgid "Kad-nodes running"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1866
+#: src/muuli_wdr.cpp:1865
 msgid "Kad-nodes session"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1870 src/muuli_wdr.cpp:2324
+#: src/muuli_wdr.cpp:1869 src/muuli_wdr.cpp:2296
 msgid "Select"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1874
+#: src/muuli_wdr.cpp:1873
 msgid "Tree"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1884
+#: src/muuli_wdr.cpp:1883
 msgid "Number of Client Versions shown (0=unlimited)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1909
+#: src/muuli_wdr.cpp:1908
 msgid "!!! WARNING !!!"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1924
+#: src/muuli_wdr.cpp:1923
 msgid "Max new connections / 5 secs"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1926
+#: src/muuli_wdr.cpp:1925
 msgid "Concurrent Kad source lookups"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1928
+#: src/muuli_wdr.cpp:1927
 #, fuzzy
 msgid "Kad source re-search interval (minutes)"
 msgstr "קצב עדכון התקופתי של ה FTP בדקות"
 
-#: src/muuli_wdr.cpp:1930
+#: src/muuli_wdr.cpp:1929
 #, fuzzy
 msgid "Source re-ask interval (minutes)"
 msgstr "קצב עדכון התקופתי של ה FTP בדקות"
 
-#: src/muuli_wdr.cpp:1934
+#: src/muuli_wdr.cpp:1933
 msgid "File Buffer Size: 240000 bytes"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1938
+#: src/muuli_wdr.cpp:1937
 msgid "Use MMAP: memory-mapped file access (lower memory use)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1939
+#: src/muuli_wdr.cpp:1938
 msgid "Maps part files into memory instead of buffering them on the heap, lowering the process memory footprint. May reduce download speed on some disks; best for memory-constrained or upload-heavy hosts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1941
+#: src/muuli_wdr.cpp:1940
 msgid "Upload Queue Size: 5000 clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1945
+#: src/muuli_wdr.cpp:1944
 msgid "Server connection refresh interval: Disable"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1949
+#: src/muuli_wdr.cpp:1948
 msgid "Disable computer's timed standby mode"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1968
+#: src/muuli_wdr.cpp:1967
 msgid "Skin to use: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1977
+#: src/muuli_wdr.cpp:1976
 msgid "Show \"Fast eD2k Links Handler\" in every window."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1980
+#: src/muuli_wdr.cpp:1979
 msgid "Show extended info on categories tabs"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1983
+#: src/muuli_wdr.cpp:1982
 msgid "Show application version on title"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1985
+#: src/muuli_wdr.cpp:1984
 msgid "Show transfer rates on title"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1987
+#: src/muuli_wdr.cpp:1986
 msgid "Before application name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1989
+#: src/muuli_wdr.cpp:1988
 msgid "After application name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1992
+#: src/muuli_wdr.cpp:1991
 msgid "Show overhead bandwidth"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1996
+#: src/muuli_wdr.cpp:1995
 msgid "Vertical toolbar orientation"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1998
+#: src/muuli_wdr.cpp:1997
 msgid "Live column sorting (auto-reorder rows as their values change)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2005
+#: src/muuli_wdr.cpp:2004
 msgid "Download Queue Files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2008
+#: src/muuli_wdr.cpp:2007
 msgid "Show progress percentage"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2014
+#: src/muuli_wdr.cpp:2013
 msgid "Show progress bar"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2017
+#: src/muuli_wdr.cpp:2016
 msgid "Flat"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2021
+#: src/muuli_wdr.cpp:2020
 msgid "Round"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2039
+#: src/muuli_wdr.cpp:2038
 msgid "External Connection Parameters"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2042
+#: src/muuli_wdr.cpp:2041
 msgid "Accept external connections"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2049 src/muuli_wdr.cpp:2108
+#: src/muuli_wdr.cpp:2048 src/muuli_wdr.cpp:2107
 msgid "IP of the listening interface:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2052
+#: src/muuli_wdr.cpp:2051
 msgid "Enter here a valid ip in the a.b.c.d format for the listening EC interface. An empty field or 0.0.0.0 will mean any interface."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2073 src/muuli_wdr.cpp:2184
+#: src/muuli_wdr.cpp:2072 src/muuli_wdr.cpp:2156
 msgid "TCP port:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2079
+#: src/muuli_wdr.cpp:2078
 msgid "Enable UPnP port forwarding on the EC port"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2083 src/muuli_wdr.cpp:3069
+#: src/muuli_wdr.cpp:2082 src/muuli_wdr.cpp:3041
 #: src/utils/wxCas/src/wxcasprefs.cpp:167
 msgid "Password"
 msgstr "סיסמא"
 
-#: src/muuli_wdr.cpp:2089
+#: src/muuli_wdr.cpp:2088
 msgid "aMule API server parameters"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2092
+#: src/muuli_wdr.cpp:2091
 msgid "Run amuleapi (REST API) on startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2097
+#: src/muuli_wdr.cpp:2096
 #, fuzzy
 msgid "HTTP port:"
 msgstr "מבואת UPnP"
 
-#: src/muuli_wdr.cpp:2111
+#: src/muuli_wdr.cpp:2110
 msgid "The interface amuleapi's HTTP server listens on. 127.0.0.1 (default) accepts only local connections; use 0.0.0.0 or a specific IP to expose it to other hosts (set an admin password below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2116
-msgid "Type a password to set or change it. Stored passwords cannot be shown, so leaving this empty keeps the current one."
-msgstr ""
-
-#: src/muuli_wdr.cpp:2118
+#: src/muuli_wdr.cpp:2113
 #, fuzzy
 msgid "Admin password"
 msgstr "בודק סיסמא\n"
 
-#: src/muuli_wdr.cpp:2130 src/muuli_wdr.cpp:2147 src/PrefsUnifiedDlg.cpp:1103
-#, fuzzy
-msgid "A password is set."
-msgstr "בודק סיסמא\n"
-
-#: src/muuli_wdr.cpp:2134
-#, fuzzy
-msgid "Enable guest access"
-msgstr "מנע גישה מאורחים"
-
-#: src/muuli_wdr.cpp:2135
-msgid "Guest sessions may read status and listings but cannot change anything. Turning this off clears the stored guest password."
-msgstr ""
-
-#: src/muuli_wdr.cpp:2139
-#, fuzzy
-msgid "Guest password"
-msgstr "בודק סיסמא\n"
-
-#: src/muuli_wdr.cpp:2154
-msgid "Web server parameters"
-msgstr ""
-
-#: src/muuli_wdr.cpp:2157
-msgid "Run webserver on startup (deprecated)"
-msgstr ""
-
-#: src/muuli_wdr.cpp:2163
-msgid "Web template"
-msgstr ""
-
-#: src/muuli_wdr.cpp:2168
-msgid "Full rights password"
-msgstr ""
-
-#: src/muuli_wdr.cpp:2172
-msgid "Enable Low rights User"
-msgstr ""
-
-#: src/muuli_wdr.cpp:2177
+#: src/muuli_wdr.cpp:2118 src/muuli_wdr.cpp:2149
 msgid "Low rights password"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2191
+#: src/muuli_wdr.cpp:2126
+msgid "Web server parameters"
+msgstr ""
+
+#: src/muuli_wdr.cpp:2129
+msgid "Run webserver on startup (deprecated)"
+msgstr ""
+
+#: src/muuli_wdr.cpp:2135
+msgid "Web template"
+msgstr ""
+
+#: src/muuli_wdr.cpp:2140
+msgid "Full rights password"
+msgstr ""
+
+#: src/muuli_wdr.cpp:2144
+msgid "Enable Low rights User"
+msgstr ""
+
+#: src/muuli_wdr.cpp:2163
 msgid "Enable UPnP port forwarding of the web server port"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2196
+#: src/muuli_wdr.cpp:2168
 msgid "Web server UPnP TCP port (Optional)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2204
+#: src/muuli_wdr.cpp:2176
 msgid "Page Refresh Time (in secs)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2211
+#: src/muuli_wdr.cpp:2183
 msgid "Enable Gzip compression"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2245
+#: src/muuli_wdr.cpp:2217
 #, fuzzy
 msgid "Reset page to defaults"
 msgstr "ברירת מחדל של המערכת"
 
-#: src/muuli_wdr.cpp:2246
+#: src/muuli_wdr.cpp:2218
 msgid "Reset the settings on the current page to their default values."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2248 src/muuli_wdr.cpp:2334 src/ServerWnd.cpp:274
+#: src/muuli_wdr.cpp:2220 src/muuli_wdr.cpp:2306 src/ServerWnd.cpp:274
 #: src/ServerWnd.cpp:282
 msgid "OK"
 msgstr "בסדר"
 
-#: src/muuli_wdr.cpp:2250
+#: src/muuli_wdr.cpp:2222
 msgid "Click here to apply any changes made to the preferences."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2253
+#: src/muuli_wdr.cpp:2225
 msgid "Reset any changes made to the preferences."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2282
+#: src/muuli_wdr.cpp:2254
 msgid "Comment :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2289
+#: src/muuli_wdr.cpp:2261
 msgid "Incoming Dir :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2298
+#: src/muuli_wdr.cpp:2270
 msgid "Change priority for new assigned files :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2302
+#: src/muuli_wdr.cpp:2274
 #, fuzzy
 msgid "Don't change"
 msgstr "- מבואת UDP שונתה \n"
 
-#: src/muuli_wdr.cpp:2314
+#: src/muuli_wdr.cpp:2286
 msgid "Select color for this Category (currently selected) :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2381 src/muuli_wdr.cpp:2400 src/muuli_wdr.cpp:2422
+#: src/muuli_wdr.cpp:2353 src/muuli_wdr.cpp:2372 src/muuli_wdr.cpp:2394
 msgid "Click this button to reset the log."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2441
+#: src/muuli_wdr.cpp:2413
 msgid "Click on this button to update the servers list from URL ..."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2445
+#: src/muuli_wdr.cpp:2417
 msgid "Server list"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2449
+#: src/muuli_wdr.cpp:2421
 msgid "Enter the url to a server.met file here and press the button to the left to update the list of known servers."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2454
+#: src/muuli_wdr.cpp:2426
 msgid "Add server manually: Name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2457
+#: src/muuli_wdr.cpp:2429
 msgid "Enter the name of the new server here"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2459 src/ServerWnd.cpp:206
+#: src/muuli_wdr.cpp:2431 src/ServerWnd.cpp:206
 msgid "IP:Port"
 msgstr "אי.פי.:מבואה"
 
-#: src/muuli_wdr.cpp:2462
+#: src/muuli_wdr.cpp:2434
 msgid "Enter the IP of the server here, using the x.x.x.x format."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2468
+#: src/muuli_wdr.cpp:2440
 msgid "Enter the port of the server here."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2471
+#: src/muuli_wdr.cpp:2443
 msgid "Add manually a server (fill fields to the left before) ..."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2500
+#: src/muuli_wdr.cpp:2472
 msgid "aMule Log"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2508
+#: src/muuli_wdr.cpp:2480
 msgid "Server Info"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2512
+#: src/muuli_wdr.cpp:2484
 msgid "ED2K Info"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2516
+#: src/muuli_wdr.cpp:2488
 msgid "Kad Info"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2544
+#: src/muuli_wdr.cpp:2516
 msgid "Click on this button to update the nodes list from URL ..."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2548
+#: src/muuli_wdr.cpp:2520
 msgid "Nodes (0)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2552
+#: src/muuli_wdr.cpp:2524
 msgid "Enter the url to a nodes.dat file here and press the button to the left to update the list of known nodes."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2555
+#: src/muuli_wdr.cpp:2527
 msgid "Nodes stats"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2597
+#: src/muuli_wdr.cpp:2569
 msgid "Bootstrap"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2600
+#: src/muuli_wdr.cpp:2572
 msgid "New node"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2605
+#: src/muuli_wdr.cpp:2577
 msgid "IP:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2625
+#: src/muuli_wdr.cpp:2597
 msgid "Port:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2638
+#: src/muuli_wdr.cpp:2610
 msgid "Bootstrap from known clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2640
+#: src/muuli_wdr.cpp:2612
 msgid "Disconnect Kad"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2674
+#: src/muuli_wdr.cpp:2646
 msgid "Use Secure User Identification"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2676
+#: src/muuli_wdr.cpp:2648
 msgid "It is recommended to enable this option. You will not receive credits if SUI is not enabled."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2678
+#: src/muuli_wdr.cpp:2650
 msgid "Protocol Obfuscation"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2681
+#: src/muuli_wdr.cpp:2653
 msgid "Support Protocol Obfuscation"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2683
+#: src/muuli_wdr.cpp:2655
 msgid "This option enabled Protocol Obfuscation, and makes aMule accept obfuscated connections from other clients."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2685
+#: src/muuli_wdr.cpp:2657
 msgid "Use obfuscation for outgoing connections"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2687
+#: src/muuli_wdr.cpp:2659
 msgid "This option makes aMule use Protocol Obfuscation when connecting other clients/servers."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2689
+#: src/muuli_wdr.cpp:2661
 msgid "Accept only obfuscated connections"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2690
+#: src/muuli_wdr.cpp:2662
 msgid "This option makes aMule only accept obfuscated connections. You will have less sources, but all your traffic will be obfuscated"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2695
+#: src/muuli_wdr.cpp:2667
 msgid "Everybody"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2697
+#: src/muuli_wdr.cpp:2669
 msgid "No one"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2699
+#: src/muuli_wdr.cpp:2671
 msgid "Who can see my shared files:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2700
+#: src/muuli_wdr.cpp:2672
 msgid "Select who can request to view a list of your shared files."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2702
+#: src/muuli_wdr.cpp:2674
 msgid "IP-Filtering"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2709
+#: src/muuli_wdr.cpp:2681
 msgid "Filter clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2711
+#: src/muuli_wdr.cpp:2683
 msgid "Enable filtering of the client IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2713
+#: src/muuli_wdr.cpp:2685
 msgid "Filter servers"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2715
+#: src/muuli_wdr.cpp:2687
 msgid "Enable filtering of the server IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2719
+#: src/muuli_wdr.cpp:2691
 msgid "Reload List"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2720
+#: src/muuli_wdr.cpp:2692
 msgid "Reload the list of IPs to filter from the file ~/.aMule/ipfilter.dat"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2726
+#: src/muuli_wdr.cpp:2698
 msgid "URL:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2730 src/muuli_wdr.cpp:2923
+#: src/muuli_wdr.cpp:2702 src/muuli_wdr.cpp:2895
 msgid "Update now"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2733
+#: src/muuli_wdr.cpp:2705
 msgid "Auto-update ipfilter at startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2737
+#: src/muuli_wdr.cpp:2709
 msgid "Filtering Level:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2743
+#: src/muuli_wdr.cpp:2715
 msgid "Always filter LAN IPs"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2746
+#: src/muuli_wdr.cpp:2718
 msgid "Paranoid handling of non-matching IPs"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2748
+#: src/muuli_wdr.cpp:2720
 msgid "Rejects a packet when its source IP differs from the IP the client claims (an anti-spoofing check). Disable only if it causes connection problems."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2750
+#: src/muuli_wdr.cpp:2722
 msgid "Use system-wide ipfilter.dat if available"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2751
+#: src/muuli_wdr.cpp:2723
 msgid "If there's no local ipfilter.dat found, allow usage of a system-wide ipfilter file."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2768
+#: src/muuli_wdr.cpp:2740
 msgid "Enable Online-Signature"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2770
+#: src/muuli_wdr.cpp:2742
 msgid "Enables the writing of the OS file, which can be used by external apps to create signatures and the like."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2774
+#: src/muuli_wdr.cpp:2746
 msgid "Update Frequency (Secs):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2777
+#: src/muuli_wdr.cpp:2749
 msgid "Change the frequency (in seconds) of Online Signature updates."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2785
+#: src/muuli_wdr.cpp:2757
 msgid "Save online signature file in: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:2791
+#: src/muuli_wdr.cpp:2763
 msgid "Click here to select the directory containing the the Online Signature files."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2824
+#: src/muuli_wdr.cpp:2796
 msgid "Show country flags for clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2825
+#: src/muuli_wdr.cpp:2797
 msgid "Render the country flag column in the transfers, queue and search views. Requires a valid MMDB GeoIP database (see below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2830
+#: src/muuli_wdr.cpp:2802
 #, fuzzy
 msgid "Database"
 msgstr "קצב מידע :"
 
-#: src/muuli_wdr.cpp:2846
+#: src/muuli_wdr.cpp:2818
 #, fuzzy
 msgid "Source:"
 msgstr "מקורות"
 
-#: src/muuli_wdr.cpp:2849
+#: src/muuli_wdr.cpp:2821
 msgid "DB-IP (free, no account)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2850
+#: src/muuli_wdr.cpp:2822
 msgid "MaxMind GeoLite2 (free, account required)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2851
+#: src/muuli_wdr.cpp:2823
 msgid "Custom URL"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2854
+#: src/muuli_wdr.cpp:2826
 msgid "Choose which provider supplies the GeoIP MMDB database. DB-IP is the default - no account required. MaxMind requires a free account + license key. Use Custom URL to point at any other MMDB host (e.g. a local mirror)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2871
+#: src/muuli_wdr.cpp:2843
 msgid ""
 "No configuration required.\n"
 "\n"
@@ -4834,11 +4801,11 @@ msgid ""
 "License: Creative Commons BY 4.0 - https://creativecommons.org/licenses/by/4.0/"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2884
+#: src/muuli_wdr.cpp:2856
 msgid "License key:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2890
+#: src/muuli_wdr.cpp:2862
 msgid ""
 "Sign up for a free MaxMind account, then generate a License Key:\n"
 "https://www.maxmind.com/en/geolite2/signup\n"
@@ -4848,230 +4815,230 @@ msgid ""
 "Requires attribution and account registration; refresh at least every 30 days."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2905
+#: src/muuli_wdr.cpp:2877
 #, fuzzy
 msgid "Download URL:"
 msgstr "מוריד: "
 
-#: src/muuli_wdr.cpp:2911
+#: src/muuli_wdr.cpp:2883
 msgid ""
 "Must point to an .mmdb file or a .gz / .tar.gz containing one.\n"
 "URL may include credentials (https://user:pass@host/...).\n"
 "License and attribution terms are set by the upstream URL - you are responsible."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2924
+#: src/muuli_wdr.cpp:2896
 msgid "Download the GeoIP database from the selected source."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2926
+#: src/muuli_wdr.cpp:2898
 msgid "Auto-update on startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2927
+#: src/muuli_wdr.cpp:2899
 msgid "Re-download the GeoIP database from the selected source every time aMule starts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2950
+#: src/muuli_wdr.cpp:2922
 msgid "Filter incoming messages (except current chat):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2952
+#: src/muuli_wdr.cpp:2924
 msgid "Filter all messages"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2954
+#: src/muuli_wdr.cpp:2926
 msgid "Filter messages from people not on your friend list"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2956
+#: src/muuli_wdr.cpp:2928
 msgid "Filter messages from unknown clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2958
+#: src/muuli_wdr.cpp:2930
 msgid "Filter messages containing (use ',' as separator):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2961 src/muuli_wdr.cpp:2972
+#: src/muuli_wdr.cpp:2933 src/muuli_wdr.cpp:2944
 msgid "add here the words amule should filter and block messages including it"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2963
+#: src/muuli_wdr.cpp:2935
 msgid "Show received messages in the log"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2966
+#: src/muuli_wdr.cpp:2938
 msgid "Comments"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2969
+#: src/muuli_wdr.cpp:2941
 msgid "Filter comments containing (use ',' as separator):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2994
+#: src/muuli_wdr.cpp:2966
 msgid "Enable Proxy"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2995
+#: src/muuli_wdr.cpp:2967
 msgid "Enable/disable proxy support"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2998
+#: src/muuli_wdr.cpp:2970
 msgid "Proxy type:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3009
+#: src/muuli_wdr.cpp:2981
 msgid "Proxy host:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3012
+#: src/muuli_wdr.cpp:2984
 msgid "The proxy host name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3014
+#: src/muuli_wdr.cpp:2986
 msgid "Proxy port:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3017
+#: src/muuli_wdr.cpp:2989
 msgid "The proxy port"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3019
+#: src/muuli_wdr.cpp:2991
 msgid "Enable authentication"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3020
+#: src/muuli_wdr.cpp:2992
 msgid "Enable/disable username/password authentication"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3023
+#: src/muuli_wdr.cpp:2995
 msgid "Username: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:3026
+#: src/muuli_wdr.cpp:2998
 msgid "The username to use to connect to the proxy"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3028
+#: src/muuli_wdr.cpp:3000
 msgid "Password:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3031
+#: src/muuli_wdr.cpp:3003
 msgid "The password to use to connect to the proxy"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3050
+#: src/muuli_wdr.cpp:3022
 msgid "Connect to:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3059
+#: src/muuli_wdr.cpp:3031
 msgid "Login to remote amule"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3064
+#: src/muuli_wdr.cpp:3036
 msgid "User name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3075
+#: src/muuli_wdr.cpp:3047
 msgid "Remember those settings"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3078
+#: src/muuli_wdr.cpp:3050
 #, fuzzy
 msgid "Force ZLIB compression"
 msgstr "השמתש בדחיסת gzip"
 
-#: src/muuli_wdr.cpp:3102
+#: src/muuli_wdr.cpp:3074
 msgid "Enable Verbose Debug-Logging."
 msgstr ""
 
-#: src/muuli_wdr.cpp:3104
+#: src/muuli_wdr.cpp:3076
 #, fuzzy
 msgid "Only to Logfile"
 msgstr "&תפתח את הקובץ"
 
-#: src/muuli_wdr.cpp:3106
+#: src/muuli_wdr.cpp:3078
 msgid "Message Categories:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3130 src/PartFileConvertDlg.cpp:160
+#: src/muuli_wdr.cpp:3102 src/PartFileConvertDlg.cpp:160
 msgid "Waiting..."
 msgstr "ממתין..."
 
-#: src/muuli_wdr.cpp:3150
+#: src/muuli_wdr.cpp:3122
 msgid "Add imports"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3153
+#: src/muuli_wdr.cpp:3125
 msgid "Retry selected"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3155
+#: src/muuli_wdr.cpp:3127
 msgid "Remove selected"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3218
+#: src/muuli_wdr.cpp:3190
 msgid "Event Types"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3237
+#: src/muuli_wdr.cpp:3209
 msgid "Statistics and queued clients for selected file(s) : Session / All time"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3261
+#: src/muuli_wdr.cpp:3233
 #, fuzzy
 msgid "Active Uploads"
 msgstr "העלאות פעילים :"
 
-#: src/muuli_wdr.cpp:3275
+#: src/muuli_wdr.cpp:3247
 msgid "Percent of total files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3327
+#: src/muuli_wdr.cpp:3299
 #, fuzzy
 msgid "Show Clients for"
 msgstr "לקוחות"
 
-#: src/muuli_wdr.cpp:3329
+#: src/muuli_wdr.cpp:3301
 #, fuzzy
 msgid "All files"
 msgstr "קבצים משותפים"
 
-#: src/muuli_wdr.cpp:3332
+#: src/muuli_wdr.cpp:3304
 #, fuzzy
 msgid "Selected files"
 msgstr "בחר מסנן תצוגה"
 
-#: src/muuli_wdr.cpp:3335
+#: src/muuli_wdr.cpp:3307
 #, fuzzy
 msgid "Active uploads only"
 msgstr "העלאות פעילים"
 
-#: src/muuli_wdr.cpp:3342
+#: src/muuli_wdr.cpp:3314
 msgid "Reload:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3346
+#: src/muuli_wdr.cpp:3318
 msgid "Reload your shared files"
 msgstr "טען מחדש את הקבצים המשותפים שלך"
 
-#: src/muuli_wdr.cpp:3409
+#: src/muuli_wdr.cpp:3381
 msgid "Send"
 msgstr "שלח"
 
-#: src/muuli_wdr.cpp:3410
+#: src/muuli_wdr.cpp:3382
 msgid "Sends the specified message."
 msgstr "שולח את ההודעה המצויינת."
 
-#: src/muuli_wdr.cpp:3414
+#: src/muuli_wdr.cpp:3386
 msgid "Close this chat-session."
 msgstr "סגור את הצ'אט הנוכחי."
 
-#: src/muuli_wdr.cpp:3437
+#: src/muuli_wdr.cpp:3409
 msgid "Connect to any server and/or Kad"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3443 src/SharedFilesCtrl.cpp:142 src/Statistics.cpp:941
+#: src/muuli_wdr.cpp:3415 src/SharedFilesCtrl.cpp:142 src/Statistics.cpp:941
 msgid "Shared Files"
 msgstr "קבצים משותפים"
 
@@ -5434,267 +5401,267 @@ msgstr ""
 msgid "ERROR: Failed to open partfile '%s'"
 msgstr ""
 
-#: src/Preferences.cpp:701
+#: src/Preferences.cpp:673
 msgid "System default"
 msgstr "ברירת מחדל של המערכת"
 
-#: src/Preferences.cpp:702
+#: src/Preferences.cpp:674
 msgid "Albanian"
 msgstr "אלבני"
 
-#: src/Preferences.cpp:703
+#: src/Preferences.cpp:675
 msgid "Arabic"
 msgstr "ערבית"
 
-#: src/Preferences.cpp:704
+#: src/Preferences.cpp:676
 #, fuzzy
 msgid "Asturian"
 msgstr "אסטונית"
 
-#: src/Preferences.cpp:705
+#: src/Preferences.cpp:677
 msgid "Basque"
 msgstr "בסקית"
 
-#: src/Preferences.cpp:706
+#: src/Preferences.cpp:678
 msgid "Bulgarian"
 msgstr "בולגרית"
 
-#: src/Preferences.cpp:707
+#: src/Preferences.cpp:679
 msgid "Catalan"
 msgstr "קטלונית"
 
-#: src/Preferences.cpp:708
+#: src/Preferences.cpp:680
 msgid "Chinese (Simplified)"
 msgstr "סינית (מופשטת)"
 
-#: src/Preferences.cpp:709
+#: src/Preferences.cpp:681
 msgid "Chinese (Traditional)"
 msgstr "סינית (מסורתית)"
 
-#: src/Preferences.cpp:710
+#: src/Preferences.cpp:682
 msgid "Croatian"
 msgstr "קרואטית"
 
-#: src/Preferences.cpp:711
+#: src/Preferences.cpp:683
 msgid "Czech"
 msgstr "צ'כית"
 
-#: src/Preferences.cpp:712
+#: src/Preferences.cpp:684
 msgid "Danish"
 msgstr "דנית"
 
-#: src/Preferences.cpp:713
+#: src/Preferences.cpp:685
 msgid "Dutch"
 msgstr "הולנדית"
 
-#: src/Preferences.cpp:714
+#: src/Preferences.cpp:686
 msgid "English (U.K.)"
 msgstr "אנגלית (בריטית)"
 
-#: src/Preferences.cpp:715
+#: src/Preferences.cpp:687
 #, fuzzy
 msgid "English (U.S.)"
 msgstr "אנגלית (בריטית)"
 
-#: src/Preferences.cpp:716
+#: src/Preferences.cpp:688
 msgid "Estonian"
 msgstr "אסטונית"
 
-#: src/Preferences.cpp:717
+#: src/Preferences.cpp:689
 msgid "Finnish"
 msgstr "פינית"
 
-#: src/Preferences.cpp:718
+#: src/Preferences.cpp:690
 msgid "French"
 msgstr "צרפתית"
 
-#: src/Preferences.cpp:719
+#: src/Preferences.cpp:691
 msgid "Galician"
 msgstr "גאלית"
 
-#: src/Preferences.cpp:720
+#: src/Preferences.cpp:692
 msgid "German"
 msgstr "גרמנית"
 
-#: src/Preferences.cpp:721
+#: src/Preferences.cpp:693
 msgid "Greek"
 msgstr "יוונית"
 
-#: src/Preferences.cpp:722
+#: src/Preferences.cpp:694
 msgid "Hebrew"
 msgstr ""
 
-#: src/Preferences.cpp:723
+#: src/Preferences.cpp:695
 msgid "Hungarian"
 msgstr "הונגרית"
 
-#: src/Preferences.cpp:724
+#: src/Preferences.cpp:696
 msgid "Italian"
 msgstr "איטלקית"
 
-#: src/Preferences.cpp:725
+#: src/Preferences.cpp:697
 msgid "Japanese"
 msgstr "יפנית"
 
-#: src/Preferences.cpp:726
+#: src/Preferences.cpp:698
 msgid "Korean"
 msgstr "קוראינית"
 
-#: src/Preferences.cpp:727
+#: src/Preferences.cpp:699
 msgid "Latvian"
 msgstr ""
 
-#: src/Preferences.cpp:728
+#: src/Preferences.cpp:700
 msgid "Lithuanian"
 msgstr "ליטאית"
 
-#: src/Preferences.cpp:729
+#: src/Preferences.cpp:701
 msgid "Norwegian (Nynorsk)"
 msgstr "נורבגית (Nynorsk)"
 
-#: src/Preferences.cpp:730
+#: src/Preferences.cpp:702
 msgid "Polish"
 msgstr "פונלית"
 
-#: src/Preferences.cpp:731
+#: src/Preferences.cpp:703
 msgid "Portuguese"
 msgstr "פורטגזית"
 
-#: src/Preferences.cpp:732
+#: src/Preferences.cpp:704
 msgid "Portuguese (Brazilian)"
 msgstr "פורטגזית (ברזילאית)"
 
-#: src/Preferences.cpp:733
+#: src/Preferences.cpp:705
 #, fuzzy
 msgid "Romanian"
 msgstr "אלבני"
 
-#: src/Preferences.cpp:734
+#: src/Preferences.cpp:706
 msgid "Russian"
 msgstr "רוסית"
 
-#: src/Preferences.cpp:735
+#: src/Preferences.cpp:707
 msgid "Slovenian"
 msgstr "סלובקית"
 
-#: src/Preferences.cpp:736
+#: src/Preferences.cpp:708
 msgid "Spanish"
 msgstr "ספרדית"
 
-#: src/Preferences.cpp:737
+#: src/Preferences.cpp:709
 msgid "Swedish"
 msgstr "שוודית"
 
-#: src/Preferences.cpp:738
+#: src/Preferences.cpp:710
 msgid "Turkish"
 msgstr "טורקית"
 
-#: src/Preferences.cpp:739
+#: src/Preferences.cpp:711
 msgid "Ukrainian"
 msgstr ""
 
-#: src/Preferences.cpp:842
+#: src/Preferences.cpp:814
 msgid "Change Language"
 msgstr ""
 
-#: src/Preferences.cpp:906
+#: src/Preferences.cpp:878
 msgid "There are no translations installed for aMule"
 msgstr ""
 
-#: src/Preferences.cpp:907
+#: src/Preferences.cpp:879
 #, fuzzy
 msgid "No languages available"
 msgstr "לא זמין"
 
-#: src/Preferences.cpp:1038
+#: src/Preferences.cpp:1010
 msgid "no options available"
 msgstr ""
 
-#: src/Preferences.cpp:2226
+#: src/Preferences.cpp:2179
 msgid "Invalid category found, skipping"
 msgstr ""
 
-#: src/Preferences.cpp:2395
+#: src/Preferences.cpp:2348
 msgid "TCP port can't be higher than 65532 due to server UDP socket being TCP+3"
 msgstr "מבואת ה TCP אינה יכולה להיות גבוהה יותר מ 65532 מאחר שמבואת ה UDP של השרת היא מבואת ה TCP +3"
 
-#: src/Preferences.cpp:2396
+#: src/Preferences.cpp:2349
 #, c-format
 msgid "Default port will be used (%d)"
 msgstr "נשתמש במבואה שבברירת מחדך (%d)"
 
-#: src/PrefsUnifiedDlg.cpp:300 src/Statistics.cpp:866
+#: src/PrefsUnifiedDlg.cpp:298 src/Statistics.cpp:866
 msgid "Connection"
 msgstr "חיבור"
 
-#: src/PrefsUnifiedDlg.cpp:301 src/SearchListCtrl.cpp:117
+#: src/PrefsUnifiedDlg.cpp:299 src/SearchListCtrl.cpp:117
 msgid "Directories"
 msgstr "מלונים"
 
-#: src/PrefsUnifiedDlg.cpp:302 src/Statistics.cpp:917
+#: src/PrefsUnifiedDlg.cpp:300 src/Statistics.cpp:917
 msgid "Servers"
 msgstr "שרתים"
 
-#: src/PrefsUnifiedDlg.cpp:303 src/ServerListCtrl.cpp:96
+#: src/PrefsUnifiedDlg.cpp:301 src/ServerListCtrl.cpp:96
 msgid "Files"
 msgstr "קבצים"
 
-#: src/PrefsUnifiedDlg.cpp:304
+#: src/PrefsUnifiedDlg.cpp:302
 msgid "Security"
 msgstr "אבטחה"
 
-#: src/PrefsUnifiedDlg.cpp:305
+#: src/PrefsUnifiedDlg.cpp:303
 msgid "Interface"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:312
+#: src/PrefsUnifiedDlg.cpp:310
 msgid "IP2Country"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:315
+#: src/PrefsUnifiedDlg.cpp:313
 msgid "Proxy"
 msgstr "פרוקסי"
 
-#: src/PrefsUnifiedDlg.cpp:316
+#: src/PrefsUnifiedDlg.cpp:314
 msgid "Filters"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:317
+#: src/PrefsUnifiedDlg.cpp:315
 msgid "Remote Controls"
 msgstr "שליטה מרחוק"
 
-#: src/PrefsUnifiedDlg.cpp:318
+#: src/PrefsUnifiedDlg.cpp:316
 msgid "Online Signature"
 msgstr "חתימה מקוונת"
 
-#: src/PrefsUnifiedDlg.cpp:319
+#: src/PrefsUnifiedDlg.cpp:317
 msgid "Advanced"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:320
+#: src/PrefsUnifiedDlg.cpp:318
 msgid "Events"
 msgstr "ארועים"
 
-#: src/PrefsUnifiedDlg.cpp:323
+#: src/PrefsUnifiedDlg.cpp:321
 msgid "Debugging"
 msgstr "ניפוי שגיאות"
 
-#: src/PrefsUnifiedDlg.cpp:453
+#: src/PrefsUnifiedDlg.cpp:451
 msgid ""
 "The following variables will be substituted:\n"
 "    %PARTFILE - full path to the file\n"
 "    %PARTNAME - file name only"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:474
+#: src/PrefsUnifiedDlg.cpp:472
 msgid "Tray icon support requires libayatana-appindicator3 at compile time."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:490
+#: src/PrefsUnifiedDlg.cpp:488
 msgid "Not available on Wayland: the protocol does not report when a window is minimized, so this option cannot intercept the system minimize button. Workaround: launch aMule with `GDK_BACKEND=x11` to use XWayland instead."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:536
+#: src/PrefsUnifiedDlg.cpp:534
 msgid ""
 "Do not change these setting unless you know\n"
 "what you are doing, otherwise you can easily\n"
@@ -5704,35 +5671,26 @@ msgid ""
 "these settings."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:647
+#: src/PrefsUnifiedDlg.cpp:645
 #, c-format
 msgid "Failed to connect Cfg to widget with the ID %d and key %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:695
+#: src/PrefsUnifiedDlg.cpp:693
 #, c-format
 msgid "Failed to transfer data from Cfg to Widget with the ID %d and key %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:801
+#: src/PrefsUnifiedDlg.cpp:799
 msgid "The type of proxy you are connecting to"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1020
+#: src/PrefsUnifiedDlg.cpp:1003
 #, c-format
 msgid "Failed to transfer data from Widget to Cfg with the ID %d and key %s"
 msgstr ""
 
 #: src/PrefsUnifiedDlg.cpp:1103
-#, fuzzy
-msgid "No password set."
-msgstr "בודק סיסמא\n"
-
-#: src/PrefsUnifiedDlg.cpp:1132
-msgid "Guest access needs a password. Type one in the guest password field, or untick Enable guest access."
-msgstr ""
-
-#: src/PrefsUnifiedDlg.cpp:1144
 msgid ""
 "aMule must be restarted to enable these changes:\n"
 "\n"
@@ -5740,51 +5698,51 @@ msgstr ""
 "אימיול חייב להיות מאותחל מחדש על מנת לאפשר את השינויים הללו:\n"
 "\n"
 
-#: src/PrefsUnifiedDlg.cpp:1151
+#: src/PrefsUnifiedDlg.cpp:1110
 msgid "- TCP port changed.\n"
 msgstr "- מבואת TCP שונתה \n"
 
-#: src/PrefsUnifiedDlg.cpp:1156
+#: src/PrefsUnifiedDlg.cpp:1115
 msgid "- UDP port changed.\n"
 msgstr "- מבואת UDP שונתה \n"
 
-#: src/PrefsUnifiedDlg.cpp:1161
+#: src/PrefsUnifiedDlg.cpp:1120
 #, fuzzy
 msgid "- Network interface binding changed.\n"
 msgstr "חיבור חיצוני נסגר."
 
-#: src/PrefsUnifiedDlg.cpp:1166
+#: src/PrefsUnifiedDlg.cpp:1125
 #, fuzzy
 msgid "- External connect port changed.\n"
 msgstr "חיבור חיצוני נסגר."
 
-#: src/PrefsUnifiedDlg.cpp:1170
+#: src/PrefsUnifiedDlg.cpp:1129
 #, fuzzy
 msgid "- External connect acceptance changed.\n"
 msgstr "גישה חיצונית חדשה התקבלה"
 
-#: src/PrefsUnifiedDlg.cpp:1174
+#: src/PrefsUnifiedDlg.cpp:1133
 #, fuzzy
 msgid "- External connect interface changed.\n"
 msgstr "חיבור חיצוני נסגר."
 
-#: src/PrefsUnifiedDlg.cpp:1178
+#: src/PrefsUnifiedDlg.cpp:1137
 #, fuzzy
 msgid "- Protocol obfuscation support changed.\n"
 msgstr "חיבור חיצוני נסגר."
 
-#: src/PrefsUnifiedDlg.cpp:1193
+#: src/PrefsUnifiedDlg.cpp:1151
 #, fuzzy
 msgid "- amuleapi settings changed.\n"
 msgstr "- השפה שונתה.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1202
+#: src/PrefsUnifiedDlg.cpp:1160
 msgid ""
 "Your Auto-update server list is empty.\n"
 "'Auto-update server list at startup' will be disabled."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1213
+#: src/PrefsUnifiedDlg.cpp:1171
 msgid ""
 "You have enabled external connections but have not specified a password.\n"
 "External connections cannot be enabled unless a valid password is specified."
@@ -5792,40 +5750,35 @@ msgstr ""
 "אתה אפשרת חיבוריים חיצוניים אבל לא הזנת סיסמא תקיפה.\n"
 "חיבורים חיצוניים לא יאופשרו אלא אם כן תוזן סיסמא תקיפה."
 
-#: src/PrefsUnifiedDlg.cpp:1246
-#, c-format
-msgid "The amuleapi password could not be saved: %s"
-msgstr ""
-
-#: src/PrefsUnifiedDlg.cpp:1276
+#: src/PrefsUnifiedDlg.cpp:1202
 msgid "- Language changed.\n"
 msgstr "- השפה שונתה.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1281
+#: src/PrefsUnifiedDlg.cpp:1207
 msgid "- Temp folder changed.\n"
 msgstr "- הפסרייה הזמנית שונתה.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1286
+#: src/PrefsUnifiedDlg.cpp:1212
 #, fuzzy
 msgid "- ED2K network enabled.\n"
 msgstr "כל הרשתות מנוטרלות."
 
-#: src/PrefsUnifiedDlg.cpp:1319
+#: src/PrefsUnifiedDlg.cpp:1245
 msgid "The shared-file exclusion pattern is not a valid regular expression. The filter has been left disabled."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1321 src/PrefsUnifiedDlg.cpp:1921
+#: src/PrefsUnifiedDlg.cpp:1247 src/PrefsUnifiedDlg.cpp:1841
 #, fuzzy
 msgid "Invalid regular expression"
 msgstr "גרסת פרוטוקל לא תקפה."
 
-#: src/PrefsUnifiedDlg.cpp:1398
+#: src/PrefsUnifiedDlg.cpp:1324
 msgid ""
 "Both eD2k and Kad network are disabled.\n"
 "You won't be able to connect until you enable at least one of them."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1403
+#: src/PrefsUnifiedDlg.cpp:1329
 msgid ""
 "Kad will not start if your UDP port is disabled.\n"
 "Enable UDP port or disable Kad."
@@ -5833,7 +5786,7 @@ msgstr ""
 "קאד לא יתחיל אם מבואת ה UDB מנוטרלת.\n"
 "תאפשר את מבואת ה UDP או שתנטרל את קאד."
 
-#: src/PrefsUnifiedDlg.cpp:1459
+#: src/PrefsUnifiedDlg.cpp:1385
 msgid ""
 "\n"
 "You MUST restart aMule now.\n"
@@ -5843,69 +5796,69 @@ msgstr ""
 "אתה חייב לאתחל את אימיול עכשיו!\n"
 "אם לא תאתחל את אימיול עכשיו אל תתלונן אם משהו רע יקרה.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1524
+#: src/PrefsUnifiedDlg.cpp:1450
 msgid "Could not register aMule for autostart at login. The autostart store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1526
+#: src/PrefsUnifiedDlg.cpp:1452
 msgid "Could not remove the autostart-at-login entry."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1527
+#: src/PrefsUnifiedDlg.cpp:1453
 #, fuzzy
 msgid "Autostart"
 msgstr "רענון אוטמטי התחיל"
 
-#: src/PrefsUnifiedDlg.cpp:1542
+#: src/PrefsUnifiedDlg.cpp:1468
 msgid "Register file type"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1542
+#: src/PrefsUnifiedDlg.cpp:1468
 msgid "Register URL handler"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1550
+#: src/PrefsUnifiedDlg.cpp:1476
 #, c-format
 msgid "aMule only handles eD2k-compatible magnets. If you replace the current magnet handler (%s), BitTorrent magnet links will stop working - aMule cannot download BitTorrent content. Continue?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1555
+#: src/PrefsUnifiedDlg.cpp:1481
 #, c-format
 msgid "Another application currently opens .emulecollection files (%s). Replace it with aMule?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1560
+#: src/PrefsUnifiedDlg.cpp:1486
 #, c-format
 msgid "Another application is currently the default handler for these links (%s). Replace it with aMule?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1585
+#: src/PrefsUnifiedDlg.cpp:1511
 msgid "Could not register aMule for .emulecollection files. The registration store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1587
+#: src/PrefsUnifiedDlg.cpp:1513
 #, fuzzy
 msgid "Could not remove the file type registration."
 msgstr "אתה כבר מנסה להוריד את הקובץ %s"
 
-#: src/PrefsUnifiedDlg.cpp:1589
+#: src/PrefsUnifiedDlg.cpp:1515
 msgid "Could not register aMule as the URL handler. The registration store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1591
+#: src/PrefsUnifiedDlg.cpp:1517
 msgid "Could not remove the URL handler registration."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1661 src/PrefsUnifiedDlg.cpp:1688
+#: src/PrefsUnifiedDlg.cpp:1587 src/PrefsUnifiedDlg.cpp:1614
 #, fuzzy
 msgid "The web server and aMule API require external connections to be enabled."
 msgstr "גישה חיצונית חדשה התקבלה"
 
-#: src/PrefsUnifiedDlg.cpp:1671
+#: src/PrefsUnifiedDlg.cpp:1597
 msgid "The aMule web server is deprecated. Consider running the aMule API instead."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1735
+#: src/PrefsUnifiedDlg.cpp:1655
 msgid ""
 "Your Auto-update servers list is in blank.\n"
 "Please fill in at least one URL to point to a valid server.met file.\n"
@@ -5915,66 +5868,66 @@ msgstr ""
 "בבקשה תכניס לפחות כתובת URL אחת שתצביע לקובץ server.met תקף.\n"
 "לחץ על הכפתור \"רשימה\" שליד הצ'קבוקס הזה כדי להכניס בתובת URL."
 
-#: src/PrefsUnifiedDlg.cpp:1876
+#: src/PrefsUnifiedDlg.cpp:1796
 msgid "Temporary files"
 msgstr "קבצים זמניים"
 
-#: src/PrefsUnifiedDlg.cpp:1881
+#: src/PrefsUnifiedDlg.cpp:1801
 msgid "Incoming files"
 msgstr "קבצים נכנסים"
 
-#: src/PrefsUnifiedDlg.cpp:1886
+#: src/PrefsUnifiedDlg.cpp:1806
 msgid "Online Signatures"
 msgstr "חתימה מקוונת"
 
-#: src/PrefsUnifiedDlg.cpp:1899
+#: src/PrefsUnifiedDlg.cpp:1819
 #, c-format
 msgid "Choose a folder for %s"
 msgstr "בחר תיקייה עבור %s"
 
-#: src/PrefsUnifiedDlg.cpp:1923
+#: src/PrefsUnifiedDlg.cpp:1843
 #, fuzzy, c-format
 msgid "Would exclude %u of %u shared file"
 msgid_plural "Would exclude %u of %u shared files"
 msgstr[0] "נמצא %i קובץ משותף מוכר"
 msgstr[1] "נמצא %i קובץ משותף מוכר"
 
-#: src/PrefsUnifiedDlg.cpp:1940
+#: src/PrefsUnifiedDlg.cpp:1860
 msgid "Browse for videoplayer"
 msgstr "חפש נגן סרטים"
 
-#: src/PrefsUnifiedDlg.cpp:1944
+#: src/PrefsUnifiedDlg.cpp:1864
 msgid "Select browser"
 msgstr "בחר דפדפן"
 
-#: src/PrefsUnifiedDlg.cpp:1948
+#: src/PrefsUnifiedDlg.cpp:1868
 #, fuzzy
 msgid "Select ffprobe binary"
 msgstr "בחר דפדפן"
 
-#: src/PrefsUnifiedDlg.cpp:1954
+#: src/PrefsUnifiedDlg.cpp:1874
 #, c-format
 msgid "Executable%s"
 msgstr "קובץ הרצה %s"
 
-#: src/PrefsUnifiedDlg.cpp:1988
+#: src/PrefsUnifiedDlg.cpp:1908
 msgid "ffprobe not found on PATH or in the standard install locations. Install ffmpeg (which ships ffprobe) or use Browse to pick a binary manually."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2000
+#: src/PrefsUnifiedDlg.cpp:1920
 msgid "Reset the settings on this page to their default values?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2001
+#: src/PrefsUnifiedDlg.cpp:1921
 #, fuzzy
 msgid "Reset to defaults"
 msgstr "ברירת מחדל של המערכת"
 
-#: src/PrefsUnifiedDlg.cpp:2028
+#: src/PrefsUnifiedDlg.cpp:1948
 msgid "Edit server list"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2029
+#: src/PrefsUnifiedDlg.cpp:1949
 msgid ""
 "Add here URL's to download server.met files.\n"
 "Only one url on each line."
@@ -5982,181 +5935,177 @@ msgstr ""
 "הוסף כאן כתובות URL שמהם ניתן להוריד קבצי server.met.\n"
 "רק כתובת אחת בכל שורה."
 
-#: src/PrefsUnifiedDlg.cpp:2084
+#: src/PrefsUnifiedDlg.cpp:2004
 msgid "IP2Country update failed"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2229 src/PrefsUnifiedDlg.cpp:2260
+#: src/PrefsUnifiedDlg.cpp:2149 src/PrefsUnifiedDlg.cpp:2180
 msgid "Data by MaxMind GeoLite2"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2231 src/PrefsUnifiedDlg.cpp:2262
+#: src/PrefsUnifiedDlg.cpp:2151 src/PrefsUnifiedDlg.cpp:2182
 #, fuzzy
 msgid "Custom source"
 msgstr "מקורות שלמים"
 
-#: src/PrefsUnifiedDlg.cpp:2233 src/PrefsUnifiedDlg.cpp:2264
+#: src/PrefsUnifiedDlg.cpp:2153 src/PrefsUnifiedDlg.cpp:2184
 msgid "Data by DB-IP.com"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2284
+#: src/PrefsUnifiedDlg.cpp:2204
 #, fuzzy, c-format
 msgid "Status: Loaded%s"
 msgstr "סטאטוס:"
 
-#: src/PrefsUnifiedDlg.cpp:2286
+#: src/PrefsUnifiedDlg.cpp:2206
 #, fuzzy, c-format
 msgid "Status: Loaded%s - %s"
 msgstr "סטאטוס:"
 
-#: src/PrefsUnifiedDlg.cpp:2290
+#: src/PrefsUnifiedDlg.cpp:2210
 msgid "Status: Failed to load - click 'Update now' to refresh."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2292
+#: src/PrefsUnifiedDlg.cpp:2212
 msgid "Status: Not found - click 'Update now' to download."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2350 src/PrefsUnifiedDlg.cpp:2374
+#: src/PrefsUnifiedDlg.cpp:2270 src/PrefsUnifiedDlg.cpp:2294
 #, fuzzy, c-format
 msgid "Update delay: %d second"
 msgid_plural "Update delay: %d seconds"
 msgstr[0] "השהיית עדון: %d שניות"
 msgstr[1] "השהיית עדון: %d שניות"
 
-#: src/PrefsUnifiedDlg.cpp:2358
+#: src/PrefsUnifiedDlg.cpp:2278
 #, fuzzy, c-format
 msgid "Time for average graph: %d minute"
 msgid_plural "Time for average graph: %d minutes"
 msgstr[0] "זמן עבור גרף הממוצע: %d דקות"
 msgstr[1] "זמן עבור גרף הממוצע: %d דקות"
 
-#: src/PrefsUnifiedDlg.cpp:2367
+#: src/PrefsUnifiedDlg.cpp:2287
 #, c-format
 msgid "Connections Graph Scale: %d"
 msgstr "סקאלאת גרף החיבורים: %d"
 
-#: src/PrefsUnifiedDlg.cpp:2382
+#: src/PrefsUnifiedDlg.cpp:2302
 #, fuzzy, c-format
 msgid "File Buffer Size: %d byte"
 msgid_plural "File Buffer Size: %d bytes"
 msgstr[0] "גודל זיכרון זמני לקובץ: %d בתים"
 msgstr[1] "גודל זיכרון זמני לקובץ: %d בתים"
 
-#: src/PrefsUnifiedDlg.cpp:2392
+#: src/PrefsUnifiedDlg.cpp:2312
 #, fuzzy, c-format
 msgid "Upload Queue Size: %d client"
 msgid_plural "Upload Queue Size: %d clients"
 msgstr[0] "גודל תור ההאלעות: %d לקוחות"
 msgstr[1] "גודל תור ההאלעות: %d לקוחות"
 
-#: src/PrefsUnifiedDlg.cpp:2402
+#: src/PrefsUnifiedDlg.cpp:2322
 #, fuzzy, c-format
 msgid "Server connection refresh interval: %d minute"
 msgid_plural "Server connection refresh interval: %d minutes"
 msgstr[0] "רענון חיבור לשרת כל: %d דקות"
 msgstr[1] "רענון חיבור לשרת כל: %d דקות"
 
-#: src/PrefsUnifiedDlg.cpp:2407
+#: src/PrefsUnifiedDlg.cpp:2327
 msgid "Server connection refresh interval: Disabled"
 msgstr "רענון חיבור לשרת: מנוטרל"
 
-#: src/PrefsUnifiedDlg.cpp:2451
+#: src/PrefsUnifiedDlg.cpp:2371
 #, fuzzy
 msgid "disabled"
 msgstr "נוטרל [%s]"
 
-#: src/PrefsUnifiedDlg.cpp:2477
+#: src/PrefsUnifiedDlg.cpp:2397
 #, fuzzy, c-format
 msgid "Execute command on '%s' event"
 msgstr "בצע פקודה בעת ארוע '%s'"
 
-#: src/PrefsUnifiedDlg.cpp:2484
+#: src/PrefsUnifiedDlg.cpp:2404
 msgid "Enable command execution on core"
 msgstr "אפשר הרצת פקודות על הליבה"
 
-#: src/PrefsUnifiedDlg.cpp:2496
+#: src/PrefsUnifiedDlg.cpp:2416
 msgid "Core command:"
 msgstr "פקודת ליבה:"
 
-#: src/PrefsUnifiedDlg.cpp:2512
+#: src/PrefsUnifiedDlg.cpp:2432
 msgid "Enable command execution on GUI"
 msgstr "אפשר ביצוע פקודות על ממשק גרפי"
 
-#: src/PrefsUnifiedDlg.cpp:2524
+#: src/PrefsUnifiedDlg.cpp:2444
 msgid "GUI command:"
 msgstr "פקודת ממשק גרפי:"
 
-#: src/PrefsUnifiedDlg.cpp:2540
+#: src/PrefsUnifiedDlg.cpp:2460
 msgid "The following variables will be replaced:"
 msgstr "המשתנים הבאים יוחלפו:"
 
-#: src/PrefsUnifiedDlg.cpp:2708
+#: src/PrefsUnifiedDlg.cpp:2628
 msgid ""
 "The following folders look like system or sensitive locations:\n"
 "\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2713
+#: src/PrefsUnifiedDlg.cpp:2633
 msgid "Sharing them recursively will publish every file underneath on the eD2k/Kad networks. Do you really want to do this?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2716
+#: src/PrefsUnifiedDlg.cpp:2636
 #, fuzzy
 msgid "Confirm shared folders"
 msgstr "טען מחדש את הקבצים המשותפים שלך"
 
-#: src/PrefsUnifiedDlg.cpp:2744
+#: src/PrefsUnifiedDlg.cpp:2664
 #, fuzzy
 msgid "Reloading shared files..."
 msgstr "טען מחדש את הקבצים המשותפים שלך"
 
-#: src/PrefsUnifiedDlg.cpp:2745
+#: src/PrefsUnifiedDlg.cpp:2665
 msgid "Scanning for subdirectories..."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2746
+#: src/PrefsUnifiedDlg.cpp:2666
 #, fuzzy
 msgid "Updating shared folders"
 msgstr "קורא את הספרייה הזמנית"
 
-#: src/PrefsUnifiedDlg.cpp:2773
+#: src/PrefsUnifiedDlg.cpp:2693
 #, c-format
 msgid "Scanned %u directories..."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2823
+#: src/PrefsUnifiedDlg.cpp:2743
 #, fuzzy, c-format
 msgid "Reloading shared files: %u files scanned"
 msgstr "טוען מחדש את רשימת הקבצים המשותפים."
 
-#: src/PrefsUnifiedDlg.cpp:2873
+#: src/PrefsUnifiedDlg.cpp:2793
 #, fuzzy
 msgid "Shared folder"
 msgstr "קבצים משותפים"
 
-#: src/SearchDlg.cpp:280
-msgid "Clear search history"
-msgstr ""
-
-#: src/SearchDlg.cpp:584
+#: src/SearchDlg.cpp:425
 msgid "It's impossible to search when both eD2k and Kademlia are disabled."
 msgstr ""
 
-#: src/SearchDlg.cpp:585 src/SearchListCtrl.cpp:858
+#: src/SearchDlg.cpp:426 src/SearchListCtrl.cpp:858
 #, fuzzy
 msgid "Search error"
 msgstr "חיפושים"
 
-#: src/SearchDlg.cpp:929
+#: src/SearchDlg.cpp:768
 msgid "Min size must be smaller than max size. Max size ignored."
 msgstr ""
 
-#: src/SearchDlg.cpp:930 src/SearchDlg.cpp:1012
+#: src/SearchDlg.cpp:769 src/SearchDlg.cpp:851
 msgid "Search warning"
 msgstr ""
 
-#: src/SearchDlg.cpp:1092 src/SearchListCtrl.cpp:735
+#: src/SearchDlg.cpp:929 src/SearchListCtrl.cpp:735
 msgid "Main"
 msgstr "ראשי"
 

--- a/po/he.po
+++ b/po/he.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-28 08:06+0200\n"
+"POT-Creation-Date: 2026-07-28 10:19+0200\n"
 "PO-Revision-Date: 2026-07-27 11:39+0000\n"
 "Last-Translator: Peace Kramer <kpeace1@gmail.com>\n"
 "Language-Team: Hebrew\n"
@@ -140,7 +140,7 @@ msgstr ""
 msgid "Not now"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:422 src/amuleDlg.cpp:600
+#: src/AppImageIntegration.cpp:422 src/amuleDlg.cpp:665
 msgid "Don't ask again"
 msgstr ""
 
@@ -214,7 +214,7 @@ msgid "Killing amuleweb instance with pid '%d' ... "
 msgstr ""
 
 #: src/amule.cpp:336 src/amule.cpp:349 src/ClientRef.cpp:180
-#: src/SearchDlg.cpp:880 src/ServerListCtrl.cpp:98
+#: src/SearchDlg.cpp:1041 src/ServerListCtrl.cpp:98
 msgid "Failed"
 msgstr "נכשל"
 
@@ -561,30 +561,68 @@ msgstr ""
 msgid "ERROR: %s"
 msgstr "אירעה שגיאה: %s"
 
-#: src/amuleDlg.cpp:236
+#: src/amuleDlg.cpp:250
 #, c-format
 msgid "This is aMule %s based on eMule."
 msgstr "זהו אֵימיול %s המבוסס על אִמיול"
 
-#: src/amuleDlg.cpp:237
+#: src/amuleDlg.cpp:251
 #, c-format
 msgid "Running on %s"
 msgstr "פועל על %s"
 
-#: src/amuleDlg.cpp:239
+#: src/amuleDlg.cpp:253
 msgid "Visit https://github.com/amule-org/amule/releases/latest to check if a new version is available."
 msgstr "בקר ב https://github.com/amule-org/amule/releases/latest כדי לבדוק האם ישנה גירסה חדישה זמינה."
 
-#: src/amuleDlg.cpp:268
+#: src/amuleDlg.cpp:282
 msgid "FATAL ERROR: Failed to create Timer"
 msgstr ""
 
-#: src/amuleDlg.cpp:592
+#: src/amuleDlg.cpp:361 src/amuleDlg.cpp:1787 src/amuleDlg.cpp:2033
+#: src/muuli_wdr.cpp:1492 src/muuli_wdr.cpp:3418
+msgid "Networks"
+msgstr "רשתות"
+
+#: src/amuleDlg.cpp:362 src/amuleDlg.cpp:1793 src/muuli_wdr.cpp:3419
+msgid "Searches"
+msgstr "חיפושים"
+
+#: src/amuleDlg.cpp:363 src/amuleDlg.cpp:1799 src/DownloadListCtrl.cpp:740
+#: src/muuli_wdr.cpp:392 src/muuli_wdr.cpp:1585 src/muuli_wdr.cpp:3420
+#: src/Statistics.cpp:829
+msgid "Downloads"
+msgstr "הורדות"
+
+#: src/amuleDlg.cpp:364 src/amuleDlg.cpp:1805 src/muuli_wdr.cpp:3294
+msgid "Shared files"
+msgstr ""
+
+#: src/amuleDlg.cpp:365 src/amuleDlg.cpp:1811 src/muuli_wdr.cpp:2926
+#: src/muuli_wdr.cpp:3376 src/muuli_wdr.cpp:3423
+msgid "Messages"
+msgstr "הודעות"
+
+#: src/amuleDlg.cpp:366 src/amuleDlg.cpp:1817 src/muuli_wdr.cpp:3424
+#: src/PrefsUnifiedDlg.cpp:312 src/Statistics.cpp:779 src/Statistics.cpp:1235
+msgid "Statistics"
+msgstr "סטטיסטיקות"
+
+#: src/amuleDlg.cpp:368 src/amuleDlg.cpp:1824 src/muuli_wdr.cpp:3426
+#: src/PrefsUnifiedDlg.cpp:328 src/utils/wxCas/src/wxcasprefs.cpp:39
+msgid "Preferences"
+msgstr "העדפות"
+
+#: src/amuleDlg.cpp:371
+msgid "Navigate"
+msgstr ""
+
+#: src/amuleDlg.cpp:657
 #, fuzzy
 msgid "New version available"
 msgstr "לא זמין"
 
-#: src/amuleDlg.cpp:596
+#: src/amuleDlg.cpp:661
 #, c-format
 msgid ""
 "A new version of aMule (%s) is available.\n"
@@ -594,219 +632,186 @@ msgid ""
 "Would you like to open the download page?"
 msgstr ""
 
-#: src/amuleDlg.cpp:678
+#: src/amuleDlg.cpp:743
 msgid "aMule dialog destroyed"
 msgstr ""
 
-#: src/amuleDlg.cpp:701 src/DataToText.cpp:68 src/IPFilter.cpp:547
+#: src/amuleDlg.cpp:766 src/DataToText.cpp:68 src/IPFilter.cpp:547
 msgid "Connecting"
 msgstr "מתחבר"
 
-#: src/amuleDlg.cpp:893
+#: src/amuleDlg.cpp:958
 msgid "eD2k: Connecting"
 msgstr ""
 
-#: src/amuleDlg.cpp:897
+#: src/amuleDlg.cpp:962
 msgid "eD2k: Disconnected"
 msgstr ""
 
-#: src/amuleDlg.cpp:903
+#: src/amuleDlg.cpp:968
 msgid "Kad: Firewalled"
 msgstr "קאד: חסום חומתאש"
 
-#: src/amuleDlg.cpp:907
+#: src/amuleDlg.cpp:972
 msgid "Kad: Connected"
 msgstr "קאד: מחובר"
 
-#: src/amuleDlg.cpp:912
+#: src/amuleDlg.cpp:977
 msgid "Kad: Connecting"
 msgstr "קאד: מתחבר"
 
-#: src/amuleDlg.cpp:916
+#: src/amuleDlg.cpp:981
 msgid "Kad: Off"
 msgstr "קאד: מכובה"
 
-#: src/amuleDlg.cpp:964 src/DownloadListCtrl.cpp:505
+#: src/amuleDlg.cpp:1029 src/DownloadListCtrl.cpp:505
 #: src/DownloadListCtrl.cpp:749 src/FriendListCtrl.cpp:180
 #: src/muuli_wdr.cpp:731 src/muuli_wdr.cpp:782 src/muuli_wdr.cpp:846
-#: src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2224 src/muuli_wdr.cpp:2309
-#: src/muuli_wdr.cpp:3057 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
+#: src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2231 src/muuli_wdr.cpp:2316
+#: src/muuli_wdr.cpp:3064 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
 #: src/ServerListCtrl.cpp:606 src/TransferWnd.cpp:378
 #: src/utils/wxCas/src/wxcasprefs.cpp:235
 msgid "Cancel"
 msgstr "ביטול"
 
-#: src/amuleDlg.cpp:965
+#: src/amuleDlg.cpp:1030
 msgid "Stop the current connection attempts"
 msgstr "הפסק את ניסיונות ההתחברות הנוכחיים"
 
-#: src/amuleDlg.cpp:970 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976
-#: src/muuli_wdr.cpp:2447
+#: src/amuleDlg.cpp:1035 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976
+#: src/muuli_wdr.cpp:2454
 msgid "Disconnect"
 msgstr "מנותק"
 
-#: src/amuleDlg.cpp:971
+#: src/amuleDlg.cpp:1036
 msgid "Disconnect from the currently connected networks"
 msgstr "התנתק מהרשתות שאליהם אתה מחובר כעת"
 
-#: src/amuleDlg.cpp:976 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979
-#: src/muuli_wdr.cpp:2602 src/muuli_wdr.cpp:3054 src/muuli_wdr.cpp:3409
+#: src/amuleDlg.cpp:1041 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979
+#: src/muuli_wdr.cpp:2609 src/muuli_wdr.cpp:3061 src/muuli_wdr.cpp:3416
 msgid "Connect"
 msgstr "התחבר"
 
-#: src/amuleDlg.cpp:977
+#: src/amuleDlg.cpp:1042
 msgid "Connect to the currently enabled networks"
 msgstr "התחבר לרשתות שמאופשרות כרגע"
 
-#: src/amuleDlg.cpp:1089
+#: src/amuleDlg.cpp:1154
 #, fuzzy, c-format
 msgid "Up: %.1f%s (%.1f) | Down: %.1f%s (%.1f)"
 msgstr "מעלה: %.1f(%.1f) | מוריד: %.1f(%.1f)"
 
-#: src/amuleDlg.cpp:1091 src/amuleDlg.cpp:1093 src/amuleDlg.cpp:1097
-#: src/amuleDlg.cpp:1099 src/amuleDlg.cpp:1110 src/amuleDlg.cpp:1112
+#: src/amuleDlg.cpp:1156 src/amuleDlg.cpp:1158 src/amuleDlg.cpp:1162
+#: src/amuleDlg.cpp:1164 src/amuleDlg.cpp:1175 src/amuleDlg.cpp:1177
 #: src/MuleTrayIcon.cpp:796 src/MuleTrayIcon.cpp:799
 #, fuzzy
 msgid " MB/s"
 msgstr "מ\"ב/ש"
 
-#: src/amuleDlg.cpp:1091 src/amuleDlg.cpp:1093 src/amuleDlg.cpp:1097
-#: src/amuleDlg.cpp:1099 src/amuleDlg.cpp:1110 src/amuleDlg.cpp:1112
+#: src/amuleDlg.cpp:1156 src/amuleDlg.cpp:1158 src/amuleDlg.cpp:1162
+#: src/amuleDlg.cpp:1164 src/amuleDlg.cpp:1175 src/amuleDlg.cpp:1177
 #: src/MuleTrayIcon.cpp:796 src/MuleTrayIcon.cpp:799
 #: src/utils/wxCas/src/wxcasframe.cpp:1041
 msgid " kB/s"
 msgstr " ק\"ב/ש"
 
-#: src/amuleDlg.cpp:1096
+#: src/amuleDlg.cpp:1161
 #, fuzzy, c-format
 msgid "Up: %.1f%s | Down: %.1f%s"
 msgstr "מעלה: %.1f | מוריד: %.1f"
 
-#: src/amuleDlg.cpp:1128
+#: src/amuleDlg.cpp:1193
 #, c-format
 msgid "aMule (%s | Connected)"
 msgstr "אימיול (%s | מחובר)"
 
-#: src/amuleDlg.cpp:1130
+#: src/amuleDlg.cpp:1195
 #, c-format
 msgid "aMule (%s | Disconnected)"
 msgstr "אימיול (%s | מנותק)"
 
-#: src/amuleDlg.cpp:1183
+#: src/amuleDlg.cpp:1248
 #, fuzzy, c-format
 msgid "Do you really want to exit %s?"
 msgstr "האם אתה באמת רוצה לצאת מאימיול?"
 
-#: src/amuleDlg.cpp:1185
+#: src/amuleDlg.cpp:1250
 msgid "Exit confirmation"
 msgstr "אישרור יצאיה"
 
-#: src/amuleDlg.cpp:1548
+#: src/amuleDlg.cpp:1613
 msgid "Launch Command: "
 msgstr ""
 
-#: src/amuleDlg.cpp:1567 src/muuli_wdr.cpp:1971 src/Preferences.cpp:951
+#: src/amuleDlg.cpp:1632 src/muuli_wdr.cpp:1978 src/Preferences.cpp:952
 msgid "- default -"
 msgstr ""
 
-#: src/amuleDlg.cpp:1595
+#: src/amuleDlg.cpp:1660
 #, c-format
 msgid "Skin directory '%s' does not exist"
 msgstr "ספריית הסקינים '%s' לא קיימת"
 
-#: src/amuleDlg.cpp:1598
+#: src/amuleDlg.cpp:1663
 #, c-format
 msgid "WARNING: Unable to open skin file '%s' for read"
 msgstr ""
 
-#: src/amuleDlg.cpp:1722 src/amuleDlg.cpp:1968 src/muuli_wdr.cpp:1485
-#: src/muuli_wdr.cpp:3411
-msgid "Networks"
-msgstr "רשתות"
-
-#: src/amuleDlg.cpp:1726 src/muuli_wdr.cpp:3411
+#: src/amuleDlg.cpp:1791 src/muuli_wdr.cpp:3418
 msgid "Networks Window"
 msgstr "חלון הרשתות"
 
-#: src/amuleDlg.cpp:1728 src/muuli_wdr.cpp:3412
-msgid "Searches"
-msgstr "חיפושים"
-
-#: src/amuleDlg.cpp:1732 src/muuli_wdr.cpp:3412
+#: src/amuleDlg.cpp:1797 src/muuli_wdr.cpp:3419
 msgid "Searches Window"
 msgstr "חלון החיפושים"
 
-#: src/amuleDlg.cpp:1734 src/DownloadListCtrl.cpp:740 src/muuli_wdr.cpp:392
-#: src/muuli_wdr.cpp:1578 src/muuli_wdr.cpp:3413 src/Statistics.cpp:829
-msgid "Downloads"
-msgstr "הורדות"
-
-#: src/amuleDlg.cpp:1738 src/muuli_wdr.cpp:3413
+#: src/amuleDlg.cpp:1803 src/muuli_wdr.cpp:3420
 #, fuzzy
 msgid "Downloads Window"
 msgstr "מוריד מהרשת"
 
-#: src/amuleDlg.cpp:1740 src/muuli_wdr.cpp:3287
-msgid "Shared files"
-msgstr ""
-
-#: src/amuleDlg.cpp:1744 src/muuli_wdr.cpp:3415
+#: src/amuleDlg.cpp:1809 src/muuli_wdr.cpp:3422
 msgid "Shared Files Window"
 msgstr "חלון הקבצים המשותפים"
 
-#: src/amuleDlg.cpp:1746 src/muuli_wdr.cpp:2919 src/muuli_wdr.cpp:3369
-#: src/muuli_wdr.cpp:3416
-msgid "Messages"
-msgstr "הודעות"
-
-#: src/amuleDlg.cpp:1750 src/muuli_wdr.cpp:3416
+#: src/amuleDlg.cpp:1815 src/muuli_wdr.cpp:3423
 msgid "Messages Window"
 msgstr "חלון ההודעות"
 
-#: src/amuleDlg.cpp:1752 src/muuli_wdr.cpp:3417 src/PrefsUnifiedDlg.cpp:312
-#: src/Statistics.cpp:779 src/Statistics.cpp:1235
-msgid "Statistics"
-msgstr "סטטיסטיקות"
-
-#: src/amuleDlg.cpp:1756 src/muuli_wdr.cpp:3417
+#: src/amuleDlg.cpp:1821 src/muuli_wdr.cpp:3424
 msgid "Statistics Graph Window"
 msgstr "חלון גרפי הסטטיסטיקה"
 
-#: src/amuleDlg.cpp:1759 src/muuli_wdr.cpp:3419 src/PrefsUnifiedDlg.cpp:328
-#: src/utils/wxCas/src/wxcasprefs.cpp:39
-msgid "Preferences"
-msgstr "העדפות"
-
-#: src/amuleDlg.cpp:1763 src/muuli_wdr.cpp:3419
+#: src/amuleDlg.cpp:1828 src/muuli_wdr.cpp:3426
 msgid "Preferences Settings Window"
 msgstr "חלון הגדרת ההעדפות"
 
-#: src/amuleDlg.cpp:1766 src/muuli_wdr.cpp:3420
+#: src/amuleDlg.cpp:1831 src/muuli_wdr.cpp:3427
 msgid "Import"
 msgstr "ייבא"
 
-#: src/amuleDlg.cpp:1770 src/muuli_wdr.cpp:3420
+#: src/amuleDlg.cpp:1835 src/muuli_wdr.cpp:3427
 msgid "The partfile importer tool"
 msgstr "כלי הייבא עבור קובץ-החלקים"
 
-#: src/amuleDlg.cpp:1773 src/muuli_wdr.cpp:3421
+#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3428
 #: src/utils/aLinkCreator/src/alcframe.cpp:262
 msgid "About"
 msgstr "אודות"
 
-#: src/amuleDlg.cpp:1773 src/muuli_wdr.cpp:3421
+#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3428
 msgid "About/Help"
 msgstr "אודות/עזרה"
 
-#: src/amuleDlg.cpp:1971
+#: src/amuleDlg.cpp:2036
 msgid "eD2k network"
 msgstr ""
 
-#: src/amuleDlg.cpp:1974
+#: src/amuleDlg.cpp:2039
 msgid "Kad network"
 msgstr ""
 
-#: src/amuleDlg.cpp:1974
+#: src/amuleDlg.cpp:2039
 msgid "No network"
 msgstr ""
 
@@ -1342,19 +1347,19 @@ msgstr "אוטומטי [גבוה]"
 msgid "Very low"
 msgstr "מאוד נמוך"
 
-#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:743 src/muuli_wdr.cpp:2275
+#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:743 src/muuli_wdr.cpp:2282
 #: src/ServerListCtrl.cpp:263 src/ServerListCtrl.cpp:456
 #: src/SharedFilesCtrl.cpp:145
 msgid "Low"
 msgstr "נמוך"
 
-#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:744 src/muuli_wdr.cpp:2276
+#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:744 src/muuli_wdr.cpp:2283
 #: src/ServerListCtrl.cpp:266 src/ServerListCtrl.cpp:457
 #: src/SharedFilesCtrl.cpp:146
 msgid "Normal"
 msgstr "רגיל"
 
-#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:745 src/muuli_wdr.cpp:2277
+#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:745 src/muuli_wdr.cpp:2284
 #: src/ServerListCtrl.cpp:269 src/ServerListCtrl.cpp:458
 #: src/SharedFilesCtrl.cpp:147
 msgid "High"
@@ -1446,8 +1451,8 @@ msgstr "שרת מקומי"
 msgid "Remote Server"
 msgstr "שרת מרוחק"
 
-#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3174
-#: src/SearchDlg.cpp:111 src/TextClient.cpp:911
+#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3181
+#: src/SearchDlg.cpp:119 src/TextClient.cpp:911
 msgid "Kad"
 msgstr "קאד"
 
@@ -1518,7 +1523,7 @@ msgstr ""
 msgid "Size"
 msgstr "גודל"
 
-#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3241
+#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3248
 msgid "Transferred"
 msgstr "הועברו"
 
@@ -1574,7 +1579,7 @@ msgid ""
 "\n"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:746 src/muuli_wdr.cpp:2278
+#: src/DownloadListCtrl.cpp:746 src/muuli_wdr.cpp:2285
 #: src/SharedFilesCtrl.cpp:150
 msgid "Auto"
 msgstr "אוטמטי"
@@ -1612,7 +1617,7 @@ msgid "Extended Options"
 msgstr "אפשרויות מורחבות"
 
 #: src/DownloadListCtrl.cpp:770 src/DownloadListCtrl.cpp:822
-#: src/muuli_wdr.cpp:1789
+#: src/muuli_wdr.cpp:1796
 msgid "Preview"
 msgstr "תקדימון"
 
@@ -2301,19 +2306,19 @@ msgstr ""
 msgid "eD2k"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:349 src/muuli_wdr.cpp:1488
+#: src/FirstRunWizard.cpp:349 src/muuli_wdr.cpp:1495
 msgid "Kademlia"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:359 src/muuli_wdr.cpp:1416
+#: src/FirstRunWizard.cpp:359 src/muuli_wdr.cpp:1423
 msgid "Standard TCP Port "
 msgstr ""
 
-#: src/FirstRunWizard.cpp:365 src/muuli_wdr.cpp:1428
+#: src/FirstRunWizard.cpp:365 src/muuli_wdr.cpp:1435
 msgid "Extended UDP port (Kad / global search) "
 msgstr ""
 
-#: src/FirstRunWizard.cpp:377 src/muuli_wdr.cpp:1435
+#: src/FirstRunWizard.cpp:377 src/muuli_wdr.cpp:1442
 msgid "Enable UPnP for router port forwarding"
 msgstr ""
 
@@ -2340,7 +2345,7 @@ msgstr ""
 msgid "Your peer lists are already in place - nothing to download."
 msgstr "אתה כבר מנסה להוריד את הקובץ %s"
 
-#: src/FirstRunWizard.cpp:434 src/muuli_wdr.cpp:1533
+#: src/FirstRunWizard.cpp:434 src/muuli_wdr.cpp:1540
 msgid "Auto-update server list at startup"
 msgstr ""
 
@@ -2386,23 +2391,23 @@ msgid ""
 "want downloads on a different (e.g. larger) disk."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:549 src/FirstRunWizard.cpp:611 src/muuli_wdr.cpp:1701
+#: src/FirstRunWizard.cpp:549 src/FirstRunWizard.cpp:611 src/muuli_wdr.cpp:1708
 msgid "Destination folder for downloads"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:553 src/FirstRunWizard.cpp:569 src/muuli_wdr.cpp:1342
-#: src/muuli_wdr.cpp:1359 src/muuli_wdr.cpp:1676 src/muuli_wdr.cpp:1707
-#: src/muuli_wdr.cpp:1719 src/muuli_wdr.cpp:2762
+#: src/FirstRunWizard.cpp:553 src/FirstRunWizard.cpp:569 src/muuli_wdr.cpp:1349
+#: src/muuli_wdr.cpp:1366 src/muuli_wdr.cpp:1683 src/muuli_wdr.cpp:1714
+#: src/muuli_wdr.cpp:1726 src/muuli_wdr.cpp:2769
 #: src/utils/aLinkCreator/src/alcframe.cpp:135
 #: src/utils/wxCas/src/wxcasprefs.cpp:52 src/utils/wxCas/src/wxcasprefs.cpp:118
 msgid "Browse"
 msgstr "דפדף"
 
-#: src/FirstRunWizard.cpp:559 src/muuli_wdr.cpp:1712
+#: src/FirstRunWizard.cpp:559 src/muuli_wdr.cpp:1719
 msgid "(All files in this folder are shared with other peers)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:565 src/FirstRunWizard.cpp:624 src/muuli_wdr.cpp:1714
+#: src/FirstRunWizard.cpp:565 src/FirstRunWizard.cpp:624 src/muuli_wdr.cpp:1721
 msgid "Folder for temporary download files"
 msgstr ""
 
@@ -2433,7 +2438,7 @@ msgstr ""
 msgid "CRITICAL - no client on StartChatSession"
 msgstr ""
 
-#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2668 src/muuli_wdr.cpp:3345
+#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2675 src/muuli_wdr.cpp:3352
 msgid "Friends"
 msgstr "חברים"
 
@@ -2821,7 +2826,7 @@ msgstr ""
 msgid "Uploaded"
 msgstr ""
 
-#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3225
+#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3232
 msgid "Requested"
 msgstr ""
 
@@ -2947,7 +2952,7 @@ msgid "WARNING: "
 msgstr ""
 
 #: src/MuleNotebook.cpp:179 src/muuli_wdr.cpp:817 src/muuli_wdr.cpp:1229
-#: src/muuli_wdr.cpp:3129 src/muuli_wdr.cpp:3385
+#: src/muuli_wdr.cpp:3136 src/muuli_wdr.cpp:3392
 msgid "Close"
 msgstr "סגור"
 
@@ -2960,12 +2965,12 @@ msgstr "גזור"
 msgid "Copy"
 msgstr "העתק"
 
-#: src/MuleTextCtrl.cpp:88
+#: src/MuleTextCtrl.cpp:88 src/SearchDlg.cpp:261
 msgid "Paste"
 msgstr "הדבק"
 
 #: src/MuleTextCtrl.cpp:89 src/muuli_wdr.cpp:358 src/muuli_wdr.cpp:757
-#: src/muuli_wdr.cpp:2352 src/muuli_wdr.cpp:2371 src/muuli_wdr.cpp:2393
+#: src/muuli_wdr.cpp:2359 src/muuli_wdr.cpp:2378 src/muuli_wdr.cpp:2400
 #: src/utils/aLinkCreator/src/alcframe.cpp:142
 msgid "Clear"
 msgstr "נקה"
@@ -3062,8 +3067,8 @@ msgid "Exit"
 msgstr "יציאה"
 
 #: src/MuleTrayIcon.cpp:579 src/MuleTrayIcon.cpp:945 src/MuleTrayIcon.cpp:965
-#: src/muuli_wdr.cpp:1391 src/muuli_wdr.cpp:1399 src/muuli_wdr.cpp:1406
-#: src/muuli_wdr.cpp:1835 src/muuli_wdr.cpp:1841 src/OtherFunctions.cpp:91
+#: src/muuli_wdr.cpp:1398 src/muuli_wdr.cpp:1406 src/muuli_wdr.cpp:1413
+#: src/muuli_wdr.cpp:1842 src/muuli_wdr.cpp:1848 src/OtherFunctions.cpp:91
 #: src/StatisticsDlg.cpp:93 src/StatisticsDlg.cpp:95
 msgid "kB/s"
 msgstr "ק\"ב/ש"
@@ -3234,7 +3239,7 @@ msgstr "שם:"
 msgid "Type"
 msgstr "סוג/טיפוס"
 
-#: src/muuli_wdr.cpp:215 src/SearchDlg.cpp:110 src/SearchListCtrl.cpp:853
+#: src/muuli_wdr.cpp:215 src/SearchDlg.cpp:118 src/SearchListCtrl.cpp:853
 msgid "Local"
 msgstr "מקומי"
 
@@ -3305,7 +3310,7 @@ msgstr "בתים"
 msgid "KB"
 msgstr "ק\"ב"
 
-#: src/muuli_wdr.cpp:274 src/muuli_wdr.cpp:293 src/muuli_wdr.cpp:1620
+#: src/muuli_wdr.cpp:274 src/muuli_wdr.cpp:293 src/muuli_wdr.cpp:1627
 #: src/OtherFunctions.cpp:64
 msgid "MB"
 msgstr "מ\"ב"
@@ -3322,7 +3327,7 @@ msgstr "גודל מקסימלי"
 msgid "Availability"
 msgstr "זמינות"
 
-#: src/muuli_wdr.cpp:312 src/muuli_wdr.cpp:398 src/muuli_wdr.cpp:3290
+#: src/muuli_wdr.cpp:312 src/muuli_wdr.cpp:398 src/muuli_wdr.cpp:3297
 msgid "Filter:"
 msgstr "מסנן:"
 
@@ -3354,7 +3359,7 @@ msgstr ""
 msgid "Stop"
 msgstr "עצור"
 
-#: src/muuli_wdr.cpp:348 src/muuli_wdr.cpp:1385 src/SearchListCtrl.cpp:732
+#: src/muuli_wdr.cpp:348 src/muuli_wdr.cpp:1392 src/SearchListCtrl.cpp:732
 msgid "Download"
 msgstr "הורדה"
 
@@ -3386,8 +3391,8 @@ msgstr "מקורות שנמצאו :"
 #: src/muuli_wdr.cpp:1160 src/muuli_wdr.cpp:1167 src/muuli_wdr.cpp:1172
 #: src/muuli_wdr.cpp:1179 src/muuli_wdr.cpp:1184 src/muuli_wdr.cpp:1191
 #: src/muuli_wdr.cpp:1205 src/muuli_wdr.cpp:1212 src/muuli_wdr.cpp:1217
-#: src/muuli_wdr.cpp:1224 src/muuli_wdr.cpp:3227 src/muuli_wdr.cpp:3235
-#: src/muuli_wdr.cpp:3243
+#: src/muuli_wdr.cpp:1224 src/muuli_wdr.cpp:3234 src/muuli_wdr.cpp:3242
+#: src/muuli_wdr.cpp:3250
 msgid "N/A"
 msgstr "ל\"ת"
 
@@ -3531,7 +3536,7 @@ msgstr ""
 msgid "Album :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:685 src/muuli_wdr.cpp:2247
+#: src/muuli_wdr.cpp:685 src/muuli_wdr.cpp:2254
 msgid "Title :"
 msgstr ""
 
@@ -3638,7 +3643,7 @@ msgstr "שם משתמש :"
 msgid "Userhash :"
 msgstr "גיבוב משתשמ :"
 
-#: src/muuli_wdr.cpp:895 src/muuli_wdr.cpp:1741 src/muuli_wdr.cpp:2442
+#: src/muuli_wdr.cpp:895 src/muuli_wdr.cpp:1748 src/muuli_wdr.cpp:2449
 #: src/utils/aLinkCreator/src/alcframe.cpp:137
 msgid "Add"
 msgstr "הוסף"
@@ -3647,15 +3652,15 @@ msgstr "הוסף"
 msgid "Download-Speed"
 msgstr "מהירות הורדה"
 
-#: src/muuli_wdr.cpp:954 src/muuli_wdr.cpp:989 src/muuli_wdr.cpp:2546
+#: src/muuli_wdr.cpp:954 src/muuli_wdr.cpp:989 src/muuli_wdr.cpp:2553
 msgid "Current"
 msgstr "נוכחיים"
 
-#: src/muuli_wdr.cpp:962 src/muuli_wdr.cpp:997 src/muuli_wdr.cpp:2554
+#: src/muuli_wdr.cpp:962 src/muuli_wdr.cpp:997 src/muuli_wdr.cpp:2561
 msgid "Running average"
 msgstr "ממוצע רץ"
 
-#: src/muuli_wdr.cpp:970 src/muuli_wdr.cpp:1005 src/muuli_wdr.cpp:2562
+#: src/muuli_wdr.cpp:970 src/muuli_wdr.cpp:1005 src/muuli_wdr.cpp:2569
 msgid "Session average"
 msgstr "ממוצע ההרצה הנוכחית"
 
@@ -3667,7 +3672,7 @@ msgstr "מהירות-העלאה"
 msgid "Connections"
 msgstr "חיבורים"
 
-#: src/muuli_wdr.cpp:1024 src/muuli_wdr.cpp:1860
+#: src/muuli_wdr.cpp:1024 src/muuli_wdr.cpp:1867
 msgid "Active downloads"
 msgstr "הורדות פעילות"
 
@@ -3675,7 +3680,7 @@ msgstr "הורדות פעילות"
 msgid "Active connections (1:1)"
 msgstr "חיבורים פעילים (1:1)"
 
-#: src/muuli_wdr.cpp:1040 src/muuli_wdr.cpp:1861
+#: src/muuli_wdr.cpp:1040 src/muuli_wdr.cpp:1868
 msgid "Active uploads"
 msgstr "העלאות פעילים"
 
@@ -3792,8 +3797,8 @@ msgstr ""
 msgid "Language: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1257 src/muuli_wdr.cpp:1323 src/muuli_wdr.cpp:1327
-#: src/muuli_wdr.cpp:1330
+#: src/muuli_wdr.cpp:1257 src/muuli_wdr.cpp:1330 src/muuli_wdr.cpp:1334
+#: src/muuli_wdr.cpp:1337
 msgid "The delay before showing tool-tips."
 msgstr ""
 
@@ -3869,931 +3874,939 @@ msgstr ""
 msgid "Enabling this will make aMule to show notifications when finished downloading."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1322
-msgid "Tooltip delay time: "
+#: src/muuli_wdr.cpp:1323
+msgid "Remember search history"
+msgstr ""
+
+#: src/muuli_wdr.cpp:1324
+msgid "Keeps a dropdown list of your past search terms in the Search tab's Name field. This remembers the queries you typed, not the results they returned."
 msgstr ""
 
 #: src/muuli_wdr.cpp:1329
+msgid "Tooltip delay time: "
+msgstr ""
+
+#: src/muuli_wdr.cpp:1336
 msgid "seconds"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1333
+#: src/muuli_wdr.cpp:1340
 msgid "Browser Selection"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1339
+#: src/muuli_wdr.cpp:1346
 msgid "Enter your browser name here. Leave this field empty to use the system default browser."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1346
+#: src/muuli_wdr.cpp:1353
 msgid "Open in new tab if possible"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1348
+#: src/muuli_wdr.cpp:1355
 msgid "Open the web page in a new tab instead of in a new window when possible"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1352
+#: src/muuli_wdr.cpp:1359
 msgid "Video Player"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1379
+#: src/muuli_wdr.cpp:1386
 msgid "Bandwidth limits"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1393
+#: src/muuli_wdr.cpp:1400
 msgid "Upload"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1401
+#: src/muuli_wdr.cpp:1408
 msgid "Slot Allocation"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1410
+#: src/muuli_wdr.cpp:1417
 msgid "Ports"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1420
+#: src/muuli_wdr.cpp:1427
 msgid "This is the standard eD2k port and cannot be disabled."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1423
+#: src/muuli_wdr.cpp:1430
 msgid "UDP port for server requests (TCP+3):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1425
+#: src/muuli_wdr.cpp:1432
 msgid "4665"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1432
+#: src/muuli_wdr.cpp:1439
 msgid "This UDP port is used for extended eD2k requests and Kad network"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1439
+#: src/muuli_wdr.cpp:1446
 msgid "UPnP TCP Port (Optional):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1449
+#: src/muuli_wdr.cpp:1456
 msgid "Bind local address to IP (empty for any):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1452
+#: src/muuli_wdr.cpp:1459
 msgid "Advanced users only: If you have multiple network interfaces, enter the address of the interface to which aMule should be bound."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1455 src/muuli_wdr.cpp:2054
+#: src/muuli_wdr.cpp:1462 src/muuli_wdr.cpp:2061
 msgid "Bind to network interface (empty for any):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1468
+#: src/muuli_wdr.cpp:1475
 msgid "Advanced users only: pin all of aMule's traffic to one network interface, chosen from the list or typed in by name (e.g. tun0, eth0, en0) or index. Unlike binding to an IP, this stops traffic leaking out via the default route - useful with a VPN. Requires no elevated privileges."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1474
+#: src/muuli_wdr.cpp:1481
 msgid "Max sources per downloading file:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1478
+#: src/muuli_wdr.cpp:1485
 msgid "Max simultaneous connections:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1491 src/muuli_wdr.cpp:3169
+#: src/muuli_wdr.cpp:1498 src/muuli_wdr.cpp:3176
 msgid "ED2K"
 msgstr "ED2K"
 
-#: src/muuli_wdr.cpp:1498
+#: src/muuli_wdr.cpp:1505
 msgid "Autoconnect on startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1501
+#: src/muuli_wdr.cpp:1508
 msgid "Reconnect on loss"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1523
+#: src/muuli_wdr.cpp:1530
 msgid "Remove dead server after"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1524
+#: src/muuli_wdr.cpp:1531
 msgid "Static servers are never removed, even when unreachable."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1528
+#: src/muuli_wdr.cpp:1535
 msgid "retries"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1536
+#: src/muuli_wdr.cpp:1543
 msgid "List"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1539
+#: src/muuli_wdr.cpp:1546
 msgid "Update server list when connecting to a server"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1542
+#: src/muuli_wdr.cpp:1549
 msgid "Update server list when a client connects"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1545
+#: src/muuli_wdr.cpp:1552
 msgid "Use priority system"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1549
+#: src/muuli_wdr.cpp:1556
 msgid "Use smart LowID check on connect"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1553
+#: src/muuli_wdr.cpp:1560
 msgid "Safe connect"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1557
+#: src/muuli_wdr.cpp:1564
 msgid "Autoconnect to servers in static list only"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1560
+#: src/muuli_wdr.cpp:1567
 msgid "Set manually added servers to High Priority"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1581
+#: src/muuli_wdr.cpp:1588
 msgid "Add files to download in pause mode"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1583
+#: src/muuli_wdr.cpp:1590
 msgid "Add files to download with auto priority"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1586
+#: src/muuli_wdr.cpp:1593
 msgid "Try to download first and last chunks first"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1590
+#: src/muuli_wdr.cpp:1597
 msgid "Endgame mode: rotate to faster sources for the final blocks"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1593
+#: src/muuli_wdr.cpp:1600
 msgid "Start next paused file when a file completes"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1596
+#: src/muuli_wdr.cpp:1603
 msgid "From the same category"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1598
+#: src/muuli_wdr.cpp:1605
 msgid "In alphabetic order"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1600
+#: src/muuli_wdr.cpp:1607
 msgid "Preallocate disk space for new files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1601
+#: src/muuli_wdr.cpp:1608
 msgid "For new files preallocates disk space for the whole file, thus reduces fragmentation"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1606
+#: src/muuli_wdr.cpp:1613
 msgid "Create new files as sparse files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1607
+#: src/muuli_wdr.cpp:1614
 msgid "A sparse file reserves its full size on disk immediately without writing real data to it -- fast, but unsupported or slow on some filesystems, and free-space accounting stays optimistic while the download is in progress. Turn this off to grow the file only as data arrives."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1612
+#: src/muuli_wdr.cpp:1619
 msgid "Stop downloads when free disk space reaches "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1613
+#: src/muuli_wdr.cpp:1620
 msgid "Select this if you want aMule to check your disk space"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1617
+#: src/muuli_wdr.cpp:1624
 msgid "Enter here the min disk space desired."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1623
+#: src/muuli_wdr.cpp:1630
 msgid "Save 10 sources on rare files (< 20 sources)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1627 src/Statistics.cpp:790
+#: src/muuli_wdr.cpp:1634 src/Statistics.cpp:790
 msgid "Uploads"
 msgstr "ההעלאות"
 
-#: src/muuli_wdr.cpp:1630
+#: src/muuli_wdr.cpp:1637
 msgid "Add new shared files with auto priority"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1636
+#: src/muuli_wdr.cpp:1643
 msgid "Intelligent Corruption Handling (I.C.H.)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1639
+#: src/muuli_wdr.cpp:1646
 msgid "Enable"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1642
+#: src/muuli_wdr.cpp:1649
 msgid "Advanced I.C.H. trusts every hash (not recommended)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1654 src/PrefsUnifiedDlg.cpp:1910
+#: src/muuli_wdr.cpp:1661 src/PrefsUnifiedDlg.cpp:1910
 msgid "Media metadata extraction"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1658
+#: src/muuli_wdr.cpp:1665
 msgid "Extract length / bitrate / codec from shared audio and video files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1660
+#: src/muuli_wdr.cpp:1667
 msgid "When enabled, aMule runs ffprobe on each shared media file to fill in the Length / Bitrate / Codec columns other clients see when they find the file in a search. Requires ffmpeg (the ffprobe binary) to be installed."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1667
+#: src/muuli_wdr.cpp:1674
 msgid "Path to ffprobe:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1672
+#: src/muuli_wdr.cpp:1679
 msgid "Full path to the ffprobe binary. Leave empty to have aMule auto-detect it on startup."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1680
+#: src/muuli_wdr.cpp:1687
 msgid "Detect"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1681
+#: src/muuli_wdr.cpp:1688
 msgid "Search the standard install locations for an ffprobe binary and fill the path field."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1705
+#: src/muuli_wdr.cpp:1712
 msgid ""
 "Completed downloads are stored here. All files in this folder are automatically shared with other peers.\n"
 "If this folder also holds files you don't want to share, point it at an aMule-only sub-folder."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1708
+#: src/muuli_wdr.cpp:1715
 msgid "Pick the folder where completed downloads will be stored. All files in that folder will be shared with other peers."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1722
+#: src/muuli_wdr.cpp:1729
 msgid "Shared folders"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1728
+#: src/muuli_wdr.cpp:1735
 msgid "(Folders shared by the core. Enter a path to add one.)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1736
+#: src/muuli_wdr.cpp:1743
 msgid "Absolute path of a folder on the core's machine, e.g. /home/user/shared"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1738 src/PrefsUnifiedDlg.cpp:2794
+#: src/muuli_wdr.cpp:1745 src/PrefsUnifiedDlg.cpp:2794
 msgid "Recursive"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1739
+#: src/muuli_wdr.cpp:1746
 msgid "Share every sub-folder underneath this one, including ones created later."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1743 src/utils/aLinkCreator/src/alcframe.cpp:141
+#: src/muuli_wdr.cpp:1750 src/utils/aLinkCreator/src/alcframe.cpp:141
 msgid "Remove"
 msgstr "הסר"
 
-#: src/muuli_wdr.cpp:1747
+#: src/muuli_wdr.cpp:1754
 msgid "(Right click on folder icon for recursive share)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1754
+#: src/muuli_wdr.cpp:1761
 msgid "Share hidden files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1760
+#: src/muuli_wdr.cpp:1767
 msgid "Automatically rescan shared folders for changes"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1766
+#: src/muuli_wdr.cpp:1773
 msgid "Follow symbolic links in shared folders"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1772
+#: src/muuli_wdr.cpp:1779
 msgid "Exclude files matching:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1775
+#: src/muuli_wdr.cpp:1782
 msgid "Wildcard patterns separated by '|', e.g. .DS_Store|Thumbs.db|*.tmp. Files whose name matches are not shared. Matching is case-insensitive."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1779
+#: src/muuli_wdr.cpp:1786
 msgid "Patterns are regular expressions"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1780
+#: src/muuli_wdr.cpp:1787
 msgid "When set, the whole field is one regular expression ('|' is alternation). When unset, it is a list of '|'-separated wildcards."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1790
+#: src/muuli_wdr.cpp:1797
 msgid "Show how many shared files the current pattern would exclude."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1811
+#: src/muuli_wdr.cpp:1818
 msgid "Graphs"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1814 src/muuli_wdr.cpp:1876
+#: src/muuli_wdr.cpp:1821 src/muuli_wdr.cpp:1883
 msgid "Update delay : 5 secs"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1818
+#: src/muuli_wdr.cpp:1825
 msgid "Time for average graph: 100 mins"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1822
+#: src/muuli_wdr.cpp:1829
 msgid "Connections Graph Scale: 100 "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1829
+#: src/muuli_wdr.cpp:1836
 msgid "Download graph scale:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1837
+#: src/muuli_wdr.cpp:1844
 msgid "Upload graph scale:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1847
+#: src/muuli_wdr.cpp:1854
 msgid "Colors: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1851
+#: src/muuli_wdr.cpp:1858
 msgid "Background"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1852
+#: src/muuli_wdr.cpp:1859
 msgid "Grid"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1853
+#: src/muuli_wdr.cpp:1860
 msgid "Download current"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1854
+#: src/muuli_wdr.cpp:1861
 msgid "Download running average"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1855
+#: src/muuli_wdr.cpp:1862
 msgid "Download session average"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1856
+#: src/muuli_wdr.cpp:1863
 msgid "Upload current"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1857
+#: src/muuli_wdr.cpp:1864
 msgid "Upload running average"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1858
+#: src/muuli_wdr.cpp:1865
 msgid "Upload session average"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1859
+#: src/muuli_wdr.cpp:1866
 msgid "Active connections"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1862
+#: src/muuli_wdr.cpp:1869
 msgid "Systray Icon Speed Bar"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1863
+#: src/muuli_wdr.cpp:1870
 msgid "Kad-nodes current"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1864
+#: src/muuli_wdr.cpp:1871
 msgid "Kad-nodes running"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1865
+#: src/muuli_wdr.cpp:1872
 msgid "Kad-nodes session"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1869 src/muuli_wdr.cpp:2296
+#: src/muuli_wdr.cpp:1876 src/muuli_wdr.cpp:2303
 msgid "Select"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1873
+#: src/muuli_wdr.cpp:1880
 msgid "Tree"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1883
+#: src/muuli_wdr.cpp:1890
 msgid "Number of Client Versions shown (0=unlimited)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1908
+#: src/muuli_wdr.cpp:1915
 msgid "!!! WARNING !!!"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1923
+#: src/muuli_wdr.cpp:1930
 msgid "Max new connections / 5 secs"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1925
+#: src/muuli_wdr.cpp:1932
 msgid "Concurrent Kad source lookups"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1927
+#: src/muuli_wdr.cpp:1934
 #, fuzzy
 msgid "Kad source re-search interval (minutes)"
 msgstr "קצב עדכון התקופתי של ה FTP בדקות"
 
-#: src/muuli_wdr.cpp:1929
+#: src/muuli_wdr.cpp:1936
 #, fuzzy
 msgid "Source re-ask interval (minutes)"
 msgstr "קצב עדכון התקופתי של ה FTP בדקות"
 
-#: src/muuli_wdr.cpp:1933
+#: src/muuli_wdr.cpp:1940
 msgid "File Buffer Size: 240000 bytes"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1937
+#: src/muuli_wdr.cpp:1944
 msgid "Use MMAP: memory-mapped file access (lower memory use)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1938
+#: src/muuli_wdr.cpp:1945
 msgid "Maps part files into memory instead of buffering them on the heap, lowering the process memory footprint. May reduce download speed on some disks; best for memory-constrained or upload-heavy hosts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1940
+#: src/muuli_wdr.cpp:1947
 msgid "Upload Queue Size: 5000 clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1944
+#: src/muuli_wdr.cpp:1951
 msgid "Server connection refresh interval: Disable"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1948
+#: src/muuli_wdr.cpp:1955
 msgid "Disable computer's timed standby mode"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1967
+#: src/muuli_wdr.cpp:1974
 msgid "Skin to use: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1976
+#: src/muuli_wdr.cpp:1983
 msgid "Show \"Fast eD2k Links Handler\" in every window."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1979
+#: src/muuli_wdr.cpp:1986
 msgid "Show extended info on categories tabs"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1982
+#: src/muuli_wdr.cpp:1989
 msgid "Show application version on title"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1984
+#: src/muuli_wdr.cpp:1991
 msgid "Show transfer rates on title"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1986
+#: src/muuli_wdr.cpp:1993
 msgid "Before application name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1988
+#: src/muuli_wdr.cpp:1995
 msgid "After application name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1991
+#: src/muuli_wdr.cpp:1998
 msgid "Show overhead bandwidth"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1995
+#: src/muuli_wdr.cpp:2002
 msgid "Vertical toolbar orientation"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1997
+#: src/muuli_wdr.cpp:2004
 msgid "Live column sorting (auto-reorder rows as their values change)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2004
+#: src/muuli_wdr.cpp:2011
 msgid "Download Queue Files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2007
+#: src/muuli_wdr.cpp:2014
 msgid "Show progress percentage"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2013
+#: src/muuli_wdr.cpp:2020
 msgid "Show progress bar"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2016
+#: src/muuli_wdr.cpp:2023
 msgid "Flat"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2020
+#: src/muuli_wdr.cpp:2027
 msgid "Round"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2038
+#: src/muuli_wdr.cpp:2045
 msgid "External Connection Parameters"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2041
+#: src/muuli_wdr.cpp:2048
 msgid "Accept external connections"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2048 src/muuli_wdr.cpp:2107
+#: src/muuli_wdr.cpp:2055 src/muuli_wdr.cpp:2114
 msgid "IP of the listening interface:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2051
+#: src/muuli_wdr.cpp:2058
 msgid "Enter here a valid ip in the a.b.c.d format for the listening EC interface. An empty field or 0.0.0.0 will mean any interface."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2072 src/muuli_wdr.cpp:2156
+#: src/muuli_wdr.cpp:2079 src/muuli_wdr.cpp:2163
 msgid "TCP port:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2078
+#: src/muuli_wdr.cpp:2085
 msgid "Enable UPnP port forwarding on the EC port"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2082 src/muuli_wdr.cpp:3041
+#: src/muuli_wdr.cpp:2089 src/muuli_wdr.cpp:3048
 #: src/utils/wxCas/src/wxcasprefs.cpp:167
 msgid "Password"
 msgstr "סיסמא"
 
-#: src/muuli_wdr.cpp:2088
+#: src/muuli_wdr.cpp:2095
 msgid "aMule API server parameters"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2091
+#: src/muuli_wdr.cpp:2098
 msgid "Run amuleapi (REST API) on startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2096
+#: src/muuli_wdr.cpp:2103
 #, fuzzy
 msgid "HTTP port:"
 msgstr "מבואת UPnP"
 
-#: src/muuli_wdr.cpp:2110
+#: src/muuli_wdr.cpp:2117
 msgid "The interface amuleapi's HTTP server listens on. 127.0.0.1 (default) accepts only local connections; use 0.0.0.0 or a specific IP to expose it to other hosts (set an admin password below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2113
+#: src/muuli_wdr.cpp:2120
 #, fuzzy
 msgid "Admin password"
 msgstr "בודק סיסמא\n"
 
-#: src/muuli_wdr.cpp:2118 src/muuli_wdr.cpp:2149
+#: src/muuli_wdr.cpp:2125 src/muuli_wdr.cpp:2156
 msgid "Low rights password"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2126
+#: src/muuli_wdr.cpp:2133
 msgid "Web server parameters"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2129
+#: src/muuli_wdr.cpp:2136
 msgid "Run webserver on startup (deprecated)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2135
+#: src/muuli_wdr.cpp:2142
 msgid "Web template"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2140
+#: src/muuli_wdr.cpp:2147
 msgid "Full rights password"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2144
+#: src/muuli_wdr.cpp:2151
 msgid "Enable Low rights User"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2163
+#: src/muuli_wdr.cpp:2170
 msgid "Enable UPnP port forwarding of the web server port"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2168
+#: src/muuli_wdr.cpp:2175
 msgid "Web server UPnP TCP port (Optional)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2176
+#: src/muuli_wdr.cpp:2183
 msgid "Page Refresh Time (in secs)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2183
+#: src/muuli_wdr.cpp:2190
 msgid "Enable Gzip compression"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2217
+#: src/muuli_wdr.cpp:2224
 #, fuzzy
 msgid "Reset page to defaults"
 msgstr "ברירת מחדל של המערכת"
 
-#: src/muuli_wdr.cpp:2218
+#: src/muuli_wdr.cpp:2225
 msgid "Reset the settings on the current page to their default values."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2220 src/muuli_wdr.cpp:2306 src/ServerWnd.cpp:274
+#: src/muuli_wdr.cpp:2227 src/muuli_wdr.cpp:2313 src/ServerWnd.cpp:274
 #: src/ServerWnd.cpp:282
 msgid "OK"
 msgstr "בסדר"
 
-#: src/muuli_wdr.cpp:2222
+#: src/muuli_wdr.cpp:2229
 msgid "Click here to apply any changes made to the preferences."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2225
+#: src/muuli_wdr.cpp:2232
 msgid "Reset any changes made to the preferences."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2254
+#: src/muuli_wdr.cpp:2261
 msgid "Comment :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2261
+#: src/muuli_wdr.cpp:2268
 msgid "Incoming Dir :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2270
+#: src/muuli_wdr.cpp:2277
 msgid "Change priority for new assigned files :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2274
+#: src/muuli_wdr.cpp:2281
 #, fuzzy
 msgid "Don't change"
 msgstr "- מבואת UDP שונתה \n"
 
-#: src/muuli_wdr.cpp:2286
+#: src/muuli_wdr.cpp:2293
 msgid "Select color for this Category (currently selected) :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2353 src/muuli_wdr.cpp:2372 src/muuli_wdr.cpp:2394
+#: src/muuli_wdr.cpp:2360 src/muuli_wdr.cpp:2379 src/muuli_wdr.cpp:2401
 msgid "Click this button to reset the log."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2413
+#: src/muuli_wdr.cpp:2420
 msgid "Click on this button to update the servers list from URL ..."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2417
+#: src/muuli_wdr.cpp:2424
 msgid "Server list"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2421
+#: src/muuli_wdr.cpp:2428
 msgid "Enter the url to a server.met file here and press the button to the left to update the list of known servers."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2426
+#: src/muuli_wdr.cpp:2433
 msgid "Add server manually: Name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2429
+#: src/muuli_wdr.cpp:2436
 msgid "Enter the name of the new server here"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2431 src/ServerWnd.cpp:206
+#: src/muuli_wdr.cpp:2438 src/ServerWnd.cpp:206
 msgid "IP:Port"
 msgstr "אי.פי.:מבואה"
 
-#: src/muuli_wdr.cpp:2434
+#: src/muuli_wdr.cpp:2441
 msgid "Enter the IP of the server here, using the x.x.x.x format."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2440
+#: src/muuli_wdr.cpp:2447
 msgid "Enter the port of the server here."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2443
+#: src/muuli_wdr.cpp:2450
 msgid "Add manually a server (fill fields to the left before) ..."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2472
+#: src/muuli_wdr.cpp:2479
 msgid "aMule Log"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2480
+#: src/muuli_wdr.cpp:2487
 msgid "Server Info"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2484
+#: src/muuli_wdr.cpp:2491
 msgid "ED2K Info"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2488
+#: src/muuli_wdr.cpp:2495
 msgid "Kad Info"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2516
+#: src/muuli_wdr.cpp:2523
 msgid "Click on this button to update the nodes list from URL ..."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2520
+#: src/muuli_wdr.cpp:2527
 msgid "Nodes (0)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2524
+#: src/muuli_wdr.cpp:2531
 msgid "Enter the url to a nodes.dat file here and press the button to the left to update the list of known nodes."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2527
+#: src/muuli_wdr.cpp:2534
 msgid "Nodes stats"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2569
+#: src/muuli_wdr.cpp:2576
 msgid "Bootstrap"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2572
+#: src/muuli_wdr.cpp:2579
 msgid "New node"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2577
+#: src/muuli_wdr.cpp:2584
 msgid "IP:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2597
+#: src/muuli_wdr.cpp:2604
 msgid "Port:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2610
+#: src/muuli_wdr.cpp:2617
 msgid "Bootstrap from known clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2612
+#: src/muuli_wdr.cpp:2619
 msgid "Disconnect Kad"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2646
+#: src/muuli_wdr.cpp:2653
 msgid "Use Secure User Identification"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2648
+#: src/muuli_wdr.cpp:2655
 msgid "It is recommended to enable this option. You will not receive credits if SUI is not enabled."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2650
+#: src/muuli_wdr.cpp:2657
 msgid "Protocol Obfuscation"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2653
+#: src/muuli_wdr.cpp:2660
 msgid "Support Protocol Obfuscation"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2655
+#: src/muuli_wdr.cpp:2662
 msgid "This option enabled Protocol Obfuscation, and makes aMule accept obfuscated connections from other clients."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2657
+#: src/muuli_wdr.cpp:2664
 msgid "Use obfuscation for outgoing connections"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2659
+#: src/muuli_wdr.cpp:2666
 msgid "This option makes aMule use Protocol Obfuscation when connecting other clients/servers."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2661
+#: src/muuli_wdr.cpp:2668
 msgid "Accept only obfuscated connections"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2662
+#: src/muuli_wdr.cpp:2669
 msgid "This option makes aMule only accept obfuscated connections. You will have less sources, but all your traffic will be obfuscated"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2667
+#: src/muuli_wdr.cpp:2674
 msgid "Everybody"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2669
+#: src/muuli_wdr.cpp:2676
 msgid "No one"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2671
+#: src/muuli_wdr.cpp:2678
 msgid "Who can see my shared files:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2672
+#: src/muuli_wdr.cpp:2679
 msgid "Select who can request to view a list of your shared files."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2674
+#: src/muuli_wdr.cpp:2681
 msgid "IP-Filtering"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2681
+#: src/muuli_wdr.cpp:2688
 msgid "Filter clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2683
+#: src/muuli_wdr.cpp:2690
 msgid "Enable filtering of the client IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2685
+#: src/muuli_wdr.cpp:2692
 msgid "Filter servers"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2687
+#: src/muuli_wdr.cpp:2694
 msgid "Enable filtering of the server IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2691
+#: src/muuli_wdr.cpp:2698
 msgid "Reload List"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2692
+#: src/muuli_wdr.cpp:2699
 msgid "Reload the list of IPs to filter from the file ~/.aMule/ipfilter.dat"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2698
+#: src/muuli_wdr.cpp:2705
 msgid "URL:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2702 src/muuli_wdr.cpp:2895
+#: src/muuli_wdr.cpp:2709 src/muuli_wdr.cpp:2902
 msgid "Update now"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2705
+#: src/muuli_wdr.cpp:2712
 msgid "Auto-update ipfilter at startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2709
+#: src/muuli_wdr.cpp:2716
 msgid "Filtering Level:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2715
+#: src/muuli_wdr.cpp:2722
 msgid "Always filter LAN IPs"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2718
+#: src/muuli_wdr.cpp:2725
 msgid "Paranoid handling of non-matching IPs"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2720
+#: src/muuli_wdr.cpp:2727
 msgid "Rejects a packet when its source IP differs from the IP the client claims (an anti-spoofing check). Disable only if it causes connection problems."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2722
+#: src/muuli_wdr.cpp:2729
 msgid "Use system-wide ipfilter.dat if available"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2723
+#: src/muuli_wdr.cpp:2730
 msgid "If there's no local ipfilter.dat found, allow usage of a system-wide ipfilter file."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2740
+#: src/muuli_wdr.cpp:2747
 msgid "Enable Online-Signature"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2742
+#: src/muuli_wdr.cpp:2749
 msgid "Enables the writing of the OS file, which can be used by external apps to create signatures and the like."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2746
+#: src/muuli_wdr.cpp:2753
 msgid "Update Frequency (Secs):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2749
+#: src/muuli_wdr.cpp:2756
 msgid "Change the frequency (in seconds) of Online Signature updates."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2757
+#: src/muuli_wdr.cpp:2764
 msgid "Save online signature file in: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:2763
+#: src/muuli_wdr.cpp:2770
 msgid "Click here to select the directory containing the the Online Signature files."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2796
+#: src/muuli_wdr.cpp:2803
 msgid "Show country flags for clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2797
+#: src/muuli_wdr.cpp:2804
 msgid "Render the country flag column in the transfers, queue and search views. Requires a valid MMDB GeoIP database (see below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2802
+#: src/muuli_wdr.cpp:2809
 #, fuzzy
 msgid "Database"
 msgstr "קצב מידע :"
 
-#: src/muuli_wdr.cpp:2818
+#: src/muuli_wdr.cpp:2825
 #, fuzzy
 msgid "Source:"
 msgstr "מקורות"
 
-#: src/muuli_wdr.cpp:2821
+#: src/muuli_wdr.cpp:2828
 msgid "DB-IP (free, no account)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2822
+#: src/muuli_wdr.cpp:2829
 msgid "MaxMind GeoLite2 (free, account required)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2823
+#: src/muuli_wdr.cpp:2830
 msgid "Custom URL"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2826
+#: src/muuli_wdr.cpp:2833
 msgid "Choose which provider supplies the GeoIP MMDB database. DB-IP is the default - no account required. MaxMind requires a free account + license key. Use Custom URL to point at any other MMDB host (e.g. a local mirror)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2843
+#: src/muuli_wdr.cpp:2850
 msgid ""
 "No configuration required.\n"
 "\n"
@@ -4801,11 +4814,11 @@ msgid ""
 "License: Creative Commons BY 4.0 - https://creativecommons.org/licenses/by/4.0/"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2856
+#: src/muuli_wdr.cpp:2863
 msgid "License key:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2862
+#: src/muuli_wdr.cpp:2869
 msgid ""
 "Sign up for a free MaxMind account, then generate a License Key:\n"
 "https://www.maxmind.com/en/geolite2/signup\n"
@@ -4815,230 +4828,230 @@ msgid ""
 "Requires attribution and account registration; refresh at least every 30 days."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2877
+#: src/muuli_wdr.cpp:2884
 #, fuzzy
 msgid "Download URL:"
 msgstr "מוריד: "
 
-#: src/muuli_wdr.cpp:2883
+#: src/muuli_wdr.cpp:2890
 msgid ""
 "Must point to an .mmdb file or a .gz / .tar.gz containing one.\n"
 "URL may include credentials (https://user:pass@host/...).\n"
 "License and attribution terms are set by the upstream URL - you are responsible."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2896
+#: src/muuli_wdr.cpp:2903
 msgid "Download the GeoIP database from the selected source."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2898
+#: src/muuli_wdr.cpp:2905
 msgid "Auto-update on startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2899
+#: src/muuli_wdr.cpp:2906
 msgid "Re-download the GeoIP database from the selected source every time aMule starts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2922
+#: src/muuli_wdr.cpp:2929
 msgid "Filter incoming messages (except current chat):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2924
+#: src/muuli_wdr.cpp:2931
 msgid "Filter all messages"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2926
+#: src/muuli_wdr.cpp:2933
 msgid "Filter messages from people not on your friend list"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2928
+#: src/muuli_wdr.cpp:2935
 msgid "Filter messages from unknown clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2930
+#: src/muuli_wdr.cpp:2937
 msgid "Filter messages containing (use ',' as separator):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2933 src/muuli_wdr.cpp:2944
+#: src/muuli_wdr.cpp:2940 src/muuli_wdr.cpp:2951
 msgid "add here the words amule should filter and block messages including it"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2935
+#: src/muuli_wdr.cpp:2942
 msgid "Show received messages in the log"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2938
+#: src/muuli_wdr.cpp:2945
 msgid "Comments"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2941
+#: src/muuli_wdr.cpp:2948
 msgid "Filter comments containing (use ',' as separator):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2966
+#: src/muuli_wdr.cpp:2973
 msgid "Enable Proxy"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2967
+#: src/muuli_wdr.cpp:2974
 msgid "Enable/disable proxy support"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2970
+#: src/muuli_wdr.cpp:2977
 msgid "Proxy type:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2981
+#: src/muuli_wdr.cpp:2988
 msgid "Proxy host:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2984
+#: src/muuli_wdr.cpp:2991
 msgid "The proxy host name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2986
+#: src/muuli_wdr.cpp:2993
 msgid "Proxy port:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2989
+#: src/muuli_wdr.cpp:2996
 msgid "The proxy port"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2991
+#: src/muuli_wdr.cpp:2998
 msgid "Enable authentication"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2992
+#: src/muuli_wdr.cpp:2999
 msgid "Enable/disable username/password authentication"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2995
+#: src/muuli_wdr.cpp:3002
 msgid "Username: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:2998
+#: src/muuli_wdr.cpp:3005
 msgid "The username to use to connect to the proxy"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3000
+#: src/muuli_wdr.cpp:3007
 msgid "Password:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3003
+#: src/muuli_wdr.cpp:3010
 msgid "The password to use to connect to the proxy"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3022
+#: src/muuli_wdr.cpp:3029
 msgid "Connect to:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3031
+#: src/muuli_wdr.cpp:3038
 msgid "Login to remote amule"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3036
+#: src/muuli_wdr.cpp:3043
 msgid "User name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3047
+#: src/muuli_wdr.cpp:3054
 msgid "Remember those settings"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3050
+#: src/muuli_wdr.cpp:3057
 #, fuzzy
 msgid "Force ZLIB compression"
 msgstr "השמתש בדחיסת gzip"
 
-#: src/muuli_wdr.cpp:3074
+#: src/muuli_wdr.cpp:3081
 msgid "Enable Verbose Debug-Logging."
 msgstr ""
 
-#: src/muuli_wdr.cpp:3076
+#: src/muuli_wdr.cpp:3083
 #, fuzzy
 msgid "Only to Logfile"
 msgstr "&תפתח את הקובץ"
 
-#: src/muuli_wdr.cpp:3078
+#: src/muuli_wdr.cpp:3085
 msgid "Message Categories:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3102 src/PartFileConvertDlg.cpp:160
+#: src/muuli_wdr.cpp:3109 src/PartFileConvertDlg.cpp:160
 msgid "Waiting..."
 msgstr "ממתין..."
 
-#: src/muuli_wdr.cpp:3122
+#: src/muuli_wdr.cpp:3129
 msgid "Add imports"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3125
+#: src/muuli_wdr.cpp:3132
 msgid "Retry selected"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3127
+#: src/muuli_wdr.cpp:3134
 msgid "Remove selected"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3190
+#: src/muuli_wdr.cpp:3197
 msgid "Event Types"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3209
+#: src/muuli_wdr.cpp:3216
 msgid "Statistics and queued clients for selected file(s) : Session / All time"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3233
+#: src/muuli_wdr.cpp:3240
 #, fuzzy
 msgid "Active Uploads"
 msgstr "העלאות פעילים :"
 
-#: src/muuli_wdr.cpp:3247
+#: src/muuli_wdr.cpp:3254
 msgid "Percent of total files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3299
+#: src/muuli_wdr.cpp:3306
 #, fuzzy
 msgid "Show Clients for"
 msgstr "לקוחות"
 
-#: src/muuli_wdr.cpp:3301
+#: src/muuli_wdr.cpp:3308
 #, fuzzy
 msgid "All files"
 msgstr "קבצים משותפים"
 
-#: src/muuli_wdr.cpp:3304
+#: src/muuli_wdr.cpp:3311
 #, fuzzy
 msgid "Selected files"
 msgstr "בחר מסנן תצוגה"
 
-#: src/muuli_wdr.cpp:3307
+#: src/muuli_wdr.cpp:3314
 #, fuzzy
 msgid "Active uploads only"
 msgstr "העלאות פעילים"
 
-#: src/muuli_wdr.cpp:3314
+#: src/muuli_wdr.cpp:3321
 msgid "Reload:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3318
+#: src/muuli_wdr.cpp:3325
 msgid "Reload your shared files"
 msgstr "טען מחדש את הקבצים המשותפים שלך"
 
-#: src/muuli_wdr.cpp:3381
+#: src/muuli_wdr.cpp:3388
 msgid "Send"
 msgstr "שלח"
 
-#: src/muuli_wdr.cpp:3382
+#: src/muuli_wdr.cpp:3389
 msgid "Sends the specified message."
 msgstr "שולח את ההודעה המצויינת."
 
-#: src/muuli_wdr.cpp:3386
+#: src/muuli_wdr.cpp:3393
 msgid "Close this chat-session."
 msgstr "סגור את הצ'אט הנוכחי."
 
-#: src/muuli_wdr.cpp:3409
+#: src/muuli_wdr.cpp:3416
 msgid "Connect to any server and/or Kad"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3415 src/SharedFilesCtrl.cpp:142 src/Statistics.cpp:941
+#: src/muuli_wdr.cpp:3422 src/SharedFilesCtrl.cpp:142 src/Statistics.cpp:941
 msgid "Shared Files"
 msgstr "קבצים משותפים"
 
@@ -5401,191 +5414,191 @@ msgstr ""
 msgid "ERROR: Failed to open partfile '%s'"
 msgstr ""
 
-#: src/Preferences.cpp:673
+#: src/Preferences.cpp:674
 msgid "System default"
 msgstr "ברירת מחדל של המערכת"
 
-#: src/Preferences.cpp:674
+#: src/Preferences.cpp:675
 msgid "Albanian"
 msgstr "אלבני"
 
-#: src/Preferences.cpp:675
+#: src/Preferences.cpp:676
 msgid "Arabic"
 msgstr "ערבית"
 
-#: src/Preferences.cpp:676
+#: src/Preferences.cpp:677
 #, fuzzy
 msgid "Asturian"
 msgstr "אסטונית"
 
-#: src/Preferences.cpp:677
+#: src/Preferences.cpp:678
 msgid "Basque"
 msgstr "בסקית"
 
-#: src/Preferences.cpp:678
+#: src/Preferences.cpp:679
 msgid "Bulgarian"
 msgstr "בולגרית"
 
-#: src/Preferences.cpp:679
+#: src/Preferences.cpp:680
 msgid "Catalan"
 msgstr "קטלונית"
 
-#: src/Preferences.cpp:680
+#: src/Preferences.cpp:681
 msgid "Chinese (Simplified)"
 msgstr "סינית (מופשטת)"
 
-#: src/Preferences.cpp:681
+#: src/Preferences.cpp:682
 msgid "Chinese (Traditional)"
 msgstr "סינית (מסורתית)"
 
-#: src/Preferences.cpp:682
+#: src/Preferences.cpp:683
 msgid "Croatian"
 msgstr "קרואטית"
 
-#: src/Preferences.cpp:683
+#: src/Preferences.cpp:684
 msgid "Czech"
 msgstr "צ'כית"
 
-#: src/Preferences.cpp:684
+#: src/Preferences.cpp:685
 msgid "Danish"
 msgstr "דנית"
 
-#: src/Preferences.cpp:685
+#: src/Preferences.cpp:686
 msgid "Dutch"
 msgstr "הולנדית"
 
-#: src/Preferences.cpp:686
+#: src/Preferences.cpp:687
 msgid "English (U.K.)"
 msgstr "אנגלית (בריטית)"
 
-#: src/Preferences.cpp:687
+#: src/Preferences.cpp:688
 #, fuzzy
 msgid "English (U.S.)"
 msgstr "אנגלית (בריטית)"
 
-#: src/Preferences.cpp:688
+#: src/Preferences.cpp:689
 msgid "Estonian"
 msgstr "אסטונית"
 
-#: src/Preferences.cpp:689
+#: src/Preferences.cpp:690
 msgid "Finnish"
 msgstr "פינית"
 
-#: src/Preferences.cpp:690
+#: src/Preferences.cpp:691
 msgid "French"
 msgstr "צרפתית"
 
-#: src/Preferences.cpp:691
+#: src/Preferences.cpp:692
 msgid "Galician"
 msgstr "גאלית"
 
-#: src/Preferences.cpp:692
+#: src/Preferences.cpp:693
 msgid "German"
 msgstr "גרמנית"
 
-#: src/Preferences.cpp:693
+#: src/Preferences.cpp:694
 msgid "Greek"
 msgstr "יוונית"
 
-#: src/Preferences.cpp:694
+#: src/Preferences.cpp:695
 msgid "Hebrew"
 msgstr ""
 
-#: src/Preferences.cpp:695
+#: src/Preferences.cpp:696
 msgid "Hungarian"
 msgstr "הונגרית"
 
-#: src/Preferences.cpp:696
+#: src/Preferences.cpp:697
 msgid "Italian"
 msgstr "איטלקית"
 
-#: src/Preferences.cpp:697
+#: src/Preferences.cpp:698
 msgid "Japanese"
 msgstr "יפנית"
 
-#: src/Preferences.cpp:698
+#: src/Preferences.cpp:699
 msgid "Korean"
 msgstr "קוראינית"
 
-#: src/Preferences.cpp:699
+#: src/Preferences.cpp:700
 msgid "Latvian"
 msgstr ""
 
-#: src/Preferences.cpp:700
+#: src/Preferences.cpp:701
 msgid "Lithuanian"
 msgstr "ליטאית"
 
-#: src/Preferences.cpp:701
+#: src/Preferences.cpp:702
 msgid "Norwegian (Nynorsk)"
 msgstr "נורבגית (Nynorsk)"
 
-#: src/Preferences.cpp:702
+#: src/Preferences.cpp:703
 msgid "Polish"
 msgstr "פונלית"
 
-#: src/Preferences.cpp:703
+#: src/Preferences.cpp:704
 msgid "Portuguese"
 msgstr "פורטגזית"
 
-#: src/Preferences.cpp:704
+#: src/Preferences.cpp:705
 msgid "Portuguese (Brazilian)"
 msgstr "פורטגזית (ברזילאית)"
 
-#: src/Preferences.cpp:705
+#: src/Preferences.cpp:706
 #, fuzzy
 msgid "Romanian"
 msgstr "אלבני"
 
-#: src/Preferences.cpp:706
+#: src/Preferences.cpp:707
 msgid "Russian"
 msgstr "רוסית"
 
-#: src/Preferences.cpp:707
+#: src/Preferences.cpp:708
 msgid "Slovenian"
 msgstr "סלובקית"
 
-#: src/Preferences.cpp:708
+#: src/Preferences.cpp:709
 msgid "Spanish"
 msgstr "ספרדית"
 
-#: src/Preferences.cpp:709
+#: src/Preferences.cpp:710
 msgid "Swedish"
 msgstr "שוודית"
 
-#: src/Preferences.cpp:710
+#: src/Preferences.cpp:711
 msgid "Turkish"
 msgstr "טורקית"
 
-#: src/Preferences.cpp:711
+#: src/Preferences.cpp:712
 msgid "Ukrainian"
 msgstr ""
 
-#: src/Preferences.cpp:814
+#: src/Preferences.cpp:815
 msgid "Change Language"
 msgstr ""
 
-#: src/Preferences.cpp:878
+#: src/Preferences.cpp:879
 msgid "There are no translations installed for aMule"
 msgstr ""
 
-#: src/Preferences.cpp:879
+#: src/Preferences.cpp:880
 #, fuzzy
 msgid "No languages available"
 msgstr "לא זמין"
 
-#: src/Preferences.cpp:1010
+#: src/Preferences.cpp:1011
 msgid "no options available"
 msgstr ""
 
-#: src/Preferences.cpp:2179
+#: src/Preferences.cpp:2182
 msgid "Invalid category found, skipping"
 msgstr ""
 
-#: src/Preferences.cpp:2348
+#: src/Preferences.cpp:2351
 msgid "TCP port can't be higher than 65532 due to server UDP socket being TCP+3"
 msgstr "מבואת ה TCP אינה יכולה להיות גבוהה יותר מ 65532 מאחר שמבואת ה UDP של השרת היא מבואת ה TCP +3"
 
-#: src/Preferences.cpp:2349
+#: src/Preferences.cpp:2352
 #, c-format
 msgid "Default port will be used (%d)"
 msgstr "נשתמש במבואה שבברירת מחדך (%d)"
@@ -6088,24 +6101,28 @@ msgstr "טוען מחדש את רשימת הקבצים המשותפים."
 msgid "Shared folder"
 msgstr "קבצים משותפים"
 
-#: src/SearchDlg.cpp:425
+#: src/SearchDlg.cpp:280
+msgid "Clear search history"
+msgstr ""
+
+#: src/SearchDlg.cpp:584
 msgid "It's impossible to search when both eD2k and Kademlia are disabled."
 msgstr ""
 
-#: src/SearchDlg.cpp:426 src/SearchListCtrl.cpp:858
+#: src/SearchDlg.cpp:585 src/SearchListCtrl.cpp:858
 #, fuzzy
 msgid "Search error"
 msgstr "חיפושים"
 
-#: src/SearchDlg.cpp:768
+#: src/SearchDlg.cpp:929
 msgid "Min size must be smaller than max size. Max size ignored."
 msgstr ""
 
-#: src/SearchDlg.cpp:769 src/SearchDlg.cpp:851
+#: src/SearchDlg.cpp:930 src/SearchDlg.cpp:1012
 msgid "Search warning"
 msgstr ""
 
-#: src/SearchDlg.cpp:929 src/SearchListCtrl.cpp:735
+#: src/SearchDlg.cpp:1092 src/SearchListCtrl.cpp:735
 msgid "Main"
 msgstr "ראשי"
 

--- a/po/he.po
+++ b/po/he.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-28 10:19+0200\n"
+"POT-Creation-Date: 2026-07-28 12:17+0200\n"
 "PO-Revision-Date: 2026-07-27 11:39+0000\n"
 "Last-Translator: Peace Kramer <kpeace1@gmail.com>\n"
 "Language-Team: Hebrew\n"
@@ -199,156 +199,156 @@ msgstr "פתיחת הקובץ %s·(%s נכשלה"
 msgid "WARNING: You can't add yourself as a source for an eD2k link while having a lowid."
 msgstr ""
 
-#: src/amule.cpp:300
+#: src/amule.cpp:301
 msgid "Now, exiting main app..."
 msgstr ""
 
-#: src/amule.cpp:330
+#: src/amule.cpp:331
 #, c-format
 msgid "Terminating amuleweb instance with pid '%d' ... "
 msgstr ""
 
-#: src/amule.cpp:334
+#: src/amule.cpp:335
 #, c-format
 msgid "Killing amuleweb instance with pid '%d' ... "
 msgstr ""
 
-#: src/amule.cpp:336 src/amule.cpp:349 src/ClientRef.cpp:180
+#: src/amule.cpp:337 src/amule.cpp:350 src/ClientRef.cpp:180
 #: src/SearchDlg.cpp:1041 src/ServerListCtrl.cpp:98
 msgid "Failed"
 msgstr "נכשל"
 
-#: src/amule.cpp:343
+#: src/amule.cpp:344
 #, c-format
 msgid "Terminating amuleapi instance with pid '%d' ... "
 msgstr ""
 
-#: src/amule.cpp:347
+#: src/amule.cpp:348
 #, c-format
 msgid "Killing amuleapi instance with pid '%d' ... "
 msgstr ""
 
-#: src/amule.cpp:355
+#: src/amule.cpp:356
 msgid "aMule OnExit: Terminating core."
 msgstr ""
 
-#: src/amule.cpp:466
+#: src/amule.cpp:467
 #, fuzzy
 msgid "aMule shutdown completed."
 msgstr "הורדה הסתיימה"
 
-#: src/amule.cpp:470
+#: src/amule.cpp:471
 msgid "Memory debug results for aMule exit:"
 msgstr ""
 
-#: src/amule.cpp:651
+#: src/amule.cpp:652
 #, c-format
 msgid "Binding aMule's peer-to-peer traffic to interface: %s (HTTP updates use the default route)"
 msgstr ""
 
-#: src/amule.cpp:655
+#: src/amule.cpp:656
 #, c-format
 msgid "Binding all network traffic to interface: %s"
 msgstr ""
 
-#: src/amule.cpp:659
+#: src/amule.cpp:660
 #, c-format
 msgid "WARNING: configured network interface '%s' was not found - traffic is NOT bound to it and may leave via the default route. Check the interface name in Preferences."
 msgstr ""
 
-#: src/amule.cpp:665
+#: src/amule.cpp:666
 #, c-format
 msgid "WARNING: binding to network interface '%s' requires elevated privileges and was NOT applied - traffic may leave via the default route. Grant the capability (e.g. 'sudo setcap cap_net_raw+ep' on the aMule binary) or run with sufficient privileges."
 msgstr ""
 
-#: src/amule.cpp:673
+#: src/amule.cpp:674
 #, c-format
 msgid "WARNING: could not bind to network interface '%s' - traffic may leave via the default route."
 msgstr ""
 
-#: src/amule.cpp:732
+#: src/amule.cpp:733
 msgid "Your locale has been changed to System Default due to a configuration change. Sorry."
 msgstr ""
 
-#: src/amule.cpp:734 src/amule.cpp:1581 src/CatDialog.cpp:128
+#: src/amule.cpp:735 src/amule.cpp:1589 src/CatDialog.cpp:128
 #: src/CatDialog.cpp:136 src/CatDialog.cpp:149 src/ServerList.cpp:366
 #: src/ServerListCtrl.cpp:152
 msgid "Info"
 msgstr "מידע"
 
-#: src/amule.cpp:741
+#: src/amule.cpp:742
 #, fuzzy
 msgid ""
 "\n"
 "EC configuration"
 msgstr "אישרור יצאיה"
 
-#: src/amule.cpp:744
+#: src/amule.cpp:745
 #, fuzzy
 msgid "Password set and external connections enabled."
 msgstr "גישה חיצונית חדשה התקבלה"
 
-#: src/amule.cpp:754 src/KadDlg.cpp:176 src/KadDlg.cpp:185
-#: src/PrefsUnifiedDlg.cpp:1387 src/SharedFilesCtrl.cpp:476
+#: src/amule.cpp:755 src/KadDlg.cpp:176 src/KadDlg.cpp:185
+#: src/PrefsUnifiedDlg.cpp:1461 src/SharedFilesCtrl.cpp:476
 msgid "WARNING"
 msgstr "אזהרה"
 
-#: src/amule.cpp:991
+#: src/amule.cpp:992
 #, fuzzy
 msgid "Network bootstrap"
 msgstr "רשתות"
 
-#: src/amule.cpp:996
+#: src/amule.cpp:997
 msgid ""
 "aMule has detected missing network bootstrap files.\n"
 "Select which ones to download:"
 msgstr ""
 
-#: src/amule.cpp:1005 src/FirstRunWizard.cpp:411
+#: src/amule.cpp:1006 src/FirstRunWizard.cpp:411
 msgid "eD2k server list (server.met)"
 msgstr ""
 
-#: src/amule.cpp:1012 src/FirstRunWizard.cpp:416
+#: src/amule.cpp:1013 src/FirstRunWizard.cpp:416
 msgid "Kad bootstrap nodes (nodes.dat)"
 msgstr ""
 
-#: src/amule.cpp:1102
+#: src/amule.cpp:1103
 #, c-format
 msgid "web server running on pid %d"
 msgstr ""
 
-#: src/amule.cpp:1115
+#: src/amule.cpp:1116
 msgid "You requested to run web server on startup, but the amuleweb binary cannot be run. Please install the package containing aMule web server, or build aMule from source with -DBUILD_WEBSERVER=YES and install it."
 msgstr ""
 
-#: src/amule.cpp:1120 src/amule.cpp:1177 src/amule.cpp:1291 src/amule.cpp:1593
+#: src/amule.cpp:1121 src/amule.cpp:1185 src/amule.cpp:1299 src/amule.cpp:1601
 #: src/amule-remote-gui.cpp:603 src/amule-remote-gui.cpp:671
 #: src/amule-remote-gui.cpp:709 src/amule-remote-gui.cpp:1282
 #: src/amule-remote-gui.cpp:1345 src/amule-remote-gui.cpp:1372
-#: src/DownloadQueue.cpp:1481
+#: src/DownloadQueue.cpp:1481 src/PrefsUnifiedDlg.cpp:1247
 msgid "ERROR"
 msgstr ""
 
-#: src/amule.cpp:1166
+#: src/amule.cpp:1174
 #, fuzzy, c-format
 msgid "amuleapi running on pid %d"
 msgstr "אימיול פועל"
 
-#: src/amule.cpp:1172
+#: src/amule.cpp:1180
 msgid "You requested to run amuleapi on startup, but the amuleapi binary cannot be run. Please install the package containing aMule's REST API server, or build aMule from source with -DBUILD_AMULEAPI=YES and install it."
 msgstr ""
 
-#: src/amule.cpp:1259
+#: src/amule.cpp:1267
 #, c-format
 msgid "Could not bind ports to the specified address: %s"
 msgstr ""
 
-#: src/amule.cpp:1283
+#: src/amule.cpp:1291
 #, c-format
 msgid "Port %u is not available. You will be LOWID\n"
 msgstr ""
 
-#: src/amule.cpp:1288
+#: src/amule.cpp:1296
 #, c-format
 msgid ""
 "Port %u is not available!\n"
@@ -358,185 +358,185 @@ msgid ""
 "Check your network to make sure the port is open for output and input."
 msgstr ""
 
-#: src/amule.cpp:1385
+#: src/amule.cpp:1393
 msgid "Failed to create OnlineSig File"
 msgstr ""
 
-#: src/amule.cpp:1393
+#: src/amule.cpp:1401
 msgid "Failed to create aMule OnlineSig File"
 msgstr ""
 
-#: src/amule.cpp:1556
+#: src/amule.cpp:1564
 msgid "The selected locale seems not to be installed on your box. (Note: I'll try to set it anyway)"
 msgstr ""
 
-#: src/amule.cpp:1566
+#: src/amule.cpp:1574
 #, c-format
 msgid "This is the first time you run aMule %s"
 msgstr ""
 
-#: src/amule.cpp:1569
+#: src/amule.cpp:1577
 msgid "This version is a testing version, updated daily, and\n"
 msgstr ""
 
-#: src/amule.cpp:1570
+#: src/amule.cpp:1578
 msgid "we give no warranty it won't break anything, burn your house,\n"
 msgstr ""
 
-#: src/amule.cpp:1571
+#: src/amule.cpp:1579
 msgid "or kill your dog. But it *should* be safe to use anyway.\n"
 msgstr ""
 
-#: src/amule.cpp:1576
+#: src/amule.cpp:1584
 msgid "More information, support and new releases can found at our homepage,\n"
 msgstr ""
 
-#: src/amule.cpp:1577
+#: src/amule.cpp:1585
 msgid "at https://amule-org.github.io, or in our IRC channel #aMule at irc.libera.chat.\n"
 msgstr ""
 
-#: src/amule.cpp:1579
+#: src/amule.cpp:1587
 msgid "Feel free to report any bugs to https://github.com/amule-org/amule/issues"
 msgstr "תרגיש חופשי לדוואח על כל שגיאה ל https://github.com/amule-org/amule/issues"
 
-#: src/amule.cpp:1591
+#: src/amule.cpp:1599
 msgid ""
 "The folder for Online Signature files you specified is INVALID!\n"
 " OnlineSignature will be DISABLED until you fix it on preferences."
 msgstr ""
 
-#: src/amule.cpp:1654
+#: src/amule.cpp:1662
 #, fuzzy
 msgid "Server hostname notified"
 msgstr "שם שרת:"
 
-#: src/amule.cpp:2031
+#: src/amule.cpp:2039
 #, c-format
 msgid "Disk space preallocation for file '%s' failed: %s"
 msgstr ""
 
-#: src/amule.cpp:2160
+#: src/amule.cpp:2168
 msgid "ERROR: can't open logfile"
 msgstr "שגיאה: לא יכול לפתוח קובץ יומן."
 
-#: src/amule.cpp:2164
+#: src/amule.cpp:2172
 msgid "WARNING: logfile is empty. Something is wrong."
 msgstr ""
 
-#: src/amule.cpp:2181
+#: src/amule.cpp:2189
 msgid "Log has been reset"
 msgstr "היומן אופס."
 
-#: src/amule.cpp:2205
+#: src/amule.cpp:2213
 #, c-format
 msgid "ServerMessage: %s"
 msgstr ""
 
-#: src/amule.cpp:2248 src/IP2Country.cpp:220 src/IPFilter.cpp:514
+#: src/amule.cpp:2256 src/IP2Country.cpp:220 src/IPFilter.cpp:514
 #: src/ServerList.cpp:875
 #, c-format
 msgid "Skipped download of %s, because requested file is not newer."
 msgstr ""
 
-#: src/amule.cpp:2251
+#: src/amule.cpp:2259
 msgid "Failed to download the nodes list."
 msgstr ""
 
-#: src/amule.cpp:2314
+#: src/amule.cpp:2322
 msgid "Failed to open the downloaded version check file"
 msgstr ""
 
-#: src/amule.cpp:2317 src/amule.cpp:2336
+#: src/amule.cpp:2325 src/amule.cpp:2344
 msgid "Corrupted version check file"
 msgstr ""
 
-#: src/amule.cpp:2359
+#: src/amule.cpp:2367
 msgid "You are using an outdated version of aMule!"
 msgstr ""
 
-#: src/amule.cpp:2361
+#: src/amule.cpp:2369
 #, c-format
 msgid "Your aMule version is %i.%i.%i and the latest version is %li.%li.%li"
 msgstr ""
 
-#: src/amule.cpp:2365
+#: src/amule.cpp:2373
 msgid "The latest version can always be found at https://github.com/amule-org/amule/releases/latest"
 msgstr ""
 
-#: src/amule.cpp:2368
+#: src/amule.cpp:2376
 #, c-format
 msgid "WARNING: Your aMuled version is outdated: %i.%i.%i < %li.%li.%li"
 msgstr ""
 
-#: src/amule.cpp:2374
+#: src/amule.cpp:2382
 msgid "Your copy of aMule is up to date."
 msgstr ""
 
-#: src/amule.cpp:2381
+#: src/amule.cpp:2389
 msgid "Failed to download the version check file"
 msgstr ""
 
-#: src/amule.cpp:2550 src/amule-remote-gui.cpp:1133
+#: src/amule.cpp:2558 src/amule-remote-gui.cpp:1133
 #, c-format
 msgid "Users: %s | Files: %s"
 msgstr ""
 
-#: src/amule.cpp:2551 src/amule-remote-gui.cpp:1134
+#: src/amule.cpp:2559 src/amule-remote-gui.cpp:1134
 #, c-format
 msgid "Users: E: %s K: %s | Files: E: %s K: %s"
 msgstr ""
 
-#: src/amule.cpp:2565 src/amule-remote-gui.cpp:1147
+#: src/amule.cpp:2573 src/amule-remote-gui.cpp:1147
 msgid "No networks selected"
 msgstr ""
 
-#: src/amule.cpp:2633 src/TextClient.cpp:903
+#: src/amule.cpp:2641 src/TextClient.cpp:903
 msgid "with LowID"
 msgstr "עם מ\"ז נמוך (LowID)"
 
-#: src/amule.cpp:2633 src/TextClient.cpp:904
+#: src/amule.cpp:2641 src/TextClient.cpp:904
 msgid "with HighID"
 msgstr "עם מ\"ז גבוהה (HighID)"
 
-#: src/amule.cpp:2635
+#: src/amule.cpp:2643
 #, c-format
 msgid "Connected to %s %s"
 msgstr ""
 
-#: src/amule.cpp:2640
+#: src/amule.cpp:2648
 #, c-format
 msgid "Connecting to %s"
 msgstr ""
 
-#: src/amule.cpp:2642
+#: src/amule.cpp:2650
 msgid "Disconnected from eD2k"
 msgstr ""
 
-#: src/amule.cpp:2651
+#: src/amule.cpp:2659
 msgid "Kad started."
 msgstr "קאד התחיל."
 
-#: src/amule.cpp:2653
+#: src/amule.cpp:2661
 msgid "Kad stopped."
 msgstr "קאד נעצר."
 
-#: src/amule.cpp:2661
+#: src/amule.cpp:2669
 msgid "Connected to Kad (ok)"
 msgstr "קאד מחובר (בסדר)"
 
-#: src/amule.cpp:2663
+#: src/amule.cpp:2671
 msgid "Connected to Kad (firewalled)"
 msgstr "קאד מחובר (מאחורי חומת אש)"
 
-#: src/amule.cpp:2667
+#: src/amule.cpp:2675
 msgid "Disconnected from Kad"
 msgstr "מנותק מקאד."
 
-#: src/amule.cpp:2699
+#: src/amule.cpp:2707
 msgid "Kad network cannot be used if UDP port is disabled on preferences, not starting."
 msgstr "אי אפשר להשתמש ברשת הקאד אם מוואת UDP מבוטלת בהעדפות, לא התחיל."
 
-#: src/amule.cpp:2703
+#: src/amule.cpp:2711
 msgid "Kad network disabled on preferences, not connecting."
 msgstr "קאד מבוטל בהעדפות, לא מתחבר."
 
@@ -580,36 +580,36 @@ msgid "FATAL ERROR: Failed to create Timer"
 msgstr ""
 
 #: src/amuleDlg.cpp:361 src/amuleDlg.cpp:1787 src/amuleDlg.cpp:2033
-#: src/muuli_wdr.cpp:1492 src/muuli_wdr.cpp:3418
+#: src/muuli_wdr.cpp:1492 src/muuli_wdr.cpp:3449
 msgid "Networks"
 msgstr "רשתות"
 
-#: src/amuleDlg.cpp:362 src/amuleDlg.cpp:1793 src/muuli_wdr.cpp:3419
+#: src/amuleDlg.cpp:362 src/amuleDlg.cpp:1793 src/muuli_wdr.cpp:3450
 msgid "Searches"
 msgstr "חיפושים"
 
 #: src/amuleDlg.cpp:363 src/amuleDlg.cpp:1799 src/DownloadListCtrl.cpp:740
-#: src/muuli_wdr.cpp:392 src/muuli_wdr.cpp:1585 src/muuli_wdr.cpp:3420
+#: src/muuli_wdr.cpp:392 src/muuli_wdr.cpp:1585 src/muuli_wdr.cpp:3451
 #: src/Statistics.cpp:829
 msgid "Downloads"
 msgstr "הורדות"
 
-#: src/amuleDlg.cpp:364 src/amuleDlg.cpp:1805 src/muuli_wdr.cpp:3294
+#: src/amuleDlg.cpp:364 src/amuleDlg.cpp:1805 src/muuli_wdr.cpp:3325
 msgid "Shared files"
 msgstr ""
 
-#: src/amuleDlg.cpp:365 src/amuleDlg.cpp:1811 src/muuli_wdr.cpp:2926
-#: src/muuli_wdr.cpp:3376 src/muuli_wdr.cpp:3423
+#: src/amuleDlg.cpp:365 src/amuleDlg.cpp:1811 src/muuli_wdr.cpp:2957
+#: src/muuli_wdr.cpp:3407 src/muuli_wdr.cpp:3454
 msgid "Messages"
 msgstr "הודעות"
 
-#: src/amuleDlg.cpp:366 src/amuleDlg.cpp:1817 src/muuli_wdr.cpp:3424
-#: src/PrefsUnifiedDlg.cpp:312 src/Statistics.cpp:779 src/Statistics.cpp:1235
+#: src/amuleDlg.cpp:366 src/amuleDlg.cpp:1817 src/muuli_wdr.cpp:3455
+#: src/PrefsUnifiedDlg.cpp:314 src/Statistics.cpp:779 src/Statistics.cpp:1235
 msgid "Statistics"
 msgstr "סטטיסטיקות"
 
-#: src/amuleDlg.cpp:368 src/amuleDlg.cpp:1824 src/muuli_wdr.cpp:3426
-#: src/PrefsUnifiedDlg.cpp:328 src/utils/wxCas/src/wxcasprefs.cpp:39
+#: src/amuleDlg.cpp:368 src/amuleDlg.cpp:1824 src/muuli_wdr.cpp:3457
+#: src/PrefsUnifiedDlg.cpp:330 src/utils/wxCas/src/wxcasprefs.cpp:39
 msgid "Preferences"
 msgstr "העדפות"
 
@@ -667,8 +667,8 @@ msgstr "קאד: מכובה"
 #: src/amuleDlg.cpp:1029 src/DownloadListCtrl.cpp:505
 #: src/DownloadListCtrl.cpp:749 src/FriendListCtrl.cpp:180
 #: src/muuli_wdr.cpp:731 src/muuli_wdr.cpp:782 src/muuli_wdr.cpp:846
-#: src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2231 src/muuli_wdr.cpp:2316
-#: src/muuli_wdr.cpp:3064 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
+#: src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2262 src/muuli_wdr.cpp:2347
+#: src/muuli_wdr.cpp:3095 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
 #: src/ServerListCtrl.cpp:606 src/TransferWnd.cpp:378
 #: src/utils/wxCas/src/wxcasprefs.cpp:235
 msgid "Cancel"
@@ -679,7 +679,7 @@ msgid "Stop the current connection attempts"
 msgstr "הפסק את ניסיונות ההתחברות הנוכחיים"
 
 #: src/amuleDlg.cpp:1035 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976
-#: src/muuli_wdr.cpp:2454
+#: src/muuli_wdr.cpp:2485
 msgid "Disconnect"
 msgstr "מנותק"
 
@@ -688,7 +688,7 @@ msgid "Disconnect from the currently connected networks"
 msgstr "התנתק מהרשתות שאליהם אתה מחובר כעת"
 
 #: src/amuleDlg.cpp:1041 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979
-#: src/muuli_wdr.cpp:2609 src/muuli_wdr.cpp:3061 src/muuli_wdr.cpp:3416
+#: src/muuli_wdr.cpp:2640 src/muuli_wdr.cpp:3092 src/muuli_wdr.cpp:3447
 msgid "Connect"
 msgstr "התחבר"
 
@@ -743,7 +743,7 @@ msgstr "אישרור יצאיה"
 msgid "Launch Command: "
 msgstr ""
 
-#: src/amuleDlg.cpp:1632 src/muuli_wdr.cpp:1978 src/Preferences.cpp:952
+#: src/amuleDlg.cpp:1632 src/muuli_wdr.cpp:1982 src/Preferences.cpp:979
 msgid "- default -"
 msgstr ""
 
@@ -757,49 +757,49 @@ msgstr "ספריית הסקינים '%s' לא קיימת"
 msgid "WARNING: Unable to open skin file '%s' for read"
 msgstr ""
 
-#: src/amuleDlg.cpp:1791 src/muuli_wdr.cpp:3418
+#: src/amuleDlg.cpp:1791 src/muuli_wdr.cpp:3449
 msgid "Networks Window"
 msgstr "חלון הרשתות"
 
-#: src/amuleDlg.cpp:1797 src/muuli_wdr.cpp:3419
+#: src/amuleDlg.cpp:1797 src/muuli_wdr.cpp:3450
 msgid "Searches Window"
 msgstr "חלון החיפושים"
 
-#: src/amuleDlg.cpp:1803 src/muuli_wdr.cpp:3420
+#: src/amuleDlg.cpp:1803 src/muuli_wdr.cpp:3451
 #, fuzzy
 msgid "Downloads Window"
 msgstr "מוריד מהרשת"
 
-#: src/amuleDlg.cpp:1809 src/muuli_wdr.cpp:3422
+#: src/amuleDlg.cpp:1809 src/muuli_wdr.cpp:3453
 msgid "Shared Files Window"
 msgstr "חלון הקבצים המשותפים"
 
-#: src/amuleDlg.cpp:1815 src/muuli_wdr.cpp:3423
+#: src/amuleDlg.cpp:1815 src/muuli_wdr.cpp:3454
 msgid "Messages Window"
 msgstr "חלון ההודעות"
 
-#: src/amuleDlg.cpp:1821 src/muuli_wdr.cpp:3424
+#: src/amuleDlg.cpp:1821 src/muuli_wdr.cpp:3455
 msgid "Statistics Graph Window"
 msgstr "חלון גרפי הסטטיסטיקה"
 
-#: src/amuleDlg.cpp:1828 src/muuli_wdr.cpp:3426
+#: src/amuleDlg.cpp:1828 src/muuli_wdr.cpp:3457
 msgid "Preferences Settings Window"
 msgstr "חלון הגדרת ההעדפות"
 
-#: src/amuleDlg.cpp:1831 src/muuli_wdr.cpp:3427
+#: src/amuleDlg.cpp:1831 src/muuli_wdr.cpp:3458
 msgid "Import"
 msgstr "ייבא"
 
-#: src/amuleDlg.cpp:1835 src/muuli_wdr.cpp:3427
+#: src/amuleDlg.cpp:1835 src/muuli_wdr.cpp:3458
 msgid "The partfile importer tool"
 msgstr "כלי הייבא עבור קובץ-החלקים"
 
-#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3428
+#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3459
 #: src/utils/aLinkCreator/src/alcframe.cpp:262
 msgid "About"
 msgstr "אודות"
 
-#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3428
+#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3459
 msgid "About/Help"
 msgstr "אודות/עזרה"
 
@@ -944,7 +944,7 @@ msgstr "קובץ לא נמצא."
 msgid "The core rejected these shared folders:%s"
 msgstr ""
 
-#: src/amule-remote-gui.cpp:1336 src/ExternalConn.cpp:2345
+#: src/amule-remote-gui.cpp:1336 src/ExternalConn.cpp:2346
 msgid "Invalid link or already on list."
 msgstr "קישור לא תקף או שכבר נמצא ברשימה."
 
@@ -960,7 +960,7 @@ msgstr ""
 #: src/ClientDetailDialog.cpp:123 src/DataToText.cpp:61 src/DataToText.cpp:86
 #: src/DataToText.cpp:101 src/DataToText.cpp:136 src/DataToText.cpp:165
 #: src/DownloadListCtrl.cpp:1172 src/DownloadListCtrl.cpp:1185
-#: src/DownloadListCtrl.cpp:1196 src/ExternalConn.cpp:608
+#: src/DownloadListCtrl.cpp:1196 src/ExternalConn.cpp:609
 #: src/FileDetailDialog.cpp:203 src/FileDetailDialog.cpp:235
 #: src/FileDetailDialog.cpp:242 src/GenericClientListCtrl.cpp:1171
 #: src/GenericClientListCtrl.cpp:1182 src/GenericClientListCtrl.cpp:1192
@@ -1347,19 +1347,19 @@ msgstr "אוטומטי [גבוה]"
 msgid "Very low"
 msgstr "מאוד נמוך"
 
-#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:743 src/muuli_wdr.cpp:2282
+#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:743 src/muuli_wdr.cpp:2313
 #: src/ServerListCtrl.cpp:263 src/ServerListCtrl.cpp:456
 #: src/SharedFilesCtrl.cpp:145
 msgid "Low"
 msgstr "נמוך"
 
-#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:744 src/muuli_wdr.cpp:2283
+#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:744 src/muuli_wdr.cpp:2314
 #: src/ServerListCtrl.cpp:266 src/ServerListCtrl.cpp:457
 #: src/SharedFilesCtrl.cpp:146
 msgid "Normal"
 msgstr "רגיל"
 
-#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:745 src/muuli_wdr.cpp:2284
+#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:745 src/muuli_wdr.cpp:2315
 #: src/ServerListCtrl.cpp:269 src/ServerListCtrl.cpp:458
 #: src/SharedFilesCtrl.cpp:147
 msgid "High"
@@ -1451,7 +1451,7 @@ msgstr "שרת מקומי"
 msgid "Remote Server"
 msgstr "שרת מרוחק"
 
-#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3181
+#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3212
 #: src/SearchDlg.cpp:119 src/TextClient.cpp:911
 msgid "Kad"
 msgstr "קאד"
@@ -1523,7 +1523,7 @@ msgstr ""
 msgid "Size"
 msgstr "גודל"
 
-#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3248
+#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3279
 msgid "Transferred"
 msgstr "הועברו"
 
@@ -1579,7 +1579,7 @@ msgid ""
 "\n"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:746 src/muuli_wdr.cpp:2285
+#: src/DownloadListCtrl.cpp:746 src/muuli_wdr.cpp:2316
 #: src/SharedFilesCtrl.cpp:150
 msgid "Auto"
 msgstr "אוטמטי"
@@ -1617,7 +1617,7 @@ msgid "Extended Options"
 msgstr "אפשרויות מורחבות"
 
 #: src/DownloadListCtrl.cpp:770 src/DownloadListCtrl.cpp:822
-#: src/muuli_wdr.cpp:1796
+#: src/muuli_wdr.cpp:1800
 msgid "Preview"
 msgstr "תקדימון"
 
@@ -1790,232 +1790,237 @@ msgstr[1] ""
 msgid "Invalid eD2k link! ERROR: %s"
 msgstr ""
 
-#: src/ExternalConn.cpp:379
+#: src/ExternalConn.cpp:380
 #, fuzzy
 msgid "Client sent packet after authentication failed."
 msgstr "זיהוי נכשל"
 
-#: src/ExternalConn.cpp:396
+#: src/ExternalConn.cpp:397
 msgid "External connection closed."
 msgstr "חיבור חיצוני נסגר."
 
-#: src/ExternalConn.cpp:473
+#: src/ExternalConn.cpp:474
 msgid "External connections disabled due to empty password!"
 msgstr "גישה חיצונית מנוטרלת מאחר שהסיסמא ריקה!"
 
-#: src/ExternalConn.cpp:494
+#: src/ExternalConn.cpp:495
 msgid "External connections disabled in config file"
 msgstr "גישה מרוחקת מנוטרלת בקובץ ההגדרות"
 
-#: src/ExternalConn.cpp:575
+#: src/ExternalConn.cpp:576
 msgid "New external connection accepted"
 msgstr "גישה חיצונית חדשה התקבלה"
 
-#: src/ExternalConn.cpp:578
+#: src/ExternalConn.cpp:579
 msgid "ERROR: couldn't accept a new external connection"
 msgstr ""
 
-#: src/ExternalConn.cpp:595
+#: src/ExternalConn.cpp:596
 msgid "External connection refused due to empty password in preferences!"
 msgstr "גישה מרחוק נכשלה עקב סיסמא ריקה בהעדפות!"
 
-#: src/ExternalConn.cpp:607
+#: src/ExternalConn.cpp:608
 #, c-format
 msgid "Connecting client: %s %s"
 msgstr "מחבר לקוח:%s %s"
 
-#: src/ExternalConn.cpp:609
+#: src/ExternalConn.cpp:610
 msgid "Unknown version"
 msgstr "גירסה לא ידועה"
 
-#: src/ExternalConn.cpp:622
+#: src/ExternalConn.cpp:623
 msgid "Incorrect EC version ID, there might be binary incompatibility. Use core and remote from same snapshot."
 msgstr "גירסת EC לא נכונה, יתכן ויש אי התאמה בינארית. השתמש בליבה ובלקוח חיצוני מאותו תצלום (גירסה)."
 
-#: src/ExternalConn.cpp:630
+#: src/ExternalConn.cpp:631
 #, fuzzy
 msgid "You cannot connect to a release version from an arbitrary development snapshot! *sigh* possible crash prevented"
 msgstr "אתה לא להתחבר לגרסה ששוחררה מSVN (כלי לניהול גרסאות תוכנה) ! *נאנח* ייתכן והתרסקות של התוכנה נמנעה"
 
-#: src/ExternalConn.cpp:713
+#: src/ExternalConn.cpp:714
 msgid "Invalid protocol version."
 msgstr "גרסת פרוטוקל לא תקפה."
 
-#: src/ExternalConn.cpp:719
+#: src/ExternalConn.cpp:720
 msgid "Missing protocol version tag."
 msgstr "חסר התווית של גרסת הפרוטוקול."
 
-#: src/ExternalConn.cpp:727
+#: src/ExternalConn.cpp:728
 msgid "Authentication failed: invalid hash specified as EC password."
 msgstr ""
 
-#: src/ExternalConn.cpp:775
+#: src/ExternalConn.cpp:776
 #, fuzzy
 msgid "Authentication failed: wrong password."
 msgstr "זיהוי נכשל"
 
-#: src/ExternalConn.cpp:777
+#: src/ExternalConn.cpp:778
 #, fuzzy
 msgid "Authentication failed: missing password."
 msgstr "זיהוי נכשל"
 
-#: src/ExternalConn.cpp:788
+#: src/ExternalConn.cpp:789
 #, fuzzy
 msgid "Invalid request, please authenticate first."
 msgstr "בקשה לא תקפה, כדאי שקודם תאמת."
 
-#: src/ExternalConn.cpp:793
+#: src/ExternalConn.cpp:794
 msgid "Access granted."
 msgstr "גישה אושרה."
 
-#: src/ExternalConn.cpp:801
+#: src/ExternalConn.cpp:802
 #, c-format
 msgid "Sent error message \"%s\" to client."
 msgstr ""
 
-#: src/ExternalConn.cpp:806
+#: src/ExternalConn.cpp:807
 #, fuzzy, c-format
 msgid "Unauthorized access attempt from %s. Connection closed."
 msgstr "ניסיון גישה שאינו מורשה. החיבור נסגר."
 
-#: src/ExternalConn.cpp:1419
+#: src/ExternalConn.cpp:1420
 #, c-format
 msgid "Remote PartFile command failed: FileHash not found: %s"
 msgstr "פקודת קובץ-חלקים מרוחקת מכשלה: גיבוב הקובץ לא נמצא: %s"
 
-#: src/ExternalConn.cpp:1423
+#: src/ExternalConn.cpp:1424
 #, c-format
 msgid "FileHash not found: %s"
 msgstr "גיבוב הקובץ לא מצא: %s"
 
-#: src/ExternalConn.cpp:1470 src/ExternalConn.cpp:1558
-#: src/ExternalConn.cpp:1679
+#: src/ExternalConn.cpp:1471 src/ExternalConn.cpp:1559
+#: src/ExternalConn.cpp:1680
 msgid "OOPS! OpCode processing error!"
 msgstr "אופס! שגיאה בעיבוד קוד-פעולה!"
 
-#: src/ExternalConn.cpp:1501
+#: src/ExternalConn.cpp:1502
 msgid "Server not added"
 msgstr "השרת לא התווסף"
 
-#: src/ExternalConn.cpp:1520
+#: src/ExternalConn.cpp:1521
 #, c-format
 msgid "server not found: %s"
 msgstr "לא נמצא השרת: %s"
 
-#: src/ExternalConn.cpp:1537
+#: src/ExternalConn.cpp:1538
 msgid "need to define server to be removed"
 msgstr "צריך להגדיר שרת כדי להסירו"
 
-#: src/ExternalConn.cpp:1552
+#: src/ExternalConn.cpp:1553
 msgid "eD2k is disabled in preferences."
 msgstr ""
 
-#: src/ExternalConn.cpp:1657
+#: src/ExternalConn.cpp:1658
 #, fuzzy
 msgid "Friend not found."
 msgstr "קובץ לא נמצא."
 
-#: src/ExternalConn.cpp:1667
+#: src/ExternalConn.cpp:1668
 #, fuzzy
 msgid "Client not found."
 msgstr "קובץ לא נמצא."
 
-#: src/ExternalConn.cpp:1673
+#: src/ExternalConn.cpp:1674
 msgid "EC_TAG_FRIEND_SHARED requires EC_TAG_FRIEND or EC_TAG_CLIENT."
 msgstr ""
 
-#: src/ExternalConn.cpp:1991
+#: src/ExternalConn.cpp:1992
 msgid "WebSearch from remote interface makes no sense."
 msgstr "לא הגיוני לבצע חיפוש-רשתי מתוך ממשק מרוחק."
 
-#: src/ExternalConn.cpp:2026
+#: src/ExternalConn.cpp:2027
 msgid "Search in progress. Refetch results in a moment!"
 msgstr "חיפוש פועל כרגע. ייבא מחדש תוצאות בעוד רגע!"
 
-#: src/ExternalConn.cpp:2265
+#: src/ExternalConn.cpp:2266
 msgid "No points for graph."
 msgstr "אין נקודות עבור הגרף."
 
-#: src/ExternalConn.cpp:2275
+#: src/ExternalConn.cpp:2276
 msgid "Your client is not configured for this detail level."
 msgstr "הלקוח שלך אינו מוגדר עבור הרמה הזאת של פרטים."
 
-#: src/ExternalConn.cpp:2302
+#: src/ExternalConn.cpp:2303
 msgid "External Connection: shutdown requested"
 msgstr ""
 
-#: src/ExternalConn.cpp:2314
+#: src/ExternalConn.cpp:2315
 msgid "Already shutting down."
 msgstr "כבר בתהליך כיבוי."
 
-#: src/ExternalConn.cpp:2332
+#: src/ExternalConn.cpp:2333
 #, c-format
 msgid "ExternalConn: adding link '%s'."
 msgstr "חיבור-חיצוני: מוסיף קישור '%s'."
 
-#: src/ExternalConn.cpp:2350
+#: src/ExternalConn.cpp:2351
 #, fuzzy, c-format
 msgid "%d of %d links failed (invalid or already on list)."
 msgstr "קישור לא תקף או שכבר נמצא ברשימה."
 
-#: src/ExternalConn.cpp:2373
+#: src/ExternalConn.cpp:2374
 msgid "Version check throttled; try again shortly."
 msgstr ""
 
-#: src/ExternalConn.cpp:2378
+#: src/ExternalConn.cpp:2379
 msgid "Version check is not available on this daemon."
 msgstr ""
 
-#: src/ExternalConn.cpp:2508
+#: src/ExternalConn.cpp:2509
 msgid "File not found."
 msgstr "קובץ לא נמצא."
 
-#: src/ExternalConn.cpp:2513
+#: src/ExternalConn.cpp:2514
 msgid "Invalid file name."
 msgstr "שם קובץ לא תכף."
 
-#: src/ExternalConn.cpp:2521
+#: src/ExternalConn.cpp:2522
 msgid "Unable to rename file."
 msgstr "לא מצליח לשנות את השם של הקובץ."
 
-#: src/ExternalConn.cpp:2992 src/ExternalConn.cpp:3020
+#: src/ExternalConn.cpp:2839
+#, c-format
+msgid "Could not save the amuleapi password: %s"
+msgstr ""
+
+#: src/ExternalConn.cpp:3004 src/ExternalConn.cpp:3032
 msgid "Kad is disabled in preferences."
 msgstr "קאד מנוטרל בתוך ההעדפות."
 
-#: src/ExternalConn.cpp:3033
+#: src/ExternalConn.cpp:3045
 msgid "Already connected to eD2k."
 msgstr ""
 
-#: src/ExternalConn.cpp:3036
+#: src/ExternalConn.cpp:3048
 msgid "Connecting to eD2k..."
 msgstr ""
 
-#: src/ExternalConn.cpp:3045
+#: src/ExternalConn.cpp:3057
 msgid "Already connected to Kad."
 msgstr "כבר מחובר לקאד."
 
-#: src/ExternalConn.cpp:3048
+#: src/ExternalConn.cpp:3060
 msgid "Connecting to Kad..."
 msgstr "מתחבר לקאד..."
 
-#: src/ExternalConn.cpp:3055
+#: src/ExternalConn.cpp:3067
 msgid "All networks are disabled."
 msgstr "כל הרשתות מנוטרלות."
 
-#: src/ExternalConn.cpp:3064
+#: src/ExternalConn.cpp:3076
 msgid "Disconnected from eD2k."
 msgstr ""
 
-#: src/ExternalConn.cpp:3069
+#: src/ExternalConn.cpp:3081
 msgid "Disconnected from Kad."
 msgstr "מתנתק מקאד."
 
-#: src/ExternalConn.cpp:3078
+#: src/ExternalConn.cpp:3090
 #, c-format
 msgid "External Connection: invalid opcode received: %#x"
 msgstr ""
 
-#: src/ExternalConn.cpp:3083
+#: src/ExternalConn.cpp:3095
 msgid "Invalid opcode (wrong protocol version?)"
 msgstr "קוד-פעולה לא תקף (גרסת פרוטקול שגויה?)"
 
@@ -2391,23 +2396,23 @@ msgid ""
 "want downloads on a different (e.g. larger) disk."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:549 src/FirstRunWizard.cpp:611 src/muuli_wdr.cpp:1708
+#: src/FirstRunWizard.cpp:549 src/FirstRunWizard.cpp:611 src/muuli_wdr.cpp:1712
 msgid "Destination folder for downloads"
 msgstr ""
 
 #: src/FirstRunWizard.cpp:553 src/FirstRunWizard.cpp:569 src/muuli_wdr.cpp:1349
-#: src/muuli_wdr.cpp:1366 src/muuli_wdr.cpp:1683 src/muuli_wdr.cpp:1714
-#: src/muuli_wdr.cpp:1726 src/muuli_wdr.cpp:2769
+#: src/muuli_wdr.cpp:1366 src/muuli_wdr.cpp:1687 src/muuli_wdr.cpp:1718
+#: src/muuli_wdr.cpp:1730 src/muuli_wdr.cpp:2800
 #: src/utils/aLinkCreator/src/alcframe.cpp:135
 #: src/utils/wxCas/src/wxcasprefs.cpp:52 src/utils/wxCas/src/wxcasprefs.cpp:118
 msgid "Browse"
 msgstr "דפדף"
 
-#: src/FirstRunWizard.cpp:559 src/muuli_wdr.cpp:1719
+#: src/FirstRunWizard.cpp:559 src/muuli_wdr.cpp:1723
 msgid "(All files in this folder are shared with other peers)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:565 src/FirstRunWizard.cpp:624 src/muuli_wdr.cpp:1721
+#: src/FirstRunWizard.cpp:565 src/FirstRunWizard.cpp:624 src/muuli_wdr.cpp:1725
 msgid "Folder for temporary download files"
 msgstr ""
 
@@ -2438,7 +2443,7 @@ msgstr ""
 msgid "CRITICAL - no client on StartChatSession"
 msgstr ""
 
-#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2675 src/muuli_wdr.cpp:3352
+#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2706 src/muuli_wdr.cpp:3383
 msgid "Friends"
 msgstr "חברים"
 
@@ -2552,8 +2557,8 @@ msgstr "לא"
 msgid "No"
 msgstr "לא"
 
-#: src/GenericClientListCtrl.cpp:1216 src/PrefsUnifiedDlg.cpp:2818
-#: src/PrefsUnifiedDlg.cpp:2868 src/ServerListCtrl.cpp:276
+#: src/GenericClientListCtrl.cpp:1216 src/PrefsUnifiedDlg.cpp:2898
+#: src/PrefsUnifiedDlg.cpp:2948 src/ServerListCtrl.cpp:276
 msgid "Yes"
 msgstr "כן"
 
@@ -2721,10 +2726,10 @@ msgstr "מבואה לא תקפה על מנת לבצע אתחול"
 msgid "Please fill all fields required"
 msgstr "אנא מלא את כל השדות כפי שנדרש"
 
-#: src/KadDlg.cpp:192 src/PartFile.cpp:1031 src/PrefsUnifiedDlg.cpp:1162
-#: src/PrefsUnifiedDlg.cpp:1331 src/PrefsUnifiedDlg.cpp:1589
-#: src/PrefsUnifiedDlg.cpp:1599 src/PrefsUnifiedDlg.cpp:1616
-#: src/PrefsUnifiedDlg.cpp:1658
+#: src/KadDlg.cpp:192 src/PartFile.cpp:1031 src/PrefsUnifiedDlg.cpp:1134
+#: src/PrefsUnifiedDlg.cpp:1204 src/PrefsUnifiedDlg.cpp:1405
+#: src/PrefsUnifiedDlg.cpp:1663 src/PrefsUnifiedDlg.cpp:1673
+#: src/PrefsUnifiedDlg.cpp:1690 src/PrefsUnifiedDlg.cpp:1738
 msgid "Message"
 msgstr "הודעה"
 
@@ -2826,7 +2831,7 @@ msgstr ""
 msgid "Uploaded"
 msgstr ""
 
-#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3232
+#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3263
 msgid "Requested"
 msgstr ""
 
@@ -2952,7 +2957,7 @@ msgid "WARNING: "
 msgstr ""
 
 #: src/MuleNotebook.cpp:179 src/muuli_wdr.cpp:817 src/muuli_wdr.cpp:1229
-#: src/muuli_wdr.cpp:3136 src/muuli_wdr.cpp:3392
+#: src/muuli_wdr.cpp:3167 src/muuli_wdr.cpp:3423
 msgid "Close"
 msgstr "סגור"
 
@@ -2970,7 +2975,7 @@ msgid "Paste"
 msgstr "הדבק"
 
 #: src/MuleTextCtrl.cpp:89 src/muuli_wdr.cpp:358 src/muuli_wdr.cpp:757
-#: src/muuli_wdr.cpp:2359 src/muuli_wdr.cpp:2378 src/muuli_wdr.cpp:2400
+#: src/muuli_wdr.cpp:2390 src/muuli_wdr.cpp:2409 src/muuli_wdr.cpp:2431
 #: src/utils/aLinkCreator/src/alcframe.cpp:142
 msgid "Clear"
 msgstr "נקה"
@@ -3068,7 +3073,7 @@ msgstr "יציאה"
 
 #: src/MuleTrayIcon.cpp:579 src/MuleTrayIcon.cpp:945 src/MuleTrayIcon.cpp:965
 #: src/muuli_wdr.cpp:1398 src/muuli_wdr.cpp:1406 src/muuli_wdr.cpp:1413
-#: src/muuli_wdr.cpp:1842 src/muuli_wdr.cpp:1848 src/OtherFunctions.cpp:91
+#: src/muuli_wdr.cpp:1846 src/muuli_wdr.cpp:1852 src/OtherFunctions.cpp:91
 #: src/StatisticsDlg.cpp:93 src/StatisticsDlg.cpp:95
 msgid "kB/s"
 msgstr "ק\"ב/ש"
@@ -3310,7 +3315,7 @@ msgstr "בתים"
 msgid "KB"
 msgstr "ק\"ב"
 
-#: src/muuli_wdr.cpp:274 src/muuli_wdr.cpp:293 src/muuli_wdr.cpp:1627
+#: src/muuli_wdr.cpp:274 src/muuli_wdr.cpp:293 src/muuli_wdr.cpp:1631
 #: src/OtherFunctions.cpp:64
 msgid "MB"
 msgstr "מ\"ב"
@@ -3327,7 +3332,7 @@ msgstr "גודל מקסימלי"
 msgid "Availability"
 msgstr "זמינות"
 
-#: src/muuli_wdr.cpp:312 src/muuli_wdr.cpp:398 src/muuli_wdr.cpp:3297
+#: src/muuli_wdr.cpp:312 src/muuli_wdr.cpp:398 src/muuli_wdr.cpp:3328
 msgid "Filter:"
 msgstr "מסנן:"
 
@@ -3391,12 +3396,12 @@ msgstr "מקורות שנמצאו :"
 #: src/muuli_wdr.cpp:1160 src/muuli_wdr.cpp:1167 src/muuli_wdr.cpp:1172
 #: src/muuli_wdr.cpp:1179 src/muuli_wdr.cpp:1184 src/muuli_wdr.cpp:1191
 #: src/muuli_wdr.cpp:1205 src/muuli_wdr.cpp:1212 src/muuli_wdr.cpp:1217
-#: src/muuli_wdr.cpp:1224 src/muuli_wdr.cpp:3234 src/muuli_wdr.cpp:3242
-#: src/muuli_wdr.cpp:3250
+#: src/muuli_wdr.cpp:1224 src/muuli_wdr.cpp:3265 src/muuli_wdr.cpp:3273
+#: src/muuli_wdr.cpp:3281
 msgid "N/A"
 msgstr "ל\"ת"
 
-#: src/muuli_wdr.cpp:508 src/muuli_wdr.cpp:1065 src/PrefsUnifiedDlg.cpp:297
+#: src/muuli_wdr.cpp:508 src/muuli_wdr.cpp:1065 src/PrefsUnifiedDlg.cpp:299
 msgid "General"
 msgstr "כללי"
 
@@ -3536,7 +3541,7 @@ msgstr ""
 msgid "Album :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:685 src/muuli_wdr.cpp:2254
+#: src/muuli_wdr.cpp:685 src/muuli_wdr.cpp:2285
 msgid "Title :"
 msgstr ""
 
@@ -3643,7 +3648,7 @@ msgstr "שם משתמש :"
 msgid "Userhash :"
 msgstr "גיבוב משתשמ :"
 
-#: src/muuli_wdr.cpp:895 src/muuli_wdr.cpp:1748 src/muuli_wdr.cpp:2449
+#: src/muuli_wdr.cpp:895 src/muuli_wdr.cpp:1752 src/muuli_wdr.cpp:2480
 #: src/utils/aLinkCreator/src/alcframe.cpp:137
 msgid "Add"
 msgstr "הוסף"
@@ -3652,15 +3657,15 @@ msgstr "הוסף"
 msgid "Download-Speed"
 msgstr "מהירות הורדה"
 
-#: src/muuli_wdr.cpp:954 src/muuli_wdr.cpp:989 src/muuli_wdr.cpp:2553
+#: src/muuli_wdr.cpp:954 src/muuli_wdr.cpp:989 src/muuli_wdr.cpp:2584
 msgid "Current"
 msgstr "נוכחיים"
 
-#: src/muuli_wdr.cpp:962 src/muuli_wdr.cpp:997 src/muuli_wdr.cpp:2561
+#: src/muuli_wdr.cpp:962 src/muuli_wdr.cpp:997 src/muuli_wdr.cpp:2592
 msgid "Running average"
 msgstr "ממוצע רץ"
 
-#: src/muuli_wdr.cpp:970 src/muuli_wdr.cpp:1005 src/muuli_wdr.cpp:2569
+#: src/muuli_wdr.cpp:970 src/muuli_wdr.cpp:1005 src/muuli_wdr.cpp:2600
 msgid "Session average"
 msgstr "ממוצע ההרצה הנוכחית"
 
@@ -3672,7 +3677,7 @@ msgstr "מהירות-העלאה"
 msgid "Connections"
 msgstr "חיבורים"
 
-#: src/muuli_wdr.cpp:1024 src/muuli_wdr.cpp:1867
+#: src/muuli_wdr.cpp:1024 src/muuli_wdr.cpp:1871
 msgid "Active downloads"
 msgstr "הורדות פעילות"
 
@@ -3680,7 +3685,7 @@ msgstr "הורדות פעילות"
 msgid "Active connections (1:1)"
 msgstr "חיבורים פעילים (1:1)"
 
-#: src/muuli_wdr.cpp:1040 src/muuli_wdr.cpp:1868
+#: src/muuli_wdr.cpp:1040 src/muuli_wdr.cpp:1872
 msgid "Active uploads"
 msgstr "העלאות פעילים"
 
@@ -3954,7 +3959,7 @@ msgstr ""
 msgid "Advanced users only: If you have multiple network interfaces, enter the address of the interface to which aMule should be bound."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1462 src/muuli_wdr.cpp:2061
+#: src/muuli_wdr.cpp:1462 src/muuli_wdr.cpp:2065
 msgid "Bind to network interface (empty for any):"
 msgstr ""
 
@@ -3970,7 +3975,7 @@ msgstr ""
 msgid "Max simultaneous connections:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1498 src/muuli_wdr.cpp:3176
+#: src/muuli_wdr.cpp:1498 src/muuli_wdr.cpp:3207
 msgid "ED2K"
 msgstr "ED2K"
 
@@ -4062,751 +4067,774 @@ msgstr ""
 msgid "For new files preallocates disk space for the whole file, thus reduces fragmentation"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1613
+#: src/muuli_wdr.cpp:1617
 msgid "Create new files as sparse files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1614
-msgid "A sparse file reserves its full size on disk immediately without writing real data to it -- fast, but unsupported or slow on some filesystems, and free-space accounting stays optimistic while the download is in progress. Turn this off to grow the file only as data arrives."
+#: src/muuli_wdr.cpp:1618
+msgid "Sparse part files only occupy disk space for the parts already downloaded, so free space is used up gradually as the file fills in. Turn this off to use an ordinary file instead - useful where sparse files are unsupported or slow, or where backup/de-duplication tools handle them badly. Applies only when the core runs on Windows; on Linux and macOS part files are sparse anyway and this setting has no effect."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1619
+#: src/muuli_wdr.cpp:1623
 msgid "Stop downloads when free disk space reaches "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1620
+#: src/muuli_wdr.cpp:1624
 msgid "Select this if you want aMule to check your disk space"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1624
+#: src/muuli_wdr.cpp:1628
 msgid "Enter here the min disk space desired."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1630
+#: src/muuli_wdr.cpp:1634
 msgid "Save 10 sources on rare files (< 20 sources)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1634 src/Statistics.cpp:790
+#: src/muuli_wdr.cpp:1638 src/Statistics.cpp:790
 msgid "Uploads"
 msgstr "ההעלאות"
 
-#: src/muuli_wdr.cpp:1637
+#: src/muuli_wdr.cpp:1641
 msgid "Add new shared files with auto priority"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1643
+#: src/muuli_wdr.cpp:1647
 msgid "Intelligent Corruption Handling (I.C.H.)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1646
+#: src/muuli_wdr.cpp:1650
 msgid "Enable"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1649
+#: src/muuli_wdr.cpp:1653
 msgid "Advanced I.C.H. trusts every hash (not recommended)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1661 src/PrefsUnifiedDlg.cpp:1910
+#: src/muuli_wdr.cpp:1665 src/PrefsUnifiedDlg.cpp:1990
 msgid "Media metadata extraction"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1665
+#: src/muuli_wdr.cpp:1669
 msgid "Extract length / bitrate / codec from shared audio and video files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1667
+#: src/muuli_wdr.cpp:1671
 msgid "When enabled, aMule runs ffprobe on each shared media file to fill in the Length / Bitrate / Codec columns other clients see when they find the file in a search. Requires ffmpeg (the ffprobe binary) to be installed."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1674
+#: src/muuli_wdr.cpp:1678
 msgid "Path to ffprobe:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1679
+#: src/muuli_wdr.cpp:1683
 msgid "Full path to the ffprobe binary. Leave empty to have aMule auto-detect it on startup."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1687
+#: src/muuli_wdr.cpp:1691
 msgid "Detect"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1688
+#: src/muuli_wdr.cpp:1692
 msgid "Search the standard install locations for an ffprobe binary and fill the path field."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1712
+#: src/muuli_wdr.cpp:1716
 msgid ""
 "Completed downloads are stored here. All files in this folder are automatically shared with other peers.\n"
 "If this folder also holds files you don't want to share, point it at an aMule-only sub-folder."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1715
+#: src/muuli_wdr.cpp:1719
 msgid "Pick the folder where completed downloads will be stored. All files in that folder will be shared with other peers."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1729
+#: src/muuli_wdr.cpp:1733
 msgid "Shared folders"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1735
+#: src/muuli_wdr.cpp:1739
 msgid "(Folders shared by the core. Enter a path to add one.)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1743
+#: src/muuli_wdr.cpp:1747
 msgid "Absolute path of a folder on the core's machine, e.g. /home/user/shared"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1745 src/PrefsUnifiedDlg.cpp:2794
+#: src/muuli_wdr.cpp:1749 src/PrefsUnifiedDlg.cpp:2874
 msgid "Recursive"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1746
+#: src/muuli_wdr.cpp:1750
 msgid "Share every sub-folder underneath this one, including ones created later."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1750 src/utils/aLinkCreator/src/alcframe.cpp:141
+#: src/muuli_wdr.cpp:1754 src/utils/aLinkCreator/src/alcframe.cpp:141
 msgid "Remove"
 msgstr "הסר"
 
-#: src/muuli_wdr.cpp:1754
+#: src/muuli_wdr.cpp:1758
 msgid "(Right click on folder icon for recursive share)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1761
+#: src/muuli_wdr.cpp:1765
 msgid "Share hidden files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1767
+#: src/muuli_wdr.cpp:1771
 msgid "Automatically rescan shared folders for changes"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1773
+#: src/muuli_wdr.cpp:1777
 msgid "Follow symbolic links in shared folders"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1779
+#: src/muuli_wdr.cpp:1783
 msgid "Exclude files matching:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1782
+#: src/muuli_wdr.cpp:1786
 msgid "Wildcard patterns separated by '|', e.g. .DS_Store|Thumbs.db|*.tmp. Files whose name matches are not shared. Matching is case-insensitive."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1786
+#: src/muuli_wdr.cpp:1790
 msgid "Patterns are regular expressions"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1787
+#: src/muuli_wdr.cpp:1791
 msgid "When set, the whole field is one regular expression ('|' is alternation). When unset, it is a list of '|'-separated wildcards."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1797
+#: src/muuli_wdr.cpp:1801
 msgid "Show how many shared files the current pattern would exclude."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1818
+#: src/muuli_wdr.cpp:1822
 msgid "Graphs"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1821 src/muuli_wdr.cpp:1883
+#: src/muuli_wdr.cpp:1825 src/muuli_wdr.cpp:1887
 msgid "Update delay : 5 secs"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1825
+#: src/muuli_wdr.cpp:1829
 msgid "Time for average graph: 100 mins"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1829
+#: src/muuli_wdr.cpp:1833
 msgid "Connections Graph Scale: 100 "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1836
+#: src/muuli_wdr.cpp:1840
 msgid "Download graph scale:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1844
+#: src/muuli_wdr.cpp:1848
 msgid "Upload graph scale:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1854
+#: src/muuli_wdr.cpp:1858
 msgid "Colors: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1858
+#: src/muuli_wdr.cpp:1862
 msgid "Background"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1859
+#: src/muuli_wdr.cpp:1863
 msgid "Grid"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1860
+#: src/muuli_wdr.cpp:1864
 msgid "Download current"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1861
+#: src/muuli_wdr.cpp:1865
 msgid "Download running average"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1862
+#: src/muuli_wdr.cpp:1866
 msgid "Download session average"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1863
+#: src/muuli_wdr.cpp:1867
 msgid "Upload current"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1864
+#: src/muuli_wdr.cpp:1868
 msgid "Upload running average"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1865
+#: src/muuli_wdr.cpp:1869
 msgid "Upload session average"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1866
+#: src/muuli_wdr.cpp:1870
 msgid "Active connections"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1869
+#: src/muuli_wdr.cpp:1873
 msgid "Systray Icon Speed Bar"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1870
+#: src/muuli_wdr.cpp:1874
 msgid "Kad-nodes current"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1871
+#: src/muuli_wdr.cpp:1875
 msgid "Kad-nodes running"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1872
+#: src/muuli_wdr.cpp:1876
 msgid "Kad-nodes session"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1876 src/muuli_wdr.cpp:2303
+#: src/muuli_wdr.cpp:1880 src/muuli_wdr.cpp:2334
 msgid "Select"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1880
+#: src/muuli_wdr.cpp:1884
 msgid "Tree"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1890
+#: src/muuli_wdr.cpp:1894
 msgid "Number of Client Versions shown (0=unlimited)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1915
+#: src/muuli_wdr.cpp:1919
 msgid "!!! WARNING !!!"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1930
+#: src/muuli_wdr.cpp:1934
 msgid "Max new connections / 5 secs"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1932
+#: src/muuli_wdr.cpp:1936
 msgid "Concurrent Kad source lookups"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1934
+#: src/muuli_wdr.cpp:1938
 #, fuzzy
 msgid "Kad source re-search interval (minutes)"
 msgstr "קצב עדכון התקופתי של ה FTP בדקות"
 
-#: src/muuli_wdr.cpp:1936
+#: src/muuli_wdr.cpp:1940
 #, fuzzy
 msgid "Source re-ask interval (minutes)"
 msgstr "קצב עדכון התקופתי של ה FTP בדקות"
 
-#: src/muuli_wdr.cpp:1940
+#: src/muuli_wdr.cpp:1944
 msgid "File Buffer Size: 240000 bytes"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1944
+#: src/muuli_wdr.cpp:1948
 msgid "Use MMAP: memory-mapped file access (lower memory use)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1945
+#: src/muuli_wdr.cpp:1949
 msgid "Maps part files into memory instead of buffering them on the heap, lowering the process memory footprint. May reduce download speed on some disks; best for memory-constrained or upload-heavy hosts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1947
+#: src/muuli_wdr.cpp:1951
 msgid "Upload Queue Size: 5000 clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1951
+#: src/muuli_wdr.cpp:1955
 msgid "Server connection refresh interval: Disable"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1955
+#: src/muuli_wdr.cpp:1959
 msgid "Disable computer's timed standby mode"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1974
+#: src/muuli_wdr.cpp:1978
 msgid "Skin to use: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1983
+#: src/muuli_wdr.cpp:1987
 msgid "Show \"Fast eD2k Links Handler\" in every window."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1986
+#: src/muuli_wdr.cpp:1990
 msgid "Show extended info on categories tabs"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1989
+#: src/muuli_wdr.cpp:1993
 msgid "Show application version on title"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1991
+#: src/muuli_wdr.cpp:1995
 msgid "Show transfer rates on title"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1993
+#: src/muuli_wdr.cpp:1997
 msgid "Before application name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1995
+#: src/muuli_wdr.cpp:1999
 msgid "After application name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1998
+#: src/muuli_wdr.cpp:2002
 msgid "Show overhead bandwidth"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2002
+#: src/muuli_wdr.cpp:2006
 msgid "Vertical toolbar orientation"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2004
+#: src/muuli_wdr.cpp:2008
 msgid "Live column sorting (auto-reorder rows as their values change)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2011
+#: src/muuli_wdr.cpp:2015
 msgid "Download Queue Files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2014
+#: src/muuli_wdr.cpp:2018
 msgid "Show progress percentage"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2020
+#: src/muuli_wdr.cpp:2024
 msgid "Show progress bar"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2023
+#: src/muuli_wdr.cpp:2027
 msgid "Flat"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2027
+#: src/muuli_wdr.cpp:2031
 msgid "Round"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2045
+#: src/muuli_wdr.cpp:2049
 msgid "External Connection Parameters"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2048
+#: src/muuli_wdr.cpp:2052
 msgid "Accept external connections"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2055 src/muuli_wdr.cpp:2114
+#: src/muuli_wdr.cpp:2059 src/muuli_wdr.cpp:2118
 msgid "IP of the listening interface:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2058
+#: src/muuli_wdr.cpp:2062
 msgid "Enter here a valid ip in the a.b.c.d format for the listening EC interface. An empty field or 0.0.0.0 will mean any interface."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2079 src/muuli_wdr.cpp:2163
+#: src/muuli_wdr.cpp:2083 src/muuli_wdr.cpp:2194
 msgid "TCP port:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2085
+#: src/muuli_wdr.cpp:2089
 msgid "Enable UPnP port forwarding on the EC port"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2089 src/muuli_wdr.cpp:3048
+#: src/muuli_wdr.cpp:2093 src/muuli_wdr.cpp:3079
 #: src/utils/wxCas/src/wxcasprefs.cpp:167
 msgid "Password"
 msgstr "סיסמא"
 
-#: src/muuli_wdr.cpp:2095
+#: src/muuli_wdr.cpp:2099
 msgid "aMule API server parameters"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2098
+#: src/muuli_wdr.cpp:2102
 msgid "Run amuleapi (REST API) on startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2103
+#: src/muuli_wdr.cpp:2107
 #, fuzzy
 msgid "HTTP port:"
 msgstr "מבואת UPnP"
 
-#: src/muuli_wdr.cpp:2117
+#: src/muuli_wdr.cpp:2121
 msgid "The interface amuleapi's HTTP server listens on. 127.0.0.1 (default) accepts only local connections; use 0.0.0.0 or a specific IP to expose it to other hosts (set an admin password below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2120
+#: src/muuli_wdr.cpp:2126
+msgid "Type a password to set or change it. Stored passwords cannot be shown, so leaving this empty keeps the current one."
+msgstr ""
+
+#: src/muuli_wdr.cpp:2128
 #, fuzzy
 msgid "Admin password"
 msgstr "בודק סיסמא\n"
 
-#: src/muuli_wdr.cpp:2125 src/muuli_wdr.cpp:2156
-msgid "Low rights password"
+#: src/muuli_wdr.cpp:2140 src/muuli_wdr.cpp:2157 src/PrefsUnifiedDlg.cpp:1103
+#, fuzzy
+msgid "A password is set."
+msgstr "בודק סיסמא\n"
+
+#: src/muuli_wdr.cpp:2144
+#, fuzzy
+msgid "Enable guest access"
+msgstr "מנע גישה מאורחים"
+
+#: src/muuli_wdr.cpp:2145
+msgid "Guest sessions may read status and listings but cannot change anything. Turning this off clears the stored guest password."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2133
+#: src/muuli_wdr.cpp:2149
+#, fuzzy
+msgid "Guest password"
+msgstr "בודק סיסמא\n"
+
+#: src/muuli_wdr.cpp:2164
 msgid "Web server parameters"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2136
+#: src/muuli_wdr.cpp:2167
 msgid "Run webserver on startup (deprecated)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2142
+#: src/muuli_wdr.cpp:2173
 msgid "Web template"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2147
+#: src/muuli_wdr.cpp:2178
 msgid "Full rights password"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2151
+#: src/muuli_wdr.cpp:2182
 msgid "Enable Low rights User"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2170
+#: src/muuli_wdr.cpp:2187
+msgid "Low rights password"
+msgstr ""
+
+#: src/muuli_wdr.cpp:2201
 msgid "Enable UPnP port forwarding of the web server port"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2175
+#: src/muuli_wdr.cpp:2206
 msgid "Web server UPnP TCP port (Optional)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2183
+#: src/muuli_wdr.cpp:2214
 msgid "Page Refresh Time (in secs)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2190
+#: src/muuli_wdr.cpp:2221
 msgid "Enable Gzip compression"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2224
+#: src/muuli_wdr.cpp:2255
 #, fuzzy
 msgid "Reset page to defaults"
 msgstr "ברירת מחדל של המערכת"
 
-#: src/muuli_wdr.cpp:2225
+#: src/muuli_wdr.cpp:2256
 msgid "Reset the settings on the current page to their default values."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2227 src/muuli_wdr.cpp:2313 src/ServerWnd.cpp:274
+#: src/muuli_wdr.cpp:2258 src/muuli_wdr.cpp:2344 src/ServerWnd.cpp:274
 #: src/ServerWnd.cpp:282
 msgid "OK"
 msgstr "בסדר"
 
-#: src/muuli_wdr.cpp:2229
+#: src/muuli_wdr.cpp:2260
 msgid "Click here to apply any changes made to the preferences."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2232
+#: src/muuli_wdr.cpp:2263
 msgid "Reset any changes made to the preferences."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2261
+#: src/muuli_wdr.cpp:2292
 msgid "Comment :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2268
+#: src/muuli_wdr.cpp:2299
 msgid "Incoming Dir :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2277
+#: src/muuli_wdr.cpp:2308
 msgid "Change priority for new assigned files :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2281
+#: src/muuli_wdr.cpp:2312
 #, fuzzy
 msgid "Don't change"
 msgstr "- מבואת UDP שונתה \n"
 
-#: src/muuli_wdr.cpp:2293
+#: src/muuli_wdr.cpp:2324
 msgid "Select color for this Category (currently selected) :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2360 src/muuli_wdr.cpp:2379 src/muuli_wdr.cpp:2401
+#: src/muuli_wdr.cpp:2391 src/muuli_wdr.cpp:2410 src/muuli_wdr.cpp:2432
 msgid "Click this button to reset the log."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2420
+#: src/muuli_wdr.cpp:2451
 msgid "Click on this button to update the servers list from URL ..."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2424
+#: src/muuli_wdr.cpp:2455
 msgid "Server list"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2428
+#: src/muuli_wdr.cpp:2459
 msgid "Enter the url to a server.met file here and press the button to the left to update the list of known servers."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2433
+#: src/muuli_wdr.cpp:2464
 msgid "Add server manually: Name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2436
+#: src/muuli_wdr.cpp:2467
 msgid "Enter the name of the new server here"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2438 src/ServerWnd.cpp:206
+#: src/muuli_wdr.cpp:2469 src/ServerWnd.cpp:206
 msgid "IP:Port"
 msgstr "אי.פי.:מבואה"
 
-#: src/muuli_wdr.cpp:2441
+#: src/muuli_wdr.cpp:2472
 msgid "Enter the IP of the server here, using the x.x.x.x format."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2447
+#: src/muuli_wdr.cpp:2478
 msgid "Enter the port of the server here."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2450
+#: src/muuli_wdr.cpp:2481
 msgid "Add manually a server (fill fields to the left before) ..."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2479
+#: src/muuli_wdr.cpp:2510
 msgid "aMule Log"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2487
+#: src/muuli_wdr.cpp:2518
 msgid "Server Info"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2491
+#: src/muuli_wdr.cpp:2522
 msgid "ED2K Info"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2495
+#: src/muuli_wdr.cpp:2526
 msgid "Kad Info"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2523
+#: src/muuli_wdr.cpp:2554
 msgid "Click on this button to update the nodes list from URL ..."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2527
+#: src/muuli_wdr.cpp:2558
 msgid "Nodes (0)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2531
+#: src/muuli_wdr.cpp:2562
 msgid "Enter the url to a nodes.dat file here and press the button to the left to update the list of known nodes."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2534
+#: src/muuli_wdr.cpp:2565
 msgid "Nodes stats"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2576
+#: src/muuli_wdr.cpp:2607
 msgid "Bootstrap"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2579
+#: src/muuli_wdr.cpp:2610
 msgid "New node"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2584
+#: src/muuli_wdr.cpp:2615
 msgid "IP:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2604
+#: src/muuli_wdr.cpp:2635
 msgid "Port:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2617
+#: src/muuli_wdr.cpp:2648
 msgid "Bootstrap from known clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2619
+#: src/muuli_wdr.cpp:2650
 msgid "Disconnect Kad"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2653
+#: src/muuli_wdr.cpp:2684
 msgid "Use Secure User Identification"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2655
+#: src/muuli_wdr.cpp:2686
 msgid "It is recommended to enable this option. You will not receive credits if SUI is not enabled."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2657
+#: src/muuli_wdr.cpp:2688
 msgid "Protocol Obfuscation"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2660
+#: src/muuli_wdr.cpp:2691
 msgid "Support Protocol Obfuscation"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2662
+#: src/muuli_wdr.cpp:2693
 msgid "This option enabled Protocol Obfuscation, and makes aMule accept obfuscated connections from other clients."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2664
+#: src/muuli_wdr.cpp:2695
 msgid "Use obfuscation for outgoing connections"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2666
+#: src/muuli_wdr.cpp:2697
 msgid "This option makes aMule use Protocol Obfuscation when connecting other clients/servers."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2668
+#: src/muuli_wdr.cpp:2699
 msgid "Accept only obfuscated connections"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2669
+#: src/muuli_wdr.cpp:2700
 msgid "This option makes aMule only accept obfuscated connections. You will have less sources, but all your traffic will be obfuscated"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2674
+#: src/muuli_wdr.cpp:2705
 msgid "Everybody"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2676
+#: src/muuli_wdr.cpp:2707
 msgid "No one"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2678
+#: src/muuli_wdr.cpp:2709
 msgid "Who can see my shared files:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2679
+#: src/muuli_wdr.cpp:2710
 msgid "Select who can request to view a list of your shared files."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2681
+#: src/muuli_wdr.cpp:2712
 msgid "IP-Filtering"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2688
+#: src/muuli_wdr.cpp:2719
 msgid "Filter clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2690
+#: src/muuli_wdr.cpp:2721
 msgid "Enable filtering of the client IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2692
+#: src/muuli_wdr.cpp:2723
 msgid "Filter servers"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2694
+#: src/muuli_wdr.cpp:2725
 msgid "Enable filtering of the server IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2698
+#: src/muuli_wdr.cpp:2729
 msgid "Reload List"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2699
+#: src/muuli_wdr.cpp:2730
 msgid "Reload the list of IPs to filter from the file ~/.aMule/ipfilter.dat"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2705
+#: src/muuli_wdr.cpp:2736
 msgid "URL:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2709 src/muuli_wdr.cpp:2902
+#: src/muuli_wdr.cpp:2740 src/muuli_wdr.cpp:2933
 msgid "Update now"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2712
+#: src/muuli_wdr.cpp:2743
 msgid "Auto-update ipfilter at startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2716
+#: src/muuli_wdr.cpp:2747
 msgid "Filtering Level:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2722
+#: src/muuli_wdr.cpp:2753
 msgid "Always filter LAN IPs"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2725
+#: src/muuli_wdr.cpp:2756
 msgid "Paranoid handling of non-matching IPs"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2727
+#: src/muuli_wdr.cpp:2758
 msgid "Rejects a packet when its source IP differs from the IP the client claims (an anti-spoofing check). Disable only if it causes connection problems."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2729
+#: src/muuli_wdr.cpp:2760
 msgid "Use system-wide ipfilter.dat if available"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2730
+#: src/muuli_wdr.cpp:2761
 msgid "If there's no local ipfilter.dat found, allow usage of a system-wide ipfilter file."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2747
+#: src/muuli_wdr.cpp:2778
 msgid "Enable Online-Signature"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2749
+#: src/muuli_wdr.cpp:2780
 msgid "Enables the writing of the OS file, which can be used by external apps to create signatures and the like."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2753
+#: src/muuli_wdr.cpp:2784
 msgid "Update Frequency (Secs):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2756
+#: src/muuli_wdr.cpp:2787
 msgid "Change the frequency (in seconds) of Online Signature updates."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2764
+#: src/muuli_wdr.cpp:2795
 msgid "Save online signature file in: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:2770
+#: src/muuli_wdr.cpp:2801
 msgid "Click here to select the directory containing the the Online Signature files."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2803
+#: src/muuli_wdr.cpp:2834
 msgid "Show country flags for clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2804
+#: src/muuli_wdr.cpp:2835
 msgid "Render the country flag column in the transfers, queue and search views. Requires a valid MMDB GeoIP database (see below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2809
+#: src/muuli_wdr.cpp:2840
 #, fuzzy
 msgid "Database"
 msgstr "קצב מידע :"
 
-#: src/muuli_wdr.cpp:2825
+#: src/muuli_wdr.cpp:2856
 #, fuzzy
 msgid "Source:"
 msgstr "מקורות"
 
-#: src/muuli_wdr.cpp:2828
+#: src/muuli_wdr.cpp:2859
 msgid "DB-IP (free, no account)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2829
+#: src/muuli_wdr.cpp:2860
 msgid "MaxMind GeoLite2 (free, account required)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2830
+#: src/muuli_wdr.cpp:2861
 msgid "Custom URL"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2833
+#: src/muuli_wdr.cpp:2864
 msgid "Choose which provider supplies the GeoIP MMDB database. DB-IP is the default - no account required. MaxMind requires a free account + license key. Use Custom URL to point at any other MMDB host (e.g. a local mirror)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2850
+#: src/muuli_wdr.cpp:2881
 msgid ""
 "No configuration required.\n"
 "\n"
@@ -4814,11 +4842,11 @@ msgid ""
 "License: Creative Commons BY 4.0 - https://creativecommons.org/licenses/by/4.0/"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2863
+#: src/muuli_wdr.cpp:2894
 msgid "License key:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2869
+#: src/muuli_wdr.cpp:2900
 msgid ""
 "Sign up for a free MaxMind account, then generate a License Key:\n"
 "https://www.maxmind.com/en/geolite2/signup\n"
@@ -4828,230 +4856,230 @@ msgid ""
 "Requires attribution and account registration; refresh at least every 30 days."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2884
+#: src/muuli_wdr.cpp:2915
 #, fuzzy
 msgid "Download URL:"
 msgstr "מוריד: "
 
-#: src/muuli_wdr.cpp:2890
+#: src/muuli_wdr.cpp:2921
 msgid ""
 "Must point to an .mmdb file or a .gz / .tar.gz containing one.\n"
 "URL may include credentials (https://user:pass@host/...).\n"
 "License and attribution terms are set by the upstream URL - you are responsible."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2903
+#: src/muuli_wdr.cpp:2934
 msgid "Download the GeoIP database from the selected source."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2905
+#: src/muuli_wdr.cpp:2936
 msgid "Auto-update on startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2906
+#: src/muuli_wdr.cpp:2937
 msgid "Re-download the GeoIP database from the selected source every time aMule starts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2929
+#: src/muuli_wdr.cpp:2960
 msgid "Filter incoming messages (except current chat):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2931
+#: src/muuli_wdr.cpp:2962
 msgid "Filter all messages"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2933
+#: src/muuli_wdr.cpp:2964
 msgid "Filter messages from people not on your friend list"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2935
+#: src/muuli_wdr.cpp:2966
 msgid "Filter messages from unknown clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2937
+#: src/muuli_wdr.cpp:2968
 msgid "Filter messages containing (use ',' as separator):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2940 src/muuli_wdr.cpp:2951
+#: src/muuli_wdr.cpp:2971 src/muuli_wdr.cpp:2982
 msgid "add here the words amule should filter and block messages including it"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2942
+#: src/muuli_wdr.cpp:2973
 msgid "Show received messages in the log"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2945
+#: src/muuli_wdr.cpp:2976
 msgid "Comments"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2948
+#: src/muuli_wdr.cpp:2979
 msgid "Filter comments containing (use ',' as separator):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2973
+#: src/muuli_wdr.cpp:3004
 msgid "Enable Proxy"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2974
+#: src/muuli_wdr.cpp:3005
 msgid "Enable/disable proxy support"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2977
+#: src/muuli_wdr.cpp:3008
 msgid "Proxy type:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2988
+#: src/muuli_wdr.cpp:3019
 msgid "Proxy host:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2991
+#: src/muuli_wdr.cpp:3022
 msgid "The proxy host name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2993
+#: src/muuli_wdr.cpp:3024
 msgid "Proxy port:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2996
+#: src/muuli_wdr.cpp:3027
 msgid "The proxy port"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2998
+#: src/muuli_wdr.cpp:3029
 msgid "Enable authentication"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2999
+#: src/muuli_wdr.cpp:3030
 msgid "Enable/disable username/password authentication"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3002
+#: src/muuli_wdr.cpp:3033
 msgid "Username: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:3005
+#: src/muuli_wdr.cpp:3036
 msgid "The username to use to connect to the proxy"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3007
+#: src/muuli_wdr.cpp:3038
 msgid "Password:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3010
+#: src/muuli_wdr.cpp:3041
 msgid "The password to use to connect to the proxy"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3029
+#: src/muuli_wdr.cpp:3060
 msgid "Connect to:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3038
+#: src/muuli_wdr.cpp:3069
 msgid "Login to remote amule"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3043
+#: src/muuli_wdr.cpp:3074
 msgid "User name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3054
+#: src/muuli_wdr.cpp:3085
 msgid "Remember those settings"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3057
+#: src/muuli_wdr.cpp:3088
 #, fuzzy
 msgid "Force ZLIB compression"
 msgstr "השמתש בדחיסת gzip"
 
-#: src/muuli_wdr.cpp:3081
+#: src/muuli_wdr.cpp:3112
 msgid "Enable Verbose Debug-Logging."
 msgstr ""
 
-#: src/muuli_wdr.cpp:3083
+#: src/muuli_wdr.cpp:3114
 #, fuzzy
 msgid "Only to Logfile"
 msgstr "&תפתח את הקובץ"
 
-#: src/muuli_wdr.cpp:3085
+#: src/muuli_wdr.cpp:3116
 msgid "Message Categories:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3109 src/PartFileConvertDlg.cpp:160
+#: src/muuli_wdr.cpp:3140 src/PartFileConvertDlg.cpp:160
 msgid "Waiting..."
 msgstr "ממתין..."
 
-#: src/muuli_wdr.cpp:3129
+#: src/muuli_wdr.cpp:3160
 msgid "Add imports"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3132
+#: src/muuli_wdr.cpp:3163
 msgid "Retry selected"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3134
+#: src/muuli_wdr.cpp:3165
 msgid "Remove selected"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3197
+#: src/muuli_wdr.cpp:3228
 msgid "Event Types"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3216
+#: src/muuli_wdr.cpp:3247
 msgid "Statistics and queued clients for selected file(s) : Session / All time"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3240
+#: src/muuli_wdr.cpp:3271
 #, fuzzy
 msgid "Active Uploads"
 msgstr "העלאות פעילים :"
 
-#: src/muuli_wdr.cpp:3254
+#: src/muuli_wdr.cpp:3285
 msgid "Percent of total files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3306
+#: src/muuli_wdr.cpp:3337
 #, fuzzy
 msgid "Show Clients for"
 msgstr "לקוחות"
 
-#: src/muuli_wdr.cpp:3308
+#: src/muuli_wdr.cpp:3339
 #, fuzzy
 msgid "All files"
 msgstr "קבצים משותפים"
 
-#: src/muuli_wdr.cpp:3311
+#: src/muuli_wdr.cpp:3342
 #, fuzzy
 msgid "Selected files"
 msgstr "בחר מסנן תצוגה"
 
-#: src/muuli_wdr.cpp:3314
+#: src/muuli_wdr.cpp:3345
 #, fuzzy
 msgid "Active uploads only"
 msgstr "העלאות פעילים"
 
-#: src/muuli_wdr.cpp:3321
+#: src/muuli_wdr.cpp:3352
 msgid "Reload:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3325
+#: src/muuli_wdr.cpp:3356
 msgid "Reload your shared files"
 msgstr "טען מחדש את הקבצים המשותפים שלך"
 
-#: src/muuli_wdr.cpp:3388
+#: src/muuli_wdr.cpp:3419
 msgid "Send"
 msgstr "שלח"
 
-#: src/muuli_wdr.cpp:3389
+#: src/muuli_wdr.cpp:3420
 msgid "Sends the specified message."
 msgstr "שולח את ההודעה המצויינת."
 
-#: src/muuli_wdr.cpp:3393
+#: src/muuli_wdr.cpp:3424
 msgid "Close this chat-session."
 msgstr "סגור את הצ'אט הנוכחי."
 
-#: src/muuli_wdr.cpp:3416
+#: src/muuli_wdr.cpp:3447
 msgid "Connect to any server and/or Kad"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3422 src/SharedFilesCtrl.cpp:142 src/Statistics.cpp:941
+#: src/muuli_wdr.cpp:3453 src/SharedFilesCtrl.cpp:142 src/Statistics.cpp:941
 msgid "Shared Files"
 msgstr "קבצים משותפים"
 
@@ -5414,267 +5442,267 @@ msgstr ""
 msgid "ERROR: Failed to open partfile '%s'"
 msgstr ""
 
-#: src/Preferences.cpp:674
+#: src/Preferences.cpp:701
 msgid "System default"
 msgstr "ברירת מחדל של המערכת"
 
-#: src/Preferences.cpp:675
+#: src/Preferences.cpp:702
 msgid "Albanian"
 msgstr "אלבני"
 
-#: src/Preferences.cpp:676
+#: src/Preferences.cpp:703
 msgid "Arabic"
 msgstr "ערבית"
 
-#: src/Preferences.cpp:677
+#: src/Preferences.cpp:704
 #, fuzzy
 msgid "Asturian"
 msgstr "אסטונית"
 
-#: src/Preferences.cpp:678
+#: src/Preferences.cpp:705
 msgid "Basque"
 msgstr "בסקית"
 
-#: src/Preferences.cpp:679
+#: src/Preferences.cpp:706
 msgid "Bulgarian"
 msgstr "בולגרית"
 
-#: src/Preferences.cpp:680
+#: src/Preferences.cpp:707
 msgid "Catalan"
 msgstr "קטלונית"
 
-#: src/Preferences.cpp:681
+#: src/Preferences.cpp:708
 msgid "Chinese (Simplified)"
 msgstr "סינית (מופשטת)"
 
-#: src/Preferences.cpp:682
+#: src/Preferences.cpp:709
 msgid "Chinese (Traditional)"
 msgstr "סינית (מסורתית)"
 
-#: src/Preferences.cpp:683
+#: src/Preferences.cpp:710
 msgid "Croatian"
 msgstr "קרואטית"
 
-#: src/Preferences.cpp:684
+#: src/Preferences.cpp:711
 msgid "Czech"
 msgstr "צ'כית"
 
-#: src/Preferences.cpp:685
+#: src/Preferences.cpp:712
 msgid "Danish"
 msgstr "דנית"
 
-#: src/Preferences.cpp:686
+#: src/Preferences.cpp:713
 msgid "Dutch"
 msgstr "הולנדית"
 
-#: src/Preferences.cpp:687
+#: src/Preferences.cpp:714
 msgid "English (U.K.)"
 msgstr "אנגלית (בריטית)"
 
-#: src/Preferences.cpp:688
+#: src/Preferences.cpp:715
 #, fuzzy
 msgid "English (U.S.)"
 msgstr "אנגלית (בריטית)"
 
-#: src/Preferences.cpp:689
+#: src/Preferences.cpp:716
 msgid "Estonian"
 msgstr "אסטונית"
 
-#: src/Preferences.cpp:690
+#: src/Preferences.cpp:717
 msgid "Finnish"
 msgstr "פינית"
 
-#: src/Preferences.cpp:691
+#: src/Preferences.cpp:718
 msgid "French"
 msgstr "צרפתית"
 
-#: src/Preferences.cpp:692
+#: src/Preferences.cpp:719
 msgid "Galician"
 msgstr "גאלית"
 
-#: src/Preferences.cpp:693
+#: src/Preferences.cpp:720
 msgid "German"
 msgstr "גרמנית"
 
-#: src/Preferences.cpp:694
+#: src/Preferences.cpp:721
 msgid "Greek"
 msgstr "יוונית"
 
-#: src/Preferences.cpp:695
+#: src/Preferences.cpp:722
 msgid "Hebrew"
 msgstr ""
 
-#: src/Preferences.cpp:696
+#: src/Preferences.cpp:723
 msgid "Hungarian"
 msgstr "הונגרית"
 
-#: src/Preferences.cpp:697
+#: src/Preferences.cpp:724
 msgid "Italian"
 msgstr "איטלקית"
 
-#: src/Preferences.cpp:698
+#: src/Preferences.cpp:725
 msgid "Japanese"
 msgstr "יפנית"
 
-#: src/Preferences.cpp:699
+#: src/Preferences.cpp:726
 msgid "Korean"
 msgstr "קוראינית"
 
-#: src/Preferences.cpp:700
+#: src/Preferences.cpp:727
 msgid "Latvian"
 msgstr ""
 
-#: src/Preferences.cpp:701
+#: src/Preferences.cpp:728
 msgid "Lithuanian"
 msgstr "ליטאית"
 
-#: src/Preferences.cpp:702
+#: src/Preferences.cpp:729
 msgid "Norwegian (Nynorsk)"
 msgstr "נורבגית (Nynorsk)"
 
-#: src/Preferences.cpp:703
+#: src/Preferences.cpp:730
 msgid "Polish"
 msgstr "פונלית"
 
-#: src/Preferences.cpp:704
+#: src/Preferences.cpp:731
 msgid "Portuguese"
 msgstr "פורטגזית"
 
-#: src/Preferences.cpp:705
+#: src/Preferences.cpp:732
 msgid "Portuguese (Brazilian)"
 msgstr "פורטגזית (ברזילאית)"
 
-#: src/Preferences.cpp:706
+#: src/Preferences.cpp:733
 #, fuzzy
 msgid "Romanian"
 msgstr "אלבני"
 
-#: src/Preferences.cpp:707
+#: src/Preferences.cpp:734
 msgid "Russian"
 msgstr "רוסית"
 
-#: src/Preferences.cpp:708
+#: src/Preferences.cpp:735
 msgid "Slovenian"
 msgstr "סלובקית"
 
-#: src/Preferences.cpp:709
+#: src/Preferences.cpp:736
 msgid "Spanish"
 msgstr "ספרדית"
 
-#: src/Preferences.cpp:710
+#: src/Preferences.cpp:737
 msgid "Swedish"
 msgstr "שוודית"
 
-#: src/Preferences.cpp:711
+#: src/Preferences.cpp:738
 msgid "Turkish"
 msgstr "טורקית"
 
-#: src/Preferences.cpp:712
+#: src/Preferences.cpp:739
 msgid "Ukrainian"
 msgstr ""
 
-#: src/Preferences.cpp:815
+#: src/Preferences.cpp:842
 msgid "Change Language"
 msgstr ""
 
-#: src/Preferences.cpp:879
+#: src/Preferences.cpp:906
 msgid "There are no translations installed for aMule"
 msgstr ""
 
-#: src/Preferences.cpp:880
+#: src/Preferences.cpp:907
 #, fuzzy
 msgid "No languages available"
 msgstr "לא זמין"
 
-#: src/Preferences.cpp:1011
+#: src/Preferences.cpp:1038
 msgid "no options available"
 msgstr ""
 
-#: src/Preferences.cpp:2182
+#: src/Preferences.cpp:2227
 msgid "Invalid category found, skipping"
 msgstr ""
 
-#: src/Preferences.cpp:2351
+#: src/Preferences.cpp:2396
 msgid "TCP port can't be higher than 65532 due to server UDP socket being TCP+3"
 msgstr "מבואת ה TCP אינה יכולה להיות גבוהה יותר מ 65532 מאחר שמבואת ה UDP של השרת היא מבואת ה TCP +3"
 
-#: src/Preferences.cpp:2352
+#: src/Preferences.cpp:2397
 #, c-format
 msgid "Default port will be used (%d)"
 msgstr "נשתמש במבואה שבברירת מחדך (%d)"
 
-#: src/PrefsUnifiedDlg.cpp:298 src/Statistics.cpp:866
+#: src/PrefsUnifiedDlg.cpp:300 src/Statistics.cpp:866
 msgid "Connection"
 msgstr "חיבור"
 
-#: src/PrefsUnifiedDlg.cpp:299 src/SearchListCtrl.cpp:117
+#: src/PrefsUnifiedDlg.cpp:301 src/SearchListCtrl.cpp:117
 msgid "Directories"
 msgstr "מלונים"
 
-#: src/PrefsUnifiedDlg.cpp:300 src/Statistics.cpp:917
+#: src/PrefsUnifiedDlg.cpp:302 src/Statistics.cpp:917
 msgid "Servers"
 msgstr "שרתים"
 
-#: src/PrefsUnifiedDlg.cpp:301 src/ServerListCtrl.cpp:96
+#: src/PrefsUnifiedDlg.cpp:303 src/ServerListCtrl.cpp:96
 msgid "Files"
 msgstr "קבצים"
 
-#: src/PrefsUnifiedDlg.cpp:302
+#: src/PrefsUnifiedDlg.cpp:304
 msgid "Security"
 msgstr "אבטחה"
 
-#: src/PrefsUnifiedDlg.cpp:303
+#: src/PrefsUnifiedDlg.cpp:305
 msgid "Interface"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:310
+#: src/PrefsUnifiedDlg.cpp:312
 msgid "IP2Country"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:313
+#: src/PrefsUnifiedDlg.cpp:315
 msgid "Proxy"
 msgstr "פרוקסי"
 
-#: src/PrefsUnifiedDlg.cpp:314
+#: src/PrefsUnifiedDlg.cpp:316
 msgid "Filters"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:315
+#: src/PrefsUnifiedDlg.cpp:317
 msgid "Remote Controls"
 msgstr "שליטה מרחוק"
 
-#: src/PrefsUnifiedDlg.cpp:316
+#: src/PrefsUnifiedDlg.cpp:318
 msgid "Online Signature"
 msgstr "חתימה מקוונת"
 
-#: src/PrefsUnifiedDlg.cpp:317
+#: src/PrefsUnifiedDlg.cpp:319
 msgid "Advanced"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:318
+#: src/PrefsUnifiedDlg.cpp:320
 msgid "Events"
 msgstr "ארועים"
 
-#: src/PrefsUnifiedDlg.cpp:321
+#: src/PrefsUnifiedDlg.cpp:323
 msgid "Debugging"
 msgstr "ניפוי שגיאות"
 
-#: src/PrefsUnifiedDlg.cpp:451
+#: src/PrefsUnifiedDlg.cpp:453
 msgid ""
 "The following variables will be substituted:\n"
 "    %PARTFILE - full path to the file\n"
 "    %PARTNAME - file name only"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:472
+#: src/PrefsUnifiedDlg.cpp:474
 msgid "Tray icon support requires libayatana-appindicator3 at compile time."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:488
+#: src/PrefsUnifiedDlg.cpp:490
 msgid "Not available on Wayland: the protocol does not report when a window is minimized, so this option cannot intercept the system minimize button. Workaround: launch aMule with `GDK_BACKEND=x11` to use XWayland instead."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:534
+#: src/PrefsUnifiedDlg.cpp:536
 msgid ""
 "Do not change these setting unless you know\n"
 "what you are doing, otherwise you can easily\n"
@@ -5684,26 +5712,35 @@ msgid ""
 "these settings."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:645
+#: src/PrefsUnifiedDlg.cpp:647
 #, c-format
 msgid "Failed to connect Cfg to widget with the ID %d and key %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:693
+#: src/PrefsUnifiedDlg.cpp:695
 #, c-format
 msgid "Failed to transfer data from Cfg to Widget with the ID %d and key %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:799
+#: src/PrefsUnifiedDlg.cpp:801
 msgid "The type of proxy you are connecting to"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1003
+#: src/PrefsUnifiedDlg.cpp:1020
 #, c-format
 msgid "Failed to transfer data from Widget to Cfg with the ID %d and key %s"
 msgstr ""
 
 #: src/PrefsUnifiedDlg.cpp:1103
+#, fuzzy
+msgid "No password set."
+msgstr "בודק סיסמא\n"
+
+#: src/PrefsUnifiedDlg.cpp:1132
+msgid "Guest access needs a password. Type one in the guest password field, or untick Enable guest access."
+msgstr ""
+
+#: src/PrefsUnifiedDlg.cpp:1144
 msgid ""
 "aMule must be restarted to enable these changes:\n"
 "\n"
@@ -5711,51 +5748,51 @@ msgstr ""
 "אימיול חייב להיות מאותחל מחדש על מנת לאפשר את השינויים הללו:\n"
 "\n"
 
-#: src/PrefsUnifiedDlg.cpp:1110
+#: src/PrefsUnifiedDlg.cpp:1151
 msgid "- TCP port changed.\n"
 msgstr "- מבואת TCP שונתה \n"
 
-#: src/PrefsUnifiedDlg.cpp:1115
+#: src/PrefsUnifiedDlg.cpp:1156
 msgid "- UDP port changed.\n"
 msgstr "- מבואת UDP שונתה \n"
 
-#: src/PrefsUnifiedDlg.cpp:1120
+#: src/PrefsUnifiedDlg.cpp:1161
 #, fuzzy
 msgid "- Network interface binding changed.\n"
 msgstr "חיבור חיצוני נסגר."
 
-#: src/PrefsUnifiedDlg.cpp:1125
+#: src/PrefsUnifiedDlg.cpp:1166
 #, fuzzy
 msgid "- External connect port changed.\n"
 msgstr "חיבור חיצוני נסגר."
 
-#: src/PrefsUnifiedDlg.cpp:1129
+#: src/PrefsUnifiedDlg.cpp:1170
 #, fuzzy
 msgid "- External connect acceptance changed.\n"
 msgstr "גישה חיצונית חדשה התקבלה"
 
-#: src/PrefsUnifiedDlg.cpp:1133
+#: src/PrefsUnifiedDlg.cpp:1174
 #, fuzzy
 msgid "- External connect interface changed.\n"
 msgstr "חיבור חיצוני נסגר."
 
-#: src/PrefsUnifiedDlg.cpp:1137
+#: src/PrefsUnifiedDlg.cpp:1178
 #, fuzzy
 msgid "- Protocol obfuscation support changed.\n"
 msgstr "חיבור חיצוני נסגר."
 
-#: src/PrefsUnifiedDlg.cpp:1151
+#: src/PrefsUnifiedDlg.cpp:1193
 #, fuzzy
 msgid "- amuleapi settings changed.\n"
 msgstr "- השפה שונתה.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1160
+#: src/PrefsUnifiedDlg.cpp:1202
 msgid ""
 "Your Auto-update server list is empty.\n"
 "'Auto-update server list at startup' will be disabled."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1171
+#: src/PrefsUnifiedDlg.cpp:1213
 msgid ""
 "You have enabled external connections but have not specified a password.\n"
 "External connections cannot be enabled unless a valid password is specified."
@@ -5763,35 +5800,40 @@ msgstr ""
 "אתה אפשרת חיבוריים חיצוניים אבל לא הזנת סיסמא תקיפה.\n"
 "חיבורים חיצוניים לא יאופשרו אלא אם כן תוזן סיסמא תקיפה."
 
-#: src/PrefsUnifiedDlg.cpp:1202
+#: src/PrefsUnifiedDlg.cpp:1246
+#, c-format
+msgid "The amuleapi password could not be saved: %s"
+msgstr ""
+
+#: src/PrefsUnifiedDlg.cpp:1276
 msgid "- Language changed.\n"
 msgstr "- השפה שונתה.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1207
+#: src/PrefsUnifiedDlg.cpp:1281
 msgid "- Temp folder changed.\n"
 msgstr "- הפסרייה הזמנית שונתה.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1212
+#: src/PrefsUnifiedDlg.cpp:1286
 #, fuzzy
 msgid "- ED2K network enabled.\n"
 msgstr "כל הרשתות מנוטרלות."
 
-#: src/PrefsUnifiedDlg.cpp:1245
+#: src/PrefsUnifiedDlg.cpp:1319
 msgid "The shared-file exclusion pattern is not a valid regular expression. The filter has been left disabled."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1247 src/PrefsUnifiedDlg.cpp:1841
+#: src/PrefsUnifiedDlg.cpp:1321 src/PrefsUnifiedDlg.cpp:1921
 #, fuzzy
 msgid "Invalid regular expression"
 msgstr "גרסת פרוטוקל לא תקפה."
 
-#: src/PrefsUnifiedDlg.cpp:1324
+#: src/PrefsUnifiedDlg.cpp:1398
 msgid ""
 "Both eD2k and Kad network are disabled.\n"
 "You won't be able to connect until you enable at least one of them."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1329
+#: src/PrefsUnifiedDlg.cpp:1403
 msgid ""
 "Kad will not start if your UDP port is disabled.\n"
 "Enable UDP port or disable Kad."
@@ -5799,7 +5841,7 @@ msgstr ""
 "קאד לא יתחיל אם מבואת ה UDB מנוטרלת.\n"
 "תאפשר את מבואת ה UDP או שתנטרל את קאד."
 
-#: src/PrefsUnifiedDlg.cpp:1385
+#: src/PrefsUnifiedDlg.cpp:1459
 msgid ""
 "\n"
 "You MUST restart aMule now.\n"
@@ -5809,69 +5851,69 @@ msgstr ""
 "אתה חייב לאתחל את אימיול עכשיו!\n"
 "אם לא תאתחל את אימיול עכשיו אל תתלונן אם משהו רע יקרה.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1450
+#: src/PrefsUnifiedDlg.cpp:1524
 msgid "Could not register aMule for autostart at login. The autostart store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1452
+#: src/PrefsUnifiedDlg.cpp:1526
 msgid "Could not remove the autostart-at-login entry."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1453
+#: src/PrefsUnifiedDlg.cpp:1527
 #, fuzzy
 msgid "Autostart"
 msgstr "רענון אוטמטי התחיל"
 
-#: src/PrefsUnifiedDlg.cpp:1468
+#: src/PrefsUnifiedDlg.cpp:1542
 msgid "Register file type"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1468
+#: src/PrefsUnifiedDlg.cpp:1542
 msgid "Register URL handler"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1476
+#: src/PrefsUnifiedDlg.cpp:1550
 #, c-format
 msgid "aMule only handles eD2k-compatible magnets. If you replace the current magnet handler (%s), BitTorrent magnet links will stop working - aMule cannot download BitTorrent content. Continue?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1481
+#: src/PrefsUnifiedDlg.cpp:1555
 #, c-format
 msgid "Another application currently opens .emulecollection files (%s). Replace it with aMule?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1486
+#: src/PrefsUnifiedDlg.cpp:1560
 #, c-format
 msgid "Another application is currently the default handler for these links (%s). Replace it with aMule?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1511
+#: src/PrefsUnifiedDlg.cpp:1585
 msgid "Could not register aMule for .emulecollection files. The registration store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1513
+#: src/PrefsUnifiedDlg.cpp:1587
 #, fuzzy
 msgid "Could not remove the file type registration."
 msgstr "אתה כבר מנסה להוריד את הקובץ %s"
 
-#: src/PrefsUnifiedDlg.cpp:1515
+#: src/PrefsUnifiedDlg.cpp:1589
 msgid "Could not register aMule as the URL handler. The registration store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1517
+#: src/PrefsUnifiedDlg.cpp:1591
 msgid "Could not remove the URL handler registration."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1587 src/PrefsUnifiedDlg.cpp:1614
+#: src/PrefsUnifiedDlg.cpp:1661 src/PrefsUnifiedDlg.cpp:1688
 #, fuzzy
 msgid "The web server and aMule API require external connections to be enabled."
 msgstr "גישה חיצונית חדשה התקבלה"
 
-#: src/PrefsUnifiedDlg.cpp:1597
+#: src/PrefsUnifiedDlg.cpp:1671
 msgid "The aMule web server is deprecated. Consider running the aMule API instead."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1655
+#: src/PrefsUnifiedDlg.cpp:1735
 msgid ""
 "Your Auto-update servers list is in blank.\n"
 "Please fill in at least one URL to point to a valid server.met file.\n"
@@ -5881,66 +5923,66 @@ msgstr ""
 "בבקשה תכניס לפחות כתובת URL אחת שתצביע לקובץ server.met תקף.\n"
 "לחץ על הכפתור \"רשימה\" שליד הצ'קבוקס הזה כדי להכניס בתובת URL."
 
-#: src/PrefsUnifiedDlg.cpp:1796
+#: src/PrefsUnifiedDlg.cpp:1876
 msgid "Temporary files"
 msgstr "קבצים זמניים"
 
-#: src/PrefsUnifiedDlg.cpp:1801
+#: src/PrefsUnifiedDlg.cpp:1881
 msgid "Incoming files"
 msgstr "קבצים נכנסים"
 
-#: src/PrefsUnifiedDlg.cpp:1806
+#: src/PrefsUnifiedDlg.cpp:1886
 msgid "Online Signatures"
 msgstr "חתימה מקוונת"
 
-#: src/PrefsUnifiedDlg.cpp:1819
+#: src/PrefsUnifiedDlg.cpp:1899
 #, c-format
 msgid "Choose a folder for %s"
 msgstr "בחר תיקייה עבור %s"
 
-#: src/PrefsUnifiedDlg.cpp:1843
+#: src/PrefsUnifiedDlg.cpp:1923
 #, fuzzy, c-format
 msgid "Would exclude %u of %u shared file"
 msgid_plural "Would exclude %u of %u shared files"
 msgstr[0] "נמצא %i קובץ משותף מוכר"
 msgstr[1] "נמצא %i קובץ משותף מוכר"
 
-#: src/PrefsUnifiedDlg.cpp:1860
+#: src/PrefsUnifiedDlg.cpp:1940
 msgid "Browse for videoplayer"
 msgstr "חפש נגן סרטים"
 
-#: src/PrefsUnifiedDlg.cpp:1864
+#: src/PrefsUnifiedDlg.cpp:1944
 msgid "Select browser"
 msgstr "בחר דפדפן"
 
-#: src/PrefsUnifiedDlg.cpp:1868
+#: src/PrefsUnifiedDlg.cpp:1948
 #, fuzzy
 msgid "Select ffprobe binary"
 msgstr "בחר דפדפן"
 
-#: src/PrefsUnifiedDlg.cpp:1874
+#: src/PrefsUnifiedDlg.cpp:1954
 #, c-format
 msgid "Executable%s"
 msgstr "קובץ הרצה %s"
 
-#: src/PrefsUnifiedDlg.cpp:1908
+#: src/PrefsUnifiedDlg.cpp:1988
 msgid "ffprobe not found on PATH or in the standard install locations. Install ffmpeg (which ships ffprobe) or use Browse to pick a binary manually."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1920
+#: src/PrefsUnifiedDlg.cpp:2000
 msgid "Reset the settings on this page to their default values?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1921
+#: src/PrefsUnifiedDlg.cpp:2001
 #, fuzzy
 msgid "Reset to defaults"
 msgstr "ברירת מחדל של המערכת"
 
-#: src/PrefsUnifiedDlg.cpp:1948
+#: src/PrefsUnifiedDlg.cpp:2028
 msgid "Edit server list"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1949
+#: src/PrefsUnifiedDlg.cpp:2029
 msgid ""
 "Add here URL's to download server.met files.\n"
 "Only one url on each line."
@@ -5948,155 +5990,155 @@ msgstr ""
 "הוסף כאן כתובות URL שמהם ניתן להוריד קבצי server.met.\n"
 "רק כתובת אחת בכל שורה."
 
-#: src/PrefsUnifiedDlg.cpp:2004
+#: src/PrefsUnifiedDlg.cpp:2084
 msgid "IP2Country update failed"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2149 src/PrefsUnifiedDlg.cpp:2180
+#: src/PrefsUnifiedDlg.cpp:2229 src/PrefsUnifiedDlg.cpp:2260
 msgid "Data by MaxMind GeoLite2"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2151 src/PrefsUnifiedDlg.cpp:2182
+#: src/PrefsUnifiedDlg.cpp:2231 src/PrefsUnifiedDlg.cpp:2262
 #, fuzzy
 msgid "Custom source"
 msgstr "מקורות שלמים"
 
-#: src/PrefsUnifiedDlg.cpp:2153 src/PrefsUnifiedDlg.cpp:2184
+#: src/PrefsUnifiedDlg.cpp:2233 src/PrefsUnifiedDlg.cpp:2264
 msgid "Data by DB-IP.com"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2204
+#: src/PrefsUnifiedDlg.cpp:2284
 #, fuzzy, c-format
 msgid "Status: Loaded%s"
 msgstr "סטאטוס:"
 
-#: src/PrefsUnifiedDlg.cpp:2206
+#: src/PrefsUnifiedDlg.cpp:2286
 #, fuzzy, c-format
 msgid "Status: Loaded%s - %s"
 msgstr "סטאטוס:"
 
-#: src/PrefsUnifiedDlg.cpp:2210
+#: src/PrefsUnifiedDlg.cpp:2290
 msgid "Status: Failed to load - click 'Update now' to refresh."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2212
+#: src/PrefsUnifiedDlg.cpp:2292
 msgid "Status: Not found - click 'Update now' to download."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2270 src/PrefsUnifiedDlg.cpp:2294
+#: src/PrefsUnifiedDlg.cpp:2350 src/PrefsUnifiedDlg.cpp:2374
 #, fuzzy, c-format
 msgid "Update delay: %d second"
 msgid_plural "Update delay: %d seconds"
 msgstr[0] "השהיית עדון: %d שניות"
 msgstr[1] "השהיית עדון: %d שניות"
 
-#: src/PrefsUnifiedDlg.cpp:2278
+#: src/PrefsUnifiedDlg.cpp:2358
 #, fuzzy, c-format
 msgid "Time for average graph: %d minute"
 msgid_plural "Time for average graph: %d minutes"
 msgstr[0] "זמן עבור גרף הממוצע: %d דקות"
 msgstr[1] "זמן עבור גרף הממוצע: %d דקות"
 
-#: src/PrefsUnifiedDlg.cpp:2287
+#: src/PrefsUnifiedDlg.cpp:2367
 #, c-format
 msgid "Connections Graph Scale: %d"
 msgstr "סקאלאת גרף החיבורים: %d"
 
-#: src/PrefsUnifiedDlg.cpp:2302
+#: src/PrefsUnifiedDlg.cpp:2382
 #, fuzzy, c-format
 msgid "File Buffer Size: %d byte"
 msgid_plural "File Buffer Size: %d bytes"
 msgstr[0] "גודל זיכרון זמני לקובץ: %d בתים"
 msgstr[1] "גודל זיכרון זמני לקובץ: %d בתים"
 
-#: src/PrefsUnifiedDlg.cpp:2312
+#: src/PrefsUnifiedDlg.cpp:2392
 #, fuzzy, c-format
 msgid "Upload Queue Size: %d client"
 msgid_plural "Upload Queue Size: %d clients"
 msgstr[0] "גודל תור ההאלעות: %d לקוחות"
 msgstr[1] "גודל תור ההאלעות: %d לקוחות"
 
-#: src/PrefsUnifiedDlg.cpp:2322
+#: src/PrefsUnifiedDlg.cpp:2402
 #, fuzzy, c-format
 msgid "Server connection refresh interval: %d minute"
 msgid_plural "Server connection refresh interval: %d minutes"
 msgstr[0] "רענון חיבור לשרת כל: %d דקות"
 msgstr[1] "רענון חיבור לשרת כל: %d דקות"
 
-#: src/PrefsUnifiedDlg.cpp:2327
+#: src/PrefsUnifiedDlg.cpp:2407
 msgid "Server connection refresh interval: Disabled"
 msgstr "רענון חיבור לשרת: מנוטרל"
 
-#: src/PrefsUnifiedDlg.cpp:2371
+#: src/PrefsUnifiedDlg.cpp:2451
 #, fuzzy
 msgid "disabled"
 msgstr "נוטרל [%s]"
 
-#: src/PrefsUnifiedDlg.cpp:2397
+#: src/PrefsUnifiedDlg.cpp:2477
 #, fuzzy, c-format
 msgid "Execute command on '%s' event"
 msgstr "בצע פקודה בעת ארוע '%s'"
 
-#: src/PrefsUnifiedDlg.cpp:2404
+#: src/PrefsUnifiedDlg.cpp:2484
 msgid "Enable command execution on core"
 msgstr "אפשר הרצת פקודות על הליבה"
 
-#: src/PrefsUnifiedDlg.cpp:2416
+#: src/PrefsUnifiedDlg.cpp:2496
 msgid "Core command:"
 msgstr "פקודת ליבה:"
 
-#: src/PrefsUnifiedDlg.cpp:2432
+#: src/PrefsUnifiedDlg.cpp:2512
 msgid "Enable command execution on GUI"
 msgstr "אפשר ביצוע פקודות על ממשק גרפי"
 
-#: src/PrefsUnifiedDlg.cpp:2444
+#: src/PrefsUnifiedDlg.cpp:2524
 msgid "GUI command:"
 msgstr "פקודת ממשק גרפי:"
 
-#: src/PrefsUnifiedDlg.cpp:2460
+#: src/PrefsUnifiedDlg.cpp:2540
 msgid "The following variables will be replaced:"
 msgstr "המשתנים הבאים יוחלפו:"
 
-#: src/PrefsUnifiedDlg.cpp:2628
+#: src/PrefsUnifiedDlg.cpp:2708
 msgid ""
 "The following folders look like system or sensitive locations:\n"
 "\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2633
+#: src/PrefsUnifiedDlg.cpp:2713
 msgid "Sharing them recursively will publish every file underneath on the eD2k/Kad networks. Do you really want to do this?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2636
+#: src/PrefsUnifiedDlg.cpp:2716
 #, fuzzy
 msgid "Confirm shared folders"
 msgstr "טען מחדש את הקבצים המשותפים שלך"
 
-#: src/PrefsUnifiedDlg.cpp:2664
+#: src/PrefsUnifiedDlg.cpp:2744
 #, fuzzy
 msgid "Reloading shared files..."
 msgstr "טען מחדש את הקבצים המשותפים שלך"
 
-#: src/PrefsUnifiedDlg.cpp:2665
+#: src/PrefsUnifiedDlg.cpp:2745
 msgid "Scanning for subdirectories..."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2666
+#: src/PrefsUnifiedDlg.cpp:2746
 #, fuzzy
 msgid "Updating shared folders"
 msgstr "קורא את הספרייה הזמנית"
 
-#: src/PrefsUnifiedDlg.cpp:2693
+#: src/PrefsUnifiedDlg.cpp:2773
 #, c-format
 msgid "Scanned %u directories..."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2743
+#: src/PrefsUnifiedDlg.cpp:2823
 #, fuzzy, c-format
 msgid "Reloading shared files: %u files scanned"
 msgstr "טוען מחדש את רשימת הקבצים המשותפים."
 
-#: src/PrefsUnifiedDlg.cpp:2793
+#: src/PrefsUnifiedDlg.cpp:2873
 #, fuzzy
 msgid "Shared folder"
 msgstr "קבצים משותפים"

--- a/po/he.po
+++ b/po/he.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-28 12:17+0200\n"
+"POT-Creation-Date: 2026-07-28 13:09+0200\n"
 "PO-Revision-Date: 2026-07-27 11:39+0000\n"
 "Last-Translator: Peace Kramer <kpeace1@gmail.com>\n"
 "Language-Team: Hebrew\n"
@@ -289,7 +289,7 @@ msgid "Password set and external connections enabled."
 msgstr "גישה חיצונית חדשה התקבלה"
 
 #: src/amule.cpp:755 src/KadDlg.cpp:176 src/KadDlg.cpp:185
-#: src/PrefsUnifiedDlg.cpp:1461 src/SharedFilesCtrl.cpp:476
+#: src/PrefsUnifiedDlg.cpp:1470 src/SharedFilesCtrl.cpp:476
 msgid "WARNING"
 msgstr "אזהרה"
 
@@ -325,7 +325,7 @@ msgstr ""
 #: src/amule-remote-gui.cpp:603 src/amule-remote-gui.cpp:671
 #: src/amule-remote-gui.cpp:709 src/amule-remote-gui.cpp:1282
 #: src/amule-remote-gui.cpp:1345 src/amule-remote-gui.cpp:1372
-#: src/DownloadQueue.cpp:1481 src/PrefsUnifiedDlg.cpp:1247
+#: src/DownloadQueue.cpp:1481 src/PrefsUnifiedDlg.cpp:1256
 msgid "ERROR"
 msgstr ""
 
@@ -579,36 +579,36 @@ msgstr "בקר ב https://github.com/amule-org/amule/releases/latest כדי לב
 msgid "FATAL ERROR: Failed to create Timer"
 msgstr ""
 
-#: src/amuleDlg.cpp:361 src/amuleDlg.cpp:1787 src/amuleDlg.cpp:2033
-#: src/muuli_wdr.cpp:1492 src/muuli_wdr.cpp:3449
+#: src/amuleDlg.cpp:361 src/amuleDlg.cpp:1810 src/amuleDlg.cpp:2056
+#: src/muuli_wdr.cpp:1492 src/muuli_wdr.cpp:3453
 msgid "Networks"
 msgstr "רשתות"
 
-#: src/amuleDlg.cpp:362 src/amuleDlg.cpp:1793 src/muuli_wdr.cpp:3450
+#: src/amuleDlg.cpp:362 src/amuleDlg.cpp:1816 src/muuli_wdr.cpp:3454
 msgid "Searches"
 msgstr "חיפושים"
 
-#: src/amuleDlg.cpp:363 src/amuleDlg.cpp:1799 src/DownloadListCtrl.cpp:740
-#: src/muuli_wdr.cpp:392 src/muuli_wdr.cpp:1585 src/muuli_wdr.cpp:3451
+#: src/amuleDlg.cpp:363 src/amuleDlg.cpp:1822 src/DownloadListCtrl.cpp:740
+#: src/muuli_wdr.cpp:392 src/muuli_wdr.cpp:1585 src/muuli_wdr.cpp:3455
 #: src/Statistics.cpp:829
 msgid "Downloads"
 msgstr "הורדות"
 
-#: src/amuleDlg.cpp:364 src/amuleDlg.cpp:1805 src/muuli_wdr.cpp:3325
+#: src/amuleDlg.cpp:364 src/amuleDlg.cpp:1828 src/muuli_wdr.cpp:3329
 msgid "Shared files"
 msgstr ""
 
-#: src/amuleDlg.cpp:365 src/amuleDlg.cpp:1811 src/muuli_wdr.cpp:2957
-#: src/muuli_wdr.cpp:3407 src/muuli_wdr.cpp:3454
+#: src/amuleDlg.cpp:365 src/amuleDlg.cpp:1834 src/muuli_wdr.cpp:2961
+#: src/muuli_wdr.cpp:3411 src/muuli_wdr.cpp:3458
 msgid "Messages"
 msgstr "הודעות"
 
-#: src/amuleDlg.cpp:366 src/amuleDlg.cpp:1817 src/muuli_wdr.cpp:3455
+#: src/amuleDlg.cpp:366 src/amuleDlg.cpp:1840 src/muuli_wdr.cpp:3459
 #: src/PrefsUnifiedDlg.cpp:314 src/Statistics.cpp:779 src/Statistics.cpp:1235
 msgid "Statistics"
 msgstr "סטטיסטיקות"
 
-#: src/amuleDlg.cpp:368 src/amuleDlg.cpp:1824 src/muuli_wdr.cpp:3457
+#: src/amuleDlg.cpp:368 src/amuleDlg.cpp:1847 src/muuli_wdr.cpp:3461
 #: src/PrefsUnifiedDlg.cpp:330 src/utils/wxCas/src/wxcasprefs.cpp:39
 msgid "Preferences"
 msgstr "העדפות"
@@ -667,8 +667,8 @@ msgstr "קאד: מכובה"
 #: src/amuleDlg.cpp:1029 src/DownloadListCtrl.cpp:505
 #: src/DownloadListCtrl.cpp:749 src/FriendListCtrl.cpp:180
 #: src/muuli_wdr.cpp:731 src/muuli_wdr.cpp:782 src/muuli_wdr.cpp:846
-#: src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2262 src/muuli_wdr.cpp:2347
-#: src/muuli_wdr.cpp:3095 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
+#: src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2266 src/muuli_wdr.cpp:2351
+#: src/muuli_wdr.cpp:3099 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
 #: src/ServerListCtrl.cpp:606 src/TransferWnd.cpp:378
 #: src/utils/wxCas/src/wxcasprefs.cpp:235
 msgid "Cancel"
@@ -679,7 +679,7 @@ msgid "Stop the current connection attempts"
 msgstr "הפסק את ניסיונות ההתחברות הנוכחיים"
 
 #: src/amuleDlg.cpp:1035 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976
-#: src/muuli_wdr.cpp:2485
+#: src/muuli_wdr.cpp:2489
 msgid "Disconnect"
 msgstr "מנותק"
 
@@ -688,7 +688,7 @@ msgid "Disconnect from the currently connected networks"
 msgstr "התנתק מהרשתות שאליהם אתה מחובר כעת"
 
 #: src/amuleDlg.cpp:1041 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979
-#: src/muuli_wdr.cpp:2640 src/muuli_wdr.cpp:3092 src/muuli_wdr.cpp:3447
+#: src/muuli_wdr.cpp:2644 src/muuli_wdr.cpp:3096 src/muuli_wdr.cpp:3451
 msgid "Connect"
 msgstr "התחבר"
 
@@ -743,7 +743,7 @@ msgstr "אישרור יצאיה"
 msgid "Launch Command: "
 msgstr ""
 
-#: src/amuleDlg.cpp:1632 src/muuli_wdr.cpp:1982 src/Preferences.cpp:979
+#: src/amuleDlg.cpp:1632 src/muuli_wdr.cpp:1986 src/Preferences.cpp:979
 msgid "- default -"
 msgstr ""
 
@@ -757,61 +757,61 @@ msgstr "ספריית הסקינים '%s' לא קיימת"
 msgid "WARNING: Unable to open skin file '%s' for read"
 msgstr ""
 
-#: src/amuleDlg.cpp:1791 src/muuli_wdr.cpp:3449
+#: src/amuleDlg.cpp:1814 src/muuli_wdr.cpp:3453
 msgid "Networks Window"
 msgstr "חלון הרשתות"
 
-#: src/amuleDlg.cpp:1797 src/muuli_wdr.cpp:3450
+#: src/amuleDlg.cpp:1820 src/muuli_wdr.cpp:3454
 msgid "Searches Window"
 msgstr "חלון החיפושים"
 
-#: src/amuleDlg.cpp:1803 src/muuli_wdr.cpp:3451
+#: src/amuleDlg.cpp:1826 src/muuli_wdr.cpp:3455
 #, fuzzy
 msgid "Downloads Window"
 msgstr "מוריד מהרשת"
 
-#: src/amuleDlg.cpp:1809 src/muuli_wdr.cpp:3453
+#: src/amuleDlg.cpp:1832 src/muuli_wdr.cpp:3457
 msgid "Shared Files Window"
 msgstr "חלון הקבצים המשותפים"
 
-#: src/amuleDlg.cpp:1815 src/muuli_wdr.cpp:3454
+#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3458
 msgid "Messages Window"
 msgstr "חלון ההודעות"
 
-#: src/amuleDlg.cpp:1821 src/muuli_wdr.cpp:3455
+#: src/amuleDlg.cpp:1844 src/muuli_wdr.cpp:3459
 msgid "Statistics Graph Window"
 msgstr "חלון גרפי הסטטיסטיקה"
 
-#: src/amuleDlg.cpp:1828 src/muuli_wdr.cpp:3457
+#: src/amuleDlg.cpp:1851 src/muuli_wdr.cpp:3461
 msgid "Preferences Settings Window"
 msgstr "חלון הגדרת ההעדפות"
 
-#: src/amuleDlg.cpp:1831 src/muuli_wdr.cpp:3458
+#: src/amuleDlg.cpp:1854 src/muuli_wdr.cpp:3462
 msgid "Import"
 msgstr "ייבא"
 
-#: src/amuleDlg.cpp:1835 src/muuli_wdr.cpp:3458
+#: src/amuleDlg.cpp:1858 src/muuli_wdr.cpp:3462
 msgid "The partfile importer tool"
 msgstr "כלי הייבא עבור קובץ-החלקים"
 
-#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3459
+#: src/amuleDlg.cpp:1861 src/muuli_wdr.cpp:3463
 #: src/utils/aLinkCreator/src/alcframe.cpp:262
 msgid "About"
 msgstr "אודות"
 
-#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3459
+#: src/amuleDlg.cpp:1861 src/muuli_wdr.cpp:3463
 msgid "About/Help"
 msgstr "אודות/עזרה"
 
-#: src/amuleDlg.cpp:2036
+#: src/amuleDlg.cpp:2059
 msgid "eD2k network"
 msgstr ""
 
-#: src/amuleDlg.cpp:2039
+#: src/amuleDlg.cpp:2062
 msgid "Kad network"
 msgstr ""
 
-#: src/amuleDlg.cpp:2039
+#: src/amuleDlg.cpp:2062
 msgid "No network"
 msgstr ""
 
@@ -1347,19 +1347,19 @@ msgstr "אוטומטי [גבוה]"
 msgid "Very low"
 msgstr "מאוד נמוך"
 
-#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:743 src/muuli_wdr.cpp:2313
+#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:743 src/muuli_wdr.cpp:2317
 #: src/ServerListCtrl.cpp:263 src/ServerListCtrl.cpp:456
 #: src/SharedFilesCtrl.cpp:145
 msgid "Low"
 msgstr "נמוך"
 
-#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:744 src/muuli_wdr.cpp:2314
+#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:744 src/muuli_wdr.cpp:2318
 #: src/ServerListCtrl.cpp:266 src/ServerListCtrl.cpp:457
 #: src/SharedFilesCtrl.cpp:146
 msgid "Normal"
 msgstr "רגיל"
 
-#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:745 src/muuli_wdr.cpp:2315
+#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:745 src/muuli_wdr.cpp:2319
 #: src/ServerListCtrl.cpp:269 src/ServerListCtrl.cpp:458
 #: src/SharedFilesCtrl.cpp:147
 msgid "High"
@@ -1451,7 +1451,7 @@ msgstr "שרת מקומי"
 msgid "Remote Server"
 msgstr "שרת מרוחק"
 
-#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3212
+#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3216
 #: src/SearchDlg.cpp:119 src/TextClient.cpp:911
 msgid "Kad"
 msgstr "קאד"
@@ -1523,7 +1523,7 @@ msgstr ""
 msgid "Size"
 msgstr "גודל"
 
-#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3279
+#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3283
 msgid "Transferred"
 msgstr "הועברו"
 
@@ -1579,7 +1579,7 @@ msgid ""
 "\n"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:746 src/muuli_wdr.cpp:2316
+#: src/DownloadListCtrl.cpp:746 src/muuli_wdr.cpp:2320
 #: src/SharedFilesCtrl.cpp:150
 msgid "Auto"
 msgstr "אוטמטי"
@@ -1617,7 +1617,7 @@ msgid "Extended Options"
 msgstr "אפשרויות מורחבות"
 
 #: src/DownloadListCtrl.cpp:770 src/DownloadListCtrl.cpp:822
-#: src/muuli_wdr.cpp:1800
+#: src/muuli_wdr.cpp:1804
 msgid "Preview"
 msgstr "תקדימון"
 
@@ -2396,23 +2396,23 @@ msgid ""
 "want downloads on a different (e.g. larger) disk."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:549 src/FirstRunWizard.cpp:611 src/muuli_wdr.cpp:1712
+#: src/FirstRunWizard.cpp:549 src/FirstRunWizard.cpp:611 src/muuli_wdr.cpp:1716
 msgid "Destination folder for downloads"
 msgstr ""
 
 #: src/FirstRunWizard.cpp:553 src/FirstRunWizard.cpp:569 src/muuli_wdr.cpp:1349
-#: src/muuli_wdr.cpp:1366 src/muuli_wdr.cpp:1687 src/muuli_wdr.cpp:1718
-#: src/muuli_wdr.cpp:1730 src/muuli_wdr.cpp:2800
+#: src/muuli_wdr.cpp:1366 src/muuli_wdr.cpp:1691 src/muuli_wdr.cpp:1722
+#: src/muuli_wdr.cpp:1734 src/muuli_wdr.cpp:2804
 #: src/utils/aLinkCreator/src/alcframe.cpp:135
 #: src/utils/wxCas/src/wxcasprefs.cpp:52 src/utils/wxCas/src/wxcasprefs.cpp:118
 msgid "Browse"
 msgstr "דפדף"
 
-#: src/FirstRunWizard.cpp:559 src/muuli_wdr.cpp:1723
+#: src/FirstRunWizard.cpp:559 src/muuli_wdr.cpp:1727
 msgid "(All files in this folder are shared with other peers)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:565 src/FirstRunWizard.cpp:624 src/muuli_wdr.cpp:1725
+#: src/FirstRunWizard.cpp:565 src/FirstRunWizard.cpp:624 src/muuli_wdr.cpp:1729
 msgid "Folder for temporary download files"
 msgstr ""
 
@@ -2443,7 +2443,7 @@ msgstr ""
 msgid "CRITICAL - no client on StartChatSession"
 msgstr ""
 
-#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2706 src/muuli_wdr.cpp:3383
+#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2710 src/muuli_wdr.cpp:3387
 msgid "Friends"
 msgstr "חברים"
 
@@ -2557,8 +2557,8 @@ msgstr "לא"
 msgid "No"
 msgstr "לא"
 
-#: src/GenericClientListCtrl.cpp:1216 src/PrefsUnifiedDlg.cpp:2898
-#: src/PrefsUnifiedDlg.cpp:2948 src/ServerListCtrl.cpp:276
+#: src/GenericClientListCtrl.cpp:1216 src/PrefsUnifiedDlg.cpp:2907
+#: src/PrefsUnifiedDlg.cpp:2957 src/ServerListCtrl.cpp:276
 msgid "Yes"
 msgstr "כן"
 
@@ -2726,10 +2726,10 @@ msgstr "מבואה לא תקפה על מנת לבצע אתחול"
 msgid "Please fill all fields required"
 msgstr "אנא מלא את כל השדות כפי שנדרש"
 
-#: src/KadDlg.cpp:192 src/PartFile.cpp:1031 src/PrefsUnifiedDlg.cpp:1134
-#: src/PrefsUnifiedDlg.cpp:1204 src/PrefsUnifiedDlg.cpp:1405
-#: src/PrefsUnifiedDlg.cpp:1663 src/PrefsUnifiedDlg.cpp:1673
-#: src/PrefsUnifiedDlg.cpp:1690 src/PrefsUnifiedDlg.cpp:1738
+#: src/KadDlg.cpp:192 src/PartFile.cpp:1031 src/PrefsUnifiedDlg.cpp:1143
+#: src/PrefsUnifiedDlg.cpp:1213 src/PrefsUnifiedDlg.cpp:1414
+#: src/PrefsUnifiedDlg.cpp:1672 src/PrefsUnifiedDlg.cpp:1682
+#: src/PrefsUnifiedDlg.cpp:1699 src/PrefsUnifiedDlg.cpp:1747
 msgid "Message"
 msgstr "הודעה"
 
@@ -2831,7 +2831,7 @@ msgstr ""
 msgid "Uploaded"
 msgstr ""
 
-#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3263
+#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3267
 msgid "Requested"
 msgstr ""
 
@@ -2957,7 +2957,7 @@ msgid "WARNING: "
 msgstr ""
 
 #: src/MuleNotebook.cpp:179 src/muuli_wdr.cpp:817 src/muuli_wdr.cpp:1229
-#: src/muuli_wdr.cpp:3167 src/muuli_wdr.cpp:3423
+#: src/muuli_wdr.cpp:3171 src/muuli_wdr.cpp:3427
 msgid "Close"
 msgstr "סגור"
 
@@ -2975,7 +2975,7 @@ msgid "Paste"
 msgstr "הדבק"
 
 #: src/MuleTextCtrl.cpp:89 src/muuli_wdr.cpp:358 src/muuli_wdr.cpp:757
-#: src/muuli_wdr.cpp:2390 src/muuli_wdr.cpp:2409 src/muuli_wdr.cpp:2431
+#: src/muuli_wdr.cpp:2394 src/muuli_wdr.cpp:2413 src/muuli_wdr.cpp:2435
 #: src/utils/aLinkCreator/src/alcframe.cpp:142
 msgid "Clear"
 msgstr "נקה"
@@ -3073,7 +3073,7 @@ msgstr "יציאה"
 
 #: src/MuleTrayIcon.cpp:579 src/MuleTrayIcon.cpp:945 src/MuleTrayIcon.cpp:965
 #: src/muuli_wdr.cpp:1398 src/muuli_wdr.cpp:1406 src/muuli_wdr.cpp:1413
-#: src/muuli_wdr.cpp:1846 src/muuli_wdr.cpp:1852 src/OtherFunctions.cpp:91
+#: src/muuli_wdr.cpp:1850 src/muuli_wdr.cpp:1856 src/OtherFunctions.cpp:91
 #: src/StatisticsDlg.cpp:93 src/StatisticsDlg.cpp:95
 msgid "kB/s"
 msgstr "ק\"ב/ש"
@@ -3315,7 +3315,7 @@ msgstr "בתים"
 msgid "KB"
 msgstr "ק\"ב"
 
-#: src/muuli_wdr.cpp:274 src/muuli_wdr.cpp:293 src/muuli_wdr.cpp:1631
+#: src/muuli_wdr.cpp:274 src/muuli_wdr.cpp:293 src/muuli_wdr.cpp:1635
 #: src/OtherFunctions.cpp:64
 msgid "MB"
 msgstr "מ\"ב"
@@ -3332,7 +3332,7 @@ msgstr "גודל מקסימלי"
 msgid "Availability"
 msgstr "זמינות"
 
-#: src/muuli_wdr.cpp:312 src/muuli_wdr.cpp:398 src/muuli_wdr.cpp:3328
+#: src/muuli_wdr.cpp:312 src/muuli_wdr.cpp:398 src/muuli_wdr.cpp:3332
 msgid "Filter:"
 msgstr "מסנן:"
 
@@ -3396,8 +3396,8 @@ msgstr "מקורות שנמצאו :"
 #: src/muuli_wdr.cpp:1160 src/muuli_wdr.cpp:1167 src/muuli_wdr.cpp:1172
 #: src/muuli_wdr.cpp:1179 src/muuli_wdr.cpp:1184 src/muuli_wdr.cpp:1191
 #: src/muuli_wdr.cpp:1205 src/muuli_wdr.cpp:1212 src/muuli_wdr.cpp:1217
-#: src/muuli_wdr.cpp:1224 src/muuli_wdr.cpp:3265 src/muuli_wdr.cpp:3273
-#: src/muuli_wdr.cpp:3281
+#: src/muuli_wdr.cpp:1224 src/muuli_wdr.cpp:3269 src/muuli_wdr.cpp:3277
+#: src/muuli_wdr.cpp:3285
 msgid "N/A"
 msgstr "ל\"ת"
 
@@ -3541,7 +3541,7 @@ msgstr ""
 msgid "Album :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:685 src/muuli_wdr.cpp:2285
+#: src/muuli_wdr.cpp:685 src/muuli_wdr.cpp:2289
 msgid "Title :"
 msgstr ""
 
@@ -3648,7 +3648,7 @@ msgstr "שם משתמש :"
 msgid "Userhash :"
 msgstr "גיבוב משתשמ :"
 
-#: src/muuli_wdr.cpp:895 src/muuli_wdr.cpp:1752 src/muuli_wdr.cpp:2480
+#: src/muuli_wdr.cpp:895 src/muuli_wdr.cpp:1756 src/muuli_wdr.cpp:2484
 #: src/utils/aLinkCreator/src/alcframe.cpp:137
 msgid "Add"
 msgstr "הוסף"
@@ -3657,15 +3657,15 @@ msgstr "הוסף"
 msgid "Download-Speed"
 msgstr "מהירות הורדה"
 
-#: src/muuli_wdr.cpp:954 src/muuli_wdr.cpp:989 src/muuli_wdr.cpp:2584
+#: src/muuli_wdr.cpp:954 src/muuli_wdr.cpp:989 src/muuli_wdr.cpp:2588
 msgid "Current"
 msgstr "נוכחיים"
 
-#: src/muuli_wdr.cpp:962 src/muuli_wdr.cpp:997 src/muuli_wdr.cpp:2592
+#: src/muuli_wdr.cpp:962 src/muuli_wdr.cpp:997 src/muuli_wdr.cpp:2596
 msgid "Running average"
 msgstr "ממוצע רץ"
 
-#: src/muuli_wdr.cpp:970 src/muuli_wdr.cpp:1005 src/muuli_wdr.cpp:2600
+#: src/muuli_wdr.cpp:970 src/muuli_wdr.cpp:1005 src/muuli_wdr.cpp:2604
 msgid "Session average"
 msgstr "ממוצע ההרצה הנוכחית"
 
@@ -3677,7 +3677,7 @@ msgstr "מהירות-העלאה"
 msgid "Connections"
 msgstr "חיבורים"
 
-#: src/muuli_wdr.cpp:1024 src/muuli_wdr.cpp:1871
+#: src/muuli_wdr.cpp:1024 src/muuli_wdr.cpp:1875
 msgid "Active downloads"
 msgstr "הורדות פעילות"
 
@@ -3685,7 +3685,7 @@ msgstr "הורדות פעילות"
 msgid "Active connections (1:1)"
 msgstr "חיבורים פעילים (1:1)"
 
-#: src/muuli_wdr.cpp:1040 src/muuli_wdr.cpp:1872
+#: src/muuli_wdr.cpp:1040 src/muuli_wdr.cpp:1876
 msgid "Active uploads"
 msgstr "העלאות פעילים"
 
@@ -3959,7 +3959,7 @@ msgstr ""
 msgid "Advanced users only: If you have multiple network interfaces, enter the address of the interface to which aMule should be bound."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1462 src/muuli_wdr.cpp:2065
+#: src/muuli_wdr.cpp:1462 src/muuli_wdr.cpp:2069
 msgid "Bind to network interface (empty for any):"
 msgstr ""
 
@@ -3975,7 +3975,7 @@ msgstr ""
 msgid "Max simultaneous connections:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1498 src/muuli_wdr.cpp:3207
+#: src/muuli_wdr.cpp:1498 src/muuli_wdr.cpp:3211
 msgid "ED2K"
 msgstr "ED2K"
 
@@ -4067,774 +4067,774 @@ msgstr ""
 msgid "For new files preallocates disk space for the whole file, thus reduces fragmentation"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1617
+#: src/muuli_wdr.cpp:1621
 msgid "Create new files as sparse files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1618
+#: src/muuli_wdr.cpp:1622
 msgid "Sparse part files only occupy disk space for the parts already downloaded, so free space is used up gradually as the file fills in. Turn this off to use an ordinary file instead - useful where sparse files are unsupported or slow, or where backup/de-duplication tools handle them badly. Applies only when the core runs on Windows; on Linux and macOS part files are sparse anyway and this setting has no effect."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1623
+#: src/muuli_wdr.cpp:1627
 msgid "Stop downloads when free disk space reaches "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1624
+#: src/muuli_wdr.cpp:1628
 msgid "Select this if you want aMule to check your disk space"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1628
+#: src/muuli_wdr.cpp:1632
 msgid "Enter here the min disk space desired."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1634
+#: src/muuli_wdr.cpp:1638
 msgid "Save 10 sources on rare files (< 20 sources)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1638 src/Statistics.cpp:790
+#: src/muuli_wdr.cpp:1642 src/Statistics.cpp:790
 msgid "Uploads"
 msgstr "ההעלאות"
 
-#: src/muuli_wdr.cpp:1641
+#: src/muuli_wdr.cpp:1645
 msgid "Add new shared files with auto priority"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1647
+#: src/muuli_wdr.cpp:1651
 msgid "Intelligent Corruption Handling (I.C.H.)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1650
+#: src/muuli_wdr.cpp:1654
 msgid "Enable"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1653
+#: src/muuli_wdr.cpp:1657
 msgid "Advanced I.C.H. trusts every hash (not recommended)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1665 src/PrefsUnifiedDlg.cpp:1990
+#: src/muuli_wdr.cpp:1669 src/PrefsUnifiedDlg.cpp:1999
 msgid "Media metadata extraction"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1669
+#: src/muuli_wdr.cpp:1673
 msgid "Extract length / bitrate / codec from shared audio and video files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1671
+#: src/muuli_wdr.cpp:1675
 msgid "When enabled, aMule runs ffprobe on each shared media file to fill in the Length / Bitrate / Codec columns other clients see when they find the file in a search. Requires ffmpeg (the ffprobe binary) to be installed."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1678
+#: src/muuli_wdr.cpp:1682
 msgid "Path to ffprobe:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1683
+#: src/muuli_wdr.cpp:1687
 msgid "Full path to the ffprobe binary. Leave empty to have aMule auto-detect it on startup."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1691
+#: src/muuli_wdr.cpp:1695
 msgid "Detect"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1692
+#: src/muuli_wdr.cpp:1696
 msgid "Search the standard install locations for an ffprobe binary and fill the path field."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1716
+#: src/muuli_wdr.cpp:1720
 msgid ""
 "Completed downloads are stored here. All files in this folder are automatically shared with other peers.\n"
 "If this folder also holds files you don't want to share, point it at an aMule-only sub-folder."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1719
+#: src/muuli_wdr.cpp:1723
 msgid "Pick the folder where completed downloads will be stored. All files in that folder will be shared with other peers."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1733
+#: src/muuli_wdr.cpp:1737
 msgid "Shared folders"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1739
+#: src/muuli_wdr.cpp:1743
 msgid "(Folders shared by the core. Enter a path to add one.)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1747
+#: src/muuli_wdr.cpp:1751
 msgid "Absolute path of a folder on the core's machine, e.g. /home/user/shared"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1749 src/PrefsUnifiedDlg.cpp:2874
+#: src/muuli_wdr.cpp:1753 src/PrefsUnifiedDlg.cpp:2883
 msgid "Recursive"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1750
+#: src/muuli_wdr.cpp:1754
 msgid "Share every sub-folder underneath this one, including ones created later."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1754 src/utils/aLinkCreator/src/alcframe.cpp:141
+#: src/muuli_wdr.cpp:1758 src/utils/aLinkCreator/src/alcframe.cpp:141
 msgid "Remove"
 msgstr "הסר"
 
-#: src/muuli_wdr.cpp:1758
+#: src/muuli_wdr.cpp:1762
 msgid "(Right click on folder icon for recursive share)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1765
+#: src/muuli_wdr.cpp:1769
 msgid "Share hidden files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1771
+#: src/muuli_wdr.cpp:1775
 msgid "Automatically rescan shared folders for changes"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1777
+#: src/muuli_wdr.cpp:1781
 msgid "Follow symbolic links in shared folders"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1783
+#: src/muuli_wdr.cpp:1787
 msgid "Exclude files matching:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1786
+#: src/muuli_wdr.cpp:1790
 msgid "Wildcard patterns separated by '|', e.g. .DS_Store|Thumbs.db|*.tmp. Files whose name matches are not shared. Matching is case-insensitive."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1790
+#: src/muuli_wdr.cpp:1794
 msgid "Patterns are regular expressions"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1791
+#: src/muuli_wdr.cpp:1795
 msgid "When set, the whole field is one regular expression ('|' is alternation). When unset, it is a list of '|'-separated wildcards."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1801
+#: src/muuli_wdr.cpp:1805
 msgid "Show how many shared files the current pattern would exclude."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1822
+#: src/muuli_wdr.cpp:1826
 msgid "Graphs"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1825 src/muuli_wdr.cpp:1887
+#: src/muuli_wdr.cpp:1829 src/muuli_wdr.cpp:1891
 msgid "Update delay : 5 secs"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1829
+#: src/muuli_wdr.cpp:1833
 msgid "Time for average graph: 100 mins"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1833
+#: src/muuli_wdr.cpp:1837
 msgid "Connections Graph Scale: 100 "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1840
+#: src/muuli_wdr.cpp:1844
 msgid "Download graph scale:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1848
+#: src/muuli_wdr.cpp:1852
 msgid "Upload graph scale:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1858
+#: src/muuli_wdr.cpp:1862
 msgid "Colors: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1862
+#: src/muuli_wdr.cpp:1866
 msgid "Background"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1863
+#: src/muuli_wdr.cpp:1867
 msgid "Grid"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1864
+#: src/muuli_wdr.cpp:1868
 msgid "Download current"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1865
+#: src/muuli_wdr.cpp:1869
 msgid "Download running average"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1866
+#: src/muuli_wdr.cpp:1870
 msgid "Download session average"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1867
+#: src/muuli_wdr.cpp:1871
 msgid "Upload current"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1868
+#: src/muuli_wdr.cpp:1872
 msgid "Upload running average"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1869
+#: src/muuli_wdr.cpp:1873
 msgid "Upload session average"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1870
+#: src/muuli_wdr.cpp:1874
 msgid "Active connections"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1873
+#: src/muuli_wdr.cpp:1877
 msgid "Systray Icon Speed Bar"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1874
+#: src/muuli_wdr.cpp:1878
 msgid "Kad-nodes current"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1875
+#: src/muuli_wdr.cpp:1879
 msgid "Kad-nodes running"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1876
+#: src/muuli_wdr.cpp:1880
 msgid "Kad-nodes session"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1880 src/muuli_wdr.cpp:2334
+#: src/muuli_wdr.cpp:1884 src/muuli_wdr.cpp:2338
 msgid "Select"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1884
+#: src/muuli_wdr.cpp:1888
 msgid "Tree"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1894
+#: src/muuli_wdr.cpp:1898
 msgid "Number of Client Versions shown (0=unlimited)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1919
+#: src/muuli_wdr.cpp:1923
 msgid "!!! WARNING !!!"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1934
+#: src/muuli_wdr.cpp:1938
 msgid "Max new connections / 5 secs"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1936
+#: src/muuli_wdr.cpp:1940
 msgid "Concurrent Kad source lookups"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1938
+#: src/muuli_wdr.cpp:1942
 #, fuzzy
 msgid "Kad source re-search interval (minutes)"
 msgstr "קצב עדכון התקופתי של ה FTP בדקות"
 
-#: src/muuli_wdr.cpp:1940
+#: src/muuli_wdr.cpp:1944
 #, fuzzy
 msgid "Source re-ask interval (minutes)"
 msgstr "קצב עדכון התקופתי של ה FTP בדקות"
 
-#: src/muuli_wdr.cpp:1944
+#: src/muuli_wdr.cpp:1948
 msgid "File Buffer Size: 240000 bytes"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1948
+#: src/muuli_wdr.cpp:1952
 msgid "Use MMAP: memory-mapped file access (lower memory use)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1949
+#: src/muuli_wdr.cpp:1953
 msgid "Maps part files into memory instead of buffering them on the heap, lowering the process memory footprint. May reduce download speed on some disks; best for memory-constrained or upload-heavy hosts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1951
+#: src/muuli_wdr.cpp:1955
 msgid "Upload Queue Size: 5000 clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1955
+#: src/muuli_wdr.cpp:1959
 msgid "Server connection refresh interval: Disable"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1959
+#: src/muuli_wdr.cpp:1963
 msgid "Disable computer's timed standby mode"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1978
+#: src/muuli_wdr.cpp:1982
 msgid "Skin to use: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1987
+#: src/muuli_wdr.cpp:1991
 msgid "Show \"Fast eD2k Links Handler\" in every window."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1990
+#: src/muuli_wdr.cpp:1994
 msgid "Show extended info on categories tabs"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1993
+#: src/muuli_wdr.cpp:1997
 msgid "Show application version on title"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1995
+#: src/muuli_wdr.cpp:1999
 msgid "Show transfer rates on title"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1997
+#: src/muuli_wdr.cpp:2001
 msgid "Before application name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1999
+#: src/muuli_wdr.cpp:2003
 msgid "After application name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2002
+#: src/muuli_wdr.cpp:2006
 msgid "Show overhead bandwidth"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2006
+#: src/muuli_wdr.cpp:2010
 msgid "Vertical toolbar orientation"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2008
+#: src/muuli_wdr.cpp:2012
 msgid "Live column sorting (auto-reorder rows as their values change)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2015
+#: src/muuli_wdr.cpp:2019
 msgid "Download Queue Files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2018
+#: src/muuli_wdr.cpp:2022
 msgid "Show progress percentage"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2024
+#: src/muuli_wdr.cpp:2028
 msgid "Show progress bar"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2027
+#: src/muuli_wdr.cpp:2031
 msgid "Flat"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2031
+#: src/muuli_wdr.cpp:2035
 msgid "Round"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2049
+#: src/muuli_wdr.cpp:2053
 msgid "External Connection Parameters"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2052
+#: src/muuli_wdr.cpp:2056
 msgid "Accept external connections"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2059 src/muuli_wdr.cpp:2118
+#: src/muuli_wdr.cpp:2063 src/muuli_wdr.cpp:2122
 msgid "IP of the listening interface:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2062
+#: src/muuli_wdr.cpp:2066
 msgid "Enter here a valid ip in the a.b.c.d format for the listening EC interface. An empty field or 0.0.0.0 will mean any interface."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2083 src/muuli_wdr.cpp:2194
+#: src/muuli_wdr.cpp:2087 src/muuli_wdr.cpp:2198
 msgid "TCP port:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2089
+#: src/muuli_wdr.cpp:2093
 msgid "Enable UPnP port forwarding on the EC port"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2093 src/muuli_wdr.cpp:3079
+#: src/muuli_wdr.cpp:2097 src/muuli_wdr.cpp:3083
 #: src/utils/wxCas/src/wxcasprefs.cpp:167
 msgid "Password"
 msgstr "סיסמא"
 
-#: src/muuli_wdr.cpp:2099
+#: src/muuli_wdr.cpp:2103
 msgid "aMule API server parameters"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2102
+#: src/muuli_wdr.cpp:2106
 msgid "Run amuleapi (REST API) on startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2107
+#: src/muuli_wdr.cpp:2111
 #, fuzzy
 msgid "HTTP port:"
 msgstr "מבואת UPnP"
 
-#: src/muuli_wdr.cpp:2121
+#: src/muuli_wdr.cpp:2125
 msgid "The interface amuleapi's HTTP server listens on. 127.0.0.1 (default) accepts only local connections; use 0.0.0.0 or a specific IP to expose it to other hosts (set an admin password below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2126
+#: src/muuli_wdr.cpp:2130
 msgid "Type a password to set or change it. Stored passwords cannot be shown, so leaving this empty keeps the current one."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2128
+#: src/muuli_wdr.cpp:2132
 #, fuzzy
 msgid "Admin password"
 msgstr "בודק סיסמא\n"
 
-#: src/muuli_wdr.cpp:2140 src/muuli_wdr.cpp:2157 src/PrefsUnifiedDlg.cpp:1103
+#: src/muuli_wdr.cpp:2144 src/muuli_wdr.cpp:2161 src/PrefsUnifiedDlg.cpp:1112
 #, fuzzy
 msgid "A password is set."
 msgstr "בודק סיסמא\n"
 
-#: src/muuli_wdr.cpp:2144
+#: src/muuli_wdr.cpp:2148
 #, fuzzy
 msgid "Enable guest access"
 msgstr "מנע גישה מאורחים"
 
-#: src/muuli_wdr.cpp:2145
+#: src/muuli_wdr.cpp:2149
 msgid "Guest sessions may read status and listings but cannot change anything. Turning this off clears the stored guest password."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2149
+#: src/muuli_wdr.cpp:2153
 #, fuzzy
 msgid "Guest password"
 msgstr "בודק סיסמא\n"
 
-#: src/muuli_wdr.cpp:2164
+#: src/muuli_wdr.cpp:2168
 msgid "Web server parameters"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2167
+#: src/muuli_wdr.cpp:2171
 msgid "Run webserver on startup (deprecated)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2173
+#: src/muuli_wdr.cpp:2177
 msgid "Web template"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2178
+#: src/muuli_wdr.cpp:2182
 msgid "Full rights password"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2182
+#: src/muuli_wdr.cpp:2186
 msgid "Enable Low rights User"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2187
+#: src/muuli_wdr.cpp:2191
 msgid "Low rights password"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2201
+#: src/muuli_wdr.cpp:2205
 msgid "Enable UPnP port forwarding of the web server port"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2206
+#: src/muuli_wdr.cpp:2210
 msgid "Web server UPnP TCP port (Optional)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2214
+#: src/muuli_wdr.cpp:2218
 msgid "Page Refresh Time (in secs)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2221
+#: src/muuli_wdr.cpp:2225
 msgid "Enable Gzip compression"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2255
+#: src/muuli_wdr.cpp:2259
 #, fuzzy
 msgid "Reset page to defaults"
 msgstr "ברירת מחדל של המערכת"
 
-#: src/muuli_wdr.cpp:2256
+#: src/muuli_wdr.cpp:2260
 msgid "Reset the settings on the current page to their default values."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2258 src/muuli_wdr.cpp:2344 src/ServerWnd.cpp:274
+#: src/muuli_wdr.cpp:2262 src/muuli_wdr.cpp:2348 src/ServerWnd.cpp:274
 #: src/ServerWnd.cpp:282
 msgid "OK"
 msgstr "בסדר"
 
-#: src/muuli_wdr.cpp:2260
+#: src/muuli_wdr.cpp:2264
 msgid "Click here to apply any changes made to the preferences."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2263
+#: src/muuli_wdr.cpp:2267
 msgid "Reset any changes made to the preferences."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2292
+#: src/muuli_wdr.cpp:2296
 msgid "Comment :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2299
+#: src/muuli_wdr.cpp:2303
 msgid "Incoming Dir :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2308
+#: src/muuli_wdr.cpp:2312
 msgid "Change priority for new assigned files :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2312
+#: src/muuli_wdr.cpp:2316
 #, fuzzy
 msgid "Don't change"
 msgstr "- מבואת UDP שונתה \n"
 
-#: src/muuli_wdr.cpp:2324
+#: src/muuli_wdr.cpp:2328
 msgid "Select color for this Category (currently selected) :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2391 src/muuli_wdr.cpp:2410 src/muuli_wdr.cpp:2432
+#: src/muuli_wdr.cpp:2395 src/muuli_wdr.cpp:2414 src/muuli_wdr.cpp:2436
 msgid "Click this button to reset the log."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2451
+#: src/muuli_wdr.cpp:2455
 msgid "Click on this button to update the servers list from URL ..."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2455
+#: src/muuli_wdr.cpp:2459
 msgid "Server list"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2459
+#: src/muuli_wdr.cpp:2463
 msgid "Enter the url to a server.met file here and press the button to the left to update the list of known servers."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2464
+#: src/muuli_wdr.cpp:2468
 msgid "Add server manually: Name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2467
+#: src/muuli_wdr.cpp:2471
 msgid "Enter the name of the new server here"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2469 src/ServerWnd.cpp:206
+#: src/muuli_wdr.cpp:2473 src/ServerWnd.cpp:206
 msgid "IP:Port"
 msgstr "אי.פי.:מבואה"
 
-#: src/muuli_wdr.cpp:2472
+#: src/muuli_wdr.cpp:2476
 msgid "Enter the IP of the server here, using the x.x.x.x format."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2478
+#: src/muuli_wdr.cpp:2482
 msgid "Enter the port of the server here."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2481
+#: src/muuli_wdr.cpp:2485
 msgid "Add manually a server (fill fields to the left before) ..."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2510
+#: src/muuli_wdr.cpp:2514
 msgid "aMule Log"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2518
+#: src/muuli_wdr.cpp:2522
 msgid "Server Info"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2522
+#: src/muuli_wdr.cpp:2526
 msgid "ED2K Info"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2526
+#: src/muuli_wdr.cpp:2530
 msgid "Kad Info"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2554
+#: src/muuli_wdr.cpp:2558
 msgid "Click on this button to update the nodes list from URL ..."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2558
+#: src/muuli_wdr.cpp:2562
 msgid "Nodes (0)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2562
+#: src/muuli_wdr.cpp:2566
 msgid "Enter the url to a nodes.dat file here and press the button to the left to update the list of known nodes."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2565
+#: src/muuli_wdr.cpp:2569
 msgid "Nodes stats"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2607
+#: src/muuli_wdr.cpp:2611
 msgid "Bootstrap"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2610
+#: src/muuli_wdr.cpp:2614
 msgid "New node"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2615
+#: src/muuli_wdr.cpp:2619
 msgid "IP:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2635
+#: src/muuli_wdr.cpp:2639
 msgid "Port:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2648
+#: src/muuli_wdr.cpp:2652
 msgid "Bootstrap from known clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2650
+#: src/muuli_wdr.cpp:2654
 msgid "Disconnect Kad"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2684
+#: src/muuli_wdr.cpp:2688
 msgid "Use Secure User Identification"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2686
+#: src/muuli_wdr.cpp:2690
 msgid "It is recommended to enable this option. You will not receive credits if SUI is not enabled."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2688
+#: src/muuli_wdr.cpp:2692
 msgid "Protocol Obfuscation"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2691
+#: src/muuli_wdr.cpp:2695
 msgid "Support Protocol Obfuscation"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2693
+#: src/muuli_wdr.cpp:2697
 msgid "This option enabled Protocol Obfuscation, and makes aMule accept obfuscated connections from other clients."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2695
+#: src/muuli_wdr.cpp:2699
 msgid "Use obfuscation for outgoing connections"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2697
+#: src/muuli_wdr.cpp:2701
 msgid "This option makes aMule use Protocol Obfuscation when connecting other clients/servers."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2699
+#: src/muuli_wdr.cpp:2703
 msgid "Accept only obfuscated connections"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2700
+#: src/muuli_wdr.cpp:2704
 msgid "This option makes aMule only accept obfuscated connections. You will have less sources, but all your traffic will be obfuscated"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2705
+#: src/muuli_wdr.cpp:2709
 msgid "Everybody"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2707
+#: src/muuli_wdr.cpp:2711
 msgid "No one"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2709
+#: src/muuli_wdr.cpp:2713
 msgid "Who can see my shared files:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2710
+#: src/muuli_wdr.cpp:2714
 msgid "Select who can request to view a list of your shared files."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2712
+#: src/muuli_wdr.cpp:2716
 msgid "IP-Filtering"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2719
+#: src/muuli_wdr.cpp:2723
 msgid "Filter clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2721
+#: src/muuli_wdr.cpp:2725
 msgid "Enable filtering of the client IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2723
+#: src/muuli_wdr.cpp:2727
 msgid "Filter servers"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2725
+#: src/muuli_wdr.cpp:2729
 msgid "Enable filtering of the server IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2729
+#: src/muuli_wdr.cpp:2733
 msgid "Reload List"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2730
+#: src/muuli_wdr.cpp:2734
 msgid "Reload the list of IPs to filter from the file ~/.aMule/ipfilter.dat"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2736
+#: src/muuli_wdr.cpp:2740
 msgid "URL:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2740 src/muuli_wdr.cpp:2933
+#: src/muuli_wdr.cpp:2744 src/muuli_wdr.cpp:2937
 msgid "Update now"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2743
+#: src/muuli_wdr.cpp:2747
 msgid "Auto-update ipfilter at startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2747
+#: src/muuli_wdr.cpp:2751
 msgid "Filtering Level:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2753
+#: src/muuli_wdr.cpp:2757
 msgid "Always filter LAN IPs"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2756
+#: src/muuli_wdr.cpp:2760
 msgid "Paranoid handling of non-matching IPs"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2758
+#: src/muuli_wdr.cpp:2762
 msgid "Rejects a packet when its source IP differs from the IP the client claims (an anti-spoofing check). Disable only if it causes connection problems."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2760
+#: src/muuli_wdr.cpp:2764
 msgid "Use system-wide ipfilter.dat if available"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2761
+#: src/muuli_wdr.cpp:2765
 msgid "If there's no local ipfilter.dat found, allow usage of a system-wide ipfilter file."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2778
+#: src/muuli_wdr.cpp:2782
 msgid "Enable Online-Signature"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2780
+#: src/muuli_wdr.cpp:2784
 msgid "Enables the writing of the OS file, which can be used by external apps to create signatures and the like."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2784
+#: src/muuli_wdr.cpp:2788
 msgid "Update Frequency (Secs):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2787
+#: src/muuli_wdr.cpp:2791
 msgid "Change the frequency (in seconds) of Online Signature updates."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2795
+#: src/muuli_wdr.cpp:2799
 msgid "Save online signature file in: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:2801
+#: src/muuli_wdr.cpp:2805
 msgid "Click here to select the directory containing the the Online Signature files."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2834
+#: src/muuli_wdr.cpp:2838
 msgid "Show country flags for clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2835
+#: src/muuli_wdr.cpp:2839
 msgid "Render the country flag column in the transfers, queue and search views. Requires a valid MMDB GeoIP database (see below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2840
+#: src/muuli_wdr.cpp:2844
 #, fuzzy
 msgid "Database"
 msgstr "קצב מידע :"
 
-#: src/muuli_wdr.cpp:2856
+#: src/muuli_wdr.cpp:2860
 #, fuzzy
 msgid "Source:"
 msgstr "מקורות"
 
-#: src/muuli_wdr.cpp:2859
+#: src/muuli_wdr.cpp:2863
 msgid "DB-IP (free, no account)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2860
+#: src/muuli_wdr.cpp:2864
 msgid "MaxMind GeoLite2 (free, account required)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2861
+#: src/muuli_wdr.cpp:2865
 msgid "Custom URL"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2864
+#: src/muuli_wdr.cpp:2868
 msgid "Choose which provider supplies the GeoIP MMDB database. DB-IP is the default - no account required. MaxMind requires a free account + license key. Use Custom URL to point at any other MMDB host (e.g. a local mirror)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2881
+#: src/muuli_wdr.cpp:2885
 msgid ""
 "No configuration required.\n"
 "\n"
@@ -4842,11 +4842,11 @@ msgid ""
 "License: Creative Commons BY 4.0 - https://creativecommons.org/licenses/by/4.0/"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2894
+#: src/muuli_wdr.cpp:2898
 msgid "License key:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2900
+#: src/muuli_wdr.cpp:2904
 msgid ""
 "Sign up for a free MaxMind account, then generate a License Key:\n"
 "https://www.maxmind.com/en/geolite2/signup\n"
@@ -4856,230 +4856,230 @@ msgid ""
 "Requires attribution and account registration; refresh at least every 30 days."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2915
+#: src/muuli_wdr.cpp:2919
 #, fuzzy
 msgid "Download URL:"
 msgstr "מוריד: "
 
-#: src/muuli_wdr.cpp:2921
+#: src/muuli_wdr.cpp:2925
 msgid ""
 "Must point to an .mmdb file or a .gz / .tar.gz containing one.\n"
 "URL may include credentials (https://user:pass@host/...).\n"
 "License and attribution terms are set by the upstream URL - you are responsible."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2934
+#: src/muuli_wdr.cpp:2938
 msgid "Download the GeoIP database from the selected source."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2936
+#: src/muuli_wdr.cpp:2940
 msgid "Auto-update on startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2937
+#: src/muuli_wdr.cpp:2941
 msgid "Re-download the GeoIP database from the selected source every time aMule starts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2960
+#: src/muuli_wdr.cpp:2964
 msgid "Filter incoming messages (except current chat):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2962
+#: src/muuli_wdr.cpp:2966
 msgid "Filter all messages"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2964
+#: src/muuli_wdr.cpp:2968
 msgid "Filter messages from people not on your friend list"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2966
+#: src/muuli_wdr.cpp:2970
 msgid "Filter messages from unknown clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2968
+#: src/muuli_wdr.cpp:2972
 msgid "Filter messages containing (use ',' as separator):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2971 src/muuli_wdr.cpp:2982
+#: src/muuli_wdr.cpp:2975 src/muuli_wdr.cpp:2986
 msgid "add here the words amule should filter and block messages including it"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2973
+#: src/muuli_wdr.cpp:2977
 msgid "Show received messages in the log"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2976
+#: src/muuli_wdr.cpp:2980
 msgid "Comments"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2979
+#: src/muuli_wdr.cpp:2983
 msgid "Filter comments containing (use ',' as separator):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3004
+#: src/muuli_wdr.cpp:3008
 msgid "Enable Proxy"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3005
+#: src/muuli_wdr.cpp:3009
 msgid "Enable/disable proxy support"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3008
+#: src/muuli_wdr.cpp:3012
 msgid "Proxy type:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3019
+#: src/muuli_wdr.cpp:3023
 msgid "Proxy host:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3022
+#: src/muuli_wdr.cpp:3026
 msgid "The proxy host name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3024
+#: src/muuli_wdr.cpp:3028
 msgid "Proxy port:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3027
+#: src/muuli_wdr.cpp:3031
 msgid "The proxy port"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3029
+#: src/muuli_wdr.cpp:3033
 msgid "Enable authentication"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3030
+#: src/muuli_wdr.cpp:3034
 msgid "Enable/disable username/password authentication"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3033
+#: src/muuli_wdr.cpp:3037
 msgid "Username: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:3036
+#: src/muuli_wdr.cpp:3040
 msgid "The username to use to connect to the proxy"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3038
+#: src/muuli_wdr.cpp:3042
 msgid "Password:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3041
+#: src/muuli_wdr.cpp:3045
 msgid "The password to use to connect to the proxy"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3060
+#: src/muuli_wdr.cpp:3064
 msgid "Connect to:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3069
+#: src/muuli_wdr.cpp:3073
 msgid "Login to remote amule"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3074
+#: src/muuli_wdr.cpp:3078
 msgid "User name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3085
+#: src/muuli_wdr.cpp:3089
 msgid "Remember those settings"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3088
+#: src/muuli_wdr.cpp:3092
 #, fuzzy
 msgid "Force ZLIB compression"
 msgstr "השמתש בדחיסת gzip"
 
-#: src/muuli_wdr.cpp:3112
+#: src/muuli_wdr.cpp:3116
 msgid "Enable Verbose Debug-Logging."
 msgstr ""
 
-#: src/muuli_wdr.cpp:3114
+#: src/muuli_wdr.cpp:3118
 #, fuzzy
 msgid "Only to Logfile"
 msgstr "&תפתח את הקובץ"
 
-#: src/muuli_wdr.cpp:3116
+#: src/muuli_wdr.cpp:3120
 msgid "Message Categories:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3140 src/PartFileConvertDlg.cpp:160
+#: src/muuli_wdr.cpp:3144 src/PartFileConvertDlg.cpp:160
 msgid "Waiting..."
 msgstr "ממתין..."
 
-#: src/muuli_wdr.cpp:3160
+#: src/muuli_wdr.cpp:3164
 msgid "Add imports"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3163
+#: src/muuli_wdr.cpp:3167
 msgid "Retry selected"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3165
+#: src/muuli_wdr.cpp:3169
 msgid "Remove selected"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3228
+#: src/muuli_wdr.cpp:3232
 msgid "Event Types"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3247
+#: src/muuli_wdr.cpp:3251
 msgid "Statistics and queued clients for selected file(s) : Session / All time"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3271
+#: src/muuli_wdr.cpp:3275
 #, fuzzy
 msgid "Active Uploads"
 msgstr "העלאות פעילים :"
 
-#: src/muuli_wdr.cpp:3285
+#: src/muuli_wdr.cpp:3289
 msgid "Percent of total files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3337
+#: src/muuli_wdr.cpp:3341
 #, fuzzy
 msgid "Show Clients for"
 msgstr "לקוחות"
 
-#: src/muuli_wdr.cpp:3339
+#: src/muuli_wdr.cpp:3343
 #, fuzzy
 msgid "All files"
 msgstr "קבצים משותפים"
 
-#: src/muuli_wdr.cpp:3342
+#: src/muuli_wdr.cpp:3346
 #, fuzzy
 msgid "Selected files"
 msgstr "בחר מסנן תצוגה"
 
-#: src/muuli_wdr.cpp:3345
+#: src/muuli_wdr.cpp:3349
 #, fuzzy
 msgid "Active uploads only"
 msgstr "העלאות פעילים"
 
-#: src/muuli_wdr.cpp:3352
+#: src/muuli_wdr.cpp:3356
 msgid "Reload:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3356
+#: src/muuli_wdr.cpp:3360
 msgid "Reload your shared files"
 msgstr "טען מחדש את הקבצים המשותפים שלך"
 
-#: src/muuli_wdr.cpp:3419
+#: src/muuli_wdr.cpp:3423
 msgid "Send"
 msgstr "שלח"
 
-#: src/muuli_wdr.cpp:3420
+#: src/muuli_wdr.cpp:3424
 msgid "Sends the specified message."
 msgstr "שולח את ההודעה המצויינת."
 
-#: src/muuli_wdr.cpp:3424
+#: src/muuli_wdr.cpp:3428
 msgid "Close this chat-session."
 msgstr "סגור את הצ'אט הנוכחי."
 
-#: src/muuli_wdr.cpp:3447
+#: src/muuli_wdr.cpp:3451
 msgid "Connect to any server and/or Kad"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3453 src/SharedFilesCtrl.cpp:142 src/Statistics.cpp:941
+#: src/muuli_wdr.cpp:3457 src/SharedFilesCtrl.cpp:142 src/Statistics.cpp:941
 msgid "Shared Files"
 msgstr "קבצים משותפים"
 
@@ -5712,35 +5712,35 @@ msgid ""
 "these settings."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:647
+#: src/PrefsUnifiedDlg.cpp:656
 #, c-format
 msgid "Failed to connect Cfg to widget with the ID %d and key %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:695
+#: src/PrefsUnifiedDlg.cpp:704
 #, c-format
 msgid "Failed to transfer data from Cfg to Widget with the ID %d and key %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:801
+#: src/PrefsUnifiedDlg.cpp:810
 msgid "The type of proxy you are connecting to"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1020
+#: src/PrefsUnifiedDlg.cpp:1029
 #, c-format
 msgid "Failed to transfer data from Widget to Cfg with the ID %d and key %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1103
+#: src/PrefsUnifiedDlg.cpp:1112
 #, fuzzy
 msgid "No password set."
 msgstr "בודק סיסמא\n"
 
-#: src/PrefsUnifiedDlg.cpp:1132
+#: src/PrefsUnifiedDlg.cpp:1141
 msgid "Guest access needs a password. Type one in the guest password field, or untick Enable guest access."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1144
+#: src/PrefsUnifiedDlg.cpp:1153
 msgid ""
 "aMule must be restarted to enable these changes:\n"
 "\n"
@@ -5748,51 +5748,51 @@ msgstr ""
 "אימיול חייב להיות מאותחל מחדש על מנת לאפשר את השינויים הללו:\n"
 "\n"
 
-#: src/PrefsUnifiedDlg.cpp:1151
+#: src/PrefsUnifiedDlg.cpp:1160
 msgid "- TCP port changed.\n"
 msgstr "- מבואת TCP שונתה \n"
 
-#: src/PrefsUnifiedDlg.cpp:1156
+#: src/PrefsUnifiedDlg.cpp:1165
 msgid "- UDP port changed.\n"
 msgstr "- מבואת UDP שונתה \n"
 
-#: src/PrefsUnifiedDlg.cpp:1161
+#: src/PrefsUnifiedDlg.cpp:1170
 #, fuzzy
 msgid "- Network interface binding changed.\n"
 msgstr "חיבור חיצוני נסגר."
 
-#: src/PrefsUnifiedDlg.cpp:1166
+#: src/PrefsUnifiedDlg.cpp:1175
 #, fuzzy
 msgid "- External connect port changed.\n"
 msgstr "חיבור חיצוני נסגר."
 
-#: src/PrefsUnifiedDlg.cpp:1170
+#: src/PrefsUnifiedDlg.cpp:1179
 #, fuzzy
 msgid "- External connect acceptance changed.\n"
 msgstr "גישה חיצונית חדשה התקבלה"
 
-#: src/PrefsUnifiedDlg.cpp:1174
+#: src/PrefsUnifiedDlg.cpp:1183
 #, fuzzy
 msgid "- External connect interface changed.\n"
 msgstr "חיבור חיצוני נסגר."
 
-#: src/PrefsUnifiedDlg.cpp:1178
+#: src/PrefsUnifiedDlg.cpp:1187
 #, fuzzy
 msgid "- Protocol obfuscation support changed.\n"
 msgstr "חיבור חיצוני נסגר."
 
-#: src/PrefsUnifiedDlg.cpp:1193
+#: src/PrefsUnifiedDlg.cpp:1202
 #, fuzzy
 msgid "- amuleapi settings changed.\n"
 msgstr "- השפה שונתה.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1202
+#: src/PrefsUnifiedDlg.cpp:1211
 msgid ""
 "Your Auto-update server list is empty.\n"
 "'Auto-update server list at startup' will be disabled."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1213
+#: src/PrefsUnifiedDlg.cpp:1222
 msgid ""
 "You have enabled external connections but have not specified a password.\n"
 "External connections cannot be enabled unless a valid password is specified."
@@ -5800,40 +5800,40 @@ msgstr ""
 "אתה אפשרת חיבוריים חיצוניים אבל לא הזנת סיסמא תקיפה.\n"
 "חיבורים חיצוניים לא יאופשרו אלא אם כן תוזן סיסמא תקיפה."
 
-#: src/PrefsUnifiedDlg.cpp:1246
+#: src/PrefsUnifiedDlg.cpp:1255
 #, c-format
 msgid "The amuleapi password could not be saved: %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1276
+#: src/PrefsUnifiedDlg.cpp:1285
 msgid "- Language changed.\n"
 msgstr "- השפה שונתה.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1281
+#: src/PrefsUnifiedDlg.cpp:1290
 msgid "- Temp folder changed.\n"
 msgstr "- הפסרייה הזמנית שונתה.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1286
+#: src/PrefsUnifiedDlg.cpp:1295
 #, fuzzy
 msgid "- ED2K network enabled.\n"
 msgstr "כל הרשתות מנוטרלות."
 
-#: src/PrefsUnifiedDlg.cpp:1319
+#: src/PrefsUnifiedDlg.cpp:1328
 msgid "The shared-file exclusion pattern is not a valid regular expression. The filter has been left disabled."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1321 src/PrefsUnifiedDlg.cpp:1921
+#: src/PrefsUnifiedDlg.cpp:1330 src/PrefsUnifiedDlg.cpp:1930
 #, fuzzy
 msgid "Invalid regular expression"
 msgstr "גרסת פרוטוקל לא תקפה."
 
-#: src/PrefsUnifiedDlg.cpp:1398
+#: src/PrefsUnifiedDlg.cpp:1407
 msgid ""
 "Both eD2k and Kad network are disabled.\n"
 "You won't be able to connect until you enable at least one of them."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1403
+#: src/PrefsUnifiedDlg.cpp:1412
 msgid ""
 "Kad will not start if your UDP port is disabled.\n"
 "Enable UDP port or disable Kad."
@@ -5841,7 +5841,7 @@ msgstr ""
 "קאד לא יתחיל אם מבואת ה UDB מנוטרלת.\n"
 "תאפשר את מבואת ה UDP או שתנטרל את קאד."
 
-#: src/PrefsUnifiedDlg.cpp:1459
+#: src/PrefsUnifiedDlg.cpp:1468
 msgid ""
 "\n"
 "You MUST restart aMule now.\n"
@@ -5851,69 +5851,69 @@ msgstr ""
 "אתה חייב לאתחל את אימיול עכשיו!\n"
 "אם לא תאתחל את אימיול עכשיו אל תתלונן אם משהו רע יקרה.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1524
+#: src/PrefsUnifiedDlg.cpp:1533
 msgid "Could not register aMule for autostart at login. The autostart store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1526
+#: src/PrefsUnifiedDlg.cpp:1535
 msgid "Could not remove the autostart-at-login entry."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1527
+#: src/PrefsUnifiedDlg.cpp:1536
 #, fuzzy
 msgid "Autostart"
 msgstr "רענון אוטמטי התחיל"
 
-#: src/PrefsUnifiedDlg.cpp:1542
+#: src/PrefsUnifiedDlg.cpp:1551
 msgid "Register file type"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1542
+#: src/PrefsUnifiedDlg.cpp:1551
 msgid "Register URL handler"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1550
+#: src/PrefsUnifiedDlg.cpp:1559
 #, c-format
 msgid "aMule only handles eD2k-compatible magnets. If you replace the current magnet handler (%s), BitTorrent magnet links will stop working - aMule cannot download BitTorrent content. Continue?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1555
+#: src/PrefsUnifiedDlg.cpp:1564
 #, c-format
 msgid "Another application currently opens .emulecollection files (%s). Replace it with aMule?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1560
+#: src/PrefsUnifiedDlg.cpp:1569
 #, c-format
 msgid "Another application is currently the default handler for these links (%s). Replace it with aMule?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1585
+#: src/PrefsUnifiedDlg.cpp:1594
 msgid "Could not register aMule for .emulecollection files. The registration store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1587
+#: src/PrefsUnifiedDlg.cpp:1596
 #, fuzzy
 msgid "Could not remove the file type registration."
 msgstr "אתה כבר מנסה להוריד את הקובץ %s"
 
-#: src/PrefsUnifiedDlg.cpp:1589
+#: src/PrefsUnifiedDlg.cpp:1598
 msgid "Could not register aMule as the URL handler. The registration store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1591
+#: src/PrefsUnifiedDlg.cpp:1600
 msgid "Could not remove the URL handler registration."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1661 src/PrefsUnifiedDlg.cpp:1688
+#: src/PrefsUnifiedDlg.cpp:1670 src/PrefsUnifiedDlg.cpp:1697
 #, fuzzy
 msgid "The web server and aMule API require external connections to be enabled."
 msgstr "גישה חיצונית חדשה התקבלה"
 
-#: src/PrefsUnifiedDlg.cpp:1671
+#: src/PrefsUnifiedDlg.cpp:1680
 msgid "The aMule web server is deprecated. Consider running the aMule API instead."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1735
+#: src/PrefsUnifiedDlg.cpp:1744
 msgid ""
 "Your Auto-update servers list is in blank.\n"
 "Please fill in at least one URL to point to a valid server.met file.\n"
@@ -5923,66 +5923,66 @@ msgstr ""
 "בבקשה תכניס לפחות כתובת URL אחת שתצביע לקובץ server.met תקף.\n"
 "לחץ על הכפתור \"רשימה\" שליד הצ'קבוקס הזה כדי להכניס בתובת URL."
 
-#: src/PrefsUnifiedDlg.cpp:1876
+#: src/PrefsUnifiedDlg.cpp:1885
 msgid "Temporary files"
 msgstr "קבצים זמניים"
 
-#: src/PrefsUnifiedDlg.cpp:1881
+#: src/PrefsUnifiedDlg.cpp:1890
 msgid "Incoming files"
 msgstr "קבצים נכנסים"
 
-#: src/PrefsUnifiedDlg.cpp:1886
+#: src/PrefsUnifiedDlg.cpp:1895
 msgid "Online Signatures"
 msgstr "חתימה מקוונת"
 
-#: src/PrefsUnifiedDlg.cpp:1899
+#: src/PrefsUnifiedDlg.cpp:1908
 #, c-format
 msgid "Choose a folder for %s"
 msgstr "בחר תיקייה עבור %s"
 
-#: src/PrefsUnifiedDlg.cpp:1923
+#: src/PrefsUnifiedDlg.cpp:1932
 #, fuzzy, c-format
 msgid "Would exclude %u of %u shared file"
 msgid_plural "Would exclude %u of %u shared files"
 msgstr[0] "נמצא %i קובץ משותף מוכר"
 msgstr[1] "נמצא %i קובץ משותף מוכר"
 
-#: src/PrefsUnifiedDlg.cpp:1940
+#: src/PrefsUnifiedDlg.cpp:1949
 msgid "Browse for videoplayer"
 msgstr "חפש נגן סרטים"
 
-#: src/PrefsUnifiedDlg.cpp:1944
+#: src/PrefsUnifiedDlg.cpp:1953
 msgid "Select browser"
 msgstr "בחר דפדפן"
 
-#: src/PrefsUnifiedDlg.cpp:1948
+#: src/PrefsUnifiedDlg.cpp:1957
 #, fuzzy
 msgid "Select ffprobe binary"
 msgstr "בחר דפדפן"
 
-#: src/PrefsUnifiedDlg.cpp:1954
+#: src/PrefsUnifiedDlg.cpp:1963
 #, c-format
 msgid "Executable%s"
 msgstr "קובץ הרצה %s"
 
-#: src/PrefsUnifiedDlg.cpp:1988
+#: src/PrefsUnifiedDlg.cpp:1997
 msgid "ffprobe not found on PATH or in the standard install locations. Install ffmpeg (which ships ffprobe) or use Browse to pick a binary manually."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2000
+#: src/PrefsUnifiedDlg.cpp:2009
 msgid "Reset the settings on this page to their default values?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2001
+#: src/PrefsUnifiedDlg.cpp:2010
 #, fuzzy
 msgid "Reset to defaults"
 msgstr "ברירת מחדל של המערכת"
 
-#: src/PrefsUnifiedDlg.cpp:2028
+#: src/PrefsUnifiedDlg.cpp:2037
 msgid "Edit server list"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2029
+#: src/PrefsUnifiedDlg.cpp:2038
 msgid ""
 "Add here URL's to download server.met files.\n"
 "Only one url on each line."
@@ -5990,155 +5990,155 @@ msgstr ""
 "הוסף כאן כתובות URL שמהם ניתן להוריד קבצי server.met.\n"
 "רק כתובת אחת בכל שורה."
 
-#: src/PrefsUnifiedDlg.cpp:2084
+#: src/PrefsUnifiedDlg.cpp:2093
 msgid "IP2Country update failed"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2229 src/PrefsUnifiedDlg.cpp:2260
+#: src/PrefsUnifiedDlg.cpp:2238 src/PrefsUnifiedDlg.cpp:2269
 msgid "Data by MaxMind GeoLite2"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2231 src/PrefsUnifiedDlg.cpp:2262
+#: src/PrefsUnifiedDlg.cpp:2240 src/PrefsUnifiedDlg.cpp:2271
 #, fuzzy
 msgid "Custom source"
 msgstr "מקורות שלמים"
 
-#: src/PrefsUnifiedDlg.cpp:2233 src/PrefsUnifiedDlg.cpp:2264
+#: src/PrefsUnifiedDlg.cpp:2242 src/PrefsUnifiedDlg.cpp:2273
 msgid "Data by DB-IP.com"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2284
+#: src/PrefsUnifiedDlg.cpp:2293
 #, fuzzy, c-format
 msgid "Status: Loaded%s"
 msgstr "סטאטוס:"
 
-#: src/PrefsUnifiedDlg.cpp:2286
+#: src/PrefsUnifiedDlg.cpp:2295
 #, fuzzy, c-format
 msgid "Status: Loaded%s - %s"
 msgstr "סטאטוס:"
 
-#: src/PrefsUnifiedDlg.cpp:2290
+#: src/PrefsUnifiedDlg.cpp:2299
 msgid "Status: Failed to load - click 'Update now' to refresh."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2292
+#: src/PrefsUnifiedDlg.cpp:2301
 msgid "Status: Not found - click 'Update now' to download."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2350 src/PrefsUnifiedDlg.cpp:2374
+#: src/PrefsUnifiedDlg.cpp:2359 src/PrefsUnifiedDlg.cpp:2383
 #, fuzzy, c-format
 msgid "Update delay: %d second"
 msgid_plural "Update delay: %d seconds"
 msgstr[0] "השהיית עדון: %d שניות"
 msgstr[1] "השהיית עדון: %d שניות"
 
-#: src/PrefsUnifiedDlg.cpp:2358
+#: src/PrefsUnifiedDlg.cpp:2367
 #, fuzzy, c-format
 msgid "Time for average graph: %d minute"
 msgid_plural "Time for average graph: %d minutes"
 msgstr[0] "זמן עבור גרף הממוצע: %d דקות"
 msgstr[1] "זמן עבור גרף הממוצע: %d דקות"
 
-#: src/PrefsUnifiedDlg.cpp:2367
+#: src/PrefsUnifiedDlg.cpp:2376
 #, c-format
 msgid "Connections Graph Scale: %d"
 msgstr "סקאלאת גרף החיבורים: %d"
 
-#: src/PrefsUnifiedDlg.cpp:2382
+#: src/PrefsUnifiedDlg.cpp:2391
 #, fuzzy, c-format
 msgid "File Buffer Size: %d byte"
 msgid_plural "File Buffer Size: %d bytes"
 msgstr[0] "גודל זיכרון זמני לקובץ: %d בתים"
 msgstr[1] "גודל זיכרון זמני לקובץ: %d בתים"
 
-#: src/PrefsUnifiedDlg.cpp:2392
+#: src/PrefsUnifiedDlg.cpp:2401
 #, fuzzy, c-format
 msgid "Upload Queue Size: %d client"
 msgid_plural "Upload Queue Size: %d clients"
 msgstr[0] "גודל תור ההאלעות: %d לקוחות"
 msgstr[1] "גודל תור ההאלעות: %d לקוחות"
 
-#: src/PrefsUnifiedDlg.cpp:2402
+#: src/PrefsUnifiedDlg.cpp:2411
 #, fuzzy, c-format
 msgid "Server connection refresh interval: %d minute"
 msgid_plural "Server connection refresh interval: %d minutes"
 msgstr[0] "רענון חיבור לשרת כל: %d דקות"
 msgstr[1] "רענון חיבור לשרת כל: %d דקות"
 
-#: src/PrefsUnifiedDlg.cpp:2407
+#: src/PrefsUnifiedDlg.cpp:2416
 msgid "Server connection refresh interval: Disabled"
 msgstr "רענון חיבור לשרת: מנוטרל"
 
-#: src/PrefsUnifiedDlg.cpp:2451
+#: src/PrefsUnifiedDlg.cpp:2460
 #, fuzzy
 msgid "disabled"
 msgstr "נוטרל [%s]"
 
-#: src/PrefsUnifiedDlg.cpp:2477
+#: src/PrefsUnifiedDlg.cpp:2486
 #, fuzzy, c-format
 msgid "Execute command on '%s' event"
 msgstr "בצע פקודה בעת ארוע '%s'"
 
-#: src/PrefsUnifiedDlg.cpp:2484
+#: src/PrefsUnifiedDlg.cpp:2493
 msgid "Enable command execution on core"
 msgstr "אפשר הרצת פקודות על הליבה"
 
-#: src/PrefsUnifiedDlg.cpp:2496
+#: src/PrefsUnifiedDlg.cpp:2505
 msgid "Core command:"
 msgstr "פקודת ליבה:"
 
-#: src/PrefsUnifiedDlg.cpp:2512
+#: src/PrefsUnifiedDlg.cpp:2521
 msgid "Enable command execution on GUI"
 msgstr "אפשר ביצוע פקודות על ממשק גרפי"
 
-#: src/PrefsUnifiedDlg.cpp:2524
+#: src/PrefsUnifiedDlg.cpp:2533
 msgid "GUI command:"
 msgstr "פקודת ממשק גרפי:"
 
-#: src/PrefsUnifiedDlg.cpp:2540
+#: src/PrefsUnifiedDlg.cpp:2549
 msgid "The following variables will be replaced:"
 msgstr "המשתנים הבאים יוחלפו:"
 
-#: src/PrefsUnifiedDlg.cpp:2708
+#: src/PrefsUnifiedDlg.cpp:2717
 msgid ""
 "The following folders look like system or sensitive locations:\n"
 "\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2713
+#: src/PrefsUnifiedDlg.cpp:2722
 msgid "Sharing them recursively will publish every file underneath on the eD2k/Kad networks. Do you really want to do this?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2716
+#: src/PrefsUnifiedDlg.cpp:2725
 #, fuzzy
 msgid "Confirm shared folders"
 msgstr "טען מחדש את הקבצים המשותפים שלך"
 
-#: src/PrefsUnifiedDlg.cpp:2744
+#: src/PrefsUnifiedDlg.cpp:2753
 #, fuzzy
 msgid "Reloading shared files..."
 msgstr "טען מחדש את הקבצים המשותפים שלך"
 
-#: src/PrefsUnifiedDlg.cpp:2745
+#: src/PrefsUnifiedDlg.cpp:2754
 msgid "Scanning for subdirectories..."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2746
+#: src/PrefsUnifiedDlg.cpp:2755
 #, fuzzy
 msgid "Updating shared folders"
 msgstr "קורא את הספרייה הזמנית"
 
-#: src/PrefsUnifiedDlg.cpp:2773
+#: src/PrefsUnifiedDlg.cpp:2782
 #, c-format
 msgid "Scanned %u directories..."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2823
+#: src/PrefsUnifiedDlg.cpp:2832
 #, fuzzy, c-format
 msgid "Reloading shared files: %u files scanned"
 msgstr "טוען מחדש את רשימת הקבצים המשותפים."
 
-#: src/PrefsUnifiedDlg.cpp:2873
+#: src/PrefsUnifiedDlg.cpp:2882
 #, fuzzy
 msgid "Shared folder"
 msgstr "קבצים משותפים"
@@ -7838,12 +7838,12 @@ msgstr "הסר קטיגוריה"
 msgid "Hashset requested for unknown file: %s"
 msgstr "התבקשה קבוצת הגיבובים של קובץ לא ידוע: %s"
 
-#: src/UploadQueue.cpp:618
+#: src/UploadQueue.cpp:627
 #, c-format
 msgid "Resuming uploads of file: %s"
 msgstr "ממשיך את העלאה של קובץ: %s"
 
-#: src/UploadQueue.cpp:634
+#: src/UploadQueue.cpp:643
 #, c-format
 msgid "Suspending upload of file: %s"
 msgstr "משהה את העלאה של קובץ: %s"

--- a/po/hr.po
+++ b/po/hr.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-28 12:17+0200\n"
+"POT-Creation-Date: 2026-07-28 13:09+0200\n"
 "PO-Revision-Date: 2026-07-27 11:39+0000\n"
 "Last-Translator: Sebastiano Pistore <sebastiano.pistore.info@aol.com>\n"
 "Language-Team: https://github.com/amule-org/amule <forum@aMule.org>\n"
@@ -286,7 +286,7 @@ msgid "Password set and external connections enabled."
 msgstr "Nova vanjska veza prihvacena\n"
 
 #: src/amule.cpp:755 src/KadDlg.cpp:176 src/KadDlg.cpp:185
-#: src/PrefsUnifiedDlg.cpp:1461 src/SharedFilesCtrl.cpp:476
+#: src/PrefsUnifiedDlg.cpp:1470 src/SharedFilesCtrl.cpp:476
 msgid "WARNING"
 msgstr "UPOZORENJE"
 
@@ -322,7 +322,7 @@ msgstr ""
 #: src/amule-remote-gui.cpp:603 src/amule-remote-gui.cpp:671
 #: src/amule-remote-gui.cpp:709 src/amule-remote-gui.cpp:1282
 #: src/amule-remote-gui.cpp:1345 src/amule-remote-gui.cpp:1372
-#: src/DownloadQueue.cpp:1481 src/PrefsUnifiedDlg.cpp:1247
+#: src/DownloadQueue.cpp:1481 src/PrefsUnifiedDlg.cpp:1256
 msgid "ERROR"
 msgstr "GREŠKA"
 
@@ -576,36 +576,36 @@ msgstr ""
 msgid "FATAL ERROR: Failed to create Timer"
 msgstr ""
 
-#: src/amuleDlg.cpp:361 src/amuleDlg.cpp:1787 src/amuleDlg.cpp:2033
-#: src/muuli_wdr.cpp:1492 src/muuli_wdr.cpp:3449
+#: src/amuleDlg.cpp:361 src/amuleDlg.cpp:1810 src/amuleDlg.cpp:2056
+#: src/muuli_wdr.cpp:1492 src/muuli_wdr.cpp:3453
 msgid "Networks"
 msgstr ""
 
-#: src/amuleDlg.cpp:362 src/amuleDlg.cpp:1793 src/muuli_wdr.cpp:3450
+#: src/amuleDlg.cpp:362 src/amuleDlg.cpp:1816 src/muuli_wdr.cpp:3454
 msgid "Searches"
 msgstr "Pretrage"
 
-#: src/amuleDlg.cpp:363 src/amuleDlg.cpp:1799 src/DownloadListCtrl.cpp:740
-#: src/muuli_wdr.cpp:392 src/muuli_wdr.cpp:1585 src/muuli_wdr.cpp:3451
+#: src/amuleDlg.cpp:363 src/amuleDlg.cpp:1822 src/DownloadListCtrl.cpp:740
+#: src/muuli_wdr.cpp:392 src/muuli_wdr.cpp:1585 src/muuli_wdr.cpp:3455
 #: src/Statistics.cpp:829
 msgid "Downloads"
 msgstr "Downloads"
 
-#: src/amuleDlg.cpp:364 src/amuleDlg.cpp:1805 src/muuli_wdr.cpp:3325
+#: src/amuleDlg.cpp:364 src/amuleDlg.cpp:1828 src/muuli_wdr.cpp:3329
 msgid "Shared files"
 msgstr ""
 
-#: src/amuleDlg.cpp:365 src/amuleDlg.cpp:1811 src/muuli_wdr.cpp:2957
-#: src/muuli_wdr.cpp:3407 src/muuli_wdr.cpp:3454
+#: src/amuleDlg.cpp:365 src/amuleDlg.cpp:1834 src/muuli_wdr.cpp:2961
+#: src/muuli_wdr.cpp:3411 src/muuli_wdr.cpp:3458
 msgid "Messages"
 msgstr "Poruke"
 
-#: src/amuleDlg.cpp:366 src/amuleDlg.cpp:1817 src/muuli_wdr.cpp:3455
+#: src/amuleDlg.cpp:366 src/amuleDlg.cpp:1840 src/muuli_wdr.cpp:3459
 #: src/PrefsUnifiedDlg.cpp:314 src/Statistics.cpp:779 src/Statistics.cpp:1235
 msgid "Statistics"
 msgstr "Statistike"
 
-#: src/amuleDlg.cpp:368 src/amuleDlg.cpp:1824 src/muuli_wdr.cpp:3457
+#: src/amuleDlg.cpp:368 src/amuleDlg.cpp:1847 src/muuli_wdr.cpp:3461
 #: src/PrefsUnifiedDlg.cpp:330 src/utils/wxCas/src/wxcasprefs.cpp:39
 msgid "Preferences"
 msgstr "Opcije"
@@ -666,8 +666,8 @@ msgstr ""
 #: src/amuleDlg.cpp:1029 src/DownloadListCtrl.cpp:505
 #: src/DownloadListCtrl.cpp:749 src/FriendListCtrl.cpp:180
 #: src/muuli_wdr.cpp:731 src/muuli_wdr.cpp:782 src/muuli_wdr.cpp:846
-#: src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2262 src/muuli_wdr.cpp:2347
-#: src/muuli_wdr.cpp:3095 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
+#: src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2266 src/muuli_wdr.cpp:2351
+#: src/muuli_wdr.cpp:3099 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
 #: src/ServerListCtrl.cpp:606 src/TransferWnd.cpp:378
 #: src/utils/wxCas/src/wxcasprefs.cpp:235
 msgid "Cancel"
@@ -679,7 +679,7 @@ msgid "Stop the current connection attempts"
 msgstr "Zaustavlja trenutne pokusaje uspostavljanja veze"
 
 #: src/amuleDlg.cpp:1035 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976
-#: src/muuli_wdr.cpp:2485
+#: src/muuli_wdr.cpp:2489
 msgid "Disconnect"
 msgstr "Prekinuti vezu"
 
@@ -689,7 +689,7 @@ msgid "Disconnect from the currently connected networks"
 msgstr "Prekinuti vezu sa sadasnjim serverom"
 
 #: src/amuleDlg.cpp:1041 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979
-#: src/muuli_wdr.cpp:2640 src/muuli_wdr.cpp:3092 src/muuli_wdr.cpp:3447
+#: src/muuli_wdr.cpp:2644 src/muuli_wdr.cpp:3096 src/muuli_wdr.cpp:3451
 msgid "Connect"
 msgstr "Uspostavi vezu"
 
@@ -744,7 +744,7 @@ msgstr "Potvrda izlaza"
 msgid "Launch Command: "
 msgstr ""
 
-#: src/amuleDlg.cpp:1632 src/muuli_wdr.cpp:1982 src/Preferences.cpp:979
+#: src/amuleDlg.cpp:1632 src/muuli_wdr.cpp:1986 src/Preferences.cpp:979
 msgid "- default -"
 msgstr ""
 
@@ -758,61 +758,61 @@ msgstr ""
 msgid "WARNING: Unable to open skin file '%s' for read"
 msgstr ""
 
-#: src/amuleDlg.cpp:1791 src/muuli_wdr.cpp:3449
+#: src/amuleDlg.cpp:1814 src/muuli_wdr.cpp:3453
 msgid "Networks Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1797 src/muuli_wdr.cpp:3450
+#: src/amuleDlg.cpp:1820 src/muuli_wdr.cpp:3454
 msgid "Searches Window"
 msgstr "Prozor pretraga"
 
-#: src/amuleDlg.cpp:1803 src/muuli_wdr.cpp:3451
+#: src/amuleDlg.cpp:1826 src/muuli_wdr.cpp:3455
 #, fuzzy
 msgid "Downloads Window"
 msgstr "Downloading"
 
-#: src/amuleDlg.cpp:1809 src/muuli_wdr.cpp:3453
+#: src/amuleDlg.cpp:1832 src/muuli_wdr.cpp:3457
 msgid "Shared Files Window"
 msgstr "Prozor dijeljenih fajlova"
 
-#: src/amuleDlg.cpp:1815 src/muuli_wdr.cpp:3454
+#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3458
 msgid "Messages Window"
 msgstr "Prozor poruka"
 
-#: src/amuleDlg.cpp:1821 src/muuli_wdr.cpp:3455
+#: src/amuleDlg.cpp:1844 src/muuli_wdr.cpp:3459
 msgid "Statistics Graph Window"
 msgstr "Prozor grafova statistike"
 
-#: src/amuleDlg.cpp:1828 src/muuli_wdr.cpp:3457
+#: src/amuleDlg.cpp:1851 src/muuli_wdr.cpp:3461
 msgid "Preferences Settings Window"
 msgstr "Prozor postavke opcija"
 
-#: src/amuleDlg.cpp:1831 src/muuli_wdr.cpp:3458
+#: src/amuleDlg.cpp:1854 src/muuli_wdr.cpp:3462
 msgid "Import"
 msgstr "Uvezi"
 
-#: src/amuleDlg.cpp:1835 src/muuli_wdr.cpp:3458
+#: src/amuleDlg.cpp:1858 src/muuli_wdr.cpp:3462
 msgid "The partfile importer tool"
 msgstr ""
 
-#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3459
+#: src/amuleDlg.cpp:1861 src/muuli_wdr.cpp:3463
 #: src/utils/aLinkCreator/src/alcframe.cpp:262
 msgid "About"
 msgstr "O autoru:"
 
-#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3459
+#: src/amuleDlg.cpp:1861 src/muuli_wdr.cpp:3463
 msgid "About/Help"
 msgstr ""
 
-#: src/amuleDlg.cpp:2036
+#: src/amuleDlg.cpp:2059
 msgid "eD2k network"
 msgstr ""
 
-#: src/amuleDlg.cpp:2039
+#: src/amuleDlg.cpp:2062
 msgid "Kad network"
 msgstr ""
 
-#: src/amuleDlg.cpp:2039
+#: src/amuleDlg.cpp:2062
 msgid "No network"
 msgstr ""
 
@@ -1352,19 +1352,19 @@ msgstr "Auto [Vi]"
 msgid "Very low"
 msgstr "Vrlo nizak"
 
-#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:743 src/muuli_wdr.cpp:2313
+#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:743 src/muuli_wdr.cpp:2317
 #: src/ServerListCtrl.cpp:263 src/ServerListCtrl.cpp:456
 #: src/SharedFilesCtrl.cpp:145
 msgid "Low"
 msgstr "Nisko"
 
-#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:744 src/muuli_wdr.cpp:2314
+#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:744 src/muuli_wdr.cpp:2318
 #: src/ServerListCtrl.cpp:266 src/ServerListCtrl.cpp:457
 #: src/SharedFilesCtrl.cpp:146
 msgid "Normal"
 msgstr "Normalan"
 
-#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:745 src/muuli_wdr.cpp:2315
+#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:745 src/muuli_wdr.cpp:2319
 #: src/ServerListCtrl.cpp:269 src/ServerListCtrl.cpp:458
 #: src/SharedFilesCtrl.cpp:147
 msgid "High"
@@ -1456,7 +1456,7 @@ msgstr ""
 msgid "Remote Server"
 msgstr ""
 
-#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3212
+#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3216
 #: src/SearchDlg.cpp:119 src/TextClient.cpp:911
 msgid "Kad"
 msgstr "Kad"
@@ -1527,7 +1527,7 @@ msgstr ""
 msgid "Size"
 msgstr "Velicina"
 
-#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3279
+#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3283
 msgid "Transferred"
 msgstr "Transferirano"
 
@@ -1585,7 +1585,7 @@ msgid ""
 "\n"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:746 src/muuli_wdr.cpp:2316
+#: src/DownloadListCtrl.cpp:746 src/muuli_wdr.cpp:2320
 #: src/SharedFilesCtrl.cpp:150
 msgid "Auto"
 msgstr "Automatski"
@@ -1623,7 +1623,7 @@ msgid "Extended Options"
 msgstr "Prosirene opcije"
 
 #: src/DownloadListCtrl.cpp:770 src/DownloadListCtrl.cpp:822
-#: src/muuli_wdr.cpp:1800
+#: src/muuli_wdr.cpp:1804
 msgid "Preview"
 msgstr "Preuvid"
 
@@ -2397,23 +2397,23 @@ msgid ""
 "want downloads on a different (e.g. larger) disk."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:549 src/FirstRunWizard.cpp:611 src/muuli_wdr.cpp:1712
+#: src/FirstRunWizard.cpp:549 src/FirstRunWizard.cpp:611 src/muuli_wdr.cpp:1716
 msgid "Destination folder for downloads"
 msgstr ""
 
 #: src/FirstRunWizard.cpp:553 src/FirstRunWizard.cpp:569 src/muuli_wdr.cpp:1349
-#: src/muuli_wdr.cpp:1366 src/muuli_wdr.cpp:1687 src/muuli_wdr.cpp:1718
-#: src/muuli_wdr.cpp:1730 src/muuli_wdr.cpp:2800
+#: src/muuli_wdr.cpp:1366 src/muuli_wdr.cpp:1691 src/muuli_wdr.cpp:1722
+#: src/muuli_wdr.cpp:1734 src/muuli_wdr.cpp:2804
 #: src/utils/aLinkCreator/src/alcframe.cpp:135
 #: src/utils/wxCas/src/wxcasprefs.cpp:52 src/utils/wxCas/src/wxcasprefs.cpp:118
 msgid "Browse"
 msgstr "Pretrazi :"
 
-#: src/FirstRunWizard.cpp:559 src/muuli_wdr.cpp:1723
+#: src/FirstRunWizard.cpp:559 src/muuli_wdr.cpp:1727
 msgid "(All files in this folder are shared with other peers)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:565 src/FirstRunWizard.cpp:624 src/muuli_wdr.cpp:1725
+#: src/FirstRunWizard.cpp:565 src/FirstRunWizard.cpp:624 src/muuli_wdr.cpp:1729
 msgid "Folder for temporary download files"
 msgstr ""
 
@@ -2444,7 +2444,7 @@ msgstr ""
 msgid "CRITICAL - no client on StartChatSession"
 msgstr ""
 
-#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2706 src/muuli_wdr.cpp:3383
+#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2710 src/muuli_wdr.cpp:3387
 msgid "Friends"
 msgstr "Prijatelji"
 
@@ -2553,8 +2553,8 @@ msgstr "Nijedno"
 msgid "No"
 msgstr "Ne"
 
-#: src/GenericClientListCtrl.cpp:1216 src/PrefsUnifiedDlg.cpp:2898
-#: src/PrefsUnifiedDlg.cpp:2948 src/ServerListCtrl.cpp:276
+#: src/GenericClientListCtrl.cpp:1216 src/PrefsUnifiedDlg.cpp:2907
+#: src/PrefsUnifiedDlg.cpp:2957 src/ServerListCtrl.cpp:276
 msgid "Yes"
 msgstr "Da"
 
@@ -2724,10 +2724,10 @@ msgstr ""
 msgid "Please fill all fields required"
 msgstr ""
 
-#: src/KadDlg.cpp:192 src/PartFile.cpp:1031 src/PrefsUnifiedDlg.cpp:1134
-#: src/PrefsUnifiedDlg.cpp:1204 src/PrefsUnifiedDlg.cpp:1405
-#: src/PrefsUnifiedDlg.cpp:1663 src/PrefsUnifiedDlg.cpp:1673
-#: src/PrefsUnifiedDlg.cpp:1690 src/PrefsUnifiedDlg.cpp:1738
+#: src/KadDlg.cpp:192 src/PartFile.cpp:1031 src/PrefsUnifiedDlg.cpp:1143
+#: src/PrefsUnifiedDlg.cpp:1213 src/PrefsUnifiedDlg.cpp:1414
+#: src/PrefsUnifiedDlg.cpp:1672 src/PrefsUnifiedDlg.cpp:1682
+#: src/PrefsUnifiedDlg.cpp:1699 src/PrefsUnifiedDlg.cpp:1747
 msgid "Message"
 msgstr "Poruka"
 
@@ -2831,7 +2831,7 @@ msgstr ""
 msgid "Uploaded"
 msgstr ""
 
-#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3263
+#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3267
 msgid "Requested"
 msgstr ""
 
@@ -2956,7 +2956,7 @@ msgid "WARNING: "
 msgstr "UPOZORENJE: "
 
 #: src/MuleNotebook.cpp:179 src/muuli_wdr.cpp:817 src/muuli_wdr.cpp:1229
-#: src/muuli_wdr.cpp:3167 src/muuli_wdr.cpp:3423
+#: src/muuli_wdr.cpp:3171 src/muuli_wdr.cpp:3427
 msgid "Close"
 msgstr "Zatvori"
 
@@ -2974,7 +2974,7 @@ msgid "Paste"
 msgstr "Staviti"
 
 #: src/MuleTextCtrl.cpp:89 src/muuli_wdr.cpp:358 src/muuli_wdr.cpp:757
-#: src/muuli_wdr.cpp:2390 src/muuli_wdr.cpp:2409 src/muuli_wdr.cpp:2431
+#: src/muuli_wdr.cpp:2394 src/muuli_wdr.cpp:2413 src/muuli_wdr.cpp:2435
 #: src/utils/aLinkCreator/src/alcframe.cpp:142
 msgid "Clear"
 msgstr "Ocisti"
@@ -3073,7 +3073,7 @@ msgstr "Izlaz"
 
 #: src/MuleTrayIcon.cpp:579 src/MuleTrayIcon.cpp:945 src/MuleTrayIcon.cpp:965
 #: src/muuli_wdr.cpp:1398 src/muuli_wdr.cpp:1406 src/muuli_wdr.cpp:1413
-#: src/muuli_wdr.cpp:1846 src/muuli_wdr.cpp:1852 src/OtherFunctions.cpp:91
+#: src/muuli_wdr.cpp:1850 src/muuli_wdr.cpp:1856 src/OtherFunctions.cpp:91
 #: src/StatisticsDlg.cpp:93 src/StatisticsDlg.cpp:95
 msgid "kB/s"
 msgstr "kB/s"
@@ -3314,7 +3314,7 @@ msgstr "Bytes"
 msgid "KB"
 msgstr "KB"
 
-#: src/muuli_wdr.cpp:274 src/muuli_wdr.cpp:293 src/muuli_wdr.cpp:1631
+#: src/muuli_wdr.cpp:274 src/muuli_wdr.cpp:293 src/muuli_wdr.cpp:1635
 #: src/OtherFunctions.cpp:64
 msgid "MB"
 msgstr "MB"
@@ -3331,7 +3331,7 @@ msgstr "Maksimalna velicina"
 msgid "Availability"
 msgstr "Dostupnost"
 
-#: src/muuli_wdr.cpp:312 src/muuli_wdr.cpp:398 src/muuli_wdr.cpp:3328
+#: src/muuli_wdr.cpp:312 src/muuli_wdr.cpp:398 src/muuli_wdr.cpp:3332
 msgid "Filter:"
 msgstr "Filtar:"
 
@@ -3395,8 +3395,8 @@ msgstr "Nadjeni izvori :"
 #: src/muuli_wdr.cpp:1160 src/muuli_wdr.cpp:1167 src/muuli_wdr.cpp:1172
 #: src/muuli_wdr.cpp:1179 src/muuli_wdr.cpp:1184 src/muuli_wdr.cpp:1191
 #: src/muuli_wdr.cpp:1205 src/muuli_wdr.cpp:1212 src/muuli_wdr.cpp:1217
-#: src/muuli_wdr.cpp:1224 src/muuli_wdr.cpp:3265 src/muuli_wdr.cpp:3273
-#: src/muuli_wdr.cpp:3281
+#: src/muuli_wdr.cpp:1224 src/muuli_wdr.cpp:3269 src/muuli_wdr.cpp:3277
+#: src/muuli_wdr.cpp:3285
 msgid "N/A"
 msgstr "N/A"
 
@@ -3539,7 +3539,7 @@ msgstr ""
 msgid "Album :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:685 src/muuli_wdr.cpp:2285
+#: src/muuli_wdr.cpp:685 src/muuli_wdr.cpp:2289
 msgid "Title :"
 msgstr "Naziv :"
 
@@ -3645,7 +3645,7 @@ msgstr "Ime korisnika :"
 msgid "Userhash :"
 msgstr "Hash korisnika :"
 
-#: src/muuli_wdr.cpp:895 src/muuli_wdr.cpp:1752 src/muuli_wdr.cpp:2480
+#: src/muuli_wdr.cpp:895 src/muuli_wdr.cpp:1756 src/muuli_wdr.cpp:2484
 #: src/utils/aLinkCreator/src/alcframe.cpp:137
 msgid "Add"
 msgstr "Dodaj"
@@ -3654,15 +3654,15 @@ msgstr "Dodaj"
 msgid "Download-Speed"
 msgstr "Brzina downloada"
 
-#: src/muuli_wdr.cpp:954 src/muuli_wdr.cpp:989 src/muuli_wdr.cpp:2584
+#: src/muuli_wdr.cpp:954 src/muuli_wdr.cpp:989 src/muuli_wdr.cpp:2588
 msgid "Current"
 msgstr "Trenutno"
 
-#: src/muuli_wdr.cpp:962 src/muuli_wdr.cpp:997 src/muuli_wdr.cpp:2592
+#: src/muuli_wdr.cpp:962 src/muuli_wdr.cpp:997 src/muuli_wdr.cpp:2596
 msgid "Running average"
 msgstr "Prosjek rada"
 
-#: src/muuli_wdr.cpp:970 src/muuli_wdr.cpp:1005 src/muuli_wdr.cpp:2600
+#: src/muuli_wdr.cpp:970 src/muuli_wdr.cpp:1005 src/muuli_wdr.cpp:2604
 msgid "Session average"
 msgstr "Prosjek misije"
 
@@ -3674,7 +3674,7 @@ msgstr "Brzina uploada"
 msgid "Connections"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1024 src/muuli_wdr.cpp:1871
+#: src/muuli_wdr.cpp:1024 src/muuli_wdr.cpp:1875
 msgid "Active downloads"
 msgstr "Aktivni downloadovi"
 
@@ -3682,7 +3682,7 @@ msgstr "Aktivni downloadovi"
 msgid "Active connections (1:1)"
 msgstr "Aktivne veze (1:1)"
 
-#: src/muuli_wdr.cpp:1040 src/muuli_wdr.cpp:1872
+#: src/muuli_wdr.cpp:1040 src/muuli_wdr.cpp:1876
 msgid "Active uploads"
 msgstr "Aktivni uploadovi"
 
@@ -3956,7 +3956,7 @@ msgstr ""
 msgid "Advanced users only: If you have multiple network interfaces, enter the address of the interface to which aMule should be bound."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1462 src/muuli_wdr.cpp:2065
+#: src/muuli_wdr.cpp:1462 src/muuli_wdr.cpp:2069
 msgid "Bind to network interface (empty for any):"
 msgstr ""
 
@@ -3972,7 +3972,7 @@ msgstr ""
 msgid "Max simultaneous connections:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1498 src/muuli_wdr.cpp:3207
+#: src/muuli_wdr.cpp:1498 src/muuli_wdr.cpp:3211
 msgid "ED2K"
 msgstr "ED2K"
 
@@ -4064,774 +4064,774 @@ msgstr ""
 msgid "For new files preallocates disk space for the whole file, thus reduces fragmentation"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1617
+#: src/muuli_wdr.cpp:1621
 msgid "Create new files as sparse files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1618
+#: src/muuli_wdr.cpp:1622
 msgid "Sparse part files only occupy disk space for the parts already downloaded, so free space is used up gradually as the file fills in. Turn this off to use an ordinary file instead - useful where sparse files are unsupported or slow, or where backup/de-duplication tools handle them badly. Applies only when the core runs on Windows; on Linux and macOS part files are sparse anyway and this setting has no effect."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1623
+#: src/muuli_wdr.cpp:1627
 msgid "Stop downloads when free disk space reaches "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1624
+#: src/muuli_wdr.cpp:1628
 msgid "Select this if you want aMule to check your disk space"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1628
+#: src/muuli_wdr.cpp:1632
 msgid "Enter here the min disk space desired."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1634
+#: src/muuli_wdr.cpp:1638
 msgid "Save 10 sources on rare files (< 20 sources)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1638 src/Statistics.cpp:790
+#: src/muuli_wdr.cpp:1642 src/Statistics.cpp:790
 msgid "Uploads"
 msgstr "Uploadovi"
 
-#: src/muuli_wdr.cpp:1641
+#: src/muuli_wdr.cpp:1645
 msgid "Add new shared files with auto priority"
 msgstr "Dodaj nove dijeljene fajlove sa auto prioritetom"
 
-#: src/muuli_wdr.cpp:1647
+#: src/muuli_wdr.cpp:1651
 msgid "Intelligent Corruption Handling (I.C.H.)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1650
+#: src/muuli_wdr.cpp:1654
 msgid "Enable"
 msgstr "Omogućiti"
 
-#: src/muuli_wdr.cpp:1653
+#: src/muuli_wdr.cpp:1657
 msgid "Advanced I.C.H. trusts every hash (not recommended)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1665 src/PrefsUnifiedDlg.cpp:1990
+#: src/muuli_wdr.cpp:1669 src/PrefsUnifiedDlg.cpp:1999
 msgid "Media metadata extraction"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1669
+#: src/muuli_wdr.cpp:1673
 msgid "Extract length / bitrate / codec from shared audio and video files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1671
+#: src/muuli_wdr.cpp:1675
 msgid "When enabled, aMule runs ffprobe on each shared media file to fill in the Length / Bitrate / Codec columns other clients see when they find the file in a search. Requires ffmpeg (the ffprobe binary) to be installed."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1678
+#: src/muuli_wdr.cpp:1682
 msgid "Path to ffprobe:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1683
+#: src/muuli_wdr.cpp:1687
 msgid "Full path to the ffprobe binary. Leave empty to have aMule auto-detect it on startup."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1691
+#: src/muuli_wdr.cpp:1695
 msgid "Detect"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1692
+#: src/muuli_wdr.cpp:1696
 msgid "Search the standard install locations for an ffprobe binary and fill the path field."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1716
+#: src/muuli_wdr.cpp:1720
 msgid ""
 "Completed downloads are stored here. All files in this folder are automatically shared with other peers.\n"
 "If this folder also holds files you don't want to share, point it at an aMule-only sub-folder."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1719
+#: src/muuli_wdr.cpp:1723
 msgid "Pick the folder where completed downloads will be stored. All files in that folder will be shared with other peers."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1733
+#: src/muuli_wdr.cpp:1737
 msgid "Shared folders"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1739
+#: src/muuli_wdr.cpp:1743
 msgid "(Folders shared by the core. Enter a path to add one.)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1747
+#: src/muuli_wdr.cpp:1751
 msgid "Absolute path of a folder on the core's machine, e.g. /home/user/shared"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1749 src/PrefsUnifiedDlg.cpp:2874
+#: src/muuli_wdr.cpp:1753 src/PrefsUnifiedDlg.cpp:2883
 msgid "Recursive"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1750
+#: src/muuli_wdr.cpp:1754
 msgid "Share every sub-folder underneath this one, including ones created later."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1754 src/utils/aLinkCreator/src/alcframe.cpp:141
+#: src/muuli_wdr.cpp:1758 src/utils/aLinkCreator/src/alcframe.cpp:141
 msgid "Remove"
 msgstr "Ukloni"
 
-#: src/muuli_wdr.cpp:1758
+#: src/muuli_wdr.cpp:1762
 msgid "(Right click on folder icon for recursive share)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1765
+#: src/muuli_wdr.cpp:1769
 msgid "Share hidden files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1771
+#: src/muuli_wdr.cpp:1775
 msgid "Automatically rescan shared folders for changes"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1777
+#: src/muuli_wdr.cpp:1781
 msgid "Follow symbolic links in shared folders"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1783
+#: src/muuli_wdr.cpp:1787
 msgid "Exclude files matching:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1786
+#: src/muuli_wdr.cpp:1790
 msgid "Wildcard patterns separated by '|', e.g. .DS_Store|Thumbs.db|*.tmp. Files whose name matches are not shared. Matching is case-insensitive."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1790
+#: src/muuli_wdr.cpp:1794
 msgid "Patterns are regular expressions"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1791
+#: src/muuli_wdr.cpp:1795
 msgid "When set, the whole field is one regular expression ('|' is alternation). When unset, it is a list of '|'-separated wildcards."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1801
+#: src/muuli_wdr.cpp:1805
 msgid "Show how many shared files the current pattern would exclude."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1822
+#: src/muuli_wdr.cpp:1826
 msgid "Graphs"
 msgstr "Grafovi"
 
-#: src/muuli_wdr.cpp:1825 src/muuli_wdr.cpp:1887
+#: src/muuli_wdr.cpp:1829 src/muuli_wdr.cpp:1891
 msgid "Update delay : 5 secs"
 msgstr "Obnovi kasnjenje : 5 sekundi"
 
-#: src/muuli_wdr.cpp:1829
+#: src/muuli_wdr.cpp:1833
 msgid "Time for average graph: 100 mins"
 msgstr "Vrijeme za prosjecni graf: 100 minuta"
 
-#: src/muuli_wdr.cpp:1833
+#: src/muuli_wdr.cpp:1837
 msgid "Connections Graph Scale: 100 "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1840
+#: src/muuli_wdr.cpp:1844
 msgid "Download graph scale:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1848
+#: src/muuli_wdr.cpp:1852
 msgid "Upload graph scale:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1858
+#: src/muuli_wdr.cpp:1862
 #, fuzzy
 msgid "Colors: "
 msgstr "Boje: "
 
-#: src/muuli_wdr.cpp:1862
+#: src/muuli_wdr.cpp:1866
 msgid "Background"
 msgstr "Pozadina"
 
-#: src/muuli_wdr.cpp:1863
+#: src/muuli_wdr.cpp:1867
 msgid "Grid"
 msgstr "Mreza"
 
-#: src/muuli_wdr.cpp:1864
+#: src/muuli_wdr.cpp:1868
 msgid "Download current"
 msgstr "Trenutni download"
 
-#: src/muuli_wdr.cpp:1865
+#: src/muuli_wdr.cpp:1869
 msgid "Download running average"
 msgstr "Prosjek tekuceg downloada"
 
-#: src/muuli_wdr.cpp:1866
+#: src/muuli_wdr.cpp:1870
 msgid "Download session average"
 msgstr "Prosjek downloada misije"
 
-#: src/muuli_wdr.cpp:1867
+#: src/muuli_wdr.cpp:1871
 msgid "Upload current"
 msgstr "Trenutni upload"
 
-#: src/muuli_wdr.cpp:1868
+#: src/muuli_wdr.cpp:1872
 msgid "Upload running average"
 msgstr "Prosjek tekuceg uploada"
 
-#: src/muuli_wdr.cpp:1869
+#: src/muuli_wdr.cpp:1873
 msgid "Upload session average"
 msgstr "Prosjek uploada misije"
 
-#: src/muuli_wdr.cpp:1870
+#: src/muuli_wdr.cpp:1874
 msgid "Active connections"
 msgstr "Aktivne veze"
 
-#: src/muuli_wdr.cpp:1873
+#: src/muuli_wdr.cpp:1877
 #, fuzzy
 msgid "Systray Icon Speed Bar"
 msgstr "poluga brzine prikazana u sistemskom koritu"
 
-#: src/muuli_wdr.cpp:1874
+#: src/muuli_wdr.cpp:1878
 msgid "Kad-nodes current"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1875
+#: src/muuli_wdr.cpp:1879
 msgid "Kad-nodes running"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1876
+#: src/muuli_wdr.cpp:1880
 msgid "Kad-nodes session"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1880 src/muuli_wdr.cpp:2334
+#: src/muuli_wdr.cpp:1884 src/muuli_wdr.cpp:2338
 msgid "Select"
 msgstr "Izaberi"
 
-#: src/muuli_wdr.cpp:1884
+#: src/muuli_wdr.cpp:1888
 msgid "Tree"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1894
+#: src/muuli_wdr.cpp:1898
 msgid "Number of Client Versions shown (0=unlimited)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1919
+#: src/muuli_wdr.cpp:1923
 msgid "!!! WARNING !!!"
 msgstr "!!! UPOZORENJE !!!"
 
-#: src/muuli_wdr.cpp:1934
+#: src/muuli_wdr.cpp:1938
 msgid "Max new connections / 5 secs"
 msgstr "Maksimalne veze u / 5 sekundi"
 
-#: src/muuli_wdr.cpp:1936
+#: src/muuli_wdr.cpp:1940
 msgid "Concurrent Kad source lookups"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1938
+#: src/muuli_wdr.cpp:1942
 msgid "Kad source re-search interval (minutes)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1940
+#: src/muuli_wdr.cpp:1944
 #, fuzzy
 msgid "Source re-ask interval (minutes)"
 msgstr "Interval obnavljanja veze servera %i minuta"
 
-#: src/muuli_wdr.cpp:1944
+#: src/muuli_wdr.cpp:1948
 msgid "File Buffer Size: 240000 bytes"
 msgstr "Fajl Buffer velicina: 240000 bytes"
 
-#: src/muuli_wdr.cpp:1948
+#: src/muuli_wdr.cpp:1952
 msgid "Use MMAP: memory-mapped file access (lower memory use)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1949
+#: src/muuli_wdr.cpp:1953
 msgid "Maps part files into memory instead of buffering them on the heap, lowering the process memory footprint. May reduce download speed on some disks; best for memory-constrained or upload-heavy hosts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1951
+#: src/muuli_wdr.cpp:1955
 msgid "Upload Queue Size: 5000 clients"
 msgstr "Duzina reda cekanja: 5000 klienta"
 
-#: src/muuli_wdr.cpp:1955
+#: src/muuli_wdr.cpp:1959
 msgid "Server connection refresh interval: Disable"
 msgstr "Interval obnavljanja veze servera: onemoguceno"
 
-#: src/muuli_wdr.cpp:1959
+#: src/muuli_wdr.cpp:1963
 msgid "Disable computer's timed standby mode"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1978
+#: src/muuli_wdr.cpp:1982
 msgid "Skin to use: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1987
+#: src/muuli_wdr.cpp:1991
 msgid "Show \"Fast eD2k Links Handler\" in every window."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1990
+#: src/muuli_wdr.cpp:1994
 msgid "Show extended info on categories tabs"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1993
+#: src/muuli_wdr.cpp:1997
 #, fuzzy
 msgid "Show application version on title"
 msgstr "Pokazi transfer rate u naslovu"
 
-#: src/muuli_wdr.cpp:1995
+#: src/muuli_wdr.cpp:1999
 msgid "Show transfer rates on title"
 msgstr "Pokazi transfer rate u naslovu"
 
-#: src/muuli_wdr.cpp:1997
+#: src/muuli_wdr.cpp:2001
 msgid "Before application name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1999
+#: src/muuli_wdr.cpp:2003
 msgid "After application name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2002
+#: src/muuli_wdr.cpp:2006
 msgid "Show overhead bandwidth"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2006
+#: src/muuli_wdr.cpp:2010
 msgid "Vertical toolbar orientation"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2008
+#: src/muuli_wdr.cpp:2012
 msgid "Live column sorting (auto-reorder rows as their values change)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2015
+#: src/muuli_wdr.cpp:2019
 msgid "Download Queue Files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2018
+#: src/muuli_wdr.cpp:2022
 msgid "Show progress percentage"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2024
+#: src/muuli_wdr.cpp:2028
 msgid "Show progress bar"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2027
+#: src/muuli_wdr.cpp:2031
 msgid "Flat"
 msgstr "Pljosnata"
 
-#: src/muuli_wdr.cpp:2031
+#: src/muuli_wdr.cpp:2035
 msgid "Round"
 msgstr "Obla"
 
-#: src/muuli_wdr.cpp:2049
+#: src/muuli_wdr.cpp:2053
 msgid "External Connection Parameters"
 msgstr "Parametri za spoljasnju vezu"
 
-#: src/muuli_wdr.cpp:2052
+#: src/muuli_wdr.cpp:2056
 msgid "Accept external connections"
 msgstr "Prihvati spoljasnje veze"
 
-#: src/muuli_wdr.cpp:2059 src/muuli_wdr.cpp:2118
+#: src/muuli_wdr.cpp:2063 src/muuli_wdr.cpp:2122
 msgid "IP of the listening interface:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2062
+#: src/muuli_wdr.cpp:2066
 msgid "Enter here a valid ip in the a.b.c.d format for the listening EC interface. An empty field or 0.0.0.0 will mean any interface."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2083 src/muuli_wdr.cpp:2194
+#: src/muuli_wdr.cpp:2087 src/muuli_wdr.cpp:2198
 msgid "TCP port:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2089
+#: src/muuli_wdr.cpp:2093
 msgid "Enable UPnP port forwarding on the EC port"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2093 src/muuli_wdr.cpp:3079
+#: src/muuli_wdr.cpp:2097 src/muuli_wdr.cpp:3083
 #: src/utils/wxCas/src/wxcasprefs.cpp:167
 msgid "Password"
 msgstr "Lozinka"
 
-#: src/muuli_wdr.cpp:2099
+#: src/muuli_wdr.cpp:2103
 msgid "aMule API server parameters"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2102
+#: src/muuli_wdr.cpp:2106
 msgid "Run amuleapi (REST API) on startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2107
+#: src/muuli_wdr.cpp:2111
 msgid "HTTP port:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2121
+#: src/muuli_wdr.cpp:2125
 msgid "The interface amuleapi's HTTP server listens on. 127.0.0.1 (default) accepts only local connections; use 0.0.0.0 or a specific IP to expose it to other hosts (set an admin password below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2126
+#: src/muuli_wdr.cpp:2130
 msgid "Type a password to set or change it. Stored passwords cannot be shown, so leaving this empty keeps the current one."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2128
+#: src/muuli_wdr.cpp:2132
 #, fuzzy
 msgid "Admin password"
 msgstr "Lozinka"
 
-#: src/muuli_wdr.cpp:2140 src/muuli_wdr.cpp:2157 src/PrefsUnifiedDlg.cpp:1103
+#: src/muuli_wdr.cpp:2144 src/muuli_wdr.cpp:2161 src/PrefsUnifiedDlg.cpp:1112
 #, fuzzy
 msgid "A password is set."
 msgstr "Lozinka"
 
-#: src/muuli_wdr.cpp:2144
+#: src/muuli_wdr.cpp:2148
 msgid "Enable guest access"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2145
+#: src/muuli_wdr.cpp:2149
 msgid "Guest sessions may read status and listings but cannot change anything. Turning this off clears the stored guest password."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2149
+#: src/muuli_wdr.cpp:2153
 #, fuzzy
 msgid "Guest password"
 msgstr "Sifra za puna prava"
 
-#: src/muuli_wdr.cpp:2164
+#: src/muuli_wdr.cpp:2168
 msgid "Web server parameters"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2167
+#: src/muuli_wdr.cpp:2171
 msgid "Run webserver on startup (deprecated)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2173
+#: src/muuli_wdr.cpp:2177
 msgid "Web template"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2178
+#: src/muuli_wdr.cpp:2182
 msgid "Full rights password"
 msgstr "Sifra za puna prava"
 
-#: src/muuli_wdr.cpp:2182
+#: src/muuli_wdr.cpp:2186
 msgid "Enable Low rights User"
 msgstr "Odobri korisnicima sa manje prava"
 
-#: src/muuli_wdr.cpp:2187
+#: src/muuli_wdr.cpp:2191
 msgid "Low rights password"
 msgstr "Sifra za manje prava"
 
-#: src/muuli_wdr.cpp:2201
+#: src/muuli_wdr.cpp:2205
 msgid "Enable UPnP port forwarding of the web server port"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2206
+#: src/muuli_wdr.cpp:2210
 msgid "Web server UPnP TCP port (Optional)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2214
+#: src/muuli_wdr.cpp:2218
 msgid "Page Refresh Time (in secs)"
 msgstr "Vrijeme obnove stranice (u sekundama)"
 
-#: src/muuli_wdr.cpp:2221
+#: src/muuli_wdr.cpp:2225
 msgid "Enable Gzip compression"
 msgstr "Odobri Gzip kompresiju"
 
-#: src/muuli_wdr.cpp:2255
+#: src/muuli_wdr.cpp:2259
 #, fuzzy
 msgid "Reset page to defaults"
 msgstr "Standard sistema"
 
-#: src/muuli_wdr.cpp:2256
+#: src/muuli_wdr.cpp:2260
 msgid "Reset the settings on the current page to their default values."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2258 src/muuli_wdr.cpp:2344 src/ServerWnd.cpp:274
+#: src/muuli_wdr.cpp:2262 src/muuli_wdr.cpp:2348 src/ServerWnd.cpp:274
 #: src/ServerWnd.cpp:282
 msgid "OK"
 msgstr "OK"
 
-#: src/muuli_wdr.cpp:2260
+#: src/muuli_wdr.cpp:2264
 msgid "Click here to apply any changes made to the preferences."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2263
+#: src/muuli_wdr.cpp:2267
 msgid "Reset any changes made to the preferences."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2292
+#: src/muuli_wdr.cpp:2296
 msgid "Comment :"
 msgstr "Komentar:"
 
-#: src/muuli_wdr.cpp:2299
+#: src/muuli_wdr.cpp:2303
 msgid "Incoming Dir :"
 msgstr "Prijemni direktorij :"
 
-#: src/muuli_wdr.cpp:2308
+#: src/muuli_wdr.cpp:2312
 msgid "Change priority for new assigned files :"
 msgstr "Promijeni prioritet za nove fajlove :"
 
-#: src/muuli_wdr.cpp:2312
+#: src/muuli_wdr.cpp:2316
 #, fuzzy
 msgid "Don't change"
 msgstr "Ne mijenjaj"
 
-#: src/muuli_wdr.cpp:2324
+#: src/muuli_wdr.cpp:2328
 msgid "Select color for this Category (currently selected) :"
 msgstr "Izaberi boju za ovu kategoriju (trenutno izabrana) :"
 
-#: src/muuli_wdr.cpp:2391 src/muuli_wdr.cpp:2410 src/muuli_wdr.cpp:2432
+#: src/muuli_wdr.cpp:2395 src/muuli_wdr.cpp:2414 src/muuli_wdr.cpp:2436
 msgid "Click this button to reset the log."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2451
+#: src/muuli_wdr.cpp:2455
 msgid "Click on this button to update the servers list from URL ..."
 msgstr "Klikni ovdje da obnovis listu servera sa URL ..."
 
-#: src/muuli_wdr.cpp:2455
+#: src/muuli_wdr.cpp:2459
 msgid "Server list"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2459
+#: src/muuli_wdr.cpp:2463
 msgid "Enter the url to a server.met file here and press the button to the left to update the list of known servers."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2464
+#: src/muuli_wdr.cpp:2468
 msgid "Add server manually: Name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2467
+#: src/muuli_wdr.cpp:2471
 msgid "Enter the name of the new server here"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2469 src/ServerWnd.cpp:206
+#: src/muuli_wdr.cpp:2473 src/ServerWnd.cpp:206
 msgid "IP:Port"
 msgstr "IP:Port"
 
-#: src/muuli_wdr.cpp:2472
+#: src/muuli_wdr.cpp:2476
 msgid "Enter the IP of the server here, using the x.x.x.x format."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2478
+#: src/muuli_wdr.cpp:2482
 msgid "Enter the port of the server here."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2481
+#: src/muuli_wdr.cpp:2485
 msgid "Add manually a server (fill fields to the left before) ..."
 msgstr "Dodaj servera rucno (prije ispuni polja lijevo) ..."
 
-#: src/muuli_wdr.cpp:2510
+#: src/muuli_wdr.cpp:2514
 msgid "aMule Log"
 msgstr "aMule Log"
 
-#: src/muuli_wdr.cpp:2518
+#: src/muuli_wdr.cpp:2522
 msgid "Server Info"
 msgstr "Lista servera"
 
-#: src/muuli_wdr.cpp:2522
+#: src/muuli_wdr.cpp:2526
 msgid "ED2K Info"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2526
+#: src/muuli_wdr.cpp:2530
 msgid "Kad Info"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2554
+#: src/muuli_wdr.cpp:2558
 msgid "Click on this button to update the nodes list from URL ..."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2558
+#: src/muuli_wdr.cpp:2562
 msgid "Nodes (0)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2562
+#: src/muuli_wdr.cpp:2566
 msgid "Enter the url to a nodes.dat file here and press the button to the left to update the list of known nodes."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2565
+#: src/muuli_wdr.cpp:2569
 msgid "Nodes stats"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2607
+#: src/muuli_wdr.cpp:2611
 msgid "Bootstrap"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2610
+#: src/muuli_wdr.cpp:2614
 msgid "New node"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2615
+#: src/muuli_wdr.cpp:2619
 msgid "IP:"
 msgstr "IP:"
 
-#: src/muuli_wdr.cpp:2635
+#: src/muuli_wdr.cpp:2639
 msgid "Port:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2648
+#: src/muuli_wdr.cpp:2652
 msgid "Bootstrap from known clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2650
+#: src/muuli_wdr.cpp:2654
 msgid "Disconnect Kad"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2684
+#: src/muuli_wdr.cpp:2688
 msgid "Use Secure User Identification"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2686
+#: src/muuli_wdr.cpp:2690
 msgid "It is recommended to enable this option. You will not receive credits if SUI is not enabled."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2688
+#: src/muuli_wdr.cpp:2692
 msgid "Protocol Obfuscation"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2691
+#: src/muuli_wdr.cpp:2695
 msgid "Support Protocol Obfuscation"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2693
+#: src/muuli_wdr.cpp:2697
 msgid "This option enabled Protocol Obfuscation, and makes aMule accept obfuscated connections from other clients."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2695
+#: src/muuli_wdr.cpp:2699
 msgid "Use obfuscation for outgoing connections"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2697
+#: src/muuli_wdr.cpp:2701
 msgid "This option makes aMule use Protocol Obfuscation when connecting other clients/servers."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2699
+#: src/muuli_wdr.cpp:2703
 msgid "Accept only obfuscated connections"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2700
+#: src/muuli_wdr.cpp:2704
 msgid "This option makes aMule only accept obfuscated connections. You will have less sources, but all your traffic will be obfuscated"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2705
+#: src/muuli_wdr.cpp:2709
 msgid "Everybody"
 msgstr "Svi"
 
-#: src/muuli_wdr.cpp:2707
+#: src/muuli_wdr.cpp:2711
 msgid "No one"
 msgstr "Nitko"
 
-#: src/muuli_wdr.cpp:2709
+#: src/muuli_wdr.cpp:2713
 msgid "Who can see my shared files:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2710
+#: src/muuli_wdr.cpp:2714
 msgid "Select who can request to view a list of your shared files."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2712
+#: src/muuli_wdr.cpp:2716
 msgid "IP-Filtering"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2719
+#: src/muuli_wdr.cpp:2723
 msgid "Filter clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2721
+#: src/muuli_wdr.cpp:2725
 msgid "Enable filtering of the client IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2723
+#: src/muuli_wdr.cpp:2727
 msgid "Filter servers"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2725
+#: src/muuli_wdr.cpp:2729
 msgid "Enable filtering of the server IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2729
+#: src/muuli_wdr.cpp:2733
 msgid "Reload List"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2730
+#: src/muuli_wdr.cpp:2734
 msgid "Reload the list of IPs to filter from the file ~/.aMule/ipfilter.dat"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2736
+#: src/muuli_wdr.cpp:2740
 msgid "URL:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2740 src/muuli_wdr.cpp:2933
+#: src/muuli_wdr.cpp:2744 src/muuli_wdr.cpp:2937
 msgid "Update now"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2743
+#: src/muuli_wdr.cpp:2747
 msgid "Auto-update ipfilter at startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2747
+#: src/muuli_wdr.cpp:2751
 msgid "Filtering Level:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2753
+#: src/muuli_wdr.cpp:2757
 msgid "Always filter LAN IPs"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2756
+#: src/muuli_wdr.cpp:2760
 msgid "Paranoid handling of non-matching IPs"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2758
+#: src/muuli_wdr.cpp:2762
 msgid "Rejects a packet when its source IP differs from the IP the client claims (an anti-spoofing check). Disable only if it causes connection problems."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2760
+#: src/muuli_wdr.cpp:2764
 msgid "Use system-wide ipfilter.dat if available"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2761
+#: src/muuli_wdr.cpp:2765
 msgid "If there's no local ipfilter.dat found, allow usage of a system-wide ipfilter file."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2778
+#: src/muuli_wdr.cpp:2782
 msgid "Enable Online-Signature"
 msgstr "Omoguci online potpis"
 
-#: src/muuli_wdr.cpp:2780
+#: src/muuli_wdr.cpp:2784
 msgid "Enables the writing of the OS file, which can be used by external apps to create signatures and the like."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2784
+#: src/muuli_wdr.cpp:2788
 msgid "Update Frequency (Secs):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2787
+#: src/muuli_wdr.cpp:2791
 msgid "Change the frequency (in seconds) of Online Signature updates."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2795
+#: src/muuli_wdr.cpp:2799
 msgid "Save online signature file in: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:2801
+#: src/muuli_wdr.cpp:2805
 msgid "Click here to select the directory containing the the Online Signature files."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2834
+#: src/muuli_wdr.cpp:2838
 msgid "Show country flags for clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2835
+#: src/muuli_wdr.cpp:2839
 msgid "Render the country flag column in the transfers, queue and search views. Requires a valid MMDB GeoIP database (see below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2840
+#: src/muuli_wdr.cpp:2844
 #, fuzzy
 msgid "Database"
 msgstr "Podatak rate :"
 
-#: src/muuli_wdr.cpp:2856
+#: src/muuli_wdr.cpp:2860
 #, fuzzy
 msgid "Source:"
 msgstr "Izvori"
 
-#: src/muuli_wdr.cpp:2859
+#: src/muuli_wdr.cpp:2863
 msgid "DB-IP (free, no account)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2860
+#: src/muuli_wdr.cpp:2864
 msgid "MaxMind GeoLite2 (free, account required)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2861
+#: src/muuli_wdr.cpp:2865
 msgid "Custom URL"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2864
+#: src/muuli_wdr.cpp:2868
 msgid "Choose which provider supplies the GeoIP MMDB database. DB-IP is the default - no account required. MaxMind requires a free account + license key. Use Custom URL to point at any other MMDB host (e.g. a local mirror)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2881
+#: src/muuli_wdr.cpp:2885
 msgid ""
 "No configuration required.\n"
 "\n"
@@ -4839,11 +4839,11 @@ msgid ""
 "License: Creative Commons BY 4.0 - https://creativecommons.org/licenses/by/4.0/"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2894
+#: src/muuli_wdr.cpp:2898
 msgid "License key:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2900
+#: src/muuli_wdr.cpp:2904
 msgid ""
 "Sign up for a free MaxMind account, then generate a License Key:\n"
 "https://www.maxmind.com/en/geolite2/signup\n"
@@ -4853,233 +4853,233 @@ msgid ""
 "Requires attribution and account registration; refresh at least every 30 days."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2915
+#: src/muuli_wdr.cpp:2919
 #, fuzzy
 msgid "Download URL:"
 msgstr "Download"
 
-#: src/muuli_wdr.cpp:2921
+#: src/muuli_wdr.cpp:2925
 msgid ""
 "Must point to an .mmdb file or a .gz / .tar.gz containing one.\n"
 "URL may include credentials (https://user:pass@host/...).\n"
 "License and attribution terms are set by the upstream URL - you are responsible."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2934
+#: src/muuli_wdr.cpp:2938
 msgid "Download the GeoIP database from the selected source."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2936
+#: src/muuli_wdr.cpp:2940
 #, fuzzy
 msgid "Auto-update on startup"
 msgstr "Autospajanje pri startu"
 
-#: src/muuli_wdr.cpp:2937
+#: src/muuli_wdr.cpp:2941
 msgid "Re-download the GeoIP database from the selected source every time aMule starts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2960
+#: src/muuli_wdr.cpp:2964
 msgid "Filter incoming messages (except current chat):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2962
+#: src/muuli_wdr.cpp:2966
 msgid "Filter all messages"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2964
+#: src/muuli_wdr.cpp:2968
 msgid "Filter messages from people not on your friend list"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2966
+#: src/muuli_wdr.cpp:2970
 msgid "Filter messages from unknown clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2968
+#: src/muuli_wdr.cpp:2972
 msgid "Filter messages containing (use ',' as separator):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2971 src/muuli_wdr.cpp:2982
+#: src/muuli_wdr.cpp:2975 src/muuli_wdr.cpp:2986
 msgid "add here the words amule should filter and block messages including it"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2973
+#: src/muuli_wdr.cpp:2977
 msgid "Show received messages in the log"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2976
+#: src/muuli_wdr.cpp:2980
 msgid "Comments"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2979
+#: src/muuli_wdr.cpp:2983
 msgid "Filter comments containing (use ',' as separator):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3004
+#: src/muuli_wdr.cpp:3008
 msgid "Enable Proxy"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3005
+#: src/muuli_wdr.cpp:3009
 msgid "Enable/disable proxy support"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3008
+#: src/muuli_wdr.cpp:3012
 msgid "Proxy type:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3019
+#: src/muuli_wdr.cpp:3023
 msgid "Proxy host:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3022
+#: src/muuli_wdr.cpp:3026
 msgid "The proxy host name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3024
+#: src/muuli_wdr.cpp:3028
 msgid "Proxy port:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3027
+#: src/muuli_wdr.cpp:3031
 msgid "The proxy port"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3029
+#: src/muuli_wdr.cpp:3033
 msgid "Enable authentication"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3030
+#: src/muuli_wdr.cpp:3034
 msgid "Enable/disable username/password authentication"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3033
+#: src/muuli_wdr.cpp:3037
 msgid "Username: "
 msgstr "Korisničko ime:"
 
-#: src/muuli_wdr.cpp:3036
+#: src/muuli_wdr.cpp:3040
 msgid "The username to use to connect to the proxy"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3038
+#: src/muuli_wdr.cpp:3042
 msgid "Password:"
 msgstr "Lozinka:"
 
-#: src/muuli_wdr.cpp:3041
+#: src/muuli_wdr.cpp:3045
 msgid "The password to use to connect to the proxy"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3060
+#: src/muuli_wdr.cpp:3064
 msgid "Connect to:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3069
+#: src/muuli_wdr.cpp:3073
 msgid "Login to remote amule"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3074
+#: src/muuli_wdr.cpp:3078
 msgid "User name"
 msgstr "Korisničko ime"
 
-#: src/muuli_wdr.cpp:3085
+#: src/muuli_wdr.cpp:3089
 msgid "Remember those settings"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3088
+#: src/muuli_wdr.cpp:3092
 #, fuzzy
 msgid "Force ZLIB compression"
 msgstr "Steceno kompresijom :"
 
-#: src/muuli_wdr.cpp:3112
+#: src/muuli_wdr.cpp:3116
 msgid "Enable Verbose Debug-Logging."
 msgstr ""
 
-#: src/muuli_wdr.cpp:3114
+#: src/muuli_wdr.cpp:3118
 #, fuzzy
 msgid "Only to Logfile"
 msgstr "&Otvori fajl"
 
-#: src/muuli_wdr.cpp:3116
+#: src/muuli_wdr.cpp:3120
 msgid "Message Categories:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3140 src/PartFileConvertDlg.cpp:160
+#: src/muuli_wdr.cpp:3144 src/PartFileConvertDlg.cpp:160
 msgid "Waiting..."
 msgstr "Ceka ..."
 
-#: src/muuli_wdr.cpp:3160
+#: src/muuli_wdr.cpp:3164
 msgid "Add imports"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3163
+#: src/muuli_wdr.cpp:3167
 msgid "Retry selected"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3165
+#: src/muuli_wdr.cpp:3169
 msgid "Remove selected"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3228
+#: src/muuli_wdr.cpp:3232
 msgid "Event Types"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3247
+#: src/muuli_wdr.cpp:3251
 msgid "Statistics and queued clients for selected file(s) : Session / All time"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3271
+#: src/muuli_wdr.cpp:3275
 #, fuzzy
 msgid "Active Uploads"
 msgstr "Aktivni uploadovi :"
 
-#: src/muuli_wdr.cpp:3285
+#: src/muuli_wdr.cpp:3289
 #, fuzzy
 msgid "Percent of total files"
 msgstr "Ukupni fajlovi"
 
-#: src/muuli_wdr.cpp:3337
+#: src/muuli_wdr.cpp:3341
 #, fuzzy
 msgid "Show Clients for"
 msgstr "Pokazi liste"
 
-#: src/muuli_wdr.cpp:3339
+#: src/muuli_wdr.cpp:3343
 #, fuzzy
 msgid "All files"
 msgstr "Dijeljeni fajlovi"
 
-#: src/muuli_wdr.cpp:3342
+#: src/muuli_wdr.cpp:3346
 #, fuzzy
 msgid "Selected files"
 msgstr "Izaberi filter za gledanje"
 
-#: src/muuli_wdr.cpp:3345
+#: src/muuli_wdr.cpp:3349
 #, fuzzy
 msgid "Active uploads only"
 msgstr "Aktivni uploadovi"
 
-#: src/muuli_wdr.cpp:3352
+#: src/muuli_wdr.cpp:3356
 #, fuzzy
 msgid "Reload:"
 msgstr "Ponovno ucitati"
 
-#: src/muuli_wdr.cpp:3356
+#: src/muuli_wdr.cpp:3360
 msgid "Reload your shared files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3419
+#: src/muuli_wdr.cpp:3423
 msgid "Send"
 msgstr "Posalji"
 
-#: src/muuli_wdr.cpp:3420
+#: src/muuli_wdr.cpp:3424
 msgid "Sends the specified message."
 msgstr ""
 
-#: src/muuli_wdr.cpp:3424
+#: src/muuli_wdr.cpp:3428
 msgid "Close this chat-session."
 msgstr ""
 
-#: src/muuli_wdr.cpp:3447
+#: src/muuli_wdr.cpp:3451
 msgid "Connect to any server and/or Kad"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3453 src/SharedFilesCtrl.cpp:142 src/Statistics.cpp:941
+#: src/muuli_wdr.cpp:3457 src/SharedFilesCtrl.cpp:142 src/Statistics.cpp:941
 msgid "Shared Files"
 msgstr "Dijeljeni fajlovi"
 
@@ -5718,220 +5718,220 @@ msgstr ""
 "aMule ce raditi dobro iako ne promijenis\n"
 "nista od ovih opcija."
 
-#: src/PrefsUnifiedDlg.cpp:647
+#: src/PrefsUnifiedDlg.cpp:656
 #, c-format
 msgid "Failed to connect Cfg to widget with the ID %d and key %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:695
+#: src/PrefsUnifiedDlg.cpp:704
 #, c-format
 msgid "Failed to transfer data from Cfg to Widget with the ID %d and key %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:801
+#: src/PrefsUnifiedDlg.cpp:810
 msgid "The type of proxy you are connecting to"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1020
+#: src/PrefsUnifiedDlg.cpp:1029
 #, c-format
 msgid "Failed to transfer data from Widget to Cfg with the ID %d and key %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1103
+#: src/PrefsUnifiedDlg.cpp:1112
 #, fuzzy
 msgid "No password set."
 msgstr "Lozinka"
 
-#: src/PrefsUnifiedDlg.cpp:1132
+#: src/PrefsUnifiedDlg.cpp:1141
 msgid "Guest access needs a password. Type one in the guest password field, or untick Enable guest access."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1144
+#: src/PrefsUnifiedDlg.cpp:1153
 msgid ""
 "aMule must be restarted to enable these changes:\n"
 "\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1151
+#: src/PrefsUnifiedDlg.cpp:1160
 msgid "- TCP port changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1156
+#: src/PrefsUnifiedDlg.cpp:1165
 msgid "- UDP port changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1161
+#: src/PrefsUnifiedDlg.cpp:1170
 #, fuzzy
 msgid "- Network interface binding changed.\n"
 msgstr "Parametri za spoljasnju vezu"
 
-#: src/PrefsUnifiedDlg.cpp:1166
+#: src/PrefsUnifiedDlg.cpp:1175
 #, fuzzy
 msgid "- External connect port changed.\n"
 msgstr "Parametri za spoljasnju vezu"
 
-#: src/PrefsUnifiedDlg.cpp:1170
+#: src/PrefsUnifiedDlg.cpp:1179
 #, fuzzy
 msgid "- External connect acceptance changed.\n"
 msgstr "Parametri za spoljasnju vezu"
 
-#: src/PrefsUnifiedDlg.cpp:1174
+#: src/PrefsUnifiedDlg.cpp:1183
 #, fuzzy
 msgid "- External connect interface changed.\n"
 msgstr "Parametri za spoljasnju vezu"
 
-#: src/PrefsUnifiedDlg.cpp:1178
+#: src/PrefsUnifiedDlg.cpp:1187
 #, fuzzy
 msgid "- Protocol obfuscation support changed.\n"
 msgstr "Parametri za spoljasnju vezu"
 
-#: src/PrefsUnifiedDlg.cpp:1193
+#: src/PrefsUnifiedDlg.cpp:1202
 msgid "- amuleapi settings changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1202
+#: src/PrefsUnifiedDlg.cpp:1211
 msgid ""
 "Your Auto-update server list is empty.\n"
 "'Auto-update server list at startup' will be disabled."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1213
+#: src/PrefsUnifiedDlg.cpp:1222
 msgid ""
 "You have enabled external connections but have not specified a password.\n"
 "External connections cannot be enabled unless a valid password is specified."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1246
+#: src/PrefsUnifiedDlg.cpp:1255
 #, c-format
 msgid "The amuleapi password could not be saved: %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1276
+#: src/PrefsUnifiedDlg.cpp:1285
 msgid "- Language changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1281
+#: src/PrefsUnifiedDlg.cpp:1290
 msgid "- Temp folder changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1286
+#: src/PrefsUnifiedDlg.cpp:1295
 msgid "- ED2K network enabled.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1319
+#: src/PrefsUnifiedDlg.cpp:1328
 msgid "The shared-file exclusion pattern is not a valid regular expression. The filter has been left disabled."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1321 src/PrefsUnifiedDlg.cpp:1921
+#: src/PrefsUnifiedDlg.cpp:1330 src/PrefsUnifiedDlg.cpp:1930
 msgid "Invalid regular expression"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1398
+#: src/PrefsUnifiedDlg.cpp:1407
 msgid ""
 "Both eD2k and Kad network are disabled.\n"
 "You won't be able to connect until you enable at least one of them."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1403
+#: src/PrefsUnifiedDlg.cpp:1412
 msgid ""
 "Kad will not start if your UDP port is disabled.\n"
 "Enable UDP port or disable Kad."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1459
+#: src/PrefsUnifiedDlg.cpp:1468
 msgid ""
 "\n"
 "You MUST restart aMule now.\n"
 "If you do not restart now, don't complain if anything bad happens.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1524
+#: src/PrefsUnifiedDlg.cpp:1533
 msgid "Could not register aMule for autostart at login. The autostart store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1526
+#: src/PrefsUnifiedDlg.cpp:1535
 msgid "Could not remove the autostart-at-login entry."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1527
+#: src/PrefsUnifiedDlg.cpp:1536
 #, fuzzy
 msgid "Autostart"
 msgstr "Automatski"
 
-#: src/PrefsUnifiedDlg.cpp:1542
+#: src/PrefsUnifiedDlg.cpp:1551
 msgid "Register file type"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1542
+#: src/PrefsUnifiedDlg.cpp:1551
 msgid "Register URL handler"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1550
+#: src/PrefsUnifiedDlg.cpp:1559
 #, c-format
 msgid "aMule only handles eD2k-compatible magnets. If you replace the current magnet handler (%s), BitTorrent magnet links will stop working - aMule cannot download BitTorrent content. Continue?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1555
+#: src/PrefsUnifiedDlg.cpp:1564
 #, c-format
 msgid "Another application currently opens .emulecollection files (%s). Replace it with aMule?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1560
+#: src/PrefsUnifiedDlg.cpp:1569
 #, c-format
 msgid "Another application is currently the default handler for these links (%s). Replace it with aMule?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1585
+#: src/PrefsUnifiedDlg.cpp:1594
 msgid "Could not register aMule for .emulecollection files. The registration store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1587
+#: src/PrefsUnifiedDlg.cpp:1596
 #, fuzzy
 msgid "Could not remove the file type registration."
 msgstr "Vec pokusavate downloadovati fajl %s"
 
-#: src/PrefsUnifiedDlg.cpp:1589
+#: src/PrefsUnifiedDlg.cpp:1598
 msgid "Could not register aMule as the URL handler. The registration store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1591
+#: src/PrefsUnifiedDlg.cpp:1600
 msgid "Could not remove the URL handler registration."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1661 src/PrefsUnifiedDlg.cpp:1688
+#: src/PrefsUnifiedDlg.cpp:1670 src/PrefsUnifiedDlg.cpp:1697
 #, fuzzy
 msgid "The web server and aMule API require external connections to be enabled."
 msgstr "Nova vanjska veza prihvacena\n"
 
-#: src/PrefsUnifiedDlg.cpp:1671
+#: src/PrefsUnifiedDlg.cpp:1680
 msgid "The aMule web server is deprecated. Consider running the aMule API instead."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1735
+#: src/PrefsUnifiedDlg.cpp:1744
 msgid ""
 "Your Auto-update servers list is in blank.\n"
 "Please fill in at least one URL to point to a valid server.met file.\n"
 "Click on the button \"List\" by this checkbox to enter an URL."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1876
+#: src/PrefsUnifiedDlg.cpp:1885
 msgid "Temporary files"
 msgstr "Privremene datoteke"
 
-#: src/PrefsUnifiedDlg.cpp:1881
+#: src/PrefsUnifiedDlg.cpp:1890
 msgid "Incoming files"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1886
+#: src/PrefsUnifiedDlg.cpp:1895
 msgid "Online Signatures"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1899
+#: src/PrefsUnifiedDlg.cpp:1908
 #, c-format
 msgid "Choose a folder for %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1923
+#: src/PrefsUnifiedDlg.cpp:1932
 #, fuzzy, c-format
 msgid "Would exclude %u of %u shared file"
 msgid_plural "Would exclude %u of %u shared files"
@@ -5939,41 +5939,41 @@ msgstr[0] "Pronadjeno %i poznatih dijeljenih fajlova"
 msgstr[1] "Pronadjeno %i poznatih dijeljenih fajlova"
 msgstr[2] ""
 
-#: src/PrefsUnifiedDlg.cpp:1940
+#: src/PrefsUnifiedDlg.cpp:1949
 msgid "Browse for videoplayer"
 msgstr "Potrazi videoplejer"
 
-#: src/PrefsUnifiedDlg.cpp:1944
+#: src/PrefsUnifiedDlg.cpp:1953
 msgid "Select browser"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1948
+#: src/PrefsUnifiedDlg.cpp:1957
 msgid "Select ffprobe binary"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1954
+#: src/PrefsUnifiedDlg.cpp:1963
 #, c-format
 msgid "Executable%s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1988
+#: src/PrefsUnifiedDlg.cpp:1997
 msgid "ffprobe not found on PATH or in the standard install locations. Install ffmpeg (which ships ffprobe) or use Browse to pick a binary manually."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2000
+#: src/PrefsUnifiedDlg.cpp:2009
 msgid "Reset the settings on this page to their default values?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2001
+#: src/PrefsUnifiedDlg.cpp:2010
 #, fuzzy
 msgid "Reset to defaults"
 msgstr "Standard sistema"
 
-#: src/PrefsUnifiedDlg.cpp:2028
+#: src/PrefsUnifiedDlg.cpp:2037
 msgid "Edit server list"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2029
+#: src/PrefsUnifiedDlg.cpp:2038
 msgid ""
 "Add here URL's to download server.met files.\n"
 "Only one url on each line."
@@ -5981,41 +5981,41 @@ msgstr ""
 "Dodaj ovdje URLs da dobijes server.met fajlove. \n"
 "Samo jedna URL po liniji."
 
-#: src/PrefsUnifiedDlg.cpp:2084
+#: src/PrefsUnifiedDlg.cpp:2093
 msgid "IP2Country update failed"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2229 src/PrefsUnifiedDlg.cpp:2260
+#: src/PrefsUnifiedDlg.cpp:2238 src/PrefsUnifiedDlg.cpp:2269
 msgid "Data by MaxMind GeoLite2"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2231 src/PrefsUnifiedDlg.cpp:2262
+#: src/PrefsUnifiedDlg.cpp:2240 src/PrefsUnifiedDlg.cpp:2271
 msgid "Custom source"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2233 src/PrefsUnifiedDlg.cpp:2264
+#: src/PrefsUnifiedDlg.cpp:2242 src/PrefsUnifiedDlg.cpp:2273
 msgid "Data by DB-IP.com"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2284
+#: src/PrefsUnifiedDlg.cpp:2293
 #, c-format
 msgid "Status: Loaded%s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2286
+#: src/PrefsUnifiedDlg.cpp:2295
 #, c-format
 msgid "Status: Loaded%s - %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2290
+#: src/PrefsUnifiedDlg.cpp:2299
 msgid "Status: Failed to load - click 'Update now' to refresh."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2292
+#: src/PrefsUnifiedDlg.cpp:2301
 msgid "Status: Not found - click 'Update now' to download."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2350 src/PrefsUnifiedDlg.cpp:2374
+#: src/PrefsUnifiedDlg.cpp:2359 src/PrefsUnifiedDlg.cpp:2383
 #, fuzzy, c-format
 msgid "Update delay: %d second"
 msgid_plural "Update delay: %d seconds"
@@ -6023,7 +6023,7 @@ msgstr[0] "Obnovi kasnjenje : 5 sekundi"
 msgstr[1] "Obnovi kasnjenje : 5 sekundi"
 msgstr[2] ""
 
-#: src/PrefsUnifiedDlg.cpp:2358
+#: src/PrefsUnifiedDlg.cpp:2367
 #, fuzzy, c-format
 msgid "Time for average graph: %d minute"
 msgid_plural "Time for average graph: %d minutes"
@@ -6031,12 +6031,12 @@ msgstr[0] "Vrijeme za prosjecni graf: 100 minuta"
 msgstr[1] "Vrijeme za prosjecni graf: 100 minuta"
 msgstr[2] ""
 
-#: src/PrefsUnifiedDlg.cpp:2367
+#: src/PrefsUnifiedDlg.cpp:2376
 #, c-format
 msgid "Connections Graph Scale: %d"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2382
+#: src/PrefsUnifiedDlg.cpp:2391
 #, fuzzy, c-format
 msgid "File Buffer Size: %d byte"
 msgid_plural "File Buffer Size: %d bytes"
@@ -6044,7 +6044,7 @@ msgstr[0] "Velicina fajl buffera %i bytes"
 msgstr[1] "Velicina fajl buffera %i bytes"
 msgstr[2] ""
 
-#: src/PrefsUnifiedDlg.cpp:2392
+#: src/PrefsUnifiedDlg.cpp:2401
 #, fuzzy, c-format
 msgid "Upload Queue Size: %d client"
 msgid_plural "Upload Queue Size: %d clients"
@@ -6052,7 +6052,7 @@ msgstr[0] "Duzina liste cekanja %i klienata"
 msgstr[1] "Duzina liste cekanja %i klienata"
 msgstr[2] ""
 
-#: src/PrefsUnifiedDlg.cpp:2402
+#: src/PrefsUnifiedDlg.cpp:2411
 #, fuzzy, c-format
 msgid "Server connection refresh interval: %d minute"
 msgid_plural "Server connection refresh interval: %d minutes"
@@ -6060,78 +6060,78 @@ msgstr[0] "Interval obnavljanja veze servera %i minuta"
 msgstr[1] "Interval obnavljanja veze servera %i minuta"
 msgstr[2] ""
 
-#: src/PrefsUnifiedDlg.cpp:2407
+#: src/PrefsUnifiedDlg.cpp:2416
 msgid "Server connection refresh interval: Disabled"
 msgstr "Interval obnavljanja veze servera: onemoguceno"
 
-#: src/PrefsUnifiedDlg.cpp:2451
+#: src/PrefsUnifiedDlg.cpp:2460
 #, fuzzy
 msgid "disabled"
 msgstr "onemoguci"
 
-#: src/PrefsUnifiedDlg.cpp:2477
+#: src/PrefsUnifiedDlg.cpp:2486
 #, c-format
 msgid "Execute command on '%s' event"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2484
+#: src/PrefsUnifiedDlg.cpp:2493
 msgid "Enable command execution on core"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2496
+#: src/PrefsUnifiedDlg.cpp:2505
 msgid "Core command:"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2512
+#: src/PrefsUnifiedDlg.cpp:2521
 msgid "Enable command execution on GUI"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2524
+#: src/PrefsUnifiedDlg.cpp:2533
 msgid "GUI command:"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2540
+#: src/PrefsUnifiedDlg.cpp:2549
 msgid "The following variables will be replaced:"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2708
+#: src/PrefsUnifiedDlg.cpp:2717
 msgid ""
 "The following folders look like system or sensitive locations:\n"
 "\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2713
+#: src/PrefsUnifiedDlg.cpp:2722
 msgid "Sharing them recursively will publish every file underneath on the eD2k/Kad networks. Do you really want to do this?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2716
+#: src/PrefsUnifiedDlg.cpp:2725
 msgid "Confirm shared folders"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2744
+#: src/PrefsUnifiedDlg.cpp:2753
 #, fuzzy
 msgid "Reloading shared files..."
 msgstr "Pronadjeno %i poznatih dijeljenih fajlova"
 
-#: src/PrefsUnifiedDlg.cpp:2745
+#: src/PrefsUnifiedDlg.cpp:2754
 msgid "Scanning for subdirectories..."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2746
+#: src/PrefsUnifiedDlg.cpp:2755
 msgid "Updating shared folders"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2773
+#: src/PrefsUnifiedDlg.cpp:2782
 #, c-format
 msgid "Scanned %u directories..."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2823
+#: src/PrefsUnifiedDlg.cpp:2832
 #, c-format
 msgid "Reloading shared files: %u files scanned"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2873
+#: src/PrefsUnifiedDlg.cpp:2882
 #, fuzzy
 msgid "Shared folder"
 msgstr "Dijeljeni fajlovi"
@@ -7798,12 +7798,12 @@ msgstr "Odstrani kategoriju"
 msgid "Hashset requested for unknown file: %s"
 msgstr ""
 
-#: src/UploadQueue.cpp:618
+#: src/UploadQueue.cpp:627
 #, c-format
 msgid "Resuming uploads of file: %s"
 msgstr ""
 
-#: src/UploadQueue.cpp:634
+#: src/UploadQueue.cpp:643
 #, c-format
 msgid "Suspending upload of file: %s"
 msgstr ""

--- a/po/hr.po
+++ b/po/hr.po
@@ -9,8 +9,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-28 12:12+0200\n"
-"PO-Revision-Date: 2026-07-27 10:24+0000\n"
+"POT-Creation-Date: 2026-07-28 08:06+0200\n"
+"PO-Revision-Date: 2026-07-27 11:39+0000\n"
 "Last-Translator: Sebastiano Pistore <sebastiano.pistore.info@aol.com>\n"
 "Language-Team: https://github.com/amule-org/amule <forum@aMule.org>\n"
 "Language: hr\n"
@@ -138,7 +138,7 @@ msgstr ""
 msgid "Not now"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:422 src/amuleDlg.cpp:665
+#: src/AppImageIntegration.cpp:422 src/amuleDlg.cpp:600
 msgid "Don't ask again"
 msgstr ""
 
@@ -197,155 +197,155 @@ msgstr "Neuspjelo otvaranje %s (%s)"
 msgid "WARNING: You can't add yourself as a source for an eD2k link while having a lowid."
 msgstr ""
 
-#: src/amule.cpp:301
+#: src/amule.cpp:300
 msgid "Now, exiting main app..."
 msgstr ""
 
-#: src/amule.cpp:331
+#: src/amule.cpp:330
 #, c-format
 msgid "Terminating amuleweb instance with pid '%d' ... "
 msgstr ""
 
-#: src/amule.cpp:335
+#: src/amule.cpp:334
 #, c-format
 msgid "Killing amuleweb instance with pid '%d' ... "
 msgstr ""
 
-#: src/amule.cpp:337 src/amule.cpp:350 src/ClientRef.cpp:180
-#: src/SearchDlg.cpp:1041 src/ServerListCtrl.cpp:98
+#: src/amule.cpp:336 src/amule.cpp:349 src/ClientRef.cpp:180
+#: src/SearchDlg.cpp:880 src/ServerListCtrl.cpp:98
 msgid "Failed"
 msgstr "Neuspjesno"
 
-#: src/amule.cpp:344
+#: src/amule.cpp:343
 #, c-format
 msgid "Terminating amuleapi instance with pid '%d' ... "
 msgstr ""
 
-#: src/amule.cpp:348
+#: src/amule.cpp:347
 #, c-format
 msgid "Killing amuleapi instance with pid '%d' ... "
 msgstr ""
 
-#: src/amule.cpp:356
+#: src/amule.cpp:355
 msgid "aMule OnExit: Terminating core."
 msgstr ""
 
-#: src/amule.cpp:467
+#: src/amule.cpp:466
 msgid "aMule shutdown completed."
 msgstr ""
 
-#: src/amule.cpp:471
+#: src/amule.cpp:470
 msgid "Memory debug results for aMule exit:"
 msgstr ""
 
-#: src/amule.cpp:652
+#: src/amule.cpp:651
 #, c-format
 msgid "Binding aMule's peer-to-peer traffic to interface: %s (HTTP updates use the default route)"
 msgstr ""
 
-#: src/amule.cpp:656
+#: src/amule.cpp:655
 #, c-format
 msgid "Binding all network traffic to interface: %s"
 msgstr ""
 
-#: src/amule.cpp:660
+#: src/amule.cpp:659
 #, c-format
 msgid "WARNING: configured network interface '%s' was not found - traffic is NOT bound to it and may leave via the default route. Check the interface name in Preferences."
 msgstr ""
 
-#: src/amule.cpp:666
+#: src/amule.cpp:665
 #, c-format
 msgid "WARNING: binding to network interface '%s' requires elevated privileges and was NOT applied - traffic may leave via the default route. Grant the capability (e.g. 'sudo setcap cap_net_raw+ep' on the aMule binary) or run with sufficient privileges."
 msgstr ""
 
-#: src/amule.cpp:674
+#: src/amule.cpp:673
 #, c-format
 msgid "WARNING: could not bind to network interface '%s' - traffic may leave via the default route."
 msgstr ""
 
-#: src/amule.cpp:733
+#: src/amule.cpp:732
 msgid "Your locale has been changed to System Default due to a configuration change. Sorry."
 msgstr ""
 
-#: src/amule.cpp:735 src/amule.cpp:1589 src/CatDialog.cpp:128
+#: src/amule.cpp:734 src/amule.cpp:1581 src/CatDialog.cpp:128
 #: src/CatDialog.cpp:136 src/CatDialog.cpp:149 src/ServerList.cpp:366
 #: src/ServerListCtrl.cpp:152
 msgid "Info"
 msgstr "Info"
 
-#: src/amule.cpp:742
+#: src/amule.cpp:741
 #, fuzzy
 msgid ""
 "\n"
 "EC configuration"
 msgstr "Potvrda izlaza"
 
-#: src/amule.cpp:745
+#: src/amule.cpp:744
 #, fuzzy
 msgid "Password set and external connections enabled."
 msgstr "Nova vanjska veza prihvacena\n"
 
-#: src/amule.cpp:755 src/KadDlg.cpp:176 src/KadDlg.cpp:185
-#: src/PrefsUnifiedDlg.cpp:1461 src/SharedFilesCtrl.cpp:476
+#: src/amule.cpp:754 src/KadDlg.cpp:176 src/KadDlg.cpp:185
+#: src/PrefsUnifiedDlg.cpp:1387 src/SharedFilesCtrl.cpp:476
 msgid "WARNING"
 msgstr "UPOZORENJE"
 
-#: src/amule.cpp:992
+#: src/amule.cpp:991
 msgid "Network bootstrap"
 msgstr ""
 
-#: src/amule.cpp:997
+#: src/amule.cpp:996
 msgid ""
 "aMule has detected missing network bootstrap files.\n"
 "Select which ones to download:"
 msgstr ""
 
-#: src/amule.cpp:1006 src/FirstRunWizard.cpp:411
+#: src/amule.cpp:1005 src/FirstRunWizard.cpp:411
 #, fuzzy
 msgid "eD2k server list (server.met)"
 msgstr "%i servera pronadjeno u server.met"
 
-#: src/amule.cpp:1013 src/FirstRunWizard.cpp:416
+#: src/amule.cpp:1012 src/FirstRunWizard.cpp:416
 msgid "Kad bootstrap nodes (nodes.dat)"
 msgstr ""
 
-#: src/amule.cpp:1103
+#: src/amule.cpp:1102
 #, c-format
 msgid "web server running on pid %d"
 msgstr ""
 
-#: src/amule.cpp:1116
+#: src/amule.cpp:1115
 msgid "You requested to run web server on startup, but the amuleweb binary cannot be run. Please install the package containing aMule web server, or build aMule from source with -DBUILD_WEBSERVER=YES and install it."
 msgstr ""
 
-#: src/amule.cpp:1121 src/amule.cpp:1185 src/amule.cpp:1299 src/amule.cpp:1601
+#: src/amule.cpp:1120 src/amule.cpp:1177 src/amule.cpp:1291 src/amule.cpp:1593
 #: src/amule-remote-gui.cpp:603 src/amule-remote-gui.cpp:671
 #: src/amule-remote-gui.cpp:709 src/amule-remote-gui.cpp:1282
 #: src/amule-remote-gui.cpp:1345 src/amule-remote-gui.cpp:1372
-#: src/DownloadQueue.cpp:1481 src/PrefsUnifiedDlg.cpp:1247
+#: src/DownloadQueue.cpp:1481
 msgid "ERROR"
 msgstr "GREŠKA"
 
-#: src/amule.cpp:1174
+#: src/amule.cpp:1166
 #, c-format
 msgid "amuleapi running on pid %d"
 msgstr ""
 
-#: src/amule.cpp:1180
+#: src/amule.cpp:1172
 msgid "You requested to run amuleapi on startup, but the amuleapi binary cannot be run. Please install the package containing aMule's REST API server, or build aMule from source with -DBUILD_AMULEAPI=YES and install it."
 msgstr ""
 
-#: src/amule.cpp:1267
+#: src/amule.cpp:1259
 #, c-format
 msgid "Could not bind ports to the specified address: %s"
 msgstr ""
 
-#: src/amule.cpp:1291
+#: src/amule.cpp:1283
 #, c-format
 msgid "Port %u is not available. You will be LOWID\n"
 msgstr ""
 
-#: src/amule.cpp:1296
+#: src/amule.cpp:1288
 #, c-format
 msgid ""
 "Port %u is not available!\n"
@@ -355,185 +355,185 @@ msgid ""
 "Check your network to make sure the port is open for output and input."
 msgstr ""
 
-#: src/amule.cpp:1393
+#: src/amule.cpp:1385
 msgid "Failed to create OnlineSig File"
 msgstr ""
 
-#: src/amule.cpp:1401
+#: src/amule.cpp:1393
 msgid "Failed to create aMule OnlineSig File"
 msgstr ""
 
-#: src/amule.cpp:1564
+#: src/amule.cpp:1556
 msgid "The selected locale seems not to be installed on your box. (Note: I'll try to set it anyway)"
 msgstr ""
 
-#: src/amule.cpp:1574
+#: src/amule.cpp:1566
 #, c-format
 msgid "This is the first time you run aMule %s"
 msgstr ""
 
-#: src/amule.cpp:1577
+#: src/amule.cpp:1569
 msgid "This version is a testing version, updated daily, and\n"
 msgstr ""
 
-#: src/amule.cpp:1578
+#: src/amule.cpp:1570
 msgid "we give no warranty it won't break anything, burn your house,\n"
 msgstr "ne dajemo nikakvu garanciju da nece nista unistiti, tvoju kucu zapaliti, \n"
 
-#: src/amule.cpp:1579
+#: src/amule.cpp:1571
 msgid "or kill your dog. But it *should* be safe to use anyway.\n"
 msgstr ""
 
-#: src/amule.cpp:1584
+#: src/amule.cpp:1576
 msgid "More information, support and new releases can found at our homepage,\n"
 msgstr ""
 
-#: src/amule.cpp:1585
+#: src/amule.cpp:1577
 msgid "at https://amule-org.github.io, or in our IRC channel #aMule at irc.libera.chat.\n"
 msgstr ""
 
-#: src/amule.cpp:1587
+#: src/amule.cpp:1579
 msgid "Feel free to report any bugs to https://github.com/amule-org/amule/issues"
 msgstr ""
 
-#: src/amule.cpp:1599
+#: src/amule.cpp:1591
 msgid ""
 "The folder for Online Signature files you specified is INVALID!\n"
 " OnlineSignature will be DISABLED until you fix it on preferences."
 msgstr ""
 
-#: src/amule.cpp:1662
+#: src/amule.cpp:1654
 #, fuzzy
 msgid "Server hostname notified"
 msgstr "Ime servera :"
 
-#: src/amule.cpp:2039
+#: src/amule.cpp:2031
 #, c-format
 msgid "Disk space preallocation for file '%s' failed: %s"
 msgstr ""
 
-#: src/amule.cpp:2168
+#: src/amule.cpp:2160
 msgid "ERROR: can't open logfile"
 msgstr ""
 
-#: src/amule.cpp:2172
+#: src/amule.cpp:2164
 msgid "WARNING: logfile is empty. Something is wrong."
 msgstr ""
 
-#: src/amule.cpp:2189
+#: src/amule.cpp:2181
 msgid "Log has been reset"
 msgstr ""
 
-#: src/amule.cpp:2213
+#: src/amule.cpp:2205
 #, c-format
 msgid "ServerMessage: %s"
 msgstr ""
 
-#: src/amule.cpp:2256 src/IP2Country.cpp:220 src/IPFilter.cpp:514
+#: src/amule.cpp:2248 src/IP2Country.cpp:220 src/IPFilter.cpp:514
 #: src/ServerList.cpp:875
 #, c-format
 msgid "Skipped download of %s, because requested file is not newer."
 msgstr ""
 
-#: src/amule.cpp:2259
+#: src/amule.cpp:2251
 msgid "Failed to download the nodes list."
 msgstr ""
 
-#: src/amule.cpp:2322
+#: src/amule.cpp:2314
 msgid "Failed to open the downloaded version check file"
 msgstr ""
 
-#: src/amule.cpp:2325 src/amule.cpp:2344
+#: src/amule.cpp:2317 src/amule.cpp:2336
 msgid "Corrupted version check file"
 msgstr ""
 
-#: src/amule.cpp:2367
+#: src/amule.cpp:2359
 msgid "You are using an outdated version of aMule!"
 msgstr ""
 
-#: src/amule.cpp:2369
+#: src/amule.cpp:2361
 #, c-format
 msgid "Your aMule version is %i.%i.%i and the latest version is %li.%li.%li"
 msgstr ""
 
-#: src/amule.cpp:2373
+#: src/amule.cpp:2365
 msgid "The latest version can always be found at https://github.com/amule-org/amule/releases/latest"
 msgstr ""
 
-#: src/amule.cpp:2376
+#: src/amule.cpp:2368
 #, c-format
 msgid "WARNING: Your aMuled version is outdated: %i.%i.%i < %li.%li.%li"
 msgstr ""
 
-#: src/amule.cpp:2382
+#: src/amule.cpp:2374
 msgid "Your copy of aMule is up to date."
 msgstr ""
 
-#: src/amule.cpp:2389
+#: src/amule.cpp:2381
 msgid "Failed to download the version check file"
 msgstr ""
 
-#: src/amule.cpp:2558 src/amule-remote-gui.cpp:1133
+#: src/amule.cpp:2550 src/amule-remote-gui.cpp:1133
 #, c-format
 msgid "Users: %s | Files: %s"
 msgstr ""
 
-#: src/amule.cpp:2559 src/amule-remote-gui.cpp:1134
+#: src/amule.cpp:2551 src/amule-remote-gui.cpp:1134
 #, c-format
 msgid "Users: E: %s K: %s | Files: E: %s K: %s"
 msgstr ""
 
-#: src/amule.cpp:2573 src/amule-remote-gui.cpp:1147
+#: src/amule.cpp:2565 src/amule-remote-gui.cpp:1147
 msgid "No networks selected"
 msgstr ""
 
-#: src/amule.cpp:2641 src/TextClient.cpp:903
+#: src/amule.cpp:2633 src/TextClient.cpp:903
 msgid "with LowID"
 msgstr ""
 
-#: src/amule.cpp:2641 src/TextClient.cpp:904
+#: src/amule.cpp:2633 src/TextClient.cpp:904
 msgid "with HighID"
 msgstr ""
 
-#: src/amule.cpp:2643
+#: src/amule.cpp:2635
 #, c-format
 msgid "Connected to %s %s"
 msgstr ""
 
-#: src/amule.cpp:2648
+#: src/amule.cpp:2640
 #, c-format
 msgid "Connecting to %s"
 msgstr ""
 
-#: src/amule.cpp:2650
+#: src/amule.cpp:2642
 msgid "Disconnected from eD2k"
 msgstr ""
 
-#: src/amule.cpp:2659
+#: src/amule.cpp:2651
 msgid "Kad started."
 msgstr ""
 
-#: src/amule.cpp:2661
+#: src/amule.cpp:2653
 msgid "Kad stopped."
 msgstr ""
 
-#: src/amule.cpp:2669
+#: src/amule.cpp:2661
 msgid "Connected to Kad (ok)"
 msgstr ""
 
-#: src/amule.cpp:2671
+#: src/amule.cpp:2663
 msgid "Connected to Kad (firewalled)"
 msgstr ""
 
-#: src/amule.cpp:2675
+#: src/amule.cpp:2667
 msgid "Disconnected from Kad"
 msgstr ""
 
-#: src/amule.cpp:2707
+#: src/amule.cpp:2699
 msgid "Kad network cannot be used if UDP port is disabled on preferences, not starting."
 msgstr ""
 
-#: src/amule.cpp:2711
+#: src/amule.cpp:2703
 msgid "Kad network disabled on preferences, not connecting."
 msgstr ""
 
@@ -558,68 +558,30 @@ msgstr ""
 msgid "ERROR: %s"
 msgstr "POGREŠKA: %s"
 
-#: src/amuleDlg.cpp:250
+#: src/amuleDlg.cpp:236
 #, c-format
 msgid "This is aMule %s based on eMule."
 msgstr ""
 
-#: src/amuleDlg.cpp:251
+#: src/amuleDlg.cpp:237
 #, c-format
 msgid "Running on %s"
 msgstr ""
 
-#: src/amuleDlg.cpp:253
+#: src/amuleDlg.cpp:239
 msgid "Visit https://github.com/amule-org/amule/releases/latest to check if a new version is available."
 msgstr ""
 
-#: src/amuleDlg.cpp:282
+#: src/amuleDlg.cpp:268
 msgid "FATAL ERROR: Failed to create Timer"
 msgstr ""
 
-#: src/amuleDlg.cpp:361 src/amuleDlg.cpp:1810 src/amuleDlg.cpp:2056
-#: src/muuli_wdr.cpp:1492 src/muuli_wdr.cpp:3439
-msgid "Networks"
-msgstr ""
-
-#: src/amuleDlg.cpp:362 src/amuleDlg.cpp:1816 src/muuli_wdr.cpp:3440
-msgid "Searches"
-msgstr "Pretrage"
-
-#: src/amuleDlg.cpp:363 src/amuleDlg.cpp:1822 src/DownloadListCtrl.cpp:740
-#: src/muuli_wdr.cpp:392 src/muuli_wdr.cpp:1585 src/muuli_wdr.cpp:3441
-#: src/Statistics.cpp:829
-msgid "Downloads"
-msgstr "Downloads"
-
-#: src/amuleDlg.cpp:364 src/amuleDlg.cpp:1828 src/muuli_wdr.cpp:3315
-msgid "Shared files"
-msgstr ""
-
-#: src/amuleDlg.cpp:365 src/amuleDlg.cpp:1834 src/muuli_wdr.cpp:2947
-#: src/muuli_wdr.cpp:3397 src/muuli_wdr.cpp:3444
-msgid "Messages"
-msgstr "Poruke"
-
-#: src/amuleDlg.cpp:366 src/amuleDlg.cpp:1840 src/muuli_wdr.cpp:3445
-#: src/PrefsUnifiedDlg.cpp:314 src/Statistics.cpp:779 src/Statistics.cpp:1235
-msgid "Statistics"
-msgstr "Statistike"
-
-#: src/amuleDlg.cpp:368 src/amuleDlg.cpp:1847 src/muuli_wdr.cpp:3447
-#: src/PrefsUnifiedDlg.cpp:330 src/utils/wxCas/src/wxcasprefs.cpp:39
-msgid "Preferences"
-msgstr "Opcije"
-
-#: src/amuleDlg.cpp:371
-msgid "Navigate"
-msgstr ""
-
-#: src/amuleDlg.cpp:657
+#: src/amuleDlg.cpp:592
 #, fuzzy
 msgid "New version available"
 msgstr "Nije dostupno"
 
-#: src/amuleDlg.cpp:661
+#: src/amuleDlg.cpp:596
 #, c-format
 msgid ""
 "A new version of aMule (%s) is available.\n"
@@ -629,190 +591,223 @@ msgid ""
 "Would you like to open the download page?"
 msgstr ""
 
-#: src/amuleDlg.cpp:743
+#: src/amuleDlg.cpp:678
 msgid "aMule dialog destroyed"
 msgstr ""
 
-#: src/amuleDlg.cpp:766 src/DataToText.cpp:68 src/IPFilter.cpp:547
+#: src/amuleDlg.cpp:701 src/DataToText.cpp:68 src/IPFilter.cpp:547
 msgid "Connecting"
 msgstr "Spajanje"
 
-#: src/amuleDlg.cpp:958
+#: src/amuleDlg.cpp:893
 msgid "eD2k: Connecting"
 msgstr ""
 
-#: src/amuleDlg.cpp:962
+#: src/amuleDlg.cpp:897
 msgid "eD2k: Disconnected"
 msgstr ""
 
-#: src/amuleDlg.cpp:968
+#: src/amuleDlg.cpp:903
 msgid "Kad: Firewalled"
 msgstr ""
 
-#: src/amuleDlg.cpp:972
+#: src/amuleDlg.cpp:907
 #, fuzzy
 msgid "Kad: Connected"
 msgstr "Veza uspostavljena"
 
-#: src/amuleDlg.cpp:977
+#: src/amuleDlg.cpp:912
 #, fuzzy
 msgid "Kad: Connecting"
 msgstr "Spajanje"
 
-#: src/amuleDlg.cpp:981
+#: src/amuleDlg.cpp:916
 msgid "Kad: Off"
 msgstr ""
 
-#: src/amuleDlg.cpp:1029 src/DownloadListCtrl.cpp:505
+#: src/amuleDlg.cpp:964 src/DownloadListCtrl.cpp:505
 #: src/DownloadListCtrl.cpp:749 src/FriendListCtrl.cpp:180
 #: src/muuli_wdr.cpp:731 src/muuli_wdr.cpp:782 src/muuli_wdr.cpp:846
-#: src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2252 src/muuli_wdr.cpp:2337
-#: src/muuli_wdr.cpp:3085 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
+#: src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2224 src/muuli_wdr.cpp:2309
+#: src/muuli_wdr.cpp:3057 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
 #: src/ServerListCtrl.cpp:606 src/TransferWnd.cpp:378
 #: src/utils/wxCas/src/wxcasprefs.cpp:235
 msgid "Cancel"
 msgstr "Otkaz"
 
-#: src/amuleDlg.cpp:1030
+#: src/amuleDlg.cpp:965
 #, fuzzy
 msgid "Stop the current connection attempts"
 msgstr "Zaustavlja trenutne pokusaje uspostavljanja veze"
 
-#: src/amuleDlg.cpp:1035 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976
-#: src/muuli_wdr.cpp:2475
+#: src/amuleDlg.cpp:970 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976
+#: src/muuli_wdr.cpp:2447
 msgid "Disconnect"
 msgstr "Prekinuti vezu"
 
-#: src/amuleDlg.cpp:1036
+#: src/amuleDlg.cpp:971
 #, fuzzy
 msgid "Disconnect from the currently connected networks"
 msgstr "Prekinuti vezu sa sadasnjim serverom"
 
-#: src/amuleDlg.cpp:1041 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979
-#: src/muuli_wdr.cpp:2630 src/muuli_wdr.cpp:3082 src/muuli_wdr.cpp:3437
+#: src/amuleDlg.cpp:976 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979
+#: src/muuli_wdr.cpp:2602 src/muuli_wdr.cpp:3054 src/muuli_wdr.cpp:3409
 msgid "Connect"
 msgstr "Uspostavi vezu"
 
-#: src/amuleDlg.cpp:1042
+#: src/amuleDlg.cpp:977
 msgid "Connect to the currently enabled networks"
 msgstr ""
 
-#: src/amuleDlg.cpp:1154
+#: src/amuleDlg.cpp:1089
 #, fuzzy, c-format
 msgid "Up: %.1f%s (%.1f) | Down: %.1f%s (%.1f)"
 msgstr "Gore: %.1f(%.1f) | Dole: %.1f(%.1f)"
 
-#: src/amuleDlg.cpp:1156 src/amuleDlg.cpp:1158 src/amuleDlg.cpp:1162
-#: src/amuleDlg.cpp:1164 src/amuleDlg.cpp:1175 src/amuleDlg.cpp:1177
+#: src/amuleDlg.cpp:1091 src/amuleDlg.cpp:1093 src/amuleDlg.cpp:1097
+#: src/amuleDlg.cpp:1099 src/amuleDlg.cpp:1110 src/amuleDlg.cpp:1112
 #: src/MuleTrayIcon.cpp:796 src/MuleTrayIcon.cpp:799
 #, fuzzy
 msgid " MB/s"
 msgstr "MB/s"
 
-#: src/amuleDlg.cpp:1156 src/amuleDlg.cpp:1158 src/amuleDlg.cpp:1162
-#: src/amuleDlg.cpp:1164 src/amuleDlg.cpp:1175 src/amuleDlg.cpp:1177
+#: src/amuleDlg.cpp:1091 src/amuleDlg.cpp:1093 src/amuleDlg.cpp:1097
+#: src/amuleDlg.cpp:1099 src/amuleDlg.cpp:1110 src/amuleDlg.cpp:1112
 #: src/MuleTrayIcon.cpp:796 src/MuleTrayIcon.cpp:799
 #: src/utils/wxCas/src/wxcasframe.cpp:1041
 msgid " kB/s"
 msgstr " kB/s"
 
-#: src/amuleDlg.cpp:1161
+#: src/amuleDlg.cpp:1096
 #, fuzzy, c-format
 msgid "Up: %.1f%s | Down: %.1f%s"
 msgstr "Gore: %.1f | Dole: %.1f"
 
-#: src/amuleDlg.cpp:1193
+#: src/amuleDlg.cpp:1128
 #, c-format
 msgid "aMule (%s | Connected)"
 msgstr ""
 
-#: src/amuleDlg.cpp:1195
+#: src/amuleDlg.cpp:1130
 #, c-format
 msgid "aMule (%s | Disconnected)"
 msgstr ""
 
-#: src/amuleDlg.cpp:1248
+#: src/amuleDlg.cpp:1183
 #, fuzzy, c-format
 msgid "Do you really want to exit %s?"
 msgstr "Da li zaista zelite iskljuciti aMule?"
 
-#: src/amuleDlg.cpp:1250
+#: src/amuleDlg.cpp:1185
 msgid "Exit confirmation"
 msgstr "Potvrda izlaza"
 
-#: src/amuleDlg.cpp:1613
+#: src/amuleDlg.cpp:1548
 msgid "Launch Command: "
 msgstr ""
 
-#: src/amuleDlg.cpp:1632 src/muuli_wdr.cpp:1972 src/Preferences.cpp:979
+#: src/amuleDlg.cpp:1567 src/muuli_wdr.cpp:1971 src/Preferences.cpp:951
 msgid "- default -"
 msgstr ""
 
-#: src/amuleDlg.cpp:1660
+#: src/amuleDlg.cpp:1595
 #, c-format
 msgid "Skin directory '%s' does not exist"
 msgstr ""
 
-#: src/amuleDlg.cpp:1663
+#: src/amuleDlg.cpp:1598
 #, c-format
 msgid "WARNING: Unable to open skin file '%s' for read"
 msgstr ""
 
-#: src/amuleDlg.cpp:1814 src/muuli_wdr.cpp:3439
+#: src/amuleDlg.cpp:1722 src/amuleDlg.cpp:1968 src/muuli_wdr.cpp:1485
+#: src/muuli_wdr.cpp:3411
+msgid "Networks"
+msgstr ""
+
+#: src/amuleDlg.cpp:1726 src/muuli_wdr.cpp:3411
 msgid "Networks Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1820 src/muuli_wdr.cpp:3440
+#: src/amuleDlg.cpp:1728 src/muuli_wdr.cpp:3412
+msgid "Searches"
+msgstr "Pretrage"
+
+#: src/amuleDlg.cpp:1732 src/muuli_wdr.cpp:3412
 msgid "Searches Window"
 msgstr "Prozor pretraga"
 
-#: src/amuleDlg.cpp:1826 src/muuli_wdr.cpp:3441
+#: src/amuleDlg.cpp:1734 src/DownloadListCtrl.cpp:740 src/muuli_wdr.cpp:392
+#: src/muuli_wdr.cpp:1578 src/muuli_wdr.cpp:3413 src/Statistics.cpp:829
+msgid "Downloads"
+msgstr "Downloads"
+
+#: src/amuleDlg.cpp:1738 src/muuli_wdr.cpp:3413
 #, fuzzy
 msgid "Downloads Window"
 msgstr "Downloading"
 
-#: src/amuleDlg.cpp:1832 src/muuli_wdr.cpp:3443
+#: src/amuleDlg.cpp:1740 src/muuli_wdr.cpp:3287
+msgid "Shared files"
+msgstr ""
+
+#: src/amuleDlg.cpp:1744 src/muuli_wdr.cpp:3415
 msgid "Shared Files Window"
 msgstr "Prozor dijeljenih fajlova"
 
-#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3444
+#: src/amuleDlg.cpp:1746 src/muuli_wdr.cpp:2919 src/muuli_wdr.cpp:3369
+#: src/muuli_wdr.cpp:3416
+msgid "Messages"
+msgstr "Poruke"
+
+#: src/amuleDlg.cpp:1750 src/muuli_wdr.cpp:3416
 msgid "Messages Window"
 msgstr "Prozor poruka"
 
-#: src/amuleDlg.cpp:1844 src/muuli_wdr.cpp:3445
+#: src/amuleDlg.cpp:1752 src/muuli_wdr.cpp:3417 src/PrefsUnifiedDlg.cpp:312
+#: src/Statistics.cpp:779 src/Statistics.cpp:1235
+msgid "Statistics"
+msgstr "Statistike"
+
+#: src/amuleDlg.cpp:1756 src/muuli_wdr.cpp:3417
 msgid "Statistics Graph Window"
 msgstr "Prozor grafova statistike"
 
-#: src/amuleDlg.cpp:1851 src/muuli_wdr.cpp:3447
+#: src/amuleDlg.cpp:1759 src/muuli_wdr.cpp:3419 src/PrefsUnifiedDlg.cpp:328
+#: src/utils/wxCas/src/wxcasprefs.cpp:39
+msgid "Preferences"
+msgstr "Opcije"
+
+#: src/amuleDlg.cpp:1763 src/muuli_wdr.cpp:3419
 msgid "Preferences Settings Window"
 msgstr "Prozor postavke opcija"
 
-#: src/amuleDlg.cpp:1854 src/muuli_wdr.cpp:3448
+#: src/amuleDlg.cpp:1766 src/muuli_wdr.cpp:3420
 msgid "Import"
 msgstr "Uvezi"
 
-#: src/amuleDlg.cpp:1858 src/muuli_wdr.cpp:3448
+#: src/amuleDlg.cpp:1770 src/muuli_wdr.cpp:3420
 msgid "The partfile importer tool"
 msgstr ""
 
-#: src/amuleDlg.cpp:1861 src/muuli_wdr.cpp:3449
+#: src/amuleDlg.cpp:1773 src/muuli_wdr.cpp:3421
 #: src/utils/aLinkCreator/src/alcframe.cpp:262
 msgid "About"
 msgstr "O autoru:"
 
-#: src/amuleDlg.cpp:1861 src/muuli_wdr.cpp:3449
+#: src/amuleDlg.cpp:1773 src/muuli_wdr.cpp:3421
 msgid "About/Help"
 msgstr ""
 
-#: src/amuleDlg.cpp:2059
+#: src/amuleDlg.cpp:1971
 msgid "eD2k network"
 msgstr ""
 
-#: src/amuleDlg.cpp:2062
+#: src/amuleDlg.cpp:1974
 msgid "Kad network"
 msgstr ""
 
-#: src/amuleDlg.cpp:2062
+#: src/amuleDlg.cpp:1974
 msgid "No network"
 msgstr ""
 
@@ -943,7 +938,7 @@ msgstr "Datoteka nije pronađena."
 msgid "The core rejected these shared folders:%s"
 msgstr ""
 
-#: src/amule-remote-gui.cpp:1336 src/ExternalConn.cpp:2346
+#: src/amule-remote-gui.cpp:1336 src/ExternalConn.cpp:2345
 msgid "Invalid link or already on list."
 msgstr ""
 
@@ -959,7 +954,7 @@ msgstr ""
 #: src/ClientDetailDialog.cpp:123 src/DataToText.cpp:61 src/DataToText.cpp:86
 #: src/DataToText.cpp:101 src/DataToText.cpp:136 src/DataToText.cpp:165
 #: src/DownloadListCtrl.cpp:1172 src/DownloadListCtrl.cpp:1185
-#: src/DownloadListCtrl.cpp:1196 src/ExternalConn.cpp:609
+#: src/DownloadListCtrl.cpp:1196 src/ExternalConn.cpp:608
 #: src/FileDetailDialog.cpp:203 src/FileDetailDialog.cpp:235
 #: src/FileDetailDialog.cpp:242 src/GenericClientListCtrl.cpp:1171
 #: src/GenericClientListCtrl.cpp:1182 src/GenericClientListCtrl.cpp:1192
@@ -1352,19 +1347,19 @@ msgstr "Auto [Vi]"
 msgid "Very low"
 msgstr "Vrlo nizak"
 
-#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:743 src/muuli_wdr.cpp:2303
+#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:743 src/muuli_wdr.cpp:2275
 #: src/ServerListCtrl.cpp:263 src/ServerListCtrl.cpp:456
 #: src/SharedFilesCtrl.cpp:145
 msgid "Low"
 msgstr "Nisko"
 
-#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:744 src/muuli_wdr.cpp:2304
+#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:744 src/muuli_wdr.cpp:2276
 #: src/ServerListCtrl.cpp:266 src/ServerListCtrl.cpp:457
 #: src/SharedFilesCtrl.cpp:146
 msgid "Normal"
 msgstr "Normalan"
 
-#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:745 src/muuli_wdr.cpp:2305
+#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:745 src/muuli_wdr.cpp:2277
 #: src/ServerListCtrl.cpp:269 src/ServerListCtrl.cpp:458
 #: src/SharedFilesCtrl.cpp:147
 msgid "High"
@@ -1456,8 +1451,8 @@ msgstr ""
 msgid "Remote Server"
 msgstr ""
 
-#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3202
-#: src/SearchDlg.cpp:119 src/TextClient.cpp:911
+#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3174
+#: src/SearchDlg.cpp:111 src/TextClient.cpp:911
 msgid "Kad"
 msgstr "Kad"
 
@@ -1527,7 +1522,7 @@ msgstr ""
 msgid "Size"
 msgstr "Velicina"
 
-#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3269
+#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3241
 msgid "Transferred"
 msgstr "Transferirano"
 
@@ -1585,7 +1580,7 @@ msgid ""
 "\n"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:746 src/muuli_wdr.cpp:2306
+#: src/DownloadListCtrl.cpp:746 src/muuli_wdr.cpp:2278
 #: src/SharedFilesCtrl.cpp:150
 msgid "Auto"
 msgstr "Automatski"
@@ -1623,7 +1618,7 @@ msgid "Extended Options"
 msgstr "Prosirene opcije"
 
 #: src/DownloadListCtrl.cpp:770 src/DownloadListCtrl.cpp:822
-#: src/muuli_wdr.cpp:1790
+#: src/muuli_wdr.cpp:1789
 msgid "Preview"
 msgstr "Preuvid"
 
@@ -1798,232 +1793,227 @@ msgstr[2] ""
 msgid "Invalid eD2k link! ERROR: %s"
 msgstr ""
 
-#: src/ExternalConn.cpp:380
+#: src/ExternalConn.cpp:379
 msgid "Client sent packet after authentication failed."
 msgstr ""
 
-#: src/ExternalConn.cpp:397
+#: src/ExternalConn.cpp:396
 msgid "External connection closed."
 msgstr ""
 
-#: src/ExternalConn.cpp:474
+#: src/ExternalConn.cpp:473
 msgid "External connections disabled due to empty password!"
 msgstr ""
 
-#: src/ExternalConn.cpp:495
+#: src/ExternalConn.cpp:494
 msgid "External connections disabled in config file"
 msgstr ""
 
-#: src/ExternalConn.cpp:576
+#: src/ExternalConn.cpp:575
 msgid "New external connection accepted"
 msgstr ""
 
-#: src/ExternalConn.cpp:579
+#: src/ExternalConn.cpp:578
 msgid "ERROR: couldn't accept a new external connection"
 msgstr ""
 
-#: src/ExternalConn.cpp:596
+#: src/ExternalConn.cpp:595
 msgid "External connection refused due to empty password in preferences!"
 msgstr ""
 
-#: src/ExternalConn.cpp:608
+#: src/ExternalConn.cpp:607
 #, c-format
 msgid "Connecting client: %s %s"
 msgstr ""
 
-#: src/ExternalConn.cpp:610
+#: src/ExternalConn.cpp:609
 msgid "Unknown version"
 msgstr ""
 
-#: src/ExternalConn.cpp:623
+#: src/ExternalConn.cpp:622
 msgid "Incorrect EC version ID, there might be binary incompatibility. Use core and remote from same snapshot."
 msgstr ""
 
-#: src/ExternalConn.cpp:631
+#: src/ExternalConn.cpp:630
 msgid "You cannot connect to a release version from an arbitrary development snapshot! *sigh* possible crash prevented"
 msgstr ""
 
-#: src/ExternalConn.cpp:714
+#: src/ExternalConn.cpp:713
 msgid "Invalid protocol version."
 msgstr ""
 
-#: src/ExternalConn.cpp:720
+#: src/ExternalConn.cpp:719
 msgid "Missing protocol version tag."
 msgstr ""
 
-#: src/ExternalConn.cpp:728
+#: src/ExternalConn.cpp:727
 msgid "Authentication failed: invalid hash specified as EC password."
 msgstr ""
 
-#: src/ExternalConn.cpp:776
+#: src/ExternalConn.cpp:775
 msgid "Authentication failed: wrong password."
 msgstr ""
 
-#: src/ExternalConn.cpp:778
+#: src/ExternalConn.cpp:777
 msgid "Authentication failed: missing password."
 msgstr ""
 
-#: src/ExternalConn.cpp:789
+#: src/ExternalConn.cpp:788
 msgid "Invalid request, please authenticate first."
 msgstr ""
 
-#: src/ExternalConn.cpp:794
+#: src/ExternalConn.cpp:793
 msgid "Access granted."
 msgstr ""
 
-#: src/ExternalConn.cpp:802
+#: src/ExternalConn.cpp:801
 #, c-format
 msgid "Sent error message \"%s\" to client."
 msgstr ""
 
-#: src/ExternalConn.cpp:807
+#: src/ExternalConn.cpp:806
 #, c-format
 msgid "Unauthorized access attempt from %s. Connection closed."
 msgstr ""
 
-#: src/ExternalConn.cpp:1420
+#: src/ExternalConn.cpp:1419
 #, c-format
 msgid "Remote PartFile command failed: FileHash not found: %s"
 msgstr ""
 
-#: src/ExternalConn.cpp:1424
+#: src/ExternalConn.cpp:1423
 #, c-format
 msgid "FileHash not found: %s"
 msgstr ""
 
-#: src/ExternalConn.cpp:1471 src/ExternalConn.cpp:1559
-#: src/ExternalConn.cpp:1680
+#: src/ExternalConn.cpp:1470 src/ExternalConn.cpp:1558
+#: src/ExternalConn.cpp:1679
 msgid "OOPS! OpCode processing error!"
 msgstr ""
 
-#: src/ExternalConn.cpp:1502
+#: src/ExternalConn.cpp:1501
 msgid "Server not added"
 msgstr ""
 
-#: src/ExternalConn.cpp:1521
+#: src/ExternalConn.cpp:1520
 #, c-format
 msgid "server not found: %s"
 msgstr ""
 
-#: src/ExternalConn.cpp:1538
+#: src/ExternalConn.cpp:1537
 msgid "need to define server to be removed"
 msgstr ""
 
-#: src/ExternalConn.cpp:1553
+#: src/ExternalConn.cpp:1552
 msgid "eD2k is disabled in preferences."
 msgstr ""
 
-#: src/ExternalConn.cpp:1658
+#: src/ExternalConn.cpp:1657
 #, fuzzy
 msgid "Friend not found."
 msgstr "Datoteka nije pronađena."
 
-#: src/ExternalConn.cpp:1668
+#: src/ExternalConn.cpp:1667
 #, fuzzy
 msgid "Client not found."
 msgstr "Datoteka nije pronađena."
 
-#: src/ExternalConn.cpp:1674
+#: src/ExternalConn.cpp:1673
 msgid "EC_TAG_FRIEND_SHARED requires EC_TAG_FRIEND or EC_TAG_CLIENT."
 msgstr ""
 
-#: src/ExternalConn.cpp:1992
+#: src/ExternalConn.cpp:1991
 msgid "WebSearch from remote interface makes no sense."
 msgstr ""
 
-#: src/ExternalConn.cpp:2027
+#: src/ExternalConn.cpp:2026
 msgid "Search in progress. Refetch results in a moment!"
 msgstr ""
 
-#: src/ExternalConn.cpp:2266
+#: src/ExternalConn.cpp:2265
 msgid "No points for graph."
 msgstr ""
 
-#: src/ExternalConn.cpp:2276
+#: src/ExternalConn.cpp:2275
 msgid "Your client is not configured for this detail level."
 msgstr ""
 
-#: src/ExternalConn.cpp:2303
+#: src/ExternalConn.cpp:2302
 msgid "External Connection: shutdown requested"
 msgstr ""
 
-#: src/ExternalConn.cpp:2315
+#: src/ExternalConn.cpp:2314
 msgid "Already shutting down."
 msgstr ""
 
-#: src/ExternalConn.cpp:2333
+#: src/ExternalConn.cpp:2332
 #, c-format
 msgid "ExternalConn: adding link '%s'."
 msgstr ""
 
-#: src/ExternalConn.cpp:2351
+#: src/ExternalConn.cpp:2350
 #, c-format
 msgid "%d of %d links failed (invalid or already on list)."
 msgstr ""
 
-#: src/ExternalConn.cpp:2374
+#: src/ExternalConn.cpp:2373
 msgid "Version check throttled; try again shortly."
 msgstr ""
 
-#: src/ExternalConn.cpp:2379
+#: src/ExternalConn.cpp:2378
 msgid "Version check is not available on this daemon."
 msgstr ""
 
-#: src/ExternalConn.cpp:2509
+#: src/ExternalConn.cpp:2508
 msgid "File not found."
 msgstr "Datoteka nije pronađena."
 
-#: src/ExternalConn.cpp:2514
+#: src/ExternalConn.cpp:2513
 msgid "Invalid file name."
 msgstr "Nepravilan naziv datoteke."
 
-#: src/ExternalConn.cpp:2522
+#: src/ExternalConn.cpp:2521
 msgid "Unable to rename file."
 msgstr ""
 
-#: src/ExternalConn.cpp:2839
-#, c-format
-msgid "Could not save the amuleapi password: %s"
-msgstr ""
-
-#: src/ExternalConn.cpp:3004 src/ExternalConn.cpp:3032
+#: src/ExternalConn.cpp:2992 src/ExternalConn.cpp:3020
 msgid "Kad is disabled in preferences."
 msgstr ""
 
-#: src/ExternalConn.cpp:3045
+#: src/ExternalConn.cpp:3033
 msgid "Already connected to eD2k."
 msgstr ""
 
-#: src/ExternalConn.cpp:3048
+#: src/ExternalConn.cpp:3036
 msgid "Connecting to eD2k..."
 msgstr ""
 
-#: src/ExternalConn.cpp:3057
+#: src/ExternalConn.cpp:3045
 msgid "Already connected to Kad."
 msgstr ""
 
-#: src/ExternalConn.cpp:3060
+#: src/ExternalConn.cpp:3048
 msgid "Connecting to Kad..."
 msgstr ""
 
-#: src/ExternalConn.cpp:3067
+#: src/ExternalConn.cpp:3055
 msgid "All networks are disabled."
 msgstr ""
 
-#: src/ExternalConn.cpp:3076
+#: src/ExternalConn.cpp:3064
 msgid "Disconnected from eD2k."
 msgstr ""
 
-#: src/ExternalConn.cpp:3081
+#: src/ExternalConn.cpp:3069
 msgid "Disconnected from Kad."
 msgstr ""
 
-#: src/ExternalConn.cpp:3090
+#: src/ExternalConn.cpp:3078
 #, c-format
 msgid "External Connection: invalid opcode received: %#x"
 msgstr ""
 
-#: src/ExternalConn.cpp:3095
+#: src/ExternalConn.cpp:3083
 msgid "Invalid opcode (wrong protocol version?)"
 msgstr ""
 
@@ -2312,19 +2302,19 @@ msgstr ""
 msgid "eD2k"
 msgstr "eD2k"
 
-#: src/FirstRunWizard.cpp:349 src/muuli_wdr.cpp:1495
+#: src/FirstRunWizard.cpp:349 src/muuli_wdr.cpp:1488
 msgid "Kademlia"
 msgstr "Kademlia"
 
-#: src/FirstRunWizard.cpp:359 src/muuli_wdr.cpp:1423
+#: src/FirstRunWizard.cpp:359 src/muuli_wdr.cpp:1416
 msgid "Standard TCP Port "
 msgstr ""
 
-#: src/FirstRunWizard.cpp:365 src/muuli_wdr.cpp:1435
+#: src/FirstRunWizard.cpp:365 src/muuli_wdr.cpp:1428
 msgid "Extended UDP port (Kad / global search) "
 msgstr ""
 
-#: src/FirstRunWizard.cpp:377 src/muuli_wdr.cpp:1442
+#: src/FirstRunWizard.cpp:377 src/muuli_wdr.cpp:1435
 msgid "Enable UPnP for router port forwarding"
 msgstr ""
 
@@ -2351,7 +2341,7 @@ msgstr ""
 msgid "Your peer lists are already in place - nothing to download."
 msgstr "Vec pokusavate downloadovati fajl %s"
 
-#: src/FirstRunWizard.cpp:434 src/muuli_wdr.cpp:1540
+#: src/FirstRunWizard.cpp:434 src/muuli_wdr.cpp:1533
 msgid "Auto-update server list at startup"
 msgstr ""
 
@@ -2397,23 +2387,23 @@ msgid ""
 "want downloads on a different (e.g. larger) disk."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:549 src/FirstRunWizard.cpp:611 src/muuli_wdr.cpp:1702
+#: src/FirstRunWizard.cpp:549 src/FirstRunWizard.cpp:611 src/muuli_wdr.cpp:1701
 msgid "Destination folder for downloads"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:553 src/FirstRunWizard.cpp:569 src/muuli_wdr.cpp:1349
-#: src/muuli_wdr.cpp:1366 src/muuli_wdr.cpp:1677 src/muuli_wdr.cpp:1708
-#: src/muuli_wdr.cpp:1720 src/muuli_wdr.cpp:2790
+#: src/FirstRunWizard.cpp:553 src/FirstRunWizard.cpp:569 src/muuli_wdr.cpp:1342
+#: src/muuli_wdr.cpp:1359 src/muuli_wdr.cpp:1676 src/muuli_wdr.cpp:1707
+#: src/muuli_wdr.cpp:1719 src/muuli_wdr.cpp:2762
 #: src/utils/aLinkCreator/src/alcframe.cpp:135
 #: src/utils/wxCas/src/wxcasprefs.cpp:52 src/utils/wxCas/src/wxcasprefs.cpp:118
 msgid "Browse"
 msgstr "Pretrazi :"
 
-#: src/FirstRunWizard.cpp:559 src/muuli_wdr.cpp:1713
+#: src/FirstRunWizard.cpp:559 src/muuli_wdr.cpp:1712
 msgid "(All files in this folder are shared with other peers)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:565 src/FirstRunWizard.cpp:624 src/muuli_wdr.cpp:1715
+#: src/FirstRunWizard.cpp:565 src/FirstRunWizard.cpp:624 src/muuli_wdr.cpp:1714
 msgid "Folder for temporary download files"
 msgstr ""
 
@@ -2444,7 +2434,7 @@ msgstr ""
 msgid "CRITICAL - no client on StartChatSession"
 msgstr ""
 
-#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2696 src/muuli_wdr.cpp:3373
+#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2668 src/muuli_wdr.cpp:3345
 msgid "Friends"
 msgstr "Prijatelji"
 
@@ -2553,8 +2543,8 @@ msgstr "Nijedno"
 msgid "No"
 msgstr "Ne"
 
-#: src/GenericClientListCtrl.cpp:1216 src/PrefsUnifiedDlg.cpp:2898
-#: src/PrefsUnifiedDlg.cpp:2948 src/ServerListCtrl.cpp:276
+#: src/GenericClientListCtrl.cpp:1216 src/PrefsUnifiedDlg.cpp:2818
+#: src/PrefsUnifiedDlg.cpp:2868 src/ServerListCtrl.cpp:276
 msgid "Yes"
 msgstr "Da"
 
@@ -2724,10 +2714,10 @@ msgstr ""
 msgid "Please fill all fields required"
 msgstr ""
 
-#: src/KadDlg.cpp:192 src/PartFile.cpp:1031 src/PrefsUnifiedDlg.cpp:1134
-#: src/PrefsUnifiedDlg.cpp:1204 src/PrefsUnifiedDlg.cpp:1405
-#: src/PrefsUnifiedDlg.cpp:1663 src/PrefsUnifiedDlg.cpp:1673
-#: src/PrefsUnifiedDlg.cpp:1690 src/PrefsUnifiedDlg.cpp:1738
+#: src/KadDlg.cpp:192 src/PartFile.cpp:1031 src/PrefsUnifiedDlg.cpp:1162
+#: src/PrefsUnifiedDlg.cpp:1331 src/PrefsUnifiedDlg.cpp:1589
+#: src/PrefsUnifiedDlg.cpp:1599 src/PrefsUnifiedDlg.cpp:1616
+#: src/PrefsUnifiedDlg.cpp:1658
 msgid "Message"
 msgstr "Poruka"
 
@@ -2831,7 +2821,7 @@ msgstr ""
 msgid "Uploaded"
 msgstr ""
 
-#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3253
+#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3225
 msgid "Requested"
 msgstr ""
 
@@ -2956,7 +2946,7 @@ msgid "WARNING: "
 msgstr "UPOZORENJE: "
 
 #: src/MuleNotebook.cpp:179 src/muuli_wdr.cpp:817 src/muuli_wdr.cpp:1229
-#: src/muuli_wdr.cpp:3157 src/muuli_wdr.cpp:3413
+#: src/muuli_wdr.cpp:3129 src/muuli_wdr.cpp:3385
 msgid "Close"
 msgstr "Zatvori"
 
@@ -2969,12 +2959,12 @@ msgstr ""
 msgid "Copy"
 msgstr "Kopiraj"
 
-#: src/MuleTextCtrl.cpp:88 src/SearchDlg.cpp:261
+#: src/MuleTextCtrl.cpp:88
 msgid "Paste"
 msgstr "Staviti"
 
 #: src/MuleTextCtrl.cpp:89 src/muuli_wdr.cpp:358 src/muuli_wdr.cpp:757
-#: src/muuli_wdr.cpp:2380 src/muuli_wdr.cpp:2399 src/muuli_wdr.cpp:2421
+#: src/muuli_wdr.cpp:2352 src/muuli_wdr.cpp:2371 src/muuli_wdr.cpp:2393
 #: src/utils/aLinkCreator/src/alcframe.cpp:142
 msgid "Clear"
 msgstr "Ocisti"
@@ -3072,8 +3062,8 @@ msgid "Exit"
 msgstr "Izlaz"
 
 #: src/MuleTrayIcon.cpp:579 src/MuleTrayIcon.cpp:945 src/MuleTrayIcon.cpp:965
-#: src/muuli_wdr.cpp:1398 src/muuli_wdr.cpp:1406 src/muuli_wdr.cpp:1413
-#: src/muuli_wdr.cpp:1836 src/muuli_wdr.cpp:1842 src/OtherFunctions.cpp:91
+#: src/muuli_wdr.cpp:1391 src/muuli_wdr.cpp:1399 src/muuli_wdr.cpp:1406
+#: src/muuli_wdr.cpp:1835 src/muuli_wdr.cpp:1841 src/OtherFunctions.cpp:91
 #: src/StatisticsDlg.cpp:93 src/StatisticsDlg.cpp:95
 msgid "kB/s"
 msgstr "kB/s"
@@ -3243,7 +3233,7 @@ msgstr "Naziv:"
 msgid "Type"
 msgstr "Tip"
 
-#: src/muuli_wdr.cpp:215 src/SearchDlg.cpp:118 src/SearchListCtrl.cpp:853
+#: src/muuli_wdr.cpp:215 src/SearchDlg.cpp:110 src/SearchListCtrl.cpp:853
 msgid "Local"
 msgstr ""
 
@@ -3314,7 +3304,7 @@ msgstr "Bytes"
 msgid "KB"
 msgstr "KB"
 
-#: src/muuli_wdr.cpp:274 src/muuli_wdr.cpp:293 src/muuli_wdr.cpp:1621
+#: src/muuli_wdr.cpp:274 src/muuli_wdr.cpp:293 src/muuli_wdr.cpp:1620
 #: src/OtherFunctions.cpp:64
 msgid "MB"
 msgstr "MB"
@@ -3331,7 +3321,7 @@ msgstr "Maksimalna velicina"
 msgid "Availability"
 msgstr "Dostupnost"
 
-#: src/muuli_wdr.cpp:312 src/muuli_wdr.cpp:398 src/muuli_wdr.cpp:3318
+#: src/muuli_wdr.cpp:312 src/muuli_wdr.cpp:398 src/muuli_wdr.cpp:3290
 msgid "Filter:"
 msgstr "Filtar:"
 
@@ -3363,7 +3353,7 @@ msgstr ""
 msgid "Stop"
 msgstr "Stop"
 
-#: src/muuli_wdr.cpp:348 src/muuli_wdr.cpp:1392 src/SearchListCtrl.cpp:732
+#: src/muuli_wdr.cpp:348 src/muuli_wdr.cpp:1385 src/SearchListCtrl.cpp:732
 msgid "Download"
 msgstr "Download"
 
@@ -3395,12 +3385,12 @@ msgstr "Nadjeni izvori :"
 #: src/muuli_wdr.cpp:1160 src/muuli_wdr.cpp:1167 src/muuli_wdr.cpp:1172
 #: src/muuli_wdr.cpp:1179 src/muuli_wdr.cpp:1184 src/muuli_wdr.cpp:1191
 #: src/muuli_wdr.cpp:1205 src/muuli_wdr.cpp:1212 src/muuli_wdr.cpp:1217
-#: src/muuli_wdr.cpp:1224 src/muuli_wdr.cpp:3255 src/muuli_wdr.cpp:3263
-#: src/muuli_wdr.cpp:3271
+#: src/muuli_wdr.cpp:1224 src/muuli_wdr.cpp:3227 src/muuli_wdr.cpp:3235
+#: src/muuli_wdr.cpp:3243
 msgid "N/A"
 msgstr "N/A"
 
-#: src/muuli_wdr.cpp:508 src/muuli_wdr.cpp:1065 src/PrefsUnifiedDlg.cpp:299
+#: src/muuli_wdr.cpp:508 src/muuli_wdr.cpp:1065 src/PrefsUnifiedDlg.cpp:297
 msgid "General"
 msgstr "Glavni"
 
@@ -3539,7 +3529,7 @@ msgstr ""
 msgid "Album :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:685 src/muuli_wdr.cpp:2275
+#: src/muuli_wdr.cpp:685 src/muuli_wdr.cpp:2247
 msgid "Title :"
 msgstr "Naziv :"
 
@@ -3645,7 +3635,7 @@ msgstr "Ime korisnika :"
 msgid "Userhash :"
 msgstr "Hash korisnika :"
 
-#: src/muuli_wdr.cpp:895 src/muuli_wdr.cpp:1742 src/muuli_wdr.cpp:2470
+#: src/muuli_wdr.cpp:895 src/muuli_wdr.cpp:1741 src/muuli_wdr.cpp:2442
 #: src/utils/aLinkCreator/src/alcframe.cpp:137
 msgid "Add"
 msgstr "Dodaj"
@@ -3654,15 +3644,15 @@ msgstr "Dodaj"
 msgid "Download-Speed"
 msgstr "Brzina downloada"
 
-#: src/muuli_wdr.cpp:954 src/muuli_wdr.cpp:989 src/muuli_wdr.cpp:2574
+#: src/muuli_wdr.cpp:954 src/muuli_wdr.cpp:989 src/muuli_wdr.cpp:2546
 msgid "Current"
 msgstr "Trenutno"
 
-#: src/muuli_wdr.cpp:962 src/muuli_wdr.cpp:997 src/muuli_wdr.cpp:2582
+#: src/muuli_wdr.cpp:962 src/muuli_wdr.cpp:997 src/muuli_wdr.cpp:2554
 msgid "Running average"
 msgstr "Prosjek rada"
 
-#: src/muuli_wdr.cpp:970 src/muuli_wdr.cpp:1005 src/muuli_wdr.cpp:2590
+#: src/muuli_wdr.cpp:970 src/muuli_wdr.cpp:1005 src/muuli_wdr.cpp:2562
 msgid "Session average"
 msgstr "Prosjek misije"
 
@@ -3674,7 +3664,7 @@ msgstr "Brzina uploada"
 msgid "Connections"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1024 src/muuli_wdr.cpp:1861
+#: src/muuli_wdr.cpp:1024 src/muuli_wdr.cpp:1860
 msgid "Active downloads"
 msgstr "Aktivni downloadovi"
 
@@ -3682,7 +3672,7 @@ msgstr "Aktivni downloadovi"
 msgid "Active connections (1:1)"
 msgstr "Aktivne veze (1:1)"
 
-#: src/muuli_wdr.cpp:1040 src/muuli_wdr.cpp:1862
+#: src/muuli_wdr.cpp:1040 src/muuli_wdr.cpp:1861
 msgid "Active uploads"
 msgstr "Aktivni uploadovi"
 
@@ -3799,8 +3789,8 @@ msgstr ""
 msgid "Language: "
 msgstr "Jezik: "
 
-#: src/muuli_wdr.cpp:1257 src/muuli_wdr.cpp:1330 src/muuli_wdr.cpp:1334
-#: src/muuli_wdr.cpp:1337
+#: src/muuli_wdr.cpp:1257 src/muuli_wdr.cpp:1323 src/muuli_wdr.cpp:1327
+#: src/muuli_wdr.cpp:1330
 msgid "The delay before showing tool-tips."
 msgstr ""
 
@@ -3876,954 +3866,932 @@ msgstr ""
 msgid "Enabling this will make aMule to show notifications when finished downloading."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1323
-msgid "Remember search history"
-msgstr ""
-
-#: src/muuli_wdr.cpp:1324
-msgid "Keeps a dropdown list of your past search terms in the Search tab's Name field. This remembers the queries you typed, not the results they returned."
-msgstr ""
-
-#: src/muuli_wdr.cpp:1329
+#: src/muuli_wdr.cpp:1322
 msgid "Tooltip delay time: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1336
+#: src/muuli_wdr.cpp:1329
 msgid "seconds"
 msgstr "sekundi"
 
-#: src/muuli_wdr.cpp:1340
+#: src/muuli_wdr.cpp:1333
 msgid "Browser Selection"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1346
+#: src/muuli_wdr.cpp:1339
 msgid "Enter your browser name here. Leave this field empty to use the system default browser."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1353
+#: src/muuli_wdr.cpp:1346
 msgid "Open in new tab if possible"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1355
+#: src/muuli_wdr.cpp:1348
 msgid "Open the web page in a new tab instead of in a new window when possible"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1359
+#: src/muuli_wdr.cpp:1352
 msgid "Video Player"
 msgstr "Video Plejer"
 
-#: src/muuli_wdr.cpp:1386
+#: src/muuli_wdr.cpp:1379
 msgid "Bandwidth limits"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1400
+#: src/muuli_wdr.cpp:1393
 msgid "Upload"
 msgstr "Upload"
 
-#: src/muuli_wdr.cpp:1408
+#: src/muuli_wdr.cpp:1401
 msgid "Slot Allocation"
 msgstr "Alokacija slota"
 
-#: src/muuli_wdr.cpp:1417
+#: src/muuli_wdr.cpp:1410
 msgid "Ports"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1427
+#: src/muuli_wdr.cpp:1420
 msgid "This is the standard eD2k port and cannot be disabled."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1430
+#: src/muuli_wdr.cpp:1423
 msgid "UDP port for server requests (TCP+3):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1432
+#: src/muuli_wdr.cpp:1425
 msgid "4665"
 msgstr "4665"
 
-#: src/muuli_wdr.cpp:1439
+#: src/muuli_wdr.cpp:1432
 msgid "This UDP port is used for extended eD2k requests and Kad network"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1446
+#: src/muuli_wdr.cpp:1439
 msgid "UPnP TCP Port (Optional):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1456
+#: src/muuli_wdr.cpp:1449
 msgid "Bind local address to IP (empty for any):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1459
+#: src/muuli_wdr.cpp:1452
 msgid "Advanced users only: If you have multiple network interfaces, enter the address of the interface to which aMule should be bound."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1462 src/muuli_wdr.cpp:2055
+#: src/muuli_wdr.cpp:1455 src/muuli_wdr.cpp:2054
 msgid "Bind to network interface (empty for any):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1475
+#: src/muuli_wdr.cpp:1468
 msgid "Advanced users only: pin all of aMule's traffic to one network interface, chosen from the list or typed in by name (e.g. tun0, eth0, en0) or index. Unlike binding to an IP, this stops traffic leaking out via the default route - useful with a VPN. Requires no elevated privileges."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1481
+#: src/muuli_wdr.cpp:1474
 msgid "Max sources per downloading file:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1485
+#: src/muuli_wdr.cpp:1478
 msgid "Max simultaneous connections:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1498 src/muuli_wdr.cpp:3197
+#: src/muuli_wdr.cpp:1491 src/muuli_wdr.cpp:3169
 msgid "ED2K"
 msgstr "ED2K"
 
-#: src/muuli_wdr.cpp:1505
+#: src/muuli_wdr.cpp:1498
 msgid "Autoconnect on startup"
 msgstr "Autospajanje pri startu"
 
-#: src/muuli_wdr.cpp:1508
+#: src/muuli_wdr.cpp:1501
 msgid "Reconnect on loss"
 msgstr "Ponovni spoj kod gubitka veze"
 
-#: src/muuli_wdr.cpp:1530
+#: src/muuli_wdr.cpp:1523
 msgid "Remove dead server after"
 msgstr "Otstrani mrtve servere nakon"
 
-#: src/muuli_wdr.cpp:1531
+#: src/muuli_wdr.cpp:1524
 msgid "Static servers are never removed, even when unreachable."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1535
+#: src/muuli_wdr.cpp:1528
 msgid "retries"
 msgstr "pokusaja"
 
-#: src/muuli_wdr.cpp:1543
+#: src/muuli_wdr.cpp:1536
 msgid "List"
 msgstr "Lista"
 
-#: src/muuli_wdr.cpp:1546
+#: src/muuli_wdr.cpp:1539
 msgid "Update server list when connecting to a server"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1549
+#: src/muuli_wdr.cpp:1542
 msgid "Update server list when a client connects"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1552
+#: src/muuli_wdr.cpp:1545
 msgid "Use priority system"
 msgstr "Koristi sistem prioriteta"
 
-#: src/muuli_wdr.cpp:1556
+#: src/muuli_wdr.cpp:1549
 msgid "Use smart LowID check on connect"
 msgstr "Koristi pametnu LowID provjeru pri vezanju"
 
-#: src/muuli_wdr.cpp:1560
+#: src/muuli_wdr.cpp:1553
 msgid "Safe connect"
 msgstr "Sigurno povezivanje"
 
-#: src/muuli_wdr.cpp:1564
+#: src/muuli_wdr.cpp:1557
 msgid "Autoconnect to servers in static list only"
 msgstr "Autopovezivanje samo sa serverima iz staticne liste"
 
-#: src/muuli_wdr.cpp:1567
+#: src/muuli_wdr.cpp:1560
 msgid "Set manually added servers to High Priority"
 msgstr "Postavi rucno dodate servere na visoki prioritet"
 
-#: src/muuli_wdr.cpp:1588
+#: src/muuli_wdr.cpp:1581
 msgid "Add files to download in pause mode"
 msgstr "Dodaj nove fajlove u stanju pauze"
 
-#: src/muuli_wdr.cpp:1590
+#: src/muuli_wdr.cpp:1583
 msgid "Add files to download with auto priority"
 msgstr "Dodaj nove fajlove sa auto prioritetom"
 
-#: src/muuli_wdr.cpp:1593
+#: src/muuli_wdr.cpp:1586
 msgid "Try to download first and last chunks first"
 msgstr "Pokusaj prvo downloadovati pocetni i zavrsni chunk "
 
-#: src/muuli_wdr.cpp:1597
+#: src/muuli_wdr.cpp:1590
 msgid "Endgame mode: rotate to faster sources for the final blocks"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1600
+#: src/muuli_wdr.cpp:1593
 msgid "Start next paused file when a file completes"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1603
+#: src/muuli_wdr.cpp:1596
 msgid "From the same category"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1605
+#: src/muuli_wdr.cpp:1598
 msgid "In alphabetic order"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1607
+#: src/muuli_wdr.cpp:1600
 msgid "Preallocate disk space for new files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1608
+#: src/muuli_wdr.cpp:1601
 msgid "For new files preallocates disk space for the whole file, thus reduces fragmentation"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1613
+#: src/muuli_wdr.cpp:1606
+msgid "Create new files as sparse files"
+msgstr ""
+
+#: src/muuli_wdr.cpp:1607
+msgid "A sparse file reserves its full size on disk immediately without writing real data to it -- fast, but unsupported or slow on some filesystems, and free-space accounting stays optimistic while the download is in progress. Turn this off to grow the file only as data arrives."
+msgstr ""
+
+#: src/muuli_wdr.cpp:1612
 msgid "Stop downloads when free disk space reaches "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1614
+#: src/muuli_wdr.cpp:1613
 msgid "Select this if you want aMule to check your disk space"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1618
+#: src/muuli_wdr.cpp:1617
 msgid "Enter here the min disk space desired."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1624
+#: src/muuli_wdr.cpp:1623
 msgid "Save 10 sources on rare files (< 20 sources)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1628 src/Statistics.cpp:790
+#: src/muuli_wdr.cpp:1627 src/Statistics.cpp:790
 msgid "Uploads"
 msgstr "Uploadovi"
 
-#: src/muuli_wdr.cpp:1631
+#: src/muuli_wdr.cpp:1630
 msgid "Add new shared files with auto priority"
 msgstr "Dodaj nove dijeljene fajlove sa auto prioritetom"
 
-#: src/muuli_wdr.cpp:1637
+#: src/muuli_wdr.cpp:1636
 msgid "Intelligent Corruption Handling (I.C.H.)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1640
+#: src/muuli_wdr.cpp:1639
 msgid "Enable"
 msgstr "Omogućiti"
 
-#: src/muuli_wdr.cpp:1643
+#: src/muuli_wdr.cpp:1642
 msgid "Advanced I.C.H. trusts every hash (not recommended)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1655 src/PrefsUnifiedDlg.cpp:1990
+#: src/muuli_wdr.cpp:1654 src/PrefsUnifiedDlg.cpp:1910
 msgid "Media metadata extraction"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1659
+#: src/muuli_wdr.cpp:1658
 msgid "Extract length / bitrate / codec from shared audio and video files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1661
+#: src/muuli_wdr.cpp:1660
 msgid "When enabled, aMule runs ffprobe on each shared media file to fill in the Length / Bitrate / Codec columns other clients see when they find the file in a search. Requires ffmpeg (the ffprobe binary) to be installed."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1668
+#: src/muuli_wdr.cpp:1667
 msgid "Path to ffprobe:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1673
+#: src/muuli_wdr.cpp:1672
 msgid "Full path to the ffprobe binary. Leave empty to have aMule auto-detect it on startup."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1681
+#: src/muuli_wdr.cpp:1680
 msgid "Detect"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1682
+#: src/muuli_wdr.cpp:1681
 msgid "Search the standard install locations for an ffprobe binary and fill the path field."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1706
+#: src/muuli_wdr.cpp:1705
 msgid ""
 "Completed downloads are stored here. All files in this folder are automatically shared with other peers.\n"
 "If this folder also holds files you don't want to share, point it at an aMule-only sub-folder."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1709
+#: src/muuli_wdr.cpp:1708
 msgid "Pick the folder where completed downloads will be stored. All files in that folder will be shared with other peers."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1723
+#: src/muuli_wdr.cpp:1722
 msgid "Shared folders"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1729
+#: src/muuli_wdr.cpp:1728
 msgid "(Folders shared by the core. Enter a path to add one.)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1737
+#: src/muuli_wdr.cpp:1736
 msgid "Absolute path of a folder on the core's machine, e.g. /home/user/shared"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1739 src/PrefsUnifiedDlg.cpp:2874
+#: src/muuli_wdr.cpp:1738 src/PrefsUnifiedDlg.cpp:2794
 msgid "Recursive"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1740
+#: src/muuli_wdr.cpp:1739
 msgid "Share every sub-folder underneath this one, including ones created later."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1744 src/utils/aLinkCreator/src/alcframe.cpp:141
+#: src/muuli_wdr.cpp:1743 src/utils/aLinkCreator/src/alcframe.cpp:141
 msgid "Remove"
 msgstr "Ukloni"
 
-#: src/muuli_wdr.cpp:1748
+#: src/muuli_wdr.cpp:1747
 msgid "(Right click on folder icon for recursive share)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1755
+#: src/muuli_wdr.cpp:1754
 msgid "Share hidden files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1761
+#: src/muuli_wdr.cpp:1760
 msgid "Automatically rescan shared folders for changes"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1767
+#: src/muuli_wdr.cpp:1766
 msgid "Follow symbolic links in shared folders"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1773
+#: src/muuli_wdr.cpp:1772
 msgid "Exclude files matching:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1776
+#: src/muuli_wdr.cpp:1775
 msgid "Wildcard patterns separated by '|', e.g. .DS_Store|Thumbs.db|*.tmp. Files whose name matches are not shared. Matching is case-insensitive."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1780
+#: src/muuli_wdr.cpp:1779
 msgid "Patterns are regular expressions"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1781
+#: src/muuli_wdr.cpp:1780
 msgid "When set, the whole field is one regular expression ('|' is alternation). When unset, it is a list of '|'-separated wildcards."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1791
+#: src/muuli_wdr.cpp:1790
 msgid "Show how many shared files the current pattern would exclude."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1812
+#: src/muuli_wdr.cpp:1811
 msgid "Graphs"
 msgstr "Grafovi"
 
-#: src/muuli_wdr.cpp:1815 src/muuli_wdr.cpp:1877
+#: src/muuli_wdr.cpp:1814 src/muuli_wdr.cpp:1876
 msgid "Update delay : 5 secs"
 msgstr "Obnovi kasnjenje : 5 sekundi"
 
-#: src/muuli_wdr.cpp:1819
+#: src/muuli_wdr.cpp:1818
 msgid "Time for average graph: 100 mins"
 msgstr "Vrijeme za prosjecni graf: 100 minuta"
 
-#: src/muuli_wdr.cpp:1823
+#: src/muuli_wdr.cpp:1822
 msgid "Connections Graph Scale: 100 "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1830
+#: src/muuli_wdr.cpp:1829
 msgid "Download graph scale:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1838
+#: src/muuli_wdr.cpp:1837
 msgid "Upload graph scale:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1848
+#: src/muuli_wdr.cpp:1847
 #, fuzzy
 msgid "Colors: "
 msgstr "Boje: "
 
-#: src/muuli_wdr.cpp:1852
+#: src/muuli_wdr.cpp:1851
 msgid "Background"
 msgstr "Pozadina"
 
-#: src/muuli_wdr.cpp:1853
+#: src/muuli_wdr.cpp:1852
 msgid "Grid"
 msgstr "Mreza"
 
-#: src/muuli_wdr.cpp:1854
+#: src/muuli_wdr.cpp:1853
 msgid "Download current"
 msgstr "Trenutni download"
 
-#: src/muuli_wdr.cpp:1855
+#: src/muuli_wdr.cpp:1854
 msgid "Download running average"
 msgstr "Prosjek tekuceg downloada"
 
-#: src/muuli_wdr.cpp:1856
+#: src/muuli_wdr.cpp:1855
 msgid "Download session average"
 msgstr "Prosjek downloada misije"
 
-#: src/muuli_wdr.cpp:1857
+#: src/muuli_wdr.cpp:1856
 msgid "Upload current"
 msgstr "Trenutni upload"
 
-#: src/muuli_wdr.cpp:1858
+#: src/muuli_wdr.cpp:1857
 msgid "Upload running average"
 msgstr "Prosjek tekuceg uploada"
 
-#: src/muuli_wdr.cpp:1859
+#: src/muuli_wdr.cpp:1858
 msgid "Upload session average"
 msgstr "Prosjek uploada misije"
 
-#: src/muuli_wdr.cpp:1860
+#: src/muuli_wdr.cpp:1859
 msgid "Active connections"
 msgstr "Aktivne veze"
 
-#: src/muuli_wdr.cpp:1863
+#: src/muuli_wdr.cpp:1862
 #, fuzzy
 msgid "Systray Icon Speed Bar"
 msgstr "poluga brzine prikazana u sistemskom koritu"
 
-#: src/muuli_wdr.cpp:1864
+#: src/muuli_wdr.cpp:1863
 msgid "Kad-nodes current"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1865
+#: src/muuli_wdr.cpp:1864
 msgid "Kad-nodes running"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1866
+#: src/muuli_wdr.cpp:1865
 msgid "Kad-nodes session"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1870 src/muuli_wdr.cpp:2324
+#: src/muuli_wdr.cpp:1869 src/muuli_wdr.cpp:2296
 msgid "Select"
 msgstr "Izaberi"
 
-#: src/muuli_wdr.cpp:1874
+#: src/muuli_wdr.cpp:1873
 msgid "Tree"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1884
+#: src/muuli_wdr.cpp:1883
 msgid "Number of Client Versions shown (0=unlimited)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1909
+#: src/muuli_wdr.cpp:1908
 msgid "!!! WARNING !!!"
 msgstr "!!! UPOZORENJE !!!"
 
-#: src/muuli_wdr.cpp:1924
+#: src/muuli_wdr.cpp:1923
 msgid "Max new connections / 5 secs"
 msgstr "Maksimalne veze u / 5 sekundi"
 
-#: src/muuli_wdr.cpp:1926
+#: src/muuli_wdr.cpp:1925
 msgid "Concurrent Kad source lookups"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1928
+#: src/muuli_wdr.cpp:1927
 msgid "Kad source re-search interval (minutes)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1930
+#: src/muuli_wdr.cpp:1929
 #, fuzzy
 msgid "Source re-ask interval (minutes)"
 msgstr "Interval obnavljanja veze servera %i minuta"
 
-#: src/muuli_wdr.cpp:1934
+#: src/muuli_wdr.cpp:1933
 msgid "File Buffer Size: 240000 bytes"
 msgstr "Fajl Buffer velicina: 240000 bytes"
 
-#: src/muuli_wdr.cpp:1938
+#: src/muuli_wdr.cpp:1937
 msgid "Use MMAP: memory-mapped file access (lower memory use)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1939
+#: src/muuli_wdr.cpp:1938
 msgid "Maps part files into memory instead of buffering them on the heap, lowering the process memory footprint. May reduce download speed on some disks; best for memory-constrained or upload-heavy hosts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1941
+#: src/muuli_wdr.cpp:1940
 msgid "Upload Queue Size: 5000 clients"
 msgstr "Duzina reda cekanja: 5000 klienta"
 
-#: src/muuli_wdr.cpp:1945
+#: src/muuli_wdr.cpp:1944
 msgid "Server connection refresh interval: Disable"
 msgstr "Interval obnavljanja veze servera: onemoguceno"
 
-#: src/muuli_wdr.cpp:1949
+#: src/muuli_wdr.cpp:1948
 msgid "Disable computer's timed standby mode"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1968
+#: src/muuli_wdr.cpp:1967
 msgid "Skin to use: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1977
+#: src/muuli_wdr.cpp:1976
 msgid "Show \"Fast eD2k Links Handler\" in every window."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1980
+#: src/muuli_wdr.cpp:1979
 msgid "Show extended info on categories tabs"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1983
+#: src/muuli_wdr.cpp:1982
 #, fuzzy
 msgid "Show application version on title"
 msgstr "Pokazi transfer rate u naslovu"
 
-#: src/muuli_wdr.cpp:1985
+#: src/muuli_wdr.cpp:1984
 msgid "Show transfer rates on title"
 msgstr "Pokazi transfer rate u naslovu"
 
-#: src/muuli_wdr.cpp:1987
+#: src/muuli_wdr.cpp:1986
 msgid "Before application name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1989
+#: src/muuli_wdr.cpp:1988
 msgid "After application name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1992
+#: src/muuli_wdr.cpp:1991
 msgid "Show overhead bandwidth"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1996
+#: src/muuli_wdr.cpp:1995
 msgid "Vertical toolbar orientation"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1998
+#: src/muuli_wdr.cpp:1997
 msgid "Live column sorting (auto-reorder rows as their values change)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2005
+#: src/muuli_wdr.cpp:2004
 msgid "Download Queue Files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2008
+#: src/muuli_wdr.cpp:2007
 msgid "Show progress percentage"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2014
+#: src/muuli_wdr.cpp:2013
 msgid "Show progress bar"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2017
+#: src/muuli_wdr.cpp:2016
 msgid "Flat"
 msgstr "Pljosnata"
 
-#: src/muuli_wdr.cpp:2021
+#: src/muuli_wdr.cpp:2020
 msgid "Round"
 msgstr "Obla"
 
-#: src/muuli_wdr.cpp:2039
+#: src/muuli_wdr.cpp:2038
 msgid "External Connection Parameters"
 msgstr "Parametri za spoljasnju vezu"
 
-#: src/muuli_wdr.cpp:2042
+#: src/muuli_wdr.cpp:2041
 msgid "Accept external connections"
 msgstr "Prihvati spoljasnje veze"
 
-#: src/muuli_wdr.cpp:2049 src/muuli_wdr.cpp:2108
+#: src/muuli_wdr.cpp:2048 src/muuli_wdr.cpp:2107
 msgid "IP of the listening interface:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2052
+#: src/muuli_wdr.cpp:2051
 msgid "Enter here a valid ip in the a.b.c.d format for the listening EC interface. An empty field or 0.0.0.0 will mean any interface."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2073 src/muuli_wdr.cpp:2184
+#: src/muuli_wdr.cpp:2072 src/muuli_wdr.cpp:2156
 msgid "TCP port:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2079
+#: src/muuli_wdr.cpp:2078
 msgid "Enable UPnP port forwarding on the EC port"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2083 src/muuli_wdr.cpp:3069
+#: src/muuli_wdr.cpp:2082 src/muuli_wdr.cpp:3041
 #: src/utils/wxCas/src/wxcasprefs.cpp:167
 msgid "Password"
 msgstr "Lozinka"
 
-#: src/muuli_wdr.cpp:2089
+#: src/muuli_wdr.cpp:2088
 msgid "aMule API server parameters"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2092
+#: src/muuli_wdr.cpp:2091
 msgid "Run amuleapi (REST API) on startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2097
+#: src/muuli_wdr.cpp:2096
 msgid "HTTP port:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2111
+#: src/muuli_wdr.cpp:2110
 msgid "The interface amuleapi's HTTP server listens on. 127.0.0.1 (default) accepts only local connections; use 0.0.0.0 or a specific IP to expose it to other hosts (set an admin password below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2116
-msgid "Type a password to set or change it. Stored passwords cannot be shown, so leaving this empty keeps the current one."
-msgstr ""
-
-#: src/muuli_wdr.cpp:2118
+#: src/muuli_wdr.cpp:2113
 #, fuzzy
 msgid "Admin password"
 msgstr "Lozinka"
 
-#: src/muuli_wdr.cpp:2130 src/muuli_wdr.cpp:2147 src/PrefsUnifiedDlg.cpp:1103
-#, fuzzy
-msgid "A password is set."
-msgstr "Lozinka"
-
-#: src/muuli_wdr.cpp:2134
-msgid "Enable guest access"
-msgstr ""
-
-#: src/muuli_wdr.cpp:2135
-msgid "Guest sessions may read status and listings but cannot change anything. Turning this off clears the stored guest password."
-msgstr ""
-
-#: src/muuli_wdr.cpp:2139
-#, fuzzy
-msgid "Guest password"
-msgstr "Sifra za puna prava"
-
-#: src/muuli_wdr.cpp:2154
-msgid "Web server parameters"
-msgstr ""
-
-#: src/muuli_wdr.cpp:2157
-msgid "Run webserver on startup (deprecated)"
-msgstr ""
-
-#: src/muuli_wdr.cpp:2163
-msgid "Web template"
-msgstr ""
-
-#: src/muuli_wdr.cpp:2168
-msgid "Full rights password"
-msgstr "Sifra za puna prava"
-
-#: src/muuli_wdr.cpp:2172
-msgid "Enable Low rights User"
-msgstr "Odobri korisnicima sa manje prava"
-
-#: src/muuli_wdr.cpp:2177
+#: src/muuli_wdr.cpp:2118 src/muuli_wdr.cpp:2149
 msgid "Low rights password"
 msgstr "Sifra za manje prava"
 
-#: src/muuli_wdr.cpp:2191
+#: src/muuli_wdr.cpp:2126
+msgid "Web server parameters"
+msgstr ""
+
+#: src/muuli_wdr.cpp:2129
+msgid "Run webserver on startup (deprecated)"
+msgstr ""
+
+#: src/muuli_wdr.cpp:2135
+msgid "Web template"
+msgstr ""
+
+#: src/muuli_wdr.cpp:2140
+msgid "Full rights password"
+msgstr "Sifra za puna prava"
+
+#: src/muuli_wdr.cpp:2144
+msgid "Enable Low rights User"
+msgstr "Odobri korisnicima sa manje prava"
+
+#: src/muuli_wdr.cpp:2163
 msgid "Enable UPnP port forwarding of the web server port"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2196
+#: src/muuli_wdr.cpp:2168
 msgid "Web server UPnP TCP port (Optional)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2204
+#: src/muuli_wdr.cpp:2176
 msgid "Page Refresh Time (in secs)"
 msgstr "Vrijeme obnove stranice (u sekundama)"
 
-#: src/muuli_wdr.cpp:2211
+#: src/muuli_wdr.cpp:2183
 msgid "Enable Gzip compression"
 msgstr "Odobri Gzip kompresiju"
 
-#: src/muuli_wdr.cpp:2245
+#: src/muuli_wdr.cpp:2217
 #, fuzzy
 msgid "Reset page to defaults"
 msgstr "Standard sistema"
 
-#: src/muuli_wdr.cpp:2246
+#: src/muuli_wdr.cpp:2218
 msgid "Reset the settings on the current page to their default values."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2248 src/muuli_wdr.cpp:2334 src/ServerWnd.cpp:274
+#: src/muuli_wdr.cpp:2220 src/muuli_wdr.cpp:2306 src/ServerWnd.cpp:274
 #: src/ServerWnd.cpp:282
 msgid "OK"
 msgstr "OK"
 
-#: src/muuli_wdr.cpp:2250
+#: src/muuli_wdr.cpp:2222
 msgid "Click here to apply any changes made to the preferences."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2253
+#: src/muuli_wdr.cpp:2225
 msgid "Reset any changes made to the preferences."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2282
+#: src/muuli_wdr.cpp:2254
 msgid "Comment :"
 msgstr "Komentar:"
 
-#: src/muuli_wdr.cpp:2289
+#: src/muuli_wdr.cpp:2261
 msgid "Incoming Dir :"
 msgstr "Prijemni direktorij :"
 
-#: src/muuli_wdr.cpp:2298
+#: src/muuli_wdr.cpp:2270
 msgid "Change priority for new assigned files :"
 msgstr "Promijeni prioritet za nove fajlove :"
 
-#: src/muuli_wdr.cpp:2302
+#: src/muuli_wdr.cpp:2274
 #, fuzzy
 msgid "Don't change"
 msgstr "Ne mijenjaj"
 
-#: src/muuli_wdr.cpp:2314
+#: src/muuli_wdr.cpp:2286
 msgid "Select color for this Category (currently selected) :"
 msgstr "Izaberi boju za ovu kategoriju (trenutno izabrana) :"
 
-#: src/muuli_wdr.cpp:2381 src/muuli_wdr.cpp:2400 src/muuli_wdr.cpp:2422
+#: src/muuli_wdr.cpp:2353 src/muuli_wdr.cpp:2372 src/muuli_wdr.cpp:2394
 msgid "Click this button to reset the log."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2441
+#: src/muuli_wdr.cpp:2413
 msgid "Click on this button to update the servers list from URL ..."
 msgstr "Klikni ovdje da obnovis listu servera sa URL ..."
 
-#: src/muuli_wdr.cpp:2445
+#: src/muuli_wdr.cpp:2417
 msgid "Server list"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2449
+#: src/muuli_wdr.cpp:2421
 msgid "Enter the url to a server.met file here and press the button to the left to update the list of known servers."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2454
+#: src/muuli_wdr.cpp:2426
 msgid "Add server manually: Name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2457
+#: src/muuli_wdr.cpp:2429
 msgid "Enter the name of the new server here"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2459 src/ServerWnd.cpp:206
+#: src/muuli_wdr.cpp:2431 src/ServerWnd.cpp:206
 msgid "IP:Port"
 msgstr "IP:Port"
 
-#: src/muuli_wdr.cpp:2462
+#: src/muuli_wdr.cpp:2434
 msgid "Enter the IP of the server here, using the x.x.x.x format."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2468
+#: src/muuli_wdr.cpp:2440
 msgid "Enter the port of the server here."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2471
+#: src/muuli_wdr.cpp:2443
 msgid "Add manually a server (fill fields to the left before) ..."
 msgstr "Dodaj servera rucno (prije ispuni polja lijevo) ..."
 
-#: src/muuli_wdr.cpp:2500
+#: src/muuli_wdr.cpp:2472
 msgid "aMule Log"
 msgstr "aMule Log"
 
-#: src/muuli_wdr.cpp:2508
+#: src/muuli_wdr.cpp:2480
 msgid "Server Info"
 msgstr "Lista servera"
 
-#: src/muuli_wdr.cpp:2512
+#: src/muuli_wdr.cpp:2484
 msgid "ED2K Info"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2516
+#: src/muuli_wdr.cpp:2488
 msgid "Kad Info"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2544
+#: src/muuli_wdr.cpp:2516
 msgid "Click on this button to update the nodes list from URL ..."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2548
+#: src/muuli_wdr.cpp:2520
 msgid "Nodes (0)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2552
+#: src/muuli_wdr.cpp:2524
 msgid "Enter the url to a nodes.dat file here and press the button to the left to update the list of known nodes."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2555
+#: src/muuli_wdr.cpp:2527
 msgid "Nodes stats"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2597
+#: src/muuli_wdr.cpp:2569
 msgid "Bootstrap"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2600
+#: src/muuli_wdr.cpp:2572
 msgid "New node"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2605
+#: src/muuli_wdr.cpp:2577
 msgid "IP:"
 msgstr "IP:"
 
-#: src/muuli_wdr.cpp:2625
+#: src/muuli_wdr.cpp:2597
 msgid "Port:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2638
+#: src/muuli_wdr.cpp:2610
 msgid "Bootstrap from known clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2640
+#: src/muuli_wdr.cpp:2612
 msgid "Disconnect Kad"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2674
+#: src/muuli_wdr.cpp:2646
 msgid "Use Secure User Identification"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2676
+#: src/muuli_wdr.cpp:2648
 msgid "It is recommended to enable this option. You will not receive credits if SUI is not enabled."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2678
+#: src/muuli_wdr.cpp:2650
 msgid "Protocol Obfuscation"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2681
+#: src/muuli_wdr.cpp:2653
 msgid "Support Protocol Obfuscation"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2683
+#: src/muuli_wdr.cpp:2655
 msgid "This option enabled Protocol Obfuscation, and makes aMule accept obfuscated connections from other clients."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2685
+#: src/muuli_wdr.cpp:2657
 msgid "Use obfuscation for outgoing connections"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2687
+#: src/muuli_wdr.cpp:2659
 msgid "This option makes aMule use Protocol Obfuscation when connecting other clients/servers."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2689
+#: src/muuli_wdr.cpp:2661
 msgid "Accept only obfuscated connections"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2690
+#: src/muuli_wdr.cpp:2662
 msgid "This option makes aMule only accept obfuscated connections. You will have less sources, but all your traffic will be obfuscated"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2695
+#: src/muuli_wdr.cpp:2667
 msgid "Everybody"
 msgstr "Svi"
 
-#: src/muuli_wdr.cpp:2697
+#: src/muuli_wdr.cpp:2669
 msgid "No one"
 msgstr "Nitko"
 
-#: src/muuli_wdr.cpp:2699
+#: src/muuli_wdr.cpp:2671
 msgid "Who can see my shared files:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2700
+#: src/muuli_wdr.cpp:2672
 msgid "Select who can request to view a list of your shared files."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2702
+#: src/muuli_wdr.cpp:2674
 msgid "IP-Filtering"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2709
+#: src/muuli_wdr.cpp:2681
 msgid "Filter clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2711
+#: src/muuli_wdr.cpp:2683
 msgid "Enable filtering of the client IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2713
+#: src/muuli_wdr.cpp:2685
 msgid "Filter servers"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2715
+#: src/muuli_wdr.cpp:2687
 msgid "Enable filtering of the server IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2719
+#: src/muuli_wdr.cpp:2691
 msgid "Reload List"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2720
+#: src/muuli_wdr.cpp:2692
 msgid "Reload the list of IPs to filter from the file ~/.aMule/ipfilter.dat"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2726
+#: src/muuli_wdr.cpp:2698
 msgid "URL:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2730 src/muuli_wdr.cpp:2923
+#: src/muuli_wdr.cpp:2702 src/muuli_wdr.cpp:2895
 msgid "Update now"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2733
+#: src/muuli_wdr.cpp:2705
 msgid "Auto-update ipfilter at startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2737
+#: src/muuli_wdr.cpp:2709
 msgid "Filtering Level:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2743
+#: src/muuli_wdr.cpp:2715
 msgid "Always filter LAN IPs"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2746
+#: src/muuli_wdr.cpp:2718
 msgid "Paranoid handling of non-matching IPs"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2748
+#: src/muuli_wdr.cpp:2720
 msgid "Rejects a packet when its source IP differs from the IP the client claims (an anti-spoofing check). Disable only if it causes connection problems."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2750
+#: src/muuli_wdr.cpp:2722
 msgid "Use system-wide ipfilter.dat if available"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2751
+#: src/muuli_wdr.cpp:2723
 msgid "If there's no local ipfilter.dat found, allow usage of a system-wide ipfilter file."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2768
+#: src/muuli_wdr.cpp:2740
 msgid "Enable Online-Signature"
 msgstr "Omoguci online potpis"
 
-#: src/muuli_wdr.cpp:2770
+#: src/muuli_wdr.cpp:2742
 msgid "Enables the writing of the OS file, which can be used by external apps to create signatures and the like."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2774
+#: src/muuli_wdr.cpp:2746
 msgid "Update Frequency (Secs):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2777
+#: src/muuli_wdr.cpp:2749
 msgid "Change the frequency (in seconds) of Online Signature updates."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2785
+#: src/muuli_wdr.cpp:2757
 msgid "Save online signature file in: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:2791
+#: src/muuli_wdr.cpp:2763
 msgid "Click here to select the directory containing the the Online Signature files."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2824
+#: src/muuli_wdr.cpp:2796
 msgid "Show country flags for clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2825
+#: src/muuli_wdr.cpp:2797
 msgid "Render the country flag column in the transfers, queue and search views. Requires a valid MMDB GeoIP database (see below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2830
+#: src/muuli_wdr.cpp:2802
 #, fuzzy
 msgid "Database"
 msgstr "Podatak rate :"
 
-#: src/muuli_wdr.cpp:2846
+#: src/muuli_wdr.cpp:2818
 #, fuzzy
 msgid "Source:"
 msgstr "Izvori"
 
-#: src/muuli_wdr.cpp:2849
+#: src/muuli_wdr.cpp:2821
 msgid "DB-IP (free, no account)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2850
+#: src/muuli_wdr.cpp:2822
 msgid "MaxMind GeoLite2 (free, account required)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2851
+#: src/muuli_wdr.cpp:2823
 msgid "Custom URL"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2854
+#: src/muuli_wdr.cpp:2826
 msgid "Choose which provider supplies the GeoIP MMDB database. DB-IP is the default - no account required. MaxMind requires a free account + license key. Use Custom URL to point at any other MMDB host (e.g. a local mirror)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2871
+#: src/muuli_wdr.cpp:2843
 msgid ""
 "No configuration required.\n"
 "\n"
@@ -4831,11 +4799,11 @@ msgid ""
 "License: Creative Commons BY 4.0 - https://creativecommons.org/licenses/by/4.0/"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2884
+#: src/muuli_wdr.cpp:2856
 msgid "License key:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2890
+#: src/muuli_wdr.cpp:2862
 msgid ""
 "Sign up for a free MaxMind account, then generate a License Key:\n"
 "https://www.maxmind.com/en/geolite2/signup\n"
@@ -4845,233 +4813,233 @@ msgid ""
 "Requires attribution and account registration; refresh at least every 30 days."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2905
+#: src/muuli_wdr.cpp:2877
 #, fuzzy
 msgid "Download URL:"
 msgstr "Download"
 
-#: src/muuli_wdr.cpp:2911
+#: src/muuli_wdr.cpp:2883
 msgid ""
 "Must point to an .mmdb file or a .gz / .tar.gz containing one.\n"
 "URL may include credentials (https://user:pass@host/...).\n"
 "License and attribution terms are set by the upstream URL - you are responsible."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2924
+#: src/muuli_wdr.cpp:2896
 msgid "Download the GeoIP database from the selected source."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2926
+#: src/muuli_wdr.cpp:2898
 #, fuzzy
 msgid "Auto-update on startup"
 msgstr "Autospajanje pri startu"
 
-#: src/muuli_wdr.cpp:2927
+#: src/muuli_wdr.cpp:2899
 msgid "Re-download the GeoIP database from the selected source every time aMule starts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2950
+#: src/muuli_wdr.cpp:2922
 msgid "Filter incoming messages (except current chat):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2952
+#: src/muuli_wdr.cpp:2924
 msgid "Filter all messages"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2954
+#: src/muuli_wdr.cpp:2926
 msgid "Filter messages from people not on your friend list"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2956
+#: src/muuli_wdr.cpp:2928
 msgid "Filter messages from unknown clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2958
+#: src/muuli_wdr.cpp:2930
 msgid "Filter messages containing (use ',' as separator):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2961 src/muuli_wdr.cpp:2972
+#: src/muuli_wdr.cpp:2933 src/muuli_wdr.cpp:2944
 msgid "add here the words amule should filter and block messages including it"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2963
+#: src/muuli_wdr.cpp:2935
 msgid "Show received messages in the log"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2966
+#: src/muuli_wdr.cpp:2938
 msgid "Comments"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2969
+#: src/muuli_wdr.cpp:2941
 msgid "Filter comments containing (use ',' as separator):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2994
+#: src/muuli_wdr.cpp:2966
 msgid "Enable Proxy"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2995
+#: src/muuli_wdr.cpp:2967
 msgid "Enable/disable proxy support"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2998
+#: src/muuli_wdr.cpp:2970
 msgid "Proxy type:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3009
+#: src/muuli_wdr.cpp:2981
 msgid "Proxy host:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3012
+#: src/muuli_wdr.cpp:2984
 msgid "The proxy host name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3014
+#: src/muuli_wdr.cpp:2986
 msgid "Proxy port:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3017
+#: src/muuli_wdr.cpp:2989
 msgid "The proxy port"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3019
+#: src/muuli_wdr.cpp:2991
 msgid "Enable authentication"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3020
+#: src/muuli_wdr.cpp:2992
 msgid "Enable/disable username/password authentication"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3023
+#: src/muuli_wdr.cpp:2995
 msgid "Username: "
 msgstr "Korisničko ime:"
 
-#: src/muuli_wdr.cpp:3026
+#: src/muuli_wdr.cpp:2998
 msgid "The username to use to connect to the proxy"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3028
+#: src/muuli_wdr.cpp:3000
 msgid "Password:"
 msgstr "Lozinka:"
 
-#: src/muuli_wdr.cpp:3031
+#: src/muuli_wdr.cpp:3003
 msgid "The password to use to connect to the proxy"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3050
+#: src/muuli_wdr.cpp:3022
 msgid "Connect to:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3059
+#: src/muuli_wdr.cpp:3031
 msgid "Login to remote amule"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3064
+#: src/muuli_wdr.cpp:3036
 msgid "User name"
 msgstr "Korisničko ime"
 
-#: src/muuli_wdr.cpp:3075
+#: src/muuli_wdr.cpp:3047
 msgid "Remember those settings"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3078
+#: src/muuli_wdr.cpp:3050
 #, fuzzy
 msgid "Force ZLIB compression"
 msgstr "Steceno kompresijom :"
 
-#: src/muuli_wdr.cpp:3102
+#: src/muuli_wdr.cpp:3074
 msgid "Enable Verbose Debug-Logging."
 msgstr ""
 
-#: src/muuli_wdr.cpp:3104
+#: src/muuli_wdr.cpp:3076
 #, fuzzy
 msgid "Only to Logfile"
 msgstr "&Otvori fajl"
 
-#: src/muuli_wdr.cpp:3106
+#: src/muuli_wdr.cpp:3078
 msgid "Message Categories:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3130 src/PartFileConvertDlg.cpp:160
+#: src/muuli_wdr.cpp:3102 src/PartFileConvertDlg.cpp:160
 msgid "Waiting..."
 msgstr "Ceka ..."
 
-#: src/muuli_wdr.cpp:3150
+#: src/muuli_wdr.cpp:3122
 msgid "Add imports"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3153
+#: src/muuli_wdr.cpp:3125
 msgid "Retry selected"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3155
+#: src/muuli_wdr.cpp:3127
 msgid "Remove selected"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3218
+#: src/muuli_wdr.cpp:3190
 msgid "Event Types"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3237
+#: src/muuli_wdr.cpp:3209
 msgid "Statistics and queued clients for selected file(s) : Session / All time"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3261
+#: src/muuli_wdr.cpp:3233
 #, fuzzy
 msgid "Active Uploads"
 msgstr "Aktivni uploadovi :"
 
-#: src/muuli_wdr.cpp:3275
+#: src/muuli_wdr.cpp:3247
 #, fuzzy
 msgid "Percent of total files"
 msgstr "Ukupni fajlovi"
 
-#: src/muuli_wdr.cpp:3327
+#: src/muuli_wdr.cpp:3299
 #, fuzzy
 msgid "Show Clients for"
 msgstr "Pokazi liste"
 
-#: src/muuli_wdr.cpp:3329
+#: src/muuli_wdr.cpp:3301
 #, fuzzy
 msgid "All files"
 msgstr "Dijeljeni fajlovi"
 
-#: src/muuli_wdr.cpp:3332
+#: src/muuli_wdr.cpp:3304
 #, fuzzy
 msgid "Selected files"
 msgstr "Izaberi filter za gledanje"
 
-#: src/muuli_wdr.cpp:3335
+#: src/muuli_wdr.cpp:3307
 #, fuzzy
 msgid "Active uploads only"
 msgstr "Aktivni uploadovi"
 
-#: src/muuli_wdr.cpp:3342
+#: src/muuli_wdr.cpp:3314
 #, fuzzy
 msgid "Reload:"
 msgstr "Ponovno ucitati"
 
-#: src/muuli_wdr.cpp:3346
+#: src/muuli_wdr.cpp:3318
 msgid "Reload your shared files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3409
+#: src/muuli_wdr.cpp:3381
 msgid "Send"
 msgstr "Posalji"
 
-#: src/muuli_wdr.cpp:3410
+#: src/muuli_wdr.cpp:3382
 msgid "Sends the specified message."
 msgstr ""
 
-#: src/muuli_wdr.cpp:3414
+#: src/muuli_wdr.cpp:3386
 msgid "Close this chat-session."
 msgstr ""
 
-#: src/muuli_wdr.cpp:3437
+#: src/muuli_wdr.cpp:3409
 msgid "Connect to any server and/or Kad"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3443 src/SharedFilesCtrl.cpp:142 src/Statistics.cpp:941
+#: src/muuli_wdr.cpp:3415 src/SharedFilesCtrl.cpp:142 src/Statistics.cpp:941
 msgid "Shared Files"
 msgstr "Dijeljeni fajlovi"
 
@@ -5437,264 +5405,264 @@ msgstr ""
 msgid "ERROR: Failed to open partfile '%s'"
 msgstr ""
 
-#: src/Preferences.cpp:701
+#: src/Preferences.cpp:673
 msgid "System default"
 msgstr "Standard sistema"
 
-#: src/Preferences.cpp:702
+#: src/Preferences.cpp:674
 msgid "Albanian"
 msgstr "Albanski"
 
-#: src/Preferences.cpp:703
+#: src/Preferences.cpp:675
 msgid "Arabic"
 msgstr "Arapski"
 
-#: src/Preferences.cpp:704
+#: src/Preferences.cpp:676
 msgid "Asturian"
 msgstr "Asturleonski"
 
-#: src/Preferences.cpp:705
+#: src/Preferences.cpp:677
 msgid "Basque"
 msgstr "Baskijski"
 
-#: src/Preferences.cpp:706
+#: src/Preferences.cpp:678
 msgid "Bulgarian"
 msgstr "Bugarski"
 
-#: src/Preferences.cpp:707
+#: src/Preferences.cpp:679
 msgid "Catalan"
 msgstr "Katalonski"
 
-#: src/Preferences.cpp:708
+#: src/Preferences.cpp:680
 msgid "Chinese (Simplified)"
 msgstr "Kineski"
 
-#: src/Preferences.cpp:709
+#: src/Preferences.cpp:681
 msgid "Chinese (Traditional)"
 msgstr "Kinesko (tradicionalno)"
 
-#: src/Preferences.cpp:710
+#: src/Preferences.cpp:682
 msgid "Croatian"
 msgstr "Hrvatski"
 
-#: src/Preferences.cpp:711
+#: src/Preferences.cpp:683
 msgid "Czech"
 msgstr "Češki"
 
-#: src/Preferences.cpp:712
+#: src/Preferences.cpp:684
 msgid "Danish"
 msgstr "Danski"
 
-#: src/Preferences.cpp:713
+#: src/Preferences.cpp:685
 msgid "Dutch"
 msgstr "Nizozemski"
 
-#: src/Preferences.cpp:714
+#: src/Preferences.cpp:686
 msgid "English (U.K.)"
 msgstr "Engleski (U.K.)"
 
-#: src/Preferences.cpp:715
+#: src/Preferences.cpp:687
 #, fuzzy
 msgid "English (U.S.)"
 msgstr "Engleski (U.K.)"
 
-#: src/Preferences.cpp:716
+#: src/Preferences.cpp:688
 msgid "Estonian"
 msgstr "Estonski"
 
-#: src/Preferences.cpp:717
+#: src/Preferences.cpp:689
 msgid "Finnish"
 msgstr "Finski"
 
-#: src/Preferences.cpp:718
+#: src/Preferences.cpp:690
 msgid "French"
 msgstr "Francuski"
 
-#: src/Preferences.cpp:719
+#: src/Preferences.cpp:691
 msgid "Galician"
 msgstr "Galješki"
 
-#: src/Preferences.cpp:720
+#: src/Preferences.cpp:692
 msgid "German"
 msgstr "Njemački"
 
-#: src/Preferences.cpp:721
+#: src/Preferences.cpp:693
 msgid "Greek"
 msgstr "Grčki"
 
-#: src/Preferences.cpp:722
+#: src/Preferences.cpp:694
 msgid "Hebrew"
 msgstr "Hebrejski"
 
-#: src/Preferences.cpp:723
+#: src/Preferences.cpp:695
 msgid "Hungarian"
 msgstr "Mađarski"
 
-#: src/Preferences.cpp:724
+#: src/Preferences.cpp:696
 msgid "Italian"
 msgstr "Talijanski"
 
-#: src/Preferences.cpp:725
+#: src/Preferences.cpp:697
 msgid "Japanese"
 msgstr "Japanski"
 
-#: src/Preferences.cpp:726
+#: src/Preferences.cpp:698
 msgid "Korean"
 msgstr "Korejski"
 
-#: src/Preferences.cpp:727
+#: src/Preferences.cpp:699
 msgid "Latvian"
 msgstr ""
 
-#: src/Preferences.cpp:728
+#: src/Preferences.cpp:700
 msgid "Lithuanian"
 msgstr "Litavski"
 
-#: src/Preferences.cpp:729
+#: src/Preferences.cpp:701
 msgid "Norwegian (Nynorsk)"
 msgstr "Norveški (Nynorsk)"
 
-#: src/Preferences.cpp:730
+#: src/Preferences.cpp:702
 msgid "Polish"
 msgstr "Poljski"
 
-#: src/Preferences.cpp:731
+#: src/Preferences.cpp:703
 msgid "Portuguese"
 msgstr "Portugalski"
 
-#: src/Preferences.cpp:732
+#: src/Preferences.cpp:704
 msgid "Portuguese (Brazilian)"
 msgstr "Portugalski (Brazil)"
 
-#: src/Preferences.cpp:733
+#: src/Preferences.cpp:705
 msgid "Romanian"
 msgstr "Rumunjski"
 
-#: src/Preferences.cpp:734
+#: src/Preferences.cpp:706
 msgid "Russian"
 msgstr "Ruski"
 
-#: src/Preferences.cpp:735
+#: src/Preferences.cpp:707
 msgid "Slovenian"
 msgstr "Slovenski"
 
-#: src/Preferences.cpp:736
+#: src/Preferences.cpp:708
 msgid "Spanish"
 msgstr "Španjolski"
 
-#: src/Preferences.cpp:737
+#: src/Preferences.cpp:709
 msgid "Swedish"
 msgstr "Švedski"
 
-#: src/Preferences.cpp:738
+#: src/Preferences.cpp:710
 msgid "Turkish"
 msgstr "Turski"
 
-#: src/Preferences.cpp:739
+#: src/Preferences.cpp:711
 msgid "Ukrainian"
 msgstr "Ukrajinski"
 
-#: src/Preferences.cpp:842
+#: src/Preferences.cpp:814
 msgid "Change Language"
 msgstr "Promijeniti jezik"
 
-#: src/Preferences.cpp:906
+#: src/Preferences.cpp:878
 msgid "There are no translations installed for aMule"
 msgstr ""
 
-#: src/Preferences.cpp:907
+#: src/Preferences.cpp:879
 msgid "No languages available"
 msgstr "Nema dostupnih jezika"
 
-#: src/Preferences.cpp:1038
+#: src/Preferences.cpp:1010
 msgid "no options available"
 msgstr ""
 
-#: src/Preferences.cpp:2226
+#: src/Preferences.cpp:2179
 msgid "Invalid category found, skipping"
 msgstr ""
 
-#: src/Preferences.cpp:2395
+#: src/Preferences.cpp:2348
 msgid "TCP port can't be higher than 65532 due to server UDP socket being TCP+3"
 msgstr ""
 
-#: src/Preferences.cpp:2396
+#: src/Preferences.cpp:2349
 #, c-format
 msgid "Default port will be used (%d)"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:300 src/Statistics.cpp:866
+#: src/PrefsUnifiedDlg.cpp:298 src/Statistics.cpp:866
 msgid "Connection"
 msgstr "Veza"
 
-#: src/PrefsUnifiedDlg.cpp:301 src/SearchListCtrl.cpp:117
+#: src/PrefsUnifiedDlg.cpp:299 src/SearchListCtrl.cpp:117
 msgid "Directories"
 msgstr "Direktoriji"
 
-#: src/PrefsUnifiedDlg.cpp:302 src/Statistics.cpp:917
+#: src/PrefsUnifiedDlg.cpp:300 src/Statistics.cpp:917
 msgid "Servers"
 msgstr "Serveri"
 
-#: src/PrefsUnifiedDlg.cpp:303 src/ServerListCtrl.cpp:96
+#: src/PrefsUnifiedDlg.cpp:301 src/ServerListCtrl.cpp:96
 msgid "Files"
 msgstr "Fajlovi"
 
-#: src/PrefsUnifiedDlg.cpp:304
+#: src/PrefsUnifiedDlg.cpp:302
 msgid "Security"
 msgstr "Sigurnost"
 
-#: src/PrefsUnifiedDlg.cpp:305
+#: src/PrefsUnifiedDlg.cpp:303
 msgid "Interface"
 msgstr "Sučelje"
 
-#: src/PrefsUnifiedDlg.cpp:312
+#: src/PrefsUnifiedDlg.cpp:310
 msgid "IP2Country"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:315
+#: src/PrefsUnifiedDlg.cpp:313
 msgid "Proxy"
 msgstr "Proxy"
 
-#: src/PrefsUnifiedDlg.cpp:316
+#: src/PrefsUnifiedDlg.cpp:314
 msgid "Filters"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:317
+#: src/PrefsUnifiedDlg.cpp:315
 msgid "Remote Controls"
 msgstr "Daljinsko upravljanje"
 
-#: src/PrefsUnifiedDlg.cpp:318
+#: src/PrefsUnifiedDlg.cpp:316
 msgid "Online Signature"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:319
+#: src/PrefsUnifiedDlg.cpp:317
 msgid "Advanced"
 msgstr "Napredno"
 
-#: src/PrefsUnifiedDlg.cpp:320
+#: src/PrefsUnifiedDlg.cpp:318
 msgid "Events"
 msgstr "Događaji"
 
-#: src/PrefsUnifiedDlg.cpp:323
+#: src/PrefsUnifiedDlg.cpp:321
 msgid "Debugging"
 msgstr "Debugiranje"
 
-#: src/PrefsUnifiedDlg.cpp:453
+#: src/PrefsUnifiedDlg.cpp:451
 msgid ""
 "The following variables will be substituted:\n"
 "    %PARTFILE - full path to the file\n"
 "    %PARTNAME - file name only"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:474
+#: src/PrefsUnifiedDlg.cpp:472
 msgid "Tray icon support requires libayatana-appindicator3 at compile time."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:490
+#: src/PrefsUnifiedDlg.cpp:488
 msgid "Not available on Wayland: the protocol does not report when a window is minimized, so this option cannot intercept the system minimize button. Workaround: launch aMule with `GDK_BACKEND=x11` to use XWayland instead."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:536
+#: src/PrefsUnifiedDlg.cpp:534
 msgid ""
 "Do not change these setting unless you know\n"
 "what you are doing, otherwise you can easily\n"
@@ -5710,220 +5678,206 @@ msgstr ""
 "aMule ce raditi dobro iako ne promijenis\n"
 "nista od ovih opcija."
 
-#: src/PrefsUnifiedDlg.cpp:647
+#: src/PrefsUnifiedDlg.cpp:645
 #, c-format
 msgid "Failed to connect Cfg to widget with the ID %d and key %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:695
+#: src/PrefsUnifiedDlg.cpp:693
 #, c-format
 msgid "Failed to transfer data from Cfg to Widget with the ID %d and key %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:801
+#: src/PrefsUnifiedDlg.cpp:799
 msgid "The type of proxy you are connecting to"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1020
+#: src/PrefsUnifiedDlg.cpp:1003
 #, c-format
 msgid "Failed to transfer data from Widget to Cfg with the ID %d and key %s"
 msgstr ""
 
 #: src/PrefsUnifiedDlg.cpp:1103
-#, fuzzy
-msgid "No password set."
-msgstr "Lozinka"
-
-#: src/PrefsUnifiedDlg.cpp:1132
-msgid "Guest access needs a password. Type one in the guest password field, or untick Enable guest access."
-msgstr ""
-
-#: src/PrefsUnifiedDlg.cpp:1144
 msgid ""
 "aMule must be restarted to enable these changes:\n"
 "\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1151
+#: src/PrefsUnifiedDlg.cpp:1110
 msgid "- TCP port changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1156
+#: src/PrefsUnifiedDlg.cpp:1115
 msgid "- UDP port changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1161
+#: src/PrefsUnifiedDlg.cpp:1120
 #, fuzzy
 msgid "- Network interface binding changed.\n"
 msgstr "Parametri za spoljasnju vezu"
 
-#: src/PrefsUnifiedDlg.cpp:1166
+#: src/PrefsUnifiedDlg.cpp:1125
 #, fuzzy
 msgid "- External connect port changed.\n"
 msgstr "Parametri za spoljasnju vezu"
 
-#: src/PrefsUnifiedDlg.cpp:1170
+#: src/PrefsUnifiedDlg.cpp:1129
 #, fuzzy
 msgid "- External connect acceptance changed.\n"
 msgstr "Parametri za spoljasnju vezu"
 
-#: src/PrefsUnifiedDlg.cpp:1174
+#: src/PrefsUnifiedDlg.cpp:1133
 #, fuzzy
 msgid "- External connect interface changed.\n"
 msgstr "Parametri za spoljasnju vezu"
 
-#: src/PrefsUnifiedDlg.cpp:1178
+#: src/PrefsUnifiedDlg.cpp:1137
 #, fuzzy
 msgid "- Protocol obfuscation support changed.\n"
 msgstr "Parametri za spoljasnju vezu"
 
-#: src/PrefsUnifiedDlg.cpp:1193
+#: src/PrefsUnifiedDlg.cpp:1151
 msgid "- amuleapi settings changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1202
+#: src/PrefsUnifiedDlg.cpp:1160
 msgid ""
 "Your Auto-update server list is empty.\n"
 "'Auto-update server list at startup' will be disabled."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1213
+#: src/PrefsUnifiedDlg.cpp:1171
 msgid ""
 "You have enabled external connections but have not specified a password.\n"
 "External connections cannot be enabled unless a valid password is specified."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1246
-#, c-format
-msgid "The amuleapi password could not be saved: %s"
-msgstr ""
-
-#: src/PrefsUnifiedDlg.cpp:1276
+#: src/PrefsUnifiedDlg.cpp:1202
 msgid "- Language changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1281
+#: src/PrefsUnifiedDlg.cpp:1207
 msgid "- Temp folder changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1286
+#: src/PrefsUnifiedDlg.cpp:1212
 msgid "- ED2K network enabled.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1319
+#: src/PrefsUnifiedDlg.cpp:1245
 msgid "The shared-file exclusion pattern is not a valid regular expression. The filter has been left disabled."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1321 src/PrefsUnifiedDlg.cpp:1921
+#: src/PrefsUnifiedDlg.cpp:1247 src/PrefsUnifiedDlg.cpp:1841
 msgid "Invalid regular expression"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1398
+#: src/PrefsUnifiedDlg.cpp:1324
 msgid ""
 "Both eD2k and Kad network are disabled.\n"
 "You won't be able to connect until you enable at least one of them."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1403
+#: src/PrefsUnifiedDlg.cpp:1329
 msgid ""
 "Kad will not start if your UDP port is disabled.\n"
 "Enable UDP port or disable Kad."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1459
+#: src/PrefsUnifiedDlg.cpp:1385
 msgid ""
 "\n"
 "You MUST restart aMule now.\n"
 "If you do not restart now, don't complain if anything bad happens.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1524
+#: src/PrefsUnifiedDlg.cpp:1450
 msgid "Could not register aMule for autostart at login. The autostart store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1526
+#: src/PrefsUnifiedDlg.cpp:1452
 msgid "Could not remove the autostart-at-login entry."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1527
+#: src/PrefsUnifiedDlg.cpp:1453
 #, fuzzy
 msgid "Autostart"
 msgstr "Automatski"
 
-#: src/PrefsUnifiedDlg.cpp:1542
+#: src/PrefsUnifiedDlg.cpp:1468
 msgid "Register file type"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1542
+#: src/PrefsUnifiedDlg.cpp:1468
 msgid "Register URL handler"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1550
+#: src/PrefsUnifiedDlg.cpp:1476
 #, c-format
 msgid "aMule only handles eD2k-compatible magnets. If you replace the current magnet handler (%s), BitTorrent magnet links will stop working - aMule cannot download BitTorrent content. Continue?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1555
+#: src/PrefsUnifiedDlg.cpp:1481
 #, c-format
 msgid "Another application currently opens .emulecollection files (%s). Replace it with aMule?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1560
+#: src/PrefsUnifiedDlg.cpp:1486
 #, c-format
 msgid "Another application is currently the default handler for these links (%s). Replace it with aMule?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1585
+#: src/PrefsUnifiedDlg.cpp:1511
 msgid "Could not register aMule for .emulecollection files. The registration store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1587
+#: src/PrefsUnifiedDlg.cpp:1513
 #, fuzzy
 msgid "Could not remove the file type registration."
 msgstr "Vec pokusavate downloadovati fajl %s"
 
-#: src/PrefsUnifiedDlg.cpp:1589
+#: src/PrefsUnifiedDlg.cpp:1515
 msgid "Could not register aMule as the URL handler. The registration store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1591
+#: src/PrefsUnifiedDlg.cpp:1517
 msgid "Could not remove the URL handler registration."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1661 src/PrefsUnifiedDlg.cpp:1688
+#: src/PrefsUnifiedDlg.cpp:1587 src/PrefsUnifiedDlg.cpp:1614
 #, fuzzy
 msgid "The web server and aMule API require external connections to be enabled."
 msgstr "Nova vanjska veza prihvacena\n"
 
-#: src/PrefsUnifiedDlg.cpp:1671
+#: src/PrefsUnifiedDlg.cpp:1597
 msgid "The aMule web server is deprecated. Consider running the aMule API instead."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1735
+#: src/PrefsUnifiedDlg.cpp:1655
 msgid ""
 "Your Auto-update servers list is in blank.\n"
 "Please fill in at least one URL to point to a valid server.met file.\n"
 "Click on the button \"List\" by this checkbox to enter an URL."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1876
+#: src/PrefsUnifiedDlg.cpp:1796
 msgid "Temporary files"
 msgstr "Privremene datoteke"
 
-#: src/PrefsUnifiedDlg.cpp:1881
+#: src/PrefsUnifiedDlg.cpp:1801
 msgid "Incoming files"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1886
+#: src/PrefsUnifiedDlg.cpp:1806
 msgid "Online Signatures"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1899
+#: src/PrefsUnifiedDlg.cpp:1819
 #, c-format
 msgid "Choose a folder for %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1923
+#: src/PrefsUnifiedDlg.cpp:1843
 #, fuzzy, c-format
 msgid "Would exclude %u of %u shared file"
 msgid_plural "Would exclude %u of %u shared files"
@@ -5931,41 +5885,41 @@ msgstr[0] "Pronadjeno %i poznatih dijeljenih fajlova"
 msgstr[1] "Pronadjeno %i poznatih dijeljenih fajlova"
 msgstr[2] ""
 
-#: src/PrefsUnifiedDlg.cpp:1940
+#: src/PrefsUnifiedDlg.cpp:1860
 msgid "Browse for videoplayer"
 msgstr "Potrazi videoplejer"
 
-#: src/PrefsUnifiedDlg.cpp:1944
+#: src/PrefsUnifiedDlg.cpp:1864
 msgid "Select browser"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1948
+#: src/PrefsUnifiedDlg.cpp:1868
 msgid "Select ffprobe binary"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1954
+#: src/PrefsUnifiedDlg.cpp:1874
 #, c-format
 msgid "Executable%s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1988
+#: src/PrefsUnifiedDlg.cpp:1908
 msgid "ffprobe not found on PATH or in the standard install locations. Install ffmpeg (which ships ffprobe) or use Browse to pick a binary manually."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2000
+#: src/PrefsUnifiedDlg.cpp:1920
 msgid "Reset the settings on this page to their default values?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2001
+#: src/PrefsUnifiedDlg.cpp:1921
 #, fuzzy
 msgid "Reset to defaults"
 msgstr "Standard sistema"
 
-#: src/PrefsUnifiedDlg.cpp:2028
+#: src/PrefsUnifiedDlg.cpp:1948
 msgid "Edit server list"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2029
+#: src/PrefsUnifiedDlg.cpp:1949
 msgid ""
 "Add here URL's to download server.met files.\n"
 "Only one url on each line."
@@ -5973,41 +5927,41 @@ msgstr ""
 "Dodaj ovdje URLs da dobijes server.met fajlove. \n"
 "Samo jedna URL po liniji."
 
-#: src/PrefsUnifiedDlg.cpp:2084
+#: src/PrefsUnifiedDlg.cpp:2004
 msgid "IP2Country update failed"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2229 src/PrefsUnifiedDlg.cpp:2260
+#: src/PrefsUnifiedDlg.cpp:2149 src/PrefsUnifiedDlg.cpp:2180
 msgid "Data by MaxMind GeoLite2"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2231 src/PrefsUnifiedDlg.cpp:2262
+#: src/PrefsUnifiedDlg.cpp:2151 src/PrefsUnifiedDlg.cpp:2182
 msgid "Custom source"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2233 src/PrefsUnifiedDlg.cpp:2264
+#: src/PrefsUnifiedDlg.cpp:2153 src/PrefsUnifiedDlg.cpp:2184
 msgid "Data by DB-IP.com"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2284
+#: src/PrefsUnifiedDlg.cpp:2204
 #, c-format
 msgid "Status: Loaded%s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2286
+#: src/PrefsUnifiedDlg.cpp:2206
 #, c-format
 msgid "Status: Loaded%s - %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2290
+#: src/PrefsUnifiedDlg.cpp:2210
 msgid "Status: Failed to load - click 'Update now' to refresh."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2292
+#: src/PrefsUnifiedDlg.cpp:2212
 msgid "Status: Not found - click 'Update now' to download."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2350 src/PrefsUnifiedDlg.cpp:2374
+#: src/PrefsUnifiedDlg.cpp:2270 src/PrefsUnifiedDlg.cpp:2294
 #, fuzzy, c-format
 msgid "Update delay: %d second"
 msgid_plural "Update delay: %d seconds"
@@ -6015,7 +5969,7 @@ msgstr[0] "Obnovi kasnjenje : 5 sekundi"
 msgstr[1] "Obnovi kasnjenje : 5 sekundi"
 msgstr[2] ""
 
-#: src/PrefsUnifiedDlg.cpp:2358
+#: src/PrefsUnifiedDlg.cpp:2278
 #, fuzzy, c-format
 msgid "Time for average graph: %d minute"
 msgid_plural "Time for average graph: %d minutes"
@@ -6023,12 +5977,12 @@ msgstr[0] "Vrijeme za prosjecni graf: 100 minuta"
 msgstr[1] "Vrijeme za prosjecni graf: 100 minuta"
 msgstr[2] ""
 
-#: src/PrefsUnifiedDlg.cpp:2367
+#: src/PrefsUnifiedDlg.cpp:2287
 #, c-format
 msgid "Connections Graph Scale: %d"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2382
+#: src/PrefsUnifiedDlg.cpp:2302
 #, fuzzy, c-format
 msgid "File Buffer Size: %d byte"
 msgid_plural "File Buffer Size: %d bytes"
@@ -6036,7 +5990,7 @@ msgstr[0] "Velicina fajl buffera %i bytes"
 msgstr[1] "Velicina fajl buffera %i bytes"
 msgstr[2] ""
 
-#: src/PrefsUnifiedDlg.cpp:2392
+#: src/PrefsUnifiedDlg.cpp:2312
 #, fuzzy, c-format
 msgid "Upload Queue Size: %d client"
 msgid_plural "Upload Queue Size: %d clients"
@@ -6044,7 +5998,7 @@ msgstr[0] "Duzina liste cekanja %i klienata"
 msgstr[1] "Duzina liste cekanja %i klienata"
 msgstr[2] ""
 
-#: src/PrefsUnifiedDlg.cpp:2402
+#: src/PrefsUnifiedDlg.cpp:2322
 #, fuzzy, c-format
 msgid "Server connection refresh interval: %d minute"
 msgid_plural "Server connection refresh interval: %d minutes"
@@ -6052,104 +6006,100 @@ msgstr[0] "Interval obnavljanja veze servera %i minuta"
 msgstr[1] "Interval obnavljanja veze servera %i minuta"
 msgstr[2] ""
 
-#: src/PrefsUnifiedDlg.cpp:2407
+#: src/PrefsUnifiedDlg.cpp:2327
 msgid "Server connection refresh interval: Disabled"
 msgstr "Interval obnavljanja veze servera: onemoguceno"
 
-#: src/PrefsUnifiedDlg.cpp:2451
+#: src/PrefsUnifiedDlg.cpp:2371
 #, fuzzy
 msgid "disabled"
 msgstr "onemoguci"
 
-#: src/PrefsUnifiedDlg.cpp:2477
+#: src/PrefsUnifiedDlg.cpp:2397
 #, c-format
 msgid "Execute command on '%s' event"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2484
+#: src/PrefsUnifiedDlg.cpp:2404
 msgid "Enable command execution on core"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2496
+#: src/PrefsUnifiedDlg.cpp:2416
 msgid "Core command:"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2512
+#: src/PrefsUnifiedDlg.cpp:2432
 msgid "Enable command execution on GUI"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2524
+#: src/PrefsUnifiedDlg.cpp:2444
 msgid "GUI command:"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2540
+#: src/PrefsUnifiedDlg.cpp:2460
 msgid "The following variables will be replaced:"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2708
+#: src/PrefsUnifiedDlg.cpp:2628
 msgid ""
 "The following folders look like system or sensitive locations:\n"
 "\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2713
+#: src/PrefsUnifiedDlg.cpp:2633
 msgid "Sharing them recursively will publish every file underneath on the eD2k/Kad networks. Do you really want to do this?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2716
+#: src/PrefsUnifiedDlg.cpp:2636
 msgid "Confirm shared folders"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2744
+#: src/PrefsUnifiedDlg.cpp:2664
 #, fuzzy
 msgid "Reloading shared files..."
 msgstr "Pronadjeno %i poznatih dijeljenih fajlova"
 
-#: src/PrefsUnifiedDlg.cpp:2745
+#: src/PrefsUnifiedDlg.cpp:2665
 msgid "Scanning for subdirectories..."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2746
+#: src/PrefsUnifiedDlg.cpp:2666
 msgid "Updating shared folders"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2773
+#: src/PrefsUnifiedDlg.cpp:2693
 #, c-format
 msgid "Scanned %u directories..."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2823
+#: src/PrefsUnifiedDlg.cpp:2743
 #, c-format
 msgid "Reloading shared files: %u files scanned"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2873
+#: src/PrefsUnifiedDlg.cpp:2793
 #, fuzzy
 msgid "Shared folder"
 msgstr "Dijeljeni fajlovi"
 
-#: src/SearchDlg.cpp:280
-msgid "Clear search history"
-msgstr ""
-
-#: src/SearchDlg.cpp:584
+#: src/SearchDlg.cpp:425
 msgid "It's impossible to search when both eD2k and Kademlia are disabled."
 msgstr ""
 
-#: src/SearchDlg.cpp:585 src/SearchListCtrl.cpp:858
+#: src/SearchDlg.cpp:426 src/SearchListCtrl.cpp:858
 #, fuzzy
 msgid "Search error"
 msgstr "Pretrage"
 
-#: src/SearchDlg.cpp:929
+#: src/SearchDlg.cpp:768
 msgid "Min size must be smaller than max size. Max size ignored."
 msgstr ""
 
-#: src/SearchDlg.cpp:930 src/SearchDlg.cpp:1012
+#: src/SearchDlg.cpp:769 src/SearchDlg.cpp:851
 msgid "Search warning"
 msgstr ""
 
-#: src/SearchDlg.cpp:1092 src/SearchListCtrl.cpp:735
+#: src/SearchDlg.cpp:929 src/SearchListCtrl.cpp:735
 msgid "Main"
 msgstr ""
 

--- a/po/hr.po
+++ b/po/hr.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-28 10:19+0200\n"
+"POT-Creation-Date: 2026-07-28 12:17+0200\n"
 "PO-Revision-Date: 2026-07-27 11:39+0000\n"
 "Last-Translator: Sebastiano Pistore <sebastiano.pistore.info@aol.com>\n"
 "Language-Team: https://github.com/amule-org/amule <forum@aMule.org>\n"
@@ -197,155 +197,155 @@ msgstr "Neuspjelo otvaranje %s (%s)"
 msgid "WARNING: You can't add yourself as a source for an eD2k link while having a lowid."
 msgstr ""
 
-#: src/amule.cpp:300
+#: src/amule.cpp:301
 msgid "Now, exiting main app..."
 msgstr ""
 
-#: src/amule.cpp:330
+#: src/amule.cpp:331
 #, c-format
 msgid "Terminating amuleweb instance with pid '%d' ... "
 msgstr ""
 
-#: src/amule.cpp:334
+#: src/amule.cpp:335
 #, c-format
 msgid "Killing amuleweb instance with pid '%d' ... "
 msgstr ""
 
-#: src/amule.cpp:336 src/amule.cpp:349 src/ClientRef.cpp:180
+#: src/amule.cpp:337 src/amule.cpp:350 src/ClientRef.cpp:180
 #: src/SearchDlg.cpp:1041 src/ServerListCtrl.cpp:98
 msgid "Failed"
 msgstr "Neuspjesno"
 
-#: src/amule.cpp:343
+#: src/amule.cpp:344
 #, c-format
 msgid "Terminating amuleapi instance with pid '%d' ... "
 msgstr ""
 
-#: src/amule.cpp:347
+#: src/amule.cpp:348
 #, c-format
 msgid "Killing amuleapi instance with pid '%d' ... "
 msgstr ""
 
-#: src/amule.cpp:355
+#: src/amule.cpp:356
 msgid "aMule OnExit: Terminating core."
 msgstr ""
 
-#: src/amule.cpp:466
+#: src/amule.cpp:467
 msgid "aMule shutdown completed."
 msgstr ""
 
-#: src/amule.cpp:470
+#: src/amule.cpp:471
 msgid "Memory debug results for aMule exit:"
 msgstr ""
 
-#: src/amule.cpp:651
+#: src/amule.cpp:652
 #, c-format
 msgid "Binding aMule's peer-to-peer traffic to interface: %s (HTTP updates use the default route)"
 msgstr ""
 
-#: src/amule.cpp:655
+#: src/amule.cpp:656
 #, c-format
 msgid "Binding all network traffic to interface: %s"
 msgstr ""
 
-#: src/amule.cpp:659
+#: src/amule.cpp:660
 #, c-format
 msgid "WARNING: configured network interface '%s' was not found - traffic is NOT bound to it and may leave via the default route. Check the interface name in Preferences."
 msgstr ""
 
-#: src/amule.cpp:665
+#: src/amule.cpp:666
 #, c-format
 msgid "WARNING: binding to network interface '%s' requires elevated privileges and was NOT applied - traffic may leave via the default route. Grant the capability (e.g. 'sudo setcap cap_net_raw+ep' on the aMule binary) or run with sufficient privileges."
 msgstr ""
 
-#: src/amule.cpp:673
+#: src/amule.cpp:674
 #, c-format
 msgid "WARNING: could not bind to network interface '%s' - traffic may leave via the default route."
 msgstr ""
 
-#: src/amule.cpp:732
+#: src/amule.cpp:733
 msgid "Your locale has been changed to System Default due to a configuration change. Sorry."
 msgstr ""
 
-#: src/amule.cpp:734 src/amule.cpp:1581 src/CatDialog.cpp:128
+#: src/amule.cpp:735 src/amule.cpp:1589 src/CatDialog.cpp:128
 #: src/CatDialog.cpp:136 src/CatDialog.cpp:149 src/ServerList.cpp:366
 #: src/ServerListCtrl.cpp:152
 msgid "Info"
 msgstr "Info"
 
-#: src/amule.cpp:741
+#: src/amule.cpp:742
 #, fuzzy
 msgid ""
 "\n"
 "EC configuration"
 msgstr "Potvrda izlaza"
 
-#: src/amule.cpp:744
+#: src/amule.cpp:745
 #, fuzzy
 msgid "Password set and external connections enabled."
 msgstr "Nova vanjska veza prihvacena\n"
 
-#: src/amule.cpp:754 src/KadDlg.cpp:176 src/KadDlg.cpp:185
-#: src/PrefsUnifiedDlg.cpp:1387 src/SharedFilesCtrl.cpp:476
+#: src/amule.cpp:755 src/KadDlg.cpp:176 src/KadDlg.cpp:185
+#: src/PrefsUnifiedDlg.cpp:1461 src/SharedFilesCtrl.cpp:476
 msgid "WARNING"
 msgstr "UPOZORENJE"
 
-#: src/amule.cpp:991
+#: src/amule.cpp:992
 msgid "Network bootstrap"
 msgstr ""
 
-#: src/amule.cpp:996
+#: src/amule.cpp:997
 msgid ""
 "aMule has detected missing network bootstrap files.\n"
 "Select which ones to download:"
 msgstr ""
 
-#: src/amule.cpp:1005 src/FirstRunWizard.cpp:411
+#: src/amule.cpp:1006 src/FirstRunWizard.cpp:411
 #, fuzzy
 msgid "eD2k server list (server.met)"
 msgstr "%i servera pronadjeno u server.met"
 
-#: src/amule.cpp:1012 src/FirstRunWizard.cpp:416
+#: src/amule.cpp:1013 src/FirstRunWizard.cpp:416
 msgid "Kad bootstrap nodes (nodes.dat)"
 msgstr ""
 
-#: src/amule.cpp:1102
+#: src/amule.cpp:1103
 #, c-format
 msgid "web server running on pid %d"
 msgstr ""
 
-#: src/amule.cpp:1115
+#: src/amule.cpp:1116
 msgid "You requested to run web server on startup, but the amuleweb binary cannot be run. Please install the package containing aMule web server, or build aMule from source with -DBUILD_WEBSERVER=YES and install it."
 msgstr ""
 
-#: src/amule.cpp:1120 src/amule.cpp:1177 src/amule.cpp:1291 src/amule.cpp:1593
+#: src/amule.cpp:1121 src/amule.cpp:1185 src/amule.cpp:1299 src/amule.cpp:1601
 #: src/amule-remote-gui.cpp:603 src/amule-remote-gui.cpp:671
 #: src/amule-remote-gui.cpp:709 src/amule-remote-gui.cpp:1282
 #: src/amule-remote-gui.cpp:1345 src/amule-remote-gui.cpp:1372
-#: src/DownloadQueue.cpp:1481
+#: src/DownloadQueue.cpp:1481 src/PrefsUnifiedDlg.cpp:1247
 msgid "ERROR"
 msgstr "GREŠKA"
 
-#: src/amule.cpp:1166
+#: src/amule.cpp:1174
 #, c-format
 msgid "amuleapi running on pid %d"
 msgstr ""
 
-#: src/amule.cpp:1172
+#: src/amule.cpp:1180
 msgid "You requested to run amuleapi on startup, but the amuleapi binary cannot be run. Please install the package containing aMule's REST API server, or build aMule from source with -DBUILD_AMULEAPI=YES and install it."
 msgstr ""
 
-#: src/amule.cpp:1259
+#: src/amule.cpp:1267
 #, c-format
 msgid "Could not bind ports to the specified address: %s"
 msgstr ""
 
-#: src/amule.cpp:1283
+#: src/amule.cpp:1291
 #, c-format
 msgid "Port %u is not available. You will be LOWID\n"
 msgstr ""
 
-#: src/amule.cpp:1288
+#: src/amule.cpp:1296
 #, c-format
 msgid ""
 "Port %u is not available!\n"
@@ -355,185 +355,185 @@ msgid ""
 "Check your network to make sure the port is open for output and input."
 msgstr ""
 
-#: src/amule.cpp:1385
+#: src/amule.cpp:1393
 msgid "Failed to create OnlineSig File"
 msgstr ""
 
-#: src/amule.cpp:1393
+#: src/amule.cpp:1401
 msgid "Failed to create aMule OnlineSig File"
 msgstr ""
 
-#: src/amule.cpp:1556
+#: src/amule.cpp:1564
 msgid "The selected locale seems not to be installed on your box. (Note: I'll try to set it anyway)"
 msgstr ""
 
-#: src/amule.cpp:1566
+#: src/amule.cpp:1574
 #, c-format
 msgid "This is the first time you run aMule %s"
 msgstr ""
 
-#: src/amule.cpp:1569
+#: src/amule.cpp:1577
 msgid "This version is a testing version, updated daily, and\n"
 msgstr ""
 
-#: src/amule.cpp:1570
+#: src/amule.cpp:1578
 msgid "we give no warranty it won't break anything, burn your house,\n"
 msgstr "ne dajemo nikakvu garanciju da nece nista unistiti, tvoju kucu zapaliti, \n"
 
-#: src/amule.cpp:1571
+#: src/amule.cpp:1579
 msgid "or kill your dog. But it *should* be safe to use anyway.\n"
 msgstr ""
 
-#: src/amule.cpp:1576
+#: src/amule.cpp:1584
 msgid "More information, support and new releases can found at our homepage,\n"
 msgstr ""
 
-#: src/amule.cpp:1577
+#: src/amule.cpp:1585
 msgid "at https://amule-org.github.io, or in our IRC channel #aMule at irc.libera.chat.\n"
 msgstr ""
 
-#: src/amule.cpp:1579
+#: src/amule.cpp:1587
 msgid "Feel free to report any bugs to https://github.com/amule-org/amule/issues"
 msgstr ""
 
-#: src/amule.cpp:1591
+#: src/amule.cpp:1599
 msgid ""
 "The folder for Online Signature files you specified is INVALID!\n"
 " OnlineSignature will be DISABLED until you fix it on preferences."
 msgstr ""
 
-#: src/amule.cpp:1654
+#: src/amule.cpp:1662
 #, fuzzy
 msgid "Server hostname notified"
 msgstr "Ime servera :"
 
-#: src/amule.cpp:2031
+#: src/amule.cpp:2039
 #, c-format
 msgid "Disk space preallocation for file '%s' failed: %s"
 msgstr ""
 
-#: src/amule.cpp:2160
+#: src/amule.cpp:2168
 msgid "ERROR: can't open logfile"
 msgstr ""
 
-#: src/amule.cpp:2164
+#: src/amule.cpp:2172
 msgid "WARNING: logfile is empty. Something is wrong."
 msgstr ""
 
-#: src/amule.cpp:2181
+#: src/amule.cpp:2189
 msgid "Log has been reset"
 msgstr ""
 
-#: src/amule.cpp:2205
+#: src/amule.cpp:2213
 #, c-format
 msgid "ServerMessage: %s"
 msgstr ""
 
-#: src/amule.cpp:2248 src/IP2Country.cpp:220 src/IPFilter.cpp:514
+#: src/amule.cpp:2256 src/IP2Country.cpp:220 src/IPFilter.cpp:514
 #: src/ServerList.cpp:875
 #, c-format
 msgid "Skipped download of %s, because requested file is not newer."
 msgstr ""
 
-#: src/amule.cpp:2251
+#: src/amule.cpp:2259
 msgid "Failed to download the nodes list."
 msgstr ""
 
-#: src/amule.cpp:2314
+#: src/amule.cpp:2322
 msgid "Failed to open the downloaded version check file"
 msgstr ""
 
-#: src/amule.cpp:2317 src/amule.cpp:2336
+#: src/amule.cpp:2325 src/amule.cpp:2344
 msgid "Corrupted version check file"
 msgstr ""
 
-#: src/amule.cpp:2359
+#: src/amule.cpp:2367
 msgid "You are using an outdated version of aMule!"
 msgstr ""
 
-#: src/amule.cpp:2361
+#: src/amule.cpp:2369
 #, c-format
 msgid "Your aMule version is %i.%i.%i and the latest version is %li.%li.%li"
 msgstr ""
 
-#: src/amule.cpp:2365
+#: src/amule.cpp:2373
 msgid "The latest version can always be found at https://github.com/amule-org/amule/releases/latest"
 msgstr ""
 
-#: src/amule.cpp:2368
+#: src/amule.cpp:2376
 #, c-format
 msgid "WARNING: Your aMuled version is outdated: %i.%i.%i < %li.%li.%li"
 msgstr ""
 
-#: src/amule.cpp:2374
+#: src/amule.cpp:2382
 msgid "Your copy of aMule is up to date."
 msgstr ""
 
-#: src/amule.cpp:2381
+#: src/amule.cpp:2389
 msgid "Failed to download the version check file"
 msgstr ""
 
-#: src/amule.cpp:2550 src/amule-remote-gui.cpp:1133
+#: src/amule.cpp:2558 src/amule-remote-gui.cpp:1133
 #, c-format
 msgid "Users: %s | Files: %s"
 msgstr ""
 
-#: src/amule.cpp:2551 src/amule-remote-gui.cpp:1134
+#: src/amule.cpp:2559 src/amule-remote-gui.cpp:1134
 #, c-format
 msgid "Users: E: %s K: %s | Files: E: %s K: %s"
 msgstr ""
 
-#: src/amule.cpp:2565 src/amule-remote-gui.cpp:1147
+#: src/amule.cpp:2573 src/amule-remote-gui.cpp:1147
 msgid "No networks selected"
 msgstr ""
 
-#: src/amule.cpp:2633 src/TextClient.cpp:903
+#: src/amule.cpp:2641 src/TextClient.cpp:903
 msgid "with LowID"
 msgstr ""
 
-#: src/amule.cpp:2633 src/TextClient.cpp:904
+#: src/amule.cpp:2641 src/TextClient.cpp:904
 msgid "with HighID"
 msgstr ""
 
-#: src/amule.cpp:2635
+#: src/amule.cpp:2643
 #, c-format
 msgid "Connected to %s %s"
 msgstr ""
 
-#: src/amule.cpp:2640
+#: src/amule.cpp:2648
 #, c-format
 msgid "Connecting to %s"
 msgstr ""
 
-#: src/amule.cpp:2642
+#: src/amule.cpp:2650
 msgid "Disconnected from eD2k"
 msgstr ""
 
-#: src/amule.cpp:2651
+#: src/amule.cpp:2659
 msgid "Kad started."
 msgstr ""
 
-#: src/amule.cpp:2653
+#: src/amule.cpp:2661
 msgid "Kad stopped."
 msgstr ""
 
-#: src/amule.cpp:2661
+#: src/amule.cpp:2669
 msgid "Connected to Kad (ok)"
 msgstr ""
 
-#: src/amule.cpp:2663
+#: src/amule.cpp:2671
 msgid "Connected to Kad (firewalled)"
 msgstr ""
 
-#: src/amule.cpp:2667
+#: src/amule.cpp:2675
 msgid "Disconnected from Kad"
 msgstr ""
 
-#: src/amule.cpp:2699
+#: src/amule.cpp:2707
 msgid "Kad network cannot be used if UDP port is disabled on preferences, not starting."
 msgstr ""
 
-#: src/amule.cpp:2703
+#: src/amule.cpp:2711
 msgid "Kad network disabled on preferences, not connecting."
 msgstr ""
 
@@ -577,36 +577,36 @@ msgid "FATAL ERROR: Failed to create Timer"
 msgstr ""
 
 #: src/amuleDlg.cpp:361 src/amuleDlg.cpp:1787 src/amuleDlg.cpp:2033
-#: src/muuli_wdr.cpp:1492 src/muuli_wdr.cpp:3418
+#: src/muuli_wdr.cpp:1492 src/muuli_wdr.cpp:3449
 msgid "Networks"
 msgstr ""
 
-#: src/amuleDlg.cpp:362 src/amuleDlg.cpp:1793 src/muuli_wdr.cpp:3419
+#: src/amuleDlg.cpp:362 src/amuleDlg.cpp:1793 src/muuli_wdr.cpp:3450
 msgid "Searches"
 msgstr "Pretrage"
 
 #: src/amuleDlg.cpp:363 src/amuleDlg.cpp:1799 src/DownloadListCtrl.cpp:740
-#: src/muuli_wdr.cpp:392 src/muuli_wdr.cpp:1585 src/muuli_wdr.cpp:3420
+#: src/muuli_wdr.cpp:392 src/muuli_wdr.cpp:1585 src/muuli_wdr.cpp:3451
 #: src/Statistics.cpp:829
 msgid "Downloads"
 msgstr "Downloads"
 
-#: src/amuleDlg.cpp:364 src/amuleDlg.cpp:1805 src/muuli_wdr.cpp:3294
+#: src/amuleDlg.cpp:364 src/amuleDlg.cpp:1805 src/muuli_wdr.cpp:3325
 msgid "Shared files"
 msgstr ""
 
-#: src/amuleDlg.cpp:365 src/amuleDlg.cpp:1811 src/muuli_wdr.cpp:2926
-#: src/muuli_wdr.cpp:3376 src/muuli_wdr.cpp:3423
+#: src/amuleDlg.cpp:365 src/amuleDlg.cpp:1811 src/muuli_wdr.cpp:2957
+#: src/muuli_wdr.cpp:3407 src/muuli_wdr.cpp:3454
 msgid "Messages"
 msgstr "Poruke"
 
-#: src/amuleDlg.cpp:366 src/amuleDlg.cpp:1817 src/muuli_wdr.cpp:3424
-#: src/PrefsUnifiedDlg.cpp:312 src/Statistics.cpp:779 src/Statistics.cpp:1235
+#: src/amuleDlg.cpp:366 src/amuleDlg.cpp:1817 src/muuli_wdr.cpp:3455
+#: src/PrefsUnifiedDlg.cpp:314 src/Statistics.cpp:779 src/Statistics.cpp:1235
 msgid "Statistics"
 msgstr "Statistike"
 
-#: src/amuleDlg.cpp:368 src/amuleDlg.cpp:1824 src/muuli_wdr.cpp:3426
-#: src/PrefsUnifiedDlg.cpp:328 src/utils/wxCas/src/wxcasprefs.cpp:39
+#: src/amuleDlg.cpp:368 src/amuleDlg.cpp:1824 src/muuli_wdr.cpp:3457
+#: src/PrefsUnifiedDlg.cpp:330 src/utils/wxCas/src/wxcasprefs.cpp:39
 msgid "Preferences"
 msgstr "Opcije"
 
@@ -666,8 +666,8 @@ msgstr ""
 #: src/amuleDlg.cpp:1029 src/DownloadListCtrl.cpp:505
 #: src/DownloadListCtrl.cpp:749 src/FriendListCtrl.cpp:180
 #: src/muuli_wdr.cpp:731 src/muuli_wdr.cpp:782 src/muuli_wdr.cpp:846
-#: src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2231 src/muuli_wdr.cpp:2316
-#: src/muuli_wdr.cpp:3064 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
+#: src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2262 src/muuli_wdr.cpp:2347
+#: src/muuli_wdr.cpp:3095 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
 #: src/ServerListCtrl.cpp:606 src/TransferWnd.cpp:378
 #: src/utils/wxCas/src/wxcasprefs.cpp:235
 msgid "Cancel"
@@ -679,7 +679,7 @@ msgid "Stop the current connection attempts"
 msgstr "Zaustavlja trenutne pokusaje uspostavljanja veze"
 
 #: src/amuleDlg.cpp:1035 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976
-#: src/muuli_wdr.cpp:2454
+#: src/muuli_wdr.cpp:2485
 msgid "Disconnect"
 msgstr "Prekinuti vezu"
 
@@ -689,7 +689,7 @@ msgid "Disconnect from the currently connected networks"
 msgstr "Prekinuti vezu sa sadasnjim serverom"
 
 #: src/amuleDlg.cpp:1041 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979
-#: src/muuli_wdr.cpp:2609 src/muuli_wdr.cpp:3061 src/muuli_wdr.cpp:3416
+#: src/muuli_wdr.cpp:2640 src/muuli_wdr.cpp:3092 src/muuli_wdr.cpp:3447
 msgid "Connect"
 msgstr "Uspostavi vezu"
 
@@ -744,7 +744,7 @@ msgstr "Potvrda izlaza"
 msgid "Launch Command: "
 msgstr ""
 
-#: src/amuleDlg.cpp:1632 src/muuli_wdr.cpp:1978 src/Preferences.cpp:952
+#: src/amuleDlg.cpp:1632 src/muuli_wdr.cpp:1982 src/Preferences.cpp:979
 msgid "- default -"
 msgstr ""
 
@@ -758,49 +758,49 @@ msgstr ""
 msgid "WARNING: Unable to open skin file '%s' for read"
 msgstr ""
 
-#: src/amuleDlg.cpp:1791 src/muuli_wdr.cpp:3418
+#: src/amuleDlg.cpp:1791 src/muuli_wdr.cpp:3449
 msgid "Networks Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1797 src/muuli_wdr.cpp:3419
+#: src/amuleDlg.cpp:1797 src/muuli_wdr.cpp:3450
 msgid "Searches Window"
 msgstr "Prozor pretraga"
 
-#: src/amuleDlg.cpp:1803 src/muuli_wdr.cpp:3420
+#: src/amuleDlg.cpp:1803 src/muuli_wdr.cpp:3451
 #, fuzzy
 msgid "Downloads Window"
 msgstr "Downloading"
 
-#: src/amuleDlg.cpp:1809 src/muuli_wdr.cpp:3422
+#: src/amuleDlg.cpp:1809 src/muuli_wdr.cpp:3453
 msgid "Shared Files Window"
 msgstr "Prozor dijeljenih fajlova"
 
-#: src/amuleDlg.cpp:1815 src/muuli_wdr.cpp:3423
+#: src/amuleDlg.cpp:1815 src/muuli_wdr.cpp:3454
 msgid "Messages Window"
 msgstr "Prozor poruka"
 
-#: src/amuleDlg.cpp:1821 src/muuli_wdr.cpp:3424
+#: src/amuleDlg.cpp:1821 src/muuli_wdr.cpp:3455
 msgid "Statistics Graph Window"
 msgstr "Prozor grafova statistike"
 
-#: src/amuleDlg.cpp:1828 src/muuli_wdr.cpp:3426
+#: src/amuleDlg.cpp:1828 src/muuli_wdr.cpp:3457
 msgid "Preferences Settings Window"
 msgstr "Prozor postavke opcija"
 
-#: src/amuleDlg.cpp:1831 src/muuli_wdr.cpp:3427
+#: src/amuleDlg.cpp:1831 src/muuli_wdr.cpp:3458
 msgid "Import"
 msgstr "Uvezi"
 
-#: src/amuleDlg.cpp:1835 src/muuli_wdr.cpp:3427
+#: src/amuleDlg.cpp:1835 src/muuli_wdr.cpp:3458
 msgid "The partfile importer tool"
 msgstr ""
 
-#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3428
+#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3459
 #: src/utils/aLinkCreator/src/alcframe.cpp:262
 msgid "About"
 msgstr "O autoru:"
 
-#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3428
+#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3459
 msgid "About/Help"
 msgstr ""
 
@@ -943,7 +943,7 @@ msgstr "Datoteka nije pronađena."
 msgid "The core rejected these shared folders:%s"
 msgstr ""
 
-#: src/amule-remote-gui.cpp:1336 src/ExternalConn.cpp:2345
+#: src/amule-remote-gui.cpp:1336 src/ExternalConn.cpp:2346
 msgid "Invalid link or already on list."
 msgstr ""
 
@@ -959,7 +959,7 @@ msgstr ""
 #: src/ClientDetailDialog.cpp:123 src/DataToText.cpp:61 src/DataToText.cpp:86
 #: src/DataToText.cpp:101 src/DataToText.cpp:136 src/DataToText.cpp:165
 #: src/DownloadListCtrl.cpp:1172 src/DownloadListCtrl.cpp:1185
-#: src/DownloadListCtrl.cpp:1196 src/ExternalConn.cpp:608
+#: src/DownloadListCtrl.cpp:1196 src/ExternalConn.cpp:609
 #: src/FileDetailDialog.cpp:203 src/FileDetailDialog.cpp:235
 #: src/FileDetailDialog.cpp:242 src/GenericClientListCtrl.cpp:1171
 #: src/GenericClientListCtrl.cpp:1182 src/GenericClientListCtrl.cpp:1192
@@ -1352,19 +1352,19 @@ msgstr "Auto [Vi]"
 msgid "Very low"
 msgstr "Vrlo nizak"
 
-#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:743 src/muuli_wdr.cpp:2282
+#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:743 src/muuli_wdr.cpp:2313
 #: src/ServerListCtrl.cpp:263 src/ServerListCtrl.cpp:456
 #: src/SharedFilesCtrl.cpp:145
 msgid "Low"
 msgstr "Nisko"
 
-#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:744 src/muuli_wdr.cpp:2283
+#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:744 src/muuli_wdr.cpp:2314
 #: src/ServerListCtrl.cpp:266 src/ServerListCtrl.cpp:457
 #: src/SharedFilesCtrl.cpp:146
 msgid "Normal"
 msgstr "Normalan"
 
-#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:745 src/muuli_wdr.cpp:2284
+#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:745 src/muuli_wdr.cpp:2315
 #: src/ServerListCtrl.cpp:269 src/ServerListCtrl.cpp:458
 #: src/SharedFilesCtrl.cpp:147
 msgid "High"
@@ -1456,7 +1456,7 @@ msgstr ""
 msgid "Remote Server"
 msgstr ""
 
-#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3181
+#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3212
 #: src/SearchDlg.cpp:119 src/TextClient.cpp:911
 msgid "Kad"
 msgstr "Kad"
@@ -1527,7 +1527,7 @@ msgstr ""
 msgid "Size"
 msgstr "Velicina"
 
-#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3248
+#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3279
 msgid "Transferred"
 msgstr "Transferirano"
 
@@ -1585,7 +1585,7 @@ msgid ""
 "\n"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:746 src/muuli_wdr.cpp:2285
+#: src/DownloadListCtrl.cpp:746 src/muuli_wdr.cpp:2316
 #: src/SharedFilesCtrl.cpp:150
 msgid "Auto"
 msgstr "Automatski"
@@ -1623,7 +1623,7 @@ msgid "Extended Options"
 msgstr "Prosirene opcije"
 
 #: src/DownloadListCtrl.cpp:770 src/DownloadListCtrl.cpp:822
-#: src/muuli_wdr.cpp:1796
+#: src/muuli_wdr.cpp:1800
 msgid "Preview"
 msgstr "Preuvid"
 
@@ -1798,227 +1798,232 @@ msgstr[2] ""
 msgid "Invalid eD2k link! ERROR: %s"
 msgstr ""
 
-#: src/ExternalConn.cpp:379
+#: src/ExternalConn.cpp:380
 msgid "Client sent packet after authentication failed."
 msgstr ""
 
-#: src/ExternalConn.cpp:396
+#: src/ExternalConn.cpp:397
 msgid "External connection closed."
 msgstr ""
 
-#: src/ExternalConn.cpp:473
+#: src/ExternalConn.cpp:474
 msgid "External connections disabled due to empty password!"
 msgstr ""
 
-#: src/ExternalConn.cpp:494
+#: src/ExternalConn.cpp:495
 msgid "External connections disabled in config file"
 msgstr ""
 
-#: src/ExternalConn.cpp:575
+#: src/ExternalConn.cpp:576
 msgid "New external connection accepted"
 msgstr ""
 
-#: src/ExternalConn.cpp:578
+#: src/ExternalConn.cpp:579
 msgid "ERROR: couldn't accept a new external connection"
 msgstr ""
 
-#: src/ExternalConn.cpp:595
+#: src/ExternalConn.cpp:596
 msgid "External connection refused due to empty password in preferences!"
 msgstr ""
 
-#: src/ExternalConn.cpp:607
+#: src/ExternalConn.cpp:608
 #, c-format
 msgid "Connecting client: %s %s"
 msgstr ""
 
-#: src/ExternalConn.cpp:609
+#: src/ExternalConn.cpp:610
 msgid "Unknown version"
 msgstr ""
 
-#: src/ExternalConn.cpp:622
+#: src/ExternalConn.cpp:623
 msgid "Incorrect EC version ID, there might be binary incompatibility. Use core and remote from same snapshot."
 msgstr ""
 
-#: src/ExternalConn.cpp:630
+#: src/ExternalConn.cpp:631
 msgid "You cannot connect to a release version from an arbitrary development snapshot! *sigh* possible crash prevented"
 msgstr ""
 
-#: src/ExternalConn.cpp:713
+#: src/ExternalConn.cpp:714
 msgid "Invalid protocol version."
 msgstr ""
 
-#: src/ExternalConn.cpp:719
+#: src/ExternalConn.cpp:720
 msgid "Missing protocol version tag."
 msgstr ""
 
-#: src/ExternalConn.cpp:727
+#: src/ExternalConn.cpp:728
 msgid "Authentication failed: invalid hash specified as EC password."
 msgstr ""
 
-#: src/ExternalConn.cpp:775
+#: src/ExternalConn.cpp:776
 msgid "Authentication failed: wrong password."
 msgstr ""
 
-#: src/ExternalConn.cpp:777
+#: src/ExternalConn.cpp:778
 msgid "Authentication failed: missing password."
 msgstr ""
 
-#: src/ExternalConn.cpp:788
+#: src/ExternalConn.cpp:789
 msgid "Invalid request, please authenticate first."
 msgstr ""
 
-#: src/ExternalConn.cpp:793
+#: src/ExternalConn.cpp:794
 msgid "Access granted."
 msgstr ""
 
-#: src/ExternalConn.cpp:801
+#: src/ExternalConn.cpp:802
 #, c-format
 msgid "Sent error message \"%s\" to client."
 msgstr ""
 
-#: src/ExternalConn.cpp:806
+#: src/ExternalConn.cpp:807
 #, c-format
 msgid "Unauthorized access attempt from %s. Connection closed."
 msgstr ""
 
-#: src/ExternalConn.cpp:1419
+#: src/ExternalConn.cpp:1420
 #, c-format
 msgid "Remote PartFile command failed: FileHash not found: %s"
 msgstr ""
 
-#: src/ExternalConn.cpp:1423
+#: src/ExternalConn.cpp:1424
 #, c-format
 msgid "FileHash not found: %s"
 msgstr ""
 
-#: src/ExternalConn.cpp:1470 src/ExternalConn.cpp:1558
-#: src/ExternalConn.cpp:1679
+#: src/ExternalConn.cpp:1471 src/ExternalConn.cpp:1559
+#: src/ExternalConn.cpp:1680
 msgid "OOPS! OpCode processing error!"
 msgstr ""
 
-#: src/ExternalConn.cpp:1501
+#: src/ExternalConn.cpp:1502
 msgid "Server not added"
 msgstr ""
 
-#: src/ExternalConn.cpp:1520
+#: src/ExternalConn.cpp:1521
 #, c-format
 msgid "server not found: %s"
 msgstr ""
 
-#: src/ExternalConn.cpp:1537
+#: src/ExternalConn.cpp:1538
 msgid "need to define server to be removed"
 msgstr ""
 
-#: src/ExternalConn.cpp:1552
+#: src/ExternalConn.cpp:1553
 msgid "eD2k is disabled in preferences."
 msgstr ""
 
-#: src/ExternalConn.cpp:1657
+#: src/ExternalConn.cpp:1658
 #, fuzzy
 msgid "Friend not found."
 msgstr "Datoteka nije pronađena."
 
-#: src/ExternalConn.cpp:1667
+#: src/ExternalConn.cpp:1668
 #, fuzzy
 msgid "Client not found."
 msgstr "Datoteka nije pronađena."
 
-#: src/ExternalConn.cpp:1673
+#: src/ExternalConn.cpp:1674
 msgid "EC_TAG_FRIEND_SHARED requires EC_TAG_FRIEND or EC_TAG_CLIENT."
 msgstr ""
 
-#: src/ExternalConn.cpp:1991
+#: src/ExternalConn.cpp:1992
 msgid "WebSearch from remote interface makes no sense."
 msgstr ""
 
-#: src/ExternalConn.cpp:2026
+#: src/ExternalConn.cpp:2027
 msgid "Search in progress. Refetch results in a moment!"
 msgstr ""
 
-#: src/ExternalConn.cpp:2265
+#: src/ExternalConn.cpp:2266
 msgid "No points for graph."
 msgstr ""
 
-#: src/ExternalConn.cpp:2275
+#: src/ExternalConn.cpp:2276
 msgid "Your client is not configured for this detail level."
 msgstr ""
 
-#: src/ExternalConn.cpp:2302
+#: src/ExternalConn.cpp:2303
 msgid "External Connection: shutdown requested"
 msgstr ""
 
-#: src/ExternalConn.cpp:2314
+#: src/ExternalConn.cpp:2315
 msgid "Already shutting down."
 msgstr ""
 
-#: src/ExternalConn.cpp:2332
+#: src/ExternalConn.cpp:2333
 #, c-format
 msgid "ExternalConn: adding link '%s'."
 msgstr ""
 
-#: src/ExternalConn.cpp:2350
+#: src/ExternalConn.cpp:2351
 #, c-format
 msgid "%d of %d links failed (invalid or already on list)."
 msgstr ""
 
-#: src/ExternalConn.cpp:2373
+#: src/ExternalConn.cpp:2374
 msgid "Version check throttled; try again shortly."
 msgstr ""
 
-#: src/ExternalConn.cpp:2378
+#: src/ExternalConn.cpp:2379
 msgid "Version check is not available on this daemon."
 msgstr ""
 
-#: src/ExternalConn.cpp:2508
+#: src/ExternalConn.cpp:2509
 msgid "File not found."
 msgstr "Datoteka nije pronađena."
 
-#: src/ExternalConn.cpp:2513
+#: src/ExternalConn.cpp:2514
 msgid "Invalid file name."
 msgstr "Nepravilan naziv datoteke."
 
-#: src/ExternalConn.cpp:2521
+#: src/ExternalConn.cpp:2522
 msgid "Unable to rename file."
 msgstr ""
 
-#: src/ExternalConn.cpp:2992 src/ExternalConn.cpp:3020
+#: src/ExternalConn.cpp:2839
+#, c-format
+msgid "Could not save the amuleapi password: %s"
+msgstr ""
+
+#: src/ExternalConn.cpp:3004 src/ExternalConn.cpp:3032
 msgid "Kad is disabled in preferences."
 msgstr ""
 
-#: src/ExternalConn.cpp:3033
+#: src/ExternalConn.cpp:3045
 msgid "Already connected to eD2k."
 msgstr ""
 
-#: src/ExternalConn.cpp:3036
+#: src/ExternalConn.cpp:3048
 msgid "Connecting to eD2k..."
 msgstr ""
 
-#: src/ExternalConn.cpp:3045
+#: src/ExternalConn.cpp:3057
 msgid "Already connected to Kad."
 msgstr ""
 
-#: src/ExternalConn.cpp:3048
+#: src/ExternalConn.cpp:3060
 msgid "Connecting to Kad..."
 msgstr ""
 
-#: src/ExternalConn.cpp:3055
+#: src/ExternalConn.cpp:3067
 msgid "All networks are disabled."
 msgstr ""
 
-#: src/ExternalConn.cpp:3064
+#: src/ExternalConn.cpp:3076
 msgid "Disconnected from eD2k."
 msgstr ""
 
-#: src/ExternalConn.cpp:3069
+#: src/ExternalConn.cpp:3081
 msgid "Disconnected from Kad."
 msgstr ""
 
-#: src/ExternalConn.cpp:3078
+#: src/ExternalConn.cpp:3090
 #, c-format
 msgid "External Connection: invalid opcode received: %#x"
 msgstr ""
 
-#: src/ExternalConn.cpp:3083
+#: src/ExternalConn.cpp:3095
 msgid "Invalid opcode (wrong protocol version?)"
 msgstr ""
 
@@ -2392,23 +2397,23 @@ msgid ""
 "want downloads on a different (e.g. larger) disk."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:549 src/FirstRunWizard.cpp:611 src/muuli_wdr.cpp:1708
+#: src/FirstRunWizard.cpp:549 src/FirstRunWizard.cpp:611 src/muuli_wdr.cpp:1712
 msgid "Destination folder for downloads"
 msgstr ""
 
 #: src/FirstRunWizard.cpp:553 src/FirstRunWizard.cpp:569 src/muuli_wdr.cpp:1349
-#: src/muuli_wdr.cpp:1366 src/muuli_wdr.cpp:1683 src/muuli_wdr.cpp:1714
-#: src/muuli_wdr.cpp:1726 src/muuli_wdr.cpp:2769
+#: src/muuli_wdr.cpp:1366 src/muuli_wdr.cpp:1687 src/muuli_wdr.cpp:1718
+#: src/muuli_wdr.cpp:1730 src/muuli_wdr.cpp:2800
 #: src/utils/aLinkCreator/src/alcframe.cpp:135
 #: src/utils/wxCas/src/wxcasprefs.cpp:52 src/utils/wxCas/src/wxcasprefs.cpp:118
 msgid "Browse"
 msgstr "Pretrazi :"
 
-#: src/FirstRunWizard.cpp:559 src/muuli_wdr.cpp:1719
+#: src/FirstRunWizard.cpp:559 src/muuli_wdr.cpp:1723
 msgid "(All files in this folder are shared with other peers)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:565 src/FirstRunWizard.cpp:624 src/muuli_wdr.cpp:1721
+#: src/FirstRunWizard.cpp:565 src/FirstRunWizard.cpp:624 src/muuli_wdr.cpp:1725
 msgid "Folder for temporary download files"
 msgstr ""
 
@@ -2439,7 +2444,7 @@ msgstr ""
 msgid "CRITICAL - no client on StartChatSession"
 msgstr ""
 
-#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2675 src/muuli_wdr.cpp:3352
+#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2706 src/muuli_wdr.cpp:3383
 msgid "Friends"
 msgstr "Prijatelji"
 
@@ -2548,8 +2553,8 @@ msgstr "Nijedno"
 msgid "No"
 msgstr "Ne"
 
-#: src/GenericClientListCtrl.cpp:1216 src/PrefsUnifiedDlg.cpp:2818
-#: src/PrefsUnifiedDlg.cpp:2868 src/ServerListCtrl.cpp:276
+#: src/GenericClientListCtrl.cpp:1216 src/PrefsUnifiedDlg.cpp:2898
+#: src/PrefsUnifiedDlg.cpp:2948 src/ServerListCtrl.cpp:276
 msgid "Yes"
 msgstr "Da"
 
@@ -2719,10 +2724,10 @@ msgstr ""
 msgid "Please fill all fields required"
 msgstr ""
 
-#: src/KadDlg.cpp:192 src/PartFile.cpp:1031 src/PrefsUnifiedDlg.cpp:1162
-#: src/PrefsUnifiedDlg.cpp:1331 src/PrefsUnifiedDlg.cpp:1589
-#: src/PrefsUnifiedDlg.cpp:1599 src/PrefsUnifiedDlg.cpp:1616
-#: src/PrefsUnifiedDlg.cpp:1658
+#: src/KadDlg.cpp:192 src/PartFile.cpp:1031 src/PrefsUnifiedDlg.cpp:1134
+#: src/PrefsUnifiedDlg.cpp:1204 src/PrefsUnifiedDlg.cpp:1405
+#: src/PrefsUnifiedDlg.cpp:1663 src/PrefsUnifiedDlg.cpp:1673
+#: src/PrefsUnifiedDlg.cpp:1690 src/PrefsUnifiedDlg.cpp:1738
 msgid "Message"
 msgstr "Poruka"
 
@@ -2826,7 +2831,7 @@ msgstr ""
 msgid "Uploaded"
 msgstr ""
 
-#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3232
+#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3263
 msgid "Requested"
 msgstr ""
 
@@ -2951,7 +2956,7 @@ msgid "WARNING: "
 msgstr "UPOZORENJE: "
 
 #: src/MuleNotebook.cpp:179 src/muuli_wdr.cpp:817 src/muuli_wdr.cpp:1229
-#: src/muuli_wdr.cpp:3136 src/muuli_wdr.cpp:3392
+#: src/muuli_wdr.cpp:3167 src/muuli_wdr.cpp:3423
 msgid "Close"
 msgstr "Zatvori"
 
@@ -2969,7 +2974,7 @@ msgid "Paste"
 msgstr "Staviti"
 
 #: src/MuleTextCtrl.cpp:89 src/muuli_wdr.cpp:358 src/muuli_wdr.cpp:757
-#: src/muuli_wdr.cpp:2359 src/muuli_wdr.cpp:2378 src/muuli_wdr.cpp:2400
+#: src/muuli_wdr.cpp:2390 src/muuli_wdr.cpp:2409 src/muuli_wdr.cpp:2431
 #: src/utils/aLinkCreator/src/alcframe.cpp:142
 msgid "Clear"
 msgstr "Ocisti"
@@ -3068,7 +3073,7 @@ msgstr "Izlaz"
 
 #: src/MuleTrayIcon.cpp:579 src/MuleTrayIcon.cpp:945 src/MuleTrayIcon.cpp:965
 #: src/muuli_wdr.cpp:1398 src/muuli_wdr.cpp:1406 src/muuli_wdr.cpp:1413
-#: src/muuli_wdr.cpp:1842 src/muuli_wdr.cpp:1848 src/OtherFunctions.cpp:91
+#: src/muuli_wdr.cpp:1846 src/muuli_wdr.cpp:1852 src/OtherFunctions.cpp:91
 #: src/StatisticsDlg.cpp:93 src/StatisticsDlg.cpp:95
 msgid "kB/s"
 msgstr "kB/s"
@@ -3309,7 +3314,7 @@ msgstr "Bytes"
 msgid "KB"
 msgstr "KB"
 
-#: src/muuli_wdr.cpp:274 src/muuli_wdr.cpp:293 src/muuli_wdr.cpp:1627
+#: src/muuli_wdr.cpp:274 src/muuli_wdr.cpp:293 src/muuli_wdr.cpp:1631
 #: src/OtherFunctions.cpp:64
 msgid "MB"
 msgstr "MB"
@@ -3326,7 +3331,7 @@ msgstr "Maksimalna velicina"
 msgid "Availability"
 msgstr "Dostupnost"
 
-#: src/muuli_wdr.cpp:312 src/muuli_wdr.cpp:398 src/muuli_wdr.cpp:3297
+#: src/muuli_wdr.cpp:312 src/muuli_wdr.cpp:398 src/muuli_wdr.cpp:3328
 msgid "Filter:"
 msgstr "Filtar:"
 
@@ -3390,12 +3395,12 @@ msgstr "Nadjeni izvori :"
 #: src/muuli_wdr.cpp:1160 src/muuli_wdr.cpp:1167 src/muuli_wdr.cpp:1172
 #: src/muuli_wdr.cpp:1179 src/muuli_wdr.cpp:1184 src/muuli_wdr.cpp:1191
 #: src/muuli_wdr.cpp:1205 src/muuli_wdr.cpp:1212 src/muuli_wdr.cpp:1217
-#: src/muuli_wdr.cpp:1224 src/muuli_wdr.cpp:3234 src/muuli_wdr.cpp:3242
-#: src/muuli_wdr.cpp:3250
+#: src/muuli_wdr.cpp:1224 src/muuli_wdr.cpp:3265 src/muuli_wdr.cpp:3273
+#: src/muuli_wdr.cpp:3281
 msgid "N/A"
 msgstr "N/A"
 
-#: src/muuli_wdr.cpp:508 src/muuli_wdr.cpp:1065 src/PrefsUnifiedDlg.cpp:297
+#: src/muuli_wdr.cpp:508 src/muuli_wdr.cpp:1065 src/PrefsUnifiedDlg.cpp:299
 msgid "General"
 msgstr "Glavni"
 
@@ -3534,7 +3539,7 @@ msgstr ""
 msgid "Album :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:685 src/muuli_wdr.cpp:2254
+#: src/muuli_wdr.cpp:685 src/muuli_wdr.cpp:2285
 msgid "Title :"
 msgstr "Naziv :"
 
@@ -3640,7 +3645,7 @@ msgstr "Ime korisnika :"
 msgid "Userhash :"
 msgstr "Hash korisnika :"
 
-#: src/muuli_wdr.cpp:895 src/muuli_wdr.cpp:1748 src/muuli_wdr.cpp:2449
+#: src/muuli_wdr.cpp:895 src/muuli_wdr.cpp:1752 src/muuli_wdr.cpp:2480
 #: src/utils/aLinkCreator/src/alcframe.cpp:137
 msgid "Add"
 msgstr "Dodaj"
@@ -3649,15 +3654,15 @@ msgstr "Dodaj"
 msgid "Download-Speed"
 msgstr "Brzina downloada"
 
-#: src/muuli_wdr.cpp:954 src/muuli_wdr.cpp:989 src/muuli_wdr.cpp:2553
+#: src/muuli_wdr.cpp:954 src/muuli_wdr.cpp:989 src/muuli_wdr.cpp:2584
 msgid "Current"
 msgstr "Trenutno"
 
-#: src/muuli_wdr.cpp:962 src/muuli_wdr.cpp:997 src/muuli_wdr.cpp:2561
+#: src/muuli_wdr.cpp:962 src/muuli_wdr.cpp:997 src/muuli_wdr.cpp:2592
 msgid "Running average"
 msgstr "Prosjek rada"
 
-#: src/muuli_wdr.cpp:970 src/muuli_wdr.cpp:1005 src/muuli_wdr.cpp:2569
+#: src/muuli_wdr.cpp:970 src/muuli_wdr.cpp:1005 src/muuli_wdr.cpp:2600
 msgid "Session average"
 msgstr "Prosjek misije"
 
@@ -3669,7 +3674,7 @@ msgstr "Brzina uploada"
 msgid "Connections"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1024 src/muuli_wdr.cpp:1867
+#: src/muuli_wdr.cpp:1024 src/muuli_wdr.cpp:1871
 msgid "Active downloads"
 msgstr "Aktivni downloadovi"
 
@@ -3677,7 +3682,7 @@ msgstr "Aktivni downloadovi"
 msgid "Active connections (1:1)"
 msgstr "Aktivne veze (1:1)"
 
-#: src/muuli_wdr.cpp:1040 src/muuli_wdr.cpp:1868
+#: src/muuli_wdr.cpp:1040 src/muuli_wdr.cpp:1872
 msgid "Active uploads"
 msgstr "Aktivni uploadovi"
 
@@ -3951,7 +3956,7 @@ msgstr ""
 msgid "Advanced users only: If you have multiple network interfaces, enter the address of the interface to which aMule should be bound."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1462 src/muuli_wdr.cpp:2061
+#: src/muuli_wdr.cpp:1462 src/muuli_wdr.cpp:2065
 msgid "Bind to network interface (empty for any):"
 msgstr ""
 
@@ -3967,7 +3972,7 @@ msgstr ""
 msgid "Max simultaneous connections:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1498 src/muuli_wdr.cpp:3176
+#: src/muuli_wdr.cpp:1498 src/muuli_wdr.cpp:3207
 msgid "ED2K"
 msgstr "ED2K"
 
@@ -4059,752 +4064,774 @@ msgstr ""
 msgid "For new files preallocates disk space for the whole file, thus reduces fragmentation"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1613
+#: src/muuli_wdr.cpp:1617
 msgid "Create new files as sparse files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1614
-msgid "A sparse file reserves its full size on disk immediately without writing real data to it -- fast, but unsupported or slow on some filesystems, and free-space accounting stays optimistic while the download is in progress. Turn this off to grow the file only as data arrives."
+#: src/muuli_wdr.cpp:1618
+msgid "Sparse part files only occupy disk space for the parts already downloaded, so free space is used up gradually as the file fills in. Turn this off to use an ordinary file instead - useful where sparse files are unsupported or slow, or where backup/de-duplication tools handle them badly. Applies only when the core runs on Windows; on Linux and macOS part files are sparse anyway and this setting has no effect."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1619
+#: src/muuli_wdr.cpp:1623
 msgid "Stop downloads when free disk space reaches "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1620
+#: src/muuli_wdr.cpp:1624
 msgid "Select this if you want aMule to check your disk space"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1624
+#: src/muuli_wdr.cpp:1628
 msgid "Enter here the min disk space desired."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1630
+#: src/muuli_wdr.cpp:1634
 msgid "Save 10 sources on rare files (< 20 sources)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1634 src/Statistics.cpp:790
+#: src/muuli_wdr.cpp:1638 src/Statistics.cpp:790
 msgid "Uploads"
 msgstr "Uploadovi"
 
-#: src/muuli_wdr.cpp:1637
+#: src/muuli_wdr.cpp:1641
 msgid "Add new shared files with auto priority"
 msgstr "Dodaj nove dijeljene fajlove sa auto prioritetom"
 
-#: src/muuli_wdr.cpp:1643
+#: src/muuli_wdr.cpp:1647
 msgid "Intelligent Corruption Handling (I.C.H.)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1646
+#: src/muuli_wdr.cpp:1650
 msgid "Enable"
 msgstr "Omogućiti"
 
-#: src/muuli_wdr.cpp:1649
+#: src/muuli_wdr.cpp:1653
 msgid "Advanced I.C.H. trusts every hash (not recommended)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1661 src/PrefsUnifiedDlg.cpp:1910
+#: src/muuli_wdr.cpp:1665 src/PrefsUnifiedDlg.cpp:1990
 msgid "Media metadata extraction"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1665
+#: src/muuli_wdr.cpp:1669
 msgid "Extract length / bitrate / codec from shared audio and video files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1667
+#: src/muuli_wdr.cpp:1671
 msgid "When enabled, aMule runs ffprobe on each shared media file to fill in the Length / Bitrate / Codec columns other clients see when they find the file in a search. Requires ffmpeg (the ffprobe binary) to be installed."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1674
+#: src/muuli_wdr.cpp:1678
 msgid "Path to ffprobe:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1679
+#: src/muuli_wdr.cpp:1683
 msgid "Full path to the ffprobe binary. Leave empty to have aMule auto-detect it on startup."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1687
+#: src/muuli_wdr.cpp:1691
 msgid "Detect"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1688
+#: src/muuli_wdr.cpp:1692
 msgid "Search the standard install locations for an ffprobe binary and fill the path field."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1712
+#: src/muuli_wdr.cpp:1716
 msgid ""
 "Completed downloads are stored here. All files in this folder are automatically shared with other peers.\n"
 "If this folder also holds files you don't want to share, point it at an aMule-only sub-folder."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1715
+#: src/muuli_wdr.cpp:1719
 msgid "Pick the folder where completed downloads will be stored. All files in that folder will be shared with other peers."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1729
+#: src/muuli_wdr.cpp:1733
 msgid "Shared folders"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1735
+#: src/muuli_wdr.cpp:1739
 msgid "(Folders shared by the core. Enter a path to add one.)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1743
+#: src/muuli_wdr.cpp:1747
 msgid "Absolute path of a folder on the core's machine, e.g. /home/user/shared"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1745 src/PrefsUnifiedDlg.cpp:2794
+#: src/muuli_wdr.cpp:1749 src/PrefsUnifiedDlg.cpp:2874
 msgid "Recursive"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1746
+#: src/muuli_wdr.cpp:1750
 msgid "Share every sub-folder underneath this one, including ones created later."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1750 src/utils/aLinkCreator/src/alcframe.cpp:141
+#: src/muuli_wdr.cpp:1754 src/utils/aLinkCreator/src/alcframe.cpp:141
 msgid "Remove"
 msgstr "Ukloni"
 
-#: src/muuli_wdr.cpp:1754
+#: src/muuli_wdr.cpp:1758
 msgid "(Right click on folder icon for recursive share)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1761
+#: src/muuli_wdr.cpp:1765
 msgid "Share hidden files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1767
+#: src/muuli_wdr.cpp:1771
 msgid "Automatically rescan shared folders for changes"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1773
+#: src/muuli_wdr.cpp:1777
 msgid "Follow symbolic links in shared folders"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1779
+#: src/muuli_wdr.cpp:1783
 msgid "Exclude files matching:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1782
+#: src/muuli_wdr.cpp:1786
 msgid "Wildcard patterns separated by '|', e.g. .DS_Store|Thumbs.db|*.tmp. Files whose name matches are not shared. Matching is case-insensitive."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1786
+#: src/muuli_wdr.cpp:1790
 msgid "Patterns are regular expressions"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1787
+#: src/muuli_wdr.cpp:1791
 msgid "When set, the whole field is one regular expression ('|' is alternation). When unset, it is a list of '|'-separated wildcards."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1797
+#: src/muuli_wdr.cpp:1801
 msgid "Show how many shared files the current pattern would exclude."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1818
+#: src/muuli_wdr.cpp:1822
 msgid "Graphs"
 msgstr "Grafovi"
 
-#: src/muuli_wdr.cpp:1821 src/muuli_wdr.cpp:1883
+#: src/muuli_wdr.cpp:1825 src/muuli_wdr.cpp:1887
 msgid "Update delay : 5 secs"
 msgstr "Obnovi kasnjenje : 5 sekundi"
 
-#: src/muuli_wdr.cpp:1825
+#: src/muuli_wdr.cpp:1829
 msgid "Time for average graph: 100 mins"
 msgstr "Vrijeme za prosjecni graf: 100 minuta"
 
-#: src/muuli_wdr.cpp:1829
+#: src/muuli_wdr.cpp:1833
 msgid "Connections Graph Scale: 100 "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1836
+#: src/muuli_wdr.cpp:1840
 msgid "Download graph scale:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1844
+#: src/muuli_wdr.cpp:1848
 msgid "Upload graph scale:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1854
+#: src/muuli_wdr.cpp:1858
 #, fuzzy
 msgid "Colors: "
 msgstr "Boje: "
 
-#: src/muuli_wdr.cpp:1858
+#: src/muuli_wdr.cpp:1862
 msgid "Background"
 msgstr "Pozadina"
 
-#: src/muuli_wdr.cpp:1859
+#: src/muuli_wdr.cpp:1863
 msgid "Grid"
 msgstr "Mreza"
 
-#: src/muuli_wdr.cpp:1860
+#: src/muuli_wdr.cpp:1864
 msgid "Download current"
 msgstr "Trenutni download"
 
-#: src/muuli_wdr.cpp:1861
+#: src/muuli_wdr.cpp:1865
 msgid "Download running average"
 msgstr "Prosjek tekuceg downloada"
 
-#: src/muuli_wdr.cpp:1862
+#: src/muuli_wdr.cpp:1866
 msgid "Download session average"
 msgstr "Prosjek downloada misije"
 
-#: src/muuli_wdr.cpp:1863
+#: src/muuli_wdr.cpp:1867
 msgid "Upload current"
 msgstr "Trenutni upload"
 
-#: src/muuli_wdr.cpp:1864
+#: src/muuli_wdr.cpp:1868
 msgid "Upload running average"
 msgstr "Prosjek tekuceg uploada"
 
-#: src/muuli_wdr.cpp:1865
+#: src/muuli_wdr.cpp:1869
 msgid "Upload session average"
 msgstr "Prosjek uploada misije"
 
-#: src/muuli_wdr.cpp:1866
+#: src/muuli_wdr.cpp:1870
 msgid "Active connections"
 msgstr "Aktivne veze"
 
-#: src/muuli_wdr.cpp:1869
+#: src/muuli_wdr.cpp:1873
 #, fuzzy
 msgid "Systray Icon Speed Bar"
 msgstr "poluga brzine prikazana u sistemskom koritu"
 
-#: src/muuli_wdr.cpp:1870
+#: src/muuli_wdr.cpp:1874
 msgid "Kad-nodes current"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1871
+#: src/muuli_wdr.cpp:1875
 msgid "Kad-nodes running"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1872
+#: src/muuli_wdr.cpp:1876
 msgid "Kad-nodes session"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1876 src/muuli_wdr.cpp:2303
+#: src/muuli_wdr.cpp:1880 src/muuli_wdr.cpp:2334
 msgid "Select"
 msgstr "Izaberi"
 
-#: src/muuli_wdr.cpp:1880
+#: src/muuli_wdr.cpp:1884
 msgid "Tree"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1890
+#: src/muuli_wdr.cpp:1894
 msgid "Number of Client Versions shown (0=unlimited)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1915
+#: src/muuli_wdr.cpp:1919
 msgid "!!! WARNING !!!"
 msgstr "!!! UPOZORENJE !!!"
 
-#: src/muuli_wdr.cpp:1930
+#: src/muuli_wdr.cpp:1934
 msgid "Max new connections / 5 secs"
 msgstr "Maksimalne veze u / 5 sekundi"
 
-#: src/muuli_wdr.cpp:1932
+#: src/muuli_wdr.cpp:1936
 msgid "Concurrent Kad source lookups"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1934
+#: src/muuli_wdr.cpp:1938
 msgid "Kad source re-search interval (minutes)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1936
+#: src/muuli_wdr.cpp:1940
 #, fuzzy
 msgid "Source re-ask interval (minutes)"
 msgstr "Interval obnavljanja veze servera %i minuta"
 
-#: src/muuli_wdr.cpp:1940
+#: src/muuli_wdr.cpp:1944
 msgid "File Buffer Size: 240000 bytes"
 msgstr "Fajl Buffer velicina: 240000 bytes"
 
-#: src/muuli_wdr.cpp:1944
+#: src/muuli_wdr.cpp:1948
 msgid "Use MMAP: memory-mapped file access (lower memory use)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1945
+#: src/muuli_wdr.cpp:1949
 msgid "Maps part files into memory instead of buffering them on the heap, lowering the process memory footprint. May reduce download speed on some disks; best for memory-constrained or upload-heavy hosts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1947
+#: src/muuli_wdr.cpp:1951
 msgid "Upload Queue Size: 5000 clients"
 msgstr "Duzina reda cekanja: 5000 klienta"
 
-#: src/muuli_wdr.cpp:1951
+#: src/muuli_wdr.cpp:1955
 msgid "Server connection refresh interval: Disable"
 msgstr "Interval obnavljanja veze servera: onemoguceno"
 
-#: src/muuli_wdr.cpp:1955
+#: src/muuli_wdr.cpp:1959
 msgid "Disable computer's timed standby mode"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1974
+#: src/muuli_wdr.cpp:1978
 msgid "Skin to use: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1983
+#: src/muuli_wdr.cpp:1987
 msgid "Show \"Fast eD2k Links Handler\" in every window."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1986
+#: src/muuli_wdr.cpp:1990
 msgid "Show extended info on categories tabs"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1989
+#: src/muuli_wdr.cpp:1993
 #, fuzzy
 msgid "Show application version on title"
 msgstr "Pokazi transfer rate u naslovu"
 
-#: src/muuli_wdr.cpp:1991
+#: src/muuli_wdr.cpp:1995
 msgid "Show transfer rates on title"
 msgstr "Pokazi transfer rate u naslovu"
 
-#: src/muuli_wdr.cpp:1993
+#: src/muuli_wdr.cpp:1997
 msgid "Before application name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1995
+#: src/muuli_wdr.cpp:1999
 msgid "After application name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1998
+#: src/muuli_wdr.cpp:2002
 msgid "Show overhead bandwidth"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2002
+#: src/muuli_wdr.cpp:2006
 msgid "Vertical toolbar orientation"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2004
+#: src/muuli_wdr.cpp:2008
 msgid "Live column sorting (auto-reorder rows as their values change)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2011
+#: src/muuli_wdr.cpp:2015
 msgid "Download Queue Files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2014
+#: src/muuli_wdr.cpp:2018
 msgid "Show progress percentage"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2020
+#: src/muuli_wdr.cpp:2024
 msgid "Show progress bar"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2023
+#: src/muuli_wdr.cpp:2027
 msgid "Flat"
 msgstr "Pljosnata"
 
-#: src/muuli_wdr.cpp:2027
+#: src/muuli_wdr.cpp:2031
 msgid "Round"
 msgstr "Obla"
 
-#: src/muuli_wdr.cpp:2045
+#: src/muuli_wdr.cpp:2049
 msgid "External Connection Parameters"
 msgstr "Parametri za spoljasnju vezu"
 
-#: src/muuli_wdr.cpp:2048
+#: src/muuli_wdr.cpp:2052
 msgid "Accept external connections"
 msgstr "Prihvati spoljasnje veze"
 
-#: src/muuli_wdr.cpp:2055 src/muuli_wdr.cpp:2114
+#: src/muuli_wdr.cpp:2059 src/muuli_wdr.cpp:2118
 msgid "IP of the listening interface:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2058
+#: src/muuli_wdr.cpp:2062
 msgid "Enter here a valid ip in the a.b.c.d format for the listening EC interface. An empty field or 0.0.0.0 will mean any interface."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2079 src/muuli_wdr.cpp:2163
+#: src/muuli_wdr.cpp:2083 src/muuli_wdr.cpp:2194
 msgid "TCP port:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2085
+#: src/muuli_wdr.cpp:2089
 msgid "Enable UPnP port forwarding on the EC port"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2089 src/muuli_wdr.cpp:3048
+#: src/muuli_wdr.cpp:2093 src/muuli_wdr.cpp:3079
 #: src/utils/wxCas/src/wxcasprefs.cpp:167
 msgid "Password"
 msgstr "Lozinka"
 
-#: src/muuli_wdr.cpp:2095
+#: src/muuli_wdr.cpp:2099
 msgid "aMule API server parameters"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2098
+#: src/muuli_wdr.cpp:2102
 msgid "Run amuleapi (REST API) on startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2103
+#: src/muuli_wdr.cpp:2107
 msgid "HTTP port:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2117
+#: src/muuli_wdr.cpp:2121
 msgid "The interface amuleapi's HTTP server listens on. 127.0.0.1 (default) accepts only local connections; use 0.0.0.0 or a specific IP to expose it to other hosts (set an admin password below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2120
+#: src/muuli_wdr.cpp:2126
+msgid "Type a password to set or change it. Stored passwords cannot be shown, so leaving this empty keeps the current one."
+msgstr ""
+
+#: src/muuli_wdr.cpp:2128
 #, fuzzy
 msgid "Admin password"
 msgstr "Lozinka"
 
-#: src/muuli_wdr.cpp:2125 src/muuli_wdr.cpp:2156
-msgid "Low rights password"
-msgstr "Sifra za manje prava"
+#: src/muuli_wdr.cpp:2140 src/muuli_wdr.cpp:2157 src/PrefsUnifiedDlg.cpp:1103
+#, fuzzy
+msgid "A password is set."
+msgstr "Lozinka"
 
-#: src/muuli_wdr.cpp:2133
+#: src/muuli_wdr.cpp:2144
+msgid "Enable guest access"
+msgstr ""
+
+#: src/muuli_wdr.cpp:2145
+msgid "Guest sessions may read status and listings but cannot change anything. Turning this off clears the stored guest password."
+msgstr ""
+
+#: src/muuli_wdr.cpp:2149
+#, fuzzy
+msgid "Guest password"
+msgstr "Sifra za puna prava"
+
+#: src/muuli_wdr.cpp:2164
 msgid "Web server parameters"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2136
+#: src/muuli_wdr.cpp:2167
 msgid "Run webserver on startup (deprecated)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2142
+#: src/muuli_wdr.cpp:2173
 msgid "Web template"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2147
+#: src/muuli_wdr.cpp:2178
 msgid "Full rights password"
 msgstr "Sifra za puna prava"
 
-#: src/muuli_wdr.cpp:2151
+#: src/muuli_wdr.cpp:2182
 msgid "Enable Low rights User"
 msgstr "Odobri korisnicima sa manje prava"
 
-#: src/muuli_wdr.cpp:2170
+#: src/muuli_wdr.cpp:2187
+msgid "Low rights password"
+msgstr "Sifra za manje prava"
+
+#: src/muuli_wdr.cpp:2201
 msgid "Enable UPnP port forwarding of the web server port"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2175
+#: src/muuli_wdr.cpp:2206
 msgid "Web server UPnP TCP port (Optional)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2183
+#: src/muuli_wdr.cpp:2214
 msgid "Page Refresh Time (in secs)"
 msgstr "Vrijeme obnove stranice (u sekundama)"
 
-#: src/muuli_wdr.cpp:2190
+#: src/muuli_wdr.cpp:2221
 msgid "Enable Gzip compression"
 msgstr "Odobri Gzip kompresiju"
 
-#: src/muuli_wdr.cpp:2224
+#: src/muuli_wdr.cpp:2255
 #, fuzzy
 msgid "Reset page to defaults"
 msgstr "Standard sistema"
 
-#: src/muuli_wdr.cpp:2225
+#: src/muuli_wdr.cpp:2256
 msgid "Reset the settings on the current page to their default values."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2227 src/muuli_wdr.cpp:2313 src/ServerWnd.cpp:274
+#: src/muuli_wdr.cpp:2258 src/muuli_wdr.cpp:2344 src/ServerWnd.cpp:274
 #: src/ServerWnd.cpp:282
 msgid "OK"
 msgstr "OK"
 
-#: src/muuli_wdr.cpp:2229
+#: src/muuli_wdr.cpp:2260
 msgid "Click here to apply any changes made to the preferences."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2232
+#: src/muuli_wdr.cpp:2263
 msgid "Reset any changes made to the preferences."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2261
+#: src/muuli_wdr.cpp:2292
 msgid "Comment :"
 msgstr "Komentar:"
 
-#: src/muuli_wdr.cpp:2268
+#: src/muuli_wdr.cpp:2299
 msgid "Incoming Dir :"
 msgstr "Prijemni direktorij :"
 
-#: src/muuli_wdr.cpp:2277
+#: src/muuli_wdr.cpp:2308
 msgid "Change priority for new assigned files :"
 msgstr "Promijeni prioritet za nove fajlove :"
 
-#: src/muuli_wdr.cpp:2281
+#: src/muuli_wdr.cpp:2312
 #, fuzzy
 msgid "Don't change"
 msgstr "Ne mijenjaj"
 
-#: src/muuli_wdr.cpp:2293
+#: src/muuli_wdr.cpp:2324
 msgid "Select color for this Category (currently selected) :"
 msgstr "Izaberi boju za ovu kategoriju (trenutno izabrana) :"
 
-#: src/muuli_wdr.cpp:2360 src/muuli_wdr.cpp:2379 src/muuli_wdr.cpp:2401
+#: src/muuli_wdr.cpp:2391 src/muuli_wdr.cpp:2410 src/muuli_wdr.cpp:2432
 msgid "Click this button to reset the log."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2420
+#: src/muuli_wdr.cpp:2451
 msgid "Click on this button to update the servers list from URL ..."
 msgstr "Klikni ovdje da obnovis listu servera sa URL ..."
 
-#: src/muuli_wdr.cpp:2424
+#: src/muuli_wdr.cpp:2455
 msgid "Server list"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2428
+#: src/muuli_wdr.cpp:2459
 msgid "Enter the url to a server.met file here and press the button to the left to update the list of known servers."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2433
+#: src/muuli_wdr.cpp:2464
 msgid "Add server manually: Name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2436
+#: src/muuli_wdr.cpp:2467
 msgid "Enter the name of the new server here"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2438 src/ServerWnd.cpp:206
+#: src/muuli_wdr.cpp:2469 src/ServerWnd.cpp:206
 msgid "IP:Port"
 msgstr "IP:Port"
 
-#: src/muuli_wdr.cpp:2441
+#: src/muuli_wdr.cpp:2472
 msgid "Enter the IP of the server here, using the x.x.x.x format."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2447
+#: src/muuli_wdr.cpp:2478
 msgid "Enter the port of the server here."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2450
+#: src/muuli_wdr.cpp:2481
 msgid "Add manually a server (fill fields to the left before) ..."
 msgstr "Dodaj servera rucno (prije ispuni polja lijevo) ..."
 
-#: src/muuli_wdr.cpp:2479
+#: src/muuli_wdr.cpp:2510
 msgid "aMule Log"
 msgstr "aMule Log"
 
-#: src/muuli_wdr.cpp:2487
+#: src/muuli_wdr.cpp:2518
 msgid "Server Info"
 msgstr "Lista servera"
 
-#: src/muuli_wdr.cpp:2491
+#: src/muuli_wdr.cpp:2522
 msgid "ED2K Info"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2495
+#: src/muuli_wdr.cpp:2526
 msgid "Kad Info"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2523
+#: src/muuli_wdr.cpp:2554
 msgid "Click on this button to update the nodes list from URL ..."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2527
+#: src/muuli_wdr.cpp:2558
 msgid "Nodes (0)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2531
+#: src/muuli_wdr.cpp:2562
 msgid "Enter the url to a nodes.dat file here and press the button to the left to update the list of known nodes."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2534
+#: src/muuli_wdr.cpp:2565
 msgid "Nodes stats"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2576
+#: src/muuli_wdr.cpp:2607
 msgid "Bootstrap"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2579
+#: src/muuli_wdr.cpp:2610
 msgid "New node"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2584
+#: src/muuli_wdr.cpp:2615
 msgid "IP:"
 msgstr "IP:"
 
-#: src/muuli_wdr.cpp:2604
+#: src/muuli_wdr.cpp:2635
 msgid "Port:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2617
+#: src/muuli_wdr.cpp:2648
 msgid "Bootstrap from known clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2619
+#: src/muuli_wdr.cpp:2650
 msgid "Disconnect Kad"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2653
+#: src/muuli_wdr.cpp:2684
 msgid "Use Secure User Identification"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2655
+#: src/muuli_wdr.cpp:2686
 msgid "It is recommended to enable this option. You will not receive credits if SUI is not enabled."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2657
+#: src/muuli_wdr.cpp:2688
 msgid "Protocol Obfuscation"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2660
+#: src/muuli_wdr.cpp:2691
 msgid "Support Protocol Obfuscation"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2662
+#: src/muuli_wdr.cpp:2693
 msgid "This option enabled Protocol Obfuscation, and makes aMule accept obfuscated connections from other clients."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2664
+#: src/muuli_wdr.cpp:2695
 msgid "Use obfuscation for outgoing connections"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2666
+#: src/muuli_wdr.cpp:2697
 msgid "This option makes aMule use Protocol Obfuscation when connecting other clients/servers."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2668
+#: src/muuli_wdr.cpp:2699
 msgid "Accept only obfuscated connections"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2669
+#: src/muuli_wdr.cpp:2700
 msgid "This option makes aMule only accept obfuscated connections. You will have less sources, but all your traffic will be obfuscated"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2674
+#: src/muuli_wdr.cpp:2705
 msgid "Everybody"
 msgstr "Svi"
 
-#: src/muuli_wdr.cpp:2676
+#: src/muuli_wdr.cpp:2707
 msgid "No one"
 msgstr "Nitko"
 
-#: src/muuli_wdr.cpp:2678
+#: src/muuli_wdr.cpp:2709
 msgid "Who can see my shared files:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2679
+#: src/muuli_wdr.cpp:2710
 msgid "Select who can request to view a list of your shared files."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2681
+#: src/muuli_wdr.cpp:2712
 msgid "IP-Filtering"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2688
+#: src/muuli_wdr.cpp:2719
 msgid "Filter clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2690
+#: src/muuli_wdr.cpp:2721
 msgid "Enable filtering of the client IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2692
+#: src/muuli_wdr.cpp:2723
 msgid "Filter servers"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2694
+#: src/muuli_wdr.cpp:2725
 msgid "Enable filtering of the server IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2698
+#: src/muuli_wdr.cpp:2729
 msgid "Reload List"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2699
+#: src/muuli_wdr.cpp:2730
 msgid "Reload the list of IPs to filter from the file ~/.aMule/ipfilter.dat"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2705
+#: src/muuli_wdr.cpp:2736
 msgid "URL:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2709 src/muuli_wdr.cpp:2902
+#: src/muuli_wdr.cpp:2740 src/muuli_wdr.cpp:2933
 msgid "Update now"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2712
+#: src/muuli_wdr.cpp:2743
 msgid "Auto-update ipfilter at startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2716
+#: src/muuli_wdr.cpp:2747
 msgid "Filtering Level:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2722
+#: src/muuli_wdr.cpp:2753
 msgid "Always filter LAN IPs"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2725
+#: src/muuli_wdr.cpp:2756
 msgid "Paranoid handling of non-matching IPs"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2727
+#: src/muuli_wdr.cpp:2758
 msgid "Rejects a packet when its source IP differs from the IP the client claims (an anti-spoofing check). Disable only if it causes connection problems."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2729
+#: src/muuli_wdr.cpp:2760
 msgid "Use system-wide ipfilter.dat if available"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2730
+#: src/muuli_wdr.cpp:2761
 msgid "If there's no local ipfilter.dat found, allow usage of a system-wide ipfilter file."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2747
+#: src/muuli_wdr.cpp:2778
 msgid "Enable Online-Signature"
 msgstr "Omoguci online potpis"
 
-#: src/muuli_wdr.cpp:2749
+#: src/muuli_wdr.cpp:2780
 msgid "Enables the writing of the OS file, which can be used by external apps to create signatures and the like."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2753
+#: src/muuli_wdr.cpp:2784
 msgid "Update Frequency (Secs):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2756
+#: src/muuli_wdr.cpp:2787
 msgid "Change the frequency (in seconds) of Online Signature updates."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2764
+#: src/muuli_wdr.cpp:2795
 msgid "Save online signature file in: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:2770
+#: src/muuli_wdr.cpp:2801
 msgid "Click here to select the directory containing the the Online Signature files."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2803
+#: src/muuli_wdr.cpp:2834
 msgid "Show country flags for clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2804
+#: src/muuli_wdr.cpp:2835
 msgid "Render the country flag column in the transfers, queue and search views. Requires a valid MMDB GeoIP database (see below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2809
+#: src/muuli_wdr.cpp:2840
 #, fuzzy
 msgid "Database"
 msgstr "Podatak rate :"
 
-#: src/muuli_wdr.cpp:2825
+#: src/muuli_wdr.cpp:2856
 #, fuzzy
 msgid "Source:"
 msgstr "Izvori"
 
-#: src/muuli_wdr.cpp:2828
+#: src/muuli_wdr.cpp:2859
 msgid "DB-IP (free, no account)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2829
+#: src/muuli_wdr.cpp:2860
 msgid "MaxMind GeoLite2 (free, account required)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2830
+#: src/muuli_wdr.cpp:2861
 msgid "Custom URL"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2833
+#: src/muuli_wdr.cpp:2864
 msgid "Choose which provider supplies the GeoIP MMDB database. DB-IP is the default - no account required. MaxMind requires a free account + license key. Use Custom URL to point at any other MMDB host (e.g. a local mirror)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2850
+#: src/muuli_wdr.cpp:2881
 msgid ""
 "No configuration required.\n"
 "\n"
@@ -4812,11 +4839,11 @@ msgid ""
 "License: Creative Commons BY 4.0 - https://creativecommons.org/licenses/by/4.0/"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2863
+#: src/muuli_wdr.cpp:2894
 msgid "License key:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2869
+#: src/muuli_wdr.cpp:2900
 msgid ""
 "Sign up for a free MaxMind account, then generate a License Key:\n"
 "https://www.maxmind.com/en/geolite2/signup\n"
@@ -4826,233 +4853,233 @@ msgid ""
 "Requires attribution and account registration; refresh at least every 30 days."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2884
+#: src/muuli_wdr.cpp:2915
 #, fuzzy
 msgid "Download URL:"
 msgstr "Download"
 
-#: src/muuli_wdr.cpp:2890
+#: src/muuli_wdr.cpp:2921
 msgid ""
 "Must point to an .mmdb file or a .gz / .tar.gz containing one.\n"
 "URL may include credentials (https://user:pass@host/...).\n"
 "License and attribution terms are set by the upstream URL - you are responsible."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2903
+#: src/muuli_wdr.cpp:2934
 msgid "Download the GeoIP database from the selected source."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2905
+#: src/muuli_wdr.cpp:2936
 #, fuzzy
 msgid "Auto-update on startup"
 msgstr "Autospajanje pri startu"
 
-#: src/muuli_wdr.cpp:2906
+#: src/muuli_wdr.cpp:2937
 msgid "Re-download the GeoIP database from the selected source every time aMule starts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2929
+#: src/muuli_wdr.cpp:2960
 msgid "Filter incoming messages (except current chat):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2931
+#: src/muuli_wdr.cpp:2962
 msgid "Filter all messages"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2933
+#: src/muuli_wdr.cpp:2964
 msgid "Filter messages from people not on your friend list"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2935
+#: src/muuli_wdr.cpp:2966
 msgid "Filter messages from unknown clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2937
+#: src/muuli_wdr.cpp:2968
 msgid "Filter messages containing (use ',' as separator):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2940 src/muuli_wdr.cpp:2951
+#: src/muuli_wdr.cpp:2971 src/muuli_wdr.cpp:2982
 msgid "add here the words amule should filter and block messages including it"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2942
+#: src/muuli_wdr.cpp:2973
 msgid "Show received messages in the log"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2945
+#: src/muuli_wdr.cpp:2976
 msgid "Comments"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2948
+#: src/muuli_wdr.cpp:2979
 msgid "Filter comments containing (use ',' as separator):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2973
+#: src/muuli_wdr.cpp:3004
 msgid "Enable Proxy"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2974
+#: src/muuli_wdr.cpp:3005
 msgid "Enable/disable proxy support"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2977
+#: src/muuli_wdr.cpp:3008
 msgid "Proxy type:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2988
+#: src/muuli_wdr.cpp:3019
 msgid "Proxy host:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2991
+#: src/muuli_wdr.cpp:3022
 msgid "The proxy host name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2993
+#: src/muuli_wdr.cpp:3024
 msgid "Proxy port:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2996
+#: src/muuli_wdr.cpp:3027
 msgid "The proxy port"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2998
+#: src/muuli_wdr.cpp:3029
 msgid "Enable authentication"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2999
+#: src/muuli_wdr.cpp:3030
 msgid "Enable/disable username/password authentication"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3002
+#: src/muuli_wdr.cpp:3033
 msgid "Username: "
 msgstr "Korisničko ime:"
 
-#: src/muuli_wdr.cpp:3005
+#: src/muuli_wdr.cpp:3036
 msgid "The username to use to connect to the proxy"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3007
+#: src/muuli_wdr.cpp:3038
 msgid "Password:"
 msgstr "Lozinka:"
 
-#: src/muuli_wdr.cpp:3010
+#: src/muuli_wdr.cpp:3041
 msgid "The password to use to connect to the proxy"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3029
+#: src/muuli_wdr.cpp:3060
 msgid "Connect to:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3038
+#: src/muuli_wdr.cpp:3069
 msgid "Login to remote amule"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3043
+#: src/muuli_wdr.cpp:3074
 msgid "User name"
 msgstr "Korisničko ime"
 
-#: src/muuli_wdr.cpp:3054
+#: src/muuli_wdr.cpp:3085
 msgid "Remember those settings"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3057
+#: src/muuli_wdr.cpp:3088
 #, fuzzy
 msgid "Force ZLIB compression"
 msgstr "Steceno kompresijom :"
 
-#: src/muuli_wdr.cpp:3081
+#: src/muuli_wdr.cpp:3112
 msgid "Enable Verbose Debug-Logging."
 msgstr ""
 
-#: src/muuli_wdr.cpp:3083
+#: src/muuli_wdr.cpp:3114
 #, fuzzy
 msgid "Only to Logfile"
 msgstr "&Otvori fajl"
 
-#: src/muuli_wdr.cpp:3085
+#: src/muuli_wdr.cpp:3116
 msgid "Message Categories:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3109 src/PartFileConvertDlg.cpp:160
+#: src/muuli_wdr.cpp:3140 src/PartFileConvertDlg.cpp:160
 msgid "Waiting..."
 msgstr "Ceka ..."
 
-#: src/muuli_wdr.cpp:3129
+#: src/muuli_wdr.cpp:3160
 msgid "Add imports"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3132
+#: src/muuli_wdr.cpp:3163
 msgid "Retry selected"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3134
+#: src/muuli_wdr.cpp:3165
 msgid "Remove selected"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3197
+#: src/muuli_wdr.cpp:3228
 msgid "Event Types"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3216
+#: src/muuli_wdr.cpp:3247
 msgid "Statistics and queued clients for selected file(s) : Session / All time"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3240
+#: src/muuli_wdr.cpp:3271
 #, fuzzy
 msgid "Active Uploads"
 msgstr "Aktivni uploadovi :"
 
-#: src/muuli_wdr.cpp:3254
+#: src/muuli_wdr.cpp:3285
 #, fuzzy
 msgid "Percent of total files"
 msgstr "Ukupni fajlovi"
 
-#: src/muuli_wdr.cpp:3306
+#: src/muuli_wdr.cpp:3337
 #, fuzzy
 msgid "Show Clients for"
 msgstr "Pokazi liste"
 
-#: src/muuli_wdr.cpp:3308
+#: src/muuli_wdr.cpp:3339
 #, fuzzy
 msgid "All files"
 msgstr "Dijeljeni fajlovi"
 
-#: src/muuli_wdr.cpp:3311
+#: src/muuli_wdr.cpp:3342
 #, fuzzy
 msgid "Selected files"
 msgstr "Izaberi filter za gledanje"
 
-#: src/muuli_wdr.cpp:3314
+#: src/muuli_wdr.cpp:3345
 #, fuzzy
 msgid "Active uploads only"
 msgstr "Aktivni uploadovi"
 
-#: src/muuli_wdr.cpp:3321
+#: src/muuli_wdr.cpp:3352
 #, fuzzy
 msgid "Reload:"
 msgstr "Ponovno ucitati"
 
-#: src/muuli_wdr.cpp:3325
+#: src/muuli_wdr.cpp:3356
 msgid "Reload your shared files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3388
+#: src/muuli_wdr.cpp:3419
 msgid "Send"
 msgstr "Posalji"
 
-#: src/muuli_wdr.cpp:3389
+#: src/muuli_wdr.cpp:3420
 msgid "Sends the specified message."
 msgstr ""
 
-#: src/muuli_wdr.cpp:3393
+#: src/muuli_wdr.cpp:3424
 msgid "Close this chat-session."
 msgstr ""
 
-#: src/muuli_wdr.cpp:3416
+#: src/muuli_wdr.cpp:3447
 msgid "Connect to any server and/or Kad"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3422 src/SharedFilesCtrl.cpp:142 src/Statistics.cpp:941
+#: src/muuli_wdr.cpp:3453 src/SharedFilesCtrl.cpp:142 src/Statistics.cpp:941
 msgid "Shared Files"
 msgstr "Dijeljeni fajlovi"
 
@@ -5418,264 +5445,264 @@ msgstr ""
 msgid "ERROR: Failed to open partfile '%s'"
 msgstr ""
 
-#: src/Preferences.cpp:674
+#: src/Preferences.cpp:701
 msgid "System default"
 msgstr "Standard sistema"
 
-#: src/Preferences.cpp:675
+#: src/Preferences.cpp:702
 msgid "Albanian"
 msgstr "Albanski"
 
-#: src/Preferences.cpp:676
+#: src/Preferences.cpp:703
 msgid "Arabic"
 msgstr "Arapski"
 
-#: src/Preferences.cpp:677
+#: src/Preferences.cpp:704
 msgid "Asturian"
 msgstr "Asturleonski"
 
-#: src/Preferences.cpp:678
+#: src/Preferences.cpp:705
 msgid "Basque"
 msgstr "Baskijski"
 
-#: src/Preferences.cpp:679
+#: src/Preferences.cpp:706
 msgid "Bulgarian"
 msgstr "Bugarski"
 
-#: src/Preferences.cpp:680
+#: src/Preferences.cpp:707
 msgid "Catalan"
 msgstr "Katalonski"
 
-#: src/Preferences.cpp:681
+#: src/Preferences.cpp:708
 msgid "Chinese (Simplified)"
 msgstr "Kineski"
 
-#: src/Preferences.cpp:682
+#: src/Preferences.cpp:709
 msgid "Chinese (Traditional)"
 msgstr "Kinesko (tradicionalno)"
 
-#: src/Preferences.cpp:683
+#: src/Preferences.cpp:710
 msgid "Croatian"
 msgstr "Hrvatski"
 
-#: src/Preferences.cpp:684
+#: src/Preferences.cpp:711
 msgid "Czech"
 msgstr "Češki"
 
-#: src/Preferences.cpp:685
+#: src/Preferences.cpp:712
 msgid "Danish"
 msgstr "Danski"
 
-#: src/Preferences.cpp:686
+#: src/Preferences.cpp:713
 msgid "Dutch"
 msgstr "Nizozemski"
 
-#: src/Preferences.cpp:687
+#: src/Preferences.cpp:714
 msgid "English (U.K.)"
 msgstr "Engleski (U.K.)"
 
-#: src/Preferences.cpp:688
+#: src/Preferences.cpp:715
 #, fuzzy
 msgid "English (U.S.)"
 msgstr "Engleski (U.K.)"
 
-#: src/Preferences.cpp:689
+#: src/Preferences.cpp:716
 msgid "Estonian"
 msgstr "Estonski"
 
-#: src/Preferences.cpp:690
+#: src/Preferences.cpp:717
 msgid "Finnish"
 msgstr "Finski"
 
-#: src/Preferences.cpp:691
+#: src/Preferences.cpp:718
 msgid "French"
 msgstr "Francuski"
 
-#: src/Preferences.cpp:692
+#: src/Preferences.cpp:719
 msgid "Galician"
 msgstr "Galješki"
 
-#: src/Preferences.cpp:693
+#: src/Preferences.cpp:720
 msgid "German"
 msgstr "Njemački"
 
-#: src/Preferences.cpp:694
+#: src/Preferences.cpp:721
 msgid "Greek"
 msgstr "Grčki"
 
-#: src/Preferences.cpp:695
+#: src/Preferences.cpp:722
 msgid "Hebrew"
 msgstr "Hebrejski"
 
-#: src/Preferences.cpp:696
+#: src/Preferences.cpp:723
 msgid "Hungarian"
 msgstr "Mađarski"
 
-#: src/Preferences.cpp:697
+#: src/Preferences.cpp:724
 msgid "Italian"
 msgstr "Talijanski"
 
-#: src/Preferences.cpp:698
+#: src/Preferences.cpp:725
 msgid "Japanese"
 msgstr "Japanski"
 
-#: src/Preferences.cpp:699
+#: src/Preferences.cpp:726
 msgid "Korean"
 msgstr "Korejski"
 
-#: src/Preferences.cpp:700
+#: src/Preferences.cpp:727
 msgid "Latvian"
 msgstr ""
 
-#: src/Preferences.cpp:701
+#: src/Preferences.cpp:728
 msgid "Lithuanian"
 msgstr "Litavski"
 
-#: src/Preferences.cpp:702
+#: src/Preferences.cpp:729
 msgid "Norwegian (Nynorsk)"
 msgstr "Norveški (Nynorsk)"
 
-#: src/Preferences.cpp:703
+#: src/Preferences.cpp:730
 msgid "Polish"
 msgstr "Poljski"
 
-#: src/Preferences.cpp:704
+#: src/Preferences.cpp:731
 msgid "Portuguese"
 msgstr "Portugalski"
 
-#: src/Preferences.cpp:705
+#: src/Preferences.cpp:732
 msgid "Portuguese (Brazilian)"
 msgstr "Portugalski (Brazil)"
 
-#: src/Preferences.cpp:706
+#: src/Preferences.cpp:733
 msgid "Romanian"
 msgstr "Rumunjski"
 
-#: src/Preferences.cpp:707
+#: src/Preferences.cpp:734
 msgid "Russian"
 msgstr "Ruski"
 
-#: src/Preferences.cpp:708
+#: src/Preferences.cpp:735
 msgid "Slovenian"
 msgstr "Slovenski"
 
-#: src/Preferences.cpp:709
+#: src/Preferences.cpp:736
 msgid "Spanish"
 msgstr "Španjolski"
 
-#: src/Preferences.cpp:710
+#: src/Preferences.cpp:737
 msgid "Swedish"
 msgstr "Švedski"
 
-#: src/Preferences.cpp:711
+#: src/Preferences.cpp:738
 msgid "Turkish"
 msgstr "Turski"
 
-#: src/Preferences.cpp:712
+#: src/Preferences.cpp:739
 msgid "Ukrainian"
 msgstr "Ukrajinski"
 
-#: src/Preferences.cpp:815
+#: src/Preferences.cpp:842
 msgid "Change Language"
 msgstr "Promijeniti jezik"
 
-#: src/Preferences.cpp:879
+#: src/Preferences.cpp:906
 msgid "There are no translations installed for aMule"
 msgstr ""
 
-#: src/Preferences.cpp:880
+#: src/Preferences.cpp:907
 msgid "No languages available"
 msgstr "Nema dostupnih jezika"
 
-#: src/Preferences.cpp:1011
+#: src/Preferences.cpp:1038
 msgid "no options available"
 msgstr ""
 
-#: src/Preferences.cpp:2182
+#: src/Preferences.cpp:2227
 msgid "Invalid category found, skipping"
 msgstr ""
 
-#: src/Preferences.cpp:2351
+#: src/Preferences.cpp:2396
 msgid "TCP port can't be higher than 65532 due to server UDP socket being TCP+3"
 msgstr ""
 
-#: src/Preferences.cpp:2352
+#: src/Preferences.cpp:2397
 #, c-format
 msgid "Default port will be used (%d)"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:298 src/Statistics.cpp:866
+#: src/PrefsUnifiedDlg.cpp:300 src/Statistics.cpp:866
 msgid "Connection"
 msgstr "Veza"
 
-#: src/PrefsUnifiedDlg.cpp:299 src/SearchListCtrl.cpp:117
+#: src/PrefsUnifiedDlg.cpp:301 src/SearchListCtrl.cpp:117
 msgid "Directories"
 msgstr "Direktoriji"
 
-#: src/PrefsUnifiedDlg.cpp:300 src/Statistics.cpp:917
+#: src/PrefsUnifiedDlg.cpp:302 src/Statistics.cpp:917
 msgid "Servers"
 msgstr "Serveri"
 
-#: src/PrefsUnifiedDlg.cpp:301 src/ServerListCtrl.cpp:96
+#: src/PrefsUnifiedDlg.cpp:303 src/ServerListCtrl.cpp:96
 msgid "Files"
 msgstr "Fajlovi"
 
-#: src/PrefsUnifiedDlg.cpp:302
+#: src/PrefsUnifiedDlg.cpp:304
 msgid "Security"
 msgstr "Sigurnost"
 
-#: src/PrefsUnifiedDlg.cpp:303
+#: src/PrefsUnifiedDlg.cpp:305
 msgid "Interface"
 msgstr "Sučelje"
 
-#: src/PrefsUnifiedDlg.cpp:310
+#: src/PrefsUnifiedDlg.cpp:312
 msgid "IP2Country"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:313
+#: src/PrefsUnifiedDlg.cpp:315
 msgid "Proxy"
 msgstr "Proxy"
 
-#: src/PrefsUnifiedDlg.cpp:314
+#: src/PrefsUnifiedDlg.cpp:316
 msgid "Filters"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:315
+#: src/PrefsUnifiedDlg.cpp:317
 msgid "Remote Controls"
 msgstr "Daljinsko upravljanje"
 
-#: src/PrefsUnifiedDlg.cpp:316
+#: src/PrefsUnifiedDlg.cpp:318
 msgid "Online Signature"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:317
+#: src/PrefsUnifiedDlg.cpp:319
 msgid "Advanced"
 msgstr "Napredno"
 
-#: src/PrefsUnifiedDlg.cpp:318
+#: src/PrefsUnifiedDlg.cpp:320
 msgid "Events"
 msgstr "Događaji"
 
-#: src/PrefsUnifiedDlg.cpp:321
+#: src/PrefsUnifiedDlg.cpp:323
 msgid "Debugging"
 msgstr "Debugiranje"
 
-#: src/PrefsUnifiedDlg.cpp:451
+#: src/PrefsUnifiedDlg.cpp:453
 msgid ""
 "The following variables will be substituted:\n"
 "    %PARTFILE - full path to the file\n"
 "    %PARTNAME - file name only"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:472
+#: src/PrefsUnifiedDlg.cpp:474
 msgid "Tray icon support requires libayatana-appindicator3 at compile time."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:488
+#: src/PrefsUnifiedDlg.cpp:490
 msgid "Not available on Wayland: the protocol does not report when a window is minimized, so this option cannot intercept the system minimize button. Workaround: launch aMule with `GDK_BACKEND=x11` to use XWayland instead."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:534
+#: src/PrefsUnifiedDlg.cpp:536
 msgid ""
 "Do not change these setting unless you know\n"
 "what you are doing, otherwise you can easily\n"
@@ -5691,206 +5718,220 @@ msgstr ""
 "aMule ce raditi dobro iako ne promijenis\n"
 "nista od ovih opcija."
 
-#: src/PrefsUnifiedDlg.cpp:645
+#: src/PrefsUnifiedDlg.cpp:647
 #, c-format
 msgid "Failed to connect Cfg to widget with the ID %d and key %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:693
+#: src/PrefsUnifiedDlg.cpp:695
 #, c-format
 msgid "Failed to transfer data from Cfg to Widget with the ID %d and key %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:799
+#: src/PrefsUnifiedDlg.cpp:801
 msgid "The type of proxy you are connecting to"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1003
+#: src/PrefsUnifiedDlg.cpp:1020
 #, c-format
 msgid "Failed to transfer data from Widget to Cfg with the ID %d and key %s"
 msgstr ""
 
 #: src/PrefsUnifiedDlg.cpp:1103
+#, fuzzy
+msgid "No password set."
+msgstr "Lozinka"
+
+#: src/PrefsUnifiedDlg.cpp:1132
+msgid "Guest access needs a password. Type one in the guest password field, or untick Enable guest access."
+msgstr ""
+
+#: src/PrefsUnifiedDlg.cpp:1144
 msgid ""
 "aMule must be restarted to enable these changes:\n"
 "\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1110
+#: src/PrefsUnifiedDlg.cpp:1151
 msgid "- TCP port changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1115
+#: src/PrefsUnifiedDlg.cpp:1156
 msgid "- UDP port changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1120
+#: src/PrefsUnifiedDlg.cpp:1161
 #, fuzzy
 msgid "- Network interface binding changed.\n"
 msgstr "Parametri za spoljasnju vezu"
 
-#: src/PrefsUnifiedDlg.cpp:1125
+#: src/PrefsUnifiedDlg.cpp:1166
 #, fuzzy
 msgid "- External connect port changed.\n"
 msgstr "Parametri za spoljasnju vezu"
 
-#: src/PrefsUnifiedDlg.cpp:1129
+#: src/PrefsUnifiedDlg.cpp:1170
 #, fuzzy
 msgid "- External connect acceptance changed.\n"
 msgstr "Parametri za spoljasnju vezu"
 
-#: src/PrefsUnifiedDlg.cpp:1133
+#: src/PrefsUnifiedDlg.cpp:1174
 #, fuzzy
 msgid "- External connect interface changed.\n"
 msgstr "Parametri za spoljasnju vezu"
 
-#: src/PrefsUnifiedDlg.cpp:1137
+#: src/PrefsUnifiedDlg.cpp:1178
 #, fuzzy
 msgid "- Protocol obfuscation support changed.\n"
 msgstr "Parametri za spoljasnju vezu"
 
-#: src/PrefsUnifiedDlg.cpp:1151
+#: src/PrefsUnifiedDlg.cpp:1193
 msgid "- amuleapi settings changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1160
+#: src/PrefsUnifiedDlg.cpp:1202
 msgid ""
 "Your Auto-update server list is empty.\n"
 "'Auto-update server list at startup' will be disabled."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1171
+#: src/PrefsUnifiedDlg.cpp:1213
 msgid ""
 "You have enabled external connections but have not specified a password.\n"
 "External connections cannot be enabled unless a valid password is specified."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1202
+#: src/PrefsUnifiedDlg.cpp:1246
+#, c-format
+msgid "The amuleapi password could not be saved: %s"
+msgstr ""
+
+#: src/PrefsUnifiedDlg.cpp:1276
 msgid "- Language changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1207
+#: src/PrefsUnifiedDlg.cpp:1281
 msgid "- Temp folder changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1212
+#: src/PrefsUnifiedDlg.cpp:1286
 msgid "- ED2K network enabled.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1245
+#: src/PrefsUnifiedDlg.cpp:1319
 msgid "The shared-file exclusion pattern is not a valid regular expression. The filter has been left disabled."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1247 src/PrefsUnifiedDlg.cpp:1841
+#: src/PrefsUnifiedDlg.cpp:1321 src/PrefsUnifiedDlg.cpp:1921
 msgid "Invalid regular expression"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1324
+#: src/PrefsUnifiedDlg.cpp:1398
 msgid ""
 "Both eD2k and Kad network are disabled.\n"
 "You won't be able to connect until you enable at least one of them."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1329
+#: src/PrefsUnifiedDlg.cpp:1403
 msgid ""
 "Kad will not start if your UDP port is disabled.\n"
 "Enable UDP port or disable Kad."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1385
+#: src/PrefsUnifiedDlg.cpp:1459
 msgid ""
 "\n"
 "You MUST restart aMule now.\n"
 "If you do not restart now, don't complain if anything bad happens.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1450
+#: src/PrefsUnifiedDlg.cpp:1524
 msgid "Could not register aMule for autostart at login. The autostart store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1452
+#: src/PrefsUnifiedDlg.cpp:1526
 msgid "Could not remove the autostart-at-login entry."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1453
+#: src/PrefsUnifiedDlg.cpp:1527
 #, fuzzy
 msgid "Autostart"
 msgstr "Automatski"
 
-#: src/PrefsUnifiedDlg.cpp:1468
+#: src/PrefsUnifiedDlg.cpp:1542
 msgid "Register file type"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1468
+#: src/PrefsUnifiedDlg.cpp:1542
 msgid "Register URL handler"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1476
+#: src/PrefsUnifiedDlg.cpp:1550
 #, c-format
 msgid "aMule only handles eD2k-compatible magnets. If you replace the current magnet handler (%s), BitTorrent magnet links will stop working - aMule cannot download BitTorrent content. Continue?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1481
+#: src/PrefsUnifiedDlg.cpp:1555
 #, c-format
 msgid "Another application currently opens .emulecollection files (%s). Replace it with aMule?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1486
+#: src/PrefsUnifiedDlg.cpp:1560
 #, c-format
 msgid "Another application is currently the default handler for these links (%s). Replace it with aMule?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1511
+#: src/PrefsUnifiedDlg.cpp:1585
 msgid "Could not register aMule for .emulecollection files. The registration store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1513
+#: src/PrefsUnifiedDlg.cpp:1587
 #, fuzzy
 msgid "Could not remove the file type registration."
 msgstr "Vec pokusavate downloadovati fajl %s"
 
-#: src/PrefsUnifiedDlg.cpp:1515
+#: src/PrefsUnifiedDlg.cpp:1589
 msgid "Could not register aMule as the URL handler. The registration store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1517
+#: src/PrefsUnifiedDlg.cpp:1591
 msgid "Could not remove the URL handler registration."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1587 src/PrefsUnifiedDlg.cpp:1614
+#: src/PrefsUnifiedDlg.cpp:1661 src/PrefsUnifiedDlg.cpp:1688
 #, fuzzy
 msgid "The web server and aMule API require external connections to be enabled."
 msgstr "Nova vanjska veza prihvacena\n"
 
-#: src/PrefsUnifiedDlg.cpp:1597
+#: src/PrefsUnifiedDlg.cpp:1671
 msgid "The aMule web server is deprecated. Consider running the aMule API instead."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1655
+#: src/PrefsUnifiedDlg.cpp:1735
 msgid ""
 "Your Auto-update servers list is in blank.\n"
 "Please fill in at least one URL to point to a valid server.met file.\n"
 "Click on the button \"List\" by this checkbox to enter an URL."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1796
+#: src/PrefsUnifiedDlg.cpp:1876
 msgid "Temporary files"
 msgstr "Privremene datoteke"
 
-#: src/PrefsUnifiedDlg.cpp:1801
+#: src/PrefsUnifiedDlg.cpp:1881
 msgid "Incoming files"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1806
+#: src/PrefsUnifiedDlg.cpp:1886
 msgid "Online Signatures"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1819
+#: src/PrefsUnifiedDlg.cpp:1899
 #, c-format
 msgid "Choose a folder for %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1843
+#: src/PrefsUnifiedDlg.cpp:1923
 #, fuzzy, c-format
 msgid "Would exclude %u of %u shared file"
 msgid_plural "Would exclude %u of %u shared files"
@@ -5898,41 +5939,41 @@ msgstr[0] "Pronadjeno %i poznatih dijeljenih fajlova"
 msgstr[1] "Pronadjeno %i poznatih dijeljenih fajlova"
 msgstr[2] ""
 
-#: src/PrefsUnifiedDlg.cpp:1860
+#: src/PrefsUnifiedDlg.cpp:1940
 msgid "Browse for videoplayer"
 msgstr "Potrazi videoplejer"
 
-#: src/PrefsUnifiedDlg.cpp:1864
+#: src/PrefsUnifiedDlg.cpp:1944
 msgid "Select browser"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1868
+#: src/PrefsUnifiedDlg.cpp:1948
 msgid "Select ffprobe binary"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1874
+#: src/PrefsUnifiedDlg.cpp:1954
 #, c-format
 msgid "Executable%s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1908
+#: src/PrefsUnifiedDlg.cpp:1988
 msgid "ffprobe not found on PATH or in the standard install locations. Install ffmpeg (which ships ffprobe) or use Browse to pick a binary manually."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1920
+#: src/PrefsUnifiedDlg.cpp:2000
 msgid "Reset the settings on this page to their default values?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1921
+#: src/PrefsUnifiedDlg.cpp:2001
 #, fuzzy
 msgid "Reset to defaults"
 msgstr "Standard sistema"
 
-#: src/PrefsUnifiedDlg.cpp:1948
+#: src/PrefsUnifiedDlg.cpp:2028
 msgid "Edit server list"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1949
+#: src/PrefsUnifiedDlg.cpp:2029
 msgid ""
 "Add here URL's to download server.met files.\n"
 "Only one url on each line."
@@ -5940,41 +5981,41 @@ msgstr ""
 "Dodaj ovdje URLs da dobijes server.met fajlove. \n"
 "Samo jedna URL po liniji."
 
-#: src/PrefsUnifiedDlg.cpp:2004
+#: src/PrefsUnifiedDlg.cpp:2084
 msgid "IP2Country update failed"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2149 src/PrefsUnifiedDlg.cpp:2180
+#: src/PrefsUnifiedDlg.cpp:2229 src/PrefsUnifiedDlg.cpp:2260
 msgid "Data by MaxMind GeoLite2"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2151 src/PrefsUnifiedDlg.cpp:2182
+#: src/PrefsUnifiedDlg.cpp:2231 src/PrefsUnifiedDlg.cpp:2262
 msgid "Custom source"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2153 src/PrefsUnifiedDlg.cpp:2184
+#: src/PrefsUnifiedDlg.cpp:2233 src/PrefsUnifiedDlg.cpp:2264
 msgid "Data by DB-IP.com"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2204
+#: src/PrefsUnifiedDlg.cpp:2284
 #, c-format
 msgid "Status: Loaded%s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2206
+#: src/PrefsUnifiedDlg.cpp:2286
 #, c-format
 msgid "Status: Loaded%s - %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2210
+#: src/PrefsUnifiedDlg.cpp:2290
 msgid "Status: Failed to load - click 'Update now' to refresh."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2212
+#: src/PrefsUnifiedDlg.cpp:2292
 msgid "Status: Not found - click 'Update now' to download."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2270 src/PrefsUnifiedDlg.cpp:2294
+#: src/PrefsUnifiedDlg.cpp:2350 src/PrefsUnifiedDlg.cpp:2374
 #, fuzzy, c-format
 msgid "Update delay: %d second"
 msgid_plural "Update delay: %d seconds"
@@ -5982,7 +6023,7 @@ msgstr[0] "Obnovi kasnjenje : 5 sekundi"
 msgstr[1] "Obnovi kasnjenje : 5 sekundi"
 msgstr[2] ""
 
-#: src/PrefsUnifiedDlg.cpp:2278
+#: src/PrefsUnifiedDlg.cpp:2358
 #, fuzzy, c-format
 msgid "Time for average graph: %d minute"
 msgid_plural "Time for average graph: %d minutes"
@@ -5990,12 +6031,12 @@ msgstr[0] "Vrijeme za prosjecni graf: 100 minuta"
 msgstr[1] "Vrijeme za prosjecni graf: 100 minuta"
 msgstr[2] ""
 
-#: src/PrefsUnifiedDlg.cpp:2287
+#: src/PrefsUnifiedDlg.cpp:2367
 #, c-format
 msgid "Connections Graph Scale: %d"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2302
+#: src/PrefsUnifiedDlg.cpp:2382
 #, fuzzy, c-format
 msgid "File Buffer Size: %d byte"
 msgid_plural "File Buffer Size: %d bytes"
@@ -6003,7 +6044,7 @@ msgstr[0] "Velicina fajl buffera %i bytes"
 msgstr[1] "Velicina fajl buffera %i bytes"
 msgstr[2] ""
 
-#: src/PrefsUnifiedDlg.cpp:2312
+#: src/PrefsUnifiedDlg.cpp:2392
 #, fuzzy, c-format
 msgid "Upload Queue Size: %d client"
 msgid_plural "Upload Queue Size: %d clients"
@@ -6011,7 +6052,7 @@ msgstr[0] "Duzina liste cekanja %i klienata"
 msgstr[1] "Duzina liste cekanja %i klienata"
 msgstr[2] ""
 
-#: src/PrefsUnifiedDlg.cpp:2322
+#: src/PrefsUnifiedDlg.cpp:2402
 #, fuzzy, c-format
 msgid "Server connection refresh interval: %d minute"
 msgid_plural "Server connection refresh interval: %d minutes"
@@ -6019,78 +6060,78 @@ msgstr[0] "Interval obnavljanja veze servera %i minuta"
 msgstr[1] "Interval obnavljanja veze servera %i minuta"
 msgstr[2] ""
 
-#: src/PrefsUnifiedDlg.cpp:2327
+#: src/PrefsUnifiedDlg.cpp:2407
 msgid "Server connection refresh interval: Disabled"
 msgstr "Interval obnavljanja veze servera: onemoguceno"
 
-#: src/PrefsUnifiedDlg.cpp:2371
+#: src/PrefsUnifiedDlg.cpp:2451
 #, fuzzy
 msgid "disabled"
 msgstr "onemoguci"
 
-#: src/PrefsUnifiedDlg.cpp:2397
+#: src/PrefsUnifiedDlg.cpp:2477
 #, c-format
 msgid "Execute command on '%s' event"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2404
+#: src/PrefsUnifiedDlg.cpp:2484
 msgid "Enable command execution on core"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2416
+#: src/PrefsUnifiedDlg.cpp:2496
 msgid "Core command:"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2432
+#: src/PrefsUnifiedDlg.cpp:2512
 msgid "Enable command execution on GUI"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2444
+#: src/PrefsUnifiedDlg.cpp:2524
 msgid "GUI command:"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2460
+#: src/PrefsUnifiedDlg.cpp:2540
 msgid "The following variables will be replaced:"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2628
+#: src/PrefsUnifiedDlg.cpp:2708
 msgid ""
 "The following folders look like system or sensitive locations:\n"
 "\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2633
+#: src/PrefsUnifiedDlg.cpp:2713
 msgid "Sharing them recursively will publish every file underneath on the eD2k/Kad networks. Do you really want to do this?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2636
+#: src/PrefsUnifiedDlg.cpp:2716
 msgid "Confirm shared folders"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2664
+#: src/PrefsUnifiedDlg.cpp:2744
 #, fuzzy
 msgid "Reloading shared files..."
 msgstr "Pronadjeno %i poznatih dijeljenih fajlova"
 
-#: src/PrefsUnifiedDlg.cpp:2665
+#: src/PrefsUnifiedDlg.cpp:2745
 msgid "Scanning for subdirectories..."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2666
+#: src/PrefsUnifiedDlg.cpp:2746
 msgid "Updating shared folders"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2693
+#: src/PrefsUnifiedDlg.cpp:2773
 #, c-format
 msgid "Scanned %u directories..."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2743
+#: src/PrefsUnifiedDlg.cpp:2823
 #, c-format
 msgid "Reloading shared files: %u files scanned"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2793
+#: src/PrefsUnifiedDlg.cpp:2873
 #, fuzzy
 msgid "Shared folder"
 msgstr "Dijeljeni fajlovi"

--- a/po/hr.po
+++ b/po/hr.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-28 08:06+0200\n"
+"POT-Creation-Date: 2026-07-28 10:19+0200\n"
 "PO-Revision-Date: 2026-07-27 11:39+0000\n"
 "Last-Translator: Sebastiano Pistore <sebastiano.pistore.info@aol.com>\n"
 "Language-Team: https://github.com/amule-org/amule <forum@aMule.org>\n"
@@ -138,7 +138,7 @@ msgstr ""
 msgid "Not now"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:422 src/amuleDlg.cpp:600
+#: src/AppImageIntegration.cpp:422 src/amuleDlg.cpp:665
 msgid "Don't ask again"
 msgstr ""
 
@@ -212,7 +212,7 @@ msgid "Killing amuleweb instance with pid '%d' ... "
 msgstr ""
 
 #: src/amule.cpp:336 src/amule.cpp:349 src/ClientRef.cpp:180
-#: src/SearchDlg.cpp:880 src/ServerListCtrl.cpp:98
+#: src/SearchDlg.cpp:1041 src/ServerListCtrl.cpp:98
 msgid "Failed"
 msgstr "Neuspjesno"
 
@@ -558,30 +558,68 @@ msgstr ""
 msgid "ERROR: %s"
 msgstr "POGREŠKA: %s"
 
-#: src/amuleDlg.cpp:236
+#: src/amuleDlg.cpp:250
 #, c-format
 msgid "This is aMule %s based on eMule."
 msgstr ""
 
-#: src/amuleDlg.cpp:237
+#: src/amuleDlg.cpp:251
 #, c-format
 msgid "Running on %s"
 msgstr ""
 
-#: src/amuleDlg.cpp:239
+#: src/amuleDlg.cpp:253
 msgid "Visit https://github.com/amule-org/amule/releases/latest to check if a new version is available."
 msgstr ""
 
-#: src/amuleDlg.cpp:268
+#: src/amuleDlg.cpp:282
 msgid "FATAL ERROR: Failed to create Timer"
 msgstr ""
 
-#: src/amuleDlg.cpp:592
+#: src/amuleDlg.cpp:361 src/amuleDlg.cpp:1787 src/amuleDlg.cpp:2033
+#: src/muuli_wdr.cpp:1492 src/muuli_wdr.cpp:3418
+msgid "Networks"
+msgstr ""
+
+#: src/amuleDlg.cpp:362 src/amuleDlg.cpp:1793 src/muuli_wdr.cpp:3419
+msgid "Searches"
+msgstr "Pretrage"
+
+#: src/amuleDlg.cpp:363 src/amuleDlg.cpp:1799 src/DownloadListCtrl.cpp:740
+#: src/muuli_wdr.cpp:392 src/muuli_wdr.cpp:1585 src/muuli_wdr.cpp:3420
+#: src/Statistics.cpp:829
+msgid "Downloads"
+msgstr "Downloads"
+
+#: src/amuleDlg.cpp:364 src/amuleDlg.cpp:1805 src/muuli_wdr.cpp:3294
+msgid "Shared files"
+msgstr ""
+
+#: src/amuleDlg.cpp:365 src/amuleDlg.cpp:1811 src/muuli_wdr.cpp:2926
+#: src/muuli_wdr.cpp:3376 src/muuli_wdr.cpp:3423
+msgid "Messages"
+msgstr "Poruke"
+
+#: src/amuleDlg.cpp:366 src/amuleDlg.cpp:1817 src/muuli_wdr.cpp:3424
+#: src/PrefsUnifiedDlg.cpp:312 src/Statistics.cpp:779 src/Statistics.cpp:1235
+msgid "Statistics"
+msgstr "Statistike"
+
+#: src/amuleDlg.cpp:368 src/amuleDlg.cpp:1824 src/muuli_wdr.cpp:3426
+#: src/PrefsUnifiedDlg.cpp:328 src/utils/wxCas/src/wxcasprefs.cpp:39
+msgid "Preferences"
+msgstr "Opcije"
+
+#: src/amuleDlg.cpp:371
+msgid "Navigate"
+msgstr ""
+
+#: src/amuleDlg.cpp:657
 #, fuzzy
 msgid "New version available"
 msgstr "Nije dostupno"
 
-#: src/amuleDlg.cpp:596
+#: src/amuleDlg.cpp:661
 #, c-format
 msgid ""
 "A new version of aMule (%s) is available.\n"
@@ -591,223 +629,190 @@ msgid ""
 "Would you like to open the download page?"
 msgstr ""
 
-#: src/amuleDlg.cpp:678
+#: src/amuleDlg.cpp:743
 msgid "aMule dialog destroyed"
 msgstr ""
 
-#: src/amuleDlg.cpp:701 src/DataToText.cpp:68 src/IPFilter.cpp:547
+#: src/amuleDlg.cpp:766 src/DataToText.cpp:68 src/IPFilter.cpp:547
 msgid "Connecting"
 msgstr "Spajanje"
 
-#: src/amuleDlg.cpp:893
+#: src/amuleDlg.cpp:958
 msgid "eD2k: Connecting"
 msgstr ""
 
-#: src/amuleDlg.cpp:897
+#: src/amuleDlg.cpp:962
 msgid "eD2k: Disconnected"
 msgstr ""
 
-#: src/amuleDlg.cpp:903
+#: src/amuleDlg.cpp:968
 msgid "Kad: Firewalled"
 msgstr ""
 
-#: src/amuleDlg.cpp:907
+#: src/amuleDlg.cpp:972
 #, fuzzy
 msgid "Kad: Connected"
 msgstr "Veza uspostavljena"
 
-#: src/amuleDlg.cpp:912
+#: src/amuleDlg.cpp:977
 #, fuzzy
 msgid "Kad: Connecting"
 msgstr "Spajanje"
 
-#: src/amuleDlg.cpp:916
+#: src/amuleDlg.cpp:981
 msgid "Kad: Off"
 msgstr ""
 
-#: src/amuleDlg.cpp:964 src/DownloadListCtrl.cpp:505
+#: src/amuleDlg.cpp:1029 src/DownloadListCtrl.cpp:505
 #: src/DownloadListCtrl.cpp:749 src/FriendListCtrl.cpp:180
 #: src/muuli_wdr.cpp:731 src/muuli_wdr.cpp:782 src/muuli_wdr.cpp:846
-#: src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2224 src/muuli_wdr.cpp:2309
-#: src/muuli_wdr.cpp:3057 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
+#: src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2231 src/muuli_wdr.cpp:2316
+#: src/muuli_wdr.cpp:3064 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
 #: src/ServerListCtrl.cpp:606 src/TransferWnd.cpp:378
 #: src/utils/wxCas/src/wxcasprefs.cpp:235
 msgid "Cancel"
 msgstr "Otkaz"
 
-#: src/amuleDlg.cpp:965
+#: src/amuleDlg.cpp:1030
 #, fuzzy
 msgid "Stop the current connection attempts"
 msgstr "Zaustavlja trenutne pokusaje uspostavljanja veze"
 
-#: src/amuleDlg.cpp:970 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976
-#: src/muuli_wdr.cpp:2447
+#: src/amuleDlg.cpp:1035 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976
+#: src/muuli_wdr.cpp:2454
 msgid "Disconnect"
 msgstr "Prekinuti vezu"
 
-#: src/amuleDlg.cpp:971
+#: src/amuleDlg.cpp:1036
 #, fuzzy
 msgid "Disconnect from the currently connected networks"
 msgstr "Prekinuti vezu sa sadasnjim serverom"
 
-#: src/amuleDlg.cpp:976 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979
-#: src/muuli_wdr.cpp:2602 src/muuli_wdr.cpp:3054 src/muuli_wdr.cpp:3409
+#: src/amuleDlg.cpp:1041 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979
+#: src/muuli_wdr.cpp:2609 src/muuli_wdr.cpp:3061 src/muuli_wdr.cpp:3416
 msgid "Connect"
 msgstr "Uspostavi vezu"
 
-#: src/amuleDlg.cpp:977
+#: src/amuleDlg.cpp:1042
 msgid "Connect to the currently enabled networks"
 msgstr ""
 
-#: src/amuleDlg.cpp:1089
+#: src/amuleDlg.cpp:1154
 #, fuzzy, c-format
 msgid "Up: %.1f%s (%.1f) | Down: %.1f%s (%.1f)"
 msgstr "Gore: %.1f(%.1f) | Dole: %.1f(%.1f)"
 
-#: src/amuleDlg.cpp:1091 src/amuleDlg.cpp:1093 src/amuleDlg.cpp:1097
-#: src/amuleDlg.cpp:1099 src/amuleDlg.cpp:1110 src/amuleDlg.cpp:1112
+#: src/amuleDlg.cpp:1156 src/amuleDlg.cpp:1158 src/amuleDlg.cpp:1162
+#: src/amuleDlg.cpp:1164 src/amuleDlg.cpp:1175 src/amuleDlg.cpp:1177
 #: src/MuleTrayIcon.cpp:796 src/MuleTrayIcon.cpp:799
 #, fuzzy
 msgid " MB/s"
 msgstr "MB/s"
 
-#: src/amuleDlg.cpp:1091 src/amuleDlg.cpp:1093 src/amuleDlg.cpp:1097
-#: src/amuleDlg.cpp:1099 src/amuleDlg.cpp:1110 src/amuleDlg.cpp:1112
+#: src/amuleDlg.cpp:1156 src/amuleDlg.cpp:1158 src/amuleDlg.cpp:1162
+#: src/amuleDlg.cpp:1164 src/amuleDlg.cpp:1175 src/amuleDlg.cpp:1177
 #: src/MuleTrayIcon.cpp:796 src/MuleTrayIcon.cpp:799
 #: src/utils/wxCas/src/wxcasframe.cpp:1041
 msgid " kB/s"
 msgstr " kB/s"
 
-#: src/amuleDlg.cpp:1096
+#: src/amuleDlg.cpp:1161
 #, fuzzy, c-format
 msgid "Up: %.1f%s | Down: %.1f%s"
 msgstr "Gore: %.1f | Dole: %.1f"
 
-#: src/amuleDlg.cpp:1128
+#: src/amuleDlg.cpp:1193
 #, c-format
 msgid "aMule (%s | Connected)"
 msgstr ""
 
-#: src/amuleDlg.cpp:1130
+#: src/amuleDlg.cpp:1195
 #, c-format
 msgid "aMule (%s | Disconnected)"
 msgstr ""
 
-#: src/amuleDlg.cpp:1183
+#: src/amuleDlg.cpp:1248
 #, fuzzy, c-format
 msgid "Do you really want to exit %s?"
 msgstr "Da li zaista zelite iskljuciti aMule?"
 
-#: src/amuleDlg.cpp:1185
+#: src/amuleDlg.cpp:1250
 msgid "Exit confirmation"
 msgstr "Potvrda izlaza"
 
-#: src/amuleDlg.cpp:1548
+#: src/amuleDlg.cpp:1613
 msgid "Launch Command: "
 msgstr ""
 
-#: src/amuleDlg.cpp:1567 src/muuli_wdr.cpp:1971 src/Preferences.cpp:951
+#: src/amuleDlg.cpp:1632 src/muuli_wdr.cpp:1978 src/Preferences.cpp:952
 msgid "- default -"
 msgstr ""
 
-#: src/amuleDlg.cpp:1595
+#: src/amuleDlg.cpp:1660
 #, c-format
 msgid "Skin directory '%s' does not exist"
 msgstr ""
 
-#: src/amuleDlg.cpp:1598
+#: src/amuleDlg.cpp:1663
 #, c-format
 msgid "WARNING: Unable to open skin file '%s' for read"
 msgstr ""
 
-#: src/amuleDlg.cpp:1722 src/amuleDlg.cpp:1968 src/muuli_wdr.cpp:1485
-#: src/muuli_wdr.cpp:3411
-msgid "Networks"
-msgstr ""
-
-#: src/amuleDlg.cpp:1726 src/muuli_wdr.cpp:3411
+#: src/amuleDlg.cpp:1791 src/muuli_wdr.cpp:3418
 msgid "Networks Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1728 src/muuli_wdr.cpp:3412
-msgid "Searches"
-msgstr "Pretrage"
-
-#: src/amuleDlg.cpp:1732 src/muuli_wdr.cpp:3412
+#: src/amuleDlg.cpp:1797 src/muuli_wdr.cpp:3419
 msgid "Searches Window"
 msgstr "Prozor pretraga"
 
-#: src/amuleDlg.cpp:1734 src/DownloadListCtrl.cpp:740 src/muuli_wdr.cpp:392
-#: src/muuli_wdr.cpp:1578 src/muuli_wdr.cpp:3413 src/Statistics.cpp:829
-msgid "Downloads"
-msgstr "Downloads"
-
-#: src/amuleDlg.cpp:1738 src/muuli_wdr.cpp:3413
+#: src/amuleDlg.cpp:1803 src/muuli_wdr.cpp:3420
 #, fuzzy
 msgid "Downloads Window"
 msgstr "Downloading"
 
-#: src/amuleDlg.cpp:1740 src/muuli_wdr.cpp:3287
-msgid "Shared files"
-msgstr ""
-
-#: src/amuleDlg.cpp:1744 src/muuli_wdr.cpp:3415
+#: src/amuleDlg.cpp:1809 src/muuli_wdr.cpp:3422
 msgid "Shared Files Window"
 msgstr "Prozor dijeljenih fajlova"
 
-#: src/amuleDlg.cpp:1746 src/muuli_wdr.cpp:2919 src/muuli_wdr.cpp:3369
-#: src/muuli_wdr.cpp:3416
-msgid "Messages"
-msgstr "Poruke"
-
-#: src/amuleDlg.cpp:1750 src/muuli_wdr.cpp:3416
+#: src/amuleDlg.cpp:1815 src/muuli_wdr.cpp:3423
 msgid "Messages Window"
 msgstr "Prozor poruka"
 
-#: src/amuleDlg.cpp:1752 src/muuli_wdr.cpp:3417 src/PrefsUnifiedDlg.cpp:312
-#: src/Statistics.cpp:779 src/Statistics.cpp:1235
-msgid "Statistics"
-msgstr "Statistike"
-
-#: src/amuleDlg.cpp:1756 src/muuli_wdr.cpp:3417
+#: src/amuleDlg.cpp:1821 src/muuli_wdr.cpp:3424
 msgid "Statistics Graph Window"
 msgstr "Prozor grafova statistike"
 
-#: src/amuleDlg.cpp:1759 src/muuli_wdr.cpp:3419 src/PrefsUnifiedDlg.cpp:328
-#: src/utils/wxCas/src/wxcasprefs.cpp:39
-msgid "Preferences"
-msgstr "Opcije"
-
-#: src/amuleDlg.cpp:1763 src/muuli_wdr.cpp:3419
+#: src/amuleDlg.cpp:1828 src/muuli_wdr.cpp:3426
 msgid "Preferences Settings Window"
 msgstr "Prozor postavke opcija"
 
-#: src/amuleDlg.cpp:1766 src/muuli_wdr.cpp:3420
+#: src/amuleDlg.cpp:1831 src/muuli_wdr.cpp:3427
 msgid "Import"
 msgstr "Uvezi"
 
-#: src/amuleDlg.cpp:1770 src/muuli_wdr.cpp:3420
+#: src/amuleDlg.cpp:1835 src/muuli_wdr.cpp:3427
 msgid "The partfile importer tool"
 msgstr ""
 
-#: src/amuleDlg.cpp:1773 src/muuli_wdr.cpp:3421
+#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3428
 #: src/utils/aLinkCreator/src/alcframe.cpp:262
 msgid "About"
 msgstr "O autoru:"
 
-#: src/amuleDlg.cpp:1773 src/muuli_wdr.cpp:3421
+#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3428
 msgid "About/Help"
 msgstr ""
 
-#: src/amuleDlg.cpp:1971
+#: src/amuleDlg.cpp:2036
 msgid "eD2k network"
 msgstr ""
 
-#: src/amuleDlg.cpp:1974
+#: src/amuleDlg.cpp:2039
 msgid "Kad network"
 msgstr ""
 
-#: src/amuleDlg.cpp:1974
+#: src/amuleDlg.cpp:2039
 msgid "No network"
 msgstr ""
 
@@ -1347,19 +1352,19 @@ msgstr "Auto [Vi]"
 msgid "Very low"
 msgstr "Vrlo nizak"
 
-#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:743 src/muuli_wdr.cpp:2275
+#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:743 src/muuli_wdr.cpp:2282
 #: src/ServerListCtrl.cpp:263 src/ServerListCtrl.cpp:456
 #: src/SharedFilesCtrl.cpp:145
 msgid "Low"
 msgstr "Nisko"
 
-#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:744 src/muuli_wdr.cpp:2276
+#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:744 src/muuli_wdr.cpp:2283
 #: src/ServerListCtrl.cpp:266 src/ServerListCtrl.cpp:457
 #: src/SharedFilesCtrl.cpp:146
 msgid "Normal"
 msgstr "Normalan"
 
-#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:745 src/muuli_wdr.cpp:2277
+#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:745 src/muuli_wdr.cpp:2284
 #: src/ServerListCtrl.cpp:269 src/ServerListCtrl.cpp:458
 #: src/SharedFilesCtrl.cpp:147
 msgid "High"
@@ -1451,8 +1456,8 @@ msgstr ""
 msgid "Remote Server"
 msgstr ""
 
-#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3174
-#: src/SearchDlg.cpp:111 src/TextClient.cpp:911
+#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3181
+#: src/SearchDlg.cpp:119 src/TextClient.cpp:911
 msgid "Kad"
 msgstr "Kad"
 
@@ -1522,7 +1527,7 @@ msgstr ""
 msgid "Size"
 msgstr "Velicina"
 
-#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3241
+#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3248
 msgid "Transferred"
 msgstr "Transferirano"
 
@@ -1580,7 +1585,7 @@ msgid ""
 "\n"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:746 src/muuli_wdr.cpp:2278
+#: src/DownloadListCtrl.cpp:746 src/muuli_wdr.cpp:2285
 #: src/SharedFilesCtrl.cpp:150
 msgid "Auto"
 msgstr "Automatski"
@@ -1618,7 +1623,7 @@ msgid "Extended Options"
 msgstr "Prosirene opcije"
 
 #: src/DownloadListCtrl.cpp:770 src/DownloadListCtrl.cpp:822
-#: src/muuli_wdr.cpp:1789
+#: src/muuli_wdr.cpp:1796
 msgid "Preview"
 msgstr "Preuvid"
 
@@ -2302,19 +2307,19 @@ msgstr ""
 msgid "eD2k"
 msgstr "eD2k"
 
-#: src/FirstRunWizard.cpp:349 src/muuli_wdr.cpp:1488
+#: src/FirstRunWizard.cpp:349 src/muuli_wdr.cpp:1495
 msgid "Kademlia"
 msgstr "Kademlia"
 
-#: src/FirstRunWizard.cpp:359 src/muuli_wdr.cpp:1416
+#: src/FirstRunWizard.cpp:359 src/muuli_wdr.cpp:1423
 msgid "Standard TCP Port "
 msgstr ""
 
-#: src/FirstRunWizard.cpp:365 src/muuli_wdr.cpp:1428
+#: src/FirstRunWizard.cpp:365 src/muuli_wdr.cpp:1435
 msgid "Extended UDP port (Kad / global search) "
 msgstr ""
 
-#: src/FirstRunWizard.cpp:377 src/muuli_wdr.cpp:1435
+#: src/FirstRunWizard.cpp:377 src/muuli_wdr.cpp:1442
 msgid "Enable UPnP for router port forwarding"
 msgstr ""
 
@@ -2341,7 +2346,7 @@ msgstr ""
 msgid "Your peer lists are already in place - nothing to download."
 msgstr "Vec pokusavate downloadovati fajl %s"
 
-#: src/FirstRunWizard.cpp:434 src/muuli_wdr.cpp:1533
+#: src/FirstRunWizard.cpp:434 src/muuli_wdr.cpp:1540
 msgid "Auto-update server list at startup"
 msgstr ""
 
@@ -2387,23 +2392,23 @@ msgid ""
 "want downloads on a different (e.g. larger) disk."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:549 src/FirstRunWizard.cpp:611 src/muuli_wdr.cpp:1701
+#: src/FirstRunWizard.cpp:549 src/FirstRunWizard.cpp:611 src/muuli_wdr.cpp:1708
 msgid "Destination folder for downloads"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:553 src/FirstRunWizard.cpp:569 src/muuli_wdr.cpp:1342
-#: src/muuli_wdr.cpp:1359 src/muuli_wdr.cpp:1676 src/muuli_wdr.cpp:1707
-#: src/muuli_wdr.cpp:1719 src/muuli_wdr.cpp:2762
+#: src/FirstRunWizard.cpp:553 src/FirstRunWizard.cpp:569 src/muuli_wdr.cpp:1349
+#: src/muuli_wdr.cpp:1366 src/muuli_wdr.cpp:1683 src/muuli_wdr.cpp:1714
+#: src/muuli_wdr.cpp:1726 src/muuli_wdr.cpp:2769
 #: src/utils/aLinkCreator/src/alcframe.cpp:135
 #: src/utils/wxCas/src/wxcasprefs.cpp:52 src/utils/wxCas/src/wxcasprefs.cpp:118
 msgid "Browse"
 msgstr "Pretrazi :"
 
-#: src/FirstRunWizard.cpp:559 src/muuli_wdr.cpp:1712
+#: src/FirstRunWizard.cpp:559 src/muuli_wdr.cpp:1719
 msgid "(All files in this folder are shared with other peers)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:565 src/FirstRunWizard.cpp:624 src/muuli_wdr.cpp:1714
+#: src/FirstRunWizard.cpp:565 src/FirstRunWizard.cpp:624 src/muuli_wdr.cpp:1721
 msgid "Folder for temporary download files"
 msgstr ""
 
@@ -2434,7 +2439,7 @@ msgstr ""
 msgid "CRITICAL - no client on StartChatSession"
 msgstr ""
 
-#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2668 src/muuli_wdr.cpp:3345
+#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2675 src/muuli_wdr.cpp:3352
 msgid "Friends"
 msgstr "Prijatelji"
 
@@ -2821,7 +2826,7 @@ msgstr ""
 msgid "Uploaded"
 msgstr ""
 
-#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3225
+#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3232
 msgid "Requested"
 msgstr ""
 
@@ -2946,7 +2951,7 @@ msgid "WARNING: "
 msgstr "UPOZORENJE: "
 
 #: src/MuleNotebook.cpp:179 src/muuli_wdr.cpp:817 src/muuli_wdr.cpp:1229
-#: src/muuli_wdr.cpp:3129 src/muuli_wdr.cpp:3385
+#: src/muuli_wdr.cpp:3136 src/muuli_wdr.cpp:3392
 msgid "Close"
 msgstr "Zatvori"
 
@@ -2959,12 +2964,12 @@ msgstr ""
 msgid "Copy"
 msgstr "Kopiraj"
 
-#: src/MuleTextCtrl.cpp:88
+#: src/MuleTextCtrl.cpp:88 src/SearchDlg.cpp:261
 msgid "Paste"
 msgstr "Staviti"
 
 #: src/MuleTextCtrl.cpp:89 src/muuli_wdr.cpp:358 src/muuli_wdr.cpp:757
-#: src/muuli_wdr.cpp:2352 src/muuli_wdr.cpp:2371 src/muuli_wdr.cpp:2393
+#: src/muuli_wdr.cpp:2359 src/muuli_wdr.cpp:2378 src/muuli_wdr.cpp:2400
 #: src/utils/aLinkCreator/src/alcframe.cpp:142
 msgid "Clear"
 msgstr "Ocisti"
@@ -3062,8 +3067,8 @@ msgid "Exit"
 msgstr "Izlaz"
 
 #: src/MuleTrayIcon.cpp:579 src/MuleTrayIcon.cpp:945 src/MuleTrayIcon.cpp:965
-#: src/muuli_wdr.cpp:1391 src/muuli_wdr.cpp:1399 src/muuli_wdr.cpp:1406
-#: src/muuli_wdr.cpp:1835 src/muuli_wdr.cpp:1841 src/OtherFunctions.cpp:91
+#: src/muuli_wdr.cpp:1398 src/muuli_wdr.cpp:1406 src/muuli_wdr.cpp:1413
+#: src/muuli_wdr.cpp:1842 src/muuli_wdr.cpp:1848 src/OtherFunctions.cpp:91
 #: src/StatisticsDlg.cpp:93 src/StatisticsDlg.cpp:95
 msgid "kB/s"
 msgstr "kB/s"
@@ -3233,7 +3238,7 @@ msgstr "Naziv:"
 msgid "Type"
 msgstr "Tip"
 
-#: src/muuli_wdr.cpp:215 src/SearchDlg.cpp:110 src/SearchListCtrl.cpp:853
+#: src/muuli_wdr.cpp:215 src/SearchDlg.cpp:118 src/SearchListCtrl.cpp:853
 msgid "Local"
 msgstr ""
 
@@ -3304,7 +3309,7 @@ msgstr "Bytes"
 msgid "KB"
 msgstr "KB"
 
-#: src/muuli_wdr.cpp:274 src/muuli_wdr.cpp:293 src/muuli_wdr.cpp:1620
+#: src/muuli_wdr.cpp:274 src/muuli_wdr.cpp:293 src/muuli_wdr.cpp:1627
 #: src/OtherFunctions.cpp:64
 msgid "MB"
 msgstr "MB"
@@ -3321,7 +3326,7 @@ msgstr "Maksimalna velicina"
 msgid "Availability"
 msgstr "Dostupnost"
 
-#: src/muuli_wdr.cpp:312 src/muuli_wdr.cpp:398 src/muuli_wdr.cpp:3290
+#: src/muuli_wdr.cpp:312 src/muuli_wdr.cpp:398 src/muuli_wdr.cpp:3297
 msgid "Filter:"
 msgstr "Filtar:"
 
@@ -3353,7 +3358,7 @@ msgstr ""
 msgid "Stop"
 msgstr "Stop"
 
-#: src/muuli_wdr.cpp:348 src/muuli_wdr.cpp:1385 src/SearchListCtrl.cpp:732
+#: src/muuli_wdr.cpp:348 src/muuli_wdr.cpp:1392 src/SearchListCtrl.cpp:732
 msgid "Download"
 msgstr "Download"
 
@@ -3385,8 +3390,8 @@ msgstr "Nadjeni izvori :"
 #: src/muuli_wdr.cpp:1160 src/muuli_wdr.cpp:1167 src/muuli_wdr.cpp:1172
 #: src/muuli_wdr.cpp:1179 src/muuli_wdr.cpp:1184 src/muuli_wdr.cpp:1191
 #: src/muuli_wdr.cpp:1205 src/muuli_wdr.cpp:1212 src/muuli_wdr.cpp:1217
-#: src/muuli_wdr.cpp:1224 src/muuli_wdr.cpp:3227 src/muuli_wdr.cpp:3235
-#: src/muuli_wdr.cpp:3243
+#: src/muuli_wdr.cpp:1224 src/muuli_wdr.cpp:3234 src/muuli_wdr.cpp:3242
+#: src/muuli_wdr.cpp:3250
 msgid "N/A"
 msgstr "N/A"
 
@@ -3529,7 +3534,7 @@ msgstr ""
 msgid "Album :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:685 src/muuli_wdr.cpp:2247
+#: src/muuli_wdr.cpp:685 src/muuli_wdr.cpp:2254
 msgid "Title :"
 msgstr "Naziv :"
 
@@ -3635,7 +3640,7 @@ msgstr "Ime korisnika :"
 msgid "Userhash :"
 msgstr "Hash korisnika :"
 
-#: src/muuli_wdr.cpp:895 src/muuli_wdr.cpp:1741 src/muuli_wdr.cpp:2442
+#: src/muuli_wdr.cpp:895 src/muuli_wdr.cpp:1748 src/muuli_wdr.cpp:2449
 #: src/utils/aLinkCreator/src/alcframe.cpp:137
 msgid "Add"
 msgstr "Dodaj"
@@ -3644,15 +3649,15 @@ msgstr "Dodaj"
 msgid "Download-Speed"
 msgstr "Brzina downloada"
 
-#: src/muuli_wdr.cpp:954 src/muuli_wdr.cpp:989 src/muuli_wdr.cpp:2546
+#: src/muuli_wdr.cpp:954 src/muuli_wdr.cpp:989 src/muuli_wdr.cpp:2553
 msgid "Current"
 msgstr "Trenutno"
 
-#: src/muuli_wdr.cpp:962 src/muuli_wdr.cpp:997 src/muuli_wdr.cpp:2554
+#: src/muuli_wdr.cpp:962 src/muuli_wdr.cpp:997 src/muuli_wdr.cpp:2561
 msgid "Running average"
 msgstr "Prosjek rada"
 
-#: src/muuli_wdr.cpp:970 src/muuli_wdr.cpp:1005 src/muuli_wdr.cpp:2562
+#: src/muuli_wdr.cpp:970 src/muuli_wdr.cpp:1005 src/muuli_wdr.cpp:2569
 msgid "Session average"
 msgstr "Prosjek misije"
 
@@ -3664,7 +3669,7 @@ msgstr "Brzina uploada"
 msgid "Connections"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1024 src/muuli_wdr.cpp:1860
+#: src/muuli_wdr.cpp:1024 src/muuli_wdr.cpp:1867
 msgid "Active downloads"
 msgstr "Aktivni downloadovi"
 
@@ -3672,7 +3677,7 @@ msgstr "Aktivni downloadovi"
 msgid "Active connections (1:1)"
 msgstr "Aktivne veze (1:1)"
 
-#: src/muuli_wdr.cpp:1040 src/muuli_wdr.cpp:1861
+#: src/muuli_wdr.cpp:1040 src/muuli_wdr.cpp:1868
 msgid "Active uploads"
 msgstr "Aktivni uploadovi"
 
@@ -3789,8 +3794,8 @@ msgstr ""
 msgid "Language: "
 msgstr "Jezik: "
 
-#: src/muuli_wdr.cpp:1257 src/muuli_wdr.cpp:1323 src/muuli_wdr.cpp:1327
-#: src/muuli_wdr.cpp:1330
+#: src/muuli_wdr.cpp:1257 src/muuli_wdr.cpp:1330 src/muuli_wdr.cpp:1334
+#: src/muuli_wdr.cpp:1337
 msgid "The delay before showing tool-tips."
 msgstr ""
 
@@ -3866,932 +3871,940 @@ msgstr ""
 msgid "Enabling this will make aMule to show notifications when finished downloading."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1322
-msgid "Tooltip delay time: "
+#: src/muuli_wdr.cpp:1323
+msgid "Remember search history"
+msgstr ""
+
+#: src/muuli_wdr.cpp:1324
+msgid "Keeps a dropdown list of your past search terms in the Search tab's Name field. This remembers the queries you typed, not the results they returned."
 msgstr ""
 
 #: src/muuli_wdr.cpp:1329
+msgid "Tooltip delay time: "
+msgstr ""
+
+#: src/muuli_wdr.cpp:1336
 msgid "seconds"
 msgstr "sekundi"
 
-#: src/muuli_wdr.cpp:1333
+#: src/muuli_wdr.cpp:1340
 msgid "Browser Selection"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1339
+#: src/muuli_wdr.cpp:1346
 msgid "Enter your browser name here. Leave this field empty to use the system default browser."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1346
+#: src/muuli_wdr.cpp:1353
 msgid "Open in new tab if possible"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1348
+#: src/muuli_wdr.cpp:1355
 msgid "Open the web page in a new tab instead of in a new window when possible"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1352
+#: src/muuli_wdr.cpp:1359
 msgid "Video Player"
 msgstr "Video Plejer"
 
-#: src/muuli_wdr.cpp:1379
+#: src/muuli_wdr.cpp:1386
 msgid "Bandwidth limits"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1393
+#: src/muuli_wdr.cpp:1400
 msgid "Upload"
 msgstr "Upload"
 
-#: src/muuli_wdr.cpp:1401
+#: src/muuli_wdr.cpp:1408
 msgid "Slot Allocation"
 msgstr "Alokacija slota"
 
-#: src/muuli_wdr.cpp:1410
+#: src/muuli_wdr.cpp:1417
 msgid "Ports"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1420
+#: src/muuli_wdr.cpp:1427
 msgid "This is the standard eD2k port and cannot be disabled."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1423
+#: src/muuli_wdr.cpp:1430
 msgid "UDP port for server requests (TCP+3):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1425
+#: src/muuli_wdr.cpp:1432
 msgid "4665"
 msgstr "4665"
 
-#: src/muuli_wdr.cpp:1432
+#: src/muuli_wdr.cpp:1439
 msgid "This UDP port is used for extended eD2k requests and Kad network"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1439
+#: src/muuli_wdr.cpp:1446
 msgid "UPnP TCP Port (Optional):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1449
+#: src/muuli_wdr.cpp:1456
 msgid "Bind local address to IP (empty for any):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1452
+#: src/muuli_wdr.cpp:1459
 msgid "Advanced users only: If you have multiple network interfaces, enter the address of the interface to which aMule should be bound."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1455 src/muuli_wdr.cpp:2054
+#: src/muuli_wdr.cpp:1462 src/muuli_wdr.cpp:2061
 msgid "Bind to network interface (empty for any):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1468
+#: src/muuli_wdr.cpp:1475
 msgid "Advanced users only: pin all of aMule's traffic to one network interface, chosen from the list or typed in by name (e.g. tun0, eth0, en0) or index. Unlike binding to an IP, this stops traffic leaking out via the default route - useful with a VPN. Requires no elevated privileges."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1474
+#: src/muuli_wdr.cpp:1481
 msgid "Max sources per downloading file:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1478
+#: src/muuli_wdr.cpp:1485
 msgid "Max simultaneous connections:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1491 src/muuli_wdr.cpp:3169
+#: src/muuli_wdr.cpp:1498 src/muuli_wdr.cpp:3176
 msgid "ED2K"
 msgstr "ED2K"
 
-#: src/muuli_wdr.cpp:1498
+#: src/muuli_wdr.cpp:1505
 msgid "Autoconnect on startup"
 msgstr "Autospajanje pri startu"
 
-#: src/muuli_wdr.cpp:1501
+#: src/muuli_wdr.cpp:1508
 msgid "Reconnect on loss"
 msgstr "Ponovni spoj kod gubitka veze"
 
-#: src/muuli_wdr.cpp:1523
+#: src/muuli_wdr.cpp:1530
 msgid "Remove dead server after"
 msgstr "Otstrani mrtve servere nakon"
 
-#: src/muuli_wdr.cpp:1524
+#: src/muuli_wdr.cpp:1531
 msgid "Static servers are never removed, even when unreachable."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1528
+#: src/muuli_wdr.cpp:1535
 msgid "retries"
 msgstr "pokusaja"
 
-#: src/muuli_wdr.cpp:1536
+#: src/muuli_wdr.cpp:1543
 msgid "List"
 msgstr "Lista"
 
-#: src/muuli_wdr.cpp:1539
+#: src/muuli_wdr.cpp:1546
 msgid "Update server list when connecting to a server"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1542
+#: src/muuli_wdr.cpp:1549
 msgid "Update server list when a client connects"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1545
+#: src/muuli_wdr.cpp:1552
 msgid "Use priority system"
 msgstr "Koristi sistem prioriteta"
 
-#: src/muuli_wdr.cpp:1549
+#: src/muuli_wdr.cpp:1556
 msgid "Use smart LowID check on connect"
 msgstr "Koristi pametnu LowID provjeru pri vezanju"
 
-#: src/muuli_wdr.cpp:1553
+#: src/muuli_wdr.cpp:1560
 msgid "Safe connect"
 msgstr "Sigurno povezivanje"
 
-#: src/muuli_wdr.cpp:1557
+#: src/muuli_wdr.cpp:1564
 msgid "Autoconnect to servers in static list only"
 msgstr "Autopovezivanje samo sa serverima iz staticne liste"
 
-#: src/muuli_wdr.cpp:1560
+#: src/muuli_wdr.cpp:1567
 msgid "Set manually added servers to High Priority"
 msgstr "Postavi rucno dodate servere na visoki prioritet"
 
-#: src/muuli_wdr.cpp:1581
+#: src/muuli_wdr.cpp:1588
 msgid "Add files to download in pause mode"
 msgstr "Dodaj nove fajlove u stanju pauze"
 
-#: src/muuli_wdr.cpp:1583
+#: src/muuli_wdr.cpp:1590
 msgid "Add files to download with auto priority"
 msgstr "Dodaj nove fajlove sa auto prioritetom"
 
-#: src/muuli_wdr.cpp:1586
+#: src/muuli_wdr.cpp:1593
 msgid "Try to download first and last chunks first"
 msgstr "Pokusaj prvo downloadovati pocetni i zavrsni chunk "
 
-#: src/muuli_wdr.cpp:1590
+#: src/muuli_wdr.cpp:1597
 msgid "Endgame mode: rotate to faster sources for the final blocks"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1593
+#: src/muuli_wdr.cpp:1600
 msgid "Start next paused file when a file completes"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1596
+#: src/muuli_wdr.cpp:1603
 msgid "From the same category"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1598
+#: src/muuli_wdr.cpp:1605
 msgid "In alphabetic order"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1600
+#: src/muuli_wdr.cpp:1607
 msgid "Preallocate disk space for new files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1601
+#: src/muuli_wdr.cpp:1608
 msgid "For new files preallocates disk space for the whole file, thus reduces fragmentation"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1606
+#: src/muuli_wdr.cpp:1613
 msgid "Create new files as sparse files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1607
+#: src/muuli_wdr.cpp:1614
 msgid "A sparse file reserves its full size on disk immediately without writing real data to it -- fast, but unsupported or slow on some filesystems, and free-space accounting stays optimistic while the download is in progress. Turn this off to grow the file only as data arrives."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1612
+#: src/muuli_wdr.cpp:1619
 msgid "Stop downloads when free disk space reaches "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1613
+#: src/muuli_wdr.cpp:1620
 msgid "Select this if you want aMule to check your disk space"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1617
+#: src/muuli_wdr.cpp:1624
 msgid "Enter here the min disk space desired."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1623
+#: src/muuli_wdr.cpp:1630
 msgid "Save 10 sources on rare files (< 20 sources)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1627 src/Statistics.cpp:790
+#: src/muuli_wdr.cpp:1634 src/Statistics.cpp:790
 msgid "Uploads"
 msgstr "Uploadovi"
 
-#: src/muuli_wdr.cpp:1630
+#: src/muuli_wdr.cpp:1637
 msgid "Add new shared files with auto priority"
 msgstr "Dodaj nove dijeljene fajlove sa auto prioritetom"
 
-#: src/muuli_wdr.cpp:1636
+#: src/muuli_wdr.cpp:1643
 msgid "Intelligent Corruption Handling (I.C.H.)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1639
+#: src/muuli_wdr.cpp:1646
 msgid "Enable"
 msgstr "Omogućiti"
 
-#: src/muuli_wdr.cpp:1642
+#: src/muuli_wdr.cpp:1649
 msgid "Advanced I.C.H. trusts every hash (not recommended)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1654 src/PrefsUnifiedDlg.cpp:1910
+#: src/muuli_wdr.cpp:1661 src/PrefsUnifiedDlg.cpp:1910
 msgid "Media metadata extraction"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1658
+#: src/muuli_wdr.cpp:1665
 msgid "Extract length / bitrate / codec from shared audio and video files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1660
+#: src/muuli_wdr.cpp:1667
 msgid "When enabled, aMule runs ffprobe on each shared media file to fill in the Length / Bitrate / Codec columns other clients see when they find the file in a search. Requires ffmpeg (the ffprobe binary) to be installed."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1667
+#: src/muuli_wdr.cpp:1674
 msgid "Path to ffprobe:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1672
+#: src/muuli_wdr.cpp:1679
 msgid "Full path to the ffprobe binary. Leave empty to have aMule auto-detect it on startup."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1680
+#: src/muuli_wdr.cpp:1687
 msgid "Detect"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1681
+#: src/muuli_wdr.cpp:1688
 msgid "Search the standard install locations for an ffprobe binary and fill the path field."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1705
+#: src/muuli_wdr.cpp:1712
 msgid ""
 "Completed downloads are stored here. All files in this folder are automatically shared with other peers.\n"
 "If this folder also holds files you don't want to share, point it at an aMule-only sub-folder."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1708
+#: src/muuli_wdr.cpp:1715
 msgid "Pick the folder where completed downloads will be stored. All files in that folder will be shared with other peers."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1722
+#: src/muuli_wdr.cpp:1729
 msgid "Shared folders"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1728
+#: src/muuli_wdr.cpp:1735
 msgid "(Folders shared by the core. Enter a path to add one.)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1736
+#: src/muuli_wdr.cpp:1743
 msgid "Absolute path of a folder on the core's machine, e.g. /home/user/shared"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1738 src/PrefsUnifiedDlg.cpp:2794
+#: src/muuli_wdr.cpp:1745 src/PrefsUnifiedDlg.cpp:2794
 msgid "Recursive"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1739
+#: src/muuli_wdr.cpp:1746
 msgid "Share every sub-folder underneath this one, including ones created later."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1743 src/utils/aLinkCreator/src/alcframe.cpp:141
+#: src/muuli_wdr.cpp:1750 src/utils/aLinkCreator/src/alcframe.cpp:141
 msgid "Remove"
 msgstr "Ukloni"
 
-#: src/muuli_wdr.cpp:1747
+#: src/muuli_wdr.cpp:1754
 msgid "(Right click on folder icon for recursive share)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1754
+#: src/muuli_wdr.cpp:1761
 msgid "Share hidden files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1760
+#: src/muuli_wdr.cpp:1767
 msgid "Automatically rescan shared folders for changes"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1766
+#: src/muuli_wdr.cpp:1773
 msgid "Follow symbolic links in shared folders"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1772
+#: src/muuli_wdr.cpp:1779
 msgid "Exclude files matching:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1775
+#: src/muuli_wdr.cpp:1782
 msgid "Wildcard patterns separated by '|', e.g. .DS_Store|Thumbs.db|*.tmp. Files whose name matches are not shared. Matching is case-insensitive."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1779
+#: src/muuli_wdr.cpp:1786
 msgid "Patterns are regular expressions"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1780
+#: src/muuli_wdr.cpp:1787
 msgid "When set, the whole field is one regular expression ('|' is alternation). When unset, it is a list of '|'-separated wildcards."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1790
+#: src/muuli_wdr.cpp:1797
 msgid "Show how many shared files the current pattern would exclude."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1811
+#: src/muuli_wdr.cpp:1818
 msgid "Graphs"
 msgstr "Grafovi"
 
-#: src/muuli_wdr.cpp:1814 src/muuli_wdr.cpp:1876
+#: src/muuli_wdr.cpp:1821 src/muuli_wdr.cpp:1883
 msgid "Update delay : 5 secs"
 msgstr "Obnovi kasnjenje : 5 sekundi"
 
-#: src/muuli_wdr.cpp:1818
+#: src/muuli_wdr.cpp:1825
 msgid "Time for average graph: 100 mins"
 msgstr "Vrijeme za prosjecni graf: 100 minuta"
 
-#: src/muuli_wdr.cpp:1822
+#: src/muuli_wdr.cpp:1829
 msgid "Connections Graph Scale: 100 "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1829
+#: src/muuli_wdr.cpp:1836
 msgid "Download graph scale:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1837
+#: src/muuli_wdr.cpp:1844
 msgid "Upload graph scale:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1847
+#: src/muuli_wdr.cpp:1854
 #, fuzzy
 msgid "Colors: "
 msgstr "Boje: "
 
-#: src/muuli_wdr.cpp:1851
+#: src/muuli_wdr.cpp:1858
 msgid "Background"
 msgstr "Pozadina"
 
-#: src/muuli_wdr.cpp:1852
+#: src/muuli_wdr.cpp:1859
 msgid "Grid"
 msgstr "Mreza"
 
-#: src/muuli_wdr.cpp:1853
+#: src/muuli_wdr.cpp:1860
 msgid "Download current"
 msgstr "Trenutni download"
 
-#: src/muuli_wdr.cpp:1854
+#: src/muuli_wdr.cpp:1861
 msgid "Download running average"
 msgstr "Prosjek tekuceg downloada"
 
-#: src/muuli_wdr.cpp:1855
+#: src/muuli_wdr.cpp:1862
 msgid "Download session average"
 msgstr "Prosjek downloada misije"
 
-#: src/muuli_wdr.cpp:1856
+#: src/muuli_wdr.cpp:1863
 msgid "Upload current"
 msgstr "Trenutni upload"
 
-#: src/muuli_wdr.cpp:1857
+#: src/muuli_wdr.cpp:1864
 msgid "Upload running average"
 msgstr "Prosjek tekuceg uploada"
 
-#: src/muuli_wdr.cpp:1858
+#: src/muuli_wdr.cpp:1865
 msgid "Upload session average"
 msgstr "Prosjek uploada misije"
 
-#: src/muuli_wdr.cpp:1859
+#: src/muuli_wdr.cpp:1866
 msgid "Active connections"
 msgstr "Aktivne veze"
 
-#: src/muuli_wdr.cpp:1862
+#: src/muuli_wdr.cpp:1869
 #, fuzzy
 msgid "Systray Icon Speed Bar"
 msgstr "poluga brzine prikazana u sistemskom koritu"
 
-#: src/muuli_wdr.cpp:1863
+#: src/muuli_wdr.cpp:1870
 msgid "Kad-nodes current"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1864
+#: src/muuli_wdr.cpp:1871
 msgid "Kad-nodes running"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1865
+#: src/muuli_wdr.cpp:1872
 msgid "Kad-nodes session"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1869 src/muuli_wdr.cpp:2296
+#: src/muuli_wdr.cpp:1876 src/muuli_wdr.cpp:2303
 msgid "Select"
 msgstr "Izaberi"
 
-#: src/muuli_wdr.cpp:1873
+#: src/muuli_wdr.cpp:1880
 msgid "Tree"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1883
+#: src/muuli_wdr.cpp:1890
 msgid "Number of Client Versions shown (0=unlimited)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1908
+#: src/muuli_wdr.cpp:1915
 msgid "!!! WARNING !!!"
 msgstr "!!! UPOZORENJE !!!"
 
-#: src/muuli_wdr.cpp:1923
+#: src/muuli_wdr.cpp:1930
 msgid "Max new connections / 5 secs"
 msgstr "Maksimalne veze u / 5 sekundi"
 
-#: src/muuli_wdr.cpp:1925
+#: src/muuli_wdr.cpp:1932
 msgid "Concurrent Kad source lookups"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1927
+#: src/muuli_wdr.cpp:1934
 msgid "Kad source re-search interval (minutes)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1929
+#: src/muuli_wdr.cpp:1936
 #, fuzzy
 msgid "Source re-ask interval (minutes)"
 msgstr "Interval obnavljanja veze servera %i minuta"
 
-#: src/muuli_wdr.cpp:1933
+#: src/muuli_wdr.cpp:1940
 msgid "File Buffer Size: 240000 bytes"
 msgstr "Fajl Buffer velicina: 240000 bytes"
 
-#: src/muuli_wdr.cpp:1937
+#: src/muuli_wdr.cpp:1944
 msgid "Use MMAP: memory-mapped file access (lower memory use)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1938
+#: src/muuli_wdr.cpp:1945
 msgid "Maps part files into memory instead of buffering them on the heap, lowering the process memory footprint. May reduce download speed on some disks; best for memory-constrained or upload-heavy hosts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1940
+#: src/muuli_wdr.cpp:1947
 msgid "Upload Queue Size: 5000 clients"
 msgstr "Duzina reda cekanja: 5000 klienta"
 
-#: src/muuli_wdr.cpp:1944
+#: src/muuli_wdr.cpp:1951
 msgid "Server connection refresh interval: Disable"
 msgstr "Interval obnavljanja veze servera: onemoguceno"
 
-#: src/muuli_wdr.cpp:1948
+#: src/muuli_wdr.cpp:1955
 msgid "Disable computer's timed standby mode"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1967
+#: src/muuli_wdr.cpp:1974
 msgid "Skin to use: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1976
+#: src/muuli_wdr.cpp:1983
 msgid "Show \"Fast eD2k Links Handler\" in every window."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1979
+#: src/muuli_wdr.cpp:1986
 msgid "Show extended info on categories tabs"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1982
+#: src/muuli_wdr.cpp:1989
 #, fuzzy
 msgid "Show application version on title"
 msgstr "Pokazi transfer rate u naslovu"
 
-#: src/muuli_wdr.cpp:1984
+#: src/muuli_wdr.cpp:1991
 msgid "Show transfer rates on title"
 msgstr "Pokazi transfer rate u naslovu"
 
-#: src/muuli_wdr.cpp:1986
+#: src/muuli_wdr.cpp:1993
 msgid "Before application name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1988
+#: src/muuli_wdr.cpp:1995
 msgid "After application name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1991
+#: src/muuli_wdr.cpp:1998
 msgid "Show overhead bandwidth"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1995
+#: src/muuli_wdr.cpp:2002
 msgid "Vertical toolbar orientation"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1997
+#: src/muuli_wdr.cpp:2004
 msgid "Live column sorting (auto-reorder rows as their values change)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2004
+#: src/muuli_wdr.cpp:2011
 msgid "Download Queue Files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2007
+#: src/muuli_wdr.cpp:2014
 msgid "Show progress percentage"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2013
+#: src/muuli_wdr.cpp:2020
 msgid "Show progress bar"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2016
+#: src/muuli_wdr.cpp:2023
 msgid "Flat"
 msgstr "Pljosnata"
 
-#: src/muuli_wdr.cpp:2020
+#: src/muuli_wdr.cpp:2027
 msgid "Round"
 msgstr "Obla"
 
-#: src/muuli_wdr.cpp:2038
+#: src/muuli_wdr.cpp:2045
 msgid "External Connection Parameters"
 msgstr "Parametri za spoljasnju vezu"
 
-#: src/muuli_wdr.cpp:2041
+#: src/muuli_wdr.cpp:2048
 msgid "Accept external connections"
 msgstr "Prihvati spoljasnje veze"
 
-#: src/muuli_wdr.cpp:2048 src/muuli_wdr.cpp:2107
+#: src/muuli_wdr.cpp:2055 src/muuli_wdr.cpp:2114
 msgid "IP of the listening interface:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2051
+#: src/muuli_wdr.cpp:2058
 msgid "Enter here a valid ip in the a.b.c.d format for the listening EC interface. An empty field or 0.0.0.0 will mean any interface."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2072 src/muuli_wdr.cpp:2156
+#: src/muuli_wdr.cpp:2079 src/muuli_wdr.cpp:2163
 msgid "TCP port:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2078
+#: src/muuli_wdr.cpp:2085
 msgid "Enable UPnP port forwarding on the EC port"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2082 src/muuli_wdr.cpp:3041
+#: src/muuli_wdr.cpp:2089 src/muuli_wdr.cpp:3048
 #: src/utils/wxCas/src/wxcasprefs.cpp:167
 msgid "Password"
 msgstr "Lozinka"
 
-#: src/muuli_wdr.cpp:2088
+#: src/muuli_wdr.cpp:2095
 msgid "aMule API server parameters"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2091
+#: src/muuli_wdr.cpp:2098
 msgid "Run amuleapi (REST API) on startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2096
+#: src/muuli_wdr.cpp:2103
 msgid "HTTP port:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2110
+#: src/muuli_wdr.cpp:2117
 msgid "The interface amuleapi's HTTP server listens on. 127.0.0.1 (default) accepts only local connections; use 0.0.0.0 or a specific IP to expose it to other hosts (set an admin password below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2113
+#: src/muuli_wdr.cpp:2120
 #, fuzzy
 msgid "Admin password"
 msgstr "Lozinka"
 
-#: src/muuli_wdr.cpp:2118 src/muuli_wdr.cpp:2149
+#: src/muuli_wdr.cpp:2125 src/muuli_wdr.cpp:2156
 msgid "Low rights password"
 msgstr "Sifra za manje prava"
 
-#: src/muuli_wdr.cpp:2126
+#: src/muuli_wdr.cpp:2133
 msgid "Web server parameters"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2129
+#: src/muuli_wdr.cpp:2136
 msgid "Run webserver on startup (deprecated)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2135
+#: src/muuli_wdr.cpp:2142
 msgid "Web template"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2140
+#: src/muuli_wdr.cpp:2147
 msgid "Full rights password"
 msgstr "Sifra za puna prava"
 
-#: src/muuli_wdr.cpp:2144
+#: src/muuli_wdr.cpp:2151
 msgid "Enable Low rights User"
 msgstr "Odobri korisnicima sa manje prava"
 
-#: src/muuli_wdr.cpp:2163
+#: src/muuli_wdr.cpp:2170
 msgid "Enable UPnP port forwarding of the web server port"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2168
+#: src/muuli_wdr.cpp:2175
 msgid "Web server UPnP TCP port (Optional)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2176
+#: src/muuli_wdr.cpp:2183
 msgid "Page Refresh Time (in secs)"
 msgstr "Vrijeme obnove stranice (u sekundama)"
 
-#: src/muuli_wdr.cpp:2183
+#: src/muuli_wdr.cpp:2190
 msgid "Enable Gzip compression"
 msgstr "Odobri Gzip kompresiju"
 
-#: src/muuli_wdr.cpp:2217
+#: src/muuli_wdr.cpp:2224
 #, fuzzy
 msgid "Reset page to defaults"
 msgstr "Standard sistema"
 
-#: src/muuli_wdr.cpp:2218
+#: src/muuli_wdr.cpp:2225
 msgid "Reset the settings on the current page to their default values."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2220 src/muuli_wdr.cpp:2306 src/ServerWnd.cpp:274
+#: src/muuli_wdr.cpp:2227 src/muuli_wdr.cpp:2313 src/ServerWnd.cpp:274
 #: src/ServerWnd.cpp:282
 msgid "OK"
 msgstr "OK"
 
-#: src/muuli_wdr.cpp:2222
+#: src/muuli_wdr.cpp:2229
 msgid "Click here to apply any changes made to the preferences."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2225
+#: src/muuli_wdr.cpp:2232
 msgid "Reset any changes made to the preferences."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2254
+#: src/muuli_wdr.cpp:2261
 msgid "Comment :"
 msgstr "Komentar:"
 
-#: src/muuli_wdr.cpp:2261
+#: src/muuli_wdr.cpp:2268
 msgid "Incoming Dir :"
 msgstr "Prijemni direktorij :"
 
-#: src/muuli_wdr.cpp:2270
+#: src/muuli_wdr.cpp:2277
 msgid "Change priority for new assigned files :"
 msgstr "Promijeni prioritet za nove fajlove :"
 
-#: src/muuli_wdr.cpp:2274
+#: src/muuli_wdr.cpp:2281
 #, fuzzy
 msgid "Don't change"
 msgstr "Ne mijenjaj"
 
-#: src/muuli_wdr.cpp:2286
+#: src/muuli_wdr.cpp:2293
 msgid "Select color for this Category (currently selected) :"
 msgstr "Izaberi boju za ovu kategoriju (trenutno izabrana) :"
 
-#: src/muuli_wdr.cpp:2353 src/muuli_wdr.cpp:2372 src/muuli_wdr.cpp:2394
+#: src/muuli_wdr.cpp:2360 src/muuli_wdr.cpp:2379 src/muuli_wdr.cpp:2401
 msgid "Click this button to reset the log."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2413
+#: src/muuli_wdr.cpp:2420
 msgid "Click on this button to update the servers list from URL ..."
 msgstr "Klikni ovdje da obnovis listu servera sa URL ..."
 
-#: src/muuli_wdr.cpp:2417
+#: src/muuli_wdr.cpp:2424
 msgid "Server list"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2421
+#: src/muuli_wdr.cpp:2428
 msgid "Enter the url to a server.met file here and press the button to the left to update the list of known servers."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2426
+#: src/muuli_wdr.cpp:2433
 msgid "Add server manually: Name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2429
+#: src/muuli_wdr.cpp:2436
 msgid "Enter the name of the new server here"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2431 src/ServerWnd.cpp:206
+#: src/muuli_wdr.cpp:2438 src/ServerWnd.cpp:206
 msgid "IP:Port"
 msgstr "IP:Port"
 
-#: src/muuli_wdr.cpp:2434
+#: src/muuli_wdr.cpp:2441
 msgid "Enter the IP of the server here, using the x.x.x.x format."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2440
+#: src/muuli_wdr.cpp:2447
 msgid "Enter the port of the server here."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2443
+#: src/muuli_wdr.cpp:2450
 msgid "Add manually a server (fill fields to the left before) ..."
 msgstr "Dodaj servera rucno (prije ispuni polja lijevo) ..."
 
-#: src/muuli_wdr.cpp:2472
+#: src/muuli_wdr.cpp:2479
 msgid "aMule Log"
 msgstr "aMule Log"
 
-#: src/muuli_wdr.cpp:2480
+#: src/muuli_wdr.cpp:2487
 msgid "Server Info"
 msgstr "Lista servera"
 
-#: src/muuli_wdr.cpp:2484
+#: src/muuli_wdr.cpp:2491
 msgid "ED2K Info"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2488
+#: src/muuli_wdr.cpp:2495
 msgid "Kad Info"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2516
+#: src/muuli_wdr.cpp:2523
 msgid "Click on this button to update the nodes list from URL ..."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2520
+#: src/muuli_wdr.cpp:2527
 msgid "Nodes (0)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2524
+#: src/muuli_wdr.cpp:2531
 msgid "Enter the url to a nodes.dat file here and press the button to the left to update the list of known nodes."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2527
+#: src/muuli_wdr.cpp:2534
 msgid "Nodes stats"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2569
+#: src/muuli_wdr.cpp:2576
 msgid "Bootstrap"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2572
+#: src/muuli_wdr.cpp:2579
 msgid "New node"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2577
+#: src/muuli_wdr.cpp:2584
 msgid "IP:"
 msgstr "IP:"
 
-#: src/muuli_wdr.cpp:2597
+#: src/muuli_wdr.cpp:2604
 msgid "Port:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2610
+#: src/muuli_wdr.cpp:2617
 msgid "Bootstrap from known clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2612
+#: src/muuli_wdr.cpp:2619
 msgid "Disconnect Kad"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2646
+#: src/muuli_wdr.cpp:2653
 msgid "Use Secure User Identification"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2648
+#: src/muuli_wdr.cpp:2655
 msgid "It is recommended to enable this option. You will not receive credits if SUI is not enabled."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2650
+#: src/muuli_wdr.cpp:2657
 msgid "Protocol Obfuscation"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2653
+#: src/muuli_wdr.cpp:2660
 msgid "Support Protocol Obfuscation"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2655
+#: src/muuli_wdr.cpp:2662
 msgid "This option enabled Protocol Obfuscation, and makes aMule accept obfuscated connections from other clients."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2657
+#: src/muuli_wdr.cpp:2664
 msgid "Use obfuscation for outgoing connections"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2659
+#: src/muuli_wdr.cpp:2666
 msgid "This option makes aMule use Protocol Obfuscation when connecting other clients/servers."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2661
+#: src/muuli_wdr.cpp:2668
 msgid "Accept only obfuscated connections"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2662
+#: src/muuli_wdr.cpp:2669
 msgid "This option makes aMule only accept obfuscated connections. You will have less sources, but all your traffic will be obfuscated"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2667
+#: src/muuli_wdr.cpp:2674
 msgid "Everybody"
 msgstr "Svi"
 
-#: src/muuli_wdr.cpp:2669
+#: src/muuli_wdr.cpp:2676
 msgid "No one"
 msgstr "Nitko"
 
-#: src/muuli_wdr.cpp:2671
+#: src/muuli_wdr.cpp:2678
 msgid "Who can see my shared files:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2672
+#: src/muuli_wdr.cpp:2679
 msgid "Select who can request to view a list of your shared files."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2674
+#: src/muuli_wdr.cpp:2681
 msgid "IP-Filtering"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2681
+#: src/muuli_wdr.cpp:2688
 msgid "Filter clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2683
+#: src/muuli_wdr.cpp:2690
 msgid "Enable filtering of the client IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2685
+#: src/muuli_wdr.cpp:2692
 msgid "Filter servers"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2687
+#: src/muuli_wdr.cpp:2694
 msgid "Enable filtering of the server IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2691
+#: src/muuli_wdr.cpp:2698
 msgid "Reload List"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2692
+#: src/muuli_wdr.cpp:2699
 msgid "Reload the list of IPs to filter from the file ~/.aMule/ipfilter.dat"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2698
+#: src/muuli_wdr.cpp:2705
 msgid "URL:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2702 src/muuli_wdr.cpp:2895
+#: src/muuli_wdr.cpp:2709 src/muuli_wdr.cpp:2902
 msgid "Update now"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2705
+#: src/muuli_wdr.cpp:2712
 msgid "Auto-update ipfilter at startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2709
+#: src/muuli_wdr.cpp:2716
 msgid "Filtering Level:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2715
+#: src/muuli_wdr.cpp:2722
 msgid "Always filter LAN IPs"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2718
+#: src/muuli_wdr.cpp:2725
 msgid "Paranoid handling of non-matching IPs"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2720
+#: src/muuli_wdr.cpp:2727
 msgid "Rejects a packet when its source IP differs from the IP the client claims (an anti-spoofing check). Disable only if it causes connection problems."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2722
+#: src/muuli_wdr.cpp:2729
 msgid "Use system-wide ipfilter.dat if available"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2723
+#: src/muuli_wdr.cpp:2730
 msgid "If there's no local ipfilter.dat found, allow usage of a system-wide ipfilter file."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2740
+#: src/muuli_wdr.cpp:2747
 msgid "Enable Online-Signature"
 msgstr "Omoguci online potpis"
 
-#: src/muuli_wdr.cpp:2742
+#: src/muuli_wdr.cpp:2749
 msgid "Enables the writing of the OS file, which can be used by external apps to create signatures and the like."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2746
+#: src/muuli_wdr.cpp:2753
 msgid "Update Frequency (Secs):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2749
+#: src/muuli_wdr.cpp:2756
 msgid "Change the frequency (in seconds) of Online Signature updates."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2757
+#: src/muuli_wdr.cpp:2764
 msgid "Save online signature file in: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:2763
+#: src/muuli_wdr.cpp:2770
 msgid "Click here to select the directory containing the the Online Signature files."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2796
+#: src/muuli_wdr.cpp:2803
 msgid "Show country flags for clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2797
+#: src/muuli_wdr.cpp:2804
 msgid "Render the country flag column in the transfers, queue and search views. Requires a valid MMDB GeoIP database (see below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2802
+#: src/muuli_wdr.cpp:2809
 #, fuzzy
 msgid "Database"
 msgstr "Podatak rate :"
 
-#: src/muuli_wdr.cpp:2818
+#: src/muuli_wdr.cpp:2825
 #, fuzzy
 msgid "Source:"
 msgstr "Izvori"
 
-#: src/muuli_wdr.cpp:2821
+#: src/muuli_wdr.cpp:2828
 msgid "DB-IP (free, no account)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2822
+#: src/muuli_wdr.cpp:2829
 msgid "MaxMind GeoLite2 (free, account required)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2823
+#: src/muuli_wdr.cpp:2830
 msgid "Custom URL"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2826
+#: src/muuli_wdr.cpp:2833
 msgid "Choose which provider supplies the GeoIP MMDB database. DB-IP is the default - no account required. MaxMind requires a free account + license key. Use Custom URL to point at any other MMDB host (e.g. a local mirror)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2843
+#: src/muuli_wdr.cpp:2850
 msgid ""
 "No configuration required.\n"
 "\n"
@@ -4799,11 +4812,11 @@ msgid ""
 "License: Creative Commons BY 4.0 - https://creativecommons.org/licenses/by/4.0/"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2856
+#: src/muuli_wdr.cpp:2863
 msgid "License key:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2862
+#: src/muuli_wdr.cpp:2869
 msgid ""
 "Sign up for a free MaxMind account, then generate a License Key:\n"
 "https://www.maxmind.com/en/geolite2/signup\n"
@@ -4813,233 +4826,233 @@ msgid ""
 "Requires attribution and account registration; refresh at least every 30 days."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2877
+#: src/muuli_wdr.cpp:2884
 #, fuzzy
 msgid "Download URL:"
 msgstr "Download"
 
-#: src/muuli_wdr.cpp:2883
+#: src/muuli_wdr.cpp:2890
 msgid ""
 "Must point to an .mmdb file or a .gz / .tar.gz containing one.\n"
 "URL may include credentials (https://user:pass@host/...).\n"
 "License and attribution terms are set by the upstream URL - you are responsible."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2896
+#: src/muuli_wdr.cpp:2903
 msgid "Download the GeoIP database from the selected source."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2898
+#: src/muuli_wdr.cpp:2905
 #, fuzzy
 msgid "Auto-update on startup"
 msgstr "Autospajanje pri startu"
 
-#: src/muuli_wdr.cpp:2899
+#: src/muuli_wdr.cpp:2906
 msgid "Re-download the GeoIP database from the selected source every time aMule starts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2922
+#: src/muuli_wdr.cpp:2929
 msgid "Filter incoming messages (except current chat):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2924
+#: src/muuli_wdr.cpp:2931
 msgid "Filter all messages"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2926
+#: src/muuli_wdr.cpp:2933
 msgid "Filter messages from people not on your friend list"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2928
+#: src/muuli_wdr.cpp:2935
 msgid "Filter messages from unknown clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2930
+#: src/muuli_wdr.cpp:2937
 msgid "Filter messages containing (use ',' as separator):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2933 src/muuli_wdr.cpp:2944
+#: src/muuli_wdr.cpp:2940 src/muuli_wdr.cpp:2951
 msgid "add here the words amule should filter and block messages including it"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2935
+#: src/muuli_wdr.cpp:2942
 msgid "Show received messages in the log"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2938
+#: src/muuli_wdr.cpp:2945
 msgid "Comments"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2941
+#: src/muuli_wdr.cpp:2948
 msgid "Filter comments containing (use ',' as separator):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2966
+#: src/muuli_wdr.cpp:2973
 msgid "Enable Proxy"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2967
+#: src/muuli_wdr.cpp:2974
 msgid "Enable/disable proxy support"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2970
+#: src/muuli_wdr.cpp:2977
 msgid "Proxy type:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2981
+#: src/muuli_wdr.cpp:2988
 msgid "Proxy host:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2984
+#: src/muuli_wdr.cpp:2991
 msgid "The proxy host name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2986
+#: src/muuli_wdr.cpp:2993
 msgid "Proxy port:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2989
+#: src/muuli_wdr.cpp:2996
 msgid "The proxy port"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2991
+#: src/muuli_wdr.cpp:2998
 msgid "Enable authentication"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2992
+#: src/muuli_wdr.cpp:2999
 msgid "Enable/disable username/password authentication"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2995
+#: src/muuli_wdr.cpp:3002
 msgid "Username: "
 msgstr "Korisničko ime:"
 
-#: src/muuli_wdr.cpp:2998
+#: src/muuli_wdr.cpp:3005
 msgid "The username to use to connect to the proxy"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3000
+#: src/muuli_wdr.cpp:3007
 msgid "Password:"
 msgstr "Lozinka:"
 
-#: src/muuli_wdr.cpp:3003
+#: src/muuli_wdr.cpp:3010
 msgid "The password to use to connect to the proxy"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3022
+#: src/muuli_wdr.cpp:3029
 msgid "Connect to:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3031
+#: src/muuli_wdr.cpp:3038
 msgid "Login to remote amule"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3036
+#: src/muuli_wdr.cpp:3043
 msgid "User name"
 msgstr "Korisničko ime"
 
-#: src/muuli_wdr.cpp:3047
+#: src/muuli_wdr.cpp:3054
 msgid "Remember those settings"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3050
+#: src/muuli_wdr.cpp:3057
 #, fuzzy
 msgid "Force ZLIB compression"
 msgstr "Steceno kompresijom :"
 
-#: src/muuli_wdr.cpp:3074
+#: src/muuli_wdr.cpp:3081
 msgid "Enable Verbose Debug-Logging."
 msgstr ""
 
-#: src/muuli_wdr.cpp:3076
+#: src/muuli_wdr.cpp:3083
 #, fuzzy
 msgid "Only to Logfile"
 msgstr "&Otvori fajl"
 
-#: src/muuli_wdr.cpp:3078
+#: src/muuli_wdr.cpp:3085
 msgid "Message Categories:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3102 src/PartFileConvertDlg.cpp:160
+#: src/muuli_wdr.cpp:3109 src/PartFileConvertDlg.cpp:160
 msgid "Waiting..."
 msgstr "Ceka ..."
 
-#: src/muuli_wdr.cpp:3122
+#: src/muuli_wdr.cpp:3129
 msgid "Add imports"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3125
+#: src/muuli_wdr.cpp:3132
 msgid "Retry selected"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3127
+#: src/muuli_wdr.cpp:3134
 msgid "Remove selected"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3190
+#: src/muuli_wdr.cpp:3197
 msgid "Event Types"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3209
+#: src/muuli_wdr.cpp:3216
 msgid "Statistics and queued clients for selected file(s) : Session / All time"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3233
+#: src/muuli_wdr.cpp:3240
 #, fuzzy
 msgid "Active Uploads"
 msgstr "Aktivni uploadovi :"
 
-#: src/muuli_wdr.cpp:3247
+#: src/muuli_wdr.cpp:3254
 #, fuzzy
 msgid "Percent of total files"
 msgstr "Ukupni fajlovi"
 
-#: src/muuli_wdr.cpp:3299
+#: src/muuli_wdr.cpp:3306
 #, fuzzy
 msgid "Show Clients for"
 msgstr "Pokazi liste"
 
-#: src/muuli_wdr.cpp:3301
+#: src/muuli_wdr.cpp:3308
 #, fuzzy
 msgid "All files"
 msgstr "Dijeljeni fajlovi"
 
-#: src/muuli_wdr.cpp:3304
+#: src/muuli_wdr.cpp:3311
 #, fuzzy
 msgid "Selected files"
 msgstr "Izaberi filter za gledanje"
 
-#: src/muuli_wdr.cpp:3307
+#: src/muuli_wdr.cpp:3314
 #, fuzzy
 msgid "Active uploads only"
 msgstr "Aktivni uploadovi"
 
-#: src/muuli_wdr.cpp:3314
+#: src/muuli_wdr.cpp:3321
 #, fuzzy
 msgid "Reload:"
 msgstr "Ponovno ucitati"
 
-#: src/muuli_wdr.cpp:3318
+#: src/muuli_wdr.cpp:3325
 msgid "Reload your shared files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3381
+#: src/muuli_wdr.cpp:3388
 msgid "Send"
 msgstr "Posalji"
 
-#: src/muuli_wdr.cpp:3382
+#: src/muuli_wdr.cpp:3389
 msgid "Sends the specified message."
 msgstr ""
 
-#: src/muuli_wdr.cpp:3386
+#: src/muuli_wdr.cpp:3393
 msgid "Close this chat-session."
 msgstr ""
 
-#: src/muuli_wdr.cpp:3409
+#: src/muuli_wdr.cpp:3416
 msgid "Connect to any server and/or Kad"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3415 src/SharedFilesCtrl.cpp:142 src/Statistics.cpp:941
+#: src/muuli_wdr.cpp:3422 src/SharedFilesCtrl.cpp:142 src/Statistics.cpp:941
 msgid "Shared Files"
 msgstr "Dijeljeni fajlovi"
 
@@ -5405,188 +5418,188 @@ msgstr ""
 msgid "ERROR: Failed to open partfile '%s'"
 msgstr ""
 
-#: src/Preferences.cpp:673
+#: src/Preferences.cpp:674
 msgid "System default"
 msgstr "Standard sistema"
 
-#: src/Preferences.cpp:674
+#: src/Preferences.cpp:675
 msgid "Albanian"
 msgstr "Albanski"
 
-#: src/Preferences.cpp:675
+#: src/Preferences.cpp:676
 msgid "Arabic"
 msgstr "Arapski"
 
-#: src/Preferences.cpp:676
+#: src/Preferences.cpp:677
 msgid "Asturian"
 msgstr "Asturleonski"
 
-#: src/Preferences.cpp:677
+#: src/Preferences.cpp:678
 msgid "Basque"
 msgstr "Baskijski"
 
-#: src/Preferences.cpp:678
+#: src/Preferences.cpp:679
 msgid "Bulgarian"
 msgstr "Bugarski"
 
-#: src/Preferences.cpp:679
+#: src/Preferences.cpp:680
 msgid "Catalan"
 msgstr "Katalonski"
 
-#: src/Preferences.cpp:680
+#: src/Preferences.cpp:681
 msgid "Chinese (Simplified)"
 msgstr "Kineski"
 
-#: src/Preferences.cpp:681
+#: src/Preferences.cpp:682
 msgid "Chinese (Traditional)"
 msgstr "Kinesko (tradicionalno)"
 
-#: src/Preferences.cpp:682
+#: src/Preferences.cpp:683
 msgid "Croatian"
 msgstr "Hrvatski"
 
-#: src/Preferences.cpp:683
+#: src/Preferences.cpp:684
 msgid "Czech"
 msgstr "Češki"
 
-#: src/Preferences.cpp:684
+#: src/Preferences.cpp:685
 msgid "Danish"
 msgstr "Danski"
 
-#: src/Preferences.cpp:685
+#: src/Preferences.cpp:686
 msgid "Dutch"
 msgstr "Nizozemski"
 
-#: src/Preferences.cpp:686
+#: src/Preferences.cpp:687
 msgid "English (U.K.)"
 msgstr "Engleski (U.K.)"
 
-#: src/Preferences.cpp:687
+#: src/Preferences.cpp:688
 #, fuzzy
 msgid "English (U.S.)"
 msgstr "Engleski (U.K.)"
 
-#: src/Preferences.cpp:688
+#: src/Preferences.cpp:689
 msgid "Estonian"
 msgstr "Estonski"
 
-#: src/Preferences.cpp:689
+#: src/Preferences.cpp:690
 msgid "Finnish"
 msgstr "Finski"
 
-#: src/Preferences.cpp:690
+#: src/Preferences.cpp:691
 msgid "French"
 msgstr "Francuski"
 
-#: src/Preferences.cpp:691
+#: src/Preferences.cpp:692
 msgid "Galician"
 msgstr "Galješki"
 
-#: src/Preferences.cpp:692
+#: src/Preferences.cpp:693
 msgid "German"
 msgstr "Njemački"
 
-#: src/Preferences.cpp:693
+#: src/Preferences.cpp:694
 msgid "Greek"
 msgstr "Grčki"
 
-#: src/Preferences.cpp:694
+#: src/Preferences.cpp:695
 msgid "Hebrew"
 msgstr "Hebrejski"
 
-#: src/Preferences.cpp:695
+#: src/Preferences.cpp:696
 msgid "Hungarian"
 msgstr "Mađarski"
 
-#: src/Preferences.cpp:696
+#: src/Preferences.cpp:697
 msgid "Italian"
 msgstr "Talijanski"
 
-#: src/Preferences.cpp:697
+#: src/Preferences.cpp:698
 msgid "Japanese"
 msgstr "Japanski"
 
-#: src/Preferences.cpp:698
+#: src/Preferences.cpp:699
 msgid "Korean"
 msgstr "Korejski"
 
-#: src/Preferences.cpp:699
+#: src/Preferences.cpp:700
 msgid "Latvian"
 msgstr ""
 
-#: src/Preferences.cpp:700
+#: src/Preferences.cpp:701
 msgid "Lithuanian"
 msgstr "Litavski"
 
-#: src/Preferences.cpp:701
+#: src/Preferences.cpp:702
 msgid "Norwegian (Nynorsk)"
 msgstr "Norveški (Nynorsk)"
 
-#: src/Preferences.cpp:702
+#: src/Preferences.cpp:703
 msgid "Polish"
 msgstr "Poljski"
 
-#: src/Preferences.cpp:703
+#: src/Preferences.cpp:704
 msgid "Portuguese"
 msgstr "Portugalski"
 
-#: src/Preferences.cpp:704
+#: src/Preferences.cpp:705
 msgid "Portuguese (Brazilian)"
 msgstr "Portugalski (Brazil)"
 
-#: src/Preferences.cpp:705
+#: src/Preferences.cpp:706
 msgid "Romanian"
 msgstr "Rumunjski"
 
-#: src/Preferences.cpp:706
+#: src/Preferences.cpp:707
 msgid "Russian"
 msgstr "Ruski"
 
-#: src/Preferences.cpp:707
+#: src/Preferences.cpp:708
 msgid "Slovenian"
 msgstr "Slovenski"
 
-#: src/Preferences.cpp:708
+#: src/Preferences.cpp:709
 msgid "Spanish"
 msgstr "Španjolski"
 
-#: src/Preferences.cpp:709
+#: src/Preferences.cpp:710
 msgid "Swedish"
 msgstr "Švedski"
 
-#: src/Preferences.cpp:710
+#: src/Preferences.cpp:711
 msgid "Turkish"
 msgstr "Turski"
 
-#: src/Preferences.cpp:711
+#: src/Preferences.cpp:712
 msgid "Ukrainian"
 msgstr "Ukrajinski"
 
-#: src/Preferences.cpp:814
+#: src/Preferences.cpp:815
 msgid "Change Language"
 msgstr "Promijeniti jezik"
 
-#: src/Preferences.cpp:878
+#: src/Preferences.cpp:879
 msgid "There are no translations installed for aMule"
 msgstr ""
 
-#: src/Preferences.cpp:879
+#: src/Preferences.cpp:880
 msgid "No languages available"
 msgstr "Nema dostupnih jezika"
 
-#: src/Preferences.cpp:1010
+#: src/Preferences.cpp:1011
 msgid "no options available"
 msgstr ""
 
-#: src/Preferences.cpp:2179
+#: src/Preferences.cpp:2182
 msgid "Invalid category found, skipping"
 msgstr ""
 
-#: src/Preferences.cpp:2348
+#: src/Preferences.cpp:2351
 msgid "TCP port can't be higher than 65532 due to server UDP socket being TCP+3"
 msgstr ""
 
-#: src/Preferences.cpp:2349
+#: src/Preferences.cpp:2352
 #, c-format
 msgid "Default port will be used (%d)"
 msgstr ""
@@ -6082,24 +6095,28 @@ msgstr ""
 msgid "Shared folder"
 msgstr "Dijeljeni fajlovi"
 
-#: src/SearchDlg.cpp:425
+#: src/SearchDlg.cpp:280
+msgid "Clear search history"
+msgstr ""
+
+#: src/SearchDlg.cpp:584
 msgid "It's impossible to search when both eD2k and Kademlia are disabled."
 msgstr ""
 
-#: src/SearchDlg.cpp:426 src/SearchListCtrl.cpp:858
+#: src/SearchDlg.cpp:585 src/SearchListCtrl.cpp:858
 #, fuzzy
 msgid "Search error"
 msgstr "Pretrage"
 
-#: src/SearchDlg.cpp:768
+#: src/SearchDlg.cpp:929
 msgid "Min size must be smaller than max size. Max size ignored."
 msgstr ""
 
-#: src/SearchDlg.cpp:769 src/SearchDlg.cpp:851
+#: src/SearchDlg.cpp:930 src/SearchDlg.cpp:1012
 msgid "Search warning"
 msgstr ""
 
-#: src/SearchDlg.cpp:929 src/SearchListCtrl.cpp:735
+#: src/SearchDlg.cpp:1092 src/SearchListCtrl.cpp:735
 msgid "Main"
 msgstr ""
 

--- a/po/hu.po
+++ b/po/hu.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-28 12:17+0200\n"
+"POT-Creation-Date: 2026-07-28 13:09+0200\n"
 "PO-Revision-Date: 2026-07-27 11:39+0000\n"
 "Last-Translator: Dévai Tamás <gonosztopi@amule.org>\n"
 "Language-Team: Hungarian <hu@li.org>\n"
@@ -296,7 +296,7 @@ msgid "Password set and external connections enabled."
 msgstr "Jelszó beállítva, külső kapcsolatok engedélyezve."
 
 #: src/amule.cpp:755 src/KadDlg.cpp:176 src/KadDlg.cpp:185
-#: src/PrefsUnifiedDlg.cpp:1461 src/SharedFilesCtrl.cpp:476
+#: src/PrefsUnifiedDlg.cpp:1470 src/SharedFilesCtrl.cpp:476
 msgid "WARNING"
 msgstr "FIGYELEM"
 
@@ -333,7 +333,7 @@ msgstr "A web szerver futtatását kérte induláskor, de az amuleweb program ne
 #: src/amule-remote-gui.cpp:603 src/amule-remote-gui.cpp:671
 #: src/amule-remote-gui.cpp:709 src/amule-remote-gui.cpp:1282
 #: src/amule-remote-gui.cpp:1345 src/amule-remote-gui.cpp:1372
-#: src/DownloadQueue.cpp:1481 src/PrefsUnifiedDlg.cpp:1247
+#: src/DownloadQueue.cpp:1481 src/PrefsUnifiedDlg.cpp:1256
 msgid "ERROR"
 msgstr "HIBA"
 
@@ -594,36 +594,36 @@ msgstr "Új verzióért látogasd meg a https://github.com/amule-org/amule/relea
 msgid "FATAL ERROR: Failed to create Timer"
 msgstr "VÉGZETES HIBA: Időzítő létrehozása sikertelen"
 
-#: src/amuleDlg.cpp:361 src/amuleDlg.cpp:1787 src/amuleDlg.cpp:2033
-#: src/muuli_wdr.cpp:1492 src/muuli_wdr.cpp:3449
+#: src/amuleDlg.cpp:361 src/amuleDlg.cpp:1810 src/amuleDlg.cpp:2056
+#: src/muuli_wdr.cpp:1492 src/muuli_wdr.cpp:3453
 msgid "Networks"
 msgstr "Hálózatok"
 
-#: src/amuleDlg.cpp:362 src/amuleDlg.cpp:1793 src/muuli_wdr.cpp:3450
+#: src/amuleDlg.cpp:362 src/amuleDlg.cpp:1816 src/muuli_wdr.cpp:3454
 msgid "Searches"
 msgstr "Keresések"
 
-#: src/amuleDlg.cpp:363 src/amuleDlg.cpp:1799 src/DownloadListCtrl.cpp:740
-#: src/muuli_wdr.cpp:392 src/muuli_wdr.cpp:1585 src/muuli_wdr.cpp:3451
+#: src/amuleDlg.cpp:363 src/amuleDlg.cpp:1822 src/DownloadListCtrl.cpp:740
+#: src/muuli_wdr.cpp:392 src/muuli_wdr.cpp:1585 src/muuli_wdr.cpp:3455
 #: src/Statistics.cpp:829
 msgid "Downloads"
 msgstr "Letöltések"
 
-#: src/amuleDlg.cpp:364 src/amuleDlg.cpp:1805 src/muuli_wdr.cpp:3325
+#: src/amuleDlg.cpp:364 src/amuleDlg.cpp:1828 src/muuli_wdr.cpp:3329
 msgid "Shared files"
 msgstr "Megosztott fájlok"
 
-#: src/amuleDlg.cpp:365 src/amuleDlg.cpp:1811 src/muuli_wdr.cpp:2957
-#: src/muuli_wdr.cpp:3407 src/muuli_wdr.cpp:3454
+#: src/amuleDlg.cpp:365 src/amuleDlg.cpp:1834 src/muuli_wdr.cpp:2961
+#: src/muuli_wdr.cpp:3411 src/muuli_wdr.cpp:3458
 msgid "Messages"
 msgstr "Üzenetek"
 
-#: src/amuleDlg.cpp:366 src/amuleDlg.cpp:1817 src/muuli_wdr.cpp:3455
+#: src/amuleDlg.cpp:366 src/amuleDlg.cpp:1840 src/muuli_wdr.cpp:3459
 #: src/PrefsUnifiedDlg.cpp:314 src/Statistics.cpp:779 src/Statistics.cpp:1235
 msgid "Statistics"
 msgstr "Statisztikák"
 
-#: src/amuleDlg.cpp:368 src/amuleDlg.cpp:1824 src/muuli_wdr.cpp:3457
+#: src/amuleDlg.cpp:368 src/amuleDlg.cpp:1847 src/muuli_wdr.cpp:3461
 #: src/PrefsUnifiedDlg.cpp:330 src/utils/wxCas/src/wxcasprefs.cpp:39
 msgid "Preferences"
 msgstr "Beállítások"
@@ -682,8 +682,8 @@ msgstr "Kad: Nincs kapcsolat"
 #: src/amuleDlg.cpp:1029 src/DownloadListCtrl.cpp:505
 #: src/DownloadListCtrl.cpp:749 src/FriendListCtrl.cpp:180
 #: src/muuli_wdr.cpp:731 src/muuli_wdr.cpp:782 src/muuli_wdr.cpp:846
-#: src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2262 src/muuli_wdr.cpp:2347
-#: src/muuli_wdr.cpp:3095 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
+#: src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2266 src/muuli_wdr.cpp:2351
+#: src/muuli_wdr.cpp:3099 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
 #: src/ServerListCtrl.cpp:606 src/TransferWnd.cpp:378
 #: src/utils/wxCas/src/wxcasprefs.cpp:235
 msgid "Cancel"
@@ -694,7 +694,7 @@ msgid "Stop the current connection attempts"
 msgstr "Aktuális kapcsolódási kísérletek leállítása"
 
 #: src/amuleDlg.cpp:1035 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976
-#: src/muuli_wdr.cpp:2485
+#: src/muuli_wdr.cpp:2489
 msgid "Disconnect"
 msgstr "Szétkapcsolás"
 
@@ -703,7 +703,7 @@ msgid "Disconnect from the currently connected networks"
 msgstr "Leválaszt az éppen kapcsolódott hálózatokról."
 
 #: src/amuleDlg.cpp:1041 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979
-#: src/muuli_wdr.cpp:2640 src/muuli_wdr.cpp:3092 src/muuli_wdr.cpp:3447
+#: src/muuli_wdr.cpp:2644 src/muuli_wdr.cpp:3096 src/muuli_wdr.cpp:3451
 msgid "Connect"
 msgstr "Kapcsolatfelvétel"
 
@@ -757,7 +757,7 @@ msgstr "Kilépés megerősítése"
 msgid "Launch Command: "
 msgstr "Parancs futtatása: "
 
-#: src/amuleDlg.cpp:1632 src/muuli_wdr.cpp:1982 src/Preferences.cpp:979
+#: src/amuleDlg.cpp:1632 src/muuli_wdr.cpp:1986 src/Preferences.cpp:979
 msgid "- default -"
 msgstr "- alapértelmezett -"
 
@@ -771,60 +771,60 @@ msgstr "A(z) '%s' felület könyvtár nem létezik"
 msgid "WARNING: Unable to open skin file '%s' for read"
 msgstr "FIGYELEM: Nem tudom a(z) '%s' felület fáljt megnyitni olvasásra"
 
-#: src/amuleDlg.cpp:1791 src/muuli_wdr.cpp:3449
+#: src/amuleDlg.cpp:1814 src/muuli_wdr.cpp:3453
 msgid "Networks Window"
 msgstr "Hálózatok ablaka"
 
-#: src/amuleDlg.cpp:1797 src/muuli_wdr.cpp:3450
+#: src/amuleDlg.cpp:1820 src/muuli_wdr.cpp:3454
 msgid "Searches Window"
 msgstr "Keresés ablaka"
 
-#: src/amuleDlg.cpp:1803 src/muuli_wdr.cpp:3451
+#: src/amuleDlg.cpp:1826 src/muuli_wdr.cpp:3455
 msgid "Downloads Window"
 msgstr "Letöltések ablaka"
 
-#: src/amuleDlg.cpp:1809 src/muuli_wdr.cpp:3453
+#: src/amuleDlg.cpp:1832 src/muuli_wdr.cpp:3457
 msgid "Shared Files Window"
 msgstr "Megosztott fájlok ablaka"
 
-#: src/amuleDlg.cpp:1815 src/muuli_wdr.cpp:3454
+#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3458
 msgid "Messages Window"
 msgstr "Üzenetek ablaka"
 
-#: src/amuleDlg.cpp:1821 src/muuli_wdr.cpp:3455
+#: src/amuleDlg.cpp:1844 src/muuli_wdr.cpp:3459
 msgid "Statistics Graph Window"
 msgstr "Statisztikai grafikonok ablaka"
 
-#: src/amuleDlg.cpp:1828 src/muuli_wdr.cpp:3457
+#: src/amuleDlg.cpp:1851 src/muuli_wdr.cpp:3461
 msgid "Preferences Settings Window"
 msgstr "Tulajdonságok beállításának ablaka"
 
-#: src/amuleDlg.cpp:1831 src/muuli_wdr.cpp:3458
+#: src/amuleDlg.cpp:1854 src/muuli_wdr.cpp:3462
 msgid "Import"
 msgstr "Importálás"
 
-#: src/amuleDlg.cpp:1835 src/muuli_wdr.cpp:3458
+#: src/amuleDlg.cpp:1858 src/muuli_wdr.cpp:3462
 msgid "The partfile importer tool"
 msgstr "A részfájl importáló eszköz"
 
-#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3459
+#: src/amuleDlg.cpp:1861 src/muuli_wdr.cpp:3463
 #: src/utils/aLinkCreator/src/alcframe.cpp:262
 msgid "About"
 msgstr "Névjegy"
 
-#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3459
+#: src/amuleDlg.cpp:1861 src/muuli_wdr.cpp:3463
 msgid "About/Help"
 msgstr "Névjegy/Súgó"
 
-#: src/amuleDlg.cpp:2036
+#: src/amuleDlg.cpp:2059
 msgid "eD2k network"
 msgstr "eD2k hálózat"
 
-#: src/amuleDlg.cpp:2039
+#: src/amuleDlg.cpp:2062
 msgid "Kad network"
 msgstr "Kad hálózat"
 
-#: src/amuleDlg.cpp:2039
+#: src/amuleDlg.cpp:2062
 msgid "No network"
 msgstr "Nincs hálózat"
 
@@ -1354,19 +1354,19 @@ msgstr "Auto [Ma]"
 msgid "Very low"
 msgstr "Nagyon alacsony"
 
-#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:743 src/muuli_wdr.cpp:2313
+#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:743 src/muuli_wdr.cpp:2317
 #: src/ServerListCtrl.cpp:263 src/ServerListCtrl.cpp:456
 #: src/SharedFilesCtrl.cpp:145
 msgid "Low"
 msgstr "Alacsony"
 
-#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:744 src/muuli_wdr.cpp:2314
+#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:744 src/muuli_wdr.cpp:2318
 #: src/ServerListCtrl.cpp:266 src/ServerListCtrl.cpp:457
 #: src/SharedFilesCtrl.cpp:146
 msgid "Normal"
 msgstr "Normál"
 
-#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:745 src/muuli_wdr.cpp:2315
+#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:745 src/muuli_wdr.cpp:2319
 #: src/ServerListCtrl.cpp:269 src/ServerListCtrl.cpp:458
 #: src/SharedFilesCtrl.cpp:147
 msgid "High"
@@ -1458,7 +1458,7 @@ msgstr "Helyi kiszolgáló"
 msgid "Remote Server"
 msgstr "Távoli kiszolgáló"
 
-#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3212
+#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3216
 #: src/SearchDlg.cpp:119 src/TextClient.cpp:911
 msgid "Kad"
 msgstr "Kad"
@@ -1529,7 +1529,7 @@ msgstr "Rész"
 msgid "Size"
 msgstr "Méret"
 
-#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3279
+#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3283
 msgid "Transferred"
 msgstr "Átmásolva"
 
@@ -1587,7 +1587,7 @@ msgstr ""
 "Visszajelzés %s-től (%s):\n"
 "\n"
 
-#: src/DownloadListCtrl.cpp:746 src/muuli_wdr.cpp:2316
+#: src/DownloadListCtrl.cpp:746 src/muuli_wdr.cpp:2320
 #: src/SharedFilesCtrl.cpp:150
 msgid "Auto"
 msgstr "Automatikus"
@@ -1625,7 +1625,7 @@ msgid "Extended Options"
 msgstr "Kibővített beállítások"
 
 #: src/DownloadListCtrl.cpp:770 src/DownloadListCtrl.cpp:822
-#: src/muuli_wdr.cpp:1800
+#: src/muuli_wdr.cpp:1804
 msgid "Preview"
 msgstr "Előnézet"
 
@@ -2422,23 +2422,23 @@ msgid ""
 "want downloads on a different (e.g. larger) disk."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:549 src/FirstRunWizard.cpp:611 src/muuli_wdr.cpp:1712
+#: src/FirstRunWizard.cpp:549 src/FirstRunWizard.cpp:611 src/muuli_wdr.cpp:1716
 msgid "Destination folder for downloads"
 msgstr "Célkönyvtár a letöltéseknek"
 
 #: src/FirstRunWizard.cpp:553 src/FirstRunWizard.cpp:569 src/muuli_wdr.cpp:1349
-#: src/muuli_wdr.cpp:1366 src/muuli_wdr.cpp:1687 src/muuli_wdr.cpp:1718
-#: src/muuli_wdr.cpp:1730 src/muuli_wdr.cpp:2800
+#: src/muuli_wdr.cpp:1366 src/muuli_wdr.cpp:1691 src/muuli_wdr.cpp:1722
+#: src/muuli_wdr.cpp:1734 src/muuli_wdr.cpp:2804
 #: src/utils/aLinkCreator/src/alcframe.cpp:135
 #: src/utils/wxCas/src/wxcasprefs.cpp:52 src/utils/wxCas/src/wxcasprefs.cpp:118
 msgid "Browse"
 msgstr "Tallóz"
 
-#: src/FirstRunWizard.cpp:559 src/muuli_wdr.cpp:1723
+#: src/FirstRunWizard.cpp:559 src/muuli_wdr.cpp:1727
 msgid "(All files in this folder are shared with other peers)"
 msgstr "(Minden fájl ebben a könyvtárban másokkal megosztásra kerül)"
 
-#: src/FirstRunWizard.cpp:565 src/FirstRunWizard.cpp:624 src/muuli_wdr.cpp:1725
+#: src/FirstRunWizard.cpp:565 src/FirstRunWizard.cpp:624 src/muuli_wdr.cpp:1729
 msgid "Folder for temporary download files"
 msgstr "Könyvtár az ideiglenes letöltési fájloknak"
 
@@ -2469,7 +2469,7 @@ msgstr "A barátokat tartalmazó emfriends.dat fájl írásra megnyitása sikert
 msgid "CRITICAL - no client on StartChatSession"
 msgstr "KRITIKUS - nincsen kliens a StartChatSession-en"
 
-#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2706 src/muuli_wdr.cpp:3383
+#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2710 src/muuli_wdr.cpp:3387
 msgid "Friends"
 msgstr "Barátok"
 
@@ -2579,8 +2579,8 @@ msgstr "Egyik sem"
 msgid "No"
 msgstr "Nem"
 
-#: src/GenericClientListCtrl.cpp:1216 src/PrefsUnifiedDlg.cpp:2898
-#: src/PrefsUnifiedDlg.cpp:2948 src/ServerListCtrl.cpp:276
+#: src/GenericClientListCtrl.cpp:1216 src/PrefsUnifiedDlg.cpp:2907
+#: src/PrefsUnifiedDlg.cpp:2957 src/ServerListCtrl.cpp:276
 msgid "Yes"
 msgstr "Igen"
 
@@ -2747,10 +2747,10 @@ msgstr "Érvénytelen port a rendszerindításhoz"
 msgid "Please fill all fields required"
 msgstr "Kérlek töltsd ki az összes kötelező mezőt"
 
-#: src/KadDlg.cpp:192 src/PartFile.cpp:1031 src/PrefsUnifiedDlg.cpp:1134
-#: src/PrefsUnifiedDlg.cpp:1204 src/PrefsUnifiedDlg.cpp:1405
-#: src/PrefsUnifiedDlg.cpp:1663 src/PrefsUnifiedDlg.cpp:1673
-#: src/PrefsUnifiedDlg.cpp:1690 src/PrefsUnifiedDlg.cpp:1738
+#: src/KadDlg.cpp:192 src/PartFile.cpp:1031 src/PrefsUnifiedDlg.cpp:1143
+#: src/PrefsUnifiedDlg.cpp:1213 src/PrefsUnifiedDlg.cpp:1414
+#: src/PrefsUnifiedDlg.cpp:1672 src/PrefsUnifiedDlg.cpp:1682
+#: src/PrefsUnifiedDlg.cpp:1699 src/PrefsUnifiedDlg.cpp:1747
 msgid "Message"
 msgstr "Üzenet"
 
@@ -2849,7 +2849,7 @@ msgstr "Megosztási arány"
 msgid "Uploaded"
 msgstr "Feltöltve"
 
-#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3263
+#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3267
 msgid "Requested"
 msgstr "Kért"
 
@@ -2973,7 +2973,7 @@ msgid "WARNING: "
 msgstr "FIGYELEM: "
 
 #: src/MuleNotebook.cpp:179 src/muuli_wdr.cpp:817 src/muuli_wdr.cpp:1229
-#: src/muuli_wdr.cpp:3167 src/muuli_wdr.cpp:3423
+#: src/muuli_wdr.cpp:3171 src/muuli_wdr.cpp:3427
 msgid "Close"
 msgstr "Bezár"
 
@@ -2991,7 +2991,7 @@ msgid "Paste"
 msgstr "Beillesztés"
 
 #: src/MuleTextCtrl.cpp:89 src/muuli_wdr.cpp:358 src/muuli_wdr.cpp:757
-#: src/muuli_wdr.cpp:2390 src/muuli_wdr.cpp:2409 src/muuli_wdr.cpp:2431
+#: src/muuli_wdr.cpp:2394 src/muuli_wdr.cpp:2413 src/muuli_wdr.cpp:2435
 #: src/utils/aLinkCreator/src/alcframe.cpp:142
 msgid "Clear"
 msgstr "Törlés"
@@ -3083,7 +3083,7 @@ msgstr "Kilépés"
 
 #: src/MuleTrayIcon.cpp:579 src/MuleTrayIcon.cpp:945 src/MuleTrayIcon.cpp:965
 #: src/muuli_wdr.cpp:1398 src/muuli_wdr.cpp:1406 src/muuli_wdr.cpp:1413
-#: src/muuli_wdr.cpp:1846 src/muuli_wdr.cpp:1852 src/OtherFunctions.cpp:91
+#: src/muuli_wdr.cpp:1850 src/muuli_wdr.cpp:1856 src/OtherFunctions.cpp:91
 #: src/StatisticsDlg.cpp:93 src/StatisticsDlg.cpp:95
 msgid "kB/s"
 msgstr "kB/s"
@@ -3325,7 +3325,7 @@ msgstr "bájt"
 msgid "KB"
 msgstr "KB"
 
-#: src/muuli_wdr.cpp:274 src/muuli_wdr.cpp:293 src/muuli_wdr.cpp:1631
+#: src/muuli_wdr.cpp:274 src/muuli_wdr.cpp:293 src/muuli_wdr.cpp:1635
 #: src/OtherFunctions.cpp:64
 msgid "MB"
 msgstr "MB"
@@ -3342,7 +3342,7 @@ msgstr "Max. méret"
 msgid "Availability"
 msgstr "Elérhetőség"
 
-#: src/muuli_wdr.cpp:312 src/muuli_wdr.cpp:398 src/muuli_wdr.cpp:3328
+#: src/muuli_wdr.cpp:312 src/muuli_wdr.cpp:398 src/muuli_wdr.cpp:3332
 msgid "Filter:"
 msgstr "Szűrő:"
 
@@ -3405,8 +3405,8 @@ msgstr "Fájl források:"
 #: src/muuli_wdr.cpp:1160 src/muuli_wdr.cpp:1167 src/muuli_wdr.cpp:1172
 #: src/muuli_wdr.cpp:1179 src/muuli_wdr.cpp:1184 src/muuli_wdr.cpp:1191
 #: src/muuli_wdr.cpp:1205 src/muuli_wdr.cpp:1212 src/muuli_wdr.cpp:1217
-#: src/muuli_wdr.cpp:1224 src/muuli_wdr.cpp:3265 src/muuli_wdr.cpp:3273
-#: src/muuli_wdr.cpp:3281
+#: src/muuli_wdr.cpp:1224 src/muuli_wdr.cpp:3269 src/muuli_wdr.cpp:3277
+#: src/muuli_wdr.cpp:3285
 msgid "N/A"
 msgstr "N/A"
 
@@ -3551,7 +3551,7 @@ msgstr ""
 msgid "Album :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:685 src/muuli_wdr.cpp:2285
+#: src/muuli_wdr.cpp:685 src/muuli_wdr.cpp:2289
 msgid "Title :"
 msgstr "Cím :"
 
@@ -3660,7 +3660,7 @@ msgstr "User név :"
 msgid "Userhash :"
 msgstr "Userhash :"
 
-#: src/muuli_wdr.cpp:895 src/muuli_wdr.cpp:1752 src/muuli_wdr.cpp:2480
+#: src/muuli_wdr.cpp:895 src/muuli_wdr.cpp:1756 src/muuli_wdr.cpp:2484
 #: src/utils/aLinkCreator/src/alcframe.cpp:137
 msgid "Add"
 msgstr "Hozzáad"
@@ -3669,15 +3669,15 @@ msgstr "Hozzáad"
 msgid "Download-Speed"
 msgstr "Letöltési sebesség"
 
-#: src/muuli_wdr.cpp:954 src/muuli_wdr.cpp:989 src/muuli_wdr.cpp:2584
+#: src/muuli_wdr.cpp:954 src/muuli_wdr.cpp:989 src/muuli_wdr.cpp:2588
 msgid "Current"
 msgstr "Aktuális"
 
-#: src/muuli_wdr.cpp:962 src/muuli_wdr.cpp:997 src/muuli_wdr.cpp:2592
+#: src/muuli_wdr.cpp:962 src/muuli_wdr.cpp:997 src/muuli_wdr.cpp:2596
 msgid "Running average"
 msgstr "Futásátlag"
 
-#: src/muuli_wdr.cpp:970 src/muuli_wdr.cpp:1005 src/muuli_wdr.cpp:2600
+#: src/muuli_wdr.cpp:970 src/muuli_wdr.cpp:1005 src/muuli_wdr.cpp:2604
 msgid "Session average"
 msgstr "Munkafolyamatok átlaga"
 
@@ -3689,7 +3689,7 @@ msgstr "Feltöltési sebesség"
 msgid "Connections"
 msgstr "Kapcsolatok"
 
-#: src/muuli_wdr.cpp:1024 src/muuli_wdr.cpp:1871
+#: src/muuli_wdr.cpp:1024 src/muuli_wdr.cpp:1875
 msgid "Active downloads"
 msgstr "Aktív letöltések"
 
@@ -3697,7 +3697,7 @@ msgstr "Aktív letöltések"
 msgid "Active connections (1:1)"
 msgstr "Aktív kapcsolatok (1:1)"
 
-#: src/muuli_wdr.cpp:1040 src/muuli_wdr.cpp:1872
+#: src/muuli_wdr.cpp:1040 src/muuli_wdr.cpp:1876
 msgid "Active uploads"
 msgstr "Aktív feltöltések"
 
@@ -3973,7 +3973,7 @@ msgstr "Lokális cím IP-hez csatolása (mindet ha üres):"
 msgid "Advanced users only: If you have multiple network interfaces, enter the address of the interface to which aMule should be bound."
 msgstr "Csak haladó felhasználóknak: Ha több hálózati kártyád van, írd ide a címet, amelyhez az aMule kötve legyen."
 
-#: src/muuli_wdr.cpp:1462 src/muuli_wdr.cpp:2065
+#: src/muuli_wdr.cpp:1462 src/muuli_wdr.cpp:2069
 #, fuzzy
 msgid "Bind to network interface (empty for any):"
 msgstr "Lokális cím IP-hez csatolása (mindet ha üres):"
@@ -3990,7 +3990,7 @@ msgstr "Max források letöltési fájlonként:"
 msgid "Max simultaneous connections:"
 msgstr "Max egyidejű kapcsolatok:"
 
-#: src/muuli_wdr.cpp:1498 src/muuli_wdr.cpp:3207
+#: src/muuli_wdr.cpp:1498 src/muuli_wdr.cpp:3211
 msgid "ED2K"
 msgstr "ED2K"
 
@@ -4082,79 +4082,79 @@ msgstr "Lemezterület helyfogalalás az új fájloknak"
 msgid "For new files preallocates disk space for the whole file, thus reduces fragmentation"
 msgstr "Az új fájlok számára előre lefoglalja a lemezterületet, így csökkentve a töredezettséget"
 
-#: src/muuli_wdr.cpp:1617
+#: src/muuli_wdr.cpp:1621
 msgid "Create new files as sparse files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1618
+#: src/muuli_wdr.cpp:1622
 msgid "Sparse part files only occupy disk space for the parts already downloaded, so free space is used up gradually as the file fills in. Turn this off to use an ordinary file instead - useful where sparse files are unsupported or slow, or where backup/de-duplication tools handle them badly. Applies only when the core runs on Windows; on Linux and macOS part files are sparse anyway and this setting has no effect."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1623
+#: src/muuli_wdr.cpp:1627
 msgid "Stop downloads when free disk space reaches "
 msgstr "Letöltések megállítása amikor a szabad hely kevesebb mint "
 
-#: src/muuli_wdr.cpp:1624
+#: src/muuli_wdr.cpp:1628
 msgid "Select this if you want aMule to check your disk space"
 msgstr "Jelöld be, ha azt szeretnéd, hogy az aMule ellenőrizze a szabad lemezterületet"
 
-#: src/muuli_wdr.cpp:1628
+#: src/muuli_wdr.cpp:1632
 msgid "Enter here the min disk space desired."
 msgstr "Add meg a kívánt min. szabad lemezterületet."
 
-#: src/muuli_wdr.cpp:1634
+#: src/muuli_wdr.cpp:1638
 msgid "Save 10 sources on rare files (< 20 sources)"
 msgstr "Mentsen el 10 forrást ritka fájloknál (< 20 forrás)"
 
-#: src/muuli_wdr.cpp:1638 src/Statistics.cpp:790
+#: src/muuli_wdr.cpp:1642 src/Statistics.cpp:790
 msgid "Uploads"
 msgstr "Feltöltések"
 
-#: src/muuli_wdr.cpp:1641
+#: src/muuli_wdr.cpp:1645
 msgid "Add new shared files with auto priority"
 msgstr "Új megosztott fájl felvétele automatikus prioritással"
 
-#: src/muuli_wdr.cpp:1647
+#: src/muuli_wdr.cpp:1651
 msgid "Intelligent Corruption Handling (I.C.H.)"
 msgstr "Intelligens Sérülés Kezelő (I.S.K.)"
 
-#: src/muuli_wdr.cpp:1650
+#: src/muuli_wdr.cpp:1654
 msgid "Enable"
 msgstr "Engedélyezés"
 
-#: src/muuli_wdr.cpp:1653
+#: src/muuli_wdr.cpp:1657
 msgid "Advanced I.C.H. trusts every hash (not recommended)"
 msgstr "Feljett I.S.K. megbízzon minden hash-ben (nem ajánlott)"
 
-#: src/muuli_wdr.cpp:1665 src/PrefsUnifiedDlg.cpp:1990
+#: src/muuli_wdr.cpp:1669 src/PrefsUnifiedDlg.cpp:1999
 msgid "Media metadata extraction"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1669
+#: src/muuli_wdr.cpp:1673
 msgid "Extract length / bitrate / codec from shared audio and video files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1671
+#: src/muuli_wdr.cpp:1675
 msgid "When enabled, aMule runs ffprobe on each shared media file to fill in the Length / Bitrate / Codec columns other clients see when they find the file in a search. Requires ffmpeg (the ffprobe binary) to be installed."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1678
+#: src/muuli_wdr.cpp:1682
 msgid "Path to ffprobe:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1683
+#: src/muuli_wdr.cpp:1687
 msgid "Full path to the ffprobe binary. Leave empty to have aMule auto-detect it on startup."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1691
+#: src/muuli_wdr.cpp:1695
 msgid "Detect"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1692
+#: src/muuli_wdr.cpp:1696
 msgid "Search the standard install locations for an ffprobe binary and fill the path field."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1716
+#: src/muuli_wdr.cpp:1720
 msgid ""
 "Completed downloads are stored here. All files in this folder are automatically shared with other peers.\n"
 "If this folder also holds files you don't want to share, point it at an aMule-only sub-folder."
@@ -4162,695 +4162,695 @@ msgstr ""
 "Elvégzett letöltések tárolási helye. Minden fájl ebben a könytárban automatikusan megosztásra kerül másokkal.\n"
 "Ha a könyvtár fájlokat tartalmaz, amelyek ne kerüljenek megosztásra, állítsa át egy megfelelő alkönyvtárra."
 
-#: src/muuli_wdr.cpp:1719
+#: src/muuli_wdr.cpp:1723
 msgid "Pick the folder where completed downloads will be stored. All files in that folder will be shared with other peers."
 msgstr "Válassza ki a könyvtárat az elvégzett letöltéseknek. A könyvtár minden fájlja másokkal megosztásra kerül."
 
-#: src/muuli_wdr.cpp:1733
+#: src/muuli_wdr.cpp:1737
 msgid "Shared folders"
 msgstr "Megosztott mappák"
 
-#: src/muuli_wdr.cpp:1739
+#: src/muuli_wdr.cpp:1743
 msgid "(Folders shared by the core. Enter a path to add one.)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1747
+#: src/muuli_wdr.cpp:1751
 msgid "Absolute path of a folder on the core's machine, e.g. /home/user/shared"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1749 src/PrefsUnifiedDlg.cpp:2874
+#: src/muuli_wdr.cpp:1753 src/PrefsUnifiedDlg.cpp:2883
 msgid "Recursive"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1750
+#: src/muuli_wdr.cpp:1754
 msgid "Share every sub-folder underneath this one, including ones created later."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1754 src/utils/aLinkCreator/src/alcframe.cpp:141
+#: src/muuli_wdr.cpp:1758 src/utils/aLinkCreator/src/alcframe.cpp:141
 msgid "Remove"
 msgstr "Eltávolít"
 
-#: src/muuli_wdr.cpp:1758
+#: src/muuli_wdr.cpp:1762
 msgid "(Right click on folder icon for recursive share)"
 msgstr "(Jobb klikk az mappa ikonra az összes alatta levő mappát is megosztja)"
 
-#: src/muuli_wdr.cpp:1765
+#: src/muuli_wdr.cpp:1769
 msgid "Share hidden files"
 msgstr "Rejtett fájlok megosztása"
 
-#: src/muuli_wdr.cpp:1771
+#: src/muuli_wdr.cpp:1775
 msgid "Automatically rescan shared folders for changes"
 msgstr "Megosztott könyvtárak automatikus újraszkennelése"
 
-#: src/muuli_wdr.cpp:1777
+#: src/muuli_wdr.cpp:1781
 msgid "Follow symbolic links in shared folders"
 msgstr "Szimbólikus hivatkozások követése megosztott könyvtárakban"
 
-#: src/muuli_wdr.cpp:1783
+#: src/muuli_wdr.cpp:1787
 msgid "Exclude files matching:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1786
+#: src/muuli_wdr.cpp:1790
 msgid "Wildcard patterns separated by '|', e.g. .DS_Store|Thumbs.db|*.tmp. Files whose name matches are not shared. Matching is case-insensitive."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1790
+#: src/muuli_wdr.cpp:1794
 msgid "Patterns are regular expressions"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1791
+#: src/muuli_wdr.cpp:1795
 msgid "When set, the whole field is one regular expression ('|' is alternation). When unset, it is a list of '|'-separated wildcards."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1801
+#: src/muuli_wdr.cpp:1805
 msgid "Show how many shared files the current pattern would exclude."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1822
+#: src/muuli_wdr.cpp:1826
 msgid "Graphs"
 msgstr "Grafikonok"
 
-#: src/muuli_wdr.cpp:1825 src/muuli_wdr.cpp:1887
+#: src/muuli_wdr.cpp:1829 src/muuli_wdr.cpp:1891
 msgid "Update delay : 5 secs"
 msgstr "Frissítés késleltetés: 5 mp"
 
-#: src/muuli_wdr.cpp:1829
+#: src/muuli_wdr.cpp:1833
 msgid "Time for average graph: 100 mins"
 msgstr "Grafikon átlagos ideje: 100 perc"
 
-#: src/muuli_wdr.cpp:1833
+#: src/muuli_wdr.cpp:1837
 msgid "Connections Graph Scale: 100 "
 msgstr "Kapcsolatok grafikon skálája: 100 "
 
-#: src/muuli_wdr.cpp:1840
+#: src/muuli_wdr.cpp:1844
 msgid "Download graph scale:"
 msgstr "Letöltési grafikon méretaránya:"
 
-#: src/muuli_wdr.cpp:1848
+#: src/muuli_wdr.cpp:1852
 msgid "Upload graph scale:"
 msgstr "Feltöltési grafikon méretaránya:"
 
-#: src/muuli_wdr.cpp:1858
+#: src/muuli_wdr.cpp:1862
 msgid "Colors: "
 msgstr "Színek: "
 
-#: src/muuli_wdr.cpp:1862
+#: src/muuli_wdr.cpp:1866
 msgid "Background"
 msgstr "Háttér"
 
-#: src/muuli_wdr.cpp:1863
+#: src/muuli_wdr.cpp:1867
 msgid "Grid"
 msgstr "Rács"
 
-#: src/muuli_wdr.cpp:1864
+#: src/muuli_wdr.cpp:1868
 msgid "Download current"
 msgstr "Aktuális letöltés"
 
-#: src/muuli_wdr.cpp:1865
+#: src/muuli_wdr.cpp:1869
 msgid "Download running average"
 msgstr "Letöltési futás átlaga"
 
-#: src/muuli_wdr.cpp:1866
+#: src/muuli_wdr.cpp:1870
 msgid "Download session average"
 msgstr "Letöltési folyamatok átlaga"
 
-#: src/muuli_wdr.cpp:1867
+#: src/muuli_wdr.cpp:1871
 msgid "Upload current"
 msgstr "Aktuális feltöltés"
 
-#: src/muuli_wdr.cpp:1868
+#: src/muuli_wdr.cpp:1872
 msgid "Upload running average"
 msgstr "Feltöltési futás átlaga"
 
-#: src/muuli_wdr.cpp:1869
+#: src/muuli_wdr.cpp:1873
 msgid "Upload session average"
 msgstr "Feltöltési folyamatok átlaga"
 
-#: src/muuli_wdr.cpp:1870
+#: src/muuli_wdr.cpp:1874
 msgid "Active connections"
 msgstr "Aktív kapcsolatok"
 
-#: src/muuli_wdr.cpp:1873
+#: src/muuli_wdr.cpp:1877
 msgid "Systray Icon Speed Bar"
 msgstr "Sebességmérő a rendszertálcán"
 
-#: src/muuli_wdr.cpp:1874
+#: src/muuli_wdr.cpp:1878
 msgid "Kad-nodes current"
 msgstr "Kad-csomópontok aktuális"
 
-#: src/muuli_wdr.cpp:1875
+#: src/muuli_wdr.cpp:1879
 msgid "Kad-nodes running"
 msgstr "Kad-csomópontok futó"
 
-#: src/muuli_wdr.cpp:1876
+#: src/muuli_wdr.cpp:1880
 msgid "Kad-nodes session"
 msgstr "Kad-csomópontok folyamat"
 
-#: src/muuli_wdr.cpp:1880 src/muuli_wdr.cpp:2334
+#: src/muuli_wdr.cpp:1884 src/muuli_wdr.cpp:2338
 msgid "Select"
 msgstr "Kiválaszt"
 
-#: src/muuli_wdr.cpp:1884
+#: src/muuli_wdr.cpp:1888
 msgid "Tree"
 msgstr "Fa"
 
-#: src/muuli_wdr.cpp:1894
+#: src/muuli_wdr.cpp:1898
 msgid "Number of Client Versions shown (0=unlimited)"
 msgstr "Megjelenített ügyfél verziók száma (0=mind)"
 
-#: src/muuli_wdr.cpp:1919
+#: src/muuli_wdr.cpp:1923
 msgid "!!! WARNING !!!"
 msgstr "!!! FIGYELEM !!!"
 
-#: src/muuli_wdr.cpp:1934
+#: src/muuli_wdr.cpp:1938
 msgid "Max new connections / 5 secs"
 msgstr "Max új kapcsolat / 5 mp"
 
-#: src/muuli_wdr.cpp:1936
+#: src/muuli_wdr.cpp:1940
 msgid "Concurrent Kad source lookups"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1938
+#: src/muuli_wdr.cpp:1942
 #, fuzzy
 msgid "Kad source re-search interval (minutes)"
 msgstr "FTP frissítési gyakorisága percekben"
 
-#: src/muuli_wdr.cpp:1940
+#: src/muuli_wdr.cpp:1944
 #, fuzzy
 msgid "Source re-ask interval (minutes)"
 msgstr "FTP frissítési gyakorisága percekben"
 
-#: src/muuli_wdr.cpp:1944
+#: src/muuli_wdr.cpp:1948
 msgid "File Buffer Size: 240000 bytes"
 msgstr "Fájl buffer méret: 240000 bájt"
 
-#: src/muuli_wdr.cpp:1948
+#: src/muuli_wdr.cpp:1952
 msgid "Use MMAP: memory-mapped file access (lower memory use)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1949
+#: src/muuli_wdr.cpp:1953
 msgid "Maps part files into memory instead of buffering them on the heap, lowering the process memory footprint. May reduce download speed on some disks; best for memory-constrained or upload-heavy hosts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1951
+#: src/muuli_wdr.cpp:1955
 msgid "Upload Queue Size: 5000 clients"
 msgstr "Feltöltők várólistájának nagysága: 5000 kliens"
 
-#: src/muuli_wdr.cpp:1955
+#: src/muuli_wdr.cpp:1959
 msgid "Server connection refresh interval: Disable"
 msgstr "Kiszolgáló kapcsolat frissítési gyakorisága: Tiltva"
 
-#: src/muuli_wdr.cpp:1959
+#: src/muuli_wdr.cpp:1963
 msgid "Disable computer's timed standby mode"
 msgstr "Számítógép időzített készenléti állapotának hatástalanítása"
 
-#: src/muuli_wdr.cpp:1978
+#: src/muuli_wdr.cpp:1982
 msgid "Skin to use: "
 msgstr "Használt felület: "
 
-#: src/muuli_wdr.cpp:1987
+#: src/muuli_wdr.cpp:1991
 msgid "Show \"Fast eD2k Links Handler\" in every window."
 msgstr "A \"Gyors eD2k hivatkozás kezelő\" mutatása minden ablakban."
 
-#: src/muuli_wdr.cpp:1990
+#: src/muuli_wdr.cpp:1994
 msgid "Show extended info on categories tabs"
 msgstr "Kibővített infók megjelenítése a kategória füleken"
 
-#: src/muuli_wdr.cpp:1993
+#: src/muuli_wdr.cpp:1997
 msgid "Show application version on title"
 msgstr "Az alkalmazás verziójának megjelenítése a címsorban"
 
-#: src/muuli_wdr.cpp:1995
+#: src/muuli_wdr.cpp:1999
 msgid "Show transfer rates on title"
 msgstr "Átviteli ráták megjelenítése a címsorban"
 
-#: src/muuli_wdr.cpp:1997
+#: src/muuli_wdr.cpp:2001
 msgid "Before application name"
 msgstr "Az alkalmazás neve előtt"
 
-#: src/muuli_wdr.cpp:1999
+#: src/muuli_wdr.cpp:2003
 msgid "After application name"
 msgstr "Az alkalmazás neve után"
 
-#: src/muuli_wdr.cpp:2002
+#: src/muuli_wdr.cpp:2006
 msgid "Show overhead bandwidth"
 msgstr "Többletterhelés sávszélességének mutatása"
 
-#: src/muuli_wdr.cpp:2006
+#: src/muuli_wdr.cpp:2010
 msgid "Vertical toolbar orientation"
 msgstr "Függőleges eszköztár elrendezés"
 
-#: src/muuli_wdr.cpp:2008
+#: src/muuli_wdr.cpp:2012
 msgid "Live column sorting (auto-reorder rows as their values change)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2015
+#: src/muuli_wdr.cpp:2019
 msgid "Download Queue Files"
 msgstr "Letöltendő fájlok várakozási sora"
 
-#: src/muuli_wdr.cpp:2018
+#: src/muuli_wdr.cpp:2022
 msgid "Show progress percentage"
 msgstr "Százalékos arány mutatása"
 
-#: src/muuli_wdr.cpp:2024
+#: src/muuli_wdr.cpp:2028
 msgid "Show progress bar"
 msgstr "Folyamatjelző csík mutatása"
 
-#: src/muuli_wdr.cpp:2027
+#: src/muuli_wdr.cpp:2031
 msgid "Flat"
 msgstr "Lapos"
 
-#: src/muuli_wdr.cpp:2031
+#: src/muuli_wdr.cpp:2035
 msgid "Round"
 msgstr "Gömbölyű"
 
-#: src/muuli_wdr.cpp:2049
+#: src/muuli_wdr.cpp:2053
 msgid "External Connection Parameters"
 msgstr "Külső kapcsolatok jellemzői"
 
-#: src/muuli_wdr.cpp:2052
+#: src/muuli_wdr.cpp:2056
 msgid "Accept external connections"
 msgstr "Külső kapcsolat elfogadása"
 
-#: src/muuli_wdr.cpp:2059 src/muuli_wdr.cpp:2118
+#: src/muuli_wdr.cpp:2063 src/muuli_wdr.cpp:2122
 msgid "IP of the listening interface:"
 msgstr "Hallgató interfész IP-je:"
 
-#: src/muuli_wdr.cpp:2062
+#: src/muuli_wdr.cpp:2066
 msgid "Enter here a valid ip in the a.b.c.d format for the listening EC interface. An empty field or 0.0.0.0 will mean any interface."
 msgstr "Adjon meg itt egy érvényes IP címet a.b.c.d formában az EC hallgató interfésznek. Üres mező vagy 0.0.0.0 jelentése: bármelyik interfész."
 
-#: src/muuli_wdr.cpp:2083 src/muuli_wdr.cpp:2194
+#: src/muuli_wdr.cpp:2087 src/muuli_wdr.cpp:2198
 msgid "TCP port:"
 msgstr "TCP port:"
 
-#: src/muuli_wdr.cpp:2089
+#: src/muuli_wdr.cpp:2093
 msgid "Enable UPnP port forwarding on the EC port"
 msgstr "UPnP port továbbítás engedélyezése az EC porton"
 
-#: src/muuli_wdr.cpp:2093 src/muuli_wdr.cpp:3079
+#: src/muuli_wdr.cpp:2097 src/muuli_wdr.cpp:3083
 #: src/utils/wxCas/src/wxcasprefs.cpp:167
 msgid "Password"
 msgstr "Jelszó"
 
-#: src/muuli_wdr.cpp:2099
+#: src/muuli_wdr.cpp:2103
 #, fuzzy
 msgid "aMule API server parameters"
 msgstr "Web kiszolgáló paraméterek"
 
-#: src/muuli_wdr.cpp:2102
+#: src/muuli_wdr.cpp:2106
 msgid "Run amuleapi (REST API) on startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2107
+#: src/muuli_wdr.cpp:2111
 #, fuzzy
 msgid "HTTP port:"
 msgstr "TCP port:"
 
-#: src/muuli_wdr.cpp:2121
+#: src/muuli_wdr.cpp:2125
 msgid "The interface amuleapi's HTTP server listens on. 127.0.0.1 (default) accepts only local connections; use 0.0.0.0 or a specific IP to expose it to other hosts (set an admin password below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2126
+#: src/muuli_wdr.cpp:2130
 msgid "Type a password to set or change it. Stored passwords cannot be shown, so leaving this empty keeps the current one."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2128
+#: src/muuli_wdr.cpp:2132
 #, fuzzy
 msgid "Admin password"
 msgstr "Jelszó ellenőrzése\n"
 
-#: src/muuli_wdr.cpp:2140 src/muuli_wdr.cpp:2157 src/PrefsUnifiedDlg.cpp:1103
+#: src/muuli_wdr.cpp:2144 src/muuli_wdr.cpp:2161 src/PrefsUnifiedDlg.cpp:1112
 #, fuzzy
 msgid "A password is set."
 msgstr "Jelszó ellenőrzése\n"
 
-#: src/muuli_wdr.cpp:2144
+#: src/muuli_wdr.cpp:2148
 #, fuzzy
 msgid "Enable guest access"
 msgstr "Vendég felhasználó tiltása"
 
-#: src/muuli_wdr.cpp:2145
+#: src/muuli_wdr.cpp:2149
 msgid "Guest sessions may read status and listings but cannot change anything. Turning this off clears the stored guest password."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2149
+#: src/muuli_wdr.cpp:2153
 #, fuzzy
 msgid "Guest password"
 msgstr "Vendég jelszó a web kiszolgálóhoz"
 
-#: src/muuli_wdr.cpp:2164
+#: src/muuli_wdr.cpp:2168
 msgid "Web server parameters"
 msgstr "Web kiszolgáló paraméterek"
 
-#: src/muuli_wdr.cpp:2167
+#: src/muuli_wdr.cpp:2171
 #, fuzzy
 msgid "Run webserver on startup (deprecated)"
 msgstr "Webkiszolgáló indítása induláskor"
 
-#: src/muuli_wdr.cpp:2173
+#: src/muuli_wdr.cpp:2177
 msgid "Web template"
 msgstr "Web minta"
 
-#: src/muuli_wdr.cpp:2178
+#: src/muuli_wdr.cpp:2182
 msgid "Full rights password"
 msgstr "Admin jelszó"
 
-#: src/muuli_wdr.cpp:2182
+#: src/muuli_wdr.cpp:2186
 msgid "Enable Low rights User"
 msgstr "Vendég felhasználó engedélyezése"
 
-#: src/muuli_wdr.cpp:2187
+#: src/muuli_wdr.cpp:2191
 msgid "Low rights password"
 msgstr "Vendég jelszó"
 
-#: src/muuli_wdr.cpp:2201
+#: src/muuli_wdr.cpp:2205
 msgid "Enable UPnP port forwarding of the web server port"
 msgstr "A web kiszolgáló port UPnP továbbításának engedélyezése"
 
-#: src/muuli_wdr.cpp:2206
+#: src/muuli_wdr.cpp:2210
 msgid "Web server UPnP TCP port (Optional)"
 msgstr "Web szerver UPnP TCP port (nem kötelező)"
 
-#: src/muuli_wdr.cpp:2214
+#: src/muuli_wdr.cpp:2218
 msgid "Page Refresh Time (in secs)"
 msgstr "Oldal frissítésének időzítése (mp múlva)"
 
-#: src/muuli_wdr.cpp:2221
+#: src/muuli_wdr.cpp:2225
 msgid "Enable Gzip compression"
 msgstr "Gzip tömörítés engedélyezése"
 
-#: src/muuli_wdr.cpp:2255
+#: src/muuli_wdr.cpp:2259
 #, fuzzy
 msgid "Reset page to defaults"
 msgstr "Alapértelmezett"
 
-#: src/muuli_wdr.cpp:2256
+#: src/muuli_wdr.cpp:2260
 msgid "Reset the settings on the current page to their default values."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2258 src/muuli_wdr.cpp:2344 src/ServerWnd.cpp:274
+#: src/muuli_wdr.cpp:2262 src/muuli_wdr.cpp:2348 src/ServerWnd.cpp:274
 #: src/ServerWnd.cpp:282
 msgid "OK"
 msgstr "OK"
 
-#: src/muuli_wdr.cpp:2260
+#: src/muuli_wdr.cpp:2264
 msgid "Click here to apply any changes made to the preferences."
 msgstr "Kattints ide a beállítási módosítások alkalmazásához."
 
-#: src/muuli_wdr.cpp:2263
+#: src/muuli_wdr.cpp:2267
 msgid "Reset any changes made to the preferences."
 msgstr "Beállítási módosítások figyelmen kívül hagyása."
 
-#: src/muuli_wdr.cpp:2292
+#: src/muuli_wdr.cpp:2296
 msgid "Comment :"
 msgstr "Megjegyzés:"
 
-#: src/muuli_wdr.cpp:2299
+#: src/muuli_wdr.cpp:2303
 msgid "Incoming Dir :"
 msgstr "Bejövő Mappa :"
 
-#: src/muuli_wdr.cpp:2308
+#: src/muuli_wdr.cpp:2312
 msgid "Change priority for new assigned files :"
 msgstr "Újonnan hozzárendelt fájlok prioritásának változtatása :"
 
-#: src/muuli_wdr.cpp:2312
+#: src/muuli_wdr.cpp:2316
 msgid "Don't change"
 msgstr "Ne változzon"
 
-#: src/muuli_wdr.cpp:2324
+#: src/muuli_wdr.cpp:2328
 msgid "Select color for this Category (currently selected) :"
 msgstr "Válassz színt ehhez a kategóriához (jelenleg kiválasztva) :"
 
-#: src/muuli_wdr.cpp:2391 src/muuli_wdr.cpp:2410 src/muuli_wdr.cpp:2432
+#: src/muuli_wdr.cpp:2395 src/muuli_wdr.cpp:2414 src/muuli_wdr.cpp:2436
 msgid "Click this button to reset the log."
 msgstr "Kattints erre a gombra a logfájl visszaállításához."
 
-#: src/muuli_wdr.cpp:2451
+#: src/muuli_wdr.cpp:2455
 msgid "Click on this button to update the servers list from URL ..."
 msgstr "Kattints erre a gombra a kiszolgálólista frissítéséhez  ..."
 
-#: src/muuli_wdr.cpp:2455
+#: src/muuli_wdr.cpp:2459
 msgid "Server list"
 msgstr "Kiszolgálók listája"
 
-#: src/muuli_wdr.cpp:2459
+#: src/muuli_wdr.cpp:2463
 msgid "Enter the url to a server.met file here and press the button to the left to update the list of known servers."
 msgstr "Adj meg egy címet a server.met fájlhoz és nyomd meg a baloldali gombot az ismert kiszolgálók listájának frissítéséhez."
 
-#: src/muuli_wdr.cpp:2464
+#: src/muuli_wdr.cpp:2468
 msgid "Add server manually: Name"
 msgstr "Kiszolgáló hozzáadása kézzel: Név"
 
-#: src/muuli_wdr.cpp:2467
+#: src/muuli_wdr.cpp:2471
 msgid "Enter the name of the new server here"
 msgstr "Add meg az új kiszolgáló nevét"
 
-#: src/muuli_wdr.cpp:2469 src/ServerWnd.cpp:206
+#: src/muuli_wdr.cpp:2473 src/ServerWnd.cpp:206
 msgid "IP:Port"
 msgstr "IP:Port"
 
-#: src/muuli_wdr.cpp:2472
+#: src/muuli_wdr.cpp:2476
 msgid "Enter the IP of the server here, using the x.x.x.x format."
 msgstr "Itt add meg a kiszolgálók IP-jét, használd az x.x.x.x formát."
 
-#: src/muuli_wdr.cpp:2478
+#: src/muuli_wdr.cpp:2482
 msgid "Enter the port of the server here."
 msgstr "Add meg a kiszolgáló portját."
 
-#: src/muuli_wdr.cpp:2481
+#: src/muuli_wdr.cpp:2485
 msgid "Add manually a server (fill fields to the left before) ..."
 msgstr "Kiszolgáló felvétel kézzel (töltsd ki a baloldali mezőket először) ..."
 
-#: src/muuli_wdr.cpp:2510
+#: src/muuli_wdr.cpp:2514
 msgid "aMule Log"
 msgstr "aMule Napló"
 
-#: src/muuli_wdr.cpp:2518
+#: src/muuli_wdr.cpp:2522
 msgid "Server Info"
 msgstr "Kiszolgáló Infó"
 
-#: src/muuli_wdr.cpp:2522
+#: src/muuli_wdr.cpp:2526
 msgid "ED2K Info"
 msgstr "ED2K infó"
 
-#: src/muuli_wdr.cpp:2526
+#: src/muuli_wdr.cpp:2530
 msgid "Kad Info"
 msgstr "Kad infó"
 
-#: src/muuli_wdr.cpp:2554
+#: src/muuli_wdr.cpp:2558
 msgid "Click on this button to update the nodes list from URL ..."
 msgstr "Kattints erre a gombra a csomópont-lista frissítéséhez URL-ből ..."
 
-#: src/muuli_wdr.cpp:2558
+#: src/muuli_wdr.cpp:2562
 msgid "Nodes (0)"
 msgstr "Csomópontok (0)"
 
-#: src/muuli_wdr.cpp:2562
+#: src/muuli_wdr.cpp:2566
 msgid "Enter the url to a nodes.dat file here and press the button to the left to update the list of known nodes."
 msgstr "Adj meg egy címet a nodes.dat fájlhoz és nyomd meg a baloldali gombot az ismert csomópontok listájának frissítéséhez."
 
-#: src/muuli_wdr.cpp:2565
+#: src/muuli_wdr.cpp:2569
 msgid "Nodes stats"
 msgstr "Csomópont statisztikák"
 
-#: src/muuli_wdr.cpp:2607
+#: src/muuli_wdr.cpp:2611
 msgid "Bootstrap"
 msgstr "Rendszerbetöltés"
 
-#: src/muuli_wdr.cpp:2610
+#: src/muuli_wdr.cpp:2614
 msgid "New node"
 msgstr "Új csomópont (node)"
 
-#: src/muuli_wdr.cpp:2615
+#: src/muuli_wdr.cpp:2619
 msgid "IP:"
 msgstr "IP:"
 
-#: src/muuli_wdr.cpp:2635
+#: src/muuli_wdr.cpp:2639
 msgid "Port:"
 msgstr "Port:"
 
-#: src/muuli_wdr.cpp:2648
+#: src/muuli_wdr.cpp:2652
 msgid "Bootstrap from known clients"
 msgstr "Indítás ismert kliensektől"
 
-#: src/muuli_wdr.cpp:2650
+#: src/muuli_wdr.cpp:2654
 msgid "Disconnect Kad"
 msgstr "Leválasztás a Kad-ról"
 
-#: src/muuli_wdr.cpp:2684
+#: src/muuli_wdr.cpp:2688
 msgid "Use Secure User Identification"
 msgstr "Biztonságos azonosítás használata"
 
-#: src/muuli_wdr.cpp:2686
+#: src/muuli_wdr.cpp:2690
 msgid "It is recommended to enable this option. You will not receive credits if SUI is not enabled."
 msgstr "Ajánlott ezt az opciót engedélyezni. Nem fogsz kreditet kapni, ha nincs engedélyezve."
 
-#: src/muuli_wdr.cpp:2688
+#: src/muuli_wdr.cpp:2692
 msgid "Protocol Obfuscation"
 msgstr "Protokoll zavarás"
 
-#: src/muuli_wdr.cpp:2691
+#: src/muuli_wdr.cpp:2695
 msgid "Support Protocol Obfuscation"
 msgstr "Protokoll zavarás támogatása"
 
-#: src/muuli_wdr.cpp:2693
+#: src/muuli_wdr.cpp:2697
 msgid "This option enabled Protocol Obfuscation, and makes aMule accept obfuscated connections from other clients."
 msgstr "Ez az opció engedélyezi a protokoll zavarást, és az aMule elfogad zavart kapcsolatokat más ügyfelektől."
 
-#: src/muuli_wdr.cpp:2695
+#: src/muuli_wdr.cpp:2699
 msgid "Use obfuscation for outgoing connections"
 msgstr "Kimenő kapcsolatok zavarása"
 
-#: src/muuli_wdr.cpp:2697
+#: src/muuli_wdr.cpp:2701
 msgid "This option makes aMule use Protocol Obfuscation when connecting other clients/servers."
 msgstr "Ez az opció engedélyezi a protokoll zavarást, amikor más ügyfelekhez/kiszolgálókhoz kapcsolódik az aMule."
 
-#: src/muuli_wdr.cpp:2699
+#: src/muuli_wdr.cpp:2703
 msgid "Accept only obfuscated connections"
 msgstr "Csak zavart kapcsolatok elfogadása"
 
-#: src/muuli_wdr.cpp:2700
+#: src/muuli_wdr.cpp:2704
 msgid "This option makes aMule only accept obfuscated connections. You will have less sources, but all your traffic will be obfuscated"
 msgstr "Ezen opció hatására az aMule csak zavart kapcsolatokat fog elfogadni. Kevesebb forrásod lesz, de a teljes forgalom zavart lesz"
 
-#: src/muuli_wdr.cpp:2705
+#: src/muuli_wdr.cpp:2709
 msgid "Everybody"
 msgstr "Mindenki"
 
-#: src/muuli_wdr.cpp:2707
+#: src/muuli_wdr.cpp:2711
 msgid "No one"
 msgstr "Senki"
 
-#: src/muuli_wdr.cpp:2709
+#: src/muuli_wdr.cpp:2713
 msgid "Who can see my shared files:"
 msgstr "Ki láthatja a megosztott fájljaimat:"
 
-#: src/muuli_wdr.cpp:2710
+#: src/muuli_wdr.cpp:2714
 msgid "Select who can request to view a list of your shared files."
 msgstr "Válaszd ki, hogy kik kérdezhetik le megosztott fájlaid listáját."
 
-#: src/muuli_wdr.cpp:2712
+#: src/muuli_wdr.cpp:2716
 msgid "IP-Filtering"
 msgstr "IP-szűrés"
 
-#: src/muuli_wdr.cpp:2719
+#: src/muuli_wdr.cpp:2723
 msgid "Filter clients"
 msgstr "Kliensek szűrése"
 
-#: src/muuli_wdr.cpp:2721
+#: src/muuli_wdr.cpp:2725
 msgid "Enable filtering of the client IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "A ~/.aMule/ipfilter.dat állományban IP-jű kliensek szűrésének engedélyezése."
 
-#: src/muuli_wdr.cpp:2723
+#: src/muuli_wdr.cpp:2727
 msgid "Filter servers"
 msgstr "Kiszolgálók szűrése"
 
-#: src/muuli_wdr.cpp:2725
+#: src/muuli_wdr.cpp:2729
 msgid "Enable filtering of the server IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "A ~/.aMule/ipfilter.dat állományban IP-jű kiszolgálók szűrésének engedélyezése."
 
-#: src/muuli_wdr.cpp:2729
+#: src/muuli_wdr.cpp:2733
 msgid "Reload List"
 msgstr "Lista újratöltése"
 
-#: src/muuli_wdr.cpp:2730
+#: src/muuli_wdr.cpp:2734
 msgid "Reload the list of IPs to filter from the file ~/.aMule/ipfilter.dat"
 msgstr "IP-k listájának újratöltése a ~/.aMule/ipfilter.dat fájlból"
 
-#: src/muuli_wdr.cpp:2736
+#: src/muuli_wdr.cpp:2740
 msgid "URL:"
 msgstr "URL:"
 
-#: src/muuli_wdr.cpp:2740 src/muuli_wdr.cpp:2933
+#: src/muuli_wdr.cpp:2744 src/muuli_wdr.cpp:2937
 msgid "Update now"
 msgstr "Frissítés most"
 
-#: src/muuli_wdr.cpp:2743
+#: src/muuli_wdr.cpp:2747
 msgid "Auto-update ipfilter at startup"
 msgstr "IP szűrő automatikus letöltése indításkor"
 
-#: src/muuli_wdr.cpp:2747
+#: src/muuli_wdr.cpp:2751
 msgid "Filtering Level:"
 msgstr "Szűrési szint:"
 
-#: src/muuli_wdr.cpp:2753
+#: src/muuli_wdr.cpp:2757
 msgid "Always filter LAN IPs"
 msgstr "Mindig szűrje ki a LAN IP-ket"
 
-#: src/muuli_wdr.cpp:2756
+#: src/muuli_wdr.cpp:2760
 msgid "Paranoid handling of non-matching IPs"
 msgstr "A nem-megegyező IP-k paranoid kezelése"
 
-#: src/muuli_wdr.cpp:2758
+#: src/muuli_wdr.cpp:2762
 msgid "Rejects a packet when its source IP differs from the IP the client claims (an anti-spoofing check). Disable only if it causes connection problems."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2760
+#: src/muuli_wdr.cpp:2764
 msgid "Use system-wide ipfilter.dat if available"
 msgstr "Rendszer-szintű ipfilter.dat használatának engedélyezése"
 
-#: src/muuli_wdr.cpp:2761
+#: src/muuli_wdr.cpp:2765
 msgid "If there's no local ipfilter.dat found, allow usage of a system-wide ipfilter file."
 msgstr "Ha nem talál helyi ipfilter.dat fájlt, akkor engedje a rendszerszintű ipfilter fájl használatát."
 
-#: src/muuli_wdr.cpp:2778
+#: src/muuli_wdr.cpp:2782
 msgid "Enable Online-Signature"
 msgstr "Online-aláírás engedélyezése"
 
-#: src/muuli_wdr.cpp:2780
+#: src/muuli_wdr.cpp:2784
 msgid "Enables the writing of the OS file, which can be used by external apps to create signatures and the like."
 msgstr "Az online-aláírás fájl írásának engedélyezése, amit külső alkalmazások használhatnak fel aláírások létrehozásához és így tovább."
 
-#: src/muuli_wdr.cpp:2784
+#: src/muuli_wdr.cpp:2788
 msgid "Update Frequency (Secs):"
 msgstr "Frissítési gyakoriság (mp):"
 
-#: src/muuli_wdr.cpp:2787
+#: src/muuli_wdr.cpp:2791
 msgid "Change the frequency (in seconds) of Online Signature updates."
 msgstr "Online aláírás frissítési gyakoriságának módosítása (mp-ben)."
 
-#: src/muuli_wdr.cpp:2795
+#: src/muuli_wdr.cpp:2799
 msgid "Save online signature file in: "
 msgstr "Online aláírási fájl kimentési helye: "
 
-#: src/muuli_wdr.cpp:2801
+#: src/muuli_wdr.cpp:2805
 msgid "Click here to select the directory containing the the Online Signature files."
 msgstr "Kattints ide az online aláírást tartalmazó könyvtár kiválasztásához."
 
-#: src/muuli_wdr.cpp:2834
+#: src/muuli_wdr.cpp:2838
 msgid "Show country flags for clients"
 msgstr "Kliensek országzászlajainak megjelenítése"
 
-#: src/muuli_wdr.cpp:2835
+#: src/muuli_wdr.cpp:2839
 msgid "Render the country flag column in the transfers, queue and search views. Requires a valid MMDB GeoIP database (see below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2840
+#: src/muuli_wdr.cpp:2844
 msgid "Database"
 msgstr "Adatbázis"
 
-#: src/muuli_wdr.cpp:2856
+#: src/muuli_wdr.cpp:2860
 msgid "Source:"
 msgstr "Forrás:"
 
-#: src/muuli_wdr.cpp:2859
+#: src/muuli_wdr.cpp:2863
 msgid "DB-IP (free, no account)"
 msgstr "DB-IP (ingyenes, fiók nélkül)"
 
-#: src/muuli_wdr.cpp:2860
+#: src/muuli_wdr.cpp:2864
 msgid "MaxMind GeoLite2 (free, account required)"
 msgstr "MaxMind GeoLite2 (ingyenes, fiók szükséges)"
 
-#: src/muuli_wdr.cpp:2861
+#: src/muuli_wdr.cpp:2865
 msgid "Custom URL"
 msgstr "Egyéni URL"
 
-#: src/muuli_wdr.cpp:2864
+#: src/muuli_wdr.cpp:2868
 msgid "Choose which provider supplies the GeoIP MMDB database. DB-IP is the default - no account required. MaxMind requires a free account + license key. Use Custom URL to point at any other MMDB host (e.g. a local mirror)."
 msgstr "Válassza ki a GeoIP MMDB adatbázis szolgáltatóját. DB-IP az alapértelmezett - nincs szükség fiókra. MaxMind egy ingyenes fiókot és licenckulcsot igényel. Használjon egyéni URL-t bármely más MMDB host megadásához (pl. egy helyi tükörhöz)."
 
-#: src/muuli_wdr.cpp:2881
+#: src/muuli_wdr.cpp:2885
 msgid ""
 "No configuration required.\n"
 "\n"
@@ -4862,11 +4862,11 @@ msgstr ""
 "IP-to-Country adat DB-IP.com által - https://db-ip.com\n"
 "Licenc: Creative Commons BY 4.0 - https://creativecommons.org/licenses/by/4.0/"
 
-#: src/muuli_wdr.cpp:2894
+#: src/muuli_wdr.cpp:2898
 msgid "License key:"
 msgstr "Licenckulcs:"
 
-#: src/muuli_wdr.cpp:2900
+#: src/muuli_wdr.cpp:2904
 msgid ""
 "Sign up for a free MaxMind account, then generate a License Key:\n"
 "https://www.maxmind.com/en/geolite2/signup\n"
@@ -4882,11 +4882,11 @@ msgstr ""
 "Licenc: MaxMind GeoLite2 EULA - https://www.maxmind.com/en/geolite2/eula\n"
 "Hozzárendelést és fiókregisztrációt igényel; legalább 30 naponta frissítse."
 
-#: src/muuli_wdr.cpp:2915
+#: src/muuli_wdr.cpp:2919
 msgid "Download URL:"
 msgstr "Letöltési URL:"
 
-#: src/muuli_wdr.cpp:2921
+#: src/muuli_wdr.cpp:2925
 msgid ""
 "Must point to an .mmdb file or a .gz / .tar.gz containing one.\n"
 "URL may include credentials (https://user:pass@host/...).\n"
@@ -4896,211 +4896,211 @@ msgstr ""
 "Az URL tartalmazhat hitelesítő adatokat (https://user:pass@host/...).\n"
 "A licenc- és megnevezési feltételeket a felmenő URL határozza meg - ön a felelőss."
 
-#: src/muuli_wdr.cpp:2934
+#: src/muuli_wdr.cpp:2938
 msgid "Download the GeoIP database from the selected source."
 msgstr "GeoIP adatbázis letöltése a kiválasztott forrásból."
 
-#: src/muuli_wdr.cpp:2936
+#: src/muuli_wdr.cpp:2940
 msgid "Auto-update on startup"
 msgstr "Automatikus frissítés indításkor"
 
-#: src/muuli_wdr.cpp:2937
+#: src/muuli_wdr.cpp:2941
 msgid "Re-download the GeoIP database from the selected source every time aMule starts."
 msgstr "GeoIP adatbázis újonnani letöltése a kiválasztott forrásból minden aMule indításkor."
 
-#: src/muuli_wdr.cpp:2960
+#: src/muuli_wdr.cpp:2964
 msgid "Filter incoming messages (except current chat):"
 msgstr "Bejövő üzenetek kiszűrése (kivéve az aktuális csevegés):"
 
-#: src/muuli_wdr.cpp:2962
+#: src/muuli_wdr.cpp:2966
 msgid "Filter all messages"
 msgstr "Összes üzenet szűrése"
 
-#: src/muuli_wdr.cpp:2964
+#: src/muuli_wdr.cpp:2968
 msgid "Filter messages from people not on your friend list"
 msgstr "Barát listában nem szereplőktől érkező üzenetek kiszűrése"
 
-#: src/muuli_wdr.cpp:2966
+#: src/muuli_wdr.cpp:2970
 msgid "Filter messages from unknown clients"
 msgstr "Ismeretlen kliensektől érkező üzenetek kiszűrése"
 
-#: src/muuli_wdr.cpp:2968
+#: src/muuli_wdr.cpp:2972
 msgid "Filter messages containing (use ',' as separator):"
 msgstr "A következő(ke)t tartalmazó üzenetek kiszűrése (elválasztónak ','-t használj):"
 
-#: src/muuli_wdr.cpp:2971 src/muuli_wdr.cpp:2982
+#: src/muuli_wdr.cpp:2975 src/muuli_wdr.cpp:2986
 msgid "add here the words amule should filter and block messages including it"
 msgstr "Azon szavak felvétele, amelyeket az amule-nak ki kellene szűrni és blokkolni az ezeket tartalmazó üzeneteket"
 
-#: src/muuli_wdr.cpp:2973
+#: src/muuli_wdr.cpp:2977
 msgid "Show received messages in the log"
 msgstr "A kapott üzenetek megjelenítése a naplóban"
 
-#: src/muuli_wdr.cpp:2976
+#: src/muuli_wdr.cpp:2980
 msgid "Comments"
 msgstr "Megjegyzések"
 
-#: src/muuli_wdr.cpp:2979
+#: src/muuli_wdr.cpp:2983
 msgid "Filter comments containing (use ',' as separator):"
 msgstr "Megjegyzések kiszűrése, melyek tartalmazzák (',' az elválasztó):"
 
-#: src/muuli_wdr.cpp:3004
+#: src/muuli_wdr.cpp:3008
 msgid "Enable Proxy"
 msgstr "Proxy engedélyezése"
 
-#: src/muuli_wdr.cpp:3005
+#: src/muuli_wdr.cpp:3009
 msgid "Enable/disable proxy support"
 msgstr "Proxy támogatás engedélyezése/tiltása"
 
-#: src/muuli_wdr.cpp:3008
+#: src/muuli_wdr.cpp:3012
 msgid "Proxy type:"
 msgstr "Proxy típusa:"
 
-#: src/muuli_wdr.cpp:3019
+#: src/muuli_wdr.cpp:3023
 msgid "Proxy host:"
 msgstr "Proxy host:"
 
-#: src/muuli_wdr.cpp:3022
+#: src/muuli_wdr.cpp:3026
 msgid "The proxy host name"
 msgstr "A proxy host neve"
 
-#: src/muuli_wdr.cpp:3024
+#: src/muuli_wdr.cpp:3028
 msgid "Proxy port:"
 msgstr "Proxy port:"
 
-#: src/muuli_wdr.cpp:3027
+#: src/muuli_wdr.cpp:3031
 msgid "The proxy port"
 msgstr "A proxy port"
 
-#: src/muuli_wdr.cpp:3029
+#: src/muuli_wdr.cpp:3033
 msgid "Enable authentication"
 msgstr "Hitelesítés engedélyezése"
 
-#: src/muuli_wdr.cpp:3030
+#: src/muuli_wdr.cpp:3034
 msgid "Enable/disable username/password authentication"
 msgstr "Felhasználói név/jelszó hitelesítés engedélyezése/tiltása"
 
-#: src/muuli_wdr.cpp:3033
+#: src/muuli_wdr.cpp:3037
 msgid "Username: "
 msgstr "Felhasználói név: "
 
-#: src/muuli_wdr.cpp:3036
+#: src/muuli_wdr.cpp:3040
 msgid "The username to use to connect to the proxy"
 msgstr "Felhasználói név a proxy kapcsolathoz"
 
-#: src/muuli_wdr.cpp:3038
+#: src/muuli_wdr.cpp:3042
 msgid "Password:"
 msgstr "Jelszó:"
 
-#: src/muuli_wdr.cpp:3041
+#: src/muuli_wdr.cpp:3045
 msgid "The password to use to connect to the proxy"
 msgstr "Jelszó a proxy kapcsolathoz"
 
-#: src/muuli_wdr.cpp:3060
+#: src/muuli_wdr.cpp:3064
 msgid "Connect to:"
 msgstr "Kapcsolódás ehhez:"
 
-#: src/muuli_wdr.cpp:3069
+#: src/muuli_wdr.cpp:3073
 msgid "Login to remote amule"
 msgstr "Bejeletkezés a távoli amule-ra"
 
-#: src/muuli_wdr.cpp:3074
+#: src/muuli_wdr.cpp:3078
 msgid "User name"
 msgstr "Felhasználói név"
 
-#: src/muuli_wdr.cpp:3085
+#: src/muuli_wdr.cpp:3089
 msgid "Remember those settings"
 msgstr "Emlékezzen ezekre a beállításokra"
 
-#: src/muuli_wdr.cpp:3088
+#: src/muuli_wdr.cpp:3092
 msgid "Force ZLIB compression"
 msgstr "ZLIB tömörítés erőltetése"
 
-#: src/muuli_wdr.cpp:3112
+#: src/muuli_wdr.cpp:3116
 msgid "Enable Verbose Debug-Logging."
 msgstr "Bőbeszédű hiba-naplózás engedélyezése."
 
-#: src/muuli_wdr.cpp:3114
+#: src/muuli_wdr.cpp:3118
 msgid "Only to Logfile"
 msgstr "Csak napló fájlba"
 
-#: src/muuli_wdr.cpp:3116
+#: src/muuli_wdr.cpp:3120
 msgid "Message Categories:"
 msgstr "Üzenet kategóriák:"
 
-#: src/muuli_wdr.cpp:3140 src/PartFileConvertDlg.cpp:160
+#: src/muuli_wdr.cpp:3144 src/PartFileConvertDlg.cpp:160
 msgid "Waiting..."
 msgstr "Várakozás..."
 
-#: src/muuli_wdr.cpp:3160
+#: src/muuli_wdr.cpp:3164
 msgid "Add imports"
 msgstr "Importálandók hozzáadása"
 
-#: src/muuli_wdr.cpp:3163
+#: src/muuli_wdr.cpp:3167
 msgid "Retry selected"
 msgstr "Kijelöltek újrapróbálása"
 
-#: src/muuli_wdr.cpp:3165
+#: src/muuli_wdr.cpp:3169
 msgid "Remove selected"
 msgstr "Kijelöltek eltávolítása"
 
-#: src/muuli_wdr.cpp:3228
+#: src/muuli_wdr.cpp:3232
 msgid "Event Types"
 msgstr "Esemény típusok"
 
-#: src/muuli_wdr.cpp:3247
+#: src/muuli_wdr.cpp:3251
 msgid "Statistics and queued clients for selected file(s) : Session / All time"
 msgstr "Statisztikák és várakozó kliensek a kiválasztott fájl(ok)hoz: Folyamat / Valaha"
 
-#: src/muuli_wdr.cpp:3271
+#: src/muuli_wdr.cpp:3275
 msgid "Active Uploads"
 msgstr "Aktív feltöltések"
 
-#: src/muuli_wdr.cpp:3285
+#: src/muuli_wdr.cpp:3289
 msgid "Percent of total files"
 msgstr "Összes fájl százalékaként"
 
-#: src/muuli_wdr.cpp:3337
+#: src/muuli_wdr.cpp:3341
 msgid "Show Clients for"
 msgstr "Kliensek megjelenítése ehhez:"
 
-#: src/muuli_wdr.cpp:3339
+#: src/muuli_wdr.cpp:3343
 msgid "All files"
 msgstr "Összes fájl"
 
-#: src/muuli_wdr.cpp:3342
+#: src/muuli_wdr.cpp:3346
 msgid "Selected files"
 msgstr "Kiválasztott fájlok"
 
-#: src/muuli_wdr.cpp:3345
+#: src/muuli_wdr.cpp:3349
 msgid "Active uploads only"
 msgstr "Csak aktív feltöltések"
 
-#: src/muuli_wdr.cpp:3352
+#: src/muuli_wdr.cpp:3356
 msgid "Reload:"
 msgstr "Újratöltés:"
 
-#: src/muuli_wdr.cpp:3356
+#: src/muuli_wdr.cpp:3360
 msgid "Reload your shared files"
 msgstr "Megosztott fájlok frissítése"
 
-#: src/muuli_wdr.cpp:3419
+#: src/muuli_wdr.cpp:3423
 msgid "Send"
 msgstr "Küldés"
 
-#: src/muuli_wdr.cpp:3420
+#: src/muuli_wdr.cpp:3424
 msgid "Sends the specified message."
 msgstr "Megadott üzenet küldése."
 
-#: src/muuli_wdr.cpp:3424
+#: src/muuli_wdr.cpp:3428
 msgid "Close this chat-session."
 msgstr "Csevegési folyamat bezárása."
 
-#: src/muuli_wdr.cpp:3447
+#: src/muuli_wdr.cpp:3451
 msgid "Connect to any server and/or Kad"
 msgstr "Kapcsolódás bármelyik kiszolgálóhoz és/vagy a Kad-hoz"
 
-#: src/muuli_wdr.cpp:3453 src/SharedFilesCtrl.cpp:142 src/Statistics.cpp:941
+#: src/muuli_wdr.cpp:3457 src/SharedFilesCtrl.cpp:142 src/Statistics.cpp:941
 msgid "Shared Files"
 msgstr "Megosztott fájlok"
 
@@ -5732,35 +5732,35 @@ msgstr ""
 "Ezen beállítások módosítása nélkül is remekül fog\n"
 "működni az aMule."
 
-#: src/PrefsUnifiedDlg.cpp:647
+#: src/PrefsUnifiedDlg.cpp:656
 #, c-format
 msgid "Failed to connect Cfg to widget with the ID %d and key %s"
 msgstr "Cfg csatolása a widget-hez (ID-je: %d, kulcsa: %s) sikertelen"
 
-#: src/PrefsUnifiedDlg.cpp:695
+#: src/PrefsUnifiedDlg.cpp:704
 #, c-format
 msgid "Failed to transfer data from Cfg to Widget with the ID %d and key %s"
 msgstr "Adatátvitel a Cfg-ből a Widget-be (ID-je: %d, kulcsa: %s) sikertelen."
 
-#: src/PrefsUnifiedDlg.cpp:801
+#: src/PrefsUnifiedDlg.cpp:810
 msgid "The type of proxy you are connecting to"
 msgstr "A proxy típusa amihez kapcsolódsz"
 
-#: src/PrefsUnifiedDlg.cpp:1020
+#: src/PrefsUnifiedDlg.cpp:1029
 #, c-format
 msgid "Failed to transfer data from Widget to Cfg with the ID %d and key %s"
 msgstr "Adatátvitel a Widget-ből a Cfg-be (ID-je: %d, kulcsa: %s) sikertelen."
 
-#: src/PrefsUnifiedDlg.cpp:1103
+#: src/PrefsUnifiedDlg.cpp:1112
 #, fuzzy
 msgid "No password set."
 msgstr "Jelszó ellenőrzése\n"
 
-#: src/PrefsUnifiedDlg.cpp:1132
+#: src/PrefsUnifiedDlg.cpp:1141
 msgid "Guest access needs a password. Type one in the guest password field, or untick Enable guest access."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1144
+#: src/PrefsUnifiedDlg.cpp:1153
 msgid ""
 "aMule must be restarted to enable these changes:\n"
 "\n"
@@ -5768,41 +5768,41 @@ msgstr ""
 "Újra kell indítani az aMule-t, hogy az alábbi változás(ok) érvénybe lépjen(ek):\n"
 "\n"
 
-#: src/PrefsUnifiedDlg.cpp:1151
+#: src/PrefsUnifiedDlg.cpp:1160
 msgid "- TCP port changed.\n"
 msgstr "- TCP port megváltozott.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1156
+#: src/PrefsUnifiedDlg.cpp:1165
 msgid "- UDP port changed.\n"
 msgstr "- UDP port megváltozott.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1161
+#: src/PrefsUnifiedDlg.cpp:1170
 #, fuzzy
 msgid "- Network interface binding changed.\n"
 msgstr "- Külső kapcsolat interfész megváltoztatva.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1166
+#: src/PrefsUnifiedDlg.cpp:1175
 msgid "- External connect port changed.\n"
 msgstr "- Külső kapcsolat port megváltoztatva.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1170
+#: src/PrefsUnifiedDlg.cpp:1179
 msgid "- External connect acceptance changed.\n"
 msgstr "- Külső kapcsolat elfogadása megváltoztatva.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1174
+#: src/PrefsUnifiedDlg.cpp:1183
 msgid "- External connect interface changed.\n"
 msgstr "- Külső kapcsolat interfész megváltoztatva.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1178
+#: src/PrefsUnifiedDlg.cpp:1187
 msgid "- Protocol obfuscation support changed.\n"
 msgstr "- Protokoll zavarás támogatása megváltozott.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1193
+#: src/PrefsUnifiedDlg.cpp:1202
 #, fuzzy
 msgid "- amuleapi settings changed.\n"
 msgstr "- Nyelv megváltozott.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1202
+#: src/PrefsUnifiedDlg.cpp:1211
 msgid ""
 "Your Auto-update server list is empty.\n"
 "'Auto-update server list at startup' will be disabled."
@@ -5810,7 +5810,7 @@ msgstr ""
 "Az automatikusan frissített kiszolgálóü lista üres.\n"
 "A 'kiszolgáló lista automatikus frissítése induláskor' letiltva."
 
-#: src/PrefsUnifiedDlg.cpp:1213
+#: src/PrefsUnifiedDlg.cpp:1222
 msgid ""
 "You have enabled external connections but have not specified a password.\n"
 "External connections cannot be enabled unless a valid password is specified."
@@ -5818,33 +5818,33 @@ msgstr ""
 "Engedélyezted a távoli elérést, de nem adtál meg jelszót.\n"
 "A távoli elérés nem használható érvényes jelszó nélkül."
 
-#: src/PrefsUnifiedDlg.cpp:1246
+#: src/PrefsUnifiedDlg.cpp:1255
 #, c-format
 msgid "The amuleapi password could not be saved: %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1276
+#: src/PrefsUnifiedDlg.cpp:1285
 msgid "- Language changed.\n"
 msgstr "- Nyelv megváltozott.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1281
+#: src/PrefsUnifiedDlg.cpp:1290
 msgid "- Temp folder changed.\n"
 msgstr "- Ideiglenes mappa megváltozott.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1286
+#: src/PrefsUnifiedDlg.cpp:1295
 msgid "- ED2K network enabled.\n"
 msgstr "- ED2K hálózat engedélyezve.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1319
+#: src/PrefsUnifiedDlg.cpp:1328
 msgid "The shared-file exclusion pattern is not a valid regular expression. The filter has been left disabled."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1321 src/PrefsUnifiedDlg.cpp:1921
+#: src/PrefsUnifiedDlg.cpp:1330 src/PrefsUnifiedDlg.cpp:1930
 #, fuzzy
 msgid "Invalid regular expression"
 msgstr "Érvénytelen protokoll verzió."
 
-#: src/PrefsUnifiedDlg.cpp:1398
+#: src/PrefsUnifiedDlg.cpp:1407
 msgid ""
 "Both eD2k and Kad network are disabled.\n"
 "You won't be able to connect until you enable at least one of them."
@@ -5852,7 +5852,7 @@ msgstr ""
 "Az eD2k és a Kad hálózat is le van tiltva.\n"
 "Nem fogsz tudni kapcsolódni, amíg legalább az egyiket nem engedélyezed."
 
-#: src/PrefsUnifiedDlg.cpp:1403
+#: src/PrefsUnifiedDlg.cpp:1412
 msgid ""
 "Kad will not start if your UDP port is disabled.\n"
 "Enable UDP port or disable Kad."
@@ -5860,7 +5860,7 @@ msgstr ""
 "A Kad nem fog elindulni, ha az UDP portod le van tiltva.\n"
 "Engedélyezd az UDP portot vagy tiltsd le a Kad-ot."
 
-#: src/PrefsUnifiedDlg.cpp:1459
+#: src/PrefsUnifiedDlg.cpp:1468
 msgid ""
 "\n"
 "You MUST restart aMule now.\n"
@@ -5870,69 +5870,69 @@ msgstr ""
 "Most újra KELL indítanod az aMule-t.\n"
 "Ha nem indítod újra most, ne panaszkodj, ha bármi rossz történik.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1524
+#: src/PrefsUnifiedDlg.cpp:1533
 msgid "Could not register aMule for autostart at login. The autostart store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1526
+#: src/PrefsUnifiedDlg.cpp:1535
 msgid "Could not remove the autostart-at-login entry."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1527
+#: src/PrefsUnifiedDlg.cpp:1536
 #, fuzzy
 msgid "Autostart"
 msgstr "Automatikus frissítés elindítva"
 
-#: src/PrefsUnifiedDlg.cpp:1542
+#: src/PrefsUnifiedDlg.cpp:1551
 msgid "Register file type"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1542
+#: src/PrefsUnifiedDlg.cpp:1551
 msgid "Register URL handler"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1550
+#: src/PrefsUnifiedDlg.cpp:1559
 #, c-format
 msgid "aMule only handles eD2k-compatible magnets. If you replace the current magnet handler (%s), BitTorrent magnet links will stop working - aMule cannot download BitTorrent content. Continue?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1555
+#: src/PrefsUnifiedDlg.cpp:1564
 #, c-format
 msgid "Another application currently opens .emulecollection files (%s). Replace it with aMule?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1560
+#: src/PrefsUnifiedDlg.cpp:1569
 #, c-format
 msgid "Another application is currently the default handler for these links (%s). Replace it with aMule?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1585
+#: src/PrefsUnifiedDlg.cpp:1594
 msgid "Could not register aMule for .emulecollection files. The registration store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1587
+#: src/PrefsUnifiedDlg.cpp:1596
 #, fuzzy
 msgid "Could not remove the file type registration."
 msgstr "A letöltött fájlok eltolása %s helyre sikertelen"
 
-#: src/PrefsUnifiedDlg.cpp:1589
+#: src/PrefsUnifiedDlg.cpp:1598
 msgid "Could not register aMule as the URL handler. The registration store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1591
+#: src/PrefsUnifiedDlg.cpp:1600
 msgid "Could not remove the URL handler registration."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1661 src/PrefsUnifiedDlg.cpp:1688
+#: src/PrefsUnifiedDlg.cpp:1670 src/PrefsUnifiedDlg.cpp:1697
 #, fuzzy
 msgid "The web server and aMule API require external connections to be enabled."
 msgstr "Jelszó beállítva, külső kapcsolatok engedélyezve."
 
-#: src/PrefsUnifiedDlg.cpp:1671
+#: src/PrefsUnifiedDlg.cpp:1680
 msgid "The aMule web server is deprecated. Consider running the aMule API instead."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1735
+#: src/PrefsUnifiedDlg.cpp:1744
 msgid ""
 "Your Auto-update servers list is in blank.\n"
 "Please fill in at least one URL to point to a valid server.met file.\n"
@@ -5942,65 +5942,65 @@ msgstr ""
 "Kérlek adj meg legalább egy URL-t, ami érvényes server.met fájlra mutat .\n"
 "Az URL megadásához klikkelj a \"Lista\" gombra ezen checkbox mellett."
 
-#: src/PrefsUnifiedDlg.cpp:1876
+#: src/PrefsUnifiedDlg.cpp:1885
 msgid "Temporary files"
 msgstr "az Ideiglenes fájloknak"
 
-#: src/PrefsUnifiedDlg.cpp:1881
+#: src/PrefsUnifiedDlg.cpp:1890
 msgid "Incoming files"
 msgstr "Bejövő fájlok"
 
-#: src/PrefsUnifiedDlg.cpp:1886
+#: src/PrefsUnifiedDlg.cpp:1895
 msgid "Online Signatures"
 msgstr "az Online aláírásnak"
 
-#: src/PrefsUnifiedDlg.cpp:1899
+#: src/PrefsUnifiedDlg.cpp:1908
 #, c-format
 msgid "Choose a folder for %s"
 msgstr "Válassz egy mappát a %s-nek"
 
-#: src/PrefsUnifiedDlg.cpp:1923
+#: src/PrefsUnifiedDlg.cpp:1932
 #, fuzzy, c-format
 msgid "Would exclude %u of %u shared file"
 msgid_plural "Would exclude %u of %u shared files"
 msgstr[0] "%i ismert megosztott fájlt találtam"
 
-#: src/PrefsUnifiedDlg.cpp:1940
+#: src/PrefsUnifiedDlg.cpp:1949
 msgid "Browse for videoplayer"
 msgstr "Böngészés a videolejátszóhoz"
 
-#: src/PrefsUnifiedDlg.cpp:1944
+#: src/PrefsUnifiedDlg.cpp:1953
 msgid "Select browser"
 msgstr "Válaszd ki a böngésződet"
 
-#: src/PrefsUnifiedDlg.cpp:1948
+#: src/PrefsUnifiedDlg.cpp:1957
 #, fuzzy
 msgid "Select ffprobe binary"
 msgstr "Válaszd ki a böngésződet"
 
-#: src/PrefsUnifiedDlg.cpp:1954
+#: src/PrefsUnifiedDlg.cpp:1963
 #, c-format
 msgid "Executable%s"
 msgstr "Futtatható%s"
 
-#: src/PrefsUnifiedDlg.cpp:1988
+#: src/PrefsUnifiedDlg.cpp:1997
 msgid "ffprobe not found on PATH or in the standard install locations. Install ffmpeg (which ships ffprobe) or use Browse to pick a binary manually."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2000
+#: src/PrefsUnifiedDlg.cpp:2009
 msgid "Reset the settings on this page to their default values?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2001
+#: src/PrefsUnifiedDlg.cpp:2010
 #, fuzzy
 msgid "Reset to defaults"
 msgstr "Alapértelmezett"
 
-#: src/PrefsUnifiedDlg.cpp:2028
+#: src/PrefsUnifiedDlg.cpp:2037
 msgid "Edit server list"
 msgstr "Kiszolgáló lista szerkesztése"
 
-#: src/PrefsUnifiedDlg.cpp:2029
+#: src/PrefsUnifiedDlg.cpp:2038
 msgid ""
 "Add here URL's to download server.met files.\n"
 "Only one url on each line."
@@ -6008,149 +6008,149 @@ msgstr ""
 "URL-ek felvétele a server.met fájl letöltéséhez.\n"
 "Egy sorba csak egy URL."
 
-#: src/PrefsUnifiedDlg.cpp:2084
+#: src/PrefsUnifiedDlg.cpp:2093
 msgid "IP2Country update failed"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2229 src/PrefsUnifiedDlg.cpp:2260
+#: src/PrefsUnifiedDlg.cpp:2238 src/PrefsUnifiedDlg.cpp:2269
 msgid "Data by MaxMind GeoLite2"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2231 src/PrefsUnifiedDlg.cpp:2262
+#: src/PrefsUnifiedDlg.cpp:2240 src/PrefsUnifiedDlg.cpp:2271
 #, fuzzy
 msgid "Custom source"
 msgstr "Teljes források"
 
-#: src/PrefsUnifiedDlg.cpp:2233 src/PrefsUnifiedDlg.cpp:2264
+#: src/PrefsUnifiedDlg.cpp:2242 src/PrefsUnifiedDlg.cpp:2273
 msgid "Data by DB-IP.com"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2284
+#: src/PrefsUnifiedDlg.cpp:2293
 #, fuzzy, c-format
 msgid "Status: Loaded%s"
 msgstr "Állapot:"
 
-#: src/PrefsUnifiedDlg.cpp:2286
+#: src/PrefsUnifiedDlg.cpp:2295
 #, fuzzy, c-format
 msgid "Status: Loaded%s - %s"
 msgstr "Állapot:"
 
-#: src/PrefsUnifiedDlg.cpp:2290
+#: src/PrefsUnifiedDlg.cpp:2299
 msgid "Status: Failed to load - click 'Update now' to refresh."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2292
+#: src/PrefsUnifiedDlg.cpp:2301
 msgid "Status: Not found - click 'Update now' to download."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2350 src/PrefsUnifiedDlg.cpp:2374
+#: src/PrefsUnifiedDlg.cpp:2359 src/PrefsUnifiedDlg.cpp:2383
 #, c-format
 msgid "Update delay: %d second"
 msgid_plural "Update delay: %d seconds"
 msgstr[0] "Frissítés késleltetése: %d másodperc"
 
-#: src/PrefsUnifiedDlg.cpp:2358
+#: src/PrefsUnifiedDlg.cpp:2367
 #, c-format
 msgid "Time for average graph: %d minute"
 msgid_plural "Time for average graph: %d minutes"
 msgstr[0] "Grafikon átlagos ideje: %d perc"
 
-#: src/PrefsUnifiedDlg.cpp:2367
+#: src/PrefsUnifiedDlg.cpp:2376
 #, c-format
 msgid "Connections Graph Scale: %d"
 msgstr "Kapcsolatok grafikon-skálája: %d"
 
-#: src/PrefsUnifiedDlg.cpp:2382
+#: src/PrefsUnifiedDlg.cpp:2391
 #, c-format
 msgid "File Buffer Size: %d byte"
 msgid_plural "File Buffer Size: %d bytes"
 msgstr[0] "Fájl buffer méret: %d bájt"
 
-#: src/PrefsUnifiedDlg.cpp:2392
+#: src/PrefsUnifiedDlg.cpp:2401
 #, c-format
 msgid "Upload Queue Size: %d client"
 msgid_plural "Upload Queue Size: %d clients"
 msgstr[0] "Feltöltési várólista nagysága: %d kliens"
 
-#: src/PrefsUnifiedDlg.cpp:2402
+#: src/PrefsUnifiedDlg.cpp:2411
 #, c-format
 msgid "Server connection refresh interval: %d minute"
 msgid_plural "Server connection refresh interval: %d minutes"
 msgstr[0] "Kiszolgáló kapcsolat frissítési gyakorisága: %d perc"
 
-#: src/PrefsUnifiedDlg.cpp:2407
+#: src/PrefsUnifiedDlg.cpp:2416
 msgid "Server connection refresh interval: Disabled"
 msgstr "Kiszolgáló kapcsolat frissítési gyakorisága: Tiltva"
 
-#: src/PrefsUnifiedDlg.cpp:2451
+#: src/PrefsUnifiedDlg.cpp:2460
 msgid "disabled"
 msgstr "letiltva"
 
-#: src/PrefsUnifiedDlg.cpp:2477
+#: src/PrefsUnifiedDlg.cpp:2486
 #, c-format
 msgid "Execute command on '%s' event"
 msgstr "Parancs végrehajtása a(z) '%s' eseménynél"
 
-#: src/PrefsUnifiedDlg.cpp:2484
+#: src/PrefsUnifiedDlg.cpp:2493
 msgid "Enable command execution on core"
 msgstr "Parancs futtatása a magon"
 
-#: src/PrefsUnifiedDlg.cpp:2496
+#: src/PrefsUnifiedDlg.cpp:2505
 msgid "Core command:"
 msgstr "Mag parancs:"
 
-#: src/PrefsUnifiedDlg.cpp:2512
+#: src/PrefsUnifiedDlg.cpp:2521
 msgid "Enable command execution on GUI"
 msgstr "Parancs futtatása a grafikus felületen"
 
-#: src/PrefsUnifiedDlg.cpp:2524
+#: src/PrefsUnifiedDlg.cpp:2533
 msgid "GUI command:"
 msgstr "GUI parancs:"
 
-#: src/PrefsUnifiedDlg.cpp:2540
+#: src/PrefsUnifiedDlg.cpp:2549
 msgid "The following variables will be replaced:"
 msgstr "A következő változók lesznek behelyettesítve:"
 
-#: src/PrefsUnifiedDlg.cpp:2708
+#: src/PrefsUnifiedDlg.cpp:2717
 msgid ""
 "The following folders look like system or sensitive locations:\n"
 "\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2713
+#: src/PrefsUnifiedDlg.cpp:2722
 msgid "Sharing them recursively will publish every file underneath on the eD2k/Kad networks. Do you really want to do this?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2716
+#: src/PrefsUnifiedDlg.cpp:2725
 #, fuzzy
 msgid "Confirm shared folders"
 msgstr "Megosztott mappák"
 
-#: src/PrefsUnifiedDlg.cpp:2744
+#: src/PrefsUnifiedDlg.cpp:2753
 #, fuzzy
 msgid "Reloading shared files..."
 msgstr "Megosztott fájlok frissítése"
 
-#: src/PrefsUnifiedDlg.cpp:2745
+#: src/PrefsUnifiedDlg.cpp:2754
 msgid "Scanning for subdirectories..."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2746
+#: src/PrefsUnifiedDlg.cpp:2755
 #, fuzzy
 msgid "Updating shared folders"
 msgstr "Megosztott mappák"
 
-#: src/PrefsUnifiedDlg.cpp:2773
+#: src/PrefsUnifiedDlg.cpp:2782
 #, c-format
 msgid "Scanned %u directories..."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2823
+#: src/PrefsUnifiedDlg.cpp:2832
 #, fuzzy, c-format
 msgid "Reloading shared files: %u files scanned"
 msgstr "A megosztott fájlok listájának újratöltése."
 
-#: src/PrefsUnifiedDlg.cpp:2873
+#: src/PrefsUnifiedDlg.cpp:2882
 #, fuzzy
 msgid "Shared folder"
 msgstr "Megosztott mappák"
@@ -7825,12 +7825,12 @@ msgstr "Kategória törlése"
 msgid "Hashset requested for unknown file: %s"
 msgstr "Hash-készlet kérés az ismeretlen %s fájlhoz"
 
-#: src/UploadQueue.cpp:618
+#: src/UploadQueue.cpp:627
 #, c-format
 msgid "Resuming uploads of file: %s"
 msgstr "Fájl feltöltés folytatása: %s"
 
-#: src/UploadQueue.cpp:634
+#: src/UploadQueue.cpp:643
 #, c-format
 msgid "Suspending upload of file: %s"
 msgstr "Fájl feltöltés felfüggesztése: %s"

--- a/po/hu.po
+++ b/po/hu.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-28 08:06+0200\n"
+"POT-Creation-Date: 2026-07-28 10:19+0200\n"
 "PO-Revision-Date: 2026-07-27 11:39+0000\n"
 "Last-Translator: Dévai Tamás <gonosztopi@amule.org>\n"
 "Language-Team: Hungarian <hu@li.org>\n"
@@ -145,7 +145,7 @@ msgstr "Telepítés"
 msgid "Not now"
 msgstr "Most nem"
 
-#: src/AppImageIntegration.cpp:422 src/amuleDlg.cpp:600
+#: src/AppImageIntegration.cpp:422 src/amuleDlg.cpp:665
 msgid "Don't ask again"
 msgstr "Ne kérdezze újra"
 
@@ -222,7 +222,7 @@ msgid "Killing amuleweb instance with pid '%d' ... "
 msgstr "Az amuleweb instancia - melynek a pid-je '%d' - kivégzése ... "
 
 #: src/amule.cpp:336 src/amule.cpp:349 src/ClientRef.cpp:180
-#: src/SearchDlg.cpp:880 src/ServerListCtrl.cpp:98
+#: src/SearchDlg.cpp:1041 src/ServerListCtrl.cpp:98
 msgid "Failed"
 msgstr "Sikertelen"
 
@@ -576,30 +576,68 @@ msgstr "Pid fájl létrehozása nem lehetséges"
 msgid "ERROR: %s"
 msgstr "HIBA: %s"
 
-#: src/amuleDlg.cpp:236
+#: src/amuleDlg.cpp:250
 #, c-format
 msgid "This is aMule %s based on eMule."
 msgstr "Ez az aMule %s, az eMule alapján."
 
-#: src/amuleDlg.cpp:237
+#: src/amuleDlg.cpp:251
 #, c-format
 msgid "Running on %s"
 msgstr "%s-en fut"
 
-#: src/amuleDlg.cpp:239
+#: src/amuleDlg.cpp:253
 msgid "Visit https://github.com/amule-org/amule/releases/latest to check if a new version is available."
 msgstr "Új verzióért látogasd meg a https://github.com/amule-org/amule/releases/latest oldalt."
 
-#: src/amuleDlg.cpp:268
+#: src/amuleDlg.cpp:282
 msgid "FATAL ERROR: Failed to create Timer"
 msgstr "VÉGZETES HIBA: Időzítő létrehozása sikertelen"
 
-#: src/amuleDlg.cpp:592
+#: src/amuleDlg.cpp:361 src/amuleDlg.cpp:1787 src/amuleDlg.cpp:2033
+#: src/muuli_wdr.cpp:1492 src/muuli_wdr.cpp:3418
+msgid "Networks"
+msgstr "Hálózatok"
+
+#: src/amuleDlg.cpp:362 src/amuleDlg.cpp:1793 src/muuli_wdr.cpp:3419
+msgid "Searches"
+msgstr "Keresések"
+
+#: src/amuleDlg.cpp:363 src/amuleDlg.cpp:1799 src/DownloadListCtrl.cpp:740
+#: src/muuli_wdr.cpp:392 src/muuli_wdr.cpp:1585 src/muuli_wdr.cpp:3420
+#: src/Statistics.cpp:829
+msgid "Downloads"
+msgstr "Letöltések"
+
+#: src/amuleDlg.cpp:364 src/amuleDlg.cpp:1805 src/muuli_wdr.cpp:3294
+msgid "Shared files"
+msgstr "Megosztott fájlok"
+
+#: src/amuleDlg.cpp:365 src/amuleDlg.cpp:1811 src/muuli_wdr.cpp:2926
+#: src/muuli_wdr.cpp:3376 src/muuli_wdr.cpp:3423
+msgid "Messages"
+msgstr "Üzenetek"
+
+#: src/amuleDlg.cpp:366 src/amuleDlg.cpp:1817 src/muuli_wdr.cpp:3424
+#: src/PrefsUnifiedDlg.cpp:312 src/Statistics.cpp:779 src/Statistics.cpp:1235
+msgid "Statistics"
+msgstr "Statisztikák"
+
+#: src/amuleDlg.cpp:368 src/amuleDlg.cpp:1824 src/muuli_wdr.cpp:3426
+#: src/PrefsUnifiedDlg.cpp:328 src/utils/wxCas/src/wxcasprefs.cpp:39
+msgid "Preferences"
+msgstr "Beállítások"
+
+#: src/amuleDlg.cpp:371
+msgid "Navigate"
+msgstr ""
+
+#: src/amuleDlg.cpp:657
 #, fuzzy
 msgid "New version available"
 msgstr "Nem elérhető"
 
-#: src/amuleDlg.cpp:596
+#: src/amuleDlg.cpp:661
 #, fuzzy, c-format
 msgid ""
 "A new version of aMule (%s) is available.\n"
@@ -609,217 +647,184 @@ msgid ""
 "Would you like to open the download page?"
 msgstr "A legújabb verzió mindig megtalálható a https://github.com/amule-org/amule/releases/latest honlapon."
 
-#: src/amuleDlg.cpp:678
+#: src/amuleDlg.cpp:743
 msgid "aMule dialog destroyed"
 msgstr "aMule dialógus elpusztítva"
 
-#: src/amuleDlg.cpp:701 src/DataToText.cpp:68 src/IPFilter.cpp:547
+#: src/amuleDlg.cpp:766 src/DataToText.cpp:68 src/IPFilter.cpp:547
 msgid "Connecting"
 msgstr "Kapcsolódás"
 
-#: src/amuleDlg.cpp:893
+#: src/amuleDlg.cpp:958
 msgid "eD2k: Connecting"
 msgstr "eD2K: Kapcsolódás"
 
-#: src/amuleDlg.cpp:897
+#: src/amuleDlg.cpp:962
 msgid "eD2k: Disconnected"
 msgstr "eD2k: Szétkapcsolva"
 
-#: src/amuleDlg.cpp:903
+#: src/amuleDlg.cpp:968
 msgid "Kad: Firewalled"
 msgstr "Kad: Tűzfal mögött"
 
-#: src/amuleDlg.cpp:907
+#: src/amuleDlg.cpp:972
 msgid "Kad: Connected"
 msgstr "Kad: Csatlakozva"
 
-#: src/amuleDlg.cpp:912
+#: src/amuleDlg.cpp:977
 msgid "Kad: Connecting"
 msgstr "Kad: Kapcsolódás"
 
-#: src/amuleDlg.cpp:916
+#: src/amuleDlg.cpp:981
 msgid "Kad: Off"
 msgstr "Kad: Nincs kapcsolat"
 
-#: src/amuleDlg.cpp:964 src/DownloadListCtrl.cpp:505
+#: src/amuleDlg.cpp:1029 src/DownloadListCtrl.cpp:505
 #: src/DownloadListCtrl.cpp:749 src/FriendListCtrl.cpp:180
 #: src/muuli_wdr.cpp:731 src/muuli_wdr.cpp:782 src/muuli_wdr.cpp:846
-#: src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2224 src/muuli_wdr.cpp:2309
-#: src/muuli_wdr.cpp:3057 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
+#: src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2231 src/muuli_wdr.cpp:2316
+#: src/muuli_wdr.cpp:3064 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
 #: src/ServerListCtrl.cpp:606 src/TransferWnd.cpp:378
 #: src/utils/wxCas/src/wxcasprefs.cpp:235
 msgid "Cancel"
 msgstr "Mégsem"
 
-#: src/amuleDlg.cpp:965
+#: src/amuleDlg.cpp:1030
 msgid "Stop the current connection attempts"
 msgstr "Aktuális kapcsolódási kísérletek leállítása"
 
-#: src/amuleDlg.cpp:970 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976
-#: src/muuli_wdr.cpp:2447
+#: src/amuleDlg.cpp:1035 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976
+#: src/muuli_wdr.cpp:2454
 msgid "Disconnect"
 msgstr "Szétkapcsolás"
 
-#: src/amuleDlg.cpp:971
+#: src/amuleDlg.cpp:1036
 msgid "Disconnect from the currently connected networks"
 msgstr "Leválaszt az éppen kapcsolódott hálózatokról."
 
-#: src/amuleDlg.cpp:976 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979
-#: src/muuli_wdr.cpp:2602 src/muuli_wdr.cpp:3054 src/muuli_wdr.cpp:3409
+#: src/amuleDlg.cpp:1041 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979
+#: src/muuli_wdr.cpp:2609 src/muuli_wdr.cpp:3061 src/muuli_wdr.cpp:3416
 msgid "Connect"
 msgstr "Kapcsolatfelvétel"
 
-#: src/amuleDlg.cpp:977
+#: src/amuleDlg.cpp:1042
 msgid "Connect to the currently enabled networks"
 msgstr "Kapcsolódás a pillanatnyilag engedélyezett hálózatokhoz."
 
-#: src/amuleDlg.cpp:1089
+#: src/amuleDlg.cpp:1154
 #, c-format
 msgid "Up: %.1f%s (%.1f) | Down: %.1f%s (%.1f)"
 msgstr "Fel: %.1f%s (%.1f) | Le: %.1f%s (%.1f)"
 
-#: src/amuleDlg.cpp:1091 src/amuleDlg.cpp:1093 src/amuleDlg.cpp:1097
-#: src/amuleDlg.cpp:1099 src/amuleDlg.cpp:1110 src/amuleDlg.cpp:1112
+#: src/amuleDlg.cpp:1156 src/amuleDlg.cpp:1158 src/amuleDlg.cpp:1162
+#: src/amuleDlg.cpp:1164 src/amuleDlg.cpp:1175 src/amuleDlg.cpp:1177
 #: src/MuleTrayIcon.cpp:796 src/MuleTrayIcon.cpp:799
 msgid " MB/s"
 msgstr " MB/s"
 
-#: src/amuleDlg.cpp:1091 src/amuleDlg.cpp:1093 src/amuleDlg.cpp:1097
-#: src/amuleDlg.cpp:1099 src/amuleDlg.cpp:1110 src/amuleDlg.cpp:1112
+#: src/amuleDlg.cpp:1156 src/amuleDlg.cpp:1158 src/amuleDlg.cpp:1162
+#: src/amuleDlg.cpp:1164 src/amuleDlg.cpp:1175 src/amuleDlg.cpp:1177
 #: src/MuleTrayIcon.cpp:796 src/MuleTrayIcon.cpp:799
 #: src/utils/wxCas/src/wxcasframe.cpp:1041
 msgid " kB/s"
 msgstr " kB/s"
 
-#: src/amuleDlg.cpp:1096
+#: src/amuleDlg.cpp:1161
 #, c-format
 msgid "Up: %.1f%s | Down: %.1f%s"
 msgstr "Fel: %.1f%s | Le: %.1f%s"
 
-#: src/amuleDlg.cpp:1128
+#: src/amuleDlg.cpp:1193
 #, c-format
 msgid "aMule (%s | Connected)"
 msgstr "aMule (%s | Kapcsolódva)"
 
-#: src/amuleDlg.cpp:1130
+#: src/amuleDlg.cpp:1195
 #, c-format
 msgid "aMule (%s | Disconnected)"
 msgstr "aMule (%s | Nincs kapcsolat)"
 
-#: src/amuleDlg.cpp:1183
+#: src/amuleDlg.cpp:1248
 #, c-format
 msgid "Do you really want to exit %s?"
 msgstr "Biztos, hogy ki szeretnél lépni a(z) %s alkalmazásból?"
 
-#: src/amuleDlg.cpp:1185
+#: src/amuleDlg.cpp:1250
 msgid "Exit confirmation"
 msgstr "Kilépés megerősítése"
 
-#: src/amuleDlg.cpp:1548
+#: src/amuleDlg.cpp:1613
 msgid "Launch Command: "
 msgstr "Parancs futtatása: "
 
-#: src/amuleDlg.cpp:1567 src/muuli_wdr.cpp:1971 src/Preferences.cpp:951
+#: src/amuleDlg.cpp:1632 src/muuli_wdr.cpp:1978 src/Preferences.cpp:952
 msgid "- default -"
 msgstr "- alapértelmezett -"
 
-#: src/amuleDlg.cpp:1595
+#: src/amuleDlg.cpp:1660
 #, c-format
 msgid "Skin directory '%s' does not exist"
 msgstr "A(z) '%s' felület könyvtár nem létezik"
 
-#: src/amuleDlg.cpp:1598
+#: src/amuleDlg.cpp:1663
 #, c-format
 msgid "WARNING: Unable to open skin file '%s' for read"
 msgstr "FIGYELEM: Nem tudom a(z) '%s' felület fáljt megnyitni olvasásra"
 
-#: src/amuleDlg.cpp:1722 src/amuleDlg.cpp:1968 src/muuli_wdr.cpp:1485
-#: src/muuli_wdr.cpp:3411
-msgid "Networks"
-msgstr "Hálózatok"
-
-#: src/amuleDlg.cpp:1726 src/muuli_wdr.cpp:3411
+#: src/amuleDlg.cpp:1791 src/muuli_wdr.cpp:3418
 msgid "Networks Window"
 msgstr "Hálózatok ablaka"
 
-#: src/amuleDlg.cpp:1728 src/muuli_wdr.cpp:3412
-msgid "Searches"
-msgstr "Keresések"
-
-#: src/amuleDlg.cpp:1732 src/muuli_wdr.cpp:3412
+#: src/amuleDlg.cpp:1797 src/muuli_wdr.cpp:3419
 msgid "Searches Window"
 msgstr "Keresés ablaka"
 
-#: src/amuleDlg.cpp:1734 src/DownloadListCtrl.cpp:740 src/muuli_wdr.cpp:392
-#: src/muuli_wdr.cpp:1578 src/muuli_wdr.cpp:3413 src/Statistics.cpp:829
-msgid "Downloads"
-msgstr "Letöltések"
-
-#: src/amuleDlg.cpp:1738 src/muuli_wdr.cpp:3413
+#: src/amuleDlg.cpp:1803 src/muuli_wdr.cpp:3420
 msgid "Downloads Window"
 msgstr "Letöltések ablaka"
 
-#: src/amuleDlg.cpp:1740 src/muuli_wdr.cpp:3287
-msgid "Shared files"
-msgstr "Megosztott fájlok"
-
-#: src/amuleDlg.cpp:1744 src/muuli_wdr.cpp:3415
+#: src/amuleDlg.cpp:1809 src/muuli_wdr.cpp:3422
 msgid "Shared Files Window"
 msgstr "Megosztott fájlok ablaka"
 
-#: src/amuleDlg.cpp:1746 src/muuli_wdr.cpp:2919 src/muuli_wdr.cpp:3369
-#: src/muuli_wdr.cpp:3416
-msgid "Messages"
-msgstr "Üzenetek"
-
-#: src/amuleDlg.cpp:1750 src/muuli_wdr.cpp:3416
+#: src/amuleDlg.cpp:1815 src/muuli_wdr.cpp:3423
 msgid "Messages Window"
 msgstr "Üzenetek ablaka"
 
-#: src/amuleDlg.cpp:1752 src/muuli_wdr.cpp:3417 src/PrefsUnifiedDlg.cpp:312
-#: src/Statistics.cpp:779 src/Statistics.cpp:1235
-msgid "Statistics"
-msgstr "Statisztikák"
-
-#: src/amuleDlg.cpp:1756 src/muuli_wdr.cpp:3417
+#: src/amuleDlg.cpp:1821 src/muuli_wdr.cpp:3424
 msgid "Statistics Graph Window"
 msgstr "Statisztikai grafikonok ablaka"
 
-#: src/amuleDlg.cpp:1759 src/muuli_wdr.cpp:3419 src/PrefsUnifiedDlg.cpp:328
-#: src/utils/wxCas/src/wxcasprefs.cpp:39
-msgid "Preferences"
-msgstr "Beállítások"
-
-#: src/amuleDlg.cpp:1763 src/muuli_wdr.cpp:3419
+#: src/amuleDlg.cpp:1828 src/muuli_wdr.cpp:3426
 msgid "Preferences Settings Window"
 msgstr "Tulajdonságok beállításának ablaka"
 
-#: src/amuleDlg.cpp:1766 src/muuli_wdr.cpp:3420
+#: src/amuleDlg.cpp:1831 src/muuli_wdr.cpp:3427
 msgid "Import"
 msgstr "Importálás"
 
-#: src/amuleDlg.cpp:1770 src/muuli_wdr.cpp:3420
+#: src/amuleDlg.cpp:1835 src/muuli_wdr.cpp:3427
 msgid "The partfile importer tool"
 msgstr "A részfájl importáló eszköz"
 
-#: src/amuleDlg.cpp:1773 src/muuli_wdr.cpp:3421
+#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3428
 #: src/utils/aLinkCreator/src/alcframe.cpp:262
 msgid "About"
 msgstr "Névjegy"
 
-#: src/amuleDlg.cpp:1773 src/muuli_wdr.cpp:3421
+#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3428
 msgid "About/Help"
 msgstr "Névjegy/Súgó"
 
-#: src/amuleDlg.cpp:1971
+#: src/amuleDlg.cpp:2036
 msgid "eD2k network"
 msgstr "eD2k hálózat"
 
-#: src/amuleDlg.cpp:1974
+#: src/amuleDlg.cpp:2039
 msgid "Kad network"
 msgstr "Kad hálózat"
 
-#: src/amuleDlg.cpp:1974
+#: src/amuleDlg.cpp:2039
 msgid "No network"
 msgstr "Nincs hálózat"
 
@@ -1349,19 +1354,19 @@ msgstr "Auto [Ma]"
 msgid "Very low"
 msgstr "Nagyon alacsony"
 
-#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:743 src/muuli_wdr.cpp:2275
+#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:743 src/muuli_wdr.cpp:2282
 #: src/ServerListCtrl.cpp:263 src/ServerListCtrl.cpp:456
 #: src/SharedFilesCtrl.cpp:145
 msgid "Low"
 msgstr "Alacsony"
 
-#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:744 src/muuli_wdr.cpp:2276
+#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:744 src/muuli_wdr.cpp:2283
 #: src/ServerListCtrl.cpp:266 src/ServerListCtrl.cpp:457
 #: src/SharedFilesCtrl.cpp:146
 msgid "Normal"
 msgstr "Normál"
 
-#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:745 src/muuli_wdr.cpp:2277
+#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:745 src/muuli_wdr.cpp:2284
 #: src/ServerListCtrl.cpp:269 src/ServerListCtrl.cpp:458
 #: src/SharedFilesCtrl.cpp:147
 msgid "High"
@@ -1453,8 +1458,8 @@ msgstr "Helyi kiszolgáló"
 msgid "Remote Server"
 msgstr "Távoli kiszolgáló"
 
-#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3174
-#: src/SearchDlg.cpp:111 src/TextClient.cpp:911
+#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3181
+#: src/SearchDlg.cpp:119 src/TextClient.cpp:911
 msgid "Kad"
 msgstr "Kad"
 
@@ -1524,7 +1529,7 @@ msgstr "Rész"
 msgid "Size"
 msgstr "Méret"
 
-#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3241
+#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3248
 msgid "Transferred"
 msgstr "Átmásolva"
 
@@ -1582,7 +1587,7 @@ msgstr ""
 "Visszajelzés %s-től (%s):\n"
 "\n"
 
-#: src/DownloadListCtrl.cpp:746 src/muuli_wdr.cpp:2278
+#: src/DownloadListCtrl.cpp:746 src/muuli_wdr.cpp:2285
 #: src/SharedFilesCtrl.cpp:150
 msgid "Auto"
 msgstr "Automatikus"
@@ -1620,7 +1625,7 @@ msgid "Extended Options"
 msgstr "Kibővített beállítások"
 
 #: src/DownloadListCtrl.cpp:770 src/DownloadListCtrl.cpp:822
-#: src/muuli_wdr.cpp:1789
+#: src/muuli_wdr.cpp:1796
 msgid "Preview"
 msgstr "Előnézet"
 
@@ -2327,19 +2332,19 @@ msgstr ""
 msgid "eD2k"
 msgstr "eD2k"
 
-#: src/FirstRunWizard.cpp:349 src/muuli_wdr.cpp:1488
+#: src/FirstRunWizard.cpp:349 src/muuli_wdr.cpp:1495
 msgid "Kademlia"
 msgstr "Kademlia"
 
-#: src/FirstRunWizard.cpp:359 src/muuli_wdr.cpp:1416
+#: src/FirstRunWizard.cpp:359 src/muuli_wdr.cpp:1423
 msgid "Standard TCP Port "
 msgstr "Szabvány TCP port "
 
-#: src/FirstRunWizard.cpp:365 src/muuli_wdr.cpp:1428
+#: src/FirstRunWizard.cpp:365 src/muuli_wdr.cpp:1435
 msgid "Extended UDP port (Kad / global search) "
 msgstr "Bővített UDP port (Kad / globális keresés) "
 
-#: src/FirstRunWizard.cpp:377 src/muuli_wdr.cpp:1435
+#: src/FirstRunWizard.cpp:377 src/muuli_wdr.cpp:1442
 msgid "Enable UPnP for router port forwarding"
 msgstr "UPnP engedélyezése a router port továbbításhoz"
 
@@ -2366,7 +2371,7 @@ msgstr ""
 msgid "Your peer lists are already in place - nothing to download."
 msgstr "Már próbálod letölteni a(z) '%s' fájlt."
 
-#: src/FirstRunWizard.cpp:434 src/muuli_wdr.cpp:1533
+#: src/FirstRunWizard.cpp:434 src/muuli_wdr.cpp:1540
 msgid "Auto-update server list at startup"
 msgstr "Kiszolgáló lista automatikus frissítése indításkor"
 
@@ -2412,23 +2417,23 @@ msgid ""
 "want downloads on a different (e.g. larger) disk."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:549 src/FirstRunWizard.cpp:611 src/muuli_wdr.cpp:1701
+#: src/FirstRunWizard.cpp:549 src/FirstRunWizard.cpp:611 src/muuli_wdr.cpp:1708
 msgid "Destination folder for downloads"
 msgstr "Célkönyvtár a letöltéseknek"
 
-#: src/FirstRunWizard.cpp:553 src/FirstRunWizard.cpp:569 src/muuli_wdr.cpp:1342
-#: src/muuli_wdr.cpp:1359 src/muuli_wdr.cpp:1676 src/muuli_wdr.cpp:1707
-#: src/muuli_wdr.cpp:1719 src/muuli_wdr.cpp:2762
+#: src/FirstRunWizard.cpp:553 src/FirstRunWizard.cpp:569 src/muuli_wdr.cpp:1349
+#: src/muuli_wdr.cpp:1366 src/muuli_wdr.cpp:1683 src/muuli_wdr.cpp:1714
+#: src/muuli_wdr.cpp:1726 src/muuli_wdr.cpp:2769
 #: src/utils/aLinkCreator/src/alcframe.cpp:135
 #: src/utils/wxCas/src/wxcasprefs.cpp:52 src/utils/wxCas/src/wxcasprefs.cpp:118
 msgid "Browse"
 msgstr "Tallóz"
 
-#: src/FirstRunWizard.cpp:559 src/muuli_wdr.cpp:1712
+#: src/FirstRunWizard.cpp:559 src/muuli_wdr.cpp:1719
 msgid "(All files in this folder are shared with other peers)"
 msgstr "(Minden fájl ebben a könyvtárban másokkal megosztásra kerül)"
 
-#: src/FirstRunWizard.cpp:565 src/FirstRunWizard.cpp:624 src/muuli_wdr.cpp:1714
+#: src/FirstRunWizard.cpp:565 src/FirstRunWizard.cpp:624 src/muuli_wdr.cpp:1721
 msgid "Folder for temporary download files"
 msgstr "Könyvtár az ideiglenes letöltési fájloknak"
 
@@ -2459,7 +2464,7 @@ msgstr "A barátokat tartalmazó emfriends.dat fájl írásra megnyitása sikert
 msgid "CRITICAL - no client on StartChatSession"
 msgstr "KRITIKUS - nincsen kliens a StartChatSession-en"
 
-#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2668 src/muuli_wdr.cpp:3345
+#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2675 src/muuli_wdr.cpp:3352
 msgid "Friends"
 msgstr "Barátok"
 
@@ -2839,7 +2844,7 @@ msgstr "Megosztási arány"
 msgid "Uploaded"
 msgstr "Feltöltve"
 
-#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3225
+#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3232
 msgid "Requested"
 msgstr "Kért"
 
@@ -2963,7 +2968,7 @@ msgid "WARNING: "
 msgstr "FIGYELEM: "
 
 #: src/MuleNotebook.cpp:179 src/muuli_wdr.cpp:817 src/muuli_wdr.cpp:1229
-#: src/muuli_wdr.cpp:3129 src/muuli_wdr.cpp:3385
+#: src/muuli_wdr.cpp:3136 src/muuli_wdr.cpp:3392
 msgid "Close"
 msgstr "Bezár"
 
@@ -2976,12 +2981,12 @@ msgstr "Kivágás"
 msgid "Copy"
 msgstr "Másolás"
 
-#: src/MuleTextCtrl.cpp:88
+#: src/MuleTextCtrl.cpp:88 src/SearchDlg.cpp:261
 msgid "Paste"
 msgstr "Beillesztés"
 
 #: src/MuleTextCtrl.cpp:89 src/muuli_wdr.cpp:358 src/muuli_wdr.cpp:757
-#: src/muuli_wdr.cpp:2352 src/muuli_wdr.cpp:2371 src/muuli_wdr.cpp:2393
+#: src/muuli_wdr.cpp:2359 src/muuli_wdr.cpp:2378 src/muuli_wdr.cpp:2400
 #: src/utils/aLinkCreator/src/alcframe.cpp:142
 msgid "Clear"
 msgstr "Törlés"
@@ -3072,8 +3077,8 @@ msgid "Exit"
 msgstr "Kilépés"
 
 #: src/MuleTrayIcon.cpp:579 src/MuleTrayIcon.cpp:945 src/MuleTrayIcon.cpp:965
-#: src/muuli_wdr.cpp:1391 src/muuli_wdr.cpp:1399 src/muuli_wdr.cpp:1406
-#: src/muuli_wdr.cpp:1835 src/muuli_wdr.cpp:1841 src/OtherFunctions.cpp:91
+#: src/muuli_wdr.cpp:1398 src/muuli_wdr.cpp:1406 src/muuli_wdr.cpp:1413
+#: src/muuli_wdr.cpp:1842 src/muuli_wdr.cpp:1848 src/OtherFunctions.cpp:91
 #: src/StatisticsDlg.cpp:93 src/StatisticsDlg.cpp:95
 msgid "kB/s"
 msgstr "kB/s"
@@ -3244,7 +3249,7 @@ msgstr "Név:"
 msgid "Type"
 msgstr "Típus"
 
-#: src/muuli_wdr.cpp:215 src/SearchDlg.cpp:110 src/SearchListCtrl.cpp:853
+#: src/muuli_wdr.cpp:215 src/SearchDlg.cpp:118 src/SearchListCtrl.cpp:853
 msgid "Local"
 msgstr "Helyi"
 
@@ -3315,7 +3320,7 @@ msgstr "bájt"
 msgid "KB"
 msgstr "KB"
 
-#: src/muuli_wdr.cpp:274 src/muuli_wdr.cpp:293 src/muuli_wdr.cpp:1620
+#: src/muuli_wdr.cpp:274 src/muuli_wdr.cpp:293 src/muuli_wdr.cpp:1627
 #: src/OtherFunctions.cpp:64
 msgid "MB"
 msgstr "MB"
@@ -3332,7 +3337,7 @@ msgstr "Max. méret"
 msgid "Availability"
 msgstr "Elérhetőség"
 
-#: src/muuli_wdr.cpp:312 src/muuli_wdr.cpp:398 src/muuli_wdr.cpp:3290
+#: src/muuli_wdr.cpp:312 src/muuli_wdr.cpp:398 src/muuli_wdr.cpp:3297
 msgid "Filter:"
 msgstr "Szűrő:"
 
@@ -3364,7 +3369,7 @@ msgstr "Kérje meg a már válaszolt Kad partnereket, hogy szélesítsék a kere
 msgid "Stop"
 msgstr "Leállít"
 
-#: src/muuli_wdr.cpp:348 src/muuli_wdr.cpp:1385 src/SearchListCtrl.cpp:732
+#: src/muuli_wdr.cpp:348 src/muuli_wdr.cpp:1392 src/SearchListCtrl.cpp:732
 msgid "Download"
 msgstr "Letöltés"
 
@@ -3395,8 +3400,8 @@ msgstr "Fájl források:"
 #: src/muuli_wdr.cpp:1160 src/muuli_wdr.cpp:1167 src/muuli_wdr.cpp:1172
 #: src/muuli_wdr.cpp:1179 src/muuli_wdr.cpp:1184 src/muuli_wdr.cpp:1191
 #: src/muuli_wdr.cpp:1205 src/muuli_wdr.cpp:1212 src/muuli_wdr.cpp:1217
-#: src/muuli_wdr.cpp:1224 src/muuli_wdr.cpp:3227 src/muuli_wdr.cpp:3235
-#: src/muuli_wdr.cpp:3243
+#: src/muuli_wdr.cpp:1224 src/muuli_wdr.cpp:3234 src/muuli_wdr.cpp:3242
+#: src/muuli_wdr.cpp:3250
 msgid "N/A"
 msgstr "N/A"
 
@@ -3541,7 +3546,7 @@ msgstr ""
 msgid "Album :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:685 src/muuli_wdr.cpp:2247
+#: src/muuli_wdr.cpp:685 src/muuli_wdr.cpp:2254
 msgid "Title :"
 msgstr "Cím :"
 
@@ -3650,7 +3655,7 @@ msgstr "User név :"
 msgid "Userhash :"
 msgstr "Userhash :"
 
-#: src/muuli_wdr.cpp:895 src/muuli_wdr.cpp:1741 src/muuli_wdr.cpp:2442
+#: src/muuli_wdr.cpp:895 src/muuli_wdr.cpp:1748 src/muuli_wdr.cpp:2449
 #: src/utils/aLinkCreator/src/alcframe.cpp:137
 msgid "Add"
 msgstr "Hozzáad"
@@ -3659,15 +3664,15 @@ msgstr "Hozzáad"
 msgid "Download-Speed"
 msgstr "Letöltési sebesség"
 
-#: src/muuli_wdr.cpp:954 src/muuli_wdr.cpp:989 src/muuli_wdr.cpp:2546
+#: src/muuli_wdr.cpp:954 src/muuli_wdr.cpp:989 src/muuli_wdr.cpp:2553
 msgid "Current"
 msgstr "Aktuális"
 
-#: src/muuli_wdr.cpp:962 src/muuli_wdr.cpp:997 src/muuli_wdr.cpp:2554
+#: src/muuli_wdr.cpp:962 src/muuli_wdr.cpp:997 src/muuli_wdr.cpp:2561
 msgid "Running average"
 msgstr "Futásátlag"
 
-#: src/muuli_wdr.cpp:970 src/muuli_wdr.cpp:1005 src/muuli_wdr.cpp:2562
+#: src/muuli_wdr.cpp:970 src/muuli_wdr.cpp:1005 src/muuli_wdr.cpp:2569
 msgid "Session average"
 msgstr "Munkafolyamatok átlaga"
 
@@ -3679,7 +3684,7 @@ msgstr "Feltöltési sebesség"
 msgid "Connections"
 msgstr "Kapcsolatok"
 
-#: src/muuli_wdr.cpp:1024 src/muuli_wdr.cpp:1860
+#: src/muuli_wdr.cpp:1024 src/muuli_wdr.cpp:1867
 msgid "Active downloads"
 msgstr "Aktív letöltések"
 
@@ -3687,7 +3692,7 @@ msgstr "Aktív letöltések"
 msgid "Active connections (1:1)"
 msgstr "Aktív kapcsolatok (1:1)"
 
-#: src/muuli_wdr.cpp:1040 src/muuli_wdr.cpp:1861
+#: src/muuli_wdr.cpp:1040 src/muuli_wdr.cpp:1868
 msgid "Active uploads"
 msgstr "Aktív feltöltések"
 
@@ -3803,8 +3808,8 @@ msgstr "Ezt a nevet fogja a többi felhasználó látni, amikor kapcsolódnak ho
 msgid "Language: "
 msgstr "Nyelv: "
 
-#: src/muuli_wdr.cpp:1257 src/muuli_wdr.cpp:1323 src/muuli_wdr.cpp:1327
-#: src/muuli_wdr.cpp:1330
+#: src/muuli_wdr.cpp:1257 src/muuli_wdr.cpp:1330 src/muuli_wdr.cpp:1334
+#: src/muuli_wdr.cpp:1337
 msgid "The delay before showing tool-tips."
 msgstr "Késleltetés a tool-tippek előtt."
 
@@ -3882,260 +3887,269 @@ msgstr "Értesítések megjelenítése a letöltés befejezésekor"
 msgid "Enabling this will make aMule to show notifications when finished downloading."
 msgstr "Ezt engedélyezve az aMule értesítéseket fog megjeleníteni a befejezett letöltésekről."
 
-#: src/muuli_wdr.cpp:1322
+#: src/muuli_wdr.cpp:1323
+#, fuzzy
+msgid "Remember search history"
+msgstr "Emlékezzen ezekre a beállításokra"
+
+#: src/muuli_wdr.cpp:1324
+msgid "Keeps a dropdown list of your past search terms in the Search tab's Name field. This remembers the queries you typed, not the results they returned."
+msgstr ""
+
+#: src/muuli_wdr.cpp:1329
 msgid "Tooltip delay time: "
 msgstr "Szóbuborék késési idő: "
 
-#: src/muuli_wdr.cpp:1329
+#: src/muuli_wdr.cpp:1336
 msgid "seconds"
 msgstr "másodperc"
 
-#: src/muuli_wdr.cpp:1333
+#: src/muuli_wdr.cpp:1340
 msgid "Browser Selection"
 msgstr "Böngésző kiválasztása"
 
-#: src/muuli_wdr.cpp:1339
+#: src/muuli_wdr.cpp:1346
 msgid "Enter your browser name here. Leave this field empty to use the system default browser."
 msgstr "Írd ide a böngésződ nevét. Hagyd üresen, hogy a rendszer alapértelmezett böngészőjéhez."
 
-#: src/muuli_wdr.cpp:1346
+#: src/muuli_wdr.cpp:1353
 msgid "Open in new tab if possible"
 msgstr "Megnyitás új fülön, ha lehetséges"
 
-#: src/muuli_wdr.cpp:1348
+#: src/muuli_wdr.cpp:1355
 msgid "Open the web page in a new tab instead of in a new window when possible"
 msgstr "Weboldal megnyitása új fülön új ablak helyett, ha lehetséges"
 
-#: src/muuli_wdr.cpp:1352
+#: src/muuli_wdr.cpp:1359
 msgid "Video Player"
 msgstr "Videólejátszó"
 
-#: src/muuli_wdr.cpp:1379
+#: src/muuli_wdr.cpp:1386
 msgid "Bandwidth limits"
 msgstr "Sávszélesség korlátok"
 
-#: src/muuli_wdr.cpp:1393
+#: src/muuli_wdr.cpp:1400
 msgid "Upload"
 msgstr "Feltöltés"
 
-#: src/muuli_wdr.cpp:1401
+#: src/muuli_wdr.cpp:1408
 msgid "Slot Allocation"
 msgstr "Slot kiosztás"
 
-#: src/muuli_wdr.cpp:1410
+#: src/muuli_wdr.cpp:1417
 msgid "Ports"
 msgstr "Portok"
 
-#: src/muuli_wdr.cpp:1420
+#: src/muuli_wdr.cpp:1427
 msgid "This is the standard eD2k port and cannot be disabled."
 msgstr "Ez a szabvány eD2k port és nem lehet letiltani."
 
-#: src/muuli_wdr.cpp:1423
+#: src/muuli_wdr.cpp:1430
 msgid "UDP port for server requests (TCP+3):"
 msgstr "UDP port a kiszolgáló kérésekhez (TCP+3):"
 
-#: src/muuli_wdr.cpp:1425
+#: src/muuli_wdr.cpp:1432
 msgid "4665"
 msgstr "4665"
 
-#: src/muuli_wdr.cpp:1432
+#: src/muuli_wdr.cpp:1439
 msgid "This UDP port is used for extended eD2k requests and Kad network"
 msgstr "Ezt az UDP portot a bővített eD2k kérések és a Kad hálózat használja"
 
-#: src/muuli_wdr.cpp:1439
+#: src/muuli_wdr.cpp:1446
 msgid "UPnP TCP Port (Optional):"
 msgstr "UPnP TCP port (nem kötelező):"
 
-#: src/muuli_wdr.cpp:1449
+#: src/muuli_wdr.cpp:1456
 msgid "Bind local address to IP (empty for any):"
 msgstr "Lokális cím IP-hez csatolása (mindet ha üres):"
 
-#: src/muuli_wdr.cpp:1452
+#: src/muuli_wdr.cpp:1459
 msgid "Advanced users only: If you have multiple network interfaces, enter the address of the interface to which aMule should be bound."
 msgstr "Csak haladó felhasználóknak: Ha több hálózati kártyád van, írd ide a címet, amelyhez az aMule kötve legyen."
 
-#: src/muuli_wdr.cpp:1455 src/muuli_wdr.cpp:2054
+#: src/muuli_wdr.cpp:1462 src/muuli_wdr.cpp:2061
 #, fuzzy
 msgid "Bind to network interface (empty for any):"
 msgstr "Lokális cím IP-hez csatolása (mindet ha üres):"
 
-#: src/muuli_wdr.cpp:1468
+#: src/muuli_wdr.cpp:1475
 msgid "Advanced users only: pin all of aMule's traffic to one network interface, chosen from the list or typed in by name (e.g. tun0, eth0, en0) or index. Unlike binding to an IP, this stops traffic leaking out via the default route - useful with a VPN. Requires no elevated privileges."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1474
+#: src/muuli_wdr.cpp:1481
 msgid "Max sources per downloading file:"
 msgstr "Max források letöltési fájlonként:"
 
-#: src/muuli_wdr.cpp:1478
+#: src/muuli_wdr.cpp:1485
 msgid "Max simultaneous connections:"
 msgstr "Max egyidejű kapcsolatok:"
 
-#: src/muuli_wdr.cpp:1491 src/muuli_wdr.cpp:3169
+#: src/muuli_wdr.cpp:1498 src/muuli_wdr.cpp:3176
 msgid "ED2K"
 msgstr "ED2K"
 
-#: src/muuli_wdr.cpp:1498
+#: src/muuli_wdr.cpp:1505
 msgid "Autoconnect on startup"
 msgstr "Automatikus kapcsolódás induláskor"
 
-#: src/muuli_wdr.cpp:1501
+#: src/muuli_wdr.cpp:1508
 msgid "Reconnect on loss"
 msgstr "Kapcsolódás megismétlése megszakadt kapcsolat esetén"
 
-#: src/muuli_wdr.cpp:1523
+#: src/muuli_wdr.cpp:1530
 msgid "Remove dead server after"
 msgstr "Halott kiszolgálók eltávolítása"
 
-#: src/muuli_wdr.cpp:1524
+#: src/muuli_wdr.cpp:1531
 msgid "Static servers are never removed, even when unreachable."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1528
+#: src/muuli_wdr.cpp:1535
 msgid "retries"
 msgstr "próbálkozás után"
 
-#: src/muuli_wdr.cpp:1536
+#: src/muuli_wdr.cpp:1543
 msgid "List"
 msgstr "Lista"
 
-#: src/muuli_wdr.cpp:1539
+#: src/muuli_wdr.cpp:1546
 msgid "Update server list when connecting to a server"
 msgstr "Kiszolgáló lista frissítése kiszolgálóhoz való kapcsolódáskor"
 
-#: src/muuli_wdr.cpp:1542
+#: src/muuli_wdr.cpp:1549
 msgid "Update server list when a client connects"
 msgstr "Kiszolgáló lista frissítése amikor egy ügyfél kapcsolódik"
 
-#: src/muuli_wdr.cpp:1545
+#: src/muuli_wdr.cpp:1552
 msgid "Use priority system"
 msgstr "Prioritási rendszer használata"
 
-#: src/muuli_wdr.cpp:1549
+#: src/muuli_wdr.cpp:1556
 msgid "Use smart LowID check on connect"
 msgstr "Intelligens LowID ellenőrzés használata kapcsolódáskor"
 
-#: src/muuli_wdr.cpp:1553
+#: src/muuli_wdr.cpp:1560
 msgid "Safe connect"
 msgstr "Biztonságos kapcsolódás"
 
-#: src/muuli_wdr.cpp:1557
+#: src/muuli_wdr.cpp:1564
 msgid "Autoconnect to servers in static list only"
 msgstr "Automatikus kapcsolódás kizárólag az állandó kiszolgálókhoz"
 
-#: src/muuli_wdr.cpp:1560
+#: src/muuli_wdr.cpp:1567
 msgid "Set manually added servers to High Priority"
 msgstr "A kézileg hozzáadott kiszolgálók Magas Prioritással történő felvétele"
 
-#: src/muuli_wdr.cpp:1581
+#: src/muuli_wdr.cpp:1588
 msgid "Add files to download in pause mode"
 msgstr "Fájlok felvétele szüneteltetett módban"
 
-#: src/muuli_wdr.cpp:1583
+#: src/muuli_wdr.cpp:1590
 msgid "Add files to download with auto priority"
 msgstr "Új letöltések felvétele automatikus prioritással"
 
-#: src/muuli_wdr.cpp:1586
+#: src/muuli_wdr.cpp:1593
 msgid "Try to download first and last chunks first"
 msgstr "Előszőr az első és utolsó adatelemet próbálja meg letölteni"
 
-#: src/muuli_wdr.cpp:1590
+#: src/muuli_wdr.cpp:1597
 msgid "Endgame mode: rotate to faster sources for the final blocks"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1593
+#: src/muuli_wdr.cpp:1600
 msgid "Start next paused file when a file completes"
 msgstr "Következő szüneteltetett fájl indítása amikor egy letöltés befejeződik"
 
-#: src/muuli_wdr.cpp:1596
+#: src/muuli_wdr.cpp:1603
 msgid "From the same category"
 msgstr "Ugyanabból a kategóriából"
 
-#: src/muuli_wdr.cpp:1598
+#: src/muuli_wdr.cpp:1605
 msgid "In alphabetic order"
 msgstr "Betűrendi sorrendben"
 
-#: src/muuli_wdr.cpp:1600
+#: src/muuli_wdr.cpp:1607
 msgid "Preallocate disk space for new files"
 msgstr "Lemezterület helyfogalalás az új fájloknak"
 
-#: src/muuli_wdr.cpp:1601
+#: src/muuli_wdr.cpp:1608
 msgid "For new files preallocates disk space for the whole file, thus reduces fragmentation"
 msgstr "Az új fájlok számára előre lefoglalja a lemezterületet, így csökkentve a töredezettséget"
 
-#: src/muuli_wdr.cpp:1606
+#: src/muuli_wdr.cpp:1613
 msgid "Create new files as sparse files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1607
+#: src/muuli_wdr.cpp:1614
 msgid "A sparse file reserves its full size on disk immediately without writing real data to it -- fast, but unsupported or slow on some filesystems, and free-space accounting stays optimistic while the download is in progress. Turn this off to grow the file only as data arrives."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1612
+#: src/muuli_wdr.cpp:1619
 msgid "Stop downloads when free disk space reaches "
 msgstr "Letöltések megállítása amikor a szabad hely kevesebb mint "
 
-#: src/muuli_wdr.cpp:1613
+#: src/muuli_wdr.cpp:1620
 msgid "Select this if you want aMule to check your disk space"
 msgstr "Jelöld be, ha azt szeretnéd, hogy az aMule ellenőrizze a szabad lemezterületet"
 
-#: src/muuli_wdr.cpp:1617
+#: src/muuli_wdr.cpp:1624
 msgid "Enter here the min disk space desired."
 msgstr "Add meg a kívánt min. szabad lemezterületet."
 
-#: src/muuli_wdr.cpp:1623
+#: src/muuli_wdr.cpp:1630
 msgid "Save 10 sources on rare files (< 20 sources)"
 msgstr "Mentsen el 10 forrást ritka fájloknál (< 20 forrás)"
 
-#: src/muuli_wdr.cpp:1627 src/Statistics.cpp:790
+#: src/muuli_wdr.cpp:1634 src/Statistics.cpp:790
 msgid "Uploads"
 msgstr "Feltöltések"
 
-#: src/muuli_wdr.cpp:1630
+#: src/muuli_wdr.cpp:1637
 msgid "Add new shared files with auto priority"
 msgstr "Új megosztott fájl felvétele automatikus prioritással"
 
-#: src/muuli_wdr.cpp:1636
+#: src/muuli_wdr.cpp:1643
 msgid "Intelligent Corruption Handling (I.C.H.)"
 msgstr "Intelligens Sérülés Kezelő (I.S.K.)"
 
-#: src/muuli_wdr.cpp:1639
+#: src/muuli_wdr.cpp:1646
 msgid "Enable"
 msgstr "Engedélyezés"
 
-#: src/muuli_wdr.cpp:1642
+#: src/muuli_wdr.cpp:1649
 msgid "Advanced I.C.H. trusts every hash (not recommended)"
 msgstr "Feljett I.S.K. megbízzon minden hash-ben (nem ajánlott)"
 
-#: src/muuli_wdr.cpp:1654 src/PrefsUnifiedDlg.cpp:1910
+#: src/muuli_wdr.cpp:1661 src/PrefsUnifiedDlg.cpp:1910
 msgid "Media metadata extraction"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1658
+#: src/muuli_wdr.cpp:1665
 msgid "Extract length / bitrate / codec from shared audio and video files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1660
+#: src/muuli_wdr.cpp:1667
 msgid "When enabled, aMule runs ffprobe on each shared media file to fill in the Length / Bitrate / Codec columns other clients see when they find the file in a search. Requires ffmpeg (the ffprobe binary) to be installed."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1667
+#: src/muuli_wdr.cpp:1674
 msgid "Path to ffprobe:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1672
+#: src/muuli_wdr.cpp:1679
 msgid "Full path to the ffprobe binary. Leave empty to have aMule auto-detect it on startup."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1680
+#: src/muuli_wdr.cpp:1687
 msgid "Detect"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1681
+#: src/muuli_wdr.cpp:1688
 msgid "Search the standard install locations for an ffprobe binary and fill the path field."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1705
+#: src/muuli_wdr.cpp:1712
 msgid ""
 "Completed downloads are stored here. All files in this folder are automatically shared with other peers.\n"
 "If this folder also holds files you don't want to share, point it at an aMule-only sub-folder."
@@ -4143,672 +4157,672 @@ msgstr ""
 "Elvégzett letöltések tárolási helye. Minden fájl ebben a könytárban automatikusan megosztásra kerül másokkal.\n"
 "Ha a könyvtár fájlokat tartalmaz, amelyek ne kerüljenek megosztásra, állítsa át egy megfelelő alkönyvtárra."
 
-#: src/muuli_wdr.cpp:1708
+#: src/muuli_wdr.cpp:1715
 msgid "Pick the folder where completed downloads will be stored. All files in that folder will be shared with other peers."
 msgstr "Válassza ki a könyvtárat az elvégzett letöltéseknek. A könyvtár minden fájlja másokkal megosztásra kerül."
 
-#: src/muuli_wdr.cpp:1722
+#: src/muuli_wdr.cpp:1729
 msgid "Shared folders"
 msgstr "Megosztott mappák"
 
-#: src/muuli_wdr.cpp:1728
+#: src/muuli_wdr.cpp:1735
 msgid "(Folders shared by the core. Enter a path to add one.)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1736
+#: src/muuli_wdr.cpp:1743
 msgid "Absolute path of a folder on the core's machine, e.g. /home/user/shared"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1738 src/PrefsUnifiedDlg.cpp:2794
+#: src/muuli_wdr.cpp:1745 src/PrefsUnifiedDlg.cpp:2794
 msgid "Recursive"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1739
+#: src/muuli_wdr.cpp:1746
 msgid "Share every sub-folder underneath this one, including ones created later."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1743 src/utils/aLinkCreator/src/alcframe.cpp:141
+#: src/muuli_wdr.cpp:1750 src/utils/aLinkCreator/src/alcframe.cpp:141
 msgid "Remove"
 msgstr "Eltávolít"
 
-#: src/muuli_wdr.cpp:1747
+#: src/muuli_wdr.cpp:1754
 msgid "(Right click on folder icon for recursive share)"
 msgstr "(Jobb klikk az mappa ikonra az összes alatta levő mappát is megosztja)"
 
-#: src/muuli_wdr.cpp:1754
+#: src/muuli_wdr.cpp:1761
 msgid "Share hidden files"
 msgstr "Rejtett fájlok megosztása"
 
-#: src/muuli_wdr.cpp:1760
+#: src/muuli_wdr.cpp:1767
 msgid "Automatically rescan shared folders for changes"
 msgstr "Megosztott könyvtárak automatikus újraszkennelése"
 
-#: src/muuli_wdr.cpp:1766
+#: src/muuli_wdr.cpp:1773
 msgid "Follow symbolic links in shared folders"
 msgstr "Szimbólikus hivatkozások követése megosztott könyvtárakban"
 
-#: src/muuli_wdr.cpp:1772
+#: src/muuli_wdr.cpp:1779
 msgid "Exclude files matching:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1775
+#: src/muuli_wdr.cpp:1782
 msgid "Wildcard patterns separated by '|', e.g. .DS_Store|Thumbs.db|*.tmp. Files whose name matches are not shared. Matching is case-insensitive."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1779
+#: src/muuli_wdr.cpp:1786
 msgid "Patterns are regular expressions"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1780
+#: src/muuli_wdr.cpp:1787
 msgid "When set, the whole field is one regular expression ('|' is alternation). When unset, it is a list of '|'-separated wildcards."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1790
+#: src/muuli_wdr.cpp:1797
 msgid "Show how many shared files the current pattern would exclude."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1811
+#: src/muuli_wdr.cpp:1818
 msgid "Graphs"
 msgstr "Grafikonok"
 
-#: src/muuli_wdr.cpp:1814 src/muuli_wdr.cpp:1876
+#: src/muuli_wdr.cpp:1821 src/muuli_wdr.cpp:1883
 msgid "Update delay : 5 secs"
 msgstr "Frissítés késleltetés: 5 mp"
 
-#: src/muuli_wdr.cpp:1818
+#: src/muuli_wdr.cpp:1825
 msgid "Time for average graph: 100 mins"
 msgstr "Grafikon átlagos ideje: 100 perc"
 
-#: src/muuli_wdr.cpp:1822
+#: src/muuli_wdr.cpp:1829
 msgid "Connections Graph Scale: 100 "
 msgstr "Kapcsolatok grafikon skálája: 100 "
 
-#: src/muuli_wdr.cpp:1829
+#: src/muuli_wdr.cpp:1836
 msgid "Download graph scale:"
 msgstr "Letöltési grafikon méretaránya:"
 
-#: src/muuli_wdr.cpp:1837
+#: src/muuli_wdr.cpp:1844
 msgid "Upload graph scale:"
 msgstr "Feltöltési grafikon méretaránya:"
 
-#: src/muuli_wdr.cpp:1847
+#: src/muuli_wdr.cpp:1854
 msgid "Colors: "
 msgstr "Színek: "
 
-#: src/muuli_wdr.cpp:1851
+#: src/muuli_wdr.cpp:1858
 msgid "Background"
 msgstr "Háttér"
 
-#: src/muuli_wdr.cpp:1852
+#: src/muuli_wdr.cpp:1859
 msgid "Grid"
 msgstr "Rács"
 
-#: src/muuli_wdr.cpp:1853
+#: src/muuli_wdr.cpp:1860
 msgid "Download current"
 msgstr "Aktuális letöltés"
 
-#: src/muuli_wdr.cpp:1854
+#: src/muuli_wdr.cpp:1861
 msgid "Download running average"
 msgstr "Letöltési futás átlaga"
 
-#: src/muuli_wdr.cpp:1855
+#: src/muuli_wdr.cpp:1862
 msgid "Download session average"
 msgstr "Letöltési folyamatok átlaga"
 
-#: src/muuli_wdr.cpp:1856
+#: src/muuli_wdr.cpp:1863
 msgid "Upload current"
 msgstr "Aktuális feltöltés"
 
-#: src/muuli_wdr.cpp:1857
+#: src/muuli_wdr.cpp:1864
 msgid "Upload running average"
 msgstr "Feltöltési futás átlaga"
 
-#: src/muuli_wdr.cpp:1858
+#: src/muuli_wdr.cpp:1865
 msgid "Upload session average"
 msgstr "Feltöltési folyamatok átlaga"
 
-#: src/muuli_wdr.cpp:1859
+#: src/muuli_wdr.cpp:1866
 msgid "Active connections"
 msgstr "Aktív kapcsolatok"
 
-#: src/muuli_wdr.cpp:1862
+#: src/muuli_wdr.cpp:1869
 msgid "Systray Icon Speed Bar"
 msgstr "Sebességmérő a rendszertálcán"
 
-#: src/muuli_wdr.cpp:1863
+#: src/muuli_wdr.cpp:1870
 msgid "Kad-nodes current"
 msgstr "Kad-csomópontok aktuális"
 
-#: src/muuli_wdr.cpp:1864
+#: src/muuli_wdr.cpp:1871
 msgid "Kad-nodes running"
 msgstr "Kad-csomópontok futó"
 
-#: src/muuli_wdr.cpp:1865
+#: src/muuli_wdr.cpp:1872
 msgid "Kad-nodes session"
 msgstr "Kad-csomópontok folyamat"
 
-#: src/muuli_wdr.cpp:1869 src/muuli_wdr.cpp:2296
+#: src/muuli_wdr.cpp:1876 src/muuli_wdr.cpp:2303
 msgid "Select"
 msgstr "Kiválaszt"
 
-#: src/muuli_wdr.cpp:1873
+#: src/muuli_wdr.cpp:1880
 msgid "Tree"
 msgstr "Fa"
 
-#: src/muuli_wdr.cpp:1883
+#: src/muuli_wdr.cpp:1890
 msgid "Number of Client Versions shown (0=unlimited)"
 msgstr "Megjelenített ügyfél verziók száma (0=mind)"
 
-#: src/muuli_wdr.cpp:1908
+#: src/muuli_wdr.cpp:1915
 msgid "!!! WARNING !!!"
 msgstr "!!! FIGYELEM !!!"
 
-#: src/muuli_wdr.cpp:1923
+#: src/muuli_wdr.cpp:1930
 msgid "Max new connections / 5 secs"
 msgstr "Max új kapcsolat / 5 mp"
 
-#: src/muuli_wdr.cpp:1925
+#: src/muuli_wdr.cpp:1932
 msgid "Concurrent Kad source lookups"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1927
+#: src/muuli_wdr.cpp:1934
 #, fuzzy
 msgid "Kad source re-search interval (minutes)"
 msgstr "FTP frissítési gyakorisága percekben"
 
-#: src/muuli_wdr.cpp:1929
+#: src/muuli_wdr.cpp:1936
 #, fuzzy
 msgid "Source re-ask interval (minutes)"
 msgstr "FTP frissítési gyakorisága percekben"
 
-#: src/muuli_wdr.cpp:1933
+#: src/muuli_wdr.cpp:1940
 msgid "File Buffer Size: 240000 bytes"
 msgstr "Fájl buffer méret: 240000 bájt"
 
-#: src/muuli_wdr.cpp:1937
+#: src/muuli_wdr.cpp:1944
 msgid "Use MMAP: memory-mapped file access (lower memory use)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1938
+#: src/muuli_wdr.cpp:1945
 msgid "Maps part files into memory instead of buffering them on the heap, lowering the process memory footprint. May reduce download speed on some disks; best for memory-constrained or upload-heavy hosts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1940
+#: src/muuli_wdr.cpp:1947
 msgid "Upload Queue Size: 5000 clients"
 msgstr "Feltöltők várólistájának nagysága: 5000 kliens"
 
-#: src/muuli_wdr.cpp:1944
+#: src/muuli_wdr.cpp:1951
 msgid "Server connection refresh interval: Disable"
 msgstr "Kiszolgáló kapcsolat frissítési gyakorisága: Tiltva"
 
-#: src/muuli_wdr.cpp:1948
+#: src/muuli_wdr.cpp:1955
 msgid "Disable computer's timed standby mode"
 msgstr "Számítógép időzített készenléti állapotának hatástalanítása"
 
-#: src/muuli_wdr.cpp:1967
+#: src/muuli_wdr.cpp:1974
 msgid "Skin to use: "
 msgstr "Használt felület: "
 
-#: src/muuli_wdr.cpp:1976
+#: src/muuli_wdr.cpp:1983
 msgid "Show \"Fast eD2k Links Handler\" in every window."
 msgstr "A \"Gyors eD2k hivatkozás kezelő\" mutatása minden ablakban."
 
-#: src/muuli_wdr.cpp:1979
+#: src/muuli_wdr.cpp:1986
 msgid "Show extended info on categories tabs"
 msgstr "Kibővített infók megjelenítése a kategória füleken"
 
-#: src/muuli_wdr.cpp:1982
+#: src/muuli_wdr.cpp:1989
 msgid "Show application version on title"
 msgstr "Az alkalmazás verziójának megjelenítése a címsorban"
 
-#: src/muuli_wdr.cpp:1984
+#: src/muuli_wdr.cpp:1991
 msgid "Show transfer rates on title"
 msgstr "Átviteli ráták megjelenítése a címsorban"
 
-#: src/muuli_wdr.cpp:1986
+#: src/muuli_wdr.cpp:1993
 msgid "Before application name"
 msgstr "Az alkalmazás neve előtt"
 
-#: src/muuli_wdr.cpp:1988
+#: src/muuli_wdr.cpp:1995
 msgid "After application name"
 msgstr "Az alkalmazás neve után"
 
-#: src/muuli_wdr.cpp:1991
+#: src/muuli_wdr.cpp:1998
 msgid "Show overhead bandwidth"
 msgstr "Többletterhelés sávszélességének mutatása"
 
-#: src/muuli_wdr.cpp:1995
+#: src/muuli_wdr.cpp:2002
 msgid "Vertical toolbar orientation"
 msgstr "Függőleges eszköztár elrendezés"
 
-#: src/muuli_wdr.cpp:1997
+#: src/muuli_wdr.cpp:2004
 msgid "Live column sorting (auto-reorder rows as their values change)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2004
+#: src/muuli_wdr.cpp:2011
 msgid "Download Queue Files"
 msgstr "Letöltendő fájlok várakozási sora"
 
-#: src/muuli_wdr.cpp:2007
+#: src/muuli_wdr.cpp:2014
 msgid "Show progress percentage"
 msgstr "Százalékos arány mutatása"
 
-#: src/muuli_wdr.cpp:2013
+#: src/muuli_wdr.cpp:2020
 msgid "Show progress bar"
 msgstr "Folyamatjelző csík mutatása"
 
-#: src/muuli_wdr.cpp:2016
+#: src/muuli_wdr.cpp:2023
 msgid "Flat"
 msgstr "Lapos"
 
-#: src/muuli_wdr.cpp:2020
+#: src/muuli_wdr.cpp:2027
 msgid "Round"
 msgstr "Gömbölyű"
 
-#: src/muuli_wdr.cpp:2038
+#: src/muuli_wdr.cpp:2045
 msgid "External Connection Parameters"
 msgstr "Külső kapcsolatok jellemzői"
 
-#: src/muuli_wdr.cpp:2041
+#: src/muuli_wdr.cpp:2048
 msgid "Accept external connections"
 msgstr "Külső kapcsolat elfogadása"
 
-#: src/muuli_wdr.cpp:2048 src/muuli_wdr.cpp:2107
+#: src/muuli_wdr.cpp:2055 src/muuli_wdr.cpp:2114
 msgid "IP of the listening interface:"
 msgstr "Hallgató interfész IP-je:"
 
-#: src/muuli_wdr.cpp:2051
+#: src/muuli_wdr.cpp:2058
 msgid "Enter here a valid ip in the a.b.c.d format for the listening EC interface. An empty field or 0.0.0.0 will mean any interface."
 msgstr "Adjon meg itt egy érvényes IP címet a.b.c.d formában az EC hallgató interfésznek. Üres mező vagy 0.0.0.0 jelentése: bármelyik interfész."
 
-#: src/muuli_wdr.cpp:2072 src/muuli_wdr.cpp:2156
+#: src/muuli_wdr.cpp:2079 src/muuli_wdr.cpp:2163
 msgid "TCP port:"
 msgstr "TCP port:"
 
-#: src/muuli_wdr.cpp:2078
+#: src/muuli_wdr.cpp:2085
 msgid "Enable UPnP port forwarding on the EC port"
 msgstr "UPnP port továbbítás engedélyezése az EC porton"
 
-#: src/muuli_wdr.cpp:2082 src/muuli_wdr.cpp:3041
+#: src/muuli_wdr.cpp:2089 src/muuli_wdr.cpp:3048
 #: src/utils/wxCas/src/wxcasprefs.cpp:167
 msgid "Password"
 msgstr "Jelszó"
 
-#: src/muuli_wdr.cpp:2088
+#: src/muuli_wdr.cpp:2095
 #, fuzzy
 msgid "aMule API server parameters"
 msgstr "Web kiszolgáló paraméterek"
 
-#: src/muuli_wdr.cpp:2091
+#: src/muuli_wdr.cpp:2098
 msgid "Run amuleapi (REST API) on startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2096
+#: src/muuli_wdr.cpp:2103
 #, fuzzy
 msgid "HTTP port:"
 msgstr "TCP port:"
 
-#: src/muuli_wdr.cpp:2110
+#: src/muuli_wdr.cpp:2117
 msgid "The interface amuleapi's HTTP server listens on. 127.0.0.1 (default) accepts only local connections; use 0.0.0.0 or a specific IP to expose it to other hosts (set an admin password below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2113
+#: src/muuli_wdr.cpp:2120
 #, fuzzy
 msgid "Admin password"
 msgstr "Jelszó ellenőrzése\n"
 
-#: src/muuli_wdr.cpp:2118 src/muuli_wdr.cpp:2149
+#: src/muuli_wdr.cpp:2125 src/muuli_wdr.cpp:2156
 msgid "Low rights password"
 msgstr "Vendég jelszó"
 
-#: src/muuli_wdr.cpp:2126
+#: src/muuli_wdr.cpp:2133
 msgid "Web server parameters"
 msgstr "Web kiszolgáló paraméterek"
 
-#: src/muuli_wdr.cpp:2129
+#: src/muuli_wdr.cpp:2136
 #, fuzzy
 msgid "Run webserver on startup (deprecated)"
 msgstr "Webkiszolgáló indítása induláskor"
 
-#: src/muuli_wdr.cpp:2135
+#: src/muuli_wdr.cpp:2142
 msgid "Web template"
 msgstr "Web minta"
 
-#: src/muuli_wdr.cpp:2140
+#: src/muuli_wdr.cpp:2147
 msgid "Full rights password"
 msgstr "Admin jelszó"
 
-#: src/muuli_wdr.cpp:2144
+#: src/muuli_wdr.cpp:2151
 msgid "Enable Low rights User"
 msgstr "Vendég felhasználó engedélyezése"
 
-#: src/muuli_wdr.cpp:2163
+#: src/muuli_wdr.cpp:2170
 msgid "Enable UPnP port forwarding of the web server port"
 msgstr "A web kiszolgáló port UPnP továbbításának engedélyezése"
 
-#: src/muuli_wdr.cpp:2168
+#: src/muuli_wdr.cpp:2175
 msgid "Web server UPnP TCP port (Optional)"
 msgstr "Web szerver UPnP TCP port (nem kötelező)"
 
-#: src/muuli_wdr.cpp:2176
+#: src/muuli_wdr.cpp:2183
 msgid "Page Refresh Time (in secs)"
 msgstr "Oldal frissítésének időzítése (mp múlva)"
 
-#: src/muuli_wdr.cpp:2183
+#: src/muuli_wdr.cpp:2190
 msgid "Enable Gzip compression"
 msgstr "Gzip tömörítés engedélyezése"
 
-#: src/muuli_wdr.cpp:2217
+#: src/muuli_wdr.cpp:2224
 #, fuzzy
 msgid "Reset page to defaults"
 msgstr "Alapértelmezett"
 
-#: src/muuli_wdr.cpp:2218
+#: src/muuli_wdr.cpp:2225
 msgid "Reset the settings on the current page to their default values."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2220 src/muuli_wdr.cpp:2306 src/ServerWnd.cpp:274
+#: src/muuli_wdr.cpp:2227 src/muuli_wdr.cpp:2313 src/ServerWnd.cpp:274
 #: src/ServerWnd.cpp:282
 msgid "OK"
 msgstr "OK"
 
-#: src/muuli_wdr.cpp:2222
+#: src/muuli_wdr.cpp:2229
 msgid "Click here to apply any changes made to the preferences."
 msgstr "Kattints ide a beállítási módosítások alkalmazásához."
 
-#: src/muuli_wdr.cpp:2225
+#: src/muuli_wdr.cpp:2232
 msgid "Reset any changes made to the preferences."
 msgstr "Beállítási módosítások figyelmen kívül hagyása."
 
-#: src/muuli_wdr.cpp:2254
+#: src/muuli_wdr.cpp:2261
 msgid "Comment :"
 msgstr "Megjegyzés:"
 
-#: src/muuli_wdr.cpp:2261
+#: src/muuli_wdr.cpp:2268
 msgid "Incoming Dir :"
 msgstr "Bejövő Mappa :"
 
-#: src/muuli_wdr.cpp:2270
+#: src/muuli_wdr.cpp:2277
 msgid "Change priority for new assigned files :"
 msgstr "Újonnan hozzárendelt fájlok prioritásának változtatása :"
 
-#: src/muuli_wdr.cpp:2274
+#: src/muuli_wdr.cpp:2281
 msgid "Don't change"
 msgstr "Ne változzon"
 
-#: src/muuli_wdr.cpp:2286
+#: src/muuli_wdr.cpp:2293
 msgid "Select color for this Category (currently selected) :"
 msgstr "Válassz színt ehhez a kategóriához (jelenleg kiválasztva) :"
 
-#: src/muuli_wdr.cpp:2353 src/muuli_wdr.cpp:2372 src/muuli_wdr.cpp:2394
+#: src/muuli_wdr.cpp:2360 src/muuli_wdr.cpp:2379 src/muuli_wdr.cpp:2401
 msgid "Click this button to reset the log."
 msgstr "Kattints erre a gombra a logfájl visszaállításához."
 
-#: src/muuli_wdr.cpp:2413
+#: src/muuli_wdr.cpp:2420
 msgid "Click on this button to update the servers list from URL ..."
 msgstr "Kattints erre a gombra a kiszolgálólista frissítéséhez  ..."
 
-#: src/muuli_wdr.cpp:2417
+#: src/muuli_wdr.cpp:2424
 msgid "Server list"
 msgstr "Kiszolgálók listája"
 
-#: src/muuli_wdr.cpp:2421
+#: src/muuli_wdr.cpp:2428
 msgid "Enter the url to a server.met file here and press the button to the left to update the list of known servers."
 msgstr "Adj meg egy címet a server.met fájlhoz és nyomd meg a baloldali gombot az ismert kiszolgálók listájának frissítéséhez."
 
-#: src/muuli_wdr.cpp:2426
+#: src/muuli_wdr.cpp:2433
 msgid "Add server manually: Name"
 msgstr "Kiszolgáló hozzáadása kézzel: Név"
 
-#: src/muuli_wdr.cpp:2429
+#: src/muuli_wdr.cpp:2436
 msgid "Enter the name of the new server here"
 msgstr "Add meg az új kiszolgáló nevét"
 
-#: src/muuli_wdr.cpp:2431 src/ServerWnd.cpp:206
+#: src/muuli_wdr.cpp:2438 src/ServerWnd.cpp:206
 msgid "IP:Port"
 msgstr "IP:Port"
 
-#: src/muuli_wdr.cpp:2434
+#: src/muuli_wdr.cpp:2441
 msgid "Enter the IP of the server here, using the x.x.x.x format."
 msgstr "Itt add meg a kiszolgálók IP-jét, használd az x.x.x.x formát."
 
-#: src/muuli_wdr.cpp:2440
+#: src/muuli_wdr.cpp:2447
 msgid "Enter the port of the server here."
 msgstr "Add meg a kiszolgáló portját."
 
-#: src/muuli_wdr.cpp:2443
+#: src/muuli_wdr.cpp:2450
 msgid "Add manually a server (fill fields to the left before) ..."
 msgstr "Kiszolgáló felvétel kézzel (töltsd ki a baloldali mezőket először) ..."
 
-#: src/muuli_wdr.cpp:2472
+#: src/muuli_wdr.cpp:2479
 msgid "aMule Log"
 msgstr "aMule Napló"
 
-#: src/muuli_wdr.cpp:2480
+#: src/muuli_wdr.cpp:2487
 msgid "Server Info"
 msgstr "Kiszolgáló Infó"
 
-#: src/muuli_wdr.cpp:2484
+#: src/muuli_wdr.cpp:2491
 msgid "ED2K Info"
 msgstr "ED2K infó"
 
-#: src/muuli_wdr.cpp:2488
+#: src/muuli_wdr.cpp:2495
 msgid "Kad Info"
 msgstr "Kad infó"
 
-#: src/muuli_wdr.cpp:2516
+#: src/muuli_wdr.cpp:2523
 msgid "Click on this button to update the nodes list from URL ..."
 msgstr "Kattints erre a gombra a csomópont-lista frissítéséhez URL-ből ..."
 
-#: src/muuli_wdr.cpp:2520
+#: src/muuli_wdr.cpp:2527
 msgid "Nodes (0)"
 msgstr "Csomópontok (0)"
 
-#: src/muuli_wdr.cpp:2524
+#: src/muuli_wdr.cpp:2531
 msgid "Enter the url to a nodes.dat file here and press the button to the left to update the list of known nodes."
 msgstr "Adj meg egy címet a nodes.dat fájlhoz és nyomd meg a baloldali gombot az ismert csomópontok listájának frissítéséhez."
 
-#: src/muuli_wdr.cpp:2527
+#: src/muuli_wdr.cpp:2534
 msgid "Nodes stats"
 msgstr "Csomópont statisztikák"
 
-#: src/muuli_wdr.cpp:2569
+#: src/muuli_wdr.cpp:2576
 msgid "Bootstrap"
 msgstr "Rendszerbetöltés"
 
-#: src/muuli_wdr.cpp:2572
+#: src/muuli_wdr.cpp:2579
 msgid "New node"
 msgstr "Új csomópont (node)"
 
-#: src/muuli_wdr.cpp:2577
+#: src/muuli_wdr.cpp:2584
 msgid "IP:"
 msgstr "IP:"
 
-#: src/muuli_wdr.cpp:2597
+#: src/muuli_wdr.cpp:2604
 msgid "Port:"
 msgstr "Port:"
 
-#: src/muuli_wdr.cpp:2610
+#: src/muuli_wdr.cpp:2617
 msgid "Bootstrap from known clients"
 msgstr "Indítás ismert kliensektől"
 
-#: src/muuli_wdr.cpp:2612
+#: src/muuli_wdr.cpp:2619
 msgid "Disconnect Kad"
 msgstr "Leválasztás a Kad-ról"
 
-#: src/muuli_wdr.cpp:2646
+#: src/muuli_wdr.cpp:2653
 msgid "Use Secure User Identification"
 msgstr "Biztonságos azonosítás használata"
 
-#: src/muuli_wdr.cpp:2648
+#: src/muuli_wdr.cpp:2655
 msgid "It is recommended to enable this option. You will not receive credits if SUI is not enabled."
 msgstr "Ajánlott ezt az opciót engedélyezni. Nem fogsz kreditet kapni, ha nincs engedélyezve."
 
-#: src/muuli_wdr.cpp:2650
+#: src/muuli_wdr.cpp:2657
 msgid "Protocol Obfuscation"
 msgstr "Protokoll zavarás"
 
-#: src/muuli_wdr.cpp:2653
+#: src/muuli_wdr.cpp:2660
 msgid "Support Protocol Obfuscation"
 msgstr "Protokoll zavarás támogatása"
 
-#: src/muuli_wdr.cpp:2655
+#: src/muuli_wdr.cpp:2662
 msgid "This option enabled Protocol Obfuscation, and makes aMule accept obfuscated connections from other clients."
 msgstr "Ez az opció engedélyezi a protokoll zavarást, és az aMule elfogad zavart kapcsolatokat más ügyfelektől."
 
-#: src/muuli_wdr.cpp:2657
+#: src/muuli_wdr.cpp:2664
 msgid "Use obfuscation for outgoing connections"
 msgstr "Kimenő kapcsolatok zavarása"
 
-#: src/muuli_wdr.cpp:2659
+#: src/muuli_wdr.cpp:2666
 msgid "This option makes aMule use Protocol Obfuscation when connecting other clients/servers."
 msgstr "Ez az opció engedélyezi a protokoll zavarást, amikor más ügyfelekhez/kiszolgálókhoz kapcsolódik az aMule."
 
-#: src/muuli_wdr.cpp:2661
+#: src/muuli_wdr.cpp:2668
 msgid "Accept only obfuscated connections"
 msgstr "Csak zavart kapcsolatok elfogadása"
 
-#: src/muuli_wdr.cpp:2662
+#: src/muuli_wdr.cpp:2669
 msgid "This option makes aMule only accept obfuscated connections. You will have less sources, but all your traffic will be obfuscated"
 msgstr "Ezen opció hatására az aMule csak zavart kapcsolatokat fog elfogadni. Kevesebb forrásod lesz, de a teljes forgalom zavart lesz"
 
-#: src/muuli_wdr.cpp:2667
+#: src/muuli_wdr.cpp:2674
 msgid "Everybody"
 msgstr "Mindenki"
 
-#: src/muuli_wdr.cpp:2669
+#: src/muuli_wdr.cpp:2676
 msgid "No one"
 msgstr "Senki"
 
-#: src/muuli_wdr.cpp:2671
+#: src/muuli_wdr.cpp:2678
 msgid "Who can see my shared files:"
 msgstr "Ki láthatja a megosztott fájljaimat:"
 
-#: src/muuli_wdr.cpp:2672
+#: src/muuli_wdr.cpp:2679
 msgid "Select who can request to view a list of your shared files."
 msgstr "Válaszd ki, hogy kik kérdezhetik le megosztott fájlaid listáját."
 
-#: src/muuli_wdr.cpp:2674
+#: src/muuli_wdr.cpp:2681
 msgid "IP-Filtering"
 msgstr "IP-szűrés"
 
-#: src/muuli_wdr.cpp:2681
+#: src/muuli_wdr.cpp:2688
 msgid "Filter clients"
 msgstr "Kliensek szűrése"
 
-#: src/muuli_wdr.cpp:2683
+#: src/muuli_wdr.cpp:2690
 msgid "Enable filtering of the client IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "A ~/.aMule/ipfilter.dat állományban IP-jű kliensek szűrésének engedélyezése."
 
-#: src/muuli_wdr.cpp:2685
+#: src/muuli_wdr.cpp:2692
 msgid "Filter servers"
 msgstr "Kiszolgálók szűrése"
 
-#: src/muuli_wdr.cpp:2687
+#: src/muuli_wdr.cpp:2694
 msgid "Enable filtering of the server IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "A ~/.aMule/ipfilter.dat állományban IP-jű kiszolgálók szűrésének engedélyezése."
 
-#: src/muuli_wdr.cpp:2691
+#: src/muuli_wdr.cpp:2698
 msgid "Reload List"
 msgstr "Lista újratöltése"
 
-#: src/muuli_wdr.cpp:2692
+#: src/muuli_wdr.cpp:2699
 msgid "Reload the list of IPs to filter from the file ~/.aMule/ipfilter.dat"
 msgstr "IP-k listájának újratöltése a ~/.aMule/ipfilter.dat fájlból"
 
-#: src/muuli_wdr.cpp:2698
+#: src/muuli_wdr.cpp:2705
 msgid "URL:"
 msgstr "URL:"
 
-#: src/muuli_wdr.cpp:2702 src/muuli_wdr.cpp:2895
+#: src/muuli_wdr.cpp:2709 src/muuli_wdr.cpp:2902
 msgid "Update now"
 msgstr "Frissítés most"
 
-#: src/muuli_wdr.cpp:2705
+#: src/muuli_wdr.cpp:2712
 msgid "Auto-update ipfilter at startup"
 msgstr "IP szűrő automatikus letöltése indításkor"
 
-#: src/muuli_wdr.cpp:2709
+#: src/muuli_wdr.cpp:2716
 msgid "Filtering Level:"
 msgstr "Szűrési szint:"
 
-#: src/muuli_wdr.cpp:2715
+#: src/muuli_wdr.cpp:2722
 msgid "Always filter LAN IPs"
 msgstr "Mindig szűrje ki a LAN IP-ket"
 
-#: src/muuli_wdr.cpp:2718
+#: src/muuli_wdr.cpp:2725
 msgid "Paranoid handling of non-matching IPs"
 msgstr "A nem-megegyező IP-k paranoid kezelése"
 
-#: src/muuli_wdr.cpp:2720
+#: src/muuli_wdr.cpp:2727
 msgid "Rejects a packet when its source IP differs from the IP the client claims (an anti-spoofing check). Disable only if it causes connection problems."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2722
+#: src/muuli_wdr.cpp:2729
 msgid "Use system-wide ipfilter.dat if available"
 msgstr "Rendszer-szintű ipfilter.dat használatának engedélyezése"
 
-#: src/muuli_wdr.cpp:2723
+#: src/muuli_wdr.cpp:2730
 msgid "If there's no local ipfilter.dat found, allow usage of a system-wide ipfilter file."
 msgstr "Ha nem talál helyi ipfilter.dat fájlt, akkor engedje a rendszerszintű ipfilter fájl használatát."
 
-#: src/muuli_wdr.cpp:2740
+#: src/muuli_wdr.cpp:2747
 msgid "Enable Online-Signature"
 msgstr "Online-aláírás engedélyezése"
 
-#: src/muuli_wdr.cpp:2742
+#: src/muuli_wdr.cpp:2749
 msgid "Enables the writing of the OS file, which can be used by external apps to create signatures and the like."
 msgstr "Az online-aláírás fájl írásának engedélyezése, amit külső alkalmazások használhatnak fel aláírások létrehozásához és így tovább."
 
-#: src/muuli_wdr.cpp:2746
+#: src/muuli_wdr.cpp:2753
 msgid "Update Frequency (Secs):"
 msgstr "Frissítési gyakoriság (mp):"
 
-#: src/muuli_wdr.cpp:2749
+#: src/muuli_wdr.cpp:2756
 msgid "Change the frequency (in seconds) of Online Signature updates."
 msgstr "Online aláírás frissítési gyakoriságának módosítása (mp-ben)."
 
-#: src/muuli_wdr.cpp:2757
+#: src/muuli_wdr.cpp:2764
 msgid "Save online signature file in: "
 msgstr "Online aláírási fájl kimentési helye: "
 
-#: src/muuli_wdr.cpp:2763
+#: src/muuli_wdr.cpp:2770
 msgid "Click here to select the directory containing the the Online Signature files."
 msgstr "Kattints ide az online aláírást tartalmazó könyvtár kiválasztásához."
 
-#: src/muuli_wdr.cpp:2796
+#: src/muuli_wdr.cpp:2803
 msgid "Show country flags for clients"
 msgstr "Kliensek országzászlajainak megjelenítése"
 
-#: src/muuli_wdr.cpp:2797
+#: src/muuli_wdr.cpp:2804
 msgid "Render the country flag column in the transfers, queue and search views. Requires a valid MMDB GeoIP database (see below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2802
+#: src/muuli_wdr.cpp:2809
 msgid "Database"
 msgstr "Adatbázis"
 
-#: src/muuli_wdr.cpp:2818
+#: src/muuli_wdr.cpp:2825
 msgid "Source:"
 msgstr "Forrás:"
 
-#: src/muuli_wdr.cpp:2821
+#: src/muuli_wdr.cpp:2828
 msgid "DB-IP (free, no account)"
 msgstr "DB-IP (ingyenes, fiók nélkül)"
 
-#: src/muuli_wdr.cpp:2822
+#: src/muuli_wdr.cpp:2829
 msgid "MaxMind GeoLite2 (free, account required)"
 msgstr "MaxMind GeoLite2 (ingyenes, fiók szükséges)"
 
-#: src/muuli_wdr.cpp:2823
+#: src/muuli_wdr.cpp:2830
 msgid "Custom URL"
 msgstr "Egyéni URL"
 
-#: src/muuli_wdr.cpp:2826
+#: src/muuli_wdr.cpp:2833
 msgid "Choose which provider supplies the GeoIP MMDB database. DB-IP is the default - no account required. MaxMind requires a free account + license key. Use Custom URL to point at any other MMDB host (e.g. a local mirror)."
 msgstr "Válassza ki a GeoIP MMDB adatbázis szolgáltatóját. DB-IP az alapértelmezett - nincs szükség fiókra. MaxMind egy ingyenes fiókot és licenckulcsot igényel. Használjon egyéni URL-t bármely más MMDB host megadásához (pl. egy helyi tükörhöz)."
 
-#: src/muuli_wdr.cpp:2843
+#: src/muuli_wdr.cpp:2850
 msgid ""
 "No configuration required.\n"
 "\n"
@@ -4820,11 +4834,11 @@ msgstr ""
 "IP-to-Country adat DB-IP.com által - https://db-ip.com\n"
 "Licenc: Creative Commons BY 4.0 - https://creativecommons.org/licenses/by/4.0/"
 
-#: src/muuli_wdr.cpp:2856
+#: src/muuli_wdr.cpp:2863
 msgid "License key:"
 msgstr "Licenckulcs:"
 
-#: src/muuli_wdr.cpp:2862
+#: src/muuli_wdr.cpp:2869
 msgid ""
 "Sign up for a free MaxMind account, then generate a License Key:\n"
 "https://www.maxmind.com/en/geolite2/signup\n"
@@ -4840,11 +4854,11 @@ msgstr ""
 "Licenc: MaxMind GeoLite2 EULA - https://www.maxmind.com/en/geolite2/eula\n"
 "Hozzárendelést és fiókregisztrációt igényel; legalább 30 naponta frissítse."
 
-#: src/muuli_wdr.cpp:2877
+#: src/muuli_wdr.cpp:2884
 msgid "Download URL:"
 msgstr "Letöltési URL:"
 
-#: src/muuli_wdr.cpp:2883
+#: src/muuli_wdr.cpp:2890
 msgid ""
 "Must point to an .mmdb file or a .gz / .tar.gz containing one.\n"
 "URL may include credentials (https://user:pass@host/...).\n"
@@ -4854,211 +4868,211 @@ msgstr ""
 "Az URL tartalmazhat hitelesítő adatokat (https://user:pass@host/...).\n"
 "A licenc- és megnevezési feltételeket a felmenő URL határozza meg - ön a felelőss."
 
-#: src/muuli_wdr.cpp:2896
+#: src/muuli_wdr.cpp:2903
 msgid "Download the GeoIP database from the selected source."
 msgstr "GeoIP adatbázis letöltése a kiválasztott forrásból."
 
-#: src/muuli_wdr.cpp:2898
+#: src/muuli_wdr.cpp:2905
 msgid "Auto-update on startup"
 msgstr "Automatikus frissítés indításkor"
 
-#: src/muuli_wdr.cpp:2899
+#: src/muuli_wdr.cpp:2906
 msgid "Re-download the GeoIP database from the selected source every time aMule starts."
 msgstr "GeoIP adatbázis újonnani letöltése a kiválasztott forrásból minden aMule indításkor."
 
-#: src/muuli_wdr.cpp:2922
+#: src/muuli_wdr.cpp:2929
 msgid "Filter incoming messages (except current chat):"
 msgstr "Bejövő üzenetek kiszűrése (kivéve az aktuális csevegés):"
 
-#: src/muuli_wdr.cpp:2924
+#: src/muuli_wdr.cpp:2931
 msgid "Filter all messages"
 msgstr "Összes üzenet szűrése"
 
-#: src/muuli_wdr.cpp:2926
+#: src/muuli_wdr.cpp:2933
 msgid "Filter messages from people not on your friend list"
 msgstr "Barát listában nem szereplőktől érkező üzenetek kiszűrése"
 
-#: src/muuli_wdr.cpp:2928
+#: src/muuli_wdr.cpp:2935
 msgid "Filter messages from unknown clients"
 msgstr "Ismeretlen kliensektől érkező üzenetek kiszűrése"
 
-#: src/muuli_wdr.cpp:2930
+#: src/muuli_wdr.cpp:2937
 msgid "Filter messages containing (use ',' as separator):"
 msgstr "A következő(ke)t tartalmazó üzenetek kiszűrése (elválasztónak ','-t használj):"
 
-#: src/muuli_wdr.cpp:2933 src/muuli_wdr.cpp:2944
+#: src/muuli_wdr.cpp:2940 src/muuli_wdr.cpp:2951
 msgid "add here the words amule should filter and block messages including it"
 msgstr "Azon szavak felvétele, amelyeket az amule-nak ki kellene szűrni és blokkolni az ezeket tartalmazó üzeneteket"
 
-#: src/muuli_wdr.cpp:2935
+#: src/muuli_wdr.cpp:2942
 msgid "Show received messages in the log"
 msgstr "A kapott üzenetek megjelenítése a naplóban"
 
-#: src/muuli_wdr.cpp:2938
+#: src/muuli_wdr.cpp:2945
 msgid "Comments"
 msgstr "Megjegyzések"
 
-#: src/muuli_wdr.cpp:2941
+#: src/muuli_wdr.cpp:2948
 msgid "Filter comments containing (use ',' as separator):"
 msgstr "Megjegyzések kiszűrése, melyek tartalmazzák (',' az elválasztó):"
 
-#: src/muuli_wdr.cpp:2966
+#: src/muuli_wdr.cpp:2973
 msgid "Enable Proxy"
 msgstr "Proxy engedélyezése"
 
-#: src/muuli_wdr.cpp:2967
+#: src/muuli_wdr.cpp:2974
 msgid "Enable/disable proxy support"
 msgstr "Proxy támogatás engedélyezése/tiltása"
 
-#: src/muuli_wdr.cpp:2970
+#: src/muuli_wdr.cpp:2977
 msgid "Proxy type:"
 msgstr "Proxy típusa:"
 
-#: src/muuli_wdr.cpp:2981
+#: src/muuli_wdr.cpp:2988
 msgid "Proxy host:"
 msgstr "Proxy host:"
 
-#: src/muuli_wdr.cpp:2984
+#: src/muuli_wdr.cpp:2991
 msgid "The proxy host name"
 msgstr "A proxy host neve"
 
-#: src/muuli_wdr.cpp:2986
+#: src/muuli_wdr.cpp:2993
 msgid "Proxy port:"
 msgstr "Proxy port:"
 
-#: src/muuli_wdr.cpp:2989
+#: src/muuli_wdr.cpp:2996
 msgid "The proxy port"
 msgstr "A proxy port"
 
-#: src/muuli_wdr.cpp:2991
+#: src/muuli_wdr.cpp:2998
 msgid "Enable authentication"
 msgstr "Hitelesítés engedélyezése"
 
-#: src/muuli_wdr.cpp:2992
+#: src/muuli_wdr.cpp:2999
 msgid "Enable/disable username/password authentication"
 msgstr "Felhasználói név/jelszó hitelesítés engedélyezése/tiltása"
 
-#: src/muuli_wdr.cpp:2995
+#: src/muuli_wdr.cpp:3002
 msgid "Username: "
 msgstr "Felhasználói név: "
 
-#: src/muuli_wdr.cpp:2998
+#: src/muuli_wdr.cpp:3005
 msgid "The username to use to connect to the proxy"
 msgstr "Felhasználói név a proxy kapcsolathoz"
 
-#: src/muuli_wdr.cpp:3000
+#: src/muuli_wdr.cpp:3007
 msgid "Password:"
 msgstr "Jelszó:"
 
-#: src/muuli_wdr.cpp:3003
+#: src/muuli_wdr.cpp:3010
 msgid "The password to use to connect to the proxy"
 msgstr "Jelszó a proxy kapcsolathoz"
 
-#: src/muuli_wdr.cpp:3022
+#: src/muuli_wdr.cpp:3029
 msgid "Connect to:"
 msgstr "Kapcsolódás ehhez:"
 
-#: src/muuli_wdr.cpp:3031
+#: src/muuli_wdr.cpp:3038
 msgid "Login to remote amule"
 msgstr "Bejeletkezés a távoli amule-ra"
 
-#: src/muuli_wdr.cpp:3036
+#: src/muuli_wdr.cpp:3043
 msgid "User name"
 msgstr "Felhasználói név"
 
-#: src/muuli_wdr.cpp:3047
+#: src/muuli_wdr.cpp:3054
 msgid "Remember those settings"
 msgstr "Emlékezzen ezekre a beállításokra"
 
-#: src/muuli_wdr.cpp:3050
+#: src/muuli_wdr.cpp:3057
 msgid "Force ZLIB compression"
 msgstr "ZLIB tömörítés erőltetése"
 
-#: src/muuli_wdr.cpp:3074
+#: src/muuli_wdr.cpp:3081
 msgid "Enable Verbose Debug-Logging."
 msgstr "Bőbeszédű hiba-naplózás engedélyezése."
 
-#: src/muuli_wdr.cpp:3076
+#: src/muuli_wdr.cpp:3083
 msgid "Only to Logfile"
 msgstr "Csak napló fájlba"
 
-#: src/muuli_wdr.cpp:3078
+#: src/muuli_wdr.cpp:3085
 msgid "Message Categories:"
 msgstr "Üzenet kategóriák:"
 
-#: src/muuli_wdr.cpp:3102 src/PartFileConvertDlg.cpp:160
+#: src/muuli_wdr.cpp:3109 src/PartFileConvertDlg.cpp:160
 msgid "Waiting..."
 msgstr "Várakozás..."
 
-#: src/muuli_wdr.cpp:3122
+#: src/muuli_wdr.cpp:3129
 msgid "Add imports"
 msgstr "Importálandók hozzáadása"
 
-#: src/muuli_wdr.cpp:3125
+#: src/muuli_wdr.cpp:3132
 msgid "Retry selected"
 msgstr "Kijelöltek újrapróbálása"
 
-#: src/muuli_wdr.cpp:3127
+#: src/muuli_wdr.cpp:3134
 msgid "Remove selected"
 msgstr "Kijelöltek eltávolítása"
 
-#: src/muuli_wdr.cpp:3190
+#: src/muuli_wdr.cpp:3197
 msgid "Event Types"
 msgstr "Esemény típusok"
 
-#: src/muuli_wdr.cpp:3209
+#: src/muuli_wdr.cpp:3216
 msgid "Statistics and queued clients for selected file(s) : Session / All time"
 msgstr "Statisztikák és várakozó kliensek a kiválasztott fájl(ok)hoz: Folyamat / Valaha"
 
-#: src/muuli_wdr.cpp:3233
+#: src/muuli_wdr.cpp:3240
 msgid "Active Uploads"
 msgstr "Aktív feltöltések"
 
-#: src/muuli_wdr.cpp:3247
+#: src/muuli_wdr.cpp:3254
 msgid "Percent of total files"
 msgstr "Összes fájl százalékaként"
 
-#: src/muuli_wdr.cpp:3299
+#: src/muuli_wdr.cpp:3306
 msgid "Show Clients for"
 msgstr "Kliensek megjelenítése ehhez:"
 
-#: src/muuli_wdr.cpp:3301
+#: src/muuli_wdr.cpp:3308
 msgid "All files"
 msgstr "Összes fájl"
 
-#: src/muuli_wdr.cpp:3304
+#: src/muuli_wdr.cpp:3311
 msgid "Selected files"
 msgstr "Kiválasztott fájlok"
 
-#: src/muuli_wdr.cpp:3307
+#: src/muuli_wdr.cpp:3314
 msgid "Active uploads only"
 msgstr "Csak aktív feltöltések"
 
-#: src/muuli_wdr.cpp:3314
+#: src/muuli_wdr.cpp:3321
 msgid "Reload:"
 msgstr "Újratöltés:"
 
-#: src/muuli_wdr.cpp:3318
+#: src/muuli_wdr.cpp:3325
 msgid "Reload your shared files"
 msgstr "Megosztott fájlok frissítése"
 
-#: src/muuli_wdr.cpp:3381
+#: src/muuli_wdr.cpp:3388
 msgid "Send"
 msgstr "Küldés"
 
-#: src/muuli_wdr.cpp:3382
+#: src/muuli_wdr.cpp:3389
 msgid "Sends the specified message."
 msgstr "Megadott üzenet küldése."
 
-#: src/muuli_wdr.cpp:3386
+#: src/muuli_wdr.cpp:3393
 msgid "Close this chat-session."
 msgstr "Csevegési folyamat bezárása."
 
-#: src/muuli_wdr.cpp:3409
+#: src/muuli_wdr.cpp:3416
 msgid "Connect to any server and/or Kad"
 msgstr "Kapcsolódás bármelyik kiszolgálóhoz és/vagy a Kad-hoz"
 
-#: src/muuli_wdr.cpp:3415 src/SharedFilesCtrl.cpp:142 src/Statistics.cpp:941
+#: src/muuli_wdr.cpp:3422 src/SharedFilesCtrl.cpp:142 src/Statistics.cpp:941
 msgid "Shared Files"
 msgstr "Megosztott fájlok"
 
@@ -5414,188 +5428,188 @@ msgstr "Letöltve"
 msgid "ERROR: Failed to open partfile '%s'"
 msgstr "HIBA: A(z) '%s' részfájl megnyitása sikertelen."
 
-#: src/Preferences.cpp:673
+#: src/Preferences.cpp:674
 msgid "System default"
 msgstr "Alapértelmezett"
 
-#: src/Preferences.cpp:674
+#: src/Preferences.cpp:675
 msgid "Albanian"
 msgstr "Albán"
 
-#: src/Preferences.cpp:675
+#: src/Preferences.cpp:676
 msgid "Arabic"
 msgstr "Arab"
 
-#: src/Preferences.cpp:676
+#: src/Preferences.cpp:677
 msgid "Asturian"
 msgstr "Asztúriai"
 
-#: src/Preferences.cpp:677
+#: src/Preferences.cpp:678
 msgid "Basque"
 msgstr "Baszk"
 
-#: src/Preferences.cpp:678
+#: src/Preferences.cpp:679
 msgid "Bulgarian"
 msgstr "Bolgár"
 
-#: src/Preferences.cpp:679
+#: src/Preferences.cpp:680
 msgid "Catalan"
 msgstr "Katalán"
 
-#: src/Preferences.cpp:680
+#: src/Preferences.cpp:681
 msgid "Chinese (Simplified)"
 msgstr "Kínai (egyszerűsített)"
 
-#: src/Preferences.cpp:681
+#: src/Preferences.cpp:682
 msgid "Chinese (Traditional)"
 msgstr "Kínai (hagyományos)"
 
-#: src/Preferences.cpp:682
+#: src/Preferences.cpp:683
 msgid "Croatian"
 msgstr "Horvát"
 
-#: src/Preferences.cpp:683
+#: src/Preferences.cpp:684
 msgid "Czech"
 msgstr "Cseh"
 
-#: src/Preferences.cpp:684
+#: src/Preferences.cpp:685
 msgid "Danish"
 msgstr "Dán"
 
-#: src/Preferences.cpp:685
+#: src/Preferences.cpp:686
 msgid "Dutch"
 msgstr "Holland"
 
-#: src/Preferences.cpp:686
+#: src/Preferences.cpp:687
 msgid "English (U.K.)"
 msgstr "Angol (Egyesült Királyság)"
 
-#: src/Preferences.cpp:687
+#: src/Preferences.cpp:688
 #, fuzzy
 msgid "English (U.S.)"
 msgstr "Angol (Egyesült Királyság)"
 
-#: src/Preferences.cpp:688
+#: src/Preferences.cpp:689
 msgid "Estonian"
 msgstr "Észt"
 
-#: src/Preferences.cpp:689
+#: src/Preferences.cpp:690
 msgid "Finnish"
 msgstr "Finn"
 
-#: src/Preferences.cpp:690
+#: src/Preferences.cpp:691
 msgid "French"
 msgstr "Francia"
 
-#: src/Preferences.cpp:691
+#: src/Preferences.cpp:692
 msgid "Galician"
 msgstr "Gall"
 
-#: src/Preferences.cpp:692
+#: src/Preferences.cpp:693
 msgid "German"
 msgstr "Német"
 
-#: src/Preferences.cpp:693
+#: src/Preferences.cpp:694
 msgid "Greek"
 msgstr "Görög"
 
-#: src/Preferences.cpp:694
+#: src/Preferences.cpp:695
 msgid "Hebrew"
 msgstr "Héber"
 
-#: src/Preferences.cpp:695
+#: src/Preferences.cpp:696
 msgid "Hungarian"
 msgstr "Magyar"
 
-#: src/Preferences.cpp:696
+#: src/Preferences.cpp:697
 msgid "Italian"
 msgstr "Olasz"
 
-#: src/Preferences.cpp:697
+#: src/Preferences.cpp:698
 msgid "Japanese"
 msgstr "Japán"
 
-#: src/Preferences.cpp:698
+#: src/Preferences.cpp:699
 msgid "Korean"
 msgstr "Koreai"
 
-#: src/Preferences.cpp:699
+#: src/Preferences.cpp:700
 msgid "Latvian"
 msgstr ""
 
-#: src/Preferences.cpp:700
+#: src/Preferences.cpp:701
 msgid "Lithuanian"
 msgstr "Litván"
 
-#: src/Preferences.cpp:701
+#: src/Preferences.cpp:702
 msgid "Norwegian (Nynorsk)"
 msgstr "Norvég (Nynorsk)"
 
-#: src/Preferences.cpp:702
+#: src/Preferences.cpp:703
 msgid "Polish"
 msgstr "Lengyel"
 
-#: src/Preferences.cpp:703
+#: src/Preferences.cpp:704
 msgid "Portuguese"
 msgstr "Portugál"
 
-#: src/Preferences.cpp:704
+#: src/Preferences.cpp:705
 msgid "Portuguese (Brazilian)"
 msgstr "Portugál (Brazíliai)"
 
-#: src/Preferences.cpp:705
+#: src/Preferences.cpp:706
 msgid "Romanian"
 msgstr "Román"
 
-#: src/Preferences.cpp:706
+#: src/Preferences.cpp:707
 msgid "Russian"
 msgstr "Orosz"
 
-#: src/Preferences.cpp:707
+#: src/Preferences.cpp:708
 msgid "Slovenian"
 msgstr "Szlovén"
 
-#: src/Preferences.cpp:708
+#: src/Preferences.cpp:709
 msgid "Spanish"
 msgstr "Spanyol"
 
-#: src/Preferences.cpp:709
+#: src/Preferences.cpp:710
 msgid "Swedish"
 msgstr "Svéd"
 
-#: src/Preferences.cpp:710
+#: src/Preferences.cpp:711
 msgid "Turkish"
 msgstr "Török"
 
-#: src/Preferences.cpp:711
+#: src/Preferences.cpp:712
 msgid "Ukrainian"
 msgstr "Ukrán"
 
-#: src/Preferences.cpp:814
+#: src/Preferences.cpp:815
 msgid "Change Language"
 msgstr "Nyelv megváltoztatása"
 
-#: src/Preferences.cpp:878
+#: src/Preferences.cpp:879
 msgid "There are no translations installed for aMule"
 msgstr "Nincsenek fordítások telepítve az aMule-hez"
 
-#: src/Preferences.cpp:879
+#: src/Preferences.cpp:880
 msgid "No languages available"
 msgstr "Nincs elérhető nyelv"
 
-#: src/Preferences.cpp:1010
+#: src/Preferences.cpp:1011
 msgid "no options available"
 msgstr "nincs elérhető opció"
 
-#: src/Preferences.cpp:2179
+#: src/Preferences.cpp:2182
 msgid "Invalid category found, skipping"
 msgstr "Érvénytelen kategória találva, mellőzés"
 
-#: src/Preferences.cpp:2348
+#: src/Preferences.cpp:2351
 msgid "TCP port can't be higher than 65532 due to server UDP socket being TCP+3"
 msgstr "A TCP port nem lehet magasabb 65532-nél, mert a kiszolgáló UDP port = TCP+3"
 
-#: src/Preferences.cpp:2349
+#: src/Preferences.cpp:2352
 #, c-format
 msgid "Default port will be used (%d)"
 msgstr "Alapértelmezett port lesz használva (%d)"
@@ -6099,23 +6113,27 @@ msgstr "A megosztott fájlok listájának újratöltése."
 msgid "Shared folder"
 msgstr "Megosztott mappák"
 
-#: src/SearchDlg.cpp:425
+#: src/SearchDlg.cpp:280
+msgid "Clear search history"
+msgstr ""
+
+#: src/SearchDlg.cpp:584
 msgid "It's impossible to search when both eD2k and Kademlia are disabled."
 msgstr "Nem lehet keresni, ha az eD2k és a Kademlia hálózat is le van tiltva."
 
-#: src/SearchDlg.cpp:426 src/SearchListCtrl.cpp:858
+#: src/SearchDlg.cpp:585 src/SearchListCtrl.cpp:858
 msgid "Search error"
 msgstr "Keresési hiba"
 
-#: src/SearchDlg.cpp:768
+#: src/SearchDlg.cpp:929
 msgid "Min size must be smaller than max size. Max size ignored."
 msgstr "A minimum méretnek kisebbnek kell lennie a maximum méretnél. Maximum méret figyelmen kívül hagyva."
 
-#: src/SearchDlg.cpp:769 src/SearchDlg.cpp:851
+#: src/SearchDlg.cpp:930 src/SearchDlg.cpp:1012
 msgid "Search warning"
 msgstr "Keresési figyelmeztetés"
 
-#: src/SearchDlg.cpp:929 src/SearchListCtrl.cpp:735
+#: src/SearchDlg.cpp:1092 src/SearchListCtrl.cpp:735
 msgid "Main"
 msgstr "Alap"
 

--- a/po/hu.po
+++ b/po/hu.po
@@ -7,8 +7,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-28 12:12+0200\n"
-"PO-Revision-Date: 2026-07-27 10:25+0000\n"
+"POT-Creation-Date: 2026-07-28 08:06+0200\n"
+"PO-Revision-Date: 2026-07-27 11:39+0000\n"
 "Last-Translator: Dévai Tamás <gonosztopi@amule.org>\n"
 "Language-Team: Hungarian <hu@li.org>\n"
 "Language: hu\n"
@@ -145,7 +145,7 @@ msgstr "Telepítés"
 msgid "Not now"
 msgstr "Most nem"
 
-#: src/AppImageIntegration.cpp:422 src/amuleDlg.cpp:665
+#: src/AppImageIntegration.cpp:422 src/amuleDlg.cpp:600
 msgid "Don't ask again"
 msgstr "Ne kérdezze újra"
 
@@ -207,83 +207,83 @@ msgstr "ED2KLinks fájl megnyitása sikertelen."
 msgid "WARNING: You can't add yourself as a source for an eD2k link while having a lowid."
 msgstr "FIGYELEM: Nem adhatod magad forrásként egy eD2k hivatkozáshoz amíg alacsony azonosítód (lowid) van."
 
-#: src/amule.cpp:301
+#: src/amule.cpp:300
 msgid "Now, exiting main app..."
 msgstr "Kilépés a fő alkalmazásból..."
 
-#: src/amule.cpp:331
+#: src/amule.cpp:330
 #, c-format
 msgid "Terminating amuleweb instance with pid '%d' ... "
 msgstr "Az amuleweb instancia - melynek a pid-je '%d' - bezárása ... "
 
-#: src/amule.cpp:335
+#: src/amule.cpp:334
 #, c-format
 msgid "Killing amuleweb instance with pid '%d' ... "
 msgstr "Az amuleweb instancia - melynek a pid-je '%d' - kivégzése ... "
 
-#: src/amule.cpp:337 src/amule.cpp:350 src/ClientRef.cpp:180
-#: src/SearchDlg.cpp:1041 src/ServerListCtrl.cpp:98
+#: src/amule.cpp:336 src/amule.cpp:349 src/ClientRef.cpp:180
+#: src/SearchDlg.cpp:880 src/ServerListCtrl.cpp:98
 msgid "Failed"
 msgstr "Sikertelen"
 
-#: src/amule.cpp:344
+#: src/amule.cpp:343
 #, fuzzy, c-format
 msgid "Terminating amuleapi instance with pid '%d' ... "
 msgstr "Az amuleweb instancia - melynek a pid-je '%d' - bezárása ... "
 
-#: src/amule.cpp:348
+#: src/amule.cpp:347
 #, fuzzy, c-format
 msgid "Killing amuleapi instance with pid '%d' ... "
 msgstr "Az amuleweb instancia - melynek a pid-je '%d' - kivégzése ... "
 
-#: src/amule.cpp:356
+#: src/amule.cpp:355
 msgid "aMule OnExit: Terminating core."
 msgstr "aMule OnExit: Mag leállítása."
 
-#: src/amule.cpp:467
+#: src/amule.cpp:466
 msgid "aMule shutdown completed."
 msgstr "Az aMule leállítása befejeződött."
 
-#: src/amule.cpp:471
+#: src/amule.cpp:470
 msgid "Memory debug results for aMule exit:"
 msgstr "Memória debug eredmények az aMule bezárásáról:"
 
-#: src/amule.cpp:652
+#: src/amule.cpp:651
 #, c-format
 msgid "Binding aMule's peer-to-peer traffic to interface: %s (HTTP updates use the default route)"
 msgstr ""
 
-#: src/amule.cpp:656
+#: src/amule.cpp:655
 #, c-format
 msgid "Binding all network traffic to interface: %s"
 msgstr ""
 
-#: src/amule.cpp:660
+#: src/amule.cpp:659
 #, c-format
 msgid "WARNING: configured network interface '%s' was not found - traffic is NOT bound to it and may leave via the default route. Check the interface name in Preferences."
 msgstr ""
 
-#: src/amule.cpp:666
+#: src/amule.cpp:665
 #, c-format
 msgid "WARNING: binding to network interface '%s' requires elevated privileges and was NOT applied - traffic may leave via the default route. Grant the capability (e.g. 'sudo setcap cap_net_raw+ep' on the aMule binary) or run with sufficient privileges."
 msgstr ""
 
-#: src/amule.cpp:674
+#: src/amule.cpp:673
 #, c-format
 msgid "WARNING: could not bind to network interface '%s' - traffic may leave via the default route."
 msgstr ""
 
-#: src/amule.cpp:733
+#: src/amule.cpp:732
 msgid "Your locale has been changed to System Default due to a configuration change. Sorry."
 msgstr "Nyelvi beállításaid egy konfigurációs változás miatt az alapértelmezettre lettek átállítva. Bocs."
 
-#: src/amule.cpp:735 src/amule.cpp:1589 src/CatDialog.cpp:128
+#: src/amule.cpp:734 src/amule.cpp:1581 src/CatDialog.cpp:128
 #: src/CatDialog.cpp:136 src/CatDialog.cpp:149 src/ServerList.cpp:366
 #: src/ServerListCtrl.cpp:152
 msgid "Info"
 msgstr "Infó"
 
-#: src/amule.cpp:742
+#: src/amule.cpp:741
 msgid ""
 "\n"
 "EC configuration"
@@ -291,20 +291,20 @@ msgstr ""
 "\n"
 "EC beállítások"
 
-#: src/amule.cpp:745
+#: src/amule.cpp:744
 msgid "Password set and external connections enabled."
 msgstr "Jelszó beállítva, külső kapcsolatok engedélyezve."
 
-#: src/amule.cpp:755 src/KadDlg.cpp:176 src/KadDlg.cpp:185
-#: src/PrefsUnifiedDlg.cpp:1461 src/SharedFilesCtrl.cpp:476
+#: src/amule.cpp:754 src/KadDlg.cpp:176 src/KadDlg.cpp:185
+#: src/PrefsUnifiedDlg.cpp:1387 src/SharedFilesCtrl.cpp:476
 msgid "WARNING"
 msgstr "FIGYELEM"
 
-#: src/amule.cpp:992
+#: src/amule.cpp:991
 msgid "Network bootstrap"
 msgstr "Hálózati bootstrap"
 
-#: src/amule.cpp:997
+#: src/amule.cpp:996
 msgid ""
 "aMule has detected missing network bootstrap files.\n"
 "Select which ones to download:"
@@ -312,52 +312,52 @@ msgstr ""
 "aMule hiányzó hálózati bootstrap fájlokat észlelt.\n"
 "Válassza ki a letölteni kivántakat:"
 
-#: src/amule.cpp:1006 src/FirstRunWizard.cpp:411
+#: src/amule.cpp:1005 src/FirstRunWizard.cpp:411
 msgid "eD2k server list (server.met)"
 msgstr "eD2k szerver lista (server.met)"
 
-#: src/amule.cpp:1013 src/FirstRunWizard.cpp:416
+#: src/amule.cpp:1012 src/FirstRunWizard.cpp:416
 msgid "Kad bootstrap nodes (nodes.dat)"
 msgstr "Kad bootstrap csomópontok (nodes.dat)"
 
-#: src/amule.cpp:1103
+#: src/amule.cpp:1102
 #, c-format
 msgid "web server running on pid %d"
 msgstr "web kiszolgáló fut, pid=%d"
 
-#: src/amule.cpp:1116
+#: src/amule.cpp:1115
 msgid "You requested to run web server on startup, but the amuleweb binary cannot be run. Please install the package containing aMule web server, or build aMule from source with -DBUILD_WEBSERVER=YES and install it."
 msgstr "A web szerver futtatását kérte induláskor, de az amuleweb program nem futtatható. Kérem telepítse az aMule web szervert tartalmazó csomagot, vagy építse az aMule-t a forráskódból a -DBUILD_WEBSERVER=YES paraméterrel és installálja azt."
 
-#: src/amule.cpp:1121 src/amule.cpp:1185 src/amule.cpp:1299 src/amule.cpp:1601
+#: src/amule.cpp:1120 src/amule.cpp:1177 src/amule.cpp:1291 src/amule.cpp:1593
 #: src/amule-remote-gui.cpp:603 src/amule-remote-gui.cpp:671
 #: src/amule-remote-gui.cpp:709 src/amule-remote-gui.cpp:1282
 #: src/amule-remote-gui.cpp:1345 src/amule-remote-gui.cpp:1372
-#: src/DownloadQueue.cpp:1481 src/PrefsUnifiedDlg.cpp:1247
+#: src/DownloadQueue.cpp:1481
 msgid "ERROR"
 msgstr "HIBA"
 
-#: src/amule.cpp:1174
+#: src/amule.cpp:1166
 #, fuzzy, c-format
 msgid "amuleapi running on pid %d"
 msgstr "web kiszolgáló fut, pid=%d"
 
-#: src/amule.cpp:1180
+#: src/amule.cpp:1172
 #, fuzzy
 msgid "You requested to run amuleapi on startup, but the amuleapi binary cannot be run. Please install the package containing aMule's REST API server, or build aMule from source with -DBUILD_AMULEAPI=YES and install it."
 msgstr "A web szerver futtatását kérte induláskor, de az amuleweb program nem futtatható. Kérem telepítse az aMule web szervert tartalmazó csomagot, vagy építse az aMule-t a forráskódból a -DBUILD_WEBSERVER=YES paraméterrel és installálja azt."
 
-#: src/amule.cpp:1267
+#: src/amule.cpp:1259
 #, c-format
 msgid "Could not bind ports to the specified address: %s"
 msgstr "Nem tudom a portokat a megadott címhez (%s) rendelni."
 
-#: src/amule.cpp:1291
+#: src/amule.cpp:1283
 #, c-format
 msgid "Port %u is not available. You will be LOWID\n"
 msgstr "A %u port nem elérhető. Alacsony kliens azonosítót kapsz (LOWID)\n"
 
-#: src/amule.cpp:1296
+#: src/amule.cpp:1288
 #, c-format
 msgid ""
 "Port %u is not available!\n"
@@ -372,48 +372,48 @@ msgstr ""
 "\n"
 "Ellenőrízd a hálózatodat, hogy megbizonyosodj, hogy a port nyitva van kifelé és befelé egyaránt."
 
-#: src/amule.cpp:1393
+#: src/amule.cpp:1385
 msgid "Failed to create OnlineSig File"
 msgstr "Online-Aláírás fájl létrehozása sikertelen"
 
-#: src/amule.cpp:1401
+#: src/amule.cpp:1393
 msgid "Failed to create aMule OnlineSig File"
 msgstr "Az aMule OnlineAláírás fájl létrehozása sikertelen"
 
-#: src/amule.cpp:1564
+#: src/amule.cpp:1556
 msgid "The selected locale seems not to be installed on your box. (Note: I'll try to set it anyway)"
 msgstr "A kiválasztott nyelvi beállítások úgy látszik nincsenek telepítve a gépeden. (Megjegyzés: Mindenesetre mepróbálom ezt beállítani)"
 
-#: src/amule.cpp:1574
+#: src/amule.cpp:1566
 #, c-format
 msgid "This is the first time you run aMule %s"
 msgstr "Ez az első alkalom, hogy az aMule %s-t futtatod"
 
-#: src/amule.cpp:1577
+#: src/amule.cpp:1569
 msgid "This version is a testing version, updated daily, and\n"
 msgstr "Ez egy teszt verzió, naponta frissítve, és\n"
 
-#: src/amule.cpp:1578
+#: src/amule.cpp:1570
 msgid "we give no warranty it won't break anything, burn your house,\n"
 msgstr "nem vállalunk garanciát, hogy nem omlik össze, gyújtja fel a házad,\n"
 
-#: src/amule.cpp:1579
+#: src/amule.cpp:1571
 msgid "or kill your dog. But it *should* be safe to use anyway.\n"
 msgstr "vagy öli meg a kutyád. *Elvileg* nyugodtan használható.\n"
 
-#: src/amule.cpp:1584
+#: src/amule.cpp:1576
 msgid "More information, support and new releases can found at our homepage,\n"
 msgstr "Még több információ, támogatás és új kiadások találhatóak honlapunkon,\n"
 
-#: src/amule.cpp:1585
+#: src/amule.cpp:1577
 msgid "at https://amule-org.github.io, or in our IRC channel #aMule at irc.libera.chat.\n"
 msgstr "a https://amule-org.github.io, vagy az #aMule IRC csatornánkon az irc.libera.chat.\n"
 
-#: src/amule.cpp:1587
+#: src/amule.cpp:1579
 msgid "Feel free to report any bugs to https://github.com/amule-org/amule/issues"
 msgstr "Nyugodtan jelezz bármilyen hibát a https://github.com/amule-org/amule/issues"
 
-#: src/amule.cpp:1599
+#: src/amule.cpp:1591
 msgid ""
 "The folder for Online Signature files you specified is INVALID!\n"
 " OnlineSignature will be DISABLED until you fix it on preferences."
@@ -421,137 +421,137 @@ msgstr ""
 "Az Online aláírás fájl könyvtárának megadott hely ÉRVÉNYTELEN!\n"
 " Az OnlineAláírás letiltásra kerül, amíg ki nem javítod azt a beállítások menüpontban."
 
-#: src/amule.cpp:1662
+#: src/amule.cpp:1654
 msgid "Server hostname notified"
 msgstr "Szerver hostname értesítve"
 
-#: src/amule.cpp:2039
+#: src/amule.cpp:2031
 #, c-format
 msgid "Disk space preallocation for file '%s' failed: %s"
 msgstr "Lemezterület helyfoglalás a '%s' fájl számára sikertelen: %s"
 
-#: src/amule.cpp:2168
+#: src/amule.cpp:2160
 msgid "ERROR: can't open logfile"
 msgstr "HIBA: Nem tudom megnyitni a napló fájlt"
 
-#: src/amule.cpp:2172
+#: src/amule.cpp:2164
 msgid "WARNING: logfile is empty. Something is wrong."
 msgstr "FIGYELEM: a napló üres. Valami nem stimmel."
 
-#: src/amule.cpp:2189
+#: src/amule.cpp:2181
 msgid "Log has been reset"
 msgstr "Napló törölve"
 
-#: src/amule.cpp:2213
+#: src/amule.cpp:2205
 #, c-format
 msgid "ServerMessage: %s"
 msgstr "KiszolgálóÜzenet: %s"
 
-#: src/amule.cpp:2256 src/IP2Country.cpp:220 src/IPFilter.cpp:514
+#: src/amule.cpp:2248 src/IP2Country.cpp:220 src/IPFilter.cpp:514
 #: src/ServerList.cpp:875
 #, c-format
 msgid "Skipped download of %s, because requested file is not newer."
 msgstr "A %s letöltése kihagyva, mert a kívánt fájl nem újabb."
 
-#: src/amule.cpp:2259
+#: src/amule.cpp:2251
 msgid "Failed to download the nodes list."
 msgstr "Csomópont-lista letöltése sikertelen."
 
-#: src/amule.cpp:2322
+#: src/amule.cpp:2314
 msgid "Failed to open the downloaded version check file"
 msgstr "Nem sikerült megnyitni a letöltött verzió-ellenőrző fájlt"
 
-#: src/amule.cpp:2325 src/amule.cpp:2344
+#: src/amule.cpp:2317 src/amule.cpp:2336
 msgid "Corrupted version check file"
 msgstr "Sérült verzió-ellenőrző fájl"
 
-#: src/amule.cpp:2367
+#: src/amule.cpp:2359
 msgid "You are using an outdated version of aMule!"
 msgstr "Az aMule egy elavult verzióját használod!"
 
-#: src/amule.cpp:2369
+#: src/amule.cpp:2361
 #, c-format
 msgid "Your aMule version is %i.%i.%i and the latest version is %li.%li.%li"
 msgstr "A te aMule verziód %i.%i.%i, a legújabb verzió pedig %li.%li.%li"
 
-#: src/amule.cpp:2373
+#: src/amule.cpp:2365
 msgid "The latest version can always be found at https://github.com/amule-org/amule/releases/latest"
 msgstr "A legújabb verzió mindig megtalálható a https://github.com/amule-org/amule/releases/latest honlapon."
 
-#: src/amule.cpp:2376
+#: src/amule.cpp:2368
 #, c-format
 msgid "WARNING: Your aMuled version is outdated: %i.%i.%i < %li.%li.%li"
 msgstr "FIGYELEM: A te aMule verziód elavult: %i.%i.%i < %li.%li.%li"
 
-#: src/amule.cpp:2382
+#: src/amule.cpp:2374
 msgid "Your copy of aMule is up to date."
 msgstr "Az aMule verziód naprakész."
 
-#: src/amule.cpp:2389
+#: src/amule.cpp:2381
 msgid "Failed to download the version check file"
 msgstr "Verzió-ellenőrzés fájl letöltése sikertelen."
 
-#: src/amule.cpp:2558 src/amule-remote-gui.cpp:1133
+#: src/amule.cpp:2550 src/amule-remote-gui.cpp:1133
 #, c-format
 msgid "Users: %s | Files: %s"
 msgstr "Felhasználók: %s | Fájlok: %s"
 
-#: src/amule.cpp:2559 src/amule-remote-gui.cpp:1134
+#: src/amule.cpp:2551 src/amule-remote-gui.cpp:1134
 #, c-format
 msgid "Users: E: %s K: %s | Files: E: %s K: %s"
 msgstr "Felhasználók: E: %s K: %s | Fájlok: E: %s K: %s"
 
-#: src/amule.cpp:2573 src/amule-remote-gui.cpp:1147
+#: src/amule.cpp:2565 src/amule-remote-gui.cpp:1147
 msgid "No networks selected"
 msgstr "Nincs hálózat kiválasztva"
 
-#: src/amule.cpp:2641 src/TextClient.cpp:903
+#: src/amule.cpp:2633 src/TextClient.cpp:903
 msgid "with LowID"
 msgstr "LowID-val"
 
-#: src/amule.cpp:2641 src/TextClient.cpp:904
+#: src/amule.cpp:2633 src/TextClient.cpp:904
 msgid "with HighID"
 msgstr "HighID-val"
 
-#: src/amule.cpp:2643
+#: src/amule.cpp:2635
 #, c-format
 msgid "Connected to %s %s"
 msgstr "Kapcsolódva ehhez %s %s"
 
-#: src/amule.cpp:2648
+#: src/amule.cpp:2640
 #, c-format
 msgid "Connecting to %s"
 msgstr "Kapcsolódás %s-hez"
 
-#: src/amule.cpp:2650
+#: src/amule.cpp:2642
 msgid "Disconnected from eD2k"
 msgstr "Leválasztva az eD2k-ról"
 
-#: src/amule.cpp:2659
+#: src/amule.cpp:2651
 msgid "Kad started."
 msgstr "Kad elindítva."
 
-#: src/amule.cpp:2661
+#: src/amule.cpp:2653
 msgid "Kad stopped."
 msgstr "Kad leállítva."
 
-#: src/amule.cpp:2669
+#: src/amule.cpp:2661
 msgid "Connected to Kad (ok)"
 msgstr "Kapcsolódva a Kad-hoz (rendben)"
 
-#: src/amule.cpp:2671
+#: src/amule.cpp:2663
 msgid "Connected to Kad (firewalled)"
 msgstr "Kapcsolódva a Kad-hoz (tűzfal mögül)"
 
-#: src/amule.cpp:2675
+#: src/amule.cpp:2667
 msgid "Disconnected from Kad"
 msgstr "Leválasztva a Kad-ról"
 
-#: src/amule.cpp:2707
+#: src/amule.cpp:2699
 msgid "Kad network cannot be used if UDP port is disabled on preferences, not starting."
 msgstr "A Kad hálózat nem használható, ha az UDP port le van tiltva a beállításokban, nem indítom."
 
-#: src/amule.cpp:2711
+#: src/amule.cpp:2703
 msgid "Kad network disabled on preferences, not connecting."
 msgstr "A Kad hálózat le van tiltva  a beállításokban, nem kapcsolódom."
 
@@ -576,68 +576,30 @@ msgstr "Pid fájl létrehozása nem lehetséges"
 msgid "ERROR: %s"
 msgstr "HIBA: %s"
 
-#: src/amuleDlg.cpp:250
+#: src/amuleDlg.cpp:236
 #, c-format
 msgid "This is aMule %s based on eMule."
 msgstr "Ez az aMule %s, az eMule alapján."
 
-#: src/amuleDlg.cpp:251
+#: src/amuleDlg.cpp:237
 #, c-format
 msgid "Running on %s"
 msgstr "%s-en fut"
 
-#: src/amuleDlg.cpp:253
+#: src/amuleDlg.cpp:239
 msgid "Visit https://github.com/amule-org/amule/releases/latest to check if a new version is available."
 msgstr "Új verzióért látogasd meg a https://github.com/amule-org/amule/releases/latest oldalt."
 
-#: src/amuleDlg.cpp:282
+#: src/amuleDlg.cpp:268
 msgid "FATAL ERROR: Failed to create Timer"
 msgstr "VÉGZETES HIBA: Időzítő létrehozása sikertelen"
 
-#: src/amuleDlg.cpp:361 src/amuleDlg.cpp:1810 src/amuleDlg.cpp:2056
-#: src/muuli_wdr.cpp:1492 src/muuli_wdr.cpp:3439
-msgid "Networks"
-msgstr "Hálózatok"
-
-#: src/amuleDlg.cpp:362 src/amuleDlg.cpp:1816 src/muuli_wdr.cpp:3440
-msgid "Searches"
-msgstr "Keresések"
-
-#: src/amuleDlg.cpp:363 src/amuleDlg.cpp:1822 src/DownloadListCtrl.cpp:740
-#: src/muuli_wdr.cpp:392 src/muuli_wdr.cpp:1585 src/muuli_wdr.cpp:3441
-#: src/Statistics.cpp:829
-msgid "Downloads"
-msgstr "Letöltések"
-
-#: src/amuleDlg.cpp:364 src/amuleDlg.cpp:1828 src/muuli_wdr.cpp:3315
-msgid "Shared files"
-msgstr "Megosztott fájlok"
-
-#: src/amuleDlg.cpp:365 src/amuleDlg.cpp:1834 src/muuli_wdr.cpp:2947
-#: src/muuli_wdr.cpp:3397 src/muuli_wdr.cpp:3444
-msgid "Messages"
-msgstr "Üzenetek"
-
-#: src/amuleDlg.cpp:366 src/amuleDlg.cpp:1840 src/muuli_wdr.cpp:3445
-#: src/PrefsUnifiedDlg.cpp:314 src/Statistics.cpp:779 src/Statistics.cpp:1235
-msgid "Statistics"
-msgstr "Statisztikák"
-
-#: src/amuleDlg.cpp:368 src/amuleDlg.cpp:1847 src/muuli_wdr.cpp:3447
-#: src/PrefsUnifiedDlg.cpp:330 src/utils/wxCas/src/wxcasprefs.cpp:39
-msgid "Preferences"
-msgstr "Beállítások"
-
-#: src/amuleDlg.cpp:371
-msgid "Navigate"
-msgstr ""
-
-#: src/amuleDlg.cpp:657
+#: src/amuleDlg.cpp:592
 #, fuzzy
 msgid "New version available"
 msgstr "Nem elérhető"
 
-#: src/amuleDlg.cpp:661
+#: src/amuleDlg.cpp:596
 #, fuzzy, c-format
 msgid ""
 "A new version of aMule (%s) is available.\n"
@@ -647,184 +609,217 @@ msgid ""
 "Would you like to open the download page?"
 msgstr "A legújabb verzió mindig megtalálható a https://github.com/amule-org/amule/releases/latest honlapon."
 
-#: src/amuleDlg.cpp:743
+#: src/amuleDlg.cpp:678
 msgid "aMule dialog destroyed"
 msgstr "aMule dialógus elpusztítva"
 
-#: src/amuleDlg.cpp:766 src/DataToText.cpp:68 src/IPFilter.cpp:547
+#: src/amuleDlg.cpp:701 src/DataToText.cpp:68 src/IPFilter.cpp:547
 msgid "Connecting"
 msgstr "Kapcsolódás"
 
-#: src/amuleDlg.cpp:958
+#: src/amuleDlg.cpp:893
 msgid "eD2k: Connecting"
 msgstr "eD2K: Kapcsolódás"
 
-#: src/amuleDlg.cpp:962
+#: src/amuleDlg.cpp:897
 msgid "eD2k: Disconnected"
 msgstr "eD2k: Szétkapcsolva"
 
-#: src/amuleDlg.cpp:968
+#: src/amuleDlg.cpp:903
 msgid "Kad: Firewalled"
 msgstr "Kad: Tűzfal mögött"
 
-#: src/amuleDlg.cpp:972
+#: src/amuleDlg.cpp:907
 msgid "Kad: Connected"
 msgstr "Kad: Csatlakozva"
 
-#: src/amuleDlg.cpp:977
+#: src/amuleDlg.cpp:912
 msgid "Kad: Connecting"
 msgstr "Kad: Kapcsolódás"
 
-#: src/amuleDlg.cpp:981
+#: src/amuleDlg.cpp:916
 msgid "Kad: Off"
 msgstr "Kad: Nincs kapcsolat"
 
-#: src/amuleDlg.cpp:1029 src/DownloadListCtrl.cpp:505
+#: src/amuleDlg.cpp:964 src/DownloadListCtrl.cpp:505
 #: src/DownloadListCtrl.cpp:749 src/FriendListCtrl.cpp:180
 #: src/muuli_wdr.cpp:731 src/muuli_wdr.cpp:782 src/muuli_wdr.cpp:846
-#: src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2252 src/muuli_wdr.cpp:2337
-#: src/muuli_wdr.cpp:3085 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
+#: src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2224 src/muuli_wdr.cpp:2309
+#: src/muuli_wdr.cpp:3057 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
 #: src/ServerListCtrl.cpp:606 src/TransferWnd.cpp:378
 #: src/utils/wxCas/src/wxcasprefs.cpp:235
 msgid "Cancel"
 msgstr "Mégsem"
 
-#: src/amuleDlg.cpp:1030
+#: src/amuleDlg.cpp:965
 msgid "Stop the current connection attempts"
 msgstr "Aktuális kapcsolódási kísérletek leállítása"
 
-#: src/amuleDlg.cpp:1035 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976
-#: src/muuli_wdr.cpp:2475
+#: src/amuleDlg.cpp:970 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976
+#: src/muuli_wdr.cpp:2447
 msgid "Disconnect"
 msgstr "Szétkapcsolás"
 
-#: src/amuleDlg.cpp:1036
+#: src/amuleDlg.cpp:971
 msgid "Disconnect from the currently connected networks"
 msgstr "Leválaszt az éppen kapcsolódott hálózatokról."
 
-#: src/amuleDlg.cpp:1041 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979
-#: src/muuli_wdr.cpp:2630 src/muuli_wdr.cpp:3082 src/muuli_wdr.cpp:3437
+#: src/amuleDlg.cpp:976 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979
+#: src/muuli_wdr.cpp:2602 src/muuli_wdr.cpp:3054 src/muuli_wdr.cpp:3409
 msgid "Connect"
 msgstr "Kapcsolatfelvétel"
 
-#: src/amuleDlg.cpp:1042
+#: src/amuleDlg.cpp:977
 msgid "Connect to the currently enabled networks"
 msgstr "Kapcsolódás a pillanatnyilag engedélyezett hálózatokhoz."
 
-#: src/amuleDlg.cpp:1154
+#: src/amuleDlg.cpp:1089
 #, c-format
 msgid "Up: %.1f%s (%.1f) | Down: %.1f%s (%.1f)"
 msgstr "Fel: %.1f%s (%.1f) | Le: %.1f%s (%.1f)"
 
-#: src/amuleDlg.cpp:1156 src/amuleDlg.cpp:1158 src/amuleDlg.cpp:1162
-#: src/amuleDlg.cpp:1164 src/amuleDlg.cpp:1175 src/amuleDlg.cpp:1177
+#: src/amuleDlg.cpp:1091 src/amuleDlg.cpp:1093 src/amuleDlg.cpp:1097
+#: src/amuleDlg.cpp:1099 src/amuleDlg.cpp:1110 src/amuleDlg.cpp:1112
 #: src/MuleTrayIcon.cpp:796 src/MuleTrayIcon.cpp:799
 msgid " MB/s"
 msgstr " MB/s"
 
-#: src/amuleDlg.cpp:1156 src/amuleDlg.cpp:1158 src/amuleDlg.cpp:1162
-#: src/amuleDlg.cpp:1164 src/amuleDlg.cpp:1175 src/amuleDlg.cpp:1177
+#: src/amuleDlg.cpp:1091 src/amuleDlg.cpp:1093 src/amuleDlg.cpp:1097
+#: src/amuleDlg.cpp:1099 src/amuleDlg.cpp:1110 src/amuleDlg.cpp:1112
 #: src/MuleTrayIcon.cpp:796 src/MuleTrayIcon.cpp:799
 #: src/utils/wxCas/src/wxcasframe.cpp:1041
 msgid " kB/s"
 msgstr " kB/s"
 
-#: src/amuleDlg.cpp:1161
+#: src/amuleDlg.cpp:1096
 #, c-format
 msgid "Up: %.1f%s | Down: %.1f%s"
 msgstr "Fel: %.1f%s | Le: %.1f%s"
 
-#: src/amuleDlg.cpp:1193
+#: src/amuleDlg.cpp:1128
 #, c-format
 msgid "aMule (%s | Connected)"
 msgstr "aMule (%s | Kapcsolódva)"
 
-#: src/amuleDlg.cpp:1195
+#: src/amuleDlg.cpp:1130
 #, c-format
 msgid "aMule (%s | Disconnected)"
 msgstr "aMule (%s | Nincs kapcsolat)"
 
-#: src/amuleDlg.cpp:1248
+#: src/amuleDlg.cpp:1183
 #, c-format
 msgid "Do you really want to exit %s?"
 msgstr "Biztos, hogy ki szeretnél lépni a(z) %s alkalmazásból?"
 
-#: src/amuleDlg.cpp:1250
+#: src/amuleDlg.cpp:1185
 msgid "Exit confirmation"
 msgstr "Kilépés megerősítése"
 
-#: src/amuleDlg.cpp:1613
+#: src/amuleDlg.cpp:1548
 msgid "Launch Command: "
 msgstr "Parancs futtatása: "
 
-#: src/amuleDlg.cpp:1632 src/muuli_wdr.cpp:1972 src/Preferences.cpp:979
+#: src/amuleDlg.cpp:1567 src/muuli_wdr.cpp:1971 src/Preferences.cpp:951
 msgid "- default -"
 msgstr "- alapértelmezett -"
 
-#: src/amuleDlg.cpp:1660
+#: src/amuleDlg.cpp:1595
 #, c-format
 msgid "Skin directory '%s' does not exist"
 msgstr "A(z) '%s' felület könyvtár nem létezik"
 
-#: src/amuleDlg.cpp:1663
+#: src/amuleDlg.cpp:1598
 #, c-format
 msgid "WARNING: Unable to open skin file '%s' for read"
 msgstr "FIGYELEM: Nem tudom a(z) '%s' felület fáljt megnyitni olvasásra"
 
-#: src/amuleDlg.cpp:1814 src/muuli_wdr.cpp:3439
+#: src/amuleDlg.cpp:1722 src/amuleDlg.cpp:1968 src/muuli_wdr.cpp:1485
+#: src/muuli_wdr.cpp:3411
+msgid "Networks"
+msgstr "Hálózatok"
+
+#: src/amuleDlg.cpp:1726 src/muuli_wdr.cpp:3411
 msgid "Networks Window"
 msgstr "Hálózatok ablaka"
 
-#: src/amuleDlg.cpp:1820 src/muuli_wdr.cpp:3440
+#: src/amuleDlg.cpp:1728 src/muuli_wdr.cpp:3412
+msgid "Searches"
+msgstr "Keresések"
+
+#: src/amuleDlg.cpp:1732 src/muuli_wdr.cpp:3412
 msgid "Searches Window"
 msgstr "Keresés ablaka"
 
-#: src/amuleDlg.cpp:1826 src/muuli_wdr.cpp:3441
+#: src/amuleDlg.cpp:1734 src/DownloadListCtrl.cpp:740 src/muuli_wdr.cpp:392
+#: src/muuli_wdr.cpp:1578 src/muuli_wdr.cpp:3413 src/Statistics.cpp:829
+msgid "Downloads"
+msgstr "Letöltések"
+
+#: src/amuleDlg.cpp:1738 src/muuli_wdr.cpp:3413
 msgid "Downloads Window"
 msgstr "Letöltések ablaka"
 
-#: src/amuleDlg.cpp:1832 src/muuli_wdr.cpp:3443
+#: src/amuleDlg.cpp:1740 src/muuli_wdr.cpp:3287
+msgid "Shared files"
+msgstr "Megosztott fájlok"
+
+#: src/amuleDlg.cpp:1744 src/muuli_wdr.cpp:3415
 msgid "Shared Files Window"
 msgstr "Megosztott fájlok ablaka"
 
-#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3444
+#: src/amuleDlg.cpp:1746 src/muuli_wdr.cpp:2919 src/muuli_wdr.cpp:3369
+#: src/muuli_wdr.cpp:3416
+msgid "Messages"
+msgstr "Üzenetek"
+
+#: src/amuleDlg.cpp:1750 src/muuli_wdr.cpp:3416
 msgid "Messages Window"
 msgstr "Üzenetek ablaka"
 
-#: src/amuleDlg.cpp:1844 src/muuli_wdr.cpp:3445
+#: src/amuleDlg.cpp:1752 src/muuli_wdr.cpp:3417 src/PrefsUnifiedDlg.cpp:312
+#: src/Statistics.cpp:779 src/Statistics.cpp:1235
+msgid "Statistics"
+msgstr "Statisztikák"
+
+#: src/amuleDlg.cpp:1756 src/muuli_wdr.cpp:3417
 msgid "Statistics Graph Window"
 msgstr "Statisztikai grafikonok ablaka"
 
-#: src/amuleDlg.cpp:1851 src/muuli_wdr.cpp:3447
+#: src/amuleDlg.cpp:1759 src/muuli_wdr.cpp:3419 src/PrefsUnifiedDlg.cpp:328
+#: src/utils/wxCas/src/wxcasprefs.cpp:39
+msgid "Preferences"
+msgstr "Beállítások"
+
+#: src/amuleDlg.cpp:1763 src/muuli_wdr.cpp:3419
 msgid "Preferences Settings Window"
 msgstr "Tulajdonságok beállításának ablaka"
 
-#: src/amuleDlg.cpp:1854 src/muuli_wdr.cpp:3448
+#: src/amuleDlg.cpp:1766 src/muuli_wdr.cpp:3420
 msgid "Import"
 msgstr "Importálás"
 
-#: src/amuleDlg.cpp:1858 src/muuli_wdr.cpp:3448
+#: src/amuleDlg.cpp:1770 src/muuli_wdr.cpp:3420
 msgid "The partfile importer tool"
 msgstr "A részfájl importáló eszköz"
 
-#: src/amuleDlg.cpp:1861 src/muuli_wdr.cpp:3449
+#: src/amuleDlg.cpp:1773 src/muuli_wdr.cpp:3421
 #: src/utils/aLinkCreator/src/alcframe.cpp:262
 msgid "About"
 msgstr "Névjegy"
 
-#: src/amuleDlg.cpp:1861 src/muuli_wdr.cpp:3449
+#: src/amuleDlg.cpp:1773 src/muuli_wdr.cpp:3421
 msgid "About/Help"
 msgstr "Névjegy/Súgó"
 
-#: src/amuleDlg.cpp:2059
+#: src/amuleDlg.cpp:1971
 msgid "eD2k network"
 msgstr "eD2k hálózat"
 
-#: src/amuleDlg.cpp:2062
+#: src/amuleDlg.cpp:1974
 msgid "Kad network"
 msgstr "Kad hálózat"
 
-#: src/amuleDlg.cpp:2062
+#: src/amuleDlg.cpp:1974
 msgid "No network"
 msgstr "Nincs hálózat"
 
@@ -956,7 +951,7 @@ msgstr "Fájl nem található."
 msgid "The core rejected these shared folders:%s"
 msgstr ""
 
-#: src/amule-remote-gui.cpp:1336 src/ExternalConn.cpp:2346
+#: src/amule-remote-gui.cpp:1336 src/ExternalConn.cpp:2345
 msgid "Invalid link or already on list."
 msgstr "Érvénytelen hivatkozás, vagy már rajta van a listán."
 
@@ -972,7 +967,7 @@ msgstr "A '%s' könyvtár létrehozása a '%s' kategóriához nem lehetséges, a
 #: src/ClientDetailDialog.cpp:123 src/DataToText.cpp:61 src/DataToText.cpp:86
 #: src/DataToText.cpp:101 src/DataToText.cpp:136 src/DataToText.cpp:165
 #: src/DownloadListCtrl.cpp:1172 src/DownloadListCtrl.cpp:1185
-#: src/DownloadListCtrl.cpp:1196 src/ExternalConn.cpp:609
+#: src/DownloadListCtrl.cpp:1196 src/ExternalConn.cpp:608
 #: src/FileDetailDialog.cpp:203 src/FileDetailDialog.cpp:235
 #: src/FileDetailDialog.cpp:242 src/GenericClientListCtrl.cpp:1171
 #: src/GenericClientListCtrl.cpp:1182 src/GenericClientListCtrl.cpp:1192
@@ -1354,19 +1349,19 @@ msgstr "Auto [Ma]"
 msgid "Very low"
 msgstr "Nagyon alacsony"
 
-#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:743 src/muuli_wdr.cpp:2303
+#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:743 src/muuli_wdr.cpp:2275
 #: src/ServerListCtrl.cpp:263 src/ServerListCtrl.cpp:456
 #: src/SharedFilesCtrl.cpp:145
 msgid "Low"
 msgstr "Alacsony"
 
-#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:744 src/muuli_wdr.cpp:2304
+#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:744 src/muuli_wdr.cpp:2276
 #: src/ServerListCtrl.cpp:266 src/ServerListCtrl.cpp:457
 #: src/SharedFilesCtrl.cpp:146
 msgid "Normal"
 msgstr "Normál"
 
-#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:745 src/muuli_wdr.cpp:2305
+#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:745 src/muuli_wdr.cpp:2277
 #: src/ServerListCtrl.cpp:269 src/ServerListCtrl.cpp:458
 #: src/SharedFilesCtrl.cpp:147
 msgid "High"
@@ -1458,8 +1453,8 @@ msgstr "Helyi kiszolgáló"
 msgid "Remote Server"
 msgstr "Távoli kiszolgáló"
 
-#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3202
-#: src/SearchDlg.cpp:119 src/TextClient.cpp:911
+#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3174
+#: src/SearchDlg.cpp:111 src/TextClient.cpp:911
 msgid "Kad"
 msgstr "Kad"
 
@@ -1529,7 +1524,7 @@ msgstr "Rész"
 msgid "Size"
 msgstr "Méret"
 
-#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3269
+#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3241
 msgid "Transferred"
 msgstr "Átmásolva"
 
@@ -1587,7 +1582,7 @@ msgstr ""
 "Visszajelzés %s-től (%s):\n"
 "\n"
 
-#: src/DownloadListCtrl.cpp:746 src/muuli_wdr.cpp:2306
+#: src/DownloadListCtrl.cpp:746 src/muuli_wdr.cpp:2278
 #: src/SharedFilesCtrl.cpp:150
 msgid "Auto"
 msgstr "Automatikus"
@@ -1625,7 +1620,7 @@ msgid "Extended Options"
 msgstr "Kibővített beállítások"
 
 #: src/DownloadListCtrl.cpp:770 src/DownloadListCtrl.cpp:822
-#: src/muuli_wdr.cpp:1790
+#: src/muuli_wdr.cpp:1789
 msgid "Preview"
 msgstr "Előnézet"
 
@@ -1798,230 +1793,225 @@ msgstr[0] ""
 msgid "Invalid eD2k link! ERROR: %s"
 msgstr "Érvénytelen eD2k hivatkozás! HIBA: %s"
 
-#: src/ExternalConn.cpp:380
+#: src/ExternalConn.cpp:379
 msgid "Client sent packet after authentication failed."
 msgstr "Kliens csomagot küldött sikertelen hitelesítést követően."
 
-#: src/ExternalConn.cpp:397
+#: src/ExternalConn.cpp:396
 msgid "External connection closed."
 msgstr "Külső kapcsolat lezárva."
 
-#: src/ExternalConn.cpp:474
+#: src/ExternalConn.cpp:473
 msgid "External connections disabled due to empty password!"
 msgstr "A külső kapcsolatok letiltásra kerültek üres jelszó miatt!"
 
-#: src/ExternalConn.cpp:495
+#: src/ExternalConn.cpp:494
 msgid "External connections disabled in config file"
 msgstr "A külső kapcsolatok le vannak tiltva konfig fájlban"
 
-#: src/ExternalConn.cpp:576
+#: src/ExternalConn.cpp:575
 msgid "New external connection accepted"
 msgstr "Új külső kapcsolat elfogadva"
 
-#: src/ExternalConn.cpp:579
+#: src/ExternalConn.cpp:578
 msgid "ERROR: couldn't accept a new external connection"
 msgstr "HIBA: nem tudtam fogadni egy új külső kapcsolatot"
 
-#: src/ExternalConn.cpp:596
+#: src/ExternalConn.cpp:595
 msgid "External connection refused due to empty password in preferences!"
 msgstr "Külső kapcsolat elutasítva, üres jelszó a beállításokban!"
 
-#: src/ExternalConn.cpp:608
+#: src/ExternalConn.cpp:607
 #, c-format
 msgid "Connecting client: %s %s"
 msgstr "Kapcsolódó kliens: %s %s"
 
-#: src/ExternalConn.cpp:610
+#: src/ExternalConn.cpp:609
 msgid "Unknown version"
 msgstr "Ismeretlen verzió"
 
-#: src/ExternalConn.cpp:623
+#: src/ExternalConn.cpp:622
 msgid "Incorrect EC version ID, there might be binary incompatibility. Use core and remote from same snapshot."
 msgstr "Helytelen EC verzió azonosító, összeférhetetlenség lehetséges. A fő- és a távoli programot ugyanabból a pillanatképből használd."
 
-#: src/ExternalConn.cpp:631
+#: src/ExternalConn.cpp:630
 msgid "You cannot connect to a release version from an arbitrary development snapshot! *sigh* possible crash prevented"
 msgstr "Nem kapcsolódhatsz egy kiadott verzióhoz egy tetszőleges fejlesztés alatti verzióval! *sóhaj* lehetséges összeomlás megelőzve"
 
-#: src/ExternalConn.cpp:714
+#: src/ExternalConn.cpp:713
 msgid "Invalid protocol version."
 msgstr "Érvénytelen protokoll verzió."
 
-#: src/ExternalConn.cpp:720
+#: src/ExternalConn.cpp:719
 msgid "Missing protocol version tag."
 msgstr "Hiányzó protokoll verzió azonosító."
 
-#: src/ExternalConn.cpp:728
+#: src/ExternalConn.cpp:727
 msgid "Authentication failed: invalid hash specified as EC password."
 msgstr "Hitelesítés sikertelen: az EC jelszóként megadott hash érvénytelen."
 
-#: src/ExternalConn.cpp:776
+#: src/ExternalConn.cpp:775
 msgid "Authentication failed: wrong password."
 msgstr "Hitelesítés sikertelen: rossz jelszó."
 
-#: src/ExternalConn.cpp:778
+#: src/ExternalConn.cpp:777
 msgid "Authentication failed: missing password."
 msgstr "Hitelesítés sikertelen: hiányzó jelszó."
 
-#: src/ExternalConn.cpp:789
+#: src/ExternalConn.cpp:788
 msgid "Invalid request, please authenticate first."
 msgstr "Érvénytelen kérés, először hitelesíteni kell."
 
-#: src/ExternalConn.cpp:794
+#: src/ExternalConn.cpp:793
 msgid "Access granted."
 msgstr "Hozzáférés elfogadva."
 
-#: src/ExternalConn.cpp:802
+#: src/ExternalConn.cpp:801
 #, c-format
 msgid "Sent error message \"%s\" to client."
 msgstr "Hibaüzenet elküldve a \"%s\" klienshez."
 
-#: src/ExternalConn.cpp:807
+#: src/ExternalConn.cpp:806
 #, c-format
 msgid "Unauthorized access attempt from %s. Connection closed."
 msgstr "Jogosulatlan hozzáférési kísérlet %s részéről. Kapcsolat lezárva."
 
-#: src/ExternalConn.cpp:1420
+#: src/ExternalConn.cpp:1419
 #, c-format
 msgid "Remote PartFile command failed: FileHash not found: %s"
 msgstr "Távoli PartFile parancs sikertelen: nem található FileHash: %s"
 
-#: src/ExternalConn.cpp:1424
+#: src/ExternalConn.cpp:1423
 #, c-format
 msgid "FileHash not found: %s"
 msgstr "FileHash nem található: %s"
 
-#: src/ExternalConn.cpp:1471 src/ExternalConn.cpp:1559
-#: src/ExternalConn.cpp:1680
+#: src/ExternalConn.cpp:1470 src/ExternalConn.cpp:1558
+#: src/ExternalConn.cpp:1679
 msgid "OOPS! OpCode processing error!"
 msgstr "Hoppá! Opkód feldolgozási hiba!"
 
-#: src/ExternalConn.cpp:1502
+#: src/ExternalConn.cpp:1501
 msgid "Server not added"
 msgstr "Kiszolgáló nem lett hozzáadva"
 
-#: src/ExternalConn.cpp:1521
+#: src/ExternalConn.cpp:1520
 #, c-format
 msgid "server not found: %s"
 msgstr "kiszolgáló nem található: %s"
 
-#: src/ExternalConn.cpp:1538
+#: src/ExternalConn.cpp:1537
 msgid "need to define server to be removed"
 msgstr "ki kell jelölnöd a kiszolgálót az eltávolításhoz"
 
-#: src/ExternalConn.cpp:1553
+#: src/ExternalConn.cpp:1552
 msgid "eD2k is disabled in preferences."
 msgstr "Az eD2k le van tiltva a beállításokban."
 
-#: src/ExternalConn.cpp:1658
+#: src/ExternalConn.cpp:1657
 msgid "Friend not found."
 msgstr "Barát nem található."
 
-#: src/ExternalConn.cpp:1668
+#: src/ExternalConn.cpp:1667
 msgid "Client not found."
 msgstr "Kliens nem található."
 
-#: src/ExternalConn.cpp:1674
+#: src/ExternalConn.cpp:1673
 msgid "EC_TAG_FRIEND_SHARED requires EC_TAG_FRIEND or EC_TAG_CLIENT."
 msgstr "EC_TAG_FRIEND_SHARED igényel EC_TAG_FRIEND vagy EC_TAG_CLIENT értéket."
 
-#: src/ExternalConn.cpp:1992
+#: src/ExternalConn.cpp:1991
 msgid "WebSearch from remote interface makes no sense."
 msgstr "Webes keresésnek a távoli felületről nincs értelme."
 
-#: src/ExternalConn.cpp:2027
+#: src/ExternalConn.cpp:2026
 msgid "Search in progress. Refetch results in a moment!"
 msgstr "Keresés folyamatban. Kérdezze le az eredményeket egy rövid idő múlva!"
 
-#: src/ExternalConn.cpp:2266
+#: src/ExternalConn.cpp:2265
 msgid "No points for graph."
 msgstr "Nincsenek pontok a grafikonhoz."
 
-#: src/ExternalConn.cpp:2276
+#: src/ExternalConn.cpp:2275
 msgid "Your client is not configured for this detail level."
 msgstr "A kliensed nincs beállítva ehhez a részletességi szinthez."
 
-#: src/ExternalConn.cpp:2303
+#: src/ExternalConn.cpp:2302
 msgid "External Connection: shutdown requested"
 msgstr "Külső kapcsolat: leállítás kérve"
 
-#: src/ExternalConn.cpp:2315
+#: src/ExternalConn.cpp:2314
 msgid "Already shutting down."
 msgstr "Kikapcsolás folyamatban."
 
-#: src/ExternalConn.cpp:2333
+#: src/ExternalConn.cpp:2332
 #, c-format
 msgid "ExternalConn: adding link '%s'."
 msgstr "ExternalConn: hivatkozás hozzáadása: '%s'."
 
-#: src/ExternalConn.cpp:2351
+#: src/ExternalConn.cpp:2350
 #, c-format
 msgid "%d of %d links failed (invalid or already on list)."
 msgstr "%d link %d linkből sikertelen (érvénytelen vagy már a listán van)."
 
-#: src/ExternalConn.cpp:2374
+#: src/ExternalConn.cpp:2373
 msgid "Version check throttled; try again shortly."
 msgstr ""
 
-#: src/ExternalConn.cpp:2379
+#: src/ExternalConn.cpp:2378
 msgid "Version check is not available on this daemon."
 msgstr ""
 
-#: src/ExternalConn.cpp:2509
+#: src/ExternalConn.cpp:2508
 msgid "File not found."
 msgstr "Fájl nem található."
 
-#: src/ExternalConn.cpp:2514
+#: src/ExternalConn.cpp:2513
 msgid "Invalid file name."
 msgstr "Érvénytelen fájl név."
 
-#: src/ExternalConn.cpp:2522
+#: src/ExternalConn.cpp:2521
 msgid "Unable to rename file."
 msgstr "Nem tudom átnevezni a fájlt."
 
-#: src/ExternalConn.cpp:2839
-#, c-format
-msgid "Could not save the amuleapi password: %s"
-msgstr ""
-
-#: src/ExternalConn.cpp:3004 src/ExternalConn.cpp:3032
+#: src/ExternalConn.cpp:2992 src/ExternalConn.cpp:3020
 msgid "Kad is disabled in preferences."
 msgstr "A Kad le van tiltva a beállításokban."
 
-#: src/ExternalConn.cpp:3045
+#: src/ExternalConn.cpp:3033
 msgid "Already connected to eD2k."
 msgstr "Már csatlakozva az eD2k-hoz."
 
-#: src/ExternalConn.cpp:3048
+#: src/ExternalConn.cpp:3036
 msgid "Connecting to eD2k..."
 msgstr "Kapcsolódás az eD2k-hoz..."
 
-#: src/ExternalConn.cpp:3057
+#: src/ExternalConn.cpp:3045
 msgid "Already connected to Kad."
 msgstr "Már kapcsolódva a Kad-hoz."
 
-#: src/ExternalConn.cpp:3060
+#: src/ExternalConn.cpp:3048
 msgid "Connecting to Kad..."
 msgstr "Kapcsolódás a Kad-hoz..."
 
-#: src/ExternalConn.cpp:3067
+#: src/ExternalConn.cpp:3055
 msgid "All networks are disabled."
 msgstr "Minden hálózat le van tiltva."
 
-#: src/ExternalConn.cpp:3076
+#: src/ExternalConn.cpp:3064
 msgid "Disconnected from eD2k."
 msgstr "Leválasztva az eD2k-ról."
 
-#: src/ExternalConn.cpp:3081
+#: src/ExternalConn.cpp:3069
 msgid "Disconnected from Kad."
 msgstr "Leválasztva a Kad-ról."
 
-#: src/ExternalConn.cpp:3090
+#: src/ExternalConn.cpp:3078
 #, c-format
 msgid "External Connection: invalid opcode received: %#x"
 msgstr "Külső kapcsolat: érvénytelen opcode: %#x"
 
-#: src/ExternalConn.cpp:3095
+#: src/ExternalConn.cpp:3083
 msgid "Invalid opcode (wrong protocol version?)"
 msgstr "Érvénytelen opcode (rossz protokoll verzió?)"
 
@@ -2337,19 +2327,19 @@ msgstr ""
 msgid "eD2k"
 msgstr "eD2k"
 
-#: src/FirstRunWizard.cpp:349 src/muuli_wdr.cpp:1495
+#: src/FirstRunWizard.cpp:349 src/muuli_wdr.cpp:1488
 msgid "Kademlia"
 msgstr "Kademlia"
 
-#: src/FirstRunWizard.cpp:359 src/muuli_wdr.cpp:1423
+#: src/FirstRunWizard.cpp:359 src/muuli_wdr.cpp:1416
 msgid "Standard TCP Port "
 msgstr "Szabvány TCP port "
 
-#: src/FirstRunWizard.cpp:365 src/muuli_wdr.cpp:1435
+#: src/FirstRunWizard.cpp:365 src/muuli_wdr.cpp:1428
 msgid "Extended UDP port (Kad / global search) "
 msgstr "Bővített UDP port (Kad / globális keresés) "
 
-#: src/FirstRunWizard.cpp:377 src/muuli_wdr.cpp:1442
+#: src/FirstRunWizard.cpp:377 src/muuli_wdr.cpp:1435
 msgid "Enable UPnP for router port forwarding"
 msgstr "UPnP engedélyezése a router port továbbításhoz"
 
@@ -2376,7 +2366,7 @@ msgstr ""
 msgid "Your peer lists are already in place - nothing to download."
 msgstr "Már próbálod letölteni a(z) '%s' fájlt."
 
-#: src/FirstRunWizard.cpp:434 src/muuli_wdr.cpp:1540
+#: src/FirstRunWizard.cpp:434 src/muuli_wdr.cpp:1533
 msgid "Auto-update server list at startup"
 msgstr "Kiszolgáló lista automatikus frissítése indításkor"
 
@@ -2422,23 +2412,23 @@ msgid ""
 "want downloads on a different (e.g. larger) disk."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:549 src/FirstRunWizard.cpp:611 src/muuli_wdr.cpp:1702
+#: src/FirstRunWizard.cpp:549 src/FirstRunWizard.cpp:611 src/muuli_wdr.cpp:1701
 msgid "Destination folder for downloads"
 msgstr "Célkönyvtár a letöltéseknek"
 
-#: src/FirstRunWizard.cpp:553 src/FirstRunWizard.cpp:569 src/muuli_wdr.cpp:1349
-#: src/muuli_wdr.cpp:1366 src/muuli_wdr.cpp:1677 src/muuli_wdr.cpp:1708
-#: src/muuli_wdr.cpp:1720 src/muuli_wdr.cpp:2790
+#: src/FirstRunWizard.cpp:553 src/FirstRunWizard.cpp:569 src/muuli_wdr.cpp:1342
+#: src/muuli_wdr.cpp:1359 src/muuli_wdr.cpp:1676 src/muuli_wdr.cpp:1707
+#: src/muuli_wdr.cpp:1719 src/muuli_wdr.cpp:2762
 #: src/utils/aLinkCreator/src/alcframe.cpp:135
 #: src/utils/wxCas/src/wxcasprefs.cpp:52 src/utils/wxCas/src/wxcasprefs.cpp:118
 msgid "Browse"
 msgstr "Tallóz"
 
-#: src/FirstRunWizard.cpp:559 src/muuli_wdr.cpp:1713
+#: src/FirstRunWizard.cpp:559 src/muuli_wdr.cpp:1712
 msgid "(All files in this folder are shared with other peers)"
 msgstr "(Minden fájl ebben a könyvtárban másokkal megosztásra kerül)"
 
-#: src/FirstRunWizard.cpp:565 src/FirstRunWizard.cpp:624 src/muuli_wdr.cpp:1715
+#: src/FirstRunWizard.cpp:565 src/FirstRunWizard.cpp:624 src/muuli_wdr.cpp:1714
 msgid "Folder for temporary download files"
 msgstr "Könyvtár az ideiglenes letöltési fájloknak"
 
@@ -2469,7 +2459,7 @@ msgstr "A barátokat tartalmazó emfriends.dat fájl írásra megnyitása sikert
 msgid "CRITICAL - no client on StartChatSession"
 msgstr "KRITIKUS - nincsen kliens a StartChatSession-en"
 
-#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2696 src/muuli_wdr.cpp:3373
+#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2668 src/muuli_wdr.cpp:3345
 msgid "Friends"
 msgstr "Barátok"
 
@@ -2579,8 +2569,8 @@ msgstr "Egyik sem"
 msgid "No"
 msgstr "Nem"
 
-#: src/GenericClientListCtrl.cpp:1216 src/PrefsUnifiedDlg.cpp:2898
-#: src/PrefsUnifiedDlg.cpp:2948 src/ServerListCtrl.cpp:276
+#: src/GenericClientListCtrl.cpp:1216 src/PrefsUnifiedDlg.cpp:2818
+#: src/PrefsUnifiedDlg.cpp:2868 src/ServerListCtrl.cpp:276
 msgid "Yes"
 msgstr "Igen"
 
@@ -2747,10 +2737,10 @@ msgstr "Érvénytelen port a rendszerindításhoz"
 msgid "Please fill all fields required"
 msgstr "Kérlek töltsd ki az összes kötelező mezőt"
 
-#: src/KadDlg.cpp:192 src/PartFile.cpp:1031 src/PrefsUnifiedDlg.cpp:1134
-#: src/PrefsUnifiedDlg.cpp:1204 src/PrefsUnifiedDlg.cpp:1405
-#: src/PrefsUnifiedDlg.cpp:1663 src/PrefsUnifiedDlg.cpp:1673
-#: src/PrefsUnifiedDlg.cpp:1690 src/PrefsUnifiedDlg.cpp:1738
+#: src/KadDlg.cpp:192 src/PartFile.cpp:1031 src/PrefsUnifiedDlg.cpp:1162
+#: src/PrefsUnifiedDlg.cpp:1331 src/PrefsUnifiedDlg.cpp:1589
+#: src/PrefsUnifiedDlg.cpp:1599 src/PrefsUnifiedDlg.cpp:1616
+#: src/PrefsUnifiedDlg.cpp:1658
 msgid "Message"
 msgstr "Üzenet"
 
@@ -2849,7 +2839,7 @@ msgstr "Megosztási arány"
 msgid "Uploaded"
 msgstr "Feltöltve"
 
-#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3253
+#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3225
 msgid "Requested"
 msgstr "Kért"
 
@@ -2973,7 +2963,7 @@ msgid "WARNING: "
 msgstr "FIGYELEM: "
 
 #: src/MuleNotebook.cpp:179 src/muuli_wdr.cpp:817 src/muuli_wdr.cpp:1229
-#: src/muuli_wdr.cpp:3157 src/muuli_wdr.cpp:3413
+#: src/muuli_wdr.cpp:3129 src/muuli_wdr.cpp:3385
 msgid "Close"
 msgstr "Bezár"
 
@@ -2986,12 +2976,12 @@ msgstr "Kivágás"
 msgid "Copy"
 msgstr "Másolás"
 
-#: src/MuleTextCtrl.cpp:88 src/SearchDlg.cpp:261
+#: src/MuleTextCtrl.cpp:88
 msgid "Paste"
 msgstr "Beillesztés"
 
 #: src/MuleTextCtrl.cpp:89 src/muuli_wdr.cpp:358 src/muuli_wdr.cpp:757
-#: src/muuli_wdr.cpp:2380 src/muuli_wdr.cpp:2399 src/muuli_wdr.cpp:2421
+#: src/muuli_wdr.cpp:2352 src/muuli_wdr.cpp:2371 src/muuli_wdr.cpp:2393
 #: src/utils/aLinkCreator/src/alcframe.cpp:142
 msgid "Clear"
 msgstr "Törlés"
@@ -3082,8 +3072,8 @@ msgid "Exit"
 msgstr "Kilépés"
 
 #: src/MuleTrayIcon.cpp:579 src/MuleTrayIcon.cpp:945 src/MuleTrayIcon.cpp:965
-#: src/muuli_wdr.cpp:1398 src/muuli_wdr.cpp:1406 src/muuli_wdr.cpp:1413
-#: src/muuli_wdr.cpp:1836 src/muuli_wdr.cpp:1842 src/OtherFunctions.cpp:91
+#: src/muuli_wdr.cpp:1391 src/muuli_wdr.cpp:1399 src/muuli_wdr.cpp:1406
+#: src/muuli_wdr.cpp:1835 src/muuli_wdr.cpp:1841 src/OtherFunctions.cpp:91
 #: src/StatisticsDlg.cpp:93 src/StatisticsDlg.cpp:95
 msgid "kB/s"
 msgstr "kB/s"
@@ -3254,7 +3244,7 @@ msgstr "Név:"
 msgid "Type"
 msgstr "Típus"
 
-#: src/muuli_wdr.cpp:215 src/SearchDlg.cpp:118 src/SearchListCtrl.cpp:853
+#: src/muuli_wdr.cpp:215 src/SearchDlg.cpp:110 src/SearchListCtrl.cpp:853
 msgid "Local"
 msgstr "Helyi"
 
@@ -3325,7 +3315,7 @@ msgstr "bájt"
 msgid "KB"
 msgstr "KB"
 
-#: src/muuli_wdr.cpp:274 src/muuli_wdr.cpp:293 src/muuli_wdr.cpp:1621
+#: src/muuli_wdr.cpp:274 src/muuli_wdr.cpp:293 src/muuli_wdr.cpp:1620
 #: src/OtherFunctions.cpp:64
 msgid "MB"
 msgstr "MB"
@@ -3342,7 +3332,7 @@ msgstr "Max. méret"
 msgid "Availability"
 msgstr "Elérhetőség"
 
-#: src/muuli_wdr.cpp:312 src/muuli_wdr.cpp:398 src/muuli_wdr.cpp:3318
+#: src/muuli_wdr.cpp:312 src/muuli_wdr.cpp:398 src/muuli_wdr.cpp:3290
 msgid "Filter:"
 msgstr "Szűrő:"
 
@@ -3374,7 +3364,7 @@ msgstr "Kérje meg a már válaszolt Kad partnereket, hogy szélesítsék a kere
 msgid "Stop"
 msgstr "Leállít"
 
-#: src/muuli_wdr.cpp:348 src/muuli_wdr.cpp:1392 src/SearchListCtrl.cpp:732
+#: src/muuli_wdr.cpp:348 src/muuli_wdr.cpp:1385 src/SearchListCtrl.cpp:732
 msgid "Download"
 msgstr "Letöltés"
 
@@ -3405,12 +3395,12 @@ msgstr "Fájl források:"
 #: src/muuli_wdr.cpp:1160 src/muuli_wdr.cpp:1167 src/muuli_wdr.cpp:1172
 #: src/muuli_wdr.cpp:1179 src/muuli_wdr.cpp:1184 src/muuli_wdr.cpp:1191
 #: src/muuli_wdr.cpp:1205 src/muuli_wdr.cpp:1212 src/muuli_wdr.cpp:1217
-#: src/muuli_wdr.cpp:1224 src/muuli_wdr.cpp:3255 src/muuli_wdr.cpp:3263
-#: src/muuli_wdr.cpp:3271
+#: src/muuli_wdr.cpp:1224 src/muuli_wdr.cpp:3227 src/muuli_wdr.cpp:3235
+#: src/muuli_wdr.cpp:3243
 msgid "N/A"
 msgstr "N/A"
 
-#: src/muuli_wdr.cpp:508 src/muuli_wdr.cpp:1065 src/PrefsUnifiedDlg.cpp:299
+#: src/muuli_wdr.cpp:508 src/muuli_wdr.cpp:1065 src/PrefsUnifiedDlg.cpp:297
 msgid "General"
 msgstr "Általános"
 
@@ -3551,7 +3541,7 @@ msgstr ""
 msgid "Album :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:685 src/muuli_wdr.cpp:2275
+#: src/muuli_wdr.cpp:685 src/muuli_wdr.cpp:2247
 msgid "Title :"
 msgstr "Cím :"
 
@@ -3660,7 +3650,7 @@ msgstr "User név :"
 msgid "Userhash :"
 msgstr "Userhash :"
 
-#: src/muuli_wdr.cpp:895 src/muuli_wdr.cpp:1742 src/muuli_wdr.cpp:2470
+#: src/muuli_wdr.cpp:895 src/muuli_wdr.cpp:1741 src/muuli_wdr.cpp:2442
 #: src/utils/aLinkCreator/src/alcframe.cpp:137
 msgid "Add"
 msgstr "Hozzáad"
@@ -3669,15 +3659,15 @@ msgstr "Hozzáad"
 msgid "Download-Speed"
 msgstr "Letöltési sebesség"
 
-#: src/muuli_wdr.cpp:954 src/muuli_wdr.cpp:989 src/muuli_wdr.cpp:2574
+#: src/muuli_wdr.cpp:954 src/muuli_wdr.cpp:989 src/muuli_wdr.cpp:2546
 msgid "Current"
 msgstr "Aktuális"
 
-#: src/muuli_wdr.cpp:962 src/muuli_wdr.cpp:997 src/muuli_wdr.cpp:2582
+#: src/muuli_wdr.cpp:962 src/muuli_wdr.cpp:997 src/muuli_wdr.cpp:2554
 msgid "Running average"
 msgstr "Futásátlag"
 
-#: src/muuli_wdr.cpp:970 src/muuli_wdr.cpp:1005 src/muuli_wdr.cpp:2590
+#: src/muuli_wdr.cpp:970 src/muuli_wdr.cpp:1005 src/muuli_wdr.cpp:2562
 msgid "Session average"
 msgstr "Munkafolyamatok átlaga"
 
@@ -3689,7 +3679,7 @@ msgstr "Feltöltési sebesség"
 msgid "Connections"
 msgstr "Kapcsolatok"
 
-#: src/muuli_wdr.cpp:1024 src/muuli_wdr.cpp:1861
+#: src/muuli_wdr.cpp:1024 src/muuli_wdr.cpp:1860
 msgid "Active downloads"
 msgstr "Aktív letöltések"
 
@@ -3697,7 +3687,7 @@ msgstr "Aktív letöltések"
 msgid "Active connections (1:1)"
 msgstr "Aktív kapcsolatok (1:1)"
 
-#: src/muuli_wdr.cpp:1040 src/muuli_wdr.cpp:1862
+#: src/muuli_wdr.cpp:1040 src/muuli_wdr.cpp:1861
 msgid "Active uploads"
 msgstr "Aktív feltöltések"
 
@@ -3813,8 +3803,8 @@ msgstr "Ezt a nevet fogja a többi felhasználó látni, amikor kapcsolódnak ho
 msgid "Language: "
 msgstr "Nyelv: "
 
-#: src/muuli_wdr.cpp:1257 src/muuli_wdr.cpp:1330 src/muuli_wdr.cpp:1334
-#: src/muuli_wdr.cpp:1337
+#: src/muuli_wdr.cpp:1257 src/muuli_wdr.cpp:1323 src/muuli_wdr.cpp:1327
+#: src/muuli_wdr.cpp:1330
 msgid "The delay before showing tool-tips."
 msgstr "Késleltetés a tool-tippek előtt."
 
@@ -3892,261 +3882,260 @@ msgstr "Értesítések megjelenítése a letöltés befejezésekor"
 msgid "Enabling this will make aMule to show notifications when finished downloading."
 msgstr "Ezt engedélyezve az aMule értesítéseket fog megjeleníteni a befejezett letöltésekről."
 
-#: src/muuli_wdr.cpp:1323
-#, fuzzy
-msgid "Remember search history"
-msgstr "Emlékezzen ezekre a beállításokra"
-
-#: src/muuli_wdr.cpp:1324
-msgid "Keeps a dropdown list of your past search terms in the Search tab's Name field. This remembers the queries you typed, not the results they returned."
-msgstr ""
-
-#: src/muuli_wdr.cpp:1329
+#: src/muuli_wdr.cpp:1322
 msgid "Tooltip delay time: "
 msgstr "Szóbuborék késési idő: "
 
-#: src/muuli_wdr.cpp:1336
+#: src/muuli_wdr.cpp:1329
 msgid "seconds"
 msgstr "másodperc"
 
-#: src/muuli_wdr.cpp:1340
+#: src/muuli_wdr.cpp:1333
 msgid "Browser Selection"
 msgstr "Böngésző kiválasztása"
 
-#: src/muuli_wdr.cpp:1346
+#: src/muuli_wdr.cpp:1339
 msgid "Enter your browser name here. Leave this field empty to use the system default browser."
 msgstr "Írd ide a böngésződ nevét. Hagyd üresen, hogy a rendszer alapértelmezett böngészőjéhez."
 
-#: src/muuli_wdr.cpp:1353
+#: src/muuli_wdr.cpp:1346
 msgid "Open in new tab if possible"
 msgstr "Megnyitás új fülön, ha lehetséges"
 
-#: src/muuli_wdr.cpp:1355
+#: src/muuli_wdr.cpp:1348
 msgid "Open the web page in a new tab instead of in a new window when possible"
 msgstr "Weboldal megnyitása új fülön új ablak helyett, ha lehetséges"
 
-#: src/muuli_wdr.cpp:1359
+#: src/muuli_wdr.cpp:1352
 msgid "Video Player"
 msgstr "Videólejátszó"
 
-#: src/muuli_wdr.cpp:1386
+#: src/muuli_wdr.cpp:1379
 msgid "Bandwidth limits"
 msgstr "Sávszélesség korlátok"
 
-#: src/muuli_wdr.cpp:1400
+#: src/muuli_wdr.cpp:1393
 msgid "Upload"
 msgstr "Feltöltés"
 
-#: src/muuli_wdr.cpp:1408
+#: src/muuli_wdr.cpp:1401
 msgid "Slot Allocation"
 msgstr "Slot kiosztás"
 
-#: src/muuli_wdr.cpp:1417
+#: src/muuli_wdr.cpp:1410
 msgid "Ports"
 msgstr "Portok"
 
-#: src/muuli_wdr.cpp:1427
+#: src/muuli_wdr.cpp:1420
 msgid "This is the standard eD2k port and cannot be disabled."
 msgstr "Ez a szabvány eD2k port és nem lehet letiltani."
 
-#: src/muuli_wdr.cpp:1430
+#: src/muuli_wdr.cpp:1423
 msgid "UDP port for server requests (TCP+3):"
 msgstr "UDP port a kiszolgáló kérésekhez (TCP+3):"
 
-#: src/muuli_wdr.cpp:1432
+#: src/muuli_wdr.cpp:1425
 msgid "4665"
 msgstr "4665"
 
-#: src/muuli_wdr.cpp:1439
+#: src/muuli_wdr.cpp:1432
 msgid "This UDP port is used for extended eD2k requests and Kad network"
 msgstr "Ezt az UDP portot a bővített eD2k kérések és a Kad hálózat használja"
 
-#: src/muuli_wdr.cpp:1446
+#: src/muuli_wdr.cpp:1439
 msgid "UPnP TCP Port (Optional):"
 msgstr "UPnP TCP port (nem kötelező):"
 
-#: src/muuli_wdr.cpp:1456
+#: src/muuli_wdr.cpp:1449
 msgid "Bind local address to IP (empty for any):"
 msgstr "Lokális cím IP-hez csatolása (mindet ha üres):"
 
-#: src/muuli_wdr.cpp:1459
+#: src/muuli_wdr.cpp:1452
 msgid "Advanced users only: If you have multiple network interfaces, enter the address of the interface to which aMule should be bound."
 msgstr "Csak haladó felhasználóknak: Ha több hálózati kártyád van, írd ide a címet, amelyhez az aMule kötve legyen."
 
-#: src/muuli_wdr.cpp:1462 src/muuli_wdr.cpp:2055
+#: src/muuli_wdr.cpp:1455 src/muuli_wdr.cpp:2054
 #, fuzzy
 msgid "Bind to network interface (empty for any):"
 msgstr "Lokális cím IP-hez csatolása (mindet ha üres):"
 
-#: src/muuli_wdr.cpp:1475
+#: src/muuli_wdr.cpp:1468
 msgid "Advanced users only: pin all of aMule's traffic to one network interface, chosen from the list or typed in by name (e.g. tun0, eth0, en0) or index. Unlike binding to an IP, this stops traffic leaking out via the default route - useful with a VPN. Requires no elevated privileges."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1481
+#: src/muuli_wdr.cpp:1474
 msgid "Max sources per downloading file:"
 msgstr "Max források letöltési fájlonként:"
 
-#: src/muuli_wdr.cpp:1485
+#: src/muuli_wdr.cpp:1478
 msgid "Max simultaneous connections:"
 msgstr "Max egyidejű kapcsolatok:"
 
-#: src/muuli_wdr.cpp:1498 src/muuli_wdr.cpp:3197
+#: src/muuli_wdr.cpp:1491 src/muuli_wdr.cpp:3169
 msgid "ED2K"
 msgstr "ED2K"
 
-#: src/muuli_wdr.cpp:1505
+#: src/muuli_wdr.cpp:1498
 msgid "Autoconnect on startup"
 msgstr "Automatikus kapcsolódás induláskor"
 
-#: src/muuli_wdr.cpp:1508
+#: src/muuli_wdr.cpp:1501
 msgid "Reconnect on loss"
 msgstr "Kapcsolódás megismétlése megszakadt kapcsolat esetén"
 
-#: src/muuli_wdr.cpp:1530
+#: src/muuli_wdr.cpp:1523
 msgid "Remove dead server after"
 msgstr "Halott kiszolgálók eltávolítása"
 
-#: src/muuli_wdr.cpp:1531
+#: src/muuli_wdr.cpp:1524
 msgid "Static servers are never removed, even when unreachable."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1535
+#: src/muuli_wdr.cpp:1528
 msgid "retries"
 msgstr "próbálkozás után"
 
-#: src/muuli_wdr.cpp:1543
+#: src/muuli_wdr.cpp:1536
 msgid "List"
 msgstr "Lista"
 
-#: src/muuli_wdr.cpp:1546
+#: src/muuli_wdr.cpp:1539
 msgid "Update server list when connecting to a server"
 msgstr "Kiszolgáló lista frissítése kiszolgálóhoz való kapcsolódáskor"
 
-#: src/muuli_wdr.cpp:1549
+#: src/muuli_wdr.cpp:1542
 msgid "Update server list when a client connects"
 msgstr "Kiszolgáló lista frissítése amikor egy ügyfél kapcsolódik"
 
-#: src/muuli_wdr.cpp:1552
+#: src/muuli_wdr.cpp:1545
 msgid "Use priority system"
 msgstr "Prioritási rendszer használata"
 
-#: src/muuli_wdr.cpp:1556
+#: src/muuli_wdr.cpp:1549
 msgid "Use smart LowID check on connect"
 msgstr "Intelligens LowID ellenőrzés használata kapcsolódáskor"
 
-#: src/muuli_wdr.cpp:1560
+#: src/muuli_wdr.cpp:1553
 msgid "Safe connect"
 msgstr "Biztonságos kapcsolódás"
 
-#: src/muuli_wdr.cpp:1564
+#: src/muuli_wdr.cpp:1557
 msgid "Autoconnect to servers in static list only"
 msgstr "Automatikus kapcsolódás kizárólag az állandó kiszolgálókhoz"
 
-#: src/muuli_wdr.cpp:1567
+#: src/muuli_wdr.cpp:1560
 msgid "Set manually added servers to High Priority"
 msgstr "A kézileg hozzáadott kiszolgálók Magas Prioritással történő felvétele"
 
-#: src/muuli_wdr.cpp:1588
+#: src/muuli_wdr.cpp:1581
 msgid "Add files to download in pause mode"
 msgstr "Fájlok felvétele szüneteltetett módban"
 
-#: src/muuli_wdr.cpp:1590
+#: src/muuli_wdr.cpp:1583
 msgid "Add files to download with auto priority"
 msgstr "Új letöltések felvétele automatikus prioritással"
 
-#: src/muuli_wdr.cpp:1593
+#: src/muuli_wdr.cpp:1586
 msgid "Try to download first and last chunks first"
 msgstr "Előszőr az első és utolsó adatelemet próbálja meg letölteni"
 
-#: src/muuli_wdr.cpp:1597
+#: src/muuli_wdr.cpp:1590
 msgid "Endgame mode: rotate to faster sources for the final blocks"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1600
+#: src/muuli_wdr.cpp:1593
 msgid "Start next paused file when a file completes"
 msgstr "Következő szüneteltetett fájl indítása amikor egy letöltés befejeződik"
 
-#: src/muuli_wdr.cpp:1603
+#: src/muuli_wdr.cpp:1596
 msgid "From the same category"
 msgstr "Ugyanabból a kategóriából"
 
-#: src/muuli_wdr.cpp:1605
+#: src/muuli_wdr.cpp:1598
 msgid "In alphabetic order"
 msgstr "Betűrendi sorrendben"
 
-#: src/muuli_wdr.cpp:1607
+#: src/muuli_wdr.cpp:1600
 msgid "Preallocate disk space for new files"
 msgstr "Lemezterület helyfogalalás az új fájloknak"
 
-#: src/muuli_wdr.cpp:1608
+#: src/muuli_wdr.cpp:1601
 msgid "For new files preallocates disk space for the whole file, thus reduces fragmentation"
 msgstr "Az új fájlok számára előre lefoglalja a lemezterületet, így csökkentve a töredezettséget"
 
-#: src/muuli_wdr.cpp:1613
+#: src/muuli_wdr.cpp:1606
+msgid "Create new files as sparse files"
+msgstr ""
+
+#: src/muuli_wdr.cpp:1607
+msgid "A sparse file reserves its full size on disk immediately without writing real data to it -- fast, but unsupported or slow on some filesystems, and free-space accounting stays optimistic while the download is in progress. Turn this off to grow the file only as data arrives."
+msgstr ""
+
+#: src/muuli_wdr.cpp:1612
 msgid "Stop downloads when free disk space reaches "
 msgstr "Letöltések megállítása amikor a szabad hely kevesebb mint "
 
-#: src/muuli_wdr.cpp:1614
+#: src/muuli_wdr.cpp:1613
 msgid "Select this if you want aMule to check your disk space"
 msgstr "Jelöld be, ha azt szeretnéd, hogy az aMule ellenőrizze a szabad lemezterületet"
 
-#: src/muuli_wdr.cpp:1618
+#: src/muuli_wdr.cpp:1617
 msgid "Enter here the min disk space desired."
 msgstr "Add meg a kívánt min. szabad lemezterületet."
 
-#: src/muuli_wdr.cpp:1624
+#: src/muuli_wdr.cpp:1623
 msgid "Save 10 sources on rare files (< 20 sources)"
 msgstr "Mentsen el 10 forrást ritka fájloknál (< 20 forrás)"
 
-#: src/muuli_wdr.cpp:1628 src/Statistics.cpp:790
+#: src/muuli_wdr.cpp:1627 src/Statistics.cpp:790
 msgid "Uploads"
 msgstr "Feltöltések"
 
-#: src/muuli_wdr.cpp:1631
+#: src/muuli_wdr.cpp:1630
 msgid "Add new shared files with auto priority"
 msgstr "Új megosztott fájl felvétele automatikus prioritással"
 
-#: src/muuli_wdr.cpp:1637
+#: src/muuli_wdr.cpp:1636
 msgid "Intelligent Corruption Handling (I.C.H.)"
 msgstr "Intelligens Sérülés Kezelő (I.S.K.)"
 
-#: src/muuli_wdr.cpp:1640
+#: src/muuli_wdr.cpp:1639
 msgid "Enable"
 msgstr "Engedélyezés"
 
-#: src/muuli_wdr.cpp:1643
+#: src/muuli_wdr.cpp:1642
 msgid "Advanced I.C.H. trusts every hash (not recommended)"
 msgstr "Feljett I.S.K. megbízzon minden hash-ben (nem ajánlott)"
 
-#: src/muuli_wdr.cpp:1655 src/PrefsUnifiedDlg.cpp:1990
+#: src/muuli_wdr.cpp:1654 src/PrefsUnifiedDlg.cpp:1910
 msgid "Media metadata extraction"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1659
+#: src/muuli_wdr.cpp:1658
 msgid "Extract length / bitrate / codec from shared audio and video files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1661
+#: src/muuli_wdr.cpp:1660
 msgid "When enabled, aMule runs ffprobe on each shared media file to fill in the Length / Bitrate / Codec columns other clients see when they find the file in a search. Requires ffmpeg (the ffprobe binary) to be installed."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1668
+#: src/muuli_wdr.cpp:1667
 msgid "Path to ffprobe:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1673
+#: src/muuli_wdr.cpp:1672
 msgid "Full path to the ffprobe binary. Leave empty to have aMule auto-detect it on startup."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1681
+#: src/muuli_wdr.cpp:1680
 msgid "Detect"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1682
+#: src/muuli_wdr.cpp:1681
 msgid "Search the standard install locations for an ffprobe binary and fill the path field."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1706
+#: src/muuli_wdr.cpp:1705
 msgid ""
 "Completed downloads are stored here. All files in this folder are automatically shared with other peers.\n"
 "If this folder also holds files you don't want to share, point it at an aMule-only sub-folder."
@@ -4154,695 +4143,672 @@ msgstr ""
 "Elvégzett letöltések tárolási helye. Minden fájl ebben a könytárban automatikusan megosztásra kerül másokkal.\n"
 "Ha a könyvtár fájlokat tartalmaz, amelyek ne kerüljenek megosztásra, állítsa át egy megfelelő alkönyvtárra."
 
-#: src/muuli_wdr.cpp:1709
+#: src/muuli_wdr.cpp:1708
 msgid "Pick the folder where completed downloads will be stored. All files in that folder will be shared with other peers."
 msgstr "Válassza ki a könyvtárat az elvégzett letöltéseknek. A könyvtár minden fájlja másokkal megosztásra kerül."
 
-#: src/muuli_wdr.cpp:1723
+#: src/muuli_wdr.cpp:1722
 msgid "Shared folders"
 msgstr "Megosztott mappák"
 
-#: src/muuli_wdr.cpp:1729
+#: src/muuli_wdr.cpp:1728
 msgid "(Folders shared by the core. Enter a path to add one.)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1737
+#: src/muuli_wdr.cpp:1736
 msgid "Absolute path of a folder on the core's machine, e.g. /home/user/shared"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1739 src/PrefsUnifiedDlg.cpp:2874
+#: src/muuli_wdr.cpp:1738 src/PrefsUnifiedDlg.cpp:2794
 msgid "Recursive"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1740
+#: src/muuli_wdr.cpp:1739
 msgid "Share every sub-folder underneath this one, including ones created later."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1744 src/utils/aLinkCreator/src/alcframe.cpp:141
+#: src/muuli_wdr.cpp:1743 src/utils/aLinkCreator/src/alcframe.cpp:141
 msgid "Remove"
 msgstr "Eltávolít"
 
-#: src/muuli_wdr.cpp:1748
+#: src/muuli_wdr.cpp:1747
 msgid "(Right click on folder icon for recursive share)"
 msgstr "(Jobb klikk az mappa ikonra az összes alatta levő mappát is megosztja)"
 
-#: src/muuli_wdr.cpp:1755
+#: src/muuli_wdr.cpp:1754
 msgid "Share hidden files"
 msgstr "Rejtett fájlok megosztása"
 
-#: src/muuli_wdr.cpp:1761
+#: src/muuli_wdr.cpp:1760
 msgid "Automatically rescan shared folders for changes"
 msgstr "Megosztott könyvtárak automatikus újraszkennelése"
 
-#: src/muuli_wdr.cpp:1767
+#: src/muuli_wdr.cpp:1766
 msgid "Follow symbolic links in shared folders"
 msgstr "Szimbólikus hivatkozások követése megosztott könyvtárakban"
 
-#: src/muuli_wdr.cpp:1773
+#: src/muuli_wdr.cpp:1772
 msgid "Exclude files matching:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1776
+#: src/muuli_wdr.cpp:1775
 msgid "Wildcard patterns separated by '|', e.g. .DS_Store|Thumbs.db|*.tmp. Files whose name matches are not shared. Matching is case-insensitive."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1780
+#: src/muuli_wdr.cpp:1779
 msgid "Patterns are regular expressions"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1781
+#: src/muuli_wdr.cpp:1780
 msgid "When set, the whole field is one regular expression ('|' is alternation). When unset, it is a list of '|'-separated wildcards."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1791
+#: src/muuli_wdr.cpp:1790
 msgid "Show how many shared files the current pattern would exclude."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1812
+#: src/muuli_wdr.cpp:1811
 msgid "Graphs"
 msgstr "Grafikonok"
 
-#: src/muuli_wdr.cpp:1815 src/muuli_wdr.cpp:1877
+#: src/muuli_wdr.cpp:1814 src/muuli_wdr.cpp:1876
 msgid "Update delay : 5 secs"
 msgstr "Frissítés késleltetés: 5 mp"
 
-#: src/muuli_wdr.cpp:1819
+#: src/muuli_wdr.cpp:1818
 msgid "Time for average graph: 100 mins"
 msgstr "Grafikon átlagos ideje: 100 perc"
 
-#: src/muuli_wdr.cpp:1823
+#: src/muuli_wdr.cpp:1822
 msgid "Connections Graph Scale: 100 "
 msgstr "Kapcsolatok grafikon skálája: 100 "
 
-#: src/muuli_wdr.cpp:1830
+#: src/muuli_wdr.cpp:1829
 msgid "Download graph scale:"
 msgstr "Letöltési grafikon méretaránya:"
 
-#: src/muuli_wdr.cpp:1838
+#: src/muuli_wdr.cpp:1837
 msgid "Upload graph scale:"
 msgstr "Feltöltési grafikon méretaránya:"
 
-#: src/muuli_wdr.cpp:1848
+#: src/muuli_wdr.cpp:1847
 msgid "Colors: "
 msgstr "Színek: "
 
-#: src/muuli_wdr.cpp:1852
+#: src/muuli_wdr.cpp:1851
 msgid "Background"
 msgstr "Háttér"
 
-#: src/muuli_wdr.cpp:1853
+#: src/muuli_wdr.cpp:1852
 msgid "Grid"
 msgstr "Rács"
 
-#: src/muuli_wdr.cpp:1854
+#: src/muuli_wdr.cpp:1853
 msgid "Download current"
 msgstr "Aktuális letöltés"
 
-#: src/muuli_wdr.cpp:1855
+#: src/muuli_wdr.cpp:1854
 msgid "Download running average"
 msgstr "Letöltési futás átlaga"
 
-#: src/muuli_wdr.cpp:1856
+#: src/muuli_wdr.cpp:1855
 msgid "Download session average"
 msgstr "Letöltési folyamatok átlaga"
 
-#: src/muuli_wdr.cpp:1857
+#: src/muuli_wdr.cpp:1856
 msgid "Upload current"
 msgstr "Aktuális feltöltés"
 
-#: src/muuli_wdr.cpp:1858
+#: src/muuli_wdr.cpp:1857
 msgid "Upload running average"
 msgstr "Feltöltési futás átlaga"
 
-#: src/muuli_wdr.cpp:1859
+#: src/muuli_wdr.cpp:1858
 msgid "Upload session average"
 msgstr "Feltöltési folyamatok átlaga"
 
-#: src/muuli_wdr.cpp:1860
+#: src/muuli_wdr.cpp:1859
 msgid "Active connections"
 msgstr "Aktív kapcsolatok"
 
-#: src/muuli_wdr.cpp:1863
+#: src/muuli_wdr.cpp:1862
 msgid "Systray Icon Speed Bar"
 msgstr "Sebességmérő a rendszertálcán"
 
-#: src/muuli_wdr.cpp:1864
+#: src/muuli_wdr.cpp:1863
 msgid "Kad-nodes current"
 msgstr "Kad-csomópontok aktuális"
 
-#: src/muuli_wdr.cpp:1865
+#: src/muuli_wdr.cpp:1864
 msgid "Kad-nodes running"
 msgstr "Kad-csomópontok futó"
 
-#: src/muuli_wdr.cpp:1866
+#: src/muuli_wdr.cpp:1865
 msgid "Kad-nodes session"
 msgstr "Kad-csomópontok folyamat"
 
-#: src/muuli_wdr.cpp:1870 src/muuli_wdr.cpp:2324
+#: src/muuli_wdr.cpp:1869 src/muuli_wdr.cpp:2296
 msgid "Select"
 msgstr "Kiválaszt"
 
-#: src/muuli_wdr.cpp:1874
+#: src/muuli_wdr.cpp:1873
 msgid "Tree"
 msgstr "Fa"
 
-#: src/muuli_wdr.cpp:1884
+#: src/muuli_wdr.cpp:1883
 msgid "Number of Client Versions shown (0=unlimited)"
 msgstr "Megjelenített ügyfél verziók száma (0=mind)"
 
-#: src/muuli_wdr.cpp:1909
+#: src/muuli_wdr.cpp:1908
 msgid "!!! WARNING !!!"
 msgstr "!!! FIGYELEM !!!"
 
-#: src/muuli_wdr.cpp:1924
+#: src/muuli_wdr.cpp:1923
 msgid "Max new connections / 5 secs"
 msgstr "Max új kapcsolat / 5 mp"
 
-#: src/muuli_wdr.cpp:1926
+#: src/muuli_wdr.cpp:1925
 msgid "Concurrent Kad source lookups"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1928
+#: src/muuli_wdr.cpp:1927
 #, fuzzy
 msgid "Kad source re-search interval (minutes)"
 msgstr "FTP frissítési gyakorisága percekben"
 
-#: src/muuli_wdr.cpp:1930
+#: src/muuli_wdr.cpp:1929
 #, fuzzy
 msgid "Source re-ask interval (minutes)"
 msgstr "FTP frissítési gyakorisága percekben"
 
-#: src/muuli_wdr.cpp:1934
+#: src/muuli_wdr.cpp:1933
 msgid "File Buffer Size: 240000 bytes"
 msgstr "Fájl buffer méret: 240000 bájt"
 
-#: src/muuli_wdr.cpp:1938
+#: src/muuli_wdr.cpp:1937
 msgid "Use MMAP: memory-mapped file access (lower memory use)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1939
+#: src/muuli_wdr.cpp:1938
 msgid "Maps part files into memory instead of buffering them on the heap, lowering the process memory footprint. May reduce download speed on some disks; best for memory-constrained or upload-heavy hosts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1941
+#: src/muuli_wdr.cpp:1940
 msgid "Upload Queue Size: 5000 clients"
 msgstr "Feltöltők várólistájának nagysága: 5000 kliens"
 
-#: src/muuli_wdr.cpp:1945
+#: src/muuli_wdr.cpp:1944
 msgid "Server connection refresh interval: Disable"
 msgstr "Kiszolgáló kapcsolat frissítési gyakorisága: Tiltva"
 
-#: src/muuli_wdr.cpp:1949
+#: src/muuli_wdr.cpp:1948
 msgid "Disable computer's timed standby mode"
 msgstr "Számítógép időzített készenléti állapotának hatástalanítása"
 
-#: src/muuli_wdr.cpp:1968
+#: src/muuli_wdr.cpp:1967
 msgid "Skin to use: "
 msgstr "Használt felület: "
 
-#: src/muuli_wdr.cpp:1977
+#: src/muuli_wdr.cpp:1976
 msgid "Show \"Fast eD2k Links Handler\" in every window."
 msgstr "A \"Gyors eD2k hivatkozás kezelő\" mutatása minden ablakban."
 
-#: src/muuli_wdr.cpp:1980
+#: src/muuli_wdr.cpp:1979
 msgid "Show extended info on categories tabs"
 msgstr "Kibővített infók megjelenítése a kategória füleken"
 
-#: src/muuli_wdr.cpp:1983
+#: src/muuli_wdr.cpp:1982
 msgid "Show application version on title"
 msgstr "Az alkalmazás verziójának megjelenítése a címsorban"
 
-#: src/muuli_wdr.cpp:1985
+#: src/muuli_wdr.cpp:1984
 msgid "Show transfer rates on title"
 msgstr "Átviteli ráták megjelenítése a címsorban"
 
-#: src/muuli_wdr.cpp:1987
+#: src/muuli_wdr.cpp:1986
 msgid "Before application name"
 msgstr "Az alkalmazás neve előtt"
 
-#: src/muuli_wdr.cpp:1989
+#: src/muuli_wdr.cpp:1988
 msgid "After application name"
 msgstr "Az alkalmazás neve után"
 
-#: src/muuli_wdr.cpp:1992
+#: src/muuli_wdr.cpp:1991
 msgid "Show overhead bandwidth"
 msgstr "Többletterhelés sávszélességének mutatása"
 
-#: src/muuli_wdr.cpp:1996
+#: src/muuli_wdr.cpp:1995
 msgid "Vertical toolbar orientation"
 msgstr "Függőleges eszköztár elrendezés"
 
-#: src/muuli_wdr.cpp:1998
+#: src/muuli_wdr.cpp:1997
 msgid "Live column sorting (auto-reorder rows as their values change)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2005
+#: src/muuli_wdr.cpp:2004
 msgid "Download Queue Files"
 msgstr "Letöltendő fájlok várakozási sora"
 
-#: src/muuli_wdr.cpp:2008
+#: src/muuli_wdr.cpp:2007
 msgid "Show progress percentage"
 msgstr "Százalékos arány mutatása"
 
-#: src/muuli_wdr.cpp:2014
+#: src/muuli_wdr.cpp:2013
 msgid "Show progress bar"
 msgstr "Folyamatjelző csík mutatása"
 
-#: src/muuli_wdr.cpp:2017
+#: src/muuli_wdr.cpp:2016
 msgid "Flat"
 msgstr "Lapos"
 
-#: src/muuli_wdr.cpp:2021
+#: src/muuli_wdr.cpp:2020
 msgid "Round"
 msgstr "Gömbölyű"
 
-#: src/muuli_wdr.cpp:2039
+#: src/muuli_wdr.cpp:2038
 msgid "External Connection Parameters"
 msgstr "Külső kapcsolatok jellemzői"
 
-#: src/muuli_wdr.cpp:2042
+#: src/muuli_wdr.cpp:2041
 msgid "Accept external connections"
 msgstr "Külső kapcsolat elfogadása"
 
-#: src/muuli_wdr.cpp:2049 src/muuli_wdr.cpp:2108
+#: src/muuli_wdr.cpp:2048 src/muuli_wdr.cpp:2107
 msgid "IP of the listening interface:"
 msgstr "Hallgató interfész IP-je:"
 
-#: src/muuli_wdr.cpp:2052
+#: src/muuli_wdr.cpp:2051
 msgid "Enter here a valid ip in the a.b.c.d format for the listening EC interface. An empty field or 0.0.0.0 will mean any interface."
 msgstr "Adjon meg itt egy érvényes IP címet a.b.c.d formában az EC hallgató interfésznek. Üres mező vagy 0.0.0.0 jelentése: bármelyik interfész."
 
-#: src/muuli_wdr.cpp:2073 src/muuli_wdr.cpp:2184
+#: src/muuli_wdr.cpp:2072 src/muuli_wdr.cpp:2156
 msgid "TCP port:"
 msgstr "TCP port:"
 
-#: src/muuli_wdr.cpp:2079
+#: src/muuli_wdr.cpp:2078
 msgid "Enable UPnP port forwarding on the EC port"
 msgstr "UPnP port továbbítás engedélyezése az EC porton"
 
-#: src/muuli_wdr.cpp:2083 src/muuli_wdr.cpp:3069
+#: src/muuli_wdr.cpp:2082 src/muuli_wdr.cpp:3041
 #: src/utils/wxCas/src/wxcasprefs.cpp:167
 msgid "Password"
 msgstr "Jelszó"
 
-#: src/muuli_wdr.cpp:2089
+#: src/muuli_wdr.cpp:2088
 #, fuzzy
 msgid "aMule API server parameters"
 msgstr "Web kiszolgáló paraméterek"
 
-#: src/muuli_wdr.cpp:2092
+#: src/muuli_wdr.cpp:2091
 msgid "Run amuleapi (REST API) on startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2097
+#: src/muuli_wdr.cpp:2096
 #, fuzzy
 msgid "HTTP port:"
 msgstr "TCP port:"
 
-#: src/muuli_wdr.cpp:2111
+#: src/muuli_wdr.cpp:2110
 msgid "The interface amuleapi's HTTP server listens on. 127.0.0.1 (default) accepts only local connections; use 0.0.0.0 or a specific IP to expose it to other hosts (set an admin password below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2116
-msgid "Type a password to set or change it. Stored passwords cannot be shown, so leaving this empty keeps the current one."
-msgstr ""
-
-#: src/muuli_wdr.cpp:2118
+#: src/muuli_wdr.cpp:2113
 #, fuzzy
 msgid "Admin password"
 msgstr "Jelszó ellenőrzése\n"
 
-#: src/muuli_wdr.cpp:2130 src/muuli_wdr.cpp:2147 src/PrefsUnifiedDlg.cpp:1103
-#, fuzzy
-msgid "A password is set."
-msgstr "Jelszó ellenőrzése\n"
+#: src/muuli_wdr.cpp:2118 src/muuli_wdr.cpp:2149
+msgid "Low rights password"
+msgstr "Vendég jelszó"
 
-#: src/muuli_wdr.cpp:2134
-#, fuzzy
-msgid "Enable guest access"
-msgstr "Vendég felhasználó tiltása"
-
-#: src/muuli_wdr.cpp:2135
-msgid "Guest sessions may read status and listings but cannot change anything. Turning this off clears the stored guest password."
-msgstr ""
-
-#: src/muuli_wdr.cpp:2139
-#, fuzzy
-msgid "Guest password"
-msgstr "Vendég jelszó a web kiszolgálóhoz"
-
-#: src/muuli_wdr.cpp:2154
+#: src/muuli_wdr.cpp:2126
 msgid "Web server parameters"
 msgstr "Web kiszolgáló paraméterek"
 
-#: src/muuli_wdr.cpp:2157
+#: src/muuli_wdr.cpp:2129
 #, fuzzy
 msgid "Run webserver on startup (deprecated)"
 msgstr "Webkiszolgáló indítása induláskor"
 
-#: src/muuli_wdr.cpp:2163
+#: src/muuli_wdr.cpp:2135
 msgid "Web template"
 msgstr "Web minta"
 
-#: src/muuli_wdr.cpp:2168
+#: src/muuli_wdr.cpp:2140
 msgid "Full rights password"
 msgstr "Admin jelszó"
 
-#: src/muuli_wdr.cpp:2172
+#: src/muuli_wdr.cpp:2144
 msgid "Enable Low rights User"
 msgstr "Vendég felhasználó engedélyezése"
 
-#: src/muuli_wdr.cpp:2177
-msgid "Low rights password"
-msgstr "Vendég jelszó"
-
-#: src/muuli_wdr.cpp:2191
+#: src/muuli_wdr.cpp:2163
 msgid "Enable UPnP port forwarding of the web server port"
 msgstr "A web kiszolgáló port UPnP továbbításának engedélyezése"
 
-#: src/muuli_wdr.cpp:2196
+#: src/muuli_wdr.cpp:2168
 msgid "Web server UPnP TCP port (Optional)"
 msgstr "Web szerver UPnP TCP port (nem kötelező)"
 
-#: src/muuli_wdr.cpp:2204
+#: src/muuli_wdr.cpp:2176
 msgid "Page Refresh Time (in secs)"
 msgstr "Oldal frissítésének időzítése (mp múlva)"
 
-#: src/muuli_wdr.cpp:2211
+#: src/muuli_wdr.cpp:2183
 msgid "Enable Gzip compression"
 msgstr "Gzip tömörítés engedélyezése"
 
-#: src/muuli_wdr.cpp:2245
+#: src/muuli_wdr.cpp:2217
 #, fuzzy
 msgid "Reset page to defaults"
 msgstr "Alapértelmezett"
 
-#: src/muuli_wdr.cpp:2246
+#: src/muuli_wdr.cpp:2218
 msgid "Reset the settings on the current page to their default values."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2248 src/muuli_wdr.cpp:2334 src/ServerWnd.cpp:274
+#: src/muuli_wdr.cpp:2220 src/muuli_wdr.cpp:2306 src/ServerWnd.cpp:274
 #: src/ServerWnd.cpp:282
 msgid "OK"
 msgstr "OK"
 
-#: src/muuli_wdr.cpp:2250
+#: src/muuli_wdr.cpp:2222
 msgid "Click here to apply any changes made to the preferences."
 msgstr "Kattints ide a beállítási módosítások alkalmazásához."
 
-#: src/muuli_wdr.cpp:2253
+#: src/muuli_wdr.cpp:2225
 msgid "Reset any changes made to the preferences."
 msgstr "Beállítási módosítások figyelmen kívül hagyása."
 
-#: src/muuli_wdr.cpp:2282
+#: src/muuli_wdr.cpp:2254
 msgid "Comment :"
 msgstr "Megjegyzés:"
 
-#: src/muuli_wdr.cpp:2289
+#: src/muuli_wdr.cpp:2261
 msgid "Incoming Dir :"
 msgstr "Bejövő Mappa :"
 
-#: src/muuli_wdr.cpp:2298
+#: src/muuli_wdr.cpp:2270
 msgid "Change priority for new assigned files :"
 msgstr "Újonnan hozzárendelt fájlok prioritásának változtatása :"
 
-#: src/muuli_wdr.cpp:2302
+#: src/muuli_wdr.cpp:2274
 msgid "Don't change"
 msgstr "Ne változzon"
 
-#: src/muuli_wdr.cpp:2314
+#: src/muuli_wdr.cpp:2286
 msgid "Select color for this Category (currently selected) :"
 msgstr "Válassz színt ehhez a kategóriához (jelenleg kiválasztva) :"
 
-#: src/muuli_wdr.cpp:2381 src/muuli_wdr.cpp:2400 src/muuli_wdr.cpp:2422
+#: src/muuli_wdr.cpp:2353 src/muuli_wdr.cpp:2372 src/muuli_wdr.cpp:2394
 msgid "Click this button to reset the log."
 msgstr "Kattints erre a gombra a logfájl visszaállításához."
 
-#: src/muuli_wdr.cpp:2441
+#: src/muuli_wdr.cpp:2413
 msgid "Click on this button to update the servers list from URL ..."
 msgstr "Kattints erre a gombra a kiszolgálólista frissítéséhez  ..."
 
-#: src/muuli_wdr.cpp:2445
+#: src/muuli_wdr.cpp:2417
 msgid "Server list"
 msgstr "Kiszolgálók listája"
 
-#: src/muuli_wdr.cpp:2449
+#: src/muuli_wdr.cpp:2421
 msgid "Enter the url to a server.met file here and press the button to the left to update the list of known servers."
 msgstr "Adj meg egy címet a server.met fájlhoz és nyomd meg a baloldali gombot az ismert kiszolgálók listájának frissítéséhez."
 
-#: src/muuli_wdr.cpp:2454
+#: src/muuli_wdr.cpp:2426
 msgid "Add server manually: Name"
 msgstr "Kiszolgáló hozzáadása kézzel: Név"
 
-#: src/muuli_wdr.cpp:2457
+#: src/muuli_wdr.cpp:2429
 msgid "Enter the name of the new server here"
 msgstr "Add meg az új kiszolgáló nevét"
 
-#: src/muuli_wdr.cpp:2459 src/ServerWnd.cpp:206
+#: src/muuli_wdr.cpp:2431 src/ServerWnd.cpp:206
 msgid "IP:Port"
 msgstr "IP:Port"
 
-#: src/muuli_wdr.cpp:2462
+#: src/muuli_wdr.cpp:2434
 msgid "Enter the IP of the server here, using the x.x.x.x format."
 msgstr "Itt add meg a kiszolgálók IP-jét, használd az x.x.x.x formát."
 
-#: src/muuli_wdr.cpp:2468
+#: src/muuli_wdr.cpp:2440
 msgid "Enter the port of the server here."
 msgstr "Add meg a kiszolgáló portját."
 
-#: src/muuli_wdr.cpp:2471
+#: src/muuli_wdr.cpp:2443
 msgid "Add manually a server (fill fields to the left before) ..."
 msgstr "Kiszolgáló felvétel kézzel (töltsd ki a baloldali mezőket először) ..."
 
-#: src/muuli_wdr.cpp:2500
+#: src/muuli_wdr.cpp:2472
 msgid "aMule Log"
 msgstr "aMule Napló"
 
-#: src/muuli_wdr.cpp:2508
+#: src/muuli_wdr.cpp:2480
 msgid "Server Info"
 msgstr "Kiszolgáló Infó"
 
-#: src/muuli_wdr.cpp:2512
+#: src/muuli_wdr.cpp:2484
 msgid "ED2K Info"
 msgstr "ED2K infó"
 
-#: src/muuli_wdr.cpp:2516
+#: src/muuli_wdr.cpp:2488
 msgid "Kad Info"
 msgstr "Kad infó"
 
-#: src/muuli_wdr.cpp:2544
+#: src/muuli_wdr.cpp:2516
 msgid "Click on this button to update the nodes list from URL ..."
 msgstr "Kattints erre a gombra a csomópont-lista frissítéséhez URL-ből ..."
 
-#: src/muuli_wdr.cpp:2548
+#: src/muuli_wdr.cpp:2520
 msgid "Nodes (0)"
 msgstr "Csomópontok (0)"
 
-#: src/muuli_wdr.cpp:2552
+#: src/muuli_wdr.cpp:2524
 msgid "Enter the url to a nodes.dat file here and press the button to the left to update the list of known nodes."
 msgstr "Adj meg egy címet a nodes.dat fájlhoz és nyomd meg a baloldali gombot az ismert csomópontok listájának frissítéséhez."
 
-#: src/muuli_wdr.cpp:2555
+#: src/muuli_wdr.cpp:2527
 msgid "Nodes stats"
 msgstr "Csomópont statisztikák"
 
-#: src/muuli_wdr.cpp:2597
+#: src/muuli_wdr.cpp:2569
 msgid "Bootstrap"
 msgstr "Rendszerbetöltés"
 
-#: src/muuli_wdr.cpp:2600
+#: src/muuli_wdr.cpp:2572
 msgid "New node"
 msgstr "Új csomópont (node)"
 
-#: src/muuli_wdr.cpp:2605
+#: src/muuli_wdr.cpp:2577
 msgid "IP:"
 msgstr "IP:"
 
-#: src/muuli_wdr.cpp:2625
+#: src/muuli_wdr.cpp:2597
 msgid "Port:"
 msgstr "Port:"
 
-#: src/muuli_wdr.cpp:2638
+#: src/muuli_wdr.cpp:2610
 msgid "Bootstrap from known clients"
 msgstr "Indítás ismert kliensektől"
 
-#: src/muuli_wdr.cpp:2640
+#: src/muuli_wdr.cpp:2612
 msgid "Disconnect Kad"
 msgstr "Leválasztás a Kad-ról"
 
-#: src/muuli_wdr.cpp:2674
+#: src/muuli_wdr.cpp:2646
 msgid "Use Secure User Identification"
 msgstr "Biztonságos azonosítás használata"
 
-#: src/muuli_wdr.cpp:2676
+#: src/muuli_wdr.cpp:2648
 msgid "It is recommended to enable this option. You will not receive credits if SUI is not enabled."
 msgstr "Ajánlott ezt az opciót engedélyezni. Nem fogsz kreditet kapni, ha nincs engedélyezve."
 
-#: src/muuli_wdr.cpp:2678
+#: src/muuli_wdr.cpp:2650
 msgid "Protocol Obfuscation"
 msgstr "Protokoll zavarás"
 
-#: src/muuli_wdr.cpp:2681
+#: src/muuli_wdr.cpp:2653
 msgid "Support Protocol Obfuscation"
 msgstr "Protokoll zavarás támogatása"
 
-#: src/muuli_wdr.cpp:2683
+#: src/muuli_wdr.cpp:2655
 msgid "This option enabled Protocol Obfuscation, and makes aMule accept obfuscated connections from other clients."
 msgstr "Ez az opció engedélyezi a protokoll zavarást, és az aMule elfogad zavart kapcsolatokat más ügyfelektől."
 
-#: src/muuli_wdr.cpp:2685
+#: src/muuli_wdr.cpp:2657
 msgid "Use obfuscation for outgoing connections"
 msgstr "Kimenő kapcsolatok zavarása"
 
-#: src/muuli_wdr.cpp:2687
+#: src/muuli_wdr.cpp:2659
 msgid "This option makes aMule use Protocol Obfuscation when connecting other clients/servers."
 msgstr "Ez az opció engedélyezi a protokoll zavarást, amikor más ügyfelekhez/kiszolgálókhoz kapcsolódik az aMule."
 
-#: src/muuli_wdr.cpp:2689
+#: src/muuli_wdr.cpp:2661
 msgid "Accept only obfuscated connections"
 msgstr "Csak zavart kapcsolatok elfogadása"
 
-#: src/muuli_wdr.cpp:2690
+#: src/muuli_wdr.cpp:2662
 msgid "This option makes aMule only accept obfuscated connections. You will have less sources, but all your traffic will be obfuscated"
 msgstr "Ezen opció hatására az aMule csak zavart kapcsolatokat fog elfogadni. Kevesebb forrásod lesz, de a teljes forgalom zavart lesz"
 
-#: src/muuli_wdr.cpp:2695
+#: src/muuli_wdr.cpp:2667
 msgid "Everybody"
 msgstr "Mindenki"
 
-#: src/muuli_wdr.cpp:2697
+#: src/muuli_wdr.cpp:2669
 msgid "No one"
 msgstr "Senki"
 
-#: src/muuli_wdr.cpp:2699
+#: src/muuli_wdr.cpp:2671
 msgid "Who can see my shared files:"
 msgstr "Ki láthatja a megosztott fájljaimat:"
 
-#: src/muuli_wdr.cpp:2700
+#: src/muuli_wdr.cpp:2672
 msgid "Select who can request to view a list of your shared files."
 msgstr "Válaszd ki, hogy kik kérdezhetik le megosztott fájlaid listáját."
 
-#: src/muuli_wdr.cpp:2702
+#: src/muuli_wdr.cpp:2674
 msgid "IP-Filtering"
 msgstr "IP-szűrés"
 
-#: src/muuli_wdr.cpp:2709
+#: src/muuli_wdr.cpp:2681
 msgid "Filter clients"
 msgstr "Kliensek szűrése"
 
-#: src/muuli_wdr.cpp:2711
+#: src/muuli_wdr.cpp:2683
 msgid "Enable filtering of the client IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "A ~/.aMule/ipfilter.dat állományban IP-jű kliensek szűrésének engedélyezése."
 
-#: src/muuli_wdr.cpp:2713
+#: src/muuli_wdr.cpp:2685
 msgid "Filter servers"
 msgstr "Kiszolgálók szűrése"
 
-#: src/muuli_wdr.cpp:2715
+#: src/muuli_wdr.cpp:2687
 msgid "Enable filtering of the server IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "A ~/.aMule/ipfilter.dat állományban IP-jű kiszolgálók szűrésének engedélyezése."
 
-#: src/muuli_wdr.cpp:2719
+#: src/muuli_wdr.cpp:2691
 msgid "Reload List"
 msgstr "Lista újratöltése"
 
-#: src/muuli_wdr.cpp:2720
+#: src/muuli_wdr.cpp:2692
 msgid "Reload the list of IPs to filter from the file ~/.aMule/ipfilter.dat"
 msgstr "IP-k listájának újratöltése a ~/.aMule/ipfilter.dat fájlból"
 
-#: src/muuli_wdr.cpp:2726
+#: src/muuli_wdr.cpp:2698
 msgid "URL:"
 msgstr "URL:"
 
-#: src/muuli_wdr.cpp:2730 src/muuli_wdr.cpp:2923
+#: src/muuli_wdr.cpp:2702 src/muuli_wdr.cpp:2895
 msgid "Update now"
 msgstr "Frissítés most"
 
-#: src/muuli_wdr.cpp:2733
+#: src/muuli_wdr.cpp:2705
 msgid "Auto-update ipfilter at startup"
 msgstr "IP szűrő automatikus letöltése indításkor"
 
-#: src/muuli_wdr.cpp:2737
+#: src/muuli_wdr.cpp:2709
 msgid "Filtering Level:"
 msgstr "Szűrési szint:"
 
-#: src/muuli_wdr.cpp:2743
+#: src/muuli_wdr.cpp:2715
 msgid "Always filter LAN IPs"
 msgstr "Mindig szűrje ki a LAN IP-ket"
 
-#: src/muuli_wdr.cpp:2746
+#: src/muuli_wdr.cpp:2718
 msgid "Paranoid handling of non-matching IPs"
 msgstr "A nem-megegyező IP-k paranoid kezelése"
 
-#: src/muuli_wdr.cpp:2748
+#: src/muuli_wdr.cpp:2720
 msgid "Rejects a packet when its source IP differs from the IP the client claims (an anti-spoofing check). Disable only if it causes connection problems."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2750
+#: src/muuli_wdr.cpp:2722
 msgid "Use system-wide ipfilter.dat if available"
 msgstr "Rendszer-szintű ipfilter.dat használatának engedélyezése"
 
-#: src/muuli_wdr.cpp:2751
+#: src/muuli_wdr.cpp:2723
 msgid "If there's no local ipfilter.dat found, allow usage of a system-wide ipfilter file."
 msgstr "Ha nem talál helyi ipfilter.dat fájlt, akkor engedje a rendszerszintű ipfilter fájl használatát."
 
-#: src/muuli_wdr.cpp:2768
+#: src/muuli_wdr.cpp:2740
 msgid "Enable Online-Signature"
 msgstr "Online-aláírás engedélyezése"
 
-#: src/muuli_wdr.cpp:2770
+#: src/muuli_wdr.cpp:2742
 msgid "Enables the writing of the OS file, which can be used by external apps to create signatures and the like."
 msgstr "Az online-aláírás fájl írásának engedélyezése, amit külső alkalmazások használhatnak fel aláírások létrehozásához és így tovább."
 
-#: src/muuli_wdr.cpp:2774
+#: src/muuli_wdr.cpp:2746
 msgid "Update Frequency (Secs):"
 msgstr "Frissítési gyakoriság (mp):"
 
-#: src/muuli_wdr.cpp:2777
+#: src/muuli_wdr.cpp:2749
 msgid "Change the frequency (in seconds) of Online Signature updates."
 msgstr "Online aláírás frissítési gyakoriságának módosítása (mp-ben)."
 
-#: src/muuli_wdr.cpp:2785
+#: src/muuli_wdr.cpp:2757
 msgid "Save online signature file in: "
 msgstr "Online aláírási fájl kimentési helye: "
 
-#: src/muuli_wdr.cpp:2791
+#: src/muuli_wdr.cpp:2763
 msgid "Click here to select the directory containing the the Online Signature files."
 msgstr "Kattints ide az online aláírást tartalmazó könyvtár kiválasztásához."
 
-#: src/muuli_wdr.cpp:2824
+#: src/muuli_wdr.cpp:2796
 msgid "Show country flags for clients"
 msgstr "Kliensek országzászlajainak megjelenítése"
 
-#: src/muuli_wdr.cpp:2825
+#: src/muuli_wdr.cpp:2797
 msgid "Render the country flag column in the transfers, queue and search views. Requires a valid MMDB GeoIP database (see below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2830
+#: src/muuli_wdr.cpp:2802
 msgid "Database"
 msgstr "Adatbázis"
 
-#: src/muuli_wdr.cpp:2846
+#: src/muuli_wdr.cpp:2818
 msgid "Source:"
 msgstr "Forrás:"
 
-#: src/muuli_wdr.cpp:2849
+#: src/muuli_wdr.cpp:2821
 msgid "DB-IP (free, no account)"
 msgstr "DB-IP (ingyenes, fiók nélkül)"
 
-#: src/muuli_wdr.cpp:2850
+#: src/muuli_wdr.cpp:2822
 msgid "MaxMind GeoLite2 (free, account required)"
 msgstr "MaxMind GeoLite2 (ingyenes, fiók szükséges)"
 
-#: src/muuli_wdr.cpp:2851
+#: src/muuli_wdr.cpp:2823
 msgid "Custom URL"
 msgstr "Egyéni URL"
 
-#: src/muuli_wdr.cpp:2854
+#: src/muuli_wdr.cpp:2826
 msgid "Choose which provider supplies the GeoIP MMDB database. DB-IP is the default - no account required. MaxMind requires a free account + license key. Use Custom URL to point at any other MMDB host (e.g. a local mirror)."
 msgstr "Válassza ki a GeoIP MMDB adatbázis szolgáltatóját. DB-IP az alapértelmezett - nincs szükség fiókra. MaxMind egy ingyenes fiókot és licenckulcsot igényel. Használjon egyéni URL-t bármely más MMDB host megadásához (pl. egy helyi tükörhöz)."
 
-#: src/muuli_wdr.cpp:2871
+#: src/muuli_wdr.cpp:2843
 msgid ""
 "No configuration required.\n"
 "\n"
@@ -4854,11 +4820,11 @@ msgstr ""
 "IP-to-Country adat DB-IP.com által - https://db-ip.com\n"
 "Licenc: Creative Commons BY 4.0 - https://creativecommons.org/licenses/by/4.0/"
 
-#: src/muuli_wdr.cpp:2884
+#: src/muuli_wdr.cpp:2856
 msgid "License key:"
 msgstr "Licenckulcs:"
 
-#: src/muuli_wdr.cpp:2890
+#: src/muuli_wdr.cpp:2862
 msgid ""
 "Sign up for a free MaxMind account, then generate a License Key:\n"
 "https://www.maxmind.com/en/geolite2/signup\n"
@@ -4874,11 +4840,11 @@ msgstr ""
 "Licenc: MaxMind GeoLite2 EULA - https://www.maxmind.com/en/geolite2/eula\n"
 "Hozzárendelést és fiókregisztrációt igényel; legalább 30 naponta frissítse."
 
-#: src/muuli_wdr.cpp:2905
+#: src/muuli_wdr.cpp:2877
 msgid "Download URL:"
 msgstr "Letöltési URL:"
 
-#: src/muuli_wdr.cpp:2911
+#: src/muuli_wdr.cpp:2883
 msgid ""
 "Must point to an .mmdb file or a .gz / .tar.gz containing one.\n"
 "URL may include credentials (https://user:pass@host/...).\n"
@@ -4888,211 +4854,211 @@ msgstr ""
 "Az URL tartalmazhat hitelesítő adatokat (https://user:pass@host/...).\n"
 "A licenc- és megnevezési feltételeket a felmenő URL határozza meg - ön a felelőss."
 
-#: src/muuli_wdr.cpp:2924
+#: src/muuli_wdr.cpp:2896
 msgid "Download the GeoIP database from the selected source."
 msgstr "GeoIP adatbázis letöltése a kiválasztott forrásból."
 
-#: src/muuli_wdr.cpp:2926
+#: src/muuli_wdr.cpp:2898
 msgid "Auto-update on startup"
 msgstr "Automatikus frissítés indításkor"
 
-#: src/muuli_wdr.cpp:2927
+#: src/muuli_wdr.cpp:2899
 msgid "Re-download the GeoIP database from the selected source every time aMule starts."
 msgstr "GeoIP adatbázis újonnani letöltése a kiválasztott forrásból minden aMule indításkor."
 
-#: src/muuli_wdr.cpp:2950
+#: src/muuli_wdr.cpp:2922
 msgid "Filter incoming messages (except current chat):"
 msgstr "Bejövő üzenetek kiszűrése (kivéve az aktuális csevegés):"
 
-#: src/muuli_wdr.cpp:2952
+#: src/muuli_wdr.cpp:2924
 msgid "Filter all messages"
 msgstr "Összes üzenet szűrése"
 
-#: src/muuli_wdr.cpp:2954
+#: src/muuli_wdr.cpp:2926
 msgid "Filter messages from people not on your friend list"
 msgstr "Barát listában nem szereplőktől érkező üzenetek kiszűrése"
 
-#: src/muuli_wdr.cpp:2956
+#: src/muuli_wdr.cpp:2928
 msgid "Filter messages from unknown clients"
 msgstr "Ismeretlen kliensektől érkező üzenetek kiszűrése"
 
-#: src/muuli_wdr.cpp:2958
+#: src/muuli_wdr.cpp:2930
 msgid "Filter messages containing (use ',' as separator):"
 msgstr "A következő(ke)t tartalmazó üzenetek kiszűrése (elválasztónak ','-t használj):"
 
-#: src/muuli_wdr.cpp:2961 src/muuli_wdr.cpp:2972
+#: src/muuli_wdr.cpp:2933 src/muuli_wdr.cpp:2944
 msgid "add here the words amule should filter and block messages including it"
 msgstr "Azon szavak felvétele, amelyeket az amule-nak ki kellene szűrni és blokkolni az ezeket tartalmazó üzeneteket"
 
-#: src/muuli_wdr.cpp:2963
+#: src/muuli_wdr.cpp:2935
 msgid "Show received messages in the log"
 msgstr "A kapott üzenetek megjelenítése a naplóban"
 
-#: src/muuli_wdr.cpp:2966
+#: src/muuli_wdr.cpp:2938
 msgid "Comments"
 msgstr "Megjegyzések"
 
-#: src/muuli_wdr.cpp:2969
+#: src/muuli_wdr.cpp:2941
 msgid "Filter comments containing (use ',' as separator):"
 msgstr "Megjegyzések kiszűrése, melyek tartalmazzák (',' az elválasztó):"
 
-#: src/muuli_wdr.cpp:2994
+#: src/muuli_wdr.cpp:2966
 msgid "Enable Proxy"
 msgstr "Proxy engedélyezése"
 
-#: src/muuli_wdr.cpp:2995
+#: src/muuli_wdr.cpp:2967
 msgid "Enable/disable proxy support"
 msgstr "Proxy támogatás engedélyezése/tiltása"
 
-#: src/muuli_wdr.cpp:2998
+#: src/muuli_wdr.cpp:2970
 msgid "Proxy type:"
 msgstr "Proxy típusa:"
 
-#: src/muuli_wdr.cpp:3009
+#: src/muuli_wdr.cpp:2981
 msgid "Proxy host:"
 msgstr "Proxy host:"
 
-#: src/muuli_wdr.cpp:3012
+#: src/muuli_wdr.cpp:2984
 msgid "The proxy host name"
 msgstr "A proxy host neve"
 
-#: src/muuli_wdr.cpp:3014
+#: src/muuli_wdr.cpp:2986
 msgid "Proxy port:"
 msgstr "Proxy port:"
 
-#: src/muuli_wdr.cpp:3017
+#: src/muuli_wdr.cpp:2989
 msgid "The proxy port"
 msgstr "A proxy port"
 
-#: src/muuli_wdr.cpp:3019
+#: src/muuli_wdr.cpp:2991
 msgid "Enable authentication"
 msgstr "Hitelesítés engedélyezése"
 
-#: src/muuli_wdr.cpp:3020
+#: src/muuli_wdr.cpp:2992
 msgid "Enable/disable username/password authentication"
 msgstr "Felhasználói név/jelszó hitelesítés engedélyezése/tiltása"
 
-#: src/muuli_wdr.cpp:3023
+#: src/muuli_wdr.cpp:2995
 msgid "Username: "
 msgstr "Felhasználói név: "
 
-#: src/muuli_wdr.cpp:3026
+#: src/muuli_wdr.cpp:2998
 msgid "The username to use to connect to the proxy"
 msgstr "Felhasználói név a proxy kapcsolathoz"
 
-#: src/muuli_wdr.cpp:3028
+#: src/muuli_wdr.cpp:3000
 msgid "Password:"
 msgstr "Jelszó:"
 
-#: src/muuli_wdr.cpp:3031
+#: src/muuli_wdr.cpp:3003
 msgid "The password to use to connect to the proxy"
 msgstr "Jelszó a proxy kapcsolathoz"
 
-#: src/muuli_wdr.cpp:3050
+#: src/muuli_wdr.cpp:3022
 msgid "Connect to:"
 msgstr "Kapcsolódás ehhez:"
 
-#: src/muuli_wdr.cpp:3059
+#: src/muuli_wdr.cpp:3031
 msgid "Login to remote amule"
 msgstr "Bejeletkezés a távoli amule-ra"
 
-#: src/muuli_wdr.cpp:3064
+#: src/muuli_wdr.cpp:3036
 msgid "User name"
 msgstr "Felhasználói név"
 
-#: src/muuli_wdr.cpp:3075
+#: src/muuli_wdr.cpp:3047
 msgid "Remember those settings"
 msgstr "Emlékezzen ezekre a beállításokra"
 
-#: src/muuli_wdr.cpp:3078
+#: src/muuli_wdr.cpp:3050
 msgid "Force ZLIB compression"
 msgstr "ZLIB tömörítés erőltetése"
 
-#: src/muuli_wdr.cpp:3102
+#: src/muuli_wdr.cpp:3074
 msgid "Enable Verbose Debug-Logging."
 msgstr "Bőbeszédű hiba-naplózás engedélyezése."
 
-#: src/muuli_wdr.cpp:3104
+#: src/muuli_wdr.cpp:3076
 msgid "Only to Logfile"
 msgstr "Csak napló fájlba"
 
-#: src/muuli_wdr.cpp:3106
+#: src/muuli_wdr.cpp:3078
 msgid "Message Categories:"
 msgstr "Üzenet kategóriák:"
 
-#: src/muuli_wdr.cpp:3130 src/PartFileConvertDlg.cpp:160
+#: src/muuli_wdr.cpp:3102 src/PartFileConvertDlg.cpp:160
 msgid "Waiting..."
 msgstr "Várakozás..."
 
-#: src/muuli_wdr.cpp:3150
+#: src/muuli_wdr.cpp:3122
 msgid "Add imports"
 msgstr "Importálandók hozzáadása"
 
-#: src/muuli_wdr.cpp:3153
+#: src/muuli_wdr.cpp:3125
 msgid "Retry selected"
 msgstr "Kijelöltek újrapróbálása"
 
-#: src/muuli_wdr.cpp:3155
+#: src/muuli_wdr.cpp:3127
 msgid "Remove selected"
 msgstr "Kijelöltek eltávolítása"
 
-#: src/muuli_wdr.cpp:3218
+#: src/muuli_wdr.cpp:3190
 msgid "Event Types"
 msgstr "Esemény típusok"
 
-#: src/muuli_wdr.cpp:3237
+#: src/muuli_wdr.cpp:3209
 msgid "Statistics and queued clients for selected file(s) : Session / All time"
 msgstr "Statisztikák és várakozó kliensek a kiválasztott fájl(ok)hoz: Folyamat / Valaha"
 
-#: src/muuli_wdr.cpp:3261
+#: src/muuli_wdr.cpp:3233
 msgid "Active Uploads"
 msgstr "Aktív feltöltések"
 
-#: src/muuli_wdr.cpp:3275
+#: src/muuli_wdr.cpp:3247
 msgid "Percent of total files"
 msgstr "Összes fájl százalékaként"
 
-#: src/muuli_wdr.cpp:3327
+#: src/muuli_wdr.cpp:3299
 msgid "Show Clients for"
 msgstr "Kliensek megjelenítése ehhez:"
 
-#: src/muuli_wdr.cpp:3329
+#: src/muuli_wdr.cpp:3301
 msgid "All files"
 msgstr "Összes fájl"
 
-#: src/muuli_wdr.cpp:3332
+#: src/muuli_wdr.cpp:3304
 msgid "Selected files"
 msgstr "Kiválasztott fájlok"
 
-#: src/muuli_wdr.cpp:3335
+#: src/muuli_wdr.cpp:3307
 msgid "Active uploads only"
 msgstr "Csak aktív feltöltések"
 
-#: src/muuli_wdr.cpp:3342
+#: src/muuli_wdr.cpp:3314
 msgid "Reload:"
 msgstr "Újratöltés:"
 
-#: src/muuli_wdr.cpp:3346
+#: src/muuli_wdr.cpp:3318
 msgid "Reload your shared files"
 msgstr "Megosztott fájlok frissítése"
 
-#: src/muuli_wdr.cpp:3409
+#: src/muuli_wdr.cpp:3381
 msgid "Send"
 msgstr "Küldés"
 
-#: src/muuli_wdr.cpp:3410
+#: src/muuli_wdr.cpp:3382
 msgid "Sends the specified message."
 msgstr "Megadott üzenet küldése."
 
-#: src/muuli_wdr.cpp:3414
+#: src/muuli_wdr.cpp:3386
 msgid "Close this chat-session."
 msgstr "Csevegési folyamat bezárása."
 
-#: src/muuli_wdr.cpp:3437
+#: src/muuli_wdr.cpp:3409
 msgid "Connect to any server and/or Kad"
 msgstr "Kapcsolódás bármelyik kiszolgálóhoz és/vagy a Kad-hoz"
 
-#: src/muuli_wdr.cpp:3443 src/SharedFilesCtrl.cpp:142 src/Statistics.cpp:941
+#: src/muuli_wdr.cpp:3415 src/SharedFilesCtrl.cpp:142 src/Statistics.cpp:941
 msgid "Shared Files"
 msgstr "Megosztott fájlok"
 
@@ -5448,249 +5414,249 @@ msgstr "Letöltve"
 msgid "ERROR: Failed to open partfile '%s'"
 msgstr "HIBA: A(z) '%s' részfájl megnyitása sikertelen."
 
-#: src/Preferences.cpp:701
+#: src/Preferences.cpp:673
 msgid "System default"
 msgstr "Alapértelmezett"
 
-#: src/Preferences.cpp:702
+#: src/Preferences.cpp:674
 msgid "Albanian"
 msgstr "Albán"
 
-#: src/Preferences.cpp:703
+#: src/Preferences.cpp:675
 msgid "Arabic"
 msgstr "Arab"
 
-#: src/Preferences.cpp:704
+#: src/Preferences.cpp:676
 msgid "Asturian"
 msgstr "Asztúriai"
 
-#: src/Preferences.cpp:705
+#: src/Preferences.cpp:677
 msgid "Basque"
 msgstr "Baszk"
 
-#: src/Preferences.cpp:706
+#: src/Preferences.cpp:678
 msgid "Bulgarian"
 msgstr "Bolgár"
 
-#: src/Preferences.cpp:707
+#: src/Preferences.cpp:679
 msgid "Catalan"
 msgstr "Katalán"
 
-#: src/Preferences.cpp:708
+#: src/Preferences.cpp:680
 msgid "Chinese (Simplified)"
 msgstr "Kínai (egyszerűsített)"
 
-#: src/Preferences.cpp:709
+#: src/Preferences.cpp:681
 msgid "Chinese (Traditional)"
 msgstr "Kínai (hagyományos)"
 
-#: src/Preferences.cpp:710
+#: src/Preferences.cpp:682
 msgid "Croatian"
 msgstr "Horvát"
 
-#: src/Preferences.cpp:711
+#: src/Preferences.cpp:683
 msgid "Czech"
 msgstr "Cseh"
 
-#: src/Preferences.cpp:712
+#: src/Preferences.cpp:684
 msgid "Danish"
 msgstr "Dán"
 
-#: src/Preferences.cpp:713
+#: src/Preferences.cpp:685
 msgid "Dutch"
 msgstr "Holland"
 
-#: src/Preferences.cpp:714
+#: src/Preferences.cpp:686
 msgid "English (U.K.)"
 msgstr "Angol (Egyesült Királyság)"
 
-#: src/Preferences.cpp:715
+#: src/Preferences.cpp:687
 #, fuzzy
 msgid "English (U.S.)"
 msgstr "Angol (Egyesült Királyság)"
 
-#: src/Preferences.cpp:716
+#: src/Preferences.cpp:688
 msgid "Estonian"
 msgstr "Észt"
 
-#: src/Preferences.cpp:717
+#: src/Preferences.cpp:689
 msgid "Finnish"
 msgstr "Finn"
 
-#: src/Preferences.cpp:718
+#: src/Preferences.cpp:690
 msgid "French"
 msgstr "Francia"
 
-#: src/Preferences.cpp:719
+#: src/Preferences.cpp:691
 msgid "Galician"
 msgstr "Gall"
 
-#: src/Preferences.cpp:720
+#: src/Preferences.cpp:692
 msgid "German"
 msgstr "Német"
 
-#: src/Preferences.cpp:721
+#: src/Preferences.cpp:693
 msgid "Greek"
 msgstr "Görög"
 
-#: src/Preferences.cpp:722
+#: src/Preferences.cpp:694
 msgid "Hebrew"
 msgstr "Héber"
 
-#: src/Preferences.cpp:723
+#: src/Preferences.cpp:695
 msgid "Hungarian"
 msgstr "Magyar"
 
-#: src/Preferences.cpp:724
+#: src/Preferences.cpp:696
 msgid "Italian"
 msgstr "Olasz"
 
-#: src/Preferences.cpp:725
+#: src/Preferences.cpp:697
 msgid "Japanese"
 msgstr "Japán"
 
-#: src/Preferences.cpp:726
+#: src/Preferences.cpp:698
 msgid "Korean"
 msgstr "Koreai"
 
-#: src/Preferences.cpp:727
+#: src/Preferences.cpp:699
 msgid "Latvian"
 msgstr ""
 
-#: src/Preferences.cpp:728
+#: src/Preferences.cpp:700
 msgid "Lithuanian"
 msgstr "Litván"
 
-#: src/Preferences.cpp:729
+#: src/Preferences.cpp:701
 msgid "Norwegian (Nynorsk)"
 msgstr "Norvég (Nynorsk)"
 
-#: src/Preferences.cpp:730
+#: src/Preferences.cpp:702
 msgid "Polish"
 msgstr "Lengyel"
 
-#: src/Preferences.cpp:731
+#: src/Preferences.cpp:703
 msgid "Portuguese"
 msgstr "Portugál"
 
-#: src/Preferences.cpp:732
+#: src/Preferences.cpp:704
 msgid "Portuguese (Brazilian)"
 msgstr "Portugál (Brazíliai)"
 
-#: src/Preferences.cpp:733
+#: src/Preferences.cpp:705
 msgid "Romanian"
 msgstr "Román"
 
-#: src/Preferences.cpp:734
+#: src/Preferences.cpp:706
 msgid "Russian"
 msgstr "Orosz"
 
-#: src/Preferences.cpp:735
+#: src/Preferences.cpp:707
 msgid "Slovenian"
 msgstr "Szlovén"
 
-#: src/Preferences.cpp:736
+#: src/Preferences.cpp:708
 msgid "Spanish"
 msgstr "Spanyol"
 
-#: src/Preferences.cpp:737
+#: src/Preferences.cpp:709
 msgid "Swedish"
 msgstr "Svéd"
 
-#: src/Preferences.cpp:738
+#: src/Preferences.cpp:710
 msgid "Turkish"
 msgstr "Török"
 
-#: src/Preferences.cpp:739
+#: src/Preferences.cpp:711
 msgid "Ukrainian"
 msgstr "Ukrán"
 
-#: src/Preferences.cpp:842
+#: src/Preferences.cpp:814
 msgid "Change Language"
 msgstr "Nyelv megváltoztatása"
 
-#: src/Preferences.cpp:906
+#: src/Preferences.cpp:878
 msgid "There are no translations installed for aMule"
 msgstr "Nincsenek fordítások telepítve az aMule-hez"
 
-#: src/Preferences.cpp:907
+#: src/Preferences.cpp:879
 msgid "No languages available"
 msgstr "Nincs elérhető nyelv"
 
-#: src/Preferences.cpp:1038
+#: src/Preferences.cpp:1010
 msgid "no options available"
 msgstr "nincs elérhető opció"
 
-#: src/Preferences.cpp:2226
+#: src/Preferences.cpp:2179
 msgid "Invalid category found, skipping"
 msgstr "Érvénytelen kategória találva, mellőzés"
 
-#: src/Preferences.cpp:2395
+#: src/Preferences.cpp:2348
 msgid "TCP port can't be higher than 65532 due to server UDP socket being TCP+3"
 msgstr "A TCP port nem lehet magasabb 65532-nél, mert a kiszolgáló UDP port = TCP+3"
 
-#: src/Preferences.cpp:2396
+#: src/Preferences.cpp:2349
 #, c-format
 msgid "Default port will be used (%d)"
 msgstr "Alapértelmezett port lesz használva (%d)"
 
-#: src/PrefsUnifiedDlg.cpp:300 src/Statistics.cpp:866
+#: src/PrefsUnifiedDlg.cpp:298 src/Statistics.cpp:866
 msgid "Connection"
 msgstr "Csatlakozás"
 
-#: src/PrefsUnifiedDlg.cpp:301 src/SearchListCtrl.cpp:117
+#: src/PrefsUnifiedDlg.cpp:299 src/SearchListCtrl.cpp:117
 msgid "Directories"
 msgstr "Mappák"
 
-#: src/PrefsUnifiedDlg.cpp:302 src/Statistics.cpp:917
+#: src/PrefsUnifiedDlg.cpp:300 src/Statistics.cpp:917
 msgid "Servers"
 msgstr "Kiszolgálók"
 
-#: src/PrefsUnifiedDlg.cpp:303 src/ServerListCtrl.cpp:96
+#: src/PrefsUnifiedDlg.cpp:301 src/ServerListCtrl.cpp:96
 msgid "Files"
 msgstr "Fájlok"
 
-#: src/PrefsUnifiedDlg.cpp:304
+#: src/PrefsUnifiedDlg.cpp:302
 msgid "Security"
 msgstr "Biztonság"
 
-#: src/PrefsUnifiedDlg.cpp:305
+#: src/PrefsUnifiedDlg.cpp:303
 msgid "Interface"
 msgstr "Felület"
 
-#: src/PrefsUnifiedDlg.cpp:312
+#: src/PrefsUnifiedDlg.cpp:310
 msgid "IP2Country"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:315
+#: src/PrefsUnifiedDlg.cpp:313
 msgid "Proxy"
 msgstr "Proxy"
 
-#: src/PrefsUnifiedDlg.cpp:316
+#: src/PrefsUnifiedDlg.cpp:314
 msgid "Filters"
 msgstr "Szűrők"
 
-#: src/PrefsUnifiedDlg.cpp:317
+#: src/PrefsUnifiedDlg.cpp:315
 msgid "Remote Controls"
 msgstr "Távoli elérés"
 
-#: src/PrefsUnifiedDlg.cpp:318
+#: src/PrefsUnifiedDlg.cpp:316
 msgid "Online Signature"
 msgstr "Online aláírás"
 
-#: src/PrefsUnifiedDlg.cpp:319
+#: src/PrefsUnifiedDlg.cpp:317
 msgid "Advanced"
 msgstr "Haladó"
 
-#: src/PrefsUnifiedDlg.cpp:320
+#: src/PrefsUnifiedDlg.cpp:318
 msgid "Events"
 msgstr "Események"
 
-#: src/PrefsUnifiedDlg.cpp:323
+#: src/PrefsUnifiedDlg.cpp:321
 msgid "Debugging"
 msgstr "Hibakeresés"
 
-#: src/PrefsUnifiedDlg.cpp:453
+#: src/PrefsUnifiedDlg.cpp:451
 msgid ""
 "The following variables will be substituted:\n"
 "    %PARTFILE - full path to the file\n"
@@ -5700,15 +5666,15 @@ msgstr ""
 "    %PARTFILE - teljes út a fájlhoz\n"
 "    %PARTNAME - csak a fájl neve"
 
-#: src/PrefsUnifiedDlg.cpp:474
+#: src/PrefsUnifiedDlg.cpp:472
 msgid "Tray icon support requires libayatana-appindicator3 at compile time."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:490
+#: src/PrefsUnifiedDlg.cpp:488
 msgid "Not available on Wayland: the protocol does not report when a window is minimized, so this option cannot intercept the system minimize button. Workaround: launch aMule with `GDK_BACKEND=x11` to use XWayland instead."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:536
+#: src/PrefsUnifiedDlg.cpp:534
 msgid ""
 "Do not change these setting unless you know\n"
 "what you are doing, otherwise you can easily\n"
@@ -5724,35 +5690,26 @@ msgstr ""
 "Ezen beállítások módosítása nélkül is remekül fog\n"
 "működni az aMule."
 
-#: src/PrefsUnifiedDlg.cpp:647
+#: src/PrefsUnifiedDlg.cpp:645
 #, c-format
 msgid "Failed to connect Cfg to widget with the ID %d and key %s"
 msgstr "Cfg csatolása a widget-hez (ID-je: %d, kulcsa: %s) sikertelen"
 
-#: src/PrefsUnifiedDlg.cpp:695
+#: src/PrefsUnifiedDlg.cpp:693
 #, c-format
 msgid "Failed to transfer data from Cfg to Widget with the ID %d and key %s"
 msgstr "Adatátvitel a Cfg-ből a Widget-be (ID-je: %d, kulcsa: %s) sikertelen."
 
-#: src/PrefsUnifiedDlg.cpp:801
+#: src/PrefsUnifiedDlg.cpp:799
 msgid "The type of proxy you are connecting to"
 msgstr "A proxy típusa amihez kapcsolódsz"
 
-#: src/PrefsUnifiedDlg.cpp:1020
+#: src/PrefsUnifiedDlg.cpp:1003
 #, c-format
 msgid "Failed to transfer data from Widget to Cfg with the ID %d and key %s"
 msgstr "Adatátvitel a Widget-ből a Cfg-be (ID-je: %d, kulcsa: %s) sikertelen."
 
 #: src/PrefsUnifiedDlg.cpp:1103
-#, fuzzy
-msgid "No password set."
-msgstr "Jelszó ellenőrzése\n"
-
-#: src/PrefsUnifiedDlg.cpp:1132
-msgid "Guest access needs a password. Type one in the guest password field, or untick Enable guest access."
-msgstr ""
-
-#: src/PrefsUnifiedDlg.cpp:1144
 msgid ""
 "aMule must be restarted to enable these changes:\n"
 "\n"
@@ -5760,41 +5717,41 @@ msgstr ""
 "Újra kell indítani az aMule-t, hogy az alábbi változás(ok) érvénybe lépjen(ek):\n"
 "\n"
 
-#: src/PrefsUnifiedDlg.cpp:1151
+#: src/PrefsUnifiedDlg.cpp:1110
 msgid "- TCP port changed.\n"
 msgstr "- TCP port megváltozott.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1156
+#: src/PrefsUnifiedDlg.cpp:1115
 msgid "- UDP port changed.\n"
 msgstr "- UDP port megváltozott.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1161
+#: src/PrefsUnifiedDlg.cpp:1120
 #, fuzzy
 msgid "- Network interface binding changed.\n"
 msgstr "- Külső kapcsolat interfész megváltoztatva.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1166
+#: src/PrefsUnifiedDlg.cpp:1125
 msgid "- External connect port changed.\n"
 msgstr "- Külső kapcsolat port megváltoztatva.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1170
+#: src/PrefsUnifiedDlg.cpp:1129
 msgid "- External connect acceptance changed.\n"
 msgstr "- Külső kapcsolat elfogadása megváltoztatva.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1174
+#: src/PrefsUnifiedDlg.cpp:1133
 msgid "- External connect interface changed.\n"
 msgstr "- Külső kapcsolat interfész megváltoztatva.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1178
+#: src/PrefsUnifiedDlg.cpp:1137
 msgid "- Protocol obfuscation support changed.\n"
 msgstr "- Protokoll zavarás támogatása megváltozott.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1193
+#: src/PrefsUnifiedDlg.cpp:1151
 #, fuzzy
 msgid "- amuleapi settings changed.\n"
 msgstr "- Nyelv megváltozott.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1202
+#: src/PrefsUnifiedDlg.cpp:1160
 msgid ""
 "Your Auto-update server list is empty.\n"
 "'Auto-update server list at startup' will be disabled."
@@ -5802,7 +5759,7 @@ msgstr ""
 "Az automatikusan frissített kiszolgálóü lista üres.\n"
 "A 'kiszolgáló lista automatikus frissítése induláskor' letiltva."
 
-#: src/PrefsUnifiedDlg.cpp:1213
+#: src/PrefsUnifiedDlg.cpp:1171
 msgid ""
 "You have enabled external connections but have not specified a password.\n"
 "External connections cannot be enabled unless a valid password is specified."
@@ -5810,33 +5767,28 @@ msgstr ""
 "Engedélyezted a távoli elérést, de nem adtál meg jelszót.\n"
 "A távoli elérés nem használható érvényes jelszó nélkül."
 
-#: src/PrefsUnifiedDlg.cpp:1246
-#, c-format
-msgid "The amuleapi password could not be saved: %s"
-msgstr ""
-
-#: src/PrefsUnifiedDlg.cpp:1276
+#: src/PrefsUnifiedDlg.cpp:1202
 msgid "- Language changed.\n"
 msgstr "- Nyelv megváltozott.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1281
+#: src/PrefsUnifiedDlg.cpp:1207
 msgid "- Temp folder changed.\n"
 msgstr "- Ideiglenes mappa megváltozott.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1286
+#: src/PrefsUnifiedDlg.cpp:1212
 msgid "- ED2K network enabled.\n"
 msgstr "- ED2K hálózat engedélyezve.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1319
+#: src/PrefsUnifiedDlg.cpp:1245
 msgid "The shared-file exclusion pattern is not a valid regular expression. The filter has been left disabled."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1321 src/PrefsUnifiedDlg.cpp:1921
+#: src/PrefsUnifiedDlg.cpp:1247 src/PrefsUnifiedDlg.cpp:1841
 #, fuzzy
 msgid "Invalid regular expression"
 msgstr "Érvénytelen protokoll verzió."
 
-#: src/PrefsUnifiedDlg.cpp:1398
+#: src/PrefsUnifiedDlg.cpp:1324
 msgid ""
 "Both eD2k and Kad network are disabled.\n"
 "You won't be able to connect until you enable at least one of them."
@@ -5844,7 +5796,7 @@ msgstr ""
 "Az eD2k és a Kad hálózat is le van tiltva.\n"
 "Nem fogsz tudni kapcsolódni, amíg legalább az egyiket nem engedélyezed."
 
-#: src/PrefsUnifiedDlg.cpp:1403
+#: src/PrefsUnifiedDlg.cpp:1329
 msgid ""
 "Kad will not start if your UDP port is disabled.\n"
 "Enable UDP port or disable Kad."
@@ -5852,7 +5804,7 @@ msgstr ""
 "A Kad nem fog elindulni, ha az UDP portod le van tiltva.\n"
 "Engedélyezd az UDP portot vagy tiltsd le a Kad-ot."
 
-#: src/PrefsUnifiedDlg.cpp:1459
+#: src/PrefsUnifiedDlg.cpp:1385
 msgid ""
 "\n"
 "You MUST restart aMule now.\n"
@@ -5862,69 +5814,69 @@ msgstr ""
 "Most újra KELL indítanod az aMule-t.\n"
 "Ha nem indítod újra most, ne panaszkodj, ha bármi rossz történik.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1524
+#: src/PrefsUnifiedDlg.cpp:1450
 msgid "Could not register aMule for autostart at login. The autostart store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1526
+#: src/PrefsUnifiedDlg.cpp:1452
 msgid "Could not remove the autostart-at-login entry."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1527
+#: src/PrefsUnifiedDlg.cpp:1453
 #, fuzzy
 msgid "Autostart"
 msgstr "Automatikus frissítés elindítva"
 
-#: src/PrefsUnifiedDlg.cpp:1542
+#: src/PrefsUnifiedDlg.cpp:1468
 msgid "Register file type"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1542
+#: src/PrefsUnifiedDlg.cpp:1468
 msgid "Register URL handler"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1550
+#: src/PrefsUnifiedDlg.cpp:1476
 #, c-format
 msgid "aMule only handles eD2k-compatible magnets. If you replace the current magnet handler (%s), BitTorrent magnet links will stop working - aMule cannot download BitTorrent content. Continue?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1555
+#: src/PrefsUnifiedDlg.cpp:1481
 #, c-format
 msgid "Another application currently opens .emulecollection files (%s). Replace it with aMule?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1560
+#: src/PrefsUnifiedDlg.cpp:1486
 #, c-format
 msgid "Another application is currently the default handler for these links (%s). Replace it with aMule?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1585
+#: src/PrefsUnifiedDlg.cpp:1511
 msgid "Could not register aMule for .emulecollection files. The registration store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1587
+#: src/PrefsUnifiedDlg.cpp:1513
 #, fuzzy
 msgid "Could not remove the file type registration."
 msgstr "A letöltött fájlok eltolása %s helyre sikertelen"
 
-#: src/PrefsUnifiedDlg.cpp:1589
+#: src/PrefsUnifiedDlg.cpp:1515
 msgid "Could not register aMule as the URL handler. The registration store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1591
+#: src/PrefsUnifiedDlg.cpp:1517
 msgid "Could not remove the URL handler registration."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1661 src/PrefsUnifiedDlg.cpp:1688
+#: src/PrefsUnifiedDlg.cpp:1587 src/PrefsUnifiedDlg.cpp:1614
 #, fuzzy
 msgid "The web server and aMule API require external connections to be enabled."
 msgstr "Jelszó beállítva, külső kapcsolatok engedélyezve."
 
-#: src/PrefsUnifiedDlg.cpp:1671
+#: src/PrefsUnifiedDlg.cpp:1597
 msgid "The aMule web server is deprecated. Consider running the aMule API instead."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1735
+#: src/PrefsUnifiedDlg.cpp:1655
 msgid ""
 "Your Auto-update servers list is in blank.\n"
 "Please fill in at least one URL to point to a valid server.met file.\n"
@@ -5934,65 +5886,65 @@ msgstr ""
 "Kérlek adj meg legalább egy URL-t, ami érvényes server.met fájlra mutat .\n"
 "Az URL megadásához klikkelj a \"Lista\" gombra ezen checkbox mellett."
 
-#: src/PrefsUnifiedDlg.cpp:1876
+#: src/PrefsUnifiedDlg.cpp:1796
 msgid "Temporary files"
 msgstr "az Ideiglenes fájloknak"
 
-#: src/PrefsUnifiedDlg.cpp:1881
+#: src/PrefsUnifiedDlg.cpp:1801
 msgid "Incoming files"
 msgstr "Bejövő fájlok"
 
-#: src/PrefsUnifiedDlg.cpp:1886
+#: src/PrefsUnifiedDlg.cpp:1806
 msgid "Online Signatures"
 msgstr "az Online aláírásnak"
 
-#: src/PrefsUnifiedDlg.cpp:1899
+#: src/PrefsUnifiedDlg.cpp:1819
 #, c-format
 msgid "Choose a folder for %s"
 msgstr "Válassz egy mappát a %s-nek"
 
-#: src/PrefsUnifiedDlg.cpp:1923
+#: src/PrefsUnifiedDlg.cpp:1843
 #, fuzzy, c-format
 msgid "Would exclude %u of %u shared file"
 msgid_plural "Would exclude %u of %u shared files"
 msgstr[0] "%i ismert megosztott fájlt találtam"
 
-#: src/PrefsUnifiedDlg.cpp:1940
+#: src/PrefsUnifiedDlg.cpp:1860
 msgid "Browse for videoplayer"
 msgstr "Böngészés a videolejátszóhoz"
 
-#: src/PrefsUnifiedDlg.cpp:1944
+#: src/PrefsUnifiedDlg.cpp:1864
 msgid "Select browser"
 msgstr "Válaszd ki a böngésződet"
 
-#: src/PrefsUnifiedDlg.cpp:1948
+#: src/PrefsUnifiedDlg.cpp:1868
 #, fuzzy
 msgid "Select ffprobe binary"
 msgstr "Válaszd ki a böngésződet"
 
-#: src/PrefsUnifiedDlg.cpp:1954
+#: src/PrefsUnifiedDlg.cpp:1874
 #, c-format
 msgid "Executable%s"
 msgstr "Futtatható%s"
 
-#: src/PrefsUnifiedDlg.cpp:1988
+#: src/PrefsUnifiedDlg.cpp:1908
 msgid "ffprobe not found on PATH or in the standard install locations. Install ffmpeg (which ships ffprobe) or use Browse to pick a binary manually."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2000
+#: src/PrefsUnifiedDlg.cpp:1920
 msgid "Reset the settings on this page to their default values?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2001
+#: src/PrefsUnifiedDlg.cpp:1921
 #, fuzzy
 msgid "Reset to defaults"
 msgstr "Alapértelmezett"
 
-#: src/PrefsUnifiedDlg.cpp:2028
+#: src/PrefsUnifiedDlg.cpp:1948
 msgid "Edit server list"
 msgstr "Kiszolgáló lista szerkesztése"
 
-#: src/PrefsUnifiedDlg.cpp:2029
+#: src/PrefsUnifiedDlg.cpp:1949
 msgid ""
 "Add here URL's to download server.met files.\n"
 "Only one url on each line."
@@ -6000,174 +5952,170 @@ msgstr ""
 "URL-ek felvétele a server.met fájl letöltéséhez.\n"
 "Egy sorba csak egy URL."
 
-#: src/PrefsUnifiedDlg.cpp:2084
+#: src/PrefsUnifiedDlg.cpp:2004
 msgid "IP2Country update failed"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2229 src/PrefsUnifiedDlg.cpp:2260
+#: src/PrefsUnifiedDlg.cpp:2149 src/PrefsUnifiedDlg.cpp:2180
 msgid "Data by MaxMind GeoLite2"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2231 src/PrefsUnifiedDlg.cpp:2262
+#: src/PrefsUnifiedDlg.cpp:2151 src/PrefsUnifiedDlg.cpp:2182
 #, fuzzy
 msgid "Custom source"
 msgstr "Teljes források"
 
-#: src/PrefsUnifiedDlg.cpp:2233 src/PrefsUnifiedDlg.cpp:2264
+#: src/PrefsUnifiedDlg.cpp:2153 src/PrefsUnifiedDlg.cpp:2184
 msgid "Data by DB-IP.com"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2284
+#: src/PrefsUnifiedDlg.cpp:2204
 #, fuzzy, c-format
 msgid "Status: Loaded%s"
 msgstr "Állapot:"
 
-#: src/PrefsUnifiedDlg.cpp:2286
+#: src/PrefsUnifiedDlg.cpp:2206
 #, fuzzy, c-format
 msgid "Status: Loaded%s - %s"
 msgstr "Állapot:"
 
-#: src/PrefsUnifiedDlg.cpp:2290
+#: src/PrefsUnifiedDlg.cpp:2210
 msgid "Status: Failed to load - click 'Update now' to refresh."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2292
+#: src/PrefsUnifiedDlg.cpp:2212
 msgid "Status: Not found - click 'Update now' to download."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2350 src/PrefsUnifiedDlg.cpp:2374
+#: src/PrefsUnifiedDlg.cpp:2270 src/PrefsUnifiedDlg.cpp:2294
 #, c-format
 msgid "Update delay: %d second"
 msgid_plural "Update delay: %d seconds"
 msgstr[0] "Frissítés késleltetése: %d másodperc"
 
-#: src/PrefsUnifiedDlg.cpp:2358
+#: src/PrefsUnifiedDlg.cpp:2278
 #, c-format
 msgid "Time for average graph: %d minute"
 msgid_plural "Time for average graph: %d minutes"
 msgstr[0] "Grafikon átlagos ideje: %d perc"
 
-#: src/PrefsUnifiedDlg.cpp:2367
+#: src/PrefsUnifiedDlg.cpp:2287
 #, c-format
 msgid "Connections Graph Scale: %d"
 msgstr "Kapcsolatok grafikon-skálája: %d"
 
-#: src/PrefsUnifiedDlg.cpp:2382
+#: src/PrefsUnifiedDlg.cpp:2302
 #, c-format
 msgid "File Buffer Size: %d byte"
 msgid_plural "File Buffer Size: %d bytes"
 msgstr[0] "Fájl buffer méret: %d bájt"
 
-#: src/PrefsUnifiedDlg.cpp:2392
+#: src/PrefsUnifiedDlg.cpp:2312
 #, c-format
 msgid "Upload Queue Size: %d client"
 msgid_plural "Upload Queue Size: %d clients"
 msgstr[0] "Feltöltési várólista nagysága: %d kliens"
 
-#: src/PrefsUnifiedDlg.cpp:2402
+#: src/PrefsUnifiedDlg.cpp:2322
 #, c-format
 msgid "Server connection refresh interval: %d minute"
 msgid_plural "Server connection refresh interval: %d minutes"
 msgstr[0] "Kiszolgáló kapcsolat frissítési gyakorisága: %d perc"
 
-#: src/PrefsUnifiedDlg.cpp:2407
+#: src/PrefsUnifiedDlg.cpp:2327
 msgid "Server connection refresh interval: Disabled"
 msgstr "Kiszolgáló kapcsolat frissítési gyakorisága: Tiltva"
 
-#: src/PrefsUnifiedDlg.cpp:2451
+#: src/PrefsUnifiedDlg.cpp:2371
 msgid "disabled"
 msgstr "letiltva"
 
-#: src/PrefsUnifiedDlg.cpp:2477
+#: src/PrefsUnifiedDlg.cpp:2397
 #, c-format
 msgid "Execute command on '%s' event"
 msgstr "Parancs végrehajtása a(z) '%s' eseménynél"
 
-#: src/PrefsUnifiedDlg.cpp:2484
+#: src/PrefsUnifiedDlg.cpp:2404
 msgid "Enable command execution on core"
 msgstr "Parancs futtatása a magon"
 
-#: src/PrefsUnifiedDlg.cpp:2496
+#: src/PrefsUnifiedDlg.cpp:2416
 msgid "Core command:"
 msgstr "Mag parancs:"
 
-#: src/PrefsUnifiedDlg.cpp:2512
+#: src/PrefsUnifiedDlg.cpp:2432
 msgid "Enable command execution on GUI"
 msgstr "Parancs futtatása a grafikus felületen"
 
-#: src/PrefsUnifiedDlg.cpp:2524
+#: src/PrefsUnifiedDlg.cpp:2444
 msgid "GUI command:"
 msgstr "GUI parancs:"
 
-#: src/PrefsUnifiedDlg.cpp:2540
+#: src/PrefsUnifiedDlg.cpp:2460
 msgid "The following variables will be replaced:"
 msgstr "A következő változók lesznek behelyettesítve:"
 
-#: src/PrefsUnifiedDlg.cpp:2708
+#: src/PrefsUnifiedDlg.cpp:2628
 msgid ""
 "The following folders look like system or sensitive locations:\n"
 "\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2713
+#: src/PrefsUnifiedDlg.cpp:2633
 msgid "Sharing them recursively will publish every file underneath on the eD2k/Kad networks. Do you really want to do this?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2716
+#: src/PrefsUnifiedDlg.cpp:2636
 #, fuzzy
 msgid "Confirm shared folders"
 msgstr "Megosztott mappák"
 
-#: src/PrefsUnifiedDlg.cpp:2744
+#: src/PrefsUnifiedDlg.cpp:2664
 #, fuzzy
 msgid "Reloading shared files..."
 msgstr "Megosztott fájlok frissítése"
 
-#: src/PrefsUnifiedDlg.cpp:2745
+#: src/PrefsUnifiedDlg.cpp:2665
 msgid "Scanning for subdirectories..."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2746
+#: src/PrefsUnifiedDlg.cpp:2666
 #, fuzzy
 msgid "Updating shared folders"
 msgstr "Megosztott mappák"
 
-#: src/PrefsUnifiedDlg.cpp:2773
+#: src/PrefsUnifiedDlg.cpp:2693
 #, c-format
 msgid "Scanned %u directories..."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2823
+#: src/PrefsUnifiedDlg.cpp:2743
 #, fuzzy, c-format
 msgid "Reloading shared files: %u files scanned"
 msgstr "A megosztott fájlok listájának újratöltése."
 
-#: src/PrefsUnifiedDlg.cpp:2873
+#: src/PrefsUnifiedDlg.cpp:2793
 #, fuzzy
 msgid "Shared folder"
 msgstr "Megosztott mappák"
 
-#: src/SearchDlg.cpp:280
-msgid "Clear search history"
-msgstr ""
-
-#: src/SearchDlg.cpp:584
+#: src/SearchDlg.cpp:425
 msgid "It's impossible to search when both eD2k and Kademlia are disabled."
 msgstr "Nem lehet keresni, ha az eD2k és a Kademlia hálózat is le van tiltva."
 
-#: src/SearchDlg.cpp:585 src/SearchListCtrl.cpp:858
+#: src/SearchDlg.cpp:426 src/SearchListCtrl.cpp:858
 msgid "Search error"
 msgstr "Keresési hiba"
 
-#: src/SearchDlg.cpp:929
+#: src/SearchDlg.cpp:768
 msgid "Min size must be smaller than max size. Max size ignored."
 msgstr "A minimum méretnek kisebbnek kell lennie a maximum méretnél. Maximum méret figyelmen kívül hagyva."
 
-#: src/SearchDlg.cpp:930 src/SearchDlg.cpp:1012
+#: src/SearchDlg.cpp:769 src/SearchDlg.cpp:851
 msgid "Search warning"
 msgstr "Keresési figyelmeztetés"
 
-#: src/SearchDlg.cpp:1092 src/SearchListCtrl.cpp:735
+#: src/SearchDlg.cpp:929 src/SearchListCtrl.cpp:735
 msgid "Main"
 msgstr "Alap"
 

--- a/po/hu.po
+++ b/po/hu.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-28 10:19+0200\n"
+"POT-Creation-Date: 2026-07-28 12:17+0200\n"
 "PO-Revision-Date: 2026-07-27 11:39+0000\n"
 "Last-Translator: Dévai Tamás <gonosztopi@amule.org>\n"
 "Language-Team: Hungarian <hu@li.org>\n"
@@ -207,83 +207,83 @@ msgstr "ED2KLinks fájl megnyitása sikertelen."
 msgid "WARNING: You can't add yourself as a source for an eD2k link while having a lowid."
 msgstr "FIGYELEM: Nem adhatod magad forrásként egy eD2k hivatkozáshoz amíg alacsony azonosítód (lowid) van."
 
-#: src/amule.cpp:300
+#: src/amule.cpp:301
 msgid "Now, exiting main app..."
 msgstr "Kilépés a fő alkalmazásból..."
 
-#: src/amule.cpp:330
+#: src/amule.cpp:331
 #, c-format
 msgid "Terminating amuleweb instance with pid '%d' ... "
 msgstr "Az amuleweb instancia - melynek a pid-je '%d' - bezárása ... "
 
-#: src/amule.cpp:334
+#: src/amule.cpp:335
 #, c-format
 msgid "Killing amuleweb instance with pid '%d' ... "
 msgstr "Az amuleweb instancia - melynek a pid-je '%d' - kivégzése ... "
 
-#: src/amule.cpp:336 src/amule.cpp:349 src/ClientRef.cpp:180
+#: src/amule.cpp:337 src/amule.cpp:350 src/ClientRef.cpp:180
 #: src/SearchDlg.cpp:1041 src/ServerListCtrl.cpp:98
 msgid "Failed"
 msgstr "Sikertelen"
 
-#: src/amule.cpp:343
+#: src/amule.cpp:344
 #, fuzzy, c-format
 msgid "Terminating amuleapi instance with pid '%d' ... "
 msgstr "Az amuleweb instancia - melynek a pid-je '%d' - bezárása ... "
 
-#: src/amule.cpp:347
+#: src/amule.cpp:348
 #, fuzzy, c-format
 msgid "Killing amuleapi instance with pid '%d' ... "
 msgstr "Az amuleweb instancia - melynek a pid-je '%d' - kivégzése ... "
 
-#: src/amule.cpp:355
+#: src/amule.cpp:356
 msgid "aMule OnExit: Terminating core."
 msgstr "aMule OnExit: Mag leállítása."
 
-#: src/amule.cpp:466
+#: src/amule.cpp:467
 msgid "aMule shutdown completed."
 msgstr "Az aMule leállítása befejeződött."
 
-#: src/amule.cpp:470
+#: src/amule.cpp:471
 msgid "Memory debug results for aMule exit:"
 msgstr "Memória debug eredmények az aMule bezárásáról:"
 
-#: src/amule.cpp:651
+#: src/amule.cpp:652
 #, c-format
 msgid "Binding aMule's peer-to-peer traffic to interface: %s (HTTP updates use the default route)"
 msgstr ""
 
-#: src/amule.cpp:655
+#: src/amule.cpp:656
 #, c-format
 msgid "Binding all network traffic to interface: %s"
 msgstr ""
 
-#: src/amule.cpp:659
+#: src/amule.cpp:660
 #, c-format
 msgid "WARNING: configured network interface '%s' was not found - traffic is NOT bound to it and may leave via the default route. Check the interface name in Preferences."
 msgstr ""
 
-#: src/amule.cpp:665
+#: src/amule.cpp:666
 #, c-format
 msgid "WARNING: binding to network interface '%s' requires elevated privileges and was NOT applied - traffic may leave via the default route. Grant the capability (e.g. 'sudo setcap cap_net_raw+ep' on the aMule binary) or run with sufficient privileges."
 msgstr ""
 
-#: src/amule.cpp:673
+#: src/amule.cpp:674
 #, c-format
 msgid "WARNING: could not bind to network interface '%s' - traffic may leave via the default route."
 msgstr ""
 
-#: src/amule.cpp:732
+#: src/amule.cpp:733
 msgid "Your locale has been changed to System Default due to a configuration change. Sorry."
 msgstr "Nyelvi beállításaid egy konfigurációs változás miatt az alapértelmezettre lettek átállítva. Bocs."
 
-#: src/amule.cpp:734 src/amule.cpp:1581 src/CatDialog.cpp:128
+#: src/amule.cpp:735 src/amule.cpp:1589 src/CatDialog.cpp:128
 #: src/CatDialog.cpp:136 src/CatDialog.cpp:149 src/ServerList.cpp:366
 #: src/ServerListCtrl.cpp:152
 msgid "Info"
 msgstr "Infó"
 
-#: src/amule.cpp:741
+#: src/amule.cpp:742
 msgid ""
 "\n"
 "EC configuration"
@@ -291,20 +291,20 @@ msgstr ""
 "\n"
 "EC beállítások"
 
-#: src/amule.cpp:744
+#: src/amule.cpp:745
 msgid "Password set and external connections enabled."
 msgstr "Jelszó beállítva, külső kapcsolatok engedélyezve."
 
-#: src/amule.cpp:754 src/KadDlg.cpp:176 src/KadDlg.cpp:185
-#: src/PrefsUnifiedDlg.cpp:1387 src/SharedFilesCtrl.cpp:476
+#: src/amule.cpp:755 src/KadDlg.cpp:176 src/KadDlg.cpp:185
+#: src/PrefsUnifiedDlg.cpp:1461 src/SharedFilesCtrl.cpp:476
 msgid "WARNING"
 msgstr "FIGYELEM"
 
-#: src/amule.cpp:991
+#: src/amule.cpp:992
 msgid "Network bootstrap"
 msgstr "Hálózati bootstrap"
 
-#: src/amule.cpp:996
+#: src/amule.cpp:997
 msgid ""
 "aMule has detected missing network bootstrap files.\n"
 "Select which ones to download:"
@@ -312,52 +312,52 @@ msgstr ""
 "aMule hiányzó hálózati bootstrap fájlokat észlelt.\n"
 "Válassza ki a letölteni kivántakat:"
 
-#: src/amule.cpp:1005 src/FirstRunWizard.cpp:411
+#: src/amule.cpp:1006 src/FirstRunWizard.cpp:411
 msgid "eD2k server list (server.met)"
 msgstr "eD2k szerver lista (server.met)"
 
-#: src/amule.cpp:1012 src/FirstRunWizard.cpp:416
+#: src/amule.cpp:1013 src/FirstRunWizard.cpp:416
 msgid "Kad bootstrap nodes (nodes.dat)"
 msgstr "Kad bootstrap csomópontok (nodes.dat)"
 
-#: src/amule.cpp:1102
+#: src/amule.cpp:1103
 #, c-format
 msgid "web server running on pid %d"
 msgstr "web kiszolgáló fut, pid=%d"
 
-#: src/amule.cpp:1115
+#: src/amule.cpp:1116
 msgid "You requested to run web server on startup, but the amuleweb binary cannot be run. Please install the package containing aMule web server, or build aMule from source with -DBUILD_WEBSERVER=YES and install it."
 msgstr "A web szerver futtatását kérte induláskor, de az amuleweb program nem futtatható. Kérem telepítse az aMule web szervert tartalmazó csomagot, vagy építse az aMule-t a forráskódból a -DBUILD_WEBSERVER=YES paraméterrel és installálja azt."
 
-#: src/amule.cpp:1120 src/amule.cpp:1177 src/amule.cpp:1291 src/amule.cpp:1593
+#: src/amule.cpp:1121 src/amule.cpp:1185 src/amule.cpp:1299 src/amule.cpp:1601
 #: src/amule-remote-gui.cpp:603 src/amule-remote-gui.cpp:671
 #: src/amule-remote-gui.cpp:709 src/amule-remote-gui.cpp:1282
 #: src/amule-remote-gui.cpp:1345 src/amule-remote-gui.cpp:1372
-#: src/DownloadQueue.cpp:1481
+#: src/DownloadQueue.cpp:1481 src/PrefsUnifiedDlg.cpp:1247
 msgid "ERROR"
 msgstr "HIBA"
 
-#: src/amule.cpp:1166
+#: src/amule.cpp:1174
 #, fuzzy, c-format
 msgid "amuleapi running on pid %d"
 msgstr "web kiszolgáló fut, pid=%d"
 
-#: src/amule.cpp:1172
+#: src/amule.cpp:1180
 #, fuzzy
 msgid "You requested to run amuleapi on startup, but the amuleapi binary cannot be run. Please install the package containing aMule's REST API server, or build aMule from source with -DBUILD_AMULEAPI=YES and install it."
 msgstr "A web szerver futtatását kérte induláskor, de az amuleweb program nem futtatható. Kérem telepítse az aMule web szervert tartalmazó csomagot, vagy építse az aMule-t a forráskódból a -DBUILD_WEBSERVER=YES paraméterrel és installálja azt."
 
-#: src/amule.cpp:1259
+#: src/amule.cpp:1267
 #, c-format
 msgid "Could not bind ports to the specified address: %s"
 msgstr "Nem tudom a portokat a megadott címhez (%s) rendelni."
 
-#: src/amule.cpp:1283
+#: src/amule.cpp:1291
 #, c-format
 msgid "Port %u is not available. You will be LOWID\n"
 msgstr "A %u port nem elérhető. Alacsony kliens azonosítót kapsz (LOWID)\n"
 
-#: src/amule.cpp:1288
+#: src/amule.cpp:1296
 #, c-format
 msgid ""
 "Port %u is not available!\n"
@@ -372,48 +372,48 @@ msgstr ""
 "\n"
 "Ellenőrízd a hálózatodat, hogy megbizonyosodj, hogy a port nyitva van kifelé és befelé egyaránt."
 
-#: src/amule.cpp:1385
+#: src/amule.cpp:1393
 msgid "Failed to create OnlineSig File"
 msgstr "Online-Aláírás fájl létrehozása sikertelen"
 
-#: src/amule.cpp:1393
+#: src/amule.cpp:1401
 msgid "Failed to create aMule OnlineSig File"
 msgstr "Az aMule OnlineAláírás fájl létrehozása sikertelen"
 
-#: src/amule.cpp:1556
+#: src/amule.cpp:1564
 msgid "The selected locale seems not to be installed on your box. (Note: I'll try to set it anyway)"
 msgstr "A kiválasztott nyelvi beállítások úgy látszik nincsenek telepítve a gépeden. (Megjegyzés: Mindenesetre mepróbálom ezt beállítani)"
 
-#: src/amule.cpp:1566
+#: src/amule.cpp:1574
 #, c-format
 msgid "This is the first time you run aMule %s"
 msgstr "Ez az első alkalom, hogy az aMule %s-t futtatod"
 
-#: src/amule.cpp:1569
+#: src/amule.cpp:1577
 msgid "This version is a testing version, updated daily, and\n"
 msgstr "Ez egy teszt verzió, naponta frissítve, és\n"
 
-#: src/amule.cpp:1570
+#: src/amule.cpp:1578
 msgid "we give no warranty it won't break anything, burn your house,\n"
 msgstr "nem vállalunk garanciát, hogy nem omlik össze, gyújtja fel a házad,\n"
 
-#: src/amule.cpp:1571
+#: src/amule.cpp:1579
 msgid "or kill your dog. But it *should* be safe to use anyway.\n"
 msgstr "vagy öli meg a kutyád. *Elvileg* nyugodtan használható.\n"
 
-#: src/amule.cpp:1576
+#: src/amule.cpp:1584
 msgid "More information, support and new releases can found at our homepage,\n"
 msgstr "Még több információ, támogatás és új kiadások találhatóak honlapunkon,\n"
 
-#: src/amule.cpp:1577
+#: src/amule.cpp:1585
 msgid "at https://amule-org.github.io, or in our IRC channel #aMule at irc.libera.chat.\n"
 msgstr "a https://amule-org.github.io, vagy az #aMule IRC csatornánkon az irc.libera.chat.\n"
 
-#: src/amule.cpp:1579
+#: src/amule.cpp:1587
 msgid "Feel free to report any bugs to https://github.com/amule-org/amule/issues"
 msgstr "Nyugodtan jelezz bármilyen hibát a https://github.com/amule-org/amule/issues"
 
-#: src/amule.cpp:1591
+#: src/amule.cpp:1599
 msgid ""
 "The folder for Online Signature files you specified is INVALID!\n"
 " OnlineSignature will be DISABLED until you fix it on preferences."
@@ -421,137 +421,137 @@ msgstr ""
 "Az Online aláírás fájl könyvtárának megadott hely ÉRVÉNYTELEN!\n"
 " Az OnlineAláírás letiltásra kerül, amíg ki nem javítod azt a beállítások menüpontban."
 
-#: src/amule.cpp:1654
+#: src/amule.cpp:1662
 msgid "Server hostname notified"
 msgstr "Szerver hostname értesítve"
 
-#: src/amule.cpp:2031
+#: src/amule.cpp:2039
 #, c-format
 msgid "Disk space preallocation for file '%s' failed: %s"
 msgstr "Lemezterület helyfoglalás a '%s' fájl számára sikertelen: %s"
 
-#: src/amule.cpp:2160
+#: src/amule.cpp:2168
 msgid "ERROR: can't open logfile"
 msgstr "HIBA: Nem tudom megnyitni a napló fájlt"
 
-#: src/amule.cpp:2164
+#: src/amule.cpp:2172
 msgid "WARNING: logfile is empty. Something is wrong."
 msgstr "FIGYELEM: a napló üres. Valami nem stimmel."
 
-#: src/amule.cpp:2181
+#: src/amule.cpp:2189
 msgid "Log has been reset"
 msgstr "Napló törölve"
 
-#: src/amule.cpp:2205
+#: src/amule.cpp:2213
 #, c-format
 msgid "ServerMessage: %s"
 msgstr "KiszolgálóÜzenet: %s"
 
-#: src/amule.cpp:2248 src/IP2Country.cpp:220 src/IPFilter.cpp:514
+#: src/amule.cpp:2256 src/IP2Country.cpp:220 src/IPFilter.cpp:514
 #: src/ServerList.cpp:875
 #, c-format
 msgid "Skipped download of %s, because requested file is not newer."
 msgstr "A %s letöltése kihagyva, mert a kívánt fájl nem újabb."
 
-#: src/amule.cpp:2251
+#: src/amule.cpp:2259
 msgid "Failed to download the nodes list."
 msgstr "Csomópont-lista letöltése sikertelen."
 
-#: src/amule.cpp:2314
+#: src/amule.cpp:2322
 msgid "Failed to open the downloaded version check file"
 msgstr "Nem sikerült megnyitni a letöltött verzió-ellenőrző fájlt"
 
-#: src/amule.cpp:2317 src/amule.cpp:2336
+#: src/amule.cpp:2325 src/amule.cpp:2344
 msgid "Corrupted version check file"
 msgstr "Sérült verzió-ellenőrző fájl"
 
-#: src/amule.cpp:2359
+#: src/amule.cpp:2367
 msgid "You are using an outdated version of aMule!"
 msgstr "Az aMule egy elavult verzióját használod!"
 
-#: src/amule.cpp:2361
+#: src/amule.cpp:2369
 #, c-format
 msgid "Your aMule version is %i.%i.%i and the latest version is %li.%li.%li"
 msgstr "A te aMule verziód %i.%i.%i, a legújabb verzió pedig %li.%li.%li"
 
-#: src/amule.cpp:2365
+#: src/amule.cpp:2373
 msgid "The latest version can always be found at https://github.com/amule-org/amule/releases/latest"
 msgstr "A legújabb verzió mindig megtalálható a https://github.com/amule-org/amule/releases/latest honlapon."
 
-#: src/amule.cpp:2368
+#: src/amule.cpp:2376
 #, c-format
 msgid "WARNING: Your aMuled version is outdated: %i.%i.%i < %li.%li.%li"
 msgstr "FIGYELEM: A te aMule verziód elavult: %i.%i.%i < %li.%li.%li"
 
-#: src/amule.cpp:2374
+#: src/amule.cpp:2382
 msgid "Your copy of aMule is up to date."
 msgstr "Az aMule verziód naprakész."
 
-#: src/amule.cpp:2381
+#: src/amule.cpp:2389
 msgid "Failed to download the version check file"
 msgstr "Verzió-ellenőrzés fájl letöltése sikertelen."
 
-#: src/amule.cpp:2550 src/amule-remote-gui.cpp:1133
+#: src/amule.cpp:2558 src/amule-remote-gui.cpp:1133
 #, c-format
 msgid "Users: %s | Files: %s"
 msgstr "Felhasználók: %s | Fájlok: %s"
 
-#: src/amule.cpp:2551 src/amule-remote-gui.cpp:1134
+#: src/amule.cpp:2559 src/amule-remote-gui.cpp:1134
 #, c-format
 msgid "Users: E: %s K: %s | Files: E: %s K: %s"
 msgstr "Felhasználók: E: %s K: %s | Fájlok: E: %s K: %s"
 
-#: src/amule.cpp:2565 src/amule-remote-gui.cpp:1147
+#: src/amule.cpp:2573 src/amule-remote-gui.cpp:1147
 msgid "No networks selected"
 msgstr "Nincs hálózat kiválasztva"
 
-#: src/amule.cpp:2633 src/TextClient.cpp:903
+#: src/amule.cpp:2641 src/TextClient.cpp:903
 msgid "with LowID"
 msgstr "LowID-val"
 
-#: src/amule.cpp:2633 src/TextClient.cpp:904
+#: src/amule.cpp:2641 src/TextClient.cpp:904
 msgid "with HighID"
 msgstr "HighID-val"
 
-#: src/amule.cpp:2635
+#: src/amule.cpp:2643
 #, c-format
 msgid "Connected to %s %s"
 msgstr "Kapcsolódva ehhez %s %s"
 
-#: src/amule.cpp:2640
+#: src/amule.cpp:2648
 #, c-format
 msgid "Connecting to %s"
 msgstr "Kapcsolódás %s-hez"
 
-#: src/amule.cpp:2642
+#: src/amule.cpp:2650
 msgid "Disconnected from eD2k"
 msgstr "Leválasztva az eD2k-ról"
 
-#: src/amule.cpp:2651
+#: src/amule.cpp:2659
 msgid "Kad started."
 msgstr "Kad elindítva."
 
-#: src/amule.cpp:2653
+#: src/amule.cpp:2661
 msgid "Kad stopped."
 msgstr "Kad leállítva."
 
-#: src/amule.cpp:2661
+#: src/amule.cpp:2669
 msgid "Connected to Kad (ok)"
 msgstr "Kapcsolódva a Kad-hoz (rendben)"
 
-#: src/amule.cpp:2663
+#: src/amule.cpp:2671
 msgid "Connected to Kad (firewalled)"
 msgstr "Kapcsolódva a Kad-hoz (tűzfal mögül)"
 
-#: src/amule.cpp:2667
+#: src/amule.cpp:2675
 msgid "Disconnected from Kad"
 msgstr "Leválasztva a Kad-ról"
 
-#: src/amule.cpp:2699
+#: src/amule.cpp:2707
 msgid "Kad network cannot be used if UDP port is disabled on preferences, not starting."
 msgstr "A Kad hálózat nem használható, ha az UDP port le van tiltva a beállításokban, nem indítom."
 
-#: src/amule.cpp:2703
+#: src/amule.cpp:2711
 msgid "Kad network disabled on preferences, not connecting."
 msgstr "A Kad hálózat le van tiltva  a beállításokban, nem kapcsolódom."
 
@@ -595,36 +595,36 @@ msgid "FATAL ERROR: Failed to create Timer"
 msgstr "VÉGZETES HIBA: Időzítő létrehozása sikertelen"
 
 #: src/amuleDlg.cpp:361 src/amuleDlg.cpp:1787 src/amuleDlg.cpp:2033
-#: src/muuli_wdr.cpp:1492 src/muuli_wdr.cpp:3418
+#: src/muuli_wdr.cpp:1492 src/muuli_wdr.cpp:3449
 msgid "Networks"
 msgstr "Hálózatok"
 
-#: src/amuleDlg.cpp:362 src/amuleDlg.cpp:1793 src/muuli_wdr.cpp:3419
+#: src/amuleDlg.cpp:362 src/amuleDlg.cpp:1793 src/muuli_wdr.cpp:3450
 msgid "Searches"
 msgstr "Keresések"
 
 #: src/amuleDlg.cpp:363 src/amuleDlg.cpp:1799 src/DownloadListCtrl.cpp:740
-#: src/muuli_wdr.cpp:392 src/muuli_wdr.cpp:1585 src/muuli_wdr.cpp:3420
+#: src/muuli_wdr.cpp:392 src/muuli_wdr.cpp:1585 src/muuli_wdr.cpp:3451
 #: src/Statistics.cpp:829
 msgid "Downloads"
 msgstr "Letöltések"
 
-#: src/amuleDlg.cpp:364 src/amuleDlg.cpp:1805 src/muuli_wdr.cpp:3294
+#: src/amuleDlg.cpp:364 src/amuleDlg.cpp:1805 src/muuli_wdr.cpp:3325
 msgid "Shared files"
 msgstr "Megosztott fájlok"
 
-#: src/amuleDlg.cpp:365 src/amuleDlg.cpp:1811 src/muuli_wdr.cpp:2926
-#: src/muuli_wdr.cpp:3376 src/muuli_wdr.cpp:3423
+#: src/amuleDlg.cpp:365 src/amuleDlg.cpp:1811 src/muuli_wdr.cpp:2957
+#: src/muuli_wdr.cpp:3407 src/muuli_wdr.cpp:3454
 msgid "Messages"
 msgstr "Üzenetek"
 
-#: src/amuleDlg.cpp:366 src/amuleDlg.cpp:1817 src/muuli_wdr.cpp:3424
-#: src/PrefsUnifiedDlg.cpp:312 src/Statistics.cpp:779 src/Statistics.cpp:1235
+#: src/amuleDlg.cpp:366 src/amuleDlg.cpp:1817 src/muuli_wdr.cpp:3455
+#: src/PrefsUnifiedDlg.cpp:314 src/Statistics.cpp:779 src/Statistics.cpp:1235
 msgid "Statistics"
 msgstr "Statisztikák"
 
-#: src/amuleDlg.cpp:368 src/amuleDlg.cpp:1824 src/muuli_wdr.cpp:3426
-#: src/PrefsUnifiedDlg.cpp:328 src/utils/wxCas/src/wxcasprefs.cpp:39
+#: src/amuleDlg.cpp:368 src/amuleDlg.cpp:1824 src/muuli_wdr.cpp:3457
+#: src/PrefsUnifiedDlg.cpp:330 src/utils/wxCas/src/wxcasprefs.cpp:39
 msgid "Preferences"
 msgstr "Beállítások"
 
@@ -682,8 +682,8 @@ msgstr "Kad: Nincs kapcsolat"
 #: src/amuleDlg.cpp:1029 src/DownloadListCtrl.cpp:505
 #: src/DownloadListCtrl.cpp:749 src/FriendListCtrl.cpp:180
 #: src/muuli_wdr.cpp:731 src/muuli_wdr.cpp:782 src/muuli_wdr.cpp:846
-#: src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2231 src/muuli_wdr.cpp:2316
-#: src/muuli_wdr.cpp:3064 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
+#: src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2262 src/muuli_wdr.cpp:2347
+#: src/muuli_wdr.cpp:3095 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
 #: src/ServerListCtrl.cpp:606 src/TransferWnd.cpp:378
 #: src/utils/wxCas/src/wxcasprefs.cpp:235
 msgid "Cancel"
@@ -694,7 +694,7 @@ msgid "Stop the current connection attempts"
 msgstr "Aktuális kapcsolódási kísérletek leállítása"
 
 #: src/amuleDlg.cpp:1035 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976
-#: src/muuli_wdr.cpp:2454
+#: src/muuli_wdr.cpp:2485
 msgid "Disconnect"
 msgstr "Szétkapcsolás"
 
@@ -703,7 +703,7 @@ msgid "Disconnect from the currently connected networks"
 msgstr "Leválaszt az éppen kapcsolódott hálózatokról."
 
 #: src/amuleDlg.cpp:1041 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979
-#: src/muuli_wdr.cpp:2609 src/muuli_wdr.cpp:3061 src/muuli_wdr.cpp:3416
+#: src/muuli_wdr.cpp:2640 src/muuli_wdr.cpp:3092 src/muuli_wdr.cpp:3447
 msgid "Connect"
 msgstr "Kapcsolatfelvétel"
 
@@ -757,7 +757,7 @@ msgstr "Kilépés megerősítése"
 msgid "Launch Command: "
 msgstr "Parancs futtatása: "
 
-#: src/amuleDlg.cpp:1632 src/muuli_wdr.cpp:1978 src/Preferences.cpp:952
+#: src/amuleDlg.cpp:1632 src/muuli_wdr.cpp:1982 src/Preferences.cpp:979
 msgid "- default -"
 msgstr "- alapértelmezett -"
 
@@ -771,48 +771,48 @@ msgstr "A(z) '%s' felület könyvtár nem létezik"
 msgid "WARNING: Unable to open skin file '%s' for read"
 msgstr "FIGYELEM: Nem tudom a(z) '%s' felület fáljt megnyitni olvasásra"
 
-#: src/amuleDlg.cpp:1791 src/muuli_wdr.cpp:3418
+#: src/amuleDlg.cpp:1791 src/muuli_wdr.cpp:3449
 msgid "Networks Window"
 msgstr "Hálózatok ablaka"
 
-#: src/amuleDlg.cpp:1797 src/muuli_wdr.cpp:3419
+#: src/amuleDlg.cpp:1797 src/muuli_wdr.cpp:3450
 msgid "Searches Window"
 msgstr "Keresés ablaka"
 
-#: src/amuleDlg.cpp:1803 src/muuli_wdr.cpp:3420
+#: src/amuleDlg.cpp:1803 src/muuli_wdr.cpp:3451
 msgid "Downloads Window"
 msgstr "Letöltések ablaka"
 
-#: src/amuleDlg.cpp:1809 src/muuli_wdr.cpp:3422
+#: src/amuleDlg.cpp:1809 src/muuli_wdr.cpp:3453
 msgid "Shared Files Window"
 msgstr "Megosztott fájlok ablaka"
 
-#: src/amuleDlg.cpp:1815 src/muuli_wdr.cpp:3423
+#: src/amuleDlg.cpp:1815 src/muuli_wdr.cpp:3454
 msgid "Messages Window"
 msgstr "Üzenetek ablaka"
 
-#: src/amuleDlg.cpp:1821 src/muuli_wdr.cpp:3424
+#: src/amuleDlg.cpp:1821 src/muuli_wdr.cpp:3455
 msgid "Statistics Graph Window"
 msgstr "Statisztikai grafikonok ablaka"
 
-#: src/amuleDlg.cpp:1828 src/muuli_wdr.cpp:3426
+#: src/amuleDlg.cpp:1828 src/muuli_wdr.cpp:3457
 msgid "Preferences Settings Window"
 msgstr "Tulajdonságok beállításának ablaka"
 
-#: src/amuleDlg.cpp:1831 src/muuli_wdr.cpp:3427
+#: src/amuleDlg.cpp:1831 src/muuli_wdr.cpp:3458
 msgid "Import"
 msgstr "Importálás"
 
-#: src/amuleDlg.cpp:1835 src/muuli_wdr.cpp:3427
+#: src/amuleDlg.cpp:1835 src/muuli_wdr.cpp:3458
 msgid "The partfile importer tool"
 msgstr "A részfájl importáló eszköz"
 
-#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3428
+#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3459
 #: src/utils/aLinkCreator/src/alcframe.cpp:262
 msgid "About"
 msgstr "Névjegy"
 
-#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3428
+#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3459
 msgid "About/Help"
 msgstr "Névjegy/Súgó"
 
@@ -956,7 +956,7 @@ msgstr "Fájl nem található."
 msgid "The core rejected these shared folders:%s"
 msgstr ""
 
-#: src/amule-remote-gui.cpp:1336 src/ExternalConn.cpp:2345
+#: src/amule-remote-gui.cpp:1336 src/ExternalConn.cpp:2346
 msgid "Invalid link or already on list."
 msgstr "Érvénytelen hivatkozás, vagy már rajta van a listán."
 
@@ -972,7 +972,7 @@ msgstr "A '%s' könyvtár létrehozása a '%s' kategóriához nem lehetséges, a
 #: src/ClientDetailDialog.cpp:123 src/DataToText.cpp:61 src/DataToText.cpp:86
 #: src/DataToText.cpp:101 src/DataToText.cpp:136 src/DataToText.cpp:165
 #: src/DownloadListCtrl.cpp:1172 src/DownloadListCtrl.cpp:1185
-#: src/DownloadListCtrl.cpp:1196 src/ExternalConn.cpp:608
+#: src/DownloadListCtrl.cpp:1196 src/ExternalConn.cpp:609
 #: src/FileDetailDialog.cpp:203 src/FileDetailDialog.cpp:235
 #: src/FileDetailDialog.cpp:242 src/GenericClientListCtrl.cpp:1171
 #: src/GenericClientListCtrl.cpp:1182 src/GenericClientListCtrl.cpp:1192
@@ -1354,19 +1354,19 @@ msgstr "Auto [Ma]"
 msgid "Very low"
 msgstr "Nagyon alacsony"
 
-#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:743 src/muuli_wdr.cpp:2282
+#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:743 src/muuli_wdr.cpp:2313
 #: src/ServerListCtrl.cpp:263 src/ServerListCtrl.cpp:456
 #: src/SharedFilesCtrl.cpp:145
 msgid "Low"
 msgstr "Alacsony"
 
-#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:744 src/muuli_wdr.cpp:2283
+#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:744 src/muuli_wdr.cpp:2314
 #: src/ServerListCtrl.cpp:266 src/ServerListCtrl.cpp:457
 #: src/SharedFilesCtrl.cpp:146
 msgid "Normal"
 msgstr "Normál"
 
-#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:745 src/muuli_wdr.cpp:2284
+#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:745 src/muuli_wdr.cpp:2315
 #: src/ServerListCtrl.cpp:269 src/ServerListCtrl.cpp:458
 #: src/SharedFilesCtrl.cpp:147
 msgid "High"
@@ -1458,7 +1458,7 @@ msgstr "Helyi kiszolgáló"
 msgid "Remote Server"
 msgstr "Távoli kiszolgáló"
 
-#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3181
+#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3212
 #: src/SearchDlg.cpp:119 src/TextClient.cpp:911
 msgid "Kad"
 msgstr "Kad"
@@ -1529,7 +1529,7 @@ msgstr "Rész"
 msgid "Size"
 msgstr "Méret"
 
-#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3248
+#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3279
 msgid "Transferred"
 msgstr "Átmásolva"
 
@@ -1587,7 +1587,7 @@ msgstr ""
 "Visszajelzés %s-től (%s):\n"
 "\n"
 
-#: src/DownloadListCtrl.cpp:746 src/muuli_wdr.cpp:2285
+#: src/DownloadListCtrl.cpp:746 src/muuli_wdr.cpp:2316
 #: src/SharedFilesCtrl.cpp:150
 msgid "Auto"
 msgstr "Automatikus"
@@ -1625,7 +1625,7 @@ msgid "Extended Options"
 msgstr "Kibővített beállítások"
 
 #: src/DownloadListCtrl.cpp:770 src/DownloadListCtrl.cpp:822
-#: src/muuli_wdr.cpp:1796
+#: src/muuli_wdr.cpp:1800
 msgid "Preview"
 msgstr "Előnézet"
 
@@ -1798,225 +1798,230 @@ msgstr[0] ""
 msgid "Invalid eD2k link! ERROR: %s"
 msgstr "Érvénytelen eD2k hivatkozás! HIBA: %s"
 
-#: src/ExternalConn.cpp:379
+#: src/ExternalConn.cpp:380
 msgid "Client sent packet after authentication failed."
 msgstr "Kliens csomagot küldött sikertelen hitelesítést követően."
 
-#: src/ExternalConn.cpp:396
+#: src/ExternalConn.cpp:397
 msgid "External connection closed."
 msgstr "Külső kapcsolat lezárva."
 
-#: src/ExternalConn.cpp:473
+#: src/ExternalConn.cpp:474
 msgid "External connections disabled due to empty password!"
 msgstr "A külső kapcsolatok letiltásra kerültek üres jelszó miatt!"
 
-#: src/ExternalConn.cpp:494
+#: src/ExternalConn.cpp:495
 msgid "External connections disabled in config file"
 msgstr "A külső kapcsolatok le vannak tiltva konfig fájlban"
 
-#: src/ExternalConn.cpp:575
+#: src/ExternalConn.cpp:576
 msgid "New external connection accepted"
 msgstr "Új külső kapcsolat elfogadva"
 
-#: src/ExternalConn.cpp:578
+#: src/ExternalConn.cpp:579
 msgid "ERROR: couldn't accept a new external connection"
 msgstr "HIBA: nem tudtam fogadni egy új külső kapcsolatot"
 
-#: src/ExternalConn.cpp:595
+#: src/ExternalConn.cpp:596
 msgid "External connection refused due to empty password in preferences!"
 msgstr "Külső kapcsolat elutasítva, üres jelszó a beállításokban!"
 
-#: src/ExternalConn.cpp:607
+#: src/ExternalConn.cpp:608
 #, c-format
 msgid "Connecting client: %s %s"
 msgstr "Kapcsolódó kliens: %s %s"
 
-#: src/ExternalConn.cpp:609
+#: src/ExternalConn.cpp:610
 msgid "Unknown version"
 msgstr "Ismeretlen verzió"
 
-#: src/ExternalConn.cpp:622
+#: src/ExternalConn.cpp:623
 msgid "Incorrect EC version ID, there might be binary incompatibility. Use core and remote from same snapshot."
 msgstr "Helytelen EC verzió azonosító, összeférhetetlenség lehetséges. A fő- és a távoli programot ugyanabból a pillanatképből használd."
 
-#: src/ExternalConn.cpp:630
+#: src/ExternalConn.cpp:631
 msgid "You cannot connect to a release version from an arbitrary development snapshot! *sigh* possible crash prevented"
 msgstr "Nem kapcsolódhatsz egy kiadott verzióhoz egy tetszőleges fejlesztés alatti verzióval! *sóhaj* lehetséges összeomlás megelőzve"
 
-#: src/ExternalConn.cpp:713
+#: src/ExternalConn.cpp:714
 msgid "Invalid protocol version."
 msgstr "Érvénytelen protokoll verzió."
 
-#: src/ExternalConn.cpp:719
+#: src/ExternalConn.cpp:720
 msgid "Missing protocol version tag."
 msgstr "Hiányzó protokoll verzió azonosító."
 
-#: src/ExternalConn.cpp:727
+#: src/ExternalConn.cpp:728
 msgid "Authentication failed: invalid hash specified as EC password."
 msgstr "Hitelesítés sikertelen: az EC jelszóként megadott hash érvénytelen."
 
-#: src/ExternalConn.cpp:775
+#: src/ExternalConn.cpp:776
 msgid "Authentication failed: wrong password."
 msgstr "Hitelesítés sikertelen: rossz jelszó."
 
-#: src/ExternalConn.cpp:777
+#: src/ExternalConn.cpp:778
 msgid "Authentication failed: missing password."
 msgstr "Hitelesítés sikertelen: hiányzó jelszó."
 
-#: src/ExternalConn.cpp:788
+#: src/ExternalConn.cpp:789
 msgid "Invalid request, please authenticate first."
 msgstr "Érvénytelen kérés, először hitelesíteni kell."
 
-#: src/ExternalConn.cpp:793
+#: src/ExternalConn.cpp:794
 msgid "Access granted."
 msgstr "Hozzáférés elfogadva."
 
-#: src/ExternalConn.cpp:801
+#: src/ExternalConn.cpp:802
 #, c-format
 msgid "Sent error message \"%s\" to client."
 msgstr "Hibaüzenet elküldve a \"%s\" klienshez."
 
-#: src/ExternalConn.cpp:806
+#: src/ExternalConn.cpp:807
 #, c-format
 msgid "Unauthorized access attempt from %s. Connection closed."
 msgstr "Jogosulatlan hozzáférési kísérlet %s részéről. Kapcsolat lezárva."
 
-#: src/ExternalConn.cpp:1419
+#: src/ExternalConn.cpp:1420
 #, c-format
 msgid "Remote PartFile command failed: FileHash not found: %s"
 msgstr "Távoli PartFile parancs sikertelen: nem található FileHash: %s"
 
-#: src/ExternalConn.cpp:1423
+#: src/ExternalConn.cpp:1424
 #, c-format
 msgid "FileHash not found: %s"
 msgstr "FileHash nem található: %s"
 
-#: src/ExternalConn.cpp:1470 src/ExternalConn.cpp:1558
-#: src/ExternalConn.cpp:1679
+#: src/ExternalConn.cpp:1471 src/ExternalConn.cpp:1559
+#: src/ExternalConn.cpp:1680
 msgid "OOPS! OpCode processing error!"
 msgstr "Hoppá! Opkód feldolgozási hiba!"
 
-#: src/ExternalConn.cpp:1501
+#: src/ExternalConn.cpp:1502
 msgid "Server not added"
 msgstr "Kiszolgáló nem lett hozzáadva"
 
-#: src/ExternalConn.cpp:1520
+#: src/ExternalConn.cpp:1521
 #, c-format
 msgid "server not found: %s"
 msgstr "kiszolgáló nem található: %s"
 
-#: src/ExternalConn.cpp:1537
+#: src/ExternalConn.cpp:1538
 msgid "need to define server to be removed"
 msgstr "ki kell jelölnöd a kiszolgálót az eltávolításhoz"
 
-#: src/ExternalConn.cpp:1552
+#: src/ExternalConn.cpp:1553
 msgid "eD2k is disabled in preferences."
 msgstr "Az eD2k le van tiltva a beállításokban."
 
-#: src/ExternalConn.cpp:1657
+#: src/ExternalConn.cpp:1658
 msgid "Friend not found."
 msgstr "Barát nem található."
 
-#: src/ExternalConn.cpp:1667
+#: src/ExternalConn.cpp:1668
 msgid "Client not found."
 msgstr "Kliens nem található."
 
-#: src/ExternalConn.cpp:1673
+#: src/ExternalConn.cpp:1674
 msgid "EC_TAG_FRIEND_SHARED requires EC_TAG_FRIEND or EC_TAG_CLIENT."
 msgstr "EC_TAG_FRIEND_SHARED igényel EC_TAG_FRIEND vagy EC_TAG_CLIENT értéket."
 
-#: src/ExternalConn.cpp:1991
+#: src/ExternalConn.cpp:1992
 msgid "WebSearch from remote interface makes no sense."
 msgstr "Webes keresésnek a távoli felületről nincs értelme."
 
-#: src/ExternalConn.cpp:2026
+#: src/ExternalConn.cpp:2027
 msgid "Search in progress. Refetch results in a moment!"
 msgstr "Keresés folyamatban. Kérdezze le az eredményeket egy rövid idő múlva!"
 
-#: src/ExternalConn.cpp:2265
+#: src/ExternalConn.cpp:2266
 msgid "No points for graph."
 msgstr "Nincsenek pontok a grafikonhoz."
 
-#: src/ExternalConn.cpp:2275
+#: src/ExternalConn.cpp:2276
 msgid "Your client is not configured for this detail level."
 msgstr "A kliensed nincs beállítva ehhez a részletességi szinthez."
 
-#: src/ExternalConn.cpp:2302
+#: src/ExternalConn.cpp:2303
 msgid "External Connection: shutdown requested"
 msgstr "Külső kapcsolat: leállítás kérve"
 
-#: src/ExternalConn.cpp:2314
+#: src/ExternalConn.cpp:2315
 msgid "Already shutting down."
 msgstr "Kikapcsolás folyamatban."
 
-#: src/ExternalConn.cpp:2332
+#: src/ExternalConn.cpp:2333
 #, c-format
 msgid "ExternalConn: adding link '%s'."
 msgstr "ExternalConn: hivatkozás hozzáadása: '%s'."
 
-#: src/ExternalConn.cpp:2350
+#: src/ExternalConn.cpp:2351
 #, c-format
 msgid "%d of %d links failed (invalid or already on list)."
 msgstr "%d link %d linkből sikertelen (érvénytelen vagy már a listán van)."
 
-#: src/ExternalConn.cpp:2373
+#: src/ExternalConn.cpp:2374
 msgid "Version check throttled; try again shortly."
 msgstr ""
 
-#: src/ExternalConn.cpp:2378
+#: src/ExternalConn.cpp:2379
 msgid "Version check is not available on this daemon."
 msgstr ""
 
-#: src/ExternalConn.cpp:2508
+#: src/ExternalConn.cpp:2509
 msgid "File not found."
 msgstr "Fájl nem található."
 
-#: src/ExternalConn.cpp:2513
+#: src/ExternalConn.cpp:2514
 msgid "Invalid file name."
 msgstr "Érvénytelen fájl név."
 
-#: src/ExternalConn.cpp:2521
+#: src/ExternalConn.cpp:2522
 msgid "Unable to rename file."
 msgstr "Nem tudom átnevezni a fájlt."
 
-#: src/ExternalConn.cpp:2992 src/ExternalConn.cpp:3020
+#: src/ExternalConn.cpp:2839
+#, c-format
+msgid "Could not save the amuleapi password: %s"
+msgstr ""
+
+#: src/ExternalConn.cpp:3004 src/ExternalConn.cpp:3032
 msgid "Kad is disabled in preferences."
 msgstr "A Kad le van tiltva a beállításokban."
 
-#: src/ExternalConn.cpp:3033
+#: src/ExternalConn.cpp:3045
 msgid "Already connected to eD2k."
 msgstr "Már csatlakozva az eD2k-hoz."
 
-#: src/ExternalConn.cpp:3036
+#: src/ExternalConn.cpp:3048
 msgid "Connecting to eD2k..."
 msgstr "Kapcsolódás az eD2k-hoz..."
 
-#: src/ExternalConn.cpp:3045
+#: src/ExternalConn.cpp:3057
 msgid "Already connected to Kad."
 msgstr "Már kapcsolódva a Kad-hoz."
 
-#: src/ExternalConn.cpp:3048
+#: src/ExternalConn.cpp:3060
 msgid "Connecting to Kad..."
 msgstr "Kapcsolódás a Kad-hoz..."
 
-#: src/ExternalConn.cpp:3055
+#: src/ExternalConn.cpp:3067
 msgid "All networks are disabled."
 msgstr "Minden hálózat le van tiltva."
 
-#: src/ExternalConn.cpp:3064
+#: src/ExternalConn.cpp:3076
 msgid "Disconnected from eD2k."
 msgstr "Leválasztva az eD2k-ról."
 
-#: src/ExternalConn.cpp:3069
+#: src/ExternalConn.cpp:3081
 msgid "Disconnected from Kad."
 msgstr "Leválasztva a Kad-ról."
 
-#: src/ExternalConn.cpp:3078
+#: src/ExternalConn.cpp:3090
 #, c-format
 msgid "External Connection: invalid opcode received: %#x"
 msgstr "Külső kapcsolat: érvénytelen opcode: %#x"
 
-#: src/ExternalConn.cpp:3083
+#: src/ExternalConn.cpp:3095
 msgid "Invalid opcode (wrong protocol version?)"
 msgstr "Érvénytelen opcode (rossz protokoll verzió?)"
 
@@ -2417,23 +2422,23 @@ msgid ""
 "want downloads on a different (e.g. larger) disk."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:549 src/FirstRunWizard.cpp:611 src/muuli_wdr.cpp:1708
+#: src/FirstRunWizard.cpp:549 src/FirstRunWizard.cpp:611 src/muuli_wdr.cpp:1712
 msgid "Destination folder for downloads"
 msgstr "Célkönyvtár a letöltéseknek"
 
 #: src/FirstRunWizard.cpp:553 src/FirstRunWizard.cpp:569 src/muuli_wdr.cpp:1349
-#: src/muuli_wdr.cpp:1366 src/muuli_wdr.cpp:1683 src/muuli_wdr.cpp:1714
-#: src/muuli_wdr.cpp:1726 src/muuli_wdr.cpp:2769
+#: src/muuli_wdr.cpp:1366 src/muuli_wdr.cpp:1687 src/muuli_wdr.cpp:1718
+#: src/muuli_wdr.cpp:1730 src/muuli_wdr.cpp:2800
 #: src/utils/aLinkCreator/src/alcframe.cpp:135
 #: src/utils/wxCas/src/wxcasprefs.cpp:52 src/utils/wxCas/src/wxcasprefs.cpp:118
 msgid "Browse"
 msgstr "Tallóz"
 
-#: src/FirstRunWizard.cpp:559 src/muuli_wdr.cpp:1719
+#: src/FirstRunWizard.cpp:559 src/muuli_wdr.cpp:1723
 msgid "(All files in this folder are shared with other peers)"
 msgstr "(Minden fájl ebben a könyvtárban másokkal megosztásra kerül)"
 
-#: src/FirstRunWizard.cpp:565 src/FirstRunWizard.cpp:624 src/muuli_wdr.cpp:1721
+#: src/FirstRunWizard.cpp:565 src/FirstRunWizard.cpp:624 src/muuli_wdr.cpp:1725
 msgid "Folder for temporary download files"
 msgstr "Könyvtár az ideiglenes letöltési fájloknak"
 
@@ -2464,7 +2469,7 @@ msgstr "A barátokat tartalmazó emfriends.dat fájl írásra megnyitása sikert
 msgid "CRITICAL - no client on StartChatSession"
 msgstr "KRITIKUS - nincsen kliens a StartChatSession-en"
 
-#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2675 src/muuli_wdr.cpp:3352
+#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2706 src/muuli_wdr.cpp:3383
 msgid "Friends"
 msgstr "Barátok"
 
@@ -2574,8 +2579,8 @@ msgstr "Egyik sem"
 msgid "No"
 msgstr "Nem"
 
-#: src/GenericClientListCtrl.cpp:1216 src/PrefsUnifiedDlg.cpp:2818
-#: src/PrefsUnifiedDlg.cpp:2868 src/ServerListCtrl.cpp:276
+#: src/GenericClientListCtrl.cpp:1216 src/PrefsUnifiedDlg.cpp:2898
+#: src/PrefsUnifiedDlg.cpp:2948 src/ServerListCtrl.cpp:276
 msgid "Yes"
 msgstr "Igen"
 
@@ -2742,10 +2747,10 @@ msgstr "Érvénytelen port a rendszerindításhoz"
 msgid "Please fill all fields required"
 msgstr "Kérlek töltsd ki az összes kötelező mezőt"
 
-#: src/KadDlg.cpp:192 src/PartFile.cpp:1031 src/PrefsUnifiedDlg.cpp:1162
-#: src/PrefsUnifiedDlg.cpp:1331 src/PrefsUnifiedDlg.cpp:1589
-#: src/PrefsUnifiedDlg.cpp:1599 src/PrefsUnifiedDlg.cpp:1616
-#: src/PrefsUnifiedDlg.cpp:1658
+#: src/KadDlg.cpp:192 src/PartFile.cpp:1031 src/PrefsUnifiedDlg.cpp:1134
+#: src/PrefsUnifiedDlg.cpp:1204 src/PrefsUnifiedDlg.cpp:1405
+#: src/PrefsUnifiedDlg.cpp:1663 src/PrefsUnifiedDlg.cpp:1673
+#: src/PrefsUnifiedDlg.cpp:1690 src/PrefsUnifiedDlg.cpp:1738
 msgid "Message"
 msgstr "Üzenet"
 
@@ -2844,7 +2849,7 @@ msgstr "Megosztási arány"
 msgid "Uploaded"
 msgstr "Feltöltve"
 
-#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3232
+#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3263
 msgid "Requested"
 msgstr "Kért"
 
@@ -2968,7 +2973,7 @@ msgid "WARNING: "
 msgstr "FIGYELEM: "
 
 #: src/MuleNotebook.cpp:179 src/muuli_wdr.cpp:817 src/muuli_wdr.cpp:1229
-#: src/muuli_wdr.cpp:3136 src/muuli_wdr.cpp:3392
+#: src/muuli_wdr.cpp:3167 src/muuli_wdr.cpp:3423
 msgid "Close"
 msgstr "Bezár"
 
@@ -2986,7 +2991,7 @@ msgid "Paste"
 msgstr "Beillesztés"
 
 #: src/MuleTextCtrl.cpp:89 src/muuli_wdr.cpp:358 src/muuli_wdr.cpp:757
-#: src/muuli_wdr.cpp:2359 src/muuli_wdr.cpp:2378 src/muuli_wdr.cpp:2400
+#: src/muuli_wdr.cpp:2390 src/muuli_wdr.cpp:2409 src/muuli_wdr.cpp:2431
 #: src/utils/aLinkCreator/src/alcframe.cpp:142
 msgid "Clear"
 msgstr "Törlés"
@@ -3078,7 +3083,7 @@ msgstr "Kilépés"
 
 #: src/MuleTrayIcon.cpp:579 src/MuleTrayIcon.cpp:945 src/MuleTrayIcon.cpp:965
 #: src/muuli_wdr.cpp:1398 src/muuli_wdr.cpp:1406 src/muuli_wdr.cpp:1413
-#: src/muuli_wdr.cpp:1842 src/muuli_wdr.cpp:1848 src/OtherFunctions.cpp:91
+#: src/muuli_wdr.cpp:1846 src/muuli_wdr.cpp:1852 src/OtherFunctions.cpp:91
 #: src/StatisticsDlg.cpp:93 src/StatisticsDlg.cpp:95
 msgid "kB/s"
 msgstr "kB/s"
@@ -3320,7 +3325,7 @@ msgstr "bájt"
 msgid "KB"
 msgstr "KB"
 
-#: src/muuli_wdr.cpp:274 src/muuli_wdr.cpp:293 src/muuli_wdr.cpp:1627
+#: src/muuli_wdr.cpp:274 src/muuli_wdr.cpp:293 src/muuli_wdr.cpp:1631
 #: src/OtherFunctions.cpp:64
 msgid "MB"
 msgstr "MB"
@@ -3337,7 +3342,7 @@ msgstr "Max. méret"
 msgid "Availability"
 msgstr "Elérhetőség"
 
-#: src/muuli_wdr.cpp:312 src/muuli_wdr.cpp:398 src/muuli_wdr.cpp:3297
+#: src/muuli_wdr.cpp:312 src/muuli_wdr.cpp:398 src/muuli_wdr.cpp:3328
 msgid "Filter:"
 msgstr "Szűrő:"
 
@@ -3400,12 +3405,12 @@ msgstr "Fájl források:"
 #: src/muuli_wdr.cpp:1160 src/muuli_wdr.cpp:1167 src/muuli_wdr.cpp:1172
 #: src/muuli_wdr.cpp:1179 src/muuli_wdr.cpp:1184 src/muuli_wdr.cpp:1191
 #: src/muuli_wdr.cpp:1205 src/muuli_wdr.cpp:1212 src/muuli_wdr.cpp:1217
-#: src/muuli_wdr.cpp:1224 src/muuli_wdr.cpp:3234 src/muuli_wdr.cpp:3242
-#: src/muuli_wdr.cpp:3250
+#: src/muuli_wdr.cpp:1224 src/muuli_wdr.cpp:3265 src/muuli_wdr.cpp:3273
+#: src/muuli_wdr.cpp:3281
 msgid "N/A"
 msgstr "N/A"
 
-#: src/muuli_wdr.cpp:508 src/muuli_wdr.cpp:1065 src/PrefsUnifiedDlg.cpp:297
+#: src/muuli_wdr.cpp:508 src/muuli_wdr.cpp:1065 src/PrefsUnifiedDlg.cpp:299
 msgid "General"
 msgstr "Általános"
 
@@ -3546,7 +3551,7 @@ msgstr ""
 msgid "Album :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:685 src/muuli_wdr.cpp:2254
+#: src/muuli_wdr.cpp:685 src/muuli_wdr.cpp:2285
 msgid "Title :"
 msgstr "Cím :"
 
@@ -3655,7 +3660,7 @@ msgstr "User név :"
 msgid "Userhash :"
 msgstr "Userhash :"
 
-#: src/muuli_wdr.cpp:895 src/muuli_wdr.cpp:1748 src/muuli_wdr.cpp:2449
+#: src/muuli_wdr.cpp:895 src/muuli_wdr.cpp:1752 src/muuli_wdr.cpp:2480
 #: src/utils/aLinkCreator/src/alcframe.cpp:137
 msgid "Add"
 msgstr "Hozzáad"
@@ -3664,15 +3669,15 @@ msgstr "Hozzáad"
 msgid "Download-Speed"
 msgstr "Letöltési sebesség"
 
-#: src/muuli_wdr.cpp:954 src/muuli_wdr.cpp:989 src/muuli_wdr.cpp:2553
+#: src/muuli_wdr.cpp:954 src/muuli_wdr.cpp:989 src/muuli_wdr.cpp:2584
 msgid "Current"
 msgstr "Aktuális"
 
-#: src/muuli_wdr.cpp:962 src/muuli_wdr.cpp:997 src/muuli_wdr.cpp:2561
+#: src/muuli_wdr.cpp:962 src/muuli_wdr.cpp:997 src/muuli_wdr.cpp:2592
 msgid "Running average"
 msgstr "Futásátlag"
 
-#: src/muuli_wdr.cpp:970 src/muuli_wdr.cpp:1005 src/muuli_wdr.cpp:2569
+#: src/muuli_wdr.cpp:970 src/muuli_wdr.cpp:1005 src/muuli_wdr.cpp:2600
 msgid "Session average"
 msgstr "Munkafolyamatok átlaga"
 
@@ -3684,7 +3689,7 @@ msgstr "Feltöltési sebesség"
 msgid "Connections"
 msgstr "Kapcsolatok"
 
-#: src/muuli_wdr.cpp:1024 src/muuli_wdr.cpp:1867
+#: src/muuli_wdr.cpp:1024 src/muuli_wdr.cpp:1871
 msgid "Active downloads"
 msgstr "Aktív letöltések"
 
@@ -3692,7 +3697,7 @@ msgstr "Aktív letöltések"
 msgid "Active connections (1:1)"
 msgstr "Aktív kapcsolatok (1:1)"
 
-#: src/muuli_wdr.cpp:1040 src/muuli_wdr.cpp:1868
+#: src/muuli_wdr.cpp:1040 src/muuli_wdr.cpp:1872
 msgid "Active uploads"
 msgstr "Aktív feltöltések"
 
@@ -3968,7 +3973,7 @@ msgstr "Lokális cím IP-hez csatolása (mindet ha üres):"
 msgid "Advanced users only: If you have multiple network interfaces, enter the address of the interface to which aMule should be bound."
 msgstr "Csak haladó felhasználóknak: Ha több hálózati kártyád van, írd ide a címet, amelyhez az aMule kötve legyen."
 
-#: src/muuli_wdr.cpp:1462 src/muuli_wdr.cpp:2061
+#: src/muuli_wdr.cpp:1462 src/muuli_wdr.cpp:2065
 #, fuzzy
 msgid "Bind to network interface (empty for any):"
 msgstr "Lokális cím IP-hez csatolása (mindet ha üres):"
@@ -3985,7 +3990,7 @@ msgstr "Max források letöltési fájlonként:"
 msgid "Max simultaneous connections:"
 msgstr "Max egyidejű kapcsolatok:"
 
-#: src/muuli_wdr.cpp:1498 src/muuli_wdr.cpp:3176
+#: src/muuli_wdr.cpp:1498 src/muuli_wdr.cpp:3207
 msgid "ED2K"
 msgstr "ED2K"
 
@@ -4077,79 +4082,79 @@ msgstr "Lemezterület helyfogalalás az új fájloknak"
 msgid "For new files preallocates disk space for the whole file, thus reduces fragmentation"
 msgstr "Az új fájlok számára előre lefoglalja a lemezterületet, így csökkentve a töredezettséget"
 
-#: src/muuli_wdr.cpp:1613
+#: src/muuli_wdr.cpp:1617
 msgid "Create new files as sparse files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1614
-msgid "A sparse file reserves its full size on disk immediately without writing real data to it -- fast, but unsupported or slow on some filesystems, and free-space accounting stays optimistic while the download is in progress. Turn this off to grow the file only as data arrives."
+#: src/muuli_wdr.cpp:1618
+msgid "Sparse part files only occupy disk space for the parts already downloaded, so free space is used up gradually as the file fills in. Turn this off to use an ordinary file instead - useful where sparse files are unsupported or slow, or where backup/de-duplication tools handle them badly. Applies only when the core runs on Windows; on Linux and macOS part files are sparse anyway and this setting has no effect."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1619
+#: src/muuli_wdr.cpp:1623
 msgid "Stop downloads when free disk space reaches "
 msgstr "Letöltések megállítása amikor a szabad hely kevesebb mint "
 
-#: src/muuli_wdr.cpp:1620
+#: src/muuli_wdr.cpp:1624
 msgid "Select this if you want aMule to check your disk space"
 msgstr "Jelöld be, ha azt szeretnéd, hogy az aMule ellenőrizze a szabad lemezterületet"
 
-#: src/muuli_wdr.cpp:1624
+#: src/muuli_wdr.cpp:1628
 msgid "Enter here the min disk space desired."
 msgstr "Add meg a kívánt min. szabad lemezterületet."
 
-#: src/muuli_wdr.cpp:1630
+#: src/muuli_wdr.cpp:1634
 msgid "Save 10 sources on rare files (< 20 sources)"
 msgstr "Mentsen el 10 forrást ritka fájloknál (< 20 forrás)"
 
-#: src/muuli_wdr.cpp:1634 src/Statistics.cpp:790
+#: src/muuli_wdr.cpp:1638 src/Statistics.cpp:790
 msgid "Uploads"
 msgstr "Feltöltések"
 
-#: src/muuli_wdr.cpp:1637
+#: src/muuli_wdr.cpp:1641
 msgid "Add new shared files with auto priority"
 msgstr "Új megosztott fájl felvétele automatikus prioritással"
 
-#: src/muuli_wdr.cpp:1643
+#: src/muuli_wdr.cpp:1647
 msgid "Intelligent Corruption Handling (I.C.H.)"
 msgstr "Intelligens Sérülés Kezelő (I.S.K.)"
 
-#: src/muuli_wdr.cpp:1646
+#: src/muuli_wdr.cpp:1650
 msgid "Enable"
 msgstr "Engedélyezés"
 
-#: src/muuli_wdr.cpp:1649
+#: src/muuli_wdr.cpp:1653
 msgid "Advanced I.C.H. trusts every hash (not recommended)"
 msgstr "Feljett I.S.K. megbízzon minden hash-ben (nem ajánlott)"
 
-#: src/muuli_wdr.cpp:1661 src/PrefsUnifiedDlg.cpp:1910
+#: src/muuli_wdr.cpp:1665 src/PrefsUnifiedDlg.cpp:1990
 msgid "Media metadata extraction"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1665
+#: src/muuli_wdr.cpp:1669
 msgid "Extract length / bitrate / codec from shared audio and video files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1667
+#: src/muuli_wdr.cpp:1671
 msgid "When enabled, aMule runs ffprobe on each shared media file to fill in the Length / Bitrate / Codec columns other clients see when they find the file in a search. Requires ffmpeg (the ffprobe binary) to be installed."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1674
+#: src/muuli_wdr.cpp:1678
 msgid "Path to ffprobe:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1679
+#: src/muuli_wdr.cpp:1683
 msgid "Full path to the ffprobe binary. Leave empty to have aMule auto-detect it on startup."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1687
+#: src/muuli_wdr.cpp:1691
 msgid "Detect"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1688
+#: src/muuli_wdr.cpp:1692
 msgid "Search the standard install locations for an ffprobe binary and fill the path field."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1712
+#: src/muuli_wdr.cpp:1716
 msgid ""
 "Completed downloads are stored here. All files in this folder are automatically shared with other peers.\n"
 "If this folder also holds files you don't want to share, point it at an aMule-only sub-folder."
@@ -4157,672 +4162,695 @@ msgstr ""
 "Elvégzett letöltések tárolási helye. Minden fájl ebben a könytárban automatikusan megosztásra kerül másokkal.\n"
 "Ha a könyvtár fájlokat tartalmaz, amelyek ne kerüljenek megosztásra, állítsa át egy megfelelő alkönyvtárra."
 
-#: src/muuli_wdr.cpp:1715
+#: src/muuli_wdr.cpp:1719
 msgid "Pick the folder where completed downloads will be stored. All files in that folder will be shared with other peers."
 msgstr "Válassza ki a könyvtárat az elvégzett letöltéseknek. A könyvtár minden fájlja másokkal megosztásra kerül."
 
-#: src/muuli_wdr.cpp:1729
+#: src/muuli_wdr.cpp:1733
 msgid "Shared folders"
 msgstr "Megosztott mappák"
 
-#: src/muuli_wdr.cpp:1735
+#: src/muuli_wdr.cpp:1739
 msgid "(Folders shared by the core. Enter a path to add one.)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1743
+#: src/muuli_wdr.cpp:1747
 msgid "Absolute path of a folder on the core's machine, e.g. /home/user/shared"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1745 src/PrefsUnifiedDlg.cpp:2794
+#: src/muuli_wdr.cpp:1749 src/PrefsUnifiedDlg.cpp:2874
 msgid "Recursive"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1746
+#: src/muuli_wdr.cpp:1750
 msgid "Share every sub-folder underneath this one, including ones created later."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1750 src/utils/aLinkCreator/src/alcframe.cpp:141
+#: src/muuli_wdr.cpp:1754 src/utils/aLinkCreator/src/alcframe.cpp:141
 msgid "Remove"
 msgstr "Eltávolít"
 
-#: src/muuli_wdr.cpp:1754
+#: src/muuli_wdr.cpp:1758
 msgid "(Right click on folder icon for recursive share)"
 msgstr "(Jobb klikk az mappa ikonra az összes alatta levő mappát is megosztja)"
 
-#: src/muuli_wdr.cpp:1761
+#: src/muuli_wdr.cpp:1765
 msgid "Share hidden files"
 msgstr "Rejtett fájlok megosztása"
 
-#: src/muuli_wdr.cpp:1767
+#: src/muuli_wdr.cpp:1771
 msgid "Automatically rescan shared folders for changes"
 msgstr "Megosztott könyvtárak automatikus újraszkennelése"
 
-#: src/muuli_wdr.cpp:1773
+#: src/muuli_wdr.cpp:1777
 msgid "Follow symbolic links in shared folders"
 msgstr "Szimbólikus hivatkozások követése megosztott könyvtárakban"
 
-#: src/muuli_wdr.cpp:1779
+#: src/muuli_wdr.cpp:1783
 msgid "Exclude files matching:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1782
+#: src/muuli_wdr.cpp:1786
 msgid "Wildcard patterns separated by '|', e.g. .DS_Store|Thumbs.db|*.tmp. Files whose name matches are not shared. Matching is case-insensitive."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1786
+#: src/muuli_wdr.cpp:1790
 msgid "Patterns are regular expressions"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1787
+#: src/muuli_wdr.cpp:1791
 msgid "When set, the whole field is one regular expression ('|' is alternation). When unset, it is a list of '|'-separated wildcards."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1797
+#: src/muuli_wdr.cpp:1801
 msgid "Show how many shared files the current pattern would exclude."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1818
+#: src/muuli_wdr.cpp:1822
 msgid "Graphs"
 msgstr "Grafikonok"
 
-#: src/muuli_wdr.cpp:1821 src/muuli_wdr.cpp:1883
+#: src/muuli_wdr.cpp:1825 src/muuli_wdr.cpp:1887
 msgid "Update delay : 5 secs"
 msgstr "Frissítés késleltetés: 5 mp"
 
-#: src/muuli_wdr.cpp:1825
+#: src/muuli_wdr.cpp:1829
 msgid "Time for average graph: 100 mins"
 msgstr "Grafikon átlagos ideje: 100 perc"
 
-#: src/muuli_wdr.cpp:1829
+#: src/muuli_wdr.cpp:1833
 msgid "Connections Graph Scale: 100 "
 msgstr "Kapcsolatok grafikon skálája: 100 "
 
-#: src/muuli_wdr.cpp:1836
+#: src/muuli_wdr.cpp:1840
 msgid "Download graph scale:"
 msgstr "Letöltési grafikon méretaránya:"
 
-#: src/muuli_wdr.cpp:1844
+#: src/muuli_wdr.cpp:1848
 msgid "Upload graph scale:"
 msgstr "Feltöltési grafikon méretaránya:"
 
-#: src/muuli_wdr.cpp:1854
+#: src/muuli_wdr.cpp:1858
 msgid "Colors: "
 msgstr "Színek: "
 
-#: src/muuli_wdr.cpp:1858
+#: src/muuli_wdr.cpp:1862
 msgid "Background"
 msgstr "Háttér"
 
-#: src/muuli_wdr.cpp:1859
+#: src/muuli_wdr.cpp:1863
 msgid "Grid"
 msgstr "Rács"
 
-#: src/muuli_wdr.cpp:1860
+#: src/muuli_wdr.cpp:1864
 msgid "Download current"
 msgstr "Aktuális letöltés"
 
-#: src/muuli_wdr.cpp:1861
+#: src/muuli_wdr.cpp:1865
 msgid "Download running average"
 msgstr "Letöltési futás átlaga"
 
-#: src/muuli_wdr.cpp:1862
+#: src/muuli_wdr.cpp:1866
 msgid "Download session average"
 msgstr "Letöltési folyamatok átlaga"
 
-#: src/muuli_wdr.cpp:1863
+#: src/muuli_wdr.cpp:1867
 msgid "Upload current"
 msgstr "Aktuális feltöltés"
 
-#: src/muuli_wdr.cpp:1864
+#: src/muuli_wdr.cpp:1868
 msgid "Upload running average"
 msgstr "Feltöltési futás átlaga"
 
-#: src/muuli_wdr.cpp:1865
+#: src/muuli_wdr.cpp:1869
 msgid "Upload session average"
 msgstr "Feltöltési folyamatok átlaga"
 
-#: src/muuli_wdr.cpp:1866
+#: src/muuli_wdr.cpp:1870
 msgid "Active connections"
 msgstr "Aktív kapcsolatok"
 
-#: src/muuli_wdr.cpp:1869
+#: src/muuli_wdr.cpp:1873
 msgid "Systray Icon Speed Bar"
 msgstr "Sebességmérő a rendszertálcán"
 
-#: src/muuli_wdr.cpp:1870
+#: src/muuli_wdr.cpp:1874
 msgid "Kad-nodes current"
 msgstr "Kad-csomópontok aktuális"
 
-#: src/muuli_wdr.cpp:1871
+#: src/muuli_wdr.cpp:1875
 msgid "Kad-nodes running"
 msgstr "Kad-csomópontok futó"
 
-#: src/muuli_wdr.cpp:1872
+#: src/muuli_wdr.cpp:1876
 msgid "Kad-nodes session"
 msgstr "Kad-csomópontok folyamat"
 
-#: src/muuli_wdr.cpp:1876 src/muuli_wdr.cpp:2303
+#: src/muuli_wdr.cpp:1880 src/muuli_wdr.cpp:2334
 msgid "Select"
 msgstr "Kiválaszt"
 
-#: src/muuli_wdr.cpp:1880
+#: src/muuli_wdr.cpp:1884
 msgid "Tree"
 msgstr "Fa"
 
-#: src/muuli_wdr.cpp:1890
+#: src/muuli_wdr.cpp:1894
 msgid "Number of Client Versions shown (0=unlimited)"
 msgstr "Megjelenített ügyfél verziók száma (0=mind)"
 
-#: src/muuli_wdr.cpp:1915
+#: src/muuli_wdr.cpp:1919
 msgid "!!! WARNING !!!"
 msgstr "!!! FIGYELEM !!!"
 
-#: src/muuli_wdr.cpp:1930
+#: src/muuli_wdr.cpp:1934
 msgid "Max new connections / 5 secs"
 msgstr "Max új kapcsolat / 5 mp"
 
-#: src/muuli_wdr.cpp:1932
+#: src/muuli_wdr.cpp:1936
 msgid "Concurrent Kad source lookups"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1934
+#: src/muuli_wdr.cpp:1938
 #, fuzzy
 msgid "Kad source re-search interval (minutes)"
 msgstr "FTP frissítési gyakorisága percekben"
 
-#: src/muuli_wdr.cpp:1936
+#: src/muuli_wdr.cpp:1940
 #, fuzzy
 msgid "Source re-ask interval (minutes)"
 msgstr "FTP frissítési gyakorisága percekben"
 
-#: src/muuli_wdr.cpp:1940
+#: src/muuli_wdr.cpp:1944
 msgid "File Buffer Size: 240000 bytes"
 msgstr "Fájl buffer méret: 240000 bájt"
 
-#: src/muuli_wdr.cpp:1944
+#: src/muuli_wdr.cpp:1948
 msgid "Use MMAP: memory-mapped file access (lower memory use)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1945
+#: src/muuli_wdr.cpp:1949
 msgid "Maps part files into memory instead of buffering them on the heap, lowering the process memory footprint. May reduce download speed on some disks; best for memory-constrained or upload-heavy hosts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1947
+#: src/muuli_wdr.cpp:1951
 msgid "Upload Queue Size: 5000 clients"
 msgstr "Feltöltők várólistájának nagysága: 5000 kliens"
 
-#: src/muuli_wdr.cpp:1951
+#: src/muuli_wdr.cpp:1955
 msgid "Server connection refresh interval: Disable"
 msgstr "Kiszolgáló kapcsolat frissítési gyakorisága: Tiltva"
 
-#: src/muuli_wdr.cpp:1955
+#: src/muuli_wdr.cpp:1959
 msgid "Disable computer's timed standby mode"
 msgstr "Számítógép időzített készenléti állapotának hatástalanítása"
 
-#: src/muuli_wdr.cpp:1974
+#: src/muuli_wdr.cpp:1978
 msgid "Skin to use: "
 msgstr "Használt felület: "
 
-#: src/muuli_wdr.cpp:1983
+#: src/muuli_wdr.cpp:1987
 msgid "Show \"Fast eD2k Links Handler\" in every window."
 msgstr "A \"Gyors eD2k hivatkozás kezelő\" mutatása minden ablakban."
 
-#: src/muuli_wdr.cpp:1986
+#: src/muuli_wdr.cpp:1990
 msgid "Show extended info on categories tabs"
 msgstr "Kibővített infók megjelenítése a kategória füleken"
 
-#: src/muuli_wdr.cpp:1989
+#: src/muuli_wdr.cpp:1993
 msgid "Show application version on title"
 msgstr "Az alkalmazás verziójának megjelenítése a címsorban"
 
-#: src/muuli_wdr.cpp:1991
+#: src/muuli_wdr.cpp:1995
 msgid "Show transfer rates on title"
 msgstr "Átviteli ráták megjelenítése a címsorban"
 
-#: src/muuli_wdr.cpp:1993
+#: src/muuli_wdr.cpp:1997
 msgid "Before application name"
 msgstr "Az alkalmazás neve előtt"
 
-#: src/muuli_wdr.cpp:1995
+#: src/muuli_wdr.cpp:1999
 msgid "After application name"
 msgstr "Az alkalmazás neve után"
 
-#: src/muuli_wdr.cpp:1998
+#: src/muuli_wdr.cpp:2002
 msgid "Show overhead bandwidth"
 msgstr "Többletterhelés sávszélességének mutatása"
 
-#: src/muuli_wdr.cpp:2002
+#: src/muuli_wdr.cpp:2006
 msgid "Vertical toolbar orientation"
 msgstr "Függőleges eszköztár elrendezés"
 
-#: src/muuli_wdr.cpp:2004
+#: src/muuli_wdr.cpp:2008
 msgid "Live column sorting (auto-reorder rows as their values change)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2011
+#: src/muuli_wdr.cpp:2015
 msgid "Download Queue Files"
 msgstr "Letöltendő fájlok várakozási sora"
 
-#: src/muuli_wdr.cpp:2014
+#: src/muuli_wdr.cpp:2018
 msgid "Show progress percentage"
 msgstr "Százalékos arány mutatása"
 
-#: src/muuli_wdr.cpp:2020
+#: src/muuli_wdr.cpp:2024
 msgid "Show progress bar"
 msgstr "Folyamatjelző csík mutatása"
 
-#: src/muuli_wdr.cpp:2023
+#: src/muuli_wdr.cpp:2027
 msgid "Flat"
 msgstr "Lapos"
 
-#: src/muuli_wdr.cpp:2027
+#: src/muuli_wdr.cpp:2031
 msgid "Round"
 msgstr "Gömbölyű"
 
-#: src/muuli_wdr.cpp:2045
+#: src/muuli_wdr.cpp:2049
 msgid "External Connection Parameters"
 msgstr "Külső kapcsolatok jellemzői"
 
-#: src/muuli_wdr.cpp:2048
+#: src/muuli_wdr.cpp:2052
 msgid "Accept external connections"
 msgstr "Külső kapcsolat elfogadása"
 
-#: src/muuli_wdr.cpp:2055 src/muuli_wdr.cpp:2114
+#: src/muuli_wdr.cpp:2059 src/muuli_wdr.cpp:2118
 msgid "IP of the listening interface:"
 msgstr "Hallgató interfész IP-je:"
 
-#: src/muuli_wdr.cpp:2058
+#: src/muuli_wdr.cpp:2062
 msgid "Enter here a valid ip in the a.b.c.d format for the listening EC interface. An empty field or 0.0.0.0 will mean any interface."
 msgstr "Adjon meg itt egy érvényes IP címet a.b.c.d formában az EC hallgató interfésznek. Üres mező vagy 0.0.0.0 jelentése: bármelyik interfész."
 
-#: src/muuli_wdr.cpp:2079 src/muuli_wdr.cpp:2163
+#: src/muuli_wdr.cpp:2083 src/muuli_wdr.cpp:2194
 msgid "TCP port:"
 msgstr "TCP port:"
 
-#: src/muuli_wdr.cpp:2085
+#: src/muuli_wdr.cpp:2089
 msgid "Enable UPnP port forwarding on the EC port"
 msgstr "UPnP port továbbítás engedélyezése az EC porton"
 
-#: src/muuli_wdr.cpp:2089 src/muuli_wdr.cpp:3048
+#: src/muuli_wdr.cpp:2093 src/muuli_wdr.cpp:3079
 #: src/utils/wxCas/src/wxcasprefs.cpp:167
 msgid "Password"
 msgstr "Jelszó"
 
-#: src/muuli_wdr.cpp:2095
+#: src/muuli_wdr.cpp:2099
 #, fuzzy
 msgid "aMule API server parameters"
 msgstr "Web kiszolgáló paraméterek"
 
-#: src/muuli_wdr.cpp:2098
+#: src/muuli_wdr.cpp:2102
 msgid "Run amuleapi (REST API) on startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2103
+#: src/muuli_wdr.cpp:2107
 #, fuzzy
 msgid "HTTP port:"
 msgstr "TCP port:"
 
-#: src/muuli_wdr.cpp:2117
+#: src/muuli_wdr.cpp:2121
 msgid "The interface amuleapi's HTTP server listens on. 127.0.0.1 (default) accepts only local connections; use 0.0.0.0 or a specific IP to expose it to other hosts (set an admin password below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2120
+#: src/muuli_wdr.cpp:2126
+msgid "Type a password to set or change it. Stored passwords cannot be shown, so leaving this empty keeps the current one."
+msgstr ""
+
+#: src/muuli_wdr.cpp:2128
 #, fuzzy
 msgid "Admin password"
 msgstr "Jelszó ellenőrzése\n"
 
-#: src/muuli_wdr.cpp:2125 src/muuli_wdr.cpp:2156
-msgid "Low rights password"
-msgstr "Vendég jelszó"
+#: src/muuli_wdr.cpp:2140 src/muuli_wdr.cpp:2157 src/PrefsUnifiedDlg.cpp:1103
+#, fuzzy
+msgid "A password is set."
+msgstr "Jelszó ellenőrzése\n"
 
-#: src/muuli_wdr.cpp:2133
+#: src/muuli_wdr.cpp:2144
+#, fuzzy
+msgid "Enable guest access"
+msgstr "Vendég felhasználó tiltása"
+
+#: src/muuli_wdr.cpp:2145
+msgid "Guest sessions may read status and listings but cannot change anything. Turning this off clears the stored guest password."
+msgstr ""
+
+#: src/muuli_wdr.cpp:2149
+#, fuzzy
+msgid "Guest password"
+msgstr "Vendég jelszó a web kiszolgálóhoz"
+
+#: src/muuli_wdr.cpp:2164
 msgid "Web server parameters"
 msgstr "Web kiszolgáló paraméterek"
 
-#: src/muuli_wdr.cpp:2136
+#: src/muuli_wdr.cpp:2167
 #, fuzzy
 msgid "Run webserver on startup (deprecated)"
 msgstr "Webkiszolgáló indítása induláskor"
 
-#: src/muuli_wdr.cpp:2142
+#: src/muuli_wdr.cpp:2173
 msgid "Web template"
 msgstr "Web minta"
 
-#: src/muuli_wdr.cpp:2147
+#: src/muuli_wdr.cpp:2178
 msgid "Full rights password"
 msgstr "Admin jelszó"
 
-#: src/muuli_wdr.cpp:2151
+#: src/muuli_wdr.cpp:2182
 msgid "Enable Low rights User"
 msgstr "Vendég felhasználó engedélyezése"
 
-#: src/muuli_wdr.cpp:2170
+#: src/muuli_wdr.cpp:2187
+msgid "Low rights password"
+msgstr "Vendég jelszó"
+
+#: src/muuli_wdr.cpp:2201
 msgid "Enable UPnP port forwarding of the web server port"
 msgstr "A web kiszolgáló port UPnP továbbításának engedélyezése"
 
-#: src/muuli_wdr.cpp:2175
+#: src/muuli_wdr.cpp:2206
 msgid "Web server UPnP TCP port (Optional)"
 msgstr "Web szerver UPnP TCP port (nem kötelező)"
 
-#: src/muuli_wdr.cpp:2183
+#: src/muuli_wdr.cpp:2214
 msgid "Page Refresh Time (in secs)"
 msgstr "Oldal frissítésének időzítése (mp múlva)"
 
-#: src/muuli_wdr.cpp:2190
+#: src/muuli_wdr.cpp:2221
 msgid "Enable Gzip compression"
 msgstr "Gzip tömörítés engedélyezése"
 
-#: src/muuli_wdr.cpp:2224
+#: src/muuli_wdr.cpp:2255
 #, fuzzy
 msgid "Reset page to defaults"
 msgstr "Alapértelmezett"
 
-#: src/muuli_wdr.cpp:2225
+#: src/muuli_wdr.cpp:2256
 msgid "Reset the settings on the current page to their default values."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2227 src/muuli_wdr.cpp:2313 src/ServerWnd.cpp:274
+#: src/muuli_wdr.cpp:2258 src/muuli_wdr.cpp:2344 src/ServerWnd.cpp:274
 #: src/ServerWnd.cpp:282
 msgid "OK"
 msgstr "OK"
 
-#: src/muuli_wdr.cpp:2229
+#: src/muuli_wdr.cpp:2260
 msgid "Click here to apply any changes made to the preferences."
 msgstr "Kattints ide a beállítási módosítások alkalmazásához."
 
-#: src/muuli_wdr.cpp:2232
+#: src/muuli_wdr.cpp:2263
 msgid "Reset any changes made to the preferences."
 msgstr "Beállítási módosítások figyelmen kívül hagyása."
 
-#: src/muuli_wdr.cpp:2261
+#: src/muuli_wdr.cpp:2292
 msgid "Comment :"
 msgstr "Megjegyzés:"
 
-#: src/muuli_wdr.cpp:2268
+#: src/muuli_wdr.cpp:2299
 msgid "Incoming Dir :"
 msgstr "Bejövő Mappa :"
 
-#: src/muuli_wdr.cpp:2277
+#: src/muuli_wdr.cpp:2308
 msgid "Change priority for new assigned files :"
 msgstr "Újonnan hozzárendelt fájlok prioritásának változtatása :"
 
-#: src/muuli_wdr.cpp:2281
+#: src/muuli_wdr.cpp:2312
 msgid "Don't change"
 msgstr "Ne változzon"
 
-#: src/muuli_wdr.cpp:2293
+#: src/muuli_wdr.cpp:2324
 msgid "Select color for this Category (currently selected) :"
 msgstr "Válassz színt ehhez a kategóriához (jelenleg kiválasztva) :"
 
-#: src/muuli_wdr.cpp:2360 src/muuli_wdr.cpp:2379 src/muuli_wdr.cpp:2401
+#: src/muuli_wdr.cpp:2391 src/muuli_wdr.cpp:2410 src/muuli_wdr.cpp:2432
 msgid "Click this button to reset the log."
 msgstr "Kattints erre a gombra a logfájl visszaállításához."
 
-#: src/muuli_wdr.cpp:2420
+#: src/muuli_wdr.cpp:2451
 msgid "Click on this button to update the servers list from URL ..."
 msgstr "Kattints erre a gombra a kiszolgálólista frissítéséhez  ..."
 
-#: src/muuli_wdr.cpp:2424
+#: src/muuli_wdr.cpp:2455
 msgid "Server list"
 msgstr "Kiszolgálók listája"
 
-#: src/muuli_wdr.cpp:2428
+#: src/muuli_wdr.cpp:2459
 msgid "Enter the url to a server.met file here and press the button to the left to update the list of known servers."
 msgstr "Adj meg egy címet a server.met fájlhoz és nyomd meg a baloldali gombot az ismert kiszolgálók listájának frissítéséhez."
 
-#: src/muuli_wdr.cpp:2433
+#: src/muuli_wdr.cpp:2464
 msgid "Add server manually: Name"
 msgstr "Kiszolgáló hozzáadása kézzel: Név"
 
-#: src/muuli_wdr.cpp:2436
+#: src/muuli_wdr.cpp:2467
 msgid "Enter the name of the new server here"
 msgstr "Add meg az új kiszolgáló nevét"
 
-#: src/muuli_wdr.cpp:2438 src/ServerWnd.cpp:206
+#: src/muuli_wdr.cpp:2469 src/ServerWnd.cpp:206
 msgid "IP:Port"
 msgstr "IP:Port"
 
-#: src/muuli_wdr.cpp:2441
+#: src/muuli_wdr.cpp:2472
 msgid "Enter the IP of the server here, using the x.x.x.x format."
 msgstr "Itt add meg a kiszolgálók IP-jét, használd az x.x.x.x formát."
 
-#: src/muuli_wdr.cpp:2447
+#: src/muuli_wdr.cpp:2478
 msgid "Enter the port of the server here."
 msgstr "Add meg a kiszolgáló portját."
 
-#: src/muuli_wdr.cpp:2450
+#: src/muuli_wdr.cpp:2481
 msgid "Add manually a server (fill fields to the left before) ..."
 msgstr "Kiszolgáló felvétel kézzel (töltsd ki a baloldali mezőket először) ..."
 
-#: src/muuli_wdr.cpp:2479
+#: src/muuli_wdr.cpp:2510
 msgid "aMule Log"
 msgstr "aMule Napló"
 
-#: src/muuli_wdr.cpp:2487
+#: src/muuli_wdr.cpp:2518
 msgid "Server Info"
 msgstr "Kiszolgáló Infó"
 
-#: src/muuli_wdr.cpp:2491
+#: src/muuli_wdr.cpp:2522
 msgid "ED2K Info"
 msgstr "ED2K infó"
 
-#: src/muuli_wdr.cpp:2495
+#: src/muuli_wdr.cpp:2526
 msgid "Kad Info"
 msgstr "Kad infó"
 
-#: src/muuli_wdr.cpp:2523
+#: src/muuli_wdr.cpp:2554
 msgid "Click on this button to update the nodes list from URL ..."
 msgstr "Kattints erre a gombra a csomópont-lista frissítéséhez URL-ből ..."
 
-#: src/muuli_wdr.cpp:2527
+#: src/muuli_wdr.cpp:2558
 msgid "Nodes (0)"
 msgstr "Csomópontok (0)"
 
-#: src/muuli_wdr.cpp:2531
+#: src/muuli_wdr.cpp:2562
 msgid "Enter the url to a nodes.dat file here and press the button to the left to update the list of known nodes."
 msgstr "Adj meg egy címet a nodes.dat fájlhoz és nyomd meg a baloldali gombot az ismert csomópontok listájának frissítéséhez."
 
-#: src/muuli_wdr.cpp:2534
+#: src/muuli_wdr.cpp:2565
 msgid "Nodes stats"
 msgstr "Csomópont statisztikák"
 
-#: src/muuli_wdr.cpp:2576
+#: src/muuli_wdr.cpp:2607
 msgid "Bootstrap"
 msgstr "Rendszerbetöltés"
 
-#: src/muuli_wdr.cpp:2579
+#: src/muuli_wdr.cpp:2610
 msgid "New node"
 msgstr "Új csomópont (node)"
 
-#: src/muuli_wdr.cpp:2584
+#: src/muuli_wdr.cpp:2615
 msgid "IP:"
 msgstr "IP:"
 
-#: src/muuli_wdr.cpp:2604
+#: src/muuli_wdr.cpp:2635
 msgid "Port:"
 msgstr "Port:"
 
-#: src/muuli_wdr.cpp:2617
+#: src/muuli_wdr.cpp:2648
 msgid "Bootstrap from known clients"
 msgstr "Indítás ismert kliensektől"
 
-#: src/muuli_wdr.cpp:2619
+#: src/muuli_wdr.cpp:2650
 msgid "Disconnect Kad"
 msgstr "Leválasztás a Kad-ról"
 
-#: src/muuli_wdr.cpp:2653
+#: src/muuli_wdr.cpp:2684
 msgid "Use Secure User Identification"
 msgstr "Biztonságos azonosítás használata"
 
-#: src/muuli_wdr.cpp:2655
+#: src/muuli_wdr.cpp:2686
 msgid "It is recommended to enable this option. You will not receive credits if SUI is not enabled."
 msgstr "Ajánlott ezt az opciót engedélyezni. Nem fogsz kreditet kapni, ha nincs engedélyezve."
 
-#: src/muuli_wdr.cpp:2657
+#: src/muuli_wdr.cpp:2688
 msgid "Protocol Obfuscation"
 msgstr "Protokoll zavarás"
 
-#: src/muuli_wdr.cpp:2660
+#: src/muuli_wdr.cpp:2691
 msgid "Support Protocol Obfuscation"
 msgstr "Protokoll zavarás támogatása"
 
-#: src/muuli_wdr.cpp:2662
+#: src/muuli_wdr.cpp:2693
 msgid "This option enabled Protocol Obfuscation, and makes aMule accept obfuscated connections from other clients."
 msgstr "Ez az opció engedélyezi a protokoll zavarást, és az aMule elfogad zavart kapcsolatokat más ügyfelektől."
 
-#: src/muuli_wdr.cpp:2664
+#: src/muuli_wdr.cpp:2695
 msgid "Use obfuscation for outgoing connections"
 msgstr "Kimenő kapcsolatok zavarása"
 
-#: src/muuli_wdr.cpp:2666
+#: src/muuli_wdr.cpp:2697
 msgid "This option makes aMule use Protocol Obfuscation when connecting other clients/servers."
 msgstr "Ez az opció engedélyezi a protokoll zavarást, amikor más ügyfelekhez/kiszolgálókhoz kapcsolódik az aMule."
 
-#: src/muuli_wdr.cpp:2668
+#: src/muuli_wdr.cpp:2699
 msgid "Accept only obfuscated connections"
 msgstr "Csak zavart kapcsolatok elfogadása"
 
-#: src/muuli_wdr.cpp:2669
+#: src/muuli_wdr.cpp:2700
 msgid "This option makes aMule only accept obfuscated connections. You will have less sources, but all your traffic will be obfuscated"
 msgstr "Ezen opció hatására az aMule csak zavart kapcsolatokat fog elfogadni. Kevesebb forrásod lesz, de a teljes forgalom zavart lesz"
 
-#: src/muuli_wdr.cpp:2674
+#: src/muuli_wdr.cpp:2705
 msgid "Everybody"
 msgstr "Mindenki"
 
-#: src/muuli_wdr.cpp:2676
+#: src/muuli_wdr.cpp:2707
 msgid "No one"
 msgstr "Senki"
 
-#: src/muuli_wdr.cpp:2678
+#: src/muuli_wdr.cpp:2709
 msgid "Who can see my shared files:"
 msgstr "Ki láthatja a megosztott fájljaimat:"
 
-#: src/muuli_wdr.cpp:2679
+#: src/muuli_wdr.cpp:2710
 msgid "Select who can request to view a list of your shared files."
 msgstr "Válaszd ki, hogy kik kérdezhetik le megosztott fájlaid listáját."
 
-#: src/muuli_wdr.cpp:2681
+#: src/muuli_wdr.cpp:2712
 msgid "IP-Filtering"
 msgstr "IP-szűrés"
 
-#: src/muuli_wdr.cpp:2688
+#: src/muuli_wdr.cpp:2719
 msgid "Filter clients"
 msgstr "Kliensek szűrése"
 
-#: src/muuli_wdr.cpp:2690
+#: src/muuli_wdr.cpp:2721
 msgid "Enable filtering of the client IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "A ~/.aMule/ipfilter.dat állományban IP-jű kliensek szűrésének engedélyezése."
 
-#: src/muuli_wdr.cpp:2692
+#: src/muuli_wdr.cpp:2723
 msgid "Filter servers"
 msgstr "Kiszolgálók szűrése"
 
-#: src/muuli_wdr.cpp:2694
+#: src/muuli_wdr.cpp:2725
 msgid "Enable filtering of the server IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "A ~/.aMule/ipfilter.dat állományban IP-jű kiszolgálók szűrésének engedélyezése."
 
-#: src/muuli_wdr.cpp:2698
+#: src/muuli_wdr.cpp:2729
 msgid "Reload List"
 msgstr "Lista újratöltése"
 
-#: src/muuli_wdr.cpp:2699
+#: src/muuli_wdr.cpp:2730
 msgid "Reload the list of IPs to filter from the file ~/.aMule/ipfilter.dat"
 msgstr "IP-k listájának újratöltése a ~/.aMule/ipfilter.dat fájlból"
 
-#: src/muuli_wdr.cpp:2705
+#: src/muuli_wdr.cpp:2736
 msgid "URL:"
 msgstr "URL:"
 
-#: src/muuli_wdr.cpp:2709 src/muuli_wdr.cpp:2902
+#: src/muuli_wdr.cpp:2740 src/muuli_wdr.cpp:2933
 msgid "Update now"
 msgstr "Frissítés most"
 
-#: src/muuli_wdr.cpp:2712
+#: src/muuli_wdr.cpp:2743
 msgid "Auto-update ipfilter at startup"
 msgstr "IP szűrő automatikus letöltése indításkor"
 
-#: src/muuli_wdr.cpp:2716
+#: src/muuli_wdr.cpp:2747
 msgid "Filtering Level:"
 msgstr "Szűrési szint:"
 
-#: src/muuli_wdr.cpp:2722
+#: src/muuli_wdr.cpp:2753
 msgid "Always filter LAN IPs"
 msgstr "Mindig szűrje ki a LAN IP-ket"
 
-#: src/muuli_wdr.cpp:2725
+#: src/muuli_wdr.cpp:2756
 msgid "Paranoid handling of non-matching IPs"
 msgstr "A nem-megegyező IP-k paranoid kezelése"
 
-#: src/muuli_wdr.cpp:2727
+#: src/muuli_wdr.cpp:2758
 msgid "Rejects a packet when its source IP differs from the IP the client claims (an anti-spoofing check). Disable only if it causes connection problems."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2729
+#: src/muuli_wdr.cpp:2760
 msgid "Use system-wide ipfilter.dat if available"
 msgstr "Rendszer-szintű ipfilter.dat használatának engedélyezése"
 
-#: src/muuli_wdr.cpp:2730
+#: src/muuli_wdr.cpp:2761
 msgid "If there's no local ipfilter.dat found, allow usage of a system-wide ipfilter file."
 msgstr "Ha nem talál helyi ipfilter.dat fájlt, akkor engedje a rendszerszintű ipfilter fájl használatát."
 
-#: src/muuli_wdr.cpp:2747
+#: src/muuli_wdr.cpp:2778
 msgid "Enable Online-Signature"
 msgstr "Online-aláírás engedélyezése"
 
-#: src/muuli_wdr.cpp:2749
+#: src/muuli_wdr.cpp:2780
 msgid "Enables the writing of the OS file, which can be used by external apps to create signatures and the like."
 msgstr "Az online-aláírás fájl írásának engedélyezése, amit külső alkalmazások használhatnak fel aláírások létrehozásához és így tovább."
 
-#: src/muuli_wdr.cpp:2753
+#: src/muuli_wdr.cpp:2784
 msgid "Update Frequency (Secs):"
 msgstr "Frissítési gyakoriság (mp):"
 
-#: src/muuli_wdr.cpp:2756
+#: src/muuli_wdr.cpp:2787
 msgid "Change the frequency (in seconds) of Online Signature updates."
 msgstr "Online aláírás frissítési gyakoriságának módosítása (mp-ben)."
 
-#: src/muuli_wdr.cpp:2764
+#: src/muuli_wdr.cpp:2795
 msgid "Save online signature file in: "
 msgstr "Online aláírási fájl kimentési helye: "
 
-#: src/muuli_wdr.cpp:2770
+#: src/muuli_wdr.cpp:2801
 msgid "Click here to select the directory containing the the Online Signature files."
 msgstr "Kattints ide az online aláírást tartalmazó könyvtár kiválasztásához."
 
-#: src/muuli_wdr.cpp:2803
+#: src/muuli_wdr.cpp:2834
 msgid "Show country flags for clients"
 msgstr "Kliensek országzászlajainak megjelenítése"
 
-#: src/muuli_wdr.cpp:2804
+#: src/muuli_wdr.cpp:2835
 msgid "Render the country flag column in the transfers, queue and search views. Requires a valid MMDB GeoIP database (see below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2809
+#: src/muuli_wdr.cpp:2840
 msgid "Database"
 msgstr "Adatbázis"
 
-#: src/muuli_wdr.cpp:2825
+#: src/muuli_wdr.cpp:2856
 msgid "Source:"
 msgstr "Forrás:"
 
-#: src/muuli_wdr.cpp:2828
+#: src/muuli_wdr.cpp:2859
 msgid "DB-IP (free, no account)"
 msgstr "DB-IP (ingyenes, fiók nélkül)"
 
-#: src/muuli_wdr.cpp:2829
+#: src/muuli_wdr.cpp:2860
 msgid "MaxMind GeoLite2 (free, account required)"
 msgstr "MaxMind GeoLite2 (ingyenes, fiók szükséges)"
 
-#: src/muuli_wdr.cpp:2830
+#: src/muuli_wdr.cpp:2861
 msgid "Custom URL"
 msgstr "Egyéni URL"
 
-#: src/muuli_wdr.cpp:2833
+#: src/muuli_wdr.cpp:2864
 msgid "Choose which provider supplies the GeoIP MMDB database. DB-IP is the default - no account required. MaxMind requires a free account + license key. Use Custom URL to point at any other MMDB host (e.g. a local mirror)."
 msgstr "Válassza ki a GeoIP MMDB adatbázis szolgáltatóját. DB-IP az alapértelmezett - nincs szükség fiókra. MaxMind egy ingyenes fiókot és licenckulcsot igényel. Használjon egyéni URL-t bármely más MMDB host megadásához (pl. egy helyi tükörhöz)."
 
-#: src/muuli_wdr.cpp:2850
+#: src/muuli_wdr.cpp:2881
 msgid ""
 "No configuration required.\n"
 "\n"
@@ -4834,11 +4862,11 @@ msgstr ""
 "IP-to-Country adat DB-IP.com által - https://db-ip.com\n"
 "Licenc: Creative Commons BY 4.0 - https://creativecommons.org/licenses/by/4.0/"
 
-#: src/muuli_wdr.cpp:2863
+#: src/muuli_wdr.cpp:2894
 msgid "License key:"
 msgstr "Licenckulcs:"
 
-#: src/muuli_wdr.cpp:2869
+#: src/muuli_wdr.cpp:2900
 msgid ""
 "Sign up for a free MaxMind account, then generate a License Key:\n"
 "https://www.maxmind.com/en/geolite2/signup\n"
@@ -4854,11 +4882,11 @@ msgstr ""
 "Licenc: MaxMind GeoLite2 EULA - https://www.maxmind.com/en/geolite2/eula\n"
 "Hozzárendelést és fiókregisztrációt igényel; legalább 30 naponta frissítse."
 
-#: src/muuli_wdr.cpp:2884
+#: src/muuli_wdr.cpp:2915
 msgid "Download URL:"
 msgstr "Letöltési URL:"
 
-#: src/muuli_wdr.cpp:2890
+#: src/muuli_wdr.cpp:2921
 msgid ""
 "Must point to an .mmdb file or a .gz / .tar.gz containing one.\n"
 "URL may include credentials (https://user:pass@host/...).\n"
@@ -4868,211 +4896,211 @@ msgstr ""
 "Az URL tartalmazhat hitelesítő adatokat (https://user:pass@host/...).\n"
 "A licenc- és megnevezési feltételeket a felmenő URL határozza meg - ön a felelőss."
 
-#: src/muuli_wdr.cpp:2903
+#: src/muuli_wdr.cpp:2934
 msgid "Download the GeoIP database from the selected source."
 msgstr "GeoIP adatbázis letöltése a kiválasztott forrásból."
 
-#: src/muuli_wdr.cpp:2905
+#: src/muuli_wdr.cpp:2936
 msgid "Auto-update on startup"
 msgstr "Automatikus frissítés indításkor"
 
-#: src/muuli_wdr.cpp:2906
+#: src/muuli_wdr.cpp:2937
 msgid "Re-download the GeoIP database from the selected source every time aMule starts."
 msgstr "GeoIP adatbázis újonnani letöltése a kiválasztott forrásból minden aMule indításkor."
 
-#: src/muuli_wdr.cpp:2929
+#: src/muuli_wdr.cpp:2960
 msgid "Filter incoming messages (except current chat):"
 msgstr "Bejövő üzenetek kiszűrése (kivéve az aktuális csevegés):"
 
-#: src/muuli_wdr.cpp:2931
+#: src/muuli_wdr.cpp:2962
 msgid "Filter all messages"
 msgstr "Összes üzenet szűrése"
 
-#: src/muuli_wdr.cpp:2933
+#: src/muuli_wdr.cpp:2964
 msgid "Filter messages from people not on your friend list"
 msgstr "Barát listában nem szereplőktől érkező üzenetek kiszűrése"
 
-#: src/muuli_wdr.cpp:2935
+#: src/muuli_wdr.cpp:2966
 msgid "Filter messages from unknown clients"
 msgstr "Ismeretlen kliensektől érkező üzenetek kiszűrése"
 
-#: src/muuli_wdr.cpp:2937
+#: src/muuli_wdr.cpp:2968
 msgid "Filter messages containing (use ',' as separator):"
 msgstr "A következő(ke)t tartalmazó üzenetek kiszűrése (elválasztónak ','-t használj):"
 
-#: src/muuli_wdr.cpp:2940 src/muuli_wdr.cpp:2951
+#: src/muuli_wdr.cpp:2971 src/muuli_wdr.cpp:2982
 msgid "add here the words amule should filter and block messages including it"
 msgstr "Azon szavak felvétele, amelyeket az amule-nak ki kellene szűrni és blokkolni az ezeket tartalmazó üzeneteket"
 
-#: src/muuli_wdr.cpp:2942
+#: src/muuli_wdr.cpp:2973
 msgid "Show received messages in the log"
 msgstr "A kapott üzenetek megjelenítése a naplóban"
 
-#: src/muuli_wdr.cpp:2945
+#: src/muuli_wdr.cpp:2976
 msgid "Comments"
 msgstr "Megjegyzések"
 
-#: src/muuli_wdr.cpp:2948
+#: src/muuli_wdr.cpp:2979
 msgid "Filter comments containing (use ',' as separator):"
 msgstr "Megjegyzések kiszűrése, melyek tartalmazzák (',' az elválasztó):"
 
-#: src/muuli_wdr.cpp:2973
+#: src/muuli_wdr.cpp:3004
 msgid "Enable Proxy"
 msgstr "Proxy engedélyezése"
 
-#: src/muuli_wdr.cpp:2974
+#: src/muuli_wdr.cpp:3005
 msgid "Enable/disable proxy support"
 msgstr "Proxy támogatás engedélyezése/tiltása"
 
-#: src/muuli_wdr.cpp:2977
+#: src/muuli_wdr.cpp:3008
 msgid "Proxy type:"
 msgstr "Proxy típusa:"
 
-#: src/muuli_wdr.cpp:2988
+#: src/muuli_wdr.cpp:3019
 msgid "Proxy host:"
 msgstr "Proxy host:"
 
-#: src/muuli_wdr.cpp:2991
+#: src/muuli_wdr.cpp:3022
 msgid "The proxy host name"
 msgstr "A proxy host neve"
 
-#: src/muuli_wdr.cpp:2993
+#: src/muuli_wdr.cpp:3024
 msgid "Proxy port:"
 msgstr "Proxy port:"
 
-#: src/muuli_wdr.cpp:2996
+#: src/muuli_wdr.cpp:3027
 msgid "The proxy port"
 msgstr "A proxy port"
 
-#: src/muuli_wdr.cpp:2998
+#: src/muuli_wdr.cpp:3029
 msgid "Enable authentication"
 msgstr "Hitelesítés engedélyezése"
 
-#: src/muuli_wdr.cpp:2999
+#: src/muuli_wdr.cpp:3030
 msgid "Enable/disable username/password authentication"
 msgstr "Felhasználói név/jelszó hitelesítés engedélyezése/tiltása"
 
-#: src/muuli_wdr.cpp:3002
+#: src/muuli_wdr.cpp:3033
 msgid "Username: "
 msgstr "Felhasználói név: "
 
-#: src/muuli_wdr.cpp:3005
+#: src/muuli_wdr.cpp:3036
 msgid "The username to use to connect to the proxy"
 msgstr "Felhasználói név a proxy kapcsolathoz"
 
-#: src/muuli_wdr.cpp:3007
+#: src/muuli_wdr.cpp:3038
 msgid "Password:"
 msgstr "Jelszó:"
 
-#: src/muuli_wdr.cpp:3010
+#: src/muuli_wdr.cpp:3041
 msgid "The password to use to connect to the proxy"
 msgstr "Jelszó a proxy kapcsolathoz"
 
-#: src/muuli_wdr.cpp:3029
+#: src/muuli_wdr.cpp:3060
 msgid "Connect to:"
 msgstr "Kapcsolódás ehhez:"
 
-#: src/muuli_wdr.cpp:3038
+#: src/muuli_wdr.cpp:3069
 msgid "Login to remote amule"
 msgstr "Bejeletkezés a távoli amule-ra"
 
-#: src/muuli_wdr.cpp:3043
+#: src/muuli_wdr.cpp:3074
 msgid "User name"
 msgstr "Felhasználói név"
 
-#: src/muuli_wdr.cpp:3054
+#: src/muuli_wdr.cpp:3085
 msgid "Remember those settings"
 msgstr "Emlékezzen ezekre a beállításokra"
 
-#: src/muuli_wdr.cpp:3057
+#: src/muuli_wdr.cpp:3088
 msgid "Force ZLIB compression"
 msgstr "ZLIB tömörítés erőltetése"
 
-#: src/muuli_wdr.cpp:3081
+#: src/muuli_wdr.cpp:3112
 msgid "Enable Verbose Debug-Logging."
 msgstr "Bőbeszédű hiba-naplózás engedélyezése."
 
-#: src/muuli_wdr.cpp:3083
+#: src/muuli_wdr.cpp:3114
 msgid "Only to Logfile"
 msgstr "Csak napló fájlba"
 
-#: src/muuli_wdr.cpp:3085
+#: src/muuli_wdr.cpp:3116
 msgid "Message Categories:"
 msgstr "Üzenet kategóriák:"
 
-#: src/muuli_wdr.cpp:3109 src/PartFileConvertDlg.cpp:160
+#: src/muuli_wdr.cpp:3140 src/PartFileConvertDlg.cpp:160
 msgid "Waiting..."
 msgstr "Várakozás..."
 
-#: src/muuli_wdr.cpp:3129
+#: src/muuli_wdr.cpp:3160
 msgid "Add imports"
 msgstr "Importálandók hozzáadása"
 
-#: src/muuli_wdr.cpp:3132
+#: src/muuli_wdr.cpp:3163
 msgid "Retry selected"
 msgstr "Kijelöltek újrapróbálása"
 
-#: src/muuli_wdr.cpp:3134
+#: src/muuli_wdr.cpp:3165
 msgid "Remove selected"
 msgstr "Kijelöltek eltávolítása"
 
-#: src/muuli_wdr.cpp:3197
+#: src/muuli_wdr.cpp:3228
 msgid "Event Types"
 msgstr "Esemény típusok"
 
-#: src/muuli_wdr.cpp:3216
+#: src/muuli_wdr.cpp:3247
 msgid "Statistics and queued clients for selected file(s) : Session / All time"
 msgstr "Statisztikák és várakozó kliensek a kiválasztott fájl(ok)hoz: Folyamat / Valaha"
 
-#: src/muuli_wdr.cpp:3240
+#: src/muuli_wdr.cpp:3271
 msgid "Active Uploads"
 msgstr "Aktív feltöltések"
 
-#: src/muuli_wdr.cpp:3254
+#: src/muuli_wdr.cpp:3285
 msgid "Percent of total files"
 msgstr "Összes fájl százalékaként"
 
-#: src/muuli_wdr.cpp:3306
+#: src/muuli_wdr.cpp:3337
 msgid "Show Clients for"
 msgstr "Kliensek megjelenítése ehhez:"
 
-#: src/muuli_wdr.cpp:3308
+#: src/muuli_wdr.cpp:3339
 msgid "All files"
 msgstr "Összes fájl"
 
-#: src/muuli_wdr.cpp:3311
+#: src/muuli_wdr.cpp:3342
 msgid "Selected files"
 msgstr "Kiválasztott fájlok"
 
-#: src/muuli_wdr.cpp:3314
+#: src/muuli_wdr.cpp:3345
 msgid "Active uploads only"
 msgstr "Csak aktív feltöltések"
 
-#: src/muuli_wdr.cpp:3321
+#: src/muuli_wdr.cpp:3352
 msgid "Reload:"
 msgstr "Újratöltés:"
 
-#: src/muuli_wdr.cpp:3325
+#: src/muuli_wdr.cpp:3356
 msgid "Reload your shared files"
 msgstr "Megosztott fájlok frissítése"
 
-#: src/muuli_wdr.cpp:3388
+#: src/muuli_wdr.cpp:3419
 msgid "Send"
 msgstr "Küldés"
 
-#: src/muuli_wdr.cpp:3389
+#: src/muuli_wdr.cpp:3420
 msgid "Sends the specified message."
 msgstr "Megadott üzenet küldése."
 
-#: src/muuli_wdr.cpp:3393
+#: src/muuli_wdr.cpp:3424
 msgid "Close this chat-session."
 msgstr "Csevegési folyamat bezárása."
 
-#: src/muuli_wdr.cpp:3416
+#: src/muuli_wdr.cpp:3447
 msgid "Connect to any server and/or Kad"
 msgstr "Kapcsolódás bármelyik kiszolgálóhoz és/vagy a Kad-hoz"
 
-#: src/muuli_wdr.cpp:3422 src/SharedFilesCtrl.cpp:142 src/Statistics.cpp:941
+#: src/muuli_wdr.cpp:3453 src/SharedFilesCtrl.cpp:142 src/Statistics.cpp:941
 msgid "Shared Files"
 msgstr "Megosztott fájlok"
 
@@ -5428,249 +5456,249 @@ msgstr "Letöltve"
 msgid "ERROR: Failed to open partfile '%s'"
 msgstr "HIBA: A(z) '%s' részfájl megnyitása sikertelen."
 
-#: src/Preferences.cpp:674
+#: src/Preferences.cpp:701
 msgid "System default"
 msgstr "Alapértelmezett"
 
-#: src/Preferences.cpp:675
+#: src/Preferences.cpp:702
 msgid "Albanian"
 msgstr "Albán"
 
-#: src/Preferences.cpp:676
+#: src/Preferences.cpp:703
 msgid "Arabic"
 msgstr "Arab"
 
-#: src/Preferences.cpp:677
+#: src/Preferences.cpp:704
 msgid "Asturian"
 msgstr "Asztúriai"
 
-#: src/Preferences.cpp:678
+#: src/Preferences.cpp:705
 msgid "Basque"
 msgstr "Baszk"
 
-#: src/Preferences.cpp:679
+#: src/Preferences.cpp:706
 msgid "Bulgarian"
 msgstr "Bolgár"
 
-#: src/Preferences.cpp:680
+#: src/Preferences.cpp:707
 msgid "Catalan"
 msgstr "Katalán"
 
-#: src/Preferences.cpp:681
+#: src/Preferences.cpp:708
 msgid "Chinese (Simplified)"
 msgstr "Kínai (egyszerűsített)"
 
-#: src/Preferences.cpp:682
+#: src/Preferences.cpp:709
 msgid "Chinese (Traditional)"
 msgstr "Kínai (hagyományos)"
 
-#: src/Preferences.cpp:683
+#: src/Preferences.cpp:710
 msgid "Croatian"
 msgstr "Horvát"
 
-#: src/Preferences.cpp:684
+#: src/Preferences.cpp:711
 msgid "Czech"
 msgstr "Cseh"
 
-#: src/Preferences.cpp:685
+#: src/Preferences.cpp:712
 msgid "Danish"
 msgstr "Dán"
 
-#: src/Preferences.cpp:686
+#: src/Preferences.cpp:713
 msgid "Dutch"
 msgstr "Holland"
 
-#: src/Preferences.cpp:687
+#: src/Preferences.cpp:714
 msgid "English (U.K.)"
 msgstr "Angol (Egyesült Királyság)"
 
-#: src/Preferences.cpp:688
+#: src/Preferences.cpp:715
 #, fuzzy
 msgid "English (U.S.)"
 msgstr "Angol (Egyesült Királyság)"
 
-#: src/Preferences.cpp:689
+#: src/Preferences.cpp:716
 msgid "Estonian"
 msgstr "Észt"
 
-#: src/Preferences.cpp:690
+#: src/Preferences.cpp:717
 msgid "Finnish"
 msgstr "Finn"
 
-#: src/Preferences.cpp:691
+#: src/Preferences.cpp:718
 msgid "French"
 msgstr "Francia"
 
-#: src/Preferences.cpp:692
+#: src/Preferences.cpp:719
 msgid "Galician"
 msgstr "Gall"
 
-#: src/Preferences.cpp:693
+#: src/Preferences.cpp:720
 msgid "German"
 msgstr "Német"
 
-#: src/Preferences.cpp:694
+#: src/Preferences.cpp:721
 msgid "Greek"
 msgstr "Görög"
 
-#: src/Preferences.cpp:695
+#: src/Preferences.cpp:722
 msgid "Hebrew"
 msgstr "Héber"
 
-#: src/Preferences.cpp:696
+#: src/Preferences.cpp:723
 msgid "Hungarian"
 msgstr "Magyar"
 
-#: src/Preferences.cpp:697
+#: src/Preferences.cpp:724
 msgid "Italian"
 msgstr "Olasz"
 
-#: src/Preferences.cpp:698
+#: src/Preferences.cpp:725
 msgid "Japanese"
 msgstr "Japán"
 
-#: src/Preferences.cpp:699
+#: src/Preferences.cpp:726
 msgid "Korean"
 msgstr "Koreai"
 
-#: src/Preferences.cpp:700
+#: src/Preferences.cpp:727
 msgid "Latvian"
 msgstr ""
 
-#: src/Preferences.cpp:701
+#: src/Preferences.cpp:728
 msgid "Lithuanian"
 msgstr "Litván"
 
-#: src/Preferences.cpp:702
+#: src/Preferences.cpp:729
 msgid "Norwegian (Nynorsk)"
 msgstr "Norvég (Nynorsk)"
 
-#: src/Preferences.cpp:703
+#: src/Preferences.cpp:730
 msgid "Polish"
 msgstr "Lengyel"
 
-#: src/Preferences.cpp:704
+#: src/Preferences.cpp:731
 msgid "Portuguese"
 msgstr "Portugál"
 
-#: src/Preferences.cpp:705
+#: src/Preferences.cpp:732
 msgid "Portuguese (Brazilian)"
 msgstr "Portugál (Brazíliai)"
 
-#: src/Preferences.cpp:706
+#: src/Preferences.cpp:733
 msgid "Romanian"
 msgstr "Román"
 
-#: src/Preferences.cpp:707
+#: src/Preferences.cpp:734
 msgid "Russian"
 msgstr "Orosz"
 
-#: src/Preferences.cpp:708
+#: src/Preferences.cpp:735
 msgid "Slovenian"
 msgstr "Szlovén"
 
-#: src/Preferences.cpp:709
+#: src/Preferences.cpp:736
 msgid "Spanish"
 msgstr "Spanyol"
 
-#: src/Preferences.cpp:710
+#: src/Preferences.cpp:737
 msgid "Swedish"
 msgstr "Svéd"
 
-#: src/Preferences.cpp:711
+#: src/Preferences.cpp:738
 msgid "Turkish"
 msgstr "Török"
 
-#: src/Preferences.cpp:712
+#: src/Preferences.cpp:739
 msgid "Ukrainian"
 msgstr "Ukrán"
 
-#: src/Preferences.cpp:815
+#: src/Preferences.cpp:842
 msgid "Change Language"
 msgstr "Nyelv megváltoztatása"
 
-#: src/Preferences.cpp:879
+#: src/Preferences.cpp:906
 msgid "There are no translations installed for aMule"
 msgstr "Nincsenek fordítások telepítve az aMule-hez"
 
-#: src/Preferences.cpp:880
+#: src/Preferences.cpp:907
 msgid "No languages available"
 msgstr "Nincs elérhető nyelv"
 
-#: src/Preferences.cpp:1011
+#: src/Preferences.cpp:1038
 msgid "no options available"
 msgstr "nincs elérhető opció"
 
-#: src/Preferences.cpp:2182
+#: src/Preferences.cpp:2227
 msgid "Invalid category found, skipping"
 msgstr "Érvénytelen kategória találva, mellőzés"
 
-#: src/Preferences.cpp:2351
+#: src/Preferences.cpp:2396
 msgid "TCP port can't be higher than 65532 due to server UDP socket being TCP+3"
 msgstr "A TCP port nem lehet magasabb 65532-nél, mert a kiszolgáló UDP port = TCP+3"
 
-#: src/Preferences.cpp:2352
+#: src/Preferences.cpp:2397
 #, c-format
 msgid "Default port will be used (%d)"
 msgstr "Alapértelmezett port lesz használva (%d)"
 
-#: src/PrefsUnifiedDlg.cpp:298 src/Statistics.cpp:866
+#: src/PrefsUnifiedDlg.cpp:300 src/Statistics.cpp:866
 msgid "Connection"
 msgstr "Csatlakozás"
 
-#: src/PrefsUnifiedDlg.cpp:299 src/SearchListCtrl.cpp:117
+#: src/PrefsUnifiedDlg.cpp:301 src/SearchListCtrl.cpp:117
 msgid "Directories"
 msgstr "Mappák"
 
-#: src/PrefsUnifiedDlg.cpp:300 src/Statistics.cpp:917
+#: src/PrefsUnifiedDlg.cpp:302 src/Statistics.cpp:917
 msgid "Servers"
 msgstr "Kiszolgálók"
 
-#: src/PrefsUnifiedDlg.cpp:301 src/ServerListCtrl.cpp:96
+#: src/PrefsUnifiedDlg.cpp:303 src/ServerListCtrl.cpp:96
 msgid "Files"
 msgstr "Fájlok"
 
-#: src/PrefsUnifiedDlg.cpp:302
+#: src/PrefsUnifiedDlg.cpp:304
 msgid "Security"
 msgstr "Biztonság"
 
-#: src/PrefsUnifiedDlg.cpp:303
+#: src/PrefsUnifiedDlg.cpp:305
 msgid "Interface"
 msgstr "Felület"
 
-#: src/PrefsUnifiedDlg.cpp:310
+#: src/PrefsUnifiedDlg.cpp:312
 msgid "IP2Country"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:313
+#: src/PrefsUnifiedDlg.cpp:315
 msgid "Proxy"
 msgstr "Proxy"
 
-#: src/PrefsUnifiedDlg.cpp:314
+#: src/PrefsUnifiedDlg.cpp:316
 msgid "Filters"
 msgstr "Szűrők"
 
-#: src/PrefsUnifiedDlg.cpp:315
+#: src/PrefsUnifiedDlg.cpp:317
 msgid "Remote Controls"
 msgstr "Távoli elérés"
 
-#: src/PrefsUnifiedDlg.cpp:316
+#: src/PrefsUnifiedDlg.cpp:318
 msgid "Online Signature"
 msgstr "Online aláírás"
 
-#: src/PrefsUnifiedDlg.cpp:317
+#: src/PrefsUnifiedDlg.cpp:319
 msgid "Advanced"
 msgstr "Haladó"
 
-#: src/PrefsUnifiedDlg.cpp:318
+#: src/PrefsUnifiedDlg.cpp:320
 msgid "Events"
 msgstr "Események"
 
-#: src/PrefsUnifiedDlg.cpp:321
+#: src/PrefsUnifiedDlg.cpp:323
 msgid "Debugging"
 msgstr "Hibakeresés"
 
-#: src/PrefsUnifiedDlg.cpp:451
+#: src/PrefsUnifiedDlg.cpp:453
 msgid ""
 "The following variables will be substituted:\n"
 "    %PARTFILE - full path to the file\n"
@@ -5680,15 +5708,15 @@ msgstr ""
 "    %PARTFILE - teljes út a fájlhoz\n"
 "    %PARTNAME - csak a fájl neve"
 
-#: src/PrefsUnifiedDlg.cpp:472
+#: src/PrefsUnifiedDlg.cpp:474
 msgid "Tray icon support requires libayatana-appindicator3 at compile time."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:488
+#: src/PrefsUnifiedDlg.cpp:490
 msgid "Not available on Wayland: the protocol does not report when a window is minimized, so this option cannot intercept the system minimize button. Workaround: launch aMule with `GDK_BACKEND=x11` to use XWayland instead."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:534
+#: src/PrefsUnifiedDlg.cpp:536
 msgid ""
 "Do not change these setting unless you know\n"
 "what you are doing, otherwise you can easily\n"
@@ -5704,26 +5732,35 @@ msgstr ""
 "Ezen beállítások módosítása nélkül is remekül fog\n"
 "működni az aMule."
 
-#: src/PrefsUnifiedDlg.cpp:645
+#: src/PrefsUnifiedDlg.cpp:647
 #, c-format
 msgid "Failed to connect Cfg to widget with the ID %d and key %s"
 msgstr "Cfg csatolása a widget-hez (ID-je: %d, kulcsa: %s) sikertelen"
 
-#: src/PrefsUnifiedDlg.cpp:693
+#: src/PrefsUnifiedDlg.cpp:695
 #, c-format
 msgid "Failed to transfer data from Cfg to Widget with the ID %d and key %s"
 msgstr "Adatátvitel a Cfg-ből a Widget-be (ID-je: %d, kulcsa: %s) sikertelen."
 
-#: src/PrefsUnifiedDlg.cpp:799
+#: src/PrefsUnifiedDlg.cpp:801
 msgid "The type of proxy you are connecting to"
 msgstr "A proxy típusa amihez kapcsolódsz"
 
-#: src/PrefsUnifiedDlg.cpp:1003
+#: src/PrefsUnifiedDlg.cpp:1020
 #, c-format
 msgid "Failed to transfer data from Widget to Cfg with the ID %d and key %s"
 msgstr "Adatátvitel a Widget-ből a Cfg-be (ID-je: %d, kulcsa: %s) sikertelen."
 
 #: src/PrefsUnifiedDlg.cpp:1103
+#, fuzzy
+msgid "No password set."
+msgstr "Jelszó ellenőrzése\n"
+
+#: src/PrefsUnifiedDlg.cpp:1132
+msgid "Guest access needs a password. Type one in the guest password field, or untick Enable guest access."
+msgstr ""
+
+#: src/PrefsUnifiedDlg.cpp:1144
 msgid ""
 "aMule must be restarted to enable these changes:\n"
 "\n"
@@ -5731,41 +5768,41 @@ msgstr ""
 "Újra kell indítani az aMule-t, hogy az alábbi változás(ok) érvénybe lépjen(ek):\n"
 "\n"
 
-#: src/PrefsUnifiedDlg.cpp:1110
+#: src/PrefsUnifiedDlg.cpp:1151
 msgid "- TCP port changed.\n"
 msgstr "- TCP port megváltozott.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1115
+#: src/PrefsUnifiedDlg.cpp:1156
 msgid "- UDP port changed.\n"
 msgstr "- UDP port megváltozott.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1120
+#: src/PrefsUnifiedDlg.cpp:1161
 #, fuzzy
 msgid "- Network interface binding changed.\n"
 msgstr "- Külső kapcsolat interfész megváltoztatva.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1125
+#: src/PrefsUnifiedDlg.cpp:1166
 msgid "- External connect port changed.\n"
 msgstr "- Külső kapcsolat port megváltoztatva.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1129
+#: src/PrefsUnifiedDlg.cpp:1170
 msgid "- External connect acceptance changed.\n"
 msgstr "- Külső kapcsolat elfogadása megváltoztatva.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1133
+#: src/PrefsUnifiedDlg.cpp:1174
 msgid "- External connect interface changed.\n"
 msgstr "- Külső kapcsolat interfész megváltoztatva.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1137
+#: src/PrefsUnifiedDlg.cpp:1178
 msgid "- Protocol obfuscation support changed.\n"
 msgstr "- Protokoll zavarás támogatása megváltozott.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1151
+#: src/PrefsUnifiedDlg.cpp:1193
 #, fuzzy
 msgid "- amuleapi settings changed.\n"
 msgstr "- Nyelv megváltozott.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1160
+#: src/PrefsUnifiedDlg.cpp:1202
 msgid ""
 "Your Auto-update server list is empty.\n"
 "'Auto-update server list at startup' will be disabled."
@@ -5773,7 +5810,7 @@ msgstr ""
 "Az automatikusan frissített kiszolgálóü lista üres.\n"
 "A 'kiszolgáló lista automatikus frissítése induláskor' letiltva."
 
-#: src/PrefsUnifiedDlg.cpp:1171
+#: src/PrefsUnifiedDlg.cpp:1213
 msgid ""
 "You have enabled external connections but have not specified a password.\n"
 "External connections cannot be enabled unless a valid password is specified."
@@ -5781,28 +5818,33 @@ msgstr ""
 "Engedélyezted a távoli elérést, de nem adtál meg jelszót.\n"
 "A távoli elérés nem használható érvényes jelszó nélkül."
 
-#: src/PrefsUnifiedDlg.cpp:1202
+#: src/PrefsUnifiedDlg.cpp:1246
+#, c-format
+msgid "The amuleapi password could not be saved: %s"
+msgstr ""
+
+#: src/PrefsUnifiedDlg.cpp:1276
 msgid "- Language changed.\n"
 msgstr "- Nyelv megváltozott.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1207
+#: src/PrefsUnifiedDlg.cpp:1281
 msgid "- Temp folder changed.\n"
 msgstr "- Ideiglenes mappa megváltozott.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1212
+#: src/PrefsUnifiedDlg.cpp:1286
 msgid "- ED2K network enabled.\n"
 msgstr "- ED2K hálózat engedélyezve.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1245
+#: src/PrefsUnifiedDlg.cpp:1319
 msgid "The shared-file exclusion pattern is not a valid regular expression. The filter has been left disabled."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1247 src/PrefsUnifiedDlg.cpp:1841
+#: src/PrefsUnifiedDlg.cpp:1321 src/PrefsUnifiedDlg.cpp:1921
 #, fuzzy
 msgid "Invalid regular expression"
 msgstr "Érvénytelen protokoll verzió."
 
-#: src/PrefsUnifiedDlg.cpp:1324
+#: src/PrefsUnifiedDlg.cpp:1398
 msgid ""
 "Both eD2k and Kad network are disabled.\n"
 "You won't be able to connect until you enable at least one of them."
@@ -5810,7 +5852,7 @@ msgstr ""
 "Az eD2k és a Kad hálózat is le van tiltva.\n"
 "Nem fogsz tudni kapcsolódni, amíg legalább az egyiket nem engedélyezed."
 
-#: src/PrefsUnifiedDlg.cpp:1329
+#: src/PrefsUnifiedDlg.cpp:1403
 msgid ""
 "Kad will not start if your UDP port is disabled.\n"
 "Enable UDP port or disable Kad."
@@ -5818,7 +5860,7 @@ msgstr ""
 "A Kad nem fog elindulni, ha az UDP portod le van tiltva.\n"
 "Engedélyezd az UDP portot vagy tiltsd le a Kad-ot."
 
-#: src/PrefsUnifiedDlg.cpp:1385
+#: src/PrefsUnifiedDlg.cpp:1459
 msgid ""
 "\n"
 "You MUST restart aMule now.\n"
@@ -5828,69 +5870,69 @@ msgstr ""
 "Most újra KELL indítanod az aMule-t.\n"
 "Ha nem indítod újra most, ne panaszkodj, ha bármi rossz történik.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1450
+#: src/PrefsUnifiedDlg.cpp:1524
 msgid "Could not register aMule for autostart at login. The autostart store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1452
+#: src/PrefsUnifiedDlg.cpp:1526
 msgid "Could not remove the autostart-at-login entry."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1453
+#: src/PrefsUnifiedDlg.cpp:1527
 #, fuzzy
 msgid "Autostart"
 msgstr "Automatikus frissítés elindítva"
 
-#: src/PrefsUnifiedDlg.cpp:1468
+#: src/PrefsUnifiedDlg.cpp:1542
 msgid "Register file type"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1468
+#: src/PrefsUnifiedDlg.cpp:1542
 msgid "Register URL handler"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1476
+#: src/PrefsUnifiedDlg.cpp:1550
 #, c-format
 msgid "aMule only handles eD2k-compatible magnets. If you replace the current magnet handler (%s), BitTorrent magnet links will stop working - aMule cannot download BitTorrent content. Continue?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1481
+#: src/PrefsUnifiedDlg.cpp:1555
 #, c-format
 msgid "Another application currently opens .emulecollection files (%s). Replace it with aMule?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1486
+#: src/PrefsUnifiedDlg.cpp:1560
 #, c-format
 msgid "Another application is currently the default handler for these links (%s). Replace it with aMule?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1511
+#: src/PrefsUnifiedDlg.cpp:1585
 msgid "Could not register aMule for .emulecollection files. The registration store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1513
+#: src/PrefsUnifiedDlg.cpp:1587
 #, fuzzy
 msgid "Could not remove the file type registration."
 msgstr "A letöltött fájlok eltolása %s helyre sikertelen"
 
-#: src/PrefsUnifiedDlg.cpp:1515
+#: src/PrefsUnifiedDlg.cpp:1589
 msgid "Could not register aMule as the URL handler. The registration store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1517
+#: src/PrefsUnifiedDlg.cpp:1591
 msgid "Could not remove the URL handler registration."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1587 src/PrefsUnifiedDlg.cpp:1614
+#: src/PrefsUnifiedDlg.cpp:1661 src/PrefsUnifiedDlg.cpp:1688
 #, fuzzy
 msgid "The web server and aMule API require external connections to be enabled."
 msgstr "Jelszó beállítva, külső kapcsolatok engedélyezve."
 
-#: src/PrefsUnifiedDlg.cpp:1597
+#: src/PrefsUnifiedDlg.cpp:1671
 msgid "The aMule web server is deprecated. Consider running the aMule API instead."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1655
+#: src/PrefsUnifiedDlg.cpp:1735
 msgid ""
 "Your Auto-update servers list is in blank.\n"
 "Please fill in at least one URL to point to a valid server.met file.\n"
@@ -5900,65 +5942,65 @@ msgstr ""
 "Kérlek adj meg legalább egy URL-t, ami érvényes server.met fájlra mutat .\n"
 "Az URL megadásához klikkelj a \"Lista\" gombra ezen checkbox mellett."
 
-#: src/PrefsUnifiedDlg.cpp:1796
+#: src/PrefsUnifiedDlg.cpp:1876
 msgid "Temporary files"
 msgstr "az Ideiglenes fájloknak"
 
-#: src/PrefsUnifiedDlg.cpp:1801
+#: src/PrefsUnifiedDlg.cpp:1881
 msgid "Incoming files"
 msgstr "Bejövő fájlok"
 
-#: src/PrefsUnifiedDlg.cpp:1806
+#: src/PrefsUnifiedDlg.cpp:1886
 msgid "Online Signatures"
 msgstr "az Online aláírásnak"
 
-#: src/PrefsUnifiedDlg.cpp:1819
+#: src/PrefsUnifiedDlg.cpp:1899
 #, c-format
 msgid "Choose a folder for %s"
 msgstr "Válassz egy mappát a %s-nek"
 
-#: src/PrefsUnifiedDlg.cpp:1843
+#: src/PrefsUnifiedDlg.cpp:1923
 #, fuzzy, c-format
 msgid "Would exclude %u of %u shared file"
 msgid_plural "Would exclude %u of %u shared files"
 msgstr[0] "%i ismert megosztott fájlt találtam"
 
-#: src/PrefsUnifiedDlg.cpp:1860
+#: src/PrefsUnifiedDlg.cpp:1940
 msgid "Browse for videoplayer"
 msgstr "Böngészés a videolejátszóhoz"
 
-#: src/PrefsUnifiedDlg.cpp:1864
+#: src/PrefsUnifiedDlg.cpp:1944
 msgid "Select browser"
 msgstr "Válaszd ki a böngésződet"
 
-#: src/PrefsUnifiedDlg.cpp:1868
+#: src/PrefsUnifiedDlg.cpp:1948
 #, fuzzy
 msgid "Select ffprobe binary"
 msgstr "Válaszd ki a böngésződet"
 
-#: src/PrefsUnifiedDlg.cpp:1874
+#: src/PrefsUnifiedDlg.cpp:1954
 #, c-format
 msgid "Executable%s"
 msgstr "Futtatható%s"
 
-#: src/PrefsUnifiedDlg.cpp:1908
+#: src/PrefsUnifiedDlg.cpp:1988
 msgid "ffprobe not found on PATH or in the standard install locations. Install ffmpeg (which ships ffprobe) or use Browse to pick a binary manually."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1920
+#: src/PrefsUnifiedDlg.cpp:2000
 msgid "Reset the settings on this page to their default values?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1921
+#: src/PrefsUnifiedDlg.cpp:2001
 #, fuzzy
 msgid "Reset to defaults"
 msgstr "Alapértelmezett"
 
-#: src/PrefsUnifiedDlg.cpp:1948
+#: src/PrefsUnifiedDlg.cpp:2028
 msgid "Edit server list"
 msgstr "Kiszolgáló lista szerkesztése"
 
-#: src/PrefsUnifiedDlg.cpp:1949
+#: src/PrefsUnifiedDlg.cpp:2029
 msgid ""
 "Add here URL's to download server.met files.\n"
 "Only one url on each line."
@@ -5966,149 +6008,149 @@ msgstr ""
 "URL-ek felvétele a server.met fájl letöltéséhez.\n"
 "Egy sorba csak egy URL."
 
-#: src/PrefsUnifiedDlg.cpp:2004
+#: src/PrefsUnifiedDlg.cpp:2084
 msgid "IP2Country update failed"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2149 src/PrefsUnifiedDlg.cpp:2180
+#: src/PrefsUnifiedDlg.cpp:2229 src/PrefsUnifiedDlg.cpp:2260
 msgid "Data by MaxMind GeoLite2"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2151 src/PrefsUnifiedDlg.cpp:2182
+#: src/PrefsUnifiedDlg.cpp:2231 src/PrefsUnifiedDlg.cpp:2262
 #, fuzzy
 msgid "Custom source"
 msgstr "Teljes források"
 
-#: src/PrefsUnifiedDlg.cpp:2153 src/PrefsUnifiedDlg.cpp:2184
+#: src/PrefsUnifiedDlg.cpp:2233 src/PrefsUnifiedDlg.cpp:2264
 msgid "Data by DB-IP.com"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2204
+#: src/PrefsUnifiedDlg.cpp:2284
 #, fuzzy, c-format
 msgid "Status: Loaded%s"
 msgstr "Állapot:"
 
-#: src/PrefsUnifiedDlg.cpp:2206
+#: src/PrefsUnifiedDlg.cpp:2286
 #, fuzzy, c-format
 msgid "Status: Loaded%s - %s"
 msgstr "Állapot:"
 
-#: src/PrefsUnifiedDlg.cpp:2210
+#: src/PrefsUnifiedDlg.cpp:2290
 msgid "Status: Failed to load - click 'Update now' to refresh."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2212
+#: src/PrefsUnifiedDlg.cpp:2292
 msgid "Status: Not found - click 'Update now' to download."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2270 src/PrefsUnifiedDlg.cpp:2294
+#: src/PrefsUnifiedDlg.cpp:2350 src/PrefsUnifiedDlg.cpp:2374
 #, c-format
 msgid "Update delay: %d second"
 msgid_plural "Update delay: %d seconds"
 msgstr[0] "Frissítés késleltetése: %d másodperc"
 
-#: src/PrefsUnifiedDlg.cpp:2278
+#: src/PrefsUnifiedDlg.cpp:2358
 #, c-format
 msgid "Time for average graph: %d minute"
 msgid_plural "Time for average graph: %d minutes"
 msgstr[0] "Grafikon átlagos ideje: %d perc"
 
-#: src/PrefsUnifiedDlg.cpp:2287
+#: src/PrefsUnifiedDlg.cpp:2367
 #, c-format
 msgid "Connections Graph Scale: %d"
 msgstr "Kapcsolatok grafikon-skálája: %d"
 
-#: src/PrefsUnifiedDlg.cpp:2302
+#: src/PrefsUnifiedDlg.cpp:2382
 #, c-format
 msgid "File Buffer Size: %d byte"
 msgid_plural "File Buffer Size: %d bytes"
 msgstr[0] "Fájl buffer méret: %d bájt"
 
-#: src/PrefsUnifiedDlg.cpp:2312
+#: src/PrefsUnifiedDlg.cpp:2392
 #, c-format
 msgid "Upload Queue Size: %d client"
 msgid_plural "Upload Queue Size: %d clients"
 msgstr[0] "Feltöltési várólista nagysága: %d kliens"
 
-#: src/PrefsUnifiedDlg.cpp:2322
+#: src/PrefsUnifiedDlg.cpp:2402
 #, c-format
 msgid "Server connection refresh interval: %d minute"
 msgid_plural "Server connection refresh interval: %d minutes"
 msgstr[0] "Kiszolgáló kapcsolat frissítési gyakorisága: %d perc"
 
-#: src/PrefsUnifiedDlg.cpp:2327
+#: src/PrefsUnifiedDlg.cpp:2407
 msgid "Server connection refresh interval: Disabled"
 msgstr "Kiszolgáló kapcsolat frissítési gyakorisága: Tiltva"
 
-#: src/PrefsUnifiedDlg.cpp:2371
+#: src/PrefsUnifiedDlg.cpp:2451
 msgid "disabled"
 msgstr "letiltva"
 
-#: src/PrefsUnifiedDlg.cpp:2397
+#: src/PrefsUnifiedDlg.cpp:2477
 #, c-format
 msgid "Execute command on '%s' event"
 msgstr "Parancs végrehajtása a(z) '%s' eseménynél"
 
-#: src/PrefsUnifiedDlg.cpp:2404
+#: src/PrefsUnifiedDlg.cpp:2484
 msgid "Enable command execution on core"
 msgstr "Parancs futtatása a magon"
 
-#: src/PrefsUnifiedDlg.cpp:2416
+#: src/PrefsUnifiedDlg.cpp:2496
 msgid "Core command:"
 msgstr "Mag parancs:"
 
-#: src/PrefsUnifiedDlg.cpp:2432
+#: src/PrefsUnifiedDlg.cpp:2512
 msgid "Enable command execution on GUI"
 msgstr "Parancs futtatása a grafikus felületen"
 
-#: src/PrefsUnifiedDlg.cpp:2444
+#: src/PrefsUnifiedDlg.cpp:2524
 msgid "GUI command:"
 msgstr "GUI parancs:"
 
-#: src/PrefsUnifiedDlg.cpp:2460
+#: src/PrefsUnifiedDlg.cpp:2540
 msgid "The following variables will be replaced:"
 msgstr "A következő változók lesznek behelyettesítve:"
 
-#: src/PrefsUnifiedDlg.cpp:2628
+#: src/PrefsUnifiedDlg.cpp:2708
 msgid ""
 "The following folders look like system or sensitive locations:\n"
 "\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2633
+#: src/PrefsUnifiedDlg.cpp:2713
 msgid "Sharing them recursively will publish every file underneath on the eD2k/Kad networks. Do you really want to do this?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2636
+#: src/PrefsUnifiedDlg.cpp:2716
 #, fuzzy
 msgid "Confirm shared folders"
 msgstr "Megosztott mappák"
 
-#: src/PrefsUnifiedDlg.cpp:2664
+#: src/PrefsUnifiedDlg.cpp:2744
 #, fuzzy
 msgid "Reloading shared files..."
 msgstr "Megosztott fájlok frissítése"
 
-#: src/PrefsUnifiedDlg.cpp:2665
+#: src/PrefsUnifiedDlg.cpp:2745
 msgid "Scanning for subdirectories..."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2666
+#: src/PrefsUnifiedDlg.cpp:2746
 #, fuzzy
 msgid "Updating shared folders"
 msgstr "Megosztott mappák"
 
-#: src/PrefsUnifiedDlg.cpp:2693
+#: src/PrefsUnifiedDlg.cpp:2773
 #, c-format
 msgid "Scanned %u directories..."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2743
+#: src/PrefsUnifiedDlg.cpp:2823
 #, fuzzy, c-format
 msgid "Reloading shared files: %u files scanned"
 msgstr "A megosztott fájlok listájának újratöltése."
 
-#: src/PrefsUnifiedDlg.cpp:2793
+#: src/PrefsUnifiedDlg.cpp:2873
 #, fuzzy
 msgid "Shared folder"
 msgstr "Megosztott mappák"

--- a/po/it.po
+++ b/po/it.po
@@ -19,8 +19,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule 2.3.3\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-28 12:12+0200\n"
-"PO-Revision-Date: 2026-07-27 10:25+0000\n"
+"POT-Creation-Date: 2026-07-28 08:06+0200\n"
+"PO-Revision-Date: 2026-07-27 11:40+0000\n"
 "Last-Translator: got3nks <got3nks@users.noreply.github.com>\n"
 "Language-Team: SebastianoPistore.info@protonmail.ch\n"
 "Language: it\n"
@@ -151,7 +151,7 @@ msgstr "Installa"
 msgid "Not now"
 msgstr "Non ora"
 
-#: src/AppImageIntegration.cpp:422 src/amuleDlg.cpp:665
+#: src/AppImageIntegration.cpp:422 src/amuleDlg.cpp:600
 msgid "Don't ask again"
 msgstr "Non chiedere più"
 
@@ -213,83 +213,83 @@ msgstr "Impossibile aprire il link ed2k."
 msgid "WARNING: You can't add yourself as a source for an eD2k link while having a lowid."
 msgstr "ATTENZIONE: non è possibile aggiungere te stesso come fonte di un link eD2k finché avrai un ID basso."
 
-#: src/amule.cpp:301
+#: src/amule.cpp:300
 msgid "Now, exiting main app..."
 msgstr "Chiusura dell'applicazione..."
 
-#: src/amule.cpp:331
+#: src/amule.cpp:330
 #, c-format
 msgid "Terminating amuleweb instance with pid '%d' ... "
 msgstr "Sto terminando l'istanza di amuleweb con pid `%d' ... "
 
-#: src/amule.cpp:335
+#: src/amule.cpp:334
 #, c-format
 msgid "Killing amuleweb instance with pid '%d' ... "
 msgstr "Sto terminando forzatamente l'istanza di amuleweb con pid `%d' ... "
 
-#: src/amule.cpp:337 src/amule.cpp:350 src/ClientRef.cpp:180
-#: src/SearchDlg.cpp:1041 src/ServerListCtrl.cpp:98
+#: src/amule.cpp:336 src/amule.cpp:349 src/ClientRef.cpp:180
+#: src/SearchDlg.cpp:880 src/ServerListCtrl.cpp:98
 msgid "Failed"
 msgstr "Fallito"
 
-#: src/amule.cpp:344
+#: src/amule.cpp:343
 #, c-format
 msgid "Terminating amuleapi instance with pid '%d' ... "
 msgstr "Sto terminando l'istanza di amuleapi con pid `%d' ... "
 
-#: src/amule.cpp:348
+#: src/amule.cpp:347
 #, c-format
 msgid "Killing amuleapi instance with pid '%d' ... "
 msgstr "Sto terminando forzatamente l'istanza di amuleapi con pid `%d' ... "
 
-#: src/amule.cpp:356
+#: src/amule.cpp:355
 msgid "aMule OnExit: Terminating core."
 msgstr "aMule in fase di chiusura: Terminazione del core."
 
-#: src/amule.cpp:467
+#: src/amule.cpp:466
 msgid "aMule shutdown completed."
 msgstr "aMule, arresto completato."
 
-#: src/amule.cpp:471
+#: src/amule.cpp:470
 msgid "Memory debug results for aMule exit:"
 msgstr "Risultati del debug della memoria per la chiusura di aMule:"
 
-#: src/amule.cpp:652
+#: src/amule.cpp:651
 #, c-format
 msgid "Binding aMule's peer-to-peer traffic to interface: %s (HTTP updates use the default route)"
 msgstr "Associazione del traffico peer-to-peer di aMule all'interfaccia: %s (gli aggiornamenti HTTP usano la route predefinita)"
 
-#: src/amule.cpp:656
+#: src/amule.cpp:655
 #, c-format
 msgid "Binding all network traffic to interface: %s"
 msgstr "Associazione di tutto il traffico di rete all'interfaccia: %s"
 
-#: src/amule.cpp:660
+#: src/amule.cpp:659
 #, c-format
 msgid "WARNING: configured network interface '%s' was not found - traffic is NOT bound to it and may leave via the default route. Check the interface name in Preferences."
 msgstr "ATTENZIONE: l'interfaccia di rete configurata '%s' non è stata trovata - il traffico NON è associato ad essa e potrebbe uscire tramite la route predefinita. Controlla il nome dell'interfaccia nelle Preferenze."
 
-#: src/amule.cpp:666
+#: src/amule.cpp:665
 #, c-format
 msgid "WARNING: binding to network interface '%s' requires elevated privileges and was NOT applied - traffic may leave via the default route. Grant the capability (e.g. 'sudo setcap cap_net_raw+ep' on the aMule binary) or run with sufficient privileges."
 msgstr "ATTENZIONE: l'associazione all'interfaccia di rete '%s' richiede privilegi elevati e NON è stata applicata - il traffico potrebbe uscire tramite la route predefinita. Concedi la capability (ad es. 'sudo setcap cap_net_raw+ep' sul binario di aMule) oppure esegui con privilegi sufficienti."
 
-#: src/amule.cpp:674
+#: src/amule.cpp:673
 #, c-format
 msgid "WARNING: could not bind to network interface '%s' - traffic may leave via the default route."
 msgstr "ATTENZIONE: impossibile associare all'interfaccia di rete '%s' - il traffico potrebbe uscire tramite la route predefinita."
 
-#: src/amule.cpp:733
+#: src/amule.cpp:732
 msgid "Your locale has been changed to System Default due to a configuration change. Sorry."
 msgstr "Le tue impostazioni di localizzazione sono state impostate a quelle predefinite dal sistema in conseguenza del cambio di configurazione. Spiacente."
 
-#: src/amule.cpp:735 src/amule.cpp:1589 src/CatDialog.cpp:128
+#: src/amule.cpp:734 src/amule.cpp:1581 src/CatDialog.cpp:128
 #: src/CatDialog.cpp:136 src/CatDialog.cpp:149 src/ServerList.cpp:366
 #: src/ServerListCtrl.cpp:152
 msgid "Info"
 msgstr "Info"
 
-#: src/amule.cpp:742
+#: src/amule.cpp:741
 msgid ""
 "\n"
 "EC configuration"
@@ -297,22 +297,22 @@ msgstr ""
 "\n"
 "Configurazione EC"
 
-#: src/amule.cpp:745
+#: src/amule.cpp:744
 msgid "Password set and external connections enabled."
 msgstr "Password impostata, connessioni esterne abilitate."
 
-#: src/amule.cpp:755 src/KadDlg.cpp:176 src/KadDlg.cpp:185
-#: src/PrefsUnifiedDlg.cpp:1461 src/SharedFilesCtrl.cpp:476
+#: src/amule.cpp:754 src/KadDlg.cpp:176 src/KadDlg.cpp:185
+#: src/PrefsUnifiedDlg.cpp:1387 src/SharedFilesCtrl.cpp:476
 msgid "WARNING"
 msgstr "ATTENZIONE"
 
 # AI-GENERATED — please review.
-#: src/amule.cpp:992
+#: src/amule.cpp:991
 msgid "Network bootstrap"
 msgstr "Bootstrap di rete"
 
 # AI-GENERATED — please review.
-#: src/amule.cpp:997
+#: src/amule.cpp:996
 msgid ""
 "aMule has detected missing network bootstrap files.\n"
 "Select which ones to download:"
@@ -321,52 +321,52 @@ msgstr ""
 "Selezionare quali scaricare:"
 
 # AI-GENERATED — please review.
-#: src/amule.cpp:1006 src/FirstRunWizard.cpp:411
+#: src/amule.cpp:1005 src/FirstRunWizard.cpp:411
 msgid "eD2k server list (server.met)"
 msgstr "Lista server eD2k (server.met)"
 
 # AI-GENERATED — please review.
-#: src/amule.cpp:1013 src/FirstRunWizard.cpp:416
+#: src/amule.cpp:1012 src/FirstRunWizard.cpp:416
 msgid "Kad bootstrap nodes (nodes.dat)"
 msgstr "Nodi di bootstrap Kad (nodes.dat)"
 
-#: src/amule.cpp:1103
+#: src/amule.cpp:1102
 #, c-format
 msgid "web server running on pid %d"
 msgstr "web server in esecuzione su pid %d"
 
-#: src/amule.cpp:1116
+#: src/amule.cpp:1115
 msgid "You requested to run web server on startup, but the amuleweb binary cannot be run. Please install the package containing aMule web server, or build aMule from source with -DBUILD_WEBSERVER=YES and install it."
 msgstr "Hai scelto di lanciare il web server all'avvio, ma il programma amuleweb non può essere eseguito. Installa il pacchetto contenente aMule web server, oppure compila aMule dai sorgenti con -DBUILD_WEBSERVER=YES e installalo."
 
-#: src/amule.cpp:1121 src/amule.cpp:1185 src/amule.cpp:1299 src/amule.cpp:1601
+#: src/amule.cpp:1120 src/amule.cpp:1177 src/amule.cpp:1291 src/amule.cpp:1593
 #: src/amule-remote-gui.cpp:603 src/amule-remote-gui.cpp:671
 #: src/amule-remote-gui.cpp:709 src/amule-remote-gui.cpp:1282
 #: src/amule-remote-gui.cpp:1345 src/amule-remote-gui.cpp:1372
-#: src/DownloadQueue.cpp:1481 src/PrefsUnifiedDlg.cpp:1247
+#: src/DownloadQueue.cpp:1481
 msgid "ERROR"
 msgstr "ERRORE"
 
-#: src/amule.cpp:1174
+#: src/amule.cpp:1166
 #, c-format
 msgid "amuleapi running on pid %d"
 msgstr "amuleapi in esecuzione su pid %d"
 
-#: src/amule.cpp:1180
+#: src/amule.cpp:1172
 msgid "You requested to run amuleapi on startup, but the amuleapi binary cannot be run. Please install the package containing aMule's REST API server, or build aMule from source with -DBUILD_AMULEAPI=YES and install it."
 msgstr "Hai scelto di lanciare amuleapi all'avvio, ma il programma amuleapi non può essere eseguito. Installa il pacchetto contenente amuleapi, oppure compila aMule dai sorgenti con -DBUILD_AMULEAPI=YES e installalo."
 
-#: src/amule.cpp:1267
+#: src/amule.cpp:1259
 #, c-format
 msgid "Could not bind ports to the specified address: %s"
 msgstr "Impossibile aprire le porte sull'indirizzo specificato: %s"
 
-#: src/amule.cpp:1291
+#: src/amule.cpp:1283
 #, c-format
 msgid "Port %u is not available. You will be LOWID\n"
 msgstr "La porta %u non è disponibile. Otterrai un ID basso\n"
 
-#: src/amule.cpp:1296
+#: src/amule.cpp:1288
 #, c-format
 msgid ""
 "Port %u is not available!\n"
@@ -381,48 +381,48 @@ msgstr ""
 "\n"
 "Controlla le impostazioni di rete e verifica che la porta sia aperta in ingresso e in uscita."
 
-#: src/amule.cpp:1393
+#: src/amule.cpp:1385
 msgid "Failed to create OnlineSig File"
 msgstr "Impossibile creare il file per l'online signature"
 
-#: src/amule.cpp:1401
+#: src/amule.cpp:1393
 msgid "Failed to create aMule OnlineSig File"
 msgstr "Impossibile creare il file per l'online signature di aMule"
 
-#: src/amule.cpp:1564
+#: src/amule.cpp:1556
 msgid "The selected locale seems not to be installed on your box. (Note: I'll try to set it anyway)"
 msgstr "L'impostazione locale selezionata non sembra essere installata sul tuo computer (si tenterà di impostarla in ogni caso)"
 
-#: src/amule.cpp:1574
+#: src/amule.cpp:1566
 #, c-format
 msgid "This is the first time you run aMule %s"
 msgstr "È la prima che volta che avvii aMule %s"
 
-#: src/amule.cpp:1577
+#: src/amule.cpp:1569
 msgid "This version is a testing version, updated daily, and\n"
 msgstr "Questa è una versione di prova, aggiornata quotidianamente, e\n"
 
-#: src/amule.cpp:1578
+#: src/amule.cpp:1570
 msgid "we give no warranty it won't break anything, burn your house,\n"
 msgstr "non garantiamo che essa non distrugga qualcosa, bruci la tua casa,\n"
 
-#: src/amule.cpp:1579
+#: src/amule.cpp:1571
 msgid "or kill your dog. But it *should* be safe to use anyway.\n"
 msgstr "o uccida il tuo cane. Ma *dovrebbe* essere comunque sicura.\n"
 
-#: src/amule.cpp:1584
+#: src/amule.cpp:1576
 msgid "More information, support and new releases can found at our homepage,\n"
 msgstr "Altre informazioni, supporto e nuove versioni possono essere trovate nella nostra homepage,\n"
 
-#: src/amule.cpp:1585
+#: src/amule.cpp:1577
 msgid "at https://amule-org.github.io, or in our IRC channel #aMule at irc.libera.chat.\n"
 msgstr "https://amule-org.github.io, o nel nostro canale IRC #aMule su irc.libera.chat.\n"
 
-#: src/amule.cpp:1587
+#: src/amule.cpp:1579
 msgid "Feel free to report any bugs to https://github.com/amule-org/amule/issues"
 msgstr "Puoi segnalare qualsiasi bug su https://github.com/amule-org/amule/issues"
 
-#: src/amule.cpp:1599
+#: src/amule.cpp:1591
 msgid ""
 "The folder for Online Signature files you specified is INVALID!\n"
 " OnlineSignature will be DISABLED until you fix it on preferences."
@@ -430,137 +430,137 @@ msgstr ""
 "La directory scelta per contenere il file dell'online signature non è valida!\n"
 "La firma verrà pertanto disabilitata fino a quando il problema non sarà stato risolto attraverso il pannello delle preferenze."
 
-#: src/amule.cpp:1662
+#: src/amule.cpp:1654
 msgid "Server hostname notified"
 msgstr "Nome host del server notificato"
 
-#: src/amule.cpp:2039
+#: src/amule.cpp:2031
 #, c-format
 msgid "Disk space preallocation for file '%s' failed: %s"
 msgstr "Preallocazione dello spazio su disco per il file '%s' fallita: %s"
 
-#: src/amule.cpp:2168
+#: src/amule.cpp:2160
 msgid "ERROR: can't open logfile"
 msgstr "ERRORE: impossibile aprire il file di log"
 
-#: src/amule.cpp:2172
+#: src/amule.cpp:2164
 msgid "WARNING: logfile is empty. Something is wrong."
 msgstr "ERRORE: il file di log è vuoto. Qualcosa non va."
 
-#: src/amule.cpp:2189
+#: src/amule.cpp:2181
 msgid "Log has been reset"
 msgstr "Il file di log è stato reimpostato"
 
-#: src/amule.cpp:2213
+#: src/amule.cpp:2205
 #, c-format
 msgid "ServerMessage: %s"
 msgstr "Messaggio del server: %s"
 
-#: src/amule.cpp:2256 src/IP2Country.cpp:220 src/IPFilter.cpp:514
+#: src/amule.cpp:2248 src/IP2Country.cpp:220 src/IPFilter.cpp:514
 #: src/ServerList.cpp:875
 #, c-format
 msgid "Skipped download of %s, because requested file is not newer."
 msgstr "Download di %s saltato, perché il file richiesto non è il più recente."
 
-#: src/amule.cpp:2259
+#: src/amule.cpp:2251
 msgid "Failed to download the nodes list."
 msgstr "Impossibile scaricare la lista dei nodi."
 
-#: src/amule.cpp:2322
+#: src/amule.cpp:2314
 msgid "Failed to open the downloaded version check file"
 msgstr "Impossibile aprire il file scaricato per il controllo della versione"
 
-#: src/amule.cpp:2325 src/amule.cpp:2344
+#: src/amule.cpp:2317 src/amule.cpp:2336
 msgid "Corrupted version check file"
 msgstr "Il file per il controllo della versione è corrotto"
 
-#: src/amule.cpp:2367
+#: src/amule.cpp:2359
 msgid "You are using an outdated version of aMule!"
 msgstr "Stai usando una versione non aggiornata di aMule!"
 
-#: src/amule.cpp:2369
+#: src/amule.cpp:2361
 #, c-format
 msgid "Your aMule version is %i.%i.%i and the latest version is %li.%li.%li"
 msgstr "La tua versione di aMule è la %i.%i.%i e l'ultima è la %li.%li.%li"
 
-#: src/amule.cpp:2373
+#: src/amule.cpp:2365
 msgid "The latest version can always be found at https://github.com/amule-org/amule/releases/latest"
 msgstr "L'ultima versione è sempre disponibile su https://github.com/amule-org/amule/releases/latest"
 
-#: src/amule.cpp:2376
+#: src/amule.cpp:2368
 #, c-format
 msgid "WARNING: Your aMuled version is outdated: %i.%i.%i < %li.%li.%li"
 msgstr "ATTENZIONE: La tua versione di aMuled è obsoleta: %i.%i.%i < %li.%li.%li"
 
-#: src/amule.cpp:2382
+#: src/amule.cpp:2374
 msgid "Your copy of aMule is up to date."
 msgstr "La tua copia di aMule è aggiornata."
 
-#: src/amule.cpp:2389
+#: src/amule.cpp:2381
 msgid "Failed to download the version check file"
 msgstr "Impossibile scaricare il file per il controllo della versione"
 
-#: src/amule.cpp:2558 src/amule-remote-gui.cpp:1133
+#: src/amule.cpp:2550 src/amule-remote-gui.cpp:1133
 #, c-format
 msgid "Users: %s | Files: %s"
 msgstr "Utenti: %s | File: %s"
 
-#: src/amule.cpp:2559 src/amule-remote-gui.cpp:1134
+#: src/amule.cpp:2551 src/amule-remote-gui.cpp:1134
 #, c-format
 msgid "Users: E: %s K: %s | Files: E: %s K: %s"
 msgstr "Utenti: E: %s K: %s | File: E: %s K: %s"
 
-#: src/amule.cpp:2573 src/amule-remote-gui.cpp:1147
+#: src/amule.cpp:2565 src/amule-remote-gui.cpp:1147
 msgid "No networks selected"
 msgstr "Nessuna rete selezionata"
 
-#: src/amule.cpp:2641 src/TextClient.cpp:903
+#: src/amule.cpp:2633 src/TextClient.cpp:903
 msgid "with LowID"
 msgstr "con ID basso"
 
-#: src/amule.cpp:2641 src/TextClient.cpp:904
+#: src/amule.cpp:2633 src/TextClient.cpp:904
 msgid "with HighID"
 msgstr "con ID alto"
 
-#: src/amule.cpp:2643
+#: src/amule.cpp:2635
 #, c-format
 msgid "Connected to %s %s"
 msgstr "Connesso a %s %s"
 
-#: src/amule.cpp:2648
+#: src/amule.cpp:2640
 #, c-format
 msgid "Connecting to %s"
 msgstr "Connessione in corso a %s"
 
-#: src/amule.cpp:2650
+#: src/amule.cpp:2642
 msgid "Disconnected from eD2k"
 msgstr "Disconnesso dalla rete eD2k"
 
-#: src/amule.cpp:2659
+#: src/amule.cpp:2651
 msgid "Kad started."
 msgstr "Kad avviato."
 
-#: src/amule.cpp:2661
+#: src/amule.cpp:2653
 msgid "Kad stopped."
 msgstr "Kad arrestato."
 
-#: src/amule.cpp:2669
+#: src/amule.cpp:2661
 msgid "Connected to Kad (ok)"
 msgstr "Connesso alla rete Kad (ok)"
 
-#: src/amule.cpp:2671
+#: src/amule.cpp:2663
 msgid "Connected to Kad (firewalled)"
 msgstr "Connesso alla rete Kad (firewalled)"
 
-#: src/amule.cpp:2675
+#: src/amule.cpp:2667
 msgid "Disconnected from Kad"
 msgstr "Disconnesso dalla rete Kad"
 
-#: src/amule.cpp:2707
+#: src/amule.cpp:2699
 msgid "Kad network cannot be used if UDP port is disabled on preferences, not starting."
 msgstr "La rete Kad non può essere utilizzata se la porta UDP è disattivata dalle opzioni. Connessione non avviata."
 
-#: src/amule.cpp:2711
+#: src/amule.cpp:2703
 msgid "Kad network disabled on preferences, not connecting."
 msgstr "Rete Kad disattivata dalle opzioni. Connessione interrotta."
 
@@ -585,67 +585,29 @@ msgstr "Impossibile creare il file Pid"
 msgid "ERROR: %s"
 msgstr "ERRORE: %s"
 
-#: src/amuleDlg.cpp:250
+#: src/amuleDlg.cpp:236
 #, c-format
 msgid "This is aMule %s based on eMule."
 msgstr "Questo è aMule %s basato su eMule."
 
-#: src/amuleDlg.cpp:251
+#: src/amuleDlg.cpp:237
 #, c-format
 msgid "Running on %s"
 msgstr "In esecuzione su %s"
 
-#: src/amuleDlg.cpp:253
+#: src/amuleDlg.cpp:239
 msgid "Visit https://github.com/amule-org/amule/releases/latest to check if a new version is available."
 msgstr "Visita https://github.com/amule-org/amule/releases/latest per controllare se è disponibile una nuova versione."
 
-#: src/amuleDlg.cpp:282
+#: src/amuleDlg.cpp:268
 msgid "FATAL ERROR: Failed to create Timer"
 msgstr "ERRORE FATALE: Creazione timer fallita"
 
-#: src/amuleDlg.cpp:361 src/amuleDlg.cpp:1810 src/amuleDlg.cpp:2056
-#: src/muuli_wdr.cpp:1492 src/muuli_wdr.cpp:3439
-msgid "Networks"
-msgstr "Reti"
-
-#: src/amuleDlg.cpp:362 src/amuleDlg.cpp:1816 src/muuli_wdr.cpp:3440
-msgid "Searches"
-msgstr "Ricerca"
-
-#: src/amuleDlg.cpp:363 src/amuleDlg.cpp:1822 src/DownloadListCtrl.cpp:740
-#: src/muuli_wdr.cpp:392 src/muuli_wdr.cpp:1585 src/muuli_wdr.cpp:3441
-#: src/Statistics.cpp:829
-msgid "Downloads"
-msgstr "Download"
-
-#: src/amuleDlg.cpp:364 src/amuleDlg.cpp:1828 src/muuli_wdr.cpp:3315
-msgid "Shared files"
-msgstr "File condivisi"
-
-#: src/amuleDlg.cpp:365 src/amuleDlg.cpp:1834 src/muuli_wdr.cpp:2947
-#: src/muuli_wdr.cpp:3397 src/muuli_wdr.cpp:3444
-msgid "Messages"
-msgstr "Messaggi"
-
-#: src/amuleDlg.cpp:366 src/amuleDlg.cpp:1840 src/muuli_wdr.cpp:3445
-#: src/PrefsUnifiedDlg.cpp:314 src/Statistics.cpp:779 src/Statistics.cpp:1235
-msgid "Statistics"
-msgstr "Statistiche"
-
-#: src/amuleDlg.cpp:368 src/amuleDlg.cpp:1847 src/muuli_wdr.cpp:3447
-#: src/PrefsUnifiedDlg.cpp:330 src/utils/wxCas/src/wxcasprefs.cpp:39
-msgid "Preferences"
-msgstr "Preferenze"
-
-#: src/amuleDlg.cpp:371
-msgid "Navigate"
-msgstr ""
-
-#: src/amuleDlg.cpp:657
+#: src/amuleDlg.cpp:592
 msgid "New version available"
 msgstr "Nuova versione disponibile"
 
-#: src/amuleDlg.cpp:661
+#: src/amuleDlg.cpp:596
 #, c-format
 msgid ""
 "A new version of aMule (%s) is available.\n"
@@ -660,184 +622,217 @@ msgstr ""
 "\n"
 "Vuoi aprire la pagina di download?"
 
-#: src/amuleDlg.cpp:743
+#: src/amuleDlg.cpp:678
 msgid "aMule dialog destroyed"
 msgstr "Finestra di aMule chiusa"
 
-#: src/amuleDlg.cpp:766 src/DataToText.cpp:68 src/IPFilter.cpp:547
+#: src/amuleDlg.cpp:701 src/DataToText.cpp:68 src/IPFilter.cpp:547
 msgid "Connecting"
 msgstr "Connessione in corso"
 
-#: src/amuleDlg.cpp:958
+#: src/amuleDlg.cpp:893
 msgid "eD2k: Connecting"
 msgstr "eD2k: Connessione in corso"
 
-#: src/amuleDlg.cpp:962
+#: src/amuleDlg.cpp:897
 msgid "eD2k: Disconnected"
 msgstr "eD2k: Disconnesso"
 
-#: src/amuleDlg.cpp:968
+#: src/amuleDlg.cpp:903
 msgid "Kad: Firewalled"
 msgstr "Kad: Firewalled"
 
-#: src/amuleDlg.cpp:972
+#: src/amuleDlg.cpp:907
 msgid "Kad: Connected"
 msgstr "Kad: Connesso"
 
-#: src/amuleDlg.cpp:977
+#: src/amuleDlg.cpp:912
 msgid "Kad: Connecting"
 msgstr "Kad: Connessione in corso"
 
-#: src/amuleDlg.cpp:981
+#: src/amuleDlg.cpp:916
 msgid "Kad: Off"
 msgstr "Kad: Spento"
 
-#: src/amuleDlg.cpp:1029 src/DownloadListCtrl.cpp:505
+#: src/amuleDlg.cpp:964 src/DownloadListCtrl.cpp:505
 #: src/DownloadListCtrl.cpp:749 src/FriendListCtrl.cpp:180
 #: src/muuli_wdr.cpp:731 src/muuli_wdr.cpp:782 src/muuli_wdr.cpp:846
-#: src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2252 src/muuli_wdr.cpp:2337
-#: src/muuli_wdr.cpp:3085 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
+#: src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2224 src/muuli_wdr.cpp:2309
+#: src/muuli_wdr.cpp:3057 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
 #: src/ServerListCtrl.cpp:606 src/TransferWnd.cpp:378
 #: src/utils/wxCas/src/wxcasprefs.cpp:235
 msgid "Cancel"
 msgstr "Annulla"
 
-#: src/amuleDlg.cpp:1030
+#: src/amuleDlg.cpp:965
 msgid "Stop the current connection attempts"
 msgstr "Ferma i tentativi di connessione in corso"
 
-#: src/amuleDlg.cpp:1035 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976
-#: src/muuli_wdr.cpp:2475
+#: src/amuleDlg.cpp:970 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976
+#: src/muuli_wdr.cpp:2447
 msgid "Disconnect"
 msgstr "Disconnetti"
 
-#: src/amuleDlg.cpp:1036
+#: src/amuleDlg.cpp:971
 msgid "Disconnect from the currently connected networks"
 msgstr "Disconnetti dalle reti a cui sei connesso"
 
-#: src/amuleDlg.cpp:1041 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979
-#: src/muuli_wdr.cpp:2630 src/muuli_wdr.cpp:3082 src/muuli_wdr.cpp:3437
+#: src/amuleDlg.cpp:976 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979
+#: src/muuli_wdr.cpp:2602 src/muuli_wdr.cpp:3054 src/muuli_wdr.cpp:3409
 msgid "Connect"
 msgstr "Connetti"
 
-#: src/amuleDlg.cpp:1042
+#: src/amuleDlg.cpp:977
 msgid "Connect to the currently enabled networks"
 msgstr "Connetti alle reti attualmente abilitate"
 
-#: src/amuleDlg.cpp:1154
+#: src/amuleDlg.cpp:1089
 #, c-format
 msgid "Up: %.1f%s (%.1f) | Down: %.1f%s (%.1f)"
 msgstr "Up: %.1f%s (%.1f) | Down: %.1f%s (%.1f)"
 
-#: src/amuleDlg.cpp:1156 src/amuleDlg.cpp:1158 src/amuleDlg.cpp:1162
-#: src/amuleDlg.cpp:1164 src/amuleDlg.cpp:1175 src/amuleDlg.cpp:1177
+#: src/amuleDlg.cpp:1091 src/amuleDlg.cpp:1093 src/amuleDlg.cpp:1097
+#: src/amuleDlg.cpp:1099 src/amuleDlg.cpp:1110 src/amuleDlg.cpp:1112
 #: src/MuleTrayIcon.cpp:796 src/MuleTrayIcon.cpp:799
 msgid " MB/s"
 msgstr " MB/s"
 
-#: src/amuleDlg.cpp:1156 src/amuleDlg.cpp:1158 src/amuleDlg.cpp:1162
-#: src/amuleDlg.cpp:1164 src/amuleDlg.cpp:1175 src/amuleDlg.cpp:1177
+#: src/amuleDlg.cpp:1091 src/amuleDlg.cpp:1093 src/amuleDlg.cpp:1097
+#: src/amuleDlg.cpp:1099 src/amuleDlg.cpp:1110 src/amuleDlg.cpp:1112
 #: src/MuleTrayIcon.cpp:796 src/MuleTrayIcon.cpp:799
 #: src/utils/wxCas/src/wxcasframe.cpp:1041
 msgid " kB/s"
 msgstr " kB/s"
 
-#: src/amuleDlg.cpp:1161
+#: src/amuleDlg.cpp:1096
 #, c-format
 msgid "Up: %.1f%s | Down: %.1f%s"
 msgstr "Up: %.1f%s | Down: %.1f%s"
 
-#: src/amuleDlg.cpp:1193
+#: src/amuleDlg.cpp:1128
 #, c-format
 msgid "aMule (%s | Connected)"
 msgstr "aMule (%s | Connesso)"
 
-#: src/amuleDlg.cpp:1195
+#: src/amuleDlg.cpp:1130
 #, c-format
 msgid "aMule (%s | Disconnected)"
 msgstr "aMule (%s | Disconnesso)"
 
-#: src/amuleDlg.cpp:1248
+#: src/amuleDlg.cpp:1183
 #, c-format
 msgid "Do you really want to exit %s?"
 msgstr "Vuoi veramente uscire da %s?"
 
-#: src/amuleDlg.cpp:1250
+#: src/amuleDlg.cpp:1185
 msgid "Exit confirmation"
 msgstr "Chiedi conferma prima di uscire"
 
-#: src/amuleDlg.cpp:1613
+#: src/amuleDlg.cpp:1548
 msgid "Launch Command: "
 msgstr "Comando di avvio: "
 
-#: src/amuleDlg.cpp:1632 src/muuli_wdr.cpp:1972 src/Preferences.cpp:979
+#: src/amuleDlg.cpp:1567 src/muuli_wdr.cpp:1971 src/Preferences.cpp:951
 msgid "- default -"
 msgstr "- predefinita -"
 
-#: src/amuleDlg.cpp:1660
+#: src/amuleDlg.cpp:1595
 #, c-format
 msgid "Skin directory '%s' does not exist"
 msgstr "La directory delle skin '%s' non esiste"
 
-#: src/amuleDlg.cpp:1663
+#: src/amuleDlg.cpp:1598
 #, c-format
 msgid "WARNING: Unable to open skin file '%s' for read"
 msgstr "ATTENZIONE: Impossibile aprire il file della skin '%s' in lettura"
 
-#: src/amuleDlg.cpp:1814 src/muuli_wdr.cpp:3439
+#: src/amuleDlg.cpp:1722 src/amuleDlg.cpp:1968 src/muuli_wdr.cpp:1485
+#: src/muuli_wdr.cpp:3411
+msgid "Networks"
+msgstr "Reti"
+
+#: src/amuleDlg.cpp:1726 src/muuli_wdr.cpp:3411
 msgid "Networks Window"
 msgstr "Finestra reti"
 
-#: src/amuleDlg.cpp:1820 src/muuli_wdr.cpp:3440
+#: src/amuleDlg.cpp:1728 src/muuli_wdr.cpp:3412
+msgid "Searches"
+msgstr "Ricerca"
+
+#: src/amuleDlg.cpp:1732 src/muuli_wdr.cpp:3412
 msgid "Searches Window"
 msgstr "Finestra ricerche"
 
-#: src/amuleDlg.cpp:1826 src/muuli_wdr.cpp:3441
+#: src/amuleDlg.cpp:1734 src/DownloadListCtrl.cpp:740 src/muuli_wdr.cpp:392
+#: src/muuli_wdr.cpp:1578 src/muuli_wdr.cpp:3413 src/Statistics.cpp:829
+msgid "Downloads"
+msgstr "Download"
+
+#: src/amuleDlg.cpp:1738 src/muuli_wdr.cpp:3413
 msgid "Downloads Window"
 msgstr "Finestra dei Download"
 
-#: src/amuleDlg.cpp:1832 src/muuli_wdr.cpp:3443
+#: src/amuleDlg.cpp:1740 src/muuli_wdr.cpp:3287
+msgid "Shared files"
+msgstr "File condivisi"
+
+#: src/amuleDlg.cpp:1744 src/muuli_wdr.cpp:3415
 msgid "Shared Files Window"
 msgstr "Finestra file condivisi"
 
-#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3444
+#: src/amuleDlg.cpp:1746 src/muuli_wdr.cpp:2919 src/muuli_wdr.cpp:3369
+#: src/muuli_wdr.cpp:3416
+msgid "Messages"
+msgstr "Messaggi"
+
+#: src/amuleDlg.cpp:1750 src/muuli_wdr.cpp:3416
 msgid "Messages Window"
 msgstr "Finestra messaggi"
 
-#: src/amuleDlg.cpp:1844 src/muuli_wdr.cpp:3445
+#: src/amuleDlg.cpp:1752 src/muuli_wdr.cpp:3417 src/PrefsUnifiedDlg.cpp:312
+#: src/Statistics.cpp:779 src/Statistics.cpp:1235
+msgid "Statistics"
+msgstr "Statistiche"
+
+#: src/amuleDlg.cpp:1756 src/muuli_wdr.cpp:3417
 msgid "Statistics Graph Window"
 msgstr "Finestra grafici e statistiche"
 
-#: src/amuleDlg.cpp:1851 src/muuli_wdr.cpp:3447
+#: src/amuleDlg.cpp:1759 src/muuli_wdr.cpp:3419 src/PrefsUnifiedDlg.cpp:328
+#: src/utils/wxCas/src/wxcasprefs.cpp:39
+msgid "Preferences"
+msgstr "Preferenze"
+
+#: src/amuleDlg.cpp:1763 src/muuli_wdr.cpp:3419
 msgid "Preferences Settings Window"
 msgstr "Finestra Preferenze"
 
-#: src/amuleDlg.cpp:1854 src/muuli_wdr.cpp:3448
+#: src/amuleDlg.cpp:1766 src/muuli_wdr.cpp:3420
 msgid "Import"
 msgstr "Importazione"
 
-#: src/amuleDlg.cpp:1858 src/muuli_wdr.cpp:3448
+#: src/amuleDlg.cpp:1770 src/muuli_wdr.cpp:3420
 msgid "The partfile importer tool"
 msgstr "Strumento per l'importazione dei file parziali"
 
-#: src/amuleDlg.cpp:1861 src/muuli_wdr.cpp:3449
+#: src/amuleDlg.cpp:1773 src/muuli_wdr.cpp:3421
 #: src/utils/aLinkCreator/src/alcframe.cpp:262
 msgid "About"
 msgstr "Informazioni"
 
-#: src/amuleDlg.cpp:1861 src/muuli_wdr.cpp:3449
+#: src/amuleDlg.cpp:1773 src/muuli_wdr.cpp:3421
 msgid "About/Help"
 msgstr "Informazioni/Aiuto"
 
-#: src/amuleDlg.cpp:2059
+#: src/amuleDlg.cpp:1971
 msgid "eD2k network"
 msgstr "rete eD2k"
 
-#: src/amuleDlg.cpp:2062
+#: src/amuleDlg.cpp:1974
 msgid "Kad network"
 msgstr "Rete Kad"
 
-#: src/amuleDlg.cpp:2062
+#: src/amuleDlg.cpp:1974
 msgid "No network"
 msgstr "Nessuna rete"
 
@@ -968,7 +963,7 @@ msgstr "non trovato"
 msgid "The core rejected these shared folders:%s"
 msgstr "Il core ha rifiutato queste cartelle condivise:%s"
 
-#: src/amule-remote-gui.cpp:1336 src/ExternalConn.cpp:2346
+#: src/amule-remote-gui.cpp:1336 src/ExternalConn.cpp:2345
 msgid "Invalid link or already on list."
 msgstr "Collegamento non valido o già nella lista."
 
@@ -984,7 +979,7 @@ msgstr "Impossibile creare la directory '%s' per la categoria '%s', verrà mante
 #: src/ClientDetailDialog.cpp:123 src/DataToText.cpp:61 src/DataToText.cpp:86
 #: src/DataToText.cpp:101 src/DataToText.cpp:136 src/DataToText.cpp:165
 #: src/DownloadListCtrl.cpp:1172 src/DownloadListCtrl.cpp:1185
-#: src/DownloadListCtrl.cpp:1196 src/ExternalConn.cpp:609
+#: src/DownloadListCtrl.cpp:1196 src/ExternalConn.cpp:608
 #: src/FileDetailDialog.cpp:203 src/FileDetailDialog.cpp:235
 #: src/FileDetailDialog.cpp:242 src/GenericClientListCtrl.cpp:1171
 #: src/GenericClientListCtrl.cpp:1182 src/GenericClientListCtrl.cpp:1192
@@ -1370,19 +1365,19 @@ msgstr "Auto [Alta]"
 msgid "Very low"
 msgstr "Molto bassa"
 
-#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:743 src/muuli_wdr.cpp:2303
+#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:743 src/muuli_wdr.cpp:2275
 #: src/ServerListCtrl.cpp:263 src/ServerListCtrl.cpp:456
 #: src/SharedFilesCtrl.cpp:145
 msgid "Low"
 msgstr "Bassa"
 
-#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:744 src/muuli_wdr.cpp:2304
+#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:744 src/muuli_wdr.cpp:2276
 #: src/ServerListCtrl.cpp:266 src/ServerListCtrl.cpp:457
 #: src/SharedFilesCtrl.cpp:146
 msgid "Normal"
 msgstr "Normale"
 
-#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:745 src/muuli_wdr.cpp:2305
+#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:745 src/muuli_wdr.cpp:2277
 #: src/ServerListCtrl.cpp:269 src/ServerListCtrl.cpp:458
 #: src/SharedFilesCtrl.cpp:147
 msgid "High"
@@ -1474,8 +1469,8 @@ msgstr "Server locale"
 msgid "Remote Server"
 msgstr "Server remoto"
 
-#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3202
-#: src/SearchDlg.cpp:119 src/TextClient.cpp:911
+#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3174
+#: src/SearchDlg.cpp:111 src/TextClient.cpp:911
 msgid "Kad"
 msgstr "Kad"
 
@@ -1545,7 +1540,7 @@ msgstr "Parte"
 msgid "Size"
 msgstr "Dimensione"
 
-#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3269
+#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3241
 msgid "Transferred"
 msgstr "Trasferiti"
 
@@ -1603,7 +1598,7 @@ msgstr ""
 "Feedback da: %s (%s)\n"
 "\n"
 
-#: src/DownloadListCtrl.cpp:746 src/muuli_wdr.cpp:2306
+#: src/DownloadListCtrl.cpp:746 src/muuli_wdr.cpp:2278
 #: src/SharedFilesCtrl.cpp:150
 msgid "Auto"
 msgstr "Auto"
@@ -1641,7 +1636,7 @@ msgid "Extended Options"
 msgstr "Opzioni avanzate"
 
 #: src/DownloadListCtrl.cpp:770 src/DownloadListCtrl.cpp:822
-#: src/muuli_wdr.cpp:1790
+#: src/muuli_wdr.cpp:1789
 msgid "Preview"
 msgstr "Anteprima"
 
@@ -1816,230 +1811,225 @@ msgstr[1] "Impossibile aggiungere %u collegamenti (vedere il log per i dettagli)
 msgid "Invalid eD2k link! ERROR: %s"
 msgstr "Collegamento eD2k non valido! ERRORE: %s"
 
-#: src/ExternalConn.cpp:380
+#: src/ExternalConn.cpp:379
 msgid "Client sent packet after authentication failed."
 msgstr "Il client ha inviato un pacchetto dopo che l'autenticazione era fallita."
 
-#: src/ExternalConn.cpp:397
+#: src/ExternalConn.cpp:396
 msgid "External connection closed."
 msgstr "Connessione esterna chiusa."
 
-#: src/ExternalConn.cpp:474
+#: src/ExternalConn.cpp:473
 msgid "External connections disabled due to empty password!"
 msgstr "Connessioni esterne disabilitate perché la password è vuota!"
 
-#: src/ExternalConn.cpp:495
+#: src/ExternalConn.cpp:494
 msgid "External connections disabled in config file"
 msgstr "Connessioni esterne disabilitate nel file di configurazione"
 
-#: src/ExternalConn.cpp:576
+#: src/ExternalConn.cpp:575
 msgid "New external connection accepted"
 msgstr "Accettata nuova connessione esterna"
 
-#: src/ExternalConn.cpp:579
+#: src/ExternalConn.cpp:578
 msgid "ERROR: couldn't accept a new external connection"
 msgstr "ERRORE: impossibile accettare una nuova connessione esterna"
 
-#: src/ExternalConn.cpp:596
+#: src/ExternalConn.cpp:595
 msgid "External connection refused due to empty password in preferences!"
 msgstr "Connessione esterna rifiutata perché la password nelle preferenze è vuota!"
 
-#: src/ExternalConn.cpp:608
+#: src/ExternalConn.cpp:607
 #, c-format
 msgid "Connecting client: %s %s"
 msgstr "Connessione al client: %s %s"
 
-#: src/ExternalConn.cpp:610
+#: src/ExternalConn.cpp:609
 msgid "Unknown version"
 msgstr "Versione sconosciuta"
 
-#: src/ExternalConn.cpp:623
+#: src/ExternalConn.cpp:622
 msgid "Incorrect EC version ID, there might be binary incompatibility. Use core and remote from same snapshot."
 msgstr "ID della versione EC non corretto, potrebbe esserci un'incompatibilità binaria. Usare core e client remoto dello stesso snapshot."
 
-#: src/ExternalConn.cpp:631
+#: src/ExternalConn.cpp:630
 msgid "You cannot connect to a release version from an arbitrary development snapshot! *sigh* possible crash prevented"
 msgstr "Non puoi connetterti a una versione stabile da una versione CVS qualsiasi! *fiuu!* possibile crash evitato"
 
-#: src/ExternalConn.cpp:714
+#: src/ExternalConn.cpp:713
 msgid "Invalid protocol version."
 msgstr "Versione protocollo non valida."
 
-#: src/ExternalConn.cpp:720
+#: src/ExternalConn.cpp:719
 msgid "Missing protocol version tag."
 msgstr "Tag versione protocollo mancante."
 
-#: src/ExternalConn.cpp:728
+#: src/ExternalConn.cpp:727
 msgid "Authentication failed: invalid hash specified as EC password."
 msgstr "Autenticazione fallita: l'hash specificato come password EC non è valido."
 
-#: src/ExternalConn.cpp:776
+#: src/ExternalConn.cpp:775
 msgid "Authentication failed: wrong password."
 msgstr "Autenticazione fallita: password errata."
 
-#: src/ExternalConn.cpp:778
+#: src/ExternalConn.cpp:777
 msgid "Authentication failed: missing password."
 msgstr "Autenticazione fallita: devi inserire la password."
 
-#: src/ExternalConn.cpp:789
+#: src/ExternalConn.cpp:788
 msgid "Invalid request, please authenticate first."
 msgstr "Richiesta non valida, prima devi autenticarti."
 
-#: src/ExternalConn.cpp:794
+#: src/ExternalConn.cpp:793
 msgid "Access granted."
 msgstr "Accesso consentito."
 
-#: src/ExternalConn.cpp:802
+#: src/ExternalConn.cpp:801
 #, c-format
 msgid "Sent error message \"%s\" to client."
 msgstr "Invia il messaggio di errore \"%s\" al client."
 
-#: src/ExternalConn.cpp:807
+#: src/ExternalConn.cpp:806
 #, c-format
 msgid "Unauthorized access attempt from %s. Connection closed."
 msgstr "Tentativo di accesso non autorizzato da %s. Connessione terminata."
 
-#: src/ExternalConn.cpp:1420
+#: src/ExternalConn.cpp:1419
 #, c-format
 msgid "Remote PartFile command failed: FileHash not found: %s"
 msgstr "Comando Partfile remoto fallito: hash del file non trovato: %s"
 
-#: src/ExternalConn.cpp:1424
+#: src/ExternalConn.cpp:1423
 #, c-format
 msgid "FileHash not found: %s"
 msgstr "Hash del file non trovato: %s"
 
-#: src/ExternalConn.cpp:1471 src/ExternalConn.cpp:1559
-#: src/ExternalConn.cpp:1680
+#: src/ExternalConn.cpp:1470 src/ExternalConn.cpp:1558
+#: src/ExternalConn.cpp:1679
 msgid "OOPS! OpCode processing error!"
 msgstr "OOPS! errore nel processare l'opcode!"
 
-#: src/ExternalConn.cpp:1502
+#: src/ExternalConn.cpp:1501
 msgid "Server not added"
 msgstr "Server non aggiunto"
 
-#: src/ExternalConn.cpp:1521
+#: src/ExternalConn.cpp:1520
 #, c-format
 msgid "server not found: %s"
 msgstr "server non trovato: %s"
 
-#: src/ExternalConn.cpp:1538
+#: src/ExternalConn.cpp:1537
 msgid "need to define server to be removed"
 msgstr "è necessario definire il server da rimuovere"
 
-#: src/ExternalConn.cpp:1553
+#: src/ExternalConn.cpp:1552
 msgid "eD2k is disabled in preferences."
 msgstr "eD2k è disabilitato nelle preferenze."
 
-#: src/ExternalConn.cpp:1658
+#: src/ExternalConn.cpp:1657
 msgid "Friend not found."
 msgstr "Amico non trovato."
 
-#: src/ExternalConn.cpp:1668
+#: src/ExternalConn.cpp:1667
 msgid "Client not found."
 msgstr "Client non trovato."
 
-#: src/ExternalConn.cpp:1674
+#: src/ExternalConn.cpp:1673
 msgid "EC_TAG_FRIEND_SHARED requires EC_TAG_FRIEND or EC_TAG_CLIENT."
 msgstr "EC_TAG_FRIEND_SHARED richiede EC_TAG_FRIEND o EC_TAG_CLIENT."
 
-#: src/ExternalConn.cpp:1992
+#: src/ExternalConn.cpp:1991
 msgid "WebSearch from remote interface makes no sense."
 msgstr "Non ha senso usare la ricerca Web da interfaccia remota."
 
-#: src/ExternalConn.cpp:2027
+#: src/ExternalConn.cpp:2026
 msgid "Search in progress. Refetch results in a moment!"
 msgstr "Ricerca in corso. Risultati in arrivo!"
 
-#: src/ExternalConn.cpp:2266
+#: src/ExternalConn.cpp:2265
 msgid "No points for graph."
 msgstr "Niente punti per il grafico."
 
-#: src/ExternalConn.cpp:2276
+#: src/ExternalConn.cpp:2275
 msgid "Your client is not configured for this detail level."
 msgstr "Il tuo client non è configurato per questo livello di dettaglio."
 
-#: src/ExternalConn.cpp:2303
+#: src/ExternalConn.cpp:2302
 msgid "External Connection: shutdown requested"
 msgstr "Connessione esterna: arresto richiesto"
 
-#: src/ExternalConn.cpp:2315
+#: src/ExternalConn.cpp:2314
 msgid "Already shutting down."
 msgstr "Sto già uscendo."
 
-#: src/ExternalConn.cpp:2333
+#: src/ExternalConn.cpp:2332
 #, c-format
 msgid "ExternalConn: adding link '%s'."
 msgstr "ExternalConn: aggiungo il collegamento '%s'."
 
-#: src/ExternalConn.cpp:2351
+#: src/ExternalConn.cpp:2350
 #, c-format
 msgid "%d of %d links failed (invalid or already on list)."
 msgstr "%d di %d collegamenti non riusciti (non validi o già in elenco)."
 
-#: src/ExternalConn.cpp:2374
+#: src/ExternalConn.cpp:2373
 msgid "Version check throttled; try again shortly."
 msgstr "Controllo versione soggetto a limite di frequenza; riprova a breve."
 
-#: src/ExternalConn.cpp:2379
+#: src/ExternalConn.cpp:2378
 msgid "Version check is not available on this daemon."
 msgstr "Il controllo versione non è disponibile su questo demone."
 
-#: src/ExternalConn.cpp:2509
+#: src/ExternalConn.cpp:2508
 msgid "File not found."
 msgstr "File non trovato."
 
-#: src/ExternalConn.cpp:2514
+#: src/ExternalConn.cpp:2513
 msgid "Invalid file name."
 msgstr "Nome file non valido."
 
-#: src/ExternalConn.cpp:2522
+#: src/ExternalConn.cpp:2521
 msgid "Unable to rename file."
 msgstr "Impossibile rinominare il file."
 
-#: src/ExternalConn.cpp:2839
-#, c-format
-msgid "Could not save the amuleapi password: %s"
-msgstr ""
-
-#: src/ExternalConn.cpp:3004 src/ExternalConn.cpp:3032
+#: src/ExternalConn.cpp:2992 src/ExternalConn.cpp:3020
 msgid "Kad is disabled in preferences."
 msgstr "La rete Kad è disabilitata nelle Preferenze."
 
-#: src/ExternalConn.cpp:3045
+#: src/ExternalConn.cpp:3033
 msgid "Already connected to eD2k."
 msgstr "Già connesso ad eD2k."
 
-#: src/ExternalConn.cpp:3048
+#: src/ExternalConn.cpp:3036
 msgid "Connecting to eD2k..."
 msgstr "Connessione alla rete eD2k in corso..."
 
-#: src/ExternalConn.cpp:3057
+#: src/ExternalConn.cpp:3045
 msgid "Already connected to Kad."
 msgstr "Già connesso alla rete Kad."
 
-#: src/ExternalConn.cpp:3060
+#: src/ExternalConn.cpp:3048
 msgid "Connecting to Kad..."
 msgstr "Connessione alla rete Kad..."
 
-#: src/ExternalConn.cpp:3067
+#: src/ExternalConn.cpp:3055
 msgid "All networks are disabled."
 msgstr "Tutte le reti sono disabilitate."
 
-#: src/ExternalConn.cpp:3076
+#: src/ExternalConn.cpp:3064
 msgid "Disconnected from eD2k."
 msgstr "Disconnesso dalla rete eD2k."
 
-#: src/ExternalConn.cpp:3081
+#: src/ExternalConn.cpp:3069
 msgid "Disconnected from Kad."
 msgstr "Disconnesso dalla rete Kad."
 
-#: src/ExternalConn.cpp:3090
+#: src/ExternalConn.cpp:3078
 #, c-format
 msgid "External Connection: invalid opcode received: %#x"
 msgstr "Connessione esterna: ricevuto un opcode invalido: %#x"
 
-#: src/ExternalConn.cpp:3095
+#: src/ExternalConn.cpp:3083
 msgid "Invalid opcode (wrong protocol version?)"
 msgstr "Opcode non valido (versione errata del protocollo?)"
 
@@ -2355,19 +2345,19 @@ msgstr ""
 msgid "eD2k"
 msgstr "eD2k"
 
-#: src/FirstRunWizard.cpp:349 src/muuli_wdr.cpp:1495
+#: src/FirstRunWizard.cpp:349 src/muuli_wdr.cpp:1488
 msgid "Kademlia"
 msgstr "Kademlia"
 
-#: src/FirstRunWizard.cpp:359 src/muuli_wdr.cpp:1423
+#: src/FirstRunWizard.cpp:359 src/muuli_wdr.cpp:1416
 msgid "Standard TCP Port "
 msgstr "Porta TCP standard "
 
-#: src/FirstRunWizard.cpp:365 src/muuli_wdr.cpp:1435
+#: src/FirstRunWizard.cpp:365 src/muuli_wdr.cpp:1428
 msgid "Extended UDP port (Kad / global search) "
 msgstr "Porta UDP estesa (Kad / ricerca globale) "
 
-#: src/FirstRunWizard.cpp:377 src/muuli_wdr.cpp:1442
+#: src/FirstRunWizard.cpp:377 src/muuli_wdr.cpp:1435
 msgid "Enable UPnP for router port forwarding"
 msgstr "Abilita UPnP per il port forwarding del router"
 
@@ -2394,7 +2384,7 @@ msgstr ""
 msgid "Your peer lists are already in place - nothing to download."
 msgstr "Stai già cercando di scaricare il file %s"
 
-#: src/FirstRunWizard.cpp:434 src/muuli_wdr.cpp:1540
+#: src/FirstRunWizard.cpp:434 src/muuli_wdr.cpp:1533
 msgid "Auto-update server list at startup"
 msgstr "Aggiorna lista server all'avvio"
 
@@ -2440,23 +2430,23 @@ msgid ""
 "want downloads on a different (e.g. larger) disk."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:549 src/FirstRunWizard.cpp:611 src/muuli_wdr.cpp:1702
+#: src/FirstRunWizard.cpp:549 src/FirstRunWizard.cpp:611 src/muuli_wdr.cpp:1701
 msgid "Destination folder for downloads"
 msgstr "Cartella di destinazione per i file scaricati"
 
-#: src/FirstRunWizard.cpp:553 src/FirstRunWizard.cpp:569 src/muuli_wdr.cpp:1349
-#: src/muuli_wdr.cpp:1366 src/muuli_wdr.cpp:1677 src/muuli_wdr.cpp:1708
-#: src/muuli_wdr.cpp:1720 src/muuli_wdr.cpp:2790
+#: src/FirstRunWizard.cpp:553 src/FirstRunWizard.cpp:569 src/muuli_wdr.cpp:1342
+#: src/muuli_wdr.cpp:1359 src/muuli_wdr.cpp:1676 src/muuli_wdr.cpp:1707
+#: src/muuli_wdr.cpp:1719 src/muuli_wdr.cpp:2762
 #: src/utils/aLinkCreator/src/alcframe.cpp:135
 #: src/utils/wxCas/src/wxcasprefs.cpp:52 src/utils/wxCas/src/wxcasprefs.cpp:118
 msgid "Browse"
 msgstr "Sfoglia"
 
-#: src/FirstRunWizard.cpp:559 src/muuli_wdr.cpp:1713
+#: src/FirstRunWizard.cpp:559 src/muuli_wdr.cpp:1712
 msgid "(All files in this folder are shared with other peers)"
 msgstr "(Tutti i file in questa cartella sono condivisi con gli altri peer)"
 
-#: src/FirstRunWizard.cpp:565 src/FirstRunWizard.cpp:624 src/muuli_wdr.cpp:1715
+#: src/FirstRunWizard.cpp:565 src/FirstRunWizard.cpp:624 src/muuli_wdr.cpp:1714
 msgid "Folder for temporary download files"
 msgstr "Cartella per i file temporanei"
 
@@ -2487,7 +2477,7 @@ msgstr "Impossibile aprire in scrittura il file della lista degli amici 'emfrien
 msgid "CRITICAL - no client on StartChatSession"
 msgstr "CRITICO - nessun client in StartChatSession"
 
-#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2696 src/muuli_wdr.cpp:3373
+#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2668 src/muuli_wdr.cpp:3345
 msgid "Friends"
 msgstr "Amici"
 
@@ -2597,8 +2587,8 @@ msgstr "Nessuno"
 msgid "No"
 msgstr "No"
 
-#: src/GenericClientListCtrl.cpp:1216 src/PrefsUnifiedDlg.cpp:2898
-#: src/PrefsUnifiedDlg.cpp:2948 src/ServerListCtrl.cpp:276
+#: src/GenericClientListCtrl.cpp:1216 src/PrefsUnifiedDlg.cpp:2818
+#: src/PrefsUnifiedDlg.cpp:2868 src/ServerListCtrl.cpp:276
 msgid "Yes"
 msgstr "Sì"
 
@@ -2767,10 +2757,10 @@ msgstr "Porta non valida per il bootstrap"
 msgid "Please fill all fields required"
 msgstr "Completa tutti i campi obbligatori"
 
-#: src/KadDlg.cpp:192 src/PartFile.cpp:1031 src/PrefsUnifiedDlg.cpp:1134
-#: src/PrefsUnifiedDlg.cpp:1204 src/PrefsUnifiedDlg.cpp:1405
-#: src/PrefsUnifiedDlg.cpp:1663 src/PrefsUnifiedDlg.cpp:1673
-#: src/PrefsUnifiedDlg.cpp:1690 src/PrefsUnifiedDlg.cpp:1738
+#: src/KadDlg.cpp:192 src/PartFile.cpp:1031 src/PrefsUnifiedDlg.cpp:1162
+#: src/PrefsUnifiedDlg.cpp:1331 src/PrefsUnifiedDlg.cpp:1589
+#: src/PrefsUnifiedDlg.cpp:1599 src/PrefsUnifiedDlg.cpp:1616
+#: src/PrefsUnifiedDlg.cpp:1658
 msgid "Message"
 msgstr "Messaggio"
 
@@ -2871,7 +2861,7 @@ msgstr "Rapporto di condivisione"
 msgid "Uploaded"
 msgstr "Inviato"
 
-#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3253
+#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3225
 msgid "Requested"
 msgstr "Richiesto"
 
@@ -2994,7 +2984,7 @@ msgid "WARNING: "
 msgstr "ATTENZIONE: "
 
 #: src/MuleNotebook.cpp:179 src/muuli_wdr.cpp:817 src/muuli_wdr.cpp:1229
-#: src/muuli_wdr.cpp:3157 src/muuli_wdr.cpp:3413
+#: src/muuli_wdr.cpp:3129 src/muuli_wdr.cpp:3385
 msgid "Close"
 msgstr "Chiudi"
 
@@ -3007,12 +2997,12 @@ msgstr "Taglia"
 msgid "Copy"
 msgstr "Copia"
 
-#: src/MuleTextCtrl.cpp:88 src/SearchDlg.cpp:261
+#: src/MuleTextCtrl.cpp:88
 msgid "Paste"
 msgstr "Incolla"
 
 #: src/MuleTextCtrl.cpp:89 src/muuli_wdr.cpp:358 src/muuli_wdr.cpp:757
-#: src/muuli_wdr.cpp:2380 src/muuli_wdr.cpp:2399 src/muuli_wdr.cpp:2421
+#: src/muuli_wdr.cpp:2352 src/muuli_wdr.cpp:2371 src/muuli_wdr.cpp:2393
 #: src/utils/aLinkCreator/src/alcframe.cpp:142
 msgid "Clear"
 msgstr "Pulisci"
@@ -3103,8 +3093,8 @@ msgid "Exit"
 msgstr "Esci"
 
 #: src/MuleTrayIcon.cpp:579 src/MuleTrayIcon.cpp:945 src/MuleTrayIcon.cpp:965
-#: src/muuli_wdr.cpp:1398 src/muuli_wdr.cpp:1406 src/muuli_wdr.cpp:1413
-#: src/muuli_wdr.cpp:1836 src/muuli_wdr.cpp:1842 src/OtherFunctions.cpp:91
+#: src/muuli_wdr.cpp:1391 src/muuli_wdr.cpp:1399 src/muuli_wdr.cpp:1406
+#: src/muuli_wdr.cpp:1835 src/muuli_wdr.cpp:1841 src/OtherFunctions.cpp:91
 #: src/StatisticsDlg.cpp:93 src/StatisticsDlg.cpp:95
 msgid "kB/s"
 msgstr "kB/s"
@@ -3273,7 +3263,7 @@ msgstr "Nome:"
 msgid "Type"
 msgstr "Tipo"
 
-#: src/muuli_wdr.cpp:215 src/SearchDlg.cpp:118 src/SearchListCtrl.cpp:853
+#: src/muuli_wdr.cpp:215 src/SearchDlg.cpp:110 src/SearchListCtrl.cpp:853
 msgid "Local"
 msgstr "Locale"
 
@@ -3344,7 +3334,7 @@ msgstr "Byte"
 msgid "KB"
 msgstr "KB"
 
-#: src/muuli_wdr.cpp:274 src/muuli_wdr.cpp:293 src/muuli_wdr.cpp:1621
+#: src/muuli_wdr.cpp:274 src/muuli_wdr.cpp:293 src/muuli_wdr.cpp:1620
 #: src/OtherFunctions.cpp:64
 msgid "MB"
 msgstr "MB"
@@ -3361,7 +3351,7 @@ msgstr "Dimensione massima"
 msgid "Availability"
 msgstr "Disponibilità"
 
-#: src/muuli_wdr.cpp:312 src/muuli_wdr.cpp:398 src/muuli_wdr.cpp:3318
+#: src/muuli_wdr.cpp:312 src/muuli_wdr.cpp:398 src/muuli_wdr.cpp:3290
 msgid "Filter:"
 msgstr "Filtro:"
 
@@ -3393,7 +3383,7 @@ msgstr "Chiedi ai peer Kad che hanno già risposto di ampliare la ricerca. Ogni 
 msgid "Stop"
 msgstr "Ferma"
 
-#: src/muuli_wdr.cpp:348 src/muuli_wdr.cpp:1392 src/SearchListCtrl.cpp:732
+#: src/muuli_wdr.cpp:348 src/muuli_wdr.cpp:1385 src/SearchListCtrl.cpp:732
 msgid "Download"
 msgstr "Download"
 
@@ -3424,12 +3414,12 @@ msgstr "Fonti del file:"
 #: src/muuli_wdr.cpp:1160 src/muuli_wdr.cpp:1167 src/muuli_wdr.cpp:1172
 #: src/muuli_wdr.cpp:1179 src/muuli_wdr.cpp:1184 src/muuli_wdr.cpp:1191
 #: src/muuli_wdr.cpp:1205 src/muuli_wdr.cpp:1212 src/muuli_wdr.cpp:1217
-#: src/muuli_wdr.cpp:1224 src/muuli_wdr.cpp:3255 src/muuli_wdr.cpp:3263
-#: src/muuli_wdr.cpp:3271
+#: src/muuli_wdr.cpp:1224 src/muuli_wdr.cpp:3227 src/muuli_wdr.cpp:3235
+#: src/muuli_wdr.cpp:3243
 msgid "N/A"
 msgstr "N/D"
 
-#: src/muuli_wdr.cpp:508 src/muuli_wdr.cpp:1065 src/PrefsUnifiedDlg.cpp:299
+#: src/muuli_wdr.cpp:508 src/muuli_wdr.cpp:1065 src/PrefsUnifiedDlg.cpp:297
 msgid "General"
 msgstr "Generale"
 
@@ -3565,7 +3555,7 @@ msgstr "Artista :"
 msgid "Album :"
 msgstr "Album :"
 
-#: src/muuli_wdr.cpp:685 src/muuli_wdr.cpp:2275
+#: src/muuli_wdr.cpp:685 src/muuli_wdr.cpp:2247
 msgid "Title :"
 msgstr "Titolo:"
 
@@ -3673,7 +3663,7 @@ msgstr "Nome utente:"
 msgid "Userhash :"
 msgstr "Hash utente:"
 
-#: src/muuli_wdr.cpp:895 src/muuli_wdr.cpp:1742 src/muuli_wdr.cpp:2470
+#: src/muuli_wdr.cpp:895 src/muuli_wdr.cpp:1741 src/muuli_wdr.cpp:2442
 #: src/utils/aLinkCreator/src/alcframe.cpp:137
 msgid "Add"
 msgstr "Aggiungi"
@@ -3682,15 +3672,15 @@ msgstr "Aggiungi"
 msgid "Download-Speed"
 msgstr "Velocità download"
 
-#: src/muuli_wdr.cpp:954 src/muuli_wdr.cpp:989 src/muuli_wdr.cpp:2574
+#: src/muuli_wdr.cpp:954 src/muuli_wdr.cpp:989 src/muuli_wdr.cpp:2546
 msgid "Current"
 msgstr "Corrente"
 
-#: src/muuli_wdr.cpp:962 src/muuli_wdr.cpp:997 src/muuli_wdr.cpp:2582
+#: src/muuli_wdr.cpp:962 src/muuli_wdr.cpp:997 src/muuli_wdr.cpp:2554
 msgid "Running average"
 msgstr "Media attuale"
 
-#: src/muuli_wdr.cpp:970 src/muuli_wdr.cpp:1005 src/muuli_wdr.cpp:2590
+#: src/muuli_wdr.cpp:970 src/muuli_wdr.cpp:1005 src/muuli_wdr.cpp:2562
 msgid "Session average"
 msgstr "Media sessione"
 
@@ -3702,7 +3692,7 @@ msgstr "Velocità upload"
 msgid "Connections"
 msgstr "Connessioni"
 
-#: src/muuli_wdr.cpp:1024 src/muuli_wdr.cpp:1861
+#: src/muuli_wdr.cpp:1024 src/muuli_wdr.cpp:1860
 msgid "Active downloads"
 msgstr "Download attivi"
 
@@ -3710,7 +3700,7 @@ msgstr "Download attivi"
 msgid "Active connections (1:1)"
 msgstr "Connessioni attive (1:1)"
 
-#: src/muuli_wdr.cpp:1040 src/muuli_wdr.cpp:1862
+#: src/muuli_wdr.cpp:1040 src/muuli_wdr.cpp:1861
 msgid "Active uploads"
 msgstr "Upload attivi"
 
@@ -3826,8 +3816,8 @@ msgstr "Questo è il nome che gli altri utenti visualizzeranno quando saranno co
 msgid "Language: "
 msgstr "Lingua: "
 
-#: src/muuli_wdr.cpp:1257 src/muuli_wdr.cpp:1330 src/muuli_wdr.cpp:1334
-#: src/muuli_wdr.cpp:1337
+#: src/muuli_wdr.cpp:1257 src/muuli_wdr.cpp:1323 src/muuli_wdr.cpp:1327
+#: src/muuli_wdr.cpp:1330
 msgid "The delay before showing tool-tips."
 msgstr "Intervallo prima che vengano mostrati i suggerimenti."
 
@@ -3903,260 +3893,259 @@ msgstr "Mostra notifica al termine dello scaricamento"
 msgid "Enabling this will make aMule to show notifications when finished downloading."
 msgstr "Con questa funzione abilitata aMule mostrerà una notifica al termine di ogni download."
 
-#: src/muuli_wdr.cpp:1323
-#, fuzzy
-msgid "Remember search history"
-msgstr "Ricorda impostazioni"
-
-#: src/muuli_wdr.cpp:1324
-msgid "Keeps a dropdown list of your past search terms in the Search tab's Name field. This remembers the queries you typed, not the results they returned."
-msgstr ""
-
-#: src/muuli_wdr.cpp:1329
+#: src/muuli_wdr.cpp:1322
 msgid "Tooltip delay time: "
 msgstr "Ritardo dei suggerimenti: "
 
-#: src/muuli_wdr.cpp:1336
+#: src/muuli_wdr.cpp:1329
 msgid "seconds"
 msgstr "secondi"
 
-#: src/muuli_wdr.cpp:1340
+#: src/muuli_wdr.cpp:1333
 msgid "Browser Selection"
 msgstr "Selezione browser"
 
-#: src/muuli_wdr.cpp:1346
+#: src/muuli_wdr.cpp:1339
 msgid "Enter your browser name here. Leave this field empty to use the system default browser."
 msgstr "Inserisci qui il nome del tuo browser. Lascia vuoto questo campo per utilizzare il browser di sistema predefinito."
 
-#: src/muuli_wdr.cpp:1353
+#: src/muuli_wdr.cpp:1346
 msgid "Open in new tab if possible"
 msgstr "Apri in una nuova scheda se possibile"
 
-#: src/muuli_wdr.cpp:1355
+#: src/muuli_wdr.cpp:1348
 msgid "Open the web page in a new tab instead of in a new window when possible"
 msgstr "Se possibile, apri la pagina web in una nuova scheda invece che in una nuova finestra"
 
-#: src/muuli_wdr.cpp:1359
+#: src/muuli_wdr.cpp:1352
 msgid "Video Player"
 msgstr "Riproduttore video"
 
-#: src/muuli_wdr.cpp:1386
+#: src/muuli_wdr.cpp:1379
 msgid "Bandwidth limits"
 msgstr "Limiti di banda"
 
-#: src/muuli_wdr.cpp:1400
+#: src/muuli_wdr.cpp:1393
 msgid "Upload"
 msgstr "Upload"
 
-#: src/muuli_wdr.cpp:1408
+#: src/muuli_wdr.cpp:1401
 msgid "Slot Allocation"
 msgstr "Allocazione slot"
 
-#: src/muuli_wdr.cpp:1417
+#: src/muuli_wdr.cpp:1410
 msgid "Ports"
 msgstr "Porte"
 
-#: src/muuli_wdr.cpp:1427
+#: src/muuli_wdr.cpp:1420
 msgid "This is the standard eD2k port and cannot be disabled."
 msgstr "Questa è la porta standard di eD2k e non può essere disabilitata."
 
-#: src/muuli_wdr.cpp:1430
+#: src/muuli_wdr.cpp:1423
 msgid "UDP port for server requests (TCP+3):"
 msgstr "Porta UDP per le richieste al server (TCP+3):"
 
-#: src/muuli_wdr.cpp:1432
+#: src/muuli_wdr.cpp:1425
 msgid "4665"
 msgstr "4665"
 
-#: src/muuli_wdr.cpp:1439
+#: src/muuli_wdr.cpp:1432
 msgid "This UDP port is used for extended eD2k requests and Kad network"
 msgstr "Questa porta UDP è utilizzata per le richieste estese eD2k e per la rete Kad"
 
-#: src/muuli_wdr.cpp:1446
+#: src/muuli_wdr.cpp:1439
 msgid "UPnP TCP Port (Optional):"
 msgstr "Porta TCP per UPnP (Facoltativa):"
 
-#: src/muuli_wdr.cpp:1456
+#: src/muuli_wdr.cpp:1449
 msgid "Bind local address to IP (empty for any):"
 msgstr "Lega l'indirizzo locale all'IP (lascia vuoto per qualsiasi):"
 
-#: src/muuli_wdr.cpp:1459
+#: src/muuli_wdr.cpp:1452
 msgid "Advanced users only: If you have multiple network interfaces, enter the address of the interface to which aMule should be bound."
 msgstr "Solo per utenti esperti: se hai interfacce di rete multiple, inserisci l'indirizzo dell'interfaccia che aMule dovrà utilizzare."
 
-#: src/muuli_wdr.cpp:1462 src/muuli_wdr.cpp:2055
+#: src/muuli_wdr.cpp:1455 src/muuli_wdr.cpp:2054
 msgid "Bind to network interface (empty for any):"
 msgstr "Associa all'interfaccia di rete (vuoto per qualsiasi):"
 
-#: src/muuli_wdr.cpp:1475
+#: src/muuli_wdr.cpp:1468
 msgid "Advanced users only: pin all of aMule's traffic to one network interface, chosen from the list or typed in by name (e.g. tun0, eth0, en0) or index. Unlike binding to an IP, this stops traffic leaking out via the default route - useful with a VPN. Requires no elevated privileges."
 msgstr "Solo per utenti esperti: forza tutto il traffico di aMule su un'unica interfaccia di rete, scelta dall'elenco oppure digitata per nome (ad es. tun0, eth0, en0) o indice. A differenza dell'associazione a un IP, questo impedisce al traffico di fuoriuscire tramite la route predefinita - utile con una VPN. Non richiede privilegi elevati."
 
-#: src/muuli_wdr.cpp:1481
+#: src/muuli_wdr.cpp:1474
 msgid "Max sources per downloading file:"
 msgstr "Fonti massime per file in scaricamento:"
 
-#: src/muuli_wdr.cpp:1485
+#: src/muuli_wdr.cpp:1478
 msgid "Max simultaneous connections:"
 msgstr "Connessioni massime simultanee:"
 
-#: src/muuli_wdr.cpp:1498 src/muuli_wdr.cpp:3197
+#: src/muuli_wdr.cpp:1491 src/muuli_wdr.cpp:3169
 msgid "ED2K"
 msgstr "ED2K"
 
-#: src/muuli_wdr.cpp:1505
+#: src/muuli_wdr.cpp:1498
 msgid "Autoconnect on startup"
 msgstr "Connetti automaticamente all'avvio"
 
-#: src/muuli_wdr.cpp:1508
+#: src/muuli_wdr.cpp:1501
 msgid "Reconnect on loss"
 msgstr "Riconnetti dopo perdita connessione"
 
-#: src/muuli_wdr.cpp:1530
+#: src/muuli_wdr.cpp:1523
 msgid "Remove dead server after"
 msgstr "Rimuovi server inattivi dopo"
 
-#: src/muuli_wdr.cpp:1531
+#: src/muuli_wdr.cpp:1524
 msgid "Static servers are never removed, even when unreachable."
 msgstr "I server statici non vengono mai rimossi, nemmeno quando risultano irraggiungibili."
 
-#: src/muuli_wdr.cpp:1535
+#: src/muuli_wdr.cpp:1528
 msgid "retries"
 msgstr "tentativi"
 
-#: src/muuli_wdr.cpp:1543
+#: src/muuli_wdr.cpp:1536
 msgid "List"
 msgstr "Lista"
 
-#: src/muuli_wdr.cpp:1546
+#: src/muuli_wdr.cpp:1539
 msgid "Update server list when connecting to a server"
 msgstr "Aggiorna la lista server quando ti connetti ad un server"
 
-#: src/muuli_wdr.cpp:1549
+#: src/muuli_wdr.cpp:1542
 msgid "Update server list when a client connects"
 msgstr "Aggiorna la lista server quando ti connetti ad un client"
 
-#: src/muuli_wdr.cpp:1552
+#: src/muuli_wdr.cpp:1545
 msgid "Use priority system"
 msgstr "Usa sistema di priorità"
 
-#: src/muuli_wdr.cpp:1556
+#: src/muuli_wdr.cpp:1549
 msgid "Use smart LowID check on connect"
 msgstr "Usa controllo intelligente ID basso in fase di connessione"
 
-#: src/muuli_wdr.cpp:1560
+#: src/muuli_wdr.cpp:1553
 msgid "Safe connect"
 msgstr "Connessione sicura"
 
-#: src/muuli_wdr.cpp:1564
+#: src/muuli_wdr.cpp:1557
 msgid "Autoconnect to servers in static list only"
 msgstr "Connetti automaticamente solo ai server statici"
 
-#: src/muuli_wdr.cpp:1567
+#: src/muuli_wdr.cpp:1560
 msgid "Set manually added servers to High Priority"
 msgstr "Assegna priorità alta ai server aggiunti manualmente"
 
-#: src/muuli_wdr.cpp:1588
+#: src/muuli_wdr.cpp:1581
 msgid "Add files to download in pause mode"
 msgstr "Aggiungi i nuovi file da scaricare mettendoli in pausa"
 
-#: src/muuli_wdr.cpp:1590
+#: src/muuli_wdr.cpp:1583
 msgid "Add files to download with auto priority"
 msgstr "Aggiungi i nuovi file da scaricare con priorità automatica"
 
-#: src/muuli_wdr.cpp:1593
+#: src/muuli_wdr.cpp:1586
 msgid "Try to download first and last chunks first"
 msgstr "Cerca di scaricare prima la parte iniziale e finale del file"
 
-#: src/muuli_wdr.cpp:1597
+#: src/muuli_wdr.cpp:1590
 msgid "Endgame mode: rotate to faster sources for the final blocks"
 msgstr "Modalità endgame: passa a fonti più veloci per gli ultimi blocchi"
 
-#: src/muuli_wdr.cpp:1600
+#: src/muuli_wdr.cpp:1593
 msgid "Start next paused file when a file completes"
 msgstr "Quando un file viene completato inizia a scaricare il primo file in pausa"
 
-#: src/muuli_wdr.cpp:1603
+#: src/muuli_wdr.cpp:1596
 msgid "From the same category"
 msgstr "Della stessa categoria"
 
-#: src/muuli_wdr.cpp:1605
+#: src/muuli_wdr.cpp:1598
 msgid "In alphabetic order"
 msgstr "In ordine alfabetico"
 
-#: src/muuli_wdr.cpp:1607
+#: src/muuli_wdr.cpp:1600
 msgid "Preallocate disk space for new files"
 msgstr "Prealloca lo spazio su disco per i nuovi file"
 
-#: src/muuli_wdr.cpp:1608
+#: src/muuli_wdr.cpp:1601
 msgid "For new files preallocates disk space for the whole file, thus reduces fragmentation"
 msgstr "Per i nuovi file prealloca lo spazio su disco per l'intero file, in questo modo ridurrai la frammentazione"
 
-#: src/muuli_wdr.cpp:1613
+#: src/muuli_wdr.cpp:1606
+msgid "Create new files as sparse files"
+msgstr ""
+
+#: src/muuli_wdr.cpp:1607
+msgid "A sparse file reserves its full size on disk immediately without writing real data to it -- fast, but unsupported or slow on some filesystems, and free-space accounting stays optimistic while the download is in progress. Turn this off to grow the file only as data arrives."
+msgstr ""
+
+#: src/muuli_wdr.cpp:1612
 msgid "Stop downloads when free disk space reaches "
 msgstr "Interrompi i download quando termina lo spazio su disco "
 
-#: src/muuli_wdr.cpp:1614
+#: src/muuli_wdr.cpp:1613
 msgid "Select this if you want aMule to check your disk space"
 msgstr "Seleziona se vuoi che aMule controlli il tuo spazio su disco"
 
-#: src/muuli_wdr.cpp:1618
+#: src/muuli_wdr.cpp:1617
 msgid "Enter here the min disk space desired."
 msgstr "Inserire lo spazio disco minimo desiderato."
 
-#: src/muuli_wdr.cpp:1624
+#: src/muuli_wdr.cpp:1623
 msgid "Save 10 sources on rare files (< 20 sources)"
 msgstr "Salva 10 fonti per i file rari ( con < 20 fonti)"
 
-#: src/muuli_wdr.cpp:1628 src/Statistics.cpp:790
+#: src/muuli_wdr.cpp:1627 src/Statistics.cpp:790
 msgid "Uploads"
 msgstr "Upload"
 
-#: src/muuli_wdr.cpp:1631
+#: src/muuli_wdr.cpp:1630
 msgid "Add new shared files with auto priority"
 msgstr "Assegna priorità automatica ai nuovi file condivisi"
 
-#: src/muuli_wdr.cpp:1637
+#: src/muuli_wdr.cpp:1636
 msgid "Intelligent Corruption Handling (I.C.H.)"
 msgstr "Trattamento intelligente delle corruzioni (I.C.H.)"
 
-#: src/muuli_wdr.cpp:1640
+#: src/muuli_wdr.cpp:1639
 msgid "Enable"
 msgstr "Abilita"
 
-#: src/muuli_wdr.cpp:1643
+#: src/muuli_wdr.cpp:1642
 msgid "Advanced I.C.H. trusts every hash (not recommended)"
 msgstr "L'I.C.H. avanzato si fida di ogni hash (sconsigliato)"
 
-#: src/muuli_wdr.cpp:1655 src/PrefsUnifiedDlg.cpp:1990
+#: src/muuli_wdr.cpp:1654 src/PrefsUnifiedDlg.cpp:1910
 msgid "Media metadata extraction"
 msgstr "Estrazione dei metadati multimediali"
 
-#: src/muuli_wdr.cpp:1659
+#: src/muuli_wdr.cpp:1658
 msgid "Extract length / bitrate / codec from shared audio and video files"
 msgstr "Estrai durata / bitrate / codec dai file audio e video condivisi"
 
-#: src/muuli_wdr.cpp:1661
+#: src/muuli_wdr.cpp:1660
 msgid "When enabled, aMule runs ffprobe on each shared media file to fill in the Length / Bitrate / Codec columns other clients see when they find the file in a search. Requires ffmpeg (the ffprobe binary) to be installed."
 msgstr "Quando abilitato, aMule esegue ffprobe su ogni file multimediale condiviso per compilare le colonne Durata / Bitrate / Codec che gli altri client vedono quando trovano il file in una ricerca. Richiede l'installazione di ffmpeg (il binario ffprobe)."
 
-#: src/muuli_wdr.cpp:1668
+#: src/muuli_wdr.cpp:1667
 msgid "Path to ffprobe:"
 msgstr "Percorso di ffprobe:"
 
-#: src/muuli_wdr.cpp:1673
+#: src/muuli_wdr.cpp:1672
 msgid "Full path to the ffprobe binary. Leave empty to have aMule auto-detect it on startup."
 msgstr "Percorso completo del binario ffprobe. Lascia vuoto per far sì che aMule lo rilevi automaticamente all'avvio."
 
-#: src/muuli_wdr.cpp:1681
+#: src/muuli_wdr.cpp:1680
 msgid "Detect"
 msgstr "Rileva"
 
-#: src/muuli_wdr.cpp:1682
+#: src/muuli_wdr.cpp:1681
 msgid "Search the standard install locations for an ffprobe binary and fill the path field."
 msgstr "Cerca nei percorsi di installazione standard un binario ffprobe e compila il campo del percorso."
 
-#: src/muuli_wdr.cpp:1706
+#: src/muuli_wdr.cpp:1705
 msgid ""
 "Completed downloads are stored here. All files in this folder are automatically shared with other peers.\n"
 "If this folder also holds files you don't want to share, point it at an aMule-only sub-folder."
@@ -4164,688 +4153,665 @@ msgstr ""
 "Qui vengono salvati i download completati. Tutti i file in questa cartella sono condivisi automaticamente con gli altri peer.\n"
 "Se questa cartella contiene anche file che non vuoi condividere, impostala su una sottocartella riservata ad aMule."
 
-#: src/muuli_wdr.cpp:1709
+#: src/muuli_wdr.cpp:1708
 msgid "Pick the folder where completed downloads will be stored. All files in that folder will be shared with other peers."
 msgstr "Scegli la cartella in cui salvare i download completati. Tutti i file in quella cartella saranno condivisi con gli altri peer."
 
-#: src/muuli_wdr.cpp:1723
+#: src/muuli_wdr.cpp:1722
 msgid "Shared folders"
 msgstr "Cartelle condivise"
 
-#: src/muuli_wdr.cpp:1729
+#: src/muuli_wdr.cpp:1728
 msgid "(Folders shared by the core. Enter a path to add one.)"
 msgstr "(Cartelle condivise dal core. Inserisci un percorso per aggiungerne una.)"
 
-#: src/muuli_wdr.cpp:1737
+#: src/muuli_wdr.cpp:1736
 msgid "Absolute path of a folder on the core's machine, e.g. /home/user/shared"
 msgstr "Percorso assoluto di una cartella sulla macchina del core, ad es. /home/user/shared"
 
-#: src/muuli_wdr.cpp:1739 src/PrefsUnifiedDlg.cpp:2874
+#: src/muuli_wdr.cpp:1738 src/PrefsUnifiedDlg.cpp:2794
 msgid "Recursive"
 msgstr "Ricorsivo"
 
-#: src/muuli_wdr.cpp:1740
+#: src/muuli_wdr.cpp:1739
 msgid "Share every sub-folder underneath this one, including ones created later."
 msgstr "Condividi tutte le sottocartelle contenute in questa, comprese quelle create in seguito."
 
-#: src/muuli_wdr.cpp:1744 src/utils/aLinkCreator/src/alcframe.cpp:141
+#: src/muuli_wdr.cpp:1743 src/utils/aLinkCreator/src/alcframe.cpp:141
 msgid "Remove"
 msgstr "Rimuovi"
 
-#: src/muuli_wdr.cpp:1748
+#: src/muuli_wdr.cpp:1747
 msgid "(Right click on folder icon for recursive share)"
 msgstr "(fai click con il tasto destro sulle icone per condividere ricorsivamente le sottodirectory)"
 
-#: src/muuli_wdr.cpp:1755
+#: src/muuli_wdr.cpp:1754
 msgid "Share hidden files"
 msgstr "Condividi file nascosti"
 
-#: src/muuli_wdr.cpp:1761
+#: src/muuli_wdr.cpp:1760
 msgid "Automatically rescan shared folders for changes"
 msgstr "Ricontrolla automaticamente le modifiche nelle cartelle condivise"
 
-#: src/muuli_wdr.cpp:1767
+#: src/muuli_wdr.cpp:1766
 msgid "Follow symbolic links in shared folders"
 msgstr "Segui i collegamenti simbolici nelle cartelle condivise"
 
-#: src/muuli_wdr.cpp:1773
+#: src/muuli_wdr.cpp:1772
 msgid "Exclude files matching:"
 msgstr "Escludi i file corrispondenti a:"
 
-#: src/muuli_wdr.cpp:1776
+#: src/muuli_wdr.cpp:1775
 msgid "Wildcard patterns separated by '|', e.g. .DS_Store|Thumbs.db|*.tmp. Files whose name matches are not shared. Matching is case-insensitive."
 msgstr "Modelli con caratteri jolly separati da '|', ad es. .DS_Store|Thumbs.db|*.tmp. I file il cui nome corrisponde non vengono condivisi. La corrispondenza non distingue tra maiuscole e minuscole."
 
-#: src/muuli_wdr.cpp:1780
+#: src/muuli_wdr.cpp:1779
 msgid "Patterns are regular expressions"
 msgstr "I pattern sono espressioni regolari"
 
-#: src/muuli_wdr.cpp:1781
+#: src/muuli_wdr.cpp:1780
 msgid "When set, the whole field is one regular expression ('|' is alternation). When unset, it is a list of '|'-separated wildcards."
 msgstr "Se attivato, l'intero campo è un'unica espressione regolare ('|' indica l'alternanza). Se disattivato, è un elenco di caratteri jolly separati da '|'."
 
-#: src/muuli_wdr.cpp:1791
+#: src/muuli_wdr.cpp:1790
 msgid "Show how many shared files the current pattern would exclude."
 msgstr "Mostra quanti file condivisi verrebbero esclusi dal pattern attuale."
 
-#: src/muuli_wdr.cpp:1812
+#: src/muuli_wdr.cpp:1811
 msgid "Graphs"
 msgstr "Grafici"
 
-#: src/muuli_wdr.cpp:1815 src/muuli_wdr.cpp:1877
+#: src/muuli_wdr.cpp:1814 src/muuli_wdr.cpp:1876
 msgid "Update delay : 5 secs"
 msgstr "Intervallo di aggiornamento: 5 secondi"
 
-#: src/muuli_wdr.cpp:1819
+#: src/muuli_wdr.cpp:1818
 msgid "Time for average graph: 100 mins"
 msgstr "Intervallo grafico valori medi: 100 minuti"
 
-#: src/muuli_wdr.cpp:1823
+#: src/muuli_wdr.cpp:1822
 msgid "Connections Graph Scale: 100 "
 msgstr "Scala grafico connessioni: 100 "
 
-#: src/muuli_wdr.cpp:1830
+#: src/muuli_wdr.cpp:1829
 msgid "Download graph scale:"
 msgstr "Scala grafico di scaricamento:"
 
-#: src/muuli_wdr.cpp:1838
+#: src/muuli_wdr.cpp:1837
 msgid "Upload graph scale:"
 msgstr "Scala grafico d'invio:"
 
-#: src/muuli_wdr.cpp:1848
+#: src/muuli_wdr.cpp:1847
 msgid "Colors: "
 msgstr "Colori: "
 
-#: src/muuli_wdr.cpp:1852
+#: src/muuli_wdr.cpp:1851
 msgid "Background"
 msgstr "Sfondo"
 
-#: src/muuli_wdr.cpp:1853
+#: src/muuli_wdr.cpp:1852
 msgid "Grid"
 msgstr "Griglia"
 
-#: src/muuli_wdr.cpp:1854
+#: src/muuli_wdr.cpp:1853
 msgid "Download current"
 msgstr "Download attuale"
 
-#: src/muuli_wdr.cpp:1855
+#: src/muuli_wdr.cpp:1854
 msgid "Download running average"
 msgstr "Media download in corso"
 
-#: src/muuli_wdr.cpp:1856
+#: src/muuli_wdr.cpp:1855
 msgid "Download session average"
 msgstr "Media sessione di download"
 
-#: src/muuli_wdr.cpp:1857
+#: src/muuli_wdr.cpp:1856
 msgid "Upload current"
 msgstr "Upload attuale"
 
-#: src/muuli_wdr.cpp:1858
+#: src/muuli_wdr.cpp:1857
 msgid "Upload running average"
 msgstr "Media upload in corso"
 
-#: src/muuli_wdr.cpp:1859
+#: src/muuli_wdr.cpp:1858
 msgid "Upload session average"
 msgstr "Media sessione di upload"
 
-#: src/muuli_wdr.cpp:1860
+#: src/muuli_wdr.cpp:1859
 msgid "Active connections"
 msgstr "Connessioni attive"
 
-#: src/muuli_wdr.cpp:1863
+#: src/muuli_wdr.cpp:1862
 msgid "Systray Icon Speed Bar"
 msgstr "Barra della velocità nell'icona sulla barra di sistema"
 
-#: src/muuli_wdr.cpp:1864
+#: src/muuli_wdr.cpp:1863
 msgid "Kad-nodes current"
 msgstr "Nodi Kad attuali"
 
-#: src/muuli_wdr.cpp:1865
+#: src/muuli_wdr.cpp:1864
 msgid "Kad-nodes running"
 msgstr "Nodi Kad attivi"
 
-#: src/muuli_wdr.cpp:1866
+#: src/muuli_wdr.cpp:1865
 msgid "Kad-nodes session"
 msgstr "Nodi Kad nella sessione"
 
-#: src/muuli_wdr.cpp:1870 src/muuli_wdr.cpp:2324
+#: src/muuli_wdr.cpp:1869 src/muuli_wdr.cpp:2296
 msgid "Select"
 msgstr "Seleziona"
 
-#: src/muuli_wdr.cpp:1874
+#: src/muuli_wdr.cpp:1873
 msgid "Tree"
 msgstr "Albero"
 
-#: src/muuli_wdr.cpp:1884
+#: src/muuli_wdr.cpp:1883
 msgid "Number of Client Versions shown (0=unlimited)"
 msgstr "Numero di versioni di client visualizzate (0=illimitate)"
 
-#: src/muuli_wdr.cpp:1909
+#: src/muuli_wdr.cpp:1908
 msgid "!!! WARNING !!!"
 msgstr "!!! ATTENZIONE !!!"
 
-#: src/muuli_wdr.cpp:1924
+#: src/muuli_wdr.cpp:1923
 msgid "Max new connections / 5 secs"
 msgstr "Numero massimo nuove connessioni / 5 secondi"
 
-#: src/muuli_wdr.cpp:1926
+#: src/muuli_wdr.cpp:1925
 msgid "Concurrent Kad source lookups"
 msgstr "Ricerche di fonti Kad simultanee"
 
-#: src/muuli_wdr.cpp:1928
+#: src/muuli_wdr.cpp:1927
 msgid "Kad source re-search interval (minutes)"
 msgstr "Intervallo tra le ricerche di fonti Kad (minuti)"
 
-#: src/muuli_wdr.cpp:1930
+#: src/muuli_wdr.cpp:1929
 msgid "Source re-ask interval (minutes)"
 msgstr "Intervallo tra le richieste alle fonti (minuti)"
 
-#: src/muuli_wdr.cpp:1934
+#: src/muuli_wdr.cpp:1933
 msgid "File Buffer Size: 240000 bytes"
 msgstr "Dimensione buffer file: 240000 byte"
 
-#: src/muuli_wdr.cpp:1938
+#: src/muuli_wdr.cpp:1937
 msgid "Use MMAP: memory-mapped file access (lower memory use)"
 msgstr "Usa MMAP: accesso ai file mappato in memoria (minor uso di memoria)"
 
-#: src/muuli_wdr.cpp:1939
+#: src/muuli_wdr.cpp:1938
 msgid "Maps part files into memory instead of buffering them on the heap, lowering the process memory footprint. May reduce download speed on some disks; best for memory-constrained or upload-heavy hosts."
 msgstr "Mappa i file parziali in memoria invece di bufferizzarli nell'heap, riducendo l'occupazione di memoria del processo. Potrebbe ridurre la velocità di download su alcuni dischi; ideale per sistemi con memoria limitata o con molto traffico in upload."
 
-#: src/muuli_wdr.cpp:1941
+#: src/muuli_wdr.cpp:1940
 msgid "Upload Queue Size: 5000 clients"
 msgstr "Dimensione coda upload: 5000 client"
 
-#: src/muuli_wdr.cpp:1945
+#: src/muuli_wdr.cpp:1944
 msgid "Server connection refresh interval: Disable"
 msgstr "Intervallo aggiornamento connessione al server: disabilitato"
 
-#: src/muuli_wdr.cpp:1949
+#: src/muuli_wdr.cpp:1948
 msgid "Disable computer's timed standby mode"
 msgstr "Disabilita la modalità standby a tempo"
 
-#: src/muuli_wdr.cpp:1968
+#: src/muuli_wdr.cpp:1967
 msgid "Skin to use: "
 msgstr "Skin da usare: "
 
-#: src/muuli_wdr.cpp:1977
+#: src/muuli_wdr.cpp:1976
 msgid "Show \"Fast eD2k Links Handler\" in every window."
 msgstr "Mostra il \"Gestore rapido dei collegamenti eD2k\" in ogni finestra."
 
-#: src/muuli_wdr.cpp:1980
+#: src/muuli_wdr.cpp:1979
 msgid "Show extended info on categories tabs"
 msgstr "Mostra informazioni estese sulle schede delle categorie"
 
-#: src/muuli_wdr.cpp:1983
+#: src/muuli_wdr.cpp:1982
 msgid "Show application version on title"
 msgstr "Mostra versione dell'applicazione nella barra del titolo"
 
-#: src/muuli_wdr.cpp:1985
+#: src/muuli_wdr.cpp:1984
 msgid "Show transfer rates on title"
 msgstr "Mostra velocità di trasferimento nella barra del titolo"
 
-#: src/muuli_wdr.cpp:1987
+#: src/muuli_wdr.cpp:1986
 msgid "Before application name"
 msgstr "Prima del nome dell'applicazione"
 
-#: src/muuli_wdr.cpp:1989
+#: src/muuli_wdr.cpp:1988
 msgid "After application name"
 msgstr "Dopo il nome dell'applicazione"
 
-#: src/muuli_wdr.cpp:1992
+#: src/muuli_wdr.cpp:1991
 msgid "Show overhead bandwidth"
 msgstr "Mostra l'overhead di banda"
 
-#: src/muuli_wdr.cpp:1996
+#: src/muuli_wdr.cpp:1995
 msgid "Vertical toolbar orientation"
 msgstr "Orientamento verticale della barra degli strumenti"
 
-#: src/muuli_wdr.cpp:1998
+#: src/muuli_wdr.cpp:1997
 msgid "Live column sorting (auto-reorder rows as their values change)"
 msgstr "Ordinamento colonne in tempo reale (riordina le righe automaticamente al variare dei loro valori)"
 
-#: src/muuli_wdr.cpp:2005
+#: src/muuli_wdr.cpp:2004
 msgid "Download Queue Files"
 msgstr "Scaricamento dei file in coda"
 
-#: src/muuli_wdr.cpp:2008
+#: src/muuli_wdr.cpp:2007
 msgid "Show progress percentage"
 msgstr "Mostra la percentuale di avanzamento"
 
-#: src/muuli_wdr.cpp:2014
+#: src/muuli_wdr.cpp:2013
 msgid "Show progress bar"
 msgstr "Mostra la barra di avanzamento"
 
-#: src/muuli_wdr.cpp:2017
+#: src/muuli_wdr.cpp:2016
 msgid "Flat"
 msgstr "Piatta"
 
-#: src/muuli_wdr.cpp:2021
+#: src/muuli_wdr.cpp:2020
 msgid "Round"
 msgstr "Arrotondata"
 
-#: src/muuli_wdr.cpp:2039
+#: src/muuli_wdr.cpp:2038
 msgid "External Connection Parameters"
 msgstr "Parametri connessioni esterne"
 
-#: src/muuli_wdr.cpp:2042
+#: src/muuli_wdr.cpp:2041
 msgid "Accept external connections"
 msgstr "Accetta connessioni esterne"
 
-#: src/muuli_wdr.cpp:2049 src/muuli_wdr.cpp:2108
+#: src/muuli_wdr.cpp:2048 src/muuli_wdr.cpp:2107
 msgid "IP of the listening interface:"
 msgstr "IP dell'interfaccia di ascolto:"
 
-#: src/muuli_wdr.cpp:2052
+#: src/muuli_wdr.cpp:2051
 msgid "Enter here a valid ip in the a.b.c.d format for the listening EC interface. An empty field or 0.0.0.0 will mean any interface."
 msgstr "Inserisci un IP valido nel formato a.b.c.d per l'interfaccia di ascolto EC. Lasciare il campo vuoto o inserire 0.0.0.0 significa qualsiasi interfaccia."
 
-#: src/muuli_wdr.cpp:2073 src/muuli_wdr.cpp:2184
+#: src/muuli_wdr.cpp:2072 src/muuli_wdr.cpp:2156
 msgid "TCP port:"
 msgstr "Porta TCP:"
 
-#: src/muuli_wdr.cpp:2079
+#: src/muuli_wdr.cpp:2078
 msgid "Enable UPnP port forwarding on the EC port"
 msgstr "Abilita il port forwarding tramite UPnP sulla porta EC"
 
-#: src/muuli_wdr.cpp:2083 src/muuli_wdr.cpp:3069
+#: src/muuli_wdr.cpp:2082 src/muuli_wdr.cpp:3041
 #: src/utils/wxCas/src/wxcasprefs.cpp:167
 msgid "Password"
 msgstr "Password"
 
-#: src/muuli_wdr.cpp:2089
+#: src/muuli_wdr.cpp:2088
 msgid "aMule API server parameters"
 msgstr "Parametri del server API di aMule"
 
-#: src/muuli_wdr.cpp:2092
+#: src/muuli_wdr.cpp:2091
 msgid "Run amuleapi (REST API) on startup"
 msgstr "Avvia amuleapi (REST API) all'avvio"
 
-#: src/muuli_wdr.cpp:2097
+#: src/muuli_wdr.cpp:2096
 msgid "HTTP port:"
 msgstr "Porta HTTP:"
 
-#: src/muuli_wdr.cpp:2111
+#: src/muuli_wdr.cpp:2110
 msgid "The interface amuleapi's HTTP server listens on. 127.0.0.1 (default) accepts only local connections; use 0.0.0.0 or a specific IP to expose it to other hosts (set an admin password below)."
 msgstr "L'interfaccia su cui è in ascolto il server HTTP di amuleapi. 127.0.0.1 (predefinito) accetta solo connessioni locali; usa 0.0.0.0 o un IP specifico per esporlo ad altri host (imposta una password di amministrazione qui sotto)."
 
-#: src/muuli_wdr.cpp:2116
-msgid "Type a password to set or change it. Stored passwords cannot be shown, so leaving this empty keeps the current one."
-msgstr ""
-
-#: src/muuli_wdr.cpp:2118
+#: src/muuli_wdr.cpp:2113
 msgid "Admin password"
 msgstr "Password amministrazione"
 
-#: src/muuli_wdr.cpp:2130 src/muuli_wdr.cpp:2147 src/PrefsUnifiedDlg.cpp:1103
-#, fuzzy
-msgid "A password is set."
-msgstr "Password amministrazione"
-
-#: src/muuli_wdr.cpp:2134
-#, fuzzy
-msgid "Enable guest access"
-msgstr "Vieta l'accesso guest"
-
-#: src/muuli_wdr.cpp:2135
-msgid "Guest sessions may read status and listings but cannot change anything. Turning this off clears the stored guest password."
-msgstr ""
-
-#: src/muuli_wdr.cpp:2139
-#, fuzzy
-msgid "Guest password"
-msgstr "Password per l'accesso Guest al web server"
-
-#: src/muuli_wdr.cpp:2154
-msgid "Web server parameters"
-msgstr "Parametri del server web"
-
-#: src/muuli_wdr.cpp:2157
-msgid "Run webserver on startup (deprecated)"
-msgstr "Lancia il webserver all'avvio (deprecato)"
-
-#: src/muuli_wdr.cpp:2163
-msgid "Web template"
-msgstr "Template web"
-
-#: src/muuli_wdr.cpp:2168
-msgid "Full rights password"
-msgstr "Password per diritti completi"
-
-#: src/muuli_wdr.cpp:2172
-msgid "Enable Low rights User"
-msgstr "Abilita utente con diritti limitati"
-
-#: src/muuli_wdr.cpp:2177
+#: src/muuli_wdr.cpp:2118 src/muuli_wdr.cpp:2149
 msgid "Low rights password"
 msgstr "Password per diritti limitati"
 
-#: src/muuli_wdr.cpp:2191
+#: src/muuli_wdr.cpp:2126
+msgid "Web server parameters"
+msgstr "Parametri del server web"
+
+#: src/muuli_wdr.cpp:2129
+msgid "Run webserver on startup (deprecated)"
+msgstr "Lancia il webserver all'avvio (deprecato)"
+
+#: src/muuli_wdr.cpp:2135
+msgid "Web template"
+msgstr "Template web"
+
+#: src/muuli_wdr.cpp:2140
+msgid "Full rights password"
+msgstr "Password per diritti completi"
+
+#: src/muuli_wdr.cpp:2144
+msgid "Enable Low rights User"
+msgstr "Abilita utente con diritti limitati"
+
+#: src/muuli_wdr.cpp:2163
 msgid "Enable UPnP port forwarding of the web server port"
 msgstr "Abilita port forwarding tramite UPnP sulla porta del server web"
 
-#: src/muuli_wdr.cpp:2196
+#: src/muuli_wdr.cpp:2168
 msgid "Web server UPnP TCP port (Optional)"
 msgstr "Porta TCP del  server web per UPnP (Facoltativa)"
 
-#: src/muuli_wdr.cpp:2204
+#: src/muuli_wdr.cpp:2176
 msgid "Page Refresh Time (in secs)"
 msgstr "Intervallo di aggiornamento pagina (in sec)"
 
-#: src/muuli_wdr.cpp:2211
+#: src/muuli_wdr.cpp:2183
 msgid "Enable Gzip compression"
 msgstr "Abilita compressione gzip"
 
-#: src/muuli_wdr.cpp:2245
+#: src/muuli_wdr.cpp:2217
 msgid "Reset page to defaults"
 msgstr "Ripristina i valori predefiniti della pagina"
 
-#: src/muuli_wdr.cpp:2246
+#: src/muuli_wdr.cpp:2218
 msgid "Reset the settings on the current page to their default values."
 msgstr "Ripristina le impostazioni della pagina corrente ai loro valori predefiniti."
 
-#: src/muuli_wdr.cpp:2248 src/muuli_wdr.cpp:2334 src/ServerWnd.cpp:274
+#: src/muuli_wdr.cpp:2220 src/muuli_wdr.cpp:2306 src/ServerWnd.cpp:274
 #: src/ServerWnd.cpp:282
 msgid "OK"
 msgstr "OK"
 
-#: src/muuli_wdr.cpp:2250
+#: src/muuli_wdr.cpp:2222
 msgid "Click here to apply any changes made to the preferences."
 msgstr "Fai click qui per applicare le modifiche apportate alle impostazioni."
 
-#: src/muuli_wdr.cpp:2253
+#: src/muuli_wdr.cpp:2225
 msgid "Reset any changes made to the preferences."
 msgstr "Annulla ogni modifica alle preferenze."
 
-#: src/muuli_wdr.cpp:2282
+#: src/muuli_wdr.cpp:2254
 msgid "Comment :"
 msgstr "Commento:"
 
-#: src/muuli_wdr.cpp:2289
+#: src/muuli_wdr.cpp:2261
 msgid "Incoming Dir :"
 msgstr "Directory file scaricati:"
 
-#: src/muuli_wdr.cpp:2298
+#: src/muuli_wdr.cpp:2270
 msgid "Change priority for new assigned files :"
 msgstr "Cambia priorità per i nuovi file assegnati:"
 
-#: src/muuli_wdr.cpp:2302
+#: src/muuli_wdr.cpp:2274
 msgid "Don't change"
 msgstr "Non modificare"
 
-#: src/muuli_wdr.cpp:2314
+#: src/muuli_wdr.cpp:2286
 msgid "Select color for this Category (currently selected) :"
 msgstr "Seleziona colore per questa categoria (attualmente selezionata):"
 
-#: src/muuli_wdr.cpp:2381 src/muuli_wdr.cpp:2400 src/muuli_wdr.cpp:2422
+#: src/muuli_wdr.cpp:2353 src/muuli_wdr.cpp:2372 src/muuli_wdr.cpp:2394
 msgid "Click this button to reset the log."
 msgstr "Fai clic su questo pulsante per cancellare i log."
 
-#: src/muuli_wdr.cpp:2441
+#: src/muuli_wdr.cpp:2413
 msgid "Click on this button to update the servers list from URL ..."
 msgstr "Fai clic qui per aggiornare la lista dei server dall'indirizzo..."
 
-#: src/muuli_wdr.cpp:2445
+#: src/muuli_wdr.cpp:2417
 msgid "Server list"
 msgstr "Lista server"
 
-#: src/muuli_wdr.cpp:2449
+#: src/muuli_wdr.cpp:2421
 msgid "Enter the url to a server.met file here and press the button to the left to update the list of known servers."
 msgstr "Inserisci l'url di un file server.met e premi il pulsante a sinistra per aggiornare la lista dei server conosciuti."
 
-#: src/muuli_wdr.cpp:2454
+#: src/muuli_wdr.cpp:2426
 msgid "Add server manually: Name"
 msgstr "Aggiungi un server manualmente: Nome"
 
-#: src/muuli_wdr.cpp:2457
+#: src/muuli_wdr.cpp:2429
 msgid "Enter the name of the new server here"
 msgstr "Inserisci qui il nome di un nuovo server"
 
-#: src/muuli_wdr.cpp:2459 src/ServerWnd.cpp:206
+#: src/muuli_wdr.cpp:2431 src/ServerWnd.cpp:206
 msgid "IP:Port"
 msgstr "IP:Porta"
 
-#: src/muuli_wdr.cpp:2462
+#: src/muuli_wdr.cpp:2434
 msgid "Enter the IP of the server here, using the x.x.x.x format."
 msgstr "Inserisci qui l'IP del server, nel formato x.x.x.x."
 
-#: src/muuli_wdr.cpp:2468
+#: src/muuli_wdr.cpp:2440
 msgid "Enter the port of the server here."
 msgstr "Inserisci qui la porta del server."
 
-#: src/muuli_wdr.cpp:2471
+#: src/muuli_wdr.cpp:2443
 msgid "Add manually a server (fill fields to the left before) ..."
 msgstr "Aggiungi server (riempi campi a sinistra)..."
 
-#: src/muuli_wdr.cpp:2500
+#: src/muuli_wdr.cpp:2472
 msgid "aMule Log"
 msgstr "log di aMule"
 
-#: src/muuli_wdr.cpp:2508
+#: src/muuli_wdr.cpp:2480
 msgid "Server Info"
 msgstr "Informazioni server"
 
-#: src/muuli_wdr.cpp:2512
+#: src/muuli_wdr.cpp:2484
 msgid "ED2K Info"
 msgstr "Informazioni ed2k"
 
-#: src/muuli_wdr.cpp:2516
+#: src/muuli_wdr.cpp:2488
 msgid "Kad Info"
 msgstr "Informazioni Kad"
 
-#: src/muuli_wdr.cpp:2544
+#: src/muuli_wdr.cpp:2516
 msgid "Click on this button to update the nodes list from URL ..."
 msgstr "Fai clic su questo pulsante per aggiornare la lista nodi da un URL..."
 
-#: src/muuli_wdr.cpp:2548
+#: src/muuli_wdr.cpp:2520
 msgid "Nodes (0)"
 msgstr "Nodi (0)"
 
-#: src/muuli_wdr.cpp:2552
+#: src/muuli_wdr.cpp:2524
 msgid "Enter the url to a nodes.dat file here and press the button to the left to update the list of known nodes."
 msgstr "Inserisci l'URL di un file nodes.dat e premi il pulsante a sinistra per aggiornare la lista dei nodi conosciuti."
 
-#: src/muuli_wdr.cpp:2555
+#: src/muuli_wdr.cpp:2527
 msgid "Nodes stats"
 msgstr "Statistiche nodi"
 
-#: src/muuli_wdr.cpp:2597
+#: src/muuli_wdr.cpp:2569
 msgid "Bootstrap"
 msgstr "Bootstrap"
 
-#: src/muuli_wdr.cpp:2600
+#: src/muuli_wdr.cpp:2572
 msgid "New node"
 msgstr "Nuovo nodo"
 
-#: src/muuli_wdr.cpp:2605
+#: src/muuli_wdr.cpp:2577
 msgid "IP:"
 msgstr "IP:"
 
-#: src/muuli_wdr.cpp:2625
+#: src/muuli_wdr.cpp:2597
 msgid "Port:"
 msgstr "Porta:"
 
-#: src/muuli_wdr.cpp:2638
+#: src/muuli_wdr.cpp:2610
 msgid "Bootstrap from known clients"
 msgstr "Bootstrap dai client noti"
 
-#: src/muuli_wdr.cpp:2640
+#: src/muuli_wdr.cpp:2612
 msgid "Disconnect Kad"
 msgstr "Disconnetti rete Kad"
 
-#: src/muuli_wdr.cpp:2674
+#: src/muuli_wdr.cpp:2646
 msgid "Use Secure User Identification"
 msgstr "Usa identificazione sicura"
 
-#: src/muuli_wdr.cpp:2676
+#: src/muuli_wdr.cpp:2648
 msgid "It is recommended to enable this option. You will not receive credits if SUI is not enabled."
 msgstr "È consigliato attivare questa opzione. Non riceverai crediti se \" \"l'identificazione non sarà abilitata."
 
-#: src/muuli_wdr.cpp:2678
+#: src/muuli_wdr.cpp:2650
 msgid "Protocol Obfuscation"
 msgstr "Offuscamento del protocollo"
 
-#: src/muuli_wdr.cpp:2681
+#: src/muuli_wdr.cpp:2653
 msgid "Support Protocol Obfuscation"
 msgstr "Supporta offuscamento del protocollo"
 
-#: src/muuli_wdr.cpp:2683
+#: src/muuli_wdr.cpp:2655
 msgid "This option enabled Protocol Obfuscation, and makes aMule accept obfuscated connections from other clients."
 msgstr "Questa opzione abilita l'offuscamento del protocollo, e fa sì che aMule accetti connessioni offuscate dagli altri client."
 
-#: src/muuli_wdr.cpp:2685
+#: src/muuli_wdr.cpp:2657
 msgid "Use obfuscation for outgoing connections"
 msgstr "Utilizza offuscamento per le connessioni in uscita"
 
-#: src/muuli_wdr.cpp:2687
+#: src/muuli_wdr.cpp:2659
 msgid "This option makes aMule use Protocol Obfuscation when connecting other clients/servers."
 msgstr "Questa opzione fa sì che aMule utilizzi l'offuscamento del protocollo quando si collega ad altri client/server."
 
-#: src/muuli_wdr.cpp:2689
+#: src/muuli_wdr.cpp:2661
 msgid "Accept only obfuscated connections"
 msgstr "Accetta SOLO connessioni offuscate"
 
-#: src/muuli_wdr.cpp:2690
+#: src/muuli_wdr.cpp:2662
 msgid "This option makes aMule only accept obfuscated connections. You will have less sources, but all your traffic will be obfuscated"
 msgstr "Attivando questa opzione aMule accetterà solo connessioni offuscate. Avrai meno fonti, ma tutto il tuo traffico sarà offuscato"
 
-#: src/muuli_wdr.cpp:2695
+#: src/muuli_wdr.cpp:2667
 msgid "Everybody"
 msgstr "Chiunque"
 
-#: src/muuli_wdr.cpp:2697
+#: src/muuli_wdr.cpp:2669
 msgid "No one"
 msgstr "Nessuno"
 
-#: src/muuli_wdr.cpp:2699
+#: src/muuli_wdr.cpp:2671
 msgid "Who can see my shared files:"
 msgstr "Chi può vedere i miei file condivisi:"
 
-#: src/muuli_wdr.cpp:2700
+#: src/muuli_wdr.cpp:2672
 msgid "Select who can request to view a list of your shared files."
 msgstr "Seleziona chi può richiedere di vedere la lista dei tuoi file condivisi."
 
-#: src/muuli_wdr.cpp:2702
+#: src/muuli_wdr.cpp:2674
 msgid "IP-Filtering"
 msgstr "Filtraggio IP"
 
-#: src/muuli_wdr.cpp:2709
+#: src/muuli_wdr.cpp:2681
 msgid "Filter clients"
 msgstr "Filtra i client"
 
-#: src/muuli_wdr.cpp:2711
+#: src/muuli_wdr.cpp:2683
 msgid "Enable filtering of the client IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "Filtra i client in base agli ip contenuti in ~/.aMule/ipfilter.dat."
 
-#: src/muuli_wdr.cpp:2713
+#: src/muuli_wdr.cpp:2685
 msgid "Filter servers"
 msgstr "Filtra i server"
 
-#: src/muuli_wdr.cpp:2715
+#: src/muuli_wdr.cpp:2687
 msgid "Enable filtering of the server IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "Filtra i server in base agli ip contenuti in ~/.aMule/ipfilter.dat."
 
-#: src/muuli_wdr.cpp:2719
+#: src/muuli_wdr.cpp:2691
 msgid "Reload List"
 msgstr "Ricarica lista"
 
-#: src/muuli_wdr.cpp:2720
+#: src/muuli_wdr.cpp:2692
 msgid "Reload the list of IPs to filter from the file ~/.aMule/ipfilter.dat"
 msgstr "Ricarica lista degli IP da filtrare dal file ~/.aMule/ipfilter.dat"
 
-#: src/muuli_wdr.cpp:2726
+#: src/muuli_wdr.cpp:2698
 msgid "URL:"
 msgstr "URL:"
 
-#: src/muuli_wdr.cpp:2730 src/muuli_wdr.cpp:2923
+#: src/muuli_wdr.cpp:2702 src/muuli_wdr.cpp:2895
 msgid "Update now"
 msgstr "Aggiorna ora"
 
-#: src/muuli_wdr.cpp:2733
+#: src/muuli_wdr.cpp:2705
 msgid "Auto-update ipfilter at startup"
 msgstr "Aggiorna ipfilter all'avvio"
 
-#: src/muuli_wdr.cpp:2737
+#: src/muuli_wdr.cpp:2709
 msgid "Filtering Level:"
 msgstr "Livello filtraggio:"
 
-#: src/muuli_wdr.cpp:2743
+#: src/muuli_wdr.cpp:2715
 msgid "Always filter LAN IPs"
 msgstr "Filtra sempre gli IP di una LAN"
 
-#: src/muuli_wdr.cpp:2746
+#: src/muuli_wdr.cpp:2718
 msgid "Paranoid handling of non-matching IPs"
 msgstr "Gestione paranoica degli IP non corrispondenti"
 
-#: src/muuli_wdr.cpp:2748
+#: src/muuli_wdr.cpp:2720
 msgid "Rejects a packet when its source IP differs from the IP the client claims (an anti-spoofing check). Disable only if it causes connection problems."
 msgstr "Rifiuta un pacchetto quando l'IP di origine è diverso dall'IP dichiarato dal client (un controllo anti-spoofing). Disabilitare solo se causa problemi di connessione."
 
-#: src/muuli_wdr.cpp:2750
+#: src/muuli_wdr.cpp:2722
 msgid "Use system-wide ipfilter.dat if available"
 msgstr "Usa l'ipfilter.dat di sistema se disponibile"
 
-#: src/muuli_wdr.cpp:2751
+#: src/muuli_wdr.cpp:2723
 msgid "If there's no local ipfilter.dat found, allow usage of a system-wide ipfilter file."
 msgstr "Se un file ipfilter.dat locale non viene trovato, consenti l'utilizzo del file ipfilter.dat di sistema."
 
-#: src/muuli_wdr.cpp:2768
+#: src/muuli_wdr.cpp:2740
 msgid "Enable Online-Signature"
 msgstr "Abilita Online Signature"
 
-#: src/muuli_wdr.cpp:2770
+#: src/muuli_wdr.cpp:2742
 msgid "Enables the writing of the OS file, which can be used by external apps to create signatures and the like."
 msgstr "Abilita la scrittura del file OS che può essere usato da applicazioni esterne per creare firme e simili."
 
-#: src/muuli_wdr.cpp:2774
+#: src/muuli_wdr.cpp:2746
 msgid "Update Frequency (Secs):"
 msgstr "Frequenza di aggiornamento (secondi):"
 
-#: src/muuli_wdr.cpp:2777
+#: src/muuli_wdr.cpp:2749
 msgid "Change the frequency (in seconds) of Online Signature updates."
 msgstr "Cambia la frequenza (in secondi) degli aggiornamenti dell'Online Signature."
 
-#: src/muuli_wdr.cpp:2785
+#: src/muuli_wdr.cpp:2757
 msgid "Save online signature file in: "
 msgstr "Salva la firma in linea in: "
 
-#: src/muuli_wdr.cpp:2791
+#: src/muuli_wdr.cpp:2763
 msgid "Click here to select the directory containing the the Online Signature files."
 msgstr "Clicca qui per selezionare la directory che contiene i file dell'Online Signature."
 
-#: src/muuli_wdr.cpp:2824
+#: src/muuli_wdr.cpp:2796
 msgid "Show country flags for clients"
 msgstr "Mostra la nazionalità dei client"
 
-#: src/muuli_wdr.cpp:2825
+#: src/muuli_wdr.cpp:2797
 msgid "Render the country flag column in the transfers, queue and search views. Requires a valid MMDB GeoIP database (see below)."
 msgstr "Mostra la colonna delle bandiere dei paesi nelle viste trasferimenti, coda e ricerca. Richiede un database GeoIP MMDB valido (vedi sotto)."
 
-#: src/muuli_wdr.cpp:2830
+#: src/muuli_wdr.cpp:2802
 msgid "Database"
 msgstr "Database"
 
-#: src/muuli_wdr.cpp:2846
+#: src/muuli_wdr.cpp:2818
 msgid "Source:"
 msgstr "Sorgente:"
 
-#: src/muuli_wdr.cpp:2849
+#: src/muuli_wdr.cpp:2821
 msgid "DB-IP (free, no account)"
 msgstr "DB-IP (gratuito, nessun account)"
 
-#: src/muuli_wdr.cpp:2850
+#: src/muuli_wdr.cpp:2822
 msgid "MaxMind GeoLite2 (free, account required)"
 msgstr "MaxMind GeoLite2 (gratuito, richiede account)"
 
-#: src/muuli_wdr.cpp:2851
+#: src/muuli_wdr.cpp:2823
 msgid "Custom URL"
 msgstr "URL personalizzato"
 
-#: src/muuli_wdr.cpp:2854
+#: src/muuli_wdr.cpp:2826
 msgid "Choose which provider supplies the GeoIP MMDB database. DB-IP is the default - no account required. MaxMind requires a free account + license key. Use Custom URL to point at any other MMDB host (e.g. a local mirror)."
 msgstr "Scegli quale provider fornisce il database GeoIP MMDB. DB-IP è il default - nessun account richiesto. MaxMind richiede un account gratuito + license key. Usa URL personalizzato per puntare a qualsiasi altro host MMDB (es. un mirror locale)."
 
-#: src/muuli_wdr.cpp:2871
+#: src/muuli_wdr.cpp:2843
 msgid ""
 "No configuration required.\n"
 "\n"
@@ -4857,11 +4823,11 @@ msgstr ""
 "Dati IP-to-Country di DB-IP.com - https://db-ip.com\n"
 "Licenza: Creative Commons BY 4.0 - https://creativecommons.org/licenses/by/4.0/"
 
-#: src/muuli_wdr.cpp:2884
+#: src/muuli_wdr.cpp:2856
 msgid "License key:"
 msgstr "License key:"
 
-#: src/muuli_wdr.cpp:2890
+#: src/muuli_wdr.cpp:2862
 msgid ""
 "Sign up for a free MaxMind account, then generate a License Key:\n"
 "https://www.maxmind.com/en/geolite2/signup\n"
@@ -4877,11 +4843,11 @@ msgstr ""
 "Licenza: MaxMind GeoLite2 EULA - https://www.maxmind.com/en/geolite2/eula\n"
 "Richiede attribuzione e registrazione dell'account; aggiornare almeno ogni 30 giorni."
 
-#: src/muuli_wdr.cpp:2905
+#: src/muuli_wdr.cpp:2877
 msgid "Download URL:"
 msgstr "URL di scaricamento:"
 
-#: src/muuli_wdr.cpp:2911
+#: src/muuli_wdr.cpp:2883
 msgid ""
 "Must point to an .mmdb file or a .gz / .tar.gz containing one.\n"
 "URL may include credentials (https://user:pass@host/...).\n"
@@ -4891,211 +4857,211 @@ msgstr ""
 "L'URL può includere credenziali (https://user:pass@host/...).\n"
 "I termini di licenza e attribuzione sono definiti dall'URL upstream - ne sei responsabile."
 
-#: src/muuli_wdr.cpp:2924
+#: src/muuli_wdr.cpp:2896
 msgid "Download the GeoIP database from the selected source."
 msgstr "Scarica il database GeoIP dalla sorgente selezionata."
 
-#: src/muuli_wdr.cpp:2926
+#: src/muuli_wdr.cpp:2898
 msgid "Auto-update on startup"
 msgstr "Aggiornamento automatico all'avvio"
 
-#: src/muuli_wdr.cpp:2927
+#: src/muuli_wdr.cpp:2899
 msgid "Re-download the GeoIP database from the selected source every time aMule starts."
 msgstr "Riscarica il database GeoIP dalla sorgente selezionata ogni volta che aMule si avvia."
 
-#: src/muuli_wdr.cpp:2950
+#: src/muuli_wdr.cpp:2922
 msgid "Filter incoming messages (except current chat):"
 msgstr "Filtra messaggi in arrivo (tranne per la chat in corso):"
 
-#: src/muuli_wdr.cpp:2952
+#: src/muuli_wdr.cpp:2924
 msgid "Filter all messages"
 msgstr "Filtra tutti i messaggi"
 
-#: src/muuli_wdr.cpp:2954
+#: src/muuli_wdr.cpp:2926
 msgid "Filter messages from people not on your friend list"
 msgstr "Filtra i messaggi da utenti che non sono nella tua lista degli amici"
 
-#: src/muuli_wdr.cpp:2956
+#: src/muuli_wdr.cpp:2928
 msgid "Filter messages from unknown clients"
 msgstr "Filtra i messaggi da client sconosciuti"
 
-#: src/muuli_wdr.cpp:2958
+#: src/muuli_wdr.cpp:2930
 msgid "Filter messages containing (use ',' as separator):"
 msgstr "Filtra i messaggi che contengono (usa ',' come separatore):"
 
-#: src/muuli_wdr.cpp:2961 src/muuli_wdr.cpp:2972
+#: src/muuli_wdr.cpp:2933 src/muuli_wdr.cpp:2944
 msgid "add here the words amule should filter and block messages including it"
 msgstr "aggiungi qui le parole che aMule filtrerà rimuovendo i messaggi che le contengono"
 
-#: src/muuli_wdr.cpp:2963
+#: src/muuli_wdr.cpp:2935
 msgid "Show received messages in the log"
 msgstr "Mostra nel log i messaggi ricevuti"
 
-#: src/muuli_wdr.cpp:2966
+#: src/muuli_wdr.cpp:2938
 msgid "Comments"
 msgstr "Commenti"
 
-#: src/muuli_wdr.cpp:2969
+#: src/muuli_wdr.cpp:2941
 msgid "Filter comments containing (use ',' as separator):"
 msgstr "Filtra i commenti contenenti (usa ',' come separatore):"
 
-#: src/muuli_wdr.cpp:2994
+#: src/muuli_wdr.cpp:2966
 msgid "Enable Proxy"
 msgstr "Abilita proxy"
 
-#: src/muuli_wdr.cpp:2995
+#: src/muuli_wdr.cpp:2967
 msgid "Enable/disable proxy support"
 msgstr "Abilita o disabilita il supporto proxy"
 
-#: src/muuli_wdr.cpp:2998
+#: src/muuli_wdr.cpp:2970
 msgid "Proxy type:"
 msgstr "Tipo proxy:"
 
-#: src/muuli_wdr.cpp:3009
+#: src/muuli_wdr.cpp:2981
 msgid "Proxy host:"
 msgstr "Indirizzo proxy:"
 
-#: src/muuli_wdr.cpp:3012
+#: src/muuli_wdr.cpp:2984
 msgid "The proxy host name"
 msgstr "Il nome host del proxy"
 
-#: src/muuli_wdr.cpp:3014
+#: src/muuli_wdr.cpp:2986
 msgid "Proxy port:"
 msgstr "Porta proxy:"
 
-#: src/muuli_wdr.cpp:3017
+#: src/muuli_wdr.cpp:2989
 msgid "The proxy port"
 msgstr "La porta del proxy"
 
-#: src/muuli_wdr.cpp:3019
+#: src/muuli_wdr.cpp:2991
 msgid "Enable authentication"
 msgstr "Abilita autenticazione"
 
-#: src/muuli_wdr.cpp:3020
+#: src/muuli_wdr.cpp:2992
 msgid "Enable/disable username/password authentication"
 msgstr "Abilita o disabilita l'autenticazione con nome utente e password"
 
-#: src/muuli_wdr.cpp:3023
+#: src/muuli_wdr.cpp:2995
 msgid "Username: "
 msgstr "Nome utente: "
 
-#: src/muuli_wdr.cpp:3026
+#: src/muuli_wdr.cpp:2998
 msgid "The username to use to connect to the proxy"
 msgstr "Nome utente utilizzato per la connessione al proxy"
 
-#: src/muuli_wdr.cpp:3028
+#: src/muuli_wdr.cpp:3000
 msgid "Password:"
 msgstr "Password:"
 
-#: src/muuli_wdr.cpp:3031
+#: src/muuli_wdr.cpp:3003
 msgid "The password to use to connect to the proxy"
 msgstr "La password usata per la connessione al proxy"
 
-#: src/muuli_wdr.cpp:3050
+#: src/muuli_wdr.cpp:3022
 msgid "Connect to:"
 msgstr "Connetti a:"
 
-#: src/muuli_wdr.cpp:3059
+#: src/muuli_wdr.cpp:3031
 msgid "Login to remote amule"
 msgstr "Login su aMule remoto"
 
-#: src/muuli_wdr.cpp:3064
+#: src/muuli_wdr.cpp:3036
 msgid "User name"
 msgstr "Nome utente"
 
-#: src/muuli_wdr.cpp:3075
+#: src/muuli_wdr.cpp:3047
 msgid "Remember those settings"
 msgstr "Ricorda impostazioni"
 
-#: src/muuli_wdr.cpp:3078
+#: src/muuli_wdr.cpp:3050
 msgid "Force ZLIB compression"
 msgstr "Forza la compressione ZLIB"
 
-#: src/muuli_wdr.cpp:3102
+#: src/muuli_wdr.cpp:3074
 msgid "Enable Verbose Debug-Logging."
 msgstr "Abilita il log dettagliato dei messaggi di debug."
 
-#: src/muuli_wdr.cpp:3104
+#: src/muuli_wdr.cpp:3076
 msgid "Only to Logfile"
 msgstr "Solamente sul file di log"
 
-#: src/muuli_wdr.cpp:3106
+#: src/muuli_wdr.cpp:3078
 msgid "Message Categories:"
 msgstr "Categorie messaggi:"
 
-#: src/muuli_wdr.cpp:3130 src/PartFileConvertDlg.cpp:160
+#: src/muuli_wdr.cpp:3102 src/PartFileConvertDlg.cpp:160
 msgid "Waiting..."
 msgstr "In attesa..."
 
-#: src/muuli_wdr.cpp:3150
+#: src/muuli_wdr.cpp:3122
 msgid "Add imports"
 msgstr "Aggiungi importazioni"
 
-#: src/muuli_wdr.cpp:3153
+#: src/muuli_wdr.cpp:3125
 msgid "Retry selected"
 msgstr "Riprova selezionati"
 
-#: src/muuli_wdr.cpp:3155
+#: src/muuli_wdr.cpp:3127
 msgid "Remove selected"
 msgstr "Rimuovi selezionati"
 
-#: src/muuli_wdr.cpp:3218
+#: src/muuli_wdr.cpp:3190
 msgid "Event Types"
 msgstr "Tipi di evento"
 
-#: src/muuli_wdr.cpp:3237
+#: src/muuli_wdr.cpp:3209
 msgid "Statistics and queued clients for selected file(s) : Session / All time"
 msgstr "Statistiche e client in coda per i(l) file selezionati(o) : Sessione / Totale"
 
-#: src/muuli_wdr.cpp:3261
+#: src/muuli_wdr.cpp:3233
 msgid "Active Uploads"
 msgstr "Upload attivi"
 
-#: src/muuli_wdr.cpp:3275
+#: src/muuli_wdr.cpp:3247
 msgid "Percent of total files"
 msgstr "Percentuale di file totali"
 
-#: src/muuli_wdr.cpp:3327
+#: src/muuli_wdr.cpp:3299
 msgid "Show Clients for"
 msgstr "Mostra client per"
 
-#: src/muuli_wdr.cpp:3329
+#: src/muuli_wdr.cpp:3301
 msgid "All files"
 msgstr "Tutti i file"
 
-#: src/muuli_wdr.cpp:3332
+#: src/muuli_wdr.cpp:3304
 msgid "Selected files"
 msgstr "File selezionati"
 
-#: src/muuli_wdr.cpp:3335
+#: src/muuli_wdr.cpp:3307
 msgid "Active uploads only"
 msgstr "Solo upload attivi"
 
-#: src/muuli_wdr.cpp:3342
+#: src/muuli_wdr.cpp:3314
 msgid "Reload:"
 msgstr "Ricarica lista:"
 
-#: src/muuli_wdr.cpp:3346
+#: src/muuli_wdr.cpp:3318
 msgid "Reload your shared files"
 msgstr "Ricarica file condivisi"
 
-#: src/muuli_wdr.cpp:3409
+#: src/muuli_wdr.cpp:3381
 msgid "Send"
 msgstr "Invia"
 
-#: src/muuli_wdr.cpp:3410
+#: src/muuli_wdr.cpp:3382
 msgid "Sends the specified message."
 msgstr "Invia messaggio specificato."
 
-#: src/muuli_wdr.cpp:3414
+#: src/muuli_wdr.cpp:3386
 msgid "Close this chat-session."
 msgstr "Chiude questa sessione di chat."
 
-#: src/muuli_wdr.cpp:3437
+#: src/muuli_wdr.cpp:3409
 msgid "Connect to any server and/or Kad"
 msgstr "Connetti a qualsiasi server e/o a Kad"
 
-#: src/muuli_wdr.cpp:3443 src/SharedFilesCtrl.cpp:142 src/Statistics.cpp:941
+#: src/muuli_wdr.cpp:3415 src/SharedFilesCtrl.cpp:142 src/Statistics.cpp:941
 msgid "Shared Files"
 msgstr "File condivisi"
 
@@ -5455,248 +5421,248 @@ msgstr "Scaricato"
 msgid "ERROR: Failed to open partfile '%s'"
 msgstr "ERRORE: Apertura del file Part fallita '%s'"
 
-#: src/Preferences.cpp:701
+#: src/Preferences.cpp:673
 msgid "System default"
 msgstr "Predefinita di sistema"
 
-#: src/Preferences.cpp:702
+#: src/Preferences.cpp:674
 msgid "Albanian"
 msgstr "Albanese"
 
-#: src/Preferences.cpp:703
+#: src/Preferences.cpp:675
 msgid "Arabic"
 msgstr "Arabo"
 
-#: src/Preferences.cpp:704
+#: src/Preferences.cpp:676
 msgid "Asturian"
 msgstr "Asturiano"
 
-#: src/Preferences.cpp:705
+#: src/Preferences.cpp:677
 msgid "Basque"
 msgstr "Basco"
 
-#: src/Preferences.cpp:706
+#: src/Preferences.cpp:678
 msgid "Bulgarian"
 msgstr "Bulgaro"
 
-#: src/Preferences.cpp:707
+#: src/Preferences.cpp:679
 msgid "Catalan"
 msgstr "Catalano"
 
-#: src/Preferences.cpp:708
+#: src/Preferences.cpp:680
 msgid "Chinese (Simplified)"
 msgstr "Cinese (semplificato)"
 
-#: src/Preferences.cpp:709
+#: src/Preferences.cpp:681
 msgid "Chinese (Traditional)"
 msgstr "Cinese (tradizionale)"
 
-#: src/Preferences.cpp:710
+#: src/Preferences.cpp:682
 msgid "Croatian"
 msgstr "Croato"
 
-#: src/Preferences.cpp:711
+#: src/Preferences.cpp:683
 msgid "Czech"
 msgstr "Ceco"
 
-#: src/Preferences.cpp:712
+#: src/Preferences.cpp:684
 msgid "Danish"
 msgstr "Danese"
 
-#: src/Preferences.cpp:713
+#: src/Preferences.cpp:685
 msgid "Dutch"
 msgstr "Olandese"
 
-#: src/Preferences.cpp:714
+#: src/Preferences.cpp:686
 msgid "English (U.K.)"
 msgstr "Inglese (Regno Unito)"
 
-#: src/Preferences.cpp:715
+#: src/Preferences.cpp:687
 msgid "English (U.S.)"
 msgstr "Inglese (U.S.)"
 
-#: src/Preferences.cpp:716
+#: src/Preferences.cpp:688
 msgid "Estonian"
 msgstr "Estone"
 
-#: src/Preferences.cpp:717
+#: src/Preferences.cpp:689
 msgid "Finnish"
 msgstr "Finlandese"
 
-#: src/Preferences.cpp:718
+#: src/Preferences.cpp:690
 msgid "French"
 msgstr "Francese"
 
-#: src/Preferences.cpp:719
+#: src/Preferences.cpp:691
 msgid "Galician"
 msgstr "Galiziano"
 
-#: src/Preferences.cpp:720
+#: src/Preferences.cpp:692
 msgid "German"
 msgstr "Tedesco"
 
-#: src/Preferences.cpp:721
+#: src/Preferences.cpp:693
 msgid "Greek"
 msgstr "Greco"
 
-#: src/Preferences.cpp:722
+#: src/Preferences.cpp:694
 msgid "Hebrew"
 msgstr "Ebraico"
 
-#: src/Preferences.cpp:723
+#: src/Preferences.cpp:695
 msgid "Hungarian"
 msgstr "Ungherese"
 
-#: src/Preferences.cpp:724
+#: src/Preferences.cpp:696
 msgid "Italian"
 msgstr "Italiano"
 
-#: src/Preferences.cpp:725
+#: src/Preferences.cpp:697
 msgid "Japanese"
 msgstr "Giapponese"
 
-#: src/Preferences.cpp:726
+#: src/Preferences.cpp:698
 msgid "Korean"
 msgstr "Coreano"
 
-#: src/Preferences.cpp:727
+#: src/Preferences.cpp:699
 msgid "Latvian"
 msgstr "Lettone"
 
-#: src/Preferences.cpp:728
+#: src/Preferences.cpp:700
 msgid "Lithuanian"
 msgstr "Lituano"
 
-#: src/Preferences.cpp:729
+#: src/Preferences.cpp:701
 msgid "Norwegian (Nynorsk)"
 msgstr "Norvegese (Nynorsk)"
 
-#: src/Preferences.cpp:730
+#: src/Preferences.cpp:702
 msgid "Polish"
 msgstr "Polacco"
 
-#: src/Preferences.cpp:731
+#: src/Preferences.cpp:703
 msgid "Portuguese"
 msgstr "Portoghese"
 
-#: src/Preferences.cpp:732
+#: src/Preferences.cpp:704
 msgid "Portuguese (Brazilian)"
 msgstr "Portoghese (Brasile)"
 
-#: src/Preferences.cpp:733
+#: src/Preferences.cpp:705
 msgid "Romanian"
 msgstr "Romeno"
 
-#: src/Preferences.cpp:734
+#: src/Preferences.cpp:706
 msgid "Russian"
 msgstr "Russo"
 
-#: src/Preferences.cpp:735
+#: src/Preferences.cpp:707
 msgid "Slovenian"
 msgstr "Sloveno"
 
-#: src/Preferences.cpp:736
+#: src/Preferences.cpp:708
 msgid "Spanish"
 msgstr "Spagnolo"
 
-#: src/Preferences.cpp:737
+#: src/Preferences.cpp:709
 msgid "Swedish"
 msgstr "Svedese"
 
-#: src/Preferences.cpp:738
+#: src/Preferences.cpp:710
 msgid "Turkish"
 msgstr "Turco"
 
-#: src/Preferences.cpp:739
+#: src/Preferences.cpp:711
 msgid "Ukrainian"
 msgstr "Ucraino"
 
-#: src/Preferences.cpp:842
+#: src/Preferences.cpp:814
 msgid "Change Language"
 msgstr "Cambia lingua"
 
-#: src/Preferences.cpp:906
+#: src/Preferences.cpp:878
 msgid "There are no translations installed for aMule"
 msgstr "Non ci sono traduzioni di aMule installate"
 
-#: src/Preferences.cpp:907
+#: src/Preferences.cpp:879
 msgid "No languages available"
 msgstr "Nessuna lingua disponibile"
 
-#: src/Preferences.cpp:1038
+#: src/Preferences.cpp:1010
 msgid "no options available"
 msgstr "nessuna opzione disponibile"
 
-#: src/Preferences.cpp:2226
+#: src/Preferences.cpp:2179
 msgid "Invalid category found, skipping"
 msgstr "Trovata categoria non valida, ignorata"
 
-#: src/Preferences.cpp:2395
+#: src/Preferences.cpp:2348
 msgid "TCP port can't be higher than 65532 due to server UDP socket being TCP+3"
 msgstr "La porta TCP non può essere superiore a 65532 perché il socket UDP è fissato a TCP+3"
 
-#: src/Preferences.cpp:2396
+#: src/Preferences.cpp:2349
 #, c-format
 msgid "Default port will be used (%d)"
 msgstr "Sarà usata la porta predefinita (%d)"
 
-#: src/PrefsUnifiedDlg.cpp:300 src/Statistics.cpp:866
+#: src/PrefsUnifiedDlg.cpp:298 src/Statistics.cpp:866
 msgid "Connection"
 msgstr "Connessione"
 
-#: src/PrefsUnifiedDlg.cpp:301 src/SearchListCtrl.cpp:117
+#: src/PrefsUnifiedDlg.cpp:299 src/SearchListCtrl.cpp:117
 msgid "Directories"
 msgstr "Directory"
 
-#: src/PrefsUnifiedDlg.cpp:302 src/Statistics.cpp:917
+#: src/PrefsUnifiedDlg.cpp:300 src/Statistics.cpp:917
 msgid "Servers"
 msgstr "Server"
 
-#: src/PrefsUnifiedDlg.cpp:303 src/ServerListCtrl.cpp:96
+#: src/PrefsUnifiedDlg.cpp:301 src/ServerListCtrl.cpp:96
 msgid "Files"
 msgstr "File"
 
-#: src/PrefsUnifiedDlg.cpp:304
+#: src/PrefsUnifiedDlg.cpp:302
 msgid "Security"
 msgstr "Sicurezza"
 
-#: src/PrefsUnifiedDlg.cpp:305
+#: src/PrefsUnifiedDlg.cpp:303
 msgid "Interface"
 msgstr "Interfaccia"
 
-#: src/PrefsUnifiedDlg.cpp:312
+#: src/PrefsUnifiedDlg.cpp:310
 msgid "IP2Country"
 msgstr "IP2Country"
 
-#: src/PrefsUnifiedDlg.cpp:315
+#: src/PrefsUnifiedDlg.cpp:313
 msgid "Proxy"
 msgstr "Proxy"
 
-#: src/PrefsUnifiedDlg.cpp:316
+#: src/PrefsUnifiedDlg.cpp:314
 msgid "Filters"
 msgstr "Filtri"
 
-#: src/PrefsUnifiedDlg.cpp:317
+#: src/PrefsUnifiedDlg.cpp:315
 msgid "Remote Controls"
 msgstr "Controlli remoti"
 
-#: src/PrefsUnifiedDlg.cpp:318
+#: src/PrefsUnifiedDlg.cpp:316
 msgid "Online Signature"
 msgstr "Online Signature"
 
-#: src/PrefsUnifiedDlg.cpp:319
+#: src/PrefsUnifiedDlg.cpp:317
 msgid "Advanced"
 msgstr "Avanzato"
 
-#: src/PrefsUnifiedDlg.cpp:320
+#: src/PrefsUnifiedDlg.cpp:318
 msgid "Events"
 msgstr "Eventi"
 
-#: src/PrefsUnifiedDlg.cpp:323
+#: src/PrefsUnifiedDlg.cpp:321
 msgid "Debugging"
 msgstr "Debug"
 
-#: src/PrefsUnifiedDlg.cpp:453
+#: src/PrefsUnifiedDlg.cpp:451
 msgid ""
 "The following variables will be substituted:\n"
 "    %PARTFILE - full path to the file\n"
@@ -5706,15 +5672,15 @@ msgstr ""
 "    %PARTFILE - percorso completo del file\n"
 "    %PARTNAME - solamente il nome del file"
 
-#: src/PrefsUnifiedDlg.cpp:474
+#: src/PrefsUnifiedDlg.cpp:472
 msgid "Tray icon support requires libayatana-appindicator3 at compile time."
 msgstr "Il supporto per l'icona nella tray richiede libayatana-appindicator3 in fase di compilazione."
 
-#: src/PrefsUnifiedDlg.cpp:490
+#: src/PrefsUnifiedDlg.cpp:488
 msgid "Not available on Wayland: the protocol does not report when a window is minimized, so this option cannot intercept the system minimize button. Workaround: launch aMule with `GDK_BACKEND=x11` to use XWayland instead."
 msgstr "Non disponibile su Wayland: il protocollo non segnala quando una finestra viene ridotta a icona, quindi questa opzione non può intercettare il pulsante di riduzione del sistema. Soluzione alternativa: avvia aMule con `GDK_BACKEND=x11` per usare XWayland."
 
-#: src/PrefsUnifiedDlg.cpp:536
+#: src/PrefsUnifiedDlg.cpp:534
 msgid ""
 "Do not change these setting unless you know\n"
 "what you are doing, otherwise you can easily\n"
@@ -5729,35 +5695,26 @@ msgstr ""
 "\n"
 "aMule funzionerà anche senza modificare questi parametri."
 
-#: src/PrefsUnifiedDlg.cpp:647
+#: src/PrefsUnifiedDlg.cpp:645
 #, c-format
 msgid "Failed to connect Cfg to widget with the ID %d and key %s"
 msgstr "Insuccesso nel collegare Cfg al widget con ID %d e chiave %s"
 
-#: src/PrefsUnifiedDlg.cpp:695
+#: src/PrefsUnifiedDlg.cpp:693
 #, c-format
 msgid "Failed to transfer data from Cfg to Widget with the ID %d and key %s"
 msgstr "Insuccesso nel trasferire dati da Cfg al Widget con ID %d e chiave %s"
 
-#: src/PrefsUnifiedDlg.cpp:801
+#: src/PrefsUnifiedDlg.cpp:799
 msgid "The type of proxy you are connecting to"
 msgstr "Il tipo di proxy a cui ti stai connettendo"
 
-#: src/PrefsUnifiedDlg.cpp:1020
+#: src/PrefsUnifiedDlg.cpp:1003
 #, c-format
 msgid "Failed to transfer data from Widget to Cfg with the ID %d and key %s"
 msgstr "Insuccesso nel trasferire dati dal widget al Cfg con ID %d e chiave %s"
 
 #: src/PrefsUnifiedDlg.cpp:1103
-#, fuzzy
-msgid "No password set."
-msgstr "Password amministrazione"
-
-#: src/PrefsUnifiedDlg.cpp:1132
-msgid "Guest access needs a password. Type one in the guest password field, or untick Enable guest access."
-msgstr ""
-
-#: src/PrefsUnifiedDlg.cpp:1144
 msgid ""
 "aMule must be restarted to enable these changes:\n"
 "\n"
@@ -5765,39 +5722,39 @@ msgstr ""
 "aMule deve essere riavviato per rendere effettive queste modifiche:\n"
 "\n"
 
-#: src/PrefsUnifiedDlg.cpp:1151
+#: src/PrefsUnifiedDlg.cpp:1110
 msgid "- TCP port changed.\n"
 msgstr "- Modifica della porta TCP.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1156
+#: src/PrefsUnifiedDlg.cpp:1115
 msgid "- UDP port changed.\n"
 msgstr "- Modifica della porta UDP.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1161
+#: src/PrefsUnifiedDlg.cpp:1120
 msgid "- Network interface binding changed.\n"
 msgstr "- Associazione all'interfaccia di rete modificata.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1166
+#: src/PrefsUnifiedDlg.cpp:1125
 msgid "- External connect port changed.\n"
 msgstr "- Porta della connessione esterna modificata. \n"
 
-#: src/PrefsUnifiedDlg.cpp:1170
+#: src/PrefsUnifiedDlg.cpp:1129
 msgid "- External connect acceptance changed.\n"
 msgstr "- Accetta connessione esterna modificata. \n"
 
-#: src/PrefsUnifiedDlg.cpp:1174
+#: src/PrefsUnifiedDlg.cpp:1133
 msgid "- External connect interface changed.\n"
 msgstr "- Interfaccia connessione esterna modificata. \n"
 
-#: src/PrefsUnifiedDlg.cpp:1178
+#: src/PrefsUnifiedDlg.cpp:1137
 msgid "- Protocol obfuscation support changed.\n"
 msgstr "- Modificato il supporto all'offuscamento del protocollo.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1193
+#: src/PrefsUnifiedDlg.cpp:1151
 msgid "- amuleapi settings changed.\n"
 msgstr "- configurazione di amuleapi modificata.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1202
+#: src/PrefsUnifiedDlg.cpp:1160
 msgid ""
 "Your Auto-update server list is empty.\n"
 "'Auto-update server list at startup' will be disabled."
@@ -5805,7 +5762,7 @@ msgstr ""
 "La tua lista dei server per l'aggiornamento automatico è vuota.\n"
 "L'aggiornamento automatico all'avvio sarà disattivato."
 
-#: src/PrefsUnifiedDlg.cpp:1213
+#: src/PrefsUnifiedDlg.cpp:1171
 msgid ""
 "You have enabled external connections but have not specified a password.\n"
 "External connections cannot be enabled unless a valid password is specified."
@@ -5813,32 +5770,27 @@ msgstr ""
 "Hai abilitato le connessioni esterne senza però specificare una password.\n"
 "Le connessioni esterne non possono essere abilitate a meno che tu non scelga una password valida."
 
-#: src/PrefsUnifiedDlg.cpp:1246
-#, c-format
-msgid "The amuleapi password could not be saved: %s"
-msgstr ""
-
-#: src/PrefsUnifiedDlg.cpp:1276
+#: src/PrefsUnifiedDlg.cpp:1202
 msgid "- Language changed.\n"
 msgstr "- Modifica della lingua.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1281
+#: src/PrefsUnifiedDlg.cpp:1207
 msgid "- Temp folder changed.\n"
 msgstr "- Modifica della cartella Temp.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1286
+#: src/PrefsUnifiedDlg.cpp:1212
 msgid "- ED2K network enabled.\n"
 msgstr "- Rete ed2k abilitata.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1319
+#: src/PrefsUnifiedDlg.cpp:1245
 msgid "The shared-file exclusion pattern is not a valid regular expression. The filter has been left disabled."
 msgstr "Il pattern di esclusione dei file condivisi non è un'espressione regolare valida. Il filtro è stato lasciato disattivato."
 
-#: src/PrefsUnifiedDlg.cpp:1321 src/PrefsUnifiedDlg.cpp:1921
+#: src/PrefsUnifiedDlg.cpp:1247 src/PrefsUnifiedDlg.cpp:1841
 msgid "Invalid regular expression"
 msgstr "Espressione regolare non valida"
 
-#: src/PrefsUnifiedDlg.cpp:1398
+#: src/PrefsUnifiedDlg.cpp:1324
 msgid ""
 "Both eD2k and Kad network are disabled.\n"
 "You won't be able to connect until you enable at least one of them."
@@ -5846,7 +5798,7 @@ msgstr ""
 "Le reti eD2k e Kad sono entrambe disabilitate.\n"
 "Non potrai connetterti finché non ne abiliterai almeno una."
 
-#: src/PrefsUnifiedDlg.cpp:1403
+#: src/PrefsUnifiedDlg.cpp:1329
 msgid ""
 "Kad will not start if your UDP port is disabled.\n"
 "Enable UDP port or disable Kad."
@@ -5854,7 +5806,7 @@ msgstr ""
 "Kad non può partire se la porta UDP è disabilitata.\n"
 "Abilitala o disabilita Kad."
 
-#: src/PrefsUnifiedDlg.cpp:1459
+#: src/PrefsUnifiedDlg.cpp:1385
 msgid ""
 "\n"
 "You MUST restart aMule now.\n"
@@ -5864,68 +5816,68 @@ msgstr ""
 "DEVI riavviare aMule ADESSO.\n"
 "Se non lo fai, non lamentarti se succede qualcosa di strano.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1524
+#: src/PrefsUnifiedDlg.cpp:1450
 msgid "Could not register aMule for autostart at login. The autostart store may be read-only."
 msgstr "Impossibile registrare aMule per l'avvio automatico all'accesso. L'archivio di avvio automatico potrebbe essere in sola lettura."
 
-#: src/PrefsUnifiedDlg.cpp:1526
+#: src/PrefsUnifiedDlg.cpp:1452
 msgid "Could not remove the autostart-at-login entry."
 msgstr "Impossibile rimuovere la voce di avvio automatico all'accesso."
 
-#: src/PrefsUnifiedDlg.cpp:1527
+#: src/PrefsUnifiedDlg.cpp:1453
 msgid "Autostart"
 msgstr "Avvio automatico"
 
-#: src/PrefsUnifiedDlg.cpp:1542
+#: src/PrefsUnifiedDlg.cpp:1468
 msgid "Register file type"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1542
+#: src/PrefsUnifiedDlg.cpp:1468
 msgid "Register URL handler"
 msgstr "Registra gestore URL"
 
-#: src/PrefsUnifiedDlg.cpp:1550
+#: src/PrefsUnifiedDlg.cpp:1476
 #, c-format
 msgid "aMule only handles eD2k-compatible magnets. If you replace the current magnet handler (%s), BitTorrent magnet links will stop working - aMule cannot download BitTorrent content. Continue?"
 msgstr "aMule gestisce solo i magnet compatibili con eD2k. Se sostituisci il gestore magnet attuale (%s), i link magnet BitTorrent smetteranno di funzionare: aMule non può scaricare contenuti BitTorrent. Continuare?"
 
-#: src/PrefsUnifiedDlg.cpp:1555
+#: src/PrefsUnifiedDlg.cpp:1481
 #, fuzzy, c-format
 msgid "Another application currently opens .emulecollection files (%s). Replace it with aMule?"
 msgstr "Attualmente un'altra applicazione è il gestore predefinito per questi link (%s). Sostituirla con aMule?"
 
-#: src/PrefsUnifiedDlg.cpp:1560
+#: src/PrefsUnifiedDlg.cpp:1486
 #, c-format
 msgid "Another application is currently the default handler for these links (%s). Replace it with aMule?"
 msgstr "Attualmente un'altra applicazione è il gestore predefinito per questi link (%s). Sostituirla con aMule?"
 
-#: src/PrefsUnifiedDlg.cpp:1585
+#: src/PrefsUnifiedDlg.cpp:1511
 #, fuzzy
 msgid "Could not register aMule for .emulecollection files. The registration store may be read-only."
 msgstr "Impossibile registrare aMule come gestore URL. Il registro delle associazioni potrebbe essere in sola lettura."
 
-#: src/PrefsUnifiedDlg.cpp:1587
+#: src/PrefsUnifiedDlg.cpp:1513
 #, fuzzy
 msgid "Could not remove the file type registration."
 msgstr "Impossibile rimuovere la registrazione del gestore URL."
 
-#: src/PrefsUnifiedDlg.cpp:1589
+#: src/PrefsUnifiedDlg.cpp:1515
 msgid "Could not register aMule as the URL handler. The registration store may be read-only."
 msgstr "Impossibile registrare aMule come gestore URL. Il registro delle associazioni potrebbe essere in sola lettura."
 
-#: src/PrefsUnifiedDlg.cpp:1591
+#: src/PrefsUnifiedDlg.cpp:1517
 msgid "Could not remove the URL handler registration."
 msgstr "Impossibile rimuovere la registrazione del gestore URL."
 
-#: src/PrefsUnifiedDlg.cpp:1661 src/PrefsUnifiedDlg.cpp:1688
+#: src/PrefsUnifiedDlg.cpp:1587 src/PrefsUnifiedDlg.cpp:1614
 msgid "The web server and aMule API require external connections to be enabled."
 msgstr "Il server web e aMule API richiedono che le connessioni esterne siano abilitate."
 
-#: src/PrefsUnifiedDlg.cpp:1671
+#: src/PrefsUnifiedDlg.cpp:1597
 msgid "The aMule web server is deprecated. Consider running the aMule API instead."
 msgstr "Il server web di aMule è deprecato. Valuta in alternativa l'uso di aMule API."
 
-#: src/PrefsUnifiedDlg.cpp:1735
+#: src/PrefsUnifiedDlg.cpp:1655
 msgid ""
 "Your Auto-update servers list is in blank.\n"
 "Please fill in at least one URL to point to a valid server.met file.\n"
@@ -5935,64 +5887,64 @@ msgstr ""
 "Inserisci l'URL di almeno un server valido nel file server.met.\n"
 "Clicca sul pulsante \"Lista\" per inserire l'URL."
 
-#: src/PrefsUnifiedDlg.cpp:1876
+#: src/PrefsUnifiedDlg.cpp:1796
 msgid "Temporary files"
 msgstr "File temporanei"
 
-#: src/PrefsUnifiedDlg.cpp:1881
+#: src/PrefsUnifiedDlg.cpp:1801
 msgid "Incoming files"
 msgstr "File completi"
 
-#: src/PrefsUnifiedDlg.cpp:1886
+#: src/PrefsUnifiedDlg.cpp:1806
 msgid "Online Signatures"
 msgstr "Online Signature"
 
-#: src/PrefsUnifiedDlg.cpp:1899
+#: src/PrefsUnifiedDlg.cpp:1819
 #, c-format
 msgid "Choose a folder for %s"
 msgstr "Scegli una directory per i %s"
 
-#: src/PrefsUnifiedDlg.cpp:1923
+#: src/PrefsUnifiedDlg.cpp:1843
 #, c-format
 msgid "Would exclude %u of %u shared file"
 msgid_plural "Would exclude %u of %u shared files"
 msgstr[0] "Escluderebbe %u di %u file condiviso"
 msgstr[1] "Escluderebbe %u di %u file condivisi"
 
-#: src/PrefsUnifiedDlg.cpp:1940
+#: src/PrefsUnifiedDlg.cpp:1860
 msgid "Browse for videoplayer"
 msgstr "Sfoglia per trovare un riproduttore video"
 
-#: src/PrefsUnifiedDlg.cpp:1944
+#: src/PrefsUnifiedDlg.cpp:1864
 msgid "Select browser"
 msgstr "Scegli browser"
 
-#: src/PrefsUnifiedDlg.cpp:1948
+#: src/PrefsUnifiedDlg.cpp:1868
 msgid "Select ffprobe binary"
 msgstr "Seleziona il binario ffprobe"
 
-#: src/PrefsUnifiedDlg.cpp:1954
+#: src/PrefsUnifiedDlg.cpp:1874
 #, c-format
 msgid "Executable%s"
 msgstr "Eseguibile%s"
 
-#: src/PrefsUnifiedDlg.cpp:1988
+#: src/PrefsUnifiedDlg.cpp:1908
 msgid "ffprobe not found on PATH or in the standard install locations. Install ffmpeg (which ships ffprobe) or use Browse to pick a binary manually."
 msgstr "ffprobe non trovato nel PATH né nei percorsi di installazione standard. Installa ffmpeg (che include ffprobe) oppure usa Sfoglia per selezionare manualmente un binario."
 
-#: src/PrefsUnifiedDlg.cpp:2000
+#: src/PrefsUnifiedDlg.cpp:1920
 msgid "Reset the settings on this page to their default values?"
 msgstr "Ripristinare le impostazioni di questa pagina ai loro valori predefiniti?"
 
-#: src/PrefsUnifiedDlg.cpp:2001
+#: src/PrefsUnifiedDlg.cpp:1921
 msgid "Reset to defaults"
 msgstr "Ripristina i valori predefiniti"
 
-#: src/PrefsUnifiedDlg.cpp:2028
+#: src/PrefsUnifiedDlg.cpp:1948
 msgid "Edit server list"
 msgstr "Modifica la lista dei server"
 
-#: src/PrefsUnifiedDlg.cpp:2029
+#: src/PrefsUnifiedDlg.cpp:1949
 msgid ""
 "Add here URL's to download server.met files.\n"
 "Only one url on each line."
@@ -6000,114 +5952,114 @@ msgstr ""
 "Inserisci l'URL da cui scaricare il file server.met.\n"
 "Solo un URL per riga."
 
-#: src/PrefsUnifiedDlg.cpp:2084
+#: src/PrefsUnifiedDlg.cpp:2004
 msgid "IP2Country update failed"
 msgstr "Aggiornamento IP2Country fallito"
 
-#: src/PrefsUnifiedDlg.cpp:2229 src/PrefsUnifiedDlg.cpp:2260
+#: src/PrefsUnifiedDlg.cpp:2149 src/PrefsUnifiedDlg.cpp:2180
 msgid "Data by MaxMind GeoLite2"
 msgstr "Dati di MaxMind GeoLite2"
 
-#: src/PrefsUnifiedDlg.cpp:2231 src/PrefsUnifiedDlg.cpp:2262
+#: src/PrefsUnifiedDlg.cpp:2151 src/PrefsUnifiedDlg.cpp:2182
 msgid "Custom source"
 msgstr "Sorgente personalizzata"
 
-#: src/PrefsUnifiedDlg.cpp:2233 src/PrefsUnifiedDlg.cpp:2264
+#: src/PrefsUnifiedDlg.cpp:2153 src/PrefsUnifiedDlg.cpp:2184
 msgid "Data by DB-IP.com"
 msgstr "Dati di DB-IP.com"
 
-#: src/PrefsUnifiedDlg.cpp:2284
+#: src/PrefsUnifiedDlg.cpp:2204
 #, c-format
 msgid "Status: Loaded%s"
 msgstr "Stato: Caricato%s"
 
-#: src/PrefsUnifiedDlg.cpp:2286
+#: src/PrefsUnifiedDlg.cpp:2206
 #, c-format
 msgid "Status: Loaded%s - %s"
 msgstr "Stato: Caricato%s - %s"
 
-#: src/PrefsUnifiedDlg.cpp:2290
+#: src/PrefsUnifiedDlg.cpp:2210
 msgid "Status: Failed to load - click 'Update now' to refresh."
 msgstr "Stato: Caricamento fallito - clicca su 'Aggiorna ora' per ricaricare."
 
-#: src/PrefsUnifiedDlg.cpp:2292
+#: src/PrefsUnifiedDlg.cpp:2212
 msgid "Status: Not found - click 'Update now' to download."
 msgstr "Stato: Non trovato - clicca su 'Aggiorna ora' per scaricare."
 
-#: src/PrefsUnifiedDlg.cpp:2350 src/PrefsUnifiedDlg.cpp:2374
+#: src/PrefsUnifiedDlg.cpp:2270 src/PrefsUnifiedDlg.cpp:2294
 #, c-format
 msgid "Update delay: %d second"
 msgid_plural "Update delay: %d seconds"
 msgstr[0] "Intervallo aggiornamento: %d secondo"
 msgstr[1] "Intervallo aggiornamento: %d secondi"
 
-#: src/PrefsUnifiedDlg.cpp:2358
+#: src/PrefsUnifiedDlg.cpp:2278
 #, c-format
 msgid "Time for average graph: %d minute"
 msgid_plural "Time for average graph: %d minutes"
 msgstr[0] "Intervallo grafico della media: %d minuto"
 msgstr[1] "Intervallo grafico della media: %d minuti"
 
-#: src/PrefsUnifiedDlg.cpp:2367
+#: src/PrefsUnifiedDlg.cpp:2287
 #, c-format
 msgid "Connections Graph Scale: %d"
 msgstr "Scala grafico delle connessioni: %d"
 
-#: src/PrefsUnifiedDlg.cpp:2382
+#: src/PrefsUnifiedDlg.cpp:2302
 #, c-format
 msgid "File Buffer Size: %d byte"
 msgid_plural "File Buffer Size: %d bytes"
 msgstr[0] "Dimensione buffer file: %d byte"
 msgstr[1] "Dimensione buffer file: %d bytes"
 
-#: src/PrefsUnifiedDlg.cpp:2392
+#: src/PrefsUnifiedDlg.cpp:2312
 #, c-format
 msgid "Upload Queue Size: %d client"
 msgid_plural "Upload Queue Size: %d clients"
 msgstr[0] "Dimensione coda upload: %d client"
 msgstr[1] "Dimensione coda upload: %d client"
 
-#: src/PrefsUnifiedDlg.cpp:2402
+#: src/PrefsUnifiedDlg.cpp:2322
 #, c-format
 msgid "Server connection refresh interval: %d minute"
 msgid_plural "Server connection refresh interval: %d minutes"
 msgstr[0] "Intervallo aggiornamento connessione ai server: %d minuto"
 msgstr[1] "Intervallo aggiornamento connessione ai server: %d minuti"
 
-#: src/PrefsUnifiedDlg.cpp:2407
+#: src/PrefsUnifiedDlg.cpp:2327
 msgid "Server connection refresh interval: Disabled"
 msgstr "Intervallo aggiornamento connessione ai server: disabilitato"
 
-#: src/PrefsUnifiedDlg.cpp:2451
+#: src/PrefsUnifiedDlg.cpp:2371
 msgid "disabled"
 msgstr "disattivato"
 
-#: src/PrefsUnifiedDlg.cpp:2477
+#: src/PrefsUnifiedDlg.cpp:2397
 #, c-format
 msgid "Execute command on '%s' event"
 msgstr "Esegui comando se si verifica l'evento '%s'"
 
-#: src/PrefsUnifiedDlg.cpp:2484
+#: src/PrefsUnifiedDlg.cpp:2404
 msgid "Enable command execution on core"
 msgstr "Abilita l'esecuzione del comando sul core"
 
-#: src/PrefsUnifiedDlg.cpp:2496
+#: src/PrefsUnifiedDlg.cpp:2416
 msgid "Core command:"
 msgstr "Comando Core:"
 
-#: src/PrefsUnifiedDlg.cpp:2512
+#: src/PrefsUnifiedDlg.cpp:2432
 msgid "Enable command execution on GUI"
 msgstr "Abilita l'esecuzione del comando sulla GUI"
 
-#: src/PrefsUnifiedDlg.cpp:2524
+#: src/PrefsUnifiedDlg.cpp:2444
 msgid "GUI command:"
 msgstr "Comando GUI:"
 
-#: src/PrefsUnifiedDlg.cpp:2540
+#: src/PrefsUnifiedDlg.cpp:2460
 msgid "The following variables will be replaced:"
 msgstr "Le seguenti variabili saranno sostituite:"
 
-#: src/PrefsUnifiedDlg.cpp:2708
+#: src/PrefsUnifiedDlg.cpp:2628
 msgid ""
 "The following folders look like system or sensitive locations:\n"
 "\n"
@@ -6115,61 +6067,57 @@ msgstr ""
 "Le seguenti cartelle sembrano posizioni di sistema o sensibili:\n"
 "\n"
 
-#: src/PrefsUnifiedDlg.cpp:2713
+#: src/PrefsUnifiedDlg.cpp:2633
 msgid "Sharing them recursively will publish every file underneath on the eD2k/Kad networks. Do you really want to do this?"
 msgstr "Condividerle ricorsivamente pubblicherà ogni file al loro interno sulle reti eD2k/Kad. Vuoi davvero procedere?"
 
-#: src/PrefsUnifiedDlg.cpp:2716
+#: src/PrefsUnifiedDlg.cpp:2636
 msgid "Confirm shared folders"
 msgstr "Conferma cartelle condivise"
 
-#: src/PrefsUnifiedDlg.cpp:2744
+#: src/PrefsUnifiedDlg.cpp:2664
 msgid "Reloading shared files..."
 msgstr "Ricarica file condivisi in corso..."
 
-#: src/PrefsUnifiedDlg.cpp:2745
+#: src/PrefsUnifiedDlg.cpp:2665
 msgid "Scanning for subdirectories..."
 msgstr "Analisi delle sottocartelle in corso..."
 
-#: src/PrefsUnifiedDlg.cpp:2746
+#: src/PrefsUnifiedDlg.cpp:2666
 msgid "Updating shared folders"
 msgstr "Aggiornamento cartelle condivise"
 
-#: src/PrefsUnifiedDlg.cpp:2773
+#: src/PrefsUnifiedDlg.cpp:2693
 #, c-format
 msgid "Scanned %u directories..."
 msgstr "%u cartelle analizzate..."
 
-#: src/PrefsUnifiedDlg.cpp:2823
+#: src/PrefsUnifiedDlg.cpp:2743
 #, c-format
 msgid "Reloading shared files: %u files scanned"
 msgstr "Ricarica file condivisi: %u file analizzati"
 
-#: src/PrefsUnifiedDlg.cpp:2873
+#: src/PrefsUnifiedDlg.cpp:2793
 msgid "Shared folder"
 msgstr "Cartella condivisa"
 
-#: src/SearchDlg.cpp:280
-msgid "Clear search history"
-msgstr ""
-
-#: src/SearchDlg.cpp:584
+#: src/SearchDlg.cpp:425
 msgid "It's impossible to search when both eD2k and Kademlia are disabled."
 msgstr "Impossibile avviare ricerche con eD2k e Kademlia entrambi disabilitati."
 
-#: src/SearchDlg.cpp:585 src/SearchListCtrl.cpp:858
+#: src/SearchDlg.cpp:426 src/SearchListCtrl.cpp:858
 msgid "Search error"
 msgstr "Errore di ricerca"
 
-#: src/SearchDlg.cpp:929
+#: src/SearchDlg.cpp:768
 msgid "Min size must be smaller than max size. Max size ignored."
 msgstr "Min size deve essere più piccola di max size. Ignoro max size."
 
-#: src/SearchDlg.cpp:930 src/SearchDlg.cpp:1012
+#: src/SearchDlg.cpp:769 src/SearchDlg.cpp:851
 msgid "Search warning"
 msgstr "Avviso di ricerca"
 
-#: src/SearchDlg.cpp:1092 src/SearchListCtrl.cpp:735
+#: src/SearchDlg.cpp:929 src/SearchListCtrl.cpp:735
 msgid "Main"
 msgstr "Principale"
 

--- a/po/it.po
+++ b/po/it.po
@@ -19,7 +19,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule 2.3.3\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-28 08:06+0200\n"
+"POT-Creation-Date: 2026-07-28 10:19+0200\n"
 "PO-Revision-Date: 2026-07-27 11:40+0000\n"
 "Last-Translator: got3nks <got3nks@users.noreply.github.com>\n"
 "Language-Team: SebastianoPistore.info@protonmail.ch\n"
@@ -151,7 +151,7 @@ msgstr "Installa"
 msgid "Not now"
 msgstr "Non ora"
 
-#: src/AppImageIntegration.cpp:422 src/amuleDlg.cpp:600
+#: src/AppImageIntegration.cpp:422 src/amuleDlg.cpp:665
 msgid "Don't ask again"
 msgstr "Non chiedere più"
 
@@ -228,7 +228,7 @@ msgid "Killing amuleweb instance with pid '%d' ... "
 msgstr "Sto terminando forzatamente l'istanza di amuleweb con pid `%d' ... "
 
 #: src/amule.cpp:336 src/amule.cpp:349 src/ClientRef.cpp:180
-#: src/SearchDlg.cpp:880 src/ServerListCtrl.cpp:98
+#: src/SearchDlg.cpp:1041 src/ServerListCtrl.cpp:98
 msgid "Failed"
 msgstr "Fallito"
 
@@ -585,29 +585,67 @@ msgstr "Impossibile creare il file Pid"
 msgid "ERROR: %s"
 msgstr "ERRORE: %s"
 
-#: src/amuleDlg.cpp:236
+#: src/amuleDlg.cpp:250
 #, c-format
 msgid "This is aMule %s based on eMule."
 msgstr "Questo è aMule %s basato su eMule."
 
-#: src/amuleDlg.cpp:237
+#: src/amuleDlg.cpp:251
 #, c-format
 msgid "Running on %s"
 msgstr "In esecuzione su %s"
 
-#: src/amuleDlg.cpp:239
+#: src/amuleDlg.cpp:253
 msgid "Visit https://github.com/amule-org/amule/releases/latest to check if a new version is available."
 msgstr "Visita https://github.com/amule-org/amule/releases/latest per controllare se è disponibile una nuova versione."
 
-#: src/amuleDlg.cpp:268
+#: src/amuleDlg.cpp:282
 msgid "FATAL ERROR: Failed to create Timer"
 msgstr "ERRORE FATALE: Creazione timer fallita"
 
-#: src/amuleDlg.cpp:592
+#: src/amuleDlg.cpp:361 src/amuleDlg.cpp:1787 src/amuleDlg.cpp:2033
+#: src/muuli_wdr.cpp:1492 src/muuli_wdr.cpp:3418
+msgid "Networks"
+msgstr "Reti"
+
+#: src/amuleDlg.cpp:362 src/amuleDlg.cpp:1793 src/muuli_wdr.cpp:3419
+msgid "Searches"
+msgstr "Ricerca"
+
+#: src/amuleDlg.cpp:363 src/amuleDlg.cpp:1799 src/DownloadListCtrl.cpp:740
+#: src/muuli_wdr.cpp:392 src/muuli_wdr.cpp:1585 src/muuli_wdr.cpp:3420
+#: src/Statistics.cpp:829
+msgid "Downloads"
+msgstr "Download"
+
+#: src/amuleDlg.cpp:364 src/amuleDlg.cpp:1805 src/muuli_wdr.cpp:3294
+msgid "Shared files"
+msgstr "File condivisi"
+
+#: src/amuleDlg.cpp:365 src/amuleDlg.cpp:1811 src/muuli_wdr.cpp:2926
+#: src/muuli_wdr.cpp:3376 src/muuli_wdr.cpp:3423
+msgid "Messages"
+msgstr "Messaggi"
+
+#: src/amuleDlg.cpp:366 src/amuleDlg.cpp:1817 src/muuli_wdr.cpp:3424
+#: src/PrefsUnifiedDlg.cpp:312 src/Statistics.cpp:779 src/Statistics.cpp:1235
+msgid "Statistics"
+msgstr "Statistiche"
+
+#: src/amuleDlg.cpp:368 src/amuleDlg.cpp:1824 src/muuli_wdr.cpp:3426
+#: src/PrefsUnifiedDlg.cpp:328 src/utils/wxCas/src/wxcasprefs.cpp:39
+msgid "Preferences"
+msgstr "Preferenze"
+
+#: src/amuleDlg.cpp:371
+msgid "Navigate"
+msgstr ""
+
+#: src/amuleDlg.cpp:657
 msgid "New version available"
 msgstr "Nuova versione disponibile"
 
-#: src/amuleDlg.cpp:596
+#: src/amuleDlg.cpp:661
 #, c-format
 msgid ""
 "A new version of aMule (%s) is available.\n"
@@ -622,217 +660,184 @@ msgstr ""
 "\n"
 "Vuoi aprire la pagina di download?"
 
-#: src/amuleDlg.cpp:678
+#: src/amuleDlg.cpp:743
 msgid "aMule dialog destroyed"
 msgstr "Finestra di aMule chiusa"
 
-#: src/amuleDlg.cpp:701 src/DataToText.cpp:68 src/IPFilter.cpp:547
+#: src/amuleDlg.cpp:766 src/DataToText.cpp:68 src/IPFilter.cpp:547
 msgid "Connecting"
 msgstr "Connessione in corso"
 
-#: src/amuleDlg.cpp:893
+#: src/amuleDlg.cpp:958
 msgid "eD2k: Connecting"
 msgstr "eD2k: Connessione in corso"
 
-#: src/amuleDlg.cpp:897
+#: src/amuleDlg.cpp:962
 msgid "eD2k: Disconnected"
 msgstr "eD2k: Disconnesso"
 
-#: src/amuleDlg.cpp:903
+#: src/amuleDlg.cpp:968
 msgid "Kad: Firewalled"
 msgstr "Kad: Firewalled"
 
-#: src/amuleDlg.cpp:907
+#: src/amuleDlg.cpp:972
 msgid "Kad: Connected"
 msgstr "Kad: Connesso"
 
-#: src/amuleDlg.cpp:912
+#: src/amuleDlg.cpp:977
 msgid "Kad: Connecting"
 msgstr "Kad: Connessione in corso"
 
-#: src/amuleDlg.cpp:916
+#: src/amuleDlg.cpp:981
 msgid "Kad: Off"
 msgstr "Kad: Spento"
 
-#: src/amuleDlg.cpp:964 src/DownloadListCtrl.cpp:505
+#: src/amuleDlg.cpp:1029 src/DownloadListCtrl.cpp:505
 #: src/DownloadListCtrl.cpp:749 src/FriendListCtrl.cpp:180
 #: src/muuli_wdr.cpp:731 src/muuli_wdr.cpp:782 src/muuli_wdr.cpp:846
-#: src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2224 src/muuli_wdr.cpp:2309
-#: src/muuli_wdr.cpp:3057 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
+#: src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2231 src/muuli_wdr.cpp:2316
+#: src/muuli_wdr.cpp:3064 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
 #: src/ServerListCtrl.cpp:606 src/TransferWnd.cpp:378
 #: src/utils/wxCas/src/wxcasprefs.cpp:235
 msgid "Cancel"
 msgstr "Annulla"
 
-#: src/amuleDlg.cpp:965
+#: src/amuleDlg.cpp:1030
 msgid "Stop the current connection attempts"
 msgstr "Ferma i tentativi di connessione in corso"
 
-#: src/amuleDlg.cpp:970 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976
-#: src/muuli_wdr.cpp:2447
+#: src/amuleDlg.cpp:1035 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976
+#: src/muuli_wdr.cpp:2454
 msgid "Disconnect"
 msgstr "Disconnetti"
 
-#: src/amuleDlg.cpp:971
+#: src/amuleDlg.cpp:1036
 msgid "Disconnect from the currently connected networks"
 msgstr "Disconnetti dalle reti a cui sei connesso"
 
-#: src/amuleDlg.cpp:976 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979
-#: src/muuli_wdr.cpp:2602 src/muuli_wdr.cpp:3054 src/muuli_wdr.cpp:3409
+#: src/amuleDlg.cpp:1041 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979
+#: src/muuli_wdr.cpp:2609 src/muuli_wdr.cpp:3061 src/muuli_wdr.cpp:3416
 msgid "Connect"
 msgstr "Connetti"
 
-#: src/amuleDlg.cpp:977
+#: src/amuleDlg.cpp:1042
 msgid "Connect to the currently enabled networks"
 msgstr "Connetti alle reti attualmente abilitate"
 
-#: src/amuleDlg.cpp:1089
+#: src/amuleDlg.cpp:1154
 #, c-format
 msgid "Up: %.1f%s (%.1f) | Down: %.1f%s (%.1f)"
 msgstr "Up: %.1f%s (%.1f) | Down: %.1f%s (%.1f)"
 
-#: src/amuleDlg.cpp:1091 src/amuleDlg.cpp:1093 src/amuleDlg.cpp:1097
-#: src/amuleDlg.cpp:1099 src/amuleDlg.cpp:1110 src/amuleDlg.cpp:1112
+#: src/amuleDlg.cpp:1156 src/amuleDlg.cpp:1158 src/amuleDlg.cpp:1162
+#: src/amuleDlg.cpp:1164 src/amuleDlg.cpp:1175 src/amuleDlg.cpp:1177
 #: src/MuleTrayIcon.cpp:796 src/MuleTrayIcon.cpp:799
 msgid " MB/s"
 msgstr " MB/s"
 
-#: src/amuleDlg.cpp:1091 src/amuleDlg.cpp:1093 src/amuleDlg.cpp:1097
-#: src/amuleDlg.cpp:1099 src/amuleDlg.cpp:1110 src/amuleDlg.cpp:1112
+#: src/amuleDlg.cpp:1156 src/amuleDlg.cpp:1158 src/amuleDlg.cpp:1162
+#: src/amuleDlg.cpp:1164 src/amuleDlg.cpp:1175 src/amuleDlg.cpp:1177
 #: src/MuleTrayIcon.cpp:796 src/MuleTrayIcon.cpp:799
 #: src/utils/wxCas/src/wxcasframe.cpp:1041
 msgid " kB/s"
 msgstr " kB/s"
 
-#: src/amuleDlg.cpp:1096
+#: src/amuleDlg.cpp:1161
 #, c-format
 msgid "Up: %.1f%s | Down: %.1f%s"
 msgstr "Up: %.1f%s | Down: %.1f%s"
 
-#: src/amuleDlg.cpp:1128
+#: src/amuleDlg.cpp:1193
 #, c-format
 msgid "aMule (%s | Connected)"
 msgstr "aMule (%s | Connesso)"
 
-#: src/amuleDlg.cpp:1130
+#: src/amuleDlg.cpp:1195
 #, c-format
 msgid "aMule (%s | Disconnected)"
 msgstr "aMule (%s | Disconnesso)"
 
-#: src/amuleDlg.cpp:1183
+#: src/amuleDlg.cpp:1248
 #, c-format
 msgid "Do you really want to exit %s?"
 msgstr "Vuoi veramente uscire da %s?"
 
-#: src/amuleDlg.cpp:1185
+#: src/amuleDlg.cpp:1250
 msgid "Exit confirmation"
 msgstr "Chiedi conferma prima di uscire"
 
-#: src/amuleDlg.cpp:1548
+#: src/amuleDlg.cpp:1613
 msgid "Launch Command: "
 msgstr "Comando di avvio: "
 
-#: src/amuleDlg.cpp:1567 src/muuli_wdr.cpp:1971 src/Preferences.cpp:951
+#: src/amuleDlg.cpp:1632 src/muuli_wdr.cpp:1978 src/Preferences.cpp:952
 msgid "- default -"
 msgstr "- predefinita -"
 
-#: src/amuleDlg.cpp:1595
+#: src/amuleDlg.cpp:1660
 #, c-format
 msgid "Skin directory '%s' does not exist"
 msgstr "La directory delle skin '%s' non esiste"
 
-#: src/amuleDlg.cpp:1598
+#: src/amuleDlg.cpp:1663
 #, c-format
 msgid "WARNING: Unable to open skin file '%s' for read"
 msgstr "ATTENZIONE: Impossibile aprire il file della skin '%s' in lettura"
 
-#: src/amuleDlg.cpp:1722 src/amuleDlg.cpp:1968 src/muuli_wdr.cpp:1485
-#: src/muuli_wdr.cpp:3411
-msgid "Networks"
-msgstr "Reti"
-
-#: src/amuleDlg.cpp:1726 src/muuli_wdr.cpp:3411
+#: src/amuleDlg.cpp:1791 src/muuli_wdr.cpp:3418
 msgid "Networks Window"
 msgstr "Finestra reti"
 
-#: src/amuleDlg.cpp:1728 src/muuli_wdr.cpp:3412
-msgid "Searches"
-msgstr "Ricerca"
-
-#: src/amuleDlg.cpp:1732 src/muuli_wdr.cpp:3412
+#: src/amuleDlg.cpp:1797 src/muuli_wdr.cpp:3419
 msgid "Searches Window"
 msgstr "Finestra ricerche"
 
-#: src/amuleDlg.cpp:1734 src/DownloadListCtrl.cpp:740 src/muuli_wdr.cpp:392
-#: src/muuli_wdr.cpp:1578 src/muuli_wdr.cpp:3413 src/Statistics.cpp:829
-msgid "Downloads"
-msgstr "Download"
-
-#: src/amuleDlg.cpp:1738 src/muuli_wdr.cpp:3413
+#: src/amuleDlg.cpp:1803 src/muuli_wdr.cpp:3420
 msgid "Downloads Window"
 msgstr "Finestra dei Download"
 
-#: src/amuleDlg.cpp:1740 src/muuli_wdr.cpp:3287
-msgid "Shared files"
-msgstr "File condivisi"
-
-#: src/amuleDlg.cpp:1744 src/muuli_wdr.cpp:3415
+#: src/amuleDlg.cpp:1809 src/muuli_wdr.cpp:3422
 msgid "Shared Files Window"
 msgstr "Finestra file condivisi"
 
-#: src/amuleDlg.cpp:1746 src/muuli_wdr.cpp:2919 src/muuli_wdr.cpp:3369
-#: src/muuli_wdr.cpp:3416
-msgid "Messages"
-msgstr "Messaggi"
-
-#: src/amuleDlg.cpp:1750 src/muuli_wdr.cpp:3416
+#: src/amuleDlg.cpp:1815 src/muuli_wdr.cpp:3423
 msgid "Messages Window"
 msgstr "Finestra messaggi"
 
-#: src/amuleDlg.cpp:1752 src/muuli_wdr.cpp:3417 src/PrefsUnifiedDlg.cpp:312
-#: src/Statistics.cpp:779 src/Statistics.cpp:1235
-msgid "Statistics"
-msgstr "Statistiche"
-
-#: src/amuleDlg.cpp:1756 src/muuli_wdr.cpp:3417
+#: src/amuleDlg.cpp:1821 src/muuli_wdr.cpp:3424
 msgid "Statistics Graph Window"
 msgstr "Finestra grafici e statistiche"
 
-#: src/amuleDlg.cpp:1759 src/muuli_wdr.cpp:3419 src/PrefsUnifiedDlg.cpp:328
-#: src/utils/wxCas/src/wxcasprefs.cpp:39
-msgid "Preferences"
-msgstr "Preferenze"
-
-#: src/amuleDlg.cpp:1763 src/muuli_wdr.cpp:3419
+#: src/amuleDlg.cpp:1828 src/muuli_wdr.cpp:3426
 msgid "Preferences Settings Window"
 msgstr "Finestra Preferenze"
 
-#: src/amuleDlg.cpp:1766 src/muuli_wdr.cpp:3420
+#: src/amuleDlg.cpp:1831 src/muuli_wdr.cpp:3427
 msgid "Import"
 msgstr "Importazione"
 
-#: src/amuleDlg.cpp:1770 src/muuli_wdr.cpp:3420
+#: src/amuleDlg.cpp:1835 src/muuli_wdr.cpp:3427
 msgid "The partfile importer tool"
 msgstr "Strumento per l'importazione dei file parziali"
 
-#: src/amuleDlg.cpp:1773 src/muuli_wdr.cpp:3421
+#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3428
 #: src/utils/aLinkCreator/src/alcframe.cpp:262
 msgid "About"
 msgstr "Informazioni"
 
-#: src/amuleDlg.cpp:1773 src/muuli_wdr.cpp:3421
+#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3428
 msgid "About/Help"
 msgstr "Informazioni/Aiuto"
 
-#: src/amuleDlg.cpp:1971
+#: src/amuleDlg.cpp:2036
 msgid "eD2k network"
 msgstr "rete eD2k"
 
-#: src/amuleDlg.cpp:1974
+#: src/amuleDlg.cpp:2039
 msgid "Kad network"
 msgstr "Rete Kad"
 
-#: src/amuleDlg.cpp:1974
+#: src/amuleDlg.cpp:2039
 msgid "No network"
 msgstr "Nessuna rete"
 
@@ -1365,19 +1370,19 @@ msgstr "Auto [Alta]"
 msgid "Very low"
 msgstr "Molto bassa"
 
-#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:743 src/muuli_wdr.cpp:2275
+#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:743 src/muuli_wdr.cpp:2282
 #: src/ServerListCtrl.cpp:263 src/ServerListCtrl.cpp:456
 #: src/SharedFilesCtrl.cpp:145
 msgid "Low"
 msgstr "Bassa"
 
-#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:744 src/muuli_wdr.cpp:2276
+#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:744 src/muuli_wdr.cpp:2283
 #: src/ServerListCtrl.cpp:266 src/ServerListCtrl.cpp:457
 #: src/SharedFilesCtrl.cpp:146
 msgid "Normal"
 msgstr "Normale"
 
-#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:745 src/muuli_wdr.cpp:2277
+#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:745 src/muuli_wdr.cpp:2284
 #: src/ServerListCtrl.cpp:269 src/ServerListCtrl.cpp:458
 #: src/SharedFilesCtrl.cpp:147
 msgid "High"
@@ -1469,8 +1474,8 @@ msgstr "Server locale"
 msgid "Remote Server"
 msgstr "Server remoto"
 
-#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3174
-#: src/SearchDlg.cpp:111 src/TextClient.cpp:911
+#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3181
+#: src/SearchDlg.cpp:119 src/TextClient.cpp:911
 msgid "Kad"
 msgstr "Kad"
 
@@ -1540,7 +1545,7 @@ msgstr "Parte"
 msgid "Size"
 msgstr "Dimensione"
 
-#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3241
+#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3248
 msgid "Transferred"
 msgstr "Trasferiti"
 
@@ -1598,7 +1603,7 @@ msgstr ""
 "Feedback da: %s (%s)\n"
 "\n"
 
-#: src/DownloadListCtrl.cpp:746 src/muuli_wdr.cpp:2278
+#: src/DownloadListCtrl.cpp:746 src/muuli_wdr.cpp:2285
 #: src/SharedFilesCtrl.cpp:150
 msgid "Auto"
 msgstr "Auto"
@@ -1636,7 +1641,7 @@ msgid "Extended Options"
 msgstr "Opzioni avanzate"
 
 #: src/DownloadListCtrl.cpp:770 src/DownloadListCtrl.cpp:822
-#: src/muuli_wdr.cpp:1789
+#: src/muuli_wdr.cpp:1796
 msgid "Preview"
 msgstr "Anteprima"
 
@@ -2345,19 +2350,19 @@ msgstr ""
 msgid "eD2k"
 msgstr "eD2k"
 
-#: src/FirstRunWizard.cpp:349 src/muuli_wdr.cpp:1488
+#: src/FirstRunWizard.cpp:349 src/muuli_wdr.cpp:1495
 msgid "Kademlia"
 msgstr "Kademlia"
 
-#: src/FirstRunWizard.cpp:359 src/muuli_wdr.cpp:1416
+#: src/FirstRunWizard.cpp:359 src/muuli_wdr.cpp:1423
 msgid "Standard TCP Port "
 msgstr "Porta TCP standard "
 
-#: src/FirstRunWizard.cpp:365 src/muuli_wdr.cpp:1428
+#: src/FirstRunWizard.cpp:365 src/muuli_wdr.cpp:1435
 msgid "Extended UDP port (Kad / global search) "
 msgstr "Porta UDP estesa (Kad / ricerca globale) "
 
-#: src/FirstRunWizard.cpp:377 src/muuli_wdr.cpp:1435
+#: src/FirstRunWizard.cpp:377 src/muuli_wdr.cpp:1442
 msgid "Enable UPnP for router port forwarding"
 msgstr "Abilita UPnP per il port forwarding del router"
 
@@ -2384,7 +2389,7 @@ msgstr ""
 msgid "Your peer lists are already in place - nothing to download."
 msgstr "Stai già cercando di scaricare il file %s"
 
-#: src/FirstRunWizard.cpp:434 src/muuli_wdr.cpp:1533
+#: src/FirstRunWizard.cpp:434 src/muuli_wdr.cpp:1540
 msgid "Auto-update server list at startup"
 msgstr "Aggiorna lista server all'avvio"
 
@@ -2430,23 +2435,23 @@ msgid ""
 "want downloads on a different (e.g. larger) disk."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:549 src/FirstRunWizard.cpp:611 src/muuli_wdr.cpp:1701
+#: src/FirstRunWizard.cpp:549 src/FirstRunWizard.cpp:611 src/muuli_wdr.cpp:1708
 msgid "Destination folder for downloads"
 msgstr "Cartella di destinazione per i file scaricati"
 
-#: src/FirstRunWizard.cpp:553 src/FirstRunWizard.cpp:569 src/muuli_wdr.cpp:1342
-#: src/muuli_wdr.cpp:1359 src/muuli_wdr.cpp:1676 src/muuli_wdr.cpp:1707
-#: src/muuli_wdr.cpp:1719 src/muuli_wdr.cpp:2762
+#: src/FirstRunWizard.cpp:553 src/FirstRunWizard.cpp:569 src/muuli_wdr.cpp:1349
+#: src/muuli_wdr.cpp:1366 src/muuli_wdr.cpp:1683 src/muuli_wdr.cpp:1714
+#: src/muuli_wdr.cpp:1726 src/muuli_wdr.cpp:2769
 #: src/utils/aLinkCreator/src/alcframe.cpp:135
 #: src/utils/wxCas/src/wxcasprefs.cpp:52 src/utils/wxCas/src/wxcasprefs.cpp:118
 msgid "Browse"
 msgstr "Sfoglia"
 
-#: src/FirstRunWizard.cpp:559 src/muuli_wdr.cpp:1712
+#: src/FirstRunWizard.cpp:559 src/muuli_wdr.cpp:1719
 msgid "(All files in this folder are shared with other peers)"
 msgstr "(Tutti i file in questa cartella sono condivisi con gli altri peer)"
 
-#: src/FirstRunWizard.cpp:565 src/FirstRunWizard.cpp:624 src/muuli_wdr.cpp:1714
+#: src/FirstRunWizard.cpp:565 src/FirstRunWizard.cpp:624 src/muuli_wdr.cpp:1721
 msgid "Folder for temporary download files"
 msgstr "Cartella per i file temporanei"
 
@@ -2477,7 +2482,7 @@ msgstr "Impossibile aprire in scrittura il file della lista degli amici 'emfrien
 msgid "CRITICAL - no client on StartChatSession"
 msgstr "CRITICO - nessun client in StartChatSession"
 
-#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2668 src/muuli_wdr.cpp:3345
+#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2675 src/muuli_wdr.cpp:3352
 msgid "Friends"
 msgstr "Amici"
 
@@ -2861,7 +2866,7 @@ msgstr "Rapporto di condivisione"
 msgid "Uploaded"
 msgstr "Inviato"
 
-#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3225
+#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3232
 msgid "Requested"
 msgstr "Richiesto"
 
@@ -2984,7 +2989,7 @@ msgid "WARNING: "
 msgstr "ATTENZIONE: "
 
 #: src/MuleNotebook.cpp:179 src/muuli_wdr.cpp:817 src/muuli_wdr.cpp:1229
-#: src/muuli_wdr.cpp:3129 src/muuli_wdr.cpp:3385
+#: src/muuli_wdr.cpp:3136 src/muuli_wdr.cpp:3392
 msgid "Close"
 msgstr "Chiudi"
 
@@ -2997,12 +3002,12 @@ msgstr "Taglia"
 msgid "Copy"
 msgstr "Copia"
 
-#: src/MuleTextCtrl.cpp:88
+#: src/MuleTextCtrl.cpp:88 src/SearchDlg.cpp:261
 msgid "Paste"
 msgstr "Incolla"
 
 #: src/MuleTextCtrl.cpp:89 src/muuli_wdr.cpp:358 src/muuli_wdr.cpp:757
-#: src/muuli_wdr.cpp:2352 src/muuli_wdr.cpp:2371 src/muuli_wdr.cpp:2393
+#: src/muuli_wdr.cpp:2359 src/muuli_wdr.cpp:2378 src/muuli_wdr.cpp:2400
 #: src/utils/aLinkCreator/src/alcframe.cpp:142
 msgid "Clear"
 msgstr "Pulisci"
@@ -3093,8 +3098,8 @@ msgid "Exit"
 msgstr "Esci"
 
 #: src/MuleTrayIcon.cpp:579 src/MuleTrayIcon.cpp:945 src/MuleTrayIcon.cpp:965
-#: src/muuli_wdr.cpp:1391 src/muuli_wdr.cpp:1399 src/muuli_wdr.cpp:1406
-#: src/muuli_wdr.cpp:1835 src/muuli_wdr.cpp:1841 src/OtherFunctions.cpp:91
+#: src/muuli_wdr.cpp:1398 src/muuli_wdr.cpp:1406 src/muuli_wdr.cpp:1413
+#: src/muuli_wdr.cpp:1842 src/muuli_wdr.cpp:1848 src/OtherFunctions.cpp:91
 #: src/StatisticsDlg.cpp:93 src/StatisticsDlg.cpp:95
 msgid "kB/s"
 msgstr "kB/s"
@@ -3263,7 +3268,7 @@ msgstr "Nome:"
 msgid "Type"
 msgstr "Tipo"
 
-#: src/muuli_wdr.cpp:215 src/SearchDlg.cpp:110 src/SearchListCtrl.cpp:853
+#: src/muuli_wdr.cpp:215 src/SearchDlg.cpp:118 src/SearchListCtrl.cpp:853
 msgid "Local"
 msgstr "Locale"
 
@@ -3334,7 +3339,7 @@ msgstr "Byte"
 msgid "KB"
 msgstr "KB"
 
-#: src/muuli_wdr.cpp:274 src/muuli_wdr.cpp:293 src/muuli_wdr.cpp:1620
+#: src/muuli_wdr.cpp:274 src/muuli_wdr.cpp:293 src/muuli_wdr.cpp:1627
 #: src/OtherFunctions.cpp:64
 msgid "MB"
 msgstr "MB"
@@ -3351,7 +3356,7 @@ msgstr "Dimensione massima"
 msgid "Availability"
 msgstr "Disponibilità"
 
-#: src/muuli_wdr.cpp:312 src/muuli_wdr.cpp:398 src/muuli_wdr.cpp:3290
+#: src/muuli_wdr.cpp:312 src/muuli_wdr.cpp:398 src/muuli_wdr.cpp:3297
 msgid "Filter:"
 msgstr "Filtro:"
 
@@ -3383,7 +3388,7 @@ msgstr "Chiedi ai peer Kad che hanno già risposto di ampliare la ricerca. Ogni 
 msgid "Stop"
 msgstr "Ferma"
 
-#: src/muuli_wdr.cpp:348 src/muuli_wdr.cpp:1385 src/SearchListCtrl.cpp:732
+#: src/muuli_wdr.cpp:348 src/muuli_wdr.cpp:1392 src/SearchListCtrl.cpp:732
 msgid "Download"
 msgstr "Download"
 
@@ -3414,8 +3419,8 @@ msgstr "Fonti del file:"
 #: src/muuli_wdr.cpp:1160 src/muuli_wdr.cpp:1167 src/muuli_wdr.cpp:1172
 #: src/muuli_wdr.cpp:1179 src/muuli_wdr.cpp:1184 src/muuli_wdr.cpp:1191
 #: src/muuli_wdr.cpp:1205 src/muuli_wdr.cpp:1212 src/muuli_wdr.cpp:1217
-#: src/muuli_wdr.cpp:1224 src/muuli_wdr.cpp:3227 src/muuli_wdr.cpp:3235
-#: src/muuli_wdr.cpp:3243
+#: src/muuli_wdr.cpp:1224 src/muuli_wdr.cpp:3234 src/muuli_wdr.cpp:3242
+#: src/muuli_wdr.cpp:3250
 msgid "N/A"
 msgstr "N/D"
 
@@ -3555,7 +3560,7 @@ msgstr "Artista :"
 msgid "Album :"
 msgstr "Album :"
 
-#: src/muuli_wdr.cpp:685 src/muuli_wdr.cpp:2247
+#: src/muuli_wdr.cpp:685 src/muuli_wdr.cpp:2254
 msgid "Title :"
 msgstr "Titolo:"
 
@@ -3663,7 +3668,7 @@ msgstr "Nome utente:"
 msgid "Userhash :"
 msgstr "Hash utente:"
 
-#: src/muuli_wdr.cpp:895 src/muuli_wdr.cpp:1741 src/muuli_wdr.cpp:2442
+#: src/muuli_wdr.cpp:895 src/muuli_wdr.cpp:1748 src/muuli_wdr.cpp:2449
 #: src/utils/aLinkCreator/src/alcframe.cpp:137
 msgid "Add"
 msgstr "Aggiungi"
@@ -3672,15 +3677,15 @@ msgstr "Aggiungi"
 msgid "Download-Speed"
 msgstr "Velocità download"
 
-#: src/muuli_wdr.cpp:954 src/muuli_wdr.cpp:989 src/muuli_wdr.cpp:2546
+#: src/muuli_wdr.cpp:954 src/muuli_wdr.cpp:989 src/muuli_wdr.cpp:2553
 msgid "Current"
 msgstr "Corrente"
 
-#: src/muuli_wdr.cpp:962 src/muuli_wdr.cpp:997 src/muuli_wdr.cpp:2554
+#: src/muuli_wdr.cpp:962 src/muuli_wdr.cpp:997 src/muuli_wdr.cpp:2561
 msgid "Running average"
 msgstr "Media attuale"
 
-#: src/muuli_wdr.cpp:970 src/muuli_wdr.cpp:1005 src/muuli_wdr.cpp:2562
+#: src/muuli_wdr.cpp:970 src/muuli_wdr.cpp:1005 src/muuli_wdr.cpp:2569
 msgid "Session average"
 msgstr "Media sessione"
 
@@ -3692,7 +3697,7 @@ msgstr "Velocità upload"
 msgid "Connections"
 msgstr "Connessioni"
 
-#: src/muuli_wdr.cpp:1024 src/muuli_wdr.cpp:1860
+#: src/muuli_wdr.cpp:1024 src/muuli_wdr.cpp:1867
 msgid "Active downloads"
 msgstr "Download attivi"
 
@@ -3700,7 +3705,7 @@ msgstr "Download attivi"
 msgid "Active connections (1:1)"
 msgstr "Connessioni attive (1:1)"
 
-#: src/muuli_wdr.cpp:1040 src/muuli_wdr.cpp:1861
+#: src/muuli_wdr.cpp:1040 src/muuli_wdr.cpp:1868
 msgid "Active uploads"
 msgstr "Upload attivi"
 
@@ -3816,8 +3821,8 @@ msgstr "Questo è il nome che gli altri utenti visualizzeranno quando saranno co
 msgid "Language: "
 msgstr "Lingua: "
 
-#: src/muuli_wdr.cpp:1257 src/muuli_wdr.cpp:1323 src/muuli_wdr.cpp:1327
-#: src/muuli_wdr.cpp:1330
+#: src/muuli_wdr.cpp:1257 src/muuli_wdr.cpp:1330 src/muuli_wdr.cpp:1334
+#: src/muuli_wdr.cpp:1337
 msgid "The delay before showing tool-tips."
 msgstr "Intervallo prima che vengano mostrati i suggerimenti."
 
@@ -3893,259 +3898,268 @@ msgstr "Mostra notifica al termine dello scaricamento"
 msgid "Enabling this will make aMule to show notifications when finished downloading."
 msgstr "Con questa funzione abilitata aMule mostrerà una notifica al termine di ogni download."
 
-#: src/muuli_wdr.cpp:1322
+#: src/muuli_wdr.cpp:1323
+#, fuzzy
+msgid "Remember search history"
+msgstr "Ricorda impostazioni"
+
+#: src/muuli_wdr.cpp:1324
+msgid "Keeps a dropdown list of your past search terms in the Search tab's Name field. This remembers the queries you typed, not the results they returned."
+msgstr ""
+
+#: src/muuli_wdr.cpp:1329
 msgid "Tooltip delay time: "
 msgstr "Ritardo dei suggerimenti: "
 
-#: src/muuli_wdr.cpp:1329
+#: src/muuli_wdr.cpp:1336
 msgid "seconds"
 msgstr "secondi"
 
-#: src/muuli_wdr.cpp:1333
+#: src/muuli_wdr.cpp:1340
 msgid "Browser Selection"
 msgstr "Selezione browser"
 
-#: src/muuli_wdr.cpp:1339
+#: src/muuli_wdr.cpp:1346
 msgid "Enter your browser name here. Leave this field empty to use the system default browser."
 msgstr "Inserisci qui il nome del tuo browser. Lascia vuoto questo campo per utilizzare il browser di sistema predefinito."
 
-#: src/muuli_wdr.cpp:1346
+#: src/muuli_wdr.cpp:1353
 msgid "Open in new tab if possible"
 msgstr "Apri in una nuova scheda se possibile"
 
-#: src/muuli_wdr.cpp:1348
+#: src/muuli_wdr.cpp:1355
 msgid "Open the web page in a new tab instead of in a new window when possible"
 msgstr "Se possibile, apri la pagina web in una nuova scheda invece che in una nuova finestra"
 
-#: src/muuli_wdr.cpp:1352
+#: src/muuli_wdr.cpp:1359
 msgid "Video Player"
 msgstr "Riproduttore video"
 
-#: src/muuli_wdr.cpp:1379
+#: src/muuli_wdr.cpp:1386
 msgid "Bandwidth limits"
 msgstr "Limiti di banda"
 
-#: src/muuli_wdr.cpp:1393
+#: src/muuli_wdr.cpp:1400
 msgid "Upload"
 msgstr "Upload"
 
-#: src/muuli_wdr.cpp:1401
+#: src/muuli_wdr.cpp:1408
 msgid "Slot Allocation"
 msgstr "Allocazione slot"
 
-#: src/muuli_wdr.cpp:1410
+#: src/muuli_wdr.cpp:1417
 msgid "Ports"
 msgstr "Porte"
 
-#: src/muuli_wdr.cpp:1420
+#: src/muuli_wdr.cpp:1427
 msgid "This is the standard eD2k port and cannot be disabled."
 msgstr "Questa è la porta standard di eD2k e non può essere disabilitata."
 
-#: src/muuli_wdr.cpp:1423
+#: src/muuli_wdr.cpp:1430
 msgid "UDP port for server requests (TCP+3):"
 msgstr "Porta UDP per le richieste al server (TCP+3):"
 
-#: src/muuli_wdr.cpp:1425
+#: src/muuli_wdr.cpp:1432
 msgid "4665"
 msgstr "4665"
 
-#: src/muuli_wdr.cpp:1432
+#: src/muuli_wdr.cpp:1439
 msgid "This UDP port is used for extended eD2k requests and Kad network"
 msgstr "Questa porta UDP è utilizzata per le richieste estese eD2k e per la rete Kad"
 
-#: src/muuli_wdr.cpp:1439
+#: src/muuli_wdr.cpp:1446
 msgid "UPnP TCP Port (Optional):"
 msgstr "Porta TCP per UPnP (Facoltativa):"
 
-#: src/muuli_wdr.cpp:1449
+#: src/muuli_wdr.cpp:1456
 msgid "Bind local address to IP (empty for any):"
 msgstr "Lega l'indirizzo locale all'IP (lascia vuoto per qualsiasi):"
 
-#: src/muuli_wdr.cpp:1452
+#: src/muuli_wdr.cpp:1459
 msgid "Advanced users only: If you have multiple network interfaces, enter the address of the interface to which aMule should be bound."
 msgstr "Solo per utenti esperti: se hai interfacce di rete multiple, inserisci l'indirizzo dell'interfaccia che aMule dovrà utilizzare."
 
-#: src/muuli_wdr.cpp:1455 src/muuli_wdr.cpp:2054
+#: src/muuli_wdr.cpp:1462 src/muuli_wdr.cpp:2061
 msgid "Bind to network interface (empty for any):"
 msgstr "Associa all'interfaccia di rete (vuoto per qualsiasi):"
 
-#: src/muuli_wdr.cpp:1468
+#: src/muuli_wdr.cpp:1475
 msgid "Advanced users only: pin all of aMule's traffic to one network interface, chosen from the list or typed in by name (e.g. tun0, eth0, en0) or index. Unlike binding to an IP, this stops traffic leaking out via the default route - useful with a VPN. Requires no elevated privileges."
 msgstr "Solo per utenti esperti: forza tutto il traffico di aMule su un'unica interfaccia di rete, scelta dall'elenco oppure digitata per nome (ad es. tun0, eth0, en0) o indice. A differenza dell'associazione a un IP, questo impedisce al traffico di fuoriuscire tramite la route predefinita - utile con una VPN. Non richiede privilegi elevati."
 
-#: src/muuli_wdr.cpp:1474
+#: src/muuli_wdr.cpp:1481
 msgid "Max sources per downloading file:"
 msgstr "Fonti massime per file in scaricamento:"
 
-#: src/muuli_wdr.cpp:1478
+#: src/muuli_wdr.cpp:1485
 msgid "Max simultaneous connections:"
 msgstr "Connessioni massime simultanee:"
 
-#: src/muuli_wdr.cpp:1491 src/muuli_wdr.cpp:3169
+#: src/muuli_wdr.cpp:1498 src/muuli_wdr.cpp:3176
 msgid "ED2K"
 msgstr "ED2K"
 
-#: src/muuli_wdr.cpp:1498
+#: src/muuli_wdr.cpp:1505
 msgid "Autoconnect on startup"
 msgstr "Connetti automaticamente all'avvio"
 
-#: src/muuli_wdr.cpp:1501
+#: src/muuli_wdr.cpp:1508
 msgid "Reconnect on loss"
 msgstr "Riconnetti dopo perdita connessione"
 
-#: src/muuli_wdr.cpp:1523
+#: src/muuli_wdr.cpp:1530
 msgid "Remove dead server after"
 msgstr "Rimuovi server inattivi dopo"
 
-#: src/muuli_wdr.cpp:1524
+#: src/muuli_wdr.cpp:1531
 msgid "Static servers are never removed, even when unreachable."
 msgstr "I server statici non vengono mai rimossi, nemmeno quando risultano irraggiungibili."
 
-#: src/muuli_wdr.cpp:1528
+#: src/muuli_wdr.cpp:1535
 msgid "retries"
 msgstr "tentativi"
 
-#: src/muuli_wdr.cpp:1536
+#: src/muuli_wdr.cpp:1543
 msgid "List"
 msgstr "Lista"
 
-#: src/muuli_wdr.cpp:1539
+#: src/muuli_wdr.cpp:1546
 msgid "Update server list when connecting to a server"
 msgstr "Aggiorna la lista server quando ti connetti ad un server"
 
-#: src/muuli_wdr.cpp:1542
+#: src/muuli_wdr.cpp:1549
 msgid "Update server list when a client connects"
 msgstr "Aggiorna la lista server quando ti connetti ad un client"
 
-#: src/muuli_wdr.cpp:1545
+#: src/muuli_wdr.cpp:1552
 msgid "Use priority system"
 msgstr "Usa sistema di priorità"
 
-#: src/muuli_wdr.cpp:1549
+#: src/muuli_wdr.cpp:1556
 msgid "Use smart LowID check on connect"
 msgstr "Usa controllo intelligente ID basso in fase di connessione"
 
-#: src/muuli_wdr.cpp:1553
+#: src/muuli_wdr.cpp:1560
 msgid "Safe connect"
 msgstr "Connessione sicura"
 
-#: src/muuli_wdr.cpp:1557
+#: src/muuli_wdr.cpp:1564
 msgid "Autoconnect to servers in static list only"
 msgstr "Connetti automaticamente solo ai server statici"
 
-#: src/muuli_wdr.cpp:1560
+#: src/muuli_wdr.cpp:1567
 msgid "Set manually added servers to High Priority"
 msgstr "Assegna priorità alta ai server aggiunti manualmente"
 
-#: src/muuli_wdr.cpp:1581
+#: src/muuli_wdr.cpp:1588
 msgid "Add files to download in pause mode"
 msgstr "Aggiungi i nuovi file da scaricare mettendoli in pausa"
 
-#: src/muuli_wdr.cpp:1583
+#: src/muuli_wdr.cpp:1590
 msgid "Add files to download with auto priority"
 msgstr "Aggiungi i nuovi file da scaricare con priorità automatica"
 
-#: src/muuli_wdr.cpp:1586
+#: src/muuli_wdr.cpp:1593
 msgid "Try to download first and last chunks first"
 msgstr "Cerca di scaricare prima la parte iniziale e finale del file"
 
-#: src/muuli_wdr.cpp:1590
+#: src/muuli_wdr.cpp:1597
 msgid "Endgame mode: rotate to faster sources for the final blocks"
 msgstr "Modalità endgame: passa a fonti più veloci per gli ultimi blocchi"
 
-#: src/muuli_wdr.cpp:1593
+#: src/muuli_wdr.cpp:1600
 msgid "Start next paused file when a file completes"
 msgstr "Quando un file viene completato inizia a scaricare il primo file in pausa"
 
-#: src/muuli_wdr.cpp:1596
+#: src/muuli_wdr.cpp:1603
 msgid "From the same category"
 msgstr "Della stessa categoria"
 
-#: src/muuli_wdr.cpp:1598
+#: src/muuli_wdr.cpp:1605
 msgid "In alphabetic order"
 msgstr "In ordine alfabetico"
 
-#: src/muuli_wdr.cpp:1600
+#: src/muuli_wdr.cpp:1607
 msgid "Preallocate disk space for new files"
 msgstr "Prealloca lo spazio su disco per i nuovi file"
 
-#: src/muuli_wdr.cpp:1601
+#: src/muuli_wdr.cpp:1608
 msgid "For new files preallocates disk space for the whole file, thus reduces fragmentation"
 msgstr "Per i nuovi file prealloca lo spazio su disco per l'intero file, in questo modo ridurrai la frammentazione"
 
-#: src/muuli_wdr.cpp:1606
+#: src/muuli_wdr.cpp:1613
 msgid "Create new files as sparse files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1607
+#: src/muuli_wdr.cpp:1614
 msgid "A sparse file reserves its full size on disk immediately without writing real data to it -- fast, but unsupported or slow on some filesystems, and free-space accounting stays optimistic while the download is in progress. Turn this off to grow the file only as data arrives."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1612
+#: src/muuli_wdr.cpp:1619
 msgid "Stop downloads when free disk space reaches "
 msgstr "Interrompi i download quando termina lo spazio su disco "
 
-#: src/muuli_wdr.cpp:1613
+#: src/muuli_wdr.cpp:1620
 msgid "Select this if you want aMule to check your disk space"
 msgstr "Seleziona se vuoi che aMule controlli il tuo spazio su disco"
 
-#: src/muuli_wdr.cpp:1617
+#: src/muuli_wdr.cpp:1624
 msgid "Enter here the min disk space desired."
 msgstr "Inserire lo spazio disco minimo desiderato."
 
-#: src/muuli_wdr.cpp:1623
+#: src/muuli_wdr.cpp:1630
 msgid "Save 10 sources on rare files (< 20 sources)"
 msgstr "Salva 10 fonti per i file rari ( con < 20 fonti)"
 
-#: src/muuli_wdr.cpp:1627 src/Statistics.cpp:790
+#: src/muuli_wdr.cpp:1634 src/Statistics.cpp:790
 msgid "Uploads"
 msgstr "Upload"
 
-#: src/muuli_wdr.cpp:1630
+#: src/muuli_wdr.cpp:1637
 msgid "Add new shared files with auto priority"
 msgstr "Assegna priorità automatica ai nuovi file condivisi"
 
-#: src/muuli_wdr.cpp:1636
+#: src/muuli_wdr.cpp:1643
 msgid "Intelligent Corruption Handling (I.C.H.)"
 msgstr "Trattamento intelligente delle corruzioni (I.C.H.)"
 
-#: src/muuli_wdr.cpp:1639
+#: src/muuli_wdr.cpp:1646
 msgid "Enable"
 msgstr "Abilita"
 
-#: src/muuli_wdr.cpp:1642
+#: src/muuli_wdr.cpp:1649
 msgid "Advanced I.C.H. trusts every hash (not recommended)"
 msgstr "L'I.C.H. avanzato si fida di ogni hash (sconsigliato)"
 
-#: src/muuli_wdr.cpp:1654 src/PrefsUnifiedDlg.cpp:1910
+#: src/muuli_wdr.cpp:1661 src/PrefsUnifiedDlg.cpp:1910
 msgid "Media metadata extraction"
 msgstr "Estrazione dei metadati multimediali"
 
-#: src/muuli_wdr.cpp:1658
+#: src/muuli_wdr.cpp:1665
 msgid "Extract length / bitrate / codec from shared audio and video files"
 msgstr "Estrai durata / bitrate / codec dai file audio e video condivisi"
 
-#: src/muuli_wdr.cpp:1660
+#: src/muuli_wdr.cpp:1667
 msgid "When enabled, aMule runs ffprobe on each shared media file to fill in the Length / Bitrate / Codec columns other clients see when they find the file in a search. Requires ffmpeg (the ffprobe binary) to be installed."
 msgstr "Quando abilitato, aMule esegue ffprobe su ogni file multimediale condiviso per compilare le colonne Durata / Bitrate / Codec che gli altri client vedono quando trovano il file in una ricerca. Richiede l'installazione di ffmpeg (il binario ffprobe)."
 
-#: src/muuli_wdr.cpp:1667
+#: src/muuli_wdr.cpp:1674
 msgid "Path to ffprobe:"
 msgstr "Percorso di ffprobe:"
 
-#: src/muuli_wdr.cpp:1672
+#: src/muuli_wdr.cpp:1679
 msgid "Full path to the ffprobe binary. Leave empty to have aMule auto-detect it on startup."
 msgstr "Percorso completo del binario ffprobe. Lascia vuoto per far sì che aMule lo rilevi automaticamente all'avvio."
 
-#: src/muuli_wdr.cpp:1680
+#: src/muuli_wdr.cpp:1687
 msgid "Detect"
 msgstr "Rileva"
 
-#: src/muuli_wdr.cpp:1681
+#: src/muuli_wdr.cpp:1688
 msgid "Search the standard install locations for an ffprobe binary and fill the path field."
 msgstr "Cerca nei percorsi di installazione standard un binario ffprobe e compila il campo del percorso."
 
-#: src/muuli_wdr.cpp:1705
+#: src/muuli_wdr.cpp:1712
 msgid ""
 "Completed downloads are stored here. All files in this folder are automatically shared with other peers.\n"
 "If this folder also holds files you don't want to share, point it at an aMule-only sub-folder."
@@ -4153,665 +4167,665 @@ msgstr ""
 "Qui vengono salvati i download completati. Tutti i file in questa cartella sono condivisi automaticamente con gli altri peer.\n"
 "Se questa cartella contiene anche file che non vuoi condividere, impostala su una sottocartella riservata ad aMule."
 
-#: src/muuli_wdr.cpp:1708
+#: src/muuli_wdr.cpp:1715
 msgid "Pick the folder where completed downloads will be stored. All files in that folder will be shared with other peers."
 msgstr "Scegli la cartella in cui salvare i download completati. Tutti i file in quella cartella saranno condivisi con gli altri peer."
 
-#: src/muuli_wdr.cpp:1722
+#: src/muuli_wdr.cpp:1729
 msgid "Shared folders"
 msgstr "Cartelle condivise"
 
-#: src/muuli_wdr.cpp:1728
+#: src/muuli_wdr.cpp:1735
 msgid "(Folders shared by the core. Enter a path to add one.)"
 msgstr "(Cartelle condivise dal core. Inserisci un percorso per aggiungerne una.)"
 
-#: src/muuli_wdr.cpp:1736
+#: src/muuli_wdr.cpp:1743
 msgid "Absolute path of a folder on the core's machine, e.g. /home/user/shared"
 msgstr "Percorso assoluto di una cartella sulla macchina del core, ad es. /home/user/shared"
 
-#: src/muuli_wdr.cpp:1738 src/PrefsUnifiedDlg.cpp:2794
+#: src/muuli_wdr.cpp:1745 src/PrefsUnifiedDlg.cpp:2794
 msgid "Recursive"
 msgstr "Ricorsivo"
 
-#: src/muuli_wdr.cpp:1739
+#: src/muuli_wdr.cpp:1746
 msgid "Share every sub-folder underneath this one, including ones created later."
 msgstr "Condividi tutte le sottocartelle contenute in questa, comprese quelle create in seguito."
 
-#: src/muuli_wdr.cpp:1743 src/utils/aLinkCreator/src/alcframe.cpp:141
+#: src/muuli_wdr.cpp:1750 src/utils/aLinkCreator/src/alcframe.cpp:141
 msgid "Remove"
 msgstr "Rimuovi"
 
-#: src/muuli_wdr.cpp:1747
+#: src/muuli_wdr.cpp:1754
 msgid "(Right click on folder icon for recursive share)"
 msgstr "(fai click con il tasto destro sulle icone per condividere ricorsivamente le sottodirectory)"
 
-#: src/muuli_wdr.cpp:1754
+#: src/muuli_wdr.cpp:1761
 msgid "Share hidden files"
 msgstr "Condividi file nascosti"
 
-#: src/muuli_wdr.cpp:1760
+#: src/muuli_wdr.cpp:1767
 msgid "Automatically rescan shared folders for changes"
 msgstr "Ricontrolla automaticamente le modifiche nelle cartelle condivise"
 
-#: src/muuli_wdr.cpp:1766
+#: src/muuli_wdr.cpp:1773
 msgid "Follow symbolic links in shared folders"
 msgstr "Segui i collegamenti simbolici nelle cartelle condivise"
 
-#: src/muuli_wdr.cpp:1772
+#: src/muuli_wdr.cpp:1779
 msgid "Exclude files matching:"
 msgstr "Escludi i file corrispondenti a:"
 
-#: src/muuli_wdr.cpp:1775
+#: src/muuli_wdr.cpp:1782
 msgid "Wildcard patterns separated by '|', e.g. .DS_Store|Thumbs.db|*.tmp. Files whose name matches are not shared. Matching is case-insensitive."
 msgstr "Modelli con caratteri jolly separati da '|', ad es. .DS_Store|Thumbs.db|*.tmp. I file il cui nome corrisponde non vengono condivisi. La corrispondenza non distingue tra maiuscole e minuscole."
 
-#: src/muuli_wdr.cpp:1779
+#: src/muuli_wdr.cpp:1786
 msgid "Patterns are regular expressions"
 msgstr "I pattern sono espressioni regolari"
 
-#: src/muuli_wdr.cpp:1780
+#: src/muuli_wdr.cpp:1787
 msgid "When set, the whole field is one regular expression ('|' is alternation). When unset, it is a list of '|'-separated wildcards."
 msgstr "Se attivato, l'intero campo è un'unica espressione regolare ('|' indica l'alternanza). Se disattivato, è un elenco di caratteri jolly separati da '|'."
 
-#: src/muuli_wdr.cpp:1790
+#: src/muuli_wdr.cpp:1797
 msgid "Show how many shared files the current pattern would exclude."
 msgstr "Mostra quanti file condivisi verrebbero esclusi dal pattern attuale."
 
-#: src/muuli_wdr.cpp:1811
+#: src/muuli_wdr.cpp:1818
 msgid "Graphs"
 msgstr "Grafici"
 
-#: src/muuli_wdr.cpp:1814 src/muuli_wdr.cpp:1876
+#: src/muuli_wdr.cpp:1821 src/muuli_wdr.cpp:1883
 msgid "Update delay : 5 secs"
 msgstr "Intervallo di aggiornamento: 5 secondi"
 
-#: src/muuli_wdr.cpp:1818
+#: src/muuli_wdr.cpp:1825
 msgid "Time for average graph: 100 mins"
 msgstr "Intervallo grafico valori medi: 100 minuti"
 
-#: src/muuli_wdr.cpp:1822
+#: src/muuli_wdr.cpp:1829
 msgid "Connections Graph Scale: 100 "
 msgstr "Scala grafico connessioni: 100 "
 
-#: src/muuli_wdr.cpp:1829
+#: src/muuli_wdr.cpp:1836
 msgid "Download graph scale:"
 msgstr "Scala grafico di scaricamento:"
 
-#: src/muuli_wdr.cpp:1837
+#: src/muuli_wdr.cpp:1844
 msgid "Upload graph scale:"
 msgstr "Scala grafico d'invio:"
 
-#: src/muuli_wdr.cpp:1847
+#: src/muuli_wdr.cpp:1854
 msgid "Colors: "
 msgstr "Colori: "
 
-#: src/muuli_wdr.cpp:1851
+#: src/muuli_wdr.cpp:1858
 msgid "Background"
 msgstr "Sfondo"
 
-#: src/muuli_wdr.cpp:1852
+#: src/muuli_wdr.cpp:1859
 msgid "Grid"
 msgstr "Griglia"
 
-#: src/muuli_wdr.cpp:1853
+#: src/muuli_wdr.cpp:1860
 msgid "Download current"
 msgstr "Download attuale"
 
-#: src/muuli_wdr.cpp:1854
+#: src/muuli_wdr.cpp:1861
 msgid "Download running average"
 msgstr "Media download in corso"
 
-#: src/muuli_wdr.cpp:1855
+#: src/muuli_wdr.cpp:1862
 msgid "Download session average"
 msgstr "Media sessione di download"
 
-#: src/muuli_wdr.cpp:1856
+#: src/muuli_wdr.cpp:1863
 msgid "Upload current"
 msgstr "Upload attuale"
 
-#: src/muuli_wdr.cpp:1857
+#: src/muuli_wdr.cpp:1864
 msgid "Upload running average"
 msgstr "Media upload in corso"
 
-#: src/muuli_wdr.cpp:1858
+#: src/muuli_wdr.cpp:1865
 msgid "Upload session average"
 msgstr "Media sessione di upload"
 
-#: src/muuli_wdr.cpp:1859
+#: src/muuli_wdr.cpp:1866
 msgid "Active connections"
 msgstr "Connessioni attive"
 
-#: src/muuli_wdr.cpp:1862
+#: src/muuli_wdr.cpp:1869
 msgid "Systray Icon Speed Bar"
 msgstr "Barra della velocità nell'icona sulla barra di sistema"
 
-#: src/muuli_wdr.cpp:1863
+#: src/muuli_wdr.cpp:1870
 msgid "Kad-nodes current"
 msgstr "Nodi Kad attuali"
 
-#: src/muuli_wdr.cpp:1864
+#: src/muuli_wdr.cpp:1871
 msgid "Kad-nodes running"
 msgstr "Nodi Kad attivi"
 
-#: src/muuli_wdr.cpp:1865
+#: src/muuli_wdr.cpp:1872
 msgid "Kad-nodes session"
 msgstr "Nodi Kad nella sessione"
 
-#: src/muuli_wdr.cpp:1869 src/muuli_wdr.cpp:2296
+#: src/muuli_wdr.cpp:1876 src/muuli_wdr.cpp:2303
 msgid "Select"
 msgstr "Seleziona"
 
-#: src/muuli_wdr.cpp:1873
+#: src/muuli_wdr.cpp:1880
 msgid "Tree"
 msgstr "Albero"
 
-#: src/muuli_wdr.cpp:1883
+#: src/muuli_wdr.cpp:1890
 msgid "Number of Client Versions shown (0=unlimited)"
 msgstr "Numero di versioni di client visualizzate (0=illimitate)"
 
-#: src/muuli_wdr.cpp:1908
+#: src/muuli_wdr.cpp:1915
 msgid "!!! WARNING !!!"
 msgstr "!!! ATTENZIONE !!!"
 
-#: src/muuli_wdr.cpp:1923
+#: src/muuli_wdr.cpp:1930
 msgid "Max new connections / 5 secs"
 msgstr "Numero massimo nuove connessioni / 5 secondi"
 
-#: src/muuli_wdr.cpp:1925
+#: src/muuli_wdr.cpp:1932
 msgid "Concurrent Kad source lookups"
 msgstr "Ricerche di fonti Kad simultanee"
 
-#: src/muuli_wdr.cpp:1927
+#: src/muuli_wdr.cpp:1934
 msgid "Kad source re-search interval (minutes)"
 msgstr "Intervallo tra le ricerche di fonti Kad (minuti)"
 
-#: src/muuli_wdr.cpp:1929
+#: src/muuli_wdr.cpp:1936
 msgid "Source re-ask interval (minutes)"
 msgstr "Intervallo tra le richieste alle fonti (minuti)"
 
-#: src/muuli_wdr.cpp:1933
+#: src/muuli_wdr.cpp:1940
 msgid "File Buffer Size: 240000 bytes"
 msgstr "Dimensione buffer file: 240000 byte"
 
-#: src/muuli_wdr.cpp:1937
+#: src/muuli_wdr.cpp:1944
 msgid "Use MMAP: memory-mapped file access (lower memory use)"
 msgstr "Usa MMAP: accesso ai file mappato in memoria (minor uso di memoria)"
 
-#: src/muuli_wdr.cpp:1938
+#: src/muuli_wdr.cpp:1945
 msgid "Maps part files into memory instead of buffering them on the heap, lowering the process memory footprint. May reduce download speed on some disks; best for memory-constrained or upload-heavy hosts."
 msgstr "Mappa i file parziali in memoria invece di bufferizzarli nell'heap, riducendo l'occupazione di memoria del processo. Potrebbe ridurre la velocità di download su alcuni dischi; ideale per sistemi con memoria limitata o con molto traffico in upload."
 
-#: src/muuli_wdr.cpp:1940
+#: src/muuli_wdr.cpp:1947
 msgid "Upload Queue Size: 5000 clients"
 msgstr "Dimensione coda upload: 5000 client"
 
-#: src/muuli_wdr.cpp:1944
+#: src/muuli_wdr.cpp:1951
 msgid "Server connection refresh interval: Disable"
 msgstr "Intervallo aggiornamento connessione al server: disabilitato"
 
-#: src/muuli_wdr.cpp:1948
+#: src/muuli_wdr.cpp:1955
 msgid "Disable computer's timed standby mode"
 msgstr "Disabilita la modalità standby a tempo"
 
-#: src/muuli_wdr.cpp:1967
+#: src/muuli_wdr.cpp:1974
 msgid "Skin to use: "
 msgstr "Skin da usare: "
 
-#: src/muuli_wdr.cpp:1976
+#: src/muuli_wdr.cpp:1983
 msgid "Show \"Fast eD2k Links Handler\" in every window."
 msgstr "Mostra il \"Gestore rapido dei collegamenti eD2k\" in ogni finestra."
 
-#: src/muuli_wdr.cpp:1979
+#: src/muuli_wdr.cpp:1986
 msgid "Show extended info on categories tabs"
 msgstr "Mostra informazioni estese sulle schede delle categorie"
 
-#: src/muuli_wdr.cpp:1982
+#: src/muuli_wdr.cpp:1989
 msgid "Show application version on title"
 msgstr "Mostra versione dell'applicazione nella barra del titolo"
 
-#: src/muuli_wdr.cpp:1984
+#: src/muuli_wdr.cpp:1991
 msgid "Show transfer rates on title"
 msgstr "Mostra velocità di trasferimento nella barra del titolo"
 
-#: src/muuli_wdr.cpp:1986
+#: src/muuli_wdr.cpp:1993
 msgid "Before application name"
 msgstr "Prima del nome dell'applicazione"
 
-#: src/muuli_wdr.cpp:1988
+#: src/muuli_wdr.cpp:1995
 msgid "After application name"
 msgstr "Dopo il nome dell'applicazione"
 
-#: src/muuli_wdr.cpp:1991
+#: src/muuli_wdr.cpp:1998
 msgid "Show overhead bandwidth"
 msgstr "Mostra l'overhead di banda"
 
-#: src/muuli_wdr.cpp:1995
+#: src/muuli_wdr.cpp:2002
 msgid "Vertical toolbar orientation"
 msgstr "Orientamento verticale della barra degli strumenti"
 
-#: src/muuli_wdr.cpp:1997
+#: src/muuli_wdr.cpp:2004
 msgid "Live column sorting (auto-reorder rows as their values change)"
 msgstr "Ordinamento colonne in tempo reale (riordina le righe automaticamente al variare dei loro valori)"
 
-#: src/muuli_wdr.cpp:2004
+#: src/muuli_wdr.cpp:2011
 msgid "Download Queue Files"
 msgstr "Scaricamento dei file in coda"
 
-#: src/muuli_wdr.cpp:2007
+#: src/muuli_wdr.cpp:2014
 msgid "Show progress percentage"
 msgstr "Mostra la percentuale di avanzamento"
 
-#: src/muuli_wdr.cpp:2013
+#: src/muuli_wdr.cpp:2020
 msgid "Show progress bar"
 msgstr "Mostra la barra di avanzamento"
 
-#: src/muuli_wdr.cpp:2016
+#: src/muuli_wdr.cpp:2023
 msgid "Flat"
 msgstr "Piatta"
 
-#: src/muuli_wdr.cpp:2020
+#: src/muuli_wdr.cpp:2027
 msgid "Round"
 msgstr "Arrotondata"
 
-#: src/muuli_wdr.cpp:2038
+#: src/muuli_wdr.cpp:2045
 msgid "External Connection Parameters"
 msgstr "Parametri connessioni esterne"
 
-#: src/muuli_wdr.cpp:2041
+#: src/muuli_wdr.cpp:2048
 msgid "Accept external connections"
 msgstr "Accetta connessioni esterne"
 
-#: src/muuli_wdr.cpp:2048 src/muuli_wdr.cpp:2107
+#: src/muuli_wdr.cpp:2055 src/muuli_wdr.cpp:2114
 msgid "IP of the listening interface:"
 msgstr "IP dell'interfaccia di ascolto:"
 
-#: src/muuli_wdr.cpp:2051
+#: src/muuli_wdr.cpp:2058
 msgid "Enter here a valid ip in the a.b.c.d format for the listening EC interface. An empty field or 0.0.0.0 will mean any interface."
 msgstr "Inserisci un IP valido nel formato a.b.c.d per l'interfaccia di ascolto EC. Lasciare il campo vuoto o inserire 0.0.0.0 significa qualsiasi interfaccia."
 
-#: src/muuli_wdr.cpp:2072 src/muuli_wdr.cpp:2156
+#: src/muuli_wdr.cpp:2079 src/muuli_wdr.cpp:2163
 msgid "TCP port:"
 msgstr "Porta TCP:"
 
-#: src/muuli_wdr.cpp:2078
+#: src/muuli_wdr.cpp:2085
 msgid "Enable UPnP port forwarding on the EC port"
 msgstr "Abilita il port forwarding tramite UPnP sulla porta EC"
 
-#: src/muuli_wdr.cpp:2082 src/muuli_wdr.cpp:3041
+#: src/muuli_wdr.cpp:2089 src/muuli_wdr.cpp:3048
 #: src/utils/wxCas/src/wxcasprefs.cpp:167
 msgid "Password"
 msgstr "Password"
 
-#: src/muuli_wdr.cpp:2088
+#: src/muuli_wdr.cpp:2095
 msgid "aMule API server parameters"
 msgstr "Parametri del server API di aMule"
 
-#: src/muuli_wdr.cpp:2091
+#: src/muuli_wdr.cpp:2098
 msgid "Run amuleapi (REST API) on startup"
 msgstr "Avvia amuleapi (REST API) all'avvio"
 
-#: src/muuli_wdr.cpp:2096
+#: src/muuli_wdr.cpp:2103
 msgid "HTTP port:"
 msgstr "Porta HTTP:"
 
-#: src/muuli_wdr.cpp:2110
+#: src/muuli_wdr.cpp:2117
 msgid "The interface amuleapi's HTTP server listens on. 127.0.0.1 (default) accepts only local connections; use 0.0.0.0 or a specific IP to expose it to other hosts (set an admin password below)."
 msgstr "L'interfaccia su cui è in ascolto il server HTTP di amuleapi. 127.0.0.1 (predefinito) accetta solo connessioni locali; usa 0.0.0.0 o un IP specifico per esporlo ad altri host (imposta una password di amministrazione qui sotto)."
 
-#: src/muuli_wdr.cpp:2113
+#: src/muuli_wdr.cpp:2120
 msgid "Admin password"
 msgstr "Password amministrazione"
 
-#: src/muuli_wdr.cpp:2118 src/muuli_wdr.cpp:2149
+#: src/muuli_wdr.cpp:2125 src/muuli_wdr.cpp:2156
 msgid "Low rights password"
 msgstr "Password per diritti limitati"
 
-#: src/muuli_wdr.cpp:2126
+#: src/muuli_wdr.cpp:2133
 msgid "Web server parameters"
 msgstr "Parametri del server web"
 
-#: src/muuli_wdr.cpp:2129
+#: src/muuli_wdr.cpp:2136
 msgid "Run webserver on startup (deprecated)"
 msgstr "Lancia il webserver all'avvio (deprecato)"
 
-#: src/muuli_wdr.cpp:2135
+#: src/muuli_wdr.cpp:2142
 msgid "Web template"
 msgstr "Template web"
 
-#: src/muuli_wdr.cpp:2140
+#: src/muuli_wdr.cpp:2147
 msgid "Full rights password"
 msgstr "Password per diritti completi"
 
-#: src/muuli_wdr.cpp:2144
+#: src/muuli_wdr.cpp:2151
 msgid "Enable Low rights User"
 msgstr "Abilita utente con diritti limitati"
 
-#: src/muuli_wdr.cpp:2163
+#: src/muuli_wdr.cpp:2170
 msgid "Enable UPnP port forwarding of the web server port"
 msgstr "Abilita port forwarding tramite UPnP sulla porta del server web"
 
-#: src/muuli_wdr.cpp:2168
+#: src/muuli_wdr.cpp:2175
 msgid "Web server UPnP TCP port (Optional)"
 msgstr "Porta TCP del  server web per UPnP (Facoltativa)"
 
-#: src/muuli_wdr.cpp:2176
+#: src/muuli_wdr.cpp:2183
 msgid "Page Refresh Time (in secs)"
 msgstr "Intervallo di aggiornamento pagina (in sec)"
 
-#: src/muuli_wdr.cpp:2183
+#: src/muuli_wdr.cpp:2190
 msgid "Enable Gzip compression"
 msgstr "Abilita compressione gzip"
 
-#: src/muuli_wdr.cpp:2217
+#: src/muuli_wdr.cpp:2224
 msgid "Reset page to defaults"
 msgstr "Ripristina i valori predefiniti della pagina"
 
-#: src/muuli_wdr.cpp:2218
+#: src/muuli_wdr.cpp:2225
 msgid "Reset the settings on the current page to their default values."
 msgstr "Ripristina le impostazioni della pagina corrente ai loro valori predefiniti."
 
-#: src/muuli_wdr.cpp:2220 src/muuli_wdr.cpp:2306 src/ServerWnd.cpp:274
+#: src/muuli_wdr.cpp:2227 src/muuli_wdr.cpp:2313 src/ServerWnd.cpp:274
 #: src/ServerWnd.cpp:282
 msgid "OK"
 msgstr "OK"
 
-#: src/muuli_wdr.cpp:2222
+#: src/muuli_wdr.cpp:2229
 msgid "Click here to apply any changes made to the preferences."
 msgstr "Fai click qui per applicare le modifiche apportate alle impostazioni."
 
-#: src/muuli_wdr.cpp:2225
+#: src/muuli_wdr.cpp:2232
 msgid "Reset any changes made to the preferences."
 msgstr "Annulla ogni modifica alle preferenze."
 
-#: src/muuli_wdr.cpp:2254
+#: src/muuli_wdr.cpp:2261
 msgid "Comment :"
 msgstr "Commento:"
 
-#: src/muuli_wdr.cpp:2261
+#: src/muuli_wdr.cpp:2268
 msgid "Incoming Dir :"
 msgstr "Directory file scaricati:"
 
-#: src/muuli_wdr.cpp:2270
+#: src/muuli_wdr.cpp:2277
 msgid "Change priority for new assigned files :"
 msgstr "Cambia priorità per i nuovi file assegnati:"
 
-#: src/muuli_wdr.cpp:2274
+#: src/muuli_wdr.cpp:2281
 msgid "Don't change"
 msgstr "Non modificare"
 
-#: src/muuli_wdr.cpp:2286
+#: src/muuli_wdr.cpp:2293
 msgid "Select color for this Category (currently selected) :"
 msgstr "Seleziona colore per questa categoria (attualmente selezionata):"
 
-#: src/muuli_wdr.cpp:2353 src/muuli_wdr.cpp:2372 src/muuli_wdr.cpp:2394
+#: src/muuli_wdr.cpp:2360 src/muuli_wdr.cpp:2379 src/muuli_wdr.cpp:2401
 msgid "Click this button to reset the log."
 msgstr "Fai clic su questo pulsante per cancellare i log."
 
-#: src/muuli_wdr.cpp:2413
+#: src/muuli_wdr.cpp:2420
 msgid "Click on this button to update the servers list from URL ..."
 msgstr "Fai clic qui per aggiornare la lista dei server dall'indirizzo..."
 
-#: src/muuli_wdr.cpp:2417
+#: src/muuli_wdr.cpp:2424
 msgid "Server list"
 msgstr "Lista server"
 
-#: src/muuli_wdr.cpp:2421
+#: src/muuli_wdr.cpp:2428
 msgid "Enter the url to a server.met file here and press the button to the left to update the list of known servers."
 msgstr "Inserisci l'url di un file server.met e premi il pulsante a sinistra per aggiornare la lista dei server conosciuti."
 
-#: src/muuli_wdr.cpp:2426
+#: src/muuli_wdr.cpp:2433
 msgid "Add server manually: Name"
 msgstr "Aggiungi un server manualmente: Nome"
 
-#: src/muuli_wdr.cpp:2429
+#: src/muuli_wdr.cpp:2436
 msgid "Enter the name of the new server here"
 msgstr "Inserisci qui il nome di un nuovo server"
 
-#: src/muuli_wdr.cpp:2431 src/ServerWnd.cpp:206
+#: src/muuli_wdr.cpp:2438 src/ServerWnd.cpp:206
 msgid "IP:Port"
 msgstr "IP:Porta"
 
-#: src/muuli_wdr.cpp:2434
+#: src/muuli_wdr.cpp:2441
 msgid "Enter the IP of the server here, using the x.x.x.x format."
 msgstr "Inserisci qui l'IP del server, nel formato x.x.x.x."
 
-#: src/muuli_wdr.cpp:2440
+#: src/muuli_wdr.cpp:2447
 msgid "Enter the port of the server here."
 msgstr "Inserisci qui la porta del server."
 
-#: src/muuli_wdr.cpp:2443
+#: src/muuli_wdr.cpp:2450
 msgid "Add manually a server (fill fields to the left before) ..."
 msgstr "Aggiungi server (riempi campi a sinistra)..."
 
-#: src/muuli_wdr.cpp:2472
+#: src/muuli_wdr.cpp:2479
 msgid "aMule Log"
 msgstr "log di aMule"
 
-#: src/muuli_wdr.cpp:2480
+#: src/muuli_wdr.cpp:2487
 msgid "Server Info"
 msgstr "Informazioni server"
 
-#: src/muuli_wdr.cpp:2484
+#: src/muuli_wdr.cpp:2491
 msgid "ED2K Info"
 msgstr "Informazioni ed2k"
 
-#: src/muuli_wdr.cpp:2488
+#: src/muuli_wdr.cpp:2495
 msgid "Kad Info"
 msgstr "Informazioni Kad"
 
-#: src/muuli_wdr.cpp:2516
+#: src/muuli_wdr.cpp:2523
 msgid "Click on this button to update the nodes list from URL ..."
 msgstr "Fai clic su questo pulsante per aggiornare la lista nodi da un URL..."
 
-#: src/muuli_wdr.cpp:2520
+#: src/muuli_wdr.cpp:2527
 msgid "Nodes (0)"
 msgstr "Nodi (0)"
 
-#: src/muuli_wdr.cpp:2524
+#: src/muuli_wdr.cpp:2531
 msgid "Enter the url to a nodes.dat file here and press the button to the left to update the list of known nodes."
 msgstr "Inserisci l'URL di un file nodes.dat e premi il pulsante a sinistra per aggiornare la lista dei nodi conosciuti."
 
-#: src/muuli_wdr.cpp:2527
+#: src/muuli_wdr.cpp:2534
 msgid "Nodes stats"
 msgstr "Statistiche nodi"
 
-#: src/muuli_wdr.cpp:2569
+#: src/muuli_wdr.cpp:2576
 msgid "Bootstrap"
 msgstr "Bootstrap"
 
-#: src/muuli_wdr.cpp:2572
+#: src/muuli_wdr.cpp:2579
 msgid "New node"
 msgstr "Nuovo nodo"
 
-#: src/muuli_wdr.cpp:2577
+#: src/muuli_wdr.cpp:2584
 msgid "IP:"
 msgstr "IP:"
 
-#: src/muuli_wdr.cpp:2597
+#: src/muuli_wdr.cpp:2604
 msgid "Port:"
 msgstr "Porta:"
 
-#: src/muuli_wdr.cpp:2610
+#: src/muuli_wdr.cpp:2617
 msgid "Bootstrap from known clients"
 msgstr "Bootstrap dai client noti"
 
-#: src/muuli_wdr.cpp:2612
+#: src/muuli_wdr.cpp:2619
 msgid "Disconnect Kad"
 msgstr "Disconnetti rete Kad"
 
-#: src/muuli_wdr.cpp:2646
+#: src/muuli_wdr.cpp:2653
 msgid "Use Secure User Identification"
 msgstr "Usa identificazione sicura"
 
-#: src/muuli_wdr.cpp:2648
+#: src/muuli_wdr.cpp:2655
 msgid "It is recommended to enable this option. You will not receive credits if SUI is not enabled."
 msgstr "È consigliato attivare questa opzione. Non riceverai crediti se \" \"l'identificazione non sarà abilitata."
 
-#: src/muuli_wdr.cpp:2650
+#: src/muuli_wdr.cpp:2657
 msgid "Protocol Obfuscation"
 msgstr "Offuscamento del protocollo"
 
-#: src/muuli_wdr.cpp:2653
+#: src/muuli_wdr.cpp:2660
 msgid "Support Protocol Obfuscation"
 msgstr "Supporta offuscamento del protocollo"
 
-#: src/muuli_wdr.cpp:2655
+#: src/muuli_wdr.cpp:2662
 msgid "This option enabled Protocol Obfuscation, and makes aMule accept obfuscated connections from other clients."
 msgstr "Questa opzione abilita l'offuscamento del protocollo, e fa sì che aMule accetti connessioni offuscate dagli altri client."
 
-#: src/muuli_wdr.cpp:2657
+#: src/muuli_wdr.cpp:2664
 msgid "Use obfuscation for outgoing connections"
 msgstr "Utilizza offuscamento per le connessioni in uscita"
 
-#: src/muuli_wdr.cpp:2659
+#: src/muuli_wdr.cpp:2666
 msgid "This option makes aMule use Protocol Obfuscation when connecting other clients/servers."
 msgstr "Questa opzione fa sì che aMule utilizzi l'offuscamento del protocollo quando si collega ad altri client/server."
 
-#: src/muuli_wdr.cpp:2661
+#: src/muuli_wdr.cpp:2668
 msgid "Accept only obfuscated connections"
 msgstr "Accetta SOLO connessioni offuscate"
 
-#: src/muuli_wdr.cpp:2662
+#: src/muuli_wdr.cpp:2669
 msgid "This option makes aMule only accept obfuscated connections. You will have less sources, but all your traffic will be obfuscated"
 msgstr "Attivando questa opzione aMule accetterà solo connessioni offuscate. Avrai meno fonti, ma tutto il tuo traffico sarà offuscato"
 
-#: src/muuli_wdr.cpp:2667
+#: src/muuli_wdr.cpp:2674
 msgid "Everybody"
 msgstr "Chiunque"
 
-#: src/muuli_wdr.cpp:2669
+#: src/muuli_wdr.cpp:2676
 msgid "No one"
 msgstr "Nessuno"
 
-#: src/muuli_wdr.cpp:2671
+#: src/muuli_wdr.cpp:2678
 msgid "Who can see my shared files:"
 msgstr "Chi può vedere i miei file condivisi:"
 
-#: src/muuli_wdr.cpp:2672
+#: src/muuli_wdr.cpp:2679
 msgid "Select who can request to view a list of your shared files."
 msgstr "Seleziona chi può richiedere di vedere la lista dei tuoi file condivisi."
 
-#: src/muuli_wdr.cpp:2674
+#: src/muuli_wdr.cpp:2681
 msgid "IP-Filtering"
 msgstr "Filtraggio IP"
 
-#: src/muuli_wdr.cpp:2681
+#: src/muuli_wdr.cpp:2688
 msgid "Filter clients"
 msgstr "Filtra i client"
 
-#: src/muuli_wdr.cpp:2683
+#: src/muuli_wdr.cpp:2690
 msgid "Enable filtering of the client IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "Filtra i client in base agli ip contenuti in ~/.aMule/ipfilter.dat."
 
-#: src/muuli_wdr.cpp:2685
+#: src/muuli_wdr.cpp:2692
 msgid "Filter servers"
 msgstr "Filtra i server"
 
-#: src/muuli_wdr.cpp:2687
+#: src/muuli_wdr.cpp:2694
 msgid "Enable filtering of the server IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "Filtra i server in base agli ip contenuti in ~/.aMule/ipfilter.dat."
 
-#: src/muuli_wdr.cpp:2691
+#: src/muuli_wdr.cpp:2698
 msgid "Reload List"
 msgstr "Ricarica lista"
 
-#: src/muuli_wdr.cpp:2692
+#: src/muuli_wdr.cpp:2699
 msgid "Reload the list of IPs to filter from the file ~/.aMule/ipfilter.dat"
 msgstr "Ricarica lista degli IP da filtrare dal file ~/.aMule/ipfilter.dat"
 
-#: src/muuli_wdr.cpp:2698
+#: src/muuli_wdr.cpp:2705
 msgid "URL:"
 msgstr "URL:"
 
-#: src/muuli_wdr.cpp:2702 src/muuli_wdr.cpp:2895
+#: src/muuli_wdr.cpp:2709 src/muuli_wdr.cpp:2902
 msgid "Update now"
 msgstr "Aggiorna ora"
 
-#: src/muuli_wdr.cpp:2705
+#: src/muuli_wdr.cpp:2712
 msgid "Auto-update ipfilter at startup"
 msgstr "Aggiorna ipfilter all'avvio"
 
-#: src/muuli_wdr.cpp:2709
+#: src/muuli_wdr.cpp:2716
 msgid "Filtering Level:"
 msgstr "Livello filtraggio:"
 
-#: src/muuli_wdr.cpp:2715
+#: src/muuli_wdr.cpp:2722
 msgid "Always filter LAN IPs"
 msgstr "Filtra sempre gli IP di una LAN"
 
-#: src/muuli_wdr.cpp:2718
+#: src/muuli_wdr.cpp:2725
 msgid "Paranoid handling of non-matching IPs"
 msgstr "Gestione paranoica degli IP non corrispondenti"
 
-#: src/muuli_wdr.cpp:2720
+#: src/muuli_wdr.cpp:2727
 msgid "Rejects a packet when its source IP differs from the IP the client claims (an anti-spoofing check). Disable only if it causes connection problems."
 msgstr "Rifiuta un pacchetto quando l'IP di origine è diverso dall'IP dichiarato dal client (un controllo anti-spoofing). Disabilitare solo se causa problemi di connessione."
 
-#: src/muuli_wdr.cpp:2722
+#: src/muuli_wdr.cpp:2729
 msgid "Use system-wide ipfilter.dat if available"
 msgstr "Usa l'ipfilter.dat di sistema se disponibile"
 
-#: src/muuli_wdr.cpp:2723
+#: src/muuli_wdr.cpp:2730
 msgid "If there's no local ipfilter.dat found, allow usage of a system-wide ipfilter file."
 msgstr "Se un file ipfilter.dat locale non viene trovato, consenti l'utilizzo del file ipfilter.dat di sistema."
 
-#: src/muuli_wdr.cpp:2740
+#: src/muuli_wdr.cpp:2747
 msgid "Enable Online-Signature"
 msgstr "Abilita Online Signature"
 
-#: src/muuli_wdr.cpp:2742
+#: src/muuli_wdr.cpp:2749
 msgid "Enables the writing of the OS file, which can be used by external apps to create signatures and the like."
 msgstr "Abilita la scrittura del file OS che può essere usato da applicazioni esterne per creare firme e simili."
 
-#: src/muuli_wdr.cpp:2746
+#: src/muuli_wdr.cpp:2753
 msgid "Update Frequency (Secs):"
 msgstr "Frequenza di aggiornamento (secondi):"
 
-#: src/muuli_wdr.cpp:2749
+#: src/muuli_wdr.cpp:2756
 msgid "Change the frequency (in seconds) of Online Signature updates."
 msgstr "Cambia la frequenza (in secondi) degli aggiornamenti dell'Online Signature."
 
-#: src/muuli_wdr.cpp:2757
+#: src/muuli_wdr.cpp:2764
 msgid "Save online signature file in: "
 msgstr "Salva la firma in linea in: "
 
-#: src/muuli_wdr.cpp:2763
+#: src/muuli_wdr.cpp:2770
 msgid "Click here to select the directory containing the the Online Signature files."
 msgstr "Clicca qui per selezionare la directory che contiene i file dell'Online Signature."
 
-#: src/muuli_wdr.cpp:2796
+#: src/muuli_wdr.cpp:2803
 msgid "Show country flags for clients"
 msgstr "Mostra la nazionalità dei client"
 
-#: src/muuli_wdr.cpp:2797
+#: src/muuli_wdr.cpp:2804
 msgid "Render the country flag column in the transfers, queue and search views. Requires a valid MMDB GeoIP database (see below)."
 msgstr "Mostra la colonna delle bandiere dei paesi nelle viste trasferimenti, coda e ricerca. Richiede un database GeoIP MMDB valido (vedi sotto)."
 
-#: src/muuli_wdr.cpp:2802
+#: src/muuli_wdr.cpp:2809
 msgid "Database"
 msgstr "Database"
 
-#: src/muuli_wdr.cpp:2818
+#: src/muuli_wdr.cpp:2825
 msgid "Source:"
 msgstr "Sorgente:"
 
-#: src/muuli_wdr.cpp:2821
+#: src/muuli_wdr.cpp:2828
 msgid "DB-IP (free, no account)"
 msgstr "DB-IP (gratuito, nessun account)"
 
-#: src/muuli_wdr.cpp:2822
+#: src/muuli_wdr.cpp:2829
 msgid "MaxMind GeoLite2 (free, account required)"
 msgstr "MaxMind GeoLite2 (gratuito, richiede account)"
 
-#: src/muuli_wdr.cpp:2823
+#: src/muuli_wdr.cpp:2830
 msgid "Custom URL"
 msgstr "URL personalizzato"
 
-#: src/muuli_wdr.cpp:2826
+#: src/muuli_wdr.cpp:2833
 msgid "Choose which provider supplies the GeoIP MMDB database. DB-IP is the default - no account required. MaxMind requires a free account + license key. Use Custom URL to point at any other MMDB host (e.g. a local mirror)."
 msgstr "Scegli quale provider fornisce il database GeoIP MMDB. DB-IP è il default - nessun account richiesto. MaxMind richiede un account gratuito + license key. Usa URL personalizzato per puntare a qualsiasi altro host MMDB (es. un mirror locale)."
 
-#: src/muuli_wdr.cpp:2843
+#: src/muuli_wdr.cpp:2850
 msgid ""
 "No configuration required.\n"
 "\n"
@@ -4823,11 +4837,11 @@ msgstr ""
 "Dati IP-to-Country di DB-IP.com - https://db-ip.com\n"
 "Licenza: Creative Commons BY 4.0 - https://creativecommons.org/licenses/by/4.0/"
 
-#: src/muuli_wdr.cpp:2856
+#: src/muuli_wdr.cpp:2863
 msgid "License key:"
 msgstr "License key:"
 
-#: src/muuli_wdr.cpp:2862
+#: src/muuli_wdr.cpp:2869
 msgid ""
 "Sign up for a free MaxMind account, then generate a License Key:\n"
 "https://www.maxmind.com/en/geolite2/signup\n"
@@ -4843,11 +4857,11 @@ msgstr ""
 "Licenza: MaxMind GeoLite2 EULA - https://www.maxmind.com/en/geolite2/eula\n"
 "Richiede attribuzione e registrazione dell'account; aggiornare almeno ogni 30 giorni."
 
-#: src/muuli_wdr.cpp:2877
+#: src/muuli_wdr.cpp:2884
 msgid "Download URL:"
 msgstr "URL di scaricamento:"
 
-#: src/muuli_wdr.cpp:2883
+#: src/muuli_wdr.cpp:2890
 msgid ""
 "Must point to an .mmdb file or a .gz / .tar.gz containing one.\n"
 "URL may include credentials (https://user:pass@host/...).\n"
@@ -4857,211 +4871,211 @@ msgstr ""
 "L'URL può includere credenziali (https://user:pass@host/...).\n"
 "I termini di licenza e attribuzione sono definiti dall'URL upstream - ne sei responsabile."
 
-#: src/muuli_wdr.cpp:2896
+#: src/muuli_wdr.cpp:2903
 msgid "Download the GeoIP database from the selected source."
 msgstr "Scarica il database GeoIP dalla sorgente selezionata."
 
-#: src/muuli_wdr.cpp:2898
+#: src/muuli_wdr.cpp:2905
 msgid "Auto-update on startup"
 msgstr "Aggiornamento automatico all'avvio"
 
-#: src/muuli_wdr.cpp:2899
+#: src/muuli_wdr.cpp:2906
 msgid "Re-download the GeoIP database from the selected source every time aMule starts."
 msgstr "Riscarica il database GeoIP dalla sorgente selezionata ogni volta che aMule si avvia."
 
-#: src/muuli_wdr.cpp:2922
+#: src/muuli_wdr.cpp:2929
 msgid "Filter incoming messages (except current chat):"
 msgstr "Filtra messaggi in arrivo (tranne per la chat in corso):"
 
-#: src/muuli_wdr.cpp:2924
+#: src/muuli_wdr.cpp:2931
 msgid "Filter all messages"
 msgstr "Filtra tutti i messaggi"
 
-#: src/muuli_wdr.cpp:2926
+#: src/muuli_wdr.cpp:2933
 msgid "Filter messages from people not on your friend list"
 msgstr "Filtra i messaggi da utenti che non sono nella tua lista degli amici"
 
-#: src/muuli_wdr.cpp:2928
+#: src/muuli_wdr.cpp:2935
 msgid "Filter messages from unknown clients"
 msgstr "Filtra i messaggi da client sconosciuti"
 
-#: src/muuli_wdr.cpp:2930
+#: src/muuli_wdr.cpp:2937
 msgid "Filter messages containing (use ',' as separator):"
 msgstr "Filtra i messaggi che contengono (usa ',' come separatore):"
 
-#: src/muuli_wdr.cpp:2933 src/muuli_wdr.cpp:2944
+#: src/muuli_wdr.cpp:2940 src/muuli_wdr.cpp:2951
 msgid "add here the words amule should filter and block messages including it"
 msgstr "aggiungi qui le parole che aMule filtrerà rimuovendo i messaggi che le contengono"
 
-#: src/muuli_wdr.cpp:2935
+#: src/muuli_wdr.cpp:2942
 msgid "Show received messages in the log"
 msgstr "Mostra nel log i messaggi ricevuti"
 
-#: src/muuli_wdr.cpp:2938
+#: src/muuli_wdr.cpp:2945
 msgid "Comments"
 msgstr "Commenti"
 
-#: src/muuli_wdr.cpp:2941
+#: src/muuli_wdr.cpp:2948
 msgid "Filter comments containing (use ',' as separator):"
 msgstr "Filtra i commenti contenenti (usa ',' come separatore):"
 
-#: src/muuli_wdr.cpp:2966
+#: src/muuli_wdr.cpp:2973
 msgid "Enable Proxy"
 msgstr "Abilita proxy"
 
-#: src/muuli_wdr.cpp:2967
+#: src/muuli_wdr.cpp:2974
 msgid "Enable/disable proxy support"
 msgstr "Abilita o disabilita il supporto proxy"
 
-#: src/muuli_wdr.cpp:2970
+#: src/muuli_wdr.cpp:2977
 msgid "Proxy type:"
 msgstr "Tipo proxy:"
 
-#: src/muuli_wdr.cpp:2981
+#: src/muuli_wdr.cpp:2988
 msgid "Proxy host:"
 msgstr "Indirizzo proxy:"
 
-#: src/muuli_wdr.cpp:2984
+#: src/muuli_wdr.cpp:2991
 msgid "The proxy host name"
 msgstr "Il nome host del proxy"
 
-#: src/muuli_wdr.cpp:2986
+#: src/muuli_wdr.cpp:2993
 msgid "Proxy port:"
 msgstr "Porta proxy:"
 
-#: src/muuli_wdr.cpp:2989
+#: src/muuli_wdr.cpp:2996
 msgid "The proxy port"
 msgstr "La porta del proxy"
 
-#: src/muuli_wdr.cpp:2991
+#: src/muuli_wdr.cpp:2998
 msgid "Enable authentication"
 msgstr "Abilita autenticazione"
 
-#: src/muuli_wdr.cpp:2992
+#: src/muuli_wdr.cpp:2999
 msgid "Enable/disable username/password authentication"
 msgstr "Abilita o disabilita l'autenticazione con nome utente e password"
 
-#: src/muuli_wdr.cpp:2995
+#: src/muuli_wdr.cpp:3002
 msgid "Username: "
 msgstr "Nome utente: "
 
-#: src/muuli_wdr.cpp:2998
+#: src/muuli_wdr.cpp:3005
 msgid "The username to use to connect to the proxy"
 msgstr "Nome utente utilizzato per la connessione al proxy"
 
-#: src/muuli_wdr.cpp:3000
+#: src/muuli_wdr.cpp:3007
 msgid "Password:"
 msgstr "Password:"
 
-#: src/muuli_wdr.cpp:3003
+#: src/muuli_wdr.cpp:3010
 msgid "The password to use to connect to the proxy"
 msgstr "La password usata per la connessione al proxy"
 
-#: src/muuli_wdr.cpp:3022
+#: src/muuli_wdr.cpp:3029
 msgid "Connect to:"
 msgstr "Connetti a:"
 
-#: src/muuli_wdr.cpp:3031
+#: src/muuli_wdr.cpp:3038
 msgid "Login to remote amule"
 msgstr "Login su aMule remoto"
 
-#: src/muuli_wdr.cpp:3036
+#: src/muuli_wdr.cpp:3043
 msgid "User name"
 msgstr "Nome utente"
 
-#: src/muuli_wdr.cpp:3047
+#: src/muuli_wdr.cpp:3054
 msgid "Remember those settings"
 msgstr "Ricorda impostazioni"
 
-#: src/muuli_wdr.cpp:3050
+#: src/muuli_wdr.cpp:3057
 msgid "Force ZLIB compression"
 msgstr "Forza la compressione ZLIB"
 
-#: src/muuli_wdr.cpp:3074
+#: src/muuli_wdr.cpp:3081
 msgid "Enable Verbose Debug-Logging."
 msgstr "Abilita il log dettagliato dei messaggi di debug."
 
-#: src/muuli_wdr.cpp:3076
+#: src/muuli_wdr.cpp:3083
 msgid "Only to Logfile"
 msgstr "Solamente sul file di log"
 
-#: src/muuli_wdr.cpp:3078
+#: src/muuli_wdr.cpp:3085
 msgid "Message Categories:"
 msgstr "Categorie messaggi:"
 
-#: src/muuli_wdr.cpp:3102 src/PartFileConvertDlg.cpp:160
+#: src/muuli_wdr.cpp:3109 src/PartFileConvertDlg.cpp:160
 msgid "Waiting..."
 msgstr "In attesa..."
 
-#: src/muuli_wdr.cpp:3122
+#: src/muuli_wdr.cpp:3129
 msgid "Add imports"
 msgstr "Aggiungi importazioni"
 
-#: src/muuli_wdr.cpp:3125
+#: src/muuli_wdr.cpp:3132
 msgid "Retry selected"
 msgstr "Riprova selezionati"
 
-#: src/muuli_wdr.cpp:3127
+#: src/muuli_wdr.cpp:3134
 msgid "Remove selected"
 msgstr "Rimuovi selezionati"
 
-#: src/muuli_wdr.cpp:3190
+#: src/muuli_wdr.cpp:3197
 msgid "Event Types"
 msgstr "Tipi di evento"
 
-#: src/muuli_wdr.cpp:3209
+#: src/muuli_wdr.cpp:3216
 msgid "Statistics and queued clients for selected file(s) : Session / All time"
 msgstr "Statistiche e client in coda per i(l) file selezionati(o) : Sessione / Totale"
 
-#: src/muuli_wdr.cpp:3233
+#: src/muuli_wdr.cpp:3240
 msgid "Active Uploads"
 msgstr "Upload attivi"
 
-#: src/muuli_wdr.cpp:3247
+#: src/muuli_wdr.cpp:3254
 msgid "Percent of total files"
 msgstr "Percentuale di file totali"
 
-#: src/muuli_wdr.cpp:3299
+#: src/muuli_wdr.cpp:3306
 msgid "Show Clients for"
 msgstr "Mostra client per"
 
-#: src/muuli_wdr.cpp:3301
+#: src/muuli_wdr.cpp:3308
 msgid "All files"
 msgstr "Tutti i file"
 
-#: src/muuli_wdr.cpp:3304
+#: src/muuli_wdr.cpp:3311
 msgid "Selected files"
 msgstr "File selezionati"
 
-#: src/muuli_wdr.cpp:3307
+#: src/muuli_wdr.cpp:3314
 msgid "Active uploads only"
 msgstr "Solo upload attivi"
 
-#: src/muuli_wdr.cpp:3314
+#: src/muuli_wdr.cpp:3321
 msgid "Reload:"
 msgstr "Ricarica lista:"
 
-#: src/muuli_wdr.cpp:3318
+#: src/muuli_wdr.cpp:3325
 msgid "Reload your shared files"
 msgstr "Ricarica file condivisi"
 
-#: src/muuli_wdr.cpp:3381
+#: src/muuli_wdr.cpp:3388
 msgid "Send"
 msgstr "Invia"
 
-#: src/muuli_wdr.cpp:3382
+#: src/muuli_wdr.cpp:3389
 msgid "Sends the specified message."
 msgstr "Invia messaggio specificato."
 
-#: src/muuli_wdr.cpp:3386
+#: src/muuli_wdr.cpp:3393
 msgid "Close this chat-session."
 msgstr "Chiude questa sessione di chat."
 
-#: src/muuli_wdr.cpp:3409
+#: src/muuli_wdr.cpp:3416
 msgid "Connect to any server and/or Kad"
 msgstr "Connetti a qualsiasi server e/o a Kad"
 
-#: src/muuli_wdr.cpp:3415 src/SharedFilesCtrl.cpp:142 src/Statistics.cpp:941
+#: src/muuli_wdr.cpp:3422 src/SharedFilesCtrl.cpp:142 src/Statistics.cpp:941
 msgid "Shared Files"
 msgstr "File condivisi"
 
@@ -5421,187 +5435,187 @@ msgstr "Scaricato"
 msgid "ERROR: Failed to open partfile '%s'"
 msgstr "ERRORE: Apertura del file Part fallita '%s'"
 
-#: src/Preferences.cpp:673
+#: src/Preferences.cpp:674
 msgid "System default"
 msgstr "Predefinita di sistema"
 
-#: src/Preferences.cpp:674
+#: src/Preferences.cpp:675
 msgid "Albanian"
 msgstr "Albanese"
 
-#: src/Preferences.cpp:675
+#: src/Preferences.cpp:676
 msgid "Arabic"
 msgstr "Arabo"
 
-#: src/Preferences.cpp:676
+#: src/Preferences.cpp:677
 msgid "Asturian"
 msgstr "Asturiano"
 
-#: src/Preferences.cpp:677
+#: src/Preferences.cpp:678
 msgid "Basque"
 msgstr "Basco"
 
-#: src/Preferences.cpp:678
+#: src/Preferences.cpp:679
 msgid "Bulgarian"
 msgstr "Bulgaro"
 
-#: src/Preferences.cpp:679
+#: src/Preferences.cpp:680
 msgid "Catalan"
 msgstr "Catalano"
 
-#: src/Preferences.cpp:680
+#: src/Preferences.cpp:681
 msgid "Chinese (Simplified)"
 msgstr "Cinese (semplificato)"
 
-#: src/Preferences.cpp:681
+#: src/Preferences.cpp:682
 msgid "Chinese (Traditional)"
 msgstr "Cinese (tradizionale)"
 
-#: src/Preferences.cpp:682
+#: src/Preferences.cpp:683
 msgid "Croatian"
 msgstr "Croato"
 
-#: src/Preferences.cpp:683
+#: src/Preferences.cpp:684
 msgid "Czech"
 msgstr "Ceco"
 
-#: src/Preferences.cpp:684
+#: src/Preferences.cpp:685
 msgid "Danish"
 msgstr "Danese"
 
-#: src/Preferences.cpp:685
+#: src/Preferences.cpp:686
 msgid "Dutch"
 msgstr "Olandese"
 
-#: src/Preferences.cpp:686
+#: src/Preferences.cpp:687
 msgid "English (U.K.)"
 msgstr "Inglese (Regno Unito)"
 
-#: src/Preferences.cpp:687
+#: src/Preferences.cpp:688
 msgid "English (U.S.)"
 msgstr "Inglese (U.S.)"
 
-#: src/Preferences.cpp:688
+#: src/Preferences.cpp:689
 msgid "Estonian"
 msgstr "Estone"
 
-#: src/Preferences.cpp:689
+#: src/Preferences.cpp:690
 msgid "Finnish"
 msgstr "Finlandese"
 
-#: src/Preferences.cpp:690
+#: src/Preferences.cpp:691
 msgid "French"
 msgstr "Francese"
 
-#: src/Preferences.cpp:691
+#: src/Preferences.cpp:692
 msgid "Galician"
 msgstr "Galiziano"
 
-#: src/Preferences.cpp:692
+#: src/Preferences.cpp:693
 msgid "German"
 msgstr "Tedesco"
 
-#: src/Preferences.cpp:693
+#: src/Preferences.cpp:694
 msgid "Greek"
 msgstr "Greco"
 
-#: src/Preferences.cpp:694
+#: src/Preferences.cpp:695
 msgid "Hebrew"
 msgstr "Ebraico"
 
-#: src/Preferences.cpp:695
+#: src/Preferences.cpp:696
 msgid "Hungarian"
 msgstr "Ungherese"
 
-#: src/Preferences.cpp:696
+#: src/Preferences.cpp:697
 msgid "Italian"
 msgstr "Italiano"
 
-#: src/Preferences.cpp:697
+#: src/Preferences.cpp:698
 msgid "Japanese"
 msgstr "Giapponese"
 
-#: src/Preferences.cpp:698
+#: src/Preferences.cpp:699
 msgid "Korean"
 msgstr "Coreano"
 
-#: src/Preferences.cpp:699
+#: src/Preferences.cpp:700
 msgid "Latvian"
 msgstr "Lettone"
 
-#: src/Preferences.cpp:700
+#: src/Preferences.cpp:701
 msgid "Lithuanian"
 msgstr "Lituano"
 
-#: src/Preferences.cpp:701
+#: src/Preferences.cpp:702
 msgid "Norwegian (Nynorsk)"
 msgstr "Norvegese (Nynorsk)"
 
-#: src/Preferences.cpp:702
+#: src/Preferences.cpp:703
 msgid "Polish"
 msgstr "Polacco"
 
-#: src/Preferences.cpp:703
+#: src/Preferences.cpp:704
 msgid "Portuguese"
 msgstr "Portoghese"
 
-#: src/Preferences.cpp:704
+#: src/Preferences.cpp:705
 msgid "Portuguese (Brazilian)"
 msgstr "Portoghese (Brasile)"
 
-#: src/Preferences.cpp:705
+#: src/Preferences.cpp:706
 msgid "Romanian"
 msgstr "Romeno"
 
-#: src/Preferences.cpp:706
+#: src/Preferences.cpp:707
 msgid "Russian"
 msgstr "Russo"
 
-#: src/Preferences.cpp:707
+#: src/Preferences.cpp:708
 msgid "Slovenian"
 msgstr "Sloveno"
 
-#: src/Preferences.cpp:708
+#: src/Preferences.cpp:709
 msgid "Spanish"
 msgstr "Spagnolo"
 
-#: src/Preferences.cpp:709
+#: src/Preferences.cpp:710
 msgid "Swedish"
 msgstr "Svedese"
 
-#: src/Preferences.cpp:710
+#: src/Preferences.cpp:711
 msgid "Turkish"
 msgstr "Turco"
 
-#: src/Preferences.cpp:711
+#: src/Preferences.cpp:712
 msgid "Ukrainian"
 msgstr "Ucraino"
 
-#: src/Preferences.cpp:814
+#: src/Preferences.cpp:815
 msgid "Change Language"
 msgstr "Cambia lingua"
 
-#: src/Preferences.cpp:878
+#: src/Preferences.cpp:879
 msgid "There are no translations installed for aMule"
 msgstr "Non ci sono traduzioni di aMule installate"
 
-#: src/Preferences.cpp:879
+#: src/Preferences.cpp:880
 msgid "No languages available"
 msgstr "Nessuna lingua disponibile"
 
-#: src/Preferences.cpp:1010
+#: src/Preferences.cpp:1011
 msgid "no options available"
 msgstr "nessuna opzione disponibile"
 
-#: src/Preferences.cpp:2179
+#: src/Preferences.cpp:2182
 msgid "Invalid category found, skipping"
 msgstr "Trovata categoria non valida, ignorata"
 
-#: src/Preferences.cpp:2348
+#: src/Preferences.cpp:2351
 msgid "TCP port can't be higher than 65532 due to server UDP socket being TCP+3"
 msgstr "La porta TCP non può essere superiore a 65532 perché il socket UDP è fissato a TCP+3"
 
-#: src/Preferences.cpp:2349
+#: src/Preferences.cpp:2352
 #, c-format
 msgid "Default port will be used (%d)"
 msgstr "Sarà usata la porta predefinita (%d)"
@@ -6101,23 +6115,27 @@ msgstr "Ricarica file condivisi: %u file analizzati"
 msgid "Shared folder"
 msgstr "Cartella condivisa"
 
-#: src/SearchDlg.cpp:425
+#: src/SearchDlg.cpp:280
+msgid "Clear search history"
+msgstr ""
+
+#: src/SearchDlg.cpp:584
 msgid "It's impossible to search when both eD2k and Kademlia are disabled."
 msgstr "Impossibile avviare ricerche con eD2k e Kademlia entrambi disabilitati."
 
-#: src/SearchDlg.cpp:426 src/SearchListCtrl.cpp:858
+#: src/SearchDlg.cpp:585 src/SearchListCtrl.cpp:858
 msgid "Search error"
 msgstr "Errore di ricerca"
 
-#: src/SearchDlg.cpp:768
+#: src/SearchDlg.cpp:929
 msgid "Min size must be smaller than max size. Max size ignored."
 msgstr "Min size deve essere più piccola di max size. Ignoro max size."
 
-#: src/SearchDlg.cpp:769 src/SearchDlg.cpp:851
+#: src/SearchDlg.cpp:930 src/SearchDlg.cpp:1012
 msgid "Search warning"
 msgstr "Avviso di ricerca"
 
-#: src/SearchDlg.cpp:929 src/SearchListCtrl.cpp:735
+#: src/SearchDlg.cpp:1092 src/SearchListCtrl.cpp:735
 msgid "Main"
 msgstr "Principale"
 

--- a/po/it.po
+++ b/po/it.po
@@ -19,7 +19,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule 2.3.3\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-28 12:17+0200\n"
+"POT-Creation-Date: 2026-07-28 13:09+0200\n"
 "PO-Revision-Date: 2026-07-27 11:40+0000\n"
 "Last-Translator: got3nks <got3nks@users.noreply.github.com>\n"
 "Language-Team: SebastianoPistore.info@protonmail.ch\n"
@@ -302,7 +302,7 @@ msgid "Password set and external connections enabled."
 msgstr "Password impostata, connessioni esterne abilitate."
 
 #: src/amule.cpp:755 src/KadDlg.cpp:176 src/KadDlg.cpp:185
-#: src/PrefsUnifiedDlg.cpp:1461 src/SharedFilesCtrl.cpp:476
+#: src/PrefsUnifiedDlg.cpp:1470 src/SharedFilesCtrl.cpp:476
 msgid "WARNING"
 msgstr "ATTENZIONE"
 
@@ -343,7 +343,7 @@ msgstr "Hai scelto di lanciare il web server all'avvio, ma il programma amuleweb
 #: src/amule-remote-gui.cpp:603 src/amule-remote-gui.cpp:671
 #: src/amule-remote-gui.cpp:709 src/amule-remote-gui.cpp:1282
 #: src/amule-remote-gui.cpp:1345 src/amule-remote-gui.cpp:1372
-#: src/DownloadQueue.cpp:1481 src/PrefsUnifiedDlg.cpp:1247
+#: src/DownloadQueue.cpp:1481 src/PrefsUnifiedDlg.cpp:1256
 msgid "ERROR"
 msgstr "ERRORE"
 
@@ -603,36 +603,36 @@ msgstr "Visita https://github.com/amule-org/amule/releases/latest per controllar
 msgid "FATAL ERROR: Failed to create Timer"
 msgstr "ERRORE FATALE: Creazione timer fallita"
 
-#: src/amuleDlg.cpp:361 src/amuleDlg.cpp:1787 src/amuleDlg.cpp:2033
-#: src/muuli_wdr.cpp:1492 src/muuli_wdr.cpp:3449
+#: src/amuleDlg.cpp:361 src/amuleDlg.cpp:1810 src/amuleDlg.cpp:2056
+#: src/muuli_wdr.cpp:1492 src/muuli_wdr.cpp:3453
 msgid "Networks"
 msgstr "Reti"
 
-#: src/amuleDlg.cpp:362 src/amuleDlg.cpp:1793 src/muuli_wdr.cpp:3450
+#: src/amuleDlg.cpp:362 src/amuleDlg.cpp:1816 src/muuli_wdr.cpp:3454
 msgid "Searches"
 msgstr "Ricerca"
 
-#: src/amuleDlg.cpp:363 src/amuleDlg.cpp:1799 src/DownloadListCtrl.cpp:740
-#: src/muuli_wdr.cpp:392 src/muuli_wdr.cpp:1585 src/muuli_wdr.cpp:3451
+#: src/amuleDlg.cpp:363 src/amuleDlg.cpp:1822 src/DownloadListCtrl.cpp:740
+#: src/muuli_wdr.cpp:392 src/muuli_wdr.cpp:1585 src/muuli_wdr.cpp:3455
 #: src/Statistics.cpp:829
 msgid "Downloads"
 msgstr "Download"
 
-#: src/amuleDlg.cpp:364 src/amuleDlg.cpp:1805 src/muuli_wdr.cpp:3325
+#: src/amuleDlg.cpp:364 src/amuleDlg.cpp:1828 src/muuli_wdr.cpp:3329
 msgid "Shared files"
 msgstr "File condivisi"
 
-#: src/amuleDlg.cpp:365 src/amuleDlg.cpp:1811 src/muuli_wdr.cpp:2957
-#: src/muuli_wdr.cpp:3407 src/muuli_wdr.cpp:3454
+#: src/amuleDlg.cpp:365 src/amuleDlg.cpp:1834 src/muuli_wdr.cpp:2961
+#: src/muuli_wdr.cpp:3411 src/muuli_wdr.cpp:3458
 msgid "Messages"
 msgstr "Messaggi"
 
-#: src/amuleDlg.cpp:366 src/amuleDlg.cpp:1817 src/muuli_wdr.cpp:3455
+#: src/amuleDlg.cpp:366 src/amuleDlg.cpp:1840 src/muuli_wdr.cpp:3459
 #: src/PrefsUnifiedDlg.cpp:314 src/Statistics.cpp:779 src/Statistics.cpp:1235
 msgid "Statistics"
 msgstr "Statistiche"
 
-#: src/amuleDlg.cpp:368 src/amuleDlg.cpp:1824 src/muuli_wdr.cpp:3457
+#: src/amuleDlg.cpp:368 src/amuleDlg.cpp:1847 src/muuli_wdr.cpp:3461
 #: src/PrefsUnifiedDlg.cpp:330 src/utils/wxCas/src/wxcasprefs.cpp:39
 msgid "Preferences"
 msgstr "Preferenze"
@@ -695,8 +695,8 @@ msgstr "Kad: Spento"
 #: src/amuleDlg.cpp:1029 src/DownloadListCtrl.cpp:505
 #: src/DownloadListCtrl.cpp:749 src/FriendListCtrl.cpp:180
 #: src/muuli_wdr.cpp:731 src/muuli_wdr.cpp:782 src/muuli_wdr.cpp:846
-#: src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2262 src/muuli_wdr.cpp:2347
-#: src/muuli_wdr.cpp:3095 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
+#: src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2266 src/muuli_wdr.cpp:2351
+#: src/muuli_wdr.cpp:3099 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
 #: src/ServerListCtrl.cpp:606 src/TransferWnd.cpp:378
 #: src/utils/wxCas/src/wxcasprefs.cpp:235
 msgid "Cancel"
@@ -707,7 +707,7 @@ msgid "Stop the current connection attempts"
 msgstr "Ferma i tentativi di connessione in corso"
 
 #: src/amuleDlg.cpp:1035 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976
-#: src/muuli_wdr.cpp:2485
+#: src/muuli_wdr.cpp:2489
 msgid "Disconnect"
 msgstr "Disconnetti"
 
@@ -716,7 +716,7 @@ msgid "Disconnect from the currently connected networks"
 msgstr "Disconnetti dalle reti a cui sei connesso"
 
 #: src/amuleDlg.cpp:1041 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979
-#: src/muuli_wdr.cpp:2640 src/muuli_wdr.cpp:3092 src/muuli_wdr.cpp:3447
+#: src/muuli_wdr.cpp:2644 src/muuli_wdr.cpp:3096 src/muuli_wdr.cpp:3451
 msgid "Connect"
 msgstr "Connetti"
 
@@ -770,7 +770,7 @@ msgstr "Chiedi conferma prima di uscire"
 msgid "Launch Command: "
 msgstr "Comando di avvio: "
 
-#: src/amuleDlg.cpp:1632 src/muuli_wdr.cpp:1982 src/Preferences.cpp:979
+#: src/amuleDlg.cpp:1632 src/muuli_wdr.cpp:1986 src/Preferences.cpp:979
 msgid "- default -"
 msgstr "- predefinita -"
 
@@ -784,60 +784,60 @@ msgstr "La directory delle skin '%s' non esiste"
 msgid "WARNING: Unable to open skin file '%s' for read"
 msgstr "ATTENZIONE: Impossibile aprire il file della skin '%s' in lettura"
 
-#: src/amuleDlg.cpp:1791 src/muuli_wdr.cpp:3449
+#: src/amuleDlg.cpp:1814 src/muuli_wdr.cpp:3453
 msgid "Networks Window"
 msgstr "Finestra reti"
 
-#: src/amuleDlg.cpp:1797 src/muuli_wdr.cpp:3450
+#: src/amuleDlg.cpp:1820 src/muuli_wdr.cpp:3454
 msgid "Searches Window"
 msgstr "Finestra ricerche"
 
-#: src/amuleDlg.cpp:1803 src/muuli_wdr.cpp:3451
+#: src/amuleDlg.cpp:1826 src/muuli_wdr.cpp:3455
 msgid "Downloads Window"
 msgstr "Finestra dei Download"
 
-#: src/amuleDlg.cpp:1809 src/muuli_wdr.cpp:3453
+#: src/amuleDlg.cpp:1832 src/muuli_wdr.cpp:3457
 msgid "Shared Files Window"
 msgstr "Finestra file condivisi"
 
-#: src/amuleDlg.cpp:1815 src/muuli_wdr.cpp:3454
+#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3458
 msgid "Messages Window"
 msgstr "Finestra messaggi"
 
-#: src/amuleDlg.cpp:1821 src/muuli_wdr.cpp:3455
+#: src/amuleDlg.cpp:1844 src/muuli_wdr.cpp:3459
 msgid "Statistics Graph Window"
 msgstr "Finestra grafici e statistiche"
 
-#: src/amuleDlg.cpp:1828 src/muuli_wdr.cpp:3457
+#: src/amuleDlg.cpp:1851 src/muuli_wdr.cpp:3461
 msgid "Preferences Settings Window"
 msgstr "Finestra Preferenze"
 
-#: src/amuleDlg.cpp:1831 src/muuli_wdr.cpp:3458
+#: src/amuleDlg.cpp:1854 src/muuli_wdr.cpp:3462
 msgid "Import"
 msgstr "Importazione"
 
-#: src/amuleDlg.cpp:1835 src/muuli_wdr.cpp:3458
+#: src/amuleDlg.cpp:1858 src/muuli_wdr.cpp:3462
 msgid "The partfile importer tool"
 msgstr "Strumento per l'importazione dei file parziali"
 
-#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3459
+#: src/amuleDlg.cpp:1861 src/muuli_wdr.cpp:3463
 #: src/utils/aLinkCreator/src/alcframe.cpp:262
 msgid "About"
 msgstr "Informazioni"
 
-#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3459
+#: src/amuleDlg.cpp:1861 src/muuli_wdr.cpp:3463
 msgid "About/Help"
 msgstr "Informazioni/Aiuto"
 
-#: src/amuleDlg.cpp:2036
+#: src/amuleDlg.cpp:2059
 msgid "eD2k network"
 msgstr "rete eD2k"
 
-#: src/amuleDlg.cpp:2039
+#: src/amuleDlg.cpp:2062
 msgid "Kad network"
 msgstr "Rete Kad"
 
-#: src/amuleDlg.cpp:2039
+#: src/amuleDlg.cpp:2062
 msgid "No network"
 msgstr "Nessuna rete"
 
@@ -1370,19 +1370,19 @@ msgstr "Auto [Alta]"
 msgid "Very low"
 msgstr "Molto bassa"
 
-#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:743 src/muuli_wdr.cpp:2313
+#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:743 src/muuli_wdr.cpp:2317
 #: src/ServerListCtrl.cpp:263 src/ServerListCtrl.cpp:456
 #: src/SharedFilesCtrl.cpp:145
 msgid "Low"
 msgstr "Bassa"
 
-#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:744 src/muuli_wdr.cpp:2314
+#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:744 src/muuli_wdr.cpp:2318
 #: src/ServerListCtrl.cpp:266 src/ServerListCtrl.cpp:457
 #: src/SharedFilesCtrl.cpp:146
 msgid "Normal"
 msgstr "Normale"
 
-#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:745 src/muuli_wdr.cpp:2315
+#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:745 src/muuli_wdr.cpp:2319
 #: src/ServerListCtrl.cpp:269 src/ServerListCtrl.cpp:458
 #: src/SharedFilesCtrl.cpp:147
 msgid "High"
@@ -1474,7 +1474,7 @@ msgstr "Server locale"
 msgid "Remote Server"
 msgstr "Server remoto"
 
-#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3212
+#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3216
 #: src/SearchDlg.cpp:119 src/TextClient.cpp:911
 msgid "Kad"
 msgstr "Kad"
@@ -1545,7 +1545,7 @@ msgstr "Parte"
 msgid "Size"
 msgstr "Dimensione"
 
-#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3279
+#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3283
 msgid "Transferred"
 msgstr "Trasferiti"
 
@@ -1603,7 +1603,7 @@ msgstr ""
 "Feedback da: %s (%s)\n"
 "\n"
 
-#: src/DownloadListCtrl.cpp:746 src/muuli_wdr.cpp:2316
+#: src/DownloadListCtrl.cpp:746 src/muuli_wdr.cpp:2320
 #: src/SharedFilesCtrl.cpp:150
 msgid "Auto"
 msgstr "Auto"
@@ -1641,7 +1641,7 @@ msgid "Extended Options"
 msgstr "Opzioni avanzate"
 
 #: src/DownloadListCtrl.cpp:770 src/DownloadListCtrl.cpp:822
-#: src/muuli_wdr.cpp:1800
+#: src/muuli_wdr.cpp:1804
 msgid "Preview"
 msgstr "Anteprima"
 
@@ -2440,23 +2440,23 @@ msgid ""
 "want downloads on a different (e.g. larger) disk."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:549 src/FirstRunWizard.cpp:611 src/muuli_wdr.cpp:1712
+#: src/FirstRunWizard.cpp:549 src/FirstRunWizard.cpp:611 src/muuli_wdr.cpp:1716
 msgid "Destination folder for downloads"
 msgstr "Cartella di destinazione per i file scaricati"
 
 #: src/FirstRunWizard.cpp:553 src/FirstRunWizard.cpp:569 src/muuli_wdr.cpp:1349
-#: src/muuli_wdr.cpp:1366 src/muuli_wdr.cpp:1687 src/muuli_wdr.cpp:1718
-#: src/muuli_wdr.cpp:1730 src/muuli_wdr.cpp:2800
+#: src/muuli_wdr.cpp:1366 src/muuli_wdr.cpp:1691 src/muuli_wdr.cpp:1722
+#: src/muuli_wdr.cpp:1734 src/muuli_wdr.cpp:2804
 #: src/utils/aLinkCreator/src/alcframe.cpp:135
 #: src/utils/wxCas/src/wxcasprefs.cpp:52 src/utils/wxCas/src/wxcasprefs.cpp:118
 msgid "Browse"
 msgstr "Sfoglia"
 
-#: src/FirstRunWizard.cpp:559 src/muuli_wdr.cpp:1723
+#: src/FirstRunWizard.cpp:559 src/muuli_wdr.cpp:1727
 msgid "(All files in this folder are shared with other peers)"
 msgstr "(Tutti i file in questa cartella sono condivisi con gli altri peer)"
 
-#: src/FirstRunWizard.cpp:565 src/FirstRunWizard.cpp:624 src/muuli_wdr.cpp:1725
+#: src/FirstRunWizard.cpp:565 src/FirstRunWizard.cpp:624 src/muuli_wdr.cpp:1729
 msgid "Folder for temporary download files"
 msgstr "Cartella per i file temporanei"
 
@@ -2487,7 +2487,7 @@ msgstr "Impossibile aprire in scrittura il file della lista degli amici 'emfrien
 msgid "CRITICAL - no client on StartChatSession"
 msgstr "CRITICO - nessun client in StartChatSession"
 
-#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2706 src/muuli_wdr.cpp:3383
+#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2710 src/muuli_wdr.cpp:3387
 msgid "Friends"
 msgstr "Amici"
 
@@ -2597,8 +2597,8 @@ msgstr "Nessuno"
 msgid "No"
 msgstr "No"
 
-#: src/GenericClientListCtrl.cpp:1216 src/PrefsUnifiedDlg.cpp:2898
-#: src/PrefsUnifiedDlg.cpp:2948 src/ServerListCtrl.cpp:276
+#: src/GenericClientListCtrl.cpp:1216 src/PrefsUnifiedDlg.cpp:2907
+#: src/PrefsUnifiedDlg.cpp:2957 src/ServerListCtrl.cpp:276
 msgid "Yes"
 msgstr "Sì"
 
@@ -2767,10 +2767,10 @@ msgstr "Porta non valida per il bootstrap"
 msgid "Please fill all fields required"
 msgstr "Completa tutti i campi obbligatori"
 
-#: src/KadDlg.cpp:192 src/PartFile.cpp:1031 src/PrefsUnifiedDlg.cpp:1134
-#: src/PrefsUnifiedDlg.cpp:1204 src/PrefsUnifiedDlg.cpp:1405
-#: src/PrefsUnifiedDlg.cpp:1663 src/PrefsUnifiedDlg.cpp:1673
-#: src/PrefsUnifiedDlg.cpp:1690 src/PrefsUnifiedDlg.cpp:1738
+#: src/KadDlg.cpp:192 src/PartFile.cpp:1031 src/PrefsUnifiedDlg.cpp:1143
+#: src/PrefsUnifiedDlg.cpp:1213 src/PrefsUnifiedDlg.cpp:1414
+#: src/PrefsUnifiedDlg.cpp:1672 src/PrefsUnifiedDlg.cpp:1682
+#: src/PrefsUnifiedDlg.cpp:1699 src/PrefsUnifiedDlg.cpp:1747
 msgid "Message"
 msgstr "Messaggio"
 
@@ -2871,7 +2871,7 @@ msgstr "Rapporto di condivisione"
 msgid "Uploaded"
 msgstr "Inviato"
 
-#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3263
+#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3267
 msgid "Requested"
 msgstr "Richiesto"
 
@@ -2994,7 +2994,7 @@ msgid "WARNING: "
 msgstr "ATTENZIONE: "
 
 #: src/MuleNotebook.cpp:179 src/muuli_wdr.cpp:817 src/muuli_wdr.cpp:1229
-#: src/muuli_wdr.cpp:3167 src/muuli_wdr.cpp:3423
+#: src/muuli_wdr.cpp:3171 src/muuli_wdr.cpp:3427
 msgid "Close"
 msgstr "Chiudi"
 
@@ -3012,7 +3012,7 @@ msgid "Paste"
 msgstr "Incolla"
 
 #: src/MuleTextCtrl.cpp:89 src/muuli_wdr.cpp:358 src/muuli_wdr.cpp:757
-#: src/muuli_wdr.cpp:2390 src/muuli_wdr.cpp:2409 src/muuli_wdr.cpp:2431
+#: src/muuli_wdr.cpp:2394 src/muuli_wdr.cpp:2413 src/muuli_wdr.cpp:2435
 #: src/utils/aLinkCreator/src/alcframe.cpp:142
 msgid "Clear"
 msgstr "Pulisci"
@@ -3104,7 +3104,7 @@ msgstr "Esci"
 
 #: src/MuleTrayIcon.cpp:579 src/MuleTrayIcon.cpp:945 src/MuleTrayIcon.cpp:965
 #: src/muuli_wdr.cpp:1398 src/muuli_wdr.cpp:1406 src/muuli_wdr.cpp:1413
-#: src/muuli_wdr.cpp:1846 src/muuli_wdr.cpp:1852 src/OtherFunctions.cpp:91
+#: src/muuli_wdr.cpp:1850 src/muuli_wdr.cpp:1856 src/OtherFunctions.cpp:91
 #: src/StatisticsDlg.cpp:93 src/StatisticsDlg.cpp:95
 msgid "kB/s"
 msgstr "kB/s"
@@ -3344,7 +3344,7 @@ msgstr "Byte"
 msgid "KB"
 msgstr "KB"
 
-#: src/muuli_wdr.cpp:274 src/muuli_wdr.cpp:293 src/muuli_wdr.cpp:1631
+#: src/muuli_wdr.cpp:274 src/muuli_wdr.cpp:293 src/muuli_wdr.cpp:1635
 #: src/OtherFunctions.cpp:64
 msgid "MB"
 msgstr "MB"
@@ -3361,7 +3361,7 @@ msgstr "Dimensione massima"
 msgid "Availability"
 msgstr "Disponibilità"
 
-#: src/muuli_wdr.cpp:312 src/muuli_wdr.cpp:398 src/muuli_wdr.cpp:3328
+#: src/muuli_wdr.cpp:312 src/muuli_wdr.cpp:398 src/muuli_wdr.cpp:3332
 msgid "Filter:"
 msgstr "Filtro:"
 
@@ -3424,8 +3424,8 @@ msgstr "Fonti del file:"
 #: src/muuli_wdr.cpp:1160 src/muuli_wdr.cpp:1167 src/muuli_wdr.cpp:1172
 #: src/muuli_wdr.cpp:1179 src/muuli_wdr.cpp:1184 src/muuli_wdr.cpp:1191
 #: src/muuli_wdr.cpp:1205 src/muuli_wdr.cpp:1212 src/muuli_wdr.cpp:1217
-#: src/muuli_wdr.cpp:1224 src/muuli_wdr.cpp:3265 src/muuli_wdr.cpp:3273
-#: src/muuli_wdr.cpp:3281
+#: src/muuli_wdr.cpp:1224 src/muuli_wdr.cpp:3269 src/muuli_wdr.cpp:3277
+#: src/muuli_wdr.cpp:3285
 msgid "N/A"
 msgstr "N/D"
 
@@ -3565,7 +3565,7 @@ msgstr "Artista :"
 msgid "Album :"
 msgstr "Album :"
 
-#: src/muuli_wdr.cpp:685 src/muuli_wdr.cpp:2285
+#: src/muuli_wdr.cpp:685 src/muuli_wdr.cpp:2289
 msgid "Title :"
 msgstr "Titolo:"
 
@@ -3673,7 +3673,7 @@ msgstr "Nome utente:"
 msgid "Userhash :"
 msgstr "Hash utente:"
 
-#: src/muuli_wdr.cpp:895 src/muuli_wdr.cpp:1752 src/muuli_wdr.cpp:2480
+#: src/muuli_wdr.cpp:895 src/muuli_wdr.cpp:1756 src/muuli_wdr.cpp:2484
 #: src/utils/aLinkCreator/src/alcframe.cpp:137
 msgid "Add"
 msgstr "Aggiungi"
@@ -3682,15 +3682,15 @@ msgstr "Aggiungi"
 msgid "Download-Speed"
 msgstr "Velocità download"
 
-#: src/muuli_wdr.cpp:954 src/muuli_wdr.cpp:989 src/muuli_wdr.cpp:2584
+#: src/muuli_wdr.cpp:954 src/muuli_wdr.cpp:989 src/muuli_wdr.cpp:2588
 msgid "Current"
 msgstr "Corrente"
 
-#: src/muuli_wdr.cpp:962 src/muuli_wdr.cpp:997 src/muuli_wdr.cpp:2592
+#: src/muuli_wdr.cpp:962 src/muuli_wdr.cpp:997 src/muuli_wdr.cpp:2596
 msgid "Running average"
 msgstr "Media attuale"
 
-#: src/muuli_wdr.cpp:970 src/muuli_wdr.cpp:1005 src/muuli_wdr.cpp:2600
+#: src/muuli_wdr.cpp:970 src/muuli_wdr.cpp:1005 src/muuli_wdr.cpp:2604
 msgid "Session average"
 msgstr "Media sessione"
 
@@ -3702,7 +3702,7 @@ msgstr "Velocità upload"
 msgid "Connections"
 msgstr "Connessioni"
 
-#: src/muuli_wdr.cpp:1024 src/muuli_wdr.cpp:1871
+#: src/muuli_wdr.cpp:1024 src/muuli_wdr.cpp:1875
 msgid "Active downloads"
 msgstr "Download attivi"
 
@@ -3710,7 +3710,7 @@ msgstr "Download attivi"
 msgid "Active connections (1:1)"
 msgstr "Connessioni attive (1:1)"
 
-#: src/muuli_wdr.cpp:1040 src/muuli_wdr.cpp:1872
+#: src/muuli_wdr.cpp:1040 src/muuli_wdr.cpp:1876
 msgid "Active uploads"
 msgstr "Upload attivi"
 
@@ -3984,7 +3984,7 @@ msgstr "Lega l'indirizzo locale all'IP (lascia vuoto per qualsiasi):"
 msgid "Advanced users only: If you have multiple network interfaces, enter the address of the interface to which aMule should be bound."
 msgstr "Solo per utenti esperti: se hai interfacce di rete multiple, inserisci l'indirizzo dell'interfaccia che aMule dovrà utilizzare."
 
-#: src/muuli_wdr.cpp:1462 src/muuli_wdr.cpp:2065
+#: src/muuli_wdr.cpp:1462 src/muuli_wdr.cpp:2069
 msgid "Bind to network interface (empty for any):"
 msgstr "Associa all'interfaccia di rete (vuoto per qualsiasi):"
 
@@ -4000,7 +4000,7 @@ msgstr "Fonti massime per file in scaricamento:"
 msgid "Max simultaneous connections:"
 msgstr "Connessioni massime simultanee:"
 
-#: src/muuli_wdr.cpp:1498 src/muuli_wdr.cpp:3207
+#: src/muuli_wdr.cpp:1498 src/muuli_wdr.cpp:3211
 msgid "ED2K"
 msgstr "ED2K"
 
@@ -4092,79 +4092,79 @@ msgstr "Prealloca lo spazio su disco per i nuovi file"
 msgid "For new files preallocates disk space for the whole file, thus reduces fragmentation"
 msgstr "Per i nuovi file prealloca lo spazio su disco per l'intero file, in questo modo ridurrai la frammentazione"
 
-#: src/muuli_wdr.cpp:1617
+#: src/muuli_wdr.cpp:1621
 msgid "Create new files as sparse files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1618
+#: src/muuli_wdr.cpp:1622
 msgid "Sparse part files only occupy disk space for the parts already downloaded, so free space is used up gradually as the file fills in. Turn this off to use an ordinary file instead - useful where sparse files are unsupported or slow, or where backup/de-duplication tools handle them badly. Applies only when the core runs on Windows; on Linux and macOS part files are sparse anyway and this setting has no effect."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1623
+#: src/muuli_wdr.cpp:1627
 msgid "Stop downloads when free disk space reaches "
 msgstr "Interrompi i download quando termina lo spazio su disco "
 
-#: src/muuli_wdr.cpp:1624
+#: src/muuli_wdr.cpp:1628
 msgid "Select this if you want aMule to check your disk space"
 msgstr "Seleziona se vuoi che aMule controlli il tuo spazio su disco"
 
-#: src/muuli_wdr.cpp:1628
+#: src/muuli_wdr.cpp:1632
 msgid "Enter here the min disk space desired."
 msgstr "Inserire lo spazio disco minimo desiderato."
 
-#: src/muuli_wdr.cpp:1634
+#: src/muuli_wdr.cpp:1638
 msgid "Save 10 sources on rare files (< 20 sources)"
 msgstr "Salva 10 fonti per i file rari ( con < 20 fonti)"
 
-#: src/muuli_wdr.cpp:1638 src/Statistics.cpp:790
+#: src/muuli_wdr.cpp:1642 src/Statistics.cpp:790
 msgid "Uploads"
 msgstr "Upload"
 
-#: src/muuli_wdr.cpp:1641
+#: src/muuli_wdr.cpp:1645
 msgid "Add new shared files with auto priority"
 msgstr "Assegna priorità automatica ai nuovi file condivisi"
 
-#: src/muuli_wdr.cpp:1647
+#: src/muuli_wdr.cpp:1651
 msgid "Intelligent Corruption Handling (I.C.H.)"
 msgstr "Trattamento intelligente delle corruzioni (I.C.H.)"
 
-#: src/muuli_wdr.cpp:1650
+#: src/muuli_wdr.cpp:1654
 msgid "Enable"
 msgstr "Abilita"
 
-#: src/muuli_wdr.cpp:1653
+#: src/muuli_wdr.cpp:1657
 msgid "Advanced I.C.H. trusts every hash (not recommended)"
 msgstr "L'I.C.H. avanzato si fida di ogni hash (sconsigliato)"
 
-#: src/muuli_wdr.cpp:1665 src/PrefsUnifiedDlg.cpp:1990
+#: src/muuli_wdr.cpp:1669 src/PrefsUnifiedDlg.cpp:1999
 msgid "Media metadata extraction"
 msgstr "Estrazione dei metadati multimediali"
 
-#: src/muuli_wdr.cpp:1669
+#: src/muuli_wdr.cpp:1673
 msgid "Extract length / bitrate / codec from shared audio and video files"
 msgstr "Estrai durata / bitrate / codec dai file audio e video condivisi"
 
-#: src/muuli_wdr.cpp:1671
+#: src/muuli_wdr.cpp:1675
 msgid "When enabled, aMule runs ffprobe on each shared media file to fill in the Length / Bitrate / Codec columns other clients see when they find the file in a search. Requires ffmpeg (the ffprobe binary) to be installed."
 msgstr "Quando abilitato, aMule esegue ffprobe su ogni file multimediale condiviso per compilare le colonne Durata / Bitrate / Codec che gli altri client vedono quando trovano il file in una ricerca. Richiede l'installazione di ffmpeg (il binario ffprobe)."
 
-#: src/muuli_wdr.cpp:1678
+#: src/muuli_wdr.cpp:1682
 msgid "Path to ffprobe:"
 msgstr "Percorso di ffprobe:"
 
-#: src/muuli_wdr.cpp:1683
+#: src/muuli_wdr.cpp:1687
 msgid "Full path to the ffprobe binary. Leave empty to have aMule auto-detect it on startup."
 msgstr "Percorso completo del binario ffprobe. Lascia vuoto per far sì che aMule lo rilevi automaticamente all'avvio."
 
-#: src/muuli_wdr.cpp:1691
+#: src/muuli_wdr.cpp:1695
 msgid "Detect"
 msgstr "Rileva"
 
-#: src/muuli_wdr.cpp:1692
+#: src/muuli_wdr.cpp:1696
 msgid "Search the standard install locations for an ffprobe binary and fill the path field."
 msgstr "Cerca nei percorsi di installazione standard un binario ffprobe e compila il campo del percorso."
 
-#: src/muuli_wdr.cpp:1716
+#: src/muuli_wdr.cpp:1720
 msgid ""
 "Completed downloads are stored here. All files in this folder are automatically shared with other peers.\n"
 "If this folder also holds files you don't want to share, point it at an aMule-only sub-folder."
@@ -4172,688 +4172,688 @@ msgstr ""
 "Qui vengono salvati i download completati. Tutti i file in questa cartella sono condivisi automaticamente con gli altri peer.\n"
 "Se questa cartella contiene anche file che non vuoi condividere, impostala su una sottocartella riservata ad aMule."
 
-#: src/muuli_wdr.cpp:1719
+#: src/muuli_wdr.cpp:1723
 msgid "Pick the folder where completed downloads will be stored. All files in that folder will be shared with other peers."
 msgstr "Scegli la cartella in cui salvare i download completati. Tutti i file in quella cartella saranno condivisi con gli altri peer."
 
-#: src/muuli_wdr.cpp:1733
+#: src/muuli_wdr.cpp:1737
 msgid "Shared folders"
 msgstr "Cartelle condivise"
 
-#: src/muuli_wdr.cpp:1739
+#: src/muuli_wdr.cpp:1743
 msgid "(Folders shared by the core. Enter a path to add one.)"
 msgstr "(Cartelle condivise dal core. Inserisci un percorso per aggiungerne una.)"
 
-#: src/muuli_wdr.cpp:1747
+#: src/muuli_wdr.cpp:1751
 msgid "Absolute path of a folder on the core's machine, e.g. /home/user/shared"
 msgstr "Percorso assoluto di una cartella sulla macchina del core, ad es. /home/user/shared"
 
-#: src/muuli_wdr.cpp:1749 src/PrefsUnifiedDlg.cpp:2874
+#: src/muuli_wdr.cpp:1753 src/PrefsUnifiedDlg.cpp:2883
 msgid "Recursive"
 msgstr "Ricorsivo"
 
-#: src/muuli_wdr.cpp:1750
+#: src/muuli_wdr.cpp:1754
 msgid "Share every sub-folder underneath this one, including ones created later."
 msgstr "Condividi tutte le sottocartelle contenute in questa, comprese quelle create in seguito."
 
-#: src/muuli_wdr.cpp:1754 src/utils/aLinkCreator/src/alcframe.cpp:141
+#: src/muuli_wdr.cpp:1758 src/utils/aLinkCreator/src/alcframe.cpp:141
 msgid "Remove"
 msgstr "Rimuovi"
 
-#: src/muuli_wdr.cpp:1758
+#: src/muuli_wdr.cpp:1762
 msgid "(Right click on folder icon for recursive share)"
 msgstr "(fai click con il tasto destro sulle icone per condividere ricorsivamente le sottodirectory)"
 
-#: src/muuli_wdr.cpp:1765
+#: src/muuli_wdr.cpp:1769
 msgid "Share hidden files"
 msgstr "Condividi file nascosti"
 
-#: src/muuli_wdr.cpp:1771
+#: src/muuli_wdr.cpp:1775
 msgid "Automatically rescan shared folders for changes"
 msgstr "Ricontrolla automaticamente le modifiche nelle cartelle condivise"
 
-#: src/muuli_wdr.cpp:1777
+#: src/muuli_wdr.cpp:1781
 msgid "Follow symbolic links in shared folders"
 msgstr "Segui i collegamenti simbolici nelle cartelle condivise"
 
-#: src/muuli_wdr.cpp:1783
+#: src/muuli_wdr.cpp:1787
 msgid "Exclude files matching:"
 msgstr "Escludi i file corrispondenti a:"
 
-#: src/muuli_wdr.cpp:1786
+#: src/muuli_wdr.cpp:1790
 msgid "Wildcard patterns separated by '|', e.g. .DS_Store|Thumbs.db|*.tmp. Files whose name matches are not shared. Matching is case-insensitive."
 msgstr "Modelli con caratteri jolly separati da '|', ad es. .DS_Store|Thumbs.db|*.tmp. I file il cui nome corrisponde non vengono condivisi. La corrispondenza non distingue tra maiuscole e minuscole."
 
-#: src/muuli_wdr.cpp:1790
+#: src/muuli_wdr.cpp:1794
 msgid "Patterns are regular expressions"
 msgstr "I pattern sono espressioni regolari"
 
-#: src/muuli_wdr.cpp:1791
+#: src/muuli_wdr.cpp:1795
 msgid "When set, the whole field is one regular expression ('|' is alternation). When unset, it is a list of '|'-separated wildcards."
 msgstr "Se attivato, l'intero campo è un'unica espressione regolare ('|' indica l'alternanza). Se disattivato, è un elenco di caratteri jolly separati da '|'."
 
-#: src/muuli_wdr.cpp:1801
+#: src/muuli_wdr.cpp:1805
 msgid "Show how many shared files the current pattern would exclude."
 msgstr "Mostra quanti file condivisi verrebbero esclusi dal pattern attuale."
 
-#: src/muuli_wdr.cpp:1822
+#: src/muuli_wdr.cpp:1826
 msgid "Graphs"
 msgstr "Grafici"
 
-#: src/muuli_wdr.cpp:1825 src/muuli_wdr.cpp:1887
+#: src/muuli_wdr.cpp:1829 src/muuli_wdr.cpp:1891
 msgid "Update delay : 5 secs"
 msgstr "Intervallo di aggiornamento: 5 secondi"
 
-#: src/muuli_wdr.cpp:1829
+#: src/muuli_wdr.cpp:1833
 msgid "Time for average graph: 100 mins"
 msgstr "Intervallo grafico valori medi: 100 minuti"
 
-#: src/muuli_wdr.cpp:1833
+#: src/muuli_wdr.cpp:1837
 msgid "Connections Graph Scale: 100 "
 msgstr "Scala grafico connessioni: 100 "
 
-#: src/muuli_wdr.cpp:1840
+#: src/muuli_wdr.cpp:1844
 msgid "Download graph scale:"
 msgstr "Scala grafico di scaricamento:"
 
-#: src/muuli_wdr.cpp:1848
+#: src/muuli_wdr.cpp:1852
 msgid "Upload graph scale:"
 msgstr "Scala grafico d'invio:"
 
-#: src/muuli_wdr.cpp:1858
+#: src/muuli_wdr.cpp:1862
 msgid "Colors: "
 msgstr "Colori: "
 
-#: src/muuli_wdr.cpp:1862
+#: src/muuli_wdr.cpp:1866
 msgid "Background"
 msgstr "Sfondo"
 
-#: src/muuli_wdr.cpp:1863
+#: src/muuli_wdr.cpp:1867
 msgid "Grid"
 msgstr "Griglia"
 
-#: src/muuli_wdr.cpp:1864
+#: src/muuli_wdr.cpp:1868
 msgid "Download current"
 msgstr "Download attuale"
 
-#: src/muuli_wdr.cpp:1865
+#: src/muuli_wdr.cpp:1869
 msgid "Download running average"
 msgstr "Media download in corso"
 
-#: src/muuli_wdr.cpp:1866
+#: src/muuli_wdr.cpp:1870
 msgid "Download session average"
 msgstr "Media sessione di download"
 
-#: src/muuli_wdr.cpp:1867
+#: src/muuli_wdr.cpp:1871
 msgid "Upload current"
 msgstr "Upload attuale"
 
-#: src/muuli_wdr.cpp:1868
+#: src/muuli_wdr.cpp:1872
 msgid "Upload running average"
 msgstr "Media upload in corso"
 
-#: src/muuli_wdr.cpp:1869
+#: src/muuli_wdr.cpp:1873
 msgid "Upload session average"
 msgstr "Media sessione di upload"
 
-#: src/muuli_wdr.cpp:1870
+#: src/muuli_wdr.cpp:1874
 msgid "Active connections"
 msgstr "Connessioni attive"
 
-#: src/muuli_wdr.cpp:1873
+#: src/muuli_wdr.cpp:1877
 msgid "Systray Icon Speed Bar"
 msgstr "Barra della velocità nell'icona sulla barra di sistema"
 
-#: src/muuli_wdr.cpp:1874
+#: src/muuli_wdr.cpp:1878
 msgid "Kad-nodes current"
 msgstr "Nodi Kad attuali"
 
-#: src/muuli_wdr.cpp:1875
+#: src/muuli_wdr.cpp:1879
 msgid "Kad-nodes running"
 msgstr "Nodi Kad attivi"
 
-#: src/muuli_wdr.cpp:1876
+#: src/muuli_wdr.cpp:1880
 msgid "Kad-nodes session"
 msgstr "Nodi Kad nella sessione"
 
-#: src/muuli_wdr.cpp:1880 src/muuli_wdr.cpp:2334
+#: src/muuli_wdr.cpp:1884 src/muuli_wdr.cpp:2338
 msgid "Select"
 msgstr "Seleziona"
 
-#: src/muuli_wdr.cpp:1884
+#: src/muuli_wdr.cpp:1888
 msgid "Tree"
 msgstr "Albero"
 
-#: src/muuli_wdr.cpp:1894
+#: src/muuli_wdr.cpp:1898
 msgid "Number of Client Versions shown (0=unlimited)"
 msgstr "Numero di versioni di client visualizzate (0=illimitate)"
 
-#: src/muuli_wdr.cpp:1919
+#: src/muuli_wdr.cpp:1923
 msgid "!!! WARNING !!!"
 msgstr "!!! ATTENZIONE !!!"
 
-#: src/muuli_wdr.cpp:1934
+#: src/muuli_wdr.cpp:1938
 msgid "Max new connections / 5 secs"
 msgstr "Numero massimo nuove connessioni / 5 secondi"
 
-#: src/muuli_wdr.cpp:1936
+#: src/muuli_wdr.cpp:1940
 msgid "Concurrent Kad source lookups"
 msgstr "Ricerche di fonti Kad simultanee"
 
-#: src/muuli_wdr.cpp:1938
+#: src/muuli_wdr.cpp:1942
 msgid "Kad source re-search interval (minutes)"
 msgstr "Intervallo tra le ricerche di fonti Kad (minuti)"
 
-#: src/muuli_wdr.cpp:1940
+#: src/muuli_wdr.cpp:1944
 msgid "Source re-ask interval (minutes)"
 msgstr "Intervallo tra le richieste alle fonti (minuti)"
 
-#: src/muuli_wdr.cpp:1944
+#: src/muuli_wdr.cpp:1948
 msgid "File Buffer Size: 240000 bytes"
 msgstr "Dimensione buffer file: 240000 byte"
 
-#: src/muuli_wdr.cpp:1948
+#: src/muuli_wdr.cpp:1952
 msgid "Use MMAP: memory-mapped file access (lower memory use)"
 msgstr "Usa MMAP: accesso ai file mappato in memoria (minor uso di memoria)"
 
-#: src/muuli_wdr.cpp:1949
+#: src/muuli_wdr.cpp:1953
 msgid "Maps part files into memory instead of buffering them on the heap, lowering the process memory footprint. May reduce download speed on some disks; best for memory-constrained or upload-heavy hosts."
 msgstr "Mappa i file parziali in memoria invece di bufferizzarli nell'heap, riducendo l'occupazione di memoria del processo. Potrebbe ridurre la velocità di download su alcuni dischi; ideale per sistemi con memoria limitata o con molto traffico in upload."
 
-#: src/muuli_wdr.cpp:1951
+#: src/muuli_wdr.cpp:1955
 msgid "Upload Queue Size: 5000 clients"
 msgstr "Dimensione coda upload: 5000 client"
 
-#: src/muuli_wdr.cpp:1955
+#: src/muuli_wdr.cpp:1959
 msgid "Server connection refresh interval: Disable"
 msgstr "Intervallo aggiornamento connessione al server: disabilitato"
 
-#: src/muuli_wdr.cpp:1959
+#: src/muuli_wdr.cpp:1963
 msgid "Disable computer's timed standby mode"
 msgstr "Disabilita la modalità standby a tempo"
 
-#: src/muuli_wdr.cpp:1978
+#: src/muuli_wdr.cpp:1982
 msgid "Skin to use: "
 msgstr "Skin da usare: "
 
-#: src/muuli_wdr.cpp:1987
+#: src/muuli_wdr.cpp:1991
 msgid "Show \"Fast eD2k Links Handler\" in every window."
 msgstr "Mostra il \"Gestore rapido dei collegamenti eD2k\" in ogni finestra."
 
-#: src/muuli_wdr.cpp:1990
+#: src/muuli_wdr.cpp:1994
 msgid "Show extended info on categories tabs"
 msgstr "Mostra informazioni estese sulle schede delle categorie"
 
-#: src/muuli_wdr.cpp:1993
+#: src/muuli_wdr.cpp:1997
 msgid "Show application version on title"
 msgstr "Mostra versione dell'applicazione nella barra del titolo"
 
-#: src/muuli_wdr.cpp:1995
+#: src/muuli_wdr.cpp:1999
 msgid "Show transfer rates on title"
 msgstr "Mostra velocità di trasferimento nella barra del titolo"
 
-#: src/muuli_wdr.cpp:1997
+#: src/muuli_wdr.cpp:2001
 msgid "Before application name"
 msgstr "Prima del nome dell'applicazione"
 
-#: src/muuli_wdr.cpp:1999
+#: src/muuli_wdr.cpp:2003
 msgid "After application name"
 msgstr "Dopo il nome dell'applicazione"
 
-#: src/muuli_wdr.cpp:2002
+#: src/muuli_wdr.cpp:2006
 msgid "Show overhead bandwidth"
 msgstr "Mostra l'overhead di banda"
 
-#: src/muuli_wdr.cpp:2006
+#: src/muuli_wdr.cpp:2010
 msgid "Vertical toolbar orientation"
 msgstr "Orientamento verticale della barra degli strumenti"
 
-#: src/muuli_wdr.cpp:2008
+#: src/muuli_wdr.cpp:2012
 msgid "Live column sorting (auto-reorder rows as their values change)"
 msgstr "Ordinamento colonne in tempo reale (riordina le righe automaticamente al variare dei loro valori)"
 
-#: src/muuli_wdr.cpp:2015
+#: src/muuli_wdr.cpp:2019
 msgid "Download Queue Files"
 msgstr "Scaricamento dei file in coda"
 
-#: src/muuli_wdr.cpp:2018
+#: src/muuli_wdr.cpp:2022
 msgid "Show progress percentage"
 msgstr "Mostra la percentuale di avanzamento"
 
-#: src/muuli_wdr.cpp:2024
+#: src/muuli_wdr.cpp:2028
 msgid "Show progress bar"
 msgstr "Mostra la barra di avanzamento"
 
-#: src/muuli_wdr.cpp:2027
+#: src/muuli_wdr.cpp:2031
 msgid "Flat"
 msgstr "Piatta"
 
-#: src/muuli_wdr.cpp:2031
+#: src/muuli_wdr.cpp:2035
 msgid "Round"
 msgstr "Arrotondata"
 
-#: src/muuli_wdr.cpp:2049
+#: src/muuli_wdr.cpp:2053
 msgid "External Connection Parameters"
 msgstr "Parametri connessioni esterne"
 
-#: src/muuli_wdr.cpp:2052
+#: src/muuli_wdr.cpp:2056
 msgid "Accept external connections"
 msgstr "Accetta connessioni esterne"
 
-#: src/muuli_wdr.cpp:2059 src/muuli_wdr.cpp:2118
+#: src/muuli_wdr.cpp:2063 src/muuli_wdr.cpp:2122
 msgid "IP of the listening interface:"
 msgstr "IP dell'interfaccia di ascolto:"
 
-#: src/muuli_wdr.cpp:2062
+#: src/muuli_wdr.cpp:2066
 msgid "Enter here a valid ip in the a.b.c.d format for the listening EC interface. An empty field or 0.0.0.0 will mean any interface."
 msgstr "Inserisci un IP valido nel formato a.b.c.d per l'interfaccia di ascolto EC. Lasciare il campo vuoto o inserire 0.0.0.0 significa qualsiasi interfaccia."
 
-#: src/muuli_wdr.cpp:2083 src/muuli_wdr.cpp:2194
+#: src/muuli_wdr.cpp:2087 src/muuli_wdr.cpp:2198
 msgid "TCP port:"
 msgstr "Porta TCP:"
 
-#: src/muuli_wdr.cpp:2089
+#: src/muuli_wdr.cpp:2093
 msgid "Enable UPnP port forwarding on the EC port"
 msgstr "Abilita il port forwarding tramite UPnP sulla porta EC"
 
-#: src/muuli_wdr.cpp:2093 src/muuli_wdr.cpp:3079
+#: src/muuli_wdr.cpp:2097 src/muuli_wdr.cpp:3083
 #: src/utils/wxCas/src/wxcasprefs.cpp:167
 msgid "Password"
 msgstr "Password"
 
-#: src/muuli_wdr.cpp:2099
+#: src/muuli_wdr.cpp:2103
 msgid "aMule API server parameters"
 msgstr "Parametri del server API di aMule"
 
-#: src/muuli_wdr.cpp:2102
+#: src/muuli_wdr.cpp:2106
 msgid "Run amuleapi (REST API) on startup"
 msgstr "Avvia amuleapi (REST API) all'avvio"
 
-#: src/muuli_wdr.cpp:2107
+#: src/muuli_wdr.cpp:2111
 msgid "HTTP port:"
 msgstr "Porta HTTP:"
 
-#: src/muuli_wdr.cpp:2121
+#: src/muuli_wdr.cpp:2125
 msgid "The interface amuleapi's HTTP server listens on. 127.0.0.1 (default) accepts only local connections; use 0.0.0.0 or a specific IP to expose it to other hosts (set an admin password below)."
 msgstr "L'interfaccia su cui è in ascolto il server HTTP di amuleapi. 127.0.0.1 (predefinito) accetta solo connessioni locali; usa 0.0.0.0 o un IP specifico per esporlo ad altri host (imposta una password di amministrazione qui sotto)."
 
-#: src/muuli_wdr.cpp:2126
+#: src/muuli_wdr.cpp:2130
 msgid "Type a password to set or change it. Stored passwords cannot be shown, so leaving this empty keeps the current one."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2128
+#: src/muuli_wdr.cpp:2132
 msgid "Admin password"
 msgstr "Password amministrazione"
 
-#: src/muuli_wdr.cpp:2140 src/muuli_wdr.cpp:2157 src/PrefsUnifiedDlg.cpp:1103
+#: src/muuli_wdr.cpp:2144 src/muuli_wdr.cpp:2161 src/PrefsUnifiedDlg.cpp:1112
 #, fuzzy
 msgid "A password is set."
 msgstr "Password amministrazione"
 
-#: src/muuli_wdr.cpp:2144
+#: src/muuli_wdr.cpp:2148
 #, fuzzy
 msgid "Enable guest access"
 msgstr "Vieta l'accesso guest"
 
-#: src/muuli_wdr.cpp:2145
+#: src/muuli_wdr.cpp:2149
 msgid "Guest sessions may read status and listings but cannot change anything. Turning this off clears the stored guest password."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2149
+#: src/muuli_wdr.cpp:2153
 #, fuzzy
 msgid "Guest password"
 msgstr "Password per l'accesso Guest al web server"
 
-#: src/muuli_wdr.cpp:2164
+#: src/muuli_wdr.cpp:2168
 msgid "Web server parameters"
 msgstr "Parametri del server web"
 
-#: src/muuli_wdr.cpp:2167
+#: src/muuli_wdr.cpp:2171
 msgid "Run webserver on startup (deprecated)"
 msgstr "Lancia il webserver all'avvio (deprecato)"
 
-#: src/muuli_wdr.cpp:2173
+#: src/muuli_wdr.cpp:2177
 msgid "Web template"
 msgstr "Template web"
 
-#: src/muuli_wdr.cpp:2178
+#: src/muuli_wdr.cpp:2182
 msgid "Full rights password"
 msgstr "Password per diritti completi"
 
-#: src/muuli_wdr.cpp:2182
+#: src/muuli_wdr.cpp:2186
 msgid "Enable Low rights User"
 msgstr "Abilita utente con diritti limitati"
 
-#: src/muuli_wdr.cpp:2187
+#: src/muuli_wdr.cpp:2191
 msgid "Low rights password"
 msgstr "Password per diritti limitati"
 
-#: src/muuli_wdr.cpp:2201
+#: src/muuli_wdr.cpp:2205
 msgid "Enable UPnP port forwarding of the web server port"
 msgstr "Abilita port forwarding tramite UPnP sulla porta del server web"
 
-#: src/muuli_wdr.cpp:2206
+#: src/muuli_wdr.cpp:2210
 msgid "Web server UPnP TCP port (Optional)"
 msgstr "Porta TCP del  server web per UPnP (Facoltativa)"
 
-#: src/muuli_wdr.cpp:2214
+#: src/muuli_wdr.cpp:2218
 msgid "Page Refresh Time (in secs)"
 msgstr "Intervallo di aggiornamento pagina (in sec)"
 
-#: src/muuli_wdr.cpp:2221
+#: src/muuli_wdr.cpp:2225
 msgid "Enable Gzip compression"
 msgstr "Abilita compressione gzip"
 
-#: src/muuli_wdr.cpp:2255
+#: src/muuli_wdr.cpp:2259
 msgid "Reset page to defaults"
 msgstr "Ripristina i valori predefiniti della pagina"
 
-#: src/muuli_wdr.cpp:2256
+#: src/muuli_wdr.cpp:2260
 msgid "Reset the settings on the current page to their default values."
 msgstr "Ripristina le impostazioni della pagina corrente ai loro valori predefiniti."
 
-#: src/muuli_wdr.cpp:2258 src/muuli_wdr.cpp:2344 src/ServerWnd.cpp:274
+#: src/muuli_wdr.cpp:2262 src/muuli_wdr.cpp:2348 src/ServerWnd.cpp:274
 #: src/ServerWnd.cpp:282
 msgid "OK"
 msgstr "OK"
 
-#: src/muuli_wdr.cpp:2260
+#: src/muuli_wdr.cpp:2264
 msgid "Click here to apply any changes made to the preferences."
 msgstr "Fai click qui per applicare le modifiche apportate alle impostazioni."
 
-#: src/muuli_wdr.cpp:2263
+#: src/muuli_wdr.cpp:2267
 msgid "Reset any changes made to the preferences."
 msgstr "Annulla ogni modifica alle preferenze."
 
-#: src/muuli_wdr.cpp:2292
+#: src/muuli_wdr.cpp:2296
 msgid "Comment :"
 msgstr "Commento:"
 
-#: src/muuli_wdr.cpp:2299
+#: src/muuli_wdr.cpp:2303
 msgid "Incoming Dir :"
 msgstr "Directory file scaricati:"
 
-#: src/muuli_wdr.cpp:2308
+#: src/muuli_wdr.cpp:2312
 msgid "Change priority for new assigned files :"
 msgstr "Cambia priorità per i nuovi file assegnati:"
 
-#: src/muuli_wdr.cpp:2312
+#: src/muuli_wdr.cpp:2316
 msgid "Don't change"
 msgstr "Non modificare"
 
-#: src/muuli_wdr.cpp:2324
+#: src/muuli_wdr.cpp:2328
 msgid "Select color for this Category (currently selected) :"
 msgstr "Seleziona colore per questa categoria (attualmente selezionata):"
 
-#: src/muuli_wdr.cpp:2391 src/muuli_wdr.cpp:2410 src/muuli_wdr.cpp:2432
+#: src/muuli_wdr.cpp:2395 src/muuli_wdr.cpp:2414 src/muuli_wdr.cpp:2436
 msgid "Click this button to reset the log."
 msgstr "Fai clic su questo pulsante per cancellare i log."
 
-#: src/muuli_wdr.cpp:2451
+#: src/muuli_wdr.cpp:2455
 msgid "Click on this button to update the servers list from URL ..."
 msgstr "Fai clic qui per aggiornare la lista dei server dall'indirizzo..."
 
-#: src/muuli_wdr.cpp:2455
+#: src/muuli_wdr.cpp:2459
 msgid "Server list"
 msgstr "Lista server"
 
-#: src/muuli_wdr.cpp:2459
+#: src/muuli_wdr.cpp:2463
 msgid "Enter the url to a server.met file here and press the button to the left to update the list of known servers."
 msgstr "Inserisci l'url di un file server.met e premi il pulsante a sinistra per aggiornare la lista dei server conosciuti."
 
-#: src/muuli_wdr.cpp:2464
+#: src/muuli_wdr.cpp:2468
 msgid "Add server manually: Name"
 msgstr "Aggiungi un server manualmente: Nome"
 
-#: src/muuli_wdr.cpp:2467
+#: src/muuli_wdr.cpp:2471
 msgid "Enter the name of the new server here"
 msgstr "Inserisci qui il nome di un nuovo server"
 
-#: src/muuli_wdr.cpp:2469 src/ServerWnd.cpp:206
+#: src/muuli_wdr.cpp:2473 src/ServerWnd.cpp:206
 msgid "IP:Port"
 msgstr "IP:Porta"
 
-#: src/muuli_wdr.cpp:2472
+#: src/muuli_wdr.cpp:2476
 msgid "Enter the IP of the server here, using the x.x.x.x format."
 msgstr "Inserisci qui l'IP del server, nel formato x.x.x.x."
 
-#: src/muuli_wdr.cpp:2478
+#: src/muuli_wdr.cpp:2482
 msgid "Enter the port of the server here."
 msgstr "Inserisci qui la porta del server."
 
-#: src/muuli_wdr.cpp:2481
+#: src/muuli_wdr.cpp:2485
 msgid "Add manually a server (fill fields to the left before) ..."
 msgstr "Aggiungi server (riempi campi a sinistra)..."
 
-#: src/muuli_wdr.cpp:2510
+#: src/muuli_wdr.cpp:2514
 msgid "aMule Log"
 msgstr "log di aMule"
 
-#: src/muuli_wdr.cpp:2518
+#: src/muuli_wdr.cpp:2522
 msgid "Server Info"
 msgstr "Informazioni server"
 
-#: src/muuli_wdr.cpp:2522
+#: src/muuli_wdr.cpp:2526
 msgid "ED2K Info"
 msgstr "Informazioni ed2k"
 
-#: src/muuli_wdr.cpp:2526
+#: src/muuli_wdr.cpp:2530
 msgid "Kad Info"
 msgstr "Informazioni Kad"
 
-#: src/muuli_wdr.cpp:2554
+#: src/muuli_wdr.cpp:2558
 msgid "Click on this button to update the nodes list from URL ..."
 msgstr "Fai clic su questo pulsante per aggiornare la lista nodi da un URL..."
 
-#: src/muuli_wdr.cpp:2558
+#: src/muuli_wdr.cpp:2562
 msgid "Nodes (0)"
 msgstr "Nodi (0)"
 
-#: src/muuli_wdr.cpp:2562
+#: src/muuli_wdr.cpp:2566
 msgid "Enter the url to a nodes.dat file here and press the button to the left to update the list of known nodes."
 msgstr "Inserisci l'URL di un file nodes.dat e premi il pulsante a sinistra per aggiornare la lista dei nodi conosciuti."
 
-#: src/muuli_wdr.cpp:2565
+#: src/muuli_wdr.cpp:2569
 msgid "Nodes stats"
 msgstr "Statistiche nodi"
 
-#: src/muuli_wdr.cpp:2607
+#: src/muuli_wdr.cpp:2611
 msgid "Bootstrap"
 msgstr "Bootstrap"
 
-#: src/muuli_wdr.cpp:2610
+#: src/muuli_wdr.cpp:2614
 msgid "New node"
 msgstr "Nuovo nodo"
 
-#: src/muuli_wdr.cpp:2615
+#: src/muuli_wdr.cpp:2619
 msgid "IP:"
 msgstr "IP:"
 
-#: src/muuli_wdr.cpp:2635
+#: src/muuli_wdr.cpp:2639
 msgid "Port:"
 msgstr "Porta:"
 
-#: src/muuli_wdr.cpp:2648
+#: src/muuli_wdr.cpp:2652
 msgid "Bootstrap from known clients"
 msgstr "Bootstrap dai client noti"
 
-#: src/muuli_wdr.cpp:2650
+#: src/muuli_wdr.cpp:2654
 msgid "Disconnect Kad"
 msgstr "Disconnetti rete Kad"
 
-#: src/muuli_wdr.cpp:2684
+#: src/muuli_wdr.cpp:2688
 msgid "Use Secure User Identification"
 msgstr "Usa identificazione sicura"
 
-#: src/muuli_wdr.cpp:2686
+#: src/muuli_wdr.cpp:2690
 msgid "It is recommended to enable this option. You will not receive credits if SUI is not enabled."
 msgstr "È consigliato attivare questa opzione. Non riceverai crediti se \" \"l'identificazione non sarà abilitata."
 
-#: src/muuli_wdr.cpp:2688
+#: src/muuli_wdr.cpp:2692
 msgid "Protocol Obfuscation"
 msgstr "Offuscamento del protocollo"
 
-#: src/muuli_wdr.cpp:2691
+#: src/muuli_wdr.cpp:2695
 msgid "Support Protocol Obfuscation"
 msgstr "Supporta offuscamento del protocollo"
 
-#: src/muuli_wdr.cpp:2693
+#: src/muuli_wdr.cpp:2697
 msgid "This option enabled Protocol Obfuscation, and makes aMule accept obfuscated connections from other clients."
 msgstr "Questa opzione abilita l'offuscamento del protocollo, e fa sì che aMule accetti connessioni offuscate dagli altri client."
 
-#: src/muuli_wdr.cpp:2695
+#: src/muuli_wdr.cpp:2699
 msgid "Use obfuscation for outgoing connections"
 msgstr "Utilizza offuscamento per le connessioni in uscita"
 
-#: src/muuli_wdr.cpp:2697
+#: src/muuli_wdr.cpp:2701
 msgid "This option makes aMule use Protocol Obfuscation when connecting other clients/servers."
 msgstr "Questa opzione fa sì che aMule utilizzi l'offuscamento del protocollo quando si collega ad altri client/server."
 
-#: src/muuli_wdr.cpp:2699
+#: src/muuli_wdr.cpp:2703
 msgid "Accept only obfuscated connections"
 msgstr "Accetta SOLO connessioni offuscate"
 
-#: src/muuli_wdr.cpp:2700
+#: src/muuli_wdr.cpp:2704
 msgid "This option makes aMule only accept obfuscated connections. You will have less sources, but all your traffic will be obfuscated"
 msgstr "Attivando questa opzione aMule accetterà solo connessioni offuscate. Avrai meno fonti, ma tutto il tuo traffico sarà offuscato"
 
-#: src/muuli_wdr.cpp:2705
+#: src/muuli_wdr.cpp:2709
 msgid "Everybody"
 msgstr "Chiunque"
 
-#: src/muuli_wdr.cpp:2707
+#: src/muuli_wdr.cpp:2711
 msgid "No one"
 msgstr "Nessuno"
 
-#: src/muuli_wdr.cpp:2709
+#: src/muuli_wdr.cpp:2713
 msgid "Who can see my shared files:"
 msgstr "Chi può vedere i miei file condivisi:"
 
-#: src/muuli_wdr.cpp:2710
+#: src/muuli_wdr.cpp:2714
 msgid "Select who can request to view a list of your shared files."
 msgstr "Seleziona chi può richiedere di vedere la lista dei tuoi file condivisi."
 
-#: src/muuli_wdr.cpp:2712
+#: src/muuli_wdr.cpp:2716
 msgid "IP-Filtering"
 msgstr "Filtraggio IP"
 
-#: src/muuli_wdr.cpp:2719
+#: src/muuli_wdr.cpp:2723
 msgid "Filter clients"
 msgstr "Filtra i client"
 
-#: src/muuli_wdr.cpp:2721
+#: src/muuli_wdr.cpp:2725
 msgid "Enable filtering of the client IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "Filtra i client in base agli ip contenuti in ~/.aMule/ipfilter.dat."
 
-#: src/muuli_wdr.cpp:2723
+#: src/muuli_wdr.cpp:2727
 msgid "Filter servers"
 msgstr "Filtra i server"
 
-#: src/muuli_wdr.cpp:2725
+#: src/muuli_wdr.cpp:2729
 msgid "Enable filtering of the server IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "Filtra i server in base agli ip contenuti in ~/.aMule/ipfilter.dat."
 
-#: src/muuli_wdr.cpp:2729
+#: src/muuli_wdr.cpp:2733
 msgid "Reload List"
 msgstr "Ricarica lista"
 
-#: src/muuli_wdr.cpp:2730
+#: src/muuli_wdr.cpp:2734
 msgid "Reload the list of IPs to filter from the file ~/.aMule/ipfilter.dat"
 msgstr "Ricarica lista degli IP da filtrare dal file ~/.aMule/ipfilter.dat"
 
-#: src/muuli_wdr.cpp:2736
+#: src/muuli_wdr.cpp:2740
 msgid "URL:"
 msgstr "URL:"
 
-#: src/muuli_wdr.cpp:2740 src/muuli_wdr.cpp:2933
+#: src/muuli_wdr.cpp:2744 src/muuli_wdr.cpp:2937
 msgid "Update now"
 msgstr "Aggiorna ora"
 
-#: src/muuli_wdr.cpp:2743
+#: src/muuli_wdr.cpp:2747
 msgid "Auto-update ipfilter at startup"
 msgstr "Aggiorna ipfilter all'avvio"
 
-#: src/muuli_wdr.cpp:2747
+#: src/muuli_wdr.cpp:2751
 msgid "Filtering Level:"
 msgstr "Livello filtraggio:"
 
-#: src/muuli_wdr.cpp:2753
+#: src/muuli_wdr.cpp:2757
 msgid "Always filter LAN IPs"
 msgstr "Filtra sempre gli IP di una LAN"
 
-#: src/muuli_wdr.cpp:2756
+#: src/muuli_wdr.cpp:2760
 msgid "Paranoid handling of non-matching IPs"
 msgstr "Gestione paranoica degli IP non corrispondenti"
 
-#: src/muuli_wdr.cpp:2758
+#: src/muuli_wdr.cpp:2762
 msgid "Rejects a packet when its source IP differs from the IP the client claims (an anti-spoofing check). Disable only if it causes connection problems."
 msgstr "Rifiuta un pacchetto quando l'IP di origine è diverso dall'IP dichiarato dal client (un controllo anti-spoofing). Disabilitare solo se causa problemi di connessione."
 
-#: src/muuli_wdr.cpp:2760
+#: src/muuli_wdr.cpp:2764
 msgid "Use system-wide ipfilter.dat if available"
 msgstr "Usa l'ipfilter.dat di sistema se disponibile"
 
-#: src/muuli_wdr.cpp:2761
+#: src/muuli_wdr.cpp:2765
 msgid "If there's no local ipfilter.dat found, allow usage of a system-wide ipfilter file."
 msgstr "Se un file ipfilter.dat locale non viene trovato, consenti l'utilizzo del file ipfilter.dat di sistema."
 
-#: src/muuli_wdr.cpp:2778
+#: src/muuli_wdr.cpp:2782
 msgid "Enable Online-Signature"
 msgstr "Abilita Online Signature"
 
-#: src/muuli_wdr.cpp:2780
+#: src/muuli_wdr.cpp:2784
 msgid "Enables the writing of the OS file, which can be used by external apps to create signatures and the like."
 msgstr "Abilita la scrittura del file OS che può essere usato da applicazioni esterne per creare firme e simili."
 
-#: src/muuli_wdr.cpp:2784
+#: src/muuli_wdr.cpp:2788
 msgid "Update Frequency (Secs):"
 msgstr "Frequenza di aggiornamento (secondi):"
 
-#: src/muuli_wdr.cpp:2787
+#: src/muuli_wdr.cpp:2791
 msgid "Change the frequency (in seconds) of Online Signature updates."
 msgstr "Cambia la frequenza (in secondi) degli aggiornamenti dell'Online Signature."
 
-#: src/muuli_wdr.cpp:2795
+#: src/muuli_wdr.cpp:2799
 msgid "Save online signature file in: "
 msgstr "Salva la firma in linea in: "
 
-#: src/muuli_wdr.cpp:2801
+#: src/muuli_wdr.cpp:2805
 msgid "Click here to select the directory containing the the Online Signature files."
 msgstr "Clicca qui per selezionare la directory che contiene i file dell'Online Signature."
 
-#: src/muuli_wdr.cpp:2834
+#: src/muuli_wdr.cpp:2838
 msgid "Show country flags for clients"
 msgstr "Mostra la nazionalità dei client"
 
-#: src/muuli_wdr.cpp:2835
+#: src/muuli_wdr.cpp:2839
 msgid "Render the country flag column in the transfers, queue and search views. Requires a valid MMDB GeoIP database (see below)."
 msgstr "Mostra la colonna delle bandiere dei paesi nelle viste trasferimenti, coda e ricerca. Richiede un database GeoIP MMDB valido (vedi sotto)."
 
-#: src/muuli_wdr.cpp:2840
+#: src/muuli_wdr.cpp:2844
 msgid "Database"
 msgstr "Database"
 
-#: src/muuli_wdr.cpp:2856
+#: src/muuli_wdr.cpp:2860
 msgid "Source:"
 msgstr "Sorgente:"
 
-#: src/muuli_wdr.cpp:2859
+#: src/muuli_wdr.cpp:2863
 msgid "DB-IP (free, no account)"
 msgstr "DB-IP (gratuito, nessun account)"
 
-#: src/muuli_wdr.cpp:2860
+#: src/muuli_wdr.cpp:2864
 msgid "MaxMind GeoLite2 (free, account required)"
 msgstr "MaxMind GeoLite2 (gratuito, richiede account)"
 
-#: src/muuli_wdr.cpp:2861
+#: src/muuli_wdr.cpp:2865
 msgid "Custom URL"
 msgstr "URL personalizzato"
 
-#: src/muuli_wdr.cpp:2864
+#: src/muuli_wdr.cpp:2868
 msgid "Choose which provider supplies the GeoIP MMDB database. DB-IP is the default - no account required. MaxMind requires a free account + license key. Use Custom URL to point at any other MMDB host (e.g. a local mirror)."
 msgstr "Scegli quale provider fornisce il database GeoIP MMDB. DB-IP è il default - nessun account richiesto. MaxMind richiede un account gratuito + license key. Usa URL personalizzato per puntare a qualsiasi altro host MMDB (es. un mirror locale)."
 
-#: src/muuli_wdr.cpp:2881
+#: src/muuli_wdr.cpp:2885
 msgid ""
 "No configuration required.\n"
 "\n"
@@ -4865,11 +4865,11 @@ msgstr ""
 "Dati IP-to-Country di DB-IP.com - https://db-ip.com\n"
 "Licenza: Creative Commons BY 4.0 - https://creativecommons.org/licenses/by/4.0/"
 
-#: src/muuli_wdr.cpp:2894
+#: src/muuli_wdr.cpp:2898
 msgid "License key:"
 msgstr "License key:"
 
-#: src/muuli_wdr.cpp:2900
+#: src/muuli_wdr.cpp:2904
 msgid ""
 "Sign up for a free MaxMind account, then generate a License Key:\n"
 "https://www.maxmind.com/en/geolite2/signup\n"
@@ -4885,11 +4885,11 @@ msgstr ""
 "Licenza: MaxMind GeoLite2 EULA - https://www.maxmind.com/en/geolite2/eula\n"
 "Richiede attribuzione e registrazione dell'account; aggiornare almeno ogni 30 giorni."
 
-#: src/muuli_wdr.cpp:2915
+#: src/muuli_wdr.cpp:2919
 msgid "Download URL:"
 msgstr "URL di scaricamento:"
 
-#: src/muuli_wdr.cpp:2921
+#: src/muuli_wdr.cpp:2925
 msgid ""
 "Must point to an .mmdb file or a .gz / .tar.gz containing one.\n"
 "URL may include credentials (https://user:pass@host/...).\n"
@@ -4899,211 +4899,211 @@ msgstr ""
 "L'URL può includere credenziali (https://user:pass@host/...).\n"
 "I termini di licenza e attribuzione sono definiti dall'URL upstream - ne sei responsabile."
 
-#: src/muuli_wdr.cpp:2934
+#: src/muuli_wdr.cpp:2938
 msgid "Download the GeoIP database from the selected source."
 msgstr "Scarica il database GeoIP dalla sorgente selezionata."
 
-#: src/muuli_wdr.cpp:2936
+#: src/muuli_wdr.cpp:2940
 msgid "Auto-update on startup"
 msgstr "Aggiornamento automatico all'avvio"
 
-#: src/muuli_wdr.cpp:2937
+#: src/muuli_wdr.cpp:2941
 msgid "Re-download the GeoIP database from the selected source every time aMule starts."
 msgstr "Riscarica il database GeoIP dalla sorgente selezionata ogni volta che aMule si avvia."
 
-#: src/muuli_wdr.cpp:2960
+#: src/muuli_wdr.cpp:2964
 msgid "Filter incoming messages (except current chat):"
 msgstr "Filtra messaggi in arrivo (tranne per la chat in corso):"
 
-#: src/muuli_wdr.cpp:2962
+#: src/muuli_wdr.cpp:2966
 msgid "Filter all messages"
 msgstr "Filtra tutti i messaggi"
 
-#: src/muuli_wdr.cpp:2964
+#: src/muuli_wdr.cpp:2968
 msgid "Filter messages from people not on your friend list"
 msgstr "Filtra i messaggi da utenti che non sono nella tua lista degli amici"
 
-#: src/muuli_wdr.cpp:2966
+#: src/muuli_wdr.cpp:2970
 msgid "Filter messages from unknown clients"
 msgstr "Filtra i messaggi da client sconosciuti"
 
-#: src/muuli_wdr.cpp:2968
+#: src/muuli_wdr.cpp:2972
 msgid "Filter messages containing (use ',' as separator):"
 msgstr "Filtra i messaggi che contengono (usa ',' come separatore):"
 
-#: src/muuli_wdr.cpp:2971 src/muuli_wdr.cpp:2982
+#: src/muuli_wdr.cpp:2975 src/muuli_wdr.cpp:2986
 msgid "add here the words amule should filter and block messages including it"
 msgstr "aggiungi qui le parole che aMule filtrerà rimuovendo i messaggi che le contengono"
 
-#: src/muuli_wdr.cpp:2973
+#: src/muuli_wdr.cpp:2977
 msgid "Show received messages in the log"
 msgstr "Mostra nel log i messaggi ricevuti"
 
-#: src/muuli_wdr.cpp:2976
+#: src/muuli_wdr.cpp:2980
 msgid "Comments"
 msgstr "Commenti"
 
-#: src/muuli_wdr.cpp:2979
+#: src/muuli_wdr.cpp:2983
 msgid "Filter comments containing (use ',' as separator):"
 msgstr "Filtra i commenti contenenti (usa ',' come separatore):"
 
-#: src/muuli_wdr.cpp:3004
+#: src/muuli_wdr.cpp:3008
 msgid "Enable Proxy"
 msgstr "Abilita proxy"
 
-#: src/muuli_wdr.cpp:3005
+#: src/muuli_wdr.cpp:3009
 msgid "Enable/disable proxy support"
 msgstr "Abilita o disabilita il supporto proxy"
 
-#: src/muuli_wdr.cpp:3008
+#: src/muuli_wdr.cpp:3012
 msgid "Proxy type:"
 msgstr "Tipo proxy:"
 
-#: src/muuli_wdr.cpp:3019
+#: src/muuli_wdr.cpp:3023
 msgid "Proxy host:"
 msgstr "Indirizzo proxy:"
 
-#: src/muuli_wdr.cpp:3022
+#: src/muuli_wdr.cpp:3026
 msgid "The proxy host name"
 msgstr "Il nome host del proxy"
 
-#: src/muuli_wdr.cpp:3024
+#: src/muuli_wdr.cpp:3028
 msgid "Proxy port:"
 msgstr "Porta proxy:"
 
-#: src/muuli_wdr.cpp:3027
+#: src/muuli_wdr.cpp:3031
 msgid "The proxy port"
 msgstr "La porta del proxy"
 
-#: src/muuli_wdr.cpp:3029
+#: src/muuli_wdr.cpp:3033
 msgid "Enable authentication"
 msgstr "Abilita autenticazione"
 
-#: src/muuli_wdr.cpp:3030
+#: src/muuli_wdr.cpp:3034
 msgid "Enable/disable username/password authentication"
 msgstr "Abilita o disabilita l'autenticazione con nome utente e password"
 
-#: src/muuli_wdr.cpp:3033
+#: src/muuli_wdr.cpp:3037
 msgid "Username: "
 msgstr "Nome utente: "
 
-#: src/muuli_wdr.cpp:3036
+#: src/muuli_wdr.cpp:3040
 msgid "The username to use to connect to the proxy"
 msgstr "Nome utente utilizzato per la connessione al proxy"
 
-#: src/muuli_wdr.cpp:3038
+#: src/muuli_wdr.cpp:3042
 msgid "Password:"
 msgstr "Password:"
 
-#: src/muuli_wdr.cpp:3041
+#: src/muuli_wdr.cpp:3045
 msgid "The password to use to connect to the proxy"
 msgstr "La password usata per la connessione al proxy"
 
-#: src/muuli_wdr.cpp:3060
+#: src/muuli_wdr.cpp:3064
 msgid "Connect to:"
 msgstr "Connetti a:"
 
-#: src/muuli_wdr.cpp:3069
+#: src/muuli_wdr.cpp:3073
 msgid "Login to remote amule"
 msgstr "Login su aMule remoto"
 
-#: src/muuli_wdr.cpp:3074
+#: src/muuli_wdr.cpp:3078
 msgid "User name"
 msgstr "Nome utente"
 
-#: src/muuli_wdr.cpp:3085
+#: src/muuli_wdr.cpp:3089
 msgid "Remember those settings"
 msgstr "Ricorda impostazioni"
 
-#: src/muuli_wdr.cpp:3088
+#: src/muuli_wdr.cpp:3092
 msgid "Force ZLIB compression"
 msgstr "Forza la compressione ZLIB"
 
-#: src/muuli_wdr.cpp:3112
+#: src/muuli_wdr.cpp:3116
 msgid "Enable Verbose Debug-Logging."
 msgstr "Abilita il log dettagliato dei messaggi di debug."
 
-#: src/muuli_wdr.cpp:3114
+#: src/muuli_wdr.cpp:3118
 msgid "Only to Logfile"
 msgstr "Solamente sul file di log"
 
-#: src/muuli_wdr.cpp:3116
+#: src/muuli_wdr.cpp:3120
 msgid "Message Categories:"
 msgstr "Categorie messaggi:"
 
-#: src/muuli_wdr.cpp:3140 src/PartFileConvertDlg.cpp:160
+#: src/muuli_wdr.cpp:3144 src/PartFileConvertDlg.cpp:160
 msgid "Waiting..."
 msgstr "In attesa..."
 
-#: src/muuli_wdr.cpp:3160
+#: src/muuli_wdr.cpp:3164
 msgid "Add imports"
 msgstr "Aggiungi importazioni"
 
-#: src/muuli_wdr.cpp:3163
+#: src/muuli_wdr.cpp:3167
 msgid "Retry selected"
 msgstr "Riprova selezionati"
 
-#: src/muuli_wdr.cpp:3165
+#: src/muuli_wdr.cpp:3169
 msgid "Remove selected"
 msgstr "Rimuovi selezionati"
 
-#: src/muuli_wdr.cpp:3228
+#: src/muuli_wdr.cpp:3232
 msgid "Event Types"
 msgstr "Tipi di evento"
 
-#: src/muuli_wdr.cpp:3247
+#: src/muuli_wdr.cpp:3251
 msgid "Statistics and queued clients for selected file(s) : Session / All time"
 msgstr "Statistiche e client in coda per i(l) file selezionati(o) : Sessione / Totale"
 
-#: src/muuli_wdr.cpp:3271
+#: src/muuli_wdr.cpp:3275
 msgid "Active Uploads"
 msgstr "Upload attivi"
 
-#: src/muuli_wdr.cpp:3285
+#: src/muuli_wdr.cpp:3289
 msgid "Percent of total files"
 msgstr "Percentuale di file totali"
 
-#: src/muuli_wdr.cpp:3337
+#: src/muuli_wdr.cpp:3341
 msgid "Show Clients for"
 msgstr "Mostra client per"
 
-#: src/muuli_wdr.cpp:3339
+#: src/muuli_wdr.cpp:3343
 msgid "All files"
 msgstr "Tutti i file"
 
-#: src/muuli_wdr.cpp:3342
+#: src/muuli_wdr.cpp:3346
 msgid "Selected files"
 msgstr "File selezionati"
 
-#: src/muuli_wdr.cpp:3345
+#: src/muuli_wdr.cpp:3349
 msgid "Active uploads only"
 msgstr "Solo upload attivi"
 
-#: src/muuli_wdr.cpp:3352
+#: src/muuli_wdr.cpp:3356
 msgid "Reload:"
 msgstr "Ricarica lista:"
 
-#: src/muuli_wdr.cpp:3356
+#: src/muuli_wdr.cpp:3360
 msgid "Reload your shared files"
 msgstr "Ricarica file condivisi"
 
-#: src/muuli_wdr.cpp:3419
+#: src/muuli_wdr.cpp:3423
 msgid "Send"
 msgstr "Invia"
 
-#: src/muuli_wdr.cpp:3420
+#: src/muuli_wdr.cpp:3424
 msgid "Sends the specified message."
 msgstr "Invia messaggio specificato."
 
-#: src/muuli_wdr.cpp:3424
+#: src/muuli_wdr.cpp:3428
 msgid "Close this chat-session."
 msgstr "Chiude questa sessione di chat."
 
-#: src/muuli_wdr.cpp:3447
+#: src/muuli_wdr.cpp:3451
 msgid "Connect to any server and/or Kad"
 msgstr "Connetti a qualsiasi server e/o a Kad"
 
-#: src/muuli_wdr.cpp:3453 src/SharedFilesCtrl.cpp:142 src/Statistics.cpp:941
+#: src/muuli_wdr.cpp:3457 src/SharedFilesCtrl.cpp:142 src/Statistics.cpp:941
 msgid "Shared Files"
 msgstr "File condivisi"
 
@@ -5737,35 +5737,35 @@ msgstr ""
 "\n"
 "aMule funzionerà anche senza modificare questi parametri."
 
-#: src/PrefsUnifiedDlg.cpp:647
+#: src/PrefsUnifiedDlg.cpp:656
 #, c-format
 msgid "Failed to connect Cfg to widget with the ID %d and key %s"
 msgstr "Insuccesso nel collegare Cfg al widget con ID %d e chiave %s"
 
-#: src/PrefsUnifiedDlg.cpp:695
+#: src/PrefsUnifiedDlg.cpp:704
 #, c-format
 msgid "Failed to transfer data from Cfg to Widget with the ID %d and key %s"
 msgstr "Insuccesso nel trasferire dati da Cfg al Widget con ID %d e chiave %s"
 
-#: src/PrefsUnifiedDlg.cpp:801
+#: src/PrefsUnifiedDlg.cpp:810
 msgid "The type of proxy you are connecting to"
 msgstr "Il tipo di proxy a cui ti stai connettendo"
 
-#: src/PrefsUnifiedDlg.cpp:1020
+#: src/PrefsUnifiedDlg.cpp:1029
 #, c-format
 msgid "Failed to transfer data from Widget to Cfg with the ID %d and key %s"
 msgstr "Insuccesso nel trasferire dati dal widget al Cfg con ID %d e chiave %s"
 
-#: src/PrefsUnifiedDlg.cpp:1103
+#: src/PrefsUnifiedDlg.cpp:1112
 #, fuzzy
 msgid "No password set."
 msgstr "Password amministrazione"
 
-#: src/PrefsUnifiedDlg.cpp:1132
+#: src/PrefsUnifiedDlg.cpp:1141
 msgid "Guest access needs a password. Type one in the guest password field, or untick Enable guest access."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1144
+#: src/PrefsUnifiedDlg.cpp:1153
 msgid ""
 "aMule must be restarted to enable these changes:\n"
 "\n"
@@ -5773,39 +5773,39 @@ msgstr ""
 "aMule deve essere riavviato per rendere effettive queste modifiche:\n"
 "\n"
 
-#: src/PrefsUnifiedDlg.cpp:1151
+#: src/PrefsUnifiedDlg.cpp:1160
 msgid "- TCP port changed.\n"
 msgstr "- Modifica della porta TCP.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1156
+#: src/PrefsUnifiedDlg.cpp:1165
 msgid "- UDP port changed.\n"
 msgstr "- Modifica della porta UDP.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1161
+#: src/PrefsUnifiedDlg.cpp:1170
 msgid "- Network interface binding changed.\n"
 msgstr "- Associazione all'interfaccia di rete modificata.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1166
+#: src/PrefsUnifiedDlg.cpp:1175
 msgid "- External connect port changed.\n"
 msgstr "- Porta della connessione esterna modificata. \n"
 
-#: src/PrefsUnifiedDlg.cpp:1170
+#: src/PrefsUnifiedDlg.cpp:1179
 msgid "- External connect acceptance changed.\n"
 msgstr "- Accetta connessione esterna modificata. \n"
 
-#: src/PrefsUnifiedDlg.cpp:1174
+#: src/PrefsUnifiedDlg.cpp:1183
 msgid "- External connect interface changed.\n"
 msgstr "- Interfaccia connessione esterna modificata. \n"
 
-#: src/PrefsUnifiedDlg.cpp:1178
+#: src/PrefsUnifiedDlg.cpp:1187
 msgid "- Protocol obfuscation support changed.\n"
 msgstr "- Modificato il supporto all'offuscamento del protocollo.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1193
+#: src/PrefsUnifiedDlg.cpp:1202
 msgid "- amuleapi settings changed.\n"
 msgstr "- configurazione di amuleapi modificata.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1202
+#: src/PrefsUnifiedDlg.cpp:1211
 msgid ""
 "Your Auto-update server list is empty.\n"
 "'Auto-update server list at startup' will be disabled."
@@ -5813,7 +5813,7 @@ msgstr ""
 "La tua lista dei server per l'aggiornamento automatico è vuota.\n"
 "L'aggiornamento automatico all'avvio sarà disattivato."
 
-#: src/PrefsUnifiedDlg.cpp:1213
+#: src/PrefsUnifiedDlg.cpp:1222
 msgid ""
 "You have enabled external connections but have not specified a password.\n"
 "External connections cannot be enabled unless a valid password is specified."
@@ -5821,32 +5821,32 @@ msgstr ""
 "Hai abilitato le connessioni esterne senza però specificare una password.\n"
 "Le connessioni esterne non possono essere abilitate a meno che tu non scelga una password valida."
 
-#: src/PrefsUnifiedDlg.cpp:1246
+#: src/PrefsUnifiedDlg.cpp:1255
 #, c-format
 msgid "The amuleapi password could not be saved: %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1276
+#: src/PrefsUnifiedDlg.cpp:1285
 msgid "- Language changed.\n"
 msgstr "- Modifica della lingua.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1281
+#: src/PrefsUnifiedDlg.cpp:1290
 msgid "- Temp folder changed.\n"
 msgstr "- Modifica della cartella Temp.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1286
+#: src/PrefsUnifiedDlg.cpp:1295
 msgid "- ED2K network enabled.\n"
 msgstr "- Rete ed2k abilitata.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1319
+#: src/PrefsUnifiedDlg.cpp:1328
 msgid "The shared-file exclusion pattern is not a valid regular expression. The filter has been left disabled."
 msgstr "Il pattern di esclusione dei file condivisi non è un'espressione regolare valida. Il filtro è stato lasciato disattivato."
 
-#: src/PrefsUnifiedDlg.cpp:1321 src/PrefsUnifiedDlg.cpp:1921
+#: src/PrefsUnifiedDlg.cpp:1330 src/PrefsUnifiedDlg.cpp:1930
 msgid "Invalid regular expression"
 msgstr "Espressione regolare non valida"
 
-#: src/PrefsUnifiedDlg.cpp:1398
+#: src/PrefsUnifiedDlg.cpp:1407
 msgid ""
 "Both eD2k and Kad network are disabled.\n"
 "You won't be able to connect until you enable at least one of them."
@@ -5854,7 +5854,7 @@ msgstr ""
 "Le reti eD2k e Kad sono entrambe disabilitate.\n"
 "Non potrai connetterti finché non ne abiliterai almeno una."
 
-#: src/PrefsUnifiedDlg.cpp:1403
+#: src/PrefsUnifiedDlg.cpp:1412
 msgid ""
 "Kad will not start if your UDP port is disabled.\n"
 "Enable UDP port or disable Kad."
@@ -5862,7 +5862,7 @@ msgstr ""
 "Kad non può partire se la porta UDP è disabilitata.\n"
 "Abilitala o disabilita Kad."
 
-#: src/PrefsUnifiedDlg.cpp:1459
+#: src/PrefsUnifiedDlg.cpp:1468
 msgid ""
 "\n"
 "You MUST restart aMule now.\n"
@@ -5872,68 +5872,68 @@ msgstr ""
 "DEVI riavviare aMule ADESSO.\n"
 "Se non lo fai, non lamentarti se succede qualcosa di strano.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1524
+#: src/PrefsUnifiedDlg.cpp:1533
 msgid "Could not register aMule for autostart at login. The autostart store may be read-only."
 msgstr "Impossibile registrare aMule per l'avvio automatico all'accesso. L'archivio di avvio automatico potrebbe essere in sola lettura."
 
-#: src/PrefsUnifiedDlg.cpp:1526
+#: src/PrefsUnifiedDlg.cpp:1535
 msgid "Could not remove the autostart-at-login entry."
 msgstr "Impossibile rimuovere la voce di avvio automatico all'accesso."
 
-#: src/PrefsUnifiedDlg.cpp:1527
+#: src/PrefsUnifiedDlg.cpp:1536
 msgid "Autostart"
 msgstr "Avvio automatico"
 
-#: src/PrefsUnifiedDlg.cpp:1542
+#: src/PrefsUnifiedDlg.cpp:1551
 msgid "Register file type"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1542
+#: src/PrefsUnifiedDlg.cpp:1551
 msgid "Register URL handler"
 msgstr "Registra gestore URL"
 
-#: src/PrefsUnifiedDlg.cpp:1550
+#: src/PrefsUnifiedDlg.cpp:1559
 #, c-format
 msgid "aMule only handles eD2k-compatible magnets. If you replace the current magnet handler (%s), BitTorrent magnet links will stop working - aMule cannot download BitTorrent content. Continue?"
 msgstr "aMule gestisce solo i magnet compatibili con eD2k. Se sostituisci il gestore magnet attuale (%s), i link magnet BitTorrent smetteranno di funzionare: aMule non può scaricare contenuti BitTorrent. Continuare?"
 
-#: src/PrefsUnifiedDlg.cpp:1555
+#: src/PrefsUnifiedDlg.cpp:1564
 #, fuzzy, c-format
 msgid "Another application currently opens .emulecollection files (%s). Replace it with aMule?"
 msgstr "Attualmente un'altra applicazione è il gestore predefinito per questi link (%s). Sostituirla con aMule?"
 
-#: src/PrefsUnifiedDlg.cpp:1560
+#: src/PrefsUnifiedDlg.cpp:1569
 #, c-format
 msgid "Another application is currently the default handler for these links (%s). Replace it with aMule?"
 msgstr "Attualmente un'altra applicazione è il gestore predefinito per questi link (%s). Sostituirla con aMule?"
 
-#: src/PrefsUnifiedDlg.cpp:1585
+#: src/PrefsUnifiedDlg.cpp:1594
 #, fuzzy
 msgid "Could not register aMule for .emulecollection files. The registration store may be read-only."
 msgstr "Impossibile registrare aMule come gestore URL. Il registro delle associazioni potrebbe essere in sola lettura."
 
-#: src/PrefsUnifiedDlg.cpp:1587
+#: src/PrefsUnifiedDlg.cpp:1596
 #, fuzzy
 msgid "Could not remove the file type registration."
 msgstr "Impossibile rimuovere la registrazione del gestore URL."
 
-#: src/PrefsUnifiedDlg.cpp:1589
+#: src/PrefsUnifiedDlg.cpp:1598
 msgid "Could not register aMule as the URL handler. The registration store may be read-only."
 msgstr "Impossibile registrare aMule come gestore URL. Il registro delle associazioni potrebbe essere in sola lettura."
 
-#: src/PrefsUnifiedDlg.cpp:1591
+#: src/PrefsUnifiedDlg.cpp:1600
 msgid "Could not remove the URL handler registration."
 msgstr "Impossibile rimuovere la registrazione del gestore URL."
 
-#: src/PrefsUnifiedDlg.cpp:1661 src/PrefsUnifiedDlg.cpp:1688
+#: src/PrefsUnifiedDlg.cpp:1670 src/PrefsUnifiedDlg.cpp:1697
 msgid "The web server and aMule API require external connections to be enabled."
 msgstr "Il server web e aMule API richiedono che le connessioni esterne siano abilitate."
 
-#: src/PrefsUnifiedDlg.cpp:1671
+#: src/PrefsUnifiedDlg.cpp:1680
 msgid "The aMule web server is deprecated. Consider running the aMule API instead."
 msgstr "Il server web di aMule è deprecato. Valuta in alternativa l'uso di aMule API."
 
-#: src/PrefsUnifiedDlg.cpp:1735
+#: src/PrefsUnifiedDlg.cpp:1744
 msgid ""
 "Your Auto-update servers list is in blank.\n"
 "Please fill in at least one URL to point to a valid server.met file.\n"
@@ -5943,64 +5943,64 @@ msgstr ""
 "Inserisci l'URL di almeno un server valido nel file server.met.\n"
 "Clicca sul pulsante \"Lista\" per inserire l'URL."
 
-#: src/PrefsUnifiedDlg.cpp:1876
+#: src/PrefsUnifiedDlg.cpp:1885
 msgid "Temporary files"
 msgstr "File temporanei"
 
-#: src/PrefsUnifiedDlg.cpp:1881
+#: src/PrefsUnifiedDlg.cpp:1890
 msgid "Incoming files"
 msgstr "File completi"
 
-#: src/PrefsUnifiedDlg.cpp:1886
+#: src/PrefsUnifiedDlg.cpp:1895
 msgid "Online Signatures"
 msgstr "Online Signature"
 
-#: src/PrefsUnifiedDlg.cpp:1899
+#: src/PrefsUnifiedDlg.cpp:1908
 #, c-format
 msgid "Choose a folder for %s"
 msgstr "Scegli una directory per i %s"
 
-#: src/PrefsUnifiedDlg.cpp:1923
+#: src/PrefsUnifiedDlg.cpp:1932
 #, c-format
 msgid "Would exclude %u of %u shared file"
 msgid_plural "Would exclude %u of %u shared files"
 msgstr[0] "Escluderebbe %u di %u file condiviso"
 msgstr[1] "Escluderebbe %u di %u file condivisi"
 
-#: src/PrefsUnifiedDlg.cpp:1940
+#: src/PrefsUnifiedDlg.cpp:1949
 msgid "Browse for videoplayer"
 msgstr "Sfoglia per trovare un riproduttore video"
 
-#: src/PrefsUnifiedDlg.cpp:1944
+#: src/PrefsUnifiedDlg.cpp:1953
 msgid "Select browser"
 msgstr "Scegli browser"
 
-#: src/PrefsUnifiedDlg.cpp:1948
+#: src/PrefsUnifiedDlg.cpp:1957
 msgid "Select ffprobe binary"
 msgstr "Seleziona il binario ffprobe"
 
-#: src/PrefsUnifiedDlg.cpp:1954
+#: src/PrefsUnifiedDlg.cpp:1963
 #, c-format
 msgid "Executable%s"
 msgstr "Eseguibile%s"
 
-#: src/PrefsUnifiedDlg.cpp:1988
+#: src/PrefsUnifiedDlg.cpp:1997
 msgid "ffprobe not found on PATH or in the standard install locations. Install ffmpeg (which ships ffprobe) or use Browse to pick a binary manually."
 msgstr "ffprobe non trovato nel PATH né nei percorsi di installazione standard. Installa ffmpeg (che include ffprobe) oppure usa Sfoglia per selezionare manualmente un binario."
 
-#: src/PrefsUnifiedDlg.cpp:2000
+#: src/PrefsUnifiedDlg.cpp:2009
 msgid "Reset the settings on this page to their default values?"
 msgstr "Ripristinare le impostazioni di questa pagina ai loro valori predefiniti?"
 
-#: src/PrefsUnifiedDlg.cpp:2001
+#: src/PrefsUnifiedDlg.cpp:2010
 msgid "Reset to defaults"
 msgstr "Ripristina i valori predefiniti"
 
-#: src/PrefsUnifiedDlg.cpp:2028
+#: src/PrefsUnifiedDlg.cpp:2037
 msgid "Edit server list"
 msgstr "Modifica la lista dei server"
 
-#: src/PrefsUnifiedDlg.cpp:2029
+#: src/PrefsUnifiedDlg.cpp:2038
 msgid ""
 "Add here URL's to download server.met files.\n"
 "Only one url on each line."
@@ -6008,114 +6008,114 @@ msgstr ""
 "Inserisci l'URL da cui scaricare il file server.met.\n"
 "Solo un URL per riga."
 
-#: src/PrefsUnifiedDlg.cpp:2084
+#: src/PrefsUnifiedDlg.cpp:2093
 msgid "IP2Country update failed"
 msgstr "Aggiornamento IP2Country fallito"
 
-#: src/PrefsUnifiedDlg.cpp:2229 src/PrefsUnifiedDlg.cpp:2260
+#: src/PrefsUnifiedDlg.cpp:2238 src/PrefsUnifiedDlg.cpp:2269
 msgid "Data by MaxMind GeoLite2"
 msgstr "Dati di MaxMind GeoLite2"
 
-#: src/PrefsUnifiedDlg.cpp:2231 src/PrefsUnifiedDlg.cpp:2262
+#: src/PrefsUnifiedDlg.cpp:2240 src/PrefsUnifiedDlg.cpp:2271
 msgid "Custom source"
 msgstr "Sorgente personalizzata"
 
-#: src/PrefsUnifiedDlg.cpp:2233 src/PrefsUnifiedDlg.cpp:2264
+#: src/PrefsUnifiedDlg.cpp:2242 src/PrefsUnifiedDlg.cpp:2273
 msgid "Data by DB-IP.com"
 msgstr "Dati di DB-IP.com"
 
-#: src/PrefsUnifiedDlg.cpp:2284
+#: src/PrefsUnifiedDlg.cpp:2293
 #, c-format
 msgid "Status: Loaded%s"
 msgstr "Stato: Caricato%s"
 
-#: src/PrefsUnifiedDlg.cpp:2286
+#: src/PrefsUnifiedDlg.cpp:2295
 #, c-format
 msgid "Status: Loaded%s - %s"
 msgstr "Stato: Caricato%s - %s"
 
-#: src/PrefsUnifiedDlg.cpp:2290
+#: src/PrefsUnifiedDlg.cpp:2299
 msgid "Status: Failed to load - click 'Update now' to refresh."
 msgstr "Stato: Caricamento fallito - clicca su 'Aggiorna ora' per ricaricare."
 
-#: src/PrefsUnifiedDlg.cpp:2292
+#: src/PrefsUnifiedDlg.cpp:2301
 msgid "Status: Not found - click 'Update now' to download."
 msgstr "Stato: Non trovato - clicca su 'Aggiorna ora' per scaricare."
 
-#: src/PrefsUnifiedDlg.cpp:2350 src/PrefsUnifiedDlg.cpp:2374
+#: src/PrefsUnifiedDlg.cpp:2359 src/PrefsUnifiedDlg.cpp:2383
 #, c-format
 msgid "Update delay: %d second"
 msgid_plural "Update delay: %d seconds"
 msgstr[0] "Intervallo aggiornamento: %d secondo"
 msgstr[1] "Intervallo aggiornamento: %d secondi"
 
-#: src/PrefsUnifiedDlg.cpp:2358
+#: src/PrefsUnifiedDlg.cpp:2367
 #, c-format
 msgid "Time for average graph: %d minute"
 msgid_plural "Time for average graph: %d minutes"
 msgstr[0] "Intervallo grafico della media: %d minuto"
 msgstr[1] "Intervallo grafico della media: %d minuti"
 
-#: src/PrefsUnifiedDlg.cpp:2367
+#: src/PrefsUnifiedDlg.cpp:2376
 #, c-format
 msgid "Connections Graph Scale: %d"
 msgstr "Scala grafico delle connessioni: %d"
 
-#: src/PrefsUnifiedDlg.cpp:2382
+#: src/PrefsUnifiedDlg.cpp:2391
 #, c-format
 msgid "File Buffer Size: %d byte"
 msgid_plural "File Buffer Size: %d bytes"
 msgstr[0] "Dimensione buffer file: %d byte"
 msgstr[1] "Dimensione buffer file: %d bytes"
 
-#: src/PrefsUnifiedDlg.cpp:2392
+#: src/PrefsUnifiedDlg.cpp:2401
 #, c-format
 msgid "Upload Queue Size: %d client"
 msgid_plural "Upload Queue Size: %d clients"
 msgstr[0] "Dimensione coda upload: %d client"
 msgstr[1] "Dimensione coda upload: %d client"
 
-#: src/PrefsUnifiedDlg.cpp:2402
+#: src/PrefsUnifiedDlg.cpp:2411
 #, c-format
 msgid "Server connection refresh interval: %d minute"
 msgid_plural "Server connection refresh interval: %d minutes"
 msgstr[0] "Intervallo aggiornamento connessione ai server: %d minuto"
 msgstr[1] "Intervallo aggiornamento connessione ai server: %d minuti"
 
-#: src/PrefsUnifiedDlg.cpp:2407
+#: src/PrefsUnifiedDlg.cpp:2416
 msgid "Server connection refresh interval: Disabled"
 msgstr "Intervallo aggiornamento connessione ai server: disabilitato"
 
-#: src/PrefsUnifiedDlg.cpp:2451
+#: src/PrefsUnifiedDlg.cpp:2460
 msgid "disabled"
 msgstr "disattivato"
 
-#: src/PrefsUnifiedDlg.cpp:2477
+#: src/PrefsUnifiedDlg.cpp:2486
 #, c-format
 msgid "Execute command on '%s' event"
 msgstr "Esegui comando se si verifica l'evento '%s'"
 
-#: src/PrefsUnifiedDlg.cpp:2484
+#: src/PrefsUnifiedDlg.cpp:2493
 msgid "Enable command execution on core"
 msgstr "Abilita l'esecuzione del comando sul core"
 
-#: src/PrefsUnifiedDlg.cpp:2496
+#: src/PrefsUnifiedDlg.cpp:2505
 msgid "Core command:"
 msgstr "Comando Core:"
 
-#: src/PrefsUnifiedDlg.cpp:2512
+#: src/PrefsUnifiedDlg.cpp:2521
 msgid "Enable command execution on GUI"
 msgstr "Abilita l'esecuzione del comando sulla GUI"
 
-#: src/PrefsUnifiedDlg.cpp:2524
+#: src/PrefsUnifiedDlg.cpp:2533
 msgid "GUI command:"
 msgstr "Comando GUI:"
 
-#: src/PrefsUnifiedDlg.cpp:2540
+#: src/PrefsUnifiedDlg.cpp:2549
 msgid "The following variables will be replaced:"
 msgstr "Le seguenti variabili saranno sostituite:"
 
-#: src/PrefsUnifiedDlg.cpp:2708
+#: src/PrefsUnifiedDlg.cpp:2717
 msgid ""
 "The following folders look like system or sensitive locations:\n"
 "\n"
@@ -6123,37 +6123,37 @@ msgstr ""
 "Le seguenti cartelle sembrano posizioni di sistema o sensibili:\n"
 "\n"
 
-#: src/PrefsUnifiedDlg.cpp:2713
+#: src/PrefsUnifiedDlg.cpp:2722
 msgid "Sharing them recursively will publish every file underneath on the eD2k/Kad networks. Do you really want to do this?"
 msgstr "Condividerle ricorsivamente pubblicherà ogni file al loro interno sulle reti eD2k/Kad. Vuoi davvero procedere?"
 
-#: src/PrefsUnifiedDlg.cpp:2716
+#: src/PrefsUnifiedDlg.cpp:2725
 msgid "Confirm shared folders"
 msgstr "Conferma cartelle condivise"
 
-#: src/PrefsUnifiedDlg.cpp:2744
+#: src/PrefsUnifiedDlg.cpp:2753
 msgid "Reloading shared files..."
 msgstr "Ricarica file condivisi in corso..."
 
-#: src/PrefsUnifiedDlg.cpp:2745
+#: src/PrefsUnifiedDlg.cpp:2754
 msgid "Scanning for subdirectories..."
 msgstr "Analisi delle sottocartelle in corso..."
 
-#: src/PrefsUnifiedDlg.cpp:2746
+#: src/PrefsUnifiedDlg.cpp:2755
 msgid "Updating shared folders"
 msgstr "Aggiornamento cartelle condivise"
 
-#: src/PrefsUnifiedDlg.cpp:2773
+#: src/PrefsUnifiedDlg.cpp:2782
 #, c-format
 msgid "Scanned %u directories..."
 msgstr "%u cartelle analizzate..."
 
-#: src/PrefsUnifiedDlg.cpp:2823
+#: src/PrefsUnifiedDlg.cpp:2832
 #, c-format
 msgid "Reloading shared files: %u files scanned"
 msgstr "Ricarica file condivisi: %u file analizzati"
 
-#: src/PrefsUnifiedDlg.cpp:2873
+#: src/PrefsUnifiedDlg.cpp:2882
 msgid "Shared folder"
 msgstr "Cartella condivisa"
 
@@ -7839,12 +7839,12 @@ msgstr "Elimina categoria"
 msgid "Hashset requested for unknown file: %s"
 msgstr "Hashset richiesto per il file sconosciuto: %s"
 
-#: src/UploadQueue.cpp:618
+#: src/UploadQueue.cpp:627
 #, c-format
 msgid "Resuming uploads of file: %s"
 msgstr "Ripristino invio del file: %s"
 
-#: src/UploadQueue.cpp:634
+#: src/UploadQueue.cpp:643
 #, c-format
 msgid "Suspending upload of file: %s"
 msgstr "Sospensione invio del file: %s"

--- a/po/it.po
+++ b/po/it.po
@@ -19,7 +19,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule 2.3.3\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-28 10:19+0200\n"
+"POT-Creation-Date: 2026-07-28 12:17+0200\n"
 "PO-Revision-Date: 2026-07-27 11:40+0000\n"
 "Last-Translator: got3nks <got3nks@users.noreply.github.com>\n"
 "Language-Team: SebastianoPistore.info@protonmail.ch\n"
@@ -213,83 +213,83 @@ msgstr "Impossibile aprire il link ed2k."
 msgid "WARNING: You can't add yourself as a source for an eD2k link while having a lowid."
 msgstr "ATTENZIONE: non è possibile aggiungere te stesso come fonte di un link eD2k finché avrai un ID basso."
 
-#: src/amule.cpp:300
+#: src/amule.cpp:301
 msgid "Now, exiting main app..."
 msgstr "Chiusura dell'applicazione..."
 
-#: src/amule.cpp:330
+#: src/amule.cpp:331
 #, c-format
 msgid "Terminating amuleweb instance with pid '%d' ... "
 msgstr "Sto terminando l'istanza di amuleweb con pid `%d' ... "
 
-#: src/amule.cpp:334
+#: src/amule.cpp:335
 #, c-format
 msgid "Killing amuleweb instance with pid '%d' ... "
 msgstr "Sto terminando forzatamente l'istanza di amuleweb con pid `%d' ... "
 
-#: src/amule.cpp:336 src/amule.cpp:349 src/ClientRef.cpp:180
+#: src/amule.cpp:337 src/amule.cpp:350 src/ClientRef.cpp:180
 #: src/SearchDlg.cpp:1041 src/ServerListCtrl.cpp:98
 msgid "Failed"
 msgstr "Fallito"
 
-#: src/amule.cpp:343
+#: src/amule.cpp:344
 #, c-format
 msgid "Terminating amuleapi instance with pid '%d' ... "
 msgstr "Sto terminando l'istanza di amuleapi con pid `%d' ... "
 
-#: src/amule.cpp:347
+#: src/amule.cpp:348
 #, c-format
 msgid "Killing amuleapi instance with pid '%d' ... "
 msgstr "Sto terminando forzatamente l'istanza di amuleapi con pid `%d' ... "
 
-#: src/amule.cpp:355
+#: src/amule.cpp:356
 msgid "aMule OnExit: Terminating core."
 msgstr "aMule in fase di chiusura: Terminazione del core."
 
-#: src/amule.cpp:466
+#: src/amule.cpp:467
 msgid "aMule shutdown completed."
 msgstr "aMule, arresto completato."
 
-#: src/amule.cpp:470
+#: src/amule.cpp:471
 msgid "Memory debug results for aMule exit:"
 msgstr "Risultati del debug della memoria per la chiusura di aMule:"
 
-#: src/amule.cpp:651
+#: src/amule.cpp:652
 #, c-format
 msgid "Binding aMule's peer-to-peer traffic to interface: %s (HTTP updates use the default route)"
 msgstr "Associazione del traffico peer-to-peer di aMule all'interfaccia: %s (gli aggiornamenti HTTP usano la route predefinita)"
 
-#: src/amule.cpp:655
+#: src/amule.cpp:656
 #, c-format
 msgid "Binding all network traffic to interface: %s"
 msgstr "Associazione di tutto il traffico di rete all'interfaccia: %s"
 
-#: src/amule.cpp:659
+#: src/amule.cpp:660
 #, c-format
 msgid "WARNING: configured network interface '%s' was not found - traffic is NOT bound to it and may leave via the default route. Check the interface name in Preferences."
 msgstr "ATTENZIONE: l'interfaccia di rete configurata '%s' non è stata trovata - il traffico NON è associato ad essa e potrebbe uscire tramite la route predefinita. Controlla il nome dell'interfaccia nelle Preferenze."
 
-#: src/amule.cpp:665
+#: src/amule.cpp:666
 #, c-format
 msgid "WARNING: binding to network interface '%s' requires elevated privileges and was NOT applied - traffic may leave via the default route. Grant the capability (e.g. 'sudo setcap cap_net_raw+ep' on the aMule binary) or run with sufficient privileges."
 msgstr "ATTENZIONE: l'associazione all'interfaccia di rete '%s' richiede privilegi elevati e NON è stata applicata - il traffico potrebbe uscire tramite la route predefinita. Concedi la capability (ad es. 'sudo setcap cap_net_raw+ep' sul binario di aMule) oppure esegui con privilegi sufficienti."
 
-#: src/amule.cpp:673
+#: src/amule.cpp:674
 #, c-format
 msgid "WARNING: could not bind to network interface '%s' - traffic may leave via the default route."
 msgstr "ATTENZIONE: impossibile associare all'interfaccia di rete '%s' - il traffico potrebbe uscire tramite la route predefinita."
 
-#: src/amule.cpp:732
+#: src/amule.cpp:733
 msgid "Your locale has been changed to System Default due to a configuration change. Sorry."
 msgstr "Le tue impostazioni di localizzazione sono state impostate a quelle predefinite dal sistema in conseguenza del cambio di configurazione. Spiacente."
 
-#: src/amule.cpp:734 src/amule.cpp:1581 src/CatDialog.cpp:128
+#: src/amule.cpp:735 src/amule.cpp:1589 src/CatDialog.cpp:128
 #: src/CatDialog.cpp:136 src/CatDialog.cpp:149 src/ServerList.cpp:366
 #: src/ServerListCtrl.cpp:152
 msgid "Info"
 msgstr "Info"
 
-#: src/amule.cpp:741
+#: src/amule.cpp:742
 msgid ""
 "\n"
 "EC configuration"
@@ -297,22 +297,22 @@ msgstr ""
 "\n"
 "Configurazione EC"
 
-#: src/amule.cpp:744
+#: src/amule.cpp:745
 msgid "Password set and external connections enabled."
 msgstr "Password impostata, connessioni esterne abilitate."
 
-#: src/amule.cpp:754 src/KadDlg.cpp:176 src/KadDlg.cpp:185
-#: src/PrefsUnifiedDlg.cpp:1387 src/SharedFilesCtrl.cpp:476
+#: src/amule.cpp:755 src/KadDlg.cpp:176 src/KadDlg.cpp:185
+#: src/PrefsUnifiedDlg.cpp:1461 src/SharedFilesCtrl.cpp:476
 msgid "WARNING"
 msgstr "ATTENZIONE"
 
 # AI-GENERATED — please review.
-#: src/amule.cpp:991
+#: src/amule.cpp:992
 msgid "Network bootstrap"
 msgstr "Bootstrap di rete"
 
 # AI-GENERATED — please review.
-#: src/amule.cpp:996
+#: src/amule.cpp:997
 msgid ""
 "aMule has detected missing network bootstrap files.\n"
 "Select which ones to download:"
@@ -321,52 +321,52 @@ msgstr ""
 "Selezionare quali scaricare:"
 
 # AI-GENERATED — please review.
-#: src/amule.cpp:1005 src/FirstRunWizard.cpp:411
+#: src/amule.cpp:1006 src/FirstRunWizard.cpp:411
 msgid "eD2k server list (server.met)"
 msgstr "Lista server eD2k (server.met)"
 
 # AI-GENERATED — please review.
-#: src/amule.cpp:1012 src/FirstRunWizard.cpp:416
+#: src/amule.cpp:1013 src/FirstRunWizard.cpp:416
 msgid "Kad bootstrap nodes (nodes.dat)"
 msgstr "Nodi di bootstrap Kad (nodes.dat)"
 
-#: src/amule.cpp:1102
+#: src/amule.cpp:1103
 #, c-format
 msgid "web server running on pid %d"
 msgstr "web server in esecuzione su pid %d"
 
-#: src/amule.cpp:1115
+#: src/amule.cpp:1116
 msgid "You requested to run web server on startup, but the amuleweb binary cannot be run. Please install the package containing aMule web server, or build aMule from source with -DBUILD_WEBSERVER=YES and install it."
 msgstr "Hai scelto di lanciare il web server all'avvio, ma il programma amuleweb non può essere eseguito. Installa il pacchetto contenente aMule web server, oppure compila aMule dai sorgenti con -DBUILD_WEBSERVER=YES e installalo."
 
-#: src/amule.cpp:1120 src/amule.cpp:1177 src/amule.cpp:1291 src/amule.cpp:1593
+#: src/amule.cpp:1121 src/amule.cpp:1185 src/amule.cpp:1299 src/amule.cpp:1601
 #: src/amule-remote-gui.cpp:603 src/amule-remote-gui.cpp:671
 #: src/amule-remote-gui.cpp:709 src/amule-remote-gui.cpp:1282
 #: src/amule-remote-gui.cpp:1345 src/amule-remote-gui.cpp:1372
-#: src/DownloadQueue.cpp:1481
+#: src/DownloadQueue.cpp:1481 src/PrefsUnifiedDlg.cpp:1247
 msgid "ERROR"
 msgstr "ERRORE"
 
-#: src/amule.cpp:1166
+#: src/amule.cpp:1174
 #, c-format
 msgid "amuleapi running on pid %d"
 msgstr "amuleapi in esecuzione su pid %d"
 
-#: src/amule.cpp:1172
+#: src/amule.cpp:1180
 msgid "You requested to run amuleapi on startup, but the amuleapi binary cannot be run. Please install the package containing aMule's REST API server, or build aMule from source with -DBUILD_AMULEAPI=YES and install it."
 msgstr "Hai scelto di lanciare amuleapi all'avvio, ma il programma amuleapi non può essere eseguito. Installa il pacchetto contenente amuleapi, oppure compila aMule dai sorgenti con -DBUILD_AMULEAPI=YES e installalo."
 
-#: src/amule.cpp:1259
+#: src/amule.cpp:1267
 #, c-format
 msgid "Could not bind ports to the specified address: %s"
 msgstr "Impossibile aprire le porte sull'indirizzo specificato: %s"
 
-#: src/amule.cpp:1283
+#: src/amule.cpp:1291
 #, c-format
 msgid "Port %u is not available. You will be LOWID\n"
 msgstr "La porta %u non è disponibile. Otterrai un ID basso\n"
 
-#: src/amule.cpp:1288
+#: src/amule.cpp:1296
 #, c-format
 msgid ""
 "Port %u is not available!\n"
@@ -381,48 +381,48 @@ msgstr ""
 "\n"
 "Controlla le impostazioni di rete e verifica che la porta sia aperta in ingresso e in uscita."
 
-#: src/amule.cpp:1385
+#: src/amule.cpp:1393
 msgid "Failed to create OnlineSig File"
 msgstr "Impossibile creare il file per l'online signature"
 
-#: src/amule.cpp:1393
+#: src/amule.cpp:1401
 msgid "Failed to create aMule OnlineSig File"
 msgstr "Impossibile creare il file per l'online signature di aMule"
 
-#: src/amule.cpp:1556
+#: src/amule.cpp:1564
 msgid "The selected locale seems not to be installed on your box. (Note: I'll try to set it anyway)"
 msgstr "L'impostazione locale selezionata non sembra essere installata sul tuo computer (si tenterà di impostarla in ogni caso)"
 
-#: src/amule.cpp:1566
+#: src/amule.cpp:1574
 #, c-format
 msgid "This is the first time you run aMule %s"
 msgstr "È la prima che volta che avvii aMule %s"
 
-#: src/amule.cpp:1569
+#: src/amule.cpp:1577
 msgid "This version is a testing version, updated daily, and\n"
 msgstr "Questa è una versione di prova, aggiornata quotidianamente, e\n"
 
-#: src/amule.cpp:1570
+#: src/amule.cpp:1578
 msgid "we give no warranty it won't break anything, burn your house,\n"
 msgstr "non garantiamo che essa non distrugga qualcosa, bruci la tua casa,\n"
 
-#: src/amule.cpp:1571
+#: src/amule.cpp:1579
 msgid "or kill your dog. But it *should* be safe to use anyway.\n"
 msgstr "o uccida il tuo cane. Ma *dovrebbe* essere comunque sicura.\n"
 
-#: src/amule.cpp:1576
+#: src/amule.cpp:1584
 msgid "More information, support and new releases can found at our homepage,\n"
 msgstr "Altre informazioni, supporto e nuove versioni possono essere trovate nella nostra homepage,\n"
 
-#: src/amule.cpp:1577
+#: src/amule.cpp:1585
 msgid "at https://amule-org.github.io, or in our IRC channel #aMule at irc.libera.chat.\n"
 msgstr "https://amule-org.github.io, o nel nostro canale IRC #aMule su irc.libera.chat.\n"
 
-#: src/amule.cpp:1579
+#: src/amule.cpp:1587
 msgid "Feel free to report any bugs to https://github.com/amule-org/amule/issues"
 msgstr "Puoi segnalare qualsiasi bug su https://github.com/amule-org/amule/issues"
 
-#: src/amule.cpp:1591
+#: src/amule.cpp:1599
 msgid ""
 "The folder for Online Signature files you specified is INVALID!\n"
 " OnlineSignature will be DISABLED until you fix it on preferences."
@@ -430,137 +430,137 @@ msgstr ""
 "La directory scelta per contenere il file dell'online signature non è valida!\n"
 "La firma verrà pertanto disabilitata fino a quando il problema non sarà stato risolto attraverso il pannello delle preferenze."
 
-#: src/amule.cpp:1654
+#: src/amule.cpp:1662
 msgid "Server hostname notified"
 msgstr "Nome host del server notificato"
 
-#: src/amule.cpp:2031
+#: src/amule.cpp:2039
 #, c-format
 msgid "Disk space preallocation for file '%s' failed: %s"
 msgstr "Preallocazione dello spazio su disco per il file '%s' fallita: %s"
 
-#: src/amule.cpp:2160
+#: src/amule.cpp:2168
 msgid "ERROR: can't open logfile"
 msgstr "ERRORE: impossibile aprire il file di log"
 
-#: src/amule.cpp:2164
+#: src/amule.cpp:2172
 msgid "WARNING: logfile is empty. Something is wrong."
 msgstr "ERRORE: il file di log è vuoto. Qualcosa non va."
 
-#: src/amule.cpp:2181
+#: src/amule.cpp:2189
 msgid "Log has been reset"
 msgstr "Il file di log è stato reimpostato"
 
-#: src/amule.cpp:2205
+#: src/amule.cpp:2213
 #, c-format
 msgid "ServerMessage: %s"
 msgstr "Messaggio del server: %s"
 
-#: src/amule.cpp:2248 src/IP2Country.cpp:220 src/IPFilter.cpp:514
+#: src/amule.cpp:2256 src/IP2Country.cpp:220 src/IPFilter.cpp:514
 #: src/ServerList.cpp:875
 #, c-format
 msgid "Skipped download of %s, because requested file is not newer."
 msgstr "Download di %s saltato, perché il file richiesto non è il più recente."
 
-#: src/amule.cpp:2251
+#: src/amule.cpp:2259
 msgid "Failed to download the nodes list."
 msgstr "Impossibile scaricare la lista dei nodi."
 
-#: src/amule.cpp:2314
+#: src/amule.cpp:2322
 msgid "Failed to open the downloaded version check file"
 msgstr "Impossibile aprire il file scaricato per il controllo della versione"
 
-#: src/amule.cpp:2317 src/amule.cpp:2336
+#: src/amule.cpp:2325 src/amule.cpp:2344
 msgid "Corrupted version check file"
 msgstr "Il file per il controllo della versione è corrotto"
 
-#: src/amule.cpp:2359
+#: src/amule.cpp:2367
 msgid "You are using an outdated version of aMule!"
 msgstr "Stai usando una versione non aggiornata di aMule!"
 
-#: src/amule.cpp:2361
+#: src/amule.cpp:2369
 #, c-format
 msgid "Your aMule version is %i.%i.%i and the latest version is %li.%li.%li"
 msgstr "La tua versione di aMule è la %i.%i.%i e l'ultima è la %li.%li.%li"
 
-#: src/amule.cpp:2365
+#: src/amule.cpp:2373
 msgid "The latest version can always be found at https://github.com/amule-org/amule/releases/latest"
 msgstr "L'ultima versione è sempre disponibile su https://github.com/amule-org/amule/releases/latest"
 
-#: src/amule.cpp:2368
+#: src/amule.cpp:2376
 #, c-format
 msgid "WARNING: Your aMuled version is outdated: %i.%i.%i < %li.%li.%li"
 msgstr "ATTENZIONE: La tua versione di aMuled è obsoleta: %i.%i.%i < %li.%li.%li"
 
-#: src/amule.cpp:2374
+#: src/amule.cpp:2382
 msgid "Your copy of aMule is up to date."
 msgstr "La tua copia di aMule è aggiornata."
 
-#: src/amule.cpp:2381
+#: src/amule.cpp:2389
 msgid "Failed to download the version check file"
 msgstr "Impossibile scaricare il file per il controllo della versione"
 
-#: src/amule.cpp:2550 src/amule-remote-gui.cpp:1133
+#: src/amule.cpp:2558 src/amule-remote-gui.cpp:1133
 #, c-format
 msgid "Users: %s | Files: %s"
 msgstr "Utenti: %s | File: %s"
 
-#: src/amule.cpp:2551 src/amule-remote-gui.cpp:1134
+#: src/amule.cpp:2559 src/amule-remote-gui.cpp:1134
 #, c-format
 msgid "Users: E: %s K: %s | Files: E: %s K: %s"
 msgstr "Utenti: E: %s K: %s | File: E: %s K: %s"
 
-#: src/amule.cpp:2565 src/amule-remote-gui.cpp:1147
+#: src/amule.cpp:2573 src/amule-remote-gui.cpp:1147
 msgid "No networks selected"
 msgstr "Nessuna rete selezionata"
 
-#: src/amule.cpp:2633 src/TextClient.cpp:903
+#: src/amule.cpp:2641 src/TextClient.cpp:903
 msgid "with LowID"
 msgstr "con ID basso"
 
-#: src/amule.cpp:2633 src/TextClient.cpp:904
+#: src/amule.cpp:2641 src/TextClient.cpp:904
 msgid "with HighID"
 msgstr "con ID alto"
 
-#: src/amule.cpp:2635
+#: src/amule.cpp:2643
 #, c-format
 msgid "Connected to %s %s"
 msgstr "Connesso a %s %s"
 
-#: src/amule.cpp:2640
+#: src/amule.cpp:2648
 #, c-format
 msgid "Connecting to %s"
 msgstr "Connessione in corso a %s"
 
-#: src/amule.cpp:2642
+#: src/amule.cpp:2650
 msgid "Disconnected from eD2k"
 msgstr "Disconnesso dalla rete eD2k"
 
-#: src/amule.cpp:2651
+#: src/amule.cpp:2659
 msgid "Kad started."
 msgstr "Kad avviato."
 
-#: src/amule.cpp:2653
+#: src/amule.cpp:2661
 msgid "Kad stopped."
 msgstr "Kad arrestato."
 
-#: src/amule.cpp:2661
+#: src/amule.cpp:2669
 msgid "Connected to Kad (ok)"
 msgstr "Connesso alla rete Kad (ok)"
 
-#: src/amule.cpp:2663
+#: src/amule.cpp:2671
 msgid "Connected to Kad (firewalled)"
 msgstr "Connesso alla rete Kad (firewalled)"
 
-#: src/amule.cpp:2667
+#: src/amule.cpp:2675
 msgid "Disconnected from Kad"
 msgstr "Disconnesso dalla rete Kad"
 
-#: src/amule.cpp:2699
+#: src/amule.cpp:2707
 msgid "Kad network cannot be used if UDP port is disabled on preferences, not starting."
 msgstr "La rete Kad non può essere utilizzata se la porta UDP è disattivata dalle opzioni. Connessione non avviata."
 
-#: src/amule.cpp:2703
+#: src/amule.cpp:2711
 msgid "Kad network disabled on preferences, not connecting."
 msgstr "Rete Kad disattivata dalle opzioni. Connessione interrotta."
 
@@ -604,36 +604,36 @@ msgid "FATAL ERROR: Failed to create Timer"
 msgstr "ERRORE FATALE: Creazione timer fallita"
 
 #: src/amuleDlg.cpp:361 src/amuleDlg.cpp:1787 src/amuleDlg.cpp:2033
-#: src/muuli_wdr.cpp:1492 src/muuli_wdr.cpp:3418
+#: src/muuli_wdr.cpp:1492 src/muuli_wdr.cpp:3449
 msgid "Networks"
 msgstr "Reti"
 
-#: src/amuleDlg.cpp:362 src/amuleDlg.cpp:1793 src/muuli_wdr.cpp:3419
+#: src/amuleDlg.cpp:362 src/amuleDlg.cpp:1793 src/muuli_wdr.cpp:3450
 msgid "Searches"
 msgstr "Ricerca"
 
 #: src/amuleDlg.cpp:363 src/amuleDlg.cpp:1799 src/DownloadListCtrl.cpp:740
-#: src/muuli_wdr.cpp:392 src/muuli_wdr.cpp:1585 src/muuli_wdr.cpp:3420
+#: src/muuli_wdr.cpp:392 src/muuli_wdr.cpp:1585 src/muuli_wdr.cpp:3451
 #: src/Statistics.cpp:829
 msgid "Downloads"
 msgstr "Download"
 
-#: src/amuleDlg.cpp:364 src/amuleDlg.cpp:1805 src/muuli_wdr.cpp:3294
+#: src/amuleDlg.cpp:364 src/amuleDlg.cpp:1805 src/muuli_wdr.cpp:3325
 msgid "Shared files"
 msgstr "File condivisi"
 
-#: src/amuleDlg.cpp:365 src/amuleDlg.cpp:1811 src/muuli_wdr.cpp:2926
-#: src/muuli_wdr.cpp:3376 src/muuli_wdr.cpp:3423
+#: src/amuleDlg.cpp:365 src/amuleDlg.cpp:1811 src/muuli_wdr.cpp:2957
+#: src/muuli_wdr.cpp:3407 src/muuli_wdr.cpp:3454
 msgid "Messages"
 msgstr "Messaggi"
 
-#: src/amuleDlg.cpp:366 src/amuleDlg.cpp:1817 src/muuli_wdr.cpp:3424
-#: src/PrefsUnifiedDlg.cpp:312 src/Statistics.cpp:779 src/Statistics.cpp:1235
+#: src/amuleDlg.cpp:366 src/amuleDlg.cpp:1817 src/muuli_wdr.cpp:3455
+#: src/PrefsUnifiedDlg.cpp:314 src/Statistics.cpp:779 src/Statistics.cpp:1235
 msgid "Statistics"
 msgstr "Statistiche"
 
-#: src/amuleDlg.cpp:368 src/amuleDlg.cpp:1824 src/muuli_wdr.cpp:3426
-#: src/PrefsUnifiedDlg.cpp:328 src/utils/wxCas/src/wxcasprefs.cpp:39
+#: src/amuleDlg.cpp:368 src/amuleDlg.cpp:1824 src/muuli_wdr.cpp:3457
+#: src/PrefsUnifiedDlg.cpp:330 src/utils/wxCas/src/wxcasprefs.cpp:39
 msgid "Preferences"
 msgstr "Preferenze"
 
@@ -695,8 +695,8 @@ msgstr "Kad: Spento"
 #: src/amuleDlg.cpp:1029 src/DownloadListCtrl.cpp:505
 #: src/DownloadListCtrl.cpp:749 src/FriendListCtrl.cpp:180
 #: src/muuli_wdr.cpp:731 src/muuli_wdr.cpp:782 src/muuli_wdr.cpp:846
-#: src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2231 src/muuli_wdr.cpp:2316
-#: src/muuli_wdr.cpp:3064 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
+#: src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2262 src/muuli_wdr.cpp:2347
+#: src/muuli_wdr.cpp:3095 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
 #: src/ServerListCtrl.cpp:606 src/TransferWnd.cpp:378
 #: src/utils/wxCas/src/wxcasprefs.cpp:235
 msgid "Cancel"
@@ -707,7 +707,7 @@ msgid "Stop the current connection attempts"
 msgstr "Ferma i tentativi di connessione in corso"
 
 #: src/amuleDlg.cpp:1035 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976
-#: src/muuli_wdr.cpp:2454
+#: src/muuli_wdr.cpp:2485
 msgid "Disconnect"
 msgstr "Disconnetti"
 
@@ -716,7 +716,7 @@ msgid "Disconnect from the currently connected networks"
 msgstr "Disconnetti dalle reti a cui sei connesso"
 
 #: src/amuleDlg.cpp:1041 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979
-#: src/muuli_wdr.cpp:2609 src/muuli_wdr.cpp:3061 src/muuli_wdr.cpp:3416
+#: src/muuli_wdr.cpp:2640 src/muuli_wdr.cpp:3092 src/muuli_wdr.cpp:3447
 msgid "Connect"
 msgstr "Connetti"
 
@@ -770,7 +770,7 @@ msgstr "Chiedi conferma prima di uscire"
 msgid "Launch Command: "
 msgstr "Comando di avvio: "
 
-#: src/amuleDlg.cpp:1632 src/muuli_wdr.cpp:1978 src/Preferences.cpp:952
+#: src/amuleDlg.cpp:1632 src/muuli_wdr.cpp:1982 src/Preferences.cpp:979
 msgid "- default -"
 msgstr "- predefinita -"
 
@@ -784,48 +784,48 @@ msgstr "La directory delle skin '%s' non esiste"
 msgid "WARNING: Unable to open skin file '%s' for read"
 msgstr "ATTENZIONE: Impossibile aprire il file della skin '%s' in lettura"
 
-#: src/amuleDlg.cpp:1791 src/muuli_wdr.cpp:3418
+#: src/amuleDlg.cpp:1791 src/muuli_wdr.cpp:3449
 msgid "Networks Window"
 msgstr "Finestra reti"
 
-#: src/amuleDlg.cpp:1797 src/muuli_wdr.cpp:3419
+#: src/amuleDlg.cpp:1797 src/muuli_wdr.cpp:3450
 msgid "Searches Window"
 msgstr "Finestra ricerche"
 
-#: src/amuleDlg.cpp:1803 src/muuli_wdr.cpp:3420
+#: src/amuleDlg.cpp:1803 src/muuli_wdr.cpp:3451
 msgid "Downloads Window"
 msgstr "Finestra dei Download"
 
-#: src/amuleDlg.cpp:1809 src/muuli_wdr.cpp:3422
+#: src/amuleDlg.cpp:1809 src/muuli_wdr.cpp:3453
 msgid "Shared Files Window"
 msgstr "Finestra file condivisi"
 
-#: src/amuleDlg.cpp:1815 src/muuli_wdr.cpp:3423
+#: src/amuleDlg.cpp:1815 src/muuli_wdr.cpp:3454
 msgid "Messages Window"
 msgstr "Finestra messaggi"
 
-#: src/amuleDlg.cpp:1821 src/muuli_wdr.cpp:3424
+#: src/amuleDlg.cpp:1821 src/muuli_wdr.cpp:3455
 msgid "Statistics Graph Window"
 msgstr "Finestra grafici e statistiche"
 
-#: src/amuleDlg.cpp:1828 src/muuli_wdr.cpp:3426
+#: src/amuleDlg.cpp:1828 src/muuli_wdr.cpp:3457
 msgid "Preferences Settings Window"
 msgstr "Finestra Preferenze"
 
-#: src/amuleDlg.cpp:1831 src/muuli_wdr.cpp:3427
+#: src/amuleDlg.cpp:1831 src/muuli_wdr.cpp:3458
 msgid "Import"
 msgstr "Importazione"
 
-#: src/amuleDlg.cpp:1835 src/muuli_wdr.cpp:3427
+#: src/amuleDlg.cpp:1835 src/muuli_wdr.cpp:3458
 msgid "The partfile importer tool"
 msgstr "Strumento per l'importazione dei file parziali"
 
-#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3428
+#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3459
 #: src/utils/aLinkCreator/src/alcframe.cpp:262
 msgid "About"
 msgstr "Informazioni"
 
-#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3428
+#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3459
 msgid "About/Help"
 msgstr "Informazioni/Aiuto"
 
@@ -968,7 +968,7 @@ msgstr "non trovato"
 msgid "The core rejected these shared folders:%s"
 msgstr "Il core ha rifiutato queste cartelle condivise:%s"
 
-#: src/amule-remote-gui.cpp:1336 src/ExternalConn.cpp:2345
+#: src/amule-remote-gui.cpp:1336 src/ExternalConn.cpp:2346
 msgid "Invalid link or already on list."
 msgstr "Collegamento non valido o già nella lista."
 
@@ -984,7 +984,7 @@ msgstr "Impossibile creare la directory '%s' per la categoria '%s', verrà mante
 #: src/ClientDetailDialog.cpp:123 src/DataToText.cpp:61 src/DataToText.cpp:86
 #: src/DataToText.cpp:101 src/DataToText.cpp:136 src/DataToText.cpp:165
 #: src/DownloadListCtrl.cpp:1172 src/DownloadListCtrl.cpp:1185
-#: src/DownloadListCtrl.cpp:1196 src/ExternalConn.cpp:608
+#: src/DownloadListCtrl.cpp:1196 src/ExternalConn.cpp:609
 #: src/FileDetailDialog.cpp:203 src/FileDetailDialog.cpp:235
 #: src/FileDetailDialog.cpp:242 src/GenericClientListCtrl.cpp:1171
 #: src/GenericClientListCtrl.cpp:1182 src/GenericClientListCtrl.cpp:1192
@@ -1370,19 +1370,19 @@ msgstr "Auto [Alta]"
 msgid "Very low"
 msgstr "Molto bassa"
 
-#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:743 src/muuli_wdr.cpp:2282
+#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:743 src/muuli_wdr.cpp:2313
 #: src/ServerListCtrl.cpp:263 src/ServerListCtrl.cpp:456
 #: src/SharedFilesCtrl.cpp:145
 msgid "Low"
 msgstr "Bassa"
 
-#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:744 src/muuli_wdr.cpp:2283
+#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:744 src/muuli_wdr.cpp:2314
 #: src/ServerListCtrl.cpp:266 src/ServerListCtrl.cpp:457
 #: src/SharedFilesCtrl.cpp:146
 msgid "Normal"
 msgstr "Normale"
 
-#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:745 src/muuli_wdr.cpp:2284
+#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:745 src/muuli_wdr.cpp:2315
 #: src/ServerListCtrl.cpp:269 src/ServerListCtrl.cpp:458
 #: src/SharedFilesCtrl.cpp:147
 msgid "High"
@@ -1474,7 +1474,7 @@ msgstr "Server locale"
 msgid "Remote Server"
 msgstr "Server remoto"
 
-#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3181
+#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3212
 #: src/SearchDlg.cpp:119 src/TextClient.cpp:911
 msgid "Kad"
 msgstr "Kad"
@@ -1545,7 +1545,7 @@ msgstr "Parte"
 msgid "Size"
 msgstr "Dimensione"
 
-#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3248
+#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3279
 msgid "Transferred"
 msgstr "Trasferiti"
 
@@ -1603,7 +1603,7 @@ msgstr ""
 "Feedback da: %s (%s)\n"
 "\n"
 
-#: src/DownloadListCtrl.cpp:746 src/muuli_wdr.cpp:2285
+#: src/DownloadListCtrl.cpp:746 src/muuli_wdr.cpp:2316
 #: src/SharedFilesCtrl.cpp:150
 msgid "Auto"
 msgstr "Auto"
@@ -1641,7 +1641,7 @@ msgid "Extended Options"
 msgstr "Opzioni avanzate"
 
 #: src/DownloadListCtrl.cpp:770 src/DownloadListCtrl.cpp:822
-#: src/muuli_wdr.cpp:1796
+#: src/muuli_wdr.cpp:1800
 msgid "Preview"
 msgstr "Anteprima"
 
@@ -1816,225 +1816,230 @@ msgstr[1] "Impossibile aggiungere %u collegamenti (vedere il log per i dettagli)
 msgid "Invalid eD2k link! ERROR: %s"
 msgstr "Collegamento eD2k non valido! ERRORE: %s"
 
-#: src/ExternalConn.cpp:379
+#: src/ExternalConn.cpp:380
 msgid "Client sent packet after authentication failed."
 msgstr "Il client ha inviato un pacchetto dopo che l'autenticazione era fallita."
 
-#: src/ExternalConn.cpp:396
+#: src/ExternalConn.cpp:397
 msgid "External connection closed."
 msgstr "Connessione esterna chiusa."
 
-#: src/ExternalConn.cpp:473
+#: src/ExternalConn.cpp:474
 msgid "External connections disabled due to empty password!"
 msgstr "Connessioni esterne disabilitate perché la password è vuota!"
 
-#: src/ExternalConn.cpp:494
+#: src/ExternalConn.cpp:495
 msgid "External connections disabled in config file"
 msgstr "Connessioni esterne disabilitate nel file di configurazione"
 
-#: src/ExternalConn.cpp:575
+#: src/ExternalConn.cpp:576
 msgid "New external connection accepted"
 msgstr "Accettata nuova connessione esterna"
 
-#: src/ExternalConn.cpp:578
+#: src/ExternalConn.cpp:579
 msgid "ERROR: couldn't accept a new external connection"
 msgstr "ERRORE: impossibile accettare una nuova connessione esterna"
 
-#: src/ExternalConn.cpp:595
+#: src/ExternalConn.cpp:596
 msgid "External connection refused due to empty password in preferences!"
 msgstr "Connessione esterna rifiutata perché la password nelle preferenze è vuota!"
 
-#: src/ExternalConn.cpp:607
+#: src/ExternalConn.cpp:608
 #, c-format
 msgid "Connecting client: %s %s"
 msgstr "Connessione al client: %s %s"
 
-#: src/ExternalConn.cpp:609
+#: src/ExternalConn.cpp:610
 msgid "Unknown version"
 msgstr "Versione sconosciuta"
 
-#: src/ExternalConn.cpp:622
+#: src/ExternalConn.cpp:623
 msgid "Incorrect EC version ID, there might be binary incompatibility. Use core and remote from same snapshot."
 msgstr "ID della versione EC non corretto, potrebbe esserci un'incompatibilità binaria. Usare core e client remoto dello stesso snapshot."
 
-#: src/ExternalConn.cpp:630
+#: src/ExternalConn.cpp:631
 msgid "You cannot connect to a release version from an arbitrary development snapshot! *sigh* possible crash prevented"
 msgstr "Non puoi connetterti a una versione stabile da una versione CVS qualsiasi! *fiuu!* possibile crash evitato"
 
-#: src/ExternalConn.cpp:713
+#: src/ExternalConn.cpp:714
 msgid "Invalid protocol version."
 msgstr "Versione protocollo non valida."
 
-#: src/ExternalConn.cpp:719
+#: src/ExternalConn.cpp:720
 msgid "Missing protocol version tag."
 msgstr "Tag versione protocollo mancante."
 
-#: src/ExternalConn.cpp:727
+#: src/ExternalConn.cpp:728
 msgid "Authentication failed: invalid hash specified as EC password."
 msgstr "Autenticazione fallita: l'hash specificato come password EC non è valido."
 
-#: src/ExternalConn.cpp:775
+#: src/ExternalConn.cpp:776
 msgid "Authentication failed: wrong password."
 msgstr "Autenticazione fallita: password errata."
 
-#: src/ExternalConn.cpp:777
+#: src/ExternalConn.cpp:778
 msgid "Authentication failed: missing password."
 msgstr "Autenticazione fallita: devi inserire la password."
 
-#: src/ExternalConn.cpp:788
+#: src/ExternalConn.cpp:789
 msgid "Invalid request, please authenticate first."
 msgstr "Richiesta non valida, prima devi autenticarti."
 
-#: src/ExternalConn.cpp:793
+#: src/ExternalConn.cpp:794
 msgid "Access granted."
 msgstr "Accesso consentito."
 
-#: src/ExternalConn.cpp:801
+#: src/ExternalConn.cpp:802
 #, c-format
 msgid "Sent error message \"%s\" to client."
 msgstr "Invia il messaggio di errore \"%s\" al client."
 
-#: src/ExternalConn.cpp:806
+#: src/ExternalConn.cpp:807
 #, c-format
 msgid "Unauthorized access attempt from %s. Connection closed."
 msgstr "Tentativo di accesso non autorizzato da %s. Connessione terminata."
 
-#: src/ExternalConn.cpp:1419
+#: src/ExternalConn.cpp:1420
 #, c-format
 msgid "Remote PartFile command failed: FileHash not found: %s"
 msgstr "Comando Partfile remoto fallito: hash del file non trovato: %s"
 
-#: src/ExternalConn.cpp:1423
+#: src/ExternalConn.cpp:1424
 #, c-format
 msgid "FileHash not found: %s"
 msgstr "Hash del file non trovato: %s"
 
-#: src/ExternalConn.cpp:1470 src/ExternalConn.cpp:1558
-#: src/ExternalConn.cpp:1679
+#: src/ExternalConn.cpp:1471 src/ExternalConn.cpp:1559
+#: src/ExternalConn.cpp:1680
 msgid "OOPS! OpCode processing error!"
 msgstr "OOPS! errore nel processare l'opcode!"
 
-#: src/ExternalConn.cpp:1501
+#: src/ExternalConn.cpp:1502
 msgid "Server not added"
 msgstr "Server non aggiunto"
 
-#: src/ExternalConn.cpp:1520
+#: src/ExternalConn.cpp:1521
 #, c-format
 msgid "server not found: %s"
 msgstr "server non trovato: %s"
 
-#: src/ExternalConn.cpp:1537
+#: src/ExternalConn.cpp:1538
 msgid "need to define server to be removed"
 msgstr "è necessario definire il server da rimuovere"
 
-#: src/ExternalConn.cpp:1552
+#: src/ExternalConn.cpp:1553
 msgid "eD2k is disabled in preferences."
 msgstr "eD2k è disabilitato nelle preferenze."
 
-#: src/ExternalConn.cpp:1657
+#: src/ExternalConn.cpp:1658
 msgid "Friend not found."
 msgstr "Amico non trovato."
 
-#: src/ExternalConn.cpp:1667
+#: src/ExternalConn.cpp:1668
 msgid "Client not found."
 msgstr "Client non trovato."
 
-#: src/ExternalConn.cpp:1673
+#: src/ExternalConn.cpp:1674
 msgid "EC_TAG_FRIEND_SHARED requires EC_TAG_FRIEND or EC_TAG_CLIENT."
 msgstr "EC_TAG_FRIEND_SHARED richiede EC_TAG_FRIEND o EC_TAG_CLIENT."
 
-#: src/ExternalConn.cpp:1991
+#: src/ExternalConn.cpp:1992
 msgid "WebSearch from remote interface makes no sense."
 msgstr "Non ha senso usare la ricerca Web da interfaccia remota."
 
-#: src/ExternalConn.cpp:2026
+#: src/ExternalConn.cpp:2027
 msgid "Search in progress. Refetch results in a moment!"
 msgstr "Ricerca in corso. Risultati in arrivo!"
 
-#: src/ExternalConn.cpp:2265
+#: src/ExternalConn.cpp:2266
 msgid "No points for graph."
 msgstr "Niente punti per il grafico."
 
-#: src/ExternalConn.cpp:2275
+#: src/ExternalConn.cpp:2276
 msgid "Your client is not configured for this detail level."
 msgstr "Il tuo client non è configurato per questo livello di dettaglio."
 
-#: src/ExternalConn.cpp:2302
+#: src/ExternalConn.cpp:2303
 msgid "External Connection: shutdown requested"
 msgstr "Connessione esterna: arresto richiesto"
 
-#: src/ExternalConn.cpp:2314
+#: src/ExternalConn.cpp:2315
 msgid "Already shutting down."
 msgstr "Sto già uscendo."
 
-#: src/ExternalConn.cpp:2332
+#: src/ExternalConn.cpp:2333
 #, c-format
 msgid "ExternalConn: adding link '%s'."
 msgstr "ExternalConn: aggiungo il collegamento '%s'."
 
-#: src/ExternalConn.cpp:2350
+#: src/ExternalConn.cpp:2351
 #, c-format
 msgid "%d of %d links failed (invalid or already on list)."
 msgstr "%d di %d collegamenti non riusciti (non validi o già in elenco)."
 
-#: src/ExternalConn.cpp:2373
+#: src/ExternalConn.cpp:2374
 msgid "Version check throttled; try again shortly."
 msgstr "Controllo versione soggetto a limite di frequenza; riprova a breve."
 
-#: src/ExternalConn.cpp:2378
+#: src/ExternalConn.cpp:2379
 msgid "Version check is not available on this daemon."
 msgstr "Il controllo versione non è disponibile su questo demone."
 
-#: src/ExternalConn.cpp:2508
+#: src/ExternalConn.cpp:2509
 msgid "File not found."
 msgstr "File non trovato."
 
-#: src/ExternalConn.cpp:2513
+#: src/ExternalConn.cpp:2514
 msgid "Invalid file name."
 msgstr "Nome file non valido."
 
-#: src/ExternalConn.cpp:2521
+#: src/ExternalConn.cpp:2522
 msgid "Unable to rename file."
 msgstr "Impossibile rinominare il file."
 
-#: src/ExternalConn.cpp:2992 src/ExternalConn.cpp:3020
+#: src/ExternalConn.cpp:2839
+#, c-format
+msgid "Could not save the amuleapi password: %s"
+msgstr ""
+
+#: src/ExternalConn.cpp:3004 src/ExternalConn.cpp:3032
 msgid "Kad is disabled in preferences."
 msgstr "La rete Kad è disabilitata nelle Preferenze."
 
-#: src/ExternalConn.cpp:3033
+#: src/ExternalConn.cpp:3045
 msgid "Already connected to eD2k."
 msgstr "Già connesso ad eD2k."
 
-#: src/ExternalConn.cpp:3036
+#: src/ExternalConn.cpp:3048
 msgid "Connecting to eD2k..."
 msgstr "Connessione alla rete eD2k in corso..."
 
-#: src/ExternalConn.cpp:3045
+#: src/ExternalConn.cpp:3057
 msgid "Already connected to Kad."
 msgstr "Già connesso alla rete Kad."
 
-#: src/ExternalConn.cpp:3048
+#: src/ExternalConn.cpp:3060
 msgid "Connecting to Kad..."
 msgstr "Connessione alla rete Kad..."
 
-#: src/ExternalConn.cpp:3055
+#: src/ExternalConn.cpp:3067
 msgid "All networks are disabled."
 msgstr "Tutte le reti sono disabilitate."
 
-#: src/ExternalConn.cpp:3064
+#: src/ExternalConn.cpp:3076
 msgid "Disconnected from eD2k."
 msgstr "Disconnesso dalla rete eD2k."
 
-#: src/ExternalConn.cpp:3069
+#: src/ExternalConn.cpp:3081
 msgid "Disconnected from Kad."
 msgstr "Disconnesso dalla rete Kad."
 
-#: src/ExternalConn.cpp:3078
+#: src/ExternalConn.cpp:3090
 #, c-format
 msgid "External Connection: invalid opcode received: %#x"
 msgstr "Connessione esterna: ricevuto un opcode invalido: %#x"
 
-#: src/ExternalConn.cpp:3083
+#: src/ExternalConn.cpp:3095
 msgid "Invalid opcode (wrong protocol version?)"
 msgstr "Opcode non valido (versione errata del protocollo?)"
 
@@ -2435,23 +2440,23 @@ msgid ""
 "want downloads on a different (e.g. larger) disk."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:549 src/FirstRunWizard.cpp:611 src/muuli_wdr.cpp:1708
+#: src/FirstRunWizard.cpp:549 src/FirstRunWizard.cpp:611 src/muuli_wdr.cpp:1712
 msgid "Destination folder for downloads"
 msgstr "Cartella di destinazione per i file scaricati"
 
 #: src/FirstRunWizard.cpp:553 src/FirstRunWizard.cpp:569 src/muuli_wdr.cpp:1349
-#: src/muuli_wdr.cpp:1366 src/muuli_wdr.cpp:1683 src/muuli_wdr.cpp:1714
-#: src/muuli_wdr.cpp:1726 src/muuli_wdr.cpp:2769
+#: src/muuli_wdr.cpp:1366 src/muuli_wdr.cpp:1687 src/muuli_wdr.cpp:1718
+#: src/muuli_wdr.cpp:1730 src/muuli_wdr.cpp:2800
 #: src/utils/aLinkCreator/src/alcframe.cpp:135
 #: src/utils/wxCas/src/wxcasprefs.cpp:52 src/utils/wxCas/src/wxcasprefs.cpp:118
 msgid "Browse"
 msgstr "Sfoglia"
 
-#: src/FirstRunWizard.cpp:559 src/muuli_wdr.cpp:1719
+#: src/FirstRunWizard.cpp:559 src/muuli_wdr.cpp:1723
 msgid "(All files in this folder are shared with other peers)"
 msgstr "(Tutti i file in questa cartella sono condivisi con gli altri peer)"
 
-#: src/FirstRunWizard.cpp:565 src/FirstRunWizard.cpp:624 src/muuli_wdr.cpp:1721
+#: src/FirstRunWizard.cpp:565 src/FirstRunWizard.cpp:624 src/muuli_wdr.cpp:1725
 msgid "Folder for temporary download files"
 msgstr "Cartella per i file temporanei"
 
@@ -2482,7 +2487,7 @@ msgstr "Impossibile aprire in scrittura il file della lista degli amici 'emfrien
 msgid "CRITICAL - no client on StartChatSession"
 msgstr "CRITICO - nessun client in StartChatSession"
 
-#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2675 src/muuli_wdr.cpp:3352
+#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2706 src/muuli_wdr.cpp:3383
 msgid "Friends"
 msgstr "Amici"
 
@@ -2592,8 +2597,8 @@ msgstr "Nessuno"
 msgid "No"
 msgstr "No"
 
-#: src/GenericClientListCtrl.cpp:1216 src/PrefsUnifiedDlg.cpp:2818
-#: src/PrefsUnifiedDlg.cpp:2868 src/ServerListCtrl.cpp:276
+#: src/GenericClientListCtrl.cpp:1216 src/PrefsUnifiedDlg.cpp:2898
+#: src/PrefsUnifiedDlg.cpp:2948 src/ServerListCtrl.cpp:276
 msgid "Yes"
 msgstr "Sì"
 
@@ -2762,10 +2767,10 @@ msgstr "Porta non valida per il bootstrap"
 msgid "Please fill all fields required"
 msgstr "Completa tutti i campi obbligatori"
 
-#: src/KadDlg.cpp:192 src/PartFile.cpp:1031 src/PrefsUnifiedDlg.cpp:1162
-#: src/PrefsUnifiedDlg.cpp:1331 src/PrefsUnifiedDlg.cpp:1589
-#: src/PrefsUnifiedDlg.cpp:1599 src/PrefsUnifiedDlg.cpp:1616
-#: src/PrefsUnifiedDlg.cpp:1658
+#: src/KadDlg.cpp:192 src/PartFile.cpp:1031 src/PrefsUnifiedDlg.cpp:1134
+#: src/PrefsUnifiedDlg.cpp:1204 src/PrefsUnifiedDlg.cpp:1405
+#: src/PrefsUnifiedDlg.cpp:1663 src/PrefsUnifiedDlg.cpp:1673
+#: src/PrefsUnifiedDlg.cpp:1690 src/PrefsUnifiedDlg.cpp:1738
 msgid "Message"
 msgstr "Messaggio"
 
@@ -2866,7 +2871,7 @@ msgstr "Rapporto di condivisione"
 msgid "Uploaded"
 msgstr "Inviato"
 
-#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3232
+#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3263
 msgid "Requested"
 msgstr "Richiesto"
 
@@ -2989,7 +2994,7 @@ msgid "WARNING: "
 msgstr "ATTENZIONE: "
 
 #: src/MuleNotebook.cpp:179 src/muuli_wdr.cpp:817 src/muuli_wdr.cpp:1229
-#: src/muuli_wdr.cpp:3136 src/muuli_wdr.cpp:3392
+#: src/muuli_wdr.cpp:3167 src/muuli_wdr.cpp:3423
 msgid "Close"
 msgstr "Chiudi"
 
@@ -3007,7 +3012,7 @@ msgid "Paste"
 msgstr "Incolla"
 
 #: src/MuleTextCtrl.cpp:89 src/muuli_wdr.cpp:358 src/muuli_wdr.cpp:757
-#: src/muuli_wdr.cpp:2359 src/muuli_wdr.cpp:2378 src/muuli_wdr.cpp:2400
+#: src/muuli_wdr.cpp:2390 src/muuli_wdr.cpp:2409 src/muuli_wdr.cpp:2431
 #: src/utils/aLinkCreator/src/alcframe.cpp:142
 msgid "Clear"
 msgstr "Pulisci"
@@ -3099,7 +3104,7 @@ msgstr "Esci"
 
 #: src/MuleTrayIcon.cpp:579 src/MuleTrayIcon.cpp:945 src/MuleTrayIcon.cpp:965
 #: src/muuli_wdr.cpp:1398 src/muuli_wdr.cpp:1406 src/muuli_wdr.cpp:1413
-#: src/muuli_wdr.cpp:1842 src/muuli_wdr.cpp:1848 src/OtherFunctions.cpp:91
+#: src/muuli_wdr.cpp:1846 src/muuli_wdr.cpp:1852 src/OtherFunctions.cpp:91
 #: src/StatisticsDlg.cpp:93 src/StatisticsDlg.cpp:95
 msgid "kB/s"
 msgstr "kB/s"
@@ -3339,7 +3344,7 @@ msgstr "Byte"
 msgid "KB"
 msgstr "KB"
 
-#: src/muuli_wdr.cpp:274 src/muuli_wdr.cpp:293 src/muuli_wdr.cpp:1627
+#: src/muuli_wdr.cpp:274 src/muuli_wdr.cpp:293 src/muuli_wdr.cpp:1631
 #: src/OtherFunctions.cpp:64
 msgid "MB"
 msgstr "MB"
@@ -3356,7 +3361,7 @@ msgstr "Dimensione massima"
 msgid "Availability"
 msgstr "Disponibilità"
 
-#: src/muuli_wdr.cpp:312 src/muuli_wdr.cpp:398 src/muuli_wdr.cpp:3297
+#: src/muuli_wdr.cpp:312 src/muuli_wdr.cpp:398 src/muuli_wdr.cpp:3328
 msgid "Filter:"
 msgstr "Filtro:"
 
@@ -3419,12 +3424,12 @@ msgstr "Fonti del file:"
 #: src/muuli_wdr.cpp:1160 src/muuli_wdr.cpp:1167 src/muuli_wdr.cpp:1172
 #: src/muuli_wdr.cpp:1179 src/muuli_wdr.cpp:1184 src/muuli_wdr.cpp:1191
 #: src/muuli_wdr.cpp:1205 src/muuli_wdr.cpp:1212 src/muuli_wdr.cpp:1217
-#: src/muuli_wdr.cpp:1224 src/muuli_wdr.cpp:3234 src/muuli_wdr.cpp:3242
-#: src/muuli_wdr.cpp:3250
+#: src/muuli_wdr.cpp:1224 src/muuli_wdr.cpp:3265 src/muuli_wdr.cpp:3273
+#: src/muuli_wdr.cpp:3281
 msgid "N/A"
 msgstr "N/D"
 
-#: src/muuli_wdr.cpp:508 src/muuli_wdr.cpp:1065 src/PrefsUnifiedDlg.cpp:297
+#: src/muuli_wdr.cpp:508 src/muuli_wdr.cpp:1065 src/PrefsUnifiedDlg.cpp:299
 msgid "General"
 msgstr "Generale"
 
@@ -3560,7 +3565,7 @@ msgstr "Artista :"
 msgid "Album :"
 msgstr "Album :"
 
-#: src/muuli_wdr.cpp:685 src/muuli_wdr.cpp:2254
+#: src/muuli_wdr.cpp:685 src/muuli_wdr.cpp:2285
 msgid "Title :"
 msgstr "Titolo:"
 
@@ -3668,7 +3673,7 @@ msgstr "Nome utente:"
 msgid "Userhash :"
 msgstr "Hash utente:"
 
-#: src/muuli_wdr.cpp:895 src/muuli_wdr.cpp:1748 src/muuli_wdr.cpp:2449
+#: src/muuli_wdr.cpp:895 src/muuli_wdr.cpp:1752 src/muuli_wdr.cpp:2480
 #: src/utils/aLinkCreator/src/alcframe.cpp:137
 msgid "Add"
 msgstr "Aggiungi"
@@ -3677,15 +3682,15 @@ msgstr "Aggiungi"
 msgid "Download-Speed"
 msgstr "Velocità download"
 
-#: src/muuli_wdr.cpp:954 src/muuli_wdr.cpp:989 src/muuli_wdr.cpp:2553
+#: src/muuli_wdr.cpp:954 src/muuli_wdr.cpp:989 src/muuli_wdr.cpp:2584
 msgid "Current"
 msgstr "Corrente"
 
-#: src/muuli_wdr.cpp:962 src/muuli_wdr.cpp:997 src/muuli_wdr.cpp:2561
+#: src/muuli_wdr.cpp:962 src/muuli_wdr.cpp:997 src/muuli_wdr.cpp:2592
 msgid "Running average"
 msgstr "Media attuale"
 
-#: src/muuli_wdr.cpp:970 src/muuli_wdr.cpp:1005 src/muuli_wdr.cpp:2569
+#: src/muuli_wdr.cpp:970 src/muuli_wdr.cpp:1005 src/muuli_wdr.cpp:2600
 msgid "Session average"
 msgstr "Media sessione"
 
@@ -3697,7 +3702,7 @@ msgstr "Velocità upload"
 msgid "Connections"
 msgstr "Connessioni"
 
-#: src/muuli_wdr.cpp:1024 src/muuli_wdr.cpp:1867
+#: src/muuli_wdr.cpp:1024 src/muuli_wdr.cpp:1871
 msgid "Active downloads"
 msgstr "Download attivi"
 
@@ -3705,7 +3710,7 @@ msgstr "Download attivi"
 msgid "Active connections (1:1)"
 msgstr "Connessioni attive (1:1)"
 
-#: src/muuli_wdr.cpp:1040 src/muuli_wdr.cpp:1868
+#: src/muuli_wdr.cpp:1040 src/muuli_wdr.cpp:1872
 msgid "Active uploads"
 msgstr "Upload attivi"
 
@@ -3979,7 +3984,7 @@ msgstr "Lega l'indirizzo locale all'IP (lascia vuoto per qualsiasi):"
 msgid "Advanced users only: If you have multiple network interfaces, enter the address of the interface to which aMule should be bound."
 msgstr "Solo per utenti esperti: se hai interfacce di rete multiple, inserisci l'indirizzo dell'interfaccia che aMule dovrà utilizzare."
 
-#: src/muuli_wdr.cpp:1462 src/muuli_wdr.cpp:2061
+#: src/muuli_wdr.cpp:1462 src/muuli_wdr.cpp:2065
 msgid "Bind to network interface (empty for any):"
 msgstr "Associa all'interfaccia di rete (vuoto per qualsiasi):"
 
@@ -3995,7 +4000,7 @@ msgstr "Fonti massime per file in scaricamento:"
 msgid "Max simultaneous connections:"
 msgstr "Connessioni massime simultanee:"
 
-#: src/muuli_wdr.cpp:1498 src/muuli_wdr.cpp:3176
+#: src/muuli_wdr.cpp:1498 src/muuli_wdr.cpp:3207
 msgid "ED2K"
 msgstr "ED2K"
 
@@ -4087,79 +4092,79 @@ msgstr "Prealloca lo spazio su disco per i nuovi file"
 msgid "For new files preallocates disk space for the whole file, thus reduces fragmentation"
 msgstr "Per i nuovi file prealloca lo spazio su disco per l'intero file, in questo modo ridurrai la frammentazione"
 
-#: src/muuli_wdr.cpp:1613
+#: src/muuli_wdr.cpp:1617
 msgid "Create new files as sparse files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1614
-msgid "A sparse file reserves its full size on disk immediately without writing real data to it -- fast, but unsupported or slow on some filesystems, and free-space accounting stays optimistic while the download is in progress. Turn this off to grow the file only as data arrives."
+#: src/muuli_wdr.cpp:1618
+msgid "Sparse part files only occupy disk space for the parts already downloaded, so free space is used up gradually as the file fills in. Turn this off to use an ordinary file instead - useful where sparse files are unsupported or slow, or where backup/de-duplication tools handle them badly. Applies only when the core runs on Windows; on Linux and macOS part files are sparse anyway and this setting has no effect."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1619
+#: src/muuli_wdr.cpp:1623
 msgid "Stop downloads when free disk space reaches "
 msgstr "Interrompi i download quando termina lo spazio su disco "
 
-#: src/muuli_wdr.cpp:1620
+#: src/muuli_wdr.cpp:1624
 msgid "Select this if you want aMule to check your disk space"
 msgstr "Seleziona se vuoi che aMule controlli il tuo spazio su disco"
 
-#: src/muuli_wdr.cpp:1624
+#: src/muuli_wdr.cpp:1628
 msgid "Enter here the min disk space desired."
 msgstr "Inserire lo spazio disco minimo desiderato."
 
-#: src/muuli_wdr.cpp:1630
+#: src/muuli_wdr.cpp:1634
 msgid "Save 10 sources on rare files (< 20 sources)"
 msgstr "Salva 10 fonti per i file rari ( con < 20 fonti)"
 
-#: src/muuli_wdr.cpp:1634 src/Statistics.cpp:790
+#: src/muuli_wdr.cpp:1638 src/Statistics.cpp:790
 msgid "Uploads"
 msgstr "Upload"
 
-#: src/muuli_wdr.cpp:1637
+#: src/muuli_wdr.cpp:1641
 msgid "Add new shared files with auto priority"
 msgstr "Assegna priorità automatica ai nuovi file condivisi"
 
-#: src/muuli_wdr.cpp:1643
+#: src/muuli_wdr.cpp:1647
 msgid "Intelligent Corruption Handling (I.C.H.)"
 msgstr "Trattamento intelligente delle corruzioni (I.C.H.)"
 
-#: src/muuli_wdr.cpp:1646
+#: src/muuli_wdr.cpp:1650
 msgid "Enable"
 msgstr "Abilita"
 
-#: src/muuli_wdr.cpp:1649
+#: src/muuli_wdr.cpp:1653
 msgid "Advanced I.C.H. trusts every hash (not recommended)"
 msgstr "L'I.C.H. avanzato si fida di ogni hash (sconsigliato)"
 
-#: src/muuli_wdr.cpp:1661 src/PrefsUnifiedDlg.cpp:1910
+#: src/muuli_wdr.cpp:1665 src/PrefsUnifiedDlg.cpp:1990
 msgid "Media metadata extraction"
 msgstr "Estrazione dei metadati multimediali"
 
-#: src/muuli_wdr.cpp:1665
+#: src/muuli_wdr.cpp:1669
 msgid "Extract length / bitrate / codec from shared audio and video files"
 msgstr "Estrai durata / bitrate / codec dai file audio e video condivisi"
 
-#: src/muuli_wdr.cpp:1667
+#: src/muuli_wdr.cpp:1671
 msgid "When enabled, aMule runs ffprobe on each shared media file to fill in the Length / Bitrate / Codec columns other clients see when they find the file in a search. Requires ffmpeg (the ffprobe binary) to be installed."
 msgstr "Quando abilitato, aMule esegue ffprobe su ogni file multimediale condiviso per compilare le colonne Durata / Bitrate / Codec che gli altri client vedono quando trovano il file in una ricerca. Richiede l'installazione di ffmpeg (il binario ffprobe)."
 
-#: src/muuli_wdr.cpp:1674
+#: src/muuli_wdr.cpp:1678
 msgid "Path to ffprobe:"
 msgstr "Percorso di ffprobe:"
 
-#: src/muuli_wdr.cpp:1679
+#: src/muuli_wdr.cpp:1683
 msgid "Full path to the ffprobe binary. Leave empty to have aMule auto-detect it on startup."
 msgstr "Percorso completo del binario ffprobe. Lascia vuoto per far sì che aMule lo rilevi automaticamente all'avvio."
 
-#: src/muuli_wdr.cpp:1687
+#: src/muuli_wdr.cpp:1691
 msgid "Detect"
 msgstr "Rileva"
 
-#: src/muuli_wdr.cpp:1688
+#: src/muuli_wdr.cpp:1692
 msgid "Search the standard install locations for an ffprobe binary and fill the path field."
 msgstr "Cerca nei percorsi di installazione standard un binario ffprobe e compila il campo del percorso."
 
-#: src/muuli_wdr.cpp:1712
+#: src/muuli_wdr.cpp:1716
 msgid ""
 "Completed downloads are stored here. All files in this folder are automatically shared with other peers.\n"
 "If this folder also holds files you don't want to share, point it at an aMule-only sub-folder."
@@ -4167,665 +4172,688 @@ msgstr ""
 "Qui vengono salvati i download completati. Tutti i file in questa cartella sono condivisi automaticamente con gli altri peer.\n"
 "Se questa cartella contiene anche file che non vuoi condividere, impostala su una sottocartella riservata ad aMule."
 
-#: src/muuli_wdr.cpp:1715
+#: src/muuli_wdr.cpp:1719
 msgid "Pick the folder where completed downloads will be stored. All files in that folder will be shared with other peers."
 msgstr "Scegli la cartella in cui salvare i download completati. Tutti i file in quella cartella saranno condivisi con gli altri peer."
 
-#: src/muuli_wdr.cpp:1729
+#: src/muuli_wdr.cpp:1733
 msgid "Shared folders"
 msgstr "Cartelle condivise"
 
-#: src/muuli_wdr.cpp:1735
+#: src/muuli_wdr.cpp:1739
 msgid "(Folders shared by the core. Enter a path to add one.)"
 msgstr "(Cartelle condivise dal core. Inserisci un percorso per aggiungerne una.)"
 
-#: src/muuli_wdr.cpp:1743
+#: src/muuli_wdr.cpp:1747
 msgid "Absolute path of a folder on the core's machine, e.g. /home/user/shared"
 msgstr "Percorso assoluto di una cartella sulla macchina del core, ad es. /home/user/shared"
 
-#: src/muuli_wdr.cpp:1745 src/PrefsUnifiedDlg.cpp:2794
+#: src/muuli_wdr.cpp:1749 src/PrefsUnifiedDlg.cpp:2874
 msgid "Recursive"
 msgstr "Ricorsivo"
 
-#: src/muuli_wdr.cpp:1746
+#: src/muuli_wdr.cpp:1750
 msgid "Share every sub-folder underneath this one, including ones created later."
 msgstr "Condividi tutte le sottocartelle contenute in questa, comprese quelle create in seguito."
 
-#: src/muuli_wdr.cpp:1750 src/utils/aLinkCreator/src/alcframe.cpp:141
+#: src/muuli_wdr.cpp:1754 src/utils/aLinkCreator/src/alcframe.cpp:141
 msgid "Remove"
 msgstr "Rimuovi"
 
-#: src/muuli_wdr.cpp:1754
+#: src/muuli_wdr.cpp:1758
 msgid "(Right click on folder icon for recursive share)"
 msgstr "(fai click con il tasto destro sulle icone per condividere ricorsivamente le sottodirectory)"
 
-#: src/muuli_wdr.cpp:1761
+#: src/muuli_wdr.cpp:1765
 msgid "Share hidden files"
 msgstr "Condividi file nascosti"
 
-#: src/muuli_wdr.cpp:1767
+#: src/muuli_wdr.cpp:1771
 msgid "Automatically rescan shared folders for changes"
 msgstr "Ricontrolla automaticamente le modifiche nelle cartelle condivise"
 
-#: src/muuli_wdr.cpp:1773
+#: src/muuli_wdr.cpp:1777
 msgid "Follow symbolic links in shared folders"
 msgstr "Segui i collegamenti simbolici nelle cartelle condivise"
 
-#: src/muuli_wdr.cpp:1779
+#: src/muuli_wdr.cpp:1783
 msgid "Exclude files matching:"
 msgstr "Escludi i file corrispondenti a:"
 
-#: src/muuli_wdr.cpp:1782
+#: src/muuli_wdr.cpp:1786
 msgid "Wildcard patterns separated by '|', e.g. .DS_Store|Thumbs.db|*.tmp. Files whose name matches are not shared. Matching is case-insensitive."
 msgstr "Modelli con caratteri jolly separati da '|', ad es. .DS_Store|Thumbs.db|*.tmp. I file il cui nome corrisponde non vengono condivisi. La corrispondenza non distingue tra maiuscole e minuscole."
 
-#: src/muuli_wdr.cpp:1786
+#: src/muuli_wdr.cpp:1790
 msgid "Patterns are regular expressions"
 msgstr "I pattern sono espressioni regolari"
 
-#: src/muuli_wdr.cpp:1787
+#: src/muuli_wdr.cpp:1791
 msgid "When set, the whole field is one regular expression ('|' is alternation). When unset, it is a list of '|'-separated wildcards."
 msgstr "Se attivato, l'intero campo è un'unica espressione regolare ('|' indica l'alternanza). Se disattivato, è un elenco di caratteri jolly separati da '|'."
 
-#: src/muuli_wdr.cpp:1797
+#: src/muuli_wdr.cpp:1801
 msgid "Show how many shared files the current pattern would exclude."
 msgstr "Mostra quanti file condivisi verrebbero esclusi dal pattern attuale."
 
-#: src/muuli_wdr.cpp:1818
+#: src/muuli_wdr.cpp:1822
 msgid "Graphs"
 msgstr "Grafici"
 
-#: src/muuli_wdr.cpp:1821 src/muuli_wdr.cpp:1883
+#: src/muuli_wdr.cpp:1825 src/muuli_wdr.cpp:1887
 msgid "Update delay : 5 secs"
 msgstr "Intervallo di aggiornamento: 5 secondi"
 
-#: src/muuli_wdr.cpp:1825
+#: src/muuli_wdr.cpp:1829
 msgid "Time for average graph: 100 mins"
 msgstr "Intervallo grafico valori medi: 100 minuti"
 
-#: src/muuli_wdr.cpp:1829
+#: src/muuli_wdr.cpp:1833
 msgid "Connections Graph Scale: 100 "
 msgstr "Scala grafico connessioni: 100 "
 
-#: src/muuli_wdr.cpp:1836
+#: src/muuli_wdr.cpp:1840
 msgid "Download graph scale:"
 msgstr "Scala grafico di scaricamento:"
 
-#: src/muuli_wdr.cpp:1844
+#: src/muuli_wdr.cpp:1848
 msgid "Upload graph scale:"
 msgstr "Scala grafico d'invio:"
 
-#: src/muuli_wdr.cpp:1854
+#: src/muuli_wdr.cpp:1858
 msgid "Colors: "
 msgstr "Colori: "
 
-#: src/muuli_wdr.cpp:1858
+#: src/muuli_wdr.cpp:1862
 msgid "Background"
 msgstr "Sfondo"
 
-#: src/muuli_wdr.cpp:1859
+#: src/muuli_wdr.cpp:1863
 msgid "Grid"
 msgstr "Griglia"
 
-#: src/muuli_wdr.cpp:1860
+#: src/muuli_wdr.cpp:1864
 msgid "Download current"
 msgstr "Download attuale"
 
-#: src/muuli_wdr.cpp:1861
+#: src/muuli_wdr.cpp:1865
 msgid "Download running average"
 msgstr "Media download in corso"
 
-#: src/muuli_wdr.cpp:1862
+#: src/muuli_wdr.cpp:1866
 msgid "Download session average"
 msgstr "Media sessione di download"
 
-#: src/muuli_wdr.cpp:1863
+#: src/muuli_wdr.cpp:1867
 msgid "Upload current"
 msgstr "Upload attuale"
 
-#: src/muuli_wdr.cpp:1864
+#: src/muuli_wdr.cpp:1868
 msgid "Upload running average"
 msgstr "Media upload in corso"
 
-#: src/muuli_wdr.cpp:1865
+#: src/muuli_wdr.cpp:1869
 msgid "Upload session average"
 msgstr "Media sessione di upload"
 
-#: src/muuli_wdr.cpp:1866
+#: src/muuli_wdr.cpp:1870
 msgid "Active connections"
 msgstr "Connessioni attive"
 
-#: src/muuli_wdr.cpp:1869
+#: src/muuli_wdr.cpp:1873
 msgid "Systray Icon Speed Bar"
 msgstr "Barra della velocità nell'icona sulla barra di sistema"
 
-#: src/muuli_wdr.cpp:1870
+#: src/muuli_wdr.cpp:1874
 msgid "Kad-nodes current"
 msgstr "Nodi Kad attuali"
 
-#: src/muuli_wdr.cpp:1871
+#: src/muuli_wdr.cpp:1875
 msgid "Kad-nodes running"
 msgstr "Nodi Kad attivi"
 
-#: src/muuli_wdr.cpp:1872
+#: src/muuli_wdr.cpp:1876
 msgid "Kad-nodes session"
 msgstr "Nodi Kad nella sessione"
 
-#: src/muuli_wdr.cpp:1876 src/muuli_wdr.cpp:2303
+#: src/muuli_wdr.cpp:1880 src/muuli_wdr.cpp:2334
 msgid "Select"
 msgstr "Seleziona"
 
-#: src/muuli_wdr.cpp:1880
+#: src/muuli_wdr.cpp:1884
 msgid "Tree"
 msgstr "Albero"
 
-#: src/muuli_wdr.cpp:1890
+#: src/muuli_wdr.cpp:1894
 msgid "Number of Client Versions shown (0=unlimited)"
 msgstr "Numero di versioni di client visualizzate (0=illimitate)"
 
-#: src/muuli_wdr.cpp:1915
+#: src/muuli_wdr.cpp:1919
 msgid "!!! WARNING !!!"
 msgstr "!!! ATTENZIONE !!!"
 
-#: src/muuli_wdr.cpp:1930
+#: src/muuli_wdr.cpp:1934
 msgid "Max new connections / 5 secs"
 msgstr "Numero massimo nuove connessioni / 5 secondi"
 
-#: src/muuli_wdr.cpp:1932
+#: src/muuli_wdr.cpp:1936
 msgid "Concurrent Kad source lookups"
 msgstr "Ricerche di fonti Kad simultanee"
 
-#: src/muuli_wdr.cpp:1934
+#: src/muuli_wdr.cpp:1938
 msgid "Kad source re-search interval (minutes)"
 msgstr "Intervallo tra le ricerche di fonti Kad (minuti)"
 
-#: src/muuli_wdr.cpp:1936
+#: src/muuli_wdr.cpp:1940
 msgid "Source re-ask interval (minutes)"
 msgstr "Intervallo tra le richieste alle fonti (minuti)"
 
-#: src/muuli_wdr.cpp:1940
+#: src/muuli_wdr.cpp:1944
 msgid "File Buffer Size: 240000 bytes"
 msgstr "Dimensione buffer file: 240000 byte"
 
-#: src/muuli_wdr.cpp:1944
+#: src/muuli_wdr.cpp:1948
 msgid "Use MMAP: memory-mapped file access (lower memory use)"
 msgstr "Usa MMAP: accesso ai file mappato in memoria (minor uso di memoria)"
 
-#: src/muuli_wdr.cpp:1945
+#: src/muuli_wdr.cpp:1949
 msgid "Maps part files into memory instead of buffering them on the heap, lowering the process memory footprint. May reduce download speed on some disks; best for memory-constrained or upload-heavy hosts."
 msgstr "Mappa i file parziali in memoria invece di bufferizzarli nell'heap, riducendo l'occupazione di memoria del processo. Potrebbe ridurre la velocità di download su alcuni dischi; ideale per sistemi con memoria limitata o con molto traffico in upload."
 
-#: src/muuli_wdr.cpp:1947
+#: src/muuli_wdr.cpp:1951
 msgid "Upload Queue Size: 5000 clients"
 msgstr "Dimensione coda upload: 5000 client"
 
-#: src/muuli_wdr.cpp:1951
+#: src/muuli_wdr.cpp:1955
 msgid "Server connection refresh interval: Disable"
 msgstr "Intervallo aggiornamento connessione al server: disabilitato"
 
-#: src/muuli_wdr.cpp:1955
+#: src/muuli_wdr.cpp:1959
 msgid "Disable computer's timed standby mode"
 msgstr "Disabilita la modalità standby a tempo"
 
-#: src/muuli_wdr.cpp:1974
+#: src/muuli_wdr.cpp:1978
 msgid "Skin to use: "
 msgstr "Skin da usare: "
 
-#: src/muuli_wdr.cpp:1983
+#: src/muuli_wdr.cpp:1987
 msgid "Show \"Fast eD2k Links Handler\" in every window."
 msgstr "Mostra il \"Gestore rapido dei collegamenti eD2k\" in ogni finestra."
 
-#: src/muuli_wdr.cpp:1986
+#: src/muuli_wdr.cpp:1990
 msgid "Show extended info on categories tabs"
 msgstr "Mostra informazioni estese sulle schede delle categorie"
 
-#: src/muuli_wdr.cpp:1989
+#: src/muuli_wdr.cpp:1993
 msgid "Show application version on title"
 msgstr "Mostra versione dell'applicazione nella barra del titolo"
 
-#: src/muuli_wdr.cpp:1991
+#: src/muuli_wdr.cpp:1995
 msgid "Show transfer rates on title"
 msgstr "Mostra velocità di trasferimento nella barra del titolo"
 
-#: src/muuli_wdr.cpp:1993
+#: src/muuli_wdr.cpp:1997
 msgid "Before application name"
 msgstr "Prima del nome dell'applicazione"
 
-#: src/muuli_wdr.cpp:1995
+#: src/muuli_wdr.cpp:1999
 msgid "After application name"
 msgstr "Dopo il nome dell'applicazione"
 
-#: src/muuli_wdr.cpp:1998
+#: src/muuli_wdr.cpp:2002
 msgid "Show overhead bandwidth"
 msgstr "Mostra l'overhead di banda"
 
-#: src/muuli_wdr.cpp:2002
+#: src/muuli_wdr.cpp:2006
 msgid "Vertical toolbar orientation"
 msgstr "Orientamento verticale della barra degli strumenti"
 
-#: src/muuli_wdr.cpp:2004
+#: src/muuli_wdr.cpp:2008
 msgid "Live column sorting (auto-reorder rows as their values change)"
 msgstr "Ordinamento colonne in tempo reale (riordina le righe automaticamente al variare dei loro valori)"
 
-#: src/muuli_wdr.cpp:2011
+#: src/muuli_wdr.cpp:2015
 msgid "Download Queue Files"
 msgstr "Scaricamento dei file in coda"
 
-#: src/muuli_wdr.cpp:2014
+#: src/muuli_wdr.cpp:2018
 msgid "Show progress percentage"
 msgstr "Mostra la percentuale di avanzamento"
 
-#: src/muuli_wdr.cpp:2020
+#: src/muuli_wdr.cpp:2024
 msgid "Show progress bar"
 msgstr "Mostra la barra di avanzamento"
 
-#: src/muuli_wdr.cpp:2023
+#: src/muuli_wdr.cpp:2027
 msgid "Flat"
 msgstr "Piatta"
 
-#: src/muuli_wdr.cpp:2027
+#: src/muuli_wdr.cpp:2031
 msgid "Round"
 msgstr "Arrotondata"
 
-#: src/muuli_wdr.cpp:2045
+#: src/muuli_wdr.cpp:2049
 msgid "External Connection Parameters"
 msgstr "Parametri connessioni esterne"
 
-#: src/muuli_wdr.cpp:2048
+#: src/muuli_wdr.cpp:2052
 msgid "Accept external connections"
 msgstr "Accetta connessioni esterne"
 
-#: src/muuli_wdr.cpp:2055 src/muuli_wdr.cpp:2114
+#: src/muuli_wdr.cpp:2059 src/muuli_wdr.cpp:2118
 msgid "IP of the listening interface:"
 msgstr "IP dell'interfaccia di ascolto:"
 
-#: src/muuli_wdr.cpp:2058
+#: src/muuli_wdr.cpp:2062
 msgid "Enter here a valid ip in the a.b.c.d format for the listening EC interface. An empty field or 0.0.0.0 will mean any interface."
 msgstr "Inserisci un IP valido nel formato a.b.c.d per l'interfaccia di ascolto EC. Lasciare il campo vuoto o inserire 0.0.0.0 significa qualsiasi interfaccia."
 
-#: src/muuli_wdr.cpp:2079 src/muuli_wdr.cpp:2163
+#: src/muuli_wdr.cpp:2083 src/muuli_wdr.cpp:2194
 msgid "TCP port:"
 msgstr "Porta TCP:"
 
-#: src/muuli_wdr.cpp:2085
+#: src/muuli_wdr.cpp:2089
 msgid "Enable UPnP port forwarding on the EC port"
 msgstr "Abilita il port forwarding tramite UPnP sulla porta EC"
 
-#: src/muuli_wdr.cpp:2089 src/muuli_wdr.cpp:3048
+#: src/muuli_wdr.cpp:2093 src/muuli_wdr.cpp:3079
 #: src/utils/wxCas/src/wxcasprefs.cpp:167
 msgid "Password"
 msgstr "Password"
 
-#: src/muuli_wdr.cpp:2095
+#: src/muuli_wdr.cpp:2099
 msgid "aMule API server parameters"
 msgstr "Parametri del server API di aMule"
 
-#: src/muuli_wdr.cpp:2098
+#: src/muuli_wdr.cpp:2102
 msgid "Run amuleapi (REST API) on startup"
 msgstr "Avvia amuleapi (REST API) all'avvio"
 
-#: src/muuli_wdr.cpp:2103
+#: src/muuli_wdr.cpp:2107
 msgid "HTTP port:"
 msgstr "Porta HTTP:"
 
-#: src/muuli_wdr.cpp:2117
+#: src/muuli_wdr.cpp:2121
 msgid "The interface amuleapi's HTTP server listens on. 127.0.0.1 (default) accepts only local connections; use 0.0.0.0 or a specific IP to expose it to other hosts (set an admin password below)."
 msgstr "L'interfaccia su cui è in ascolto il server HTTP di amuleapi. 127.0.0.1 (predefinito) accetta solo connessioni locali; usa 0.0.0.0 o un IP specifico per esporlo ad altri host (imposta una password di amministrazione qui sotto)."
 
-#: src/muuli_wdr.cpp:2120
+#: src/muuli_wdr.cpp:2126
+msgid "Type a password to set or change it. Stored passwords cannot be shown, so leaving this empty keeps the current one."
+msgstr ""
+
+#: src/muuli_wdr.cpp:2128
 msgid "Admin password"
 msgstr "Password amministrazione"
 
-#: src/muuli_wdr.cpp:2125 src/muuli_wdr.cpp:2156
-msgid "Low rights password"
-msgstr "Password per diritti limitati"
+#: src/muuli_wdr.cpp:2140 src/muuli_wdr.cpp:2157 src/PrefsUnifiedDlg.cpp:1103
+#, fuzzy
+msgid "A password is set."
+msgstr "Password amministrazione"
 
-#: src/muuli_wdr.cpp:2133
+#: src/muuli_wdr.cpp:2144
+#, fuzzy
+msgid "Enable guest access"
+msgstr "Vieta l'accesso guest"
+
+#: src/muuli_wdr.cpp:2145
+msgid "Guest sessions may read status and listings but cannot change anything. Turning this off clears the stored guest password."
+msgstr ""
+
+#: src/muuli_wdr.cpp:2149
+#, fuzzy
+msgid "Guest password"
+msgstr "Password per l'accesso Guest al web server"
+
+#: src/muuli_wdr.cpp:2164
 msgid "Web server parameters"
 msgstr "Parametri del server web"
 
-#: src/muuli_wdr.cpp:2136
+#: src/muuli_wdr.cpp:2167
 msgid "Run webserver on startup (deprecated)"
 msgstr "Lancia il webserver all'avvio (deprecato)"
 
-#: src/muuli_wdr.cpp:2142
+#: src/muuli_wdr.cpp:2173
 msgid "Web template"
 msgstr "Template web"
 
-#: src/muuli_wdr.cpp:2147
+#: src/muuli_wdr.cpp:2178
 msgid "Full rights password"
 msgstr "Password per diritti completi"
 
-#: src/muuli_wdr.cpp:2151
+#: src/muuli_wdr.cpp:2182
 msgid "Enable Low rights User"
 msgstr "Abilita utente con diritti limitati"
 
-#: src/muuli_wdr.cpp:2170
+#: src/muuli_wdr.cpp:2187
+msgid "Low rights password"
+msgstr "Password per diritti limitati"
+
+#: src/muuli_wdr.cpp:2201
 msgid "Enable UPnP port forwarding of the web server port"
 msgstr "Abilita port forwarding tramite UPnP sulla porta del server web"
 
-#: src/muuli_wdr.cpp:2175
+#: src/muuli_wdr.cpp:2206
 msgid "Web server UPnP TCP port (Optional)"
 msgstr "Porta TCP del  server web per UPnP (Facoltativa)"
 
-#: src/muuli_wdr.cpp:2183
+#: src/muuli_wdr.cpp:2214
 msgid "Page Refresh Time (in secs)"
 msgstr "Intervallo di aggiornamento pagina (in sec)"
 
-#: src/muuli_wdr.cpp:2190
+#: src/muuli_wdr.cpp:2221
 msgid "Enable Gzip compression"
 msgstr "Abilita compressione gzip"
 
-#: src/muuli_wdr.cpp:2224
+#: src/muuli_wdr.cpp:2255
 msgid "Reset page to defaults"
 msgstr "Ripristina i valori predefiniti della pagina"
 
-#: src/muuli_wdr.cpp:2225
+#: src/muuli_wdr.cpp:2256
 msgid "Reset the settings on the current page to their default values."
 msgstr "Ripristina le impostazioni della pagina corrente ai loro valori predefiniti."
 
-#: src/muuli_wdr.cpp:2227 src/muuli_wdr.cpp:2313 src/ServerWnd.cpp:274
+#: src/muuli_wdr.cpp:2258 src/muuli_wdr.cpp:2344 src/ServerWnd.cpp:274
 #: src/ServerWnd.cpp:282
 msgid "OK"
 msgstr "OK"
 
-#: src/muuli_wdr.cpp:2229
+#: src/muuli_wdr.cpp:2260
 msgid "Click here to apply any changes made to the preferences."
 msgstr "Fai click qui per applicare le modifiche apportate alle impostazioni."
 
-#: src/muuli_wdr.cpp:2232
+#: src/muuli_wdr.cpp:2263
 msgid "Reset any changes made to the preferences."
 msgstr "Annulla ogni modifica alle preferenze."
 
-#: src/muuli_wdr.cpp:2261
+#: src/muuli_wdr.cpp:2292
 msgid "Comment :"
 msgstr "Commento:"
 
-#: src/muuli_wdr.cpp:2268
+#: src/muuli_wdr.cpp:2299
 msgid "Incoming Dir :"
 msgstr "Directory file scaricati:"
 
-#: src/muuli_wdr.cpp:2277
+#: src/muuli_wdr.cpp:2308
 msgid "Change priority for new assigned files :"
 msgstr "Cambia priorità per i nuovi file assegnati:"
 
-#: src/muuli_wdr.cpp:2281
+#: src/muuli_wdr.cpp:2312
 msgid "Don't change"
 msgstr "Non modificare"
 
-#: src/muuli_wdr.cpp:2293
+#: src/muuli_wdr.cpp:2324
 msgid "Select color for this Category (currently selected) :"
 msgstr "Seleziona colore per questa categoria (attualmente selezionata):"
 
-#: src/muuli_wdr.cpp:2360 src/muuli_wdr.cpp:2379 src/muuli_wdr.cpp:2401
+#: src/muuli_wdr.cpp:2391 src/muuli_wdr.cpp:2410 src/muuli_wdr.cpp:2432
 msgid "Click this button to reset the log."
 msgstr "Fai clic su questo pulsante per cancellare i log."
 
-#: src/muuli_wdr.cpp:2420
+#: src/muuli_wdr.cpp:2451
 msgid "Click on this button to update the servers list from URL ..."
 msgstr "Fai clic qui per aggiornare la lista dei server dall'indirizzo..."
 
-#: src/muuli_wdr.cpp:2424
+#: src/muuli_wdr.cpp:2455
 msgid "Server list"
 msgstr "Lista server"
 
-#: src/muuli_wdr.cpp:2428
+#: src/muuli_wdr.cpp:2459
 msgid "Enter the url to a server.met file here and press the button to the left to update the list of known servers."
 msgstr "Inserisci l'url di un file server.met e premi il pulsante a sinistra per aggiornare la lista dei server conosciuti."
 
-#: src/muuli_wdr.cpp:2433
+#: src/muuli_wdr.cpp:2464
 msgid "Add server manually: Name"
 msgstr "Aggiungi un server manualmente: Nome"
 
-#: src/muuli_wdr.cpp:2436
+#: src/muuli_wdr.cpp:2467
 msgid "Enter the name of the new server here"
 msgstr "Inserisci qui il nome di un nuovo server"
 
-#: src/muuli_wdr.cpp:2438 src/ServerWnd.cpp:206
+#: src/muuli_wdr.cpp:2469 src/ServerWnd.cpp:206
 msgid "IP:Port"
 msgstr "IP:Porta"
 
-#: src/muuli_wdr.cpp:2441
+#: src/muuli_wdr.cpp:2472
 msgid "Enter the IP of the server here, using the x.x.x.x format."
 msgstr "Inserisci qui l'IP del server, nel formato x.x.x.x."
 
-#: src/muuli_wdr.cpp:2447
+#: src/muuli_wdr.cpp:2478
 msgid "Enter the port of the server here."
 msgstr "Inserisci qui la porta del server."
 
-#: src/muuli_wdr.cpp:2450
+#: src/muuli_wdr.cpp:2481
 msgid "Add manually a server (fill fields to the left before) ..."
 msgstr "Aggiungi server (riempi campi a sinistra)..."
 
-#: src/muuli_wdr.cpp:2479
+#: src/muuli_wdr.cpp:2510
 msgid "aMule Log"
 msgstr "log di aMule"
 
-#: src/muuli_wdr.cpp:2487
+#: src/muuli_wdr.cpp:2518
 msgid "Server Info"
 msgstr "Informazioni server"
 
-#: src/muuli_wdr.cpp:2491
+#: src/muuli_wdr.cpp:2522
 msgid "ED2K Info"
 msgstr "Informazioni ed2k"
 
-#: src/muuli_wdr.cpp:2495
+#: src/muuli_wdr.cpp:2526
 msgid "Kad Info"
 msgstr "Informazioni Kad"
 
-#: src/muuli_wdr.cpp:2523
+#: src/muuli_wdr.cpp:2554
 msgid "Click on this button to update the nodes list from URL ..."
 msgstr "Fai clic su questo pulsante per aggiornare la lista nodi da un URL..."
 
-#: src/muuli_wdr.cpp:2527
+#: src/muuli_wdr.cpp:2558
 msgid "Nodes (0)"
 msgstr "Nodi (0)"
 
-#: src/muuli_wdr.cpp:2531
+#: src/muuli_wdr.cpp:2562
 msgid "Enter the url to a nodes.dat file here and press the button to the left to update the list of known nodes."
 msgstr "Inserisci l'URL di un file nodes.dat e premi il pulsante a sinistra per aggiornare la lista dei nodi conosciuti."
 
-#: src/muuli_wdr.cpp:2534
+#: src/muuli_wdr.cpp:2565
 msgid "Nodes stats"
 msgstr "Statistiche nodi"
 
-#: src/muuli_wdr.cpp:2576
+#: src/muuli_wdr.cpp:2607
 msgid "Bootstrap"
 msgstr "Bootstrap"
 
-#: src/muuli_wdr.cpp:2579
+#: src/muuli_wdr.cpp:2610
 msgid "New node"
 msgstr "Nuovo nodo"
 
-#: src/muuli_wdr.cpp:2584
+#: src/muuli_wdr.cpp:2615
 msgid "IP:"
 msgstr "IP:"
 
-#: src/muuli_wdr.cpp:2604
+#: src/muuli_wdr.cpp:2635
 msgid "Port:"
 msgstr "Porta:"
 
-#: src/muuli_wdr.cpp:2617
+#: src/muuli_wdr.cpp:2648
 msgid "Bootstrap from known clients"
 msgstr "Bootstrap dai client noti"
 
-#: src/muuli_wdr.cpp:2619
+#: src/muuli_wdr.cpp:2650
 msgid "Disconnect Kad"
 msgstr "Disconnetti rete Kad"
 
-#: src/muuli_wdr.cpp:2653
+#: src/muuli_wdr.cpp:2684
 msgid "Use Secure User Identification"
 msgstr "Usa identificazione sicura"
 
-#: src/muuli_wdr.cpp:2655
+#: src/muuli_wdr.cpp:2686
 msgid "It is recommended to enable this option. You will not receive credits if SUI is not enabled."
 msgstr "È consigliato attivare questa opzione. Non riceverai crediti se \" \"l'identificazione non sarà abilitata."
 
-#: src/muuli_wdr.cpp:2657
+#: src/muuli_wdr.cpp:2688
 msgid "Protocol Obfuscation"
 msgstr "Offuscamento del protocollo"
 
-#: src/muuli_wdr.cpp:2660
+#: src/muuli_wdr.cpp:2691
 msgid "Support Protocol Obfuscation"
 msgstr "Supporta offuscamento del protocollo"
 
-#: src/muuli_wdr.cpp:2662
+#: src/muuli_wdr.cpp:2693
 msgid "This option enabled Protocol Obfuscation, and makes aMule accept obfuscated connections from other clients."
 msgstr "Questa opzione abilita l'offuscamento del protocollo, e fa sì che aMule accetti connessioni offuscate dagli altri client."
 
-#: src/muuli_wdr.cpp:2664
+#: src/muuli_wdr.cpp:2695
 msgid "Use obfuscation for outgoing connections"
 msgstr "Utilizza offuscamento per le connessioni in uscita"
 
-#: src/muuli_wdr.cpp:2666
+#: src/muuli_wdr.cpp:2697
 msgid "This option makes aMule use Protocol Obfuscation when connecting other clients/servers."
 msgstr "Questa opzione fa sì che aMule utilizzi l'offuscamento del protocollo quando si collega ad altri client/server."
 
-#: src/muuli_wdr.cpp:2668
+#: src/muuli_wdr.cpp:2699
 msgid "Accept only obfuscated connections"
 msgstr "Accetta SOLO connessioni offuscate"
 
-#: src/muuli_wdr.cpp:2669
+#: src/muuli_wdr.cpp:2700
 msgid "This option makes aMule only accept obfuscated connections. You will have less sources, but all your traffic will be obfuscated"
 msgstr "Attivando questa opzione aMule accetterà solo connessioni offuscate. Avrai meno fonti, ma tutto il tuo traffico sarà offuscato"
 
-#: src/muuli_wdr.cpp:2674
+#: src/muuli_wdr.cpp:2705
 msgid "Everybody"
 msgstr "Chiunque"
 
-#: src/muuli_wdr.cpp:2676
+#: src/muuli_wdr.cpp:2707
 msgid "No one"
 msgstr "Nessuno"
 
-#: src/muuli_wdr.cpp:2678
+#: src/muuli_wdr.cpp:2709
 msgid "Who can see my shared files:"
 msgstr "Chi può vedere i miei file condivisi:"
 
-#: src/muuli_wdr.cpp:2679
+#: src/muuli_wdr.cpp:2710
 msgid "Select who can request to view a list of your shared files."
 msgstr "Seleziona chi può richiedere di vedere la lista dei tuoi file condivisi."
 
-#: src/muuli_wdr.cpp:2681
+#: src/muuli_wdr.cpp:2712
 msgid "IP-Filtering"
 msgstr "Filtraggio IP"
 
-#: src/muuli_wdr.cpp:2688
+#: src/muuli_wdr.cpp:2719
 msgid "Filter clients"
 msgstr "Filtra i client"
 
-#: src/muuli_wdr.cpp:2690
+#: src/muuli_wdr.cpp:2721
 msgid "Enable filtering of the client IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "Filtra i client in base agli ip contenuti in ~/.aMule/ipfilter.dat."
 
-#: src/muuli_wdr.cpp:2692
+#: src/muuli_wdr.cpp:2723
 msgid "Filter servers"
 msgstr "Filtra i server"
 
-#: src/muuli_wdr.cpp:2694
+#: src/muuli_wdr.cpp:2725
 msgid "Enable filtering of the server IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "Filtra i server in base agli ip contenuti in ~/.aMule/ipfilter.dat."
 
-#: src/muuli_wdr.cpp:2698
+#: src/muuli_wdr.cpp:2729
 msgid "Reload List"
 msgstr "Ricarica lista"
 
-#: src/muuli_wdr.cpp:2699
+#: src/muuli_wdr.cpp:2730
 msgid "Reload the list of IPs to filter from the file ~/.aMule/ipfilter.dat"
 msgstr "Ricarica lista degli IP da filtrare dal file ~/.aMule/ipfilter.dat"
 
-#: src/muuli_wdr.cpp:2705
+#: src/muuli_wdr.cpp:2736
 msgid "URL:"
 msgstr "URL:"
 
-#: src/muuli_wdr.cpp:2709 src/muuli_wdr.cpp:2902
+#: src/muuli_wdr.cpp:2740 src/muuli_wdr.cpp:2933
 msgid "Update now"
 msgstr "Aggiorna ora"
 
-#: src/muuli_wdr.cpp:2712
+#: src/muuli_wdr.cpp:2743
 msgid "Auto-update ipfilter at startup"
 msgstr "Aggiorna ipfilter all'avvio"
 
-#: src/muuli_wdr.cpp:2716
+#: src/muuli_wdr.cpp:2747
 msgid "Filtering Level:"
 msgstr "Livello filtraggio:"
 
-#: src/muuli_wdr.cpp:2722
+#: src/muuli_wdr.cpp:2753
 msgid "Always filter LAN IPs"
 msgstr "Filtra sempre gli IP di una LAN"
 
-#: src/muuli_wdr.cpp:2725
+#: src/muuli_wdr.cpp:2756
 msgid "Paranoid handling of non-matching IPs"
 msgstr "Gestione paranoica degli IP non corrispondenti"
 
-#: src/muuli_wdr.cpp:2727
+#: src/muuli_wdr.cpp:2758
 msgid "Rejects a packet when its source IP differs from the IP the client claims (an anti-spoofing check). Disable only if it causes connection problems."
 msgstr "Rifiuta un pacchetto quando l'IP di origine è diverso dall'IP dichiarato dal client (un controllo anti-spoofing). Disabilitare solo se causa problemi di connessione."
 
-#: src/muuli_wdr.cpp:2729
+#: src/muuli_wdr.cpp:2760
 msgid "Use system-wide ipfilter.dat if available"
 msgstr "Usa l'ipfilter.dat di sistema se disponibile"
 
-#: src/muuli_wdr.cpp:2730
+#: src/muuli_wdr.cpp:2761
 msgid "If there's no local ipfilter.dat found, allow usage of a system-wide ipfilter file."
 msgstr "Se un file ipfilter.dat locale non viene trovato, consenti l'utilizzo del file ipfilter.dat di sistema."
 
-#: src/muuli_wdr.cpp:2747
+#: src/muuli_wdr.cpp:2778
 msgid "Enable Online-Signature"
 msgstr "Abilita Online Signature"
 
-#: src/muuli_wdr.cpp:2749
+#: src/muuli_wdr.cpp:2780
 msgid "Enables the writing of the OS file, which can be used by external apps to create signatures and the like."
 msgstr "Abilita la scrittura del file OS che può essere usato da applicazioni esterne per creare firme e simili."
 
-#: src/muuli_wdr.cpp:2753
+#: src/muuli_wdr.cpp:2784
 msgid "Update Frequency (Secs):"
 msgstr "Frequenza di aggiornamento (secondi):"
 
-#: src/muuli_wdr.cpp:2756
+#: src/muuli_wdr.cpp:2787
 msgid "Change the frequency (in seconds) of Online Signature updates."
 msgstr "Cambia la frequenza (in secondi) degli aggiornamenti dell'Online Signature."
 
-#: src/muuli_wdr.cpp:2764
+#: src/muuli_wdr.cpp:2795
 msgid "Save online signature file in: "
 msgstr "Salva la firma in linea in: "
 
-#: src/muuli_wdr.cpp:2770
+#: src/muuli_wdr.cpp:2801
 msgid "Click here to select the directory containing the the Online Signature files."
 msgstr "Clicca qui per selezionare la directory che contiene i file dell'Online Signature."
 
-#: src/muuli_wdr.cpp:2803
+#: src/muuli_wdr.cpp:2834
 msgid "Show country flags for clients"
 msgstr "Mostra la nazionalità dei client"
 
-#: src/muuli_wdr.cpp:2804
+#: src/muuli_wdr.cpp:2835
 msgid "Render the country flag column in the transfers, queue and search views. Requires a valid MMDB GeoIP database (see below)."
 msgstr "Mostra la colonna delle bandiere dei paesi nelle viste trasferimenti, coda e ricerca. Richiede un database GeoIP MMDB valido (vedi sotto)."
 
-#: src/muuli_wdr.cpp:2809
+#: src/muuli_wdr.cpp:2840
 msgid "Database"
 msgstr "Database"
 
-#: src/muuli_wdr.cpp:2825
+#: src/muuli_wdr.cpp:2856
 msgid "Source:"
 msgstr "Sorgente:"
 
-#: src/muuli_wdr.cpp:2828
+#: src/muuli_wdr.cpp:2859
 msgid "DB-IP (free, no account)"
 msgstr "DB-IP (gratuito, nessun account)"
 
-#: src/muuli_wdr.cpp:2829
+#: src/muuli_wdr.cpp:2860
 msgid "MaxMind GeoLite2 (free, account required)"
 msgstr "MaxMind GeoLite2 (gratuito, richiede account)"
 
-#: src/muuli_wdr.cpp:2830
+#: src/muuli_wdr.cpp:2861
 msgid "Custom URL"
 msgstr "URL personalizzato"
 
-#: src/muuli_wdr.cpp:2833
+#: src/muuli_wdr.cpp:2864
 msgid "Choose which provider supplies the GeoIP MMDB database. DB-IP is the default - no account required. MaxMind requires a free account + license key. Use Custom URL to point at any other MMDB host (e.g. a local mirror)."
 msgstr "Scegli quale provider fornisce il database GeoIP MMDB. DB-IP è il default - nessun account richiesto. MaxMind richiede un account gratuito + license key. Usa URL personalizzato per puntare a qualsiasi altro host MMDB (es. un mirror locale)."
 
-#: src/muuli_wdr.cpp:2850
+#: src/muuli_wdr.cpp:2881
 msgid ""
 "No configuration required.\n"
 "\n"
@@ -4837,11 +4865,11 @@ msgstr ""
 "Dati IP-to-Country di DB-IP.com - https://db-ip.com\n"
 "Licenza: Creative Commons BY 4.0 - https://creativecommons.org/licenses/by/4.0/"
 
-#: src/muuli_wdr.cpp:2863
+#: src/muuli_wdr.cpp:2894
 msgid "License key:"
 msgstr "License key:"
 
-#: src/muuli_wdr.cpp:2869
+#: src/muuli_wdr.cpp:2900
 msgid ""
 "Sign up for a free MaxMind account, then generate a License Key:\n"
 "https://www.maxmind.com/en/geolite2/signup\n"
@@ -4857,11 +4885,11 @@ msgstr ""
 "Licenza: MaxMind GeoLite2 EULA - https://www.maxmind.com/en/geolite2/eula\n"
 "Richiede attribuzione e registrazione dell'account; aggiornare almeno ogni 30 giorni."
 
-#: src/muuli_wdr.cpp:2884
+#: src/muuli_wdr.cpp:2915
 msgid "Download URL:"
 msgstr "URL di scaricamento:"
 
-#: src/muuli_wdr.cpp:2890
+#: src/muuli_wdr.cpp:2921
 msgid ""
 "Must point to an .mmdb file or a .gz / .tar.gz containing one.\n"
 "URL may include credentials (https://user:pass@host/...).\n"
@@ -4871,211 +4899,211 @@ msgstr ""
 "L'URL può includere credenziali (https://user:pass@host/...).\n"
 "I termini di licenza e attribuzione sono definiti dall'URL upstream - ne sei responsabile."
 
-#: src/muuli_wdr.cpp:2903
+#: src/muuli_wdr.cpp:2934
 msgid "Download the GeoIP database from the selected source."
 msgstr "Scarica il database GeoIP dalla sorgente selezionata."
 
-#: src/muuli_wdr.cpp:2905
+#: src/muuli_wdr.cpp:2936
 msgid "Auto-update on startup"
 msgstr "Aggiornamento automatico all'avvio"
 
-#: src/muuli_wdr.cpp:2906
+#: src/muuli_wdr.cpp:2937
 msgid "Re-download the GeoIP database from the selected source every time aMule starts."
 msgstr "Riscarica il database GeoIP dalla sorgente selezionata ogni volta che aMule si avvia."
 
-#: src/muuli_wdr.cpp:2929
+#: src/muuli_wdr.cpp:2960
 msgid "Filter incoming messages (except current chat):"
 msgstr "Filtra messaggi in arrivo (tranne per la chat in corso):"
 
-#: src/muuli_wdr.cpp:2931
+#: src/muuli_wdr.cpp:2962
 msgid "Filter all messages"
 msgstr "Filtra tutti i messaggi"
 
-#: src/muuli_wdr.cpp:2933
+#: src/muuli_wdr.cpp:2964
 msgid "Filter messages from people not on your friend list"
 msgstr "Filtra i messaggi da utenti che non sono nella tua lista degli amici"
 
-#: src/muuli_wdr.cpp:2935
+#: src/muuli_wdr.cpp:2966
 msgid "Filter messages from unknown clients"
 msgstr "Filtra i messaggi da client sconosciuti"
 
-#: src/muuli_wdr.cpp:2937
+#: src/muuli_wdr.cpp:2968
 msgid "Filter messages containing (use ',' as separator):"
 msgstr "Filtra i messaggi che contengono (usa ',' come separatore):"
 
-#: src/muuli_wdr.cpp:2940 src/muuli_wdr.cpp:2951
+#: src/muuli_wdr.cpp:2971 src/muuli_wdr.cpp:2982
 msgid "add here the words amule should filter and block messages including it"
 msgstr "aggiungi qui le parole che aMule filtrerà rimuovendo i messaggi che le contengono"
 
-#: src/muuli_wdr.cpp:2942
+#: src/muuli_wdr.cpp:2973
 msgid "Show received messages in the log"
 msgstr "Mostra nel log i messaggi ricevuti"
 
-#: src/muuli_wdr.cpp:2945
+#: src/muuli_wdr.cpp:2976
 msgid "Comments"
 msgstr "Commenti"
 
-#: src/muuli_wdr.cpp:2948
+#: src/muuli_wdr.cpp:2979
 msgid "Filter comments containing (use ',' as separator):"
 msgstr "Filtra i commenti contenenti (usa ',' come separatore):"
 
-#: src/muuli_wdr.cpp:2973
+#: src/muuli_wdr.cpp:3004
 msgid "Enable Proxy"
 msgstr "Abilita proxy"
 
-#: src/muuli_wdr.cpp:2974
+#: src/muuli_wdr.cpp:3005
 msgid "Enable/disable proxy support"
 msgstr "Abilita o disabilita il supporto proxy"
 
-#: src/muuli_wdr.cpp:2977
+#: src/muuli_wdr.cpp:3008
 msgid "Proxy type:"
 msgstr "Tipo proxy:"
 
-#: src/muuli_wdr.cpp:2988
+#: src/muuli_wdr.cpp:3019
 msgid "Proxy host:"
 msgstr "Indirizzo proxy:"
 
-#: src/muuli_wdr.cpp:2991
+#: src/muuli_wdr.cpp:3022
 msgid "The proxy host name"
 msgstr "Il nome host del proxy"
 
-#: src/muuli_wdr.cpp:2993
+#: src/muuli_wdr.cpp:3024
 msgid "Proxy port:"
 msgstr "Porta proxy:"
 
-#: src/muuli_wdr.cpp:2996
+#: src/muuli_wdr.cpp:3027
 msgid "The proxy port"
 msgstr "La porta del proxy"
 
-#: src/muuli_wdr.cpp:2998
+#: src/muuli_wdr.cpp:3029
 msgid "Enable authentication"
 msgstr "Abilita autenticazione"
 
-#: src/muuli_wdr.cpp:2999
+#: src/muuli_wdr.cpp:3030
 msgid "Enable/disable username/password authentication"
 msgstr "Abilita o disabilita l'autenticazione con nome utente e password"
 
-#: src/muuli_wdr.cpp:3002
+#: src/muuli_wdr.cpp:3033
 msgid "Username: "
 msgstr "Nome utente: "
 
-#: src/muuli_wdr.cpp:3005
+#: src/muuli_wdr.cpp:3036
 msgid "The username to use to connect to the proxy"
 msgstr "Nome utente utilizzato per la connessione al proxy"
 
-#: src/muuli_wdr.cpp:3007
+#: src/muuli_wdr.cpp:3038
 msgid "Password:"
 msgstr "Password:"
 
-#: src/muuli_wdr.cpp:3010
+#: src/muuli_wdr.cpp:3041
 msgid "The password to use to connect to the proxy"
 msgstr "La password usata per la connessione al proxy"
 
-#: src/muuli_wdr.cpp:3029
+#: src/muuli_wdr.cpp:3060
 msgid "Connect to:"
 msgstr "Connetti a:"
 
-#: src/muuli_wdr.cpp:3038
+#: src/muuli_wdr.cpp:3069
 msgid "Login to remote amule"
 msgstr "Login su aMule remoto"
 
-#: src/muuli_wdr.cpp:3043
+#: src/muuli_wdr.cpp:3074
 msgid "User name"
 msgstr "Nome utente"
 
-#: src/muuli_wdr.cpp:3054
+#: src/muuli_wdr.cpp:3085
 msgid "Remember those settings"
 msgstr "Ricorda impostazioni"
 
-#: src/muuli_wdr.cpp:3057
+#: src/muuli_wdr.cpp:3088
 msgid "Force ZLIB compression"
 msgstr "Forza la compressione ZLIB"
 
-#: src/muuli_wdr.cpp:3081
+#: src/muuli_wdr.cpp:3112
 msgid "Enable Verbose Debug-Logging."
 msgstr "Abilita il log dettagliato dei messaggi di debug."
 
-#: src/muuli_wdr.cpp:3083
+#: src/muuli_wdr.cpp:3114
 msgid "Only to Logfile"
 msgstr "Solamente sul file di log"
 
-#: src/muuli_wdr.cpp:3085
+#: src/muuli_wdr.cpp:3116
 msgid "Message Categories:"
 msgstr "Categorie messaggi:"
 
-#: src/muuli_wdr.cpp:3109 src/PartFileConvertDlg.cpp:160
+#: src/muuli_wdr.cpp:3140 src/PartFileConvertDlg.cpp:160
 msgid "Waiting..."
 msgstr "In attesa..."
 
-#: src/muuli_wdr.cpp:3129
+#: src/muuli_wdr.cpp:3160
 msgid "Add imports"
 msgstr "Aggiungi importazioni"
 
-#: src/muuli_wdr.cpp:3132
+#: src/muuli_wdr.cpp:3163
 msgid "Retry selected"
 msgstr "Riprova selezionati"
 
-#: src/muuli_wdr.cpp:3134
+#: src/muuli_wdr.cpp:3165
 msgid "Remove selected"
 msgstr "Rimuovi selezionati"
 
-#: src/muuli_wdr.cpp:3197
+#: src/muuli_wdr.cpp:3228
 msgid "Event Types"
 msgstr "Tipi di evento"
 
-#: src/muuli_wdr.cpp:3216
+#: src/muuli_wdr.cpp:3247
 msgid "Statistics and queued clients for selected file(s) : Session / All time"
 msgstr "Statistiche e client in coda per i(l) file selezionati(o) : Sessione / Totale"
 
-#: src/muuli_wdr.cpp:3240
+#: src/muuli_wdr.cpp:3271
 msgid "Active Uploads"
 msgstr "Upload attivi"
 
-#: src/muuli_wdr.cpp:3254
+#: src/muuli_wdr.cpp:3285
 msgid "Percent of total files"
 msgstr "Percentuale di file totali"
 
-#: src/muuli_wdr.cpp:3306
+#: src/muuli_wdr.cpp:3337
 msgid "Show Clients for"
 msgstr "Mostra client per"
 
-#: src/muuli_wdr.cpp:3308
+#: src/muuli_wdr.cpp:3339
 msgid "All files"
 msgstr "Tutti i file"
 
-#: src/muuli_wdr.cpp:3311
+#: src/muuli_wdr.cpp:3342
 msgid "Selected files"
 msgstr "File selezionati"
 
-#: src/muuli_wdr.cpp:3314
+#: src/muuli_wdr.cpp:3345
 msgid "Active uploads only"
 msgstr "Solo upload attivi"
 
-#: src/muuli_wdr.cpp:3321
+#: src/muuli_wdr.cpp:3352
 msgid "Reload:"
 msgstr "Ricarica lista:"
 
-#: src/muuli_wdr.cpp:3325
+#: src/muuli_wdr.cpp:3356
 msgid "Reload your shared files"
 msgstr "Ricarica file condivisi"
 
-#: src/muuli_wdr.cpp:3388
+#: src/muuli_wdr.cpp:3419
 msgid "Send"
 msgstr "Invia"
 
-#: src/muuli_wdr.cpp:3389
+#: src/muuli_wdr.cpp:3420
 msgid "Sends the specified message."
 msgstr "Invia messaggio specificato."
 
-#: src/muuli_wdr.cpp:3393
+#: src/muuli_wdr.cpp:3424
 msgid "Close this chat-session."
 msgstr "Chiude questa sessione di chat."
 
-#: src/muuli_wdr.cpp:3416
+#: src/muuli_wdr.cpp:3447
 msgid "Connect to any server and/or Kad"
 msgstr "Connetti a qualsiasi server e/o a Kad"
 
-#: src/muuli_wdr.cpp:3422 src/SharedFilesCtrl.cpp:142 src/Statistics.cpp:941
+#: src/muuli_wdr.cpp:3453 src/SharedFilesCtrl.cpp:142 src/Statistics.cpp:941
 msgid "Shared Files"
 msgstr "File condivisi"
 
@@ -5435,248 +5463,248 @@ msgstr "Scaricato"
 msgid "ERROR: Failed to open partfile '%s'"
 msgstr "ERRORE: Apertura del file Part fallita '%s'"
 
-#: src/Preferences.cpp:674
+#: src/Preferences.cpp:701
 msgid "System default"
 msgstr "Predefinita di sistema"
 
-#: src/Preferences.cpp:675
+#: src/Preferences.cpp:702
 msgid "Albanian"
 msgstr "Albanese"
 
-#: src/Preferences.cpp:676
+#: src/Preferences.cpp:703
 msgid "Arabic"
 msgstr "Arabo"
 
-#: src/Preferences.cpp:677
+#: src/Preferences.cpp:704
 msgid "Asturian"
 msgstr "Asturiano"
 
-#: src/Preferences.cpp:678
+#: src/Preferences.cpp:705
 msgid "Basque"
 msgstr "Basco"
 
-#: src/Preferences.cpp:679
+#: src/Preferences.cpp:706
 msgid "Bulgarian"
 msgstr "Bulgaro"
 
-#: src/Preferences.cpp:680
+#: src/Preferences.cpp:707
 msgid "Catalan"
 msgstr "Catalano"
 
-#: src/Preferences.cpp:681
+#: src/Preferences.cpp:708
 msgid "Chinese (Simplified)"
 msgstr "Cinese (semplificato)"
 
-#: src/Preferences.cpp:682
+#: src/Preferences.cpp:709
 msgid "Chinese (Traditional)"
 msgstr "Cinese (tradizionale)"
 
-#: src/Preferences.cpp:683
+#: src/Preferences.cpp:710
 msgid "Croatian"
 msgstr "Croato"
 
-#: src/Preferences.cpp:684
+#: src/Preferences.cpp:711
 msgid "Czech"
 msgstr "Ceco"
 
-#: src/Preferences.cpp:685
+#: src/Preferences.cpp:712
 msgid "Danish"
 msgstr "Danese"
 
-#: src/Preferences.cpp:686
+#: src/Preferences.cpp:713
 msgid "Dutch"
 msgstr "Olandese"
 
-#: src/Preferences.cpp:687
+#: src/Preferences.cpp:714
 msgid "English (U.K.)"
 msgstr "Inglese (Regno Unito)"
 
-#: src/Preferences.cpp:688
+#: src/Preferences.cpp:715
 msgid "English (U.S.)"
 msgstr "Inglese (U.S.)"
 
-#: src/Preferences.cpp:689
+#: src/Preferences.cpp:716
 msgid "Estonian"
 msgstr "Estone"
 
-#: src/Preferences.cpp:690
+#: src/Preferences.cpp:717
 msgid "Finnish"
 msgstr "Finlandese"
 
-#: src/Preferences.cpp:691
+#: src/Preferences.cpp:718
 msgid "French"
 msgstr "Francese"
 
-#: src/Preferences.cpp:692
+#: src/Preferences.cpp:719
 msgid "Galician"
 msgstr "Galiziano"
 
-#: src/Preferences.cpp:693
+#: src/Preferences.cpp:720
 msgid "German"
 msgstr "Tedesco"
 
-#: src/Preferences.cpp:694
+#: src/Preferences.cpp:721
 msgid "Greek"
 msgstr "Greco"
 
-#: src/Preferences.cpp:695
+#: src/Preferences.cpp:722
 msgid "Hebrew"
 msgstr "Ebraico"
 
-#: src/Preferences.cpp:696
+#: src/Preferences.cpp:723
 msgid "Hungarian"
 msgstr "Ungherese"
 
-#: src/Preferences.cpp:697
+#: src/Preferences.cpp:724
 msgid "Italian"
 msgstr "Italiano"
 
-#: src/Preferences.cpp:698
+#: src/Preferences.cpp:725
 msgid "Japanese"
 msgstr "Giapponese"
 
-#: src/Preferences.cpp:699
+#: src/Preferences.cpp:726
 msgid "Korean"
 msgstr "Coreano"
 
-#: src/Preferences.cpp:700
+#: src/Preferences.cpp:727
 msgid "Latvian"
 msgstr "Lettone"
 
-#: src/Preferences.cpp:701
+#: src/Preferences.cpp:728
 msgid "Lithuanian"
 msgstr "Lituano"
 
-#: src/Preferences.cpp:702
+#: src/Preferences.cpp:729
 msgid "Norwegian (Nynorsk)"
 msgstr "Norvegese (Nynorsk)"
 
-#: src/Preferences.cpp:703
+#: src/Preferences.cpp:730
 msgid "Polish"
 msgstr "Polacco"
 
-#: src/Preferences.cpp:704
+#: src/Preferences.cpp:731
 msgid "Portuguese"
 msgstr "Portoghese"
 
-#: src/Preferences.cpp:705
+#: src/Preferences.cpp:732
 msgid "Portuguese (Brazilian)"
 msgstr "Portoghese (Brasile)"
 
-#: src/Preferences.cpp:706
+#: src/Preferences.cpp:733
 msgid "Romanian"
 msgstr "Romeno"
 
-#: src/Preferences.cpp:707
+#: src/Preferences.cpp:734
 msgid "Russian"
 msgstr "Russo"
 
-#: src/Preferences.cpp:708
+#: src/Preferences.cpp:735
 msgid "Slovenian"
 msgstr "Sloveno"
 
-#: src/Preferences.cpp:709
+#: src/Preferences.cpp:736
 msgid "Spanish"
 msgstr "Spagnolo"
 
-#: src/Preferences.cpp:710
+#: src/Preferences.cpp:737
 msgid "Swedish"
 msgstr "Svedese"
 
-#: src/Preferences.cpp:711
+#: src/Preferences.cpp:738
 msgid "Turkish"
 msgstr "Turco"
 
-#: src/Preferences.cpp:712
+#: src/Preferences.cpp:739
 msgid "Ukrainian"
 msgstr "Ucraino"
 
-#: src/Preferences.cpp:815
+#: src/Preferences.cpp:842
 msgid "Change Language"
 msgstr "Cambia lingua"
 
-#: src/Preferences.cpp:879
+#: src/Preferences.cpp:906
 msgid "There are no translations installed for aMule"
 msgstr "Non ci sono traduzioni di aMule installate"
 
-#: src/Preferences.cpp:880
+#: src/Preferences.cpp:907
 msgid "No languages available"
 msgstr "Nessuna lingua disponibile"
 
-#: src/Preferences.cpp:1011
+#: src/Preferences.cpp:1038
 msgid "no options available"
 msgstr "nessuna opzione disponibile"
 
-#: src/Preferences.cpp:2182
+#: src/Preferences.cpp:2227
 msgid "Invalid category found, skipping"
 msgstr "Trovata categoria non valida, ignorata"
 
-#: src/Preferences.cpp:2351
+#: src/Preferences.cpp:2396
 msgid "TCP port can't be higher than 65532 due to server UDP socket being TCP+3"
 msgstr "La porta TCP non può essere superiore a 65532 perché il socket UDP è fissato a TCP+3"
 
-#: src/Preferences.cpp:2352
+#: src/Preferences.cpp:2397
 #, c-format
 msgid "Default port will be used (%d)"
 msgstr "Sarà usata la porta predefinita (%d)"
 
-#: src/PrefsUnifiedDlg.cpp:298 src/Statistics.cpp:866
+#: src/PrefsUnifiedDlg.cpp:300 src/Statistics.cpp:866
 msgid "Connection"
 msgstr "Connessione"
 
-#: src/PrefsUnifiedDlg.cpp:299 src/SearchListCtrl.cpp:117
+#: src/PrefsUnifiedDlg.cpp:301 src/SearchListCtrl.cpp:117
 msgid "Directories"
 msgstr "Directory"
 
-#: src/PrefsUnifiedDlg.cpp:300 src/Statistics.cpp:917
+#: src/PrefsUnifiedDlg.cpp:302 src/Statistics.cpp:917
 msgid "Servers"
 msgstr "Server"
 
-#: src/PrefsUnifiedDlg.cpp:301 src/ServerListCtrl.cpp:96
+#: src/PrefsUnifiedDlg.cpp:303 src/ServerListCtrl.cpp:96
 msgid "Files"
 msgstr "File"
 
-#: src/PrefsUnifiedDlg.cpp:302
+#: src/PrefsUnifiedDlg.cpp:304
 msgid "Security"
 msgstr "Sicurezza"
 
-#: src/PrefsUnifiedDlg.cpp:303
+#: src/PrefsUnifiedDlg.cpp:305
 msgid "Interface"
 msgstr "Interfaccia"
 
-#: src/PrefsUnifiedDlg.cpp:310
+#: src/PrefsUnifiedDlg.cpp:312
 msgid "IP2Country"
 msgstr "IP2Country"
 
-#: src/PrefsUnifiedDlg.cpp:313
+#: src/PrefsUnifiedDlg.cpp:315
 msgid "Proxy"
 msgstr "Proxy"
 
-#: src/PrefsUnifiedDlg.cpp:314
+#: src/PrefsUnifiedDlg.cpp:316
 msgid "Filters"
 msgstr "Filtri"
 
-#: src/PrefsUnifiedDlg.cpp:315
+#: src/PrefsUnifiedDlg.cpp:317
 msgid "Remote Controls"
 msgstr "Controlli remoti"
 
-#: src/PrefsUnifiedDlg.cpp:316
+#: src/PrefsUnifiedDlg.cpp:318
 msgid "Online Signature"
 msgstr "Online Signature"
 
-#: src/PrefsUnifiedDlg.cpp:317
+#: src/PrefsUnifiedDlg.cpp:319
 msgid "Advanced"
 msgstr "Avanzato"
 
-#: src/PrefsUnifiedDlg.cpp:318
+#: src/PrefsUnifiedDlg.cpp:320
 msgid "Events"
 msgstr "Eventi"
 
-#: src/PrefsUnifiedDlg.cpp:321
+#: src/PrefsUnifiedDlg.cpp:323
 msgid "Debugging"
 msgstr "Debug"
 
-#: src/PrefsUnifiedDlg.cpp:451
+#: src/PrefsUnifiedDlg.cpp:453
 msgid ""
 "The following variables will be substituted:\n"
 "    %PARTFILE - full path to the file\n"
@@ -5686,15 +5714,15 @@ msgstr ""
 "    %PARTFILE - percorso completo del file\n"
 "    %PARTNAME - solamente il nome del file"
 
-#: src/PrefsUnifiedDlg.cpp:472
+#: src/PrefsUnifiedDlg.cpp:474
 msgid "Tray icon support requires libayatana-appindicator3 at compile time."
 msgstr "Il supporto per l'icona nella tray richiede libayatana-appindicator3 in fase di compilazione."
 
-#: src/PrefsUnifiedDlg.cpp:488
+#: src/PrefsUnifiedDlg.cpp:490
 msgid "Not available on Wayland: the protocol does not report when a window is minimized, so this option cannot intercept the system minimize button. Workaround: launch aMule with `GDK_BACKEND=x11` to use XWayland instead."
 msgstr "Non disponibile su Wayland: il protocollo non segnala quando una finestra viene ridotta a icona, quindi questa opzione non può intercettare il pulsante di riduzione del sistema. Soluzione alternativa: avvia aMule con `GDK_BACKEND=x11` per usare XWayland."
 
-#: src/PrefsUnifiedDlg.cpp:534
+#: src/PrefsUnifiedDlg.cpp:536
 msgid ""
 "Do not change these setting unless you know\n"
 "what you are doing, otherwise you can easily\n"
@@ -5709,26 +5737,35 @@ msgstr ""
 "\n"
 "aMule funzionerà anche senza modificare questi parametri."
 
-#: src/PrefsUnifiedDlg.cpp:645
+#: src/PrefsUnifiedDlg.cpp:647
 #, c-format
 msgid "Failed to connect Cfg to widget with the ID %d and key %s"
 msgstr "Insuccesso nel collegare Cfg al widget con ID %d e chiave %s"
 
-#: src/PrefsUnifiedDlg.cpp:693
+#: src/PrefsUnifiedDlg.cpp:695
 #, c-format
 msgid "Failed to transfer data from Cfg to Widget with the ID %d and key %s"
 msgstr "Insuccesso nel trasferire dati da Cfg al Widget con ID %d e chiave %s"
 
-#: src/PrefsUnifiedDlg.cpp:799
+#: src/PrefsUnifiedDlg.cpp:801
 msgid "The type of proxy you are connecting to"
 msgstr "Il tipo di proxy a cui ti stai connettendo"
 
-#: src/PrefsUnifiedDlg.cpp:1003
+#: src/PrefsUnifiedDlg.cpp:1020
 #, c-format
 msgid "Failed to transfer data from Widget to Cfg with the ID %d and key %s"
 msgstr "Insuccesso nel trasferire dati dal widget al Cfg con ID %d e chiave %s"
 
 #: src/PrefsUnifiedDlg.cpp:1103
+#, fuzzy
+msgid "No password set."
+msgstr "Password amministrazione"
+
+#: src/PrefsUnifiedDlg.cpp:1132
+msgid "Guest access needs a password. Type one in the guest password field, or untick Enable guest access."
+msgstr ""
+
+#: src/PrefsUnifiedDlg.cpp:1144
 msgid ""
 "aMule must be restarted to enable these changes:\n"
 "\n"
@@ -5736,39 +5773,39 @@ msgstr ""
 "aMule deve essere riavviato per rendere effettive queste modifiche:\n"
 "\n"
 
-#: src/PrefsUnifiedDlg.cpp:1110
+#: src/PrefsUnifiedDlg.cpp:1151
 msgid "- TCP port changed.\n"
 msgstr "- Modifica della porta TCP.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1115
+#: src/PrefsUnifiedDlg.cpp:1156
 msgid "- UDP port changed.\n"
 msgstr "- Modifica della porta UDP.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1120
+#: src/PrefsUnifiedDlg.cpp:1161
 msgid "- Network interface binding changed.\n"
 msgstr "- Associazione all'interfaccia di rete modificata.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1125
+#: src/PrefsUnifiedDlg.cpp:1166
 msgid "- External connect port changed.\n"
 msgstr "- Porta della connessione esterna modificata. \n"
 
-#: src/PrefsUnifiedDlg.cpp:1129
+#: src/PrefsUnifiedDlg.cpp:1170
 msgid "- External connect acceptance changed.\n"
 msgstr "- Accetta connessione esterna modificata. \n"
 
-#: src/PrefsUnifiedDlg.cpp:1133
+#: src/PrefsUnifiedDlg.cpp:1174
 msgid "- External connect interface changed.\n"
 msgstr "- Interfaccia connessione esterna modificata. \n"
 
-#: src/PrefsUnifiedDlg.cpp:1137
+#: src/PrefsUnifiedDlg.cpp:1178
 msgid "- Protocol obfuscation support changed.\n"
 msgstr "- Modificato il supporto all'offuscamento del protocollo.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1151
+#: src/PrefsUnifiedDlg.cpp:1193
 msgid "- amuleapi settings changed.\n"
 msgstr "- configurazione di amuleapi modificata.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1160
+#: src/PrefsUnifiedDlg.cpp:1202
 msgid ""
 "Your Auto-update server list is empty.\n"
 "'Auto-update server list at startup' will be disabled."
@@ -5776,7 +5813,7 @@ msgstr ""
 "La tua lista dei server per l'aggiornamento automatico è vuota.\n"
 "L'aggiornamento automatico all'avvio sarà disattivato."
 
-#: src/PrefsUnifiedDlg.cpp:1171
+#: src/PrefsUnifiedDlg.cpp:1213
 msgid ""
 "You have enabled external connections but have not specified a password.\n"
 "External connections cannot be enabled unless a valid password is specified."
@@ -5784,27 +5821,32 @@ msgstr ""
 "Hai abilitato le connessioni esterne senza però specificare una password.\n"
 "Le connessioni esterne non possono essere abilitate a meno che tu non scelga una password valida."
 
-#: src/PrefsUnifiedDlg.cpp:1202
+#: src/PrefsUnifiedDlg.cpp:1246
+#, c-format
+msgid "The amuleapi password could not be saved: %s"
+msgstr ""
+
+#: src/PrefsUnifiedDlg.cpp:1276
 msgid "- Language changed.\n"
 msgstr "- Modifica della lingua.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1207
+#: src/PrefsUnifiedDlg.cpp:1281
 msgid "- Temp folder changed.\n"
 msgstr "- Modifica della cartella Temp.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1212
+#: src/PrefsUnifiedDlg.cpp:1286
 msgid "- ED2K network enabled.\n"
 msgstr "- Rete ed2k abilitata.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1245
+#: src/PrefsUnifiedDlg.cpp:1319
 msgid "The shared-file exclusion pattern is not a valid regular expression. The filter has been left disabled."
 msgstr "Il pattern di esclusione dei file condivisi non è un'espressione regolare valida. Il filtro è stato lasciato disattivato."
 
-#: src/PrefsUnifiedDlg.cpp:1247 src/PrefsUnifiedDlg.cpp:1841
+#: src/PrefsUnifiedDlg.cpp:1321 src/PrefsUnifiedDlg.cpp:1921
 msgid "Invalid regular expression"
 msgstr "Espressione regolare non valida"
 
-#: src/PrefsUnifiedDlg.cpp:1324
+#: src/PrefsUnifiedDlg.cpp:1398
 msgid ""
 "Both eD2k and Kad network are disabled.\n"
 "You won't be able to connect until you enable at least one of them."
@@ -5812,7 +5854,7 @@ msgstr ""
 "Le reti eD2k e Kad sono entrambe disabilitate.\n"
 "Non potrai connetterti finché non ne abiliterai almeno una."
 
-#: src/PrefsUnifiedDlg.cpp:1329
+#: src/PrefsUnifiedDlg.cpp:1403
 msgid ""
 "Kad will not start if your UDP port is disabled.\n"
 "Enable UDP port or disable Kad."
@@ -5820,7 +5862,7 @@ msgstr ""
 "Kad non può partire se la porta UDP è disabilitata.\n"
 "Abilitala o disabilita Kad."
 
-#: src/PrefsUnifiedDlg.cpp:1385
+#: src/PrefsUnifiedDlg.cpp:1459
 msgid ""
 "\n"
 "You MUST restart aMule now.\n"
@@ -5830,68 +5872,68 @@ msgstr ""
 "DEVI riavviare aMule ADESSO.\n"
 "Se non lo fai, non lamentarti se succede qualcosa di strano.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1450
+#: src/PrefsUnifiedDlg.cpp:1524
 msgid "Could not register aMule for autostart at login. The autostart store may be read-only."
 msgstr "Impossibile registrare aMule per l'avvio automatico all'accesso. L'archivio di avvio automatico potrebbe essere in sola lettura."
 
-#: src/PrefsUnifiedDlg.cpp:1452
+#: src/PrefsUnifiedDlg.cpp:1526
 msgid "Could not remove the autostart-at-login entry."
 msgstr "Impossibile rimuovere la voce di avvio automatico all'accesso."
 
-#: src/PrefsUnifiedDlg.cpp:1453
+#: src/PrefsUnifiedDlg.cpp:1527
 msgid "Autostart"
 msgstr "Avvio automatico"
 
-#: src/PrefsUnifiedDlg.cpp:1468
+#: src/PrefsUnifiedDlg.cpp:1542
 msgid "Register file type"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1468
+#: src/PrefsUnifiedDlg.cpp:1542
 msgid "Register URL handler"
 msgstr "Registra gestore URL"
 
-#: src/PrefsUnifiedDlg.cpp:1476
+#: src/PrefsUnifiedDlg.cpp:1550
 #, c-format
 msgid "aMule only handles eD2k-compatible magnets. If you replace the current magnet handler (%s), BitTorrent magnet links will stop working - aMule cannot download BitTorrent content. Continue?"
 msgstr "aMule gestisce solo i magnet compatibili con eD2k. Se sostituisci il gestore magnet attuale (%s), i link magnet BitTorrent smetteranno di funzionare: aMule non può scaricare contenuti BitTorrent. Continuare?"
 
-#: src/PrefsUnifiedDlg.cpp:1481
+#: src/PrefsUnifiedDlg.cpp:1555
 #, fuzzy, c-format
 msgid "Another application currently opens .emulecollection files (%s). Replace it with aMule?"
 msgstr "Attualmente un'altra applicazione è il gestore predefinito per questi link (%s). Sostituirla con aMule?"
 
-#: src/PrefsUnifiedDlg.cpp:1486
+#: src/PrefsUnifiedDlg.cpp:1560
 #, c-format
 msgid "Another application is currently the default handler for these links (%s). Replace it with aMule?"
 msgstr "Attualmente un'altra applicazione è il gestore predefinito per questi link (%s). Sostituirla con aMule?"
 
-#: src/PrefsUnifiedDlg.cpp:1511
+#: src/PrefsUnifiedDlg.cpp:1585
 #, fuzzy
 msgid "Could not register aMule for .emulecollection files. The registration store may be read-only."
 msgstr "Impossibile registrare aMule come gestore URL. Il registro delle associazioni potrebbe essere in sola lettura."
 
-#: src/PrefsUnifiedDlg.cpp:1513
+#: src/PrefsUnifiedDlg.cpp:1587
 #, fuzzy
 msgid "Could not remove the file type registration."
 msgstr "Impossibile rimuovere la registrazione del gestore URL."
 
-#: src/PrefsUnifiedDlg.cpp:1515
+#: src/PrefsUnifiedDlg.cpp:1589
 msgid "Could not register aMule as the URL handler. The registration store may be read-only."
 msgstr "Impossibile registrare aMule come gestore URL. Il registro delle associazioni potrebbe essere in sola lettura."
 
-#: src/PrefsUnifiedDlg.cpp:1517
+#: src/PrefsUnifiedDlg.cpp:1591
 msgid "Could not remove the URL handler registration."
 msgstr "Impossibile rimuovere la registrazione del gestore URL."
 
-#: src/PrefsUnifiedDlg.cpp:1587 src/PrefsUnifiedDlg.cpp:1614
+#: src/PrefsUnifiedDlg.cpp:1661 src/PrefsUnifiedDlg.cpp:1688
 msgid "The web server and aMule API require external connections to be enabled."
 msgstr "Il server web e aMule API richiedono che le connessioni esterne siano abilitate."
 
-#: src/PrefsUnifiedDlg.cpp:1597
+#: src/PrefsUnifiedDlg.cpp:1671
 msgid "The aMule web server is deprecated. Consider running the aMule API instead."
 msgstr "Il server web di aMule è deprecato. Valuta in alternativa l'uso di aMule API."
 
-#: src/PrefsUnifiedDlg.cpp:1655
+#: src/PrefsUnifiedDlg.cpp:1735
 msgid ""
 "Your Auto-update servers list is in blank.\n"
 "Please fill in at least one URL to point to a valid server.met file.\n"
@@ -5901,64 +5943,64 @@ msgstr ""
 "Inserisci l'URL di almeno un server valido nel file server.met.\n"
 "Clicca sul pulsante \"Lista\" per inserire l'URL."
 
-#: src/PrefsUnifiedDlg.cpp:1796
+#: src/PrefsUnifiedDlg.cpp:1876
 msgid "Temporary files"
 msgstr "File temporanei"
 
-#: src/PrefsUnifiedDlg.cpp:1801
+#: src/PrefsUnifiedDlg.cpp:1881
 msgid "Incoming files"
 msgstr "File completi"
 
-#: src/PrefsUnifiedDlg.cpp:1806
+#: src/PrefsUnifiedDlg.cpp:1886
 msgid "Online Signatures"
 msgstr "Online Signature"
 
-#: src/PrefsUnifiedDlg.cpp:1819
+#: src/PrefsUnifiedDlg.cpp:1899
 #, c-format
 msgid "Choose a folder for %s"
 msgstr "Scegli una directory per i %s"
 
-#: src/PrefsUnifiedDlg.cpp:1843
+#: src/PrefsUnifiedDlg.cpp:1923
 #, c-format
 msgid "Would exclude %u of %u shared file"
 msgid_plural "Would exclude %u of %u shared files"
 msgstr[0] "Escluderebbe %u di %u file condiviso"
 msgstr[1] "Escluderebbe %u di %u file condivisi"
 
-#: src/PrefsUnifiedDlg.cpp:1860
+#: src/PrefsUnifiedDlg.cpp:1940
 msgid "Browse for videoplayer"
 msgstr "Sfoglia per trovare un riproduttore video"
 
-#: src/PrefsUnifiedDlg.cpp:1864
+#: src/PrefsUnifiedDlg.cpp:1944
 msgid "Select browser"
 msgstr "Scegli browser"
 
-#: src/PrefsUnifiedDlg.cpp:1868
+#: src/PrefsUnifiedDlg.cpp:1948
 msgid "Select ffprobe binary"
 msgstr "Seleziona il binario ffprobe"
 
-#: src/PrefsUnifiedDlg.cpp:1874
+#: src/PrefsUnifiedDlg.cpp:1954
 #, c-format
 msgid "Executable%s"
 msgstr "Eseguibile%s"
 
-#: src/PrefsUnifiedDlg.cpp:1908
+#: src/PrefsUnifiedDlg.cpp:1988
 msgid "ffprobe not found on PATH or in the standard install locations. Install ffmpeg (which ships ffprobe) or use Browse to pick a binary manually."
 msgstr "ffprobe non trovato nel PATH né nei percorsi di installazione standard. Installa ffmpeg (che include ffprobe) oppure usa Sfoglia per selezionare manualmente un binario."
 
-#: src/PrefsUnifiedDlg.cpp:1920
+#: src/PrefsUnifiedDlg.cpp:2000
 msgid "Reset the settings on this page to their default values?"
 msgstr "Ripristinare le impostazioni di questa pagina ai loro valori predefiniti?"
 
-#: src/PrefsUnifiedDlg.cpp:1921
+#: src/PrefsUnifiedDlg.cpp:2001
 msgid "Reset to defaults"
 msgstr "Ripristina i valori predefiniti"
 
-#: src/PrefsUnifiedDlg.cpp:1948
+#: src/PrefsUnifiedDlg.cpp:2028
 msgid "Edit server list"
 msgstr "Modifica la lista dei server"
 
-#: src/PrefsUnifiedDlg.cpp:1949
+#: src/PrefsUnifiedDlg.cpp:2029
 msgid ""
 "Add here URL's to download server.met files.\n"
 "Only one url on each line."
@@ -5966,114 +6008,114 @@ msgstr ""
 "Inserisci l'URL da cui scaricare il file server.met.\n"
 "Solo un URL per riga."
 
-#: src/PrefsUnifiedDlg.cpp:2004
+#: src/PrefsUnifiedDlg.cpp:2084
 msgid "IP2Country update failed"
 msgstr "Aggiornamento IP2Country fallito"
 
-#: src/PrefsUnifiedDlg.cpp:2149 src/PrefsUnifiedDlg.cpp:2180
+#: src/PrefsUnifiedDlg.cpp:2229 src/PrefsUnifiedDlg.cpp:2260
 msgid "Data by MaxMind GeoLite2"
 msgstr "Dati di MaxMind GeoLite2"
 
-#: src/PrefsUnifiedDlg.cpp:2151 src/PrefsUnifiedDlg.cpp:2182
+#: src/PrefsUnifiedDlg.cpp:2231 src/PrefsUnifiedDlg.cpp:2262
 msgid "Custom source"
 msgstr "Sorgente personalizzata"
 
-#: src/PrefsUnifiedDlg.cpp:2153 src/PrefsUnifiedDlg.cpp:2184
+#: src/PrefsUnifiedDlg.cpp:2233 src/PrefsUnifiedDlg.cpp:2264
 msgid "Data by DB-IP.com"
 msgstr "Dati di DB-IP.com"
 
-#: src/PrefsUnifiedDlg.cpp:2204
+#: src/PrefsUnifiedDlg.cpp:2284
 #, c-format
 msgid "Status: Loaded%s"
 msgstr "Stato: Caricato%s"
 
-#: src/PrefsUnifiedDlg.cpp:2206
+#: src/PrefsUnifiedDlg.cpp:2286
 #, c-format
 msgid "Status: Loaded%s - %s"
 msgstr "Stato: Caricato%s - %s"
 
-#: src/PrefsUnifiedDlg.cpp:2210
+#: src/PrefsUnifiedDlg.cpp:2290
 msgid "Status: Failed to load - click 'Update now' to refresh."
 msgstr "Stato: Caricamento fallito - clicca su 'Aggiorna ora' per ricaricare."
 
-#: src/PrefsUnifiedDlg.cpp:2212
+#: src/PrefsUnifiedDlg.cpp:2292
 msgid "Status: Not found - click 'Update now' to download."
 msgstr "Stato: Non trovato - clicca su 'Aggiorna ora' per scaricare."
 
-#: src/PrefsUnifiedDlg.cpp:2270 src/PrefsUnifiedDlg.cpp:2294
+#: src/PrefsUnifiedDlg.cpp:2350 src/PrefsUnifiedDlg.cpp:2374
 #, c-format
 msgid "Update delay: %d second"
 msgid_plural "Update delay: %d seconds"
 msgstr[0] "Intervallo aggiornamento: %d secondo"
 msgstr[1] "Intervallo aggiornamento: %d secondi"
 
-#: src/PrefsUnifiedDlg.cpp:2278
+#: src/PrefsUnifiedDlg.cpp:2358
 #, c-format
 msgid "Time for average graph: %d minute"
 msgid_plural "Time for average graph: %d minutes"
 msgstr[0] "Intervallo grafico della media: %d minuto"
 msgstr[1] "Intervallo grafico della media: %d minuti"
 
-#: src/PrefsUnifiedDlg.cpp:2287
+#: src/PrefsUnifiedDlg.cpp:2367
 #, c-format
 msgid "Connections Graph Scale: %d"
 msgstr "Scala grafico delle connessioni: %d"
 
-#: src/PrefsUnifiedDlg.cpp:2302
+#: src/PrefsUnifiedDlg.cpp:2382
 #, c-format
 msgid "File Buffer Size: %d byte"
 msgid_plural "File Buffer Size: %d bytes"
 msgstr[0] "Dimensione buffer file: %d byte"
 msgstr[1] "Dimensione buffer file: %d bytes"
 
-#: src/PrefsUnifiedDlg.cpp:2312
+#: src/PrefsUnifiedDlg.cpp:2392
 #, c-format
 msgid "Upload Queue Size: %d client"
 msgid_plural "Upload Queue Size: %d clients"
 msgstr[0] "Dimensione coda upload: %d client"
 msgstr[1] "Dimensione coda upload: %d client"
 
-#: src/PrefsUnifiedDlg.cpp:2322
+#: src/PrefsUnifiedDlg.cpp:2402
 #, c-format
 msgid "Server connection refresh interval: %d minute"
 msgid_plural "Server connection refresh interval: %d minutes"
 msgstr[0] "Intervallo aggiornamento connessione ai server: %d minuto"
 msgstr[1] "Intervallo aggiornamento connessione ai server: %d minuti"
 
-#: src/PrefsUnifiedDlg.cpp:2327
+#: src/PrefsUnifiedDlg.cpp:2407
 msgid "Server connection refresh interval: Disabled"
 msgstr "Intervallo aggiornamento connessione ai server: disabilitato"
 
-#: src/PrefsUnifiedDlg.cpp:2371
+#: src/PrefsUnifiedDlg.cpp:2451
 msgid "disabled"
 msgstr "disattivato"
 
-#: src/PrefsUnifiedDlg.cpp:2397
+#: src/PrefsUnifiedDlg.cpp:2477
 #, c-format
 msgid "Execute command on '%s' event"
 msgstr "Esegui comando se si verifica l'evento '%s'"
 
-#: src/PrefsUnifiedDlg.cpp:2404
+#: src/PrefsUnifiedDlg.cpp:2484
 msgid "Enable command execution on core"
 msgstr "Abilita l'esecuzione del comando sul core"
 
-#: src/PrefsUnifiedDlg.cpp:2416
+#: src/PrefsUnifiedDlg.cpp:2496
 msgid "Core command:"
 msgstr "Comando Core:"
 
-#: src/PrefsUnifiedDlg.cpp:2432
+#: src/PrefsUnifiedDlg.cpp:2512
 msgid "Enable command execution on GUI"
 msgstr "Abilita l'esecuzione del comando sulla GUI"
 
-#: src/PrefsUnifiedDlg.cpp:2444
+#: src/PrefsUnifiedDlg.cpp:2524
 msgid "GUI command:"
 msgstr "Comando GUI:"
 
-#: src/PrefsUnifiedDlg.cpp:2460
+#: src/PrefsUnifiedDlg.cpp:2540
 msgid "The following variables will be replaced:"
 msgstr "Le seguenti variabili saranno sostituite:"
 
-#: src/PrefsUnifiedDlg.cpp:2628
+#: src/PrefsUnifiedDlg.cpp:2708
 msgid ""
 "The following folders look like system or sensitive locations:\n"
 "\n"
@@ -6081,37 +6123,37 @@ msgstr ""
 "Le seguenti cartelle sembrano posizioni di sistema o sensibili:\n"
 "\n"
 
-#: src/PrefsUnifiedDlg.cpp:2633
+#: src/PrefsUnifiedDlg.cpp:2713
 msgid "Sharing them recursively will publish every file underneath on the eD2k/Kad networks. Do you really want to do this?"
 msgstr "Condividerle ricorsivamente pubblicherà ogni file al loro interno sulle reti eD2k/Kad. Vuoi davvero procedere?"
 
-#: src/PrefsUnifiedDlg.cpp:2636
+#: src/PrefsUnifiedDlg.cpp:2716
 msgid "Confirm shared folders"
 msgstr "Conferma cartelle condivise"
 
-#: src/PrefsUnifiedDlg.cpp:2664
+#: src/PrefsUnifiedDlg.cpp:2744
 msgid "Reloading shared files..."
 msgstr "Ricarica file condivisi in corso..."
 
-#: src/PrefsUnifiedDlg.cpp:2665
+#: src/PrefsUnifiedDlg.cpp:2745
 msgid "Scanning for subdirectories..."
 msgstr "Analisi delle sottocartelle in corso..."
 
-#: src/PrefsUnifiedDlg.cpp:2666
+#: src/PrefsUnifiedDlg.cpp:2746
 msgid "Updating shared folders"
 msgstr "Aggiornamento cartelle condivise"
 
-#: src/PrefsUnifiedDlg.cpp:2693
+#: src/PrefsUnifiedDlg.cpp:2773
 #, c-format
 msgid "Scanned %u directories..."
 msgstr "%u cartelle analizzate..."
 
-#: src/PrefsUnifiedDlg.cpp:2743
+#: src/PrefsUnifiedDlg.cpp:2823
 #, c-format
 msgid "Reloading shared files: %u files scanned"
 msgstr "Ricarica file condivisi: %u file analizzati"
 
-#: src/PrefsUnifiedDlg.cpp:2793
+#: src/PrefsUnifiedDlg.cpp:2873
 msgid "Shared folder"
 msgstr "Cartella condivisa"
 

--- a/po/ja.po
+++ b/po/ja.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-28 10:19+0200\n"
+"POT-Creation-Date: 2026-07-28 12:17+0200\n"
 "PO-Revision-Date: 2026-07-27 11:41+0000\n"
 "Last-Translator: \n"
 "Language-Team: Japanese\n"
@@ -200,160 +200,160 @@ msgstr "%s（%s）を開くことはできませんでした"
 msgid "WARNING: You can't add yourself as a source for an eD2k link while having a lowid."
 msgstr ""
 
-#: src/amule.cpp:300
+#: src/amule.cpp:301
 #, fuzzy
 msgid "Now, exiting main app..."
 msgstr ""
 "\n"
 "OK、%s を終了中です...\n"
 
-#: src/amule.cpp:330
+#: src/amule.cpp:331
 #, c-format
 msgid "Terminating amuleweb instance with pid '%d' ... "
 msgstr ""
 
-#: src/amule.cpp:334
+#: src/amule.cpp:335
 #, c-format
 msgid "Killing amuleweb instance with pid '%d' ... "
 msgstr ""
 
-#: src/amule.cpp:336 src/amule.cpp:349 src/ClientRef.cpp:180
+#: src/amule.cpp:337 src/amule.cpp:350 src/ClientRef.cpp:180
 #: src/SearchDlg.cpp:1041 src/ServerListCtrl.cpp:98
 msgid "Failed"
 msgstr "失敗しました"
 
-#: src/amule.cpp:343
+#: src/amule.cpp:344
 #, c-format
 msgid "Terminating amuleapi instance with pid '%d' ... "
 msgstr ""
 
-#: src/amule.cpp:347
+#: src/amule.cpp:348
 #, c-format
 msgid "Killing amuleapi instance with pid '%d' ... "
 msgstr ""
 
-#: src/amule.cpp:355
+#: src/amule.cpp:356
 msgid "aMule OnExit: Terminating core."
 msgstr ""
 
-#: src/amule.cpp:466
+#: src/amule.cpp:467
 #, fuzzy
 msgid "aMule shutdown completed."
 msgstr "ダウンロード完了"
 
-#: src/amule.cpp:470
+#: src/amule.cpp:471
 msgid "Memory debug results for aMule exit:"
 msgstr ""
 
-#: src/amule.cpp:651
+#: src/amule.cpp:652
 #, c-format
 msgid "Binding aMule's peer-to-peer traffic to interface: %s (HTTP updates use the default route)"
 msgstr ""
 
-#: src/amule.cpp:655
+#: src/amule.cpp:656
 #, c-format
 msgid "Binding all network traffic to interface: %s"
 msgstr ""
 
-#: src/amule.cpp:659
+#: src/amule.cpp:660
 #, c-format
 msgid "WARNING: configured network interface '%s' was not found - traffic is NOT bound to it and may leave via the default route. Check the interface name in Preferences."
 msgstr ""
 
-#: src/amule.cpp:665
+#: src/amule.cpp:666
 #, c-format
 msgid "WARNING: binding to network interface '%s' requires elevated privileges and was NOT applied - traffic may leave via the default route. Grant the capability (e.g. 'sudo setcap cap_net_raw+ep' on the aMule binary) or run with sufficient privileges."
 msgstr ""
 
-#: src/amule.cpp:673
+#: src/amule.cpp:674
 #, c-format
 msgid "WARNING: could not bind to network interface '%s' - traffic may leave via the default route."
 msgstr ""
 
-#: src/amule.cpp:732
+#: src/amule.cpp:733
 msgid "Your locale has been changed to System Default due to a configuration change. Sorry."
 msgstr "申し訳ありませんが、設定の変更を行ったため、あなたのロケールはシステム標準に変更されました。"
 
-#: src/amule.cpp:734 src/amule.cpp:1581 src/CatDialog.cpp:128
+#: src/amule.cpp:735 src/amule.cpp:1589 src/CatDialog.cpp:128
 #: src/CatDialog.cpp:136 src/CatDialog.cpp:149 src/ServerList.cpp:366
 #: src/ServerListCtrl.cpp:152
 msgid "Info"
 msgstr "情報"
 
-#: src/amule.cpp:741
+#: src/amule.cpp:742
 #, fuzzy
 msgid ""
 "\n"
 "EC configuration"
 msgstr "終了の確認"
 
-#: src/amule.cpp:744
+#: src/amule.cpp:745
 #, fuzzy
 msgid "Password set and external connections enabled."
 msgstr "新しい外部接続を認められました"
 
-#: src/amule.cpp:754 src/KadDlg.cpp:176 src/KadDlg.cpp:185
-#: src/PrefsUnifiedDlg.cpp:1387 src/SharedFilesCtrl.cpp:476
+#: src/amule.cpp:755 src/KadDlg.cpp:176 src/KadDlg.cpp:185
+#: src/PrefsUnifiedDlg.cpp:1461 src/SharedFilesCtrl.cpp:476
 msgid "WARNING"
 msgstr "警告"
 
-#: src/amule.cpp:991
+#: src/amule.cpp:992
 #, fuzzy
 msgid "Network bootstrap"
 msgstr "ネットワーク"
 
-#: src/amule.cpp:996
+#: src/amule.cpp:997
 msgid ""
 "aMule has detected missing network bootstrap files.\n"
 "Select which ones to download:"
 msgstr ""
 
-#: src/amule.cpp:1005 src/FirstRunWizard.cpp:411
+#: src/amule.cpp:1006 src/FirstRunWizard.cpp:411
 #, fuzzy
 msgid "eD2k server list (server.met)"
 msgstr "server.metに%i個のサーバが見つかりました"
 
-#: src/amule.cpp:1012 src/FirstRunWizard.cpp:416
+#: src/amule.cpp:1013 src/FirstRunWizard.cpp:416
 msgid "Kad bootstrap nodes (nodes.dat)"
 msgstr ""
 
-#: src/amule.cpp:1102
+#: src/amule.cpp:1103
 #, c-format
 msgid "web server running on pid %d"
 msgstr ""
 
-#: src/amule.cpp:1115
+#: src/amule.cpp:1116
 msgid "You requested to run web server on startup, but the amuleweb binary cannot be run. Please install the package containing aMule web server, or build aMule from source with -DBUILD_WEBSERVER=YES and install it."
 msgstr ""
 
-#: src/amule.cpp:1120 src/amule.cpp:1177 src/amule.cpp:1291 src/amule.cpp:1593
+#: src/amule.cpp:1121 src/amule.cpp:1185 src/amule.cpp:1299 src/amule.cpp:1601
 #: src/amule-remote-gui.cpp:603 src/amule-remote-gui.cpp:671
 #: src/amule-remote-gui.cpp:709 src/amule-remote-gui.cpp:1282
 #: src/amule-remote-gui.cpp:1345 src/amule-remote-gui.cpp:1372
-#: src/DownloadQueue.cpp:1481
+#: src/DownloadQueue.cpp:1481 src/PrefsUnifiedDlg.cpp:1247
 msgid "ERROR"
 msgstr ""
 
-#: src/amule.cpp:1166
+#: src/amule.cpp:1174
 #, fuzzy, c-format
 msgid "amuleapi running on pid %d"
 msgstr "aMuleは動作しています"
 
-#: src/amule.cpp:1172
+#: src/amule.cpp:1180
 msgid "You requested to run amuleapi on startup, but the amuleapi binary cannot be run. Please install the package containing aMule's REST API server, or build aMule from source with -DBUILD_AMULEAPI=YES and install it."
 msgstr ""
 
-#: src/amule.cpp:1259
+#: src/amule.cpp:1267
 #, c-format
 msgid "Could not bind ports to the specified address: %s"
 msgstr "指定したアドレスにポートをバインドできませんでした: %s"
 
-#: src/amule.cpp:1283
+#: src/amule.cpp:1291
 #, c-format
 msgid "Port %u is not available. You will be LOWID\n"
 msgstr "ポート%uは利用できません。あなたにはLOWIDが与えられます\n"
 
-#: src/amule.cpp:1288
+#: src/amule.cpp:1296
 #, c-format
 msgid ""
 "Port %u is not available!\n"
@@ -368,48 +368,48 @@ msgstr ""
 "\n"
 "ネットワークを調べ、ポートが入出力に対して開いているか確認してください。"
 
-#: src/amule.cpp:1385
+#: src/amule.cpp:1393
 msgid "Failed to create OnlineSig File"
 msgstr "オンライン証明ファイルの生成に失敗しました"
 
-#: src/amule.cpp:1393
+#: src/amule.cpp:1401
 msgid "Failed to create aMule OnlineSig File"
 msgstr "aMuleのオンライン証明ファイルの生成に失敗しました"
 
-#: src/amule.cpp:1556
+#: src/amule.cpp:1564
 msgid "The selected locale seems not to be installed on your box. (Note: I'll try to set it anyway)"
 msgstr "選択したロケールはあなたのシステムにインストールされていないようです。（注意：いずれにせよ設定を試みます）"
 
-#: src/amule.cpp:1566
+#: src/amule.cpp:1574
 #, c-format
 msgid "This is the first time you run aMule %s"
 msgstr "初めてaMule %sを起動しています"
 
-#: src/amule.cpp:1569
+#: src/amule.cpp:1577
 msgid "This version is a testing version, updated daily, and\n"
 msgstr "このバージョンはテスト・バージョンで、毎日更新されているものです。\n"
 
-#: src/amule.cpp:1570
+#: src/amule.cpp:1578
 msgid "we give no warranty it won't break anything, burn your house,\n"
 msgstr "あなたに損害を与えないということは保証できません。家を焼いてしまうかも知れないし、\n"
 
-#: src/amule.cpp:1571
+#: src/amule.cpp:1579
 msgid "or kill your dog. But it *should* be safe to use anyway.\n"
 msgstr "犬を殺してしまうかも知れません。しかし、安全に使用できる「はず」です。\n"
 
-#: src/amule.cpp:1576
+#: src/amule.cpp:1584
 msgid "More information, support and new releases can found at our homepage,\n"
 msgstr "私たちのホームページamule-org.github.io、またはIRCチャネルirc.libera.chatの#aMuleには、\n"
 
-#: src/amule.cpp:1577
+#: src/amule.cpp:1585
 msgid "at https://amule-org.github.io, or in our IRC channel #aMule at irc.libera.chat.\n"
 msgstr "詳細な情報、サポートや新しいリリースがあります。\n"
 
-#: src/amule.cpp:1579
+#: src/amule.cpp:1587
 msgid "Feel free to report any bugs to https://github.com/amule-org/amule/issues"
 msgstr "バグはhttps://github.com/amule-org/amule/issuesに気楽に報告してください"
 
-#: src/amule.cpp:1591
+#: src/amule.cpp:1599
 msgid ""
 "The folder for Online Signature files you specified is INVALID!\n"
 " OnlineSignature will be DISABLED until you fix it on preferences."
@@ -417,138 +417,138 @@ msgstr ""
 "あなたが指定したオンライン証明ファイルのフォルダは不正です！\n"
 "設定で訂正するまでオンライン証明を無効にします。"
 
-#: src/amule.cpp:1654
+#: src/amule.cpp:1662
 #, fuzzy
 msgid "Server hostname notified"
 msgstr "サーバ名："
 
-#: src/amule.cpp:2031
+#: src/amule.cpp:2039
 #, c-format
 msgid "Disk space preallocation for file '%s' failed: %s"
 msgstr "ファイル '%s' のディスク領域の事前確保が失敗しました: %s"
 
-#: src/amule.cpp:2160
+#: src/amule.cpp:2168
 msgid "ERROR: can't open logfile"
 msgstr "エラー：ログファイルを開くことはできません"
 
-#: src/amule.cpp:2164
+#: src/amule.cpp:2172
 msgid "WARNING: logfile is empty. Something is wrong."
 msgstr "注意：ログファイルは空です。何かがおかしいです。"
 
-#: src/amule.cpp:2181
+#: src/amule.cpp:2189
 msgid "Log has been reset"
 msgstr "ログはリセットされました"
 
-#: src/amule.cpp:2205
+#: src/amule.cpp:2213
 #, c-format
 msgid "ServerMessage: %s"
 msgstr "サーバ・メッセージ：%s"
 
-#: src/amule.cpp:2248 src/IP2Country.cpp:220 src/IPFilter.cpp:514
+#: src/amule.cpp:2256 src/IP2Country.cpp:220 src/IPFilter.cpp:514
 #: src/ServerList.cpp:875
 #, c-format
 msgid "Skipped download of %s, because requested file is not newer."
 msgstr ""
 
-#: src/amule.cpp:2251
+#: src/amule.cpp:2259
 msgid "Failed to download the nodes list."
 msgstr "ノード・リストをダウンロードのに失敗しました。"
 
-#: src/amule.cpp:2314
+#: src/amule.cpp:2322
 msgid "Failed to open the downloaded version check file"
 msgstr "ダウンロードされたバージョン確認ファイルを開くのに失敗しました。"
 
-#: src/amule.cpp:2317 src/amule.cpp:2336
+#: src/amule.cpp:2325 src/amule.cpp:2344
 msgid "Corrupted version check file"
 msgstr "破損されたバージョン確認ファイル"
 
-#: src/amule.cpp:2359
+#: src/amule.cpp:2367
 msgid "You are using an outdated version of aMule!"
 msgstr "あなたは古いバージョンのaMuleを使用しています！"
 
-#: src/amule.cpp:2361
+#: src/amule.cpp:2369
 #, c-format
 msgid "Your aMule version is %i.%i.%i and the latest version is %li.%li.%li"
 msgstr "あなたのaMuleバージョンは%i.%i.%iで、最新バージョンは%li.%li.%liです"
 
-#: src/amule.cpp:2365
+#: src/amule.cpp:2373
 msgid "The latest version can always be found at https://github.com/amule-org/amule/releases/latest"
 msgstr "最新バージョンはいつもhttps://github.com/amule-org/amule/releases/latestにあります"
 
-#: src/amule.cpp:2368
+#: src/amule.cpp:2376
 #, c-format
 msgid "WARNING: Your aMuled version is outdated: %i.%i.%i < %li.%li.%li"
 msgstr "警告：あなたのaMuledバージョンは古くなっています：%i.%i.%i < %li.%li.%li"
 
-#: src/amule.cpp:2374
+#: src/amule.cpp:2382
 msgid "Your copy of aMule is up to date."
 msgstr "あなたのaMuleは最新のバージョンです。"
 
-#: src/amule.cpp:2381
+#: src/amule.cpp:2389
 msgid "Failed to download the version check file"
 msgstr "バージョン確認ファイルのダウンロードに失敗しました"
 
-#: src/amule.cpp:2550 src/amule-remote-gui.cpp:1133
+#: src/amule.cpp:2558 src/amule-remote-gui.cpp:1133
 #, c-format
 msgid "Users: %s | Files: %s"
 msgstr "ユーザ: %s | ファイル: %s"
 
-#: src/amule.cpp:2551 src/amule-remote-gui.cpp:1134
+#: src/amule.cpp:2559 src/amule-remote-gui.cpp:1134
 #, c-format
 msgid "Users: E: %s K: %s | Files: E: %s K: %s"
 msgstr "ユーザ: E: %s K: %s | ファイル: E: %s K: %s"
 
-#: src/amule.cpp:2565 src/amule-remote-gui.cpp:1147
+#: src/amule.cpp:2573 src/amule-remote-gui.cpp:1147
 msgid "No networks selected"
 msgstr "ネットワークが選択されていません"
 
-#: src/amule.cpp:2633 src/TextClient.cpp:903
+#: src/amule.cpp:2641 src/TextClient.cpp:903
 msgid "with LowID"
 msgstr "LowIDを持っています"
 
-#: src/amule.cpp:2633 src/TextClient.cpp:904
+#: src/amule.cpp:2641 src/TextClient.cpp:904
 msgid "with HighID"
 msgstr "HighIDを持っています"
 
-#: src/amule.cpp:2635
+#: src/amule.cpp:2643
 #, c-format
 msgid "Connected to %s %s"
 msgstr "接続しています：%s %s"
 
-#: src/amule.cpp:2640
+#: src/amule.cpp:2648
 #, c-format
 msgid "Connecting to %s"
 msgstr "%sに接続中です"
 
-#: src/amule.cpp:2642
+#: src/amule.cpp:2650
 msgid "Disconnected from eD2k"
 msgstr ""
 
-#: src/amule.cpp:2651
+#: src/amule.cpp:2659
 msgid "Kad started."
 msgstr "Kadを開始しました。"
 
-#: src/amule.cpp:2653
+#: src/amule.cpp:2661
 msgid "Kad stopped."
 msgstr "Kadを中止しました。"
 
-#: src/amule.cpp:2661
+#: src/amule.cpp:2669
 msgid "Connected to Kad (ok)"
 msgstr "Kadに接続しています（OK）"
 
-#: src/amule.cpp:2663
+#: src/amule.cpp:2671
 msgid "Connected to Kad (firewalled)"
 msgstr "Kadに接続しています（ファイアウォール）"
 
-#: src/amule.cpp:2667
+#: src/amule.cpp:2675
 msgid "Disconnected from Kad"
 msgstr "Kadから切断しています"
 
-#: src/amule.cpp:2699
+#: src/amule.cpp:2707
 msgid "Kad network cannot be used if UDP port is disabled on preferences, not starting."
 msgstr "UDPポートが設定で無効にされていると、Kadネットワークを使用できないため、開始しません。"
 
-#: src/amule.cpp:2703
+#: src/amule.cpp:2711
 msgid "Kad network disabled on preferences, not connecting."
 msgstr "Kadネットワークは設定で無効にされているため、接続はしません。"
 
@@ -593,36 +593,36 @@ msgid "FATAL ERROR: Failed to create Timer"
 msgstr ""
 
 #: src/amuleDlg.cpp:361 src/amuleDlg.cpp:1787 src/amuleDlg.cpp:2033
-#: src/muuli_wdr.cpp:1492 src/muuli_wdr.cpp:3418
+#: src/muuli_wdr.cpp:1492 src/muuli_wdr.cpp:3449
 msgid "Networks"
 msgstr "ネットワーク"
 
-#: src/amuleDlg.cpp:362 src/amuleDlg.cpp:1793 src/muuli_wdr.cpp:3419
+#: src/amuleDlg.cpp:362 src/amuleDlg.cpp:1793 src/muuli_wdr.cpp:3450
 msgid "Searches"
 msgstr "検索"
 
 #: src/amuleDlg.cpp:363 src/amuleDlg.cpp:1799 src/DownloadListCtrl.cpp:740
-#: src/muuli_wdr.cpp:392 src/muuli_wdr.cpp:1585 src/muuli_wdr.cpp:3420
+#: src/muuli_wdr.cpp:392 src/muuli_wdr.cpp:1585 src/muuli_wdr.cpp:3451
 #: src/Statistics.cpp:829
 msgid "Downloads"
 msgstr "ダウンロード数"
 
-#: src/amuleDlg.cpp:364 src/amuleDlg.cpp:1805 src/muuli_wdr.cpp:3294
+#: src/amuleDlg.cpp:364 src/amuleDlg.cpp:1805 src/muuli_wdr.cpp:3325
 msgid "Shared files"
 msgstr ""
 
-#: src/amuleDlg.cpp:365 src/amuleDlg.cpp:1811 src/muuli_wdr.cpp:2926
-#: src/muuli_wdr.cpp:3376 src/muuli_wdr.cpp:3423
+#: src/amuleDlg.cpp:365 src/amuleDlg.cpp:1811 src/muuli_wdr.cpp:2957
+#: src/muuli_wdr.cpp:3407 src/muuli_wdr.cpp:3454
 msgid "Messages"
 msgstr "メッセージ"
 
-#: src/amuleDlg.cpp:366 src/amuleDlg.cpp:1817 src/muuli_wdr.cpp:3424
-#: src/PrefsUnifiedDlg.cpp:312 src/Statistics.cpp:779 src/Statistics.cpp:1235
+#: src/amuleDlg.cpp:366 src/amuleDlg.cpp:1817 src/muuli_wdr.cpp:3455
+#: src/PrefsUnifiedDlg.cpp:314 src/Statistics.cpp:779 src/Statistics.cpp:1235
 msgid "Statistics"
 msgstr "統計"
 
-#: src/amuleDlg.cpp:368 src/amuleDlg.cpp:1824 src/muuli_wdr.cpp:3426
-#: src/PrefsUnifiedDlg.cpp:328 src/utils/wxCas/src/wxcasprefs.cpp:39
+#: src/amuleDlg.cpp:368 src/amuleDlg.cpp:1824 src/muuli_wdr.cpp:3457
+#: src/PrefsUnifiedDlg.cpp:330 src/utils/wxCas/src/wxcasprefs.cpp:39
 msgid "Preferences"
 msgstr "設定"
 
@@ -680,8 +680,8 @@ msgstr "Kad: オフ"
 #: src/amuleDlg.cpp:1029 src/DownloadListCtrl.cpp:505
 #: src/DownloadListCtrl.cpp:749 src/FriendListCtrl.cpp:180
 #: src/muuli_wdr.cpp:731 src/muuli_wdr.cpp:782 src/muuli_wdr.cpp:846
-#: src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2231 src/muuli_wdr.cpp:2316
-#: src/muuli_wdr.cpp:3064 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
+#: src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2262 src/muuli_wdr.cpp:2347
+#: src/muuli_wdr.cpp:3095 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
 #: src/ServerListCtrl.cpp:606 src/TransferWnd.cpp:378
 #: src/utils/wxCas/src/wxcasprefs.cpp:235
 msgid "Cancel"
@@ -692,7 +692,7 @@ msgid "Stop the current connection attempts"
 msgstr "現在の接続試行を中止する"
 
 #: src/amuleDlg.cpp:1035 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976
-#: src/muuli_wdr.cpp:2454
+#: src/muuli_wdr.cpp:2485
 msgid "Disconnect"
 msgstr "切断する"
 
@@ -701,7 +701,7 @@ msgid "Disconnect from the currently connected networks"
 msgstr "ネットワークから切断します。"
 
 #: src/amuleDlg.cpp:1041 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979
-#: src/muuli_wdr.cpp:2609 src/muuli_wdr.cpp:3061 src/muuli_wdr.cpp:3416
+#: src/muuli_wdr.cpp:2640 src/muuli_wdr.cpp:3092 src/muuli_wdr.cpp:3447
 msgid "Connect"
 msgstr "接続する"
 
@@ -757,7 +757,7 @@ msgstr "終了の確認"
 msgid "Launch Command: "
 msgstr "コマンド： %s"
 
-#: src/amuleDlg.cpp:1632 src/muuli_wdr.cpp:1978 src/Preferences.cpp:952
+#: src/amuleDlg.cpp:1632 src/muuli_wdr.cpp:1982 src/Preferences.cpp:979
 msgid "- default -"
 msgstr ""
 
@@ -771,49 +771,49 @@ msgstr "スキンディレクトリ '%s' は存在しません"
 msgid "WARNING: Unable to open skin file '%s' for read"
 msgstr ""
 
-#: src/amuleDlg.cpp:1791 src/muuli_wdr.cpp:3418
+#: src/amuleDlg.cpp:1791 src/muuli_wdr.cpp:3449
 msgid "Networks Window"
 msgstr "ネットワークウィンドウ"
 
-#: src/amuleDlg.cpp:1797 src/muuli_wdr.cpp:3419
+#: src/amuleDlg.cpp:1797 src/muuli_wdr.cpp:3450
 msgid "Searches Window"
 msgstr "検索ウィンドウ"
 
-#: src/amuleDlg.cpp:1803 src/muuli_wdr.cpp:3420
+#: src/amuleDlg.cpp:1803 src/muuli_wdr.cpp:3451
 #, fuzzy
 msgid "Downloads Window"
 msgstr "ダウンロード"
 
-#: src/amuleDlg.cpp:1809 src/muuli_wdr.cpp:3422
+#: src/amuleDlg.cpp:1809 src/muuli_wdr.cpp:3453
 msgid "Shared Files Window"
 msgstr "共有ファイルウィンドウ"
 
-#: src/amuleDlg.cpp:1815 src/muuli_wdr.cpp:3423
+#: src/amuleDlg.cpp:1815 src/muuli_wdr.cpp:3454
 msgid "Messages Window"
 msgstr "メッセージウィンドウ"
 
-#: src/amuleDlg.cpp:1821 src/muuli_wdr.cpp:3424
+#: src/amuleDlg.cpp:1821 src/muuli_wdr.cpp:3455
 msgid "Statistics Graph Window"
 msgstr "統計グラフウィインドウ"
 
-#: src/amuleDlg.cpp:1828 src/muuli_wdr.cpp:3426
+#: src/amuleDlg.cpp:1828 src/muuli_wdr.cpp:3457
 msgid "Preferences Settings Window"
 msgstr "個人設定ウィンドウ"
 
-#: src/amuleDlg.cpp:1831 src/muuli_wdr.cpp:3427
+#: src/amuleDlg.cpp:1831 src/muuli_wdr.cpp:3458
 msgid "Import"
 msgstr "インポート"
 
-#: src/amuleDlg.cpp:1835 src/muuli_wdr.cpp:3427
+#: src/amuleDlg.cpp:1835 src/muuli_wdr.cpp:3458
 msgid "The partfile importer tool"
 msgstr "部分ファイルをインポートするためのツール"
 
-#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3428
+#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3459
 #: src/utils/aLinkCreator/src/alcframe.cpp:262
 msgid "About"
 msgstr "情報"
 
-#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3428
+#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3459
 msgid "About/Help"
 msgstr "ソフトウェア情報／ヘルプ"
 
@@ -959,7 +959,7 @@ msgstr "ファイルは見付かりませんでした。"
 msgid "The core rejected these shared folders:%s"
 msgstr ""
 
-#: src/amule-remote-gui.cpp:1336 src/ExternalConn.cpp:2345
+#: src/amule-remote-gui.cpp:1336 src/ExternalConn.cpp:2346
 msgid "Invalid link or already on list."
 msgstr "不正なリンク、またはリンクがすでにリストに入っています。"
 
@@ -975,7 +975,7 @@ msgstr ""
 #: src/ClientDetailDialog.cpp:123 src/DataToText.cpp:61 src/DataToText.cpp:86
 #: src/DataToText.cpp:101 src/DataToText.cpp:136 src/DataToText.cpp:165
 #: src/DownloadListCtrl.cpp:1172 src/DownloadListCtrl.cpp:1185
-#: src/DownloadListCtrl.cpp:1196 src/ExternalConn.cpp:608
+#: src/DownloadListCtrl.cpp:1196 src/ExternalConn.cpp:609
 #: src/FileDetailDialog.cpp:203 src/FileDetailDialog.cpp:235
 #: src/FileDetailDialog.cpp:242 src/GenericClientListCtrl.cpp:1171
 #: src/GenericClientListCtrl.cpp:1182 src/GenericClientListCtrl.cpp:1192
@@ -1357,19 +1357,19 @@ msgstr "オート [Hi]"
 msgid "Very low"
 msgstr "非常に低い"
 
-#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:743 src/muuli_wdr.cpp:2282
+#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:743 src/muuli_wdr.cpp:2313
 #: src/ServerListCtrl.cpp:263 src/ServerListCtrl.cpp:456
 #: src/SharedFilesCtrl.cpp:145
 msgid "Low"
 msgstr "低い"
 
-#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:744 src/muuli_wdr.cpp:2283
+#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:744 src/muuli_wdr.cpp:2314
 #: src/ServerListCtrl.cpp:266 src/ServerListCtrl.cpp:457
 #: src/SharedFilesCtrl.cpp:146
 msgid "Normal"
 msgstr "普通"
 
-#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:745 src/muuli_wdr.cpp:2284
+#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:745 src/muuli_wdr.cpp:2315
 #: src/ServerListCtrl.cpp:269 src/ServerListCtrl.cpp:458
 #: src/SharedFilesCtrl.cpp:147
 msgid "High"
@@ -1461,7 +1461,7 @@ msgstr "ローカルサーバ"
 msgid "Remote Server"
 msgstr "リモートサーバ"
 
-#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3181
+#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3212
 #: src/SearchDlg.cpp:119 src/TextClient.cpp:911
 msgid "Kad"
 msgstr "Kad"
@@ -1533,7 +1533,7 @@ msgstr ""
 msgid "Size"
 msgstr "サイズ"
 
-#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3248
+#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3279
 msgid "Transferred"
 msgstr "転送済み"
 
@@ -1591,7 +1591,7 @@ msgstr ""
 "フィードバック:%s (%s)\n"
 "\n"
 
-#: src/DownloadListCtrl.cpp:746 src/muuli_wdr.cpp:2285
+#: src/DownloadListCtrl.cpp:746 src/muuli_wdr.cpp:2316
 #: src/SharedFilesCtrl.cpp:150
 msgid "Auto"
 msgstr "自動"
@@ -1629,7 +1629,7 @@ msgid "Extended Options"
 msgstr "拡張オプション"
 
 #: src/DownloadListCtrl.cpp:770 src/DownloadListCtrl.cpp:822
-#: src/muuli_wdr.cpp:1796
+#: src/muuli_wdr.cpp:1800
 msgid "Preview"
 msgstr "プレビュー"
 
@@ -1800,232 +1800,237 @@ msgstr[0] ""
 msgid "Invalid eD2k link! ERROR: %s"
 msgstr ""
 
-#: src/ExternalConn.cpp:379
+#: src/ExternalConn.cpp:380
 #, fuzzy
 msgid "Client sent packet after authentication failed."
 msgstr "認証に失敗しました。"
 
-#: src/ExternalConn.cpp:396
+#: src/ExternalConn.cpp:397
 msgid "External connection closed."
 msgstr "外部接続は終了しました。"
 
-#: src/ExternalConn.cpp:473
+#: src/ExternalConn.cpp:474
 msgid "External connections disabled due to empty password!"
 msgstr "外部接続は空パスワードのため無効にしました！"
 
-#: src/ExternalConn.cpp:494
+#: src/ExternalConn.cpp:495
 msgid "External connections disabled in config file"
 msgstr "外部接続を設定ファイルに無効しました"
 
-#: src/ExternalConn.cpp:575
+#: src/ExternalConn.cpp:576
 msgid "New external connection accepted"
 msgstr "新しい外部接続を認められました"
 
-#: src/ExternalConn.cpp:578
+#: src/ExternalConn.cpp:579
 msgid "ERROR: couldn't accept a new external connection"
 msgstr ""
 
-#: src/ExternalConn.cpp:595
+#: src/ExternalConn.cpp:596
 msgid "External connection refused due to empty password in preferences!"
 msgstr "個人設定に空欄のパスワードがあるため、外部接続を拒否しました！"
 
-#: src/ExternalConn.cpp:607
+#: src/ExternalConn.cpp:608
 #, c-format
 msgid "Connecting client: %s %s"
 msgstr "クライアントを接続中： %s %s"
 
-#: src/ExternalConn.cpp:609
+#: src/ExternalConn.cpp:610
 msgid "Unknown version"
 msgstr "不明なバージョン"
 
-#: src/ExternalConn.cpp:622
+#: src/ExternalConn.cpp:623
 msgid "Incorrect EC version ID, there might be binary incompatibility. Use core and remote from same snapshot."
 msgstr "間違ったECバージョンID。バイナリ不互換性の可能性があります。同じスナップショットの コアとリモートを使用してください。"
 
-#: src/ExternalConn.cpp:630
+#: src/ExternalConn.cpp:631
 #, fuzzy
 msgid "You cannot connect to a release version from an arbitrary development snapshot! *sigh* possible crash prevented"
 msgstr "任意CVSバージョンからリリースバージョンに接続はできません！ *ハァ...*起こり得るクラッシュを予防しました"
 
-#: src/ExternalConn.cpp:713
+#: src/ExternalConn.cpp:714
 msgid "Invalid protocol version."
 msgstr "無効なプロトコルバージョン。"
 
-#: src/ExternalConn.cpp:719
+#: src/ExternalConn.cpp:720
 msgid "Missing protocol version tag."
 msgstr "プロトコルバージョンタグがありません。"
 
-#: src/ExternalConn.cpp:727
+#: src/ExternalConn.cpp:728
 msgid "Authentication failed: invalid hash specified as EC password."
 msgstr ""
 
-#: src/ExternalConn.cpp:775
+#: src/ExternalConn.cpp:776
 #, fuzzy
 msgid "Authentication failed: wrong password."
 msgstr "認証に失敗しました。"
 
-#: src/ExternalConn.cpp:777
+#: src/ExternalConn.cpp:778
 #, fuzzy
 msgid "Authentication failed: missing password."
 msgstr "認証に失敗しました。"
 
-#: src/ExternalConn.cpp:788
+#: src/ExternalConn.cpp:789
 #, fuzzy
 msgid "Invalid request, please authenticate first."
 msgstr "無効なリクエストです。先に認証をしてください。"
 
-#: src/ExternalConn.cpp:793
+#: src/ExternalConn.cpp:794
 msgid "Access granted."
 msgstr "アクセスを認められました。"
 
-#: src/ExternalConn.cpp:801
+#: src/ExternalConn.cpp:802
 #, fuzzy, c-format
 msgid "Sent error message \"%s\" to client."
 msgstr "知らないクライアントからのメッセージをフィルタする"
 
-#: src/ExternalConn.cpp:806
+#: src/ExternalConn.cpp:807
 #, fuzzy, c-format
 msgid "Unauthorized access attempt from %s. Connection closed."
 msgstr "不正アクセスの試みがなされました。接続は閉じました。"
 
-#: src/ExternalConn.cpp:1419
+#: src/ExternalConn.cpp:1420
 #, c-format
 msgid "Remote PartFile command failed: FileHash not found: %s"
 msgstr "リモート部分ファイルコマンドが失敗しました：ファイルハッシュは見付かりませんでした： %s"
 
-#: src/ExternalConn.cpp:1423
+#: src/ExternalConn.cpp:1424
 #, c-format
 msgid "FileHash not found: %s"
 msgstr "ファイルハッシュは見付かりませんでした： %s"
 
-#: src/ExternalConn.cpp:1470 src/ExternalConn.cpp:1558
-#: src/ExternalConn.cpp:1679
+#: src/ExternalConn.cpp:1471 src/ExternalConn.cpp:1559
+#: src/ExternalConn.cpp:1680
 msgid "OOPS! OpCode processing error!"
 msgstr "あら！OpCode処理エラーが発生しました！"
 
-#: src/ExternalConn.cpp:1501
+#: src/ExternalConn.cpp:1502
 msgid "Server not added"
 msgstr "サーバは追加しませんでした"
 
-#: src/ExternalConn.cpp:1520
+#: src/ExternalConn.cpp:1521
 #, c-format
 msgid "server not found: %s"
 msgstr "サーバは見付かりませんでした： %s"
 
-#: src/ExternalConn.cpp:1537
+#: src/ExternalConn.cpp:1538
 msgid "need to define server to be removed"
 msgstr "削除したいサーバを定義しなければなりません"
 
-#: src/ExternalConn.cpp:1552
+#: src/ExternalConn.cpp:1553
 msgid "eD2k is disabled in preferences."
 msgstr ""
 
-#: src/ExternalConn.cpp:1657
+#: src/ExternalConn.cpp:1658
 #, fuzzy
 msgid "Friend not found."
 msgstr "ファイルは見付かりませんでした。"
 
-#: src/ExternalConn.cpp:1667
+#: src/ExternalConn.cpp:1668
 #, fuzzy
 msgid "Client not found."
 msgstr "ファイルは見付かりませんでした。"
 
-#: src/ExternalConn.cpp:1673
+#: src/ExternalConn.cpp:1674
 msgid "EC_TAG_FRIEND_SHARED requires EC_TAG_FRIEND or EC_TAG_CLIENT."
 msgstr ""
 
-#: src/ExternalConn.cpp:1991
+#: src/ExternalConn.cpp:1992
 msgid "WebSearch from remote interface makes no sense."
 msgstr "リモートインタフェイスからWebSearchする意味がありません。"
 
-#: src/ExternalConn.cpp:2026
+#: src/ExternalConn.cpp:2027
 msgid "Search in progress. Refetch results in a moment!"
 msgstr "検索中です。あと少しで結果をもう一度取ってきます！"
 
-#: src/ExternalConn.cpp:2265
+#: src/ExternalConn.cpp:2266
 msgid "No points for graph."
 msgstr "グラフを表示するための点がありません。"
 
-#: src/ExternalConn.cpp:2275
+#: src/ExternalConn.cpp:2276
 msgid "Your client is not configured for this detail level."
 msgstr "あなたのクライアントはこの詳細段階には設定されていません。"
 
-#: src/ExternalConn.cpp:2302
+#: src/ExternalConn.cpp:2303
 msgid "External Connection: shutdown requested"
 msgstr ""
 
-#: src/ExternalConn.cpp:2314
+#: src/ExternalConn.cpp:2315
 msgid "Already shutting down."
 msgstr "既にシャットダウン中です。"
 
-#: src/ExternalConn.cpp:2332
+#: src/ExternalConn.cpp:2333
 #, c-format
 msgid "ExternalConn: adding link '%s'."
 msgstr "ExternalConn：次のリンクを追加中です： '%s'。"
 
-#: src/ExternalConn.cpp:2350
+#: src/ExternalConn.cpp:2351
 #, fuzzy, c-format
 msgid "%d of %d links failed (invalid or already on list)."
 msgstr "不正なリンク、またはリンクがすでにリストに入っています。"
 
-#: src/ExternalConn.cpp:2373
+#: src/ExternalConn.cpp:2374
 msgid "Version check throttled; try again shortly."
 msgstr ""
 
-#: src/ExternalConn.cpp:2378
+#: src/ExternalConn.cpp:2379
 msgid "Version check is not available on this daemon."
 msgstr ""
 
-#: src/ExternalConn.cpp:2508
+#: src/ExternalConn.cpp:2509
 msgid "File not found."
 msgstr "ファイルは見付かりませんでした。"
 
-#: src/ExternalConn.cpp:2513
+#: src/ExternalConn.cpp:2514
 msgid "Invalid file name."
 msgstr "不正なファイル名。"
 
-#: src/ExternalConn.cpp:2521
+#: src/ExternalConn.cpp:2522
 msgid "Unable to rename file."
 msgstr "ファイルを改名できません。"
 
-#: src/ExternalConn.cpp:2992 src/ExternalConn.cpp:3020
+#: src/ExternalConn.cpp:2839
+#, c-format
+msgid "Could not save the amuleapi password: %s"
+msgstr ""
+
+#: src/ExternalConn.cpp:3004 src/ExternalConn.cpp:3032
 msgid "Kad is disabled in preferences."
 msgstr "Kadは個人設定に無効されています。"
 
-#: src/ExternalConn.cpp:3033
+#: src/ExternalConn.cpp:3045
 msgid "Already connected to eD2k."
 msgstr ""
 
-#: src/ExternalConn.cpp:3036
+#: src/ExternalConn.cpp:3048
 msgid "Connecting to eD2k..."
 msgstr ""
 
-#: src/ExternalConn.cpp:3045
+#: src/ExternalConn.cpp:3057
 msgid "Already connected to Kad."
 msgstr "すでにKadに接続しています。"
 
-#: src/ExternalConn.cpp:3048
+#: src/ExternalConn.cpp:3060
 msgid "Connecting to Kad..."
 msgstr "Kadに接続中です…"
 
-#: src/ExternalConn.cpp:3055
+#: src/ExternalConn.cpp:3067
 msgid "All networks are disabled."
 msgstr "全てのネットワークが無効になっています。"
 
-#: src/ExternalConn.cpp:3064
+#: src/ExternalConn.cpp:3076
 msgid "Disconnected from eD2k."
 msgstr ""
 
-#: src/ExternalConn.cpp:3069
+#: src/ExternalConn.cpp:3081
 msgid "Disconnected from Kad."
 msgstr "Kadから切断しています。"
 
-#: src/ExternalConn.cpp:3078
+#: src/ExternalConn.cpp:3090
 #, c-format
 msgid "External Connection: invalid opcode received: %#x"
 msgstr ""
 
-#: src/ExternalConn.cpp:3083
+#: src/ExternalConn.cpp:3095
 msgid "Invalid opcode (wrong protocol version?)"
 msgstr "不正なOpCode（プロトコルバージョンが違いますか？）"
 
@@ -2426,23 +2431,23 @@ msgid ""
 "want downloads on a different (e.g. larger) disk."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:549 src/FirstRunWizard.cpp:611 src/muuli_wdr.cpp:1708
+#: src/FirstRunWizard.cpp:549 src/FirstRunWizard.cpp:611 src/muuli_wdr.cpp:1712
 msgid "Destination folder for downloads"
 msgstr ""
 
 #: src/FirstRunWizard.cpp:553 src/FirstRunWizard.cpp:569 src/muuli_wdr.cpp:1349
-#: src/muuli_wdr.cpp:1366 src/muuli_wdr.cpp:1683 src/muuli_wdr.cpp:1714
-#: src/muuli_wdr.cpp:1726 src/muuli_wdr.cpp:2769
+#: src/muuli_wdr.cpp:1366 src/muuli_wdr.cpp:1687 src/muuli_wdr.cpp:1718
+#: src/muuli_wdr.cpp:1730 src/muuli_wdr.cpp:2800
 #: src/utils/aLinkCreator/src/alcframe.cpp:135
 #: src/utils/wxCas/src/wxcasprefs.cpp:52 src/utils/wxCas/src/wxcasprefs.cpp:118
 msgid "Browse"
 msgstr "閲覧"
 
-#: src/FirstRunWizard.cpp:559 src/muuli_wdr.cpp:1719
+#: src/FirstRunWizard.cpp:559 src/muuli_wdr.cpp:1723
 msgid "(All files in this folder are shared with other peers)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:565 src/FirstRunWizard.cpp:624 src/muuli_wdr.cpp:1721
+#: src/FirstRunWizard.cpp:565 src/FirstRunWizard.cpp:624 src/muuli_wdr.cpp:1725
 msgid "Folder for temporary download files"
 msgstr ""
 
@@ -2473,7 +2478,7 @@ msgstr ""
 msgid "CRITICAL - no client on StartChatSession"
 msgstr ""
 
-#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2675 src/muuli_wdr.cpp:3352
+#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2706 src/muuli_wdr.cpp:3383
 msgid "Friends"
 msgstr "友達"
 
@@ -2583,8 +2588,8 @@ msgstr "誰も許可しない"
 msgid "No"
 msgstr "いいえ"
 
-#: src/GenericClientListCtrl.cpp:1216 src/PrefsUnifiedDlg.cpp:2818
-#: src/PrefsUnifiedDlg.cpp:2868 src/ServerListCtrl.cpp:276
+#: src/GenericClientListCtrl.cpp:1216 src/PrefsUnifiedDlg.cpp:2898
+#: src/PrefsUnifiedDlg.cpp:2948 src/ServerListCtrl.cpp:276
 msgid "Yes"
 msgstr "はい"
 
@@ -2752,10 +2757,10 @@ msgstr "ブートストラップするためには正しくないポートです
 msgid "Please fill all fields required"
 msgstr "必要なフィールドをすべて入力してください"
 
-#: src/KadDlg.cpp:192 src/PartFile.cpp:1031 src/PrefsUnifiedDlg.cpp:1162
-#: src/PrefsUnifiedDlg.cpp:1331 src/PrefsUnifiedDlg.cpp:1589
-#: src/PrefsUnifiedDlg.cpp:1599 src/PrefsUnifiedDlg.cpp:1616
-#: src/PrefsUnifiedDlg.cpp:1658
+#: src/KadDlg.cpp:192 src/PartFile.cpp:1031 src/PrefsUnifiedDlg.cpp:1134
+#: src/PrefsUnifiedDlg.cpp:1204 src/PrefsUnifiedDlg.cpp:1405
+#: src/PrefsUnifiedDlg.cpp:1663 src/PrefsUnifiedDlg.cpp:1673
+#: src/PrefsUnifiedDlg.cpp:1690 src/PrefsUnifiedDlg.cpp:1738
 msgid "Message"
 msgstr "メッセージ"
 
@@ -2854,7 +2859,7 @@ msgstr "共有比"
 msgid "Uploaded"
 msgstr "アップロード済み"
 
-#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3232
+#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3263
 msgid "Requested"
 msgstr "要求済み"
 
@@ -2980,7 +2985,7 @@ msgid "WARNING: "
 msgstr ""
 
 #: src/MuleNotebook.cpp:179 src/muuli_wdr.cpp:817 src/muuli_wdr.cpp:1229
-#: src/muuli_wdr.cpp:3136 src/muuli_wdr.cpp:3392
+#: src/muuli_wdr.cpp:3167 src/muuli_wdr.cpp:3423
 msgid "Close"
 msgstr "閉じる"
 
@@ -2998,7 +3003,7 @@ msgid "Paste"
 msgstr "ペースト"
 
 #: src/MuleTextCtrl.cpp:89 src/muuli_wdr.cpp:358 src/muuli_wdr.cpp:757
-#: src/muuli_wdr.cpp:2359 src/muuli_wdr.cpp:2378 src/muuli_wdr.cpp:2400
+#: src/muuli_wdr.cpp:2390 src/muuli_wdr.cpp:2409 src/muuli_wdr.cpp:2431
 #: src/utils/aLinkCreator/src/alcframe.cpp:142
 msgid "Clear"
 msgstr "クリア"
@@ -3096,7 +3101,7 @@ msgstr "終了"
 
 #: src/MuleTrayIcon.cpp:579 src/MuleTrayIcon.cpp:945 src/MuleTrayIcon.cpp:965
 #: src/muuli_wdr.cpp:1398 src/muuli_wdr.cpp:1406 src/muuli_wdr.cpp:1413
-#: src/muuli_wdr.cpp:1842 src/muuli_wdr.cpp:1848 src/OtherFunctions.cpp:91
+#: src/muuli_wdr.cpp:1846 src/muuli_wdr.cpp:1852 src/OtherFunctions.cpp:91
 #: src/StatisticsDlg.cpp:93 src/StatisticsDlg.cpp:95
 msgid "kB/s"
 msgstr "kB/s"
@@ -3338,7 +3343,7 @@ msgstr "B"
 msgid "KB"
 msgstr "KB"
 
-#: src/muuli_wdr.cpp:274 src/muuli_wdr.cpp:293 src/muuli_wdr.cpp:1627
+#: src/muuli_wdr.cpp:274 src/muuli_wdr.cpp:293 src/muuli_wdr.cpp:1631
 #: src/OtherFunctions.cpp:64
 msgid "MB"
 msgstr "MB"
@@ -3355,7 +3360,7 @@ msgstr "最大サイズ"
 msgid "Availability"
 msgstr "入手可能範囲"
 
-#: src/muuli_wdr.cpp:312 src/muuli_wdr.cpp:398 src/muuli_wdr.cpp:3297
+#: src/muuli_wdr.cpp:312 src/muuli_wdr.cpp:398 src/muuli_wdr.cpp:3328
 msgid "Filter:"
 msgstr "フィルタ："
 
@@ -3419,12 +3424,12 @@ msgstr "ソース完了"
 #: src/muuli_wdr.cpp:1160 src/muuli_wdr.cpp:1167 src/muuli_wdr.cpp:1172
 #: src/muuli_wdr.cpp:1179 src/muuli_wdr.cpp:1184 src/muuli_wdr.cpp:1191
 #: src/muuli_wdr.cpp:1205 src/muuli_wdr.cpp:1212 src/muuli_wdr.cpp:1217
-#: src/muuli_wdr.cpp:1224 src/muuli_wdr.cpp:3234 src/muuli_wdr.cpp:3242
-#: src/muuli_wdr.cpp:3250
+#: src/muuli_wdr.cpp:1224 src/muuli_wdr.cpp:3265 src/muuli_wdr.cpp:3273
+#: src/muuli_wdr.cpp:3281
 msgid "N/A"
 msgstr "非適用"
 
-#: src/muuli_wdr.cpp:508 src/muuli_wdr.cpp:1065 src/PrefsUnifiedDlg.cpp:297
+#: src/muuli_wdr.cpp:508 src/muuli_wdr.cpp:1065 src/PrefsUnifiedDlg.cpp:299
 msgid "General"
 msgstr "一般"
 
@@ -3565,7 +3570,7 @@ msgstr ""
 msgid "Album :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:685 src/muuli_wdr.cpp:2254
+#: src/muuli_wdr.cpp:685 src/muuli_wdr.cpp:2285
 msgid "Title :"
 msgstr "タイトル："
 
@@ -3672,7 +3677,7 @@ msgstr "ユーザ名："
 msgid "Userhash :"
 msgstr "ユーザ・ハッシュ："
 
-#: src/muuli_wdr.cpp:895 src/muuli_wdr.cpp:1748 src/muuli_wdr.cpp:2449
+#: src/muuli_wdr.cpp:895 src/muuli_wdr.cpp:1752 src/muuli_wdr.cpp:2480
 #: src/utils/aLinkCreator/src/alcframe.cpp:137
 msgid "Add"
 msgstr "追加"
@@ -3681,15 +3686,15 @@ msgstr "追加"
 msgid "Download-Speed"
 msgstr "ダウンロード速度："
 
-#: src/muuli_wdr.cpp:954 src/muuli_wdr.cpp:989 src/muuli_wdr.cpp:2553
+#: src/muuli_wdr.cpp:954 src/muuli_wdr.cpp:989 src/muuli_wdr.cpp:2584
 msgid "Current"
 msgstr "現在"
 
-#: src/muuli_wdr.cpp:962 src/muuli_wdr.cpp:997 src/muuli_wdr.cpp:2561
+#: src/muuli_wdr.cpp:962 src/muuli_wdr.cpp:997 src/muuli_wdr.cpp:2592
 msgid "Running average"
 msgstr "移動平均"
 
-#: src/muuli_wdr.cpp:970 src/muuli_wdr.cpp:1005 src/muuli_wdr.cpp:2569
+#: src/muuli_wdr.cpp:970 src/muuli_wdr.cpp:1005 src/muuli_wdr.cpp:2600
 msgid "Session average"
 msgstr "セッション平均"
 
@@ -3701,7 +3706,7 @@ msgstr "アップロード速度"
 msgid "Connections"
 msgstr "接続数"
 
-#: src/muuli_wdr.cpp:1024 src/muuli_wdr.cpp:1867
+#: src/muuli_wdr.cpp:1024 src/muuli_wdr.cpp:1871
 msgid "Active downloads"
 msgstr "アクティブなダウンロード数"
 
@@ -3709,7 +3714,7 @@ msgstr "アクティブなダウンロード数"
 msgid "Active connections (1:1)"
 msgstr "アクティブな接続（1:1）"
 
-#: src/muuli_wdr.cpp:1040 src/muuli_wdr.cpp:1868
+#: src/muuli_wdr.cpp:1040 src/muuli_wdr.cpp:1872
 msgid "Active uploads"
 msgstr "アクティブなアップロード数"
 
@@ -3986,7 +3991,7 @@ msgstr ""
 msgid "Advanced users only: If you have multiple network interfaces, enter the address of the interface to which aMule should be bound."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1462 src/muuli_wdr.cpp:2061
+#: src/muuli_wdr.cpp:1462 src/muuli_wdr.cpp:2065
 msgid "Bind to network interface (empty for any):"
 msgstr ""
 
@@ -4002,7 +4007,7 @@ msgstr ""
 msgid "Max simultaneous connections:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1498 src/muuli_wdr.cpp:3176
+#: src/muuli_wdr.cpp:1498 src/muuli_wdr.cpp:3207
 msgid "ED2K"
 msgstr "ED2K"
 
@@ -4094,757 +4099,780 @@ msgstr "新しいファイルのためのディスク領域を事前に確保す
 msgid "For new files preallocates disk space for the whole file, thus reduces fragmentation"
 msgstr "新しいファイルのためにファイル全体が格納できるディスク領域を事前に確保し、断片化を防ぎます。"
 
-#: src/muuli_wdr.cpp:1613
+#: src/muuli_wdr.cpp:1617
 msgid "Create new files as sparse files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1614
-msgid "A sparse file reserves its full size on disk immediately without writing real data to it -- fast, but unsupported or slow on some filesystems, and free-space accounting stays optimistic while the download is in progress. Turn this off to grow the file only as data arrives."
+#: src/muuli_wdr.cpp:1618
+msgid "Sparse part files only occupy disk space for the parts already downloaded, so free space is used up gradually as the file fills in. Turn this off to use an ordinary file instead - useful where sparse files are unsupported or slow, or where backup/de-duplication tools handle them badly. Applies only when the core runs on Windows; on Linux and macOS part files are sparse anyway and this setting has no effect."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1619
+#: src/muuli_wdr.cpp:1623
 msgid "Stop downloads when free disk space reaches "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1620
+#: src/muuli_wdr.cpp:1624
 msgid "Select this if you want aMule to check your disk space"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1624
+#: src/muuli_wdr.cpp:1628
 msgid "Enter here the min disk space desired."
 msgstr "望ましい最小のディスク領域をここに入力してください。"
 
-#: src/muuli_wdr.cpp:1630
+#: src/muuli_wdr.cpp:1634
 msgid "Save 10 sources on rare files (< 20 sources)"
 msgstr "珍しいファイルには10ソースを保存する（<20ソース）"
 
-#: src/muuli_wdr.cpp:1634 src/Statistics.cpp:790
+#: src/muuli_wdr.cpp:1638 src/Statistics.cpp:790
 msgid "Uploads"
 msgstr "アップロード数"
 
-#: src/muuli_wdr.cpp:1637
+#: src/muuli_wdr.cpp:1641
 msgid "Add new shared files with auto priority"
 msgstr "新しい共有ファイルを自動優先度として追加する"
 
-#: src/muuli_wdr.cpp:1643
+#: src/muuli_wdr.cpp:1647
 msgid "Intelligent Corruption Handling (I.C.H.)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1646
+#: src/muuli_wdr.cpp:1650
 msgid "Enable"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1649
+#: src/muuli_wdr.cpp:1653
 msgid "Advanced I.C.H. trusts every hash (not recommended)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1661 src/PrefsUnifiedDlg.cpp:1910
+#: src/muuli_wdr.cpp:1665 src/PrefsUnifiedDlg.cpp:1990
 msgid "Media metadata extraction"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1665
+#: src/muuli_wdr.cpp:1669
 msgid "Extract length / bitrate / codec from shared audio and video files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1667
+#: src/muuli_wdr.cpp:1671
 msgid "When enabled, aMule runs ffprobe on each shared media file to fill in the Length / Bitrate / Codec columns other clients see when they find the file in a search. Requires ffmpeg (the ffprobe binary) to be installed."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1674
+#: src/muuli_wdr.cpp:1678
 msgid "Path to ffprobe:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1679
+#: src/muuli_wdr.cpp:1683
 msgid "Full path to the ffprobe binary. Leave empty to have aMule auto-detect it on startup."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1687
+#: src/muuli_wdr.cpp:1691
 msgid "Detect"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1688
+#: src/muuli_wdr.cpp:1692
 msgid "Search the standard install locations for an ffprobe binary and fill the path field."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1712
+#: src/muuli_wdr.cpp:1716
 msgid ""
 "Completed downloads are stored here. All files in this folder are automatically shared with other peers.\n"
 "If this folder also holds files you don't want to share, point it at an aMule-only sub-folder."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1715
+#: src/muuli_wdr.cpp:1719
 msgid "Pick the folder where completed downloads will be stored. All files in that folder will be shared with other peers."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1729
+#: src/muuli_wdr.cpp:1733
 msgid "Shared folders"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1735
+#: src/muuli_wdr.cpp:1739
 msgid "(Folders shared by the core. Enter a path to add one.)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1743
+#: src/muuli_wdr.cpp:1747
 msgid "Absolute path of a folder on the core's machine, e.g. /home/user/shared"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1745 src/PrefsUnifiedDlg.cpp:2794
+#: src/muuli_wdr.cpp:1749 src/PrefsUnifiedDlg.cpp:2874
 msgid "Recursive"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1746
+#: src/muuli_wdr.cpp:1750
 msgid "Share every sub-folder underneath this one, including ones created later."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1750 src/utils/aLinkCreator/src/alcframe.cpp:141
+#: src/muuli_wdr.cpp:1754 src/utils/aLinkCreator/src/alcframe.cpp:141
 msgid "Remove"
 msgstr "削除"
 
-#: src/muuli_wdr.cpp:1754
+#: src/muuli_wdr.cpp:1758
 msgid "(Right click on folder icon for recursive share)"
 msgstr "（再帰的に共有するにはフォルダ・アイコンを右クリックしてください）"
 
-#: src/muuli_wdr.cpp:1761
+#: src/muuli_wdr.cpp:1765
 msgid "Share hidden files"
 msgstr "隠れたファイルを共有する"
 
-#: src/muuli_wdr.cpp:1767
+#: src/muuli_wdr.cpp:1771
 msgid "Automatically rescan shared folders for changes"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1773
+#: src/muuli_wdr.cpp:1777
 msgid "Follow symbolic links in shared folders"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1779
+#: src/muuli_wdr.cpp:1783
 msgid "Exclude files matching:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1782
+#: src/muuli_wdr.cpp:1786
 msgid "Wildcard patterns separated by '|', e.g. .DS_Store|Thumbs.db|*.tmp. Files whose name matches are not shared. Matching is case-insensitive."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1786
+#: src/muuli_wdr.cpp:1790
 msgid "Patterns are regular expressions"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1787
+#: src/muuli_wdr.cpp:1791
 msgid "When set, the whole field is one regular expression ('|' is alternation). When unset, it is a list of '|'-separated wildcards."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1797
+#: src/muuli_wdr.cpp:1801
 msgid "Show how many shared files the current pattern would exclude."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1818
+#: src/muuli_wdr.cpp:1822
 msgid "Graphs"
 msgstr "グラフ"
 
-#: src/muuli_wdr.cpp:1821 src/muuli_wdr.cpp:1883
+#: src/muuli_wdr.cpp:1825 src/muuli_wdr.cpp:1887
 msgid "Update delay : 5 secs"
 msgstr "アップデート延期：５秒"
 
-#: src/muuli_wdr.cpp:1825
+#: src/muuli_wdr.cpp:1829
 msgid "Time for average graph: 100 mins"
 msgstr "平均グラフの時間：１００分"
 
-#: src/muuli_wdr.cpp:1829
+#: src/muuli_wdr.cpp:1833
 msgid "Connections Graph Scale: 100 "
 msgstr "接続数のグラフスケール：１００"
 
-#: src/muuli_wdr.cpp:1836
+#: src/muuli_wdr.cpp:1840
 msgid "Download graph scale:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1844
+#: src/muuli_wdr.cpp:1848
 msgid "Upload graph scale:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1854
+#: src/muuli_wdr.cpp:1858
 msgid "Colors: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1858
+#: src/muuli_wdr.cpp:1862
 msgid "Background"
 msgstr "背景"
 
-#: src/muuli_wdr.cpp:1859
+#: src/muuli_wdr.cpp:1863
 msgid "Grid"
 msgstr "グリッド"
 
-#: src/muuli_wdr.cpp:1860
+#: src/muuli_wdr.cpp:1864
 msgid "Download current"
 msgstr "ダウンロード現在"
 
-#: src/muuli_wdr.cpp:1861
+#: src/muuli_wdr.cpp:1865
 msgid "Download running average"
 msgstr "ダウンロード移動平均"
 
-#: src/muuli_wdr.cpp:1862
+#: src/muuli_wdr.cpp:1866
 msgid "Download session average"
 msgstr "ダウンロードセッション平均"
 
-#: src/muuli_wdr.cpp:1863
+#: src/muuli_wdr.cpp:1867
 msgid "Upload current"
 msgstr "アップロード現在"
 
-#: src/muuli_wdr.cpp:1864
+#: src/muuli_wdr.cpp:1868
 msgid "Upload running average"
 msgstr "アップロード移動平均"
 
-#: src/muuli_wdr.cpp:1865
+#: src/muuli_wdr.cpp:1869
 msgid "Upload session average"
 msgstr "アップロードセッション平均"
 
-#: src/muuli_wdr.cpp:1866
+#: src/muuli_wdr.cpp:1870
 msgid "Active connections"
 msgstr "アクティブ接続数"
 
-#: src/muuli_wdr.cpp:1869
+#: src/muuli_wdr.cpp:1873
 #, fuzzy
 msgid "Systray Icon Speed Bar"
 msgstr "システム・トレイ・アイコン・スピードバー"
 
-#: src/muuli_wdr.cpp:1870
+#: src/muuli_wdr.cpp:1874
 msgid "Kad-nodes current"
 msgstr "現在のKadノード数"
 
-#: src/muuli_wdr.cpp:1871
+#: src/muuli_wdr.cpp:1875
 msgid "Kad-nodes running"
 msgstr "動作中のKadノード数"
 
-#: src/muuli_wdr.cpp:1872
+#: src/muuli_wdr.cpp:1876
 msgid "Kad-nodes session"
 msgstr "セッションのKadノード数"
 
-#: src/muuli_wdr.cpp:1876 src/muuli_wdr.cpp:2303
+#: src/muuli_wdr.cpp:1880 src/muuli_wdr.cpp:2334
 msgid "Select"
 msgstr "選択"
 
-#: src/muuli_wdr.cpp:1880
+#: src/muuli_wdr.cpp:1884
 msgid "Tree"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1890
+#: src/muuli_wdr.cpp:1894
 msgid "Number of Client Versions shown (0=unlimited)"
 msgstr "表示されているクライアントのバージョン数（0＝無制限）"
 
-#: src/muuli_wdr.cpp:1915
+#: src/muuli_wdr.cpp:1919
 msgid "!!! WARNING !!!"
 msgstr "！！！注意！！！"
 
-#: src/muuli_wdr.cpp:1930
+#: src/muuli_wdr.cpp:1934
 msgid "Max new connections / 5 secs"
 msgstr "最大の新しい接続数（5秒ごと）"
 
-#: src/muuli_wdr.cpp:1932
+#: src/muuli_wdr.cpp:1936
 msgid "Concurrent Kad source lookups"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1934
+#: src/muuli_wdr.cpp:1938
 #, fuzzy
 msgid "Kad source re-search interval (minutes)"
 msgstr "FTPアップデートレート間隔（分）"
 
-#: src/muuli_wdr.cpp:1936
+#: src/muuli_wdr.cpp:1940
 #, fuzzy
 msgid "Source re-ask interval (minutes)"
 msgstr "FTPアップデートレート間隔（分）"
 
-#: src/muuli_wdr.cpp:1940
+#: src/muuli_wdr.cpp:1944
 msgid "File Buffer Size: 240000 bytes"
 msgstr "ファイル・バファー・サイズ：240000バイト"
 
-#: src/muuli_wdr.cpp:1944
+#: src/muuli_wdr.cpp:1948
 msgid "Use MMAP: memory-mapped file access (lower memory use)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1945
+#: src/muuli_wdr.cpp:1949
 msgid "Maps part files into memory instead of buffering them on the heap, lowering the process memory footprint. May reduce download speed on some disks; best for memory-constrained or upload-heavy hosts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1947
+#: src/muuli_wdr.cpp:1951
 msgid "Upload Queue Size: 5000 clients"
 msgstr "アップロードキューサイズ：5000クライアント"
 
-#: src/muuli_wdr.cpp:1951
+#: src/muuli_wdr.cpp:1955
 msgid "Server connection refresh interval: Disable"
 msgstr "サーバ接続のリフレッシュ空間：無効にする"
 
-#: src/muuli_wdr.cpp:1955
+#: src/muuli_wdr.cpp:1959
 msgid "Disable computer's timed standby mode"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1974
+#: src/muuli_wdr.cpp:1978
 msgid "Skin to use: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1983
+#: src/muuli_wdr.cpp:1987
 msgid "Show \"Fast eD2k Links Handler\" in every window."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1986
+#: src/muuli_wdr.cpp:1990
 msgid "Show extended info on categories tabs"
 msgstr "延長情報をカテゴリ・タブで表示する"
 
-#: src/muuli_wdr.cpp:1989
+#: src/muuli_wdr.cpp:1993
 #, fuzzy
 msgid "Show application version on title"
 msgstr "タイトルに転送速度を表示する"
 
-#: src/muuli_wdr.cpp:1991
+#: src/muuli_wdr.cpp:1995
 msgid "Show transfer rates on title"
 msgstr "タイトルに転送速度を表示する"
 
-#: src/muuli_wdr.cpp:1993
+#: src/muuli_wdr.cpp:1997
 msgid "Before application name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1995
+#: src/muuli_wdr.cpp:1999
 msgid "After application name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1998
+#: src/muuli_wdr.cpp:2002
 msgid "Show overhead bandwidth"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2002
+#: src/muuli_wdr.cpp:2006
 msgid "Vertical toolbar orientation"
 msgstr "垂直ツールバー"
 
-#: src/muuli_wdr.cpp:2004
+#: src/muuli_wdr.cpp:2008
 msgid "Live column sorting (auto-reorder rows as their values change)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2011
+#: src/muuli_wdr.cpp:2015
 msgid "Download Queue Files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2014
+#: src/muuli_wdr.cpp:2018
 msgid "Show progress percentage"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2020
+#: src/muuli_wdr.cpp:2024
 msgid "Show progress bar"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2023
+#: src/muuli_wdr.cpp:2027
 msgid "Flat"
 msgstr "フラット"
 
-#: src/muuli_wdr.cpp:2027
+#: src/muuli_wdr.cpp:2031
 msgid "Round"
 msgstr "ラウンド"
 
-#: src/muuli_wdr.cpp:2045
+#: src/muuli_wdr.cpp:2049
 msgid "External Connection Parameters"
 msgstr "外部接続のパラメタ"
 
-#: src/muuli_wdr.cpp:2048
+#: src/muuli_wdr.cpp:2052
 msgid "Accept external connections"
 msgstr "外部接続を許可にする"
 
-#: src/muuli_wdr.cpp:2055 src/muuli_wdr.cpp:2114
+#: src/muuli_wdr.cpp:2059 src/muuli_wdr.cpp:2118
 msgid "IP of the listening interface:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2058
+#: src/muuli_wdr.cpp:2062
 msgid "Enter here a valid ip in the a.b.c.d format for the listening EC interface. An empty field or 0.0.0.0 will mean any interface."
 msgstr "リスンしているECインターフェイス用の正当なIPアドレスをa.b.c.dのフォーマットで入力してください。空のフィールド、または0.0.0.0は任意のインターフェイスを意味します。"
 
-#: src/muuli_wdr.cpp:2079 src/muuli_wdr.cpp:2163
+#: src/muuli_wdr.cpp:2083 src/muuli_wdr.cpp:2194
 msgid "TCP port:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2085
+#: src/muuli_wdr.cpp:2089
 msgid "Enable UPnP port forwarding on the EC port"
 msgstr "ECポートでUPnPポート転送を有効にする"
 
-#: src/muuli_wdr.cpp:2089 src/muuli_wdr.cpp:3048
+#: src/muuli_wdr.cpp:2093 src/muuli_wdr.cpp:3079
 #: src/utils/wxCas/src/wxcasprefs.cpp:167
 msgid "Password"
 msgstr "パスワード"
 
-#: src/muuli_wdr.cpp:2095
+#: src/muuli_wdr.cpp:2099
 msgid "aMule API server parameters"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2098
+#: src/muuli_wdr.cpp:2102
 msgid "Run amuleapi (REST API) on startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2103
+#: src/muuli_wdr.cpp:2107
 #, fuzzy
 msgid "HTTP port:"
 msgstr "プロクシー・ポート："
 
-#: src/muuli_wdr.cpp:2117
+#: src/muuli_wdr.cpp:2121
 msgid "The interface amuleapi's HTTP server listens on. 127.0.0.1 (default) accepts only local connections; use 0.0.0.0 or a specific IP to expose it to other hosts (set an admin password below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2120
+#: src/muuli_wdr.cpp:2126
+msgid "Type a password to set or change it. Stored passwords cannot be shown, so leaving this empty keeps the current one."
+msgstr ""
+
+#: src/muuli_wdr.cpp:2128
 #, fuzzy
 msgid "Admin password"
 msgstr "パスワードをチェック中です\n"
 
-#: src/muuli_wdr.cpp:2125 src/muuli_wdr.cpp:2156
-msgid "Low rights password"
-msgstr "低権限パスワード"
+#: src/muuli_wdr.cpp:2140 src/muuli_wdr.cpp:2157 src/PrefsUnifiedDlg.cpp:1103
+#, fuzzy
+msgid "A password is set."
+msgstr "パスワードをチェック中です\n"
 
-#: src/muuli_wdr.cpp:2133
+#: src/muuli_wdr.cpp:2144
+#, fuzzy
+msgid "Enable guest access"
+msgstr "ゲストアクセスを拒否する"
+
+#: src/muuli_wdr.cpp:2145
+msgid "Guest sessions may read status and listings but cannot change anything. Turning this off clears the stored guest password."
+msgstr ""
+
+#: src/muuli_wdr.cpp:2149
+#, fuzzy
+msgid "Guest password"
+msgstr "全権限パスワード"
+
+#: src/muuli_wdr.cpp:2164
 msgid "Web server parameters"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2136
+#: src/muuli_wdr.cpp:2167
 msgid "Run webserver on startup (deprecated)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2142
+#: src/muuli_wdr.cpp:2173
 msgid "Web template"
 msgstr "ウェブテンプレート"
 
-#: src/muuli_wdr.cpp:2147
+#: src/muuli_wdr.cpp:2178
 msgid "Full rights password"
 msgstr "全権限パスワード"
 
-#: src/muuli_wdr.cpp:2151
+#: src/muuli_wdr.cpp:2182
 msgid "Enable Low rights User"
 msgstr "低権限ユーザを有効にする"
 
-#: src/muuli_wdr.cpp:2170
+#: src/muuli_wdr.cpp:2187
+msgid "Low rights password"
+msgstr "低権限パスワード"
+
+#: src/muuli_wdr.cpp:2201
 msgid "Enable UPnP port forwarding of the web server port"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2175
+#: src/muuli_wdr.cpp:2206
 msgid "Web server UPnP TCP port (Optional)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2183
+#: src/muuli_wdr.cpp:2214
 msgid "Page Refresh Time (in secs)"
 msgstr "ページのリフレッシュ間隔（秒単位）"
 
-#: src/muuli_wdr.cpp:2190
+#: src/muuli_wdr.cpp:2221
 msgid "Enable Gzip compression"
 msgstr "gzip圧縮を有効にする"
 
-#: src/muuli_wdr.cpp:2224
+#: src/muuli_wdr.cpp:2255
 #, fuzzy
 msgid "Reset page to defaults"
 msgstr "システムの標準設定"
 
-#: src/muuli_wdr.cpp:2225
+#: src/muuli_wdr.cpp:2256
 msgid "Reset the settings on the current page to their default values."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2227 src/muuli_wdr.cpp:2313 src/ServerWnd.cpp:274
+#: src/muuli_wdr.cpp:2258 src/muuli_wdr.cpp:2344 src/ServerWnd.cpp:274
 #: src/ServerWnd.cpp:282
 msgid "OK"
 msgstr "OK"
 
-#: src/muuli_wdr.cpp:2229
+#: src/muuli_wdr.cpp:2260
 msgid "Click here to apply any changes made to the preferences."
 msgstr "設定の変更をすべて適用します。"
 
-#: src/muuli_wdr.cpp:2232
+#: src/muuli_wdr.cpp:2263
 msgid "Reset any changes made to the preferences."
 msgstr "設定の変更を全てリセットする"
 
-#: src/muuli_wdr.cpp:2261
+#: src/muuli_wdr.cpp:2292
 msgid "Comment :"
 msgstr "コメント："
 
-#: src/muuli_wdr.cpp:2268
+#: src/muuli_wdr.cpp:2299
 msgid "Incoming Dir :"
 msgstr "受信ディレクトリ："
 
-#: src/muuli_wdr.cpp:2277
+#: src/muuli_wdr.cpp:2308
 msgid "Change priority for new assigned files :"
 msgstr "新しく割り当てられたファイルの優先度を変更する："
 
-#: src/muuli_wdr.cpp:2281
+#: src/muuli_wdr.cpp:2312
 #, fuzzy
 msgid "Don't change"
 msgstr "変更しない"
 
-#: src/muuli_wdr.cpp:2293
+#: src/muuli_wdr.cpp:2324
 msgid "Select color for this Category (currently selected) :"
 msgstr "このカテゴリの色を選択する（現在選択中）："
 
-#: src/muuli_wdr.cpp:2360 src/muuli_wdr.cpp:2379 src/muuli_wdr.cpp:2401
+#: src/muuli_wdr.cpp:2391 src/muuli_wdr.cpp:2410 src/muuli_wdr.cpp:2432
 msgid "Click this button to reset the log."
 msgstr "このボタンをクリックするとログのリセットが行います。"
 
-#: src/muuli_wdr.cpp:2420
+#: src/muuli_wdr.cpp:2451
 msgid "Click on this button to update the servers list from URL ..."
 msgstr "このボタンをクリックするとサーバ・リストはURLから最新化する..."
 
-#: src/muuli_wdr.cpp:2424
+#: src/muuli_wdr.cpp:2455
 msgid "Server list"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2428
+#: src/muuli_wdr.cpp:2459
 msgid "Enter the url to a server.met file here and press the button to the left to update the list of known servers."
 msgstr "server.metファイルへのURLをここに入力してから左側のボタンをクリックすると、既知のサーバのリストがアップデートされます。"
 
-#: src/muuli_wdr.cpp:2433
+#: src/muuli_wdr.cpp:2464
 msgid "Add server manually: Name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2436
+#: src/muuli_wdr.cpp:2467
 msgid "Enter the name of the new server here"
 msgstr "新しいサーバの名前をここに入力してください"
 
-#: src/muuli_wdr.cpp:2438 src/ServerWnd.cpp:206
+#: src/muuli_wdr.cpp:2469 src/ServerWnd.cpp:206
 msgid "IP:Port"
 msgstr "IP:ポート"
 
-#: src/muuli_wdr.cpp:2441
+#: src/muuli_wdr.cpp:2472
 msgid "Enter the IP of the server here, using the x.x.x.x format."
 msgstr "x.x.x.xフォーマットでサーバのIPアドレスを入力してください。"
 
-#: src/muuli_wdr.cpp:2447
+#: src/muuli_wdr.cpp:2478
 msgid "Enter the port of the server here."
 msgstr "サーバのポートをここに入力してください。"
 
-#: src/muuli_wdr.cpp:2450
+#: src/muuli_wdr.cpp:2481
 msgid "Add manually a server (fill fields to the left before) ..."
 msgstr "手動でサーバを追加する（先に左側のフィールドを入力してください）..."
 
-#: src/muuli_wdr.cpp:2479
+#: src/muuli_wdr.cpp:2510
 msgid "aMule Log"
 msgstr "aMuleのログ"
 
-#: src/muuli_wdr.cpp:2487
+#: src/muuli_wdr.cpp:2518
 msgid "Server Info"
 msgstr "サーバ情報"
 
-#: src/muuli_wdr.cpp:2491
+#: src/muuli_wdr.cpp:2522
 msgid "ED2K Info"
 msgstr "ED2K情報"
 
-#: src/muuli_wdr.cpp:2495
+#: src/muuli_wdr.cpp:2526
 msgid "Kad Info"
 msgstr "Kad情報"
 
-#: src/muuli_wdr.cpp:2523
+#: src/muuli_wdr.cpp:2554
 msgid "Click on this button to update the nodes list from URL ..."
 msgstr "このボタンをクリックするとノード・リストをURLからアップデートします..."
 
-#: src/muuli_wdr.cpp:2527
+#: src/muuli_wdr.cpp:2558
 msgid "Nodes (0)"
 msgstr "ノード数（0）"
 
-#: src/muuli_wdr.cpp:2531
+#: src/muuli_wdr.cpp:2562
 msgid "Enter the url to a nodes.dat file here and press the button to the left to update the list of known nodes."
 msgstr "ここにnodes.datファイルへのURLを入力してから左側のボタンをクリックすると、既知のノード・リストをアップデートします。"
 
-#: src/muuli_wdr.cpp:2534
+#: src/muuli_wdr.cpp:2565
 msgid "Nodes stats"
 msgstr "ノードの統計"
 
-#: src/muuli_wdr.cpp:2576
+#: src/muuli_wdr.cpp:2607
 msgid "Bootstrap"
 msgstr "ブートストラップ"
 
-#: src/muuli_wdr.cpp:2579
+#: src/muuli_wdr.cpp:2610
 msgid "New node"
 msgstr "新しいノード"
 
-#: src/muuli_wdr.cpp:2584
+#: src/muuli_wdr.cpp:2615
 msgid "IP:"
 msgstr "IP："
 
-#: src/muuli_wdr.cpp:2604
+#: src/muuli_wdr.cpp:2635
 msgid "Port:"
 msgstr "ポート："
 
-#: src/muuli_wdr.cpp:2617
+#: src/muuli_wdr.cpp:2648
 #, fuzzy
 msgid "Bootstrap from known clients"
 msgstr ""
 "既知のクライアントから\n"
 "ブートストラップする"
 
-#: src/muuli_wdr.cpp:2619
+#: src/muuli_wdr.cpp:2650
 msgid "Disconnect Kad"
 msgstr "Kadを切断する"
 
-#: src/muuli_wdr.cpp:2653
+#: src/muuli_wdr.cpp:2684
 msgid "Use Secure User Identification"
 msgstr "セキュア・ユーザ保証（SUI）を使用する"
 
-#: src/muuli_wdr.cpp:2655
+#: src/muuli_wdr.cpp:2686
 msgid "It is recommended to enable this option. You will not receive credits if SUI is not enabled."
 msgstr "このオプションを有効にするのは推奨されます。SUIが有効でないとあなたはクレジットを得られません。"
 
-#: src/muuli_wdr.cpp:2657
+#: src/muuli_wdr.cpp:2688
 msgid "Protocol Obfuscation"
 msgstr "プロトコルを難読化する"
 
-#: src/muuli_wdr.cpp:2660
+#: src/muuli_wdr.cpp:2691
 msgid "Support Protocol Obfuscation"
 msgstr "プロトコルの難読化を有効にする"
 
-#: src/muuli_wdr.cpp:2662
+#: src/muuli_wdr.cpp:2693
 msgid "This option enabled Protocol Obfuscation, and makes aMule accept obfuscated connections from other clients."
 msgstr "このオプションによってプロトコルの難読化を有効にできます。そうすると、aMuleは他のクライアントからの難読化された接続を受け入れられます。"
 
-#: src/muuli_wdr.cpp:2664
+#: src/muuli_wdr.cpp:2695
 msgid "Use obfuscation for outgoing connections"
 msgstr "外方向の接続に難読化を使用する"
 
-#: src/muuli_wdr.cpp:2666
+#: src/muuli_wdr.cpp:2697
 msgid "This option makes aMule use Protocol Obfuscation when connecting other clients/servers."
 msgstr "このオプションによって、aMuleは他のサーバまたはクライアントに接続する時にプロトコル難読化を使用します。"
 
-#: src/muuli_wdr.cpp:2668
+#: src/muuli_wdr.cpp:2699
 msgid "Accept only obfuscated connections"
 msgstr "難読化された接続のみを受信する"
 
-#: src/muuli_wdr.cpp:2669
+#: src/muuli_wdr.cpp:2700
 msgid "This option makes aMule only accept obfuscated connections. You will have less sources, but all your traffic will be obfuscated"
 msgstr "このオプションによって、aMuleは難読化された接続のみを受信します。ソース数が減りますが、トラフィックが全て難読化されます。"
 
-#: src/muuli_wdr.cpp:2674
+#: src/muuli_wdr.cpp:2705
 msgid "Everybody"
 msgstr "全員"
 
-#: src/muuli_wdr.cpp:2676
+#: src/muuli_wdr.cpp:2707
 msgid "No one"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2678
+#: src/muuli_wdr.cpp:2709
 msgid "Who can see my shared files:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2679
+#: src/muuli_wdr.cpp:2710
 msgid "Select who can request to view a list of your shared files."
 msgstr "あなたの共有ファイル・リストを要求できるユーザを選択してください。"
 
-#: src/muuli_wdr.cpp:2681
+#: src/muuli_wdr.cpp:2712
 msgid "IP-Filtering"
 msgstr "IPフィルタリング"
 
-#: src/muuli_wdr.cpp:2688
+#: src/muuli_wdr.cpp:2719
 msgid "Filter clients"
 msgstr "クライアントをフィルタする"
 
-#: src/muuli_wdr.cpp:2690
+#: src/muuli_wdr.cpp:2721
 msgid "Enable filtering of the client IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "~/.aMule/ipfilter.datに登録されちるクライアントIPにフィルタリングをかけることを有効にします。"
 
-#: src/muuli_wdr.cpp:2692
+#: src/muuli_wdr.cpp:2723
 msgid "Filter servers"
 msgstr "サーバをフィルタする"
 
-#: src/muuli_wdr.cpp:2694
+#: src/muuli_wdr.cpp:2725
 msgid "Enable filtering of the server IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "~/.aMule/ipfilter.datに登録されちるサーバIPにフィルタリングをかけることを有効にします。"
 
-#: src/muuli_wdr.cpp:2698
+#: src/muuli_wdr.cpp:2729
 msgid "Reload List"
 msgstr "リストを再ロードする"
 
-#: src/muuli_wdr.cpp:2699
+#: src/muuli_wdr.cpp:2730
 msgid "Reload the list of IPs to filter from the file ~/.aMule/ipfilter.dat"
 msgstr "フィルタリングをかける目標のIPリストを~/.aMule/ipfilter.datから再ロードをします。"
 
-#: src/muuli_wdr.cpp:2705
+#: src/muuli_wdr.cpp:2736
 msgid "URL:"
 msgstr "URL："
 
-#: src/muuli_wdr.cpp:2709 src/muuli_wdr.cpp:2902
+#: src/muuli_wdr.cpp:2740 src/muuli_wdr.cpp:2933
 msgid "Update now"
 msgstr "只今アップデートする"
 
-#: src/muuli_wdr.cpp:2712
+#: src/muuli_wdr.cpp:2743
 msgid "Auto-update ipfilter at startup"
 msgstr "スタートアップの時にipfilterを自動アップデートする"
 
-#: src/muuli_wdr.cpp:2716
+#: src/muuli_wdr.cpp:2747
 msgid "Filtering Level:"
 msgstr "フィルタリング段階："
 
-#: src/muuli_wdr.cpp:2722
+#: src/muuli_wdr.cpp:2753
 msgid "Always filter LAN IPs"
 msgstr "いつもLANのIPにフィルタリングをかける"
 
-#: src/muuli_wdr.cpp:2725
+#: src/muuli_wdr.cpp:2756
 msgid "Paranoid handling of non-matching IPs"
 msgstr "適合しないIPを被害妄想的に扱う"
 
-#: src/muuli_wdr.cpp:2727
+#: src/muuli_wdr.cpp:2758
 msgid "Rejects a packet when its source IP differs from the IP the client claims (an anti-spoofing check). Disable only if it causes connection problems."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2729
+#: src/muuli_wdr.cpp:2760
 msgid "Use system-wide ipfilter.dat if available"
 msgstr "提供されていれば、全システム応用のipfilter.datファイルを使用する"
 
-#: src/muuli_wdr.cpp:2730
+#: src/muuli_wdr.cpp:2761
 #, fuzzy
 msgid "If there's no local ipfilter.dat found, allow usage of a system-wide ipfilter file."
 msgstr "ローカルなipfilter.datファイルが見つからなければ、全システム応用のipfilter.datファイルを使用可能します。"
 
-#: src/muuli_wdr.cpp:2747
+#: src/muuli_wdr.cpp:2778
 msgid "Enable Online-Signature"
 msgstr "オンライン証明を有効にする"
 
-#: src/muuli_wdr.cpp:2749
+#: src/muuli_wdr.cpp:2780
 msgid "Enables the writing of the OS file, which can be used by external apps to create signatures and the like."
 msgstr "OSファイルの書き込みを有効にします。このファイルは外のアプリケーションに証明等を作成するためにを使用されます。"
 
-#: src/muuli_wdr.cpp:2753
+#: src/muuli_wdr.cpp:2784
 msgid "Update Frequency (Secs):"
 msgstr "アップデート頻度（秒単位）"
 
-#: src/muuli_wdr.cpp:2756
+#: src/muuli_wdr.cpp:2787
 msgid "Change the frequency (in seconds) of Online Signature updates."
 msgstr "オンライン証明アップデート頻度（秒単位）を変化します。"
 
-#: src/muuli_wdr.cpp:2764
+#: src/muuli_wdr.cpp:2795
 msgid "Save online signature file in: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:2770
+#: src/muuli_wdr.cpp:2801
 msgid "Click here to select the directory containing the the Online Signature files."
 msgstr "ここをクリックするとオンライン証明ファイルが入っているディレクトリを選択できます。"
 
-#: src/muuli_wdr.cpp:2803
+#: src/muuli_wdr.cpp:2834
 msgid "Show country flags for clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2804
+#: src/muuli_wdr.cpp:2835
 msgid "Render the country flag column in the transfers, queue and search views. Requires a valid MMDB GeoIP database (see below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2809
+#: src/muuli_wdr.cpp:2840
 #, fuzzy
 msgid "Database"
 msgstr "データ・レート："
 
-#: src/muuli_wdr.cpp:2825
+#: src/muuli_wdr.cpp:2856
 #, fuzzy
 msgid "Source:"
 msgstr "ソース数"
 
-#: src/muuli_wdr.cpp:2828
+#: src/muuli_wdr.cpp:2859
 msgid "DB-IP (free, no account)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2829
+#: src/muuli_wdr.cpp:2860
 msgid "MaxMind GeoLite2 (free, account required)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2830
+#: src/muuli_wdr.cpp:2861
 msgid "Custom URL"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2833
+#: src/muuli_wdr.cpp:2864
 msgid "Choose which provider supplies the GeoIP MMDB database. DB-IP is the default - no account required. MaxMind requires a free account + license key. Use Custom URL to point at any other MMDB host (e.g. a local mirror)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2850
+#: src/muuli_wdr.cpp:2881
 msgid ""
 "No configuration required.\n"
 "\n"
@@ -4852,11 +4880,11 @@ msgid ""
 "License: Creative Commons BY 4.0 - https://creativecommons.org/licenses/by/4.0/"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2863
+#: src/muuli_wdr.cpp:2894
 msgid "License key:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2869
+#: src/muuli_wdr.cpp:2900
 msgid ""
 "Sign up for a free MaxMind account, then generate a License Key:\n"
 "https://www.maxmind.com/en/geolite2/signup\n"
@@ -4866,232 +4894,232 @@ msgid ""
 "Requires attribution and account registration; refresh at least every 30 days."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2884
+#: src/muuli_wdr.cpp:2915
 #, fuzzy
 msgid "Download URL:"
 msgstr "ダウンロード： "
 
-#: src/muuli_wdr.cpp:2890
+#: src/muuli_wdr.cpp:2921
 msgid ""
 "Must point to an .mmdb file or a .gz / .tar.gz containing one.\n"
 "URL may include credentials (https://user:pass@host/...).\n"
 "License and attribution terms are set by the upstream URL - you are responsible."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2903
+#: src/muuli_wdr.cpp:2934
 msgid "Download the GeoIP database from the selected source."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2905
+#: src/muuli_wdr.cpp:2936
 #, fuzzy
 msgid "Auto-update on startup"
 msgstr "スタートアップの時にipfilterを自動アップデートする"
 
-#: src/muuli_wdr.cpp:2906
+#: src/muuli_wdr.cpp:2937
 msgid "Re-download the GeoIP database from the selected source every time aMule starts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2929
+#: src/muuli_wdr.cpp:2960
 msgid "Filter incoming messages (except current chat):"
 msgstr "受信メッセージをフィルタする（現在のチャットを除く）："
 
-#: src/muuli_wdr.cpp:2931
+#: src/muuli_wdr.cpp:2962
 msgid "Filter all messages"
 msgstr "全てのメッセージをフィルタする"
 
-#: src/muuli_wdr.cpp:2933
+#: src/muuli_wdr.cpp:2964
 msgid "Filter messages from people not on your friend list"
 msgstr "友達リストの入っていない方々からのメッセージをフィルタする"
 
-#: src/muuli_wdr.cpp:2935
+#: src/muuli_wdr.cpp:2966
 msgid "Filter messages from unknown clients"
 msgstr "知らないクライアントからのメッセージをフィルタする"
 
-#: src/muuli_wdr.cpp:2937
+#: src/muuli_wdr.cpp:2968
 msgid "Filter messages containing (use ',' as separator):"
 msgstr "次のストリングが入っているメッセージをフィルタする（','で区分する）："
 
-#: src/muuli_wdr.cpp:2940 src/muuli_wdr.cpp:2951
+#: src/muuli_wdr.cpp:2971 src/muuli_wdr.cpp:2982
 msgid "add here the words amule should filter and block messages including it"
 msgstr "amuleがメッセージ・フィルタ／ブロックの目標にする言葉をここに追加してください"
 
-#: src/muuli_wdr.cpp:2942
+#: src/muuli_wdr.cpp:2973
 msgid "Show received messages in the log"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2945
+#: src/muuli_wdr.cpp:2976
 msgid "Comments"
 msgstr "コメント"
 
-#: src/muuli_wdr.cpp:2948
+#: src/muuli_wdr.cpp:2979
 msgid "Filter comments containing (use ',' as separator):"
 msgstr "次のストリングが入っていコメントをフィルタする（','で区分する）："
 
-#: src/muuli_wdr.cpp:2973
+#: src/muuli_wdr.cpp:3004
 msgid "Enable Proxy"
 msgstr "プロクシを有効にする"
 
-#: src/muuli_wdr.cpp:2974
+#: src/muuli_wdr.cpp:3005
 msgid "Enable/disable proxy support"
 msgstr "プロクシ・サポートを有効／無効にする"
 
-#: src/muuli_wdr.cpp:2977
+#: src/muuli_wdr.cpp:3008
 msgid "Proxy type:"
 msgstr "プロクシの種類："
 
-#: src/muuli_wdr.cpp:2988
+#: src/muuli_wdr.cpp:3019
 msgid "Proxy host:"
 msgstr "プロクシー・ホスト："
 
-#: src/muuli_wdr.cpp:2991
+#: src/muuli_wdr.cpp:3022
 msgid "The proxy host name"
 msgstr "プロクシー・ホスト名："
 
-#: src/muuli_wdr.cpp:2993
+#: src/muuli_wdr.cpp:3024
 msgid "Proxy port:"
 msgstr "プロクシー・ポート："
 
-#: src/muuli_wdr.cpp:2996
+#: src/muuli_wdr.cpp:3027
 msgid "The proxy port"
 msgstr "プロクシーのポート"
 
-#: src/muuli_wdr.cpp:2998
+#: src/muuli_wdr.cpp:3029
 msgid "Enable authentication"
 msgstr "認証を有効にする"
 
-#: src/muuli_wdr.cpp:2999
+#: src/muuli_wdr.cpp:3030
 msgid "Enable/disable username/password authentication"
 msgstr "ユーザ名／パスワード認証を有効／無効にする"
 
-#: src/muuli_wdr.cpp:3002
+#: src/muuli_wdr.cpp:3033
 msgid "Username: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:3005
+#: src/muuli_wdr.cpp:3036
 msgid "The username to use to connect to the proxy"
 msgstr "プロクシーに接続に使うユーザ名"
 
-#: src/muuli_wdr.cpp:3007
+#: src/muuli_wdr.cpp:3038
 msgid "Password:"
 msgstr "パスワード："
 
-#: src/muuli_wdr.cpp:3010
+#: src/muuli_wdr.cpp:3041
 msgid "The password to use to connect to the proxy"
 msgstr "プロクシーに接続に使うパスワード"
 
-#: src/muuli_wdr.cpp:3029
+#: src/muuli_wdr.cpp:3060
 msgid "Connect to:"
 msgstr "次に接続する："
 
-#: src/muuli_wdr.cpp:3038
+#: src/muuli_wdr.cpp:3069
 msgid "Login to remote amule"
 msgstr "リモートamuleにログインする"
 
-#: src/muuli_wdr.cpp:3043
+#: src/muuli_wdr.cpp:3074
 msgid "User name"
 msgstr "ユーザ名"
 
-#: src/muuli_wdr.cpp:3054
+#: src/muuli_wdr.cpp:3085
 msgid "Remember those settings"
 msgstr "設定を記憶する"
 
-#: src/muuli_wdr.cpp:3057
+#: src/muuli_wdr.cpp:3088
 #, fuzzy
 msgid "Force ZLIB compression"
 msgstr "gzip圧縮を使用する"
 
-#: src/muuli_wdr.cpp:3081
+#: src/muuli_wdr.cpp:3112
 msgid "Enable Verbose Debug-Logging."
 msgstr "冗長なデバッグ・ロギングを有効にする"
 
-#: src/muuli_wdr.cpp:3083
+#: src/muuli_wdr.cpp:3114
 #, fuzzy
 msgid "Only to Logfile"
 msgstr "ファイルを開く(&O)"
 
-#: src/muuli_wdr.cpp:3085
+#: src/muuli_wdr.cpp:3116
 msgid "Message Categories:"
 msgstr "メッセージのカテゴリ："
 
-#: src/muuli_wdr.cpp:3109 src/PartFileConvertDlg.cpp:160
+#: src/muuli_wdr.cpp:3140 src/PartFileConvertDlg.cpp:160
 msgid "Waiting..."
 msgstr "待機中…"
 
-#: src/muuli_wdr.cpp:3129
+#: src/muuli_wdr.cpp:3160
 msgid "Add imports"
 msgstr "インポートを追加する"
 
-#: src/muuli_wdr.cpp:3132
+#: src/muuli_wdr.cpp:3163
 msgid "Retry selected"
 msgstr "選択したものを再試行"
 
-#: src/muuli_wdr.cpp:3134
+#: src/muuli_wdr.cpp:3165
 msgid "Remove selected"
 msgstr "選択したものを破棄"
 
-#: src/muuli_wdr.cpp:3197
+#: src/muuli_wdr.cpp:3228
 msgid "Event Types"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3216
+#: src/muuli_wdr.cpp:3247
 msgid "Statistics and queued clients for selected file(s) : Session / All time"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3240
+#: src/muuli_wdr.cpp:3271
 #, fuzzy
 msgid "Active Uploads"
 msgstr "アクティブなアップロード数："
 
-#: src/muuli_wdr.cpp:3254
+#: src/muuli_wdr.cpp:3285
 msgid "Percent of total files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3306
+#: src/muuli_wdr.cpp:3337
 #, fuzzy
 msgid "Show Clients for"
 msgstr "クライアントを表示する"
 
-#: src/muuli_wdr.cpp:3308
+#: src/muuli_wdr.cpp:3339
 #, fuzzy
 msgid "All files"
 msgstr "共有ファイルを隠す"
 
-#: src/muuli_wdr.cpp:3311
+#: src/muuli_wdr.cpp:3342
 #, fuzzy
 msgid "Selected files"
 msgstr "ビュー・フィルタを選択してください"
 
-#: src/muuli_wdr.cpp:3314
+#: src/muuli_wdr.cpp:3345
 #, fuzzy
 msgid "Active uploads only"
 msgstr "アクティブなアップロード数"
 
-#: src/muuli_wdr.cpp:3321
+#: src/muuli_wdr.cpp:3352
 #, fuzzy
 msgid "Reload:"
 msgstr "リストを再ロードする"
 
-#: src/muuli_wdr.cpp:3325
+#: src/muuli_wdr.cpp:3356
 msgid "Reload your shared files"
 msgstr "共有ファイルを再ロードする"
 
-#: src/muuli_wdr.cpp:3388
+#: src/muuli_wdr.cpp:3419
 msgid "Send"
 msgstr "送信する"
 
-#: src/muuli_wdr.cpp:3389
+#: src/muuli_wdr.cpp:3420
 msgid "Sends the specified message."
 msgstr "指示するメッセージを送信します。"
 
-#: src/muuli_wdr.cpp:3393
+#: src/muuli_wdr.cpp:3424
 msgid "Close this chat-session."
 msgstr "チャット・セションを閉じます。"
 
-#: src/muuli_wdr.cpp:3416
+#: src/muuli_wdr.cpp:3447
 msgid "Connect to any server and/or Kad"
 msgstr "すべてのサーバ、もしくはKadに接続する"
 
-#: src/muuli_wdr.cpp:3422 src/SharedFilesCtrl.cpp:142 src/Statistics.cpp:941
+#: src/muuli_wdr.cpp:3453 src/SharedFilesCtrl.cpp:142 src/Statistics.cpp:941
 msgid "Shared Files"
 msgstr "共有ファイル"
 
@@ -5448,268 +5476,268 @@ msgstr "ダウンロード済み"
 msgid "ERROR: Failed to open partfile '%s'"
 msgstr "エラー: 部分ファイル '%s' が開けませんでした"
 
-#: src/Preferences.cpp:674
+#: src/Preferences.cpp:701
 msgid "System default"
 msgstr "システムの標準設定"
 
-#: src/Preferences.cpp:675
+#: src/Preferences.cpp:702
 msgid "Albanian"
 msgstr "アルバニア語"
 
-#: src/Preferences.cpp:676
+#: src/Preferences.cpp:703
 msgid "Arabic"
 msgstr "アラブ語"
 
-#: src/Preferences.cpp:677
+#: src/Preferences.cpp:704
 #, fuzzy
 msgid "Asturian"
 msgstr "エストニア語"
 
-#: src/Preferences.cpp:678
+#: src/Preferences.cpp:705
 msgid "Basque"
 msgstr "バスク語"
 
-#: src/Preferences.cpp:679
+#: src/Preferences.cpp:706
 msgid "Bulgarian"
 msgstr "ブルガリア語"
 
-#: src/Preferences.cpp:680
+#: src/Preferences.cpp:707
 msgid "Catalan"
 msgstr "カタロニア語"
 
-#: src/Preferences.cpp:681
+#: src/Preferences.cpp:708
 msgid "Chinese (Simplified)"
 msgstr "中国語（簡体字）"
 
-#: src/Preferences.cpp:682
+#: src/Preferences.cpp:709
 msgid "Chinese (Traditional)"
 msgstr "中国語（繁体字）"
 
-#: src/Preferences.cpp:683
+#: src/Preferences.cpp:710
 msgid "Croatian"
 msgstr "クロアチア語"
 
-#: src/Preferences.cpp:684
+#: src/Preferences.cpp:711
 msgid "Czech"
 msgstr "チェコ語"
 
-#: src/Preferences.cpp:685
+#: src/Preferences.cpp:712
 msgid "Danish"
 msgstr "デンマーク語"
 
-#: src/Preferences.cpp:686
+#: src/Preferences.cpp:713
 msgid "Dutch"
 msgstr "オランダ語"
 
-#: src/Preferences.cpp:687
+#: src/Preferences.cpp:714
 msgid "English (U.K.)"
 msgstr "英語（U.K.）"
 
-#: src/Preferences.cpp:688
+#: src/Preferences.cpp:715
 #, fuzzy
 msgid "English (U.S.)"
 msgstr "英語（U.K.）"
 
-#: src/Preferences.cpp:689
+#: src/Preferences.cpp:716
 msgid "Estonian"
 msgstr "エストニア語"
 
-#: src/Preferences.cpp:690
+#: src/Preferences.cpp:717
 msgid "Finnish"
 msgstr "フィンランド語"
 
-#: src/Preferences.cpp:691
+#: src/Preferences.cpp:718
 msgid "French"
 msgstr "フランス語"
 
-#: src/Preferences.cpp:692
+#: src/Preferences.cpp:719
 msgid "Galician"
 msgstr "ガリシア語"
 
-#: src/Preferences.cpp:693
+#: src/Preferences.cpp:720
 msgid "German"
 msgstr "ドイツ語"
 
-#: src/Preferences.cpp:694
+#: src/Preferences.cpp:721
 msgid "Greek"
 msgstr "ギリシア語"
 
-#: src/Preferences.cpp:695
+#: src/Preferences.cpp:722
 msgid "Hebrew"
 msgstr "ヘブライ語"
 
-#: src/Preferences.cpp:696
+#: src/Preferences.cpp:723
 msgid "Hungarian"
 msgstr "ハンガリー語"
 
-#: src/Preferences.cpp:697
+#: src/Preferences.cpp:724
 msgid "Italian"
 msgstr "イタリア語"
 
-#: src/Preferences.cpp:698
+#: src/Preferences.cpp:725
 msgid "Japanese"
 msgstr "日本語"
 
-#: src/Preferences.cpp:699
+#: src/Preferences.cpp:726
 msgid "Korean"
 msgstr "韓国語"
 
-#: src/Preferences.cpp:700
+#: src/Preferences.cpp:727
 msgid "Latvian"
 msgstr ""
 
-#: src/Preferences.cpp:701
+#: src/Preferences.cpp:728
 msgid "Lithuanian"
 msgstr "リトアニア語"
 
-#: src/Preferences.cpp:702
+#: src/Preferences.cpp:729
 msgid "Norwegian (Nynorsk)"
 msgstr "ルウェー語"
 
-#: src/Preferences.cpp:703
+#: src/Preferences.cpp:730
 msgid "Polish"
 msgstr "ポーランド語"
 
-#: src/Preferences.cpp:704
+#: src/Preferences.cpp:731
 msgid "Portuguese"
 msgstr "ポルトガル語"
 
-#: src/Preferences.cpp:705
+#: src/Preferences.cpp:732
 msgid "Portuguese (Brazilian)"
 msgstr "ポルトガル語（ブラジル）"
 
-#: src/Preferences.cpp:706
+#: src/Preferences.cpp:733
 #, fuzzy
 msgid "Romanian"
 msgstr "アルバニア語"
 
-#: src/Preferences.cpp:707
+#: src/Preferences.cpp:734
 msgid "Russian"
 msgstr "ロシア語"
 
-#: src/Preferences.cpp:708
+#: src/Preferences.cpp:735
 msgid "Slovenian"
 msgstr "スロベニア語"
 
-#: src/Preferences.cpp:709
+#: src/Preferences.cpp:736
 msgid "Spanish"
 msgstr "スペイン語"
 
-#: src/Preferences.cpp:710
+#: src/Preferences.cpp:737
 msgid "Swedish"
 msgstr "スウェーデン語"
 
-#: src/Preferences.cpp:711
+#: src/Preferences.cpp:738
 msgid "Turkish"
 msgstr "トルコ語"
 
-#: src/Preferences.cpp:712
+#: src/Preferences.cpp:739
 msgid "Ukrainian"
 msgstr ""
 
-#: src/Preferences.cpp:815
+#: src/Preferences.cpp:842
 #, fuzzy
 msgid "Change Language"
 msgstr "言語"
 
-#: src/Preferences.cpp:879
+#: src/Preferences.cpp:906
 msgid "There are no translations installed for aMule"
 msgstr ""
 
-#: src/Preferences.cpp:880
+#: src/Preferences.cpp:907
 #, fuzzy
 msgid "No languages available"
 msgstr "利用不可"
 
-#: src/Preferences.cpp:1011
+#: src/Preferences.cpp:1038
 msgid "no options available"
 msgstr ""
 
-#: src/Preferences.cpp:2182
+#: src/Preferences.cpp:2227
 msgid "Invalid category found, skipping"
 msgstr ""
 
-#: src/Preferences.cpp:2351
+#: src/Preferences.cpp:2396
 msgid "TCP port can't be higher than 65532 due to server UDP socket being TCP+3"
 msgstr "サーバのUDPソケトがTCP+3であるためTCPポートを65532以上には設定できません"
 
-#: src/Preferences.cpp:2352
+#: src/Preferences.cpp:2397
 #, c-format
 msgid "Default port will be used (%d)"
 msgstr "デフォルトポートを使用します (%d)"
 
-#: src/PrefsUnifiedDlg.cpp:298 src/Statistics.cpp:866
+#: src/PrefsUnifiedDlg.cpp:300 src/Statistics.cpp:866
 msgid "Connection"
 msgstr "接続"
 
-#: src/PrefsUnifiedDlg.cpp:299 src/SearchListCtrl.cpp:117
+#: src/PrefsUnifiedDlg.cpp:301 src/SearchListCtrl.cpp:117
 msgid "Directories"
 msgstr "ディレクトリ"
 
-#: src/PrefsUnifiedDlg.cpp:300 src/Statistics.cpp:917
+#: src/PrefsUnifiedDlg.cpp:302 src/Statistics.cpp:917
 msgid "Servers"
 msgstr "サーバ数"
 
-#: src/PrefsUnifiedDlg.cpp:301 src/ServerListCtrl.cpp:96
+#: src/PrefsUnifiedDlg.cpp:303 src/ServerListCtrl.cpp:96
 msgid "Files"
 msgstr "ファイル"
 
-#: src/PrefsUnifiedDlg.cpp:302
+#: src/PrefsUnifiedDlg.cpp:304
 msgid "Security"
 msgstr "セキュリティ"
 
-#: src/PrefsUnifiedDlg.cpp:303
+#: src/PrefsUnifiedDlg.cpp:305
 msgid "Interface"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:310
+#: src/PrefsUnifiedDlg.cpp:312
 msgid "IP2Country"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:313
+#: src/PrefsUnifiedDlg.cpp:315
 msgid "Proxy"
 msgstr "プロクシ"
 
-#: src/PrefsUnifiedDlg.cpp:314
+#: src/PrefsUnifiedDlg.cpp:316
 msgid "Filters"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:315
+#: src/PrefsUnifiedDlg.cpp:317
 msgid "Remote Controls"
 msgstr "リモート制御"
 
-#: src/PrefsUnifiedDlg.cpp:316
+#: src/PrefsUnifiedDlg.cpp:318
 msgid "Online Signature"
 msgstr "オンライン署名"
 
-#: src/PrefsUnifiedDlg.cpp:317
+#: src/PrefsUnifiedDlg.cpp:319
 msgid "Advanced"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:318
+#: src/PrefsUnifiedDlg.cpp:320
 msgid "Events"
 msgstr "イベント"
 
-#: src/PrefsUnifiedDlg.cpp:321
+#: src/PrefsUnifiedDlg.cpp:323
 msgid "Debugging"
 msgstr "デバッグ"
 
-#: src/PrefsUnifiedDlg.cpp:451
+#: src/PrefsUnifiedDlg.cpp:453
 msgid ""
 "The following variables will be substituted:\n"
 "    %PARTFILE - full path to the file\n"
 "    %PARTNAME - file name only"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:472
+#: src/PrefsUnifiedDlg.cpp:474
 msgid "Tray icon support requires libayatana-appindicator3 at compile time."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:488
+#: src/PrefsUnifiedDlg.cpp:490
 msgid "Not available on Wayland: the protocol does not report when a window is minimized, so this option cannot intercept the system minimize button. Workaround: launch aMule with `GDK_BACKEND=x11` to use XWayland instead."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:534
+#: src/PrefsUnifiedDlg.cpp:536
 msgid ""
 "Do not change these setting unless you know\n"
 "what you are doing, otherwise you can easily\n"
@@ -5725,76 +5753,85 @@ msgstr ""
 "この設定を変更しなくてもaMuleはうまく動いて\n"
 "います。"
 
-#: src/PrefsUnifiedDlg.cpp:645
+#: src/PrefsUnifiedDlg.cpp:647
 #, c-format
 msgid "Failed to connect Cfg to widget with the ID %d and key %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:693
+#: src/PrefsUnifiedDlg.cpp:695
 #, c-format
 msgid "Failed to transfer data from Cfg to Widget with the ID %d and key %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:799
+#: src/PrefsUnifiedDlg.cpp:801
 msgid "The type of proxy you are connecting to"
 msgstr "接続するプロクシーの種類"
 
-#: src/PrefsUnifiedDlg.cpp:1003
+#: src/PrefsUnifiedDlg.cpp:1020
 #, c-format
 msgid "Failed to transfer data from Widget to Cfg with the ID %d and key %s"
 msgstr ""
 
 #: src/PrefsUnifiedDlg.cpp:1103
+#, fuzzy
+msgid "No password set."
+msgstr "パスワードをチェック中です\n"
+
+#: src/PrefsUnifiedDlg.cpp:1132
+msgid "Guest access needs a password. Type one in the guest password field, or untick Enable guest access."
+msgstr ""
+
+#: src/PrefsUnifiedDlg.cpp:1144
 msgid ""
 "aMule must be restarted to enable these changes:\n"
 "\n"
 msgstr "この変更点を有効するにはaMuleを再起動しなければなりません：\n"
 
-#: src/PrefsUnifiedDlg.cpp:1110
+#: src/PrefsUnifiedDlg.cpp:1151
 msgid "- TCP port changed.\n"
 msgstr "- TCPポートを変更しました。\n"
 
-#: src/PrefsUnifiedDlg.cpp:1115
+#: src/PrefsUnifiedDlg.cpp:1156
 msgid "- UDP port changed.\n"
 msgstr "- UDPポートを変更しました。\n"
 
-#: src/PrefsUnifiedDlg.cpp:1120
+#: src/PrefsUnifiedDlg.cpp:1161
 #, fuzzy
 msgid "- Network interface binding changed.\n"
 msgstr "外部接続は終了しました。"
 
-#: src/PrefsUnifiedDlg.cpp:1125
+#: src/PrefsUnifiedDlg.cpp:1166
 #, fuzzy
 msgid "- External connect port changed.\n"
 msgstr "外部接続は終了しました。"
 
-#: src/PrefsUnifiedDlg.cpp:1129
+#: src/PrefsUnifiedDlg.cpp:1170
 #, fuzzy
 msgid "- External connect acceptance changed.\n"
 msgstr "新しい外部接続を認められました"
 
-#: src/PrefsUnifiedDlg.cpp:1133
+#: src/PrefsUnifiedDlg.cpp:1174
 #, fuzzy
 msgid "- External connect interface changed.\n"
 msgstr "外部接続は終了しました。"
 
-#: src/PrefsUnifiedDlg.cpp:1137
+#: src/PrefsUnifiedDlg.cpp:1178
 #, fuzzy
 msgid "- Protocol obfuscation support changed.\n"
 msgstr "プロトコルを難読化する"
 
-#: src/PrefsUnifiedDlg.cpp:1151
+#: src/PrefsUnifiedDlg.cpp:1193
 #, fuzzy
 msgid "- amuleapi settings changed.\n"
 msgstr "- 言語を変更しました。\n"
 
-#: src/PrefsUnifiedDlg.cpp:1160
+#: src/PrefsUnifiedDlg.cpp:1202
 msgid ""
 "Your Auto-update server list is empty.\n"
 "'Auto-update server list at startup' will be disabled."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1171
+#: src/PrefsUnifiedDlg.cpp:1213
 msgid ""
 "You have enabled external connections but have not specified a password.\n"
 "External connections cannot be enabled unless a valid password is specified."
@@ -5802,35 +5839,40 @@ msgstr ""
 "外部接続を有効にしましたがパスワードを設定していません。\n"
 "有効なパスワードを設定しないと外部接続を可能できません。"
 
-#: src/PrefsUnifiedDlg.cpp:1202
+#: src/PrefsUnifiedDlg.cpp:1246
+#, c-format
+msgid "The amuleapi password could not be saved: %s"
+msgstr ""
+
+#: src/PrefsUnifiedDlg.cpp:1276
 msgid "- Language changed.\n"
 msgstr "- 言語を変更しました。\n"
 
-#: src/PrefsUnifiedDlg.cpp:1207
+#: src/PrefsUnifiedDlg.cpp:1281
 msgid "- Temp folder changed.\n"
 msgstr "- 一時フォルダを変更しました。\n"
 
-#: src/PrefsUnifiedDlg.cpp:1212
+#: src/PrefsUnifiedDlg.cpp:1286
 #, fuzzy
 msgid "- ED2K network enabled.\n"
 msgstr "全てのネットワークが無効になっています。"
 
-#: src/PrefsUnifiedDlg.cpp:1245
+#: src/PrefsUnifiedDlg.cpp:1319
 msgid "The shared-file exclusion pattern is not a valid regular expression. The filter has been left disabled."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1247 src/PrefsUnifiedDlg.cpp:1841
+#: src/PrefsUnifiedDlg.cpp:1321 src/PrefsUnifiedDlg.cpp:1921
 #, fuzzy
 msgid "Invalid regular expression"
 msgstr "無効なプロトコルバージョン。"
 
-#: src/PrefsUnifiedDlg.cpp:1324
+#: src/PrefsUnifiedDlg.cpp:1398
 msgid ""
 "Both eD2k and Kad network are disabled.\n"
 "You won't be able to connect until you enable at least one of them."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1329
+#: src/PrefsUnifiedDlg.cpp:1403
 msgid ""
 "Kad will not start if your UDP port is disabled.\n"
 "Enable UDP port or disable Kad."
@@ -5838,7 +5880,7 @@ msgstr ""
 "UDPポートが無効になっているとKadは開始できません。\n"
 "UDPポートを有効にするか、またはKadを無効にしてください。"
 
-#: src/PrefsUnifiedDlg.cpp:1385
+#: src/PrefsUnifiedDlg.cpp:1459
 msgid ""
 "\n"
 "You MUST restart aMule now.\n"
@@ -5848,69 +5890,69 @@ msgstr ""
 "必ず早急にaMuleを再起動してください。\n"
 "今すぐに再起動しなければ、挙動がおかしくなる可能性があります。\n"
 
-#: src/PrefsUnifiedDlg.cpp:1450
+#: src/PrefsUnifiedDlg.cpp:1524
 msgid "Could not register aMule for autostart at login. The autostart store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1452
+#: src/PrefsUnifiedDlg.cpp:1526
 msgid "Could not remove the autostart-at-login entry."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1453
+#: src/PrefsUnifiedDlg.cpp:1527
 #, fuzzy
 msgid "Autostart"
 msgstr "オートリフレッシュを開始しました"
 
-#: src/PrefsUnifiedDlg.cpp:1468
+#: src/PrefsUnifiedDlg.cpp:1542
 msgid "Register file type"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1468
+#: src/PrefsUnifiedDlg.cpp:1542
 msgid "Register URL handler"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1476
+#: src/PrefsUnifiedDlg.cpp:1550
 #, c-format
 msgid "aMule only handles eD2k-compatible magnets. If you replace the current magnet handler (%s), BitTorrent magnet links will stop working - aMule cannot download BitTorrent content. Continue?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1481
+#: src/PrefsUnifiedDlg.cpp:1555
 #, c-format
 msgid "Another application currently opens .emulecollection files (%s). Replace it with aMule?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1486
+#: src/PrefsUnifiedDlg.cpp:1560
 #, c-format
 msgid "Another application is currently the default handler for these links (%s). Replace it with aMule?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1511
+#: src/PrefsUnifiedDlg.cpp:1585
 msgid "Could not register aMule for .emulecollection files. The registration store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1513
+#: src/PrefsUnifiedDlg.cpp:1587
 #, fuzzy
 msgid "Could not remove the file type registration."
 msgstr "あなたはすでにファイル%sをダウンロードしようとしています"
 
-#: src/PrefsUnifiedDlg.cpp:1515
+#: src/PrefsUnifiedDlg.cpp:1589
 msgid "Could not register aMule as the URL handler. The registration store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1517
+#: src/PrefsUnifiedDlg.cpp:1591
 msgid "Could not remove the URL handler registration."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1587 src/PrefsUnifiedDlg.cpp:1614
+#: src/PrefsUnifiedDlg.cpp:1661 src/PrefsUnifiedDlg.cpp:1688
 #, fuzzy
 msgid "The web server and aMule API require external connections to be enabled."
 msgstr "新しい外部接続を認められました"
 
-#: src/PrefsUnifiedDlg.cpp:1597
+#: src/PrefsUnifiedDlg.cpp:1671
 msgid "The aMule web server is deprecated. Consider running the aMule API instead."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1655
+#: src/PrefsUnifiedDlg.cpp:1735
 msgid ""
 "Your Auto-update servers list is in blank.\n"
 "Please fill in at least one URL to point to a valid server.met file.\n"
@@ -5920,65 +5962,65 @@ msgstr ""
 "せめて一つのURLを入力して、有効なserver.metファイルを指定してください。\n"
 "このチェックボクスの近くの\"表\"ボタンをクリックして、URLを入力してください。"
 
-#: src/PrefsUnifiedDlg.cpp:1796
+#: src/PrefsUnifiedDlg.cpp:1876
 msgid "Temporary files"
 msgstr "一時ファイル"
 
-#: src/PrefsUnifiedDlg.cpp:1801
+#: src/PrefsUnifiedDlg.cpp:1881
 msgid "Incoming files"
 msgstr "受信ファイル"
 
-#: src/PrefsUnifiedDlg.cpp:1806
+#: src/PrefsUnifiedDlg.cpp:1886
 msgid "Online Signatures"
 msgstr "オンライン署名"
 
-#: src/PrefsUnifiedDlg.cpp:1819
+#: src/PrefsUnifiedDlg.cpp:1899
 #, c-format
 msgid "Choose a folder for %s"
 msgstr " %s のためのフォルダを選択する"
 
-#: src/PrefsUnifiedDlg.cpp:1843
+#: src/PrefsUnifiedDlg.cpp:1923
 #, fuzzy, c-format
 msgid "Would exclude %u of %u shared file"
 msgid_plural "Would exclude %u of %u shared files"
 msgstr[0] "%i個の既知の共有ファイルが見つかりました"
 
-#: src/PrefsUnifiedDlg.cpp:1860
+#: src/PrefsUnifiedDlg.cpp:1940
 msgid "Browse for videoplayer"
 msgstr "ビデオプレイヤーを選択する"
 
-#: src/PrefsUnifiedDlg.cpp:1864
+#: src/PrefsUnifiedDlg.cpp:1944
 msgid "Select browser"
 msgstr "ブラウザを選択する"
 
-#: src/PrefsUnifiedDlg.cpp:1868
+#: src/PrefsUnifiedDlg.cpp:1948
 #, fuzzy
 msgid "Select ffprobe binary"
 msgstr "ブラウザを選択する"
 
-#: src/PrefsUnifiedDlg.cpp:1874
+#: src/PrefsUnifiedDlg.cpp:1954
 #, c-format
 msgid "Executable%s"
 msgstr "実行ファイル%s"
 
-#: src/PrefsUnifiedDlg.cpp:1908
+#: src/PrefsUnifiedDlg.cpp:1988
 msgid "ffprobe not found on PATH or in the standard install locations. Install ffmpeg (which ships ffprobe) or use Browse to pick a binary manually."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1920
+#: src/PrefsUnifiedDlg.cpp:2000
 msgid "Reset the settings on this page to their default values?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1921
+#: src/PrefsUnifiedDlg.cpp:2001
 #, fuzzy
 msgid "Reset to defaults"
 msgstr "システムの標準設定"
 
-#: src/PrefsUnifiedDlg.cpp:1948
+#: src/PrefsUnifiedDlg.cpp:2028
 msgid "Edit server list"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1949
+#: src/PrefsUnifiedDlg.cpp:2029
 msgid ""
 "Add here URL's to download server.met files.\n"
 "Only one url on each line."
@@ -5986,150 +6028,150 @@ msgstr ""
 "server.metファイルをダウンロードするURLをここに追加してください。\n"
 "一行にひとつのURLのみです。"
 
-#: src/PrefsUnifiedDlg.cpp:2004
+#: src/PrefsUnifiedDlg.cpp:2084
 msgid "IP2Country update failed"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2149 src/PrefsUnifiedDlg.cpp:2180
+#: src/PrefsUnifiedDlg.cpp:2229 src/PrefsUnifiedDlg.cpp:2260
 msgid "Data by MaxMind GeoLite2"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2151 src/PrefsUnifiedDlg.cpp:2182
+#: src/PrefsUnifiedDlg.cpp:2231 src/PrefsUnifiedDlg.cpp:2262
 #, fuzzy
 msgid "Custom source"
 msgstr "ソース完了"
 
-#: src/PrefsUnifiedDlg.cpp:2153 src/PrefsUnifiedDlg.cpp:2184
+#: src/PrefsUnifiedDlg.cpp:2233 src/PrefsUnifiedDlg.cpp:2264
 msgid "Data by DB-IP.com"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2204
+#: src/PrefsUnifiedDlg.cpp:2284
 #, fuzzy, c-format
 msgid "Status: Loaded%s"
 msgstr "ステータス："
 
-#: src/PrefsUnifiedDlg.cpp:2206
+#: src/PrefsUnifiedDlg.cpp:2286
 #, fuzzy, c-format
 msgid "Status: Loaded%s - %s"
 msgstr "ステータス："
 
-#: src/PrefsUnifiedDlg.cpp:2210
+#: src/PrefsUnifiedDlg.cpp:2290
 msgid "Status: Failed to load - click 'Update now' to refresh."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2212
+#: src/PrefsUnifiedDlg.cpp:2292
 msgid "Status: Not found - click 'Update now' to download."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2270 src/PrefsUnifiedDlg.cpp:2294
+#: src/PrefsUnifiedDlg.cpp:2350 src/PrefsUnifiedDlg.cpp:2374
 #, c-format
 msgid "Update delay: %d second"
 msgid_plural "Update delay: %d seconds"
 msgstr[0] "アップデート遅延時間： %d 秒"
 
-#: src/PrefsUnifiedDlg.cpp:2278
+#: src/PrefsUnifiedDlg.cpp:2358
 #, c-format
 msgid "Time for average graph: %d minute"
 msgid_plural "Time for average graph: %d minutes"
 msgstr[0] "平均グラフの時間： %d 分"
 
-#: src/PrefsUnifiedDlg.cpp:2287
+#: src/PrefsUnifiedDlg.cpp:2367
 #, c-format
 msgid "Connections Graph Scale: %d"
 msgstr "接続グラフスケール： %d"
 
-#: src/PrefsUnifiedDlg.cpp:2302
+#: src/PrefsUnifiedDlg.cpp:2382
 #, c-format
 msgid "File Buffer Size: %d byte"
 msgid_plural "File Buffer Size: %d bytes"
 msgstr[0] "ファイルバッファサイズ： %d バイト"
 
-#: src/PrefsUnifiedDlg.cpp:2312
+#: src/PrefsUnifiedDlg.cpp:2392
 #, c-format
 msgid "Upload Queue Size: %d client"
 msgid_plural "Upload Queue Size: %d clients"
 msgstr[0] "アップロードキューサイズ： %d クライアント"
 
-#: src/PrefsUnifiedDlg.cpp:2322
+#: src/PrefsUnifiedDlg.cpp:2402
 #, c-format
 msgid "Server connection refresh interval: %d minute"
 msgid_plural "Server connection refresh interval: %d minutes"
 msgstr[0] "サーバ接続リフレッシュ遅延時間： %d 分"
 
-#: src/PrefsUnifiedDlg.cpp:2327
+#: src/PrefsUnifiedDlg.cpp:2407
 msgid "Server connection refresh interval: Disabled"
 msgstr "サーバ接続リフレッシュ遅延時間： 無効"
 
-#: src/PrefsUnifiedDlg.cpp:2371
+#: src/PrefsUnifiedDlg.cpp:2451
 #, fuzzy
 msgid "disabled"
 msgstr "無効にする"
 
-#: src/PrefsUnifiedDlg.cpp:2397
+#: src/PrefsUnifiedDlg.cpp:2477
 #, fuzzy, c-format
 msgid "Execute command on '%s' event"
 msgstr " `%s' イベントにコマンドを実行する"
 
-#: src/PrefsUnifiedDlg.cpp:2404
+#: src/PrefsUnifiedDlg.cpp:2484
 msgid "Enable command execution on core"
 msgstr "コアにコマンドを実行することを有効にする"
 
-#: src/PrefsUnifiedDlg.cpp:2416
+#: src/PrefsUnifiedDlg.cpp:2496
 msgid "Core command:"
 msgstr "コアコマンド："
 
-#: src/PrefsUnifiedDlg.cpp:2432
+#: src/PrefsUnifiedDlg.cpp:2512
 msgid "Enable command execution on GUI"
 msgstr "GUIにコマンドを実行することを有効にする"
 
-#: src/PrefsUnifiedDlg.cpp:2444
+#: src/PrefsUnifiedDlg.cpp:2524
 msgid "GUI command:"
 msgstr "GUIコマンド："
 
-#: src/PrefsUnifiedDlg.cpp:2460
+#: src/PrefsUnifiedDlg.cpp:2540
 msgid "The following variables will be replaced:"
 msgstr "次の変数は置換されます："
 
-#: src/PrefsUnifiedDlg.cpp:2628
+#: src/PrefsUnifiedDlg.cpp:2708
 msgid ""
 "The following folders look like system or sensitive locations:\n"
 "\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2633
+#: src/PrefsUnifiedDlg.cpp:2713
 msgid "Sharing them recursively will publish every file underneath on the eD2k/Kad networks. Do you really want to do this?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2636
+#: src/PrefsUnifiedDlg.cpp:2716
 #, fuzzy
 msgid "Confirm shared folders"
 msgstr "共有ファイルを再ロードする"
 
-#: src/PrefsUnifiedDlg.cpp:2664
+#: src/PrefsUnifiedDlg.cpp:2744
 #, fuzzy
 msgid "Reloading shared files..."
 msgstr "共有ファイルを再ロードする"
 
-#: src/PrefsUnifiedDlg.cpp:2665
+#: src/PrefsUnifiedDlg.cpp:2745
 msgid "Scanning for subdirectories..."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2666
+#: src/PrefsUnifiedDlg.cpp:2746
 #, fuzzy
 msgid "Updating shared folders"
 msgstr "一時フォルダを読み中です"
 
-#: src/PrefsUnifiedDlg.cpp:2693
+#: src/PrefsUnifiedDlg.cpp:2773
 #, c-format
 msgid "Scanned %u directories..."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2743
+#: src/PrefsUnifiedDlg.cpp:2823
 #, fuzzy, c-format
 msgid "Reloading shared files: %u files scanned"
 msgstr "共有ファイル・リストを再ロードします。"
 
-#: src/PrefsUnifiedDlg.cpp:2793
+#: src/PrefsUnifiedDlg.cpp:2873
 #, fuzzy
 msgid "Shared folder"
 msgstr "共有ファイル"

--- a/po/ja.po
+++ b/po/ja.po
@@ -9,8 +9,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-28 12:12+0200\n"
-"PO-Revision-Date: 2026-07-27 10:26+0000\n"
+"POT-Creation-Date: 2026-07-28 08:06+0200\n"
+"PO-Revision-Date: 2026-07-27 11:41+0000\n"
 "Last-Translator: \n"
 "Language-Team: Japanese\n"
 "Language: ja\n"
@@ -141,7 +141,7 @@ msgstr ""
 msgid "Not now"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:422 src/amuleDlg.cpp:665
+#: src/AppImageIntegration.cpp:422 src/amuleDlg.cpp:600
 msgid "Don't ask again"
 msgstr ""
 
@@ -200,160 +200,160 @@ msgstr "%s（%s）を開くことはできませんでした"
 msgid "WARNING: You can't add yourself as a source for an eD2k link while having a lowid."
 msgstr ""
 
-#: src/amule.cpp:301
+#: src/amule.cpp:300
 #, fuzzy
 msgid "Now, exiting main app..."
 msgstr ""
 "\n"
 "OK、%s を終了中です...\n"
 
-#: src/amule.cpp:331
+#: src/amule.cpp:330
 #, c-format
 msgid "Terminating amuleweb instance with pid '%d' ... "
 msgstr ""
 
-#: src/amule.cpp:335
+#: src/amule.cpp:334
 #, c-format
 msgid "Killing amuleweb instance with pid '%d' ... "
 msgstr ""
 
-#: src/amule.cpp:337 src/amule.cpp:350 src/ClientRef.cpp:180
-#: src/SearchDlg.cpp:1041 src/ServerListCtrl.cpp:98
+#: src/amule.cpp:336 src/amule.cpp:349 src/ClientRef.cpp:180
+#: src/SearchDlg.cpp:880 src/ServerListCtrl.cpp:98
 msgid "Failed"
 msgstr "失敗しました"
 
-#: src/amule.cpp:344
+#: src/amule.cpp:343
 #, c-format
 msgid "Terminating amuleapi instance with pid '%d' ... "
 msgstr ""
 
-#: src/amule.cpp:348
+#: src/amule.cpp:347
 #, c-format
 msgid "Killing amuleapi instance with pid '%d' ... "
 msgstr ""
 
-#: src/amule.cpp:356
+#: src/amule.cpp:355
 msgid "aMule OnExit: Terminating core."
 msgstr ""
 
-#: src/amule.cpp:467
+#: src/amule.cpp:466
 #, fuzzy
 msgid "aMule shutdown completed."
 msgstr "ダウンロード完了"
 
-#: src/amule.cpp:471
+#: src/amule.cpp:470
 msgid "Memory debug results for aMule exit:"
 msgstr ""
 
-#: src/amule.cpp:652
+#: src/amule.cpp:651
 #, c-format
 msgid "Binding aMule's peer-to-peer traffic to interface: %s (HTTP updates use the default route)"
 msgstr ""
 
-#: src/amule.cpp:656
+#: src/amule.cpp:655
 #, c-format
 msgid "Binding all network traffic to interface: %s"
 msgstr ""
 
-#: src/amule.cpp:660
+#: src/amule.cpp:659
 #, c-format
 msgid "WARNING: configured network interface '%s' was not found - traffic is NOT bound to it and may leave via the default route. Check the interface name in Preferences."
 msgstr ""
 
-#: src/amule.cpp:666
+#: src/amule.cpp:665
 #, c-format
 msgid "WARNING: binding to network interface '%s' requires elevated privileges and was NOT applied - traffic may leave via the default route. Grant the capability (e.g. 'sudo setcap cap_net_raw+ep' on the aMule binary) or run with sufficient privileges."
 msgstr ""
 
-#: src/amule.cpp:674
+#: src/amule.cpp:673
 #, c-format
 msgid "WARNING: could not bind to network interface '%s' - traffic may leave via the default route."
 msgstr ""
 
-#: src/amule.cpp:733
+#: src/amule.cpp:732
 msgid "Your locale has been changed to System Default due to a configuration change. Sorry."
 msgstr "申し訳ありませんが、設定の変更を行ったため、あなたのロケールはシステム標準に変更されました。"
 
-#: src/amule.cpp:735 src/amule.cpp:1589 src/CatDialog.cpp:128
+#: src/amule.cpp:734 src/amule.cpp:1581 src/CatDialog.cpp:128
 #: src/CatDialog.cpp:136 src/CatDialog.cpp:149 src/ServerList.cpp:366
 #: src/ServerListCtrl.cpp:152
 msgid "Info"
 msgstr "情報"
 
-#: src/amule.cpp:742
+#: src/amule.cpp:741
 #, fuzzy
 msgid ""
 "\n"
 "EC configuration"
 msgstr "終了の確認"
 
-#: src/amule.cpp:745
+#: src/amule.cpp:744
 #, fuzzy
 msgid "Password set and external connections enabled."
 msgstr "新しい外部接続を認められました"
 
-#: src/amule.cpp:755 src/KadDlg.cpp:176 src/KadDlg.cpp:185
-#: src/PrefsUnifiedDlg.cpp:1461 src/SharedFilesCtrl.cpp:476
+#: src/amule.cpp:754 src/KadDlg.cpp:176 src/KadDlg.cpp:185
+#: src/PrefsUnifiedDlg.cpp:1387 src/SharedFilesCtrl.cpp:476
 msgid "WARNING"
 msgstr "警告"
 
-#: src/amule.cpp:992
+#: src/amule.cpp:991
 #, fuzzy
 msgid "Network bootstrap"
 msgstr "ネットワーク"
 
-#: src/amule.cpp:997
+#: src/amule.cpp:996
 msgid ""
 "aMule has detected missing network bootstrap files.\n"
 "Select which ones to download:"
 msgstr ""
 
-#: src/amule.cpp:1006 src/FirstRunWizard.cpp:411
+#: src/amule.cpp:1005 src/FirstRunWizard.cpp:411
 #, fuzzy
 msgid "eD2k server list (server.met)"
 msgstr "server.metに%i個のサーバが見つかりました"
 
-#: src/amule.cpp:1013 src/FirstRunWizard.cpp:416
+#: src/amule.cpp:1012 src/FirstRunWizard.cpp:416
 msgid "Kad bootstrap nodes (nodes.dat)"
 msgstr ""
 
-#: src/amule.cpp:1103
+#: src/amule.cpp:1102
 #, c-format
 msgid "web server running on pid %d"
 msgstr ""
 
-#: src/amule.cpp:1116
+#: src/amule.cpp:1115
 msgid "You requested to run web server on startup, but the amuleweb binary cannot be run. Please install the package containing aMule web server, or build aMule from source with -DBUILD_WEBSERVER=YES and install it."
 msgstr ""
 
-#: src/amule.cpp:1121 src/amule.cpp:1185 src/amule.cpp:1299 src/amule.cpp:1601
+#: src/amule.cpp:1120 src/amule.cpp:1177 src/amule.cpp:1291 src/amule.cpp:1593
 #: src/amule-remote-gui.cpp:603 src/amule-remote-gui.cpp:671
 #: src/amule-remote-gui.cpp:709 src/amule-remote-gui.cpp:1282
 #: src/amule-remote-gui.cpp:1345 src/amule-remote-gui.cpp:1372
-#: src/DownloadQueue.cpp:1481 src/PrefsUnifiedDlg.cpp:1247
+#: src/DownloadQueue.cpp:1481
 msgid "ERROR"
 msgstr ""
 
-#: src/amule.cpp:1174
+#: src/amule.cpp:1166
 #, fuzzy, c-format
 msgid "amuleapi running on pid %d"
 msgstr "aMuleは動作しています"
 
-#: src/amule.cpp:1180
+#: src/amule.cpp:1172
 msgid "You requested to run amuleapi on startup, but the amuleapi binary cannot be run. Please install the package containing aMule's REST API server, or build aMule from source with -DBUILD_AMULEAPI=YES and install it."
 msgstr ""
 
-#: src/amule.cpp:1267
+#: src/amule.cpp:1259
 #, c-format
 msgid "Could not bind ports to the specified address: %s"
 msgstr "指定したアドレスにポートをバインドできませんでした: %s"
 
-#: src/amule.cpp:1291
+#: src/amule.cpp:1283
 #, c-format
 msgid "Port %u is not available. You will be LOWID\n"
 msgstr "ポート%uは利用できません。あなたにはLOWIDが与えられます\n"
 
-#: src/amule.cpp:1296
+#: src/amule.cpp:1288
 #, c-format
 msgid ""
 "Port %u is not available!\n"
@@ -368,48 +368,48 @@ msgstr ""
 "\n"
 "ネットワークを調べ、ポートが入出力に対して開いているか確認してください。"
 
-#: src/amule.cpp:1393
+#: src/amule.cpp:1385
 msgid "Failed to create OnlineSig File"
 msgstr "オンライン証明ファイルの生成に失敗しました"
 
-#: src/amule.cpp:1401
+#: src/amule.cpp:1393
 msgid "Failed to create aMule OnlineSig File"
 msgstr "aMuleのオンライン証明ファイルの生成に失敗しました"
 
-#: src/amule.cpp:1564
+#: src/amule.cpp:1556
 msgid "The selected locale seems not to be installed on your box. (Note: I'll try to set it anyway)"
 msgstr "選択したロケールはあなたのシステムにインストールされていないようです。（注意：いずれにせよ設定を試みます）"
 
-#: src/amule.cpp:1574
+#: src/amule.cpp:1566
 #, c-format
 msgid "This is the first time you run aMule %s"
 msgstr "初めてaMule %sを起動しています"
 
-#: src/amule.cpp:1577
+#: src/amule.cpp:1569
 msgid "This version is a testing version, updated daily, and\n"
 msgstr "このバージョンはテスト・バージョンで、毎日更新されているものです。\n"
 
-#: src/amule.cpp:1578
+#: src/amule.cpp:1570
 msgid "we give no warranty it won't break anything, burn your house,\n"
 msgstr "あなたに損害を与えないということは保証できません。家を焼いてしまうかも知れないし、\n"
 
-#: src/amule.cpp:1579
+#: src/amule.cpp:1571
 msgid "or kill your dog. But it *should* be safe to use anyway.\n"
 msgstr "犬を殺してしまうかも知れません。しかし、安全に使用できる「はず」です。\n"
 
-#: src/amule.cpp:1584
+#: src/amule.cpp:1576
 msgid "More information, support and new releases can found at our homepage,\n"
 msgstr "私たちのホームページamule-org.github.io、またはIRCチャネルirc.libera.chatの#aMuleには、\n"
 
-#: src/amule.cpp:1585
+#: src/amule.cpp:1577
 msgid "at https://amule-org.github.io, or in our IRC channel #aMule at irc.libera.chat.\n"
 msgstr "詳細な情報、サポートや新しいリリースがあります。\n"
 
-#: src/amule.cpp:1587
+#: src/amule.cpp:1579
 msgid "Feel free to report any bugs to https://github.com/amule-org/amule/issues"
 msgstr "バグはhttps://github.com/amule-org/amule/issuesに気楽に報告してください"
 
-#: src/amule.cpp:1599
+#: src/amule.cpp:1591
 msgid ""
 "The folder for Online Signature files you specified is INVALID!\n"
 " OnlineSignature will be DISABLED until you fix it on preferences."
@@ -417,138 +417,138 @@ msgstr ""
 "あなたが指定したオンライン証明ファイルのフォルダは不正です！\n"
 "設定で訂正するまでオンライン証明を無効にします。"
 
-#: src/amule.cpp:1662
+#: src/amule.cpp:1654
 #, fuzzy
 msgid "Server hostname notified"
 msgstr "サーバ名："
 
-#: src/amule.cpp:2039
+#: src/amule.cpp:2031
 #, c-format
 msgid "Disk space preallocation for file '%s' failed: %s"
 msgstr "ファイル '%s' のディスク領域の事前確保が失敗しました: %s"
 
-#: src/amule.cpp:2168
+#: src/amule.cpp:2160
 msgid "ERROR: can't open logfile"
 msgstr "エラー：ログファイルを開くことはできません"
 
-#: src/amule.cpp:2172
+#: src/amule.cpp:2164
 msgid "WARNING: logfile is empty. Something is wrong."
 msgstr "注意：ログファイルは空です。何かがおかしいです。"
 
-#: src/amule.cpp:2189
+#: src/amule.cpp:2181
 msgid "Log has been reset"
 msgstr "ログはリセットされました"
 
-#: src/amule.cpp:2213
+#: src/amule.cpp:2205
 #, c-format
 msgid "ServerMessage: %s"
 msgstr "サーバ・メッセージ：%s"
 
-#: src/amule.cpp:2256 src/IP2Country.cpp:220 src/IPFilter.cpp:514
+#: src/amule.cpp:2248 src/IP2Country.cpp:220 src/IPFilter.cpp:514
 #: src/ServerList.cpp:875
 #, c-format
 msgid "Skipped download of %s, because requested file is not newer."
 msgstr ""
 
-#: src/amule.cpp:2259
+#: src/amule.cpp:2251
 msgid "Failed to download the nodes list."
 msgstr "ノード・リストをダウンロードのに失敗しました。"
 
-#: src/amule.cpp:2322
+#: src/amule.cpp:2314
 msgid "Failed to open the downloaded version check file"
 msgstr "ダウンロードされたバージョン確認ファイルを開くのに失敗しました。"
 
-#: src/amule.cpp:2325 src/amule.cpp:2344
+#: src/amule.cpp:2317 src/amule.cpp:2336
 msgid "Corrupted version check file"
 msgstr "破損されたバージョン確認ファイル"
 
-#: src/amule.cpp:2367
+#: src/amule.cpp:2359
 msgid "You are using an outdated version of aMule!"
 msgstr "あなたは古いバージョンのaMuleを使用しています！"
 
-#: src/amule.cpp:2369
+#: src/amule.cpp:2361
 #, c-format
 msgid "Your aMule version is %i.%i.%i and the latest version is %li.%li.%li"
 msgstr "あなたのaMuleバージョンは%i.%i.%iで、最新バージョンは%li.%li.%liです"
 
-#: src/amule.cpp:2373
+#: src/amule.cpp:2365
 msgid "The latest version can always be found at https://github.com/amule-org/amule/releases/latest"
 msgstr "最新バージョンはいつもhttps://github.com/amule-org/amule/releases/latestにあります"
 
-#: src/amule.cpp:2376
+#: src/amule.cpp:2368
 #, c-format
 msgid "WARNING: Your aMuled version is outdated: %i.%i.%i < %li.%li.%li"
 msgstr "警告：あなたのaMuledバージョンは古くなっています：%i.%i.%i < %li.%li.%li"
 
-#: src/amule.cpp:2382
+#: src/amule.cpp:2374
 msgid "Your copy of aMule is up to date."
 msgstr "あなたのaMuleは最新のバージョンです。"
 
-#: src/amule.cpp:2389
+#: src/amule.cpp:2381
 msgid "Failed to download the version check file"
 msgstr "バージョン確認ファイルのダウンロードに失敗しました"
 
-#: src/amule.cpp:2558 src/amule-remote-gui.cpp:1133
+#: src/amule.cpp:2550 src/amule-remote-gui.cpp:1133
 #, c-format
 msgid "Users: %s | Files: %s"
 msgstr "ユーザ: %s | ファイル: %s"
 
-#: src/amule.cpp:2559 src/amule-remote-gui.cpp:1134
+#: src/amule.cpp:2551 src/amule-remote-gui.cpp:1134
 #, c-format
 msgid "Users: E: %s K: %s | Files: E: %s K: %s"
 msgstr "ユーザ: E: %s K: %s | ファイル: E: %s K: %s"
 
-#: src/amule.cpp:2573 src/amule-remote-gui.cpp:1147
+#: src/amule.cpp:2565 src/amule-remote-gui.cpp:1147
 msgid "No networks selected"
 msgstr "ネットワークが選択されていません"
 
-#: src/amule.cpp:2641 src/TextClient.cpp:903
+#: src/amule.cpp:2633 src/TextClient.cpp:903
 msgid "with LowID"
 msgstr "LowIDを持っています"
 
-#: src/amule.cpp:2641 src/TextClient.cpp:904
+#: src/amule.cpp:2633 src/TextClient.cpp:904
 msgid "with HighID"
 msgstr "HighIDを持っています"
 
-#: src/amule.cpp:2643
+#: src/amule.cpp:2635
 #, c-format
 msgid "Connected to %s %s"
 msgstr "接続しています：%s %s"
 
-#: src/amule.cpp:2648
+#: src/amule.cpp:2640
 #, c-format
 msgid "Connecting to %s"
 msgstr "%sに接続中です"
 
-#: src/amule.cpp:2650
+#: src/amule.cpp:2642
 msgid "Disconnected from eD2k"
 msgstr ""
 
-#: src/amule.cpp:2659
+#: src/amule.cpp:2651
 msgid "Kad started."
 msgstr "Kadを開始しました。"
 
-#: src/amule.cpp:2661
+#: src/amule.cpp:2653
 msgid "Kad stopped."
 msgstr "Kadを中止しました。"
 
-#: src/amule.cpp:2669
+#: src/amule.cpp:2661
 msgid "Connected to Kad (ok)"
 msgstr "Kadに接続しています（OK）"
 
-#: src/amule.cpp:2671
+#: src/amule.cpp:2663
 msgid "Connected to Kad (firewalled)"
 msgstr "Kadに接続しています（ファイアウォール）"
 
-#: src/amule.cpp:2675
+#: src/amule.cpp:2667
 msgid "Disconnected from Kad"
 msgstr "Kadから切断しています"
 
-#: src/amule.cpp:2707
+#: src/amule.cpp:2699
 msgid "Kad network cannot be used if UDP port is disabled on preferences, not starting."
 msgstr "UDPポートが設定で無効にされていると、Kadネットワークを使用できないため、開始しません。"
 
-#: src/amule.cpp:2711
+#: src/amule.cpp:2703
 msgid "Kad network disabled on preferences, not connecting."
 msgstr "Kadネットワークは設定で無効にされているため、接続はしません。"
 
@@ -574,68 +574,30 @@ msgstr ""
 msgid "ERROR: %s"
 msgstr "エラー： %s"
 
-#: src/amuleDlg.cpp:250
+#: src/amuleDlg.cpp:236
 #, c-format
 msgid "This is aMule %s based on eMule."
 msgstr "これはeMuleに基づいたaMule %s です。"
 
-#: src/amuleDlg.cpp:251
+#: src/amuleDlg.cpp:237
 #, c-format
 msgid "Running on %s"
 msgstr "%s に起動しています"
 
-#: src/amuleDlg.cpp:253
+#: src/amuleDlg.cpp:239
 msgid "Visit https://github.com/amule-org/amule/releases/latest to check if a new version is available."
 msgstr "新しいバージョンの確認はhttps://github.com/amule-org/amule/releases/latestで。"
 
-#: src/amuleDlg.cpp:282
+#: src/amuleDlg.cpp:268
 msgid "FATAL ERROR: Failed to create Timer"
 msgstr ""
 
-#: src/amuleDlg.cpp:361 src/amuleDlg.cpp:1810 src/amuleDlg.cpp:2056
-#: src/muuli_wdr.cpp:1492 src/muuli_wdr.cpp:3439
-msgid "Networks"
-msgstr "ネットワーク"
-
-#: src/amuleDlg.cpp:362 src/amuleDlg.cpp:1816 src/muuli_wdr.cpp:3440
-msgid "Searches"
-msgstr "検索"
-
-#: src/amuleDlg.cpp:363 src/amuleDlg.cpp:1822 src/DownloadListCtrl.cpp:740
-#: src/muuli_wdr.cpp:392 src/muuli_wdr.cpp:1585 src/muuli_wdr.cpp:3441
-#: src/Statistics.cpp:829
-msgid "Downloads"
-msgstr "ダウンロード数"
-
-#: src/amuleDlg.cpp:364 src/amuleDlg.cpp:1828 src/muuli_wdr.cpp:3315
-msgid "Shared files"
-msgstr ""
-
-#: src/amuleDlg.cpp:365 src/amuleDlg.cpp:1834 src/muuli_wdr.cpp:2947
-#: src/muuli_wdr.cpp:3397 src/muuli_wdr.cpp:3444
-msgid "Messages"
-msgstr "メッセージ"
-
-#: src/amuleDlg.cpp:366 src/amuleDlg.cpp:1840 src/muuli_wdr.cpp:3445
-#: src/PrefsUnifiedDlg.cpp:314 src/Statistics.cpp:779 src/Statistics.cpp:1235
-msgid "Statistics"
-msgstr "統計"
-
-#: src/amuleDlg.cpp:368 src/amuleDlg.cpp:1847 src/muuli_wdr.cpp:3447
-#: src/PrefsUnifiedDlg.cpp:330 src/utils/wxCas/src/wxcasprefs.cpp:39
-msgid "Preferences"
-msgstr "設定"
-
-#: src/amuleDlg.cpp:371
-msgid "Navigate"
-msgstr ""
-
-#: src/amuleDlg.cpp:657
+#: src/amuleDlg.cpp:592
 #, fuzzy
 msgid "New version available"
 msgstr "利用不可"
 
-#: src/amuleDlg.cpp:661
+#: src/amuleDlg.cpp:596
 #, fuzzy, c-format
 msgid ""
 "A new version of aMule (%s) is available.\n"
@@ -645,187 +607,220 @@ msgid ""
 "Would you like to open the download page?"
 msgstr "最新バージョンはいつもhttps://github.com/amule-org/amule/releases/latestにあります"
 
-#: src/amuleDlg.cpp:743
+#: src/amuleDlg.cpp:678
 msgid "aMule dialog destroyed"
 msgstr ""
 
-#: src/amuleDlg.cpp:766 src/DataToText.cpp:68 src/IPFilter.cpp:547
+#: src/amuleDlg.cpp:701 src/DataToText.cpp:68 src/IPFilter.cpp:547
 msgid "Connecting"
 msgstr "接続中"
 
-#: src/amuleDlg.cpp:958
+#: src/amuleDlg.cpp:893
 msgid "eD2k: Connecting"
 msgstr ""
 
-#: src/amuleDlg.cpp:962
+#: src/amuleDlg.cpp:897
 msgid "eD2k: Disconnected"
 msgstr ""
 
-#: src/amuleDlg.cpp:968
+#: src/amuleDlg.cpp:903
 msgid "Kad: Firewalled"
 msgstr "Kad: ファイアウォールされています"
 
-#: src/amuleDlg.cpp:972
+#: src/amuleDlg.cpp:907
 msgid "Kad: Connected"
 msgstr "Kad: 接続"
 
-#: src/amuleDlg.cpp:977
+#: src/amuleDlg.cpp:912
 msgid "Kad: Connecting"
 msgstr "Kad: 接続中"
 
-#: src/amuleDlg.cpp:981
+#: src/amuleDlg.cpp:916
 msgid "Kad: Off"
 msgstr "Kad: オフ"
 
-#: src/amuleDlg.cpp:1029 src/DownloadListCtrl.cpp:505
+#: src/amuleDlg.cpp:964 src/DownloadListCtrl.cpp:505
 #: src/DownloadListCtrl.cpp:749 src/FriendListCtrl.cpp:180
 #: src/muuli_wdr.cpp:731 src/muuli_wdr.cpp:782 src/muuli_wdr.cpp:846
-#: src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2252 src/muuli_wdr.cpp:2337
-#: src/muuli_wdr.cpp:3085 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
+#: src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2224 src/muuli_wdr.cpp:2309
+#: src/muuli_wdr.cpp:3057 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
 #: src/ServerListCtrl.cpp:606 src/TransferWnd.cpp:378
 #: src/utils/wxCas/src/wxcasprefs.cpp:235
 msgid "Cancel"
 msgstr "キャンセル"
 
-#: src/amuleDlg.cpp:1030
+#: src/amuleDlg.cpp:965
 msgid "Stop the current connection attempts"
 msgstr "現在の接続試行を中止する"
 
-#: src/amuleDlg.cpp:1035 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976
-#: src/muuli_wdr.cpp:2475
+#: src/amuleDlg.cpp:970 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976
+#: src/muuli_wdr.cpp:2447
 msgid "Disconnect"
 msgstr "切断する"
 
-#: src/amuleDlg.cpp:1036
+#: src/amuleDlg.cpp:971
 msgid "Disconnect from the currently connected networks"
 msgstr "ネットワークから切断します。"
 
-#: src/amuleDlg.cpp:1041 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979
-#: src/muuli_wdr.cpp:2630 src/muuli_wdr.cpp:3082 src/muuli_wdr.cpp:3437
+#: src/amuleDlg.cpp:976 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979
+#: src/muuli_wdr.cpp:2602 src/muuli_wdr.cpp:3054 src/muuli_wdr.cpp:3409
 msgid "Connect"
 msgstr "接続する"
 
-#: src/amuleDlg.cpp:1042
+#: src/amuleDlg.cpp:977
 msgid "Connect to the currently enabled networks"
 msgstr "ネットワークへ接続します。"
 
-#: src/amuleDlg.cpp:1154
+#: src/amuleDlg.cpp:1089
 #, fuzzy, c-format
 msgid "Up: %.1f%s (%.1f) | Down: %.1f%s (%.1f)"
 msgstr "アップ： %.1f(%.1f) | ダウン： %.1f(%.1f)"
 
-#: src/amuleDlg.cpp:1156 src/amuleDlg.cpp:1158 src/amuleDlg.cpp:1162
-#: src/amuleDlg.cpp:1164 src/amuleDlg.cpp:1175 src/amuleDlg.cpp:1177
+#: src/amuleDlg.cpp:1091 src/amuleDlg.cpp:1093 src/amuleDlg.cpp:1097
+#: src/amuleDlg.cpp:1099 src/amuleDlg.cpp:1110 src/amuleDlg.cpp:1112
 #: src/MuleTrayIcon.cpp:796 src/MuleTrayIcon.cpp:799
 #, fuzzy
 msgid " MB/s"
 msgstr "MB/s"
 
-#: src/amuleDlg.cpp:1156 src/amuleDlg.cpp:1158 src/amuleDlg.cpp:1162
-#: src/amuleDlg.cpp:1164 src/amuleDlg.cpp:1175 src/amuleDlg.cpp:1177
+#: src/amuleDlg.cpp:1091 src/amuleDlg.cpp:1093 src/amuleDlg.cpp:1097
+#: src/amuleDlg.cpp:1099 src/amuleDlg.cpp:1110 src/amuleDlg.cpp:1112
 #: src/MuleTrayIcon.cpp:796 src/MuleTrayIcon.cpp:799
 #: src/utils/wxCas/src/wxcasframe.cpp:1041
 msgid " kB/s"
 msgstr " kB/s"
 
-#: src/amuleDlg.cpp:1161
+#: src/amuleDlg.cpp:1096
 #, fuzzy, c-format
 msgid "Up: %.1f%s | Down: %.1f%s"
 msgstr "アップ： %.1f | ダウン： %.1f"
 
-#: src/amuleDlg.cpp:1193
+#: src/amuleDlg.cpp:1128
 #, c-format
 msgid "aMule (%s | Connected)"
 msgstr "aMule (%s | 接続しています)"
 
-#: src/amuleDlg.cpp:1195
+#: src/amuleDlg.cpp:1130
 #, c-format
 msgid "aMule (%s | Disconnected)"
 msgstr "aMule (%s | 切断しています)"
 
-#: src/amuleDlg.cpp:1248
+#: src/amuleDlg.cpp:1183
 #, fuzzy, c-format
 msgid "Do you really want to exit %s?"
 msgstr "本当にaMuleを終了しますか？"
 
-#: src/amuleDlg.cpp:1250
+#: src/amuleDlg.cpp:1185
 msgid "Exit confirmation"
 msgstr "終了の確認"
 
-#: src/amuleDlg.cpp:1613
+#: src/amuleDlg.cpp:1548
 #, fuzzy
 msgid "Launch Command: "
 msgstr "コマンド： %s"
 
-#: src/amuleDlg.cpp:1632 src/muuli_wdr.cpp:1972 src/Preferences.cpp:979
+#: src/amuleDlg.cpp:1567 src/muuli_wdr.cpp:1971 src/Preferences.cpp:951
 msgid "- default -"
 msgstr ""
 
-#: src/amuleDlg.cpp:1660
+#: src/amuleDlg.cpp:1595
 #, c-format
 msgid "Skin directory '%s' does not exist"
 msgstr "スキンディレクトリ '%s' は存在しません"
 
-#: src/amuleDlg.cpp:1663
+#: src/amuleDlg.cpp:1598
 #, c-format
 msgid "WARNING: Unable to open skin file '%s' for read"
 msgstr ""
 
-#: src/amuleDlg.cpp:1814 src/muuli_wdr.cpp:3439
+#: src/amuleDlg.cpp:1722 src/amuleDlg.cpp:1968 src/muuli_wdr.cpp:1485
+#: src/muuli_wdr.cpp:3411
+msgid "Networks"
+msgstr "ネットワーク"
+
+#: src/amuleDlg.cpp:1726 src/muuli_wdr.cpp:3411
 msgid "Networks Window"
 msgstr "ネットワークウィンドウ"
 
-#: src/amuleDlg.cpp:1820 src/muuli_wdr.cpp:3440
+#: src/amuleDlg.cpp:1728 src/muuli_wdr.cpp:3412
+msgid "Searches"
+msgstr "検索"
+
+#: src/amuleDlg.cpp:1732 src/muuli_wdr.cpp:3412
 msgid "Searches Window"
 msgstr "検索ウィンドウ"
 
-#: src/amuleDlg.cpp:1826 src/muuli_wdr.cpp:3441
+#: src/amuleDlg.cpp:1734 src/DownloadListCtrl.cpp:740 src/muuli_wdr.cpp:392
+#: src/muuli_wdr.cpp:1578 src/muuli_wdr.cpp:3413 src/Statistics.cpp:829
+msgid "Downloads"
+msgstr "ダウンロード数"
+
+#: src/amuleDlg.cpp:1738 src/muuli_wdr.cpp:3413
 #, fuzzy
 msgid "Downloads Window"
 msgstr "ダウンロード"
 
-#: src/amuleDlg.cpp:1832 src/muuli_wdr.cpp:3443
+#: src/amuleDlg.cpp:1740 src/muuli_wdr.cpp:3287
+msgid "Shared files"
+msgstr ""
+
+#: src/amuleDlg.cpp:1744 src/muuli_wdr.cpp:3415
 msgid "Shared Files Window"
 msgstr "共有ファイルウィンドウ"
 
-#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3444
+#: src/amuleDlg.cpp:1746 src/muuli_wdr.cpp:2919 src/muuli_wdr.cpp:3369
+#: src/muuli_wdr.cpp:3416
+msgid "Messages"
+msgstr "メッセージ"
+
+#: src/amuleDlg.cpp:1750 src/muuli_wdr.cpp:3416
 msgid "Messages Window"
 msgstr "メッセージウィンドウ"
 
-#: src/amuleDlg.cpp:1844 src/muuli_wdr.cpp:3445
+#: src/amuleDlg.cpp:1752 src/muuli_wdr.cpp:3417 src/PrefsUnifiedDlg.cpp:312
+#: src/Statistics.cpp:779 src/Statistics.cpp:1235
+msgid "Statistics"
+msgstr "統計"
+
+#: src/amuleDlg.cpp:1756 src/muuli_wdr.cpp:3417
 msgid "Statistics Graph Window"
 msgstr "統計グラフウィインドウ"
 
-#: src/amuleDlg.cpp:1851 src/muuli_wdr.cpp:3447
+#: src/amuleDlg.cpp:1759 src/muuli_wdr.cpp:3419 src/PrefsUnifiedDlg.cpp:328
+#: src/utils/wxCas/src/wxcasprefs.cpp:39
+msgid "Preferences"
+msgstr "設定"
+
+#: src/amuleDlg.cpp:1763 src/muuli_wdr.cpp:3419
 msgid "Preferences Settings Window"
 msgstr "個人設定ウィンドウ"
 
-#: src/amuleDlg.cpp:1854 src/muuli_wdr.cpp:3448
+#: src/amuleDlg.cpp:1766 src/muuli_wdr.cpp:3420
 msgid "Import"
 msgstr "インポート"
 
-#: src/amuleDlg.cpp:1858 src/muuli_wdr.cpp:3448
+#: src/amuleDlg.cpp:1770 src/muuli_wdr.cpp:3420
 msgid "The partfile importer tool"
 msgstr "部分ファイルをインポートするためのツール"
 
-#: src/amuleDlg.cpp:1861 src/muuli_wdr.cpp:3449
+#: src/amuleDlg.cpp:1773 src/muuli_wdr.cpp:3421
 #: src/utils/aLinkCreator/src/alcframe.cpp:262
 msgid "About"
 msgstr "情報"
 
-#: src/amuleDlg.cpp:1861 src/muuli_wdr.cpp:3449
+#: src/amuleDlg.cpp:1773 src/muuli_wdr.cpp:3421
 msgid "About/Help"
 msgstr "ソフトウェア情報／ヘルプ"
 
-#: src/amuleDlg.cpp:2059
+#: src/amuleDlg.cpp:1971
 msgid "eD2k network"
 msgstr ""
 
-#: src/amuleDlg.cpp:2062
+#: src/amuleDlg.cpp:1974
 msgid "Kad network"
 msgstr "Kadネットワーク"
 
-#: src/amuleDlg.cpp:2062
+#: src/amuleDlg.cpp:1974
 msgid "No network"
 msgstr "ネットワークなし"
 
@@ -959,7 +954,7 @@ msgstr "ファイルは見付かりませんでした。"
 msgid "The core rejected these shared folders:%s"
 msgstr ""
 
-#: src/amule-remote-gui.cpp:1336 src/ExternalConn.cpp:2346
+#: src/amule-remote-gui.cpp:1336 src/ExternalConn.cpp:2345
 msgid "Invalid link or already on list."
 msgstr "不正なリンク、またはリンクがすでにリストに入っています。"
 
@@ -975,7 +970,7 @@ msgstr ""
 #: src/ClientDetailDialog.cpp:123 src/DataToText.cpp:61 src/DataToText.cpp:86
 #: src/DataToText.cpp:101 src/DataToText.cpp:136 src/DataToText.cpp:165
 #: src/DownloadListCtrl.cpp:1172 src/DownloadListCtrl.cpp:1185
-#: src/DownloadListCtrl.cpp:1196 src/ExternalConn.cpp:609
+#: src/DownloadListCtrl.cpp:1196 src/ExternalConn.cpp:608
 #: src/FileDetailDialog.cpp:203 src/FileDetailDialog.cpp:235
 #: src/FileDetailDialog.cpp:242 src/GenericClientListCtrl.cpp:1171
 #: src/GenericClientListCtrl.cpp:1182 src/GenericClientListCtrl.cpp:1192
@@ -1357,19 +1352,19 @@ msgstr "オート [Hi]"
 msgid "Very low"
 msgstr "非常に低い"
 
-#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:743 src/muuli_wdr.cpp:2303
+#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:743 src/muuli_wdr.cpp:2275
 #: src/ServerListCtrl.cpp:263 src/ServerListCtrl.cpp:456
 #: src/SharedFilesCtrl.cpp:145
 msgid "Low"
 msgstr "低い"
 
-#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:744 src/muuli_wdr.cpp:2304
+#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:744 src/muuli_wdr.cpp:2276
 #: src/ServerListCtrl.cpp:266 src/ServerListCtrl.cpp:457
 #: src/SharedFilesCtrl.cpp:146
 msgid "Normal"
 msgstr "普通"
 
-#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:745 src/muuli_wdr.cpp:2305
+#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:745 src/muuli_wdr.cpp:2277
 #: src/ServerListCtrl.cpp:269 src/ServerListCtrl.cpp:458
 #: src/SharedFilesCtrl.cpp:147
 msgid "High"
@@ -1461,8 +1456,8 @@ msgstr "ローカルサーバ"
 msgid "Remote Server"
 msgstr "リモートサーバ"
 
-#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3202
-#: src/SearchDlg.cpp:119 src/TextClient.cpp:911
+#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3174
+#: src/SearchDlg.cpp:111 src/TextClient.cpp:911
 msgid "Kad"
 msgstr "Kad"
 
@@ -1533,7 +1528,7 @@ msgstr ""
 msgid "Size"
 msgstr "サイズ"
 
-#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3269
+#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3241
 msgid "Transferred"
 msgstr "転送済み"
 
@@ -1591,7 +1586,7 @@ msgstr ""
 "フィードバック:%s (%s)\n"
 "\n"
 
-#: src/DownloadListCtrl.cpp:746 src/muuli_wdr.cpp:2306
+#: src/DownloadListCtrl.cpp:746 src/muuli_wdr.cpp:2278
 #: src/SharedFilesCtrl.cpp:150
 msgid "Auto"
 msgstr "自動"
@@ -1629,7 +1624,7 @@ msgid "Extended Options"
 msgstr "拡張オプション"
 
 #: src/DownloadListCtrl.cpp:770 src/DownloadListCtrl.cpp:822
-#: src/muuli_wdr.cpp:1790
+#: src/muuli_wdr.cpp:1789
 msgid "Preview"
 msgstr "プレビュー"
 
@@ -1800,237 +1795,232 @@ msgstr[0] ""
 msgid "Invalid eD2k link! ERROR: %s"
 msgstr ""
 
-#: src/ExternalConn.cpp:380
+#: src/ExternalConn.cpp:379
 #, fuzzy
 msgid "Client sent packet after authentication failed."
 msgstr "認証に失敗しました。"
 
-#: src/ExternalConn.cpp:397
+#: src/ExternalConn.cpp:396
 msgid "External connection closed."
 msgstr "外部接続は終了しました。"
 
-#: src/ExternalConn.cpp:474
+#: src/ExternalConn.cpp:473
 msgid "External connections disabled due to empty password!"
 msgstr "外部接続は空パスワードのため無効にしました！"
 
-#: src/ExternalConn.cpp:495
+#: src/ExternalConn.cpp:494
 msgid "External connections disabled in config file"
 msgstr "外部接続を設定ファイルに無効しました"
 
-#: src/ExternalConn.cpp:576
+#: src/ExternalConn.cpp:575
 msgid "New external connection accepted"
 msgstr "新しい外部接続を認められました"
 
-#: src/ExternalConn.cpp:579
+#: src/ExternalConn.cpp:578
 msgid "ERROR: couldn't accept a new external connection"
 msgstr ""
 
-#: src/ExternalConn.cpp:596
+#: src/ExternalConn.cpp:595
 msgid "External connection refused due to empty password in preferences!"
 msgstr "個人設定に空欄のパスワードがあるため、外部接続を拒否しました！"
 
-#: src/ExternalConn.cpp:608
+#: src/ExternalConn.cpp:607
 #, c-format
 msgid "Connecting client: %s %s"
 msgstr "クライアントを接続中： %s %s"
 
-#: src/ExternalConn.cpp:610
+#: src/ExternalConn.cpp:609
 msgid "Unknown version"
 msgstr "不明なバージョン"
 
-#: src/ExternalConn.cpp:623
+#: src/ExternalConn.cpp:622
 msgid "Incorrect EC version ID, there might be binary incompatibility. Use core and remote from same snapshot."
 msgstr "間違ったECバージョンID。バイナリ不互換性の可能性があります。同じスナップショットの コアとリモートを使用してください。"
 
-#: src/ExternalConn.cpp:631
+#: src/ExternalConn.cpp:630
 #, fuzzy
 msgid "You cannot connect to a release version from an arbitrary development snapshot! *sigh* possible crash prevented"
 msgstr "任意CVSバージョンからリリースバージョンに接続はできません！ *ハァ...*起こり得るクラッシュを予防しました"
 
-#: src/ExternalConn.cpp:714
+#: src/ExternalConn.cpp:713
 msgid "Invalid protocol version."
 msgstr "無効なプロトコルバージョン。"
 
-#: src/ExternalConn.cpp:720
+#: src/ExternalConn.cpp:719
 msgid "Missing protocol version tag."
 msgstr "プロトコルバージョンタグがありません。"
 
-#: src/ExternalConn.cpp:728
+#: src/ExternalConn.cpp:727
 msgid "Authentication failed: invalid hash specified as EC password."
 msgstr ""
 
-#: src/ExternalConn.cpp:776
+#: src/ExternalConn.cpp:775
 #, fuzzy
 msgid "Authentication failed: wrong password."
 msgstr "認証に失敗しました。"
 
-#: src/ExternalConn.cpp:778
+#: src/ExternalConn.cpp:777
 #, fuzzy
 msgid "Authentication failed: missing password."
 msgstr "認証に失敗しました。"
 
-#: src/ExternalConn.cpp:789
+#: src/ExternalConn.cpp:788
 #, fuzzy
 msgid "Invalid request, please authenticate first."
 msgstr "無効なリクエストです。先に認証をしてください。"
 
-#: src/ExternalConn.cpp:794
+#: src/ExternalConn.cpp:793
 msgid "Access granted."
 msgstr "アクセスを認められました。"
 
-#: src/ExternalConn.cpp:802
+#: src/ExternalConn.cpp:801
 #, fuzzy, c-format
 msgid "Sent error message \"%s\" to client."
 msgstr "知らないクライアントからのメッセージをフィルタする"
 
-#: src/ExternalConn.cpp:807
+#: src/ExternalConn.cpp:806
 #, fuzzy, c-format
 msgid "Unauthorized access attempt from %s. Connection closed."
 msgstr "不正アクセスの試みがなされました。接続は閉じました。"
 
-#: src/ExternalConn.cpp:1420
+#: src/ExternalConn.cpp:1419
 #, c-format
 msgid "Remote PartFile command failed: FileHash not found: %s"
 msgstr "リモート部分ファイルコマンドが失敗しました：ファイルハッシュは見付かりませんでした： %s"
 
-#: src/ExternalConn.cpp:1424
+#: src/ExternalConn.cpp:1423
 #, c-format
 msgid "FileHash not found: %s"
 msgstr "ファイルハッシュは見付かりませんでした： %s"
 
-#: src/ExternalConn.cpp:1471 src/ExternalConn.cpp:1559
-#: src/ExternalConn.cpp:1680
+#: src/ExternalConn.cpp:1470 src/ExternalConn.cpp:1558
+#: src/ExternalConn.cpp:1679
 msgid "OOPS! OpCode processing error!"
 msgstr "あら！OpCode処理エラーが発生しました！"
 
-#: src/ExternalConn.cpp:1502
+#: src/ExternalConn.cpp:1501
 msgid "Server not added"
 msgstr "サーバは追加しませんでした"
 
-#: src/ExternalConn.cpp:1521
+#: src/ExternalConn.cpp:1520
 #, c-format
 msgid "server not found: %s"
 msgstr "サーバは見付かりませんでした： %s"
 
-#: src/ExternalConn.cpp:1538
+#: src/ExternalConn.cpp:1537
 msgid "need to define server to be removed"
 msgstr "削除したいサーバを定義しなければなりません"
 
-#: src/ExternalConn.cpp:1553
+#: src/ExternalConn.cpp:1552
 msgid "eD2k is disabled in preferences."
 msgstr ""
 
-#: src/ExternalConn.cpp:1658
+#: src/ExternalConn.cpp:1657
 #, fuzzy
 msgid "Friend not found."
 msgstr "ファイルは見付かりませんでした。"
 
-#: src/ExternalConn.cpp:1668
+#: src/ExternalConn.cpp:1667
 #, fuzzy
 msgid "Client not found."
 msgstr "ファイルは見付かりませんでした。"
 
-#: src/ExternalConn.cpp:1674
+#: src/ExternalConn.cpp:1673
 msgid "EC_TAG_FRIEND_SHARED requires EC_TAG_FRIEND or EC_TAG_CLIENT."
 msgstr ""
 
-#: src/ExternalConn.cpp:1992
+#: src/ExternalConn.cpp:1991
 msgid "WebSearch from remote interface makes no sense."
 msgstr "リモートインタフェイスからWebSearchする意味がありません。"
 
-#: src/ExternalConn.cpp:2027
+#: src/ExternalConn.cpp:2026
 msgid "Search in progress. Refetch results in a moment!"
 msgstr "検索中です。あと少しで結果をもう一度取ってきます！"
 
-#: src/ExternalConn.cpp:2266
+#: src/ExternalConn.cpp:2265
 msgid "No points for graph."
 msgstr "グラフを表示するための点がありません。"
 
-#: src/ExternalConn.cpp:2276
+#: src/ExternalConn.cpp:2275
 msgid "Your client is not configured for this detail level."
 msgstr "あなたのクライアントはこの詳細段階には設定されていません。"
 
-#: src/ExternalConn.cpp:2303
+#: src/ExternalConn.cpp:2302
 msgid "External Connection: shutdown requested"
 msgstr ""
 
-#: src/ExternalConn.cpp:2315
+#: src/ExternalConn.cpp:2314
 msgid "Already shutting down."
 msgstr "既にシャットダウン中です。"
 
-#: src/ExternalConn.cpp:2333
+#: src/ExternalConn.cpp:2332
 #, c-format
 msgid "ExternalConn: adding link '%s'."
 msgstr "ExternalConn：次のリンクを追加中です： '%s'。"
 
-#: src/ExternalConn.cpp:2351
+#: src/ExternalConn.cpp:2350
 #, fuzzy, c-format
 msgid "%d of %d links failed (invalid or already on list)."
 msgstr "不正なリンク、またはリンクがすでにリストに入っています。"
 
-#: src/ExternalConn.cpp:2374
+#: src/ExternalConn.cpp:2373
 msgid "Version check throttled; try again shortly."
 msgstr ""
 
-#: src/ExternalConn.cpp:2379
+#: src/ExternalConn.cpp:2378
 msgid "Version check is not available on this daemon."
 msgstr ""
 
-#: src/ExternalConn.cpp:2509
+#: src/ExternalConn.cpp:2508
 msgid "File not found."
 msgstr "ファイルは見付かりませんでした。"
 
-#: src/ExternalConn.cpp:2514
+#: src/ExternalConn.cpp:2513
 msgid "Invalid file name."
 msgstr "不正なファイル名。"
 
-#: src/ExternalConn.cpp:2522
+#: src/ExternalConn.cpp:2521
 msgid "Unable to rename file."
 msgstr "ファイルを改名できません。"
 
-#: src/ExternalConn.cpp:2839
-#, c-format
-msgid "Could not save the amuleapi password: %s"
-msgstr ""
-
-#: src/ExternalConn.cpp:3004 src/ExternalConn.cpp:3032
+#: src/ExternalConn.cpp:2992 src/ExternalConn.cpp:3020
 msgid "Kad is disabled in preferences."
 msgstr "Kadは個人設定に無効されています。"
 
-#: src/ExternalConn.cpp:3045
+#: src/ExternalConn.cpp:3033
 msgid "Already connected to eD2k."
 msgstr ""
 
-#: src/ExternalConn.cpp:3048
+#: src/ExternalConn.cpp:3036
 msgid "Connecting to eD2k..."
 msgstr ""
 
-#: src/ExternalConn.cpp:3057
+#: src/ExternalConn.cpp:3045
 msgid "Already connected to Kad."
 msgstr "すでにKadに接続しています。"
 
-#: src/ExternalConn.cpp:3060
+#: src/ExternalConn.cpp:3048
 msgid "Connecting to Kad..."
 msgstr "Kadに接続中です…"
 
-#: src/ExternalConn.cpp:3067
+#: src/ExternalConn.cpp:3055
 msgid "All networks are disabled."
 msgstr "全てのネットワークが無効になっています。"
 
-#: src/ExternalConn.cpp:3076
+#: src/ExternalConn.cpp:3064
 msgid "Disconnected from eD2k."
 msgstr ""
 
-#: src/ExternalConn.cpp:3081
+#: src/ExternalConn.cpp:3069
 msgid "Disconnected from Kad."
 msgstr "Kadから切断しています。"
 
-#: src/ExternalConn.cpp:3090
+#: src/ExternalConn.cpp:3078
 #, c-format
 msgid "External Connection: invalid opcode received: %#x"
 msgstr ""
 
-#: src/ExternalConn.cpp:3095
+#: src/ExternalConn.cpp:3083
 msgid "Invalid opcode (wrong protocol version?)"
 msgstr "不正なOpCode（プロトコルバージョンが違いますか？）"
 
@@ -2346,19 +2336,19 @@ msgstr ""
 msgid "eD2k"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:349 src/muuli_wdr.cpp:1495
+#: src/FirstRunWizard.cpp:349 src/muuli_wdr.cpp:1488
 msgid "Kademlia"
 msgstr "Kademlia"
 
-#: src/FirstRunWizard.cpp:359 src/muuli_wdr.cpp:1423
+#: src/FirstRunWizard.cpp:359 src/muuli_wdr.cpp:1416
 msgid "Standard TCP Port "
 msgstr ""
 
-#: src/FirstRunWizard.cpp:365 src/muuli_wdr.cpp:1435
+#: src/FirstRunWizard.cpp:365 src/muuli_wdr.cpp:1428
 msgid "Extended UDP port (Kad / global search) "
 msgstr ""
 
-#: src/FirstRunWizard.cpp:377 src/muuli_wdr.cpp:1442
+#: src/FirstRunWizard.cpp:377 src/muuli_wdr.cpp:1435
 msgid "Enable UPnP for router port forwarding"
 msgstr ""
 
@@ -2385,7 +2375,7 @@ msgstr ""
 msgid "Your peer lists are already in place - nothing to download."
 msgstr "あなたはすでにファイル%sをダウンロードしようとしています"
 
-#: src/FirstRunWizard.cpp:434 src/muuli_wdr.cpp:1540
+#: src/FirstRunWizard.cpp:434 src/muuli_wdr.cpp:1533
 msgid "Auto-update server list at startup"
 msgstr ""
 
@@ -2431,23 +2421,23 @@ msgid ""
 "want downloads on a different (e.g. larger) disk."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:549 src/FirstRunWizard.cpp:611 src/muuli_wdr.cpp:1702
+#: src/FirstRunWizard.cpp:549 src/FirstRunWizard.cpp:611 src/muuli_wdr.cpp:1701
 msgid "Destination folder for downloads"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:553 src/FirstRunWizard.cpp:569 src/muuli_wdr.cpp:1349
-#: src/muuli_wdr.cpp:1366 src/muuli_wdr.cpp:1677 src/muuli_wdr.cpp:1708
-#: src/muuli_wdr.cpp:1720 src/muuli_wdr.cpp:2790
+#: src/FirstRunWizard.cpp:553 src/FirstRunWizard.cpp:569 src/muuli_wdr.cpp:1342
+#: src/muuli_wdr.cpp:1359 src/muuli_wdr.cpp:1676 src/muuli_wdr.cpp:1707
+#: src/muuli_wdr.cpp:1719 src/muuli_wdr.cpp:2762
 #: src/utils/aLinkCreator/src/alcframe.cpp:135
 #: src/utils/wxCas/src/wxcasprefs.cpp:52 src/utils/wxCas/src/wxcasprefs.cpp:118
 msgid "Browse"
 msgstr "閲覧"
 
-#: src/FirstRunWizard.cpp:559 src/muuli_wdr.cpp:1713
+#: src/FirstRunWizard.cpp:559 src/muuli_wdr.cpp:1712
 msgid "(All files in this folder are shared with other peers)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:565 src/FirstRunWizard.cpp:624 src/muuli_wdr.cpp:1715
+#: src/FirstRunWizard.cpp:565 src/FirstRunWizard.cpp:624 src/muuli_wdr.cpp:1714
 msgid "Folder for temporary download files"
 msgstr ""
 
@@ -2478,7 +2468,7 @@ msgstr ""
 msgid "CRITICAL - no client on StartChatSession"
 msgstr ""
 
-#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2696 src/muuli_wdr.cpp:3373
+#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2668 src/muuli_wdr.cpp:3345
 msgid "Friends"
 msgstr "友達"
 
@@ -2588,8 +2578,8 @@ msgstr "誰も許可しない"
 msgid "No"
 msgstr "いいえ"
 
-#: src/GenericClientListCtrl.cpp:1216 src/PrefsUnifiedDlg.cpp:2898
-#: src/PrefsUnifiedDlg.cpp:2948 src/ServerListCtrl.cpp:276
+#: src/GenericClientListCtrl.cpp:1216 src/PrefsUnifiedDlg.cpp:2818
+#: src/PrefsUnifiedDlg.cpp:2868 src/ServerListCtrl.cpp:276
 msgid "Yes"
 msgstr "はい"
 
@@ -2757,10 +2747,10 @@ msgstr "ブートストラップするためには正しくないポートです
 msgid "Please fill all fields required"
 msgstr "必要なフィールドをすべて入力してください"
 
-#: src/KadDlg.cpp:192 src/PartFile.cpp:1031 src/PrefsUnifiedDlg.cpp:1134
-#: src/PrefsUnifiedDlg.cpp:1204 src/PrefsUnifiedDlg.cpp:1405
-#: src/PrefsUnifiedDlg.cpp:1663 src/PrefsUnifiedDlg.cpp:1673
-#: src/PrefsUnifiedDlg.cpp:1690 src/PrefsUnifiedDlg.cpp:1738
+#: src/KadDlg.cpp:192 src/PartFile.cpp:1031 src/PrefsUnifiedDlg.cpp:1162
+#: src/PrefsUnifiedDlg.cpp:1331 src/PrefsUnifiedDlg.cpp:1589
+#: src/PrefsUnifiedDlg.cpp:1599 src/PrefsUnifiedDlg.cpp:1616
+#: src/PrefsUnifiedDlg.cpp:1658
 msgid "Message"
 msgstr "メッセージ"
 
@@ -2859,7 +2849,7 @@ msgstr "共有比"
 msgid "Uploaded"
 msgstr "アップロード済み"
 
-#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3253
+#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3225
 msgid "Requested"
 msgstr "要求済み"
 
@@ -2985,7 +2975,7 @@ msgid "WARNING: "
 msgstr ""
 
 #: src/MuleNotebook.cpp:179 src/muuli_wdr.cpp:817 src/muuli_wdr.cpp:1229
-#: src/muuli_wdr.cpp:3157 src/muuli_wdr.cpp:3413
+#: src/muuli_wdr.cpp:3129 src/muuli_wdr.cpp:3385
 msgid "Close"
 msgstr "閉じる"
 
@@ -2998,12 +2988,12 @@ msgstr "カット"
 msgid "Copy"
 msgstr "コピー"
 
-#: src/MuleTextCtrl.cpp:88 src/SearchDlg.cpp:261
+#: src/MuleTextCtrl.cpp:88
 msgid "Paste"
 msgstr "ペースト"
 
 #: src/MuleTextCtrl.cpp:89 src/muuli_wdr.cpp:358 src/muuli_wdr.cpp:757
-#: src/muuli_wdr.cpp:2380 src/muuli_wdr.cpp:2399 src/muuli_wdr.cpp:2421
+#: src/muuli_wdr.cpp:2352 src/muuli_wdr.cpp:2371 src/muuli_wdr.cpp:2393
 #: src/utils/aLinkCreator/src/alcframe.cpp:142
 msgid "Clear"
 msgstr "クリア"
@@ -3100,8 +3090,8 @@ msgid "Exit"
 msgstr "終了"
 
 #: src/MuleTrayIcon.cpp:579 src/MuleTrayIcon.cpp:945 src/MuleTrayIcon.cpp:965
-#: src/muuli_wdr.cpp:1398 src/muuli_wdr.cpp:1406 src/muuli_wdr.cpp:1413
-#: src/muuli_wdr.cpp:1836 src/muuli_wdr.cpp:1842 src/OtherFunctions.cpp:91
+#: src/muuli_wdr.cpp:1391 src/muuli_wdr.cpp:1399 src/muuli_wdr.cpp:1406
+#: src/muuli_wdr.cpp:1835 src/muuli_wdr.cpp:1841 src/OtherFunctions.cpp:91
 #: src/StatisticsDlg.cpp:93 src/StatisticsDlg.cpp:95
 msgid "kB/s"
 msgstr "kB/s"
@@ -3272,7 +3262,7 @@ msgstr "名前："
 msgid "Type"
 msgstr "タイプ"
 
-#: src/muuli_wdr.cpp:215 src/SearchDlg.cpp:118 src/SearchListCtrl.cpp:853
+#: src/muuli_wdr.cpp:215 src/SearchDlg.cpp:110 src/SearchListCtrl.cpp:853
 msgid "Local"
 msgstr "ローカル"
 
@@ -3343,7 +3333,7 @@ msgstr "B"
 msgid "KB"
 msgstr "KB"
 
-#: src/muuli_wdr.cpp:274 src/muuli_wdr.cpp:293 src/muuli_wdr.cpp:1621
+#: src/muuli_wdr.cpp:274 src/muuli_wdr.cpp:293 src/muuli_wdr.cpp:1620
 #: src/OtherFunctions.cpp:64
 msgid "MB"
 msgstr "MB"
@@ -3360,7 +3350,7 @@ msgstr "最大サイズ"
 msgid "Availability"
 msgstr "入手可能範囲"
 
-#: src/muuli_wdr.cpp:312 src/muuli_wdr.cpp:398 src/muuli_wdr.cpp:3318
+#: src/muuli_wdr.cpp:312 src/muuli_wdr.cpp:398 src/muuli_wdr.cpp:3290
 msgid "Filter:"
 msgstr "フィルタ："
 
@@ -3392,7 +3382,7 @@ msgstr ""
 msgid "Stop"
 msgstr "中止"
 
-#: src/muuli_wdr.cpp:348 src/muuli_wdr.cpp:1392 src/SearchListCtrl.cpp:732
+#: src/muuli_wdr.cpp:348 src/muuli_wdr.cpp:1385 src/SearchListCtrl.cpp:732
 msgid "Download"
 msgstr "ダウンロード"
 
@@ -3424,12 +3414,12 @@ msgstr "ソース完了"
 #: src/muuli_wdr.cpp:1160 src/muuli_wdr.cpp:1167 src/muuli_wdr.cpp:1172
 #: src/muuli_wdr.cpp:1179 src/muuli_wdr.cpp:1184 src/muuli_wdr.cpp:1191
 #: src/muuli_wdr.cpp:1205 src/muuli_wdr.cpp:1212 src/muuli_wdr.cpp:1217
-#: src/muuli_wdr.cpp:1224 src/muuli_wdr.cpp:3255 src/muuli_wdr.cpp:3263
-#: src/muuli_wdr.cpp:3271
+#: src/muuli_wdr.cpp:1224 src/muuli_wdr.cpp:3227 src/muuli_wdr.cpp:3235
+#: src/muuli_wdr.cpp:3243
 msgid "N/A"
 msgstr "非適用"
 
-#: src/muuli_wdr.cpp:508 src/muuli_wdr.cpp:1065 src/PrefsUnifiedDlg.cpp:299
+#: src/muuli_wdr.cpp:508 src/muuli_wdr.cpp:1065 src/PrefsUnifiedDlg.cpp:297
 msgid "General"
 msgstr "一般"
 
@@ -3570,7 +3560,7 @@ msgstr ""
 msgid "Album :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:685 src/muuli_wdr.cpp:2275
+#: src/muuli_wdr.cpp:685 src/muuli_wdr.cpp:2247
 msgid "Title :"
 msgstr "タイトル："
 
@@ -3677,7 +3667,7 @@ msgstr "ユーザ名："
 msgid "Userhash :"
 msgstr "ユーザ・ハッシュ："
 
-#: src/muuli_wdr.cpp:895 src/muuli_wdr.cpp:1742 src/muuli_wdr.cpp:2470
+#: src/muuli_wdr.cpp:895 src/muuli_wdr.cpp:1741 src/muuli_wdr.cpp:2442
 #: src/utils/aLinkCreator/src/alcframe.cpp:137
 msgid "Add"
 msgstr "追加"
@@ -3686,15 +3676,15 @@ msgstr "追加"
 msgid "Download-Speed"
 msgstr "ダウンロード速度："
 
-#: src/muuli_wdr.cpp:954 src/muuli_wdr.cpp:989 src/muuli_wdr.cpp:2574
+#: src/muuli_wdr.cpp:954 src/muuli_wdr.cpp:989 src/muuli_wdr.cpp:2546
 msgid "Current"
 msgstr "現在"
 
-#: src/muuli_wdr.cpp:962 src/muuli_wdr.cpp:997 src/muuli_wdr.cpp:2582
+#: src/muuli_wdr.cpp:962 src/muuli_wdr.cpp:997 src/muuli_wdr.cpp:2554
 msgid "Running average"
 msgstr "移動平均"
 
-#: src/muuli_wdr.cpp:970 src/muuli_wdr.cpp:1005 src/muuli_wdr.cpp:2590
+#: src/muuli_wdr.cpp:970 src/muuli_wdr.cpp:1005 src/muuli_wdr.cpp:2562
 msgid "Session average"
 msgstr "セッション平均"
 
@@ -3706,7 +3696,7 @@ msgstr "アップロード速度"
 msgid "Connections"
 msgstr "接続数"
 
-#: src/muuli_wdr.cpp:1024 src/muuli_wdr.cpp:1861
+#: src/muuli_wdr.cpp:1024 src/muuli_wdr.cpp:1860
 msgid "Active downloads"
 msgstr "アクティブなダウンロード数"
 
@@ -3714,7 +3704,7 @@ msgstr "アクティブなダウンロード数"
 msgid "Active connections (1:1)"
 msgstr "アクティブな接続（1:1）"
 
-#: src/muuli_wdr.cpp:1040 src/muuli_wdr.cpp:1862
+#: src/muuli_wdr.cpp:1040 src/muuli_wdr.cpp:1861
 msgid "Active uploads"
 msgstr "アクティブなアップロード数"
 
@@ -3831,8 +3821,8 @@ msgstr "接続してくるユーザはこの名前を見ることになります
 msgid "Language: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1257 src/muuli_wdr.cpp:1330 src/muuli_wdr.cpp:1334
-#: src/muuli_wdr.cpp:1337
+#: src/muuli_wdr.cpp:1257 src/muuli_wdr.cpp:1323 src/muuli_wdr.cpp:1327
+#: src/muuli_wdr.cpp:1330
 msgid "The delay before showing tool-tips."
 msgstr "ツールチップを表示するまでの遅延時間。"
 
@@ -3910,961 +3900,937 @@ msgstr ""
 msgid "Enabling this will make aMule to show notifications when finished downloading."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1323
-#, fuzzy
-msgid "Remember search history"
-msgstr "設定を記憶する"
-
-#: src/muuli_wdr.cpp:1324
-msgid "Keeps a dropdown list of your past search terms in the Search tab's Name field. This remembers the queries you typed, not the results they returned."
-msgstr ""
-
-#: src/muuli_wdr.cpp:1329
+#: src/muuli_wdr.cpp:1322
 msgid "Tooltip delay time: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1336
+#: src/muuli_wdr.cpp:1329
 msgid "seconds"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1340
+#: src/muuli_wdr.cpp:1333
 msgid "Browser Selection"
 msgstr "ブラウザ選択"
 
-#: src/muuli_wdr.cpp:1346
+#: src/muuli_wdr.cpp:1339
 msgid "Enter your browser name here. Leave this field empty to use the system default browser."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1353
+#: src/muuli_wdr.cpp:1346
 msgid "Open in new tab if possible"
 msgstr "可能ならば新しいタブで開く"
 
-#: src/muuli_wdr.cpp:1355
+#: src/muuli_wdr.cpp:1348
 msgid "Open the web page in a new tab instead of in a new window when possible"
 msgstr "可能なら、ウェブ・ページを新しいウインドウではなくて新しいタブで開きます"
 
-#: src/muuli_wdr.cpp:1359
+#: src/muuli_wdr.cpp:1352
 msgid "Video Player"
 msgstr "ビデオ・プレイヤー"
 
-#: src/muuli_wdr.cpp:1386
+#: src/muuli_wdr.cpp:1379
 msgid "Bandwidth limits"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1400
+#: src/muuli_wdr.cpp:1393
 msgid "Upload"
 msgstr "アップロード"
 
-#: src/muuli_wdr.cpp:1408
+#: src/muuli_wdr.cpp:1401
 msgid "Slot Allocation"
 msgstr "スロット割り当て"
 
-#: src/muuli_wdr.cpp:1417
+#: src/muuli_wdr.cpp:1410
 msgid "Ports"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1427
+#: src/muuli_wdr.cpp:1420
 msgid "This is the standard eD2k port and cannot be disabled."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1430
+#: src/muuli_wdr.cpp:1423
 msgid "UDP port for server requests (TCP+3):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1432
+#: src/muuli_wdr.cpp:1425
 msgid "4665"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1439
+#: src/muuli_wdr.cpp:1432
 msgid "This UDP port is used for extended eD2k requests and Kad network"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1446
+#: src/muuli_wdr.cpp:1439
 msgid "UPnP TCP Port (Optional):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1456
+#: src/muuli_wdr.cpp:1449
 msgid "Bind local address to IP (empty for any):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1459
+#: src/muuli_wdr.cpp:1452
 msgid "Advanced users only: If you have multiple network interfaces, enter the address of the interface to which aMule should be bound."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1462 src/muuli_wdr.cpp:2055
+#: src/muuli_wdr.cpp:1455 src/muuli_wdr.cpp:2054
 msgid "Bind to network interface (empty for any):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1475
+#: src/muuli_wdr.cpp:1468
 msgid "Advanced users only: pin all of aMule's traffic to one network interface, chosen from the list or typed in by name (e.g. tun0, eth0, en0) or index. Unlike binding to an IP, this stops traffic leaking out via the default route - useful with a VPN. Requires no elevated privileges."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1481
+#: src/muuli_wdr.cpp:1474
 msgid "Max sources per downloading file:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1485
+#: src/muuli_wdr.cpp:1478
 msgid "Max simultaneous connections:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1498 src/muuli_wdr.cpp:3197
+#: src/muuli_wdr.cpp:1491 src/muuli_wdr.cpp:3169
 msgid "ED2K"
 msgstr "ED2K"
 
-#: src/muuli_wdr.cpp:1505
+#: src/muuli_wdr.cpp:1498
 msgid "Autoconnect on startup"
 msgstr "スタートアップに自動接続する"
 
-#: src/muuli_wdr.cpp:1508
+#: src/muuli_wdr.cpp:1501
 msgid "Reconnect on loss"
 msgstr "接続を失う時に再接続する"
 
-#: src/muuli_wdr.cpp:1530
+#: src/muuli_wdr.cpp:1523
 msgid "Remove dead server after"
 msgstr "再試行後、応答のないサーバを削除する。再試行回数："
 
-#: src/muuli_wdr.cpp:1531
+#: src/muuli_wdr.cpp:1524
 msgid "Static servers are never removed, even when unreachable."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1535
+#: src/muuli_wdr.cpp:1528
 msgid "retries"
 msgstr "回"
 
-#: src/muuli_wdr.cpp:1543
+#: src/muuli_wdr.cpp:1536
 msgid "List"
 msgstr "リスト"
 
-#: src/muuli_wdr.cpp:1546
+#: src/muuli_wdr.cpp:1539
 msgid "Update server list when connecting to a server"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1549
+#: src/muuli_wdr.cpp:1542
 msgid "Update server list when a client connects"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1552
+#: src/muuli_wdr.cpp:1545
 msgid "Use priority system"
 msgstr "優先度システムを使用する"
 
-#: src/muuli_wdr.cpp:1556
+#: src/muuli_wdr.cpp:1549
 msgid "Use smart LowID check on connect"
 msgstr "接続の時にLowIDチェックを使用する"
 
-#: src/muuli_wdr.cpp:1560
+#: src/muuli_wdr.cpp:1553
 msgid "Safe connect"
 msgstr "安全接続"
 
-#: src/muuli_wdr.cpp:1564
+#: src/muuli_wdr.cpp:1557
 msgid "Autoconnect to servers in static list only"
 msgstr "スタティック・リストに含まれているサーバのみに自動接続する"
 
-#: src/muuli_wdr.cpp:1567
+#: src/muuli_wdr.cpp:1560
 msgid "Set manually added servers to High Priority"
 msgstr "手動で追加したサーバを高い優先度に設定する"
 
-#: src/muuli_wdr.cpp:1588
+#: src/muuli_wdr.cpp:1581
 msgid "Add files to download in pause mode"
 msgstr "ダウンロードファイルを停止モードで追加する"
 
-#: src/muuli_wdr.cpp:1590
+#: src/muuli_wdr.cpp:1583
 msgid "Add files to download with auto priority"
 msgstr "ダウンロードファイルを優先度を自動にして追加する"
 
-#: src/muuli_wdr.cpp:1593
+#: src/muuli_wdr.cpp:1586
 msgid "Try to download first and last chunks first"
 msgstr "最初と最後のチャンクを先にダウンロードしようとする"
 
-#: src/muuli_wdr.cpp:1597
+#: src/muuli_wdr.cpp:1590
 msgid "Endgame mode: rotate to faster sources for the final blocks"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1600
+#: src/muuli_wdr.cpp:1593
 msgid "Start next paused file when a file completes"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1603
+#: src/muuli_wdr.cpp:1596
 msgid "From the same category"
 msgstr "同じカテゴリから"
 
-#: src/muuli_wdr.cpp:1605
+#: src/muuli_wdr.cpp:1598
 msgid "In alphabetic order"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1607
+#: src/muuli_wdr.cpp:1600
 msgid "Preallocate disk space for new files"
 msgstr "新しいファイルのためのディスク領域を事前に確保する"
 
-#: src/muuli_wdr.cpp:1608
+#: src/muuli_wdr.cpp:1601
 msgid "For new files preallocates disk space for the whole file, thus reduces fragmentation"
 msgstr "新しいファイルのためにファイル全体が格納できるディスク領域を事前に確保し、断片化を防ぎます。"
 
-#: src/muuli_wdr.cpp:1613
+#: src/muuli_wdr.cpp:1606
+msgid "Create new files as sparse files"
+msgstr ""
+
+#: src/muuli_wdr.cpp:1607
+msgid "A sparse file reserves its full size on disk immediately without writing real data to it -- fast, but unsupported or slow on some filesystems, and free-space accounting stays optimistic while the download is in progress. Turn this off to grow the file only as data arrives."
+msgstr ""
+
+#: src/muuli_wdr.cpp:1612
 msgid "Stop downloads when free disk space reaches "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1614
+#: src/muuli_wdr.cpp:1613
 msgid "Select this if you want aMule to check your disk space"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1618
+#: src/muuli_wdr.cpp:1617
 msgid "Enter here the min disk space desired."
 msgstr "望ましい最小のディスク領域をここに入力してください。"
 
-#: src/muuli_wdr.cpp:1624
+#: src/muuli_wdr.cpp:1623
 msgid "Save 10 sources on rare files (< 20 sources)"
 msgstr "珍しいファイルには10ソースを保存する（<20ソース）"
 
-#: src/muuli_wdr.cpp:1628 src/Statistics.cpp:790
+#: src/muuli_wdr.cpp:1627 src/Statistics.cpp:790
 msgid "Uploads"
 msgstr "アップロード数"
 
-#: src/muuli_wdr.cpp:1631
+#: src/muuli_wdr.cpp:1630
 msgid "Add new shared files with auto priority"
 msgstr "新しい共有ファイルを自動優先度として追加する"
 
-#: src/muuli_wdr.cpp:1637
+#: src/muuli_wdr.cpp:1636
 msgid "Intelligent Corruption Handling (I.C.H.)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1640
+#: src/muuli_wdr.cpp:1639
 msgid "Enable"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1643
+#: src/muuli_wdr.cpp:1642
 msgid "Advanced I.C.H. trusts every hash (not recommended)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1655 src/PrefsUnifiedDlg.cpp:1990
+#: src/muuli_wdr.cpp:1654 src/PrefsUnifiedDlg.cpp:1910
 msgid "Media metadata extraction"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1659
+#: src/muuli_wdr.cpp:1658
 msgid "Extract length / bitrate / codec from shared audio and video files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1661
+#: src/muuli_wdr.cpp:1660
 msgid "When enabled, aMule runs ffprobe on each shared media file to fill in the Length / Bitrate / Codec columns other clients see when they find the file in a search. Requires ffmpeg (the ffprobe binary) to be installed."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1668
+#: src/muuli_wdr.cpp:1667
 msgid "Path to ffprobe:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1673
+#: src/muuli_wdr.cpp:1672
 msgid "Full path to the ffprobe binary. Leave empty to have aMule auto-detect it on startup."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1681
+#: src/muuli_wdr.cpp:1680
 msgid "Detect"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1682
+#: src/muuli_wdr.cpp:1681
 msgid "Search the standard install locations for an ffprobe binary and fill the path field."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1706
+#: src/muuli_wdr.cpp:1705
 msgid ""
 "Completed downloads are stored here. All files in this folder are automatically shared with other peers.\n"
 "If this folder also holds files you don't want to share, point it at an aMule-only sub-folder."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1709
+#: src/muuli_wdr.cpp:1708
 msgid "Pick the folder where completed downloads will be stored. All files in that folder will be shared with other peers."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1723
+#: src/muuli_wdr.cpp:1722
 msgid "Shared folders"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1729
+#: src/muuli_wdr.cpp:1728
 msgid "(Folders shared by the core. Enter a path to add one.)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1737
+#: src/muuli_wdr.cpp:1736
 msgid "Absolute path of a folder on the core's machine, e.g. /home/user/shared"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1739 src/PrefsUnifiedDlg.cpp:2874
+#: src/muuli_wdr.cpp:1738 src/PrefsUnifiedDlg.cpp:2794
 msgid "Recursive"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1740
+#: src/muuli_wdr.cpp:1739
 msgid "Share every sub-folder underneath this one, including ones created later."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1744 src/utils/aLinkCreator/src/alcframe.cpp:141
+#: src/muuli_wdr.cpp:1743 src/utils/aLinkCreator/src/alcframe.cpp:141
 msgid "Remove"
 msgstr "削除"
 
-#: src/muuli_wdr.cpp:1748
+#: src/muuli_wdr.cpp:1747
 msgid "(Right click on folder icon for recursive share)"
 msgstr "（再帰的に共有するにはフォルダ・アイコンを右クリックしてください）"
 
-#: src/muuli_wdr.cpp:1755
+#: src/muuli_wdr.cpp:1754
 msgid "Share hidden files"
 msgstr "隠れたファイルを共有する"
 
-#: src/muuli_wdr.cpp:1761
+#: src/muuli_wdr.cpp:1760
 msgid "Automatically rescan shared folders for changes"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1767
+#: src/muuli_wdr.cpp:1766
 msgid "Follow symbolic links in shared folders"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1773
+#: src/muuli_wdr.cpp:1772
 msgid "Exclude files matching:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1776
+#: src/muuli_wdr.cpp:1775
 msgid "Wildcard patterns separated by '|', e.g. .DS_Store|Thumbs.db|*.tmp. Files whose name matches are not shared. Matching is case-insensitive."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1780
+#: src/muuli_wdr.cpp:1779
 msgid "Patterns are regular expressions"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1781
+#: src/muuli_wdr.cpp:1780
 msgid "When set, the whole field is one regular expression ('|' is alternation). When unset, it is a list of '|'-separated wildcards."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1791
+#: src/muuli_wdr.cpp:1790
 msgid "Show how many shared files the current pattern would exclude."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1812
+#: src/muuli_wdr.cpp:1811
 msgid "Graphs"
 msgstr "グラフ"
 
-#: src/muuli_wdr.cpp:1815 src/muuli_wdr.cpp:1877
+#: src/muuli_wdr.cpp:1814 src/muuli_wdr.cpp:1876
 msgid "Update delay : 5 secs"
 msgstr "アップデート延期：５秒"
 
-#: src/muuli_wdr.cpp:1819
+#: src/muuli_wdr.cpp:1818
 msgid "Time for average graph: 100 mins"
 msgstr "平均グラフの時間：１００分"
 
-#: src/muuli_wdr.cpp:1823
+#: src/muuli_wdr.cpp:1822
 msgid "Connections Graph Scale: 100 "
 msgstr "接続数のグラフスケール：１００"
 
-#: src/muuli_wdr.cpp:1830
+#: src/muuli_wdr.cpp:1829
 msgid "Download graph scale:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1838
+#: src/muuli_wdr.cpp:1837
 msgid "Upload graph scale:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1848
+#: src/muuli_wdr.cpp:1847
 msgid "Colors: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1852
+#: src/muuli_wdr.cpp:1851
 msgid "Background"
 msgstr "背景"
 
-#: src/muuli_wdr.cpp:1853
+#: src/muuli_wdr.cpp:1852
 msgid "Grid"
 msgstr "グリッド"
 
-#: src/muuli_wdr.cpp:1854
+#: src/muuli_wdr.cpp:1853
 msgid "Download current"
 msgstr "ダウンロード現在"
 
-#: src/muuli_wdr.cpp:1855
+#: src/muuli_wdr.cpp:1854
 msgid "Download running average"
 msgstr "ダウンロード移動平均"
 
-#: src/muuli_wdr.cpp:1856
+#: src/muuli_wdr.cpp:1855
 msgid "Download session average"
 msgstr "ダウンロードセッション平均"
 
-#: src/muuli_wdr.cpp:1857
+#: src/muuli_wdr.cpp:1856
 msgid "Upload current"
 msgstr "アップロード現在"
 
-#: src/muuli_wdr.cpp:1858
+#: src/muuli_wdr.cpp:1857
 msgid "Upload running average"
 msgstr "アップロード移動平均"
 
-#: src/muuli_wdr.cpp:1859
+#: src/muuli_wdr.cpp:1858
 msgid "Upload session average"
 msgstr "アップロードセッション平均"
 
-#: src/muuli_wdr.cpp:1860
+#: src/muuli_wdr.cpp:1859
 msgid "Active connections"
 msgstr "アクティブ接続数"
 
-#: src/muuli_wdr.cpp:1863
+#: src/muuli_wdr.cpp:1862
 #, fuzzy
 msgid "Systray Icon Speed Bar"
 msgstr "システム・トレイ・アイコン・スピードバー"
 
-#: src/muuli_wdr.cpp:1864
+#: src/muuli_wdr.cpp:1863
 msgid "Kad-nodes current"
 msgstr "現在のKadノード数"
 
-#: src/muuli_wdr.cpp:1865
+#: src/muuli_wdr.cpp:1864
 msgid "Kad-nodes running"
 msgstr "動作中のKadノード数"
 
-#: src/muuli_wdr.cpp:1866
+#: src/muuli_wdr.cpp:1865
 msgid "Kad-nodes session"
 msgstr "セッションのKadノード数"
 
-#: src/muuli_wdr.cpp:1870 src/muuli_wdr.cpp:2324
+#: src/muuli_wdr.cpp:1869 src/muuli_wdr.cpp:2296
 msgid "Select"
 msgstr "選択"
 
-#: src/muuli_wdr.cpp:1874
+#: src/muuli_wdr.cpp:1873
 msgid "Tree"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1884
+#: src/muuli_wdr.cpp:1883
 msgid "Number of Client Versions shown (0=unlimited)"
 msgstr "表示されているクライアントのバージョン数（0＝無制限）"
 
-#: src/muuli_wdr.cpp:1909
+#: src/muuli_wdr.cpp:1908
 msgid "!!! WARNING !!!"
 msgstr "！！！注意！！！"
 
-#: src/muuli_wdr.cpp:1924
+#: src/muuli_wdr.cpp:1923
 msgid "Max new connections / 5 secs"
 msgstr "最大の新しい接続数（5秒ごと）"
 
-#: src/muuli_wdr.cpp:1926
+#: src/muuli_wdr.cpp:1925
 msgid "Concurrent Kad source lookups"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1928
+#: src/muuli_wdr.cpp:1927
 #, fuzzy
 msgid "Kad source re-search interval (minutes)"
 msgstr "FTPアップデートレート間隔（分）"
 
-#: src/muuli_wdr.cpp:1930
+#: src/muuli_wdr.cpp:1929
 #, fuzzy
 msgid "Source re-ask interval (minutes)"
 msgstr "FTPアップデートレート間隔（分）"
 
-#: src/muuli_wdr.cpp:1934
+#: src/muuli_wdr.cpp:1933
 msgid "File Buffer Size: 240000 bytes"
 msgstr "ファイル・バファー・サイズ：240000バイト"
 
-#: src/muuli_wdr.cpp:1938
+#: src/muuli_wdr.cpp:1937
 msgid "Use MMAP: memory-mapped file access (lower memory use)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1939
+#: src/muuli_wdr.cpp:1938
 msgid "Maps part files into memory instead of buffering them on the heap, lowering the process memory footprint. May reduce download speed on some disks; best for memory-constrained or upload-heavy hosts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1941
+#: src/muuli_wdr.cpp:1940
 msgid "Upload Queue Size: 5000 clients"
 msgstr "アップロードキューサイズ：5000クライアント"
 
-#: src/muuli_wdr.cpp:1945
+#: src/muuli_wdr.cpp:1944
 msgid "Server connection refresh interval: Disable"
 msgstr "サーバ接続のリフレッシュ空間：無効にする"
 
-#: src/muuli_wdr.cpp:1949
+#: src/muuli_wdr.cpp:1948
 msgid "Disable computer's timed standby mode"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1968
+#: src/muuli_wdr.cpp:1967
 msgid "Skin to use: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1977
+#: src/muuli_wdr.cpp:1976
 msgid "Show \"Fast eD2k Links Handler\" in every window."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1980
+#: src/muuli_wdr.cpp:1979
 msgid "Show extended info on categories tabs"
 msgstr "延長情報をカテゴリ・タブで表示する"
 
-#: src/muuli_wdr.cpp:1983
+#: src/muuli_wdr.cpp:1982
 #, fuzzy
 msgid "Show application version on title"
 msgstr "タイトルに転送速度を表示する"
 
-#: src/muuli_wdr.cpp:1985
+#: src/muuli_wdr.cpp:1984
 msgid "Show transfer rates on title"
 msgstr "タイトルに転送速度を表示する"
 
-#: src/muuli_wdr.cpp:1987
+#: src/muuli_wdr.cpp:1986
 msgid "Before application name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1989
+#: src/muuli_wdr.cpp:1988
 msgid "After application name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1992
+#: src/muuli_wdr.cpp:1991
 msgid "Show overhead bandwidth"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1996
+#: src/muuli_wdr.cpp:1995
 msgid "Vertical toolbar orientation"
 msgstr "垂直ツールバー"
 
-#: src/muuli_wdr.cpp:1998
+#: src/muuli_wdr.cpp:1997
 msgid "Live column sorting (auto-reorder rows as their values change)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2005
+#: src/muuli_wdr.cpp:2004
 msgid "Download Queue Files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2008
+#: src/muuli_wdr.cpp:2007
 msgid "Show progress percentage"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2014
+#: src/muuli_wdr.cpp:2013
 msgid "Show progress bar"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2017
+#: src/muuli_wdr.cpp:2016
 msgid "Flat"
 msgstr "フラット"
 
-#: src/muuli_wdr.cpp:2021
+#: src/muuli_wdr.cpp:2020
 msgid "Round"
 msgstr "ラウンド"
 
-#: src/muuli_wdr.cpp:2039
+#: src/muuli_wdr.cpp:2038
 msgid "External Connection Parameters"
 msgstr "外部接続のパラメタ"
 
-#: src/muuli_wdr.cpp:2042
+#: src/muuli_wdr.cpp:2041
 msgid "Accept external connections"
 msgstr "外部接続を許可にする"
 
-#: src/muuli_wdr.cpp:2049 src/muuli_wdr.cpp:2108
+#: src/muuli_wdr.cpp:2048 src/muuli_wdr.cpp:2107
 msgid "IP of the listening interface:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2052
+#: src/muuli_wdr.cpp:2051
 msgid "Enter here a valid ip in the a.b.c.d format for the listening EC interface. An empty field or 0.0.0.0 will mean any interface."
 msgstr "リスンしているECインターフェイス用の正当なIPアドレスをa.b.c.dのフォーマットで入力してください。空のフィールド、または0.0.0.0は任意のインターフェイスを意味します。"
 
-#: src/muuli_wdr.cpp:2073 src/muuli_wdr.cpp:2184
+#: src/muuli_wdr.cpp:2072 src/muuli_wdr.cpp:2156
 msgid "TCP port:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2079
+#: src/muuli_wdr.cpp:2078
 msgid "Enable UPnP port forwarding on the EC port"
 msgstr "ECポートでUPnPポート転送を有効にする"
 
-#: src/muuli_wdr.cpp:2083 src/muuli_wdr.cpp:3069
+#: src/muuli_wdr.cpp:2082 src/muuli_wdr.cpp:3041
 #: src/utils/wxCas/src/wxcasprefs.cpp:167
 msgid "Password"
 msgstr "パスワード"
 
-#: src/muuli_wdr.cpp:2089
+#: src/muuli_wdr.cpp:2088
 msgid "aMule API server parameters"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2092
+#: src/muuli_wdr.cpp:2091
 msgid "Run amuleapi (REST API) on startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2097
+#: src/muuli_wdr.cpp:2096
 #, fuzzy
 msgid "HTTP port:"
 msgstr "プロクシー・ポート："
 
-#: src/muuli_wdr.cpp:2111
+#: src/muuli_wdr.cpp:2110
 msgid "The interface amuleapi's HTTP server listens on. 127.0.0.1 (default) accepts only local connections; use 0.0.0.0 or a specific IP to expose it to other hosts (set an admin password below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2116
-msgid "Type a password to set or change it. Stored passwords cannot be shown, so leaving this empty keeps the current one."
-msgstr ""
-
-#: src/muuli_wdr.cpp:2118
+#: src/muuli_wdr.cpp:2113
 #, fuzzy
 msgid "Admin password"
 msgstr "パスワードをチェック中です\n"
 
-#: src/muuli_wdr.cpp:2130 src/muuli_wdr.cpp:2147 src/PrefsUnifiedDlg.cpp:1103
-#, fuzzy
-msgid "A password is set."
-msgstr "パスワードをチェック中です\n"
-
-#: src/muuli_wdr.cpp:2134
-#, fuzzy
-msgid "Enable guest access"
-msgstr "ゲストアクセスを拒否する"
-
-#: src/muuli_wdr.cpp:2135
-msgid "Guest sessions may read status and listings but cannot change anything. Turning this off clears the stored guest password."
-msgstr ""
-
-#: src/muuli_wdr.cpp:2139
-#, fuzzy
-msgid "Guest password"
-msgstr "全権限パスワード"
-
-#: src/muuli_wdr.cpp:2154
-msgid "Web server parameters"
-msgstr ""
-
-#: src/muuli_wdr.cpp:2157
-msgid "Run webserver on startup (deprecated)"
-msgstr ""
-
-#: src/muuli_wdr.cpp:2163
-msgid "Web template"
-msgstr "ウェブテンプレート"
-
-#: src/muuli_wdr.cpp:2168
-msgid "Full rights password"
-msgstr "全権限パスワード"
-
-#: src/muuli_wdr.cpp:2172
-msgid "Enable Low rights User"
-msgstr "低権限ユーザを有効にする"
-
-#: src/muuli_wdr.cpp:2177
+#: src/muuli_wdr.cpp:2118 src/muuli_wdr.cpp:2149
 msgid "Low rights password"
 msgstr "低権限パスワード"
 
-#: src/muuli_wdr.cpp:2191
+#: src/muuli_wdr.cpp:2126
+msgid "Web server parameters"
+msgstr ""
+
+#: src/muuli_wdr.cpp:2129
+msgid "Run webserver on startup (deprecated)"
+msgstr ""
+
+#: src/muuli_wdr.cpp:2135
+msgid "Web template"
+msgstr "ウェブテンプレート"
+
+#: src/muuli_wdr.cpp:2140
+msgid "Full rights password"
+msgstr "全権限パスワード"
+
+#: src/muuli_wdr.cpp:2144
+msgid "Enable Low rights User"
+msgstr "低権限ユーザを有効にする"
+
+#: src/muuli_wdr.cpp:2163
 msgid "Enable UPnP port forwarding of the web server port"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2196
+#: src/muuli_wdr.cpp:2168
 msgid "Web server UPnP TCP port (Optional)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2204
+#: src/muuli_wdr.cpp:2176
 msgid "Page Refresh Time (in secs)"
 msgstr "ページのリフレッシュ間隔（秒単位）"
 
-#: src/muuli_wdr.cpp:2211
+#: src/muuli_wdr.cpp:2183
 msgid "Enable Gzip compression"
 msgstr "gzip圧縮を有効にする"
 
-#: src/muuli_wdr.cpp:2245
+#: src/muuli_wdr.cpp:2217
 #, fuzzy
 msgid "Reset page to defaults"
 msgstr "システムの標準設定"
 
-#: src/muuli_wdr.cpp:2246
+#: src/muuli_wdr.cpp:2218
 msgid "Reset the settings on the current page to their default values."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2248 src/muuli_wdr.cpp:2334 src/ServerWnd.cpp:274
+#: src/muuli_wdr.cpp:2220 src/muuli_wdr.cpp:2306 src/ServerWnd.cpp:274
 #: src/ServerWnd.cpp:282
 msgid "OK"
 msgstr "OK"
 
-#: src/muuli_wdr.cpp:2250
+#: src/muuli_wdr.cpp:2222
 msgid "Click here to apply any changes made to the preferences."
 msgstr "設定の変更をすべて適用します。"
 
-#: src/muuli_wdr.cpp:2253
+#: src/muuli_wdr.cpp:2225
 msgid "Reset any changes made to the preferences."
 msgstr "設定の変更を全てリセットする"
 
-#: src/muuli_wdr.cpp:2282
+#: src/muuli_wdr.cpp:2254
 msgid "Comment :"
 msgstr "コメント："
 
-#: src/muuli_wdr.cpp:2289
+#: src/muuli_wdr.cpp:2261
 msgid "Incoming Dir :"
 msgstr "受信ディレクトリ："
 
-#: src/muuli_wdr.cpp:2298
+#: src/muuli_wdr.cpp:2270
 msgid "Change priority for new assigned files :"
 msgstr "新しく割り当てられたファイルの優先度を変更する："
 
-#: src/muuli_wdr.cpp:2302
+#: src/muuli_wdr.cpp:2274
 #, fuzzy
 msgid "Don't change"
 msgstr "変更しない"
 
-#: src/muuli_wdr.cpp:2314
+#: src/muuli_wdr.cpp:2286
 msgid "Select color for this Category (currently selected) :"
 msgstr "このカテゴリの色を選択する（現在選択中）："
 
-#: src/muuli_wdr.cpp:2381 src/muuli_wdr.cpp:2400 src/muuli_wdr.cpp:2422
+#: src/muuli_wdr.cpp:2353 src/muuli_wdr.cpp:2372 src/muuli_wdr.cpp:2394
 msgid "Click this button to reset the log."
 msgstr "このボタンをクリックするとログのリセットが行います。"
 
-#: src/muuli_wdr.cpp:2441
+#: src/muuli_wdr.cpp:2413
 msgid "Click on this button to update the servers list from URL ..."
 msgstr "このボタンをクリックするとサーバ・リストはURLから最新化する..."
 
-#: src/muuli_wdr.cpp:2445
+#: src/muuli_wdr.cpp:2417
 msgid "Server list"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2449
+#: src/muuli_wdr.cpp:2421
 msgid "Enter the url to a server.met file here and press the button to the left to update the list of known servers."
 msgstr "server.metファイルへのURLをここに入力してから左側のボタンをクリックすると、既知のサーバのリストがアップデートされます。"
 
-#: src/muuli_wdr.cpp:2454
+#: src/muuli_wdr.cpp:2426
 msgid "Add server manually: Name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2457
+#: src/muuli_wdr.cpp:2429
 msgid "Enter the name of the new server here"
 msgstr "新しいサーバの名前をここに入力してください"
 
-#: src/muuli_wdr.cpp:2459 src/ServerWnd.cpp:206
+#: src/muuli_wdr.cpp:2431 src/ServerWnd.cpp:206
 msgid "IP:Port"
 msgstr "IP:ポート"
 
-#: src/muuli_wdr.cpp:2462
+#: src/muuli_wdr.cpp:2434
 msgid "Enter the IP of the server here, using the x.x.x.x format."
 msgstr "x.x.x.xフォーマットでサーバのIPアドレスを入力してください。"
 
-#: src/muuli_wdr.cpp:2468
+#: src/muuli_wdr.cpp:2440
 msgid "Enter the port of the server here."
 msgstr "サーバのポートをここに入力してください。"
 
-#: src/muuli_wdr.cpp:2471
+#: src/muuli_wdr.cpp:2443
 msgid "Add manually a server (fill fields to the left before) ..."
 msgstr "手動でサーバを追加する（先に左側のフィールドを入力してください）..."
 
-#: src/muuli_wdr.cpp:2500
+#: src/muuli_wdr.cpp:2472
 msgid "aMule Log"
 msgstr "aMuleのログ"
 
-#: src/muuli_wdr.cpp:2508
+#: src/muuli_wdr.cpp:2480
 msgid "Server Info"
 msgstr "サーバ情報"
 
-#: src/muuli_wdr.cpp:2512
+#: src/muuli_wdr.cpp:2484
 msgid "ED2K Info"
 msgstr "ED2K情報"
 
-#: src/muuli_wdr.cpp:2516
+#: src/muuli_wdr.cpp:2488
 msgid "Kad Info"
 msgstr "Kad情報"
 
-#: src/muuli_wdr.cpp:2544
+#: src/muuli_wdr.cpp:2516
 msgid "Click on this button to update the nodes list from URL ..."
 msgstr "このボタンをクリックするとノード・リストをURLからアップデートします..."
 
-#: src/muuli_wdr.cpp:2548
+#: src/muuli_wdr.cpp:2520
 msgid "Nodes (0)"
 msgstr "ノード数（0）"
 
-#: src/muuli_wdr.cpp:2552
+#: src/muuli_wdr.cpp:2524
 msgid "Enter the url to a nodes.dat file here and press the button to the left to update the list of known nodes."
 msgstr "ここにnodes.datファイルへのURLを入力してから左側のボタンをクリックすると、既知のノード・リストをアップデートします。"
 
-#: src/muuli_wdr.cpp:2555
+#: src/muuli_wdr.cpp:2527
 msgid "Nodes stats"
 msgstr "ノードの統計"
 
-#: src/muuli_wdr.cpp:2597
+#: src/muuli_wdr.cpp:2569
 msgid "Bootstrap"
 msgstr "ブートストラップ"
 
-#: src/muuli_wdr.cpp:2600
+#: src/muuli_wdr.cpp:2572
 msgid "New node"
 msgstr "新しいノード"
 
-#: src/muuli_wdr.cpp:2605
+#: src/muuli_wdr.cpp:2577
 msgid "IP:"
 msgstr "IP："
 
-#: src/muuli_wdr.cpp:2625
+#: src/muuli_wdr.cpp:2597
 msgid "Port:"
 msgstr "ポート："
 
-#: src/muuli_wdr.cpp:2638
+#: src/muuli_wdr.cpp:2610
 #, fuzzy
 msgid "Bootstrap from known clients"
 msgstr ""
 "既知のクライアントから\n"
 "ブートストラップする"
 
-#: src/muuli_wdr.cpp:2640
+#: src/muuli_wdr.cpp:2612
 msgid "Disconnect Kad"
 msgstr "Kadを切断する"
 
-#: src/muuli_wdr.cpp:2674
+#: src/muuli_wdr.cpp:2646
 msgid "Use Secure User Identification"
 msgstr "セキュア・ユーザ保証（SUI）を使用する"
 
-#: src/muuli_wdr.cpp:2676
+#: src/muuli_wdr.cpp:2648
 msgid "It is recommended to enable this option. You will not receive credits if SUI is not enabled."
 msgstr "このオプションを有効にするのは推奨されます。SUIが有効でないとあなたはクレジットを得られません。"
 
-#: src/muuli_wdr.cpp:2678
+#: src/muuli_wdr.cpp:2650
 msgid "Protocol Obfuscation"
 msgstr "プロトコルを難読化する"
 
-#: src/muuli_wdr.cpp:2681
+#: src/muuli_wdr.cpp:2653
 msgid "Support Protocol Obfuscation"
 msgstr "プロトコルの難読化を有効にする"
 
-#: src/muuli_wdr.cpp:2683
+#: src/muuli_wdr.cpp:2655
 msgid "This option enabled Protocol Obfuscation, and makes aMule accept obfuscated connections from other clients."
 msgstr "このオプションによってプロトコルの難読化を有効にできます。そうすると、aMuleは他のクライアントからの難読化された接続を受け入れられます。"
 
-#: src/muuli_wdr.cpp:2685
+#: src/muuli_wdr.cpp:2657
 msgid "Use obfuscation for outgoing connections"
 msgstr "外方向の接続に難読化を使用する"
 
-#: src/muuli_wdr.cpp:2687
+#: src/muuli_wdr.cpp:2659
 msgid "This option makes aMule use Protocol Obfuscation when connecting other clients/servers."
 msgstr "このオプションによって、aMuleは他のサーバまたはクライアントに接続する時にプロトコル難読化を使用します。"
 
-#: src/muuli_wdr.cpp:2689
+#: src/muuli_wdr.cpp:2661
 msgid "Accept only obfuscated connections"
 msgstr "難読化された接続のみを受信する"
 
-#: src/muuli_wdr.cpp:2690
+#: src/muuli_wdr.cpp:2662
 msgid "This option makes aMule only accept obfuscated connections. You will have less sources, but all your traffic will be obfuscated"
 msgstr "このオプションによって、aMuleは難読化された接続のみを受信します。ソース数が減りますが、トラフィックが全て難読化されます。"
 
-#: src/muuli_wdr.cpp:2695
+#: src/muuli_wdr.cpp:2667
 msgid "Everybody"
 msgstr "全員"
 
-#: src/muuli_wdr.cpp:2697
+#: src/muuli_wdr.cpp:2669
 msgid "No one"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2699
+#: src/muuli_wdr.cpp:2671
 msgid "Who can see my shared files:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2700
+#: src/muuli_wdr.cpp:2672
 msgid "Select who can request to view a list of your shared files."
 msgstr "あなたの共有ファイル・リストを要求できるユーザを選択してください。"
 
-#: src/muuli_wdr.cpp:2702
+#: src/muuli_wdr.cpp:2674
 msgid "IP-Filtering"
 msgstr "IPフィルタリング"
 
-#: src/muuli_wdr.cpp:2709
+#: src/muuli_wdr.cpp:2681
 msgid "Filter clients"
 msgstr "クライアントをフィルタする"
 
-#: src/muuli_wdr.cpp:2711
+#: src/muuli_wdr.cpp:2683
 msgid "Enable filtering of the client IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "~/.aMule/ipfilter.datに登録されちるクライアントIPにフィルタリングをかけることを有効にします。"
 
-#: src/muuli_wdr.cpp:2713
+#: src/muuli_wdr.cpp:2685
 msgid "Filter servers"
 msgstr "サーバをフィルタする"
 
-#: src/muuli_wdr.cpp:2715
+#: src/muuli_wdr.cpp:2687
 msgid "Enable filtering of the server IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "~/.aMule/ipfilter.datに登録されちるサーバIPにフィルタリングをかけることを有効にします。"
 
-#: src/muuli_wdr.cpp:2719
+#: src/muuli_wdr.cpp:2691
 msgid "Reload List"
 msgstr "リストを再ロードする"
 
-#: src/muuli_wdr.cpp:2720
+#: src/muuli_wdr.cpp:2692
 msgid "Reload the list of IPs to filter from the file ~/.aMule/ipfilter.dat"
 msgstr "フィルタリングをかける目標のIPリストを~/.aMule/ipfilter.datから再ロードをします。"
 
-#: src/muuli_wdr.cpp:2726
+#: src/muuli_wdr.cpp:2698
 msgid "URL:"
 msgstr "URL："
 
-#: src/muuli_wdr.cpp:2730 src/muuli_wdr.cpp:2923
+#: src/muuli_wdr.cpp:2702 src/muuli_wdr.cpp:2895
 msgid "Update now"
 msgstr "只今アップデートする"
 
-#: src/muuli_wdr.cpp:2733
+#: src/muuli_wdr.cpp:2705
 msgid "Auto-update ipfilter at startup"
 msgstr "スタートアップの時にipfilterを自動アップデートする"
 
-#: src/muuli_wdr.cpp:2737
+#: src/muuli_wdr.cpp:2709
 msgid "Filtering Level:"
 msgstr "フィルタリング段階："
 
-#: src/muuli_wdr.cpp:2743
+#: src/muuli_wdr.cpp:2715
 msgid "Always filter LAN IPs"
 msgstr "いつもLANのIPにフィルタリングをかける"
 
-#: src/muuli_wdr.cpp:2746
+#: src/muuli_wdr.cpp:2718
 msgid "Paranoid handling of non-matching IPs"
 msgstr "適合しないIPを被害妄想的に扱う"
 
-#: src/muuli_wdr.cpp:2748
+#: src/muuli_wdr.cpp:2720
 msgid "Rejects a packet when its source IP differs from the IP the client claims (an anti-spoofing check). Disable only if it causes connection problems."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2750
+#: src/muuli_wdr.cpp:2722
 msgid "Use system-wide ipfilter.dat if available"
 msgstr "提供されていれば、全システム応用のipfilter.datファイルを使用する"
 
-#: src/muuli_wdr.cpp:2751
+#: src/muuli_wdr.cpp:2723
 #, fuzzy
 msgid "If there's no local ipfilter.dat found, allow usage of a system-wide ipfilter file."
 msgstr "ローカルなipfilter.datファイルが見つからなければ、全システム応用のipfilter.datファイルを使用可能します。"
 
-#: src/muuli_wdr.cpp:2768
+#: src/muuli_wdr.cpp:2740
 msgid "Enable Online-Signature"
 msgstr "オンライン証明を有効にする"
 
-#: src/muuli_wdr.cpp:2770
+#: src/muuli_wdr.cpp:2742
 msgid "Enables the writing of the OS file, which can be used by external apps to create signatures and the like."
 msgstr "OSファイルの書き込みを有効にします。このファイルは外のアプリケーションに証明等を作成するためにを使用されます。"
 
-#: src/muuli_wdr.cpp:2774
+#: src/muuli_wdr.cpp:2746
 msgid "Update Frequency (Secs):"
 msgstr "アップデート頻度（秒単位）"
 
-#: src/muuli_wdr.cpp:2777
+#: src/muuli_wdr.cpp:2749
 msgid "Change the frequency (in seconds) of Online Signature updates."
 msgstr "オンライン証明アップデート頻度（秒単位）を変化します。"
 
-#: src/muuli_wdr.cpp:2785
+#: src/muuli_wdr.cpp:2757
 msgid "Save online signature file in: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:2791
+#: src/muuli_wdr.cpp:2763
 msgid "Click here to select the directory containing the the Online Signature files."
 msgstr "ここをクリックするとオンライン証明ファイルが入っているディレクトリを選択できます。"
 
-#: src/muuli_wdr.cpp:2824
+#: src/muuli_wdr.cpp:2796
 msgid "Show country flags for clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2825
+#: src/muuli_wdr.cpp:2797
 msgid "Render the country flag column in the transfers, queue and search views. Requires a valid MMDB GeoIP database (see below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2830
+#: src/muuli_wdr.cpp:2802
 #, fuzzy
 msgid "Database"
 msgstr "データ・レート："
 
-#: src/muuli_wdr.cpp:2846
+#: src/muuli_wdr.cpp:2818
 #, fuzzy
 msgid "Source:"
 msgstr "ソース数"
 
-#: src/muuli_wdr.cpp:2849
+#: src/muuli_wdr.cpp:2821
 msgid "DB-IP (free, no account)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2850
+#: src/muuli_wdr.cpp:2822
 msgid "MaxMind GeoLite2 (free, account required)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2851
+#: src/muuli_wdr.cpp:2823
 msgid "Custom URL"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2854
+#: src/muuli_wdr.cpp:2826
 msgid "Choose which provider supplies the GeoIP MMDB database. DB-IP is the default - no account required. MaxMind requires a free account + license key. Use Custom URL to point at any other MMDB host (e.g. a local mirror)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2871
+#: src/muuli_wdr.cpp:2843
 msgid ""
 "No configuration required.\n"
 "\n"
@@ -4872,11 +4838,11 @@ msgid ""
 "License: Creative Commons BY 4.0 - https://creativecommons.org/licenses/by/4.0/"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2884
+#: src/muuli_wdr.cpp:2856
 msgid "License key:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2890
+#: src/muuli_wdr.cpp:2862
 msgid ""
 "Sign up for a free MaxMind account, then generate a License Key:\n"
 "https://www.maxmind.com/en/geolite2/signup\n"
@@ -4886,232 +4852,232 @@ msgid ""
 "Requires attribution and account registration; refresh at least every 30 days."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2905
+#: src/muuli_wdr.cpp:2877
 #, fuzzy
 msgid "Download URL:"
 msgstr "ダウンロード： "
 
-#: src/muuli_wdr.cpp:2911
+#: src/muuli_wdr.cpp:2883
 msgid ""
 "Must point to an .mmdb file or a .gz / .tar.gz containing one.\n"
 "URL may include credentials (https://user:pass@host/...).\n"
 "License and attribution terms are set by the upstream URL - you are responsible."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2924
+#: src/muuli_wdr.cpp:2896
 msgid "Download the GeoIP database from the selected source."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2926
+#: src/muuli_wdr.cpp:2898
 #, fuzzy
 msgid "Auto-update on startup"
 msgstr "スタートアップの時にipfilterを自動アップデートする"
 
-#: src/muuli_wdr.cpp:2927
+#: src/muuli_wdr.cpp:2899
 msgid "Re-download the GeoIP database from the selected source every time aMule starts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2950
+#: src/muuli_wdr.cpp:2922
 msgid "Filter incoming messages (except current chat):"
 msgstr "受信メッセージをフィルタする（現在のチャットを除く）："
 
-#: src/muuli_wdr.cpp:2952
+#: src/muuli_wdr.cpp:2924
 msgid "Filter all messages"
 msgstr "全てのメッセージをフィルタする"
 
-#: src/muuli_wdr.cpp:2954
+#: src/muuli_wdr.cpp:2926
 msgid "Filter messages from people not on your friend list"
 msgstr "友達リストの入っていない方々からのメッセージをフィルタする"
 
-#: src/muuli_wdr.cpp:2956
+#: src/muuli_wdr.cpp:2928
 msgid "Filter messages from unknown clients"
 msgstr "知らないクライアントからのメッセージをフィルタする"
 
-#: src/muuli_wdr.cpp:2958
+#: src/muuli_wdr.cpp:2930
 msgid "Filter messages containing (use ',' as separator):"
 msgstr "次のストリングが入っているメッセージをフィルタする（','で区分する）："
 
-#: src/muuli_wdr.cpp:2961 src/muuli_wdr.cpp:2972
+#: src/muuli_wdr.cpp:2933 src/muuli_wdr.cpp:2944
 msgid "add here the words amule should filter and block messages including it"
 msgstr "amuleがメッセージ・フィルタ／ブロックの目標にする言葉をここに追加してください"
 
-#: src/muuli_wdr.cpp:2963
+#: src/muuli_wdr.cpp:2935
 msgid "Show received messages in the log"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2966
+#: src/muuli_wdr.cpp:2938
 msgid "Comments"
 msgstr "コメント"
 
-#: src/muuli_wdr.cpp:2969
+#: src/muuli_wdr.cpp:2941
 msgid "Filter comments containing (use ',' as separator):"
 msgstr "次のストリングが入っていコメントをフィルタする（','で区分する）："
 
-#: src/muuli_wdr.cpp:2994
+#: src/muuli_wdr.cpp:2966
 msgid "Enable Proxy"
 msgstr "プロクシを有効にする"
 
-#: src/muuli_wdr.cpp:2995
+#: src/muuli_wdr.cpp:2967
 msgid "Enable/disable proxy support"
 msgstr "プロクシ・サポートを有効／無効にする"
 
-#: src/muuli_wdr.cpp:2998
+#: src/muuli_wdr.cpp:2970
 msgid "Proxy type:"
 msgstr "プロクシの種類："
 
-#: src/muuli_wdr.cpp:3009
+#: src/muuli_wdr.cpp:2981
 msgid "Proxy host:"
 msgstr "プロクシー・ホスト："
 
-#: src/muuli_wdr.cpp:3012
+#: src/muuli_wdr.cpp:2984
 msgid "The proxy host name"
 msgstr "プロクシー・ホスト名："
 
-#: src/muuli_wdr.cpp:3014
+#: src/muuli_wdr.cpp:2986
 msgid "Proxy port:"
 msgstr "プロクシー・ポート："
 
-#: src/muuli_wdr.cpp:3017
+#: src/muuli_wdr.cpp:2989
 msgid "The proxy port"
 msgstr "プロクシーのポート"
 
-#: src/muuli_wdr.cpp:3019
+#: src/muuli_wdr.cpp:2991
 msgid "Enable authentication"
 msgstr "認証を有効にする"
 
-#: src/muuli_wdr.cpp:3020
+#: src/muuli_wdr.cpp:2992
 msgid "Enable/disable username/password authentication"
 msgstr "ユーザ名／パスワード認証を有効／無効にする"
 
-#: src/muuli_wdr.cpp:3023
+#: src/muuli_wdr.cpp:2995
 msgid "Username: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:3026
+#: src/muuli_wdr.cpp:2998
 msgid "The username to use to connect to the proxy"
 msgstr "プロクシーに接続に使うユーザ名"
 
-#: src/muuli_wdr.cpp:3028
+#: src/muuli_wdr.cpp:3000
 msgid "Password:"
 msgstr "パスワード："
 
-#: src/muuli_wdr.cpp:3031
+#: src/muuli_wdr.cpp:3003
 msgid "The password to use to connect to the proxy"
 msgstr "プロクシーに接続に使うパスワード"
 
-#: src/muuli_wdr.cpp:3050
+#: src/muuli_wdr.cpp:3022
 msgid "Connect to:"
 msgstr "次に接続する："
 
-#: src/muuli_wdr.cpp:3059
+#: src/muuli_wdr.cpp:3031
 msgid "Login to remote amule"
 msgstr "リモートamuleにログインする"
 
-#: src/muuli_wdr.cpp:3064
+#: src/muuli_wdr.cpp:3036
 msgid "User name"
 msgstr "ユーザ名"
 
-#: src/muuli_wdr.cpp:3075
+#: src/muuli_wdr.cpp:3047
 msgid "Remember those settings"
 msgstr "設定を記憶する"
 
-#: src/muuli_wdr.cpp:3078
+#: src/muuli_wdr.cpp:3050
 #, fuzzy
 msgid "Force ZLIB compression"
 msgstr "gzip圧縮を使用する"
 
-#: src/muuli_wdr.cpp:3102
+#: src/muuli_wdr.cpp:3074
 msgid "Enable Verbose Debug-Logging."
 msgstr "冗長なデバッグ・ロギングを有効にする"
 
-#: src/muuli_wdr.cpp:3104
+#: src/muuli_wdr.cpp:3076
 #, fuzzy
 msgid "Only to Logfile"
 msgstr "ファイルを開く(&O)"
 
-#: src/muuli_wdr.cpp:3106
+#: src/muuli_wdr.cpp:3078
 msgid "Message Categories:"
 msgstr "メッセージのカテゴリ："
 
-#: src/muuli_wdr.cpp:3130 src/PartFileConvertDlg.cpp:160
+#: src/muuli_wdr.cpp:3102 src/PartFileConvertDlg.cpp:160
 msgid "Waiting..."
 msgstr "待機中…"
 
-#: src/muuli_wdr.cpp:3150
+#: src/muuli_wdr.cpp:3122
 msgid "Add imports"
 msgstr "インポートを追加する"
 
-#: src/muuli_wdr.cpp:3153
+#: src/muuli_wdr.cpp:3125
 msgid "Retry selected"
 msgstr "選択したものを再試行"
 
-#: src/muuli_wdr.cpp:3155
+#: src/muuli_wdr.cpp:3127
 msgid "Remove selected"
 msgstr "選択したものを破棄"
 
-#: src/muuli_wdr.cpp:3218
+#: src/muuli_wdr.cpp:3190
 msgid "Event Types"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3237
+#: src/muuli_wdr.cpp:3209
 msgid "Statistics and queued clients for selected file(s) : Session / All time"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3261
+#: src/muuli_wdr.cpp:3233
 #, fuzzy
 msgid "Active Uploads"
 msgstr "アクティブなアップロード数："
 
-#: src/muuli_wdr.cpp:3275
+#: src/muuli_wdr.cpp:3247
 msgid "Percent of total files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3327
+#: src/muuli_wdr.cpp:3299
 #, fuzzy
 msgid "Show Clients for"
 msgstr "クライアントを表示する"
 
-#: src/muuli_wdr.cpp:3329
+#: src/muuli_wdr.cpp:3301
 #, fuzzy
 msgid "All files"
 msgstr "共有ファイルを隠す"
 
-#: src/muuli_wdr.cpp:3332
+#: src/muuli_wdr.cpp:3304
 #, fuzzy
 msgid "Selected files"
 msgstr "ビュー・フィルタを選択してください"
 
-#: src/muuli_wdr.cpp:3335
+#: src/muuli_wdr.cpp:3307
 #, fuzzy
 msgid "Active uploads only"
 msgstr "アクティブなアップロード数"
 
-#: src/muuli_wdr.cpp:3342
+#: src/muuli_wdr.cpp:3314
 #, fuzzy
 msgid "Reload:"
 msgstr "リストを再ロードする"
 
-#: src/muuli_wdr.cpp:3346
+#: src/muuli_wdr.cpp:3318
 msgid "Reload your shared files"
 msgstr "共有ファイルを再ロードする"
 
-#: src/muuli_wdr.cpp:3409
+#: src/muuli_wdr.cpp:3381
 msgid "Send"
 msgstr "送信する"
 
-#: src/muuli_wdr.cpp:3410
+#: src/muuli_wdr.cpp:3382
 msgid "Sends the specified message."
 msgstr "指示するメッセージを送信します。"
 
-#: src/muuli_wdr.cpp:3414
+#: src/muuli_wdr.cpp:3386
 msgid "Close this chat-session."
 msgstr "チャット・セションを閉じます。"
 
-#: src/muuli_wdr.cpp:3437
+#: src/muuli_wdr.cpp:3409
 msgid "Connect to any server and/or Kad"
 msgstr "すべてのサーバ、もしくはKadに接続する"
 
-#: src/muuli_wdr.cpp:3443 src/SharedFilesCtrl.cpp:142 src/Statistics.cpp:941
+#: src/muuli_wdr.cpp:3415 src/SharedFilesCtrl.cpp:142 src/Statistics.cpp:941
 msgid "Shared Files"
 msgstr "共有ファイル"
 
@@ -5468,268 +5434,268 @@ msgstr "ダウンロード済み"
 msgid "ERROR: Failed to open partfile '%s'"
 msgstr "エラー: 部分ファイル '%s' が開けませんでした"
 
-#: src/Preferences.cpp:701
+#: src/Preferences.cpp:673
 msgid "System default"
 msgstr "システムの標準設定"
 
-#: src/Preferences.cpp:702
+#: src/Preferences.cpp:674
 msgid "Albanian"
 msgstr "アルバニア語"
 
-#: src/Preferences.cpp:703
+#: src/Preferences.cpp:675
 msgid "Arabic"
 msgstr "アラブ語"
 
-#: src/Preferences.cpp:704
+#: src/Preferences.cpp:676
 #, fuzzy
 msgid "Asturian"
 msgstr "エストニア語"
 
-#: src/Preferences.cpp:705
+#: src/Preferences.cpp:677
 msgid "Basque"
 msgstr "バスク語"
 
-#: src/Preferences.cpp:706
+#: src/Preferences.cpp:678
 msgid "Bulgarian"
 msgstr "ブルガリア語"
 
-#: src/Preferences.cpp:707
+#: src/Preferences.cpp:679
 msgid "Catalan"
 msgstr "カタロニア語"
 
-#: src/Preferences.cpp:708
+#: src/Preferences.cpp:680
 msgid "Chinese (Simplified)"
 msgstr "中国語（簡体字）"
 
-#: src/Preferences.cpp:709
+#: src/Preferences.cpp:681
 msgid "Chinese (Traditional)"
 msgstr "中国語（繁体字）"
 
-#: src/Preferences.cpp:710
+#: src/Preferences.cpp:682
 msgid "Croatian"
 msgstr "クロアチア語"
 
-#: src/Preferences.cpp:711
+#: src/Preferences.cpp:683
 msgid "Czech"
 msgstr "チェコ語"
 
-#: src/Preferences.cpp:712
+#: src/Preferences.cpp:684
 msgid "Danish"
 msgstr "デンマーク語"
 
-#: src/Preferences.cpp:713
+#: src/Preferences.cpp:685
 msgid "Dutch"
 msgstr "オランダ語"
 
-#: src/Preferences.cpp:714
+#: src/Preferences.cpp:686
 msgid "English (U.K.)"
 msgstr "英語（U.K.）"
 
-#: src/Preferences.cpp:715
+#: src/Preferences.cpp:687
 #, fuzzy
 msgid "English (U.S.)"
 msgstr "英語（U.K.）"
 
-#: src/Preferences.cpp:716
+#: src/Preferences.cpp:688
 msgid "Estonian"
 msgstr "エストニア語"
 
-#: src/Preferences.cpp:717
+#: src/Preferences.cpp:689
 msgid "Finnish"
 msgstr "フィンランド語"
 
-#: src/Preferences.cpp:718
+#: src/Preferences.cpp:690
 msgid "French"
 msgstr "フランス語"
 
-#: src/Preferences.cpp:719
+#: src/Preferences.cpp:691
 msgid "Galician"
 msgstr "ガリシア語"
 
-#: src/Preferences.cpp:720
+#: src/Preferences.cpp:692
 msgid "German"
 msgstr "ドイツ語"
 
-#: src/Preferences.cpp:721
+#: src/Preferences.cpp:693
 msgid "Greek"
 msgstr "ギリシア語"
 
-#: src/Preferences.cpp:722
+#: src/Preferences.cpp:694
 msgid "Hebrew"
 msgstr "ヘブライ語"
 
-#: src/Preferences.cpp:723
+#: src/Preferences.cpp:695
 msgid "Hungarian"
 msgstr "ハンガリー語"
 
-#: src/Preferences.cpp:724
+#: src/Preferences.cpp:696
 msgid "Italian"
 msgstr "イタリア語"
 
-#: src/Preferences.cpp:725
+#: src/Preferences.cpp:697
 msgid "Japanese"
 msgstr "日本語"
 
-#: src/Preferences.cpp:726
+#: src/Preferences.cpp:698
 msgid "Korean"
 msgstr "韓国語"
 
-#: src/Preferences.cpp:727
+#: src/Preferences.cpp:699
 msgid "Latvian"
 msgstr ""
 
-#: src/Preferences.cpp:728
+#: src/Preferences.cpp:700
 msgid "Lithuanian"
 msgstr "リトアニア語"
 
-#: src/Preferences.cpp:729
+#: src/Preferences.cpp:701
 msgid "Norwegian (Nynorsk)"
 msgstr "ルウェー語"
 
-#: src/Preferences.cpp:730
+#: src/Preferences.cpp:702
 msgid "Polish"
 msgstr "ポーランド語"
 
-#: src/Preferences.cpp:731
+#: src/Preferences.cpp:703
 msgid "Portuguese"
 msgstr "ポルトガル語"
 
-#: src/Preferences.cpp:732
+#: src/Preferences.cpp:704
 msgid "Portuguese (Brazilian)"
 msgstr "ポルトガル語（ブラジル）"
 
-#: src/Preferences.cpp:733
+#: src/Preferences.cpp:705
 #, fuzzy
 msgid "Romanian"
 msgstr "アルバニア語"
 
-#: src/Preferences.cpp:734
+#: src/Preferences.cpp:706
 msgid "Russian"
 msgstr "ロシア語"
 
-#: src/Preferences.cpp:735
+#: src/Preferences.cpp:707
 msgid "Slovenian"
 msgstr "スロベニア語"
 
-#: src/Preferences.cpp:736
+#: src/Preferences.cpp:708
 msgid "Spanish"
 msgstr "スペイン語"
 
-#: src/Preferences.cpp:737
+#: src/Preferences.cpp:709
 msgid "Swedish"
 msgstr "スウェーデン語"
 
-#: src/Preferences.cpp:738
+#: src/Preferences.cpp:710
 msgid "Turkish"
 msgstr "トルコ語"
 
-#: src/Preferences.cpp:739
+#: src/Preferences.cpp:711
 msgid "Ukrainian"
 msgstr ""
 
-#: src/Preferences.cpp:842
+#: src/Preferences.cpp:814
 #, fuzzy
 msgid "Change Language"
 msgstr "言語"
 
-#: src/Preferences.cpp:906
+#: src/Preferences.cpp:878
 msgid "There are no translations installed for aMule"
 msgstr ""
 
-#: src/Preferences.cpp:907
+#: src/Preferences.cpp:879
 #, fuzzy
 msgid "No languages available"
 msgstr "利用不可"
 
-#: src/Preferences.cpp:1038
+#: src/Preferences.cpp:1010
 msgid "no options available"
 msgstr ""
 
-#: src/Preferences.cpp:2226
+#: src/Preferences.cpp:2179
 msgid "Invalid category found, skipping"
 msgstr ""
 
-#: src/Preferences.cpp:2395
+#: src/Preferences.cpp:2348
 msgid "TCP port can't be higher than 65532 due to server UDP socket being TCP+3"
 msgstr "サーバのUDPソケトがTCP+3であるためTCPポートを65532以上には設定できません"
 
-#: src/Preferences.cpp:2396
+#: src/Preferences.cpp:2349
 #, c-format
 msgid "Default port will be used (%d)"
 msgstr "デフォルトポートを使用します (%d)"
 
-#: src/PrefsUnifiedDlg.cpp:300 src/Statistics.cpp:866
+#: src/PrefsUnifiedDlg.cpp:298 src/Statistics.cpp:866
 msgid "Connection"
 msgstr "接続"
 
-#: src/PrefsUnifiedDlg.cpp:301 src/SearchListCtrl.cpp:117
+#: src/PrefsUnifiedDlg.cpp:299 src/SearchListCtrl.cpp:117
 msgid "Directories"
 msgstr "ディレクトリ"
 
-#: src/PrefsUnifiedDlg.cpp:302 src/Statistics.cpp:917
+#: src/PrefsUnifiedDlg.cpp:300 src/Statistics.cpp:917
 msgid "Servers"
 msgstr "サーバ数"
 
-#: src/PrefsUnifiedDlg.cpp:303 src/ServerListCtrl.cpp:96
+#: src/PrefsUnifiedDlg.cpp:301 src/ServerListCtrl.cpp:96
 msgid "Files"
 msgstr "ファイル"
 
-#: src/PrefsUnifiedDlg.cpp:304
+#: src/PrefsUnifiedDlg.cpp:302
 msgid "Security"
 msgstr "セキュリティ"
 
-#: src/PrefsUnifiedDlg.cpp:305
+#: src/PrefsUnifiedDlg.cpp:303
 msgid "Interface"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:312
+#: src/PrefsUnifiedDlg.cpp:310
 msgid "IP2Country"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:315
+#: src/PrefsUnifiedDlg.cpp:313
 msgid "Proxy"
 msgstr "プロクシ"
 
-#: src/PrefsUnifiedDlg.cpp:316
+#: src/PrefsUnifiedDlg.cpp:314
 msgid "Filters"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:317
+#: src/PrefsUnifiedDlg.cpp:315
 msgid "Remote Controls"
 msgstr "リモート制御"
 
-#: src/PrefsUnifiedDlg.cpp:318
+#: src/PrefsUnifiedDlg.cpp:316
 msgid "Online Signature"
 msgstr "オンライン署名"
 
-#: src/PrefsUnifiedDlg.cpp:319
+#: src/PrefsUnifiedDlg.cpp:317
 msgid "Advanced"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:320
+#: src/PrefsUnifiedDlg.cpp:318
 msgid "Events"
 msgstr "イベント"
 
-#: src/PrefsUnifiedDlg.cpp:323
+#: src/PrefsUnifiedDlg.cpp:321
 msgid "Debugging"
 msgstr "デバッグ"
 
-#: src/PrefsUnifiedDlg.cpp:453
+#: src/PrefsUnifiedDlg.cpp:451
 msgid ""
 "The following variables will be substituted:\n"
 "    %PARTFILE - full path to the file\n"
 "    %PARTNAME - file name only"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:474
+#: src/PrefsUnifiedDlg.cpp:472
 msgid "Tray icon support requires libayatana-appindicator3 at compile time."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:490
+#: src/PrefsUnifiedDlg.cpp:488
 msgid "Not available on Wayland: the protocol does not report when a window is minimized, so this option cannot intercept the system minimize button. Workaround: launch aMule with `GDK_BACKEND=x11` to use XWayland instead."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:536
+#: src/PrefsUnifiedDlg.cpp:534
 msgid ""
 "Do not change these setting unless you know\n"
 "what you are doing, otherwise you can easily\n"
@@ -5745,85 +5711,76 @@ msgstr ""
 "この設定を変更しなくてもaMuleはうまく動いて\n"
 "います。"
 
-#: src/PrefsUnifiedDlg.cpp:647
+#: src/PrefsUnifiedDlg.cpp:645
 #, c-format
 msgid "Failed to connect Cfg to widget with the ID %d and key %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:695
+#: src/PrefsUnifiedDlg.cpp:693
 #, c-format
 msgid "Failed to transfer data from Cfg to Widget with the ID %d and key %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:801
+#: src/PrefsUnifiedDlg.cpp:799
 msgid "The type of proxy you are connecting to"
 msgstr "接続するプロクシーの種類"
 
-#: src/PrefsUnifiedDlg.cpp:1020
+#: src/PrefsUnifiedDlg.cpp:1003
 #, c-format
 msgid "Failed to transfer data from Widget to Cfg with the ID %d and key %s"
 msgstr ""
 
 #: src/PrefsUnifiedDlg.cpp:1103
-#, fuzzy
-msgid "No password set."
-msgstr "パスワードをチェック中です\n"
-
-#: src/PrefsUnifiedDlg.cpp:1132
-msgid "Guest access needs a password. Type one in the guest password field, or untick Enable guest access."
-msgstr ""
-
-#: src/PrefsUnifiedDlg.cpp:1144
 msgid ""
 "aMule must be restarted to enable these changes:\n"
 "\n"
 msgstr "この変更点を有効するにはaMuleを再起動しなければなりません：\n"
 
-#: src/PrefsUnifiedDlg.cpp:1151
+#: src/PrefsUnifiedDlg.cpp:1110
 msgid "- TCP port changed.\n"
 msgstr "- TCPポートを変更しました。\n"
 
-#: src/PrefsUnifiedDlg.cpp:1156
+#: src/PrefsUnifiedDlg.cpp:1115
 msgid "- UDP port changed.\n"
 msgstr "- UDPポートを変更しました。\n"
 
-#: src/PrefsUnifiedDlg.cpp:1161
+#: src/PrefsUnifiedDlg.cpp:1120
 #, fuzzy
 msgid "- Network interface binding changed.\n"
 msgstr "外部接続は終了しました。"
 
-#: src/PrefsUnifiedDlg.cpp:1166
+#: src/PrefsUnifiedDlg.cpp:1125
 #, fuzzy
 msgid "- External connect port changed.\n"
 msgstr "外部接続は終了しました。"
 
-#: src/PrefsUnifiedDlg.cpp:1170
+#: src/PrefsUnifiedDlg.cpp:1129
 #, fuzzy
 msgid "- External connect acceptance changed.\n"
 msgstr "新しい外部接続を認められました"
 
-#: src/PrefsUnifiedDlg.cpp:1174
+#: src/PrefsUnifiedDlg.cpp:1133
 #, fuzzy
 msgid "- External connect interface changed.\n"
 msgstr "外部接続は終了しました。"
 
-#: src/PrefsUnifiedDlg.cpp:1178
+#: src/PrefsUnifiedDlg.cpp:1137
 #, fuzzy
 msgid "- Protocol obfuscation support changed.\n"
 msgstr "プロトコルを難読化する"
 
-#: src/PrefsUnifiedDlg.cpp:1193
+#: src/PrefsUnifiedDlg.cpp:1151
 #, fuzzy
 msgid "- amuleapi settings changed.\n"
 msgstr "- 言語を変更しました。\n"
 
-#: src/PrefsUnifiedDlg.cpp:1202
+#: src/PrefsUnifiedDlg.cpp:1160
 msgid ""
 "Your Auto-update server list is empty.\n"
 "'Auto-update server list at startup' will be disabled."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1213
+#: src/PrefsUnifiedDlg.cpp:1171
 msgid ""
 "You have enabled external connections but have not specified a password.\n"
 "External connections cannot be enabled unless a valid password is specified."
@@ -5831,40 +5788,35 @@ msgstr ""
 "外部接続を有効にしましたがパスワードを設定していません。\n"
 "有効なパスワードを設定しないと外部接続を可能できません。"
 
-#: src/PrefsUnifiedDlg.cpp:1246
-#, c-format
-msgid "The amuleapi password could not be saved: %s"
-msgstr ""
-
-#: src/PrefsUnifiedDlg.cpp:1276
+#: src/PrefsUnifiedDlg.cpp:1202
 msgid "- Language changed.\n"
 msgstr "- 言語を変更しました。\n"
 
-#: src/PrefsUnifiedDlg.cpp:1281
+#: src/PrefsUnifiedDlg.cpp:1207
 msgid "- Temp folder changed.\n"
 msgstr "- 一時フォルダを変更しました。\n"
 
-#: src/PrefsUnifiedDlg.cpp:1286
+#: src/PrefsUnifiedDlg.cpp:1212
 #, fuzzy
 msgid "- ED2K network enabled.\n"
 msgstr "全てのネットワークが無効になっています。"
 
-#: src/PrefsUnifiedDlg.cpp:1319
+#: src/PrefsUnifiedDlg.cpp:1245
 msgid "The shared-file exclusion pattern is not a valid regular expression. The filter has been left disabled."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1321 src/PrefsUnifiedDlg.cpp:1921
+#: src/PrefsUnifiedDlg.cpp:1247 src/PrefsUnifiedDlg.cpp:1841
 #, fuzzy
 msgid "Invalid regular expression"
 msgstr "無効なプロトコルバージョン。"
 
-#: src/PrefsUnifiedDlg.cpp:1398
+#: src/PrefsUnifiedDlg.cpp:1324
 msgid ""
 "Both eD2k and Kad network are disabled.\n"
 "You won't be able to connect until you enable at least one of them."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1403
+#: src/PrefsUnifiedDlg.cpp:1329
 msgid ""
 "Kad will not start if your UDP port is disabled.\n"
 "Enable UDP port or disable Kad."
@@ -5872,7 +5824,7 @@ msgstr ""
 "UDPポートが無効になっているとKadは開始できません。\n"
 "UDPポートを有効にするか、またはKadを無効にしてください。"
 
-#: src/PrefsUnifiedDlg.cpp:1459
+#: src/PrefsUnifiedDlg.cpp:1385
 msgid ""
 "\n"
 "You MUST restart aMule now.\n"
@@ -5882,69 +5834,69 @@ msgstr ""
 "必ず早急にaMuleを再起動してください。\n"
 "今すぐに再起動しなければ、挙動がおかしくなる可能性があります。\n"
 
-#: src/PrefsUnifiedDlg.cpp:1524
+#: src/PrefsUnifiedDlg.cpp:1450
 msgid "Could not register aMule for autostart at login. The autostart store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1526
+#: src/PrefsUnifiedDlg.cpp:1452
 msgid "Could not remove the autostart-at-login entry."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1527
+#: src/PrefsUnifiedDlg.cpp:1453
 #, fuzzy
 msgid "Autostart"
 msgstr "オートリフレッシュを開始しました"
 
-#: src/PrefsUnifiedDlg.cpp:1542
+#: src/PrefsUnifiedDlg.cpp:1468
 msgid "Register file type"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1542
+#: src/PrefsUnifiedDlg.cpp:1468
 msgid "Register URL handler"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1550
+#: src/PrefsUnifiedDlg.cpp:1476
 #, c-format
 msgid "aMule only handles eD2k-compatible magnets. If you replace the current magnet handler (%s), BitTorrent magnet links will stop working - aMule cannot download BitTorrent content. Continue?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1555
+#: src/PrefsUnifiedDlg.cpp:1481
 #, c-format
 msgid "Another application currently opens .emulecollection files (%s). Replace it with aMule?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1560
+#: src/PrefsUnifiedDlg.cpp:1486
 #, c-format
 msgid "Another application is currently the default handler for these links (%s). Replace it with aMule?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1585
+#: src/PrefsUnifiedDlg.cpp:1511
 msgid "Could not register aMule for .emulecollection files. The registration store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1587
+#: src/PrefsUnifiedDlg.cpp:1513
 #, fuzzy
 msgid "Could not remove the file type registration."
 msgstr "あなたはすでにファイル%sをダウンロードしようとしています"
 
-#: src/PrefsUnifiedDlg.cpp:1589
+#: src/PrefsUnifiedDlg.cpp:1515
 msgid "Could not register aMule as the URL handler. The registration store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1591
+#: src/PrefsUnifiedDlg.cpp:1517
 msgid "Could not remove the URL handler registration."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1661 src/PrefsUnifiedDlg.cpp:1688
+#: src/PrefsUnifiedDlg.cpp:1587 src/PrefsUnifiedDlg.cpp:1614
 #, fuzzy
 msgid "The web server and aMule API require external connections to be enabled."
 msgstr "新しい外部接続を認められました"
 
-#: src/PrefsUnifiedDlg.cpp:1671
+#: src/PrefsUnifiedDlg.cpp:1597
 msgid "The aMule web server is deprecated. Consider running the aMule API instead."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1735
+#: src/PrefsUnifiedDlg.cpp:1655
 msgid ""
 "Your Auto-update servers list is in blank.\n"
 "Please fill in at least one URL to point to a valid server.met file.\n"
@@ -5954,65 +5906,65 @@ msgstr ""
 "せめて一つのURLを入力して、有効なserver.metファイルを指定してください。\n"
 "このチェックボクスの近くの\"表\"ボタンをクリックして、URLを入力してください。"
 
-#: src/PrefsUnifiedDlg.cpp:1876
+#: src/PrefsUnifiedDlg.cpp:1796
 msgid "Temporary files"
 msgstr "一時ファイル"
 
-#: src/PrefsUnifiedDlg.cpp:1881
+#: src/PrefsUnifiedDlg.cpp:1801
 msgid "Incoming files"
 msgstr "受信ファイル"
 
-#: src/PrefsUnifiedDlg.cpp:1886
+#: src/PrefsUnifiedDlg.cpp:1806
 msgid "Online Signatures"
 msgstr "オンライン署名"
 
-#: src/PrefsUnifiedDlg.cpp:1899
+#: src/PrefsUnifiedDlg.cpp:1819
 #, c-format
 msgid "Choose a folder for %s"
 msgstr " %s のためのフォルダを選択する"
 
-#: src/PrefsUnifiedDlg.cpp:1923
+#: src/PrefsUnifiedDlg.cpp:1843
 #, fuzzy, c-format
 msgid "Would exclude %u of %u shared file"
 msgid_plural "Would exclude %u of %u shared files"
 msgstr[0] "%i個の既知の共有ファイルが見つかりました"
 
-#: src/PrefsUnifiedDlg.cpp:1940
+#: src/PrefsUnifiedDlg.cpp:1860
 msgid "Browse for videoplayer"
 msgstr "ビデオプレイヤーを選択する"
 
-#: src/PrefsUnifiedDlg.cpp:1944
+#: src/PrefsUnifiedDlg.cpp:1864
 msgid "Select browser"
 msgstr "ブラウザを選択する"
 
-#: src/PrefsUnifiedDlg.cpp:1948
+#: src/PrefsUnifiedDlg.cpp:1868
 #, fuzzy
 msgid "Select ffprobe binary"
 msgstr "ブラウザを選択する"
 
-#: src/PrefsUnifiedDlg.cpp:1954
+#: src/PrefsUnifiedDlg.cpp:1874
 #, c-format
 msgid "Executable%s"
 msgstr "実行ファイル%s"
 
-#: src/PrefsUnifiedDlg.cpp:1988
+#: src/PrefsUnifiedDlg.cpp:1908
 msgid "ffprobe not found on PATH or in the standard install locations. Install ffmpeg (which ships ffprobe) or use Browse to pick a binary manually."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2000
+#: src/PrefsUnifiedDlg.cpp:1920
 msgid "Reset the settings on this page to their default values?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2001
+#: src/PrefsUnifiedDlg.cpp:1921
 #, fuzzy
 msgid "Reset to defaults"
 msgstr "システムの標準設定"
 
-#: src/PrefsUnifiedDlg.cpp:2028
+#: src/PrefsUnifiedDlg.cpp:1948
 msgid "Edit server list"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2029
+#: src/PrefsUnifiedDlg.cpp:1949
 msgid ""
 "Add here URL's to download server.met files.\n"
 "Only one url on each line."
@@ -6020,176 +5972,172 @@ msgstr ""
 "server.metファイルをダウンロードするURLをここに追加してください。\n"
 "一行にひとつのURLのみです。"
 
-#: src/PrefsUnifiedDlg.cpp:2084
+#: src/PrefsUnifiedDlg.cpp:2004
 msgid "IP2Country update failed"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2229 src/PrefsUnifiedDlg.cpp:2260
+#: src/PrefsUnifiedDlg.cpp:2149 src/PrefsUnifiedDlg.cpp:2180
 msgid "Data by MaxMind GeoLite2"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2231 src/PrefsUnifiedDlg.cpp:2262
+#: src/PrefsUnifiedDlg.cpp:2151 src/PrefsUnifiedDlg.cpp:2182
 #, fuzzy
 msgid "Custom source"
 msgstr "ソース完了"
 
-#: src/PrefsUnifiedDlg.cpp:2233 src/PrefsUnifiedDlg.cpp:2264
+#: src/PrefsUnifiedDlg.cpp:2153 src/PrefsUnifiedDlg.cpp:2184
 msgid "Data by DB-IP.com"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2284
+#: src/PrefsUnifiedDlg.cpp:2204
 #, fuzzy, c-format
 msgid "Status: Loaded%s"
 msgstr "ステータス："
 
-#: src/PrefsUnifiedDlg.cpp:2286
+#: src/PrefsUnifiedDlg.cpp:2206
 #, fuzzy, c-format
 msgid "Status: Loaded%s - %s"
 msgstr "ステータス："
 
-#: src/PrefsUnifiedDlg.cpp:2290
+#: src/PrefsUnifiedDlg.cpp:2210
 msgid "Status: Failed to load - click 'Update now' to refresh."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2292
+#: src/PrefsUnifiedDlg.cpp:2212
 msgid "Status: Not found - click 'Update now' to download."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2350 src/PrefsUnifiedDlg.cpp:2374
+#: src/PrefsUnifiedDlg.cpp:2270 src/PrefsUnifiedDlg.cpp:2294
 #, c-format
 msgid "Update delay: %d second"
 msgid_plural "Update delay: %d seconds"
 msgstr[0] "アップデート遅延時間： %d 秒"
 
-#: src/PrefsUnifiedDlg.cpp:2358
+#: src/PrefsUnifiedDlg.cpp:2278
 #, c-format
 msgid "Time for average graph: %d minute"
 msgid_plural "Time for average graph: %d minutes"
 msgstr[0] "平均グラフの時間： %d 分"
 
-#: src/PrefsUnifiedDlg.cpp:2367
+#: src/PrefsUnifiedDlg.cpp:2287
 #, c-format
 msgid "Connections Graph Scale: %d"
 msgstr "接続グラフスケール： %d"
 
-#: src/PrefsUnifiedDlg.cpp:2382
+#: src/PrefsUnifiedDlg.cpp:2302
 #, c-format
 msgid "File Buffer Size: %d byte"
 msgid_plural "File Buffer Size: %d bytes"
 msgstr[0] "ファイルバッファサイズ： %d バイト"
 
-#: src/PrefsUnifiedDlg.cpp:2392
+#: src/PrefsUnifiedDlg.cpp:2312
 #, c-format
 msgid "Upload Queue Size: %d client"
 msgid_plural "Upload Queue Size: %d clients"
 msgstr[0] "アップロードキューサイズ： %d クライアント"
 
-#: src/PrefsUnifiedDlg.cpp:2402
+#: src/PrefsUnifiedDlg.cpp:2322
 #, c-format
 msgid "Server connection refresh interval: %d minute"
 msgid_plural "Server connection refresh interval: %d minutes"
 msgstr[0] "サーバ接続リフレッシュ遅延時間： %d 分"
 
-#: src/PrefsUnifiedDlg.cpp:2407
+#: src/PrefsUnifiedDlg.cpp:2327
 msgid "Server connection refresh interval: Disabled"
 msgstr "サーバ接続リフレッシュ遅延時間： 無効"
 
-#: src/PrefsUnifiedDlg.cpp:2451
+#: src/PrefsUnifiedDlg.cpp:2371
 #, fuzzy
 msgid "disabled"
 msgstr "無効にする"
 
-#: src/PrefsUnifiedDlg.cpp:2477
+#: src/PrefsUnifiedDlg.cpp:2397
 #, fuzzy, c-format
 msgid "Execute command on '%s' event"
 msgstr " `%s' イベントにコマンドを実行する"
 
-#: src/PrefsUnifiedDlg.cpp:2484
+#: src/PrefsUnifiedDlg.cpp:2404
 msgid "Enable command execution on core"
 msgstr "コアにコマンドを実行することを有効にする"
 
-#: src/PrefsUnifiedDlg.cpp:2496
+#: src/PrefsUnifiedDlg.cpp:2416
 msgid "Core command:"
 msgstr "コアコマンド："
 
-#: src/PrefsUnifiedDlg.cpp:2512
+#: src/PrefsUnifiedDlg.cpp:2432
 msgid "Enable command execution on GUI"
 msgstr "GUIにコマンドを実行することを有効にする"
 
-#: src/PrefsUnifiedDlg.cpp:2524
+#: src/PrefsUnifiedDlg.cpp:2444
 msgid "GUI command:"
 msgstr "GUIコマンド："
 
-#: src/PrefsUnifiedDlg.cpp:2540
+#: src/PrefsUnifiedDlg.cpp:2460
 msgid "The following variables will be replaced:"
 msgstr "次の変数は置換されます："
 
-#: src/PrefsUnifiedDlg.cpp:2708
+#: src/PrefsUnifiedDlg.cpp:2628
 msgid ""
 "The following folders look like system or sensitive locations:\n"
 "\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2713
+#: src/PrefsUnifiedDlg.cpp:2633
 msgid "Sharing them recursively will publish every file underneath on the eD2k/Kad networks. Do you really want to do this?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2716
+#: src/PrefsUnifiedDlg.cpp:2636
 #, fuzzy
 msgid "Confirm shared folders"
 msgstr "共有ファイルを再ロードする"
 
-#: src/PrefsUnifiedDlg.cpp:2744
+#: src/PrefsUnifiedDlg.cpp:2664
 #, fuzzy
 msgid "Reloading shared files..."
 msgstr "共有ファイルを再ロードする"
 
-#: src/PrefsUnifiedDlg.cpp:2745
+#: src/PrefsUnifiedDlg.cpp:2665
 msgid "Scanning for subdirectories..."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2746
+#: src/PrefsUnifiedDlg.cpp:2666
 #, fuzzy
 msgid "Updating shared folders"
 msgstr "一時フォルダを読み中です"
 
-#: src/PrefsUnifiedDlg.cpp:2773
+#: src/PrefsUnifiedDlg.cpp:2693
 #, c-format
 msgid "Scanned %u directories..."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2823
+#: src/PrefsUnifiedDlg.cpp:2743
 #, fuzzy, c-format
 msgid "Reloading shared files: %u files scanned"
 msgstr "共有ファイル・リストを再ロードします。"
 
-#: src/PrefsUnifiedDlg.cpp:2873
+#: src/PrefsUnifiedDlg.cpp:2793
 #, fuzzy
 msgid "Shared folder"
 msgstr "共有ファイル"
 
-#: src/SearchDlg.cpp:280
-msgid "Clear search history"
-msgstr ""
-
-#: src/SearchDlg.cpp:584
+#: src/SearchDlg.cpp:425
 msgid "It's impossible to search when both eD2k and Kademlia are disabled."
 msgstr ""
 
-#: src/SearchDlg.cpp:585 src/SearchListCtrl.cpp:858
+#: src/SearchDlg.cpp:426 src/SearchListCtrl.cpp:858
 #, fuzzy
 msgid "Search error"
 msgstr "検索"
 
-#: src/SearchDlg.cpp:929
+#: src/SearchDlg.cpp:768
 msgid "Min size must be smaller than max size. Max size ignored."
 msgstr "最小サイズは最大サイズより小さくなければなりません。最大サイズを無視します。"
 
-#: src/SearchDlg.cpp:930 src/SearchDlg.cpp:1012
+#: src/SearchDlg.cpp:769 src/SearchDlg.cpp:851
 msgid "Search warning"
 msgstr "検索の注意"
 
-#: src/SearchDlg.cpp:1092 src/SearchListCtrl.cpp:735
+#: src/SearchDlg.cpp:929 src/SearchListCtrl.cpp:735
 msgid "Main"
 msgstr "メイン"
 

--- a/po/ja.po
+++ b/po/ja.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-28 12:17+0200\n"
+"POT-Creation-Date: 2026-07-28 13:09+0200\n"
 "PO-Revision-Date: 2026-07-27 11:41+0000\n"
 "Last-Translator: \n"
 "Language-Team: Japanese\n"
@@ -293,7 +293,7 @@ msgid "Password set and external connections enabled."
 msgstr "新しい外部接続を認められました"
 
 #: src/amule.cpp:755 src/KadDlg.cpp:176 src/KadDlg.cpp:185
-#: src/PrefsUnifiedDlg.cpp:1461 src/SharedFilesCtrl.cpp:476
+#: src/PrefsUnifiedDlg.cpp:1470 src/SharedFilesCtrl.cpp:476
 msgid "WARNING"
 msgstr "警告"
 
@@ -330,7 +330,7 @@ msgstr ""
 #: src/amule-remote-gui.cpp:603 src/amule-remote-gui.cpp:671
 #: src/amule-remote-gui.cpp:709 src/amule-remote-gui.cpp:1282
 #: src/amule-remote-gui.cpp:1345 src/amule-remote-gui.cpp:1372
-#: src/DownloadQueue.cpp:1481 src/PrefsUnifiedDlg.cpp:1247
+#: src/DownloadQueue.cpp:1481 src/PrefsUnifiedDlg.cpp:1256
 msgid "ERROR"
 msgstr ""
 
@@ -592,36 +592,36 @@ msgstr "新しいバージョンの確認はhttps://github.com/amule-org/amule/r
 msgid "FATAL ERROR: Failed to create Timer"
 msgstr ""
 
-#: src/amuleDlg.cpp:361 src/amuleDlg.cpp:1787 src/amuleDlg.cpp:2033
-#: src/muuli_wdr.cpp:1492 src/muuli_wdr.cpp:3449
+#: src/amuleDlg.cpp:361 src/amuleDlg.cpp:1810 src/amuleDlg.cpp:2056
+#: src/muuli_wdr.cpp:1492 src/muuli_wdr.cpp:3453
 msgid "Networks"
 msgstr "ネットワーク"
 
-#: src/amuleDlg.cpp:362 src/amuleDlg.cpp:1793 src/muuli_wdr.cpp:3450
+#: src/amuleDlg.cpp:362 src/amuleDlg.cpp:1816 src/muuli_wdr.cpp:3454
 msgid "Searches"
 msgstr "検索"
 
-#: src/amuleDlg.cpp:363 src/amuleDlg.cpp:1799 src/DownloadListCtrl.cpp:740
-#: src/muuli_wdr.cpp:392 src/muuli_wdr.cpp:1585 src/muuli_wdr.cpp:3451
+#: src/amuleDlg.cpp:363 src/amuleDlg.cpp:1822 src/DownloadListCtrl.cpp:740
+#: src/muuli_wdr.cpp:392 src/muuli_wdr.cpp:1585 src/muuli_wdr.cpp:3455
 #: src/Statistics.cpp:829
 msgid "Downloads"
 msgstr "ダウンロード数"
 
-#: src/amuleDlg.cpp:364 src/amuleDlg.cpp:1805 src/muuli_wdr.cpp:3325
+#: src/amuleDlg.cpp:364 src/amuleDlg.cpp:1828 src/muuli_wdr.cpp:3329
 msgid "Shared files"
 msgstr ""
 
-#: src/amuleDlg.cpp:365 src/amuleDlg.cpp:1811 src/muuli_wdr.cpp:2957
-#: src/muuli_wdr.cpp:3407 src/muuli_wdr.cpp:3454
+#: src/amuleDlg.cpp:365 src/amuleDlg.cpp:1834 src/muuli_wdr.cpp:2961
+#: src/muuli_wdr.cpp:3411 src/muuli_wdr.cpp:3458
 msgid "Messages"
 msgstr "メッセージ"
 
-#: src/amuleDlg.cpp:366 src/amuleDlg.cpp:1817 src/muuli_wdr.cpp:3455
+#: src/amuleDlg.cpp:366 src/amuleDlg.cpp:1840 src/muuli_wdr.cpp:3459
 #: src/PrefsUnifiedDlg.cpp:314 src/Statistics.cpp:779 src/Statistics.cpp:1235
 msgid "Statistics"
 msgstr "統計"
 
-#: src/amuleDlg.cpp:368 src/amuleDlg.cpp:1824 src/muuli_wdr.cpp:3457
+#: src/amuleDlg.cpp:368 src/amuleDlg.cpp:1847 src/muuli_wdr.cpp:3461
 #: src/PrefsUnifiedDlg.cpp:330 src/utils/wxCas/src/wxcasprefs.cpp:39
 msgid "Preferences"
 msgstr "設定"
@@ -680,8 +680,8 @@ msgstr "Kad: オフ"
 #: src/amuleDlg.cpp:1029 src/DownloadListCtrl.cpp:505
 #: src/DownloadListCtrl.cpp:749 src/FriendListCtrl.cpp:180
 #: src/muuli_wdr.cpp:731 src/muuli_wdr.cpp:782 src/muuli_wdr.cpp:846
-#: src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2262 src/muuli_wdr.cpp:2347
-#: src/muuli_wdr.cpp:3095 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
+#: src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2266 src/muuli_wdr.cpp:2351
+#: src/muuli_wdr.cpp:3099 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
 #: src/ServerListCtrl.cpp:606 src/TransferWnd.cpp:378
 #: src/utils/wxCas/src/wxcasprefs.cpp:235
 msgid "Cancel"
@@ -692,7 +692,7 @@ msgid "Stop the current connection attempts"
 msgstr "現在の接続試行を中止する"
 
 #: src/amuleDlg.cpp:1035 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976
-#: src/muuli_wdr.cpp:2485
+#: src/muuli_wdr.cpp:2489
 msgid "Disconnect"
 msgstr "切断する"
 
@@ -701,7 +701,7 @@ msgid "Disconnect from the currently connected networks"
 msgstr "ネットワークから切断します。"
 
 #: src/amuleDlg.cpp:1041 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979
-#: src/muuli_wdr.cpp:2640 src/muuli_wdr.cpp:3092 src/muuli_wdr.cpp:3447
+#: src/muuli_wdr.cpp:2644 src/muuli_wdr.cpp:3096 src/muuli_wdr.cpp:3451
 msgid "Connect"
 msgstr "接続する"
 
@@ -757,7 +757,7 @@ msgstr "終了の確認"
 msgid "Launch Command: "
 msgstr "コマンド： %s"
 
-#: src/amuleDlg.cpp:1632 src/muuli_wdr.cpp:1982 src/Preferences.cpp:979
+#: src/amuleDlg.cpp:1632 src/muuli_wdr.cpp:1986 src/Preferences.cpp:979
 msgid "- default -"
 msgstr ""
 
@@ -771,61 +771,61 @@ msgstr "スキンディレクトリ '%s' は存在しません"
 msgid "WARNING: Unable to open skin file '%s' for read"
 msgstr ""
 
-#: src/amuleDlg.cpp:1791 src/muuli_wdr.cpp:3449
+#: src/amuleDlg.cpp:1814 src/muuli_wdr.cpp:3453
 msgid "Networks Window"
 msgstr "ネットワークウィンドウ"
 
-#: src/amuleDlg.cpp:1797 src/muuli_wdr.cpp:3450
+#: src/amuleDlg.cpp:1820 src/muuli_wdr.cpp:3454
 msgid "Searches Window"
 msgstr "検索ウィンドウ"
 
-#: src/amuleDlg.cpp:1803 src/muuli_wdr.cpp:3451
+#: src/amuleDlg.cpp:1826 src/muuli_wdr.cpp:3455
 #, fuzzy
 msgid "Downloads Window"
 msgstr "ダウンロード"
 
-#: src/amuleDlg.cpp:1809 src/muuli_wdr.cpp:3453
+#: src/amuleDlg.cpp:1832 src/muuli_wdr.cpp:3457
 msgid "Shared Files Window"
 msgstr "共有ファイルウィンドウ"
 
-#: src/amuleDlg.cpp:1815 src/muuli_wdr.cpp:3454
+#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3458
 msgid "Messages Window"
 msgstr "メッセージウィンドウ"
 
-#: src/amuleDlg.cpp:1821 src/muuli_wdr.cpp:3455
+#: src/amuleDlg.cpp:1844 src/muuli_wdr.cpp:3459
 msgid "Statistics Graph Window"
 msgstr "統計グラフウィインドウ"
 
-#: src/amuleDlg.cpp:1828 src/muuli_wdr.cpp:3457
+#: src/amuleDlg.cpp:1851 src/muuli_wdr.cpp:3461
 msgid "Preferences Settings Window"
 msgstr "個人設定ウィンドウ"
 
-#: src/amuleDlg.cpp:1831 src/muuli_wdr.cpp:3458
+#: src/amuleDlg.cpp:1854 src/muuli_wdr.cpp:3462
 msgid "Import"
 msgstr "インポート"
 
-#: src/amuleDlg.cpp:1835 src/muuli_wdr.cpp:3458
+#: src/amuleDlg.cpp:1858 src/muuli_wdr.cpp:3462
 msgid "The partfile importer tool"
 msgstr "部分ファイルをインポートするためのツール"
 
-#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3459
+#: src/amuleDlg.cpp:1861 src/muuli_wdr.cpp:3463
 #: src/utils/aLinkCreator/src/alcframe.cpp:262
 msgid "About"
 msgstr "情報"
 
-#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3459
+#: src/amuleDlg.cpp:1861 src/muuli_wdr.cpp:3463
 msgid "About/Help"
 msgstr "ソフトウェア情報／ヘルプ"
 
-#: src/amuleDlg.cpp:2036
+#: src/amuleDlg.cpp:2059
 msgid "eD2k network"
 msgstr ""
 
-#: src/amuleDlg.cpp:2039
+#: src/amuleDlg.cpp:2062
 msgid "Kad network"
 msgstr "Kadネットワーク"
 
-#: src/amuleDlg.cpp:2039
+#: src/amuleDlg.cpp:2062
 msgid "No network"
 msgstr "ネットワークなし"
 
@@ -1357,19 +1357,19 @@ msgstr "オート [Hi]"
 msgid "Very low"
 msgstr "非常に低い"
 
-#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:743 src/muuli_wdr.cpp:2313
+#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:743 src/muuli_wdr.cpp:2317
 #: src/ServerListCtrl.cpp:263 src/ServerListCtrl.cpp:456
 #: src/SharedFilesCtrl.cpp:145
 msgid "Low"
 msgstr "低い"
 
-#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:744 src/muuli_wdr.cpp:2314
+#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:744 src/muuli_wdr.cpp:2318
 #: src/ServerListCtrl.cpp:266 src/ServerListCtrl.cpp:457
 #: src/SharedFilesCtrl.cpp:146
 msgid "Normal"
 msgstr "普通"
 
-#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:745 src/muuli_wdr.cpp:2315
+#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:745 src/muuli_wdr.cpp:2319
 #: src/ServerListCtrl.cpp:269 src/ServerListCtrl.cpp:458
 #: src/SharedFilesCtrl.cpp:147
 msgid "High"
@@ -1461,7 +1461,7 @@ msgstr "ローカルサーバ"
 msgid "Remote Server"
 msgstr "リモートサーバ"
 
-#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3212
+#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3216
 #: src/SearchDlg.cpp:119 src/TextClient.cpp:911
 msgid "Kad"
 msgstr "Kad"
@@ -1533,7 +1533,7 @@ msgstr ""
 msgid "Size"
 msgstr "サイズ"
 
-#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3279
+#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3283
 msgid "Transferred"
 msgstr "転送済み"
 
@@ -1591,7 +1591,7 @@ msgstr ""
 "フィードバック:%s (%s)\n"
 "\n"
 
-#: src/DownloadListCtrl.cpp:746 src/muuli_wdr.cpp:2316
+#: src/DownloadListCtrl.cpp:746 src/muuli_wdr.cpp:2320
 #: src/SharedFilesCtrl.cpp:150
 msgid "Auto"
 msgstr "自動"
@@ -1629,7 +1629,7 @@ msgid "Extended Options"
 msgstr "拡張オプション"
 
 #: src/DownloadListCtrl.cpp:770 src/DownloadListCtrl.cpp:822
-#: src/muuli_wdr.cpp:1800
+#: src/muuli_wdr.cpp:1804
 msgid "Preview"
 msgstr "プレビュー"
 
@@ -2431,23 +2431,23 @@ msgid ""
 "want downloads on a different (e.g. larger) disk."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:549 src/FirstRunWizard.cpp:611 src/muuli_wdr.cpp:1712
+#: src/FirstRunWizard.cpp:549 src/FirstRunWizard.cpp:611 src/muuli_wdr.cpp:1716
 msgid "Destination folder for downloads"
 msgstr ""
 
 #: src/FirstRunWizard.cpp:553 src/FirstRunWizard.cpp:569 src/muuli_wdr.cpp:1349
-#: src/muuli_wdr.cpp:1366 src/muuli_wdr.cpp:1687 src/muuli_wdr.cpp:1718
-#: src/muuli_wdr.cpp:1730 src/muuli_wdr.cpp:2800
+#: src/muuli_wdr.cpp:1366 src/muuli_wdr.cpp:1691 src/muuli_wdr.cpp:1722
+#: src/muuli_wdr.cpp:1734 src/muuli_wdr.cpp:2804
 #: src/utils/aLinkCreator/src/alcframe.cpp:135
 #: src/utils/wxCas/src/wxcasprefs.cpp:52 src/utils/wxCas/src/wxcasprefs.cpp:118
 msgid "Browse"
 msgstr "閲覧"
 
-#: src/FirstRunWizard.cpp:559 src/muuli_wdr.cpp:1723
+#: src/FirstRunWizard.cpp:559 src/muuli_wdr.cpp:1727
 msgid "(All files in this folder are shared with other peers)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:565 src/FirstRunWizard.cpp:624 src/muuli_wdr.cpp:1725
+#: src/FirstRunWizard.cpp:565 src/FirstRunWizard.cpp:624 src/muuli_wdr.cpp:1729
 msgid "Folder for temporary download files"
 msgstr ""
 
@@ -2478,7 +2478,7 @@ msgstr ""
 msgid "CRITICAL - no client on StartChatSession"
 msgstr ""
 
-#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2706 src/muuli_wdr.cpp:3383
+#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2710 src/muuli_wdr.cpp:3387
 msgid "Friends"
 msgstr "友達"
 
@@ -2588,8 +2588,8 @@ msgstr "誰も許可しない"
 msgid "No"
 msgstr "いいえ"
 
-#: src/GenericClientListCtrl.cpp:1216 src/PrefsUnifiedDlg.cpp:2898
-#: src/PrefsUnifiedDlg.cpp:2948 src/ServerListCtrl.cpp:276
+#: src/GenericClientListCtrl.cpp:1216 src/PrefsUnifiedDlg.cpp:2907
+#: src/PrefsUnifiedDlg.cpp:2957 src/ServerListCtrl.cpp:276
 msgid "Yes"
 msgstr "はい"
 
@@ -2757,10 +2757,10 @@ msgstr "ブートストラップするためには正しくないポートです
 msgid "Please fill all fields required"
 msgstr "必要なフィールドをすべて入力してください"
 
-#: src/KadDlg.cpp:192 src/PartFile.cpp:1031 src/PrefsUnifiedDlg.cpp:1134
-#: src/PrefsUnifiedDlg.cpp:1204 src/PrefsUnifiedDlg.cpp:1405
-#: src/PrefsUnifiedDlg.cpp:1663 src/PrefsUnifiedDlg.cpp:1673
-#: src/PrefsUnifiedDlg.cpp:1690 src/PrefsUnifiedDlg.cpp:1738
+#: src/KadDlg.cpp:192 src/PartFile.cpp:1031 src/PrefsUnifiedDlg.cpp:1143
+#: src/PrefsUnifiedDlg.cpp:1213 src/PrefsUnifiedDlg.cpp:1414
+#: src/PrefsUnifiedDlg.cpp:1672 src/PrefsUnifiedDlg.cpp:1682
+#: src/PrefsUnifiedDlg.cpp:1699 src/PrefsUnifiedDlg.cpp:1747
 msgid "Message"
 msgstr "メッセージ"
 
@@ -2859,7 +2859,7 @@ msgstr "共有比"
 msgid "Uploaded"
 msgstr "アップロード済み"
 
-#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3263
+#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3267
 msgid "Requested"
 msgstr "要求済み"
 
@@ -2985,7 +2985,7 @@ msgid "WARNING: "
 msgstr ""
 
 #: src/MuleNotebook.cpp:179 src/muuli_wdr.cpp:817 src/muuli_wdr.cpp:1229
-#: src/muuli_wdr.cpp:3167 src/muuli_wdr.cpp:3423
+#: src/muuli_wdr.cpp:3171 src/muuli_wdr.cpp:3427
 msgid "Close"
 msgstr "閉じる"
 
@@ -3003,7 +3003,7 @@ msgid "Paste"
 msgstr "ペースト"
 
 #: src/MuleTextCtrl.cpp:89 src/muuli_wdr.cpp:358 src/muuli_wdr.cpp:757
-#: src/muuli_wdr.cpp:2390 src/muuli_wdr.cpp:2409 src/muuli_wdr.cpp:2431
+#: src/muuli_wdr.cpp:2394 src/muuli_wdr.cpp:2413 src/muuli_wdr.cpp:2435
 #: src/utils/aLinkCreator/src/alcframe.cpp:142
 msgid "Clear"
 msgstr "クリア"
@@ -3101,7 +3101,7 @@ msgstr "終了"
 
 #: src/MuleTrayIcon.cpp:579 src/MuleTrayIcon.cpp:945 src/MuleTrayIcon.cpp:965
 #: src/muuli_wdr.cpp:1398 src/muuli_wdr.cpp:1406 src/muuli_wdr.cpp:1413
-#: src/muuli_wdr.cpp:1846 src/muuli_wdr.cpp:1852 src/OtherFunctions.cpp:91
+#: src/muuli_wdr.cpp:1850 src/muuli_wdr.cpp:1856 src/OtherFunctions.cpp:91
 #: src/StatisticsDlg.cpp:93 src/StatisticsDlg.cpp:95
 msgid "kB/s"
 msgstr "kB/s"
@@ -3343,7 +3343,7 @@ msgstr "B"
 msgid "KB"
 msgstr "KB"
 
-#: src/muuli_wdr.cpp:274 src/muuli_wdr.cpp:293 src/muuli_wdr.cpp:1631
+#: src/muuli_wdr.cpp:274 src/muuli_wdr.cpp:293 src/muuli_wdr.cpp:1635
 #: src/OtherFunctions.cpp:64
 msgid "MB"
 msgstr "MB"
@@ -3360,7 +3360,7 @@ msgstr "最大サイズ"
 msgid "Availability"
 msgstr "入手可能範囲"
 
-#: src/muuli_wdr.cpp:312 src/muuli_wdr.cpp:398 src/muuli_wdr.cpp:3328
+#: src/muuli_wdr.cpp:312 src/muuli_wdr.cpp:398 src/muuli_wdr.cpp:3332
 msgid "Filter:"
 msgstr "フィルタ："
 
@@ -3424,8 +3424,8 @@ msgstr "ソース完了"
 #: src/muuli_wdr.cpp:1160 src/muuli_wdr.cpp:1167 src/muuli_wdr.cpp:1172
 #: src/muuli_wdr.cpp:1179 src/muuli_wdr.cpp:1184 src/muuli_wdr.cpp:1191
 #: src/muuli_wdr.cpp:1205 src/muuli_wdr.cpp:1212 src/muuli_wdr.cpp:1217
-#: src/muuli_wdr.cpp:1224 src/muuli_wdr.cpp:3265 src/muuli_wdr.cpp:3273
-#: src/muuli_wdr.cpp:3281
+#: src/muuli_wdr.cpp:1224 src/muuli_wdr.cpp:3269 src/muuli_wdr.cpp:3277
+#: src/muuli_wdr.cpp:3285
 msgid "N/A"
 msgstr "非適用"
 
@@ -3570,7 +3570,7 @@ msgstr ""
 msgid "Album :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:685 src/muuli_wdr.cpp:2285
+#: src/muuli_wdr.cpp:685 src/muuli_wdr.cpp:2289
 msgid "Title :"
 msgstr "タイトル："
 
@@ -3677,7 +3677,7 @@ msgstr "ユーザ名："
 msgid "Userhash :"
 msgstr "ユーザ・ハッシュ："
 
-#: src/muuli_wdr.cpp:895 src/muuli_wdr.cpp:1752 src/muuli_wdr.cpp:2480
+#: src/muuli_wdr.cpp:895 src/muuli_wdr.cpp:1756 src/muuli_wdr.cpp:2484
 #: src/utils/aLinkCreator/src/alcframe.cpp:137
 msgid "Add"
 msgstr "追加"
@@ -3686,15 +3686,15 @@ msgstr "追加"
 msgid "Download-Speed"
 msgstr "ダウンロード速度："
 
-#: src/muuli_wdr.cpp:954 src/muuli_wdr.cpp:989 src/muuli_wdr.cpp:2584
+#: src/muuli_wdr.cpp:954 src/muuli_wdr.cpp:989 src/muuli_wdr.cpp:2588
 msgid "Current"
 msgstr "現在"
 
-#: src/muuli_wdr.cpp:962 src/muuli_wdr.cpp:997 src/muuli_wdr.cpp:2592
+#: src/muuli_wdr.cpp:962 src/muuli_wdr.cpp:997 src/muuli_wdr.cpp:2596
 msgid "Running average"
 msgstr "移動平均"
 
-#: src/muuli_wdr.cpp:970 src/muuli_wdr.cpp:1005 src/muuli_wdr.cpp:2600
+#: src/muuli_wdr.cpp:970 src/muuli_wdr.cpp:1005 src/muuli_wdr.cpp:2604
 msgid "Session average"
 msgstr "セッション平均"
 
@@ -3706,7 +3706,7 @@ msgstr "アップロード速度"
 msgid "Connections"
 msgstr "接続数"
 
-#: src/muuli_wdr.cpp:1024 src/muuli_wdr.cpp:1871
+#: src/muuli_wdr.cpp:1024 src/muuli_wdr.cpp:1875
 msgid "Active downloads"
 msgstr "アクティブなダウンロード数"
 
@@ -3714,7 +3714,7 @@ msgstr "アクティブなダウンロード数"
 msgid "Active connections (1:1)"
 msgstr "アクティブな接続（1:1）"
 
-#: src/muuli_wdr.cpp:1040 src/muuli_wdr.cpp:1872
+#: src/muuli_wdr.cpp:1040 src/muuli_wdr.cpp:1876
 msgid "Active uploads"
 msgstr "アクティブなアップロード数"
 
@@ -3991,7 +3991,7 @@ msgstr ""
 msgid "Advanced users only: If you have multiple network interfaces, enter the address of the interface to which aMule should be bound."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1462 src/muuli_wdr.cpp:2065
+#: src/muuli_wdr.cpp:1462 src/muuli_wdr.cpp:2069
 msgid "Bind to network interface (empty for any):"
 msgstr ""
 
@@ -4007,7 +4007,7 @@ msgstr ""
 msgid "Max simultaneous connections:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1498 src/muuli_wdr.cpp:3207
+#: src/muuli_wdr.cpp:1498 src/muuli_wdr.cpp:3211
 msgid "ED2K"
 msgstr "ED2K"
 
@@ -4099,780 +4099,780 @@ msgstr "新しいファイルのためのディスク領域を事前に確保す
 msgid "For new files preallocates disk space for the whole file, thus reduces fragmentation"
 msgstr "新しいファイルのためにファイル全体が格納できるディスク領域を事前に確保し、断片化を防ぎます。"
 
-#: src/muuli_wdr.cpp:1617
+#: src/muuli_wdr.cpp:1621
 msgid "Create new files as sparse files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1618
+#: src/muuli_wdr.cpp:1622
 msgid "Sparse part files only occupy disk space for the parts already downloaded, so free space is used up gradually as the file fills in. Turn this off to use an ordinary file instead - useful where sparse files are unsupported or slow, or where backup/de-duplication tools handle them badly. Applies only when the core runs on Windows; on Linux and macOS part files are sparse anyway and this setting has no effect."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1623
+#: src/muuli_wdr.cpp:1627
 msgid "Stop downloads when free disk space reaches "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1624
+#: src/muuli_wdr.cpp:1628
 msgid "Select this if you want aMule to check your disk space"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1628
+#: src/muuli_wdr.cpp:1632
 msgid "Enter here the min disk space desired."
 msgstr "望ましい最小のディスク領域をここに入力してください。"
 
-#: src/muuli_wdr.cpp:1634
+#: src/muuli_wdr.cpp:1638
 msgid "Save 10 sources on rare files (< 20 sources)"
 msgstr "珍しいファイルには10ソースを保存する（<20ソース）"
 
-#: src/muuli_wdr.cpp:1638 src/Statistics.cpp:790
+#: src/muuli_wdr.cpp:1642 src/Statistics.cpp:790
 msgid "Uploads"
 msgstr "アップロード数"
 
-#: src/muuli_wdr.cpp:1641
+#: src/muuli_wdr.cpp:1645
 msgid "Add new shared files with auto priority"
 msgstr "新しい共有ファイルを自動優先度として追加する"
 
-#: src/muuli_wdr.cpp:1647
+#: src/muuli_wdr.cpp:1651
 msgid "Intelligent Corruption Handling (I.C.H.)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1650
+#: src/muuli_wdr.cpp:1654
 msgid "Enable"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1653
+#: src/muuli_wdr.cpp:1657
 msgid "Advanced I.C.H. trusts every hash (not recommended)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1665 src/PrefsUnifiedDlg.cpp:1990
+#: src/muuli_wdr.cpp:1669 src/PrefsUnifiedDlg.cpp:1999
 msgid "Media metadata extraction"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1669
+#: src/muuli_wdr.cpp:1673
 msgid "Extract length / bitrate / codec from shared audio and video files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1671
+#: src/muuli_wdr.cpp:1675
 msgid "When enabled, aMule runs ffprobe on each shared media file to fill in the Length / Bitrate / Codec columns other clients see when they find the file in a search. Requires ffmpeg (the ffprobe binary) to be installed."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1678
+#: src/muuli_wdr.cpp:1682
 msgid "Path to ffprobe:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1683
+#: src/muuli_wdr.cpp:1687
 msgid "Full path to the ffprobe binary. Leave empty to have aMule auto-detect it on startup."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1691
+#: src/muuli_wdr.cpp:1695
 msgid "Detect"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1692
+#: src/muuli_wdr.cpp:1696
 msgid "Search the standard install locations for an ffprobe binary and fill the path field."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1716
+#: src/muuli_wdr.cpp:1720
 msgid ""
 "Completed downloads are stored here. All files in this folder are automatically shared with other peers.\n"
 "If this folder also holds files you don't want to share, point it at an aMule-only sub-folder."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1719
+#: src/muuli_wdr.cpp:1723
 msgid "Pick the folder where completed downloads will be stored. All files in that folder will be shared with other peers."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1733
+#: src/muuli_wdr.cpp:1737
 msgid "Shared folders"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1739
+#: src/muuli_wdr.cpp:1743
 msgid "(Folders shared by the core. Enter a path to add one.)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1747
+#: src/muuli_wdr.cpp:1751
 msgid "Absolute path of a folder on the core's machine, e.g. /home/user/shared"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1749 src/PrefsUnifiedDlg.cpp:2874
+#: src/muuli_wdr.cpp:1753 src/PrefsUnifiedDlg.cpp:2883
 msgid "Recursive"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1750
+#: src/muuli_wdr.cpp:1754
 msgid "Share every sub-folder underneath this one, including ones created later."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1754 src/utils/aLinkCreator/src/alcframe.cpp:141
+#: src/muuli_wdr.cpp:1758 src/utils/aLinkCreator/src/alcframe.cpp:141
 msgid "Remove"
 msgstr "削除"
 
-#: src/muuli_wdr.cpp:1758
+#: src/muuli_wdr.cpp:1762
 msgid "(Right click on folder icon for recursive share)"
 msgstr "（再帰的に共有するにはフォルダ・アイコンを右クリックしてください）"
 
-#: src/muuli_wdr.cpp:1765
+#: src/muuli_wdr.cpp:1769
 msgid "Share hidden files"
 msgstr "隠れたファイルを共有する"
 
-#: src/muuli_wdr.cpp:1771
+#: src/muuli_wdr.cpp:1775
 msgid "Automatically rescan shared folders for changes"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1777
+#: src/muuli_wdr.cpp:1781
 msgid "Follow symbolic links in shared folders"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1783
+#: src/muuli_wdr.cpp:1787
 msgid "Exclude files matching:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1786
+#: src/muuli_wdr.cpp:1790
 msgid "Wildcard patterns separated by '|', e.g. .DS_Store|Thumbs.db|*.tmp. Files whose name matches are not shared. Matching is case-insensitive."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1790
+#: src/muuli_wdr.cpp:1794
 msgid "Patterns are regular expressions"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1791
+#: src/muuli_wdr.cpp:1795
 msgid "When set, the whole field is one regular expression ('|' is alternation). When unset, it is a list of '|'-separated wildcards."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1801
+#: src/muuli_wdr.cpp:1805
 msgid "Show how many shared files the current pattern would exclude."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1822
+#: src/muuli_wdr.cpp:1826
 msgid "Graphs"
 msgstr "グラフ"
 
-#: src/muuli_wdr.cpp:1825 src/muuli_wdr.cpp:1887
+#: src/muuli_wdr.cpp:1829 src/muuli_wdr.cpp:1891
 msgid "Update delay : 5 secs"
 msgstr "アップデート延期：５秒"
 
-#: src/muuli_wdr.cpp:1829
+#: src/muuli_wdr.cpp:1833
 msgid "Time for average graph: 100 mins"
 msgstr "平均グラフの時間：１００分"
 
-#: src/muuli_wdr.cpp:1833
+#: src/muuli_wdr.cpp:1837
 msgid "Connections Graph Scale: 100 "
 msgstr "接続数のグラフスケール：１００"
 
-#: src/muuli_wdr.cpp:1840
+#: src/muuli_wdr.cpp:1844
 msgid "Download graph scale:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1848
+#: src/muuli_wdr.cpp:1852
 msgid "Upload graph scale:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1858
+#: src/muuli_wdr.cpp:1862
 msgid "Colors: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1862
+#: src/muuli_wdr.cpp:1866
 msgid "Background"
 msgstr "背景"
 
-#: src/muuli_wdr.cpp:1863
+#: src/muuli_wdr.cpp:1867
 msgid "Grid"
 msgstr "グリッド"
 
-#: src/muuli_wdr.cpp:1864
+#: src/muuli_wdr.cpp:1868
 msgid "Download current"
 msgstr "ダウンロード現在"
 
-#: src/muuli_wdr.cpp:1865
+#: src/muuli_wdr.cpp:1869
 msgid "Download running average"
 msgstr "ダウンロード移動平均"
 
-#: src/muuli_wdr.cpp:1866
+#: src/muuli_wdr.cpp:1870
 msgid "Download session average"
 msgstr "ダウンロードセッション平均"
 
-#: src/muuli_wdr.cpp:1867
+#: src/muuli_wdr.cpp:1871
 msgid "Upload current"
 msgstr "アップロード現在"
 
-#: src/muuli_wdr.cpp:1868
+#: src/muuli_wdr.cpp:1872
 msgid "Upload running average"
 msgstr "アップロード移動平均"
 
-#: src/muuli_wdr.cpp:1869
+#: src/muuli_wdr.cpp:1873
 msgid "Upload session average"
 msgstr "アップロードセッション平均"
 
-#: src/muuli_wdr.cpp:1870
+#: src/muuli_wdr.cpp:1874
 msgid "Active connections"
 msgstr "アクティブ接続数"
 
-#: src/muuli_wdr.cpp:1873
+#: src/muuli_wdr.cpp:1877
 #, fuzzy
 msgid "Systray Icon Speed Bar"
 msgstr "システム・トレイ・アイコン・スピードバー"
 
-#: src/muuli_wdr.cpp:1874
+#: src/muuli_wdr.cpp:1878
 msgid "Kad-nodes current"
 msgstr "現在のKadノード数"
 
-#: src/muuli_wdr.cpp:1875
+#: src/muuli_wdr.cpp:1879
 msgid "Kad-nodes running"
 msgstr "動作中のKadノード数"
 
-#: src/muuli_wdr.cpp:1876
+#: src/muuli_wdr.cpp:1880
 msgid "Kad-nodes session"
 msgstr "セッションのKadノード数"
 
-#: src/muuli_wdr.cpp:1880 src/muuli_wdr.cpp:2334
+#: src/muuli_wdr.cpp:1884 src/muuli_wdr.cpp:2338
 msgid "Select"
 msgstr "選択"
 
-#: src/muuli_wdr.cpp:1884
+#: src/muuli_wdr.cpp:1888
 msgid "Tree"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1894
+#: src/muuli_wdr.cpp:1898
 msgid "Number of Client Versions shown (0=unlimited)"
 msgstr "表示されているクライアントのバージョン数（0＝無制限）"
 
-#: src/muuli_wdr.cpp:1919
+#: src/muuli_wdr.cpp:1923
 msgid "!!! WARNING !!!"
 msgstr "！！！注意！！！"
 
-#: src/muuli_wdr.cpp:1934
+#: src/muuli_wdr.cpp:1938
 msgid "Max new connections / 5 secs"
 msgstr "最大の新しい接続数（5秒ごと）"
 
-#: src/muuli_wdr.cpp:1936
+#: src/muuli_wdr.cpp:1940
 msgid "Concurrent Kad source lookups"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1938
+#: src/muuli_wdr.cpp:1942
 #, fuzzy
 msgid "Kad source re-search interval (minutes)"
 msgstr "FTPアップデートレート間隔（分）"
 
-#: src/muuli_wdr.cpp:1940
+#: src/muuli_wdr.cpp:1944
 #, fuzzy
 msgid "Source re-ask interval (minutes)"
 msgstr "FTPアップデートレート間隔（分）"
 
-#: src/muuli_wdr.cpp:1944
+#: src/muuli_wdr.cpp:1948
 msgid "File Buffer Size: 240000 bytes"
 msgstr "ファイル・バファー・サイズ：240000バイト"
 
-#: src/muuli_wdr.cpp:1948
+#: src/muuli_wdr.cpp:1952
 msgid "Use MMAP: memory-mapped file access (lower memory use)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1949
+#: src/muuli_wdr.cpp:1953
 msgid "Maps part files into memory instead of buffering them on the heap, lowering the process memory footprint. May reduce download speed on some disks; best for memory-constrained or upload-heavy hosts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1951
+#: src/muuli_wdr.cpp:1955
 msgid "Upload Queue Size: 5000 clients"
 msgstr "アップロードキューサイズ：5000クライアント"
 
-#: src/muuli_wdr.cpp:1955
+#: src/muuli_wdr.cpp:1959
 msgid "Server connection refresh interval: Disable"
 msgstr "サーバ接続のリフレッシュ空間：無効にする"
 
-#: src/muuli_wdr.cpp:1959
+#: src/muuli_wdr.cpp:1963
 msgid "Disable computer's timed standby mode"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1978
+#: src/muuli_wdr.cpp:1982
 msgid "Skin to use: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1987
+#: src/muuli_wdr.cpp:1991
 msgid "Show \"Fast eD2k Links Handler\" in every window."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1990
+#: src/muuli_wdr.cpp:1994
 msgid "Show extended info on categories tabs"
 msgstr "延長情報をカテゴリ・タブで表示する"
 
-#: src/muuli_wdr.cpp:1993
+#: src/muuli_wdr.cpp:1997
 #, fuzzy
 msgid "Show application version on title"
 msgstr "タイトルに転送速度を表示する"
 
-#: src/muuli_wdr.cpp:1995
+#: src/muuli_wdr.cpp:1999
 msgid "Show transfer rates on title"
 msgstr "タイトルに転送速度を表示する"
 
-#: src/muuli_wdr.cpp:1997
+#: src/muuli_wdr.cpp:2001
 msgid "Before application name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1999
+#: src/muuli_wdr.cpp:2003
 msgid "After application name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2002
+#: src/muuli_wdr.cpp:2006
 msgid "Show overhead bandwidth"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2006
+#: src/muuli_wdr.cpp:2010
 msgid "Vertical toolbar orientation"
 msgstr "垂直ツールバー"
 
-#: src/muuli_wdr.cpp:2008
+#: src/muuli_wdr.cpp:2012
 msgid "Live column sorting (auto-reorder rows as their values change)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2015
+#: src/muuli_wdr.cpp:2019
 msgid "Download Queue Files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2018
+#: src/muuli_wdr.cpp:2022
 msgid "Show progress percentage"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2024
+#: src/muuli_wdr.cpp:2028
 msgid "Show progress bar"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2027
+#: src/muuli_wdr.cpp:2031
 msgid "Flat"
 msgstr "フラット"
 
-#: src/muuli_wdr.cpp:2031
+#: src/muuli_wdr.cpp:2035
 msgid "Round"
 msgstr "ラウンド"
 
-#: src/muuli_wdr.cpp:2049
+#: src/muuli_wdr.cpp:2053
 msgid "External Connection Parameters"
 msgstr "外部接続のパラメタ"
 
-#: src/muuli_wdr.cpp:2052
+#: src/muuli_wdr.cpp:2056
 msgid "Accept external connections"
 msgstr "外部接続を許可にする"
 
-#: src/muuli_wdr.cpp:2059 src/muuli_wdr.cpp:2118
+#: src/muuli_wdr.cpp:2063 src/muuli_wdr.cpp:2122
 msgid "IP of the listening interface:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2062
+#: src/muuli_wdr.cpp:2066
 msgid "Enter here a valid ip in the a.b.c.d format for the listening EC interface. An empty field or 0.0.0.0 will mean any interface."
 msgstr "リスンしているECインターフェイス用の正当なIPアドレスをa.b.c.dのフォーマットで入力してください。空のフィールド、または0.0.0.0は任意のインターフェイスを意味します。"
 
-#: src/muuli_wdr.cpp:2083 src/muuli_wdr.cpp:2194
+#: src/muuli_wdr.cpp:2087 src/muuli_wdr.cpp:2198
 msgid "TCP port:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2089
+#: src/muuli_wdr.cpp:2093
 msgid "Enable UPnP port forwarding on the EC port"
 msgstr "ECポートでUPnPポート転送を有効にする"
 
-#: src/muuli_wdr.cpp:2093 src/muuli_wdr.cpp:3079
+#: src/muuli_wdr.cpp:2097 src/muuli_wdr.cpp:3083
 #: src/utils/wxCas/src/wxcasprefs.cpp:167
 msgid "Password"
 msgstr "パスワード"
 
-#: src/muuli_wdr.cpp:2099
+#: src/muuli_wdr.cpp:2103
 msgid "aMule API server parameters"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2102
+#: src/muuli_wdr.cpp:2106
 msgid "Run amuleapi (REST API) on startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2107
+#: src/muuli_wdr.cpp:2111
 #, fuzzy
 msgid "HTTP port:"
 msgstr "プロクシー・ポート："
 
-#: src/muuli_wdr.cpp:2121
+#: src/muuli_wdr.cpp:2125
 msgid "The interface amuleapi's HTTP server listens on. 127.0.0.1 (default) accepts only local connections; use 0.0.0.0 or a specific IP to expose it to other hosts (set an admin password below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2126
+#: src/muuli_wdr.cpp:2130
 msgid "Type a password to set or change it. Stored passwords cannot be shown, so leaving this empty keeps the current one."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2128
+#: src/muuli_wdr.cpp:2132
 #, fuzzy
 msgid "Admin password"
 msgstr "パスワードをチェック中です\n"
 
-#: src/muuli_wdr.cpp:2140 src/muuli_wdr.cpp:2157 src/PrefsUnifiedDlg.cpp:1103
+#: src/muuli_wdr.cpp:2144 src/muuli_wdr.cpp:2161 src/PrefsUnifiedDlg.cpp:1112
 #, fuzzy
 msgid "A password is set."
 msgstr "パスワードをチェック中です\n"
 
-#: src/muuli_wdr.cpp:2144
+#: src/muuli_wdr.cpp:2148
 #, fuzzy
 msgid "Enable guest access"
 msgstr "ゲストアクセスを拒否する"
 
-#: src/muuli_wdr.cpp:2145
+#: src/muuli_wdr.cpp:2149
 msgid "Guest sessions may read status and listings but cannot change anything. Turning this off clears the stored guest password."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2149
+#: src/muuli_wdr.cpp:2153
 #, fuzzy
 msgid "Guest password"
 msgstr "全権限パスワード"
 
-#: src/muuli_wdr.cpp:2164
+#: src/muuli_wdr.cpp:2168
 msgid "Web server parameters"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2167
+#: src/muuli_wdr.cpp:2171
 msgid "Run webserver on startup (deprecated)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2173
+#: src/muuli_wdr.cpp:2177
 msgid "Web template"
 msgstr "ウェブテンプレート"
 
-#: src/muuli_wdr.cpp:2178
+#: src/muuli_wdr.cpp:2182
 msgid "Full rights password"
 msgstr "全権限パスワード"
 
-#: src/muuli_wdr.cpp:2182
+#: src/muuli_wdr.cpp:2186
 msgid "Enable Low rights User"
 msgstr "低権限ユーザを有効にする"
 
-#: src/muuli_wdr.cpp:2187
+#: src/muuli_wdr.cpp:2191
 msgid "Low rights password"
 msgstr "低権限パスワード"
 
-#: src/muuli_wdr.cpp:2201
+#: src/muuli_wdr.cpp:2205
 msgid "Enable UPnP port forwarding of the web server port"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2206
+#: src/muuli_wdr.cpp:2210
 msgid "Web server UPnP TCP port (Optional)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2214
+#: src/muuli_wdr.cpp:2218
 msgid "Page Refresh Time (in secs)"
 msgstr "ページのリフレッシュ間隔（秒単位）"
 
-#: src/muuli_wdr.cpp:2221
+#: src/muuli_wdr.cpp:2225
 msgid "Enable Gzip compression"
 msgstr "gzip圧縮を有効にする"
 
-#: src/muuli_wdr.cpp:2255
+#: src/muuli_wdr.cpp:2259
 #, fuzzy
 msgid "Reset page to defaults"
 msgstr "システムの標準設定"
 
-#: src/muuli_wdr.cpp:2256
+#: src/muuli_wdr.cpp:2260
 msgid "Reset the settings on the current page to their default values."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2258 src/muuli_wdr.cpp:2344 src/ServerWnd.cpp:274
+#: src/muuli_wdr.cpp:2262 src/muuli_wdr.cpp:2348 src/ServerWnd.cpp:274
 #: src/ServerWnd.cpp:282
 msgid "OK"
 msgstr "OK"
 
-#: src/muuli_wdr.cpp:2260
+#: src/muuli_wdr.cpp:2264
 msgid "Click here to apply any changes made to the preferences."
 msgstr "設定の変更をすべて適用します。"
 
-#: src/muuli_wdr.cpp:2263
+#: src/muuli_wdr.cpp:2267
 msgid "Reset any changes made to the preferences."
 msgstr "設定の変更を全てリセットする"
 
-#: src/muuli_wdr.cpp:2292
+#: src/muuli_wdr.cpp:2296
 msgid "Comment :"
 msgstr "コメント："
 
-#: src/muuli_wdr.cpp:2299
+#: src/muuli_wdr.cpp:2303
 msgid "Incoming Dir :"
 msgstr "受信ディレクトリ："
 
-#: src/muuli_wdr.cpp:2308
+#: src/muuli_wdr.cpp:2312
 msgid "Change priority for new assigned files :"
 msgstr "新しく割り当てられたファイルの優先度を変更する："
 
-#: src/muuli_wdr.cpp:2312
+#: src/muuli_wdr.cpp:2316
 #, fuzzy
 msgid "Don't change"
 msgstr "変更しない"
 
-#: src/muuli_wdr.cpp:2324
+#: src/muuli_wdr.cpp:2328
 msgid "Select color for this Category (currently selected) :"
 msgstr "このカテゴリの色を選択する（現在選択中）："
 
-#: src/muuli_wdr.cpp:2391 src/muuli_wdr.cpp:2410 src/muuli_wdr.cpp:2432
+#: src/muuli_wdr.cpp:2395 src/muuli_wdr.cpp:2414 src/muuli_wdr.cpp:2436
 msgid "Click this button to reset the log."
 msgstr "このボタンをクリックするとログのリセットが行います。"
 
-#: src/muuli_wdr.cpp:2451
+#: src/muuli_wdr.cpp:2455
 msgid "Click on this button to update the servers list from URL ..."
 msgstr "このボタンをクリックするとサーバ・リストはURLから最新化する..."
 
-#: src/muuli_wdr.cpp:2455
+#: src/muuli_wdr.cpp:2459
 msgid "Server list"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2459
+#: src/muuli_wdr.cpp:2463
 msgid "Enter the url to a server.met file here and press the button to the left to update the list of known servers."
 msgstr "server.metファイルへのURLをここに入力してから左側のボタンをクリックすると、既知のサーバのリストがアップデートされます。"
 
-#: src/muuli_wdr.cpp:2464
+#: src/muuli_wdr.cpp:2468
 msgid "Add server manually: Name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2467
+#: src/muuli_wdr.cpp:2471
 msgid "Enter the name of the new server here"
 msgstr "新しいサーバの名前をここに入力してください"
 
-#: src/muuli_wdr.cpp:2469 src/ServerWnd.cpp:206
+#: src/muuli_wdr.cpp:2473 src/ServerWnd.cpp:206
 msgid "IP:Port"
 msgstr "IP:ポート"
 
-#: src/muuli_wdr.cpp:2472
+#: src/muuli_wdr.cpp:2476
 msgid "Enter the IP of the server here, using the x.x.x.x format."
 msgstr "x.x.x.xフォーマットでサーバのIPアドレスを入力してください。"
 
-#: src/muuli_wdr.cpp:2478
+#: src/muuli_wdr.cpp:2482
 msgid "Enter the port of the server here."
 msgstr "サーバのポートをここに入力してください。"
 
-#: src/muuli_wdr.cpp:2481
+#: src/muuli_wdr.cpp:2485
 msgid "Add manually a server (fill fields to the left before) ..."
 msgstr "手動でサーバを追加する（先に左側のフィールドを入力してください）..."
 
-#: src/muuli_wdr.cpp:2510
+#: src/muuli_wdr.cpp:2514
 msgid "aMule Log"
 msgstr "aMuleのログ"
 
-#: src/muuli_wdr.cpp:2518
+#: src/muuli_wdr.cpp:2522
 msgid "Server Info"
 msgstr "サーバ情報"
 
-#: src/muuli_wdr.cpp:2522
+#: src/muuli_wdr.cpp:2526
 msgid "ED2K Info"
 msgstr "ED2K情報"
 
-#: src/muuli_wdr.cpp:2526
+#: src/muuli_wdr.cpp:2530
 msgid "Kad Info"
 msgstr "Kad情報"
 
-#: src/muuli_wdr.cpp:2554
+#: src/muuli_wdr.cpp:2558
 msgid "Click on this button to update the nodes list from URL ..."
 msgstr "このボタンをクリックするとノード・リストをURLからアップデートします..."
 
-#: src/muuli_wdr.cpp:2558
+#: src/muuli_wdr.cpp:2562
 msgid "Nodes (0)"
 msgstr "ノード数（0）"
 
-#: src/muuli_wdr.cpp:2562
+#: src/muuli_wdr.cpp:2566
 msgid "Enter the url to a nodes.dat file here and press the button to the left to update the list of known nodes."
 msgstr "ここにnodes.datファイルへのURLを入力してから左側のボタンをクリックすると、既知のノード・リストをアップデートします。"
 
-#: src/muuli_wdr.cpp:2565
+#: src/muuli_wdr.cpp:2569
 msgid "Nodes stats"
 msgstr "ノードの統計"
 
-#: src/muuli_wdr.cpp:2607
+#: src/muuli_wdr.cpp:2611
 msgid "Bootstrap"
 msgstr "ブートストラップ"
 
-#: src/muuli_wdr.cpp:2610
+#: src/muuli_wdr.cpp:2614
 msgid "New node"
 msgstr "新しいノード"
 
-#: src/muuli_wdr.cpp:2615
+#: src/muuli_wdr.cpp:2619
 msgid "IP:"
 msgstr "IP："
 
-#: src/muuli_wdr.cpp:2635
+#: src/muuli_wdr.cpp:2639
 msgid "Port:"
 msgstr "ポート："
 
-#: src/muuli_wdr.cpp:2648
+#: src/muuli_wdr.cpp:2652
 #, fuzzy
 msgid "Bootstrap from known clients"
 msgstr ""
 "既知のクライアントから\n"
 "ブートストラップする"
 
-#: src/muuli_wdr.cpp:2650
+#: src/muuli_wdr.cpp:2654
 msgid "Disconnect Kad"
 msgstr "Kadを切断する"
 
-#: src/muuli_wdr.cpp:2684
+#: src/muuli_wdr.cpp:2688
 msgid "Use Secure User Identification"
 msgstr "セキュア・ユーザ保証（SUI）を使用する"
 
-#: src/muuli_wdr.cpp:2686
+#: src/muuli_wdr.cpp:2690
 msgid "It is recommended to enable this option. You will not receive credits if SUI is not enabled."
 msgstr "このオプションを有効にするのは推奨されます。SUIが有効でないとあなたはクレジットを得られません。"
 
-#: src/muuli_wdr.cpp:2688
+#: src/muuli_wdr.cpp:2692
 msgid "Protocol Obfuscation"
 msgstr "プロトコルを難読化する"
 
-#: src/muuli_wdr.cpp:2691
+#: src/muuli_wdr.cpp:2695
 msgid "Support Protocol Obfuscation"
 msgstr "プロトコルの難読化を有効にする"
 
-#: src/muuli_wdr.cpp:2693
+#: src/muuli_wdr.cpp:2697
 msgid "This option enabled Protocol Obfuscation, and makes aMule accept obfuscated connections from other clients."
 msgstr "このオプションによってプロトコルの難読化を有効にできます。そうすると、aMuleは他のクライアントからの難読化された接続を受け入れられます。"
 
-#: src/muuli_wdr.cpp:2695
+#: src/muuli_wdr.cpp:2699
 msgid "Use obfuscation for outgoing connections"
 msgstr "外方向の接続に難読化を使用する"
 
-#: src/muuli_wdr.cpp:2697
+#: src/muuli_wdr.cpp:2701
 msgid "This option makes aMule use Protocol Obfuscation when connecting other clients/servers."
 msgstr "このオプションによって、aMuleは他のサーバまたはクライアントに接続する時にプロトコル難読化を使用します。"
 
-#: src/muuli_wdr.cpp:2699
+#: src/muuli_wdr.cpp:2703
 msgid "Accept only obfuscated connections"
 msgstr "難読化された接続のみを受信する"
 
-#: src/muuli_wdr.cpp:2700
+#: src/muuli_wdr.cpp:2704
 msgid "This option makes aMule only accept obfuscated connections. You will have less sources, but all your traffic will be obfuscated"
 msgstr "このオプションによって、aMuleは難読化された接続のみを受信します。ソース数が減りますが、トラフィックが全て難読化されます。"
 
-#: src/muuli_wdr.cpp:2705
+#: src/muuli_wdr.cpp:2709
 msgid "Everybody"
 msgstr "全員"
 
-#: src/muuli_wdr.cpp:2707
+#: src/muuli_wdr.cpp:2711
 msgid "No one"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2709
+#: src/muuli_wdr.cpp:2713
 msgid "Who can see my shared files:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2710
+#: src/muuli_wdr.cpp:2714
 msgid "Select who can request to view a list of your shared files."
 msgstr "あなたの共有ファイル・リストを要求できるユーザを選択してください。"
 
-#: src/muuli_wdr.cpp:2712
+#: src/muuli_wdr.cpp:2716
 msgid "IP-Filtering"
 msgstr "IPフィルタリング"
 
-#: src/muuli_wdr.cpp:2719
+#: src/muuli_wdr.cpp:2723
 msgid "Filter clients"
 msgstr "クライアントをフィルタする"
 
-#: src/muuli_wdr.cpp:2721
+#: src/muuli_wdr.cpp:2725
 msgid "Enable filtering of the client IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "~/.aMule/ipfilter.datに登録されちるクライアントIPにフィルタリングをかけることを有効にします。"
 
-#: src/muuli_wdr.cpp:2723
+#: src/muuli_wdr.cpp:2727
 msgid "Filter servers"
 msgstr "サーバをフィルタする"
 
-#: src/muuli_wdr.cpp:2725
+#: src/muuli_wdr.cpp:2729
 msgid "Enable filtering of the server IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "~/.aMule/ipfilter.datに登録されちるサーバIPにフィルタリングをかけることを有効にします。"
 
-#: src/muuli_wdr.cpp:2729
+#: src/muuli_wdr.cpp:2733
 msgid "Reload List"
 msgstr "リストを再ロードする"
 
-#: src/muuli_wdr.cpp:2730
+#: src/muuli_wdr.cpp:2734
 msgid "Reload the list of IPs to filter from the file ~/.aMule/ipfilter.dat"
 msgstr "フィルタリングをかける目標のIPリストを~/.aMule/ipfilter.datから再ロードをします。"
 
-#: src/muuli_wdr.cpp:2736
+#: src/muuli_wdr.cpp:2740
 msgid "URL:"
 msgstr "URL："
 
-#: src/muuli_wdr.cpp:2740 src/muuli_wdr.cpp:2933
+#: src/muuli_wdr.cpp:2744 src/muuli_wdr.cpp:2937
 msgid "Update now"
 msgstr "只今アップデートする"
 
-#: src/muuli_wdr.cpp:2743
+#: src/muuli_wdr.cpp:2747
 msgid "Auto-update ipfilter at startup"
 msgstr "スタートアップの時にipfilterを自動アップデートする"
 
-#: src/muuli_wdr.cpp:2747
+#: src/muuli_wdr.cpp:2751
 msgid "Filtering Level:"
 msgstr "フィルタリング段階："
 
-#: src/muuli_wdr.cpp:2753
+#: src/muuli_wdr.cpp:2757
 msgid "Always filter LAN IPs"
 msgstr "いつもLANのIPにフィルタリングをかける"
 
-#: src/muuli_wdr.cpp:2756
+#: src/muuli_wdr.cpp:2760
 msgid "Paranoid handling of non-matching IPs"
 msgstr "適合しないIPを被害妄想的に扱う"
 
-#: src/muuli_wdr.cpp:2758
+#: src/muuli_wdr.cpp:2762
 msgid "Rejects a packet when its source IP differs from the IP the client claims (an anti-spoofing check). Disable only if it causes connection problems."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2760
+#: src/muuli_wdr.cpp:2764
 msgid "Use system-wide ipfilter.dat if available"
 msgstr "提供されていれば、全システム応用のipfilter.datファイルを使用する"
 
-#: src/muuli_wdr.cpp:2761
+#: src/muuli_wdr.cpp:2765
 #, fuzzy
 msgid "If there's no local ipfilter.dat found, allow usage of a system-wide ipfilter file."
 msgstr "ローカルなipfilter.datファイルが見つからなければ、全システム応用のipfilter.datファイルを使用可能します。"
 
-#: src/muuli_wdr.cpp:2778
+#: src/muuli_wdr.cpp:2782
 msgid "Enable Online-Signature"
 msgstr "オンライン証明を有効にする"
 
-#: src/muuli_wdr.cpp:2780
+#: src/muuli_wdr.cpp:2784
 msgid "Enables the writing of the OS file, which can be used by external apps to create signatures and the like."
 msgstr "OSファイルの書き込みを有効にします。このファイルは外のアプリケーションに証明等を作成するためにを使用されます。"
 
-#: src/muuli_wdr.cpp:2784
+#: src/muuli_wdr.cpp:2788
 msgid "Update Frequency (Secs):"
 msgstr "アップデート頻度（秒単位）"
 
-#: src/muuli_wdr.cpp:2787
+#: src/muuli_wdr.cpp:2791
 msgid "Change the frequency (in seconds) of Online Signature updates."
 msgstr "オンライン証明アップデート頻度（秒単位）を変化します。"
 
-#: src/muuli_wdr.cpp:2795
+#: src/muuli_wdr.cpp:2799
 msgid "Save online signature file in: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:2801
+#: src/muuli_wdr.cpp:2805
 msgid "Click here to select the directory containing the the Online Signature files."
 msgstr "ここをクリックするとオンライン証明ファイルが入っているディレクトリを選択できます。"
 
-#: src/muuli_wdr.cpp:2834
+#: src/muuli_wdr.cpp:2838
 msgid "Show country flags for clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2835
+#: src/muuli_wdr.cpp:2839
 msgid "Render the country flag column in the transfers, queue and search views. Requires a valid MMDB GeoIP database (see below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2840
+#: src/muuli_wdr.cpp:2844
 #, fuzzy
 msgid "Database"
 msgstr "データ・レート："
 
-#: src/muuli_wdr.cpp:2856
+#: src/muuli_wdr.cpp:2860
 #, fuzzy
 msgid "Source:"
 msgstr "ソース数"
 
-#: src/muuli_wdr.cpp:2859
+#: src/muuli_wdr.cpp:2863
 msgid "DB-IP (free, no account)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2860
+#: src/muuli_wdr.cpp:2864
 msgid "MaxMind GeoLite2 (free, account required)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2861
+#: src/muuli_wdr.cpp:2865
 msgid "Custom URL"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2864
+#: src/muuli_wdr.cpp:2868
 msgid "Choose which provider supplies the GeoIP MMDB database. DB-IP is the default - no account required. MaxMind requires a free account + license key. Use Custom URL to point at any other MMDB host (e.g. a local mirror)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2881
+#: src/muuli_wdr.cpp:2885
 msgid ""
 "No configuration required.\n"
 "\n"
@@ -4880,11 +4880,11 @@ msgid ""
 "License: Creative Commons BY 4.0 - https://creativecommons.org/licenses/by/4.0/"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2894
+#: src/muuli_wdr.cpp:2898
 msgid "License key:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2900
+#: src/muuli_wdr.cpp:2904
 msgid ""
 "Sign up for a free MaxMind account, then generate a License Key:\n"
 "https://www.maxmind.com/en/geolite2/signup\n"
@@ -4894,232 +4894,232 @@ msgid ""
 "Requires attribution and account registration; refresh at least every 30 days."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2915
+#: src/muuli_wdr.cpp:2919
 #, fuzzy
 msgid "Download URL:"
 msgstr "ダウンロード： "
 
-#: src/muuli_wdr.cpp:2921
+#: src/muuli_wdr.cpp:2925
 msgid ""
 "Must point to an .mmdb file or a .gz / .tar.gz containing one.\n"
 "URL may include credentials (https://user:pass@host/...).\n"
 "License and attribution terms are set by the upstream URL - you are responsible."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2934
+#: src/muuli_wdr.cpp:2938
 msgid "Download the GeoIP database from the selected source."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2936
+#: src/muuli_wdr.cpp:2940
 #, fuzzy
 msgid "Auto-update on startup"
 msgstr "スタートアップの時にipfilterを自動アップデートする"
 
-#: src/muuli_wdr.cpp:2937
+#: src/muuli_wdr.cpp:2941
 msgid "Re-download the GeoIP database from the selected source every time aMule starts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2960
+#: src/muuli_wdr.cpp:2964
 msgid "Filter incoming messages (except current chat):"
 msgstr "受信メッセージをフィルタする（現在のチャットを除く）："
 
-#: src/muuli_wdr.cpp:2962
+#: src/muuli_wdr.cpp:2966
 msgid "Filter all messages"
 msgstr "全てのメッセージをフィルタする"
 
-#: src/muuli_wdr.cpp:2964
+#: src/muuli_wdr.cpp:2968
 msgid "Filter messages from people not on your friend list"
 msgstr "友達リストの入っていない方々からのメッセージをフィルタする"
 
-#: src/muuli_wdr.cpp:2966
+#: src/muuli_wdr.cpp:2970
 msgid "Filter messages from unknown clients"
 msgstr "知らないクライアントからのメッセージをフィルタする"
 
-#: src/muuli_wdr.cpp:2968
+#: src/muuli_wdr.cpp:2972
 msgid "Filter messages containing (use ',' as separator):"
 msgstr "次のストリングが入っているメッセージをフィルタする（','で区分する）："
 
-#: src/muuli_wdr.cpp:2971 src/muuli_wdr.cpp:2982
+#: src/muuli_wdr.cpp:2975 src/muuli_wdr.cpp:2986
 msgid "add here the words amule should filter and block messages including it"
 msgstr "amuleがメッセージ・フィルタ／ブロックの目標にする言葉をここに追加してください"
 
-#: src/muuli_wdr.cpp:2973
+#: src/muuli_wdr.cpp:2977
 msgid "Show received messages in the log"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2976
+#: src/muuli_wdr.cpp:2980
 msgid "Comments"
 msgstr "コメント"
 
-#: src/muuli_wdr.cpp:2979
+#: src/muuli_wdr.cpp:2983
 msgid "Filter comments containing (use ',' as separator):"
 msgstr "次のストリングが入っていコメントをフィルタする（','で区分する）："
 
-#: src/muuli_wdr.cpp:3004
+#: src/muuli_wdr.cpp:3008
 msgid "Enable Proxy"
 msgstr "プロクシを有効にする"
 
-#: src/muuli_wdr.cpp:3005
+#: src/muuli_wdr.cpp:3009
 msgid "Enable/disable proxy support"
 msgstr "プロクシ・サポートを有効／無効にする"
 
-#: src/muuli_wdr.cpp:3008
+#: src/muuli_wdr.cpp:3012
 msgid "Proxy type:"
 msgstr "プロクシの種類："
 
-#: src/muuli_wdr.cpp:3019
+#: src/muuli_wdr.cpp:3023
 msgid "Proxy host:"
 msgstr "プロクシー・ホスト："
 
-#: src/muuli_wdr.cpp:3022
+#: src/muuli_wdr.cpp:3026
 msgid "The proxy host name"
 msgstr "プロクシー・ホスト名："
 
-#: src/muuli_wdr.cpp:3024
+#: src/muuli_wdr.cpp:3028
 msgid "Proxy port:"
 msgstr "プロクシー・ポート："
 
-#: src/muuli_wdr.cpp:3027
+#: src/muuli_wdr.cpp:3031
 msgid "The proxy port"
 msgstr "プロクシーのポート"
 
-#: src/muuli_wdr.cpp:3029
+#: src/muuli_wdr.cpp:3033
 msgid "Enable authentication"
 msgstr "認証を有効にする"
 
-#: src/muuli_wdr.cpp:3030
+#: src/muuli_wdr.cpp:3034
 msgid "Enable/disable username/password authentication"
 msgstr "ユーザ名／パスワード認証を有効／無効にする"
 
-#: src/muuli_wdr.cpp:3033
+#: src/muuli_wdr.cpp:3037
 msgid "Username: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:3036
+#: src/muuli_wdr.cpp:3040
 msgid "The username to use to connect to the proxy"
 msgstr "プロクシーに接続に使うユーザ名"
 
-#: src/muuli_wdr.cpp:3038
+#: src/muuli_wdr.cpp:3042
 msgid "Password:"
 msgstr "パスワード："
 
-#: src/muuli_wdr.cpp:3041
+#: src/muuli_wdr.cpp:3045
 msgid "The password to use to connect to the proxy"
 msgstr "プロクシーに接続に使うパスワード"
 
-#: src/muuli_wdr.cpp:3060
+#: src/muuli_wdr.cpp:3064
 msgid "Connect to:"
 msgstr "次に接続する："
 
-#: src/muuli_wdr.cpp:3069
+#: src/muuli_wdr.cpp:3073
 msgid "Login to remote amule"
 msgstr "リモートamuleにログインする"
 
-#: src/muuli_wdr.cpp:3074
+#: src/muuli_wdr.cpp:3078
 msgid "User name"
 msgstr "ユーザ名"
 
-#: src/muuli_wdr.cpp:3085
+#: src/muuli_wdr.cpp:3089
 msgid "Remember those settings"
 msgstr "設定を記憶する"
 
-#: src/muuli_wdr.cpp:3088
+#: src/muuli_wdr.cpp:3092
 #, fuzzy
 msgid "Force ZLIB compression"
 msgstr "gzip圧縮を使用する"
 
-#: src/muuli_wdr.cpp:3112
+#: src/muuli_wdr.cpp:3116
 msgid "Enable Verbose Debug-Logging."
 msgstr "冗長なデバッグ・ロギングを有効にする"
 
-#: src/muuli_wdr.cpp:3114
+#: src/muuli_wdr.cpp:3118
 #, fuzzy
 msgid "Only to Logfile"
 msgstr "ファイルを開く(&O)"
 
-#: src/muuli_wdr.cpp:3116
+#: src/muuli_wdr.cpp:3120
 msgid "Message Categories:"
 msgstr "メッセージのカテゴリ："
 
-#: src/muuli_wdr.cpp:3140 src/PartFileConvertDlg.cpp:160
+#: src/muuli_wdr.cpp:3144 src/PartFileConvertDlg.cpp:160
 msgid "Waiting..."
 msgstr "待機中…"
 
-#: src/muuli_wdr.cpp:3160
+#: src/muuli_wdr.cpp:3164
 msgid "Add imports"
 msgstr "インポートを追加する"
 
-#: src/muuli_wdr.cpp:3163
+#: src/muuli_wdr.cpp:3167
 msgid "Retry selected"
 msgstr "選択したものを再試行"
 
-#: src/muuli_wdr.cpp:3165
+#: src/muuli_wdr.cpp:3169
 msgid "Remove selected"
 msgstr "選択したものを破棄"
 
-#: src/muuli_wdr.cpp:3228
+#: src/muuli_wdr.cpp:3232
 msgid "Event Types"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3247
+#: src/muuli_wdr.cpp:3251
 msgid "Statistics and queued clients for selected file(s) : Session / All time"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3271
+#: src/muuli_wdr.cpp:3275
 #, fuzzy
 msgid "Active Uploads"
 msgstr "アクティブなアップロード数："
 
-#: src/muuli_wdr.cpp:3285
+#: src/muuli_wdr.cpp:3289
 msgid "Percent of total files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3337
+#: src/muuli_wdr.cpp:3341
 #, fuzzy
 msgid "Show Clients for"
 msgstr "クライアントを表示する"
 
-#: src/muuli_wdr.cpp:3339
+#: src/muuli_wdr.cpp:3343
 #, fuzzy
 msgid "All files"
 msgstr "共有ファイルを隠す"
 
-#: src/muuli_wdr.cpp:3342
+#: src/muuli_wdr.cpp:3346
 #, fuzzy
 msgid "Selected files"
 msgstr "ビュー・フィルタを選択してください"
 
-#: src/muuli_wdr.cpp:3345
+#: src/muuli_wdr.cpp:3349
 #, fuzzy
 msgid "Active uploads only"
 msgstr "アクティブなアップロード数"
 
-#: src/muuli_wdr.cpp:3352
+#: src/muuli_wdr.cpp:3356
 #, fuzzy
 msgid "Reload:"
 msgstr "リストを再ロードする"
 
-#: src/muuli_wdr.cpp:3356
+#: src/muuli_wdr.cpp:3360
 msgid "Reload your shared files"
 msgstr "共有ファイルを再ロードする"
 
-#: src/muuli_wdr.cpp:3419
+#: src/muuli_wdr.cpp:3423
 msgid "Send"
 msgstr "送信する"
 
-#: src/muuli_wdr.cpp:3420
+#: src/muuli_wdr.cpp:3424
 msgid "Sends the specified message."
 msgstr "指示するメッセージを送信します。"
 
-#: src/muuli_wdr.cpp:3424
+#: src/muuli_wdr.cpp:3428
 msgid "Close this chat-session."
 msgstr "チャット・セションを閉じます。"
 
-#: src/muuli_wdr.cpp:3447
+#: src/muuli_wdr.cpp:3451
 msgid "Connect to any server and/or Kad"
 msgstr "すべてのサーバ、もしくはKadに接続する"
 
-#: src/muuli_wdr.cpp:3453 src/SharedFilesCtrl.cpp:142 src/Statistics.cpp:941
+#: src/muuli_wdr.cpp:3457 src/SharedFilesCtrl.cpp:142 src/Statistics.cpp:941
 msgid "Shared Files"
 msgstr "共有ファイル"
 
@@ -5753,85 +5753,85 @@ msgstr ""
 "この設定を変更しなくてもaMuleはうまく動いて\n"
 "います。"
 
-#: src/PrefsUnifiedDlg.cpp:647
+#: src/PrefsUnifiedDlg.cpp:656
 #, c-format
 msgid "Failed to connect Cfg to widget with the ID %d and key %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:695
+#: src/PrefsUnifiedDlg.cpp:704
 #, c-format
 msgid "Failed to transfer data from Cfg to Widget with the ID %d and key %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:801
+#: src/PrefsUnifiedDlg.cpp:810
 msgid "The type of proxy you are connecting to"
 msgstr "接続するプロクシーの種類"
 
-#: src/PrefsUnifiedDlg.cpp:1020
+#: src/PrefsUnifiedDlg.cpp:1029
 #, c-format
 msgid "Failed to transfer data from Widget to Cfg with the ID %d and key %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1103
+#: src/PrefsUnifiedDlg.cpp:1112
 #, fuzzy
 msgid "No password set."
 msgstr "パスワードをチェック中です\n"
 
-#: src/PrefsUnifiedDlg.cpp:1132
+#: src/PrefsUnifiedDlg.cpp:1141
 msgid "Guest access needs a password. Type one in the guest password field, or untick Enable guest access."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1144
+#: src/PrefsUnifiedDlg.cpp:1153
 msgid ""
 "aMule must be restarted to enable these changes:\n"
 "\n"
 msgstr "この変更点を有効するにはaMuleを再起動しなければなりません：\n"
 
-#: src/PrefsUnifiedDlg.cpp:1151
+#: src/PrefsUnifiedDlg.cpp:1160
 msgid "- TCP port changed.\n"
 msgstr "- TCPポートを変更しました。\n"
 
-#: src/PrefsUnifiedDlg.cpp:1156
+#: src/PrefsUnifiedDlg.cpp:1165
 msgid "- UDP port changed.\n"
 msgstr "- UDPポートを変更しました。\n"
 
-#: src/PrefsUnifiedDlg.cpp:1161
+#: src/PrefsUnifiedDlg.cpp:1170
 #, fuzzy
 msgid "- Network interface binding changed.\n"
 msgstr "外部接続は終了しました。"
 
-#: src/PrefsUnifiedDlg.cpp:1166
+#: src/PrefsUnifiedDlg.cpp:1175
 #, fuzzy
 msgid "- External connect port changed.\n"
 msgstr "外部接続は終了しました。"
 
-#: src/PrefsUnifiedDlg.cpp:1170
+#: src/PrefsUnifiedDlg.cpp:1179
 #, fuzzy
 msgid "- External connect acceptance changed.\n"
 msgstr "新しい外部接続を認められました"
 
-#: src/PrefsUnifiedDlg.cpp:1174
+#: src/PrefsUnifiedDlg.cpp:1183
 #, fuzzy
 msgid "- External connect interface changed.\n"
 msgstr "外部接続は終了しました。"
 
-#: src/PrefsUnifiedDlg.cpp:1178
+#: src/PrefsUnifiedDlg.cpp:1187
 #, fuzzy
 msgid "- Protocol obfuscation support changed.\n"
 msgstr "プロトコルを難読化する"
 
-#: src/PrefsUnifiedDlg.cpp:1193
+#: src/PrefsUnifiedDlg.cpp:1202
 #, fuzzy
 msgid "- amuleapi settings changed.\n"
 msgstr "- 言語を変更しました。\n"
 
-#: src/PrefsUnifiedDlg.cpp:1202
+#: src/PrefsUnifiedDlg.cpp:1211
 msgid ""
 "Your Auto-update server list is empty.\n"
 "'Auto-update server list at startup' will be disabled."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1213
+#: src/PrefsUnifiedDlg.cpp:1222
 msgid ""
 "You have enabled external connections but have not specified a password.\n"
 "External connections cannot be enabled unless a valid password is specified."
@@ -5839,40 +5839,40 @@ msgstr ""
 "外部接続を有効にしましたがパスワードを設定していません。\n"
 "有効なパスワードを設定しないと外部接続を可能できません。"
 
-#: src/PrefsUnifiedDlg.cpp:1246
+#: src/PrefsUnifiedDlg.cpp:1255
 #, c-format
 msgid "The amuleapi password could not be saved: %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1276
+#: src/PrefsUnifiedDlg.cpp:1285
 msgid "- Language changed.\n"
 msgstr "- 言語を変更しました。\n"
 
-#: src/PrefsUnifiedDlg.cpp:1281
+#: src/PrefsUnifiedDlg.cpp:1290
 msgid "- Temp folder changed.\n"
 msgstr "- 一時フォルダを変更しました。\n"
 
-#: src/PrefsUnifiedDlg.cpp:1286
+#: src/PrefsUnifiedDlg.cpp:1295
 #, fuzzy
 msgid "- ED2K network enabled.\n"
 msgstr "全てのネットワークが無効になっています。"
 
-#: src/PrefsUnifiedDlg.cpp:1319
+#: src/PrefsUnifiedDlg.cpp:1328
 msgid "The shared-file exclusion pattern is not a valid regular expression. The filter has been left disabled."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1321 src/PrefsUnifiedDlg.cpp:1921
+#: src/PrefsUnifiedDlg.cpp:1330 src/PrefsUnifiedDlg.cpp:1930
 #, fuzzy
 msgid "Invalid regular expression"
 msgstr "無効なプロトコルバージョン。"
 
-#: src/PrefsUnifiedDlg.cpp:1398
+#: src/PrefsUnifiedDlg.cpp:1407
 msgid ""
 "Both eD2k and Kad network are disabled.\n"
 "You won't be able to connect until you enable at least one of them."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1403
+#: src/PrefsUnifiedDlg.cpp:1412
 msgid ""
 "Kad will not start if your UDP port is disabled.\n"
 "Enable UDP port or disable Kad."
@@ -5880,7 +5880,7 @@ msgstr ""
 "UDPポートが無効になっているとKadは開始できません。\n"
 "UDPポートを有効にするか、またはKadを無効にしてください。"
 
-#: src/PrefsUnifiedDlg.cpp:1459
+#: src/PrefsUnifiedDlg.cpp:1468
 msgid ""
 "\n"
 "You MUST restart aMule now.\n"
@@ -5890,69 +5890,69 @@ msgstr ""
 "必ず早急にaMuleを再起動してください。\n"
 "今すぐに再起動しなければ、挙動がおかしくなる可能性があります。\n"
 
-#: src/PrefsUnifiedDlg.cpp:1524
+#: src/PrefsUnifiedDlg.cpp:1533
 msgid "Could not register aMule for autostart at login. The autostart store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1526
+#: src/PrefsUnifiedDlg.cpp:1535
 msgid "Could not remove the autostart-at-login entry."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1527
+#: src/PrefsUnifiedDlg.cpp:1536
 #, fuzzy
 msgid "Autostart"
 msgstr "オートリフレッシュを開始しました"
 
-#: src/PrefsUnifiedDlg.cpp:1542
+#: src/PrefsUnifiedDlg.cpp:1551
 msgid "Register file type"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1542
+#: src/PrefsUnifiedDlg.cpp:1551
 msgid "Register URL handler"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1550
+#: src/PrefsUnifiedDlg.cpp:1559
 #, c-format
 msgid "aMule only handles eD2k-compatible magnets. If you replace the current magnet handler (%s), BitTorrent magnet links will stop working - aMule cannot download BitTorrent content. Continue?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1555
+#: src/PrefsUnifiedDlg.cpp:1564
 #, c-format
 msgid "Another application currently opens .emulecollection files (%s). Replace it with aMule?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1560
+#: src/PrefsUnifiedDlg.cpp:1569
 #, c-format
 msgid "Another application is currently the default handler for these links (%s). Replace it with aMule?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1585
+#: src/PrefsUnifiedDlg.cpp:1594
 msgid "Could not register aMule for .emulecollection files. The registration store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1587
+#: src/PrefsUnifiedDlg.cpp:1596
 #, fuzzy
 msgid "Could not remove the file type registration."
 msgstr "あなたはすでにファイル%sをダウンロードしようとしています"
 
-#: src/PrefsUnifiedDlg.cpp:1589
+#: src/PrefsUnifiedDlg.cpp:1598
 msgid "Could not register aMule as the URL handler. The registration store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1591
+#: src/PrefsUnifiedDlg.cpp:1600
 msgid "Could not remove the URL handler registration."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1661 src/PrefsUnifiedDlg.cpp:1688
+#: src/PrefsUnifiedDlg.cpp:1670 src/PrefsUnifiedDlg.cpp:1697
 #, fuzzy
 msgid "The web server and aMule API require external connections to be enabled."
 msgstr "新しい外部接続を認められました"
 
-#: src/PrefsUnifiedDlg.cpp:1671
+#: src/PrefsUnifiedDlg.cpp:1680
 msgid "The aMule web server is deprecated. Consider running the aMule API instead."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1735
+#: src/PrefsUnifiedDlg.cpp:1744
 msgid ""
 "Your Auto-update servers list is in blank.\n"
 "Please fill in at least one URL to point to a valid server.met file.\n"
@@ -5962,65 +5962,65 @@ msgstr ""
 "せめて一つのURLを入力して、有効なserver.metファイルを指定してください。\n"
 "このチェックボクスの近くの\"表\"ボタンをクリックして、URLを入力してください。"
 
-#: src/PrefsUnifiedDlg.cpp:1876
+#: src/PrefsUnifiedDlg.cpp:1885
 msgid "Temporary files"
 msgstr "一時ファイル"
 
-#: src/PrefsUnifiedDlg.cpp:1881
+#: src/PrefsUnifiedDlg.cpp:1890
 msgid "Incoming files"
 msgstr "受信ファイル"
 
-#: src/PrefsUnifiedDlg.cpp:1886
+#: src/PrefsUnifiedDlg.cpp:1895
 msgid "Online Signatures"
 msgstr "オンライン署名"
 
-#: src/PrefsUnifiedDlg.cpp:1899
+#: src/PrefsUnifiedDlg.cpp:1908
 #, c-format
 msgid "Choose a folder for %s"
 msgstr " %s のためのフォルダを選択する"
 
-#: src/PrefsUnifiedDlg.cpp:1923
+#: src/PrefsUnifiedDlg.cpp:1932
 #, fuzzy, c-format
 msgid "Would exclude %u of %u shared file"
 msgid_plural "Would exclude %u of %u shared files"
 msgstr[0] "%i個の既知の共有ファイルが見つかりました"
 
-#: src/PrefsUnifiedDlg.cpp:1940
+#: src/PrefsUnifiedDlg.cpp:1949
 msgid "Browse for videoplayer"
 msgstr "ビデオプレイヤーを選択する"
 
-#: src/PrefsUnifiedDlg.cpp:1944
+#: src/PrefsUnifiedDlg.cpp:1953
 msgid "Select browser"
 msgstr "ブラウザを選択する"
 
-#: src/PrefsUnifiedDlg.cpp:1948
+#: src/PrefsUnifiedDlg.cpp:1957
 #, fuzzy
 msgid "Select ffprobe binary"
 msgstr "ブラウザを選択する"
 
-#: src/PrefsUnifiedDlg.cpp:1954
+#: src/PrefsUnifiedDlg.cpp:1963
 #, c-format
 msgid "Executable%s"
 msgstr "実行ファイル%s"
 
-#: src/PrefsUnifiedDlg.cpp:1988
+#: src/PrefsUnifiedDlg.cpp:1997
 msgid "ffprobe not found on PATH or in the standard install locations. Install ffmpeg (which ships ffprobe) or use Browse to pick a binary manually."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2000
+#: src/PrefsUnifiedDlg.cpp:2009
 msgid "Reset the settings on this page to their default values?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2001
+#: src/PrefsUnifiedDlg.cpp:2010
 #, fuzzy
 msgid "Reset to defaults"
 msgstr "システムの標準設定"
 
-#: src/PrefsUnifiedDlg.cpp:2028
+#: src/PrefsUnifiedDlg.cpp:2037
 msgid "Edit server list"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2029
+#: src/PrefsUnifiedDlg.cpp:2038
 msgid ""
 "Add here URL's to download server.met files.\n"
 "Only one url on each line."
@@ -6028,150 +6028,150 @@ msgstr ""
 "server.metファイルをダウンロードするURLをここに追加してください。\n"
 "一行にひとつのURLのみです。"
 
-#: src/PrefsUnifiedDlg.cpp:2084
+#: src/PrefsUnifiedDlg.cpp:2093
 msgid "IP2Country update failed"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2229 src/PrefsUnifiedDlg.cpp:2260
+#: src/PrefsUnifiedDlg.cpp:2238 src/PrefsUnifiedDlg.cpp:2269
 msgid "Data by MaxMind GeoLite2"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2231 src/PrefsUnifiedDlg.cpp:2262
+#: src/PrefsUnifiedDlg.cpp:2240 src/PrefsUnifiedDlg.cpp:2271
 #, fuzzy
 msgid "Custom source"
 msgstr "ソース完了"
 
-#: src/PrefsUnifiedDlg.cpp:2233 src/PrefsUnifiedDlg.cpp:2264
+#: src/PrefsUnifiedDlg.cpp:2242 src/PrefsUnifiedDlg.cpp:2273
 msgid "Data by DB-IP.com"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2284
+#: src/PrefsUnifiedDlg.cpp:2293
 #, fuzzy, c-format
 msgid "Status: Loaded%s"
 msgstr "ステータス："
 
-#: src/PrefsUnifiedDlg.cpp:2286
+#: src/PrefsUnifiedDlg.cpp:2295
 #, fuzzy, c-format
 msgid "Status: Loaded%s - %s"
 msgstr "ステータス："
 
-#: src/PrefsUnifiedDlg.cpp:2290
+#: src/PrefsUnifiedDlg.cpp:2299
 msgid "Status: Failed to load - click 'Update now' to refresh."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2292
+#: src/PrefsUnifiedDlg.cpp:2301
 msgid "Status: Not found - click 'Update now' to download."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2350 src/PrefsUnifiedDlg.cpp:2374
+#: src/PrefsUnifiedDlg.cpp:2359 src/PrefsUnifiedDlg.cpp:2383
 #, c-format
 msgid "Update delay: %d second"
 msgid_plural "Update delay: %d seconds"
 msgstr[0] "アップデート遅延時間： %d 秒"
 
-#: src/PrefsUnifiedDlg.cpp:2358
+#: src/PrefsUnifiedDlg.cpp:2367
 #, c-format
 msgid "Time for average graph: %d minute"
 msgid_plural "Time for average graph: %d minutes"
 msgstr[0] "平均グラフの時間： %d 分"
 
-#: src/PrefsUnifiedDlg.cpp:2367
+#: src/PrefsUnifiedDlg.cpp:2376
 #, c-format
 msgid "Connections Graph Scale: %d"
 msgstr "接続グラフスケール： %d"
 
-#: src/PrefsUnifiedDlg.cpp:2382
+#: src/PrefsUnifiedDlg.cpp:2391
 #, c-format
 msgid "File Buffer Size: %d byte"
 msgid_plural "File Buffer Size: %d bytes"
 msgstr[0] "ファイルバッファサイズ： %d バイト"
 
-#: src/PrefsUnifiedDlg.cpp:2392
+#: src/PrefsUnifiedDlg.cpp:2401
 #, c-format
 msgid "Upload Queue Size: %d client"
 msgid_plural "Upload Queue Size: %d clients"
 msgstr[0] "アップロードキューサイズ： %d クライアント"
 
-#: src/PrefsUnifiedDlg.cpp:2402
+#: src/PrefsUnifiedDlg.cpp:2411
 #, c-format
 msgid "Server connection refresh interval: %d minute"
 msgid_plural "Server connection refresh interval: %d minutes"
 msgstr[0] "サーバ接続リフレッシュ遅延時間： %d 分"
 
-#: src/PrefsUnifiedDlg.cpp:2407
+#: src/PrefsUnifiedDlg.cpp:2416
 msgid "Server connection refresh interval: Disabled"
 msgstr "サーバ接続リフレッシュ遅延時間： 無効"
 
-#: src/PrefsUnifiedDlg.cpp:2451
+#: src/PrefsUnifiedDlg.cpp:2460
 #, fuzzy
 msgid "disabled"
 msgstr "無効にする"
 
-#: src/PrefsUnifiedDlg.cpp:2477
+#: src/PrefsUnifiedDlg.cpp:2486
 #, fuzzy, c-format
 msgid "Execute command on '%s' event"
 msgstr " `%s' イベントにコマンドを実行する"
 
-#: src/PrefsUnifiedDlg.cpp:2484
+#: src/PrefsUnifiedDlg.cpp:2493
 msgid "Enable command execution on core"
 msgstr "コアにコマンドを実行することを有効にする"
 
-#: src/PrefsUnifiedDlg.cpp:2496
+#: src/PrefsUnifiedDlg.cpp:2505
 msgid "Core command:"
 msgstr "コアコマンド："
 
-#: src/PrefsUnifiedDlg.cpp:2512
+#: src/PrefsUnifiedDlg.cpp:2521
 msgid "Enable command execution on GUI"
 msgstr "GUIにコマンドを実行することを有効にする"
 
-#: src/PrefsUnifiedDlg.cpp:2524
+#: src/PrefsUnifiedDlg.cpp:2533
 msgid "GUI command:"
 msgstr "GUIコマンド："
 
-#: src/PrefsUnifiedDlg.cpp:2540
+#: src/PrefsUnifiedDlg.cpp:2549
 msgid "The following variables will be replaced:"
 msgstr "次の変数は置換されます："
 
-#: src/PrefsUnifiedDlg.cpp:2708
+#: src/PrefsUnifiedDlg.cpp:2717
 msgid ""
 "The following folders look like system or sensitive locations:\n"
 "\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2713
+#: src/PrefsUnifiedDlg.cpp:2722
 msgid "Sharing them recursively will publish every file underneath on the eD2k/Kad networks. Do you really want to do this?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2716
+#: src/PrefsUnifiedDlg.cpp:2725
 #, fuzzy
 msgid "Confirm shared folders"
 msgstr "共有ファイルを再ロードする"
 
-#: src/PrefsUnifiedDlg.cpp:2744
+#: src/PrefsUnifiedDlg.cpp:2753
 #, fuzzy
 msgid "Reloading shared files..."
 msgstr "共有ファイルを再ロードする"
 
-#: src/PrefsUnifiedDlg.cpp:2745
+#: src/PrefsUnifiedDlg.cpp:2754
 msgid "Scanning for subdirectories..."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2746
+#: src/PrefsUnifiedDlg.cpp:2755
 #, fuzzy
 msgid "Updating shared folders"
 msgstr "一時フォルダを読み中です"
 
-#: src/PrefsUnifiedDlg.cpp:2773
+#: src/PrefsUnifiedDlg.cpp:2782
 #, c-format
 msgid "Scanned %u directories..."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2823
+#: src/PrefsUnifiedDlg.cpp:2832
 #, fuzzy, c-format
 msgid "Reloading shared files: %u files scanned"
 msgstr "共有ファイル・リストを再ロードします。"
 
-#: src/PrefsUnifiedDlg.cpp:2873
+#: src/PrefsUnifiedDlg.cpp:2882
 #, fuzzy
 msgid "Shared folder"
 msgstr "共有ファイル"
@@ -7868,12 +7868,12 @@ msgstr "カテゴリを削除します"
 msgid "Hashset requested for unknown file: %s"
 msgstr "不明なファイルのハッシュセットが要求されました： %s"
 
-#: src/UploadQueue.cpp:618
+#: src/UploadQueue.cpp:627
 #, c-format
 msgid "Resuming uploads of file: %s"
 msgstr "ファイル %s のアップロードを再開します"
 
-#: src/UploadQueue.cpp:634
+#: src/UploadQueue.cpp:643
 #, c-format
 msgid "Suspending upload of file: %s"
 msgstr "ファイル %s のアップロードを一時停止します"

--- a/po/ja.po
+++ b/po/ja.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-28 08:06+0200\n"
+"POT-Creation-Date: 2026-07-28 10:19+0200\n"
 "PO-Revision-Date: 2026-07-27 11:41+0000\n"
 "Last-Translator: \n"
 "Language-Team: Japanese\n"
@@ -141,7 +141,7 @@ msgstr ""
 msgid "Not now"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:422 src/amuleDlg.cpp:600
+#: src/AppImageIntegration.cpp:422 src/amuleDlg.cpp:665
 msgid "Don't ask again"
 msgstr ""
 
@@ -218,7 +218,7 @@ msgid "Killing amuleweb instance with pid '%d' ... "
 msgstr ""
 
 #: src/amule.cpp:336 src/amule.cpp:349 src/ClientRef.cpp:180
-#: src/SearchDlg.cpp:880 src/ServerListCtrl.cpp:98
+#: src/SearchDlg.cpp:1041 src/ServerListCtrl.cpp:98
 msgid "Failed"
 msgstr "失敗しました"
 
@@ -574,30 +574,68 @@ msgstr ""
 msgid "ERROR: %s"
 msgstr "エラー： %s"
 
-#: src/amuleDlg.cpp:236
+#: src/amuleDlg.cpp:250
 #, c-format
 msgid "This is aMule %s based on eMule."
 msgstr "これはeMuleに基づいたaMule %s です。"
 
-#: src/amuleDlg.cpp:237
+#: src/amuleDlg.cpp:251
 #, c-format
 msgid "Running on %s"
 msgstr "%s に起動しています"
 
-#: src/amuleDlg.cpp:239
+#: src/amuleDlg.cpp:253
 msgid "Visit https://github.com/amule-org/amule/releases/latest to check if a new version is available."
 msgstr "新しいバージョンの確認はhttps://github.com/amule-org/amule/releases/latestで。"
 
-#: src/amuleDlg.cpp:268
+#: src/amuleDlg.cpp:282
 msgid "FATAL ERROR: Failed to create Timer"
 msgstr ""
 
-#: src/amuleDlg.cpp:592
+#: src/amuleDlg.cpp:361 src/amuleDlg.cpp:1787 src/amuleDlg.cpp:2033
+#: src/muuli_wdr.cpp:1492 src/muuli_wdr.cpp:3418
+msgid "Networks"
+msgstr "ネットワーク"
+
+#: src/amuleDlg.cpp:362 src/amuleDlg.cpp:1793 src/muuli_wdr.cpp:3419
+msgid "Searches"
+msgstr "検索"
+
+#: src/amuleDlg.cpp:363 src/amuleDlg.cpp:1799 src/DownloadListCtrl.cpp:740
+#: src/muuli_wdr.cpp:392 src/muuli_wdr.cpp:1585 src/muuli_wdr.cpp:3420
+#: src/Statistics.cpp:829
+msgid "Downloads"
+msgstr "ダウンロード数"
+
+#: src/amuleDlg.cpp:364 src/amuleDlg.cpp:1805 src/muuli_wdr.cpp:3294
+msgid "Shared files"
+msgstr ""
+
+#: src/amuleDlg.cpp:365 src/amuleDlg.cpp:1811 src/muuli_wdr.cpp:2926
+#: src/muuli_wdr.cpp:3376 src/muuli_wdr.cpp:3423
+msgid "Messages"
+msgstr "メッセージ"
+
+#: src/amuleDlg.cpp:366 src/amuleDlg.cpp:1817 src/muuli_wdr.cpp:3424
+#: src/PrefsUnifiedDlg.cpp:312 src/Statistics.cpp:779 src/Statistics.cpp:1235
+msgid "Statistics"
+msgstr "統計"
+
+#: src/amuleDlg.cpp:368 src/amuleDlg.cpp:1824 src/muuli_wdr.cpp:3426
+#: src/PrefsUnifiedDlg.cpp:328 src/utils/wxCas/src/wxcasprefs.cpp:39
+msgid "Preferences"
+msgstr "設定"
+
+#: src/amuleDlg.cpp:371
+msgid "Navigate"
+msgstr ""
+
+#: src/amuleDlg.cpp:657
 #, fuzzy
 msgid "New version available"
 msgstr "利用不可"
 
-#: src/amuleDlg.cpp:596
+#: src/amuleDlg.cpp:661
 #, fuzzy, c-format
 msgid ""
 "A new version of aMule (%s) is available.\n"
@@ -607,220 +645,187 @@ msgid ""
 "Would you like to open the download page?"
 msgstr "最新バージョンはいつもhttps://github.com/amule-org/amule/releases/latestにあります"
 
-#: src/amuleDlg.cpp:678
+#: src/amuleDlg.cpp:743
 msgid "aMule dialog destroyed"
 msgstr ""
 
-#: src/amuleDlg.cpp:701 src/DataToText.cpp:68 src/IPFilter.cpp:547
+#: src/amuleDlg.cpp:766 src/DataToText.cpp:68 src/IPFilter.cpp:547
 msgid "Connecting"
 msgstr "接続中"
 
-#: src/amuleDlg.cpp:893
+#: src/amuleDlg.cpp:958
 msgid "eD2k: Connecting"
 msgstr ""
 
-#: src/amuleDlg.cpp:897
+#: src/amuleDlg.cpp:962
 msgid "eD2k: Disconnected"
 msgstr ""
 
-#: src/amuleDlg.cpp:903
+#: src/amuleDlg.cpp:968
 msgid "Kad: Firewalled"
 msgstr "Kad: ファイアウォールされています"
 
-#: src/amuleDlg.cpp:907
+#: src/amuleDlg.cpp:972
 msgid "Kad: Connected"
 msgstr "Kad: 接続"
 
-#: src/amuleDlg.cpp:912
+#: src/amuleDlg.cpp:977
 msgid "Kad: Connecting"
 msgstr "Kad: 接続中"
 
-#: src/amuleDlg.cpp:916
+#: src/amuleDlg.cpp:981
 msgid "Kad: Off"
 msgstr "Kad: オフ"
 
-#: src/amuleDlg.cpp:964 src/DownloadListCtrl.cpp:505
+#: src/amuleDlg.cpp:1029 src/DownloadListCtrl.cpp:505
 #: src/DownloadListCtrl.cpp:749 src/FriendListCtrl.cpp:180
 #: src/muuli_wdr.cpp:731 src/muuli_wdr.cpp:782 src/muuli_wdr.cpp:846
-#: src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2224 src/muuli_wdr.cpp:2309
-#: src/muuli_wdr.cpp:3057 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
+#: src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2231 src/muuli_wdr.cpp:2316
+#: src/muuli_wdr.cpp:3064 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
 #: src/ServerListCtrl.cpp:606 src/TransferWnd.cpp:378
 #: src/utils/wxCas/src/wxcasprefs.cpp:235
 msgid "Cancel"
 msgstr "キャンセル"
 
-#: src/amuleDlg.cpp:965
+#: src/amuleDlg.cpp:1030
 msgid "Stop the current connection attempts"
 msgstr "現在の接続試行を中止する"
 
-#: src/amuleDlg.cpp:970 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976
-#: src/muuli_wdr.cpp:2447
+#: src/amuleDlg.cpp:1035 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976
+#: src/muuli_wdr.cpp:2454
 msgid "Disconnect"
 msgstr "切断する"
 
-#: src/amuleDlg.cpp:971
+#: src/amuleDlg.cpp:1036
 msgid "Disconnect from the currently connected networks"
 msgstr "ネットワークから切断します。"
 
-#: src/amuleDlg.cpp:976 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979
-#: src/muuli_wdr.cpp:2602 src/muuli_wdr.cpp:3054 src/muuli_wdr.cpp:3409
+#: src/amuleDlg.cpp:1041 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979
+#: src/muuli_wdr.cpp:2609 src/muuli_wdr.cpp:3061 src/muuli_wdr.cpp:3416
 msgid "Connect"
 msgstr "接続する"
 
-#: src/amuleDlg.cpp:977
+#: src/amuleDlg.cpp:1042
 msgid "Connect to the currently enabled networks"
 msgstr "ネットワークへ接続します。"
 
-#: src/amuleDlg.cpp:1089
+#: src/amuleDlg.cpp:1154
 #, fuzzy, c-format
 msgid "Up: %.1f%s (%.1f) | Down: %.1f%s (%.1f)"
 msgstr "アップ： %.1f(%.1f) | ダウン： %.1f(%.1f)"
 
-#: src/amuleDlg.cpp:1091 src/amuleDlg.cpp:1093 src/amuleDlg.cpp:1097
-#: src/amuleDlg.cpp:1099 src/amuleDlg.cpp:1110 src/amuleDlg.cpp:1112
+#: src/amuleDlg.cpp:1156 src/amuleDlg.cpp:1158 src/amuleDlg.cpp:1162
+#: src/amuleDlg.cpp:1164 src/amuleDlg.cpp:1175 src/amuleDlg.cpp:1177
 #: src/MuleTrayIcon.cpp:796 src/MuleTrayIcon.cpp:799
 #, fuzzy
 msgid " MB/s"
 msgstr "MB/s"
 
-#: src/amuleDlg.cpp:1091 src/amuleDlg.cpp:1093 src/amuleDlg.cpp:1097
-#: src/amuleDlg.cpp:1099 src/amuleDlg.cpp:1110 src/amuleDlg.cpp:1112
+#: src/amuleDlg.cpp:1156 src/amuleDlg.cpp:1158 src/amuleDlg.cpp:1162
+#: src/amuleDlg.cpp:1164 src/amuleDlg.cpp:1175 src/amuleDlg.cpp:1177
 #: src/MuleTrayIcon.cpp:796 src/MuleTrayIcon.cpp:799
 #: src/utils/wxCas/src/wxcasframe.cpp:1041
 msgid " kB/s"
 msgstr " kB/s"
 
-#: src/amuleDlg.cpp:1096
+#: src/amuleDlg.cpp:1161
 #, fuzzy, c-format
 msgid "Up: %.1f%s | Down: %.1f%s"
 msgstr "アップ： %.1f | ダウン： %.1f"
 
-#: src/amuleDlg.cpp:1128
+#: src/amuleDlg.cpp:1193
 #, c-format
 msgid "aMule (%s | Connected)"
 msgstr "aMule (%s | 接続しています)"
 
-#: src/amuleDlg.cpp:1130
+#: src/amuleDlg.cpp:1195
 #, c-format
 msgid "aMule (%s | Disconnected)"
 msgstr "aMule (%s | 切断しています)"
 
-#: src/amuleDlg.cpp:1183
+#: src/amuleDlg.cpp:1248
 #, fuzzy, c-format
 msgid "Do you really want to exit %s?"
 msgstr "本当にaMuleを終了しますか？"
 
-#: src/amuleDlg.cpp:1185
+#: src/amuleDlg.cpp:1250
 msgid "Exit confirmation"
 msgstr "終了の確認"
 
-#: src/amuleDlg.cpp:1548
+#: src/amuleDlg.cpp:1613
 #, fuzzy
 msgid "Launch Command: "
 msgstr "コマンド： %s"
 
-#: src/amuleDlg.cpp:1567 src/muuli_wdr.cpp:1971 src/Preferences.cpp:951
+#: src/amuleDlg.cpp:1632 src/muuli_wdr.cpp:1978 src/Preferences.cpp:952
 msgid "- default -"
 msgstr ""
 
-#: src/amuleDlg.cpp:1595
+#: src/amuleDlg.cpp:1660
 #, c-format
 msgid "Skin directory '%s' does not exist"
 msgstr "スキンディレクトリ '%s' は存在しません"
 
-#: src/amuleDlg.cpp:1598
+#: src/amuleDlg.cpp:1663
 #, c-format
 msgid "WARNING: Unable to open skin file '%s' for read"
 msgstr ""
 
-#: src/amuleDlg.cpp:1722 src/amuleDlg.cpp:1968 src/muuli_wdr.cpp:1485
-#: src/muuli_wdr.cpp:3411
-msgid "Networks"
-msgstr "ネットワーク"
-
-#: src/amuleDlg.cpp:1726 src/muuli_wdr.cpp:3411
+#: src/amuleDlg.cpp:1791 src/muuli_wdr.cpp:3418
 msgid "Networks Window"
 msgstr "ネットワークウィンドウ"
 
-#: src/amuleDlg.cpp:1728 src/muuli_wdr.cpp:3412
-msgid "Searches"
-msgstr "検索"
-
-#: src/amuleDlg.cpp:1732 src/muuli_wdr.cpp:3412
+#: src/amuleDlg.cpp:1797 src/muuli_wdr.cpp:3419
 msgid "Searches Window"
 msgstr "検索ウィンドウ"
 
-#: src/amuleDlg.cpp:1734 src/DownloadListCtrl.cpp:740 src/muuli_wdr.cpp:392
-#: src/muuli_wdr.cpp:1578 src/muuli_wdr.cpp:3413 src/Statistics.cpp:829
-msgid "Downloads"
-msgstr "ダウンロード数"
-
-#: src/amuleDlg.cpp:1738 src/muuli_wdr.cpp:3413
+#: src/amuleDlg.cpp:1803 src/muuli_wdr.cpp:3420
 #, fuzzy
 msgid "Downloads Window"
 msgstr "ダウンロード"
 
-#: src/amuleDlg.cpp:1740 src/muuli_wdr.cpp:3287
-msgid "Shared files"
-msgstr ""
-
-#: src/amuleDlg.cpp:1744 src/muuli_wdr.cpp:3415
+#: src/amuleDlg.cpp:1809 src/muuli_wdr.cpp:3422
 msgid "Shared Files Window"
 msgstr "共有ファイルウィンドウ"
 
-#: src/amuleDlg.cpp:1746 src/muuli_wdr.cpp:2919 src/muuli_wdr.cpp:3369
-#: src/muuli_wdr.cpp:3416
-msgid "Messages"
-msgstr "メッセージ"
-
-#: src/amuleDlg.cpp:1750 src/muuli_wdr.cpp:3416
+#: src/amuleDlg.cpp:1815 src/muuli_wdr.cpp:3423
 msgid "Messages Window"
 msgstr "メッセージウィンドウ"
 
-#: src/amuleDlg.cpp:1752 src/muuli_wdr.cpp:3417 src/PrefsUnifiedDlg.cpp:312
-#: src/Statistics.cpp:779 src/Statistics.cpp:1235
-msgid "Statistics"
-msgstr "統計"
-
-#: src/amuleDlg.cpp:1756 src/muuli_wdr.cpp:3417
+#: src/amuleDlg.cpp:1821 src/muuli_wdr.cpp:3424
 msgid "Statistics Graph Window"
 msgstr "統計グラフウィインドウ"
 
-#: src/amuleDlg.cpp:1759 src/muuli_wdr.cpp:3419 src/PrefsUnifiedDlg.cpp:328
-#: src/utils/wxCas/src/wxcasprefs.cpp:39
-msgid "Preferences"
-msgstr "設定"
-
-#: src/amuleDlg.cpp:1763 src/muuli_wdr.cpp:3419
+#: src/amuleDlg.cpp:1828 src/muuli_wdr.cpp:3426
 msgid "Preferences Settings Window"
 msgstr "個人設定ウィンドウ"
 
-#: src/amuleDlg.cpp:1766 src/muuli_wdr.cpp:3420
+#: src/amuleDlg.cpp:1831 src/muuli_wdr.cpp:3427
 msgid "Import"
 msgstr "インポート"
 
-#: src/amuleDlg.cpp:1770 src/muuli_wdr.cpp:3420
+#: src/amuleDlg.cpp:1835 src/muuli_wdr.cpp:3427
 msgid "The partfile importer tool"
 msgstr "部分ファイルをインポートするためのツール"
 
-#: src/amuleDlg.cpp:1773 src/muuli_wdr.cpp:3421
+#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3428
 #: src/utils/aLinkCreator/src/alcframe.cpp:262
 msgid "About"
 msgstr "情報"
 
-#: src/amuleDlg.cpp:1773 src/muuli_wdr.cpp:3421
+#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3428
 msgid "About/Help"
 msgstr "ソフトウェア情報／ヘルプ"
 
-#: src/amuleDlg.cpp:1971
+#: src/amuleDlg.cpp:2036
 msgid "eD2k network"
 msgstr ""
 
-#: src/amuleDlg.cpp:1974
+#: src/amuleDlg.cpp:2039
 msgid "Kad network"
 msgstr "Kadネットワーク"
 
-#: src/amuleDlg.cpp:1974
+#: src/amuleDlg.cpp:2039
 msgid "No network"
 msgstr "ネットワークなし"
 
@@ -1352,19 +1357,19 @@ msgstr "オート [Hi]"
 msgid "Very low"
 msgstr "非常に低い"
 
-#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:743 src/muuli_wdr.cpp:2275
+#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:743 src/muuli_wdr.cpp:2282
 #: src/ServerListCtrl.cpp:263 src/ServerListCtrl.cpp:456
 #: src/SharedFilesCtrl.cpp:145
 msgid "Low"
 msgstr "低い"
 
-#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:744 src/muuli_wdr.cpp:2276
+#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:744 src/muuli_wdr.cpp:2283
 #: src/ServerListCtrl.cpp:266 src/ServerListCtrl.cpp:457
 #: src/SharedFilesCtrl.cpp:146
 msgid "Normal"
 msgstr "普通"
 
-#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:745 src/muuli_wdr.cpp:2277
+#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:745 src/muuli_wdr.cpp:2284
 #: src/ServerListCtrl.cpp:269 src/ServerListCtrl.cpp:458
 #: src/SharedFilesCtrl.cpp:147
 msgid "High"
@@ -1456,8 +1461,8 @@ msgstr "ローカルサーバ"
 msgid "Remote Server"
 msgstr "リモートサーバ"
 
-#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3174
-#: src/SearchDlg.cpp:111 src/TextClient.cpp:911
+#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3181
+#: src/SearchDlg.cpp:119 src/TextClient.cpp:911
 msgid "Kad"
 msgstr "Kad"
 
@@ -1528,7 +1533,7 @@ msgstr ""
 msgid "Size"
 msgstr "サイズ"
 
-#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3241
+#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3248
 msgid "Transferred"
 msgstr "転送済み"
 
@@ -1586,7 +1591,7 @@ msgstr ""
 "フィードバック:%s (%s)\n"
 "\n"
 
-#: src/DownloadListCtrl.cpp:746 src/muuli_wdr.cpp:2278
+#: src/DownloadListCtrl.cpp:746 src/muuli_wdr.cpp:2285
 #: src/SharedFilesCtrl.cpp:150
 msgid "Auto"
 msgstr "自動"
@@ -1624,7 +1629,7 @@ msgid "Extended Options"
 msgstr "拡張オプション"
 
 #: src/DownloadListCtrl.cpp:770 src/DownloadListCtrl.cpp:822
-#: src/muuli_wdr.cpp:1789
+#: src/muuli_wdr.cpp:1796
 msgid "Preview"
 msgstr "プレビュー"
 
@@ -2336,19 +2341,19 @@ msgstr ""
 msgid "eD2k"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:349 src/muuli_wdr.cpp:1488
+#: src/FirstRunWizard.cpp:349 src/muuli_wdr.cpp:1495
 msgid "Kademlia"
 msgstr "Kademlia"
 
-#: src/FirstRunWizard.cpp:359 src/muuli_wdr.cpp:1416
+#: src/FirstRunWizard.cpp:359 src/muuli_wdr.cpp:1423
 msgid "Standard TCP Port "
 msgstr ""
 
-#: src/FirstRunWizard.cpp:365 src/muuli_wdr.cpp:1428
+#: src/FirstRunWizard.cpp:365 src/muuli_wdr.cpp:1435
 msgid "Extended UDP port (Kad / global search) "
 msgstr ""
 
-#: src/FirstRunWizard.cpp:377 src/muuli_wdr.cpp:1435
+#: src/FirstRunWizard.cpp:377 src/muuli_wdr.cpp:1442
 msgid "Enable UPnP for router port forwarding"
 msgstr ""
 
@@ -2375,7 +2380,7 @@ msgstr ""
 msgid "Your peer lists are already in place - nothing to download."
 msgstr "あなたはすでにファイル%sをダウンロードしようとしています"
 
-#: src/FirstRunWizard.cpp:434 src/muuli_wdr.cpp:1533
+#: src/FirstRunWizard.cpp:434 src/muuli_wdr.cpp:1540
 msgid "Auto-update server list at startup"
 msgstr ""
 
@@ -2421,23 +2426,23 @@ msgid ""
 "want downloads on a different (e.g. larger) disk."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:549 src/FirstRunWizard.cpp:611 src/muuli_wdr.cpp:1701
+#: src/FirstRunWizard.cpp:549 src/FirstRunWizard.cpp:611 src/muuli_wdr.cpp:1708
 msgid "Destination folder for downloads"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:553 src/FirstRunWizard.cpp:569 src/muuli_wdr.cpp:1342
-#: src/muuli_wdr.cpp:1359 src/muuli_wdr.cpp:1676 src/muuli_wdr.cpp:1707
-#: src/muuli_wdr.cpp:1719 src/muuli_wdr.cpp:2762
+#: src/FirstRunWizard.cpp:553 src/FirstRunWizard.cpp:569 src/muuli_wdr.cpp:1349
+#: src/muuli_wdr.cpp:1366 src/muuli_wdr.cpp:1683 src/muuli_wdr.cpp:1714
+#: src/muuli_wdr.cpp:1726 src/muuli_wdr.cpp:2769
 #: src/utils/aLinkCreator/src/alcframe.cpp:135
 #: src/utils/wxCas/src/wxcasprefs.cpp:52 src/utils/wxCas/src/wxcasprefs.cpp:118
 msgid "Browse"
 msgstr "閲覧"
 
-#: src/FirstRunWizard.cpp:559 src/muuli_wdr.cpp:1712
+#: src/FirstRunWizard.cpp:559 src/muuli_wdr.cpp:1719
 msgid "(All files in this folder are shared with other peers)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:565 src/FirstRunWizard.cpp:624 src/muuli_wdr.cpp:1714
+#: src/FirstRunWizard.cpp:565 src/FirstRunWizard.cpp:624 src/muuli_wdr.cpp:1721
 msgid "Folder for temporary download files"
 msgstr ""
 
@@ -2468,7 +2473,7 @@ msgstr ""
 msgid "CRITICAL - no client on StartChatSession"
 msgstr ""
 
-#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2668 src/muuli_wdr.cpp:3345
+#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2675 src/muuli_wdr.cpp:3352
 msgid "Friends"
 msgstr "友達"
 
@@ -2849,7 +2854,7 @@ msgstr "共有比"
 msgid "Uploaded"
 msgstr "アップロード済み"
 
-#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3225
+#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3232
 msgid "Requested"
 msgstr "要求済み"
 
@@ -2975,7 +2980,7 @@ msgid "WARNING: "
 msgstr ""
 
 #: src/MuleNotebook.cpp:179 src/muuli_wdr.cpp:817 src/muuli_wdr.cpp:1229
-#: src/muuli_wdr.cpp:3129 src/muuli_wdr.cpp:3385
+#: src/muuli_wdr.cpp:3136 src/muuli_wdr.cpp:3392
 msgid "Close"
 msgstr "閉じる"
 
@@ -2988,12 +2993,12 @@ msgstr "カット"
 msgid "Copy"
 msgstr "コピー"
 
-#: src/MuleTextCtrl.cpp:88
+#: src/MuleTextCtrl.cpp:88 src/SearchDlg.cpp:261
 msgid "Paste"
 msgstr "ペースト"
 
 #: src/MuleTextCtrl.cpp:89 src/muuli_wdr.cpp:358 src/muuli_wdr.cpp:757
-#: src/muuli_wdr.cpp:2352 src/muuli_wdr.cpp:2371 src/muuli_wdr.cpp:2393
+#: src/muuli_wdr.cpp:2359 src/muuli_wdr.cpp:2378 src/muuli_wdr.cpp:2400
 #: src/utils/aLinkCreator/src/alcframe.cpp:142
 msgid "Clear"
 msgstr "クリア"
@@ -3090,8 +3095,8 @@ msgid "Exit"
 msgstr "終了"
 
 #: src/MuleTrayIcon.cpp:579 src/MuleTrayIcon.cpp:945 src/MuleTrayIcon.cpp:965
-#: src/muuli_wdr.cpp:1391 src/muuli_wdr.cpp:1399 src/muuli_wdr.cpp:1406
-#: src/muuli_wdr.cpp:1835 src/muuli_wdr.cpp:1841 src/OtherFunctions.cpp:91
+#: src/muuli_wdr.cpp:1398 src/muuli_wdr.cpp:1406 src/muuli_wdr.cpp:1413
+#: src/muuli_wdr.cpp:1842 src/muuli_wdr.cpp:1848 src/OtherFunctions.cpp:91
 #: src/StatisticsDlg.cpp:93 src/StatisticsDlg.cpp:95
 msgid "kB/s"
 msgstr "kB/s"
@@ -3262,7 +3267,7 @@ msgstr "名前："
 msgid "Type"
 msgstr "タイプ"
 
-#: src/muuli_wdr.cpp:215 src/SearchDlg.cpp:110 src/SearchListCtrl.cpp:853
+#: src/muuli_wdr.cpp:215 src/SearchDlg.cpp:118 src/SearchListCtrl.cpp:853
 msgid "Local"
 msgstr "ローカル"
 
@@ -3333,7 +3338,7 @@ msgstr "B"
 msgid "KB"
 msgstr "KB"
 
-#: src/muuli_wdr.cpp:274 src/muuli_wdr.cpp:293 src/muuli_wdr.cpp:1620
+#: src/muuli_wdr.cpp:274 src/muuli_wdr.cpp:293 src/muuli_wdr.cpp:1627
 #: src/OtherFunctions.cpp:64
 msgid "MB"
 msgstr "MB"
@@ -3350,7 +3355,7 @@ msgstr "最大サイズ"
 msgid "Availability"
 msgstr "入手可能範囲"
 
-#: src/muuli_wdr.cpp:312 src/muuli_wdr.cpp:398 src/muuli_wdr.cpp:3290
+#: src/muuli_wdr.cpp:312 src/muuli_wdr.cpp:398 src/muuli_wdr.cpp:3297
 msgid "Filter:"
 msgstr "フィルタ："
 
@@ -3382,7 +3387,7 @@ msgstr ""
 msgid "Stop"
 msgstr "中止"
 
-#: src/muuli_wdr.cpp:348 src/muuli_wdr.cpp:1385 src/SearchListCtrl.cpp:732
+#: src/muuli_wdr.cpp:348 src/muuli_wdr.cpp:1392 src/SearchListCtrl.cpp:732
 msgid "Download"
 msgstr "ダウンロード"
 
@@ -3414,8 +3419,8 @@ msgstr "ソース完了"
 #: src/muuli_wdr.cpp:1160 src/muuli_wdr.cpp:1167 src/muuli_wdr.cpp:1172
 #: src/muuli_wdr.cpp:1179 src/muuli_wdr.cpp:1184 src/muuli_wdr.cpp:1191
 #: src/muuli_wdr.cpp:1205 src/muuli_wdr.cpp:1212 src/muuli_wdr.cpp:1217
-#: src/muuli_wdr.cpp:1224 src/muuli_wdr.cpp:3227 src/muuli_wdr.cpp:3235
-#: src/muuli_wdr.cpp:3243
+#: src/muuli_wdr.cpp:1224 src/muuli_wdr.cpp:3234 src/muuli_wdr.cpp:3242
+#: src/muuli_wdr.cpp:3250
 msgid "N/A"
 msgstr "非適用"
 
@@ -3560,7 +3565,7 @@ msgstr ""
 msgid "Album :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:685 src/muuli_wdr.cpp:2247
+#: src/muuli_wdr.cpp:685 src/muuli_wdr.cpp:2254
 msgid "Title :"
 msgstr "タイトル："
 
@@ -3667,7 +3672,7 @@ msgstr "ユーザ名："
 msgid "Userhash :"
 msgstr "ユーザ・ハッシュ："
 
-#: src/muuli_wdr.cpp:895 src/muuli_wdr.cpp:1741 src/muuli_wdr.cpp:2442
+#: src/muuli_wdr.cpp:895 src/muuli_wdr.cpp:1748 src/muuli_wdr.cpp:2449
 #: src/utils/aLinkCreator/src/alcframe.cpp:137
 msgid "Add"
 msgstr "追加"
@@ -3676,15 +3681,15 @@ msgstr "追加"
 msgid "Download-Speed"
 msgstr "ダウンロード速度："
 
-#: src/muuli_wdr.cpp:954 src/muuli_wdr.cpp:989 src/muuli_wdr.cpp:2546
+#: src/muuli_wdr.cpp:954 src/muuli_wdr.cpp:989 src/muuli_wdr.cpp:2553
 msgid "Current"
 msgstr "現在"
 
-#: src/muuli_wdr.cpp:962 src/muuli_wdr.cpp:997 src/muuli_wdr.cpp:2554
+#: src/muuli_wdr.cpp:962 src/muuli_wdr.cpp:997 src/muuli_wdr.cpp:2561
 msgid "Running average"
 msgstr "移動平均"
 
-#: src/muuli_wdr.cpp:970 src/muuli_wdr.cpp:1005 src/muuli_wdr.cpp:2562
+#: src/muuli_wdr.cpp:970 src/muuli_wdr.cpp:1005 src/muuli_wdr.cpp:2569
 msgid "Session average"
 msgstr "セッション平均"
 
@@ -3696,7 +3701,7 @@ msgstr "アップロード速度"
 msgid "Connections"
 msgstr "接続数"
 
-#: src/muuli_wdr.cpp:1024 src/muuli_wdr.cpp:1860
+#: src/muuli_wdr.cpp:1024 src/muuli_wdr.cpp:1867
 msgid "Active downloads"
 msgstr "アクティブなダウンロード数"
 
@@ -3704,7 +3709,7 @@ msgstr "アクティブなダウンロード数"
 msgid "Active connections (1:1)"
 msgstr "アクティブな接続（1:1）"
 
-#: src/muuli_wdr.cpp:1040 src/muuli_wdr.cpp:1861
+#: src/muuli_wdr.cpp:1040 src/muuli_wdr.cpp:1868
 msgid "Active uploads"
 msgstr "アクティブなアップロード数"
 
@@ -3821,8 +3826,8 @@ msgstr "接続してくるユーザはこの名前を見ることになります
 msgid "Language: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1257 src/muuli_wdr.cpp:1323 src/muuli_wdr.cpp:1327
-#: src/muuli_wdr.cpp:1330
+#: src/muuli_wdr.cpp:1257 src/muuli_wdr.cpp:1330 src/muuli_wdr.cpp:1334
+#: src/muuli_wdr.cpp:1337
 msgid "The delay before showing tool-tips."
 msgstr "ツールチップを表示するまでの遅延時間。"
 
@@ -3900,937 +3905,946 @@ msgstr ""
 msgid "Enabling this will make aMule to show notifications when finished downloading."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1322
-msgid "Tooltip delay time: "
+#: src/muuli_wdr.cpp:1323
+#, fuzzy
+msgid "Remember search history"
+msgstr "設定を記憶する"
+
+#: src/muuli_wdr.cpp:1324
+msgid "Keeps a dropdown list of your past search terms in the Search tab's Name field. This remembers the queries you typed, not the results they returned."
 msgstr ""
 
 #: src/muuli_wdr.cpp:1329
+msgid "Tooltip delay time: "
+msgstr ""
+
+#: src/muuli_wdr.cpp:1336
 msgid "seconds"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1333
+#: src/muuli_wdr.cpp:1340
 msgid "Browser Selection"
 msgstr "ブラウザ選択"
 
-#: src/muuli_wdr.cpp:1339
+#: src/muuli_wdr.cpp:1346
 msgid "Enter your browser name here. Leave this field empty to use the system default browser."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1346
+#: src/muuli_wdr.cpp:1353
 msgid "Open in new tab if possible"
 msgstr "可能ならば新しいタブで開く"
 
-#: src/muuli_wdr.cpp:1348
+#: src/muuli_wdr.cpp:1355
 msgid "Open the web page in a new tab instead of in a new window when possible"
 msgstr "可能なら、ウェブ・ページを新しいウインドウではなくて新しいタブで開きます"
 
-#: src/muuli_wdr.cpp:1352
+#: src/muuli_wdr.cpp:1359
 msgid "Video Player"
 msgstr "ビデオ・プレイヤー"
 
-#: src/muuli_wdr.cpp:1379
+#: src/muuli_wdr.cpp:1386
 msgid "Bandwidth limits"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1393
+#: src/muuli_wdr.cpp:1400
 msgid "Upload"
 msgstr "アップロード"
 
-#: src/muuli_wdr.cpp:1401
+#: src/muuli_wdr.cpp:1408
 msgid "Slot Allocation"
 msgstr "スロット割り当て"
 
-#: src/muuli_wdr.cpp:1410
+#: src/muuli_wdr.cpp:1417
 msgid "Ports"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1420
+#: src/muuli_wdr.cpp:1427
 msgid "This is the standard eD2k port and cannot be disabled."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1423
+#: src/muuli_wdr.cpp:1430
 msgid "UDP port for server requests (TCP+3):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1425
+#: src/muuli_wdr.cpp:1432
 msgid "4665"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1432
+#: src/muuli_wdr.cpp:1439
 msgid "This UDP port is used for extended eD2k requests and Kad network"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1439
+#: src/muuli_wdr.cpp:1446
 msgid "UPnP TCP Port (Optional):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1449
+#: src/muuli_wdr.cpp:1456
 msgid "Bind local address to IP (empty for any):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1452
+#: src/muuli_wdr.cpp:1459
 msgid "Advanced users only: If you have multiple network interfaces, enter the address of the interface to which aMule should be bound."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1455 src/muuli_wdr.cpp:2054
+#: src/muuli_wdr.cpp:1462 src/muuli_wdr.cpp:2061
 msgid "Bind to network interface (empty for any):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1468
+#: src/muuli_wdr.cpp:1475
 msgid "Advanced users only: pin all of aMule's traffic to one network interface, chosen from the list or typed in by name (e.g. tun0, eth0, en0) or index. Unlike binding to an IP, this stops traffic leaking out via the default route - useful with a VPN. Requires no elevated privileges."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1474
+#: src/muuli_wdr.cpp:1481
 msgid "Max sources per downloading file:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1478
+#: src/muuli_wdr.cpp:1485
 msgid "Max simultaneous connections:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1491 src/muuli_wdr.cpp:3169
+#: src/muuli_wdr.cpp:1498 src/muuli_wdr.cpp:3176
 msgid "ED2K"
 msgstr "ED2K"
 
-#: src/muuli_wdr.cpp:1498
+#: src/muuli_wdr.cpp:1505
 msgid "Autoconnect on startup"
 msgstr "スタートアップに自動接続する"
 
-#: src/muuli_wdr.cpp:1501
+#: src/muuli_wdr.cpp:1508
 msgid "Reconnect on loss"
 msgstr "接続を失う時に再接続する"
 
-#: src/muuli_wdr.cpp:1523
+#: src/muuli_wdr.cpp:1530
 msgid "Remove dead server after"
 msgstr "再試行後、応答のないサーバを削除する。再試行回数："
 
-#: src/muuli_wdr.cpp:1524
+#: src/muuli_wdr.cpp:1531
 msgid "Static servers are never removed, even when unreachable."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1528
+#: src/muuli_wdr.cpp:1535
 msgid "retries"
 msgstr "回"
 
-#: src/muuli_wdr.cpp:1536
+#: src/muuli_wdr.cpp:1543
 msgid "List"
 msgstr "リスト"
 
-#: src/muuli_wdr.cpp:1539
+#: src/muuli_wdr.cpp:1546
 msgid "Update server list when connecting to a server"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1542
+#: src/muuli_wdr.cpp:1549
 msgid "Update server list when a client connects"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1545
+#: src/muuli_wdr.cpp:1552
 msgid "Use priority system"
 msgstr "優先度システムを使用する"
 
-#: src/muuli_wdr.cpp:1549
+#: src/muuli_wdr.cpp:1556
 msgid "Use smart LowID check on connect"
 msgstr "接続の時にLowIDチェックを使用する"
 
-#: src/muuli_wdr.cpp:1553
+#: src/muuli_wdr.cpp:1560
 msgid "Safe connect"
 msgstr "安全接続"
 
-#: src/muuli_wdr.cpp:1557
+#: src/muuli_wdr.cpp:1564
 msgid "Autoconnect to servers in static list only"
 msgstr "スタティック・リストに含まれているサーバのみに自動接続する"
 
-#: src/muuli_wdr.cpp:1560
+#: src/muuli_wdr.cpp:1567
 msgid "Set manually added servers to High Priority"
 msgstr "手動で追加したサーバを高い優先度に設定する"
 
-#: src/muuli_wdr.cpp:1581
+#: src/muuli_wdr.cpp:1588
 msgid "Add files to download in pause mode"
 msgstr "ダウンロードファイルを停止モードで追加する"
 
-#: src/muuli_wdr.cpp:1583
+#: src/muuli_wdr.cpp:1590
 msgid "Add files to download with auto priority"
 msgstr "ダウンロードファイルを優先度を自動にして追加する"
 
-#: src/muuli_wdr.cpp:1586
+#: src/muuli_wdr.cpp:1593
 msgid "Try to download first and last chunks first"
 msgstr "最初と最後のチャンクを先にダウンロードしようとする"
 
-#: src/muuli_wdr.cpp:1590
+#: src/muuli_wdr.cpp:1597
 msgid "Endgame mode: rotate to faster sources for the final blocks"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1593
+#: src/muuli_wdr.cpp:1600
 msgid "Start next paused file when a file completes"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1596
+#: src/muuli_wdr.cpp:1603
 msgid "From the same category"
 msgstr "同じカテゴリから"
 
-#: src/muuli_wdr.cpp:1598
+#: src/muuli_wdr.cpp:1605
 msgid "In alphabetic order"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1600
+#: src/muuli_wdr.cpp:1607
 msgid "Preallocate disk space for new files"
 msgstr "新しいファイルのためのディスク領域を事前に確保する"
 
-#: src/muuli_wdr.cpp:1601
+#: src/muuli_wdr.cpp:1608
 msgid "For new files preallocates disk space for the whole file, thus reduces fragmentation"
 msgstr "新しいファイルのためにファイル全体が格納できるディスク領域を事前に確保し、断片化を防ぎます。"
 
-#: src/muuli_wdr.cpp:1606
+#: src/muuli_wdr.cpp:1613
 msgid "Create new files as sparse files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1607
+#: src/muuli_wdr.cpp:1614
 msgid "A sparse file reserves its full size on disk immediately without writing real data to it -- fast, but unsupported or slow on some filesystems, and free-space accounting stays optimistic while the download is in progress. Turn this off to grow the file only as data arrives."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1612
+#: src/muuli_wdr.cpp:1619
 msgid "Stop downloads when free disk space reaches "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1613
+#: src/muuli_wdr.cpp:1620
 msgid "Select this if you want aMule to check your disk space"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1617
+#: src/muuli_wdr.cpp:1624
 msgid "Enter here the min disk space desired."
 msgstr "望ましい最小のディスク領域をここに入力してください。"
 
-#: src/muuli_wdr.cpp:1623
+#: src/muuli_wdr.cpp:1630
 msgid "Save 10 sources on rare files (< 20 sources)"
 msgstr "珍しいファイルには10ソースを保存する（<20ソース）"
 
-#: src/muuli_wdr.cpp:1627 src/Statistics.cpp:790
+#: src/muuli_wdr.cpp:1634 src/Statistics.cpp:790
 msgid "Uploads"
 msgstr "アップロード数"
 
-#: src/muuli_wdr.cpp:1630
+#: src/muuli_wdr.cpp:1637
 msgid "Add new shared files with auto priority"
 msgstr "新しい共有ファイルを自動優先度として追加する"
 
-#: src/muuli_wdr.cpp:1636
+#: src/muuli_wdr.cpp:1643
 msgid "Intelligent Corruption Handling (I.C.H.)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1639
+#: src/muuli_wdr.cpp:1646
 msgid "Enable"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1642
+#: src/muuli_wdr.cpp:1649
 msgid "Advanced I.C.H. trusts every hash (not recommended)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1654 src/PrefsUnifiedDlg.cpp:1910
+#: src/muuli_wdr.cpp:1661 src/PrefsUnifiedDlg.cpp:1910
 msgid "Media metadata extraction"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1658
+#: src/muuli_wdr.cpp:1665
 msgid "Extract length / bitrate / codec from shared audio and video files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1660
+#: src/muuli_wdr.cpp:1667
 msgid "When enabled, aMule runs ffprobe on each shared media file to fill in the Length / Bitrate / Codec columns other clients see when they find the file in a search. Requires ffmpeg (the ffprobe binary) to be installed."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1667
+#: src/muuli_wdr.cpp:1674
 msgid "Path to ffprobe:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1672
+#: src/muuli_wdr.cpp:1679
 msgid "Full path to the ffprobe binary. Leave empty to have aMule auto-detect it on startup."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1680
+#: src/muuli_wdr.cpp:1687
 msgid "Detect"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1681
+#: src/muuli_wdr.cpp:1688
 msgid "Search the standard install locations for an ffprobe binary and fill the path field."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1705
+#: src/muuli_wdr.cpp:1712
 msgid ""
 "Completed downloads are stored here. All files in this folder are automatically shared with other peers.\n"
 "If this folder also holds files you don't want to share, point it at an aMule-only sub-folder."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1708
+#: src/muuli_wdr.cpp:1715
 msgid "Pick the folder where completed downloads will be stored. All files in that folder will be shared with other peers."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1722
+#: src/muuli_wdr.cpp:1729
 msgid "Shared folders"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1728
+#: src/muuli_wdr.cpp:1735
 msgid "(Folders shared by the core. Enter a path to add one.)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1736
+#: src/muuli_wdr.cpp:1743
 msgid "Absolute path of a folder on the core's machine, e.g. /home/user/shared"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1738 src/PrefsUnifiedDlg.cpp:2794
+#: src/muuli_wdr.cpp:1745 src/PrefsUnifiedDlg.cpp:2794
 msgid "Recursive"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1739
+#: src/muuli_wdr.cpp:1746
 msgid "Share every sub-folder underneath this one, including ones created later."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1743 src/utils/aLinkCreator/src/alcframe.cpp:141
+#: src/muuli_wdr.cpp:1750 src/utils/aLinkCreator/src/alcframe.cpp:141
 msgid "Remove"
 msgstr "削除"
 
-#: src/muuli_wdr.cpp:1747
+#: src/muuli_wdr.cpp:1754
 msgid "(Right click on folder icon for recursive share)"
 msgstr "（再帰的に共有するにはフォルダ・アイコンを右クリックしてください）"
 
-#: src/muuli_wdr.cpp:1754
+#: src/muuli_wdr.cpp:1761
 msgid "Share hidden files"
 msgstr "隠れたファイルを共有する"
 
-#: src/muuli_wdr.cpp:1760
+#: src/muuli_wdr.cpp:1767
 msgid "Automatically rescan shared folders for changes"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1766
+#: src/muuli_wdr.cpp:1773
 msgid "Follow symbolic links in shared folders"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1772
+#: src/muuli_wdr.cpp:1779
 msgid "Exclude files matching:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1775
+#: src/muuli_wdr.cpp:1782
 msgid "Wildcard patterns separated by '|', e.g. .DS_Store|Thumbs.db|*.tmp. Files whose name matches are not shared. Matching is case-insensitive."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1779
+#: src/muuli_wdr.cpp:1786
 msgid "Patterns are regular expressions"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1780
+#: src/muuli_wdr.cpp:1787
 msgid "When set, the whole field is one regular expression ('|' is alternation). When unset, it is a list of '|'-separated wildcards."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1790
+#: src/muuli_wdr.cpp:1797
 msgid "Show how many shared files the current pattern would exclude."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1811
+#: src/muuli_wdr.cpp:1818
 msgid "Graphs"
 msgstr "グラフ"
 
-#: src/muuli_wdr.cpp:1814 src/muuli_wdr.cpp:1876
+#: src/muuli_wdr.cpp:1821 src/muuli_wdr.cpp:1883
 msgid "Update delay : 5 secs"
 msgstr "アップデート延期：５秒"
 
-#: src/muuli_wdr.cpp:1818
+#: src/muuli_wdr.cpp:1825
 msgid "Time for average graph: 100 mins"
 msgstr "平均グラフの時間：１００分"
 
-#: src/muuli_wdr.cpp:1822
+#: src/muuli_wdr.cpp:1829
 msgid "Connections Graph Scale: 100 "
 msgstr "接続数のグラフスケール：１００"
 
-#: src/muuli_wdr.cpp:1829
+#: src/muuli_wdr.cpp:1836
 msgid "Download graph scale:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1837
+#: src/muuli_wdr.cpp:1844
 msgid "Upload graph scale:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1847
+#: src/muuli_wdr.cpp:1854
 msgid "Colors: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1851
+#: src/muuli_wdr.cpp:1858
 msgid "Background"
 msgstr "背景"
 
-#: src/muuli_wdr.cpp:1852
+#: src/muuli_wdr.cpp:1859
 msgid "Grid"
 msgstr "グリッド"
 
-#: src/muuli_wdr.cpp:1853
+#: src/muuli_wdr.cpp:1860
 msgid "Download current"
 msgstr "ダウンロード現在"
 
-#: src/muuli_wdr.cpp:1854
+#: src/muuli_wdr.cpp:1861
 msgid "Download running average"
 msgstr "ダウンロード移動平均"
 
-#: src/muuli_wdr.cpp:1855
+#: src/muuli_wdr.cpp:1862
 msgid "Download session average"
 msgstr "ダウンロードセッション平均"
 
-#: src/muuli_wdr.cpp:1856
+#: src/muuli_wdr.cpp:1863
 msgid "Upload current"
 msgstr "アップロード現在"
 
-#: src/muuli_wdr.cpp:1857
+#: src/muuli_wdr.cpp:1864
 msgid "Upload running average"
 msgstr "アップロード移動平均"
 
-#: src/muuli_wdr.cpp:1858
+#: src/muuli_wdr.cpp:1865
 msgid "Upload session average"
 msgstr "アップロードセッション平均"
 
-#: src/muuli_wdr.cpp:1859
+#: src/muuli_wdr.cpp:1866
 msgid "Active connections"
 msgstr "アクティブ接続数"
 
-#: src/muuli_wdr.cpp:1862
+#: src/muuli_wdr.cpp:1869
 #, fuzzy
 msgid "Systray Icon Speed Bar"
 msgstr "システム・トレイ・アイコン・スピードバー"
 
-#: src/muuli_wdr.cpp:1863
+#: src/muuli_wdr.cpp:1870
 msgid "Kad-nodes current"
 msgstr "現在のKadノード数"
 
-#: src/muuli_wdr.cpp:1864
+#: src/muuli_wdr.cpp:1871
 msgid "Kad-nodes running"
 msgstr "動作中のKadノード数"
 
-#: src/muuli_wdr.cpp:1865
+#: src/muuli_wdr.cpp:1872
 msgid "Kad-nodes session"
 msgstr "セッションのKadノード数"
 
-#: src/muuli_wdr.cpp:1869 src/muuli_wdr.cpp:2296
+#: src/muuli_wdr.cpp:1876 src/muuli_wdr.cpp:2303
 msgid "Select"
 msgstr "選択"
 
-#: src/muuli_wdr.cpp:1873
+#: src/muuli_wdr.cpp:1880
 msgid "Tree"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1883
+#: src/muuli_wdr.cpp:1890
 msgid "Number of Client Versions shown (0=unlimited)"
 msgstr "表示されているクライアントのバージョン数（0＝無制限）"
 
-#: src/muuli_wdr.cpp:1908
+#: src/muuli_wdr.cpp:1915
 msgid "!!! WARNING !!!"
 msgstr "！！！注意！！！"
 
-#: src/muuli_wdr.cpp:1923
+#: src/muuli_wdr.cpp:1930
 msgid "Max new connections / 5 secs"
 msgstr "最大の新しい接続数（5秒ごと）"
 
-#: src/muuli_wdr.cpp:1925
+#: src/muuli_wdr.cpp:1932
 msgid "Concurrent Kad source lookups"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1927
+#: src/muuli_wdr.cpp:1934
 #, fuzzy
 msgid "Kad source re-search interval (minutes)"
 msgstr "FTPアップデートレート間隔（分）"
 
-#: src/muuli_wdr.cpp:1929
+#: src/muuli_wdr.cpp:1936
 #, fuzzy
 msgid "Source re-ask interval (minutes)"
 msgstr "FTPアップデートレート間隔（分）"
 
-#: src/muuli_wdr.cpp:1933
+#: src/muuli_wdr.cpp:1940
 msgid "File Buffer Size: 240000 bytes"
 msgstr "ファイル・バファー・サイズ：240000バイト"
 
-#: src/muuli_wdr.cpp:1937
+#: src/muuli_wdr.cpp:1944
 msgid "Use MMAP: memory-mapped file access (lower memory use)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1938
+#: src/muuli_wdr.cpp:1945
 msgid "Maps part files into memory instead of buffering them on the heap, lowering the process memory footprint. May reduce download speed on some disks; best for memory-constrained or upload-heavy hosts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1940
+#: src/muuli_wdr.cpp:1947
 msgid "Upload Queue Size: 5000 clients"
 msgstr "アップロードキューサイズ：5000クライアント"
 
-#: src/muuli_wdr.cpp:1944
+#: src/muuli_wdr.cpp:1951
 msgid "Server connection refresh interval: Disable"
 msgstr "サーバ接続のリフレッシュ空間：無効にする"
 
-#: src/muuli_wdr.cpp:1948
+#: src/muuli_wdr.cpp:1955
 msgid "Disable computer's timed standby mode"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1967
+#: src/muuli_wdr.cpp:1974
 msgid "Skin to use: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1976
+#: src/muuli_wdr.cpp:1983
 msgid "Show \"Fast eD2k Links Handler\" in every window."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1979
+#: src/muuli_wdr.cpp:1986
 msgid "Show extended info on categories tabs"
 msgstr "延長情報をカテゴリ・タブで表示する"
 
-#: src/muuli_wdr.cpp:1982
+#: src/muuli_wdr.cpp:1989
 #, fuzzy
 msgid "Show application version on title"
 msgstr "タイトルに転送速度を表示する"
 
-#: src/muuli_wdr.cpp:1984
+#: src/muuli_wdr.cpp:1991
 msgid "Show transfer rates on title"
 msgstr "タイトルに転送速度を表示する"
 
-#: src/muuli_wdr.cpp:1986
+#: src/muuli_wdr.cpp:1993
 msgid "Before application name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1988
+#: src/muuli_wdr.cpp:1995
 msgid "After application name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1991
+#: src/muuli_wdr.cpp:1998
 msgid "Show overhead bandwidth"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1995
+#: src/muuli_wdr.cpp:2002
 msgid "Vertical toolbar orientation"
 msgstr "垂直ツールバー"
 
-#: src/muuli_wdr.cpp:1997
+#: src/muuli_wdr.cpp:2004
 msgid "Live column sorting (auto-reorder rows as their values change)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2004
+#: src/muuli_wdr.cpp:2011
 msgid "Download Queue Files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2007
+#: src/muuli_wdr.cpp:2014
 msgid "Show progress percentage"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2013
+#: src/muuli_wdr.cpp:2020
 msgid "Show progress bar"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2016
+#: src/muuli_wdr.cpp:2023
 msgid "Flat"
 msgstr "フラット"
 
-#: src/muuli_wdr.cpp:2020
+#: src/muuli_wdr.cpp:2027
 msgid "Round"
 msgstr "ラウンド"
 
-#: src/muuli_wdr.cpp:2038
+#: src/muuli_wdr.cpp:2045
 msgid "External Connection Parameters"
 msgstr "外部接続のパラメタ"
 
-#: src/muuli_wdr.cpp:2041
+#: src/muuli_wdr.cpp:2048
 msgid "Accept external connections"
 msgstr "外部接続を許可にする"
 
-#: src/muuli_wdr.cpp:2048 src/muuli_wdr.cpp:2107
+#: src/muuli_wdr.cpp:2055 src/muuli_wdr.cpp:2114
 msgid "IP of the listening interface:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2051
+#: src/muuli_wdr.cpp:2058
 msgid "Enter here a valid ip in the a.b.c.d format for the listening EC interface. An empty field or 0.0.0.0 will mean any interface."
 msgstr "リスンしているECインターフェイス用の正当なIPアドレスをa.b.c.dのフォーマットで入力してください。空のフィールド、または0.0.0.0は任意のインターフェイスを意味します。"
 
-#: src/muuli_wdr.cpp:2072 src/muuli_wdr.cpp:2156
+#: src/muuli_wdr.cpp:2079 src/muuli_wdr.cpp:2163
 msgid "TCP port:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2078
+#: src/muuli_wdr.cpp:2085
 msgid "Enable UPnP port forwarding on the EC port"
 msgstr "ECポートでUPnPポート転送を有効にする"
 
-#: src/muuli_wdr.cpp:2082 src/muuli_wdr.cpp:3041
+#: src/muuli_wdr.cpp:2089 src/muuli_wdr.cpp:3048
 #: src/utils/wxCas/src/wxcasprefs.cpp:167
 msgid "Password"
 msgstr "パスワード"
 
-#: src/muuli_wdr.cpp:2088
+#: src/muuli_wdr.cpp:2095
 msgid "aMule API server parameters"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2091
+#: src/muuli_wdr.cpp:2098
 msgid "Run amuleapi (REST API) on startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2096
+#: src/muuli_wdr.cpp:2103
 #, fuzzy
 msgid "HTTP port:"
 msgstr "プロクシー・ポート："
 
-#: src/muuli_wdr.cpp:2110
+#: src/muuli_wdr.cpp:2117
 msgid "The interface amuleapi's HTTP server listens on. 127.0.0.1 (default) accepts only local connections; use 0.0.0.0 or a specific IP to expose it to other hosts (set an admin password below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2113
+#: src/muuli_wdr.cpp:2120
 #, fuzzy
 msgid "Admin password"
 msgstr "パスワードをチェック中です\n"
 
-#: src/muuli_wdr.cpp:2118 src/muuli_wdr.cpp:2149
+#: src/muuli_wdr.cpp:2125 src/muuli_wdr.cpp:2156
 msgid "Low rights password"
 msgstr "低権限パスワード"
 
-#: src/muuli_wdr.cpp:2126
+#: src/muuli_wdr.cpp:2133
 msgid "Web server parameters"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2129
+#: src/muuli_wdr.cpp:2136
 msgid "Run webserver on startup (deprecated)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2135
+#: src/muuli_wdr.cpp:2142
 msgid "Web template"
 msgstr "ウェブテンプレート"
 
-#: src/muuli_wdr.cpp:2140
+#: src/muuli_wdr.cpp:2147
 msgid "Full rights password"
 msgstr "全権限パスワード"
 
-#: src/muuli_wdr.cpp:2144
+#: src/muuli_wdr.cpp:2151
 msgid "Enable Low rights User"
 msgstr "低権限ユーザを有効にする"
 
-#: src/muuli_wdr.cpp:2163
+#: src/muuli_wdr.cpp:2170
 msgid "Enable UPnP port forwarding of the web server port"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2168
+#: src/muuli_wdr.cpp:2175
 msgid "Web server UPnP TCP port (Optional)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2176
+#: src/muuli_wdr.cpp:2183
 msgid "Page Refresh Time (in secs)"
 msgstr "ページのリフレッシュ間隔（秒単位）"
 
-#: src/muuli_wdr.cpp:2183
+#: src/muuli_wdr.cpp:2190
 msgid "Enable Gzip compression"
 msgstr "gzip圧縮を有効にする"
 
-#: src/muuli_wdr.cpp:2217
+#: src/muuli_wdr.cpp:2224
 #, fuzzy
 msgid "Reset page to defaults"
 msgstr "システムの標準設定"
 
-#: src/muuli_wdr.cpp:2218
+#: src/muuli_wdr.cpp:2225
 msgid "Reset the settings on the current page to their default values."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2220 src/muuli_wdr.cpp:2306 src/ServerWnd.cpp:274
+#: src/muuli_wdr.cpp:2227 src/muuli_wdr.cpp:2313 src/ServerWnd.cpp:274
 #: src/ServerWnd.cpp:282
 msgid "OK"
 msgstr "OK"
 
-#: src/muuli_wdr.cpp:2222
+#: src/muuli_wdr.cpp:2229
 msgid "Click here to apply any changes made to the preferences."
 msgstr "設定の変更をすべて適用します。"
 
-#: src/muuli_wdr.cpp:2225
+#: src/muuli_wdr.cpp:2232
 msgid "Reset any changes made to the preferences."
 msgstr "設定の変更を全てリセットする"
 
-#: src/muuli_wdr.cpp:2254
+#: src/muuli_wdr.cpp:2261
 msgid "Comment :"
 msgstr "コメント："
 
-#: src/muuli_wdr.cpp:2261
+#: src/muuli_wdr.cpp:2268
 msgid "Incoming Dir :"
 msgstr "受信ディレクトリ："
 
-#: src/muuli_wdr.cpp:2270
+#: src/muuli_wdr.cpp:2277
 msgid "Change priority for new assigned files :"
 msgstr "新しく割り当てられたファイルの優先度を変更する："
 
-#: src/muuli_wdr.cpp:2274
+#: src/muuli_wdr.cpp:2281
 #, fuzzy
 msgid "Don't change"
 msgstr "変更しない"
 
-#: src/muuli_wdr.cpp:2286
+#: src/muuli_wdr.cpp:2293
 msgid "Select color for this Category (currently selected) :"
 msgstr "このカテゴリの色を選択する（現在選択中）："
 
-#: src/muuli_wdr.cpp:2353 src/muuli_wdr.cpp:2372 src/muuli_wdr.cpp:2394
+#: src/muuli_wdr.cpp:2360 src/muuli_wdr.cpp:2379 src/muuli_wdr.cpp:2401
 msgid "Click this button to reset the log."
 msgstr "このボタンをクリックするとログのリセットが行います。"
 
-#: src/muuli_wdr.cpp:2413
+#: src/muuli_wdr.cpp:2420
 msgid "Click on this button to update the servers list from URL ..."
 msgstr "このボタンをクリックするとサーバ・リストはURLから最新化する..."
 
-#: src/muuli_wdr.cpp:2417
+#: src/muuli_wdr.cpp:2424
 msgid "Server list"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2421
+#: src/muuli_wdr.cpp:2428
 msgid "Enter the url to a server.met file here and press the button to the left to update the list of known servers."
 msgstr "server.metファイルへのURLをここに入力してから左側のボタンをクリックすると、既知のサーバのリストがアップデートされます。"
 
-#: src/muuli_wdr.cpp:2426
+#: src/muuli_wdr.cpp:2433
 msgid "Add server manually: Name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2429
+#: src/muuli_wdr.cpp:2436
 msgid "Enter the name of the new server here"
 msgstr "新しいサーバの名前をここに入力してください"
 
-#: src/muuli_wdr.cpp:2431 src/ServerWnd.cpp:206
+#: src/muuli_wdr.cpp:2438 src/ServerWnd.cpp:206
 msgid "IP:Port"
 msgstr "IP:ポート"
 
-#: src/muuli_wdr.cpp:2434
+#: src/muuli_wdr.cpp:2441
 msgid "Enter the IP of the server here, using the x.x.x.x format."
 msgstr "x.x.x.xフォーマットでサーバのIPアドレスを入力してください。"
 
-#: src/muuli_wdr.cpp:2440
+#: src/muuli_wdr.cpp:2447
 msgid "Enter the port of the server here."
 msgstr "サーバのポートをここに入力してください。"
 
-#: src/muuli_wdr.cpp:2443
+#: src/muuli_wdr.cpp:2450
 msgid "Add manually a server (fill fields to the left before) ..."
 msgstr "手動でサーバを追加する（先に左側のフィールドを入力してください）..."
 
-#: src/muuli_wdr.cpp:2472
+#: src/muuli_wdr.cpp:2479
 msgid "aMule Log"
 msgstr "aMuleのログ"
 
-#: src/muuli_wdr.cpp:2480
+#: src/muuli_wdr.cpp:2487
 msgid "Server Info"
 msgstr "サーバ情報"
 
-#: src/muuli_wdr.cpp:2484
+#: src/muuli_wdr.cpp:2491
 msgid "ED2K Info"
 msgstr "ED2K情報"
 
-#: src/muuli_wdr.cpp:2488
+#: src/muuli_wdr.cpp:2495
 msgid "Kad Info"
 msgstr "Kad情報"
 
-#: src/muuli_wdr.cpp:2516
+#: src/muuli_wdr.cpp:2523
 msgid "Click on this button to update the nodes list from URL ..."
 msgstr "このボタンをクリックするとノード・リストをURLからアップデートします..."
 
-#: src/muuli_wdr.cpp:2520
+#: src/muuli_wdr.cpp:2527
 msgid "Nodes (0)"
 msgstr "ノード数（0）"
 
-#: src/muuli_wdr.cpp:2524
+#: src/muuli_wdr.cpp:2531
 msgid "Enter the url to a nodes.dat file here and press the button to the left to update the list of known nodes."
 msgstr "ここにnodes.datファイルへのURLを入力してから左側のボタンをクリックすると、既知のノード・リストをアップデートします。"
 
-#: src/muuli_wdr.cpp:2527
+#: src/muuli_wdr.cpp:2534
 msgid "Nodes stats"
 msgstr "ノードの統計"
 
-#: src/muuli_wdr.cpp:2569
+#: src/muuli_wdr.cpp:2576
 msgid "Bootstrap"
 msgstr "ブートストラップ"
 
-#: src/muuli_wdr.cpp:2572
+#: src/muuli_wdr.cpp:2579
 msgid "New node"
 msgstr "新しいノード"
 
-#: src/muuli_wdr.cpp:2577
+#: src/muuli_wdr.cpp:2584
 msgid "IP:"
 msgstr "IP："
 
-#: src/muuli_wdr.cpp:2597
+#: src/muuli_wdr.cpp:2604
 msgid "Port:"
 msgstr "ポート："
 
-#: src/muuli_wdr.cpp:2610
+#: src/muuli_wdr.cpp:2617
 #, fuzzy
 msgid "Bootstrap from known clients"
 msgstr ""
 "既知のクライアントから\n"
 "ブートストラップする"
 
-#: src/muuli_wdr.cpp:2612
+#: src/muuli_wdr.cpp:2619
 msgid "Disconnect Kad"
 msgstr "Kadを切断する"
 
-#: src/muuli_wdr.cpp:2646
+#: src/muuli_wdr.cpp:2653
 msgid "Use Secure User Identification"
 msgstr "セキュア・ユーザ保証（SUI）を使用する"
 
-#: src/muuli_wdr.cpp:2648
+#: src/muuli_wdr.cpp:2655
 msgid "It is recommended to enable this option. You will not receive credits if SUI is not enabled."
 msgstr "このオプションを有効にするのは推奨されます。SUIが有効でないとあなたはクレジットを得られません。"
 
-#: src/muuli_wdr.cpp:2650
+#: src/muuli_wdr.cpp:2657
 msgid "Protocol Obfuscation"
 msgstr "プロトコルを難読化する"
 
-#: src/muuli_wdr.cpp:2653
+#: src/muuli_wdr.cpp:2660
 msgid "Support Protocol Obfuscation"
 msgstr "プロトコルの難読化を有効にする"
 
-#: src/muuli_wdr.cpp:2655
+#: src/muuli_wdr.cpp:2662
 msgid "This option enabled Protocol Obfuscation, and makes aMule accept obfuscated connections from other clients."
 msgstr "このオプションによってプロトコルの難読化を有効にできます。そうすると、aMuleは他のクライアントからの難読化された接続を受け入れられます。"
 
-#: src/muuli_wdr.cpp:2657
+#: src/muuli_wdr.cpp:2664
 msgid "Use obfuscation for outgoing connections"
 msgstr "外方向の接続に難読化を使用する"
 
-#: src/muuli_wdr.cpp:2659
+#: src/muuli_wdr.cpp:2666
 msgid "This option makes aMule use Protocol Obfuscation when connecting other clients/servers."
 msgstr "このオプションによって、aMuleは他のサーバまたはクライアントに接続する時にプロトコル難読化を使用します。"
 
-#: src/muuli_wdr.cpp:2661
+#: src/muuli_wdr.cpp:2668
 msgid "Accept only obfuscated connections"
 msgstr "難読化された接続のみを受信する"
 
-#: src/muuli_wdr.cpp:2662
+#: src/muuli_wdr.cpp:2669
 msgid "This option makes aMule only accept obfuscated connections. You will have less sources, but all your traffic will be obfuscated"
 msgstr "このオプションによって、aMuleは難読化された接続のみを受信します。ソース数が減りますが、トラフィックが全て難読化されます。"
 
-#: src/muuli_wdr.cpp:2667
+#: src/muuli_wdr.cpp:2674
 msgid "Everybody"
 msgstr "全員"
 
-#: src/muuli_wdr.cpp:2669
+#: src/muuli_wdr.cpp:2676
 msgid "No one"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2671
+#: src/muuli_wdr.cpp:2678
 msgid "Who can see my shared files:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2672
+#: src/muuli_wdr.cpp:2679
 msgid "Select who can request to view a list of your shared files."
 msgstr "あなたの共有ファイル・リストを要求できるユーザを選択してください。"
 
-#: src/muuli_wdr.cpp:2674
+#: src/muuli_wdr.cpp:2681
 msgid "IP-Filtering"
 msgstr "IPフィルタリング"
 
-#: src/muuli_wdr.cpp:2681
+#: src/muuli_wdr.cpp:2688
 msgid "Filter clients"
 msgstr "クライアントをフィルタする"
 
-#: src/muuli_wdr.cpp:2683
+#: src/muuli_wdr.cpp:2690
 msgid "Enable filtering of the client IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "~/.aMule/ipfilter.datに登録されちるクライアントIPにフィルタリングをかけることを有効にします。"
 
-#: src/muuli_wdr.cpp:2685
+#: src/muuli_wdr.cpp:2692
 msgid "Filter servers"
 msgstr "サーバをフィルタする"
 
-#: src/muuli_wdr.cpp:2687
+#: src/muuli_wdr.cpp:2694
 msgid "Enable filtering of the server IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "~/.aMule/ipfilter.datに登録されちるサーバIPにフィルタリングをかけることを有効にします。"
 
-#: src/muuli_wdr.cpp:2691
+#: src/muuli_wdr.cpp:2698
 msgid "Reload List"
 msgstr "リストを再ロードする"
 
-#: src/muuli_wdr.cpp:2692
+#: src/muuli_wdr.cpp:2699
 msgid "Reload the list of IPs to filter from the file ~/.aMule/ipfilter.dat"
 msgstr "フィルタリングをかける目標のIPリストを~/.aMule/ipfilter.datから再ロードをします。"
 
-#: src/muuli_wdr.cpp:2698
+#: src/muuli_wdr.cpp:2705
 msgid "URL:"
 msgstr "URL："
 
-#: src/muuli_wdr.cpp:2702 src/muuli_wdr.cpp:2895
+#: src/muuli_wdr.cpp:2709 src/muuli_wdr.cpp:2902
 msgid "Update now"
 msgstr "只今アップデートする"
 
-#: src/muuli_wdr.cpp:2705
+#: src/muuli_wdr.cpp:2712
 msgid "Auto-update ipfilter at startup"
 msgstr "スタートアップの時にipfilterを自動アップデートする"
 
-#: src/muuli_wdr.cpp:2709
+#: src/muuli_wdr.cpp:2716
 msgid "Filtering Level:"
 msgstr "フィルタリング段階："
 
-#: src/muuli_wdr.cpp:2715
+#: src/muuli_wdr.cpp:2722
 msgid "Always filter LAN IPs"
 msgstr "いつもLANのIPにフィルタリングをかける"
 
-#: src/muuli_wdr.cpp:2718
+#: src/muuli_wdr.cpp:2725
 msgid "Paranoid handling of non-matching IPs"
 msgstr "適合しないIPを被害妄想的に扱う"
 
-#: src/muuli_wdr.cpp:2720
+#: src/muuli_wdr.cpp:2727
 msgid "Rejects a packet when its source IP differs from the IP the client claims (an anti-spoofing check). Disable only if it causes connection problems."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2722
+#: src/muuli_wdr.cpp:2729
 msgid "Use system-wide ipfilter.dat if available"
 msgstr "提供されていれば、全システム応用のipfilter.datファイルを使用する"
 
-#: src/muuli_wdr.cpp:2723
+#: src/muuli_wdr.cpp:2730
 #, fuzzy
 msgid "If there's no local ipfilter.dat found, allow usage of a system-wide ipfilter file."
 msgstr "ローカルなipfilter.datファイルが見つからなければ、全システム応用のipfilter.datファイルを使用可能します。"
 
-#: src/muuli_wdr.cpp:2740
+#: src/muuli_wdr.cpp:2747
 msgid "Enable Online-Signature"
 msgstr "オンライン証明を有効にする"
 
-#: src/muuli_wdr.cpp:2742
+#: src/muuli_wdr.cpp:2749
 msgid "Enables the writing of the OS file, which can be used by external apps to create signatures and the like."
 msgstr "OSファイルの書き込みを有効にします。このファイルは外のアプリケーションに証明等を作成するためにを使用されます。"
 
-#: src/muuli_wdr.cpp:2746
+#: src/muuli_wdr.cpp:2753
 msgid "Update Frequency (Secs):"
 msgstr "アップデート頻度（秒単位）"
 
-#: src/muuli_wdr.cpp:2749
+#: src/muuli_wdr.cpp:2756
 msgid "Change the frequency (in seconds) of Online Signature updates."
 msgstr "オンライン証明アップデート頻度（秒単位）を変化します。"
 
-#: src/muuli_wdr.cpp:2757
+#: src/muuli_wdr.cpp:2764
 msgid "Save online signature file in: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:2763
+#: src/muuli_wdr.cpp:2770
 msgid "Click here to select the directory containing the the Online Signature files."
 msgstr "ここをクリックするとオンライン証明ファイルが入っているディレクトリを選択できます。"
 
-#: src/muuli_wdr.cpp:2796
+#: src/muuli_wdr.cpp:2803
 msgid "Show country flags for clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2797
+#: src/muuli_wdr.cpp:2804
 msgid "Render the country flag column in the transfers, queue and search views. Requires a valid MMDB GeoIP database (see below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2802
+#: src/muuli_wdr.cpp:2809
 #, fuzzy
 msgid "Database"
 msgstr "データ・レート："
 
-#: src/muuli_wdr.cpp:2818
+#: src/muuli_wdr.cpp:2825
 #, fuzzy
 msgid "Source:"
 msgstr "ソース数"
 
-#: src/muuli_wdr.cpp:2821
+#: src/muuli_wdr.cpp:2828
 msgid "DB-IP (free, no account)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2822
+#: src/muuli_wdr.cpp:2829
 msgid "MaxMind GeoLite2 (free, account required)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2823
+#: src/muuli_wdr.cpp:2830
 msgid "Custom URL"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2826
+#: src/muuli_wdr.cpp:2833
 msgid "Choose which provider supplies the GeoIP MMDB database. DB-IP is the default - no account required. MaxMind requires a free account + license key. Use Custom URL to point at any other MMDB host (e.g. a local mirror)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2843
+#: src/muuli_wdr.cpp:2850
 msgid ""
 "No configuration required.\n"
 "\n"
@@ -4838,11 +4852,11 @@ msgid ""
 "License: Creative Commons BY 4.0 - https://creativecommons.org/licenses/by/4.0/"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2856
+#: src/muuli_wdr.cpp:2863
 msgid "License key:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2862
+#: src/muuli_wdr.cpp:2869
 msgid ""
 "Sign up for a free MaxMind account, then generate a License Key:\n"
 "https://www.maxmind.com/en/geolite2/signup\n"
@@ -4852,232 +4866,232 @@ msgid ""
 "Requires attribution and account registration; refresh at least every 30 days."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2877
+#: src/muuli_wdr.cpp:2884
 #, fuzzy
 msgid "Download URL:"
 msgstr "ダウンロード： "
 
-#: src/muuli_wdr.cpp:2883
+#: src/muuli_wdr.cpp:2890
 msgid ""
 "Must point to an .mmdb file or a .gz / .tar.gz containing one.\n"
 "URL may include credentials (https://user:pass@host/...).\n"
 "License and attribution terms are set by the upstream URL - you are responsible."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2896
+#: src/muuli_wdr.cpp:2903
 msgid "Download the GeoIP database from the selected source."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2898
+#: src/muuli_wdr.cpp:2905
 #, fuzzy
 msgid "Auto-update on startup"
 msgstr "スタートアップの時にipfilterを自動アップデートする"
 
-#: src/muuli_wdr.cpp:2899
+#: src/muuli_wdr.cpp:2906
 msgid "Re-download the GeoIP database from the selected source every time aMule starts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2922
+#: src/muuli_wdr.cpp:2929
 msgid "Filter incoming messages (except current chat):"
 msgstr "受信メッセージをフィルタする（現在のチャットを除く）："
 
-#: src/muuli_wdr.cpp:2924
+#: src/muuli_wdr.cpp:2931
 msgid "Filter all messages"
 msgstr "全てのメッセージをフィルタする"
 
-#: src/muuli_wdr.cpp:2926
+#: src/muuli_wdr.cpp:2933
 msgid "Filter messages from people not on your friend list"
 msgstr "友達リストの入っていない方々からのメッセージをフィルタする"
 
-#: src/muuli_wdr.cpp:2928
+#: src/muuli_wdr.cpp:2935
 msgid "Filter messages from unknown clients"
 msgstr "知らないクライアントからのメッセージをフィルタする"
 
-#: src/muuli_wdr.cpp:2930
+#: src/muuli_wdr.cpp:2937
 msgid "Filter messages containing (use ',' as separator):"
 msgstr "次のストリングが入っているメッセージをフィルタする（','で区分する）："
 
-#: src/muuli_wdr.cpp:2933 src/muuli_wdr.cpp:2944
+#: src/muuli_wdr.cpp:2940 src/muuli_wdr.cpp:2951
 msgid "add here the words amule should filter and block messages including it"
 msgstr "amuleがメッセージ・フィルタ／ブロックの目標にする言葉をここに追加してください"
 
-#: src/muuli_wdr.cpp:2935
+#: src/muuli_wdr.cpp:2942
 msgid "Show received messages in the log"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2938
+#: src/muuli_wdr.cpp:2945
 msgid "Comments"
 msgstr "コメント"
 
-#: src/muuli_wdr.cpp:2941
+#: src/muuli_wdr.cpp:2948
 msgid "Filter comments containing (use ',' as separator):"
 msgstr "次のストリングが入っていコメントをフィルタする（','で区分する）："
 
-#: src/muuli_wdr.cpp:2966
+#: src/muuli_wdr.cpp:2973
 msgid "Enable Proxy"
 msgstr "プロクシを有効にする"
 
-#: src/muuli_wdr.cpp:2967
+#: src/muuli_wdr.cpp:2974
 msgid "Enable/disable proxy support"
 msgstr "プロクシ・サポートを有効／無効にする"
 
-#: src/muuli_wdr.cpp:2970
+#: src/muuli_wdr.cpp:2977
 msgid "Proxy type:"
 msgstr "プロクシの種類："
 
-#: src/muuli_wdr.cpp:2981
+#: src/muuli_wdr.cpp:2988
 msgid "Proxy host:"
 msgstr "プロクシー・ホスト："
 
-#: src/muuli_wdr.cpp:2984
+#: src/muuli_wdr.cpp:2991
 msgid "The proxy host name"
 msgstr "プロクシー・ホスト名："
 
-#: src/muuli_wdr.cpp:2986
+#: src/muuli_wdr.cpp:2993
 msgid "Proxy port:"
 msgstr "プロクシー・ポート："
 
-#: src/muuli_wdr.cpp:2989
+#: src/muuli_wdr.cpp:2996
 msgid "The proxy port"
 msgstr "プロクシーのポート"
 
-#: src/muuli_wdr.cpp:2991
+#: src/muuli_wdr.cpp:2998
 msgid "Enable authentication"
 msgstr "認証を有効にする"
 
-#: src/muuli_wdr.cpp:2992
+#: src/muuli_wdr.cpp:2999
 msgid "Enable/disable username/password authentication"
 msgstr "ユーザ名／パスワード認証を有効／無効にする"
 
-#: src/muuli_wdr.cpp:2995
+#: src/muuli_wdr.cpp:3002
 msgid "Username: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:2998
+#: src/muuli_wdr.cpp:3005
 msgid "The username to use to connect to the proxy"
 msgstr "プロクシーに接続に使うユーザ名"
 
-#: src/muuli_wdr.cpp:3000
+#: src/muuli_wdr.cpp:3007
 msgid "Password:"
 msgstr "パスワード："
 
-#: src/muuli_wdr.cpp:3003
+#: src/muuli_wdr.cpp:3010
 msgid "The password to use to connect to the proxy"
 msgstr "プロクシーに接続に使うパスワード"
 
-#: src/muuli_wdr.cpp:3022
+#: src/muuli_wdr.cpp:3029
 msgid "Connect to:"
 msgstr "次に接続する："
 
-#: src/muuli_wdr.cpp:3031
+#: src/muuli_wdr.cpp:3038
 msgid "Login to remote amule"
 msgstr "リモートamuleにログインする"
 
-#: src/muuli_wdr.cpp:3036
+#: src/muuli_wdr.cpp:3043
 msgid "User name"
 msgstr "ユーザ名"
 
-#: src/muuli_wdr.cpp:3047
+#: src/muuli_wdr.cpp:3054
 msgid "Remember those settings"
 msgstr "設定を記憶する"
 
-#: src/muuli_wdr.cpp:3050
+#: src/muuli_wdr.cpp:3057
 #, fuzzy
 msgid "Force ZLIB compression"
 msgstr "gzip圧縮を使用する"
 
-#: src/muuli_wdr.cpp:3074
+#: src/muuli_wdr.cpp:3081
 msgid "Enable Verbose Debug-Logging."
 msgstr "冗長なデバッグ・ロギングを有効にする"
 
-#: src/muuli_wdr.cpp:3076
+#: src/muuli_wdr.cpp:3083
 #, fuzzy
 msgid "Only to Logfile"
 msgstr "ファイルを開く(&O)"
 
-#: src/muuli_wdr.cpp:3078
+#: src/muuli_wdr.cpp:3085
 msgid "Message Categories:"
 msgstr "メッセージのカテゴリ："
 
-#: src/muuli_wdr.cpp:3102 src/PartFileConvertDlg.cpp:160
+#: src/muuli_wdr.cpp:3109 src/PartFileConvertDlg.cpp:160
 msgid "Waiting..."
 msgstr "待機中…"
 
-#: src/muuli_wdr.cpp:3122
+#: src/muuli_wdr.cpp:3129
 msgid "Add imports"
 msgstr "インポートを追加する"
 
-#: src/muuli_wdr.cpp:3125
+#: src/muuli_wdr.cpp:3132
 msgid "Retry selected"
 msgstr "選択したものを再試行"
 
-#: src/muuli_wdr.cpp:3127
+#: src/muuli_wdr.cpp:3134
 msgid "Remove selected"
 msgstr "選択したものを破棄"
 
-#: src/muuli_wdr.cpp:3190
+#: src/muuli_wdr.cpp:3197
 msgid "Event Types"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3209
+#: src/muuli_wdr.cpp:3216
 msgid "Statistics and queued clients for selected file(s) : Session / All time"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3233
+#: src/muuli_wdr.cpp:3240
 #, fuzzy
 msgid "Active Uploads"
 msgstr "アクティブなアップロード数："
 
-#: src/muuli_wdr.cpp:3247
+#: src/muuli_wdr.cpp:3254
 msgid "Percent of total files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3299
+#: src/muuli_wdr.cpp:3306
 #, fuzzy
 msgid "Show Clients for"
 msgstr "クライアントを表示する"
 
-#: src/muuli_wdr.cpp:3301
+#: src/muuli_wdr.cpp:3308
 #, fuzzy
 msgid "All files"
 msgstr "共有ファイルを隠す"
 
-#: src/muuli_wdr.cpp:3304
+#: src/muuli_wdr.cpp:3311
 #, fuzzy
 msgid "Selected files"
 msgstr "ビュー・フィルタを選択してください"
 
-#: src/muuli_wdr.cpp:3307
+#: src/muuli_wdr.cpp:3314
 #, fuzzy
 msgid "Active uploads only"
 msgstr "アクティブなアップロード数"
 
-#: src/muuli_wdr.cpp:3314
+#: src/muuli_wdr.cpp:3321
 #, fuzzy
 msgid "Reload:"
 msgstr "リストを再ロードする"
 
-#: src/muuli_wdr.cpp:3318
+#: src/muuli_wdr.cpp:3325
 msgid "Reload your shared files"
 msgstr "共有ファイルを再ロードする"
 
-#: src/muuli_wdr.cpp:3381
+#: src/muuli_wdr.cpp:3388
 msgid "Send"
 msgstr "送信する"
 
-#: src/muuli_wdr.cpp:3382
+#: src/muuli_wdr.cpp:3389
 msgid "Sends the specified message."
 msgstr "指示するメッセージを送信します。"
 
-#: src/muuli_wdr.cpp:3386
+#: src/muuli_wdr.cpp:3393
 msgid "Close this chat-session."
 msgstr "チャット・セションを閉じます。"
 
-#: src/muuli_wdr.cpp:3409
+#: src/muuli_wdr.cpp:3416
 msgid "Connect to any server and/or Kad"
 msgstr "すべてのサーバ、もしくはKadに接続する"
 
-#: src/muuli_wdr.cpp:3415 src/SharedFilesCtrl.cpp:142 src/Statistics.cpp:941
+#: src/muuli_wdr.cpp:3422 src/SharedFilesCtrl.cpp:142 src/Statistics.cpp:941
 msgid "Shared Files"
 msgstr "共有ファイル"
 
@@ -5434,192 +5448,192 @@ msgstr "ダウンロード済み"
 msgid "ERROR: Failed to open partfile '%s'"
 msgstr "エラー: 部分ファイル '%s' が開けませんでした"
 
-#: src/Preferences.cpp:673
+#: src/Preferences.cpp:674
 msgid "System default"
 msgstr "システムの標準設定"
 
-#: src/Preferences.cpp:674
+#: src/Preferences.cpp:675
 msgid "Albanian"
 msgstr "アルバニア語"
 
-#: src/Preferences.cpp:675
+#: src/Preferences.cpp:676
 msgid "Arabic"
 msgstr "アラブ語"
 
-#: src/Preferences.cpp:676
+#: src/Preferences.cpp:677
 #, fuzzy
 msgid "Asturian"
 msgstr "エストニア語"
 
-#: src/Preferences.cpp:677
+#: src/Preferences.cpp:678
 msgid "Basque"
 msgstr "バスク語"
 
-#: src/Preferences.cpp:678
+#: src/Preferences.cpp:679
 msgid "Bulgarian"
 msgstr "ブルガリア語"
 
-#: src/Preferences.cpp:679
+#: src/Preferences.cpp:680
 msgid "Catalan"
 msgstr "カタロニア語"
 
-#: src/Preferences.cpp:680
+#: src/Preferences.cpp:681
 msgid "Chinese (Simplified)"
 msgstr "中国語（簡体字）"
 
-#: src/Preferences.cpp:681
+#: src/Preferences.cpp:682
 msgid "Chinese (Traditional)"
 msgstr "中国語（繁体字）"
 
-#: src/Preferences.cpp:682
+#: src/Preferences.cpp:683
 msgid "Croatian"
 msgstr "クロアチア語"
 
-#: src/Preferences.cpp:683
+#: src/Preferences.cpp:684
 msgid "Czech"
 msgstr "チェコ語"
 
-#: src/Preferences.cpp:684
+#: src/Preferences.cpp:685
 msgid "Danish"
 msgstr "デンマーク語"
 
-#: src/Preferences.cpp:685
+#: src/Preferences.cpp:686
 msgid "Dutch"
 msgstr "オランダ語"
 
-#: src/Preferences.cpp:686
+#: src/Preferences.cpp:687
 msgid "English (U.K.)"
 msgstr "英語（U.K.）"
 
-#: src/Preferences.cpp:687
+#: src/Preferences.cpp:688
 #, fuzzy
 msgid "English (U.S.)"
 msgstr "英語（U.K.）"
 
-#: src/Preferences.cpp:688
+#: src/Preferences.cpp:689
 msgid "Estonian"
 msgstr "エストニア語"
 
-#: src/Preferences.cpp:689
+#: src/Preferences.cpp:690
 msgid "Finnish"
 msgstr "フィンランド語"
 
-#: src/Preferences.cpp:690
+#: src/Preferences.cpp:691
 msgid "French"
 msgstr "フランス語"
 
-#: src/Preferences.cpp:691
+#: src/Preferences.cpp:692
 msgid "Galician"
 msgstr "ガリシア語"
 
-#: src/Preferences.cpp:692
+#: src/Preferences.cpp:693
 msgid "German"
 msgstr "ドイツ語"
 
-#: src/Preferences.cpp:693
+#: src/Preferences.cpp:694
 msgid "Greek"
 msgstr "ギリシア語"
 
-#: src/Preferences.cpp:694
+#: src/Preferences.cpp:695
 msgid "Hebrew"
 msgstr "ヘブライ語"
 
-#: src/Preferences.cpp:695
+#: src/Preferences.cpp:696
 msgid "Hungarian"
 msgstr "ハンガリー語"
 
-#: src/Preferences.cpp:696
+#: src/Preferences.cpp:697
 msgid "Italian"
 msgstr "イタリア語"
 
-#: src/Preferences.cpp:697
+#: src/Preferences.cpp:698
 msgid "Japanese"
 msgstr "日本語"
 
-#: src/Preferences.cpp:698
+#: src/Preferences.cpp:699
 msgid "Korean"
 msgstr "韓国語"
 
-#: src/Preferences.cpp:699
+#: src/Preferences.cpp:700
 msgid "Latvian"
 msgstr ""
 
-#: src/Preferences.cpp:700
+#: src/Preferences.cpp:701
 msgid "Lithuanian"
 msgstr "リトアニア語"
 
-#: src/Preferences.cpp:701
+#: src/Preferences.cpp:702
 msgid "Norwegian (Nynorsk)"
 msgstr "ルウェー語"
 
-#: src/Preferences.cpp:702
+#: src/Preferences.cpp:703
 msgid "Polish"
 msgstr "ポーランド語"
 
-#: src/Preferences.cpp:703
+#: src/Preferences.cpp:704
 msgid "Portuguese"
 msgstr "ポルトガル語"
 
-#: src/Preferences.cpp:704
+#: src/Preferences.cpp:705
 msgid "Portuguese (Brazilian)"
 msgstr "ポルトガル語（ブラジル）"
 
-#: src/Preferences.cpp:705
+#: src/Preferences.cpp:706
 #, fuzzy
 msgid "Romanian"
 msgstr "アルバニア語"
 
-#: src/Preferences.cpp:706
+#: src/Preferences.cpp:707
 msgid "Russian"
 msgstr "ロシア語"
 
-#: src/Preferences.cpp:707
+#: src/Preferences.cpp:708
 msgid "Slovenian"
 msgstr "スロベニア語"
 
-#: src/Preferences.cpp:708
+#: src/Preferences.cpp:709
 msgid "Spanish"
 msgstr "スペイン語"
 
-#: src/Preferences.cpp:709
+#: src/Preferences.cpp:710
 msgid "Swedish"
 msgstr "スウェーデン語"
 
-#: src/Preferences.cpp:710
+#: src/Preferences.cpp:711
 msgid "Turkish"
 msgstr "トルコ語"
 
-#: src/Preferences.cpp:711
+#: src/Preferences.cpp:712
 msgid "Ukrainian"
 msgstr ""
 
-#: src/Preferences.cpp:814
+#: src/Preferences.cpp:815
 #, fuzzy
 msgid "Change Language"
 msgstr "言語"
 
-#: src/Preferences.cpp:878
+#: src/Preferences.cpp:879
 msgid "There are no translations installed for aMule"
 msgstr ""
 
-#: src/Preferences.cpp:879
+#: src/Preferences.cpp:880
 #, fuzzy
 msgid "No languages available"
 msgstr "利用不可"
 
-#: src/Preferences.cpp:1010
+#: src/Preferences.cpp:1011
 msgid "no options available"
 msgstr ""
 
-#: src/Preferences.cpp:2179
+#: src/Preferences.cpp:2182
 msgid "Invalid category found, skipping"
 msgstr ""
 
-#: src/Preferences.cpp:2348
+#: src/Preferences.cpp:2351
 msgid "TCP port can't be higher than 65532 due to server UDP socket being TCP+3"
 msgstr "サーバのUDPソケトがTCP+3であるためTCPポートを65532以上には設定できません"
 
-#: src/Preferences.cpp:2349
+#: src/Preferences.cpp:2352
 #, c-format
 msgid "Default port will be used (%d)"
 msgstr "デフォルトポートを使用します (%d)"
@@ -6120,24 +6134,28 @@ msgstr "共有ファイル・リストを再ロードします。"
 msgid "Shared folder"
 msgstr "共有ファイル"
 
-#: src/SearchDlg.cpp:425
+#: src/SearchDlg.cpp:280
+msgid "Clear search history"
+msgstr ""
+
+#: src/SearchDlg.cpp:584
 msgid "It's impossible to search when both eD2k and Kademlia are disabled."
 msgstr ""
 
-#: src/SearchDlg.cpp:426 src/SearchListCtrl.cpp:858
+#: src/SearchDlg.cpp:585 src/SearchListCtrl.cpp:858
 #, fuzzy
 msgid "Search error"
 msgstr "検索"
 
-#: src/SearchDlg.cpp:768
+#: src/SearchDlg.cpp:929
 msgid "Min size must be smaller than max size. Max size ignored."
 msgstr "最小サイズは最大サイズより小さくなければなりません。最大サイズを無視します。"
 
-#: src/SearchDlg.cpp:769 src/SearchDlg.cpp:851
+#: src/SearchDlg.cpp:930 src/SearchDlg.cpp:1012
 msgid "Search warning"
 msgstr "検索の注意"
 
-#: src/SearchDlg.cpp:929 src/SearchListCtrl.cpp:735
+#: src/SearchDlg.cpp:1092 src/SearchListCtrl.cpp:735
 msgid "Main"
 msgstr "メイン"
 

--- a/po/ko_KR.po
+++ b/po/ko_KR.po
@@ -10,8 +10,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-28 12:12+0200\n"
-"PO-Revision-Date: 2026-07-27 10:27+0000\n"
+"POT-Creation-Date: 2026-07-28 08:06+0200\n"
+"PO-Revision-Date: 2026-07-27 11:41+0000\n"
 "Last-Translator: Hyunju Kang <rexington@gmail.com>\n"
 "Language-Team: Korean <hoenny@daum.net>\n"
 "Language: ko_KR\n"
@@ -140,7 +140,7 @@ msgstr ""
 msgid "Not now"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:422 src/amuleDlg.cpp:665
+#: src/AppImageIntegration.cpp:422 src/amuleDlg.cpp:600
 msgid "Don't ask again"
 msgstr ""
 
@@ -199,159 +199,159 @@ msgstr "%s(%s)을 열지 못했습니다."
 msgid "WARNING: You can't add yourself as a source for an eD2k link while having a lowid."
 msgstr ""
 
-#: src/amule.cpp:301
+#: src/amule.cpp:300
 #, fuzzy
 msgid "Now, exiting main app..."
 msgstr ""
 "\n"
 "좋아, 나가는중 %s...\n"
 
-#: src/amule.cpp:331
+#: src/amule.cpp:330
 #, c-format
 msgid "Terminating amuleweb instance with pid '%d' ... "
 msgstr ""
 
-#: src/amule.cpp:335
+#: src/amule.cpp:334
 #, c-format
 msgid "Killing amuleweb instance with pid '%d' ... "
 msgstr ""
 
-#: src/amule.cpp:337 src/amule.cpp:350 src/ClientRef.cpp:180
-#: src/SearchDlg.cpp:1041 src/ServerListCtrl.cpp:98
+#: src/amule.cpp:336 src/amule.cpp:349 src/ClientRef.cpp:180
+#: src/SearchDlg.cpp:880 src/ServerListCtrl.cpp:98
 msgid "Failed"
 msgstr "실패"
 
-#: src/amule.cpp:344
+#: src/amule.cpp:343
 #, c-format
 msgid "Terminating amuleapi instance with pid '%d' ... "
 msgstr ""
 
-#: src/amule.cpp:348
+#: src/amule.cpp:347
 #, c-format
 msgid "Killing amuleapi instance with pid '%d' ... "
 msgstr ""
 
-#: src/amule.cpp:356
+#: src/amule.cpp:355
 msgid "aMule OnExit: Terminating core."
 msgstr ""
 
-#: src/amule.cpp:467
+#: src/amule.cpp:466
 msgid "aMule shutdown completed."
 msgstr ""
 
-#: src/amule.cpp:471
+#: src/amule.cpp:470
 msgid "Memory debug results for aMule exit:"
 msgstr ""
 
-#: src/amule.cpp:652
+#: src/amule.cpp:651
 #, c-format
 msgid "Binding aMule's peer-to-peer traffic to interface: %s (HTTP updates use the default route)"
 msgstr ""
 
-#: src/amule.cpp:656
+#: src/amule.cpp:655
 #, c-format
 msgid "Binding all network traffic to interface: %s"
 msgstr ""
 
-#: src/amule.cpp:660
+#: src/amule.cpp:659
 #, c-format
 msgid "WARNING: configured network interface '%s' was not found - traffic is NOT bound to it and may leave via the default route. Check the interface name in Preferences."
 msgstr ""
 
-#: src/amule.cpp:666
+#: src/amule.cpp:665
 #, c-format
 msgid "WARNING: binding to network interface '%s' requires elevated privileges and was NOT applied - traffic may leave via the default route. Grant the capability (e.g. 'sudo setcap cap_net_raw+ep' on the aMule binary) or run with sufficient privileges."
 msgstr ""
 
-#: src/amule.cpp:674
+#: src/amule.cpp:673
 #, c-format
 msgid "WARNING: could not bind to network interface '%s' - traffic may leave via the default route."
 msgstr ""
 
-#: src/amule.cpp:733
+#: src/amule.cpp:732
 msgid "Your locale has been changed to System Default due to a configuration change. Sorry."
 msgstr "지역정보(로케일)가 설정 변경으로 인해 시스템 기본값으로 변경되었습니다. 죄송합니다."
 
-#: src/amule.cpp:735 src/amule.cpp:1589 src/CatDialog.cpp:128
+#: src/amule.cpp:734 src/amule.cpp:1581 src/CatDialog.cpp:128
 #: src/CatDialog.cpp:136 src/CatDialog.cpp:149 src/ServerList.cpp:366
 #: src/ServerListCtrl.cpp:152
 msgid "Info"
 msgstr "정보"
 
-#: src/amule.cpp:742
+#: src/amule.cpp:741
 #, fuzzy
 msgid ""
 "\n"
 "EC configuration"
 msgstr "종료 확인"
 
-#: src/amule.cpp:745
+#: src/amule.cpp:744
 #, fuzzy
 msgid "Password set and external connections enabled."
 msgstr "새로운 외부연결이 승인되었습니다."
 
-#: src/amule.cpp:755 src/KadDlg.cpp:176 src/KadDlg.cpp:185
-#: src/PrefsUnifiedDlg.cpp:1461 src/SharedFilesCtrl.cpp:476
+#: src/amule.cpp:754 src/KadDlg.cpp:176 src/KadDlg.cpp:185
+#: src/PrefsUnifiedDlg.cpp:1387 src/SharedFilesCtrl.cpp:476
 msgid "WARNING"
 msgstr "경고"
 
-#: src/amule.cpp:992
+#: src/amule.cpp:991
 #, fuzzy
 msgid "Network bootstrap"
 msgstr "통신망"
 
-#: src/amule.cpp:997
+#: src/amule.cpp:996
 msgid ""
 "aMule has detected missing network bootstrap files.\n"
 "Select which ones to download:"
 msgstr ""
 
-#: src/amule.cpp:1006 src/FirstRunWizard.cpp:411
+#: src/amule.cpp:1005 src/FirstRunWizard.cpp:411
 #, fuzzy
 msgid "eD2k server list (server.met)"
 msgstr "server.met에서 %i개의 서버가 발견됨"
 
-#: src/amule.cpp:1013 src/FirstRunWizard.cpp:416
+#: src/amule.cpp:1012 src/FirstRunWizard.cpp:416
 msgid "Kad bootstrap nodes (nodes.dat)"
 msgstr ""
 
-#: src/amule.cpp:1103
+#: src/amule.cpp:1102
 #, c-format
 msgid "web server running on pid %d"
 msgstr ""
 
-#: src/amule.cpp:1116
+#: src/amule.cpp:1115
 msgid "You requested to run web server on startup, but the amuleweb binary cannot be run. Please install the package containing aMule web server, or build aMule from source with -DBUILD_WEBSERVER=YES and install it."
 msgstr ""
 
-#: src/amule.cpp:1121 src/amule.cpp:1185 src/amule.cpp:1299 src/amule.cpp:1601
+#: src/amule.cpp:1120 src/amule.cpp:1177 src/amule.cpp:1291 src/amule.cpp:1593
 #: src/amule-remote-gui.cpp:603 src/amule-remote-gui.cpp:671
 #: src/amule-remote-gui.cpp:709 src/amule-remote-gui.cpp:1282
 #: src/amule-remote-gui.cpp:1345 src/amule-remote-gui.cpp:1372
-#: src/DownloadQueue.cpp:1481 src/PrefsUnifiedDlg.cpp:1247
+#: src/DownloadQueue.cpp:1481
 msgid "ERROR"
 msgstr ""
 
-#: src/amule.cpp:1174
+#: src/amule.cpp:1166
 #, fuzzy, c-format
 msgid "amuleapi running on pid %d"
 msgstr "어뮬은 실행중입니다."
 
-#: src/amule.cpp:1180
+#: src/amule.cpp:1172
 msgid "You requested to run amuleapi on startup, but the amuleapi binary cannot be run. Please install the package containing aMule's REST API server, or build aMule from source with -DBUILD_AMULEAPI=YES and install it."
 msgstr ""
 
-#: src/amule.cpp:1267
+#: src/amule.cpp:1259
 #, c-format
 msgid "Could not bind ports to the specified address: %s"
 msgstr ""
 
-#: src/amule.cpp:1291
+#: src/amule.cpp:1283
 #, c-format
 msgid "Port %u is not available. You will be LOWID\n"
 msgstr "포트 %u는 사용할 수 없습니다. 낮은아이디를 가질것입니다.\n"
 
-#: src/amule.cpp:1296
+#: src/amule.cpp:1288
 #, c-format
 msgid ""
 "Port %u is not available!\n"
@@ -366,48 +366,48 @@ msgstr ""
 "\n"
 "나가고 들어오는것에 대해 포트가 열려있는지 통신망을 체크하세요. "
 
-#: src/amule.cpp:1393
+#: src/amule.cpp:1385
 msgid "Failed to create OnlineSig File"
 msgstr "온라인서명 파일을 생성하지 못함"
 
-#: src/amule.cpp:1401
+#: src/amule.cpp:1393
 msgid "Failed to create aMule OnlineSig File"
 msgstr "어뮬 온라인서명 파일을 생성하지 못함"
 
-#: src/amule.cpp:1564
+#: src/amule.cpp:1556
 msgid "The selected locale seems not to be installed on your box. (Note: I'll try to set it anyway)"
 msgstr "컴퓨터에 선택한 지역정보(로케일)가 설치 않된것 같습니다. (주의: 어쨌든 설정하겠습니다)"
 
-#: src/amule.cpp:1574
+#: src/amule.cpp:1566
 #, c-format
 msgid "This is the first time you run aMule %s"
 msgstr "이번에 어뮬 %s를 처음 실행했습니다."
 
-#: src/amule.cpp:1577
+#: src/amule.cpp:1569
 msgid "This version is a testing version, updated daily, and\n"
 msgstr "이 버전은 테스트 버젼으로, 매일 업데이트되며, \n"
 
-#: src/amule.cpp:1578
+#: src/amule.cpp:1570
 msgid "we give no warranty it won't break anything, burn your house,\n"
 msgstr "이 프로그램이 어느 것도 부수지 않는다고, 집을 태우지 않는다고, 혹은 \n"
 
-#: src/amule.cpp:1579
+#: src/amule.cpp:1571
 msgid "or kill your dog. But it *should* be safe to use anyway.\n"
 msgstr "개를 죽이지 않는다고 보장하지 않습니다. 그렇지만 안전하게 사용할 수 있을 것입니다.\n"
 
-#: src/amule.cpp:1584
+#: src/amule.cpp:1576
 msgid "More information, support and new releases can found at our homepage,\n"
 msgstr "더 많은 정보, 지원, 새 릴리즈는 홈페이지 amule-org.github.io, 또는 IRC 채널\n"
 
-#: src/amule.cpp:1585
+#: src/amule.cpp:1577
 msgid "at https://amule-org.github.io, or in our IRC channel #aMule at irc.libera.chat.\n"
 msgstr "(irc.libera.chat의 #aMule)에서 찾을 수 있습니다.\n"
 
-#: src/amule.cpp:1587
+#: src/amule.cpp:1579
 msgid "Feel free to report any bugs to https://github.com/amule-org/amule/issues"
 msgstr "버그는 https://github.com/amule-org/amule/issues로 보고해 주십시오."
 
-#: src/amule.cpp:1599
+#: src/amule.cpp:1591
 msgid ""
 "The folder for Online Signature files you specified is INVALID!\n"
 " OnlineSignature will be DISABLED until you fix it on preferences."
@@ -415,138 +415,138 @@ msgstr ""
 "지정한 온라인 서명 파일을 위한 폴더가 유효하지 않습니다.\n"
 " 온라인 서명은 환경설정에서 수정될 때까지 비활성화 됩니다."
 
-#: src/amule.cpp:1662
+#: src/amule.cpp:1654
 #, fuzzy
 msgid "Server hostname notified"
 msgstr "서버 이름:"
 
-#: src/amule.cpp:2039
+#: src/amule.cpp:2031
 #, c-format
 msgid "Disk space preallocation for file '%s' failed: %s"
 msgstr ""
 
-#: src/amule.cpp:2168
+#: src/amule.cpp:2160
 msgid "ERROR: can't open logfile"
 msgstr "오류: 로그파일을 열 수 없음"
 
-#: src/amule.cpp:2172
+#: src/amule.cpp:2164
 msgid "WARNING: logfile is empty. Something is wrong."
 msgstr "경고: 로그파일이 비어있습니다. 뭔가 잘못되어 있습니다."
 
-#: src/amule.cpp:2189
+#: src/amule.cpp:2181
 msgid "Log has been reset"
 msgstr "로그가 초기화되었습니다."
 
-#: src/amule.cpp:2213
+#: src/amule.cpp:2205
 #, c-format
 msgid "ServerMessage: %s"
 msgstr "서버메시지: %s"
 
-#: src/amule.cpp:2256 src/IP2Country.cpp:220 src/IPFilter.cpp:514
+#: src/amule.cpp:2248 src/IP2Country.cpp:220 src/IPFilter.cpp:514
 #: src/ServerList.cpp:875
 #, c-format
 msgid "Skipped download of %s, because requested file is not newer."
 msgstr ""
 
-#: src/amule.cpp:2259
+#: src/amule.cpp:2251
 msgid "Failed to download the nodes list."
 msgstr "노드 목록을 내려받지 못했습니다."
 
-#: src/amule.cpp:2322
+#: src/amule.cpp:2314
 msgid "Failed to open the downloaded version check file"
 msgstr "내려받은 버젼 검사 파일을 열지 못했습니다."
 
-#: src/amule.cpp:2325 src/amule.cpp:2344
+#: src/amule.cpp:2317 src/amule.cpp:2336
 msgid "Corrupted version check file"
 msgstr "손상된 버젼 검사 파일"
 
-#: src/amule.cpp:2367
+#: src/amule.cpp:2359
 msgid "You are using an outdated version of aMule!"
 msgstr "오래된 어뮬 버젼을 사용하고 있습니다!"
 
-#: src/amule.cpp:2369
+#: src/amule.cpp:2361
 #, c-format
 msgid "Your aMule version is %i.%i.%i and the latest version is %li.%li.%li"
 msgstr "어뮬 버젼은 %i.%i.%i이며 최신 버젼은 %li.%li.%li입니다."
 
-#: src/amule.cpp:2373
+#: src/amule.cpp:2365
 msgid "The latest version can always be found at https://github.com/amule-org/amule/releases/latest"
 msgstr "최신 버젼은 항상 https://github.com/amule-org/amule/releases/latest 에서 찾을 수 있습니다."
 
-#: src/amule.cpp:2376
+#: src/amule.cpp:2368
 #, c-format
 msgid "WARNING: Your aMuled version is outdated: %i.%i.%i < %li.%li.%li"
 msgstr "경고: 어뮬 버젼은 오래되었습니다: %i.%i.%i < %li.%li.%li"
 
-#: src/amule.cpp:2382
+#: src/amule.cpp:2374
 msgid "Your copy of aMule is up to date."
 msgstr "어뮬은 최신 버전입니다."
 
-#: src/amule.cpp:2389
+#: src/amule.cpp:2381
 msgid "Failed to download the version check file"
 msgstr "버젼 검사 파일을 내려받지 못했습니다."
 
-#: src/amule.cpp:2558 src/amule-remote-gui.cpp:1133
+#: src/amule.cpp:2550 src/amule-remote-gui.cpp:1133
 #, c-format
 msgid "Users: %s | Files: %s"
 msgstr ""
 
-#: src/amule.cpp:2559 src/amule-remote-gui.cpp:1134
+#: src/amule.cpp:2551 src/amule-remote-gui.cpp:1134
 #, c-format
 msgid "Users: E: %s K: %s | Files: E: %s K: %s"
 msgstr ""
 
-#: src/amule.cpp:2573 src/amule-remote-gui.cpp:1147
+#: src/amule.cpp:2565 src/amule-remote-gui.cpp:1147
 msgid "No networks selected"
 msgstr ""
 
-#: src/amule.cpp:2641 src/TextClient.cpp:903
+#: src/amule.cpp:2633 src/TextClient.cpp:903
 msgid "with LowID"
 msgstr "낮은아이디로"
 
-#: src/amule.cpp:2641 src/TextClient.cpp:904
+#: src/amule.cpp:2633 src/TextClient.cpp:904
 msgid "with HighID"
 msgstr "높은아이디로"
 
-#: src/amule.cpp:2643
+#: src/amule.cpp:2635
 #, c-format
 msgid "Connected to %s %s"
 msgstr "%s %s에 연결되었음"
 
-#: src/amule.cpp:2648
+#: src/amule.cpp:2640
 #, c-format
 msgid "Connecting to %s"
 msgstr "%s에 연결중"
 
-#: src/amule.cpp:2650
+#: src/amule.cpp:2642
 msgid "Disconnected from eD2k"
 msgstr ""
 
-#: src/amule.cpp:2659
+#: src/amule.cpp:2651
 msgid "Kad started."
 msgstr "Kad를 시작했습니다."
 
-#: src/amule.cpp:2661
+#: src/amule.cpp:2653
 msgid "Kad stopped."
 msgstr "Kad를 멈췄습니다."
 
-#: src/amule.cpp:2669
+#: src/amule.cpp:2661
 msgid "Connected to Kad (ok)"
 msgstr "Kad에 연결됨 (양호)"
 
-#: src/amule.cpp:2671
+#: src/amule.cpp:2663
 msgid "Connected to Kad (firewalled)"
 msgstr "Kad에 연결됨 (방화벽)"
 
-#: src/amule.cpp:2675
+#: src/amule.cpp:2667
 msgid "Disconnected from Kad"
 msgstr "Kad로부터 연결이 끊김"
 
-#: src/amule.cpp:2707
+#: src/amule.cpp:2699
 msgid "Kad network cannot be used if UDP port is disabled on preferences, not starting."
 msgstr "Kad 네트워크는 UDP 포트가 비활성될 시 사용할 수 없으며, 따라서 시작하지 않습니다."
 
-#: src/amule.cpp:2711
+#: src/amule.cpp:2703
 msgid "Kad network disabled on preferences, not connecting."
 msgstr "Kad 네트워크가 환경설정에서 비활성되어, 연결하지 않습니다."
 
@@ -572,68 +572,30 @@ msgstr ""
 msgid "ERROR: %s"
 msgstr "오류: %s"
 
-#: src/amuleDlg.cpp:250
+#: src/amuleDlg.cpp:236
 #, c-format
 msgid "This is aMule %s based on eMule."
 msgstr "이 어뮬 %s는 이뮬 기반으로 되어있습니다."
 
-#: src/amuleDlg.cpp:251
+#: src/amuleDlg.cpp:237
 #, c-format
 msgid "Running on %s"
 msgstr "%s에 동작중"
 
-#: src/amuleDlg.cpp:253
+#: src/amuleDlg.cpp:239
 msgid "Visit https://github.com/amule-org/amule/releases/latest to check if a new version is available."
 msgstr "https://github.com/amule-org/amule/releases/latest에 방문하셔서 새로운버젼이 있는지 확인하십시오."
 
-#: src/amuleDlg.cpp:282
+#: src/amuleDlg.cpp:268
 msgid "FATAL ERROR: Failed to create Timer"
 msgstr ""
 
-#: src/amuleDlg.cpp:361 src/amuleDlg.cpp:1810 src/amuleDlg.cpp:2056
-#: src/muuli_wdr.cpp:1492 src/muuli_wdr.cpp:3439
-msgid "Networks"
-msgstr "통신망"
-
-#: src/amuleDlg.cpp:362 src/amuleDlg.cpp:1816 src/muuli_wdr.cpp:3440
-msgid "Searches"
-msgstr "검색"
-
-#: src/amuleDlg.cpp:363 src/amuleDlg.cpp:1822 src/DownloadListCtrl.cpp:740
-#: src/muuli_wdr.cpp:392 src/muuli_wdr.cpp:1585 src/muuli_wdr.cpp:3441
-#: src/Statistics.cpp:829
-msgid "Downloads"
-msgstr "내려받기"
-
-#: src/amuleDlg.cpp:364 src/amuleDlg.cpp:1828 src/muuli_wdr.cpp:3315
-msgid "Shared files"
-msgstr ""
-
-#: src/amuleDlg.cpp:365 src/amuleDlg.cpp:1834 src/muuli_wdr.cpp:2947
-#: src/muuli_wdr.cpp:3397 src/muuli_wdr.cpp:3444
-msgid "Messages"
-msgstr "메시지"
-
-#: src/amuleDlg.cpp:366 src/amuleDlg.cpp:1840 src/muuli_wdr.cpp:3445
-#: src/PrefsUnifiedDlg.cpp:314 src/Statistics.cpp:779 src/Statistics.cpp:1235
-msgid "Statistics"
-msgstr "통계"
-
-#: src/amuleDlg.cpp:368 src/amuleDlg.cpp:1847 src/muuli_wdr.cpp:3447
-#: src/PrefsUnifiedDlg.cpp:330 src/utils/wxCas/src/wxcasprefs.cpp:39
-msgid "Preferences"
-msgstr "환경설정"
-
-#: src/amuleDlg.cpp:371
-msgid "Navigate"
-msgstr ""
-
-#: src/amuleDlg.cpp:657
+#: src/amuleDlg.cpp:592
 #, fuzzy
 msgid "New version available"
 msgstr "유효하지 않음"
 
-#: src/amuleDlg.cpp:661
+#: src/amuleDlg.cpp:596
 #, fuzzy, c-format
 msgid ""
 "A new version of aMule (%s) is available.\n"
@@ -643,195 +605,228 @@ msgid ""
 "Would you like to open the download page?"
 msgstr "최신 버젼은 항상 https://github.com/amule-org/amule/releases/latest 에서 찾을 수 있습니다."
 
-#: src/amuleDlg.cpp:743
+#: src/amuleDlg.cpp:678
 msgid "aMule dialog destroyed"
 msgstr ""
 
-#: src/amuleDlg.cpp:766 src/DataToText.cpp:68 src/IPFilter.cpp:547
+#: src/amuleDlg.cpp:701 src/DataToText.cpp:68 src/IPFilter.cpp:547
 msgid "Connecting"
 msgstr "연결중"
 
-#: src/amuleDlg.cpp:958
+#: src/amuleDlg.cpp:893
 msgid "eD2k: Connecting"
 msgstr ""
 
-#: src/amuleDlg.cpp:962
+#: src/amuleDlg.cpp:897
 msgid "eD2k: Disconnected"
 msgstr ""
 
-#: src/amuleDlg.cpp:968
+#: src/amuleDlg.cpp:903
 #, fuzzy
 msgid "Kad: Firewalled"
 msgstr "방화벽"
 
-#: src/amuleDlg.cpp:972
+#: src/amuleDlg.cpp:907
 #, fuzzy
 msgid "Kad: Connected"
 msgstr "연결됨"
 
-#: src/amuleDlg.cpp:977
+#: src/amuleDlg.cpp:912
 #, fuzzy
 msgid "Kad: Connecting"
 msgstr "연결중"
 
-#: src/amuleDlg.cpp:981
+#: src/amuleDlg.cpp:916
 #, fuzzy
 msgid "Kad: Off"
 msgstr " Kad: "
 
-#: src/amuleDlg.cpp:1029 src/DownloadListCtrl.cpp:505
+#: src/amuleDlg.cpp:964 src/DownloadListCtrl.cpp:505
 #: src/DownloadListCtrl.cpp:749 src/FriendListCtrl.cpp:180
 #: src/muuli_wdr.cpp:731 src/muuli_wdr.cpp:782 src/muuli_wdr.cpp:846
-#: src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2252 src/muuli_wdr.cpp:2337
-#: src/muuli_wdr.cpp:3085 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
+#: src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2224 src/muuli_wdr.cpp:2309
+#: src/muuli_wdr.cpp:3057 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
 #: src/ServerListCtrl.cpp:606 src/TransferWnd.cpp:378
 #: src/utils/wxCas/src/wxcasprefs.cpp:235
 msgid "Cancel"
 msgstr "취소"
 
-#: src/amuleDlg.cpp:1030
+#: src/amuleDlg.cpp:965
 #, fuzzy
 msgid "Stop the current connection attempts"
 msgstr "현재 연결시도를 멈춤"
 
-#: src/amuleDlg.cpp:1035 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976
-#: src/muuli_wdr.cpp:2475
+#: src/amuleDlg.cpp:970 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976
+#: src/muuli_wdr.cpp:2447
 msgid "Disconnect"
 msgstr "연결 끊기"
 
-#: src/amuleDlg.cpp:1036
+#: src/amuleDlg.cpp:971
 #, fuzzy
 msgid "Disconnect from the currently connected networks"
 msgstr "통신망으로부터 연결을 끊습니다."
 
-#: src/amuleDlg.cpp:1041 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979
-#: src/muuli_wdr.cpp:2630 src/muuli_wdr.cpp:3082 src/muuli_wdr.cpp:3437
+#: src/amuleDlg.cpp:976 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979
+#: src/muuli_wdr.cpp:2602 src/muuli_wdr.cpp:3054 src/muuli_wdr.cpp:3409
 msgid "Connect"
 msgstr "연결"
 
-#: src/amuleDlg.cpp:1042
+#: src/amuleDlg.cpp:977
 #, fuzzy
 msgid "Connect to the currently enabled networks"
 msgstr "통신망에 연결합니다."
 
-#: src/amuleDlg.cpp:1154
+#: src/amuleDlg.cpp:1089
 #, fuzzy, c-format
 msgid "Up: %.1f%s (%.1f) | Down: %.1f%s (%.1f)"
 msgstr "올려주기: %.1f(%.1f) | 내려받기: %.1f(%.1f)"
 
-#: src/amuleDlg.cpp:1156 src/amuleDlg.cpp:1158 src/amuleDlg.cpp:1162
-#: src/amuleDlg.cpp:1164 src/amuleDlg.cpp:1175 src/amuleDlg.cpp:1177
+#: src/amuleDlg.cpp:1091 src/amuleDlg.cpp:1093 src/amuleDlg.cpp:1097
+#: src/amuleDlg.cpp:1099 src/amuleDlg.cpp:1110 src/amuleDlg.cpp:1112
 #: src/MuleTrayIcon.cpp:796 src/MuleTrayIcon.cpp:799
 #, fuzzy
 msgid " MB/s"
 msgstr "MB/s"
 
-#: src/amuleDlg.cpp:1156 src/amuleDlg.cpp:1158 src/amuleDlg.cpp:1162
-#: src/amuleDlg.cpp:1164 src/amuleDlg.cpp:1175 src/amuleDlg.cpp:1177
+#: src/amuleDlg.cpp:1091 src/amuleDlg.cpp:1093 src/amuleDlg.cpp:1097
+#: src/amuleDlg.cpp:1099 src/amuleDlg.cpp:1110 src/amuleDlg.cpp:1112
 #: src/MuleTrayIcon.cpp:796 src/MuleTrayIcon.cpp:799
 #: src/utils/wxCas/src/wxcasframe.cpp:1041
 #, fuzzy
 msgid " kB/s"
 msgstr "kB/s"
 
-#: src/amuleDlg.cpp:1161
+#: src/amuleDlg.cpp:1096
 #, fuzzy, c-format
 msgid "Up: %.1f%s | Down: %.1f%s"
 msgstr "올려주기: %.1f | 내려받기: %.1f"
 
-#: src/amuleDlg.cpp:1193
+#: src/amuleDlg.cpp:1128
 #, c-format
 msgid "aMule (%s | Connected)"
 msgstr "어뮬 (%s | 연결됨)"
 
-#: src/amuleDlg.cpp:1195
+#: src/amuleDlg.cpp:1130
 #, c-format
 msgid "aMule (%s | Disconnected)"
 msgstr "어뮬 (%s | 끊김)"
 
-#: src/amuleDlg.cpp:1248
+#: src/amuleDlg.cpp:1183
 #, fuzzy, c-format
 msgid "Do you really want to exit %s?"
 msgstr "어뮬을 종료하시겠습니까?"
 
-#: src/amuleDlg.cpp:1250
+#: src/amuleDlg.cpp:1185
 msgid "Exit confirmation"
 msgstr "종료 확인"
 
-#: src/amuleDlg.cpp:1613
+#: src/amuleDlg.cpp:1548
 #, fuzzy
 msgid "Launch Command: "
 msgstr "명령: %s"
 
-#: src/amuleDlg.cpp:1632 src/muuli_wdr.cpp:1972 src/Preferences.cpp:979
+#: src/amuleDlg.cpp:1567 src/muuli_wdr.cpp:1971 src/Preferences.cpp:951
 msgid "- default -"
 msgstr ""
 
-#: src/amuleDlg.cpp:1660
+#: src/amuleDlg.cpp:1595
 #, c-format
 msgid "Skin directory '%s' does not exist"
 msgstr "외형 폴더 '%s'가 없습니다."
 
-#: src/amuleDlg.cpp:1663
+#: src/amuleDlg.cpp:1598
 #, c-format
 msgid "WARNING: Unable to open skin file '%s' for read"
 msgstr ""
 
-#: src/amuleDlg.cpp:1814 src/muuli_wdr.cpp:3439
+#: src/amuleDlg.cpp:1722 src/amuleDlg.cpp:1968 src/muuli_wdr.cpp:1485
+#: src/muuli_wdr.cpp:3411
+msgid "Networks"
+msgstr "통신망"
+
+#: src/amuleDlg.cpp:1726 src/muuli_wdr.cpp:3411
 msgid "Networks Window"
 msgstr "통신망 창"
 
-#: src/amuleDlg.cpp:1820 src/muuli_wdr.cpp:3440
+#: src/amuleDlg.cpp:1728 src/muuli_wdr.cpp:3412
+msgid "Searches"
+msgstr "검색"
+
+#: src/amuleDlg.cpp:1732 src/muuli_wdr.cpp:3412
 msgid "Searches Window"
 msgstr "검색 창"
 
-#: src/amuleDlg.cpp:1826 src/muuli_wdr.cpp:3441
+#: src/amuleDlg.cpp:1734 src/DownloadListCtrl.cpp:740 src/muuli_wdr.cpp:392
+#: src/muuli_wdr.cpp:1578 src/muuli_wdr.cpp:3413 src/Statistics.cpp:829
+msgid "Downloads"
+msgstr "내려받기"
+
+#: src/amuleDlg.cpp:1738 src/muuli_wdr.cpp:3413
 #, fuzzy
 msgid "Downloads Window"
 msgstr "받는중"
 
-#: src/amuleDlg.cpp:1832 src/muuli_wdr.cpp:3443
+#: src/amuleDlg.cpp:1740 src/muuli_wdr.cpp:3287
+msgid "Shared files"
+msgstr ""
+
+#: src/amuleDlg.cpp:1744 src/muuli_wdr.cpp:3415
 msgid "Shared Files Window"
 msgstr "공유 파일 창"
 
-#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3444
+#: src/amuleDlg.cpp:1746 src/muuli_wdr.cpp:2919 src/muuli_wdr.cpp:3369
+#: src/muuli_wdr.cpp:3416
+msgid "Messages"
+msgstr "메시지"
+
+#: src/amuleDlg.cpp:1750 src/muuli_wdr.cpp:3416
 msgid "Messages Window"
 msgstr "메시지 창"
 
-#: src/amuleDlg.cpp:1844 src/muuli_wdr.cpp:3445
+#: src/amuleDlg.cpp:1752 src/muuli_wdr.cpp:3417 src/PrefsUnifiedDlg.cpp:312
+#: src/Statistics.cpp:779 src/Statistics.cpp:1235
+msgid "Statistics"
+msgstr "통계"
+
+#: src/amuleDlg.cpp:1756 src/muuli_wdr.cpp:3417
 msgid "Statistics Graph Window"
 msgstr "통계 그래프 창"
 
-#: src/amuleDlg.cpp:1851 src/muuli_wdr.cpp:3447
+#: src/amuleDlg.cpp:1759 src/muuli_wdr.cpp:3419 src/PrefsUnifiedDlg.cpp:328
+#: src/utils/wxCas/src/wxcasprefs.cpp:39
+msgid "Preferences"
+msgstr "환경설정"
+
+#: src/amuleDlg.cpp:1763 src/muuli_wdr.cpp:3419
 msgid "Preferences Settings Window"
 msgstr "환경 설정 창"
 
-#: src/amuleDlg.cpp:1854 src/muuli_wdr.cpp:3448
+#: src/amuleDlg.cpp:1766 src/muuli_wdr.cpp:3420
 msgid "Import"
 msgstr "가져오기"
 
-#: src/amuleDlg.cpp:1858 src/muuli_wdr.cpp:3448
+#: src/amuleDlg.cpp:1770 src/muuli_wdr.cpp:3420
 msgid "The partfile importer tool"
 msgstr "부분파일 가져오기 도구"
 
-#: src/amuleDlg.cpp:1861 src/muuli_wdr.cpp:3449
+#: src/amuleDlg.cpp:1773 src/muuli_wdr.cpp:3421
 #: src/utils/aLinkCreator/src/alcframe.cpp:262
 msgid "About"
 msgstr "정보"
 
-#: src/amuleDlg.cpp:1861 src/muuli_wdr.cpp:3449
+#: src/amuleDlg.cpp:1773 src/muuli_wdr.cpp:3421
 msgid "About/Help"
 msgstr "정보/도움"
 
-#: src/amuleDlg.cpp:2059
+#: src/amuleDlg.cpp:1971
 msgid "eD2k network"
 msgstr ""
 
-#: src/amuleDlg.cpp:2062
+#: src/amuleDlg.cpp:1974
 msgid "Kad network"
 msgstr ""
 
-#: src/amuleDlg.cpp:2062
+#: src/amuleDlg.cpp:1974
 msgid "No network"
 msgstr ""
 
@@ -965,7 +960,7 @@ msgstr "파일을 찾을 수 없습니다."
 msgid "The core rejected these shared folders:%s"
 msgstr ""
 
-#: src/amule-remote-gui.cpp:1336 src/ExternalConn.cpp:2346
+#: src/amule-remote-gui.cpp:1336 src/ExternalConn.cpp:2345
 msgid "Invalid link or already on list."
 msgstr "유효하지 않은 링크거나 이미 목록에 존재합니다."
 
@@ -981,7 +976,7 @@ msgstr ""
 #: src/ClientDetailDialog.cpp:123 src/DataToText.cpp:61 src/DataToText.cpp:86
 #: src/DataToText.cpp:101 src/DataToText.cpp:136 src/DataToText.cpp:165
 #: src/DownloadListCtrl.cpp:1172 src/DownloadListCtrl.cpp:1185
-#: src/DownloadListCtrl.cpp:1196 src/ExternalConn.cpp:609
+#: src/DownloadListCtrl.cpp:1196 src/ExternalConn.cpp:608
 #: src/FileDetailDialog.cpp:203 src/FileDetailDialog.cpp:235
 #: src/FileDetailDialog.cpp:242 src/GenericClientListCtrl.cpp:1171
 #: src/GenericClientListCtrl.cpp:1182 src/GenericClientListCtrl.cpp:1192
@@ -1368,19 +1363,19 @@ msgstr "자동[높음]"
 msgid "Very low"
 msgstr "매우 낮음"
 
-#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:743 src/muuli_wdr.cpp:2303
+#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:743 src/muuli_wdr.cpp:2275
 #: src/ServerListCtrl.cpp:263 src/ServerListCtrl.cpp:456
 #: src/SharedFilesCtrl.cpp:145
 msgid "Low"
 msgstr "낮음"
 
-#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:744 src/muuli_wdr.cpp:2304
+#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:744 src/muuli_wdr.cpp:2276
 #: src/ServerListCtrl.cpp:266 src/ServerListCtrl.cpp:457
 #: src/SharedFilesCtrl.cpp:146
 msgid "Normal"
 msgstr "보통"
 
-#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:745 src/muuli_wdr.cpp:2305
+#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:745 src/muuli_wdr.cpp:2277
 #: src/ServerListCtrl.cpp:269 src/ServerListCtrl.cpp:458
 #: src/SharedFilesCtrl.cpp:147
 msgid "High"
@@ -1472,8 +1467,8 @@ msgstr "지역 서버"
 msgid "Remote Server"
 msgstr "원격 서버"
 
-#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3202
-#: src/SearchDlg.cpp:119 src/TextClient.cpp:911
+#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3174
+#: src/SearchDlg.cpp:111 src/TextClient.cpp:911
 msgid "Kad"
 msgstr "Kad"
 
@@ -1543,7 +1538,7 @@ msgstr ""
 msgid "Size"
 msgstr "크기"
 
-#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3269
+#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3241
 msgid "Transferred"
 msgstr "전송됨"
 
@@ -1601,7 +1596,7 @@ msgid ""
 "\n"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:746 src/muuli_wdr.cpp:2306
+#: src/DownloadListCtrl.cpp:746 src/muuli_wdr.cpp:2278
 #: src/SharedFilesCtrl.cpp:150
 msgid "Auto"
 msgstr "자동"
@@ -1639,7 +1634,7 @@ msgid "Extended Options"
 msgstr "확장 옵션"
 
 #: src/DownloadListCtrl.cpp:770 src/DownloadListCtrl.cpp:822
-#: src/muuli_wdr.cpp:1790
+#: src/muuli_wdr.cpp:1789
 msgid "Preview"
 msgstr "미리보기"
 
@@ -1812,237 +1807,232 @@ msgstr[1] ""
 msgid "Invalid eD2k link! ERROR: %s"
 msgstr ""
 
-#: src/ExternalConn.cpp:380
+#: src/ExternalConn.cpp:379
 #, fuzzy
 msgid "Client sent packet after authentication failed."
 msgstr "인증에 실패했습니다."
 
-#: src/ExternalConn.cpp:397
+#: src/ExternalConn.cpp:396
 msgid "External connection closed."
 msgstr "외부연결 끊겼습니다."
 
-#: src/ExternalConn.cpp:474
+#: src/ExternalConn.cpp:473
 msgid "External connections disabled due to empty password!"
 msgstr "빈암호 때문에 외부연결이 불가능합니다."
 
-#: src/ExternalConn.cpp:495
+#: src/ExternalConn.cpp:494
 msgid "External connections disabled in config file"
 msgstr "이 환경설정에서 외부연결은 불가능합니다."
 
-#: src/ExternalConn.cpp:576
+#: src/ExternalConn.cpp:575
 msgid "New external connection accepted"
 msgstr "새로운 외부연결이 승인되었습니다."
 
-#: src/ExternalConn.cpp:579
+#: src/ExternalConn.cpp:578
 msgid "ERROR: couldn't accept a new external connection"
 msgstr ""
 
-#: src/ExternalConn.cpp:596
+#: src/ExternalConn.cpp:595
 msgid "External connection refused due to empty password in preferences!"
 msgstr "환경설정의 빈암호로 인해 외부연결이 거부되었습니다."
 
-#: src/ExternalConn.cpp:608
+#: src/ExternalConn.cpp:607
 #, c-format
 msgid "Connecting client: %s %s"
 msgstr "연결중인 클라이언트: %s %s"
 
-#: src/ExternalConn.cpp:610
+#: src/ExternalConn.cpp:609
 msgid "Unknown version"
 msgstr "알수없는 버젼"
 
-#: src/ExternalConn.cpp:623
+#: src/ExternalConn.cpp:622
 msgid "Incorrect EC version ID, there might be binary incompatibility. Use core and remote from same snapshot."
 msgstr "불확실한 외부연결 버젼 아이디, 이것은 바이너리와 호환되지 않습니다. 동일한 스냅삿으로부터 코어와 원격을 사용하세요."
 
-#: src/ExternalConn.cpp:631
+#: src/ExternalConn.cpp:630
 #, fuzzy
 msgid "You cannot connect to a release version from an arbitrary development snapshot! *sigh* possible crash prevented"
 msgstr "비정식 CVS 버젼으로부터 릴리즈된 버젼에 연결할수없습니다! *휴우* 있을 수 있었던 충돌을 막았습니다."
 
-#: src/ExternalConn.cpp:714
+#: src/ExternalConn.cpp:713
 msgid "Invalid protocol version."
 msgstr "유효하지 않은 프로토콜 버젼입니다"
 
-#: src/ExternalConn.cpp:720
+#: src/ExternalConn.cpp:719
 msgid "Missing protocol version tag."
 msgstr "프로토콜 버젼 태그 없음"
 
-#: src/ExternalConn.cpp:728
+#: src/ExternalConn.cpp:727
 msgid "Authentication failed: invalid hash specified as EC password."
 msgstr ""
 
-#: src/ExternalConn.cpp:776
+#: src/ExternalConn.cpp:775
 #, fuzzy
 msgid "Authentication failed: wrong password."
 msgstr "인증에 실패했습니다."
 
-#: src/ExternalConn.cpp:778
+#: src/ExternalConn.cpp:777
 #, fuzzy
 msgid "Authentication failed: missing password."
 msgstr "인증에 실패했습니다."
 
-#: src/ExternalConn.cpp:789
+#: src/ExternalConn.cpp:788
 #, fuzzy
 msgid "Invalid request, please authenticate first."
 msgstr "유효하지않은 요청, 먼저 인증을 하세요."
 
-#: src/ExternalConn.cpp:794
+#: src/ExternalConn.cpp:793
 msgid "Access granted."
 msgstr "접근 허가되었습니다."
 
-#: src/ExternalConn.cpp:802
+#: src/ExternalConn.cpp:801
 #, fuzzy, c-format
 msgid "Sent error message \"%s\" to client."
 msgstr "알 수 없는 클라이언트로부터 메시지를 차단"
 
-#: src/ExternalConn.cpp:807
+#: src/ExternalConn.cpp:806
 #, fuzzy, c-format
 msgid "Unauthorized access attempt from %s. Connection closed."
 msgstr "허락되지않은 접속입니다. 연결이 끊깁니다."
 
-#: src/ExternalConn.cpp:1420
+#: src/ExternalConn.cpp:1419
 #, c-format
 msgid "Remote PartFile command failed: FileHash not found: %s"
 msgstr "원격 부분파일 명령 실패: 파일해시를 찾을 수 없음: %s "
 
-#: src/ExternalConn.cpp:1424
+#: src/ExternalConn.cpp:1423
 #, c-format
 msgid "FileHash not found: %s"
 msgstr "파일해시를 찾을 수 없음: %s"
 
-#: src/ExternalConn.cpp:1471 src/ExternalConn.cpp:1559
-#: src/ExternalConn.cpp:1680
+#: src/ExternalConn.cpp:1470 src/ExternalConn.cpp:1558
+#: src/ExternalConn.cpp:1679
 msgid "OOPS! OpCode processing error!"
 msgstr "이런! 명령코드 처리 오류!"
 
-#: src/ExternalConn.cpp:1502
+#: src/ExternalConn.cpp:1501
 msgid "Server not added"
 msgstr "서버가 추가되지 않음"
 
-#: src/ExternalConn.cpp:1521
+#: src/ExternalConn.cpp:1520
 #, c-format
 msgid "server not found: %s"
 msgstr "서버가 발견되지 않음: %s"
 
-#: src/ExternalConn.cpp:1538
+#: src/ExternalConn.cpp:1537
 msgid "need to define server to be removed"
 msgstr "제거할 서버의 정의가 필요합니다."
 
-#: src/ExternalConn.cpp:1553
+#: src/ExternalConn.cpp:1552
 msgid "eD2k is disabled in preferences."
 msgstr ""
 
-#: src/ExternalConn.cpp:1658
+#: src/ExternalConn.cpp:1657
 #, fuzzy
 msgid "Friend not found."
 msgstr "파일을 찾을 수 없습니다."
 
-#: src/ExternalConn.cpp:1668
+#: src/ExternalConn.cpp:1667
 #, fuzzy
 msgid "Client not found."
 msgstr "파일을 찾을 수 없습니다."
 
-#: src/ExternalConn.cpp:1674
+#: src/ExternalConn.cpp:1673
 msgid "EC_TAG_FRIEND_SHARED requires EC_TAG_FRIEND or EC_TAG_CLIENT."
 msgstr ""
 
-#: src/ExternalConn.cpp:1992
+#: src/ExternalConn.cpp:1991
 msgid "WebSearch from remote interface makes no sense."
 msgstr "원격 인터페이스로부터 웹검색은 좋지않은 선택입니다."
 
-#: src/ExternalConn.cpp:2027
+#: src/ExternalConn.cpp:2026
 msgid "Search in progress. Refetch results in a moment!"
 msgstr "검색중입니다. 금방 결과를 다시 가져옵니다."
 
-#: src/ExternalConn.cpp:2266
+#: src/ExternalConn.cpp:2265
 msgid "No points for graph."
 msgstr "그래프가 비어있음."
 
-#: src/ExternalConn.cpp:2276
+#: src/ExternalConn.cpp:2275
 msgid "Your client is not configured for this detail level."
 msgstr "클라이언트는 세부 수준이 구성되지 않았습니다."
 
-#: src/ExternalConn.cpp:2303
+#: src/ExternalConn.cpp:2302
 msgid "External Connection: shutdown requested"
 msgstr ""
 
-#: src/ExternalConn.cpp:2315
+#: src/ExternalConn.cpp:2314
 msgid "Already shutting down."
 msgstr "이미 종료하는중입니다."
 
-#: src/ExternalConn.cpp:2333
+#: src/ExternalConn.cpp:2332
 #, c-format
 msgid "ExternalConn: adding link '%s'."
 msgstr "외부연결: '%s' 링크를 추가합니다."
 
-#: src/ExternalConn.cpp:2351
+#: src/ExternalConn.cpp:2350
 #, fuzzy, c-format
 msgid "%d of %d links failed (invalid or already on list)."
 msgstr "유효하지 않은 링크거나 이미 목록에 존재합니다."
 
-#: src/ExternalConn.cpp:2374
+#: src/ExternalConn.cpp:2373
 msgid "Version check throttled; try again shortly."
 msgstr ""
 
-#: src/ExternalConn.cpp:2379
+#: src/ExternalConn.cpp:2378
 msgid "Version check is not available on this daemon."
 msgstr ""
 
-#: src/ExternalConn.cpp:2509
+#: src/ExternalConn.cpp:2508
 msgid "File not found."
 msgstr "파일을 찾을 수 없습니다."
 
-#: src/ExternalConn.cpp:2514
+#: src/ExternalConn.cpp:2513
 msgid "Invalid file name."
 msgstr "유효하지 않은 파일 이름입니다."
 
-#: src/ExternalConn.cpp:2522
+#: src/ExternalConn.cpp:2521
 msgid "Unable to rename file."
 msgstr "파일이름을 변경할 수 없습니다."
 
-#: src/ExternalConn.cpp:2839
-#, c-format
-msgid "Could not save the amuleapi password: %s"
-msgstr ""
-
-#: src/ExternalConn.cpp:3004 src/ExternalConn.cpp:3032
+#: src/ExternalConn.cpp:2992 src/ExternalConn.cpp:3020
 msgid "Kad is disabled in preferences."
 msgstr "Kad는 환경설정에서 비활성화되어 있습니다."
 
-#: src/ExternalConn.cpp:3045
+#: src/ExternalConn.cpp:3033
 msgid "Already connected to eD2k."
 msgstr ""
 
-#: src/ExternalConn.cpp:3048
+#: src/ExternalConn.cpp:3036
 msgid "Connecting to eD2k..."
 msgstr ""
 
-#: src/ExternalConn.cpp:3057
+#: src/ExternalConn.cpp:3045
 msgid "Already connected to Kad."
 msgstr "이미 Kad에 연결되었습니다."
 
-#: src/ExternalConn.cpp:3060
+#: src/ExternalConn.cpp:3048
 msgid "Connecting to Kad..."
 msgstr "Kad에 연결중..."
 
-#: src/ExternalConn.cpp:3067
+#: src/ExternalConn.cpp:3055
 msgid "All networks are disabled."
 msgstr "모든 통신망을 사용할수 없습니다."
 
-#: src/ExternalConn.cpp:3076
+#: src/ExternalConn.cpp:3064
 msgid "Disconnected from eD2k."
 msgstr ""
 
-#: src/ExternalConn.cpp:3081
+#: src/ExternalConn.cpp:3069
 msgid "Disconnected from Kad."
 msgstr "Kad로부터 연결이 끊겼습니다."
 
-#: src/ExternalConn.cpp:3090
+#: src/ExternalConn.cpp:3078
 #, c-format
 msgid "External Connection: invalid opcode received: %#x"
 msgstr ""
 
-#: src/ExternalConn.cpp:3095
+#: src/ExternalConn.cpp:3083
 msgid "Invalid opcode (wrong protocol version?)"
 msgstr "유효하지 않은 실행코드(잘못된 프로토콜 버젼?)"
 
@@ -2358,19 +2348,19 @@ msgstr ""
 msgid "eD2k"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:349 src/muuli_wdr.cpp:1495
+#: src/FirstRunWizard.cpp:349 src/muuli_wdr.cpp:1488
 msgid "Kademlia"
 msgstr "카뎀리아"
 
-#: src/FirstRunWizard.cpp:359 src/muuli_wdr.cpp:1423
+#: src/FirstRunWizard.cpp:359 src/muuli_wdr.cpp:1416
 msgid "Standard TCP Port "
 msgstr ""
 
-#: src/FirstRunWizard.cpp:365 src/muuli_wdr.cpp:1435
+#: src/FirstRunWizard.cpp:365 src/muuli_wdr.cpp:1428
 msgid "Extended UDP port (Kad / global search) "
 msgstr ""
 
-#: src/FirstRunWizard.cpp:377 src/muuli_wdr.cpp:1442
+#: src/FirstRunWizard.cpp:377 src/muuli_wdr.cpp:1435
 msgid "Enable UPnP for router port forwarding"
 msgstr ""
 
@@ -2397,7 +2387,7 @@ msgstr ""
 msgid "Your peer lists are already in place - nothing to download."
 msgstr "이미 %s 파일을 내려받으려고 하고있음"
 
-#: src/FirstRunWizard.cpp:434 src/muuli_wdr.cpp:1540
+#: src/FirstRunWizard.cpp:434 src/muuli_wdr.cpp:1533
 msgid "Auto-update server list at startup"
 msgstr ""
 
@@ -2443,23 +2433,23 @@ msgid ""
 "want downloads on a different (e.g. larger) disk."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:549 src/FirstRunWizard.cpp:611 src/muuli_wdr.cpp:1702
+#: src/FirstRunWizard.cpp:549 src/FirstRunWizard.cpp:611 src/muuli_wdr.cpp:1701
 msgid "Destination folder for downloads"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:553 src/FirstRunWizard.cpp:569 src/muuli_wdr.cpp:1349
-#: src/muuli_wdr.cpp:1366 src/muuli_wdr.cpp:1677 src/muuli_wdr.cpp:1708
-#: src/muuli_wdr.cpp:1720 src/muuli_wdr.cpp:2790
+#: src/FirstRunWizard.cpp:553 src/FirstRunWizard.cpp:569 src/muuli_wdr.cpp:1342
+#: src/muuli_wdr.cpp:1359 src/muuli_wdr.cpp:1676 src/muuli_wdr.cpp:1707
+#: src/muuli_wdr.cpp:1719 src/muuli_wdr.cpp:2762
 #: src/utils/aLinkCreator/src/alcframe.cpp:135
 #: src/utils/wxCas/src/wxcasprefs.cpp:52 src/utils/wxCas/src/wxcasprefs.cpp:118
 msgid "Browse"
 msgstr "탐색"
 
-#: src/FirstRunWizard.cpp:559 src/muuli_wdr.cpp:1713
+#: src/FirstRunWizard.cpp:559 src/muuli_wdr.cpp:1712
 msgid "(All files in this folder are shared with other peers)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:565 src/FirstRunWizard.cpp:624 src/muuli_wdr.cpp:1715
+#: src/FirstRunWizard.cpp:565 src/FirstRunWizard.cpp:624 src/muuli_wdr.cpp:1714
 msgid "Folder for temporary download files"
 msgstr ""
 
@@ -2490,7 +2480,7 @@ msgstr ""
 msgid "CRITICAL - no client on StartChatSession"
 msgstr ""
 
-#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2696 src/muuli_wdr.cpp:3373
+#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2668 src/muuli_wdr.cpp:3345
 msgid "Friends"
 msgstr "친구"
 
@@ -2606,8 +2596,8 @@ msgstr "아무도"
 msgid "No"
 msgstr "아니오"
 
-#: src/GenericClientListCtrl.cpp:1216 src/PrefsUnifiedDlg.cpp:2898
-#: src/PrefsUnifiedDlg.cpp:2948 src/ServerListCtrl.cpp:276
+#: src/GenericClientListCtrl.cpp:1216 src/PrefsUnifiedDlg.cpp:2818
+#: src/PrefsUnifiedDlg.cpp:2868 src/ServerListCtrl.cpp:276
 msgid "Yes"
 msgstr "예"
 
@@ -2777,10 +2767,10 @@ msgstr "초기적재에 유효하지 않은 포트"
 msgid "Please fill all fields required"
 msgstr "모든 항목을 채워주세요."
 
-#: src/KadDlg.cpp:192 src/PartFile.cpp:1031 src/PrefsUnifiedDlg.cpp:1134
-#: src/PrefsUnifiedDlg.cpp:1204 src/PrefsUnifiedDlg.cpp:1405
-#: src/PrefsUnifiedDlg.cpp:1663 src/PrefsUnifiedDlg.cpp:1673
-#: src/PrefsUnifiedDlg.cpp:1690 src/PrefsUnifiedDlg.cpp:1738
+#: src/KadDlg.cpp:192 src/PartFile.cpp:1031 src/PrefsUnifiedDlg.cpp:1162
+#: src/PrefsUnifiedDlg.cpp:1331 src/PrefsUnifiedDlg.cpp:1589
+#: src/PrefsUnifiedDlg.cpp:1599 src/PrefsUnifiedDlg.cpp:1616
+#: src/PrefsUnifiedDlg.cpp:1658
 msgid "Message"
 msgstr "메시지"
 
@@ -2882,7 +2872,7 @@ msgstr ""
 msgid "Uploaded"
 msgstr ""
 
-#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3253
+#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3225
 msgid "Requested"
 msgstr ""
 
@@ -3008,7 +2998,7 @@ msgid "WARNING: "
 msgstr ""
 
 #: src/MuleNotebook.cpp:179 src/muuli_wdr.cpp:817 src/muuli_wdr.cpp:1229
-#: src/muuli_wdr.cpp:3157 src/muuli_wdr.cpp:3413
+#: src/muuli_wdr.cpp:3129 src/muuli_wdr.cpp:3385
 msgid "Close"
 msgstr "닫기"
 
@@ -3021,12 +3011,12 @@ msgstr "자르기"
 msgid "Copy"
 msgstr "복사"
 
-#: src/MuleTextCtrl.cpp:88 src/SearchDlg.cpp:261
+#: src/MuleTextCtrl.cpp:88
 msgid "Paste"
 msgstr "붙이기"
 
 #: src/MuleTextCtrl.cpp:89 src/muuli_wdr.cpp:358 src/muuli_wdr.cpp:757
-#: src/muuli_wdr.cpp:2380 src/muuli_wdr.cpp:2399 src/muuli_wdr.cpp:2421
+#: src/muuli_wdr.cpp:2352 src/muuli_wdr.cpp:2371 src/muuli_wdr.cpp:2393
 #: src/utils/aLinkCreator/src/alcframe.cpp:142
 msgid "Clear"
 msgstr "깨끗이"
@@ -3123,8 +3113,8 @@ msgid "Exit"
 msgstr "종료"
 
 #: src/MuleTrayIcon.cpp:579 src/MuleTrayIcon.cpp:945 src/MuleTrayIcon.cpp:965
-#: src/muuli_wdr.cpp:1398 src/muuli_wdr.cpp:1406 src/muuli_wdr.cpp:1413
-#: src/muuli_wdr.cpp:1836 src/muuli_wdr.cpp:1842 src/OtherFunctions.cpp:91
+#: src/muuli_wdr.cpp:1391 src/muuli_wdr.cpp:1399 src/muuli_wdr.cpp:1406
+#: src/muuli_wdr.cpp:1835 src/muuli_wdr.cpp:1841 src/OtherFunctions.cpp:91
 #: src/StatisticsDlg.cpp:93 src/StatisticsDlg.cpp:95
 msgid "kB/s"
 msgstr "kB/s"
@@ -3295,7 +3285,7 @@ msgstr "이름:"
 msgid "Type"
 msgstr "종류"
 
-#: src/muuli_wdr.cpp:215 src/SearchDlg.cpp:118 src/SearchListCtrl.cpp:853
+#: src/muuli_wdr.cpp:215 src/SearchDlg.cpp:110 src/SearchListCtrl.cpp:853
 msgid "Local"
 msgstr "지역"
 
@@ -3366,7 +3356,7 @@ msgstr "바이트"
 msgid "KB"
 msgstr "KB"
 
-#: src/muuli_wdr.cpp:274 src/muuli_wdr.cpp:293 src/muuli_wdr.cpp:1621
+#: src/muuli_wdr.cpp:274 src/muuli_wdr.cpp:293 src/muuli_wdr.cpp:1620
 #: src/OtherFunctions.cpp:64
 msgid "MB"
 msgstr "MB"
@@ -3383,7 +3373,7 @@ msgstr "최대 크기"
 msgid "Availability"
 msgstr "유효성"
 
-#: src/muuli_wdr.cpp:312 src/muuli_wdr.cpp:398 src/muuli_wdr.cpp:3318
+#: src/muuli_wdr.cpp:312 src/muuli_wdr.cpp:398 src/muuli_wdr.cpp:3290
 msgid "Filter:"
 msgstr "필터:"
 
@@ -3415,7 +3405,7 @@ msgstr ""
 msgid "Stop"
 msgstr "멈춤"
 
-#: src/muuli_wdr.cpp:348 src/muuli_wdr.cpp:1392 src/SearchListCtrl.cpp:732
+#: src/muuli_wdr.cpp:348 src/muuli_wdr.cpp:1385 src/SearchListCtrl.cpp:732
 msgid "Download"
 msgstr "내려받기"
 
@@ -3447,12 +3437,12 @@ msgstr "자료 유지"
 #: src/muuli_wdr.cpp:1160 src/muuli_wdr.cpp:1167 src/muuli_wdr.cpp:1172
 #: src/muuli_wdr.cpp:1179 src/muuli_wdr.cpp:1184 src/muuli_wdr.cpp:1191
 #: src/muuli_wdr.cpp:1205 src/muuli_wdr.cpp:1212 src/muuli_wdr.cpp:1217
-#: src/muuli_wdr.cpp:1224 src/muuli_wdr.cpp:3255 src/muuli_wdr.cpp:3263
-#: src/muuli_wdr.cpp:3271
+#: src/muuli_wdr.cpp:1224 src/muuli_wdr.cpp:3227 src/muuli_wdr.cpp:3235
+#: src/muuli_wdr.cpp:3243
 msgid "N/A"
 msgstr "없음"
 
-#: src/muuli_wdr.cpp:508 src/muuli_wdr.cpp:1065 src/PrefsUnifiedDlg.cpp:299
+#: src/muuli_wdr.cpp:508 src/muuli_wdr.cpp:1065 src/PrefsUnifiedDlg.cpp:297
 msgid "General"
 msgstr "일반"
 
@@ -3593,7 +3583,7 @@ msgstr ""
 msgid "Album :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:685 src/muuli_wdr.cpp:2275
+#: src/muuli_wdr.cpp:685 src/muuli_wdr.cpp:2247
 msgid "Title :"
 msgstr "제목 :"
 
@@ -3700,7 +3690,7 @@ msgstr "사용자 이름 :"
 msgid "Userhash :"
 msgstr "사용자 해시 :"
 
-#: src/muuli_wdr.cpp:895 src/muuli_wdr.cpp:1742 src/muuli_wdr.cpp:2470
+#: src/muuli_wdr.cpp:895 src/muuli_wdr.cpp:1741 src/muuli_wdr.cpp:2442
 #: src/utils/aLinkCreator/src/alcframe.cpp:137
 msgid "Add"
 msgstr "추가"
@@ -3709,15 +3699,15 @@ msgstr "추가"
 msgid "Download-Speed"
 msgstr "내려받기 속도"
 
-#: src/muuli_wdr.cpp:954 src/muuli_wdr.cpp:989 src/muuli_wdr.cpp:2574
+#: src/muuli_wdr.cpp:954 src/muuli_wdr.cpp:989 src/muuli_wdr.cpp:2546
 msgid "Current"
 msgstr "현재"
 
-#: src/muuli_wdr.cpp:962 src/muuli_wdr.cpp:997 src/muuli_wdr.cpp:2582
+#: src/muuli_wdr.cpp:962 src/muuli_wdr.cpp:997 src/muuli_wdr.cpp:2554
 msgid "Running average"
 msgstr "동작중 평균"
 
-#: src/muuli_wdr.cpp:970 src/muuli_wdr.cpp:1005 src/muuli_wdr.cpp:2590
+#: src/muuli_wdr.cpp:970 src/muuli_wdr.cpp:1005 src/muuli_wdr.cpp:2562
 msgid "Session average"
 msgstr "세션 평균"
 
@@ -3729,7 +3719,7 @@ msgstr "올려주기 속도"
 msgid "Connections"
 msgstr "연결"
 
-#: src/muuli_wdr.cpp:1024 src/muuli_wdr.cpp:1861
+#: src/muuli_wdr.cpp:1024 src/muuli_wdr.cpp:1860
 msgid "Active downloads"
 msgstr "활성화된 내려받기"
 
@@ -3737,7 +3727,7 @@ msgstr "활성화된 내려받기"
 msgid "Active connections (1:1)"
 msgstr "활성화된 연결 (1:1)"
 
-#: src/muuli_wdr.cpp:1040 src/muuli_wdr.cpp:1862
+#: src/muuli_wdr.cpp:1040 src/muuli_wdr.cpp:1861
 msgid "Active uploads"
 msgstr "활성화된 올려주기"
 
@@ -3854,8 +3844,8 @@ msgstr "이것은 접속했을때 다른 사용자가 볼 수 있는 이름입�
 msgid "Language: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1257 src/muuli_wdr.cpp:1330 src/muuli_wdr.cpp:1334
-#: src/muuli_wdr.cpp:1337
+#: src/muuli_wdr.cpp:1257 src/muuli_wdr.cpp:1323 src/muuli_wdr.cpp:1327
+#: src/muuli_wdr.cpp:1330
 msgid "The delay before showing tool-tips."
 msgstr "도구도움이 보여주기 이전의 지연시간."
 
@@ -3933,960 +3923,936 @@ msgstr ""
 msgid "Enabling this will make aMule to show notifications when finished downloading."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1323
-#, fuzzy
-msgid "Remember search history"
-msgstr "설정을 기억"
-
-#: src/muuli_wdr.cpp:1324
-msgid "Keeps a dropdown list of your past search terms in the Search tab's Name field. This remembers the queries you typed, not the results they returned."
-msgstr ""
-
-#: src/muuli_wdr.cpp:1329
+#: src/muuli_wdr.cpp:1322
 msgid "Tooltip delay time: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1336
+#: src/muuli_wdr.cpp:1329
 msgid "seconds"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1340
+#: src/muuli_wdr.cpp:1333
 msgid "Browser Selection"
 msgstr "브라우저 선택"
 
-#: src/muuli_wdr.cpp:1346
+#: src/muuli_wdr.cpp:1339
 msgid "Enter your browser name here. Leave this field empty to use the system default browser."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1353
+#: src/muuli_wdr.cpp:1346
 msgid "Open in new tab if possible"
 msgstr "가능하면 새로운 탭을 생성함"
 
-#: src/muuli_wdr.cpp:1355
+#: src/muuli_wdr.cpp:1348
 msgid "Open the web page in a new tab instead of in a new window when possible"
 msgstr "가능하면 새로운 창을 여는것 대신 새로운 탭을 생성합니다."
 
-#: src/muuli_wdr.cpp:1359
+#: src/muuli_wdr.cpp:1352
 msgid "Video Player"
 msgstr "비디오 재생기"
 
-#: src/muuli_wdr.cpp:1386
+#: src/muuli_wdr.cpp:1379
 msgid "Bandwidth limits"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1400
+#: src/muuli_wdr.cpp:1393
 msgid "Upload"
 msgstr "올려주기"
 
-#: src/muuli_wdr.cpp:1408
+#: src/muuli_wdr.cpp:1401
 msgid "Slot Allocation"
 msgstr "칸 배분"
 
-#: src/muuli_wdr.cpp:1417
+#: src/muuli_wdr.cpp:1410
 msgid "Ports"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1427
+#: src/muuli_wdr.cpp:1420
 msgid "This is the standard eD2k port and cannot be disabled."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1430
+#: src/muuli_wdr.cpp:1423
 msgid "UDP port for server requests (TCP+3):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1432
+#: src/muuli_wdr.cpp:1425
 msgid "4665"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1439
+#: src/muuli_wdr.cpp:1432
 msgid "This UDP port is used for extended eD2k requests and Kad network"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1446
+#: src/muuli_wdr.cpp:1439
 msgid "UPnP TCP Port (Optional):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1456
+#: src/muuli_wdr.cpp:1449
 msgid "Bind local address to IP (empty for any):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1459
+#: src/muuli_wdr.cpp:1452
 msgid "Advanced users only: If you have multiple network interfaces, enter the address of the interface to which aMule should be bound."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1462 src/muuli_wdr.cpp:2055
+#: src/muuli_wdr.cpp:1455 src/muuli_wdr.cpp:2054
 msgid "Bind to network interface (empty for any):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1475
+#: src/muuli_wdr.cpp:1468
 msgid "Advanced users only: pin all of aMule's traffic to one network interface, chosen from the list or typed in by name (e.g. tun0, eth0, en0) or index. Unlike binding to an IP, this stops traffic leaking out via the default route - useful with a VPN. Requires no elevated privileges."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1481
+#: src/muuli_wdr.cpp:1474
 msgid "Max sources per downloading file:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1485
+#: src/muuli_wdr.cpp:1478
 msgid "Max simultaneous connections:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1498 src/muuli_wdr.cpp:3197
+#: src/muuli_wdr.cpp:1491 src/muuli_wdr.cpp:3169
 msgid "ED2K"
 msgstr "ED2k"
 
-#: src/muuli_wdr.cpp:1505
+#: src/muuli_wdr.cpp:1498
 msgid "Autoconnect on startup"
 msgstr "시작시 자동연결"
 
-#: src/muuli_wdr.cpp:1508
+#: src/muuli_wdr.cpp:1501
 msgid "Reconnect on loss"
 msgstr "끊겼을시 재연결"
 
-#: src/muuli_wdr.cpp:1530
+#: src/muuli_wdr.cpp:1523
 msgid "Remove dead server after"
 msgstr "죽은서버 제거"
 
-#: src/muuli_wdr.cpp:1531
+#: src/muuli_wdr.cpp:1524
 msgid "Static servers are never removed, even when unreachable."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1535
+#: src/muuli_wdr.cpp:1528
 msgid "retries"
 msgstr "재시도"
 
-#: src/muuli_wdr.cpp:1543
+#: src/muuli_wdr.cpp:1536
 msgid "List"
 msgstr "목록"
 
-#: src/muuli_wdr.cpp:1546
+#: src/muuli_wdr.cpp:1539
 msgid "Update server list when connecting to a server"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1549
+#: src/muuli_wdr.cpp:1542
 msgid "Update server list when a client connects"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1552
+#: src/muuli_wdr.cpp:1545
 msgid "Use priority system"
 msgstr "우선순위 시스템을 사용"
 
-#: src/muuli_wdr.cpp:1556
+#: src/muuli_wdr.cpp:1549
 msgid "Use smart LowID check on connect"
 msgstr "연결할때 현명한 낮은아이디 검사를 사용"
 
-#: src/muuli_wdr.cpp:1560
+#: src/muuli_wdr.cpp:1553
 msgid "Safe connect"
 msgstr "안전한 연결"
 
-#: src/muuli_wdr.cpp:1564
+#: src/muuli_wdr.cpp:1557
 msgid "Autoconnect to servers in static list only"
 msgstr "정적목록내의 서버에만 연결"
 
-#: src/muuli_wdr.cpp:1567
+#: src/muuli_wdr.cpp:1560
 msgid "Set manually added servers to High Priority"
 msgstr "수동으로 추가된 서버에 높은 우선권 부여"
 
-#: src/muuli_wdr.cpp:1588
+#: src/muuli_wdr.cpp:1581
 msgid "Add files to download in pause mode"
 msgstr "멈춤 상태로 내려받기에 파일 추가"
 
-#: src/muuli_wdr.cpp:1590
+#: src/muuli_wdr.cpp:1583
 msgid "Add files to download with auto priority"
 msgstr "자동 우선권으로 내려받기에 파일 추가"
 
-#: src/muuli_wdr.cpp:1593
+#: src/muuli_wdr.cpp:1586
 msgid "Try to download first and last chunks first"
 msgstr "처음과 마지막 부분을 먼저 내려받음"
 
-#: src/muuli_wdr.cpp:1597
+#: src/muuli_wdr.cpp:1590
 msgid "Endgame mode: rotate to faster sources for the final blocks"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1600
+#: src/muuli_wdr.cpp:1593
 msgid "Start next paused file when a file completes"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1603
+#: src/muuli_wdr.cpp:1596
 msgid "From the same category"
 msgstr "동일한 분류로부터"
 
-#: src/muuli_wdr.cpp:1605
+#: src/muuli_wdr.cpp:1598
 msgid "In alphabetic order"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1607
+#: src/muuli_wdr.cpp:1600
 msgid "Preallocate disk space for new files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1608
+#: src/muuli_wdr.cpp:1601
 msgid "For new files preallocates disk space for the whole file, thus reduces fragmentation"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1613
+#: src/muuli_wdr.cpp:1606
+msgid "Create new files as sparse files"
+msgstr ""
+
+#: src/muuli_wdr.cpp:1607
+msgid "A sparse file reserves its full size on disk immediately without writing real data to it -- fast, but unsupported or slow on some filesystems, and free-space accounting stays optimistic while the download is in progress. Turn this off to grow the file only as data arrives."
+msgstr ""
+
+#: src/muuli_wdr.cpp:1612
 msgid "Stop downloads when free disk space reaches "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1614
+#: src/muuli_wdr.cpp:1613
 msgid "Select this if you want aMule to check your disk space"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1618
+#: src/muuli_wdr.cpp:1617
 msgid "Enter here the min disk space desired."
 msgstr "원하는 최소한의 디스크공간을 입력하세요."
 
-#: src/muuli_wdr.cpp:1624
+#: src/muuli_wdr.cpp:1623
 msgid "Save 10 sources on rare files (< 20 sources)"
 msgstr "희귀한 파일인 경우 10개의 자료 저장 (<20 자료)"
 
-#: src/muuli_wdr.cpp:1628 src/Statistics.cpp:790
+#: src/muuli_wdr.cpp:1627 src/Statistics.cpp:790
 msgid "Uploads"
 msgstr "올려주기"
 
-#: src/muuli_wdr.cpp:1631
+#: src/muuli_wdr.cpp:1630
 msgid "Add new shared files with auto priority"
 msgstr "자동 우선권으로 새로운 공유파일을 추가"
 
-#: src/muuli_wdr.cpp:1637
+#: src/muuli_wdr.cpp:1636
 msgid "Intelligent Corruption Handling (I.C.H.)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1640
+#: src/muuli_wdr.cpp:1639
 msgid "Enable"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1643
+#: src/muuli_wdr.cpp:1642
 msgid "Advanced I.C.H. trusts every hash (not recommended)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1655 src/PrefsUnifiedDlg.cpp:1990
+#: src/muuli_wdr.cpp:1654 src/PrefsUnifiedDlg.cpp:1910
 msgid "Media metadata extraction"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1659
+#: src/muuli_wdr.cpp:1658
 msgid "Extract length / bitrate / codec from shared audio and video files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1661
+#: src/muuli_wdr.cpp:1660
 msgid "When enabled, aMule runs ffprobe on each shared media file to fill in the Length / Bitrate / Codec columns other clients see when they find the file in a search. Requires ffmpeg (the ffprobe binary) to be installed."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1668
+#: src/muuli_wdr.cpp:1667
 msgid "Path to ffprobe:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1673
+#: src/muuli_wdr.cpp:1672
 msgid "Full path to the ffprobe binary. Leave empty to have aMule auto-detect it on startup."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1681
+#: src/muuli_wdr.cpp:1680
 msgid "Detect"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1682
+#: src/muuli_wdr.cpp:1681
 msgid "Search the standard install locations for an ffprobe binary and fill the path field."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1706
+#: src/muuli_wdr.cpp:1705
 msgid ""
 "Completed downloads are stored here. All files in this folder are automatically shared with other peers.\n"
 "If this folder also holds files you don't want to share, point it at an aMule-only sub-folder."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1709
+#: src/muuli_wdr.cpp:1708
 msgid "Pick the folder where completed downloads will be stored. All files in that folder will be shared with other peers."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1723
+#: src/muuli_wdr.cpp:1722
 msgid "Shared folders"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1729
+#: src/muuli_wdr.cpp:1728
 msgid "(Folders shared by the core. Enter a path to add one.)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1737
+#: src/muuli_wdr.cpp:1736
 msgid "Absolute path of a folder on the core's machine, e.g. /home/user/shared"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1739 src/PrefsUnifiedDlg.cpp:2874
+#: src/muuli_wdr.cpp:1738 src/PrefsUnifiedDlg.cpp:2794
 msgid "Recursive"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1740
+#: src/muuli_wdr.cpp:1739
 msgid "Share every sub-folder underneath this one, including ones created later."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1744 src/utils/aLinkCreator/src/alcframe.cpp:141
+#: src/muuli_wdr.cpp:1743 src/utils/aLinkCreator/src/alcframe.cpp:141
 msgid "Remove"
 msgstr "삭제"
 
-#: src/muuli_wdr.cpp:1748
+#: src/muuli_wdr.cpp:1747
 msgid "(Right click on folder icon for recursive share)"
 msgstr "(하위폴더 전체를 공유하려면 폴더 아이콘상에서 오른쪽 버튼을 클릭)"
 
-#: src/muuli_wdr.cpp:1755
+#: src/muuli_wdr.cpp:1754
 msgid "Share hidden files"
 msgstr "숨은파일 공유"
 
-#: src/muuli_wdr.cpp:1761
+#: src/muuli_wdr.cpp:1760
 msgid "Automatically rescan shared folders for changes"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1767
+#: src/muuli_wdr.cpp:1766
 msgid "Follow symbolic links in shared folders"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1773
+#: src/muuli_wdr.cpp:1772
 msgid "Exclude files matching:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1776
+#: src/muuli_wdr.cpp:1775
 msgid "Wildcard patterns separated by '|', e.g. .DS_Store|Thumbs.db|*.tmp. Files whose name matches are not shared. Matching is case-insensitive."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1780
+#: src/muuli_wdr.cpp:1779
 msgid "Patterns are regular expressions"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1781
+#: src/muuli_wdr.cpp:1780
 msgid "When set, the whole field is one regular expression ('|' is alternation). When unset, it is a list of '|'-separated wildcards."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1791
+#: src/muuli_wdr.cpp:1790
 msgid "Show how many shared files the current pattern would exclude."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1812
+#: src/muuli_wdr.cpp:1811
 msgid "Graphs"
 msgstr "그래프"
 
-#: src/muuli_wdr.cpp:1815 src/muuli_wdr.cpp:1877
+#: src/muuli_wdr.cpp:1814 src/muuli_wdr.cpp:1876
 msgid "Update delay : 5 secs"
 msgstr "갱신 지연 : 5 초"
 
-#: src/muuli_wdr.cpp:1819
+#: src/muuli_wdr.cpp:1818
 msgid "Time for average graph: 100 mins"
 msgstr "평균 그래프 시간 : 100 분"
 
-#: src/muuli_wdr.cpp:1823
+#: src/muuli_wdr.cpp:1822
 msgid "Connections Graph Scale: 100 "
 msgstr "연결 그래프 크기 : 100"
 
-#: src/muuli_wdr.cpp:1830
+#: src/muuli_wdr.cpp:1829
 msgid "Download graph scale:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1838
+#: src/muuli_wdr.cpp:1837
 msgid "Upload graph scale:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1848
+#: src/muuli_wdr.cpp:1847
 msgid "Colors: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1852
+#: src/muuli_wdr.cpp:1851
 msgid "Background"
 msgstr "바탕"
 
-#: src/muuli_wdr.cpp:1853
+#: src/muuli_wdr.cpp:1852
 msgid "Grid"
 msgstr "눈금"
 
-#: src/muuli_wdr.cpp:1854
+#: src/muuli_wdr.cpp:1853
 msgid "Download current"
 msgstr "현재 내려받기"
 
-#: src/muuli_wdr.cpp:1855
+#: src/muuli_wdr.cpp:1854
 msgid "Download running average"
 msgstr "내려받기 운용 평균"
 
-#: src/muuli_wdr.cpp:1856
+#: src/muuli_wdr.cpp:1855
 msgid "Download session average"
 msgstr "내려받기 세션 평균"
 
-#: src/muuli_wdr.cpp:1857
+#: src/muuli_wdr.cpp:1856
 msgid "Upload current"
 msgstr "현재 올려주기"
 
-#: src/muuli_wdr.cpp:1858
+#: src/muuli_wdr.cpp:1857
 msgid "Upload running average"
 msgstr "올려주기 운용 평균"
 
-#: src/muuli_wdr.cpp:1859
+#: src/muuli_wdr.cpp:1858
 msgid "Upload session average"
 msgstr "올려주기 세션 평균"
 
-#: src/muuli_wdr.cpp:1860
+#: src/muuli_wdr.cpp:1859
 msgid "Active connections"
 msgstr "활성화된 연결"
 
-#: src/muuli_wdr.cpp:1863
+#: src/muuli_wdr.cpp:1862
 #, fuzzy
 msgid "Systray Icon Speed Bar"
 msgstr "시스템트레이 아이콘 속도바"
 
-#: src/muuli_wdr.cpp:1864
+#: src/muuli_wdr.cpp:1863
 msgid "Kad-nodes current"
 msgstr "현재 Kad-노드"
 
-#: src/muuli_wdr.cpp:1865
+#: src/muuli_wdr.cpp:1864
 msgid "Kad-nodes running"
 msgstr "Kad-노드 운용"
 
-#: src/muuli_wdr.cpp:1866
+#: src/muuli_wdr.cpp:1865
 msgid "Kad-nodes session"
 msgstr "Kad-노드 세션"
 
-#: src/muuli_wdr.cpp:1870 src/muuli_wdr.cpp:2324
+#: src/muuli_wdr.cpp:1869 src/muuli_wdr.cpp:2296
 msgid "Select"
 msgstr "선택"
 
-#: src/muuli_wdr.cpp:1874
+#: src/muuli_wdr.cpp:1873
 msgid "Tree"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1884
+#: src/muuli_wdr.cpp:1883
 msgid "Number of Client Versions shown (0=unlimited)"
 msgstr "표시될 클라이언트 버젼의 수 (0=무제한)"
 
-#: src/muuli_wdr.cpp:1909
+#: src/muuli_wdr.cpp:1908
 msgid "!!! WARNING !!!"
 msgstr "!!! 경고 !!!"
 
-#: src/muuli_wdr.cpp:1924
+#: src/muuli_wdr.cpp:1923
 msgid "Max new connections / 5 secs"
 msgstr "최대 새연결 / 5 초"
 
-#: src/muuli_wdr.cpp:1926
+#: src/muuli_wdr.cpp:1925
 msgid "Concurrent Kad source lookups"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1928
+#: src/muuli_wdr.cpp:1927
 #, fuzzy
 msgid "Kad source re-search interval (minutes)"
 msgstr "FTP 갱신율 분당 간격"
 
-#: src/muuli_wdr.cpp:1930
+#: src/muuli_wdr.cpp:1929
 #, fuzzy
 msgid "Source re-ask interval (minutes)"
 msgstr "FTP 갱신율 분당 간격"
 
-#: src/muuli_wdr.cpp:1934
+#: src/muuli_wdr.cpp:1933
 msgid "File Buffer Size: 240000 bytes"
 msgstr "파일 버퍼 크기: 240000 바이트"
 
-#: src/muuli_wdr.cpp:1938
+#: src/muuli_wdr.cpp:1937
 msgid "Use MMAP: memory-mapped file access (lower memory use)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1939
+#: src/muuli_wdr.cpp:1938
 msgid "Maps part files into memory instead of buffering them on the heap, lowering the process memory footprint. May reduce download speed on some disks; best for memory-constrained or upload-heavy hosts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1941
+#: src/muuli_wdr.cpp:1940
 msgid "Upload Queue Size: 5000 clients"
 msgstr "올려주기 대기열 크기: 5000 클라이언트"
 
-#: src/muuli_wdr.cpp:1945
+#: src/muuli_wdr.cpp:1944
 msgid "Server connection refresh interval: Disable"
 msgstr "서버 연결 갱신 간격: 사용않함"
 
-#: src/muuli_wdr.cpp:1949
+#: src/muuli_wdr.cpp:1948
 msgid "Disable computer's timed standby mode"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1968
+#: src/muuli_wdr.cpp:1967
 msgid "Skin to use: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1977
+#: src/muuli_wdr.cpp:1976
 msgid "Show \"Fast eD2k Links Handler\" in every window."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1980
+#: src/muuli_wdr.cpp:1979
 msgid "Show extended info on categories tabs"
 msgstr "분류탭의 확장된 정보를 보여줌"
 
-#: src/muuli_wdr.cpp:1983
+#: src/muuli_wdr.cpp:1982
 #, fuzzy
 msgid "Show application version on title"
 msgstr "제목에 전송률을 보여줌"
 
-#: src/muuli_wdr.cpp:1985
+#: src/muuli_wdr.cpp:1984
 msgid "Show transfer rates on title"
 msgstr "제목에 전송률을 보여줌"
 
-#: src/muuli_wdr.cpp:1987
+#: src/muuli_wdr.cpp:1986
 msgid "Before application name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1989
+#: src/muuli_wdr.cpp:1988
 msgid "After application name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1992
+#: src/muuli_wdr.cpp:1991
 msgid "Show overhead bandwidth"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1996
+#: src/muuli_wdr.cpp:1995
 msgid "Vertical toolbar orientation"
 msgstr "수직방향 툴바"
 
-#: src/muuli_wdr.cpp:1998
+#: src/muuli_wdr.cpp:1997
 msgid "Live column sorting (auto-reorder rows as their values change)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2005
+#: src/muuli_wdr.cpp:2004
 msgid "Download Queue Files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2008
+#: src/muuli_wdr.cpp:2007
 msgid "Show progress percentage"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2014
+#: src/muuli_wdr.cpp:2013
 msgid "Show progress bar"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2017
+#: src/muuli_wdr.cpp:2016
 msgid "Flat"
 msgstr "평평한"
 
-#: src/muuli_wdr.cpp:2021
+#: src/muuli_wdr.cpp:2020
 msgid "Round"
 msgstr "둥근"
 
-#: src/muuli_wdr.cpp:2039
+#: src/muuli_wdr.cpp:2038
 msgid "External Connection Parameters"
 msgstr "외부연결 설정"
 
-#: src/muuli_wdr.cpp:2042
+#: src/muuli_wdr.cpp:2041
 msgid "Accept external connections"
 msgstr "외부연결 받아들임"
 
-#: src/muuli_wdr.cpp:2049 src/muuli_wdr.cpp:2108
+#: src/muuli_wdr.cpp:2048 src/muuli_wdr.cpp:2107
 msgid "IP of the listening interface:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2052
+#: src/muuli_wdr.cpp:2051
 msgid "Enter here a valid ip in the a.b.c.d format for the listening EC interface. An empty field or 0.0.0.0 will mean any interface."
 msgstr "수신대기 외부연결 인터페이스에 a.b.c.d 형식의 유효한 IP를 입력하세요. 항목이 비었거나 0.0.0.0이면 모든 인터페이스를 의미합니다."
 
-#: src/muuli_wdr.cpp:2073 src/muuli_wdr.cpp:2184
+#: src/muuli_wdr.cpp:2072 src/muuli_wdr.cpp:2156
 msgid "TCP port:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2079
+#: src/muuli_wdr.cpp:2078
 msgid "Enable UPnP port forwarding on the EC port"
 msgstr "외부연결 포트에 UPnP 포트포워딩 활성화"
 
-#: src/muuli_wdr.cpp:2083 src/muuli_wdr.cpp:3069
+#: src/muuli_wdr.cpp:2082 src/muuli_wdr.cpp:3041
 #: src/utils/wxCas/src/wxcasprefs.cpp:167
 msgid "Password"
 msgstr "암호"
 
-#: src/muuli_wdr.cpp:2089
+#: src/muuli_wdr.cpp:2088
 msgid "aMule API server parameters"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2092
+#: src/muuli_wdr.cpp:2091
 msgid "Run amuleapi (REST API) on startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2097
+#: src/muuli_wdr.cpp:2096
 #, fuzzy
 msgid "HTTP port:"
 msgstr "프록시 포트:"
 
-#: src/muuli_wdr.cpp:2111
+#: src/muuli_wdr.cpp:2110
 msgid "The interface amuleapi's HTTP server listens on. 127.0.0.1 (default) accepts only local connections; use 0.0.0.0 or a specific IP to expose it to other hosts (set an admin password below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2116
-msgid "Type a password to set or change it. Stored passwords cannot be shown, so leaving this empty keeps the current one."
-msgstr ""
-
-#: src/muuli_wdr.cpp:2118
+#: src/muuli_wdr.cpp:2113
 #, fuzzy
 msgid "Admin password"
 msgstr "암호를 검사중\n"
 
-#: src/muuli_wdr.cpp:2130 src/muuli_wdr.cpp:2147 src/PrefsUnifiedDlg.cpp:1103
-#, fuzzy
-msgid "A password is set."
-msgstr "암호를 검사중\n"
-
-#: src/muuli_wdr.cpp:2134
-#, fuzzy
-msgid "Enable guest access"
-msgstr "손님 접근 금지"
-
-#: src/muuli_wdr.cpp:2135
-msgid "Guest sessions may read status and listings but cannot change anything. Turning this off clears the stored guest password."
-msgstr ""
-
-#: src/muuli_wdr.cpp:2139
-#, fuzzy
-msgid "Guest password"
-msgstr "모든 권한 암호"
-
-#: src/muuli_wdr.cpp:2154
-msgid "Web server parameters"
-msgstr ""
-
-#: src/muuli_wdr.cpp:2157
-msgid "Run webserver on startup (deprecated)"
-msgstr ""
-
-#: src/muuli_wdr.cpp:2163
-msgid "Web template"
-msgstr "웹 템플릿"
-
-#: src/muuli_wdr.cpp:2168
-msgid "Full rights password"
-msgstr "모든 권한 암호"
-
-#: src/muuli_wdr.cpp:2172
-msgid "Enable Low rights User"
-msgstr "낮은권한 사용자 활성화"
-
-#: src/muuli_wdr.cpp:2177
+#: src/muuli_wdr.cpp:2118 src/muuli_wdr.cpp:2149
 msgid "Low rights password"
 msgstr "낮은 권한 암호"
 
-#: src/muuli_wdr.cpp:2191
+#: src/muuli_wdr.cpp:2126
+msgid "Web server parameters"
+msgstr ""
+
+#: src/muuli_wdr.cpp:2129
+msgid "Run webserver on startup (deprecated)"
+msgstr ""
+
+#: src/muuli_wdr.cpp:2135
+msgid "Web template"
+msgstr "웹 템플릿"
+
+#: src/muuli_wdr.cpp:2140
+msgid "Full rights password"
+msgstr "모든 권한 암호"
+
+#: src/muuli_wdr.cpp:2144
+msgid "Enable Low rights User"
+msgstr "낮은권한 사용자 활성화"
+
+#: src/muuli_wdr.cpp:2163
 msgid "Enable UPnP port forwarding of the web server port"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2196
+#: src/muuli_wdr.cpp:2168
 msgid "Web server UPnP TCP port (Optional)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2204
+#: src/muuli_wdr.cpp:2176
 msgid "Page Refresh Time (in secs)"
 msgstr "페이지를 갱신 시간 (초)"
 
-#: src/muuli_wdr.cpp:2211
+#: src/muuli_wdr.cpp:2183
 msgid "Enable Gzip compression"
 msgstr "Gzip압축을 활성화"
 
-#: src/muuli_wdr.cpp:2245
+#: src/muuli_wdr.cpp:2217
 #, fuzzy
 msgid "Reset page to defaults"
 msgstr "기본 설정"
 
-#: src/muuli_wdr.cpp:2246
+#: src/muuli_wdr.cpp:2218
 msgid "Reset the settings on the current page to their default values."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2248 src/muuli_wdr.cpp:2334 src/ServerWnd.cpp:274
+#: src/muuli_wdr.cpp:2220 src/muuli_wdr.cpp:2306 src/ServerWnd.cpp:274
 #: src/ServerWnd.cpp:282
 msgid "OK"
 msgstr "확인"
 
-#: src/muuli_wdr.cpp:2250
+#: src/muuli_wdr.cpp:2222
 msgid "Click here to apply any changes made to the preferences."
 msgstr "환경설정으로 바꾼것을 적용하려면 이곳을 클릭하세요."
 
-#: src/muuli_wdr.cpp:2253
+#: src/muuli_wdr.cpp:2225
 msgid "Reset any changes made to the preferences."
 msgstr "환경설정으로 바꾼것을 초기화합니다."
 
-#: src/muuli_wdr.cpp:2282
+#: src/muuli_wdr.cpp:2254
 msgid "Comment :"
 msgstr "의견 :"
 
-#: src/muuli_wdr.cpp:2289
+#: src/muuli_wdr.cpp:2261
 msgid "Incoming Dir :"
 msgstr "내려받는 폴더 :"
 
-#: src/muuli_wdr.cpp:2298
+#: src/muuli_wdr.cpp:2270
 msgid "Change priority for new assigned files :"
 msgstr "새롭게 할당된 파일의 우선권를 바꿉니다. :"
 
-#: src/muuli_wdr.cpp:2302
+#: src/muuli_wdr.cpp:2274
 #, fuzzy
 msgid "Don't change"
 msgstr "변경 않음"
 
-#: src/muuli_wdr.cpp:2314
+#: src/muuli_wdr.cpp:2286
 msgid "Select color for this Category (currently selected) :"
 msgstr "이 분류의 색을 선택 (일반적으로 선택된) :"
 
-#: src/muuli_wdr.cpp:2381 src/muuli_wdr.cpp:2400 src/muuli_wdr.cpp:2422
+#: src/muuli_wdr.cpp:2353 src/muuli_wdr.cpp:2372 src/muuli_wdr.cpp:2394
 msgid "Click this button to reset the log."
 msgstr "로그를 초기화하려면 이 버튼을 클릭하세요."
 
-#: src/muuli_wdr.cpp:2441
+#: src/muuli_wdr.cpp:2413
 msgid "Click on this button to update the servers list from URL ..."
 msgstr "URL로부터 서버 목록을 갱신하려면 이 버튼을 클릭..."
 
-#: src/muuli_wdr.cpp:2445
+#: src/muuli_wdr.cpp:2417
 msgid "Server list"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2449
+#: src/muuli_wdr.cpp:2421
 msgid "Enter the url to a server.met file here and press the button to the left to update the list of known servers."
 msgstr "알려진 서버의 목록을 갱신하기 위해서는 이곳에 server.met파일의 url을 입력하고 왼쪽편의 버튼을 누르세요."
 
-#: src/muuli_wdr.cpp:2454
+#: src/muuli_wdr.cpp:2426
 msgid "Add server manually: Name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2457
+#: src/muuli_wdr.cpp:2429
 msgid "Enter the name of the new server here"
 msgstr "새로운 서버의 이름을 입력하세요."
 
-#: src/muuli_wdr.cpp:2459 src/ServerWnd.cpp:206
+#: src/muuli_wdr.cpp:2431 src/ServerWnd.cpp:206
 msgid "IP:Port"
 msgstr "IP:포트"
 
-#: src/muuli_wdr.cpp:2462
+#: src/muuli_wdr.cpp:2434
 msgid "Enter the IP of the server here, using the x.x.x.x format."
 msgstr "x.x.x.x형식으로 서버의 IP를 이곳에 입력하세요."
 
-#: src/muuli_wdr.cpp:2468
+#: src/muuli_wdr.cpp:2440
 msgid "Enter the port of the server here."
 msgstr "서버의 포트를 이곳에 입력하세요."
 
-#: src/muuli_wdr.cpp:2471
+#: src/muuli_wdr.cpp:2443
 msgid "Add manually a server (fill fields to the left before) ..."
 msgstr "서버 수동 추가 (미리 왼쪽 부분을 채울 것) ..."
 
-#: src/muuli_wdr.cpp:2500
+#: src/muuli_wdr.cpp:2472
 msgid "aMule Log"
 msgstr "어뮬 로그"
 
-#: src/muuli_wdr.cpp:2508
+#: src/muuli_wdr.cpp:2480
 msgid "Server Info"
 msgstr "서버 정보"
 
-#: src/muuli_wdr.cpp:2512
+#: src/muuli_wdr.cpp:2484
 msgid "ED2K Info"
 msgstr "ED2k 정보"
 
-#: src/muuli_wdr.cpp:2516
+#: src/muuli_wdr.cpp:2488
 msgid "Kad Info"
 msgstr "Kad 정보"
 
-#: src/muuli_wdr.cpp:2544
+#: src/muuli_wdr.cpp:2516
 msgid "Click on this button to update the nodes list from URL ..."
 msgstr "URL로부터 노드를 갱신하려면 이 버튼을 클릭..."
 
-#: src/muuli_wdr.cpp:2548
+#: src/muuli_wdr.cpp:2520
 msgid "Nodes (0)"
 msgstr "노드 (0)"
 
-#: src/muuli_wdr.cpp:2552
+#: src/muuli_wdr.cpp:2524
 msgid "Enter the url to a nodes.dat file here and press the button to the left to update the list of known nodes."
 msgstr "알려진 노드의 목록을 갱신하기 위해서는 이곳에 nodes.dat파일의 url을 입력하고 왼쪽편의 버튼을 누르세요."
 
-#: src/muuli_wdr.cpp:2555
+#: src/muuli_wdr.cpp:2527
 msgid "Nodes stats"
 msgstr "노드 상태"
 
-#: src/muuli_wdr.cpp:2597
+#: src/muuli_wdr.cpp:2569
 msgid "Bootstrap"
 msgstr "초기적재"
 
-#: src/muuli_wdr.cpp:2600
+#: src/muuli_wdr.cpp:2572
 msgid "New node"
 msgstr "새로운 노드"
 
-#: src/muuli_wdr.cpp:2605
+#: src/muuli_wdr.cpp:2577
 msgid "IP:"
 msgstr "IP:"
 
-#: src/muuli_wdr.cpp:2625
+#: src/muuli_wdr.cpp:2597
 msgid "Port:"
 msgstr "포트:"
 
-#: src/muuli_wdr.cpp:2638
+#: src/muuli_wdr.cpp:2610
 #, fuzzy
 msgid "Bootstrap from known clients"
 msgstr ""
 "알려진 클라이언트로부터 \n"
 "초기적재"
 
-#: src/muuli_wdr.cpp:2640
+#: src/muuli_wdr.cpp:2612
 msgid "Disconnect Kad"
 msgstr "Kad 끊김"
 
-#: src/muuli_wdr.cpp:2674
+#: src/muuli_wdr.cpp:2646
 msgid "Use Secure User Identification"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2676
+#: src/muuli_wdr.cpp:2648
 msgid "It is recommended to enable this option. You will not receive credits if SUI is not enabled."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2678
+#: src/muuli_wdr.cpp:2650
 msgid "Protocol Obfuscation"
 msgstr "프로토콜 난독화"
 
-#: src/muuli_wdr.cpp:2681
+#: src/muuli_wdr.cpp:2653
 msgid "Support Protocol Obfuscation"
 msgstr "프로토콜 난독화 지원"
 
-#: src/muuli_wdr.cpp:2683
+#: src/muuli_wdr.cpp:2655
 msgid "This option enabled Protocol Obfuscation, and makes aMule accept obfuscated connections from other clients."
 msgstr "이 선택은 프로토콜 난독화를 활성화하며, 어뮬이 다른 클라이언트로부터 난독화된 연결을 받아들이도록 합니다. "
 
-#: src/muuli_wdr.cpp:2685
+#: src/muuli_wdr.cpp:2657
 msgid "Use obfuscation for outgoing connections"
 msgstr "나가는 연결에 난독화 사용"
 
-#: src/muuli_wdr.cpp:2687
+#: src/muuli_wdr.cpp:2659
 msgid "This option makes aMule use Protocol Obfuscation when connecting other clients/servers."
 msgstr "이 선택은 어뮬이 다른 서버나 클라이언트에 연결할때 프로토콜 난독화를 사용하게 합니다."
 
-#: src/muuli_wdr.cpp:2689
+#: src/muuli_wdr.cpp:2661
 msgid "Accept only obfuscated connections"
 msgstr "난독화된 연결만 받음"
 
-#: src/muuli_wdr.cpp:2690
+#: src/muuli_wdr.cpp:2662
 msgid "This option makes aMule only accept obfuscated connections. You will have less sources, but all your traffic will be obfuscated"
 msgstr "이 선택은 어뮬이 난독화된 연결만 받아들이도록 합니다. 더 작은 자료를 가지지만 자료교환은 난독화됩니다."
 
-#: src/muuli_wdr.cpp:2695
+#: src/muuli_wdr.cpp:2667
 msgid "Everybody"
 msgstr "모두"
 
-#: src/muuli_wdr.cpp:2697
+#: src/muuli_wdr.cpp:2669
 msgid "No one"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2699
+#: src/muuli_wdr.cpp:2671
 msgid "Who can see my shared files:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2700
+#: src/muuli_wdr.cpp:2672
 msgid "Select who can request to view a list of your shared files."
 msgstr "공유 파일 목록 보기를 요청할 수 있는 사람을 선택하세요."
 
-#: src/muuli_wdr.cpp:2702
+#: src/muuli_wdr.cpp:2674
 msgid "IP-Filtering"
 msgstr "IP 차단"
 
-#: src/muuli_wdr.cpp:2709
+#: src/muuli_wdr.cpp:2681
 msgid "Filter clients"
 msgstr "클라이언트 차단"
 
-#: src/muuli_wdr.cpp:2711
+#: src/muuli_wdr.cpp:2683
 msgid "Enable filtering of the client IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "~/.aMule/ipfilter.dat에 기록된 클라이언트 IP의 차단을 활성화합니다."
 
-#: src/muuli_wdr.cpp:2713
+#: src/muuli_wdr.cpp:2685
 msgid "Filter servers"
 msgstr "서버 차단"
 
-#: src/muuli_wdr.cpp:2715
+#: src/muuli_wdr.cpp:2687
 msgid "Enable filtering of the server IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "~/.aMule/ipfilter.dat에 기록된 서버 IP의 차단을 활성화합니다."
 
-#: src/muuli_wdr.cpp:2719
+#: src/muuli_wdr.cpp:2691
 msgid "Reload List"
 msgstr "목록 다시읽기"
 
-#: src/muuli_wdr.cpp:2720
+#: src/muuli_wdr.cpp:2692
 msgid "Reload the list of IPs to filter from the file ~/.aMule/ipfilter.dat"
 msgstr "~/.aMule/ipfilter.dat 파일에서 차단할 IP의 목록을 다시 읽음"
 
-#: src/muuli_wdr.cpp:2726
+#: src/muuli_wdr.cpp:2698
 msgid "URL:"
 msgstr "URL:"
 
-#: src/muuli_wdr.cpp:2730 src/muuli_wdr.cpp:2923
+#: src/muuli_wdr.cpp:2702 src/muuli_wdr.cpp:2895
 msgid "Update now"
 msgstr "지금 갱신"
 
-#: src/muuli_wdr.cpp:2733
+#: src/muuli_wdr.cpp:2705
 msgid "Auto-update ipfilter at startup"
 msgstr "시작시 IP차단을 자동 갱신"
 
-#: src/muuli_wdr.cpp:2737
+#: src/muuli_wdr.cpp:2709
 msgid "Filtering Level:"
 msgstr "차단 수준:"
 
-#: src/muuli_wdr.cpp:2743
+#: src/muuli_wdr.cpp:2715
 msgid "Always filter LAN IPs"
 msgstr "랜 IP를 항상 차단"
 
-#: src/muuli_wdr.cpp:2746
+#: src/muuli_wdr.cpp:2718
 msgid "Paranoid handling of non-matching IPs"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2748
+#: src/muuli_wdr.cpp:2720
 msgid "Rejects a packet when its source IP differs from the IP the client claims (an anti-spoofing check). Disable only if it causes connection problems."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2750
+#: src/muuli_wdr.cpp:2722
 msgid "Use system-wide ipfilter.dat if available"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2751
+#: src/muuli_wdr.cpp:2723
 msgid "If there's no local ipfilter.dat found, allow usage of a system-wide ipfilter file."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2768
+#: src/muuli_wdr.cpp:2740
 msgid "Enable Online-Signature"
 msgstr "온라인서명을 활성화"
 
-#: src/muuli_wdr.cpp:2770
+#: src/muuli_wdr.cpp:2742
 msgid "Enables the writing of the OS file, which can be used by external apps to create signatures and the like."
 msgstr "서명을 생성할 수 있는 외부 응용프로그램에 의해 사용될 수 있는 운영체제 파일의 기록을 활성화합니다."
 
-#: src/muuli_wdr.cpp:2774
+#: src/muuli_wdr.cpp:2746
 msgid "Update Frequency (Secs):"
 msgstr "갱신 주기(초)"
 
-#: src/muuli_wdr.cpp:2777
+#: src/muuli_wdr.cpp:2749
 msgid "Change the frequency (in seconds) of Online Signature updates."
 msgstr "온라인 서명 갱신 주기(초)를 바꿉니다."
 
-#: src/muuli_wdr.cpp:2785
+#: src/muuli_wdr.cpp:2757
 msgid "Save online signature file in: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:2791
+#: src/muuli_wdr.cpp:2763
 msgid "Click here to select the directory containing the the Online Signature files."
 msgstr "온라인서명 파일을 포함하는 폴더를 선택하려면 클릭하세요."
 
-#: src/muuli_wdr.cpp:2824
+#: src/muuli_wdr.cpp:2796
 msgid "Show country flags for clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2825
+#: src/muuli_wdr.cpp:2797
 msgid "Render the country flag column in the transfers, queue and search views. Requires a valid MMDB GeoIP database (see below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2830
+#: src/muuli_wdr.cpp:2802
 #, fuzzy
 msgid "Database"
 msgstr "데이터율 :"
 
-#: src/muuli_wdr.cpp:2846
+#: src/muuli_wdr.cpp:2818
 #, fuzzy
 msgid "Source:"
 msgstr "자료"
 
-#: src/muuli_wdr.cpp:2849
+#: src/muuli_wdr.cpp:2821
 msgid "DB-IP (free, no account)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2850
+#: src/muuli_wdr.cpp:2822
 msgid "MaxMind GeoLite2 (free, account required)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2851
+#: src/muuli_wdr.cpp:2823
 msgid "Custom URL"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2854
+#: src/muuli_wdr.cpp:2826
 msgid "Choose which provider supplies the GeoIP MMDB database. DB-IP is the default - no account required. MaxMind requires a free account + license key. Use Custom URL to point at any other MMDB host (e.g. a local mirror)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2871
+#: src/muuli_wdr.cpp:2843
 msgid ""
 "No configuration required.\n"
 "\n"
@@ -4894,11 +4860,11 @@ msgid ""
 "License: Creative Commons BY 4.0 - https://creativecommons.org/licenses/by/4.0/"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2884
+#: src/muuli_wdr.cpp:2856
 msgid "License key:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2890
+#: src/muuli_wdr.cpp:2862
 msgid ""
 "Sign up for a free MaxMind account, then generate a License Key:\n"
 "https://www.maxmind.com/en/geolite2/signup\n"
@@ -4908,232 +4874,232 @@ msgid ""
 "Requires attribution and account registration; refresh at least every 30 days."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2905
+#: src/muuli_wdr.cpp:2877
 #, fuzzy
 msgid "Download URL:"
 msgstr "내려받기: "
 
-#: src/muuli_wdr.cpp:2911
+#: src/muuli_wdr.cpp:2883
 msgid ""
 "Must point to an .mmdb file or a .gz / .tar.gz containing one.\n"
 "URL may include credentials (https://user:pass@host/...).\n"
 "License and attribution terms are set by the upstream URL - you are responsible."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2924
+#: src/muuli_wdr.cpp:2896
 msgid "Download the GeoIP database from the selected source."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2926
+#: src/muuli_wdr.cpp:2898
 #, fuzzy
 msgid "Auto-update on startup"
 msgstr "시작시 IP차단을 자동 갱신"
 
-#: src/muuli_wdr.cpp:2927
+#: src/muuli_wdr.cpp:2899
 msgid "Re-download the GeoIP database from the selected source every time aMule starts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2950
+#: src/muuli_wdr.cpp:2922
 msgid "Filter incoming messages (except current chat):"
 msgstr "받는 메시지 차단(현재 채팅은 제외)"
 
-#: src/muuli_wdr.cpp:2952
+#: src/muuli_wdr.cpp:2924
 msgid "Filter all messages"
 msgstr "모든 메시지를 차단"
 
-#: src/muuli_wdr.cpp:2954
+#: src/muuli_wdr.cpp:2926
 msgid "Filter messages from people not on your friend list"
 msgstr "친구 목록에 없는 사람으로부터 메시지를 차단"
 
-#: src/muuli_wdr.cpp:2956
+#: src/muuli_wdr.cpp:2928
 msgid "Filter messages from unknown clients"
 msgstr "알 수 없는 클라이언트로부터 메시지를 차단"
 
-#: src/muuli_wdr.cpp:2958
+#: src/muuli_wdr.cpp:2930
 msgid "Filter messages containing (use ',' as separator):"
 msgstr "다음 내용이 포함된 메시지를 차단 (쉼표로 분리):"
 
-#: src/muuli_wdr.cpp:2961 src/muuli_wdr.cpp:2972
+#: src/muuli_wdr.cpp:2933 src/muuli_wdr.cpp:2944
 msgid "add here the words amule should filter and block messages including it"
 msgstr "이곳에 어뮬이 차단하고 막을 메시지에 포함될 단어를 추가하세요."
 
-#: src/muuli_wdr.cpp:2963
+#: src/muuli_wdr.cpp:2935
 msgid "Show received messages in the log"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2966
+#: src/muuli_wdr.cpp:2938
 msgid "Comments"
 msgstr "의견들"
 
-#: src/muuli_wdr.cpp:2969
+#: src/muuli_wdr.cpp:2941
 msgid "Filter comments containing (use ',' as separator):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2994
+#: src/muuli_wdr.cpp:2966
 msgid "Enable Proxy"
 msgstr "프록시 활성화"
 
-#: src/muuli_wdr.cpp:2995
+#: src/muuli_wdr.cpp:2967
 msgid "Enable/disable proxy support"
 msgstr "프록시지원을 활성화/비활성화"
 
-#: src/muuli_wdr.cpp:2998
+#: src/muuli_wdr.cpp:2970
 msgid "Proxy type:"
 msgstr "프록시 종류:"
 
-#: src/muuli_wdr.cpp:3009
+#: src/muuli_wdr.cpp:2981
 msgid "Proxy host:"
 msgstr "프록시 호스트:"
 
-#: src/muuli_wdr.cpp:3012
+#: src/muuli_wdr.cpp:2984
 msgid "The proxy host name"
 msgstr "프록시 호스트 이름"
 
-#: src/muuli_wdr.cpp:3014
+#: src/muuli_wdr.cpp:2986
 msgid "Proxy port:"
 msgstr "프록시 포트:"
 
-#: src/muuli_wdr.cpp:3017
+#: src/muuli_wdr.cpp:2989
 msgid "The proxy port"
 msgstr "프록시 포트"
 
-#: src/muuli_wdr.cpp:3019
+#: src/muuli_wdr.cpp:2991
 msgid "Enable authentication"
 msgstr "인증 활성화"
 
-#: src/muuli_wdr.cpp:3020
+#: src/muuli_wdr.cpp:2992
 msgid "Enable/disable username/password authentication"
 msgstr "사용자이름/암호 인증을 활성화/비활성화"
 
-#: src/muuli_wdr.cpp:3023
+#: src/muuli_wdr.cpp:2995
 msgid "Username: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:3026
+#: src/muuli_wdr.cpp:2998
 msgid "The username to use to connect to the proxy"
 msgstr "프록시에 접속하기 위한 사용자이름"
 
-#: src/muuli_wdr.cpp:3028
+#: src/muuli_wdr.cpp:3000
 msgid "Password:"
 msgstr "암호:"
 
-#: src/muuli_wdr.cpp:3031
+#: src/muuli_wdr.cpp:3003
 msgid "The password to use to connect to the proxy"
 msgstr "프록시에 접속하기 위한 암호"
 
-#: src/muuli_wdr.cpp:3050
+#: src/muuli_wdr.cpp:3022
 msgid "Connect to:"
 msgstr "연결함:"
 
-#: src/muuli_wdr.cpp:3059
+#: src/muuli_wdr.cpp:3031
 msgid "Login to remote amule"
 msgstr "원격 어뮬에 로그인"
 
-#: src/muuli_wdr.cpp:3064
+#: src/muuli_wdr.cpp:3036
 msgid "User name"
 msgstr "사용자이름"
 
-#: src/muuli_wdr.cpp:3075
+#: src/muuli_wdr.cpp:3047
 msgid "Remember those settings"
 msgstr "설정을 기억"
 
-#: src/muuli_wdr.cpp:3078
+#: src/muuli_wdr.cpp:3050
 #, fuzzy
 msgid "Force ZLIB compression"
 msgstr "gzip 압축 사용"
 
-#: src/muuli_wdr.cpp:3102
+#: src/muuli_wdr.cpp:3074
 msgid "Enable Verbose Debug-Logging."
 msgstr "상세한 디버그-로깅 활성화"
 
-#: src/muuli_wdr.cpp:3104
+#: src/muuli_wdr.cpp:3076
 #, fuzzy
 msgid "Only to Logfile"
 msgstr "파일 열기(&O)"
 
-#: src/muuli_wdr.cpp:3106
+#: src/muuli_wdr.cpp:3078
 msgid "Message Categories:"
 msgstr "메시지 분류:"
 
-#: src/muuli_wdr.cpp:3130 src/PartFileConvertDlg.cpp:160
+#: src/muuli_wdr.cpp:3102 src/PartFileConvertDlg.cpp:160
 msgid "Waiting..."
 msgstr "대기중..."
 
-#: src/muuli_wdr.cpp:3150
+#: src/muuli_wdr.cpp:3122
 msgid "Add imports"
 msgstr "가져오기 추가"
 
-#: src/muuli_wdr.cpp:3153
+#: src/muuli_wdr.cpp:3125
 msgid "Retry selected"
 msgstr "선택된 것을 재시도"
 
-#: src/muuli_wdr.cpp:3155
+#: src/muuli_wdr.cpp:3127
 msgid "Remove selected"
 msgstr "선택된 것을 삭제"
 
-#: src/muuli_wdr.cpp:3218
+#: src/muuli_wdr.cpp:3190
 msgid "Event Types"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3237
+#: src/muuli_wdr.cpp:3209
 msgid "Statistics and queued clients for selected file(s) : Session / All time"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3261
+#: src/muuli_wdr.cpp:3233
 #, fuzzy
 msgid "Active Uploads"
 msgstr "활성화된 올려주기 :"
 
-#: src/muuli_wdr.cpp:3275
+#: src/muuli_wdr.cpp:3247
 msgid "Percent of total files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3327
+#: src/muuli_wdr.cpp:3299
 #, fuzzy
 msgid "Show Clients for"
 msgstr "클라이언트 보기"
 
-#: src/muuli_wdr.cpp:3329
+#: src/muuli_wdr.cpp:3301
 #, fuzzy
 msgid "All files"
 msgstr "공유된 파일을 숨김"
 
-#: src/muuli_wdr.cpp:3332
+#: src/muuli_wdr.cpp:3304
 #, fuzzy
 msgid "Selected files"
 msgstr "보기 필터 선택"
 
-#: src/muuli_wdr.cpp:3335
+#: src/muuli_wdr.cpp:3307
 #, fuzzy
 msgid "Active uploads only"
 msgstr "활성화된 올려주기"
 
-#: src/muuli_wdr.cpp:3342
+#: src/muuli_wdr.cpp:3314
 #, fuzzy
 msgid "Reload:"
 msgstr "목록 다시읽기"
 
-#: src/muuli_wdr.cpp:3346
+#: src/muuli_wdr.cpp:3318
 msgid "Reload your shared files"
 msgstr "공유된 파일을 다시 읽어들임"
 
-#: src/muuli_wdr.cpp:3409
+#: src/muuli_wdr.cpp:3381
 msgid "Send"
 msgstr "보내기"
 
-#: src/muuli_wdr.cpp:3410
+#: src/muuli_wdr.cpp:3382
 msgid "Sends the specified message."
 msgstr "지정된 메시지를 보냅니다."
 
-#: src/muuli_wdr.cpp:3414
+#: src/muuli_wdr.cpp:3386
 msgid "Close this chat-session."
 msgstr "이 채팅세션을 닫습니다."
 
-#: src/muuli_wdr.cpp:3437
+#: src/muuli_wdr.cpp:3409
 msgid "Connect to any server and/or Kad"
 msgstr "서버 혹은 Kad에 연결"
 
-#: src/muuli_wdr.cpp:3443 src/SharedFilesCtrl.cpp:142 src/Statistics.cpp:941
+#: src/muuli_wdr.cpp:3415 src/SharedFilesCtrl.cpp:142 src/Statistics.cpp:941
 msgid "Shared Files"
 msgstr "공유 파일"
 
@@ -5496,268 +5462,268 @@ msgstr ""
 msgid "ERROR: Failed to open partfile '%s'"
 msgstr ""
 
-#: src/Preferences.cpp:701
+#: src/Preferences.cpp:673
 msgid "System default"
 msgstr "기본 설정"
 
-#: src/Preferences.cpp:702
+#: src/Preferences.cpp:674
 msgid "Albanian"
 msgstr ""
 
-#: src/Preferences.cpp:703
+#: src/Preferences.cpp:675
 msgid "Arabic"
 msgstr "아랍어"
 
-#: src/Preferences.cpp:704
+#: src/Preferences.cpp:676
 #, fuzzy
 msgid "Asturian"
 msgstr "에스토니아어"
 
-#: src/Preferences.cpp:705
+#: src/Preferences.cpp:677
 msgid "Basque"
 msgstr "바스크어"
 
-#: src/Preferences.cpp:706
+#: src/Preferences.cpp:678
 msgid "Bulgarian"
 msgstr "불가리아어"
 
-#: src/Preferences.cpp:707
+#: src/Preferences.cpp:679
 msgid "Catalan"
 msgstr "카탈로니아어"
 
-#: src/Preferences.cpp:708
+#: src/Preferences.cpp:680
 msgid "Chinese (Simplified)"
 msgstr "중국어(간체)"
 
-#: src/Preferences.cpp:709
+#: src/Preferences.cpp:681
 msgid "Chinese (Traditional)"
 msgstr "중국어(번체)"
 
-#: src/Preferences.cpp:710
+#: src/Preferences.cpp:682
 msgid "Croatian"
 msgstr "크로티아어"
 
-#: src/Preferences.cpp:711
+#: src/Preferences.cpp:683
 msgid "Czech"
 msgstr ""
 
-#: src/Preferences.cpp:712
+#: src/Preferences.cpp:684
 msgid "Danish"
 msgstr "덴마크어"
 
-#: src/Preferences.cpp:713
+#: src/Preferences.cpp:685
 msgid "Dutch"
 msgstr "네델란드어"
 
-#: src/Preferences.cpp:714
+#: src/Preferences.cpp:686
 msgid "English (U.K.)"
 msgstr "영어(영국)"
 
-#: src/Preferences.cpp:715
+#: src/Preferences.cpp:687
 #, fuzzy
 msgid "English (U.S.)"
 msgstr "영어(영국)"
 
-#: src/Preferences.cpp:716
+#: src/Preferences.cpp:688
 msgid "Estonian"
 msgstr "에스토니아어"
 
-#: src/Preferences.cpp:717
+#: src/Preferences.cpp:689
 msgid "Finnish"
 msgstr "필란드어"
 
-#: src/Preferences.cpp:718
+#: src/Preferences.cpp:690
 msgid "French"
 msgstr "프랑스어"
 
-#: src/Preferences.cpp:719
+#: src/Preferences.cpp:691
 msgid "Galician"
 msgstr "갈리시아어"
 
-#: src/Preferences.cpp:720
+#: src/Preferences.cpp:692
 msgid "German"
 msgstr "독일어"
 
-#: src/Preferences.cpp:721
+#: src/Preferences.cpp:693
 msgid "Greek"
 msgstr ""
 
-#: src/Preferences.cpp:722
+#: src/Preferences.cpp:694
 msgid "Hebrew"
 msgstr ""
 
-#: src/Preferences.cpp:723
+#: src/Preferences.cpp:695
 msgid "Hungarian"
 msgstr "헝가리어"
 
-#: src/Preferences.cpp:724
+#: src/Preferences.cpp:696
 msgid "Italian"
 msgstr "이탈리아어"
 
-#: src/Preferences.cpp:725
+#: src/Preferences.cpp:697
 msgid "Japanese"
 msgstr ""
 
-#: src/Preferences.cpp:726
+#: src/Preferences.cpp:698
 msgid "Korean"
 msgstr "한국어"
 
-#: src/Preferences.cpp:727
+#: src/Preferences.cpp:699
 msgid "Latvian"
 msgstr ""
 
-#: src/Preferences.cpp:728
+#: src/Preferences.cpp:700
 msgid "Lithuanian"
 msgstr ""
 
-#: src/Preferences.cpp:729
+#: src/Preferences.cpp:701
 msgid "Norwegian (Nynorsk)"
 msgstr ""
 
-#: src/Preferences.cpp:730
+#: src/Preferences.cpp:702
 msgid "Polish"
 msgstr "폴란드어"
 
-#: src/Preferences.cpp:731
+#: src/Preferences.cpp:703
 msgid "Portuguese"
 msgstr "포르투갈어"
 
-#: src/Preferences.cpp:732
+#: src/Preferences.cpp:704
 msgid "Portuguese (Brazilian)"
 msgstr "포르투갈어(브라질)"
 
-#: src/Preferences.cpp:733
+#: src/Preferences.cpp:705
 #, fuzzy
 msgid "Romanian"
 msgstr "크로티아어"
 
-#: src/Preferences.cpp:734
+#: src/Preferences.cpp:706
 msgid "Russian"
 msgstr "러시아어"
 
-#: src/Preferences.cpp:735
+#: src/Preferences.cpp:707
 msgid "Slovenian"
 msgstr "슬로베니아어"
 
-#: src/Preferences.cpp:736
+#: src/Preferences.cpp:708
 msgid "Spanish"
 msgstr "스페인어"
 
-#: src/Preferences.cpp:737
+#: src/Preferences.cpp:709
 msgid "Swedish"
 msgstr ""
 
-#: src/Preferences.cpp:738
+#: src/Preferences.cpp:710
 msgid "Turkish"
 msgstr "터키어"
 
-#: src/Preferences.cpp:739
+#: src/Preferences.cpp:711
 msgid "Ukrainian"
 msgstr ""
 
-#: src/Preferences.cpp:842
+#: src/Preferences.cpp:814
 #, fuzzy
 msgid "Change Language"
 msgstr "언어"
 
-#: src/Preferences.cpp:906
+#: src/Preferences.cpp:878
 msgid "There are no translations installed for aMule"
 msgstr ""
 
-#: src/Preferences.cpp:907
+#: src/Preferences.cpp:879
 #, fuzzy
 msgid "No languages available"
 msgstr "유효하지 않음"
 
-#: src/Preferences.cpp:1038
+#: src/Preferences.cpp:1010
 msgid "no options available"
 msgstr ""
 
-#: src/Preferences.cpp:2226
+#: src/Preferences.cpp:2179
 msgid "Invalid category found, skipping"
 msgstr ""
 
-#: src/Preferences.cpp:2395
+#: src/Preferences.cpp:2348
 msgid "TCP port can't be higher than 65532 due to server UDP socket being TCP+3"
 msgstr "서버 UDP 소켓이 TCP+3이 되기위해서 TCP 포트가 65532보다 커서는 안됩니다."
 
-#: src/Preferences.cpp:2396
+#: src/Preferences.cpp:2349
 #, c-format
 msgid "Default port will be used (%d)"
 msgstr "기본 포트가 사용될 것입니다.(%d)"
 
-#: src/PrefsUnifiedDlg.cpp:300 src/Statistics.cpp:866
+#: src/PrefsUnifiedDlg.cpp:298 src/Statistics.cpp:866
 msgid "Connection"
 msgstr "연결"
 
-#: src/PrefsUnifiedDlg.cpp:301 src/SearchListCtrl.cpp:117
+#: src/PrefsUnifiedDlg.cpp:299 src/SearchListCtrl.cpp:117
 msgid "Directories"
 msgstr "폴더"
 
-#: src/PrefsUnifiedDlg.cpp:302 src/Statistics.cpp:917
+#: src/PrefsUnifiedDlg.cpp:300 src/Statistics.cpp:917
 msgid "Servers"
 msgstr "서버"
 
-#: src/PrefsUnifiedDlg.cpp:303 src/ServerListCtrl.cpp:96
+#: src/PrefsUnifiedDlg.cpp:301 src/ServerListCtrl.cpp:96
 msgid "Files"
 msgstr "파일"
 
-#: src/PrefsUnifiedDlg.cpp:304
+#: src/PrefsUnifiedDlg.cpp:302
 msgid "Security"
 msgstr "보안"
 
-#: src/PrefsUnifiedDlg.cpp:305
+#: src/PrefsUnifiedDlg.cpp:303
 msgid "Interface"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:312
+#: src/PrefsUnifiedDlg.cpp:310
 msgid "IP2Country"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:315
+#: src/PrefsUnifiedDlg.cpp:313
 msgid "Proxy"
 msgstr "프록시"
 
-#: src/PrefsUnifiedDlg.cpp:316
+#: src/PrefsUnifiedDlg.cpp:314
 msgid "Filters"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:317
+#: src/PrefsUnifiedDlg.cpp:315
 msgid "Remote Controls"
 msgstr "원격 조정"
 
-#: src/PrefsUnifiedDlg.cpp:318
+#: src/PrefsUnifiedDlg.cpp:316
 msgid "Online Signature"
 msgstr "온라인 서명"
 
-#: src/PrefsUnifiedDlg.cpp:319
+#: src/PrefsUnifiedDlg.cpp:317
 msgid "Advanced"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:320
+#: src/PrefsUnifiedDlg.cpp:318
 msgid "Events"
 msgstr "사건들"
 
-#: src/PrefsUnifiedDlg.cpp:323
+#: src/PrefsUnifiedDlg.cpp:321
 msgid "Debugging"
 msgstr "디버깅"
 
-#: src/PrefsUnifiedDlg.cpp:453
+#: src/PrefsUnifiedDlg.cpp:451
 msgid ""
 "The following variables will be substituted:\n"
 "    %PARTFILE - full path to the file\n"
 "    %PARTNAME - file name only"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:474
+#: src/PrefsUnifiedDlg.cpp:472
 msgid "Tray icon support requires libayatana-appindicator3 at compile time."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:490
+#: src/PrefsUnifiedDlg.cpp:488
 msgid "Not available on Wayland: the protocol does not report when a window is minimized, so this option cannot intercept the system minimize button. Workaround: launch aMule with `GDK_BACKEND=x11` to use XWayland instead."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:536
+#: src/PrefsUnifiedDlg.cpp:534
 msgid ""
 "Do not change these setting unless you know\n"
 "what you are doing, otherwise you can easily\n"
@@ -5773,35 +5739,26 @@ msgstr ""
 "이 설정들을 조정하지 않아도\n"
 "어뮬은 잘 동작할 것입니다."
 
-#: src/PrefsUnifiedDlg.cpp:647
+#: src/PrefsUnifiedDlg.cpp:645
 #, c-format
 msgid "Failed to connect Cfg to widget with the ID %d and key %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:695
+#: src/PrefsUnifiedDlg.cpp:693
 #, c-format
 msgid "Failed to transfer data from Cfg to Widget with the ID %d and key %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:801
+#: src/PrefsUnifiedDlg.cpp:799
 msgid "The type of proxy you are connecting to"
 msgstr "연결하고 있는 프록시 타입"
 
-#: src/PrefsUnifiedDlg.cpp:1020
+#: src/PrefsUnifiedDlg.cpp:1003
 #, c-format
 msgid "Failed to transfer data from Widget to Cfg with the ID %d and key %s"
 msgstr ""
 
 #: src/PrefsUnifiedDlg.cpp:1103
-#, fuzzy
-msgid "No password set."
-msgstr "암호를 검사중\n"
-
-#: src/PrefsUnifiedDlg.cpp:1132
-msgid "Guest access needs a password. Type one in the guest password field, or untick Enable guest access."
-msgstr ""
-
-#: src/PrefsUnifiedDlg.cpp:1144
 msgid ""
 "aMule must be restarted to enable these changes:\n"
 "\n"
@@ -5809,51 +5766,51 @@ msgstr ""
 "변경사항을 활성화 하기위해 어뮬을 재시작해야 합니다:\n"
 "\n"
 
-#: src/PrefsUnifiedDlg.cpp:1151
+#: src/PrefsUnifiedDlg.cpp:1110
 msgid "- TCP port changed.\n"
 msgstr "- TCP 포트가 변경되었습니다.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1156
+#: src/PrefsUnifiedDlg.cpp:1115
 msgid "- UDP port changed.\n"
 msgstr "- UDP 포트가 변경되었습니다.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1161
+#: src/PrefsUnifiedDlg.cpp:1120
 #, fuzzy
 msgid "- Network interface binding changed.\n"
 msgstr "외부연결 끊겼습니다."
 
-#: src/PrefsUnifiedDlg.cpp:1166
+#: src/PrefsUnifiedDlg.cpp:1125
 #, fuzzy
 msgid "- External connect port changed.\n"
 msgstr "외부연결 끊겼습니다."
 
-#: src/PrefsUnifiedDlg.cpp:1170
+#: src/PrefsUnifiedDlg.cpp:1129
 #, fuzzy
 msgid "- External connect acceptance changed.\n"
 msgstr "새로운 외부연결이 승인되었습니다."
 
-#: src/PrefsUnifiedDlg.cpp:1174
+#: src/PrefsUnifiedDlg.cpp:1133
 #, fuzzy
 msgid "- External connect interface changed.\n"
 msgstr "외부연결 끊겼습니다."
 
-#: src/PrefsUnifiedDlg.cpp:1178
+#: src/PrefsUnifiedDlg.cpp:1137
 #, fuzzy
 msgid "- Protocol obfuscation support changed.\n"
 msgstr "프로토콜 난독화"
 
-#: src/PrefsUnifiedDlg.cpp:1193
+#: src/PrefsUnifiedDlg.cpp:1151
 #, fuzzy
 msgid "- amuleapi settings changed.\n"
 msgstr "- 언어가 변경되었습니다.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1202
+#: src/PrefsUnifiedDlg.cpp:1160
 msgid ""
 "Your Auto-update server list is empty.\n"
 "'Auto-update server list at startup' will be disabled."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1213
+#: src/PrefsUnifiedDlg.cpp:1171
 msgid ""
 "You have enabled external connections but have not specified a password.\n"
 "External connections cannot be enabled unless a valid password is specified."
@@ -5861,40 +5818,35 @@ msgstr ""
 "외부연결이 횔성화되어 있지만, 암호를 설정하지 않았습니다.\n"
 "외부연결은 유효한 암호가 설정되기전까지 활성화되지 않습니다."
 
-#: src/PrefsUnifiedDlg.cpp:1246
-#, c-format
-msgid "The amuleapi password could not be saved: %s"
-msgstr ""
-
-#: src/PrefsUnifiedDlg.cpp:1276
+#: src/PrefsUnifiedDlg.cpp:1202
 msgid "- Language changed.\n"
 msgstr "- 언어가 변경되었습니다.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1281
+#: src/PrefsUnifiedDlg.cpp:1207
 msgid "- Temp folder changed.\n"
 msgstr "- 임시 폴더가 변경되었습니다.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1286
+#: src/PrefsUnifiedDlg.cpp:1212
 #, fuzzy
 msgid "- ED2K network enabled.\n"
 msgstr "모든 통신망을 사용할수 없습니다."
 
-#: src/PrefsUnifiedDlg.cpp:1319
+#: src/PrefsUnifiedDlg.cpp:1245
 msgid "The shared-file exclusion pattern is not a valid regular expression. The filter has been left disabled."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1321 src/PrefsUnifiedDlg.cpp:1921
+#: src/PrefsUnifiedDlg.cpp:1247 src/PrefsUnifiedDlg.cpp:1841
 #, fuzzy
 msgid "Invalid regular expression"
 msgstr "유효하지 않은 프로토콜 버젼입니다"
 
-#: src/PrefsUnifiedDlg.cpp:1398
+#: src/PrefsUnifiedDlg.cpp:1324
 msgid ""
 "Both eD2k and Kad network are disabled.\n"
 "You won't be able to connect until you enable at least one of them."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1403
+#: src/PrefsUnifiedDlg.cpp:1329
 msgid ""
 "Kad will not start if your UDP port is disabled.\n"
 "Enable UDP port or disable Kad."
@@ -5902,7 +5854,7 @@ msgstr ""
 "UDP 포트가 비활성화되어 있으면 Kad는 시작하지 않을 것입니다.\n"
 "UDP 포트를 활성화시키거나 Kad를 비활성화시키십시오."
 
-#: src/PrefsUnifiedDlg.cpp:1459
+#: src/PrefsUnifiedDlg.cpp:1385
 msgid ""
 "\n"
 "You MUST restart aMule now.\n"
@@ -5912,69 +5864,69 @@ msgstr ""
 "지금 바로 어뮬을 재시작해야 합니다.\n"
 "만일 재시작하지 않는다면, 나쁜 일이 일어나도 불평하지 마십시오.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1524
+#: src/PrefsUnifiedDlg.cpp:1450
 msgid "Could not register aMule for autostart at login. The autostart store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1526
+#: src/PrefsUnifiedDlg.cpp:1452
 msgid "Could not remove the autostart-at-login entry."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1527
+#: src/PrefsUnifiedDlg.cpp:1453
 #, fuzzy
 msgid "Autostart"
 msgstr "자동갱신이 시작됨"
 
-#: src/PrefsUnifiedDlg.cpp:1542
+#: src/PrefsUnifiedDlg.cpp:1468
 msgid "Register file type"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1542
+#: src/PrefsUnifiedDlg.cpp:1468
 msgid "Register URL handler"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1550
+#: src/PrefsUnifiedDlg.cpp:1476
 #, c-format
 msgid "aMule only handles eD2k-compatible magnets. If you replace the current magnet handler (%s), BitTorrent magnet links will stop working - aMule cannot download BitTorrent content. Continue?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1555
+#: src/PrefsUnifiedDlg.cpp:1481
 #, c-format
 msgid "Another application currently opens .emulecollection files (%s). Replace it with aMule?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1560
+#: src/PrefsUnifiedDlg.cpp:1486
 #, c-format
 msgid "Another application is currently the default handler for these links (%s). Replace it with aMule?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1585
+#: src/PrefsUnifiedDlg.cpp:1511
 msgid "Could not register aMule for .emulecollection files. The registration store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1587
+#: src/PrefsUnifiedDlg.cpp:1513
 #, fuzzy
 msgid "Could not remove the file type registration."
 msgstr "이미 %s 파일을 내려받으려고 하고있음"
 
-#: src/PrefsUnifiedDlg.cpp:1589
+#: src/PrefsUnifiedDlg.cpp:1515
 msgid "Could not register aMule as the URL handler. The registration store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1591
+#: src/PrefsUnifiedDlg.cpp:1517
 msgid "Could not remove the URL handler registration."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1661 src/PrefsUnifiedDlg.cpp:1688
+#: src/PrefsUnifiedDlg.cpp:1587 src/PrefsUnifiedDlg.cpp:1614
 #, fuzzy
 msgid "The web server and aMule API require external connections to be enabled."
 msgstr "새로운 외부연결이 승인되었습니다."
 
-#: src/PrefsUnifiedDlg.cpp:1671
+#: src/PrefsUnifiedDlg.cpp:1597
 msgid "The aMule web server is deprecated. Consider running the aMule API instead."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1735
+#: src/PrefsUnifiedDlg.cpp:1655
 msgid ""
 "Your Auto-update servers list is in blank.\n"
 "Please fill in at least one URL to point to a valid server.met file.\n"
@@ -5984,66 +5936,66 @@ msgstr ""
 "적어도 한개의 유효한 server.met파일을 가르키는 URL을 적으세요.\n"
 "URL을 입력하려면 채크박스 옆의 \"목록\"버튼을 클릭하세요."
 
-#: src/PrefsUnifiedDlg.cpp:1876
+#: src/PrefsUnifiedDlg.cpp:1796
 msgid "Temporary files"
 msgstr "임시 파일"
 
-#: src/PrefsUnifiedDlg.cpp:1881
+#: src/PrefsUnifiedDlg.cpp:1801
 msgid "Incoming files"
 msgstr "내려받은 파일"
 
-#: src/PrefsUnifiedDlg.cpp:1886
+#: src/PrefsUnifiedDlg.cpp:1806
 msgid "Online Signatures"
 msgstr "온라인 서명"
 
-#: src/PrefsUnifiedDlg.cpp:1899
+#: src/PrefsUnifiedDlg.cpp:1819
 #, c-format
 msgid "Choose a folder for %s"
 msgstr "%s하기 위한 폴더를 선택하세요."
 
-#: src/PrefsUnifiedDlg.cpp:1923
+#: src/PrefsUnifiedDlg.cpp:1843
 #, fuzzy, c-format
 msgid "Would exclude %u of %u shared file"
 msgid_plural "Would exclude %u of %u shared files"
 msgstr[0] "알려진 공유 파일 %i개를 찾았음"
 msgstr[1] "알려진 공유 파일 %i개를 찾았음"
 
-#: src/PrefsUnifiedDlg.cpp:1940
+#: src/PrefsUnifiedDlg.cpp:1860
 msgid "Browse for videoplayer"
 msgstr "비디오재생을 위한 브라우즈"
 
-#: src/PrefsUnifiedDlg.cpp:1944
+#: src/PrefsUnifiedDlg.cpp:1864
 msgid "Select browser"
 msgstr "브라우저 선택"
 
-#: src/PrefsUnifiedDlg.cpp:1948
+#: src/PrefsUnifiedDlg.cpp:1868
 #, fuzzy
 msgid "Select ffprobe binary"
 msgstr "브라우저 선택"
 
-#: src/PrefsUnifiedDlg.cpp:1954
+#: src/PrefsUnifiedDlg.cpp:1874
 #, c-format
 msgid "Executable%s"
 msgstr "실행할수 있는 %s"
 
-#: src/PrefsUnifiedDlg.cpp:1988
+#: src/PrefsUnifiedDlg.cpp:1908
 msgid "ffprobe not found on PATH or in the standard install locations. Install ffmpeg (which ships ffprobe) or use Browse to pick a binary manually."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2000
+#: src/PrefsUnifiedDlg.cpp:1920
 msgid "Reset the settings on this page to their default values?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2001
+#: src/PrefsUnifiedDlg.cpp:1921
 #, fuzzy
 msgid "Reset to defaults"
 msgstr "기본 설정"
 
-#: src/PrefsUnifiedDlg.cpp:2028
+#: src/PrefsUnifiedDlg.cpp:1948
 msgid "Edit server list"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2029
+#: src/PrefsUnifiedDlg.cpp:1949
 msgid ""
 "Add here URL's to download server.met files.\n"
 "Only one url on each line."
@@ -6051,181 +6003,177 @@ msgstr ""
 "server.met파일을 내려받을 URL을 추가하세요.\n"
 "각 행에 오직 하나의 URL을 넣으세요."
 
-#: src/PrefsUnifiedDlg.cpp:2084
+#: src/PrefsUnifiedDlg.cpp:2004
 msgid "IP2Country update failed"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2229 src/PrefsUnifiedDlg.cpp:2260
+#: src/PrefsUnifiedDlg.cpp:2149 src/PrefsUnifiedDlg.cpp:2180
 msgid "Data by MaxMind GeoLite2"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2231 src/PrefsUnifiedDlg.cpp:2262
+#: src/PrefsUnifiedDlg.cpp:2151 src/PrefsUnifiedDlg.cpp:2182
 #, fuzzy
 msgid "Custom source"
 msgstr "완료된 자료"
 
-#: src/PrefsUnifiedDlg.cpp:2233 src/PrefsUnifiedDlg.cpp:2264
+#: src/PrefsUnifiedDlg.cpp:2153 src/PrefsUnifiedDlg.cpp:2184
 msgid "Data by DB-IP.com"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2284
+#: src/PrefsUnifiedDlg.cpp:2204
 #, fuzzy, c-format
 msgid "Status: Loaded%s"
 msgstr "상태:"
 
-#: src/PrefsUnifiedDlg.cpp:2286
+#: src/PrefsUnifiedDlg.cpp:2206
 #, fuzzy, c-format
 msgid "Status: Loaded%s - %s"
 msgstr "상태:"
 
-#: src/PrefsUnifiedDlg.cpp:2290
+#: src/PrefsUnifiedDlg.cpp:2210
 msgid "Status: Failed to load - click 'Update now' to refresh."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2292
+#: src/PrefsUnifiedDlg.cpp:2212
 msgid "Status: Not found - click 'Update now' to download."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2350 src/PrefsUnifiedDlg.cpp:2374
+#: src/PrefsUnifiedDlg.cpp:2270 src/PrefsUnifiedDlg.cpp:2294
 #, fuzzy, c-format
 msgid "Update delay: %d second"
 msgid_plural "Update delay: %d seconds"
 msgstr[0] "갱신 지연: %d 초"
 msgstr[1] "갱신 지연: %d 초"
 
-#: src/PrefsUnifiedDlg.cpp:2358
+#: src/PrefsUnifiedDlg.cpp:2278
 #, fuzzy, c-format
 msgid "Time for average graph: %d minute"
 msgid_plural "Time for average graph: %d minutes"
 msgstr[0] "평균 그래프 시간: %d 분"
 msgstr[1] "평균 그래프 시간: %d 분"
 
-#: src/PrefsUnifiedDlg.cpp:2367
+#: src/PrefsUnifiedDlg.cpp:2287
 #, c-format
 msgid "Connections Graph Scale: %d"
 msgstr "연결 그래프 크기: %d"
 
-#: src/PrefsUnifiedDlg.cpp:2382
+#: src/PrefsUnifiedDlg.cpp:2302
 #, fuzzy, c-format
 msgid "File Buffer Size: %d byte"
 msgid_plural "File Buffer Size: %d bytes"
 msgstr[0] "파일 버퍼 크기: %d 바이트"
 msgstr[1] "파일 버퍼 크기: %d 바이트"
 
-#: src/PrefsUnifiedDlg.cpp:2392
+#: src/PrefsUnifiedDlg.cpp:2312
 #, fuzzy, c-format
 msgid "Upload Queue Size: %d client"
 msgid_plural "Upload Queue Size: %d clients"
 msgstr[0] "올려주기 대기열 크기: %d 클라이언트"
 msgstr[1] "올려주기 대기열 크기: %d 클라이언트"
 
-#: src/PrefsUnifiedDlg.cpp:2402
+#: src/PrefsUnifiedDlg.cpp:2322
 #, fuzzy, c-format
 msgid "Server connection refresh interval: %d minute"
 msgid_plural "Server connection refresh interval: %d minutes"
 msgstr[0] "서버 연결 갱신 주기: %d 분"
 msgstr[1] "서버 연결 갱신 주기: %d 분"
 
-#: src/PrefsUnifiedDlg.cpp:2407
+#: src/PrefsUnifiedDlg.cpp:2327
 msgid "Server connection refresh interval: Disabled"
 msgstr "서버 연결 갱신 주기: 비활성화"
 
-#: src/PrefsUnifiedDlg.cpp:2451
+#: src/PrefsUnifiedDlg.cpp:2371
 #, fuzzy
 msgid "disabled"
 msgstr "비활성화"
 
-#: src/PrefsUnifiedDlg.cpp:2477
+#: src/PrefsUnifiedDlg.cpp:2397
 #, fuzzy, c-format
 msgid "Execute command on '%s' event"
 msgstr "`%s' 사건에 명령을 실행"
 
-#: src/PrefsUnifiedDlg.cpp:2484
+#: src/PrefsUnifiedDlg.cpp:2404
 msgid "Enable command execution on core"
 msgstr "코어에 명령 실행 활성화"
 
-#: src/PrefsUnifiedDlg.cpp:2496
+#: src/PrefsUnifiedDlg.cpp:2416
 msgid "Core command:"
 msgstr "코어 명령어:"
 
-#: src/PrefsUnifiedDlg.cpp:2512
+#: src/PrefsUnifiedDlg.cpp:2432
 msgid "Enable command execution on GUI"
 msgstr "GUI에 명령 실행 활성화"
 
-#: src/PrefsUnifiedDlg.cpp:2524
+#: src/PrefsUnifiedDlg.cpp:2444
 msgid "GUI command:"
 msgstr "GUI 명령어:"
 
-#: src/PrefsUnifiedDlg.cpp:2540
+#: src/PrefsUnifiedDlg.cpp:2460
 msgid "The following variables will be replaced:"
 msgstr "다음 변수들은 교체됩니다.:"
 
-#: src/PrefsUnifiedDlg.cpp:2708
+#: src/PrefsUnifiedDlg.cpp:2628
 msgid ""
 "The following folders look like system or sensitive locations:\n"
 "\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2713
+#: src/PrefsUnifiedDlg.cpp:2633
 msgid "Sharing them recursively will publish every file underneath on the eD2k/Kad networks. Do you really want to do this?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2716
+#: src/PrefsUnifiedDlg.cpp:2636
 #, fuzzy
 msgid "Confirm shared folders"
 msgstr "공유된 파일을 다시 읽어들임"
 
-#: src/PrefsUnifiedDlg.cpp:2744
+#: src/PrefsUnifiedDlg.cpp:2664
 #, fuzzy
 msgid "Reloading shared files..."
 msgstr "공유된 파일을 다시 읽어들임"
 
-#: src/PrefsUnifiedDlg.cpp:2745
+#: src/PrefsUnifiedDlg.cpp:2665
 msgid "Scanning for subdirectories..."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2746
+#: src/PrefsUnifiedDlg.cpp:2666
 #, fuzzy
 msgid "Updating shared folders"
 msgstr "임시 폴더를 읽는중"
 
-#: src/PrefsUnifiedDlg.cpp:2773
+#: src/PrefsUnifiedDlg.cpp:2693
 #, c-format
 msgid "Scanned %u directories..."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2823
+#: src/PrefsUnifiedDlg.cpp:2743
 #, fuzzy, c-format
 msgid "Reloading shared files: %u files scanned"
 msgstr "공유된 파일 목록을 다시 읽어들입니다."
 
-#: src/PrefsUnifiedDlg.cpp:2873
+#: src/PrefsUnifiedDlg.cpp:2793
 #, fuzzy
 msgid "Shared folder"
 msgstr "공유 파일"
 
-#: src/SearchDlg.cpp:280
-msgid "Clear search history"
-msgstr ""
-
-#: src/SearchDlg.cpp:584
+#: src/SearchDlg.cpp:425
 msgid "It's impossible to search when both eD2k and Kademlia are disabled."
 msgstr ""
 
-#: src/SearchDlg.cpp:585 src/SearchListCtrl.cpp:858
+#: src/SearchDlg.cpp:426 src/SearchListCtrl.cpp:858
 #, fuzzy
 msgid "Search error"
 msgstr "검색"
 
-#: src/SearchDlg.cpp:929
+#: src/SearchDlg.cpp:768
 msgid "Min size must be smaller than max size. Max size ignored."
 msgstr "최소 크기가 최대 크기보다 작아야 합니다. 최대 크기는 무시됩니다.."
 
-#: src/SearchDlg.cpp:930 src/SearchDlg.cpp:1012
+#: src/SearchDlg.cpp:769 src/SearchDlg.cpp:851
 msgid "Search warning"
 msgstr "검색 경고"
 
-#: src/SearchDlg.cpp:1092 src/SearchListCtrl.cpp:735
+#: src/SearchDlg.cpp:929 src/SearchListCtrl.cpp:735
 msgid "Main"
 msgstr "주"
 

--- a/po/ko_KR.po
+++ b/po/ko_KR.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-28 08:06+0200\n"
+"POT-Creation-Date: 2026-07-28 10:19+0200\n"
 "PO-Revision-Date: 2026-07-27 11:41+0000\n"
 "Last-Translator: Hyunju Kang <rexington@gmail.com>\n"
 "Language-Team: Korean <hoenny@daum.net>\n"
@@ -140,7 +140,7 @@ msgstr ""
 msgid "Not now"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:422 src/amuleDlg.cpp:600
+#: src/AppImageIntegration.cpp:422 src/amuleDlg.cpp:665
 msgid "Don't ask again"
 msgstr ""
 
@@ -217,7 +217,7 @@ msgid "Killing amuleweb instance with pid '%d' ... "
 msgstr ""
 
 #: src/amule.cpp:336 src/amule.cpp:349 src/ClientRef.cpp:180
-#: src/SearchDlg.cpp:880 src/ServerListCtrl.cpp:98
+#: src/SearchDlg.cpp:1041 src/ServerListCtrl.cpp:98
 msgid "Failed"
 msgstr "실패"
 
@@ -572,30 +572,68 @@ msgstr ""
 msgid "ERROR: %s"
 msgstr "오류: %s"
 
-#: src/amuleDlg.cpp:236
+#: src/amuleDlg.cpp:250
 #, c-format
 msgid "This is aMule %s based on eMule."
 msgstr "이 어뮬 %s는 이뮬 기반으로 되어있습니다."
 
-#: src/amuleDlg.cpp:237
+#: src/amuleDlg.cpp:251
 #, c-format
 msgid "Running on %s"
 msgstr "%s에 동작중"
 
-#: src/amuleDlg.cpp:239
+#: src/amuleDlg.cpp:253
 msgid "Visit https://github.com/amule-org/amule/releases/latest to check if a new version is available."
 msgstr "https://github.com/amule-org/amule/releases/latest에 방문하셔서 새로운버젼이 있는지 확인하십시오."
 
-#: src/amuleDlg.cpp:268
+#: src/amuleDlg.cpp:282
 msgid "FATAL ERROR: Failed to create Timer"
 msgstr ""
 
-#: src/amuleDlg.cpp:592
+#: src/amuleDlg.cpp:361 src/amuleDlg.cpp:1787 src/amuleDlg.cpp:2033
+#: src/muuli_wdr.cpp:1492 src/muuli_wdr.cpp:3418
+msgid "Networks"
+msgstr "통신망"
+
+#: src/amuleDlg.cpp:362 src/amuleDlg.cpp:1793 src/muuli_wdr.cpp:3419
+msgid "Searches"
+msgstr "검색"
+
+#: src/amuleDlg.cpp:363 src/amuleDlg.cpp:1799 src/DownloadListCtrl.cpp:740
+#: src/muuli_wdr.cpp:392 src/muuli_wdr.cpp:1585 src/muuli_wdr.cpp:3420
+#: src/Statistics.cpp:829
+msgid "Downloads"
+msgstr "내려받기"
+
+#: src/amuleDlg.cpp:364 src/amuleDlg.cpp:1805 src/muuli_wdr.cpp:3294
+msgid "Shared files"
+msgstr ""
+
+#: src/amuleDlg.cpp:365 src/amuleDlg.cpp:1811 src/muuli_wdr.cpp:2926
+#: src/muuli_wdr.cpp:3376 src/muuli_wdr.cpp:3423
+msgid "Messages"
+msgstr "메시지"
+
+#: src/amuleDlg.cpp:366 src/amuleDlg.cpp:1817 src/muuli_wdr.cpp:3424
+#: src/PrefsUnifiedDlg.cpp:312 src/Statistics.cpp:779 src/Statistics.cpp:1235
+msgid "Statistics"
+msgstr "통계"
+
+#: src/amuleDlg.cpp:368 src/amuleDlg.cpp:1824 src/muuli_wdr.cpp:3426
+#: src/PrefsUnifiedDlg.cpp:328 src/utils/wxCas/src/wxcasprefs.cpp:39
+msgid "Preferences"
+msgstr "환경설정"
+
+#: src/amuleDlg.cpp:371
+msgid "Navigate"
+msgstr ""
+
+#: src/amuleDlg.cpp:657
 #, fuzzy
 msgid "New version available"
 msgstr "유효하지 않음"
 
-#: src/amuleDlg.cpp:596
+#: src/amuleDlg.cpp:661
 #, fuzzy, c-format
 msgid ""
 "A new version of aMule (%s) is available.\n"
@@ -605,228 +643,195 @@ msgid ""
 "Would you like to open the download page?"
 msgstr "최신 버젼은 항상 https://github.com/amule-org/amule/releases/latest 에서 찾을 수 있습니다."
 
-#: src/amuleDlg.cpp:678
+#: src/amuleDlg.cpp:743
 msgid "aMule dialog destroyed"
 msgstr ""
 
-#: src/amuleDlg.cpp:701 src/DataToText.cpp:68 src/IPFilter.cpp:547
+#: src/amuleDlg.cpp:766 src/DataToText.cpp:68 src/IPFilter.cpp:547
 msgid "Connecting"
 msgstr "연결중"
 
-#: src/amuleDlg.cpp:893
+#: src/amuleDlg.cpp:958
 msgid "eD2k: Connecting"
 msgstr ""
 
-#: src/amuleDlg.cpp:897
+#: src/amuleDlg.cpp:962
 msgid "eD2k: Disconnected"
 msgstr ""
 
-#: src/amuleDlg.cpp:903
+#: src/amuleDlg.cpp:968
 #, fuzzy
 msgid "Kad: Firewalled"
 msgstr "방화벽"
 
-#: src/amuleDlg.cpp:907
+#: src/amuleDlg.cpp:972
 #, fuzzy
 msgid "Kad: Connected"
 msgstr "연결됨"
 
-#: src/amuleDlg.cpp:912
+#: src/amuleDlg.cpp:977
 #, fuzzy
 msgid "Kad: Connecting"
 msgstr "연결중"
 
-#: src/amuleDlg.cpp:916
+#: src/amuleDlg.cpp:981
 #, fuzzy
 msgid "Kad: Off"
 msgstr " Kad: "
 
-#: src/amuleDlg.cpp:964 src/DownloadListCtrl.cpp:505
+#: src/amuleDlg.cpp:1029 src/DownloadListCtrl.cpp:505
 #: src/DownloadListCtrl.cpp:749 src/FriendListCtrl.cpp:180
 #: src/muuli_wdr.cpp:731 src/muuli_wdr.cpp:782 src/muuli_wdr.cpp:846
-#: src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2224 src/muuli_wdr.cpp:2309
-#: src/muuli_wdr.cpp:3057 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
+#: src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2231 src/muuli_wdr.cpp:2316
+#: src/muuli_wdr.cpp:3064 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
 #: src/ServerListCtrl.cpp:606 src/TransferWnd.cpp:378
 #: src/utils/wxCas/src/wxcasprefs.cpp:235
 msgid "Cancel"
 msgstr "취소"
 
-#: src/amuleDlg.cpp:965
+#: src/amuleDlg.cpp:1030
 #, fuzzy
 msgid "Stop the current connection attempts"
 msgstr "현재 연결시도를 멈춤"
 
-#: src/amuleDlg.cpp:970 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976
-#: src/muuli_wdr.cpp:2447
+#: src/amuleDlg.cpp:1035 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976
+#: src/muuli_wdr.cpp:2454
 msgid "Disconnect"
 msgstr "연결 끊기"
 
-#: src/amuleDlg.cpp:971
+#: src/amuleDlg.cpp:1036
 #, fuzzy
 msgid "Disconnect from the currently connected networks"
 msgstr "통신망으로부터 연결을 끊습니다."
 
-#: src/amuleDlg.cpp:976 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979
-#: src/muuli_wdr.cpp:2602 src/muuli_wdr.cpp:3054 src/muuli_wdr.cpp:3409
+#: src/amuleDlg.cpp:1041 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979
+#: src/muuli_wdr.cpp:2609 src/muuli_wdr.cpp:3061 src/muuli_wdr.cpp:3416
 msgid "Connect"
 msgstr "연결"
 
-#: src/amuleDlg.cpp:977
+#: src/amuleDlg.cpp:1042
 #, fuzzy
 msgid "Connect to the currently enabled networks"
 msgstr "통신망에 연결합니다."
 
-#: src/amuleDlg.cpp:1089
+#: src/amuleDlg.cpp:1154
 #, fuzzy, c-format
 msgid "Up: %.1f%s (%.1f) | Down: %.1f%s (%.1f)"
 msgstr "올려주기: %.1f(%.1f) | 내려받기: %.1f(%.1f)"
 
-#: src/amuleDlg.cpp:1091 src/amuleDlg.cpp:1093 src/amuleDlg.cpp:1097
-#: src/amuleDlg.cpp:1099 src/amuleDlg.cpp:1110 src/amuleDlg.cpp:1112
+#: src/amuleDlg.cpp:1156 src/amuleDlg.cpp:1158 src/amuleDlg.cpp:1162
+#: src/amuleDlg.cpp:1164 src/amuleDlg.cpp:1175 src/amuleDlg.cpp:1177
 #: src/MuleTrayIcon.cpp:796 src/MuleTrayIcon.cpp:799
 #, fuzzy
 msgid " MB/s"
 msgstr "MB/s"
 
-#: src/amuleDlg.cpp:1091 src/amuleDlg.cpp:1093 src/amuleDlg.cpp:1097
-#: src/amuleDlg.cpp:1099 src/amuleDlg.cpp:1110 src/amuleDlg.cpp:1112
+#: src/amuleDlg.cpp:1156 src/amuleDlg.cpp:1158 src/amuleDlg.cpp:1162
+#: src/amuleDlg.cpp:1164 src/amuleDlg.cpp:1175 src/amuleDlg.cpp:1177
 #: src/MuleTrayIcon.cpp:796 src/MuleTrayIcon.cpp:799
 #: src/utils/wxCas/src/wxcasframe.cpp:1041
 #, fuzzy
 msgid " kB/s"
 msgstr "kB/s"
 
-#: src/amuleDlg.cpp:1096
+#: src/amuleDlg.cpp:1161
 #, fuzzy, c-format
 msgid "Up: %.1f%s | Down: %.1f%s"
 msgstr "올려주기: %.1f | 내려받기: %.1f"
 
-#: src/amuleDlg.cpp:1128
+#: src/amuleDlg.cpp:1193
 #, c-format
 msgid "aMule (%s | Connected)"
 msgstr "어뮬 (%s | 연결됨)"
 
-#: src/amuleDlg.cpp:1130
+#: src/amuleDlg.cpp:1195
 #, c-format
 msgid "aMule (%s | Disconnected)"
 msgstr "어뮬 (%s | 끊김)"
 
-#: src/amuleDlg.cpp:1183
+#: src/amuleDlg.cpp:1248
 #, fuzzy, c-format
 msgid "Do you really want to exit %s?"
 msgstr "어뮬을 종료하시겠습니까?"
 
-#: src/amuleDlg.cpp:1185
+#: src/amuleDlg.cpp:1250
 msgid "Exit confirmation"
 msgstr "종료 확인"
 
-#: src/amuleDlg.cpp:1548
+#: src/amuleDlg.cpp:1613
 #, fuzzy
 msgid "Launch Command: "
 msgstr "명령: %s"
 
-#: src/amuleDlg.cpp:1567 src/muuli_wdr.cpp:1971 src/Preferences.cpp:951
+#: src/amuleDlg.cpp:1632 src/muuli_wdr.cpp:1978 src/Preferences.cpp:952
 msgid "- default -"
 msgstr ""
 
-#: src/amuleDlg.cpp:1595
+#: src/amuleDlg.cpp:1660
 #, c-format
 msgid "Skin directory '%s' does not exist"
 msgstr "외형 폴더 '%s'가 없습니다."
 
-#: src/amuleDlg.cpp:1598
+#: src/amuleDlg.cpp:1663
 #, c-format
 msgid "WARNING: Unable to open skin file '%s' for read"
 msgstr ""
 
-#: src/amuleDlg.cpp:1722 src/amuleDlg.cpp:1968 src/muuli_wdr.cpp:1485
-#: src/muuli_wdr.cpp:3411
-msgid "Networks"
-msgstr "통신망"
-
-#: src/amuleDlg.cpp:1726 src/muuli_wdr.cpp:3411
+#: src/amuleDlg.cpp:1791 src/muuli_wdr.cpp:3418
 msgid "Networks Window"
 msgstr "통신망 창"
 
-#: src/amuleDlg.cpp:1728 src/muuli_wdr.cpp:3412
-msgid "Searches"
-msgstr "검색"
-
-#: src/amuleDlg.cpp:1732 src/muuli_wdr.cpp:3412
+#: src/amuleDlg.cpp:1797 src/muuli_wdr.cpp:3419
 msgid "Searches Window"
 msgstr "검색 창"
 
-#: src/amuleDlg.cpp:1734 src/DownloadListCtrl.cpp:740 src/muuli_wdr.cpp:392
-#: src/muuli_wdr.cpp:1578 src/muuli_wdr.cpp:3413 src/Statistics.cpp:829
-msgid "Downloads"
-msgstr "내려받기"
-
-#: src/amuleDlg.cpp:1738 src/muuli_wdr.cpp:3413
+#: src/amuleDlg.cpp:1803 src/muuli_wdr.cpp:3420
 #, fuzzy
 msgid "Downloads Window"
 msgstr "받는중"
 
-#: src/amuleDlg.cpp:1740 src/muuli_wdr.cpp:3287
-msgid "Shared files"
-msgstr ""
-
-#: src/amuleDlg.cpp:1744 src/muuli_wdr.cpp:3415
+#: src/amuleDlg.cpp:1809 src/muuli_wdr.cpp:3422
 msgid "Shared Files Window"
 msgstr "공유 파일 창"
 
-#: src/amuleDlg.cpp:1746 src/muuli_wdr.cpp:2919 src/muuli_wdr.cpp:3369
-#: src/muuli_wdr.cpp:3416
-msgid "Messages"
-msgstr "메시지"
-
-#: src/amuleDlg.cpp:1750 src/muuli_wdr.cpp:3416
+#: src/amuleDlg.cpp:1815 src/muuli_wdr.cpp:3423
 msgid "Messages Window"
 msgstr "메시지 창"
 
-#: src/amuleDlg.cpp:1752 src/muuli_wdr.cpp:3417 src/PrefsUnifiedDlg.cpp:312
-#: src/Statistics.cpp:779 src/Statistics.cpp:1235
-msgid "Statistics"
-msgstr "통계"
-
-#: src/amuleDlg.cpp:1756 src/muuli_wdr.cpp:3417
+#: src/amuleDlg.cpp:1821 src/muuli_wdr.cpp:3424
 msgid "Statistics Graph Window"
 msgstr "통계 그래프 창"
 
-#: src/amuleDlg.cpp:1759 src/muuli_wdr.cpp:3419 src/PrefsUnifiedDlg.cpp:328
-#: src/utils/wxCas/src/wxcasprefs.cpp:39
-msgid "Preferences"
-msgstr "환경설정"
-
-#: src/amuleDlg.cpp:1763 src/muuli_wdr.cpp:3419
+#: src/amuleDlg.cpp:1828 src/muuli_wdr.cpp:3426
 msgid "Preferences Settings Window"
 msgstr "환경 설정 창"
 
-#: src/amuleDlg.cpp:1766 src/muuli_wdr.cpp:3420
+#: src/amuleDlg.cpp:1831 src/muuli_wdr.cpp:3427
 msgid "Import"
 msgstr "가져오기"
 
-#: src/amuleDlg.cpp:1770 src/muuli_wdr.cpp:3420
+#: src/amuleDlg.cpp:1835 src/muuli_wdr.cpp:3427
 msgid "The partfile importer tool"
 msgstr "부분파일 가져오기 도구"
 
-#: src/amuleDlg.cpp:1773 src/muuli_wdr.cpp:3421
+#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3428
 #: src/utils/aLinkCreator/src/alcframe.cpp:262
 msgid "About"
 msgstr "정보"
 
-#: src/amuleDlg.cpp:1773 src/muuli_wdr.cpp:3421
+#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3428
 msgid "About/Help"
 msgstr "정보/도움"
 
-#: src/amuleDlg.cpp:1971
+#: src/amuleDlg.cpp:2036
 msgid "eD2k network"
 msgstr ""
 
-#: src/amuleDlg.cpp:1974
+#: src/amuleDlg.cpp:2039
 msgid "Kad network"
 msgstr ""
 
-#: src/amuleDlg.cpp:1974
+#: src/amuleDlg.cpp:2039
 msgid "No network"
 msgstr ""
 
@@ -1363,19 +1368,19 @@ msgstr "자동[높음]"
 msgid "Very low"
 msgstr "매우 낮음"
 
-#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:743 src/muuli_wdr.cpp:2275
+#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:743 src/muuli_wdr.cpp:2282
 #: src/ServerListCtrl.cpp:263 src/ServerListCtrl.cpp:456
 #: src/SharedFilesCtrl.cpp:145
 msgid "Low"
 msgstr "낮음"
 
-#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:744 src/muuli_wdr.cpp:2276
+#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:744 src/muuli_wdr.cpp:2283
 #: src/ServerListCtrl.cpp:266 src/ServerListCtrl.cpp:457
 #: src/SharedFilesCtrl.cpp:146
 msgid "Normal"
 msgstr "보통"
 
-#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:745 src/muuli_wdr.cpp:2277
+#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:745 src/muuli_wdr.cpp:2284
 #: src/ServerListCtrl.cpp:269 src/ServerListCtrl.cpp:458
 #: src/SharedFilesCtrl.cpp:147
 msgid "High"
@@ -1467,8 +1472,8 @@ msgstr "지역 서버"
 msgid "Remote Server"
 msgstr "원격 서버"
 
-#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3174
-#: src/SearchDlg.cpp:111 src/TextClient.cpp:911
+#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3181
+#: src/SearchDlg.cpp:119 src/TextClient.cpp:911
 msgid "Kad"
 msgstr "Kad"
 
@@ -1538,7 +1543,7 @@ msgstr ""
 msgid "Size"
 msgstr "크기"
 
-#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3241
+#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3248
 msgid "Transferred"
 msgstr "전송됨"
 
@@ -1596,7 +1601,7 @@ msgid ""
 "\n"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:746 src/muuli_wdr.cpp:2278
+#: src/DownloadListCtrl.cpp:746 src/muuli_wdr.cpp:2285
 #: src/SharedFilesCtrl.cpp:150
 msgid "Auto"
 msgstr "자동"
@@ -1634,7 +1639,7 @@ msgid "Extended Options"
 msgstr "확장 옵션"
 
 #: src/DownloadListCtrl.cpp:770 src/DownloadListCtrl.cpp:822
-#: src/muuli_wdr.cpp:1789
+#: src/muuli_wdr.cpp:1796
 msgid "Preview"
 msgstr "미리보기"
 
@@ -2348,19 +2353,19 @@ msgstr ""
 msgid "eD2k"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:349 src/muuli_wdr.cpp:1488
+#: src/FirstRunWizard.cpp:349 src/muuli_wdr.cpp:1495
 msgid "Kademlia"
 msgstr "카뎀리아"
 
-#: src/FirstRunWizard.cpp:359 src/muuli_wdr.cpp:1416
+#: src/FirstRunWizard.cpp:359 src/muuli_wdr.cpp:1423
 msgid "Standard TCP Port "
 msgstr ""
 
-#: src/FirstRunWizard.cpp:365 src/muuli_wdr.cpp:1428
+#: src/FirstRunWizard.cpp:365 src/muuli_wdr.cpp:1435
 msgid "Extended UDP port (Kad / global search) "
 msgstr ""
 
-#: src/FirstRunWizard.cpp:377 src/muuli_wdr.cpp:1435
+#: src/FirstRunWizard.cpp:377 src/muuli_wdr.cpp:1442
 msgid "Enable UPnP for router port forwarding"
 msgstr ""
 
@@ -2387,7 +2392,7 @@ msgstr ""
 msgid "Your peer lists are already in place - nothing to download."
 msgstr "이미 %s 파일을 내려받으려고 하고있음"
 
-#: src/FirstRunWizard.cpp:434 src/muuli_wdr.cpp:1533
+#: src/FirstRunWizard.cpp:434 src/muuli_wdr.cpp:1540
 msgid "Auto-update server list at startup"
 msgstr ""
 
@@ -2433,23 +2438,23 @@ msgid ""
 "want downloads on a different (e.g. larger) disk."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:549 src/FirstRunWizard.cpp:611 src/muuli_wdr.cpp:1701
+#: src/FirstRunWizard.cpp:549 src/FirstRunWizard.cpp:611 src/muuli_wdr.cpp:1708
 msgid "Destination folder for downloads"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:553 src/FirstRunWizard.cpp:569 src/muuli_wdr.cpp:1342
-#: src/muuli_wdr.cpp:1359 src/muuli_wdr.cpp:1676 src/muuli_wdr.cpp:1707
-#: src/muuli_wdr.cpp:1719 src/muuli_wdr.cpp:2762
+#: src/FirstRunWizard.cpp:553 src/FirstRunWizard.cpp:569 src/muuli_wdr.cpp:1349
+#: src/muuli_wdr.cpp:1366 src/muuli_wdr.cpp:1683 src/muuli_wdr.cpp:1714
+#: src/muuli_wdr.cpp:1726 src/muuli_wdr.cpp:2769
 #: src/utils/aLinkCreator/src/alcframe.cpp:135
 #: src/utils/wxCas/src/wxcasprefs.cpp:52 src/utils/wxCas/src/wxcasprefs.cpp:118
 msgid "Browse"
 msgstr "탐색"
 
-#: src/FirstRunWizard.cpp:559 src/muuli_wdr.cpp:1712
+#: src/FirstRunWizard.cpp:559 src/muuli_wdr.cpp:1719
 msgid "(All files in this folder are shared with other peers)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:565 src/FirstRunWizard.cpp:624 src/muuli_wdr.cpp:1714
+#: src/FirstRunWizard.cpp:565 src/FirstRunWizard.cpp:624 src/muuli_wdr.cpp:1721
 msgid "Folder for temporary download files"
 msgstr ""
 
@@ -2480,7 +2485,7 @@ msgstr ""
 msgid "CRITICAL - no client on StartChatSession"
 msgstr ""
 
-#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2668 src/muuli_wdr.cpp:3345
+#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2675 src/muuli_wdr.cpp:3352
 msgid "Friends"
 msgstr "친구"
 
@@ -2872,7 +2877,7 @@ msgstr ""
 msgid "Uploaded"
 msgstr ""
 
-#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3225
+#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3232
 msgid "Requested"
 msgstr ""
 
@@ -2998,7 +3003,7 @@ msgid "WARNING: "
 msgstr ""
 
 #: src/MuleNotebook.cpp:179 src/muuli_wdr.cpp:817 src/muuli_wdr.cpp:1229
-#: src/muuli_wdr.cpp:3129 src/muuli_wdr.cpp:3385
+#: src/muuli_wdr.cpp:3136 src/muuli_wdr.cpp:3392
 msgid "Close"
 msgstr "닫기"
 
@@ -3011,12 +3016,12 @@ msgstr "자르기"
 msgid "Copy"
 msgstr "복사"
 
-#: src/MuleTextCtrl.cpp:88
+#: src/MuleTextCtrl.cpp:88 src/SearchDlg.cpp:261
 msgid "Paste"
 msgstr "붙이기"
 
 #: src/MuleTextCtrl.cpp:89 src/muuli_wdr.cpp:358 src/muuli_wdr.cpp:757
-#: src/muuli_wdr.cpp:2352 src/muuli_wdr.cpp:2371 src/muuli_wdr.cpp:2393
+#: src/muuli_wdr.cpp:2359 src/muuli_wdr.cpp:2378 src/muuli_wdr.cpp:2400
 #: src/utils/aLinkCreator/src/alcframe.cpp:142
 msgid "Clear"
 msgstr "깨끗이"
@@ -3113,8 +3118,8 @@ msgid "Exit"
 msgstr "종료"
 
 #: src/MuleTrayIcon.cpp:579 src/MuleTrayIcon.cpp:945 src/MuleTrayIcon.cpp:965
-#: src/muuli_wdr.cpp:1391 src/muuli_wdr.cpp:1399 src/muuli_wdr.cpp:1406
-#: src/muuli_wdr.cpp:1835 src/muuli_wdr.cpp:1841 src/OtherFunctions.cpp:91
+#: src/muuli_wdr.cpp:1398 src/muuli_wdr.cpp:1406 src/muuli_wdr.cpp:1413
+#: src/muuli_wdr.cpp:1842 src/muuli_wdr.cpp:1848 src/OtherFunctions.cpp:91
 #: src/StatisticsDlg.cpp:93 src/StatisticsDlg.cpp:95
 msgid "kB/s"
 msgstr "kB/s"
@@ -3285,7 +3290,7 @@ msgstr "이름:"
 msgid "Type"
 msgstr "종류"
 
-#: src/muuli_wdr.cpp:215 src/SearchDlg.cpp:110 src/SearchListCtrl.cpp:853
+#: src/muuli_wdr.cpp:215 src/SearchDlg.cpp:118 src/SearchListCtrl.cpp:853
 msgid "Local"
 msgstr "지역"
 
@@ -3356,7 +3361,7 @@ msgstr "바이트"
 msgid "KB"
 msgstr "KB"
 
-#: src/muuli_wdr.cpp:274 src/muuli_wdr.cpp:293 src/muuli_wdr.cpp:1620
+#: src/muuli_wdr.cpp:274 src/muuli_wdr.cpp:293 src/muuli_wdr.cpp:1627
 #: src/OtherFunctions.cpp:64
 msgid "MB"
 msgstr "MB"
@@ -3373,7 +3378,7 @@ msgstr "최대 크기"
 msgid "Availability"
 msgstr "유효성"
 
-#: src/muuli_wdr.cpp:312 src/muuli_wdr.cpp:398 src/muuli_wdr.cpp:3290
+#: src/muuli_wdr.cpp:312 src/muuli_wdr.cpp:398 src/muuli_wdr.cpp:3297
 msgid "Filter:"
 msgstr "필터:"
 
@@ -3405,7 +3410,7 @@ msgstr ""
 msgid "Stop"
 msgstr "멈춤"
 
-#: src/muuli_wdr.cpp:348 src/muuli_wdr.cpp:1385 src/SearchListCtrl.cpp:732
+#: src/muuli_wdr.cpp:348 src/muuli_wdr.cpp:1392 src/SearchListCtrl.cpp:732
 msgid "Download"
 msgstr "내려받기"
 
@@ -3437,8 +3442,8 @@ msgstr "자료 유지"
 #: src/muuli_wdr.cpp:1160 src/muuli_wdr.cpp:1167 src/muuli_wdr.cpp:1172
 #: src/muuli_wdr.cpp:1179 src/muuli_wdr.cpp:1184 src/muuli_wdr.cpp:1191
 #: src/muuli_wdr.cpp:1205 src/muuli_wdr.cpp:1212 src/muuli_wdr.cpp:1217
-#: src/muuli_wdr.cpp:1224 src/muuli_wdr.cpp:3227 src/muuli_wdr.cpp:3235
-#: src/muuli_wdr.cpp:3243
+#: src/muuli_wdr.cpp:1224 src/muuli_wdr.cpp:3234 src/muuli_wdr.cpp:3242
+#: src/muuli_wdr.cpp:3250
 msgid "N/A"
 msgstr "없음"
 
@@ -3583,7 +3588,7 @@ msgstr ""
 msgid "Album :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:685 src/muuli_wdr.cpp:2247
+#: src/muuli_wdr.cpp:685 src/muuli_wdr.cpp:2254
 msgid "Title :"
 msgstr "제목 :"
 
@@ -3690,7 +3695,7 @@ msgstr "사용자 이름 :"
 msgid "Userhash :"
 msgstr "사용자 해시 :"
 
-#: src/muuli_wdr.cpp:895 src/muuli_wdr.cpp:1741 src/muuli_wdr.cpp:2442
+#: src/muuli_wdr.cpp:895 src/muuli_wdr.cpp:1748 src/muuli_wdr.cpp:2449
 #: src/utils/aLinkCreator/src/alcframe.cpp:137
 msgid "Add"
 msgstr "추가"
@@ -3699,15 +3704,15 @@ msgstr "추가"
 msgid "Download-Speed"
 msgstr "내려받기 속도"
 
-#: src/muuli_wdr.cpp:954 src/muuli_wdr.cpp:989 src/muuli_wdr.cpp:2546
+#: src/muuli_wdr.cpp:954 src/muuli_wdr.cpp:989 src/muuli_wdr.cpp:2553
 msgid "Current"
 msgstr "현재"
 
-#: src/muuli_wdr.cpp:962 src/muuli_wdr.cpp:997 src/muuli_wdr.cpp:2554
+#: src/muuli_wdr.cpp:962 src/muuli_wdr.cpp:997 src/muuli_wdr.cpp:2561
 msgid "Running average"
 msgstr "동작중 평균"
 
-#: src/muuli_wdr.cpp:970 src/muuli_wdr.cpp:1005 src/muuli_wdr.cpp:2562
+#: src/muuli_wdr.cpp:970 src/muuli_wdr.cpp:1005 src/muuli_wdr.cpp:2569
 msgid "Session average"
 msgstr "세션 평균"
 
@@ -3719,7 +3724,7 @@ msgstr "올려주기 속도"
 msgid "Connections"
 msgstr "연결"
 
-#: src/muuli_wdr.cpp:1024 src/muuli_wdr.cpp:1860
+#: src/muuli_wdr.cpp:1024 src/muuli_wdr.cpp:1867
 msgid "Active downloads"
 msgstr "활성화된 내려받기"
 
@@ -3727,7 +3732,7 @@ msgstr "활성화된 내려받기"
 msgid "Active connections (1:1)"
 msgstr "활성화된 연결 (1:1)"
 
-#: src/muuli_wdr.cpp:1040 src/muuli_wdr.cpp:1861
+#: src/muuli_wdr.cpp:1040 src/muuli_wdr.cpp:1868
 msgid "Active uploads"
 msgstr "활성화된 올려주기"
 
@@ -3844,8 +3849,8 @@ msgstr "이것은 접속했을때 다른 사용자가 볼 수 있는 이름입�
 msgid "Language: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1257 src/muuli_wdr.cpp:1323 src/muuli_wdr.cpp:1327
-#: src/muuli_wdr.cpp:1330
+#: src/muuli_wdr.cpp:1257 src/muuli_wdr.cpp:1330 src/muuli_wdr.cpp:1334
+#: src/muuli_wdr.cpp:1337
 msgid "The delay before showing tool-tips."
 msgstr "도구도움이 보여주기 이전의 지연시간."
 
@@ -3923,936 +3928,945 @@ msgstr ""
 msgid "Enabling this will make aMule to show notifications when finished downloading."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1322
-msgid "Tooltip delay time: "
+#: src/muuli_wdr.cpp:1323
+#, fuzzy
+msgid "Remember search history"
+msgstr "설정을 기억"
+
+#: src/muuli_wdr.cpp:1324
+msgid "Keeps a dropdown list of your past search terms in the Search tab's Name field. This remembers the queries you typed, not the results they returned."
 msgstr ""
 
 #: src/muuli_wdr.cpp:1329
+msgid "Tooltip delay time: "
+msgstr ""
+
+#: src/muuli_wdr.cpp:1336
 msgid "seconds"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1333
+#: src/muuli_wdr.cpp:1340
 msgid "Browser Selection"
 msgstr "브라우저 선택"
 
-#: src/muuli_wdr.cpp:1339
+#: src/muuli_wdr.cpp:1346
 msgid "Enter your browser name here. Leave this field empty to use the system default browser."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1346
+#: src/muuli_wdr.cpp:1353
 msgid "Open in new tab if possible"
 msgstr "가능하면 새로운 탭을 생성함"
 
-#: src/muuli_wdr.cpp:1348
+#: src/muuli_wdr.cpp:1355
 msgid "Open the web page in a new tab instead of in a new window when possible"
 msgstr "가능하면 새로운 창을 여는것 대신 새로운 탭을 생성합니다."
 
-#: src/muuli_wdr.cpp:1352
+#: src/muuli_wdr.cpp:1359
 msgid "Video Player"
 msgstr "비디오 재생기"
 
-#: src/muuli_wdr.cpp:1379
+#: src/muuli_wdr.cpp:1386
 msgid "Bandwidth limits"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1393
+#: src/muuli_wdr.cpp:1400
 msgid "Upload"
 msgstr "올려주기"
 
-#: src/muuli_wdr.cpp:1401
+#: src/muuli_wdr.cpp:1408
 msgid "Slot Allocation"
 msgstr "칸 배분"
 
-#: src/muuli_wdr.cpp:1410
+#: src/muuli_wdr.cpp:1417
 msgid "Ports"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1420
+#: src/muuli_wdr.cpp:1427
 msgid "This is the standard eD2k port and cannot be disabled."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1423
+#: src/muuli_wdr.cpp:1430
 msgid "UDP port for server requests (TCP+3):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1425
+#: src/muuli_wdr.cpp:1432
 msgid "4665"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1432
+#: src/muuli_wdr.cpp:1439
 msgid "This UDP port is used for extended eD2k requests and Kad network"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1439
+#: src/muuli_wdr.cpp:1446
 msgid "UPnP TCP Port (Optional):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1449
+#: src/muuli_wdr.cpp:1456
 msgid "Bind local address to IP (empty for any):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1452
+#: src/muuli_wdr.cpp:1459
 msgid "Advanced users only: If you have multiple network interfaces, enter the address of the interface to which aMule should be bound."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1455 src/muuli_wdr.cpp:2054
+#: src/muuli_wdr.cpp:1462 src/muuli_wdr.cpp:2061
 msgid "Bind to network interface (empty for any):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1468
+#: src/muuli_wdr.cpp:1475
 msgid "Advanced users only: pin all of aMule's traffic to one network interface, chosen from the list or typed in by name (e.g. tun0, eth0, en0) or index. Unlike binding to an IP, this stops traffic leaking out via the default route - useful with a VPN. Requires no elevated privileges."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1474
+#: src/muuli_wdr.cpp:1481
 msgid "Max sources per downloading file:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1478
+#: src/muuli_wdr.cpp:1485
 msgid "Max simultaneous connections:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1491 src/muuli_wdr.cpp:3169
+#: src/muuli_wdr.cpp:1498 src/muuli_wdr.cpp:3176
 msgid "ED2K"
 msgstr "ED2k"
 
-#: src/muuli_wdr.cpp:1498
+#: src/muuli_wdr.cpp:1505
 msgid "Autoconnect on startup"
 msgstr "시작시 자동연결"
 
-#: src/muuli_wdr.cpp:1501
+#: src/muuli_wdr.cpp:1508
 msgid "Reconnect on loss"
 msgstr "끊겼을시 재연결"
 
-#: src/muuli_wdr.cpp:1523
+#: src/muuli_wdr.cpp:1530
 msgid "Remove dead server after"
 msgstr "죽은서버 제거"
 
-#: src/muuli_wdr.cpp:1524
+#: src/muuli_wdr.cpp:1531
 msgid "Static servers are never removed, even when unreachable."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1528
+#: src/muuli_wdr.cpp:1535
 msgid "retries"
 msgstr "재시도"
 
-#: src/muuli_wdr.cpp:1536
+#: src/muuli_wdr.cpp:1543
 msgid "List"
 msgstr "목록"
 
-#: src/muuli_wdr.cpp:1539
+#: src/muuli_wdr.cpp:1546
 msgid "Update server list when connecting to a server"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1542
+#: src/muuli_wdr.cpp:1549
 msgid "Update server list when a client connects"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1545
+#: src/muuli_wdr.cpp:1552
 msgid "Use priority system"
 msgstr "우선순위 시스템을 사용"
 
-#: src/muuli_wdr.cpp:1549
+#: src/muuli_wdr.cpp:1556
 msgid "Use smart LowID check on connect"
 msgstr "연결할때 현명한 낮은아이디 검사를 사용"
 
-#: src/muuli_wdr.cpp:1553
+#: src/muuli_wdr.cpp:1560
 msgid "Safe connect"
 msgstr "안전한 연결"
 
-#: src/muuli_wdr.cpp:1557
+#: src/muuli_wdr.cpp:1564
 msgid "Autoconnect to servers in static list only"
 msgstr "정적목록내의 서버에만 연결"
 
-#: src/muuli_wdr.cpp:1560
+#: src/muuli_wdr.cpp:1567
 msgid "Set manually added servers to High Priority"
 msgstr "수동으로 추가된 서버에 높은 우선권 부여"
 
-#: src/muuli_wdr.cpp:1581
+#: src/muuli_wdr.cpp:1588
 msgid "Add files to download in pause mode"
 msgstr "멈춤 상태로 내려받기에 파일 추가"
 
-#: src/muuli_wdr.cpp:1583
+#: src/muuli_wdr.cpp:1590
 msgid "Add files to download with auto priority"
 msgstr "자동 우선권으로 내려받기에 파일 추가"
 
-#: src/muuli_wdr.cpp:1586
+#: src/muuli_wdr.cpp:1593
 msgid "Try to download first and last chunks first"
 msgstr "처음과 마지막 부분을 먼저 내려받음"
 
-#: src/muuli_wdr.cpp:1590
+#: src/muuli_wdr.cpp:1597
 msgid "Endgame mode: rotate to faster sources for the final blocks"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1593
+#: src/muuli_wdr.cpp:1600
 msgid "Start next paused file when a file completes"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1596
+#: src/muuli_wdr.cpp:1603
 msgid "From the same category"
 msgstr "동일한 분류로부터"
 
-#: src/muuli_wdr.cpp:1598
+#: src/muuli_wdr.cpp:1605
 msgid "In alphabetic order"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1600
+#: src/muuli_wdr.cpp:1607
 msgid "Preallocate disk space for new files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1601
+#: src/muuli_wdr.cpp:1608
 msgid "For new files preallocates disk space for the whole file, thus reduces fragmentation"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1606
+#: src/muuli_wdr.cpp:1613
 msgid "Create new files as sparse files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1607
+#: src/muuli_wdr.cpp:1614
 msgid "A sparse file reserves its full size on disk immediately without writing real data to it -- fast, but unsupported or slow on some filesystems, and free-space accounting stays optimistic while the download is in progress. Turn this off to grow the file only as data arrives."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1612
+#: src/muuli_wdr.cpp:1619
 msgid "Stop downloads when free disk space reaches "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1613
+#: src/muuli_wdr.cpp:1620
 msgid "Select this if you want aMule to check your disk space"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1617
+#: src/muuli_wdr.cpp:1624
 msgid "Enter here the min disk space desired."
 msgstr "원하는 최소한의 디스크공간을 입력하세요."
 
-#: src/muuli_wdr.cpp:1623
+#: src/muuli_wdr.cpp:1630
 msgid "Save 10 sources on rare files (< 20 sources)"
 msgstr "희귀한 파일인 경우 10개의 자료 저장 (<20 자료)"
 
-#: src/muuli_wdr.cpp:1627 src/Statistics.cpp:790
+#: src/muuli_wdr.cpp:1634 src/Statistics.cpp:790
 msgid "Uploads"
 msgstr "올려주기"
 
-#: src/muuli_wdr.cpp:1630
+#: src/muuli_wdr.cpp:1637
 msgid "Add new shared files with auto priority"
 msgstr "자동 우선권으로 새로운 공유파일을 추가"
 
-#: src/muuli_wdr.cpp:1636
+#: src/muuli_wdr.cpp:1643
 msgid "Intelligent Corruption Handling (I.C.H.)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1639
+#: src/muuli_wdr.cpp:1646
 msgid "Enable"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1642
+#: src/muuli_wdr.cpp:1649
 msgid "Advanced I.C.H. trusts every hash (not recommended)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1654 src/PrefsUnifiedDlg.cpp:1910
+#: src/muuli_wdr.cpp:1661 src/PrefsUnifiedDlg.cpp:1910
 msgid "Media metadata extraction"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1658
+#: src/muuli_wdr.cpp:1665
 msgid "Extract length / bitrate / codec from shared audio and video files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1660
+#: src/muuli_wdr.cpp:1667
 msgid "When enabled, aMule runs ffprobe on each shared media file to fill in the Length / Bitrate / Codec columns other clients see when they find the file in a search. Requires ffmpeg (the ffprobe binary) to be installed."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1667
+#: src/muuli_wdr.cpp:1674
 msgid "Path to ffprobe:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1672
+#: src/muuli_wdr.cpp:1679
 msgid "Full path to the ffprobe binary. Leave empty to have aMule auto-detect it on startup."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1680
+#: src/muuli_wdr.cpp:1687
 msgid "Detect"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1681
+#: src/muuli_wdr.cpp:1688
 msgid "Search the standard install locations for an ffprobe binary and fill the path field."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1705
+#: src/muuli_wdr.cpp:1712
 msgid ""
 "Completed downloads are stored here. All files in this folder are automatically shared with other peers.\n"
 "If this folder also holds files you don't want to share, point it at an aMule-only sub-folder."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1708
+#: src/muuli_wdr.cpp:1715
 msgid "Pick the folder where completed downloads will be stored. All files in that folder will be shared with other peers."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1722
+#: src/muuli_wdr.cpp:1729
 msgid "Shared folders"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1728
+#: src/muuli_wdr.cpp:1735
 msgid "(Folders shared by the core. Enter a path to add one.)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1736
+#: src/muuli_wdr.cpp:1743
 msgid "Absolute path of a folder on the core's machine, e.g. /home/user/shared"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1738 src/PrefsUnifiedDlg.cpp:2794
+#: src/muuli_wdr.cpp:1745 src/PrefsUnifiedDlg.cpp:2794
 msgid "Recursive"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1739
+#: src/muuli_wdr.cpp:1746
 msgid "Share every sub-folder underneath this one, including ones created later."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1743 src/utils/aLinkCreator/src/alcframe.cpp:141
+#: src/muuli_wdr.cpp:1750 src/utils/aLinkCreator/src/alcframe.cpp:141
 msgid "Remove"
 msgstr "삭제"
 
-#: src/muuli_wdr.cpp:1747
+#: src/muuli_wdr.cpp:1754
 msgid "(Right click on folder icon for recursive share)"
 msgstr "(하위폴더 전체를 공유하려면 폴더 아이콘상에서 오른쪽 버튼을 클릭)"
 
-#: src/muuli_wdr.cpp:1754
+#: src/muuli_wdr.cpp:1761
 msgid "Share hidden files"
 msgstr "숨은파일 공유"
 
-#: src/muuli_wdr.cpp:1760
+#: src/muuli_wdr.cpp:1767
 msgid "Automatically rescan shared folders for changes"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1766
+#: src/muuli_wdr.cpp:1773
 msgid "Follow symbolic links in shared folders"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1772
+#: src/muuli_wdr.cpp:1779
 msgid "Exclude files matching:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1775
+#: src/muuli_wdr.cpp:1782
 msgid "Wildcard patterns separated by '|', e.g. .DS_Store|Thumbs.db|*.tmp. Files whose name matches are not shared. Matching is case-insensitive."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1779
+#: src/muuli_wdr.cpp:1786
 msgid "Patterns are regular expressions"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1780
+#: src/muuli_wdr.cpp:1787
 msgid "When set, the whole field is one regular expression ('|' is alternation). When unset, it is a list of '|'-separated wildcards."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1790
+#: src/muuli_wdr.cpp:1797
 msgid "Show how many shared files the current pattern would exclude."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1811
+#: src/muuli_wdr.cpp:1818
 msgid "Graphs"
 msgstr "그래프"
 
-#: src/muuli_wdr.cpp:1814 src/muuli_wdr.cpp:1876
+#: src/muuli_wdr.cpp:1821 src/muuli_wdr.cpp:1883
 msgid "Update delay : 5 secs"
 msgstr "갱신 지연 : 5 초"
 
-#: src/muuli_wdr.cpp:1818
+#: src/muuli_wdr.cpp:1825
 msgid "Time for average graph: 100 mins"
 msgstr "평균 그래프 시간 : 100 분"
 
-#: src/muuli_wdr.cpp:1822
+#: src/muuli_wdr.cpp:1829
 msgid "Connections Graph Scale: 100 "
 msgstr "연결 그래프 크기 : 100"
 
-#: src/muuli_wdr.cpp:1829
+#: src/muuli_wdr.cpp:1836
 msgid "Download graph scale:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1837
+#: src/muuli_wdr.cpp:1844
 msgid "Upload graph scale:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1847
+#: src/muuli_wdr.cpp:1854
 msgid "Colors: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1851
+#: src/muuli_wdr.cpp:1858
 msgid "Background"
 msgstr "바탕"
 
-#: src/muuli_wdr.cpp:1852
+#: src/muuli_wdr.cpp:1859
 msgid "Grid"
 msgstr "눈금"
 
-#: src/muuli_wdr.cpp:1853
+#: src/muuli_wdr.cpp:1860
 msgid "Download current"
 msgstr "현재 내려받기"
 
-#: src/muuli_wdr.cpp:1854
+#: src/muuli_wdr.cpp:1861
 msgid "Download running average"
 msgstr "내려받기 운용 평균"
 
-#: src/muuli_wdr.cpp:1855
+#: src/muuli_wdr.cpp:1862
 msgid "Download session average"
 msgstr "내려받기 세션 평균"
 
-#: src/muuli_wdr.cpp:1856
+#: src/muuli_wdr.cpp:1863
 msgid "Upload current"
 msgstr "현재 올려주기"
 
-#: src/muuli_wdr.cpp:1857
+#: src/muuli_wdr.cpp:1864
 msgid "Upload running average"
 msgstr "올려주기 운용 평균"
 
-#: src/muuli_wdr.cpp:1858
+#: src/muuli_wdr.cpp:1865
 msgid "Upload session average"
 msgstr "올려주기 세션 평균"
 
-#: src/muuli_wdr.cpp:1859
+#: src/muuli_wdr.cpp:1866
 msgid "Active connections"
 msgstr "활성화된 연결"
 
-#: src/muuli_wdr.cpp:1862
+#: src/muuli_wdr.cpp:1869
 #, fuzzy
 msgid "Systray Icon Speed Bar"
 msgstr "시스템트레이 아이콘 속도바"
 
-#: src/muuli_wdr.cpp:1863
+#: src/muuli_wdr.cpp:1870
 msgid "Kad-nodes current"
 msgstr "현재 Kad-노드"
 
-#: src/muuli_wdr.cpp:1864
+#: src/muuli_wdr.cpp:1871
 msgid "Kad-nodes running"
 msgstr "Kad-노드 운용"
 
-#: src/muuli_wdr.cpp:1865
+#: src/muuli_wdr.cpp:1872
 msgid "Kad-nodes session"
 msgstr "Kad-노드 세션"
 
-#: src/muuli_wdr.cpp:1869 src/muuli_wdr.cpp:2296
+#: src/muuli_wdr.cpp:1876 src/muuli_wdr.cpp:2303
 msgid "Select"
 msgstr "선택"
 
-#: src/muuli_wdr.cpp:1873
+#: src/muuli_wdr.cpp:1880
 msgid "Tree"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1883
+#: src/muuli_wdr.cpp:1890
 msgid "Number of Client Versions shown (0=unlimited)"
 msgstr "표시될 클라이언트 버젼의 수 (0=무제한)"
 
-#: src/muuli_wdr.cpp:1908
+#: src/muuli_wdr.cpp:1915
 msgid "!!! WARNING !!!"
 msgstr "!!! 경고 !!!"
 
-#: src/muuli_wdr.cpp:1923
+#: src/muuli_wdr.cpp:1930
 msgid "Max new connections / 5 secs"
 msgstr "최대 새연결 / 5 초"
 
-#: src/muuli_wdr.cpp:1925
+#: src/muuli_wdr.cpp:1932
 msgid "Concurrent Kad source lookups"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1927
+#: src/muuli_wdr.cpp:1934
 #, fuzzy
 msgid "Kad source re-search interval (minutes)"
 msgstr "FTP 갱신율 분당 간격"
 
-#: src/muuli_wdr.cpp:1929
+#: src/muuli_wdr.cpp:1936
 #, fuzzy
 msgid "Source re-ask interval (minutes)"
 msgstr "FTP 갱신율 분당 간격"
 
-#: src/muuli_wdr.cpp:1933
+#: src/muuli_wdr.cpp:1940
 msgid "File Buffer Size: 240000 bytes"
 msgstr "파일 버퍼 크기: 240000 바이트"
 
-#: src/muuli_wdr.cpp:1937
+#: src/muuli_wdr.cpp:1944
 msgid "Use MMAP: memory-mapped file access (lower memory use)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1938
+#: src/muuli_wdr.cpp:1945
 msgid "Maps part files into memory instead of buffering them on the heap, lowering the process memory footprint. May reduce download speed on some disks; best for memory-constrained or upload-heavy hosts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1940
+#: src/muuli_wdr.cpp:1947
 msgid "Upload Queue Size: 5000 clients"
 msgstr "올려주기 대기열 크기: 5000 클라이언트"
 
-#: src/muuli_wdr.cpp:1944
+#: src/muuli_wdr.cpp:1951
 msgid "Server connection refresh interval: Disable"
 msgstr "서버 연결 갱신 간격: 사용않함"
 
-#: src/muuli_wdr.cpp:1948
+#: src/muuli_wdr.cpp:1955
 msgid "Disable computer's timed standby mode"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1967
+#: src/muuli_wdr.cpp:1974
 msgid "Skin to use: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1976
+#: src/muuli_wdr.cpp:1983
 msgid "Show \"Fast eD2k Links Handler\" in every window."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1979
+#: src/muuli_wdr.cpp:1986
 msgid "Show extended info on categories tabs"
 msgstr "분류탭의 확장된 정보를 보여줌"
 
-#: src/muuli_wdr.cpp:1982
+#: src/muuli_wdr.cpp:1989
 #, fuzzy
 msgid "Show application version on title"
 msgstr "제목에 전송률을 보여줌"
 
-#: src/muuli_wdr.cpp:1984
+#: src/muuli_wdr.cpp:1991
 msgid "Show transfer rates on title"
 msgstr "제목에 전송률을 보여줌"
 
-#: src/muuli_wdr.cpp:1986
+#: src/muuli_wdr.cpp:1993
 msgid "Before application name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1988
+#: src/muuli_wdr.cpp:1995
 msgid "After application name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1991
+#: src/muuli_wdr.cpp:1998
 msgid "Show overhead bandwidth"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1995
+#: src/muuli_wdr.cpp:2002
 msgid "Vertical toolbar orientation"
 msgstr "수직방향 툴바"
 
-#: src/muuli_wdr.cpp:1997
+#: src/muuli_wdr.cpp:2004
 msgid "Live column sorting (auto-reorder rows as their values change)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2004
+#: src/muuli_wdr.cpp:2011
 msgid "Download Queue Files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2007
+#: src/muuli_wdr.cpp:2014
 msgid "Show progress percentage"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2013
+#: src/muuli_wdr.cpp:2020
 msgid "Show progress bar"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2016
+#: src/muuli_wdr.cpp:2023
 msgid "Flat"
 msgstr "평평한"
 
-#: src/muuli_wdr.cpp:2020
+#: src/muuli_wdr.cpp:2027
 msgid "Round"
 msgstr "둥근"
 
-#: src/muuli_wdr.cpp:2038
+#: src/muuli_wdr.cpp:2045
 msgid "External Connection Parameters"
 msgstr "외부연결 설정"
 
-#: src/muuli_wdr.cpp:2041
+#: src/muuli_wdr.cpp:2048
 msgid "Accept external connections"
 msgstr "외부연결 받아들임"
 
-#: src/muuli_wdr.cpp:2048 src/muuli_wdr.cpp:2107
+#: src/muuli_wdr.cpp:2055 src/muuli_wdr.cpp:2114
 msgid "IP of the listening interface:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2051
+#: src/muuli_wdr.cpp:2058
 msgid "Enter here a valid ip in the a.b.c.d format for the listening EC interface. An empty field or 0.0.0.0 will mean any interface."
 msgstr "수신대기 외부연결 인터페이스에 a.b.c.d 형식의 유효한 IP를 입력하세요. 항목이 비었거나 0.0.0.0이면 모든 인터페이스를 의미합니다."
 
-#: src/muuli_wdr.cpp:2072 src/muuli_wdr.cpp:2156
+#: src/muuli_wdr.cpp:2079 src/muuli_wdr.cpp:2163
 msgid "TCP port:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2078
+#: src/muuli_wdr.cpp:2085
 msgid "Enable UPnP port forwarding on the EC port"
 msgstr "외부연결 포트에 UPnP 포트포워딩 활성화"
 
-#: src/muuli_wdr.cpp:2082 src/muuli_wdr.cpp:3041
+#: src/muuli_wdr.cpp:2089 src/muuli_wdr.cpp:3048
 #: src/utils/wxCas/src/wxcasprefs.cpp:167
 msgid "Password"
 msgstr "암호"
 
-#: src/muuli_wdr.cpp:2088
+#: src/muuli_wdr.cpp:2095
 msgid "aMule API server parameters"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2091
+#: src/muuli_wdr.cpp:2098
 msgid "Run amuleapi (REST API) on startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2096
+#: src/muuli_wdr.cpp:2103
 #, fuzzy
 msgid "HTTP port:"
 msgstr "프록시 포트:"
 
-#: src/muuli_wdr.cpp:2110
+#: src/muuli_wdr.cpp:2117
 msgid "The interface amuleapi's HTTP server listens on. 127.0.0.1 (default) accepts only local connections; use 0.0.0.0 or a specific IP to expose it to other hosts (set an admin password below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2113
+#: src/muuli_wdr.cpp:2120
 #, fuzzy
 msgid "Admin password"
 msgstr "암호를 검사중\n"
 
-#: src/muuli_wdr.cpp:2118 src/muuli_wdr.cpp:2149
+#: src/muuli_wdr.cpp:2125 src/muuli_wdr.cpp:2156
 msgid "Low rights password"
 msgstr "낮은 권한 암호"
 
-#: src/muuli_wdr.cpp:2126
+#: src/muuli_wdr.cpp:2133
 msgid "Web server parameters"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2129
+#: src/muuli_wdr.cpp:2136
 msgid "Run webserver on startup (deprecated)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2135
+#: src/muuli_wdr.cpp:2142
 msgid "Web template"
 msgstr "웹 템플릿"
 
-#: src/muuli_wdr.cpp:2140
+#: src/muuli_wdr.cpp:2147
 msgid "Full rights password"
 msgstr "모든 권한 암호"
 
-#: src/muuli_wdr.cpp:2144
+#: src/muuli_wdr.cpp:2151
 msgid "Enable Low rights User"
 msgstr "낮은권한 사용자 활성화"
 
-#: src/muuli_wdr.cpp:2163
+#: src/muuli_wdr.cpp:2170
 msgid "Enable UPnP port forwarding of the web server port"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2168
+#: src/muuli_wdr.cpp:2175
 msgid "Web server UPnP TCP port (Optional)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2176
+#: src/muuli_wdr.cpp:2183
 msgid "Page Refresh Time (in secs)"
 msgstr "페이지를 갱신 시간 (초)"
 
-#: src/muuli_wdr.cpp:2183
+#: src/muuli_wdr.cpp:2190
 msgid "Enable Gzip compression"
 msgstr "Gzip압축을 활성화"
 
-#: src/muuli_wdr.cpp:2217
+#: src/muuli_wdr.cpp:2224
 #, fuzzy
 msgid "Reset page to defaults"
 msgstr "기본 설정"
 
-#: src/muuli_wdr.cpp:2218
+#: src/muuli_wdr.cpp:2225
 msgid "Reset the settings on the current page to their default values."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2220 src/muuli_wdr.cpp:2306 src/ServerWnd.cpp:274
+#: src/muuli_wdr.cpp:2227 src/muuli_wdr.cpp:2313 src/ServerWnd.cpp:274
 #: src/ServerWnd.cpp:282
 msgid "OK"
 msgstr "확인"
 
-#: src/muuli_wdr.cpp:2222
+#: src/muuli_wdr.cpp:2229
 msgid "Click here to apply any changes made to the preferences."
 msgstr "환경설정으로 바꾼것을 적용하려면 이곳을 클릭하세요."
 
-#: src/muuli_wdr.cpp:2225
+#: src/muuli_wdr.cpp:2232
 msgid "Reset any changes made to the preferences."
 msgstr "환경설정으로 바꾼것을 초기화합니다."
 
-#: src/muuli_wdr.cpp:2254
+#: src/muuli_wdr.cpp:2261
 msgid "Comment :"
 msgstr "의견 :"
 
-#: src/muuli_wdr.cpp:2261
+#: src/muuli_wdr.cpp:2268
 msgid "Incoming Dir :"
 msgstr "내려받는 폴더 :"
 
-#: src/muuli_wdr.cpp:2270
+#: src/muuli_wdr.cpp:2277
 msgid "Change priority for new assigned files :"
 msgstr "새롭게 할당된 파일의 우선권를 바꿉니다. :"
 
-#: src/muuli_wdr.cpp:2274
+#: src/muuli_wdr.cpp:2281
 #, fuzzy
 msgid "Don't change"
 msgstr "변경 않음"
 
-#: src/muuli_wdr.cpp:2286
+#: src/muuli_wdr.cpp:2293
 msgid "Select color for this Category (currently selected) :"
 msgstr "이 분류의 색을 선택 (일반적으로 선택된) :"
 
-#: src/muuli_wdr.cpp:2353 src/muuli_wdr.cpp:2372 src/muuli_wdr.cpp:2394
+#: src/muuli_wdr.cpp:2360 src/muuli_wdr.cpp:2379 src/muuli_wdr.cpp:2401
 msgid "Click this button to reset the log."
 msgstr "로그를 초기화하려면 이 버튼을 클릭하세요."
 
-#: src/muuli_wdr.cpp:2413
+#: src/muuli_wdr.cpp:2420
 msgid "Click on this button to update the servers list from URL ..."
 msgstr "URL로부터 서버 목록을 갱신하려면 이 버튼을 클릭..."
 
-#: src/muuli_wdr.cpp:2417
+#: src/muuli_wdr.cpp:2424
 msgid "Server list"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2421
+#: src/muuli_wdr.cpp:2428
 msgid "Enter the url to a server.met file here and press the button to the left to update the list of known servers."
 msgstr "알려진 서버의 목록을 갱신하기 위해서는 이곳에 server.met파일의 url을 입력하고 왼쪽편의 버튼을 누르세요."
 
-#: src/muuli_wdr.cpp:2426
+#: src/muuli_wdr.cpp:2433
 msgid "Add server manually: Name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2429
+#: src/muuli_wdr.cpp:2436
 msgid "Enter the name of the new server here"
 msgstr "새로운 서버의 이름을 입력하세요."
 
-#: src/muuli_wdr.cpp:2431 src/ServerWnd.cpp:206
+#: src/muuli_wdr.cpp:2438 src/ServerWnd.cpp:206
 msgid "IP:Port"
 msgstr "IP:포트"
 
-#: src/muuli_wdr.cpp:2434
+#: src/muuli_wdr.cpp:2441
 msgid "Enter the IP of the server here, using the x.x.x.x format."
 msgstr "x.x.x.x형식으로 서버의 IP를 이곳에 입력하세요."
 
-#: src/muuli_wdr.cpp:2440
+#: src/muuli_wdr.cpp:2447
 msgid "Enter the port of the server here."
 msgstr "서버의 포트를 이곳에 입력하세요."
 
-#: src/muuli_wdr.cpp:2443
+#: src/muuli_wdr.cpp:2450
 msgid "Add manually a server (fill fields to the left before) ..."
 msgstr "서버 수동 추가 (미리 왼쪽 부분을 채울 것) ..."
 
-#: src/muuli_wdr.cpp:2472
+#: src/muuli_wdr.cpp:2479
 msgid "aMule Log"
 msgstr "어뮬 로그"
 
-#: src/muuli_wdr.cpp:2480
+#: src/muuli_wdr.cpp:2487
 msgid "Server Info"
 msgstr "서버 정보"
 
-#: src/muuli_wdr.cpp:2484
+#: src/muuli_wdr.cpp:2491
 msgid "ED2K Info"
 msgstr "ED2k 정보"
 
-#: src/muuli_wdr.cpp:2488
+#: src/muuli_wdr.cpp:2495
 msgid "Kad Info"
 msgstr "Kad 정보"
 
-#: src/muuli_wdr.cpp:2516
+#: src/muuli_wdr.cpp:2523
 msgid "Click on this button to update the nodes list from URL ..."
 msgstr "URL로부터 노드를 갱신하려면 이 버튼을 클릭..."
 
-#: src/muuli_wdr.cpp:2520
+#: src/muuli_wdr.cpp:2527
 msgid "Nodes (0)"
 msgstr "노드 (0)"
 
-#: src/muuli_wdr.cpp:2524
+#: src/muuli_wdr.cpp:2531
 msgid "Enter the url to a nodes.dat file here and press the button to the left to update the list of known nodes."
 msgstr "알려진 노드의 목록을 갱신하기 위해서는 이곳에 nodes.dat파일의 url을 입력하고 왼쪽편의 버튼을 누르세요."
 
-#: src/muuli_wdr.cpp:2527
+#: src/muuli_wdr.cpp:2534
 msgid "Nodes stats"
 msgstr "노드 상태"
 
-#: src/muuli_wdr.cpp:2569
+#: src/muuli_wdr.cpp:2576
 msgid "Bootstrap"
 msgstr "초기적재"
 
-#: src/muuli_wdr.cpp:2572
+#: src/muuli_wdr.cpp:2579
 msgid "New node"
 msgstr "새로운 노드"
 
-#: src/muuli_wdr.cpp:2577
+#: src/muuli_wdr.cpp:2584
 msgid "IP:"
 msgstr "IP:"
 
-#: src/muuli_wdr.cpp:2597
+#: src/muuli_wdr.cpp:2604
 msgid "Port:"
 msgstr "포트:"
 
-#: src/muuli_wdr.cpp:2610
+#: src/muuli_wdr.cpp:2617
 #, fuzzy
 msgid "Bootstrap from known clients"
 msgstr ""
 "알려진 클라이언트로부터 \n"
 "초기적재"
 
-#: src/muuli_wdr.cpp:2612
+#: src/muuli_wdr.cpp:2619
 msgid "Disconnect Kad"
 msgstr "Kad 끊김"
 
-#: src/muuli_wdr.cpp:2646
+#: src/muuli_wdr.cpp:2653
 msgid "Use Secure User Identification"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2648
+#: src/muuli_wdr.cpp:2655
 msgid "It is recommended to enable this option. You will not receive credits if SUI is not enabled."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2650
+#: src/muuli_wdr.cpp:2657
 msgid "Protocol Obfuscation"
 msgstr "프로토콜 난독화"
 
-#: src/muuli_wdr.cpp:2653
+#: src/muuli_wdr.cpp:2660
 msgid "Support Protocol Obfuscation"
 msgstr "프로토콜 난독화 지원"
 
-#: src/muuli_wdr.cpp:2655
+#: src/muuli_wdr.cpp:2662
 msgid "This option enabled Protocol Obfuscation, and makes aMule accept obfuscated connections from other clients."
 msgstr "이 선택은 프로토콜 난독화를 활성화하며, 어뮬이 다른 클라이언트로부터 난독화된 연결을 받아들이도록 합니다. "
 
-#: src/muuli_wdr.cpp:2657
+#: src/muuli_wdr.cpp:2664
 msgid "Use obfuscation for outgoing connections"
 msgstr "나가는 연결에 난독화 사용"
 
-#: src/muuli_wdr.cpp:2659
+#: src/muuli_wdr.cpp:2666
 msgid "This option makes aMule use Protocol Obfuscation when connecting other clients/servers."
 msgstr "이 선택은 어뮬이 다른 서버나 클라이언트에 연결할때 프로토콜 난독화를 사용하게 합니다."
 
-#: src/muuli_wdr.cpp:2661
+#: src/muuli_wdr.cpp:2668
 msgid "Accept only obfuscated connections"
 msgstr "난독화된 연결만 받음"
 
-#: src/muuli_wdr.cpp:2662
+#: src/muuli_wdr.cpp:2669
 msgid "This option makes aMule only accept obfuscated connections. You will have less sources, but all your traffic will be obfuscated"
 msgstr "이 선택은 어뮬이 난독화된 연결만 받아들이도록 합니다. 더 작은 자료를 가지지만 자료교환은 난독화됩니다."
 
-#: src/muuli_wdr.cpp:2667
+#: src/muuli_wdr.cpp:2674
 msgid "Everybody"
 msgstr "모두"
 
-#: src/muuli_wdr.cpp:2669
+#: src/muuli_wdr.cpp:2676
 msgid "No one"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2671
+#: src/muuli_wdr.cpp:2678
 msgid "Who can see my shared files:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2672
+#: src/muuli_wdr.cpp:2679
 msgid "Select who can request to view a list of your shared files."
 msgstr "공유 파일 목록 보기를 요청할 수 있는 사람을 선택하세요."
 
-#: src/muuli_wdr.cpp:2674
+#: src/muuli_wdr.cpp:2681
 msgid "IP-Filtering"
 msgstr "IP 차단"
 
-#: src/muuli_wdr.cpp:2681
+#: src/muuli_wdr.cpp:2688
 msgid "Filter clients"
 msgstr "클라이언트 차단"
 
-#: src/muuli_wdr.cpp:2683
+#: src/muuli_wdr.cpp:2690
 msgid "Enable filtering of the client IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "~/.aMule/ipfilter.dat에 기록된 클라이언트 IP의 차단을 활성화합니다."
 
-#: src/muuli_wdr.cpp:2685
+#: src/muuli_wdr.cpp:2692
 msgid "Filter servers"
 msgstr "서버 차단"
 
-#: src/muuli_wdr.cpp:2687
+#: src/muuli_wdr.cpp:2694
 msgid "Enable filtering of the server IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "~/.aMule/ipfilter.dat에 기록된 서버 IP의 차단을 활성화합니다."
 
-#: src/muuli_wdr.cpp:2691
+#: src/muuli_wdr.cpp:2698
 msgid "Reload List"
 msgstr "목록 다시읽기"
 
-#: src/muuli_wdr.cpp:2692
+#: src/muuli_wdr.cpp:2699
 msgid "Reload the list of IPs to filter from the file ~/.aMule/ipfilter.dat"
 msgstr "~/.aMule/ipfilter.dat 파일에서 차단할 IP의 목록을 다시 읽음"
 
-#: src/muuli_wdr.cpp:2698
+#: src/muuli_wdr.cpp:2705
 msgid "URL:"
 msgstr "URL:"
 
-#: src/muuli_wdr.cpp:2702 src/muuli_wdr.cpp:2895
+#: src/muuli_wdr.cpp:2709 src/muuli_wdr.cpp:2902
 msgid "Update now"
 msgstr "지금 갱신"
 
-#: src/muuli_wdr.cpp:2705
+#: src/muuli_wdr.cpp:2712
 msgid "Auto-update ipfilter at startup"
 msgstr "시작시 IP차단을 자동 갱신"
 
-#: src/muuli_wdr.cpp:2709
+#: src/muuli_wdr.cpp:2716
 msgid "Filtering Level:"
 msgstr "차단 수준:"
 
-#: src/muuli_wdr.cpp:2715
+#: src/muuli_wdr.cpp:2722
 msgid "Always filter LAN IPs"
 msgstr "랜 IP를 항상 차단"
 
-#: src/muuli_wdr.cpp:2718
+#: src/muuli_wdr.cpp:2725
 msgid "Paranoid handling of non-matching IPs"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2720
+#: src/muuli_wdr.cpp:2727
 msgid "Rejects a packet when its source IP differs from the IP the client claims (an anti-spoofing check). Disable only if it causes connection problems."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2722
+#: src/muuli_wdr.cpp:2729
 msgid "Use system-wide ipfilter.dat if available"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2723
+#: src/muuli_wdr.cpp:2730
 msgid "If there's no local ipfilter.dat found, allow usage of a system-wide ipfilter file."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2740
+#: src/muuli_wdr.cpp:2747
 msgid "Enable Online-Signature"
 msgstr "온라인서명을 활성화"
 
-#: src/muuli_wdr.cpp:2742
+#: src/muuli_wdr.cpp:2749
 msgid "Enables the writing of the OS file, which can be used by external apps to create signatures and the like."
 msgstr "서명을 생성할 수 있는 외부 응용프로그램에 의해 사용될 수 있는 운영체제 파일의 기록을 활성화합니다."
 
-#: src/muuli_wdr.cpp:2746
+#: src/muuli_wdr.cpp:2753
 msgid "Update Frequency (Secs):"
 msgstr "갱신 주기(초)"
 
-#: src/muuli_wdr.cpp:2749
+#: src/muuli_wdr.cpp:2756
 msgid "Change the frequency (in seconds) of Online Signature updates."
 msgstr "온라인 서명 갱신 주기(초)를 바꿉니다."
 
-#: src/muuli_wdr.cpp:2757
+#: src/muuli_wdr.cpp:2764
 msgid "Save online signature file in: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:2763
+#: src/muuli_wdr.cpp:2770
 msgid "Click here to select the directory containing the the Online Signature files."
 msgstr "온라인서명 파일을 포함하는 폴더를 선택하려면 클릭하세요."
 
-#: src/muuli_wdr.cpp:2796
+#: src/muuli_wdr.cpp:2803
 msgid "Show country flags for clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2797
+#: src/muuli_wdr.cpp:2804
 msgid "Render the country flag column in the transfers, queue and search views. Requires a valid MMDB GeoIP database (see below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2802
+#: src/muuli_wdr.cpp:2809
 #, fuzzy
 msgid "Database"
 msgstr "데이터율 :"
 
-#: src/muuli_wdr.cpp:2818
+#: src/muuli_wdr.cpp:2825
 #, fuzzy
 msgid "Source:"
 msgstr "자료"
 
-#: src/muuli_wdr.cpp:2821
+#: src/muuli_wdr.cpp:2828
 msgid "DB-IP (free, no account)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2822
+#: src/muuli_wdr.cpp:2829
 msgid "MaxMind GeoLite2 (free, account required)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2823
+#: src/muuli_wdr.cpp:2830
 msgid "Custom URL"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2826
+#: src/muuli_wdr.cpp:2833
 msgid "Choose which provider supplies the GeoIP MMDB database. DB-IP is the default - no account required. MaxMind requires a free account + license key. Use Custom URL to point at any other MMDB host (e.g. a local mirror)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2843
+#: src/muuli_wdr.cpp:2850
 msgid ""
 "No configuration required.\n"
 "\n"
@@ -4860,11 +4874,11 @@ msgid ""
 "License: Creative Commons BY 4.0 - https://creativecommons.org/licenses/by/4.0/"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2856
+#: src/muuli_wdr.cpp:2863
 msgid "License key:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2862
+#: src/muuli_wdr.cpp:2869
 msgid ""
 "Sign up for a free MaxMind account, then generate a License Key:\n"
 "https://www.maxmind.com/en/geolite2/signup\n"
@@ -4874,232 +4888,232 @@ msgid ""
 "Requires attribution and account registration; refresh at least every 30 days."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2877
+#: src/muuli_wdr.cpp:2884
 #, fuzzy
 msgid "Download URL:"
 msgstr "내려받기: "
 
-#: src/muuli_wdr.cpp:2883
+#: src/muuli_wdr.cpp:2890
 msgid ""
 "Must point to an .mmdb file or a .gz / .tar.gz containing one.\n"
 "URL may include credentials (https://user:pass@host/...).\n"
 "License and attribution terms are set by the upstream URL - you are responsible."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2896
+#: src/muuli_wdr.cpp:2903
 msgid "Download the GeoIP database from the selected source."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2898
+#: src/muuli_wdr.cpp:2905
 #, fuzzy
 msgid "Auto-update on startup"
 msgstr "시작시 IP차단을 자동 갱신"
 
-#: src/muuli_wdr.cpp:2899
+#: src/muuli_wdr.cpp:2906
 msgid "Re-download the GeoIP database from the selected source every time aMule starts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2922
+#: src/muuli_wdr.cpp:2929
 msgid "Filter incoming messages (except current chat):"
 msgstr "받는 메시지 차단(현재 채팅은 제외)"
 
-#: src/muuli_wdr.cpp:2924
+#: src/muuli_wdr.cpp:2931
 msgid "Filter all messages"
 msgstr "모든 메시지를 차단"
 
-#: src/muuli_wdr.cpp:2926
+#: src/muuli_wdr.cpp:2933
 msgid "Filter messages from people not on your friend list"
 msgstr "친구 목록에 없는 사람으로부터 메시지를 차단"
 
-#: src/muuli_wdr.cpp:2928
+#: src/muuli_wdr.cpp:2935
 msgid "Filter messages from unknown clients"
 msgstr "알 수 없는 클라이언트로부터 메시지를 차단"
 
-#: src/muuli_wdr.cpp:2930
+#: src/muuli_wdr.cpp:2937
 msgid "Filter messages containing (use ',' as separator):"
 msgstr "다음 내용이 포함된 메시지를 차단 (쉼표로 분리):"
 
-#: src/muuli_wdr.cpp:2933 src/muuli_wdr.cpp:2944
+#: src/muuli_wdr.cpp:2940 src/muuli_wdr.cpp:2951
 msgid "add here the words amule should filter and block messages including it"
 msgstr "이곳에 어뮬이 차단하고 막을 메시지에 포함될 단어를 추가하세요."
 
-#: src/muuli_wdr.cpp:2935
+#: src/muuli_wdr.cpp:2942
 msgid "Show received messages in the log"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2938
+#: src/muuli_wdr.cpp:2945
 msgid "Comments"
 msgstr "의견들"
 
-#: src/muuli_wdr.cpp:2941
+#: src/muuli_wdr.cpp:2948
 msgid "Filter comments containing (use ',' as separator):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2966
+#: src/muuli_wdr.cpp:2973
 msgid "Enable Proxy"
 msgstr "프록시 활성화"
 
-#: src/muuli_wdr.cpp:2967
+#: src/muuli_wdr.cpp:2974
 msgid "Enable/disable proxy support"
 msgstr "프록시지원을 활성화/비활성화"
 
-#: src/muuli_wdr.cpp:2970
+#: src/muuli_wdr.cpp:2977
 msgid "Proxy type:"
 msgstr "프록시 종류:"
 
-#: src/muuli_wdr.cpp:2981
+#: src/muuli_wdr.cpp:2988
 msgid "Proxy host:"
 msgstr "프록시 호스트:"
 
-#: src/muuli_wdr.cpp:2984
+#: src/muuli_wdr.cpp:2991
 msgid "The proxy host name"
 msgstr "프록시 호스트 이름"
 
-#: src/muuli_wdr.cpp:2986
+#: src/muuli_wdr.cpp:2993
 msgid "Proxy port:"
 msgstr "프록시 포트:"
 
-#: src/muuli_wdr.cpp:2989
+#: src/muuli_wdr.cpp:2996
 msgid "The proxy port"
 msgstr "프록시 포트"
 
-#: src/muuli_wdr.cpp:2991
+#: src/muuli_wdr.cpp:2998
 msgid "Enable authentication"
 msgstr "인증 활성화"
 
-#: src/muuli_wdr.cpp:2992
+#: src/muuli_wdr.cpp:2999
 msgid "Enable/disable username/password authentication"
 msgstr "사용자이름/암호 인증을 활성화/비활성화"
 
-#: src/muuli_wdr.cpp:2995
+#: src/muuli_wdr.cpp:3002
 msgid "Username: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:2998
+#: src/muuli_wdr.cpp:3005
 msgid "The username to use to connect to the proxy"
 msgstr "프록시에 접속하기 위한 사용자이름"
 
-#: src/muuli_wdr.cpp:3000
+#: src/muuli_wdr.cpp:3007
 msgid "Password:"
 msgstr "암호:"
 
-#: src/muuli_wdr.cpp:3003
+#: src/muuli_wdr.cpp:3010
 msgid "The password to use to connect to the proxy"
 msgstr "프록시에 접속하기 위한 암호"
 
-#: src/muuli_wdr.cpp:3022
+#: src/muuli_wdr.cpp:3029
 msgid "Connect to:"
 msgstr "연결함:"
 
-#: src/muuli_wdr.cpp:3031
+#: src/muuli_wdr.cpp:3038
 msgid "Login to remote amule"
 msgstr "원격 어뮬에 로그인"
 
-#: src/muuli_wdr.cpp:3036
+#: src/muuli_wdr.cpp:3043
 msgid "User name"
 msgstr "사용자이름"
 
-#: src/muuli_wdr.cpp:3047
+#: src/muuli_wdr.cpp:3054
 msgid "Remember those settings"
 msgstr "설정을 기억"
 
-#: src/muuli_wdr.cpp:3050
+#: src/muuli_wdr.cpp:3057
 #, fuzzy
 msgid "Force ZLIB compression"
 msgstr "gzip 압축 사용"
 
-#: src/muuli_wdr.cpp:3074
+#: src/muuli_wdr.cpp:3081
 msgid "Enable Verbose Debug-Logging."
 msgstr "상세한 디버그-로깅 활성화"
 
-#: src/muuli_wdr.cpp:3076
+#: src/muuli_wdr.cpp:3083
 #, fuzzy
 msgid "Only to Logfile"
 msgstr "파일 열기(&O)"
 
-#: src/muuli_wdr.cpp:3078
+#: src/muuli_wdr.cpp:3085
 msgid "Message Categories:"
 msgstr "메시지 분류:"
 
-#: src/muuli_wdr.cpp:3102 src/PartFileConvertDlg.cpp:160
+#: src/muuli_wdr.cpp:3109 src/PartFileConvertDlg.cpp:160
 msgid "Waiting..."
 msgstr "대기중..."
 
-#: src/muuli_wdr.cpp:3122
+#: src/muuli_wdr.cpp:3129
 msgid "Add imports"
 msgstr "가져오기 추가"
 
-#: src/muuli_wdr.cpp:3125
+#: src/muuli_wdr.cpp:3132
 msgid "Retry selected"
 msgstr "선택된 것을 재시도"
 
-#: src/muuli_wdr.cpp:3127
+#: src/muuli_wdr.cpp:3134
 msgid "Remove selected"
 msgstr "선택된 것을 삭제"
 
-#: src/muuli_wdr.cpp:3190
+#: src/muuli_wdr.cpp:3197
 msgid "Event Types"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3209
+#: src/muuli_wdr.cpp:3216
 msgid "Statistics and queued clients for selected file(s) : Session / All time"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3233
+#: src/muuli_wdr.cpp:3240
 #, fuzzy
 msgid "Active Uploads"
 msgstr "활성화된 올려주기 :"
 
-#: src/muuli_wdr.cpp:3247
+#: src/muuli_wdr.cpp:3254
 msgid "Percent of total files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3299
+#: src/muuli_wdr.cpp:3306
 #, fuzzy
 msgid "Show Clients for"
 msgstr "클라이언트 보기"
 
-#: src/muuli_wdr.cpp:3301
+#: src/muuli_wdr.cpp:3308
 #, fuzzy
 msgid "All files"
 msgstr "공유된 파일을 숨김"
 
-#: src/muuli_wdr.cpp:3304
+#: src/muuli_wdr.cpp:3311
 #, fuzzy
 msgid "Selected files"
 msgstr "보기 필터 선택"
 
-#: src/muuli_wdr.cpp:3307
+#: src/muuli_wdr.cpp:3314
 #, fuzzy
 msgid "Active uploads only"
 msgstr "활성화된 올려주기"
 
-#: src/muuli_wdr.cpp:3314
+#: src/muuli_wdr.cpp:3321
 #, fuzzy
 msgid "Reload:"
 msgstr "목록 다시읽기"
 
-#: src/muuli_wdr.cpp:3318
+#: src/muuli_wdr.cpp:3325
 msgid "Reload your shared files"
 msgstr "공유된 파일을 다시 읽어들임"
 
-#: src/muuli_wdr.cpp:3381
+#: src/muuli_wdr.cpp:3388
 msgid "Send"
 msgstr "보내기"
 
-#: src/muuli_wdr.cpp:3382
+#: src/muuli_wdr.cpp:3389
 msgid "Sends the specified message."
 msgstr "지정된 메시지를 보냅니다."
 
-#: src/muuli_wdr.cpp:3386
+#: src/muuli_wdr.cpp:3393
 msgid "Close this chat-session."
 msgstr "이 채팅세션을 닫습니다."
 
-#: src/muuli_wdr.cpp:3409
+#: src/muuli_wdr.cpp:3416
 msgid "Connect to any server and/or Kad"
 msgstr "서버 혹은 Kad에 연결"
 
-#: src/muuli_wdr.cpp:3415 src/SharedFilesCtrl.cpp:142 src/Statistics.cpp:941
+#: src/muuli_wdr.cpp:3422 src/SharedFilesCtrl.cpp:142 src/Statistics.cpp:941
 msgid "Shared Files"
 msgstr "공유 파일"
 
@@ -5462,192 +5476,192 @@ msgstr ""
 msgid "ERROR: Failed to open partfile '%s'"
 msgstr ""
 
-#: src/Preferences.cpp:673
+#: src/Preferences.cpp:674
 msgid "System default"
 msgstr "기본 설정"
 
-#: src/Preferences.cpp:674
+#: src/Preferences.cpp:675
 msgid "Albanian"
 msgstr ""
 
-#: src/Preferences.cpp:675
+#: src/Preferences.cpp:676
 msgid "Arabic"
 msgstr "아랍어"
 
-#: src/Preferences.cpp:676
+#: src/Preferences.cpp:677
 #, fuzzy
 msgid "Asturian"
 msgstr "에스토니아어"
 
-#: src/Preferences.cpp:677
+#: src/Preferences.cpp:678
 msgid "Basque"
 msgstr "바스크어"
 
-#: src/Preferences.cpp:678
+#: src/Preferences.cpp:679
 msgid "Bulgarian"
 msgstr "불가리아어"
 
-#: src/Preferences.cpp:679
+#: src/Preferences.cpp:680
 msgid "Catalan"
 msgstr "카탈로니아어"
 
-#: src/Preferences.cpp:680
+#: src/Preferences.cpp:681
 msgid "Chinese (Simplified)"
 msgstr "중국어(간체)"
 
-#: src/Preferences.cpp:681
+#: src/Preferences.cpp:682
 msgid "Chinese (Traditional)"
 msgstr "중국어(번체)"
 
-#: src/Preferences.cpp:682
+#: src/Preferences.cpp:683
 msgid "Croatian"
 msgstr "크로티아어"
 
-#: src/Preferences.cpp:683
+#: src/Preferences.cpp:684
 msgid "Czech"
 msgstr ""
 
-#: src/Preferences.cpp:684
+#: src/Preferences.cpp:685
 msgid "Danish"
 msgstr "덴마크어"
 
-#: src/Preferences.cpp:685
+#: src/Preferences.cpp:686
 msgid "Dutch"
 msgstr "네델란드어"
 
-#: src/Preferences.cpp:686
+#: src/Preferences.cpp:687
 msgid "English (U.K.)"
 msgstr "영어(영국)"
 
-#: src/Preferences.cpp:687
+#: src/Preferences.cpp:688
 #, fuzzy
 msgid "English (U.S.)"
 msgstr "영어(영국)"
 
-#: src/Preferences.cpp:688
+#: src/Preferences.cpp:689
 msgid "Estonian"
 msgstr "에스토니아어"
 
-#: src/Preferences.cpp:689
+#: src/Preferences.cpp:690
 msgid "Finnish"
 msgstr "필란드어"
 
-#: src/Preferences.cpp:690
+#: src/Preferences.cpp:691
 msgid "French"
 msgstr "프랑스어"
 
-#: src/Preferences.cpp:691
+#: src/Preferences.cpp:692
 msgid "Galician"
 msgstr "갈리시아어"
 
-#: src/Preferences.cpp:692
+#: src/Preferences.cpp:693
 msgid "German"
 msgstr "독일어"
 
-#: src/Preferences.cpp:693
+#: src/Preferences.cpp:694
 msgid "Greek"
 msgstr ""
 
-#: src/Preferences.cpp:694
+#: src/Preferences.cpp:695
 msgid "Hebrew"
 msgstr ""
 
-#: src/Preferences.cpp:695
+#: src/Preferences.cpp:696
 msgid "Hungarian"
 msgstr "헝가리어"
 
-#: src/Preferences.cpp:696
+#: src/Preferences.cpp:697
 msgid "Italian"
 msgstr "이탈리아어"
 
-#: src/Preferences.cpp:697
+#: src/Preferences.cpp:698
 msgid "Japanese"
 msgstr ""
 
-#: src/Preferences.cpp:698
+#: src/Preferences.cpp:699
 msgid "Korean"
 msgstr "한국어"
 
-#: src/Preferences.cpp:699
+#: src/Preferences.cpp:700
 msgid "Latvian"
 msgstr ""
 
-#: src/Preferences.cpp:700
+#: src/Preferences.cpp:701
 msgid "Lithuanian"
 msgstr ""
 
-#: src/Preferences.cpp:701
+#: src/Preferences.cpp:702
 msgid "Norwegian (Nynorsk)"
 msgstr ""
 
-#: src/Preferences.cpp:702
+#: src/Preferences.cpp:703
 msgid "Polish"
 msgstr "폴란드어"
 
-#: src/Preferences.cpp:703
+#: src/Preferences.cpp:704
 msgid "Portuguese"
 msgstr "포르투갈어"
 
-#: src/Preferences.cpp:704
+#: src/Preferences.cpp:705
 msgid "Portuguese (Brazilian)"
 msgstr "포르투갈어(브라질)"
 
-#: src/Preferences.cpp:705
+#: src/Preferences.cpp:706
 #, fuzzy
 msgid "Romanian"
 msgstr "크로티아어"
 
-#: src/Preferences.cpp:706
+#: src/Preferences.cpp:707
 msgid "Russian"
 msgstr "러시아어"
 
-#: src/Preferences.cpp:707
+#: src/Preferences.cpp:708
 msgid "Slovenian"
 msgstr "슬로베니아어"
 
-#: src/Preferences.cpp:708
+#: src/Preferences.cpp:709
 msgid "Spanish"
 msgstr "스페인어"
 
-#: src/Preferences.cpp:709
+#: src/Preferences.cpp:710
 msgid "Swedish"
 msgstr ""
 
-#: src/Preferences.cpp:710
+#: src/Preferences.cpp:711
 msgid "Turkish"
 msgstr "터키어"
 
-#: src/Preferences.cpp:711
+#: src/Preferences.cpp:712
 msgid "Ukrainian"
 msgstr ""
 
-#: src/Preferences.cpp:814
+#: src/Preferences.cpp:815
 #, fuzzy
 msgid "Change Language"
 msgstr "언어"
 
-#: src/Preferences.cpp:878
+#: src/Preferences.cpp:879
 msgid "There are no translations installed for aMule"
 msgstr ""
 
-#: src/Preferences.cpp:879
+#: src/Preferences.cpp:880
 #, fuzzy
 msgid "No languages available"
 msgstr "유효하지 않음"
 
-#: src/Preferences.cpp:1010
+#: src/Preferences.cpp:1011
 msgid "no options available"
 msgstr ""
 
-#: src/Preferences.cpp:2179
+#: src/Preferences.cpp:2182
 msgid "Invalid category found, skipping"
 msgstr ""
 
-#: src/Preferences.cpp:2348
+#: src/Preferences.cpp:2351
 msgid "TCP port can't be higher than 65532 due to server UDP socket being TCP+3"
 msgstr "서버 UDP 소켓이 TCP+3이 되기위해서 TCP 포트가 65532보다 커서는 안됩니다."
 
-#: src/Preferences.cpp:2349
+#: src/Preferences.cpp:2352
 #, c-format
 msgid "Default port will be used (%d)"
 msgstr "기본 포트가 사용될 것입니다.(%d)"
@@ -6156,24 +6170,28 @@ msgstr "공유된 파일 목록을 다시 읽어들입니다."
 msgid "Shared folder"
 msgstr "공유 파일"
 
-#: src/SearchDlg.cpp:425
+#: src/SearchDlg.cpp:280
+msgid "Clear search history"
+msgstr ""
+
+#: src/SearchDlg.cpp:584
 msgid "It's impossible to search when both eD2k and Kademlia are disabled."
 msgstr ""
 
-#: src/SearchDlg.cpp:426 src/SearchListCtrl.cpp:858
+#: src/SearchDlg.cpp:585 src/SearchListCtrl.cpp:858
 #, fuzzy
 msgid "Search error"
 msgstr "검색"
 
-#: src/SearchDlg.cpp:768
+#: src/SearchDlg.cpp:929
 msgid "Min size must be smaller than max size. Max size ignored."
 msgstr "최소 크기가 최대 크기보다 작아야 합니다. 최대 크기는 무시됩니다.."
 
-#: src/SearchDlg.cpp:769 src/SearchDlg.cpp:851
+#: src/SearchDlg.cpp:930 src/SearchDlg.cpp:1012
 msgid "Search warning"
 msgstr "검색 경고"
 
-#: src/SearchDlg.cpp:929 src/SearchListCtrl.cpp:735
+#: src/SearchDlg.cpp:1092 src/SearchListCtrl.cpp:735
 msgid "Main"
 msgstr "주"
 

--- a/po/ko_KR.po
+++ b/po/ko_KR.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-28 10:19+0200\n"
+"POT-Creation-Date: 2026-07-28 12:17+0200\n"
 "PO-Revision-Date: 2026-07-27 11:41+0000\n"
 "Last-Translator: Hyunju Kang <rexington@gmail.com>\n"
 "Language-Team: Korean <hoenny@daum.net>\n"
@@ -199,159 +199,159 @@ msgstr "%s(%s)을 열지 못했습니다."
 msgid "WARNING: You can't add yourself as a source for an eD2k link while having a lowid."
 msgstr ""
 
-#: src/amule.cpp:300
+#: src/amule.cpp:301
 #, fuzzy
 msgid "Now, exiting main app..."
 msgstr ""
 "\n"
 "좋아, 나가는중 %s...\n"
 
-#: src/amule.cpp:330
+#: src/amule.cpp:331
 #, c-format
 msgid "Terminating amuleweb instance with pid '%d' ... "
 msgstr ""
 
-#: src/amule.cpp:334
+#: src/amule.cpp:335
 #, c-format
 msgid "Killing amuleweb instance with pid '%d' ... "
 msgstr ""
 
-#: src/amule.cpp:336 src/amule.cpp:349 src/ClientRef.cpp:180
+#: src/amule.cpp:337 src/amule.cpp:350 src/ClientRef.cpp:180
 #: src/SearchDlg.cpp:1041 src/ServerListCtrl.cpp:98
 msgid "Failed"
 msgstr "실패"
 
-#: src/amule.cpp:343
+#: src/amule.cpp:344
 #, c-format
 msgid "Terminating amuleapi instance with pid '%d' ... "
 msgstr ""
 
-#: src/amule.cpp:347
+#: src/amule.cpp:348
 #, c-format
 msgid "Killing amuleapi instance with pid '%d' ... "
 msgstr ""
 
-#: src/amule.cpp:355
+#: src/amule.cpp:356
 msgid "aMule OnExit: Terminating core."
 msgstr ""
 
-#: src/amule.cpp:466
+#: src/amule.cpp:467
 msgid "aMule shutdown completed."
 msgstr ""
 
-#: src/amule.cpp:470
+#: src/amule.cpp:471
 msgid "Memory debug results for aMule exit:"
 msgstr ""
 
-#: src/amule.cpp:651
+#: src/amule.cpp:652
 #, c-format
 msgid "Binding aMule's peer-to-peer traffic to interface: %s (HTTP updates use the default route)"
 msgstr ""
 
-#: src/amule.cpp:655
+#: src/amule.cpp:656
 #, c-format
 msgid "Binding all network traffic to interface: %s"
 msgstr ""
 
-#: src/amule.cpp:659
+#: src/amule.cpp:660
 #, c-format
 msgid "WARNING: configured network interface '%s' was not found - traffic is NOT bound to it and may leave via the default route. Check the interface name in Preferences."
 msgstr ""
 
-#: src/amule.cpp:665
+#: src/amule.cpp:666
 #, c-format
 msgid "WARNING: binding to network interface '%s' requires elevated privileges and was NOT applied - traffic may leave via the default route. Grant the capability (e.g. 'sudo setcap cap_net_raw+ep' on the aMule binary) or run with sufficient privileges."
 msgstr ""
 
-#: src/amule.cpp:673
+#: src/amule.cpp:674
 #, c-format
 msgid "WARNING: could not bind to network interface '%s' - traffic may leave via the default route."
 msgstr ""
 
-#: src/amule.cpp:732
+#: src/amule.cpp:733
 msgid "Your locale has been changed to System Default due to a configuration change. Sorry."
 msgstr "지역정보(로케일)가 설정 변경으로 인해 시스템 기본값으로 변경되었습니다. 죄송합니다."
 
-#: src/amule.cpp:734 src/amule.cpp:1581 src/CatDialog.cpp:128
+#: src/amule.cpp:735 src/amule.cpp:1589 src/CatDialog.cpp:128
 #: src/CatDialog.cpp:136 src/CatDialog.cpp:149 src/ServerList.cpp:366
 #: src/ServerListCtrl.cpp:152
 msgid "Info"
 msgstr "정보"
 
-#: src/amule.cpp:741
+#: src/amule.cpp:742
 #, fuzzy
 msgid ""
 "\n"
 "EC configuration"
 msgstr "종료 확인"
 
-#: src/amule.cpp:744
+#: src/amule.cpp:745
 #, fuzzy
 msgid "Password set and external connections enabled."
 msgstr "새로운 외부연결이 승인되었습니다."
 
-#: src/amule.cpp:754 src/KadDlg.cpp:176 src/KadDlg.cpp:185
-#: src/PrefsUnifiedDlg.cpp:1387 src/SharedFilesCtrl.cpp:476
+#: src/amule.cpp:755 src/KadDlg.cpp:176 src/KadDlg.cpp:185
+#: src/PrefsUnifiedDlg.cpp:1461 src/SharedFilesCtrl.cpp:476
 msgid "WARNING"
 msgstr "경고"
 
-#: src/amule.cpp:991
+#: src/amule.cpp:992
 #, fuzzy
 msgid "Network bootstrap"
 msgstr "통신망"
 
-#: src/amule.cpp:996
+#: src/amule.cpp:997
 msgid ""
 "aMule has detected missing network bootstrap files.\n"
 "Select which ones to download:"
 msgstr ""
 
-#: src/amule.cpp:1005 src/FirstRunWizard.cpp:411
+#: src/amule.cpp:1006 src/FirstRunWizard.cpp:411
 #, fuzzy
 msgid "eD2k server list (server.met)"
 msgstr "server.met에서 %i개의 서버가 발견됨"
 
-#: src/amule.cpp:1012 src/FirstRunWizard.cpp:416
+#: src/amule.cpp:1013 src/FirstRunWizard.cpp:416
 msgid "Kad bootstrap nodes (nodes.dat)"
 msgstr ""
 
-#: src/amule.cpp:1102
+#: src/amule.cpp:1103
 #, c-format
 msgid "web server running on pid %d"
 msgstr ""
 
-#: src/amule.cpp:1115
+#: src/amule.cpp:1116
 msgid "You requested to run web server on startup, but the amuleweb binary cannot be run. Please install the package containing aMule web server, or build aMule from source with -DBUILD_WEBSERVER=YES and install it."
 msgstr ""
 
-#: src/amule.cpp:1120 src/amule.cpp:1177 src/amule.cpp:1291 src/amule.cpp:1593
+#: src/amule.cpp:1121 src/amule.cpp:1185 src/amule.cpp:1299 src/amule.cpp:1601
 #: src/amule-remote-gui.cpp:603 src/amule-remote-gui.cpp:671
 #: src/amule-remote-gui.cpp:709 src/amule-remote-gui.cpp:1282
 #: src/amule-remote-gui.cpp:1345 src/amule-remote-gui.cpp:1372
-#: src/DownloadQueue.cpp:1481
+#: src/DownloadQueue.cpp:1481 src/PrefsUnifiedDlg.cpp:1247
 msgid "ERROR"
 msgstr ""
 
-#: src/amule.cpp:1166
+#: src/amule.cpp:1174
 #, fuzzy, c-format
 msgid "amuleapi running on pid %d"
 msgstr "어뮬은 실행중입니다."
 
-#: src/amule.cpp:1172
+#: src/amule.cpp:1180
 msgid "You requested to run amuleapi on startup, but the amuleapi binary cannot be run. Please install the package containing aMule's REST API server, or build aMule from source with -DBUILD_AMULEAPI=YES and install it."
 msgstr ""
 
-#: src/amule.cpp:1259
+#: src/amule.cpp:1267
 #, c-format
 msgid "Could not bind ports to the specified address: %s"
 msgstr ""
 
-#: src/amule.cpp:1283
+#: src/amule.cpp:1291
 #, c-format
 msgid "Port %u is not available. You will be LOWID\n"
 msgstr "포트 %u는 사용할 수 없습니다. 낮은아이디를 가질것입니다.\n"
 
-#: src/amule.cpp:1288
+#: src/amule.cpp:1296
 #, c-format
 msgid ""
 "Port %u is not available!\n"
@@ -366,48 +366,48 @@ msgstr ""
 "\n"
 "나가고 들어오는것에 대해 포트가 열려있는지 통신망을 체크하세요. "
 
-#: src/amule.cpp:1385
+#: src/amule.cpp:1393
 msgid "Failed to create OnlineSig File"
 msgstr "온라인서명 파일을 생성하지 못함"
 
-#: src/amule.cpp:1393
+#: src/amule.cpp:1401
 msgid "Failed to create aMule OnlineSig File"
 msgstr "어뮬 온라인서명 파일을 생성하지 못함"
 
-#: src/amule.cpp:1556
+#: src/amule.cpp:1564
 msgid "The selected locale seems not to be installed on your box. (Note: I'll try to set it anyway)"
 msgstr "컴퓨터에 선택한 지역정보(로케일)가 설치 않된것 같습니다. (주의: 어쨌든 설정하겠습니다)"
 
-#: src/amule.cpp:1566
+#: src/amule.cpp:1574
 #, c-format
 msgid "This is the first time you run aMule %s"
 msgstr "이번에 어뮬 %s를 처음 실행했습니다."
 
-#: src/amule.cpp:1569
+#: src/amule.cpp:1577
 msgid "This version is a testing version, updated daily, and\n"
 msgstr "이 버전은 테스트 버젼으로, 매일 업데이트되며, \n"
 
-#: src/amule.cpp:1570
+#: src/amule.cpp:1578
 msgid "we give no warranty it won't break anything, burn your house,\n"
 msgstr "이 프로그램이 어느 것도 부수지 않는다고, 집을 태우지 않는다고, 혹은 \n"
 
-#: src/amule.cpp:1571
+#: src/amule.cpp:1579
 msgid "or kill your dog. But it *should* be safe to use anyway.\n"
 msgstr "개를 죽이지 않는다고 보장하지 않습니다. 그렇지만 안전하게 사용할 수 있을 것입니다.\n"
 
-#: src/amule.cpp:1576
+#: src/amule.cpp:1584
 msgid "More information, support and new releases can found at our homepage,\n"
 msgstr "더 많은 정보, 지원, 새 릴리즈는 홈페이지 amule-org.github.io, 또는 IRC 채널\n"
 
-#: src/amule.cpp:1577
+#: src/amule.cpp:1585
 msgid "at https://amule-org.github.io, or in our IRC channel #aMule at irc.libera.chat.\n"
 msgstr "(irc.libera.chat의 #aMule)에서 찾을 수 있습니다.\n"
 
-#: src/amule.cpp:1579
+#: src/amule.cpp:1587
 msgid "Feel free to report any bugs to https://github.com/amule-org/amule/issues"
 msgstr "버그는 https://github.com/amule-org/amule/issues로 보고해 주십시오."
 
-#: src/amule.cpp:1591
+#: src/amule.cpp:1599
 msgid ""
 "The folder for Online Signature files you specified is INVALID!\n"
 " OnlineSignature will be DISABLED until you fix it on preferences."
@@ -415,138 +415,138 @@ msgstr ""
 "지정한 온라인 서명 파일을 위한 폴더가 유효하지 않습니다.\n"
 " 온라인 서명은 환경설정에서 수정될 때까지 비활성화 됩니다."
 
-#: src/amule.cpp:1654
+#: src/amule.cpp:1662
 #, fuzzy
 msgid "Server hostname notified"
 msgstr "서버 이름:"
 
-#: src/amule.cpp:2031
+#: src/amule.cpp:2039
 #, c-format
 msgid "Disk space preallocation for file '%s' failed: %s"
 msgstr ""
 
-#: src/amule.cpp:2160
+#: src/amule.cpp:2168
 msgid "ERROR: can't open logfile"
 msgstr "오류: 로그파일을 열 수 없음"
 
-#: src/amule.cpp:2164
+#: src/amule.cpp:2172
 msgid "WARNING: logfile is empty. Something is wrong."
 msgstr "경고: 로그파일이 비어있습니다. 뭔가 잘못되어 있습니다."
 
-#: src/amule.cpp:2181
+#: src/amule.cpp:2189
 msgid "Log has been reset"
 msgstr "로그가 초기화되었습니다."
 
-#: src/amule.cpp:2205
+#: src/amule.cpp:2213
 #, c-format
 msgid "ServerMessage: %s"
 msgstr "서버메시지: %s"
 
-#: src/amule.cpp:2248 src/IP2Country.cpp:220 src/IPFilter.cpp:514
+#: src/amule.cpp:2256 src/IP2Country.cpp:220 src/IPFilter.cpp:514
 #: src/ServerList.cpp:875
 #, c-format
 msgid "Skipped download of %s, because requested file is not newer."
 msgstr ""
 
-#: src/amule.cpp:2251
+#: src/amule.cpp:2259
 msgid "Failed to download the nodes list."
 msgstr "노드 목록을 내려받지 못했습니다."
 
-#: src/amule.cpp:2314
+#: src/amule.cpp:2322
 msgid "Failed to open the downloaded version check file"
 msgstr "내려받은 버젼 검사 파일을 열지 못했습니다."
 
-#: src/amule.cpp:2317 src/amule.cpp:2336
+#: src/amule.cpp:2325 src/amule.cpp:2344
 msgid "Corrupted version check file"
 msgstr "손상된 버젼 검사 파일"
 
-#: src/amule.cpp:2359
+#: src/amule.cpp:2367
 msgid "You are using an outdated version of aMule!"
 msgstr "오래된 어뮬 버젼을 사용하고 있습니다!"
 
-#: src/amule.cpp:2361
+#: src/amule.cpp:2369
 #, c-format
 msgid "Your aMule version is %i.%i.%i and the latest version is %li.%li.%li"
 msgstr "어뮬 버젼은 %i.%i.%i이며 최신 버젼은 %li.%li.%li입니다."
 
-#: src/amule.cpp:2365
+#: src/amule.cpp:2373
 msgid "The latest version can always be found at https://github.com/amule-org/amule/releases/latest"
 msgstr "최신 버젼은 항상 https://github.com/amule-org/amule/releases/latest 에서 찾을 수 있습니다."
 
-#: src/amule.cpp:2368
+#: src/amule.cpp:2376
 #, c-format
 msgid "WARNING: Your aMuled version is outdated: %i.%i.%i < %li.%li.%li"
 msgstr "경고: 어뮬 버젼은 오래되었습니다: %i.%i.%i < %li.%li.%li"
 
-#: src/amule.cpp:2374
+#: src/amule.cpp:2382
 msgid "Your copy of aMule is up to date."
 msgstr "어뮬은 최신 버전입니다."
 
-#: src/amule.cpp:2381
+#: src/amule.cpp:2389
 msgid "Failed to download the version check file"
 msgstr "버젼 검사 파일을 내려받지 못했습니다."
 
-#: src/amule.cpp:2550 src/amule-remote-gui.cpp:1133
+#: src/amule.cpp:2558 src/amule-remote-gui.cpp:1133
 #, c-format
 msgid "Users: %s | Files: %s"
 msgstr ""
 
-#: src/amule.cpp:2551 src/amule-remote-gui.cpp:1134
+#: src/amule.cpp:2559 src/amule-remote-gui.cpp:1134
 #, c-format
 msgid "Users: E: %s K: %s | Files: E: %s K: %s"
 msgstr ""
 
-#: src/amule.cpp:2565 src/amule-remote-gui.cpp:1147
+#: src/amule.cpp:2573 src/amule-remote-gui.cpp:1147
 msgid "No networks selected"
 msgstr ""
 
-#: src/amule.cpp:2633 src/TextClient.cpp:903
+#: src/amule.cpp:2641 src/TextClient.cpp:903
 msgid "with LowID"
 msgstr "낮은아이디로"
 
-#: src/amule.cpp:2633 src/TextClient.cpp:904
+#: src/amule.cpp:2641 src/TextClient.cpp:904
 msgid "with HighID"
 msgstr "높은아이디로"
 
-#: src/amule.cpp:2635
+#: src/amule.cpp:2643
 #, c-format
 msgid "Connected to %s %s"
 msgstr "%s %s에 연결되었음"
 
-#: src/amule.cpp:2640
+#: src/amule.cpp:2648
 #, c-format
 msgid "Connecting to %s"
 msgstr "%s에 연결중"
 
-#: src/amule.cpp:2642
+#: src/amule.cpp:2650
 msgid "Disconnected from eD2k"
 msgstr ""
 
-#: src/amule.cpp:2651
+#: src/amule.cpp:2659
 msgid "Kad started."
 msgstr "Kad를 시작했습니다."
 
-#: src/amule.cpp:2653
+#: src/amule.cpp:2661
 msgid "Kad stopped."
 msgstr "Kad를 멈췄습니다."
 
-#: src/amule.cpp:2661
+#: src/amule.cpp:2669
 msgid "Connected to Kad (ok)"
 msgstr "Kad에 연결됨 (양호)"
 
-#: src/amule.cpp:2663
+#: src/amule.cpp:2671
 msgid "Connected to Kad (firewalled)"
 msgstr "Kad에 연결됨 (방화벽)"
 
-#: src/amule.cpp:2667
+#: src/amule.cpp:2675
 msgid "Disconnected from Kad"
 msgstr "Kad로부터 연결이 끊김"
 
-#: src/amule.cpp:2699
+#: src/amule.cpp:2707
 msgid "Kad network cannot be used if UDP port is disabled on preferences, not starting."
 msgstr "Kad 네트워크는 UDP 포트가 비활성될 시 사용할 수 없으며, 따라서 시작하지 않습니다."
 
-#: src/amule.cpp:2703
+#: src/amule.cpp:2711
 msgid "Kad network disabled on preferences, not connecting."
 msgstr "Kad 네트워크가 환경설정에서 비활성되어, 연결하지 않습니다."
 
@@ -591,36 +591,36 @@ msgid "FATAL ERROR: Failed to create Timer"
 msgstr ""
 
 #: src/amuleDlg.cpp:361 src/amuleDlg.cpp:1787 src/amuleDlg.cpp:2033
-#: src/muuli_wdr.cpp:1492 src/muuli_wdr.cpp:3418
+#: src/muuli_wdr.cpp:1492 src/muuli_wdr.cpp:3449
 msgid "Networks"
 msgstr "통신망"
 
-#: src/amuleDlg.cpp:362 src/amuleDlg.cpp:1793 src/muuli_wdr.cpp:3419
+#: src/amuleDlg.cpp:362 src/amuleDlg.cpp:1793 src/muuli_wdr.cpp:3450
 msgid "Searches"
 msgstr "검색"
 
 #: src/amuleDlg.cpp:363 src/amuleDlg.cpp:1799 src/DownloadListCtrl.cpp:740
-#: src/muuli_wdr.cpp:392 src/muuli_wdr.cpp:1585 src/muuli_wdr.cpp:3420
+#: src/muuli_wdr.cpp:392 src/muuli_wdr.cpp:1585 src/muuli_wdr.cpp:3451
 #: src/Statistics.cpp:829
 msgid "Downloads"
 msgstr "내려받기"
 
-#: src/amuleDlg.cpp:364 src/amuleDlg.cpp:1805 src/muuli_wdr.cpp:3294
+#: src/amuleDlg.cpp:364 src/amuleDlg.cpp:1805 src/muuli_wdr.cpp:3325
 msgid "Shared files"
 msgstr ""
 
-#: src/amuleDlg.cpp:365 src/amuleDlg.cpp:1811 src/muuli_wdr.cpp:2926
-#: src/muuli_wdr.cpp:3376 src/muuli_wdr.cpp:3423
+#: src/amuleDlg.cpp:365 src/amuleDlg.cpp:1811 src/muuli_wdr.cpp:2957
+#: src/muuli_wdr.cpp:3407 src/muuli_wdr.cpp:3454
 msgid "Messages"
 msgstr "메시지"
 
-#: src/amuleDlg.cpp:366 src/amuleDlg.cpp:1817 src/muuli_wdr.cpp:3424
-#: src/PrefsUnifiedDlg.cpp:312 src/Statistics.cpp:779 src/Statistics.cpp:1235
+#: src/amuleDlg.cpp:366 src/amuleDlg.cpp:1817 src/muuli_wdr.cpp:3455
+#: src/PrefsUnifiedDlg.cpp:314 src/Statistics.cpp:779 src/Statistics.cpp:1235
 msgid "Statistics"
 msgstr "통계"
 
-#: src/amuleDlg.cpp:368 src/amuleDlg.cpp:1824 src/muuli_wdr.cpp:3426
-#: src/PrefsUnifiedDlg.cpp:328 src/utils/wxCas/src/wxcasprefs.cpp:39
+#: src/amuleDlg.cpp:368 src/amuleDlg.cpp:1824 src/muuli_wdr.cpp:3457
+#: src/PrefsUnifiedDlg.cpp:330 src/utils/wxCas/src/wxcasprefs.cpp:39
 msgid "Preferences"
 msgstr "환경설정"
 
@@ -682,8 +682,8 @@ msgstr " Kad: "
 #: src/amuleDlg.cpp:1029 src/DownloadListCtrl.cpp:505
 #: src/DownloadListCtrl.cpp:749 src/FriendListCtrl.cpp:180
 #: src/muuli_wdr.cpp:731 src/muuli_wdr.cpp:782 src/muuli_wdr.cpp:846
-#: src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2231 src/muuli_wdr.cpp:2316
-#: src/muuli_wdr.cpp:3064 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
+#: src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2262 src/muuli_wdr.cpp:2347
+#: src/muuli_wdr.cpp:3095 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
 #: src/ServerListCtrl.cpp:606 src/TransferWnd.cpp:378
 #: src/utils/wxCas/src/wxcasprefs.cpp:235
 msgid "Cancel"
@@ -695,7 +695,7 @@ msgid "Stop the current connection attempts"
 msgstr "현재 연결시도를 멈춤"
 
 #: src/amuleDlg.cpp:1035 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976
-#: src/muuli_wdr.cpp:2454
+#: src/muuli_wdr.cpp:2485
 msgid "Disconnect"
 msgstr "연결 끊기"
 
@@ -705,7 +705,7 @@ msgid "Disconnect from the currently connected networks"
 msgstr "통신망으로부터 연결을 끊습니다."
 
 #: src/amuleDlg.cpp:1041 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979
-#: src/muuli_wdr.cpp:2609 src/muuli_wdr.cpp:3061 src/muuli_wdr.cpp:3416
+#: src/muuli_wdr.cpp:2640 src/muuli_wdr.cpp:3092 src/muuli_wdr.cpp:3447
 msgid "Connect"
 msgstr "연결"
 
@@ -763,7 +763,7 @@ msgstr "종료 확인"
 msgid "Launch Command: "
 msgstr "명령: %s"
 
-#: src/amuleDlg.cpp:1632 src/muuli_wdr.cpp:1978 src/Preferences.cpp:952
+#: src/amuleDlg.cpp:1632 src/muuli_wdr.cpp:1982 src/Preferences.cpp:979
 msgid "- default -"
 msgstr ""
 
@@ -777,49 +777,49 @@ msgstr "외형 폴더 '%s'가 없습니다."
 msgid "WARNING: Unable to open skin file '%s' for read"
 msgstr ""
 
-#: src/amuleDlg.cpp:1791 src/muuli_wdr.cpp:3418
+#: src/amuleDlg.cpp:1791 src/muuli_wdr.cpp:3449
 msgid "Networks Window"
 msgstr "통신망 창"
 
-#: src/amuleDlg.cpp:1797 src/muuli_wdr.cpp:3419
+#: src/amuleDlg.cpp:1797 src/muuli_wdr.cpp:3450
 msgid "Searches Window"
 msgstr "검색 창"
 
-#: src/amuleDlg.cpp:1803 src/muuli_wdr.cpp:3420
+#: src/amuleDlg.cpp:1803 src/muuli_wdr.cpp:3451
 #, fuzzy
 msgid "Downloads Window"
 msgstr "받는중"
 
-#: src/amuleDlg.cpp:1809 src/muuli_wdr.cpp:3422
+#: src/amuleDlg.cpp:1809 src/muuli_wdr.cpp:3453
 msgid "Shared Files Window"
 msgstr "공유 파일 창"
 
-#: src/amuleDlg.cpp:1815 src/muuli_wdr.cpp:3423
+#: src/amuleDlg.cpp:1815 src/muuli_wdr.cpp:3454
 msgid "Messages Window"
 msgstr "메시지 창"
 
-#: src/amuleDlg.cpp:1821 src/muuli_wdr.cpp:3424
+#: src/amuleDlg.cpp:1821 src/muuli_wdr.cpp:3455
 msgid "Statistics Graph Window"
 msgstr "통계 그래프 창"
 
-#: src/amuleDlg.cpp:1828 src/muuli_wdr.cpp:3426
+#: src/amuleDlg.cpp:1828 src/muuli_wdr.cpp:3457
 msgid "Preferences Settings Window"
 msgstr "환경 설정 창"
 
-#: src/amuleDlg.cpp:1831 src/muuli_wdr.cpp:3427
+#: src/amuleDlg.cpp:1831 src/muuli_wdr.cpp:3458
 msgid "Import"
 msgstr "가져오기"
 
-#: src/amuleDlg.cpp:1835 src/muuli_wdr.cpp:3427
+#: src/amuleDlg.cpp:1835 src/muuli_wdr.cpp:3458
 msgid "The partfile importer tool"
 msgstr "부분파일 가져오기 도구"
 
-#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3428
+#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3459
 #: src/utils/aLinkCreator/src/alcframe.cpp:262
 msgid "About"
 msgstr "정보"
 
-#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3428
+#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3459
 msgid "About/Help"
 msgstr "정보/도움"
 
@@ -965,7 +965,7 @@ msgstr "파일을 찾을 수 없습니다."
 msgid "The core rejected these shared folders:%s"
 msgstr ""
 
-#: src/amule-remote-gui.cpp:1336 src/ExternalConn.cpp:2345
+#: src/amule-remote-gui.cpp:1336 src/ExternalConn.cpp:2346
 msgid "Invalid link or already on list."
 msgstr "유효하지 않은 링크거나 이미 목록에 존재합니다."
 
@@ -981,7 +981,7 @@ msgstr ""
 #: src/ClientDetailDialog.cpp:123 src/DataToText.cpp:61 src/DataToText.cpp:86
 #: src/DataToText.cpp:101 src/DataToText.cpp:136 src/DataToText.cpp:165
 #: src/DownloadListCtrl.cpp:1172 src/DownloadListCtrl.cpp:1185
-#: src/DownloadListCtrl.cpp:1196 src/ExternalConn.cpp:608
+#: src/DownloadListCtrl.cpp:1196 src/ExternalConn.cpp:609
 #: src/FileDetailDialog.cpp:203 src/FileDetailDialog.cpp:235
 #: src/FileDetailDialog.cpp:242 src/GenericClientListCtrl.cpp:1171
 #: src/GenericClientListCtrl.cpp:1182 src/GenericClientListCtrl.cpp:1192
@@ -1368,19 +1368,19 @@ msgstr "자동[높음]"
 msgid "Very low"
 msgstr "매우 낮음"
 
-#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:743 src/muuli_wdr.cpp:2282
+#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:743 src/muuli_wdr.cpp:2313
 #: src/ServerListCtrl.cpp:263 src/ServerListCtrl.cpp:456
 #: src/SharedFilesCtrl.cpp:145
 msgid "Low"
 msgstr "낮음"
 
-#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:744 src/muuli_wdr.cpp:2283
+#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:744 src/muuli_wdr.cpp:2314
 #: src/ServerListCtrl.cpp:266 src/ServerListCtrl.cpp:457
 #: src/SharedFilesCtrl.cpp:146
 msgid "Normal"
 msgstr "보통"
 
-#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:745 src/muuli_wdr.cpp:2284
+#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:745 src/muuli_wdr.cpp:2315
 #: src/ServerListCtrl.cpp:269 src/ServerListCtrl.cpp:458
 #: src/SharedFilesCtrl.cpp:147
 msgid "High"
@@ -1472,7 +1472,7 @@ msgstr "지역 서버"
 msgid "Remote Server"
 msgstr "원격 서버"
 
-#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3181
+#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3212
 #: src/SearchDlg.cpp:119 src/TextClient.cpp:911
 msgid "Kad"
 msgstr "Kad"
@@ -1543,7 +1543,7 @@ msgstr ""
 msgid "Size"
 msgstr "크기"
 
-#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3248
+#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3279
 msgid "Transferred"
 msgstr "전송됨"
 
@@ -1601,7 +1601,7 @@ msgid ""
 "\n"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:746 src/muuli_wdr.cpp:2285
+#: src/DownloadListCtrl.cpp:746 src/muuli_wdr.cpp:2316
 #: src/SharedFilesCtrl.cpp:150
 msgid "Auto"
 msgstr "자동"
@@ -1639,7 +1639,7 @@ msgid "Extended Options"
 msgstr "확장 옵션"
 
 #: src/DownloadListCtrl.cpp:770 src/DownloadListCtrl.cpp:822
-#: src/muuli_wdr.cpp:1796
+#: src/muuli_wdr.cpp:1800
 msgid "Preview"
 msgstr "미리보기"
 
@@ -1812,232 +1812,237 @@ msgstr[1] ""
 msgid "Invalid eD2k link! ERROR: %s"
 msgstr ""
 
-#: src/ExternalConn.cpp:379
+#: src/ExternalConn.cpp:380
 #, fuzzy
 msgid "Client sent packet after authentication failed."
 msgstr "인증에 실패했습니다."
 
-#: src/ExternalConn.cpp:396
+#: src/ExternalConn.cpp:397
 msgid "External connection closed."
 msgstr "외부연결 끊겼습니다."
 
-#: src/ExternalConn.cpp:473
+#: src/ExternalConn.cpp:474
 msgid "External connections disabled due to empty password!"
 msgstr "빈암호 때문에 외부연결이 불가능합니다."
 
-#: src/ExternalConn.cpp:494
+#: src/ExternalConn.cpp:495
 msgid "External connections disabled in config file"
 msgstr "이 환경설정에서 외부연결은 불가능합니다."
 
-#: src/ExternalConn.cpp:575
+#: src/ExternalConn.cpp:576
 msgid "New external connection accepted"
 msgstr "새로운 외부연결이 승인되었습니다."
 
-#: src/ExternalConn.cpp:578
+#: src/ExternalConn.cpp:579
 msgid "ERROR: couldn't accept a new external connection"
 msgstr ""
 
-#: src/ExternalConn.cpp:595
+#: src/ExternalConn.cpp:596
 msgid "External connection refused due to empty password in preferences!"
 msgstr "환경설정의 빈암호로 인해 외부연결이 거부되었습니다."
 
-#: src/ExternalConn.cpp:607
+#: src/ExternalConn.cpp:608
 #, c-format
 msgid "Connecting client: %s %s"
 msgstr "연결중인 클라이언트: %s %s"
 
-#: src/ExternalConn.cpp:609
+#: src/ExternalConn.cpp:610
 msgid "Unknown version"
 msgstr "알수없는 버젼"
 
-#: src/ExternalConn.cpp:622
+#: src/ExternalConn.cpp:623
 msgid "Incorrect EC version ID, there might be binary incompatibility. Use core and remote from same snapshot."
 msgstr "불확실한 외부연결 버젼 아이디, 이것은 바이너리와 호환되지 않습니다. 동일한 스냅삿으로부터 코어와 원격을 사용하세요."
 
-#: src/ExternalConn.cpp:630
+#: src/ExternalConn.cpp:631
 #, fuzzy
 msgid "You cannot connect to a release version from an arbitrary development snapshot! *sigh* possible crash prevented"
 msgstr "비정식 CVS 버젼으로부터 릴리즈된 버젼에 연결할수없습니다! *휴우* 있을 수 있었던 충돌을 막았습니다."
 
-#: src/ExternalConn.cpp:713
+#: src/ExternalConn.cpp:714
 msgid "Invalid protocol version."
 msgstr "유효하지 않은 프로토콜 버젼입니다"
 
-#: src/ExternalConn.cpp:719
+#: src/ExternalConn.cpp:720
 msgid "Missing protocol version tag."
 msgstr "프로토콜 버젼 태그 없음"
 
-#: src/ExternalConn.cpp:727
+#: src/ExternalConn.cpp:728
 msgid "Authentication failed: invalid hash specified as EC password."
 msgstr ""
 
-#: src/ExternalConn.cpp:775
+#: src/ExternalConn.cpp:776
 #, fuzzy
 msgid "Authentication failed: wrong password."
 msgstr "인증에 실패했습니다."
 
-#: src/ExternalConn.cpp:777
+#: src/ExternalConn.cpp:778
 #, fuzzy
 msgid "Authentication failed: missing password."
 msgstr "인증에 실패했습니다."
 
-#: src/ExternalConn.cpp:788
+#: src/ExternalConn.cpp:789
 #, fuzzy
 msgid "Invalid request, please authenticate first."
 msgstr "유효하지않은 요청, 먼저 인증을 하세요."
 
-#: src/ExternalConn.cpp:793
+#: src/ExternalConn.cpp:794
 msgid "Access granted."
 msgstr "접근 허가되었습니다."
 
-#: src/ExternalConn.cpp:801
+#: src/ExternalConn.cpp:802
 #, fuzzy, c-format
 msgid "Sent error message \"%s\" to client."
 msgstr "알 수 없는 클라이언트로부터 메시지를 차단"
 
-#: src/ExternalConn.cpp:806
+#: src/ExternalConn.cpp:807
 #, fuzzy, c-format
 msgid "Unauthorized access attempt from %s. Connection closed."
 msgstr "허락되지않은 접속입니다. 연결이 끊깁니다."
 
-#: src/ExternalConn.cpp:1419
+#: src/ExternalConn.cpp:1420
 #, c-format
 msgid "Remote PartFile command failed: FileHash not found: %s"
 msgstr "원격 부분파일 명령 실패: 파일해시를 찾을 수 없음: %s "
 
-#: src/ExternalConn.cpp:1423
+#: src/ExternalConn.cpp:1424
 #, c-format
 msgid "FileHash not found: %s"
 msgstr "파일해시를 찾을 수 없음: %s"
 
-#: src/ExternalConn.cpp:1470 src/ExternalConn.cpp:1558
-#: src/ExternalConn.cpp:1679
+#: src/ExternalConn.cpp:1471 src/ExternalConn.cpp:1559
+#: src/ExternalConn.cpp:1680
 msgid "OOPS! OpCode processing error!"
 msgstr "이런! 명령코드 처리 오류!"
 
-#: src/ExternalConn.cpp:1501
+#: src/ExternalConn.cpp:1502
 msgid "Server not added"
 msgstr "서버가 추가되지 않음"
 
-#: src/ExternalConn.cpp:1520
+#: src/ExternalConn.cpp:1521
 #, c-format
 msgid "server not found: %s"
 msgstr "서버가 발견되지 않음: %s"
 
-#: src/ExternalConn.cpp:1537
+#: src/ExternalConn.cpp:1538
 msgid "need to define server to be removed"
 msgstr "제거할 서버의 정의가 필요합니다."
 
-#: src/ExternalConn.cpp:1552
+#: src/ExternalConn.cpp:1553
 msgid "eD2k is disabled in preferences."
 msgstr ""
 
-#: src/ExternalConn.cpp:1657
+#: src/ExternalConn.cpp:1658
 #, fuzzy
 msgid "Friend not found."
 msgstr "파일을 찾을 수 없습니다."
 
-#: src/ExternalConn.cpp:1667
+#: src/ExternalConn.cpp:1668
 #, fuzzy
 msgid "Client not found."
 msgstr "파일을 찾을 수 없습니다."
 
-#: src/ExternalConn.cpp:1673
+#: src/ExternalConn.cpp:1674
 msgid "EC_TAG_FRIEND_SHARED requires EC_TAG_FRIEND or EC_TAG_CLIENT."
 msgstr ""
 
-#: src/ExternalConn.cpp:1991
+#: src/ExternalConn.cpp:1992
 msgid "WebSearch from remote interface makes no sense."
 msgstr "원격 인터페이스로부터 웹검색은 좋지않은 선택입니다."
 
-#: src/ExternalConn.cpp:2026
+#: src/ExternalConn.cpp:2027
 msgid "Search in progress. Refetch results in a moment!"
 msgstr "검색중입니다. 금방 결과를 다시 가져옵니다."
 
-#: src/ExternalConn.cpp:2265
+#: src/ExternalConn.cpp:2266
 msgid "No points for graph."
 msgstr "그래프가 비어있음."
 
-#: src/ExternalConn.cpp:2275
+#: src/ExternalConn.cpp:2276
 msgid "Your client is not configured for this detail level."
 msgstr "클라이언트는 세부 수준이 구성되지 않았습니다."
 
-#: src/ExternalConn.cpp:2302
+#: src/ExternalConn.cpp:2303
 msgid "External Connection: shutdown requested"
 msgstr ""
 
-#: src/ExternalConn.cpp:2314
+#: src/ExternalConn.cpp:2315
 msgid "Already shutting down."
 msgstr "이미 종료하는중입니다."
 
-#: src/ExternalConn.cpp:2332
+#: src/ExternalConn.cpp:2333
 #, c-format
 msgid "ExternalConn: adding link '%s'."
 msgstr "외부연결: '%s' 링크를 추가합니다."
 
-#: src/ExternalConn.cpp:2350
+#: src/ExternalConn.cpp:2351
 #, fuzzy, c-format
 msgid "%d of %d links failed (invalid or already on list)."
 msgstr "유효하지 않은 링크거나 이미 목록에 존재합니다."
 
-#: src/ExternalConn.cpp:2373
+#: src/ExternalConn.cpp:2374
 msgid "Version check throttled; try again shortly."
 msgstr ""
 
-#: src/ExternalConn.cpp:2378
+#: src/ExternalConn.cpp:2379
 msgid "Version check is not available on this daemon."
 msgstr ""
 
-#: src/ExternalConn.cpp:2508
+#: src/ExternalConn.cpp:2509
 msgid "File not found."
 msgstr "파일을 찾을 수 없습니다."
 
-#: src/ExternalConn.cpp:2513
+#: src/ExternalConn.cpp:2514
 msgid "Invalid file name."
 msgstr "유효하지 않은 파일 이름입니다."
 
-#: src/ExternalConn.cpp:2521
+#: src/ExternalConn.cpp:2522
 msgid "Unable to rename file."
 msgstr "파일이름을 변경할 수 없습니다."
 
-#: src/ExternalConn.cpp:2992 src/ExternalConn.cpp:3020
+#: src/ExternalConn.cpp:2839
+#, c-format
+msgid "Could not save the amuleapi password: %s"
+msgstr ""
+
+#: src/ExternalConn.cpp:3004 src/ExternalConn.cpp:3032
 msgid "Kad is disabled in preferences."
 msgstr "Kad는 환경설정에서 비활성화되어 있습니다."
 
-#: src/ExternalConn.cpp:3033
+#: src/ExternalConn.cpp:3045
 msgid "Already connected to eD2k."
 msgstr ""
 
-#: src/ExternalConn.cpp:3036
+#: src/ExternalConn.cpp:3048
 msgid "Connecting to eD2k..."
 msgstr ""
 
-#: src/ExternalConn.cpp:3045
+#: src/ExternalConn.cpp:3057
 msgid "Already connected to Kad."
 msgstr "이미 Kad에 연결되었습니다."
 
-#: src/ExternalConn.cpp:3048
+#: src/ExternalConn.cpp:3060
 msgid "Connecting to Kad..."
 msgstr "Kad에 연결중..."
 
-#: src/ExternalConn.cpp:3055
+#: src/ExternalConn.cpp:3067
 msgid "All networks are disabled."
 msgstr "모든 통신망을 사용할수 없습니다."
 
-#: src/ExternalConn.cpp:3064
+#: src/ExternalConn.cpp:3076
 msgid "Disconnected from eD2k."
 msgstr ""
 
-#: src/ExternalConn.cpp:3069
+#: src/ExternalConn.cpp:3081
 msgid "Disconnected from Kad."
 msgstr "Kad로부터 연결이 끊겼습니다."
 
-#: src/ExternalConn.cpp:3078
+#: src/ExternalConn.cpp:3090
 #, c-format
 msgid "External Connection: invalid opcode received: %#x"
 msgstr ""
 
-#: src/ExternalConn.cpp:3083
+#: src/ExternalConn.cpp:3095
 msgid "Invalid opcode (wrong protocol version?)"
 msgstr "유효하지 않은 실행코드(잘못된 프로토콜 버젼?)"
 
@@ -2438,23 +2443,23 @@ msgid ""
 "want downloads on a different (e.g. larger) disk."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:549 src/FirstRunWizard.cpp:611 src/muuli_wdr.cpp:1708
+#: src/FirstRunWizard.cpp:549 src/FirstRunWizard.cpp:611 src/muuli_wdr.cpp:1712
 msgid "Destination folder for downloads"
 msgstr ""
 
 #: src/FirstRunWizard.cpp:553 src/FirstRunWizard.cpp:569 src/muuli_wdr.cpp:1349
-#: src/muuli_wdr.cpp:1366 src/muuli_wdr.cpp:1683 src/muuli_wdr.cpp:1714
-#: src/muuli_wdr.cpp:1726 src/muuli_wdr.cpp:2769
+#: src/muuli_wdr.cpp:1366 src/muuli_wdr.cpp:1687 src/muuli_wdr.cpp:1718
+#: src/muuli_wdr.cpp:1730 src/muuli_wdr.cpp:2800
 #: src/utils/aLinkCreator/src/alcframe.cpp:135
 #: src/utils/wxCas/src/wxcasprefs.cpp:52 src/utils/wxCas/src/wxcasprefs.cpp:118
 msgid "Browse"
 msgstr "탐색"
 
-#: src/FirstRunWizard.cpp:559 src/muuli_wdr.cpp:1719
+#: src/FirstRunWizard.cpp:559 src/muuli_wdr.cpp:1723
 msgid "(All files in this folder are shared with other peers)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:565 src/FirstRunWizard.cpp:624 src/muuli_wdr.cpp:1721
+#: src/FirstRunWizard.cpp:565 src/FirstRunWizard.cpp:624 src/muuli_wdr.cpp:1725
 msgid "Folder for temporary download files"
 msgstr ""
 
@@ -2485,7 +2490,7 @@ msgstr ""
 msgid "CRITICAL - no client on StartChatSession"
 msgstr ""
 
-#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2675 src/muuli_wdr.cpp:3352
+#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2706 src/muuli_wdr.cpp:3383
 msgid "Friends"
 msgstr "친구"
 
@@ -2601,8 +2606,8 @@ msgstr "아무도"
 msgid "No"
 msgstr "아니오"
 
-#: src/GenericClientListCtrl.cpp:1216 src/PrefsUnifiedDlg.cpp:2818
-#: src/PrefsUnifiedDlg.cpp:2868 src/ServerListCtrl.cpp:276
+#: src/GenericClientListCtrl.cpp:1216 src/PrefsUnifiedDlg.cpp:2898
+#: src/PrefsUnifiedDlg.cpp:2948 src/ServerListCtrl.cpp:276
 msgid "Yes"
 msgstr "예"
 
@@ -2772,10 +2777,10 @@ msgstr "초기적재에 유효하지 않은 포트"
 msgid "Please fill all fields required"
 msgstr "모든 항목을 채워주세요."
 
-#: src/KadDlg.cpp:192 src/PartFile.cpp:1031 src/PrefsUnifiedDlg.cpp:1162
-#: src/PrefsUnifiedDlg.cpp:1331 src/PrefsUnifiedDlg.cpp:1589
-#: src/PrefsUnifiedDlg.cpp:1599 src/PrefsUnifiedDlg.cpp:1616
-#: src/PrefsUnifiedDlg.cpp:1658
+#: src/KadDlg.cpp:192 src/PartFile.cpp:1031 src/PrefsUnifiedDlg.cpp:1134
+#: src/PrefsUnifiedDlg.cpp:1204 src/PrefsUnifiedDlg.cpp:1405
+#: src/PrefsUnifiedDlg.cpp:1663 src/PrefsUnifiedDlg.cpp:1673
+#: src/PrefsUnifiedDlg.cpp:1690 src/PrefsUnifiedDlg.cpp:1738
 msgid "Message"
 msgstr "메시지"
 
@@ -2877,7 +2882,7 @@ msgstr ""
 msgid "Uploaded"
 msgstr ""
 
-#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3232
+#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3263
 msgid "Requested"
 msgstr ""
 
@@ -3003,7 +3008,7 @@ msgid "WARNING: "
 msgstr ""
 
 #: src/MuleNotebook.cpp:179 src/muuli_wdr.cpp:817 src/muuli_wdr.cpp:1229
-#: src/muuli_wdr.cpp:3136 src/muuli_wdr.cpp:3392
+#: src/muuli_wdr.cpp:3167 src/muuli_wdr.cpp:3423
 msgid "Close"
 msgstr "닫기"
 
@@ -3021,7 +3026,7 @@ msgid "Paste"
 msgstr "붙이기"
 
 #: src/MuleTextCtrl.cpp:89 src/muuli_wdr.cpp:358 src/muuli_wdr.cpp:757
-#: src/muuli_wdr.cpp:2359 src/muuli_wdr.cpp:2378 src/muuli_wdr.cpp:2400
+#: src/muuli_wdr.cpp:2390 src/muuli_wdr.cpp:2409 src/muuli_wdr.cpp:2431
 #: src/utils/aLinkCreator/src/alcframe.cpp:142
 msgid "Clear"
 msgstr "깨끗이"
@@ -3119,7 +3124,7 @@ msgstr "종료"
 
 #: src/MuleTrayIcon.cpp:579 src/MuleTrayIcon.cpp:945 src/MuleTrayIcon.cpp:965
 #: src/muuli_wdr.cpp:1398 src/muuli_wdr.cpp:1406 src/muuli_wdr.cpp:1413
-#: src/muuli_wdr.cpp:1842 src/muuli_wdr.cpp:1848 src/OtherFunctions.cpp:91
+#: src/muuli_wdr.cpp:1846 src/muuli_wdr.cpp:1852 src/OtherFunctions.cpp:91
 #: src/StatisticsDlg.cpp:93 src/StatisticsDlg.cpp:95
 msgid "kB/s"
 msgstr "kB/s"
@@ -3361,7 +3366,7 @@ msgstr "바이트"
 msgid "KB"
 msgstr "KB"
 
-#: src/muuli_wdr.cpp:274 src/muuli_wdr.cpp:293 src/muuli_wdr.cpp:1627
+#: src/muuli_wdr.cpp:274 src/muuli_wdr.cpp:293 src/muuli_wdr.cpp:1631
 #: src/OtherFunctions.cpp:64
 msgid "MB"
 msgstr "MB"
@@ -3378,7 +3383,7 @@ msgstr "최대 크기"
 msgid "Availability"
 msgstr "유효성"
 
-#: src/muuli_wdr.cpp:312 src/muuli_wdr.cpp:398 src/muuli_wdr.cpp:3297
+#: src/muuli_wdr.cpp:312 src/muuli_wdr.cpp:398 src/muuli_wdr.cpp:3328
 msgid "Filter:"
 msgstr "필터:"
 
@@ -3442,12 +3447,12 @@ msgstr "자료 유지"
 #: src/muuli_wdr.cpp:1160 src/muuli_wdr.cpp:1167 src/muuli_wdr.cpp:1172
 #: src/muuli_wdr.cpp:1179 src/muuli_wdr.cpp:1184 src/muuli_wdr.cpp:1191
 #: src/muuli_wdr.cpp:1205 src/muuli_wdr.cpp:1212 src/muuli_wdr.cpp:1217
-#: src/muuli_wdr.cpp:1224 src/muuli_wdr.cpp:3234 src/muuli_wdr.cpp:3242
-#: src/muuli_wdr.cpp:3250
+#: src/muuli_wdr.cpp:1224 src/muuli_wdr.cpp:3265 src/muuli_wdr.cpp:3273
+#: src/muuli_wdr.cpp:3281
 msgid "N/A"
 msgstr "없음"
 
-#: src/muuli_wdr.cpp:508 src/muuli_wdr.cpp:1065 src/PrefsUnifiedDlg.cpp:297
+#: src/muuli_wdr.cpp:508 src/muuli_wdr.cpp:1065 src/PrefsUnifiedDlg.cpp:299
 msgid "General"
 msgstr "일반"
 
@@ -3588,7 +3593,7 @@ msgstr ""
 msgid "Album :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:685 src/muuli_wdr.cpp:2254
+#: src/muuli_wdr.cpp:685 src/muuli_wdr.cpp:2285
 msgid "Title :"
 msgstr "제목 :"
 
@@ -3695,7 +3700,7 @@ msgstr "사용자 이름 :"
 msgid "Userhash :"
 msgstr "사용자 해시 :"
 
-#: src/muuli_wdr.cpp:895 src/muuli_wdr.cpp:1748 src/muuli_wdr.cpp:2449
+#: src/muuli_wdr.cpp:895 src/muuli_wdr.cpp:1752 src/muuli_wdr.cpp:2480
 #: src/utils/aLinkCreator/src/alcframe.cpp:137
 msgid "Add"
 msgstr "추가"
@@ -3704,15 +3709,15 @@ msgstr "추가"
 msgid "Download-Speed"
 msgstr "내려받기 속도"
 
-#: src/muuli_wdr.cpp:954 src/muuli_wdr.cpp:989 src/muuli_wdr.cpp:2553
+#: src/muuli_wdr.cpp:954 src/muuli_wdr.cpp:989 src/muuli_wdr.cpp:2584
 msgid "Current"
 msgstr "현재"
 
-#: src/muuli_wdr.cpp:962 src/muuli_wdr.cpp:997 src/muuli_wdr.cpp:2561
+#: src/muuli_wdr.cpp:962 src/muuli_wdr.cpp:997 src/muuli_wdr.cpp:2592
 msgid "Running average"
 msgstr "동작중 평균"
 
-#: src/muuli_wdr.cpp:970 src/muuli_wdr.cpp:1005 src/muuli_wdr.cpp:2569
+#: src/muuli_wdr.cpp:970 src/muuli_wdr.cpp:1005 src/muuli_wdr.cpp:2600
 msgid "Session average"
 msgstr "세션 평균"
 
@@ -3724,7 +3729,7 @@ msgstr "올려주기 속도"
 msgid "Connections"
 msgstr "연결"
 
-#: src/muuli_wdr.cpp:1024 src/muuli_wdr.cpp:1867
+#: src/muuli_wdr.cpp:1024 src/muuli_wdr.cpp:1871
 msgid "Active downloads"
 msgstr "활성화된 내려받기"
 
@@ -3732,7 +3737,7 @@ msgstr "활성화된 내려받기"
 msgid "Active connections (1:1)"
 msgstr "활성화된 연결 (1:1)"
 
-#: src/muuli_wdr.cpp:1040 src/muuli_wdr.cpp:1868
+#: src/muuli_wdr.cpp:1040 src/muuli_wdr.cpp:1872
 msgid "Active uploads"
 msgstr "활성화된 올려주기"
 
@@ -4009,7 +4014,7 @@ msgstr ""
 msgid "Advanced users only: If you have multiple network interfaces, enter the address of the interface to which aMule should be bound."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1462 src/muuli_wdr.cpp:2061
+#: src/muuli_wdr.cpp:1462 src/muuli_wdr.cpp:2065
 msgid "Bind to network interface (empty for any):"
 msgstr ""
 
@@ -4025,7 +4030,7 @@ msgstr ""
 msgid "Max simultaneous connections:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1498 src/muuli_wdr.cpp:3176
+#: src/muuli_wdr.cpp:1498 src/muuli_wdr.cpp:3207
 msgid "ED2K"
 msgstr "ED2k"
 
@@ -4117,756 +4122,779 @@ msgstr ""
 msgid "For new files preallocates disk space for the whole file, thus reduces fragmentation"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1613
+#: src/muuli_wdr.cpp:1617
 msgid "Create new files as sparse files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1614
-msgid "A sparse file reserves its full size on disk immediately without writing real data to it -- fast, but unsupported or slow on some filesystems, and free-space accounting stays optimistic while the download is in progress. Turn this off to grow the file only as data arrives."
+#: src/muuli_wdr.cpp:1618
+msgid "Sparse part files only occupy disk space for the parts already downloaded, so free space is used up gradually as the file fills in. Turn this off to use an ordinary file instead - useful where sparse files are unsupported or slow, or where backup/de-duplication tools handle them badly. Applies only when the core runs on Windows; on Linux and macOS part files are sparse anyway and this setting has no effect."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1619
+#: src/muuli_wdr.cpp:1623
 msgid "Stop downloads when free disk space reaches "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1620
+#: src/muuli_wdr.cpp:1624
 msgid "Select this if you want aMule to check your disk space"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1624
+#: src/muuli_wdr.cpp:1628
 msgid "Enter here the min disk space desired."
 msgstr "원하는 최소한의 디스크공간을 입력하세요."
 
-#: src/muuli_wdr.cpp:1630
+#: src/muuli_wdr.cpp:1634
 msgid "Save 10 sources on rare files (< 20 sources)"
 msgstr "희귀한 파일인 경우 10개의 자료 저장 (<20 자료)"
 
-#: src/muuli_wdr.cpp:1634 src/Statistics.cpp:790
+#: src/muuli_wdr.cpp:1638 src/Statistics.cpp:790
 msgid "Uploads"
 msgstr "올려주기"
 
-#: src/muuli_wdr.cpp:1637
+#: src/muuli_wdr.cpp:1641
 msgid "Add new shared files with auto priority"
 msgstr "자동 우선권으로 새로운 공유파일을 추가"
 
-#: src/muuli_wdr.cpp:1643
+#: src/muuli_wdr.cpp:1647
 msgid "Intelligent Corruption Handling (I.C.H.)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1646
+#: src/muuli_wdr.cpp:1650
 msgid "Enable"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1649
+#: src/muuli_wdr.cpp:1653
 msgid "Advanced I.C.H. trusts every hash (not recommended)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1661 src/PrefsUnifiedDlg.cpp:1910
+#: src/muuli_wdr.cpp:1665 src/PrefsUnifiedDlg.cpp:1990
 msgid "Media metadata extraction"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1665
+#: src/muuli_wdr.cpp:1669
 msgid "Extract length / bitrate / codec from shared audio and video files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1667
+#: src/muuli_wdr.cpp:1671
 msgid "When enabled, aMule runs ffprobe on each shared media file to fill in the Length / Bitrate / Codec columns other clients see when they find the file in a search. Requires ffmpeg (the ffprobe binary) to be installed."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1674
+#: src/muuli_wdr.cpp:1678
 msgid "Path to ffprobe:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1679
+#: src/muuli_wdr.cpp:1683
 msgid "Full path to the ffprobe binary. Leave empty to have aMule auto-detect it on startup."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1687
+#: src/muuli_wdr.cpp:1691
 msgid "Detect"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1688
+#: src/muuli_wdr.cpp:1692
 msgid "Search the standard install locations for an ffprobe binary and fill the path field."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1712
+#: src/muuli_wdr.cpp:1716
 msgid ""
 "Completed downloads are stored here. All files in this folder are automatically shared with other peers.\n"
 "If this folder also holds files you don't want to share, point it at an aMule-only sub-folder."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1715
+#: src/muuli_wdr.cpp:1719
 msgid "Pick the folder where completed downloads will be stored. All files in that folder will be shared with other peers."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1729
+#: src/muuli_wdr.cpp:1733
 msgid "Shared folders"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1735
+#: src/muuli_wdr.cpp:1739
 msgid "(Folders shared by the core. Enter a path to add one.)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1743
+#: src/muuli_wdr.cpp:1747
 msgid "Absolute path of a folder on the core's machine, e.g. /home/user/shared"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1745 src/PrefsUnifiedDlg.cpp:2794
+#: src/muuli_wdr.cpp:1749 src/PrefsUnifiedDlg.cpp:2874
 msgid "Recursive"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1746
+#: src/muuli_wdr.cpp:1750
 msgid "Share every sub-folder underneath this one, including ones created later."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1750 src/utils/aLinkCreator/src/alcframe.cpp:141
+#: src/muuli_wdr.cpp:1754 src/utils/aLinkCreator/src/alcframe.cpp:141
 msgid "Remove"
 msgstr "삭제"
 
-#: src/muuli_wdr.cpp:1754
+#: src/muuli_wdr.cpp:1758
 msgid "(Right click on folder icon for recursive share)"
 msgstr "(하위폴더 전체를 공유하려면 폴더 아이콘상에서 오른쪽 버튼을 클릭)"
 
-#: src/muuli_wdr.cpp:1761
+#: src/muuli_wdr.cpp:1765
 msgid "Share hidden files"
 msgstr "숨은파일 공유"
 
-#: src/muuli_wdr.cpp:1767
+#: src/muuli_wdr.cpp:1771
 msgid "Automatically rescan shared folders for changes"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1773
+#: src/muuli_wdr.cpp:1777
 msgid "Follow symbolic links in shared folders"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1779
+#: src/muuli_wdr.cpp:1783
 msgid "Exclude files matching:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1782
+#: src/muuli_wdr.cpp:1786
 msgid "Wildcard patterns separated by '|', e.g. .DS_Store|Thumbs.db|*.tmp. Files whose name matches are not shared. Matching is case-insensitive."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1786
+#: src/muuli_wdr.cpp:1790
 msgid "Patterns are regular expressions"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1787
+#: src/muuli_wdr.cpp:1791
 msgid "When set, the whole field is one regular expression ('|' is alternation). When unset, it is a list of '|'-separated wildcards."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1797
+#: src/muuli_wdr.cpp:1801
 msgid "Show how many shared files the current pattern would exclude."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1818
+#: src/muuli_wdr.cpp:1822
 msgid "Graphs"
 msgstr "그래프"
 
-#: src/muuli_wdr.cpp:1821 src/muuli_wdr.cpp:1883
+#: src/muuli_wdr.cpp:1825 src/muuli_wdr.cpp:1887
 msgid "Update delay : 5 secs"
 msgstr "갱신 지연 : 5 초"
 
-#: src/muuli_wdr.cpp:1825
+#: src/muuli_wdr.cpp:1829
 msgid "Time for average graph: 100 mins"
 msgstr "평균 그래프 시간 : 100 분"
 
-#: src/muuli_wdr.cpp:1829
+#: src/muuli_wdr.cpp:1833
 msgid "Connections Graph Scale: 100 "
 msgstr "연결 그래프 크기 : 100"
 
-#: src/muuli_wdr.cpp:1836
+#: src/muuli_wdr.cpp:1840
 msgid "Download graph scale:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1844
+#: src/muuli_wdr.cpp:1848
 msgid "Upload graph scale:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1854
+#: src/muuli_wdr.cpp:1858
 msgid "Colors: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1858
+#: src/muuli_wdr.cpp:1862
 msgid "Background"
 msgstr "바탕"
 
-#: src/muuli_wdr.cpp:1859
+#: src/muuli_wdr.cpp:1863
 msgid "Grid"
 msgstr "눈금"
 
-#: src/muuli_wdr.cpp:1860
+#: src/muuli_wdr.cpp:1864
 msgid "Download current"
 msgstr "현재 내려받기"
 
-#: src/muuli_wdr.cpp:1861
+#: src/muuli_wdr.cpp:1865
 msgid "Download running average"
 msgstr "내려받기 운용 평균"
 
-#: src/muuli_wdr.cpp:1862
+#: src/muuli_wdr.cpp:1866
 msgid "Download session average"
 msgstr "내려받기 세션 평균"
 
-#: src/muuli_wdr.cpp:1863
+#: src/muuli_wdr.cpp:1867
 msgid "Upload current"
 msgstr "현재 올려주기"
 
-#: src/muuli_wdr.cpp:1864
+#: src/muuli_wdr.cpp:1868
 msgid "Upload running average"
 msgstr "올려주기 운용 평균"
 
-#: src/muuli_wdr.cpp:1865
+#: src/muuli_wdr.cpp:1869
 msgid "Upload session average"
 msgstr "올려주기 세션 평균"
 
-#: src/muuli_wdr.cpp:1866
+#: src/muuli_wdr.cpp:1870
 msgid "Active connections"
 msgstr "활성화된 연결"
 
-#: src/muuli_wdr.cpp:1869
+#: src/muuli_wdr.cpp:1873
 #, fuzzy
 msgid "Systray Icon Speed Bar"
 msgstr "시스템트레이 아이콘 속도바"
 
-#: src/muuli_wdr.cpp:1870
+#: src/muuli_wdr.cpp:1874
 msgid "Kad-nodes current"
 msgstr "현재 Kad-노드"
 
-#: src/muuli_wdr.cpp:1871
+#: src/muuli_wdr.cpp:1875
 msgid "Kad-nodes running"
 msgstr "Kad-노드 운용"
 
-#: src/muuli_wdr.cpp:1872
+#: src/muuli_wdr.cpp:1876
 msgid "Kad-nodes session"
 msgstr "Kad-노드 세션"
 
-#: src/muuli_wdr.cpp:1876 src/muuli_wdr.cpp:2303
+#: src/muuli_wdr.cpp:1880 src/muuli_wdr.cpp:2334
 msgid "Select"
 msgstr "선택"
 
-#: src/muuli_wdr.cpp:1880
+#: src/muuli_wdr.cpp:1884
 msgid "Tree"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1890
+#: src/muuli_wdr.cpp:1894
 msgid "Number of Client Versions shown (0=unlimited)"
 msgstr "표시될 클라이언트 버젼의 수 (0=무제한)"
 
-#: src/muuli_wdr.cpp:1915
+#: src/muuli_wdr.cpp:1919
 msgid "!!! WARNING !!!"
 msgstr "!!! 경고 !!!"
 
-#: src/muuli_wdr.cpp:1930
+#: src/muuli_wdr.cpp:1934
 msgid "Max new connections / 5 secs"
 msgstr "최대 새연결 / 5 초"
 
-#: src/muuli_wdr.cpp:1932
+#: src/muuli_wdr.cpp:1936
 msgid "Concurrent Kad source lookups"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1934
+#: src/muuli_wdr.cpp:1938
 #, fuzzy
 msgid "Kad source re-search interval (minutes)"
 msgstr "FTP 갱신율 분당 간격"
 
-#: src/muuli_wdr.cpp:1936
+#: src/muuli_wdr.cpp:1940
 #, fuzzy
 msgid "Source re-ask interval (minutes)"
 msgstr "FTP 갱신율 분당 간격"
 
-#: src/muuli_wdr.cpp:1940
+#: src/muuli_wdr.cpp:1944
 msgid "File Buffer Size: 240000 bytes"
 msgstr "파일 버퍼 크기: 240000 바이트"
 
-#: src/muuli_wdr.cpp:1944
+#: src/muuli_wdr.cpp:1948
 msgid "Use MMAP: memory-mapped file access (lower memory use)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1945
+#: src/muuli_wdr.cpp:1949
 msgid "Maps part files into memory instead of buffering them on the heap, lowering the process memory footprint. May reduce download speed on some disks; best for memory-constrained or upload-heavy hosts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1947
+#: src/muuli_wdr.cpp:1951
 msgid "Upload Queue Size: 5000 clients"
 msgstr "올려주기 대기열 크기: 5000 클라이언트"
 
-#: src/muuli_wdr.cpp:1951
+#: src/muuli_wdr.cpp:1955
 msgid "Server connection refresh interval: Disable"
 msgstr "서버 연결 갱신 간격: 사용않함"
 
-#: src/muuli_wdr.cpp:1955
+#: src/muuli_wdr.cpp:1959
 msgid "Disable computer's timed standby mode"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1974
+#: src/muuli_wdr.cpp:1978
 msgid "Skin to use: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1983
+#: src/muuli_wdr.cpp:1987
 msgid "Show \"Fast eD2k Links Handler\" in every window."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1986
+#: src/muuli_wdr.cpp:1990
 msgid "Show extended info on categories tabs"
 msgstr "분류탭의 확장된 정보를 보여줌"
 
-#: src/muuli_wdr.cpp:1989
+#: src/muuli_wdr.cpp:1993
 #, fuzzy
 msgid "Show application version on title"
 msgstr "제목에 전송률을 보여줌"
 
-#: src/muuli_wdr.cpp:1991
+#: src/muuli_wdr.cpp:1995
 msgid "Show transfer rates on title"
 msgstr "제목에 전송률을 보여줌"
 
-#: src/muuli_wdr.cpp:1993
+#: src/muuli_wdr.cpp:1997
 msgid "Before application name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1995
+#: src/muuli_wdr.cpp:1999
 msgid "After application name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1998
+#: src/muuli_wdr.cpp:2002
 msgid "Show overhead bandwidth"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2002
+#: src/muuli_wdr.cpp:2006
 msgid "Vertical toolbar orientation"
 msgstr "수직방향 툴바"
 
-#: src/muuli_wdr.cpp:2004
+#: src/muuli_wdr.cpp:2008
 msgid "Live column sorting (auto-reorder rows as their values change)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2011
+#: src/muuli_wdr.cpp:2015
 msgid "Download Queue Files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2014
+#: src/muuli_wdr.cpp:2018
 msgid "Show progress percentage"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2020
+#: src/muuli_wdr.cpp:2024
 msgid "Show progress bar"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2023
+#: src/muuli_wdr.cpp:2027
 msgid "Flat"
 msgstr "평평한"
 
-#: src/muuli_wdr.cpp:2027
+#: src/muuli_wdr.cpp:2031
 msgid "Round"
 msgstr "둥근"
 
-#: src/muuli_wdr.cpp:2045
+#: src/muuli_wdr.cpp:2049
 msgid "External Connection Parameters"
 msgstr "외부연결 설정"
 
-#: src/muuli_wdr.cpp:2048
+#: src/muuli_wdr.cpp:2052
 msgid "Accept external connections"
 msgstr "외부연결 받아들임"
 
-#: src/muuli_wdr.cpp:2055 src/muuli_wdr.cpp:2114
+#: src/muuli_wdr.cpp:2059 src/muuli_wdr.cpp:2118
 msgid "IP of the listening interface:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2058
+#: src/muuli_wdr.cpp:2062
 msgid "Enter here a valid ip in the a.b.c.d format for the listening EC interface. An empty field or 0.0.0.0 will mean any interface."
 msgstr "수신대기 외부연결 인터페이스에 a.b.c.d 형식의 유효한 IP를 입력하세요. 항목이 비었거나 0.0.0.0이면 모든 인터페이스를 의미합니다."
 
-#: src/muuli_wdr.cpp:2079 src/muuli_wdr.cpp:2163
+#: src/muuli_wdr.cpp:2083 src/muuli_wdr.cpp:2194
 msgid "TCP port:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2085
+#: src/muuli_wdr.cpp:2089
 msgid "Enable UPnP port forwarding on the EC port"
 msgstr "외부연결 포트에 UPnP 포트포워딩 활성화"
 
-#: src/muuli_wdr.cpp:2089 src/muuli_wdr.cpp:3048
+#: src/muuli_wdr.cpp:2093 src/muuli_wdr.cpp:3079
 #: src/utils/wxCas/src/wxcasprefs.cpp:167
 msgid "Password"
 msgstr "암호"
 
-#: src/muuli_wdr.cpp:2095
+#: src/muuli_wdr.cpp:2099
 msgid "aMule API server parameters"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2098
+#: src/muuli_wdr.cpp:2102
 msgid "Run amuleapi (REST API) on startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2103
+#: src/muuli_wdr.cpp:2107
 #, fuzzy
 msgid "HTTP port:"
 msgstr "프록시 포트:"
 
-#: src/muuli_wdr.cpp:2117
+#: src/muuli_wdr.cpp:2121
 msgid "The interface amuleapi's HTTP server listens on. 127.0.0.1 (default) accepts only local connections; use 0.0.0.0 or a specific IP to expose it to other hosts (set an admin password below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2120
+#: src/muuli_wdr.cpp:2126
+msgid "Type a password to set or change it. Stored passwords cannot be shown, so leaving this empty keeps the current one."
+msgstr ""
+
+#: src/muuli_wdr.cpp:2128
 #, fuzzy
 msgid "Admin password"
 msgstr "암호를 검사중\n"
 
-#: src/muuli_wdr.cpp:2125 src/muuli_wdr.cpp:2156
-msgid "Low rights password"
-msgstr "낮은 권한 암호"
+#: src/muuli_wdr.cpp:2140 src/muuli_wdr.cpp:2157 src/PrefsUnifiedDlg.cpp:1103
+#, fuzzy
+msgid "A password is set."
+msgstr "암호를 검사중\n"
 
-#: src/muuli_wdr.cpp:2133
+#: src/muuli_wdr.cpp:2144
+#, fuzzy
+msgid "Enable guest access"
+msgstr "손님 접근 금지"
+
+#: src/muuli_wdr.cpp:2145
+msgid "Guest sessions may read status and listings but cannot change anything. Turning this off clears the stored guest password."
+msgstr ""
+
+#: src/muuli_wdr.cpp:2149
+#, fuzzy
+msgid "Guest password"
+msgstr "모든 권한 암호"
+
+#: src/muuli_wdr.cpp:2164
 msgid "Web server parameters"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2136
+#: src/muuli_wdr.cpp:2167
 msgid "Run webserver on startup (deprecated)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2142
+#: src/muuli_wdr.cpp:2173
 msgid "Web template"
 msgstr "웹 템플릿"
 
-#: src/muuli_wdr.cpp:2147
+#: src/muuli_wdr.cpp:2178
 msgid "Full rights password"
 msgstr "모든 권한 암호"
 
-#: src/muuli_wdr.cpp:2151
+#: src/muuli_wdr.cpp:2182
 msgid "Enable Low rights User"
 msgstr "낮은권한 사용자 활성화"
 
-#: src/muuli_wdr.cpp:2170
+#: src/muuli_wdr.cpp:2187
+msgid "Low rights password"
+msgstr "낮은 권한 암호"
+
+#: src/muuli_wdr.cpp:2201
 msgid "Enable UPnP port forwarding of the web server port"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2175
+#: src/muuli_wdr.cpp:2206
 msgid "Web server UPnP TCP port (Optional)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2183
+#: src/muuli_wdr.cpp:2214
 msgid "Page Refresh Time (in secs)"
 msgstr "페이지를 갱신 시간 (초)"
 
-#: src/muuli_wdr.cpp:2190
+#: src/muuli_wdr.cpp:2221
 msgid "Enable Gzip compression"
 msgstr "Gzip압축을 활성화"
 
-#: src/muuli_wdr.cpp:2224
+#: src/muuli_wdr.cpp:2255
 #, fuzzy
 msgid "Reset page to defaults"
 msgstr "기본 설정"
 
-#: src/muuli_wdr.cpp:2225
+#: src/muuli_wdr.cpp:2256
 msgid "Reset the settings on the current page to their default values."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2227 src/muuli_wdr.cpp:2313 src/ServerWnd.cpp:274
+#: src/muuli_wdr.cpp:2258 src/muuli_wdr.cpp:2344 src/ServerWnd.cpp:274
 #: src/ServerWnd.cpp:282
 msgid "OK"
 msgstr "확인"
 
-#: src/muuli_wdr.cpp:2229
+#: src/muuli_wdr.cpp:2260
 msgid "Click here to apply any changes made to the preferences."
 msgstr "환경설정으로 바꾼것을 적용하려면 이곳을 클릭하세요."
 
-#: src/muuli_wdr.cpp:2232
+#: src/muuli_wdr.cpp:2263
 msgid "Reset any changes made to the preferences."
 msgstr "환경설정으로 바꾼것을 초기화합니다."
 
-#: src/muuli_wdr.cpp:2261
+#: src/muuli_wdr.cpp:2292
 msgid "Comment :"
 msgstr "의견 :"
 
-#: src/muuli_wdr.cpp:2268
+#: src/muuli_wdr.cpp:2299
 msgid "Incoming Dir :"
 msgstr "내려받는 폴더 :"
 
-#: src/muuli_wdr.cpp:2277
+#: src/muuli_wdr.cpp:2308
 msgid "Change priority for new assigned files :"
 msgstr "새롭게 할당된 파일의 우선권를 바꿉니다. :"
 
-#: src/muuli_wdr.cpp:2281
+#: src/muuli_wdr.cpp:2312
 #, fuzzy
 msgid "Don't change"
 msgstr "변경 않음"
 
-#: src/muuli_wdr.cpp:2293
+#: src/muuli_wdr.cpp:2324
 msgid "Select color for this Category (currently selected) :"
 msgstr "이 분류의 색을 선택 (일반적으로 선택된) :"
 
-#: src/muuli_wdr.cpp:2360 src/muuli_wdr.cpp:2379 src/muuli_wdr.cpp:2401
+#: src/muuli_wdr.cpp:2391 src/muuli_wdr.cpp:2410 src/muuli_wdr.cpp:2432
 msgid "Click this button to reset the log."
 msgstr "로그를 초기화하려면 이 버튼을 클릭하세요."
 
-#: src/muuli_wdr.cpp:2420
+#: src/muuli_wdr.cpp:2451
 msgid "Click on this button to update the servers list from URL ..."
 msgstr "URL로부터 서버 목록을 갱신하려면 이 버튼을 클릭..."
 
-#: src/muuli_wdr.cpp:2424
+#: src/muuli_wdr.cpp:2455
 msgid "Server list"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2428
+#: src/muuli_wdr.cpp:2459
 msgid "Enter the url to a server.met file here and press the button to the left to update the list of known servers."
 msgstr "알려진 서버의 목록을 갱신하기 위해서는 이곳에 server.met파일의 url을 입력하고 왼쪽편의 버튼을 누르세요."
 
-#: src/muuli_wdr.cpp:2433
+#: src/muuli_wdr.cpp:2464
 msgid "Add server manually: Name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2436
+#: src/muuli_wdr.cpp:2467
 msgid "Enter the name of the new server here"
 msgstr "새로운 서버의 이름을 입력하세요."
 
-#: src/muuli_wdr.cpp:2438 src/ServerWnd.cpp:206
+#: src/muuli_wdr.cpp:2469 src/ServerWnd.cpp:206
 msgid "IP:Port"
 msgstr "IP:포트"
 
-#: src/muuli_wdr.cpp:2441
+#: src/muuli_wdr.cpp:2472
 msgid "Enter the IP of the server here, using the x.x.x.x format."
 msgstr "x.x.x.x형식으로 서버의 IP를 이곳에 입력하세요."
 
-#: src/muuli_wdr.cpp:2447
+#: src/muuli_wdr.cpp:2478
 msgid "Enter the port of the server here."
 msgstr "서버의 포트를 이곳에 입력하세요."
 
-#: src/muuli_wdr.cpp:2450
+#: src/muuli_wdr.cpp:2481
 msgid "Add manually a server (fill fields to the left before) ..."
 msgstr "서버 수동 추가 (미리 왼쪽 부분을 채울 것) ..."
 
-#: src/muuli_wdr.cpp:2479
+#: src/muuli_wdr.cpp:2510
 msgid "aMule Log"
 msgstr "어뮬 로그"
 
-#: src/muuli_wdr.cpp:2487
+#: src/muuli_wdr.cpp:2518
 msgid "Server Info"
 msgstr "서버 정보"
 
-#: src/muuli_wdr.cpp:2491
+#: src/muuli_wdr.cpp:2522
 msgid "ED2K Info"
 msgstr "ED2k 정보"
 
-#: src/muuli_wdr.cpp:2495
+#: src/muuli_wdr.cpp:2526
 msgid "Kad Info"
 msgstr "Kad 정보"
 
-#: src/muuli_wdr.cpp:2523
+#: src/muuli_wdr.cpp:2554
 msgid "Click on this button to update the nodes list from URL ..."
 msgstr "URL로부터 노드를 갱신하려면 이 버튼을 클릭..."
 
-#: src/muuli_wdr.cpp:2527
+#: src/muuli_wdr.cpp:2558
 msgid "Nodes (0)"
 msgstr "노드 (0)"
 
-#: src/muuli_wdr.cpp:2531
+#: src/muuli_wdr.cpp:2562
 msgid "Enter the url to a nodes.dat file here and press the button to the left to update the list of known nodes."
 msgstr "알려진 노드의 목록을 갱신하기 위해서는 이곳에 nodes.dat파일의 url을 입력하고 왼쪽편의 버튼을 누르세요."
 
-#: src/muuli_wdr.cpp:2534
+#: src/muuli_wdr.cpp:2565
 msgid "Nodes stats"
 msgstr "노드 상태"
 
-#: src/muuli_wdr.cpp:2576
+#: src/muuli_wdr.cpp:2607
 msgid "Bootstrap"
 msgstr "초기적재"
 
-#: src/muuli_wdr.cpp:2579
+#: src/muuli_wdr.cpp:2610
 msgid "New node"
 msgstr "새로운 노드"
 
-#: src/muuli_wdr.cpp:2584
+#: src/muuli_wdr.cpp:2615
 msgid "IP:"
 msgstr "IP:"
 
-#: src/muuli_wdr.cpp:2604
+#: src/muuli_wdr.cpp:2635
 msgid "Port:"
 msgstr "포트:"
 
-#: src/muuli_wdr.cpp:2617
+#: src/muuli_wdr.cpp:2648
 #, fuzzy
 msgid "Bootstrap from known clients"
 msgstr ""
 "알려진 클라이언트로부터 \n"
 "초기적재"
 
-#: src/muuli_wdr.cpp:2619
+#: src/muuli_wdr.cpp:2650
 msgid "Disconnect Kad"
 msgstr "Kad 끊김"
 
-#: src/muuli_wdr.cpp:2653
+#: src/muuli_wdr.cpp:2684
 msgid "Use Secure User Identification"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2655
+#: src/muuli_wdr.cpp:2686
 msgid "It is recommended to enable this option. You will not receive credits if SUI is not enabled."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2657
+#: src/muuli_wdr.cpp:2688
 msgid "Protocol Obfuscation"
 msgstr "프로토콜 난독화"
 
-#: src/muuli_wdr.cpp:2660
+#: src/muuli_wdr.cpp:2691
 msgid "Support Protocol Obfuscation"
 msgstr "프로토콜 난독화 지원"
 
-#: src/muuli_wdr.cpp:2662
+#: src/muuli_wdr.cpp:2693
 msgid "This option enabled Protocol Obfuscation, and makes aMule accept obfuscated connections from other clients."
 msgstr "이 선택은 프로토콜 난독화를 활성화하며, 어뮬이 다른 클라이언트로부터 난독화된 연결을 받아들이도록 합니다. "
 
-#: src/muuli_wdr.cpp:2664
+#: src/muuli_wdr.cpp:2695
 msgid "Use obfuscation for outgoing connections"
 msgstr "나가는 연결에 난독화 사용"
 
-#: src/muuli_wdr.cpp:2666
+#: src/muuli_wdr.cpp:2697
 msgid "This option makes aMule use Protocol Obfuscation when connecting other clients/servers."
 msgstr "이 선택은 어뮬이 다른 서버나 클라이언트에 연결할때 프로토콜 난독화를 사용하게 합니다."
 
-#: src/muuli_wdr.cpp:2668
+#: src/muuli_wdr.cpp:2699
 msgid "Accept only obfuscated connections"
 msgstr "난독화된 연결만 받음"
 
-#: src/muuli_wdr.cpp:2669
+#: src/muuli_wdr.cpp:2700
 msgid "This option makes aMule only accept obfuscated connections. You will have less sources, but all your traffic will be obfuscated"
 msgstr "이 선택은 어뮬이 난독화된 연결만 받아들이도록 합니다. 더 작은 자료를 가지지만 자료교환은 난독화됩니다."
 
-#: src/muuli_wdr.cpp:2674
+#: src/muuli_wdr.cpp:2705
 msgid "Everybody"
 msgstr "모두"
 
-#: src/muuli_wdr.cpp:2676
+#: src/muuli_wdr.cpp:2707
 msgid "No one"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2678
+#: src/muuli_wdr.cpp:2709
 msgid "Who can see my shared files:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2679
+#: src/muuli_wdr.cpp:2710
 msgid "Select who can request to view a list of your shared files."
 msgstr "공유 파일 목록 보기를 요청할 수 있는 사람을 선택하세요."
 
-#: src/muuli_wdr.cpp:2681
+#: src/muuli_wdr.cpp:2712
 msgid "IP-Filtering"
 msgstr "IP 차단"
 
-#: src/muuli_wdr.cpp:2688
+#: src/muuli_wdr.cpp:2719
 msgid "Filter clients"
 msgstr "클라이언트 차단"
 
-#: src/muuli_wdr.cpp:2690
+#: src/muuli_wdr.cpp:2721
 msgid "Enable filtering of the client IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "~/.aMule/ipfilter.dat에 기록된 클라이언트 IP의 차단을 활성화합니다."
 
-#: src/muuli_wdr.cpp:2692
+#: src/muuli_wdr.cpp:2723
 msgid "Filter servers"
 msgstr "서버 차단"
 
-#: src/muuli_wdr.cpp:2694
+#: src/muuli_wdr.cpp:2725
 msgid "Enable filtering of the server IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "~/.aMule/ipfilter.dat에 기록된 서버 IP의 차단을 활성화합니다."
 
-#: src/muuli_wdr.cpp:2698
+#: src/muuli_wdr.cpp:2729
 msgid "Reload List"
 msgstr "목록 다시읽기"
 
-#: src/muuli_wdr.cpp:2699
+#: src/muuli_wdr.cpp:2730
 msgid "Reload the list of IPs to filter from the file ~/.aMule/ipfilter.dat"
 msgstr "~/.aMule/ipfilter.dat 파일에서 차단할 IP의 목록을 다시 읽음"
 
-#: src/muuli_wdr.cpp:2705
+#: src/muuli_wdr.cpp:2736
 msgid "URL:"
 msgstr "URL:"
 
-#: src/muuli_wdr.cpp:2709 src/muuli_wdr.cpp:2902
+#: src/muuli_wdr.cpp:2740 src/muuli_wdr.cpp:2933
 msgid "Update now"
 msgstr "지금 갱신"
 
-#: src/muuli_wdr.cpp:2712
+#: src/muuli_wdr.cpp:2743
 msgid "Auto-update ipfilter at startup"
 msgstr "시작시 IP차단을 자동 갱신"
 
-#: src/muuli_wdr.cpp:2716
+#: src/muuli_wdr.cpp:2747
 msgid "Filtering Level:"
 msgstr "차단 수준:"
 
-#: src/muuli_wdr.cpp:2722
+#: src/muuli_wdr.cpp:2753
 msgid "Always filter LAN IPs"
 msgstr "랜 IP를 항상 차단"
 
-#: src/muuli_wdr.cpp:2725
+#: src/muuli_wdr.cpp:2756
 msgid "Paranoid handling of non-matching IPs"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2727
+#: src/muuli_wdr.cpp:2758
 msgid "Rejects a packet when its source IP differs from the IP the client claims (an anti-spoofing check). Disable only if it causes connection problems."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2729
+#: src/muuli_wdr.cpp:2760
 msgid "Use system-wide ipfilter.dat if available"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2730
+#: src/muuli_wdr.cpp:2761
 msgid "If there's no local ipfilter.dat found, allow usage of a system-wide ipfilter file."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2747
+#: src/muuli_wdr.cpp:2778
 msgid "Enable Online-Signature"
 msgstr "온라인서명을 활성화"
 
-#: src/muuli_wdr.cpp:2749
+#: src/muuli_wdr.cpp:2780
 msgid "Enables the writing of the OS file, which can be used by external apps to create signatures and the like."
 msgstr "서명을 생성할 수 있는 외부 응용프로그램에 의해 사용될 수 있는 운영체제 파일의 기록을 활성화합니다."
 
-#: src/muuli_wdr.cpp:2753
+#: src/muuli_wdr.cpp:2784
 msgid "Update Frequency (Secs):"
 msgstr "갱신 주기(초)"
 
-#: src/muuli_wdr.cpp:2756
+#: src/muuli_wdr.cpp:2787
 msgid "Change the frequency (in seconds) of Online Signature updates."
 msgstr "온라인 서명 갱신 주기(초)를 바꿉니다."
 
-#: src/muuli_wdr.cpp:2764
+#: src/muuli_wdr.cpp:2795
 msgid "Save online signature file in: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:2770
+#: src/muuli_wdr.cpp:2801
 msgid "Click here to select the directory containing the the Online Signature files."
 msgstr "온라인서명 파일을 포함하는 폴더를 선택하려면 클릭하세요."
 
-#: src/muuli_wdr.cpp:2803
+#: src/muuli_wdr.cpp:2834
 msgid "Show country flags for clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2804
+#: src/muuli_wdr.cpp:2835
 msgid "Render the country flag column in the transfers, queue and search views. Requires a valid MMDB GeoIP database (see below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2809
+#: src/muuli_wdr.cpp:2840
 #, fuzzy
 msgid "Database"
 msgstr "데이터율 :"
 
-#: src/muuli_wdr.cpp:2825
+#: src/muuli_wdr.cpp:2856
 #, fuzzy
 msgid "Source:"
 msgstr "자료"
 
-#: src/muuli_wdr.cpp:2828
+#: src/muuli_wdr.cpp:2859
 msgid "DB-IP (free, no account)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2829
+#: src/muuli_wdr.cpp:2860
 msgid "MaxMind GeoLite2 (free, account required)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2830
+#: src/muuli_wdr.cpp:2861
 msgid "Custom URL"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2833
+#: src/muuli_wdr.cpp:2864
 msgid "Choose which provider supplies the GeoIP MMDB database. DB-IP is the default - no account required. MaxMind requires a free account + license key. Use Custom URL to point at any other MMDB host (e.g. a local mirror)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2850
+#: src/muuli_wdr.cpp:2881
 msgid ""
 "No configuration required.\n"
 "\n"
@@ -4874,11 +4902,11 @@ msgid ""
 "License: Creative Commons BY 4.0 - https://creativecommons.org/licenses/by/4.0/"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2863
+#: src/muuli_wdr.cpp:2894
 msgid "License key:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2869
+#: src/muuli_wdr.cpp:2900
 msgid ""
 "Sign up for a free MaxMind account, then generate a License Key:\n"
 "https://www.maxmind.com/en/geolite2/signup\n"
@@ -4888,232 +4916,232 @@ msgid ""
 "Requires attribution and account registration; refresh at least every 30 days."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2884
+#: src/muuli_wdr.cpp:2915
 #, fuzzy
 msgid "Download URL:"
 msgstr "내려받기: "
 
-#: src/muuli_wdr.cpp:2890
+#: src/muuli_wdr.cpp:2921
 msgid ""
 "Must point to an .mmdb file or a .gz / .tar.gz containing one.\n"
 "URL may include credentials (https://user:pass@host/...).\n"
 "License and attribution terms are set by the upstream URL - you are responsible."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2903
+#: src/muuli_wdr.cpp:2934
 msgid "Download the GeoIP database from the selected source."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2905
+#: src/muuli_wdr.cpp:2936
 #, fuzzy
 msgid "Auto-update on startup"
 msgstr "시작시 IP차단을 자동 갱신"
 
-#: src/muuli_wdr.cpp:2906
+#: src/muuli_wdr.cpp:2937
 msgid "Re-download the GeoIP database from the selected source every time aMule starts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2929
+#: src/muuli_wdr.cpp:2960
 msgid "Filter incoming messages (except current chat):"
 msgstr "받는 메시지 차단(현재 채팅은 제외)"
 
-#: src/muuli_wdr.cpp:2931
+#: src/muuli_wdr.cpp:2962
 msgid "Filter all messages"
 msgstr "모든 메시지를 차단"
 
-#: src/muuli_wdr.cpp:2933
+#: src/muuli_wdr.cpp:2964
 msgid "Filter messages from people not on your friend list"
 msgstr "친구 목록에 없는 사람으로부터 메시지를 차단"
 
-#: src/muuli_wdr.cpp:2935
+#: src/muuli_wdr.cpp:2966
 msgid "Filter messages from unknown clients"
 msgstr "알 수 없는 클라이언트로부터 메시지를 차단"
 
-#: src/muuli_wdr.cpp:2937
+#: src/muuli_wdr.cpp:2968
 msgid "Filter messages containing (use ',' as separator):"
 msgstr "다음 내용이 포함된 메시지를 차단 (쉼표로 분리):"
 
-#: src/muuli_wdr.cpp:2940 src/muuli_wdr.cpp:2951
+#: src/muuli_wdr.cpp:2971 src/muuli_wdr.cpp:2982
 msgid "add here the words amule should filter and block messages including it"
 msgstr "이곳에 어뮬이 차단하고 막을 메시지에 포함될 단어를 추가하세요."
 
-#: src/muuli_wdr.cpp:2942
+#: src/muuli_wdr.cpp:2973
 msgid "Show received messages in the log"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2945
+#: src/muuli_wdr.cpp:2976
 msgid "Comments"
 msgstr "의견들"
 
-#: src/muuli_wdr.cpp:2948
+#: src/muuli_wdr.cpp:2979
 msgid "Filter comments containing (use ',' as separator):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2973
+#: src/muuli_wdr.cpp:3004
 msgid "Enable Proxy"
 msgstr "프록시 활성화"
 
-#: src/muuli_wdr.cpp:2974
+#: src/muuli_wdr.cpp:3005
 msgid "Enable/disable proxy support"
 msgstr "프록시지원을 활성화/비활성화"
 
-#: src/muuli_wdr.cpp:2977
+#: src/muuli_wdr.cpp:3008
 msgid "Proxy type:"
 msgstr "프록시 종류:"
 
-#: src/muuli_wdr.cpp:2988
+#: src/muuli_wdr.cpp:3019
 msgid "Proxy host:"
 msgstr "프록시 호스트:"
 
-#: src/muuli_wdr.cpp:2991
+#: src/muuli_wdr.cpp:3022
 msgid "The proxy host name"
 msgstr "프록시 호스트 이름"
 
-#: src/muuli_wdr.cpp:2993
+#: src/muuli_wdr.cpp:3024
 msgid "Proxy port:"
 msgstr "프록시 포트:"
 
-#: src/muuli_wdr.cpp:2996
+#: src/muuli_wdr.cpp:3027
 msgid "The proxy port"
 msgstr "프록시 포트"
 
-#: src/muuli_wdr.cpp:2998
+#: src/muuli_wdr.cpp:3029
 msgid "Enable authentication"
 msgstr "인증 활성화"
 
-#: src/muuli_wdr.cpp:2999
+#: src/muuli_wdr.cpp:3030
 msgid "Enable/disable username/password authentication"
 msgstr "사용자이름/암호 인증을 활성화/비활성화"
 
-#: src/muuli_wdr.cpp:3002
+#: src/muuli_wdr.cpp:3033
 msgid "Username: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:3005
+#: src/muuli_wdr.cpp:3036
 msgid "The username to use to connect to the proxy"
 msgstr "프록시에 접속하기 위한 사용자이름"
 
-#: src/muuli_wdr.cpp:3007
+#: src/muuli_wdr.cpp:3038
 msgid "Password:"
 msgstr "암호:"
 
-#: src/muuli_wdr.cpp:3010
+#: src/muuli_wdr.cpp:3041
 msgid "The password to use to connect to the proxy"
 msgstr "프록시에 접속하기 위한 암호"
 
-#: src/muuli_wdr.cpp:3029
+#: src/muuli_wdr.cpp:3060
 msgid "Connect to:"
 msgstr "연결함:"
 
-#: src/muuli_wdr.cpp:3038
+#: src/muuli_wdr.cpp:3069
 msgid "Login to remote amule"
 msgstr "원격 어뮬에 로그인"
 
-#: src/muuli_wdr.cpp:3043
+#: src/muuli_wdr.cpp:3074
 msgid "User name"
 msgstr "사용자이름"
 
-#: src/muuli_wdr.cpp:3054
+#: src/muuli_wdr.cpp:3085
 msgid "Remember those settings"
 msgstr "설정을 기억"
 
-#: src/muuli_wdr.cpp:3057
+#: src/muuli_wdr.cpp:3088
 #, fuzzy
 msgid "Force ZLIB compression"
 msgstr "gzip 압축 사용"
 
-#: src/muuli_wdr.cpp:3081
+#: src/muuli_wdr.cpp:3112
 msgid "Enable Verbose Debug-Logging."
 msgstr "상세한 디버그-로깅 활성화"
 
-#: src/muuli_wdr.cpp:3083
+#: src/muuli_wdr.cpp:3114
 #, fuzzy
 msgid "Only to Logfile"
 msgstr "파일 열기(&O)"
 
-#: src/muuli_wdr.cpp:3085
+#: src/muuli_wdr.cpp:3116
 msgid "Message Categories:"
 msgstr "메시지 분류:"
 
-#: src/muuli_wdr.cpp:3109 src/PartFileConvertDlg.cpp:160
+#: src/muuli_wdr.cpp:3140 src/PartFileConvertDlg.cpp:160
 msgid "Waiting..."
 msgstr "대기중..."
 
-#: src/muuli_wdr.cpp:3129
+#: src/muuli_wdr.cpp:3160
 msgid "Add imports"
 msgstr "가져오기 추가"
 
-#: src/muuli_wdr.cpp:3132
+#: src/muuli_wdr.cpp:3163
 msgid "Retry selected"
 msgstr "선택된 것을 재시도"
 
-#: src/muuli_wdr.cpp:3134
+#: src/muuli_wdr.cpp:3165
 msgid "Remove selected"
 msgstr "선택된 것을 삭제"
 
-#: src/muuli_wdr.cpp:3197
+#: src/muuli_wdr.cpp:3228
 msgid "Event Types"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3216
+#: src/muuli_wdr.cpp:3247
 msgid "Statistics and queued clients for selected file(s) : Session / All time"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3240
+#: src/muuli_wdr.cpp:3271
 #, fuzzy
 msgid "Active Uploads"
 msgstr "활성화된 올려주기 :"
 
-#: src/muuli_wdr.cpp:3254
+#: src/muuli_wdr.cpp:3285
 msgid "Percent of total files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3306
+#: src/muuli_wdr.cpp:3337
 #, fuzzy
 msgid "Show Clients for"
 msgstr "클라이언트 보기"
 
-#: src/muuli_wdr.cpp:3308
+#: src/muuli_wdr.cpp:3339
 #, fuzzy
 msgid "All files"
 msgstr "공유된 파일을 숨김"
 
-#: src/muuli_wdr.cpp:3311
+#: src/muuli_wdr.cpp:3342
 #, fuzzy
 msgid "Selected files"
 msgstr "보기 필터 선택"
 
-#: src/muuli_wdr.cpp:3314
+#: src/muuli_wdr.cpp:3345
 #, fuzzy
 msgid "Active uploads only"
 msgstr "활성화된 올려주기"
 
-#: src/muuli_wdr.cpp:3321
+#: src/muuli_wdr.cpp:3352
 #, fuzzy
 msgid "Reload:"
 msgstr "목록 다시읽기"
 
-#: src/muuli_wdr.cpp:3325
+#: src/muuli_wdr.cpp:3356
 msgid "Reload your shared files"
 msgstr "공유된 파일을 다시 읽어들임"
 
-#: src/muuli_wdr.cpp:3388
+#: src/muuli_wdr.cpp:3419
 msgid "Send"
 msgstr "보내기"
 
-#: src/muuli_wdr.cpp:3389
+#: src/muuli_wdr.cpp:3420
 msgid "Sends the specified message."
 msgstr "지정된 메시지를 보냅니다."
 
-#: src/muuli_wdr.cpp:3393
+#: src/muuli_wdr.cpp:3424
 msgid "Close this chat-session."
 msgstr "이 채팅세션을 닫습니다."
 
-#: src/muuli_wdr.cpp:3416
+#: src/muuli_wdr.cpp:3447
 msgid "Connect to any server and/or Kad"
 msgstr "서버 혹은 Kad에 연결"
 
-#: src/muuli_wdr.cpp:3422 src/SharedFilesCtrl.cpp:142 src/Statistics.cpp:941
+#: src/muuli_wdr.cpp:3453 src/SharedFilesCtrl.cpp:142 src/Statistics.cpp:941
 msgid "Shared Files"
 msgstr "공유 파일"
 
@@ -5476,268 +5504,268 @@ msgstr ""
 msgid "ERROR: Failed to open partfile '%s'"
 msgstr ""
 
-#: src/Preferences.cpp:674
+#: src/Preferences.cpp:701
 msgid "System default"
 msgstr "기본 설정"
 
-#: src/Preferences.cpp:675
+#: src/Preferences.cpp:702
 msgid "Albanian"
 msgstr ""
 
-#: src/Preferences.cpp:676
+#: src/Preferences.cpp:703
 msgid "Arabic"
 msgstr "아랍어"
 
-#: src/Preferences.cpp:677
+#: src/Preferences.cpp:704
 #, fuzzy
 msgid "Asturian"
 msgstr "에스토니아어"
 
-#: src/Preferences.cpp:678
+#: src/Preferences.cpp:705
 msgid "Basque"
 msgstr "바스크어"
 
-#: src/Preferences.cpp:679
+#: src/Preferences.cpp:706
 msgid "Bulgarian"
 msgstr "불가리아어"
 
-#: src/Preferences.cpp:680
+#: src/Preferences.cpp:707
 msgid "Catalan"
 msgstr "카탈로니아어"
 
-#: src/Preferences.cpp:681
+#: src/Preferences.cpp:708
 msgid "Chinese (Simplified)"
 msgstr "중국어(간체)"
 
-#: src/Preferences.cpp:682
+#: src/Preferences.cpp:709
 msgid "Chinese (Traditional)"
 msgstr "중국어(번체)"
 
-#: src/Preferences.cpp:683
+#: src/Preferences.cpp:710
 msgid "Croatian"
 msgstr "크로티아어"
 
-#: src/Preferences.cpp:684
+#: src/Preferences.cpp:711
 msgid "Czech"
 msgstr ""
 
-#: src/Preferences.cpp:685
+#: src/Preferences.cpp:712
 msgid "Danish"
 msgstr "덴마크어"
 
-#: src/Preferences.cpp:686
+#: src/Preferences.cpp:713
 msgid "Dutch"
 msgstr "네델란드어"
 
-#: src/Preferences.cpp:687
+#: src/Preferences.cpp:714
 msgid "English (U.K.)"
 msgstr "영어(영국)"
 
-#: src/Preferences.cpp:688
+#: src/Preferences.cpp:715
 #, fuzzy
 msgid "English (U.S.)"
 msgstr "영어(영국)"
 
-#: src/Preferences.cpp:689
+#: src/Preferences.cpp:716
 msgid "Estonian"
 msgstr "에스토니아어"
 
-#: src/Preferences.cpp:690
+#: src/Preferences.cpp:717
 msgid "Finnish"
 msgstr "필란드어"
 
-#: src/Preferences.cpp:691
+#: src/Preferences.cpp:718
 msgid "French"
 msgstr "프랑스어"
 
-#: src/Preferences.cpp:692
+#: src/Preferences.cpp:719
 msgid "Galician"
 msgstr "갈리시아어"
 
-#: src/Preferences.cpp:693
+#: src/Preferences.cpp:720
 msgid "German"
 msgstr "독일어"
 
-#: src/Preferences.cpp:694
+#: src/Preferences.cpp:721
 msgid "Greek"
 msgstr ""
 
-#: src/Preferences.cpp:695
+#: src/Preferences.cpp:722
 msgid "Hebrew"
 msgstr ""
 
-#: src/Preferences.cpp:696
+#: src/Preferences.cpp:723
 msgid "Hungarian"
 msgstr "헝가리어"
 
-#: src/Preferences.cpp:697
+#: src/Preferences.cpp:724
 msgid "Italian"
 msgstr "이탈리아어"
 
-#: src/Preferences.cpp:698
+#: src/Preferences.cpp:725
 msgid "Japanese"
 msgstr ""
 
-#: src/Preferences.cpp:699
+#: src/Preferences.cpp:726
 msgid "Korean"
 msgstr "한국어"
 
-#: src/Preferences.cpp:700
+#: src/Preferences.cpp:727
 msgid "Latvian"
 msgstr ""
 
-#: src/Preferences.cpp:701
+#: src/Preferences.cpp:728
 msgid "Lithuanian"
 msgstr ""
 
-#: src/Preferences.cpp:702
+#: src/Preferences.cpp:729
 msgid "Norwegian (Nynorsk)"
 msgstr ""
 
-#: src/Preferences.cpp:703
+#: src/Preferences.cpp:730
 msgid "Polish"
 msgstr "폴란드어"
 
-#: src/Preferences.cpp:704
+#: src/Preferences.cpp:731
 msgid "Portuguese"
 msgstr "포르투갈어"
 
-#: src/Preferences.cpp:705
+#: src/Preferences.cpp:732
 msgid "Portuguese (Brazilian)"
 msgstr "포르투갈어(브라질)"
 
-#: src/Preferences.cpp:706
+#: src/Preferences.cpp:733
 #, fuzzy
 msgid "Romanian"
 msgstr "크로티아어"
 
-#: src/Preferences.cpp:707
+#: src/Preferences.cpp:734
 msgid "Russian"
 msgstr "러시아어"
 
-#: src/Preferences.cpp:708
+#: src/Preferences.cpp:735
 msgid "Slovenian"
 msgstr "슬로베니아어"
 
-#: src/Preferences.cpp:709
+#: src/Preferences.cpp:736
 msgid "Spanish"
 msgstr "스페인어"
 
-#: src/Preferences.cpp:710
+#: src/Preferences.cpp:737
 msgid "Swedish"
 msgstr ""
 
-#: src/Preferences.cpp:711
+#: src/Preferences.cpp:738
 msgid "Turkish"
 msgstr "터키어"
 
-#: src/Preferences.cpp:712
+#: src/Preferences.cpp:739
 msgid "Ukrainian"
 msgstr ""
 
-#: src/Preferences.cpp:815
+#: src/Preferences.cpp:842
 #, fuzzy
 msgid "Change Language"
 msgstr "언어"
 
-#: src/Preferences.cpp:879
+#: src/Preferences.cpp:906
 msgid "There are no translations installed for aMule"
 msgstr ""
 
-#: src/Preferences.cpp:880
+#: src/Preferences.cpp:907
 #, fuzzy
 msgid "No languages available"
 msgstr "유효하지 않음"
 
-#: src/Preferences.cpp:1011
+#: src/Preferences.cpp:1038
 msgid "no options available"
 msgstr ""
 
-#: src/Preferences.cpp:2182
+#: src/Preferences.cpp:2227
 msgid "Invalid category found, skipping"
 msgstr ""
 
-#: src/Preferences.cpp:2351
+#: src/Preferences.cpp:2396
 msgid "TCP port can't be higher than 65532 due to server UDP socket being TCP+3"
 msgstr "서버 UDP 소켓이 TCP+3이 되기위해서 TCP 포트가 65532보다 커서는 안됩니다."
 
-#: src/Preferences.cpp:2352
+#: src/Preferences.cpp:2397
 #, c-format
 msgid "Default port will be used (%d)"
 msgstr "기본 포트가 사용될 것입니다.(%d)"
 
-#: src/PrefsUnifiedDlg.cpp:298 src/Statistics.cpp:866
+#: src/PrefsUnifiedDlg.cpp:300 src/Statistics.cpp:866
 msgid "Connection"
 msgstr "연결"
 
-#: src/PrefsUnifiedDlg.cpp:299 src/SearchListCtrl.cpp:117
+#: src/PrefsUnifiedDlg.cpp:301 src/SearchListCtrl.cpp:117
 msgid "Directories"
 msgstr "폴더"
 
-#: src/PrefsUnifiedDlg.cpp:300 src/Statistics.cpp:917
+#: src/PrefsUnifiedDlg.cpp:302 src/Statistics.cpp:917
 msgid "Servers"
 msgstr "서버"
 
-#: src/PrefsUnifiedDlg.cpp:301 src/ServerListCtrl.cpp:96
+#: src/PrefsUnifiedDlg.cpp:303 src/ServerListCtrl.cpp:96
 msgid "Files"
 msgstr "파일"
 
-#: src/PrefsUnifiedDlg.cpp:302
+#: src/PrefsUnifiedDlg.cpp:304
 msgid "Security"
 msgstr "보안"
 
-#: src/PrefsUnifiedDlg.cpp:303
+#: src/PrefsUnifiedDlg.cpp:305
 msgid "Interface"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:310
+#: src/PrefsUnifiedDlg.cpp:312
 msgid "IP2Country"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:313
+#: src/PrefsUnifiedDlg.cpp:315
 msgid "Proxy"
 msgstr "프록시"
 
-#: src/PrefsUnifiedDlg.cpp:314
+#: src/PrefsUnifiedDlg.cpp:316
 msgid "Filters"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:315
+#: src/PrefsUnifiedDlg.cpp:317
 msgid "Remote Controls"
 msgstr "원격 조정"
 
-#: src/PrefsUnifiedDlg.cpp:316
+#: src/PrefsUnifiedDlg.cpp:318
 msgid "Online Signature"
 msgstr "온라인 서명"
 
-#: src/PrefsUnifiedDlg.cpp:317
+#: src/PrefsUnifiedDlg.cpp:319
 msgid "Advanced"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:318
+#: src/PrefsUnifiedDlg.cpp:320
 msgid "Events"
 msgstr "사건들"
 
-#: src/PrefsUnifiedDlg.cpp:321
+#: src/PrefsUnifiedDlg.cpp:323
 msgid "Debugging"
 msgstr "디버깅"
 
-#: src/PrefsUnifiedDlg.cpp:451
+#: src/PrefsUnifiedDlg.cpp:453
 msgid ""
 "The following variables will be substituted:\n"
 "    %PARTFILE - full path to the file\n"
 "    %PARTNAME - file name only"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:472
+#: src/PrefsUnifiedDlg.cpp:474
 msgid "Tray icon support requires libayatana-appindicator3 at compile time."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:488
+#: src/PrefsUnifiedDlg.cpp:490
 msgid "Not available on Wayland: the protocol does not report when a window is minimized, so this option cannot intercept the system minimize button. Workaround: launch aMule with `GDK_BACKEND=x11` to use XWayland instead."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:534
+#: src/PrefsUnifiedDlg.cpp:536
 msgid ""
 "Do not change these setting unless you know\n"
 "what you are doing, otherwise you can easily\n"
@@ -5753,26 +5781,35 @@ msgstr ""
 "이 설정들을 조정하지 않아도\n"
 "어뮬은 잘 동작할 것입니다."
 
-#: src/PrefsUnifiedDlg.cpp:645
+#: src/PrefsUnifiedDlg.cpp:647
 #, c-format
 msgid "Failed to connect Cfg to widget with the ID %d and key %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:693
+#: src/PrefsUnifiedDlg.cpp:695
 #, c-format
 msgid "Failed to transfer data from Cfg to Widget with the ID %d and key %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:799
+#: src/PrefsUnifiedDlg.cpp:801
 msgid "The type of proxy you are connecting to"
 msgstr "연결하고 있는 프록시 타입"
 
-#: src/PrefsUnifiedDlg.cpp:1003
+#: src/PrefsUnifiedDlg.cpp:1020
 #, c-format
 msgid "Failed to transfer data from Widget to Cfg with the ID %d and key %s"
 msgstr ""
 
 #: src/PrefsUnifiedDlg.cpp:1103
+#, fuzzy
+msgid "No password set."
+msgstr "암호를 검사중\n"
+
+#: src/PrefsUnifiedDlg.cpp:1132
+msgid "Guest access needs a password. Type one in the guest password field, or untick Enable guest access."
+msgstr ""
+
+#: src/PrefsUnifiedDlg.cpp:1144
 msgid ""
 "aMule must be restarted to enable these changes:\n"
 "\n"
@@ -5780,51 +5817,51 @@ msgstr ""
 "변경사항을 활성화 하기위해 어뮬을 재시작해야 합니다:\n"
 "\n"
 
-#: src/PrefsUnifiedDlg.cpp:1110
+#: src/PrefsUnifiedDlg.cpp:1151
 msgid "- TCP port changed.\n"
 msgstr "- TCP 포트가 변경되었습니다.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1115
+#: src/PrefsUnifiedDlg.cpp:1156
 msgid "- UDP port changed.\n"
 msgstr "- UDP 포트가 변경되었습니다.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1120
+#: src/PrefsUnifiedDlg.cpp:1161
 #, fuzzy
 msgid "- Network interface binding changed.\n"
 msgstr "외부연결 끊겼습니다."
 
-#: src/PrefsUnifiedDlg.cpp:1125
+#: src/PrefsUnifiedDlg.cpp:1166
 #, fuzzy
 msgid "- External connect port changed.\n"
 msgstr "외부연결 끊겼습니다."
 
-#: src/PrefsUnifiedDlg.cpp:1129
+#: src/PrefsUnifiedDlg.cpp:1170
 #, fuzzy
 msgid "- External connect acceptance changed.\n"
 msgstr "새로운 외부연결이 승인되었습니다."
 
-#: src/PrefsUnifiedDlg.cpp:1133
+#: src/PrefsUnifiedDlg.cpp:1174
 #, fuzzy
 msgid "- External connect interface changed.\n"
 msgstr "외부연결 끊겼습니다."
 
-#: src/PrefsUnifiedDlg.cpp:1137
+#: src/PrefsUnifiedDlg.cpp:1178
 #, fuzzy
 msgid "- Protocol obfuscation support changed.\n"
 msgstr "프로토콜 난독화"
 
-#: src/PrefsUnifiedDlg.cpp:1151
+#: src/PrefsUnifiedDlg.cpp:1193
 #, fuzzy
 msgid "- amuleapi settings changed.\n"
 msgstr "- 언어가 변경되었습니다.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1160
+#: src/PrefsUnifiedDlg.cpp:1202
 msgid ""
 "Your Auto-update server list is empty.\n"
 "'Auto-update server list at startup' will be disabled."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1171
+#: src/PrefsUnifiedDlg.cpp:1213
 msgid ""
 "You have enabled external connections but have not specified a password.\n"
 "External connections cannot be enabled unless a valid password is specified."
@@ -5832,35 +5869,40 @@ msgstr ""
 "외부연결이 횔성화되어 있지만, 암호를 설정하지 않았습니다.\n"
 "외부연결은 유효한 암호가 설정되기전까지 활성화되지 않습니다."
 
-#: src/PrefsUnifiedDlg.cpp:1202
+#: src/PrefsUnifiedDlg.cpp:1246
+#, c-format
+msgid "The amuleapi password could not be saved: %s"
+msgstr ""
+
+#: src/PrefsUnifiedDlg.cpp:1276
 msgid "- Language changed.\n"
 msgstr "- 언어가 변경되었습니다.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1207
+#: src/PrefsUnifiedDlg.cpp:1281
 msgid "- Temp folder changed.\n"
 msgstr "- 임시 폴더가 변경되었습니다.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1212
+#: src/PrefsUnifiedDlg.cpp:1286
 #, fuzzy
 msgid "- ED2K network enabled.\n"
 msgstr "모든 통신망을 사용할수 없습니다."
 
-#: src/PrefsUnifiedDlg.cpp:1245
+#: src/PrefsUnifiedDlg.cpp:1319
 msgid "The shared-file exclusion pattern is not a valid regular expression. The filter has been left disabled."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1247 src/PrefsUnifiedDlg.cpp:1841
+#: src/PrefsUnifiedDlg.cpp:1321 src/PrefsUnifiedDlg.cpp:1921
 #, fuzzy
 msgid "Invalid regular expression"
 msgstr "유효하지 않은 프로토콜 버젼입니다"
 
-#: src/PrefsUnifiedDlg.cpp:1324
+#: src/PrefsUnifiedDlg.cpp:1398
 msgid ""
 "Both eD2k and Kad network are disabled.\n"
 "You won't be able to connect until you enable at least one of them."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1329
+#: src/PrefsUnifiedDlg.cpp:1403
 msgid ""
 "Kad will not start if your UDP port is disabled.\n"
 "Enable UDP port or disable Kad."
@@ -5868,7 +5910,7 @@ msgstr ""
 "UDP 포트가 비활성화되어 있으면 Kad는 시작하지 않을 것입니다.\n"
 "UDP 포트를 활성화시키거나 Kad를 비활성화시키십시오."
 
-#: src/PrefsUnifiedDlg.cpp:1385
+#: src/PrefsUnifiedDlg.cpp:1459
 msgid ""
 "\n"
 "You MUST restart aMule now.\n"
@@ -5878,69 +5920,69 @@ msgstr ""
 "지금 바로 어뮬을 재시작해야 합니다.\n"
 "만일 재시작하지 않는다면, 나쁜 일이 일어나도 불평하지 마십시오.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1450
+#: src/PrefsUnifiedDlg.cpp:1524
 msgid "Could not register aMule for autostart at login. The autostart store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1452
+#: src/PrefsUnifiedDlg.cpp:1526
 msgid "Could not remove the autostart-at-login entry."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1453
+#: src/PrefsUnifiedDlg.cpp:1527
 #, fuzzy
 msgid "Autostart"
 msgstr "자동갱신이 시작됨"
 
-#: src/PrefsUnifiedDlg.cpp:1468
+#: src/PrefsUnifiedDlg.cpp:1542
 msgid "Register file type"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1468
+#: src/PrefsUnifiedDlg.cpp:1542
 msgid "Register URL handler"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1476
+#: src/PrefsUnifiedDlg.cpp:1550
 #, c-format
 msgid "aMule only handles eD2k-compatible magnets. If you replace the current magnet handler (%s), BitTorrent magnet links will stop working - aMule cannot download BitTorrent content. Continue?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1481
+#: src/PrefsUnifiedDlg.cpp:1555
 #, c-format
 msgid "Another application currently opens .emulecollection files (%s). Replace it with aMule?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1486
+#: src/PrefsUnifiedDlg.cpp:1560
 #, c-format
 msgid "Another application is currently the default handler for these links (%s). Replace it with aMule?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1511
+#: src/PrefsUnifiedDlg.cpp:1585
 msgid "Could not register aMule for .emulecollection files. The registration store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1513
+#: src/PrefsUnifiedDlg.cpp:1587
 #, fuzzy
 msgid "Could not remove the file type registration."
 msgstr "이미 %s 파일을 내려받으려고 하고있음"
 
-#: src/PrefsUnifiedDlg.cpp:1515
+#: src/PrefsUnifiedDlg.cpp:1589
 msgid "Could not register aMule as the URL handler. The registration store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1517
+#: src/PrefsUnifiedDlg.cpp:1591
 msgid "Could not remove the URL handler registration."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1587 src/PrefsUnifiedDlg.cpp:1614
+#: src/PrefsUnifiedDlg.cpp:1661 src/PrefsUnifiedDlg.cpp:1688
 #, fuzzy
 msgid "The web server and aMule API require external connections to be enabled."
 msgstr "새로운 외부연결이 승인되었습니다."
 
-#: src/PrefsUnifiedDlg.cpp:1597
+#: src/PrefsUnifiedDlg.cpp:1671
 msgid "The aMule web server is deprecated. Consider running the aMule API instead."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1655
+#: src/PrefsUnifiedDlg.cpp:1735
 msgid ""
 "Your Auto-update servers list is in blank.\n"
 "Please fill in at least one URL to point to a valid server.met file.\n"
@@ -5950,66 +5992,66 @@ msgstr ""
 "적어도 한개의 유효한 server.met파일을 가르키는 URL을 적으세요.\n"
 "URL을 입력하려면 채크박스 옆의 \"목록\"버튼을 클릭하세요."
 
-#: src/PrefsUnifiedDlg.cpp:1796
+#: src/PrefsUnifiedDlg.cpp:1876
 msgid "Temporary files"
 msgstr "임시 파일"
 
-#: src/PrefsUnifiedDlg.cpp:1801
+#: src/PrefsUnifiedDlg.cpp:1881
 msgid "Incoming files"
 msgstr "내려받은 파일"
 
-#: src/PrefsUnifiedDlg.cpp:1806
+#: src/PrefsUnifiedDlg.cpp:1886
 msgid "Online Signatures"
 msgstr "온라인 서명"
 
-#: src/PrefsUnifiedDlg.cpp:1819
+#: src/PrefsUnifiedDlg.cpp:1899
 #, c-format
 msgid "Choose a folder for %s"
 msgstr "%s하기 위한 폴더를 선택하세요."
 
-#: src/PrefsUnifiedDlg.cpp:1843
+#: src/PrefsUnifiedDlg.cpp:1923
 #, fuzzy, c-format
 msgid "Would exclude %u of %u shared file"
 msgid_plural "Would exclude %u of %u shared files"
 msgstr[0] "알려진 공유 파일 %i개를 찾았음"
 msgstr[1] "알려진 공유 파일 %i개를 찾았음"
 
-#: src/PrefsUnifiedDlg.cpp:1860
+#: src/PrefsUnifiedDlg.cpp:1940
 msgid "Browse for videoplayer"
 msgstr "비디오재생을 위한 브라우즈"
 
-#: src/PrefsUnifiedDlg.cpp:1864
+#: src/PrefsUnifiedDlg.cpp:1944
 msgid "Select browser"
 msgstr "브라우저 선택"
 
-#: src/PrefsUnifiedDlg.cpp:1868
+#: src/PrefsUnifiedDlg.cpp:1948
 #, fuzzy
 msgid "Select ffprobe binary"
 msgstr "브라우저 선택"
 
-#: src/PrefsUnifiedDlg.cpp:1874
+#: src/PrefsUnifiedDlg.cpp:1954
 #, c-format
 msgid "Executable%s"
 msgstr "실행할수 있는 %s"
 
-#: src/PrefsUnifiedDlg.cpp:1908
+#: src/PrefsUnifiedDlg.cpp:1988
 msgid "ffprobe not found on PATH or in the standard install locations. Install ffmpeg (which ships ffprobe) or use Browse to pick a binary manually."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1920
+#: src/PrefsUnifiedDlg.cpp:2000
 msgid "Reset the settings on this page to their default values?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1921
+#: src/PrefsUnifiedDlg.cpp:2001
 #, fuzzy
 msgid "Reset to defaults"
 msgstr "기본 설정"
 
-#: src/PrefsUnifiedDlg.cpp:1948
+#: src/PrefsUnifiedDlg.cpp:2028
 msgid "Edit server list"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1949
+#: src/PrefsUnifiedDlg.cpp:2029
 msgid ""
 "Add here URL's to download server.met files.\n"
 "Only one url on each line."
@@ -6017,155 +6059,155 @@ msgstr ""
 "server.met파일을 내려받을 URL을 추가하세요.\n"
 "각 행에 오직 하나의 URL을 넣으세요."
 
-#: src/PrefsUnifiedDlg.cpp:2004
+#: src/PrefsUnifiedDlg.cpp:2084
 msgid "IP2Country update failed"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2149 src/PrefsUnifiedDlg.cpp:2180
+#: src/PrefsUnifiedDlg.cpp:2229 src/PrefsUnifiedDlg.cpp:2260
 msgid "Data by MaxMind GeoLite2"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2151 src/PrefsUnifiedDlg.cpp:2182
+#: src/PrefsUnifiedDlg.cpp:2231 src/PrefsUnifiedDlg.cpp:2262
 #, fuzzy
 msgid "Custom source"
 msgstr "완료된 자료"
 
-#: src/PrefsUnifiedDlg.cpp:2153 src/PrefsUnifiedDlg.cpp:2184
+#: src/PrefsUnifiedDlg.cpp:2233 src/PrefsUnifiedDlg.cpp:2264
 msgid "Data by DB-IP.com"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2204
+#: src/PrefsUnifiedDlg.cpp:2284
 #, fuzzy, c-format
 msgid "Status: Loaded%s"
 msgstr "상태:"
 
-#: src/PrefsUnifiedDlg.cpp:2206
+#: src/PrefsUnifiedDlg.cpp:2286
 #, fuzzy, c-format
 msgid "Status: Loaded%s - %s"
 msgstr "상태:"
 
-#: src/PrefsUnifiedDlg.cpp:2210
+#: src/PrefsUnifiedDlg.cpp:2290
 msgid "Status: Failed to load - click 'Update now' to refresh."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2212
+#: src/PrefsUnifiedDlg.cpp:2292
 msgid "Status: Not found - click 'Update now' to download."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2270 src/PrefsUnifiedDlg.cpp:2294
+#: src/PrefsUnifiedDlg.cpp:2350 src/PrefsUnifiedDlg.cpp:2374
 #, fuzzy, c-format
 msgid "Update delay: %d second"
 msgid_plural "Update delay: %d seconds"
 msgstr[0] "갱신 지연: %d 초"
 msgstr[1] "갱신 지연: %d 초"
 
-#: src/PrefsUnifiedDlg.cpp:2278
+#: src/PrefsUnifiedDlg.cpp:2358
 #, fuzzy, c-format
 msgid "Time for average graph: %d minute"
 msgid_plural "Time for average graph: %d minutes"
 msgstr[0] "평균 그래프 시간: %d 분"
 msgstr[1] "평균 그래프 시간: %d 분"
 
-#: src/PrefsUnifiedDlg.cpp:2287
+#: src/PrefsUnifiedDlg.cpp:2367
 #, c-format
 msgid "Connections Graph Scale: %d"
 msgstr "연결 그래프 크기: %d"
 
-#: src/PrefsUnifiedDlg.cpp:2302
+#: src/PrefsUnifiedDlg.cpp:2382
 #, fuzzy, c-format
 msgid "File Buffer Size: %d byte"
 msgid_plural "File Buffer Size: %d bytes"
 msgstr[0] "파일 버퍼 크기: %d 바이트"
 msgstr[1] "파일 버퍼 크기: %d 바이트"
 
-#: src/PrefsUnifiedDlg.cpp:2312
+#: src/PrefsUnifiedDlg.cpp:2392
 #, fuzzy, c-format
 msgid "Upload Queue Size: %d client"
 msgid_plural "Upload Queue Size: %d clients"
 msgstr[0] "올려주기 대기열 크기: %d 클라이언트"
 msgstr[1] "올려주기 대기열 크기: %d 클라이언트"
 
-#: src/PrefsUnifiedDlg.cpp:2322
+#: src/PrefsUnifiedDlg.cpp:2402
 #, fuzzy, c-format
 msgid "Server connection refresh interval: %d minute"
 msgid_plural "Server connection refresh interval: %d minutes"
 msgstr[0] "서버 연결 갱신 주기: %d 분"
 msgstr[1] "서버 연결 갱신 주기: %d 분"
 
-#: src/PrefsUnifiedDlg.cpp:2327
+#: src/PrefsUnifiedDlg.cpp:2407
 msgid "Server connection refresh interval: Disabled"
 msgstr "서버 연결 갱신 주기: 비활성화"
 
-#: src/PrefsUnifiedDlg.cpp:2371
+#: src/PrefsUnifiedDlg.cpp:2451
 #, fuzzy
 msgid "disabled"
 msgstr "비활성화"
 
-#: src/PrefsUnifiedDlg.cpp:2397
+#: src/PrefsUnifiedDlg.cpp:2477
 #, fuzzy, c-format
 msgid "Execute command on '%s' event"
 msgstr "`%s' 사건에 명령을 실행"
 
-#: src/PrefsUnifiedDlg.cpp:2404
+#: src/PrefsUnifiedDlg.cpp:2484
 msgid "Enable command execution on core"
 msgstr "코어에 명령 실행 활성화"
 
-#: src/PrefsUnifiedDlg.cpp:2416
+#: src/PrefsUnifiedDlg.cpp:2496
 msgid "Core command:"
 msgstr "코어 명령어:"
 
-#: src/PrefsUnifiedDlg.cpp:2432
+#: src/PrefsUnifiedDlg.cpp:2512
 msgid "Enable command execution on GUI"
 msgstr "GUI에 명령 실행 활성화"
 
-#: src/PrefsUnifiedDlg.cpp:2444
+#: src/PrefsUnifiedDlg.cpp:2524
 msgid "GUI command:"
 msgstr "GUI 명령어:"
 
-#: src/PrefsUnifiedDlg.cpp:2460
+#: src/PrefsUnifiedDlg.cpp:2540
 msgid "The following variables will be replaced:"
 msgstr "다음 변수들은 교체됩니다.:"
 
-#: src/PrefsUnifiedDlg.cpp:2628
+#: src/PrefsUnifiedDlg.cpp:2708
 msgid ""
 "The following folders look like system or sensitive locations:\n"
 "\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2633
+#: src/PrefsUnifiedDlg.cpp:2713
 msgid "Sharing them recursively will publish every file underneath on the eD2k/Kad networks. Do you really want to do this?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2636
+#: src/PrefsUnifiedDlg.cpp:2716
 #, fuzzy
 msgid "Confirm shared folders"
 msgstr "공유된 파일을 다시 읽어들임"
 
-#: src/PrefsUnifiedDlg.cpp:2664
+#: src/PrefsUnifiedDlg.cpp:2744
 #, fuzzy
 msgid "Reloading shared files..."
 msgstr "공유된 파일을 다시 읽어들임"
 
-#: src/PrefsUnifiedDlg.cpp:2665
+#: src/PrefsUnifiedDlg.cpp:2745
 msgid "Scanning for subdirectories..."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2666
+#: src/PrefsUnifiedDlg.cpp:2746
 #, fuzzy
 msgid "Updating shared folders"
 msgstr "임시 폴더를 읽는중"
 
-#: src/PrefsUnifiedDlg.cpp:2693
+#: src/PrefsUnifiedDlg.cpp:2773
 #, c-format
 msgid "Scanned %u directories..."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2743
+#: src/PrefsUnifiedDlg.cpp:2823
 #, fuzzy, c-format
 msgid "Reloading shared files: %u files scanned"
 msgstr "공유된 파일 목록을 다시 읽어들입니다."
 
-#: src/PrefsUnifiedDlg.cpp:2793
+#: src/PrefsUnifiedDlg.cpp:2873
 #, fuzzy
 msgid "Shared folder"
 msgstr "공유 파일"

--- a/po/ko_KR.po
+++ b/po/ko_KR.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-28 12:17+0200\n"
+"POT-Creation-Date: 2026-07-28 13:09+0200\n"
 "PO-Revision-Date: 2026-07-27 11:41+0000\n"
 "Last-Translator: Hyunju Kang <rexington@gmail.com>\n"
 "Language-Team: Korean <hoenny@daum.net>\n"
@@ -291,7 +291,7 @@ msgid "Password set and external connections enabled."
 msgstr "새로운 외부연결이 승인되었습니다."
 
 #: src/amule.cpp:755 src/KadDlg.cpp:176 src/KadDlg.cpp:185
-#: src/PrefsUnifiedDlg.cpp:1461 src/SharedFilesCtrl.cpp:476
+#: src/PrefsUnifiedDlg.cpp:1470 src/SharedFilesCtrl.cpp:476
 msgid "WARNING"
 msgstr "경고"
 
@@ -328,7 +328,7 @@ msgstr ""
 #: src/amule-remote-gui.cpp:603 src/amule-remote-gui.cpp:671
 #: src/amule-remote-gui.cpp:709 src/amule-remote-gui.cpp:1282
 #: src/amule-remote-gui.cpp:1345 src/amule-remote-gui.cpp:1372
-#: src/DownloadQueue.cpp:1481 src/PrefsUnifiedDlg.cpp:1247
+#: src/DownloadQueue.cpp:1481 src/PrefsUnifiedDlg.cpp:1256
 msgid "ERROR"
 msgstr ""
 
@@ -590,36 +590,36 @@ msgstr "https://github.com/amule-org/amule/releases/latest에 방문하셔서 �
 msgid "FATAL ERROR: Failed to create Timer"
 msgstr ""
 
-#: src/amuleDlg.cpp:361 src/amuleDlg.cpp:1787 src/amuleDlg.cpp:2033
-#: src/muuli_wdr.cpp:1492 src/muuli_wdr.cpp:3449
+#: src/amuleDlg.cpp:361 src/amuleDlg.cpp:1810 src/amuleDlg.cpp:2056
+#: src/muuli_wdr.cpp:1492 src/muuli_wdr.cpp:3453
 msgid "Networks"
 msgstr "통신망"
 
-#: src/amuleDlg.cpp:362 src/amuleDlg.cpp:1793 src/muuli_wdr.cpp:3450
+#: src/amuleDlg.cpp:362 src/amuleDlg.cpp:1816 src/muuli_wdr.cpp:3454
 msgid "Searches"
 msgstr "검색"
 
-#: src/amuleDlg.cpp:363 src/amuleDlg.cpp:1799 src/DownloadListCtrl.cpp:740
-#: src/muuli_wdr.cpp:392 src/muuli_wdr.cpp:1585 src/muuli_wdr.cpp:3451
+#: src/amuleDlg.cpp:363 src/amuleDlg.cpp:1822 src/DownloadListCtrl.cpp:740
+#: src/muuli_wdr.cpp:392 src/muuli_wdr.cpp:1585 src/muuli_wdr.cpp:3455
 #: src/Statistics.cpp:829
 msgid "Downloads"
 msgstr "내려받기"
 
-#: src/amuleDlg.cpp:364 src/amuleDlg.cpp:1805 src/muuli_wdr.cpp:3325
+#: src/amuleDlg.cpp:364 src/amuleDlg.cpp:1828 src/muuli_wdr.cpp:3329
 msgid "Shared files"
 msgstr ""
 
-#: src/amuleDlg.cpp:365 src/amuleDlg.cpp:1811 src/muuli_wdr.cpp:2957
-#: src/muuli_wdr.cpp:3407 src/muuli_wdr.cpp:3454
+#: src/amuleDlg.cpp:365 src/amuleDlg.cpp:1834 src/muuli_wdr.cpp:2961
+#: src/muuli_wdr.cpp:3411 src/muuli_wdr.cpp:3458
 msgid "Messages"
 msgstr "메시지"
 
-#: src/amuleDlg.cpp:366 src/amuleDlg.cpp:1817 src/muuli_wdr.cpp:3455
+#: src/amuleDlg.cpp:366 src/amuleDlg.cpp:1840 src/muuli_wdr.cpp:3459
 #: src/PrefsUnifiedDlg.cpp:314 src/Statistics.cpp:779 src/Statistics.cpp:1235
 msgid "Statistics"
 msgstr "통계"
 
-#: src/amuleDlg.cpp:368 src/amuleDlg.cpp:1824 src/muuli_wdr.cpp:3457
+#: src/amuleDlg.cpp:368 src/amuleDlg.cpp:1847 src/muuli_wdr.cpp:3461
 #: src/PrefsUnifiedDlg.cpp:330 src/utils/wxCas/src/wxcasprefs.cpp:39
 msgid "Preferences"
 msgstr "환경설정"
@@ -682,8 +682,8 @@ msgstr " Kad: "
 #: src/amuleDlg.cpp:1029 src/DownloadListCtrl.cpp:505
 #: src/DownloadListCtrl.cpp:749 src/FriendListCtrl.cpp:180
 #: src/muuli_wdr.cpp:731 src/muuli_wdr.cpp:782 src/muuli_wdr.cpp:846
-#: src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2262 src/muuli_wdr.cpp:2347
-#: src/muuli_wdr.cpp:3095 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
+#: src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2266 src/muuli_wdr.cpp:2351
+#: src/muuli_wdr.cpp:3099 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
 #: src/ServerListCtrl.cpp:606 src/TransferWnd.cpp:378
 #: src/utils/wxCas/src/wxcasprefs.cpp:235
 msgid "Cancel"
@@ -695,7 +695,7 @@ msgid "Stop the current connection attempts"
 msgstr "현재 연결시도를 멈춤"
 
 #: src/amuleDlg.cpp:1035 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976
-#: src/muuli_wdr.cpp:2485
+#: src/muuli_wdr.cpp:2489
 msgid "Disconnect"
 msgstr "연결 끊기"
 
@@ -705,7 +705,7 @@ msgid "Disconnect from the currently connected networks"
 msgstr "통신망으로부터 연결을 끊습니다."
 
 #: src/amuleDlg.cpp:1041 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979
-#: src/muuli_wdr.cpp:2640 src/muuli_wdr.cpp:3092 src/muuli_wdr.cpp:3447
+#: src/muuli_wdr.cpp:2644 src/muuli_wdr.cpp:3096 src/muuli_wdr.cpp:3451
 msgid "Connect"
 msgstr "연결"
 
@@ -763,7 +763,7 @@ msgstr "종료 확인"
 msgid "Launch Command: "
 msgstr "명령: %s"
 
-#: src/amuleDlg.cpp:1632 src/muuli_wdr.cpp:1982 src/Preferences.cpp:979
+#: src/amuleDlg.cpp:1632 src/muuli_wdr.cpp:1986 src/Preferences.cpp:979
 msgid "- default -"
 msgstr ""
 
@@ -777,61 +777,61 @@ msgstr "외형 폴더 '%s'가 없습니다."
 msgid "WARNING: Unable to open skin file '%s' for read"
 msgstr ""
 
-#: src/amuleDlg.cpp:1791 src/muuli_wdr.cpp:3449
+#: src/amuleDlg.cpp:1814 src/muuli_wdr.cpp:3453
 msgid "Networks Window"
 msgstr "통신망 창"
 
-#: src/amuleDlg.cpp:1797 src/muuli_wdr.cpp:3450
+#: src/amuleDlg.cpp:1820 src/muuli_wdr.cpp:3454
 msgid "Searches Window"
 msgstr "검색 창"
 
-#: src/amuleDlg.cpp:1803 src/muuli_wdr.cpp:3451
+#: src/amuleDlg.cpp:1826 src/muuli_wdr.cpp:3455
 #, fuzzy
 msgid "Downloads Window"
 msgstr "받는중"
 
-#: src/amuleDlg.cpp:1809 src/muuli_wdr.cpp:3453
+#: src/amuleDlg.cpp:1832 src/muuli_wdr.cpp:3457
 msgid "Shared Files Window"
 msgstr "공유 파일 창"
 
-#: src/amuleDlg.cpp:1815 src/muuli_wdr.cpp:3454
+#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3458
 msgid "Messages Window"
 msgstr "메시지 창"
 
-#: src/amuleDlg.cpp:1821 src/muuli_wdr.cpp:3455
+#: src/amuleDlg.cpp:1844 src/muuli_wdr.cpp:3459
 msgid "Statistics Graph Window"
 msgstr "통계 그래프 창"
 
-#: src/amuleDlg.cpp:1828 src/muuli_wdr.cpp:3457
+#: src/amuleDlg.cpp:1851 src/muuli_wdr.cpp:3461
 msgid "Preferences Settings Window"
 msgstr "환경 설정 창"
 
-#: src/amuleDlg.cpp:1831 src/muuli_wdr.cpp:3458
+#: src/amuleDlg.cpp:1854 src/muuli_wdr.cpp:3462
 msgid "Import"
 msgstr "가져오기"
 
-#: src/amuleDlg.cpp:1835 src/muuli_wdr.cpp:3458
+#: src/amuleDlg.cpp:1858 src/muuli_wdr.cpp:3462
 msgid "The partfile importer tool"
 msgstr "부분파일 가져오기 도구"
 
-#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3459
+#: src/amuleDlg.cpp:1861 src/muuli_wdr.cpp:3463
 #: src/utils/aLinkCreator/src/alcframe.cpp:262
 msgid "About"
 msgstr "정보"
 
-#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3459
+#: src/amuleDlg.cpp:1861 src/muuli_wdr.cpp:3463
 msgid "About/Help"
 msgstr "정보/도움"
 
-#: src/amuleDlg.cpp:2036
+#: src/amuleDlg.cpp:2059
 msgid "eD2k network"
 msgstr ""
 
-#: src/amuleDlg.cpp:2039
+#: src/amuleDlg.cpp:2062
 msgid "Kad network"
 msgstr ""
 
-#: src/amuleDlg.cpp:2039
+#: src/amuleDlg.cpp:2062
 msgid "No network"
 msgstr ""
 
@@ -1368,19 +1368,19 @@ msgstr "자동[높음]"
 msgid "Very low"
 msgstr "매우 낮음"
 
-#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:743 src/muuli_wdr.cpp:2313
+#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:743 src/muuli_wdr.cpp:2317
 #: src/ServerListCtrl.cpp:263 src/ServerListCtrl.cpp:456
 #: src/SharedFilesCtrl.cpp:145
 msgid "Low"
 msgstr "낮음"
 
-#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:744 src/muuli_wdr.cpp:2314
+#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:744 src/muuli_wdr.cpp:2318
 #: src/ServerListCtrl.cpp:266 src/ServerListCtrl.cpp:457
 #: src/SharedFilesCtrl.cpp:146
 msgid "Normal"
 msgstr "보통"
 
-#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:745 src/muuli_wdr.cpp:2315
+#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:745 src/muuli_wdr.cpp:2319
 #: src/ServerListCtrl.cpp:269 src/ServerListCtrl.cpp:458
 #: src/SharedFilesCtrl.cpp:147
 msgid "High"
@@ -1472,7 +1472,7 @@ msgstr "지역 서버"
 msgid "Remote Server"
 msgstr "원격 서버"
 
-#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3212
+#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3216
 #: src/SearchDlg.cpp:119 src/TextClient.cpp:911
 msgid "Kad"
 msgstr "Kad"
@@ -1543,7 +1543,7 @@ msgstr ""
 msgid "Size"
 msgstr "크기"
 
-#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3279
+#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3283
 msgid "Transferred"
 msgstr "전송됨"
 
@@ -1601,7 +1601,7 @@ msgid ""
 "\n"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:746 src/muuli_wdr.cpp:2316
+#: src/DownloadListCtrl.cpp:746 src/muuli_wdr.cpp:2320
 #: src/SharedFilesCtrl.cpp:150
 msgid "Auto"
 msgstr "자동"
@@ -1639,7 +1639,7 @@ msgid "Extended Options"
 msgstr "확장 옵션"
 
 #: src/DownloadListCtrl.cpp:770 src/DownloadListCtrl.cpp:822
-#: src/muuli_wdr.cpp:1800
+#: src/muuli_wdr.cpp:1804
 msgid "Preview"
 msgstr "미리보기"
 
@@ -2443,23 +2443,23 @@ msgid ""
 "want downloads on a different (e.g. larger) disk."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:549 src/FirstRunWizard.cpp:611 src/muuli_wdr.cpp:1712
+#: src/FirstRunWizard.cpp:549 src/FirstRunWizard.cpp:611 src/muuli_wdr.cpp:1716
 msgid "Destination folder for downloads"
 msgstr ""
 
 #: src/FirstRunWizard.cpp:553 src/FirstRunWizard.cpp:569 src/muuli_wdr.cpp:1349
-#: src/muuli_wdr.cpp:1366 src/muuli_wdr.cpp:1687 src/muuli_wdr.cpp:1718
-#: src/muuli_wdr.cpp:1730 src/muuli_wdr.cpp:2800
+#: src/muuli_wdr.cpp:1366 src/muuli_wdr.cpp:1691 src/muuli_wdr.cpp:1722
+#: src/muuli_wdr.cpp:1734 src/muuli_wdr.cpp:2804
 #: src/utils/aLinkCreator/src/alcframe.cpp:135
 #: src/utils/wxCas/src/wxcasprefs.cpp:52 src/utils/wxCas/src/wxcasprefs.cpp:118
 msgid "Browse"
 msgstr "탐색"
 
-#: src/FirstRunWizard.cpp:559 src/muuli_wdr.cpp:1723
+#: src/FirstRunWizard.cpp:559 src/muuli_wdr.cpp:1727
 msgid "(All files in this folder are shared with other peers)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:565 src/FirstRunWizard.cpp:624 src/muuli_wdr.cpp:1725
+#: src/FirstRunWizard.cpp:565 src/FirstRunWizard.cpp:624 src/muuli_wdr.cpp:1729
 msgid "Folder for temporary download files"
 msgstr ""
 
@@ -2490,7 +2490,7 @@ msgstr ""
 msgid "CRITICAL - no client on StartChatSession"
 msgstr ""
 
-#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2706 src/muuli_wdr.cpp:3383
+#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2710 src/muuli_wdr.cpp:3387
 msgid "Friends"
 msgstr "친구"
 
@@ -2606,8 +2606,8 @@ msgstr "아무도"
 msgid "No"
 msgstr "아니오"
 
-#: src/GenericClientListCtrl.cpp:1216 src/PrefsUnifiedDlg.cpp:2898
-#: src/PrefsUnifiedDlg.cpp:2948 src/ServerListCtrl.cpp:276
+#: src/GenericClientListCtrl.cpp:1216 src/PrefsUnifiedDlg.cpp:2907
+#: src/PrefsUnifiedDlg.cpp:2957 src/ServerListCtrl.cpp:276
 msgid "Yes"
 msgstr "예"
 
@@ -2777,10 +2777,10 @@ msgstr "초기적재에 유효하지 않은 포트"
 msgid "Please fill all fields required"
 msgstr "모든 항목을 채워주세요."
 
-#: src/KadDlg.cpp:192 src/PartFile.cpp:1031 src/PrefsUnifiedDlg.cpp:1134
-#: src/PrefsUnifiedDlg.cpp:1204 src/PrefsUnifiedDlg.cpp:1405
-#: src/PrefsUnifiedDlg.cpp:1663 src/PrefsUnifiedDlg.cpp:1673
-#: src/PrefsUnifiedDlg.cpp:1690 src/PrefsUnifiedDlg.cpp:1738
+#: src/KadDlg.cpp:192 src/PartFile.cpp:1031 src/PrefsUnifiedDlg.cpp:1143
+#: src/PrefsUnifiedDlg.cpp:1213 src/PrefsUnifiedDlg.cpp:1414
+#: src/PrefsUnifiedDlg.cpp:1672 src/PrefsUnifiedDlg.cpp:1682
+#: src/PrefsUnifiedDlg.cpp:1699 src/PrefsUnifiedDlg.cpp:1747
 msgid "Message"
 msgstr "메시지"
 
@@ -2882,7 +2882,7 @@ msgstr ""
 msgid "Uploaded"
 msgstr ""
 
-#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3263
+#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3267
 msgid "Requested"
 msgstr ""
 
@@ -3008,7 +3008,7 @@ msgid "WARNING: "
 msgstr ""
 
 #: src/MuleNotebook.cpp:179 src/muuli_wdr.cpp:817 src/muuli_wdr.cpp:1229
-#: src/muuli_wdr.cpp:3167 src/muuli_wdr.cpp:3423
+#: src/muuli_wdr.cpp:3171 src/muuli_wdr.cpp:3427
 msgid "Close"
 msgstr "닫기"
 
@@ -3026,7 +3026,7 @@ msgid "Paste"
 msgstr "붙이기"
 
 #: src/MuleTextCtrl.cpp:89 src/muuli_wdr.cpp:358 src/muuli_wdr.cpp:757
-#: src/muuli_wdr.cpp:2390 src/muuli_wdr.cpp:2409 src/muuli_wdr.cpp:2431
+#: src/muuli_wdr.cpp:2394 src/muuli_wdr.cpp:2413 src/muuli_wdr.cpp:2435
 #: src/utils/aLinkCreator/src/alcframe.cpp:142
 msgid "Clear"
 msgstr "깨끗이"
@@ -3124,7 +3124,7 @@ msgstr "종료"
 
 #: src/MuleTrayIcon.cpp:579 src/MuleTrayIcon.cpp:945 src/MuleTrayIcon.cpp:965
 #: src/muuli_wdr.cpp:1398 src/muuli_wdr.cpp:1406 src/muuli_wdr.cpp:1413
-#: src/muuli_wdr.cpp:1846 src/muuli_wdr.cpp:1852 src/OtherFunctions.cpp:91
+#: src/muuli_wdr.cpp:1850 src/muuli_wdr.cpp:1856 src/OtherFunctions.cpp:91
 #: src/StatisticsDlg.cpp:93 src/StatisticsDlg.cpp:95
 msgid "kB/s"
 msgstr "kB/s"
@@ -3366,7 +3366,7 @@ msgstr "바이트"
 msgid "KB"
 msgstr "KB"
 
-#: src/muuli_wdr.cpp:274 src/muuli_wdr.cpp:293 src/muuli_wdr.cpp:1631
+#: src/muuli_wdr.cpp:274 src/muuli_wdr.cpp:293 src/muuli_wdr.cpp:1635
 #: src/OtherFunctions.cpp:64
 msgid "MB"
 msgstr "MB"
@@ -3383,7 +3383,7 @@ msgstr "최대 크기"
 msgid "Availability"
 msgstr "유효성"
 
-#: src/muuli_wdr.cpp:312 src/muuli_wdr.cpp:398 src/muuli_wdr.cpp:3328
+#: src/muuli_wdr.cpp:312 src/muuli_wdr.cpp:398 src/muuli_wdr.cpp:3332
 msgid "Filter:"
 msgstr "필터:"
 
@@ -3447,8 +3447,8 @@ msgstr "자료 유지"
 #: src/muuli_wdr.cpp:1160 src/muuli_wdr.cpp:1167 src/muuli_wdr.cpp:1172
 #: src/muuli_wdr.cpp:1179 src/muuli_wdr.cpp:1184 src/muuli_wdr.cpp:1191
 #: src/muuli_wdr.cpp:1205 src/muuli_wdr.cpp:1212 src/muuli_wdr.cpp:1217
-#: src/muuli_wdr.cpp:1224 src/muuli_wdr.cpp:3265 src/muuli_wdr.cpp:3273
-#: src/muuli_wdr.cpp:3281
+#: src/muuli_wdr.cpp:1224 src/muuli_wdr.cpp:3269 src/muuli_wdr.cpp:3277
+#: src/muuli_wdr.cpp:3285
 msgid "N/A"
 msgstr "없음"
 
@@ -3593,7 +3593,7 @@ msgstr ""
 msgid "Album :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:685 src/muuli_wdr.cpp:2285
+#: src/muuli_wdr.cpp:685 src/muuli_wdr.cpp:2289
 msgid "Title :"
 msgstr "제목 :"
 
@@ -3700,7 +3700,7 @@ msgstr "사용자 이름 :"
 msgid "Userhash :"
 msgstr "사용자 해시 :"
 
-#: src/muuli_wdr.cpp:895 src/muuli_wdr.cpp:1752 src/muuli_wdr.cpp:2480
+#: src/muuli_wdr.cpp:895 src/muuli_wdr.cpp:1756 src/muuli_wdr.cpp:2484
 #: src/utils/aLinkCreator/src/alcframe.cpp:137
 msgid "Add"
 msgstr "추가"
@@ -3709,15 +3709,15 @@ msgstr "추가"
 msgid "Download-Speed"
 msgstr "내려받기 속도"
 
-#: src/muuli_wdr.cpp:954 src/muuli_wdr.cpp:989 src/muuli_wdr.cpp:2584
+#: src/muuli_wdr.cpp:954 src/muuli_wdr.cpp:989 src/muuli_wdr.cpp:2588
 msgid "Current"
 msgstr "현재"
 
-#: src/muuli_wdr.cpp:962 src/muuli_wdr.cpp:997 src/muuli_wdr.cpp:2592
+#: src/muuli_wdr.cpp:962 src/muuli_wdr.cpp:997 src/muuli_wdr.cpp:2596
 msgid "Running average"
 msgstr "동작중 평균"
 
-#: src/muuli_wdr.cpp:970 src/muuli_wdr.cpp:1005 src/muuli_wdr.cpp:2600
+#: src/muuli_wdr.cpp:970 src/muuli_wdr.cpp:1005 src/muuli_wdr.cpp:2604
 msgid "Session average"
 msgstr "세션 평균"
 
@@ -3729,7 +3729,7 @@ msgstr "올려주기 속도"
 msgid "Connections"
 msgstr "연결"
 
-#: src/muuli_wdr.cpp:1024 src/muuli_wdr.cpp:1871
+#: src/muuli_wdr.cpp:1024 src/muuli_wdr.cpp:1875
 msgid "Active downloads"
 msgstr "활성화된 내려받기"
 
@@ -3737,7 +3737,7 @@ msgstr "활성화된 내려받기"
 msgid "Active connections (1:1)"
 msgstr "활성화된 연결 (1:1)"
 
-#: src/muuli_wdr.cpp:1040 src/muuli_wdr.cpp:1872
+#: src/muuli_wdr.cpp:1040 src/muuli_wdr.cpp:1876
 msgid "Active uploads"
 msgstr "활성화된 올려주기"
 
@@ -4014,7 +4014,7 @@ msgstr ""
 msgid "Advanced users only: If you have multiple network interfaces, enter the address of the interface to which aMule should be bound."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1462 src/muuli_wdr.cpp:2065
+#: src/muuli_wdr.cpp:1462 src/muuli_wdr.cpp:2069
 msgid "Bind to network interface (empty for any):"
 msgstr ""
 
@@ -4030,7 +4030,7 @@ msgstr ""
 msgid "Max simultaneous connections:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1498 src/muuli_wdr.cpp:3207
+#: src/muuli_wdr.cpp:1498 src/muuli_wdr.cpp:3211
 msgid "ED2K"
 msgstr "ED2k"
 
@@ -4122,779 +4122,779 @@ msgstr ""
 msgid "For new files preallocates disk space for the whole file, thus reduces fragmentation"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1617
+#: src/muuli_wdr.cpp:1621
 msgid "Create new files as sparse files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1618
+#: src/muuli_wdr.cpp:1622
 msgid "Sparse part files only occupy disk space for the parts already downloaded, so free space is used up gradually as the file fills in. Turn this off to use an ordinary file instead - useful where sparse files are unsupported or slow, or where backup/de-duplication tools handle them badly. Applies only when the core runs on Windows; on Linux and macOS part files are sparse anyway and this setting has no effect."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1623
+#: src/muuli_wdr.cpp:1627
 msgid "Stop downloads when free disk space reaches "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1624
+#: src/muuli_wdr.cpp:1628
 msgid "Select this if you want aMule to check your disk space"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1628
+#: src/muuli_wdr.cpp:1632
 msgid "Enter here the min disk space desired."
 msgstr "원하는 최소한의 디스크공간을 입력하세요."
 
-#: src/muuli_wdr.cpp:1634
+#: src/muuli_wdr.cpp:1638
 msgid "Save 10 sources on rare files (< 20 sources)"
 msgstr "희귀한 파일인 경우 10개의 자료 저장 (<20 자료)"
 
-#: src/muuli_wdr.cpp:1638 src/Statistics.cpp:790
+#: src/muuli_wdr.cpp:1642 src/Statistics.cpp:790
 msgid "Uploads"
 msgstr "올려주기"
 
-#: src/muuli_wdr.cpp:1641
+#: src/muuli_wdr.cpp:1645
 msgid "Add new shared files with auto priority"
 msgstr "자동 우선권으로 새로운 공유파일을 추가"
 
-#: src/muuli_wdr.cpp:1647
+#: src/muuli_wdr.cpp:1651
 msgid "Intelligent Corruption Handling (I.C.H.)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1650
+#: src/muuli_wdr.cpp:1654
 msgid "Enable"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1653
+#: src/muuli_wdr.cpp:1657
 msgid "Advanced I.C.H. trusts every hash (not recommended)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1665 src/PrefsUnifiedDlg.cpp:1990
+#: src/muuli_wdr.cpp:1669 src/PrefsUnifiedDlg.cpp:1999
 msgid "Media metadata extraction"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1669
+#: src/muuli_wdr.cpp:1673
 msgid "Extract length / bitrate / codec from shared audio and video files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1671
+#: src/muuli_wdr.cpp:1675
 msgid "When enabled, aMule runs ffprobe on each shared media file to fill in the Length / Bitrate / Codec columns other clients see when they find the file in a search. Requires ffmpeg (the ffprobe binary) to be installed."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1678
+#: src/muuli_wdr.cpp:1682
 msgid "Path to ffprobe:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1683
+#: src/muuli_wdr.cpp:1687
 msgid "Full path to the ffprobe binary. Leave empty to have aMule auto-detect it on startup."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1691
+#: src/muuli_wdr.cpp:1695
 msgid "Detect"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1692
+#: src/muuli_wdr.cpp:1696
 msgid "Search the standard install locations for an ffprobe binary and fill the path field."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1716
+#: src/muuli_wdr.cpp:1720
 msgid ""
 "Completed downloads are stored here. All files in this folder are automatically shared with other peers.\n"
 "If this folder also holds files you don't want to share, point it at an aMule-only sub-folder."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1719
+#: src/muuli_wdr.cpp:1723
 msgid "Pick the folder where completed downloads will be stored. All files in that folder will be shared with other peers."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1733
+#: src/muuli_wdr.cpp:1737
 msgid "Shared folders"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1739
+#: src/muuli_wdr.cpp:1743
 msgid "(Folders shared by the core. Enter a path to add one.)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1747
+#: src/muuli_wdr.cpp:1751
 msgid "Absolute path of a folder on the core's machine, e.g. /home/user/shared"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1749 src/PrefsUnifiedDlg.cpp:2874
+#: src/muuli_wdr.cpp:1753 src/PrefsUnifiedDlg.cpp:2883
 msgid "Recursive"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1750
+#: src/muuli_wdr.cpp:1754
 msgid "Share every sub-folder underneath this one, including ones created later."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1754 src/utils/aLinkCreator/src/alcframe.cpp:141
+#: src/muuli_wdr.cpp:1758 src/utils/aLinkCreator/src/alcframe.cpp:141
 msgid "Remove"
 msgstr "삭제"
 
-#: src/muuli_wdr.cpp:1758
+#: src/muuli_wdr.cpp:1762
 msgid "(Right click on folder icon for recursive share)"
 msgstr "(하위폴더 전체를 공유하려면 폴더 아이콘상에서 오른쪽 버튼을 클릭)"
 
-#: src/muuli_wdr.cpp:1765
+#: src/muuli_wdr.cpp:1769
 msgid "Share hidden files"
 msgstr "숨은파일 공유"
 
-#: src/muuli_wdr.cpp:1771
+#: src/muuli_wdr.cpp:1775
 msgid "Automatically rescan shared folders for changes"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1777
+#: src/muuli_wdr.cpp:1781
 msgid "Follow symbolic links in shared folders"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1783
+#: src/muuli_wdr.cpp:1787
 msgid "Exclude files matching:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1786
+#: src/muuli_wdr.cpp:1790
 msgid "Wildcard patterns separated by '|', e.g. .DS_Store|Thumbs.db|*.tmp. Files whose name matches are not shared. Matching is case-insensitive."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1790
+#: src/muuli_wdr.cpp:1794
 msgid "Patterns are regular expressions"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1791
+#: src/muuli_wdr.cpp:1795
 msgid "When set, the whole field is one regular expression ('|' is alternation). When unset, it is a list of '|'-separated wildcards."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1801
+#: src/muuli_wdr.cpp:1805
 msgid "Show how many shared files the current pattern would exclude."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1822
+#: src/muuli_wdr.cpp:1826
 msgid "Graphs"
 msgstr "그래프"
 
-#: src/muuli_wdr.cpp:1825 src/muuli_wdr.cpp:1887
+#: src/muuli_wdr.cpp:1829 src/muuli_wdr.cpp:1891
 msgid "Update delay : 5 secs"
 msgstr "갱신 지연 : 5 초"
 
-#: src/muuli_wdr.cpp:1829
+#: src/muuli_wdr.cpp:1833
 msgid "Time for average graph: 100 mins"
 msgstr "평균 그래프 시간 : 100 분"
 
-#: src/muuli_wdr.cpp:1833
+#: src/muuli_wdr.cpp:1837
 msgid "Connections Graph Scale: 100 "
 msgstr "연결 그래프 크기 : 100"
 
-#: src/muuli_wdr.cpp:1840
+#: src/muuli_wdr.cpp:1844
 msgid "Download graph scale:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1848
+#: src/muuli_wdr.cpp:1852
 msgid "Upload graph scale:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1858
+#: src/muuli_wdr.cpp:1862
 msgid "Colors: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1862
+#: src/muuli_wdr.cpp:1866
 msgid "Background"
 msgstr "바탕"
 
-#: src/muuli_wdr.cpp:1863
+#: src/muuli_wdr.cpp:1867
 msgid "Grid"
 msgstr "눈금"
 
-#: src/muuli_wdr.cpp:1864
+#: src/muuli_wdr.cpp:1868
 msgid "Download current"
 msgstr "현재 내려받기"
 
-#: src/muuli_wdr.cpp:1865
+#: src/muuli_wdr.cpp:1869
 msgid "Download running average"
 msgstr "내려받기 운용 평균"
 
-#: src/muuli_wdr.cpp:1866
+#: src/muuli_wdr.cpp:1870
 msgid "Download session average"
 msgstr "내려받기 세션 평균"
 
-#: src/muuli_wdr.cpp:1867
+#: src/muuli_wdr.cpp:1871
 msgid "Upload current"
 msgstr "현재 올려주기"
 
-#: src/muuli_wdr.cpp:1868
+#: src/muuli_wdr.cpp:1872
 msgid "Upload running average"
 msgstr "올려주기 운용 평균"
 
-#: src/muuli_wdr.cpp:1869
+#: src/muuli_wdr.cpp:1873
 msgid "Upload session average"
 msgstr "올려주기 세션 평균"
 
-#: src/muuli_wdr.cpp:1870
+#: src/muuli_wdr.cpp:1874
 msgid "Active connections"
 msgstr "활성화된 연결"
 
-#: src/muuli_wdr.cpp:1873
+#: src/muuli_wdr.cpp:1877
 #, fuzzy
 msgid "Systray Icon Speed Bar"
 msgstr "시스템트레이 아이콘 속도바"
 
-#: src/muuli_wdr.cpp:1874
+#: src/muuli_wdr.cpp:1878
 msgid "Kad-nodes current"
 msgstr "현재 Kad-노드"
 
-#: src/muuli_wdr.cpp:1875
+#: src/muuli_wdr.cpp:1879
 msgid "Kad-nodes running"
 msgstr "Kad-노드 운용"
 
-#: src/muuli_wdr.cpp:1876
+#: src/muuli_wdr.cpp:1880
 msgid "Kad-nodes session"
 msgstr "Kad-노드 세션"
 
-#: src/muuli_wdr.cpp:1880 src/muuli_wdr.cpp:2334
+#: src/muuli_wdr.cpp:1884 src/muuli_wdr.cpp:2338
 msgid "Select"
 msgstr "선택"
 
-#: src/muuli_wdr.cpp:1884
+#: src/muuli_wdr.cpp:1888
 msgid "Tree"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1894
+#: src/muuli_wdr.cpp:1898
 msgid "Number of Client Versions shown (0=unlimited)"
 msgstr "표시될 클라이언트 버젼의 수 (0=무제한)"
 
-#: src/muuli_wdr.cpp:1919
+#: src/muuli_wdr.cpp:1923
 msgid "!!! WARNING !!!"
 msgstr "!!! 경고 !!!"
 
-#: src/muuli_wdr.cpp:1934
+#: src/muuli_wdr.cpp:1938
 msgid "Max new connections / 5 secs"
 msgstr "최대 새연결 / 5 초"
 
-#: src/muuli_wdr.cpp:1936
+#: src/muuli_wdr.cpp:1940
 msgid "Concurrent Kad source lookups"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1938
+#: src/muuli_wdr.cpp:1942
 #, fuzzy
 msgid "Kad source re-search interval (minutes)"
 msgstr "FTP 갱신율 분당 간격"
 
-#: src/muuli_wdr.cpp:1940
+#: src/muuli_wdr.cpp:1944
 #, fuzzy
 msgid "Source re-ask interval (minutes)"
 msgstr "FTP 갱신율 분당 간격"
 
-#: src/muuli_wdr.cpp:1944
+#: src/muuli_wdr.cpp:1948
 msgid "File Buffer Size: 240000 bytes"
 msgstr "파일 버퍼 크기: 240000 바이트"
 
-#: src/muuli_wdr.cpp:1948
+#: src/muuli_wdr.cpp:1952
 msgid "Use MMAP: memory-mapped file access (lower memory use)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1949
+#: src/muuli_wdr.cpp:1953
 msgid "Maps part files into memory instead of buffering them on the heap, lowering the process memory footprint. May reduce download speed on some disks; best for memory-constrained or upload-heavy hosts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1951
+#: src/muuli_wdr.cpp:1955
 msgid "Upload Queue Size: 5000 clients"
 msgstr "올려주기 대기열 크기: 5000 클라이언트"
 
-#: src/muuli_wdr.cpp:1955
+#: src/muuli_wdr.cpp:1959
 msgid "Server connection refresh interval: Disable"
 msgstr "서버 연결 갱신 간격: 사용않함"
 
-#: src/muuli_wdr.cpp:1959
+#: src/muuli_wdr.cpp:1963
 msgid "Disable computer's timed standby mode"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1978
+#: src/muuli_wdr.cpp:1982
 msgid "Skin to use: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1987
+#: src/muuli_wdr.cpp:1991
 msgid "Show \"Fast eD2k Links Handler\" in every window."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1990
+#: src/muuli_wdr.cpp:1994
 msgid "Show extended info on categories tabs"
 msgstr "분류탭의 확장된 정보를 보여줌"
 
-#: src/muuli_wdr.cpp:1993
+#: src/muuli_wdr.cpp:1997
 #, fuzzy
 msgid "Show application version on title"
 msgstr "제목에 전송률을 보여줌"
 
-#: src/muuli_wdr.cpp:1995
+#: src/muuli_wdr.cpp:1999
 msgid "Show transfer rates on title"
 msgstr "제목에 전송률을 보여줌"
 
-#: src/muuli_wdr.cpp:1997
+#: src/muuli_wdr.cpp:2001
 msgid "Before application name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1999
+#: src/muuli_wdr.cpp:2003
 msgid "After application name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2002
+#: src/muuli_wdr.cpp:2006
 msgid "Show overhead bandwidth"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2006
+#: src/muuli_wdr.cpp:2010
 msgid "Vertical toolbar orientation"
 msgstr "수직방향 툴바"
 
-#: src/muuli_wdr.cpp:2008
+#: src/muuli_wdr.cpp:2012
 msgid "Live column sorting (auto-reorder rows as their values change)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2015
+#: src/muuli_wdr.cpp:2019
 msgid "Download Queue Files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2018
+#: src/muuli_wdr.cpp:2022
 msgid "Show progress percentage"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2024
+#: src/muuli_wdr.cpp:2028
 msgid "Show progress bar"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2027
+#: src/muuli_wdr.cpp:2031
 msgid "Flat"
 msgstr "평평한"
 
-#: src/muuli_wdr.cpp:2031
+#: src/muuli_wdr.cpp:2035
 msgid "Round"
 msgstr "둥근"
 
-#: src/muuli_wdr.cpp:2049
+#: src/muuli_wdr.cpp:2053
 msgid "External Connection Parameters"
 msgstr "외부연결 설정"
 
-#: src/muuli_wdr.cpp:2052
+#: src/muuli_wdr.cpp:2056
 msgid "Accept external connections"
 msgstr "외부연결 받아들임"
 
-#: src/muuli_wdr.cpp:2059 src/muuli_wdr.cpp:2118
+#: src/muuli_wdr.cpp:2063 src/muuli_wdr.cpp:2122
 msgid "IP of the listening interface:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2062
+#: src/muuli_wdr.cpp:2066
 msgid "Enter here a valid ip in the a.b.c.d format for the listening EC interface. An empty field or 0.0.0.0 will mean any interface."
 msgstr "수신대기 외부연결 인터페이스에 a.b.c.d 형식의 유효한 IP를 입력하세요. 항목이 비었거나 0.0.0.0이면 모든 인터페이스를 의미합니다."
 
-#: src/muuli_wdr.cpp:2083 src/muuli_wdr.cpp:2194
+#: src/muuli_wdr.cpp:2087 src/muuli_wdr.cpp:2198
 msgid "TCP port:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2089
+#: src/muuli_wdr.cpp:2093
 msgid "Enable UPnP port forwarding on the EC port"
 msgstr "외부연결 포트에 UPnP 포트포워딩 활성화"
 
-#: src/muuli_wdr.cpp:2093 src/muuli_wdr.cpp:3079
+#: src/muuli_wdr.cpp:2097 src/muuli_wdr.cpp:3083
 #: src/utils/wxCas/src/wxcasprefs.cpp:167
 msgid "Password"
 msgstr "암호"
 
-#: src/muuli_wdr.cpp:2099
+#: src/muuli_wdr.cpp:2103
 msgid "aMule API server parameters"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2102
+#: src/muuli_wdr.cpp:2106
 msgid "Run amuleapi (REST API) on startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2107
+#: src/muuli_wdr.cpp:2111
 #, fuzzy
 msgid "HTTP port:"
 msgstr "프록시 포트:"
 
-#: src/muuli_wdr.cpp:2121
+#: src/muuli_wdr.cpp:2125
 msgid "The interface amuleapi's HTTP server listens on. 127.0.0.1 (default) accepts only local connections; use 0.0.0.0 or a specific IP to expose it to other hosts (set an admin password below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2126
+#: src/muuli_wdr.cpp:2130
 msgid "Type a password to set or change it. Stored passwords cannot be shown, so leaving this empty keeps the current one."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2128
+#: src/muuli_wdr.cpp:2132
 #, fuzzy
 msgid "Admin password"
 msgstr "암호를 검사중\n"
 
-#: src/muuli_wdr.cpp:2140 src/muuli_wdr.cpp:2157 src/PrefsUnifiedDlg.cpp:1103
+#: src/muuli_wdr.cpp:2144 src/muuli_wdr.cpp:2161 src/PrefsUnifiedDlg.cpp:1112
 #, fuzzy
 msgid "A password is set."
 msgstr "암호를 검사중\n"
 
-#: src/muuli_wdr.cpp:2144
+#: src/muuli_wdr.cpp:2148
 #, fuzzy
 msgid "Enable guest access"
 msgstr "손님 접근 금지"
 
-#: src/muuli_wdr.cpp:2145
+#: src/muuli_wdr.cpp:2149
 msgid "Guest sessions may read status and listings but cannot change anything. Turning this off clears the stored guest password."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2149
+#: src/muuli_wdr.cpp:2153
 #, fuzzy
 msgid "Guest password"
 msgstr "모든 권한 암호"
 
-#: src/muuli_wdr.cpp:2164
+#: src/muuli_wdr.cpp:2168
 msgid "Web server parameters"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2167
+#: src/muuli_wdr.cpp:2171
 msgid "Run webserver on startup (deprecated)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2173
+#: src/muuli_wdr.cpp:2177
 msgid "Web template"
 msgstr "웹 템플릿"
 
-#: src/muuli_wdr.cpp:2178
+#: src/muuli_wdr.cpp:2182
 msgid "Full rights password"
 msgstr "모든 권한 암호"
 
-#: src/muuli_wdr.cpp:2182
+#: src/muuli_wdr.cpp:2186
 msgid "Enable Low rights User"
 msgstr "낮은권한 사용자 활성화"
 
-#: src/muuli_wdr.cpp:2187
+#: src/muuli_wdr.cpp:2191
 msgid "Low rights password"
 msgstr "낮은 권한 암호"
 
-#: src/muuli_wdr.cpp:2201
+#: src/muuli_wdr.cpp:2205
 msgid "Enable UPnP port forwarding of the web server port"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2206
+#: src/muuli_wdr.cpp:2210
 msgid "Web server UPnP TCP port (Optional)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2214
+#: src/muuli_wdr.cpp:2218
 msgid "Page Refresh Time (in secs)"
 msgstr "페이지를 갱신 시간 (초)"
 
-#: src/muuli_wdr.cpp:2221
+#: src/muuli_wdr.cpp:2225
 msgid "Enable Gzip compression"
 msgstr "Gzip압축을 활성화"
 
-#: src/muuli_wdr.cpp:2255
+#: src/muuli_wdr.cpp:2259
 #, fuzzy
 msgid "Reset page to defaults"
 msgstr "기본 설정"
 
-#: src/muuli_wdr.cpp:2256
+#: src/muuli_wdr.cpp:2260
 msgid "Reset the settings on the current page to their default values."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2258 src/muuli_wdr.cpp:2344 src/ServerWnd.cpp:274
+#: src/muuli_wdr.cpp:2262 src/muuli_wdr.cpp:2348 src/ServerWnd.cpp:274
 #: src/ServerWnd.cpp:282
 msgid "OK"
 msgstr "확인"
 
-#: src/muuli_wdr.cpp:2260
+#: src/muuli_wdr.cpp:2264
 msgid "Click here to apply any changes made to the preferences."
 msgstr "환경설정으로 바꾼것을 적용하려면 이곳을 클릭하세요."
 
-#: src/muuli_wdr.cpp:2263
+#: src/muuli_wdr.cpp:2267
 msgid "Reset any changes made to the preferences."
 msgstr "환경설정으로 바꾼것을 초기화합니다."
 
-#: src/muuli_wdr.cpp:2292
+#: src/muuli_wdr.cpp:2296
 msgid "Comment :"
 msgstr "의견 :"
 
-#: src/muuli_wdr.cpp:2299
+#: src/muuli_wdr.cpp:2303
 msgid "Incoming Dir :"
 msgstr "내려받는 폴더 :"
 
-#: src/muuli_wdr.cpp:2308
+#: src/muuli_wdr.cpp:2312
 msgid "Change priority for new assigned files :"
 msgstr "새롭게 할당된 파일의 우선권를 바꿉니다. :"
 
-#: src/muuli_wdr.cpp:2312
+#: src/muuli_wdr.cpp:2316
 #, fuzzy
 msgid "Don't change"
 msgstr "변경 않음"
 
-#: src/muuli_wdr.cpp:2324
+#: src/muuli_wdr.cpp:2328
 msgid "Select color for this Category (currently selected) :"
 msgstr "이 분류의 색을 선택 (일반적으로 선택된) :"
 
-#: src/muuli_wdr.cpp:2391 src/muuli_wdr.cpp:2410 src/muuli_wdr.cpp:2432
+#: src/muuli_wdr.cpp:2395 src/muuli_wdr.cpp:2414 src/muuli_wdr.cpp:2436
 msgid "Click this button to reset the log."
 msgstr "로그를 초기화하려면 이 버튼을 클릭하세요."
 
-#: src/muuli_wdr.cpp:2451
+#: src/muuli_wdr.cpp:2455
 msgid "Click on this button to update the servers list from URL ..."
 msgstr "URL로부터 서버 목록을 갱신하려면 이 버튼을 클릭..."
 
-#: src/muuli_wdr.cpp:2455
+#: src/muuli_wdr.cpp:2459
 msgid "Server list"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2459
+#: src/muuli_wdr.cpp:2463
 msgid "Enter the url to a server.met file here and press the button to the left to update the list of known servers."
 msgstr "알려진 서버의 목록을 갱신하기 위해서는 이곳에 server.met파일의 url을 입력하고 왼쪽편의 버튼을 누르세요."
 
-#: src/muuli_wdr.cpp:2464
+#: src/muuli_wdr.cpp:2468
 msgid "Add server manually: Name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2467
+#: src/muuli_wdr.cpp:2471
 msgid "Enter the name of the new server here"
 msgstr "새로운 서버의 이름을 입력하세요."
 
-#: src/muuli_wdr.cpp:2469 src/ServerWnd.cpp:206
+#: src/muuli_wdr.cpp:2473 src/ServerWnd.cpp:206
 msgid "IP:Port"
 msgstr "IP:포트"
 
-#: src/muuli_wdr.cpp:2472
+#: src/muuli_wdr.cpp:2476
 msgid "Enter the IP of the server here, using the x.x.x.x format."
 msgstr "x.x.x.x형식으로 서버의 IP를 이곳에 입력하세요."
 
-#: src/muuli_wdr.cpp:2478
+#: src/muuli_wdr.cpp:2482
 msgid "Enter the port of the server here."
 msgstr "서버의 포트를 이곳에 입력하세요."
 
-#: src/muuli_wdr.cpp:2481
+#: src/muuli_wdr.cpp:2485
 msgid "Add manually a server (fill fields to the left before) ..."
 msgstr "서버 수동 추가 (미리 왼쪽 부분을 채울 것) ..."
 
-#: src/muuli_wdr.cpp:2510
+#: src/muuli_wdr.cpp:2514
 msgid "aMule Log"
 msgstr "어뮬 로그"
 
-#: src/muuli_wdr.cpp:2518
+#: src/muuli_wdr.cpp:2522
 msgid "Server Info"
 msgstr "서버 정보"
 
-#: src/muuli_wdr.cpp:2522
+#: src/muuli_wdr.cpp:2526
 msgid "ED2K Info"
 msgstr "ED2k 정보"
 
-#: src/muuli_wdr.cpp:2526
+#: src/muuli_wdr.cpp:2530
 msgid "Kad Info"
 msgstr "Kad 정보"
 
-#: src/muuli_wdr.cpp:2554
+#: src/muuli_wdr.cpp:2558
 msgid "Click on this button to update the nodes list from URL ..."
 msgstr "URL로부터 노드를 갱신하려면 이 버튼을 클릭..."
 
-#: src/muuli_wdr.cpp:2558
+#: src/muuli_wdr.cpp:2562
 msgid "Nodes (0)"
 msgstr "노드 (0)"
 
-#: src/muuli_wdr.cpp:2562
+#: src/muuli_wdr.cpp:2566
 msgid "Enter the url to a nodes.dat file here and press the button to the left to update the list of known nodes."
 msgstr "알려진 노드의 목록을 갱신하기 위해서는 이곳에 nodes.dat파일의 url을 입력하고 왼쪽편의 버튼을 누르세요."
 
-#: src/muuli_wdr.cpp:2565
+#: src/muuli_wdr.cpp:2569
 msgid "Nodes stats"
 msgstr "노드 상태"
 
-#: src/muuli_wdr.cpp:2607
+#: src/muuli_wdr.cpp:2611
 msgid "Bootstrap"
 msgstr "초기적재"
 
-#: src/muuli_wdr.cpp:2610
+#: src/muuli_wdr.cpp:2614
 msgid "New node"
 msgstr "새로운 노드"
 
-#: src/muuli_wdr.cpp:2615
+#: src/muuli_wdr.cpp:2619
 msgid "IP:"
 msgstr "IP:"
 
-#: src/muuli_wdr.cpp:2635
+#: src/muuli_wdr.cpp:2639
 msgid "Port:"
 msgstr "포트:"
 
-#: src/muuli_wdr.cpp:2648
+#: src/muuli_wdr.cpp:2652
 #, fuzzy
 msgid "Bootstrap from known clients"
 msgstr ""
 "알려진 클라이언트로부터 \n"
 "초기적재"
 
-#: src/muuli_wdr.cpp:2650
+#: src/muuli_wdr.cpp:2654
 msgid "Disconnect Kad"
 msgstr "Kad 끊김"
 
-#: src/muuli_wdr.cpp:2684
+#: src/muuli_wdr.cpp:2688
 msgid "Use Secure User Identification"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2686
+#: src/muuli_wdr.cpp:2690
 msgid "It is recommended to enable this option. You will not receive credits if SUI is not enabled."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2688
+#: src/muuli_wdr.cpp:2692
 msgid "Protocol Obfuscation"
 msgstr "프로토콜 난독화"
 
-#: src/muuli_wdr.cpp:2691
+#: src/muuli_wdr.cpp:2695
 msgid "Support Protocol Obfuscation"
 msgstr "프로토콜 난독화 지원"
 
-#: src/muuli_wdr.cpp:2693
+#: src/muuli_wdr.cpp:2697
 msgid "This option enabled Protocol Obfuscation, and makes aMule accept obfuscated connections from other clients."
 msgstr "이 선택은 프로토콜 난독화를 활성화하며, 어뮬이 다른 클라이언트로부터 난독화된 연결을 받아들이도록 합니다. "
 
-#: src/muuli_wdr.cpp:2695
+#: src/muuli_wdr.cpp:2699
 msgid "Use obfuscation for outgoing connections"
 msgstr "나가는 연결에 난독화 사용"
 
-#: src/muuli_wdr.cpp:2697
+#: src/muuli_wdr.cpp:2701
 msgid "This option makes aMule use Protocol Obfuscation when connecting other clients/servers."
 msgstr "이 선택은 어뮬이 다른 서버나 클라이언트에 연결할때 프로토콜 난독화를 사용하게 합니다."
 
-#: src/muuli_wdr.cpp:2699
+#: src/muuli_wdr.cpp:2703
 msgid "Accept only obfuscated connections"
 msgstr "난독화된 연결만 받음"
 
-#: src/muuli_wdr.cpp:2700
+#: src/muuli_wdr.cpp:2704
 msgid "This option makes aMule only accept obfuscated connections. You will have less sources, but all your traffic will be obfuscated"
 msgstr "이 선택은 어뮬이 난독화된 연결만 받아들이도록 합니다. 더 작은 자료를 가지지만 자료교환은 난독화됩니다."
 
-#: src/muuli_wdr.cpp:2705
+#: src/muuli_wdr.cpp:2709
 msgid "Everybody"
 msgstr "모두"
 
-#: src/muuli_wdr.cpp:2707
+#: src/muuli_wdr.cpp:2711
 msgid "No one"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2709
+#: src/muuli_wdr.cpp:2713
 msgid "Who can see my shared files:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2710
+#: src/muuli_wdr.cpp:2714
 msgid "Select who can request to view a list of your shared files."
 msgstr "공유 파일 목록 보기를 요청할 수 있는 사람을 선택하세요."
 
-#: src/muuli_wdr.cpp:2712
+#: src/muuli_wdr.cpp:2716
 msgid "IP-Filtering"
 msgstr "IP 차단"
 
-#: src/muuli_wdr.cpp:2719
+#: src/muuli_wdr.cpp:2723
 msgid "Filter clients"
 msgstr "클라이언트 차단"
 
-#: src/muuli_wdr.cpp:2721
+#: src/muuli_wdr.cpp:2725
 msgid "Enable filtering of the client IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "~/.aMule/ipfilter.dat에 기록된 클라이언트 IP의 차단을 활성화합니다."
 
-#: src/muuli_wdr.cpp:2723
+#: src/muuli_wdr.cpp:2727
 msgid "Filter servers"
 msgstr "서버 차단"
 
-#: src/muuli_wdr.cpp:2725
+#: src/muuli_wdr.cpp:2729
 msgid "Enable filtering of the server IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "~/.aMule/ipfilter.dat에 기록된 서버 IP의 차단을 활성화합니다."
 
-#: src/muuli_wdr.cpp:2729
+#: src/muuli_wdr.cpp:2733
 msgid "Reload List"
 msgstr "목록 다시읽기"
 
-#: src/muuli_wdr.cpp:2730
+#: src/muuli_wdr.cpp:2734
 msgid "Reload the list of IPs to filter from the file ~/.aMule/ipfilter.dat"
 msgstr "~/.aMule/ipfilter.dat 파일에서 차단할 IP의 목록을 다시 읽음"
 
-#: src/muuli_wdr.cpp:2736
+#: src/muuli_wdr.cpp:2740
 msgid "URL:"
 msgstr "URL:"
 
-#: src/muuli_wdr.cpp:2740 src/muuli_wdr.cpp:2933
+#: src/muuli_wdr.cpp:2744 src/muuli_wdr.cpp:2937
 msgid "Update now"
 msgstr "지금 갱신"
 
-#: src/muuli_wdr.cpp:2743
+#: src/muuli_wdr.cpp:2747
 msgid "Auto-update ipfilter at startup"
 msgstr "시작시 IP차단을 자동 갱신"
 
-#: src/muuli_wdr.cpp:2747
+#: src/muuli_wdr.cpp:2751
 msgid "Filtering Level:"
 msgstr "차단 수준:"
 
-#: src/muuli_wdr.cpp:2753
+#: src/muuli_wdr.cpp:2757
 msgid "Always filter LAN IPs"
 msgstr "랜 IP를 항상 차단"
 
-#: src/muuli_wdr.cpp:2756
+#: src/muuli_wdr.cpp:2760
 msgid "Paranoid handling of non-matching IPs"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2758
+#: src/muuli_wdr.cpp:2762
 msgid "Rejects a packet when its source IP differs from the IP the client claims (an anti-spoofing check). Disable only if it causes connection problems."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2760
+#: src/muuli_wdr.cpp:2764
 msgid "Use system-wide ipfilter.dat if available"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2761
+#: src/muuli_wdr.cpp:2765
 msgid "If there's no local ipfilter.dat found, allow usage of a system-wide ipfilter file."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2778
+#: src/muuli_wdr.cpp:2782
 msgid "Enable Online-Signature"
 msgstr "온라인서명을 활성화"
 
-#: src/muuli_wdr.cpp:2780
+#: src/muuli_wdr.cpp:2784
 msgid "Enables the writing of the OS file, which can be used by external apps to create signatures and the like."
 msgstr "서명을 생성할 수 있는 외부 응용프로그램에 의해 사용될 수 있는 운영체제 파일의 기록을 활성화합니다."
 
-#: src/muuli_wdr.cpp:2784
+#: src/muuli_wdr.cpp:2788
 msgid "Update Frequency (Secs):"
 msgstr "갱신 주기(초)"
 
-#: src/muuli_wdr.cpp:2787
+#: src/muuli_wdr.cpp:2791
 msgid "Change the frequency (in seconds) of Online Signature updates."
 msgstr "온라인 서명 갱신 주기(초)를 바꿉니다."
 
-#: src/muuli_wdr.cpp:2795
+#: src/muuli_wdr.cpp:2799
 msgid "Save online signature file in: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:2801
+#: src/muuli_wdr.cpp:2805
 msgid "Click here to select the directory containing the the Online Signature files."
 msgstr "온라인서명 파일을 포함하는 폴더를 선택하려면 클릭하세요."
 
-#: src/muuli_wdr.cpp:2834
+#: src/muuli_wdr.cpp:2838
 msgid "Show country flags for clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2835
+#: src/muuli_wdr.cpp:2839
 msgid "Render the country flag column in the transfers, queue and search views. Requires a valid MMDB GeoIP database (see below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2840
+#: src/muuli_wdr.cpp:2844
 #, fuzzy
 msgid "Database"
 msgstr "데이터율 :"
 
-#: src/muuli_wdr.cpp:2856
+#: src/muuli_wdr.cpp:2860
 #, fuzzy
 msgid "Source:"
 msgstr "자료"
 
-#: src/muuli_wdr.cpp:2859
+#: src/muuli_wdr.cpp:2863
 msgid "DB-IP (free, no account)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2860
+#: src/muuli_wdr.cpp:2864
 msgid "MaxMind GeoLite2 (free, account required)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2861
+#: src/muuli_wdr.cpp:2865
 msgid "Custom URL"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2864
+#: src/muuli_wdr.cpp:2868
 msgid "Choose which provider supplies the GeoIP MMDB database. DB-IP is the default - no account required. MaxMind requires a free account + license key. Use Custom URL to point at any other MMDB host (e.g. a local mirror)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2881
+#: src/muuli_wdr.cpp:2885
 msgid ""
 "No configuration required.\n"
 "\n"
@@ -4902,11 +4902,11 @@ msgid ""
 "License: Creative Commons BY 4.0 - https://creativecommons.org/licenses/by/4.0/"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2894
+#: src/muuli_wdr.cpp:2898
 msgid "License key:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2900
+#: src/muuli_wdr.cpp:2904
 msgid ""
 "Sign up for a free MaxMind account, then generate a License Key:\n"
 "https://www.maxmind.com/en/geolite2/signup\n"
@@ -4916,232 +4916,232 @@ msgid ""
 "Requires attribution and account registration; refresh at least every 30 days."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2915
+#: src/muuli_wdr.cpp:2919
 #, fuzzy
 msgid "Download URL:"
 msgstr "내려받기: "
 
-#: src/muuli_wdr.cpp:2921
+#: src/muuli_wdr.cpp:2925
 msgid ""
 "Must point to an .mmdb file or a .gz / .tar.gz containing one.\n"
 "URL may include credentials (https://user:pass@host/...).\n"
 "License and attribution terms are set by the upstream URL - you are responsible."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2934
+#: src/muuli_wdr.cpp:2938
 msgid "Download the GeoIP database from the selected source."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2936
+#: src/muuli_wdr.cpp:2940
 #, fuzzy
 msgid "Auto-update on startup"
 msgstr "시작시 IP차단을 자동 갱신"
 
-#: src/muuli_wdr.cpp:2937
+#: src/muuli_wdr.cpp:2941
 msgid "Re-download the GeoIP database from the selected source every time aMule starts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2960
+#: src/muuli_wdr.cpp:2964
 msgid "Filter incoming messages (except current chat):"
 msgstr "받는 메시지 차단(현재 채팅은 제외)"
 
-#: src/muuli_wdr.cpp:2962
+#: src/muuli_wdr.cpp:2966
 msgid "Filter all messages"
 msgstr "모든 메시지를 차단"
 
-#: src/muuli_wdr.cpp:2964
+#: src/muuli_wdr.cpp:2968
 msgid "Filter messages from people not on your friend list"
 msgstr "친구 목록에 없는 사람으로부터 메시지를 차단"
 
-#: src/muuli_wdr.cpp:2966
+#: src/muuli_wdr.cpp:2970
 msgid "Filter messages from unknown clients"
 msgstr "알 수 없는 클라이언트로부터 메시지를 차단"
 
-#: src/muuli_wdr.cpp:2968
+#: src/muuli_wdr.cpp:2972
 msgid "Filter messages containing (use ',' as separator):"
 msgstr "다음 내용이 포함된 메시지를 차단 (쉼표로 분리):"
 
-#: src/muuli_wdr.cpp:2971 src/muuli_wdr.cpp:2982
+#: src/muuli_wdr.cpp:2975 src/muuli_wdr.cpp:2986
 msgid "add here the words amule should filter and block messages including it"
 msgstr "이곳에 어뮬이 차단하고 막을 메시지에 포함될 단어를 추가하세요."
 
-#: src/muuli_wdr.cpp:2973
+#: src/muuli_wdr.cpp:2977
 msgid "Show received messages in the log"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2976
+#: src/muuli_wdr.cpp:2980
 msgid "Comments"
 msgstr "의견들"
 
-#: src/muuli_wdr.cpp:2979
+#: src/muuli_wdr.cpp:2983
 msgid "Filter comments containing (use ',' as separator):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3004
+#: src/muuli_wdr.cpp:3008
 msgid "Enable Proxy"
 msgstr "프록시 활성화"
 
-#: src/muuli_wdr.cpp:3005
+#: src/muuli_wdr.cpp:3009
 msgid "Enable/disable proxy support"
 msgstr "프록시지원을 활성화/비활성화"
 
-#: src/muuli_wdr.cpp:3008
+#: src/muuli_wdr.cpp:3012
 msgid "Proxy type:"
 msgstr "프록시 종류:"
 
-#: src/muuli_wdr.cpp:3019
+#: src/muuli_wdr.cpp:3023
 msgid "Proxy host:"
 msgstr "프록시 호스트:"
 
-#: src/muuli_wdr.cpp:3022
+#: src/muuli_wdr.cpp:3026
 msgid "The proxy host name"
 msgstr "프록시 호스트 이름"
 
-#: src/muuli_wdr.cpp:3024
+#: src/muuli_wdr.cpp:3028
 msgid "Proxy port:"
 msgstr "프록시 포트:"
 
-#: src/muuli_wdr.cpp:3027
+#: src/muuli_wdr.cpp:3031
 msgid "The proxy port"
 msgstr "프록시 포트"
 
-#: src/muuli_wdr.cpp:3029
+#: src/muuli_wdr.cpp:3033
 msgid "Enable authentication"
 msgstr "인증 활성화"
 
-#: src/muuli_wdr.cpp:3030
+#: src/muuli_wdr.cpp:3034
 msgid "Enable/disable username/password authentication"
 msgstr "사용자이름/암호 인증을 활성화/비활성화"
 
-#: src/muuli_wdr.cpp:3033
+#: src/muuli_wdr.cpp:3037
 msgid "Username: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:3036
+#: src/muuli_wdr.cpp:3040
 msgid "The username to use to connect to the proxy"
 msgstr "프록시에 접속하기 위한 사용자이름"
 
-#: src/muuli_wdr.cpp:3038
+#: src/muuli_wdr.cpp:3042
 msgid "Password:"
 msgstr "암호:"
 
-#: src/muuli_wdr.cpp:3041
+#: src/muuli_wdr.cpp:3045
 msgid "The password to use to connect to the proxy"
 msgstr "프록시에 접속하기 위한 암호"
 
-#: src/muuli_wdr.cpp:3060
+#: src/muuli_wdr.cpp:3064
 msgid "Connect to:"
 msgstr "연결함:"
 
-#: src/muuli_wdr.cpp:3069
+#: src/muuli_wdr.cpp:3073
 msgid "Login to remote amule"
 msgstr "원격 어뮬에 로그인"
 
-#: src/muuli_wdr.cpp:3074
+#: src/muuli_wdr.cpp:3078
 msgid "User name"
 msgstr "사용자이름"
 
-#: src/muuli_wdr.cpp:3085
+#: src/muuli_wdr.cpp:3089
 msgid "Remember those settings"
 msgstr "설정을 기억"
 
-#: src/muuli_wdr.cpp:3088
+#: src/muuli_wdr.cpp:3092
 #, fuzzy
 msgid "Force ZLIB compression"
 msgstr "gzip 압축 사용"
 
-#: src/muuli_wdr.cpp:3112
+#: src/muuli_wdr.cpp:3116
 msgid "Enable Verbose Debug-Logging."
 msgstr "상세한 디버그-로깅 활성화"
 
-#: src/muuli_wdr.cpp:3114
+#: src/muuli_wdr.cpp:3118
 #, fuzzy
 msgid "Only to Logfile"
 msgstr "파일 열기(&O)"
 
-#: src/muuli_wdr.cpp:3116
+#: src/muuli_wdr.cpp:3120
 msgid "Message Categories:"
 msgstr "메시지 분류:"
 
-#: src/muuli_wdr.cpp:3140 src/PartFileConvertDlg.cpp:160
+#: src/muuli_wdr.cpp:3144 src/PartFileConvertDlg.cpp:160
 msgid "Waiting..."
 msgstr "대기중..."
 
-#: src/muuli_wdr.cpp:3160
+#: src/muuli_wdr.cpp:3164
 msgid "Add imports"
 msgstr "가져오기 추가"
 
-#: src/muuli_wdr.cpp:3163
+#: src/muuli_wdr.cpp:3167
 msgid "Retry selected"
 msgstr "선택된 것을 재시도"
 
-#: src/muuli_wdr.cpp:3165
+#: src/muuli_wdr.cpp:3169
 msgid "Remove selected"
 msgstr "선택된 것을 삭제"
 
-#: src/muuli_wdr.cpp:3228
+#: src/muuli_wdr.cpp:3232
 msgid "Event Types"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3247
+#: src/muuli_wdr.cpp:3251
 msgid "Statistics and queued clients for selected file(s) : Session / All time"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3271
+#: src/muuli_wdr.cpp:3275
 #, fuzzy
 msgid "Active Uploads"
 msgstr "활성화된 올려주기 :"
 
-#: src/muuli_wdr.cpp:3285
+#: src/muuli_wdr.cpp:3289
 msgid "Percent of total files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3337
+#: src/muuli_wdr.cpp:3341
 #, fuzzy
 msgid "Show Clients for"
 msgstr "클라이언트 보기"
 
-#: src/muuli_wdr.cpp:3339
+#: src/muuli_wdr.cpp:3343
 #, fuzzy
 msgid "All files"
 msgstr "공유된 파일을 숨김"
 
-#: src/muuli_wdr.cpp:3342
+#: src/muuli_wdr.cpp:3346
 #, fuzzy
 msgid "Selected files"
 msgstr "보기 필터 선택"
 
-#: src/muuli_wdr.cpp:3345
+#: src/muuli_wdr.cpp:3349
 #, fuzzy
 msgid "Active uploads only"
 msgstr "활성화된 올려주기"
 
-#: src/muuli_wdr.cpp:3352
+#: src/muuli_wdr.cpp:3356
 #, fuzzy
 msgid "Reload:"
 msgstr "목록 다시읽기"
 
-#: src/muuli_wdr.cpp:3356
+#: src/muuli_wdr.cpp:3360
 msgid "Reload your shared files"
 msgstr "공유된 파일을 다시 읽어들임"
 
-#: src/muuli_wdr.cpp:3419
+#: src/muuli_wdr.cpp:3423
 msgid "Send"
 msgstr "보내기"
 
-#: src/muuli_wdr.cpp:3420
+#: src/muuli_wdr.cpp:3424
 msgid "Sends the specified message."
 msgstr "지정된 메시지를 보냅니다."
 
-#: src/muuli_wdr.cpp:3424
+#: src/muuli_wdr.cpp:3428
 msgid "Close this chat-session."
 msgstr "이 채팅세션을 닫습니다."
 
-#: src/muuli_wdr.cpp:3447
+#: src/muuli_wdr.cpp:3451
 msgid "Connect to any server and/or Kad"
 msgstr "서버 혹은 Kad에 연결"
 
-#: src/muuli_wdr.cpp:3453 src/SharedFilesCtrl.cpp:142 src/Statistics.cpp:941
+#: src/muuli_wdr.cpp:3457 src/SharedFilesCtrl.cpp:142 src/Statistics.cpp:941
 msgid "Shared Files"
 msgstr "공유 파일"
 
@@ -5781,35 +5781,35 @@ msgstr ""
 "이 설정들을 조정하지 않아도\n"
 "어뮬은 잘 동작할 것입니다."
 
-#: src/PrefsUnifiedDlg.cpp:647
+#: src/PrefsUnifiedDlg.cpp:656
 #, c-format
 msgid "Failed to connect Cfg to widget with the ID %d and key %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:695
+#: src/PrefsUnifiedDlg.cpp:704
 #, c-format
 msgid "Failed to transfer data from Cfg to Widget with the ID %d and key %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:801
+#: src/PrefsUnifiedDlg.cpp:810
 msgid "The type of proxy you are connecting to"
 msgstr "연결하고 있는 프록시 타입"
 
-#: src/PrefsUnifiedDlg.cpp:1020
+#: src/PrefsUnifiedDlg.cpp:1029
 #, c-format
 msgid "Failed to transfer data from Widget to Cfg with the ID %d and key %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1103
+#: src/PrefsUnifiedDlg.cpp:1112
 #, fuzzy
 msgid "No password set."
 msgstr "암호를 검사중\n"
 
-#: src/PrefsUnifiedDlg.cpp:1132
+#: src/PrefsUnifiedDlg.cpp:1141
 msgid "Guest access needs a password. Type one in the guest password field, or untick Enable guest access."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1144
+#: src/PrefsUnifiedDlg.cpp:1153
 msgid ""
 "aMule must be restarted to enable these changes:\n"
 "\n"
@@ -5817,51 +5817,51 @@ msgstr ""
 "변경사항을 활성화 하기위해 어뮬을 재시작해야 합니다:\n"
 "\n"
 
-#: src/PrefsUnifiedDlg.cpp:1151
+#: src/PrefsUnifiedDlg.cpp:1160
 msgid "- TCP port changed.\n"
 msgstr "- TCP 포트가 변경되었습니다.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1156
+#: src/PrefsUnifiedDlg.cpp:1165
 msgid "- UDP port changed.\n"
 msgstr "- UDP 포트가 변경되었습니다.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1161
+#: src/PrefsUnifiedDlg.cpp:1170
 #, fuzzy
 msgid "- Network interface binding changed.\n"
 msgstr "외부연결 끊겼습니다."
 
-#: src/PrefsUnifiedDlg.cpp:1166
+#: src/PrefsUnifiedDlg.cpp:1175
 #, fuzzy
 msgid "- External connect port changed.\n"
 msgstr "외부연결 끊겼습니다."
 
-#: src/PrefsUnifiedDlg.cpp:1170
+#: src/PrefsUnifiedDlg.cpp:1179
 #, fuzzy
 msgid "- External connect acceptance changed.\n"
 msgstr "새로운 외부연결이 승인되었습니다."
 
-#: src/PrefsUnifiedDlg.cpp:1174
+#: src/PrefsUnifiedDlg.cpp:1183
 #, fuzzy
 msgid "- External connect interface changed.\n"
 msgstr "외부연결 끊겼습니다."
 
-#: src/PrefsUnifiedDlg.cpp:1178
+#: src/PrefsUnifiedDlg.cpp:1187
 #, fuzzy
 msgid "- Protocol obfuscation support changed.\n"
 msgstr "프로토콜 난독화"
 
-#: src/PrefsUnifiedDlg.cpp:1193
+#: src/PrefsUnifiedDlg.cpp:1202
 #, fuzzy
 msgid "- amuleapi settings changed.\n"
 msgstr "- 언어가 변경되었습니다.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1202
+#: src/PrefsUnifiedDlg.cpp:1211
 msgid ""
 "Your Auto-update server list is empty.\n"
 "'Auto-update server list at startup' will be disabled."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1213
+#: src/PrefsUnifiedDlg.cpp:1222
 msgid ""
 "You have enabled external connections but have not specified a password.\n"
 "External connections cannot be enabled unless a valid password is specified."
@@ -5869,40 +5869,40 @@ msgstr ""
 "외부연결이 횔성화되어 있지만, 암호를 설정하지 않았습니다.\n"
 "외부연결은 유효한 암호가 설정되기전까지 활성화되지 않습니다."
 
-#: src/PrefsUnifiedDlg.cpp:1246
+#: src/PrefsUnifiedDlg.cpp:1255
 #, c-format
 msgid "The amuleapi password could not be saved: %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1276
+#: src/PrefsUnifiedDlg.cpp:1285
 msgid "- Language changed.\n"
 msgstr "- 언어가 변경되었습니다.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1281
+#: src/PrefsUnifiedDlg.cpp:1290
 msgid "- Temp folder changed.\n"
 msgstr "- 임시 폴더가 변경되었습니다.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1286
+#: src/PrefsUnifiedDlg.cpp:1295
 #, fuzzy
 msgid "- ED2K network enabled.\n"
 msgstr "모든 통신망을 사용할수 없습니다."
 
-#: src/PrefsUnifiedDlg.cpp:1319
+#: src/PrefsUnifiedDlg.cpp:1328
 msgid "The shared-file exclusion pattern is not a valid regular expression. The filter has been left disabled."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1321 src/PrefsUnifiedDlg.cpp:1921
+#: src/PrefsUnifiedDlg.cpp:1330 src/PrefsUnifiedDlg.cpp:1930
 #, fuzzy
 msgid "Invalid regular expression"
 msgstr "유효하지 않은 프로토콜 버젼입니다"
 
-#: src/PrefsUnifiedDlg.cpp:1398
+#: src/PrefsUnifiedDlg.cpp:1407
 msgid ""
 "Both eD2k and Kad network are disabled.\n"
 "You won't be able to connect until you enable at least one of them."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1403
+#: src/PrefsUnifiedDlg.cpp:1412
 msgid ""
 "Kad will not start if your UDP port is disabled.\n"
 "Enable UDP port or disable Kad."
@@ -5910,7 +5910,7 @@ msgstr ""
 "UDP 포트가 비활성화되어 있으면 Kad는 시작하지 않을 것입니다.\n"
 "UDP 포트를 활성화시키거나 Kad를 비활성화시키십시오."
 
-#: src/PrefsUnifiedDlg.cpp:1459
+#: src/PrefsUnifiedDlg.cpp:1468
 msgid ""
 "\n"
 "You MUST restart aMule now.\n"
@@ -5920,69 +5920,69 @@ msgstr ""
 "지금 바로 어뮬을 재시작해야 합니다.\n"
 "만일 재시작하지 않는다면, 나쁜 일이 일어나도 불평하지 마십시오.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1524
+#: src/PrefsUnifiedDlg.cpp:1533
 msgid "Could not register aMule for autostart at login. The autostart store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1526
+#: src/PrefsUnifiedDlg.cpp:1535
 msgid "Could not remove the autostart-at-login entry."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1527
+#: src/PrefsUnifiedDlg.cpp:1536
 #, fuzzy
 msgid "Autostart"
 msgstr "자동갱신이 시작됨"
 
-#: src/PrefsUnifiedDlg.cpp:1542
+#: src/PrefsUnifiedDlg.cpp:1551
 msgid "Register file type"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1542
+#: src/PrefsUnifiedDlg.cpp:1551
 msgid "Register URL handler"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1550
+#: src/PrefsUnifiedDlg.cpp:1559
 #, c-format
 msgid "aMule only handles eD2k-compatible magnets. If you replace the current magnet handler (%s), BitTorrent magnet links will stop working - aMule cannot download BitTorrent content. Continue?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1555
+#: src/PrefsUnifiedDlg.cpp:1564
 #, c-format
 msgid "Another application currently opens .emulecollection files (%s). Replace it with aMule?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1560
+#: src/PrefsUnifiedDlg.cpp:1569
 #, c-format
 msgid "Another application is currently the default handler for these links (%s). Replace it with aMule?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1585
+#: src/PrefsUnifiedDlg.cpp:1594
 msgid "Could not register aMule for .emulecollection files. The registration store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1587
+#: src/PrefsUnifiedDlg.cpp:1596
 #, fuzzy
 msgid "Could not remove the file type registration."
 msgstr "이미 %s 파일을 내려받으려고 하고있음"
 
-#: src/PrefsUnifiedDlg.cpp:1589
+#: src/PrefsUnifiedDlg.cpp:1598
 msgid "Could not register aMule as the URL handler. The registration store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1591
+#: src/PrefsUnifiedDlg.cpp:1600
 msgid "Could not remove the URL handler registration."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1661 src/PrefsUnifiedDlg.cpp:1688
+#: src/PrefsUnifiedDlg.cpp:1670 src/PrefsUnifiedDlg.cpp:1697
 #, fuzzy
 msgid "The web server and aMule API require external connections to be enabled."
 msgstr "새로운 외부연결이 승인되었습니다."
 
-#: src/PrefsUnifiedDlg.cpp:1671
+#: src/PrefsUnifiedDlg.cpp:1680
 msgid "The aMule web server is deprecated. Consider running the aMule API instead."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1735
+#: src/PrefsUnifiedDlg.cpp:1744
 msgid ""
 "Your Auto-update servers list is in blank.\n"
 "Please fill in at least one URL to point to a valid server.met file.\n"
@@ -5992,66 +5992,66 @@ msgstr ""
 "적어도 한개의 유효한 server.met파일을 가르키는 URL을 적으세요.\n"
 "URL을 입력하려면 채크박스 옆의 \"목록\"버튼을 클릭하세요."
 
-#: src/PrefsUnifiedDlg.cpp:1876
+#: src/PrefsUnifiedDlg.cpp:1885
 msgid "Temporary files"
 msgstr "임시 파일"
 
-#: src/PrefsUnifiedDlg.cpp:1881
+#: src/PrefsUnifiedDlg.cpp:1890
 msgid "Incoming files"
 msgstr "내려받은 파일"
 
-#: src/PrefsUnifiedDlg.cpp:1886
+#: src/PrefsUnifiedDlg.cpp:1895
 msgid "Online Signatures"
 msgstr "온라인 서명"
 
-#: src/PrefsUnifiedDlg.cpp:1899
+#: src/PrefsUnifiedDlg.cpp:1908
 #, c-format
 msgid "Choose a folder for %s"
 msgstr "%s하기 위한 폴더를 선택하세요."
 
-#: src/PrefsUnifiedDlg.cpp:1923
+#: src/PrefsUnifiedDlg.cpp:1932
 #, fuzzy, c-format
 msgid "Would exclude %u of %u shared file"
 msgid_plural "Would exclude %u of %u shared files"
 msgstr[0] "알려진 공유 파일 %i개를 찾았음"
 msgstr[1] "알려진 공유 파일 %i개를 찾았음"
 
-#: src/PrefsUnifiedDlg.cpp:1940
+#: src/PrefsUnifiedDlg.cpp:1949
 msgid "Browse for videoplayer"
 msgstr "비디오재생을 위한 브라우즈"
 
-#: src/PrefsUnifiedDlg.cpp:1944
+#: src/PrefsUnifiedDlg.cpp:1953
 msgid "Select browser"
 msgstr "브라우저 선택"
 
-#: src/PrefsUnifiedDlg.cpp:1948
+#: src/PrefsUnifiedDlg.cpp:1957
 #, fuzzy
 msgid "Select ffprobe binary"
 msgstr "브라우저 선택"
 
-#: src/PrefsUnifiedDlg.cpp:1954
+#: src/PrefsUnifiedDlg.cpp:1963
 #, c-format
 msgid "Executable%s"
 msgstr "실행할수 있는 %s"
 
-#: src/PrefsUnifiedDlg.cpp:1988
+#: src/PrefsUnifiedDlg.cpp:1997
 msgid "ffprobe not found on PATH or in the standard install locations. Install ffmpeg (which ships ffprobe) or use Browse to pick a binary manually."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2000
+#: src/PrefsUnifiedDlg.cpp:2009
 msgid "Reset the settings on this page to their default values?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2001
+#: src/PrefsUnifiedDlg.cpp:2010
 #, fuzzy
 msgid "Reset to defaults"
 msgstr "기본 설정"
 
-#: src/PrefsUnifiedDlg.cpp:2028
+#: src/PrefsUnifiedDlg.cpp:2037
 msgid "Edit server list"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2029
+#: src/PrefsUnifiedDlg.cpp:2038
 msgid ""
 "Add here URL's to download server.met files.\n"
 "Only one url on each line."
@@ -6059,155 +6059,155 @@ msgstr ""
 "server.met파일을 내려받을 URL을 추가하세요.\n"
 "각 행에 오직 하나의 URL을 넣으세요."
 
-#: src/PrefsUnifiedDlg.cpp:2084
+#: src/PrefsUnifiedDlg.cpp:2093
 msgid "IP2Country update failed"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2229 src/PrefsUnifiedDlg.cpp:2260
+#: src/PrefsUnifiedDlg.cpp:2238 src/PrefsUnifiedDlg.cpp:2269
 msgid "Data by MaxMind GeoLite2"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2231 src/PrefsUnifiedDlg.cpp:2262
+#: src/PrefsUnifiedDlg.cpp:2240 src/PrefsUnifiedDlg.cpp:2271
 #, fuzzy
 msgid "Custom source"
 msgstr "완료된 자료"
 
-#: src/PrefsUnifiedDlg.cpp:2233 src/PrefsUnifiedDlg.cpp:2264
+#: src/PrefsUnifiedDlg.cpp:2242 src/PrefsUnifiedDlg.cpp:2273
 msgid "Data by DB-IP.com"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2284
+#: src/PrefsUnifiedDlg.cpp:2293
 #, fuzzy, c-format
 msgid "Status: Loaded%s"
 msgstr "상태:"
 
-#: src/PrefsUnifiedDlg.cpp:2286
+#: src/PrefsUnifiedDlg.cpp:2295
 #, fuzzy, c-format
 msgid "Status: Loaded%s - %s"
 msgstr "상태:"
 
-#: src/PrefsUnifiedDlg.cpp:2290
+#: src/PrefsUnifiedDlg.cpp:2299
 msgid "Status: Failed to load - click 'Update now' to refresh."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2292
+#: src/PrefsUnifiedDlg.cpp:2301
 msgid "Status: Not found - click 'Update now' to download."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2350 src/PrefsUnifiedDlg.cpp:2374
+#: src/PrefsUnifiedDlg.cpp:2359 src/PrefsUnifiedDlg.cpp:2383
 #, fuzzy, c-format
 msgid "Update delay: %d second"
 msgid_plural "Update delay: %d seconds"
 msgstr[0] "갱신 지연: %d 초"
 msgstr[1] "갱신 지연: %d 초"
 
-#: src/PrefsUnifiedDlg.cpp:2358
+#: src/PrefsUnifiedDlg.cpp:2367
 #, fuzzy, c-format
 msgid "Time for average graph: %d minute"
 msgid_plural "Time for average graph: %d minutes"
 msgstr[0] "평균 그래프 시간: %d 분"
 msgstr[1] "평균 그래프 시간: %d 분"
 
-#: src/PrefsUnifiedDlg.cpp:2367
+#: src/PrefsUnifiedDlg.cpp:2376
 #, c-format
 msgid "Connections Graph Scale: %d"
 msgstr "연결 그래프 크기: %d"
 
-#: src/PrefsUnifiedDlg.cpp:2382
+#: src/PrefsUnifiedDlg.cpp:2391
 #, fuzzy, c-format
 msgid "File Buffer Size: %d byte"
 msgid_plural "File Buffer Size: %d bytes"
 msgstr[0] "파일 버퍼 크기: %d 바이트"
 msgstr[1] "파일 버퍼 크기: %d 바이트"
 
-#: src/PrefsUnifiedDlg.cpp:2392
+#: src/PrefsUnifiedDlg.cpp:2401
 #, fuzzy, c-format
 msgid "Upload Queue Size: %d client"
 msgid_plural "Upload Queue Size: %d clients"
 msgstr[0] "올려주기 대기열 크기: %d 클라이언트"
 msgstr[1] "올려주기 대기열 크기: %d 클라이언트"
 
-#: src/PrefsUnifiedDlg.cpp:2402
+#: src/PrefsUnifiedDlg.cpp:2411
 #, fuzzy, c-format
 msgid "Server connection refresh interval: %d minute"
 msgid_plural "Server connection refresh interval: %d minutes"
 msgstr[0] "서버 연결 갱신 주기: %d 분"
 msgstr[1] "서버 연결 갱신 주기: %d 분"
 
-#: src/PrefsUnifiedDlg.cpp:2407
+#: src/PrefsUnifiedDlg.cpp:2416
 msgid "Server connection refresh interval: Disabled"
 msgstr "서버 연결 갱신 주기: 비활성화"
 
-#: src/PrefsUnifiedDlg.cpp:2451
+#: src/PrefsUnifiedDlg.cpp:2460
 #, fuzzy
 msgid "disabled"
 msgstr "비활성화"
 
-#: src/PrefsUnifiedDlg.cpp:2477
+#: src/PrefsUnifiedDlg.cpp:2486
 #, fuzzy, c-format
 msgid "Execute command on '%s' event"
 msgstr "`%s' 사건에 명령을 실행"
 
-#: src/PrefsUnifiedDlg.cpp:2484
+#: src/PrefsUnifiedDlg.cpp:2493
 msgid "Enable command execution on core"
 msgstr "코어에 명령 실행 활성화"
 
-#: src/PrefsUnifiedDlg.cpp:2496
+#: src/PrefsUnifiedDlg.cpp:2505
 msgid "Core command:"
 msgstr "코어 명령어:"
 
-#: src/PrefsUnifiedDlg.cpp:2512
+#: src/PrefsUnifiedDlg.cpp:2521
 msgid "Enable command execution on GUI"
 msgstr "GUI에 명령 실행 활성화"
 
-#: src/PrefsUnifiedDlg.cpp:2524
+#: src/PrefsUnifiedDlg.cpp:2533
 msgid "GUI command:"
 msgstr "GUI 명령어:"
 
-#: src/PrefsUnifiedDlg.cpp:2540
+#: src/PrefsUnifiedDlg.cpp:2549
 msgid "The following variables will be replaced:"
 msgstr "다음 변수들은 교체됩니다.:"
 
-#: src/PrefsUnifiedDlg.cpp:2708
+#: src/PrefsUnifiedDlg.cpp:2717
 msgid ""
 "The following folders look like system or sensitive locations:\n"
 "\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2713
+#: src/PrefsUnifiedDlg.cpp:2722
 msgid "Sharing them recursively will publish every file underneath on the eD2k/Kad networks. Do you really want to do this?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2716
+#: src/PrefsUnifiedDlg.cpp:2725
 #, fuzzy
 msgid "Confirm shared folders"
 msgstr "공유된 파일을 다시 읽어들임"
 
-#: src/PrefsUnifiedDlg.cpp:2744
+#: src/PrefsUnifiedDlg.cpp:2753
 #, fuzzy
 msgid "Reloading shared files..."
 msgstr "공유된 파일을 다시 읽어들임"
 
-#: src/PrefsUnifiedDlg.cpp:2745
+#: src/PrefsUnifiedDlg.cpp:2754
 msgid "Scanning for subdirectories..."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2746
+#: src/PrefsUnifiedDlg.cpp:2755
 #, fuzzy
 msgid "Updating shared folders"
 msgstr "임시 폴더를 읽는중"
 
-#: src/PrefsUnifiedDlg.cpp:2773
+#: src/PrefsUnifiedDlg.cpp:2782
 #, c-format
 msgid "Scanned %u directories..."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2823
+#: src/PrefsUnifiedDlg.cpp:2832
 #, fuzzy, c-format
 msgid "Reloading shared files: %u files scanned"
 msgstr "공유된 파일 목록을 다시 읽어들입니다."
 
-#: src/PrefsUnifiedDlg.cpp:2873
+#: src/PrefsUnifiedDlg.cpp:2882
 #, fuzzy
 msgid "Shared folder"
 msgstr "공유 파일"
@@ -7919,12 +7919,12 @@ msgstr "분류 삭제"
 msgid "Hashset requested for unknown file: %s"
 msgstr "알수 없는 파일의 해시설정이 요청되었습니다: %s"
 
-#: src/UploadQueue.cpp:618
+#: src/UploadQueue.cpp:627
 #, c-format
 msgid "Resuming uploads of file: %s"
 msgstr "파일의 올려주기를 재시작합니다: %s"
 
-#: src/UploadQueue.cpp:634
+#: src/UploadQueue.cpp:643
 #, c-format
 msgid "Suspending upload of file: %s"
 msgstr "파일의 올려주기를 정지합니다: %s"

--- a/po/lt.po
+++ b/po/lt.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-28 12:17+0200\n"
+"POT-Creation-Date: 2026-07-28 13:09+0200\n"
 "PO-Revision-Date: 2026-07-27 11:41+0000\n"
 "Last-Translator: Dovydas Sankauskas <laisve@gmail.com>\n"
 "Language-Team: Lithuanian <komp_lt@konf.lt>\n"
@@ -294,7 +294,7 @@ msgid "Password set and external connections enabled."
 msgstr "Naujas išorinis ryšys priimtas"
 
 #: src/amule.cpp:755 src/KadDlg.cpp:176 src/KadDlg.cpp:185
-#: src/PrefsUnifiedDlg.cpp:1461 src/SharedFilesCtrl.cpp:476
+#: src/PrefsUnifiedDlg.cpp:1470 src/SharedFilesCtrl.cpp:476
 msgid "WARNING"
 msgstr "DĖMESIO"
 
@@ -332,7 +332,7 @@ msgstr "Nurodėte paleidus programą paleisti žiniatinklio serverį, bet amulew
 #: src/amule-remote-gui.cpp:603 src/amule-remote-gui.cpp:671
 #: src/amule-remote-gui.cpp:709 src/amule-remote-gui.cpp:1282
 #: src/amule-remote-gui.cpp:1345 src/amule-remote-gui.cpp:1372
-#: src/DownloadQueue.cpp:1481 src/PrefsUnifiedDlg.cpp:1247
+#: src/DownloadQueue.cpp:1481 src/PrefsUnifiedDlg.cpp:1256
 msgid "ERROR"
 msgstr "KLAIDA"
 
@@ -596,36 +596,36 @@ msgstr "Aplankykite https://github.com/amule-org/amule/releases/latest ir pasiti
 msgid "FATAL ERROR: Failed to create Timer"
 msgstr "KRITINĖ KLAIDA: nepavyko sukurti laiko skaitliuko"
 
-#: src/amuleDlg.cpp:361 src/amuleDlg.cpp:1787 src/amuleDlg.cpp:2033
-#: src/muuli_wdr.cpp:1492 src/muuli_wdr.cpp:3449
+#: src/amuleDlg.cpp:361 src/amuleDlg.cpp:1810 src/amuleDlg.cpp:2056
+#: src/muuli_wdr.cpp:1492 src/muuli_wdr.cpp:3453
 msgid "Networks"
 msgstr "Tinklas"
 
-#: src/amuleDlg.cpp:362 src/amuleDlg.cpp:1793 src/muuli_wdr.cpp:3450
+#: src/amuleDlg.cpp:362 src/amuleDlg.cpp:1816 src/muuli_wdr.cpp:3454
 msgid "Searches"
 msgstr "Paieška"
 
-#: src/amuleDlg.cpp:363 src/amuleDlg.cpp:1799 src/DownloadListCtrl.cpp:740
-#: src/muuli_wdr.cpp:392 src/muuli_wdr.cpp:1585 src/muuli_wdr.cpp:3451
+#: src/amuleDlg.cpp:363 src/amuleDlg.cpp:1822 src/DownloadListCtrl.cpp:740
+#: src/muuli_wdr.cpp:392 src/muuli_wdr.cpp:1585 src/muuli_wdr.cpp:3455
 #: src/Statistics.cpp:829
 msgid "Downloads"
 msgstr "Siuntimai"
 
-#: src/amuleDlg.cpp:364 src/amuleDlg.cpp:1805 src/muuli_wdr.cpp:3325
+#: src/amuleDlg.cpp:364 src/amuleDlg.cpp:1828 src/muuli_wdr.cpp:3329
 msgid "Shared files"
 msgstr "Dalinami failai"
 
-#: src/amuleDlg.cpp:365 src/amuleDlg.cpp:1811 src/muuli_wdr.cpp:2957
-#: src/muuli_wdr.cpp:3407 src/muuli_wdr.cpp:3454
+#: src/amuleDlg.cpp:365 src/amuleDlg.cpp:1834 src/muuli_wdr.cpp:2961
+#: src/muuli_wdr.cpp:3411 src/muuli_wdr.cpp:3458
 msgid "Messages"
 msgstr "Žinutės"
 
-#: src/amuleDlg.cpp:366 src/amuleDlg.cpp:1817 src/muuli_wdr.cpp:3455
+#: src/amuleDlg.cpp:366 src/amuleDlg.cpp:1840 src/muuli_wdr.cpp:3459
 #: src/PrefsUnifiedDlg.cpp:314 src/Statistics.cpp:779 src/Statistics.cpp:1235
 msgid "Statistics"
 msgstr "Statistika"
 
-#: src/amuleDlg.cpp:368 src/amuleDlg.cpp:1824 src/muuli_wdr.cpp:3457
+#: src/amuleDlg.cpp:368 src/amuleDlg.cpp:1847 src/muuli_wdr.cpp:3461
 #: src/PrefsUnifiedDlg.cpp:330 src/utils/wxCas/src/wxcasprefs.cpp:39
 msgid "Preferences"
 msgstr "Parinktys"
@@ -684,8 +684,8 @@ msgstr "Kad: išjungta"
 #: src/amuleDlg.cpp:1029 src/DownloadListCtrl.cpp:505
 #: src/DownloadListCtrl.cpp:749 src/FriendListCtrl.cpp:180
 #: src/muuli_wdr.cpp:731 src/muuli_wdr.cpp:782 src/muuli_wdr.cpp:846
-#: src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2262 src/muuli_wdr.cpp:2347
-#: src/muuli_wdr.cpp:3095 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
+#: src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2266 src/muuli_wdr.cpp:2351
+#: src/muuli_wdr.cpp:3099 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
 #: src/ServerListCtrl.cpp:606 src/TransferWnd.cpp:378
 #: src/utils/wxCas/src/wxcasprefs.cpp:235
 msgid "Cancel"
@@ -696,7 +696,7 @@ msgid "Stop the current connection attempts"
 msgstr "Nutraukti bandymus prisijungti"
 
 #: src/amuleDlg.cpp:1035 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976
-#: src/muuli_wdr.cpp:2485
+#: src/muuli_wdr.cpp:2489
 msgid "Disconnect"
 msgstr "Atsijungti"
 
@@ -705,7 +705,7 @@ msgid "Disconnect from the currently connected networks"
 msgstr "Atsijungti nuo pasirinktų tinklų"
 
 #: src/amuleDlg.cpp:1041 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979
-#: src/muuli_wdr.cpp:2640 src/muuli_wdr.cpp:3092 src/muuli_wdr.cpp:3447
+#: src/muuli_wdr.cpp:2644 src/muuli_wdr.cpp:3096 src/muuli_wdr.cpp:3451
 msgid "Connect"
 msgstr "Prisijungti"
 
@@ -760,7 +760,7 @@ msgstr "Baigimo patvirtinimas"
 msgid "Launch Command: "
 msgstr ""
 
-#: src/amuleDlg.cpp:1632 src/muuli_wdr.cpp:1982 src/Preferences.cpp:979
+#: src/amuleDlg.cpp:1632 src/muuli_wdr.cpp:1986 src/Preferences.cpp:979
 msgid "- default -"
 msgstr ""
 
@@ -774,61 +774,61 @@ msgstr "Išvaizdos failų aplankas %s neegzistuoja"
 msgid "WARNING: Unable to open skin file '%s' for read"
 msgstr "DĖMESIO: nepavyko atverti temos failo „%s“ skaitymui"
 
-#: src/amuleDlg.cpp:1791 src/muuli_wdr.cpp:3449
+#: src/amuleDlg.cpp:1814 src/muuli_wdr.cpp:3453
 msgid "Networks Window"
 msgstr "Tinklo langas"
 
-#: src/amuleDlg.cpp:1797 src/muuli_wdr.cpp:3450
+#: src/amuleDlg.cpp:1820 src/muuli_wdr.cpp:3454
 msgid "Searches Window"
 msgstr "Paieškos langas"
 
-#: src/amuleDlg.cpp:1803 src/muuli_wdr.cpp:3451
+#: src/amuleDlg.cpp:1826 src/muuli_wdr.cpp:3455
 #, fuzzy
 msgid "Downloads Window"
 msgstr "Atsiunčiama"
 
-#: src/amuleDlg.cpp:1809 src/muuli_wdr.cpp:3453
+#: src/amuleDlg.cpp:1832 src/muuli_wdr.cpp:3457
 msgid "Shared Files Window"
 msgstr "Dalinamų failų langas"
 
-#: src/amuleDlg.cpp:1815 src/muuli_wdr.cpp:3454
+#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3458
 msgid "Messages Window"
 msgstr "Žinučių langas"
 
-#: src/amuleDlg.cpp:1821 src/muuli_wdr.cpp:3455
+#: src/amuleDlg.cpp:1844 src/muuli_wdr.cpp:3459
 msgid "Statistics Graph Window"
 msgstr "Statistikos grafikų langas"
 
-#: src/amuleDlg.cpp:1828 src/muuli_wdr.cpp:3457
+#: src/amuleDlg.cpp:1851 src/muuli_wdr.cpp:3461
 msgid "Preferences Settings Window"
 msgstr "Parinkčių langas"
 
-#: src/amuleDlg.cpp:1831 src/muuli_wdr.cpp:3458
+#: src/amuleDlg.cpp:1854 src/muuli_wdr.cpp:3462
 msgid "Import"
 msgstr "Įkelti"
 
-#: src/amuleDlg.cpp:1835 src/muuli_wdr.cpp:3458
+#: src/amuleDlg.cpp:1858 src/muuli_wdr.cpp:3462
 msgid "The partfile importer tool"
 msgstr "Dalinai atsiųstų failų įkėlimo įrankis"
 
-#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3459
+#: src/amuleDlg.cpp:1861 src/muuli_wdr.cpp:3463
 #: src/utils/aLinkCreator/src/alcframe.cpp:262
 msgid "About"
 msgstr "Apie"
 
-#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3459
+#: src/amuleDlg.cpp:1861 src/muuli_wdr.cpp:3463
 msgid "About/Help"
 msgstr "Apie/pagalba"
 
-#: src/amuleDlg.cpp:2036
+#: src/amuleDlg.cpp:2059
 msgid "eD2k network"
 msgstr "eD2k tinklas"
 
-#: src/amuleDlg.cpp:2039
+#: src/amuleDlg.cpp:2062
 msgid "Kad network"
 msgstr "Kad tinklas"
 
-#: src/amuleDlg.cpp:2039
+#: src/amuleDlg.cpp:2062
 msgid "No network"
 msgstr "Jokio tinklo"
 
@@ -1370,19 +1370,19 @@ msgstr "Automatiškai (aukštas)"
 msgid "Very low"
 msgstr "Labai žemas"
 
-#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:743 src/muuli_wdr.cpp:2313
+#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:743 src/muuli_wdr.cpp:2317
 #: src/ServerListCtrl.cpp:263 src/ServerListCtrl.cpp:456
 #: src/SharedFilesCtrl.cpp:145
 msgid "Low"
 msgstr "Žemas"
 
-#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:744 src/muuli_wdr.cpp:2314
+#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:744 src/muuli_wdr.cpp:2318
 #: src/ServerListCtrl.cpp:266 src/ServerListCtrl.cpp:457
 #: src/SharedFilesCtrl.cpp:146
 msgid "Normal"
 msgstr "Normalus"
 
-#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:745 src/muuli_wdr.cpp:2315
+#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:745 src/muuli_wdr.cpp:2319
 #: src/ServerListCtrl.cpp:269 src/ServerListCtrl.cpp:458
 #: src/SharedFilesCtrl.cpp:147
 msgid "High"
@@ -1474,7 +1474,7 @@ msgstr "Vietinis serveris"
 msgid "Remote Server"
 msgstr "Nutolęs serveris"
 
-#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3212
+#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3216
 #: src/SearchDlg.cpp:119 src/TextClient.cpp:911
 msgid "Kad"
 msgstr "Kademlia"
@@ -1546,7 +1546,7 @@ msgstr ""
 msgid "Size"
 msgstr "Dydis"
 
-#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3279
+#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3283
 msgid "Transferred"
 msgstr "Persiųsta"
 
@@ -1604,7 +1604,7 @@ msgstr ""
 "Atsakymas iš: %s (%s)\n"
 "\n"
 
-#: src/DownloadListCtrl.cpp:746 src/muuli_wdr.cpp:2316
+#: src/DownloadListCtrl.cpp:746 src/muuli_wdr.cpp:2320
 #: src/SharedFilesCtrl.cpp:150
 msgid "Auto"
 msgstr "Automatiškas"
@@ -1642,7 +1642,7 @@ msgid "Extended Options"
 msgstr "Papildomi veiksmai"
 
 #: src/DownloadListCtrl.cpp:770 src/DownloadListCtrl.cpp:822
-#: src/muuli_wdr.cpp:1800
+#: src/muuli_wdr.cpp:1804
 msgid "Preview"
 msgstr "Peržiūra"
 
@@ -2450,23 +2450,23 @@ msgid ""
 "want downloads on a different (e.g. larger) disk."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:549 src/FirstRunWizard.cpp:611 src/muuli_wdr.cpp:1712
+#: src/FirstRunWizard.cpp:549 src/FirstRunWizard.cpp:611 src/muuli_wdr.cpp:1716
 msgid "Destination folder for downloads"
 msgstr ""
 
 #: src/FirstRunWizard.cpp:553 src/FirstRunWizard.cpp:569 src/muuli_wdr.cpp:1349
-#: src/muuli_wdr.cpp:1366 src/muuli_wdr.cpp:1687 src/muuli_wdr.cpp:1718
-#: src/muuli_wdr.cpp:1730 src/muuli_wdr.cpp:2800
+#: src/muuli_wdr.cpp:1366 src/muuli_wdr.cpp:1691 src/muuli_wdr.cpp:1722
+#: src/muuli_wdr.cpp:1734 src/muuli_wdr.cpp:2804
 #: src/utils/aLinkCreator/src/alcframe.cpp:135
 #: src/utils/wxCas/src/wxcasprefs.cpp:52 src/utils/wxCas/src/wxcasprefs.cpp:118
 msgid "Browse"
 msgstr "Naršyti"
 
-#: src/FirstRunWizard.cpp:559 src/muuli_wdr.cpp:1723
+#: src/FirstRunWizard.cpp:559 src/muuli_wdr.cpp:1727
 msgid "(All files in this folder are shared with other peers)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:565 src/FirstRunWizard.cpp:624 src/muuli_wdr.cpp:1725
+#: src/FirstRunWizard.cpp:565 src/FirstRunWizard.cpp:624 src/muuli_wdr.cpp:1729
 msgid "Folder for temporary download files"
 msgstr ""
 
@@ -2497,7 +2497,7 @@ msgstr "Nepavyko atverti draugų sąrašo failo „emfriends.met“ rašymui!"
 msgid "CRITICAL - no client on StartChatSession"
 msgstr ""
 
-#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2706 src/muuli_wdr.cpp:3383
+#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2710 src/muuli_wdr.cpp:3387
 msgid "Friends"
 msgstr "Draugai"
 
@@ -2611,8 +2611,8 @@ msgstr "Niekas"
 msgid "No"
 msgstr "Ne"
 
-#: src/GenericClientListCtrl.cpp:1216 src/PrefsUnifiedDlg.cpp:2898
-#: src/PrefsUnifiedDlg.cpp:2948 src/ServerListCtrl.cpp:276
+#: src/GenericClientListCtrl.cpp:1216 src/PrefsUnifiedDlg.cpp:2907
+#: src/PrefsUnifiedDlg.cpp:2957 src/ServerListCtrl.cpp:276
 msgid "Yes"
 msgstr "Taip"
 
@@ -2784,10 +2784,10 @@ msgstr "Klaidingas inicializavimo prievadas"
 msgid "Please fill all fields required"
 msgstr "Prašome užpildyti visus privalomus laukus"
 
-#: src/KadDlg.cpp:192 src/PartFile.cpp:1031 src/PrefsUnifiedDlg.cpp:1134
-#: src/PrefsUnifiedDlg.cpp:1204 src/PrefsUnifiedDlg.cpp:1405
-#: src/PrefsUnifiedDlg.cpp:1663 src/PrefsUnifiedDlg.cpp:1673
-#: src/PrefsUnifiedDlg.cpp:1690 src/PrefsUnifiedDlg.cpp:1738
+#: src/KadDlg.cpp:192 src/PartFile.cpp:1031 src/PrefsUnifiedDlg.cpp:1143
+#: src/PrefsUnifiedDlg.cpp:1213 src/PrefsUnifiedDlg.cpp:1414
+#: src/PrefsUnifiedDlg.cpp:1672 src/PrefsUnifiedDlg.cpp:1682
+#: src/PrefsUnifiedDlg.cpp:1699 src/PrefsUnifiedDlg.cpp:1747
 msgid "Message"
 msgstr "Žinutė"
 
@@ -2892,7 +2892,7 @@ msgstr "Platinimo santykis"
 msgid "Uploaded"
 msgstr "Išsiųsta"
 
-#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3263
+#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3267
 msgid "Requested"
 msgstr "Paprašyta"
 
@@ -3018,7 +3018,7 @@ msgid "WARNING: "
 msgstr "DĖMESIO: "
 
 #: src/MuleNotebook.cpp:179 src/muuli_wdr.cpp:817 src/muuli_wdr.cpp:1229
-#: src/muuli_wdr.cpp:3167 src/muuli_wdr.cpp:3423
+#: src/muuli_wdr.cpp:3171 src/muuli_wdr.cpp:3427
 msgid "Close"
 msgstr "Užverti"
 
@@ -3036,7 +3036,7 @@ msgid "Paste"
 msgstr "Įterpti"
 
 #: src/MuleTextCtrl.cpp:89 src/muuli_wdr.cpp:358 src/muuli_wdr.cpp:757
-#: src/muuli_wdr.cpp:2390 src/muuli_wdr.cpp:2409 src/muuli_wdr.cpp:2431
+#: src/muuli_wdr.cpp:2394 src/muuli_wdr.cpp:2413 src/muuli_wdr.cpp:2435
 #: src/utils/aLinkCreator/src/alcframe.cpp:142
 msgid "Clear"
 msgstr "Išvalyti"
@@ -3135,7 +3135,7 @@ msgstr "Baigti"
 
 #: src/MuleTrayIcon.cpp:579 src/MuleTrayIcon.cpp:945 src/MuleTrayIcon.cpp:965
 #: src/muuli_wdr.cpp:1398 src/muuli_wdr.cpp:1406 src/muuli_wdr.cpp:1413
-#: src/muuli_wdr.cpp:1846 src/muuli_wdr.cpp:1852 src/OtherFunctions.cpp:91
+#: src/muuli_wdr.cpp:1850 src/muuli_wdr.cpp:1856 src/OtherFunctions.cpp:91
 #: src/StatisticsDlg.cpp:93 src/StatisticsDlg.cpp:95
 msgid "kB/s"
 msgstr "kB/s"
@@ -3377,7 +3377,7 @@ msgstr "Baitai"
 msgid "KB"
 msgstr "KB"
 
-#: src/muuli_wdr.cpp:274 src/muuli_wdr.cpp:293 src/muuli_wdr.cpp:1631
+#: src/muuli_wdr.cpp:274 src/muuli_wdr.cpp:293 src/muuli_wdr.cpp:1635
 #: src/OtherFunctions.cpp:64
 msgid "MB"
 msgstr "MB"
@@ -3394,7 +3394,7 @@ msgstr "Maks dydis"
 msgid "Availability"
 msgstr "Skaičius"
 
-#: src/muuli_wdr.cpp:312 src/muuli_wdr.cpp:398 src/muuli_wdr.cpp:3328
+#: src/muuli_wdr.cpp:312 src/muuli_wdr.cpp:398 src/muuli_wdr.cpp:3332
 msgid "Filter:"
 msgstr "Filtras:"
 
@@ -3458,8 +3458,8 @@ msgstr "Pilni šaltiniai"
 #: src/muuli_wdr.cpp:1160 src/muuli_wdr.cpp:1167 src/muuli_wdr.cpp:1172
 #: src/muuli_wdr.cpp:1179 src/muuli_wdr.cpp:1184 src/muuli_wdr.cpp:1191
 #: src/muuli_wdr.cpp:1205 src/muuli_wdr.cpp:1212 src/muuli_wdr.cpp:1217
-#: src/muuli_wdr.cpp:1224 src/muuli_wdr.cpp:3265 src/muuli_wdr.cpp:3273
-#: src/muuli_wdr.cpp:3281
+#: src/muuli_wdr.cpp:1224 src/muuli_wdr.cpp:3269 src/muuli_wdr.cpp:3277
+#: src/muuli_wdr.cpp:3285
 msgid "N/A"
 msgstr "Nežinoma"
 
@@ -3604,7 +3604,7 @@ msgstr ""
 msgid "Album :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:685 src/muuli_wdr.cpp:2285
+#: src/muuli_wdr.cpp:685 src/muuli_wdr.cpp:2289
 msgid "Title :"
 msgstr "Pavadinimas:"
 
@@ -3711,7 +3711,7 @@ msgstr "Naudotojo vardas:"
 msgid "Userhash :"
 msgstr "Naudotojo maišos f-ja:"
 
-#: src/muuli_wdr.cpp:895 src/muuli_wdr.cpp:1752 src/muuli_wdr.cpp:2480
+#: src/muuli_wdr.cpp:895 src/muuli_wdr.cpp:1756 src/muuli_wdr.cpp:2484
 #: src/utils/aLinkCreator/src/alcframe.cpp:137
 msgid "Add"
 msgstr "Įdėti"
@@ -3720,15 +3720,15 @@ msgstr "Įdėti"
 msgid "Download-Speed"
 msgstr "Atsiuntimo sparta"
 
-#: src/muuli_wdr.cpp:954 src/muuli_wdr.cpp:989 src/muuli_wdr.cpp:2584
+#: src/muuli_wdr.cpp:954 src/muuli_wdr.cpp:989 src/muuli_wdr.cpp:2588
 msgid "Current"
 msgstr "Dabartinė sparta"
 
-#: src/muuli_wdr.cpp:962 src/muuli_wdr.cpp:997 src/muuli_wdr.cpp:2592
+#: src/muuli_wdr.cpp:962 src/muuli_wdr.cpp:997 src/muuli_wdr.cpp:2596
 msgid "Running average"
 msgstr "Dabartinis vidurkis"
 
-#: src/muuli_wdr.cpp:970 src/muuli_wdr.cpp:1005 src/muuli_wdr.cpp:2600
+#: src/muuli_wdr.cpp:970 src/muuli_wdr.cpp:1005 src/muuli_wdr.cpp:2604
 msgid "Session average"
 msgstr "Seanso vidurkis"
 
@@ -3740,7 +3740,7 @@ msgstr "Išsiuntimo sparta"
 msgid "Connections"
 msgstr "Ryšiai"
 
-#: src/muuli_wdr.cpp:1024 src/muuli_wdr.cpp:1871
+#: src/muuli_wdr.cpp:1024 src/muuli_wdr.cpp:1875
 msgid "Active downloads"
 msgstr "Aktyvūs atsiuntimai"
 
@@ -3748,7 +3748,7 @@ msgstr "Aktyvūs atsiuntimai"
 msgid "Active connections (1:1)"
 msgstr "Aktyvūs ryšiai (1:1)"
 
-#: src/muuli_wdr.cpp:1040 src/muuli_wdr.cpp:1872
+#: src/muuli_wdr.cpp:1040 src/muuli_wdr.cpp:1876
 msgid "Active uploads"
 msgstr "Aktyvūs išsiuntimai"
 
@@ -4025,7 +4025,7 @@ msgstr ""
 msgid "Advanced users only: If you have multiple network interfaces, enter the address of the interface to which aMule should be bound."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1462 src/muuli_wdr.cpp:2065
+#: src/muuli_wdr.cpp:1462 src/muuli_wdr.cpp:2069
 msgid "Bind to network interface (empty for any):"
 msgstr ""
 
@@ -4041,7 +4041,7 @@ msgstr ""
 msgid "Max simultaneous connections:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1498 src/muuli_wdr.cpp:3207
+#: src/muuli_wdr.cpp:1498 src/muuli_wdr.cpp:3211
 msgid "ED2K"
 msgstr "ED2K"
 
@@ -4133,781 +4133,781 @@ msgstr "Naujiems failams paskirti vietą diske"
 msgid "For new files preallocates disk space for the whole file, thus reduces fragmentation"
 msgstr "Naujiems failams iš anksto paskirti vietą diske visam failui. Taip bus sumažinta fragmentacija"
 
-#: src/muuli_wdr.cpp:1617
+#: src/muuli_wdr.cpp:1621
 msgid "Create new files as sparse files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1618
+#: src/muuli_wdr.cpp:1622
 msgid "Sparse part files only occupy disk space for the parts already downloaded, so free space is used up gradually as the file fills in. Turn this off to use an ordinary file instead - useful where sparse files are unsupported or slow, or where backup/de-duplication tools handle them badly. Applies only when the core runs on Windows; on Linux and macOS part files are sparse anyway and this setting has no effect."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1623
+#: src/muuli_wdr.cpp:1627
 msgid "Stop downloads when free disk space reaches "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1624
+#: src/muuli_wdr.cpp:1628
 msgid "Select this if you want aMule to check your disk space"
 msgstr "Įjunkite, jei norite, kad aMule tikrintų laisvą vietą diske"
 
-#: src/muuli_wdr.cpp:1628
+#: src/muuli_wdr.cpp:1632
 msgid "Enter here the min disk space desired."
 msgstr "Įrašykite kiek diske palikti laisvos vietos."
 
-#: src/muuli_wdr.cpp:1634
+#: src/muuli_wdr.cpp:1638
 msgid "Save 10 sources on rare files (< 20 sources)"
 msgstr "Įrašyti 10 šaltinių retiems failams (mažiau nei 20 šaltinių)"
 
-#: src/muuli_wdr.cpp:1638 src/Statistics.cpp:790
+#: src/muuli_wdr.cpp:1642 src/Statistics.cpp:790
 msgid "Uploads"
 msgstr "Išsiuntimai"
 
-#: src/muuli_wdr.cpp:1641
+#: src/muuli_wdr.cpp:1645
 msgid "Add new shared files with auto priority"
 msgstr "Naujiems dalinamiems failams nurodyti automatinį prioritetą"
 
-#: src/muuli_wdr.cpp:1647
+#: src/muuli_wdr.cpp:1651
 msgid "Intelligent Corruption Handling (I.C.H.)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1650
+#: src/muuli_wdr.cpp:1654
 msgid "Enable"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1653
+#: src/muuli_wdr.cpp:1657
 msgid "Advanced I.C.H. trusts every hash (not recommended)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1665 src/PrefsUnifiedDlg.cpp:1990
+#: src/muuli_wdr.cpp:1669 src/PrefsUnifiedDlg.cpp:1999
 msgid "Media metadata extraction"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1669
+#: src/muuli_wdr.cpp:1673
 msgid "Extract length / bitrate / codec from shared audio and video files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1671
+#: src/muuli_wdr.cpp:1675
 msgid "When enabled, aMule runs ffprobe on each shared media file to fill in the Length / Bitrate / Codec columns other clients see when they find the file in a search. Requires ffmpeg (the ffprobe binary) to be installed."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1678
+#: src/muuli_wdr.cpp:1682
 msgid "Path to ffprobe:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1683
+#: src/muuli_wdr.cpp:1687
 msgid "Full path to the ffprobe binary. Leave empty to have aMule auto-detect it on startup."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1691
+#: src/muuli_wdr.cpp:1695
 msgid "Detect"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1692
+#: src/muuli_wdr.cpp:1696
 msgid "Search the standard install locations for an ffprobe binary and fill the path field."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1716
+#: src/muuli_wdr.cpp:1720
 msgid ""
 "Completed downloads are stored here. All files in this folder are automatically shared with other peers.\n"
 "If this folder also holds files you don't want to share, point it at an aMule-only sub-folder."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1719
+#: src/muuli_wdr.cpp:1723
 msgid "Pick the folder where completed downloads will be stored. All files in that folder will be shared with other peers."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1733
+#: src/muuli_wdr.cpp:1737
 msgid "Shared folders"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1739
+#: src/muuli_wdr.cpp:1743
 msgid "(Folders shared by the core. Enter a path to add one.)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1747
+#: src/muuli_wdr.cpp:1751
 msgid "Absolute path of a folder on the core's machine, e.g. /home/user/shared"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1749 src/PrefsUnifiedDlg.cpp:2874
+#: src/muuli_wdr.cpp:1753 src/PrefsUnifiedDlg.cpp:2883
 msgid "Recursive"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1750
+#: src/muuli_wdr.cpp:1754
 msgid "Share every sub-folder underneath this one, including ones created later."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1754 src/utils/aLinkCreator/src/alcframe.cpp:141
+#: src/muuli_wdr.cpp:1758 src/utils/aLinkCreator/src/alcframe.cpp:141
 msgid "Remove"
 msgstr "Pašalinti"
 
-#: src/muuli_wdr.cpp:1758
+#: src/muuli_wdr.cpp:1762
 msgid "(Right click on folder icon for recursive share)"
 msgstr "(spragtelėję dešiniu klavišu dalinsitės ir gilesniais paaplankiais)"
 
-#: src/muuli_wdr.cpp:1765
+#: src/muuli_wdr.cpp:1769
 msgid "Share hidden files"
 msgstr "Dalintis slepiamais failais"
 
-#: src/muuli_wdr.cpp:1771
+#: src/muuli_wdr.cpp:1775
 msgid "Automatically rescan shared folders for changes"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1777
+#: src/muuli_wdr.cpp:1781
 msgid "Follow symbolic links in shared folders"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1783
+#: src/muuli_wdr.cpp:1787
 msgid "Exclude files matching:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1786
+#: src/muuli_wdr.cpp:1790
 msgid "Wildcard patterns separated by '|', e.g. .DS_Store|Thumbs.db|*.tmp. Files whose name matches are not shared. Matching is case-insensitive."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1790
+#: src/muuli_wdr.cpp:1794
 msgid "Patterns are regular expressions"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1791
+#: src/muuli_wdr.cpp:1795
 msgid "When set, the whole field is one regular expression ('|' is alternation). When unset, it is a list of '|'-separated wildcards."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1801
+#: src/muuli_wdr.cpp:1805
 msgid "Show how many shared files the current pattern would exclude."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1822
+#: src/muuli_wdr.cpp:1826
 msgid "Graphs"
 msgstr "Grafikai"
 
-#: src/muuli_wdr.cpp:1825 src/muuli_wdr.cpp:1887
+#: src/muuli_wdr.cpp:1829 src/muuli_wdr.cpp:1891
 msgid "Update delay : 5 secs"
 msgstr "Atnaujinimo dažnis: 5 s"
 
-#: src/muuli_wdr.cpp:1829
+#: src/muuli_wdr.cpp:1833
 msgid "Time for average graph: 100 mins"
 msgstr "Vidurkių grafiko dydis: 100 min"
 
-#: src/muuli_wdr.cpp:1833
+#: src/muuli_wdr.cpp:1837
 msgid "Connections Graph Scale: 100 "
 msgstr "Ryšių grafiko skalė: 100 "
 
-#: src/muuli_wdr.cpp:1840
+#: src/muuli_wdr.cpp:1844
 msgid "Download graph scale:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1848
+#: src/muuli_wdr.cpp:1852
 msgid "Upload graph scale:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1858
+#: src/muuli_wdr.cpp:1862
 msgid "Colors: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1862
+#: src/muuli_wdr.cpp:1866
 msgid "Background"
 msgstr "Fonas"
 
-#: src/muuli_wdr.cpp:1863
+#: src/muuli_wdr.cpp:1867
 msgid "Grid"
 msgstr "Rėmeliai"
 
-#: src/muuli_wdr.cpp:1864
+#: src/muuli_wdr.cpp:1868
 msgid "Download current"
 msgstr "Dabartinė atsiuntimo sparta"
 
-#: src/muuli_wdr.cpp:1865
+#: src/muuli_wdr.cpp:1869
 msgid "Download running average"
 msgstr "Dabartinis atsiuntimo vidurkis"
 
-#: src/muuli_wdr.cpp:1866
+#: src/muuli_wdr.cpp:1870
 msgid "Download session average"
 msgstr "Seanso atsiuntimo vidurkis"
 
-#: src/muuli_wdr.cpp:1867
+#: src/muuli_wdr.cpp:1871
 msgid "Upload current"
 msgstr "Dabartinė išsiuntimo sparta"
 
-#: src/muuli_wdr.cpp:1868
+#: src/muuli_wdr.cpp:1872
 msgid "Upload running average"
 msgstr "Dabartinis išsiuntimo vidurkis"
 
-#: src/muuli_wdr.cpp:1869
+#: src/muuli_wdr.cpp:1873
 msgid "Upload session average"
 msgstr "Seanso išsiuntimo vidurkis"
 
-#: src/muuli_wdr.cpp:1870
+#: src/muuli_wdr.cpp:1874
 msgid "Active connections"
 msgstr "Aktyvūs ryšiai"
 
-#: src/muuli_wdr.cpp:1873
+#: src/muuli_wdr.cpp:1877
 #, fuzzy
 msgid "Systray Icon Speed Bar"
 msgstr "Sistemos dėklo spartos indikatorius"
 
-#: src/muuli_wdr.cpp:1874
+#: src/muuli_wdr.cpp:1878
 msgid "Kad-nodes current"
 msgstr "Dabartiniai Kademlia mazgai"
 
-#: src/muuli_wdr.cpp:1875
+#: src/muuli_wdr.cpp:1879
 msgid "Kad-nodes running"
 msgstr "Kademlia mazgų dabartinis vidurkis"
 
-#: src/muuli_wdr.cpp:1876
+#: src/muuli_wdr.cpp:1880
 msgid "Kad-nodes session"
 msgstr "Kademlia mazgų seanso vidurkis"
 
-#: src/muuli_wdr.cpp:1880 src/muuli_wdr.cpp:2334
+#: src/muuli_wdr.cpp:1884 src/muuli_wdr.cpp:2338
 msgid "Select"
 msgstr "Nurodykite spalvą"
 
-#: src/muuli_wdr.cpp:1884
+#: src/muuli_wdr.cpp:1888
 msgid "Tree"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1894
+#: src/muuli_wdr.cpp:1898
 msgid "Number of Client Versions shown (0=unlimited)"
 msgstr "Rodomų klientų versijų skaičius (0 – neribojama)"
 
-#: src/muuli_wdr.cpp:1919
+#: src/muuli_wdr.cpp:1923
 msgid "!!! WARNING !!!"
 msgstr "DĖMESIO!!!"
 
-#: src/muuli_wdr.cpp:1934
+#: src/muuli_wdr.cpp:1938
 msgid "Max new connections / 5 secs"
 msgstr "Per 5 s užmegzti ne daugiau ryšių, nei nurodyta"
 
-#: src/muuli_wdr.cpp:1936
+#: src/muuli_wdr.cpp:1940
 msgid "Concurrent Kad source lookups"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1938
+#: src/muuli_wdr.cpp:1942
 #, fuzzy
 msgid "Kad source re-search interval (minutes)"
 msgstr "FTP atnaujinimo intervalas minutėmis"
 
-#: src/muuli_wdr.cpp:1940
+#: src/muuli_wdr.cpp:1944
 #, fuzzy
 msgid "Source re-ask interval (minutes)"
 msgstr "FTP atnaujinimo intervalas minutėmis"
 
-#: src/muuli_wdr.cpp:1944
+#: src/muuli_wdr.cpp:1948
 msgid "File Buffer Size: 240000 bytes"
 msgstr "Failo buferio dydis: 240000 baitai"
 
-#: src/muuli_wdr.cpp:1948
+#: src/muuli_wdr.cpp:1952
 msgid "Use MMAP: memory-mapped file access (lower memory use)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1949
+#: src/muuli_wdr.cpp:1953
 msgid "Maps part files into memory instead of buffering them on the heap, lowering the process memory footprint. May reduce download speed on some disks; best for memory-constrained or upload-heavy hosts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1951
+#: src/muuli_wdr.cpp:1955
 msgid "Upload Queue Size: 5000 clients"
 msgstr "Išsiuntimo eilė: 5000 klientų"
 
-#: src/muuli_wdr.cpp:1955
+#: src/muuli_wdr.cpp:1959
 msgid "Server connection refresh interval: Disable"
 msgstr "Serverio ryšio atnaujinimo intervalas: išjungta"
 
-#: src/muuli_wdr.cpp:1959
+#: src/muuli_wdr.cpp:1963
 msgid "Disable computer's timed standby mode"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1978
+#: src/muuli_wdr.cpp:1982
 msgid "Skin to use: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1987
+#: src/muuli_wdr.cpp:1991
 msgid "Show \"Fast eD2k Links Handler\" in every window."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1990
+#: src/muuli_wdr.cpp:1994
 msgid "Show extended info on categories tabs"
 msgstr "Rodyti papildomą informaciją kategorijų kortelėse"
 
-#: src/muuli_wdr.cpp:1993
+#: src/muuli_wdr.cpp:1997
 #, fuzzy
 msgid "Show application version on title"
 msgstr "Rodyti siuntimo spartą failo pavadinime"
 
-#: src/muuli_wdr.cpp:1995
+#: src/muuli_wdr.cpp:1999
 msgid "Show transfer rates on title"
 msgstr "Rodyti siuntimo spartą failo pavadinime"
 
-#: src/muuli_wdr.cpp:1997
+#: src/muuli_wdr.cpp:2001
 msgid "Before application name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1999
+#: src/muuli_wdr.cpp:2003
 msgid "After application name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2002
+#: src/muuli_wdr.cpp:2006
 msgid "Show overhead bandwidth"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2006
+#: src/muuli_wdr.cpp:2010
 msgid "Vertical toolbar orientation"
 msgstr "Mygtukus išdėstyti vertikaliai"
 
-#: src/muuli_wdr.cpp:2008
+#: src/muuli_wdr.cpp:2012
 msgid "Live column sorting (auto-reorder rows as their values change)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2015
+#: src/muuli_wdr.cpp:2019
 msgid "Download Queue Files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2018
+#: src/muuli_wdr.cpp:2022
 msgid "Show progress percentage"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2024
+#: src/muuli_wdr.cpp:2028
 msgid "Show progress bar"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2027
+#: src/muuli_wdr.cpp:2031
 msgid "Flat"
 msgstr "Plokščia"
 
-#: src/muuli_wdr.cpp:2031
+#: src/muuli_wdr.cpp:2035
 msgid "Round"
 msgstr "Erdvinė"
 
-#: src/muuli_wdr.cpp:2049
+#: src/muuli_wdr.cpp:2053
 msgid "External Connection Parameters"
 msgstr "Išorinio ryšio parinktys"
 
-#: src/muuli_wdr.cpp:2052
+#: src/muuli_wdr.cpp:2056
 msgid "Accept external connections"
 msgstr "Priimti išorinius ryšius"
 
-#: src/muuli_wdr.cpp:2059 src/muuli_wdr.cpp:2118
+#: src/muuli_wdr.cpp:2063 src/muuli_wdr.cpp:2122
 msgid "IP of the listening interface:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2062
+#: src/muuli_wdr.cpp:2066
 msgid "Enter here a valid ip in the a.b.c.d format for the listening EC interface. An empty field or 0.0.0.0 will mean any interface."
 msgstr "Įrašykite išorinių ryšių besiklausančio įrenginio IP adresą a.b.c.d forma. Tuščias laukelis arba adresas 0.0.0.0 reiškia bet kokį įrenginį."
 
-#: src/muuli_wdr.cpp:2083 src/muuli_wdr.cpp:2194
+#: src/muuli_wdr.cpp:2087 src/muuli_wdr.cpp:2198
 msgid "TCP port:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2089
+#: src/muuli_wdr.cpp:2093
 msgid "Enable UPnP port forwarding on the EC port"
 msgstr "EC prievade įjungti UPnP prievadų perdavimą"
 
-#: src/muuli_wdr.cpp:2093 src/muuli_wdr.cpp:3079
+#: src/muuli_wdr.cpp:2097 src/muuli_wdr.cpp:3083
 #: src/utils/wxCas/src/wxcasprefs.cpp:167
 msgid "Password"
 msgstr "Slaptažodis"
 
-#: src/muuli_wdr.cpp:2099
+#: src/muuli_wdr.cpp:2103
 #, fuzzy
 msgid "aMule API server parameters"
 msgstr "Žiniatinklio serverio parinktys"
 
-#: src/muuli_wdr.cpp:2102
+#: src/muuli_wdr.cpp:2106
 msgid "Run amuleapi (REST API) on startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2107
+#: src/muuli_wdr.cpp:2111
 #, fuzzy
 msgid "HTTP port:"
 msgstr "TCP prievadas: %d"
 
-#: src/muuli_wdr.cpp:2121
+#: src/muuli_wdr.cpp:2125
 msgid "The interface amuleapi's HTTP server listens on. 127.0.0.1 (default) accepts only local connections; use 0.0.0.0 or a specific IP to expose it to other hosts (set an admin password below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2126
+#: src/muuli_wdr.cpp:2130
 msgid "Type a password to set or change it. Stored passwords cannot be shown, so leaving this empty keeps the current one."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2128
+#: src/muuli_wdr.cpp:2132
 #, fuzzy
 msgid "Admin password"
 msgstr "Tikrinamas slaptažodis\n"
 
-#: src/muuli_wdr.cpp:2140 src/muuli_wdr.cpp:2157 src/PrefsUnifiedDlg.cpp:1103
+#: src/muuli_wdr.cpp:2144 src/muuli_wdr.cpp:2161 src/PrefsUnifiedDlg.cpp:1112
 #, fuzzy
 msgid "A password is set."
 msgstr "Tikrinamas slaptažodis\n"
 
-#: src/muuli_wdr.cpp:2144
+#: src/muuli_wdr.cpp:2148
 #, fuzzy
 msgid "Enable guest access"
 msgstr "Išjungti svečio prieigą"
 
-#: src/muuli_wdr.cpp:2145
+#: src/muuli_wdr.cpp:2149
 msgid "Guest sessions may read status and listings but cannot change anything. Turning this off clears the stored guest password."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2149
+#: src/muuli_wdr.cpp:2153
 #, fuzzy
 msgid "Guest password"
 msgstr "Svečio prieigos prie žiniatinklio serverio slaptažodis"
 
-#: src/muuli_wdr.cpp:2164
+#: src/muuli_wdr.cpp:2168
 msgid "Web server parameters"
 msgstr "Žiniatinklio serverio parinktys"
 
-#: src/muuli_wdr.cpp:2167
+#: src/muuli_wdr.cpp:2171
 msgid "Run webserver on startup (deprecated)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2173
+#: src/muuli_wdr.cpp:2177
 msgid "Web template"
 msgstr "www šablonas"
 
-#: src/muuli_wdr.cpp:2178
+#: src/muuli_wdr.cpp:2182
 msgid "Full rights password"
 msgstr "Pilnos prieigos slaptažodis"
 
-#: src/muuli_wdr.cpp:2182
+#: src/muuli_wdr.cpp:2186
 msgid "Enable Low rights User"
 msgstr "Įjungti nepilnos prieigos naudotoją"
 
-#: src/muuli_wdr.cpp:2187
+#: src/muuli_wdr.cpp:2191
 msgid "Low rights password"
 msgstr "Nepilnos prieigos slaptažodis"
 
-#: src/muuli_wdr.cpp:2201
+#: src/muuli_wdr.cpp:2205
 msgid "Enable UPnP port forwarding of the web server port"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2206
+#: src/muuli_wdr.cpp:2210
 msgid "Web server UPnP TCP port (Optional)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2214
+#: src/muuli_wdr.cpp:2218
 msgid "Page Refresh Time (in secs)"
 msgstr "Puslapio atnaujinimo periodas (sekundėmis)"
 
-#: src/muuli_wdr.cpp:2221
+#: src/muuli_wdr.cpp:2225
 msgid "Enable Gzip compression"
 msgstr "Įjungti Gzip suspaudimą"
 
-#: src/muuli_wdr.cpp:2255
+#: src/muuli_wdr.cpp:2259
 #, fuzzy
 msgid "Reset page to defaults"
 msgstr "Numatyta"
 
-#: src/muuli_wdr.cpp:2256
+#: src/muuli_wdr.cpp:2260
 msgid "Reset the settings on the current page to their default values."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2258 src/muuli_wdr.cpp:2344 src/ServerWnd.cpp:274
+#: src/muuli_wdr.cpp:2262 src/muuli_wdr.cpp:2348 src/ServerWnd.cpp:274
 #: src/ServerWnd.cpp:282
 msgid "OK"
 msgstr "Gerai"
 
-#: src/muuli_wdr.cpp:2260
+#: src/muuli_wdr.cpp:2264
 msgid "Click here to apply any changes made to the preferences."
 msgstr "Patvirtinti naujai nurodytas parinktis."
 
-#: src/muuli_wdr.cpp:2263
+#: src/muuli_wdr.cpp:2267
 msgid "Reset any changes made to the preferences."
 msgstr "Atšaukti bet kokius pakeitimus."
 
-#: src/muuli_wdr.cpp:2292
+#: src/muuli_wdr.cpp:2296
 msgid "Comment :"
 msgstr "Komentaras:"
 
-#: src/muuli_wdr.cpp:2299
+#: src/muuli_wdr.cpp:2303
 msgid "Incoming Dir :"
 msgstr "Atsiųstų failų aplankas:"
 
-#: src/muuli_wdr.cpp:2308
+#: src/muuli_wdr.cpp:2312
 msgid "Change priority for new assigned files :"
 msgstr "Keisti naujai priskirtų failų prioritetą:"
 
-#: src/muuli_wdr.cpp:2312
+#: src/muuli_wdr.cpp:2316
 #, fuzzy
 msgid "Don't change"
 msgstr "Nekeisti"
 
-#: src/muuli_wdr.cpp:2324
+#: src/muuli_wdr.cpp:2328
 msgid "Select color for this Category (currently selected) :"
 msgstr "Nurodykite dabartinės kategorijos spalvą:"
 
-#: src/muuli_wdr.cpp:2391 src/muuli_wdr.cpp:2410 src/muuli_wdr.cpp:2432
+#: src/muuli_wdr.cpp:2395 src/muuli_wdr.cpp:2414 src/muuli_wdr.cpp:2436
 msgid "Click this button to reset the log."
 msgstr "Išvalyti įvykių žurnalą."
 
-#: src/muuli_wdr.cpp:2451
+#: src/muuli_wdr.cpp:2455
 msgid "Click on this button to update the servers list from URL ..."
 msgstr "Paspaudę šį mygtuką atnaujinsite serverių sąrašą iš URL..."
 
-#: src/muuli_wdr.cpp:2455
+#: src/muuli_wdr.cpp:2459
 msgid "Server list"
 msgstr "Serverių sąrašas"
 
-#: src/muuli_wdr.cpp:2459
+#: src/muuli_wdr.cpp:2463
 msgid "Enter the url to a server.met file here and press the button to the left to update the list of known servers."
 msgstr "Įrašykite server.met failo URL ir paspaudę mygtuką kairėje atnaujinsite serverių sąrašą."
 
-#: src/muuli_wdr.cpp:2464
+#: src/muuli_wdr.cpp:2468
 msgid "Add server manually: Name"
 msgstr "Įdėti serverį rankiniu būdu: pavadinimas"
 
-#: src/muuli_wdr.cpp:2467
+#: src/muuli_wdr.cpp:2471
 msgid "Enter the name of the new server here"
 msgstr "Įrašykite serverio pavadinimą"
 
-#: src/muuli_wdr.cpp:2469 src/ServerWnd.cpp:206
+#: src/muuli_wdr.cpp:2473 src/ServerWnd.cpp:206
 msgid "IP:Port"
 msgstr "IP:prievadas"
 
-#: src/muuli_wdr.cpp:2472
+#: src/muuli_wdr.cpp:2476
 msgid "Enter the IP of the server here, using the x.x.x.x format."
 msgstr "Įrašykite serverio IP adresą naudodami a.b.c.d formą."
 
-#: src/muuli_wdr.cpp:2478
+#: src/muuli_wdr.cpp:2482
 msgid "Enter the port of the server here."
 msgstr "Įrašykite serverio prievadą."
 
-#: src/muuli_wdr.cpp:2481
+#: src/muuli_wdr.cpp:2485
 msgid "Add manually a server (fill fields to the left before) ..."
 msgstr "Įdėti serverį (prieš tai užpildykite laukelius kairėje)..."
 
-#: src/muuli_wdr.cpp:2510
+#: src/muuli_wdr.cpp:2514
 msgid "aMule Log"
 msgstr "aMule žurnalas"
 
-#: src/muuli_wdr.cpp:2518
+#: src/muuli_wdr.cpp:2522
 msgid "Server Info"
 msgstr "Serverio informacija"
 
-#: src/muuli_wdr.cpp:2522
+#: src/muuli_wdr.cpp:2526
 msgid "ED2K Info"
 msgstr "ED2K informacija"
 
-#: src/muuli_wdr.cpp:2526
+#: src/muuli_wdr.cpp:2530
 msgid "Kad Info"
 msgstr "Kademlia informacija"
 
-#: src/muuli_wdr.cpp:2554
+#: src/muuli_wdr.cpp:2558
 msgid "Click on this button to update the nodes list from URL ..."
 msgstr "Spragtelėję šį mygtuką atnaujinsite mazgų sąrašą iš URL..."
 
-#: src/muuli_wdr.cpp:2558
+#: src/muuli_wdr.cpp:2562
 msgid "Nodes (0)"
 msgstr "Mazgai (0)"
 
-#: src/muuli_wdr.cpp:2562
+#: src/muuli_wdr.cpp:2566
 msgid "Enter the url to a nodes.dat file here and press the button to the left to update the list of known nodes."
 msgstr "Įrašykite nodes.dat failo URL ir paspaudę mygtuką kairėje atnaujinsite mazgų sąrašą."
 
-#: src/muuli_wdr.cpp:2565
+#: src/muuli_wdr.cpp:2569
 msgid "Nodes stats"
 msgstr "Mazgų statistika"
 
-#: src/muuli_wdr.cpp:2607
+#: src/muuli_wdr.cpp:2611
 msgid "Bootstrap"
 msgstr "Inicializavimas"
 
-#: src/muuli_wdr.cpp:2610
+#: src/muuli_wdr.cpp:2614
 msgid "New node"
 msgstr "Naujas mazgas"
 
-#: src/muuli_wdr.cpp:2615
+#: src/muuli_wdr.cpp:2619
 msgid "IP:"
 msgstr "IP:"
 
-#: src/muuli_wdr.cpp:2635
+#: src/muuli_wdr.cpp:2639
 msgid "Port:"
 msgstr "Prievadas:"
 
-#: src/muuli_wdr.cpp:2648
+#: src/muuli_wdr.cpp:2652
 #, fuzzy
 msgid "Bootstrap from known clients"
 msgstr ""
 "Inicializuoti iš \n"
 "žinomų klientų"
 
-#: src/muuli_wdr.cpp:2650
+#: src/muuli_wdr.cpp:2654
 msgid "Disconnect Kad"
 msgstr "Atjungti Kademlia"
 
-#: src/muuli_wdr.cpp:2684
+#: src/muuli_wdr.cpp:2688
 msgid "Use Secure User Identification"
 msgstr "Naudoti saugų kliento atpažinimą"
 
-#: src/muuli_wdr.cpp:2686
+#: src/muuli_wdr.cpp:2690
 msgid "It is recommended to enable this option. You will not receive credits if SUI is not enabled."
 msgstr "Rekomenduojama įjungti šią parinktį. Jei išjungsite, negausite kreditų."
 
-#: src/muuli_wdr.cpp:2688
+#: src/muuli_wdr.cpp:2692
 msgid "Protocol Obfuscation"
 msgstr "Protokolo slėpimas"
 
-#: src/muuli_wdr.cpp:2691
+#: src/muuli_wdr.cpp:2695
 msgid "Support Protocol Obfuscation"
 msgstr "Įjungti protokolo slėpimą"
 
-#: src/muuli_wdr.cpp:2693
+#: src/muuli_wdr.cpp:2697
 msgid "This option enabled Protocol Obfuscation, and makes aMule accept obfuscated connections from other clients."
 msgstr "Ši parinktis įjungia protokolo slėpimą. Tuomet aMule priiminės slepiamus ryšius iš kitų klientų."
 
-#: src/muuli_wdr.cpp:2695
+#: src/muuli_wdr.cpp:2699
 msgid "Use obfuscation for outgoing connections"
 msgstr "Slėpti išeinančius ryšius"
 
-#: src/muuli_wdr.cpp:2697
+#: src/muuli_wdr.cpp:2701
 msgid "This option makes aMule use Protocol Obfuscation when connecting other clients/servers."
 msgstr "Įjungus šią parinktį aMule, jungdamasi prie kitų klientų ar serverių, slėps išeinančius ryšius."
 
-#: src/muuli_wdr.cpp:2699
+#: src/muuli_wdr.cpp:2703
 msgid "Accept only obfuscated connections"
 msgstr "Priimti tik slepiamus ryšius"
 
-#: src/muuli_wdr.cpp:2700
+#: src/muuli_wdr.cpp:2704
 msgid "This option makes aMule only accept obfuscated connections. You will have less sources, but all your traffic will be obfuscated"
 msgstr "Įjungus šią parinktį aMule priims tik slepiamus ryšius. Šaltinių bus rasta mažiau, bet visas srautas bus slepiamas"
 
-#: src/muuli_wdr.cpp:2705
+#: src/muuli_wdr.cpp:2709
 msgid "Everybody"
 msgstr "Visi"
 
-#: src/muuli_wdr.cpp:2707
+#: src/muuli_wdr.cpp:2711
 msgid "No one"
 msgstr "Niekas"
 
-#: src/muuli_wdr.cpp:2709
+#: src/muuli_wdr.cpp:2713
 msgid "Who can see my shared files:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2710
+#: src/muuli_wdr.cpp:2714
 msgid "Select who can request to view a list of your shared files."
 msgstr "Nurodykite kas gali pamatyti dalinamų failų sąrašą."
 
-#: src/muuli_wdr.cpp:2712
+#: src/muuli_wdr.cpp:2716
 msgid "IP-Filtering"
 msgstr "IP filtravimas"
 
-#: src/muuli_wdr.cpp:2719
+#: src/muuli_wdr.cpp:2723
 msgid "Filter clients"
 msgstr "Filtruoti klientus"
 
-#: src/muuli_wdr.cpp:2721
+#: src/muuli_wdr.cpp:2725
 msgid "Enable filtering of the client IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "Įjungti klientų IP adresų filtravimą, aprašytą ~/.aMule/ipfilter.dat faile."
 
-#: src/muuli_wdr.cpp:2723
+#: src/muuli_wdr.cpp:2727
 msgid "Filter servers"
 msgstr "Filtruoti serverius"
 
-#: src/muuli_wdr.cpp:2725
+#: src/muuli_wdr.cpp:2729
 msgid "Enable filtering of the server IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "Įjungti serverių IP adresų filtravimą, aprašytą ~/.aMule/ipfilter.dat faile."
 
-#: src/muuli_wdr.cpp:2729
+#: src/muuli_wdr.cpp:2733
 msgid "Reload List"
 msgstr "Atnaujinti sąrašą"
 
-#: src/muuli_wdr.cpp:2730
+#: src/muuli_wdr.cpp:2734
 msgid "Reload the list of IPs to filter from the file ~/.aMule/ipfilter.dat"
 msgstr "Atnaujinti IP adresų sąrašą iš ~/.aMule/ipfilter.dat failo"
 
-#: src/muuli_wdr.cpp:2736
+#: src/muuli_wdr.cpp:2740
 msgid "URL:"
 msgstr "URL:"
 
-#: src/muuli_wdr.cpp:2740 src/muuli_wdr.cpp:2933
+#: src/muuli_wdr.cpp:2744 src/muuli_wdr.cpp:2937
 msgid "Update now"
 msgstr "Atnaujinti dabar"
 
-#: src/muuli_wdr.cpp:2743
+#: src/muuli_wdr.cpp:2747
 msgid "Auto-update ipfilter at startup"
 msgstr "Automatiškai įkelti IP filtrą paleidus programą"
 
-#: src/muuli_wdr.cpp:2747
+#: src/muuli_wdr.cpp:2751
 msgid "Filtering Level:"
 msgstr "Filtravimo lygmuo:"
 
-#: src/muuli_wdr.cpp:2753
+#: src/muuli_wdr.cpp:2757
 msgid "Always filter LAN IPs"
 msgstr "Visuomet filtruoti LAN IP adresus"
 
-#: src/muuli_wdr.cpp:2756
+#: src/muuli_wdr.cpp:2760
 msgid "Paranoid handling of non-matching IPs"
 msgstr "Paranojiškai elgtis su neatitikusiais IP adresais"
 
-#: src/muuli_wdr.cpp:2758
+#: src/muuli_wdr.cpp:2762
 msgid "Rejects a packet when its source IP differs from the IP the client claims (an anti-spoofing check). Disable only if it causes connection problems."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2760
+#: src/muuli_wdr.cpp:2764
 msgid "Use system-wide ipfilter.dat if available"
 msgstr "Jei įjungtas, naudoti ipfilter.dat failą visoje sistemoje"
 
-#: src/muuli_wdr.cpp:2761
+#: src/muuli_wdr.cpp:2765
 #, fuzzy
 msgid "If there's no local ipfilter.dat found, allow usage of a system-wide ipfilter file."
 msgstr "Jei nėra vietinio ipilter.dat failo, naudoti ipfilter.dat visoje sistemoje."
 
-#: src/muuli_wdr.cpp:2778
+#: src/muuli_wdr.cpp:2782
 msgid "Enable Online-Signature"
 msgstr "Įjungti keičiamą parašą"
 
-#: src/muuli_wdr.cpp:2780
+#: src/muuli_wdr.cpp:2784
 msgid "Enables the writing of the OS file, which can be used by external apps to create signatures and the like."
 msgstr "Įjungus šią parinktį bus įrašomas keičiamo parašo failas, kurį galite naudoti kitoje programoje parašų kūrimui ir pan."
 
-#: src/muuli_wdr.cpp:2784
+#: src/muuli_wdr.cpp:2788
 msgid "Update Frequency (Secs):"
 msgstr "Atnaujinimo dažnis (sekundėmis):"
 
-#: src/muuli_wdr.cpp:2787
+#: src/muuli_wdr.cpp:2791
 msgid "Change the frequency (in seconds) of Online Signature updates."
 msgstr "Keičiamo parašo atnaujinimo dažnis sekundėmis."
 
-#: src/muuli_wdr.cpp:2795
+#: src/muuli_wdr.cpp:2799
 msgid "Save online signature file in: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:2801
+#: src/muuli_wdr.cpp:2805
 msgid "Click here to select the directory containing the the Online Signature files."
 msgstr "Nurodykite aplanką, kuriame yra keičiamo parašo failas."
 
-#: src/muuli_wdr.cpp:2834
+#: src/muuli_wdr.cpp:2838
 msgid "Show country flags for clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2835
+#: src/muuli_wdr.cpp:2839
 msgid "Render the country flag column in the transfers, queue and search views. Requires a valid MMDB GeoIP database (see below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2840
+#: src/muuli_wdr.cpp:2844
 #, fuzzy
 msgid "Database"
 msgstr "Siuntimo sparta:"
 
-#: src/muuli_wdr.cpp:2856
+#: src/muuli_wdr.cpp:2860
 #, fuzzy
 msgid "Source:"
 msgstr "Šaltiniai"
 
-#: src/muuli_wdr.cpp:2859
+#: src/muuli_wdr.cpp:2863
 msgid "DB-IP (free, no account)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2860
+#: src/muuli_wdr.cpp:2864
 msgid "MaxMind GeoLite2 (free, account required)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2861
+#: src/muuli_wdr.cpp:2865
 msgid "Custom URL"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2864
+#: src/muuli_wdr.cpp:2868
 msgid "Choose which provider supplies the GeoIP MMDB database. DB-IP is the default - no account required. MaxMind requires a free account + license key. Use Custom URL to point at any other MMDB host (e.g. a local mirror)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2881
+#: src/muuli_wdr.cpp:2885
 msgid ""
 "No configuration required.\n"
 "\n"
@@ -4915,11 +4915,11 @@ msgid ""
 "License: Creative Commons BY 4.0 - https://creativecommons.org/licenses/by/4.0/"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2894
+#: src/muuli_wdr.cpp:2898
 msgid "License key:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2900
+#: src/muuli_wdr.cpp:2904
 msgid ""
 "Sign up for a free MaxMind account, then generate a License Key:\n"
 "https://www.maxmind.com/en/geolite2/signup\n"
@@ -4929,232 +4929,232 @@ msgid ""
 "Requires attribution and account registration; refresh at least every 30 days."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2915
+#: src/muuli_wdr.cpp:2919
 #, fuzzy
 msgid "Download URL:"
 msgstr "Atsiųsta: "
 
-#: src/muuli_wdr.cpp:2921
+#: src/muuli_wdr.cpp:2925
 msgid ""
 "Must point to an .mmdb file or a .gz / .tar.gz containing one.\n"
 "URL may include credentials (https://user:pass@host/...).\n"
 "License and attribution terms are set by the upstream URL - you are responsible."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2934
+#: src/muuli_wdr.cpp:2938
 msgid "Download the GeoIP database from the selected source."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2936
+#: src/muuli_wdr.cpp:2940
 #, fuzzy
 msgid "Auto-update on startup"
 msgstr "Automatiškai įkelti IP filtrą paleidus programą"
 
-#: src/muuli_wdr.cpp:2937
+#: src/muuli_wdr.cpp:2941
 msgid "Re-download the GeoIP database from the selected source every time aMule starts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2960
+#: src/muuli_wdr.cpp:2964
 msgid "Filter incoming messages (except current chat):"
 msgstr "Filtruoti gaunamas žinutes (išskyrus dabartinį pokalbį):"
 
-#: src/muuli_wdr.cpp:2962
+#: src/muuli_wdr.cpp:2966
 msgid "Filter all messages"
 msgstr "Filtruoti visas žinutes"
 
-#: src/muuli_wdr.cpp:2964
+#: src/muuli_wdr.cpp:2968
 msgid "Filter messages from people not on your friend list"
 msgstr "Filtruoti žinutes nuo naudotojų, nesančių draugų sąraše"
 
-#: src/muuli_wdr.cpp:2966
+#: src/muuli_wdr.cpp:2970
 msgid "Filter messages from unknown clients"
 msgstr "Filtruoti žinutes nuo nežinomų klientų"
 
-#: src/muuli_wdr.cpp:2968
+#: src/muuli_wdr.cpp:2972
 msgid "Filter messages containing (use ',' as separator):"
 msgstr "Filtruoti žinutes turinčias tekstą („,“ naudokite kaip skirtuką):"
 
-#: src/muuli_wdr.cpp:2971 src/muuli_wdr.cpp:2982
+#: src/muuli_wdr.cpp:2975 src/muuli_wdr.cpp:2986
 msgid "add here the words amule should filter and block messages including it"
 msgstr "Įrašykite žodžius, kurių aMule ieškos žinutės tekste ir filtruos žinutę"
 
-#: src/muuli_wdr.cpp:2973
+#: src/muuli_wdr.cpp:2977
 msgid "Show received messages in the log"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2976
+#: src/muuli_wdr.cpp:2980
 msgid "Comments"
 msgstr "Komentarai"
 
-#: src/muuli_wdr.cpp:2979
+#: src/muuli_wdr.cpp:2983
 msgid "Filter comments containing (use ',' as separator):"
 msgstr "Filtruoti komentarus, turinčius (atskirkite kableliu):"
 
-#: src/muuli_wdr.cpp:3004
+#: src/muuli_wdr.cpp:3008
 msgid "Enable Proxy"
 msgstr "Įjungti atstovaujančius serverius"
 
-#: src/muuli_wdr.cpp:3005
+#: src/muuli_wdr.cpp:3009
 msgid "Enable/disable proxy support"
 msgstr "Įjungti ar išjungti atstovaujančius serverius"
 
-#: src/muuli_wdr.cpp:3008
+#: src/muuli_wdr.cpp:3012
 msgid "Proxy type:"
 msgstr "Serverio tipas:"
 
-#: src/muuli_wdr.cpp:3019
+#: src/muuli_wdr.cpp:3023
 msgid "Proxy host:"
 msgstr "Serverio mazgas:"
 
-#: src/muuli_wdr.cpp:3022
+#: src/muuli_wdr.cpp:3026
 msgid "The proxy host name"
 msgstr "Atstovaujančio serverio mazgo pavadinimas"
 
-#: src/muuli_wdr.cpp:3024
+#: src/muuli_wdr.cpp:3028
 msgid "Proxy port:"
 msgstr "Serverio prievadas:"
 
-#: src/muuli_wdr.cpp:3027
+#: src/muuli_wdr.cpp:3031
 msgid "The proxy port"
 msgstr "Atstovaujančio serverio prievadas"
 
-#: src/muuli_wdr.cpp:3029
+#: src/muuli_wdr.cpp:3033
 msgid "Enable authentication"
 msgstr "Įjungti autentifikavimą"
 
-#: src/muuli_wdr.cpp:3030
+#: src/muuli_wdr.cpp:3034
 msgid "Enable/disable username/password authentication"
 msgstr "Įjungti ar išjungti naudotojo vardo ir slaptažodžio autentifikavimą"
 
-#: src/muuli_wdr.cpp:3033
+#: src/muuli_wdr.cpp:3037
 msgid "Username: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:3036
+#: src/muuli_wdr.cpp:3040
 msgid "The username to use to connect to the proxy"
 msgstr "Naudotojo vardas prisijungimui prie atstovaujančio serverio"
 
-#: src/muuli_wdr.cpp:3038
+#: src/muuli_wdr.cpp:3042
 msgid "Password:"
 msgstr "Slaptažodis:"
 
-#: src/muuli_wdr.cpp:3041
+#: src/muuli_wdr.cpp:3045
 msgid "The password to use to connect to the proxy"
 msgstr "Slaptažodis prisijungimui prie atstovaujančio serverio"
 
-#: src/muuli_wdr.cpp:3060
+#: src/muuli_wdr.cpp:3064
 msgid "Connect to:"
 msgstr "Prijungti prie:"
 
-#: src/muuli_wdr.cpp:3069
+#: src/muuli_wdr.cpp:3073
 msgid "Login to remote amule"
 msgstr "Prisijungti prie nutolusios aMule"
 
-#: src/muuli_wdr.cpp:3074
+#: src/muuli_wdr.cpp:3078
 msgid "User name"
 msgstr "Naudotojo vardas"
 
-#: src/muuli_wdr.cpp:3085
+#: src/muuli_wdr.cpp:3089
 msgid "Remember those settings"
 msgstr "Įsiminti parinktis"
 
-#: src/muuli_wdr.cpp:3088
+#: src/muuli_wdr.cpp:3092
 #, fuzzy
 msgid "Force ZLIB compression"
 msgstr "Naudoti gzip pakavimą"
 
-#: src/muuli_wdr.cpp:3112
+#: src/muuli_wdr.cpp:3116
 msgid "Enable Verbose Debug-Logging."
 msgstr "Įjungti išsamų klaidų taisymo žurnalą."
 
-#: src/muuli_wdr.cpp:3114
+#: src/muuli_wdr.cpp:3118
 #, fuzzy
 msgid "Only to Logfile"
 msgstr "&Atverti failą"
 
-#: src/muuli_wdr.cpp:3116
+#: src/muuli_wdr.cpp:3120
 msgid "Message Categories:"
 msgstr "Žinučių kategorijos:"
 
-#: src/muuli_wdr.cpp:3140 src/PartFileConvertDlg.cpp:160
+#: src/muuli_wdr.cpp:3144 src/PartFileConvertDlg.cpp:160
 msgid "Waiting..."
 msgstr "Laukiama..."
 
-#: src/muuli_wdr.cpp:3160
+#: src/muuli_wdr.cpp:3164
 msgid "Add imports"
 msgstr "Įdėti failus"
 
-#: src/muuli_wdr.cpp:3163
+#: src/muuli_wdr.cpp:3167
 msgid "Retry selected"
 msgstr "Pažymėtas bandyti iš naujo"
 
-#: src/muuli_wdr.cpp:3165
+#: src/muuli_wdr.cpp:3169
 msgid "Remove selected"
 msgstr "Pašalinti pažymėtas"
 
-#: src/muuli_wdr.cpp:3228
+#: src/muuli_wdr.cpp:3232
 msgid "Event Types"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3247
+#: src/muuli_wdr.cpp:3251
 msgid "Statistics and queued clients for selected file(s) : Session / All time"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3271
+#: src/muuli_wdr.cpp:3275
 #, fuzzy
 msgid "Active Uploads"
 msgstr "Aktyvūs išsiuntimai:"
 
-#: src/muuli_wdr.cpp:3285
+#: src/muuli_wdr.cpp:3289
 msgid "Percent of total files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3337
+#: src/muuli_wdr.cpp:3341
 #, fuzzy
 msgid "Show Clients for"
 msgstr "Rodyti klientus"
 
-#: src/muuli_wdr.cpp:3339
+#: src/muuli_wdr.cpp:3343
 #, fuzzy
 msgid "All files"
 msgstr "Slėpti dalinamus failus"
 
-#: src/muuli_wdr.cpp:3342
+#: src/muuli_wdr.cpp:3346
 #, fuzzy
 msgid "Selected files"
 msgstr "Parinkite filtrą"
 
-#: src/muuli_wdr.cpp:3345
+#: src/muuli_wdr.cpp:3349
 #, fuzzy
 msgid "Active uploads only"
 msgstr "Aktyvūs išsiuntimai"
 
-#: src/muuli_wdr.cpp:3352
+#: src/muuli_wdr.cpp:3356
 #, fuzzy
 msgid "Reload:"
 msgstr "Atnaujinti sąrašą"
 
-#: src/muuli_wdr.cpp:3356
+#: src/muuli_wdr.cpp:3360
 msgid "Reload your shared files"
 msgstr "Atnaujinti dalinamų failų sąrašą"
 
-#: src/muuli_wdr.cpp:3419
+#: src/muuli_wdr.cpp:3423
 msgid "Send"
 msgstr "Siųsti"
 
-#: src/muuli_wdr.cpp:3420
+#: src/muuli_wdr.cpp:3424
 msgid "Sends the specified message."
 msgstr "Išsiųsti įrašytą žinutę."
 
-#: src/muuli_wdr.cpp:3424
+#: src/muuli_wdr.cpp:3428
 msgid "Close this chat-session."
 msgstr "Baigti pokalbį ir užverti pokalbio kortelę."
 
-#: src/muuli_wdr.cpp:3447
+#: src/muuli_wdr.cpp:3451
 msgid "Connect to any server and/or Kad"
 msgstr "Prisijungti prie bet kurio serverio ir/ar Kademlia tinklo"
 
-#: src/muuli_wdr.cpp:3453 src/SharedFilesCtrl.cpp:142 src/Statistics.cpp:941
+#: src/muuli_wdr.cpp:3457 src/SharedFilesCtrl.cpp:142 src/Statistics.cpp:941
 msgid "Shared Files"
 msgstr "Dalinami failai"
 
@@ -5795,35 +5795,35 @@ msgstr ""
 "\n"
 "aMule puikiai veikia nieko nepakeitus šiame lange."
 
-#: src/PrefsUnifiedDlg.cpp:647
+#: src/PrefsUnifiedDlg.cpp:656
 #, c-format
 msgid "Failed to connect Cfg to widget with the ID %d and key %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:695
+#: src/PrefsUnifiedDlg.cpp:704
 #, c-format
 msgid "Failed to transfer data from Cfg to Widget with the ID %d and key %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:801
+#: src/PrefsUnifiedDlg.cpp:810
 msgid "The type of proxy you are connecting to"
 msgstr "Atstovaujančio serverio, prie kurio jungsitės, tipas"
 
-#: src/PrefsUnifiedDlg.cpp:1020
+#: src/PrefsUnifiedDlg.cpp:1029
 #, c-format
 msgid "Failed to transfer data from Widget to Cfg with the ID %d and key %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1103
+#: src/PrefsUnifiedDlg.cpp:1112
 #, fuzzy
 msgid "No password set."
 msgstr "Tikrinamas slaptažodis\n"
 
-#: src/PrefsUnifiedDlg.cpp:1132
+#: src/PrefsUnifiedDlg.cpp:1141
 msgid "Guest access needs a password. Type one in the guest password field, or untick Enable guest access."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1144
+#: src/PrefsUnifiedDlg.cpp:1153
 msgid ""
 "aMule must be restarted to enable these changes:\n"
 "\n"
@@ -5831,51 +5831,51 @@ msgstr ""
 "Kad įsigaliotų šie pakeitimai, aMule reikia paleisti iš naujo:\n"
 "\n"
 
-#: src/PrefsUnifiedDlg.cpp:1151
+#: src/PrefsUnifiedDlg.cpp:1160
 msgid "- TCP port changed.\n"
 msgstr "– pakeistas TCP prievadas.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1156
+#: src/PrefsUnifiedDlg.cpp:1165
 msgid "- UDP port changed.\n"
 msgstr "– pakeistas UDP prievadas.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1161
+#: src/PrefsUnifiedDlg.cpp:1170
 #, fuzzy
 msgid "- Network interface binding changed.\n"
 msgstr "Išorinis ryšys nutrauktas."
 
-#: src/PrefsUnifiedDlg.cpp:1166
+#: src/PrefsUnifiedDlg.cpp:1175
 #, fuzzy
 msgid "- External connect port changed.\n"
 msgstr "Išorinis ryšys nutrauktas."
 
-#: src/PrefsUnifiedDlg.cpp:1170
+#: src/PrefsUnifiedDlg.cpp:1179
 #, fuzzy
 msgid "- External connect acceptance changed.\n"
 msgstr "Naujas išorinis ryšys priimtas"
 
-#: src/PrefsUnifiedDlg.cpp:1174
+#: src/PrefsUnifiedDlg.cpp:1183
 #, fuzzy
 msgid "- External connect interface changed.\n"
 msgstr "Išorinis ryšys nutrauktas."
 
-#: src/PrefsUnifiedDlg.cpp:1178
+#: src/PrefsUnifiedDlg.cpp:1187
 #, fuzzy
 msgid "- Protocol obfuscation support changed.\n"
 msgstr "Protokolo slėpimas"
 
-#: src/PrefsUnifiedDlg.cpp:1193
+#: src/PrefsUnifiedDlg.cpp:1202
 #, fuzzy
 msgid "- amuleapi settings changed.\n"
 msgstr "– kalba pakeista.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1202
+#: src/PrefsUnifiedDlg.cpp:1211
 msgid ""
 "Your Auto-update server list is empty.\n"
 "'Auto-update server list at startup' will be disabled."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1213
+#: src/PrefsUnifiedDlg.cpp:1222
 msgid ""
 "You have enabled external connections but have not specified a password.\n"
 "External connections cannot be enabled unless a valid password is specified."
@@ -5883,34 +5883,34 @@ msgstr ""
 "Įjungėte išorinius ryšius, bet parinktyse nenurodėte slaptažodžio.\n"
 "Kol nenurodysite slaptažodžio, išoriniai ryšiai nebus įjungti."
 
-#: src/PrefsUnifiedDlg.cpp:1246
+#: src/PrefsUnifiedDlg.cpp:1255
 #, c-format
 msgid "The amuleapi password could not be saved: %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1276
+#: src/PrefsUnifiedDlg.cpp:1285
 msgid "- Language changed.\n"
 msgstr "– kalba pakeista.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1281
+#: src/PrefsUnifiedDlg.cpp:1290
 msgid "- Temp folder changed.\n"
 msgstr "– laikinų failų aplankas pakeistas.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1286
+#: src/PrefsUnifiedDlg.cpp:1295
 #, fuzzy
 msgid "- ED2K network enabled.\n"
 msgstr "Visi tinklai išjungti."
 
-#: src/PrefsUnifiedDlg.cpp:1319
+#: src/PrefsUnifiedDlg.cpp:1328
 msgid "The shared-file exclusion pattern is not a valid regular expression. The filter has been left disabled."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1321 src/PrefsUnifiedDlg.cpp:1921
+#: src/PrefsUnifiedDlg.cpp:1330 src/PrefsUnifiedDlg.cpp:1930
 #, fuzzy
 msgid "Invalid regular expression"
 msgstr "Neteisinga protokolo versija."
 
-#: src/PrefsUnifiedDlg.cpp:1398
+#: src/PrefsUnifiedDlg.cpp:1407
 msgid ""
 "Both eD2k and Kad network are disabled.\n"
 "You won't be able to connect until you enable at least one of them."
@@ -5918,7 +5918,7 @@ msgstr ""
 "Tiek eD2k, tiek Kademlia tinklai yra išjungti.\n"
 "Norėdami prisijungti įjunkite bent vieną iš šių tinklų."
 
-#: src/PrefsUnifiedDlg.cpp:1403
+#: src/PrefsUnifiedDlg.cpp:1412
 msgid ""
 "Kad will not start if your UDP port is disabled.\n"
 "Enable UDP port or disable Kad."
@@ -5926,7 +5926,7 @@ msgstr ""
 "Nepavyks prisijungti prie Kademlia tinklo, nes išjungtas UDP prievadas.\n"
 "Arba įjunkite UDP prievadą, arba išjunkite Kademlia tinklą."
 
-#: src/PrefsUnifiedDlg.cpp:1459
+#: src/PrefsUnifiedDlg.cpp:1468
 msgid ""
 "\n"
 "You MUST restart aMule now.\n"
@@ -5936,69 +5936,69 @@ msgstr ""
 "Būtina paleisti aMule iš naujo.\n"
 "Jei dabar pat neperleisite aMule, nesiskųskite jei kas nors bus ne taip.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1524
+#: src/PrefsUnifiedDlg.cpp:1533
 msgid "Could not register aMule for autostart at login. The autostart store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1526
+#: src/PrefsUnifiedDlg.cpp:1535
 msgid "Could not remove the autostart-at-login entry."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1527
+#: src/PrefsUnifiedDlg.cpp:1536
 #, fuzzy
 msgid "Autostart"
 msgstr "Automatinis atnaujinimas paleistas"
 
-#: src/PrefsUnifiedDlg.cpp:1542
+#: src/PrefsUnifiedDlg.cpp:1551
 msgid "Register file type"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1542
+#: src/PrefsUnifiedDlg.cpp:1551
 msgid "Register URL handler"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1550
+#: src/PrefsUnifiedDlg.cpp:1559
 #, c-format
 msgid "aMule only handles eD2k-compatible magnets. If you replace the current magnet handler (%s), BitTorrent magnet links will stop working - aMule cannot download BitTorrent content. Continue?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1555
+#: src/PrefsUnifiedDlg.cpp:1564
 #, c-format
 msgid "Another application currently opens .emulecollection files (%s). Replace it with aMule?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1560
+#: src/PrefsUnifiedDlg.cpp:1569
 #, c-format
 msgid "Another application is currently the default handler for these links (%s). Replace it with aMule?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1585
+#: src/PrefsUnifiedDlg.cpp:1594
 msgid "Could not register aMule for .emulecollection files. The registration store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1587
+#: src/PrefsUnifiedDlg.cpp:1596
 #, fuzzy
 msgid "Could not remove the file type registration."
 msgstr "Failas %s jau yra atsiunčiamų failų sąraše"
 
-#: src/PrefsUnifiedDlg.cpp:1589
+#: src/PrefsUnifiedDlg.cpp:1598
 msgid "Could not register aMule as the URL handler. The registration store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1591
+#: src/PrefsUnifiedDlg.cpp:1600
 msgid "Could not remove the URL handler registration."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1661 src/PrefsUnifiedDlg.cpp:1688
+#: src/PrefsUnifiedDlg.cpp:1670 src/PrefsUnifiedDlg.cpp:1697
 #, fuzzy
 msgid "The web server and aMule API require external connections to be enabled."
 msgstr "Naujas išorinis ryšys priimtas"
 
-#: src/PrefsUnifiedDlg.cpp:1671
+#: src/PrefsUnifiedDlg.cpp:1680
 msgid "The aMule web server is deprecated. Consider running the aMule API instead."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1735
+#: src/PrefsUnifiedDlg.cpp:1744
 msgid ""
 "Your Auto-update servers list is in blank.\n"
 "Please fill in at least one URL to point to a valid server.met file.\n"
@@ -6008,24 +6008,24 @@ msgstr ""
 "Įrašykite bent vieną server.met failo URL.\n"
 "Norėdami įrašyti URL, paspauskite mygtuką „Sąrašas“."
 
-#: src/PrefsUnifiedDlg.cpp:1876
+#: src/PrefsUnifiedDlg.cpp:1885
 msgid "Temporary files"
 msgstr "Laikini failai"
 
-#: src/PrefsUnifiedDlg.cpp:1881
+#: src/PrefsUnifiedDlg.cpp:1890
 msgid "Incoming files"
 msgstr "Atsiųsti failai"
 
-#: src/PrefsUnifiedDlg.cpp:1886
+#: src/PrefsUnifiedDlg.cpp:1895
 msgid "Online Signatures"
 msgstr "Keičiami parašai"
 
-#: src/PrefsUnifiedDlg.cpp:1899
+#: src/PrefsUnifiedDlg.cpp:1908
 #, c-format
 msgid "Choose a folder for %s"
 msgstr "Parinkite aplanką %s"
 
-#: src/PrefsUnifiedDlg.cpp:1923
+#: src/PrefsUnifiedDlg.cpp:1932
 #, fuzzy, c-format
 msgid "Would exclude %u of %u shared file"
 msgid_plural "Would exclude %u of %u shared files"
@@ -6033,42 +6033,42 @@ msgstr[0] "Aptiktas %i dalinamas failas"
 msgstr[1] "Aptikti %i dalinami failai"
 msgstr[2] "Aptikta %i dalinamų failų"
 
-#: src/PrefsUnifiedDlg.cpp:1940
+#: src/PrefsUnifiedDlg.cpp:1949
 msgid "Browse for videoplayer"
 msgstr "Parinkite video grotuvą"
 
-#: src/PrefsUnifiedDlg.cpp:1944
+#: src/PrefsUnifiedDlg.cpp:1953
 msgid "Select browser"
 msgstr "Parinkite naršyklę"
 
-#: src/PrefsUnifiedDlg.cpp:1948
+#: src/PrefsUnifiedDlg.cpp:1957
 #, fuzzy
 msgid "Select ffprobe binary"
 msgstr "Parinkite naršyklę"
 
-#: src/PrefsUnifiedDlg.cpp:1954
+#: src/PrefsUnifiedDlg.cpp:1963
 #, c-format
 msgid "Executable%s"
 msgstr "Vykdomas failas %s"
 
-#: src/PrefsUnifiedDlg.cpp:1988
+#: src/PrefsUnifiedDlg.cpp:1997
 msgid "ffprobe not found on PATH or in the standard install locations. Install ffmpeg (which ships ffprobe) or use Browse to pick a binary manually."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2000
+#: src/PrefsUnifiedDlg.cpp:2009
 msgid "Reset the settings on this page to their default values?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2001
+#: src/PrefsUnifiedDlg.cpp:2010
 #, fuzzy
 msgid "Reset to defaults"
 msgstr "Numatyta"
 
-#: src/PrefsUnifiedDlg.cpp:2028
+#: src/PrefsUnifiedDlg.cpp:2037
 msgid "Edit server list"
 msgstr "Keisti serverių sąrašą"
 
-#: src/PrefsUnifiedDlg.cpp:2029
+#: src/PrefsUnifiedDlg.cpp:2038
 msgid ""
 "Add here URL's to download server.met files.\n"
 "Only one url on each line."
@@ -6076,42 +6076,42 @@ msgstr ""
 "Įrašykite server.met failų URL.\n"
 "Vieną URL vienoje eilutėje."
 
-#: src/PrefsUnifiedDlg.cpp:2084
+#: src/PrefsUnifiedDlg.cpp:2093
 msgid "IP2Country update failed"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2229 src/PrefsUnifiedDlg.cpp:2260
+#: src/PrefsUnifiedDlg.cpp:2238 src/PrefsUnifiedDlg.cpp:2269
 msgid "Data by MaxMind GeoLite2"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2231 src/PrefsUnifiedDlg.cpp:2262
+#: src/PrefsUnifiedDlg.cpp:2240 src/PrefsUnifiedDlg.cpp:2271
 #, fuzzy
 msgid "Custom source"
 msgstr "Pilni šaltiniai"
 
-#: src/PrefsUnifiedDlg.cpp:2233 src/PrefsUnifiedDlg.cpp:2264
+#: src/PrefsUnifiedDlg.cpp:2242 src/PrefsUnifiedDlg.cpp:2273
 msgid "Data by DB-IP.com"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2284
+#: src/PrefsUnifiedDlg.cpp:2293
 #, fuzzy, c-format
 msgid "Status: Loaded%s"
 msgstr "Būsena:"
 
-#: src/PrefsUnifiedDlg.cpp:2286
+#: src/PrefsUnifiedDlg.cpp:2295
 #, fuzzy, c-format
 msgid "Status: Loaded%s - %s"
 msgstr "Būsena:"
 
-#: src/PrefsUnifiedDlg.cpp:2290
+#: src/PrefsUnifiedDlg.cpp:2299
 msgid "Status: Failed to load - click 'Update now' to refresh."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2292
+#: src/PrefsUnifiedDlg.cpp:2301
 msgid "Status: Not found - click 'Update now' to download."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2350 src/PrefsUnifiedDlg.cpp:2374
+#: src/PrefsUnifiedDlg.cpp:2359 src/PrefsUnifiedDlg.cpp:2383
 #, c-format
 msgid "Update delay: %d second"
 msgid_plural "Update delay: %d seconds"
@@ -6119,7 +6119,7 @@ msgstr[0] "Atnaujinimo intervalas: %d s"
 msgstr[1] "Atnaujinimo intervalas: %d s"
 msgstr[2] "Atnaujinimo intervalas: %d s"
 
-#: src/PrefsUnifiedDlg.cpp:2358
+#: src/PrefsUnifiedDlg.cpp:2367
 #, c-format
 msgid "Time for average graph: %d minute"
 msgid_plural "Time for average graph: %d minutes"
@@ -6127,12 +6127,12 @@ msgstr[0] "Vidurkių grafiko trukmė: %d min."
 msgstr[1] "Vidurkių grafiko trukmė: %d min."
 msgstr[2] "Vidurkių grafiko trukmė: %d min."
 
-#: src/PrefsUnifiedDlg.cpp:2367
+#: src/PrefsUnifiedDlg.cpp:2376
 #, c-format
 msgid "Connections Graph Scale: %d"
 msgstr "Ryšių grafiko mastelis: %d"
 
-#: src/PrefsUnifiedDlg.cpp:2382
+#: src/PrefsUnifiedDlg.cpp:2391
 #, c-format
 msgid "File Buffer Size: %d byte"
 msgid_plural "File Buffer Size: %d bytes"
@@ -6140,7 +6140,7 @@ msgstr[0] "Failų buferio dydis: %d baitas"
 msgstr[1] "Failų buferio dydis: %d baitai"
 msgstr[2] "Failų buferio dydis: %d baitų"
 
-#: src/PrefsUnifiedDlg.cpp:2392
+#: src/PrefsUnifiedDlg.cpp:2401
 #, c-format
 msgid "Upload Queue Size: %d client"
 msgid_plural "Upload Queue Size: %d clients"
@@ -6148,7 +6148,7 @@ msgstr[0] "Išsiuntimo eilės dydis: %d klientas"
 msgstr[1] "Išsiuntimo eilės dydis: %d klientai"
 msgstr[2] "Išsiuntimo eilės dydis: %d klientų"
 
-#: src/PrefsUnifiedDlg.cpp:2402
+#: src/PrefsUnifiedDlg.cpp:2411
 #, c-format
 msgid "Server connection refresh interval: %d minute"
 msgid_plural "Server connection refresh interval: %d minutes"
@@ -6156,80 +6156,80 @@ msgstr[0] "Serverio ryšio atnaujinimo intervalas: %d min."
 msgstr[1] "Serverio ryšio atnaujinimo intervalas: %d min."
 msgstr[2] "Serverio ryšio atnaujinimo intervalas: %d min."
 
-#: src/PrefsUnifiedDlg.cpp:2407
+#: src/PrefsUnifiedDlg.cpp:2416
 msgid "Server connection refresh interval: Disabled"
 msgstr "Serverio ryšio atnaujinimo intervalas: išjungta"
 
-#: src/PrefsUnifiedDlg.cpp:2451
+#: src/PrefsUnifiedDlg.cpp:2460
 #, fuzzy
 msgid "disabled"
 msgstr "Išjungti"
 
-#: src/PrefsUnifiedDlg.cpp:2477
+#: src/PrefsUnifiedDlg.cpp:2486
 #, fuzzy, c-format
 msgid "Execute command on '%s' event"
 msgstr "Įvykus „%s“ įvykiui įvykdyti komandą"
 
-#: src/PrefsUnifiedDlg.cpp:2484
+#: src/PrefsUnifiedDlg.cpp:2493
 msgid "Enable command execution on core"
 msgstr "Įjungti komandos vykdymą branduolyje"
 
-#: src/PrefsUnifiedDlg.cpp:2496
+#: src/PrefsUnifiedDlg.cpp:2505
 msgid "Core command:"
 msgstr "Branduolio komanda:"
 
-#: src/PrefsUnifiedDlg.cpp:2512
+#: src/PrefsUnifiedDlg.cpp:2521
 msgid "Enable command execution on GUI"
 msgstr "Įjungti komandos vykdymą grafinėje aplinkoje"
 
-#: src/PrefsUnifiedDlg.cpp:2524
+#: src/PrefsUnifiedDlg.cpp:2533
 msgid "GUI command:"
 msgstr "Grafinės aplinkos komanda:"
 
-#: src/PrefsUnifiedDlg.cpp:2540
+#: src/PrefsUnifiedDlg.cpp:2549
 msgid "The following variables will be replaced:"
 msgstr "Šie kintamieji bus pakeisti:"
 
-#: src/PrefsUnifiedDlg.cpp:2708
+#: src/PrefsUnifiedDlg.cpp:2717
 msgid ""
 "The following folders look like system or sensitive locations:\n"
 "\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2713
+#: src/PrefsUnifiedDlg.cpp:2722
 msgid "Sharing them recursively will publish every file underneath on the eD2k/Kad networks. Do you really want to do this?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2716
+#: src/PrefsUnifiedDlg.cpp:2725
 #, fuzzy
 msgid "Confirm shared folders"
 msgstr "Atnaujinti dalinamų failų sąrašą"
 
-#: src/PrefsUnifiedDlg.cpp:2744
+#: src/PrefsUnifiedDlg.cpp:2753
 #, fuzzy
 msgid "Reloading shared files..."
 msgstr "Atnaujinti dalinamų failų sąrašą"
 
-#: src/PrefsUnifiedDlg.cpp:2745
+#: src/PrefsUnifiedDlg.cpp:2754
 msgid "Scanning for subdirectories..."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2746
+#: src/PrefsUnifiedDlg.cpp:2755
 #, fuzzy
 msgid "Updating shared folders"
 msgstr "Skaitomas laikinų failų aplankas"
 
-#: src/PrefsUnifiedDlg.cpp:2773
+#: src/PrefsUnifiedDlg.cpp:2782
 #, c-format
 msgid "Scanned %u directories..."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2823
+#: src/PrefsUnifiedDlg.cpp:2832
 #, fuzzy, c-format
 msgid "Reloading shared files: %u files scanned"
 msgstr "Atnaujinti dalinamų failų sąrašą."
 
-#: src/PrefsUnifiedDlg.cpp:2873
+#: src/PrefsUnifiedDlg.cpp:2882
 #, fuzzy
 msgid "Shared folder"
 msgstr "Dalinami failai"
@@ -7947,12 +7947,12 @@ msgstr "Pašalinti kategoriją"
 msgid "Hashset requested for unknown file: %s"
 msgstr "Gautas prašymas nežinomo failo maišos f-jai: %s"
 
-#: src/UploadQueue.cpp:618
+#: src/UploadQueue.cpp:627
 #, c-format
 msgid "Resuming uploads of file: %s"
 msgstr "Tęsiame failos siuntimą: %s"
 
-#: src/UploadQueue.cpp:634
+#: src/UploadQueue.cpp:643
 #, c-format
 msgid "Suspending upload of file: %s"
 msgstr "Nutraukiamas failo siuntimas: %s"

--- a/po/lt.po
+++ b/po/lt.po
@@ -10,8 +10,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-28 12:12+0200\n"
-"PO-Revision-Date: 2026-07-27 10:28+0000\n"
+"POT-Creation-Date: 2026-07-28 08:06+0200\n"
+"PO-Revision-Date: 2026-07-27 11:41+0000\n"
 "Last-Translator: Dovydas Sankauskas <laisve@gmail.com>\n"
 "Language-Team: Lithuanian <komp_lt@konf.lt>\n"
 "Language: lt\n"
@@ -142,7 +142,7 @@ msgstr ""
 msgid "Not now"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:422 src/amuleDlg.cpp:665
+#: src/AppImageIntegration.cpp:422 src/amuleDlg.cpp:600
 msgid "Don't ask again"
 msgstr ""
 
@@ -201,162 +201,162 @@ msgstr "Nepavyko atverti %s (%s)"
 msgid "WARNING: You can't add yourself as a source for an eD2k link while having a lowid."
 msgstr "DĖMESIO: jei jūsų ID yra žemas, negalite įdėti savęs prie eD2k nuorodos šaltinių."
 
-#: src/amule.cpp:301
+#: src/amule.cpp:300
 #, fuzzy
 msgid "Now, exiting main app..."
 msgstr ""
 "\n"
 "Darbas baigiamas %s...\n"
 
-#: src/amule.cpp:331
+#: src/amule.cpp:330
 #, c-format
 msgid "Terminating amuleweb instance with pid '%d' ... "
 msgstr ""
 
-#: src/amule.cpp:335
+#: src/amule.cpp:334
 #, c-format
 msgid "Killing amuleweb instance with pid '%d' ... "
 msgstr ""
 
-#: src/amule.cpp:337 src/amule.cpp:350 src/ClientRef.cpp:180
-#: src/SearchDlg.cpp:1041 src/ServerListCtrl.cpp:98
+#: src/amule.cpp:336 src/amule.cpp:349 src/ClientRef.cpp:180
+#: src/SearchDlg.cpp:880 src/ServerListCtrl.cpp:98
 msgid "Failed"
 msgstr "Nepavyko"
 
-#: src/amule.cpp:344
+#: src/amule.cpp:343
 #, c-format
 msgid "Terminating amuleapi instance with pid '%d' ... "
 msgstr ""
 
-#: src/amule.cpp:348
+#: src/amule.cpp:347
 #, c-format
 msgid "Killing amuleapi instance with pid '%d' ... "
 msgstr ""
 
-#: src/amule.cpp:356
+#: src/amule.cpp:355
 msgid "aMule OnExit: Terminating core."
 msgstr ""
 
-#: src/amule.cpp:467
+#: src/amule.cpp:466
 #, fuzzy
 msgid "aMule shutdown completed."
 msgstr "Atsiuntimas baigtas"
 
-#: src/amule.cpp:471
+#: src/amule.cpp:470
 msgid "Memory debug results for aMule exit:"
 msgstr ""
 
-#: src/amule.cpp:652
+#: src/amule.cpp:651
 #, c-format
 msgid "Binding aMule's peer-to-peer traffic to interface: %s (HTTP updates use the default route)"
 msgstr ""
 
-#: src/amule.cpp:656
+#: src/amule.cpp:655
 #, c-format
 msgid "Binding all network traffic to interface: %s"
 msgstr ""
 
-#: src/amule.cpp:660
+#: src/amule.cpp:659
 #, c-format
 msgid "WARNING: configured network interface '%s' was not found - traffic is NOT bound to it and may leave via the default route. Check the interface name in Preferences."
 msgstr ""
 
-#: src/amule.cpp:666
+#: src/amule.cpp:665
 #, c-format
 msgid "WARNING: binding to network interface '%s' requires elevated privileges and was NOT applied - traffic may leave via the default route. Grant the capability (e.g. 'sudo setcap cap_net_raw+ep' on the aMule binary) or run with sufficient privileges."
 msgstr ""
 
-#: src/amule.cpp:674
+#: src/amule.cpp:673
 #, c-format
 msgid "WARNING: could not bind to network interface '%s' - traffic may leave via the default route."
 msgstr ""
 
-#: src/amule.cpp:733
+#: src/amule.cpp:732
 msgid "Your locale has been changed to System Default due to a configuration change. Sorry."
 msgstr "Pasikeitus parinktims aplinkos kalba buvo pakeista į sistemoje numatytą kalbą."
 
-#: src/amule.cpp:735 src/amule.cpp:1589 src/CatDialog.cpp:128
+#: src/amule.cpp:734 src/amule.cpp:1581 src/CatDialog.cpp:128
 #: src/CatDialog.cpp:136 src/CatDialog.cpp:149 src/ServerList.cpp:366
 #: src/ServerListCtrl.cpp:152
 msgid "Info"
 msgstr "Informacija"
 
-#: src/amule.cpp:742
+#: src/amule.cpp:741
 #, fuzzy
 msgid ""
 "\n"
 "EC configuration"
 msgstr "Baigimo patvirtinimas"
 
-#: src/amule.cpp:745
+#: src/amule.cpp:744
 #, fuzzy
 msgid "Password set and external connections enabled."
 msgstr "Naujas išorinis ryšys priimtas"
 
-#: src/amule.cpp:755 src/KadDlg.cpp:176 src/KadDlg.cpp:185
-#: src/PrefsUnifiedDlg.cpp:1461 src/SharedFilesCtrl.cpp:476
+#: src/amule.cpp:754 src/KadDlg.cpp:176 src/KadDlg.cpp:185
+#: src/PrefsUnifiedDlg.cpp:1387 src/SharedFilesCtrl.cpp:476
 msgid "WARNING"
 msgstr "DĖMESIO"
 
-#: src/amule.cpp:992
+#: src/amule.cpp:991
 #, fuzzy
 msgid "Network bootstrap"
 msgstr "Tinklas"
 
-#: src/amule.cpp:997
+#: src/amule.cpp:996
 msgid ""
 "aMule has detected missing network bootstrap files.\n"
 "Select which ones to download:"
 msgstr ""
 
-#: src/amule.cpp:1006 src/FirstRunWizard.cpp:411
+#: src/amule.cpp:1005 src/FirstRunWizard.cpp:411
 #, fuzzy
 msgid "eD2k server list (server.met)"
 msgstr "server.met faile rastas %i serveris"
 
-#: src/amule.cpp:1013 src/FirstRunWizard.cpp:416
+#: src/amule.cpp:1012 src/FirstRunWizard.cpp:416
 msgid "Kad bootstrap nodes (nodes.dat)"
 msgstr ""
 
-#: src/amule.cpp:1103
+#: src/amule.cpp:1102
 #, c-format
 msgid "web server running on pid %d"
 msgstr "žiniatinklio serverio pid yra %d"
 
-#: src/amule.cpp:1116
+#: src/amule.cpp:1115
 #, fuzzy
 msgid "You requested to run web server on startup, but the amuleweb binary cannot be run. Please install the package containing aMule web server, or build aMule from source with -DBUILD_WEBSERVER=YES and install it."
 msgstr "Nurodėte paleidus programą paleisti žiniatinklio serverį, bet amuleweb programos nepavyko paleisti. Įdiekite aMule žiniatinklio programos paketą arba sukompiliuokite aMule su --enable-webserver parinktimi ir paleiskite „make install“."
 
-#: src/amule.cpp:1121 src/amule.cpp:1185 src/amule.cpp:1299 src/amule.cpp:1601
+#: src/amule.cpp:1120 src/amule.cpp:1177 src/amule.cpp:1291 src/amule.cpp:1593
 #: src/amule-remote-gui.cpp:603 src/amule-remote-gui.cpp:671
 #: src/amule-remote-gui.cpp:709 src/amule-remote-gui.cpp:1282
 #: src/amule-remote-gui.cpp:1345 src/amule-remote-gui.cpp:1372
-#: src/DownloadQueue.cpp:1481 src/PrefsUnifiedDlg.cpp:1247
+#: src/DownloadQueue.cpp:1481
 msgid "ERROR"
 msgstr "KLAIDA"
 
-#: src/amule.cpp:1174
+#: src/amule.cpp:1166
 #, fuzzy, c-format
 msgid "amuleapi running on pid %d"
 msgstr "žiniatinklio serverio pid yra %d"
 
-#: src/amule.cpp:1180
+#: src/amule.cpp:1172
 #, fuzzy
 msgid "You requested to run amuleapi on startup, but the amuleapi binary cannot be run. Please install the package containing aMule's REST API server, or build aMule from source with -DBUILD_AMULEAPI=YES and install it."
 msgstr "Nurodėte paleidus programą paleisti žiniatinklio serverį, bet amuleweb programos nepavyko paleisti. Įdiekite aMule žiniatinklio programos paketą arba sukompiliuokite aMule su --enable-webserver parinktimi ir paleiskite „make install“."
 
-#: src/amule.cpp:1267
+#: src/amule.cpp:1259
 #, c-format
 msgid "Could not bind ports to the specified address: %s"
 msgstr "Nepavyko susieti prievadų su nurodytu adresu: %s"
 
-#: src/amule.cpp:1291
+#: src/amule.cpp:1283
 #, c-format
 msgid "Port %u is not available. You will be LOWID\n"
 msgstr "Prievadas %u neprieinamas. Gavote žemą ID\n"
 
-#: src/amule.cpp:1296
+#: src/amule.cpp:1288
 #, c-format
 msgid ""
 "Port %u is not available!\n"
@@ -372,48 +372,48 @@ msgstr ""
 "\n"
 "Patikrinkite sistemines tinklo parinktis ir įsitikinkite, kad nurodytas prievadas atviras tiek išsiuntimui, tiek priėmimui."
 
-#: src/amule.cpp:1393
+#: src/amule.cpp:1385
 msgid "Failed to create OnlineSig File"
 msgstr "Nepavyko sukurti keičiamo parašo failo"
 
-#: src/amule.cpp:1401
+#: src/amule.cpp:1393
 msgid "Failed to create aMule OnlineSig File"
 msgstr "Nepavyko sukurti keičiamo aMule parašo failo"
 
-#: src/amule.cpp:1564
+#: src/amule.cpp:1556
 msgid "The selected locale seems not to be installed on your box. (Note: I'll try to set it anyway)"
 msgstr "Nurodyta lokalė jūsų kompiuteryje neįdiegta. (Dėmesio: šiaip ar taip vis tiek pabandysime naudoti nurodytą lokalę)."
 
-#: src/amule.cpp:1574
+#: src/amule.cpp:1566
 #, c-format
 msgid "This is the first time you run aMule %s"
 msgstr "aMule paleista pirmą kartą %s"
 
-#: src/amule.cpp:1577
+#: src/amule.cpp:1569
 msgid "This version is a testing version, updated daily, and\n"
 msgstr "Ši versija yra darbinė versija, atnaujinama kasdien, ir\n"
 
-#: src/amule.cpp:1578
+#: src/amule.cpp:1570
 msgid "we give no warranty it won't break anything, burn your house,\n"
 msgstr "todėl negalime garantuoti, kad ji nenulūš, nepadegs namų ar\n"
 
-#: src/amule.cpp:1579
+#: src/amule.cpp:1571
 msgid "or kill your dog. But it *should* be safe to use anyway.\n"
 msgstr "nenumarins šuns. Bet šiaip ar taip ją naudoti turėtų būti saugu.\n"
 
-#: src/amule.cpp:1584
+#: src/amule.cpp:1576
 msgid "More information, support and new releases can found at our homepage,\n"
 msgstr "Daugiau informacijos, pagalbos ir naujausias galutines versijas rasite mūsų\n"
 
-#: src/amule.cpp:1585
+#: src/amule.cpp:1577
 msgid "at https://amule-org.github.io, or in our IRC channel #aMule at irc.libera.chat.\n"
 msgstr "svetainėje https://amule-org.github.io arba IRC kanale #aMule serveryje irc.libera.chat.\n"
 
-#: src/amule.cpp:1587
+#: src/amule.cpp:1579
 msgid "Feel free to report any bugs to https://github.com/amule-org/amule/issues"
 msgstr "Nesikuklinkite pranešti rastas klaidas adresu https://github.com/amule-org/amule/issues"
 
-#: src/amule.cpp:1599
+#: src/amule.cpp:1591
 msgid ""
 "The folder for Online Signature files you specified is INVALID!\n"
 " OnlineSignature will be DISABLED until you fix it on preferences."
@@ -421,138 +421,138 @@ msgstr ""
 "Neteisingai nurodėte keičiamo parašo aplanką!\n"
 "Keičiamas parašas bus išjungtas tol, kol pakeisite parinktis."
 
-#: src/amule.cpp:1662
+#: src/amule.cpp:1654
 #, fuzzy
 msgid "Server hostname notified"
 msgstr "Serverio pavadinimas:"
 
-#: src/amule.cpp:2039
+#: src/amule.cpp:2031
 #, c-format
 msgid "Disk space preallocation for file '%s' failed: %s"
 msgstr "Nepavyko paskirti disko vietos failui „%s“: %s"
 
-#: src/amule.cpp:2168
+#: src/amule.cpp:2160
 msgid "ERROR: can't open logfile"
 msgstr "KLAIDA: nepavyko atverti žurnalo failo"
 
-#: src/amule.cpp:2172
+#: src/amule.cpp:2164
 msgid "WARNING: logfile is empty. Something is wrong."
 msgstr "DĖMESIO: žurnalas tuščias. Kažkas čia ne taip."
 
-#: src/amule.cpp:2189
+#: src/amule.cpp:2181
 msgid "Log has been reset"
 msgstr "Žurnalas išvalytas"
 
-#: src/amule.cpp:2213
+#: src/amule.cpp:2205
 #, c-format
 msgid "ServerMessage: %s"
 msgstr "Serverio pranešimas: %s"
 
-#: src/amule.cpp:2256 src/IP2Country.cpp:220 src/IPFilter.cpp:514
+#: src/amule.cpp:2248 src/IP2Country.cpp:220 src/IPFilter.cpp:514
 #: src/ServerList.cpp:875
 #, c-format
 msgid "Skipped download of %s, because requested file is not newer."
 msgstr ""
 
-#: src/amule.cpp:2259
+#: src/amule.cpp:2251
 msgid "Failed to download the nodes list."
 msgstr "Nepavyko atsiųsti mazgų sąrašo."
 
-#: src/amule.cpp:2322
+#: src/amule.cpp:2314
 msgid "Failed to open the downloaded version check file"
 msgstr "Nepavyko atverti atsiųstos versijos tikrinimo failo"
 
-#: src/amule.cpp:2325 src/amule.cpp:2344
+#: src/amule.cpp:2317 src/amule.cpp:2336
 msgid "Corrupted version check file"
 msgstr "Sugadintas versijos tikrinimo failas"
 
-#: src/amule.cpp:2367
+#: src/amule.cpp:2359
 msgid "You are using an outdated version of aMule!"
 msgstr "Naudojate pasenusią aMule versiją!"
 
-#: src/amule.cpp:2369
+#: src/amule.cpp:2361
 #, c-format
 msgid "Your aMule version is %i.%i.%i and the latest version is %li.%li.%li"
 msgstr "Ši aMule versija yra %i.%i.%i, o naujausia versija yra %li.%li.%li"
 
-#: src/amule.cpp:2373
+#: src/amule.cpp:2365
 msgid "The latest version can always be found at https://github.com/amule-org/amule/releases/latest"
 msgstr "Naujausią versiją bet kada galima atsisiųsti iš https://github.com/amule-org/amule/releases/latest"
 
-#: src/amule.cpp:2376
+#: src/amule.cpp:2368
 #, c-format
 msgid "WARNING: Your aMuled version is outdated: %i.%i.%i < %li.%li.%li"
 msgstr "DĖMESIO: ši aMule versija yra pasenusi: %i.%i.%i < %li.%li.%li"
 
-#: src/amule.cpp:2382
+#: src/amule.cpp:2374
 msgid "Your copy of aMule is up to date."
 msgstr "Naudojate naują aMule versiją."
 
-#: src/amule.cpp:2389
+#: src/amule.cpp:2381
 msgid "Failed to download the version check file"
 msgstr "Nepavyko atsiųsti versijos tikrinimo failo"
 
-#: src/amule.cpp:2558 src/amule-remote-gui.cpp:1133
+#: src/amule.cpp:2550 src/amule-remote-gui.cpp:1133
 #, c-format
 msgid "Users: %s | Files: %s"
 msgstr "Naudotojai: %s | Failai: %s"
 
-#: src/amule.cpp:2559 src/amule-remote-gui.cpp:1134
+#: src/amule.cpp:2551 src/amule-remote-gui.cpp:1134
 #, c-format
 msgid "Users: E: %s K: %s | Files: E: %s K: %s"
 msgstr "Naudotojai: eD2k: %s Kad: %s | Failai: eD2k: %s Kad: %s"
 
-#: src/amule.cpp:2573 src/amule-remote-gui.cpp:1147
+#: src/amule.cpp:2565 src/amule-remote-gui.cpp:1147
 msgid "No networks selected"
 msgstr "Neparinktas joks tinklas"
 
-#: src/amule.cpp:2641 src/TextClient.cpp:903
+#: src/amule.cpp:2633 src/TextClient.cpp:903
 msgid "with LowID"
 msgstr "žemas ID"
 
-#: src/amule.cpp:2641 src/TextClient.cpp:904
+#: src/amule.cpp:2633 src/TextClient.cpp:904
 msgid "with HighID"
 msgstr "aukštas ID"
 
-#: src/amule.cpp:2643
+#: src/amule.cpp:2635
 #, c-format
 msgid "Connected to %s %s"
 msgstr "Prisijungta prie %s %s"
 
-#: src/amule.cpp:2648
+#: src/amule.cpp:2640
 #, c-format
 msgid "Connecting to %s"
 msgstr "Jungiamasi prie %s"
 
-#: src/amule.cpp:2650
+#: src/amule.cpp:2642
 msgid "Disconnected from eD2k"
 msgstr "Atsijungta nuo eD2k"
 
-#: src/amule.cpp:2659
+#: src/amule.cpp:2651
 msgid "Kad started."
 msgstr "Kademlia paleista."
 
-#: src/amule.cpp:2661
+#: src/amule.cpp:2653
 msgid "Kad stopped."
 msgstr "Kademlia sustabdyta."
 
-#: src/amule.cpp:2669
+#: src/amule.cpp:2661
 msgid "Connected to Kad (ok)"
 msgstr "Prisijungta prie Kademlia"
 
-#: src/amule.cpp:2671
+#: src/amule.cpp:2663
 msgid "Connected to Kad (firewalled)"
 msgstr "Prisijungta prie Kademlia (už ugniasienės)"
 
-#: src/amule.cpp:2675
+#: src/amule.cpp:2667
 msgid "Disconnected from Kad"
 msgstr "Atsijungta nuo Kademlia"
 
-#: src/amule.cpp:2707
+#: src/amule.cpp:2699
 msgid "Kad network cannot be used if UDP port is disabled on preferences, not starting."
 msgstr "Nepavyks prisijungti prie Kademlia tinklo, jei parinktyse yra išjungtas UDP prievadas."
 
-#: src/amule.cpp:2711
+#: src/amule.cpp:2703
 msgid "Kad network disabled on preferences, not connecting."
 msgstr "Kademlia tinklas išjungtas parinktyse, ryšys nebus užmezgamas."
 
@@ -578,68 +578,30 @@ msgstr ""
 msgid "ERROR: %s"
 msgstr "KLAIDA: %s"
 
-#: src/amuleDlg.cpp:250
+#: src/amuleDlg.cpp:236
 #, c-format
 msgid "This is aMule %s based on eMule."
 msgstr "aMule %s, sukurta eMule pagrindu."
 
-#: src/amuleDlg.cpp:251
+#: src/amuleDlg.cpp:237
 #, c-format
 msgid "Running on %s"
 msgstr "Vykdoma %s sistemoje"
 
-#: src/amuleDlg.cpp:253
+#: src/amuleDlg.cpp:239
 msgid "Visit https://github.com/amule-org/amule/releases/latest to check if a new version is available."
 msgstr "Aplankykite https://github.com/amule-org/amule/releases/latest ir pasitikrinkite ar nėra naujesnės versijos."
 
-#: src/amuleDlg.cpp:282
+#: src/amuleDlg.cpp:268
 msgid "FATAL ERROR: Failed to create Timer"
 msgstr "KRITINĖ KLAIDA: nepavyko sukurti laiko skaitliuko"
 
-#: src/amuleDlg.cpp:361 src/amuleDlg.cpp:1810 src/amuleDlg.cpp:2056
-#: src/muuli_wdr.cpp:1492 src/muuli_wdr.cpp:3439
-msgid "Networks"
-msgstr "Tinklas"
-
-#: src/amuleDlg.cpp:362 src/amuleDlg.cpp:1816 src/muuli_wdr.cpp:3440
-msgid "Searches"
-msgstr "Paieška"
-
-#: src/amuleDlg.cpp:363 src/amuleDlg.cpp:1822 src/DownloadListCtrl.cpp:740
-#: src/muuli_wdr.cpp:392 src/muuli_wdr.cpp:1585 src/muuli_wdr.cpp:3441
-#: src/Statistics.cpp:829
-msgid "Downloads"
-msgstr "Siuntimai"
-
-#: src/amuleDlg.cpp:364 src/amuleDlg.cpp:1828 src/muuli_wdr.cpp:3315
-msgid "Shared files"
-msgstr "Dalinami failai"
-
-#: src/amuleDlg.cpp:365 src/amuleDlg.cpp:1834 src/muuli_wdr.cpp:2947
-#: src/muuli_wdr.cpp:3397 src/muuli_wdr.cpp:3444
-msgid "Messages"
-msgstr "Žinutės"
-
-#: src/amuleDlg.cpp:366 src/amuleDlg.cpp:1840 src/muuli_wdr.cpp:3445
-#: src/PrefsUnifiedDlg.cpp:314 src/Statistics.cpp:779 src/Statistics.cpp:1235
-msgid "Statistics"
-msgstr "Statistika"
-
-#: src/amuleDlg.cpp:368 src/amuleDlg.cpp:1847 src/muuli_wdr.cpp:3447
-#: src/PrefsUnifiedDlg.cpp:330 src/utils/wxCas/src/wxcasprefs.cpp:39
-msgid "Preferences"
-msgstr "Parinktys"
-
-#: src/amuleDlg.cpp:371
-msgid "Navigate"
-msgstr ""
-
-#: src/amuleDlg.cpp:657
+#: src/amuleDlg.cpp:592
 #, fuzzy
 msgid "New version available"
 msgstr "Nėra"
 
-#: src/amuleDlg.cpp:661
+#: src/amuleDlg.cpp:596
 #, fuzzy, c-format
 msgid ""
 "A new version of aMule (%s) is available.\n"
@@ -649,186 +611,219 @@ msgid ""
 "Would you like to open the download page?"
 msgstr "Naujausią versiją bet kada galima atsisiųsti iš https://github.com/amule-org/amule/releases/latest"
 
-#: src/amuleDlg.cpp:743
+#: src/amuleDlg.cpp:678
 msgid "aMule dialog destroyed"
 msgstr ""
 
-#: src/amuleDlg.cpp:766 src/DataToText.cpp:68 src/IPFilter.cpp:547
+#: src/amuleDlg.cpp:701 src/DataToText.cpp:68 src/IPFilter.cpp:547
 msgid "Connecting"
 msgstr "Jungiamasi"
 
-#: src/amuleDlg.cpp:958
+#: src/amuleDlg.cpp:893
 msgid "eD2k: Connecting"
 msgstr "eD2k: jungiamasi"
 
-#: src/amuleDlg.cpp:962
+#: src/amuleDlg.cpp:897
 msgid "eD2k: Disconnected"
 msgstr "eD2k: atsijungta"
 
-#: src/amuleDlg.cpp:968
+#: src/amuleDlg.cpp:903
 msgid "Kad: Firewalled"
 msgstr "Kad: už ugniasienės"
 
-#: src/amuleDlg.cpp:972
+#: src/amuleDlg.cpp:907
 msgid "Kad: Connected"
 msgstr "Kad: prisijungta"
 
-#: src/amuleDlg.cpp:977
+#: src/amuleDlg.cpp:912
 msgid "Kad: Connecting"
 msgstr "Kad: jungiamasi"
 
-#: src/amuleDlg.cpp:981
+#: src/amuleDlg.cpp:916
 msgid "Kad: Off"
 msgstr "Kad: išjungta"
 
-#: src/amuleDlg.cpp:1029 src/DownloadListCtrl.cpp:505
+#: src/amuleDlg.cpp:964 src/DownloadListCtrl.cpp:505
 #: src/DownloadListCtrl.cpp:749 src/FriendListCtrl.cpp:180
 #: src/muuli_wdr.cpp:731 src/muuli_wdr.cpp:782 src/muuli_wdr.cpp:846
-#: src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2252 src/muuli_wdr.cpp:2337
-#: src/muuli_wdr.cpp:3085 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
+#: src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2224 src/muuli_wdr.cpp:2309
+#: src/muuli_wdr.cpp:3057 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
 #: src/ServerListCtrl.cpp:606 src/TransferWnd.cpp:378
 #: src/utils/wxCas/src/wxcasprefs.cpp:235
 msgid "Cancel"
 msgstr "Atšaukti"
 
-#: src/amuleDlg.cpp:1030
+#: src/amuleDlg.cpp:965
 msgid "Stop the current connection attempts"
 msgstr "Nutraukti bandymus prisijungti"
 
-#: src/amuleDlg.cpp:1035 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976
-#: src/muuli_wdr.cpp:2475
+#: src/amuleDlg.cpp:970 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976
+#: src/muuli_wdr.cpp:2447
 msgid "Disconnect"
 msgstr "Atsijungti"
 
-#: src/amuleDlg.cpp:1036
+#: src/amuleDlg.cpp:971
 msgid "Disconnect from the currently connected networks"
 msgstr "Atsijungti nuo pasirinktų tinklų"
 
-#: src/amuleDlg.cpp:1041 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979
-#: src/muuli_wdr.cpp:2630 src/muuli_wdr.cpp:3082 src/muuli_wdr.cpp:3437
+#: src/amuleDlg.cpp:976 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979
+#: src/muuli_wdr.cpp:2602 src/muuli_wdr.cpp:3054 src/muuli_wdr.cpp:3409
 msgid "Connect"
 msgstr "Prisijungti"
 
-#: src/amuleDlg.cpp:1042
+#: src/amuleDlg.cpp:977
 msgid "Connect to the currently enabled networks"
 msgstr "Prisijungti prie pasirinktų tinklų"
 
-#: src/amuleDlg.cpp:1154
+#: src/amuleDlg.cpp:1089
 #, fuzzy, c-format
 msgid "Up: %.1f%s (%.1f) | Down: %.1f%s (%.1f)"
 msgstr "Išs.: %.1f(%.1f) | Ats.: %.1f(%.1f)"
 
-#: src/amuleDlg.cpp:1156 src/amuleDlg.cpp:1158 src/amuleDlg.cpp:1162
-#: src/amuleDlg.cpp:1164 src/amuleDlg.cpp:1175 src/amuleDlg.cpp:1177
+#: src/amuleDlg.cpp:1091 src/amuleDlg.cpp:1093 src/amuleDlg.cpp:1097
+#: src/amuleDlg.cpp:1099 src/amuleDlg.cpp:1110 src/amuleDlg.cpp:1112
 #: src/MuleTrayIcon.cpp:796 src/MuleTrayIcon.cpp:799
 #, fuzzy
 msgid " MB/s"
 msgstr "MB/s"
 
-#: src/amuleDlg.cpp:1156 src/amuleDlg.cpp:1158 src/amuleDlg.cpp:1162
-#: src/amuleDlg.cpp:1164 src/amuleDlg.cpp:1175 src/amuleDlg.cpp:1177
+#: src/amuleDlg.cpp:1091 src/amuleDlg.cpp:1093 src/amuleDlg.cpp:1097
+#: src/amuleDlg.cpp:1099 src/amuleDlg.cpp:1110 src/amuleDlg.cpp:1112
 #: src/MuleTrayIcon.cpp:796 src/MuleTrayIcon.cpp:799
 #: src/utils/wxCas/src/wxcasframe.cpp:1041
 msgid " kB/s"
 msgstr " kB/s"
 
-#: src/amuleDlg.cpp:1161
+#: src/amuleDlg.cpp:1096
 #, fuzzy, c-format
 msgid "Up: %.1f%s | Down: %.1f%s"
 msgstr "Išs.: %.1f | Ats.: %.1f"
 
-#: src/amuleDlg.cpp:1193
+#: src/amuleDlg.cpp:1128
 #, c-format
 msgid "aMule (%s | Connected)"
 msgstr "aMule (%s | prisijungta)"
 
-#: src/amuleDlg.cpp:1195
+#: src/amuleDlg.cpp:1130
 #, c-format
 msgid "aMule (%s | Disconnected)"
 msgstr "aMule (%s | neprisijungta)"
 
-#: src/amuleDlg.cpp:1248
+#: src/amuleDlg.cpp:1183
 #, fuzzy, c-format
 msgid "Do you really want to exit %s?"
 msgstr "Ar tikrai norite baigti darbą su aMule?"
 
-#: src/amuleDlg.cpp:1250
+#: src/amuleDlg.cpp:1185
 msgid "Exit confirmation"
 msgstr "Baigimo patvirtinimas"
 
-#: src/amuleDlg.cpp:1613
+#: src/amuleDlg.cpp:1548
 msgid "Launch Command: "
 msgstr ""
 
-#: src/amuleDlg.cpp:1632 src/muuli_wdr.cpp:1972 src/Preferences.cpp:979
+#: src/amuleDlg.cpp:1567 src/muuli_wdr.cpp:1971 src/Preferences.cpp:951
 msgid "- default -"
 msgstr ""
 
-#: src/amuleDlg.cpp:1660
+#: src/amuleDlg.cpp:1595
 #, c-format
 msgid "Skin directory '%s' does not exist"
 msgstr "Išvaizdos failų aplankas %s neegzistuoja"
 
-#: src/amuleDlg.cpp:1663
+#: src/amuleDlg.cpp:1598
 #, c-format
 msgid "WARNING: Unable to open skin file '%s' for read"
 msgstr "DĖMESIO: nepavyko atverti temos failo „%s“ skaitymui"
 
-#: src/amuleDlg.cpp:1814 src/muuli_wdr.cpp:3439
+#: src/amuleDlg.cpp:1722 src/amuleDlg.cpp:1968 src/muuli_wdr.cpp:1485
+#: src/muuli_wdr.cpp:3411
+msgid "Networks"
+msgstr "Tinklas"
+
+#: src/amuleDlg.cpp:1726 src/muuli_wdr.cpp:3411
 msgid "Networks Window"
 msgstr "Tinklo langas"
 
-#: src/amuleDlg.cpp:1820 src/muuli_wdr.cpp:3440
+#: src/amuleDlg.cpp:1728 src/muuli_wdr.cpp:3412
+msgid "Searches"
+msgstr "Paieška"
+
+#: src/amuleDlg.cpp:1732 src/muuli_wdr.cpp:3412
 msgid "Searches Window"
 msgstr "Paieškos langas"
 
-#: src/amuleDlg.cpp:1826 src/muuli_wdr.cpp:3441
+#: src/amuleDlg.cpp:1734 src/DownloadListCtrl.cpp:740 src/muuli_wdr.cpp:392
+#: src/muuli_wdr.cpp:1578 src/muuli_wdr.cpp:3413 src/Statistics.cpp:829
+msgid "Downloads"
+msgstr "Siuntimai"
+
+#: src/amuleDlg.cpp:1738 src/muuli_wdr.cpp:3413
 #, fuzzy
 msgid "Downloads Window"
 msgstr "Atsiunčiama"
 
-#: src/amuleDlg.cpp:1832 src/muuli_wdr.cpp:3443
+#: src/amuleDlg.cpp:1740 src/muuli_wdr.cpp:3287
+msgid "Shared files"
+msgstr "Dalinami failai"
+
+#: src/amuleDlg.cpp:1744 src/muuli_wdr.cpp:3415
 msgid "Shared Files Window"
 msgstr "Dalinamų failų langas"
 
-#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3444
+#: src/amuleDlg.cpp:1746 src/muuli_wdr.cpp:2919 src/muuli_wdr.cpp:3369
+#: src/muuli_wdr.cpp:3416
+msgid "Messages"
+msgstr "Žinutės"
+
+#: src/amuleDlg.cpp:1750 src/muuli_wdr.cpp:3416
 msgid "Messages Window"
 msgstr "Žinučių langas"
 
-#: src/amuleDlg.cpp:1844 src/muuli_wdr.cpp:3445
+#: src/amuleDlg.cpp:1752 src/muuli_wdr.cpp:3417 src/PrefsUnifiedDlg.cpp:312
+#: src/Statistics.cpp:779 src/Statistics.cpp:1235
+msgid "Statistics"
+msgstr "Statistika"
+
+#: src/amuleDlg.cpp:1756 src/muuli_wdr.cpp:3417
 msgid "Statistics Graph Window"
 msgstr "Statistikos grafikų langas"
 
-#: src/amuleDlg.cpp:1851 src/muuli_wdr.cpp:3447
+#: src/amuleDlg.cpp:1759 src/muuli_wdr.cpp:3419 src/PrefsUnifiedDlg.cpp:328
+#: src/utils/wxCas/src/wxcasprefs.cpp:39
+msgid "Preferences"
+msgstr "Parinktys"
+
+#: src/amuleDlg.cpp:1763 src/muuli_wdr.cpp:3419
 msgid "Preferences Settings Window"
 msgstr "Parinkčių langas"
 
-#: src/amuleDlg.cpp:1854 src/muuli_wdr.cpp:3448
+#: src/amuleDlg.cpp:1766 src/muuli_wdr.cpp:3420
 msgid "Import"
 msgstr "Įkelti"
 
-#: src/amuleDlg.cpp:1858 src/muuli_wdr.cpp:3448
+#: src/amuleDlg.cpp:1770 src/muuli_wdr.cpp:3420
 msgid "The partfile importer tool"
 msgstr "Dalinai atsiųstų failų įkėlimo įrankis"
 
-#: src/amuleDlg.cpp:1861 src/muuli_wdr.cpp:3449
+#: src/amuleDlg.cpp:1773 src/muuli_wdr.cpp:3421
 #: src/utils/aLinkCreator/src/alcframe.cpp:262
 msgid "About"
 msgstr "Apie"
 
-#: src/amuleDlg.cpp:1861 src/muuli_wdr.cpp:3449
+#: src/amuleDlg.cpp:1773 src/muuli_wdr.cpp:3421
 msgid "About/Help"
 msgstr "Apie/pagalba"
 
-#: src/amuleDlg.cpp:2059
+#: src/amuleDlg.cpp:1971
 msgid "eD2k network"
 msgstr "eD2k tinklas"
 
-#: src/amuleDlg.cpp:2062
+#: src/amuleDlg.cpp:1974
 msgid "Kad network"
 msgstr "Kad tinklas"
 
-#: src/amuleDlg.cpp:2062
+#: src/amuleDlg.cpp:1974
 msgid "No network"
 msgstr "Jokio tinklo"
 
@@ -962,7 +957,7 @@ msgstr "Failas nerastas."
 msgid "The core rejected these shared folders:%s"
 msgstr ""
 
-#: src/amule-remote-gui.cpp:1336 src/ExternalConn.cpp:2346
+#: src/amule-remote-gui.cpp:1336 src/ExternalConn.cpp:2345
 msgid "Invalid link or already on list."
 msgstr "Klaidinga nuoroda arba failas sąraše jau yra."
 
@@ -978,7 +973,7 @@ msgstr ""
 #: src/ClientDetailDialog.cpp:123 src/DataToText.cpp:61 src/DataToText.cpp:86
 #: src/DataToText.cpp:101 src/DataToText.cpp:136 src/DataToText.cpp:165
 #: src/DownloadListCtrl.cpp:1172 src/DownloadListCtrl.cpp:1185
-#: src/DownloadListCtrl.cpp:1196 src/ExternalConn.cpp:609
+#: src/DownloadListCtrl.cpp:1196 src/ExternalConn.cpp:608
 #: src/FileDetailDialog.cpp:203 src/FileDetailDialog.cpp:235
 #: src/FileDetailDialog.cpp:242 src/GenericClientListCtrl.cpp:1171
 #: src/GenericClientListCtrl.cpp:1182 src/GenericClientListCtrl.cpp:1192
@@ -1370,19 +1365,19 @@ msgstr "Automatiškai (aukštas)"
 msgid "Very low"
 msgstr "Labai žemas"
 
-#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:743 src/muuli_wdr.cpp:2303
+#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:743 src/muuli_wdr.cpp:2275
 #: src/ServerListCtrl.cpp:263 src/ServerListCtrl.cpp:456
 #: src/SharedFilesCtrl.cpp:145
 msgid "Low"
 msgstr "Žemas"
 
-#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:744 src/muuli_wdr.cpp:2304
+#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:744 src/muuli_wdr.cpp:2276
 #: src/ServerListCtrl.cpp:266 src/ServerListCtrl.cpp:457
 #: src/SharedFilesCtrl.cpp:146
 msgid "Normal"
 msgstr "Normalus"
 
-#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:745 src/muuli_wdr.cpp:2305
+#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:745 src/muuli_wdr.cpp:2277
 #: src/ServerListCtrl.cpp:269 src/ServerListCtrl.cpp:458
 #: src/SharedFilesCtrl.cpp:147
 msgid "High"
@@ -1474,8 +1469,8 @@ msgstr "Vietinis serveris"
 msgid "Remote Server"
 msgstr "Nutolęs serveris"
 
-#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3202
-#: src/SearchDlg.cpp:119 src/TextClient.cpp:911
+#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3174
+#: src/SearchDlg.cpp:111 src/TextClient.cpp:911
 msgid "Kad"
 msgstr "Kademlia"
 
@@ -1546,7 +1541,7 @@ msgstr ""
 msgid "Size"
 msgstr "Dydis"
 
-#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3269
+#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3241
 msgid "Transferred"
 msgstr "Persiųsta"
 
@@ -1604,7 +1599,7 @@ msgstr ""
 "Atsakymas iš: %s (%s)\n"
 "\n"
 
-#: src/DownloadListCtrl.cpp:746 src/muuli_wdr.cpp:2306
+#: src/DownloadListCtrl.cpp:746 src/muuli_wdr.cpp:2278
 #: src/SharedFilesCtrl.cpp:150
 msgid "Auto"
 msgstr "Automatiškas"
@@ -1642,7 +1637,7 @@ msgid "Extended Options"
 msgstr "Papildomi veiksmai"
 
 #: src/DownloadListCtrl.cpp:770 src/DownloadListCtrl.cpp:822
-#: src/muuli_wdr.cpp:1790
+#: src/muuli_wdr.cpp:1789
 msgid "Preview"
 msgstr "Peržiūra"
 
@@ -1819,237 +1814,232 @@ msgstr[2] ""
 msgid "Invalid eD2k link! ERROR: %s"
 msgstr "Klaidinga eD2k nuoroda! KLAIDA: %s"
 
-#: src/ExternalConn.cpp:380
+#: src/ExternalConn.cpp:379
 #, fuzzy
 msgid "Client sent packet after authentication failed."
 msgstr "Patvirtinimas nepavyko."
 
-#: src/ExternalConn.cpp:397
+#: src/ExternalConn.cpp:396
 msgid "External connection closed."
 msgstr "Išorinis ryšys nutrauktas."
 
-#: src/ExternalConn.cpp:474
+#: src/ExternalConn.cpp:473
 msgid "External connections disabled due to empty password!"
 msgstr "Išoriniai ryšiai atjungti, nes slaptažodis tuščias!"
 
-#: src/ExternalConn.cpp:495
+#: src/ExternalConn.cpp:494
 msgid "External connections disabled in config file"
 msgstr "Išoriniai ryšiai atjungti parinkčių faile"
 
-#: src/ExternalConn.cpp:576
+#: src/ExternalConn.cpp:575
 msgid "New external connection accepted"
 msgstr "Naujas išorinis ryšys priimtas"
 
-#: src/ExternalConn.cpp:579
+#: src/ExternalConn.cpp:578
 msgid "ERROR: couldn't accept a new external connection"
 msgstr "KLAIDA: nepavyko priimti išorinio ryšio"
 
-#: src/ExternalConn.cpp:596
+#: src/ExternalConn.cpp:595
 msgid "External connection refused due to empty password in preferences!"
 msgstr "Išorinis ryšys nepriimtas, nes parinktyse nurodytas tuščias slaptažodis!"
 
-#: src/ExternalConn.cpp:608
+#: src/ExternalConn.cpp:607
 #, c-format
 msgid "Connecting client: %s %s"
 msgstr "Jungiasi klientas: %s %s"
 
-#: src/ExternalConn.cpp:610
+#: src/ExternalConn.cpp:609
 msgid "Unknown version"
 msgstr "Nežinoma versija"
 
-#: src/ExternalConn.cpp:623
+#: src/ExternalConn.cpp:622
 msgid "Incorrect EC version ID, there might be binary incompatibility. Use core and remote from same snapshot."
 msgstr "Klaidingos išorinių ryšių versijos, taip gali būti dėl skirtingų programų. Programos branduolį ir nutolusią aplinką naudokite kompiliuotą iš tos pačios pradinio kodo versijos."
 
-#: src/ExternalConn.cpp:631
+#: src/ExternalConn.cpp:630
 #, fuzzy
 msgid "You cannot connect to a release version from an arbitrary development snapshot! *sigh* possible crash prevented"
 msgstr "Nepavyks prie galutinės leidimo versijos prisijungti iš SVN versijos! Ech, buvo išvengta galimo programos lūžimo"
 
-#: src/ExternalConn.cpp:714
+#: src/ExternalConn.cpp:713
 msgid "Invalid protocol version."
 msgstr "Neteisinga protokolo versija."
 
-#: src/ExternalConn.cpp:720
+#: src/ExternalConn.cpp:719
 msgid "Missing protocol version tag."
 msgstr "Trūksta protokolo versijos žymės."
 
-#: src/ExternalConn.cpp:728
+#: src/ExternalConn.cpp:727
 msgid "Authentication failed: invalid hash specified as EC password."
 msgstr ""
 
-#: src/ExternalConn.cpp:776
+#: src/ExternalConn.cpp:775
 #, fuzzy
 msgid "Authentication failed: wrong password."
 msgstr "Patvirtinimas nepavyko."
 
-#: src/ExternalConn.cpp:778
+#: src/ExternalConn.cpp:777
 #, fuzzy
 msgid "Authentication failed: missing password."
 msgstr "Patvirtinimas nepavyko."
 
-#: src/ExternalConn.cpp:789
+#: src/ExternalConn.cpp:788
 #, fuzzy
 msgid "Invalid request, please authenticate first."
 msgstr "Klaidingas prašymas, iš pradžių turite būti atpažinti."
 
-#: src/ExternalConn.cpp:794
+#: src/ExternalConn.cpp:793
 msgid "Access granted."
 msgstr "Prieiga suteikta."
 
-#: src/ExternalConn.cpp:802
+#: src/ExternalConn.cpp:801
 #, fuzzy, c-format
 msgid "Sent error message \"%s\" to client."
 msgstr "Filtruoti žinutes nuo nežinomų klientų"
 
-#: src/ExternalConn.cpp:807
+#: src/ExternalConn.cpp:806
 #, fuzzy, c-format
 msgid "Unauthorized access attempt from %s. Connection closed."
 msgstr "Bandymas gauti prieigą. Prieiga nesuteikta, ryšys nutrauktas."
 
-#: src/ExternalConn.cpp:1420
+#: src/ExternalConn.cpp:1419
 #, c-format
 msgid "Remote PartFile command failed: FileHash not found: %s"
 msgstr "Nutolusio dalinio failo komanda nepavyko. Failo maišos funkcija nerasta: %s"
 
-#: src/ExternalConn.cpp:1424
+#: src/ExternalConn.cpp:1423
 #, c-format
 msgid "FileHash not found: %s"
 msgstr "Failo maišos funkcija nerasta: %s"
 
-#: src/ExternalConn.cpp:1471 src/ExternalConn.cpp:1559
-#: src/ExternalConn.cpp:1680
+#: src/ExternalConn.cpp:1470 src/ExternalConn.cpp:1558
+#: src/ExternalConn.cpp:1679
 msgid "OOPS! OpCode processing error!"
 msgstr "Oi! OpCode vykdymo klaida!"
 
-#: src/ExternalConn.cpp:1502
+#: src/ExternalConn.cpp:1501
 msgid "Server not added"
 msgstr "Serveris neįdėtas"
 
-#: src/ExternalConn.cpp:1521
+#: src/ExternalConn.cpp:1520
 #, c-format
 msgid "server not found: %s"
 msgstr "serveris nerastas: %s"
 
-#: src/ExternalConn.cpp:1538
+#: src/ExternalConn.cpp:1537
 msgid "need to define server to be removed"
 msgstr "Nurodykite serverį, kurį pašalinti"
 
-#: src/ExternalConn.cpp:1553
+#: src/ExternalConn.cpp:1552
 msgid "eD2k is disabled in preferences."
 msgstr "eD2k išjungtas parinktyse."
 
-#: src/ExternalConn.cpp:1658
+#: src/ExternalConn.cpp:1657
 #, fuzzy
 msgid "Friend not found."
 msgstr "Failas nerastas."
 
-#: src/ExternalConn.cpp:1668
+#: src/ExternalConn.cpp:1667
 #, fuzzy
 msgid "Client not found."
 msgstr "Failas nerastas."
 
-#: src/ExternalConn.cpp:1674
+#: src/ExternalConn.cpp:1673
 msgid "EC_TAG_FRIEND_SHARED requires EC_TAG_FRIEND or EC_TAG_CLIENT."
 msgstr ""
 
-#: src/ExternalConn.cpp:1992
+#: src/ExternalConn.cpp:1991
 msgid "WebSearch from remote interface makes no sense."
 msgstr "www paieška iš nutolusios programos neturi prasmės."
 
-#: src/ExternalConn.cpp:2027
+#: src/ExternalConn.cpp:2026
 msgid "Search in progress. Refetch results in a moment!"
 msgstr "Ieškoma. Tuoj bus gauti rezultatai!"
 
-#: src/ExternalConn.cpp:2266
+#: src/ExternalConn.cpp:2265
 msgid "No points for graph."
 msgstr "Grafikui nėra duomenų."
 
-#: src/ExternalConn.cpp:2276
+#: src/ExternalConn.cpp:2275
 msgid "Your client is not configured for this detail level."
 msgstr "Šis klientas nesuderintas pateikti tiek detalių."
 
-#: src/ExternalConn.cpp:2303
+#: src/ExternalConn.cpp:2302
 msgid "External Connection: shutdown requested"
 msgstr "Išorinis ryšys: gautas prašymas išjungti"
 
-#: src/ExternalConn.cpp:2315
+#: src/ExternalConn.cpp:2314
 msgid "Already shutting down."
 msgstr "Jau išsijungiama."
 
-#: src/ExternalConn.cpp:2333
+#: src/ExternalConn.cpp:2332
 #, c-format
 msgid "ExternalConn: adding link '%s'."
 msgstr "Išoriniai ryšiai: įdedama nuoroda %s."
 
-#: src/ExternalConn.cpp:2351
+#: src/ExternalConn.cpp:2350
 #, fuzzy, c-format
 msgid "%d of %d links failed (invalid or already on list)."
 msgstr "Klaidinga nuoroda arba failas sąraše jau yra."
 
-#: src/ExternalConn.cpp:2374
+#: src/ExternalConn.cpp:2373
 msgid "Version check throttled; try again shortly."
 msgstr ""
 
-#: src/ExternalConn.cpp:2379
+#: src/ExternalConn.cpp:2378
 msgid "Version check is not available on this daemon."
 msgstr ""
 
-#: src/ExternalConn.cpp:2509
+#: src/ExternalConn.cpp:2508
 msgid "File not found."
 msgstr "Failas nerastas."
 
-#: src/ExternalConn.cpp:2514
+#: src/ExternalConn.cpp:2513
 msgid "Invalid file name."
 msgstr "Klaidingas failo pavadinimas."
 
-#: src/ExternalConn.cpp:2522
+#: src/ExternalConn.cpp:2521
 msgid "Unable to rename file."
 msgstr "Nepavyko pervadinti failo."
 
-#: src/ExternalConn.cpp:2839
-#, c-format
-msgid "Could not save the amuleapi password: %s"
-msgstr ""
-
-#: src/ExternalConn.cpp:3004 src/ExternalConn.cpp:3032
+#: src/ExternalConn.cpp:2992 src/ExternalConn.cpp:3020
 msgid "Kad is disabled in preferences."
 msgstr "Kademlia išjungta parinktyse."
 
-#: src/ExternalConn.cpp:3045
+#: src/ExternalConn.cpp:3033
 msgid "Already connected to eD2k."
 msgstr "Prie eD2k jau prisijungta."
 
-#: src/ExternalConn.cpp:3048
+#: src/ExternalConn.cpp:3036
 msgid "Connecting to eD2k..."
 msgstr "Jungiamasi prie eD2k..."
 
-#: src/ExternalConn.cpp:3057
+#: src/ExternalConn.cpp:3045
 msgid "Already connected to Kad."
 msgstr "Prie Kademlia jau prisijungta."
 
-#: src/ExternalConn.cpp:3060
+#: src/ExternalConn.cpp:3048
 msgid "Connecting to Kad..."
 msgstr "Jungiamsi prie Kademlia..."
 
-#: src/ExternalConn.cpp:3067
+#: src/ExternalConn.cpp:3055
 msgid "All networks are disabled."
 msgstr "Visi tinklai išjungti."
 
-#: src/ExternalConn.cpp:3076
+#: src/ExternalConn.cpp:3064
 msgid "Disconnected from eD2k."
 msgstr "Atsijungta nuo eD2k."
 
-#: src/ExternalConn.cpp:3081
+#: src/ExternalConn.cpp:3069
 msgid "Disconnected from Kad."
 msgstr "Atsijungta nuo Kademlia."
 
-#: src/ExternalConn.cpp:3090
+#: src/ExternalConn.cpp:3078
 #, c-format
 msgid "External Connection: invalid opcode received: %#x"
 msgstr "Išorinis ryšys: gautas klaidingas opcode: %#x"
 
-#: src/ExternalConn.cpp:3095
+#: src/ExternalConn.cpp:3083
 msgid "Invalid opcode (wrong protocol version?)"
 msgstr "Klaidingas opcode (bloga protokolo versija?)"
 
@@ -2365,19 +2355,19 @@ msgstr ""
 msgid "eD2k"
 msgstr "eD2k"
 
-#: src/FirstRunWizard.cpp:349 src/muuli_wdr.cpp:1495
+#: src/FirstRunWizard.cpp:349 src/muuli_wdr.cpp:1488
 msgid "Kademlia"
 msgstr "Kademlia"
 
-#: src/FirstRunWizard.cpp:359 src/muuli_wdr.cpp:1423
+#: src/FirstRunWizard.cpp:359 src/muuli_wdr.cpp:1416
 msgid "Standard TCP Port "
 msgstr ""
 
-#: src/FirstRunWizard.cpp:365 src/muuli_wdr.cpp:1435
+#: src/FirstRunWizard.cpp:365 src/muuli_wdr.cpp:1428
 msgid "Extended UDP port (Kad / global search) "
 msgstr ""
 
-#: src/FirstRunWizard.cpp:377 src/muuli_wdr.cpp:1442
+#: src/FirstRunWizard.cpp:377 src/muuli_wdr.cpp:1435
 msgid "Enable UPnP for router port forwarding"
 msgstr ""
 
@@ -2404,7 +2394,7 @@ msgstr ""
 msgid "Your peer lists are already in place - nothing to download."
 msgstr "Failas %s jau yra atsiunčiamų failų sąraše"
 
-#: src/FirstRunWizard.cpp:434 src/muuli_wdr.cpp:1540
+#: src/FirstRunWizard.cpp:434 src/muuli_wdr.cpp:1533
 msgid "Auto-update server list at startup"
 msgstr "Automatiškai atnaujinti serverių sąrašą paleidus programą"
 
@@ -2450,23 +2440,23 @@ msgid ""
 "want downloads on a different (e.g. larger) disk."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:549 src/FirstRunWizard.cpp:611 src/muuli_wdr.cpp:1702
+#: src/FirstRunWizard.cpp:549 src/FirstRunWizard.cpp:611 src/muuli_wdr.cpp:1701
 msgid "Destination folder for downloads"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:553 src/FirstRunWizard.cpp:569 src/muuli_wdr.cpp:1349
-#: src/muuli_wdr.cpp:1366 src/muuli_wdr.cpp:1677 src/muuli_wdr.cpp:1708
-#: src/muuli_wdr.cpp:1720 src/muuli_wdr.cpp:2790
+#: src/FirstRunWizard.cpp:553 src/FirstRunWizard.cpp:569 src/muuli_wdr.cpp:1342
+#: src/muuli_wdr.cpp:1359 src/muuli_wdr.cpp:1676 src/muuli_wdr.cpp:1707
+#: src/muuli_wdr.cpp:1719 src/muuli_wdr.cpp:2762
 #: src/utils/aLinkCreator/src/alcframe.cpp:135
 #: src/utils/wxCas/src/wxcasprefs.cpp:52 src/utils/wxCas/src/wxcasprefs.cpp:118
 msgid "Browse"
 msgstr "Naršyti"
 
-#: src/FirstRunWizard.cpp:559 src/muuli_wdr.cpp:1713
+#: src/FirstRunWizard.cpp:559 src/muuli_wdr.cpp:1712
 msgid "(All files in this folder are shared with other peers)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:565 src/FirstRunWizard.cpp:624 src/muuli_wdr.cpp:1715
+#: src/FirstRunWizard.cpp:565 src/FirstRunWizard.cpp:624 src/muuli_wdr.cpp:1714
 msgid "Folder for temporary download files"
 msgstr ""
 
@@ -2497,7 +2487,7 @@ msgstr "Nepavyko atverti draugų sąrašo failo „emfriends.met“ rašymui!"
 msgid "CRITICAL - no client on StartChatSession"
 msgstr ""
 
-#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2696 src/muuli_wdr.cpp:3373
+#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2668 src/muuli_wdr.cpp:3345
 msgid "Friends"
 msgstr "Draugai"
 
@@ -2611,8 +2601,8 @@ msgstr "Niekas"
 msgid "No"
 msgstr "Ne"
 
-#: src/GenericClientListCtrl.cpp:1216 src/PrefsUnifiedDlg.cpp:2898
-#: src/PrefsUnifiedDlg.cpp:2948 src/ServerListCtrl.cpp:276
+#: src/GenericClientListCtrl.cpp:1216 src/PrefsUnifiedDlg.cpp:2818
+#: src/PrefsUnifiedDlg.cpp:2868 src/ServerListCtrl.cpp:276
 msgid "Yes"
 msgstr "Taip"
 
@@ -2784,10 +2774,10 @@ msgstr "Klaidingas inicializavimo prievadas"
 msgid "Please fill all fields required"
 msgstr "Prašome užpildyti visus privalomus laukus"
 
-#: src/KadDlg.cpp:192 src/PartFile.cpp:1031 src/PrefsUnifiedDlg.cpp:1134
-#: src/PrefsUnifiedDlg.cpp:1204 src/PrefsUnifiedDlg.cpp:1405
-#: src/PrefsUnifiedDlg.cpp:1663 src/PrefsUnifiedDlg.cpp:1673
-#: src/PrefsUnifiedDlg.cpp:1690 src/PrefsUnifiedDlg.cpp:1738
+#: src/KadDlg.cpp:192 src/PartFile.cpp:1031 src/PrefsUnifiedDlg.cpp:1162
+#: src/PrefsUnifiedDlg.cpp:1331 src/PrefsUnifiedDlg.cpp:1589
+#: src/PrefsUnifiedDlg.cpp:1599 src/PrefsUnifiedDlg.cpp:1616
+#: src/PrefsUnifiedDlg.cpp:1658
 msgid "Message"
 msgstr "Žinutė"
 
@@ -2892,7 +2882,7 @@ msgstr "Platinimo santykis"
 msgid "Uploaded"
 msgstr "Išsiųsta"
 
-#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3253
+#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3225
 msgid "Requested"
 msgstr "Paprašyta"
 
@@ -3018,7 +3008,7 @@ msgid "WARNING: "
 msgstr "DĖMESIO: "
 
 #: src/MuleNotebook.cpp:179 src/muuli_wdr.cpp:817 src/muuli_wdr.cpp:1229
-#: src/muuli_wdr.cpp:3157 src/muuli_wdr.cpp:3413
+#: src/muuli_wdr.cpp:3129 src/muuli_wdr.cpp:3385
 msgid "Close"
 msgstr "Užverti"
 
@@ -3031,12 +3021,12 @@ msgstr "Iškirpti"
 msgid "Copy"
 msgstr "Kopijuoti"
 
-#: src/MuleTextCtrl.cpp:88 src/SearchDlg.cpp:261
+#: src/MuleTextCtrl.cpp:88
 msgid "Paste"
 msgstr "Įterpti"
 
 #: src/MuleTextCtrl.cpp:89 src/muuli_wdr.cpp:358 src/muuli_wdr.cpp:757
-#: src/muuli_wdr.cpp:2380 src/muuli_wdr.cpp:2399 src/muuli_wdr.cpp:2421
+#: src/muuli_wdr.cpp:2352 src/muuli_wdr.cpp:2371 src/muuli_wdr.cpp:2393
 #: src/utils/aLinkCreator/src/alcframe.cpp:142
 msgid "Clear"
 msgstr "Išvalyti"
@@ -3134,8 +3124,8 @@ msgid "Exit"
 msgstr "Baigti"
 
 #: src/MuleTrayIcon.cpp:579 src/MuleTrayIcon.cpp:945 src/MuleTrayIcon.cpp:965
-#: src/muuli_wdr.cpp:1398 src/muuli_wdr.cpp:1406 src/muuli_wdr.cpp:1413
-#: src/muuli_wdr.cpp:1836 src/muuli_wdr.cpp:1842 src/OtherFunctions.cpp:91
+#: src/muuli_wdr.cpp:1391 src/muuli_wdr.cpp:1399 src/muuli_wdr.cpp:1406
+#: src/muuli_wdr.cpp:1835 src/muuli_wdr.cpp:1841 src/OtherFunctions.cpp:91
 #: src/StatisticsDlg.cpp:93 src/StatisticsDlg.cpp:95
 msgid "kB/s"
 msgstr "kB/s"
@@ -3306,7 +3296,7 @@ msgstr "Pavadinimas:"
 msgid "Type"
 msgstr "Tipas"
 
-#: src/muuli_wdr.cpp:215 src/SearchDlg.cpp:118 src/SearchListCtrl.cpp:853
+#: src/muuli_wdr.cpp:215 src/SearchDlg.cpp:110 src/SearchListCtrl.cpp:853
 msgid "Local"
 msgstr "Vietinis"
 
@@ -3377,7 +3367,7 @@ msgstr "Baitai"
 msgid "KB"
 msgstr "KB"
 
-#: src/muuli_wdr.cpp:274 src/muuli_wdr.cpp:293 src/muuli_wdr.cpp:1621
+#: src/muuli_wdr.cpp:274 src/muuli_wdr.cpp:293 src/muuli_wdr.cpp:1620
 #: src/OtherFunctions.cpp:64
 msgid "MB"
 msgstr "MB"
@@ -3394,7 +3384,7 @@ msgstr "Maks dydis"
 msgid "Availability"
 msgstr "Skaičius"
 
-#: src/muuli_wdr.cpp:312 src/muuli_wdr.cpp:398 src/muuli_wdr.cpp:3318
+#: src/muuli_wdr.cpp:312 src/muuli_wdr.cpp:398 src/muuli_wdr.cpp:3290
 msgid "Filter:"
 msgstr "Filtras:"
 
@@ -3426,7 +3416,7 @@ msgstr ""
 msgid "Stop"
 msgstr "Sustabdyti"
 
-#: src/muuli_wdr.cpp:348 src/muuli_wdr.cpp:1392 src/SearchListCtrl.cpp:732
+#: src/muuli_wdr.cpp:348 src/muuli_wdr.cpp:1385 src/SearchListCtrl.cpp:732
 msgid "Download"
 msgstr "Atsiųsti"
 
@@ -3458,12 +3448,12 @@ msgstr "Pilni šaltiniai"
 #: src/muuli_wdr.cpp:1160 src/muuli_wdr.cpp:1167 src/muuli_wdr.cpp:1172
 #: src/muuli_wdr.cpp:1179 src/muuli_wdr.cpp:1184 src/muuli_wdr.cpp:1191
 #: src/muuli_wdr.cpp:1205 src/muuli_wdr.cpp:1212 src/muuli_wdr.cpp:1217
-#: src/muuli_wdr.cpp:1224 src/muuli_wdr.cpp:3255 src/muuli_wdr.cpp:3263
-#: src/muuli_wdr.cpp:3271
+#: src/muuli_wdr.cpp:1224 src/muuli_wdr.cpp:3227 src/muuli_wdr.cpp:3235
+#: src/muuli_wdr.cpp:3243
 msgid "N/A"
 msgstr "Nežinoma"
 
-#: src/muuli_wdr.cpp:508 src/muuli_wdr.cpp:1065 src/PrefsUnifiedDlg.cpp:299
+#: src/muuli_wdr.cpp:508 src/muuli_wdr.cpp:1065 src/PrefsUnifiedDlg.cpp:297
 msgid "General"
 msgstr "Bendra"
 
@@ -3604,7 +3594,7 @@ msgstr ""
 msgid "Album :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:685 src/muuli_wdr.cpp:2275
+#: src/muuli_wdr.cpp:685 src/muuli_wdr.cpp:2247
 msgid "Title :"
 msgstr "Pavadinimas:"
 
@@ -3711,7 +3701,7 @@ msgstr "Naudotojo vardas:"
 msgid "Userhash :"
 msgstr "Naudotojo maišos f-ja:"
 
-#: src/muuli_wdr.cpp:895 src/muuli_wdr.cpp:1742 src/muuli_wdr.cpp:2470
+#: src/muuli_wdr.cpp:895 src/muuli_wdr.cpp:1741 src/muuli_wdr.cpp:2442
 #: src/utils/aLinkCreator/src/alcframe.cpp:137
 msgid "Add"
 msgstr "Įdėti"
@@ -3720,15 +3710,15 @@ msgstr "Įdėti"
 msgid "Download-Speed"
 msgstr "Atsiuntimo sparta"
 
-#: src/muuli_wdr.cpp:954 src/muuli_wdr.cpp:989 src/muuli_wdr.cpp:2574
+#: src/muuli_wdr.cpp:954 src/muuli_wdr.cpp:989 src/muuli_wdr.cpp:2546
 msgid "Current"
 msgstr "Dabartinė sparta"
 
-#: src/muuli_wdr.cpp:962 src/muuli_wdr.cpp:997 src/muuli_wdr.cpp:2582
+#: src/muuli_wdr.cpp:962 src/muuli_wdr.cpp:997 src/muuli_wdr.cpp:2554
 msgid "Running average"
 msgstr "Dabartinis vidurkis"
 
-#: src/muuli_wdr.cpp:970 src/muuli_wdr.cpp:1005 src/muuli_wdr.cpp:2590
+#: src/muuli_wdr.cpp:970 src/muuli_wdr.cpp:1005 src/muuli_wdr.cpp:2562
 msgid "Session average"
 msgstr "Seanso vidurkis"
 
@@ -3740,7 +3730,7 @@ msgstr "Išsiuntimo sparta"
 msgid "Connections"
 msgstr "Ryšiai"
 
-#: src/muuli_wdr.cpp:1024 src/muuli_wdr.cpp:1861
+#: src/muuli_wdr.cpp:1024 src/muuli_wdr.cpp:1860
 msgid "Active downloads"
 msgstr "Aktyvūs atsiuntimai"
 
@@ -3748,7 +3738,7 @@ msgstr "Aktyvūs atsiuntimai"
 msgid "Active connections (1:1)"
 msgstr "Aktyvūs ryšiai (1:1)"
 
-#: src/muuli_wdr.cpp:1040 src/muuli_wdr.cpp:1862
+#: src/muuli_wdr.cpp:1040 src/muuli_wdr.cpp:1861
 msgid "Active uploads"
 msgstr "Aktyvūs išsiuntimai"
 
@@ -3865,8 +3855,8 @@ msgstr "Įrašykite vardą, kurį matys kiti su jumis užmezgę ryšį naudotoja
 msgid "Language: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1257 src/muuli_wdr.cpp:1330 src/muuli_wdr.cpp:1334
-#: src/muuli_wdr.cpp:1337
+#: src/muuli_wdr.cpp:1257 src/muuli_wdr.cpp:1323 src/muuli_wdr.cpp:1327
+#: src/muuli_wdr.cpp:1330
 msgid "The delay before showing tool-tips."
 msgstr "Kiek sekundžių uždelsti prieš parodant patarimą užvedus pelę ant objekto."
 
@@ -3944,962 +3934,938 @@ msgstr ""
 msgid "Enabling this will make aMule to show notifications when finished downloading."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1323
-#, fuzzy
-msgid "Remember search history"
-msgstr "Įsiminti parinktis"
-
-#: src/muuli_wdr.cpp:1324
-msgid "Keeps a dropdown list of your past search terms in the Search tab's Name field. This remembers the queries you typed, not the results they returned."
-msgstr ""
-
-#: src/muuli_wdr.cpp:1329
+#: src/muuli_wdr.cpp:1322
 msgid "Tooltip delay time: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1336
+#: src/muuli_wdr.cpp:1329
 msgid "seconds"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1340
+#: src/muuli_wdr.cpp:1333
 msgid "Browser Selection"
 msgstr "Naršyklės parintys"
 
-#: src/muuli_wdr.cpp:1346
+#: src/muuli_wdr.cpp:1339
 msgid "Enter your browser name here. Leave this field empty to use the system default browser."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1353
+#: src/muuli_wdr.cpp:1346
 msgid "Open in new tab if possible"
 msgstr "Jei įmanoma, atverti naują kortelę"
 
-#: src/muuli_wdr.cpp:1355
+#: src/muuli_wdr.cpp:1348
 msgid "Open the web page in a new tab instead of in a new window when possible"
 msgstr "Įjungus šią parinktį, stengtis nurodytą puslapį atverti naujoje naršyklės kortelėje, o ne pagrindiniame naršyklės lange"
 
-#: src/muuli_wdr.cpp:1359
+#: src/muuli_wdr.cpp:1352
 msgid "Video Player"
 msgstr "Vaizdo grotuvas"
 
-#: src/muuli_wdr.cpp:1386
+#: src/muuli_wdr.cpp:1379
 msgid "Bandwidth limits"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1400
+#: src/muuli_wdr.cpp:1393
 msgid "Upload"
 msgstr "Išsiuntimas"
 
-#: src/muuli_wdr.cpp:1408
+#: src/muuli_wdr.cpp:1401
 msgid "Slot Allocation"
 msgstr "Vieno ryšio sparta"
 
-#: src/muuli_wdr.cpp:1417
+#: src/muuli_wdr.cpp:1410
 msgid "Ports"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1427
+#: src/muuli_wdr.cpp:1420
 msgid "This is the standard eD2k port and cannot be disabled."
 msgstr "Tai standartinis eD2k prievadas. Jis negali būti išjungtas."
 
-#: src/muuli_wdr.cpp:1430
+#: src/muuli_wdr.cpp:1423
 msgid "UDP port for server requests (TCP+3):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1432
+#: src/muuli_wdr.cpp:1425
 msgid "4665"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1439
+#: src/muuli_wdr.cpp:1432
 msgid "This UDP port is used for extended eD2k requests and Kad network"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1446
+#: src/muuli_wdr.cpp:1439
 msgid "UPnP TCP Port (Optional):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1456
+#: src/muuli_wdr.cpp:1449
 msgid "Bind local address to IP (empty for any):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1459
+#: src/muuli_wdr.cpp:1452
 msgid "Advanced users only: If you have multiple network interfaces, enter the address of the interface to which aMule should be bound."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1462 src/muuli_wdr.cpp:2055
+#: src/muuli_wdr.cpp:1455 src/muuli_wdr.cpp:2054
 msgid "Bind to network interface (empty for any):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1475
+#: src/muuli_wdr.cpp:1468
 msgid "Advanced users only: pin all of aMule's traffic to one network interface, chosen from the list or typed in by name (e.g. tun0, eth0, en0) or index. Unlike binding to an IP, this stops traffic leaking out via the default route - useful with a VPN. Requires no elevated privileges."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1481
+#: src/muuli_wdr.cpp:1474
 msgid "Max sources per downloading file:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1485
+#: src/muuli_wdr.cpp:1478
 msgid "Max simultaneous connections:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1498 src/muuli_wdr.cpp:3197
+#: src/muuli_wdr.cpp:1491 src/muuli_wdr.cpp:3169
 msgid "ED2K"
 msgstr "ED2K"
 
-#: src/muuli_wdr.cpp:1505
+#: src/muuli_wdr.cpp:1498
 msgid "Autoconnect on startup"
 msgstr "Pradėjus darbą prisijungti automatiškai"
 
-#: src/muuli_wdr.cpp:1508
+#: src/muuli_wdr.cpp:1501
 msgid "Reconnect on loss"
 msgstr "Nutrūkus ryšiui prisijungti vėl"
 
-#: src/muuli_wdr.cpp:1530
+#: src/muuli_wdr.cpp:1523
 msgid "Remove dead server after"
 msgstr "Pašalinti neatsiliepiantį serverį po"
 
-#: src/muuli_wdr.cpp:1531
+#: src/muuli_wdr.cpp:1524
 msgid "Static servers are never removed, even when unreachable."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1535
+#: src/muuli_wdr.cpp:1528
 msgid "retries"
 msgstr "bandymų"
 
-#: src/muuli_wdr.cpp:1543
+#: src/muuli_wdr.cpp:1536
 msgid "List"
 msgstr "Sąrašas"
 
-#: src/muuli_wdr.cpp:1546
+#: src/muuli_wdr.cpp:1539
 msgid "Update server list when connecting to a server"
 msgstr "Atnaujinti serverių sąrašą prisijungus prie serverio"
 
-#: src/muuli_wdr.cpp:1549
+#: src/muuli_wdr.cpp:1542
 msgid "Update server list when a client connects"
 msgstr "Atnaujinti serverių sąrašą prisijungus klientui"
 
-#: src/muuli_wdr.cpp:1552
+#: src/muuli_wdr.cpp:1545
 msgid "Use priority system"
 msgstr "Naudoti prioritetų sistemą"
 
-#: src/muuli_wdr.cpp:1556
+#: src/muuli_wdr.cpp:1549
 msgid "Use smart LowID check on connect"
 msgstr "Jungiantis naudoti išmoningą žemo ID tikrinimą"
 
-#: src/muuli_wdr.cpp:1560
+#: src/muuli_wdr.cpp:1553
 msgid "Safe connect"
 msgstr "Saugus jungimasis"
 
-#: src/muuli_wdr.cpp:1564
+#: src/muuli_wdr.cpp:1557
 msgid "Autoconnect to servers in static list only"
 msgstr "Automatiškai jungtis tik prie serverių iš pastovaus sąrašo"
 
-#: src/muuli_wdr.cpp:1567
+#: src/muuli_wdr.cpp:1560
 msgid "Set manually added servers to High Priority"
 msgstr "Naudotojo įdėtiems serveriams nurodyti aukštą prioritetą"
 
-#: src/muuli_wdr.cpp:1588
+#: src/muuli_wdr.cpp:1581
 msgid "Add files to download in pause mode"
 msgstr "Failus į atsiuntimo eilę įdėti pristabdytos būsenos"
 
-#: src/muuli_wdr.cpp:1590
+#: src/muuli_wdr.cpp:1583
 msgid "Add files to download with auto priority"
 msgstr "Į atsiuntimo eilę įdedamiems failams nurodyti automatinį prioritetą"
 
-#: src/muuli_wdr.cpp:1593
+#: src/muuli_wdr.cpp:1586
 msgid "Try to download first and last chunks first"
 msgstr "Visų pirma bandyti atsiųsti pirmą ir paskutinę failo dalį"
 
-#: src/muuli_wdr.cpp:1597
+#: src/muuli_wdr.cpp:1590
 msgid "Endgame mode: rotate to faster sources for the final blocks"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1600
+#: src/muuli_wdr.cpp:1593
 msgid "Start next paused file when a file completes"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1603
+#: src/muuli_wdr.cpp:1596
 msgid "From the same category"
 msgstr "Siųsti tos pačios kategorijos failą"
 
-#: src/muuli_wdr.cpp:1605
+#: src/muuli_wdr.cpp:1598
 msgid "In alphabetic order"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1607
+#: src/muuli_wdr.cpp:1600
 msgid "Preallocate disk space for new files"
 msgstr "Naujiems failams paskirti vietą diske"
 
-#: src/muuli_wdr.cpp:1608
+#: src/muuli_wdr.cpp:1601
 msgid "For new files preallocates disk space for the whole file, thus reduces fragmentation"
 msgstr "Naujiems failams iš anksto paskirti vietą diske visam failui. Taip bus sumažinta fragmentacija"
 
-#: src/muuli_wdr.cpp:1613
+#: src/muuli_wdr.cpp:1606
+msgid "Create new files as sparse files"
+msgstr ""
+
+#: src/muuli_wdr.cpp:1607
+msgid "A sparse file reserves its full size on disk immediately without writing real data to it -- fast, but unsupported or slow on some filesystems, and free-space accounting stays optimistic while the download is in progress. Turn this off to grow the file only as data arrives."
+msgstr ""
+
+#: src/muuli_wdr.cpp:1612
 msgid "Stop downloads when free disk space reaches "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1614
+#: src/muuli_wdr.cpp:1613
 msgid "Select this if you want aMule to check your disk space"
 msgstr "Įjunkite, jei norite, kad aMule tikrintų laisvą vietą diske"
 
-#: src/muuli_wdr.cpp:1618
+#: src/muuli_wdr.cpp:1617
 msgid "Enter here the min disk space desired."
 msgstr "Įrašykite kiek diske palikti laisvos vietos."
 
-#: src/muuli_wdr.cpp:1624
+#: src/muuli_wdr.cpp:1623
 msgid "Save 10 sources on rare files (< 20 sources)"
 msgstr "Įrašyti 10 šaltinių retiems failams (mažiau nei 20 šaltinių)"
 
-#: src/muuli_wdr.cpp:1628 src/Statistics.cpp:790
+#: src/muuli_wdr.cpp:1627 src/Statistics.cpp:790
 msgid "Uploads"
 msgstr "Išsiuntimai"
 
-#: src/muuli_wdr.cpp:1631
+#: src/muuli_wdr.cpp:1630
 msgid "Add new shared files with auto priority"
 msgstr "Naujiems dalinamiems failams nurodyti automatinį prioritetą"
 
-#: src/muuli_wdr.cpp:1637
+#: src/muuli_wdr.cpp:1636
 msgid "Intelligent Corruption Handling (I.C.H.)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1640
+#: src/muuli_wdr.cpp:1639
 msgid "Enable"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1643
+#: src/muuli_wdr.cpp:1642
 msgid "Advanced I.C.H. trusts every hash (not recommended)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1655 src/PrefsUnifiedDlg.cpp:1990
+#: src/muuli_wdr.cpp:1654 src/PrefsUnifiedDlg.cpp:1910
 msgid "Media metadata extraction"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1659
+#: src/muuli_wdr.cpp:1658
 msgid "Extract length / bitrate / codec from shared audio and video files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1661
+#: src/muuli_wdr.cpp:1660
 msgid "When enabled, aMule runs ffprobe on each shared media file to fill in the Length / Bitrate / Codec columns other clients see when they find the file in a search. Requires ffmpeg (the ffprobe binary) to be installed."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1668
+#: src/muuli_wdr.cpp:1667
 msgid "Path to ffprobe:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1673
+#: src/muuli_wdr.cpp:1672
 msgid "Full path to the ffprobe binary. Leave empty to have aMule auto-detect it on startup."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1681
+#: src/muuli_wdr.cpp:1680
 msgid "Detect"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1682
+#: src/muuli_wdr.cpp:1681
 msgid "Search the standard install locations for an ffprobe binary and fill the path field."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1706
+#: src/muuli_wdr.cpp:1705
 msgid ""
 "Completed downloads are stored here. All files in this folder are automatically shared with other peers.\n"
 "If this folder also holds files you don't want to share, point it at an aMule-only sub-folder."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1709
+#: src/muuli_wdr.cpp:1708
 msgid "Pick the folder where completed downloads will be stored. All files in that folder will be shared with other peers."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1723
+#: src/muuli_wdr.cpp:1722
 msgid "Shared folders"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1729
+#: src/muuli_wdr.cpp:1728
 msgid "(Folders shared by the core. Enter a path to add one.)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1737
+#: src/muuli_wdr.cpp:1736
 msgid "Absolute path of a folder on the core's machine, e.g. /home/user/shared"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1739 src/PrefsUnifiedDlg.cpp:2874
+#: src/muuli_wdr.cpp:1738 src/PrefsUnifiedDlg.cpp:2794
 msgid "Recursive"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1740
+#: src/muuli_wdr.cpp:1739
 msgid "Share every sub-folder underneath this one, including ones created later."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1744 src/utils/aLinkCreator/src/alcframe.cpp:141
+#: src/muuli_wdr.cpp:1743 src/utils/aLinkCreator/src/alcframe.cpp:141
 msgid "Remove"
 msgstr "Pašalinti"
 
-#: src/muuli_wdr.cpp:1748
+#: src/muuli_wdr.cpp:1747
 msgid "(Right click on folder icon for recursive share)"
 msgstr "(spragtelėję dešiniu klavišu dalinsitės ir gilesniais paaplankiais)"
 
-#: src/muuli_wdr.cpp:1755
+#: src/muuli_wdr.cpp:1754
 msgid "Share hidden files"
 msgstr "Dalintis slepiamais failais"
 
-#: src/muuli_wdr.cpp:1761
+#: src/muuli_wdr.cpp:1760
 msgid "Automatically rescan shared folders for changes"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1767
+#: src/muuli_wdr.cpp:1766
 msgid "Follow symbolic links in shared folders"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1773
+#: src/muuli_wdr.cpp:1772
 msgid "Exclude files matching:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1776
+#: src/muuli_wdr.cpp:1775
 msgid "Wildcard patterns separated by '|', e.g. .DS_Store|Thumbs.db|*.tmp. Files whose name matches are not shared. Matching is case-insensitive."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1780
+#: src/muuli_wdr.cpp:1779
 msgid "Patterns are regular expressions"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1781
+#: src/muuli_wdr.cpp:1780
 msgid "When set, the whole field is one regular expression ('|' is alternation). When unset, it is a list of '|'-separated wildcards."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1791
+#: src/muuli_wdr.cpp:1790
 msgid "Show how many shared files the current pattern would exclude."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1812
+#: src/muuli_wdr.cpp:1811
 msgid "Graphs"
 msgstr "Grafikai"
 
-#: src/muuli_wdr.cpp:1815 src/muuli_wdr.cpp:1877
+#: src/muuli_wdr.cpp:1814 src/muuli_wdr.cpp:1876
 msgid "Update delay : 5 secs"
 msgstr "Atnaujinimo dažnis: 5 s"
 
-#: src/muuli_wdr.cpp:1819
+#: src/muuli_wdr.cpp:1818
 msgid "Time for average graph: 100 mins"
 msgstr "Vidurkių grafiko dydis: 100 min"
 
-#: src/muuli_wdr.cpp:1823
+#: src/muuli_wdr.cpp:1822
 msgid "Connections Graph Scale: 100 "
 msgstr "Ryšių grafiko skalė: 100 "
 
-#: src/muuli_wdr.cpp:1830
+#: src/muuli_wdr.cpp:1829
 msgid "Download graph scale:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1838
+#: src/muuli_wdr.cpp:1837
 msgid "Upload graph scale:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1848
+#: src/muuli_wdr.cpp:1847
 msgid "Colors: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1852
+#: src/muuli_wdr.cpp:1851
 msgid "Background"
 msgstr "Fonas"
 
-#: src/muuli_wdr.cpp:1853
+#: src/muuli_wdr.cpp:1852
 msgid "Grid"
 msgstr "Rėmeliai"
 
-#: src/muuli_wdr.cpp:1854
+#: src/muuli_wdr.cpp:1853
 msgid "Download current"
 msgstr "Dabartinė atsiuntimo sparta"
 
-#: src/muuli_wdr.cpp:1855
+#: src/muuli_wdr.cpp:1854
 msgid "Download running average"
 msgstr "Dabartinis atsiuntimo vidurkis"
 
-#: src/muuli_wdr.cpp:1856
+#: src/muuli_wdr.cpp:1855
 msgid "Download session average"
 msgstr "Seanso atsiuntimo vidurkis"
 
-#: src/muuli_wdr.cpp:1857
+#: src/muuli_wdr.cpp:1856
 msgid "Upload current"
 msgstr "Dabartinė išsiuntimo sparta"
 
-#: src/muuli_wdr.cpp:1858
+#: src/muuli_wdr.cpp:1857
 msgid "Upload running average"
 msgstr "Dabartinis išsiuntimo vidurkis"
 
-#: src/muuli_wdr.cpp:1859
+#: src/muuli_wdr.cpp:1858
 msgid "Upload session average"
 msgstr "Seanso išsiuntimo vidurkis"
 
-#: src/muuli_wdr.cpp:1860
+#: src/muuli_wdr.cpp:1859
 msgid "Active connections"
 msgstr "Aktyvūs ryšiai"
 
-#: src/muuli_wdr.cpp:1863
+#: src/muuli_wdr.cpp:1862
 #, fuzzy
 msgid "Systray Icon Speed Bar"
 msgstr "Sistemos dėklo spartos indikatorius"
 
-#: src/muuli_wdr.cpp:1864
+#: src/muuli_wdr.cpp:1863
 msgid "Kad-nodes current"
 msgstr "Dabartiniai Kademlia mazgai"
 
-#: src/muuli_wdr.cpp:1865
+#: src/muuli_wdr.cpp:1864
 msgid "Kad-nodes running"
 msgstr "Kademlia mazgų dabartinis vidurkis"
 
-#: src/muuli_wdr.cpp:1866
+#: src/muuli_wdr.cpp:1865
 msgid "Kad-nodes session"
 msgstr "Kademlia mazgų seanso vidurkis"
 
-#: src/muuli_wdr.cpp:1870 src/muuli_wdr.cpp:2324
+#: src/muuli_wdr.cpp:1869 src/muuli_wdr.cpp:2296
 msgid "Select"
 msgstr "Nurodykite spalvą"
 
-#: src/muuli_wdr.cpp:1874
+#: src/muuli_wdr.cpp:1873
 msgid "Tree"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1884
+#: src/muuli_wdr.cpp:1883
 msgid "Number of Client Versions shown (0=unlimited)"
 msgstr "Rodomų klientų versijų skaičius (0 – neribojama)"
 
-#: src/muuli_wdr.cpp:1909
+#: src/muuli_wdr.cpp:1908
 msgid "!!! WARNING !!!"
 msgstr "DĖMESIO!!!"
 
-#: src/muuli_wdr.cpp:1924
+#: src/muuli_wdr.cpp:1923
 msgid "Max new connections / 5 secs"
 msgstr "Per 5 s užmegzti ne daugiau ryšių, nei nurodyta"
 
-#: src/muuli_wdr.cpp:1926
+#: src/muuli_wdr.cpp:1925
 msgid "Concurrent Kad source lookups"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1928
+#: src/muuli_wdr.cpp:1927
 #, fuzzy
 msgid "Kad source re-search interval (minutes)"
 msgstr "FTP atnaujinimo intervalas minutėmis"
 
-#: src/muuli_wdr.cpp:1930
+#: src/muuli_wdr.cpp:1929
 #, fuzzy
 msgid "Source re-ask interval (minutes)"
 msgstr "FTP atnaujinimo intervalas minutėmis"
 
-#: src/muuli_wdr.cpp:1934
+#: src/muuli_wdr.cpp:1933
 msgid "File Buffer Size: 240000 bytes"
 msgstr "Failo buferio dydis: 240000 baitai"
 
-#: src/muuli_wdr.cpp:1938
+#: src/muuli_wdr.cpp:1937
 msgid "Use MMAP: memory-mapped file access (lower memory use)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1939
+#: src/muuli_wdr.cpp:1938
 msgid "Maps part files into memory instead of buffering them on the heap, lowering the process memory footprint. May reduce download speed on some disks; best for memory-constrained or upload-heavy hosts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1941
+#: src/muuli_wdr.cpp:1940
 msgid "Upload Queue Size: 5000 clients"
 msgstr "Išsiuntimo eilė: 5000 klientų"
 
-#: src/muuli_wdr.cpp:1945
+#: src/muuli_wdr.cpp:1944
 msgid "Server connection refresh interval: Disable"
 msgstr "Serverio ryšio atnaujinimo intervalas: išjungta"
 
-#: src/muuli_wdr.cpp:1949
+#: src/muuli_wdr.cpp:1948
 msgid "Disable computer's timed standby mode"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1968
+#: src/muuli_wdr.cpp:1967
 msgid "Skin to use: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1977
+#: src/muuli_wdr.cpp:1976
 msgid "Show \"Fast eD2k Links Handler\" in every window."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1980
+#: src/muuli_wdr.cpp:1979
 msgid "Show extended info on categories tabs"
 msgstr "Rodyti papildomą informaciją kategorijų kortelėse"
 
-#: src/muuli_wdr.cpp:1983
+#: src/muuli_wdr.cpp:1982
 #, fuzzy
 msgid "Show application version on title"
 msgstr "Rodyti siuntimo spartą failo pavadinime"
 
-#: src/muuli_wdr.cpp:1985
+#: src/muuli_wdr.cpp:1984
 msgid "Show transfer rates on title"
 msgstr "Rodyti siuntimo spartą failo pavadinime"
 
-#: src/muuli_wdr.cpp:1987
+#: src/muuli_wdr.cpp:1986
 msgid "Before application name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1989
+#: src/muuli_wdr.cpp:1988
 msgid "After application name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1992
+#: src/muuli_wdr.cpp:1991
 msgid "Show overhead bandwidth"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1996
+#: src/muuli_wdr.cpp:1995
 msgid "Vertical toolbar orientation"
 msgstr "Mygtukus išdėstyti vertikaliai"
 
-#: src/muuli_wdr.cpp:1998
+#: src/muuli_wdr.cpp:1997
 msgid "Live column sorting (auto-reorder rows as their values change)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2005
+#: src/muuli_wdr.cpp:2004
 msgid "Download Queue Files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2008
+#: src/muuli_wdr.cpp:2007
 msgid "Show progress percentage"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2014
+#: src/muuli_wdr.cpp:2013
 msgid "Show progress bar"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2017
+#: src/muuli_wdr.cpp:2016
 msgid "Flat"
 msgstr "Plokščia"
 
-#: src/muuli_wdr.cpp:2021
+#: src/muuli_wdr.cpp:2020
 msgid "Round"
 msgstr "Erdvinė"
 
-#: src/muuli_wdr.cpp:2039
+#: src/muuli_wdr.cpp:2038
 msgid "External Connection Parameters"
 msgstr "Išorinio ryšio parinktys"
 
-#: src/muuli_wdr.cpp:2042
+#: src/muuli_wdr.cpp:2041
 msgid "Accept external connections"
 msgstr "Priimti išorinius ryšius"
 
-#: src/muuli_wdr.cpp:2049 src/muuli_wdr.cpp:2108
+#: src/muuli_wdr.cpp:2048 src/muuli_wdr.cpp:2107
 msgid "IP of the listening interface:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2052
+#: src/muuli_wdr.cpp:2051
 msgid "Enter here a valid ip in the a.b.c.d format for the listening EC interface. An empty field or 0.0.0.0 will mean any interface."
 msgstr "Įrašykite išorinių ryšių besiklausančio įrenginio IP adresą a.b.c.d forma. Tuščias laukelis arba adresas 0.0.0.0 reiškia bet kokį įrenginį."
 
-#: src/muuli_wdr.cpp:2073 src/muuli_wdr.cpp:2184
+#: src/muuli_wdr.cpp:2072 src/muuli_wdr.cpp:2156
 msgid "TCP port:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2079
+#: src/muuli_wdr.cpp:2078
 msgid "Enable UPnP port forwarding on the EC port"
 msgstr "EC prievade įjungti UPnP prievadų perdavimą"
 
-#: src/muuli_wdr.cpp:2083 src/muuli_wdr.cpp:3069
+#: src/muuli_wdr.cpp:2082 src/muuli_wdr.cpp:3041
 #: src/utils/wxCas/src/wxcasprefs.cpp:167
 msgid "Password"
 msgstr "Slaptažodis"
 
-#: src/muuli_wdr.cpp:2089
+#: src/muuli_wdr.cpp:2088
 #, fuzzy
 msgid "aMule API server parameters"
 msgstr "Žiniatinklio serverio parinktys"
 
-#: src/muuli_wdr.cpp:2092
+#: src/muuli_wdr.cpp:2091
 msgid "Run amuleapi (REST API) on startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2097
+#: src/muuli_wdr.cpp:2096
 #, fuzzy
 msgid "HTTP port:"
 msgstr "TCP prievadas: %d"
 
-#: src/muuli_wdr.cpp:2111
+#: src/muuli_wdr.cpp:2110
 msgid "The interface amuleapi's HTTP server listens on. 127.0.0.1 (default) accepts only local connections; use 0.0.0.0 or a specific IP to expose it to other hosts (set an admin password below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2116
-msgid "Type a password to set or change it. Stored passwords cannot be shown, so leaving this empty keeps the current one."
-msgstr ""
-
-#: src/muuli_wdr.cpp:2118
+#: src/muuli_wdr.cpp:2113
 #, fuzzy
 msgid "Admin password"
 msgstr "Tikrinamas slaptažodis\n"
 
-#: src/muuli_wdr.cpp:2130 src/muuli_wdr.cpp:2147 src/PrefsUnifiedDlg.cpp:1103
-#, fuzzy
-msgid "A password is set."
-msgstr "Tikrinamas slaptažodis\n"
-
-#: src/muuli_wdr.cpp:2134
-#, fuzzy
-msgid "Enable guest access"
-msgstr "Išjungti svečio prieigą"
-
-#: src/muuli_wdr.cpp:2135
-msgid "Guest sessions may read status and listings but cannot change anything. Turning this off clears the stored guest password."
-msgstr ""
-
-#: src/muuli_wdr.cpp:2139
-#, fuzzy
-msgid "Guest password"
-msgstr "Svečio prieigos prie žiniatinklio serverio slaptažodis"
-
-#: src/muuli_wdr.cpp:2154
-msgid "Web server parameters"
-msgstr "Žiniatinklio serverio parinktys"
-
-#: src/muuli_wdr.cpp:2157
-msgid "Run webserver on startup (deprecated)"
-msgstr ""
-
-#: src/muuli_wdr.cpp:2163
-msgid "Web template"
-msgstr "www šablonas"
-
-#: src/muuli_wdr.cpp:2168
-msgid "Full rights password"
-msgstr "Pilnos prieigos slaptažodis"
-
-#: src/muuli_wdr.cpp:2172
-msgid "Enable Low rights User"
-msgstr "Įjungti nepilnos prieigos naudotoją"
-
-#: src/muuli_wdr.cpp:2177
+#: src/muuli_wdr.cpp:2118 src/muuli_wdr.cpp:2149
 msgid "Low rights password"
 msgstr "Nepilnos prieigos slaptažodis"
 
-#: src/muuli_wdr.cpp:2191
+#: src/muuli_wdr.cpp:2126
+msgid "Web server parameters"
+msgstr "Žiniatinklio serverio parinktys"
+
+#: src/muuli_wdr.cpp:2129
+msgid "Run webserver on startup (deprecated)"
+msgstr ""
+
+#: src/muuli_wdr.cpp:2135
+msgid "Web template"
+msgstr "www šablonas"
+
+#: src/muuli_wdr.cpp:2140
+msgid "Full rights password"
+msgstr "Pilnos prieigos slaptažodis"
+
+#: src/muuli_wdr.cpp:2144
+msgid "Enable Low rights User"
+msgstr "Įjungti nepilnos prieigos naudotoją"
+
+#: src/muuli_wdr.cpp:2163
 msgid "Enable UPnP port forwarding of the web server port"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2196
+#: src/muuli_wdr.cpp:2168
 msgid "Web server UPnP TCP port (Optional)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2204
+#: src/muuli_wdr.cpp:2176
 msgid "Page Refresh Time (in secs)"
 msgstr "Puslapio atnaujinimo periodas (sekundėmis)"
 
-#: src/muuli_wdr.cpp:2211
+#: src/muuli_wdr.cpp:2183
 msgid "Enable Gzip compression"
 msgstr "Įjungti Gzip suspaudimą"
 
-#: src/muuli_wdr.cpp:2245
+#: src/muuli_wdr.cpp:2217
 #, fuzzy
 msgid "Reset page to defaults"
 msgstr "Numatyta"
 
-#: src/muuli_wdr.cpp:2246
+#: src/muuli_wdr.cpp:2218
 msgid "Reset the settings on the current page to their default values."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2248 src/muuli_wdr.cpp:2334 src/ServerWnd.cpp:274
+#: src/muuli_wdr.cpp:2220 src/muuli_wdr.cpp:2306 src/ServerWnd.cpp:274
 #: src/ServerWnd.cpp:282
 msgid "OK"
 msgstr "Gerai"
 
-#: src/muuli_wdr.cpp:2250
+#: src/muuli_wdr.cpp:2222
 msgid "Click here to apply any changes made to the preferences."
 msgstr "Patvirtinti naujai nurodytas parinktis."
 
-#: src/muuli_wdr.cpp:2253
+#: src/muuli_wdr.cpp:2225
 msgid "Reset any changes made to the preferences."
 msgstr "Atšaukti bet kokius pakeitimus."
 
-#: src/muuli_wdr.cpp:2282
+#: src/muuli_wdr.cpp:2254
 msgid "Comment :"
 msgstr "Komentaras:"
 
-#: src/muuli_wdr.cpp:2289
+#: src/muuli_wdr.cpp:2261
 msgid "Incoming Dir :"
 msgstr "Atsiųstų failų aplankas:"
 
-#: src/muuli_wdr.cpp:2298
+#: src/muuli_wdr.cpp:2270
 msgid "Change priority for new assigned files :"
 msgstr "Keisti naujai priskirtų failų prioritetą:"
 
-#: src/muuli_wdr.cpp:2302
+#: src/muuli_wdr.cpp:2274
 #, fuzzy
 msgid "Don't change"
 msgstr "Nekeisti"
 
-#: src/muuli_wdr.cpp:2314
+#: src/muuli_wdr.cpp:2286
 msgid "Select color for this Category (currently selected) :"
 msgstr "Nurodykite dabartinės kategorijos spalvą:"
 
-#: src/muuli_wdr.cpp:2381 src/muuli_wdr.cpp:2400 src/muuli_wdr.cpp:2422
+#: src/muuli_wdr.cpp:2353 src/muuli_wdr.cpp:2372 src/muuli_wdr.cpp:2394
 msgid "Click this button to reset the log."
 msgstr "Išvalyti įvykių žurnalą."
 
-#: src/muuli_wdr.cpp:2441
+#: src/muuli_wdr.cpp:2413
 msgid "Click on this button to update the servers list from URL ..."
 msgstr "Paspaudę šį mygtuką atnaujinsite serverių sąrašą iš URL..."
 
-#: src/muuli_wdr.cpp:2445
+#: src/muuli_wdr.cpp:2417
 msgid "Server list"
 msgstr "Serverių sąrašas"
 
-#: src/muuli_wdr.cpp:2449
+#: src/muuli_wdr.cpp:2421
 msgid "Enter the url to a server.met file here and press the button to the left to update the list of known servers."
 msgstr "Įrašykite server.met failo URL ir paspaudę mygtuką kairėje atnaujinsite serverių sąrašą."
 
-#: src/muuli_wdr.cpp:2454
+#: src/muuli_wdr.cpp:2426
 msgid "Add server manually: Name"
 msgstr "Įdėti serverį rankiniu būdu: pavadinimas"
 
-#: src/muuli_wdr.cpp:2457
+#: src/muuli_wdr.cpp:2429
 msgid "Enter the name of the new server here"
 msgstr "Įrašykite serverio pavadinimą"
 
-#: src/muuli_wdr.cpp:2459 src/ServerWnd.cpp:206
+#: src/muuli_wdr.cpp:2431 src/ServerWnd.cpp:206
 msgid "IP:Port"
 msgstr "IP:prievadas"
 
-#: src/muuli_wdr.cpp:2462
+#: src/muuli_wdr.cpp:2434
 msgid "Enter the IP of the server here, using the x.x.x.x format."
 msgstr "Įrašykite serverio IP adresą naudodami a.b.c.d formą."
 
-#: src/muuli_wdr.cpp:2468
+#: src/muuli_wdr.cpp:2440
 msgid "Enter the port of the server here."
 msgstr "Įrašykite serverio prievadą."
 
-#: src/muuli_wdr.cpp:2471
+#: src/muuli_wdr.cpp:2443
 msgid "Add manually a server (fill fields to the left before) ..."
 msgstr "Įdėti serverį (prieš tai užpildykite laukelius kairėje)..."
 
-#: src/muuli_wdr.cpp:2500
+#: src/muuli_wdr.cpp:2472
 msgid "aMule Log"
 msgstr "aMule žurnalas"
 
-#: src/muuli_wdr.cpp:2508
+#: src/muuli_wdr.cpp:2480
 msgid "Server Info"
 msgstr "Serverio informacija"
 
-#: src/muuli_wdr.cpp:2512
+#: src/muuli_wdr.cpp:2484
 msgid "ED2K Info"
 msgstr "ED2K informacija"
 
-#: src/muuli_wdr.cpp:2516
+#: src/muuli_wdr.cpp:2488
 msgid "Kad Info"
 msgstr "Kademlia informacija"
 
-#: src/muuli_wdr.cpp:2544
+#: src/muuli_wdr.cpp:2516
 msgid "Click on this button to update the nodes list from URL ..."
 msgstr "Spragtelėję šį mygtuką atnaujinsite mazgų sąrašą iš URL..."
 
-#: src/muuli_wdr.cpp:2548
+#: src/muuli_wdr.cpp:2520
 msgid "Nodes (0)"
 msgstr "Mazgai (0)"
 
-#: src/muuli_wdr.cpp:2552
+#: src/muuli_wdr.cpp:2524
 msgid "Enter the url to a nodes.dat file here and press the button to the left to update the list of known nodes."
 msgstr "Įrašykite nodes.dat failo URL ir paspaudę mygtuką kairėje atnaujinsite mazgų sąrašą."
 
-#: src/muuli_wdr.cpp:2555
+#: src/muuli_wdr.cpp:2527
 msgid "Nodes stats"
 msgstr "Mazgų statistika"
 
-#: src/muuli_wdr.cpp:2597
+#: src/muuli_wdr.cpp:2569
 msgid "Bootstrap"
 msgstr "Inicializavimas"
 
-#: src/muuli_wdr.cpp:2600
+#: src/muuli_wdr.cpp:2572
 msgid "New node"
 msgstr "Naujas mazgas"
 
-#: src/muuli_wdr.cpp:2605
+#: src/muuli_wdr.cpp:2577
 msgid "IP:"
 msgstr "IP:"
 
-#: src/muuli_wdr.cpp:2625
+#: src/muuli_wdr.cpp:2597
 msgid "Port:"
 msgstr "Prievadas:"
 
-#: src/muuli_wdr.cpp:2638
+#: src/muuli_wdr.cpp:2610
 #, fuzzy
 msgid "Bootstrap from known clients"
 msgstr ""
 "Inicializuoti iš \n"
 "žinomų klientų"
 
-#: src/muuli_wdr.cpp:2640
+#: src/muuli_wdr.cpp:2612
 msgid "Disconnect Kad"
 msgstr "Atjungti Kademlia"
 
-#: src/muuli_wdr.cpp:2674
+#: src/muuli_wdr.cpp:2646
 msgid "Use Secure User Identification"
 msgstr "Naudoti saugų kliento atpažinimą"
 
-#: src/muuli_wdr.cpp:2676
+#: src/muuli_wdr.cpp:2648
 msgid "It is recommended to enable this option. You will not receive credits if SUI is not enabled."
 msgstr "Rekomenduojama įjungti šią parinktį. Jei išjungsite, negausite kreditų."
 
-#: src/muuli_wdr.cpp:2678
+#: src/muuli_wdr.cpp:2650
 msgid "Protocol Obfuscation"
 msgstr "Protokolo slėpimas"
 
-#: src/muuli_wdr.cpp:2681
+#: src/muuli_wdr.cpp:2653
 msgid "Support Protocol Obfuscation"
 msgstr "Įjungti protokolo slėpimą"
 
-#: src/muuli_wdr.cpp:2683
+#: src/muuli_wdr.cpp:2655
 msgid "This option enabled Protocol Obfuscation, and makes aMule accept obfuscated connections from other clients."
 msgstr "Ši parinktis įjungia protokolo slėpimą. Tuomet aMule priiminės slepiamus ryšius iš kitų klientų."
 
-#: src/muuli_wdr.cpp:2685
+#: src/muuli_wdr.cpp:2657
 msgid "Use obfuscation for outgoing connections"
 msgstr "Slėpti išeinančius ryšius"
 
-#: src/muuli_wdr.cpp:2687
+#: src/muuli_wdr.cpp:2659
 msgid "This option makes aMule use Protocol Obfuscation when connecting other clients/servers."
 msgstr "Įjungus šią parinktį aMule, jungdamasi prie kitų klientų ar serverių, slėps išeinančius ryšius."
 
-#: src/muuli_wdr.cpp:2689
+#: src/muuli_wdr.cpp:2661
 msgid "Accept only obfuscated connections"
 msgstr "Priimti tik slepiamus ryšius"
 
-#: src/muuli_wdr.cpp:2690
+#: src/muuli_wdr.cpp:2662
 msgid "This option makes aMule only accept obfuscated connections. You will have less sources, but all your traffic will be obfuscated"
 msgstr "Įjungus šią parinktį aMule priims tik slepiamus ryšius. Šaltinių bus rasta mažiau, bet visas srautas bus slepiamas"
 
-#: src/muuli_wdr.cpp:2695
+#: src/muuli_wdr.cpp:2667
 msgid "Everybody"
 msgstr "Visi"
 
-#: src/muuli_wdr.cpp:2697
+#: src/muuli_wdr.cpp:2669
 msgid "No one"
 msgstr "Niekas"
 
-#: src/muuli_wdr.cpp:2699
+#: src/muuli_wdr.cpp:2671
 msgid "Who can see my shared files:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2700
+#: src/muuli_wdr.cpp:2672
 msgid "Select who can request to view a list of your shared files."
 msgstr "Nurodykite kas gali pamatyti dalinamų failų sąrašą."
 
-#: src/muuli_wdr.cpp:2702
+#: src/muuli_wdr.cpp:2674
 msgid "IP-Filtering"
 msgstr "IP filtravimas"
 
-#: src/muuli_wdr.cpp:2709
+#: src/muuli_wdr.cpp:2681
 msgid "Filter clients"
 msgstr "Filtruoti klientus"
 
-#: src/muuli_wdr.cpp:2711
+#: src/muuli_wdr.cpp:2683
 msgid "Enable filtering of the client IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "Įjungti klientų IP adresų filtravimą, aprašytą ~/.aMule/ipfilter.dat faile."
 
-#: src/muuli_wdr.cpp:2713
+#: src/muuli_wdr.cpp:2685
 msgid "Filter servers"
 msgstr "Filtruoti serverius"
 
-#: src/muuli_wdr.cpp:2715
+#: src/muuli_wdr.cpp:2687
 msgid "Enable filtering of the server IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "Įjungti serverių IP adresų filtravimą, aprašytą ~/.aMule/ipfilter.dat faile."
 
-#: src/muuli_wdr.cpp:2719
+#: src/muuli_wdr.cpp:2691
 msgid "Reload List"
 msgstr "Atnaujinti sąrašą"
 
-#: src/muuli_wdr.cpp:2720
+#: src/muuli_wdr.cpp:2692
 msgid "Reload the list of IPs to filter from the file ~/.aMule/ipfilter.dat"
 msgstr "Atnaujinti IP adresų sąrašą iš ~/.aMule/ipfilter.dat failo"
 
-#: src/muuli_wdr.cpp:2726
+#: src/muuli_wdr.cpp:2698
 msgid "URL:"
 msgstr "URL:"
 
-#: src/muuli_wdr.cpp:2730 src/muuli_wdr.cpp:2923
+#: src/muuli_wdr.cpp:2702 src/muuli_wdr.cpp:2895
 msgid "Update now"
 msgstr "Atnaujinti dabar"
 
-#: src/muuli_wdr.cpp:2733
+#: src/muuli_wdr.cpp:2705
 msgid "Auto-update ipfilter at startup"
 msgstr "Automatiškai įkelti IP filtrą paleidus programą"
 
-#: src/muuli_wdr.cpp:2737
+#: src/muuli_wdr.cpp:2709
 msgid "Filtering Level:"
 msgstr "Filtravimo lygmuo:"
 
-#: src/muuli_wdr.cpp:2743
+#: src/muuli_wdr.cpp:2715
 msgid "Always filter LAN IPs"
 msgstr "Visuomet filtruoti LAN IP adresus"
 
-#: src/muuli_wdr.cpp:2746
+#: src/muuli_wdr.cpp:2718
 msgid "Paranoid handling of non-matching IPs"
 msgstr "Paranojiškai elgtis su neatitikusiais IP adresais"
 
-#: src/muuli_wdr.cpp:2748
+#: src/muuli_wdr.cpp:2720
 msgid "Rejects a packet when its source IP differs from the IP the client claims (an anti-spoofing check). Disable only if it causes connection problems."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2750
+#: src/muuli_wdr.cpp:2722
 msgid "Use system-wide ipfilter.dat if available"
 msgstr "Jei įjungtas, naudoti ipfilter.dat failą visoje sistemoje"
 
-#: src/muuli_wdr.cpp:2751
+#: src/muuli_wdr.cpp:2723
 #, fuzzy
 msgid "If there's no local ipfilter.dat found, allow usage of a system-wide ipfilter file."
 msgstr "Jei nėra vietinio ipilter.dat failo, naudoti ipfilter.dat visoje sistemoje."
 
-#: src/muuli_wdr.cpp:2768
+#: src/muuli_wdr.cpp:2740
 msgid "Enable Online-Signature"
 msgstr "Įjungti keičiamą parašą"
 
-#: src/muuli_wdr.cpp:2770
+#: src/muuli_wdr.cpp:2742
 msgid "Enables the writing of the OS file, which can be used by external apps to create signatures and the like."
 msgstr "Įjungus šią parinktį bus įrašomas keičiamo parašo failas, kurį galite naudoti kitoje programoje parašų kūrimui ir pan."
 
-#: src/muuli_wdr.cpp:2774
+#: src/muuli_wdr.cpp:2746
 msgid "Update Frequency (Secs):"
 msgstr "Atnaujinimo dažnis (sekundėmis):"
 
-#: src/muuli_wdr.cpp:2777
+#: src/muuli_wdr.cpp:2749
 msgid "Change the frequency (in seconds) of Online Signature updates."
 msgstr "Keičiamo parašo atnaujinimo dažnis sekundėmis."
 
-#: src/muuli_wdr.cpp:2785
+#: src/muuli_wdr.cpp:2757
 msgid "Save online signature file in: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:2791
+#: src/muuli_wdr.cpp:2763
 msgid "Click here to select the directory containing the the Online Signature files."
 msgstr "Nurodykite aplanką, kuriame yra keičiamo parašo failas."
 
-#: src/muuli_wdr.cpp:2824
+#: src/muuli_wdr.cpp:2796
 msgid "Show country flags for clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2825
+#: src/muuli_wdr.cpp:2797
 msgid "Render the country flag column in the transfers, queue and search views. Requires a valid MMDB GeoIP database (see below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2830
+#: src/muuli_wdr.cpp:2802
 #, fuzzy
 msgid "Database"
 msgstr "Siuntimo sparta:"
 
-#: src/muuli_wdr.cpp:2846
+#: src/muuli_wdr.cpp:2818
 #, fuzzy
 msgid "Source:"
 msgstr "Šaltiniai"
 
-#: src/muuli_wdr.cpp:2849
+#: src/muuli_wdr.cpp:2821
 msgid "DB-IP (free, no account)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2850
+#: src/muuli_wdr.cpp:2822
 msgid "MaxMind GeoLite2 (free, account required)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2851
+#: src/muuli_wdr.cpp:2823
 msgid "Custom URL"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2854
+#: src/muuli_wdr.cpp:2826
 msgid "Choose which provider supplies the GeoIP MMDB database. DB-IP is the default - no account required. MaxMind requires a free account + license key. Use Custom URL to point at any other MMDB host (e.g. a local mirror)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2871
+#: src/muuli_wdr.cpp:2843
 msgid ""
 "No configuration required.\n"
 "\n"
@@ -4907,11 +4873,11 @@ msgid ""
 "License: Creative Commons BY 4.0 - https://creativecommons.org/licenses/by/4.0/"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2884
+#: src/muuli_wdr.cpp:2856
 msgid "License key:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2890
+#: src/muuli_wdr.cpp:2862
 msgid ""
 "Sign up for a free MaxMind account, then generate a License Key:\n"
 "https://www.maxmind.com/en/geolite2/signup\n"
@@ -4921,232 +4887,232 @@ msgid ""
 "Requires attribution and account registration; refresh at least every 30 days."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2905
+#: src/muuli_wdr.cpp:2877
 #, fuzzy
 msgid "Download URL:"
 msgstr "Atsiųsta: "
 
-#: src/muuli_wdr.cpp:2911
+#: src/muuli_wdr.cpp:2883
 msgid ""
 "Must point to an .mmdb file or a .gz / .tar.gz containing one.\n"
 "URL may include credentials (https://user:pass@host/...).\n"
 "License and attribution terms are set by the upstream URL - you are responsible."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2924
+#: src/muuli_wdr.cpp:2896
 msgid "Download the GeoIP database from the selected source."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2926
+#: src/muuli_wdr.cpp:2898
 #, fuzzy
 msgid "Auto-update on startup"
 msgstr "Automatiškai įkelti IP filtrą paleidus programą"
 
-#: src/muuli_wdr.cpp:2927
+#: src/muuli_wdr.cpp:2899
 msgid "Re-download the GeoIP database from the selected source every time aMule starts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2950
+#: src/muuli_wdr.cpp:2922
 msgid "Filter incoming messages (except current chat):"
 msgstr "Filtruoti gaunamas žinutes (išskyrus dabartinį pokalbį):"
 
-#: src/muuli_wdr.cpp:2952
+#: src/muuli_wdr.cpp:2924
 msgid "Filter all messages"
 msgstr "Filtruoti visas žinutes"
 
-#: src/muuli_wdr.cpp:2954
+#: src/muuli_wdr.cpp:2926
 msgid "Filter messages from people not on your friend list"
 msgstr "Filtruoti žinutes nuo naudotojų, nesančių draugų sąraše"
 
-#: src/muuli_wdr.cpp:2956
+#: src/muuli_wdr.cpp:2928
 msgid "Filter messages from unknown clients"
 msgstr "Filtruoti žinutes nuo nežinomų klientų"
 
-#: src/muuli_wdr.cpp:2958
+#: src/muuli_wdr.cpp:2930
 msgid "Filter messages containing (use ',' as separator):"
 msgstr "Filtruoti žinutes turinčias tekstą („,“ naudokite kaip skirtuką):"
 
-#: src/muuli_wdr.cpp:2961 src/muuli_wdr.cpp:2972
+#: src/muuli_wdr.cpp:2933 src/muuli_wdr.cpp:2944
 msgid "add here the words amule should filter and block messages including it"
 msgstr "Įrašykite žodžius, kurių aMule ieškos žinutės tekste ir filtruos žinutę"
 
-#: src/muuli_wdr.cpp:2963
+#: src/muuli_wdr.cpp:2935
 msgid "Show received messages in the log"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2966
+#: src/muuli_wdr.cpp:2938
 msgid "Comments"
 msgstr "Komentarai"
 
-#: src/muuli_wdr.cpp:2969
+#: src/muuli_wdr.cpp:2941
 msgid "Filter comments containing (use ',' as separator):"
 msgstr "Filtruoti komentarus, turinčius (atskirkite kableliu):"
 
-#: src/muuli_wdr.cpp:2994
+#: src/muuli_wdr.cpp:2966
 msgid "Enable Proxy"
 msgstr "Įjungti atstovaujančius serverius"
 
-#: src/muuli_wdr.cpp:2995
+#: src/muuli_wdr.cpp:2967
 msgid "Enable/disable proxy support"
 msgstr "Įjungti ar išjungti atstovaujančius serverius"
 
-#: src/muuli_wdr.cpp:2998
+#: src/muuli_wdr.cpp:2970
 msgid "Proxy type:"
 msgstr "Serverio tipas:"
 
-#: src/muuli_wdr.cpp:3009
+#: src/muuli_wdr.cpp:2981
 msgid "Proxy host:"
 msgstr "Serverio mazgas:"
 
-#: src/muuli_wdr.cpp:3012
+#: src/muuli_wdr.cpp:2984
 msgid "The proxy host name"
 msgstr "Atstovaujančio serverio mazgo pavadinimas"
 
-#: src/muuli_wdr.cpp:3014
+#: src/muuli_wdr.cpp:2986
 msgid "Proxy port:"
 msgstr "Serverio prievadas:"
 
-#: src/muuli_wdr.cpp:3017
+#: src/muuli_wdr.cpp:2989
 msgid "The proxy port"
 msgstr "Atstovaujančio serverio prievadas"
 
-#: src/muuli_wdr.cpp:3019
+#: src/muuli_wdr.cpp:2991
 msgid "Enable authentication"
 msgstr "Įjungti autentifikavimą"
 
-#: src/muuli_wdr.cpp:3020
+#: src/muuli_wdr.cpp:2992
 msgid "Enable/disable username/password authentication"
 msgstr "Įjungti ar išjungti naudotojo vardo ir slaptažodžio autentifikavimą"
 
-#: src/muuli_wdr.cpp:3023
+#: src/muuli_wdr.cpp:2995
 msgid "Username: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:3026
+#: src/muuli_wdr.cpp:2998
 msgid "The username to use to connect to the proxy"
 msgstr "Naudotojo vardas prisijungimui prie atstovaujančio serverio"
 
-#: src/muuli_wdr.cpp:3028
+#: src/muuli_wdr.cpp:3000
 msgid "Password:"
 msgstr "Slaptažodis:"
 
-#: src/muuli_wdr.cpp:3031
+#: src/muuli_wdr.cpp:3003
 msgid "The password to use to connect to the proxy"
 msgstr "Slaptažodis prisijungimui prie atstovaujančio serverio"
 
-#: src/muuli_wdr.cpp:3050
+#: src/muuli_wdr.cpp:3022
 msgid "Connect to:"
 msgstr "Prijungti prie:"
 
-#: src/muuli_wdr.cpp:3059
+#: src/muuli_wdr.cpp:3031
 msgid "Login to remote amule"
 msgstr "Prisijungti prie nutolusios aMule"
 
-#: src/muuli_wdr.cpp:3064
+#: src/muuli_wdr.cpp:3036
 msgid "User name"
 msgstr "Naudotojo vardas"
 
-#: src/muuli_wdr.cpp:3075
+#: src/muuli_wdr.cpp:3047
 msgid "Remember those settings"
 msgstr "Įsiminti parinktis"
 
-#: src/muuli_wdr.cpp:3078
+#: src/muuli_wdr.cpp:3050
 #, fuzzy
 msgid "Force ZLIB compression"
 msgstr "Naudoti gzip pakavimą"
 
-#: src/muuli_wdr.cpp:3102
+#: src/muuli_wdr.cpp:3074
 msgid "Enable Verbose Debug-Logging."
 msgstr "Įjungti išsamų klaidų taisymo žurnalą."
 
-#: src/muuli_wdr.cpp:3104
+#: src/muuli_wdr.cpp:3076
 #, fuzzy
 msgid "Only to Logfile"
 msgstr "&Atverti failą"
 
-#: src/muuli_wdr.cpp:3106
+#: src/muuli_wdr.cpp:3078
 msgid "Message Categories:"
 msgstr "Žinučių kategorijos:"
 
-#: src/muuli_wdr.cpp:3130 src/PartFileConvertDlg.cpp:160
+#: src/muuli_wdr.cpp:3102 src/PartFileConvertDlg.cpp:160
 msgid "Waiting..."
 msgstr "Laukiama..."
 
-#: src/muuli_wdr.cpp:3150
+#: src/muuli_wdr.cpp:3122
 msgid "Add imports"
 msgstr "Įdėti failus"
 
-#: src/muuli_wdr.cpp:3153
+#: src/muuli_wdr.cpp:3125
 msgid "Retry selected"
 msgstr "Pažymėtas bandyti iš naujo"
 
-#: src/muuli_wdr.cpp:3155
+#: src/muuli_wdr.cpp:3127
 msgid "Remove selected"
 msgstr "Pašalinti pažymėtas"
 
-#: src/muuli_wdr.cpp:3218
+#: src/muuli_wdr.cpp:3190
 msgid "Event Types"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3237
+#: src/muuli_wdr.cpp:3209
 msgid "Statistics and queued clients for selected file(s) : Session / All time"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3261
+#: src/muuli_wdr.cpp:3233
 #, fuzzy
 msgid "Active Uploads"
 msgstr "Aktyvūs išsiuntimai:"
 
-#: src/muuli_wdr.cpp:3275
+#: src/muuli_wdr.cpp:3247
 msgid "Percent of total files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3327
+#: src/muuli_wdr.cpp:3299
 #, fuzzy
 msgid "Show Clients for"
 msgstr "Rodyti klientus"
 
-#: src/muuli_wdr.cpp:3329
+#: src/muuli_wdr.cpp:3301
 #, fuzzy
 msgid "All files"
 msgstr "Slėpti dalinamus failus"
 
-#: src/muuli_wdr.cpp:3332
+#: src/muuli_wdr.cpp:3304
 #, fuzzy
 msgid "Selected files"
 msgstr "Parinkite filtrą"
 
-#: src/muuli_wdr.cpp:3335
+#: src/muuli_wdr.cpp:3307
 #, fuzzy
 msgid "Active uploads only"
 msgstr "Aktyvūs išsiuntimai"
 
-#: src/muuli_wdr.cpp:3342
+#: src/muuli_wdr.cpp:3314
 #, fuzzy
 msgid "Reload:"
 msgstr "Atnaujinti sąrašą"
 
-#: src/muuli_wdr.cpp:3346
+#: src/muuli_wdr.cpp:3318
 msgid "Reload your shared files"
 msgstr "Atnaujinti dalinamų failų sąrašą"
 
-#: src/muuli_wdr.cpp:3409
+#: src/muuli_wdr.cpp:3381
 msgid "Send"
 msgstr "Siųsti"
 
-#: src/muuli_wdr.cpp:3410
+#: src/muuli_wdr.cpp:3382
 msgid "Sends the specified message."
 msgstr "Išsiųsti įrašytą žinutę."
 
-#: src/muuli_wdr.cpp:3414
+#: src/muuli_wdr.cpp:3386
 msgid "Close this chat-session."
 msgstr "Baigti pokalbį ir užverti pokalbio kortelę."
 
-#: src/muuli_wdr.cpp:3437
+#: src/muuli_wdr.cpp:3409
 msgid "Connect to any server and/or Kad"
 msgstr "Prisijungti prie bet kurio serverio ir/ar Kademlia tinklo"
 
-#: src/muuli_wdr.cpp:3443 src/SharedFilesCtrl.cpp:142 src/Statistics.cpp:941
+#: src/muuli_wdr.cpp:3415 src/SharedFilesCtrl.cpp:142 src/Statistics.cpp:941
 msgid "Shared Files"
 msgstr "Dalinami failai"
 
@@ -5511,268 +5477,268 @@ msgstr "Atsiųsta"
 msgid "ERROR: Failed to open partfile '%s'"
 msgstr "KLAIDA: nepavyko atverti dalių failo „%s“"
 
-#: src/Preferences.cpp:701
+#: src/Preferences.cpp:673
 msgid "System default"
 msgstr "Numatyta"
 
-#: src/Preferences.cpp:702
+#: src/Preferences.cpp:674
 msgid "Albanian"
 msgstr "Albanų"
 
-#: src/Preferences.cpp:703
+#: src/Preferences.cpp:675
 msgid "Arabic"
 msgstr "Arabų"
 
-#: src/Preferences.cpp:704
+#: src/Preferences.cpp:676
 #, fuzzy
 msgid "Asturian"
 msgstr "Estų"
 
-#: src/Preferences.cpp:705
+#: src/Preferences.cpp:677
 msgid "Basque"
 msgstr "Baskų"
 
-#: src/Preferences.cpp:706
+#: src/Preferences.cpp:678
 msgid "Bulgarian"
 msgstr "Bulgarų"
 
-#: src/Preferences.cpp:707
+#: src/Preferences.cpp:679
 msgid "Catalan"
 msgstr "Katalonų"
 
-#: src/Preferences.cpp:708
+#: src/Preferences.cpp:680
 msgid "Chinese (Simplified)"
 msgstr "Kinų (supaprastinta)"
 
-#: src/Preferences.cpp:709
+#: src/Preferences.cpp:681
 msgid "Chinese (Traditional)"
 msgstr "Kinų (tradicinė)"
 
-#: src/Preferences.cpp:710
+#: src/Preferences.cpp:682
 msgid "Croatian"
 msgstr "Kroatų"
 
-#: src/Preferences.cpp:711
+#: src/Preferences.cpp:683
 msgid "Czech"
 msgstr "Čekų"
 
-#: src/Preferences.cpp:712
+#: src/Preferences.cpp:684
 msgid "Danish"
 msgstr "Danų"
 
-#: src/Preferences.cpp:713
+#: src/Preferences.cpp:685
 msgid "Dutch"
 msgstr "Olandų"
 
-#: src/Preferences.cpp:714
+#: src/Preferences.cpp:686
 msgid "English (U.K.)"
 msgstr "Anglų (DB)"
 
-#: src/Preferences.cpp:715
+#: src/Preferences.cpp:687
 #, fuzzy
 msgid "English (U.S.)"
 msgstr "Anglų (DB)"
 
-#: src/Preferences.cpp:716
+#: src/Preferences.cpp:688
 msgid "Estonian"
 msgstr "Estų"
 
-#: src/Preferences.cpp:717
+#: src/Preferences.cpp:689
 msgid "Finnish"
 msgstr "Suomių"
 
-#: src/Preferences.cpp:718
+#: src/Preferences.cpp:690
 msgid "French"
 msgstr "Prancūzų"
 
-#: src/Preferences.cpp:719
+#: src/Preferences.cpp:691
 msgid "Galician"
 msgstr "Galisijos"
 
-#: src/Preferences.cpp:720
+#: src/Preferences.cpp:692
 msgid "German"
 msgstr "Vokiečių"
 
-#: src/Preferences.cpp:721
+#: src/Preferences.cpp:693
 msgid "Greek"
 msgstr "Graikų"
 
-#: src/Preferences.cpp:722
+#: src/Preferences.cpp:694
 msgid "Hebrew"
 msgstr "Žydų"
 
-#: src/Preferences.cpp:723
+#: src/Preferences.cpp:695
 msgid "Hungarian"
 msgstr "Vengrų"
 
-#: src/Preferences.cpp:724
+#: src/Preferences.cpp:696
 msgid "Italian"
 msgstr "Italų"
 
-#: src/Preferences.cpp:725
+#: src/Preferences.cpp:697
 msgid "Japanese"
 msgstr "Japonų"
 
-#: src/Preferences.cpp:726
+#: src/Preferences.cpp:698
 msgid "Korean"
 msgstr "Korėjiečių"
 
-#: src/Preferences.cpp:727
+#: src/Preferences.cpp:699
 msgid "Latvian"
 msgstr ""
 
-#: src/Preferences.cpp:728
+#: src/Preferences.cpp:700
 msgid "Lithuanian"
 msgstr "Lietuvių"
 
-#: src/Preferences.cpp:729
+#: src/Preferences.cpp:701
 msgid "Norwegian (Nynorsk)"
 msgstr "Norvegų (naujoji norvegų)"
 
-#: src/Preferences.cpp:730
+#: src/Preferences.cpp:702
 msgid "Polish"
 msgstr "Lenkų"
 
-#: src/Preferences.cpp:731
+#: src/Preferences.cpp:703
 msgid "Portuguese"
 msgstr "Portugalų"
 
-#: src/Preferences.cpp:732
+#: src/Preferences.cpp:704
 msgid "Portuguese (Brazilian)"
 msgstr "Portugalų (Brazilijos)"
 
-#: src/Preferences.cpp:733
+#: src/Preferences.cpp:705
 #, fuzzy
 msgid "Romanian"
 msgstr "Albanų"
 
-#: src/Preferences.cpp:734
+#: src/Preferences.cpp:706
 msgid "Russian"
 msgstr "Rusų"
 
-#: src/Preferences.cpp:735
+#: src/Preferences.cpp:707
 msgid "Slovenian"
 msgstr "Slovėnų"
 
-#: src/Preferences.cpp:736
+#: src/Preferences.cpp:708
 msgid "Spanish"
 msgstr "Ispanų"
 
-#: src/Preferences.cpp:737
+#: src/Preferences.cpp:709
 msgid "Swedish"
 msgstr "Švedų"
 
-#: src/Preferences.cpp:738
+#: src/Preferences.cpp:710
 msgid "Turkish"
 msgstr "Turkų"
 
-#: src/Preferences.cpp:739
+#: src/Preferences.cpp:711
 msgid "Ukrainian"
 msgstr ""
 
-#: src/Preferences.cpp:842
+#: src/Preferences.cpp:814
 #, fuzzy
 msgid "Change Language"
 msgstr "Kalba"
 
-#: src/Preferences.cpp:906
+#: src/Preferences.cpp:878
 msgid "There are no translations installed for aMule"
 msgstr ""
 
-#: src/Preferences.cpp:907
+#: src/Preferences.cpp:879
 #, fuzzy
 msgid "No languages available"
 msgstr "Nėra"
 
-#: src/Preferences.cpp:1038
+#: src/Preferences.cpp:1010
 msgid "no options available"
 msgstr ""
 
-#: src/Preferences.cpp:2226
+#: src/Preferences.cpp:2179
 msgid "Invalid category found, skipping"
 msgstr ""
 
-#: src/Preferences.cpp:2395
+#: src/Preferences.cpp:2348
 msgid "TCP port can't be higher than 65532 due to server UDP socket being TCP+3"
 msgstr "TCP prievadas negali būti didesnis nei 65532, nes serverio UDP prievadas yra TCP+3"
 
-#: src/Preferences.cpp:2396
+#: src/Preferences.cpp:2349
 #, c-format
 msgid "Default port will be used (%d)"
 msgstr "Bus naudojamas numatytas prievadas (%d)"
 
-#: src/PrefsUnifiedDlg.cpp:300 src/Statistics.cpp:866
+#: src/PrefsUnifiedDlg.cpp:298 src/Statistics.cpp:866
 msgid "Connection"
 msgstr "Kanalas"
 
-#: src/PrefsUnifiedDlg.cpp:301 src/SearchListCtrl.cpp:117
+#: src/PrefsUnifiedDlg.cpp:299 src/SearchListCtrl.cpp:117
 msgid "Directories"
 msgstr "Aplankai"
 
-#: src/PrefsUnifiedDlg.cpp:302 src/Statistics.cpp:917
+#: src/PrefsUnifiedDlg.cpp:300 src/Statistics.cpp:917
 msgid "Servers"
 msgstr "Serveriai"
 
-#: src/PrefsUnifiedDlg.cpp:303 src/ServerListCtrl.cpp:96
+#: src/PrefsUnifiedDlg.cpp:301 src/ServerListCtrl.cpp:96
 msgid "Files"
 msgstr "Failai"
 
-#: src/PrefsUnifiedDlg.cpp:304
+#: src/PrefsUnifiedDlg.cpp:302
 msgid "Security"
 msgstr "Saugumas"
 
-#: src/PrefsUnifiedDlg.cpp:305
+#: src/PrefsUnifiedDlg.cpp:303
 msgid "Interface"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:312
+#: src/PrefsUnifiedDlg.cpp:310
 msgid "IP2Country"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:315
+#: src/PrefsUnifiedDlg.cpp:313
 msgid "Proxy"
 msgstr "Atstovaujantis serveris"
 
-#: src/PrefsUnifiedDlg.cpp:316
+#: src/PrefsUnifiedDlg.cpp:314
 msgid "Filters"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:317
+#: src/PrefsUnifiedDlg.cpp:315
 msgid "Remote Controls"
 msgstr "Nutolęs valdymas"
 
-#: src/PrefsUnifiedDlg.cpp:318
+#: src/PrefsUnifiedDlg.cpp:316
 msgid "Online Signature"
 msgstr "Keičiamas parašas"
 
-#: src/PrefsUnifiedDlg.cpp:319
+#: src/PrefsUnifiedDlg.cpp:317
 msgid "Advanced"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:320
+#: src/PrefsUnifiedDlg.cpp:318
 msgid "Events"
 msgstr "Įvykiai"
 
-#: src/PrefsUnifiedDlg.cpp:323
+#: src/PrefsUnifiedDlg.cpp:321
 msgid "Debugging"
 msgstr "Taisymas"
 
-#: src/PrefsUnifiedDlg.cpp:453
+#: src/PrefsUnifiedDlg.cpp:451
 msgid ""
 "The following variables will be substituted:\n"
 "    %PARTFILE - full path to the file\n"
 "    %PARTNAME - file name only"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:474
+#: src/PrefsUnifiedDlg.cpp:472
 msgid "Tray icon support requires libayatana-appindicator3 at compile time."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:490
+#: src/PrefsUnifiedDlg.cpp:488
 msgid "Not available on Wayland: the protocol does not report when a window is minimized, so this option cannot intercept the system minimize button. Workaround: launch aMule with `GDK_BACKEND=x11` to use XWayland instead."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:536
+#: src/PrefsUnifiedDlg.cpp:534
 msgid ""
 "Do not change these setting unless you know\n"
 "what you are doing, otherwise you can easily\n"
@@ -5787,35 +5753,26 @@ msgstr ""
 "\n"
 "aMule puikiai veikia nieko nepakeitus šiame lange."
 
-#: src/PrefsUnifiedDlg.cpp:647
+#: src/PrefsUnifiedDlg.cpp:645
 #, c-format
 msgid "Failed to connect Cfg to widget with the ID %d and key %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:695
+#: src/PrefsUnifiedDlg.cpp:693
 #, c-format
 msgid "Failed to transfer data from Cfg to Widget with the ID %d and key %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:801
+#: src/PrefsUnifiedDlg.cpp:799
 msgid "The type of proxy you are connecting to"
 msgstr "Atstovaujančio serverio, prie kurio jungsitės, tipas"
 
-#: src/PrefsUnifiedDlg.cpp:1020
+#: src/PrefsUnifiedDlg.cpp:1003
 #, c-format
 msgid "Failed to transfer data from Widget to Cfg with the ID %d and key %s"
 msgstr ""
 
 #: src/PrefsUnifiedDlg.cpp:1103
-#, fuzzy
-msgid "No password set."
-msgstr "Tikrinamas slaptažodis\n"
-
-#: src/PrefsUnifiedDlg.cpp:1132
-msgid "Guest access needs a password. Type one in the guest password field, or untick Enable guest access."
-msgstr ""
-
-#: src/PrefsUnifiedDlg.cpp:1144
 msgid ""
 "aMule must be restarted to enable these changes:\n"
 "\n"
@@ -5823,51 +5780,51 @@ msgstr ""
 "Kad įsigaliotų šie pakeitimai, aMule reikia paleisti iš naujo:\n"
 "\n"
 
-#: src/PrefsUnifiedDlg.cpp:1151
+#: src/PrefsUnifiedDlg.cpp:1110
 msgid "- TCP port changed.\n"
 msgstr "– pakeistas TCP prievadas.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1156
+#: src/PrefsUnifiedDlg.cpp:1115
 msgid "- UDP port changed.\n"
 msgstr "– pakeistas UDP prievadas.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1161
+#: src/PrefsUnifiedDlg.cpp:1120
 #, fuzzy
 msgid "- Network interface binding changed.\n"
 msgstr "Išorinis ryšys nutrauktas."
 
-#: src/PrefsUnifiedDlg.cpp:1166
+#: src/PrefsUnifiedDlg.cpp:1125
 #, fuzzy
 msgid "- External connect port changed.\n"
 msgstr "Išorinis ryšys nutrauktas."
 
-#: src/PrefsUnifiedDlg.cpp:1170
+#: src/PrefsUnifiedDlg.cpp:1129
 #, fuzzy
 msgid "- External connect acceptance changed.\n"
 msgstr "Naujas išorinis ryšys priimtas"
 
-#: src/PrefsUnifiedDlg.cpp:1174
+#: src/PrefsUnifiedDlg.cpp:1133
 #, fuzzy
 msgid "- External connect interface changed.\n"
 msgstr "Išorinis ryšys nutrauktas."
 
-#: src/PrefsUnifiedDlg.cpp:1178
+#: src/PrefsUnifiedDlg.cpp:1137
 #, fuzzy
 msgid "- Protocol obfuscation support changed.\n"
 msgstr "Protokolo slėpimas"
 
-#: src/PrefsUnifiedDlg.cpp:1193
+#: src/PrefsUnifiedDlg.cpp:1151
 #, fuzzy
 msgid "- amuleapi settings changed.\n"
 msgstr "– kalba pakeista.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1202
+#: src/PrefsUnifiedDlg.cpp:1160
 msgid ""
 "Your Auto-update server list is empty.\n"
 "'Auto-update server list at startup' will be disabled."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1213
+#: src/PrefsUnifiedDlg.cpp:1171
 msgid ""
 "You have enabled external connections but have not specified a password.\n"
 "External connections cannot be enabled unless a valid password is specified."
@@ -5875,34 +5832,29 @@ msgstr ""
 "Įjungėte išorinius ryšius, bet parinktyse nenurodėte slaptažodžio.\n"
 "Kol nenurodysite slaptažodžio, išoriniai ryšiai nebus įjungti."
 
-#: src/PrefsUnifiedDlg.cpp:1246
-#, c-format
-msgid "The amuleapi password could not be saved: %s"
-msgstr ""
-
-#: src/PrefsUnifiedDlg.cpp:1276
+#: src/PrefsUnifiedDlg.cpp:1202
 msgid "- Language changed.\n"
 msgstr "– kalba pakeista.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1281
+#: src/PrefsUnifiedDlg.cpp:1207
 msgid "- Temp folder changed.\n"
 msgstr "– laikinų failų aplankas pakeistas.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1286
+#: src/PrefsUnifiedDlg.cpp:1212
 #, fuzzy
 msgid "- ED2K network enabled.\n"
 msgstr "Visi tinklai išjungti."
 
-#: src/PrefsUnifiedDlg.cpp:1319
+#: src/PrefsUnifiedDlg.cpp:1245
 msgid "The shared-file exclusion pattern is not a valid regular expression. The filter has been left disabled."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1321 src/PrefsUnifiedDlg.cpp:1921
+#: src/PrefsUnifiedDlg.cpp:1247 src/PrefsUnifiedDlg.cpp:1841
 #, fuzzy
 msgid "Invalid regular expression"
 msgstr "Neteisinga protokolo versija."
 
-#: src/PrefsUnifiedDlg.cpp:1398
+#: src/PrefsUnifiedDlg.cpp:1324
 msgid ""
 "Both eD2k and Kad network are disabled.\n"
 "You won't be able to connect until you enable at least one of them."
@@ -5910,7 +5862,7 @@ msgstr ""
 "Tiek eD2k, tiek Kademlia tinklai yra išjungti.\n"
 "Norėdami prisijungti įjunkite bent vieną iš šių tinklų."
 
-#: src/PrefsUnifiedDlg.cpp:1403
+#: src/PrefsUnifiedDlg.cpp:1329
 msgid ""
 "Kad will not start if your UDP port is disabled.\n"
 "Enable UDP port or disable Kad."
@@ -5918,7 +5870,7 @@ msgstr ""
 "Nepavyks prisijungti prie Kademlia tinklo, nes išjungtas UDP prievadas.\n"
 "Arba įjunkite UDP prievadą, arba išjunkite Kademlia tinklą."
 
-#: src/PrefsUnifiedDlg.cpp:1459
+#: src/PrefsUnifiedDlg.cpp:1385
 msgid ""
 "\n"
 "You MUST restart aMule now.\n"
@@ -5928,69 +5880,69 @@ msgstr ""
 "Būtina paleisti aMule iš naujo.\n"
 "Jei dabar pat neperleisite aMule, nesiskųskite jei kas nors bus ne taip.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1524
+#: src/PrefsUnifiedDlg.cpp:1450
 msgid "Could not register aMule for autostart at login. The autostart store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1526
+#: src/PrefsUnifiedDlg.cpp:1452
 msgid "Could not remove the autostart-at-login entry."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1527
+#: src/PrefsUnifiedDlg.cpp:1453
 #, fuzzy
 msgid "Autostart"
 msgstr "Automatinis atnaujinimas paleistas"
 
-#: src/PrefsUnifiedDlg.cpp:1542
+#: src/PrefsUnifiedDlg.cpp:1468
 msgid "Register file type"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1542
+#: src/PrefsUnifiedDlg.cpp:1468
 msgid "Register URL handler"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1550
+#: src/PrefsUnifiedDlg.cpp:1476
 #, c-format
 msgid "aMule only handles eD2k-compatible magnets. If you replace the current magnet handler (%s), BitTorrent magnet links will stop working - aMule cannot download BitTorrent content. Continue?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1555
+#: src/PrefsUnifiedDlg.cpp:1481
 #, c-format
 msgid "Another application currently opens .emulecollection files (%s). Replace it with aMule?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1560
+#: src/PrefsUnifiedDlg.cpp:1486
 #, c-format
 msgid "Another application is currently the default handler for these links (%s). Replace it with aMule?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1585
+#: src/PrefsUnifiedDlg.cpp:1511
 msgid "Could not register aMule for .emulecollection files. The registration store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1587
+#: src/PrefsUnifiedDlg.cpp:1513
 #, fuzzy
 msgid "Could not remove the file type registration."
 msgstr "Failas %s jau yra atsiunčiamų failų sąraše"
 
-#: src/PrefsUnifiedDlg.cpp:1589
+#: src/PrefsUnifiedDlg.cpp:1515
 msgid "Could not register aMule as the URL handler. The registration store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1591
+#: src/PrefsUnifiedDlg.cpp:1517
 msgid "Could not remove the URL handler registration."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1661 src/PrefsUnifiedDlg.cpp:1688
+#: src/PrefsUnifiedDlg.cpp:1587 src/PrefsUnifiedDlg.cpp:1614
 #, fuzzy
 msgid "The web server and aMule API require external connections to be enabled."
 msgstr "Naujas išorinis ryšys priimtas"
 
-#: src/PrefsUnifiedDlg.cpp:1671
+#: src/PrefsUnifiedDlg.cpp:1597
 msgid "The aMule web server is deprecated. Consider running the aMule API instead."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1735
+#: src/PrefsUnifiedDlg.cpp:1655
 msgid ""
 "Your Auto-update servers list is in blank.\n"
 "Please fill in at least one URL to point to a valid server.met file.\n"
@@ -6000,24 +5952,24 @@ msgstr ""
 "Įrašykite bent vieną server.met failo URL.\n"
 "Norėdami įrašyti URL, paspauskite mygtuką „Sąrašas“."
 
-#: src/PrefsUnifiedDlg.cpp:1876
+#: src/PrefsUnifiedDlg.cpp:1796
 msgid "Temporary files"
 msgstr "Laikini failai"
 
-#: src/PrefsUnifiedDlg.cpp:1881
+#: src/PrefsUnifiedDlg.cpp:1801
 msgid "Incoming files"
 msgstr "Atsiųsti failai"
 
-#: src/PrefsUnifiedDlg.cpp:1886
+#: src/PrefsUnifiedDlg.cpp:1806
 msgid "Online Signatures"
 msgstr "Keičiami parašai"
 
-#: src/PrefsUnifiedDlg.cpp:1899
+#: src/PrefsUnifiedDlg.cpp:1819
 #, c-format
 msgid "Choose a folder for %s"
 msgstr "Parinkite aplanką %s"
 
-#: src/PrefsUnifiedDlg.cpp:1923
+#: src/PrefsUnifiedDlg.cpp:1843
 #, fuzzy, c-format
 msgid "Would exclude %u of %u shared file"
 msgid_plural "Would exclude %u of %u shared files"
@@ -6025,42 +5977,42 @@ msgstr[0] "Aptiktas %i dalinamas failas"
 msgstr[1] "Aptikti %i dalinami failai"
 msgstr[2] "Aptikta %i dalinamų failų"
 
-#: src/PrefsUnifiedDlg.cpp:1940
+#: src/PrefsUnifiedDlg.cpp:1860
 msgid "Browse for videoplayer"
 msgstr "Parinkite video grotuvą"
 
-#: src/PrefsUnifiedDlg.cpp:1944
+#: src/PrefsUnifiedDlg.cpp:1864
 msgid "Select browser"
 msgstr "Parinkite naršyklę"
 
-#: src/PrefsUnifiedDlg.cpp:1948
+#: src/PrefsUnifiedDlg.cpp:1868
 #, fuzzy
 msgid "Select ffprobe binary"
 msgstr "Parinkite naršyklę"
 
-#: src/PrefsUnifiedDlg.cpp:1954
+#: src/PrefsUnifiedDlg.cpp:1874
 #, c-format
 msgid "Executable%s"
 msgstr "Vykdomas failas %s"
 
-#: src/PrefsUnifiedDlg.cpp:1988
+#: src/PrefsUnifiedDlg.cpp:1908
 msgid "ffprobe not found on PATH or in the standard install locations. Install ffmpeg (which ships ffprobe) or use Browse to pick a binary manually."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2000
+#: src/PrefsUnifiedDlg.cpp:1920
 msgid "Reset the settings on this page to their default values?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2001
+#: src/PrefsUnifiedDlg.cpp:1921
 #, fuzzy
 msgid "Reset to defaults"
 msgstr "Numatyta"
 
-#: src/PrefsUnifiedDlg.cpp:2028
+#: src/PrefsUnifiedDlg.cpp:1948
 msgid "Edit server list"
 msgstr "Keisti serverių sąrašą"
 
-#: src/PrefsUnifiedDlg.cpp:2029
+#: src/PrefsUnifiedDlg.cpp:1949
 msgid ""
 "Add here URL's to download server.met files.\n"
 "Only one url on each line."
@@ -6068,42 +6020,42 @@ msgstr ""
 "Įrašykite server.met failų URL.\n"
 "Vieną URL vienoje eilutėje."
 
-#: src/PrefsUnifiedDlg.cpp:2084
+#: src/PrefsUnifiedDlg.cpp:2004
 msgid "IP2Country update failed"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2229 src/PrefsUnifiedDlg.cpp:2260
+#: src/PrefsUnifiedDlg.cpp:2149 src/PrefsUnifiedDlg.cpp:2180
 msgid "Data by MaxMind GeoLite2"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2231 src/PrefsUnifiedDlg.cpp:2262
+#: src/PrefsUnifiedDlg.cpp:2151 src/PrefsUnifiedDlg.cpp:2182
 #, fuzzy
 msgid "Custom source"
 msgstr "Pilni šaltiniai"
 
-#: src/PrefsUnifiedDlg.cpp:2233 src/PrefsUnifiedDlg.cpp:2264
+#: src/PrefsUnifiedDlg.cpp:2153 src/PrefsUnifiedDlg.cpp:2184
 msgid "Data by DB-IP.com"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2284
+#: src/PrefsUnifiedDlg.cpp:2204
 #, fuzzy, c-format
 msgid "Status: Loaded%s"
 msgstr "Būsena:"
 
-#: src/PrefsUnifiedDlg.cpp:2286
+#: src/PrefsUnifiedDlg.cpp:2206
 #, fuzzy, c-format
 msgid "Status: Loaded%s - %s"
 msgstr "Būsena:"
 
-#: src/PrefsUnifiedDlg.cpp:2290
+#: src/PrefsUnifiedDlg.cpp:2210
 msgid "Status: Failed to load - click 'Update now' to refresh."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2292
+#: src/PrefsUnifiedDlg.cpp:2212
 msgid "Status: Not found - click 'Update now' to download."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2350 src/PrefsUnifiedDlg.cpp:2374
+#: src/PrefsUnifiedDlg.cpp:2270 src/PrefsUnifiedDlg.cpp:2294
 #, c-format
 msgid "Update delay: %d second"
 msgid_plural "Update delay: %d seconds"
@@ -6111,7 +6063,7 @@ msgstr[0] "Atnaujinimo intervalas: %d s"
 msgstr[1] "Atnaujinimo intervalas: %d s"
 msgstr[2] "Atnaujinimo intervalas: %d s"
 
-#: src/PrefsUnifiedDlg.cpp:2358
+#: src/PrefsUnifiedDlg.cpp:2278
 #, c-format
 msgid "Time for average graph: %d minute"
 msgid_plural "Time for average graph: %d minutes"
@@ -6119,12 +6071,12 @@ msgstr[0] "Vidurkių grafiko trukmė: %d min."
 msgstr[1] "Vidurkių grafiko trukmė: %d min."
 msgstr[2] "Vidurkių grafiko trukmė: %d min."
 
-#: src/PrefsUnifiedDlg.cpp:2367
+#: src/PrefsUnifiedDlg.cpp:2287
 #, c-format
 msgid "Connections Graph Scale: %d"
 msgstr "Ryšių grafiko mastelis: %d"
 
-#: src/PrefsUnifiedDlg.cpp:2382
+#: src/PrefsUnifiedDlg.cpp:2302
 #, c-format
 msgid "File Buffer Size: %d byte"
 msgid_plural "File Buffer Size: %d bytes"
@@ -6132,7 +6084,7 @@ msgstr[0] "Failų buferio dydis: %d baitas"
 msgstr[1] "Failų buferio dydis: %d baitai"
 msgstr[2] "Failų buferio dydis: %d baitų"
 
-#: src/PrefsUnifiedDlg.cpp:2392
+#: src/PrefsUnifiedDlg.cpp:2312
 #, c-format
 msgid "Upload Queue Size: %d client"
 msgid_plural "Upload Queue Size: %d clients"
@@ -6140,7 +6092,7 @@ msgstr[0] "Išsiuntimo eilės dydis: %d klientas"
 msgstr[1] "Išsiuntimo eilės dydis: %d klientai"
 msgstr[2] "Išsiuntimo eilės dydis: %d klientų"
 
-#: src/PrefsUnifiedDlg.cpp:2402
+#: src/PrefsUnifiedDlg.cpp:2322
 #, c-format
 msgid "Server connection refresh interval: %d minute"
 msgid_plural "Server connection refresh interval: %d minutes"
@@ -6148,106 +6100,102 @@ msgstr[0] "Serverio ryšio atnaujinimo intervalas: %d min."
 msgstr[1] "Serverio ryšio atnaujinimo intervalas: %d min."
 msgstr[2] "Serverio ryšio atnaujinimo intervalas: %d min."
 
-#: src/PrefsUnifiedDlg.cpp:2407
+#: src/PrefsUnifiedDlg.cpp:2327
 msgid "Server connection refresh interval: Disabled"
 msgstr "Serverio ryšio atnaujinimo intervalas: išjungta"
 
-#: src/PrefsUnifiedDlg.cpp:2451
+#: src/PrefsUnifiedDlg.cpp:2371
 #, fuzzy
 msgid "disabled"
 msgstr "Išjungti"
 
-#: src/PrefsUnifiedDlg.cpp:2477
+#: src/PrefsUnifiedDlg.cpp:2397
 #, fuzzy, c-format
 msgid "Execute command on '%s' event"
 msgstr "Įvykus „%s“ įvykiui įvykdyti komandą"
 
-#: src/PrefsUnifiedDlg.cpp:2484
+#: src/PrefsUnifiedDlg.cpp:2404
 msgid "Enable command execution on core"
 msgstr "Įjungti komandos vykdymą branduolyje"
 
-#: src/PrefsUnifiedDlg.cpp:2496
+#: src/PrefsUnifiedDlg.cpp:2416
 msgid "Core command:"
 msgstr "Branduolio komanda:"
 
-#: src/PrefsUnifiedDlg.cpp:2512
+#: src/PrefsUnifiedDlg.cpp:2432
 msgid "Enable command execution on GUI"
 msgstr "Įjungti komandos vykdymą grafinėje aplinkoje"
 
-#: src/PrefsUnifiedDlg.cpp:2524
+#: src/PrefsUnifiedDlg.cpp:2444
 msgid "GUI command:"
 msgstr "Grafinės aplinkos komanda:"
 
-#: src/PrefsUnifiedDlg.cpp:2540
+#: src/PrefsUnifiedDlg.cpp:2460
 msgid "The following variables will be replaced:"
 msgstr "Šie kintamieji bus pakeisti:"
 
-#: src/PrefsUnifiedDlg.cpp:2708
+#: src/PrefsUnifiedDlg.cpp:2628
 msgid ""
 "The following folders look like system or sensitive locations:\n"
 "\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2713
+#: src/PrefsUnifiedDlg.cpp:2633
 msgid "Sharing them recursively will publish every file underneath on the eD2k/Kad networks. Do you really want to do this?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2716
+#: src/PrefsUnifiedDlg.cpp:2636
 #, fuzzy
 msgid "Confirm shared folders"
 msgstr "Atnaujinti dalinamų failų sąrašą"
 
-#: src/PrefsUnifiedDlg.cpp:2744
+#: src/PrefsUnifiedDlg.cpp:2664
 #, fuzzy
 msgid "Reloading shared files..."
 msgstr "Atnaujinti dalinamų failų sąrašą"
 
-#: src/PrefsUnifiedDlg.cpp:2745
+#: src/PrefsUnifiedDlg.cpp:2665
 msgid "Scanning for subdirectories..."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2746
+#: src/PrefsUnifiedDlg.cpp:2666
 #, fuzzy
 msgid "Updating shared folders"
 msgstr "Skaitomas laikinų failų aplankas"
 
-#: src/PrefsUnifiedDlg.cpp:2773
+#: src/PrefsUnifiedDlg.cpp:2693
 #, c-format
 msgid "Scanned %u directories..."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2823
+#: src/PrefsUnifiedDlg.cpp:2743
 #, fuzzy, c-format
 msgid "Reloading shared files: %u files scanned"
 msgstr "Atnaujinti dalinamų failų sąrašą."
 
-#: src/PrefsUnifiedDlg.cpp:2873
+#: src/PrefsUnifiedDlg.cpp:2793
 #, fuzzy
 msgid "Shared folder"
 msgstr "Dalinami failai"
 
-#: src/SearchDlg.cpp:280
-msgid "Clear search history"
-msgstr ""
-
-#: src/SearchDlg.cpp:584
+#: src/SearchDlg.cpp:425
 msgid "It's impossible to search when both eD2k and Kademlia are disabled."
 msgstr ""
 
-#: src/SearchDlg.cpp:585 src/SearchListCtrl.cpp:858
+#: src/SearchDlg.cpp:426 src/SearchListCtrl.cpp:858
 #, fuzzy
 msgid "Search error"
 msgstr "Paieška"
 
-#: src/SearchDlg.cpp:929
+#: src/SearchDlg.cpp:768
 msgid "Min size must be smaller than max size. Max size ignored."
 msgstr "Apatinė dydžio riba turi būti mažesnė už viršutinę dydžio ribą. Įvestos viršutinės ribos nebus paisoma."
 
-#: src/SearchDlg.cpp:930 src/SearchDlg.cpp:1012
+#: src/SearchDlg.cpp:769 src/SearchDlg.cpp:851
 msgid "Search warning"
 msgstr "Dėmesio"
 
-#: src/SearchDlg.cpp:1092 src/SearchListCtrl.cpp:735
+#: src/SearchDlg.cpp:929 src/SearchListCtrl.cpp:735
 msgid "Main"
 msgstr "Pagrindinė"
 

--- a/po/lt.po
+++ b/po/lt.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-28 08:06+0200\n"
+"POT-Creation-Date: 2026-07-28 10:19+0200\n"
 "PO-Revision-Date: 2026-07-27 11:41+0000\n"
 "Last-Translator: Dovydas Sankauskas <laisve@gmail.com>\n"
 "Language-Team: Lithuanian <komp_lt@konf.lt>\n"
@@ -142,7 +142,7 @@ msgstr ""
 msgid "Not now"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:422 src/amuleDlg.cpp:600
+#: src/AppImageIntegration.cpp:422 src/amuleDlg.cpp:665
 msgid "Don't ask again"
 msgstr ""
 
@@ -219,7 +219,7 @@ msgid "Killing amuleweb instance with pid '%d' ... "
 msgstr ""
 
 #: src/amule.cpp:336 src/amule.cpp:349 src/ClientRef.cpp:180
-#: src/SearchDlg.cpp:880 src/ServerListCtrl.cpp:98
+#: src/SearchDlg.cpp:1041 src/ServerListCtrl.cpp:98
 msgid "Failed"
 msgstr "Nepavyko"
 
@@ -578,30 +578,68 @@ msgstr ""
 msgid "ERROR: %s"
 msgstr "KLAIDA: %s"
 
-#: src/amuleDlg.cpp:236
+#: src/amuleDlg.cpp:250
 #, c-format
 msgid "This is aMule %s based on eMule."
 msgstr "aMule %s, sukurta eMule pagrindu."
 
-#: src/amuleDlg.cpp:237
+#: src/amuleDlg.cpp:251
 #, c-format
 msgid "Running on %s"
 msgstr "Vykdoma %s sistemoje"
 
-#: src/amuleDlg.cpp:239
+#: src/amuleDlg.cpp:253
 msgid "Visit https://github.com/amule-org/amule/releases/latest to check if a new version is available."
 msgstr "Aplankykite https://github.com/amule-org/amule/releases/latest ir pasitikrinkite ar nėra naujesnės versijos."
 
-#: src/amuleDlg.cpp:268
+#: src/amuleDlg.cpp:282
 msgid "FATAL ERROR: Failed to create Timer"
 msgstr "KRITINĖ KLAIDA: nepavyko sukurti laiko skaitliuko"
 
-#: src/amuleDlg.cpp:592
+#: src/amuleDlg.cpp:361 src/amuleDlg.cpp:1787 src/amuleDlg.cpp:2033
+#: src/muuli_wdr.cpp:1492 src/muuli_wdr.cpp:3418
+msgid "Networks"
+msgstr "Tinklas"
+
+#: src/amuleDlg.cpp:362 src/amuleDlg.cpp:1793 src/muuli_wdr.cpp:3419
+msgid "Searches"
+msgstr "Paieška"
+
+#: src/amuleDlg.cpp:363 src/amuleDlg.cpp:1799 src/DownloadListCtrl.cpp:740
+#: src/muuli_wdr.cpp:392 src/muuli_wdr.cpp:1585 src/muuli_wdr.cpp:3420
+#: src/Statistics.cpp:829
+msgid "Downloads"
+msgstr "Siuntimai"
+
+#: src/amuleDlg.cpp:364 src/amuleDlg.cpp:1805 src/muuli_wdr.cpp:3294
+msgid "Shared files"
+msgstr "Dalinami failai"
+
+#: src/amuleDlg.cpp:365 src/amuleDlg.cpp:1811 src/muuli_wdr.cpp:2926
+#: src/muuli_wdr.cpp:3376 src/muuli_wdr.cpp:3423
+msgid "Messages"
+msgstr "Žinutės"
+
+#: src/amuleDlg.cpp:366 src/amuleDlg.cpp:1817 src/muuli_wdr.cpp:3424
+#: src/PrefsUnifiedDlg.cpp:312 src/Statistics.cpp:779 src/Statistics.cpp:1235
+msgid "Statistics"
+msgstr "Statistika"
+
+#: src/amuleDlg.cpp:368 src/amuleDlg.cpp:1824 src/muuli_wdr.cpp:3426
+#: src/PrefsUnifiedDlg.cpp:328 src/utils/wxCas/src/wxcasprefs.cpp:39
+msgid "Preferences"
+msgstr "Parinktys"
+
+#: src/amuleDlg.cpp:371
+msgid "Navigate"
+msgstr ""
+
+#: src/amuleDlg.cpp:657
 #, fuzzy
 msgid "New version available"
 msgstr "Nėra"
 
-#: src/amuleDlg.cpp:596
+#: src/amuleDlg.cpp:661
 #, fuzzy, c-format
 msgid ""
 "A new version of aMule (%s) is available.\n"
@@ -611,219 +649,186 @@ msgid ""
 "Would you like to open the download page?"
 msgstr "Naujausią versiją bet kada galima atsisiųsti iš https://github.com/amule-org/amule/releases/latest"
 
-#: src/amuleDlg.cpp:678
+#: src/amuleDlg.cpp:743
 msgid "aMule dialog destroyed"
 msgstr ""
 
-#: src/amuleDlg.cpp:701 src/DataToText.cpp:68 src/IPFilter.cpp:547
+#: src/amuleDlg.cpp:766 src/DataToText.cpp:68 src/IPFilter.cpp:547
 msgid "Connecting"
 msgstr "Jungiamasi"
 
-#: src/amuleDlg.cpp:893
+#: src/amuleDlg.cpp:958
 msgid "eD2k: Connecting"
 msgstr "eD2k: jungiamasi"
 
-#: src/amuleDlg.cpp:897
+#: src/amuleDlg.cpp:962
 msgid "eD2k: Disconnected"
 msgstr "eD2k: atsijungta"
 
-#: src/amuleDlg.cpp:903
+#: src/amuleDlg.cpp:968
 msgid "Kad: Firewalled"
 msgstr "Kad: už ugniasienės"
 
-#: src/amuleDlg.cpp:907
+#: src/amuleDlg.cpp:972
 msgid "Kad: Connected"
 msgstr "Kad: prisijungta"
 
-#: src/amuleDlg.cpp:912
+#: src/amuleDlg.cpp:977
 msgid "Kad: Connecting"
 msgstr "Kad: jungiamasi"
 
-#: src/amuleDlg.cpp:916
+#: src/amuleDlg.cpp:981
 msgid "Kad: Off"
 msgstr "Kad: išjungta"
 
-#: src/amuleDlg.cpp:964 src/DownloadListCtrl.cpp:505
+#: src/amuleDlg.cpp:1029 src/DownloadListCtrl.cpp:505
 #: src/DownloadListCtrl.cpp:749 src/FriendListCtrl.cpp:180
 #: src/muuli_wdr.cpp:731 src/muuli_wdr.cpp:782 src/muuli_wdr.cpp:846
-#: src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2224 src/muuli_wdr.cpp:2309
-#: src/muuli_wdr.cpp:3057 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
+#: src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2231 src/muuli_wdr.cpp:2316
+#: src/muuli_wdr.cpp:3064 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
 #: src/ServerListCtrl.cpp:606 src/TransferWnd.cpp:378
 #: src/utils/wxCas/src/wxcasprefs.cpp:235
 msgid "Cancel"
 msgstr "Atšaukti"
 
-#: src/amuleDlg.cpp:965
+#: src/amuleDlg.cpp:1030
 msgid "Stop the current connection attempts"
 msgstr "Nutraukti bandymus prisijungti"
 
-#: src/amuleDlg.cpp:970 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976
-#: src/muuli_wdr.cpp:2447
+#: src/amuleDlg.cpp:1035 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976
+#: src/muuli_wdr.cpp:2454
 msgid "Disconnect"
 msgstr "Atsijungti"
 
-#: src/amuleDlg.cpp:971
+#: src/amuleDlg.cpp:1036
 msgid "Disconnect from the currently connected networks"
 msgstr "Atsijungti nuo pasirinktų tinklų"
 
-#: src/amuleDlg.cpp:976 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979
-#: src/muuli_wdr.cpp:2602 src/muuli_wdr.cpp:3054 src/muuli_wdr.cpp:3409
+#: src/amuleDlg.cpp:1041 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979
+#: src/muuli_wdr.cpp:2609 src/muuli_wdr.cpp:3061 src/muuli_wdr.cpp:3416
 msgid "Connect"
 msgstr "Prisijungti"
 
-#: src/amuleDlg.cpp:977
+#: src/amuleDlg.cpp:1042
 msgid "Connect to the currently enabled networks"
 msgstr "Prisijungti prie pasirinktų tinklų"
 
-#: src/amuleDlg.cpp:1089
+#: src/amuleDlg.cpp:1154
 #, fuzzy, c-format
 msgid "Up: %.1f%s (%.1f) | Down: %.1f%s (%.1f)"
 msgstr "Išs.: %.1f(%.1f) | Ats.: %.1f(%.1f)"
 
-#: src/amuleDlg.cpp:1091 src/amuleDlg.cpp:1093 src/amuleDlg.cpp:1097
-#: src/amuleDlg.cpp:1099 src/amuleDlg.cpp:1110 src/amuleDlg.cpp:1112
+#: src/amuleDlg.cpp:1156 src/amuleDlg.cpp:1158 src/amuleDlg.cpp:1162
+#: src/amuleDlg.cpp:1164 src/amuleDlg.cpp:1175 src/amuleDlg.cpp:1177
 #: src/MuleTrayIcon.cpp:796 src/MuleTrayIcon.cpp:799
 #, fuzzy
 msgid " MB/s"
 msgstr "MB/s"
 
-#: src/amuleDlg.cpp:1091 src/amuleDlg.cpp:1093 src/amuleDlg.cpp:1097
-#: src/amuleDlg.cpp:1099 src/amuleDlg.cpp:1110 src/amuleDlg.cpp:1112
+#: src/amuleDlg.cpp:1156 src/amuleDlg.cpp:1158 src/amuleDlg.cpp:1162
+#: src/amuleDlg.cpp:1164 src/amuleDlg.cpp:1175 src/amuleDlg.cpp:1177
 #: src/MuleTrayIcon.cpp:796 src/MuleTrayIcon.cpp:799
 #: src/utils/wxCas/src/wxcasframe.cpp:1041
 msgid " kB/s"
 msgstr " kB/s"
 
-#: src/amuleDlg.cpp:1096
+#: src/amuleDlg.cpp:1161
 #, fuzzy, c-format
 msgid "Up: %.1f%s | Down: %.1f%s"
 msgstr "Išs.: %.1f | Ats.: %.1f"
 
-#: src/amuleDlg.cpp:1128
+#: src/amuleDlg.cpp:1193
 #, c-format
 msgid "aMule (%s | Connected)"
 msgstr "aMule (%s | prisijungta)"
 
-#: src/amuleDlg.cpp:1130
+#: src/amuleDlg.cpp:1195
 #, c-format
 msgid "aMule (%s | Disconnected)"
 msgstr "aMule (%s | neprisijungta)"
 
-#: src/amuleDlg.cpp:1183
+#: src/amuleDlg.cpp:1248
 #, fuzzy, c-format
 msgid "Do you really want to exit %s?"
 msgstr "Ar tikrai norite baigti darbą su aMule?"
 
-#: src/amuleDlg.cpp:1185
+#: src/amuleDlg.cpp:1250
 msgid "Exit confirmation"
 msgstr "Baigimo patvirtinimas"
 
-#: src/amuleDlg.cpp:1548
+#: src/amuleDlg.cpp:1613
 msgid "Launch Command: "
 msgstr ""
 
-#: src/amuleDlg.cpp:1567 src/muuli_wdr.cpp:1971 src/Preferences.cpp:951
+#: src/amuleDlg.cpp:1632 src/muuli_wdr.cpp:1978 src/Preferences.cpp:952
 msgid "- default -"
 msgstr ""
 
-#: src/amuleDlg.cpp:1595
+#: src/amuleDlg.cpp:1660
 #, c-format
 msgid "Skin directory '%s' does not exist"
 msgstr "Išvaizdos failų aplankas %s neegzistuoja"
 
-#: src/amuleDlg.cpp:1598
+#: src/amuleDlg.cpp:1663
 #, c-format
 msgid "WARNING: Unable to open skin file '%s' for read"
 msgstr "DĖMESIO: nepavyko atverti temos failo „%s“ skaitymui"
 
-#: src/amuleDlg.cpp:1722 src/amuleDlg.cpp:1968 src/muuli_wdr.cpp:1485
-#: src/muuli_wdr.cpp:3411
-msgid "Networks"
-msgstr "Tinklas"
-
-#: src/amuleDlg.cpp:1726 src/muuli_wdr.cpp:3411
+#: src/amuleDlg.cpp:1791 src/muuli_wdr.cpp:3418
 msgid "Networks Window"
 msgstr "Tinklo langas"
 
-#: src/amuleDlg.cpp:1728 src/muuli_wdr.cpp:3412
-msgid "Searches"
-msgstr "Paieška"
-
-#: src/amuleDlg.cpp:1732 src/muuli_wdr.cpp:3412
+#: src/amuleDlg.cpp:1797 src/muuli_wdr.cpp:3419
 msgid "Searches Window"
 msgstr "Paieškos langas"
 
-#: src/amuleDlg.cpp:1734 src/DownloadListCtrl.cpp:740 src/muuli_wdr.cpp:392
-#: src/muuli_wdr.cpp:1578 src/muuli_wdr.cpp:3413 src/Statistics.cpp:829
-msgid "Downloads"
-msgstr "Siuntimai"
-
-#: src/amuleDlg.cpp:1738 src/muuli_wdr.cpp:3413
+#: src/amuleDlg.cpp:1803 src/muuli_wdr.cpp:3420
 #, fuzzy
 msgid "Downloads Window"
 msgstr "Atsiunčiama"
 
-#: src/amuleDlg.cpp:1740 src/muuli_wdr.cpp:3287
-msgid "Shared files"
-msgstr "Dalinami failai"
-
-#: src/amuleDlg.cpp:1744 src/muuli_wdr.cpp:3415
+#: src/amuleDlg.cpp:1809 src/muuli_wdr.cpp:3422
 msgid "Shared Files Window"
 msgstr "Dalinamų failų langas"
 
-#: src/amuleDlg.cpp:1746 src/muuli_wdr.cpp:2919 src/muuli_wdr.cpp:3369
-#: src/muuli_wdr.cpp:3416
-msgid "Messages"
-msgstr "Žinutės"
-
-#: src/amuleDlg.cpp:1750 src/muuli_wdr.cpp:3416
+#: src/amuleDlg.cpp:1815 src/muuli_wdr.cpp:3423
 msgid "Messages Window"
 msgstr "Žinučių langas"
 
-#: src/amuleDlg.cpp:1752 src/muuli_wdr.cpp:3417 src/PrefsUnifiedDlg.cpp:312
-#: src/Statistics.cpp:779 src/Statistics.cpp:1235
-msgid "Statistics"
-msgstr "Statistika"
-
-#: src/amuleDlg.cpp:1756 src/muuli_wdr.cpp:3417
+#: src/amuleDlg.cpp:1821 src/muuli_wdr.cpp:3424
 msgid "Statistics Graph Window"
 msgstr "Statistikos grafikų langas"
 
-#: src/amuleDlg.cpp:1759 src/muuli_wdr.cpp:3419 src/PrefsUnifiedDlg.cpp:328
-#: src/utils/wxCas/src/wxcasprefs.cpp:39
-msgid "Preferences"
-msgstr "Parinktys"
-
-#: src/amuleDlg.cpp:1763 src/muuli_wdr.cpp:3419
+#: src/amuleDlg.cpp:1828 src/muuli_wdr.cpp:3426
 msgid "Preferences Settings Window"
 msgstr "Parinkčių langas"
 
-#: src/amuleDlg.cpp:1766 src/muuli_wdr.cpp:3420
+#: src/amuleDlg.cpp:1831 src/muuli_wdr.cpp:3427
 msgid "Import"
 msgstr "Įkelti"
 
-#: src/amuleDlg.cpp:1770 src/muuli_wdr.cpp:3420
+#: src/amuleDlg.cpp:1835 src/muuli_wdr.cpp:3427
 msgid "The partfile importer tool"
 msgstr "Dalinai atsiųstų failų įkėlimo įrankis"
 
-#: src/amuleDlg.cpp:1773 src/muuli_wdr.cpp:3421
+#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3428
 #: src/utils/aLinkCreator/src/alcframe.cpp:262
 msgid "About"
 msgstr "Apie"
 
-#: src/amuleDlg.cpp:1773 src/muuli_wdr.cpp:3421
+#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3428
 msgid "About/Help"
 msgstr "Apie/pagalba"
 
-#: src/amuleDlg.cpp:1971
+#: src/amuleDlg.cpp:2036
 msgid "eD2k network"
 msgstr "eD2k tinklas"
 
-#: src/amuleDlg.cpp:1974
+#: src/amuleDlg.cpp:2039
 msgid "Kad network"
 msgstr "Kad tinklas"
 
-#: src/amuleDlg.cpp:1974
+#: src/amuleDlg.cpp:2039
 msgid "No network"
 msgstr "Jokio tinklo"
 
@@ -1365,19 +1370,19 @@ msgstr "Automatiškai (aukštas)"
 msgid "Very low"
 msgstr "Labai žemas"
 
-#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:743 src/muuli_wdr.cpp:2275
+#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:743 src/muuli_wdr.cpp:2282
 #: src/ServerListCtrl.cpp:263 src/ServerListCtrl.cpp:456
 #: src/SharedFilesCtrl.cpp:145
 msgid "Low"
 msgstr "Žemas"
 
-#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:744 src/muuli_wdr.cpp:2276
+#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:744 src/muuli_wdr.cpp:2283
 #: src/ServerListCtrl.cpp:266 src/ServerListCtrl.cpp:457
 #: src/SharedFilesCtrl.cpp:146
 msgid "Normal"
 msgstr "Normalus"
 
-#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:745 src/muuli_wdr.cpp:2277
+#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:745 src/muuli_wdr.cpp:2284
 #: src/ServerListCtrl.cpp:269 src/ServerListCtrl.cpp:458
 #: src/SharedFilesCtrl.cpp:147
 msgid "High"
@@ -1469,8 +1474,8 @@ msgstr "Vietinis serveris"
 msgid "Remote Server"
 msgstr "Nutolęs serveris"
 
-#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3174
-#: src/SearchDlg.cpp:111 src/TextClient.cpp:911
+#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3181
+#: src/SearchDlg.cpp:119 src/TextClient.cpp:911
 msgid "Kad"
 msgstr "Kademlia"
 
@@ -1541,7 +1546,7 @@ msgstr ""
 msgid "Size"
 msgstr "Dydis"
 
-#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3241
+#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3248
 msgid "Transferred"
 msgstr "Persiųsta"
 
@@ -1599,7 +1604,7 @@ msgstr ""
 "Atsakymas iš: %s (%s)\n"
 "\n"
 
-#: src/DownloadListCtrl.cpp:746 src/muuli_wdr.cpp:2278
+#: src/DownloadListCtrl.cpp:746 src/muuli_wdr.cpp:2285
 #: src/SharedFilesCtrl.cpp:150
 msgid "Auto"
 msgstr "Automatiškas"
@@ -1637,7 +1642,7 @@ msgid "Extended Options"
 msgstr "Papildomi veiksmai"
 
 #: src/DownloadListCtrl.cpp:770 src/DownloadListCtrl.cpp:822
-#: src/muuli_wdr.cpp:1789
+#: src/muuli_wdr.cpp:1796
 msgid "Preview"
 msgstr "Peržiūra"
 
@@ -2355,19 +2360,19 @@ msgstr ""
 msgid "eD2k"
 msgstr "eD2k"
 
-#: src/FirstRunWizard.cpp:349 src/muuli_wdr.cpp:1488
+#: src/FirstRunWizard.cpp:349 src/muuli_wdr.cpp:1495
 msgid "Kademlia"
 msgstr "Kademlia"
 
-#: src/FirstRunWizard.cpp:359 src/muuli_wdr.cpp:1416
+#: src/FirstRunWizard.cpp:359 src/muuli_wdr.cpp:1423
 msgid "Standard TCP Port "
 msgstr ""
 
-#: src/FirstRunWizard.cpp:365 src/muuli_wdr.cpp:1428
+#: src/FirstRunWizard.cpp:365 src/muuli_wdr.cpp:1435
 msgid "Extended UDP port (Kad / global search) "
 msgstr ""
 
-#: src/FirstRunWizard.cpp:377 src/muuli_wdr.cpp:1435
+#: src/FirstRunWizard.cpp:377 src/muuli_wdr.cpp:1442
 msgid "Enable UPnP for router port forwarding"
 msgstr ""
 
@@ -2394,7 +2399,7 @@ msgstr ""
 msgid "Your peer lists are already in place - nothing to download."
 msgstr "Failas %s jau yra atsiunčiamų failų sąraše"
 
-#: src/FirstRunWizard.cpp:434 src/muuli_wdr.cpp:1533
+#: src/FirstRunWizard.cpp:434 src/muuli_wdr.cpp:1540
 msgid "Auto-update server list at startup"
 msgstr "Automatiškai atnaujinti serverių sąrašą paleidus programą"
 
@@ -2440,23 +2445,23 @@ msgid ""
 "want downloads on a different (e.g. larger) disk."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:549 src/FirstRunWizard.cpp:611 src/muuli_wdr.cpp:1701
+#: src/FirstRunWizard.cpp:549 src/FirstRunWizard.cpp:611 src/muuli_wdr.cpp:1708
 msgid "Destination folder for downloads"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:553 src/FirstRunWizard.cpp:569 src/muuli_wdr.cpp:1342
-#: src/muuli_wdr.cpp:1359 src/muuli_wdr.cpp:1676 src/muuli_wdr.cpp:1707
-#: src/muuli_wdr.cpp:1719 src/muuli_wdr.cpp:2762
+#: src/FirstRunWizard.cpp:553 src/FirstRunWizard.cpp:569 src/muuli_wdr.cpp:1349
+#: src/muuli_wdr.cpp:1366 src/muuli_wdr.cpp:1683 src/muuli_wdr.cpp:1714
+#: src/muuli_wdr.cpp:1726 src/muuli_wdr.cpp:2769
 #: src/utils/aLinkCreator/src/alcframe.cpp:135
 #: src/utils/wxCas/src/wxcasprefs.cpp:52 src/utils/wxCas/src/wxcasprefs.cpp:118
 msgid "Browse"
 msgstr "Naršyti"
 
-#: src/FirstRunWizard.cpp:559 src/muuli_wdr.cpp:1712
+#: src/FirstRunWizard.cpp:559 src/muuli_wdr.cpp:1719
 msgid "(All files in this folder are shared with other peers)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:565 src/FirstRunWizard.cpp:624 src/muuli_wdr.cpp:1714
+#: src/FirstRunWizard.cpp:565 src/FirstRunWizard.cpp:624 src/muuli_wdr.cpp:1721
 msgid "Folder for temporary download files"
 msgstr ""
 
@@ -2487,7 +2492,7 @@ msgstr "Nepavyko atverti draugų sąrašo failo „emfriends.met“ rašymui!"
 msgid "CRITICAL - no client on StartChatSession"
 msgstr ""
 
-#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2668 src/muuli_wdr.cpp:3345
+#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2675 src/muuli_wdr.cpp:3352
 msgid "Friends"
 msgstr "Draugai"
 
@@ -2882,7 +2887,7 @@ msgstr "Platinimo santykis"
 msgid "Uploaded"
 msgstr "Išsiųsta"
 
-#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3225
+#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3232
 msgid "Requested"
 msgstr "Paprašyta"
 
@@ -3008,7 +3013,7 @@ msgid "WARNING: "
 msgstr "DĖMESIO: "
 
 #: src/MuleNotebook.cpp:179 src/muuli_wdr.cpp:817 src/muuli_wdr.cpp:1229
-#: src/muuli_wdr.cpp:3129 src/muuli_wdr.cpp:3385
+#: src/muuli_wdr.cpp:3136 src/muuli_wdr.cpp:3392
 msgid "Close"
 msgstr "Užverti"
 
@@ -3021,12 +3026,12 @@ msgstr "Iškirpti"
 msgid "Copy"
 msgstr "Kopijuoti"
 
-#: src/MuleTextCtrl.cpp:88
+#: src/MuleTextCtrl.cpp:88 src/SearchDlg.cpp:261
 msgid "Paste"
 msgstr "Įterpti"
 
 #: src/MuleTextCtrl.cpp:89 src/muuli_wdr.cpp:358 src/muuli_wdr.cpp:757
-#: src/muuli_wdr.cpp:2352 src/muuli_wdr.cpp:2371 src/muuli_wdr.cpp:2393
+#: src/muuli_wdr.cpp:2359 src/muuli_wdr.cpp:2378 src/muuli_wdr.cpp:2400
 #: src/utils/aLinkCreator/src/alcframe.cpp:142
 msgid "Clear"
 msgstr "Išvalyti"
@@ -3124,8 +3129,8 @@ msgid "Exit"
 msgstr "Baigti"
 
 #: src/MuleTrayIcon.cpp:579 src/MuleTrayIcon.cpp:945 src/MuleTrayIcon.cpp:965
-#: src/muuli_wdr.cpp:1391 src/muuli_wdr.cpp:1399 src/muuli_wdr.cpp:1406
-#: src/muuli_wdr.cpp:1835 src/muuli_wdr.cpp:1841 src/OtherFunctions.cpp:91
+#: src/muuli_wdr.cpp:1398 src/muuli_wdr.cpp:1406 src/muuli_wdr.cpp:1413
+#: src/muuli_wdr.cpp:1842 src/muuli_wdr.cpp:1848 src/OtherFunctions.cpp:91
 #: src/StatisticsDlg.cpp:93 src/StatisticsDlg.cpp:95
 msgid "kB/s"
 msgstr "kB/s"
@@ -3296,7 +3301,7 @@ msgstr "Pavadinimas:"
 msgid "Type"
 msgstr "Tipas"
 
-#: src/muuli_wdr.cpp:215 src/SearchDlg.cpp:110 src/SearchListCtrl.cpp:853
+#: src/muuli_wdr.cpp:215 src/SearchDlg.cpp:118 src/SearchListCtrl.cpp:853
 msgid "Local"
 msgstr "Vietinis"
 
@@ -3367,7 +3372,7 @@ msgstr "Baitai"
 msgid "KB"
 msgstr "KB"
 
-#: src/muuli_wdr.cpp:274 src/muuli_wdr.cpp:293 src/muuli_wdr.cpp:1620
+#: src/muuli_wdr.cpp:274 src/muuli_wdr.cpp:293 src/muuli_wdr.cpp:1627
 #: src/OtherFunctions.cpp:64
 msgid "MB"
 msgstr "MB"
@@ -3384,7 +3389,7 @@ msgstr "Maks dydis"
 msgid "Availability"
 msgstr "Skaičius"
 
-#: src/muuli_wdr.cpp:312 src/muuli_wdr.cpp:398 src/muuli_wdr.cpp:3290
+#: src/muuli_wdr.cpp:312 src/muuli_wdr.cpp:398 src/muuli_wdr.cpp:3297
 msgid "Filter:"
 msgstr "Filtras:"
 
@@ -3416,7 +3421,7 @@ msgstr ""
 msgid "Stop"
 msgstr "Sustabdyti"
 
-#: src/muuli_wdr.cpp:348 src/muuli_wdr.cpp:1385 src/SearchListCtrl.cpp:732
+#: src/muuli_wdr.cpp:348 src/muuli_wdr.cpp:1392 src/SearchListCtrl.cpp:732
 msgid "Download"
 msgstr "Atsiųsti"
 
@@ -3448,8 +3453,8 @@ msgstr "Pilni šaltiniai"
 #: src/muuli_wdr.cpp:1160 src/muuli_wdr.cpp:1167 src/muuli_wdr.cpp:1172
 #: src/muuli_wdr.cpp:1179 src/muuli_wdr.cpp:1184 src/muuli_wdr.cpp:1191
 #: src/muuli_wdr.cpp:1205 src/muuli_wdr.cpp:1212 src/muuli_wdr.cpp:1217
-#: src/muuli_wdr.cpp:1224 src/muuli_wdr.cpp:3227 src/muuli_wdr.cpp:3235
-#: src/muuli_wdr.cpp:3243
+#: src/muuli_wdr.cpp:1224 src/muuli_wdr.cpp:3234 src/muuli_wdr.cpp:3242
+#: src/muuli_wdr.cpp:3250
 msgid "N/A"
 msgstr "Nežinoma"
 
@@ -3594,7 +3599,7 @@ msgstr ""
 msgid "Album :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:685 src/muuli_wdr.cpp:2247
+#: src/muuli_wdr.cpp:685 src/muuli_wdr.cpp:2254
 msgid "Title :"
 msgstr "Pavadinimas:"
 
@@ -3701,7 +3706,7 @@ msgstr "Naudotojo vardas:"
 msgid "Userhash :"
 msgstr "Naudotojo maišos f-ja:"
 
-#: src/muuli_wdr.cpp:895 src/muuli_wdr.cpp:1741 src/muuli_wdr.cpp:2442
+#: src/muuli_wdr.cpp:895 src/muuli_wdr.cpp:1748 src/muuli_wdr.cpp:2449
 #: src/utils/aLinkCreator/src/alcframe.cpp:137
 msgid "Add"
 msgstr "Įdėti"
@@ -3710,15 +3715,15 @@ msgstr "Įdėti"
 msgid "Download-Speed"
 msgstr "Atsiuntimo sparta"
 
-#: src/muuli_wdr.cpp:954 src/muuli_wdr.cpp:989 src/muuli_wdr.cpp:2546
+#: src/muuli_wdr.cpp:954 src/muuli_wdr.cpp:989 src/muuli_wdr.cpp:2553
 msgid "Current"
 msgstr "Dabartinė sparta"
 
-#: src/muuli_wdr.cpp:962 src/muuli_wdr.cpp:997 src/muuli_wdr.cpp:2554
+#: src/muuli_wdr.cpp:962 src/muuli_wdr.cpp:997 src/muuli_wdr.cpp:2561
 msgid "Running average"
 msgstr "Dabartinis vidurkis"
 
-#: src/muuli_wdr.cpp:970 src/muuli_wdr.cpp:1005 src/muuli_wdr.cpp:2562
+#: src/muuli_wdr.cpp:970 src/muuli_wdr.cpp:1005 src/muuli_wdr.cpp:2569
 msgid "Session average"
 msgstr "Seanso vidurkis"
 
@@ -3730,7 +3735,7 @@ msgstr "Išsiuntimo sparta"
 msgid "Connections"
 msgstr "Ryšiai"
 
-#: src/muuli_wdr.cpp:1024 src/muuli_wdr.cpp:1860
+#: src/muuli_wdr.cpp:1024 src/muuli_wdr.cpp:1867
 msgid "Active downloads"
 msgstr "Aktyvūs atsiuntimai"
 
@@ -3738,7 +3743,7 @@ msgstr "Aktyvūs atsiuntimai"
 msgid "Active connections (1:1)"
 msgstr "Aktyvūs ryšiai (1:1)"
 
-#: src/muuli_wdr.cpp:1040 src/muuli_wdr.cpp:1861
+#: src/muuli_wdr.cpp:1040 src/muuli_wdr.cpp:1868
 msgid "Active uploads"
 msgstr "Aktyvūs išsiuntimai"
 
@@ -3855,8 +3860,8 @@ msgstr "Įrašykite vardą, kurį matys kiti su jumis užmezgę ryšį naudotoja
 msgid "Language: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1257 src/muuli_wdr.cpp:1323 src/muuli_wdr.cpp:1327
-#: src/muuli_wdr.cpp:1330
+#: src/muuli_wdr.cpp:1257 src/muuli_wdr.cpp:1330 src/muuli_wdr.cpp:1334
+#: src/muuli_wdr.cpp:1337
 msgid "The delay before showing tool-tips."
 msgstr "Kiek sekundžių uždelsti prieš parodant patarimą užvedus pelę ant objekto."
 
@@ -3934,938 +3939,947 @@ msgstr ""
 msgid "Enabling this will make aMule to show notifications when finished downloading."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1322
-msgid "Tooltip delay time: "
+#: src/muuli_wdr.cpp:1323
+#, fuzzy
+msgid "Remember search history"
+msgstr "Įsiminti parinktis"
+
+#: src/muuli_wdr.cpp:1324
+msgid "Keeps a dropdown list of your past search terms in the Search tab's Name field. This remembers the queries you typed, not the results they returned."
 msgstr ""
 
 #: src/muuli_wdr.cpp:1329
+msgid "Tooltip delay time: "
+msgstr ""
+
+#: src/muuli_wdr.cpp:1336
 msgid "seconds"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1333
+#: src/muuli_wdr.cpp:1340
 msgid "Browser Selection"
 msgstr "Naršyklės parintys"
 
-#: src/muuli_wdr.cpp:1339
+#: src/muuli_wdr.cpp:1346
 msgid "Enter your browser name here. Leave this field empty to use the system default browser."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1346
+#: src/muuli_wdr.cpp:1353
 msgid "Open in new tab if possible"
 msgstr "Jei įmanoma, atverti naują kortelę"
 
-#: src/muuli_wdr.cpp:1348
+#: src/muuli_wdr.cpp:1355
 msgid "Open the web page in a new tab instead of in a new window when possible"
 msgstr "Įjungus šią parinktį, stengtis nurodytą puslapį atverti naujoje naršyklės kortelėje, o ne pagrindiniame naršyklės lange"
 
-#: src/muuli_wdr.cpp:1352
+#: src/muuli_wdr.cpp:1359
 msgid "Video Player"
 msgstr "Vaizdo grotuvas"
 
-#: src/muuli_wdr.cpp:1379
+#: src/muuli_wdr.cpp:1386
 msgid "Bandwidth limits"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1393
+#: src/muuli_wdr.cpp:1400
 msgid "Upload"
 msgstr "Išsiuntimas"
 
-#: src/muuli_wdr.cpp:1401
+#: src/muuli_wdr.cpp:1408
 msgid "Slot Allocation"
 msgstr "Vieno ryšio sparta"
 
-#: src/muuli_wdr.cpp:1410
+#: src/muuli_wdr.cpp:1417
 msgid "Ports"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1420
+#: src/muuli_wdr.cpp:1427
 msgid "This is the standard eD2k port and cannot be disabled."
 msgstr "Tai standartinis eD2k prievadas. Jis negali būti išjungtas."
 
-#: src/muuli_wdr.cpp:1423
+#: src/muuli_wdr.cpp:1430
 msgid "UDP port for server requests (TCP+3):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1425
+#: src/muuli_wdr.cpp:1432
 msgid "4665"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1432
+#: src/muuli_wdr.cpp:1439
 msgid "This UDP port is used for extended eD2k requests and Kad network"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1439
+#: src/muuli_wdr.cpp:1446
 msgid "UPnP TCP Port (Optional):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1449
+#: src/muuli_wdr.cpp:1456
 msgid "Bind local address to IP (empty for any):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1452
+#: src/muuli_wdr.cpp:1459
 msgid "Advanced users only: If you have multiple network interfaces, enter the address of the interface to which aMule should be bound."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1455 src/muuli_wdr.cpp:2054
+#: src/muuli_wdr.cpp:1462 src/muuli_wdr.cpp:2061
 msgid "Bind to network interface (empty for any):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1468
+#: src/muuli_wdr.cpp:1475
 msgid "Advanced users only: pin all of aMule's traffic to one network interface, chosen from the list or typed in by name (e.g. tun0, eth0, en0) or index. Unlike binding to an IP, this stops traffic leaking out via the default route - useful with a VPN. Requires no elevated privileges."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1474
+#: src/muuli_wdr.cpp:1481
 msgid "Max sources per downloading file:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1478
+#: src/muuli_wdr.cpp:1485
 msgid "Max simultaneous connections:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1491 src/muuli_wdr.cpp:3169
+#: src/muuli_wdr.cpp:1498 src/muuli_wdr.cpp:3176
 msgid "ED2K"
 msgstr "ED2K"
 
-#: src/muuli_wdr.cpp:1498
+#: src/muuli_wdr.cpp:1505
 msgid "Autoconnect on startup"
 msgstr "Pradėjus darbą prisijungti automatiškai"
 
-#: src/muuli_wdr.cpp:1501
+#: src/muuli_wdr.cpp:1508
 msgid "Reconnect on loss"
 msgstr "Nutrūkus ryšiui prisijungti vėl"
 
-#: src/muuli_wdr.cpp:1523
+#: src/muuli_wdr.cpp:1530
 msgid "Remove dead server after"
 msgstr "Pašalinti neatsiliepiantį serverį po"
 
-#: src/muuli_wdr.cpp:1524
+#: src/muuli_wdr.cpp:1531
 msgid "Static servers are never removed, even when unreachable."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1528
+#: src/muuli_wdr.cpp:1535
 msgid "retries"
 msgstr "bandymų"
 
-#: src/muuli_wdr.cpp:1536
+#: src/muuli_wdr.cpp:1543
 msgid "List"
 msgstr "Sąrašas"
 
-#: src/muuli_wdr.cpp:1539
+#: src/muuli_wdr.cpp:1546
 msgid "Update server list when connecting to a server"
 msgstr "Atnaujinti serverių sąrašą prisijungus prie serverio"
 
-#: src/muuli_wdr.cpp:1542
+#: src/muuli_wdr.cpp:1549
 msgid "Update server list when a client connects"
 msgstr "Atnaujinti serverių sąrašą prisijungus klientui"
 
-#: src/muuli_wdr.cpp:1545
+#: src/muuli_wdr.cpp:1552
 msgid "Use priority system"
 msgstr "Naudoti prioritetų sistemą"
 
-#: src/muuli_wdr.cpp:1549
+#: src/muuli_wdr.cpp:1556
 msgid "Use smart LowID check on connect"
 msgstr "Jungiantis naudoti išmoningą žemo ID tikrinimą"
 
-#: src/muuli_wdr.cpp:1553
+#: src/muuli_wdr.cpp:1560
 msgid "Safe connect"
 msgstr "Saugus jungimasis"
 
-#: src/muuli_wdr.cpp:1557
+#: src/muuli_wdr.cpp:1564
 msgid "Autoconnect to servers in static list only"
 msgstr "Automatiškai jungtis tik prie serverių iš pastovaus sąrašo"
 
-#: src/muuli_wdr.cpp:1560
+#: src/muuli_wdr.cpp:1567
 msgid "Set manually added servers to High Priority"
 msgstr "Naudotojo įdėtiems serveriams nurodyti aukštą prioritetą"
 
-#: src/muuli_wdr.cpp:1581
+#: src/muuli_wdr.cpp:1588
 msgid "Add files to download in pause mode"
 msgstr "Failus į atsiuntimo eilę įdėti pristabdytos būsenos"
 
-#: src/muuli_wdr.cpp:1583
+#: src/muuli_wdr.cpp:1590
 msgid "Add files to download with auto priority"
 msgstr "Į atsiuntimo eilę įdedamiems failams nurodyti automatinį prioritetą"
 
-#: src/muuli_wdr.cpp:1586
+#: src/muuli_wdr.cpp:1593
 msgid "Try to download first and last chunks first"
 msgstr "Visų pirma bandyti atsiųsti pirmą ir paskutinę failo dalį"
 
-#: src/muuli_wdr.cpp:1590
+#: src/muuli_wdr.cpp:1597
 msgid "Endgame mode: rotate to faster sources for the final blocks"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1593
+#: src/muuli_wdr.cpp:1600
 msgid "Start next paused file when a file completes"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1596
+#: src/muuli_wdr.cpp:1603
 msgid "From the same category"
 msgstr "Siųsti tos pačios kategorijos failą"
 
-#: src/muuli_wdr.cpp:1598
+#: src/muuli_wdr.cpp:1605
 msgid "In alphabetic order"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1600
+#: src/muuli_wdr.cpp:1607
 msgid "Preallocate disk space for new files"
 msgstr "Naujiems failams paskirti vietą diske"
 
-#: src/muuli_wdr.cpp:1601
+#: src/muuli_wdr.cpp:1608
 msgid "For new files preallocates disk space for the whole file, thus reduces fragmentation"
 msgstr "Naujiems failams iš anksto paskirti vietą diske visam failui. Taip bus sumažinta fragmentacija"
 
-#: src/muuli_wdr.cpp:1606
+#: src/muuli_wdr.cpp:1613
 msgid "Create new files as sparse files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1607
+#: src/muuli_wdr.cpp:1614
 msgid "A sparse file reserves its full size on disk immediately without writing real data to it -- fast, but unsupported or slow on some filesystems, and free-space accounting stays optimistic while the download is in progress. Turn this off to grow the file only as data arrives."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1612
+#: src/muuli_wdr.cpp:1619
 msgid "Stop downloads when free disk space reaches "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1613
+#: src/muuli_wdr.cpp:1620
 msgid "Select this if you want aMule to check your disk space"
 msgstr "Įjunkite, jei norite, kad aMule tikrintų laisvą vietą diske"
 
-#: src/muuli_wdr.cpp:1617
+#: src/muuli_wdr.cpp:1624
 msgid "Enter here the min disk space desired."
 msgstr "Įrašykite kiek diske palikti laisvos vietos."
 
-#: src/muuli_wdr.cpp:1623
+#: src/muuli_wdr.cpp:1630
 msgid "Save 10 sources on rare files (< 20 sources)"
 msgstr "Įrašyti 10 šaltinių retiems failams (mažiau nei 20 šaltinių)"
 
-#: src/muuli_wdr.cpp:1627 src/Statistics.cpp:790
+#: src/muuli_wdr.cpp:1634 src/Statistics.cpp:790
 msgid "Uploads"
 msgstr "Išsiuntimai"
 
-#: src/muuli_wdr.cpp:1630
+#: src/muuli_wdr.cpp:1637
 msgid "Add new shared files with auto priority"
 msgstr "Naujiems dalinamiems failams nurodyti automatinį prioritetą"
 
-#: src/muuli_wdr.cpp:1636
+#: src/muuli_wdr.cpp:1643
 msgid "Intelligent Corruption Handling (I.C.H.)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1639
+#: src/muuli_wdr.cpp:1646
 msgid "Enable"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1642
+#: src/muuli_wdr.cpp:1649
 msgid "Advanced I.C.H. trusts every hash (not recommended)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1654 src/PrefsUnifiedDlg.cpp:1910
+#: src/muuli_wdr.cpp:1661 src/PrefsUnifiedDlg.cpp:1910
 msgid "Media metadata extraction"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1658
+#: src/muuli_wdr.cpp:1665
 msgid "Extract length / bitrate / codec from shared audio and video files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1660
+#: src/muuli_wdr.cpp:1667
 msgid "When enabled, aMule runs ffprobe on each shared media file to fill in the Length / Bitrate / Codec columns other clients see when they find the file in a search. Requires ffmpeg (the ffprobe binary) to be installed."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1667
+#: src/muuli_wdr.cpp:1674
 msgid "Path to ffprobe:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1672
+#: src/muuli_wdr.cpp:1679
 msgid "Full path to the ffprobe binary. Leave empty to have aMule auto-detect it on startup."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1680
+#: src/muuli_wdr.cpp:1687
 msgid "Detect"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1681
+#: src/muuli_wdr.cpp:1688
 msgid "Search the standard install locations for an ffprobe binary and fill the path field."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1705
+#: src/muuli_wdr.cpp:1712
 msgid ""
 "Completed downloads are stored here. All files in this folder are automatically shared with other peers.\n"
 "If this folder also holds files you don't want to share, point it at an aMule-only sub-folder."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1708
+#: src/muuli_wdr.cpp:1715
 msgid "Pick the folder where completed downloads will be stored. All files in that folder will be shared with other peers."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1722
+#: src/muuli_wdr.cpp:1729
 msgid "Shared folders"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1728
+#: src/muuli_wdr.cpp:1735
 msgid "(Folders shared by the core. Enter a path to add one.)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1736
+#: src/muuli_wdr.cpp:1743
 msgid "Absolute path of a folder on the core's machine, e.g. /home/user/shared"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1738 src/PrefsUnifiedDlg.cpp:2794
+#: src/muuli_wdr.cpp:1745 src/PrefsUnifiedDlg.cpp:2794
 msgid "Recursive"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1739
+#: src/muuli_wdr.cpp:1746
 msgid "Share every sub-folder underneath this one, including ones created later."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1743 src/utils/aLinkCreator/src/alcframe.cpp:141
+#: src/muuli_wdr.cpp:1750 src/utils/aLinkCreator/src/alcframe.cpp:141
 msgid "Remove"
 msgstr "Pašalinti"
 
-#: src/muuli_wdr.cpp:1747
+#: src/muuli_wdr.cpp:1754
 msgid "(Right click on folder icon for recursive share)"
 msgstr "(spragtelėję dešiniu klavišu dalinsitės ir gilesniais paaplankiais)"
 
-#: src/muuli_wdr.cpp:1754
+#: src/muuli_wdr.cpp:1761
 msgid "Share hidden files"
 msgstr "Dalintis slepiamais failais"
 
-#: src/muuli_wdr.cpp:1760
+#: src/muuli_wdr.cpp:1767
 msgid "Automatically rescan shared folders for changes"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1766
+#: src/muuli_wdr.cpp:1773
 msgid "Follow symbolic links in shared folders"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1772
+#: src/muuli_wdr.cpp:1779
 msgid "Exclude files matching:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1775
+#: src/muuli_wdr.cpp:1782
 msgid "Wildcard patterns separated by '|', e.g. .DS_Store|Thumbs.db|*.tmp. Files whose name matches are not shared. Matching is case-insensitive."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1779
+#: src/muuli_wdr.cpp:1786
 msgid "Patterns are regular expressions"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1780
+#: src/muuli_wdr.cpp:1787
 msgid "When set, the whole field is one regular expression ('|' is alternation). When unset, it is a list of '|'-separated wildcards."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1790
+#: src/muuli_wdr.cpp:1797
 msgid "Show how many shared files the current pattern would exclude."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1811
+#: src/muuli_wdr.cpp:1818
 msgid "Graphs"
 msgstr "Grafikai"
 
-#: src/muuli_wdr.cpp:1814 src/muuli_wdr.cpp:1876
+#: src/muuli_wdr.cpp:1821 src/muuli_wdr.cpp:1883
 msgid "Update delay : 5 secs"
 msgstr "Atnaujinimo dažnis: 5 s"
 
-#: src/muuli_wdr.cpp:1818
+#: src/muuli_wdr.cpp:1825
 msgid "Time for average graph: 100 mins"
 msgstr "Vidurkių grafiko dydis: 100 min"
 
-#: src/muuli_wdr.cpp:1822
+#: src/muuli_wdr.cpp:1829
 msgid "Connections Graph Scale: 100 "
 msgstr "Ryšių grafiko skalė: 100 "
 
-#: src/muuli_wdr.cpp:1829
+#: src/muuli_wdr.cpp:1836
 msgid "Download graph scale:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1837
+#: src/muuli_wdr.cpp:1844
 msgid "Upload graph scale:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1847
+#: src/muuli_wdr.cpp:1854
 msgid "Colors: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1851
+#: src/muuli_wdr.cpp:1858
 msgid "Background"
 msgstr "Fonas"
 
-#: src/muuli_wdr.cpp:1852
+#: src/muuli_wdr.cpp:1859
 msgid "Grid"
 msgstr "Rėmeliai"
 
-#: src/muuli_wdr.cpp:1853
+#: src/muuli_wdr.cpp:1860
 msgid "Download current"
 msgstr "Dabartinė atsiuntimo sparta"
 
-#: src/muuli_wdr.cpp:1854
+#: src/muuli_wdr.cpp:1861
 msgid "Download running average"
 msgstr "Dabartinis atsiuntimo vidurkis"
 
-#: src/muuli_wdr.cpp:1855
+#: src/muuli_wdr.cpp:1862
 msgid "Download session average"
 msgstr "Seanso atsiuntimo vidurkis"
 
-#: src/muuli_wdr.cpp:1856
+#: src/muuli_wdr.cpp:1863
 msgid "Upload current"
 msgstr "Dabartinė išsiuntimo sparta"
 
-#: src/muuli_wdr.cpp:1857
+#: src/muuli_wdr.cpp:1864
 msgid "Upload running average"
 msgstr "Dabartinis išsiuntimo vidurkis"
 
-#: src/muuli_wdr.cpp:1858
+#: src/muuli_wdr.cpp:1865
 msgid "Upload session average"
 msgstr "Seanso išsiuntimo vidurkis"
 
-#: src/muuli_wdr.cpp:1859
+#: src/muuli_wdr.cpp:1866
 msgid "Active connections"
 msgstr "Aktyvūs ryšiai"
 
-#: src/muuli_wdr.cpp:1862
+#: src/muuli_wdr.cpp:1869
 #, fuzzy
 msgid "Systray Icon Speed Bar"
 msgstr "Sistemos dėklo spartos indikatorius"
 
-#: src/muuli_wdr.cpp:1863
+#: src/muuli_wdr.cpp:1870
 msgid "Kad-nodes current"
 msgstr "Dabartiniai Kademlia mazgai"
 
-#: src/muuli_wdr.cpp:1864
+#: src/muuli_wdr.cpp:1871
 msgid "Kad-nodes running"
 msgstr "Kademlia mazgų dabartinis vidurkis"
 
-#: src/muuli_wdr.cpp:1865
+#: src/muuli_wdr.cpp:1872
 msgid "Kad-nodes session"
 msgstr "Kademlia mazgų seanso vidurkis"
 
-#: src/muuli_wdr.cpp:1869 src/muuli_wdr.cpp:2296
+#: src/muuli_wdr.cpp:1876 src/muuli_wdr.cpp:2303
 msgid "Select"
 msgstr "Nurodykite spalvą"
 
-#: src/muuli_wdr.cpp:1873
+#: src/muuli_wdr.cpp:1880
 msgid "Tree"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1883
+#: src/muuli_wdr.cpp:1890
 msgid "Number of Client Versions shown (0=unlimited)"
 msgstr "Rodomų klientų versijų skaičius (0 – neribojama)"
 
-#: src/muuli_wdr.cpp:1908
+#: src/muuli_wdr.cpp:1915
 msgid "!!! WARNING !!!"
 msgstr "DĖMESIO!!!"
 
-#: src/muuli_wdr.cpp:1923
+#: src/muuli_wdr.cpp:1930
 msgid "Max new connections / 5 secs"
 msgstr "Per 5 s užmegzti ne daugiau ryšių, nei nurodyta"
 
-#: src/muuli_wdr.cpp:1925
+#: src/muuli_wdr.cpp:1932
 msgid "Concurrent Kad source lookups"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1927
+#: src/muuli_wdr.cpp:1934
 #, fuzzy
 msgid "Kad source re-search interval (minutes)"
 msgstr "FTP atnaujinimo intervalas minutėmis"
 
-#: src/muuli_wdr.cpp:1929
+#: src/muuli_wdr.cpp:1936
 #, fuzzy
 msgid "Source re-ask interval (minutes)"
 msgstr "FTP atnaujinimo intervalas minutėmis"
 
-#: src/muuli_wdr.cpp:1933
+#: src/muuli_wdr.cpp:1940
 msgid "File Buffer Size: 240000 bytes"
 msgstr "Failo buferio dydis: 240000 baitai"
 
-#: src/muuli_wdr.cpp:1937
+#: src/muuli_wdr.cpp:1944
 msgid "Use MMAP: memory-mapped file access (lower memory use)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1938
+#: src/muuli_wdr.cpp:1945
 msgid "Maps part files into memory instead of buffering them on the heap, lowering the process memory footprint. May reduce download speed on some disks; best for memory-constrained or upload-heavy hosts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1940
+#: src/muuli_wdr.cpp:1947
 msgid "Upload Queue Size: 5000 clients"
 msgstr "Išsiuntimo eilė: 5000 klientų"
 
-#: src/muuli_wdr.cpp:1944
+#: src/muuli_wdr.cpp:1951
 msgid "Server connection refresh interval: Disable"
 msgstr "Serverio ryšio atnaujinimo intervalas: išjungta"
 
-#: src/muuli_wdr.cpp:1948
+#: src/muuli_wdr.cpp:1955
 msgid "Disable computer's timed standby mode"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1967
+#: src/muuli_wdr.cpp:1974
 msgid "Skin to use: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1976
+#: src/muuli_wdr.cpp:1983
 msgid "Show \"Fast eD2k Links Handler\" in every window."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1979
+#: src/muuli_wdr.cpp:1986
 msgid "Show extended info on categories tabs"
 msgstr "Rodyti papildomą informaciją kategorijų kortelėse"
 
-#: src/muuli_wdr.cpp:1982
+#: src/muuli_wdr.cpp:1989
 #, fuzzy
 msgid "Show application version on title"
 msgstr "Rodyti siuntimo spartą failo pavadinime"
 
-#: src/muuli_wdr.cpp:1984
+#: src/muuli_wdr.cpp:1991
 msgid "Show transfer rates on title"
 msgstr "Rodyti siuntimo spartą failo pavadinime"
 
-#: src/muuli_wdr.cpp:1986
+#: src/muuli_wdr.cpp:1993
 msgid "Before application name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1988
+#: src/muuli_wdr.cpp:1995
 msgid "After application name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1991
+#: src/muuli_wdr.cpp:1998
 msgid "Show overhead bandwidth"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1995
+#: src/muuli_wdr.cpp:2002
 msgid "Vertical toolbar orientation"
 msgstr "Mygtukus išdėstyti vertikaliai"
 
-#: src/muuli_wdr.cpp:1997
+#: src/muuli_wdr.cpp:2004
 msgid "Live column sorting (auto-reorder rows as their values change)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2004
+#: src/muuli_wdr.cpp:2011
 msgid "Download Queue Files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2007
+#: src/muuli_wdr.cpp:2014
 msgid "Show progress percentage"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2013
+#: src/muuli_wdr.cpp:2020
 msgid "Show progress bar"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2016
+#: src/muuli_wdr.cpp:2023
 msgid "Flat"
 msgstr "Plokščia"
 
-#: src/muuli_wdr.cpp:2020
+#: src/muuli_wdr.cpp:2027
 msgid "Round"
 msgstr "Erdvinė"
 
-#: src/muuli_wdr.cpp:2038
+#: src/muuli_wdr.cpp:2045
 msgid "External Connection Parameters"
 msgstr "Išorinio ryšio parinktys"
 
-#: src/muuli_wdr.cpp:2041
+#: src/muuli_wdr.cpp:2048
 msgid "Accept external connections"
 msgstr "Priimti išorinius ryšius"
 
-#: src/muuli_wdr.cpp:2048 src/muuli_wdr.cpp:2107
+#: src/muuli_wdr.cpp:2055 src/muuli_wdr.cpp:2114
 msgid "IP of the listening interface:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2051
+#: src/muuli_wdr.cpp:2058
 msgid "Enter here a valid ip in the a.b.c.d format for the listening EC interface. An empty field or 0.0.0.0 will mean any interface."
 msgstr "Įrašykite išorinių ryšių besiklausančio įrenginio IP adresą a.b.c.d forma. Tuščias laukelis arba adresas 0.0.0.0 reiškia bet kokį įrenginį."
 
-#: src/muuli_wdr.cpp:2072 src/muuli_wdr.cpp:2156
+#: src/muuli_wdr.cpp:2079 src/muuli_wdr.cpp:2163
 msgid "TCP port:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2078
+#: src/muuli_wdr.cpp:2085
 msgid "Enable UPnP port forwarding on the EC port"
 msgstr "EC prievade įjungti UPnP prievadų perdavimą"
 
-#: src/muuli_wdr.cpp:2082 src/muuli_wdr.cpp:3041
+#: src/muuli_wdr.cpp:2089 src/muuli_wdr.cpp:3048
 #: src/utils/wxCas/src/wxcasprefs.cpp:167
 msgid "Password"
 msgstr "Slaptažodis"
 
-#: src/muuli_wdr.cpp:2088
+#: src/muuli_wdr.cpp:2095
 #, fuzzy
 msgid "aMule API server parameters"
 msgstr "Žiniatinklio serverio parinktys"
 
-#: src/muuli_wdr.cpp:2091
+#: src/muuli_wdr.cpp:2098
 msgid "Run amuleapi (REST API) on startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2096
+#: src/muuli_wdr.cpp:2103
 #, fuzzy
 msgid "HTTP port:"
 msgstr "TCP prievadas: %d"
 
-#: src/muuli_wdr.cpp:2110
+#: src/muuli_wdr.cpp:2117
 msgid "The interface amuleapi's HTTP server listens on. 127.0.0.1 (default) accepts only local connections; use 0.0.0.0 or a specific IP to expose it to other hosts (set an admin password below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2113
+#: src/muuli_wdr.cpp:2120
 #, fuzzy
 msgid "Admin password"
 msgstr "Tikrinamas slaptažodis\n"
 
-#: src/muuli_wdr.cpp:2118 src/muuli_wdr.cpp:2149
+#: src/muuli_wdr.cpp:2125 src/muuli_wdr.cpp:2156
 msgid "Low rights password"
 msgstr "Nepilnos prieigos slaptažodis"
 
-#: src/muuli_wdr.cpp:2126
+#: src/muuli_wdr.cpp:2133
 msgid "Web server parameters"
 msgstr "Žiniatinklio serverio parinktys"
 
-#: src/muuli_wdr.cpp:2129
+#: src/muuli_wdr.cpp:2136
 msgid "Run webserver on startup (deprecated)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2135
+#: src/muuli_wdr.cpp:2142
 msgid "Web template"
 msgstr "www šablonas"
 
-#: src/muuli_wdr.cpp:2140
+#: src/muuli_wdr.cpp:2147
 msgid "Full rights password"
 msgstr "Pilnos prieigos slaptažodis"
 
-#: src/muuli_wdr.cpp:2144
+#: src/muuli_wdr.cpp:2151
 msgid "Enable Low rights User"
 msgstr "Įjungti nepilnos prieigos naudotoją"
 
-#: src/muuli_wdr.cpp:2163
+#: src/muuli_wdr.cpp:2170
 msgid "Enable UPnP port forwarding of the web server port"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2168
+#: src/muuli_wdr.cpp:2175
 msgid "Web server UPnP TCP port (Optional)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2176
+#: src/muuli_wdr.cpp:2183
 msgid "Page Refresh Time (in secs)"
 msgstr "Puslapio atnaujinimo periodas (sekundėmis)"
 
-#: src/muuli_wdr.cpp:2183
+#: src/muuli_wdr.cpp:2190
 msgid "Enable Gzip compression"
 msgstr "Įjungti Gzip suspaudimą"
 
-#: src/muuli_wdr.cpp:2217
+#: src/muuli_wdr.cpp:2224
 #, fuzzy
 msgid "Reset page to defaults"
 msgstr "Numatyta"
 
-#: src/muuli_wdr.cpp:2218
+#: src/muuli_wdr.cpp:2225
 msgid "Reset the settings on the current page to their default values."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2220 src/muuli_wdr.cpp:2306 src/ServerWnd.cpp:274
+#: src/muuli_wdr.cpp:2227 src/muuli_wdr.cpp:2313 src/ServerWnd.cpp:274
 #: src/ServerWnd.cpp:282
 msgid "OK"
 msgstr "Gerai"
 
-#: src/muuli_wdr.cpp:2222
+#: src/muuli_wdr.cpp:2229
 msgid "Click here to apply any changes made to the preferences."
 msgstr "Patvirtinti naujai nurodytas parinktis."
 
-#: src/muuli_wdr.cpp:2225
+#: src/muuli_wdr.cpp:2232
 msgid "Reset any changes made to the preferences."
 msgstr "Atšaukti bet kokius pakeitimus."
 
-#: src/muuli_wdr.cpp:2254
+#: src/muuli_wdr.cpp:2261
 msgid "Comment :"
 msgstr "Komentaras:"
 
-#: src/muuli_wdr.cpp:2261
+#: src/muuli_wdr.cpp:2268
 msgid "Incoming Dir :"
 msgstr "Atsiųstų failų aplankas:"
 
-#: src/muuli_wdr.cpp:2270
+#: src/muuli_wdr.cpp:2277
 msgid "Change priority for new assigned files :"
 msgstr "Keisti naujai priskirtų failų prioritetą:"
 
-#: src/muuli_wdr.cpp:2274
+#: src/muuli_wdr.cpp:2281
 #, fuzzy
 msgid "Don't change"
 msgstr "Nekeisti"
 
-#: src/muuli_wdr.cpp:2286
+#: src/muuli_wdr.cpp:2293
 msgid "Select color for this Category (currently selected) :"
 msgstr "Nurodykite dabartinės kategorijos spalvą:"
 
-#: src/muuli_wdr.cpp:2353 src/muuli_wdr.cpp:2372 src/muuli_wdr.cpp:2394
+#: src/muuli_wdr.cpp:2360 src/muuli_wdr.cpp:2379 src/muuli_wdr.cpp:2401
 msgid "Click this button to reset the log."
 msgstr "Išvalyti įvykių žurnalą."
 
-#: src/muuli_wdr.cpp:2413
+#: src/muuli_wdr.cpp:2420
 msgid "Click on this button to update the servers list from URL ..."
 msgstr "Paspaudę šį mygtuką atnaujinsite serverių sąrašą iš URL..."
 
-#: src/muuli_wdr.cpp:2417
+#: src/muuli_wdr.cpp:2424
 msgid "Server list"
 msgstr "Serverių sąrašas"
 
-#: src/muuli_wdr.cpp:2421
+#: src/muuli_wdr.cpp:2428
 msgid "Enter the url to a server.met file here and press the button to the left to update the list of known servers."
 msgstr "Įrašykite server.met failo URL ir paspaudę mygtuką kairėje atnaujinsite serverių sąrašą."
 
-#: src/muuli_wdr.cpp:2426
+#: src/muuli_wdr.cpp:2433
 msgid "Add server manually: Name"
 msgstr "Įdėti serverį rankiniu būdu: pavadinimas"
 
-#: src/muuli_wdr.cpp:2429
+#: src/muuli_wdr.cpp:2436
 msgid "Enter the name of the new server here"
 msgstr "Įrašykite serverio pavadinimą"
 
-#: src/muuli_wdr.cpp:2431 src/ServerWnd.cpp:206
+#: src/muuli_wdr.cpp:2438 src/ServerWnd.cpp:206
 msgid "IP:Port"
 msgstr "IP:prievadas"
 
-#: src/muuli_wdr.cpp:2434
+#: src/muuli_wdr.cpp:2441
 msgid "Enter the IP of the server here, using the x.x.x.x format."
 msgstr "Įrašykite serverio IP adresą naudodami a.b.c.d formą."
 
-#: src/muuli_wdr.cpp:2440
+#: src/muuli_wdr.cpp:2447
 msgid "Enter the port of the server here."
 msgstr "Įrašykite serverio prievadą."
 
-#: src/muuli_wdr.cpp:2443
+#: src/muuli_wdr.cpp:2450
 msgid "Add manually a server (fill fields to the left before) ..."
 msgstr "Įdėti serverį (prieš tai užpildykite laukelius kairėje)..."
 
-#: src/muuli_wdr.cpp:2472
+#: src/muuli_wdr.cpp:2479
 msgid "aMule Log"
 msgstr "aMule žurnalas"
 
-#: src/muuli_wdr.cpp:2480
+#: src/muuli_wdr.cpp:2487
 msgid "Server Info"
 msgstr "Serverio informacija"
 
-#: src/muuli_wdr.cpp:2484
+#: src/muuli_wdr.cpp:2491
 msgid "ED2K Info"
 msgstr "ED2K informacija"
 
-#: src/muuli_wdr.cpp:2488
+#: src/muuli_wdr.cpp:2495
 msgid "Kad Info"
 msgstr "Kademlia informacija"
 
-#: src/muuli_wdr.cpp:2516
+#: src/muuli_wdr.cpp:2523
 msgid "Click on this button to update the nodes list from URL ..."
 msgstr "Spragtelėję šį mygtuką atnaujinsite mazgų sąrašą iš URL..."
 
-#: src/muuli_wdr.cpp:2520
+#: src/muuli_wdr.cpp:2527
 msgid "Nodes (0)"
 msgstr "Mazgai (0)"
 
-#: src/muuli_wdr.cpp:2524
+#: src/muuli_wdr.cpp:2531
 msgid "Enter the url to a nodes.dat file here and press the button to the left to update the list of known nodes."
 msgstr "Įrašykite nodes.dat failo URL ir paspaudę mygtuką kairėje atnaujinsite mazgų sąrašą."
 
-#: src/muuli_wdr.cpp:2527
+#: src/muuli_wdr.cpp:2534
 msgid "Nodes stats"
 msgstr "Mazgų statistika"
 
-#: src/muuli_wdr.cpp:2569
+#: src/muuli_wdr.cpp:2576
 msgid "Bootstrap"
 msgstr "Inicializavimas"
 
-#: src/muuli_wdr.cpp:2572
+#: src/muuli_wdr.cpp:2579
 msgid "New node"
 msgstr "Naujas mazgas"
 
-#: src/muuli_wdr.cpp:2577
+#: src/muuli_wdr.cpp:2584
 msgid "IP:"
 msgstr "IP:"
 
-#: src/muuli_wdr.cpp:2597
+#: src/muuli_wdr.cpp:2604
 msgid "Port:"
 msgstr "Prievadas:"
 
-#: src/muuli_wdr.cpp:2610
+#: src/muuli_wdr.cpp:2617
 #, fuzzy
 msgid "Bootstrap from known clients"
 msgstr ""
 "Inicializuoti iš \n"
 "žinomų klientų"
 
-#: src/muuli_wdr.cpp:2612
+#: src/muuli_wdr.cpp:2619
 msgid "Disconnect Kad"
 msgstr "Atjungti Kademlia"
 
-#: src/muuli_wdr.cpp:2646
+#: src/muuli_wdr.cpp:2653
 msgid "Use Secure User Identification"
 msgstr "Naudoti saugų kliento atpažinimą"
 
-#: src/muuli_wdr.cpp:2648
+#: src/muuli_wdr.cpp:2655
 msgid "It is recommended to enable this option. You will not receive credits if SUI is not enabled."
 msgstr "Rekomenduojama įjungti šią parinktį. Jei išjungsite, negausite kreditų."
 
-#: src/muuli_wdr.cpp:2650
+#: src/muuli_wdr.cpp:2657
 msgid "Protocol Obfuscation"
 msgstr "Protokolo slėpimas"
 
-#: src/muuli_wdr.cpp:2653
+#: src/muuli_wdr.cpp:2660
 msgid "Support Protocol Obfuscation"
 msgstr "Įjungti protokolo slėpimą"
 
-#: src/muuli_wdr.cpp:2655
+#: src/muuli_wdr.cpp:2662
 msgid "This option enabled Protocol Obfuscation, and makes aMule accept obfuscated connections from other clients."
 msgstr "Ši parinktis įjungia protokolo slėpimą. Tuomet aMule priiminės slepiamus ryšius iš kitų klientų."
 
-#: src/muuli_wdr.cpp:2657
+#: src/muuli_wdr.cpp:2664
 msgid "Use obfuscation for outgoing connections"
 msgstr "Slėpti išeinančius ryšius"
 
-#: src/muuli_wdr.cpp:2659
+#: src/muuli_wdr.cpp:2666
 msgid "This option makes aMule use Protocol Obfuscation when connecting other clients/servers."
 msgstr "Įjungus šią parinktį aMule, jungdamasi prie kitų klientų ar serverių, slėps išeinančius ryšius."
 
-#: src/muuli_wdr.cpp:2661
+#: src/muuli_wdr.cpp:2668
 msgid "Accept only obfuscated connections"
 msgstr "Priimti tik slepiamus ryšius"
 
-#: src/muuli_wdr.cpp:2662
+#: src/muuli_wdr.cpp:2669
 msgid "This option makes aMule only accept obfuscated connections. You will have less sources, but all your traffic will be obfuscated"
 msgstr "Įjungus šią parinktį aMule priims tik slepiamus ryšius. Šaltinių bus rasta mažiau, bet visas srautas bus slepiamas"
 
-#: src/muuli_wdr.cpp:2667
+#: src/muuli_wdr.cpp:2674
 msgid "Everybody"
 msgstr "Visi"
 
-#: src/muuli_wdr.cpp:2669
+#: src/muuli_wdr.cpp:2676
 msgid "No one"
 msgstr "Niekas"
 
-#: src/muuli_wdr.cpp:2671
+#: src/muuli_wdr.cpp:2678
 msgid "Who can see my shared files:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2672
+#: src/muuli_wdr.cpp:2679
 msgid "Select who can request to view a list of your shared files."
 msgstr "Nurodykite kas gali pamatyti dalinamų failų sąrašą."
 
-#: src/muuli_wdr.cpp:2674
+#: src/muuli_wdr.cpp:2681
 msgid "IP-Filtering"
 msgstr "IP filtravimas"
 
-#: src/muuli_wdr.cpp:2681
+#: src/muuli_wdr.cpp:2688
 msgid "Filter clients"
 msgstr "Filtruoti klientus"
 
-#: src/muuli_wdr.cpp:2683
+#: src/muuli_wdr.cpp:2690
 msgid "Enable filtering of the client IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "Įjungti klientų IP adresų filtravimą, aprašytą ~/.aMule/ipfilter.dat faile."
 
-#: src/muuli_wdr.cpp:2685
+#: src/muuli_wdr.cpp:2692
 msgid "Filter servers"
 msgstr "Filtruoti serverius"
 
-#: src/muuli_wdr.cpp:2687
+#: src/muuli_wdr.cpp:2694
 msgid "Enable filtering of the server IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "Įjungti serverių IP adresų filtravimą, aprašytą ~/.aMule/ipfilter.dat faile."
 
-#: src/muuli_wdr.cpp:2691
+#: src/muuli_wdr.cpp:2698
 msgid "Reload List"
 msgstr "Atnaujinti sąrašą"
 
-#: src/muuli_wdr.cpp:2692
+#: src/muuli_wdr.cpp:2699
 msgid "Reload the list of IPs to filter from the file ~/.aMule/ipfilter.dat"
 msgstr "Atnaujinti IP adresų sąrašą iš ~/.aMule/ipfilter.dat failo"
 
-#: src/muuli_wdr.cpp:2698
+#: src/muuli_wdr.cpp:2705
 msgid "URL:"
 msgstr "URL:"
 
-#: src/muuli_wdr.cpp:2702 src/muuli_wdr.cpp:2895
+#: src/muuli_wdr.cpp:2709 src/muuli_wdr.cpp:2902
 msgid "Update now"
 msgstr "Atnaujinti dabar"
 
-#: src/muuli_wdr.cpp:2705
+#: src/muuli_wdr.cpp:2712
 msgid "Auto-update ipfilter at startup"
 msgstr "Automatiškai įkelti IP filtrą paleidus programą"
 
-#: src/muuli_wdr.cpp:2709
+#: src/muuli_wdr.cpp:2716
 msgid "Filtering Level:"
 msgstr "Filtravimo lygmuo:"
 
-#: src/muuli_wdr.cpp:2715
+#: src/muuli_wdr.cpp:2722
 msgid "Always filter LAN IPs"
 msgstr "Visuomet filtruoti LAN IP adresus"
 
-#: src/muuli_wdr.cpp:2718
+#: src/muuli_wdr.cpp:2725
 msgid "Paranoid handling of non-matching IPs"
 msgstr "Paranojiškai elgtis su neatitikusiais IP adresais"
 
-#: src/muuli_wdr.cpp:2720
+#: src/muuli_wdr.cpp:2727
 msgid "Rejects a packet when its source IP differs from the IP the client claims (an anti-spoofing check). Disable only if it causes connection problems."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2722
+#: src/muuli_wdr.cpp:2729
 msgid "Use system-wide ipfilter.dat if available"
 msgstr "Jei įjungtas, naudoti ipfilter.dat failą visoje sistemoje"
 
-#: src/muuli_wdr.cpp:2723
+#: src/muuli_wdr.cpp:2730
 #, fuzzy
 msgid "If there's no local ipfilter.dat found, allow usage of a system-wide ipfilter file."
 msgstr "Jei nėra vietinio ipilter.dat failo, naudoti ipfilter.dat visoje sistemoje."
 
-#: src/muuli_wdr.cpp:2740
+#: src/muuli_wdr.cpp:2747
 msgid "Enable Online-Signature"
 msgstr "Įjungti keičiamą parašą"
 
-#: src/muuli_wdr.cpp:2742
+#: src/muuli_wdr.cpp:2749
 msgid "Enables the writing of the OS file, which can be used by external apps to create signatures and the like."
 msgstr "Įjungus šią parinktį bus įrašomas keičiamo parašo failas, kurį galite naudoti kitoje programoje parašų kūrimui ir pan."
 
-#: src/muuli_wdr.cpp:2746
+#: src/muuli_wdr.cpp:2753
 msgid "Update Frequency (Secs):"
 msgstr "Atnaujinimo dažnis (sekundėmis):"
 
-#: src/muuli_wdr.cpp:2749
+#: src/muuli_wdr.cpp:2756
 msgid "Change the frequency (in seconds) of Online Signature updates."
 msgstr "Keičiamo parašo atnaujinimo dažnis sekundėmis."
 
-#: src/muuli_wdr.cpp:2757
+#: src/muuli_wdr.cpp:2764
 msgid "Save online signature file in: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:2763
+#: src/muuli_wdr.cpp:2770
 msgid "Click here to select the directory containing the the Online Signature files."
 msgstr "Nurodykite aplanką, kuriame yra keičiamo parašo failas."
 
-#: src/muuli_wdr.cpp:2796
+#: src/muuli_wdr.cpp:2803
 msgid "Show country flags for clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2797
+#: src/muuli_wdr.cpp:2804
 msgid "Render the country flag column in the transfers, queue and search views. Requires a valid MMDB GeoIP database (see below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2802
+#: src/muuli_wdr.cpp:2809
 #, fuzzy
 msgid "Database"
 msgstr "Siuntimo sparta:"
 
-#: src/muuli_wdr.cpp:2818
+#: src/muuli_wdr.cpp:2825
 #, fuzzy
 msgid "Source:"
 msgstr "Šaltiniai"
 
-#: src/muuli_wdr.cpp:2821
+#: src/muuli_wdr.cpp:2828
 msgid "DB-IP (free, no account)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2822
+#: src/muuli_wdr.cpp:2829
 msgid "MaxMind GeoLite2 (free, account required)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2823
+#: src/muuli_wdr.cpp:2830
 msgid "Custom URL"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2826
+#: src/muuli_wdr.cpp:2833
 msgid "Choose which provider supplies the GeoIP MMDB database. DB-IP is the default - no account required. MaxMind requires a free account + license key. Use Custom URL to point at any other MMDB host (e.g. a local mirror)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2843
+#: src/muuli_wdr.cpp:2850
 msgid ""
 "No configuration required.\n"
 "\n"
@@ -4873,11 +4887,11 @@ msgid ""
 "License: Creative Commons BY 4.0 - https://creativecommons.org/licenses/by/4.0/"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2856
+#: src/muuli_wdr.cpp:2863
 msgid "License key:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2862
+#: src/muuli_wdr.cpp:2869
 msgid ""
 "Sign up for a free MaxMind account, then generate a License Key:\n"
 "https://www.maxmind.com/en/geolite2/signup\n"
@@ -4887,232 +4901,232 @@ msgid ""
 "Requires attribution and account registration; refresh at least every 30 days."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2877
+#: src/muuli_wdr.cpp:2884
 #, fuzzy
 msgid "Download URL:"
 msgstr "Atsiųsta: "
 
-#: src/muuli_wdr.cpp:2883
+#: src/muuli_wdr.cpp:2890
 msgid ""
 "Must point to an .mmdb file or a .gz / .tar.gz containing one.\n"
 "URL may include credentials (https://user:pass@host/...).\n"
 "License and attribution terms are set by the upstream URL - you are responsible."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2896
+#: src/muuli_wdr.cpp:2903
 msgid "Download the GeoIP database from the selected source."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2898
+#: src/muuli_wdr.cpp:2905
 #, fuzzy
 msgid "Auto-update on startup"
 msgstr "Automatiškai įkelti IP filtrą paleidus programą"
 
-#: src/muuli_wdr.cpp:2899
+#: src/muuli_wdr.cpp:2906
 msgid "Re-download the GeoIP database from the selected source every time aMule starts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2922
+#: src/muuli_wdr.cpp:2929
 msgid "Filter incoming messages (except current chat):"
 msgstr "Filtruoti gaunamas žinutes (išskyrus dabartinį pokalbį):"
 
-#: src/muuli_wdr.cpp:2924
+#: src/muuli_wdr.cpp:2931
 msgid "Filter all messages"
 msgstr "Filtruoti visas žinutes"
 
-#: src/muuli_wdr.cpp:2926
+#: src/muuli_wdr.cpp:2933
 msgid "Filter messages from people not on your friend list"
 msgstr "Filtruoti žinutes nuo naudotojų, nesančių draugų sąraše"
 
-#: src/muuli_wdr.cpp:2928
+#: src/muuli_wdr.cpp:2935
 msgid "Filter messages from unknown clients"
 msgstr "Filtruoti žinutes nuo nežinomų klientų"
 
-#: src/muuli_wdr.cpp:2930
+#: src/muuli_wdr.cpp:2937
 msgid "Filter messages containing (use ',' as separator):"
 msgstr "Filtruoti žinutes turinčias tekstą („,“ naudokite kaip skirtuką):"
 
-#: src/muuli_wdr.cpp:2933 src/muuli_wdr.cpp:2944
+#: src/muuli_wdr.cpp:2940 src/muuli_wdr.cpp:2951
 msgid "add here the words amule should filter and block messages including it"
 msgstr "Įrašykite žodžius, kurių aMule ieškos žinutės tekste ir filtruos žinutę"
 
-#: src/muuli_wdr.cpp:2935
+#: src/muuli_wdr.cpp:2942
 msgid "Show received messages in the log"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2938
+#: src/muuli_wdr.cpp:2945
 msgid "Comments"
 msgstr "Komentarai"
 
-#: src/muuli_wdr.cpp:2941
+#: src/muuli_wdr.cpp:2948
 msgid "Filter comments containing (use ',' as separator):"
 msgstr "Filtruoti komentarus, turinčius (atskirkite kableliu):"
 
-#: src/muuli_wdr.cpp:2966
+#: src/muuli_wdr.cpp:2973
 msgid "Enable Proxy"
 msgstr "Įjungti atstovaujančius serverius"
 
-#: src/muuli_wdr.cpp:2967
+#: src/muuli_wdr.cpp:2974
 msgid "Enable/disable proxy support"
 msgstr "Įjungti ar išjungti atstovaujančius serverius"
 
-#: src/muuli_wdr.cpp:2970
+#: src/muuli_wdr.cpp:2977
 msgid "Proxy type:"
 msgstr "Serverio tipas:"
 
-#: src/muuli_wdr.cpp:2981
+#: src/muuli_wdr.cpp:2988
 msgid "Proxy host:"
 msgstr "Serverio mazgas:"
 
-#: src/muuli_wdr.cpp:2984
+#: src/muuli_wdr.cpp:2991
 msgid "The proxy host name"
 msgstr "Atstovaujančio serverio mazgo pavadinimas"
 
-#: src/muuli_wdr.cpp:2986
+#: src/muuli_wdr.cpp:2993
 msgid "Proxy port:"
 msgstr "Serverio prievadas:"
 
-#: src/muuli_wdr.cpp:2989
+#: src/muuli_wdr.cpp:2996
 msgid "The proxy port"
 msgstr "Atstovaujančio serverio prievadas"
 
-#: src/muuli_wdr.cpp:2991
+#: src/muuli_wdr.cpp:2998
 msgid "Enable authentication"
 msgstr "Įjungti autentifikavimą"
 
-#: src/muuli_wdr.cpp:2992
+#: src/muuli_wdr.cpp:2999
 msgid "Enable/disable username/password authentication"
 msgstr "Įjungti ar išjungti naudotojo vardo ir slaptažodžio autentifikavimą"
 
-#: src/muuli_wdr.cpp:2995
+#: src/muuli_wdr.cpp:3002
 msgid "Username: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:2998
+#: src/muuli_wdr.cpp:3005
 msgid "The username to use to connect to the proxy"
 msgstr "Naudotojo vardas prisijungimui prie atstovaujančio serverio"
 
-#: src/muuli_wdr.cpp:3000
+#: src/muuli_wdr.cpp:3007
 msgid "Password:"
 msgstr "Slaptažodis:"
 
-#: src/muuli_wdr.cpp:3003
+#: src/muuli_wdr.cpp:3010
 msgid "The password to use to connect to the proxy"
 msgstr "Slaptažodis prisijungimui prie atstovaujančio serverio"
 
-#: src/muuli_wdr.cpp:3022
+#: src/muuli_wdr.cpp:3029
 msgid "Connect to:"
 msgstr "Prijungti prie:"
 
-#: src/muuli_wdr.cpp:3031
+#: src/muuli_wdr.cpp:3038
 msgid "Login to remote amule"
 msgstr "Prisijungti prie nutolusios aMule"
 
-#: src/muuli_wdr.cpp:3036
+#: src/muuli_wdr.cpp:3043
 msgid "User name"
 msgstr "Naudotojo vardas"
 
-#: src/muuli_wdr.cpp:3047
+#: src/muuli_wdr.cpp:3054
 msgid "Remember those settings"
 msgstr "Įsiminti parinktis"
 
-#: src/muuli_wdr.cpp:3050
+#: src/muuli_wdr.cpp:3057
 #, fuzzy
 msgid "Force ZLIB compression"
 msgstr "Naudoti gzip pakavimą"
 
-#: src/muuli_wdr.cpp:3074
+#: src/muuli_wdr.cpp:3081
 msgid "Enable Verbose Debug-Logging."
 msgstr "Įjungti išsamų klaidų taisymo žurnalą."
 
-#: src/muuli_wdr.cpp:3076
+#: src/muuli_wdr.cpp:3083
 #, fuzzy
 msgid "Only to Logfile"
 msgstr "&Atverti failą"
 
-#: src/muuli_wdr.cpp:3078
+#: src/muuli_wdr.cpp:3085
 msgid "Message Categories:"
 msgstr "Žinučių kategorijos:"
 
-#: src/muuli_wdr.cpp:3102 src/PartFileConvertDlg.cpp:160
+#: src/muuli_wdr.cpp:3109 src/PartFileConvertDlg.cpp:160
 msgid "Waiting..."
 msgstr "Laukiama..."
 
-#: src/muuli_wdr.cpp:3122
+#: src/muuli_wdr.cpp:3129
 msgid "Add imports"
 msgstr "Įdėti failus"
 
-#: src/muuli_wdr.cpp:3125
+#: src/muuli_wdr.cpp:3132
 msgid "Retry selected"
 msgstr "Pažymėtas bandyti iš naujo"
 
-#: src/muuli_wdr.cpp:3127
+#: src/muuli_wdr.cpp:3134
 msgid "Remove selected"
 msgstr "Pašalinti pažymėtas"
 
-#: src/muuli_wdr.cpp:3190
+#: src/muuli_wdr.cpp:3197
 msgid "Event Types"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3209
+#: src/muuli_wdr.cpp:3216
 msgid "Statistics and queued clients for selected file(s) : Session / All time"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3233
+#: src/muuli_wdr.cpp:3240
 #, fuzzy
 msgid "Active Uploads"
 msgstr "Aktyvūs išsiuntimai:"
 
-#: src/muuli_wdr.cpp:3247
+#: src/muuli_wdr.cpp:3254
 msgid "Percent of total files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3299
+#: src/muuli_wdr.cpp:3306
 #, fuzzy
 msgid "Show Clients for"
 msgstr "Rodyti klientus"
 
-#: src/muuli_wdr.cpp:3301
+#: src/muuli_wdr.cpp:3308
 #, fuzzy
 msgid "All files"
 msgstr "Slėpti dalinamus failus"
 
-#: src/muuli_wdr.cpp:3304
+#: src/muuli_wdr.cpp:3311
 #, fuzzy
 msgid "Selected files"
 msgstr "Parinkite filtrą"
 
-#: src/muuli_wdr.cpp:3307
+#: src/muuli_wdr.cpp:3314
 #, fuzzy
 msgid "Active uploads only"
 msgstr "Aktyvūs išsiuntimai"
 
-#: src/muuli_wdr.cpp:3314
+#: src/muuli_wdr.cpp:3321
 #, fuzzy
 msgid "Reload:"
 msgstr "Atnaujinti sąrašą"
 
-#: src/muuli_wdr.cpp:3318
+#: src/muuli_wdr.cpp:3325
 msgid "Reload your shared files"
 msgstr "Atnaujinti dalinamų failų sąrašą"
 
-#: src/muuli_wdr.cpp:3381
+#: src/muuli_wdr.cpp:3388
 msgid "Send"
 msgstr "Siųsti"
 
-#: src/muuli_wdr.cpp:3382
+#: src/muuli_wdr.cpp:3389
 msgid "Sends the specified message."
 msgstr "Išsiųsti įrašytą žinutę."
 
-#: src/muuli_wdr.cpp:3386
+#: src/muuli_wdr.cpp:3393
 msgid "Close this chat-session."
 msgstr "Baigti pokalbį ir užverti pokalbio kortelę."
 
-#: src/muuli_wdr.cpp:3409
+#: src/muuli_wdr.cpp:3416
 msgid "Connect to any server and/or Kad"
 msgstr "Prisijungti prie bet kurio serverio ir/ar Kademlia tinklo"
 
-#: src/muuli_wdr.cpp:3415 src/SharedFilesCtrl.cpp:142 src/Statistics.cpp:941
+#: src/muuli_wdr.cpp:3422 src/SharedFilesCtrl.cpp:142 src/Statistics.cpp:941
 msgid "Shared Files"
 msgstr "Dalinami failai"
 
@@ -5477,192 +5491,192 @@ msgstr "Atsiųsta"
 msgid "ERROR: Failed to open partfile '%s'"
 msgstr "KLAIDA: nepavyko atverti dalių failo „%s“"
 
-#: src/Preferences.cpp:673
+#: src/Preferences.cpp:674
 msgid "System default"
 msgstr "Numatyta"
 
-#: src/Preferences.cpp:674
+#: src/Preferences.cpp:675
 msgid "Albanian"
 msgstr "Albanų"
 
-#: src/Preferences.cpp:675
+#: src/Preferences.cpp:676
 msgid "Arabic"
 msgstr "Arabų"
 
-#: src/Preferences.cpp:676
+#: src/Preferences.cpp:677
 #, fuzzy
 msgid "Asturian"
 msgstr "Estų"
 
-#: src/Preferences.cpp:677
+#: src/Preferences.cpp:678
 msgid "Basque"
 msgstr "Baskų"
 
-#: src/Preferences.cpp:678
+#: src/Preferences.cpp:679
 msgid "Bulgarian"
 msgstr "Bulgarų"
 
-#: src/Preferences.cpp:679
+#: src/Preferences.cpp:680
 msgid "Catalan"
 msgstr "Katalonų"
 
-#: src/Preferences.cpp:680
+#: src/Preferences.cpp:681
 msgid "Chinese (Simplified)"
 msgstr "Kinų (supaprastinta)"
 
-#: src/Preferences.cpp:681
+#: src/Preferences.cpp:682
 msgid "Chinese (Traditional)"
 msgstr "Kinų (tradicinė)"
 
-#: src/Preferences.cpp:682
+#: src/Preferences.cpp:683
 msgid "Croatian"
 msgstr "Kroatų"
 
-#: src/Preferences.cpp:683
+#: src/Preferences.cpp:684
 msgid "Czech"
 msgstr "Čekų"
 
-#: src/Preferences.cpp:684
+#: src/Preferences.cpp:685
 msgid "Danish"
 msgstr "Danų"
 
-#: src/Preferences.cpp:685
+#: src/Preferences.cpp:686
 msgid "Dutch"
 msgstr "Olandų"
 
-#: src/Preferences.cpp:686
+#: src/Preferences.cpp:687
 msgid "English (U.K.)"
 msgstr "Anglų (DB)"
 
-#: src/Preferences.cpp:687
+#: src/Preferences.cpp:688
 #, fuzzy
 msgid "English (U.S.)"
 msgstr "Anglų (DB)"
 
-#: src/Preferences.cpp:688
+#: src/Preferences.cpp:689
 msgid "Estonian"
 msgstr "Estų"
 
-#: src/Preferences.cpp:689
+#: src/Preferences.cpp:690
 msgid "Finnish"
 msgstr "Suomių"
 
-#: src/Preferences.cpp:690
+#: src/Preferences.cpp:691
 msgid "French"
 msgstr "Prancūzų"
 
-#: src/Preferences.cpp:691
+#: src/Preferences.cpp:692
 msgid "Galician"
 msgstr "Galisijos"
 
-#: src/Preferences.cpp:692
+#: src/Preferences.cpp:693
 msgid "German"
 msgstr "Vokiečių"
 
-#: src/Preferences.cpp:693
+#: src/Preferences.cpp:694
 msgid "Greek"
 msgstr "Graikų"
 
-#: src/Preferences.cpp:694
+#: src/Preferences.cpp:695
 msgid "Hebrew"
 msgstr "Žydų"
 
-#: src/Preferences.cpp:695
+#: src/Preferences.cpp:696
 msgid "Hungarian"
 msgstr "Vengrų"
 
-#: src/Preferences.cpp:696
+#: src/Preferences.cpp:697
 msgid "Italian"
 msgstr "Italų"
 
-#: src/Preferences.cpp:697
+#: src/Preferences.cpp:698
 msgid "Japanese"
 msgstr "Japonų"
 
-#: src/Preferences.cpp:698
+#: src/Preferences.cpp:699
 msgid "Korean"
 msgstr "Korėjiečių"
 
-#: src/Preferences.cpp:699
+#: src/Preferences.cpp:700
 msgid "Latvian"
 msgstr ""
 
-#: src/Preferences.cpp:700
+#: src/Preferences.cpp:701
 msgid "Lithuanian"
 msgstr "Lietuvių"
 
-#: src/Preferences.cpp:701
+#: src/Preferences.cpp:702
 msgid "Norwegian (Nynorsk)"
 msgstr "Norvegų (naujoji norvegų)"
 
-#: src/Preferences.cpp:702
+#: src/Preferences.cpp:703
 msgid "Polish"
 msgstr "Lenkų"
 
-#: src/Preferences.cpp:703
+#: src/Preferences.cpp:704
 msgid "Portuguese"
 msgstr "Portugalų"
 
-#: src/Preferences.cpp:704
+#: src/Preferences.cpp:705
 msgid "Portuguese (Brazilian)"
 msgstr "Portugalų (Brazilijos)"
 
-#: src/Preferences.cpp:705
+#: src/Preferences.cpp:706
 #, fuzzy
 msgid "Romanian"
 msgstr "Albanų"
 
-#: src/Preferences.cpp:706
+#: src/Preferences.cpp:707
 msgid "Russian"
 msgstr "Rusų"
 
-#: src/Preferences.cpp:707
+#: src/Preferences.cpp:708
 msgid "Slovenian"
 msgstr "Slovėnų"
 
-#: src/Preferences.cpp:708
+#: src/Preferences.cpp:709
 msgid "Spanish"
 msgstr "Ispanų"
 
-#: src/Preferences.cpp:709
+#: src/Preferences.cpp:710
 msgid "Swedish"
 msgstr "Švedų"
 
-#: src/Preferences.cpp:710
+#: src/Preferences.cpp:711
 msgid "Turkish"
 msgstr "Turkų"
 
-#: src/Preferences.cpp:711
+#: src/Preferences.cpp:712
 msgid "Ukrainian"
 msgstr ""
 
-#: src/Preferences.cpp:814
+#: src/Preferences.cpp:815
 #, fuzzy
 msgid "Change Language"
 msgstr "Kalba"
 
-#: src/Preferences.cpp:878
+#: src/Preferences.cpp:879
 msgid "There are no translations installed for aMule"
 msgstr ""
 
-#: src/Preferences.cpp:879
+#: src/Preferences.cpp:880
 #, fuzzy
 msgid "No languages available"
 msgstr "Nėra"
 
-#: src/Preferences.cpp:1010
+#: src/Preferences.cpp:1011
 msgid "no options available"
 msgstr ""
 
-#: src/Preferences.cpp:2179
+#: src/Preferences.cpp:2182
 msgid "Invalid category found, skipping"
 msgstr ""
 
-#: src/Preferences.cpp:2348
+#: src/Preferences.cpp:2351
 msgid "TCP port can't be higher than 65532 due to server UDP socket being TCP+3"
 msgstr "TCP prievadas negali būti didesnis nei 65532, nes serverio UDP prievadas yra TCP+3"
 
-#: src/Preferences.cpp:2349
+#: src/Preferences.cpp:2352
 #, c-format
 msgid "Default port will be used (%d)"
 msgstr "Bus naudojamas numatytas prievadas (%d)"
@@ -6178,24 +6192,28 @@ msgstr "Atnaujinti dalinamų failų sąrašą."
 msgid "Shared folder"
 msgstr "Dalinami failai"
 
-#: src/SearchDlg.cpp:425
+#: src/SearchDlg.cpp:280
+msgid "Clear search history"
+msgstr ""
+
+#: src/SearchDlg.cpp:584
 msgid "It's impossible to search when both eD2k and Kademlia are disabled."
 msgstr ""
 
-#: src/SearchDlg.cpp:426 src/SearchListCtrl.cpp:858
+#: src/SearchDlg.cpp:585 src/SearchListCtrl.cpp:858
 #, fuzzy
 msgid "Search error"
 msgstr "Paieška"
 
-#: src/SearchDlg.cpp:768
+#: src/SearchDlg.cpp:929
 msgid "Min size must be smaller than max size. Max size ignored."
 msgstr "Apatinė dydžio riba turi būti mažesnė už viršutinę dydžio ribą. Įvestos viršutinės ribos nebus paisoma."
 
-#: src/SearchDlg.cpp:769 src/SearchDlg.cpp:851
+#: src/SearchDlg.cpp:930 src/SearchDlg.cpp:1012
 msgid "Search warning"
 msgstr "Dėmesio"
 
-#: src/SearchDlg.cpp:929 src/SearchListCtrl.cpp:735
+#: src/SearchDlg.cpp:1092 src/SearchListCtrl.cpp:735
 msgid "Main"
 msgstr "Pagrindinė"
 

--- a/po/lt.po
+++ b/po/lt.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-28 10:19+0200\n"
+"POT-Creation-Date: 2026-07-28 12:17+0200\n"
 "PO-Revision-Date: 2026-07-27 11:41+0000\n"
 "Last-Translator: Dovydas Sankauskas <laisve@gmail.com>\n"
 "Language-Team: Lithuanian <komp_lt@konf.lt>\n"
@@ -201,162 +201,162 @@ msgstr "Nepavyko atverti %s (%s)"
 msgid "WARNING: You can't add yourself as a source for an eD2k link while having a lowid."
 msgstr "DĖMESIO: jei jūsų ID yra žemas, negalite įdėti savęs prie eD2k nuorodos šaltinių."
 
-#: src/amule.cpp:300
+#: src/amule.cpp:301
 #, fuzzy
 msgid "Now, exiting main app..."
 msgstr ""
 "\n"
 "Darbas baigiamas %s...\n"
 
-#: src/amule.cpp:330
+#: src/amule.cpp:331
 #, c-format
 msgid "Terminating amuleweb instance with pid '%d' ... "
 msgstr ""
 
-#: src/amule.cpp:334
+#: src/amule.cpp:335
 #, c-format
 msgid "Killing amuleweb instance with pid '%d' ... "
 msgstr ""
 
-#: src/amule.cpp:336 src/amule.cpp:349 src/ClientRef.cpp:180
+#: src/amule.cpp:337 src/amule.cpp:350 src/ClientRef.cpp:180
 #: src/SearchDlg.cpp:1041 src/ServerListCtrl.cpp:98
 msgid "Failed"
 msgstr "Nepavyko"
 
-#: src/amule.cpp:343
+#: src/amule.cpp:344
 #, c-format
 msgid "Terminating amuleapi instance with pid '%d' ... "
 msgstr ""
 
-#: src/amule.cpp:347
+#: src/amule.cpp:348
 #, c-format
 msgid "Killing amuleapi instance with pid '%d' ... "
 msgstr ""
 
-#: src/amule.cpp:355
+#: src/amule.cpp:356
 msgid "aMule OnExit: Terminating core."
 msgstr ""
 
-#: src/amule.cpp:466
+#: src/amule.cpp:467
 #, fuzzy
 msgid "aMule shutdown completed."
 msgstr "Atsiuntimas baigtas"
 
-#: src/amule.cpp:470
+#: src/amule.cpp:471
 msgid "Memory debug results for aMule exit:"
 msgstr ""
 
-#: src/amule.cpp:651
+#: src/amule.cpp:652
 #, c-format
 msgid "Binding aMule's peer-to-peer traffic to interface: %s (HTTP updates use the default route)"
 msgstr ""
 
-#: src/amule.cpp:655
+#: src/amule.cpp:656
 #, c-format
 msgid "Binding all network traffic to interface: %s"
 msgstr ""
 
-#: src/amule.cpp:659
+#: src/amule.cpp:660
 #, c-format
 msgid "WARNING: configured network interface '%s' was not found - traffic is NOT bound to it and may leave via the default route. Check the interface name in Preferences."
 msgstr ""
 
-#: src/amule.cpp:665
+#: src/amule.cpp:666
 #, c-format
 msgid "WARNING: binding to network interface '%s' requires elevated privileges and was NOT applied - traffic may leave via the default route. Grant the capability (e.g. 'sudo setcap cap_net_raw+ep' on the aMule binary) or run with sufficient privileges."
 msgstr ""
 
-#: src/amule.cpp:673
+#: src/amule.cpp:674
 #, c-format
 msgid "WARNING: could not bind to network interface '%s' - traffic may leave via the default route."
 msgstr ""
 
-#: src/amule.cpp:732
+#: src/amule.cpp:733
 msgid "Your locale has been changed to System Default due to a configuration change. Sorry."
 msgstr "Pasikeitus parinktims aplinkos kalba buvo pakeista į sistemoje numatytą kalbą."
 
-#: src/amule.cpp:734 src/amule.cpp:1581 src/CatDialog.cpp:128
+#: src/amule.cpp:735 src/amule.cpp:1589 src/CatDialog.cpp:128
 #: src/CatDialog.cpp:136 src/CatDialog.cpp:149 src/ServerList.cpp:366
 #: src/ServerListCtrl.cpp:152
 msgid "Info"
 msgstr "Informacija"
 
-#: src/amule.cpp:741
+#: src/amule.cpp:742
 #, fuzzy
 msgid ""
 "\n"
 "EC configuration"
 msgstr "Baigimo patvirtinimas"
 
-#: src/amule.cpp:744
+#: src/amule.cpp:745
 #, fuzzy
 msgid "Password set and external connections enabled."
 msgstr "Naujas išorinis ryšys priimtas"
 
-#: src/amule.cpp:754 src/KadDlg.cpp:176 src/KadDlg.cpp:185
-#: src/PrefsUnifiedDlg.cpp:1387 src/SharedFilesCtrl.cpp:476
+#: src/amule.cpp:755 src/KadDlg.cpp:176 src/KadDlg.cpp:185
+#: src/PrefsUnifiedDlg.cpp:1461 src/SharedFilesCtrl.cpp:476
 msgid "WARNING"
 msgstr "DĖMESIO"
 
-#: src/amule.cpp:991
+#: src/amule.cpp:992
 #, fuzzy
 msgid "Network bootstrap"
 msgstr "Tinklas"
 
-#: src/amule.cpp:996
+#: src/amule.cpp:997
 msgid ""
 "aMule has detected missing network bootstrap files.\n"
 "Select which ones to download:"
 msgstr ""
 
-#: src/amule.cpp:1005 src/FirstRunWizard.cpp:411
+#: src/amule.cpp:1006 src/FirstRunWizard.cpp:411
 #, fuzzy
 msgid "eD2k server list (server.met)"
 msgstr "server.met faile rastas %i serveris"
 
-#: src/amule.cpp:1012 src/FirstRunWizard.cpp:416
+#: src/amule.cpp:1013 src/FirstRunWizard.cpp:416
 msgid "Kad bootstrap nodes (nodes.dat)"
 msgstr ""
 
-#: src/amule.cpp:1102
+#: src/amule.cpp:1103
 #, c-format
 msgid "web server running on pid %d"
 msgstr "žiniatinklio serverio pid yra %d"
 
-#: src/amule.cpp:1115
+#: src/amule.cpp:1116
 #, fuzzy
 msgid "You requested to run web server on startup, but the amuleweb binary cannot be run. Please install the package containing aMule web server, or build aMule from source with -DBUILD_WEBSERVER=YES and install it."
 msgstr "Nurodėte paleidus programą paleisti žiniatinklio serverį, bet amuleweb programos nepavyko paleisti. Įdiekite aMule žiniatinklio programos paketą arba sukompiliuokite aMule su --enable-webserver parinktimi ir paleiskite „make install“."
 
-#: src/amule.cpp:1120 src/amule.cpp:1177 src/amule.cpp:1291 src/amule.cpp:1593
+#: src/amule.cpp:1121 src/amule.cpp:1185 src/amule.cpp:1299 src/amule.cpp:1601
 #: src/amule-remote-gui.cpp:603 src/amule-remote-gui.cpp:671
 #: src/amule-remote-gui.cpp:709 src/amule-remote-gui.cpp:1282
 #: src/amule-remote-gui.cpp:1345 src/amule-remote-gui.cpp:1372
-#: src/DownloadQueue.cpp:1481
+#: src/DownloadQueue.cpp:1481 src/PrefsUnifiedDlg.cpp:1247
 msgid "ERROR"
 msgstr "KLAIDA"
 
-#: src/amule.cpp:1166
+#: src/amule.cpp:1174
 #, fuzzy, c-format
 msgid "amuleapi running on pid %d"
 msgstr "žiniatinklio serverio pid yra %d"
 
-#: src/amule.cpp:1172
+#: src/amule.cpp:1180
 #, fuzzy
 msgid "You requested to run amuleapi on startup, but the amuleapi binary cannot be run. Please install the package containing aMule's REST API server, or build aMule from source with -DBUILD_AMULEAPI=YES and install it."
 msgstr "Nurodėte paleidus programą paleisti žiniatinklio serverį, bet amuleweb programos nepavyko paleisti. Įdiekite aMule žiniatinklio programos paketą arba sukompiliuokite aMule su --enable-webserver parinktimi ir paleiskite „make install“."
 
-#: src/amule.cpp:1259
+#: src/amule.cpp:1267
 #, c-format
 msgid "Could not bind ports to the specified address: %s"
 msgstr "Nepavyko susieti prievadų su nurodytu adresu: %s"
 
-#: src/amule.cpp:1283
+#: src/amule.cpp:1291
 #, c-format
 msgid "Port %u is not available. You will be LOWID\n"
 msgstr "Prievadas %u neprieinamas. Gavote žemą ID\n"
 
-#: src/amule.cpp:1288
+#: src/amule.cpp:1296
 #, c-format
 msgid ""
 "Port %u is not available!\n"
@@ -372,48 +372,48 @@ msgstr ""
 "\n"
 "Patikrinkite sistemines tinklo parinktis ir įsitikinkite, kad nurodytas prievadas atviras tiek išsiuntimui, tiek priėmimui."
 
-#: src/amule.cpp:1385
+#: src/amule.cpp:1393
 msgid "Failed to create OnlineSig File"
 msgstr "Nepavyko sukurti keičiamo parašo failo"
 
-#: src/amule.cpp:1393
+#: src/amule.cpp:1401
 msgid "Failed to create aMule OnlineSig File"
 msgstr "Nepavyko sukurti keičiamo aMule parašo failo"
 
-#: src/amule.cpp:1556
+#: src/amule.cpp:1564
 msgid "The selected locale seems not to be installed on your box. (Note: I'll try to set it anyway)"
 msgstr "Nurodyta lokalė jūsų kompiuteryje neįdiegta. (Dėmesio: šiaip ar taip vis tiek pabandysime naudoti nurodytą lokalę)."
 
-#: src/amule.cpp:1566
+#: src/amule.cpp:1574
 #, c-format
 msgid "This is the first time you run aMule %s"
 msgstr "aMule paleista pirmą kartą %s"
 
-#: src/amule.cpp:1569
+#: src/amule.cpp:1577
 msgid "This version is a testing version, updated daily, and\n"
 msgstr "Ši versija yra darbinė versija, atnaujinama kasdien, ir\n"
 
-#: src/amule.cpp:1570
+#: src/amule.cpp:1578
 msgid "we give no warranty it won't break anything, burn your house,\n"
 msgstr "todėl negalime garantuoti, kad ji nenulūš, nepadegs namų ar\n"
 
-#: src/amule.cpp:1571
+#: src/amule.cpp:1579
 msgid "or kill your dog. But it *should* be safe to use anyway.\n"
 msgstr "nenumarins šuns. Bet šiaip ar taip ją naudoti turėtų būti saugu.\n"
 
-#: src/amule.cpp:1576
+#: src/amule.cpp:1584
 msgid "More information, support and new releases can found at our homepage,\n"
 msgstr "Daugiau informacijos, pagalbos ir naujausias galutines versijas rasite mūsų\n"
 
-#: src/amule.cpp:1577
+#: src/amule.cpp:1585
 msgid "at https://amule-org.github.io, or in our IRC channel #aMule at irc.libera.chat.\n"
 msgstr "svetainėje https://amule-org.github.io arba IRC kanale #aMule serveryje irc.libera.chat.\n"
 
-#: src/amule.cpp:1579
+#: src/amule.cpp:1587
 msgid "Feel free to report any bugs to https://github.com/amule-org/amule/issues"
 msgstr "Nesikuklinkite pranešti rastas klaidas adresu https://github.com/amule-org/amule/issues"
 
-#: src/amule.cpp:1591
+#: src/amule.cpp:1599
 msgid ""
 "The folder for Online Signature files you specified is INVALID!\n"
 " OnlineSignature will be DISABLED until you fix it on preferences."
@@ -421,138 +421,138 @@ msgstr ""
 "Neteisingai nurodėte keičiamo parašo aplanką!\n"
 "Keičiamas parašas bus išjungtas tol, kol pakeisite parinktis."
 
-#: src/amule.cpp:1654
+#: src/amule.cpp:1662
 #, fuzzy
 msgid "Server hostname notified"
 msgstr "Serverio pavadinimas:"
 
-#: src/amule.cpp:2031
+#: src/amule.cpp:2039
 #, c-format
 msgid "Disk space preallocation for file '%s' failed: %s"
 msgstr "Nepavyko paskirti disko vietos failui „%s“: %s"
 
-#: src/amule.cpp:2160
+#: src/amule.cpp:2168
 msgid "ERROR: can't open logfile"
 msgstr "KLAIDA: nepavyko atverti žurnalo failo"
 
-#: src/amule.cpp:2164
+#: src/amule.cpp:2172
 msgid "WARNING: logfile is empty. Something is wrong."
 msgstr "DĖMESIO: žurnalas tuščias. Kažkas čia ne taip."
 
-#: src/amule.cpp:2181
+#: src/amule.cpp:2189
 msgid "Log has been reset"
 msgstr "Žurnalas išvalytas"
 
-#: src/amule.cpp:2205
+#: src/amule.cpp:2213
 #, c-format
 msgid "ServerMessage: %s"
 msgstr "Serverio pranešimas: %s"
 
-#: src/amule.cpp:2248 src/IP2Country.cpp:220 src/IPFilter.cpp:514
+#: src/amule.cpp:2256 src/IP2Country.cpp:220 src/IPFilter.cpp:514
 #: src/ServerList.cpp:875
 #, c-format
 msgid "Skipped download of %s, because requested file is not newer."
 msgstr ""
 
-#: src/amule.cpp:2251
+#: src/amule.cpp:2259
 msgid "Failed to download the nodes list."
 msgstr "Nepavyko atsiųsti mazgų sąrašo."
 
-#: src/amule.cpp:2314
+#: src/amule.cpp:2322
 msgid "Failed to open the downloaded version check file"
 msgstr "Nepavyko atverti atsiųstos versijos tikrinimo failo"
 
-#: src/amule.cpp:2317 src/amule.cpp:2336
+#: src/amule.cpp:2325 src/amule.cpp:2344
 msgid "Corrupted version check file"
 msgstr "Sugadintas versijos tikrinimo failas"
 
-#: src/amule.cpp:2359
+#: src/amule.cpp:2367
 msgid "You are using an outdated version of aMule!"
 msgstr "Naudojate pasenusią aMule versiją!"
 
-#: src/amule.cpp:2361
+#: src/amule.cpp:2369
 #, c-format
 msgid "Your aMule version is %i.%i.%i and the latest version is %li.%li.%li"
 msgstr "Ši aMule versija yra %i.%i.%i, o naujausia versija yra %li.%li.%li"
 
-#: src/amule.cpp:2365
+#: src/amule.cpp:2373
 msgid "The latest version can always be found at https://github.com/amule-org/amule/releases/latest"
 msgstr "Naujausią versiją bet kada galima atsisiųsti iš https://github.com/amule-org/amule/releases/latest"
 
-#: src/amule.cpp:2368
+#: src/amule.cpp:2376
 #, c-format
 msgid "WARNING: Your aMuled version is outdated: %i.%i.%i < %li.%li.%li"
 msgstr "DĖMESIO: ši aMule versija yra pasenusi: %i.%i.%i < %li.%li.%li"
 
-#: src/amule.cpp:2374
+#: src/amule.cpp:2382
 msgid "Your copy of aMule is up to date."
 msgstr "Naudojate naują aMule versiją."
 
-#: src/amule.cpp:2381
+#: src/amule.cpp:2389
 msgid "Failed to download the version check file"
 msgstr "Nepavyko atsiųsti versijos tikrinimo failo"
 
-#: src/amule.cpp:2550 src/amule-remote-gui.cpp:1133
+#: src/amule.cpp:2558 src/amule-remote-gui.cpp:1133
 #, c-format
 msgid "Users: %s | Files: %s"
 msgstr "Naudotojai: %s | Failai: %s"
 
-#: src/amule.cpp:2551 src/amule-remote-gui.cpp:1134
+#: src/amule.cpp:2559 src/amule-remote-gui.cpp:1134
 #, c-format
 msgid "Users: E: %s K: %s | Files: E: %s K: %s"
 msgstr "Naudotojai: eD2k: %s Kad: %s | Failai: eD2k: %s Kad: %s"
 
-#: src/amule.cpp:2565 src/amule-remote-gui.cpp:1147
+#: src/amule.cpp:2573 src/amule-remote-gui.cpp:1147
 msgid "No networks selected"
 msgstr "Neparinktas joks tinklas"
 
-#: src/amule.cpp:2633 src/TextClient.cpp:903
+#: src/amule.cpp:2641 src/TextClient.cpp:903
 msgid "with LowID"
 msgstr "žemas ID"
 
-#: src/amule.cpp:2633 src/TextClient.cpp:904
+#: src/amule.cpp:2641 src/TextClient.cpp:904
 msgid "with HighID"
 msgstr "aukštas ID"
 
-#: src/amule.cpp:2635
+#: src/amule.cpp:2643
 #, c-format
 msgid "Connected to %s %s"
 msgstr "Prisijungta prie %s %s"
 
-#: src/amule.cpp:2640
+#: src/amule.cpp:2648
 #, c-format
 msgid "Connecting to %s"
 msgstr "Jungiamasi prie %s"
 
-#: src/amule.cpp:2642
+#: src/amule.cpp:2650
 msgid "Disconnected from eD2k"
 msgstr "Atsijungta nuo eD2k"
 
-#: src/amule.cpp:2651
+#: src/amule.cpp:2659
 msgid "Kad started."
 msgstr "Kademlia paleista."
 
-#: src/amule.cpp:2653
+#: src/amule.cpp:2661
 msgid "Kad stopped."
 msgstr "Kademlia sustabdyta."
 
-#: src/amule.cpp:2661
+#: src/amule.cpp:2669
 msgid "Connected to Kad (ok)"
 msgstr "Prisijungta prie Kademlia"
 
-#: src/amule.cpp:2663
+#: src/amule.cpp:2671
 msgid "Connected to Kad (firewalled)"
 msgstr "Prisijungta prie Kademlia (už ugniasienės)"
 
-#: src/amule.cpp:2667
+#: src/amule.cpp:2675
 msgid "Disconnected from Kad"
 msgstr "Atsijungta nuo Kademlia"
 
-#: src/amule.cpp:2699
+#: src/amule.cpp:2707
 msgid "Kad network cannot be used if UDP port is disabled on preferences, not starting."
 msgstr "Nepavyks prisijungti prie Kademlia tinklo, jei parinktyse yra išjungtas UDP prievadas."
 
-#: src/amule.cpp:2703
+#: src/amule.cpp:2711
 msgid "Kad network disabled on preferences, not connecting."
 msgstr "Kademlia tinklas išjungtas parinktyse, ryšys nebus užmezgamas."
 
@@ -597,36 +597,36 @@ msgid "FATAL ERROR: Failed to create Timer"
 msgstr "KRITINĖ KLAIDA: nepavyko sukurti laiko skaitliuko"
 
 #: src/amuleDlg.cpp:361 src/amuleDlg.cpp:1787 src/amuleDlg.cpp:2033
-#: src/muuli_wdr.cpp:1492 src/muuli_wdr.cpp:3418
+#: src/muuli_wdr.cpp:1492 src/muuli_wdr.cpp:3449
 msgid "Networks"
 msgstr "Tinklas"
 
-#: src/amuleDlg.cpp:362 src/amuleDlg.cpp:1793 src/muuli_wdr.cpp:3419
+#: src/amuleDlg.cpp:362 src/amuleDlg.cpp:1793 src/muuli_wdr.cpp:3450
 msgid "Searches"
 msgstr "Paieška"
 
 #: src/amuleDlg.cpp:363 src/amuleDlg.cpp:1799 src/DownloadListCtrl.cpp:740
-#: src/muuli_wdr.cpp:392 src/muuli_wdr.cpp:1585 src/muuli_wdr.cpp:3420
+#: src/muuli_wdr.cpp:392 src/muuli_wdr.cpp:1585 src/muuli_wdr.cpp:3451
 #: src/Statistics.cpp:829
 msgid "Downloads"
 msgstr "Siuntimai"
 
-#: src/amuleDlg.cpp:364 src/amuleDlg.cpp:1805 src/muuli_wdr.cpp:3294
+#: src/amuleDlg.cpp:364 src/amuleDlg.cpp:1805 src/muuli_wdr.cpp:3325
 msgid "Shared files"
 msgstr "Dalinami failai"
 
-#: src/amuleDlg.cpp:365 src/amuleDlg.cpp:1811 src/muuli_wdr.cpp:2926
-#: src/muuli_wdr.cpp:3376 src/muuli_wdr.cpp:3423
+#: src/amuleDlg.cpp:365 src/amuleDlg.cpp:1811 src/muuli_wdr.cpp:2957
+#: src/muuli_wdr.cpp:3407 src/muuli_wdr.cpp:3454
 msgid "Messages"
 msgstr "Žinutės"
 
-#: src/amuleDlg.cpp:366 src/amuleDlg.cpp:1817 src/muuli_wdr.cpp:3424
-#: src/PrefsUnifiedDlg.cpp:312 src/Statistics.cpp:779 src/Statistics.cpp:1235
+#: src/amuleDlg.cpp:366 src/amuleDlg.cpp:1817 src/muuli_wdr.cpp:3455
+#: src/PrefsUnifiedDlg.cpp:314 src/Statistics.cpp:779 src/Statistics.cpp:1235
 msgid "Statistics"
 msgstr "Statistika"
 
-#: src/amuleDlg.cpp:368 src/amuleDlg.cpp:1824 src/muuli_wdr.cpp:3426
-#: src/PrefsUnifiedDlg.cpp:328 src/utils/wxCas/src/wxcasprefs.cpp:39
+#: src/amuleDlg.cpp:368 src/amuleDlg.cpp:1824 src/muuli_wdr.cpp:3457
+#: src/PrefsUnifiedDlg.cpp:330 src/utils/wxCas/src/wxcasprefs.cpp:39
 msgid "Preferences"
 msgstr "Parinktys"
 
@@ -684,8 +684,8 @@ msgstr "Kad: išjungta"
 #: src/amuleDlg.cpp:1029 src/DownloadListCtrl.cpp:505
 #: src/DownloadListCtrl.cpp:749 src/FriendListCtrl.cpp:180
 #: src/muuli_wdr.cpp:731 src/muuli_wdr.cpp:782 src/muuli_wdr.cpp:846
-#: src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2231 src/muuli_wdr.cpp:2316
-#: src/muuli_wdr.cpp:3064 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
+#: src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2262 src/muuli_wdr.cpp:2347
+#: src/muuli_wdr.cpp:3095 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
 #: src/ServerListCtrl.cpp:606 src/TransferWnd.cpp:378
 #: src/utils/wxCas/src/wxcasprefs.cpp:235
 msgid "Cancel"
@@ -696,7 +696,7 @@ msgid "Stop the current connection attempts"
 msgstr "Nutraukti bandymus prisijungti"
 
 #: src/amuleDlg.cpp:1035 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976
-#: src/muuli_wdr.cpp:2454
+#: src/muuli_wdr.cpp:2485
 msgid "Disconnect"
 msgstr "Atsijungti"
 
@@ -705,7 +705,7 @@ msgid "Disconnect from the currently connected networks"
 msgstr "Atsijungti nuo pasirinktų tinklų"
 
 #: src/amuleDlg.cpp:1041 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979
-#: src/muuli_wdr.cpp:2609 src/muuli_wdr.cpp:3061 src/muuli_wdr.cpp:3416
+#: src/muuli_wdr.cpp:2640 src/muuli_wdr.cpp:3092 src/muuli_wdr.cpp:3447
 msgid "Connect"
 msgstr "Prisijungti"
 
@@ -760,7 +760,7 @@ msgstr "Baigimo patvirtinimas"
 msgid "Launch Command: "
 msgstr ""
 
-#: src/amuleDlg.cpp:1632 src/muuli_wdr.cpp:1978 src/Preferences.cpp:952
+#: src/amuleDlg.cpp:1632 src/muuli_wdr.cpp:1982 src/Preferences.cpp:979
 msgid "- default -"
 msgstr ""
 
@@ -774,49 +774,49 @@ msgstr "Išvaizdos failų aplankas %s neegzistuoja"
 msgid "WARNING: Unable to open skin file '%s' for read"
 msgstr "DĖMESIO: nepavyko atverti temos failo „%s“ skaitymui"
 
-#: src/amuleDlg.cpp:1791 src/muuli_wdr.cpp:3418
+#: src/amuleDlg.cpp:1791 src/muuli_wdr.cpp:3449
 msgid "Networks Window"
 msgstr "Tinklo langas"
 
-#: src/amuleDlg.cpp:1797 src/muuli_wdr.cpp:3419
+#: src/amuleDlg.cpp:1797 src/muuli_wdr.cpp:3450
 msgid "Searches Window"
 msgstr "Paieškos langas"
 
-#: src/amuleDlg.cpp:1803 src/muuli_wdr.cpp:3420
+#: src/amuleDlg.cpp:1803 src/muuli_wdr.cpp:3451
 #, fuzzy
 msgid "Downloads Window"
 msgstr "Atsiunčiama"
 
-#: src/amuleDlg.cpp:1809 src/muuli_wdr.cpp:3422
+#: src/amuleDlg.cpp:1809 src/muuli_wdr.cpp:3453
 msgid "Shared Files Window"
 msgstr "Dalinamų failų langas"
 
-#: src/amuleDlg.cpp:1815 src/muuli_wdr.cpp:3423
+#: src/amuleDlg.cpp:1815 src/muuli_wdr.cpp:3454
 msgid "Messages Window"
 msgstr "Žinučių langas"
 
-#: src/amuleDlg.cpp:1821 src/muuli_wdr.cpp:3424
+#: src/amuleDlg.cpp:1821 src/muuli_wdr.cpp:3455
 msgid "Statistics Graph Window"
 msgstr "Statistikos grafikų langas"
 
-#: src/amuleDlg.cpp:1828 src/muuli_wdr.cpp:3426
+#: src/amuleDlg.cpp:1828 src/muuli_wdr.cpp:3457
 msgid "Preferences Settings Window"
 msgstr "Parinkčių langas"
 
-#: src/amuleDlg.cpp:1831 src/muuli_wdr.cpp:3427
+#: src/amuleDlg.cpp:1831 src/muuli_wdr.cpp:3458
 msgid "Import"
 msgstr "Įkelti"
 
-#: src/amuleDlg.cpp:1835 src/muuli_wdr.cpp:3427
+#: src/amuleDlg.cpp:1835 src/muuli_wdr.cpp:3458
 msgid "The partfile importer tool"
 msgstr "Dalinai atsiųstų failų įkėlimo įrankis"
 
-#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3428
+#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3459
 #: src/utils/aLinkCreator/src/alcframe.cpp:262
 msgid "About"
 msgstr "Apie"
 
-#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3428
+#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3459
 msgid "About/Help"
 msgstr "Apie/pagalba"
 
@@ -962,7 +962,7 @@ msgstr "Failas nerastas."
 msgid "The core rejected these shared folders:%s"
 msgstr ""
 
-#: src/amule-remote-gui.cpp:1336 src/ExternalConn.cpp:2345
+#: src/amule-remote-gui.cpp:1336 src/ExternalConn.cpp:2346
 msgid "Invalid link or already on list."
 msgstr "Klaidinga nuoroda arba failas sąraše jau yra."
 
@@ -978,7 +978,7 @@ msgstr ""
 #: src/ClientDetailDialog.cpp:123 src/DataToText.cpp:61 src/DataToText.cpp:86
 #: src/DataToText.cpp:101 src/DataToText.cpp:136 src/DataToText.cpp:165
 #: src/DownloadListCtrl.cpp:1172 src/DownloadListCtrl.cpp:1185
-#: src/DownloadListCtrl.cpp:1196 src/ExternalConn.cpp:608
+#: src/DownloadListCtrl.cpp:1196 src/ExternalConn.cpp:609
 #: src/FileDetailDialog.cpp:203 src/FileDetailDialog.cpp:235
 #: src/FileDetailDialog.cpp:242 src/GenericClientListCtrl.cpp:1171
 #: src/GenericClientListCtrl.cpp:1182 src/GenericClientListCtrl.cpp:1192
@@ -1370,19 +1370,19 @@ msgstr "Automatiškai (aukštas)"
 msgid "Very low"
 msgstr "Labai žemas"
 
-#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:743 src/muuli_wdr.cpp:2282
+#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:743 src/muuli_wdr.cpp:2313
 #: src/ServerListCtrl.cpp:263 src/ServerListCtrl.cpp:456
 #: src/SharedFilesCtrl.cpp:145
 msgid "Low"
 msgstr "Žemas"
 
-#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:744 src/muuli_wdr.cpp:2283
+#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:744 src/muuli_wdr.cpp:2314
 #: src/ServerListCtrl.cpp:266 src/ServerListCtrl.cpp:457
 #: src/SharedFilesCtrl.cpp:146
 msgid "Normal"
 msgstr "Normalus"
 
-#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:745 src/muuli_wdr.cpp:2284
+#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:745 src/muuli_wdr.cpp:2315
 #: src/ServerListCtrl.cpp:269 src/ServerListCtrl.cpp:458
 #: src/SharedFilesCtrl.cpp:147
 msgid "High"
@@ -1474,7 +1474,7 @@ msgstr "Vietinis serveris"
 msgid "Remote Server"
 msgstr "Nutolęs serveris"
 
-#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3181
+#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3212
 #: src/SearchDlg.cpp:119 src/TextClient.cpp:911
 msgid "Kad"
 msgstr "Kademlia"
@@ -1546,7 +1546,7 @@ msgstr ""
 msgid "Size"
 msgstr "Dydis"
 
-#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3248
+#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3279
 msgid "Transferred"
 msgstr "Persiųsta"
 
@@ -1604,7 +1604,7 @@ msgstr ""
 "Atsakymas iš: %s (%s)\n"
 "\n"
 
-#: src/DownloadListCtrl.cpp:746 src/muuli_wdr.cpp:2285
+#: src/DownloadListCtrl.cpp:746 src/muuli_wdr.cpp:2316
 #: src/SharedFilesCtrl.cpp:150
 msgid "Auto"
 msgstr "Automatiškas"
@@ -1642,7 +1642,7 @@ msgid "Extended Options"
 msgstr "Papildomi veiksmai"
 
 #: src/DownloadListCtrl.cpp:770 src/DownloadListCtrl.cpp:822
-#: src/muuli_wdr.cpp:1796
+#: src/muuli_wdr.cpp:1800
 msgid "Preview"
 msgstr "Peržiūra"
 
@@ -1819,232 +1819,237 @@ msgstr[2] ""
 msgid "Invalid eD2k link! ERROR: %s"
 msgstr "Klaidinga eD2k nuoroda! KLAIDA: %s"
 
-#: src/ExternalConn.cpp:379
+#: src/ExternalConn.cpp:380
 #, fuzzy
 msgid "Client sent packet after authentication failed."
 msgstr "Patvirtinimas nepavyko."
 
-#: src/ExternalConn.cpp:396
+#: src/ExternalConn.cpp:397
 msgid "External connection closed."
 msgstr "Išorinis ryšys nutrauktas."
 
-#: src/ExternalConn.cpp:473
+#: src/ExternalConn.cpp:474
 msgid "External connections disabled due to empty password!"
 msgstr "Išoriniai ryšiai atjungti, nes slaptažodis tuščias!"
 
-#: src/ExternalConn.cpp:494
+#: src/ExternalConn.cpp:495
 msgid "External connections disabled in config file"
 msgstr "Išoriniai ryšiai atjungti parinkčių faile"
 
-#: src/ExternalConn.cpp:575
+#: src/ExternalConn.cpp:576
 msgid "New external connection accepted"
 msgstr "Naujas išorinis ryšys priimtas"
 
-#: src/ExternalConn.cpp:578
+#: src/ExternalConn.cpp:579
 msgid "ERROR: couldn't accept a new external connection"
 msgstr "KLAIDA: nepavyko priimti išorinio ryšio"
 
-#: src/ExternalConn.cpp:595
+#: src/ExternalConn.cpp:596
 msgid "External connection refused due to empty password in preferences!"
 msgstr "Išorinis ryšys nepriimtas, nes parinktyse nurodytas tuščias slaptažodis!"
 
-#: src/ExternalConn.cpp:607
+#: src/ExternalConn.cpp:608
 #, c-format
 msgid "Connecting client: %s %s"
 msgstr "Jungiasi klientas: %s %s"
 
-#: src/ExternalConn.cpp:609
+#: src/ExternalConn.cpp:610
 msgid "Unknown version"
 msgstr "Nežinoma versija"
 
-#: src/ExternalConn.cpp:622
+#: src/ExternalConn.cpp:623
 msgid "Incorrect EC version ID, there might be binary incompatibility. Use core and remote from same snapshot."
 msgstr "Klaidingos išorinių ryšių versijos, taip gali būti dėl skirtingų programų. Programos branduolį ir nutolusią aplinką naudokite kompiliuotą iš tos pačios pradinio kodo versijos."
 
-#: src/ExternalConn.cpp:630
+#: src/ExternalConn.cpp:631
 #, fuzzy
 msgid "You cannot connect to a release version from an arbitrary development snapshot! *sigh* possible crash prevented"
 msgstr "Nepavyks prie galutinės leidimo versijos prisijungti iš SVN versijos! Ech, buvo išvengta galimo programos lūžimo"
 
-#: src/ExternalConn.cpp:713
+#: src/ExternalConn.cpp:714
 msgid "Invalid protocol version."
 msgstr "Neteisinga protokolo versija."
 
-#: src/ExternalConn.cpp:719
+#: src/ExternalConn.cpp:720
 msgid "Missing protocol version tag."
 msgstr "Trūksta protokolo versijos žymės."
 
-#: src/ExternalConn.cpp:727
+#: src/ExternalConn.cpp:728
 msgid "Authentication failed: invalid hash specified as EC password."
 msgstr ""
 
-#: src/ExternalConn.cpp:775
+#: src/ExternalConn.cpp:776
 #, fuzzy
 msgid "Authentication failed: wrong password."
 msgstr "Patvirtinimas nepavyko."
 
-#: src/ExternalConn.cpp:777
+#: src/ExternalConn.cpp:778
 #, fuzzy
 msgid "Authentication failed: missing password."
 msgstr "Patvirtinimas nepavyko."
 
-#: src/ExternalConn.cpp:788
+#: src/ExternalConn.cpp:789
 #, fuzzy
 msgid "Invalid request, please authenticate first."
 msgstr "Klaidingas prašymas, iš pradžių turite būti atpažinti."
 
-#: src/ExternalConn.cpp:793
+#: src/ExternalConn.cpp:794
 msgid "Access granted."
 msgstr "Prieiga suteikta."
 
-#: src/ExternalConn.cpp:801
+#: src/ExternalConn.cpp:802
 #, fuzzy, c-format
 msgid "Sent error message \"%s\" to client."
 msgstr "Filtruoti žinutes nuo nežinomų klientų"
 
-#: src/ExternalConn.cpp:806
+#: src/ExternalConn.cpp:807
 #, fuzzy, c-format
 msgid "Unauthorized access attempt from %s. Connection closed."
 msgstr "Bandymas gauti prieigą. Prieiga nesuteikta, ryšys nutrauktas."
 
-#: src/ExternalConn.cpp:1419
+#: src/ExternalConn.cpp:1420
 #, c-format
 msgid "Remote PartFile command failed: FileHash not found: %s"
 msgstr "Nutolusio dalinio failo komanda nepavyko. Failo maišos funkcija nerasta: %s"
 
-#: src/ExternalConn.cpp:1423
+#: src/ExternalConn.cpp:1424
 #, c-format
 msgid "FileHash not found: %s"
 msgstr "Failo maišos funkcija nerasta: %s"
 
-#: src/ExternalConn.cpp:1470 src/ExternalConn.cpp:1558
-#: src/ExternalConn.cpp:1679
+#: src/ExternalConn.cpp:1471 src/ExternalConn.cpp:1559
+#: src/ExternalConn.cpp:1680
 msgid "OOPS! OpCode processing error!"
 msgstr "Oi! OpCode vykdymo klaida!"
 
-#: src/ExternalConn.cpp:1501
+#: src/ExternalConn.cpp:1502
 msgid "Server not added"
 msgstr "Serveris neįdėtas"
 
-#: src/ExternalConn.cpp:1520
+#: src/ExternalConn.cpp:1521
 #, c-format
 msgid "server not found: %s"
 msgstr "serveris nerastas: %s"
 
-#: src/ExternalConn.cpp:1537
+#: src/ExternalConn.cpp:1538
 msgid "need to define server to be removed"
 msgstr "Nurodykite serverį, kurį pašalinti"
 
-#: src/ExternalConn.cpp:1552
+#: src/ExternalConn.cpp:1553
 msgid "eD2k is disabled in preferences."
 msgstr "eD2k išjungtas parinktyse."
 
-#: src/ExternalConn.cpp:1657
+#: src/ExternalConn.cpp:1658
 #, fuzzy
 msgid "Friend not found."
 msgstr "Failas nerastas."
 
-#: src/ExternalConn.cpp:1667
+#: src/ExternalConn.cpp:1668
 #, fuzzy
 msgid "Client not found."
 msgstr "Failas nerastas."
 
-#: src/ExternalConn.cpp:1673
+#: src/ExternalConn.cpp:1674
 msgid "EC_TAG_FRIEND_SHARED requires EC_TAG_FRIEND or EC_TAG_CLIENT."
 msgstr ""
 
-#: src/ExternalConn.cpp:1991
+#: src/ExternalConn.cpp:1992
 msgid "WebSearch from remote interface makes no sense."
 msgstr "www paieška iš nutolusios programos neturi prasmės."
 
-#: src/ExternalConn.cpp:2026
+#: src/ExternalConn.cpp:2027
 msgid "Search in progress. Refetch results in a moment!"
 msgstr "Ieškoma. Tuoj bus gauti rezultatai!"
 
-#: src/ExternalConn.cpp:2265
+#: src/ExternalConn.cpp:2266
 msgid "No points for graph."
 msgstr "Grafikui nėra duomenų."
 
-#: src/ExternalConn.cpp:2275
+#: src/ExternalConn.cpp:2276
 msgid "Your client is not configured for this detail level."
 msgstr "Šis klientas nesuderintas pateikti tiek detalių."
 
-#: src/ExternalConn.cpp:2302
+#: src/ExternalConn.cpp:2303
 msgid "External Connection: shutdown requested"
 msgstr "Išorinis ryšys: gautas prašymas išjungti"
 
-#: src/ExternalConn.cpp:2314
+#: src/ExternalConn.cpp:2315
 msgid "Already shutting down."
 msgstr "Jau išsijungiama."
 
-#: src/ExternalConn.cpp:2332
+#: src/ExternalConn.cpp:2333
 #, c-format
 msgid "ExternalConn: adding link '%s'."
 msgstr "Išoriniai ryšiai: įdedama nuoroda %s."
 
-#: src/ExternalConn.cpp:2350
+#: src/ExternalConn.cpp:2351
 #, fuzzy, c-format
 msgid "%d of %d links failed (invalid or already on list)."
 msgstr "Klaidinga nuoroda arba failas sąraše jau yra."
 
-#: src/ExternalConn.cpp:2373
+#: src/ExternalConn.cpp:2374
 msgid "Version check throttled; try again shortly."
 msgstr ""
 
-#: src/ExternalConn.cpp:2378
+#: src/ExternalConn.cpp:2379
 msgid "Version check is not available on this daemon."
 msgstr ""
 
-#: src/ExternalConn.cpp:2508
+#: src/ExternalConn.cpp:2509
 msgid "File not found."
 msgstr "Failas nerastas."
 
-#: src/ExternalConn.cpp:2513
+#: src/ExternalConn.cpp:2514
 msgid "Invalid file name."
 msgstr "Klaidingas failo pavadinimas."
 
-#: src/ExternalConn.cpp:2521
+#: src/ExternalConn.cpp:2522
 msgid "Unable to rename file."
 msgstr "Nepavyko pervadinti failo."
 
-#: src/ExternalConn.cpp:2992 src/ExternalConn.cpp:3020
+#: src/ExternalConn.cpp:2839
+#, c-format
+msgid "Could not save the amuleapi password: %s"
+msgstr ""
+
+#: src/ExternalConn.cpp:3004 src/ExternalConn.cpp:3032
 msgid "Kad is disabled in preferences."
 msgstr "Kademlia išjungta parinktyse."
 
-#: src/ExternalConn.cpp:3033
+#: src/ExternalConn.cpp:3045
 msgid "Already connected to eD2k."
 msgstr "Prie eD2k jau prisijungta."
 
-#: src/ExternalConn.cpp:3036
+#: src/ExternalConn.cpp:3048
 msgid "Connecting to eD2k..."
 msgstr "Jungiamasi prie eD2k..."
 
-#: src/ExternalConn.cpp:3045
+#: src/ExternalConn.cpp:3057
 msgid "Already connected to Kad."
 msgstr "Prie Kademlia jau prisijungta."
 
-#: src/ExternalConn.cpp:3048
+#: src/ExternalConn.cpp:3060
 msgid "Connecting to Kad..."
 msgstr "Jungiamsi prie Kademlia..."
 
-#: src/ExternalConn.cpp:3055
+#: src/ExternalConn.cpp:3067
 msgid "All networks are disabled."
 msgstr "Visi tinklai išjungti."
 
-#: src/ExternalConn.cpp:3064
+#: src/ExternalConn.cpp:3076
 msgid "Disconnected from eD2k."
 msgstr "Atsijungta nuo eD2k."
 
-#: src/ExternalConn.cpp:3069
+#: src/ExternalConn.cpp:3081
 msgid "Disconnected from Kad."
 msgstr "Atsijungta nuo Kademlia."
 
-#: src/ExternalConn.cpp:3078
+#: src/ExternalConn.cpp:3090
 #, c-format
 msgid "External Connection: invalid opcode received: %#x"
 msgstr "Išorinis ryšys: gautas klaidingas opcode: %#x"
 
-#: src/ExternalConn.cpp:3083
+#: src/ExternalConn.cpp:3095
 msgid "Invalid opcode (wrong protocol version?)"
 msgstr "Klaidingas opcode (bloga protokolo versija?)"
 
@@ -2445,23 +2450,23 @@ msgid ""
 "want downloads on a different (e.g. larger) disk."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:549 src/FirstRunWizard.cpp:611 src/muuli_wdr.cpp:1708
+#: src/FirstRunWizard.cpp:549 src/FirstRunWizard.cpp:611 src/muuli_wdr.cpp:1712
 msgid "Destination folder for downloads"
 msgstr ""
 
 #: src/FirstRunWizard.cpp:553 src/FirstRunWizard.cpp:569 src/muuli_wdr.cpp:1349
-#: src/muuli_wdr.cpp:1366 src/muuli_wdr.cpp:1683 src/muuli_wdr.cpp:1714
-#: src/muuli_wdr.cpp:1726 src/muuli_wdr.cpp:2769
+#: src/muuli_wdr.cpp:1366 src/muuli_wdr.cpp:1687 src/muuli_wdr.cpp:1718
+#: src/muuli_wdr.cpp:1730 src/muuli_wdr.cpp:2800
 #: src/utils/aLinkCreator/src/alcframe.cpp:135
 #: src/utils/wxCas/src/wxcasprefs.cpp:52 src/utils/wxCas/src/wxcasprefs.cpp:118
 msgid "Browse"
 msgstr "Naršyti"
 
-#: src/FirstRunWizard.cpp:559 src/muuli_wdr.cpp:1719
+#: src/FirstRunWizard.cpp:559 src/muuli_wdr.cpp:1723
 msgid "(All files in this folder are shared with other peers)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:565 src/FirstRunWizard.cpp:624 src/muuli_wdr.cpp:1721
+#: src/FirstRunWizard.cpp:565 src/FirstRunWizard.cpp:624 src/muuli_wdr.cpp:1725
 msgid "Folder for temporary download files"
 msgstr ""
 
@@ -2492,7 +2497,7 @@ msgstr "Nepavyko atverti draugų sąrašo failo „emfriends.met“ rašymui!"
 msgid "CRITICAL - no client on StartChatSession"
 msgstr ""
 
-#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2675 src/muuli_wdr.cpp:3352
+#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2706 src/muuli_wdr.cpp:3383
 msgid "Friends"
 msgstr "Draugai"
 
@@ -2606,8 +2611,8 @@ msgstr "Niekas"
 msgid "No"
 msgstr "Ne"
 
-#: src/GenericClientListCtrl.cpp:1216 src/PrefsUnifiedDlg.cpp:2818
-#: src/PrefsUnifiedDlg.cpp:2868 src/ServerListCtrl.cpp:276
+#: src/GenericClientListCtrl.cpp:1216 src/PrefsUnifiedDlg.cpp:2898
+#: src/PrefsUnifiedDlg.cpp:2948 src/ServerListCtrl.cpp:276
 msgid "Yes"
 msgstr "Taip"
 
@@ -2779,10 +2784,10 @@ msgstr "Klaidingas inicializavimo prievadas"
 msgid "Please fill all fields required"
 msgstr "Prašome užpildyti visus privalomus laukus"
 
-#: src/KadDlg.cpp:192 src/PartFile.cpp:1031 src/PrefsUnifiedDlg.cpp:1162
-#: src/PrefsUnifiedDlg.cpp:1331 src/PrefsUnifiedDlg.cpp:1589
-#: src/PrefsUnifiedDlg.cpp:1599 src/PrefsUnifiedDlg.cpp:1616
-#: src/PrefsUnifiedDlg.cpp:1658
+#: src/KadDlg.cpp:192 src/PartFile.cpp:1031 src/PrefsUnifiedDlg.cpp:1134
+#: src/PrefsUnifiedDlg.cpp:1204 src/PrefsUnifiedDlg.cpp:1405
+#: src/PrefsUnifiedDlg.cpp:1663 src/PrefsUnifiedDlg.cpp:1673
+#: src/PrefsUnifiedDlg.cpp:1690 src/PrefsUnifiedDlg.cpp:1738
 msgid "Message"
 msgstr "Žinutė"
 
@@ -2887,7 +2892,7 @@ msgstr "Platinimo santykis"
 msgid "Uploaded"
 msgstr "Išsiųsta"
 
-#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3232
+#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3263
 msgid "Requested"
 msgstr "Paprašyta"
 
@@ -3013,7 +3018,7 @@ msgid "WARNING: "
 msgstr "DĖMESIO: "
 
 #: src/MuleNotebook.cpp:179 src/muuli_wdr.cpp:817 src/muuli_wdr.cpp:1229
-#: src/muuli_wdr.cpp:3136 src/muuli_wdr.cpp:3392
+#: src/muuli_wdr.cpp:3167 src/muuli_wdr.cpp:3423
 msgid "Close"
 msgstr "Užverti"
 
@@ -3031,7 +3036,7 @@ msgid "Paste"
 msgstr "Įterpti"
 
 #: src/MuleTextCtrl.cpp:89 src/muuli_wdr.cpp:358 src/muuli_wdr.cpp:757
-#: src/muuli_wdr.cpp:2359 src/muuli_wdr.cpp:2378 src/muuli_wdr.cpp:2400
+#: src/muuli_wdr.cpp:2390 src/muuli_wdr.cpp:2409 src/muuli_wdr.cpp:2431
 #: src/utils/aLinkCreator/src/alcframe.cpp:142
 msgid "Clear"
 msgstr "Išvalyti"
@@ -3130,7 +3135,7 @@ msgstr "Baigti"
 
 #: src/MuleTrayIcon.cpp:579 src/MuleTrayIcon.cpp:945 src/MuleTrayIcon.cpp:965
 #: src/muuli_wdr.cpp:1398 src/muuli_wdr.cpp:1406 src/muuli_wdr.cpp:1413
-#: src/muuli_wdr.cpp:1842 src/muuli_wdr.cpp:1848 src/OtherFunctions.cpp:91
+#: src/muuli_wdr.cpp:1846 src/muuli_wdr.cpp:1852 src/OtherFunctions.cpp:91
 #: src/StatisticsDlg.cpp:93 src/StatisticsDlg.cpp:95
 msgid "kB/s"
 msgstr "kB/s"
@@ -3372,7 +3377,7 @@ msgstr "Baitai"
 msgid "KB"
 msgstr "KB"
 
-#: src/muuli_wdr.cpp:274 src/muuli_wdr.cpp:293 src/muuli_wdr.cpp:1627
+#: src/muuli_wdr.cpp:274 src/muuli_wdr.cpp:293 src/muuli_wdr.cpp:1631
 #: src/OtherFunctions.cpp:64
 msgid "MB"
 msgstr "MB"
@@ -3389,7 +3394,7 @@ msgstr "Maks dydis"
 msgid "Availability"
 msgstr "Skaičius"
 
-#: src/muuli_wdr.cpp:312 src/muuli_wdr.cpp:398 src/muuli_wdr.cpp:3297
+#: src/muuli_wdr.cpp:312 src/muuli_wdr.cpp:398 src/muuli_wdr.cpp:3328
 msgid "Filter:"
 msgstr "Filtras:"
 
@@ -3453,12 +3458,12 @@ msgstr "Pilni šaltiniai"
 #: src/muuli_wdr.cpp:1160 src/muuli_wdr.cpp:1167 src/muuli_wdr.cpp:1172
 #: src/muuli_wdr.cpp:1179 src/muuli_wdr.cpp:1184 src/muuli_wdr.cpp:1191
 #: src/muuli_wdr.cpp:1205 src/muuli_wdr.cpp:1212 src/muuli_wdr.cpp:1217
-#: src/muuli_wdr.cpp:1224 src/muuli_wdr.cpp:3234 src/muuli_wdr.cpp:3242
-#: src/muuli_wdr.cpp:3250
+#: src/muuli_wdr.cpp:1224 src/muuli_wdr.cpp:3265 src/muuli_wdr.cpp:3273
+#: src/muuli_wdr.cpp:3281
 msgid "N/A"
 msgstr "Nežinoma"
 
-#: src/muuli_wdr.cpp:508 src/muuli_wdr.cpp:1065 src/PrefsUnifiedDlg.cpp:297
+#: src/muuli_wdr.cpp:508 src/muuli_wdr.cpp:1065 src/PrefsUnifiedDlg.cpp:299
 msgid "General"
 msgstr "Bendra"
 
@@ -3599,7 +3604,7 @@ msgstr ""
 msgid "Album :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:685 src/muuli_wdr.cpp:2254
+#: src/muuli_wdr.cpp:685 src/muuli_wdr.cpp:2285
 msgid "Title :"
 msgstr "Pavadinimas:"
 
@@ -3706,7 +3711,7 @@ msgstr "Naudotojo vardas:"
 msgid "Userhash :"
 msgstr "Naudotojo maišos f-ja:"
 
-#: src/muuli_wdr.cpp:895 src/muuli_wdr.cpp:1748 src/muuli_wdr.cpp:2449
+#: src/muuli_wdr.cpp:895 src/muuli_wdr.cpp:1752 src/muuli_wdr.cpp:2480
 #: src/utils/aLinkCreator/src/alcframe.cpp:137
 msgid "Add"
 msgstr "Įdėti"
@@ -3715,15 +3720,15 @@ msgstr "Įdėti"
 msgid "Download-Speed"
 msgstr "Atsiuntimo sparta"
 
-#: src/muuli_wdr.cpp:954 src/muuli_wdr.cpp:989 src/muuli_wdr.cpp:2553
+#: src/muuli_wdr.cpp:954 src/muuli_wdr.cpp:989 src/muuli_wdr.cpp:2584
 msgid "Current"
 msgstr "Dabartinė sparta"
 
-#: src/muuli_wdr.cpp:962 src/muuli_wdr.cpp:997 src/muuli_wdr.cpp:2561
+#: src/muuli_wdr.cpp:962 src/muuli_wdr.cpp:997 src/muuli_wdr.cpp:2592
 msgid "Running average"
 msgstr "Dabartinis vidurkis"
 
-#: src/muuli_wdr.cpp:970 src/muuli_wdr.cpp:1005 src/muuli_wdr.cpp:2569
+#: src/muuli_wdr.cpp:970 src/muuli_wdr.cpp:1005 src/muuli_wdr.cpp:2600
 msgid "Session average"
 msgstr "Seanso vidurkis"
 
@@ -3735,7 +3740,7 @@ msgstr "Išsiuntimo sparta"
 msgid "Connections"
 msgstr "Ryšiai"
 
-#: src/muuli_wdr.cpp:1024 src/muuli_wdr.cpp:1867
+#: src/muuli_wdr.cpp:1024 src/muuli_wdr.cpp:1871
 msgid "Active downloads"
 msgstr "Aktyvūs atsiuntimai"
 
@@ -3743,7 +3748,7 @@ msgstr "Aktyvūs atsiuntimai"
 msgid "Active connections (1:1)"
 msgstr "Aktyvūs ryšiai (1:1)"
 
-#: src/muuli_wdr.cpp:1040 src/muuli_wdr.cpp:1868
+#: src/muuli_wdr.cpp:1040 src/muuli_wdr.cpp:1872
 msgid "Active uploads"
 msgstr "Aktyvūs išsiuntimai"
 
@@ -4020,7 +4025,7 @@ msgstr ""
 msgid "Advanced users only: If you have multiple network interfaces, enter the address of the interface to which aMule should be bound."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1462 src/muuli_wdr.cpp:2061
+#: src/muuli_wdr.cpp:1462 src/muuli_wdr.cpp:2065
 msgid "Bind to network interface (empty for any):"
 msgstr ""
 
@@ -4036,7 +4041,7 @@ msgstr ""
 msgid "Max simultaneous connections:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1498 src/muuli_wdr.cpp:3176
+#: src/muuli_wdr.cpp:1498 src/muuli_wdr.cpp:3207
 msgid "ED2K"
 msgstr "ED2K"
 
@@ -4128,758 +4133,781 @@ msgstr "Naujiems failams paskirti vietą diske"
 msgid "For new files preallocates disk space for the whole file, thus reduces fragmentation"
 msgstr "Naujiems failams iš anksto paskirti vietą diske visam failui. Taip bus sumažinta fragmentacija"
 
-#: src/muuli_wdr.cpp:1613
+#: src/muuli_wdr.cpp:1617
 msgid "Create new files as sparse files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1614
-msgid "A sparse file reserves its full size on disk immediately without writing real data to it -- fast, but unsupported or slow on some filesystems, and free-space accounting stays optimistic while the download is in progress. Turn this off to grow the file only as data arrives."
+#: src/muuli_wdr.cpp:1618
+msgid "Sparse part files only occupy disk space for the parts already downloaded, so free space is used up gradually as the file fills in. Turn this off to use an ordinary file instead - useful where sparse files are unsupported or slow, or where backup/de-duplication tools handle them badly. Applies only when the core runs on Windows; on Linux and macOS part files are sparse anyway and this setting has no effect."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1619
+#: src/muuli_wdr.cpp:1623
 msgid "Stop downloads when free disk space reaches "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1620
+#: src/muuli_wdr.cpp:1624
 msgid "Select this if you want aMule to check your disk space"
 msgstr "Įjunkite, jei norite, kad aMule tikrintų laisvą vietą diske"
 
-#: src/muuli_wdr.cpp:1624
+#: src/muuli_wdr.cpp:1628
 msgid "Enter here the min disk space desired."
 msgstr "Įrašykite kiek diske palikti laisvos vietos."
 
-#: src/muuli_wdr.cpp:1630
+#: src/muuli_wdr.cpp:1634
 msgid "Save 10 sources on rare files (< 20 sources)"
 msgstr "Įrašyti 10 šaltinių retiems failams (mažiau nei 20 šaltinių)"
 
-#: src/muuli_wdr.cpp:1634 src/Statistics.cpp:790
+#: src/muuli_wdr.cpp:1638 src/Statistics.cpp:790
 msgid "Uploads"
 msgstr "Išsiuntimai"
 
-#: src/muuli_wdr.cpp:1637
+#: src/muuli_wdr.cpp:1641
 msgid "Add new shared files with auto priority"
 msgstr "Naujiems dalinamiems failams nurodyti automatinį prioritetą"
 
-#: src/muuli_wdr.cpp:1643
+#: src/muuli_wdr.cpp:1647
 msgid "Intelligent Corruption Handling (I.C.H.)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1646
+#: src/muuli_wdr.cpp:1650
 msgid "Enable"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1649
+#: src/muuli_wdr.cpp:1653
 msgid "Advanced I.C.H. trusts every hash (not recommended)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1661 src/PrefsUnifiedDlg.cpp:1910
+#: src/muuli_wdr.cpp:1665 src/PrefsUnifiedDlg.cpp:1990
 msgid "Media metadata extraction"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1665
+#: src/muuli_wdr.cpp:1669
 msgid "Extract length / bitrate / codec from shared audio and video files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1667
+#: src/muuli_wdr.cpp:1671
 msgid "When enabled, aMule runs ffprobe on each shared media file to fill in the Length / Bitrate / Codec columns other clients see when they find the file in a search. Requires ffmpeg (the ffprobe binary) to be installed."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1674
+#: src/muuli_wdr.cpp:1678
 msgid "Path to ffprobe:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1679
+#: src/muuli_wdr.cpp:1683
 msgid "Full path to the ffprobe binary. Leave empty to have aMule auto-detect it on startup."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1687
+#: src/muuli_wdr.cpp:1691
 msgid "Detect"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1688
+#: src/muuli_wdr.cpp:1692
 msgid "Search the standard install locations for an ffprobe binary and fill the path field."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1712
+#: src/muuli_wdr.cpp:1716
 msgid ""
 "Completed downloads are stored here. All files in this folder are automatically shared with other peers.\n"
 "If this folder also holds files you don't want to share, point it at an aMule-only sub-folder."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1715
+#: src/muuli_wdr.cpp:1719
 msgid "Pick the folder where completed downloads will be stored. All files in that folder will be shared with other peers."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1729
+#: src/muuli_wdr.cpp:1733
 msgid "Shared folders"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1735
+#: src/muuli_wdr.cpp:1739
 msgid "(Folders shared by the core. Enter a path to add one.)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1743
+#: src/muuli_wdr.cpp:1747
 msgid "Absolute path of a folder on the core's machine, e.g. /home/user/shared"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1745 src/PrefsUnifiedDlg.cpp:2794
+#: src/muuli_wdr.cpp:1749 src/PrefsUnifiedDlg.cpp:2874
 msgid "Recursive"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1746
+#: src/muuli_wdr.cpp:1750
 msgid "Share every sub-folder underneath this one, including ones created later."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1750 src/utils/aLinkCreator/src/alcframe.cpp:141
+#: src/muuli_wdr.cpp:1754 src/utils/aLinkCreator/src/alcframe.cpp:141
 msgid "Remove"
 msgstr "Pašalinti"
 
-#: src/muuli_wdr.cpp:1754
+#: src/muuli_wdr.cpp:1758
 msgid "(Right click on folder icon for recursive share)"
 msgstr "(spragtelėję dešiniu klavišu dalinsitės ir gilesniais paaplankiais)"
 
-#: src/muuli_wdr.cpp:1761
+#: src/muuli_wdr.cpp:1765
 msgid "Share hidden files"
 msgstr "Dalintis slepiamais failais"
 
-#: src/muuli_wdr.cpp:1767
+#: src/muuli_wdr.cpp:1771
 msgid "Automatically rescan shared folders for changes"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1773
+#: src/muuli_wdr.cpp:1777
 msgid "Follow symbolic links in shared folders"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1779
+#: src/muuli_wdr.cpp:1783
 msgid "Exclude files matching:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1782
+#: src/muuli_wdr.cpp:1786
 msgid "Wildcard patterns separated by '|', e.g. .DS_Store|Thumbs.db|*.tmp. Files whose name matches are not shared. Matching is case-insensitive."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1786
+#: src/muuli_wdr.cpp:1790
 msgid "Patterns are regular expressions"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1787
+#: src/muuli_wdr.cpp:1791
 msgid "When set, the whole field is one regular expression ('|' is alternation). When unset, it is a list of '|'-separated wildcards."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1797
+#: src/muuli_wdr.cpp:1801
 msgid "Show how many shared files the current pattern would exclude."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1818
+#: src/muuli_wdr.cpp:1822
 msgid "Graphs"
 msgstr "Grafikai"
 
-#: src/muuli_wdr.cpp:1821 src/muuli_wdr.cpp:1883
+#: src/muuli_wdr.cpp:1825 src/muuli_wdr.cpp:1887
 msgid "Update delay : 5 secs"
 msgstr "Atnaujinimo dažnis: 5 s"
 
-#: src/muuli_wdr.cpp:1825
+#: src/muuli_wdr.cpp:1829
 msgid "Time for average graph: 100 mins"
 msgstr "Vidurkių grafiko dydis: 100 min"
 
-#: src/muuli_wdr.cpp:1829
+#: src/muuli_wdr.cpp:1833
 msgid "Connections Graph Scale: 100 "
 msgstr "Ryšių grafiko skalė: 100 "
 
-#: src/muuli_wdr.cpp:1836
+#: src/muuli_wdr.cpp:1840
 msgid "Download graph scale:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1844
+#: src/muuli_wdr.cpp:1848
 msgid "Upload graph scale:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1854
+#: src/muuli_wdr.cpp:1858
 msgid "Colors: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1858
+#: src/muuli_wdr.cpp:1862
 msgid "Background"
 msgstr "Fonas"
 
-#: src/muuli_wdr.cpp:1859
+#: src/muuli_wdr.cpp:1863
 msgid "Grid"
 msgstr "Rėmeliai"
 
-#: src/muuli_wdr.cpp:1860
+#: src/muuli_wdr.cpp:1864
 msgid "Download current"
 msgstr "Dabartinė atsiuntimo sparta"
 
-#: src/muuli_wdr.cpp:1861
+#: src/muuli_wdr.cpp:1865
 msgid "Download running average"
 msgstr "Dabartinis atsiuntimo vidurkis"
 
-#: src/muuli_wdr.cpp:1862
+#: src/muuli_wdr.cpp:1866
 msgid "Download session average"
 msgstr "Seanso atsiuntimo vidurkis"
 
-#: src/muuli_wdr.cpp:1863
+#: src/muuli_wdr.cpp:1867
 msgid "Upload current"
 msgstr "Dabartinė išsiuntimo sparta"
 
-#: src/muuli_wdr.cpp:1864
+#: src/muuli_wdr.cpp:1868
 msgid "Upload running average"
 msgstr "Dabartinis išsiuntimo vidurkis"
 
-#: src/muuli_wdr.cpp:1865
+#: src/muuli_wdr.cpp:1869
 msgid "Upload session average"
 msgstr "Seanso išsiuntimo vidurkis"
 
-#: src/muuli_wdr.cpp:1866
+#: src/muuli_wdr.cpp:1870
 msgid "Active connections"
 msgstr "Aktyvūs ryšiai"
 
-#: src/muuli_wdr.cpp:1869
+#: src/muuli_wdr.cpp:1873
 #, fuzzy
 msgid "Systray Icon Speed Bar"
 msgstr "Sistemos dėklo spartos indikatorius"
 
-#: src/muuli_wdr.cpp:1870
+#: src/muuli_wdr.cpp:1874
 msgid "Kad-nodes current"
 msgstr "Dabartiniai Kademlia mazgai"
 
-#: src/muuli_wdr.cpp:1871
+#: src/muuli_wdr.cpp:1875
 msgid "Kad-nodes running"
 msgstr "Kademlia mazgų dabartinis vidurkis"
 
-#: src/muuli_wdr.cpp:1872
+#: src/muuli_wdr.cpp:1876
 msgid "Kad-nodes session"
 msgstr "Kademlia mazgų seanso vidurkis"
 
-#: src/muuli_wdr.cpp:1876 src/muuli_wdr.cpp:2303
+#: src/muuli_wdr.cpp:1880 src/muuli_wdr.cpp:2334
 msgid "Select"
 msgstr "Nurodykite spalvą"
 
-#: src/muuli_wdr.cpp:1880
+#: src/muuli_wdr.cpp:1884
 msgid "Tree"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1890
+#: src/muuli_wdr.cpp:1894
 msgid "Number of Client Versions shown (0=unlimited)"
 msgstr "Rodomų klientų versijų skaičius (0 – neribojama)"
 
-#: src/muuli_wdr.cpp:1915
+#: src/muuli_wdr.cpp:1919
 msgid "!!! WARNING !!!"
 msgstr "DĖMESIO!!!"
 
-#: src/muuli_wdr.cpp:1930
+#: src/muuli_wdr.cpp:1934
 msgid "Max new connections / 5 secs"
 msgstr "Per 5 s užmegzti ne daugiau ryšių, nei nurodyta"
 
-#: src/muuli_wdr.cpp:1932
+#: src/muuli_wdr.cpp:1936
 msgid "Concurrent Kad source lookups"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1934
+#: src/muuli_wdr.cpp:1938
 #, fuzzy
 msgid "Kad source re-search interval (minutes)"
 msgstr "FTP atnaujinimo intervalas minutėmis"
 
-#: src/muuli_wdr.cpp:1936
+#: src/muuli_wdr.cpp:1940
 #, fuzzy
 msgid "Source re-ask interval (minutes)"
 msgstr "FTP atnaujinimo intervalas minutėmis"
 
-#: src/muuli_wdr.cpp:1940
+#: src/muuli_wdr.cpp:1944
 msgid "File Buffer Size: 240000 bytes"
 msgstr "Failo buferio dydis: 240000 baitai"
 
-#: src/muuli_wdr.cpp:1944
+#: src/muuli_wdr.cpp:1948
 msgid "Use MMAP: memory-mapped file access (lower memory use)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1945
+#: src/muuli_wdr.cpp:1949
 msgid "Maps part files into memory instead of buffering them on the heap, lowering the process memory footprint. May reduce download speed on some disks; best for memory-constrained or upload-heavy hosts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1947
+#: src/muuli_wdr.cpp:1951
 msgid "Upload Queue Size: 5000 clients"
 msgstr "Išsiuntimo eilė: 5000 klientų"
 
-#: src/muuli_wdr.cpp:1951
+#: src/muuli_wdr.cpp:1955
 msgid "Server connection refresh interval: Disable"
 msgstr "Serverio ryšio atnaujinimo intervalas: išjungta"
 
-#: src/muuli_wdr.cpp:1955
+#: src/muuli_wdr.cpp:1959
 msgid "Disable computer's timed standby mode"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1974
+#: src/muuli_wdr.cpp:1978
 msgid "Skin to use: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1983
+#: src/muuli_wdr.cpp:1987
 msgid "Show \"Fast eD2k Links Handler\" in every window."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1986
+#: src/muuli_wdr.cpp:1990
 msgid "Show extended info on categories tabs"
 msgstr "Rodyti papildomą informaciją kategorijų kortelėse"
 
-#: src/muuli_wdr.cpp:1989
+#: src/muuli_wdr.cpp:1993
 #, fuzzy
 msgid "Show application version on title"
 msgstr "Rodyti siuntimo spartą failo pavadinime"
 
-#: src/muuli_wdr.cpp:1991
+#: src/muuli_wdr.cpp:1995
 msgid "Show transfer rates on title"
 msgstr "Rodyti siuntimo spartą failo pavadinime"
 
-#: src/muuli_wdr.cpp:1993
+#: src/muuli_wdr.cpp:1997
 msgid "Before application name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1995
+#: src/muuli_wdr.cpp:1999
 msgid "After application name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1998
+#: src/muuli_wdr.cpp:2002
 msgid "Show overhead bandwidth"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2002
+#: src/muuli_wdr.cpp:2006
 msgid "Vertical toolbar orientation"
 msgstr "Mygtukus išdėstyti vertikaliai"
 
-#: src/muuli_wdr.cpp:2004
+#: src/muuli_wdr.cpp:2008
 msgid "Live column sorting (auto-reorder rows as their values change)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2011
+#: src/muuli_wdr.cpp:2015
 msgid "Download Queue Files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2014
+#: src/muuli_wdr.cpp:2018
 msgid "Show progress percentage"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2020
+#: src/muuli_wdr.cpp:2024
 msgid "Show progress bar"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2023
+#: src/muuli_wdr.cpp:2027
 msgid "Flat"
 msgstr "Plokščia"
 
-#: src/muuli_wdr.cpp:2027
+#: src/muuli_wdr.cpp:2031
 msgid "Round"
 msgstr "Erdvinė"
 
-#: src/muuli_wdr.cpp:2045
+#: src/muuli_wdr.cpp:2049
 msgid "External Connection Parameters"
 msgstr "Išorinio ryšio parinktys"
 
-#: src/muuli_wdr.cpp:2048
+#: src/muuli_wdr.cpp:2052
 msgid "Accept external connections"
 msgstr "Priimti išorinius ryšius"
 
-#: src/muuli_wdr.cpp:2055 src/muuli_wdr.cpp:2114
+#: src/muuli_wdr.cpp:2059 src/muuli_wdr.cpp:2118
 msgid "IP of the listening interface:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2058
+#: src/muuli_wdr.cpp:2062
 msgid "Enter here a valid ip in the a.b.c.d format for the listening EC interface. An empty field or 0.0.0.0 will mean any interface."
 msgstr "Įrašykite išorinių ryšių besiklausančio įrenginio IP adresą a.b.c.d forma. Tuščias laukelis arba adresas 0.0.0.0 reiškia bet kokį įrenginį."
 
-#: src/muuli_wdr.cpp:2079 src/muuli_wdr.cpp:2163
+#: src/muuli_wdr.cpp:2083 src/muuli_wdr.cpp:2194
 msgid "TCP port:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2085
+#: src/muuli_wdr.cpp:2089
 msgid "Enable UPnP port forwarding on the EC port"
 msgstr "EC prievade įjungti UPnP prievadų perdavimą"
 
-#: src/muuli_wdr.cpp:2089 src/muuli_wdr.cpp:3048
+#: src/muuli_wdr.cpp:2093 src/muuli_wdr.cpp:3079
 #: src/utils/wxCas/src/wxcasprefs.cpp:167
 msgid "Password"
 msgstr "Slaptažodis"
 
-#: src/muuli_wdr.cpp:2095
+#: src/muuli_wdr.cpp:2099
 #, fuzzy
 msgid "aMule API server parameters"
 msgstr "Žiniatinklio serverio parinktys"
 
-#: src/muuli_wdr.cpp:2098
+#: src/muuli_wdr.cpp:2102
 msgid "Run amuleapi (REST API) on startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2103
+#: src/muuli_wdr.cpp:2107
 #, fuzzy
 msgid "HTTP port:"
 msgstr "TCP prievadas: %d"
 
-#: src/muuli_wdr.cpp:2117
+#: src/muuli_wdr.cpp:2121
 msgid "The interface amuleapi's HTTP server listens on. 127.0.0.1 (default) accepts only local connections; use 0.0.0.0 or a specific IP to expose it to other hosts (set an admin password below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2120
+#: src/muuli_wdr.cpp:2126
+msgid "Type a password to set or change it. Stored passwords cannot be shown, so leaving this empty keeps the current one."
+msgstr ""
+
+#: src/muuli_wdr.cpp:2128
 #, fuzzy
 msgid "Admin password"
 msgstr "Tikrinamas slaptažodis\n"
 
-#: src/muuli_wdr.cpp:2125 src/muuli_wdr.cpp:2156
-msgid "Low rights password"
-msgstr "Nepilnos prieigos slaptažodis"
+#: src/muuli_wdr.cpp:2140 src/muuli_wdr.cpp:2157 src/PrefsUnifiedDlg.cpp:1103
+#, fuzzy
+msgid "A password is set."
+msgstr "Tikrinamas slaptažodis\n"
 
-#: src/muuli_wdr.cpp:2133
+#: src/muuli_wdr.cpp:2144
+#, fuzzy
+msgid "Enable guest access"
+msgstr "Išjungti svečio prieigą"
+
+#: src/muuli_wdr.cpp:2145
+msgid "Guest sessions may read status and listings but cannot change anything. Turning this off clears the stored guest password."
+msgstr ""
+
+#: src/muuli_wdr.cpp:2149
+#, fuzzy
+msgid "Guest password"
+msgstr "Svečio prieigos prie žiniatinklio serverio slaptažodis"
+
+#: src/muuli_wdr.cpp:2164
 msgid "Web server parameters"
 msgstr "Žiniatinklio serverio parinktys"
 
-#: src/muuli_wdr.cpp:2136
+#: src/muuli_wdr.cpp:2167
 msgid "Run webserver on startup (deprecated)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2142
+#: src/muuli_wdr.cpp:2173
 msgid "Web template"
 msgstr "www šablonas"
 
-#: src/muuli_wdr.cpp:2147
+#: src/muuli_wdr.cpp:2178
 msgid "Full rights password"
 msgstr "Pilnos prieigos slaptažodis"
 
-#: src/muuli_wdr.cpp:2151
+#: src/muuli_wdr.cpp:2182
 msgid "Enable Low rights User"
 msgstr "Įjungti nepilnos prieigos naudotoją"
 
-#: src/muuli_wdr.cpp:2170
+#: src/muuli_wdr.cpp:2187
+msgid "Low rights password"
+msgstr "Nepilnos prieigos slaptažodis"
+
+#: src/muuli_wdr.cpp:2201
 msgid "Enable UPnP port forwarding of the web server port"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2175
+#: src/muuli_wdr.cpp:2206
 msgid "Web server UPnP TCP port (Optional)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2183
+#: src/muuli_wdr.cpp:2214
 msgid "Page Refresh Time (in secs)"
 msgstr "Puslapio atnaujinimo periodas (sekundėmis)"
 
-#: src/muuli_wdr.cpp:2190
+#: src/muuli_wdr.cpp:2221
 msgid "Enable Gzip compression"
 msgstr "Įjungti Gzip suspaudimą"
 
-#: src/muuli_wdr.cpp:2224
+#: src/muuli_wdr.cpp:2255
 #, fuzzy
 msgid "Reset page to defaults"
 msgstr "Numatyta"
 
-#: src/muuli_wdr.cpp:2225
+#: src/muuli_wdr.cpp:2256
 msgid "Reset the settings on the current page to their default values."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2227 src/muuli_wdr.cpp:2313 src/ServerWnd.cpp:274
+#: src/muuli_wdr.cpp:2258 src/muuli_wdr.cpp:2344 src/ServerWnd.cpp:274
 #: src/ServerWnd.cpp:282
 msgid "OK"
 msgstr "Gerai"
 
-#: src/muuli_wdr.cpp:2229
+#: src/muuli_wdr.cpp:2260
 msgid "Click here to apply any changes made to the preferences."
 msgstr "Patvirtinti naujai nurodytas parinktis."
 
-#: src/muuli_wdr.cpp:2232
+#: src/muuli_wdr.cpp:2263
 msgid "Reset any changes made to the preferences."
 msgstr "Atšaukti bet kokius pakeitimus."
 
-#: src/muuli_wdr.cpp:2261
+#: src/muuli_wdr.cpp:2292
 msgid "Comment :"
 msgstr "Komentaras:"
 
-#: src/muuli_wdr.cpp:2268
+#: src/muuli_wdr.cpp:2299
 msgid "Incoming Dir :"
 msgstr "Atsiųstų failų aplankas:"
 
-#: src/muuli_wdr.cpp:2277
+#: src/muuli_wdr.cpp:2308
 msgid "Change priority for new assigned files :"
 msgstr "Keisti naujai priskirtų failų prioritetą:"
 
-#: src/muuli_wdr.cpp:2281
+#: src/muuli_wdr.cpp:2312
 #, fuzzy
 msgid "Don't change"
 msgstr "Nekeisti"
 
-#: src/muuli_wdr.cpp:2293
+#: src/muuli_wdr.cpp:2324
 msgid "Select color for this Category (currently selected) :"
 msgstr "Nurodykite dabartinės kategorijos spalvą:"
 
-#: src/muuli_wdr.cpp:2360 src/muuli_wdr.cpp:2379 src/muuli_wdr.cpp:2401
+#: src/muuli_wdr.cpp:2391 src/muuli_wdr.cpp:2410 src/muuli_wdr.cpp:2432
 msgid "Click this button to reset the log."
 msgstr "Išvalyti įvykių žurnalą."
 
-#: src/muuli_wdr.cpp:2420
+#: src/muuli_wdr.cpp:2451
 msgid "Click on this button to update the servers list from URL ..."
 msgstr "Paspaudę šį mygtuką atnaujinsite serverių sąrašą iš URL..."
 
-#: src/muuli_wdr.cpp:2424
+#: src/muuli_wdr.cpp:2455
 msgid "Server list"
 msgstr "Serverių sąrašas"
 
-#: src/muuli_wdr.cpp:2428
+#: src/muuli_wdr.cpp:2459
 msgid "Enter the url to a server.met file here and press the button to the left to update the list of known servers."
 msgstr "Įrašykite server.met failo URL ir paspaudę mygtuką kairėje atnaujinsite serverių sąrašą."
 
-#: src/muuli_wdr.cpp:2433
+#: src/muuli_wdr.cpp:2464
 msgid "Add server manually: Name"
 msgstr "Įdėti serverį rankiniu būdu: pavadinimas"
 
-#: src/muuli_wdr.cpp:2436
+#: src/muuli_wdr.cpp:2467
 msgid "Enter the name of the new server here"
 msgstr "Įrašykite serverio pavadinimą"
 
-#: src/muuli_wdr.cpp:2438 src/ServerWnd.cpp:206
+#: src/muuli_wdr.cpp:2469 src/ServerWnd.cpp:206
 msgid "IP:Port"
 msgstr "IP:prievadas"
 
-#: src/muuli_wdr.cpp:2441
+#: src/muuli_wdr.cpp:2472
 msgid "Enter the IP of the server here, using the x.x.x.x format."
 msgstr "Įrašykite serverio IP adresą naudodami a.b.c.d formą."
 
-#: src/muuli_wdr.cpp:2447
+#: src/muuli_wdr.cpp:2478
 msgid "Enter the port of the server here."
 msgstr "Įrašykite serverio prievadą."
 
-#: src/muuli_wdr.cpp:2450
+#: src/muuli_wdr.cpp:2481
 msgid "Add manually a server (fill fields to the left before) ..."
 msgstr "Įdėti serverį (prieš tai užpildykite laukelius kairėje)..."
 
-#: src/muuli_wdr.cpp:2479
+#: src/muuli_wdr.cpp:2510
 msgid "aMule Log"
 msgstr "aMule žurnalas"
 
-#: src/muuli_wdr.cpp:2487
+#: src/muuli_wdr.cpp:2518
 msgid "Server Info"
 msgstr "Serverio informacija"
 
-#: src/muuli_wdr.cpp:2491
+#: src/muuli_wdr.cpp:2522
 msgid "ED2K Info"
 msgstr "ED2K informacija"
 
-#: src/muuli_wdr.cpp:2495
+#: src/muuli_wdr.cpp:2526
 msgid "Kad Info"
 msgstr "Kademlia informacija"
 
-#: src/muuli_wdr.cpp:2523
+#: src/muuli_wdr.cpp:2554
 msgid "Click on this button to update the nodes list from URL ..."
 msgstr "Spragtelėję šį mygtuką atnaujinsite mazgų sąrašą iš URL..."
 
-#: src/muuli_wdr.cpp:2527
+#: src/muuli_wdr.cpp:2558
 msgid "Nodes (0)"
 msgstr "Mazgai (0)"
 
-#: src/muuli_wdr.cpp:2531
+#: src/muuli_wdr.cpp:2562
 msgid "Enter the url to a nodes.dat file here and press the button to the left to update the list of known nodes."
 msgstr "Įrašykite nodes.dat failo URL ir paspaudę mygtuką kairėje atnaujinsite mazgų sąrašą."
 
-#: src/muuli_wdr.cpp:2534
+#: src/muuli_wdr.cpp:2565
 msgid "Nodes stats"
 msgstr "Mazgų statistika"
 
-#: src/muuli_wdr.cpp:2576
+#: src/muuli_wdr.cpp:2607
 msgid "Bootstrap"
 msgstr "Inicializavimas"
 
-#: src/muuli_wdr.cpp:2579
+#: src/muuli_wdr.cpp:2610
 msgid "New node"
 msgstr "Naujas mazgas"
 
-#: src/muuli_wdr.cpp:2584
+#: src/muuli_wdr.cpp:2615
 msgid "IP:"
 msgstr "IP:"
 
-#: src/muuli_wdr.cpp:2604
+#: src/muuli_wdr.cpp:2635
 msgid "Port:"
 msgstr "Prievadas:"
 
-#: src/muuli_wdr.cpp:2617
+#: src/muuli_wdr.cpp:2648
 #, fuzzy
 msgid "Bootstrap from known clients"
 msgstr ""
 "Inicializuoti iš \n"
 "žinomų klientų"
 
-#: src/muuli_wdr.cpp:2619
+#: src/muuli_wdr.cpp:2650
 msgid "Disconnect Kad"
 msgstr "Atjungti Kademlia"
 
-#: src/muuli_wdr.cpp:2653
+#: src/muuli_wdr.cpp:2684
 msgid "Use Secure User Identification"
 msgstr "Naudoti saugų kliento atpažinimą"
 
-#: src/muuli_wdr.cpp:2655
+#: src/muuli_wdr.cpp:2686
 msgid "It is recommended to enable this option. You will not receive credits if SUI is not enabled."
 msgstr "Rekomenduojama įjungti šią parinktį. Jei išjungsite, negausite kreditų."
 
-#: src/muuli_wdr.cpp:2657
+#: src/muuli_wdr.cpp:2688
 msgid "Protocol Obfuscation"
 msgstr "Protokolo slėpimas"
 
-#: src/muuli_wdr.cpp:2660
+#: src/muuli_wdr.cpp:2691
 msgid "Support Protocol Obfuscation"
 msgstr "Įjungti protokolo slėpimą"
 
-#: src/muuli_wdr.cpp:2662
+#: src/muuli_wdr.cpp:2693
 msgid "This option enabled Protocol Obfuscation, and makes aMule accept obfuscated connections from other clients."
 msgstr "Ši parinktis įjungia protokolo slėpimą. Tuomet aMule priiminės slepiamus ryšius iš kitų klientų."
 
-#: src/muuli_wdr.cpp:2664
+#: src/muuli_wdr.cpp:2695
 msgid "Use obfuscation for outgoing connections"
 msgstr "Slėpti išeinančius ryšius"
 
-#: src/muuli_wdr.cpp:2666
+#: src/muuli_wdr.cpp:2697
 msgid "This option makes aMule use Protocol Obfuscation when connecting other clients/servers."
 msgstr "Įjungus šią parinktį aMule, jungdamasi prie kitų klientų ar serverių, slėps išeinančius ryšius."
 
-#: src/muuli_wdr.cpp:2668
+#: src/muuli_wdr.cpp:2699
 msgid "Accept only obfuscated connections"
 msgstr "Priimti tik slepiamus ryšius"
 
-#: src/muuli_wdr.cpp:2669
+#: src/muuli_wdr.cpp:2700
 msgid "This option makes aMule only accept obfuscated connections. You will have less sources, but all your traffic will be obfuscated"
 msgstr "Įjungus šią parinktį aMule priims tik slepiamus ryšius. Šaltinių bus rasta mažiau, bet visas srautas bus slepiamas"
 
-#: src/muuli_wdr.cpp:2674
+#: src/muuli_wdr.cpp:2705
 msgid "Everybody"
 msgstr "Visi"
 
-#: src/muuli_wdr.cpp:2676
+#: src/muuli_wdr.cpp:2707
 msgid "No one"
 msgstr "Niekas"
 
-#: src/muuli_wdr.cpp:2678
+#: src/muuli_wdr.cpp:2709
 msgid "Who can see my shared files:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2679
+#: src/muuli_wdr.cpp:2710
 msgid "Select who can request to view a list of your shared files."
 msgstr "Nurodykite kas gali pamatyti dalinamų failų sąrašą."
 
-#: src/muuli_wdr.cpp:2681
+#: src/muuli_wdr.cpp:2712
 msgid "IP-Filtering"
 msgstr "IP filtravimas"
 
-#: src/muuli_wdr.cpp:2688
+#: src/muuli_wdr.cpp:2719
 msgid "Filter clients"
 msgstr "Filtruoti klientus"
 
-#: src/muuli_wdr.cpp:2690
+#: src/muuli_wdr.cpp:2721
 msgid "Enable filtering of the client IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "Įjungti klientų IP adresų filtravimą, aprašytą ~/.aMule/ipfilter.dat faile."
 
-#: src/muuli_wdr.cpp:2692
+#: src/muuli_wdr.cpp:2723
 msgid "Filter servers"
 msgstr "Filtruoti serverius"
 
-#: src/muuli_wdr.cpp:2694
+#: src/muuli_wdr.cpp:2725
 msgid "Enable filtering of the server IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "Įjungti serverių IP adresų filtravimą, aprašytą ~/.aMule/ipfilter.dat faile."
 
-#: src/muuli_wdr.cpp:2698
+#: src/muuli_wdr.cpp:2729
 msgid "Reload List"
 msgstr "Atnaujinti sąrašą"
 
-#: src/muuli_wdr.cpp:2699
+#: src/muuli_wdr.cpp:2730
 msgid "Reload the list of IPs to filter from the file ~/.aMule/ipfilter.dat"
 msgstr "Atnaujinti IP adresų sąrašą iš ~/.aMule/ipfilter.dat failo"
 
-#: src/muuli_wdr.cpp:2705
+#: src/muuli_wdr.cpp:2736
 msgid "URL:"
 msgstr "URL:"
 
-#: src/muuli_wdr.cpp:2709 src/muuli_wdr.cpp:2902
+#: src/muuli_wdr.cpp:2740 src/muuli_wdr.cpp:2933
 msgid "Update now"
 msgstr "Atnaujinti dabar"
 
-#: src/muuli_wdr.cpp:2712
+#: src/muuli_wdr.cpp:2743
 msgid "Auto-update ipfilter at startup"
 msgstr "Automatiškai įkelti IP filtrą paleidus programą"
 
-#: src/muuli_wdr.cpp:2716
+#: src/muuli_wdr.cpp:2747
 msgid "Filtering Level:"
 msgstr "Filtravimo lygmuo:"
 
-#: src/muuli_wdr.cpp:2722
+#: src/muuli_wdr.cpp:2753
 msgid "Always filter LAN IPs"
 msgstr "Visuomet filtruoti LAN IP adresus"
 
-#: src/muuli_wdr.cpp:2725
+#: src/muuli_wdr.cpp:2756
 msgid "Paranoid handling of non-matching IPs"
 msgstr "Paranojiškai elgtis su neatitikusiais IP adresais"
 
-#: src/muuli_wdr.cpp:2727
+#: src/muuli_wdr.cpp:2758
 msgid "Rejects a packet when its source IP differs from the IP the client claims (an anti-spoofing check). Disable only if it causes connection problems."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2729
+#: src/muuli_wdr.cpp:2760
 msgid "Use system-wide ipfilter.dat if available"
 msgstr "Jei įjungtas, naudoti ipfilter.dat failą visoje sistemoje"
 
-#: src/muuli_wdr.cpp:2730
+#: src/muuli_wdr.cpp:2761
 #, fuzzy
 msgid "If there's no local ipfilter.dat found, allow usage of a system-wide ipfilter file."
 msgstr "Jei nėra vietinio ipilter.dat failo, naudoti ipfilter.dat visoje sistemoje."
 
-#: src/muuli_wdr.cpp:2747
+#: src/muuli_wdr.cpp:2778
 msgid "Enable Online-Signature"
 msgstr "Įjungti keičiamą parašą"
 
-#: src/muuli_wdr.cpp:2749
+#: src/muuli_wdr.cpp:2780
 msgid "Enables the writing of the OS file, which can be used by external apps to create signatures and the like."
 msgstr "Įjungus šią parinktį bus įrašomas keičiamo parašo failas, kurį galite naudoti kitoje programoje parašų kūrimui ir pan."
 
-#: src/muuli_wdr.cpp:2753
+#: src/muuli_wdr.cpp:2784
 msgid "Update Frequency (Secs):"
 msgstr "Atnaujinimo dažnis (sekundėmis):"
 
-#: src/muuli_wdr.cpp:2756
+#: src/muuli_wdr.cpp:2787
 msgid "Change the frequency (in seconds) of Online Signature updates."
 msgstr "Keičiamo parašo atnaujinimo dažnis sekundėmis."
 
-#: src/muuli_wdr.cpp:2764
+#: src/muuli_wdr.cpp:2795
 msgid "Save online signature file in: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:2770
+#: src/muuli_wdr.cpp:2801
 msgid "Click here to select the directory containing the the Online Signature files."
 msgstr "Nurodykite aplanką, kuriame yra keičiamo parašo failas."
 
-#: src/muuli_wdr.cpp:2803
+#: src/muuli_wdr.cpp:2834
 msgid "Show country flags for clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2804
+#: src/muuli_wdr.cpp:2835
 msgid "Render the country flag column in the transfers, queue and search views. Requires a valid MMDB GeoIP database (see below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2809
+#: src/muuli_wdr.cpp:2840
 #, fuzzy
 msgid "Database"
 msgstr "Siuntimo sparta:"
 
-#: src/muuli_wdr.cpp:2825
+#: src/muuli_wdr.cpp:2856
 #, fuzzy
 msgid "Source:"
 msgstr "Šaltiniai"
 
-#: src/muuli_wdr.cpp:2828
+#: src/muuli_wdr.cpp:2859
 msgid "DB-IP (free, no account)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2829
+#: src/muuli_wdr.cpp:2860
 msgid "MaxMind GeoLite2 (free, account required)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2830
+#: src/muuli_wdr.cpp:2861
 msgid "Custom URL"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2833
+#: src/muuli_wdr.cpp:2864
 msgid "Choose which provider supplies the GeoIP MMDB database. DB-IP is the default - no account required. MaxMind requires a free account + license key. Use Custom URL to point at any other MMDB host (e.g. a local mirror)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2850
+#: src/muuli_wdr.cpp:2881
 msgid ""
 "No configuration required.\n"
 "\n"
@@ -4887,11 +4915,11 @@ msgid ""
 "License: Creative Commons BY 4.0 - https://creativecommons.org/licenses/by/4.0/"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2863
+#: src/muuli_wdr.cpp:2894
 msgid "License key:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2869
+#: src/muuli_wdr.cpp:2900
 msgid ""
 "Sign up for a free MaxMind account, then generate a License Key:\n"
 "https://www.maxmind.com/en/geolite2/signup\n"
@@ -4901,232 +4929,232 @@ msgid ""
 "Requires attribution and account registration; refresh at least every 30 days."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2884
+#: src/muuli_wdr.cpp:2915
 #, fuzzy
 msgid "Download URL:"
 msgstr "Atsiųsta: "
 
-#: src/muuli_wdr.cpp:2890
+#: src/muuli_wdr.cpp:2921
 msgid ""
 "Must point to an .mmdb file or a .gz / .tar.gz containing one.\n"
 "URL may include credentials (https://user:pass@host/...).\n"
 "License and attribution terms are set by the upstream URL - you are responsible."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2903
+#: src/muuli_wdr.cpp:2934
 msgid "Download the GeoIP database from the selected source."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2905
+#: src/muuli_wdr.cpp:2936
 #, fuzzy
 msgid "Auto-update on startup"
 msgstr "Automatiškai įkelti IP filtrą paleidus programą"
 
-#: src/muuli_wdr.cpp:2906
+#: src/muuli_wdr.cpp:2937
 msgid "Re-download the GeoIP database from the selected source every time aMule starts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2929
+#: src/muuli_wdr.cpp:2960
 msgid "Filter incoming messages (except current chat):"
 msgstr "Filtruoti gaunamas žinutes (išskyrus dabartinį pokalbį):"
 
-#: src/muuli_wdr.cpp:2931
+#: src/muuli_wdr.cpp:2962
 msgid "Filter all messages"
 msgstr "Filtruoti visas žinutes"
 
-#: src/muuli_wdr.cpp:2933
+#: src/muuli_wdr.cpp:2964
 msgid "Filter messages from people not on your friend list"
 msgstr "Filtruoti žinutes nuo naudotojų, nesančių draugų sąraše"
 
-#: src/muuli_wdr.cpp:2935
+#: src/muuli_wdr.cpp:2966
 msgid "Filter messages from unknown clients"
 msgstr "Filtruoti žinutes nuo nežinomų klientų"
 
-#: src/muuli_wdr.cpp:2937
+#: src/muuli_wdr.cpp:2968
 msgid "Filter messages containing (use ',' as separator):"
 msgstr "Filtruoti žinutes turinčias tekstą („,“ naudokite kaip skirtuką):"
 
-#: src/muuli_wdr.cpp:2940 src/muuli_wdr.cpp:2951
+#: src/muuli_wdr.cpp:2971 src/muuli_wdr.cpp:2982
 msgid "add here the words amule should filter and block messages including it"
 msgstr "Įrašykite žodžius, kurių aMule ieškos žinutės tekste ir filtruos žinutę"
 
-#: src/muuli_wdr.cpp:2942
+#: src/muuli_wdr.cpp:2973
 msgid "Show received messages in the log"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2945
+#: src/muuli_wdr.cpp:2976
 msgid "Comments"
 msgstr "Komentarai"
 
-#: src/muuli_wdr.cpp:2948
+#: src/muuli_wdr.cpp:2979
 msgid "Filter comments containing (use ',' as separator):"
 msgstr "Filtruoti komentarus, turinčius (atskirkite kableliu):"
 
-#: src/muuli_wdr.cpp:2973
+#: src/muuli_wdr.cpp:3004
 msgid "Enable Proxy"
 msgstr "Įjungti atstovaujančius serverius"
 
-#: src/muuli_wdr.cpp:2974
+#: src/muuli_wdr.cpp:3005
 msgid "Enable/disable proxy support"
 msgstr "Įjungti ar išjungti atstovaujančius serverius"
 
-#: src/muuli_wdr.cpp:2977
+#: src/muuli_wdr.cpp:3008
 msgid "Proxy type:"
 msgstr "Serverio tipas:"
 
-#: src/muuli_wdr.cpp:2988
+#: src/muuli_wdr.cpp:3019
 msgid "Proxy host:"
 msgstr "Serverio mazgas:"
 
-#: src/muuli_wdr.cpp:2991
+#: src/muuli_wdr.cpp:3022
 msgid "The proxy host name"
 msgstr "Atstovaujančio serverio mazgo pavadinimas"
 
-#: src/muuli_wdr.cpp:2993
+#: src/muuli_wdr.cpp:3024
 msgid "Proxy port:"
 msgstr "Serverio prievadas:"
 
-#: src/muuli_wdr.cpp:2996
+#: src/muuli_wdr.cpp:3027
 msgid "The proxy port"
 msgstr "Atstovaujančio serverio prievadas"
 
-#: src/muuli_wdr.cpp:2998
+#: src/muuli_wdr.cpp:3029
 msgid "Enable authentication"
 msgstr "Įjungti autentifikavimą"
 
-#: src/muuli_wdr.cpp:2999
+#: src/muuli_wdr.cpp:3030
 msgid "Enable/disable username/password authentication"
 msgstr "Įjungti ar išjungti naudotojo vardo ir slaptažodžio autentifikavimą"
 
-#: src/muuli_wdr.cpp:3002
+#: src/muuli_wdr.cpp:3033
 msgid "Username: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:3005
+#: src/muuli_wdr.cpp:3036
 msgid "The username to use to connect to the proxy"
 msgstr "Naudotojo vardas prisijungimui prie atstovaujančio serverio"
 
-#: src/muuli_wdr.cpp:3007
+#: src/muuli_wdr.cpp:3038
 msgid "Password:"
 msgstr "Slaptažodis:"
 
-#: src/muuli_wdr.cpp:3010
+#: src/muuli_wdr.cpp:3041
 msgid "The password to use to connect to the proxy"
 msgstr "Slaptažodis prisijungimui prie atstovaujančio serverio"
 
-#: src/muuli_wdr.cpp:3029
+#: src/muuli_wdr.cpp:3060
 msgid "Connect to:"
 msgstr "Prijungti prie:"
 
-#: src/muuli_wdr.cpp:3038
+#: src/muuli_wdr.cpp:3069
 msgid "Login to remote amule"
 msgstr "Prisijungti prie nutolusios aMule"
 
-#: src/muuli_wdr.cpp:3043
+#: src/muuli_wdr.cpp:3074
 msgid "User name"
 msgstr "Naudotojo vardas"
 
-#: src/muuli_wdr.cpp:3054
+#: src/muuli_wdr.cpp:3085
 msgid "Remember those settings"
 msgstr "Įsiminti parinktis"
 
-#: src/muuli_wdr.cpp:3057
+#: src/muuli_wdr.cpp:3088
 #, fuzzy
 msgid "Force ZLIB compression"
 msgstr "Naudoti gzip pakavimą"
 
-#: src/muuli_wdr.cpp:3081
+#: src/muuli_wdr.cpp:3112
 msgid "Enable Verbose Debug-Logging."
 msgstr "Įjungti išsamų klaidų taisymo žurnalą."
 
-#: src/muuli_wdr.cpp:3083
+#: src/muuli_wdr.cpp:3114
 #, fuzzy
 msgid "Only to Logfile"
 msgstr "&Atverti failą"
 
-#: src/muuli_wdr.cpp:3085
+#: src/muuli_wdr.cpp:3116
 msgid "Message Categories:"
 msgstr "Žinučių kategorijos:"
 
-#: src/muuli_wdr.cpp:3109 src/PartFileConvertDlg.cpp:160
+#: src/muuli_wdr.cpp:3140 src/PartFileConvertDlg.cpp:160
 msgid "Waiting..."
 msgstr "Laukiama..."
 
-#: src/muuli_wdr.cpp:3129
+#: src/muuli_wdr.cpp:3160
 msgid "Add imports"
 msgstr "Įdėti failus"
 
-#: src/muuli_wdr.cpp:3132
+#: src/muuli_wdr.cpp:3163
 msgid "Retry selected"
 msgstr "Pažymėtas bandyti iš naujo"
 
-#: src/muuli_wdr.cpp:3134
+#: src/muuli_wdr.cpp:3165
 msgid "Remove selected"
 msgstr "Pašalinti pažymėtas"
 
-#: src/muuli_wdr.cpp:3197
+#: src/muuli_wdr.cpp:3228
 msgid "Event Types"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3216
+#: src/muuli_wdr.cpp:3247
 msgid "Statistics and queued clients for selected file(s) : Session / All time"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3240
+#: src/muuli_wdr.cpp:3271
 #, fuzzy
 msgid "Active Uploads"
 msgstr "Aktyvūs išsiuntimai:"
 
-#: src/muuli_wdr.cpp:3254
+#: src/muuli_wdr.cpp:3285
 msgid "Percent of total files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3306
+#: src/muuli_wdr.cpp:3337
 #, fuzzy
 msgid "Show Clients for"
 msgstr "Rodyti klientus"
 
-#: src/muuli_wdr.cpp:3308
+#: src/muuli_wdr.cpp:3339
 #, fuzzy
 msgid "All files"
 msgstr "Slėpti dalinamus failus"
 
-#: src/muuli_wdr.cpp:3311
+#: src/muuli_wdr.cpp:3342
 #, fuzzy
 msgid "Selected files"
 msgstr "Parinkite filtrą"
 
-#: src/muuli_wdr.cpp:3314
+#: src/muuli_wdr.cpp:3345
 #, fuzzy
 msgid "Active uploads only"
 msgstr "Aktyvūs išsiuntimai"
 
-#: src/muuli_wdr.cpp:3321
+#: src/muuli_wdr.cpp:3352
 #, fuzzy
 msgid "Reload:"
 msgstr "Atnaujinti sąrašą"
 
-#: src/muuli_wdr.cpp:3325
+#: src/muuli_wdr.cpp:3356
 msgid "Reload your shared files"
 msgstr "Atnaujinti dalinamų failų sąrašą"
 
-#: src/muuli_wdr.cpp:3388
+#: src/muuli_wdr.cpp:3419
 msgid "Send"
 msgstr "Siųsti"
 
-#: src/muuli_wdr.cpp:3389
+#: src/muuli_wdr.cpp:3420
 msgid "Sends the specified message."
 msgstr "Išsiųsti įrašytą žinutę."
 
-#: src/muuli_wdr.cpp:3393
+#: src/muuli_wdr.cpp:3424
 msgid "Close this chat-session."
 msgstr "Baigti pokalbį ir užverti pokalbio kortelę."
 
-#: src/muuli_wdr.cpp:3416
+#: src/muuli_wdr.cpp:3447
 msgid "Connect to any server and/or Kad"
 msgstr "Prisijungti prie bet kurio serverio ir/ar Kademlia tinklo"
 
-#: src/muuli_wdr.cpp:3422 src/SharedFilesCtrl.cpp:142 src/Statistics.cpp:941
+#: src/muuli_wdr.cpp:3453 src/SharedFilesCtrl.cpp:142 src/Statistics.cpp:941
 msgid "Shared Files"
 msgstr "Dalinami failai"
 
@@ -5491,268 +5519,268 @@ msgstr "Atsiųsta"
 msgid "ERROR: Failed to open partfile '%s'"
 msgstr "KLAIDA: nepavyko atverti dalių failo „%s“"
 
-#: src/Preferences.cpp:674
+#: src/Preferences.cpp:701
 msgid "System default"
 msgstr "Numatyta"
 
-#: src/Preferences.cpp:675
+#: src/Preferences.cpp:702
 msgid "Albanian"
 msgstr "Albanų"
 
-#: src/Preferences.cpp:676
+#: src/Preferences.cpp:703
 msgid "Arabic"
 msgstr "Arabų"
 
-#: src/Preferences.cpp:677
+#: src/Preferences.cpp:704
 #, fuzzy
 msgid "Asturian"
 msgstr "Estų"
 
-#: src/Preferences.cpp:678
+#: src/Preferences.cpp:705
 msgid "Basque"
 msgstr "Baskų"
 
-#: src/Preferences.cpp:679
+#: src/Preferences.cpp:706
 msgid "Bulgarian"
 msgstr "Bulgarų"
 
-#: src/Preferences.cpp:680
+#: src/Preferences.cpp:707
 msgid "Catalan"
 msgstr "Katalonų"
 
-#: src/Preferences.cpp:681
+#: src/Preferences.cpp:708
 msgid "Chinese (Simplified)"
 msgstr "Kinų (supaprastinta)"
 
-#: src/Preferences.cpp:682
+#: src/Preferences.cpp:709
 msgid "Chinese (Traditional)"
 msgstr "Kinų (tradicinė)"
 
-#: src/Preferences.cpp:683
+#: src/Preferences.cpp:710
 msgid "Croatian"
 msgstr "Kroatų"
 
-#: src/Preferences.cpp:684
+#: src/Preferences.cpp:711
 msgid "Czech"
 msgstr "Čekų"
 
-#: src/Preferences.cpp:685
+#: src/Preferences.cpp:712
 msgid "Danish"
 msgstr "Danų"
 
-#: src/Preferences.cpp:686
+#: src/Preferences.cpp:713
 msgid "Dutch"
 msgstr "Olandų"
 
-#: src/Preferences.cpp:687
+#: src/Preferences.cpp:714
 msgid "English (U.K.)"
 msgstr "Anglų (DB)"
 
-#: src/Preferences.cpp:688
+#: src/Preferences.cpp:715
 #, fuzzy
 msgid "English (U.S.)"
 msgstr "Anglų (DB)"
 
-#: src/Preferences.cpp:689
+#: src/Preferences.cpp:716
 msgid "Estonian"
 msgstr "Estų"
 
-#: src/Preferences.cpp:690
+#: src/Preferences.cpp:717
 msgid "Finnish"
 msgstr "Suomių"
 
-#: src/Preferences.cpp:691
+#: src/Preferences.cpp:718
 msgid "French"
 msgstr "Prancūzų"
 
-#: src/Preferences.cpp:692
+#: src/Preferences.cpp:719
 msgid "Galician"
 msgstr "Galisijos"
 
-#: src/Preferences.cpp:693
+#: src/Preferences.cpp:720
 msgid "German"
 msgstr "Vokiečių"
 
-#: src/Preferences.cpp:694
+#: src/Preferences.cpp:721
 msgid "Greek"
 msgstr "Graikų"
 
-#: src/Preferences.cpp:695
+#: src/Preferences.cpp:722
 msgid "Hebrew"
 msgstr "Žydų"
 
-#: src/Preferences.cpp:696
+#: src/Preferences.cpp:723
 msgid "Hungarian"
 msgstr "Vengrų"
 
-#: src/Preferences.cpp:697
+#: src/Preferences.cpp:724
 msgid "Italian"
 msgstr "Italų"
 
-#: src/Preferences.cpp:698
+#: src/Preferences.cpp:725
 msgid "Japanese"
 msgstr "Japonų"
 
-#: src/Preferences.cpp:699
+#: src/Preferences.cpp:726
 msgid "Korean"
 msgstr "Korėjiečių"
 
-#: src/Preferences.cpp:700
+#: src/Preferences.cpp:727
 msgid "Latvian"
 msgstr ""
 
-#: src/Preferences.cpp:701
+#: src/Preferences.cpp:728
 msgid "Lithuanian"
 msgstr "Lietuvių"
 
-#: src/Preferences.cpp:702
+#: src/Preferences.cpp:729
 msgid "Norwegian (Nynorsk)"
 msgstr "Norvegų (naujoji norvegų)"
 
-#: src/Preferences.cpp:703
+#: src/Preferences.cpp:730
 msgid "Polish"
 msgstr "Lenkų"
 
-#: src/Preferences.cpp:704
+#: src/Preferences.cpp:731
 msgid "Portuguese"
 msgstr "Portugalų"
 
-#: src/Preferences.cpp:705
+#: src/Preferences.cpp:732
 msgid "Portuguese (Brazilian)"
 msgstr "Portugalų (Brazilijos)"
 
-#: src/Preferences.cpp:706
+#: src/Preferences.cpp:733
 #, fuzzy
 msgid "Romanian"
 msgstr "Albanų"
 
-#: src/Preferences.cpp:707
+#: src/Preferences.cpp:734
 msgid "Russian"
 msgstr "Rusų"
 
-#: src/Preferences.cpp:708
+#: src/Preferences.cpp:735
 msgid "Slovenian"
 msgstr "Slovėnų"
 
-#: src/Preferences.cpp:709
+#: src/Preferences.cpp:736
 msgid "Spanish"
 msgstr "Ispanų"
 
-#: src/Preferences.cpp:710
+#: src/Preferences.cpp:737
 msgid "Swedish"
 msgstr "Švedų"
 
-#: src/Preferences.cpp:711
+#: src/Preferences.cpp:738
 msgid "Turkish"
 msgstr "Turkų"
 
-#: src/Preferences.cpp:712
+#: src/Preferences.cpp:739
 msgid "Ukrainian"
 msgstr ""
 
-#: src/Preferences.cpp:815
+#: src/Preferences.cpp:842
 #, fuzzy
 msgid "Change Language"
 msgstr "Kalba"
 
-#: src/Preferences.cpp:879
+#: src/Preferences.cpp:906
 msgid "There are no translations installed for aMule"
 msgstr ""
 
-#: src/Preferences.cpp:880
+#: src/Preferences.cpp:907
 #, fuzzy
 msgid "No languages available"
 msgstr "Nėra"
 
-#: src/Preferences.cpp:1011
+#: src/Preferences.cpp:1038
 msgid "no options available"
 msgstr ""
 
-#: src/Preferences.cpp:2182
+#: src/Preferences.cpp:2227
 msgid "Invalid category found, skipping"
 msgstr ""
 
-#: src/Preferences.cpp:2351
+#: src/Preferences.cpp:2396
 msgid "TCP port can't be higher than 65532 due to server UDP socket being TCP+3"
 msgstr "TCP prievadas negali būti didesnis nei 65532, nes serverio UDP prievadas yra TCP+3"
 
-#: src/Preferences.cpp:2352
+#: src/Preferences.cpp:2397
 #, c-format
 msgid "Default port will be used (%d)"
 msgstr "Bus naudojamas numatytas prievadas (%d)"
 
-#: src/PrefsUnifiedDlg.cpp:298 src/Statistics.cpp:866
+#: src/PrefsUnifiedDlg.cpp:300 src/Statistics.cpp:866
 msgid "Connection"
 msgstr "Kanalas"
 
-#: src/PrefsUnifiedDlg.cpp:299 src/SearchListCtrl.cpp:117
+#: src/PrefsUnifiedDlg.cpp:301 src/SearchListCtrl.cpp:117
 msgid "Directories"
 msgstr "Aplankai"
 
-#: src/PrefsUnifiedDlg.cpp:300 src/Statistics.cpp:917
+#: src/PrefsUnifiedDlg.cpp:302 src/Statistics.cpp:917
 msgid "Servers"
 msgstr "Serveriai"
 
-#: src/PrefsUnifiedDlg.cpp:301 src/ServerListCtrl.cpp:96
+#: src/PrefsUnifiedDlg.cpp:303 src/ServerListCtrl.cpp:96
 msgid "Files"
 msgstr "Failai"
 
-#: src/PrefsUnifiedDlg.cpp:302
+#: src/PrefsUnifiedDlg.cpp:304
 msgid "Security"
 msgstr "Saugumas"
 
-#: src/PrefsUnifiedDlg.cpp:303
+#: src/PrefsUnifiedDlg.cpp:305
 msgid "Interface"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:310
+#: src/PrefsUnifiedDlg.cpp:312
 msgid "IP2Country"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:313
+#: src/PrefsUnifiedDlg.cpp:315
 msgid "Proxy"
 msgstr "Atstovaujantis serveris"
 
-#: src/PrefsUnifiedDlg.cpp:314
+#: src/PrefsUnifiedDlg.cpp:316
 msgid "Filters"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:315
+#: src/PrefsUnifiedDlg.cpp:317
 msgid "Remote Controls"
 msgstr "Nutolęs valdymas"
 
-#: src/PrefsUnifiedDlg.cpp:316
+#: src/PrefsUnifiedDlg.cpp:318
 msgid "Online Signature"
 msgstr "Keičiamas parašas"
 
-#: src/PrefsUnifiedDlg.cpp:317
+#: src/PrefsUnifiedDlg.cpp:319
 msgid "Advanced"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:318
+#: src/PrefsUnifiedDlg.cpp:320
 msgid "Events"
 msgstr "Įvykiai"
 
-#: src/PrefsUnifiedDlg.cpp:321
+#: src/PrefsUnifiedDlg.cpp:323
 msgid "Debugging"
 msgstr "Taisymas"
 
-#: src/PrefsUnifiedDlg.cpp:451
+#: src/PrefsUnifiedDlg.cpp:453
 msgid ""
 "The following variables will be substituted:\n"
 "    %PARTFILE - full path to the file\n"
 "    %PARTNAME - file name only"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:472
+#: src/PrefsUnifiedDlg.cpp:474
 msgid "Tray icon support requires libayatana-appindicator3 at compile time."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:488
+#: src/PrefsUnifiedDlg.cpp:490
 msgid "Not available on Wayland: the protocol does not report when a window is minimized, so this option cannot intercept the system minimize button. Workaround: launch aMule with `GDK_BACKEND=x11` to use XWayland instead."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:534
+#: src/PrefsUnifiedDlg.cpp:536
 msgid ""
 "Do not change these setting unless you know\n"
 "what you are doing, otherwise you can easily\n"
@@ -5767,26 +5795,35 @@ msgstr ""
 "\n"
 "aMule puikiai veikia nieko nepakeitus šiame lange."
 
-#: src/PrefsUnifiedDlg.cpp:645
+#: src/PrefsUnifiedDlg.cpp:647
 #, c-format
 msgid "Failed to connect Cfg to widget with the ID %d and key %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:693
+#: src/PrefsUnifiedDlg.cpp:695
 #, c-format
 msgid "Failed to transfer data from Cfg to Widget with the ID %d and key %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:799
+#: src/PrefsUnifiedDlg.cpp:801
 msgid "The type of proxy you are connecting to"
 msgstr "Atstovaujančio serverio, prie kurio jungsitės, tipas"
 
-#: src/PrefsUnifiedDlg.cpp:1003
+#: src/PrefsUnifiedDlg.cpp:1020
 #, c-format
 msgid "Failed to transfer data from Widget to Cfg with the ID %d and key %s"
 msgstr ""
 
 #: src/PrefsUnifiedDlg.cpp:1103
+#, fuzzy
+msgid "No password set."
+msgstr "Tikrinamas slaptažodis\n"
+
+#: src/PrefsUnifiedDlg.cpp:1132
+msgid "Guest access needs a password. Type one in the guest password field, or untick Enable guest access."
+msgstr ""
+
+#: src/PrefsUnifiedDlg.cpp:1144
 msgid ""
 "aMule must be restarted to enable these changes:\n"
 "\n"
@@ -5794,51 +5831,51 @@ msgstr ""
 "Kad įsigaliotų šie pakeitimai, aMule reikia paleisti iš naujo:\n"
 "\n"
 
-#: src/PrefsUnifiedDlg.cpp:1110
+#: src/PrefsUnifiedDlg.cpp:1151
 msgid "- TCP port changed.\n"
 msgstr "– pakeistas TCP prievadas.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1115
+#: src/PrefsUnifiedDlg.cpp:1156
 msgid "- UDP port changed.\n"
 msgstr "– pakeistas UDP prievadas.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1120
+#: src/PrefsUnifiedDlg.cpp:1161
 #, fuzzy
 msgid "- Network interface binding changed.\n"
 msgstr "Išorinis ryšys nutrauktas."
 
-#: src/PrefsUnifiedDlg.cpp:1125
+#: src/PrefsUnifiedDlg.cpp:1166
 #, fuzzy
 msgid "- External connect port changed.\n"
 msgstr "Išorinis ryšys nutrauktas."
 
-#: src/PrefsUnifiedDlg.cpp:1129
+#: src/PrefsUnifiedDlg.cpp:1170
 #, fuzzy
 msgid "- External connect acceptance changed.\n"
 msgstr "Naujas išorinis ryšys priimtas"
 
-#: src/PrefsUnifiedDlg.cpp:1133
+#: src/PrefsUnifiedDlg.cpp:1174
 #, fuzzy
 msgid "- External connect interface changed.\n"
 msgstr "Išorinis ryšys nutrauktas."
 
-#: src/PrefsUnifiedDlg.cpp:1137
+#: src/PrefsUnifiedDlg.cpp:1178
 #, fuzzy
 msgid "- Protocol obfuscation support changed.\n"
 msgstr "Protokolo slėpimas"
 
-#: src/PrefsUnifiedDlg.cpp:1151
+#: src/PrefsUnifiedDlg.cpp:1193
 #, fuzzy
 msgid "- amuleapi settings changed.\n"
 msgstr "– kalba pakeista.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1160
+#: src/PrefsUnifiedDlg.cpp:1202
 msgid ""
 "Your Auto-update server list is empty.\n"
 "'Auto-update server list at startup' will be disabled."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1171
+#: src/PrefsUnifiedDlg.cpp:1213
 msgid ""
 "You have enabled external connections but have not specified a password.\n"
 "External connections cannot be enabled unless a valid password is specified."
@@ -5846,29 +5883,34 @@ msgstr ""
 "Įjungėte išorinius ryšius, bet parinktyse nenurodėte slaptažodžio.\n"
 "Kol nenurodysite slaptažodžio, išoriniai ryšiai nebus įjungti."
 
-#: src/PrefsUnifiedDlg.cpp:1202
+#: src/PrefsUnifiedDlg.cpp:1246
+#, c-format
+msgid "The amuleapi password could not be saved: %s"
+msgstr ""
+
+#: src/PrefsUnifiedDlg.cpp:1276
 msgid "- Language changed.\n"
 msgstr "– kalba pakeista.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1207
+#: src/PrefsUnifiedDlg.cpp:1281
 msgid "- Temp folder changed.\n"
 msgstr "– laikinų failų aplankas pakeistas.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1212
+#: src/PrefsUnifiedDlg.cpp:1286
 #, fuzzy
 msgid "- ED2K network enabled.\n"
 msgstr "Visi tinklai išjungti."
 
-#: src/PrefsUnifiedDlg.cpp:1245
+#: src/PrefsUnifiedDlg.cpp:1319
 msgid "The shared-file exclusion pattern is not a valid regular expression. The filter has been left disabled."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1247 src/PrefsUnifiedDlg.cpp:1841
+#: src/PrefsUnifiedDlg.cpp:1321 src/PrefsUnifiedDlg.cpp:1921
 #, fuzzy
 msgid "Invalid regular expression"
 msgstr "Neteisinga protokolo versija."
 
-#: src/PrefsUnifiedDlg.cpp:1324
+#: src/PrefsUnifiedDlg.cpp:1398
 msgid ""
 "Both eD2k and Kad network are disabled.\n"
 "You won't be able to connect until you enable at least one of them."
@@ -5876,7 +5918,7 @@ msgstr ""
 "Tiek eD2k, tiek Kademlia tinklai yra išjungti.\n"
 "Norėdami prisijungti įjunkite bent vieną iš šių tinklų."
 
-#: src/PrefsUnifiedDlg.cpp:1329
+#: src/PrefsUnifiedDlg.cpp:1403
 msgid ""
 "Kad will not start if your UDP port is disabled.\n"
 "Enable UDP port or disable Kad."
@@ -5884,7 +5926,7 @@ msgstr ""
 "Nepavyks prisijungti prie Kademlia tinklo, nes išjungtas UDP prievadas.\n"
 "Arba įjunkite UDP prievadą, arba išjunkite Kademlia tinklą."
 
-#: src/PrefsUnifiedDlg.cpp:1385
+#: src/PrefsUnifiedDlg.cpp:1459
 msgid ""
 "\n"
 "You MUST restart aMule now.\n"
@@ -5894,69 +5936,69 @@ msgstr ""
 "Būtina paleisti aMule iš naujo.\n"
 "Jei dabar pat neperleisite aMule, nesiskųskite jei kas nors bus ne taip.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1450
+#: src/PrefsUnifiedDlg.cpp:1524
 msgid "Could not register aMule for autostart at login. The autostart store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1452
+#: src/PrefsUnifiedDlg.cpp:1526
 msgid "Could not remove the autostart-at-login entry."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1453
+#: src/PrefsUnifiedDlg.cpp:1527
 #, fuzzy
 msgid "Autostart"
 msgstr "Automatinis atnaujinimas paleistas"
 
-#: src/PrefsUnifiedDlg.cpp:1468
+#: src/PrefsUnifiedDlg.cpp:1542
 msgid "Register file type"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1468
+#: src/PrefsUnifiedDlg.cpp:1542
 msgid "Register URL handler"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1476
+#: src/PrefsUnifiedDlg.cpp:1550
 #, c-format
 msgid "aMule only handles eD2k-compatible magnets. If you replace the current magnet handler (%s), BitTorrent magnet links will stop working - aMule cannot download BitTorrent content. Continue?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1481
+#: src/PrefsUnifiedDlg.cpp:1555
 #, c-format
 msgid "Another application currently opens .emulecollection files (%s). Replace it with aMule?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1486
+#: src/PrefsUnifiedDlg.cpp:1560
 #, c-format
 msgid "Another application is currently the default handler for these links (%s). Replace it with aMule?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1511
+#: src/PrefsUnifiedDlg.cpp:1585
 msgid "Could not register aMule for .emulecollection files. The registration store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1513
+#: src/PrefsUnifiedDlg.cpp:1587
 #, fuzzy
 msgid "Could not remove the file type registration."
 msgstr "Failas %s jau yra atsiunčiamų failų sąraše"
 
-#: src/PrefsUnifiedDlg.cpp:1515
+#: src/PrefsUnifiedDlg.cpp:1589
 msgid "Could not register aMule as the URL handler. The registration store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1517
+#: src/PrefsUnifiedDlg.cpp:1591
 msgid "Could not remove the URL handler registration."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1587 src/PrefsUnifiedDlg.cpp:1614
+#: src/PrefsUnifiedDlg.cpp:1661 src/PrefsUnifiedDlg.cpp:1688
 #, fuzzy
 msgid "The web server and aMule API require external connections to be enabled."
 msgstr "Naujas išorinis ryšys priimtas"
 
-#: src/PrefsUnifiedDlg.cpp:1597
+#: src/PrefsUnifiedDlg.cpp:1671
 msgid "The aMule web server is deprecated. Consider running the aMule API instead."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1655
+#: src/PrefsUnifiedDlg.cpp:1735
 msgid ""
 "Your Auto-update servers list is in blank.\n"
 "Please fill in at least one URL to point to a valid server.met file.\n"
@@ -5966,24 +6008,24 @@ msgstr ""
 "Įrašykite bent vieną server.met failo URL.\n"
 "Norėdami įrašyti URL, paspauskite mygtuką „Sąrašas“."
 
-#: src/PrefsUnifiedDlg.cpp:1796
+#: src/PrefsUnifiedDlg.cpp:1876
 msgid "Temporary files"
 msgstr "Laikini failai"
 
-#: src/PrefsUnifiedDlg.cpp:1801
+#: src/PrefsUnifiedDlg.cpp:1881
 msgid "Incoming files"
 msgstr "Atsiųsti failai"
 
-#: src/PrefsUnifiedDlg.cpp:1806
+#: src/PrefsUnifiedDlg.cpp:1886
 msgid "Online Signatures"
 msgstr "Keičiami parašai"
 
-#: src/PrefsUnifiedDlg.cpp:1819
+#: src/PrefsUnifiedDlg.cpp:1899
 #, c-format
 msgid "Choose a folder for %s"
 msgstr "Parinkite aplanką %s"
 
-#: src/PrefsUnifiedDlg.cpp:1843
+#: src/PrefsUnifiedDlg.cpp:1923
 #, fuzzy, c-format
 msgid "Would exclude %u of %u shared file"
 msgid_plural "Would exclude %u of %u shared files"
@@ -5991,42 +6033,42 @@ msgstr[0] "Aptiktas %i dalinamas failas"
 msgstr[1] "Aptikti %i dalinami failai"
 msgstr[2] "Aptikta %i dalinamų failų"
 
-#: src/PrefsUnifiedDlg.cpp:1860
+#: src/PrefsUnifiedDlg.cpp:1940
 msgid "Browse for videoplayer"
 msgstr "Parinkite video grotuvą"
 
-#: src/PrefsUnifiedDlg.cpp:1864
+#: src/PrefsUnifiedDlg.cpp:1944
 msgid "Select browser"
 msgstr "Parinkite naršyklę"
 
-#: src/PrefsUnifiedDlg.cpp:1868
+#: src/PrefsUnifiedDlg.cpp:1948
 #, fuzzy
 msgid "Select ffprobe binary"
 msgstr "Parinkite naršyklę"
 
-#: src/PrefsUnifiedDlg.cpp:1874
+#: src/PrefsUnifiedDlg.cpp:1954
 #, c-format
 msgid "Executable%s"
 msgstr "Vykdomas failas %s"
 
-#: src/PrefsUnifiedDlg.cpp:1908
+#: src/PrefsUnifiedDlg.cpp:1988
 msgid "ffprobe not found on PATH or in the standard install locations. Install ffmpeg (which ships ffprobe) or use Browse to pick a binary manually."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1920
+#: src/PrefsUnifiedDlg.cpp:2000
 msgid "Reset the settings on this page to their default values?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1921
+#: src/PrefsUnifiedDlg.cpp:2001
 #, fuzzy
 msgid "Reset to defaults"
 msgstr "Numatyta"
 
-#: src/PrefsUnifiedDlg.cpp:1948
+#: src/PrefsUnifiedDlg.cpp:2028
 msgid "Edit server list"
 msgstr "Keisti serverių sąrašą"
 
-#: src/PrefsUnifiedDlg.cpp:1949
+#: src/PrefsUnifiedDlg.cpp:2029
 msgid ""
 "Add here URL's to download server.met files.\n"
 "Only one url on each line."
@@ -6034,42 +6076,42 @@ msgstr ""
 "Įrašykite server.met failų URL.\n"
 "Vieną URL vienoje eilutėje."
 
-#: src/PrefsUnifiedDlg.cpp:2004
+#: src/PrefsUnifiedDlg.cpp:2084
 msgid "IP2Country update failed"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2149 src/PrefsUnifiedDlg.cpp:2180
+#: src/PrefsUnifiedDlg.cpp:2229 src/PrefsUnifiedDlg.cpp:2260
 msgid "Data by MaxMind GeoLite2"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2151 src/PrefsUnifiedDlg.cpp:2182
+#: src/PrefsUnifiedDlg.cpp:2231 src/PrefsUnifiedDlg.cpp:2262
 #, fuzzy
 msgid "Custom source"
 msgstr "Pilni šaltiniai"
 
-#: src/PrefsUnifiedDlg.cpp:2153 src/PrefsUnifiedDlg.cpp:2184
+#: src/PrefsUnifiedDlg.cpp:2233 src/PrefsUnifiedDlg.cpp:2264
 msgid "Data by DB-IP.com"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2204
+#: src/PrefsUnifiedDlg.cpp:2284
 #, fuzzy, c-format
 msgid "Status: Loaded%s"
 msgstr "Būsena:"
 
-#: src/PrefsUnifiedDlg.cpp:2206
+#: src/PrefsUnifiedDlg.cpp:2286
 #, fuzzy, c-format
 msgid "Status: Loaded%s - %s"
 msgstr "Būsena:"
 
-#: src/PrefsUnifiedDlg.cpp:2210
+#: src/PrefsUnifiedDlg.cpp:2290
 msgid "Status: Failed to load - click 'Update now' to refresh."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2212
+#: src/PrefsUnifiedDlg.cpp:2292
 msgid "Status: Not found - click 'Update now' to download."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2270 src/PrefsUnifiedDlg.cpp:2294
+#: src/PrefsUnifiedDlg.cpp:2350 src/PrefsUnifiedDlg.cpp:2374
 #, c-format
 msgid "Update delay: %d second"
 msgid_plural "Update delay: %d seconds"
@@ -6077,7 +6119,7 @@ msgstr[0] "Atnaujinimo intervalas: %d s"
 msgstr[1] "Atnaujinimo intervalas: %d s"
 msgstr[2] "Atnaujinimo intervalas: %d s"
 
-#: src/PrefsUnifiedDlg.cpp:2278
+#: src/PrefsUnifiedDlg.cpp:2358
 #, c-format
 msgid "Time for average graph: %d minute"
 msgid_plural "Time for average graph: %d minutes"
@@ -6085,12 +6127,12 @@ msgstr[0] "Vidurkių grafiko trukmė: %d min."
 msgstr[1] "Vidurkių grafiko trukmė: %d min."
 msgstr[2] "Vidurkių grafiko trukmė: %d min."
 
-#: src/PrefsUnifiedDlg.cpp:2287
+#: src/PrefsUnifiedDlg.cpp:2367
 #, c-format
 msgid "Connections Graph Scale: %d"
 msgstr "Ryšių grafiko mastelis: %d"
 
-#: src/PrefsUnifiedDlg.cpp:2302
+#: src/PrefsUnifiedDlg.cpp:2382
 #, c-format
 msgid "File Buffer Size: %d byte"
 msgid_plural "File Buffer Size: %d bytes"
@@ -6098,7 +6140,7 @@ msgstr[0] "Failų buferio dydis: %d baitas"
 msgstr[1] "Failų buferio dydis: %d baitai"
 msgstr[2] "Failų buferio dydis: %d baitų"
 
-#: src/PrefsUnifiedDlg.cpp:2312
+#: src/PrefsUnifiedDlg.cpp:2392
 #, c-format
 msgid "Upload Queue Size: %d client"
 msgid_plural "Upload Queue Size: %d clients"
@@ -6106,7 +6148,7 @@ msgstr[0] "Išsiuntimo eilės dydis: %d klientas"
 msgstr[1] "Išsiuntimo eilės dydis: %d klientai"
 msgstr[2] "Išsiuntimo eilės dydis: %d klientų"
 
-#: src/PrefsUnifiedDlg.cpp:2322
+#: src/PrefsUnifiedDlg.cpp:2402
 #, c-format
 msgid "Server connection refresh interval: %d minute"
 msgid_plural "Server connection refresh interval: %d minutes"
@@ -6114,80 +6156,80 @@ msgstr[0] "Serverio ryšio atnaujinimo intervalas: %d min."
 msgstr[1] "Serverio ryšio atnaujinimo intervalas: %d min."
 msgstr[2] "Serverio ryšio atnaujinimo intervalas: %d min."
 
-#: src/PrefsUnifiedDlg.cpp:2327
+#: src/PrefsUnifiedDlg.cpp:2407
 msgid "Server connection refresh interval: Disabled"
 msgstr "Serverio ryšio atnaujinimo intervalas: išjungta"
 
-#: src/PrefsUnifiedDlg.cpp:2371
+#: src/PrefsUnifiedDlg.cpp:2451
 #, fuzzy
 msgid "disabled"
 msgstr "Išjungti"
 
-#: src/PrefsUnifiedDlg.cpp:2397
+#: src/PrefsUnifiedDlg.cpp:2477
 #, fuzzy, c-format
 msgid "Execute command on '%s' event"
 msgstr "Įvykus „%s“ įvykiui įvykdyti komandą"
 
-#: src/PrefsUnifiedDlg.cpp:2404
+#: src/PrefsUnifiedDlg.cpp:2484
 msgid "Enable command execution on core"
 msgstr "Įjungti komandos vykdymą branduolyje"
 
-#: src/PrefsUnifiedDlg.cpp:2416
+#: src/PrefsUnifiedDlg.cpp:2496
 msgid "Core command:"
 msgstr "Branduolio komanda:"
 
-#: src/PrefsUnifiedDlg.cpp:2432
+#: src/PrefsUnifiedDlg.cpp:2512
 msgid "Enable command execution on GUI"
 msgstr "Įjungti komandos vykdymą grafinėje aplinkoje"
 
-#: src/PrefsUnifiedDlg.cpp:2444
+#: src/PrefsUnifiedDlg.cpp:2524
 msgid "GUI command:"
 msgstr "Grafinės aplinkos komanda:"
 
-#: src/PrefsUnifiedDlg.cpp:2460
+#: src/PrefsUnifiedDlg.cpp:2540
 msgid "The following variables will be replaced:"
 msgstr "Šie kintamieji bus pakeisti:"
 
-#: src/PrefsUnifiedDlg.cpp:2628
+#: src/PrefsUnifiedDlg.cpp:2708
 msgid ""
 "The following folders look like system or sensitive locations:\n"
 "\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2633
+#: src/PrefsUnifiedDlg.cpp:2713
 msgid "Sharing them recursively will publish every file underneath on the eD2k/Kad networks. Do you really want to do this?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2636
+#: src/PrefsUnifiedDlg.cpp:2716
 #, fuzzy
 msgid "Confirm shared folders"
 msgstr "Atnaujinti dalinamų failų sąrašą"
 
-#: src/PrefsUnifiedDlg.cpp:2664
+#: src/PrefsUnifiedDlg.cpp:2744
 #, fuzzy
 msgid "Reloading shared files..."
 msgstr "Atnaujinti dalinamų failų sąrašą"
 
-#: src/PrefsUnifiedDlg.cpp:2665
+#: src/PrefsUnifiedDlg.cpp:2745
 msgid "Scanning for subdirectories..."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2666
+#: src/PrefsUnifiedDlg.cpp:2746
 #, fuzzy
 msgid "Updating shared folders"
 msgstr "Skaitomas laikinų failų aplankas"
 
-#: src/PrefsUnifiedDlg.cpp:2693
+#: src/PrefsUnifiedDlg.cpp:2773
 #, c-format
 msgid "Scanned %u directories..."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2743
+#: src/PrefsUnifiedDlg.cpp:2823
 #, fuzzy, c-format
 msgid "Reloading shared files: %u files scanned"
 msgstr "Atnaujinti dalinamų failų sąrašą."
 
-#: src/PrefsUnifiedDlg.cpp:2793
+#: src/PrefsUnifiedDlg.cpp:2873
 #, fuzzy
 msgid "Shared folder"
 msgstr "Dalinami failai"

--- a/po/lv.po
+++ b/po/lv.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-28 10:19+0200\n"
+"POT-Creation-Date: 2026-07-28 12:17+0200\n"
 "PO-Revision-Date: 2026-07-27 11:49+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: none\n"
@@ -190,83 +190,83 @@ msgstr ""
 msgid "WARNING: You can't add yourself as a source for an eD2k link while having a lowid."
 msgstr ""
 
-#: src/amule.cpp:300
+#: src/amule.cpp:301
 msgid "Now, exiting main app..."
 msgstr "Pašlaik aizver galveno programmu…"
 
-#: src/amule.cpp:330
+#: src/amule.cpp:331
 #, c-format
 msgid "Terminating amuleweb instance with pid '%d' ... "
 msgstr "Pārtrauc amuleweb procesu ar pid '%d' … "
 
-#: src/amule.cpp:334
+#: src/amule.cpp:335
 #, c-format
 msgid "Killing amuleweb instance with pid '%d' ... "
 msgstr "Iznīcina amuleweb procesu ar pid '%d' … "
 
-#: src/amule.cpp:336 src/amule.cpp:349 src/ClientRef.cpp:180
+#: src/amule.cpp:337 src/amule.cpp:350 src/ClientRef.cpp:180
 #: src/SearchDlg.cpp:1041 src/ServerListCtrl.cpp:98
 msgid "Failed"
 msgstr "Neizdevās"
 
-#: src/amule.cpp:343
+#: src/amule.cpp:344
 #, fuzzy, c-format
 msgid "Terminating amuleapi instance with pid '%d' ... "
 msgstr "Pārtrauc amuleweb procesu ar pid '%d' ... "
 
-#: src/amule.cpp:347
+#: src/amule.cpp:348
 #, c-format
 msgid "Killing amuleapi instance with pid '%d' ... "
 msgstr "Iznīcina amuleapi procesu ar pid '%d' … "
 
-#: src/amule.cpp:355
+#: src/amule.cpp:356
 msgid "aMule OnExit: Terminating core."
 msgstr ""
 
-#: src/amule.cpp:466
+#: src/amule.cpp:467
 msgid "aMule shutdown completed."
 msgstr ""
 
-#: src/amule.cpp:470
+#: src/amule.cpp:471
 msgid "Memory debug results for aMule exit:"
 msgstr ""
 
-#: src/amule.cpp:651
+#: src/amule.cpp:652
 #, c-format
 msgid "Binding aMule's peer-to-peer traffic to interface: %s (HTTP updates use the default route)"
 msgstr ""
 
-#: src/amule.cpp:655
+#: src/amule.cpp:656
 #, c-format
 msgid "Binding all network traffic to interface: %s"
 msgstr ""
 
-#: src/amule.cpp:659
+#: src/amule.cpp:660
 #, c-format
 msgid "WARNING: configured network interface '%s' was not found - traffic is NOT bound to it and may leave via the default route. Check the interface name in Preferences."
 msgstr ""
 
-#: src/amule.cpp:665
+#: src/amule.cpp:666
 #, c-format
 msgid "WARNING: binding to network interface '%s' requires elevated privileges and was NOT applied - traffic may leave via the default route. Grant the capability (e.g. 'sudo setcap cap_net_raw+ep' on the aMule binary) or run with sufficient privileges."
 msgstr ""
 
-#: src/amule.cpp:673
+#: src/amule.cpp:674
 #, c-format
 msgid "WARNING: could not bind to network interface '%s' - traffic may leave via the default route."
 msgstr ""
 
-#: src/amule.cpp:732
+#: src/amule.cpp:733
 msgid "Your locale has been changed to System Default due to a configuration change. Sorry."
 msgstr ""
 
-#: src/amule.cpp:734 src/amule.cpp:1581 src/CatDialog.cpp:128
+#: src/amule.cpp:735 src/amule.cpp:1589 src/CatDialog.cpp:128
 #: src/CatDialog.cpp:136 src/CatDialog.cpp:149 src/ServerList.cpp:366
 #: src/ServerListCtrl.cpp:152
 msgid "Info"
 msgstr "Informācija"
 
-#: src/amule.cpp:741
+#: src/amule.cpp:742
 msgid ""
 "\n"
 "EC configuration"
@@ -274,71 +274,71 @@ msgstr ""
 "\n"
 "EC iestatījumi"
 
-#: src/amule.cpp:744
+#: src/amule.cpp:745
 msgid "Password set and external connections enabled."
 msgstr ""
 
-#: src/amule.cpp:754 src/KadDlg.cpp:176 src/KadDlg.cpp:185
-#: src/PrefsUnifiedDlg.cpp:1387 src/SharedFilesCtrl.cpp:476
+#: src/amule.cpp:755 src/KadDlg.cpp:176 src/KadDlg.cpp:185
+#: src/PrefsUnifiedDlg.cpp:1461 src/SharedFilesCtrl.cpp:476
 msgid "WARNING"
 msgstr "BRĪDINĀJUMS"
 
-#: src/amule.cpp:991
+#: src/amule.cpp:992
 msgid "Network bootstrap"
 msgstr ""
 
-#: src/amule.cpp:996
+#: src/amule.cpp:997
 msgid ""
 "aMule has detected missing network bootstrap files.\n"
 "Select which ones to download:"
 msgstr ""
 
-#: src/amule.cpp:1005 src/FirstRunWizard.cpp:411
+#: src/amule.cpp:1006 src/FirstRunWizard.cpp:411
 msgid "eD2k server list (server.met)"
 msgstr "eD2k serveru saraksts (server.met)"
 
-#: src/amule.cpp:1012 src/FirstRunWizard.cpp:416
+#: src/amule.cpp:1013 src/FirstRunWizard.cpp:416
 msgid "Kad bootstrap nodes (nodes.dat)"
 msgstr ""
 
-#: src/amule.cpp:1102
+#: src/amule.cpp:1103
 #, c-format
 msgid "web server running on pid %d"
 msgstr ""
 
-#: src/amule.cpp:1115
+#: src/amule.cpp:1116
 msgid "You requested to run web server on startup, but the amuleweb binary cannot be run. Please install the package containing aMule web server, or build aMule from source with -DBUILD_WEBSERVER=YES and install it."
 msgstr "Jūs esiet iespējojuši 'Kad palaiž, palaist arī tīmekļa serveri' iestatījumu, taču amuleweb izpildāmo (bināro) datni nevar palaist. Lūdzu, uzstādiet pakotni, kas satur aMule tīmekļa serveri (amuleweb), vai pārkompilējiet aMule no pirmkoda ar -DBUILD_WEBSERVER=YES parametru un uzstādiet to."
 
-#: src/amule.cpp:1120 src/amule.cpp:1177 src/amule.cpp:1291 src/amule.cpp:1593
+#: src/amule.cpp:1121 src/amule.cpp:1185 src/amule.cpp:1299 src/amule.cpp:1601
 #: src/amule-remote-gui.cpp:603 src/amule-remote-gui.cpp:671
 #: src/amule-remote-gui.cpp:709 src/amule-remote-gui.cpp:1282
 #: src/amule-remote-gui.cpp:1345 src/amule-remote-gui.cpp:1372
-#: src/DownloadQueue.cpp:1481
+#: src/DownloadQueue.cpp:1481 src/PrefsUnifiedDlg.cpp:1247
 msgid "ERROR"
 msgstr "KĻŪDA"
 
-#: src/amule.cpp:1166
+#: src/amule.cpp:1174
 #, c-format
 msgid "amuleapi running on pid %d"
 msgstr ""
 
-#: src/amule.cpp:1172
+#: src/amule.cpp:1180
 #, fuzzy
 msgid "You requested to run amuleapi on startup, but the amuleapi binary cannot be run. Please install the package containing aMule's REST API server, or build aMule from source with -DBUILD_AMULEAPI=YES and install it."
 msgstr "Jūs esiet iespējojuši 'Kad palaiž, palaist arī tīmekļa serveri' iestatījumu, taču amuleweb izpildāmo (bināro) datni nevar palaist. Lūdzu, uzstādiet pakotni, kas satur aMule tīmekļa serveri (amuleweb), vai pārkompilējiet aMule no pirmkoda ar -DBUILD_WEBSERVER=YES parametru un uzstādiet to."
 
-#: src/amule.cpp:1259
+#: src/amule.cpp:1267
 #, c-format
 msgid "Could not bind ports to the specified address: %s"
 msgstr ""
 
-#: src/amule.cpp:1283
+#: src/amule.cpp:1291
 #, c-format
 msgid "Port %u is not available. You will be LOWID\n"
 msgstr ""
 
-#: src/amule.cpp:1288
+#: src/amule.cpp:1296
 #, c-format
 msgid ""
 "Port %u is not available!\n"
@@ -348,184 +348,184 @@ msgid ""
 "Check your network to make sure the port is open for output and input."
 msgstr ""
 
-#: src/amule.cpp:1385
+#: src/amule.cpp:1393
 msgid "Failed to create OnlineSig File"
 msgstr ""
 
-#: src/amule.cpp:1393
+#: src/amule.cpp:1401
 msgid "Failed to create aMule OnlineSig File"
 msgstr ""
 
-#: src/amule.cpp:1556
+#: src/amule.cpp:1564
 msgid "The selected locale seems not to be installed on your box. (Note: I'll try to set it anyway)"
 msgstr ""
 
-#: src/amule.cpp:1566
+#: src/amule.cpp:1574
 #, c-format
 msgid "This is the first time you run aMule %s"
 msgstr "Šī ir pirmā reize, kad aMule %s palaista"
 
-#: src/amule.cpp:1569
+#: src/amule.cpp:1577
 msgid "This version is a testing version, updated daily, and\n"
 msgstr "Šī ir ikdienas (atjaunina katru dienu) testa versija, tāpēc\n"
 
-#: src/amule.cpp:1570
+#: src/amule.cpp:1578
 msgid "we give no warranty it won't break anything, burn your house,\n"
 msgstr "mēs negarantējam, ka tā neko nesabojās, nenodedzinās jūsu māju\n"
 
-#: src/amule.cpp:1571
+#: src/amule.cpp:1579
 msgid "or kill your dog. But it *should* be safe to use anyway.\n"
 msgstr "vai nenogalinās jūsu suni. Bet tā jebkurā gadījumā *vajadzētu* būt droša lietošanā.\n"
 
-#: src/amule.cpp:1576
+#: src/amule.cpp:1584
 msgid "More information, support and new releases can found at our homepage,\n"
 msgstr "Plašāka informācija, atbalsts un jaunās versijas ir pieejamas mūsu vietnē\n"
 
-#: src/amule.cpp:1577
+#: src/amule.cpp:1585
 msgid "at https://amule-org.github.io, or in our IRC channel #aMule at irc.libera.chat.\n"
 msgstr "https://amule-org.github.io vai mūsu IRC kanālā #aMule vietnē irc.libera.chat.\n"
 
-#: src/amule.cpp:1579
+#: src/amule.cpp:1587
 msgid "Feel free to report any bugs to https://github.com/amule-org/amule/issues"
 msgstr "Nekautrējieties ziņot par problēmām https://github.com/amule-org/amule/issues vietnē"
 
-#: src/amule.cpp:1591
+#: src/amule.cpp:1599
 msgid ""
 "The folder for Online Signature files you specified is INVALID!\n"
 " OnlineSignature will be DISABLED until you fix it on preferences."
 msgstr ""
 
-#: src/amule.cpp:1654
+#: src/amule.cpp:1662
 msgid "Server hostname notified"
 msgstr ""
 
-#: src/amule.cpp:2031
+#: src/amule.cpp:2039
 #, c-format
 msgid "Disk space preallocation for file '%s' failed: %s"
 msgstr ""
 
-#: src/amule.cpp:2160
+#: src/amule.cpp:2168
 msgid "ERROR: can't open logfile"
 msgstr "KĻŪDA: nevar atvērt žurnāldatni"
 
-#: src/amule.cpp:2164
+#: src/amule.cpp:2172
 msgid "WARNING: logfile is empty. Something is wrong."
 msgstr "BRĪDINĀJUMS: žurnāldatne ir tukša. Te kaut kas nav kā vajag :-(."
 
-#: src/amule.cpp:2181
+#: src/amule.cpp:2189
 msgid "Log has been reset"
 msgstr ""
 
-#: src/amule.cpp:2205
+#: src/amule.cpp:2213
 #, c-format
 msgid "ServerMessage: %s"
 msgstr "Servera ziņojums: %s"
 
-#: src/amule.cpp:2248 src/IP2Country.cpp:220 src/IPFilter.cpp:514
+#: src/amule.cpp:2256 src/IP2Country.cpp:220 src/IPFilter.cpp:514
 #: src/ServerList.cpp:875
 #, c-format
 msgid "Skipped download of %s, because requested file is not newer."
 msgstr ""
 
-#: src/amule.cpp:2251
+#: src/amule.cpp:2259
 msgid "Failed to download the nodes list."
 msgstr ""
 
-#: src/amule.cpp:2314
+#: src/amule.cpp:2322
 msgid "Failed to open the downloaded version check file"
 msgstr ""
 
-#: src/amule.cpp:2317 src/amule.cpp:2336
+#: src/amule.cpp:2325 src/amule.cpp:2344
 msgid "Corrupted version check file"
 msgstr ""
 
-#: src/amule.cpp:2359
+#: src/amule.cpp:2367
 msgid "You are using an outdated version of aMule!"
 msgstr "Jūs izmantojiet novecojušu aMule versiju!"
 
-#: src/amule.cpp:2361
+#: src/amule.cpp:2369
 #, c-format
 msgid "Your aMule version is %i.%i.%i and the latest version is %li.%li.%li"
 msgstr "Jūsu aMule versija — %i.%i.%i un jaunākā versija — %li.%li.%li"
 
-#: src/amule.cpp:2365
+#: src/amule.cpp:2373
 msgid "The latest version can always be found at https://github.com/amule-org/amule/releases/latest"
 msgstr "Jaunāko aMule versiju vienmēr var iegūt https://github.com/amule-org/amule/releases/latest vietnē"
 
-#: src/amule.cpp:2368
+#: src/amule.cpp:2376
 #, c-format
 msgid "WARNING: Your aMuled version is outdated: %i.%i.%i < %li.%li.%li"
 msgstr "BRĪDINĀJUMS: Jūsu aMule versija ir novecojusi: %i.%i.%i < %li.%li.%li"
 
-#: src/amule.cpp:2374
+#: src/amule.cpp:2382
 msgid "Your copy of aMule is up to date."
 msgstr "Šī ir jaunākā aMule versija."
 
-#: src/amule.cpp:2381
+#: src/amule.cpp:2389
 msgid "Failed to download the version check file"
 msgstr "Neizdevās lejupielādēt versijas pārbaudes datni"
 
-#: src/amule.cpp:2550 src/amule-remote-gui.cpp:1133
+#: src/amule.cpp:2558 src/amule-remote-gui.cpp:1133
 #, c-format
 msgid "Users: %s | Files: %s"
 msgstr "Lietotāji: %s | Datnes: %s"
 
-#: src/amule.cpp:2551 src/amule-remote-gui.cpp:1134
+#: src/amule.cpp:2559 src/amule-remote-gui.cpp:1134
 #, c-format
 msgid "Users: E: %s K: %s | Files: E: %s K: %s"
 msgstr "Lietotāji: E: %s K: %s | Datnes: E: %s K: %s"
 
-#: src/amule.cpp:2565 src/amule-remote-gui.cpp:1147
+#: src/amule.cpp:2573 src/amule-remote-gui.cpp:1147
 msgid "No networks selected"
 msgstr ""
 
-#: src/amule.cpp:2633 src/TextClient.cpp:903
+#: src/amule.cpp:2641 src/TextClient.cpp:903
 msgid "with LowID"
 msgstr "ar zemu ID"
 
-#: src/amule.cpp:2633 src/TextClient.cpp:904
+#: src/amule.cpp:2641 src/TextClient.cpp:904
 msgid "with HighID"
 msgstr "ar augstu ID"
 
-#: src/amule.cpp:2635
+#: src/amule.cpp:2643
 #, c-format
 msgid "Connected to %s %s"
 msgstr "Pieslēgts %s %s"
 
-#: src/amule.cpp:2640
+#: src/amule.cpp:2648
 #, c-format
 msgid "Connecting to %s"
 msgstr "Pieslēdzas %s"
 
-#: src/amule.cpp:2642
+#: src/amule.cpp:2650
 msgid "Disconnected from eD2k"
 msgstr "Atslēgts no eD2k"
 
-#: src/amule.cpp:2651
+#: src/amule.cpp:2659
 msgid "Kad started."
 msgstr ""
 
-#: src/amule.cpp:2653
+#: src/amule.cpp:2661
 msgid "Kad stopped."
 msgstr ""
 
-#: src/amule.cpp:2661
+#: src/amule.cpp:2669
 msgid "Connected to Kad (ok)"
 msgstr "Pieslēgts Kad (veiksmīgi)"
 
-#: src/amule.cpp:2663
+#: src/amule.cpp:2671
 msgid "Connected to Kad (firewalled)"
 msgstr "Pieslēgts Kad (aiz ugunsmūra)"
 
-#: src/amule.cpp:2667
+#: src/amule.cpp:2675
 msgid "Disconnected from Kad"
 msgstr "Atslēgts no Kad"
 
-#: src/amule.cpp:2699
+#: src/amule.cpp:2707
 msgid "Kad network cannot be used if UDP port is disabled on preferences, not starting."
 msgstr ""
 
-#: src/amule.cpp:2703
+#: src/amule.cpp:2711
 msgid "Kad network disabled on preferences, not connecting."
 msgstr "Kad tīkls ir atspējots iestatījumos, nepieslēdzas tīklam."
 
@@ -569,36 +569,36 @@ msgid "FATAL ERROR: Failed to create Timer"
 msgstr ""
 
 #: src/amuleDlg.cpp:361 src/amuleDlg.cpp:1787 src/amuleDlg.cpp:2033
-#: src/muuli_wdr.cpp:1492 src/muuli_wdr.cpp:3418
+#: src/muuli_wdr.cpp:1492 src/muuli_wdr.cpp:3449
 msgid "Networks"
 msgstr "Tīkli"
 
-#: src/amuleDlg.cpp:362 src/amuleDlg.cpp:1793 src/muuli_wdr.cpp:3419
+#: src/amuleDlg.cpp:362 src/amuleDlg.cpp:1793 src/muuli_wdr.cpp:3450
 msgid "Searches"
 msgstr ""
 
 #: src/amuleDlg.cpp:363 src/amuleDlg.cpp:1799 src/DownloadListCtrl.cpp:740
-#: src/muuli_wdr.cpp:392 src/muuli_wdr.cpp:1585 src/muuli_wdr.cpp:3420
+#: src/muuli_wdr.cpp:392 src/muuli_wdr.cpp:1585 src/muuli_wdr.cpp:3451
 #: src/Statistics.cpp:829
 msgid "Downloads"
 msgstr "Lejupielādes"
 
-#: src/amuleDlg.cpp:364 src/amuleDlg.cpp:1805 src/muuli_wdr.cpp:3294
+#: src/amuleDlg.cpp:364 src/amuleDlg.cpp:1805 src/muuli_wdr.cpp:3325
 msgid "Shared files"
 msgstr "Kopīgotās datnes"
 
-#: src/amuleDlg.cpp:365 src/amuleDlg.cpp:1811 src/muuli_wdr.cpp:2926
-#: src/muuli_wdr.cpp:3376 src/muuli_wdr.cpp:3423
+#: src/amuleDlg.cpp:365 src/amuleDlg.cpp:1811 src/muuli_wdr.cpp:2957
+#: src/muuli_wdr.cpp:3407 src/muuli_wdr.cpp:3454
 msgid "Messages"
 msgstr "Ziņojumi"
 
-#: src/amuleDlg.cpp:366 src/amuleDlg.cpp:1817 src/muuli_wdr.cpp:3424
-#: src/PrefsUnifiedDlg.cpp:312 src/Statistics.cpp:779 src/Statistics.cpp:1235
+#: src/amuleDlg.cpp:366 src/amuleDlg.cpp:1817 src/muuli_wdr.cpp:3455
+#: src/PrefsUnifiedDlg.cpp:314 src/Statistics.cpp:779 src/Statistics.cpp:1235
 msgid "Statistics"
 msgstr "Statistika"
 
-#: src/amuleDlg.cpp:368 src/amuleDlg.cpp:1824 src/muuli_wdr.cpp:3426
-#: src/PrefsUnifiedDlg.cpp:328 src/utils/wxCas/src/wxcasprefs.cpp:39
+#: src/amuleDlg.cpp:368 src/amuleDlg.cpp:1824 src/muuli_wdr.cpp:3457
+#: src/PrefsUnifiedDlg.cpp:330 src/utils/wxCas/src/wxcasprefs.cpp:39
 msgid "Preferences"
 msgstr "Iestatījumi"
 
@@ -660,8 +660,8 @@ msgstr "Kad: Izslēgts"
 #: src/amuleDlg.cpp:1029 src/DownloadListCtrl.cpp:505
 #: src/DownloadListCtrl.cpp:749 src/FriendListCtrl.cpp:180
 #: src/muuli_wdr.cpp:731 src/muuli_wdr.cpp:782 src/muuli_wdr.cpp:846
-#: src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2231 src/muuli_wdr.cpp:2316
-#: src/muuli_wdr.cpp:3064 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
+#: src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2262 src/muuli_wdr.cpp:2347
+#: src/muuli_wdr.cpp:3095 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
 #: src/ServerListCtrl.cpp:606 src/TransferWnd.cpp:378
 #: src/utils/wxCas/src/wxcasprefs.cpp:235
 msgid "Cancel"
@@ -672,7 +672,7 @@ msgid "Stop the current connection attempts"
 msgstr ""
 
 #: src/amuleDlg.cpp:1035 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976
-#: src/muuli_wdr.cpp:2454
+#: src/muuli_wdr.cpp:2485
 msgid "Disconnect"
 msgstr "Atslēgties"
 
@@ -681,7 +681,7 @@ msgid "Disconnect from the currently connected networks"
 msgstr "Atslēgties no tīkliem, kuriem pašlaik esiet pieslēdzies"
 
 #: src/amuleDlg.cpp:1041 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979
-#: src/muuli_wdr.cpp:2609 src/muuli_wdr.cpp:3061 src/muuli_wdr.cpp:3416
+#: src/muuli_wdr.cpp:2640 src/muuli_wdr.cpp:3092 src/muuli_wdr.cpp:3447
 msgid "Connect"
 msgstr "Pieslēgties"
 
@@ -735,7 +735,7 @@ msgstr ""
 msgid "Launch Command: "
 msgstr ""
 
-#: src/amuleDlg.cpp:1632 src/muuli_wdr.cpp:1978 src/Preferences.cpp:952
+#: src/amuleDlg.cpp:1632 src/muuli_wdr.cpp:1982 src/Preferences.cpp:979
 msgid "- default -"
 msgstr ""
 
@@ -749,48 +749,48 @@ msgstr ""
 msgid "WARNING: Unable to open skin file '%s' for read"
 msgstr ""
 
-#: src/amuleDlg.cpp:1791 src/muuli_wdr.cpp:3418
+#: src/amuleDlg.cpp:1791 src/muuli_wdr.cpp:3449
 msgid "Networks Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1797 src/muuli_wdr.cpp:3419
+#: src/amuleDlg.cpp:1797 src/muuli_wdr.cpp:3450
 msgid "Searches Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1803 src/muuli_wdr.cpp:3420
+#: src/amuleDlg.cpp:1803 src/muuli_wdr.cpp:3451
 msgid "Downloads Window"
 msgstr "Lejupielādes logs"
 
-#: src/amuleDlg.cpp:1809 src/muuli_wdr.cpp:3422
+#: src/amuleDlg.cpp:1809 src/muuli_wdr.cpp:3453
 msgid "Shared Files Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1815 src/muuli_wdr.cpp:3423
+#: src/amuleDlg.cpp:1815 src/muuli_wdr.cpp:3454
 msgid "Messages Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1821 src/muuli_wdr.cpp:3424
+#: src/amuleDlg.cpp:1821 src/muuli_wdr.cpp:3455
 msgid "Statistics Graph Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1828 src/muuli_wdr.cpp:3426
+#: src/amuleDlg.cpp:1828 src/muuli_wdr.cpp:3457
 msgid "Preferences Settings Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1831 src/muuli_wdr.cpp:3427
+#: src/amuleDlg.cpp:1831 src/muuli_wdr.cpp:3458
 msgid "Import"
 msgstr ""
 
-#: src/amuleDlg.cpp:1835 src/muuli_wdr.cpp:3427
+#: src/amuleDlg.cpp:1835 src/muuli_wdr.cpp:3458
 msgid "The partfile importer tool"
 msgstr ""
 
-#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3428
+#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3459
 #: src/utils/aLinkCreator/src/alcframe.cpp:262
 msgid "About"
 msgstr "Par programmu"
 
-#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3428
+#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3459
 msgid "About/Help"
 msgstr "Par programmu/Palīdzība"
 
@@ -928,7 +928,7 @@ msgstr ""
 msgid "The core rejected these shared folders:%s"
 msgstr ""
 
-#: src/amule-remote-gui.cpp:1336 src/ExternalConn.cpp:2345
+#: src/amule-remote-gui.cpp:1336 src/ExternalConn.cpp:2346
 msgid "Invalid link or already on list."
 msgstr "Nederīga saite vai jau ir sarakstā."
 
@@ -944,7 +944,7 @@ msgstr "Nevar izveidot '%s' mapi '%s' kategorijai, turpinam izmantot '%s' mapi."
 #: src/ClientDetailDialog.cpp:123 src/DataToText.cpp:61 src/DataToText.cpp:86
 #: src/DataToText.cpp:101 src/DataToText.cpp:136 src/DataToText.cpp:165
 #: src/DownloadListCtrl.cpp:1172 src/DownloadListCtrl.cpp:1185
-#: src/DownloadListCtrl.cpp:1196 src/ExternalConn.cpp:608
+#: src/DownloadListCtrl.cpp:1196 src/ExternalConn.cpp:609
 #: src/FileDetailDialog.cpp:203 src/FileDetailDialog.cpp:235
 #: src/FileDetailDialog.cpp:242 src/GenericClientListCtrl.cpp:1171
 #: src/GenericClientListCtrl.cpp:1182 src/GenericClientListCtrl.cpp:1192
@@ -1331,19 +1331,19 @@ msgstr ""
 msgid "Very low"
 msgstr ""
 
-#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:743 src/muuli_wdr.cpp:2282
+#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:743 src/muuli_wdr.cpp:2313
 #: src/ServerListCtrl.cpp:263 src/ServerListCtrl.cpp:456
 #: src/SharedFilesCtrl.cpp:145
 msgid "Low"
 msgstr ""
 
-#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:744 src/muuli_wdr.cpp:2283
+#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:744 src/muuli_wdr.cpp:2314
 #: src/ServerListCtrl.cpp:266 src/ServerListCtrl.cpp:457
 #: src/SharedFilesCtrl.cpp:146
 msgid "Normal"
 msgstr ""
 
-#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:745 src/muuli_wdr.cpp:2284
+#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:745 src/muuli_wdr.cpp:2315
 #: src/ServerListCtrl.cpp:269 src/ServerListCtrl.cpp:458
 #: src/SharedFilesCtrl.cpp:147
 msgid "High"
@@ -1435,7 +1435,7 @@ msgstr ""
 msgid "Remote Server"
 msgstr ""
 
-#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3181
+#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3212
 #: src/SearchDlg.cpp:119 src/TextClient.cpp:911
 msgid "Kad"
 msgstr "Kad"
@@ -1506,7 +1506,7 @@ msgstr "Daļa"
 msgid "Size"
 msgstr "Izmērs"
 
-#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3248
+#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3279
 msgid "Transferred"
 msgstr "Pārsūtīti"
 
@@ -1562,7 +1562,7 @@ msgid ""
 "\n"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:746 src/muuli_wdr.cpp:2285
+#: src/DownloadListCtrl.cpp:746 src/muuli_wdr.cpp:2316
 #: src/SharedFilesCtrl.cpp:150
 msgid "Auto"
 msgstr ""
@@ -1600,7 +1600,7 @@ msgid "Extended Options"
 msgstr ""
 
 #: src/DownloadListCtrl.cpp:770 src/DownloadListCtrl.cpp:822
-#: src/muuli_wdr.cpp:1796
+#: src/muuli_wdr.cpp:1800
 msgid "Preview"
 msgstr "Priekšskatījums"
 
@@ -1773,225 +1773,230 @@ msgstr[1] ""
 msgid "Invalid eD2k link! ERROR: %s"
 msgstr "Nederīga eD2k saite! KĻŪDA: %s"
 
-#: src/ExternalConn.cpp:379
+#: src/ExternalConn.cpp:380
 msgid "Client sent packet after authentication failed."
 msgstr ""
 
-#: src/ExternalConn.cpp:396
+#: src/ExternalConn.cpp:397
 msgid "External connection closed."
 msgstr ""
 
-#: src/ExternalConn.cpp:473
+#: src/ExternalConn.cpp:474
 msgid "External connections disabled due to empty password!"
 msgstr ""
 
-#: src/ExternalConn.cpp:494
+#: src/ExternalConn.cpp:495
 msgid "External connections disabled in config file"
 msgstr ""
 
-#: src/ExternalConn.cpp:575
+#: src/ExternalConn.cpp:576
 msgid "New external connection accepted"
 msgstr ""
 
-#: src/ExternalConn.cpp:578
+#: src/ExternalConn.cpp:579
 msgid "ERROR: couldn't accept a new external connection"
 msgstr ""
 
-#: src/ExternalConn.cpp:595
+#: src/ExternalConn.cpp:596
 msgid "External connection refused due to empty password in preferences!"
 msgstr ""
 
-#: src/ExternalConn.cpp:607
+#: src/ExternalConn.cpp:608
 #, c-format
 msgid "Connecting client: %s %s"
 msgstr "Pieslēdzas klientam: %s %s"
 
-#: src/ExternalConn.cpp:609
+#: src/ExternalConn.cpp:610
 msgid "Unknown version"
 msgstr "Nezināma versija"
 
-#: src/ExternalConn.cpp:622
+#: src/ExternalConn.cpp:623
 msgid "Incorrect EC version ID, there might be binary incompatibility. Use core and remote from same snapshot."
 msgstr ""
 
-#: src/ExternalConn.cpp:630
+#: src/ExternalConn.cpp:631
 msgid "You cannot connect to a release version from an arbitrary development snapshot! *sigh* possible crash prevented"
 msgstr ""
 
-#: src/ExternalConn.cpp:713
+#: src/ExternalConn.cpp:714
 msgid "Invalid protocol version."
 msgstr "Nederīga protokola versija."
 
-#: src/ExternalConn.cpp:719
+#: src/ExternalConn.cpp:720
 msgid "Missing protocol version tag."
 msgstr "Trūkst protokola versijas birka."
 
-#: src/ExternalConn.cpp:727
+#: src/ExternalConn.cpp:728
 msgid "Authentication failed: invalid hash specified as EC password."
 msgstr ""
 
-#: src/ExternalConn.cpp:775
+#: src/ExternalConn.cpp:776
 msgid "Authentication failed: wrong password."
 msgstr ""
 
-#: src/ExternalConn.cpp:777
+#: src/ExternalConn.cpp:778
 msgid "Authentication failed: missing password."
 msgstr ""
 
-#: src/ExternalConn.cpp:788
+#: src/ExternalConn.cpp:789
 msgid "Invalid request, please authenticate first."
 msgstr ""
 
-#: src/ExternalConn.cpp:793
+#: src/ExternalConn.cpp:794
 msgid "Access granted."
 msgstr ""
 
-#: src/ExternalConn.cpp:801
+#: src/ExternalConn.cpp:802
 #, c-format
 msgid "Sent error message \"%s\" to client."
 msgstr ""
 
-#: src/ExternalConn.cpp:806
+#: src/ExternalConn.cpp:807
 #, c-format
 msgid "Unauthorized access attempt from %s. Connection closed."
 msgstr ""
 
-#: src/ExternalConn.cpp:1419
+#: src/ExternalConn.cpp:1420
 #, c-format
 msgid "Remote PartFile command failed: FileHash not found: %s"
 msgstr ""
 
-#: src/ExternalConn.cpp:1423
+#: src/ExternalConn.cpp:1424
 #, c-format
 msgid "FileHash not found: %s"
 msgstr ""
 
-#: src/ExternalConn.cpp:1470 src/ExternalConn.cpp:1558
-#: src/ExternalConn.cpp:1679
+#: src/ExternalConn.cpp:1471 src/ExternalConn.cpp:1559
+#: src/ExternalConn.cpp:1680
 msgid "OOPS! OpCode processing error!"
 msgstr ""
 
-#: src/ExternalConn.cpp:1501
+#: src/ExternalConn.cpp:1502
 msgid "Server not added"
 msgstr ""
 
-#: src/ExternalConn.cpp:1520
+#: src/ExternalConn.cpp:1521
 #, c-format
 msgid "server not found: %s"
 msgstr ""
 
-#: src/ExternalConn.cpp:1537
+#: src/ExternalConn.cpp:1538
 msgid "need to define server to be removed"
 msgstr ""
 
-#: src/ExternalConn.cpp:1552
+#: src/ExternalConn.cpp:1553
 msgid "eD2k is disabled in preferences."
 msgstr ""
 
-#: src/ExternalConn.cpp:1657
+#: src/ExternalConn.cpp:1658
 msgid "Friend not found."
 msgstr ""
 
-#: src/ExternalConn.cpp:1667
+#: src/ExternalConn.cpp:1668
 msgid "Client not found."
 msgstr ""
 
-#: src/ExternalConn.cpp:1673
+#: src/ExternalConn.cpp:1674
 msgid "EC_TAG_FRIEND_SHARED requires EC_TAG_FRIEND or EC_TAG_CLIENT."
 msgstr ""
 
-#: src/ExternalConn.cpp:1991
+#: src/ExternalConn.cpp:1992
 msgid "WebSearch from remote interface makes no sense."
 msgstr ""
 
-#: src/ExternalConn.cpp:2026
+#: src/ExternalConn.cpp:2027
 msgid "Search in progress. Refetch results in a moment!"
 msgstr ""
 
-#: src/ExternalConn.cpp:2265
+#: src/ExternalConn.cpp:2266
 msgid "No points for graph."
 msgstr ""
 
-#: src/ExternalConn.cpp:2275
+#: src/ExternalConn.cpp:2276
 msgid "Your client is not configured for this detail level."
 msgstr ""
 
-#: src/ExternalConn.cpp:2302
+#: src/ExternalConn.cpp:2303
 msgid "External Connection: shutdown requested"
 msgstr ""
 
-#: src/ExternalConn.cpp:2314
+#: src/ExternalConn.cpp:2315
 msgid "Already shutting down."
 msgstr ""
 
-#: src/ExternalConn.cpp:2332
+#: src/ExternalConn.cpp:2333
 #, c-format
 msgid "ExternalConn: adding link '%s'."
 msgstr ""
 
-#: src/ExternalConn.cpp:2350
+#: src/ExternalConn.cpp:2351
 #, c-format
 msgid "%d of %d links failed (invalid or already on list)."
 msgstr ""
 
-#: src/ExternalConn.cpp:2373
+#: src/ExternalConn.cpp:2374
 msgid "Version check throttled; try again shortly."
 msgstr ""
 
-#: src/ExternalConn.cpp:2378
+#: src/ExternalConn.cpp:2379
 msgid "Version check is not available on this daemon."
 msgstr ""
 
-#: src/ExternalConn.cpp:2508
+#: src/ExternalConn.cpp:2509
 msgid "File not found."
 msgstr ""
 
-#: src/ExternalConn.cpp:2513
+#: src/ExternalConn.cpp:2514
 msgid "Invalid file name."
 msgstr ""
 
-#: src/ExternalConn.cpp:2521
+#: src/ExternalConn.cpp:2522
 msgid "Unable to rename file."
 msgstr ""
 
-#: src/ExternalConn.cpp:2992 src/ExternalConn.cpp:3020
+#: src/ExternalConn.cpp:2839
+#, c-format
+msgid "Could not save the amuleapi password: %s"
+msgstr ""
+
+#: src/ExternalConn.cpp:3004 src/ExternalConn.cpp:3032
 msgid "Kad is disabled in preferences."
 msgstr ""
 
-#: src/ExternalConn.cpp:3033
+#: src/ExternalConn.cpp:3045
 msgid "Already connected to eD2k."
 msgstr "Jau pieslēgts eD2k tīklam."
 
-#: src/ExternalConn.cpp:3036
+#: src/ExternalConn.cpp:3048
 msgid "Connecting to eD2k..."
 msgstr "Pieslēdzas eD2k…"
 
-#: src/ExternalConn.cpp:3045
+#: src/ExternalConn.cpp:3057
 msgid "Already connected to Kad."
 msgstr "Jau pieslēgts Kad tīklam."
 
-#: src/ExternalConn.cpp:3048
+#: src/ExternalConn.cpp:3060
 msgid "Connecting to Kad..."
 msgstr "Pieslēdzas Kad…"
 
-#: src/ExternalConn.cpp:3055
+#: src/ExternalConn.cpp:3067
 msgid "All networks are disabled."
 msgstr ""
 
-#: src/ExternalConn.cpp:3064
+#: src/ExternalConn.cpp:3076
 msgid "Disconnected from eD2k."
 msgstr "Atslēgts no eD2k."
 
-#: src/ExternalConn.cpp:3069
+#: src/ExternalConn.cpp:3081
 msgid "Disconnected from Kad."
 msgstr "Atslēgts no Kad."
 
-#: src/ExternalConn.cpp:3078
+#: src/ExternalConn.cpp:3090
 #, c-format
 msgid "External Connection: invalid opcode received: %#x"
 msgstr ""
 
-#: src/ExternalConn.cpp:3083
+#: src/ExternalConn.cpp:3095
 msgid "Invalid opcode (wrong protocol version?)"
 msgstr ""
 
@@ -2364,23 +2369,23 @@ msgid ""
 "want downloads on a different (e.g. larger) disk."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:549 src/FirstRunWizard.cpp:611 src/muuli_wdr.cpp:1708
+#: src/FirstRunWizard.cpp:549 src/FirstRunWizard.cpp:611 src/muuli_wdr.cpp:1712
 msgid "Destination folder for downloads"
 msgstr ""
 
 #: src/FirstRunWizard.cpp:553 src/FirstRunWizard.cpp:569 src/muuli_wdr.cpp:1349
-#: src/muuli_wdr.cpp:1366 src/muuli_wdr.cpp:1683 src/muuli_wdr.cpp:1714
-#: src/muuli_wdr.cpp:1726 src/muuli_wdr.cpp:2769
+#: src/muuli_wdr.cpp:1366 src/muuli_wdr.cpp:1687 src/muuli_wdr.cpp:1718
+#: src/muuli_wdr.cpp:1730 src/muuli_wdr.cpp:2800
 #: src/utils/aLinkCreator/src/alcframe.cpp:135
 #: src/utils/wxCas/src/wxcasprefs.cpp:52 src/utils/wxCas/src/wxcasprefs.cpp:118
 msgid "Browse"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:559 src/muuli_wdr.cpp:1719
+#: src/FirstRunWizard.cpp:559 src/muuli_wdr.cpp:1723
 msgid "(All files in this folder are shared with other peers)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:565 src/FirstRunWizard.cpp:624 src/muuli_wdr.cpp:1721
+#: src/FirstRunWizard.cpp:565 src/FirstRunWizard.cpp:624 src/muuli_wdr.cpp:1725
 msgid "Folder for temporary download files"
 msgstr ""
 
@@ -2411,7 +2416,7 @@ msgstr ""
 msgid "CRITICAL - no client on StartChatSession"
 msgstr ""
 
-#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2675 src/muuli_wdr.cpp:3352
+#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2706 src/muuli_wdr.cpp:3383
 msgid "Friends"
 msgstr "Draugi"
 
@@ -2517,8 +2522,8 @@ msgstr ""
 msgid "No"
 msgstr "Nē"
 
-#: src/GenericClientListCtrl.cpp:1216 src/PrefsUnifiedDlg.cpp:2818
-#: src/PrefsUnifiedDlg.cpp:2868 src/ServerListCtrl.cpp:276
+#: src/GenericClientListCtrl.cpp:1216 src/PrefsUnifiedDlg.cpp:2898
+#: src/PrefsUnifiedDlg.cpp:2948 src/ServerListCtrl.cpp:276
 msgid "Yes"
 msgstr "Jā"
 
@@ -2685,10 +2690,10 @@ msgstr ""
 msgid "Please fill all fields required"
 msgstr ""
 
-#: src/KadDlg.cpp:192 src/PartFile.cpp:1031 src/PrefsUnifiedDlg.cpp:1162
-#: src/PrefsUnifiedDlg.cpp:1331 src/PrefsUnifiedDlg.cpp:1589
-#: src/PrefsUnifiedDlg.cpp:1599 src/PrefsUnifiedDlg.cpp:1616
-#: src/PrefsUnifiedDlg.cpp:1658
+#: src/KadDlg.cpp:192 src/PartFile.cpp:1031 src/PrefsUnifiedDlg.cpp:1134
+#: src/PrefsUnifiedDlg.cpp:1204 src/PrefsUnifiedDlg.cpp:1405
+#: src/PrefsUnifiedDlg.cpp:1663 src/PrefsUnifiedDlg.cpp:1673
+#: src/PrefsUnifiedDlg.cpp:1690 src/PrefsUnifiedDlg.cpp:1738
 msgid "Message"
 msgstr "Ziņojums"
 
@@ -2790,7 +2795,7 @@ msgstr ""
 msgid "Uploaded"
 msgstr "Augšupielādēts"
 
-#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3232
+#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3263
 msgid "Requested"
 msgstr ""
 
@@ -2913,7 +2918,7 @@ msgid "WARNING: "
 msgstr "BRĪDINĀJUMS: "
 
 #: src/MuleNotebook.cpp:179 src/muuli_wdr.cpp:817 src/muuli_wdr.cpp:1229
-#: src/muuli_wdr.cpp:3136 src/muuli_wdr.cpp:3392
+#: src/muuli_wdr.cpp:3167 src/muuli_wdr.cpp:3423
 msgid "Close"
 msgstr "Aizvērt"
 
@@ -2931,7 +2936,7 @@ msgid "Paste"
 msgstr "Ielīmēt"
 
 #: src/MuleTextCtrl.cpp:89 src/muuli_wdr.cpp:358 src/muuli_wdr.cpp:757
-#: src/muuli_wdr.cpp:2359 src/muuli_wdr.cpp:2378 src/muuli_wdr.cpp:2400
+#: src/muuli_wdr.cpp:2390 src/muuli_wdr.cpp:2409 src/muuli_wdr.cpp:2431
 #: src/utils/aLinkCreator/src/alcframe.cpp:142
 msgid "Clear"
 msgstr "Notīrīt"
@@ -3023,7 +3028,7 @@ msgstr "Iziet"
 
 #: src/MuleTrayIcon.cpp:579 src/MuleTrayIcon.cpp:945 src/MuleTrayIcon.cpp:965
 #: src/muuli_wdr.cpp:1398 src/muuli_wdr.cpp:1406 src/muuli_wdr.cpp:1413
-#: src/muuli_wdr.cpp:1842 src/muuli_wdr.cpp:1848 src/OtherFunctions.cpp:91
+#: src/muuli_wdr.cpp:1846 src/muuli_wdr.cpp:1852 src/OtherFunctions.cpp:91
 #: src/StatisticsDlg.cpp:93 src/StatisticsDlg.cpp:95
 msgid "kB/s"
 msgstr "kB/s"
@@ -3263,7 +3268,7 @@ msgstr "Baiti"
 msgid "KB"
 msgstr ""
 
-#: src/muuli_wdr.cpp:274 src/muuli_wdr.cpp:293 src/muuli_wdr.cpp:1627
+#: src/muuli_wdr.cpp:274 src/muuli_wdr.cpp:293 src/muuli_wdr.cpp:1631
 #: src/OtherFunctions.cpp:64
 msgid "MB"
 msgstr ""
@@ -3280,7 +3285,7 @@ msgstr "Maksimālais izmērs"
 msgid "Availability"
 msgstr "Pieejamība"
 
-#: src/muuli_wdr.cpp:312 src/muuli_wdr.cpp:398 src/muuli_wdr.cpp:3297
+#: src/muuli_wdr.cpp:312 src/muuli_wdr.cpp:398 src/muuli_wdr.cpp:3328
 msgid "Filter:"
 msgstr ""
 
@@ -3343,12 +3348,12 @@ msgstr ""
 #: src/muuli_wdr.cpp:1160 src/muuli_wdr.cpp:1167 src/muuli_wdr.cpp:1172
 #: src/muuli_wdr.cpp:1179 src/muuli_wdr.cpp:1184 src/muuli_wdr.cpp:1191
 #: src/muuli_wdr.cpp:1205 src/muuli_wdr.cpp:1212 src/muuli_wdr.cpp:1217
-#: src/muuli_wdr.cpp:1224 src/muuli_wdr.cpp:3234 src/muuli_wdr.cpp:3242
-#: src/muuli_wdr.cpp:3250
+#: src/muuli_wdr.cpp:1224 src/muuli_wdr.cpp:3265 src/muuli_wdr.cpp:3273
+#: src/muuli_wdr.cpp:3281
 msgid "N/A"
 msgstr ""
 
-#: src/muuli_wdr.cpp:508 src/muuli_wdr.cpp:1065 src/PrefsUnifiedDlg.cpp:297
+#: src/muuli_wdr.cpp:508 src/muuli_wdr.cpp:1065 src/PrefsUnifiedDlg.cpp:299
 msgid "General"
 msgstr ""
 
@@ -3486,7 +3491,7 @@ msgstr "Izpildītājs :"
 msgid "Album :"
 msgstr "Albums :"
 
-#: src/muuli_wdr.cpp:685 src/muuli_wdr.cpp:2254
+#: src/muuli_wdr.cpp:685 src/muuli_wdr.cpp:2285
 msgid "Title :"
 msgstr "Nosaukums :"
 
@@ -3593,7 +3598,7 @@ msgstr "Lietotājvārds :"
 msgid "Userhash :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:895 src/muuli_wdr.cpp:1748 src/muuli_wdr.cpp:2449
+#: src/muuli_wdr.cpp:895 src/muuli_wdr.cpp:1752 src/muuli_wdr.cpp:2480
 #: src/utils/aLinkCreator/src/alcframe.cpp:137
 msgid "Add"
 msgstr "Pievienot"
@@ -3602,15 +3607,15 @@ msgstr "Pievienot"
 msgid "Download-Speed"
 msgstr "Lejupielādes ātrums"
 
-#: src/muuli_wdr.cpp:954 src/muuli_wdr.cpp:989 src/muuli_wdr.cpp:2553
+#: src/muuli_wdr.cpp:954 src/muuli_wdr.cpp:989 src/muuli_wdr.cpp:2584
 msgid "Current"
 msgstr "Pašreizējais"
 
-#: src/muuli_wdr.cpp:962 src/muuli_wdr.cpp:997 src/muuli_wdr.cpp:2561
+#: src/muuli_wdr.cpp:962 src/muuli_wdr.cpp:997 src/muuli_wdr.cpp:2592
 msgid "Running average"
 msgstr "Visu laiku vidējais"
 
-#: src/muuli_wdr.cpp:970 src/muuli_wdr.cpp:1005 src/muuli_wdr.cpp:2569
+#: src/muuli_wdr.cpp:970 src/muuli_wdr.cpp:1005 src/muuli_wdr.cpp:2600
 msgid "Session average"
 msgstr "Sesijas vidējais"
 
@@ -3622,7 +3627,7 @@ msgstr "Augšupielādes ātrums"
 msgid "Connections"
 msgstr "Savienojumi"
 
-#: src/muuli_wdr.cpp:1024 src/muuli_wdr.cpp:1867
+#: src/muuli_wdr.cpp:1024 src/muuli_wdr.cpp:1871
 msgid "Active downloads"
 msgstr "Aktīvas lejupielādes"
 
@@ -3630,7 +3635,7 @@ msgstr "Aktīvas lejupielādes"
 msgid "Active connections (1:1)"
 msgstr "Aktīvi savienojumi (1:1)"
 
-#: src/muuli_wdr.cpp:1040 src/muuli_wdr.cpp:1868
+#: src/muuli_wdr.cpp:1040 src/muuli_wdr.cpp:1872
 msgid "Active uploads"
 msgstr "Aktīvas augšupielādes"
 
@@ -3904,7 +3909,7 @@ msgstr ""
 msgid "Advanced users only: If you have multiple network interfaces, enter the address of the interface to which aMule should be bound."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1462 src/muuli_wdr.cpp:2061
+#: src/muuli_wdr.cpp:1462 src/muuli_wdr.cpp:2065
 msgid "Bind to network interface (empty for any):"
 msgstr ""
 
@@ -3920,7 +3925,7 @@ msgstr ""
 msgid "Max simultaneous connections:"
 msgstr "Maksimālais vienlaicīgo savienojumu skaits:"
 
-#: src/muuli_wdr.cpp:1498 src/muuli_wdr.cpp:3176
+#: src/muuli_wdr.cpp:1498 src/muuli_wdr.cpp:3207
 msgid "ED2K"
 msgstr "ED2K"
 
@@ -4012,747 +4017,769 @@ msgstr ""
 msgid "For new files preallocates disk space for the whole file, thus reduces fragmentation"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1613
+#: src/muuli_wdr.cpp:1617
 msgid "Create new files as sparse files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1614
-msgid "A sparse file reserves its full size on disk immediately without writing real data to it -- fast, but unsupported or slow on some filesystems, and free-space accounting stays optimistic while the download is in progress. Turn this off to grow the file only as data arrives."
+#: src/muuli_wdr.cpp:1618
+msgid "Sparse part files only occupy disk space for the parts already downloaded, so free space is used up gradually as the file fills in. Turn this off to use an ordinary file instead - useful where sparse files are unsupported or slow, or where backup/de-duplication tools handle them badly. Applies only when the core runs on Windows; on Linux and macOS part files are sparse anyway and this setting has no effect."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1619
+#: src/muuli_wdr.cpp:1623
 msgid "Stop downloads when free disk space reaches "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1620
+#: src/muuli_wdr.cpp:1624
 msgid "Select this if you want aMule to check your disk space"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1624
+#: src/muuli_wdr.cpp:1628
 msgid "Enter here the min disk space desired."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1630
+#: src/muuli_wdr.cpp:1634
 msgid "Save 10 sources on rare files (< 20 sources)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1634 src/Statistics.cpp:790
+#: src/muuli_wdr.cpp:1638 src/Statistics.cpp:790
 msgid "Uploads"
 msgstr "Augšupielādes"
 
-#: src/muuli_wdr.cpp:1637
+#: src/muuli_wdr.cpp:1641
 msgid "Add new shared files with auto priority"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1643
+#: src/muuli_wdr.cpp:1647
 msgid "Intelligent Corruption Handling (I.C.H.)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1646
+#: src/muuli_wdr.cpp:1650
 msgid "Enable"
 msgstr "Iespējot"
 
-#: src/muuli_wdr.cpp:1649
+#: src/muuli_wdr.cpp:1653
 msgid "Advanced I.C.H. trusts every hash (not recommended)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1661 src/PrefsUnifiedDlg.cpp:1910
+#: src/muuli_wdr.cpp:1665 src/PrefsUnifiedDlg.cpp:1990
 msgid "Media metadata extraction"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1665
+#: src/muuli_wdr.cpp:1669
 msgid "Extract length / bitrate / codec from shared audio and video files"
 msgstr "Iegūt garuma / bitu pārraides ātruma / kodeka infomāciju no kopīgotajām audio un video datnēm"
 
-#: src/muuli_wdr.cpp:1667
+#: src/muuli_wdr.cpp:1671
 msgid "When enabled, aMule runs ffprobe on each shared media file to fill in the Length / Bitrate / Codec columns other clients see when they find the file in a search. Requires ffmpeg (the ffprobe binary) to be installed."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1674
+#: src/muuli_wdr.cpp:1678
 msgid "Path to ffprobe:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1679
+#: src/muuli_wdr.cpp:1683
 msgid "Full path to the ffprobe binary. Leave empty to have aMule auto-detect it on startup."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1687
+#: src/muuli_wdr.cpp:1691
 msgid "Detect"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1688
+#: src/muuli_wdr.cpp:1692
 msgid "Search the standard install locations for an ffprobe binary and fill the path field."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1712
+#: src/muuli_wdr.cpp:1716
 msgid ""
 "Completed downloads are stored here. All files in this folder are automatically shared with other peers.\n"
 "If this folder also holds files you don't want to share, point it at an aMule-only sub-folder."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1715
+#: src/muuli_wdr.cpp:1719
 msgid "Pick the folder where completed downloads will be stored. All files in that folder will be shared with other peers."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1729
+#: src/muuli_wdr.cpp:1733
 msgid "Shared folders"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1735
+#: src/muuli_wdr.cpp:1739
 msgid "(Folders shared by the core. Enter a path to add one.)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1743
+#: src/muuli_wdr.cpp:1747
 msgid "Absolute path of a folder on the core's machine, e.g. /home/user/shared"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1745 src/PrefsUnifiedDlg.cpp:2794
+#: src/muuli_wdr.cpp:1749 src/PrefsUnifiedDlg.cpp:2874
 msgid "Recursive"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1746
+#: src/muuli_wdr.cpp:1750
 msgid "Share every sub-folder underneath this one, including ones created later."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1750 src/utils/aLinkCreator/src/alcframe.cpp:141
+#: src/muuli_wdr.cpp:1754 src/utils/aLinkCreator/src/alcframe.cpp:141
 msgid "Remove"
 msgstr "Noņemt"
 
-#: src/muuli_wdr.cpp:1754
+#: src/muuli_wdr.cpp:1758
 msgid "(Right click on folder icon for recursive share)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1761
+#: src/muuli_wdr.cpp:1765
 msgid "Share hidden files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1767
+#: src/muuli_wdr.cpp:1771
 msgid "Automatically rescan shared folders for changes"
 msgstr "Automātiski uzraudzīt kopīgoto mapju izmaiņas"
 
-#: src/muuli_wdr.cpp:1773
+#: src/muuli_wdr.cpp:1777
 msgid "Follow symbolic links in shared folders"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1779
+#: src/muuli_wdr.cpp:1783
 msgid "Exclude files matching:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1782
+#: src/muuli_wdr.cpp:1786
 msgid "Wildcard patterns separated by '|', e.g. .DS_Store|Thumbs.db|*.tmp. Files whose name matches are not shared. Matching is case-insensitive."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1786
+#: src/muuli_wdr.cpp:1790
 msgid "Patterns are regular expressions"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1787
+#: src/muuli_wdr.cpp:1791
 msgid "When set, the whole field is one regular expression ('|' is alternation). When unset, it is a list of '|'-separated wildcards."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1797
+#: src/muuli_wdr.cpp:1801
 msgid "Show how many shared files the current pattern would exclude."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1818
+#: src/muuli_wdr.cpp:1822
 msgid "Graphs"
 msgstr "Grafiki"
 
-#: src/muuli_wdr.cpp:1821 src/muuli_wdr.cpp:1883
+#: src/muuli_wdr.cpp:1825 src/muuli_wdr.cpp:1887
 msgid "Update delay : 5 secs"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1825
+#: src/muuli_wdr.cpp:1829
 msgid "Time for average graph: 100 mins"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1829
+#: src/muuli_wdr.cpp:1833
 msgid "Connections Graph Scale: 100 "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1836
+#: src/muuli_wdr.cpp:1840
 msgid "Download graph scale:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1844
+#: src/muuli_wdr.cpp:1848
 msgid "Upload graph scale:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1854
+#: src/muuli_wdr.cpp:1858
 msgid "Colors: "
 msgstr "Krāsas: "
 
-#: src/muuli_wdr.cpp:1858
+#: src/muuli_wdr.cpp:1862
 msgid "Background"
 msgstr "Fons"
 
-#: src/muuli_wdr.cpp:1859
+#: src/muuli_wdr.cpp:1863
 msgid "Grid"
 msgstr "Režģis"
 
-#: src/muuli_wdr.cpp:1860
+#: src/muuli_wdr.cpp:1864
 msgid "Download current"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1861
+#: src/muuli_wdr.cpp:1865
 msgid "Download running average"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1862
+#: src/muuli_wdr.cpp:1866
 msgid "Download session average"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1863
+#: src/muuli_wdr.cpp:1867
 msgid "Upload current"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1864
+#: src/muuli_wdr.cpp:1868
 msgid "Upload running average"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1865
+#: src/muuli_wdr.cpp:1869
 msgid "Upload session average"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1866
+#: src/muuli_wdr.cpp:1870
 msgid "Active connections"
 msgstr "Aktīvi savienojumi"
 
-#: src/muuli_wdr.cpp:1869
+#: src/muuli_wdr.cpp:1873
 msgid "Systray Icon Speed Bar"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1870
+#: src/muuli_wdr.cpp:1874
 msgid "Kad-nodes current"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1871
+#: src/muuli_wdr.cpp:1875
 msgid "Kad-nodes running"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1872
+#: src/muuli_wdr.cpp:1876
 msgid "Kad-nodes session"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1876 src/muuli_wdr.cpp:2303
+#: src/muuli_wdr.cpp:1880 src/muuli_wdr.cpp:2334
 msgid "Select"
 msgstr "Atlasīt"
 
-#: src/muuli_wdr.cpp:1880
+#: src/muuli_wdr.cpp:1884
 msgid "Tree"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1890
+#: src/muuli_wdr.cpp:1894
 msgid "Number of Client Versions shown (0=unlimited)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1915
+#: src/muuli_wdr.cpp:1919
 msgid "!!! WARNING !!!"
 msgstr "!!! BRĪDINĀJUMS !!!"
 
-#: src/muuli_wdr.cpp:1930
+#: src/muuli_wdr.cpp:1934
 msgid "Max new connections / 5 secs"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1932
+#: src/muuli_wdr.cpp:1936
 msgid "Concurrent Kad source lookups"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1934
+#: src/muuli_wdr.cpp:1938
 msgid "Kad source re-search interval (minutes)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1936
+#: src/muuli_wdr.cpp:1940
 msgid "Source re-ask interval (minutes)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1940
+#: src/muuli_wdr.cpp:1944
 msgid "File Buffer Size: 240000 bytes"
 msgstr "Datnes bufera izmērs: 240000 baiti"
 
-#: src/muuli_wdr.cpp:1944
+#: src/muuli_wdr.cpp:1948
 msgid "Use MMAP: memory-mapped file access (lower memory use)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1945
+#: src/muuli_wdr.cpp:1949
 msgid "Maps part files into memory instead of buffering them on the heap, lowering the process memory footprint. May reduce download speed on some disks; best for memory-constrained or upload-heavy hosts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1947
+#: src/muuli_wdr.cpp:1951
 msgid "Upload Queue Size: 5000 clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1951
+#: src/muuli_wdr.cpp:1955
 msgid "Server connection refresh interval: Disable"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1955
+#: src/muuli_wdr.cpp:1959
 msgid "Disable computer's timed standby mode"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1974
+#: src/muuli_wdr.cpp:1978
 msgid "Skin to use: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1983
+#: src/muuli_wdr.cpp:1987
 msgid "Show \"Fast eD2k Links Handler\" in every window."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1986
+#: src/muuli_wdr.cpp:1990
 msgid "Show extended info on categories tabs"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1989
+#: src/muuli_wdr.cpp:1993
 msgid "Show application version on title"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1991
+#: src/muuli_wdr.cpp:1995
 msgid "Show transfer rates on title"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1993
+#: src/muuli_wdr.cpp:1997
 msgid "Before application name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1995
+#: src/muuli_wdr.cpp:1999
 msgid "After application name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1998
+#: src/muuli_wdr.cpp:2002
 msgid "Show overhead bandwidth"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2002
+#: src/muuli_wdr.cpp:2006
 msgid "Vertical toolbar orientation"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2004
+#: src/muuli_wdr.cpp:2008
 msgid "Live column sorting (auto-reorder rows as their values change)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2011
+#: src/muuli_wdr.cpp:2015
 msgid "Download Queue Files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2014
+#: src/muuli_wdr.cpp:2018
 msgid "Show progress percentage"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2020
+#: src/muuli_wdr.cpp:2024
 msgid "Show progress bar"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2023
+#: src/muuli_wdr.cpp:2027
 msgid "Flat"
 msgstr "Plakana"
 
-#: src/muuli_wdr.cpp:2027
+#: src/muuli_wdr.cpp:2031
 msgid "Round"
 msgstr "Apaļa"
 
-#: src/muuli_wdr.cpp:2045
+#: src/muuli_wdr.cpp:2049
 msgid "External Connection Parameters"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2048
+#: src/muuli_wdr.cpp:2052
 msgid "Accept external connections"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2055 src/muuli_wdr.cpp:2114
+#: src/muuli_wdr.cpp:2059 src/muuli_wdr.cpp:2118
 msgid "IP of the listening interface:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2058
+#: src/muuli_wdr.cpp:2062
 msgid "Enter here a valid ip in the a.b.c.d format for the listening EC interface. An empty field or 0.0.0.0 will mean any interface."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2079 src/muuli_wdr.cpp:2163
+#: src/muuli_wdr.cpp:2083 src/muuli_wdr.cpp:2194
 msgid "TCP port:"
 msgstr "TCP ports:"
 
-#: src/muuli_wdr.cpp:2085
+#: src/muuli_wdr.cpp:2089
 msgid "Enable UPnP port forwarding on the EC port"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2089 src/muuli_wdr.cpp:3048
+#: src/muuli_wdr.cpp:2093 src/muuli_wdr.cpp:3079
 #: src/utils/wxCas/src/wxcasprefs.cpp:167
 msgid "Password"
 msgstr "Parole"
 
-#: src/muuli_wdr.cpp:2095
+#: src/muuli_wdr.cpp:2099
 msgid "aMule API server parameters"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2098
+#: src/muuli_wdr.cpp:2102
 msgid "Run amuleapi (REST API) on startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2103
+#: src/muuli_wdr.cpp:2107
 #, fuzzy
 msgid "HTTP port:"
 msgstr "TCP ports:"
 
-#: src/muuli_wdr.cpp:2117
+#: src/muuli_wdr.cpp:2121
 msgid "The interface amuleapi's HTTP server listens on. 127.0.0.1 (default) accepts only local connections; use 0.0.0.0 or a specific IP to expose it to other hosts (set an admin password below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2120
+#: src/muuli_wdr.cpp:2126
+msgid "Type a password to set or change it. Stored passwords cannot be shown, so leaving this empty keeps the current one."
+msgstr ""
+
+#: src/muuli_wdr.cpp:2128
 #, fuzzy
 msgid "Admin password"
 msgstr "Parole"
 
-#: src/muuli_wdr.cpp:2125 src/muuli_wdr.cpp:2156
-msgid "Low rights password"
+#: src/muuli_wdr.cpp:2140 src/muuli_wdr.cpp:2157 src/PrefsUnifiedDlg.cpp:1103
+#, fuzzy
+msgid "A password is set."
+msgstr "Parole"
+
+#: src/muuli_wdr.cpp:2144
+msgid "Enable guest access"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2133
+#: src/muuli_wdr.cpp:2145
+msgid "Guest sessions may read status and listings but cannot change anything. Turning this off clears the stored guest password."
+msgstr ""
+
+#: src/muuli_wdr.cpp:2149
+#, fuzzy
+msgid "Guest password"
+msgstr "Parole"
+
+#: src/muuli_wdr.cpp:2164
 msgid "Web server parameters"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2136
+#: src/muuli_wdr.cpp:2167
 #, fuzzy
 msgid "Run webserver on startup (deprecated)"
 msgstr "Kad palaiž, palaist arī tīmekļa serveri"
 
-#: src/muuli_wdr.cpp:2142
+#: src/muuli_wdr.cpp:2173
 msgid "Web template"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2147
+#: src/muuli_wdr.cpp:2178
 msgid "Full rights password"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2151
+#: src/muuli_wdr.cpp:2182
 msgid "Enable Low rights User"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2170
+#: src/muuli_wdr.cpp:2187
+msgid "Low rights password"
+msgstr ""
+
+#: src/muuli_wdr.cpp:2201
 msgid "Enable UPnP port forwarding of the web server port"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2175
+#: src/muuli_wdr.cpp:2206
 msgid "Web server UPnP TCP port (Optional)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2183
+#: src/muuli_wdr.cpp:2214
 msgid "Page Refresh Time (in secs)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2190
+#: src/muuli_wdr.cpp:2221
 msgid "Enable Gzip compression"
 msgstr "Iespējot Gzip saspiešanu"
 
-#: src/muuli_wdr.cpp:2224
+#: src/muuli_wdr.cpp:2255
 #, fuzzy
 msgid "Reset page to defaults"
 msgstr "Sistēmas"
 
-#: src/muuli_wdr.cpp:2225
+#: src/muuli_wdr.cpp:2256
 msgid "Reset the settings on the current page to their default values."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2227 src/muuli_wdr.cpp:2313 src/ServerWnd.cpp:274
+#: src/muuli_wdr.cpp:2258 src/muuli_wdr.cpp:2344 src/ServerWnd.cpp:274
 #: src/ServerWnd.cpp:282
 msgid "OK"
 msgstr "Labi"
 
-#: src/muuli_wdr.cpp:2229
+#: src/muuli_wdr.cpp:2260
 msgid "Click here to apply any changes made to the preferences."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2232
+#: src/muuli_wdr.cpp:2263
 msgid "Reset any changes made to the preferences."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2261
+#: src/muuli_wdr.cpp:2292
 msgid "Comment :"
 msgstr "Komentārs :"
 
-#: src/muuli_wdr.cpp:2268
+#: src/muuli_wdr.cpp:2299
 msgid "Incoming Dir :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2277
+#: src/muuli_wdr.cpp:2308
 msgid "Change priority for new assigned files :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2281
+#: src/muuli_wdr.cpp:2312
 msgid "Don't change"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2293
+#: src/muuli_wdr.cpp:2324
 msgid "Select color for this Category (currently selected) :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2360 src/muuli_wdr.cpp:2379 src/muuli_wdr.cpp:2401
+#: src/muuli_wdr.cpp:2391 src/muuli_wdr.cpp:2410 src/muuli_wdr.cpp:2432
 msgid "Click this button to reset the log."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2420
+#: src/muuli_wdr.cpp:2451
 msgid "Click on this button to update the servers list from URL ..."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2424
+#: src/muuli_wdr.cpp:2455
 msgid "Server list"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2428
+#: src/muuli_wdr.cpp:2459
 msgid "Enter the url to a server.met file here and press the button to the left to update the list of known servers."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2433
+#: src/muuli_wdr.cpp:2464
 msgid "Add server manually: Name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2436
+#: src/muuli_wdr.cpp:2467
 msgid "Enter the name of the new server here"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2438 src/ServerWnd.cpp:206
+#: src/muuli_wdr.cpp:2469 src/ServerWnd.cpp:206
 msgid "IP:Port"
 msgstr "IP:Ports"
 
-#: src/muuli_wdr.cpp:2441
+#: src/muuli_wdr.cpp:2472
 msgid "Enter the IP of the server here, using the x.x.x.x format."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2447
+#: src/muuli_wdr.cpp:2478
 msgid "Enter the port of the server here."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2450
+#: src/muuli_wdr.cpp:2481
 msgid "Add manually a server (fill fields to the left before) ..."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2479
+#: src/muuli_wdr.cpp:2510
 msgid "aMule Log"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2487
+#: src/muuli_wdr.cpp:2518
 msgid "Server Info"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2491
+#: src/muuli_wdr.cpp:2522
 msgid "ED2K Info"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2495
+#: src/muuli_wdr.cpp:2526
 msgid "Kad Info"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2523
+#: src/muuli_wdr.cpp:2554
 msgid "Click on this button to update the nodes list from URL ..."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2527
+#: src/muuli_wdr.cpp:2558
 msgid "Nodes (0)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2531
+#: src/muuli_wdr.cpp:2562
 msgid "Enter the url to a nodes.dat file here and press the button to the left to update the list of known nodes."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2534
+#: src/muuli_wdr.cpp:2565
 msgid "Nodes stats"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2576
+#: src/muuli_wdr.cpp:2607
 msgid "Bootstrap"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2579
+#: src/muuli_wdr.cpp:2610
 msgid "New node"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2584
+#: src/muuli_wdr.cpp:2615
 msgid "IP:"
 msgstr "IP:"
 
-#: src/muuli_wdr.cpp:2604
+#: src/muuli_wdr.cpp:2635
 msgid "Port:"
 msgstr "Ports:"
 
-#: src/muuli_wdr.cpp:2617
+#: src/muuli_wdr.cpp:2648
 msgid "Bootstrap from known clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2619
+#: src/muuli_wdr.cpp:2650
 msgid "Disconnect Kad"
 msgstr "Atslēgt Kad"
 
-#: src/muuli_wdr.cpp:2653
+#: src/muuli_wdr.cpp:2684
 msgid "Use Secure User Identification"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2655
+#: src/muuli_wdr.cpp:2686
 msgid "It is recommended to enable this option. You will not receive credits if SUI is not enabled."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2657
+#: src/muuli_wdr.cpp:2688
 msgid "Protocol Obfuscation"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2660
+#: src/muuli_wdr.cpp:2691
 msgid "Support Protocol Obfuscation"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2662
+#: src/muuli_wdr.cpp:2693
 msgid "This option enabled Protocol Obfuscation, and makes aMule accept obfuscated connections from other clients."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2664
+#: src/muuli_wdr.cpp:2695
 msgid "Use obfuscation for outgoing connections"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2666
+#: src/muuli_wdr.cpp:2697
 msgid "This option makes aMule use Protocol Obfuscation when connecting other clients/servers."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2668
+#: src/muuli_wdr.cpp:2699
 msgid "Accept only obfuscated connections"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2669
+#: src/muuli_wdr.cpp:2700
 msgid "This option makes aMule only accept obfuscated connections. You will have less sources, but all your traffic will be obfuscated"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2674
+#: src/muuli_wdr.cpp:2705
 msgid "Everybody"
 msgstr "Jebkurš"
 
-#: src/muuli_wdr.cpp:2676
+#: src/muuli_wdr.cpp:2707
 msgid "No one"
 msgstr "Neviens"
 
-#: src/muuli_wdr.cpp:2678
+#: src/muuli_wdr.cpp:2709
 msgid "Who can see my shared files:"
 msgstr "Kas var skatīt manas kopīgotās datnes:"
 
-#: src/muuli_wdr.cpp:2679
+#: src/muuli_wdr.cpp:2710
 msgid "Select who can request to view a list of your shared files."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2681
+#: src/muuli_wdr.cpp:2712
 msgid "IP-Filtering"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2688
+#: src/muuli_wdr.cpp:2719
 msgid "Filter clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2690
+#: src/muuli_wdr.cpp:2721
 msgid "Enable filtering of the client IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2692
+#: src/muuli_wdr.cpp:2723
 msgid "Filter servers"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2694
+#: src/muuli_wdr.cpp:2725
 msgid "Enable filtering of the server IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2698
+#: src/muuli_wdr.cpp:2729
 msgid "Reload List"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2699
+#: src/muuli_wdr.cpp:2730
 msgid "Reload the list of IPs to filter from the file ~/.aMule/ipfilter.dat"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2705
+#: src/muuli_wdr.cpp:2736
 msgid "URL:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2709 src/muuli_wdr.cpp:2902
+#: src/muuli_wdr.cpp:2740 src/muuli_wdr.cpp:2933
 msgid "Update now"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2712
+#: src/muuli_wdr.cpp:2743
 msgid "Auto-update ipfilter at startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2716
+#: src/muuli_wdr.cpp:2747
 msgid "Filtering Level:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2722
+#: src/muuli_wdr.cpp:2753
 msgid "Always filter LAN IPs"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2725
+#: src/muuli_wdr.cpp:2756
 msgid "Paranoid handling of non-matching IPs"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2727
+#: src/muuli_wdr.cpp:2758
 msgid "Rejects a packet when its source IP differs from the IP the client claims (an anti-spoofing check). Disable only if it causes connection problems."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2729
+#: src/muuli_wdr.cpp:2760
 msgid "Use system-wide ipfilter.dat if available"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2730
+#: src/muuli_wdr.cpp:2761
 msgid "If there's no local ipfilter.dat found, allow usage of a system-wide ipfilter file."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2747
+#: src/muuli_wdr.cpp:2778
 msgid "Enable Online-Signature"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2749
+#: src/muuli_wdr.cpp:2780
 msgid "Enables the writing of the OS file, which can be used by external apps to create signatures and the like."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2753
+#: src/muuli_wdr.cpp:2784
 msgid "Update Frequency (Secs):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2756
+#: src/muuli_wdr.cpp:2787
 msgid "Change the frequency (in seconds) of Online Signature updates."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2764
+#: src/muuli_wdr.cpp:2795
 msgid "Save online signature file in: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:2770
+#: src/muuli_wdr.cpp:2801
 msgid "Click here to select the directory containing the the Online Signature files."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2803
+#: src/muuli_wdr.cpp:2834
 msgid "Show country flags for clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2804
+#: src/muuli_wdr.cpp:2835
 msgid "Render the country flag column in the transfers, queue and search views. Requires a valid MMDB GeoIP database (see below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2809
+#: src/muuli_wdr.cpp:2840
 msgid "Database"
 msgstr "Datubāze"
 
-#: src/muuli_wdr.cpp:2825
+#: src/muuli_wdr.cpp:2856
 msgid "Source:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2828
+#: src/muuli_wdr.cpp:2859
 msgid "DB-IP (free, no account)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2829
+#: src/muuli_wdr.cpp:2860
 msgid "MaxMind GeoLite2 (free, account required)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2830
+#: src/muuli_wdr.cpp:2861
 msgid "Custom URL"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2833
+#: src/muuli_wdr.cpp:2864
 msgid "Choose which provider supplies the GeoIP MMDB database. DB-IP is the default - no account required. MaxMind requires a free account + license key. Use Custom URL to point at any other MMDB host (e.g. a local mirror)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2850
+#: src/muuli_wdr.cpp:2881
 msgid ""
 "No configuration required.\n"
 "\n"
@@ -4760,11 +4787,11 @@ msgid ""
 "License: Creative Commons BY 4.0 - https://creativecommons.org/licenses/by/4.0/"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2863
+#: src/muuli_wdr.cpp:2894
 msgid "License key:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2869
+#: src/muuli_wdr.cpp:2900
 msgid ""
 "Sign up for a free MaxMind account, then generate a License Key:\n"
 "https://www.maxmind.com/en/geolite2/signup\n"
@@ -4774,222 +4801,222 @@ msgid ""
 "Requires attribution and account registration; refresh at least every 30 days."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2884
+#: src/muuli_wdr.cpp:2915
 msgid "Download URL:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2890
+#: src/muuli_wdr.cpp:2921
 msgid ""
 "Must point to an .mmdb file or a .gz / .tar.gz containing one.\n"
 "URL may include credentials (https://user:pass@host/...).\n"
 "License and attribution terms are set by the upstream URL - you are responsible."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2903
+#: src/muuli_wdr.cpp:2934
 msgid "Download the GeoIP database from the selected source."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2905
+#: src/muuli_wdr.cpp:2936
 msgid "Auto-update on startup"
 msgstr "Kad palaiž, automātiski atjaunināt"
 
-#: src/muuli_wdr.cpp:2906
+#: src/muuli_wdr.cpp:2937
 msgid "Re-download the GeoIP database from the selected source every time aMule starts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2929
+#: src/muuli_wdr.cpp:2960
 msgid "Filter incoming messages (except current chat):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2931
+#: src/muuli_wdr.cpp:2962
 msgid "Filter all messages"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2933
+#: src/muuli_wdr.cpp:2964
 msgid "Filter messages from people not on your friend list"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2935
+#: src/muuli_wdr.cpp:2966
 msgid "Filter messages from unknown clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2937
+#: src/muuli_wdr.cpp:2968
 msgid "Filter messages containing (use ',' as separator):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2940 src/muuli_wdr.cpp:2951
+#: src/muuli_wdr.cpp:2971 src/muuli_wdr.cpp:2982
 msgid "add here the words amule should filter and block messages including it"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2942
+#: src/muuli_wdr.cpp:2973
 msgid "Show received messages in the log"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2945
+#: src/muuli_wdr.cpp:2976
 msgid "Comments"
 msgstr "Komentāri"
 
-#: src/muuli_wdr.cpp:2948
+#: src/muuli_wdr.cpp:2979
 msgid "Filter comments containing (use ',' as separator):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2973
+#: src/muuli_wdr.cpp:3004
 msgid "Enable Proxy"
 msgstr "Izmantot starpniekserveri"
 
-#: src/muuli_wdr.cpp:2974
+#: src/muuli_wdr.cpp:3005
 msgid "Enable/disable proxy support"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2977
+#: src/muuli_wdr.cpp:3008
 msgid "Proxy type:"
 msgstr "Starpniekservera tips:"
 
-#: src/muuli_wdr.cpp:2988
+#: src/muuli_wdr.cpp:3019
 msgid "Proxy host:"
 msgstr "Starpniekserveris:"
 
-#: src/muuli_wdr.cpp:2991
+#: src/muuli_wdr.cpp:3022
 msgid "The proxy host name"
 msgstr "Starpniekservera resursdatora nosaukums"
 
-#: src/muuli_wdr.cpp:2993
+#: src/muuli_wdr.cpp:3024
 msgid "Proxy port:"
 msgstr "Starpniekservera ports:"
 
-#: src/muuli_wdr.cpp:2996
+#: src/muuli_wdr.cpp:3027
 msgid "The proxy port"
 msgstr "Starpniekservera ports"
 
-#: src/muuli_wdr.cpp:2998
+#: src/muuli_wdr.cpp:3029
 msgid "Enable authentication"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2999
+#: src/muuli_wdr.cpp:3030
 msgid "Enable/disable username/password authentication"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3002
+#: src/muuli_wdr.cpp:3033
 msgid "Username: "
 msgstr "Lietotājvārds: "
 
-#: src/muuli_wdr.cpp:3005
+#: src/muuli_wdr.cpp:3036
 msgid "The username to use to connect to the proxy"
 msgstr "Lietotājvārds, ko lietot, kad izmanto starpniekserveri"
 
-#: src/muuli_wdr.cpp:3007
+#: src/muuli_wdr.cpp:3038
 msgid "Password:"
 msgstr "Parole:"
 
-#: src/muuli_wdr.cpp:3010
+#: src/muuli_wdr.cpp:3041
 msgid "The password to use to connect to the proxy"
 msgstr "Parole, ko lietot, kad izmanto starpniekserveri"
 
-#: src/muuli_wdr.cpp:3029
+#: src/muuli_wdr.cpp:3060
 msgid "Connect to:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3038
+#: src/muuli_wdr.cpp:3069
 msgid "Login to remote amule"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3043
+#: src/muuli_wdr.cpp:3074
 msgid "User name"
 msgstr "Lietotājvārds"
 
-#: src/muuli_wdr.cpp:3054
+#: src/muuli_wdr.cpp:3085
 msgid "Remember those settings"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3057
+#: src/muuli_wdr.cpp:3088
 msgid "Force ZLIB compression"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3081
+#: src/muuli_wdr.cpp:3112
 msgid "Enable Verbose Debug-Logging."
 msgstr ""
 
-#: src/muuli_wdr.cpp:3083
+#: src/muuli_wdr.cpp:3114
 msgid "Only to Logfile"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3085
+#: src/muuli_wdr.cpp:3116
 msgid "Message Categories:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3109 src/PartFileConvertDlg.cpp:160
+#: src/muuli_wdr.cpp:3140 src/PartFileConvertDlg.cpp:160
 msgid "Waiting..."
 msgstr "Gaida…"
 
-#: src/muuli_wdr.cpp:3129
+#: src/muuli_wdr.cpp:3160
 msgid "Add imports"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3132
+#: src/muuli_wdr.cpp:3163
 msgid "Retry selected"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3134
+#: src/muuli_wdr.cpp:3165
 msgid "Remove selected"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3197
+#: src/muuli_wdr.cpp:3228
 msgid "Event Types"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3216
+#: src/muuli_wdr.cpp:3247
 msgid "Statistics and queued clients for selected file(s) : Session / All time"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3240
+#: src/muuli_wdr.cpp:3271
 msgid "Active Uploads"
 msgstr "Aktīvas augšupielādes"
 
-#: src/muuli_wdr.cpp:3254
+#: src/muuli_wdr.cpp:3285
 msgid "Percent of total files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3306
+#: src/muuli_wdr.cpp:3337
 msgid "Show Clients for"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3308
+#: src/muuli_wdr.cpp:3339
 msgid "All files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3311
+#: src/muuli_wdr.cpp:3342
 msgid "Selected files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3314
+#: src/muuli_wdr.cpp:3345
 msgid "Active uploads only"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3321
+#: src/muuli_wdr.cpp:3352
 msgid "Reload:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3325
+#: src/muuli_wdr.cpp:3356
 msgid "Reload your shared files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3388
+#: src/muuli_wdr.cpp:3419
 msgid "Send"
 msgstr "Sūtīt"
 
-#: src/muuli_wdr.cpp:3389
+#: src/muuli_wdr.cpp:3420
 msgid "Sends the specified message."
 msgstr ""
 
-#: src/muuli_wdr.cpp:3393
+#: src/muuli_wdr.cpp:3424
 msgid "Close this chat-session."
 msgstr ""
 
-#: src/muuli_wdr.cpp:3416
+#: src/muuli_wdr.cpp:3447
 msgid "Connect to any server and/or Kad"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3422 src/SharedFilesCtrl.cpp:142 src/Statistics.cpp:941
+#: src/muuli_wdr.cpp:3453 src/SharedFilesCtrl.cpp:142 src/Statistics.cpp:941
 msgid "Shared Files"
 msgstr "Kopīgotās datnes"
 
@@ -5348,263 +5375,263 @@ msgstr "Lejupielādēta"
 msgid "ERROR: Failed to open partfile '%s'"
 msgstr ""
 
-#: src/Preferences.cpp:674
+#: src/Preferences.cpp:701
 msgid "System default"
 msgstr "Sistēmas"
 
-#: src/Preferences.cpp:675
+#: src/Preferences.cpp:702
 msgid "Albanian"
 msgstr "Albāņu"
 
-#: src/Preferences.cpp:676
+#: src/Preferences.cpp:703
 msgid "Arabic"
 msgstr "Arābu"
 
-#: src/Preferences.cpp:677
+#: src/Preferences.cpp:704
 msgid "Asturian"
 msgstr "Astūriešu"
 
-#: src/Preferences.cpp:678
+#: src/Preferences.cpp:705
 msgid "Basque"
 msgstr "Basku"
 
-#: src/Preferences.cpp:679
+#: src/Preferences.cpp:706
 msgid "Bulgarian"
 msgstr "Bulgāru"
 
-#: src/Preferences.cpp:680
+#: src/Preferences.cpp:707
 msgid "Catalan"
 msgstr "Katalāņu"
 
-#: src/Preferences.cpp:681
+#: src/Preferences.cpp:708
 msgid "Chinese (Simplified)"
 msgstr "Ķīniešu (vienkāršotā)"
 
-#: src/Preferences.cpp:682
+#: src/Preferences.cpp:709
 msgid "Chinese (Traditional)"
 msgstr "Ķīniešu (tradicionālā)"
 
-#: src/Preferences.cpp:683
+#: src/Preferences.cpp:710
 msgid "Croatian"
 msgstr "Horvātu"
 
-#: src/Preferences.cpp:684
+#: src/Preferences.cpp:711
 msgid "Czech"
 msgstr "Čehu"
 
-#: src/Preferences.cpp:685
+#: src/Preferences.cpp:712
 msgid "Danish"
 msgstr "Dāņu"
 
-#: src/Preferences.cpp:686
+#: src/Preferences.cpp:713
 msgid "Dutch"
 msgstr "Nīderlandiešu"
 
-#: src/Preferences.cpp:687
+#: src/Preferences.cpp:714
 msgid "English (U.K.)"
 msgstr "Angļu (Apvienotās Karalistes)"
 
-#: src/Preferences.cpp:688
+#: src/Preferences.cpp:715
 msgid "English (U.S.)"
 msgstr "Angļu (ASV)"
 
-#: src/Preferences.cpp:689
+#: src/Preferences.cpp:716
 msgid "Estonian"
 msgstr "Igauņu"
 
-#: src/Preferences.cpp:690
+#: src/Preferences.cpp:717
 msgid "Finnish"
 msgstr "Somu"
 
-#: src/Preferences.cpp:691
+#: src/Preferences.cpp:718
 msgid "French"
 msgstr "Franču"
 
-#: src/Preferences.cpp:692
+#: src/Preferences.cpp:719
 msgid "Galician"
 msgstr "Galisiešu"
 
-#: src/Preferences.cpp:693
+#: src/Preferences.cpp:720
 msgid "German"
 msgstr "Vācu"
 
-#: src/Preferences.cpp:694
+#: src/Preferences.cpp:721
 msgid "Greek"
 msgstr "Grieķu"
 
-#: src/Preferences.cpp:695
+#: src/Preferences.cpp:722
 msgid "Hebrew"
 msgstr "Ivrits"
 
-#: src/Preferences.cpp:696
+#: src/Preferences.cpp:723
 msgid "Hungarian"
 msgstr "Ungāru"
 
-#: src/Preferences.cpp:697
+#: src/Preferences.cpp:724
 msgid "Italian"
 msgstr "Itāļu"
 
-#: src/Preferences.cpp:698
+#: src/Preferences.cpp:725
 msgid "Japanese"
 msgstr "Japāņu"
 
-#: src/Preferences.cpp:699
+#: src/Preferences.cpp:726
 msgid "Korean"
 msgstr "Korejiešu"
 
-#: src/Preferences.cpp:700
+#: src/Preferences.cpp:727
 msgid "Latvian"
 msgstr ""
 
-#: src/Preferences.cpp:701
+#: src/Preferences.cpp:728
 msgid "Lithuanian"
 msgstr "Lietuviešu"
 
-#: src/Preferences.cpp:702
+#: src/Preferences.cpp:729
 msgid "Norwegian (Nynorsk)"
 msgstr "Norvēģu (Jaunnorvēģu)"
 
-#: src/Preferences.cpp:703
+#: src/Preferences.cpp:730
 msgid "Polish"
 msgstr "Poļu"
 
-#: src/Preferences.cpp:704
+#: src/Preferences.cpp:731
 msgid "Portuguese"
 msgstr "Portugāļu"
 
-#: src/Preferences.cpp:705
+#: src/Preferences.cpp:732
 msgid "Portuguese (Brazilian)"
 msgstr "Portugāļu (Brazīlijas)"
 
-#: src/Preferences.cpp:706
+#: src/Preferences.cpp:733
 msgid "Romanian"
 msgstr "Rumāņu"
 
-#: src/Preferences.cpp:707
+#: src/Preferences.cpp:734
 msgid "Russian"
 msgstr "Krievu"
 
-#: src/Preferences.cpp:708
+#: src/Preferences.cpp:735
 msgid "Slovenian"
 msgstr "Slovēņu"
 
-#: src/Preferences.cpp:709
+#: src/Preferences.cpp:736
 msgid "Spanish"
 msgstr "Spāņu"
 
-#: src/Preferences.cpp:710
+#: src/Preferences.cpp:737
 msgid "Swedish"
 msgstr "Zviedru"
 
-#: src/Preferences.cpp:711
+#: src/Preferences.cpp:738
 msgid "Turkish"
 msgstr "Turku"
 
-#: src/Preferences.cpp:712
+#: src/Preferences.cpp:739
 msgid "Ukrainian"
 msgstr "Ukraiņu"
 
-#: src/Preferences.cpp:815
+#: src/Preferences.cpp:842
 msgid "Change Language"
 msgstr "Mainīt valodu"
 
-#: src/Preferences.cpp:879
+#: src/Preferences.cpp:906
 msgid "There are no translations installed for aMule"
 msgstr "aMule nav uzstādīta neviena valodas datne"
 
-#: src/Preferences.cpp:880
+#: src/Preferences.cpp:907
 msgid "No languages available"
 msgstr "Nav pieejama neviena valoda"
 
-#: src/Preferences.cpp:1011
+#: src/Preferences.cpp:1038
 msgid "no options available"
 msgstr ""
 
-#: src/Preferences.cpp:2182
+#: src/Preferences.cpp:2227
 msgid "Invalid category found, skipping"
 msgstr ""
 
-#: src/Preferences.cpp:2351
+#: src/Preferences.cpp:2396
 msgid "TCP port can't be higher than 65532 due to server UDP socket being TCP+3"
 msgstr ""
 
-#: src/Preferences.cpp:2352
+#: src/Preferences.cpp:2397
 #, c-format
 msgid "Default port will be used (%d)"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:298 src/Statistics.cpp:866
+#: src/PrefsUnifiedDlg.cpp:300 src/Statistics.cpp:866
 msgid "Connection"
 msgstr "Savienojums"
 
-#: src/PrefsUnifiedDlg.cpp:299 src/SearchListCtrl.cpp:117
+#: src/PrefsUnifiedDlg.cpp:301 src/SearchListCtrl.cpp:117
 msgid "Directories"
 msgstr "Mapes"
 
-#: src/PrefsUnifiedDlg.cpp:300 src/Statistics.cpp:917
+#: src/PrefsUnifiedDlg.cpp:302 src/Statistics.cpp:917
 msgid "Servers"
 msgstr "Serveri"
 
-#: src/PrefsUnifiedDlg.cpp:301 src/ServerListCtrl.cpp:96
+#: src/PrefsUnifiedDlg.cpp:303 src/ServerListCtrl.cpp:96
 msgid "Files"
 msgstr "Datnes"
 
-#: src/PrefsUnifiedDlg.cpp:302
+#: src/PrefsUnifiedDlg.cpp:304
 msgid "Security"
 msgstr "Drošība"
 
-#: src/PrefsUnifiedDlg.cpp:303
+#: src/PrefsUnifiedDlg.cpp:305
 msgid "Interface"
 msgstr "Saskarne"
 
-#: src/PrefsUnifiedDlg.cpp:310
+#: src/PrefsUnifiedDlg.cpp:312
 msgid "IP2Country"
 msgstr "IP2Country"
 
-#: src/PrefsUnifiedDlg.cpp:313
+#: src/PrefsUnifiedDlg.cpp:315
 msgid "Proxy"
 msgstr "Starpniekserveris"
 
-#: src/PrefsUnifiedDlg.cpp:314
+#: src/PrefsUnifiedDlg.cpp:316
 msgid "Filters"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:315
+#: src/PrefsUnifiedDlg.cpp:317
 msgid "Remote Controls"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:316
+#: src/PrefsUnifiedDlg.cpp:318
 msgid "Online Signature"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:317
+#: src/PrefsUnifiedDlg.cpp:319
 msgid "Advanced"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:318
+#: src/PrefsUnifiedDlg.cpp:320
 msgid "Events"
 msgstr "Notikumi"
 
-#: src/PrefsUnifiedDlg.cpp:321
+#: src/PrefsUnifiedDlg.cpp:323
 msgid "Debugging"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:451
+#: src/PrefsUnifiedDlg.cpp:453
 msgid ""
 "The following variables will be substituted:\n"
 "    %PARTFILE - full path to the file\n"
 "    %PARTNAME - file name only"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:472
+#: src/PrefsUnifiedDlg.cpp:474
 msgid "Tray icon support requires libayatana-appindicator3 at compile time."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:488
+#: src/PrefsUnifiedDlg.cpp:490
 msgid "Not available on Wayland: the protocol does not report when a window is minimized, so this option cannot intercept the system minimize button. Workaround: launch aMule with `GDK_BACKEND=x11` to use XWayland instead."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:534
+#: src/PrefsUnifiedDlg.cpp:536
 msgid ""
 "Do not change these setting unless you know\n"
 "what you are doing, otherwise you can easily\n"
@@ -5614,64 +5641,73 @@ msgid ""
 "these settings."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:645
+#: src/PrefsUnifiedDlg.cpp:647
 #, c-format
 msgid "Failed to connect Cfg to widget with the ID %d and key %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:693
+#: src/PrefsUnifiedDlg.cpp:695
 #, c-format
 msgid "Failed to transfer data from Cfg to Widget with the ID %d and key %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:799
+#: src/PrefsUnifiedDlg.cpp:801
 msgid "The type of proxy you are connecting to"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1003
+#: src/PrefsUnifiedDlg.cpp:1020
 #, c-format
 msgid "Failed to transfer data from Widget to Cfg with the ID %d and key %s"
 msgstr ""
 
 #: src/PrefsUnifiedDlg.cpp:1103
+#, fuzzy
+msgid "No password set."
+msgstr "Parole"
+
+#: src/PrefsUnifiedDlg.cpp:1132
+msgid "Guest access needs a password. Type one in the guest password field, or untick Enable guest access."
+msgstr ""
+
+#: src/PrefsUnifiedDlg.cpp:1144
 msgid ""
 "aMule must be restarted to enable these changes:\n"
 "\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1110
+#: src/PrefsUnifiedDlg.cpp:1151
 msgid "- TCP port changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1115
+#: src/PrefsUnifiedDlg.cpp:1156
 msgid "- UDP port changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1120
+#: src/PrefsUnifiedDlg.cpp:1161
 msgid "- Network interface binding changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1125
+#: src/PrefsUnifiedDlg.cpp:1166
 msgid "- External connect port changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1129
+#: src/PrefsUnifiedDlg.cpp:1170
 msgid "- External connect acceptance changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1133
+#: src/PrefsUnifiedDlg.cpp:1174
 msgid "- External connect interface changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1137
+#: src/PrefsUnifiedDlg.cpp:1178
 msgid "- Protocol obfuscation support changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1151
+#: src/PrefsUnifiedDlg.cpp:1193
 msgid "- amuleapi settings changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1160
+#: src/PrefsUnifiedDlg.cpp:1202
 msgid ""
 "Your Auto-update server list is empty.\n"
 "'Auto-update server list at startup' will be disabled."
@@ -5679,135 +5715,140 @@ msgstr ""
 "Jūsu automātiskās atjaunināšanas serveru saraksts ir tukšs.\n"
 "'Kad palaiž, automātiski atjaunināt serveru sarakstu' iestatījums tiks atspējots."
 
-#: src/PrefsUnifiedDlg.cpp:1171
+#: src/PrefsUnifiedDlg.cpp:1213
 msgid ""
 "You have enabled external connections but have not specified a password.\n"
 "External connections cannot be enabled unless a valid password is specified."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1202
+#: src/PrefsUnifiedDlg.cpp:1246
+#, c-format
+msgid "The amuleapi password could not be saved: %s"
+msgstr ""
+
+#: src/PrefsUnifiedDlg.cpp:1276
 msgid "- Language changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1207
+#: src/PrefsUnifiedDlg.cpp:1281
 msgid "- Temp folder changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1212
+#: src/PrefsUnifiedDlg.cpp:1286
 msgid "- ED2K network enabled.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1245
+#: src/PrefsUnifiedDlg.cpp:1319
 msgid "The shared-file exclusion pattern is not a valid regular expression. The filter has been left disabled."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1247 src/PrefsUnifiedDlg.cpp:1841
+#: src/PrefsUnifiedDlg.cpp:1321 src/PrefsUnifiedDlg.cpp:1921
 msgid "Invalid regular expression"
 msgstr "Nederīga regulārā izteiksme"
 
-#: src/PrefsUnifiedDlg.cpp:1324
+#: src/PrefsUnifiedDlg.cpp:1398
 msgid ""
 "Both eD2k and Kad network are disabled.\n"
 "You won't be able to connect until you enable at least one of them."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1329
+#: src/PrefsUnifiedDlg.cpp:1403
 msgid ""
 "Kad will not start if your UDP port is disabled.\n"
 "Enable UDP port or disable Kad."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1385
+#: src/PrefsUnifiedDlg.cpp:1459
 msgid ""
 "\n"
 "You MUST restart aMule now.\n"
 "If you do not restart now, don't complain if anything bad happens.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1450
+#: src/PrefsUnifiedDlg.cpp:1524
 msgid "Could not register aMule for autostart at login. The autostart store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1452
+#: src/PrefsUnifiedDlg.cpp:1526
 msgid "Could not remove the autostart-at-login entry."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1453
+#: src/PrefsUnifiedDlg.cpp:1527
 msgid "Autostart"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1468
+#: src/PrefsUnifiedDlg.cpp:1542
 msgid "Register file type"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1468
+#: src/PrefsUnifiedDlg.cpp:1542
 msgid "Register URL handler"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1476
+#: src/PrefsUnifiedDlg.cpp:1550
 #, c-format
 msgid "aMule only handles eD2k-compatible magnets. If you replace the current magnet handler (%s), BitTorrent magnet links will stop working - aMule cannot download BitTorrent content. Continue?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1481
+#: src/PrefsUnifiedDlg.cpp:1555
 #, c-format
 msgid "Another application currently opens .emulecollection files (%s). Replace it with aMule?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1486
+#: src/PrefsUnifiedDlg.cpp:1560
 #, c-format
 msgid "Another application is currently the default handler for these links (%s). Replace it with aMule?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1511
+#: src/PrefsUnifiedDlg.cpp:1585
 msgid "Could not register aMule for .emulecollection files. The registration store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1513
+#: src/PrefsUnifiedDlg.cpp:1587
 msgid "Could not remove the file type registration."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1515
+#: src/PrefsUnifiedDlg.cpp:1589
 msgid "Could not register aMule as the URL handler. The registration store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1517
+#: src/PrefsUnifiedDlg.cpp:1591
 msgid "Could not remove the URL handler registration."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1587 src/PrefsUnifiedDlg.cpp:1614
+#: src/PrefsUnifiedDlg.cpp:1661 src/PrefsUnifiedDlg.cpp:1688
 msgid "The web server and aMule API require external connections to be enabled."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1597
+#: src/PrefsUnifiedDlg.cpp:1671
 msgid "The aMule web server is deprecated. Consider running the aMule API instead."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1655
+#: src/PrefsUnifiedDlg.cpp:1735
 msgid ""
 "Your Auto-update servers list is in blank.\n"
 "Please fill in at least one URL to point to a valid server.met file.\n"
 "Click on the button \"List\" by this checkbox to enter an URL."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1796
+#: src/PrefsUnifiedDlg.cpp:1876
 msgid "Temporary files"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1801
+#: src/PrefsUnifiedDlg.cpp:1881
 msgid "Incoming files"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1806
+#: src/PrefsUnifiedDlg.cpp:1886
 msgid "Online Signatures"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1819
+#: src/PrefsUnifiedDlg.cpp:1899
 #, c-format
 msgid "Choose a folder for %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1843
+#: src/PrefsUnifiedDlg.cpp:1923
 #, c-format
 msgid "Would exclude %u of %u shared file"
 msgid_plural "Would exclude %u of %u shared files"
@@ -5815,100 +5856,100 @@ msgstr[0] ""
 msgstr[1] ""
 msgstr[2] ""
 
-#: src/PrefsUnifiedDlg.cpp:1860
+#: src/PrefsUnifiedDlg.cpp:1940
 msgid "Browse for videoplayer"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1864
+#: src/PrefsUnifiedDlg.cpp:1944
 msgid "Select browser"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1868
+#: src/PrefsUnifiedDlg.cpp:1948
 msgid "Select ffprobe binary"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1874
+#: src/PrefsUnifiedDlg.cpp:1954
 #, c-format
 msgid "Executable%s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1908
+#: src/PrefsUnifiedDlg.cpp:1988
 msgid "ffprobe not found on PATH or in the standard install locations. Install ffmpeg (which ships ffprobe) or use Browse to pick a binary manually."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1920
+#: src/PrefsUnifiedDlg.cpp:2000
 msgid "Reset the settings on this page to their default values?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1921
+#: src/PrefsUnifiedDlg.cpp:2001
 #, fuzzy
 msgid "Reset to defaults"
 msgstr "Sistēmas"
 
-#: src/PrefsUnifiedDlg.cpp:1948
+#: src/PrefsUnifiedDlg.cpp:2028
 msgid "Edit server list"
 msgstr "Rediģēt serveru sarakstu"
 
-#: src/PrefsUnifiedDlg.cpp:1949
+#: src/PrefsUnifiedDlg.cpp:2029
 msgid ""
 "Add here URL's to download server.met files.\n"
 "Only one url on each line."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2004
+#: src/PrefsUnifiedDlg.cpp:2084
 msgid "IP2Country update failed"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2149 src/PrefsUnifiedDlg.cpp:2180
+#: src/PrefsUnifiedDlg.cpp:2229 src/PrefsUnifiedDlg.cpp:2260
 msgid "Data by MaxMind GeoLite2"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2151 src/PrefsUnifiedDlg.cpp:2182
+#: src/PrefsUnifiedDlg.cpp:2231 src/PrefsUnifiedDlg.cpp:2262
 msgid "Custom source"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2153 src/PrefsUnifiedDlg.cpp:2184
+#: src/PrefsUnifiedDlg.cpp:2233 src/PrefsUnifiedDlg.cpp:2264
 msgid "Data by DB-IP.com"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2204
+#: src/PrefsUnifiedDlg.cpp:2284
 #, c-format
 msgid "Status: Loaded%s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2206
+#: src/PrefsUnifiedDlg.cpp:2286
 #, c-format
 msgid "Status: Loaded%s - %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2210
+#: src/PrefsUnifiedDlg.cpp:2290
 msgid "Status: Failed to load - click 'Update now' to refresh."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2212
+#: src/PrefsUnifiedDlg.cpp:2292
 msgid "Status: Not found - click 'Update now' to download."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2270 src/PrefsUnifiedDlg.cpp:2294
+#: src/PrefsUnifiedDlg.cpp:2350 src/PrefsUnifiedDlg.cpp:2374
 #, c-format
 msgid "Update delay: %d second"
 msgid_plural "Update delay: %d seconds"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/PrefsUnifiedDlg.cpp:2278
+#: src/PrefsUnifiedDlg.cpp:2358
 #, c-format
 msgid "Time for average graph: %d minute"
 msgid_plural "Time for average graph: %d minutes"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/PrefsUnifiedDlg.cpp:2287
+#: src/PrefsUnifiedDlg.cpp:2367
 #, c-format
 msgid "Connections Graph Scale: %d"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2302
+#: src/PrefsUnifiedDlg.cpp:2382
 #, c-format
 msgid "File Buffer Size: %d byte"
 msgid_plural "File Buffer Size: %d bytes"
@@ -5916,90 +5957,90 @@ msgstr[0] "Datnes bufera izmērs: %d baiti"
 msgstr[1] "Datnes bufera izmērs: %d baits"
 msgstr[2] "Datnes bufera izmērs: %d baiti"
 
-#: src/PrefsUnifiedDlg.cpp:2312
+#: src/PrefsUnifiedDlg.cpp:2392
 #, c-format
 msgid "Upload Queue Size: %d client"
 msgid_plural "Upload Queue Size: %d clients"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/PrefsUnifiedDlg.cpp:2322
+#: src/PrefsUnifiedDlg.cpp:2402
 #, c-format
 msgid "Server connection refresh interval: %d minute"
 msgid_plural "Server connection refresh interval: %d minutes"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/PrefsUnifiedDlg.cpp:2327
+#: src/PrefsUnifiedDlg.cpp:2407
 msgid "Server connection refresh interval: Disabled"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2371
+#: src/PrefsUnifiedDlg.cpp:2451
 msgid "disabled"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2397
+#: src/PrefsUnifiedDlg.cpp:2477
 #, c-format
 msgid "Execute command on '%s' event"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2404
+#: src/PrefsUnifiedDlg.cpp:2484
 msgid "Enable command execution on core"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2416
+#: src/PrefsUnifiedDlg.cpp:2496
 msgid "Core command:"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2432
+#: src/PrefsUnifiedDlg.cpp:2512
 msgid "Enable command execution on GUI"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2444
+#: src/PrefsUnifiedDlg.cpp:2524
 msgid "GUI command:"
 msgstr "GUI komanda:"
 
-#: src/PrefsUnifiedDlg.cpp:2460
+#: src/PrefsUnifiedDlg.cpp:2540
 msgid "The following variables will be replaced:"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2628
+#: src/PrefsUnifiedDlg.cpp:2708
 msgid ""
 "The following folders look like system or sensitive locations:\n"
 "\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2633
+#: src/PrefsUnifiedDlg.cpp:2713
 msgid "Sharing them recursively will publish every file underneath on the eD2k/Kad networks. Do you really want to do this?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2636
+#: src/PrefsUnifiedDlg.cpp:2716
 msgid "Confirm shared folders"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2664
+#: src/PrefsUnifiedDlg.cpp:2744
 msgid "Reloading shared files..."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2665
+#: src/PrefsUnifiedDlg.cpp:2745
 msgid "Scanning for subdirectories..."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2666
+#: src/PrefsUnifiedDlg.cpp:2746
 msgid "Updating shared folders"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2693
+#: src/PrefsUnifiedDlg.cpp:2773
 #, c-format
 msgid "Scanned %u directories..."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2743
+#: src/PrefsUnifiedDlg.cpp:2823
 #, c-format
 msgid "Reloading shared files: %u files scanned"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2793
+#: src/PrefsUnifiedDlg.cpp:2873
 #, fuzzy
 msgid "Shared folder"
 msgstr "Kopīgotās datnes"

--- a/po/lv.po
+++ b/po/lv.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-28 08:06+0200\n"
+"POT-Creation-Date: 2026-07-28 10:19+0200\n"
 "PO-Revision-Date: 2026-07-27 11:49+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: none\n"
@@ -133,7 +133,7 @@ msgstr "Uzstādīt"
 msgid "Not now"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:422 src/amuleDlg.cpp:600
+#: src/AppImageIntegration.cpp:422 src/amuleDlg.cpp:665
 msgid "Don't ask again"
 msgstr ""
 
@@ -205,7 +205,7 @@ msgid "Killing amuleweb instance with pid '%d' ... "
 msgstr "Iznīcina amuleweb procesu ar pid '%d' … "
 
 #: src/amule.cpp:336 src/amule.cpp:349 src/ClientRef.cpp:180
-#: src/SearchDlg.cpp:880 src/ServerListCtrl.cpp:98
+#: src/SearchDlg.cpp:1041 src/ServerListCtrl.cpp:98
 msgid "Failed"
 msgstr "Neizdevās"
 
@@ -550,29 +550,67 @@ msgstr ""
 msgid "ERROR: %s"
 msgstr "KĻŪDA: %s"
 
-#: src/amuleDlg.cpp:236
+#: src/amuleDlg.cpp:250
 #, c-format
 msgid "This is aMule %s based on eMule."
 msgstr ""
 
-#: src/amuleDlg.cpp:237
+#: src/amuleDlg.cpp:251
 #, c-format
 msgid "Running on %s"
 msgstr ""
 
-#: src/amuleDlg.cpp:239
+#: src/amuleDlg.cpp:253
 msgid "Visit https://github.com/amule-org/amule/releases/latest to check if a new version is available."
 msgstr "Apmeklējiet https://github.com/amule-org/amule/releases/latest vietni, lai pārbaudītu, vai nav pieejama jauna versija."
 
-#: src/amuleDlg.cpp:268
+#: src/amuleDlg.cpp:282
 msgid "FATAL ERROR: Failed to create Timer"
 msgstr ""
 
-#: src/amuleDlg.cpp:592
+#: src/amuleDlg.cpp:361 src/amuleDlg.cpp:1787 src/amuleDlg.cpp:2033
+#: src/muuli_wdr.cpp:1492 src/muuli_wdr.cpp:3418
+msgid "Networks"
+msgstr "Tīkli"
+
+#: src/amuleDlg.cpp:362 src/amuleDlg.cpp:1793 src/muuli_wdr.cpp:3419
+msgid "Searches"
+msgstr ""
+
+#: src/amuleDlg.cpp:363 src/amuleDlg.cpp:1799 src/DownloadListCtrl.cpp:740
+#: src/muuli_wdr.cpp:392 src/muuli_wdr.cpp:1585 src/muuli_wdr.cpp:3420
+#: src/Statistics.cpp:829
+msgid "Downloads"
+msgstr "Lejupielādes"
+
+#: src/amuleDlg.cpp:364 src/amuleDlg.cpp:1805 src/muuli_wdr.cpp:3294
+msgid "Shared files"
+msgstr "Kopīgotās datnes"
+
+#: src/amuleDlg.cpp:365 src/amuleDlg.cpp:1811 src/muuli_wdr.cpp:2926
+#: src/muuli_wdr.cpp:3376 src/muuli_wdr.cpp:3423
+msgid "Messages"
+msgstr "Ziņojumi"
+
+#: src/amuleDlg.cpp:366 src/amuleDlg.cpp:1817 src/muuli_wdr.cpp:3424
+#: src/PrefsUnifiedDlg.cpp:312 src/Statistics.cpp:779 src/Statistics.cpp:1235
+msgid "Statistics"
+msgstr "Statistika"
+
+#: src/amuleDlg.cpp:368 src/amuleDlg.cpp:1824 src/muuli_wdr.cpp:3426
+#: src/PrefsUnifiedDlg.cpp:328 src/utils/wxCas/src/wxcasprefs.cpp:39
+msgid "Preferences"
+msgstr "Iestatījumi"
+
+#: src/amuleDlg.cpp:371
+msgid "Navigate"
+msgstr ""
+
+#: src/amuleDlg.cpp:657
 msgid "New version available"
 msgstr "Pieejama jauna versija"
 
-#: src/amuleDlg.cpp:596
+#: src/amuleDlg.cpp:661
 #, c-format
 msgid ""
 "A new version of aMule (%s) is available.\n"
@@ -587,217 +625,184 @@ msgstr ""
 "\n"
 "Vai vēlaties atvērt lejupielādes lapu?"
 
-#: src/amuleDlg.cpp:678
+#: src/amuleDlg.cpp:743
 msgid "aMule dialog destroyed"
 msgstr ""
 
-#: src/amuleDlg.cpp:701 src/DataToText.cpp:68 src/IPFilter.cpp:547
+#: src/amuleDlg.cpp:766 src/DataToText.cpp:68 src/IPFilter.cpp:547
 msgid "Connecting"
 msgstr "Pieslēdzas"
 
-#: src/amuleDlg.cpp:893
+#: src/amuleDlg.cpp:958
 msgid "eD2k: Connecting"
 msgstr "eD2k: Pieslēdzas"
 
-#: src/amuleDlg.cpp:897
+#: src/amuleDlg.cpp:962
 msgid "eD2k: Disconnected"
 msgstr "eD2k: Atslēgts"
 
-#: src/amuleDlg.cpp:903
+#: src/amuleDlg.cpp:968
 msgid "Kad: Firewalled"
 msgstr "Kad: Aiz ugunsmūra"
 
-#: src/amuleDlg.cpp:907
+#: src/amuleDlg.cpp:972
 msgid "Kad: Connected"
 msgstr "Kad: Pieslēgts"
 
-#: src/amuleDlg.cpp:912
+#: src/amuleDlg.cpp:977
 msgid "Kad: Connecting"
 msgstr "Kad: Pieslēdzas"
 
-#: src/amuleDlg.cpp:916
+#: src/amuleDlg.cpp:981
 msgid "Kad: Off"
 msgstr "Kad: Izslēgts"
 
-#: src/amuleDlg.cpp:964 src/DownloadListCtrl.cpp:505
+#: src/amuleDlg.cpp:1029 src/DownloadListCtrl.cpp:505
 #: src/DownloadListCtrl.cpp:749 src/FriendListCtrl.cpp:180
 #: src/muuli_wdr.cpp:731 src/muuli_wdr.cpp:782 src/muuli_wdr.cpp:846
-#: src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2224 src/muuli_wdr.cpp:2309
-#: src/muuli_wdr.cpp:3057 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
+#: src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2231 src/muuli_wdr.cpp:2316
+#: src/muuli_wdr.cpp:3064 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
 #: src/ServerListCtrl.cpp:606 src/TransferWnd.cpp:378
 #: src/utils/wxCas/src/wxcasprefs.cpp:235
 msgid "Cancel"
 msgstr "Atcelt"
 
-#: src/amuleDlg.cpp:965
+#: src/amuleDlg.cpp:1030
 msgid "Stop the current connection attempts"
 msgstr ""
 
-#: src/amuleDlg.cpp:970 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976
-#: src/muuli_wdr.cpp:2447
+#: src/amuleDlg.cpp:1035 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976
+#: src/muuli_wdr.cpp:2454
 msgid "Disconnect"
 msgstr "Atslēgties"
 
-#: src/amuleDlg.cpp:971
+#: src/amuleDlg.cpp:1036
 msgid "Disconnect from the currently connected networks"
 msgstr "Atslēgties no tīkliem, kuriem pašlaik esiet pieslēdzies"
 
-#: src/amuleDlg.cpp:976 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979
-#: src/muuli_wdr.cpp:2602 src/muuli_wdr.cpp:3054 src/muuli_wdr.cpp:3409
+#: src/amuleDlg.cpp:1041 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979
+#: src/muuli_wdr.cpp:2609 src/muuli_wdr.cpp:3061 src/muuli_wdr.cpp:3416
 msgid "Connect"
 msgstr "Pieslēgties"
 
-#: src/amuleDlg.cpp:977
+#: src/amuleDlg.cpp:1042
 msgid "Connect to the currently enabled networks"
 msgstr "Pieslēgties pašlaik iespējotajiem tīkliem"
 
-#: src/amuleDlg.cpp:1089
+#: src/amuleDlg.cpp:1154
 #, c-format
 msgid "Up: %.1f%s (%.1f) | Down: %.1f%s (%.1f)"
 msgstr "↑Augšup.: %.1f%s (%.1f) | ↓Lejup.: %.1f%s (%.1f)"
 
-#: src/amuleDlg.cpp:1091 src/amuleDlg.cpp:1093 src/amuleDlg.cpp:1097
-#: src/amuleDlg.cpp:1099 src/amuleDlg.cpp:1110 src/amuleDlg.cpp:1112
+#: src/amuleDlg.cpp:1156 src/amuleDlg.cpp:1158 src/amuleDlg.cpp:1162
+#: src/amuleDlg.cpp:1164 src/amuleDlg.cpp:1175 src/amuleDlg.cpp:1177
 #: src/MuleTrayIcon.cpp:796 src/MuleTrayIcon.cpp:799
 msgid " MB/s"
 msgstr " MB/s"
 
-#: src/amuleDlg.cpp:1091 src/amuleDlg.cpp:1093 src/amuleDlg.cpp:1097
-#: src/amuleDlg.cpp:1099 src/amuleDlg.cpp:1110 src/amuleDlg.cpp:1112
+#: src/amuleDlg.cpp:1156 src/amuleDlg.cpp:1158 src/amuleDlg.cpp:1162
+#: src/amuleDlg.cpp:1164 src/amuleDlg.cpp:1175 src/amuleDlg.cpp:1177
 #: src/MuleTrayIcon.cpp:796 src/MuleTrayIcon.cpp:799
 #: src/utils/wxCas/src/wxcasframe.cpp:1041
 msgid " kB/s"
 msgstr " kB/s"
 
-#: src/amuleDlg.cpp:1096
+#: src/amuleDlg.cpp:1161
 #, c-format
 msgid "Up: %.1f%s | Down: %.1f%s"
 msgstr "↑Augšup.: %.1f%s | ↓Lejup.: %.1f%s"
 
-#: src/amuleDlg.cpp:1128
+#: src/amuleDlg.cpp:1193
 #, c-format
 msgid "aMule (%s | Connected)"
 msgstr "aMule (%s | Pieslēgts)"
 
-#: src/amuleDlg.cpp:1130
+#: src/amuleDlg.cpp:1195
 #, c-format
 msgid "aMule (%s | Disconnected)"
 msgstr "aMule (%s | Atslēgts)"
 
-#: src/amuleDlg.cpp:1183
+#: src/amuleDlg.cpp:1248
 #, c-format
 msgid "Do you really want to exit %s?"
 msgstr "Vai tiešām vēlaties aizvērt %s?"
 
-#: src/amuleDlg.cpp:1185
+#: src/amuleDlg.cpp:1250
 msgid "Exit confirmation"
 msgstr ""
 
-#: src/amuleDlg.cpp:1548
+#: src/amuleDlg.cpp:1613
 msgid "Launch Command: "
 msgstr ""
 
-#: src/amuleDlg.cpp:1567 src/muuli_wdr.cpp:1971 src/Preferences.cpp:951
+#: src/amuleDlg.cpp:1632 src/muuli_wdr.cpp:1978 src/Preferences.cpp:952
 msgid "- default -"
 msgstr ""
 
-#: src/amuleDlg.cpp:1595
+#: src/amuleDlg.cpp:1660
 #, c-format
 msgid "Skin directory '%s' does not exist"
 msgstr ""
 
-#: src/amuleDlg.cpp:1598
+#: src/amuleDlg.cpp:1663
 #, c-format
 msgid "WARNING: Unable to open skin file '%s' for read"
 msgstr ""
 
-#: src/amuleDlg.cpp:1722 src/amuleDlg.cpp:1968 src/muuli_wdr.cpp:1485
-#: src/muuli_wdr.cpp:3411
-msgid "Networks"
-msgstr "Tīkli"
-
-#: src/amuleDlg.cpp:1726 src/muuli_wdr.cpp:3411
+#: src/amuleDlg.cpp:1791 src/muuli_wdr.cpp:3418
 msgid "Networks Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1728 src/muuli_wdr.cpp:3412
-msgid "Searches"
-msgstr ""
-
-#: src/amuleDlg.cpp:1732 src/muuli_wdr.cpp:3412
+#: src/amuleDlg.cpp:1797 src/muuli_wdr.cpp:3419
 msgid "Searches Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1734 src/DownloadListCtrl.cpp:740 src/muuli_wdr.cpp:392
-#: src/muuli_wdr.cpp:1578 src/muuli_wdr.cpp:3413 src/Statistics.cpp:829
-msgid "Downloads"
-msgstr "Lejupielādes"
-
-#: src/amuleDlg.cpp:1738 src/muuli_wdr.cpp:3413
+#: src/amuleDlg.cpp:1803 src/muuli_wdr.cpp:3420
 msgid "Downloads Window"
 msgstr "Lejupielādes logs"
 
-#: src/amuleDlg.cpp:1740 src/muuli_wdr.cpp:3287
-msgid "Shared files"
-msgstr "Kopīgotās datnes"
-
-#: src/amuleDlg.cpp:1744 src/muuli_wdr.cpp:3415
+#: src/amuleDlg.cpp:1809 src/muuli_wdr.cpp:3422
 msgid "Shared Files Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1746 src/muuli_wdr.cpp:2919 src/muuli_wdr.cpp:3369
-#: src/muuli_wdr.cpp:3416
-msgid "Messages"
-msgstr "Ziņojumi"
-
-#: src/amuleDlg.cpp:1750 src/muuli_wdr.cpp:3416
+#: src/amuleDlg.cpp:1815 src/muuli_wdr.cpp:3423
 msgid "Messages Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1752 src/muuli_wdr.cpp:3417 src/PrefsUnifiedDlg.cpp:312
-#: src/Statistics.cpp:779 src/Statistics.cpp:1235
-msgid "Statistics"
-msgstr "Statistika"
-
-#: src/amuleDlg.cpp:1756 src/muuli_wdr.cpp:3417
+#: src/amuleDlg.cpp:1821 src/muuli_wdr.cpp:3424
 msgid "Statistics Graph Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1759 src/muuli_wdr.cpp:3419 src/PrefsUnifiedDlg.cpp:328
-#: src/utils/wxCas/src/wxcasprefs.cpp:39
-msgid "Preferences"
-msgstr "Iestatījumi"
-
-#: src/amuleDlg.cpp:1763 src/muuli_wdr.cpp:3419
+#: src/amuleDlg.cpp:1828 src/muuli_wdr.cpp:3426
 msgid "Preferences Settings Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1766 src/muuli_wdr.cpp:3420
+#: src/amuleDlg.cpp:1831 src/muuli_wdr.cpp:3427
 msgid "Import"
 msgstr ""
 
-#: src/amuleDlg.cpp:1770 src/muuli_wdr.cpp:3420
+#: src/amuleDlg.cpp:1835 src/muuli_wdr.cpp:3427
 msgid "The partfile importer tool"
 msgstr ""
 
-#: src/amuleDlg.cpp:1773 src/muuli_wdr.cpp:3421
+#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3428
 #: src/utils/aLinkCreator/src/alcframe.cpp:262
 msgid "About"
 msgstr "Par programmu"
 
-#: src/amuleDlg.cpp:1773 src/muuli_wdr.cpp:3421
+#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3428
 msgid "About/Help"
 msgstr "Par programmu/Palīdzība"
 
-#: src/amuleDlg.cpp:1971
+#: src/amuleDlg.cpp:2036
 msgid "eD2k network"
 msgstr "eD2k tīkls"
 
-#: src/amuleDlg.cpp:1974
+#: src/amuleDlg.cpp:2039
 msgid "Kad network"
 msgstr "Kad tīkls"
 
-#: src/amuleDlg.cpp:1974
+#: src/amuleDlg.cpp:2039
 msgid "No network"
 msgstr ""
 
@@ -1326,19 +1331,19 @@ msgstr ""
 msgid "Very low"
 msgstr ""
 
-#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:743 src/muuli_wdr.cpp:2275
+#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:743 src/muuli_wdr.cpp:2282
 #: src/ServerListCtrl.cpp:263 src/ServerListCtrl.cpp:456
 #: src/SharedFilesCtrl.cpp:145
 msgid "Low"
 msgstr ""
 
-#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:744 src/muuli_wdr.cpp:2276
+#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:744 src/muuli_wdr.cpp:2283
 #: src/ServerListCtrl.cpp:266 src/ServerListCtrl.cpp:457
 #: src/SharedFilesCtrl.cpp:146
 msgid "Normal"
 msgstr ""
 
-#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:745 src/muuli_wdr.cpp:2277
+#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:745 src/muuli_wdr.cpp:2284
 #: src/ServerListCtrl.cpp:269 src/ServerListCtrl.cpp:458
 #: src/SharedFilesCtrl.cpp:147
 msgid "High"
@@ -1430,8 +1435,8 @@ msgstr ""
 msgid "Remote Server"
 msgstr ""
 
-#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3174
-#: src/SearchDlg.cpp:111 src/TextClient.cpp:911
+#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3181
+#: src/SearchDlg.cpp:119 src/TextClient.cpp:911
 msgid "Kad"
 msgstr "Kad"
 
@@ -1501,7 +1506,7 @@ msgstr "Daļa"
 msgid "Size"
 msgstr "Izmērs"
 
-#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3241
+#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3248
 msgid "Transferred"
 msgstr "Pārsūtīti"
 
@@ -1557,7 +1562,7 @@ msgid ""
 "\n"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:746 src/muuli_wdr.cpp:2278
+#: src/DownloadListCtrl.cpp:746 src/muuli_wdr.cpp:2285
 #: src/SharedFilesCtrl.cpp:150
 msgid "Auto"
 msgstr ""
@@ -1595,7 +1600,7 @@ msgid "Extended Options"
 msgstr ""
 
 #: src/DownloadListCtrl.cpp:770 src/DownloadListCtrl.cpp:822
-#: src/muuli_wdr.cpp:1789
+#: src/muuli_wdr.cpp:1796
 msgid "Preview"
 msgstr "Priekšskatījums"
 
@@ -2276,19 +2281,19 @@ msgstr ""
 msgid "eD2k"
 msgstr "eD2k"
 
-#: src/FirstRunWizard.cpp:349 src/muuli_wdr.cpp:1488
+#: src/FirstRunWizard.cpp:349 src/muuli_wdr.cpp:1495
 msgid "Kademlia"
 msgstr "Kademlia"
 
-#: src/FirstRunWizard.cpp:359 src/muuli_wdr.cpp:1416
+#: src/FirstRunWizard.cpp:359 src/muuli_wdr.cpp:1423
 msgid "Standard TCP Port "
 msgstr ""
 
-#: src/FirstRunWizard.cpp:365 src/muuli_wdr.cpp:1428
+#: src/FirstRunWizard.cpp:365 src/muuli_wdr.cpp:1435
 msgid "Extended UDP port (Kad / global search) "
 msgstr ""
 
-#: src/FirstRunWizard.cpp:377 src/muuli_wdr.cpp:1435
+#: src/FirstRunWizard.cpp:377 src/muuli_wdr.cpp:1442
 msgid "Enable UPnP for router port forwarding"
 msgstr "Iespējot UPnP maršrutētāja portu pāradresāciju"
 
@@ -2313,7 +2318,7 @@ msgstr ""
 msgid "Your peer lists are already in place - nothing to download."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:434 src/muuli_wdr.cpp:1533
+#: src/FirstRunWizard.cpp:434 src/muuli_wdr.cpp:1540
 msgid "Auto-update server list at startup"
 msgstr "Kad palaiž, automātiski atjaunināt serveru sarakstu"
 
@@ -2359,23 +2364,23 @@ msgid ""
 "want downloads on a different (e.g. larger) disk."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:549 src/FirstRunWizard.cpp:611 src/muuli_wdr.cpp:1701
+#: src/FirstRunWizard.cpp:549 src/FirstRunWizard.cpp:611 src/muuli_wdr.cpp:1708
 msgid "Destination folder for downloads"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:553 src/FirstRunWizard.cpp:569 src/muuli_wdr.cpp:1342
-#: src/muuli_wdr.cpp:1359 src/muuli_wdr.cpp:1676 src/muuli_wdr.cpp:1707
-#: src/muuli_wdr.cpp:1719 src/muuli_wdr.cpp:2762
+#: src/FirstRunWizard.cpp:553 src/FirstRunWizard.cpp:569 src/muuli_wdr.cpp:1349
+#: src/muuli_wdr.cpp:1366 src/muuli_wdr.cpp:1683 src/muuli_wdr.cpp:1714
+#: src/muuli_wdr.cpp:1726 src/muuli_wdr.cpp:2769
 #: src/utils/aLinkCreator/src/alcframe.cpp:135
 #: src/utils/wxCas/src/wxcasprefs.cpp:52 src/utils/wxCas/src/wxcasprefs.cpp:118
 msgid "Browse"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:559 src/muuli_wdr.cpp:1712
+#: src/FirstRunWizard.cpp:559 src/muuli_wdr.cpp:1719
 msgid "(All files in this folder are shared with other peers)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:565 src/FirstRunWizard.cpp:624 src/muuli_wdr.cpp:1714
+#: src/FirstRunWizard.cpp:565 src/FirstRunWizard.cpp:624 src/muuli_wdr.cpp:1721
 msgid "Folder for temporary download files"
 msgstr ""
 
@@ -2406,7 +2411,7 @@ msgstr ""
 msgid "CRITICAL - no client on StartChatSession"
 msgstr ""
 
-#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2668 src/muuli_wdr.cpp:3345
+#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2675 src/muuli_wdr.cpp:3352
 msgid "Friends"
 msgstr "Draugi"
 
@@ -2785,7 +2790,7 @@ msgstr ""
 msgid "Uploaded"
 msgstr "Augšupielādēts"
 
-#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3225
+#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3232
 msgid "Requested"
 msgstr ""
 
@@ -2908,7 +2913,7 @@ msgid "WARNING: "
 msgstr "BRĪDINĀJUMS: "
 
 #: src/MuleNotebook.cpp:179 src/muuli_wdr.cpp:817 src/muuli_wdr.cpp:1229
-#: src/muuli_wdr.cpp:3129 src/muuli_wdr.cpp:3385
+#: src/muuli_wdr.cpp:3136 src/muuli_wdr.cpp:3392
 msgid "Close"
 msgstr "Aizvērt"
 
@@ -2921,12 +2926,12 @@ msgstr "Izgriezt"
 msgid "Copy"
 msgstr "Kopēt"
 
-#: src/MuleTextCtrl.cpp:88
+#: src/MuleTextCtrl.cpp:88 src/SearchDlg.cpp:261
 msgid "Paste"
 msgstr "Ielīmēt"
 
 #: src/MuleTextCtrl.cpp:89 src/muuli_wdr.cpp:358 src/muuli_wdr.cpp:757
-#: src/muuli_wdr.cpp:2352 src/muuli_wdr.cpp:2371 src/muuli_wdr.cpp:2393
+#: src/muuli_wdr.cpp:2359 src/muuli_wdr.cpp:2378 src/muuli_wdr.cpp:2400
 #: src/utils/aLinkCreator/src/alcframe.cpp:142
 msgid "Clear"
 msgstr "Notīrīt"
@@ -3017,8 +3022,8 @@ msgid "Exit"
 msgstr "Iziet"
 
 #: src/MuleTrayIcon.cpp:579 src/MuleTrayIcon.cpp:945 src/MuleTrayIcon.cpp:965
-#: src/muuli_wdr.cpp:1391 src/muuli_wdr.cpp:1399 src/muuli_wdr.cpp:1406
-#: src/muuli_wdr.cpp:1835 src/muuli_wdr.cpp:1841 src/OtherFunctions.cpp:91
+#: src/muuli_wdr.cpp:1398 src/muuli_wdr.cpp:1406 src/muuli_wdr.cpp:1413
+#: src/muuli_wdr.cpp:1842 src/muuli_wdr.cpp:1848 src/OtherFunctions.cpp:91
 #: src/StatisticsDlg.cpp:93 src/StatisticsDlg.cpp:95
 msgid "kB/s"
 msgstr "kB/s"
@@ -3187,7 +3192,7 @@ msgstr "Nosaukums:"
 msgid "Type"
 msgstr ""
 
-#: src/muuli_wdr.cpp:215 src/SearchDlg.cpp:110 src/SearchListCtrl.cpp:853
+#: src/muuli_wdr.cpp:215 src/SearchDlg.cpp:118 src/SearchListCtrl.cpp:853
 msgid "Local"
 msgstr ""
 
@@ -3258,7 +3263,7 @@ msgstr "Baiti"
 msgid "KB"
 msgstr ""
 
-#: src/muuli_wdr.cpp:274 src/muuli_wdr.cpp:293 src/muuli_wdr.cpp:1620
+#: src/muuli_wdr.cpp:274 src/muuli_wdr.cpp:293 src/muuli_wdr.cpp:1627
 #: src/OtherFunctions.cpp:64
 msgid "MB"
 msgstr ""
@@ -3275,7 +3280,7 @@ msgstr "Maksimālais izmērs"
 msgid "Availability"
 msgstr "Pieejamība"
 
-#: src/muuli_wdr.cpp:312 src/muuli_wdr.cpp:398 src/muuli_wdr.cpp:3290
+#: src/muuli_wdr.cpp:312 src/muuli_wdr.cpp:398 src/muuli_wdr.cpp:3297
 msgid "Filter:"
 msgstr ""
 
@@ -3307,7 +3312,7 @@ msgstr ""
 msgid "Stop"
 msgstr "Apturēt"
 
-#: src/muuli_wdr.cpp:348 src/muuli_wdr.cpp:1385 src/SearchListCtrl.cpp:732
+#: src/muuli_wdr.cpp:348 src/muuli_wdr.cpp:1392 src/SearchListCtrl.cpp:732
 msgid "Download"
 msgstr ""
 
@@ -3338,8 +3343,8 @@ msgstr ""
 #: src/muuli_wdr.cpp:1160 src/muuli_wdr.cpp:1167 src/muuli_wdr.cpp:1172
 #: src/muuli_wdr.cpp:1179 src/muuli_wdr.cpp:1184 src/muuli_wdr.cpp:1191
 #: src/muuli_wdr.cpp:1205 src/muuli_wdr.cpp:1212 src/muuli_wdr.cpp:1217
-#: src/muuli_wdr.cpp:1224 src/muuli_wdr.cpp:3227 src/muuli_wdr.cpp:3235
-#: src/muuli_wdr.cpp:3243
+#: src/muuli_wdr.cpp:1224 src/muuli_wdr.cpp:3234 src/muuli_wdr.cpp:3242
+#: src/muuli_wdr.cpp:3250
 msgid "N/A"
 msgstr ""
 
@@ -3481,7 +3486,7 @@ msgstr "Izpildītājs :"
 msgid "Album :"
 msgstr "Albums :"
 
-#: src/muuli_wdr.cpp:685 src/muuli_wdr.cpp:2247
+#: src/muuli_wdr.cpp:685 src/muuli_wdr.cpp:2254
 msgid "Title :"
 msgstr "Nosaukums :"
 
@@ -3588,7 +3593,7 @@ msgstr "Lietotājvārds :"
 msgid "Userhash :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:895 src/muuli_wdr.cpp:1741 src/muuli_wdr.cpp:2442
+#: src/muuli_wdr.cpp:895 src/muuli_wdr.cpp:1748 src/muuli_wdr.cpp:2449
 #: src/utils/aLinkCreator/src/alcframe.cpp:137
 msgid "Add"
 msgstr "Pievienot"
@@ -3597,15 +3602,15 @@ msgstr "Pievienot"
 msgid "Download-Speed"
 msgstr "Lejupielādes ātrums"
 
-#: src/muuli_wdr.cpp:954 src/muuli_wdr.cpp:989 src/muuli_wdr.cpp:2546
+#: src/muuli_wdr.cpp:954 src/muuli_wdr.cpp:989 src/muuli_wdr.cpp:2553
 msgid "Current"
 msgstr "Pašreizējais"
 
-#: src/muuli_wdr.cpp:962 src/muuli_wdr.cpp:997 src/muuli_wdr.cpp:2554
+#: src/muuli_wdr.cpp:962 src/muuli_wdr.cpp:997 src/muuli_wdr.cpp:2561
 msgid "Running average"
 msgstr "Visu laiku vidējais"
 
-#: src/muuli_wdr.cpp:970 src/muuli_wdr.cpp:1005 src/muuli_wdr.cpp:2562
+#: src/muuli_wdr.cpp:970 src/muuli_wdr.cpp:1005 src/muuli_wdr.cpp:2569
 msgid "Session average"
 msgstr "Sesijas vidējais"
 
@@ -3617,7 +3622,7 @@ msgstr "Augšupielādes ātrums"
 msgid "Connections"
 msgstr "Savienojumi"
 
-#: src/muuli_wdr.cpp:1024 src/muuli_wdr.cpp:1860
+#: src/muuli_wdr.cpp:1024 src/muuli_wdr.cpp:1867
 msgid "Active downloads"
 msgstr "Aktīvas lejupielādes"
 
@@ -3625,7 +3630,7 @@ msgstr "Aktīvas lejupielādes"
 msgid "Active connections (1:1)"
 msgstr "Aktīvi savienojumi (1:1)"
 
-#: src/muuli_wdr.cpp:1040 src/muuli_wdr.cpp:1861
+#: src/muuli_wdr.cpp:1040 src/muuli_wdr.cpp:1868
 msgid "Active uploads"
 msgstr "Aktīvas augšupielādes"
 
@@ -3741,8 +3746,8 @@ msgstr "Vārds, kas tiks rādīts lietotājiem, kad pieslēdzas jums."
 msgid "Language: "
 msgstr "Valoda: "
 
-#: src/muuli_wdr.cpp:1257 src/muuli_wdr.cpp:1323 src/muuli_wdr.cpp:1327
-#: src/muuli_wdr.cpp:1330
+#: src/muuli_wdr.cpp:1257 src/muuli_wdr.cpp:1330 src/muuli_wdr.cpp:1334
+#: src/muuli_wdr.cpp:1337
 msgid "The delay before showing tool-tips."
 msgstr ""
 
@@ -3819,927 +3824,935 @@ msgstr ""
 msgid "Enabling this will make aMule to show notifications when finished downloading."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1322
-msgid "Tooltip delay time: "
+#: src/muuli_wdr.cpp:1323
+msgid "Remember search history"
+msgstr ""
+
+#: src/muuli_wdr.cpp:1324
+msgid "Keeps a dropdown list of your past search terms in the Search tab's Name field. This remembers the queries you typed, not the results they returned."
 msgstr ""
 
 #: src/muuli_wdr.cpp:1329
+msgid "Tooltip delay time: "
+msgstr ""
+
+#: src/muuli_wdr.cpp:1336
 msgid "seconds"
 msgstr "sekundes"
 
-#: src/muuli_wdr.cpp:1333
+#: src/muuli_wdr.cpp:1340
 msgid "Browser Selection"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1339
+#: src/muuli_wdr.cpp:1346
 msgid "Enter your browser name here. Leave this field empty to use the system default browser."
 msgstr "Ievadiet šeit sava pārlūka nosaukumu. Atstājiet šo lauku tukšu, ja vēlaties izmantot sistēmas noklusējuma pārlūku."
 
-#: src/muuli_wdr.cpp:1346
+#: src/muuli_wdr.cpp:1353
 msgid "Open in new tab if possible"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1348
+#: src/muuli_wdr.cpp:1355
 msgid "Open the web page in a new tab instead of in a new window when possible"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1352
+#: src/muuli_wdr.cpp:1359
 msgid "Video Player"
 msgstr "Video atskaņotājs"
 
-#: src/muuli_wdr.cpp:1379
+#: src/muuli_wdr.cpp:1386
 msgid "Bandwidth limits"
 msgstr "Datu pārraides ierobežojumi"
 
-#: src/muuli_wdr.cpp:1393
+#: src/muuli_wdr.cpp:1400
 msgid "Upload"
 msgstr "Augšupielādes (Izejošais)"
 
-#: src/muuli_wdr.cpp:1401
+#: src/muuli_wdr.cpp:1408
 msgid "Slot Allocation"
 msgstr "Katram klientam (vienam savienojumam) izdalītais spraugas"
 
-#: src/muuli_wdr.cpp:1410
+#: src/muuli_wdr.cpp:1417
 msgid "Ports"
 msgstr "Porti"
 
-#: src/muuli_wdr.cpp:1420
+#: src/muuli_wdr.cpp:1427
 msgid "This is the standard eD2k port and cannot be disabled."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1423
+#: src/muuli_wdr.cpp:1430
 msgid "UDP port for server requests (TCP+3):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1425
+#: src/muuli_wdr.cpp:1432
 msgid "4665"
 msgstr "4665"
 
-#: src/muuli_wdr.cpp:1432
+#: src/muuli_wdr.cpp:1439
 msgid "This UDP port is used for extended eD2k requests and Kad network"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1439
+#: src/muuli_wdr.cpp:1446
 msgid "UPnP TCP Port (Optional):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1449
+#: src/muuli_wdr.cpp:1456
 msgid "Bind local address to IP (empty for any):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1452
+#: src/muuli_wdr.cpp:1459
 msgid "Advanced users only: If you have multiple network interfaces, enter the address of the interface to which aMule should be bound."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1455 src/muuli_wdr.cpp:2054
+#: src/muuli_wdr.cpp:1462 src/muuli_wdr.cpp:2061
 msgid "Bind to network interface (empty for any):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1468
+#: src/muuli_wdr.cpp:1475
 msgid "Advanced users only: pin all of aMule's traffic to one network interface, chosen from the list or typed in by name (e.g. tun0, eth0, en0) or index. Unlike binding to an IP, this stops traffic leaking out via the default route - useful with a VPN. Requires no elevated privileges."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1474
+#: src/muuli_wdr.cpp:1481
 msgid "Max sources per downloading file:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1478
+#: src/muuli_wdr.cpp:1485
 msgid "Max simultaneous connections:"
 msgstr "Maksimālais vienlaicīgo savienojumu skaits:"
 
-#: src/muuli_wdr.cpp:1491 src/muuli_wdr.cpp:3169
+#: src/muuli_wdr.cpp:1498 src/muuli_wdr.cpp:3176
 msgid "ED2K"
 msgstr "ED2K"
 
-#: src/muuli_wdr.cpp:1498
+#: src/muuli_wdr.cpp:1505
 msgid "Autoconnect on startup"
 msgstr "Kad palaiž, automātiski pieslēgties"
 
-#: src/muuli_wdr.cpp:1501
+#: src/muuli_wdr.cpp:1508
 msgid "Reconnect on loss"
 msgstr "Atkārtoti pieslēgties, kad zaudēts savienojums"
 
-#: src/muuli_wdr.cpp:1523
+#: src/muuli_wdr.cpp:1530
 msgid "Remove dead server after"
 msgstr "Noņemt mirušo serveri pēc"
 
-#: src/muuli_wdr.cpp:1524
+#: src/muuli_wdr.cpp:1531
 msgid "Static servers are never removed, even when unreachable."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1528
+#: src/muuli_wdr.cpp:1535
 msgid "retries"
 msgstr "mēģinājumiem"
 
-#: src/muuli_wdr.cpp:1536
+#: src/muuli_wdr.cpp:1543
 msgid "List"
 msgstr "Saraksts"
 
-#: src/muuli_wdr.cpp:1539
+#: src/muuli_wdr.cpp:1546
 msgid "Update server list when connecting to a server"
 msgstr "Atjaunināt serveru sarakstu, kad pieslēdzas serverim"
 
-#: src/muuli_wdr.cpp:1542
+#: src/muuli_wdr.cpp:1549
 msgid "Update server list when a client connects"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1545
+#: src/muuli_wdr.cpp:1552
 msgid "Use priority system"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1549
+#: src/muuli_wdr.cpp:1556
 msgid "Use smart LowID check on connect"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1553
+#: src/muuli_wdr.cpp:1560
 msgid "Safe connect"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1557
+#: src/muuli_wdr.cpp:1564
 msgid "Autoconnect to servers in static list only"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1560
+#: src/muuli_wdr.cpp:1567
 msgid "Set manually added servers to High Priority"
 msgstr "Iestatīt pašrocīgi pievienotos serverus kā augstas prioritātes"
 
-#: src/muuli_wdr.cpp:1581
+#: src/muuli_wdr.cpp:1588
 msgid "Add files to download in pause mode"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1583
+#: src/muuli_wdr.cpp:1590
 msgid "Add files to download with auto priority"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1586
+#: src/muuli_wdr.cpp:1593
 msgid "Try to download first and last chunks first"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1590
+#: src/muuli_wdr.cpp:1597
 msgid "Endgame mode: rotate to faster sources for the final blocks"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1593
+#: src/muuli_wdr.cpp:1600
 msgid "Start next paused file when a file completes"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1596
+#: src/muuli_wdr.cpp:1603
 msgid "From the same category"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1598
+#: src/muuli_wdr.cpp:1605
 msgid "In alphabetic order"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1600
+#: src/muuli_wdr.cpp:1607
 msgid "Preallocate disk space for new files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1601
+#: src/muuli_wdr.cpp:1608
 msgid "For new files preallocates disk space for the whole file, thus reduces fragmentation"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1606
+#: src/muuli_wdr.cpp:1613
 msgid "Create new files as sparse files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1607
+#: src/muuli_wdr.cpp:1614
 msgid "A sparse file reserves its full size on disk immediately without writing real data to it -- fast, but unsupported or slow on some filesystems, and free-space accounting stays optimistic while the download is in progress. Turn this off to grow the file only as data arrives."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1612
+#: src/muuli_wdr.cpp:1619
 msgid "Stop downloads when free disk space reaches "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1613
+#: src/muuli_wdr.cpp:1620
 msgid "Select this if you want aMule to check your disk space"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1617
+#: src/muuli_wdr.cpp:1624
 msgid "Enter here the min disk space desired."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1623
+#: src/muuli_wdr.cpp:1630
 msgid "Save 10 sources on rare files (< 20 sources)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1627 src/Statistics.cpp:790
+#: src/muuli_wdr.cpp:1634 src/Statistics.cpp:790
 msgid "Uploads"
 msgstr "Augšupielādes"
 
-#: src/muuli_wdr.cpp:1630
+#: src/muuli_wdr.cpp:1637
 msgid "Add new shared files with auto priority"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1636
+#: src/muuli_wdr.cpp:1643
 msgid "Intelligent Corruption Handling (I.C.H.)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1639
+#: src/muuli_wdr.cpp:1646
 msgid "Enable"
 msgstr "Iespējot"
 
-#: src/muuli_wdr.cpp:1642
+#: src/muuli_wdr.cpp:1649
 msgid "Advanced I.C.H. trusts every hash (not recommended)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1654 src/PrefsUnifiedDlg.cpp:1910
+#: src/muuli_wdr.cpp:1661 src/PrefsUnifiedDlg.cpp:1910
 msgid "Media metadata extraction"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1658
+#: src/muuli_wdr.cpp:1665
 msgid "Extract length / bitrate / codec from shared audio and video files"
 msgstr "Iegūt garuma / bitu pārraides ātruma / kodeka infomāciju no kopīgotajām audio un video datnēm"
 
-#: src/muuli_wdr.cpp:1660
+#: src/muuli_wdr.cpp:1667
 msgid "When enabled, aMule runs ffprobe on each shared media file to fill in the Length / Bitrate / Codec columns other clients see when they find the file in a search. Requires ffmpeg (the ffprobe binary) to be installed."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1667
+#: src/muuli_wdr.cpp:1674
 msgid "Path to ffprobe:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1672
+#: src/muuli_wdr.cpp:1679
 msgid "Full path to the ffprobe binary. Leave empty to have aMule auto-detect it on startup."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1680
+#: src/muuli_wdr.cpp:1687
 msgid "Detect"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1681
+#: src/muuli_wdr.cpp:1688
 msgid "Search the standard install locations for an ffprobe binary and fill the path field."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1705
+#: src/muuli_wdr.cpp:1712
 msgid ""
 "Completed downloads are stored here. All files in this folder are automatically shared with other peers.\n"
 "If this folder also holds files you don't want to share, point it at an aMule-only sub-folder."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1708
+#: src/muuli_wdr.cpp:1715
 msgid "Pick the folder where completed downloads will be stored. All files in that folder will be shared with other peers."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1722
+#: src/muuli_wdr.cpp:1729
 msgid "Shared folders"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1728
+#: src/muuli_wdr.cpp:1735
 msgid "(Folders shared by the core. Enter a path to add one.)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1736
+#: src/muuli_wdr.cpp:1743
 msgid "Absolute path of a folder on the core's machine, e.g. /home/user/shared"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1738 src/PrefsUnifiedDlg.cpp:2794
+#: src/muuli_wdr.cpp:1745 src/PrefsUnifiedDlg.cpp:2794
 msgid "Recursive"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1739
+#: src/muuli_wdr.cpp:1746
 msgid "Share every sub-folder underneath this one, including ones created later."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1743 src/utils/aLinkCreator/src/alcframe.cpp:141
+#: src/muuli_wdr.cpp:1750 src/utils/aLinkCreator/src/alcframe.cpp:141
 msgid "Remove"
 msgstr "Noņemt"
 
-#: src/muuli_wdr.cpp:1747
+#: src/muuli_wdr.cpp:1754
 msgid "(Right click on folder icon for recursive share)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1754
+#: src/muuli_wdr.cpp:1761
 msgid "Share hidden files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1760
+#: src/muuli_wdr.cpp:1767
 msgid "Automatically rescan shared folders for changes"
 msgstr "Automātiski uzraudzīt kopīgoto mapju izmaiņas"
 
-#: src/muuli_wdr.cpp:1766
+#: src/muuli_wdr.cpp:1773
 msgid "Follow symbolic links in shared folders"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1772
+#: src/muuli_wdr.cpp:1779
 msgid "Exclude files matching:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1775
+#: src/muuli_wdr.cpp:1782
 msgid "Wildcard patterns separated by '|', e.g. .DS_Store|Thumbs.db|*.tmp. Files whose name matches are not shared. Matching is case-insensitive."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1779
+#: src/muuli_wdr.cpp:1786
 msgid "Patterns are regular expressions"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1780
+#: src/muuli_wdr.cpp:1787
 msgid "When set, the whole field is one regular expression ('|' is alternation). When unset, it is a list of '|'-separated wildcards."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1790
+#: src/muuli_wdr.cpp:1797
 msgid "Show how many shared files the current pattern would exclude."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1811
+#: src/muuli_wdr.cpp:1818
 msgid "Graphs"
 msgstr "Grafiki"
 
-#: src/muuli_wdr.cpp:1814 src/muuli_wdr.cpp:1876
+#: src/muuli_wdr.cpp:1821 src/muuli_wdr.cpp:1883
 msgid "Update delay : 5 secs"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1818
+#: src/muuli_wdr.cpp:1825
 msgid "Time for average graph: 100 mins"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1822
+#: src/muuli_wdr.cpp:1829
 msgid "Connections Graph Scale: 100 "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1829
+#: src/muuli_wdr.cpp:1836
 msgid "Download graph scale:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1837
+#: src/muuli_wdr.cpp:1844
 msgid "Upload graph scale:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1847
+#: src/muuli_wdr.cpp:1854
 msgid "Colors: "
 msgstr "Krāsas: "
 
-#: src/muuli_wdr.cpp:1851
+#: src/muuli_wdr.cpp:1858
 msgid "Background"
 msgstr "Fons"
 
-#: src/muuli_wdr.cpp:1852
+#: src/muuli_wdr.cpp:1859
 msgid "Grid"
 msgstr "Režģis"
 
-#: src/muuli_wdr.cpp:1853
+#: src/muuli_wdr.cpp:1860
 msgid "Download current"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1854
+#: src/muuli_wdr.cpp:1861
 msgid "Download running average"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1855
+#: src/muuli_wdr.cpp:1862
 msgid "Download session average"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1856
+#: src/muuli_wdr.cpp:1863
 msgid "Upload current"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1857
+#: src/muuli_wdr.cpp:1864
 msgid "Upload running average"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1858
+#: src/muuli_wdr.cpp:1865
 msgid "Upload session average"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1859
+#: src/muuli_wdr.cpp:1866
 msgid "Active connections"
 msgstr "Aktīvi savienojumi"
 
-#: src/muuli_wdr.cpp:1862
+#: src/muuli_wdr.cpp:1869
 msgid "Systray Icon Speed Bar"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1863
+#: src/muuli_wdr.cpp:1870
 msgid "Kad-nodes current"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1864
+#: src/muuli_wdr.cpp:1871
 msgid "Kad-nodes running"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1865
+#: src/muuli_wdr.cpp:1872
 msgid "Kad-nodes session"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1869 src/muuli_wdr.cpp:2296
+#: src/muuli_wdr.cpp:1876 src/muuli_wdr.cpp:2303
 msgid "Select"
 msgstr "Atlasīt"
 
-#: src/muuli_wdr.cpp:1873
+#: src/muuli_wdr.cpp:1880
 msgid "Tree"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1883
+#: src/muuli_wdr.cpp:1890
 msgid "Number of Client Versions shown (0=unlimited)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1908
+#: src/muuli_wdr.cpp:1915
 msgid "!!! WARNING !!!"
 msgstr "!!! BRĪDINĀJUMS !!!"
 
-#: src/muuli_wdr.cpp:1923
+#: src/muuli_wdr.cpp:1930
 msgid "Max new connections / 5 secs"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1925
+#: src/muuli_wdr.cpp:1932
 msgid "Concurrent Kad source lookups"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1927
+#: src/muuli_wdr.cpp:1934
 msgid "Kad source re-search interval (minutes)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1929
+#: src/muuli_wdr.cpp:1936
 msgid "Source re-ask interval (minutes)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1933
+#: src/muuli_wdr.cpp:1940
 msgid "File Buffer Size: 240000 bytes"
 msgstr "Datnes bufera izmērs: 240000 baiti"
 
-#: src/muuli_wdr.cpp:1937
+#: src/muuli_wdr.cpp:1944
 msgid "Use MMAP: memory-mapped file access (lower memory use)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1938
+#: src/muuli_wdr.cpp:1945
 msgid "Maps part files into memory instead of buffering them on the heap, lowering the process memory footprint. May reduce download speed on some disks; best for memory-constrained or upload-heavy hosts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1940
+#: src/muuli_wdr.cpp:1947
 msgid "Upload Queue Size: 5000 clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1944
+#: src/muuli_wdr.cpp:1951
 msgid "Server connection refresh interval: Disable"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1948
+#: src/muuli_wdr.cpp:1955
 msgid "Disable computer's timed standby mode"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1967
+#: src/muuli_wdr.cpp:1974
 msgid "Skin to use: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1976
+#: src/muuli_wdr.cpp:1983
 msgid "Show \"Fast eD2k Links Handler\" in every window."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1979
+#: src/muuli_wdr.cpp:1986
 msgid "Show extended info on categories tabs"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1982
+#: src/muuli_wdr.cpp:1989
 msgid "Show application version on title"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1984
+#: src/muuli_wdr.cpp:1991
 msgid "Show transfer rates on title"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1986
+#: src/muuli_wdr.cpp:1993
 msgid "Before application name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1988
+#: src/muuli_wdr.cpp:1995
 msgid "After application name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1991
+#: src/muuli_wdr.cpp:1998
 msgid "Show overhead bandwidth"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1995
+#: src/muuli_wdr.cpp:2002
 msgid "Vertical toolbar orientation"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1997
+#: src/muuli_wdr.cpp:2004
 msgid "Live column sorting (auto-reorder rows as their values change)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2004
+#: src/muuli_wdr.cpp:2011
 msgid "Download Queue Files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2007
+#: src/muuli_wdr.cpp:2014
 msgid "Show progress percentage"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2013
+#: src/muuli_wdr.cpp:2020
 msgid "Show progress bar"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2016
+#: src/muuli_wdr.cpp:2023
 msgid "Flat"
 msgstr "Plakana"
 
-#: src/muuli_wdr.cpp:2020
+#: src/muuli_wdr.cpp:2027
 msgid "Round"
 msgstr "Apaļa"
 
-#: src/muuli_wdr.cpp:2038
+#: src/muuli_wdr.cpp:2045
 msgid "External Connection Parameters"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2041
+#: src/muuli_wdr.cpp:2048
 msgid "Accept external connections"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2048 src/muuli_wdr.cpp:2107
+#: src/muuli_wdr.cpp:2055 src/muuli_wdr.cpp:2114
 msgid "IP of the listening interface:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2051
+#: src/muuli_wdr.cpp:2058
 msgid "Enter here a valid ip in the a.b.c.d format for the listening EC interface. An empty field or 0.0.0.0 will mean any interface."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2072 src/muuli_wdr.cpp:2156
+#: src/muuli_wdr.cpp:2079 src/muuli_wdr.cpp:2163
 msgid "TCP port:"
 msgstr "TCP ports:"
 
-#: src/muuli_wdr.cpp:2078
+#: src/muuli_wdr.cpp:2085
 msgid "Enable UPnP port forwarding on the EC port"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2082 src/muuli_wdr.cpp:3041
+#: src/muuli_wdr.cpp:2089 src/muuli_wdr.cpp:3048
 #: src/utils/wxCas/src/wxcasprefs.cpp:167
 msgid "Password"
 msgstr "Parole"
 
-#: src/muuli_wdr.cpp:2088
+#: src/muuli_wdr.cpp:2095
 msgid "aMule API server parameters"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2091
+#: src/muuli_wdr.cpp:2098
 msgid "Run amuleapi (REST API) on startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2096
+#: src/muuli_wdr.cpp:2103
 #, fuzzy
 msgid "HTTP port:"
 msgstr "TCP ports:"
 
-#: src/muuli_wdr.cpp:2110
+#: src/muuli_wdr.cpp:2117
 msgid "The interface amuleapi's HTTP server listens on. 127.0.0.1 (default) accepts only local connections; use 0.0.0.0 or a specific IP to expose it to other hosts (set an admin password below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2113
+#: src/muuli_wdr.cpp:2120
 #, fuzzy
 msgid "Admin password"
 msgstr "Parole"
 
-#: src/muuli_wdr.cpp:2118 src/muuli_wdr.cpp:2149
+#: src/muuli_wdr.cpp:2125 src/muuli_wdr.cpp:2156
 msgid "Low rights password"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2126
+#: src/muuli_wdr.cpp:2133
 msgid "Web server parameters"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2129
+#: src/muuli_wdr.cpp:2136
 #, fuzzy
 msgid "Run webserver on startup (deprecated)"
 msgstr "Kad palaiž, palaist arī tīmekļa serveri"
 
-#: src/muuli_wdr.cpp:2135
+#: src/muuli_wdr.cpp:2142
 msgid "Web template"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2140
+#: src/muuli_wdr.cpp:2147
 msgid "Full rights password"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2144
+#: src/muuli_wdr.cpp:2151
 msgid "Enable Low rights User"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2163
+#: src/muuli_wdr.cpp:2170
 msgid "Enable UPnP port forwarding of the web server port"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2168
+#: src/muuli_wdr.cpp:2175
 msgid "Web server UPnP TCP port (Optional)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2176
+#: src/muuli_wdr.cpp:2183
 msgid "Page Refresh Time (in secs)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2183
+#: src/muuli_wdr.cpp:2190
 msgid "Enable Gzip compression"
 msgstr "Iespējot Gzip saspiešanu"
 
-#: src/muuli_wdr.cpp:2217
+#: src/muuli_wdr.cpp:2224
 #, fuzzy
 msgid "Reset page to defaults"
 msgstr "Sistēmas"
 
-#: src/muuli_wdr.cpp:2218
+#: src/muuli_wdr.cpp:2225
 msgid "Reset the settings on the current page to their default values."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2220 src/muuli_wdr.cpp:2306 src/ServerWnd.cpp:274
+#: src/muuli_wdr.cpp:2227 src/muuli_wdr.cpp:2313 src/ServerWnd.cpp:274
 #: src/ServerWnd.cpp:282
 msgid "OK"
 msgstr "Labi"
 
-#: src/muuli_wdr.cpp:2222
+#: src/muuli_wdr.cpp:2229
 msgid "Click here to apply any changes made to the preferences."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2225
+#: src/muuli_wdr.cpp:2232
 msgid "Reset any changes made to the preferences."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2254
+#: src/muuli_wdr.cpp:2261
 msgid "Comment :"
 msgstr "Komentārs :"
 
-#: src/muuli_wdr.cpp:2261
+#: src/muuli_wdr.cpp:2268
 msgid "Incoming Dir :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2270
+#: src/muuli_wdr.cpp:2277
 msgid "Change priority for new assigned files :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2274
+#: src/muuli_wdr.cpp:2281
 msgid "Don't change"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2286
+#: src/muuli_wdr.cpp:2293
 msgid "Select color for this Category (currently selected) :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2353 src/muuli_wdr.cpp:2372 src/muuli_wdr.cpp:2394
+#: src/muuli_wdr.cpp:2360 src/muuli_wdr.cpp:2379 src/muuli_wdr.cpp:2401
 msgid "Click this button to reset the log."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2413
+#: src/muuli_wdr.cpp:2420
 msgid "Click on this button to update the servers list from URL ..."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2417
+#: src/muuli_wdr.cpp:2424
 msgid "Server list"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2421
+#: src/muuli_wdr.cpp:2428
 msgid "Enter the url to a server.met file here and press the button to the left to update the list of known servers."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2426
+#: src/muuli_wdr.cpp:2433
 msgid "Add server manually: Name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2429
+#: src/muuli_wdr.cpp:2436
 msgid "Enter the name of the new server here"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2431 src/ServerWnd.cpp:206
+#: src/muuli_wdr.cpp:2438 src/ServerWnd.cpp:206
 msgid "IP:Port"
 msgstr "IP:Ports"
 
-#: src/muuli_wdr.cpp:2434
+#: src/muuli_wdr.cpp:2441
 msgid "Enter the IP of the server here, using the x.x.x.x format."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2440
+#: src/muuli_wdr.cpp:2447
 msgid "Enter the port of the server here."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2443
+#: src/muuli_wdr.cpp:2450
 msgid "Add manually a server (fill fields to the left before) ..."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2472
+#: src/muuli_wdr.cpp:2479
 msgid "aMule Log"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2480
+#: src/muuli_wdr.cpp:2487
 msgid "Server Info"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2484
+#: src/muuli_wdr.cpp:2491
 msgid "ED2K Info"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2488
+#: src/muuli_wdr.cpp:2495
 msgid "Kad Info"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2516
+#: src/muuli_wdr.cpp:2523
 msgid "Click on this button to update the nodes list from URL ..."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2520
+#: src/muuli_wdr.cpp:2527
 msgid "Nodes (0)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2524
+#: src/muuli_wdr.cpp:2531
 msgid "Enter the url to a nodes.dat file here and press the button to the left to update the list of known nodes."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2527
+#: src/muuli_wdr.cpp:2534
 msgid "Nodes stats"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2569
+#: src/muuli_wdr.cpp:2576
 msgid "Bootstrap"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2572
+#: src/muuli_wdr.cpp:2579
 msgid "New node"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2577
+#: src/muuli_wdr.cpp:2584
 msgid "IP:"
 msgstr "IP:"
 
-#: src/muuli_wdr.cpp:2597
+#: src/muuli_wdr.cpp:2604
 msgid "Port:"
 msgstr "Ports:"
 
-#: src/muuli_wdr.cpp:2610
+#: src/muuli_wdr.cpp:2617
 msgid "Bootstrap from known clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2612
+#: src/muuli_wdr.cpp:2619
 msgid "Disconnect Kad"
 msgstr "Atslēgt Kad"
 
-#: src/muuli_wdr.cpp:2646
+#: src/muuli_wdr.cpp:2653
 msgid "Use Secure User Identification"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2648
+#: src/muuli_wdr.cpp:2655
 msgid "It is recommended to enable this option. You will not receive credits if SUI is not enabled."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2650
+#: src/muuli_wdr.cpp:2657
 msgid "Protocol Obfuscation"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2653
+#: src/muuli_wdr.cpp:2660
 msgid "Support Protocol Obfuscation"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2655
+#: src/muuli_wdr.cpp:2662
 msgid "This option enabled Protocol Obfuscation, and makes aMule accept obfuscated connections from other clients."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2657
+#: src/muuli_wdr.cpp:2664
 msgid "Use obfuscation for outgoing connections"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2659
+#: src/muuli_wdr.cpp:2666
 msgid "This option makes aMule use Protocol Obfuscation when connecting other clients/servers."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2661
+#: src/muuli_wdr.cpp:2668
 msgid "Accept only obfuscated connections"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2662
+#: src/muuli_wdr.cpp:2669
 msgid "This option makes aMule only accept obfuscated connections. You will have less sources, but all your traffic will be obfuscated"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2667
+#: src/muuli_wdr.cpp:2674
 msgid "Everybody"
 msgstr "Jebkurš"
 
-#: src/muuli_wdr.cpp:2669
+#: src/muuli_wdr.cpp:2676
 msgid "No one"
 msgstr "Neviens"
 
-#: src/muuli_wdr.cpp:2671
+#: src/muuli_wdr.cpp:2678
 msgid "Who can see my shared files:"
 msgstr "Kas var skatīt manas kopīgotās datnes:"
 
-#: src/muuli_wdr.cpp:2672
+#: src/muuli_wdr.cpp:2679
 msgid "Select who can request to view a list of your shared files."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2674
+#: src/muuli_wdr.cpp:2681
 msgid "IP-Filtering"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2681
+#: src/muuli_wdr.cpp:2688
 msgid "Filter clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2683
+#: src/muuli_wdr.cpp:2690
 msgid "Enable filtering of the client IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2685
+#: src/muuli_wdr.cpp:2692
 msgid "Filter servers"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2687
+#: src/muuli_wdr.cpp:2694
 msgid "Enable filtering of the server IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2691
+#: src/muuli_wdr.cpp:2698
 msgid "Reload List"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2692
+#: src/muuli_wdr.cpp:2699
 msgid "Reload the list of IPs to filter from the file ~/.aMule/ipfilter.dat"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2698
+#: src/muuli_wdr.cpp:2705
 msgid "URL:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2702 src/muuli_wdr.cpp:2895
+#: src/muuli_wdr.cpp:2709 src/muuli_wdr.cpp:2902
 msgid "Update now"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2705
+#: src/muuli_wdr.cpp:2712
 msgid "Auto-update ipfilter at startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2709
+#: src/muuli_wdr.cpp:2716
 msgid "Filtering Level:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2715
+#: src/muuli_wdr.cpp:2722
 msgid "Always filter LAN IPs"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2718
+#: src/muuli_wdr.cpp:2725
 msgid "Paranoid handling of non-matching IPs"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2720
+#: src/muuli_wdr.cpp:2727
 msgid "Rejects a packet when its source IP differs from the IP the client claims (an anti-spoofing check). Disable only if it causes connection problems."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2722
+#: src/muuli_wdr.cpp:2729
 msgid "Use system-wide ipfilter.dat if available"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2723
+#: src/muuli_wdr.cpp:2730
 msgid "If there's no local ipfilter.dat found, allow usage of a system-wide ipfilter file."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2740
+#: src/muuli_wdr.cpp:2747
 msgid "Enable Online-Signature"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2742
+#: src/muuli_wdr.cpp:2749
 msgid "Enables the writing of the OS file, which can be used by external apps to create signatures and the like."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2746
+#: src/muuli_wdr.cpp:2753
 msgid "Update Frequency (Secs):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2749
+#: src/muuli_wdr.cpp:2756
 msgid "Change the frequency (in seconds) of Online Signature updates."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2757
+#: src/muuli_wdr.cpp:2764
 msgid "Save online signature file in: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:2763
+#: src/muuli_wdr.cpp:2770
 msgid "Click here to select the directory containing the the Online Signature files."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2796
+#: src/muuli_wdr.cpp:2803
 msgid "Show country flags for clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2797
+#: src/muuli_wdr.cpp:2804
 msgid "Render the country flag column in the transfers, queue and search views. Requires a valid MMDB GeoIP database (see below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2802
+#: src/muuli_wdr.cpp:2809
 msgid "Database"
 msgstr "Datubāze"
 
-#: src/muuli_wdr.cpp:2818
+#: src/muuli_wdr.cpp:2825
 msgid "Source:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2821
+#: src/muuli_wdr.cpp:2828
 msgid "DB-IP (free, no account)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2822
+#: src/muuli_wdr.cpp:2829
 msgid "MaxMind GeoLite2 (free, account required)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2823
+#: src/muuli_wdr.cpp:2830
 msgid "Custom URL"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2826
+#: src/muuli_wdr.cpp:2833
 msgid "Choose which provider supplies the GeoIP MMDB database. DB-IP is the default - no account required. MaxMind requires a free account + license key. Use Custom URL to point at any other MMDB host (e.g. a local mirror)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2843
+#: src/muuli_wdr.cpp:2850
 msgid ""
 "No configuration required.\n"
 "\n"
@@ -4747,11 +4760,11 @@ msgid ""
 "License: Creative Commons BY 4.0 - https://creativecommons.org/licenses/by/4.0/"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2856
+#: src/muuli_wdr.cpp:2863
 msgid "License key:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2862
+#: src/muuli_wdr.cpp:2869
 msgid ""
 "Sign up for a free MaxMind account, then generate a License Key:\n"
 "https://www.maxmind.com/en/geolite2/signup\n"
@@ -4761,222 +4774,222 @@ msgid ""
 "Requires attribution and account registration; refresh at least every 30 days."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2877
+#: src/muuli_wdr.cpp:2884
 msgid "Download URL:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2883
+#: src/muuli_wdr.cpp:2890
 msgid ""
 "Must point to an .mmdb file or a .gz / .tar.gz containing one.\n"
 "URL may include credentials (https://user:pass@host/...).\n"
 "License and attribution terms are set by the upstream URL - you are responsible."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2896
+#: src/muuli_wdr.cpp:2903
 msgid "Download the GeoIP database from the selected source."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2898
+#: src/muuli_wdr.cpp:2905
 msgid "Auto-update on startup"
 msgstr "Kad palaiž, automātiski atjaunināt"
 
-#: src/muuli_wdr.cpp:2899
+#: src/muuli_wdr.cpp:2906
 msgid "Re-download the GeoIP database from the selected source every time aMule starts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2922
+#: src/muuli_wdr.cpp:2929
 msgid "Filter incoming messages (except current chat):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2924
+#: src/muuli_wdr.cpp:2931
 msgid "Filter all messages"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2926
+#: src/muuli_wdr.cpp:2933
 msgid "Filter messages from people not on your friend list"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2928
+#: src/muuli_wdr.cpp:2935
 msgid "Filter messages from unknown clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2930
+#: src/muuli_wdr.cpp:2937
 msgid "Filter messages containing (use ',' as separator):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2933 src/muuli_wdr.cpp:2944
+#: src/muuli_wdr.cpp:2940 src/muuli_wdr.cpp:2951
 msgid "add here the words amule should filter and block messages including it"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2935
+#: src/muuli_wdr.cpp:2942
 msgid "Show received messages in the log"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2938
+#: src/muuli_wdr.cpp:2945
 msgid "Comments"
 msgstr "Komentāri"
 
-#: src/muuli_wdr.cpp:2941
+#: src/muuli_wdr.cpp:2948
 msgid "Filter comments containing (use ',' as separator):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2966
+#: src/muuli_wdr.cpp:2973
 msgid "Enable Proxy"
 msgstr "Izmantot starpniekserveri"
 
-#: src/muuli_wdr.cpp:2967
+#: src/muuli_wdr.cpp:2974
 msgid "Enable/disable proxy support"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2970
+#: src/muuli_wdr.cpp:2977
 msgid "Proxy type:"
 msgstr "Starpniekservera tips:"
 
-#: src/muuli_wdr.cpp:2981
+#: src/muuli_wdr.cpp:2988
 msgid "Proxy host:"
 msgstr "Starpniekserveris:"
 
-#: src/muuli_wdr.cpp:2984
+#: src/muuli_wdr.cpp:2991
 msgid "The proxy host name"
 msgstr "Starpniekservera resursdatora nosaukums"
 
-#: src/muuli_wdr.cpp:2986
+#: src/muuli_wdr.cpp:2993
 msgid "Proxy port:"
 msgstr "Starpniekservera ports:"
 
-#: src/muuli_wdr.cpp:2989
+#: src/muuli_wdr.cpp:2996
 msgid "The proxy port"
 msgstr "Starpniekservera ports"
 
-#: src/muuli_wdr.cpp:2991
+#: src/muuli_wdr.cpp:2998
 msgid "Enable authentication"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2992
+#: src/muuli_wdr.cpp:2999
 msgid "Enable/disable username/password authentication"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2995
+#: src/muuli_wdr.cpp:3002
 msgid "Username: "
 msgstr "Lietotājvārds: "
 
-#: src/muuli_wdr.cpp:2998
+#: src/muuli_wdr.cpp:3005
 msgid "The username to use to connect to the proxy"
 msgstr "Lietotājvārds, ko lietot, kad izmanto starpniekserveri"
 
-#: src/muuli_wdr.cpp:3000
+#: src/muuli_wdr.cpp:3007
 msgid "Password:"
 msgstr "Parole:"
 
-#: src/muuli_wdr.cpp:3003
+#: src/muuli_wdr.cpp:3010
 msgid "The password to use to connect to the proxy"
 msgstr "Parole, ko lietot, kad izmanto starpniekserveri"
 
-#: src/muuli_wdr.cpp:3022
+#: src/muuli_wdr.cpp:3029
 msgid "Connect to:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3031
+#: src/muuli_wdr.cpp:3038
 msgid "Login to remote amule"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3036
+#: src/muuli_wdr.cpp:3043
 msgid "User name"
 msgstr "Lietotājvārds"
 
-#: src/muuli_wdr.cpp:3047
+#: src/muuli_wdr.cpp:3054
 msgid "Remember those settings"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3050
+#: src/muuli_wdr.cpp:3057
 msgid "Force ZLIB compression"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3074
+#: src/muuli_wdr.cpp:3081
 msgid "Enable Verbose Debug-Logging."
 msgstr ""
 
-#: src/muuli_wdr.cpp:3076
+#: src/muuli_wdr.cpp:3083
 msgid "Only to Logfile"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3078
+#: src/muuli_wdr.cpp:3085
 msgid "Message Categories:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3102 src/PartFileConvertDlg.cpp:160
+#: src/muuli_wdr.cpp:3109 src/PartFileConvertDlg.cpp:160
 msgid "Waiting..."
 msgstr "Gaida…"
 
-#: src/muuli_wdr.cpp:3122
+#: src/muuli_wdr.cpp:3129
 msgid "Add imports"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3125
+#: src/muuli_wdr.cpp:3132
 msgid "Retry selected"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3127
+#: src/muuli_wdr.cpp:3134
 msgid "Remove selected"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3190
+#: src/muuli_wdr.cpp:3197
 msgid "Event Types"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3209
+#: src/muuli_wdr.cpp:3216
 msgid "Statistics and queued clients for selected file(s) : Session / All time"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3233
+#: src/muuli_wdr.cpp:3240
 msgid "Active Uploads"
 msgstr "Aktīvas augšupielādes"
 
-#: src/muuli_wdr.cpp:3247
+#: src/muuli_wdr.cpp:3254
 msgid "Percent of total files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3299
+#: src/muuli_wdr.cpp:3306
 msgid "Show Clients for"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3301
+#: src/muuli_wdr.cpp:3308
 msgid "All files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3304
+#: src/muuli_wdr.cpp:3311
 msgid "Selected files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3307
+#: src/muuli_wdr.cpp:3314
 msgid "Active uploads only"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3314
+#: src/muuli_wdr.cpp:3321
 msgid "Reload:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3318
+#: src/muuli_wdr.cpp:3325
 msgid "Reload your shared files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3381
+#: src/muuli_wdr.cpp:3388
 msgid "Send"
 msgstr "Sūtīt"
 
-#: src/muuli_wdr.cpp:3382
+#: src/muuli_wdr.cpp:3389
 msgid "Sends the specified message."
 msgstr ""
 
-#: src/muuli_wdr.cpp:3386
+#: src/muuli_wdr.cpp:3393
 msgid "Close this chat-session."
 msgstr ""
 
-#: src/muuli_wdr.cpp:3409
+#: src/muuli_wdr.cpp:3416
 msgid "Connect to any server and/or Kad"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3415 src/SharedFilesCtrl.cpp:142 src/Statistics.cpp:941
+#: src/muuli_wdr.cpp:3422 src/SharedFilesCtrl.cpp:142 src/Statistics.cpp:941
 msgid "Shared Files"
 msgstr "Kopīgotās datnes"
 
@@ -5335,187 +5348,187 @@ msgstr "Lejupielādēta"
 msgid "ERROR: Failed to open partfile '%s'"
 msgstr ""
 
-#: src/Preferences.cpp:673
+#: src/Preferences.cpp:674
 msgid "System default"
 msgstr "Sistēmas"
 
-#: src/Preferences.cpp:674
+#: src/Preferences.cpp:675
 msgid "Albanian"
 msgstr "Albāņu"
 
-#: src/Preferences.cpp:675
+#: src/Preferences.cpp:676
 msgid "Arabic"
 msgstr "Arābu"
 
-#: src/Preferences.cpp:676
+#: src/Preferences.cpp:677
 msgid "Asturian"
 msgstr "Astūriešu"
 
-#: src/Preferences.cpp:677
+#: src/Preferences.cpp:678
 msgid "Basque"
 msgstr "Basku"
 
-#: src/Preferences.cpp:678
+#: src/Preferences.cpp:679
 msgid "Bulgarian"
 msgstr "Bulgāru"
 
-#: src/Preferences.cpp:679
+#: src/Preferences.cpp:680
 msgid "Catalan"
 msgstr "Katalāņu"
 
-#: src/Preferences.cpp:680
+#: src/Preferences.cpp:681
 msgid "Chinese (Simplified)"
 msgstr "Ķīniešu (vienkāršotā)"
 
-#: src/Preferences.cpp:681
+#: src/Preferences.cpp:682
 msgid "Chinese (Traditional)"
 msgstr "Ķīniešu (tradicionālā)"
 
-#: src/Preferences.cpp:682
+#: src/Preferences.cpp:683
 msgid "Croatian"
 msgstr "Horvātu"
 
-#: src/Preferences.cpp:683
+#: src/Preferences.cpp:684
 msgid "Czech"
 msgstr "Čehu"
 
-#: src/Preferences.cpp:684
+#: src/Preferences.cpp:685
 msgid "Danish"
 msgstr "Dāņu"
 
-#: src/Preferences.cpp:685
+#: src/Preferences.cpp:686
 msgid "Dutch"
 msgstr "Nīderlandiešu"
 
-#: src/Preferences.cpp:686
+#: src/Preferences.cpp:687
 msgid "English (U.K.)"
 msgstr "Angļu (Apvienotās Karalistes)"
 
-#: src/Preferences.cpp:687
+#: src/Preferences.cpp:688
 msgid "English (U.S.)"
 msgstr "Angļu (ASV)"
 
-#: src/Preferences.cpp:688
+#: src/Preferences.cpp:689
 msgid "Estonian"
 msgstr "Igauņu"
 
-#: src/Preferences.cpp:689
+#: src/Preferences.cpp:690
 msgid "Finnish"
 msgstr "Somu"
 
-#: src/Preferences.cpp:690
+#: src/Preferences.cpp:691
 msgid "French"
 msgstr "Franču"
 
-#: src/Preferences.cpp:691
+#: src/Preferences.cpp:692
 msgid "Galician"
 msgstr "Galisiešu"
 
-#: src/Preferences.cpp:692
+#: src/Preferences.cpp:693
 msgid "German"
 msgstr "Vācu"
 
-#: src/Preferences.cpp:693
+#: src/Preferences.cpp:694
 msgid "Greek"
 msgstr "Grieķu"
 
-#: src/Preferences.cpp:694
+#: src/Preferences.cpp:695
 msgid "Hebrew"
 msgstr "Ivrits"
 
-#: src/Preferences.cpp:695
+#: src/Preferences.cpp:696
 msgid "Hungarian"
 msgstr "Ungāru"
 
-#: src/Preferences.cpp:696
+#: src/Preferences.cpp:697
 msgid "Italian"
 msgstr "Itāļu"
 
-#: src/Preferences.cpp:697
+#: src/Preferences.cpp:698
 msgid "Japanese"
 msgstr "Japāņu"
 
-#: src/Preferences.cpp:698
+#: src/Preferences.cpp:699
 msgid "Korean"
 msgstr "Korejiešu"
 
-#: src/Preferences.cpp:699
+#: src/Preferences.cpp:700
 msgid "Latvian"
 msgstr ""
 
-#: src/Preferences.cpp:700
+#: src/Preferences.cpp:701
 msgid "Lithuanian"
 msgstr "Lietuviešu"
 
-#: src/Preferences.cpp:701
+#: src/Preferences.cpp:702
 msgid "Norwegian (Nynorsk)"
 msgstr "Norvēģu (Jaunnorvēģu)"
 
-#: src/Preferences.cpp:702
+#: src/Preferences.cpp:703
 msgid "Polish"
 msgstr "Poļu"
 
-#: src/Preferences.cpp:703
+#: src/Preferences.cpp:704
 msgid "Portuguese"
 msgstr "Portugāļu"
 
-#: src/Preferences.cpp:704
+#: src/Preferences.cpp:705
 msgid "Portuguese (Brazilian)"
 msgstr "Portugāļu (Brazīlijas)"
 
-#: src/Preferences.cpp:705
+#: src/Preferences.cpp:706
 msgid "Romanian"
 msgstr "Rumāņu"
 
-#: src/Preferences.cpp:706
+#: src/Preferences.cpp:707
 msgid "Russian"
 msgstr "Krievu"
 
-#: src/Preferences.cpp:707
+#: src/Preferences.cpp:708
 msgid "Slovenian"
 msgstr "Slovēņu"
 
-#: src/Preferences.cpp:708
+#: src/Preferences.cpp:709
 msgid "Spanish"
 msgstr "Spāņu"
 
-#: src/Preferences.cpp:709
+#: src/Preferences.cpp:710
 msgid "Swedish"
 msgstr "Zviedru"
 
-#: src/Preferences.cpp:710
+#: src/Preferences.cpp:711
 msgid "Turkish"
 msgstr "Turku"
 
-#: src/Preferences.cpp:711
+#: src/Preferences.cpp:712
 msgid "Ukrainian"
 msgstr "Ukraiņu"
 
-#: src/Preferences.cpp:814
+#: src/Preferences.cpp:815
 msgid "Change Language"
 msgstr "Mainīt valodu"
 
-#: src/Preferences.cpp:878
+#: src/Preferences.cpp:879
 msgid "There are no translations installed for aMule"
 msgstr "aMule nav uzstādīta neviena valodas datne"
 
-#: src/Preferences.cpp:879
+#: src/Preferences.cpp:880
 msgid "No languages available"
 msgstr "Nav pieejama neviena valoda"
 
-#: src/Preferences.cpp:1010
+#: src/Preferences.cpp:1011
 msgid "no options available"
 msgstr ""
 
-#: src/Preferences.cpp:2179
+#: src/Preferences.cpp:2182
 msgid "Invalid category found, skipping"
 msgstr ""
 
-#: src/Preferences.cpp:2348
+#: src/Preferences.cpp:2351
 msgid "TCP port can't be higher than 65532 due to server UDP socket being TCP+3"
 msgstr ""
 
-#: src/Preferences.cpp:2349
+#: src/Preferences.cpp:2352
 #, c-format
 msgid "Default port will be used (%d)"
 msgstr ""
@@ -5991,23 +6004,27 @@ msgstr ""
 msgid "Shared folder"
 msgstr "Kopīgotās datnes"
 
-#: src/SearchDlg.cpp:425
+#: src/SearchDlg.cpp:280
+msgid "Clear search history"
+msgstr ""
+
+#: src/SearchDlg.cpp:584
 msgid "It's impossible to search when both eD2k and Kademlia are disabled."
 msgstr "Meklēšana nav iespējama, ja gan eD2k, gan Kademlia ir atspējoti."
 
-#: src/SearchDlg.cpp:426 src/SearchListCtrl.cpp:858
+#: src/SearchDlg.cpp:585 src/SearchListCtrl.cpp:858
 msgid "Search error"
 msgstr ""
 
-#: src/SearchDlg.cpp:768
+#: src/SearchDlg.cpp:929
 msgid "Min size must be smaller than max size. Max size ignored."
 msgstr ""
 
-#: src/SearchDlg.cpp:769 src/SearchDlg.cpp:851
+#: src/SearchDlg.cpp:930 src/SearchDlg.cpp:1012
 msgid "Search warning"
 msgstr ""
 
-#: src/SearchDlg.cpp:929 src/SearchListCtrl.cpp:735
+#: src/SearchDlg.cpp:1092 src/SearchListCtrl.cpp:735
 msgid "Main"
 msgstr ""
 

--- a/po/lv.po
+++ b/po/lv.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-28 12:17+0200\n"
+"POT-Creation-Date: 2026-07-28 13:09+0200\n"
 "PO-Revision-Date: 2026-07-27 11:49+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: none\n"
@@ -279,7 +279,7 @@ msgid "Password set and external connections enabled."
 msgstr ""
 
 #: src/amule.cpp:755 src/KadDlg.cpp:176 src/KadDlg.cpp:185
-#: src/PrefsUnifiedDlg.cpp:1461 src/SharedFilesCtrl.cpp:476
+#: src/PrefsUnifiedDlg.cpp:1470 src/SharedFilesCtrl.cpp:476
 msgid "WARNING"
 msgstr "BRĪDINĀJUMS"
 
@@ -314,7 +314,7 @@ msgstr "Jūs esiet iespējojuši 'Kad palaiž, palaist arī tīmekļa serveri' i
 #: src/amule-remote-gui.cpp:603 src/amule-remote-gui.cpp:671
 #: src/amule-remote-gui.cpp:709 src/amule-remote-gui.cpp:1282
 #: src/amule-remote-gui.cpp:1345 src/amule-remote-gui.cpp:1372
-#: src/DownloadQueue.cpp:1481 src/PrefsUnifiedDlg.cpp:1247
+#: src/DownloadQueue.cpp:1481 src/PrefsUnifiedDlg.cpp:1256
 msgid "ERROR"
 msgstr "KĻŪDA"
 
@@ -568,36 +568,36 @@ msgstr "Apmeklējiet https://github.com/amule-org/amule/releases/latest vietni, 
 msgid "FATAL ERROR: Failed to create Timer"
 msgstr ""
 
-#: src/amuleDlg.cpp:361 src/amuleDlg.cpp:1787 src/amuleDlg.cpp:2033
-#: src/muuli_wdr.cpp:1492 src/muuli_wdr.cpp:3449
+#: src/amuleDlg.cpp:361 src/amuleDlg.cpp:1810 src/amuleDlg.cpp:2056
+#: src/muuli_wdr.cpp:1492 src/muuli_wdr.cpp:3453
 msgid "Networks"
 msgstr "Tīkli"
 
-#: src/amuleDlg.cpp:362 src/amuleDlg.cpp:1793 src/muuli_wdr.cpp:3450
+#: src/amuleDlg.cpp:362 src/amuleDlg.cpp:1816 src/muuli_wdr.cpp:3454
 msgid "Searches"
 msgstr ""
 
-#: src/amuleDlg.cpp:363 src/amuleDlg.cpp:1799 src/DownloadListCtrl.cpp:740
-#: src/muuli_wdr.cpp:392 src/muuli_wdr.cpp:1585 src/muuli_wdr.cpp:3451
+#: src/amuleDlg.cpp:363 src/amuleDlg.cpp:1822 src/DownloadListCtrl.cpp:740
+#: src/muuli_wdr.cpp:392 src/muuli_wdr.cpp:1585 src/muuli_wdr.cpp:3455
 #: src/Statistics.cpp:829
 msgid "Downloads"
 msgstr "Lejupielādes"
 
-#: src/amuleDlg.cpp:364 src/amuleDlg.cpp:1805 src/muuli_wdr.cpp:3325
+#: src/amuleDlg.cpp:364 src/amuleDlg.cpp:1828 src/muuli_wdr.cpp:3329
 msgid "Shared files"
 msgstr "Kopīgotās datnes"
 
-#: src/amuleDlg.cpp:365 src/amuleDlg.cpp:1811 src/muuli_wdr.cpp:2957
-#: src/muuli_wdr.cpp:3407 src/muuli_wdr.cpp:3454
+#: src/amuleDlg.cpp:365 src/amuleDlg.cpp:1834 src/muuli_wdr.cpp:2961
+#: src/muuli_wdr.cpp:3411 src/muuli_wdr.cpp:3458
 msgid "Messages"
 msgstr "Ziņojumi"
 
-#: src/amuleDlg.cpp:366 src/amuleDlg.cpp:1817 src/muuli_wdr.cpp:3455
+#: src/amuleDlg.cpp:366 src/amuleDlg.cpp:1840 src/muuli_wdr.cpp:3459
 #: src/PrefsUnifiedDlg.cpp:314 src/Statistics.cpp:779 src/Statistics.cpp:1235
 msgid "Statistics"
 msgstr "Statistika"
 
-#: src/amuleDlg.cpp:368 src/amuleDlg.cpp:1824 src/muuli_wdr.cpp:3457
+#: src/amuleDlg.cpp:368 src/amuleDlg.cpp:1847 src/muuli_wdr.cpp:3461
 #: src/PrefsUnifiedDlg.cpp:330 src/utils/wxCas/src/wxcasprefs.cpp:39
 msgid "Preferences"
 msgstr "Iestatījumi"
@@ -660,8 +660,8 @@ msgstr "Kad: Izslēgts"
 #: src/amuleDlg.cpp:1029 src/DownloadListCtrl.cpp:505
 #: src/DownloadListCtrl.cpp:749 src/FriendListCtrl.cpp:180
 #: src/muuli_wdr.cpp:731 src/muuli_wdr.cpp:782 src/muuli_wdr.cpp:846
-#: src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2262 src/muuli_wdr.cpp:2347
-#: src/muuli_wdr.cpp:3095 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
+#: src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2266 src/muuli_wdr.cpp:2351
+#: src/muuli_wdr.cpp:3099 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
 #: src/ServerListCtrl.cpp:606 src/TransferWnd.cpp:378
 #: src/utils/wxCas/src/wxcasprefs.cpp:235
 msgid "Cancel"
@@ -672,7 +672,7 @@ msgid "Stop the current connection attempts"
 msgstr ""
 
 #: src/amuleDlg.cpp:1035 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976
-#: src/muuli_wdr.cpp:2485
+#: src/muuli_wdr.cpp:2489
 msgid "Disconnect"
 msgstr "Atslēgties"
 
@@ -681,7 +681,7 @@ msgid "Disconnect from the currently connected networks"
 msgstr "Atslēgties no tīkliem, kuriem pašlaik esiet pieslēdzies"
 
 #: src/amuleDlg.cpp:1041 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979
-#: src/muuli_wdr.cpp:2640 src/muuli_wdr.cpp:3092 src/muuli_wdr.cpp:3447
+#: src/muuli_wdr.cpp:2644 src/muuli_wdr.cpp:3096 src/muuli_wdr.cpp:3451
 msgid "Connect"
 msgstr "Pieslēgties"
 
@@ -735,7 +735,7 @@ msgstr ""
 msgid "Launch Command: "
 msgstr ""
 
-#: src/amuleDlg.cpp:1632 src/muuli_wdr.cpp:1982 src/Preferences.cpp:979
+#: src/amuleDlg.cpp:1632 src/muuli_wdr.cpp:1986 src/Preferences.cpp:979
 msgid "- default -"
 msgstr ""
 
@@ -749,60 +749,60 @@ msgstr ""
 msgid "WARNING: Unable to open skin file '%s' for read"
 msgstr ""
 
-#: src/amuleDlg.cpp:1791 src/muuli_wdr.cpp:3449
+#: src/amuleDlg.cpp:1814 src/muuli_wdr.cpp:3453
 msgid "Networks Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1797 src/muuli_wdr.cpp:3450
+#: src/amuleDlg.cpp:1820 src/muuli_wdr.cpp:3454
 msgid "Searches Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1803 src/muuli_wdr.cpp:3451
+#: src/amuleDlg.cpp:1826 src/muuli_wdr.cpp:3455
 msgid "Downloads Window"
 msgstr "Lejupielādes logs"
 
-#: src/amuleDlg.cpp:1809 src/muuli_wdr.cpp:3453
+#: src/amuleDlg.cpp:1832 src/muuli_wdr.cpp:3457
 msgid "Shared Files Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1815 src/muuli_wdr.cpp:3454
+#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3458
 msgid "Messages Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1821 src/muuli_wdr.cpp:3455
+#: src/amuleDlg.cpp:1844 src/muuli_wdr.cpp:3459
 msgid "Statistics Graph Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1828 src/muuli_wdr.cpp:3457
+#: src/amuleDlg.cpp:1851 src/muuli_wdr.cpp:3461
 msgid "Preferences Settings Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1831 src/muuli_wdr.cpp:3458
+#: src/amuleDlg.cpp:1854 src/muuli_wdr.cpp:3462
 msgid "Import"
 msgstr ""
 
-#: src/amuleDlg.cpp:1835 src/muuli_wdr.cpp:3458
+#: src/amuleDlg.cpp:1858 src/muuli_wdr.cpp:3462
 msgid "The partfile importer tool"
 msgstr ""
 
-#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3459
+#: src/amuleDlg.cpp:1861 src/muuli_wdr.cpp:3463
 #: src/utils/aLinkCreator/src/alcframe.cpp:262
 msgid "About"
 msgstr "Par programmu"
 
-#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3459
+#: src/amuleDlg.cpp:1861 src/muuli_wdr.cpp:3463
 msgid "About/Help"
 msgstr "Par programmu/Palīdzība"
 
-#: src/amuleDlg.cpp:2036
+#: src/amuleDlg.cpp:2059
 msgid "eD2k network"
 msgstr "eD2k tīkls"
 
-#: src/amuleDlg.cpp:2039
+#: src/amuleDlg.cpp:2062
 msgid "Kad network"
 msgstr "Kad tīkls"
 
-#: src/amuleDlg.cpp:2039
+#: src/amuleDlg.cpp:2062
 msgid "No network"
 msgstr ""
 
@@ -1331,19 +1331,19 @@ msgstr ""
 msgid "Very low"
 msgstr ""
 
-#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:743 src/muuli_wdr.cpp:2313
+#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:743 src/muuli_wdr.cpp:2317
 #: src/ServerListCtrl.cpp:263 src/ServerListCtrl.cpp:456
 #: src/SharedFilesCtrl.cpp:145
 msgid "Low"
 msgstr ""
 
-#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:744 src/muuli_wdr.cpp:2314
+#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:744 src/muuli_wdr.cpp:2318
 #: src/ServerListCtrl.cpp:266 src/ServerListCtrl.cpp:457
 #: src/SharedFilesCtrl.cpp:146
 msgid "Normal"
 msgstr ""
 
-#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:745 src/muuli_wdr.cpp:2315
+#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:745 src/muuli_wdr.cpp:2319
 #: src/ServerListCtrl.cpp:269 src/ServerListCtrl.cpp:458
 #: src/SharedFilesCtrl.cpp:147
 msgid "High"
@@ -1435,7 +1435,7 @@ msgstr ""
 msgid "Remote Server"
 msgstr ""
 
-#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3212
+#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3216
 #: src/SearchDlg.cpp:119 src/TextClient.cpp:911
 msgid "Kad"
 msgstr "Kad"
@@ -1506,7 +1506,7 @@ msgstr "Daļa"
 msgid "Size"
 msgstr "Izmērs"
 
-#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3279
+#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3283
 msgid "Transferred"
 msgstr "Pārsūtīti"
 
@@ -1562,7 +1562,7 @@ msgid ""
 "\n"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:746 src/muuli_wdr.cpp:2316
+#: src/DownloadListCtrl.cpp:746 src/muuli_wdr.cpp:2320
 #: src/SharedFilesCtrl.cpp:150
 msgid "Auto"
 msgstr ""
@@ -1600,7 +1600,7 @@ msgid "Extended Options"
 msgstr ""
 
 #: src/DownloadListCtrl.cpp:770 src/DownloadListCtrl.cpp:822
-#: src/muuli_wdr.cpp:1800
+#: src/muuli_wdr.cpp:1804
 msgid "Preview"
 msgstr "Priekšskatījums"
 
@@ -2369,23 +2369,23 @@ msgid ""
 "want downloads on a different (e.g. larger) disk."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:549 src/FirstRunWizard.cpp:611 src/muuli_wdr.cpp:1712
+#: src/FirstRunWizard.cpp:549 src/FirstRunWizard.cpp:611 src/muuli_wdr.cpp:1716
 msgid "Destination folder for downloads"
 msgstr ""
 
 #: src/FirstRunWizard.cpp:553 src/FirstRunWizard.cpp:569 src/muuli_wdr.cpp:1349
-#: src/muuli_wdr.cpp:1366 src/muuli_wdr.cpp:1687 src/muuli_wdr.cpp:1718
-#: src/muuli_wdr.cpp:1730 src/muuli_wdr.cpp:2800
+#: src/muuli_wdr.cpp:1366 src/muuli_wdr.cpp:1691 src/muuli_wdr.cpp:1722
+#: src/muuli_wdr.cpp:1734 src/muuli_wdr.cpp:2804
 #: src/utils/aLinkCreator/src/alcframe.cpp:135
 #: src/utils/wxCas/src/wxcasprefs.cpp:52 src/utils/wxCas/src/wxcasprefs.cpp:118
 msgid "Browse"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:559 src/muuli_wdr.cpp:1723
+#: src/FirstRunWizard.cpp:559 src/muuli_wdr.cpp:1727
 msgid "(All files in this folder are shared with other peers)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:565 src/FirstRunWizard.cpp:624 src/muuli_wdr.cpp:1725
+#: src/FirstRunWizard.cpp:565 src/FirstRunWizard.cpp:624 src/muuli_wdr.cpp:1729
 msgid "Folder for temporary download files"
 msgstr ""
 
@@ -2416,7 +2416,7 @@ msgstr ""
 msgid "CRITICAL - no client on StartChatSession"
 msgstr ""
 
-#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2706 src/muuli_wdr.cpp:3383
+#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2710 src/muuli_wdr.cpp:3387
 msgid "Friends"
 msgstr "Draugi"
 
@@ -2522,8 +2522,8 @@ msgstr ""
 msgid "No"
 msgstr "Nē"
 
-#: src/GenericClientListCtrl.cpp:1216 src/PrefsUnifiedDlg.cpp:2898
-#: src/PrefsUnifiedDlg.cpp:2948 src/ServerListCtrl.cpp:276
+#: src/GenericClientListCtrl.cpp:1216 src/PrefsUnifiedDlg.cpp:2907
+#: src/PrefsUnifiedDlg.cpp:2957 src/ServerListCtrl.cpp:276
 msgid "Yes"
 msgstr "Jā"
 
@@ -2690,10 +2690,10 @@ msgstr ""
 msgid "Please fill all fields required"
 msgstr ""
 
-#: src/KadDlg.cpp:192 src/PartFile.cpp:1031 src/PrefsUnifiedDlg.cpp:1134
-#: src/PrefsUnifiedDlg.cpp:1204 src/PrefsUnifiedDlg.cpp:1405
-#: src/PrefsUnifiedDlg.cpp:1663 src/PrefsUnifiedDlg.cpp:1673
-#: src/PrefsUnifiedDlg.cpp:1690 src/PrefsUnifiedDlg.cpp:1738
+#: src/KadDlg.cpp:192 src/PartFile.cpp:1031 src/PrefsUnifiedDlg.cpp:1143
+#: src/PrefsUnifiedDlg.cpp:1213 src/PrefsUnifiedDlg.cpp:1414
+#: src/PrefsUnifiedDlg.cpp:1672 src/PrefsUnifiedDlg.cpp:1682
+#: src/PrefsUnifiedDlg.cpp:1699 src/PrefsUnifiedDlg.cpp:1747
 msgid "Message"
 msgstr "Ziņojums"
 
@@ -2795,7 +2795,7 @@ msgstr ""
 msgid "Uploaded"
 msgstr "Augšupielādēts"
 
-#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3263
+#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3267
 msgid "Requested"
 msgstr ""
 
@@ -2918,7 +2918,7 @@ msgid "WARNING: "
 msgstr "BRĪDINĀJUMS: "
 
 #: src/MuleNotebook.cpp:179 src/muuli_wdr.cpp:817 src/muuli_wdr.cpp:1229
-#: src/muuli_wdr.cpp:3167 src/muuli_wdr.cpp:3423
+#: src/muuli_wdr.cpp:3171 src/muuli_wdr.cpp:3427
 msgid "Close"
 msgstr "Aizvērt"
 
@@ -2936,7 +2936,7 @@ msgid "Paste"
 msgstr "Ielīmēt"
 
 #: src/MuleTextCtrl.cpp:89 src/muuli_wdr.cpp:358 src/muuli_wdr.cpp:757
-#: src/muuli_wdr.cpp:2390 src/muuli_wdr.cpp:2409 src/muuli_wdr.cpp:2431
+#: src/muuli_wdr.cpp:2394 src/muuli_wdr.cpp:2413 src/muuli_wdr.cpp:2435
 #: src/utils/aLinkCreator/src/alcframe.cpp:142
 msgid "Clear"
 msgstr "Notīrīt"
@@ -3028,7 +3028,7 @@ msgstr "Iziet"
 
 #: src/MuleTrayIcon.cpp:579 src/MuleTrayIcon.cpp:945 src/MuleTrayIcon.cpp:965
 #: src/muuli_wdr.cpp:1398 src/muuli_wdr.cpp:1406 src/muuli_wdr.cpp:1413
-#: src/muuli_wdr.cpp:1846 src/muuli_wdr.cpp:1852 src/OtherFunctions.cpp:91
+#: src/muuli_wdr.cpp:1850 src/muuli_wdr.cpp:1856 src/OtherFunctions.cpp:91
 #: src/StatisticsDlg.cpp:93 src/StatisticsDlg.cpp:95
 msgid "kB/s"
 msgstr "kB/s"
@@ -3268,7 +3268,7 @@ msgstr "Baiti"
 msgid "KB"
 msgstr ""
 
-#: src/muuli_wdr.cpp:274 src/muuli_wdr.cpp:293 src/muuli_wdr.cpp:1631
+#: src/muuli_wdr.cpp:274 src/muuli_wdr.cpp:293 src/muuli_wdr.cpp:1635
 #: src/OtherFunctions.cpp:64
 msgid "MB"
 msgstr ""
@@ -3285,7 +3285,7 @@ msgstr "Maksimālais izmērs"
 msgid "Availability"
 msgstr "Pieejamība"
 
-#: src/muuli_wdr.cpp:312 src/muuli_wdr.cpp:398 src/muuli_wdr.cpp:3328
+#: src/muuli_wdr.cpp:312 src/muuli_wdr.cpp:398 src/muuli_wdr.cpp:3332
 msgid "Filter:"
 msgstr ""
 
@@ -3348,8 +3348,8 @@ msgstr ""
 #: src/muuli_wdr.cpp:1160 src/muuli_wdr.cpp:1167 src/muuli_wdr.cpp:1172
 #: src/muuli_wdr.cpp:1179 src/muuli_wdr.cpp:1184 src/muuli_wdr.cpp:1191
 #: src/muuli_wdr.cpp:1205 src/muuli_wdr.cpp:1212 src/muuli_wdr.cpp:1217
-#: src/muuli_wdr.cpp:1224 src/muuli_wdr.cpp:3265 src/muuli_wdr.cpp:3273
-#: src/muuli_wdr.cpp:3281
+#: src/muuli_wdr.cpp:1224 src/muuli_wdr.cpp:3269 src/muuli_wdr.cpp:3277
+#: src/muuli_wdr.cpp:3285
 msgid "N/A"
 msgstr ""
 
@@ -3491,7 +3491,7 @@ msgstr "Izpildītājs :"
 msgid "Album :"
 msgstr "Albums :"
 
-#: src/muuli_wdr.cpp:685 src/muuli_wdr.cpp:2285
+#: src/muuli_wdr.cpp:685 src/muuli_wdr.cpp:2289
 msgid "Title :"
 msgstr "Nosaukums :"
 
@@ -3598,7 +3598,7 @@ msgstr "Lietotājvārds :"
 msgid "Userhash :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:895 src/muuli_wdr.cpp:1752 src/muuli_wdr.cpp:2480
+#: src/muuli_wdr.cpp:895 src/muuli_wdr.cpp:1756 src/muuli_wdr.cpp:2484
 #: src/utils/aLinkCreator/src/alcframe.cpp:137
 msgid "Add"
 msgstr "Pievienot"
@@ -3607,15 +3607,15 @@ msgstr "Pievienot"
 msgid "Download-Speed"
 msgstr "Lejupielādes ātrums"
 
-#: src/muuli_wdr.cpp:954 src/muuli_wdr.cpp:989 src/muuli_wdr.cpp:2584
+#: src/muuli_wdr.cpp:954 src/muuli_wdr.cpp:989 src/muuli_wdr.cpp:2588
 msgid "Current"
 msgstr "Pašreizējais"
 
-#: src/muuli_wdr.cpp:962 src/muuli_wdr.cpp:997 src/muuli_wdr.cpp:2592
+#: src/muuli_wdr.cpp:962 src/muuli_wdr.cpp:997 src/muuli_wdr.cpp:2596
 msgid "Running average"
 msgstr "Visu laiku vidējais"
 
-#: src/muuli_wdr.cpp:970 src/muuli_wdr.cpp:1005 src/muuli_wdr.cpp:2600
+#: src/muuli_wdr.cpp:970 src/muuli_wdr.cpp:1005 src/muuli_wdr.cpp:2604
 msgid "Session average"
 msgstr "Sesijas vidējais"
 
@@ -3627,7 +3627,7 @@ msgstr "Augšupielādes ātrums"
 msgid "Connections"
 msgstr "Savienojumi"
 
-#: src/muuli_wdr.cpp:1024 src/muuli_wdr.cpp:1871
+#: src/muuli_wdr.cpp:1024 src/muuli_wdr.cpp:1875
 msgid "Active downloads"
 msgstr "Aktīvas lejupielādes"
 
@@ -3635,7 +3635,7 @@ msgstr "Aktīvas lejupielādes"
 msgid "Active connections (1:1)"
 msgstr "Aktīvi savienojumi (1:1)"
 
-#: src/muuli_wdr.cpp:1040 src/muuli_wdr.cpp:1872
+#: src/muuli_wdr.cpp:1040 src/muuli_wdr.cpp:1876
 msgid "Active uploads"
 msgstr "Aktīvas augšupielādes"
 
@@ -3909,7 +3909,7 @@ msgstr ""
 msgid "Advanced users only: If you have multiple network interfaces, enter the address of the interface to which aMule should be bound."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1462 src/muuli_wdr.cpp:2065
+#: src/muuli_wdr.cpp:1462 src/muuli_wdr.cpp:2069
 msgid "Bind to network interface (empty for any):"
 msgstr ""
 
@@ -3925,7 +3925,7 @@ msgstr ""
 msgid "Max simultaneous connections:"
 msgstr "Maksimālais vienlaicīgo savienojumu skaits:"
 
-#: src/muuli_wdr.cpp:1498 src/muuli_wdr.cpp:3207
+#: src/muuli_wdr.cpp:1498 src/muuli_wdr.cpp:3211
 msgid "ED2K"
 msgstr "ED2K"
 
@@ -4017,769 +4017,769 @@ msgstr ""
 msgid "For new files preallocates disk space for the whole file, thus reduces fragmentation"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1617
+#: src/muuli_wdr.cpp:1621
 msgid "Create new files as sparse files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1618
+#: src/muuli_wdr.cpp:1622
 msgid "Sparse part files only occupy disk space for the parts already downloaded, so free space is used up gradually as the file fills in. Turn this off to use an ordinary file instead - useful where sparse files are unsupported or slow, or where backup/de-duplication tools handle them badly. Applies only when the core runs on Windows; on Linux and macOS part files are sparse anyway and this setting has no effect."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1623
+#: src/muuli_wdr.cpp:1627
 msgid "Stop downloads when free disk space reaches "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1624
+#: src/muuli_wdr.cpp:1628
 msgid "Select this if you want aMule to check your disk space"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1628
+#: src/muuli_wdr.cpp:1632
 msgid "Enter here the min disk space desired."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1634
+#: src/muuli_wdr.cpp:1638
 msgid "Save 10 sources on rare files (< 20 sources)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1638 src/Statistics.cpp:790
+#: src/muuli_wdr.cpp:1642 src/Statistics.cpp:790
 msgid "Uploads"
 msgstr "Augšupielādes"
 
-#: src/muuli_wdr.cpp:1641
+#: src/muuli_wdr.cpp:1645
 msgid "Add new shared files with auto priority"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1647
+#: src/muuli_wdr.cpp:1651
 msgid "Intelligent Corruption Handling (I.C.H.)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1650
+#: src/muuli_wdr.cpp:1654
 msgid "Enable"
 msgstr "Iespējot"
 
-#: src/muuli_wdr.cpp:1653
+#: src/muuli_wdr.cpp:1657
 msgid "Advanced I.C.H. trusts every hash (not recommended)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1665 src/PrefsUnifiedDlg.cpp:1990
+#: src/muuli_wdr.cpp:1669 src/PrefsUnifiedDlg.cpp:1999
 msgid "Media metadata extraction"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1669
+#: src/muuli_wdr.cpp:1673
 msgid "Extract length / bitrate / codec from shared audio and video files"
 msgstr "Iegūt garuma / bitu pārraides ātruma / kodeka infomāciju no kopīgotajām audio un video datnēm"
 
-#: src/muuli_wdr.cpp:1671
+#: src/muuli_wdr.cpp:1675
 msgid "When enabled, aMule runs ffprobe on each shared media file to fill in the Length / Bitrate / Codec columns other clients see when they find the file in a search. Requires ffmpeg (the ffprobe binary) to be installed."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1678
+#: src/muuli_wdr.cpp:1682
 msgid "Path to ffprobe:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1683
+#: src/muuli_wdr.cpp:1687
 msgid "Full path to the ffprobe binary. Leave empty to have aMule auto-detect it on startup."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1691
+#: src/muuli_wdr.cpp:1695
 msgid "Detect"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1692
+#: src/muuli_wdr.cpp:1696
 msgid "Search the standard install locations for an ffprobe binary and fill the path field."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1716
+#: src/muuli_wdr.cpp:1720
 msgid ""
 "Completed downloads are stored here. All files in this folder are automatically shared with other peers.\n"
 "If this folder also holds files you don't want to share, point it at an aMule-only sub-folder."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1719
+#: src/muuli_wdr.cpp:1723
 msgid "Pick the folder where completed downloads will be stored. All files in that folder will be shared with other peers."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1733
+#: src/muuli_wdr.cpp:1737
 msgid "Shared folders"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1739
+#: src/muuli_wdr.cpp:1743
 msgid "(Folders shared by the core. Enter a path to add one.)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1747
+#: src/muuli_wdr.cpp:1751
 msgid "Absolute path of a folder on the core's machine, e.g. /home/user/shared"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1749 src/PrefsUnifiedDlg.cpp:2874
+#: src/muuli_wdr.cpp:1753 src/PrefsUnifiedDlg.cpp:2883
 msgid "Recursive"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1750
+#: src/muuli_wdr.cpp:1754
 msgid "Share every sub-folder underneath this one, including ones created later."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1754 src/utils/aLinkCreator/src/alcframe.cpp:141
+#: src/muuli_wdr.cpp:1758 src/utils/aLinkCreator/src/alcframe.cpp:141
 msgid "Remove"
 msgstr "Noņemt"
 
-#: src/muuli_wdr.cpp:1758
+#: src/muuli_wdr.cpp:1762
 msgid "(Right click on folder icon for recursive share)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1765
+#: src/muuli_wdr.cpp:1769
 msgid "Share hidden files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1771
+#: src/muuli_wdr.cpp:1775
 msgid "Automatically rescan shared folders for changes"
 msgstr "Automātiski uzraudzīt kopīgoto mapju izmaiņas"
 
-#: src/muuli_wdr.cpp:1777
+#: src/muuli_wdr.cpp:1781
 msgid "Follow symbolic links in shared folders"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1783
+#: src/muuli_wdr.cpp:1787
 msgid "Exclude files matching:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1786
+#: src/muuli_wdr.cpp:1790
 msgid "Wildcard patterns separated by '|', e.g. .DS_Store|Thumbs.db|*.tmp. Files whose name matches are not shared. Matching is case-insensitive."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1790
+#: src/muuli_wdr.cpp:1794
 msgid "Patterns are regular expressions"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1791
+#: src/muuli_wdr.cpp:1795
 msgid "When set, the whole field is one regular expression ('|' is alternation). When unset, it is a list of '|'-separated wildcards."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1801
+#: src/muuli_wdr.cpp:1805
 msgid "Show how many shared files the current pattern would exclude."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1822
+#: src/muuli_wdr.cpp:1826
 msgid "Graphs"
 msgstr "Grafiki"
 
-#: src/muuli_wdr.cpp:1825 src/muuli_wdr.cpp:1887
+#: src/muuli_wdr.cpp:1829 src/muuli_wdr.cpp:1891
 msgid "Update delay : 5 secs"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1829
+#: src/muuli_wdr.cpp:1833
 msgid "Time for average graph: 100 mins"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1833
+#: src/muuli_wdr.cpp:1837
 msgid "Connections Graph Scale: 100 "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1840
+#: src/muuli_wdr.cpp:1844
 msgid "Download graph scale:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1848
+#: src/muuli_wdr.cpp:1852
 msgid "Upload graph scale:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1858
+#: src/muuli_wdr.cpp:1862
 msgid "Colors: "
 msgstr "Krāsas: "
 
-#: src/muuli_wdr.cpp:1862
+#: src/muuli_wdr.cpp:1866
 msgid "Background"
 msgstr "Fons"
 
-#: src/muuli_wdr.cpp:1863
+#: src/muuli_wdr.cpp:1867
 msgid "Grid"
 msgstr "Režģis"
 
-#: src/muuli_wdr.cpp:1864
+#: src/muuli_wdr.cpp:1868
 msgid "Download current"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1865
+#: src/muuli_wdr.cpp:1869
 msgid "Download running average"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1866
+#: src/muuli_wdr.cpp:1870
 msgid "Download session average"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1867
+#: src/muuli_wdr.cpp:1871
 msgid "Upload current"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1868
+#: src/muuli_wdr.cpp:1872
 msgid "Upload running average"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1869
+#: src/muuli_wdr.cpp:1873
 msgid "Upload session average"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1870
+#: src/muuli_wdr.cpp:1874
 msgid "Active connections"
 msgstr "Aktīvi savienojumi"
 
-#: src/muuli_wdr.cpp:1873
+#: src/muuli_wdr.cpp:1877
 msgid "Systray Icon Speed Bar"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1874
+#: src/muuli_wdr.cpp:1878
 msgid "Kad-nodes current"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1875
+#: src/muuli_wdr.cpp:1879
 msgid "Kad-nodes running"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1876
+#: src/muuli_wdr.cpp:1880
 msgid "Kad-nodes session"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1880 src/muuli_wdr.cpp:2334
+#: src/muuli_wdr.cpp:1884 src/muuli_wdr.cpp:2338
 msgid "Select"
 msgstr "Atlasīt"
 
-#: src/muuli_wdr.cpp:1884
+#: src/muuli_wdr.cpp:1888
 msgid "Tree"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1894
+#: src/muuli_wdr.cpp:1898
 msgid "Number of Client Versions shown (0=unlimited)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1919
+#: src/muuli_wdr.cpp:1923
 msgid "!!! WARNING !!!"
 msgstr "!!! BRĪDINĀJUMS !!!"
 
-#: src/muuli_wdr.cpp:1934
+#: src/muuli_wdr.cpp:1938
 msgid "Max new connections / 5 secs"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1936
+#: src/muuli_wdr.cpp:1940
 msgid "Concurrent Kad source lookups"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1938
+#: src/muuli_wdr.cpp:1942
 msgid "Kad source re-search interval (minutes)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1940
+#: src/muuli_wdr.cpp:1944
 msgid "Source re-ask interval (minutes)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1944
+#: src/muuli_wdr.cpp:1948
 msgid "File Buffer Size: 240000 bytes"
 msgstr "Datnes bufera izmērs: 240000 baiti"
 
-#: src/muuli_wdr.cpp:1948
+#: src/muuli_wdr.cpp:1952
 msgid "Use MMAP: memory-mapped file access (lower memory use)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1949
+#: src/muuli_wdr.cpp:1953
 msgid "Maps part files into memory instead of buffering them on the heap, lowering the process memory footprint. May reduce download speed on some disks; best for memory-constrained or upload-heavy hosts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1951
+#: src/muuli_wdr.cpp:1955
 msgid "Upload Queue Size: 5000 clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1955
+#: src/muuli_wdr.cpp:1959
 msgid "Server connection refresh interval: Disable"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1959
+#: src/muuli_wdr.cpp:1963
 msgid "Disable computer's timed standby mode"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1978
+#: src/muuli_wdr.cpp:1982
 msgid "Skin to use: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1987
+#: src/muuli_wdr.cpp:1991
 msgid "Show \"Fast eD2k Links Handler\" in every window."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1990
+#: src/muuli_wdr.cpp:1994
 msgid "Show extended info on categories tabs"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1993
+#: src/muuli_wdr.cpp:1997
 msgid "Show application version on title"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1995
+#: src/muuli_wdr.cpp:1999
 msgid "Show transfer rates on title"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1997
+#: src/muuli_wdr.cpp:2001
 msgid "Before application name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1999
+#: src/muuli_wdr.cpp:2003
 msgid "After application name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2002
+#: src/muuli_wdr.cpp:2006
 msgid "Show overhead bandwidth"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2006
+#: src/muuli_wdr.cpp:2010
 msgid "Vertical toolbar orientation"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2008
+#: src/muuli_wdr.cpp:2012
 msgid "Live column sorting (auto-reorder rows as their values change)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2015
+#: src/muuli_wdr.cpp:2019
 msgid "Download Queue Files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2018
+#: src/muuli_wdr.cpp:2022
 msgid "Show progress percentage"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2024
+#: src/muuli_wdr.cpp:2028
 msgid "Show progress bar"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2027
+#: src/muuli_wdr.cpp:2031
 msgid "Flat"
 msgstr "Plakana"
 
-#: src/muuli_wdr.cpp:2031
+#: src/muuli_wdr.cpp:2035
 msgid "Round"
 msgstr "Apaļa"
 
-#: src/muuli_wdr.cpp:2049
+#: src/muuli_wdr.cpp:2053
 msgid "External Connection Parameters"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2052
+#: src/muuli_wdr.cpp:2056
 msgid "Accept external connections"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2059 src/muuli_wdr.cpp:2118
+#: src/muuli_wdr.cpp:2063 src/muuli_wdr.cpp:2122
 msgid "IP of the listening interface:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2062
+#: src/muuli_wdr.cpp:2066
 msgid "Enter here a valid ip in the a.b.c.d format for the listening EC interface. An empty field or 0.0.0.0 will mean any interface."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2083 src/muuli_wdr.cpp:2194
+#: src/muuli_wdr.cpp:2087 src/muuli_wdr.cpp:2198
 msgid "TCP port:"
 msgstr "TCP ports:"
 
-#: src/muuli_wdr.cpp:2089
+#: src/muuli_wdr.cpp:2093
 msgid "Enable UPnP port forwarding on the EC port"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2093 src/muuli_wdr.cpp:3079
+#: src/muuli_wdr.cpp:2097 src/muuli_wdr.cpp:3083
 #: src/utils/wxCas/src/wxcasprefs.cpp:167
 msgid "Password"
 msgstr "Parole"
 
-#: src/muuli_wdr.cpp:2099
+#: src/muuli_wdr.cpp:2103
 msgid "aMule API server parameters"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2102
+#: src/muuli_wdr.cpp:2106
 msgid "Run amuleapi (REST API) on startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2107
+#: src/muuli_wdr.cpp:2111
 #, fuzzy
 msgid "HTTP port:"
 msgstr "TCP ports:"
 
-#: src/muuli_wdr.cpp:2121
+#: src/muuli_wdr.cpp:2125
 msgid "The interface amuleapi's HTTP server listens on. 127.0.0.1 (default) accepts only local connections; use 0.0.0.0 or a specific IP to expose it to other hosts (set an admin password below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2126
+#: src/muuli_wdr.cpp:2130
 msgid "Type a password to set or change it. Stored passwords cannot be shown, so leaving this empty keeps the current one."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2128
+#: src/muuli_wdr.cpp:2132
 #, fuzzy
 msgid "Admin password"
 msgstr "Parole"
 
-#: src/muuli_wdr.cpp:2140 src/muuli_wdr.cpp:2157 src/PrefsUnifiedDlg.cpp:1103
+#: src/muuli_wdr.cpp:2144 src/muuli_wdr.cpp:2161 src/PrefsUnifiedDlg.cpp:1112
 #, fuzzy
 msgid "A password is set."
 msgstr "Parole"
 
-#: src/muuli_wdr.cpp:2144
+#: src/muuli_wdr.cpp:2148
 msgid "Enable guest access"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2145
+#: src/muuli_wdr.cpp:2149
 msgid "Guest sessions may read status and listings but cannot change anything. Turning this off clears the stored guest password."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2149
+#: src/muuli_wdr.cpp:2153
 #, fuzzy
 msgid "Guest password"
 msgstr "Parole"
 
-#: src/muuli_wdr.cpp:2164
+#: src/muuli_wdr.cpp:2168
 msgid "Web server parameters"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2167
+#: src/muuli_wdr.cpp:2171
 #, fuzzy
 msgid "Run webserver on startup (deprecated)"
 msgstr "Kad palaiž, palaist arī tīmekļa serveri"
 
-#: src/muuli_wdr.cpp:2173
+#: src/muuli_wdr.cpp:2177
 msgid "Web template"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2178
+#: src/muuli_wdr.cpp:2182
 msgid "Full rights password"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2182
+#: src/muuli_wdr.cpp:2186
 msgid "Enable Low rights User"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2187
+#: src/muuli_wdr.cpp:2191
 msgid "Low rights password"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2201
+#: src/muuli_wdr.cpp:2205
 msgid "Enable UPnP port forwarding of the web server port"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2206
+#: src/muuli_wdr.cpp:2210
 msgid "Web server UPnP TCP port (Optional)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2214
+#: src/muuli_wdr.cpp:2218
 msgid "Page Refresh Time (in secs)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2221
+#: src/muuli_wdr.cpp:2225
 msgid "Enable Gzip compression"
 msgstr "Iespējot Gzip saspiešanu"
 
-#: src/muuli_wdr.cpp:2255
+#: src/muuli_wdr.cpp:2259
 #, fuzzy
 msgid "Reset page to defaults"
 msgstr "Sistēmas"
 
-#: src/muuli_wdr.cpp:2256
+#: src/muuli_wdr.cpp:2260
 msgid "Reset the settings on the current page to their default values."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2258 src/muuli_wdr.cpp:2344 src/ServerWnd.cpp:274
+#: src/muuli_wdr.cpp:2262 src/muuli_wdr.cpp:2348 src/ServerWnd.cpp:274
 #: src/ServerWnd.cpp:282
 msgid "OK"
 msgstr "Labi"
 
-#: src/muuli_wdr.cpp:2260
+#: src/muuli_wdr.cpp:2264
 msgid "Click here to apply any changes made to the preferences."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2263
+#: src/muuli_wdr.cpp:2267
 msgid "Reset any changes made to the preferences."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2292
+#: src/muuli_wdr.cpp:2296
 msgid "Comment :"
 msgstr "Komentārs :"
 
-#: src/muuli_wdr.cpp:2299
+#: src/muuli_wdr.cpp:2303
 msgid "Incoming Dir :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2308
+#: src/muuli_wdr.cpp:2312
 msgid "Change priority for new assigned files :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2312
+#: src/muuli_wdr.cpp:2316
 msgid "Don't change"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2324
+#: src/muuli_wdr.cpp:2328
 msgid "Select color for this Category (currently selected) :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2391 src/muuli_wdr.cpp:2410 src/muuli_wdr.cpp:2432
+#: src/muuli_wdr.cpp:2395 src/muuli_wdr.cpp:2414 src/muuli_wdr.cpp:2436
 msgid "Click this button to reset the log."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2451
+#: src/muuli_wdr.cpp:2455
 msgid "Click on this button to update the servers list from URL ..."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2455
+#: src/muuli_wdr.cpp:2459
 msgid "Server list"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2459
+#: src/muuli_wdr.cpp:2463
 msgid "Enter the url to a server.met file here and press the button to the left to update the list of known servers."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2464
+#: src/muuli_wdr.cpp:2468
 msgid "Add server manually: Name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2467
+#: src/muuli_wdr.cpp:2471
 msgid "Enter the name of the new server here"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2469 src/ServerWnd.cpp:206
+#: src/muuli_wdr.cpp:2473 src/ServerWnd.cpp:206
 msgid "IP:Port"
 msgstr "IP:Ports"
 
-#: src/muuli_wdr.cpp:2472
+#: src/muuli_wdr.cpp:2476
 msgid "Enter the IP of the server here, using the x.x.x.x format."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2478
+#: src/muuli_wdr.cpp:2482
 msgid "Enter the port of the server here."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2481
+#: src/muuli_wdr.cpp:2485
 msgid "Add manually a server (fill fields to the left before) ..."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2510
+#: src/muuli_wdr.cpp:2514
 msgid "aMule Log"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2518
+#: src/muuli_wdr.cpp:2522
 msgid "Server Info"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2522
+#: src/muuli_wdr.cpp:2526
 msgid "ED2K Info"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2526
+#: src/muuli_wdr.cpp:2530
 msgid "Kad Info"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2554
+#: src/muuli_wdr.cpp:2558
 msgid "Click on this button to update the nodes list from URL ..."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2558
+#: src/muuli_wdr.cpp:2562
 msgid "Nodes (0)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2562
+#: src/muuli_wdr.cpp:2566
 msgid "Enter the url to a nodes.dat file here and press the button to the left to update the list of known nodes."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2565
+#: src/muuli_wdr.cpp:2569
 msgid "Nodes stats"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2607
+#: src/muuli_wdr.cpp:2611
 msgid "Bootstrap"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2610
+#: src/muuli_wdr.cpp:2614
 msgid "New node"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2615
+#: src/muuli_wdr.cpp:2619
 msgid "IP:"
 msgstr "IP:"
 
-#: src/muuli_wdr.cpp:2635
+#: src/muuli_wdr.cpp:2639
 msgid "Port:"
 msgstr "Ports:"
 
-#: src/muuli_wdr.cpp:2648
+#: src/muuli_wdr.cpp:2652
 msgid "Bootstrap from known clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2650
+#: src/muuli_wdr.cpp:2654
 msgid "Disconnect Kad"
 msgstr "Atslēgt Kad"
 
-#: src/muuli_wdr.cpp:2684
+#: src/muuli_wdr.cpp:2688
 msgid "Use Secure User Identification"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2686
+#: src/muuli_wdr.cpp:2690
 msgid "It is recommended to enable this option. You will not receive credits if SUI is not enabled."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2688
+#: src/muuli_wdr.cpp:2692
 msgid "Protocol Obfuscation"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2691
+#: src/muuli_wdr.cpp:2695
 msgid "Support Protocol Obfuscation"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2693
+#: src/muuli_wdr.cpp:2697
 msgid "This option enabled Protocol Obfuscation, and makes aMule accept obfuscated connections from other clients."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2695
+#: src/muuli_wdr.cpp:2699
 msgid "Use obfuscation for outgoing connections"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2697
+#: src/muuli_wdr.cpp:2701
 msgid "This option makes aMule use Protocol Obfuscation when connecting other clients/servers."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2699
+#: src/muuli_wdr.cpp:2703
 msgid "Accept only obfuscated connections"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2700
+#: src/muuli_wdr.cpp:2704
 msgid "This option makes aMule only accept obfuscated connections. You will have less sources, but all your traffic will be obfuscated"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2705
+#: src/muuli_wdr.cpp:2709
 msgid "Everybody"
 msgstr "Jebkurš"
 
-#: src/muuli_wdr.cpp:2707
+#: src/muuli_wdr.cpp:2711
 msgid "No one"
 msgstr "Neviens"
 
-#: src/muuli_wdr.cpp:2709
+#: src/muuli_wdr.cpp:2713
 msgid "Who can see my shared files:"
 msgstr "Kas var skatīt manas kopīgotās datnes:"
 
-#: src/muuli_wdr.cpp:2710
+#: src/muuli_wdr.cpp:2714
 msgid "Select who can request to view a list of your shared files."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2712
+#: src/muuli_wdr.cpp:2716
 msgid "IP-Filtering"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2719
+#: src/muuli_wdr.cpp:2723
 msgid "Filter clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2721
+#: src/muuli_wdr.cpp:2725
 msgid "Enable filtering of the client IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2723
+#: src/muuli_wdr.cpp:2727
 msgid "Filter servers"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2725
+#: src/muuli_wdr.cpp:2729
 msgid "Enable filtering of the server IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2729
+#: src/muuli_wdr.cpp:2733
 msgid "Reload List"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2730
+#: src/muuli_wdr.cpp:2734
 msgid "Reload the list of IPs to filter from the file ~/.aMule/ipfilter.dat"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2736
+#: src/muuli_wdr.cpp:2740
 msgid "URL:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2740 src/muuli_wdr.cpp:2933
+#: src/muuli_wdr.cpp:2744 src/muuli_wdr.cpp:2937
 msgid "Update now"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2743
+#: src/muuli_wdr.cpp:2747
 msgid "Auto-update ipfilter at startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2747
+#: src/muuli_wdr.cpp:2751
 msgid "Filtering Level:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2753
+#: src/muuli_wdr.cpp:2757
 msgid "Always filter LAN IPs"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2756
+#: src/muuli_wdr.cpp:2760
 msgid "Paranoid handling of non-matching IPs"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2758
+#: src/muuli_wdr.cpp:2762
 msgid "Rejects a packet when its source IP differs from the IP the client claims (an anti-spoofing check). Disable only if it causes connection problems."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2760
+#: src/muuli_wdr.cpp:2764
 msgid "Use system-wide ipfilter.dat if available"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2761
+#: src/muuli_wdr.cpp:2765
 msgid "If there's no local ipfilter.dat found, allow usage of a system-wide ipfilter file."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2778
+#: src/muuli_wdr.cpp:2782
 msgid "Enable Online-Signature"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2780
+#: src/muuli_wdr.cpp:2784
 msgid "Enables the writing of the OS file, which can be used by external apps to create signatures and the like."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2784
+#: src/muuli_wdr.cpp:2788
 msgid "Update Frequency (Secs):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2787
+#: src/muuli_wdr.cpp:2791
 msgid "Change the frequency (in seconds) of Online Signature updates."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2795
+#: src/muuli_wdr.cpp:2799
 msgid "Save online signature file in: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:2801
+#: src/muuli_wdr.cpp:2805
 msgid "Click here to select the directory containing the the Online Signature files."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2834
+#: src/muuli_wdr.cpp:2838
 msgid "Show country flags for clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2835
+#: src/muuli_wdr.cpp:2839
 msgid "Render the country flag column in the transfers, queue and search views. Requires a valid MMDB GeoIP database (see below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2840
+#: src/muuli_wdr.cpp:2844
 msgid "Database"
 msgstr "Datubāze"
 
-#: src/muuli_wdr.cpp:2856
+#: src/muuli_wdr.cpp:2860
 msgid "Source:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2859
+#: src/muuli_wdr.cpp:2863
 msgid "DB-IP (free, no account)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2860
+#: src/muuli_wdr.cpp:2864
 msgid "MaxMind GeoLite2 (free, account required)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2861
+#: src/muuli_wdr.cpp:2865
 msgid "Custom URL"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2864
+#: src/muuli_wdr.cpp:2868
 msgid "Choose which provider supplies the GeoIP MMDB database. DB-IP is the default - no account required. MaxMind requires a free account + license key. Use Custom URL to point at any other MMDB host (e.g. a local mirror)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2881
+#: src/muuli_wdr.cpp:2885
 msgid ""
 "No configuration required.\n"
 "\n"
@@ -4787,11 +4787,11 @@ msgid ""
 "License: Creative Commons BY 4.0 - https://creativecommons.org/licenses/by/4.0/"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2894
+#: src/muuli_wdr.cpp:2898
 msgid "License key:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2900
+#: src/muuli_wdr.cpp:2904
 msgid ""
 "Sign up for a free MaxMind account, then generate a License Key:\n"
 "https://www.maxmind.com/en/geolite2/signup\n"
@@ -4801,222 +4801,222 @@ msgid ""
 "Requires attribution and account registration; refresh at least every 30 days."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2915
+#: src/muuli_wdr.cpp:2919
 msgid "Download URL:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2921
+#: src/muuli_wdr.cpp:2925
 msgid ""
 "Must point to an .mmdb file or a .gz / .tar.gz containing one.\n"
 "URL may include credentials (https://user:pass@host/...).\n"
 "License and attribution terms are set by the upstream URL - you are responsible."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2934
+#: src/muuli_wdr.cpp:2938
 msgid "Download the GeoIP database from the selected source."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2936
+#: src/muuli_wdr.cpp:2940
 msgid "Auto-update on startup"
 msgstr "Kad palaiž, automātiski atjaunināt"
 
-#: src/muuli_wdr.cpp:2937
+#: src/muuli_wdr.cpp:2941
 msgid "Re-download the GeoIP database from the selected source every time aMule starts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2960
+#: src/muuli_wdr.cpp:2964
 msgid "Filter incoming messages (except current chat):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2962
+#: src/muuli_wdr.cpp:2966
 msgid "Filter all messages"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2964
+#: src/muuli_wdr.cpp:2968
 msgid "Filter messages from people not on your friend list"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2966
+#: src/muuli_wdr.cpp:2970
 msgid "Filter messages from unknown clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2968
+#: src/muuli_wdr.cpp:2972
 msgid "Filter messages containing (use ',' as separator):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2971 src/muuli_wdr.cpp:2982
+#: src/muuli_wdr.cpp:2975 src/muuli_wdr.cpp:2986
 msgid "add here the words amule should filter and block messages including it"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2973
+#: src/muuli_wdr.cpp:2977
 msgid "Show received messages in the log"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2976
+#: src/muuli_wdr.cpp:2980
 msgid "Comments"
 msgstr "Komentāri"
 
-#: src/muuli_wdr.cpp:2979
+#: src/muuli_wdr.cpp:2983
 msgid "Filter comments containing (use ',' as separator):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3004
+#: src/muuli_wdr.cpp:3008
 msgid "Enable Proxy"
 msgstr "Izmantot starpniekserveri"
 
-#: src/muuli_wdr.cpp:3005
+#: src/muuli_wdr.cpp:3009
 msgid "Enable/disable proxy support"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3008
+#: src/muuli_wdr.cpp:3012
 msgid "Proxy type:"
 msgstr "Starpniekservera tips:"
 
-#: src/muuli_wdr.cpp:3019
+#: src/muuli_wdr.cpp:3023
 msgid "Proxy host:"
 msgstr "Starpniekserveris:"
 
-#: src/muuli_wdr.cpp:3022
+#: src/muuli_wdr.cpp:3026
 msgid "The proxy host name"
 msgstr "Starpniekservera resursdatora nosaukums"
 
-#: src/muuli_wdr.cpp:3024
+#: src/muuli_wdr.cpp:3028
 msgid "Proxy port:"
 msgstr "Starpniekservera ports:"
 
-#: src/muuli_wdr.cpp:3027
+#: src/muuli_wdr.cpp:3031
 msgid "The proxy port"
 msgstr "Starpniekservera ports"
 
-#: src/muuli_wdr.cpp:3029
+#: src/muuli_wdr.cpp:3033
 msgid "Enable authentication"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3030
+#: src/muuli_wdr.cpp:3034
 msgid "Enable/disable username/password authentication"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3033
+#: src/muuli_wdr.cpp:3037
 msgid "Username: "
 msgstr "Lietotājvārds: "
 
-#: src/muuli_wdr.cpp:3036
+#: src/muuli_wdr.cpp:3040
 msgid "The username to use to connect to the proxy"
 msgstr "Lietotājvārds, ko lietot, kad izmanto starpniekserveri"
 
-#: src/muuli_wdr.cpp:3038
+#: src/muuli_wdr.cpp:3042
 msgid "Password:"
 msgstr "Parole:"
 
-#: src/muuli_wdr.cpp:3041
+#: src/muuli_wdr.cpp:3045
 msgid "The password to use to connect to the proxy"
 msgstr "Parole, ko lietot, kad izmanto starpniekserveri"
 
-#: src/muuli_wdr.cpp:3060
+#: src/muuli_wdr.cpp:3064
 msgid "Connect to:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3069
+#: src/muuli_wdr.cpp:3073
 msgid "Login to remote amule"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3074
+#: src/muuli_wdr.cpp:3078
 msgid "User name"
 msgstr "Lietotājvārds"
 
-#: src/muuli_wdr.cpp:3085
+#: src/muuli_wdr.cpp:3089
 msgid "Remember those settings"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3088
+#: src/muuli_wdr.cpp:3092
 msgid "Force ZLIB compression"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3112
+#: src/muuli_wdr.cpp:3116
 msgid "Enable Verbose Debug-Logging."
 msgstr ""
 
-#: src/muuli_wdr.cpp:3114
+#: src/muuli_wdr.cpp:3118
 msgid "Only to Logfile"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3116
+#: src/muuli_wdr.cpp:3120
 msgid "Message Categories:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3140 src/PartFileConvertDlg.cpp:160
+#: src/muuli_wdr.cpp:3144 src/PartFileConvertDlg.cpp:160
 msgid "Waiting..."
 msgstr "Gaida…"
 
-#: src/muuli_wdr.cpp:3160
+#: src/muuli_wdr.cpp:3164
 msgid "Add imports"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3163
+#: src/muuli_wdr.cpp:3167
 msgid "Retry selected"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3165
+#: src/muuli_wdr.cpp:3169
 msgid "Remove selected"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3228
+#: src/muuli_wdr.cpp:3232
 msgid "Event Types"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3247
+#: src/muuli_wdr.cpp:3251
 msgid "Statistics and queued clients for selected file(s) : Session / All time"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3271
+#: src/muuli_wdr.cpp:3275
 msgid "Active Uploads"
 msgstr "Aktīvas augšupielādes"
 
-#: src/muuli_wdr.cpp:3285
+#: src/muuli_wdr.cpp:3289
 msgid "Percent of total files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3337
+#: src/muuli_wdr.cpp:3341
 msgid "Show Clients for"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3339
+#: src/muuli_wdr.cpp:3343
 msgid "All files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3342
+#: src/muuli_wdr.cpp:3346
 msgid "Selected files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3345
+#: src/muuli_wdr.cpp:3349
 msgid "Active uploads only"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3352
+#: src/muuli_wdr.cpp:3356
 msgid "Reload:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3356
+#: src/muuli_wdr.cpp:3360
 msgid "Reload your shared files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3419
+#: src/muuli_wdr.cpp:3423
 msgid "Send"
 msgstr "Sūtīt"
 
-#: src/muuli_wdr.cpp:3420
+#: src/muuli_wdr.cpp:3424
 msgid "Sends the specified message."
 msgstr ""
 
-#: src/muuli_wdr.cpp:3424
+#: src/muuli_wdr.cpp:3428
 msgid "Close this chat-session."
 msgstr ""
 
-#: src/muuli_wdr.cpp:3447
+#: src/muuli_wdr.cpp:3451
 msgid "Connect to any server and/or Kad"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3453 src/SharedFilesCtrl.cpp:142 src/Statistics.cpp:941
+#: src/muuli_wdr.cpp:3457 src/SharedFilesCtrl.cpp:142 src/Statistics.cpp:941
 msgid "Shared Files"
 msgstr "Kopīgotās datnes"
 
@@ -5641,73 +5641,73 @@ msgid ""
 "these settings."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:647
+#: src/PrefsUnifiedDlg.cpp:656
 #, c-format
 msgid "Failed to connect Cfg to widget with the ID %d and key %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:695
+#: src/PrefsUnifiedDlg.cpp:704
 #, c-format
 msgid "Failed to transfer data from Cfg to Widget with the ID %d and key %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:801
+#: src/PrefsUnifiedDlg.cpp:810
 msgid "The type of proxy you are connecting to"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1020
+#: src/PrefsUnifiedDlg.cpp:1029
 #, c-format
 msgid "Failed to transfer data from Widget to Cfg with the ID %d and key %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1103
+#: src/PrefsUnifiedDlg.cpp:1112
 #, fuzzy
 msgid "No password set."
 msgstr "Parole"
 
-#: src/PrefsUnifiedDlg.cpp:1132
+#: src/PrefsUnifiedDlg.cpp:1141
 msgid "Guest access needs a password. Type one in the guest password field, or untick Enable guest access."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1144
+#: src/PrefsUnifiedDlg.cpp:1153
 msgid ""
 "aMule must be restarted to enable these changes:\n"
 "\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1151
+#: src/PrefsUnifiedDlg.cpp:1160
 msgid "- TCP port changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1156
+#: src/PrefsUnifiedDlg.cpp:1165
 msgid "- UDP port changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1161
+#: src/PrefsUnifiedDlg.cpp:1170
 msgid "- Network interface binding changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1166
+#: src/PrefsUnifiedDlg.cpp:1175
 msgid "- External connect port changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1170
+#: src/PrefsUnifiedDlg.cpp:1179
 msgid "- External connect acceptance changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1174
+#: src/PrefsUnifiedDlg.cpp:1183
 msgid "- External connect interface changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1178
+#: src/PrefsUnifiedDlg.cpp:1187
 msgid "- Protocol obfuscation support changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1193
+#: src/PrefsUnifiedDlg.cpp:1202
 msgid "- amuleapi settings changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1202
+#: src/PrefsUnifiedDlg.cpp:1211
 msgid ""
 "Your Auto-update server list is empty.\n"
 "'Auto-update server list at startup' will be disabled."
@@ -5715,140 +5715,140 @@ msgstr ""
 "Jūsu automātiskās atjaunināšanas serveru saraksts ir tukšs.\n"
 "'Kad palaiž, automātiski atjaunināt serveru sarakstu' iestatījums tiks atspējots."
 
-#: src/PrefsUnifiedDlg.cpp:1213
+#: src/PrefsUnifiedDlg.cpp:1222
 msgid ""
 "You have enabled external connections but have not specified a password.\n"
 "External connections cannot be enabled unless a valid password is specified."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1246
+#: src/PrefsUnifiedDlg.cpp:1255
 #, c-format
 msgid "The amuleapi password could not be saved: %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1276
+#: src/PrefsUnifiedDlg.cpp:1285
 msgid "- Language changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1281
+#: src/PrefsUnifiedDlg.cpp:1290
 msgid "- Temp folder changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1286
+#: src/PrefsUnifiedDlg.cpp:1295
 msgid "- ED2K network enabled.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1319
+#: src/PrefsUnifiedDlg.cpp:1328
 msgid "The shared-file exclusion pattern is not a valid regular expression. The filter has been left disabled."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1321 src/PrefsUnifiedDlg.cpp:1921
+#: src/PrefsUnifiedDlg.cpp:1330 src/PrefsUnifiedDlg.cpp:1930
 msgid "Invalid regular expression"
 msgstr "Nederīga regulārā izteiksme"
 
-#: src/PrefsUnifiedDlg.cpp:1398
+#: src/PrefsUnifiedDlg.cpp:1407
 msgid ""
 "Both eD2k and Kad network are disabled.\n"
 "You won't be able to connect until you enable at least one of them."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1403
+#: src/PrefsUnifiedDlg.cpp:1412
 msgid ""
 "Kad will not start if your UDP port is disabled.\n"
 "Enable UDP port or disable Kad."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1459
+#: src/PrefsUnifiedDlg.cpp:1468
 msgid ""
 "\n"
 "You MUST restart aMule now.\n"
 "If you do not restart now, don't complain if anything bad happens.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1524
+#: src/PrefsUnifiedDlg.cpp:1533
 msgid "Could not register aMule for autostart at login. The autostart store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1526
+#: src/PrefsUnifiedDlg.cpp:1535
 msgid "Could not remove the autostart-at-login entry."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1527
+#: src/PrefsUnifiedDlg.cpp:1536
 msgid "Autostart"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1542
+#: src/PrefsUnifiedDlg.cpp:1551
 msgid "Register file type"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1542
+#: src/PrefsUnifiedDlg.cpp:1551
 msgid "Register URL handler"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1550
+#: src/PrefsUnifiedDlg.cpp:1559
 #, c-format
 msgid "aMule only handles eD2k-compatible magnets. If you replace the current magnet handler (%s), BitTorrent magnet links will stop working - aMule cannot download BitTorrent content. Continue?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1555
+#: src/PrefsUnifiedDlg.cpp:1564
 #, c-format
 msgid "Another application currently opens .emulecollection files (%s). Replace it with aMule?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1560
+#: src/PrefsUnifiedDlg.cpp:1569
 #, c-format
 msgid "Another application is currently the default handler for these links (%s). Replace it with aMule?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1585
+#: src/PrefsUnifiedDlg.cpp:1594
 msgid "Could not register aMule for .emulecollection files. The registration store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1587
+#: src/PrefsUnifiedDlg.cpp:1596
 msgid "Could not remove the file type registration."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1589
+#: src/PrefsUnifiedDlg.cpp:1598
 msgid "Could not register aMule as the URL handler. The registration store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1591
+#: src/PrefsUnifiedDlg.cpp:1600
 msgid "Could not remove the URL handler registration."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1661 src/PrefsUnifiedDlg.cpp:1688
+#: src/PrefsUnifiedDlg.cpp:1670 src/PrefsUnifiedDlg.cpp:1697
 msgid "The web server and aMule API require external connections to be enabled."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1671
+#: src/PrefsUnifiedDlg.cpp:1680
 msgid "The aMule web server is deprecated. Consider running the aMule API instead."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1735
+#: src/PrefsUnifiedDlg.cpp:1744
 msgid ""
 "Your Auto-update servers list is in blank.\n"
 "Please fill in at least one URL to point to a valid server.met file.\n"
 "Click on the button \"List\" by this checkbox to enter an URL."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1876
+#: src/PrefsUnifiedDlg.cpp:1885
 msgid "Temporary files"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1881
+#: src/PrefsUnifiedDlg.cpp:1890
 msgid "Incoming files"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1886
+#: src/PrefsUnifiedDlg.cpp:1895
 msgid "Online Signatures"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1899
+#: src/PrefsUnifiedDlg.cpp:1908
 #, c-format
 msgid "Choose a folder for %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1923
+#: src/PrefsUnifiedDlg.cpp:1932
 #, c-format
 msgid "Would exclude %u of %u shared file"
 msgid_plural "Would exclude %u of %u shared files"
@@ -5856,100 +5856,100 @@ msgstr[0] ""
 msgstr[1] ""
 msgstr[2] ""
 
-#: src/PrefsUnifiedDlg.cpp:1940
+#: src/PrefsUnifiedDlg.cpp:1949
 msgid "Browse for videoplayer"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1944
+#: src/PrefsUnifiedDlg.cpp:1953
 msgid "Select browser"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1948
+#: src/PrefsUnifiedDlg.cpp:1957
 msgid "Select ffprobe binary"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1954
+#: src/PrefsUnifiedDlg.cpp:1963
 #, c-format
 msgid "Executable%s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1988
+#: src/PrefsUnifiedDlg.cpp:1997
 msgid "ffprobe not found on PATH or in the standard install locations. Install ffmpeg (which ships ffprobe) or use Browse to pick a binary manually."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2000
+#: src/PrefsUnifiedDlg.cpp:2009
 msgid "Reset the settings on this page to their default values?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2001
+#: src/PrefsUnifiedDlg.cpp:2010
 #, fuzzy
 msgid "Reset to defaults"
 msgstr "Sistēmas"
 
-#: src/PrefsUnifiedDlg.cpp:2028
+#: src/PrefsUnifiedDlg.cpp:2037
 msgid "Edit server list"
 msgstr "Rediģēt serveru sarakstu"
 
-#: src/PrefsUnifiedDlg.cpp:2029
+#: src/PrefsUnifiedDlg.cpp:2038
 msgid ""
 "Add here URL's to download server.met files.\n"
 "Only one url on each line."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2084
+#: src/PrefsUnifiedDlg.cpp:2093
 msgid "IP2Country update failed"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2229 src/PrefsUnifiedDlg.cpp:2260
+#: src/PrefsUnifiedDlg.cpp:2238 src/PrefsUnifiedDlg.cpp:2269
 msgid "Data by MaxMind GeoLite2"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2231 src/PrefsUnifiedDlg.cpp:2262
+#: src/PrefsUnifiedDlg.cpp:2240 src/PrefsUnifiedDlg.cpp:2271
 msgid "Custom source"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2233 src/PrefsUnifiedDlg.cpp:2264
+#: src/PrefsUnifiedDlg.cpp:2242 src/PrefsUnifiedDlg.cpp:2273
 msgid "Data by DB-IP.com"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2284
+#: src/PrefsUnifiedDlg.cpp:2293
 #, c-format
 msgid "Status: Loaded%s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2286
+#: src/PrefsUnifiedDlg.cpp:2295
 #, c-format
 msgid "Status: Loaded%s - %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2290
+#: src/PrefsUnifiedDlg.cpp:2299
 msgid "Status: Failed to load - click 'Update now' to refresh."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2292
+#: src/PrefsUnifiedDlg.cpp:2301
 msgid "Status: Not found - click 'Update now' to download."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2350 src/PrefsUnifiedDlg.cpp:2374
+#: src/PrefsUnifiedDlg.cpp:2359 src/PrefsUnifiedDlg.cpp:2383
 #, c-format
 msgid "Update delay: %d second"
 msgid_plural "Update delay: %d seconds"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/PrefsUnifiedDlg.cpp:2358
+#: src/PrefsUnifiedDlg.cpp:2367
 #, c-format
 msgid "Time for average graph: %d minute"
 msgid_plural "Time for average graph: %d minutes"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/PrefsUnifiedDlg.cpp:2367
+#: src/PrefsUnifiedDlg.cpp:2376
 #, c-format
 msgid "Connections Graph Scale: %d"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2382
+#: src/PrefsUnifiedDlg.cpp:2391
 #, c-format
 msgid "File Buffer Size: %d byte"
 msgid_plural "File Buffer Size: %d bytes"
@@ -5957,90 +5957,90 @@ msgstr[0] "Datnes bufera izmērs: %d baiti"
 msgstr[1] "Datnes bufera izmērs: %d baits"
 msgstr[2] "Datnes bufera izmērs: %d baiti"
 
-#: src/PrefsUnifiedDlg.cpp:2392
+#: src/PrefsUnifiedDlg.cpp:2401
 #, c-format
 msgid "Upload Queue Size: %d client"
 msgid_plural "Upload Queue Size: %d clients"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/PrefsUnifiedDlg.cpp:2402
+#: src/PrefsUnifiedDlg.cpp:2411
 #, c-format
 msgid "Server connection refresh interval: %d minute"
 msgid_plural "Server connection refresh interval: %d minutes"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/PrefsUnifiedDlg.cpp:2407
+#: src/PrefsUnifiedDlg.cpp:2416
 msgid "Server connection refresh interval: Disabled"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2451
+#: src/PrefsUnifiedDlg.cpp:2460
 msgid "disabled"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2477
+#: src/PrefsUnifiedDlg.cpp:2486
 #, c-format
 msgid "Execute command on '%s' event"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2484
+#: src/PrefsUnifiedDlg.cpp:2493
 msgid "Enable command execution on core"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2496
+#: src/PrefsUnifiedDlg.cpp:2505
 msgid "Core command:"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2512
+#: src/PrefsUnifiedDlg.cpp:2521
 msgid "Enable command execution on GUI"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2524
+#: src/PrefsUnifiedDlg.cpp:2533
 msgid "GUI command:"
 msgstr "GUI komanda:"
 
-#: src/PrefsUnifiedDlg.cpp:2540
+#: src/PrefsUnifiedDlg.cpp:2549
 msgid "The following variables will be replaced:"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2708
+#: src/PrefsUnifiedDlg.cpp:2717
 msgid ""
 "The following folders look like system or sensitive locations:\n"
 "\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2713
+#: src/PrefsUnifiedDlg.cpp:2722
 msgid "Sharing them recursively will publish every file underneath on the eD2k/Kad networks. Do you really want to do this?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2716
+#: src/PrefsUnifiedDlg.cpp:2725
 msgid "Confirm shared folders"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2744
+#: src/PrefsUnifiedDlg.cpp:2753
 msgid "Reloading shared files..."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2745
+#: src/PrefsUnifiedDlg.cpp:2754
 msgid "Scanning for subdirectories..."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2746
+#: src/PrefsUnifiedDlg.cpp:2755
 msgid "Updating shared folders"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2773
+#: src/PrefsUnifiedDlg.cpp:2782
 #, c-format
 msgid "Scanned %u directories..."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2823
+#: src/PrefsUnifiedDlg.cpp:2832
 #, c-format
 msgid "Reloading shared files: %u files scanned"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2873
+#: src/PrefsUnifiedDlg.cpp:2882
 #, fuzzy
 msgid "Shared folder"
 msgstr "Kopīgotās datnes"
@@ -7677,12 +7677,12 @@ msgstr "Dzēst kategoriju"
 msgid "Hashset requested for unknown file: %s"
 msgstr ""
 
-#: src/UploadQueue.cpp:618
+#: src/UploadQueue.cpp:627
 #, c-format
 msgid "Resuming uploads of file: %s"
 msgstr ""
 
-#: src/UploadQueue.cpp:634
+#: src/UploadQueue.cpp:643
 #, c-format
 msgid "Suspending upload of file: %s"
 msgstr ""

--- a/po/lv.po
+++ b/po/lv.po
@@ -7,8 +7,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-28 12:12+0200\n"
-"PO-Revision-Date: 2026-07-27 10:39+0000\n"
+"POT-Creation-Date: 2026-07-28 08:06+0200\n"
+"PO-Revision-Date: 2026-07-27 11:49+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: none\n"
 "Language: lv\n"
@@ -133,7 +133,7 @@ msgstr "Uzstādīt"
 msgid "Not now"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:422 src/amuleDlg.cpp:665
+#: src/AppImageIntegration.cpp:422 src/amuleDlg.cpp:600
 msgid "Don't ask again"
 msgstr ""
 
@@ -190,83 +190,83 @@ msgstr ""
 msgid "WARNING: You can't add yourself as a source for an eD2k link while having a lowid."
 msgstr ""
 
-#: src/amule.cpp:301
+#: src/amule.cpp:300
 msgid "Now, exiting main app..."
 msgstr "Pašlaik aizver galveno programmu…"
 
-#: src/amule.cpp:331
+#: src/amule.cpp:330
 #, c-format
 msgid "Terminating amuleweb instance with pid '%d' ... "
 msgstr "Pārtrauc amuleweb procesu ar pid '%d' … "
 
-#: src/amule.cpp:335
+#: src/amule.cpp:334
 #, c-format
 msgid "Killing amuleweb instance with pid '%d' ... "
 msgstr "Iznīcina amuleweb procesu ar pid '%d' … "
 
-#: src/amule.cpp:337 src/amule.cpp:350 src/ClientRef.cpp:180
-#: src/SearchDlg.cpp:1041 src/ServerListCtrl.cpp:98
+#: src/amule.cpp:336 src/amule.cpp:349 src/ClientRef.cpp:180
+#: src/SearchDlg.cpp:880 src/ServerListCtrl.cpp:98
 msgid "Failed"
 msgstr "Neizdevās"
 
-#: src/amule.cpp:344
+#: src/amule.cpp:343
 #, fuzzy, c-format
 msgid "Terminating amuleapi instance with pid '%d' ... "
 msgstr "Pārtrauc amuleweb procesu ar pid '%d' ... "
 
-#: src/amule.cpp:348
+#: src/amule.cpp:347
 #, c-format
 msgid "Killing amuleapi instance with pid '%d' ... "
 msgstr "Iznīcina amuleapi procesu ar pid '%d' … "
 
-#: src/amule.cpp:356
+#: src/amule.cpp:355
 msgid "aMule OnExit: Terminating core."
 msgstr ""
 
-#: src/amule.cpp:467
+#: src/amule.cpp:466
 msgid "aMule shutdown completed."
 msgstr ""
 
-#: src/amule.cpp:471
+#: src/amule.cpp:470
 msgid "Memory debug results for aMule exit:"
 msgstr ""
 
-#: src/amule.cpp:652
+#: src/amule.cpp:651
 #, c-format
 msgid "Binding aMule's peer-to-peer traffic to interface: %s (HTTP updates use the default route)"
 msgstr ""
 
-#: src/amule.cpp:656
+#: src/amule.cpp:655
 #, c-format
 msgid "Binding all network traffic to interface: %s"
 msgstr ""
 
-#: src/amule.cpp:660
+#: src/amule.cpp:659
 #, c-format
 msgid "WARNING: configured network interface '%s' was not found - traffic is NOT bound to it and may leave via the default route. Check the interface name in Preferences."
 msgstr ""
 
-#: src/amule.cpp:666
+#: src/amule.cpp:665
 #, c-format
 msgid "WARNING: binding to network interface '%s' requires elevated privileges and was NOT applied - traffic may leave via the default route. Grant the capability (e.g. 'sudo setcap cap_net_raw+ep' on the aMule binary) or run with sufficient privileges."
 msgstr ""
 
-#: src/amule.cpp:674
+#: src/amule.cpp:673
 #, c-format
 msgid "WARNING: could not bind to network interface '%s' - traffic may leave via the default route."
 msgstr ""
 
-#: src/amule.cpp:733
+#: src/amule.cpp:732
 msgid "Your locale has been changed to System Default due to a configuration change. Sorry."
 msgstr ""
 
-#: src/amule.cpp:735 src/amule.cpp:1589 src/CatDialog.cpp:128
+#: src/amule.cpp:734 src/amule.cpp:1581 src/CatDialog.cpp:128
 #: src/CatDialog.cpp:136 src/CatDialog.cpp:149 src/ServerList.cpp:366
 #: src/ServerListCtrl.cpp:152
 msgid "Info"
 msgstr "Informācija"
 
-#: src/amule.cpp:742
+#: src/amule.cpp:741
 msgid ""
 "\n"
 "EC configuration"
@@ -274,71 +274,71 @@ msgstr ""
 "\n"
 "EC iestatījumi"
 
-#: src/amule.cpp:745
+#: src/amule.cpp:744
 msgid "Password set and external connections enabled."
 msgstr ""
 
-#: src/amule.cpp:755 src/KadDlg.cpp:176 src/KadDlg.cpp:185
-#: src/PrefsUnifiedDlg.cpp:1461 src/SharedFilesCtrl.cpp:476
+#: src/amule.cpp:754 src/KadDlg.cpp:176 src/KadDlg.cpp:185
+#: src/PrefsUnifiedDlg.cpp:1387 src/SharedFilesCtrl.cpp:476
 msgid "WARNING"
 msgstr "BRĪDINĀJUMS"
 
-#: src/amule.cpp:992
+#: src/amule.cpp:991
 msgid "Network bootstrap"
 msgstr ""
 
-#: src/amule.cpp:997
+#: src/amule.cpp:996
 msgid ""
 "aMule has detected missing network bootstrap files.\n"
 "Select which ones to download:"
 msgstr ""
 
-#: src/amule.cpp:1006 src/FirstRunWizard.cpp:411
+#: src/amule.cpp:1005 src/FirstRunWizard.cpp:411
 msgid "eD2k server list (server.met)"
 msgstr "eD2k serveru saraksts (server.met)"
 
-#: src/amule.cpp:1013 src/FirstRunWizard.cpp:416
+#: src/amule.cpp:1012 src/FirstRunWizard.cpp:416
 msgid "Kad bootstrap nodes (nodes.dat)"
 msgstr ""
 
-#: src/amule.cpp:1103
+#: src/amule.cpp:1102
 #, c-format
 msgid "web server running on pid %d"
 msgstr ""
 
-#: src/amule.cpp:1116
+#: src/amule.cpp:1115
 msgid "You requested to run web server on startup, but the amuleweb binary cannot be run. Please install the package containing aMule web server, or build aMule from source with -DBUILD_WEBSERVER=YES and install it."
 msgstr "Jūs esiet iespējojuši 'Kad palaiž, palaist arī tīmekļa serveri' iestatījumu, taču amuleweb izpildāmo (bināro) datni nevar palaist. Lūdzu, uzstādiet pakotni, kas satur aMule tīmekļa serveri (amuleweb), vai pārkompilējiet aMule no pirmkoda ar -DBUILD_WEBSERVER=YES parametru un uzstādiet to."
 
-#: src/amule.cpp:1121 src/amule.cpp:1185 src/amule.cpp:1299 src/amule.cpp:1601
+#: src/amule.cpp:1120 src/amule.cpp:1177 src/amule.cpp:1291 src/amule.cpp:1593
 #: src/amule-remote-gui.cpp:603 src/amule-remote-gui.cpp:671
 #: src/amule-remote-gui.cpp:709 src/amule-remote-gui.cpp:1282
 #: src/amule-remote-gui.cpp:1345 src/amule-remote-gui.cpp:1372
-#: src/DownloadQueue.cpp:1481 src/PrefsUnifiedDlg.cpp:1247
+#: src/DownloadQueue.cpp:1481
 msgid "ERROR"
 msgstr "KĻŪDA"
 
-#: src/amule.cpp:1174
+#: src/amule.cpp:1166
 #, c-format
 msgid "amuleapi running on pid %d"
 msgstr ""
 
-#: src/amule.cpp:1180
+#: src/amule.cpp:1172
 #, fuzzy
 msgid "You requested to run amuleapi on startup, but the amuleapi binary cannot be run. Please install the package containing aMule's REST API server, or build aMule from source with -DBUILD_AMULEAPI=YES and install it."
 msgstr "Jūs esiet iespējojuši 'Kad palaiž, palaist arī tīmekļa serveri' iestatījumu, taču amuleweb izpildāmo (bināro) datni nevar palaist. Lūdzu, uzstādiet pakotni, kas satur aMule tīmekļa serveri (amuleweb), vai pārkompilējiet aMule no pirmkoda ar -DBUILD_WEBSERVER=YES parametru un uzstādiet to."
 
-#: src/amule.cpp:1267
+#: src/amule.cpp:1259
 #, c-format
 msgid "Could not bind ports to the specified address: %s"
 msgstr ""
 
-#: src/amule.cpp:1291
+#: src/amule.cpp:1283
 #, c-format
 msgid "Port %u is not available. You will be LOWID\n"
 msgstr ""
 
-#: src/amule.cpp:1296
+#: src/amule.cpp:1288
 #, c-format
 msgid ""
 "Port %u is not available!\n"
@@ -348,184 +348,184 @@ msgid ""
 "Check your network to make sure the port is open for output and input."
 msgstr ""
 
-#: src/amule.cpp:1393
+#: src/amule.cpp:1385
 msgid "Failed to create OnlineSig File"
 msgstr ""
 
-#: src/amule.cpp:1401
+#: src/amule.cpp:1393
 msgid "Failed to create aMule OnlineSig File"
 msgstr ""
 
-#: src/amule.cpp:1564
+#: src/amule.cpp:1556
 msgid "The selected locale seems not to be installed on your box. (Note: I'll try to set it anyway)"
 msgstr ""
 
-#: src/amule.cpp:1574
+#: src/amule.cpp:1566
 #, c-format
 msgid "This is the first time you run aMule %s"
 msgstr "Šī ir pirmā reize, kad aMule %s palaista"
 
-#: src/amule.cpp:1577
+#: src/amule.cpp:1569
 msgid "This version is a testing version, updated daily, and\n"
 msgstr "Šī ir ikdienas (atjaunina katru dienu) testa versija, tāpēc\n"
 
-#: src/amule.cpp:1578
+#: src/amule.cpp:1570
 msgid "we give no warranty it won't break anything, burn your house,\n"
 msgstr "mēs negarantējam, ka tā neko nesabojās, nenodedzinās jūsu māju\n"
 
-#: src/amule.cpp:1579
+#: src/amule.cpp:1571
 msgid "or kill your dog. But it *should* be safe to use anyway.\n"
 msgstr "vai nenogalinās jūsu suni. Bet tā jebkurā gadījumā *vajadzētu* būt droša lietošanā.\n"
 
-#: src/amule.cpp:1584
+#: src/amule.cpp:1576
 msgid "More information, support and new releases can found at our homepage,\n"
 msgstr "Plašāka informācija, atbalsts un jaunās versijas ir pieejamas mūsu vietnē\n"
 
-#: src/amule.cpp:1585
+#: src/amule.cpp:1577
 msgid "at https://amule-org.github.io, or in our IRC channel #aMule at irc.libera.chat.\n"
 msgstr "https://amule-org.github.io vai mūsu IRC kanālā #aMule vietnē irc.libera.chat.\n"
 
-#: src/amule.cpp:1587
+#: src/amule.cpp:1579
 msgid "Feel free to report any bugs to https://github.com/amule-org/amule/issues"
 msgstr "Nekautrējieties ziņot par problēmām https://github.com/amule-org/amule/issues vietnē"
 
-#: src/amule.cpp:1599
+#: src/amule.cpp:1591
 msgid ""
 "The folder for Online Signature files you specified is INVALID!\n"
 " OnlineSignature will be DISABLED until you fix it on preferences."
 msgstr ""
 
-#: src/amule.cpp:1662
+#: src/amule.cpp:1654
 msgid "Server hostname notified"
 msgstr ""
 
-#: src/amule.cpp:2039
+#: src/amule.cpp:2031
 #, c-format
 msgid "Disk space preallocation for file '%s' failed: %s"
 msgstr ""
 
-#: src/amule.cpp:2168
+#: src/amule.cpp:2160
 msgid "ERROR: can't open logfile"
 msgstr "KĻŪDA: nevar atvērt žurnāldatni"
 
-#: src/amule.cpp:2172
+#: src/amule.cpp:2164
 msgid "WARNING: logfile is empty. Something is wrong."
 msgstr "BRĪDINĀJUMS: žurnāldatne ir tukša. Te kaut kas nav kā vajag :-(."
 
-#: src/amule.cpp:2189
+#: src/amule.cpp:2181
 msgid "Log has been reset"
 msgstr ""
 
-#: src/amule.cpp:2213
+#: src/amule.cpp:2205
 #, c-format
 msgid "ServerMessage: %s"
 msgstr "Servera ziņojums: %s"
 
-#: src/amule.cpp:2256 src/IP2Country.cpp:220 src/IPFilter.cpp:514
+#: src/amule.cpp:2248 src/IP2Country.cpp:220 src/IPFilter.cpp:514
 #: src/ServerList.cpp:875
 #, c-format
 msgid "Skipped download of %s, because requested file is not newer."
 msgstr ""
 
-#: src/amule.cpp:2259
+#: src/amule.cpp:2251
 msgid "Failed to download the nodes list."
 msgstr ""
 
-#: src/amule.cpp:2322
+#: src/amule.cpp:2314
 msgid "Failed to open the downloaded version check file"
 msgstr ""
 
-#: src/amule.cpp:2325 src/amule.cpp:2344
+#: src/amule.cpp:2317 src/amule.cpp:2336
 msgid "Corrupted version check file"
 msgstr ""
 
-#: src/amule.cpp:2367
+#: src/amule.cpp:2359
 msgid "You are using an outdated version of aMule!"
 msgstr "Jūs izmantojiet novecojušu aMule versiju!"
 
-#: src/amule.cpp:2369
+#: src/amule.cpp:2361
 #, c-format
 msgid "Your aMule version is %i.%i.%i and the latest version is %li.%li.%li"
 msgstr "Jūsu aMule versija — %i.%i.%i un jaunākā versija — %li.%li.%li"
 
-#: src/amule.cpp:2373
+#: src/amule.cpp:2365
 msgid "The latest version can always be found at https://github.com/amule-org/amule/releases/latest"
 msgstr "Jaunāko aMule versiju vienmēr var iegūt https://github.com/amule-org/amule/releases/latest vietnē"
 
-#: src/amule.cpp:2376
+#: src/amule.cpp:2368
 #, c-format
 msgid "WARNING: Your aMuled version is outdated: %i.%i.%i < %li.%li.%li"
 msgstr "BRĪDINĀJUMS: Jūsu aMule versija ir novecojusi: %i.%i.%i < %li.%li.%li"
 
-#: src/amule.cpp:2382
+#: src/amule.cpp:2374
 msgid "Your copy of aMule is up to date."
 msgstr "Šī ir jaunākā aMule versija."
 
-#: src/amule.cpp:2389
+#: src/amule.cpp:2381
 msgid "Failed to download the version check file"
 msgstr "Neizdevās lejupielādēt versijas pārbaudes datni"
 
-#: src/amule.cpp:2558 src/amule-remote-gui.cpp:1133
+#: src/amule.cpp:2550 src/amule-remote-gui.cpp:1133
 #, c-format
 msgid "Users: %s | Files: %s"
 msgstr "Lietotāji: %s | Datnes: %s"
 
-#: src/amule.cpp:2559 src/amule-remote-gui.cpp:1134
+#: src/amule.cpp:2551 src/amule-remote-gui.cpp:1134
 #, c-format
 msgid "Users: E: %s K: %s | Files: E: %s K: %s"
 msgstr "Lietotāji: E: %s K: %s | Datnes: E: %s K: %s"
 
-#: src/amule.cpp:2573 src/amule-remote-gui.cpp:1147
+#: src/amule.cpp:2565 src/amule-remote-gui.cpp:1147
 msgid "No networks selected"
 msgstr ""
 
-#: src/amule.cpp:2641 src/TextClient.cpp:903
+#: src/amule.cpp:2633 src/TextClient.cpp:903
 msgid "with LowID"
 msgstr "ar zemu ID"
 
-#: src/amule.cpp:2641 src/TextClient.cpp:904
+#: src/amule.cpp:2633 src/TextClient.cpp:904
 msgid "with HighID"
 msgstr "ar augstu ID"
 
-#: src/amule.cpp:2643
+#: src/amule.cpp:2635
 #, c-format
 msgid "Connected to %s %s"
 msgstr "Pieslēgts %s %s"
 
-#: src/amule.cpp:2648
+#: src/amule.cpp:2640
 #, c-format
 msgid "Connecting to %s"
 msgstr "Pieslēdzas %s"
 
-#: src/amule.cpp:2650
+#: src/amule.cpp:2642
 msgid "Disconnected from eD2k"
 msgstr "Atslēgts no eD2k"
 
-#: src/amule.cpp:2659
+#: src/amule.cpp:2651
 msgid "Kad started."
 msgstr ""
 
-#: src/amule.cpp:2661
+#: src/amule.cpp:2653
 msgid "Kad stopped."
 msgstr ""
 
-#: src/amule.cpp:2669
+#: src/amule.cpp:2661
 msgid "Connected to Kad (ok)"
 msgstr "Pieslēgts Kad (veiksmīgi)"
 
-#: src/amule.cpp:2671
+#: src/amule.cpp:2663
 msgid "Connected to Kad (firewalled)"
 msgstr "Pieslēgts Kad (aiz ugunsmūra)"
 
-#: src/amule.cpp:2675
+#: src/amule.cpp:2667
 msgid "Disconnected from Kad"
 msgstr "Atslēgts no Kad"
 
-#: src/amule.cpp:2707
+#: src/amule.cpp:2699
 msgid "Kad network cannot be used if UDP port is disabled on preferences, not starting."
 msgstr ""
 
-#: src/amule.cpp:2711
+#: src/amule.cpp:2703
 msgid "Kad network disabled on preferences, not connecting."
 msgstr "Kad tīkls ir atspējots iestatījumos, nepieslēdzas tīklam."
 
@@ -550,67 +550,29 @@ msgstr ""
 msgid "ERROR: %s"
 msgstr "KĻŪDA: %s"
 
-#: src/amuleDlg.cpp:250
+#: src/amuleDlg.cpp:236
 #, c-format
 msgid "This is aMule %s based on eMule."
 msgstr ""
 
-#: src/amuleDlg.cpp:251
+#: src/amuleDlg.cpp:237
 #, c-format
 msgid "Running on %s"
 msgstr ""
 
-#: src/amuleDlg.cpp:253
+#: src/amuleDlg.cpp:239
 msgid "Visit https://github.com/amule-org/amule/releases/latest to check if a new version is available."
 msgstr "Apmeklējiet https://github.com/amule-org/amule/releases/latest vietni, lai pārbaudītu, vai nav pieejama jauna versija."
 
-#: src/amuleDlg.cpp:282
+#: src/amuleDlg.cpp:268
 msgid "FATAL ERROR: Failed to create Timer"
 msgstr ""
 
-#: src/amuleDlg.cpp:361 src/amuleDlg.cpp:1810 src/amuleDlg.cpp:2056
-#: src/muuli_wdr.cpp:1492 src/muuli_wdr.cpp:3439
-msgid "Networks"
-msgstr "Tīkli"
-
-#: src/amuleDlg.cpp:362 src/amuleDlg.cpp:1816 src/muuli_wdr.cpp:3440
-msgid "Searches"
-msgstr ""
-
-#: src/amuleDlg.cpp:363 src/amuleDlg.cpp:1822 src/DownloadListCtrl.cpp:740
-#: src/muuli_wdr.cpp:392 src/muuli_wdr.cpp:1585 src/muuli_wdr.cpp:3441
-#: src/Statistics.cpp:829
-msgid "Downloads"
-msgstr "Lejupielādes"
-
-#: src/amuleDlg.cpp:364 src/amuleDlg.cpp:1828 src/muuli_wdr.cpp:3315
-msgid "Shared files"
-msgstr "Kopīgotās datnes"
-
-#: src/amuleDlg.cpp:365 src/amuleDlg.cpp:1834 src/muuli_wdr.cpp:2947
-#: src/muuli_wdr.cpp:3397 src/muuli_wdr.cpp:3444
-msgid "Messages"
-msgstr "Ziņojumi"
-
-#: src/amuleDlg.cpp:366 src/amuleDlg.cpp:1840 src/muuli_wdr.cpp:3445
-#: src/PrefsUnifiedDlg.cpp:314 src/Statistics.cpp:779 src/Statistics.cpp:1235
-msgid "Statistics"
-msgstr "Statistika"
-
-#: src/amuleDlg.cpp:368 src/amuleDlg.cpp:1847 src/muuli_wdr.cpp:3447
-#: src/PrefsUnifiedDlg.cpp:330 src/utils/wxCas/src/wxcasprefs.cpp:39
-msgid "Preferences"
-msgstr "Iestatījumi"
-
-#: src/amuleDlg.cpp:371
-msgid "Navigate"
-msgstr ""
-
-#: src/amuleDlg.cpp:657
+#: src/amuleDlg.cpp:592
 msgid "New version available"
 msgstr "Pieejama jauna versija"
 
-#: src/amuleDlg.cpp:661
+#: src/amuleDlg.cpp:596
 #, c-format
 msgid ""
 "A new version of aMule (%s) is available.\n"
@@ -625,184 +587,217 @@ msgstr ""
 "\n"
 "Vai vēlaties atvērt lejupielādes lapu?"
 
-#: src/amuleDlg.cpp:743
+#: src/amuleDlg.cpp:678
 msgid "aMule dialog destroyed"
 msgstr ""
 
-#: src/amuleDlg.cpp:766 src/DataToText.cpp:68 src/IPFilter.cpp:547
+#: src/amuleDlg.cpp:701 src/DataToText.cpp:68 src/IPFilter.cpp:547
 msgid "Connecting"
 msgstr "Pieslēdzas"
 
-#: src/amuleDlg.cpp:958
+#: src/amuleDlg.cpp:893
 msgid "eD2k: Connecting"
 msgstr "eD2k: Pieslēdzas"
 
-#: src/amuleDlg.cpp:962
+#: src/amuleDlg.cpp:897
 msgid "eD2k: Disconnected"
 msgstr "eD2k: Atslēgts"
 
-#: src/amuleDlg.cpp:968
+#: src/amuleDlg.cpp:903
 msgid "Kad: Firewalled"
 msgstr "Kad: Aiz ugunsmūra"
 
-#: src/amuleDlg.cpp:972
+#: src/amuleDlg.cpp:907
 msgid "Kad: Connected"
 msgstr "Kad: Pieslēgts"
 
-#: src/amuleDlg.cpp:977
+#: src/amuleDlg.cpp:912
 msgid "Kad: Connecting"
 msgstr "Kad: Pieslēdzas"
 
-#: src/amuleDlg.cpp:981
+#: src/amuleDlg.cpp:916
 msgid "Kad: Off"
 msgstr "Kad: Izslēgts"
 
-#: src/amuleDlg.cpp:1029 src/DownloadListCtrl.cpp:505
+#: src/amuleDlg.cpp:964 src/DownloadListCtrl.cpp:505
 #: src/DownloadListCtrl.cpp:749 src/FriendListCtrl.cpp:180
 #: src/muuli_wdr.cpp:731 src/muuli_wdr.cpp:782 src/muuli_wdr.cpp:846
-#: src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2252 src/muuli_wdr.cpp:2337
-#: src/muuli_wdr.cpp:3085 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
+#: src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2224 src/muuli_wdr.cpp:2309
+#: src/muuli_wdr.cpp:3057 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
 #: src/ServerListCtrl.cpp:606 src/TransferWnd.cpp:378
 #: src/utils/wxCas/src/wxcasprefs.cpp:235
 msgid "Cancel"
 msgstr "Atcelt"
 
-#: src/amuleDlg.cpp:1030
+#: src/amuleDlg.cpp:965
 msgid "Stop the current connection attempts"
 msgstr ""
 
-#: src/amuleDlg.cpp:1035 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976
-#: src/muuli_wdr.cpp:2475
+#: src/amuleDlg.cpp:970 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976
+#: src/muuli_wdr.cpp:2447
 msgid "Disconnect"
 msgstr "Atslēgties"
 
-#: src/amuleDlg.cpp:1036
+#: src/amuleDlg.cpp:971
 msgid "Disconnect from the currently connected networks"
 msgstr "Atslēgties no tīkliem, kuriem pašlaik esiet pieslēdzies"
 
-#: src/amuleDlg.cpp:1041 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979
-#: src/muuli_wdr.cpp:2630 src/muuli_wdr.cpp:3082 src/muuli_wdr.cpp:3437
+#: src/amuleDlg.cpp:976 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979
+#: src/muuli_wdr.cpp:2602 src/muuli_wdr.cpp:3054 src/muuli_wdr.cpp:3409
 msgid "Connect"
 msgstr "Pieslēgties"
 
-#: src/amuleDlg.cpp:1042
+#: src/amuleDlg.cpp:977
 msgid "Connect to the currently enabled networks"
 msgstr "Pieslēgties pašlaik iespējotajiem tīkliem"
 
-#: src/amuleDlg.cpp:1154
+#: src/amuleDlg.cpp:1089
 #, c-format
 msgid "Up: %.1f%s (%.1f) | Down: %.1f%s (%.1f)"
 msgstr "↑Augšup.: %.1f%s (%.1f) | ↓Lejup.: %.1f%s (%.1f)"
 
-#: src/amuleDlg.cpp:1156 src/amuleDlg.cpp:1158 src/amuleDlg.cpp:1162
-#: src/amuleDlg.cpp:1164 src/amuleDlg.cpp:1175 src/amuleDlg.cpp:1177
+#: src/amuleDlg.cpp:1091 src/amuleDlg.cpp:1093 src/amuleDlg.cpp:1097
+#: src/amuleDlg.cpp:1099 src/amuleDlg.cpp:1110 src/amuleDlg.cpp:1112
 #: src/MuleTrayIcon.cpp:796 src/MuleTrayIcon.cpp:799
 msgid " MB/s"
 msgstr " MB/s"
 
-#: src/amuleDlg.cpp:1156 src/amuleDlg.cpp:1158 src/amuleDlg.cpp:1162
-#: src/amuleDlg.cpp:1164 src/amuleDlg.cpp:1175 src/amuleDlg.cpp:1177
+#: src/amuleDlg.cpp:1091 src/amuleDlg.cpp:1093 src/amuleDlg.cpp:1097
+#: src/amuleDlg.cpp:1099 src/amuleDlg.cpp:1110 src/amuleDlg.cpp:1112
 #: src/MuleTrayIcon.cpp:796 src/MuleTrayIcon.cpp:799
 #: src/utils/wxCas/src/wxcasframe.cpp:1041
 msgid " kB/s"
 msgstr " kB/s"
 
-#: src/amuleDlg.cpp:1161
+#: src/amuleDlg.cpp:1096
 #, c-format
 msgid "Up: %.1f%s | Down: %.1f%s"
 msgstr "↑Augšup.: %.1f%s | ↓Lejup.: %.1f%s"
 
-#: src/amuleDlg.cpp:1193
+#: src/amuleDlg.cpp:1128
 #, c-format
 msgid "aMule (%s | Connected)"
 msgstr "aMule (%s | Pieslēgts)"
 
-#: src/amuleDlg.cpp:1195
+#: src/amuleDlg.cpp:1130
 #, c-format
 msgid "aMule (%s | Disconnected)"
 msgstr "aMule (%s | Atslēgts)"
 
-#: src/amuleDlg.cpp:1248
+#: src/amuleDlg.cpp:1183
 #, c-format
 msgid "Do you really want to exit %s?"
 msgstr "Vai tiešām vēlaties aizvērt %s?"
 
-#: src/amuleDlg.cpp:1250
+#: src/amuleDlg.cpp:1185
 msgid "Exit confirmation"
 msgstr ""
 
-#: src/amuleDlg.cpp:1613
+#: src/amuleDlg.cpp:1548
 msgid "Launch Command: "
 msgstr ""
 
-#: src/amuleDlg.cpp:1632 src/muuli_wdr.cpp:1972 src/Preferences.cpp:979
+#: src/amuleDlg.cpp:1567 src/muuli_wdr.cpp:1971 src/Preferences.cpp:951
 msgid "- default -"
 msgstr ""
 
-#: src/amuleDlg.cpp:1660
+#: src/amuleDlg.cpp:1595
 #, c-format
 msgid "Skin directory '%s' does not exist"
 msgstr ""
 
-#: src/amuleDlg.cpp:1663
+#: src/amuleDlg.cpp:1598
 #, c-format
 msgid "WARNING: Unable to open skin file '%s' for read"
 msgstr ""
 
-#: src/amuleDlg.cpp:1814 src/muuli_wdr.cpp:3439
+#: src/amuleDlg.cpp:1722 src/amuleDlg.cpp:1968 src/muuli_wdr.cpp:1485
+#: src/muuli_wdr.cpp:3411
+msgid "Networks"
+msgstr "Tīkli"
+
+#: src/amuleDlg.cpp:1726 src/muuli_wdr.cpp:3411
 msgid "Networks Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1820 src/muuli_wdr.cpp:3440
+#: src/amuleDlg.cpp:1728 src/muuli_wdr.cpp:3412
+msgid "Searches"
+msgstr ""
+
+#: src/amuleDlg.cpp:1732 src/muuli_wdr.cpp:3412
 msgid "Searches Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1826 src/muuli_wdr.cpp:3441
+#: src/amuleDlg.cpp:1734 src/DownloadListCtrl.cpp:740 src/muuli_wdr.cpp:392
+#: src/muuli_wdr.cpp:1578 src/muuli_wdr.cpp:3413 src/Statistics.cpp:829
+msgid "Downloads"
+msgstr "Lejupielādes"
+
+#: src/amuleDlg.cpp:1738 src/muuli_wdr.cpp:3413
 msgid "Downloads Window"
 msgstr "Lejupielādes logs"
 
-#: src/amuleDlg.cpp:1832 src/muuli_wdr.cpp:3443
+#: src/amuleDlg.cpp:1740 src/muuli_wdr.cpp:3287
+msgid "Shared files"
+msgstr "Kopīgotās datnes"
+
+#: src/amuleDlg.cpp:1744 src/muuli_wdr.cpp:3415
 msgid "Shared Files Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3444
+#: src/amuleDlg.cpp:1746 src/muuli_wdr.cpp:2919 src/muuli_wdr.cpp:3369
+#: src/muuli_wdr.cpp:3416
+msgid "Messages"
+msgstr "Ziņojumi"
+
+#: src/amuleDlg.cpp:1750 src/muuli_wdr.cpp:3416
 msgid "Messages Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1844 src/muuli_wdr.cpp:3445
+#: src/amuleDlg.cpp:1752 src/muuli_wdr.cpp:3417 src/PrefsUnifiedDlg.cpp:312
+#: src/Statistics.cpp:779 src/Statistics.cpp:1235
+msgid "Statistics"
+msgstr "Statistika"
+
+#: src/amuleDlg.cpp:1756 src/muuli_wdr.cpp:3417
 msgid "Statistics Graph Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1851 src/muuli_wdr.cpp:3447
+#: src/amuleDlg.cpp:1759 src/muuli_wdr.cpp:3419 src/PrefsUnifiedDlg.cpp:328
+#: src/utils/wxCas/src/wxcasprefs.cpp:39
+msgid "Preferences"
+msgstr "Iestatījumi"
+
+#: src/amuleDlg.cpp:1763 src/muuli_wdr.cpp:3419
 msgid "Preferences Settings Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1854 src/muuli_wdr.cpp:3448
+#: src/amuleDlg.cpp:1766 src/muuli_wdr.cpp:3420
 msgid "Import"
 msgstr ""
 
-#: src/amuleDlg.cpp:1858 src/muuli_wdr.cpp:3448
+#: src/amuleDlg.cpp:1770 src/muuli_wdr.cpp:3420
 msgid "The partfile importer tool"
 msgstr ""
 
-#: src/amuleDlg.cpp:1861 src/muuli_wdr.cpp:3449
+#: src/amuleDlg.cpp:1773 src/muuli_wdr.cpp:3421
 #: src/utils/aLinkCreator/src/alcframe.cpp:262
 msgid "About"
 msgstr "Par programmu"
 
-#: src/amuleDlg.cpp:1861 src/muuli_wdr.cpp:3449
+#: src/amuleDlg.cpp:1773 src/muuli_wdr.cpp:3421
 msgid "About/Help"
 msgstr "Par programmu/Palīdzība"
 
-#: src/amuleDlg.cpp:2059
+#: src/amuleDlg.cpp:1971
 msgid "eD2k network"
 msgstr "eD2k tīkls"
 
-#: src/amuleDlg.cpp:2062
+#: src/amuleDlg.cpp:1974
 msgid "Kad network"
 msgstr "Kad tīkls"
 
-#: src/amuleDlg.cpp:2062
+#: src/amuleDlg.cpp:1974
 msgid "No network"
 msgstr ""
 
@@ -928,7 +923,7 @@ msgstr ""
 msgid "The core rejected these shared folders:%s"
 msgstr ""
 
-#: src/amule-remote-gui.cpp:1336 src/ExternalConn.cpp:2346
+#: src/amule-remote-gui.cpp:1336 src/ExternalConn.cpp:2345
 msgid "Invalid link or already on list."
 msgstr "Nederīga saite vai jau ir sarakstā."
 
@@ -944,7 +939,7 @@ msgstr "Nevar izveidot '%s' mapi '%s' kategorijai, turpinam izmantot '%s' mapi."
 #: src/ClientDetailDialog.cpp:123 src/DataToText.cpp:61 src/DataToText.cpp:86
 #: src/DataToText.cpp:101 src/DataToText.cpp:136 src/DataToText.cpp:165
 #: src/DownloadListCtrl.cpp:1172 src/DownloadListCtrl.cpp:1185
-#: src/DownloadListCtrl.cpp:1196 src/ExternalConn.cpp:609
+#: src/DownloadListCtrl.cpp:1196 src/ExternalConn.cpp:608
 #: src/FileDetailDialog.cpp:203 src/FileDetailDialog.cpp:235
 #: src/FileDetailDialog.cpp:242 src/GenericClientListCtrl.cpp:1171
 #: src/GenericClientListCtrl.cpp:1182 src/GenericClientListCtrl.cpp:1192
@@ -1331,19 +1326,19 @@ msgstr ""
 msgid "Very low"
 msgstr ""
 
-#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:743 src/muuli_wdr.cpp:2303
+#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:743 src/muuli_wdr.cpp:2275
 #: src/ServerListCtrl.cpp:263 src/ServerListCtrl.cpp:456
 #: src/SharedFilesCtrl.cpp:145
 msgid "Low"
 msgstr ""
 
-#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:744 src/muuli_wdr.cpp:2304
+#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:744 src/muuli_wdr.cpp:2276
 #: src/ServerListCtrl.cpp:266 src/ServerListCtrl.cpp:457
 #: src/SharedFilesCtrl.cpp:146
 msgid "Normal"
 msgstr ""
 
-#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:745 src/muuli_wdr.cpp:2305
+#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:745 src/muuli_wdr.cpp:2277
 #: src/ServerListCtrl.cpp:269 src/ServerListCtrl.cpp:458
 #: src/SharedFilesCtrl.cpp:147
 msgid "High"
@@ -1435,8 +1430,8 @@ msgstr ""
 msgid "Remote Server"
 msgstr ""
 
-#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3202
-#: src/SearchDlg.cpp:119 src/TextClient.cpp:911
+#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3174
+#: src/SearchDlg.cpp:111 src/TextClient.cpp:911
 msgid "Kad"
 msgstr "Kad"
 
@@ -1506,7 +1501,7 @@ msgstr "Daļa"
 msgid "Size"
 msgstr "Izmērs"
 
-#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3269
+#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3241
 msgid "Transferred"
 msgstr "Pārsūtīti"
 
@@ -1562,7 +1557,7 @@ msgid ""
 "\n"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:746 src/muuli_wdr.cpp:2306
+#: src/DownloadListCtrl.cpp:746 src/muuli_wdr.cpp:2278
 #: src/SharedFilesCtrl.cpp:150
 msgid "Auto"
 msgstr ""
@@ -1600,7 +1595,7 @@ msgid "Extended Options"
 msgstr ""
 
 #: src/DownloadListCtrl.cpp:770 src/DownloadListCtrl.cpp:822
-#: src/muuli_wdr.cpp:1790
+#: src/muuli_wdr.cpp:1789
 msgid "Preview"
 msgstr "Priekšskatījums"
 
@@ -1773,230 +1768,225 @@ msgstr[1] ""
 msgid "Invalid eD2k link! ERROR: %s"
 msgstr "Nederīga eD2k saite! KĻŪDA: %s"
 
-#: src/ExternalConn.cpp:380
+#: src/ExternalConn.cpp:379
 msgid "Client sent packet after authentication failed."
 msgstr ""
 
-#: src/ExternalConn.cpp:397
+#: src/ExternalConn.cpp:396
 msgid "External connection closed."
 msgstr ""
 
-#: src/ExternalConn.cpp:474
+#: src/ExternalConn.cpp:473
 msgid "External connections disabled due to empty password!"
 msgstr ""
 
-#: src/ExternalConn.cpp:495
+#: src/ExternalConn.cpp:494
 msgid "External connections disabled in config file"
 msgstr ""
 
-#: src/ExternalConn.cpp:576
+#: src/ExternalConn.cpp:575
 msgid "New external connection accepted"
 msgstr ""
 
-#: src/ExternalConn.cpp:579
+#: src/ExternalConn.cpp:578
 msgid "ERROR: couldn't accept a new external connection"
 msgstr ""
 
-#: src/ExternalConn.cpp:596
+#: src/ExternalConn.cpp:595
 msgid "External connection refused due to empty password in preferences!"
 msgstr ""
 
-#: src/ExternalConn.cpp:608
+#: src/ExternalConn.cpp:607
 #, c-format
 msgid "Connecting client: %s %s"
 msgstr "Pieslēdzas klientam: %s %s"
 
-#: src/ExternalConn.cpp:610
+#: src/ExternalConn.cpp:609
 msgid "Unknown version"
 msgstr "Nezināma versija"
 
-#: src/ExternalConn.cpp:623
+#: src/ExternalConn.cpp:622
 msgid "Incorrect EC version ID, there might be binary incompatibility. Use core and remote from same snapshot."
 msgstr ""
 
-#: src/ExternalConn.cpp:631
+#: src/ExternalConn.cpp:630
 msgid "You cannot connect to a release version from an arbitrary development snapshot! *sigh* possible crash prevented"
 msgstr ""
 
-#: src/ExternalConn.cpp:714
+#: src/ExternalConn.cpp:713
 msgid "Invalid protocol version."
 msgstr "Nederīga protokola versija."
 
-#: src/ExternalConn.cpp:720
+#: src/ExternalConn.cpp:719
 msgid "Missing protocol version tag."
 msgstr "Trūkst protokola versijas birka."
 
-#: src/ExternalConn.cpp:728
+#: src/ExternalConn.cpp:727
 msgid "Authentication failed: invalid hash specified as EC password."
 msgstr ""
 
-#: src/ExternalConn.cpp:776
+#: src/ExternalConn.cpp:775
 msgid "Authentication failed: wrong password."
 msgstr ""
 
-#: src/ExternalConn.cpp:778
+#: src/ExternalConn.cpp:777
 msgid "Authentication failed: missing password."
 msgstr ""
 
-#: src/ExternalConn.cpp:789
+#: src/ExternalConn.cpp:788
 msgid "Invalid request, please authenticate first."
 msgstr ""
 
-#: src/ExternalConn.cpp:794
+#: src/ExternalConn.cpp:793
 msgid "Access granted."
 msgstr ""
 
-#: src/ExternalConn.cpp:802
+#: src/ExternalConn.cpp:801
 #, c-format
 msgid "Sent error message \"%s\" to client."
 msgstr ""
 
-#: src/ExternalConn.cpp:807
+#: src/ExternalConn.cpp:806
 #, c-format
 msgid "Unauthorized access attempt from %s. Connection closed."
 msgstr ""
 
-#: src/ExternalConn.cpp:1420
+#: src/ExternalConn.cpp:1419
 #, c-format
 msgid "Remote PartFile command failed: FileHash not found: %s"
 msgstr ""
 
-#: src/ExternalConn.cpp:1424
+#: src/ExternalConn.cpp:1423
 #, c-format
 msgid "FileHash not found: %s"
 msgstr ""
 
-#: src/ExternalConn.cpp:1471 src/ExternalConn.cpp:1559
-#: src/ExternalConn.cpp:1680
+#: src/ExternalConn.cpp:1470 src/ExternalConn.cpp:1558
+#: src/ExternalConn.cpp:1679
 msgid "OOPS! OpCode processing error!"
 msgstr ""
 
-#: src/ExternalConn.cpp:1502
+#: src/ExternalConn.cpp:1501
 msgid "Server not added"
 msgstr ""
 
-#: src/ExternalConn.cpp:1521
+#: src/ExternalConn.cpp:1520
 #, c-format
 msgid "server not found: %s"
 msgstr ""
 
-#: src/ExternalConn.cpp:1538
+#: src/ExternalConn.cpp:1537
 msgid "need to define server to be removed"
 msgstr ""
 
-#: src/ExternalConn.cpp:1553
+#: src/ExternalConn.cpp:1552
 msgid "eD2k is disabled in preferences."
 msgstr ""
 
-#: src/ExternalConn.cpp:1658
+#: src/ExternalConn.cpp:1657
 msgid "Friend not found."
 msgstr ""
 
-#: src/ExternalConn.cpp:1668
+#: src/ExternalConn.cpp:1667
 msgid "Client not found."
 msgstr ""
 
-#: src/ExternalConn.cpp:1674
+#: src/ExternalConn.cpp:1673
 msgid "EC_TAG_FRIEND_SHARED requires EC_TAG_FRIEND or EC_TAG_CLIENT."
 msgstr ""
 
-#: src/ExternalConn.cpp:1992
+#: src/ExternalConn.cpp:1991
 msgid "WebSearch from remote interface makes no sense."
 msgstr ""
 
-#: src/ExternalConn.cpp:2027
+#: src/ExternalConn.cpp:2026
 msgid "Search in progress. Refetch results in a moment!"
 msgstr ""
 
-#: src/ExternalConn.cpp:2266
+#: src/ExternalConn.cpp:2265
 msgid "No points for graph."
 msgstr ""
 
-#: src/ExternalConn.cpp:2276
+#: src/ExternalConn.cpp:2275
 msgid "Your client is not configured for this detail level."
 msgstr ""
 
-#: src/ExternalConn.cpp:2303
+#: src/ExternalConn.cpp:2302
 msgid "External Connection: shutdown requested"
 msgstr ""
 
-#: src/ExternalConn.cpp:2315
+#: src/ExternalConn.cpp:2314
 msgid "Already shutting down."
 msgstr ""
 
-#: src/ExternalConn.cpp:2333
+#: src/ExternalConn.cpp:2332
 #, c-format
 msgid "ExternalConn: adding link '%s'."
 msgstr ""
 
-#: src/ExternalConn.cpp:2351
+#: src/ExternalConn.cpp:2350
 #, c-format
 msgid "%d of %d links failed (invalid or already on list)."
 msgstr ""
 
-#: src/ExternalConn.cpp:2374
+#: src/ExternalConn.cpp:2373
 msgid "Version check throttled; try again shortly."
 msgstr ""
 
-#: src/ExternalConn.cpp:2379
+#: src/ExternalConn.cpp:2378
 msgid "Version check is not available on this daemon."
 msgstr ""
 
-#: src/ExternalConn.cpp:2509
+#: src/ExternalConn.cpp:2508
 msgid "File not found."
 msgstr ""
 
-#: src/ExternalConn.cpp:2514
+#: src/ExternalConn.cpp:2513
 msgid "Invalid file name."
 msgstr ""
 
-#: src/ExternalConn.cpp:2522
+#: src/ExternalConn.cpp:2521
 msgid "Unable to rename file."
 msgstr ""
 
-#: src/ExternalConn.cpp:2839
-#, c-format
-msgid "Could not save the amuleapi password: %s"
-msgstr ""
-
-#: src/ExternalConn.cpp:3004 src/ExternalConn.cpp:3032
+#: src/ExternalConn.cpp:2992 src/ExternalConn.cpp:3020
 msgid "Kad is disabled in preferences."
 msgstr ""
 
-#: src/ExternalConn.cpp:3045
+#: src/ExternalConn.cpp:3033
 msgid "Already connected to eD2k."
 msgstr "Jau pieslēgts eD2k tīklam."
 
-#: src/ExternalConn.cpp:3048
+#: src/ExternalConn.cpp:3036
 msgid "Connecting to eD2k..."
 msgstr "Pieslēdzas eD2k…"
 
-#: src/ExternalConn.cpp:3057
+#: src/ExternalConn.cpp:3045
 msgid "Already connected to Kad."
 msgstr "Jau pieslēgts Kad tīklam."
 
-#: src/ExternalConn.cpp:3060
+#: src/ExternalConn.cpp:3048
 msgid "Connecting to Kad..."
 msgstr "Pieslēdzas Kad…"
 
-#: src/ExternalConn.cpp:3067
+#: src/ExternalConn.cpp:3055
 msgid "All networks are disabled."
 msgstr ""
 
-#: src/ExternalConn.cpp:3076
+#: src/ExternalConn.cpp:3064
 msgid "Disconnected from eD2k."
 msgstr "Atslēgts no eD2k."
 
-#: src/ExternalConn.cpp:3081
+#: src/ExternalConn.cpp:3069
 msgid "Disconnected from Kad."
 msgstr "Atslēgts no Kad."
 
-#: src/ExternalConn.cpp:3090
+#: src/ExternalConn.cpp:3078
 #, c-format
 msgid "External Connection: invalid opcode received: %#x"
 msgstr ""
 
-#: src/ExternalConn.cpp:3095
+#: src/ExternalConn.cpp:3083
 msgid "Invalid opcode (wrong protocol version?)"
 msgstr ""
 
@@ -2286,19 +2276,19 @@ msgstr ""
 msgid "eD2k"
 msgstr "eD2k"
 
-#: src/FirstRunWizard.cpp:349 src/muuli_wdr.cpp:1495
+#: src/FirstRunWizard.cpp:349 src/muuli_wdr.cpp:1488
 msgid "Kademlia"
 msgstr "Kademlia"
 
-#: src/FirstRunWizard.cpp:359 src/muuli_wdr.cpp:1423
+#: src/FirstRunWizard.cpp:359 src/muuli_wdr.cpp:1416
 msgid "Standard TCP Port "
 msgstr ""
 
-#: src/FirstRunWizard.cpp:365 src/muuli_wdr.cpp:1435
+#: src/FirstRunWizard.cpp:365 src/muuli_wdr.cpp:1428
 msgid "Extended UDP port (Kad / global search) "
 msgstr ""
 
-#: src/FirstRunWizard.cpp:377 src/muuli_wdr.cpp:1442
+#: src/FirstRunWizard.cpp:377 src/muuli_wdr.cpp:1435
 msgid "Enable UPnP for router port forwarding"
 msgstr "Iespējot UPnP maršrutētāja portu pāradresāciju"
 
@@ -2323,7 +2313,7 @@ msgstr ""
 msgid "Your peer lists are already in place - nothing to download."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:434 src/muuli_wdr.cpp:1540
+#: src/FirstRunWizard.cpp:434 src/muuli_wdr.cpp:1533
 msgid "Auto-update server list at startup"
 msgstr "Kad palaiž, automātiski atjaunināt serveru sarakstu"
 
@@ -2369,23 +2359,23 @@ msgid ""
 "want downloads on a different (e.g. larger) disk."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:549 src/FirstRunWizard.cpp:611 src/muuli_wdr.cpp:1702
+#: src/FirstRunWizard.cpp:549 src/FirstRunWizard.cpp:611 src/muuli_wdr.cpp:1701
 msgid "Destination folder for downloads"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:553 src/FirstRunWizard.cpp:569 src/muuli_wdr.cpp:1349
-#: src/muuli_wdr.cpp:1366 src/muuli_wdr.cpp:1677 src/muuli_wdr.cpp:1708
-#: src/muuli_wdr.cpp:1720 src/muuli_wdr.cpp:2790
+#: src/FirstRunWizard.cpp:553 src/FirstRunWizard.cpp:569 src/muuli_wdr.cpp:1342
+#: src/muuli_wdr.cpp:1359 src/muuli_wdr.cpp:1676 src/muuli_wdr.cpp:1707
+#: src/muuli_wdr.cpp:1719 src/muuli_wdr.cpp:2762
 #: src/utils/aLinkCreator/src/alcframe.cpp:135
 #: src/utils/wxCas/src/wxcasprefs.cpp:52 src/utils/wxCas/src/wxcasprefs.cpp:118
 msgid "Browse"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:559 src/muuli_wdr.cpp:1713
+#: src/FirstRunWizard.cpp:559 src/muuli_wdr.cpp:1712
 msgid "(All files in this folder are shared with other peers)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:565 src/FirstRunWizard.cpp:624 src/muuli_wdr.cpp:1715
+#: src/FirstRunWizard.cpp:565 src/FirstRunWizard.cpp:624 src/muuli_wdr.cpp:1714
 msgid "Folder for temporary download files"
 msgstr ""
 
@@ -2416,7 +2406,7 @@ msgstr ""
 msgid "CRITICAL - no client on StartChatSession"
 msgstr ""
 
-#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2696 src/muuli_wdr.cpp:3373
+#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2668 src/muuli_wdr.cpp:3345
 msgid "Friends"
 msgstr "Draugi"
 
@@ -2522,8 +2512,8 @@ msgstr ""
 msgid "No"
 msgstr "Nē"
 
-#: src/GenericClientListCtrl.cpp:1216 src/PrefsUnifiedDlg.cpp:2898
-#: src/PrefsUnifiedDlg.cpp:2948 src/ServerListCtrl.cpp:276
+#: src/GenericClientListCtrl.cpp:1216 src/PrefsUnifiedDlg.cpp:2818
+#: src/PrefsUnifiedDlg.cpp:2868 src/ServerListCtrl.cpp:276
 msgid "Yes"
 msgstr "Jā"
 
@@ -2690,10 +2680,10 @@ msgstr ""
 msgid "Please fill all fields required"
 msgstr ""
 
-#: src/KadDlg.cpp:192 src/PartFile.cpp:1031 src/PrefsUnifiedDlg.cpp:1134
-#: src/PrefsUnifiedDlg.cpp:1204 src/PrefsUnifiedDlg.cpp:1405
-#: src/PrefsUnifiedDlg.cpp:1663 src/PrefsUnifiedDlg.cpp:1673
-#: src/PrefsUnifiedDlg.cpp:1690 src/PrefsUnifiedDlg.cpp:1738
+#: src/KadDlg.cpp:192 src/PartFile.cpp:1031 src/PrefsUnifiedDlg.cpp:1162
+#: src/PrefsUnifiedDlg.cpp:1331 src/PrefsUnifiedDlg.cpp:1589
+#: src/PrefsUnifiedDlg.cpp:1599 src/PrefsUnifiedDlg.cpp:1616
+#: src/PrefsUnifiedDlg.cpp:1658
 msgid "Message"
 msgstr "Ziņojums"
 
@@ -2795,7 +2785,7 @@ msgstr ""
 msgid "Uploaded"
 msgstr "Augšupielādēts"
 
-#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3253
+#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3225
 msgid "Requested"
 msgstr ""
 
@@ -2918,7 +2908,7 @@ msgid "WARNING: "
 msgstr "BRĪDINĀJUMS: "
 
 #: src/MuleNotebook.cpp:179 src/muuli_wdr.cpp:817 src/muuli_wdr.cpp:1229
-#: src/muuli_wdr.cpp:3157 src/muuli_wdr.cpp:3413
+#: src/muuli_wdr.cpp:3129 src/muuli_wdr.cpp:3385
 msgid "Close"
 msgstr "Aizvērt"
 
@@ -2931,12 +2921,12 @@ msgstr "Izgriezt"
 msgid "Copy"
 msgstr "Kopēt"
 
-#: src/MuleTextCtrl.cpp:88 src/SearchDlg.cpp:261
+#: src/MuleTextCtrl.cpp:88
 msgid "Paste"
 msgstr "Ielīmēt"
 
 #: src/MuleTextCtrl.cpp:89 src/muuli_wdr.cpp:358 src/muuli_wdr.cpp:757
-#: src/muuli_wdr.cpp:2380 src/muuli_wdr.cpp:2399 src/muuli_wdr.cpp:2421
+#: src/muuli_wdr.cpp:2352 src/muuli_wdr.cpp:2371 src/muuli_wdr.cpp:2393
 #: src/utils/aLinkCreator/src/alcframe.cpp:142
 msgid "Clear"
 msgstr "Notīrīt"
@@ -3027,8 +3017,8 @@ msgid "Exit"
 msgstr "Iziet"
 
 #: src/MuleTrayIcon.cpp:579 src/MuleTrayIcon.cpp:945 src/MuleTrayIcon.cpp:965
-#: src/muuli_wdr.cpp:1398 src/muuli_wdr.cpp:1406 src/muuli_wdr.cpp:1413
-#: src/muuli_wdr.cpp:1836 src/muuli_wdr.cpp:1842 src/OtherFunctions.cpp:91
+#: src/muuli_wdr.cpp:1391 src/muuli_wdr.cpp:1399 src/muuli_wdr.cpp:1406
+#: src/muuli_wdr.cpp:1835 src/muuli_wdr.cpp:1841 src/OtherFunctions.cpp:91
 #: src/StatisticsDlg.cpp:93 src/StatisticsDlg.cpp:95
 msgid "kB/s"
 msgstr "kB/s"
@@ -3197,7 +3187,7 @@ msgstr "Nosaukums:"
 msgid "Type"
 msgstr ""
 
-#: src/muuli_wdr.cpp:215 src/SearchDlg.cpp:118 src/SearchListCtrl.cpp:853
+#: src/muuli_wdr.cpp:215 src/SearchDlg.cpp:110 src/SearchListCtrl.cpp:853
 msgid "Local"
 msgstr ""
 
@@ -3268,7 +3258,7 @@ msgstr "Baiti"
 msgid "KB"
 msgstr ""
 
-#: src/muuli_wdr.cpp:274 src/muuli_wdr.cpp:293 src/muuli_wdr.cpp:1621
+#: src/muuli_wdr.cpp:274 src/muuli_wdr.cpp:293 src/muuli_wdr.cpp:1620
 #: src/OtherFunctions.cpp:64
 msgid "MB"
 msgstr ""
@@ -3285,7 +3275,7 @@ msgstr "Maksimālais izmērs"
 msgid "Availability"
 msgstr "Pieejamība"
 
-#: src/muuli_wdr.cpp:312 src/muuli_wdr.cpp:398 src/muuli_wdr.cpp:3318
+#: src/muuli_wdr.cpp:312 src/muuli_wdr.cpp:398 src/muuli_wdr.cpp:3290
 msgid "Filter:"
 msgstr ""
 
@@ -3317,7 +3307,7 @@ msgstr ""
 msgid "Stop"
 msgstr "Apturēt"
 
-#: src/muuli_wdr.cpp:348 src/muuli_wdr.cpp:1392 src/SearchListCtrl.cpp:732
+#: src/muuli_wdr.cpp:348 src/muuli_wdr.cpp:1385 src/SearchListCtrl.cpp:732
 msgid "Download"
 msgstr ""
 
@@ -3348,12 +3338,12 @@ msgstr ""
 #: src/muuli_wdr.cpp:1160 src/muuli_wdr.cpp:1167 src/muuli_wdr.cpp:1172
 #: src/muuli_wdr.cpp:1179 src/muuli_wdr.cpp:1184 src/muuli_wdr.cpp:1191
 #: src/muuli_wdr.cpp:1205 src/muuli_wdr.cpp:1212 src/muuli_wdr.cpp:1217
-#: src/muuli_wdr.cpp:1224 src/muuli_wdr.cpp:3255 src/muuli_wdr.cpp:3263
-#: src/muuli_wdr.cpp:3271
+#: src/muuli_wdr.cpp:1224 src/muuli_wdr.cpp:3227 src/muuli_wdr.cpp:3235
+#: src/muuli_wdr.cpp:3243
 msgid "N/A"
 msgstr ""
 
-#: src/muuli_wdr.cpp:508 src/muuli_wdr.cpp:1065 src/PrefsUnifiedDlg.cpp:299
+#: src/muuli_wdr.cpp:508 src/muuli_wdr.cpp:1065 src/PrefsUnifiedDlg.cpp:297
 msgid "General"
 msgstr ""
 
@@ -3491,7 +3481,7 @@ msgstr "Izpildītājs :"
 msgid "Album :"
 msgstr "Albums :"
 
-#: src/muuli_wdr.cpp:685 src/muuli_wdr.cpp:2275
+#: src/muuli_wdr.cpp:685 src/muuli_wdr.cpp:2247
 msgid "Title :"
 msgstr "Nosaukums :"
 
@@ -3598,7 +3588,7 @@ msgstr "Lietotājvārds :"
 msgid "Userhash :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:895 src/muuli_wdr.cpp:1742 src/muuli_wdr.cpp:2470
+#: src/muuli_wdr.cpp:895 src/muuli_wdr.cpp:1741 src/muuli_wdr.cpp:2442
 #: src/utils/aLinkCreator/src/alcframe.cpp:137
 msgid "Add"
 msgstr "Pievienot"
@@ -3607,15 +3597,15 @@ msgstr "Pievienot"
 msgid "Download-Speed"
 msgstr "Lejupielādes ātrums"
 
-#: src/muuli_wdr.cpp:954 src/muuli_wdr.cpp:989 src/muuli_wdr.cpp:2574
+#: src/muuli_wdr.cpp:954 src/muuli_wdr.cpp:989 src/muuli_wdr.cpp:2546
 msgid "Current"
 msgstr "Pašreizējais"
 
-#: src/muuli_wdr.cpp:962 src/muuli_wdr.cpp:997 src/muuli_wdr.cpp:2582
+#: src/muuli_wdr.cpp:962 src/muuli_wdr.cpp:997 src/muuli_wdr.cpp:2554
 msgid "Running average"
 msgstr "Visu laiku vidējais"
 
-#: src/muuli_wdr.cpp:970 src/muuli_wdr.cpp:1005 src/muuli_wdr.cpp:2590
+#: src/muuli_wdr.cpp:970 src/muuli_wdr.cpp:1005 src/muuli_wdr.cpp:2562
 msgid "Session average"
 msgstr "Sesijas vidējais"
 
@@ -3627,7 +3617,7 @@ msgstr "Augšupielādes ātrums"
 msgid "Connections"
 msgstr "Savienojumi"
 
-#: src/muuli_wdr.cpp:1024 src/muuli_wdr.cpp:1861
+#: src/muuli_wdr.cpp:1024 src/muuli_wdr.cpp:1860
 msgid "Active downloads"
 msgstr "Aktīvas lejupielādes"
 
@@ -3635,7 +3625,7 @@ msgstr "Aktīvas lejupielādes"
 msgid "Active connections (1:1)"
 msgstr "Aktīvi savienojumi (1:1)"
 
-#: src/muuli_wdr.cpp:1040 src/muuli_wdr.cpp:1862
+#: src/muuli_wdr.cpp:1040 src/muuli_wdr.cpp:1861
 msgid "Active uploads"
 msgstr "Aktīvas augšupielādes"
 
@@ -3751,8 +3741,8 @@ msgstr "Vārds, kas tiks rādīts lietotājiem, kad pieslēdzas jums."
 msgid "Language: "
 msgstr "Valoda: "
 
-#: src/muuli_wdr.cpp:1257 src/muuli_wdr.cpp:1330 src/muuli_wdr.cpp:1334
-#: src/muuli_wdr.cpp:1337
+#: src/muuli_wdr.cpp:1257 src/muuli_wdr.cpp:1323 src/muuli_wdr.cpp:1327
+#: src/muuli_wdr.cpp:1330
 msgid "The delay before showing tool-tips."
 msgstr ""
 
@@ -3829,949 +3819,927 @@ msgstr ""
 msgid "Enabling this will make aMule to show notifications when finished downloading."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1323
-msgid "Remember search history"
-msgstr ""
-
-#: src/muuli_wdr.cpp:1324
-msgid "Keeps a dropdown list of your past search terms in the Search tab's Name field. This remembers the queries you typed, not the results they returned."
-msgstr ""
-
-#: src/muuli_wdr.cpp:1329
+#: src/muuli_wdr.cpp:1322
 msgid "Tooltip delay time: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1336
+#: src/muuli_wdr.cpp:1329
 msgid "seconds"
 msgstr "sekundes"
 
-#: src/muuli_wdr.cpp:1340
+#: src/muuli_wdr.cpp:1333
 msgid "Browser Selection"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1346
+#: src/muuli_wdr.cpp:1339
 msgid "Enter your browser name here. Leave this field empty to use the system default browser."
 msgstr "Ievadiet šeit sava pārlūka nosaukumu. Atstājiet šo lauku tukšu, ja vēlaties izmantot sistēmas noklusējuma pārlūku."
 
-#: src/muuli_wdr.cpp:1353
+#: src/muuli_wdr.cpp:1346
 msgid "Open in new tab if possible"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1355
+#: src/muuli_wdr.cpp:1348
 msgid "Open the web page in a new tab instead of in a new window when possible"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1359
+#: src/muuli_wdr.cpp:1352
 msgid "Video Player"
 msgstr "Video atskaņotājs"
 
-#: src/muuli_wdr.cpp:1386
+#: src/muuli_wdr.cpp:1379
 msgid "Bandwidth limits"
 msgstr "Datu pārraides ierobežojumi"
 
-#: src/muuli_wdr.cpp:1400
+#: src/muuli_wdr.cpp:1393
 msgid "Upload"
 msgstr "Augšupielādes (Izejošais)"
 
-#: src/muuli_wdr.cpp:1408
+#: src/muuli_wdr.cpp:1401
 msgid "Slot Allocation"
 msgstr "Katram klientam (vienam savienojumam) izdalītais spraugas"
 
-#: src/muuli_wdr.cpp:1417
+#: src/muuli_wdr.cpp:1410
 msgid "Ports"
 msgstr "Porti"
 
-#: src/muuli_wdr.cpp:1427
+#: src/muuli_wdr.cpp:1420
 msgid "This is the standard eD2k port and cannot be disabled."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1430
+#: src/muuli_wdr.cpp:1423
 msgid "UDP port for server requests (TCP+3):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1432
+#: src/muuli_wdr.cpp:1425
 msgid "4665"
 msgstr "4665"
 
-#: src/muuli_wdr.cpp:1439
+#: src/muuli_wdr.cpp:1432
 msgid "This UDP port is used for extended eD2k requests and Kad network"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1446
+#: src/muuli_wdr.cpp:1439
 msgid "UPnP TCP Port (Optional):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1456
+#: src/muuli_wdr.cpp:1449
 msgid "Bind local address to IP (empty for any):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1459
+#: src/muuli_wdr.cpp:1452
 msgid "Advanced users only: If you have multiple network interfaces, enter the address of the interface to which aMule should be bound."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1462 src/muuli_wdr.cpp:2055
+#: src/muuli_wdr.cpp:1455 src/muuli_wdr.cpp:2054
 msgid "Bind to network interface (empty for any):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1475
+#: src/muuli_wdr.cpp:1468
 msgid "Advanced users only: pin all of aMule's traffic to one network interface, chosen from the list or typed in by name (e.g. tun0, eth0, en0) or index. Unlike binding to an IP, this stops traffic leaking out via the default route - useful with a VPN. Requires no elevated privileges."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1481
+#: src/muuli_wdr.cpp:1474
 msgid "Max sources per downloading file:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1485
+#: src/muuli_wdr.cpp:1478
 msgid "Max simultaneous connections:"
 msgstr "Maksimālais vienlaicīgo savienojumu skaits:"
 
-#: src/muuli_wdr.cpp:1498 src/muuli_wdr.cpp:3197
+#: src/muuli_wdr.cpp:1491 src/muuli_wdr.cpp:3169
 msgid "ED2K"
 msgstr "ED2K"
 
-#: src/muuli_wdr.cpp:1505
+#: src/muuli_wdr.cpp:1498
 msgid "Autoconnect on startup"
 msgstr "Kad palaiž, automātiski pieslēgties"
 
-#: src/muuli_wdr.cpp:1508
+#: src/muuli_wdr.cpp:1501
 msgid "Reconnect on loss"
 msgstr "Atkārtoti pieslēgties, kad zaudēts savienojums"
 
-#: src/muuli_wdr.cpp:1530
+#: src/muuli_wdr.cpp:1523
 msgid "Remove dead server after"
 msgstr "Noņemt mirušo serveri pēc"
 
-#: src/muuli_wdr.cpp:1531
+#: src/muuli_wdr.cpp:1524
 msgid "Static servers are never removed, even when unreachable."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1535
+#: src/muuli_wdr.cpp:1528
 msgid "retries"
 msgstr "mēģinājumiem"
 
-#: src/muuli_wdr.cpp:1543
+#: src/muuli_wdr.cpp:1536
 msgid "List"
 msgstr "Saraksts"
 
-#: src/muuli_wdr.cpp:1546
+#: src/muuli_wdr.cpp:1539
 msgid "Update server list when connecting to a server"
 msgstr "Atjaunināt serveru sarakstu, kad pieslēdzas serverim"
 
-#: src/muuli_wdr.cpp:1549
+#: src/muuli_wdr.cpp:1542
 msgid "Update server list when a client connects"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1552
+#: src/muuli_wdr.cpp:1545
 msgid "Use priority system"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1556
+#: src/muuli_wdr.cpp:1549
 msgid "Use smart LowID check on connect"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1560
+#: src/muuli_wdr.cpp:1553
 msgid "Safe connect"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1564
+#: src/muuli_wdr.cpp:1557
 msgid "Autoconnect to servers in static list only"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1567
+#: src/muuli_wdr.cpp:1560
 msgid "Set manually added servers to High Priority"
 msgstr "Iestatīt pašrocīgi pievienotos serverus kā augstas prioritātes"
 
-#: src/muuli_wdr.cpp:1588
+#: src/muuli_wdr.cpp:1581
 msgid "Add files to download in pause mode"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1590
+#: src/muuli_wdr.cpp:1583
 msgid "Add files to download with auto priority"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1593
+#: src/muuli_wdr.cpp:1586
 msgid "Try to download first and last chunks first"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1597
+#: src/muuli_wdr.cpp:1590
 msgid "Endgame mode: rotate to faster sources for the final blocks"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1600
+#: src/muuli_wdr.cpp:1593
 msgid "Start next paused file when a file completes"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1603
+#: src/muuli_wdr.cpp:1596
 msgid "From the same category"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1605
+#: src/muuli_wdr.cpp:1598
 msgid "In alphabetic order"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1607
+#: src/muuli_wdr.cpp:1600
 msgid "Preallocate disk space for new files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1608
+#: src/muuli_wdr.cpp:1601
 msgid "For new files preallocates disk space for the whole file, thus reduces fragmentation"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1613
+#: src/muuli_wdr.cpp:1606
+msgid "Create new files as sparse files"
+msgstr ""
+
+#: src/muuli_wdr.cpp:1607
+msgid "A sparse file reserves its full size on disk immediately without writing real data to it -- fast, but unsupported or slow on some filesystems, and free-space accounting stays optimistic while the download is in progress. Turn this off to grow the file only as data arrives."
+msgstr ""
+
+#: src/muuli_wdr.cpp:1612
 msgid "Stop downloads when free disk space reaches "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1614
+#: src/muuli_wdr.cpp:1613
 msgid "Select this if you want aMule to check your disk space"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1618
+#: src/muuli_wdr.cpp:1617
 msgid "Enter here the min disk space desired."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1624
+#: src/muuli_wdr.cpp:1623
 msgid "Save 10 sources on rare files (< 20 sources)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1628 src/Statistics.cpp:790
+#: src/muuli_wdr.cpp:1627 src/Statistics.cpp:790
 msgid "Uploads"
 msgstr "Augšupielādes"
 
-#: src/muuli_wdr.cpp:1631
+#: src/muuli_wdr.cpp:1630
 msgid "Add new shared files with auto priority"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1637
+#: src/muuli_wdr.cpp:1636
 msgid "Intelligent Corruption Handling (I.C.H.)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1640
+#: src/muuli_wdr.cpp:1639
 msgid "Enable"
 msgstr "Iespējot"
 
-#: src/muuli_wdr.cpp:1643
+#: src/muuli_wdr.cpp:1642
 msgid "Advanced I.C.H. trusts every hash (not recommended)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1655 src/PrefsUnifiedDlg.cpp:1990
+#: src/muuli_wdr.cpp:1654 src/PrefsUnifiedDlg.cpp:1910
 msgid "Media metadata extraction"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1659
+#: src/muuli_wdr.cpp:1658
 msgid "Extract length / bitrate / codec from shared audio and video files"
 msgstr "Iegūt garuma / bitu pārraides ātruma / kodeka infomāciju no kopīgotajām audio un video datnēm"
 
-#: src/muuli_wdr.cpp:1661
+#: src/muuli_wdr.cpp:1660
 msgid "When enabled, aMule runs ffprobe on each shared media file to fill in the Length / Bitrate / Codec columns other clients see when they find the file in a search. Requires ffmpeg (the ffprobe binary) to be installed."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1668
+#: src/muuli_wdr.cpp:1667
 msgid "Path to ffprobe:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1673
+#: src/muuli_wdr.cpp:1672
 msgid "Full path to the ffprobe binary. Leave empty to have aMule auto-detect it on startup."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1681
+#: src/muuli_wdr.cpp:1680
 msgid "Detect"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1682
+#: src/muuli_wdr.cpp:1681
 msgid "Search the standard install locations for an ffprobe binary and fill the path field."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1706
+#: src/muuli_wdr.cpp:1705
 msgid ""
 "Completed downloads are stored here. All files in this folder are automatically shared with other peers.\n"
 "If this folder also holds files you don't want to share, point it at an aMule-only sub-folder."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1709
+#: src/muuli_wdr.cpp:1708
 msgid "Pick the folder where completed downloads will be stored. All files in that folder will be shared with other peers."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1723
+#: src/muuli_wdr.cpp:1722
 msgid "Shared folders"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1729
+#: src/muuli_wdr.cpp:1728
 msgid "(Folders shared by the core. Enter a path to add one.)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1737
+#: src/muuli_wdr.cpp:1736
 msgid "Absolute path of a folder on the core's machine, e.g. /home/user/shared"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1739 src/PrefsUnifiedDlg.cpp:2874
+#: src/muuli_wdr.cpp:1738 src/PrefsUnifiedDlg.cpp:2794
 msgid "Recursive"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1740
+#: src/muuli_wdr.cpp:1739
 msgid "Share every sub-folder underneath this one, including ones created later."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1744 src/utils/aLinkCreator/src/alcframe.cpp:141
+#: src/muuli_wdr.cpp:1743 src/utils/aLinkCreator/src/alcframe.cpp:141
 msgid "Remove"
 msgstr "Noņemt"
 
-#: src/muuli_wdr.cpp:1748
+#: src/muuli_wdr.cpp:1747
 msgid "(Right click on folder icon for recursive share)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1755
+#: src/muuli_wdr.cpp:1754
 msgid "Share hidden files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1761
+#: src/muuli_wdr.cpp:1760
 msgid "Automatically rescan shared folders for changes"
 msgstr "Automātiski uzraudzīt kopīgoto mapju izmaiņas"
 
-#: src/muuli_wdr.cpp:1767
+#: src/muuli_wdr.cpp:1766
 msgid "Follow symbolic links in shared folders"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1773
+#: src/muuli_wdr.cpp:1772
 msgid "Exclude files matching:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1776
+#: src/muuli_wdr.cpp:1775
 msgid "Wildcard patterns separated by '|', e.g. .DS_Store|Thumbs.db|*.tmp. Files whose name matches are not shared. Matching is case-insensitive."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1780
+#: src/muuli_wdr.cpp:1779
 msgid "Patterns are regular expressions"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1781
+#: src/muuli_wdr.cpp:1780
 msgid "When set, the whole field is one regular expression ('|' is alternation). When unset, it is a list of '|'-separated wildcards."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1791
+#: src/muuli_wdr.cpp:1790
 msgid "Show how many shared files the current pattern would exclude."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1812
+#: src/muuli_wdr.cpp:1811
 msgid "Graphs"
 msgstr "Grafiki"
 
-#: src/muuli_wdr.cpp:1815 src/muuli_wdr.cpp:1877
+#: src/muuli_wdr.cpp:1814 src/muuli_wdr.cpp:1876
 msgid "Update delay : 5 secs"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1819
+#: src/muuli_wdr.cpp:1818
 msgid "Time for average graph: 100 mins"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1823
+#: src/muuli_wdr.cpp:1822
 msgid "Connections Graph Scale: 100 "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1830
+#: src/muuli_wdr.cpp:1829
 msgid "Download graph scale:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1838
+#: src/muuli_wdr.cpp:1837
 msgid "Upload graph scale:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1848
+#: src/muuli_wdr.cpp:1847
 msgid "Colors: "
 msgstr "Krāsas: "
 
-#: src/muuli_wdr.cpp:1852
+#: src/muuli_wdr.cpp:1851
 msgid "Background"
 msgstr "Fons"
 
-#: src/muuli_wdr.cpp:1853
+#: src/muuli_wdr.cpp:1852
 msgid "Grid"
 msgstr "Režģis"
 
-#: src/muuli_wdr.cpp:1854
+#: src/muuli_wdr.cpp:1853
 msgid "Download current"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1855
+#: src/muuli_wdr.cpp:1854
 msgid "Download running average"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1856
+#: src/muuli_wdr.cpp:1855
 msgid "Download session average"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1857
+#: src/muuli_wdr.cpp:1856
 msgid "Upload current"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1858
+#: src/muuli_wdr.cpp:1857
 msgid "Upload running average"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1859
+#: src/muuli_wdr.cpp:1858
 msgid "Upload session average"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1860
+#: src/muuli_wdr.cpp:1859
 msgid "Active connections"
 msgstr "Aktīvi savienojumi"
 
-#: src/muuli_wdr.cpp:1863
+#: src/muuli_wdr.cpp:1862
 msgid "Systray Icon Speed Bar"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1864
+#: src/muuli_wdr.cpp:1863
 msgid "Kad-nodes current"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1865
+#: src/muuli_wdr.cpp:1864
 msgid "Kad-nodes running"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1866
+#: src/muuli_wdr.cpp:1865
 msgid "Kad-nodes session"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1870 src/muuli_wdr.cpp:2324
+#: src/muuli_wdr.cpp:1869 src/muuli_wdr.cpp:2296
 msgid "Select"
 msgstr "Atlasīt"
 
-#: src/muuli_wdr.cpp:1874
+#: src/muuli_wdr.cpp:1873
 msgid "Tree"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1884
+#: src/muuli_wdr.cpp:1883
 msgid "Number of Client Versions shown (0=unlimited)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1909
+#: src/muuli_wdr.cpp:1908
 msgid "!!! WARNING !!!"
 msgstr "!!! BRĪDINĀJUMS !!!"
 
-#: src/muuli_wdr.cpp:1924
+#: src/muuli_wdr.cpp:1923
 msgid "Max new connections / 5 secs"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1926
+#: src/muuli_wdr.cpp:1925
 msgid "Concurrent Kad source lookups"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1928
+#: src/muuli_wdr.cpp:1927
 msgid "Kad source re-search interval (minutes)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1930
+#: src/muuli_wdr.cpp:1929
 msgid "Source re-ask interval (minutes)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1934
+#: src/muuli_wdr.cpp:1933
 msgid "File Buffer Size: 240000 bytes"
 msgstr "Datnes bufera izmērs: 240000 baiti"
 
-#: src/muuli_wdr.cpp:1938
+#: src/muuli_wdr.cpp:1937
 msgid "Use MMAP: memory-mapped file access (lower memory use)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1939
+#: src/muuli_wdr.cpp:1938
 msgid "Maps part files into memory instead of buffering them on the heap, lowering the process memory footprint. May reduce download speed on some disks; best for memory-constrained or upload-heavy hosts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1941
+#: src/muuli_wdr.cpp:1940
 msgid "Upload Queue Size: 5000 clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1945
+#: src/muuli_wdr.cpp:1944
 msgid "Server connection refresh interval: Disable"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1949
+#: src/muuli_wdr.cpp:1948
 msgid "Disable computer's timed standby mode"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1968
+#: src/muuli_wdr.cpp:1967
 msgid "Skin to use: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1977
+#: src/muuli_wdr.cpp:1976
 msgid "Show \"Fast eD2k Links Handler\" in every window."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1980
+#: src/muuli_wdr.cpp:1979
 msgid "Show extended info on categories tabs"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1983
+#: src/muuli_wdr.cpp:1982
 msgid "Show application version on title"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1985
+#: src/muuli_wdr.cpp:1984
 msgid "Show transfer rates on title"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1987
+#: src/muuli_wdr.cpp:1986
 msgid "Before application name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1989
+#: src/muuli_wdr.cpp:1988
 msgid "After application name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1992
+#: src/muuli_wdr.cpp:1991
 msgid "Show overhead bandwidth"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1996
+#: src/muuli_wdr.cpp:1995
 msgid "Vertical toolbar orientation"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1998
+#: src/muuli_wdr.cpp:1997
 msgid "Live column sorting (auto-reorder rows as their values change)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2005
+#: src/muuli_wdr.cpp:2004
 msgid "Download Queue Files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2008
+#: src/muuli_wdr.cpp:2007
 msgid "Show progress percentage"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2014
+#: src/muuli_wdr.cpp:2013
 msgid "Show progress bar"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2017
+#: src/muuli_wdr.cpp:2016
 msgid "Flat"
 msgstr "Plakana"
 
-#: src/muuli_wdr.cpp:2021
+#: src/muuli_wdr.cpp:2020
 msgid "Round"
 msgstr "Apaļa"
 
-#: src/muuli_wdr.cpp:2039
+#: src/muuli_wdr.cpp:2038
 msgid "External Connection Parameters"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2042
+#: src/muuli_wdr.cpp:2041
 msgid "Accept external connections"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2049 src/muuli_wdr.cpp:2108
+#: src/muuli_wdr.cpp:2048 src/muuli_wdr.cpp:2107
 msgid "IP of the listening interface:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2052
+#: src/muuli_wdr.cpp:2051
 msgid "Enter here a valid ip in the a.b.c.d format for the listening EC interface. An empty field or 0.0.0.0 will mean any interface."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2073 src/muuli_wdr.cpp:2184
+#: src/muuli_wdr.cpp:2072 src/muuli_wdr.cpp:2156
 msgid "TCP port:"
 msgstr "TCP ports:"
 
-#: src/muuli_wdr.cpp:2079
+#: src/muuli_wdr.cpp:2078
 msgid "Enable UPnP port forwarding on the EC port"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2083 src/muuli_wdr.cpp:3069
+#: src/muuli_wdr.cpp:2082 src/muuli_wdr.cpp:3041
 #: src/utils/wxCas/src/wxcasprefs.cpp:167
 msgid "Password"
 msgstr "Parole"
 
-#: src/muuli_wdr.cpp:2089
+#: src/muuli_wdr.cpp:2088
 msgid "aMule API server parameters"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2092
+#: src/muuli_wdr.cpp:2091
 msgid "Run amuleapi (REST API) on startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2097
+#: src/muuli_wdr.cpp:2096
 #, fuzzy
 msgid "HTTP port:"
 msgstr "TCP ports:"
 
-#: src/muuli_wdr.cpp:2111
+#: src/muuli_wdr.cpp:2110
 msgid "The interface amuleapi's HTTP server listens on. 127.0.0.1 (default) accepts only local connections; use 0.0.0.0 or a specific IP to expose it to other hosts (set an admin password below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2116
-msgid "Type a password to set or change it. Stored passwords cannot be shown, so leaving this empty keeps the current one."
-msgstr ""
-
-#: src/muuli_wdr.cpp:2118
+#: src/muuli_wdr.cpp:2113
 #, fuzzy
 msgid "Admin password"
 msgstr "Parole"
 
-#: src/muuli_wdr.cpp:2130 src/muuli_wdr.cpp:2147 src/PrefsUnifiedDlg.cpp:1103
-#, fuzzy
-msgid "A password is set."
-msgstr "Parole"
-
-#: src/muuli_wdr.cpp:2134
-msgid "Enable guest access"
+#: src/muuli_wdr.cpp:2118 src/muuli_wdr.cpp:2149
+msgid "Low rights password"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2135
-msgid "Guest sessions may read status and listings but cannot change anything. Turning this off clears the stored guest password."
-msgstr ""
-
-#: src/muuli_wdr.cpp:2139
-#, fuzzy
-msgid "Guest password"
-msgstr "Parole"
-
-#: src/muuli_wdr.cpp:2154
+#: src/muuli_wdr.cpp:2126
 msgid "Web server parameters"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2157
+#: src/muuli_wdr.cpp:2129
 #, fuzzy
 msgid "Run webserver on startup (deprecated)"
 msgstr "Kad palaiž, palaist arī tīmekļa serveri"
 
-#: src/muuli_wdr.cpp:2163
+#: src/muuli_wdr.cpp:2135
 msgid "Web template"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2168
+#: src/muuli_wdr.cpp:2140
 msgid "Full rights password"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2172
+#: src/muuli_wdr.cpp:2144
 msgid "Enable Low rights User"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2177
-msgid "Low rights password"
-msgstr ""
-
-#: src/muuli_wdr.cpp:2191
+#: src/muuli_wdr.cpp:2163
 msgid "Enable UPnP port forwarding of the web server port"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2196
+#: src/muuli_wdr.cpp:2168
 msgid "Web server UPnP TCP port (Optional)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2204
+#: src/muuli_wdr.cpp:2176
 msgid "Page Refresh Time (in secs)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2211
+#: src/muuli_wdr.cpp:2183
 msgid "Enable Gzip compression"
 msgstr "Iespējot Gzip saspiešanu"
 
-#: src/muuli_wdr.cpp:2245
+#: src/muuli_wdr.cpp:2217
 #, fuzzy
 msgid "Reset page to defaults"
 msgstr "Sistēmas"
 
-#: src/muuli_wdr.cpp:2246
+#: src/muuli_wdr.cpp:2218
 msgid "Reset the settings on the current page to their default values."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2248 src/muuli_wdr.cpp:2334 src/ServerWnd.cpp:274
+#: src/muuli_wdr.cpp:2220 src/muuli_wdr.cpp:2306 src/ServerWnd.cpp:274
 #: src/ServerWnd.cpp:282
 msgid "OK"
 msgstr "Labi"
 
-#: src/muuli_wdr.cpp:2250
+#: src/muuli_wdr.cpp:2222
 msgid "Click here to apply any changes made to the preferences."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2253
+#: src/muuli_wdr.cpp:2225
 msgid "Reset any changes made to the preferences."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2282
+#: src/muuli_wdr.cpp:2254
 msgid "Comment :"
 msgstr "Komentārs :"
 
-#: src/muuli_wdr.cpp:2289
+#: src/muuli_wdr.cpp:2261
 msgid "Incoming Dir :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2298
+#: src/muuli_wdr.cpp:2270
 msgid "Change priority for new assigned files :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2302
+#: src/muuli_wdr.cpp:2274
 msgid "Don't change"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2314
+#: src/muuli_wdr.cpp:2286
 msgid "Select color for this Category (currently selected) :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2381 src/muuli_wdr.cpp:2400 src/muuli_wdr.cpp:2422
+#: src/muuli_wdr.cpp:2353 src/muuli_wdr.cpp:2372 src/muuli_wdr.cpp:2394
 msgid "Click this button to reset the log."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2441
+#: src/muuli_wdr.cpp:2413
 msgid "Click on this button to update the servers list from URL ..."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2445
+#: src/muuli_wdr.cpp:2417
 msgid "Server list"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2449
+#: src/muuli_wdr.cpp:2421
 msgid "Enter the url to a server.met file here and press the button to the left to update the list of known servers."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2454
+#: src/muuli_wdr.cpp:2426
 msgid "Add server manually: Name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2457
+#: src/muuli_wdr.cpp:2429
 msgid "Enter the name of the new server here"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2459 src/ServerWnd.cpp:206
+#: src/muuli_wdr.cpp:2431 src/ServerWnd.cpp:206
 msgid "IP:Port"
 msgstr "IP:Ports"
 
-#: src/muuli_wdr.cpp:2462
+#: src/muuli_wdr.cpp:2434
 msgid "Enter the IP of the server here, using the x.x.x.x format."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2468
+#: src/muuli_wdr.cpp:2440
 msgid "Enter the port of the server here."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2471
+#: src/muuli_wdr.cpp:2443
 msgid "Add manually a server (fill fields to the left before) ..."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2500
+#: src/muuli_wdr.cpp:2472
 msgid "aMule Log"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2508
+#: src/muuli_wdr.cpp:2480
 msgid "Server Info"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2512
+#: src/muuli_wdr.cpp:2484
 msgid "ED2K Info"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2516
+#: src/muuli_wdr.cpp:2488
 msgid "Kad Info"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2544
+#: src/muuli_wdr.cpp:2516
 msgid "Click on this button to update the nodes list from URL ..."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2548
+#: src/muuli_wdr.cpp:2520
 msgid "Nodes (0)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2552
+#: src/muuli_wdr.cpp:2524
 msgid "Enter the url to a nodes.dat file here and press the button to the left to update the list of known nodes."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2555
+#: src/muuli_wdr.cpp:2527
 msgid "Nodes stats"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2597
+#: src/muuli_wdr.cpp:2569
 msgid "Bootstrap"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2600
+#: src/muuli_wdr.cpp:2572
 msgid "New node"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2605
+#: src/muuli_wdr.cpp:2577
 msgid "IP:"
 msgstr "IP:"
 
-#: src/muuli_wdr.cpp:2625
+#: src/muuli_wdr.cpp:2597
 msgid "Port:"
 msgstr "Ports:"
 
-#: src/muuli_wdr.cpp:2638
+#: src/muuli_wdr.cpp:2610
 msgid "Bootstrap from known clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2640
+#: src/muuli_wdr.cpp:2612
 msgid "Disconnect Kad"
 msgstr "Atslēgt Kad"
 
-#: src/muuli_wdr.cpp:2674
+#: src/muuli_wdr.cpp:2646
 msgid "Use Secure User Identification"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2676
+#: src/muuli_wdr.cpp:2648
 msgid "It is recommended to enable this option. You will not receive credits if SUI is not enabled."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2678
+#: src/muuli_wdr.cpp:2650
 msgid "Protocol Obfuscation"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2681
+#: src/muuli_wdr.cpp:2653
 msgid "Support Protocol Obfuscation"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2683
+#: src/muuli_wdr.cpp:2655
 msgid "This option enabled Protocol Obfuscation, and makes aMule accept obfuscated connections from other clients."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2685
+#: src/muuli_wdr.cpp:2657
 msgid "Use obfuscation for outgoing connections"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2687
+#: src/muuli_wdr.cpp:2659
 msgid "This option makes aMule use Protocol Obfuscation when connecting other clients/servers."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2689
+#: src/muuli_wdr.cpp:2661
 msgid "Accept only obfuscated connections"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2690
+#: src/muuli_wdr.cpp:2662
 msgid "This option makes aMule only accept obfuscated connections. You will have less sources, but all your traffic will be obfuscated"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2695
+#: src/muuli_wdr.cpp:2667
 msgid "Everybody"
 msgstr "Jebkurš"
 
-#: src/muuli_wdr.cpp:2697
+#: src/muuli_wdr.cpp:2669
 msgid "No one"
 msgstr "Neviens"
 
-#: src/muuli_wdr.cpp:2699
+#: src/muuli_wdr.cpp:2671
 msgid "Who can see my shared files:"
 msgstr "Kas var skatīt manas kopīgotās datnes:"
 
-#: src/muuli_wdr.cpp:2700
+#: src/muuli_wdr.cpp:2672
 msgid "Select who can request to view a list of your shared files."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2702
+#: src/muuli_wdr.cpp:2674
 msgid "IP-Filtering"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2709
+#: src/muuli_wdr.cpp:2681
 msgid "Filter clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2711
+#: src/muuli_wdr.cpp:2683
 msgid "Enable filtering of the client IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2713
+#: src/muuli_wdr.cpp:2685
 msgid "Filter servers"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2715
+#: src/muuli_wdr.cpp:2687
 msgid "Enable filtering of the server IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2719
+#: src/muuli_wdr.cpp:2691
 msgid "Reload List"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2720
+#: src/muuli_wdr.cpp:2692
 msgid "Reload the list of IPs to filter from the file ~/.aMule/ipfilter.dat"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2726
+#: src/muuli_wdr.cpp:2698
 msgid "URL:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2730 src/muuli_wdr.cpp:2923
+#: src/muuli_wdr.cpp:2702 src/muuli_wdr.cpp:2895
 msgid "Update now"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2733
+#: src/muuli_wdr.cpp:2705
 msgid "Auto-update ipfilter at startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2737
+#: src/muuli_wdr.cpp:2709
 msgid "Filtering Level:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2743
+#: src/muuli_wdr.cpp:2715
 msgid "Always filter LAN IPs"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2746
+#: src/muuli_wdr.cpp:2718
 msgid "Paranoid handling of non-matching IPs"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2748
+#: src/muuli_wdr.cpp:2720
 msgid "Rejects a packet when its source IP differs from the IP the client claims (an anti-spoofing check). Disable only if it causes connection problems."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2750
+#: src/muuli_wdr.cpp:2722
 msgid "Use system-wide ipfilter.dat if available"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2751
+#: src/muuli_wdr.cpp:2723
 msgid "If there's no local ipfilter.dat found, allow usage of a system-wide ipfilter file."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2768
+#: src/muuli_wdr.cpp:2740
 msgid "Enable Online-Signature"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2770
+#: src/muuli_wdr.cpp:2742
 msgid "Enables the writing of the OS file, which can be used by external apps to create signatures and the like."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2774
+#: src/muuli_wdr.cpp:2746
 msgid "Update Frequency (Secs):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2777
+#: src/muuli_wdr.cpp:2749
 msgid "Change the frequency (in seconds) of Online Signature updates."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2785
+#: src/muuli_wdr.cpp:2757
 msgid "Save online signature file in: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:2791
+#: src/muuli_wdr.cpp:2763
 msgid "Click here to select the directory containing the the Online Signature files."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2824
+#: src/muuli_wdr.cpp:2796
 msgid "Show country flags for clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2825
+#: src/muuli_wdr.cpp:2797
 msgid "Render the country flag column in the transfers, queue and search views. Requires a valid MMDB GeoIP database (see below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2830
+#: src/muuli_wdr.cpp:2802
 msgid "Database"
 msgstr "Datubāze"
 
-#: src/muuli_wdr.cpp:2846
+#: src/muuli_wdr.cpp:2818
 msgid "Source:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2849
+#: src/muuli_wdr.cpp:2821
 msgid "DB-IP (free, no account)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2850
+#: src/muuli_wdr.cpp:2822
 msgid "MaxMind GeoLite2 (free, account required)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2851
+#: src/muuli_wdr.cpp:2823
 msgid "Custom URL"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2854
+#: src/muuli_wdr.cpp:2826
 msgid "Choose which provider supplies the GeoIP MMDB database. DB-IP is the default - no account required. MaxMind requires a free account + license key. Use Custom URL to point at any other MMDB host (e.g. a local mirror)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2871
+#: src/muuli_wdr.cpp:2843
 msgid ""
 "No configuration required.\n"
 "\n"
@@ -4779,11 +4747,11 @@ msgid ""
 "License: Creative Commons BY 4.0 - https://creativecommons.org/licenses/by/4.0/"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2884
+#: src/muuli_wdr.cpp:2856
 msgid "License key:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2890
+#: src/muuli_wdr.cpp:2862
 msgid ""
 "Sign up for a free MaxMind account, then generate a License Key:\n"
 "https://www.maxmind.com/en/geolite2/signup\n"
@@ -4793,222 +4761,222 @@ msgid ""
 "Requires attribution and account registration; refresh at least every 30 days."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2905
+#: src/muuli_wdr.cpp:2877
 msgid "Download URL:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2911
+#: src/muuli_wdr.cpp:2883
 msgid ""
 "Must point to an .mmdb file or a .gz / .tar.gz containing one.\n"
 "URL may include credentials (https://user:pass@host/...).\n"
 "License and attribution terms are set by the upstream URL - you are responsible."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2924
+#: src/muuli_wdr.cpp:2896
 msgid "Download the GeoIP database from the selected source."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2926
+#: src/muuli_wdr.cpp:2898
 msgid "Auto-update on startup"
 msgstr "Kad palaiž, automātiski atjaunināt"
 
-#: src/muuli_wdr.cpp:2927
+#: src/muuli_wdr.cpp:2899
 msgid "Re-download the GeoIP database from the selected source every time aMule starts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2950
+#: src/muuli_wdr.cpp:2922
 msgid "Filter incoming messages (except current chat):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2952
+#: src/muuli_wdr.cpp:2924
 msgid "Filter all messages"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2954
+#: src/muuli_wdr.cpp:2926
 msgid "Filter messages from people not on your friend list"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2956
+#: src/muuli_wdr.cpp:2928
 msgid "Filter messages from unknown clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2958
+#: src/muuli_wdr.cpp:2930
 msgid "Filter messages containing (use ',' as separator):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2961 src/muuli_wdr.cpp:2972
+#: src/muuli_wdr.cpp:2933 src/muuli_wdr.cpp:2944
 msgid "add here the words amule should filter and block messages including it"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2963
+#: src/muuli_wdr.cpp:2935
 msgid "Show received messages in the log"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2966
+#: src/muuli_wdr.cpp:2938
 msgid "Comments"
 msgstr "Komentāri"
 
-#: src/muuli_wdr.cpp:2969
+#: src/muuli_wdr.cpp:2941
 msgid "Filter comments containing (use ',' as separator):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2994
+#: src/muuli_wdr.cpp:2966
 msgid "Enable Proxy"
 msgstr "Izmantot starpniekserveri"
 
-#: src/muuli_wdr.cpp:2995
+#: src/muuli_wdr.cpp:2967
 msgid "Enable/disable proxy support"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2998
+#: src/muuli_wdr.cpp:2970
 msgid "Proxy type:"
 msgstr "Starpniekservera tips:"
 
-#: src/muuli_wdr.cpp:3009
+#: src/muuli_wdr.cpp:2981
 msgid "Proxy host:"
 msgstr "Starpniekserveris:"
 
-#: src/muuli_wdr.cpp:3012
+#: src/muuli_wdr.cpp:2984
 msgid "The proxy host name"
 msgstr "Starpniekservera resursdatora nosaukums"
 
-#: src/muuli_wdr.cpp:3014
+#: src/muuli_wdr.cpp:2986
 msgid "Proxy port:"
 msgstr "Starpniekservera ports:"
 
-#: src/muuli_wdr.cpp:3017
+#: src/muuli_wdr.cpp:2989
 msgid "The proxy port"
 msgstr "Starpniekservera ports"
 
-#: src/muuli_wdr.cpp:3019
+#: src/muuli_wdr.cpp:2991
 msgid "Enable authentication"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3020
+#: src/muuli_wdr.cpp:2992
 msgid "Enable/disable username/password authentication"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3023
+#: src/muuli_wdr.cpp:2995
 msgid "Username: "
 msgstr "Lietotājvārds: "
 
-#: src/muuli_wdr.cpp:3026
+#: src/muuli_wdr.cpp:2998
 msgid "The username to use to connect to the proxy"
 msgstr "Lietotājvārds, ko lietot, kad izmanto starpniekserveri"
 
-#: src/muuli_wdr.cpp:3028
+#: src/muuli_wdr.cpp:3000
 msgid "Password:"
 msgstr "Parole:"
 
-#: src/muuli_wdr.cpp:3031
+#: src/muuli_wdr.cpp:3003
 msgid "The password to use to connect to the proxy"
 msgstr "Parole, ko lietot, kad izmanto starpniekserveri"
 
-#: src/muuli_wdr.cpp:3050
+#: src/muuli_wdr.cpp:3022
 msgid "Connect to:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3059
+#: src/muuli_wdr.cpp:3031
 msgid "Login to remote amule"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3064
+#: src/muuli_wdr.cpp:3036
 msgid "User name"
 msgstr "Lietotājvārds"
 
-#: src/muuli_wdr.cpp:3075
+#: src/muuli_wdr.cpp:3047
 msgid "Remember those settings"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3078
+#: src/muuli_wdr.cpp:3050
 msgid "Force ZLIB compression"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3102
+#: src/muuli_wdr.cpp:3074
 msgid "Enable Verbose Debug-Logging."
 msgstr ""
 
-#: src/muuli_wdr.cpp:3104
+#: src/muuli_wdr.cpp:3076
 msgid "Only to Logfile"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3106
+#: src/muuli_wdr.cpp:3078
 msgid "Message Categories:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3130 src/PartFileConvertDlg.cpp:160
+#: src/muuli_wdr.cpp:3102 src/PartFileConvertDlg.cpp:160
 msgid "Waiting..."
 msgstr "Gaida…"
 
-#: src/muuli_wdr.cpp:3150
+#: src/muuli_wdr.cpp:3122
 msgid "Add imports"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3153
+#: src/muuli_wdr.cpp:3125
 msgid "Retry selected"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3155
+#: src/muuli_wdr.cpp:3127
 msgid "Remove selected"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3218
+#: src/muuli_wdr.cpp:3190
 msgid "Event Types"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3237
+#: src/muuli_wdr.cpp:3209
 msgid "Statistics and queued clients for selected file(s) : Session / All time"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3261
+#: src/muuli_wdr.cpp:3233
 msgid "Active Uploads"
 msgstr "Aktīvas augšupielādes"
 
-#: src/muuli_wdr.cpp:3275
+#: src/muuli_wdr.cpp:3247
 msgid "Percent of total files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3327
+#: src/muuli_wdr.cpp:3299
 msgid "Show Clients for"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3329
+#: src/muuli_wdr.cpp:3301
 msgid "All files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3332
+#: src/muuli_wdr.cpp:3304
 msgid "Selected files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3335
+#: src/muuli_wdr.cpp:3307
 msgid "Active uploads only"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3342
+#: src/muuli_wdr.cpp:3314
 msgid "Reload:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3346
+#: src/muuli_wdr.cpp:3318
 msgid "Reload your shared files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3409
+#: src/muuli_wdr.cpp:3381
 msgid "Send"
 msgstr "Sūtīt"
 
-#: src/muuli_wdr.cpp:3410
+#: src/muuli_wdr.cpp:3382
 msgid "Sends the specified message."
 msgstr ""
 
-#: src/muuli_wdr.cpp:3414
+#: src/muuli_wdr.cpp:3386
 msgid "Close this chat-session."
 msgstr ""
 
-#: src/muuli_wdr.cpp:3437
+#: src/muuli_wdr.cpp:3409
 msgid "Connect to any server and/or Kad"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3443 src/SharedFilesCtrl.cpp:142 src/Statistics.cpp:941
+#: src/muuli_wdr.cpp:3415 src/SharedFilesCtrl.cpp:142 src/Statistics.cpp:941
 msgid "Shared Files"
 msgstr "Kopīgotās datnes"
 
@@ -5367,263 +5335,263 @@ msgstr "Lejupielādēta"
 msgid "ERROR: Failed to open partfile '%s'"
 msgstr ""
 
-#: src/Preferences.cpp:701
+#: src/Preferences.cpp:673
 msgid "System default"
 msgstr "Sistēmas"
 
-#: src/Preferences.cpp:702
+#: src/Preferences.cpp:674
 msgid "Albanian"
 msgstr "Albāņu"
 
-#: src/Preferences.cpp:703
+#: src/Preferences.cpp:675
 msgid "Arabic"
 msgstr "Arābu"
 
-#: src/Preferences.cpp:704
+#: src/Preferences.cpp:676
 msgid "Asturian"
 msgstr "Astūriešu"
 
-#: src/Preferences.cpp:705
+#: src/Preferences.cpp:677
 msgid "Basque"
 msgstr "Basku"
 
-#: src/Preferences.cpp:706
+#: src/Preferences.cpp:678
 msgid "Bulgarian"
 msgstr "Bulgāru"
 
-#: src/Preferences.cpp:707
+#: src/Preferences.cpp:679
 msgid "Catalan"
 msgstr "Katalāņu"
 
-#: src/Preferences.cpp:708
+#: src/Preferences.cpp:680
 msgid "Chinese (Simplified)"
 msgstr "Ķīniešu (vienkāršotā)"
 
-#: src/Preferences.cpp:709
+#: src/Preferences.cpp:681
 msgid "Chinese (Traditional)"
 msgstr "Ķīniešu (tradicionālā)"
 
-#: src/Preferences.cpp:710
+#: src/Preferences.cpp:682
 msgid "Croatian"
 msgstr "Horvātu"
 
-#: src/Preferences.cpp:711
+#: src/Preferences.cpp:683
 msgid "Czech"
 msgstr "Čehu"
 
-#: src/Preferences.cpp:712
+#: src/Preferences.cpp:684
 msgid "Danish"
 msgstr "Dāņu"
 
-#: src/Preferences.cpp:713
+#: src/Preferences.cpp:685
 msgid "Dutch"
 msgstr "Nīderlandiešu"
 
-#: src/Preferences.cpp:714
+#: src/Preferences.cpp:686
 msgid "English (U.K.)"
 msgstr "Angļu (Apvienotās Karalistes)"
 
-#: src/Preferences.cpp:715
+#: src/Preferences.cpp:687
 msgid "English (U.S.)"
 msgstr "Angļu (ASV)"
 
-#: src/Preferences.cpp:716
+#: src/Preferences.cpp:688
 msgid "Estonian"
 msgstr "Igauņu"
 
-#: src/Preferences.cpp:717
+#: src/Preferences.cpp:689
 msgid "Finnish"
 msgstr "Somu"
 
-#: src/Preferences.cpp:718
+#: src/Preferences.cpp:690
 msgid "French"
 msgstr "Franču"
 
-#: src/Preferences.cpp:719
+#: src/Preferences.cpp:691
 msgid "Galician"
 msgstr "Galisiešu"
 
-#: src/Preferences.cpp:720
+#: src/Preferences.cpp:692
 msgid "German"
 msgstr "Vācu"
 
-#: src/Preferences.cpp:721
+#: src/Preferences.cpp:693
 msgid "Greek"
 msgstr "Grieķu"
 
-#: src/Preferences.cpp:722
+#: src/Preferences.cpp:694
 msgid "Hebrew"
 msgstr "Ivrits"
 
-#: src/Preferences.cpp:723
+#: src/Preferences.cpp:695
 msgid "Hungarian"
 msgstr "Ungāru"
 
-#: src/Preferences.cpp:724
+#: src/Preferences.cpp:696
 msgid "Italian"
 msgstr "Itāļu"
 
-#: src/Preferences.cpp:725
+#: src/Preferences.cpp:697
 msgid "Japanese"
 msgstr "Japāņu"
 
-#: src/Preferences.cpp:726
+#: src/Preferences.cpp:698
 msgid "Korean"
 msgstr "Korejiešu"
 
-#: src/Preferences.cpp:727
+#: src/Preferences.cpp:699
 msgid "Latvian"
 msgstr ""
 
-#: src/Preferences.cpp:728
+#: src/Preferences.cpp:700
 msgid "Lithuanian"
 msgstr "Lietuviešu"
 
-#: src/Preferences.cpp:729
+#: src/Preferences.cpp:701
 msgid "Norwegian (Nynorsk)"
 msgstr "Norvēģu (Jaunnorvēģu)"
 
-#: src/Preferences.cpp:730
+#: src/Preferences.cpp:702
 msgid "Polish"
 msgstr "Poļu"
 
-#: src/Preferences.cpp:731
+#: src/Preferences.cpp:703
 msgid "Portuguese"
 msgstr "Portugāļu"
 
-#: src/Preferences.cpp:732
+#: src/Preferences.cpp:704
 msgid "Portuguese (Brazilian)"
 msgstr "Portugāļu (Brazīlijas)"
 
-#: src/Preferences.cpp:733
+#: src/Preferences.cpp:705
 msgid "Romanian"
 msgstr "Rumāņu"
 
-#: src/Preferences.cpp:734
+#: src/Preferences.cpp:706
 msgid "Russian"
 msgstr "Krievu"
 
-#: src/Preferences.cpp:735
+#: src/Preferences.cpp:707
 msgid "Slovenian"
 msgstr "Slovēņu"
 
-#: src/Preferences.cpp:736
+#: src/Preferences.cpp:708
 msgid "Spanish"
 msgstr "Spāņu"
 
-#: src/Preferences.cpp:737
+#: src/Preferences.cpp:709
 msgid "Swedish"
 msgstr "Zviedru"
 
-#: src/Preferences.cpp:738
+#: src/Preferences.cpp:710
 msgid "Turkish"
 msgstr "Turku"
 
-#: src/Preferences.cpp:739
+#: src/Preferences.cpp:711
 msgid "Ukrainian"
 msgstr "Ukraiņu"
 
-#: src/Preferences.cpp:842
+#: src/Preferences.cpp:814
 msgid "Change Language"
 msgstr "Mainīt valodu"
 
-#: src/Preferences.cpp:906
+#: src/Preferences.cpp:878
 msgid "There are no translations installed for aMule"
 msgstr "aMule nav uzstādīta neviena valodas datne"
 
-#: src/Preferences.cpp:907
+#: src/Preferences.cpp:879
 msgid "No languages available"
 msgstr "Nav pieejama neviena valoda"
 
-#: src/Preferences.cpp:1038
+#: src/Preferences.cpp:1010
 msgid "no options available"
 msgstr ""
 
-#: src/Preferences.cpp:2226
+#: src/Preferences.cpp:2179
 msgid "Invalid category found, skipping"
 msgstr ""
 
-#: src/Preferences.cpp:2395
+#: src/Preferences.cpp:2348
 msgid "TCP port can't be higher than 65532 due to server UDP socket being TCP+3"
 msgstr ""
 
-#: src/Preferences.cpp:2396
+#: src/Preferences.cpp:2349
 #, c-format
 msgid "Default port will be used (%d)"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:300 src/Statistics.cpp:866
+#: src/PrefsUnifiedDlg.cpp:298 src/Statistics.cpp:866
 msgid "Connection"
 msgstr "Savienojums"
 
-#: src/PrefsUnifiedDlg.cpp:301 src/SearchListCtrl.cpp:117
+#: src/PrefsUnifiedDlg.cpp:299 src/SearchListCtrl.cpp:117
 msgid "Directories"
 msgstr "Mapes"
 
-#: src/PrefsUnifiedDlg.cpp:302 src/Statistics.cpp:917
+#: src/PrefsUnifiedDlg.cpp:300 src/Statistics.cpp:917
 msgid "Servers"
 msgstr "Serveri"
 
-#: src/PrefsUnifiedDlg.cpp:303 src/ServerListCtrl.cpp:96
+#: src/PrefsUnifiedDlg.cpp:301 src/ServerListCtrl.cpp:96
 msgid "Files"
 msgstr "Datnes"
 
-#: src/PrefsUnifiedDlg.cpp:304
+#: src/PrefsUnifiedDlg.cpp:302
 msgid "Security"
 msgstr "Drošība"
 
-#: src/PrefsUnifiedDlg.cpp:305
+#: src/PrefsUnifiedDlg.cpp:303
 msgid "Interface"
 msgstr "Saskarne"
 
-#: src/PrefsUnifiedDlg.cpp:312
+#: src/PrefsUnifiedDlg.cpp:310
 msgid "IP2Country"
 msgstr "IP2Country"
 
-#: src/PrefsUnifiedDlg.cpp:315
+#: src/PrefsUnifiedDlg.cpp:313
 msgid "Proxy"
 msgstr "Starpniekserveris"
 
-#: src/PrefsUnifiedDlg.cpp:316
+#: src/PrefsUnifiedDlg.cpp:314
 msgid "Filters"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:317
+#: src/PrefsUnifiedDlg.cpp:315
 msgid "Remote Controls"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:318
+#: src/PrefsUnifiedDlg.cpp:316
 msgid "Online Signature"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:319
+#: src/PrefsUnifiedDlg.cpp:317
 msgid "Advanced"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:320
+#: src/PrefsUnifiedDlg.cpp:318
 msgid "Events"
 msgstr "Notikumi"
 
-#: src/PrefsUnifiedDlg.cpp:323
+#: src/PrefsUnifiedDlg.cpp:321
 msgid "Debugging"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:453
+#: src/PrefsUnifiedDlg.cpp:451
 msgid ""
 "The following variables will be substituted:\n"
 "    %PARTFILE - full path to the file\n"
 "    %PARTNAME - file name only"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:474
+#: src/PrefsUnifiedDlg.cpp:472
 msgid "Tray icon support requires libayatana-appindicator3 at compile time."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:490
+#: src/PrefsUnifiedDlg.cpp:488
 msgid "Not available on Wayland: the protocol does not report when a window is minimized, so this option cannot intercept the system minimize button. Workaround: launch aMule with `GDK_BACKEND=x11` to use XWayland instead."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:536
+#: src/PrefsUnifiedDlg.cpp:534
 msgid ""
 "Do not change these setting unless you know\n"
 "what you are doing, otherwise you can easily\n"
@@ -5633,73 +5601,64 @@ msgid ""
 "these settings."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:647
+#: src/PrefsUnifiedDlg.cpp:645
 #, c-format
 msgid "Failed to connect Cfg to widget with the ID %d and key %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:695
+#: src/PrefsUnifiedDlg.cpp:693
 #, c-format
 msgid "Failed to transfer data from Cfg to Widget with the ID %d and key %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:801
+#: src/PrefsUnifiedDlg.cpp:799
 msgid "The type of proxy you are connecting to"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1020
+#: src/PrefsUnifiedDlg.cpp:1003
 #, c-format
 msgid "Failed to transfer data from Widget to Cfg with the ID %d and key %s"
 msgstr ""
 
 #: src/PrefsUnifiedDlg.cpp:1103
-#, fuzzy
-msgid "No password set."
-msgstr "Parole"
-
-#: src/PrefsUnifiedDlg.cpp:1132
-msgid "Guest access needs a password. Type one in the guest password field, or untick Enable guest access."
-msgstr ""
-
-#: src/PrefsUnifiedDlg.cpp:1144
 msgid ""
 "aMule must be restarted to enable these changes:\n"
 "\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1151
+#: src/PrefsUnifiedDlg.cpp:1110
 msgid "- TCP port changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1156
+#: src/PrefsUnifiedDlg.cpp:1115
 msgid "- UDP port changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1161
+#: src/PrefsUnifiedDlg.cpp:1120
 msgid "- Network interface binding changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1166
+#: src/PrefsUnifiedDlg.cpp:1125
 msgid "- External connect port changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1170
+#: src/PrefsUnifiedDlg.cpp:1129
 msgid "- External connect acceptance changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1174
+#: src/PrefsUnifiedDlg.cpp:1133
 msgid "- External connect interface changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1178
+#: src/PrefsUnifiedDlg.cpp:1137
 msgid "- Protocol obfuscation support changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1193
+#: src/PrefsUnifiedDlg.cpp:1151
 msgid "- amuleapi settings changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1202
+#: src/PrefsUnifiedDlg.cpp:1160
 msgid ""
 "Your Auto-update server list is empty.\n"
 "'Auto-update server list at startup' will be disabled."
@@ -5707,140 +5666,135 @@ msgstr ""
 "Jūsu automātiskās atjaunināšanas serveru saraksts ir tukšs.\n"
 "'Kad palaiž, automātiski atjaunināt serveru sarakstu' iestatījums tiks atspējots."
 
-#: src/PrefsUnifiedDlg.cpp:1213
+#: src/PrefsUnifiedDlg.cpp:1171
 msgid ""
 "You have enabled external connections but have not specified a password.\n"
 "External connections cannot be enabled unless a valid password is specified."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1246
-#, c-format
-msgid "The amuleapi password could not be saved: %s"
-msgstr ""
-
-#: src/PrefsUnifiedDlg.cpp:1276
+#: src/PrefsUnifiedDlg.cpp:1202
 msgid "- Language changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1281
+#: src/PrefsUnifiedDlg.cpp:1207
 msgid "- Temp folder changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1286
+#: src/PrefsUnifiedDlg.cpp:1212
 msgid "- ED2K network enabled.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1319
+#: src/PrefsUnifiedDlg.cpp:1245
 msgid "The shared-file exclusion pattern is not a valid regular expression. The filter has been left disabled."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1321 src/PrefsUnifiedDlg.cpp:1921
+#: src/PrefsUnifiedDlg.cpp:1247 src/PrefsUnifiedDlg.cpp:1841
 msgid "Invalid regular expression"
 msgstr "Nederīga regulārā izteiksme"
 
-#: src/PrefsUnifiedDlg.cpp:1398
+#: src/PrefsUnifiedDlg.cpp:1324
 msgid ""
 "Both eD2k and Kad network are disabled.\n"
 "You won't be able to connect until you enable at least one of them."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1403
+#: src/PrefsUnifiedDlg.cpp:1329
 msgid ""
 "Kad will not start if your UDP port is disabled.\n"
 "Enable UDP port or disable Kad."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1459
+#: src/PrefsUnifiedDlg.cpp:1385
 msgid ""
 "\n"
 "You MUST restart aMule now.\n"
 "If you do not restart now, don't complain if anything bad happens.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1524
+#: src/PrefsUnifiedDlg.cpp:1450
 msgid "Could not register aMule for autostart at login. The autostart store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1526
+#: src/PrefsUnifiedDlg.cpp:1452
 msgid "Could not remove the autostart-at-login entry."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1527
+#: src/PrefsUnifiedDlg.cpp:1453
 msgid "Autostart"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1542
+#: src/PrefsUnifiedDlg.cpp:1468
 msgid "Register file type"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1542
+#: src/PrefsUnifiedDlg.cpp:1468
 msgid "Register URL handler"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1550
+#: src/PrefsUnifiedDlg.cpp:1476
 #, c-format
 msgid "aMule only handles eD2k-compatible magnets. If you replace the current magnet handler (%s), BitTorrent magnet links will stop working - aMule cannot download BitTorrent content. Continue?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1555
+#: src/PrefsUnifiedDlg.cpp:1481
 #, c-format
 msgid "Another application currently opens .emulecollection files (%s). Replace it with aMule?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1560
+#: src/PrefsUnifiedDlg.cpp:1486
 #, c-format
 msgid "Another application is currently the default handler for these links (%s). Replace it with aMule?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1585
+#: src/PrefsUnifiedDlg.cpp:1511
 msgid "Could not register aMule for .emulecollection files. The registration store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1587
+#: src/PrefsUnifiedDlg.cpp:1513
 msgid "Could not remove the file type registration."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1589
+#: src/PrefsUnifiedDlg.cpp:1515
 msgid "Could not register aMule as the URL handler. The registration store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1591
+#: src/PrefsUnifiedDlg.cpp:1517
 msgid "Could not remove the URL handler registration."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1661 src/PrefsUnifiedDlg.cpp:1688
+#: src/PrefsUnifiedDlg.cpp:1587 src/PrefsUnifiedDlg.cpp:1614
 msgid "The web server and aMule API require external connections to be enabled."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1671
+#: src/PrefsUnifiedDlg.cpp:1597
 msgid "The aMule web server is deprecated. Consider running the aMule API instead."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1735
+#: src/PrefsUnifiedDlg.cpp:1655
 msgid ""
 "Your Auto-update servers list is in blank.\n"
 "Please fill in at least one URL to point to a valid server.met file.\n"
 "Click on the button \"List\" by this checkbox to enter an URL."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1876
+#: src/PrefsUnifiedDlg.cpp:1796
 msgid "Temporary files"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1881
+#: src/PrefsUnifiedDlg.cpp:1801
 msgid "Incoming files"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1886
+#: src/PrefsUnifiedDlg.cpp:1806
 msgid "Online Signatures"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1899
+#: src/PrefsUnifiedDlg.cpp:1819
 #, c-format
 msgid "Choose a folder for %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1923
+#: src/PrefsUnifiedDlg.cpp:1843
 #, c-format
 msgid "Would exclude %u of %u shared file"
 msgid_plural "Would exclude %u of %u shared files"
@@ -5848,100 +5802,100 @@ msgstr[0] ""
 msgstr[1] ""
 msgstr[2] ""
 
-#: src/PrefsUnifiedDlg.cpp:1940
+#: src/PrefsUnifiedDlg.cpp:1860
 msgid "Browse for videoplayer"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1944
+#: src/PrefsUnifiedDlg.cpp:1864
 msgid "Select browser"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1948
+#: src/PrefsUnifiedDlg.cpp:1868
 msgid "Select ffprobe binary"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1954
+#: src/PrefsUnifiedDlg.cpp:1874
 #, c-format
 msgid "Executable%s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1988
+#: src/PrefsUnifiedDlg.cpp:1908
 msgid "ffprobe not found on PATH or in the standard install locations. Install ffmpeg (which ships ffprobe) or use Browse to pick a binary manually."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2000
+#: src/PrefsUnifiedDlg.cpp:1920
 msgid "Reset the settings on this page to their default values?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2001
+#: src/PrefsUnifiedDlg.cpp:1921
 #, fuzzy
 msgid "Reset to defaults"
 msgstr "Sistēmas"
 
-#: src/PrefsUnifiedDlg.cpp:2028
+#: src/PrefsUnifiedDlg.cpp:1948
 msgid "Edit server list"
 msgstr "Rediģēt serveru sarakstu"
 
-#: src/PrefsUnifiedDlg.cpp:2029
+#: src/PrefsUnifiedDlg.cpp:1949
 msgid ""
 "Add here URL's to download server.met files.\n"
 "Only one url on each line."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2084
+#: src/PrefsUnifiedDlg.cpp:2004
 msgid "IP2Country update failed"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2229 src/PrefsUnifiedDlg.cpp:2260
+#: src/PrefsUnifiedDlg.cpp:2149 src/PrefsUnifiedDlg.cpp:2180
 msgid "Data by MaxMind GeoLite2"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2231 src/PrefsUnifiedDlg.cpp:2262
+#: src/PrefsUnifiedDlg.cpp:2151 src/PrefsUnifiedDlg.cpp:2182
 msgid "Custom source"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2233 src/PrefsUnifiedDlg.cpp:2264
+#: src/PrefsUnifiedDlg.cpp:2153 src/PrefsUnifiedDlg.cpp:2184
 msgid "Data by DB-IP.com"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2284
+#: src/PrefsUnifiedDlg.cpp:2204
 #, c-format
 msgid "Status: Loaded%s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2286
+#: src/PrefsUnifiedDlg.cpp:2206
 #, c-format
 msgid "Status: Loaded%s - %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2290
+#: src/PrefsUnifiedDlg.cpp:2210
 msgid "Status: Failed to load - click 'Update now' to refresh."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2292
+#: src/PrefsUnifiedDlg.cpp:2212
 msgid "Status: Not found - click 'Update now' to download."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2350 src/PrefsUnifiedDlg.cpp:2374
+#: src/PrefsUnifiedDlg.cpp:2270 src/PrefsUnifiedDlg.cpp:2294
 #, c-format
 msgid "Update delay: %d second"
 msgid_plural "Update delay: %d seconds"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/PrefsUnifiedDlg.cpp:2358
+#: src/PrefsUnifiedDlg.cpp:2278
 #, c-format
 msgid "Time for average graph: %d minute"
 msgid_plural "Time for average graph: %d minutes"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/PrefsUnifiedDlg.cpp:2367
+#: src/PrefsUnifiedDlg.cpp:2287
 #, c-format
 msgid "Connections Graph Scale: %d"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2382
+#: src/PrefsUnifiedDlg.cpp:2302
 #, c-format
 msgid "File Buffer Size: %d byte"
 msgid_plural "File Buffer Size: %d bytes"
@@ -5949,115 +5903,111 @@ msgstr[0] "Datnes bufera izmērs: %d baiti"
 msgstr[1] "Datnes bufera izmērs: %d baits"
 msgstr[2] "Datnes bufera izmērs: %d baiti"
 
-#: src/PrefsUnifiedDlg.cpp:2392
+#: src/PrefsUnifiedDlg.cpp:2312
 #, c-format
 msgid "Upload Queue Size: %d client"
 msgid_plural "Upload Queue Size: %d clients"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/PrefsUnifiedDlg.cpp:2402
+#: src/PrefsUnifiedDlg.cpp:2322
 #, c-format
 msgid "Server connection refresh interval: %d minute"
 msgid_plural "Server connection refresh interval: %d minutes"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/PrefsUnifiedDlg.cpp:2407
+#: src/PrefsUnifiedDlg.cpp:2327
 msgid "Server connection refresh interval: Disabled"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2451
+#: src/PrefsUnifiedDlg.cpp:2371
 msgid "disabled"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2477
+#: src/PrefsUnifiedDlg.cpp:2397
 #, c-format
 msgid "Execute command on '%s' event"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2484
+#: src/PrefsUnifiedDlg.cpp:2404
 msgid "Enable command execution on core"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2496
+#: src/PrefsUnifiedDlg.cpp:2416
 msgid "Core command:"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2512
+#: src/PrefsUnifiedDlg.cpp:2432
 msgid "Enable command execution on GUI"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2524
+#: src/PrefsUnifiedDlg.cpp:2444
 msgid "GUI command:"
 msgstr "GUI komanda:"
 
-#: src/PrefsUnifiedDlg.cpp:2540
+#: src/PrefsUnifiedDlg.cpp:2460
 msgid "The following variables will be replaced:"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2708
+#: src/PrefsUnifiedDlg.cpp:2628
 msgid ""
 "The following folders look like system or sensitive locations:\n"
 "\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2713
+#: src/PrefsUnifiedDlg.cpp:2633
 msgid "Sharing them recursively will publish every file underneath on the eD2k/Kad networks. Do you really want to do this?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2716
+#: src/PrefsUnifiedDlg.cpp:2636
 msgid "Confirm shared folders"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2744
+#: src/PrefsUnifiedDlg.cpp:2664
 msgid "Reloading shared files..."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2745
+#: src/PrefsUnifiedDlg.cpp:2665
 msgid "Scanning for subdirectories..."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2746
+#: src/PrefsUnifiedDlg.cpp:2666
 msgid "Updating shared folders"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2773
+#: src/PrefsUnifiedDlg.cpp:2693
 #, c-format
 msgid "Scanned %u directories..."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2823
+#: src/PrefsUnifiedDlg.cpp:2743
 #, c-format
 msgid "Reloading shared files: %u files scanned"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2873
+#: src/PrefsUnifiedDlg.cpp:2793
 #, fuzzy
 msgid "Shared folder"
 msgstr "Kopīgotās datnes"
 
-#: src/SearchDlg.cpp:280
-msgid "Clear search history"
-msgstr ""
-
-#: src/SearchDlg.cpp:584
+#: src/SearchDlg.cpp:425
 msgid "It's impossible to search when both eD2k and Kademlia are disabled."
 msgstr "Meklēšana nav iespējama, ja gan eD2k, gan Kademlia ir atspējoti."
 
-#: src/SearchDlg.cpp:585 src/SearchListCtrl.cpp:858
+#: src/SearchDlg.cpp:426 src/SearchListCtrl.cpp:858
 msgid "Search error"
 msgstr ""
 
-#: src/SearchDlg.cpp:929
+#: src/SearchDlg.cpp:768
 msgid "Min size must be smaller than max size. Max size ignored."
 msgstr ""
 
-#: src/SearchDlg.cpp:930 src/SearchDlg.cpp:1012
+#: src/SearchDlg.cpp:769 src/SearchDlg.cpp:851
 msgid "Search warning"
 msgstr ""
 
-#: src/SearchDlg.cpp:1092 src/SearchListCtrl.cpp:735
+#: src/SearchDlg.cpp:929 src/SearchListCtrl.cpp:735
 msgid "Main"
 msgstr ""
 

--- a/po/nl.po
+++ b/po/nl.po
@@ -12,7 +12,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-28 12:17+0200\n"
+"POT-Creation-Date: 2026-07-28 13:09+0200\n"
 "PO-Revision-Date: 2026-07-27 11:42+0000\n"
 "Last-Translator: Marcel Pol <marcel@timelord.nl>\n"
 "Language-Team: Dutch <nl@li.org>\n"
@@ -294,7 +294,7 @@ msgid "Password set and external connections enabled."
 msgstr "Wachtwoord ingesteld en externe verbindingen ingeschakeld."
 
 #: src/amule.cpp:755 src/KadDlg.cpp:176 src/KadDlg.cpp:185
-#: src/PrefsUnifiedDlg.cpp:1461 src/SharedFilesCtrl.cpp:476
+#: src/PrefsUnifiedDlg.cpp:1470 src/SharedFilesCtrl.cpp:476
 msgid "WARNING"
 msgstr "WAARSCHUWING"
 
@@ -332,7 +332,7 @@ msgstr "U heeft ingesteld om de webserver te starten bij het opstarten, maar amu
 #: src/amule-remote-gui.cpp:603 src/amule-remote-gui.cpp:671
 #: src/amule-remote-gui.cpp:709 src/amule-remote-gui.cpp:1282
 #: src/amule-remote-gui.cpp:1345 src/amule-remote-gui.cpp:1372
-#: src/DownloadQueue.cpp:1481 src/PrefsUnifiedDlg.cpp:1247
+#: src/DownloadQueue.cpp:1481 src/PrefsUnifiedDlg.cpp:1256
 msgid "ERROR"
 msgstr "FOUT"
 
@@ -594,36 +594,36 @@ msgstr "Bezoek https://github.com/amule-org/amule/releases/latest om te zien of 
 msgid "FATAL ERROR: Failed to create Timer"
 msgstr "FATALE FOUT: Kon Timer niet aanmaken"
 
-#: src/amuleDlg.cpp:361 src/amuleDlg.cpp:1787 src/amuleDlg.cpp:2033
-#: src/muuli_wdr.cpp:1492 src/muuli_wdr.cpp:3449
+#: src/amuleDlg.cpp:361 src/amuleDlg.cpp:1810 src/amuleDlg.cpp:2056
+#: src/muuli_wdr.cpp:1492 src/muuli_wdr.cpp:3453
 msgid "Networks"
 msgstr "Netwerken"
 
-#: src/amuleDlg.cpp:362 src/amuleDlg.cpp:1793 src/muuli_wdr.cpp:3450
+#: src/amuleDlg.cpp:362 src/amuleDlg.cpp:1816 src/muuli_wdr.cpp:3454
 msgid "Searches"
 msgstr "Zoeken"
 
-#: src/amuleDlg.cpp:363 src/amuleDlg.cpp:1799 src/DownloadListCtrl.cpp:740
-#: src/muuli_wdr.cpp:392 src/muuli_wdr.cpp:1585 src/muuli_wdr.cpp:3451
+#: src/amuleDlg.cpp:363 src/amuleDlg.cpp:1822 src/DownloadListCtrl.cpp:740
+#: src/muuli_wdr.cpp:392 src/muuli_wdr.cpp:1585 src/muuli_wdr.cpp:3455
 #: src/Statistics.cpp:829
 msgid "Downloads"
 msgstr "Downloads"
 
-#: src/amuleDlg.cpp:364 src/amuleDlg.cpp:1805 src/muuli_wdr.cpp:3325
+#: src/amuleDlg.cpp:364 src/amuleDlg.cpp:1828 src/muuli_wdr.cpp:3329
 msgid "Shared files"
 msgstr "Gedeelde bestanden"
 
-#: src/amuleDlg.cpp:365 src/amuleDlg.cpp:1811 src/muuli_wdr.cpp:2957
-#: src/muuli_wdr.cpp:3407 src/muuli_wdr.cpp:3454
+#: src/amuleDlg.cpp:365 src/amuleDlg.cpp:1834 src/muuli_wdr.cpp:2961
+#: src/muuli_wdr.cpp:3411 src/muuli_wdr.cpp:3458
 msgid "Messages"
 msgstr "Berichten"
 
-#: src/amuleDlg.cpp:366 src/amuleDlg.cpp:1817 src/muuli_wdr.cpp:3455
+#: src/amuleDlg.cpp:366 src/amuleDlg.cpp:1840 src/muuli_wdr.cpp:3459
 #: src/PrefsUnifiedDlg.cpp:314 src/Statistics.cpp:779 src/Statistics.cpp:1235
 msgid "Statistics"
 msgstr "Statistieken"
 
-#: src/amuleDlg.cpp:368 src/amuleDlg.cpp:1824 src/muuli_wdr.cpp:3457
+#: src/amuleDlg.cpp:368 src/amuleDlg.cpp:1847 src/muuli_wdr.cpp:3461
 #: src/PrefsUnifiedDlg.cpp:330 src/utils/wxCas/src/wxcasprefs.cpp:39
 msgid "Preferences"
 msgstr "Voorkeuren"
@@ -682,8 +682,8 @@ msgstr "Kad: Uitgeschakeld"
 #: src/amuleDlg.cpp:1029 src/DownloadListCtrl.cpp:505
 #: src/DownloadListCtrl.cpp:749 src/FriendListCtrl.cpp:180
 #: src/muuli_wdr.cpp:731 src/muuli_wdr.cpp:782 src/muuli_wdr.cpp:846
-#: src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2262 src/muuli_wdr.cpp:2347
-#: src/muuli_wdr.cpp:3095 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
+#: src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2266 src/muuli_wdr.cpp:2351
+#: src/muuli_wdr.cpp:3099 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
 #: src/ServerListCtrl.cpp:606 src/TransferWnd.cpp:378
 #: src/utils/wxCas/src/wxcasprefs.cpp:235
 msgid "Cancel"
@@ -694,7 +694,7 @@ msgid "Stop the current connection attempts"
 msgstr "Beëindig de huidige verbindingspogingen"
 
 #: src/amuleDlg.cpp:1035 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976
-#: src/muuli_wdr.cpp:2485
+#: src/muuli_wdr.cpp:2489
 msgid "Disconnect"
 msgstr "Verbreek"
 
@@ -703,7 +703,7 @@ msgid "Disconnect from the currently connected networks"
 msgstr "Verbreek de huidige verbonden netwerken"
 
 #: src/amuleDlg.cpp:1041 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979
-#: src/muuli_wdr.cpp:2640 src/muuli_wdr.cpp:3092 src/muuli_wdr.cpp:3447
+#: src/muuli_wdr.cpp:2644 src/muuli_wdr.cpp:3096 src/muuli_wdr.cpp:3451
 msgid "Connect"
 msgstr "Verbinden"
 
@@ -757,7 +757,7 @@ msgstr "Bevestig afsluiten"
 msgid "Launch Command: "
 msgstr "Voer commando uit: "
 
-#: src/amuleDlg.cpp:1632 src/muuli_wdr.cpp:1982 src/Preferences.cpp:979
+#: src/amuleDlg.cpp:1632 src/muuli_wdr.cpp:1986 src/Preferences.cpp:979
 msgid "- default -"
 msgstr "- standaard -"
 
@@ -771,60 +771,60 @@ msgstr "Skinmap '%s' bestaat niet"
 msgid "WARNING: Unable to open skin file '%s' for read"
 msgstr "WAARSCHUWING: Kon skin-bestand '%s' niet openen om te lezen"
 
-#: src/amuleDlg.cpp:1791 src/muuli_wdr.cpp:3449
+#: src/amuleDlg.cpp:1814 src/muuli_wdr.cpp:3453
 msgid "Networks Window"
 msgstr "Netwerkvenster"
 
-#: src/amuleDlg.cpp:1797 src/muuli_wdr.cpp:3450
+#: src/amuleDlg.cpp:1820 src/muuli_wdr.cpp:3454
 msgid "Searches Window"
 msgstr "Zoekvenster"
 
-#: src/amuleDlg.cpp:1803 src/muuli_wdr.cpp:3451
+#: src/amuleDlg.cpp:1826 src/muuli_wdr.cpp:3455
 msgid "Downloads Window"
 msgstr "Downloadsvenster"
 
-#: src/amuleDlg.cpp:1809 src/muuli_wdr.cpp:3453
+#: src/amuleDlg.cpp:1832 src/muuli_wdr.cpp:3457
 msgid "Shared Files Window"
 msgstr "Gedeelde bestanden-venster"
 
-#: src/amuleDlg.cpp:1815 src/muuli_wdr.cpp:3454
+#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3458
 msgid "Messages Window"
 msgstr "Berichtenvenster"
 
-#: src/amuleDlg.cpp:1821 src/muuli_wdr.cpp:3455
+#: src/amuleDlg.cpp:1844 src/muuli_wdr.cpp:3459
 msgid "Statistics Graph Window"
 msgstr "Statistiekenvenster (Grafieken)"
 
-#: src/amuleDlg.cpp:1828 src/muuli_wdr.cpp:3457
+#: src/amuleDlg.cpp:1851 src/muuli_wdr.cpp:3461
 msgid "Preferences Settings Window"
 msgstr "Voorkeureninstellingen-venster"
 
-#: src/amuleDlg.cpp:1831 src/muuli_wdr.cpp:3458
+#: src/amuleDlg.cpp:1854 src/muuli_wdr.cpp:3462
 msgid "Import"
 msgstr "Importeer"
 
-#: src/amuleDlg.cpp:1835 src/muuli_wdr.cpp:3458
+#: src/amuleDlg.cpp:1858 src/muuli_wdr.cpp:3462
 msgid "The partfile importer tool"
 msgstr "Het deelbestand importeerprogramma"
 
-#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3459
+#: src/amuleDlg.cpp:1861 src/muuli_wdr.cpp:3463
 #: src/utils/aLinkCreator/src/alcframe.cpp:262
 msgid "About"
 msgstr "Over"
 
-#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3459
+#: src/amuleDlg.cpp:1861 src/muuli_wdr.cpp:3463
 msgid "About/Help"
 msgstr "Over/Help"
 
-#: src/amuleDlg.cpp:2036
+#: src/amuleDlg.cpp:2059
 msgid "eD2k network"
 msgstr "eD2k-netwerk"
 
-#: src/amuleDlg.cpp:2039
+#: src/amuleDlg.cpp:2062
 msgid "Kad network"
 msgstr "Kad netwerk"
 
-#: src/amuleDlg.cpp:2039
+#: src/amuleDlg.cpp:2062
 msgid "No network"
 msgstr "Geen netwerk"
 
@@ -1357,19 +1357,19 @@ msgstr "Auto [Ho]"
 msgid "Very low"
 msgstr "Heel laag"
 
-#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:743 src/muuli_wdr.cpp:2313
+#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:743 src/muuli_wdr.cpp:2317
 #: src/ServerListCtrl.cpp:263 src/ServerListCtrl.cpp:456
 #: src/SharedFilesCtrl.cpp:145
 msgid "Low"
 msgstr "Laag"
 
-#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:744 src/muuli_wdr.cpp:2314
+#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:744 src/muuli_wdr.cpp:2318
 #: src/ServerListCtrl.cpp:266 src/ServerListCtrl.cpp:457
 #: src/SharedFilesCtrl.cpp:146
 msgid "Normal"
 msgstr "Normaal"
 
-#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:745 src/muuli_wdr.cpp:2315
+#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:745 src/muuli_wdr.cpp:2319
 #: src/ServerListCtrl.cpp:269 src/ServerListCtrl.cpp:458
 #: src/SharedFilesCtrl.cpp:147
 msgid "High"
@@ -1461,7 +1461,7 @@ msgstr "Lokale server"
 msgid "Remote Server"
 msgstr "Server op Afstand"
 
-#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3212
+#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3216
 #: src/SearchDlg.cpp:119 src/TextClient.cpp:911
 msgid "Kad"
 msgstr "Kad"
@@ -1533,7 +1533,7 @@ msgstr "Deel"
 msgid "Size"
 msgstr "Grootte"
 
-#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3279
+#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3283
 msgid "Transferred"
 msgstr "Overgebracht"
 
@@ -1591,7 +1591,7 @@ msgstr ""
 "Feedback van: %s (%s)\n"
 "\n"
 
-#: src/DownloadListCtrl.cpp:746 src/muuli_wdr.cpp:2316
+#: src/DownloadListCtrl.cpp:746 src/muuli_wdr.cpp:2320
 #: src/SharedFilesCtrl.cpp:150
 msgid "Auto"
 msgstr "Auto"
@@ -1629,7 +1629,7 @@ msgid "Extended Options"
 msgstr "Uitgebreide opties"
 
 #: src/DownloadListCtrl.cpp:770 src/DownloadListCtrl.cpp:822
-#: src/muuli_wdr.cpp:1800
+#: src/muuli_wdr.cpp:1804
 msgid "Preview"
 msgstr "Voorbeeld"
 
@@ -2432,23 +2432,23 @@ msgid ""
 "want downloads on a different (e.g. larger) disk."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:549 src/FirstRunWizard.cpp:611 src/muuli_wdr.cpp:1712
+#: src/FirstRunWizard.cpp:549 src/FirstRunWizard.cpp:611 src/muuli_wdr.cpp:1716
 msgid "Destination folder for downloads"
 msgstr "Doelmap voor downloads"
 
 #: src/FirstRunWizard.cpp:553 src/FirstRunWizard.cpp:569 src/muuli_wdr.cpp:1349
-#: src/muuli_wdr.cpp:1366 src/muuli_wdr.cpp:1687 src/muuli_wdr.cpp:1718
-#: src/muuli_wdr.cpp:1730 src/muuli_wdr.cpp:2800
+#: src/muuli_wdr.cpp:1366 src/muuli_wdr.cpp:1691 src/muuli_wdr.cpp:1722
+#: src/muuli_wdr.cpp:1734 src/muuli_wdr.cpp:2804
 #: src/utils/aLinkCreator/src/alcframe.cpp:135
 #: src/utils/wxCas/src/wxcasprefs.cpp:52 src/utils/wxCas/src/wxcasprefs.cpp:118
 msgid "Browse"
 msgstr "Bladeren"
 
-#: src/FirstRunWizard.cpp:559 src/muuli_wdr.cpp:1723
+#: src/FirstRunWizard.cpp:559 src/muuli_wdr.cpp:1727
 msgid "(All files in this folder are shared with other peers)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:565 src/FirstRunWizard.cpp:624 src/muuli_wdr.cpp:1725
+#: src/FirstRunWizard.cpp:565 src/FirstRunWizard.cpp:624 src/muuli_wdr.cpp:1729
 msgid "Folder for temporary download files"
 msgstr "Map voor tijdelijke downloadbestanden"
 
@@ -2479,7 +2479,7 @@ msgstr "Kon niet schrijven naar vriendenlijst-bestand 'emfriends.met'!"
 msgid "CRITICAL - no client on StartChatSession"
 msgstr "KRITIEK - geen client bij StartChatSession"
 
-#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2706 src/muuli_wdr.cpp:3383
+#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2710 src/muuli_wdr.cpp:3387
 msgid "Friends"
 msgstr "Vrienden"
 
@@ -2590,8 +2590,8 @@ msgstr "Geen"
 msgid "No"
 msgstr "Nee"
 
-#: src/GenericClientListCtrl.cpp:1216 src/PrefsUnifiedDlg.cpp:2898
-#: src/PrefsUnifiedDlg.cpp:2948 src/ServerListCtrl.cpp:276
+#: src/GenericClientListCtrl.cpp:1216 src/PrefsUnifiedDlg.cpp:2907
+#: src/PrefsUnifiedDlg.cpp:2957 src/ServerListCtrl.cpp:276
 msgid "Yes"
 msgstr "Ja"
 
@@ -2760,10 +2760,10 @@ msgstr "Ongeldige poort om van te bootstrappen"
 msgid "Please fill all fields required"
 msgstr "Vul alle benodigde velden in"
 
-#: src/KadDlg.cpp:192 src/PartFile.cpp:1031 src/PrefsUnifiedDlg.cpp:1134
-#: src/PrefsUnifiedDlg.cpp:1204 src/PrefsUnifiedDlg.cpp:1405
-#: src/PrefsUnifiedDlg.cpp:1663 src/PrefsUnifiedDlg.cpp:1673
-#: src/PrefsUnifiedDlg.cpp:1690 src/PrefsUnifiedDlg.cpp:1738
+#: src/KadDlg.cpp:192 src/PartFile.cpp:1031 src/PrefsUnifiedDlg.cpp:1143
+#: src/PrefsUnifiedDlg.cpp:1213 src/PrefsUnifiedDlg.cpp:1414
+#: src/PrefsUnifiedDlg.cpp:1672 src/PrefsUnifiedDlg.cpp:1682
+#: src/PrefsUnifiedDlg.cpp:1699 src/PrefsUnifiedDlg.cpp:1747
 msgid "Message"
 msgstr "Bericht"
 
@@ -2865,7 +2865,7 @@ msgstr "Deelverhouding"
 msgid "Uploaded"
 msgstr "Geüpload"
 
-#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3263
+#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3267
 msgid "Requested"
 msgstr "Aangevraagd"
 
@@ -2989,7 +2989,7 @@ msgid "WARNING: "
 msgstr "WAARSCHUWING: "
 
 #: src/MuleNotebook.cpp:179 src/muuli_wdr.cpp:817 src/muuli_wdr.cpp:1229
-#: src/muuli_wdr.cpp:3167 src/muuli_wdr.cpp:3423
+#: src/muuli_wdr.cpp:3171 src/muuli_wdr.cpp:3427
 msgid "Close"
 msgstr "Sluiten"
 
@@ -3007,7 +3007,7 @@ msgid "Paste"
 msgstr "Plakken"
 
 #: src/MuleTextCtrl.cpp:89 src/muuli_wdr.cpp:358 src/muuli_wdr.cpp:757
-#: src/muuli_wdr.cpp:2390 src/muuli_wdr.cpp:2409 src/muuli_wdr.cpp:2431
+#: src/muuli_wdr.cpp:2394 src/muuli_wdr.cpp:2413 src/muuli_wdr.cpp:2435
 #: src/utils/aLinkCreator/src/alcframe.cpp:142
 msgid "Clear"
 msgstr "Wissen"
@@ -3106,7 +3106,7 @@ msgstr "Afsluiten"
 
 #: src/MuleTrayIcon.cpp:579 src/MuleTrayIcon.cpp:945 src/MuleTrayIcon.cpp:965
 #: src/muuli_wdr.cpp:1398 src/muuli_wdr.cpp:1406 src/muuli_wdr.cpp:1413
-#: src/muuli_wdr.cpp:1846 src/muuli_wdr.cpp:1852 src/OtherFunctions.cpp:91
+#: src/muuli_wdr.cpp:1850 src/muuli_wdr.cpp:1856 src/OtherFunctions.cpp:91
 #: src/StatisticsDlg.cpp:93 src/StatisticsDlg.cpp:95
 msgid "kB/s"
 msgstr "kB/s"
@@ -3349,7 +3349,7 @@ msgstr "Bytes"
 msgid "KB"
 msgstr "KB"
 
-#: src/muuli_wdr.cpp:274 src/muuli_wdr.cpp:293 src/muuli_wdr.cpp:1631
+#: src/muuli_wdr.cpp:274 src/muuli_wdr.cpp:293 src/muuli_wdr.cpp:1635
 #: src/OtherFunctions.cpp:64
 msgid "MB"
 msgstr "MB"
@@ -3366,7 +3366,7 @@ msgstr "Max grootte"
 msgid "Availability"
 msgstr "Beschikbaarheid"
 
-#: src/muuli_wdr.cpp:312 src/muuli_wdr.cpp:398 src/muuli_wdr.cpp:3328
+#: src/muuli_wdr.cpp:312 src/muuli_wdr.cpp:398 src/muuli_wdr.cpp:3332
 msgid "Filter:"
 msgstr "Filter:"
 
@@ -3429,8 +3429,8 @@ msgstr "Bestandsbronnen:"
 #: src/muuli_wdr.cpp:1160 src/muuli_wdr.cpp:1167 src/muuli_wdr.cpp:1172
 #: src/muuli_wdr.cpp:1179 src/muuli_wdr.cpp:1184 src/muuli_wdr.cpp:1191
 #: src/muuli_wdr.cpp:1205 src/muuli_wdr.cpp:1212 src/muuli_wdr.cpp:1217
-#: src/muuli_wdr.cpp:1224 src/muuli_wdr.cpp:3265 src/muuli_wdr.cpp:3273
-#: src/muuli_wdr.cpp:3281
+#: src/muuli_wdr.cpp:1224 src/muuli_wdr.cpp:3269 src/muuli_wdr.cpp:3277
+#: src/muuli_wdr.cpp:3285
 msgid "N/A"
 msgstr "N/B"
 
@@ -3575,7 +3575,7 @@ msgstr ""
 msgid "Album :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:685 src/muuli_wdr.cpp:2285
+#: src/muuli_wdr.cpp:685 src/muuli_wdr.cpp:2289
 msgid "Title :"
 msgstr "Titel :"
 
@@ -3684,7 +3684,7 @@ msgstr "Gebruikersnaam :"
 msgid "Userhash :"
 msgstr "Gebruikershash :"
 
-#: src/muuli_wdr.cpp:895 src/muuli_wdr.cpp:1752 src/muuli_wdr.cpp:2480
+#: src/muuli_wdr.cpp:895 src/muuli_wdr.cpp:1756 src/muuli_wdr.cpp:2484
 #: src/utils/aLinkCreator/src/alcframe.cpp:137
 msgid "Add"
 msgstr "Toevoegen"
@@ -3693,15 +3693,15 @@ msgstr "Toevoegen"
 msgid "Download-Speed"
 msgstr "Downloadsnelheid"
 
-#: src/muuli_wdr.cpp:954 src/muuli_wdr.cpp:989 src/muuli_wdr.cpp:2584
+#: src/muuli_wdr.cpp:954 src/muuli_wdr.cpp:989 src/muuli_wdr.cpp:2588
 msgid "Current"
 msgstr "Huidige"
 
-#: src/muuli_wdr.cpp:962 src/muuli_wdr.cpp:997 src/muuli_wdr.cpp:2592
+#: src/muuli_wdr.cpp:962 src/muuli_wdr.cpp:997 src/muuli_wdr.cpp:2596
 msgid "Running average"
 msgstr "Lopende gemiddelde"
 
-#: src/muuli_wdr.cpp:970 src/muuli_wdr.cpp:1005 src/muuli_wdr.cpp:2600
+#: src/muuli_wdr.cpp:970 src/muuli_wdr.cpp:1005 src/muuli_wdr.cpp:2604
 msgid "Session average"
 msgstr "Sessie gemiddelde"
 
@@ -3713,7 +3713,7 @@ msgstr "Uploadsnelheid"
 msgid "Connections"
 msgstr "Verbindingen"
 
-#: src/muuli_wdr.cpp:1024 src/muuli_wdr.cpp:1871
+#: src/muuli_wdr.cpp:1024 src/muuli_wdr.cpp:1875
 msgid "Active downloads"
 msgstr "Actieve downloads"
 
@@ -3721,7 +3721,7 @@ msgstr "Actieve downloads"
 msgid "Active connections (1:1)"
 msgstr "Actieve verbinding (1:1)"
 
-#: src/muuli_wdr.cpp:1040 src/muuli_wdr.cpp:1872
+#: src/muuli_wdr.cpp:1040 src/muuli_wdr.cpp:1876
 msgid "Active uploads"
 msgstr "Actieve uploads"
 
@@ -3997,7 +3997,7 @@ msgstr "Bind lokaal adres aan IP (laat leeg voor elk):"
 msgid "Advanced users only: If you have multiple network interfaces, enter the address of the interface to which aMule should be bound."
 msgstr "Enkel voor gevorderde gebruikers: Als u meerdere netwerk-interfaces hebt, voer hier het adres in van de interface waar aMule mee verbonden moet worden."
 
-#: src/muuli_wdr.cpp:1462 src/muuli_wdr.cpp:2065
+#: src/muuli_wdr.cpp:1462 src/muuli_wdr.cpp:2069
 #, fuzzy
 msgid "Bind to network interface (empty for any):"
 msgstr "Bind lokaal adres aan IP (laat leeg voor elk):"
@@ -4014,7 +4014,7 @@ msgstr "Max bronnen per bestand aan het downloaden:"
 msgid "Max simultaneous connections:"
 msgstr "Max gelijktijdige verbindingen:"
 
-#: src/muuli_wdr.cpp:1498 src/muuli_wdr.cpp:3207
+#: src/muuli_wdr.cpp:1498 src/muuli_wdr.cpp:3211
 msgid "ED2K"
 msgstr "ED2K"
 
@@ -4106,778 +4106,778 @@ msgstr "Wijst schijfruimte toe voor nieuwe bestanden"
 msgid "For new files preallocates disk space for the whole file, thus reduces fragmentation"
 msgstr "Wijst schijfruimte toe voor nieuwe bestanden, beperkt hierdoor fragmentatie"
 
-#: src/muuli_wdr.cpp:1617
+#: src/muuli_wdr.cpp:1621
 msgid "Create new files as sparse files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1618
+#: src/muuli_wdr.cpp:1622
 msgid "Sparse part files only occupy disk space for the parts already downloaded, so free space is used up gradually as the file fills in. Turn this off to use an ordinary file instead - useful where sparse files are unsupported or slow, or where backup/de-duplication tools handle them badly. Applies only when the core runs on Windows; on Linux and macOS part files are sparse anyway and this setting has no effect."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1623
+#: src/muuli_wdr.cpp:1627
 msgid "Stop downloads when free disk space reaches "
 msgstr "Stop downloads als de vrije schijfruimte bedraagt "
 
-#: src/muuli_wdr.cpp:1624
+#: src/muuli_wdr.cpp:1628
 msgid "Select this if you want aMule to check your disk space"
 msgstr "Selecteer dit als u wilt dat aMule uw schijfruimte controleert"
 
-#: src/muuli_wdr.cpp:1628
+#: src/muuli_wdr.cpp:1632
 msgid "Enter here the min disk space desired."
 msgstr "Voer hier de gewenste min schijfruimte in."
 
-#: src/muuli_wdr.cpp:1634
+#: src/muuli_wdr.cpp:1638
 msgid "Save 10 sources on rare files (< 20 sources)"
 msgstr "Bewaar 10 bronnen van zeldzame bestanden (<20 bronnen)"
 
-#: src/muuli_wdr.cpp:1638 src/Statistics.cpp:790
+#: src/muuli_wdr.cpp:1642 src/Statistics.cpp:790
 msgid "Uploads"
 msgstr "Uploads"
 
-#: src/muuli_wdr.cpp:1641
+#: src/muuli_wdr.cpp:1645
 msgid "Add new shared files with auto priority"
 msgstr "Voeg nieuwe gedeelde bestanden toe met automatische prioriteit"
 
-#: src/muuli_wdr.cpp:1647
+#: src/muuli_wdr.cpp:1651
 msgid "Intelligent Corruption Handling (I.C.H.)"
 msgstr "Intelligente corruptieafhandling (I.C.H.)"
 
-#: src/muuli_wdr.cpp:1650
+#: src/muuli_wdr.cpp:1654
 msgid "Enable"
 msgstr "Inschakelen"
 
-#: src/muuli_wdr.cpp:1653
+#: src/muuli_wdr.cpp:1657
 msgid "Advanced I.C.H. trusts every hash (not recommended)"
 msgstr "Geavanceerde I.C.H. vertrouwt elke hash (niet aanbevolen)"
 
-#: src/muuli_wdr.cpp:1665 src/PrefsUnifiedDlg.cpp:1990
+#: src/muuli_wdr.cpp:1669 src/PrefsUnifiedDlg.cpp:1999
 msgid "Media metadata extraction"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1669
+#: src/muuli_wdr.cpp:1673
 msgid "Extract length / bitrate / codec from shared audio and video files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1671
+#: src/muuli_wdr.cpp:1675
 msgid "When enabled, aMule runs ffprobe on each shared media file to fill in the Length / Bitrate / Codec columns other clients see when they find the file in a search. Requires ffmpeg (the ffprobe binary) to be installed."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1678
+#: src/muuli_wdr.cpp:1682
 msgid "Path to ffprobe:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1683
+#: src/muuli_wdr.cpp:1687
 msgid "Full path to the ffprobe binary. Leave empty to have aMule auto-detect it on startup."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1691
+#: src/muuli_wdr.cpp:1695
 msgid "Detect"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1692
+#: src/muuli_wdr.cpp:1696
 msgid "Search the standard install locations for an ffprobe binary and fill the path field."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1716
+#: src/muuli_wdr.cpp:1720
 msgid ""
 "Completed downloads are stored here. All files in this folder are automatically shared with other peers.\n"
 "If this folder also holds files you don't want to share, point it at an aMule-only sub-folder."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1719
+#: src/muuli_wdr.cpp:1723
 msgid "Pick the folder where completed downloads will be stored. All files in that folder will be shared with other peers."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1733
+#: src/muuli_wdr.cpp:1737
 msgid "Shared folders"
 msgstr "Gedeelde mappen"
 
-#: src/muuli_wdr.cpp:1739
+#: src/muuli_wdr.cpp:1743
 msgid "(Folders shared by the core. Enter a path to add one.)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1747
+#: src/muuli_wdr.cpp:1751
 msgid "Absolute path of a folder on the core's machine, e.g. /home/user/shared"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1749 src/PrefsUnifiedDlg.cpp:2874
+#: src/muuli_wdr.cpp:1753 src/PrefsUnifiedDlg.cpp:2883
 msgid "Recursive"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1750
+#: src/muuli_wdr.cpp:1754
 msgid "Share every sub-folder underneath this one, including ones created later."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1754 src/utils/aLinkCreator/src/alcframe.cpp:141
+#: src/muuli_wdr.cpp:1758 src/utils/aLinkCreator/src/alcframe.cpp:141
 msgid "Remove"
 msgstr "Verwijder"
 
-#: src/muuli_wdr.cpp:1758
+#: src/muuli_wdr.cpp:1762
 msgid "(Right click on folder icon for recursive share)"
 msgstr "(Rechtermuisklik op mappictogram om recursief te delen)"
 
-#: src/muuli_wdr.cpp:1765
+#: src/muuli_wdr.cpp:1769
 msgid "Share hidden files"
 msgstr "Deel verborgen bestanden"
 
-#: src/muuli_wdr.cpp:1771
+#: src/muuli_wdr.cpp:1775
 msgid "Automatically rescan shared folders for changes"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1777
+#: src/muuli_wdr.cpp:1781
 msgid "Follow symbolic links in shared folders"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1783
+#: src/muuli_wdr.cpp:1787
 msgid "Exclude files matching:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1786
+#: src/muuli_wdr.cpp:1790
 msgid "Wildcard patterns separated by '|', e.g. .DS_Store|Thumbs.db|*.tmp. Files whose name matches are not shared. Matching is case-insensitive."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1790
+#: src/muuli_wdr.cpp:1794
 msgid "Patterns are regular expressions"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1791
+#: src/muuli_wdr.cpp:1795
 msgid "When set, the whole field is one regular expression ('|' is alternation). When unset, it is a list of '|'-separated wildcards."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1801
+#: src/muuli_wdr.cpp:1805
 msgid "Show how many shared files the current pattern would exclude."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1822
+#: src/muuli_wdr.cpp:1826
 msgid "Graphs"
 msgstr "Grafieken"
 
-#: src/muuli_wdr.cpp:1825 src/muuli_wdr.cpp:1887
+#: src/muuli_wdr.cpp:1829 src/muuli_wdr.cpp:1891
 msgid "Update delay : 5 secs"
 msgstr "Update-vertraging : 5 seconden"
 
-#: src/muuli_wdr.cpp:1829
+#: src/muuli_wdr.cpp:1833
 msgid "Time for average graph: 100 mins"
 msgstr "Tijd voor gemiddeldengrafiek: 100 minuten"
 
-#: src/muuli_wdr.cpp:1833
+#: src/muuli_wdr.cpp:1837
 msgid "Connections Graph Scale: 100 "
 msgstr "Schaal verbindingengrafiek: 100 "
 
-#: src/muuli_wdr.cpp:1840
+#: src/muuli_wdr.cpp:1844
 msgid "Download graph scale:"
 msgstr "Schaal downloadgrafiek:"
 
-#: src/muuli_wdr.cpp:1848
+#: src/muuli_wdr.cpp:1852
 msgid "Upload graph scale:"
 msgstr "Schaal uploadgrafiek:"
 
-#: src/muuli_wdr.cpp:1858
+#: src/muuli_wdr.cpp:1862
 #, fuzzy
 msgid "Colors: "
 msgstr "Kleuren: "
 
-#: src/muuli_wdr.cpp:1862
+#: src/muuli_wdr.cpp:1866
 msgid "Background"
 msgstr "Achtergrond"
 
-#: src/muuli_wdr.cpp:1863
+#: src/muuli_wdr.cpp:1867
 msgid "Grid"
 msgstr "Raster"
 
-#: src/muuli_wdr.cpp:1864
+#: src/muuli_wdr.cpp:1868
 msgid "Download current"
 msgstr "Huidige download"
 
-#: src/muuli_wdr.cpp:1865
+#: src/muuli_wdr.cpp:1869
 msgid "Download running average"
 msgstr "Lopend gemiddelde download"
 
-#: src/muuli_wdr.cpp:1866
+#: src/muuli_wdr.cpp:1870
 msgid "Download session average"
 msgstr "Sessie gemiddelde download"
 
-#: src/muuli_wdr.cpp:1867
+#: src/muuli_wdr.cpp:1871
 msgid "Upload current"
 msgstr "Huidige upload"
 
-#: src/muuli_wdr.cpp:1868
+#: src/muuli_wdr.cpp:1872
 msgid "Upload running average"
 msgstr "Lopend gemiddelde upload"
 
-#: src/muuli_wdr.cpp:1869
+#: src/muuli_wdr.cpp:1873
 msgid "Upload session average"
 msgstr "Sessie gemiddelde upload"
 
-#: src/muuli_wdr.cpp:1870
+#: src/muuli_wdr.cpp:1874
 msgid "Active connections"
 msgstr "Actieve verbindingen"
 
-#: src/muuli_wdr.cpp:1873
+#: src/muuli_wdr.cpp:1877
 #, fuzzy
 msgid "Systray Icon Speed Bar"
 msgstr "Systeemvak-pictogram met snelheidsbalk"
 
-#: src/muuli_wdr.cpp:1874
+#: src/muuli_wdr.cpp:1878
 msgid "Kad-nodes current"
 msgstr "Kad-nodes huidig"
 
-#: src/muuli_wdr.cpp:1875
+#: src/muuli_wdr.cpp:1879
 msgid "Kad-nodes running"
 msgstr "Kad-nodes draaiende"
 
-#: src/muuli_wdr.cpp:1876
+#: src/muuli_wdr.cpp:1880
 msgid "Kad-nodes session"
 msgstr "Kad-nodes sessie"
 
-#: src/muuli_wdr.cpp:1880 src/muuli_wdr.cpp:2334
+#: src/muuli_wdr.cpp:1884 src/muuli_wdr.cpp:2338
 msgid "Select"
 msgstr "Selecteer"
 
-#: src/muuli_wdr.cpp:1884
+#: src/muuli_wdr.cpp:1888
 msgid "Tree"
 msgstr "Boom"
 
-#: src/muuli_wdr.cpp:1894
+#: src/muuli_wdr.cpp:1898
 msgid "Number of Client Versions shown (0=unlimited)"
 msgstr "Aantal getoonde client-versies (0=onbegrensd)"
 
-#: src/muuli_wdr.cpp:1919
+#: src/muuli_wdr.cpp:1923
 msgid "!!! WARNING !!!"
 msgstr "!!! WAARSCHUWING !!!"
 
-#: src/muuli_wdr.cpp:1934
+#: src/muuli_wdr.cpp:1938
 msgid "Max new connections / 5 secs"
 msgstr "Max nieuwe verbindingen / 5 seconden"
 
-#: src/muuli_wdr.cpp:1936
+#: src/muuli_wdr.cpp:1940
 msgid "Concurrent Kad source lookups"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1938
+#: src/muuli_wdr.cpp:1942
 #, fuzzy
 msgid "Kad source re-search interval (minutes)"
 msgstr "Tijd tussen de FTP-updates in minuten"
 
-#: src/muuli_wdr.cpp:1940
+#: src/muuli_wdr.cpp:1944
 #, fuzzy
 msgid "Source re-ask interval (minutes)"
 msgstr "Tijd tussen de FTP-updates in minuten"
 
-#: src/muuli_wdr.cpp:1944
+#: src/muuli_wdr.cpp:1948
 msgid "File Buffer Size: 240000 bytes"
 msgstr "Grootte van bestandsbuffer : 240000 bytes"
 
-#: src/muuli_wdr.cpp:1948
+#: src/muuli_wdr.cpp:1952
 msgid "Use MMAP: memory-mapped file access (lower memory use)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1949
+#: src/muuli_wdr.cpp:1953
 msgid "Maps part files into memory instead of buffering them on the heap, lowering the process memory footprint. May reduce download speed on some disks; best for memory-constrained or upload-heavy hosts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1951
+#: src/muuli_wdr.cpp:1955
 msgid "Upload Queue Size: 5000 clients"
 msgstr "Grootte van uploadwachtrij: 5000 clients"
 
-#: src/muuli_wdr.cpp:1955
+#: src/muuli_wdr.cpp:1959
 msgid "Server connection refresh interval: Disable"
 msgstr "Server-verbinding verversingsinterval: Uitschakelen"
 
-#: src/muuli_wdr.cpp:1959
+#: src/muuli_wdr.cpp:1963
 msgid "Disable computer's timed standby mode"
 msgstr "Schakel standby-modus van computer uit"
 
-#: src/muuli_wdr.cpp:1978
+#: src/muuli_wdr.cpp:1982
 msgid "Skin to use: "
 msgstr "Gebruik skin: "
 
-#: src/muuli_wdr.cpp:1987
+#: src/muuli_wdr.cpp:1991
 msgid "Show \"Fast eD2k Links Handler\" in every window."
 msgstr "Toon \"Snelle eD2k-links afhandelaar\" in elk venster."
 
-#: src/muuli_wdr.cpp:1990
+#: src/muuli_wdr.cpp:1994
 msgid "Show extended info on categories tabs"
 msgstr "Geef uitgebreide informatie weer op categorie-tabs"
 
-#: src/muuli_wdr.cpp:1993
+#: src/muuli_wdr.cpp:1997
 msgid "Show application version on title"
 msgstr "Toon applicatieversie op titel"
 
-#: src/muuli_wdr.cpp:1995
+#: src/muuli_wdr.cpp:1999
 msgid "Show transfer rates on title"
 msgstr "Toon overdrachtsnelheden op titel"
 
-#: src/muuli_wdr.cpp:1997
+#: src/muuli_wdr.cpp:2001
 msgid "Before application name"
 msgstr "Voor applicatienaam"
 
-#: src/muuli_wdr.cpp:1999
+#: src/muuli_wdr.cpp:2003
 msgid "After application name"
 msgstr "Na applicatienaam"
 
-#: src/muuli_wdr.cpp:2002
+#: src/muuli_wdr.cpp:2006
 msgid "Show overhead bandwidth"
 msgstr "Toon overhead bandbreedte"
 
-#: src/muuli_wdr.cpp:2006
+#: src/muuli_wdr.cpp:2010
 msgid "Vertical toolbar orientation"
 msgstr "Verticale knoppenbalk"
 
-#: src/muuli_wdr.cpp:2008
+#: src/muuli_wdr.cpp:2012
 msgid "Live column sorting (auto-reorder rows as their values change)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2015
+#: src/muuli_wdr.cpp:2019
 msgid "Download Queue Files"
 msgstr "Downloadwachtrij bestanden"
 
-#: src/muuli_wdr.cpp:2018
+#: src/muuli_wdr.cpp:2022
 msgid "Show progress percentage"
 msgstr "Toon voortgangspercentage"
 
-#: src/muuli_wdr.cpp:2024
+#: src/muuli_wdr.cpp:2028
 msgid "Show progress bar"
 msgstr "Toon voortgangsindicator"
 
-#: src/muuli_wdr.cpp:2027
+#: src/muuli_wdr.cpp:2031
 msgid "Flat"
 msgstr "Plat"
 
-#: src/muuli_wdr.cpp:2031
+#: src/muuli_wdr.cpp:2035
 msgid "Round"
 msgstr "Rond"
 
-#: src/muuli_wdr.cpp:2049
+#: src/muuli_wdr.cpp:2053
 msgid "External Connection Parameters"
 msgstr "Externe verbinding parameters"
 
-#: src/muuli_wdr.cpp:2052
+#: src/muuli_wdr.cpp:2056
 msgid "Accept external connections"
 msgstr "Accepteer externe verbindingen"
 
-#: src/muuli_wdr.cpp:2059 src/muuli_wdr.cpp:2118
+#: src/muuli_wdr.cpp:2063 src/muuli_wdr.cpp:2122
 msgid "IP of the listening interface:"
 msgstr "IP van de luisterende interface:"
 
-#: src/muuli_wdr.cpp:2062
+#: src/muuli_wdr.cpp:2066
 msgid "Enter here a valid ip in the a.b.c.d format for the listening EC interface. An empty field or 0.0.0.0 will mean any interface."
 msgstr "Voer hier een geldig IP in het formaat a.b.c.d in van de luisterende EV-interface. Een leeg veld of 0.0.0.0 betekent elke interface."
 
-#: src/muuli_wdr.cpp:2083 src/muuli_wdr.cpp:2194
+#: src/muuli_wdr.cpp:2087 src/muuli_wdr.cpp:2198
 msgid "TCP port:"
 msgstr "TCP-poort:"
 
-#: src/muuli_wdr.cpp:2089
+#: src/muuli_wdr.cpp:2093
 msgid "Enable UPnP port forwarding on the EC port"
 msgstr "Schakel UPnP portforwarding van de EV-poort in"
 
-#: src/muuli_wdr.cpp:2093 src/muuli_wdr.cpp:3079
+#: src/muuli_wdr.cpp:2097 src/muuli_wdr.cpp:3083
 #: src/utils/wxCas/src/wxcasprefs.cpp:167
 msgid "Password"
 msgstr "Wachtwoord"
 
-#: src/muuli_wdr.cpp:2099
+#: src/muuli_wdr.cpp:2103
 #, fuzzy
 msgid "aMule API server parameters"
 msgstr "Webserver parameters"
 
-#: src/muuli_wdr.cpp:2102
+#: src/muuli_wdr.cpp:2106
 msgid "Run amuleapi (REST API) on startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2107
+#: src/muuli_wdr.cpp:2111
 #, fuzzy
 msgid "HTTP port:"
 msgstr "TCP-poort:"
 
-#: src/muuli_wdr.cpp:2121
+#: src/muuli_wdr.cpp:2125
 msgid "The interface amuleapi's HTTP server listens on. 127.0.0.1 (default) accepts only local connections; use 0.0.0.0 or a specific IP to expose it to other hosts (set an admin password below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2126
+#: src/muuli_wdr.cpp:2130
 msgid "Type a password to set or change it. Stored passwords cannot be shown, so leaving this empty keeps the current one."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2128
+#: src/muuli_wdr.cpp:2132
 #, fuzzy
 msgid "Admin password"
 msgstr "Controleren van wachtwoord\n"
 
-#: src/muuli_wdr.cpp:2140 src/muuli_wdr.cpp:2157 src/PrefsUnifiedDlg.cpp:1103
+#: src/muuli_wdr.cpp:2144 src/muuli_wdr.cpp:2161 src/PrefsUnifiedDlg.cpp:1112
 #, fuzzy
 msgid "A password is set."
 msgstr "Controleren van wachtwoord\n"
 
-#: src/muuli_wdr.cpp:2144
+#: src/muuli_wdr.cpp:2148
 #, fuzzy
 msgid "Enable guest access"
 msgstr "Weiger gasttoegang"
 
-#: src/muuli_wdr.cpp:2145
+#: src/muuli_wdr.cpp:2149
 msgid "Guest sessions may read status and listings but cannot change anything. Turning this off clears the stored guest password."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2149
+#: src/muuli_wdr.cpp:2153
 #, fuzzy
 msgid "Guest password"
 msgstr "Gastwachtwoord voor webserver"
 
-#: src/muuli_wdr.cpp:2164
+#: src/muuli_wdr.cpp:2168
 msgid "Web server parameters"
 msgstr "Webserver parameters"
 
-#: src/muuli_wdr.cpp:2167
+#: src/muuli_wdr.cpp:2171
 #, fuzzy
 msgid "Run webserver on startup (deprecated)"
 msgstr "Start webserver bij het opstarten"
 
-#: src/muuli_wdr.cpp:2173
+#: src/muuli_wdr.cpp:2177
 msgid "Web template"
 msgstr "Web-template"
 
-#: src/muuli_wdr.cpp:2178
+#: src/muuli_wdr.cpp:2182
 msgid "Full rights password"
 msgstr "Alle rechten wachtwoord"
 
-#: src/muuli_wdr.cpp:2182
+#: src/muuli_wdr.cpp:2186
 msgid "Enable Low rights User"
 msgstr "Schakel gebruiker met beperkte rechten in"
 
-#: src/muuli_wdr.cpp:2187
+#: src/muuli_wdr.cpp:2191
 msgid "Low rights password"
 msgstr "Beperkte rechten wachtwoord"
 
-#: src/muuli_wdr.cpp:2201
+#: src/muuli_wdr.cpp:2205
 msgid "Enable UPnP port forwarding of the web server port"
 msgstr "Schakel UPnP portforwarding van de webserver-poort in"
 
-#: src/muuli_wdr.cpp:2206
+#: src/muuli_wdr.cpp:2210
 msgid "Web server UPnP TCP port (Optional)"
 msgstr "Web server UPnP TCP-poort (optioneel)"
 
-#: src/muuli_wdr.cpp:2214
+#: src/muuli_wdr.cpp:2218
 msgid "Page Refresh Time (in secs)"
 msgstr "Pagina verversingstijd (in seconden)"
 
-#: src/muuli_wdr.cpp:2221
+#: src/muuli_wdr.cpp:2225
 msgid "Enable Gzip compression"
 msgstr "Schakel Gzip-compressie in"
 
-#: src/muuli_wdr.cpp:2255
+#: src/muuli_wdr.cpp:2259
 #, fuzzy
 msgid "Reset page to defaults"
 msgstr "Systeemstandaard"
 
-#: src/muuli_wdr.cpp:2256
+#: src/muuli_wdr.cpp:2260
 msgid "Reset the settings on the current page to their default values."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2258 src/muuli_wdr.cpp:2344 src/ServerWnd.cpp:274
+#: src/muuli_wdr.cpp:2262 src/muuli_wdr.cpp:2348 src/ServerWnd.cpp:274
 #: src/ServerWnd.cpp:282
 msgid "OK"
 msgstr "OK"
 
-#: src/muuli_wdr.cpp:2260
+#: src/muuli_wdr.cpp:2264
 msgid "Click here to apply any changes made to the preferences."
 msgstr "Klik hier om de veranderingen gemaakt in de voorkeuren toe te passen."
 
-#: src/muuli_wdr.cpp:2263
+#: src/muuli_wdr.cpp:2267
 msgid "Reset any changes made to the preferences."
 msgstr "Maak veranderingen aan de voorkeuren ongedaan."
 
-#: src/muuli_wdr.cpp:2292
+#: src/muuli_wdr.cpp:2296
 msgid "Comment :"
 msgstr "Commentaar :"
 
-#: src/muuli_wdr.cpp:2299
+#: src/muuli_wdr.cpp:2303
 msgid "Incoming Dir :"
 msgstr "Binnenkomende map :"
 
-#: src/muuli_wdr.cpp:2308
+#: src/muuli_wdr.cpp:2312
 msgid "Change priority for new assigned files :"
 msgstr "Verander prioriteit voor nieuw toegevoegde bestanden :"
 
-#: src/muuli_wdr.cpp:2312
+#: src/muuli_wdr.cpp:2316
 msgid "Don't change"
 msgstr "Niet veranderen"
 
-#: src/muuli_wdr.cpp:2324
+#: src/muuli_wdr.cpp:2328
 msgid "Select color for this Category (currently selected) :"
 msgstr "Selecteer kleur voor deze categorie (nu geselecteerd) :"
 
-#: src/muuli_wdr.cpp:2391 src/muuli_wdr.cpp:2410 src/muuli_wdr.cpp:2432
+#: src/muuli_wdr.cpp:2395 src/muuli_wdr.cpp:2414 src/muuli_wdr.cpp:2436
 msgid "Click this button to reset the log."
 msgstr "Klik op deze knop om het logboek te wissen."
 
-#: src/muuli_wdr.cpp:2451
+#: src/muuli_wdr.cpp:2455
 msgid "Click on this button to update the servers list from URL ..."
 msgstr "Klik op deze knop om de lijst van servers te updaten van URL ..."
 
-#: src/muuli_wdr.cpp:2455
+#: src/muuli_wdr.cpp:2459
 msgid "Server list"
 msgstr "Server-lijst"
 
-#: src/muuli_wdr.cpp:2459
+#: src/muuli_wdr.cpp:2463
 msgid "Enter the url to a server.met file here and press the button to the left to update the list of known servers."
 msgstr "Voer de url naar een server.met bestand hier in en druk op de knop links om de lijst met bekende servers te vernieuwen."
 
-#: src/muuli_wdr.cpp:2464
+#: src/muuli_wdr.cpp:2468
 msgid "Add server manually: Name"
 msgstr "Voeg server handmatig toe: Naam"
 
-#: src/muuli_wdr.cpp:2467
+#: src/muuli_wdr.cpp:2471
 msgid "Enter the name of the new server here"
 msgstr "Voer hier de naam van de nieuwe server in"
 
-#: src/muuli_wdr.cpp:2469 src/ServerWnd.cpp:206
+#: src/muuli_wdr.cpp:2473 src/ServerWnd.cpp:206
 msgid "IP:Port"
 msgstr "IP:Poort"
 
-#: src/muuli_wdr.cpp:2472
+#: src/muuli_wdr.cpp:2476
 msgid "Enter the IP of the server here, using the x.x.x.x format."
 msgstr "Voer hier het IP van de server in, gebuik het x.x.x.x formaat."
 
-#: src/muuli_wdr.cpp:2478
+#: src/muuli_wdr.cpp:2482
 msgid "Enter the port of the server here."
 msgstr "Voer hier de poort van de server in."
 
-#: src/muuli_wdr.cpp:2481
+#: src/muuli_wdr.cpp:2485
 msgid "Add manually a server (fill fields to the left before) ..."
 msgstr "Voeg een server handmatig toe (vul velden links in voor) ..."
 
-#: src/muuli_wdr.cpp:2510
+#: src/muuli_wdr.cpp:2514
 msgid "aMule Log"
 msgstr "aMule log"
 
-#: src/muuli_wdr.cpp:2518
+#: src/muuli_wdr.cpp:2522
 msgid "Server Info"
 msgstr "Server-info"
 
-#: src/muuli_wdr.cpp:2522
+#: src/muuli_wdr.cpp:2526
 msgid "ED2K Info"
 msgstr "ED2K-info"
 
-#: src/muuli_wdr.cpp:2526
+#: src/muuli_wdr.cpp:2530
 msgid "Kad Info"
 msgstr "Kad info"
 
-#: src/muuli_wdr.cpp:2554
+#: src/muuli_wdr.cpp:2558
 msgid "Click on this button to update the nodes list from URL ..."
 msgstr "Klik op deze knop om de nodes-lijst te updaten van URL ..."
 
-#: src/muuli_wdr.cpp:2558
+#: src/muuli_wdr.cpp:2562
 msgid "Nodes (0)"
 msgstr "Nodes (0)"
 
-#: src/muuli_wdr.cpp:2562
+#: src/muuli_wdr.cpp:2566
 msgid "Enter the url to a nodes.dat file here and press the button to the left to update the list of known nodes."
 msgstr "Voer hier de url in naar een nodes.dat bestand en druk op de knop links om de lijst van bekende nodes te updaten."
 
-#: src/muuli_wdr.cpp:2565
+#: src/muuli_wdr.cpp:2569
 msgid "Nodes stats"
 msgstr "Nodes stats"
 
-#: src/muuli_wdr.cpp:2607
+#: src/muuli_wdr.cpp:2611
 msgid "Bootstrap"
 msgstr "Bootstrap"
 
-#: src/muuli_wdr.cpp:2610
+#: src/muuli_wdr.cpp:2614
 msgid "New node"
 msgstr "Nieuwe node"
 
-#: src/muuli_wdr.cpp:2615
+#: src/muuli_wdr.cpp:2619
 msgid "IP:"
 msgstr "IP:"
 
-#: src/muuli_wdr.cpp:2635
+#: src/muuli_wdr.cpp:2639
 msgid "Port:"
 msgstr "Poort:"
 
-#: src/muuli_wdr.cpp:2648
+#: src/muuli_wdr.cpp:2652
 msgid "Bootstrap from known clients"
 msgstr "Bootstrap van bekende clients"
 
-#: src/muuli_wdr.cpp:2650
+#: src/muuli_wdr.cpp:2654
 msgid "Disconnect Kad"
 msgstr "Verbreek verbinding met Kad"
 
-#: src/muuli_wdr.cpp:2684
+#: src/muuli_wdr.cpp:2688
 msgid "Use Secure User Identification"
 msgstr "Gebruik beveiligde gebruikersidentificatie"
 
-#: src/muuli_wdr.cpp:2686
+#: src/muuli_wdr.cpp:2690
 msgid "It is recommended to enable this option. You will not receive credits if SUI is not enabled."
 msgstr "Het is aan te raden om deze optie in te schakelen. U ontvangt geen credits indien SUI niet ingeschakeld is."
 
-#: src/muuli_wdr.cpp:2688
+#: src/muuli_wdr.cpp:2692
 msgid "Protocol Obfuscation"
 msgstr "Protocol-obfuscatie"
 
-#: src/muuli_wdr.cpp:2691
+#: src/muuli_wdr.cpp:2695
 msgid "Support Protocol Obfuscation"
 msgstr "Ondersteun protocol-obfuscatie"
 
-#: src/muuli_wdr.cpp:2693
+#: src/muuli_wdr.cpp:2697
 msgid "This option enabled Protocol Obfuscation, and makes aMule accept obfuscated connections from other clients."
 msgstr "Deze optie schakelt Protocol Obfuscatie in, en zorgt er voor dat aMule geobfusceerde verbindingen van andere clients accepteert."
 
-#: src/muuli_wdr.cpp:2695
+#: src/muuli_wdr.cpp:2699
 msgid "Use obfuscation for outgoing connections"
 msgstr "Gebruik obfuscatie voor uitgaande verbindingen"
 
-#: src/muuli_wdr.cpp:2697
+#: src/muuli_wdr.cpp:2701
 msgid "This option makes aMule use Protocol Obfuscation when connecting other clients/servers."
 msgstr "Deze optie zorgt er voor dat aMule protocol-obfuscatie gebruikt bij het verbinden met andere clients/servers."
 
-#: src/muuli_wdr.cpp:2699
+#: src/muuli_wdr.cpp:2703
 msgid "Accept only obfuscated connections"
 msgstr "Accepteer alleen geobfusceerde verbindingen"
 
-#: src/muuli_wdr.cpp:2700
+#: src/muuli_wdr.cpp:2704
 msgid "This option makes aMule only accept obfuscated connections. You will have less sources, but all your traffic will be obfuscated"
 msgstr "Deze optie zorgt er voor dat aMule alleen geobfusceerde verbindingen accepteert. U heeft minder bronnen, maar al uw verkeer is geobfusceerd"
 
-#: src/muuli_wdr.cpp:2705
+#: src/muuli_wdr.cpp:2709
 msgid "Everybody"
 msgstr "Iedereen"
 
-#: src/muuli_wdr.cpp:2707
+#: src/muuli_wdr.cpp:2711
 msgid "No one"
 msgstr "Niemand"
 
-#: src/muuli_wdr.cpp:2709
+#: src/muuli_wdr.cpp:2713
 msgid "Who can see my shared files:"
 msgstr "Wie kan mijn gedeelde bestanden zien:"
 
-#: src/muuli_wdr.cpp:2710
+#: src/muuli_wdr.cpp:2714
 msgid "Select who can request to view a list of your shared files."
 msgstr "Selecteer wie een lijst van uw gedeelde bestanden kan opvragen."
 
-#: src/muuli_wdr.cpp:2712
+#: src/muuli_wdr.cpp:2716
 msgid "IP-Filtering"
 msgstr "IP-filteren"
 
-#: src/muuli_wdr.cpp:2719
+#: src/muuli_wdr.cpp:2723
 msgid "Filter clients"
 msgstr "Filter clients"
 
-#: src/muuli_wdr.cpp:2721
+#: src/muuli_wdr.cpp:2725
 msgid "Enable filtering of the client IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "Schakel filteren van de client-IPs in het bestand ~/.aMule/ipfilter.dat in."
 
-#: src/muuli_wdr.cpp:2723
+#: src/muuli_wdr.cpp:2727
 msgid "Filter servers"
 msgstr "Filter servers"
 
-#: src/muuli_wdr.cpp:2725
+#: src/muuli_wdr.cpp:2729
 msgid "Enable filtering of the server IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "Schakel filteren van de server-IPs in het bestand ~/.aMule/ipfilter.dat in."
 
-#: src/muuli_wdr.cpp:2729
+#: src/muuli_wdr.cpp:2733
 msgid "Reload List"
 msgstr "Lijst opnieuw laden"
 
-#: src/muuli_wdr.cpp:2730
+#: src/muuli_wdr.cpp:2734
 msgid "Reload the list of IPs to filter from the file ~/.aMule/ipfilter.dat"
 msgstr "Laadt de lijst met IPs om te filteren opnieuw uit het bestand ~/.aMule/ipfilter.dat"
 
-#: src/muuli_wdr.cpp:2736
+#: src/muuli_wdr.cpp:2740
 msgid "URL:"
 msgstr "URL:"
 
-#: src/muuli_wdr.cpp:2740 src/muuli_wdr.cpp:2933
+#: src/muuli_wdr.cpp:2744 src/muuli_wdr.cpp:2937
 msgid "Update now"
 msgstr "Update nu"
 
-#: src/muuli_wdr.cpp:2743
+#: src/muuli_wdr.cpp:2747
 msgid "Auto-update ipfilter at startup"
 msgstr "Auto-update ip-filter bij het starten"
 
-#: src/muuli_wdr.cpp:2747
+#: src/muuli_wdr.cpp:2751
 msgid "Filtering Level:"
 msgstr "Niveau van filteren:"
 
-#: src/muuli_wdr.cpp:2753
+#: src/muuli_wdr.cpp:2757
 msgid "Always filter LAN IPs"
 msgstr "Filter LAN IPs altijd"
 
-#: src/muuli_wdr.cpp:2756
+#: src/muuli_wdr.cpp:2760
 msgid "Paranoid handling of non-matching IPs"
 msgstr "Paranoïde behandeling van niet-kloppende IPs"
 
-#: src/muuli_wdr.cpp:2758
+#: src/muuli_wdr.cpp:2762
 msgid "Rejects a packet when its source IP differs from the IP the client claims (an anti-spoofing check). Disable only if it causes connection problems."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2760
+#: src/muuli_wdr.cpp:2764
 msgid "Use system-wide ipfilter.dat if available"
 msgstr "Gebruik systeemwijd ipfilter.dat indien beschikbaar"
 
-#: src/muuli_wdr.cpp:2761
+#: src/muuli_wdr.cpp:2765
 #, fuzzy
 msgid "If there's no local ipfilter.dat found, allow usage of a system-wide ipfilter file."
 msgstr "Indien er geen lokaal ipfilter.dat gevonden wordt, sta gebruik van een systeemwijd ipfilter toe."
 
-#: src/muuli_wdr.cpp:2778
+#: src/muuli_wdr.cpp:2782
 msgid "Enable Online-Signature"
 msgstr "Schakel online handtekening in"
 
-#: src/muuli_wdr.cpp:2780
+#: src/muuli_wdr.cpp:2784
 msgid "Enables the writing of the OS file, which can be used by external apps to create signatures and the like."
 msgstr "Schakelt het schrijven van het OH-bestand in, die kan gebruikt worden door externe applicaties om handtekeningen en dergelijke te maken."
 
-#: src/muuli_wdr.cpp:2784
+#: src/muuli_wdr.cpp:2788
 msgid "Update Frequency (Secs):"
 msgstr "Update-frequentie (seconden):"
 
-#: src/muuli_wdr.cpp:2787
+#: src/muuli_wdr.cpp:2791
 msgid "Change the frequency (in seconds) of Online Signature updates."
 msgstr "Verander de frequentie (in seconden) van de Online Handtekening updates."
 
-#: src/muuli_wdr.cpp:2795
+#: src/muuli_wdr.cpp:2799
 msgid "Save online signature file in: "
 msgstr "Bewaar online-handtekeningbestand in: "
 
-#: src/muuli_wdr.cpp:2801
+#: src/muuli_wdr.cpp:2805
 msgid "Click here to select the directory containing the the Online Signature files."
 msgstr "Klik hier om de map te selecteren die de online-handtekening-bestanden bevat."
 
-#: src/muuli_wdr.cpp:2834
+#: src/muuli_wdr.cpp:2838
 msgid "Show country flags for clients"
 msgstr "Toon landenvlaggen voor clients"
 
-#: src/muuli_wdr.cpp:2835
+#: src/muuli_wdr.cpp:2839
 msgid "Render the country flag column in the transfers, queue and search views. Requires a valid MMDB GeoIP database (see below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2840
+#: src/muuli_wdr.cpp:2844
 #, fuzzy
 msgid "Database"
 msgstr "Datasnelheid :"
 
-#: src/muuli_wdr.cpp:2856
+#: src/muuli_wdr.cpp:2860
 #, fuzzy
 msgid "Source:"
 msgstr "Bronnen"
 
-#: src/muuli_wdr.cpp:2859
+#: src/muuli_wdr.cpp:2863
 msgid "DB-IP (free, no account)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2860
+#: src/muuli_wdr.cpp:2864
 msgid "MaxMind GeoLite2 (free, account required)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2861
+#: src/muuli_wdr.cpp:2865
 msgid "Custom URL"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2864
+#: src/muuli_wdr.cpp:2868
 msgid "Choose which provider supplies the GeoIP MMDB database. DB-IP is the default - no account required. MaxMind requires a free account + license key. Use Custom URL to point at any other MMDB host (e.g. a local mirror)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2881
+#: src/muuli_wdr.cpp:2885
 msgid ""
 "No configuration required.\n"
 "\n"
@@ -4885,11 +4885,11 @@ msgid ""
 "License: Creative Commons BY 4.0 - https://creativecommons.org/licenses/by/4.0/"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2894
+#: src/muuli_wdr.cpp:2898
 msgid "License key:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2900
+#: src/muuli_wdr.cpp:2904
 msgid ""
 "Sign up for a free MaxMind account, then generate a License Key:\n"
 "https://www.maxmind.com/en/geolite2/signup\n"
@@ -4899,225 +4899,225 @@ msgid ""
 "Requires attribution and account registration; refresh at least every 30 days."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2915
+#: src/muuli_wdr.cpp:2919
 #, fuzzy
 msgid "Download URL:"
 msgstr "Download: "
 
-#: src/muuli_wdr.cpp:2921
+#: src/muuli_wdr.cpp:2925
 msgid ""
 "Must point to an .mmdb file or a .gz / .tar.gz containing one.\n"
 "URL may include credentials (https://user:pass@host/...).\n"
 "License and attribution terms are set by the upstream URL - you are responsible."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2934
+#: src/muuli_wdr.cpp:2938
 msgid "Download the GeoIP database from the selected source."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2936
+#: src/muuli_wdr.cpp:2940
 #, fuzzy
 msgid "Auto-update on startup"
 msgstr "Auto-update ip-filter bij het starten"
 
-#: src/muuli_wdr.cpp:2937
+#: src/muuli_wdr.cpp:2941
 msgid "Re-download the GeoIP database from the selected source every time aMule starts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2960
+#: src/muuli_wdr.cpp:2964
 msgid "Filter incoming messages (except current chat):"
 msgstr "Filter binnenkomende berichten (behalve huidige chat):"
 
-#: src/muuli_wdr.cpp:2962
+#: src/muuli_wdr.cpp:2966
 msgid "Filter all messages"
 msgstr "Filter alle berichten"
 
-#: src/muuli_wdr.cpp:2964
+#: src/muuli_wdr.cpp:2968
 msgid "Filter messages from people not on your friend list"
 msgstr "Filter berichten van mensen niet op uw vriendenlijst"
 
-#: src/muuli_wdr.cpp:2966
+#: src/muuli_wdr.cpp:2970
 msgid "Filter messages from unknown clients"
 msgstr "Filter berichten van onbekende clients"
 
-#: src/muuli_wdr.cpp:2968
+#: src/muuli_wdr.cpp:2972
 msgid "Filter messages containing (use ',' as separator):"
 msgstr "Filter berichten met (gebruik ',' als scheiding):"
 
-#: src/muuli_wdr.cpp:2971 src/muuli_wdr.cpp:2982
+#: src/muuli_wdr.cpp:2975 src/muuli_wdr.cpp:2986
 msgid "add here the words amule should filter and block messages including it"
 msgstr "voeg hier de woorden toe die amule moet filteren en berichten daarmee blokkeren"
 
-#: src/muuli_wdr.cpp:2973
+#: src/muuli_wdr.cpp:2977
 msgid "Show received messages in the log"
 msgstr "Toon ontvangen berichten in het logboek"
 
-#: src/muuli_wdr.cpp:2976
+#: src/muuli_wdr.cpp:2980
 msgid "Comments"
 msgstr "Commentaren"
 
-#: src/muuli_wdr.cpp:2979
+#: src/muuli_wdr.cpp:2983
 msgid "Filter comments containing (use ',' as separator):"
 msgstr "Filter commentaren die de volgende tekens bevatten (gebruik ',' als scheiding):"
 
-#: src/muuli_wdr.cpp:3004
+#: src/muuli_wdr.cpp:3008
 msgid "Enable Proxy"
 msgstr "Schakel proxy in"
 
-#: src/muuli_wdr.cpp:3005
+#: src/muuli_wdr.cpp:3009
 msgid "Enable/disable proxy support"
 msgstr "Schakel proxy ondersteuning in/uit"
 
-#: src/muuli_wdr.cpp:3008
+#: src/muuli_wdr.cpp:3012
 msgid "Proxy type:"
 msgstr "Proxy-type:"
 
-#: src/muuli_wdr.cpp:3019
+#: src/muuli_wdr.cpp:3023
 msgid "Proxy host:"
 msgstr "Proxy-host:"
 
-#: src/muuli_wdr.cpp:3022
+#: src/muuli_wdr.cpp:3026
 msgid "The proxy host name"
 msgstr "De proxy hostnaam"
 
-#: src/muuli_wdr.cpp:3024
+#: src/muuli_wdr.cpp:3028
 msgid "Proxy port:"
 msgstr "Proxy-poort:"
 
-#: src/muuli_wdr.cpp:3027
+#: src/muuli_wdr.cpp:3031
 msgid "The proxy port"
 msgstr "De proxy poort"
 
-#: src/muuli_wdr.cpp:3029
+#: src/muuli_wdr.cpp:3033
 msgid "Enable authentication"
 msgstr "Schakel aanmelding in"
 
-#: src/muuli_wdr.cpp:3030
+#: src/muuli_wdr.cpp:3034
 msgid "Enable/disable username/password authentication"
 msgstr "Schakel gebruikersnaam/wachtwoord aanmelding in/uit"
 
-#: src/muuli_wdr.cpp:3033
+#: src/muuli_wdr.cpp:3037
 msgid "Username: "
 msgstr "Gebruikersnaam: "
 
-#: src/muuli_wdr.cpp:3036
+#: src/muuli_wdr.cpp:3040
 msgid "The username to use to connect to the proxy"
 msgstr "De gebruikersnaam is nodig om te verbinden met de proxy"
 
-#: src/muuli_wdr.cpp:3038
+#: src/muuli_wdr.cpp:3042
 msgid "Password:"
 msgstr "Wachtwoord:"
 
-#: src/muuli_wdr.cpp:3041
+#: src/muuli_wdr.cpp:3045
 msgid "The password to use to connect to the proxy"
 msgstr "Het wachtwoord nodig om te verbinden met de proxy"
 
-#: src/muuli_wdr.cpp:3060
+#: src/muuli_wdr.cpp:3064
 msgid "Connect to:"
 msgstr "Verbind met:"
 
-#: src/muuli_wdr.cpp:3069
+#: src/muuli_wdr.cpp:3073
 msgid "Login to remote amule"
 msgstr "Inloggen op amule op afstand"
 
-#: src/muuli_wdr.cpp:3074
+#: src/muuli_wdr.cpp:3078
 msgid "User name"
 msgstr "Gebruikersnaam"
 
-#: src/muuli_wdr.cpp:3085
+#: src/muuli_wdr.cpp:3089
 msgid "Remember those settings"
 msgstr "Onthoud deze instellingen"
 
-#: src/muuli_wdr.cpp:3088
+#: src/muuli_wdr.cpp:3092
 #, fuzzy
 msgid "Force ZLIB compression"
 msgstr "Gebruik Gzip-compressie"
 
-#: src/muuli_wdr.cpp:3112
+#: src/muuli_wdr.cpp:3116
 msgid "Enable Verbose Debug-Logging."
 msgstr "Schakel uitgebreide foutopsporing en logboek in."
 
-#: src/muuli_wdr.cpp:3114
+#: src/muuli_wdr.cpp:3118
 msgid "Only to Logfile"
 msgstr "Alleen naar logbestand"
 
-#: src/muuli_wdr.cpp:3116
+#: src/muuli_wdr.cpp:3120
 msgid "Message Categories:"
 msgstr "Berichtcategorieën:"
 
-#: src/muuli_wdr.cpp:3140 src/PartFileConvertDlg.cpp:160
+#: src/muuli_wdr.cpp:3144 src/PartFileConvertDlg.cpp:160
 msgid "Waiting..."
 msgstr "Wachtend..."
 
-#: src/muuli_wdr.cpp:3160
+#: src/muuli_wdr.cpp:3164
 msgid "Add imports"
 msgstr "Voeg geïmporteerden toe"
 
-#: src/muuli_wdr.cpp:3163
+#: src/muuli_wdr.cpp:3167
 msgid "Retry selected"
 msgstr "Probeer geselecteerde opnieuw"
 
-#: src/muuli_wdr.cpp:3165
+#: src/muuli_wdr.cpp:3169
 msgid "Remove selected"
 msgstr "Verwijder geselecteerde"
 
-#: src/muuli_wdr.cpp:3228
+#: src/muuli_wdr.cpp:3232
 msgid "Event Types"
 msgstr "Gebeurtenistypes"
 
-#: src/muuli_wdr.cpp:3247
+#: src/muuli_wdr.cpp:3251
 msgid "Statistics and queued clients for selected file(s) : Session / All time"
 msgstr "Statistieken en clients in wachtrij voor geselecteerd(e) bestand(en) : Sessie / Alle"
 
-#: src/muuli_wdr.cpp:3271
+#: src/muuli_wdr.cpp:3275
 msgid "Active Uploads"
 msgstr "Actieve uploads"
 
-#: src/muuli_wdr.cpp:3285
+#: src/muuli_wdr.cpp:3289
 msgid "Percent of total files"
 msgstr "Procent van alle bestanden"
 
-#: src/muuli_wdr.cpp:3337
+#: src/muuli_wdr.cpp:3341
 msgid "Show Clients for"
 msgstr "Toon clients voor"
 
-#: src/muuli_wdr.cpp:3339
+#: src/muuli_wdr.cpp:3343
 msgid "All files"
 msgstr "Alle bestanden"
 
-#: src/muuli_wdr.cpp:3342
+#: src/muuli_wdr.cpp:3346
 msgid "Selected files"
 msgstr "Geselecteerde bestanden"
 
-#: src/muuli_wdr.cpp:3345
+#: src/muuli_wdr.cpp:3349
 msgid "Active uploads only"
 msgstr "Alleen actieve uploads"
 
-#: src/muuli_wdr.cpp:3352
+#: src/muuli_wdr.cpp:3356
 msgid "Reload:"
 msgstr "Opnieuw laden:"
 
-#: src/muuli_wdr.cpp:3356
+#: src/muuli_wdr.cpp:3360
 msgid "Reload your shared files"
 msgstr "Laad uw gedeelde bestanden opnieuw"
 
-#: src/muuli_wdr.cpp:3419
+#: src/muuli_wdr.cpp:3423
 msgid "Send"
 msgstr "Verstuur"
 
-#: src/muuli_wdr.cpp:3420
+#: src/muuli_wdr.cpp:3424
 msgid "Sends the specified message."
 msgstr "Verstuurt het opgegeven bericht."
 
-#: src/muuli_wdr.cpp:3424
+#: src/muuli_wdr.cpp:3428
 msgid "Close this chat-session."
 msgstr "Sluit deze chat-sessie."
 
-#: src/muuli_wdr.cpp:3447
+#: src/muuli_wdr.cpp:3451
 msgid "Connect to any server and/or Kad"
 msgstr "Verbind met een server en/of Kad"
 
-#: src/muuli_wdr.cpp:3453 src/SharedFilesCtrl.cpp:142 src/Statistics.cpp:941
+#: src/muuli_wdr.cpp:3457 src/SharedFilesCtrl.cpp:142 src/Statistics.cpp:941
 msgid "Shared Files"
 msgstr "Gedeelde bestanden"
 
@@ -5754,35 +5754,35 @@ msgstr ""
 "aMule zal goed draaien zonder deze instellingen\n"
 "te wijzigen."
 
-#: src/PrefsUnifiedDlg.cpp:647
+#: src/PrefsUnifiedDlg.cpp:656
 #, c-format
 msgid "Failed to connect Cfg to widget with the ID %d and key %s"
 msgstr "Kon Cfg niet verbinden met widget met ID %d en sleutel %s"
 
-#: src/PrefsUnifiedDlg.cpp:695
+#: src/PrefsUnifiedDlg.cpp:704
 #, c-format
 msgid "Failed to transfer data from Cfg to Widget with the ID %d and key %s"
 msgstr "Kon data niet overdragen van Cfg naar widget met ID %d en sleutel %s"
 
-#: src/PrefsUnifiedDlg.cpp:801
+#: src/PrefsUnifiedDlg.cpp:810
 msgid "The type of proxy you are connecting to"
 msgstr "Het type proxy waarmee u verbinding maakt"
 
-#: src/PrefsUnifiedDlg.cpp:1020
+#: src/PrefsUnifiedDlg.cpp:1029
 #, c-format
 msgid "Failed to transfer data from Widget to Cfg with the ID %d and key %s"
 msgstr "Kon data niet overdragen van Widget naar Cfg met ID %d en sleutel %s"
 
-#: src/PrefsUnifiedDlg.cpp:1103
+#: src/PrefsUnifiedDlg.cpp:1112
 #, fuzzy
 msgid "No password set."
 msgstr "Controleren van wachtwoord\n"
 
-#: src/PrefsUnifiedDlg.cpp:1132
+#: src/PrefsUnifiedDlg.cpp:1141
 msgid "Guest access needs a password. Type one in the guest password field, or untick Enable guest access."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1144
+#: src/PrefsUnifiedDlg.cpp:1153
 msgid ""
 "aMule must be restarted to enable these changes:\n"
 "\n"
@@ -5790,41 +5790,41 @@ msgstr ""
 "aMule moet opnieuw gestart worden om deze veranderingen toe te passen:\n"
 "\n"
 
-#: src/PrefsUnifiedDlg.cpp:1151
+#: src/PrefsUnifiedDlg.cpp:1160
 msgid "- TCP port changed.\n"
 msgstr "- TCP-poort veranderd.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1156
+#: src/PrefsUnifiedDlg.cpp:1165
 msgid "- UDP port changed.\n"
 msgstr "- UDP-poort veranderd.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1161
+#: src/PrefsUnifiedDlg.cpp:1170
 #, fuzzy
 msgid "- Network interface binding changed.\n"
 msgstr "- Interface voor externe verbinding veranderd.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1166
+#: src/PrefsUnifiedDlg.cpp:1175
 msgid "- External connect port changed.\n"
 msgstr "- Poort voor externe verbinding is veranderd.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1170
+#: src/PrefsUnifiedDlg.cpp:1179
 msgid "- External connect acceptance changed.\n"
 msgstr "- Acceptatie voor externe verbinding veranderd.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1174
+#: src/PrefsUnifiedDlg.cpp:1183
 msgid "- External connect interface changed.\n"
 msgstr "- Interface voor externe verbinding veranderd.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1178
+#: src/PrefsUnifiedDlg.cpp:1187
 msgid "- Protocol obfuscation support changed.\n"
 msgstr "- Ondersteuning voor Protocol-obfuscatie is veranderd.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1193
+#: src/PrefsUnifiedDlg.cpp:1202
 #, fuzzy
 msgid "- amuleapi settings changed.\n"
 msgstr "- Taal veranderd.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1202
+#: src/PrefsUnifiedDlg.cpp:1211
 msgid ""
 "Your Auto-update server list is empty.\n"
 "'Auto-update server list at startup' will be disabled."
@@ -5832,7 +5832,7 @@ msgstr ""
 "Uw Auto-update serverlijst is leeg.\n"
 "'Auto-update serverlijst bij het opstarten' wordt uitgeschakeld."
 
-#: src/PrefsUnifiedDlg.cpp:1213
+#: src/PrefsUnifiedDlg.cpp:1222
 msgid ""
 "You have enabled external connections but have not specified a password.\n"
 "External connections cannot be enabled unless a valid password is specified."
@@ -5840,33 +5840,33 @@ msgstr ""
 "U hebt externe verbindingen ingeschakeld maar geen wachtwoord ingesteld.\n"
 "Externe verbindingen kunnen niet ingeschakeld worden tenzij een geldig wachtwoord is ingesteld."
 
-#: src/PrefsUnifiedDlg.cpp:1246
+#: src/PrefsUnifiedDlg.cpp:1255
 #, c-format
 msgid "The amuleapi password could not be saved: %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1276
+#: src/PrefsUnifiedDlg.cpp:1285
 msgid "- Language changed.\n"
 msgstr "- Taal veranderd.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1281
+#: src/PrefsUnifiedDlg.cpp:1290
 msgid "- Temp folder changed.\n"
 msgstr "- Tijdelijke map veranderd.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1286
+#: src/PrefsUnifiedDlg.cpp:1295
 msgid "- ED2K network enabled.\n"
 msgstr "- ED2K-netwerk ingeschakeld.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1319
+#: src/PrefsUnifiedDlg.cpp:1328
 msgid "The shared-file exclusion pattern is not a valid regular expression. The filter has been left disabled."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1321 src/PrefsUnifiedDlg.cpp:1921
+#: src/PrefsUnifiedDlg.cpp:1330 src/PrefsUnifiedDlg.cpp:1930
 #, fuzzy
 msgid "Invalid regular expression"
 msgstr "Ongeldige protocolversie."
 
-#: src/PrefsUnifiedDlg.cpp:1398
+#: src/PrefsUnifiedDlg.cpp:1407
 msgid ""
 "Both eD2k and Kad network are disabled.\n"
 "You won't be able to connect until you enable at least one of them."
@@ -5874,7 +5874,7 @@ msgstr ""
 "Zowel het eD2K als het Kad-netwerk zijn uitgeschakeld.\n"
 "U kun niet verbinden tot u minimaal een netwerk inschakelt."
 
-#: src/PrefsUnifiedDlg.cpp:1403
+#: src/PrefsUnifiedDlg.cpp:1412
 msgid ""
 "Kad will not start if your UDP port is disabled.\n"
 "Enable UDP port or disable Kad."
@@ -5882,7 +5882,7 @@ msgstr ""
 "Kad zal niet starten als uw UDP-poort is uitgeschakeld.\n"
 "Schakel de UDP-poort in of schakel Kad uit."
 
-#: src/PrefsUnifiedDlg.cpp:1459
+#: src/PrefsUnifiedDlg.cpp:1468
 msgid ""
 "\n"
 "You MUST restart aMule now.\n"
@@ -5892,69 +5892,69 @@ msgstr ""
 "U MOET aMule nu opnieuw starten.\n"
 "Als u dat niet doet moet u niet klagen als er iets misgaat.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1524
+#: src/PrefsUnifiedDlg.cpp:1533
 msgid "Could not register aMule for autostart at login. The autostart store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1526
+#: src/PrefsUnifiedDlg.cpp:1535
 msgid "Could not remove the autostart-at-login entry."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1527
+#: src/PrefsUnifiedDlg.cpp:1536
 #, fuzzy
 msgid "Autostart"
 msgstr "Automatisch verversen gestart"
 
-#: src/PrefsUnifiedDlg.cpp:1542
+#: src/PrefsUnifiedDlg.cpp:1551
 msgid "Register file type"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1542
+#: src/PrefsUnifiedDlg.cpp:1551
 msgid "Register URL handler"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1550
+#: src/PrefsUnifiedDlg.cpp:1559
 #, c-format
 msgid "aMule only handles eD2k-compatible magnets. If you replace the current magnet handler (%s), BitTorrent magnet links will stop working - aMule cannot download BitTorrent content. Continue?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1555
+#: src/PrefsUnifiedDlg.cpp:1564
 #, c-format
 msgid "Another application currently opens .emulecollection files (%s). Replace it with aMule?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1560
+#: src/PrefsUnifiedDlg.cpp:1569
 #, c-format
 msgid "Another application is currently the default handler for these links (%s). Replace it with aMule?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1585
+#: src/PrefsUnifiedDlg.cpp:1594
 msgid "Could not register aMule for .emulecollection files. The registration store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1587
+#: src/PrefsUnifiedDlg.cpp:1596
 #, fuzzy
 msgid "Could not remove the file type registration."
 msgstr "Map voor tijdelijke downloadbestanden"
 
-#: src/PrefsUnifiedDlg.cpp:1589
+#: src/PrefsUnifiedDlg.cpp:1598
 msgid "Could not register aMule as the URL handler. The registration store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1591
+#: src/PrefsUnifiedDlg.cpp:1600
 msgid "Could not remove the URL handler registration."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1661 src/PrefsUnifiedDlg.cpp:1688
+#: src/PrefsUnifiedDlg.cpp:1670 src/PrefsUnifiedDlg.cpp:1697
 #, fuzzy
 msgid "The web server and aMule API require external connections to be enabled."
 msgstr "Wachtwoord ingesteld en externe verbindingen ingeschakeld."
 
-#: src/PrefsUnifiedDlg.cpp:1671
+#: src/PrefsUnifiedDlg.cpp:1680
 msgid "The aMule web server is deprecated. Consider running the aMule API instead."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1735
+#: src/PrefsUnifiedDlg.cpp:1744
 msgid ""
 "Your Auto-update servers list is in blank.\n"
 "Please fill in at least one URL to point to a valid server.met file.\n"
@@ -5964,66 +5964,66 @@ msgstr ""
 "Vul minimaal een URL naar een geldig server.met bestand in.\n"
 "Klik op de knop \"Lijst\" hiernaast om een URL in te voeren."
 
-#: src/PrefsUnifiedDlg.cpp:1876
+#: src/PrefsUnifiedDlg.cpp:1885
 msgid "Temporary files"
 msgstr "Tijdelijke bestanden"
 
-#: src/PrefsUnifiedDlg.cpp:1881
+#: src/PrefsUnifiedDlg.cpp:1890
 msgid "Incoming files"
 msgstr "Binnenkomende bestanden"
 
-#: src/PrefsUnifiedDlg.cpp:1886
+#: src/PrefsUnifiedDlg.cpp:1895
 msgid "Online Signatures"
 msgstr "Online handtekeningen"
 
-#: src/PrefsUnifiedDlg.cpp:1899
+#: src/PrefsUnifiedDlg.cpp:1908
 #, c-format
 msgid "Choose a folder for %s"
 msgstr "Kies een map voor %s"
 
-#: src/PrefsUnifiedDlg.cpp:1923
+#: src/PrefsUnifiedDlg.cpp:1932
 #, fuzzy, c-format
 msgid "Would exclude %u of %u shared file"
 msgid_plural "Would exclude %u of %u shared files"
 msgstr[0] "%i bekend gedeeld bestand gevonden"
 msgstr[1] "%i bekende gedeelde bestanden gevonden"
 
-#: src/PrefsUnifiedDlg.cpp:1940
+#: src/PrefsUnifiedDlg.cpp:1949
 msgid "Browse for videoplayer"
 msgstr "Blader naar videospeler"
 
-#: src/PrefsUnifiedDlg.cpp:1944
+#: src/PrefsUnifiedDlg.cpp:1953
 msgid "Select browser"
 msgstr "Selecteer browser"
 
-#: src/PrefsUnifiedDlg.cpp:1948
+#: src/PrefsUnifiedDlg.cpp:1957
 #, fuzzy
 msgid "Select ffprobe binary"
 msgstr "Selecteer browser"
 
-#: src/PrefsUnifiedDlg.cpp:1954
+#: src/PrefsUnifiedDlg.cpp:1963
 #, c-format
 msgid "Executable%s"
 msgstr "Uitvoerbare%s"
 
-#: src/PrefsUnifiedDlg.cpp:1988
+#: src/PrefsUnifiedDlg.cpp:1997
 msgid "ffprobe not found on PATH or in the standard install locations. Install ffmpeg (which ships ffprobe) or use Browse to pick a binary manually."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2000
+#: src/PrefsUnifiedDlg.cpp:2009
 msgid "Reset the settings on this page to their default values?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2001
+#: src/PrefsUnifiedDlg.cpp:2010
 #, fuzzy
 msgid "Reset to defaults"
 msgstr "Systeemstandaard"
 
-#: src/PrefsUnifiedDlg.cpp:2028
+#: src/PrefsUnifiedDlg.cpp:2037
 msgid "Edit server list"
 msgstr "Bewerk serverlijst"
 
-#: src/PrefsUnifiedDlg.cpp:2029
+#: src/PrefsUnifiedDlg.cpp:2038
 msgid ""
 "Add here URL's to download server.met files.\n"
 "Only one url on each line."
@@ -6031,154 +6031,154 @@ msgstr ""
 "Voeg hier URL's toe om server.met bestanden te downloaden.\n"
 "Slechts één url per regel."
 
-#: src/PrefsUnifiedDlg.cpp:2084
+#: src/PrefsUnifiedDlg.cpp:2093
 msgid "IP2Country update failed"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2229 src/PrefsUnifiedDlg.cpp:2260
+#: src/PrefsUnifiedDlg.cpp:2238 src/PrefsUnifiedDlg.cpp:2269
 msgid "Data by MaxMind GeoLite2"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2231 src/PrefsUnifiedDlg.cpp:2262
+#: src/PrefsUnifiedDlg.cpp:2240 src/PrefsUnifiedDlg.cpp:2271
 #, fuzzy
 msgid "Custom source"
 msgstr "Complete bronnen"
 
-#: src/PrefsUnifiedDlg.cpp:2233 src/PrefsUnifiedDlg.cpp:2264
+#: src/PrefsUnifiedDlg.cpp:2242 src/PrefsUnifiedDlg.cpp:2273
 msgid "Data by DB-IP.com"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2284
+#: src/PrefsUnifiedDlg.cpp:2293
 #, fuzzy, c-format
 msgid "Status: Loaded%s"
 msgstr "Status:"
 
-#: src/PrefsUnifiedDlg.cpp:2286
+#: src/PrefsUnifiedDlg.cpp:2295
 #, fuzzy, c-format
 msgid "Status: Loaded%s - %s"
 msgstr "Status:"
 
-#: src/PrefsUnifiedDlg.cpp:2290
+#: src/PrefsUnifiedDlg.cpp:2299
 msgid "Status: Failed to load - click 'Update now' to refresh."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2292
+#: src/PrefsUnifiedDlg.cpp:2301
 msgid "Status: Not found - click 'Update now' to download."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2350 src/PrefsUnifiedDlg.cpp:2374
+#: src/PrefsUnifiedDlg.cpp:2359 src/PrefsUnifiedDlg.cpp:2383
 #, c-format
 msgid "Update delay: %d second"
 msgid_plural "Update delay: %d seconds"
 msgstr[0] "Update-vertraging: %d seconde"
 msgstr[1] "Update-vertraging: %d seconden"
 
-#: src/PrefsUnifiedDlg.cpp:2358
+#: src/PrefsUnifiedDlg.cpp:2367
 #, c-format
 msgid "Time for average graph: %d minute"
 msgid_plural "Time for average graph: %d minutes"
 msgstr[0] "Tijd voor gemiddeldengrafiek: %d minuut"
 msgstr[1] "Tijd voor gemiddeldengrafiek: %d minuten"
 
-#: src/PrefsUnifiedDlg.cpp:2367
+#: src/PrefsUnifiedDlg.cpp:2376
 #, c-format
 msgid "Connections Graph Scale: %d"
 msgstr "Schaal verbindingengrafiek: %d"
 
-#: src/PrefsUnifiedDlg.cpp:2382
+#: src/PrefsUnifiedDlg.cpp:2391
 #, c-format
 msgid "File Buffer Size: %d byte"
 msgid_plural "File Buffer Size: %d bytes"
 msgstr[0] "Grootte van bestandsbuffer: %d byte"
 msgstr[1] "Grootte van bestandsbuffer: %d bytes"
 
-#: src/PrefsUnifiedDlg.cpp:2392
+#: src/PrefsUnifiedDlg.cpp:2401
 #, c-format
 msgid "Upload Queue Size: %d client"
 msgid_plural "Upload Queue Size: %d clients"
 msgstr[0] "Grootte van uploadwachtrij: %d client"
 msgstr[1] "Grootte van uploadwachtrij: %d clients"
 
-#: src/PrefsUnifiedDlg.cpp:2402
+#: src/PrefsUnifiedDlg.cpp:2411
 #, c-format
 msgid "Server connection refresh interval: %d minute"
 msgid_plural "Server connection refresh interval: %d minutes"
 msgstr[0] "Server-verbinding verversingsinterval: %d minuut"
 msgstr[1] "Server-verbinding verversingsinterval: %d minuten"
 
-#: src/PrefsUnifiedDlg.cpp:2407
+#: src/PrefsUnifiedDlg.cpp:2416
 msgid "Server connection refresh interval: Disabled"
 msgstr "Server verbinding verversingstijd: Uitgeschakeld"
 
-#: src/PrefsUnifiedDlg.cpp:2451
+#: src/PrefsUnifiedDlg.cpp:2460
 msgid "disabled"
 msgstr "uitgeschakeld"
 
-#: src/PrefsUnifiedDlg.cpp:2477
+#: src/PrefsUnifiedDlg.cpp:2486
 #, c-format
 msgid "Execute command on '%s' event"
 msgstr "Voer commando uit bij gebeurtenis '%s'"
 
-#: src/PrefsUnifiedDlg.cpp:2484
+#: src/PrefsUnifiedDlg.cpp:2493
 msgid "Enable command execution on core"
 msgstr "Schakel uitvoeren van commando's in kern in"
 
-#: src/PrefsUnifiedDlg.cpp:2496
+#: src/PrefsUnifiedDlg.cpp:2505
 msgid "Core command:"
 msgstr "Kerncommando:"
 
-#: src/PrefsUnifiedDlg.cpp:2512
+#: src/PrefsUnifiedDlg.cpp:2521
 msgid "Enable command execution on GUI"
 msgstr "Schakel uitvoeren van commando's in GUI in"
 
-#: src/PrefsUnifiedDlg.cpp:2524
+#: src/PrefsUnifiedDlg.cpp:2533
 msgid "GUI command:"
 msgstr "GUI commando:"
 
-#: src/PrefsUnifiedDlg.cpp:2540
+#: src/PrefsUnifiedDlg.cpp:2549
 msgid "The following variables will be replaced:"
 msgstr "De volgende variabelen worden vervangen:"
 
-#: src/PrefsUnifiedDlg.cpp:2708
+#: src/PrefsUnifiedDlg.cpp:2717
 msgid ""
 "The following folders look like system or sensitive locations:\n"
 "\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2713
+#: src/PrefsUnifiedDlg.cpp:2722
 msgid "Sharing them recursively will publish every file underneath on the eD2k/Kad networks. Do you really want to do this?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2716
+#: src/PrefsUnifiedDlg.cpp:2725
 #, fuzzy
 msgid "Confirm shared folders"
 msgstr "Gedeelde mappen"
 
-#: src/PrefsUnifiedDlg.cpp:2744
+#: src/PrefsUnifiedDlg.cpp:2753
 #, fuzzy
 msgid "Reloading shared files..."
 msgstr "Laad uw gedeelde bestanden opnieuw"
 
-#: src/PrefsUnifiedDlg.cpp:2745
+#: src/PrefsUnifiedDlg.cpp:2754
 msgid "Scanning for subdirectories..."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2746
+#: src/PrefsUnifiedDlg.cpp:2755
 #, fuzzy
 msgid "Updating shared folders"
 msgstr "Gedeelde mappen"
 
-#: src/PrefsUnifiedDlg.cpp:2773
+#: src/PrefsUnifiedDlg.cpp:2782
 #, c-format
 msgid "Scanned %u directories..."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2823
+#: src/PrefsUnifiedDlg.cpp:2832
 #, fuzzy, c-format
 msgid "Reloading shared files: %u files scanned"
 msgstr "Laad gedeelde-bestandenlijst opnieuw."
 
-#: src/PrefsUnifiedDlg.cpp:2873
+#: src/PrefsUnifiedDlg.cpp:2882
 #, fuzzy
 msgid "Shared folder"
 msgstr "Gedeelde mappen"
@@ -7859,12 +7859,12 @@ msgstr "Verwijder categorie"
 msgid "Hashset requested for unknown file: %s"
 msgstr "Hashset opgevraagd voor onbekend bestand: %s"
 
-#: src/UploadQueue.cpp:618
+#: src/UploadQueue.cpp:627
 #, c-format
 msgid "Resuming uploads of file: %s"
 msgstr "Verder gaan met uploads van bestand: %s"
 
-#: src/UploadQueue.cpp:634
+#: src/UploadQueue.cpp:643
 #, c-format
 msgid "Suspending upload of file: %s"
 msgstr "Stoppen van upload van bestand: %s"

--- a/po/nl.po
+++ b/po/nl.po
@@ -12,8 +12,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-28 12:12+0200\n"
-"PO-Revision-Date: 2026-07-27 10:28+0000\n"
+"POT-Creation-Date: 2026-07-28 08:06+0200\n"
+"PO-Revision-Date: 2026-07-27 11:42+0000\n"
 "Last-Translator: Marcel Pol <marcel@timelord.nl>\n"
 "Language-Team: Dutch <nl@li.org>\n"
 "Language: nl\n"
@@ -147,7 +147,7 @@ msgstr ""
 msgid "Not now"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:422 src/amuleDlg.cpp:665
+#: src/AppImageIntegration.cpp:422 src/amuleDlg.cpp:600
 msgid "Don't ask again"
 msgstr ""
 
@@ -205,83 +205,83 @@ msgstr "Kon bestand ED2KLinks niet openen."
 msgid "WARNING: You can't add yourself as a source for an eD2k link while having a lowid."
 msgstr "WAARSCHUWING: U kunt uzelf niet toevoegen als bron voor een eD2k-link terwijl u een laag id hebt."
 
-#: src/amule.cpp:301
+#: src/amule.cpp:300
 msgid "Now, exiting main app..."
 msgstr "Hoofdapp wordt nu afgesloten..."
 
-#: src/amule.cpp:331
+#: src/amule.cpp:330
 #, c-format
 msgid "Terminating amuleweb instance with pid '%d' ... "
 msgstr "Amuleweb-instantie met pid '%d' wordt afgesloten ... "
 
-#: src/amule.cpp:335
+#: src/amule.cpp:334
 #, c-format
 msgid "Killing amuleweb instance with pid '%d' ... "
 msgstr "Amuleweb-instantie met pid '%d' wordt gedood ... "
 
-#: src/amule.cpp:337 src/amule.cpp:350 src/ClientRef.cpp:180
-#: src/SearchDlg.cpp:1041 src/ServerListCtrl.cpp:98
+#: src/amule.cpp:336 src/amule.cpp:349 src/ClientRef.cpp:180
+#: src/SearchDlg.cpp:880 src/ServerListCtrl.cpp:98
 msgid "Failed"
 msgstr "Mislukt"
 
-#: src/amule.cpp:344
+#: src/amule.cpp:343
 #, fuzzy, c-format
 msgid "Terminating amuleapi instance with pid '%d' ... "
 msgstr "Amuleweb-instantie met pid '%d' wordt afgesloten ... "
 
-#: src/amule.cpp:348
+#: src/amule.cpp:347
 #, fuzzy, c-format
 msgid "Killing amuleapi instance with pid '%d' ... "
 msgstr "Amuleweb-instantie met pid '%d' wordt gedood ... "
 
-#: src/amule.cpp:356
+#: src/amule.cpp:355
 msgid "aMule OnExit: Terminating core."
 msgstr "aMule OnExit: Kern wordt afgesloten."
 
-#: src/amule.cpp:467
+#: src/amule.cpp:466
 msgid "aMule shutdown completed."
 msgstr "aMule is afgesloten."
 
-#: src/amule.cpp:471
+#: src/amule.cpp:470
 msgid "Memory debug results for aMule exit:"
 msgstr "Geheugen debug resultaten voor het afsluiten van aMule:"
 
-#: src/amule.cpp:652
+#: src/amule.cpp:651
 #, c-format
 msgid "Binding aMule's peer-to-peer traffic to interface: %s (HTTP updates use the default route)"
 msgstr ""
 
-#: src/amule.cpp:656
+#: src/amule.cpp:655
 #, c-format
 msgid "Binding all network traffic to interface: %s"
 msgstr ""
 
-#: src/amule.cpp:660
+#: src/amule.cpp:659
 #, c-format
 msgid "WARNING: configured network interface '%s' was not found - traffic is NOT bound to it and may leave via the default route. Check the interface name in Preferences."
 msgstr ""
 
-#: src/amule.cpp:666
+#: src/amule.cpp:665
 #, c-format
 msgid "WARNING: binding to network interface '%s' requires elevated privileges and was NOT applied - traffic may leave via the default route. Grant the capability (e.g. 'sudo setcap cap_net_raw+ep' on the aMule binary) or run with sufficient privileges."
 msgstr ""
 
-#: src/amule.cpp:674
+#: src/amule.cpp:673
 #, c-format
 msgid "WARNING: could not bind to network interface '%s' - traffic may leave via the default route."
 msgstr ""
 
-#: src/amule.cpp:733
+#: src/amule.cpp:732
 msgid "Your locale has been changed to System Default due to a configuration change. Sorry."
 msgstr "De taalinstelling is veranderd naar de systeemstandaard vanwege een configuratiewijziging. Sorry."
 
-#: src/amule.cpp:735 src/amule.cpp:1589 src/CatDialog.cpp:128
+#: src/amule.cpp:734 src/amule.cpp:1581 src/CatDialog.cpp:128
 #: src/CatDialog.cpp:136 src/CatDialog.cpp:149 src/ServerList.cpp:366
 #: src/ServerListCtrl.cpp:152
 msgid "Info"
 msgstr "Info"
 
-#: src/amule.cpp:742
+#: src/amule.cpp:741
 msgid ""
 "\n"
 "EC configuration"
@@ -289,74 +289,74 @@ msgstr ""
 "\n"
 "EV-configuratie"
 
-#: src/amule.cpp:745
+#: src/amule.cpp:744
 msgid "Password set and external connections enabled."
 msgstr "Wachtwoord ingesteld en externe verbindingen ingeschakeld."
 
-#: src/amule.cpp:755 src/KadDlg.cpp:176 src/KadDlg.cpp:185
-#: src/PrefsUnifiedDlg.cpp:1461 src/SharedFilesCtrl.cpp:476
+#: src/amule.cpp:754 src/KadDlg.cpp:176 src/KadDlg.cpp:185
+#: src/PrefsUnifiedDlg.cpp:1387 src/SharedFilesCtrl.cpp:476
 msgid "WARNING"
 msgstr "WAARSCHUWING"
 
-#: src/amule.cpp:992
+#: src/amule.cpp:991
 #, fuzzy
 msgid "Network bootstrap"
 msgstr "Netwerken"
 
-#: src/amule.cpp:997
+#: src/amule.cpp:996
 msgid ""
 "aMule has detected missing network bootstrap files.\n"
 "Select which ones to download:"
 msgstr ""
 
-#: src/amule.cpp:1006 src/FirstRunWizard.cpp:411
+#: src/amule.cpp:1005 src/FirstRunWizard.cpp:411
 #, fuzzy
 msgid "eD2k server list (server.met)"
 msgstr "%i server in server.met gevonden"
 
-#: src/amule.cpp:1013 src/FirstRunWizard.cpp:416
+#: src/amule.cpp:1012 src/FirstRunWizard.cpp:416
 msgid "Kad bootstrap nodes (nodes.dat)"
 msgstr ""
 
-#: src/amule.cpp:1103
+#: src/amule.cpp:1102
 #, c-format
 msgid "web server running on pid %d"
 msgstr "webserver draait met pid %d"
 
-#: src/amule.cpp:1116
+#: src/amule.cpp:1115
 #, fuzzy
 msgid "You requested to run web server on startup, but the amuleweb binary cannot be run. Please install the package containing aMule web server, or build aMule from source with -DBUILD_WEBSERVER=YES and install it."
 msgstr "U heeft ingesteld om de webserver te starten bij het opstarten, maar amuleweb kan niet gestart worden. Installeer het pakket met de aMule webserver, of compileer aMule met --enable-webserver en draai make install"
 
-#: src/amule.cpp:1121 src/amule.cpp:1185 src/amule.cpp:1299 src/amule.cpp:1601
+#: src/amule.cpp:1120 src/amule.cpp:1177 src/amule.cpp:1291 src/amule.cpp:1593
 #: src/amule-remote-gui.cpp:603 src/amule-remote-gui.cpp:671
 #: src/amule-remote-gui.cpp:709 src/amule-remote-gui.cpp:1282
 #: src/amule-remote-gui.cpp:1345 src/amule-remote-gui.cpp:1372
-#: src/DownloadQueue.cpp:1481 src/PrefsUnifiedDlg.cpp:1247
+#: src/DownloadQueue.cpp:1481
 msgid "ERROR"
 msgstr "FOUT"
 
-#: src/amule.cpp:1174
+#: src/amule.cpp:1166
 #, fuzzy, c-format
 msgid "amuleapi running on pid %d"
 msgstr "webserver draait met pid %d"
 
-#: src/amule.cpp:1180
+#: src/amule.cpp:1172
 #, fuzzy
 msgid "You requested to run amuleapi on startup, but the amuleapi binary cannot be run. Please install the package containing aMule's REST API server, or build aMule from source with -DBUILD_AMULEAPI=YES and install it."
 msgstr "U heeft ingesteld om de webserver te starten bij het opstarten, maar amuleweb kan niet gestart worden. Installeer het pakket met de aMule webserver, of compileer aMule met --enable-webserver en draai make install"
 
-#: src/amule.cpp:1267
+#: src/amule.cpp:1259
 #, c-format
 msgid "Could not bind ports to the specified address: %s"
 msgstr "Kon geen poorten koppelen aan het opgegeven adres: %s"
 
-#: src/amule.cpp:1291
+#: src/amule.cpp:1283
 #, c-format
 msgid "Port %u is not available. You will be LOWID\n"
 msgstr "Poort %u is niet beschikbaar. U krijgt een LAAG ID\n"
 
-#: src/amule.cpp:1296
+#: src/amule.cpp:1288
 #, c-format
 msgid ""
 "Port %u is not available!\n"
@@ -371,48 +371,48 @@ msgstr ""
 "\n"
 "Controleer uw netwerk en zorg ervoor dat de poort open is voor in- en uitgaand verkeer."
 
-#: src/amule.cpp:1393
+#: src/amule.cpp:1385
 msgid "Failed to create OnlineSig File"
 msgstr "Kon bestand met online handtekening niet maken"
 
-#: src/amule.cpp:1401
+#: src/amule.cpp:1393
 msgid "Failed to create aMule OnlineSig File"
 msgstr "Kon aMule OnlineHandtekening Bestand niet maken"
 
-#: src/amule.cpp:1564
+#: src/amule.cpp:1556
 msgid "The selected locale seems not to be installed on your box. (Note: I'll try to set it anyway)"
 msgstr "De gekozen taalinstelling lijkt niet geïnstalleerd te zijn op uw pc. (Let op: Ik probeer het toch in te stellen)"
 
-#: src/amule.cpp:1574
+#: src/amule.cpp:1566
 #, c-format
 msgid "This is the first time you run aMule %s"
 msgstr "Dit is de eerste keer dat u aMule %s draait"
 
-#: src/amule.cpp:1577
+#: src/amule.cpp:1569
 msgid "This version is a testing version, updated daily, and\n"
 msgstr "Dit is een testversie, dagelijks geupdatet, en\n"
 
-#: src/amule.cpp:1578
+#: src/amule.cpp:1570
 msgid "we give no warranty it won't break anything, burn your house,\n"
 msgstr "we geven geen garantie dat het niks kapot maakt of uw huis in brand steekt,\n"
 
-#: src/amule.cpp:1579
+#: src/amule.cpp:1571
 msgid "or kill your dog. But it *should* be safe to use anyway.\n"
 msgstr "of uw hond doodt. Maar het *zou* veilig moeten zijn om het te gebruiken.\n"
 
-#: src/amule.cpp:1584
+#: src/amule.cpp:1576
 msgid "More information, support and new releases can found at our homepage,\n"
 msgstr "Meer informatie, ondersteuning en niuwe versies kunnen gevonden worden op onze homepage,\n"
 
-#: src/amule.cpp:1585
+#: src/amule.cpp:1577
 msgid "at https://amule-org.github.io, or in our IRC channel #aMule at irc.libera.chat.\n"
 msgstr "op https://amule-org.github.io, of op ons IRC-kanaal #amule op irc.libera.chat.\n"
 
-#: src/amule.cpp:1587
+#: src/amule.cpp:1579
 msgid "Feel free to report any bugs to https://github.com/amule-org/amule/issues"
 msgstr "Bugs kunt u altijd melden op https://github.com/amule-org/amule/issues"
 
-#: src/amule.cpp:1599
+#: src/amule.cpp:1591
 msgid ""
 "The folder for Online Signature files you specified is INVALID!\n"
 " OnlineSignature will be DISABLED until you fix it on preferences."
@@ -420,137 +420,137 @@ msgstr ""
 "De map voor online-handtekeningbestanden die u heeft opgegeven is ONGELDIG!\n"
 " OnlineSignature is UITGESCHAKELD totdat u dit verbetert in voorkeuren."
 
-#: src/amule.cpp:1662
+#: src/amule.cpp:1654
 msgid "Server hostname notified"
 msgstr "Server-hostnaam geïnformeerd"
 
-#: src/amule.cpp:2039
+#: src/amule.cpp:2031
 #, c-format
 msgid "Disk space preallocation for file '%s' failed: %s"
 msgstr "Toewijzen schijfruimte voor bestand '%s' mislukt: %s"
 
-#: src/amule.cpp:2168
+#: src/amule.cpp:2160
 msgid "ERROR: can't open logfile"
 msgstr "FOUT: kan logbestand niet openen"
 
-#: src/amule.cpp:2172
+#: src/amule.cpp:2164
 msgid "WARNING: logfile is empty. Something is wrong."
 msgstr "WAARSCHUWING: logboekbestand is leeg. Er is iets mis."
 
-#: src/amule.cpp:2189
+#: src/amule.cpp:2181
 msgid "Log has been reset"
 msgstr "Logboek is gewist"
 
-#: src/amule.cpp:2213
+#: src/amule.cpp:2205
 #, c-format
 msgid "ServerMessage: %s"
 msgstr "Server-bericht: %s"
 
-#: src/amule.cpp:2256 src/IP2Country.cpp:220 src/IPFilter.cpp:514
+#: src/amule.cpp:2248 src/IP2Country.cpp:220 src/IPFilter.cpp:514
 #: src/ServerList.cpp:875
 #, c-format
 msgid "Skipped download of %s, because requested file is not newer."
 msgstr "Download van %s overgeslagen, omdat gevraagd bestand niet nieuwer is."
 
-#: src/amule.cpp:2259
+#: src/amule.cpp:2251
 msgid "Failed to download the nodes list."
 msgstr "Kon nodelijst niet downloaden."
 
-#: src/amule.cpp:2322
+#: src/amule.cpp:2314
 msgid "Failed to open the downloaded version check file"
 msgstr "Kon gedownload versie controle bestand niet openen"
 
-#: src/amule.cpp:2325 src/amule.cpp:2344
+#: src/amule.cpp:2317 src/amule.cpp:2336
 msgid "Corrupted version check file"
 msgstr "Beschadigd bestand voor versiecontrole"
 
-#: src/amule.cpp:2367
+#: src/amule.cpp:2359
 msgid "You are using an outdated version of aMule!"
 msgstr "U gebruikt een verouderde versie van aMule!"
 
-#: src/amule.cpp:2369
+#: src/amule.cpp:2361
 #, c-format
 msgid "Your aMule version is %i.%i.%i and the latest version is %li.%li.%li"
 msgstr "Uw aMule-versie is %i.%i.%i en de nieuwste versie is %li.%li.%li"
 
-#: src/amule.cpp:2373
+#: src/amule.cpp:2365
 msgid "The latest version can always be found at https://github.com/amule-org/amule/releases/latest"
 msgstr "De nieuwste versie kan altijd gevonden worden op https://github.com/amule-org/amule/releases/latest"
 
-#: src/amule.cpp:2376
+#: src/amule.cpp:2368
 #, c-format
 msgid "WARNING: Your aMuled version is outdated: %i.%i.%i < %li.%li.%li"
 msgstr "WAARSCHUWING: Uw aMuled-versie is verouderd: %i.%i.%i < %li.%li.%li"
 
-#: src/amule.cpp:2382
+#: src/amule.cpp:2374
 msgid "Your copy of aMule is up to date."
 msgstr "U heeft de nieuwste aMule-versie."
 
-#: src/amule.cpp:2389
+#: src/amule.cpp:2381
 msgid "Failed to download the version check file"
 msgstr "Kon bestand voor versiecontrole niet downloaden"
 
-#: src/amule.cpp:2558 src/amule-remote-gui.cpp:1133
+#: src/amule.cpp:2550 src/amule-remote-gui.cpp:1133
 #, c-format
 msgid "Users: %s | Files: %s"
 msgstr "Gebruikers: %s | Bestanden: %s"
 
-#: src/amule.cpp:2559 src/amule-remote-gui.cpp:1134
+#: src/amule.cpp:2551 src/amule-remote-gui.cpp:1134
 #, c-format
 msgid "Users: E: %s K: %s | Files: E: %s K: %s"
 msgstr "Gebruikers: E: %s K: %s | Bestanden: E: %s K: %s"
 
-#: src/amule.cpp:2573 src/amule-remote-gui.cpp:1147
+#: src/amule.cpp:2565 src/amule-remote-gui.cpp:1147
 msgid "No networks selected"
 msgstr "Geen netwerken geselecteerd"
 
-#: src/amule.cpp:2641 src/TextClient.cpp:903
+#: src/amule.cpp:2633 src/TextClient.cpp:903
 msgid "with LowID"
 msgstr "met Laag ID"
 
-#: src/amule.cpp:2641 src/TextClient.cpp:904
+#: src/amule.cpp:2633 src/TextClient.cpp:904
 msgid "with HighID"
 msgstr "met Hoog ID"
 
-#: src/amule.cpp:2643
+#: src/amule.cpp:2635
 #, c-format
 msgid "Connected to %s %s"
 msgstr "Verbonden met %s %s"
 
-#: src/amule.cpp:2648
+#: src/amule.cpp:2640
 #, c-format
 msgid "Connecting to %s"
 msgstr "Verbinden met %s"
 
-#: src/amule.cpp:2650
+#: src/amule.cpp:2642
 msgid "Disconnected from eD2k"
 msgstr "Verbinding verbroken met eD2K"
 
-#: src/amule.cpp:2659
+#: src/amule.cpp:2651
 msgid "Kad started."
 msgstr "Kad gestart."
 
-#: src/amule.cpp:2661
+#: src/amule.cpp:2653
 msgid "Kad stopped."
 msgstr "Kad gestopt."
 
-#: src/amule.cpp:2669
+#: src/amule.cpp:2661
 msgid "Connected to Kad (ok)"
 msgstr "Verbonden met Kad (ok)"
 
-#: src/amule.cpp:2671
+#: src/amule.cpp:2663
 msgid "Connected to Kad (firewalled)"
 msgstr "Verbonden met Kad (firewalled)"
 
-#: src/amule.cpp:2675
+#: src/amule.cpp:2667
 msgid "Disconnected from Kad"
 msgstr "Verbinding met Kad verbroken"
 
-#: src/amule.cpp:2707
+#: src/amule.cpp:2699
 msgid "Kad network cannot be used if UDP port is disabled on preferences, not starting."
 msgstr "Kad-netwerk kan niet gebruikt worden als de UDP-poort is uitgeschakeld in voorkeuren, wordt niet gestart."
 
-#: src/amule.cpp:2711
+#: src/amule.cpp:2703
 msgid "Kad network disabled on preferences, not connecting."
 msgstr "Kad-netwerk is uitgeschakeld in voorkeuren, wordt niet mee verbonden."
 
@@ -576,68 +576,30 @@ msgstr "Kan Pid-bestand niet aanmaken"
 msgid "ERROR: %s"
 msgstr "FOUT: %s"
 
-#: src/amuleDlg.cpp:250
+#: src/amuleDlg.cpp:236
 #, c-format
 msgid "This is aMule %s based on eMule."
 msgstr "Dit is aMule %s gebaseerd op eMule."
 
-#: src/amuleDlg.cpp:251
+#: src/amuleDlg.cpp:237
 #, c-format
 msgid "Running on %s"
 msgstr "Draaiend op %s"
 
-#: src/amuleDlg.cpp:253
+#: src/amuleDlg.cpp:239
 msgid "Visit https://github.com/amule-org/amule/releases/latest to check if a new version is available."
 msgstr "Bezoek https://github.com/amule-org/amule/releases/latest om te zien of een nieuwe versie beschikbaar is."
 
-#: src/amuleDlg.cpp:282
+#: src/amuleDlg.cpp:268
 msgid "FATAL ERROR: Failed to create Timer"
 msgstr "FATALE FOUT: Kon Timer niet aanmaken"
 
-#: src/amuleDlg.cpp:361 src/amuleDlg.cpp:1810 src/amuleDlg.cpp:2056
-#: src/muuli_wdr.cpp:1492 src/muuli_wdr.cpp:3439
-msgid "Networks"
-msgstr "Netwerken"
-
-#: src/amuleDlg.cpp:362 src/amuleDlg.cpp:1816 src/muuli_wdr.cpp:3440
-msgid "Searches"
-msgstr "Zoeken"
-
-#: src/amuleDlg.cpp:363 src/amuleDlg.cpp:1822 src/DownloadListCtrl.cpp:740
-#: src/muuli_wdr.cpp:392 src/muuli_wdr.cpp:1585 src/muuli_wdr.cpp:3441
-#: src/Statistics.cpp:829
-msgid "Downloads"
-msgstr "Downloads"
-
-#: src/amuleDlg.cpp:364 src/amuleDlg.cpp:1828 src/muuli_wdr.cpp:3315
-msgid "Shared files"
-msgstr "Gedeelde bestanden"
-
-#: src/amuleDlg.cpp:365 src/amuleDlg.cpp:1834 src/muuli_wdr.cpp:2947
-#: src/muuli_wdr.cpp:3397 src/muuli_wdr.cpp:3444
-msgid "Messages"
-msgstr "Berichten"
-
-#: src/amuleDlg.cpp:366 src/amuleDlg.cpp:1840 src/muuli_wdr.cpp:3445
-#: src/PrefsUnifiedDlg.cpp:314 src/Statistics.cpp:779 src/Statistics.cpp:1235
-msgid "Statistics"
-msgstr "Statistieken"
-
-#: src/amuleDlg.cpp:368 src/amuleDlg.cpp:1847 src/muuli_wdr.cpp:3447
-#: src/PrefsUnifiedDlg.cpp:330 src/utils/wxCas/src/wxcasprefs.cpp:39
-msgid "Preferences"
-msgstr "Voorkeuren"
-
-#: src/amuleDlg.cpp:371
-msgid "Navigate"
-msgstr ""
-
-#: src/amuleDlg.cpp:657
+#: src/amuleDlg.cpp:592
 #, fuzzy
 msgid "New version available"
 msgstr "Niet beschikbaar"
 
-#: src/amuleDlg.cpp:661
+#: src/amuleDlg.cpp:596
 #, fuzzy, c-format
 msgid ""
 "A new version of aMule (%s) is available.\n"
@@ -647,184 +609,217 @@ msgid ""
 "Would you like to open the download page?"
 msgstr "De nieuwste versie kan altijd gevonden worden op https://github.com/amule-org/amule/releases/latest"
 
-#: src/amuleDlg.cpp:743
+#: src/amuleDlg.cpp:678
 msgid "aMule dialog destroyed"
 msgstr "aMule dialoogvenster afgesloten"
 
-#: src/amuleDlg.cpp:766 src/DataToText.cpp:68 src/IPFilter.cpp:547
+#: src/amuleDlg.cpp:701 src/DataToText.cpp:68 src/IPFilter.cpp:547
 msgid "Connecting"
 msgstr "Aan het verbinden"
 
-#: src/amuleDlg.cpp:958
+#: src/amuleDlg.cpp:893
 msgid "eD2k: Connecting"
 msgstr "eD2K: Verbinden"
 
-#: src/amuleDlg.cpp:962
+#: src/amuleDlg.cpp:897
 msgid "eD2k: Disconnected"
 msgstr "eD2K: Verbinding verbroken"
 
-#: src/amuleDlg.cpp:968
+#: src/amuleDlg.cpp:903
 msgid "Kad: Firewalled"
 msgstr "Kad: Firewalled"
 
-#: src/amuleDlg.cpp:972
+#: src/amuleDlg.cpp:907
 msgid "Kad: Connected"
 msgstr "Kad: Verbonden"
 
-#: src/amuleDlg.cpp:977
+#: src/amuleDlg.cpp:912
 msgid "Kad: Connecting"
 msgstr "Kad: Verbinden"
 
-#: src/amuleDlg.cpp:981
+#: src/amuleDlg.cpp:916
 msgid "Kad: Off"
 msgstr "Kad: Uitgeschakeld"
 
-#: src/amuleDlg.cpp:1029 src/DownloadListCtrl.cpp:505
+#: src/amuleDlg.cpp:964 src/DownloadListCtrl.cpp:505
 #: src/DownloadListCtrl.cpp:749 src/FriendListCtrl.cpp:180
 #: src/muuli_wdr.cpp:731 src/muuli_wdr.cpp:782 src/muuli_wdr.cpp:846
-#: src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2252 src/muuli_wdr.cpp:2337
-#: src/muuli_wdr.cpp:3085 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
+#: src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2224 src/muuli_wdr.cpp:2309
+#: src/muuli_wdr.cpp:3057 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
 #: src/ServerListCtrl.cpp:606 src/TransferWnd.cpp:378
 #: src/utils/wxCas/src/wxcasprefs.cpp:235
 msgid "Cancel"
 msgstr "Annuleren"
 
-#: src/amuleDlg.cpp:1030
+#: src/amuleDlg.cpp:965
 msgid "Stop the current connection attempts"
 msgstr "Beëindig de huidige verbindingspogingen"
 
-#: src/amuleDlg.cpp:1035 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976
-#: src/muuli_wdr.cpp:2475
+#: src/amuleDlg.cpp:970 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976
+#: src/muuli_wdr.cpp:2447
 msgid "Disconnect"
 msgstr "Verbreek"
 
-#: src/amuleDlg.cpp:1036
+#: src/amuleDlg.cpp:971
 msgid "Disconnect from the currently connected networks"
 msgstr "Verbreek de huidige verbonden netwerken"
 
-#: src/amuleDlg.cpp:1041 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979
-#: src/muuli_wdr.cpp:2630 src/muuli_wdr.cpp:3082 src/muuli_wdr.cpp:3437
+#: src/amuleDlg.cpp:976 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979
+#: src/muuli_wdr.cpp:2602 src/muuli_wdr.cpp:3054 src/muuli_wdr.cpp:3409
 msgid "Connect"
 msgstr "Verbinden"
 
-#: src/amuleDlg.cpp:1042
+#: src/amuleDlg.cpp:977
 msgid "Connect to the currently enabled networks"
 msgstr "Verbind met de momenteel ingeschakelde netwerken"
 
-#: src/amuleDlg.cpp:1154
+#: src/amuleDlg.cpp:1089
 #, c-format
 msgid "Up: %.1f%s (%.1f) | Down: %.1f%s (%.1f)"
 msgstr "Upload: %.1f%s (%.1f) | Download: %.1f%s (%.1f)"
 
-#: src/amuleDlg.cpp:1156 src/amuleDlg.cpp:1158 src/amuleDlg.cpp:1162
-#: src/amuleDlg.cpp:1164 src/amuleDlg.cpp:1175 src/amuleDlg.cpp:1177
+#: src/amuleDlg.cpp:1091 src/amuleDlg.cpp:1093 src/amuleDlg.cpp:1097
+#: src/amuleDlg.cpp:1099 src/amuleDlg.cpp:1110 src/amuleDlg.cpp:1112
 #: src/MuleTrayIcon.cpp:796 src/MuleTrayIcon.cpp:799
 msgid " MB/s"
 msgstr " MB/s"
 
-#: src/amuleDlg.cpp:1156 src/amuleDlg.cpp:1158 src/amuleDlg.cpp:1162
-#: src/amuleDlg.cpp:1164 src/amuleDlg.cpp:1175 src/amuleDlg.cpp:1177
+#: src/amuleDlg.cpp:1091 src/amuleDlg.cpp:1093 src/amuleDlg.cpp:1097
+#: src/amuleDlg.cpp:1099 src/amuleDlg.cpp:1110 src/amuleDlg.cpp:1112
 #: src/MuleTrayIcon.cpp:796 src/MuleTrayIcon.cpp:799
 #: src/utils/wxCas/src/wxcasframe.cpp:1041
 msgid " kB/s"
 msgstr " kB/s"
 
-#: src/amuleDlg.cpp:1161
+#: src/amuleDlg.cpp:1096
 #, c-format
 msgid "Up: %.1f%s | Down: %.1f%s"
 msgstr "Upload: %.1f%s | Download: %.1f%s"
 
-#: src/amuleDlg.cpp:1193
+#: src/amuleDlg.cpp:1128
 #, c-format
 msgid "aMule (%s | Connected)"
 msgstr "aMule (%s | Verbonden)"
 
-#: src/amuleDlg.cpp:1195
+#: src/amuleDlg.cpp:1130
 #, c-format
 msgid "aMule (%s | Disconnected)"
 msgstr "aMule (%s | Niet verbonden)"
 
-#: src/amuleDlg.cpp:1248
+#: src/amuleDlg.cpp:1183
 #, c-format
 msgid "Do you really want to exit %s?"
 msgstr "Wilt u %s echt afsluiten?"
 
-#: src/amuleDlg.cpp:1250
+#: src/amuleDlg.cpp:1185
 msgid "Exit confirmation"
 msgstr "Bevestig afsluiten"
 
-#: src/amuleDlg.cpp:1613
+#: src/amuleDlg.cpp:1548
 msgid "Launch Command: "
 msgstr "Voer commando uit: "
 
-#: src/amuleDlg.cpp:1632 src/muuli_wdr.cpp:1972 src/Preferences.cpp:979
+#: src/amuleDlg.cpp:1567 src/muuli_wdr.cpp:1971 src/Preferences.cpp:951
 msgid "- default -"
 msgstr "- standaard -"
 
-#: src/amuleDlg.cpp:1660
+#: src/amuleDlg.cpp:1595
 #, c-format
 msgid "Skin directory '%s' does not exist"
 msgstr "Skinmap '%s' bestaat niet"
 
-#: src/amuleDlg.cpp:1663
+#: src/amuleDlg.cpp:1598
 #, c-format
 msgid "WARNING: Unable to open skin file '%s' for read"
 msgstr "WAARSCHUWING: Kon skin-bestand '%s' niet openen om te lezen"
 
-#: src/amuleDlg.cpp:1814 src/muuli_wdr.cpp:3439
+#: src/amuleDlg.cpp:1722 src/amuleDlg.cpp:1968 src/muuli_wdr.cpp:1485
+#: src/muuli_wdr.cpp:3411
+msgid "Networks"
+msgstr "Netwerken"
+
+#: src/amuleDlg.cpp:1726 src/muuli_wdr.cpp:3411
 msgid "Networks Window"
 msgstr "Netwerkvenster"
 
-#: src/amuleDlg.cpp:1820 src/muuli_wdr.cpp:3440
+#: src/amuleDlg.cpp:1728 src/muuli_wdr.cpp:3412
+msgid "Searches"
+msgstr "Zoeken"
+
+#: src/amuleDlg.cpp:1732 src/muuli_wdr.cpp:3412
 msgid "Searches Window"
 msgstr "Zoekvenster"
 
-#: src/amuleDlg.cpp:1826 src/muuli_wdr.cpp:3441
+#: src/amuleDlg.cpp:1734 src/DownloadListCtrl.cpp:740 src/muuli_wdr.cpp:392
+#: src/muuli_wdr.cpp:1578 src/muuli_wdr.cpp:3413 src/Statistics.cpp:829
+msgid "Downloads"
+msgstr "Downloads"
+
+#: src/amuleDlg.cpp:1738 src/muuli_wdr.cpp:3413
 msgid "Downloads Window"
 msgstr "Downloadsvenster"
 
-#: src/amuleDlg.cpp:1832 src/muuli_wdr.cpp:3443
+#: src/amuleDlg.cpp:1740 src/muuli_wdr.cpp:3287
+msgid "Shared files"
+msgstr "Gedeelde bestanden"
+
+#: src/amuleDlg.cpp:1744 src/muuli_wdr.cpp:3415
 msgid "Shared Files Window"
 msgstr "Gedeelde bestanden-venster"
 
-#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3444
+#: src/amuleDlg.cpp:1746 src/muuli_wdr.cpp:2919 src/muuli_wdr.cpp:3369
+#: src/muuli_wdr.cpp:3416
+msgid "Messages"
+msgstr "Berichten"
+
+#: src/amuleDlg.cpp:1750 src/muuli_wdr.cpp:3416
 msgid "Messages Window"
 msgstr "Berichtenvenster"
 
-#: src/amuleDlg.cpp:1844 src/muuli_wdr.cpp:3445
+#: src/amuleDlg.cpp:1752 src/muuli_wdr.cpp:3417 src/PrefsUnifiedDlg.cpp:312
+#: src/Statistics.cpp:779 src/Statistics.cpp:1235
+msgid "Statistics"
+msgstr "Statistieken"
+
+#: src/amuleDlg.cpp:1756 src/muuli_wdr.cpp:3417
 msgid "Statistics Graph Window"
 msgstr "Statistiekenvenster (Grafieken)"
 
-#: src/amuleDlg.cpp:1851 src/muuli_wdr.cpp:3447
+#: src/amuleDlg.cpp:1759 src/muuli_wdr.cpp:3419 src/PrefsUnifiedDlg.cpp:328
+#: src/utils/wxCas/src/wxcasprefs.cpp:39
+msgid "Preferences"
+msgstr "Voorkeuren"
+
+#: src/amuleDlg.cpp:1763 src/muuli_wdr.cpp:3419
 msgid "Preferences Settings Window"
 msgstr "Voorkeureninstellingen-venster"
 
-#: src/amuleDlg.cpp:1854 src/muuli_wdr.cpp:3448
+#: src/amuleDlg.cpp:1766 src/muuli_wdr.cpp:3420
 msgid "Import"
 msgstr "Importeer"
 
-#: src/amuleDlg.cpp:1858 src/muuli_wdr.cpp:3448
+#: src/amuleDlg.cpp:1770 src/muuli_wdr.cpp:3420
 msgid "The partfile importer tool"
 msgstr "Het deelbestand importeerprogramma"
 
-#: src/amuleDlg.cpp:1861 src/muuli_wdr.cpp:3449
+#: src/amuleDlg.cpp:1773 src/muuli_wdr.cpp:3421
 #: src/utils/aLinkCreator/src/alcframe.cpp:262
 msgid "About"
 msgstr "Over"
 
-#: src/amuleDlg.cpp:1861 src/muuli_wdr.cpp:3449
+#: src/amuleDlg.cpp:1773 src/muuli_wdr.cpp:3421
 msgid "About/Help"
 msgstr "Over/Help"
 
-#: src/amuleDlg.cpp:2059
+#: src/amuleDlg.cpp:1971
 msgid "eD2k network"
 msgstr "eD2k-netwerk"
 
-#: src/amuleDlg.cpp:2062
+#: src/amuleDlg.cpp:1974
 msgid "Kad network"
 msgstr "Kad netwerk"
 
-#: src/amuleDlg.cpp:2062
+#: src/amuleDlg.cpp:1974
 msgid "No network"
 msgstr "Geen netwerk"
 
@@ -954,7 +949,7 @@ msgstr "Bestand niet gevonden."
 msgid "The core rejected these shared folders:%s"
 msgstr ""
 
-#: src/amule-remote-gui.cpp:1336 src/ExternalConn.cpp:2346
+#: src/amule-remote-gui.cpp:1336 src/ExternalConn.cpp:2345
 msgid "Invalid link or already on list."
 msgstr "Ongeldige link of al op de lijst."
 
@@ -970,7 +965,7 @@ msgstr "Kan map '%s' niet aanmaken voor categorie '%s', map '%s' wordt behouden.
 #: src/ClientDetailDialog.cpp:123 src/DataToText.cpp:61 src/DataToText.cpp:86
 #: src/DataToText.cpp:101 src/DataToText.cpp:136 src/DataToText.cpp:165
 #: src/DownloadListCtrl.cpp:1172 src/DownloadListCtrl.cpp:1185
-#: src/DownloadListCtrl.cpp:1196 src/ExternalConn.cpp:609
+#: src/DownloadListCtrl.cpp:1196 src/ExternalConn.cpp:608
 #: src/FileDetailDialog.cpp:203 src/FileDetailDialog.cpp:235
 #: src/FileDetailDialog.cpp:242 src/GenericClientListCtrl.cpp:1171
 #: src/GenericClientListCtrl.cpp:1182 src/GenericClientListCtrl.cpp:1192
@@ -1357,19 +1352,19 @@ msgstr "Auto [Ho]"
 msgid "Very low"
 msgstr "Heel laag"
 
-#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:743 src/muuli_wdr.cpp:2303
+#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:743 src/muuli_wdr.cpp:2275
 #: src/ServerListCtrl.cpp:263 src/ServerListCtrl.cpp:456
 #: src/SharedFilesCtrl.cpp:145
 msgid "Low"
 msgstr "Laag"
 
-#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:744 src/muuli_wdr.cpp:2304
+#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:744 src/muuli_wdr.cpp:2276
 #: src/ServerListCtrl.cpp:266 src/ServerListCtrl.cpp:457
 #: src/SharedFilesCtrl.cpp:146
 msgid "Normal"
 msgstr "Normaal"
 
-#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:745 src/muuli_wdr.cpp:2305
+#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:745 src/muuli_wdr.cpp:2277
 #: src/ServerListCtrl.cpp:269 src/ServerListCtrl.cpp:458
 #: src/SharedFilesCtrl.cpp:147
 msgid "High"
@@ -1461,8 +1456,8 @@ msgstr "Lokale server"
 msgid "Remote Server"
 msgstr "Server op Afstand"
 
-#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3202
-#: src/SearchDlg.cpp:119 src/TextClient.cpp:911
+#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3174
+#: src/SearchDlg.cpp:111 src/TextClient.cpp:911
 msgid "Kad"
 msgstr "Kad"
 
@@ -1533,7 +1528,7 @@ msgstr "Deel"
 msgid "Size"
 msgstr "Grootte"
 
-#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3269
+#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3241
 msgid "Transferred"
 msgstr "Overgebracht"
 
@@ -1591,7 +1586,7 @@ msgstr ""
 "Feedback van: %s (%s)\n"
 "\n"
 
-#: src/DownloadListCtrl.cpp:746 src/muuli_wdr.cpp:2306
+#: src/DownloadListCtrl.cpp:746 src/muuli_wdr.cpp:2278
 #: src/SharedFilesCtrl.cpp:150
 msgid "Auto"
 msgstr "Auto"
@@ -1629,7 +1624,7 @@ msgid "Extended Options"
 msgstr "Uitgebreide opties"
 
 #: src/DownloadListCtrl.cpp:770 src/DownloadListCtrl.cpp:822
-#: src/muuli_wdr.cpp:1790
+#: src/muuli_wdr.cpp:1789
 msgid "Preview"
 msgstr "Voorbeeld"
 
@@ -1805,232 +1800,227 @@ msgstr[1] ""
 msgid "Invalid eD2k link! ERROR: %s"
 msgstr "Ongeldige eD2k-link! FOUT: %s"
 
-#: src/ExternalConn.cpp:380
+#: src/ExternalConn.cpp:379
 msgid "Client sent packet after authentication failed."
 msgstr "Client verstuurde pakket nadat authenticatie mislukte."
 
-#: src/ExternalConn.cpp:397
+#: src/ExternalConn.cpp:396
 msgid "External connection closed."
 msgstr "Externe verbinding gesloten."
 
-#: src/ExternalConn.cpp:474
+#: src/ExternalConn.cpp:473
 msgid "External connections disabled due to empty password!"
 msgstr "Externe verbindingen uitgeschakeld vanwege leeg wachtwoord!"
 
-#: src/ExternalConn.cpp:495
+#: src/ExternalConn.cpp:494
 msgid "External connections disabled in config file"
 msgstr "Externe verbindingen uitgeschakeld in configuratiebestand"
 
-#: src/ExternalConn.cpp:576
+#: src/ExternalConn.cpp:575
 msgid "New external connection accepted"
 msgstr "Nieuwe externe verbinding geaccepteerd"
 
-#: src/ExternalConn.cpp:579
+#: src/ExternalConn.cpp:578
 msgid "ERROR: couldn't accept a new external connection"
 msgstr "FOUT: kon nieuwe externe verbinding niet accepteren"
 
-#: src/ExternalConn.cpp:596
+#: src/ExternalConn.cpp:595
 msgid "External connection refused due to empty password in preferences!"
 msgstr "Externe verbinding geweigerd vanwege leeg wachtwoord bij voorkeuren!"
 
-#: src/ExternalConn.cpp:608
+#: src/ExternalConn.cpp:607
 #, c-format
 msgid "Connecting client: %s %s"
 msgstr "Client verbinden: %s %s"
 
-#: src/ExternalConn.cpp:610
+#: src/ExternalConn.cpp:609
 msgid "Unknown version"
 msgstr "Onbekende versie"
 
-#: src/ExternalConn.cpp:623
+#: src/ExternalConn.cpp:622
 msgid "Incorrect EC version ID, there might be binary incompatibility. Use core and remote from same snapshot."
 msgstr "Incorrecte EV-versie ID, mogelijk niet compatible. Gebruik kern en op afstand van dezelfde snapshot."
 
-#: src/ExternalConn.cpp:631
+#: src/ExternalConn.cpp:630
 msgid "You cannot connect to a release version from an arbitrary development snapshot! *sigh* possible crash prevented"
 msgstr "U kunt niet verbinden met een release-versie vanaf een willekeurig ontwikkelingssnapshot! *zucht* mogelijke crash voorkomen"
 
-#: src/ExternalConn.cpp:714
+#: src/ExternalConn.cpp:713
 msgid "Invalid protocol version."
 msgstr "Ongeldige protocolversie."
 
-#: src/ExternalConn.cpp:720
+#: src/ExternalConn.cpp:719
 msgid "Missing protocol version tag."
 msgstr "Ontbrekend label van protocolversie."
 
-#: src/ExternalConn.cpp:728
+#: src/ExternalConn.cpp:727
 msgid "Authentication failed: invalid hash specified as EC password."
 msgstr "Authenticatie mislukt: ongeldige hash opgegeven als EV-wachtwoord."
 
-#: src/ExternalConn.cpp:776
+#: src/ExternalConn.cpp:775
 msgid "Authentication failed: wrong password."
 msgstr "Authenticatie mislukt: verkeerd wachtwoord."
 
-#: src/ExternalConn.cpp:778
+#: src/ExternalConn.cpp:777
 msgid "Authentication failed: missing password."
 msgstr "Authenticatie mislukt: ontbrekend wachtwoord."
 
-#: src/ExternalConn.cpp:789
+#: src/ExternalConn.cpp:788
 msgid "Invalid request, please authenticate first."
 msgstr "Ongeldig verzoek, authenticeer eerst."
 
-#: src/ExternalConn.cpp:794
+#: src/ExternalConn.cpp:793
 msgid "Access granted."
 msgstr "Toegang verleend."
 
-#: src/ExternalConn.cpp:802
+#: src/ExternalConn.cpp:801
 #, c-format
 msgid "Sent error message \"%s\" to client."
 msgstr "Foutmelding \"%s\" verzonden naar client."
 
-#: src/ExternalConn.cpp:807
+#: src/ExternalConn.cpp:806
 #, c-format
 msgid "Unauthorized access attempt from %s. Connection closed."
 msgstr "Poging tot ongeautoriseerde toegang van %s. Verbinding gesloten."
 
-#: src/ExternalConn.cpp:1420
+#: src/ExternalConn.cpp:1419
 #, c-format
 msgid "Remote PartFile command failed: FileHash not found: %s"
 msgstr "Deelbestand-commando op afstand mislukt: Bestands-hash niet gevonden: %s"
 
-#: src/ExternalConn.cpp:1424
+#: src/ExternalConn.cpp:1423
 #, c-format
 msgid "FileHash not found: %s"
 msgstr "Bestandshash niet gevonden: %s"
 
-#: src/ExternalConn.cpp:1471 src/ExternalConn.cpp:1559
-#: src/ExternalConn.cpp:1680
+#: src/ExternalConn.cpp:1470 src/ExternalConn.cpp:1558
+#: src/ExternalConn.cpp:1679
 msgid "OOPS! OpCode processing error!"
 msgstr "OEPS! OpCode verwerkingsfout!"
 
-#: src/ExternalConn.cpp:1502
+#: src/ExternalConn.cpp:1501
 msgid "Server not added"
 msgstr "Server niet toegevoegd"
 
-#: src/ExternalConn.cpp:1521
+#: src/ExternalConn.cpp:1520
 #, c-format
 msgid "server not found: %s"
 msgstr "server niet gevonden: %s"
 
-#: src/ExternalConn.cpp:1538
+#: src/ExternalConn.cpp:1537
 msgid "need to define server to be removed"
 msgstr "moet de te verwijderen server opgeven"
 
-#: src/ExternalConn.cpp:1553
+#: src/ExternalConn.cpp:1552
 msgid "eD2k is disabled in preferences."
 msgstr "eD2K is uitgeschakeld in voorkeuren."
 
-#: src/ExternalConn.cpp:1658
+#: src/ExternalConn.cpp:1657
 #, fuzzy
 msgid "Friend not found."
 msgstr "Bestand niet gevonden."
 
-#: src/ExternalConn.cpp:1668
+#: src/ExternalConn.cpp:1667
 #, fuzzy
 msgid "Client not found."
 msgstr "Bestand niet gevonden."
 
-#: src/ExternalConn.cpp:1674
+#: src/ExternalConn.cpp:1673
 msgid "EC_TAG_FRIEND_SHARED requires EC_TAG_FRIEND or EC_TAG_CLIENT."
 msgstr ""
 
-#: src/ExternalConn.cpp:1992
+#: src/ExternalConn.cpp:1991
 msgid "WebSearch from remote interface makes no sense."
 msgstr "WebSearch vanaf afstand is zinloos."
 
-#: src/ExternalConn.cpp:2027
+#: src/ExternalConn.cpp:2026
 msgid "Search in progress. Refetch results in a moment!"
 msgstr "Bezig met zoeken. Haal de resultaten op over een momentje!"
 
-#: src/ExternalConn.cpp:2266
+#: src/ExternalConn.cpp:2265
 msgid "No points for graph."
 msgstr "Geen punten voor grafiek."
 
-#: src/ExternalConn.cpp:2276
+#: src/ExternalConn.cpp:2275
 msgid "Your client is not configured for this detail level."
 msgstr "Uw client is niet geconfigureerd voor dit niveau van details."
 
-#: src/ExternalConn.cpp:2303
+#: src/ExternalConn.cpp:2302
 msgid "External Connection: shutdown requested"
 msgstr "Externe verbinding: afsluiten aangevraagd"
 
-#: src/ExternalConn.cpp:2315
+#: src/ExternalConn.cpp:2314
 msgid "Already shutting down."
 msgstr "Al bezig met afsluiten."
 
-#: src/ExternalConn.cpp:2333
+#: src/ExternalConn.cpp:2332
 #, c-format
 msgid "ExternalConn: adding link '%s'."
 msgstr "ExterneVerb: link '%s' wordt toegevoegd."
 
-#: src/ExternalConn.cpp:2351
+#: src/ExternalConn.cpp:2350
 #, fuzzy, c-format
 msgid "%d of %d links failed (invalid or already on list)."
 msgstr "Ongeldige link of al op de lijst."
 
-#: src/ExternalConn.cpp:2374
+#: src/ExternalConn.cpp:2373
 msgid "Version check throttled; try again shortly."
 msgstr ""
 
-#: src/ExternalConn.cpp:2379
+#: src/ExternalConn.cpp:2378
 msgid "Version check is not available on this daemon."
 msgstr ""
 
-#: src/ExternalConn.cpp:2509
+#: src/ExternalConn.cpp:2508
 msgid "File not found."
 msgstr "Bestand niet gevonden."
 
-#: src/ExternalConn.cpp:2514
+#: src/ExternalConn.cpp:2513
 msgid "Invalid file name."
 msgstr "Ongeldige bestandsnaam."
 
-#: src/ExternalConn.cpp:2522
+#: src/ExternalConn.cpp:2521
 msgid "Unable to rename file."
 msgstr "Kon naam van bestand niet wijzigen."
 
-#: src/ExternalConn.cpp:2839
-#, c-format
-msgid "Could not save the amuleapi password: %s"
-msgstr ""
-
-#: src/ExternalConn.cpp:3004 src/ExternalConn.cpp:3032
+#: src/ExternalConn.cpp:2992 src/ExternalConn.cpp:3020
 msgid "Kad is disabled in preferences."
 msgstr "Kad is uitgeschakeld in voorkeuren."
 
-#: src/ExternalConn.cpp:3045
+#: src/ExternalConn.cpp:3033
 msgid "Already connected to eD2k."
 msgstr "Al verbonden met eD2K."
 
-#: src/ExternalConn.cpp:3048
+#: src/ExternalConn.cpp:3036
 msgid "Connecting to eD2k..."
 msgstr "Aan het verbinden met eD2k..."
 
-#: src/ExternalConn.cpp:3057
+#: src/ExternalConn.cpp:3045
 msgid "Already connected to Kad."
 msgstr "Al verbonden met Kad."
 
-#: src/ExternalConn.cpp:3060
+#: src/ExternalConn.cpp:3048
 msgid "Connecting to Kad..."
 msgstr "Verbinding met Kad wordt gemaakt..."
 
-#: src/ExternalConn.cpp:3067
+#: src/ExternalConn.cpp:3055
 msgid "All networks are disabled."
 msgstr "Alle netwerken zijn uitgeschakeld."
 
-#: src/ExternalConn.cpp:3076
+#: src/ExternalConn.cpp:3064
 msgid "Disconnected from eD2k."
 msgstr "Verbinding met eD2K verbroken."
 
-#: src/ExternalConn.cpp:3081
+#: src/ExternalConn.cpp:3069
 msgid "Disconnected from Kad."
 msgstr "Verbinding met Kad verbroken."
 
-#: src/ExternalConn.cpp:3090
+#: src/ExternalConn.cpp:3078
 #, c-format
 msgid "External Connection: invalid opcode received: %#x"
 msgstr "Externe verbinding: ongeldige opcode ontvangen: %#x"
 
-#: src/ExternalConn.cpp:3095
+#: src/ExternalConn.cpp:3083
 msgid "Invalid opcode (wrong protocol version?)"
 msgstr "Ongeldige opcode (verkeerde protocolversie?)"
 
@@ -2347,19 +2337,19 @@ msgstr ""
 msgid "eD2k"
 msgstr "eD2k"
 
-#: src/FirstRunWizard.cpp:349 src/muuli_wdr.cpp:1495
+#: src/FirstRunWizard.cpp:349 src/muuli_wdr.cpp:1488
 msgid "Kademlia"
 msgstr "Kademlia"
 
-#: src/FirstRunWizard.cpp:359 src/muuli_wdr.cpp:1423
+#: src/FirstRunWizard.cpp:359 src/muuli_wdr.cpp:1416
 msgid "Standard TCP Port "
 msgstr "Standaard TCP-poort "
 
-#: src/FirstRunWizard.cpp:365 src/muuli_wdr.cpp:1435
+#: src/FirstRunWizard.cpp:365 src/muuli_wdr.cpp:1428
 msgid "Extended UDP port (Kad / global search) "
 msgstr "Uitgebreide UDP-poort (Kad / globaal zoeken) "
 
-#: src/FirstRunWizard.cpp:377 src/muuli_wdr.cpp:1442
+#: src/FirstRunWizard.cpp:377 src/muuli_wdr.cpp:1435
 msgid "Enable UPnP for router port forwarding"
 msgstr "Schakel UPnP voor router portforwarding in"
 
@@ -2386,7 +2376,7 @@ msgstr ""
 msgid "Your peer lists are already in place - nothing to download."
 msgstr "U probeert het bestand %s al te downloaden"
 
-#: src/FirstRunWizard.cpp:434 src/muuli_wdr.cpp:1540
+#: src/FirstRunWizard.cpp:434 src/muuli_wdr.cpp:1533
 msgid "Auto-update server list at startup"
 msgstr "Auto-update serverlijst bij het opstarten"
 
@@ -2432,23 +2422,23 @@ msgid ""
 "want downloads on a different (e.g. larger) disk."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:549 src/FirstRunWizard.cpp:611 src/muuli_wdr.cpp:1702
+#: src/FirstRunWizard.cpp:549 src/FirstRunWizard.cpp:611 src/muuli_wdr.cpp:1701
 msgid "Destination folder for downloads"
 msgstr "Doelmap voor downloads"
 
-#: src/FirstRunWizard.cpp:553 src/FirstRunWizard.cpp:569 src/muuli_wdr.cpp:1349
-#: src/muuli_wdr.cpp:1366 src/muuli_wdr.cpp:1677 src/muuli_wdr.cpp:1708
-#: src/muuli_wdr.cpp:1720 src/muuli_wdr.cpp:2790
+#: src/FirstRunWizard.cpp:553 src/FirstRunWizard.cpp:569 src/muuli_wdr.cpp:1342
+#: src/muuli_wdr.cpp:1359 src/muuli_wdr.cpp:1676 src/muuli_wdr.cpp:1707
+#: src/muuli_wdr.cpp:1719 src/muuli_wdr.cpp:2762
 #: src/utils/aLinkCreator/src/alcframe.cpp:135
 #: src/utils/wxCas/src/wxcasprefs.cpp:52 src/utils/wxCas/src/wxcasprefs.cpp:118
 msgid "Browse"
 msgstr "Bladeren"
 
-#: src/FirstRunWizard.cpp:559 src/muuli_wdr.cpp:1713
+#: src/FirstRunWizard.cpp:559 src/muuli_wdr.cpp:1712
 msgid "(All files in this folder are shared with other peers)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:565 src/FirstRunWizard.cpp:624 src/muuli_wdr.cpp:1715
+#: src/FirstRunWizard.cpp:565 src/FirstRunWizard.cpp:624 src/muuli_wdr.cpp:1714
 msgid "Folder for temporary download files"
 msgstr "Map voor tijdelijke downloadbestanden"
 
@@ -2479,7 +2469,7 @@ msgstr "Kon niet schrijven naar vriendenlijst-bestand 'emfriends.met'!"
 msgid "CRITICAL - no client on StartChatSession"
 msgstr "KRITIEK - geen client bij StartChatSession"
 
-#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2696 src/muuli_wdr.cpp:3373
+#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2668 src/muuli_wdr.cpp:3345
 msgid "Friends"
 msgstr "Vrienden"
 
@@ -2590,8 +2580,8 @@ msgstr "Geen"
 msgid "No"
 msgstr "Nee"
 
-#: src/GenericClientListCtrl.cpp:1216 src/PrefsUnifiedDlg.cpp:2898
-#: src/PrefsUnifiedDlg.cpp:2948 src/ServerListCtrl.cpp:276
+#: src/GenericClientListCtrl.cpp:1216 src/PrefsUnifiedDlg.cpp:2818
+#: src/PrefsUnifiedDlg.cpp:2868 src/ServerListCtrl.cpp:276
 msgid "Yes"
 msgstr "Ja"
 
@@ -2760,10 +2750,10 @@ msgstr "Ongeldige poort om van te bootstrappen"
 msgid "Please fill all fields required"
 msgstr "Vul alle benodigde velden in"
 
-#: src/KadDlg.cpp:192 src/PartFile.cpp:1031 src/PrefsUnifiedDlg.cpp:1134
-#: src/PrefsUnifiedDlg.cpp:1204 src/PrefsUnifiedDlg.cpp:1405
-#: src/PrefsUnifiedDlg.cpp:1663 src/PrefsUnifiedDlg.cpp:1673
-#: src/PrefsUnifiedDlg.cpp:1690 src/PrefsUnifiedDlg.cpp:1738
+#: src/KadDlg.cpp:192 src/PartFile.cpp:1031 src/PrefsUnifiedDlg.cpp:1162
+#: src/PrefsUnifiedDlg.cpp:1331 src/PrefsUnifiedDlg.cpp:1589
+#: src/PrefsUnifiedDlg.cpp:1599 src/PrefsUnifiedDlg.cpp:1616
+#: src/PrefsUnifiedDlg.cpp:1658
 msgid "Message"
 msgstr "Bericht"
 
@@ -2865,7 +2855,7 @@ msgstr "Deelverhouding"
 msgid "Uploaded"
 msgstr "Geüpload"
 
-#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3253
+#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3225
 msgid "Requested"
 msgstr "Aangevraagd"
 
@@ -2989,7 +2979,7 @@ msgid "WARNING: "
 msgstr "WAARSCHUWING: "
 
 #: src/MuleNotebook.cpp:179 src/muuli_wdr.cpp:817 src/muuli_wdr.cpp:1229
-#: src/muuli_wdr.cpp:3157 src/muuli_wdr.cpp:3413
+#: src/muuli_wdr.cpp:3129 src/muuli_wdr.cpp:3385
 msgid "Close"
 msgstr "Sluiten"
 
@@ -3002,12 +2992,12 @@ msgstr "Knippen"
 msgid "Copy"
 msgstr "Kopiëren"
 
-#: src/MuleTextCtrl.cpp:88 src/SearchDlg.cpp:261
+#: src/MuleTextCtrl.cpp:88
 msgid "Paste"
 msgstr "Plakken"
 
 #: src/MuleTextCtrl.cpp:89 src/muuli_wdr.cpp:358 src/muuli_wdr.cpp:757
-#: src/muuli_wdr.cpp:2380 src/muuli_wdr.cpp:2399 src/muuli_wdr.cpp:2421
+#: src/muuli_wdr.cpp:2352 src/muuli_wdr.cpp:2371 src/muuli_wdr.cpp:2393
 #: src/utils/aLinkCreator/src/alcframe.cpp:142
 msgid "Clear"
 msgstr "Wissen"
@@ -3105,8 +3095,8 @@ msgid "Exit"
 msgstr "Afsluiten"
 
 #: src/MuleTrayIcon.cpp:579 src/MuleTrayIcon.cpp:945 src/MuleTrayIcon.cpp:965
-#: src/muuli_wdr.cpp:1398 src/muuli_wdr.cpp:1406 src/muuli_wdr.cpp:1413
-#: src/muuli_wdr.cpp:1836 src/muuli_wdr.cpp:1842 src/OtherFunctions.cpp:91
+#: src/muuli_wdr.cpp:1391 src/muuli_wdr.cpp:1399 src/muuli_wdr.cpp:1406
+#: src/muuli_wdr.cpp:1835 src/muuli_wdr.cpp:1841 src/OtherFunctions.cpp:91
 #: src/StatisticsDlg.cpp:93 src/StatisticsDlg.cpp:95
 msgid "kB/s"
 msgstr "kB/s"
@@ -3278,7 +3268,7 @@ msgstr "Naam:"
 msgid "Type"
 msgstr "Type"
 
-#: src/muuli_wdr.cpp:215 src/SearchDlg.cpp:118 src/SearchListCtrl.cpp:853
+#: src/muuli_wdr.cpp:215 src/SearchDlg.cpp:110 src/SearchListCtrl.cpp:853
 msgid "Local"
 msgstr "Lokaal"
 
@@ -3349,7 +3339,7 @@ msgstr "Bytes"
 msgid "KB"
 msgstr "KB"
 
-#: src/muuli_wdr.cpp:274 src/muuli_wdr.cpp:293 src/muuli_wdr.cpp:1621
+#: src/muuli_wdr.cpp:274 src/muuli_wdr.cpp:293 src/muuli_wdr.cpp:1620
 #: src/OtherFunctions.cpp:64
 msgid "MB"
 msgstr "MB"
@@ -3366,7 +3356,7 @@ msgstr "Max grootte"
 msgid "Availability"
 msgstr "Beschikbaarheid"
 
-#: src/muuli_wdr.cpp:312 src/muuli_wdr.cpp:398 src/muuli_wdr.cpp:3318
+#: src/muuli_wdr.cpp:312 src/muuli_wdr.cpp:398 src/muuli_wdr.cpp:3290
 msgid "Filter:"
 msgstr "Filter:"
 
@@ -3398,7 +3388,7 @@ msgstr ""
 msgid "Stop"
 msgstr "Stop"
 
-#: src/muuli_wdr.cpp:348 src/muuli_wdr.cpp:1392 src/SearchListCtrl.cpp:732
+#: src/muuli_wdr.cpp:348 src/muuli_wdr.cpp:1385 src/SearchListCtrl.cpp:732
 msgid "Download"
 msgstr "Download"
 
@@ -3429,12 +3419,12 @@ msgstr "Bestandsbronnen:"
 #: src/muuli_wdr.cpp:1160 src/muuli_wdr.cpp:1167 src/muuli_wdr.cpp:1172
 #: src/muuli_wdr.cpp:1179 src/muuli_wdr.cpp:1184 src/muuli_wdr.cpp:1191
 #: src/muuli_wdr.cpp:1205 src/muuli_wdr.cpp:1212 src/muuli_wdr.cpp:1217
-#: src/muuli_wdr.cpp:1224 src/muuli_wdr.cpp:3255 src/muuli_wdr.cpp:3263
-#: src/muuli_wdr.cpp:3271
+#: src/muuli_wdr.cpp:1224 src/muuli_wdr.cpp:3227 src/muuli_wdr.cpp:3235
+#: src/muuli_wdr.cpp:3243
 msgid "N/A"
 msgstr "N/B"
 
-#: src/muuli_wdr.cpp:508 src/muuli_wdr.cpp:1065 src/PrefsUnifiedDlg.cpp:299
+#: src/muuli_wdr.cpp:508 src/muuli_wdr.cpp:1065 src/PrefsUnifiedDlg.cpp:297
 msgid "General"
 msgstr "Algemeen"
 
@@ -3575,7 +3565,7 @@ msgstr ""
 msgid "Album :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:685 src/muuli_wdr.cpp:2275
+#: src/muuli_wdr.cpp:685 src/muuli_wdr.cpp:2247
 msgid "Title :"
 msgstr "Titel :"
 
@@ -3684,7 +3674,7 @@ msgstr "Gebruikersnaam :"
 msgid "Userhash :"
 msgstr "Gebruikershash :"
 
-#: src/muuli_wdr.cpp:895 src/muuli_wdr.cpp:1742 src/muuli_wdr.cpp:2470
+#: src/muuli_wdr.cpp:895 src/muuli_wdr.cpp:1741 src/muuli_wdr.cpp:2442
 #: src/utils/aLinkCreator/src/alcframe.cpp:137
 msgid "Add"
 msgstr "Toevoegen"
@@ -3693,15 +3683,15 @@ msgstr "Toevoegen"
 msgid "Download-Speed"
 msgstr "Downloadsnelheid"
 
-#: src/muuli_wdr.cpp:954 src/muuli_wdr.cpp:989 src/muuli_wdr.cpp:2574
+#: src/muuli_wdr.cpp:954 src/muuli_wdr.cpp:989 src/muuli_wdr.cpp:2546
 msgid "Current"
 msgstr "Huidige"
 
-#: src/muuli_wdr.cpp:962 src/muuli_wdr.cpp:997 src/muuli_wdr.cpp:2582
+#: src/muuli_wdr.cpp:962 src/muuli_wdr.cpp:997 src/muuli_wdr.cpp:2554
 msgid "Running average"
 msgstr "Lopende gemiddelde"
 
-#: src/muuli_wdr.cpp:970 src/muuli_wdr.cpp:1005 src/muuli_wdr.cpp:2590
+#: src/muuli_wdr.cpp:970 src/muuli_wdr.cpp:1005 src/muuli_wdr.cpp:2562
 msgid "Session average"
 msgstr "Sessie gemiddelde"
 
@@ -3713,7 +3703,7 @@ msgstr "Uploadsnelheid"
 msgid "Connections"
 msgstr "Verbindingen"
 
-#: src/muuli_wdr.cpp:1024 src/muuli_wdr.cpp:1861
+#: src/muuli_wdr.cpp:1024 src/muuli_wdr.cpp:1860
 msgid "Active downloads"
 msgstr "Actieve downloads"
 
@@ -3721,7 +3711,7 @@ msgstr "Actieve downloads"
 msgid "Active connections (1:1)"
 msgstr "Actieve verbinding (1:1)"
 
-#: src/muuli_wdr.cpp:1040 src/muuli_wdr.cpp:1862
+#: src/muuli_wdr.cpp:1040 src/muuli_wdr.cpp:1861
 msgid "Active uploads"
 msgstr "Actieve uploads"
 
@@ -3837,8 +3827,8 @@ msgstr "Dit is de naam die andere gebruikers zien wanneer ze met u verbinden."
 msgid "Language: "
 msgstr "Taal: "
 
-#: src/muuli_wdr.cpp:1257 src/muuli_wdr.cpp:1330 src/muuli_wdr.cpp:1334
-#: src/muuli_wdr.cpp:1337
+#: src/muuli_wdr.cpp:1257 src/muuli_wdr.cpp:1323 src/muuli_wdr.cpp:1327
+#: src/muuli_wdr.cpp:1330
 msgid "The delay before showing tool-tips."
 msgstr "De vertraging voordat tooltips worden getoond."
 
@@ -3916,960 +3906,936 @@ msgstr "Toon een melding wanneer een download klaar is"
 msgid "Enabling this will make aMule to show notifications when finished downloading."
 msgstr "Wanneer dit ingeschakeld is zal aMule een melding tonen wanneer een download klaar is."
 
-#: src/muuli_wdr.cpp:1323
-#, fuzzy
-msgid "Remember search history"
-msgstr "Onthoud deze instellingen"
-
-#: src/muuli_wdr.cpp:1324
-msgid "Keeps a dropdown list of your past search terms in the Search tab's Name field. This remembers the queries you typed, not the results they returned."
-msgstr ""
-
-#: src/muuli_wdr.cpp:1329
+#: src/muuli_wdr.cpp:1322
 msgid "Tooltip delay time: "
 msgstr "Tooltip vertragingstijd: "
 
-#: src/muuli_wdr.cpp:1336
+#: src/muuli_wdr.cpp:1329
 msgid "seconds"
 msgstr "seconden"
 
-#: src/muuli_wdr.cpp:1340
+#: src/muuli_wdr.cpp:1333
 msgid "Browser Selection"
 msgstr "Browserselectie"
 
-#: src/muuli_wdr.cpp:1346
+#: src/muuli_wdr.cpp:1339
 msgid "Enter your browser name here. Leave this field empty to use the system default browser."
 msgstr "Voer hier uw browsernaam in. Laat dit veld leeg om de standaardbrowser van uw systeem te gebruiken."
 
-#: src/muuli_wdr.cpp:1353
+#: src/muuli_wdr.cpp:1346
 msgid "Open in new tab if possible"
 msgstr "Open in nieuw tabblad indien mogelijk"
 
-#: src/muuli_wdr.cpp:1355
+#: src/muuli_wdr.cpp:1348
 msgid "Open the web page in a new tab instead of in a new window when possible"
 msgstr "Open de webpagina, indien mogelijk, in een nieuw tabblad in plaats van in een nieuw venster"
 
-#: src/muuli_wdr.cpp:1359
+#: src/muuli_wdr.cpp:1352
 msgid "Video Player"
 msgstr "Videospeler"
 
-#: src/muuli_wdr.cpp:1386
+#: src/muuli_wdr.cpp:1379
 msgid "Bandwidth limits"
 msgstr "Bandbreedtegrenzen"
 
-#: src/muuli_wdr.cpp:1400
+#: src/muuli_wdr.cpp:1393
 msgid "Upload"
 msgstr "Upload"
 
-#: src/muuli_wdr.cpp:1408
+#: src/muuli_wdr.cpp:1401
 msgid "Slot Allocation"
 msgstr "Slot-toewijzing"
 
-#: src/muuli_wdr.cpp:1417
+#: src/muuli_wdr.cpp:1410
 msgid "Ports"
 msgstr "Poorten"
 
-#: src/muuli_wdr.cpp:1427
+#: src/muuli_wdr.cpp:1420
 msgid "This is the standard eD2k port and cannot be disabled."
 msgstr "Dit is de standaard eD2k-poort en kan niet uitgeschakeld worden."
 
-#: src/muuli_wdr.cpp:1430
+#: src/muuli_wdr.cpp:1423
 msgid "UDP port for server requests (TCP+3):"
 msgstr "UDP-poort voor server aanvragen (TCP+3):"
 
-#: src/muuli_wdr.cpp:1432
+#: src/muuli_wdr.cpp:1425
 msgid "4665"
 msgstr "4665"
 
-#: src/muuli_wdr.cpp:1439
+#: src/muuli_wdr.cpp:1432
 msgid "This UDP port is used for extended eD2k requests and Kad network"
 msgstr "Deze UDP-poort wordt gebruikt voor uitgebreide eD2k-aanvragen en het Kad-netwerk"
 
-#: src/muuli_wdr.cpp:1446
+#: src/muuli_wdr.cpp:1439
 msgid "UPnP TCP Port (Optional):"
 msgstr "UPnP TCP-Poort (optioneel):"
 
-#: src/muuli_wdr.cpp:1456
+#: src/muuli_wdr.cpp:1449
 msgid "Bind local address to IP (empty for any):"
 msgstr "Bind lokaal adres aan IP (laat leeg voor elk):"
 
-#: src/muuli_wdr.cpp:1459
+#: src/muuli_wdr.cpp:1452
 msgid "Advanced users only: If you have multiple network interfaces, enter the address of the interface to which aMule should be bound."
 msgstr "Enkel voor gevorderde gebruikers: Als u meerdere netwerk-interfaces hebt, voer hier het adres in van de interface waar aMule mee verbonden moet worden."
 
-#: src/muuli_wdr.cpp:1462 src/muuli_wdr.cpp:2055
+#: src/muuli_wdr.cpp:1455 src/muuli_wdr.cpp:2054
 #, fuzzy
 msgid "Bind to network interface (empty for any):"
 msgstr "Bind lokaal adres aan IP (laat leeg voor elk):"
 
-#: src/muuli_wdr.cpp:1475
+#: src/muuli_wdr.cpp:1468
 msgid "Advanced users only: pin all of aMule's traffic to one network interface, chosen from the list or typed in by name (e.g. tun0, eth0, en0) or index. Unlike binding to an IP, this stops traffic leaking out via the default route - useful with a VPN. Requires no elevated privileges."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1481
+#: src/muuli_wdr.cpp:1474
 msgid "Max sources per downloading file:"
 msgstr "Max bronnen per bestand aan het downloaden:"
 
-#: src/muuli_wdr.cpp:1485
+#: src/muuli_wdr.cpp:1478
 msgid "Max simultaneous connections:"
 msgstr "Max gelijktijdige verbindingen:"
 
-#: src/muuli_wdr.cpp:1498 src/muuli_wdr.cpp:3197
+#: src/muuli_wdr.cpp:1491 src/muuli_wdr.cpp:3169
 msgid "ED2K"
 msgstr "ED2K"
 
-#: src/muuli_wdr.cpp:1505
+#: src/muuli_wdr.cpp:1498
 msgid "Autoconnect on startup"
 msgstr "Autoverbind bij het opstarten"
 
-#: src/muuli_wdr.cpp:1508
+#: src/muuli_wdr.cpp:1501
 msgid "Reconnect on loss"
 msgstr "Verbind opnieuw bij verbroken verbinding"
 
-#: src/muuli_wdr.cpp:1530
+#: src/muuli_wdr.cpp:1523
 msgid "Remove dead server after"
 msgstr "Verwijder dode server na"
 
-#: src/muuli_wdr.cpp:1531
+#: src/muuli_wdr.cpp:1524
 msgid "Static servers are never removed, even when unreachable."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1535
+#: src/muuli_wdr.cpp:1528
 msgid "retries"
 msgstr "pogingen"
 
-#: src/muuli_wdr.cpp:1543
+#: src/muuli_wdr.cpp:1536
 msgid "List"
 msgstr "Lijst"
 
-#: src/muuli_wdr.cpp:1546
+#: src/muuli_wdr.cpp:1539
 msgid "Update server list when connecting to a server"
 msgstr "Update serverlijst bij het verbinden met een server"
 
-#: src/muuli_wdr.cpp:1549
+#: src/muuli_wdr.cpp:1542
 msgid "Update server list when a client connects"
 msgstr "Update serverlijst wanneer een client verbindt"
 
-#: src/muuli_wdr.cpp:1552
+#: src/muuli_wdr.cpp:1545
 msgid "Use priority system"
 msgstr "Gebruik prioriteitssysteem"
 
-#: src/muuli_wdr.cpp:1556
+#: src/muuli_wdr.cpp:1549
 msgid "Use smart LowID check on connect"
 msgstr "Gebruik slimme laag-ID controle bij verbinden"
 
-#: src/muuli_wdr.cpp:1560
+#: src/muuli_wdr.cpp:1553
 msgid "Safe connect"
 msgstr "Veilig verbinden"
 
-#: src/muuli_wdr.cpp:1564
+#: src/muuli_wdr.cpp:1557
 msgid "Autoconnect to servers in static list only"
 msgstr "Autoverbind alleen met servers in statische lijst"
 
-#: src/muuli_wdr.cpp:1567
+#: src/muuli_wdr.cpp:1560
 msgid "Set manually added servers to High Priority"
 msgstr "Zet handmatig toegevoegde servers op hoge prioriteit"
 
-#: src/muuli_wdr.cpp:1588
+#: src/muuli_wdr.cpp:1581
 msgid "Add files to download in pause mode"
 msgstr "Voeg bestanden aan downloads toe in pauze-modus"
 
-#: src/muuli_wdr.cpp:1590
+#: src/muuli_wdr.cpp:1583
 msgid "Add files to download with auto priority"
 msgstr "Voeg bestanden aan downloads toe met automatische prioriteit"
 
-#: src/muuli_wdr.cpp:1593
+#: src/muuli_wdr.cpp:1586
 msgid "Try to download first and last chunks first"
 msgstr "Probeer eerste en laatste delen eerst te downloaden"
 
-#: src/muuli_wdr.cpp:1597
+#: src/muuli_wdr.cpp:1590
 msgid "Endgame mode: rotate to faster sources for the final blocks"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1600
+#: src/muuli_wdr.cpp:1593
 msgid "Start next paused file when a file completes"
 msgstr "Start volgend gepauzeerd bestand als een bestand compleet is"
 
-#: src/muuli_wdr.cpp:1603
+#: src/muuli_wdr.cpp:1596
 msgid "From the same category"
 msgstr "Uit dezelfde categorie"
 
-#: src/muuli_wdr.cpp:1605
+#: src/muuli_wdr.cpp:1598
 msgid "In alphabetic order"
 msgstr "In alfabetische volgorde"
 
-#: src/muuli_wdr.cpp:1607
+#: src/muuli_wdr.cpp:1600
 msgid "Preallocate disk space for new files"
 msgstr "Wijst schijfruimte toe voor nieuwe bestanden"
 
-#: src/muuli_wdr.cpp:1608
+#: src/muuli_wdr.cpp:1601
 msgid "For new files preallocates disk space for the whole file, thus reduces fragmentation"
 msgstr "Wijst schijfruimte toe voor nieuwe bestanden, beperkt hierdoor fragmentatie"
 
-#: src/muuli_wdr.cpp:1613
+#: src/muuli_wdr.cpp:1606
+msgid "Create new files as sparse files"
+msgstr ""
+
+#: src/muuli_wdr.cpp:1607
+msgid "A sparse file reserves its full size on disk immediately without writing real data to it -- fast, but unsupported or slow on some filesystems, and free-space accounting stays optimistic while the download is in progress. Turn this off to grow the file only as data arrives."
+msgstr ""
+
+#: src/muuli_wdr.cpp:1612
 msgid "Stop downloads when free disk space reaches "
 msgstr "Stop downloads als de vrije schijfruimte bedraagt "
 
-#: src/muuli_wdr.cpp:1614
+#: src/muuli_wdr.cpp:1613
 msgid "Select this if you want aMule to check your disk space"
 msgstr "Selecteer dit als u wilt dat aMule uw schijfruimte controleert"
 
-#: src/muuli_wdr.cpp:1618
+#: src/muuli_wdr.cpp:1617
 msgid "Enter here the min disk space desired."
 msgstr "Voer hier de gewenste min schijfruimte in."
 
-#: src/muuli_wdr.cpp:1624
+#: src/muuli_wdr.cpp:1623
 msgid "Save 10 sources on rare files (< 20 sources)"
 msgstr "Bewaar 10 bronnen van zeldzame bestanden (<20 bronnen)"
 
-#: src/muuli_wdr.cpp:1628 src/Statistics.cpp:790
+#: src/muuli_wdr.cpp:1627 src/Statistics.cpp:790
 msgid "Uploads"
 msgstr "Uploads"
 
-#: src/muuli_wdr.cpp:1631
+#: src/muuli_wdr.cpp:1630
 msgid "Add new shared files with auto priority"
 msgstr "Voeg nieuwe gedeelde bestanden toe met automatische prioriteit"
 
-#: src/muuli_wdr.cpp:1637
+#: src/muuli_wdr.cpp:1636
 msgid "Intelligent Corruption Handling (I.C.H.)"
 msgstr "Intelligente corruptieafhandling (I.C.H.)"
 
-#: src/muuli_wdr.cpp:1640
+#: src/muuli_wdr.cpp:1639
 msgid "Enable"
 msgstr "Inschakelen"
 
-#: src/muuli_wdr.cpp:1643
+#: src/muuli_wdr.cpp:1642
 msgid "Advanced I.C.H. trusts every hash (not recommended)"
 msgstr "Geavanceerde I.C.H. vertrouwt elke hash (niet aanbevolen)"
 
-#: src/muuli_wdr.cpp:1655 src/PrefsUnifiedDlg.cpp:1990
+#: src/muuli_wdr.cpp:1654 src/PrefsUnifiedDlg.cpp:1910
 msgid "Media metadata extraction"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1659
+#: src/muuli_wdr.cpp:1658
 msgid "Extract length / bitrate / codec from shared audio and video files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1661
+#: src/muuli_wdr.cpp:1660
 msgid "When enabled, aMule runs ffprobe on each shared media file to fill in the Length / Bitrate / Codec columns other clients see when they find the file in a search. Requires ffmpeg (the ffprobe binary) to be installed."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1668
+#: src/muuli_wdr.cpp:1667
 msgid "Path to ffprobe:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1673
+#: src/muuli_wdr.cpp:1672
 msgid "Full path to the ffprobe binary. Leave empty to have aMule auto-detect it on startup."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1681
+#: src/muuli_wdr.cpp:1680
 msgid "Detect"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1682
+#: src/muuli_wdr.cpp:1681
 msgid "Search the standard install locations for an ffprobe binary and fill the path field."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1706
+#: src/muuli_wdr.cpp:1705
 msgid ""
 "Completed downloads are stored here. All files in this folder are automatically shared with other peers.\n"
 "If this folder also holds files you don't want to share, point it at an aMule-only sub-folder."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1709
+#: src/muuli_wdr.cpp:1708
 msgid "Pick the folder where completed downloads will be stored. All files in that folder will be shared with other peers."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1723
+#: src/muuli_wdr.cpp:1722
 msgid "Shared folders"
 msgstr "Gedeelde mappen"
 
-#: src/muuli_wdr.cpp:1729
+#: src/muuli_wdr.cpp:1728
 msgid "(Folders shared by the core. Enter a path to add one.)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1737
+#: src/muuli_wdr.cpp:1736
 msgid "Absolute path of a folder on the core's machine, e.g. /home/user/shared"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1739 src/PrefsUnifiedDlg.cpp:2874
+#: src/muuli_wdr.cpp:1738 src/PrefsUnifiedDlg.cpp:2794
 msgid "Recursive"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1740
+#: src/muuli_wdr.cpp:1739
 msgid "Share every sub-folder underneath this one, including ones created later."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1744 src/utils/aLinkCreator/src/alcframe.cpp:141
+#: src/muuli_wdr.cpp:1743 src/utils/aLinkCreator/src/alcframe.cpp:141
 msgid "Remove"
 msgstr "Verwijder"
 
-#: src/muuli_wdr.cpp:1748
+#: src/muuli_wdr.cpp:1747
 msgid "(Right click on folder icon for recursive share)"
 msgstr "(Rechtermuisklik op mappictogram om recursief te delen)"
 
-#: src/muuli_wdr.cpp:1755
+#: src/muuli_wdr.cpp:1754
 msgid "Share hidden files"
 msgstr "Deel verborgen bestanden"
 
-#: src/muuli_wdr.cpp:1761
+#: src/muuli_wdr.cpp:1760
 msgid "Automatically rescan shared folders for changes"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1767
+#: src/muuli_wdr.cpp:1766
 msgid "Follow symbolic links in shared folders"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1773
+#: src/muuli_wdr.cpp:1772
 msgid "Exclude files matching:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1776
+#: src/muuli_wdr.cpp:1775
 msgid "Wildcard patterns separated by '|', e.g. .DS_Store|Thumbs.db|*.tmp. Files whose name matches are not shared. Matching is case-insensitive."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1780
+#: src/muuli_wdr.cpp:1779
 msgid "Patterns are regular expressions"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1781
+#: src/muuli_wdr.cpp:1780
 msgid "When set, the whole field is one regular expression ('|' is alternation). When unset, it is a list of '|'-separated wildcards."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1791
+#: src/muuli_wdr.cpp:1790
 msgid "Show how many shared files the current pattern would exclude."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1812
+#: src/muuli_wdr.cpp:1811
 msgid "Graphs"
 msgstr "Grafieken"
 
-#: src/muuli_wdr.cpp:1815 src/muuli_wdr.cpp:1877
+#: src/muuli_wdr.cpp:1814 src/muuli_wdr.cpp:1876
 msgid "Update delay : 5 secs"
 msgstr "Update-vertraging : 5 seconden"
 
-#: src/muuli_wdr.cpp:1819
+#: src/muuli_wdr.cpp:1818
 msgid "Time for average graph: 100 mins"
 msgstr "Tijd voor gemiddeldengrafiek: 100 minuten"
 
-#: src/muuli_wdr.cpp:1823
+#: src/muuli_wdr.cpp:1822
 msgid "Connections Graph Scale: 100 "
 msgstr "Schaal verbindingengrafiek: 100 "
 
-#: src/muuli_wdr.cpp:1830
+#: src/muuli_wdr.cpp:1829
 msgid "Download graph scale:"
 msgstr "Schaal downloadgrafiek:"
 
-#: src/muuli_wdr.cpp:1838
+#: src/muuli_wdr.cpp:1837
 msgid "Upload graph scale:"
 msgstr "Schaal uploadgrafiek:"
 
-#: src/muuli_wdr.cpp:1848
+#: src/muuli_wdr.cpp:1847
 #, fuzzy
 msgid "Colors: "
 msgstr "Kleuren: "
 
-#: src/muuli_wdr.cpp:1852
+#: src/muuli_wdr.cpp:1851
 msgid "Background"
 msgstr "Achtergrond"
 
-#: src/muuli_wdr.cpp:1853
+#: src/muuli_wdr.cpp:1852
 msgid "Grid"
 msgstr "Raster"
 
-#: src/muuli_wdr.cpp:1854
+#: src/muuli_wdr.cpp:1853
 msgid "Download current"
 msgstr "Huidige download"
 
-#: src/muuli_wdr.cpp:1855
+#: src/muuli_wdr.cpp:1854
 msgid "Download running average"
 msgstr "Lopend gemiddelde download"
 
-#: src/muuli_wdr.cpp:1856
+#: src/muuli_wdr.cpp:1855
 msgid "Download session average"
 msgstr "Sessie gemiddelde download"
 
-#: src/muuli_wdr.cpp:1857
+#: src/muuli_wdr.cpp:1856
 msgid "Upload current"
 msgstr "Huidige upload"
 
-#: src/muuli_wdr.cpp:1858
+#: src/muuli_wdr.cpp:1857
 msgid "Upload running average"
 msgstr "Lopend gemiddelde upload"
 
-#: src/muuli_wdr.cpp:1859
+#: src/muuli_wdr.cpp:1858
 msgid "Upload session average"
 msgstr "Sessie gemiddelde upload"
 
-#: src/muuli_wdr.cpp:1860
+#: src/muuli_wdr.cpp:1859
 msgid "Active connections"
 msgstr "Actieve verbindingen"
 
-#: src/muuli_wdr.cpp:1863
+#: src/muuli_wdr.cpp:1862
 #, fuzzy
 msgid "Systray Icon Speed Bar"
 msgstr "Systeemvak-pictogram met snelheidsbalk"
 
-#: src/muuli_wdr.cpp:1864
+#: src/muuli_wdr.cpp:1863
 msgid "Kad-nodes current"
 msgstr "Kad-nodes huidig"
 
-#: src/muuli_wdr.cpp:1865
+#: src/muuli_wdr.cpp:1864
 msgid "Kad-nodes running"
 msgstr "Kad-nodes draaiende"
 
-#: src/muuli_wdr.cpp:1866
+#: src/muuli_wdr.cpp:1865
 msgid "Kad-nodes session"
 msgstr "Kad-nodes sessie"
 
-#: src/muuli_wdr.cpp:1870 src/muuli_wdr.cpp:2324
+#: src/muuli_wdr.cpp:1869 src/muuli_wdr.cpp:2296
 msgid "Select"
 msgstr "Selecteer"
 
-#: src/muuli_wdr.cpp:1874
+#: src/muuli_wdr.cpp:1873
 msgid "Tree"
 msgstr "Boom"
 
-#: src/muuli_wdr.cpp:1884
+#: src/muuli_wdr.cpp:1883
 msgid "Number of Client Versions shown (0=unlimited)"
 msgstr "Aantal getoonde client-versies (0=onbegrensd)"
 
-#: src/muuli_wdr.cpp:1909
+#: src/muuli_wdr.cpp:1908
 msgid "!!! WARNING !!!"
 msgstr "!!! WAARSCHUWING !!!"
 
-#: src/muuli_wdr.cpp:1924
+#: src/muuli_wdr.cpp:1923
 msgid "Max new connections / 5 secs"
 msgstr "Max nieuwe verbindingen / 5 seconden"
 
-#: src/muuli_wdr.cpp:1926
+#: src/muuli_wdr.cpp:1925
 msgid "Concurrent Kad source lookups"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1928
+#: src/muuli_wdr.cpp:1927
 #, fuzzy
 msgid "Kad source re-search interval (minutes)"
 msgstr "Tijd tussen de FTP-updates in minuten"
 
-#: src/muuli_wdr.cpp:1930
+#: src/muuli_wdr.cpp:1929
 #, fuzzy
 msgid "Source re-ask interval (minutes)"
 msgstr "Tijd tussen de FTP-updates in minuten"
 
-#: src/muuli_wdr.cpp:1934
+#: src/muuli_wdr.cpp:1933
 msgid "File Buffer Size: 240000 bytes"
 msgstr "Grootte van bestandsbuffer : 240000 bytes"
 
-#: src/muuli_wdr.cpp:1938
+#: src/muuli_wdr.cpp:1937
 msgid "Use MMAP: memory-mapped file access (lower memory use)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1939
+#: src/muuli_wdr.cpp:1938
 msgid "Maps part files into memory instead of buffering them on the heap, lowering the process memory footprint. May reduce download speed on some disks; best for memory-constrained or upload-heavy hosts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1941
+#: src/muuli_wdr.cpp:1940
 msgid "Upload Queue Size: 5000 clients"
 msgstr "Grootte van uploadwachtrij: 5000 clients"
 
-#: src/muuli_wdr.cpp:1945
+#: src/muuli_wdr.cpp:1944
 msgid "Server connection refresh interval: Disable"
 msgstr "Server-verbinding verversingsinterval: Uitschakelen"
 
-#: src/muuli_wdr.cpp:1949
+#: src/muuli_wdr.cpp:1948
 msgid "Disable computer's timed standby mode"
 msgstr "Schakel standby-modus van computer uit"
 
-#: src/muuli_wdr.cpp:1968
+#: src/muuli_wdr.cpp:1967
 msgid "Skin to use: "
 msgstr "Gebruik skin: "
 
-#: src/muuli_wdr.cpp:1977
+#: src/muuli_wdr.cpp:1976
 msgid "Show \"Fast eD2k Links Handler\" in every window."
 msgstr "Toon \"Snelle eD2k-links afhandelaar\" in elk venster."
 
-#: src/muuli_wdr.cpp:1980
+#: src/muuli_wdr.cpp:1979
 msgid "Show extended info on categories tabs"
 msgstr "Geef uitgebreide informatie weer op categorie-tabs"
 
-#: src/muuli_wdr.cpp:1983
+#: src/muuli_wdr.cpp:1982
 msgid "Show application version on title"
 msgstr "Toon applicatieversie op titel"
 
-#: src/muuli_wdr.cpp:1985
+#: src/muuli_wdr.cpp:1984
 msgid "Show transfer rates on title"
 msgstr "Toon overdrachtsnelheden op titel"
 
-#: src/muuli_wdr.cpp:1987
+#: src/muuli_wdr.cpp:1986
 msgid "Before application name"
 msgstr "Voor applicatienaam"
 
-#: src/muuli_wdr.cpp:1989
+#: src/muuli_wdr.cpp:1988
 msgid "After application name"
 msgstr "Na applicatienaam"
 
-#: src/muuli_wdr.cpp:1992
+#: src/muuli_wdr.cpp:1991
 msgid "Show overhead bandwidth"
 msgstr "Toon overhead bandbreedte"
 
-#: src/muuli_wdr.cpp:1996
+#: src/muuli_wdr.cpp:1995
 msgid "Vertical toolbar orientation"
 msgstr "Verticale knoppenbalk"
 
-#: src/muuli_wdr.cpp:1998
+#: src/muuli_wdr.cpp:1997
 msgid "Live column sorting (auto-reorder rows as their values change)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2005
+#: src/muuli_wdr.cpp:2004
 msgid "Download Queue Files"
 msgstr "Downloadwachtrij bestanden"
 
-#: src/muuli_wdr.cpp:2008
+#: src/muuli_wdr.cpp:2007
 msgid "Show progress percentage"
 msgstr "Toon voortgangspercentage"
 
-#: src/muuli_wdr.cpp:2014
+#: src/muuli_wdr.cpp:2013
 msgid "Show progress bar"
 msgstr "Toon voortgangsindicator"
 
-#: src/muuli_wdr.cpp:2017
+#: src/muuli_wdr.cpp:2016
 msgid "Flat"
 msgstr "Plat"
 
-#: src/muuli_wdr.cpp:2021
+#: src/muuli_wdr.cpp:2020
 msgid "Round"
 msgstr "Rond"
 
-#: src/muuli_wdr.cpp:2039
+#: src/muuli_wdr.cpp:2038
 msgid "External Connection Parameters"
 msgstr "Externe verbinding parameters"
 
-#: src/muuli_wdr.cpp:2042
+#: src/muuli_wdr.cpp:2041
 msgid "Accept external connections"
 msgstr "Accepteer externe verbindingen"
 
-#: src/muuli_wdr.cpp:2049 src/muuli_wdr.cpp:2108
+#: src/muuli_wdr.cpp:2048 src/muuli_wdr.cpp:2107
 msgid "IP of the listening interface:"
 msgstr "IP van de luisterende interface:"
 
-#: src/muuli_wdr.cpp:2052
+#: src/muuli_wdr.cpp:2051
 msgid "Enter here a valid ip in the a.b.c.d format for the listening EC interface. An empty field or 0.0.0.0 will mean any interface."
 msgstr "Voer hier een geldig IP in het formaat a.b.c.d in van de luisterende EV-interface. Een leeg veld of 0.0.0.0 betekent elke interface."
 
-#: src/muuli_wdr.cpp:2073 src/muuli_wdr.cpp:2184
+#: src/muuli_wdr.cpp:2072 src/muuli_wdr.cpp:2156
 msgid "TCP port:"
 msgstr "TCP-poort:"
 
-#: src/muuli_wdr.cpp:2079
+#: src/muuli_wdr.cpp:2078
 msgid "Enable UPnP port forwarding on the EC port"
 msgstr "Schakel UPnP portforwarding van de EV-poort in"
 
-#: src/muuli_wdr.cpp:2083 src/muuli_wdr.cpp:3069
+#: src/muuli_wdr.cpp:2082 src/muuli_wdr.cpp:3041
 #: src/utils/wxCas/src/wxcasprefs.cpp:167
 msgid "Password"
 msgstr "Wachtwoord"
 
-#: src/muuli_wdr.cpp:2089
+#: src/muuli_wdr.cpp:2088
 #, fuzzy
 msgid "aMule API server parameters"
 msgstr "Webserver parameters"
 
-#: src/muuli_wdr.cpp:2092
+#: src/muuli_wdr.cpp:2091
 msgid "Run amuleapi (REST API) on startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2097
+#: src/muuli_wdr.cpp:2096
 #, fuzzy
 msgid "HTTP port:"
 msgstr "TCP-poort:"
 
-#: src/muuli_wdr.cpp:2111
+#: src/muuli_wdr.cpp:2110
 msgid "The interface amuleapi's HTTP server listens on. 127.0.0.1 (default) accepts only local connections; use 0.0.0.0 or a specific IP to expose it to other hosts (set an admin password below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2116
-msgid "Type a password to set or change it. Stored passwords cannot be shown, so leaving this empty keeps the current one."
-msgstr ""
-
-#: src/muuli_wdr.cpp:2118
+#: src/muuli_wdr.cpp:2113
 #, fuzzy
 msgid "Admin password"
 msgstr "Controleren van wachtwoord\n"
 
-#: src/muuli_wdr.cpp:2130 src/muuli_wdr.cpp:2147 src/PrefsUnifiedDlg.cpp:1103
-#, fuzzy
-msgid "A password is set."
-msgstr "Controleren van wachtwoord\n"
+#: src/muuli_wdr.cpp:2118 src/muuli_wdr.cpp:2149
+msgid "Low rights password"
+msgstr "Beperkte rechten wachtwoord"
 
-#: src/muuli_wdr.cpp:2134
-#, fuzzy
-msgid "Enable guest access"
-msgstr "Weiger gasttoegang"
-
-#: src/muuli_wdr.cpp:2135
-msgid "Guest sessions may read status and listings but cannot change anything. Turning this off clears the stored guest password."
-msgstr ""
-
-#: src/muuli_wdr.cpp:2139
-#, fuzzy
-msgid "Guest password"
-msgstr "Gastwachtwoord voor webserver"
-
-#: src/muuli_wdr.cpp:2154
+#: src/muuli_wdr.cpp:2126
 msgid "Web server parameters"
 msgstr "Webserver parameters"
 
-#: src/muuli_wdr.cpp:2157
+#: src/muuli_wdr.cpp:2129
 #, fuzzy
 msgid "Run webserver on startup (deprecated)"
 msgstr "Start webserver bij het opstarten"
 
-#: src/muuli_wdr.cpp:2163
+#: src/muuli_wdr.cpp:2135
 msgid "Web template"
 msgstr "Web-template"
 
-#: src/muuli_wdr.cpp:2168
+#: src/muuli_wdr.cpp:2140
 msgid "Full rights password"
 msgstr "Alle rechten wachtwoord"
 
-#: src/muuli_wdr.cpp:2172
+#: src/muuli_wdr.cpp:2144
 msgid "Enable Low rights User"
 msgstr "Schakel gebruiker met beperkte rechten in"
 
-#: src/muuli_wdr.cpp:2177
-msgid "Low rights password"
-msgstr "Beperkte rechten wachtwoord"
-
-#: src/muuli_wdr.cpp:2191
+#: src/muuli_wdr.cpp:2163
 msgid "Enable UPnP port forwarding of the web server port"
 msgstr "Schakel UPnP portforwarding van de webserver-poort in"
 
-#: src/muuli_wdr.cpp:2196
+#: src/muuli_wdr.cpp:2168
 msgid "Web server UPnP TCP port (Optional)"
 msgstr "Web server UPnP TCP-poort (optioneel)"
 
-#: src/muuli_wdr.cpp:2204
+#: src/muuli_wdr.cpp:2176
 msgid "Page Refresh Time (in secs)"
 msgstr "Pagina verversingstijd (in seconden)"
 
-#: src/muuli_wdr.cpp:2211
+#: src/muuli_wdr.cpp:2183
 msgid "Enable Gzip compression"
 msgstr "Schakel Gzip-compressie in"
 
-#: src/muuli_wdr.cpp:2245
+#: src/muuli_wdr.cpp:2217
 #, fuzzy
 msgid "Reset page to defaults"
 msgstr "Systeemstandaard"
 
-#: src/muuli_wdr.cpp:2246
+#: src/muuli_wdr.cpp:2218
 msgid "Reset the settings on the current page to their default values."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2248 src/muuli_wdr.cpp:2334 src/ServerWnd.cpp:274
+#: src/muuli_wdr.cpp:2220 src/muuli_wdr.cpp:2306 src/ServerWnd.cpp:274
 #: src/ServerWnd.cpp:282
 msgid "OK"
 msgstr "OK"
 
-#: src/muuli_wdr.cpp:2250
+#: src/muuli_wdr.cpp:2222
 msgid "Click here to apply any changes made to the preferences."
 msgstr "Klik hier om de veranderingen gemaakt in de voorkeuren toe te passen."
 
-#: src/muuli_wdr.cpp:2253
+#: src/muuli_wdr.cpp:2225
 msgid "Reset any changes made to the preferences."
 msgstr "Maak veranderingen aan de voorkeuren ongedaan."
 
-#: src/muuli_wdr.cpp:2282
+#: src/muuli_wdr.cpp:2254
 msgid "Comment :"
 msgstr "Commentaar :"
 
-#: src/muuli_wdr.cpp:2289
+#: src/muuli_wdr.cpp:2261
 msgid "Incoming Dir :"
 msgstr "Binnenkomende map :"
 
-#: src/muuli_wdr.cpp:2298
+#: src/muuli_wdr.cpp:2270
 msgid "Change priority for new assigned files :"
 msgstr "Verander prioriteit voor nieuw toegevoegde bestanden :"
 
-#: src/muuli_wdr.cpp:2302
+#: src/muuli_wdr.cpp:2274
 msgid "Don't change"
 msgstr "Niet veranderen"
 
-#: src/muuli_wdr.cpp:2314
+#: src/muuli_wdr.cpp:2286
 msgid "Select color for this Category (currently selected) :"
 msgstr "Selecteer kleur voor deze categorie (nu geselecteerd) :"
 
-#: src/muuli_wdr.cpp:2381 src/muuli_wdr.cpp:2400 src/muuli_wdr.cpp:2422
+#: src/muuli_wdr.cpp:2353 src/muuli_wdr.cpp:2372 src/muuli_wdr.cpp:2394
 msgid "Click this button to reset the log."
 msgstr "Klik op deze knop om het logboek te wissen."
 
-#: src/muuli_wdr.cpp:2441
+#: src/muuli_wdr.cpp:2413
 msgid "Click on this button to update the servers list from URL ..."
 msgstr "Klik op deze knop om de lijst van servers te updaten van URL ..."
 
-#: src/muuli_wdr.cpp:2445
+#: src/muuli_wdr.cpp:2417
 msgid "Server list"
 msgstr "Server-lijst"
 
-#: src/muuli_wdr.cpp:2449
+#: src/muuli_wdr.cpp:2421
 msgid "Enter the url to a server.met file here and press the button to the left to update the list of known servers."
 msgstr "Voer de url naar een server.met bestand hier in en druk op de knop links om de lijst met bekende servers te vernieuwen."
 
-#: src/muuli_wdr.cpp:2454
+#: src/muuli_wdr.cpp:2426
 msgid "Add server manually: Name"
 msgstr "Voeg server handmatig toe: Naam"
 
-#: src/muuli_wdr.cpp:2457
+#: src/muuli_wdr.cpp:2429
 msgid "Enter the name of the new server here"
 msgstr "Voer hier de naam van de nieuwe server in"
 
-#: src/muuli_wdr.cpp:2459 src/ServerWnd.cpp:206
+#: src/muuli_wdr.cpp:2431 src/ServerWnd.cpp:206
 msgid "IP:Port"
 msgstr "IP:Poort"
 
-#: src/muuli_wdr.cpp:2462
+#: src/muuli_wdr.cpp:2434
 msgid "Enter the IP of the server here, using the x.x.x.x format."
 msgstr "Voer hier het IP van de server in, gebuik het x.x.x.x formaat."
 
-#: src/muuli_wdr.cpp:2468
+#: src/muuli_wdr.cpp:2440
 msgid "Enter the port of the server here."
 msgstr "Voer hier de poort van de server in."
 
-#: src/muuli_wdr.cpp:2471
+#: src/muuli_wdr.cpp:2443
 msgid "Add manually a server (fill fields to the left before) ..."
 msgstr "Voeg een server handmatig toe (vul velden links in voor) ..."
 
-#: src/muuli_wdr.cpp:2500
+#: src/muuli_wdr.cpp:2472
 msgid "aMule Log"
 msgstr "aMule log"
 
-#: src/muuli_wdr.cpp:2508
+#: src/muuli_wdr.cpp:2480
 msgid "Server Info"
 msgstr "Server-info"
 
-#: src/muuli_wdr.cpp:2512
+#: src/muuli_wdr.cpp:2484
 msgid "ED2K Info"
 msgstr "ED2K-info"
 
-#: src/muuli_wdr.cpp:2516
+#: src/muuli_wdr.cpp:2488
 msgid "Kad Info"
 msgstr "Kad info"
 
-#: src/muuli_wdr.cpp:2544
+#: src/muuli_wdr.cpp:2516
 msgid "Click on this button to update the nodes list from URL ..."
 msgstr "Klik op deze knop om de nodes-lijst te updaten van URL ..."
 
-#: src/muuli_wdr.cpp:2548
+#: src/muuli_wdr.cpp:2520
 msgid "Nodes (0)"
 msgstr "Nodes (0)"
 
-#: src/muuli_wdr.cpp:2552
+#: src/muuli_wdr.cpp:2524
 msgid "Enter the url to a nodes.dat file here and press the button to the left to update the list of known nodes."
 msgstr "Voer hier de url in naar een nodes.dat bestand en druk op de knop links om de lijst van bekende nodes te updaten."
 
-#: src/muuli_wdr.cpp:2555
+#: src/muuli_wdr.cpp:2527
 msgid "Nodes stats"
 msgstr "Nodes stats"
 
-#: src/muuli_wdr.cpp:2597
+#: src/muuli_wdr.cpp:2569
 msgid "Bootstrap"
 msgstr "Bootstrap"
 
-#: src/muuli_wdr.cpp:2600
+#: src/muuli_wdr.cpp:2572
 msgid "New node"
 msgstr "Nieuwe node"
 
-#: src/muuli_wdr.cpp:2605
+#: src/muuli_wdr.cpp:2577
 msgid "IP:"
 msgstr "IP:"
 
-#: src/muuli_wdr.cpp:2625
+#: src/muuli_wdr.cpp:2597
 msgid "Port:"
 msgstr "Poort:"
 
-#: src/muuli_wdr.cpp:2638
+#: src/muuli_wdr.cpp:2610
 msgid "Bootstrap from known clients"
 msgstr "Bootstrap van bekende clients"
 
-#: src/muuli_wdr.cpp:2640
+#: src/muuli_wdr.cpp:2612
 msgid "Disconnect Kad"
 msgstr "Verbreek verbinding met Kad"
 
-#: src/muuli_wdr.cpp:2674
+#: src/muuli_wdr.cpp:2646
 msgid "Use Secure User Identification"
 msgstr "Gebruik beveiligde gebruikersidentificatie"
 
-#: src/muuli_wdr.cpp:2676
+#: src/muuli_wdr.cpp:2648
 msgid "It is recommended to enable this option. You will not receive credits if SUI is not enabled."
 msgstr "Het is aan te raden om deze optie in te schakelen. U ontvangt geen credits indien SUI niet ingeschakeld is."
 
-#: src/muuli_wdr.cpp:2678
+#: src/muuli_wdr.cpp:2650
 msgid "Protocol Obfuscation"
 msgstr "Protocol-obfuscatie"
 
-#: src/muuli_wdr.cpp:2681
+#: src/muuli_wdr.cpp:2653
 msgid "Support Protocol Obfuscation"
 msgstr "Ondersteun protocol-obfuscatie"
 
-#: src/muuli_wdr.cpp:2683
+#: src/muuli_wdr.cpp:2655
 msgid "This option enabled Protocol Obfuscation, and makes aMule accept obfuscated connections from other clients."
 msgstr "Deze optie schakelt Protocol Obfuscatie in, en zorgt er voor dat aMule geobfusceerde verbindingen van andere clients accepteert."
 
-#: src/muuli_wdr.cpp:2685
+#: src/muuli_wdr.cpp:2657
 msgid "Use obfuscation for outgoing connections"
 msgstr "Gebruik obfuscatie voor uitgaande verbindingen"
 
-#: src/muuli_wdr.cpp:2687
+#: src/muuli_wdr.cpp:2659
 msgid "This option makes aMule use Protocol Obfuscation when connecting other clients/servers."
 msgstr "Deze optie zorgt er voor dat aMule protocol-obfuscatie gebruikt bij het verbinden met andere clients/servers."
 
-#: src/muuli_wdr.cpp:2689
+#: src/muuli_wdr.cpp:2661
 msgid "Accept only obfuscated connections"
 msgstr "Accepteer alleen geobfusceerde verbindingen"
 
-#: src/muuli_wdr.cpp:2690
+#: src/muuli_wdr.cpp:2662
 msgid "This option makes aMule only accept obfuscated connections. You will have less sources, but all your traffic will be obfuscated"
 msgstr "Deze optie zorgt er voor dat aMule alleen geobfusceerde verbindingen accepteert. U heeft minder bronnen, maar al uw verkeer is geobfusceerd"
 
-#: src/muuli_wdr.cpp:2695
+#: src/muuli_wdr.cpp:2667
 msgid "Everybody"
 msgstr "Iedereen"
 
-#: src/muuli_wdr.cpp:2697
+#: src/muuli_wdr.cpp:2669
 msgid "No one"
 msgstr "Niemand"
 
-#: src/muuli_wdr.cpp:2699
+#: src/muuli_wdr.cpp:2671
 msgid "Who can see my shared files:"
 msgstr "Wie kan mijn gedeelde bestanden zien:"
 
-#: src/muuli_wdr.cpp:2700
+#: src/muuli_wdr.cpp:2672
 msgid "Select who can request to view a list of your shared files."
 msgstr "Selecteer wie een lijst van uw gedeelde bestanden kan opvragen."
 
-#: src/muuli_wdr.cpp:2702
+#: src/muuli_wdr.cpp:2674
 msgid "IP-Filtering"
 msgstr "IP-filteren"
 
-#: src/muuli_wdr.cpp:2709
+#: src/muuli_wdr.cpp:2681
 msgid "Filter clients"
 msgstr "Filter clients"
 
-#: src/muuli_wdr.cpp:2711
+#: src/muuli_wdr.cpp:2683
 msgid "Enable filtering of the client IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "Schakel filteren van de client-IPs in het bestand ~/.aMule/ipfilter.dat in."
 
-#: src/muuli_wdr.cpp:2713
+#: src/muuli_wdr.cpp:2685
 msgid "Filter servers"
 msgstr "Filter servers"
 
-#: src/muuli_wdr.cpp:2715
+#: src/muuli_wdr.cpp:2687
 msgid "Enable filtering of the server IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "Schakel filteren van de server-IPs in het bestand ~/.aMule/ipfilter.dat in."
 
-#: src/muuli_wdr.cpp:2719
+#: src/muuli_wdr.cpp:2691
 msgid "Reload List"
 msgstr "Lijst opnieuw laden"
 
-#: src/muuli_wdr.cpp:2720
+#: src/muuli_wdr.cpp:2692
 msgid "Reload the list of IPs to filter from the file ~/.aMule/ipfilter.dat"
 msgstr "Laadt de lijst met IPs om te filteren opnieuw uit het bestand ~/.aMule/ipfilter.dat"
 
-#: src/muuli_wdr.cpp:2726
+#: src/muuli_wdr.cpp:2698
 msgid "URL:"
 msgstr "URL:"
 
-#: src/muuli_wdr.cpp:2730 src/muuli_wdr.cpp:2923
+#: src/muuli_wdr.cpp:2702 src/muuli_wdr.cpp:2895
 msgid "Update now"
 msgstr "Update nu"
 
-#: src/muuli_wdr.cpp:2733
+#: src/muuli_wdr.cpp:2705
 msgid "Auto-update ipfilter at startup"
 msgstr "Auto-update ip-filter bij het starten"
 
-#: src/muuli_wdr.cpp:2737
+#: src/muuli_wdr.cpp:2709
 msgid "Filtering Level:"
 msgstr "Niveau van filteren:"
 
-#: src/muuli_wdr.cpp:2743
+#: src/muuli_wdr.cpp:2715
 msgid "Always filter LAN IPs"
 msgstr "Filter LAN IPs altijd"
 
-#: src/muuli_wdr.cpp:2746
+#: src/muuli_wdr.cpp:2718
 msgid "Paranoid handling of non-matching IPs"
 msgstr "Paranoïde behandeling van niet-kloppende IPs"
 
-#: src/muuli_wdr.cpp:2748
+#: src/muuli_wdr.cpp:2720
 msgid "Rejects a packet when its source IP differs from the IP the client claims (an anti-spoofing check). Disable only if it causes connection problems."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2750
+#: src/muuli_wdr.cpp:2722
 msgid "Use system-wide ipfilter.dat if available"
 msgstr "Gebruik systeemwijd ipfilter.dat indien beschikbaar"
 
-#: src/muuli_wdr.cpp:2751
+#: src/muuli_wdr.cpp:2723
 #, fuzzy
 msgid "If there's no local ipfilter.dat found, allow usage of a system-wide ipfilter file."
 msgstr "Indien er geen lokaal ipfilter.dat gevonden wordt, sta gebruik van een systeemwijd ipfilter toe."
 
-#: src/muuli_wdr.cpp:2768
+#: src/muuli_wdr.cpp:2740
 msgid "Enable Online-Signature"
 msgstr "Schakel online handtekening in"
 
-#: src/muuli_wdr.cpp:2770
+#: src/muuli_wdr.cpp:2742
 msgid "Enables the writing of the OS file, which can be used by external apps to create signatures and the like."
 msgstr "Schakelt het schrijven van het OH-bestand in, die kan gebruikt worden door externe applicaties om handtekeningen en dergelijke te maken."
 
-#: src/muuli_wdr.cpp:2774
+#: src/muuli_wdr.cpp:2746
 msgid "Update Frequency (Secs):"
 msgstr "Update-frequentie (seconden):"
 
-#: src/muuli_wdr.cpp:2777
+#: src/muuli_wdr.cpp:2749
 msgid "Change the frequency (in seconds) of Online Signature updates."
 msgstr "Verander de frequentie (in seconden) van de Online Handtekening updates."
 
-#: src/muuli_wdr.cpp:2785
+#: src/muuli_wdr.cpp:2757
 msgid "Save online signature file in: "
 msgstr "Bewaar online-handtekeningbestand in: "
 
-#: src/muuli_wdr.cpp:2791
+#: src/muuli_wdr.cpp:2763
 msgid "Click here to select the directory containing the the Online Signature files."
 msgstr "Klik hier om de map te selecteren die de online-handtekening-bestanden bevat."
 
-#: src/muuli_wdr.cpp:2824
+#: src/muuli_wdr.cpp:2796
 msgid "Show country flags for clients"
 msgstr "Toon landenvlaggen voor clients"
 
-#: src/muuli_wdr.cpp:2825
+#: src/muuli_wdr.cpp:2797
 msgid "Render the country flag column in the transfers, queue and search views. Requires a valid MMDB GeoIP database (see below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2830
+#: src/muuli_wdr.cpp:2802
 #, fuzzy
 msgid "Database"
 msgstr "Datasnelheid :"
 
-#: src/muuli_wdr.cpp:2846
+#: src/muuli_wdr.cpp:2818
 #, fuzzy
 msgid "Source:"
 msgstr "Bronnen"
 
-#: src/muuli_wdr.cpp:2849
+#: src/muuli_wdr.cpp:2821
 msgid "DB-IP (free, no account)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2850
+#: src/muuli_wdr.cpp:2822
 msgid "MaxMind GeoLite2 (free, account required)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2851
+#: src/muuli_wdr.cpp:2823
 msgid "Custom URL"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2854
+#: src/muuli_wdr.cpp:2826
 msgid "Choose which provider supplies the GeoIP MMDB database. DB-IP is the default - no account required. MaxMind requires a free account + license key. Use Custom URL to point at any other MMDB host (e.g. a local mirror)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2871
+#: src/muuli_wdr.cpp:2843
 msgid ""
 "No configuration required.\n"
 "\n"
@@ -4877,11 +4843,11 @@ msgid ""
 "License: Creative Commons BY 4.0 - https://creativecommons.org/licenses/by/4.0/"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2884
+#: src/muuli_wdr.cpp:2856
 msgid "License key:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2890
+#: src/muuli_wdr.cpp:2862
 msgid ""
 "Sign up for a free MaxMind account, then generate a License Key:\n"
 "https://www.maxmind.com/en/geolite2/signup\n"
@@ -4891,225 +4857,225 @@ msgid ""
 "Requires attribution and account registration; refresh at least every 30 days."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2905
+#: src/muuli_wdr.cpp:2877
 #, fuzzy
 msgid "Download URL:"
 msgstr "Download: "
 
-#: src/muuli_wdr.cpp:2911
+#: src/muuli_wdr.cpp:2883
 msgid ""
 "Must point to an .mmdb file or a .gz / .tar.gz containing one.\n"
 "URL may include credentials (https://user:pass@host/...).\n"
 "License and attribution terms are set by the upstream URL - you are responsible."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2924
+#: src/muuli_wdr.cpp:2896
 msgid "Download the GeoIP database from the selected source."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2926
+#: src/muuli_wdr.cpp:2898
 #, fuzzy
 msgid "Auto-update on startup"
 msgstr "Auto-update ip-filter bij het starten"
 
-#: src/muuli_wdr.cpp:2927
+#: src/muuli_wdr.cpp:2899
 msgid "Re-download the GeoIP database from the selected source every time aMule starts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2950
+#: src/muuli_wdr.cpp:2922
 msgid "Filter incoming messages (except current chat):"
 msgstr "Filter binnenkomende berichten (behalve huidige chat):"
 
-#: src/muuli_wdr.cpp:2952
+#: src/muuli_wdr.cpp:2924
 msgid "Filter all messages"
 msgstr "Filter alle berichten"
 
-#: src/muuli_wdr.cpp:2954
+#: src/muuli_wdr.cpp:2926
 msgid "Filter messages from people not on your friend list"
 msgstr "Filter berichten van mensen niet op uw vriendenlijst"
 
-#: src/muuli_wdr.cpp:2956
+#: src/muuli_wdr.cpp:2928
 msgid "Filter messages from unknown clients"
 msgstr "Filter berichten van onbekende clients"
 
-#: src/muuli_wdr.cpp:2958
+#: src/muuli_wdr.cpp:2930
 msgid "Filter messages containing (use ',' as separator):"
 msgstr "Filter berichten met (gebruik ',' als scheiding):"
 
-#: src/muuli_wdr.cpp:2961 src/muuli_wdr.cpp:2972
+#: src/muuli_wdr.cpp:2933 src/muuli_wdr.cpp:2944
 msgid "add here the words amule should filter and block messages including it"
 msgstr "voeg hier de woorden toe die amule moet filteren en berichten daarmee blokkeren"
 
-#: src/muuli_wdr.cpp:2963
+#: src/muuli_wdr.cpp:2935
 msgid "Show received messages in the log"
 msgstr "Toon ontvangen berichten in het logboek"
 
-#: src/muuli_wdr.cpp:2966
+#: src/muuli_wdr.cpp:2938
 msgid "Comments"
 msgstr "Commentaren"
 
-#: src/muuli_wdr.cpp:2969
+#: src/muuli_wdr.cpp:2941
 msgid "Filter comments containing (use ',' as separator):"
 msgstr "Filter commentaren die de volgende tekens bevatten (gebruik ',' als scheiding):"
 
-#: src/muuli_wdr.cpp:2994
+#: src/muuli_wdr.cpp:2966
 msgid "Enable Proxy"
 msgstr "Schakel proxy in"
 
-#: src/muuli_wdr.cpp:2995
+#: src/muuli_wdr.cpp:2967
 msgid "Enable/disable proxy support"
 msgstr "Schakel proxy ondersteuning in/uit"
 
-#: src/muuli_wdr.cpp:2998
+#: src/muuli_wdr.cpp:2970
 msgid "Proxy type:"
 msgstr "Proxy-type:"
 
-#: src/muuli_wdr.cpp:3009
+#: src/muuli_wdr.cpp:2981
 msgid "Proxy host:"
 msgstr "Proxy-host:"
 
-#: src/muuli_wdr.cpp:3012
+#: src/muuli_wdr.cpp:2984
 msgid "The proxy host name"
 msgstr "De proxy hostnaam"
 
-#: src/muuli_wdr.cpp:3014
+#: src/muuli_wdr.cpp:2986
 msgid "Proxy port:"
 msgstr "Proxy-poort:"
 
-#: src/muuli_wdr.cpp:3017
+#: src/muuli_wdr.cpp:2989
 msgid "The proxy port"
 msgstr "De proxy poort"
 
-#: src/muuli_wdr.cpp:3019
+#: src/muuli_wdr.cpp:2991
 msgid "Enable authentication"
 msgstr "Schakel aanmelding in"
 
-#: src/muuli_wdr.cpp:3020
+#: src/muuli_wdr.cpp:2992
 msgid "Enable/disable username/password authentication"
 msgstr "Schakel gebruikersnaam/wachtwoord aanmelding in/uit"
 
-#: src/muuli_wdr.cpp:3023
+#: src/muuli_wdr.cpp:2995
 msgid "Username: "
 msgstr "Gebruikersnaam: "
 
-#: src/muuli_wdr.cpp:3026
+#: src/muuli_wdr.cpp:2998
 msgid "The username to use to connect to the proxy"
 msgstr "De gebruikersnaam is nodig om te verbinden met de proxy"
 
-#: src/muuli_wdr.cpp:3028
+#: src/muuli_wdr.cpp:3000
 msgid "Password:"
 msgstr "Wachtwoord:"
 
-#: src/muuli_wdr.cpp:3031
+#: src/muuli_wdr.cpp:3003
 msgid "The password to use to connect to the proxy"
 msgstr "Het wachtwoord nodig om te verbinden met de proxy"
 
-#: src/muuli_wdr.cpp:3050
+#: src/muuli_wdr.cpp:3022
 msgid "Connect to:"
 msgstr "Verbind met:"
 
-#: src/muuli_wdr.cpp:3059
+#: src/muuli_wdr.cpp:3031
 msgid "Login to remote amule"
 msgstr "Inloggen op amule op afstand"
 
-#: src/muuli_wdr.cpp:3064
+#: src/muuli_wdr.cpp:3036
 msgid "User name"
 msgstr "Gebruikersnaam"
 
-#: src/muuli_wdr.cpp:3075
+#: src/muuli_wdr.cpp:3047
 msgid "Remember those settings"
 msgstr "Onthoud deze instellingen"
 
-#: src/muuli_wdr.cpp:3078
+#: src/muuli_wdr.cpp:3050
 #, fuzzy
 msgid "Force ZLIB compression"
 msgstr "Gebruik Gzip-compressie"
 
-#: src/muuli_wdr.cpp:3102
+#: src/muuli_wdr.cpp:3074
 msgid "Enable Verbose Debug-Logging."
 msgstr "Schakel uitgebreide foutopsporing en logboek in."
 
-#: src/muuli_wdr.cpp:3104
+#: src/muuli_wdr.cpp:3076
 msgid "Only to Logfile"
 msgstr "Alleen naar logbestand"
 
-#: src/muuli_wdr.cpp:3106
+#: src/muuli_wdr.cpp:3078
 msgid "Message Categories:"
 msgstr "Berichtcategorieën:"
 
-#: src/muuli_wdr.cpp:3130 src/PartFileConvertDlg.cpp:160
+#: src/muuli_wdr.cpp:3102 src/PartFileConvertDlg.cpp:160
 msgid "Waiting..."
 msgstr "Wachtend..."
 
-#: src/muuli_wdr.cpp:3150
+#: src/muuli_wdr.cpp:3122
 msgid "Add imports"
 msgstr "Voeg geïmporteerden toe"
 
-#: src/muuli_wdr.cpp:3153
+#: src/muuli_wdr.cpp:3125
 msgid "Retry selected"
 msgstr "Probeer geselecteerde opnieuw"
 
-#: src/muuli_wdr.cpp:3155
+#: src/muuli_wdr.cpp:3127
 msgid "Remove selected"
 msgstr "Verwijder geselecteerde"
 
-#: src/muuli_wdr.cpp:3218
+#: src/muuli_wdr.cpp:3190
 msgid "Event Types"
 msgstr "Gebeurtenistypes"
 
-#: src/muuli_wdr.cpp:3237
+#: src/muuli_wdr.cpp:3209
 msgid "Statistics and queued clients for selected file(s) : Session / All time"
 msgstr "Statistieken en clients in wachtrij voor geselecteerd(e) bestand(en) : Sessie / Alle"
 
-#: src/muuli_wdr.cpp:3261
+#: src/muuli_wdr.cpp:3233
 msgid "Active Uploads"
 msgstr "Actieve uploads"
 
-#: src/muuli_wdr.cpp:3275
+#: src/muuli_wdr.cpp:3247
 msgid "Percent of total files"
 msgstr "Procent van alle bestanden"
 
-#: src/muuli_wdr.cpp:3327
+#: src/muuli_wdr.cpp:3299
 msgid "Show Clients for"
 msgstr "Toon clients voor"
 
-#: src/muuli_wdr.cpp:3329
+#: src/muuli_wdr.cpp:3301
 msgid "All files"
 msgstr "Alle bestanden"
 
-#: src/muuli_wdr.cpp:3332
+#: src/muuli_wdr.cpp:3304
 msgid "Selected files"
 msgstr "Geselecteerde bestanden"
 
-#: src/muuli_wdr.cpp:3335
+#: src/muuli_wdr.cpp:3307
 msgid "Active uploads only"
 msgstr "Alleen actieve uploads"
 
-#: src/muuli_wdr.cpp:3342
+#: src/muuli_wdr.cpp:3314
 msgid "Reload:"
 msgstr "Opnieuw laden:"
 
-#: src/muuli_wdr.cpp:3346
+#: src/muuli_wdr.cpp:3318
 msgid "Reload your shared files"
 msgstr "Laad uw gedeelde bestanden opnieuw"
 
-#: src/muuli_wdr.cpp:3409
+#: src/muuli_wdr.cpp:3381
 msgid "Send"
 msgstr "Verstuur"
 
-#: src/muuli_wdr.cpp:3410
+#: src/muuli_wdr.cpp:3382
 msgid "Sends the specified message."
 msgstr "Verstuurt het opgegeven bericht."
 
-#: src/muuli_wdr.cpp:3414
+#: src/muuli_wdr.cpp:3386
 msgid "Close this chat-session."
 msgstr "Sluit deze chat-sessie."
 
-#: src/muuli_wdr.cpp:3437
+#: src/muuli_wdr.cpp:3409
 msgid "Connect to any server and/or Kad"
 msgstr "Verbind met een server en/of Kad"
 
-#: src/muuli_wdr.cpp:3443 src/SharedFilesCtrl.cpp:142 src/Statistics.cpp:941
+#: src/muuli_wdr.cpp:3415 src/SharedFilesCtrl.cpp:142 src/Statistics.cpp:941
 msgid "Shared Files"
 msgstr "Gedeelde bestanden"
 
@@ -5470,249 +5436,249 @@ msgstr "Gedownload"
 msgid "ERROR: Failed to open partfile '%s'"
 msgstr "FOUT: Kon deelbestand '%s' niet openen"
 
-#: src/Preferences.cpp:701
+#: src/Preferences.cpp:673
 msgid "System default"
 msgstr "Systeemstandaard"
 
-#: src/Preferences.cpp:702
+#: src/Preferences.cpp:674
 msgid "Albanian"
 msgstr "Albanees"
 
-#: src/Preferences.cpp:703
+#: src/Preferences.cpp:675
 msgid "Arabic"
 msgstr "Arabisch"
 
-#: src/Preferences.cpp:704
+#: src/Preferences.cpp:676
 msgid "Asturian"
 msgstr "Asturisch"
 
-#: src/Preferences.cpp:705
+#: src/Preferences.cpp:677
 msgid "Basque"
 msgstr "Baskisch"
 
-#: src/Preferences.cpp:706
+#: src/Preferences.cpp:678
 msgid "Bulgarian"
 msgstr "Bulgaars"
 
-#: src/Preferences.cpp:707
+#: src/Preferences.cpp:679
 msgid "Catalan"
 msgstr "Catalaans"
 
-#: src/Preferences.cpp:708
+#: src/Preferences.cpp:680
 msgid "Chinese (Simplified)"
 msgstr "Chinees (Vereenvoudigd)"
 
-#: src/Preferences.cpp:709
+#: src/Preferences.cpp:681
 msgid "Chinese (Traditional)"
 msgstr "Chinees (Traditioneel)"
 
-#: src/Preferences.cpp:710
+#: src/Preferences.cpp:682
 msgid "Croatian"
 msgstr "Kroatisch"
 
-#: src/Preferences.cpp:711
+#: src/Preferences.cpp:683
 msgid "Czech"
 msgstr "Tsjechisch"
 
-#: src/Preferences.cpp:712
+#: src/Preferences.cpp:684
 msgid "Danish"
 msgstr "Deens"
 
-#: src/Preferences.cpp:713
+#: src/Preferences.cpp:685
 msgid "Dutch"
 msgstr "Nederlands"
 
-#: src/Preferences.cpp:714
+#: src/Preferences.cpp:686
 msgid "English (U.K.)"
 msgstr "Engels (V.K.)"
 
-#: src/Preferences.cpp:715
+#: src/Preferences.cpp:687
 #, fuzzy
 msgid "English (U.S.)"
 msgstr "Engels (V.K.)"
 
-#: src/Preferences.cpp:716
+#: src/Preferences.cpp:688
 msgid "Estonian"
 msgstr "Estonisch"
 
-#: src/Preferences.cpp:717
+#: src/Preferences.cpp:689
 msgid "Finnish"
 msgstr "Fins"
 
-#: src/Preferences.cpp:718
+#: src/Preferences.cpp:690
 msgid "French"
 msgstr "Frans"
 
-#: src/Preferences.cpp:719
+#: src/Preferences.cpp:691
 msgid "Galician"
 msgstr "Gallisch"
 
-#: src/Preferences.cpp:720
+#: src/Preferences.cpp:692
 msgid "German"
 msgstr "Duits"
 
-#: src/Preferences.cpp:721
+#: src/Preferences.cpp:693
 msgid "Greek"
 msgstr "Grieks"
 
-#: src/Preferences.cpp:722
+#: src/Preferences.cpp:694
 msgid "Hebrew"
 msgstr "Hebreeuws"
 
-#: src/Preferences.cpp:723
+#: src/Preferences.cpp:695
 msgid "Hungarian"
 msgstr "Hongaars"
 
-#: src/Preferences.cpp:724
+#: src/Preferences.cpp:696
 msgid "Italian"
 msgstr "Italiaans"
 
-#: src/Preferences.cpp:725
+#: src/Preferences.cpp:697
 msgid "Japanese"
 msgstr "Japans"
 
-#: src/Preferences.cpp:726
+#: src/Preferences.cpp:698
 msgid "Korean"
 msgstr "Koreaans"
 
-#: src/Preferences.cpp:727
+#: src/Preferences.cpp:699
 msgid "Latvian"
 msgstr ""
 
-#: src/Preferences.cpp:728
+#: src/Preferences.cpp:700
 msgid "Lithuanian"
 msgstr "Litouws"
 
-#: src/Preferences.cpp:729
+#: src/Preferences.cpp:701
 msgid "Norwegian (Nynorsk)"
 msgstr "Noors"
 
-#: src/Preferences.cpp:730
+#: src/Preferences.cpp:702
 msgid "Polish"
 msgstr "Pools"
 
-#: src/Preferences.cpp:731
+#: src/Preferences.cpp:703
 msgid "Portuguese"
 msgstr "Portugees"
 
-#: src/Preferences.cpp:732
+#: src/Preferences.cpp:704
 msgid "Portuguese (Brazilian)"
 msgstr "Portugees (Braziliaans)"
 
-#: src/Preferences.cpp:733
+#: src/Preferences.cpp:705
 msgid "Romanian"
 msgstr "Roemeens"
 
-#: src/Preferences.cpp:734
+#: src/Preferences.cpp:706
 msgid "Russian"
 msgstr "Russisch"
 
-#: src/Preferences.cpp:735
+#: src/Preferences.cpp:707
 msgid "Slovenian"
 msgstr "Sloveens"
 
-#: src/Preferences.cpp:736
+#: src/Preferences.cpp:708
 msgid "Spanish"
 msgstr "Spaans"
 
-#: src/Preferences.cpp:737
+#: src/Preferences.cpp:709
 msgid "Swedish"
 msgstr "Zweeds"
 
-#: src/Preferences.cpp:738
+#: src/Preferences.cpp:710
 msgid "Turkish"
 msgstr "Turks"
 
-#: src/Preferences.cpp:739
+#: src/Preferences.cpp:711
 msgid "Ukrainian"
 msgstr "Oekraïens"
 
-#: src/Preferences.cpp:842
+#: src/Preferences.cpp:814
 msgid "Change Language"
 msgstr "Verander taal"
 
-#: src/Preferences.cpp:906
+#: src/Preferences.cpp:878
 msgid "There are no translations installed for aMule"
 msgstr "Er zijn geen vertalingen voor aMule geïnstalleerd"
 
-#: src/Preferences.cpp:907
+#: src/Preferences.cpp:879
 msgid "No languages available"
 msgstr "Geen talen beschikbaar"
 
-#: src/Preferences.cpp:1038
+#: src/Preferences.cpp:1010
 msgid "no options available"
 msgstr "geen opties beschikbaar"
 
-#: src/Preferences.cpp:2226
+#: src/Preferences.cpp:2179
 msgid "Invalid category found, skipping"
 msgstr "Ongeldige categorie gevonden, wordt overgeslagen"
 
-#: src/Preferences.cpp:2395
+#: src/Preferences.cpp:2348
 msgid "TCP port can't be higher than 65532 due to server UDP socket being TCP+3"
 msgstr "TCP-poort kan niet hoger zijn dan 65532 omdat de server UDP-poort de TCP-poort + 3 is"
 
-#: src/Preferences.cpp:2396
+#: src/Preferences.cpp:2349
 #, c-format
 msgid "Default port will be used (%d)"
 msgstr "Standaard poort zal worden gebruikt (%d)"
 
-#: src/PrefsUnifiedDlg.cpp:300 src/Statistics.cpp:866
+#: src/PrefsUnifiedDlg.cpp:298 src/Statistics.cpp:866
 msgid "Connection"
 msgstr "Verbinding"
 
-#: src/PrefsUnifiedDlg.cpp:301 src/SearchListCtrl.cpp:117
+#: src/PrefsUnifiedDlg.cpp:299 src/SearchListCtrl.cpp:117
 msgid "Directories"
 msgstr "Mappen"
 
-#: src/PrefsUnifiedDlg.cpp:302 src/Statistics.cpp:917
+#: src/PrefsUnifiedDlg.cpp:300 src/Statistics.cpp:917
 msgid "Servers"
 msgstr "Servers"
 
-#: src/PrefsUnifiedDlg.cpp:303 src/ServerListCtrl.cpp:96
+#: src/PrefsUnifiedDlg.cpp:301 src/ServerListCtrl.cpp:96
 msgid "Files"
 msgstr "Bestanden"
 
-#: src/PrefsUnifiedDlg.cpp:304
+#: src/PrefsUnifiedDlg.cpp:302
 msgid "Security"
 msgstr "Beveiliging"
 
-#: src/PrefsUnifiedDlg.cpp:305
+#: src/PrefsUnifiedDlg.cpp:303
 msgid "Interface"
 msgstr "Interface"
 
-#: src/PrefsUnifiedDlg.cpp:312
+#: src/PrefsUnifiedDlg.cpp:310
 msgid "IP2Country"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:315
+#: src/PrefsUnifiedDlg.cpp:313
 msgid "Proxy"
 msgstr "Proxy"
 
-#: src/PrefsUnifiedDlg.cpp:316
+#: src/PrefsUnifiedDlg.cpp:314
 msgid "Filters"
 msgstr "Filters"
 
-#: src/PrefsUnifiedDlg.cpp:317
+#: src/PrefsUnifiedDlg.cpp:315
 msgid "Remote Controls"
 msgstr "Besturing op afstand"
 
-#: src/PrefsUnifiedDlg.cpp:318
+#: src/PrefsUnifiedDlg.cpp:316
 msgid "Online Signature"
 msgstr "Online handtekening"
 
-#: src/PrefsUnifiedDlg.cpp:319
+#: src/PrefsUnifiedDlg.cpp:317
 msgid "Advanced"
 msgstr "Geavanceerd"
 
-#: src/PrefsUnifiedDlg.cpp:320
+#: src/PrefsUnifiedDlg.cpp:318
 msgid "Events"
 msgstr "Gebeurtenissen"
 
-#: src/PrefsUnifiedDlg.cpp:323
+#: src/PrefsUnifiedDlg.cpp:321
 msgid "Debugging"
 msgstr "Foutopsporing"
 
-#: src/PrefsUnifiedDlg.cpp:453
+#: src/PrefsUnifiedDlg.cpp:451
 msgid ""
 "The following variables will be substituted:\n"
 "    %PARTFILE - full path to the file\n"
@@ -5722,15 +5688,15 @@ msgstr ""
 "    %PARTFILE - volledig pad naar het bestand\n"
 "    %PARTNAME - alleen bestandsnaam"
 
-#: src/PrefsUnifiedDlg.cpp:474
+#: src/PrefsUnifiedDlg.cpp:472
 msgid "Tray icon support requires libayatana-appindicator3 at compile time."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:490
+#: src/PrefsUnifiedDlg.cpp:488
 msgid "Not available on Wayland: the protocol does not report when a window is minimized, so this option cannot intercept the system minimize button. Workaround: launch aMule with `GDK_BACKEND=x11` to use XWayland instead."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:536
+#: src/PrefsUnifiedDlg.cpp:534
 msgid ""
 "Do not change these setting unless you know\n"
 "what you are doing, otherwise you can easily\n"
@@ -5746,35 +5712,26 @@ msgstr ""
 "aMule zal goed draaien zonder deze instellingen\n"
 "te wijzigen."
 
-#: src/PrefsUnifiedDlg.cpp:647
+#: src/PrefsUnifiedDlg.cpp:645
 #, c-format
 msgid "Failed to connect Cfg to widget with the ID %d and key %s"
 msgstr "Kon Cfg niet verbinden met widget met ID %d en sleutel %s"
 
-#: src/PrefsUnifiedDlg.cpp:695
+#: src/PrefsUnifiedDlg.cpp:693
 #, c-format
 msgid "Failed to transfer data from Cfg to Widget with the ID %d and key %s"
 msgstr "Kon data niet overdragen van Cfg naar widget met ID %d en sleutel %s"
 
-#: src/PrefsUnifiedDlg.cpp:801
+#: src/PrefsUnifiedDlg.cpp:799
 msgid "The type of proxy you are connecting to"
 msgstr "Het type proxy waarmee u verbinding maakt"
 
-#: src/PrefsUnifiedDlg.cpp:1020
+#: src/PrefsUnifiedDlg.cpp:1003
 #, c-format
 msgid "Failed to transfer data from Widget to Cfg with the ID %d and key %s"
 msgstr "Kon data niet overdragen van Widget naar Cfg met ID %d en sleutel %s"
 
 #: src/PrefsUnifiedDlg.cpp:1103
-#, fuzzy
-msgid "No password set."
-msgstr "Controleren van wachtwoord\n"
-
-#: src/PrefsUnifiedDlg.cpp:1132
-msgid "Guest access needs a password. Type one in the guest password field, or untick Enable guest access."
-msgstr ""
-
-#: src/PrefsUnifiedDlg.cpp:1144
 msgid ""
 "aMule must be restarted to enable these changes:\n"
 "\n"
@@ -5782,41 +5739,41 @@ msgstr ""
 "aMule moet opnieuw gestart worden om deze veranderingen toe te passen:\n"
 "\n"
 
-#: src/PrefsUnifiedDlg.cpp:1151
+#: src/PrefsUnifiedDlg.cpp:1110
 msgid "- TCP port changed.\n"
 msgstr "- TCP-poort veranderd.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1156
+#: src/PrefsUnifiedDlg.cpp:1115
 msgid "- UDP port changed.\n"
 msgstr "- UDP-poort veranderd.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1161
+#: src/PrefsUnifiedDlg.cpp:1120
 #, fuzzy
 msgid "- Network interface binding changed.\n"
 msgstr "- Interface voor externe verbinding veranderd.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1166
+#: src/PrefsUnifiedDlg.cpp:1125
 msgid "- External connect port changed.\n"
 msgstr "- Poort voor externe verbinding is veranderd.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1170
+#: src/PrefsUnifiedDlg.cpp:1129
 msgid "- External connect acceptance changed.\n"
 msgstr "- Acceptatie voor externe verbinding veranderd.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1174
+#: src/PrefsUnifiedDlg.cpp:1133
 msgid "- External connect interface changed.\n"
 msgstr "- Interface voor externe verbinding veranderd.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1178
+#: src/PrefsUnifiedDlg.cpp:1137
 msgid "- Protocol obfuscation support changed.\n"
 msgstr "- Ondersteuning voor Protocol-obfuscatie is veranderd.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1193
+#: src/PrefsUnifiedDlg.cpp:1151
 #, fuzzy
 msgid "- amuleapi settings changed.\n"
 msgstr "- Taal veranderd.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1202
+#: src/PrefsUnifiedDlg.cpp:1160
 msgid ""
 "Your Auto-update server list is empty.\n"
 "'Auto-update server list at startup' will be disabled."
@@ -5824,7 +5781,7 @@ msgstr ""
 "Uw Auto-update serverlijst is leeg.\n"
 "'Auto-update serverlijst bij het opstarten' wordt uitgeschakeld."
 
-#: src/PrefsUnifiedDlg.cpp:1213
+#: src/PrefsUnifiedDlg.cpp:1171
 msgid ""
 "You have enabled external connections but have not specified a password.\n"
 "External connections cannot be enabled unless a valid password is specified."
@@ -5832,33 +5789,28 @@ msgstr ""
 "U hebt externe verbindingen ingeschakeld maar geen wachtwoord ingesteld.\n"
 "Externe verbindingen kunnen niet ingeschakeld worden tenzij een geldig wachtwoord is ingesteld."
 
-#: src/PrefsUnifiedDlg.cpp:1246
-#, c-format
-msgid "The amuleapi password could not be saved: %s"
-msgstr ""
-
-#: src/PrefsUnifiedDlg.cpp:1276
+#: src/PrefsUnifiedDlg.cpp:1202
 msgid "- Language changed.\n"
 msgstr "- Taal veranderd.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1281
+#: src/PrefsUnifiedDlg.cpp:1207
 msgid "- Temp folder changed.\n"
 msgstr "- Tijdelijke map veranderd.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1286
+#: src/PrefsUnifiedDlg.cpp:1212
 msgid "- ED2K network enabled.\n"
 msgstr "- ED2K-netwerk ingeschakeld.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1319
+#: src/PrefsUnifiedDlg.cpp:1245
 msgid "The shared-file exclusion pattern is not a valid regular expression. The filter has been left disabled."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1321 src/PrefsUnifiedDlg.cpp:1921
+#: src/PrefsUnifiedDlg.cpp:1247 src/PrefsUnifiedDlg.cpp:1841
 #, fuzzy
 msgid "Invalid regular expression"
 msgstr "Ongeldige protocolversie."
 
-#: src/PrefsUnifiedDlg.cpp:1398
+#: src/PrefsUnifiedDlg.cpp:1324
 msgid ""
 "Both eD2k and Kad network are disabled.\n"
 "You won't be able to connect until you enable at least one of them."
@@ -5866,7 +5818,7 @@ msgstr ""
 "Zowel het eD2K als het Kad-netwerk zijn uitgeschakeld.\n"
 "U kun niet verbinden tot u minimaal een netwerk inschakelt."
 
-#: src/PrefsUnifiedDlg.cpp:1403
+#: src/PrefsUnifiedDlg.cpp:1329
 msgid ""
 "Kad will not start if your UDP port is disabled.\n"
 "Enable UDP port or disable Kad."
@@ -5874,7 +5826,7 @@ msgstr ""
 "Kad zal niet starten als uw UDP-poort is uitgeschakeld.\n"
 "Schakel de UDP-poort in of schakel Kad uit."
 
-#: src/PrefsUnifiedDlg.cpp:1459
+#: src/PrefsUnifiedDlg.cpp:1385
 msgid ""
 "\n"
 "You MUST restart aMule now.\n"
@@ -5884,69 +5836,69 @@ msgstr ""
 "U MOET aMule nu opnieuw starten.\n"
 "Als u dat niet doet moet u niet klagen als er iets misgaat.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1524
+#: src/PrefsUnifiedDlg.cpp:1450
 msgid "Could not register aMule for autostart at login. The autostart store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1526
+#: src/PrefsUnifiedDlg.cpp:1452
 msgid "Could not remove the autostart-at-login entry."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1527
+#: src/PrefsUnifiedDlg.cpp:1453
 #, fuzzy
 msgid "Autostart"
 msgstr "Automatisch verversen gestart"
 
-#: src/PrefsUnifiedDlg.cpp:1542
+#: src/PrefsUnifiedDlg.cpp:1468
 msgid "Register file type"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1542
+#: src/PrefsUnifiedDlg.cpp:1468
 msgid "Register URL handler"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1550
+#: src/PrefsUnifiedDlg.cpp:1476
 #, c-format
 msgid "aMule only handles eD2k-compatible magnets. If you replace the current magnet handler (%s), BitTorrent magnet links will stop working - aMule cannot download BitTorrent content. Continue?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1555
+#: src/PrefsUnifiedDlg.cpp:1481
 #, c-format
 msgid "Another application currently opens .emulecollection files (%s). Replace it with aMule?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1560
+#: src/PrefsUnifiedDlg.cpp:1486
 #, c-format
 msgid "Another application is currently the default handler for these links (%s). Replace it with aMule?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1585
+#: src/PrefsUnifiedDlg.cpp:1511
 msgid "Could not register aMule for .emulecollection files. The registration store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1587
+#: src/PrefsUnifiedDlg.cpp:1513
 #, fuzzy
 msgid "Could not remove the file type registration."
 msgstr "Map voor tijdelijke downloadbestanden"
 
-#: src/PrefsUnifiedDlg.cpp:1589
+#: src/PrefsUnifiedDlg.cpp:1515
 msgid "Could not register aMule as the URL handler. The registration store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1591
+#: src/PrefsUnifiedDlg.cpp:1517
 msgid "Could not remove the URL handler registration."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1661 src/PrefsUnifiedDlg.cpp:1688
+#: src/PrefsUnifiedDlg.cpp:1587 src/PrefsUnifiedDlg.cpp:1614
 #, fuzzy
 msgid "The web server and aMule API require external connections to be enabled."
 msgstr "Wachtwoord ingesteld en externe verbindingen ingeschakeld."
 
-#: src/PrefsUnifiedDlg.cpp:1671
+#: src/PrefsUnifiedDlg.cpp:1597
 msgid "The aMule web server is deprecated. Consider running the aMule API instead."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1735
+#: src/PrefsUnifiedDlg.cpp:1655
 msgid ""
 "Your Auto-update servers list is in blank.\n"
 "Please fill in at least one URL to point to a valid server.met file.\n"
@@ -5956,66 +5908,66 @@ msgstr ""
 "Vul minimaal een URL naar een geldig server.met bestand in.\n"
 "Klik op de knop \"Lijst\" hiernaast om een URL in te voeren."
 
-#: src/PrefsUnifiedDlg.cpp:1876
+#: src/PrefsUnifiedDlg.cpp:1796
 msgid "Temporary files"
 msgstr "Tijdelijke bestanden"
 
-#: src/PrefsUnifiedDlg.cpp:1881
+#: src/PrefsUnifiedDlg.cpp:1801
 msgid "Incoming files"
 msgstr "Binnenkomende bestanden"
 
-#: src/PrefsUnifiedDlg.cpp:1886
+#: src/PrefsUnifiedDlg.cpp:1806
 msgid "Online Signatures"
 msgstr "Online handtekeningen"
 
-#: src/PrefsUnifiedDlg.cpp:1899
+#: src/PrefsUnifiedDlg.cpp:1819
 #, c-format
 msgid "Choose a folder for %s"
 msgstr "Kies een map voor %s"
 
-#: src/PrefsUnifiedDlg.cpp:1923
+#: src/PrefsUnifiedDlg.cpp:1843
 #, fuzzy, c-format
 msgid "Would exclude %u of %u shared file"
 msgid_plural "Would exclude %u of %u shared files"
 msgstr[0] "%i bekend gedeeld bestand gevonden"
 msgstr[1] "%i bekende gedeelde bestanden gevonden"
 
-#: src/PrefsUnifiedDlg.cpp:1940
+#: src/PrefsUnifiedDlg.cpp:1860
 msgid "Browse for videoplayer"
 msgstr "Blader naar videospeler"
 
-#: src/PrefsUnifiedDlg.cpp:1944
+#: src/PrefsUnifiedDlg.cpp:1864
 msgid "Select browser"
 msgstr "Selecteer browser"
 
-#: src/PrefsUnifiedDlg.cpp:1948
+#: src/PrefsUnifiedDlg.cpp:1868
 #, fuzzy
 msgid "Select ffprobe binary"
 msgstr "Selecteer browser"
 
-#: src/PrefsUnifiedDlg.cpp:1954
+#: src/PrefsUnifiedDlg.cpp:1874
 #, c-format
 msgid "Executable%s"
 msgstr "Uitvoerbare%s"
 
-#: src/PrefsUnifiedDlg.cpp:1988
+#: src/PrefsUnifiedDlg.cpp:1908
 msgid "ffprobe not found on PATH or in the standard install locations. Install ffmpeg (which ships ffprobe) or use Browse to pick a binary manually."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2000
+#: src/PrefsUnifiedDlg.cpp:1920
 msgid "Reset the settings on this page to their default values?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2001
+#: src/PrefsUnifiedDlg.cpp:1921
 #, fuzzy
 msgid "Reset to defaults"
 msgstr "Systeemstandaard"
 
-#: src/PrefsUnifiedDlg.cpp:2028
+#: src/PrefsUnifiedDlg.cpp:1948
 msgid "Edit server list"
 msgstr "Bewerk serverlijst"
 
-#: src/PrefsUnifiedDlg.cpp:2029
+#: src/PrefsUnifiedDlg.cpp:1949
 msgid ""
 "Add here URL's to download server.met files.\n"
 "Only one url on each line."
@@ -6023,179 +5975,175 @@ msgstr ""
 "Voeg hier URL's toe om server.met bestanden te downloaden.\n"
 "Slechts één url per regel."
 
-#: src/PrefsUnifiedDlg.cpp:2084
+#: src/PrefsUnifiedDlg.cpp:2004
 msgid "IP2Country update failed"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2229 src/PrefsUnifiedDlg.cpp:2260
+#: src/PrefsUnifiedDlg.cpp:2149 src/PrefsUnifiedDlg.cpp:2180
 msgid "Data by MaxMind GeoLite2"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2231 src/PrefsUnifiedDlg.cpp:2262
+#: src/PrefsUnifiedDlg.cpp:2151 src/PrefsUnifiedDlg.cpp:2182
 #, fuzzy
 msgid "Custom source"
 msgstr "Complete bronnen"
 
-#: src/PrefsUnifiedDlg.cpp:2233 src/PrefsUnifiedDlg.cpp:2264
+#: src/PrefsUnifiedDlg.cpp:2153 src/PrefsUnifiedDlg.cpp:2184
 msgid "Data by DB-IP.com"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2284
+#: src/PrefsUnifiedDlg.cpp:2204
 #, fuzzy, c-format
 msgid "Status: Loaded%s"
 msgstr "Status:"
 
-#: src/PrefsUnifiedDlg.cpp:2286
+#: src/PrefsUnifiedDlg.cpp:2206
 #, fuzzy, c-format
 msgid "Status: Loaded%s - %s"
 msgstr "Status:"
 
-#: src/PrefsUnifiedDlg.cpp:2290
+#: src/PrefsUnifiedDlg.cpp:2210
 msgid "Status: Failed to load - click 'Update now' to refresh."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2292
+#: src/PrefsUnifiedDlg.cpp:2212
 msgid "Status: Not found - click 'Update now' to download."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2350 src/PrefsUnifiedDlg.cpp:2374
+#: src/PrefsUnifiedDlg.cpp:2270 src/PrefsUnifiedDlg.cpp:2294
 #, c-format
 msgid "Update delay: %d second"
 msgid_plural "Update delay: %d seconds"
 msgstr[0] "Update-vertraging: %d seconde"
 msgstr[1] "Update-vertraging: %d seconden"
 
-#: src/PrefsUnifiedDlg.cpp:2358
+#: src/PrefsUnifiedDlg.cpp:2278
 #, c-format
 msgid "Time for average graph: %d minute"
 msgid_plural "Time for average graph: %d minutes"
 msgstr[0] "Tijd voor gemiddeldengrafiek: %d minuut"
 msgstr[1] "Tijd voor gemiddeldengrafiek: %d minuten"
 
-#: src/PrefsUnifiedDlg.cpp:2367
+#: src/PrefsUnifiedDlg.cpp:2287
 #, c-format
 msgid "Connections Graph Scale: %d"
 msgstr "Schaal verbindingengrafiek: %d"
 
-#: src/PrefsUnifiedDlg.cpp:2382
+#: src/PrefsUnifiedDlg.cpp:2302
 #, c-format
 msgid "File Buffer Size: %d byte"
 msgid_plural "File Buffer Size: %d bytes"
 msgstr[0] "Grootte van bestandsbuffer: %d byte"
 msgstr[1] "Grootte van bestandsbuffer: %d bytes"
 
-#: src/PrefsUnifiedDlg.cpp:2392
+#: src/PrefsUnifiedDlg.cpp:2312
 #, c-format
 msgid "Upload Queue Size: %d client"
 msgid_plural "Upload Queue Size: %d clients"
 msgstr[0] "Grootte van uploadwachtrij: %d client"
 msgstr[1] "Grootte van uploadwachtrij: %d clients"
 
-#: src/PrefsUnifiedDlg.cpp:2402
+#: src/PrefsUnifiedDlg.cpp:2322
 #, c-format
 msgid "Server connection refresh interval: %d minute"
 msgid_plural "Server connection refresh interval: %d minutes"
 msgstr[0] "Server-verbinding verversingsinterval: %d minuut"
 msgstr[1] "Server-verbinding verversingsinterval: %d minuten"
 
-#: src/PrefsUnifiedDlg.cpp:2407
+#: src/PrefsUnifiedDlg.cpp:2327
 msgid "Server connection refresh interval: Disabled"
 msgstr "Server verbinding verversingstijd: Uitgeschakeld"
 
-#: src/PrefsUnifiedDlg.cpp:2451
+#: src/PrefsUnifiedDlg.cpp:2371
 msgid "disabled"
 msgstr "uitgeschakeld"
 
-#: src/PrefsUnifiedDlg.cpp:2477
+#: src/PrefsUnifiedDlg.cpp:2397
 #, c-format
 msgid "Execute command on '%s' event"
 msgstr "Voer commando uit bij gebeurtenis '%s'"
 
-#: src/PrefsUnifiedDlg.cpp:2484
+#: src/PrefsUnifiedDlg.cpp:2404
 msgid "Enable command execution on core"
 msgstr "Schakel uitvoeren van commando's in kern in"
 
-#: src/PrefsUnifiedDlg.cpp:2496
+#: src/PrefsUnifiedDlg.cpp:2416
 msgid "Core command:"
 msgstr "Kerncommando:"
 
-#: src/PrefsUnifiedDlg.cpp:2512
+#: src/PrefsUnifiedDlg.cpp:2432
 msgid "Enable command execution on GUI"
 msgstr "Schakel uitvoeren van commando's in GUI in"
 
-#: src/PrefsUnifiedDlg.cpp:2524
+#: src/PrefsUnifiedDlg.cpp:2444
 msgid "GUI command:"
 msgstr "GUI commando:"
 
-#: src/PrefsUnifiedDlg.cpp:2540
+#: src/PrefsUnifiedDlg.cpp:2460
 msgid "The following variables will be replaced:"
 msgstr "De volgende variabelen worden vervangen:"
 
-#: src/PrefsUnifiedDlg.cpp:2708
+#: src/PrefsUnifiedDlg.cpp:2628
 msgid ""
 "The following folders look like system or sensitive locations:\n"
 "\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2713
+#: src/PrefsUnifiedDlg.cpp:2633
 msgid "Sharing them recursively will publish every file underneath on the eD2k/Kad networks. Do you really want to do this?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2716
+#: src/PrefsUnifiedDlg.cpp:2636
 #, fuzzy
 msgid "Confirm shared folders"
 msgstr "Gedeelde mappen"
 
-#: src/PrefsUnifiedDlg.cpp:2744
+#: src/PrefsUnifiedDlg.cpp:2664
 #, fuzzy
 msgid "Reloading shared files..."
 msgstr "Laad uw gedeelde bestanden opnieuw"
 
-#: src/PrefsUnifiedDlg.cpp:2745
+#: src/PrefsUnifiedDlg.cpp:2665
 msgid "Scanning for subdirectories..."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2746
+#: src/PrefsUnifiedDlg.cpp:2666
 #, fuzzy
 msgid "Updating shared folders"
 msgstr "Gedeelde mappen"
 
-#: src/PrefsUnifiedDlg.cpp:2773
+#: src/PrefsUnifiedDlg.cpp:2693
 #, c-format
 msgid "Scanned %u directories..."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2823
+#: src/PrefsUnifiedDlg.cpp:2743
 #, fuzzy, c-format
 msgid "Reloading shared files: %u files scanned"
 msgstr "Laad gedeelde-bestandenlijst opnieuw."
 
-#: src/PrefsUnifiedDlg.cpp:2873
+#: src/PrefsUnifiedDlg.cpp:2793
 #, fuzzy
 msgid "Shared folder"
 msgstr "Gedeelde mappen"
 
-#: src/SearchDlg.cpp:280
-msgid "Clear search history"
-msgstr ""
-
-#: src/SearchDlg.cpp:584
+#: src/SearchDlg.cpp:425
 msgid "It's impossible to search when both eD2k and Kademlia are disabled."
 msgstr "Er kan niet gezocht worden wanneer eD2k en Kademlia uitgeschakeld zijn."
 
-#: src/SearchDlg.cpp:585 src/SearchListCtrl.cpp:858
+#: src/SearchDlg.cpp:426 src/SearchListCtrl.cpp:858
 msgid "Search error"
 msgstr "Fout tijdens zoeken"
 
-#: src/SearchDlg.cpp:929
+#: src/SearchDlg.cpp:768
 msgid "Min size must be smaller than max size. Max size ignored."
 msgstr "Min grootte moet kleiner zijn dan max grootte. Max grootte wordt genegeerd."
 
-#: src/SearchDlg.cpp:930 src/SearchDlg.cpp:1012
+#: src/SearchDlg.cpp:769 src/SearchDlg.cpp:851
 msgid "Search warning"
 msgstr "Zoekwaarschuwing"
 
-#: src/SearchDlg.cpp:1092 src/SearchListCtrl.cpp:735
+#: src/SearchDlg.cpp:929 src/SearchListCtrl.cpp:735
 msgid "Main"
 msgstr "Standaard"
 

--- a/po/nl.po
+++ b/po/nl.po
@@ -12,7 +12,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-28 08:06+0200\n"
+"POT-Creation-Date: 2026-07-28 10:19+0200\n"
 "PO-Revision-Date: 2026-07-27 11:42+0000\n"
 "Last-Translator: Marcel Pol <marcel@timelord.nl>\n"
 "Language-Team: Dutch <nl@li.org>\n"
@@ -147,7 +147,7 @@ msgstr ""
 msgid "Not now"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:422 src/amuleDlg.cpp:600
+#: src/AppImageIntegration.cpp:422 src/amuleDlg.cpp:665
 msgid "Don't ask again"
 msgstr ""
 
@@ -220,7 +220,7 @@ msgid "Killing amuleweb instance with pid '%d' ... "
 msgstr "Amuleweb-instantie met pid '%d' wordt gedood ... "
 
 #: src/amule.cpp:336 src/amule.cpp:349 src/ClientRef.cpp:180
-#: src/SearchDlg.cpp:880 src/ServerListCtrl.cpp:98
+#: src/SearchDlg.cpp:1041 src/ServerListCtrl.cpp:98
 msgid "Failed"
 msgstr "Mislukt"
 
@@ -576,30 +576,68 @@ msgstr "Kan Pid-bestand niet aanmaken"
 msgid "ERROR: %s"
 msgstr "FOUT: %s"
 
-#: src/amuleDlg.cpp:236
+#: src/amuleDlg.cpp:250
 #, c-format
 msgid "This is aMule %s based on eMule."
 msgstr "Dit is aMule %s gebaseerd op eMule."
 
-#: src/amuleDlg.cpp:237
+#: src/amuleDlg.cpp:251
 #, c-format
 msgid "Running on %s"
 msgstr "Draaiend op %s"
 
-#: src/amuleDlg.cpp:239
+#: src/amuleDlg.cpp:253
 msgid "Visit https://github.com/amule-org/amule/releases/latest to check if a new version is available."
 msgstr "Bezoek https://github.com/amule-org/amule/releases/latest om te zien of een nieuwe versie beschikbaar is."
 
-#: src/amuleDlg.cpp:268
+#: src/amuleDlg.cpp:282
 msgid "FATAL ERROR: Failed to create Timer"
 msgstr "FATALE FOUT: Kon Timer niet aanmaken"
 
-#: src/amuleDlg.cpp:592
+#: src/amuleDlg.cpp:361 src/amuleDlg.cpp:1787 src/amuleDlg.cpp:2033
+#: src/muuli_wdr.cpp:1492 src/muuli_wdr.cpp:3418
+msgid "Networks"
+msgstr "Netwerken"
+
+#: src/amuleDlg.cpp:362 src/amuleDlg.cpp:1793 src/muuli_wdr.cpp:3419
+msgid "Searches"
+msgstr "Zoeken"
+
+#: src/amuleDlg.cpp:363 src/amuleDlg.cpp:1799 src/DownloadListCtrl.cpp:740
+#: src/muuli_wdr.cpp:392 src/muuli_wdr.cpp:1585 src/muuli_wdr.cpp:3420
+#: src/Statistics.cpp:829
+msgid "Downloads"
+msgstr "Downloads"
+
+#: src/amuleDlg.cpp:364 src/amuleDlg.cpp:1805 src/muuli_wdr.cpp:3294
+msgid "Shared files"
+msgstr "Gedeelde bestanden"
+
+#: src/amuleDlg.cpp:365 src/amuleDlg.cpp:1811 src/muuli_wdr.cpp:2926
+#: src/muuli_wdr.cpp:3376 src/muuli_wdr.cpp:3423
+msgid "Messages"
+msgstr "Berichten"
+
+#: src/amuleDlg.cpp:366 src/amuleDlg.cpp:1817 src/muuli_wdr.cpp:3424
+#: src/PrefsUnifiedDlg.cpp:312 src/Statistics.cpp:779 src/Statistics.cpp:1235
+msgid "Statistics"
+msgstr "Statistieken"
+
+#: src/amuleDlg.cpp:368 src/amuleDlg.cpp:1824 src/muuli_wdr.cpp:3426
+#: src/PrefsUnifiedDlg.cpp:328 src/utils/wxCas/src/wxcasprefs.cpp:39
+msgid "Preferences"
+msgstr "Voorkeuren"
+
+#: src/amuleDlg.cpp:371
+msgid "Navigate"
+msgstr ""
+
+#: src/amuleDlg.cpp:657
 #, fuzzy
 msgid "New version available"
 msgstr "Niet beschikbaar"
 
-#: src/amuleDlg.cpp:596
+#: src/amuleDlg.cpp:661
 #, fuzzy, c-format
 msgid ""
 "A new version of aMule (%s) is available.\n"
@@ -609,217 +647,184 @@ msgid ""
 "Would you like to open the download page?"
 msgstr "De nieuwste versie kan altijd gevonden worden op https://github.com/amule-org/amule/releases/latest"
 
-#: src/amuleDlg.cpp:678
+#: src/amuleDlg.cpp:743
 msgid "aMule dialog destroyed"
 msgstr "aMule dialoogvenster afgesloten"
 
-#: src/amuleDlg.cpp:701 src/DataToText.cpp:68 src/IPFilter.cpp:547
+#: src/amuleDlg.cpp:766 src/DataToText.cpp:68 src/IPFilter.cpp:547
 msgid "Connecting"
 msgstr "Aan het verbinden"
 
-#: src/amuleDlg.cpp:893
+#: src/amuleDlg.cpp:958
 msgid "eD2k: Connecting"
 msgstr "eD2K: Verbinden"
 
-#: src/amuleDlg.cpp:897
+#: src/amuleDlg.cpp:962
 msgid "eD2k: Disconnected"
 msgstr "eD2K: Verbinding verbroken"
 
-#: src/amuleDlg.cpp:903
+#: src/amuleDlg.cpp:968
 msgid "Kad: Firewalled"
 msgstr "Kad: Firewalled"
 
-#: src/amuleDlg.cpp:907
+#: src/amuleDlg.cpp:972
 msgid "Kad: Connected"
 msgstr "Kad: Verbonden"
 
-#: src/amuleDlg.cpp:912
+#: src/amuleDlg.cpp:977
 msgid "Kad: Connecting"
 msgstr "Kad: Verbinden"
 
-#: src/amuleDlg.cpp:916
+#: src/amuleDlg.cpp:981
 msgid "Kad: Off"
 msgstr "Kad: Uitgeschakeld"
 
-#: src/amuleDlg.cpp:964 src/DownloadListCtrl.cpp:505
+#: src/amuleDlg.cpp:1029 src/DownloadListCtrl.cpp:505
 #: src/DownloadListCtrl.cpp:749 src/FriendListCtrl.cpp:180
 #: src/muuli_wdr.cpp:731 src/muuli_wdr.cpp:782 src/muuli_wdr.cpp:846
-#: src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2224 src/muuli_wdr.cpp:2309
-#: src/muuli_wdr.cpp:3057 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
+#: src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2231 src/muuli_wdr.cpp:2316
+#: src/muuli_wdr.cpp:3064 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
 #: src/ServerListCtrl.cpp:606 src/TransferWnd.cpp:378
 #: src/utils/wxCas/src/wxcasprefs.cpp:235
 msgid "Cancel"
 msgstr "Annuleren"
 
-#: src/amuleDlg.cpp:965
+#: src/amuleDlg.cpp:1030
 msgid "Stop the current connection attempts"
 msgstr "Beëindig de huidige verbindingspogingen"
 
-#: src/amuleDlg.cpp:970 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976
-#: src/muuli_wdr.cpp:2447
+#: src/amuleDlg.cpp:1035 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976
+#: src/muuli_wdr.cpp:2454
 msgid "Disconnect"
 msgstr "Verbreek"
 
-#: src/amuleDlg.cpp:971
+#: src/amuleDlg.cpp:1036
 msgid "Disconnect from the currently connected networks"
 msgstr "Verbreek de huidige verbonden netwerken"
 
-#: src/amuleDlg.cpp:976 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979
-#: src/muuli_wdr.cpp:2602 src/muuli_wdr.cpp:3054 src/muuli_wdr.cpp:3409
+#: src/amuleDlg.cpp:1041 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979
+#: src/muuli_wdr.cpp:2609 src/muuli_wdr.cpp:3061 src/muuli_wdr.cpp:3416
 msgid "Connect"
 msgstr "Verbinden"
 
-#: src/amuleDlg.cpp:977
+#: src/amuleDlg.cpp:1042
 msgid "Connect to the currently enabled networks"
 msgstr "Verbind met de momenteel ingeschakelde netwerken"
 
-#: src/amuleDlg.cpp:1089
+#: src/amuleDlg.cpp:1154
 #, c-format
 msgid "Up: %.1f%s (%.1f) | Down: %.1f%s (%.1f)"
 msgstr "Upload: %.1f%s (%.1f) | Download: %.1f%s (%.1f)"
 
-#: src/amuleDlg.cpp:1091 src/amuleDlg.cpp:1093 src/amuleDlg.cpp:1097
-#: src/amuleDlg.cpp:1099 src/amuleDlg.cpp:1110 src/amuleDlg.cpp:1112
+#: src/amuleDlg.cpp:1156 src/amuleDlg.cpp:1158 src/amuleDlg.cpp:1162
+#: src/amuleDlg.cpp:1164 src/amuleDlg.cpp:1175 src/amuleDlg.cpp:1177
 #: src/MuleTrayIcon.cpp:796 src/MuleTrayIcon.cpp:799
 msgid " MB/s"
 msgstr " MB/s"
 
-#: src/amuleDlg.cpp:1091 src/amuleDlg.cpp:1093 src/amuleDlg.cpp:1097
-#: src/amuleDlg.cpp:1099 src/amuleDlg.cpp:1110 src/amuleDlg.cpp:1112
+#: src/amuleDlg.cpp:1156 src/amuleDlg.cpp:1158 src/amuleDlg.cpp:1162
+#: src/amuleDlg.cpp:1164 src/amuleDlg.cpp:1175 src/amuleDlg.cpp:1177
 #: src/MuleTrayIcon.cpp:796 src/MuleTrayIcon.cpp:799
 #: src/utils/wxCas/src/wxcasframe.cpp:1041
 msgid " kB/s"
 msgstr " kB/s"
 
-#: src/amuleDlg.cpp:1096
+#: src/amuleDlg.cpp:1161
 #, c-format
 msgid "Up: %.1f%s | Down: %.1f%s"
 msgstr "Upload: %.1f%s | Download: %.1f%s"
 
-#: src/amuleDlg.cpp:1128
+#: src/amuleDlg.cpp:1193
 #, c-format
 msgid "aMule (%s | Connected)"
 msgstr "aMule (%s | Verbonden)"
 
-#: src/amuleDlg.cpp:1130
+#: src/amuleDlg.cpp:1195
 #, c-format
 msgid "aMule (%s | Disconnected)"
 msgstr "aMule (%s | Niet verbonden)"
 
-#: src/amuleDlg.cpp:1183
+#: src/amuleDlg.cpp:1248
 #, c-format
 msgid "Do you really want to exit %s?"
 msgstr "Wilt u %s echt afsluiten?"
 
-#: src/amuleDlg.cpp:1185
+#: src/amuleDlg.cpp:1250
 msgid "Exit confirmation"
 msgstr "Bevestig afsluiten"
 
-#: src/amuleDlg.cpp:1548
+#: src/amuleDlg.cpp:1613
 msgid "Launch Command: "
 msgstr "Voer commando uit: "
 
-#: src/amuleDlg.cpp:1567 src/muuli_wdr.cpp:1971 src/Preferences.cpp:951
+#: src/amuleDlg.cpp:1632 src/muuli_wdr.cpp:1978 src/Preferences.cpp:952
 msgid "- default -"
 msgstr "- standaard -"
 
-#: src/amuleDlg.cpp:1595
+#: src/amuleDlg.cpp:1660
 #, c-format
 msgid "Skin directory '%s' does not exist"
 msgstr "Skinmap '%s' bestaat niet"
 
-#: src/amuleDlg.cpp:1598
+#: src/amuleDlg.cpp:1663
 #, c-format
 msgid "WARNING: Unable to open skin file '%s' for read"
 msgstr "WAARSCHUWING: Kon skin-bestand '%s' niet openen om te lezen"
 
-#: src/amuleDlg.cpp:1722 src/amuleDlg.cpp:1968 src/muuli_wdr.cpp:1485
-#: src/muuli_wdr.cpp:3411
-msgid "Networks"
-msgstr "Netwerken"
-
-#: src/amuleDlg.cpp:1726 src/muuli_wdr.cpp:3411
+#: src/amuleDlg.cpp:1791 src/muuli_wdr.cpp:3418
 msgid "Networks Window"
 msgstr "Netwerkvenster"
 
-#: src/amuleDlg.cpp:1728 src/muuli_wdr.cpp:3412
-msgid "Searches"
-msgstr "Zoeken"
-
-#: src/amuleDlg.cpp:1732 src/muuli_wdr.cpp:3412
+#: src/amuleDlg.cpp:1797 src/muuli_wdr.cpp:3419
 msgid "Searches Window"
 msgstr "Zoekvenster"
 
-#: src/amuleDlg.cpp:1734 src/DownloadListCtrl.cpp:740 src/muuli_wdr.cpp:392
-#: src/muuli_wdr.cpp:1578 src/muuli_wdr.cpp:3413 src/Statistics.cpp:829
-msgid "Downloads"
-msgstr "Downloads"
-
-#: src/amuleDlg.cpp:1738 src/muuli_wdr.cpp:3413
+#: src/amuleDlg.cpp:1803 src/muuli_wdr.cpp:3420
 msgid "Downloads Window"
 msgstr "Downloadsvenster"
 
-#: src/amuleDlg.cpp:1740 src/muuli_wdr.cpp:3287
-msgid "Shared files"
-msgstr "Gedeelde bestanden"
-
-#: src/amuleDlg.cpp:1744 src/muuli_wdr.cpp:3415
+#: src/amuleDlg.cpp:1809 src/muuli_wdr.cpp:3422
 msgid "Shared Files Window"
 msgstr "Gedeelde bestanden-venster"
 
-#: src/amuleDlg.cpp:1746 src/muuli_wdr.cpp:2919 src/muuli_wdr.cpp:3369
-#: src/muuli_wdr.cpp:3416
-msgid "Messages"
-msgstr "Berichten"
-
-#: src/amuleDlg.cpp:1750 src/muuli_wdr.cpp:3416
+#: src/amuleDlg.cpp:1815 src/muuli_wdr.cpp:3423
 msgid "Messages Window"
 msgstr "Berichtenvenster"
 
-#: src/amuleDlg.cpp:1752 src/muuli_wdr.cpp:3417 src/PrefsUnifiedDlg.cpp:312
-#: src/Statistics.cpp:779 src/Statistics.cpp:1235
-msgid "Statistics"
-msgstr "Statistieken"
-
-#: src/amuleDlg.cpp:1756 src/muuli_wdr.cpp:3417
+#: src/amuleDlg.cpp:1821 src/muuli_wdr.cpp:3424
 msgid "Statistics Graph Window"
 msgstr "Statistiekenvenster (Grafieken)"
 
-#: src/amuleDlg.cpp:1759 src/muuli_wdr.cpp:3419 src/PrefsUnifiedDlg.cpp:328
-#: src/utils/wxCas/src/wxcasprefs.cpp:39
-msgid "Preferences"
-msgstr "Voorkeuren"
-
-#: src/amuleDlg.cpp:1763 src/muuli_wdr.cpp:3419
+#: src/amuleDlg.cpp:1828 src/muuli_wdr.cpp:3426
 msgid "Preferences Settings Window"
 msgstr "Voorkeureninstellingen-venster"
 
-#: src/amuleDlg.cpp:1766 src/muuli_wdr.cpp:3420
+#: src/amuleDlg.cpp:1831 src/muuli_wdr.cpp:3427
 msgid "Import"
 msgstr "Importeer"
 
-#: src/amuleDlg.cpp:1770 src/muuli_wdr.cpp:3420
+#: src/amuleDlg.cpp:1835 src/muuli_wdr.cpp:3427
 msgid "The partfile importer tool"
 msgstr "Het deelbestand importeerprogramma"
 
-#: src/amuleDlg.cpp:1773 src/muuli_wdr.cpp:3421
+#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3428
 #: src/utils/aLinkCreator/src/alcframe.cpp:262
 msgid "About"
 msgstr "Over"
 
-#: src/amuleDlg.cpp:1773 src/muuli_wdr.cpp:3421
+#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3428
 msgid "About/Help"
 msgstr "Over/Help"
 
-#: src/amuleDlg.cpp:1971
+#: src/amuleDlg.cpp:2036
 msgid "eD2k network"
 msgstr "eD2k-netwerk"
 
-#: src/amuleDlg.cpp:1974
+#: src/amuleDlg.cpp:2039
 msgid "Kad network"
 msgstr "Kad netwerk"
 
-#: src/amuleDlg.cpp:1974
+#: src/amuleDlg.cpp:2039
 msgid "No network"
 msgstr "Geen netwerk"
 
@@ -1352,19 +1357,19 @@ msgstr "Auto [Ho]"
 msgid "Very low"
 msgstr "Heel laag"
 
-#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:743 src/muuli_wdr.cpp:2275
+#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:743 src/muuli_wdr.cpp:2282
 #: src/ServerListCtrl.cpp:263 src/ServerListCtrl.cpp:456
 #: src/SharedFilesCtrl.cpp:145
 msgid "Low"
 msgstr "Laag"
 
-#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:744 src/muuli_wdr.cpp:2276
+#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:744 src/muuli_wdr.cpp:2283
 #: src/ServerListCtrl.cpp:266 src/ServerListCtrl.cpp:457
 #: src/SharedFilesCtrl.cpp:146
 msgid "Normal"
 msgstr "Normaal"
 
-#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:745 src/muuli_wdr.cpp:2277
+#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:745 src/muuli_wdr.cpp:2284
 #: src/ServerListCtrl.cpp:269 src/ServerListCtrl.cpp:458
 #: src/SharedFilesCtrl.cpp:147
 msgid "High"
@@ -1456,8 +1461,8 @@ msgstr "Lokale server"
 msgid "Remote Server"
 msgstr "Server op Afstand"
 
-#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3174
-#: src/SearchDlg.cpp:111 src/TextClient.cpp:911
+#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3181
+#: src/SearchDlg.cpp:119 src/TextClient.cpp:911
 msgid "Kad"
 msgstr "Kad"
 
@@ -1528,7 +1533,7 @@ msgstr "Deel"
 msgid "Size"
 msgstr "Grootte"
 
-#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3241
+#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3248
 msgid "Transferred"
 msgstr "Overgebracht"
 
@@ -1586,7 +1591,7 @@ msgstr ""
 "Feedback van: %s (%s)\n"
 "\n"
 
-#: src/DownloadListCtrl.cpp:746 src/muuli_wdr.cpp:2278
+#: src/DownloadListCtrl.cpp:746 src/muuli_wdr.cpp:2285
 #: src/SharedFilesCtrl.cpp:150
 msgid "Auto"
 msgstr "Auto"
@@ -1624,7 +1629,7 @@ msgid "Extended Options"
 msgstr "Uitgebreide opties"
 
 #: src/DownloadListCtrl.cpp:770 src/DownloadListCtrl.cpp:822
-#: src/muuli_wdr.cpp:1789
+#: src/muuli_wdr.cpp:1796
 msgid "Preview"
 msgstr "Voorbeeld"
 
@@ -2337,19 +2342,19 @@ msgstr ""
 msgid "eD2k"
 msgstr "eD2k"
 
-#: src/FirstRunWizard.cpp:349 src/muuli_wdr.cpp:1488
+#: src/FirstRunWizard.cpp:349 src/muuli_wdr.cpp:1495
 msgid "Kademlia"
 msgstr "Kademlia"
 
-#: src/FirstRunWizard.cpp:359 src/muuli_wdr.cpp:1416
+#: src/FirstRunWizard.cpp:359 src/muuli_wdr.cpp:1423
 msgid "Standard TCP Port "
 msgstr "Standaard TCP-poort "
 
-#: src/FirstRunWizard.cpp:365 src/muuli_wdr.cpp:1428
+#: src/FirstRunWizard.cpp:365 src/muuli_wdr.cpp:1435
 msgid "Extended UDP port (Kad / global search) "
 msgstr "Uitgebreide UDP-poort (Kad / globaal zoeken) "
 
-#: src/FirstRunWizard.cpp:377 src/muuli_wdr.cpp:1435
+#: src/FirstRunWizard.cpp:377 src/muuli_wdr.cpp:1442
 msgid "Enable UPnP for router port forwarding"
 msgstr "Schakel UPnP voor router portforwarding in"
 
@@ -2376,7 +2381,7 @@ msgstr ""
 msgid "Your peer lists are already in place - nothing to download."
 msgstr "U probeert het bestand %s al te downloaden"
 
-#: src/FirstRunWizard.cpp:434 src/muuli_wdr.cpp:1533
+#: src/FirstRunWizard.cpp:434 src/muuli_wdr.cpp:1540
 msgid "Auto-update server list at startup"
 msgstr "Auto-update serverlijst bij het opstarten"
 
@@ -2422,23 +2427,23 @@ msgid ""
 "want downloads on a different (e.g. larger) disk."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:549 src/FirstRunWizard.cpp:611 src/muuli_wdr.cpp:1701
+#: src/FirstRunWizard.cpp:549 src/FirstRunWizard.cpp:611 src/muuli_wdr.cpp:1708
 msgid "Destination folder for downloads"
 msgstr "Doelmap voor downloads"
 
-#: src/FirstRunWizard.cpp:553 src/FirstRunWizard.cpp:569 src/muuli_wdr.cpp:1342
-#: src/muuli_wdr.cpp:1359 src/muuli_wdr.cpp:1676 src/muuli_wdr.cpp:1707
-#: src/muuli_wdr.cpp:1719 src/muuli_wdr.cpp:2762
+#: src/FirstRunWizard.cpp:553 src/FirstRunWizard.cpp:569 src/muuli_wdr.cpp:1349
+#: src/muuli_wdr.cpp:1366 src/muuli_wdr.cpp:1683 src/muuli_wdr.cpp:1714
+#: src/muuli_wdr.cpp:1726 src/muuli_wdr.cpp:2769
 #: src/utils/aLinkCreator/src/alcframe.cpp:135
 #: src/utils/wxCas/src/wxcasprefs.cpp:52 src/utils/wxCas/src/wxcasprefs.cpp:118
 msgid "Browse"
 msgstr "Bladeren"
 
-#: src/FirstRunWizard.cpp:559 src/muuli_wdr.cpp:1712
+#: src/FirstRunWizard.cpp:559 src/muuli_wdr.cpp:1719
 msgid "(All files in this folder are shared with other peers)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:565 src/FirstRunWizard.cpp:624 src/muuli_wdr.cpp:1714
+#: src/FirstRunWizard.cpp:565 src/FirstRunWizard.cpp:624 src/muuli_wdr.cpp:1721
 msgid "Folder for temporary download files"
 msgstr "Map voor tijdelijke downloadbestanden"
 
@@ -2469,7 +2474,7 @@ msgstr "Kon niet schrijven naar vriendenlijst-bestand 'emfriends.met'!"
 msgid "CRITICAL - no client on StartChatSession"
 msgstr "KRITIEK - geen client bij StartChatSession"
 
-#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2668 src/muuli_wdr.cpp:3345
+#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2675 src/muuli_wdr.cpp:3352
 msgid "Friends"
 msgstr "Vrienden"
 
@@ -2855,7 +2860,7 @@ msgstr "Deelverhouding"
 msgid "Uploaded"
 msgstr "Geüpload"
 
-#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3225
+#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3232
 msgid "Requested"
 msgstr "Aangevraagd"
 
@@ -2979,7 +2984,7 @@ msgid "WARNING: "
 msgstr "WAARSCHUWING: "
 
 #: src/MuleNotebook.cpp:179 src/muuli_wdr.cpp:817 src/muuli_wdr.cpp:1229
-#: src/muuli_wdr.cpp:3129 src/muuli_wdr.cpp:3385
+#: src/muuli_wdr.cpp:3136 src/muuli_wdr.cpp:3392
 msgid "Close"
 msgstr "Sluiten"
 
@@ -2992,12 +2997,12 @@ msgstr "Knippen"
 msgid "Copy"
 msgstr "Kopiëren"
 
-#: src/MuleTextCtrl.cpp:88
+#: src/MuleTextCtrl.cpp:88 src/SearchDlg.cpp:261
 msgid "Paste"
 msgstr "Plakken"
 
 #: src/MuleTextCtrl.cpp:89 src/muuli_wdr.cpp:358 src/muuli_wdr.cpp:757
-#: src/muuli_wdr.cpp:2352 src/muuli_wdr.cpp:2371 src/muuli_wdr.cpp:2393
+#: src/muuli_wdr.cpp:2359 src/muuli_wdr.cpp:2378 src/muuli_wdr.cpp:2400
 #: src/utils/aLinkCreator/src/alcframe.cpp:142
 msgid "Clear"
 msgstr "Wissen"
@@ -3095,8 +3100,8 @@ msgid "Exit"
 msgstr "Afsluiten"
 
 #: src/MuleTrayIcon.cpp:579 src/MuleTrayIcon.cpp:945 src/MuleTrayIcon.cpp:965
-#: src/muuli_wdr.cpp:1391 src/muuli_wdr.cpp:1399 src/muuli_wdr.cpp:1406
-#: src/muuli_wdr.cpp:1835 src/muuli_wdr.cpp:1841 src/OtherFunctions.cpp:91
+#: src/muuli_wdr.cpp:1398 src/muuli_wdr.cpp:1406 src/muuli_wdr.cpp:1413
+#: src/muuli_wdr.cpp:1842 src/muuli_wdr.cpp:1848 src/OtherFunctions.cpp:91
 #: src/StatisticsDlg.cpp:93 src/StatisticsDlg.cpp:95
 msgid "kB/s"
 msgstr "kB/s"
@@ -3268,7 +3273,7 @@ msgstr "Naam:"
 msgid "Type"
 msgstr "Type"
 
-#: src/muuli_wdr.cpp:215 src/SearchDlg.cpp:110 src/SearchListCtrl.cpp:853
+#: src/muuli_wdr.cpp:215 src/SearchDlg.cpp:118 src/SearchListCtrl.cpp:853
 msgid "Local"
 msgstr "Lokaal"
 
@@ -3339,7 +3344,7 @@ msgstr "Bytes"
 msgid "KB"
 msgstr "KB"
 
-#: src/muuli_wdr.cpp:274 src/muuli_wdr.cpp:293 src/muuli_wdr.cpp:1620
+#: src/muuli_wdr.cpp:274 src/muuli_wdr.cpp:293 src/muuli_wdr.cpp:1627
 #: src/OtherFunctions.cpp:64
 msgid "MB"
 msgstr "MB"
@@ -3356,7 +3361,7 @@ msgstr "Max grootte"
 msgid "Availability"
 msgstr "Beschikbaarheid"
 
-#: src/muuli_wdr.cpp:312 src/muuli_wdr.cpp:398 src/muuli_wdr.cpp:3290
+#: src/muuli_wdr.cpp:312 src/muuli_wdr.cpp:398 src/muuli_wdr.cpp:3297
 msgid "Filter:"
 msgstr "Filter:"
 
@@ -3388,7 +3393,7 @@ msgstr ""
 msgid "Stop"
 msgstr "Stop"
 
-#: src/muuli_wdr.cpp:348 src/muuli_wdr.cpp:1385 src/SearchListCtrl.cpp:732
+#: src/muuli_wdr.cpp:348 src/muuli_wdr.cpp:1392 src/SearchListCtrl.cpp:732
 msgid "Download"
 msgstr "Download"
 
@@ -3419,8 +3424,8 @@ msgstr "Bestandsbronnen:"
 #: src/muuli_wdr.cpp:1160 src/muuli_wdr.cpp:1167 src/muuli_wdr.cpp:1172
 #: src/muuli_wdr.cpp:1179 src/muuli_wdr.cpp:1184 src/muuli_wdr.cpp:1191
 #: src/muuli_wdr.cpp:1205 src/muuli_wdr.cpp:1212 src/muuli_wdr.cpp:1217
-#: src/muuli_wdr.cpp:1224 src/muuli_wdr.cpp:3227 src/muuli_wdr.cpp:3235
-#: src/muuli_wdr.cpp:3243
+#: src/muuli_wdr.cpp:1224 src/muuli_wdr.cpp:3234 src/muuli_wdr.cpp:3242
+#: src/muuli_wdr.cpp:3250
 msgid "N/A"
 msgstr "N/B"
 
@@ -3565,7 +3570,7 @@ msgstr ""
 msgid "Album :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:685 src/muuli_wdr.cpp:2247
+#: src/muuli_wdr.cpp:685 src/muuli_wdr.cpp:2254
 msgid "Title :"
 msgstr "Titel :"
 
@@ -3674,7 +3679,7 @@ msgstr "Gebruikersnaam :"
 msgid "Userhash :"
 msgstr "Gebruikershash :"
 
-#: src/muuli_wdr.cpp:895 src/muuli_wdr.cpp:1741 src/muuli_wdr.cpp:2442
+#: src/muuli_wdr.cpp:895 src/muuli_wdr.cpp:1748 src/muuli_wdr.cpp:2449
 #: src/utils/aLinkCreator/src/alcframe.cpp:137
 msgid "Add"
 msgstr "Toevoegen"
@@ -3683,15 +3688,15 @@ msgstr "Toevoegen"
 msgid "Download-Speed"
 msgstr "Downloadsnelheid"
 
-#: src/muuli_wdr.cpp:954 src/muuli_wdr.cpp:989 src/muuli_wdr.cpp:2546
+#: src/muuli_wdr.cpp:954 src/muuli_wdr.cpp:989 src/muuli_wdr.cpp:2553
 msgid "Current"
 msgstr "Huidige"
 
-#: src/muuli_wdr.cpp:962 src/muuli_wdr.cpp:997 src/muuli_wdr.cpp:2554
+#: src/muuli_wdr.cpp:962 src/muuli_wdr.cpp:997 src/muuli_wdr.cpp:2561
 msgid "Running average"
 msgstr "Lopende gemiddelde"
 
-#: src/muuli_wdr.cpp:970 src/muuli_wdr.cpp:1005 src/muuli_wdr.cpp:2562
+#: src/muuli_wdr.cpp:970 src/muuli_wdr.cpp:1005 src/muuli_wdr.cpp:2569
 msgid "Session average"
 msgstr "Sessie gemiddelde"
 
@@ -3703,7 +3708,7 @@ msgstr "Uploadsnelheid"
 msgid "Connections"
 msgstr "Verbindingen"
 
-#: src/muuli_wdr.cpp:1024 src/muuli_wdr.cpp:1860
+#: src/muuli_wdr.cpp:1024 src/muuli_wdr.cpp:1867
 msgid "Active downloads"
 msgstr "Actieve downloads"
 
@@ -3711,7 +3716,7 @@ msgstr "Actieve downloads"
 msgid "Active connections (1:1)"
 msgstr "Actieve verbinding (1:1)"
 
-#: src/muuli_wdr.cpp:1040 src/muuli_wdr.cpp:1861
+#: src/muuli_wdr.cpp:1040 src/muuli_wdr.cpp:1868
 msgid "Active uploads"
 msgstr "Actieve uploads"
 
@@ -3827,8 +3832,8 @@ msgstr "Dit is de naam die andere gebruikers zien wanneer ze met u verbinden."
 msgid "Language: "
 msgstr "Taal: "
 
-#: src/muuli_wdr.cpp:1257 src/muuli_wdr.cpp:1323 src/muuli_wdr.cpp:1327
-#: src/muuli_wdr.cpp:1330
+#: src/muuli_wdr.cpp:1257 src/muuli_wdr.cpp:1330 src/muuli_wdr.cpp:1334
+#: src/muuli_wdr.cpp:1337
 msgid "The delay before showing tool-tips."
 msgstr "De vertraging voordat tooltips worden getoond."
 
@@ -3906,936 +3911,945 @@ msgstr "Toon een melding wanneer een download klaar is"
 msgid "Enabling this will make aMule to show notifications when finished downloading."
 msgstr "Wanneer dit ingeschakeld is zal aMule een melding tonen wanneer een download klaar is."
 
-#: src/muuli_wdr.cpp:1322
+#: src/muuli_wdr.cpp:1323
+#, fuzzy
+msgid "Remember search history"
+msgstr "Onthoud deze instellingen"
+
+#: src/muuli_wdr.cpp:1324
+msgid "Keeps a dropdown list of your past search terms in the Search tab's Name field. This remembers the queries you typed, not the results they returned."
+msgstr ""
+
+#: src/muuli_wdr.cpp:1329
 msgid "Tooltip delay time: "
 msgstr "Tooltip vertragingstijd: "
 
-#: src/muuli_wdr.cpp:1329
+#: src/muuli_wdr.cpp:1336
 msgid "seconds"
 msgstr "seconden"
 
-#: src/muuli_wdr.cpp:1333
+#: src/muuli_wdr.cpp:1340
 msgid "Browser Selection"
 msgstr "Browserselectie"
 
-#: src/muuli_wdr.cpp:1339
+#: src/muuli_wdr.cpp:1346
 msgid "Enter your browser name here. Leave this field empty to use the system default browser."
 msgstr "Voer hier uw browsernaam in. Laat dit veld leeg om de standaardbrowser van uw systeem te gebruiken."
 
-#: src/muuli_wdr.cpp:1346
+#: src/muuli_wdr.cpp:1353
 msgid "Open in new tab if possible"
 msgstr "Open in nieuw tabblad indien mogelijk"
 
-#: src/muuli_wdr.cpp:1348
+#: src/muuli_wdr.cpp:1355
 msgid "Open the web page in a new tab instead of in a new window when possible"
 msgstr "Open de webpagina, indien mogelijk, in een nieuw tabblad in plaats van in een nieuw venster"
 
-#: src/muuli_wdr.cpp:1352
+#: src/muuli_wdr.cpp:1359
 msgid "Video Player"
 msgstr "Videospeler"
 
-#: src/muuli_wdr.cpp:1379
+#: src/muuli_wdr.cpp:1386
 msgid "Bandwidth limits"
 msgstr "Bandbreedtegrenzen"
 
-#: src/muuli_wdr.cpp:1393
+#: src/muuli_wdr.cpp:1400
 msgid "Upload"
 msgstr "Upload"
 
-#: src/muuli_wdr.cpp:1401
+#: src/muuli_wdr.cpp:1408
 msgid "Slot Allocation"
 msgstr "Slot-toewijzing"
 
-#: src/muuli_wdr.cpp:1410
+#: src/muuli_wdr.cpp:1417
 msgid "Ports"
 msgstr "Poorten"
 
-#: src/muuli_wdr.cpp:1420
+#: src/muuli_wdr.cpp:1427
 msgid "This is the standard eD2k port and cannot be disabled."
 msgstr "Dit is de standaard eD2k-poort en kan niet uitgeschakeld worden."
 
-#: src/muuli_wdr.cpp:1423
+#: src/muuli_wdr.cpp:1430
 msgid "UDP port for server requests (TCP+3):"
 msgstr "UDP-poort voor server aanvragen (TCP+3):"
 
-#: src/muuli_wdr.cpp:1425
+#: src/muuli_wdr.cpp:1432
 msgid "4665"
 msgstr "4665"
 
-#: src/muuli_wdr.cpp:1432
+#: src/muuli_wdr.cpp:1439
 msgid "This UDP port is used for extended eD2k requests and Kad network"
 msgstr "Deze UDP-poort wordt gebruikt voor uitgebreide eD2k-aanvragen en het Kad-netwerk"
 
-#: src/muuli_wdr.cpp:1439
+#: src/muuli_wdr.cpp:1446
 msgid "UPnP TCP Port (Optional):"
 msgstr "UPnP TCP-Poort (optioneel):"
 
-#: src/muuli_wdr.cpp:1449
+#: src/muuli_wdr.cpp:1456
 msgid "Bind local address to IP (empty for any):"
 msgstr "Bind lokaal adres aan IP (laat leeg voor elk):"
 
-#: src/muuli_wdr.cpp:1452
+#: src/muuli_wdr.cpp:1459
 msgid "Advanced users only: If you have multiple network interfaces, enter the address of the interface to which aMule should be bound."
 msgstr "Enkel voor gevorderde gebruikers: Als u meerdere netwerk-interfaces hebt, voer hier het adres in van de interface waar aMule mee verbonden moet worden."
 
-#: src/muuli_wdr.cpp:1455 src/muuli_wdr.cpp:2054
+#: src/muuli_wdr.cpp:1462 src/muuli_wdr.cpp:2061
 #, fuzzy
 msgid "Bind to network interface (empty for any):"
 msgstr "Bind lokaal adres aan IP (laat leeg voor elk):"
 
-#: src/muuli_wdr.cpp:1468
+#: src/muuli_wdr.cpp:1475
 msgid "Advanced users only: pin all of aMule's traffic to one network interface, chosen from the list or typed in by name (e.g. tun0, eth0, en0) or index. Unlike binding to an IP, this stops traffic leaking out via the default route - useful with a VPN. Requires no elevated privileges."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1474
+#: src/muuli_wdr.cpp:1481
 msgid "Max sources per downloading file:"
 msgstr "Max bronnen per bestand aan het downloaden:"
 
-#: src/muuli_wdr.cpp:1478
+#: src/muuli_wdr.cpp:1485
 msgid "Max simultaneous connections:"
 msgstr "Max gelijktijdige verbindingen:"
 
-#: src/muuli_wdr.cpp:1491 src/muuli_wdr.cpp:3169
+#: src/muuli_wdr.cpp:1498 src/muuli_wdr.cpp:3176
 msgid "ED2K"
 msgstr "ED2K"
 
-#: src/muuli_wdr.cpp:1498
+#: src/muuli_wdr.cpp:1505
 msgid "Autoconnect on startup"
 msgstr "Autoverbind bij het opstarten"
 
-#: src/muuli_wdr.cpp:1501
+#: src/muuli_wdr.cpp:1508
 msgid "Reconnect on loss"
 msgstr "Verbind opnieuw bij verbroken verbinding"
 
-#: src/muuli_wdr.cpp:1523
+#: src/muuli_wdr.cpp:1530
 msgid "Remove dead server after"
 msgstr "Verwijder dode server na"
 
-#: src/muuli_wdr.cpp:1524
+#: src/muuli_wdr.cpp:1531
 msgid "Static servers are never removed, even when unreachable."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1528
+#: src/muuli_wdr.cpp:1535
 msgid "retries"
 msgstr "pogingen"
 
-#: src/muuli_wdr.cpp:1536
+#: src/muuli_wdr.cpp:1543
 msgid "List"
 msgstr "Lijst"
 
-#: src/muuli_wdr.cpp:1539
+#: src/muuli_wdr.cpp:1546
 msgid "Update server list when connecting to a server"
 msgstr "Update serverlijst bij het verbinden met een server"
 
-#: src/muuli_wdr.cpp:1542
+#: src/muuli_wdr.cpp:1549
 msgid "Update server list when a client connects"
 msgstr "Update serverlijst wanneer een client verbindt"
 
-#: src/muuli_wdr.cpp:1545
+#: src/muuli_wdr.cpp:1552
 msgid "Use priority system"
 msgstr "Gebruik prioriteitssysteem"
 
-#: src/muuli_wdr.cpp:1549
+#: src/muuli_wdr.cpp:1556
 msgid "Use smart LowID check on connect"
 msgstr "Gebruik slimme laag-ID controle bij verbinden"
 
-#: src/muuli_wdr.cpp:1553
+#: src/muuli_wdr.cpp:1560
 msgid "Safe connect"
 msgstr "Veilig verbinden"
 
-#: src/muuli_wdr.cpp:1557
+#: src/muuli_wdr.cpp:1564
 msgid "Autoconnect to servers in static list only"
 msgstr "Autoverbind alleen met servers in statische lijst"
 
-#: src/muuli_wdr.cpp:1560
+#: src/muuli_wdr.cpp:1567
 msgid "Set manually added servers to High Priority"
 msgstr "Zet handmatig toegevoegde servers op hoge prioriteit"
 
-#: src/muuli_wdr.cpp:1581
+#: src/muuli_wdr.cpp:1588
 msgid "Add files to download in pause mode"
 msgstr "Voeg bestanden aan downloads toe in pauze-modus"
 
-#: src/muuli_wdr.cpp:1583
+#: src/muuli_wdr.cpp:1590
 msgid "Add files to download with auto priority"
 msgstr "Voeg bestanden aan downloads toe met automatische prioriteit"
 
-#: src/muuli_wdr.cpp:1586
+#: src/muuli_wdr.cpp:1593
 msgid "Try to download first and last chunks first"
 msgstr "Probeer eerste en laatste delen eerst te downloaden"
 
-#: src/muuli_wdr.cpp:1590
+#: src/muuli_wdr.cpp:1597
 msgid "Endgame mode: rotate to faster sources for the final blocks"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1593
+#: src/muuli_wdr.cpp:1600
 msgid "Start next paused file when a file completes"
 msgstr "Start volgend gepauzeerd bestand als een bestand compleet is"
 
-#: src/muuli_wdr.cpp:1596
+#: src/muuli_wdr.cpp:1603
 msgid "From the same category"
 msgstr "Uit dezelfde categorie"
 
-#: src/muuli_wdr.cpp:1598
+#: src/muuli_wdr.cpp:1605
 msgid "In alphabetic order"
 msgstr "In alfabetische volgorde"
 
-#: src/muuli_wdr.cpp:1600
+#: src/muuli_wdr.cpp:1607
 msgid "Preallocate disk space for new files"
 msgstr "Wijst schijfruimte toe voor nieuwe bestanden"
 
-#: src/muuli_wdr.cpp:1601
+#: src/muuli_wdr.cpp:1608
 msgid "For new files preallocates disk space for the whole file, thus reduces fragmentation"
 msgstr "Wijst schijfruimte toe voor nieuwe bestanden, beperkt hierdoor fragmentatie"
 
-#: src/muuli_wdr.cpp:1606
+#: src/muuli_wdr.cpp:1613
 msgid "Create new files as sparse files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1607
+#: src/muuli_wdr.cpp:1614
 msgid "A sparse file reserves its full size on disk immediately without writing real data to it -- fast, but unsupported or slow on some filesystems, and free-space accounting stays optimistic while the download is in progress. Turn this off to grow the file only as data arrives."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1612
+#: src/muuli_wdr.cpp:1619
 msgid "Stop downloads when free disk space reaches "
 msgstr "Stop downloads als de vrije schijfruimte bedraagt "
 
-#: src/muuli_wdr.cpp:1613
+#: src/muuli_wdr.cpp:1620
 msgid "Select this if you want aMule to check your disk space"
 msgstr "Selecteer dit als u wilt dat aMule uw schijfruimte controleert"
 
-#: src/muuli_wdr.cpp:1617
+#: src/muuli_wdr.cpp:1624
 msgid "Enter here the min disk space desired."
 msgstr "Voer hier de gewenste min schijfruimte in."
 
-#: src/muuli_wdr.cpp:1623
+#: src/muuli_wdr.cpp:1630
 msgid "Save 10 sources on rare files (< 20 sources)"
 msgstr "Bewaar 10 bronnen van zeldzame bestanden (<20 bronnen)"
 
-#: src/muuli_wdr.cpp:1627 src/Statistics.cpp:790
+#: src/muuli_wdr.cpp:1634 src/Statistics.cpp:790
 msgid "Uploads"
 msgstr "Uploads"
 
-#: src/muuli_wdr.cpp:1630
+#: src/muuli_wdr.cpp:1637
 msgid "Add new shared files with auto priority"
 msgstr "Voeg nieuwe gedeelde bestanden toe met automatische prioriteit"
 
-#: src/muuli_wdr.cpp:1636
+#: src/muuli_wdr.cpp:1643
 msgid "Intelligent Corruption Handling (I.C.H.)"
 msgstr "Intelligente corruptieafhandling (I.C.H.)"
 
-#: src/muuli_wdr.cpp:1639
+#: src/muuli_wdr.cpp:1646
 msgid "Enable"
 msgstr "Inschakelen"
 
-#: src/muuli_wdr.cpp:1642
+#: src/muuli_wdr.cpp:1649
 msgid "Advanced I.C.H. trusts every hash (not recommended)"
 msgstr "Geavanceerde I.C.H. vertrouwt elke hash (niet aanbevolen)"
 
-#: src/muuli_wdr.cpp:1654 src/PrefsUnifiedDlg.cpp:1910
+#: src/muuli_wdr.cpp:1661 src/PrefsUnifiedDlg.cpp:1910
 msgid "Media metadata extraction"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1658
+#: src/muuli_wdr.cpp:1665
 msgid "Extract length / bitrate / codec from shared audio and video files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1660
+#: src/muuli_wdr.cpp:1667
 msgid "When enabled, aMule runs ffprobe on each shared media file to fill in the Length / Bitrate / Codec columns other clients see when they find the file in a search. Requires ffmpeg (the ffprobe binary) to be installed."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1667
+#: src/muuli_wdr.cpp:1674
 msgid "Path to ffprobe:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1672
+#: src/muuli_wdr.cpp:1679
 msgid "Full path to the ffprobe binary. Leave empty to have aMule auto-detect it on startup."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1680
+#: src/muuli_wdr.cpp:1687
 msgid "Detect"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1681
+#: src/muuli_wdr.cpp:1688
 msgid "Search the standard install locations for an ffprobe binary and fill the path field."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1705
+#: src/muuli_wdr.cpp:1712
 msgid ""
 "Completed downloads are stored here. All files in this folder are automatically shared with other peers.\n"
 "If this folder also holds files you don't want to share, point it at an aMule-only sub-folder."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1708
+#: src/muuli_wdr.cpp:1715
 msgid "Pick the folder where completed downloads will be stored. All files in that folder will be shared with other peers."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1722
+#: src/muuli_wdr.cpp:1729
 msgid "Shared folders"
 msgstr "Gedeelde mappen"
 
-#: src/muuli_wdr.cpp:1728
+#: src/muuli_wdr.cpp:1735
 msgid "(Folders shared by the core. Enter a path to add one.)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1736
+#: src/muuli_wdr.cpp:1743
 msgid "Absolute path of a folder on the core's machine, e.g. /home/user/shared"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1738 src/PrefsUnifiedDlg.cpp:2794
+#: src/muuli_wdr.cpp:1745 src/PrefsUnifiedDlg.cpp:2794
 msgid "Recursive"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1739
+#: src/muuli_wdr.cpp:1746
 msgid "Share every sub-folder underneath this one, including ones created later."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1743 src/utils/aLinkCreator/src/alcframe.cpp:141
+#: src/muuli_wdr.cpp:1750 src/utils/aLinkCreator/src/alcframe.cpp:141
 msgid "Remove"
 msgstr "Verwijder"
 
-#: src/muuli_wdr.cpp:1747
+#: src/muuli_wdr.cpp:1754
 msgid "(Right click on folder icon for recursive share)"
 msgstr "(Rechtermuisklik op mappictogram om recursief te delen)"
 
-#: src/muuli_wdr.cpp:1754
+#: src/muuli_wdr.cpp:1761
 msgid "Share hidden files"
 msgstr "Deel verborgen bestanden"
 
-#: src/muuli_wdr.cpp:1760
+#: src/muuli_wdr.cpp:1767
 msgid "Automatically rescan shared folders for changes"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1766
+#: src/muuli_wdr.cpp:1773
 msgid "Follow symbolic links in shared folders"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1772
+#: src/muuli_wdr.cpp:1779
 msgid "Exclude files matching:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1775
+#: src/muuli_wdr.cpp:1782
 msgid "Wildcard patterns separated by '|', e.g. .DS_Store|Thumbs.db|*.tmp. Files whose name matches are not shared. Matching is case-insensitive."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1779
+#: src/muuli_wdr.cpp:1786
 msgid "Patterns are regular expressions"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1780
+#: src/muuli_wdr.cpp:1787
 msgid "When set, the whole field is one regular expression ('|' is alternation). When unset, it is a list of '|'-separated wildcards."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1790
+#: src/muuli_wdr.cpp:1797
 msgid "Show how many shared files the current pattern would exclude."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1811
+#: src/muuli_wdr.cpp:1818
 msgid "Graphs"
 msgstr "Grafieken"
 
-#: src/muuli_wdr.cpp:1814 src/muuli_wdr.cpp:1876
+#: src/muuli_wdr.cpp:1821 src/muuli_wdr.cpp:1883
 msgid "Update delay : 5 secs"
 msgstr "Update-vertraging : 5 seconden"
 
-#: src/muuli_wdr.cpp:1818
+#: src/muuli_wdr.cpp:1825
 msgid "Time for average graph: 100 mins"
 msgstr "Tijd voor gemiddeldengrafiek: 100 minuten"
 
-#: src/muuli_wdr.cpp:1822
+#: src/muuli_wdr.cpp:1829
 msgid "Connections Graph Scale: 100 "
 msgstr "Schaal verbindingengrafiek: 100 "
 
-#: src/muuli_wdr.cpp:1829
+#: src/muuli_wdr.cpp:1836
 msgid "Download graph scale:"
 msgstr "Schaal downloadgrafiek:"
 
-#: src/muuli_wdr.cpp:1837
+#: src/muuli_wdr.cpp:1844
 msgid "Upload graph scale:"
 msgstr "Schaal uploadgrafiek:"
 
-#: src/muuli_wdr.cpp:1847
+#: src/muuli_wdr.cpp:1854
 #, fuzzy
 msgid "Colors: "
 msgstr "Kleuren: "
 
-#: src/muuli_wdr.cpp:1851
+#: src/muuli_wdr.cpp:1858
 msgid "Background"
 msgstr "Achtergrond"
 
-#: src/muuli_wdr.cpp:1852
+#: src/muuli_wdr.cpp:1859
 msgid "Grid"
 msgstr "Raster"
 
-#: src/muuli_wdr.cpp:1853
+#: src/muuli_wdr.cpp:1860
 msgid "Download current"
 msgstr "Huidige download"
 
-#: src/muuli_wdr.cpp:1854
+#: src/muuli_wdr.cpp:1861
 msgid "Download running average"
 msgstr "Lopend gemiddelde download"
 
-#: src/muuli_wdr.cpp:1855
+#: src/muuli_wdr.cpp:1862
 msgid "Download session average"
 msgstr "Sessie gemiddelde download"
 
-#: src/muuli_wdr.cpp:1856
+#: src/muuli_wdr.cpp:1863
 msgid "Upload current"
 msgstr "Huidige upload"
 
-#: src/muuli_wdr.cpp:1857
+#: src/muuli_wdr.cpp:1864
 msgid "Upload running average"
 msgstr "Lopend gemiddelde upload"
 
-#: src/muuli_wdr.cpp:1858
+#: src/muuli_wdr.cpp:1865
 msgid "Upload session average"
 msgstr "Sessie gemiddelde upload"
 
-#: src/muuli_wdr.cpp:1859
+#: src/muuli_wdr.cpp:1866
 msgid "Active connections"
 msgstr "Actieve verbindingen"
 
-#: src/muuli_wdr.cpp:1862
+#: src/muuli_wdr.cpp:1869
 #, fuzzy
 msgid "Systray Icon Speed Bar"
 msgstr "Systeemvak-pictogram met snelheidsbalk"
 
-#: src/muuli_wdr.cpp:1863
+#: src/muuli_wdr.cpp:1870
 msgid "Kad-nodes current"
 msgstr "Kad-nodes huidig"
 
-#: src/muuli_wdr.cpp:1864
+#: src/muuli_wdr.cpp:1871
 msgid "Kad-nodes running"
 msgstr "Kad-nodes draaiende"
 
-#: src/muuli_wdr.cpp:1865
+#: src/muuli_wdr.cpp:1872
 msgid "Kad-nodes session"
 msgstr "Kad-nodes sessie"
 
-#: src/muuli_wdr.cpp:1869 src/muuli_wdr.cpp:2296
+#: src/muuli_wdr.cpp:1876 src/muuli_wdr.cpp:2303
 msgid "Select"
 msgstr "Selecteer"
 
-#: src/muuli_wdr.cpp:1873
+#: src/muuli_wdr.cpp:1880
 msgid "Tree"
 msgstr "Boom"
 
-#: src/muuli_wdr.cpp:1883
+#: src/muuli_wdr.cpp:1890
 msgid "Number of Client Versions shown (0=unlimited)"
 msgstr "Aantal getoonde client-versies (0=onbegrensd)"
 
-#: src/muuli_wdr.cpp:1908
+#: src/muuli_wdr.cpp:1915
 msgid "!!! WARNING !!!"
 msgstr "!!! WAARSCHUWING !!!"
 
-#: src/muuli_wdr.cpp:1923
+#: src/muuli_wdr.cpp:1930
 msgid "Max new connections / 5 secs"
 msgstr "Max nieuwe verbindingen / 5 seconden"
 
-#: src/muuli_wdr.cpp:1925
+#: src/muuli_wdr.cpp:1932
 msgid "Concurrent Kad source lookups"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1927
+#: src/muuli_wdr.cpp:1934
 #, fuzzy
 msgid "Kad source re-search interval (minutes)"
 msgstr "Tijd tussen de FTP-updates in minuten"
 
-#: src/muuli_wdr.cpp:1929
+#: src/muuli_wdr.cpp:1936
 #, fuzzy
 msgid "Source re-ask interval (minutes)"
 msgstr "Tijd tussen de FTP-updates in minuten"
 
-#: src/muuli_wdr.cpp:1933
+#: src/muuli_wdr.cpp:1940
 msgid "File Buffer Size: 240000 bytes"
 msgstr "Grootte van bestandsbuffer : 240000 bytes"
 
-#: src/muuli_wdr.cpp:1937
+#: src/muuli_wdr.cpp:1944
 msgid "Use MMAP: memory-mapped file access (lower memory use)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1938
+#: src/muuli_wdr.cpp:1945
 msgid "Maps part files into memory instead of buffering them on the heap, lowering the process memory footprint. May reduce download speed on some disks; best for memory-constrained or upload-heavy hosts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1940
+#: src/muuli_wdr.cpp:1947
 msgid "Upload Queue Size: 5000 clients"
 msgstr "Grootte van uploadwachtrij: 5000 clients"
 
-#: src/muuli_wdr.cpp:1944
+#: src/muuli_wdr.cpp:1951
 msgid "Server connection refresh interval: Disable"
 msgstr "Server-verbinding verversingsinterval: Uitschakelen"
 
-#: src/muuli_wdr.cpp:1948
+#: src/muuli_wdr.cpp:1955
 msgid "Disable computer's timed standby mode"
 msgstr "Schakel standby-modus van computer uit"
 
-#: src/muuli_wdr.cpp:1967
+#: src/muuli_wdr.cpp:1974
 msgid "Skin to use: "
 msgstr "Gebruik skin: "
 
-#: src/muuli_wdr.cpp:1976
+#: src/muuli_wdr.cpp:1983
 msgid "Show \"Fast eD2k Links Handler\" in every window."
 msgstr "Toon \"Snelle eD2k-links afhandelaar\" in elk venster."
 
-#: src/muuli_wdr.cpp:1979
+#: src/muuli_wdr.cpp:1986
 msgid "Show extended info on categories tabs"
 msgstr "Geef uitgebreide informatie weer op categorie-tabs"
 
-#: src/muuli_wdr.cpp:1982
+#: src/muuli_wdr.cpp:1989
 msgid "Show application version on title"
 msgstr "Toon applicatieversie op titel"
 
-#: src/muuli_wdr.cpp:1984
+#: src/muuli_wdr.cpp:1991
 msgid "Show transfer rates on title"
 msgstr "Toon overdrachtsnelheden op titel"
 
-#: src/muuli_wdr.cpp:1986
+#: src/muuli_wdr.cpp:1993
 msgid "Before application name"
 msgstr "Voor applicatienaam"
 
-#: src/muuli_wdr.cpp:1988
+#: src/muuli_wdr.cpp:1995
 msgid "After application name"
 msgstr "Na applicatienaam"
 
-#: src/muuli_wdr.cpp:1991
+#: src/muuli_wdr.cpp:1998
 msgid "Show overhead bandwidth"
 msgstr "Toon overhead bandbreedte"
 
-#: src/muuli_wdr.cpp:1995
+#: src/muuli_wdr.cpp:2002
 msgid "Vertical toolbar orientation"
 msgstr "Verticale knoppenbalk"
 
-#: src/muuli_wdr.cpp:1997
+#: src/muuli_wdr.cpp:2004
 msgid "Live column sorting (auto-reorder rows as their values change)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2004
+#: src/muuli_wdr.cpp:2011
 msgid "Download Queue Files"
 msgstr "Downloadwachtrij bestanden"
 
-#: src/muuli_wdr.cpp:2007
+#: src/muuli_wdr.cpp:2014
 msgid "Show progress percentage"
 msgstr "Toon voortgangspercentage"
 
-#: src/muuli_wdr.cpp:2013
+#: src/muuli_wdr.cpp:2020
 msgid "Show progress bar"
 msgstr "Toon voortgangsindicator"
 
-#: src/muuli_wdr.cpp:2016
+#: src/muuli_wdr.cpp:2023
 msgid "Flat"
 msgstr "Plat"
 
-#: src/muuli_wdr.cpp:2020
+#: src/muuli_wdr.cpp:2027
 msgid "Round"
 msgstr "Rond"
 
-#: src/muuli_wdr.cpp:2038
+#: src/muuli_wdr.cpp:2045
 msgid "External Connection Parameters"
 msgstr "Externe verbinding parameters"
 
-#: src/muuli_wdr.cpp:2041
+#: src/muuli_wdr.cpp:2048
 msgid "Accept external connections"
 msgstr "Accepteer externe verbindingen"
 
-#: src/muuli_wdr.cpp:2048 src/muuli_wdr.cpp:2107
+#: src/muuli_wdr.cpp:2055 src/muuli_wdr.cpp:2114
 msgid "IP of the listening interface:"
 msgstr "IP van de luisterende interface:"
 
-#: src/muuli_wdr.cpp:2051
+#: src/muuli_wdr.cpp:2058
 msgid "Enter here a valid ip in the a.b.c.d format for the listening EC interface. An empty field or 0.0.0.0 will mean any interface."
 msgstr "Voer hier een geldig IP in het formaat a.b.c.d in van de luisterende EV-interface. Een leeg veld of 0.0.0.0 betekent elke interface."
 
-#: src/muuli_wdr.cpp:2072 src/muuli_wdr.cpp:2156
+#: src/muuli_wdr.cpp:2079 src/muuli_wdr.cpp:2163
 msgid "TCP port:"
 msgstr "TCP-poort:"
 
-#: src/muuli_wdr.cpp:2078
+#: src/muuli_wdr.cpp:2085
 msgid "Enable UPnP port forwarding on the EC port"
 msgstr "Schakel UPnP portforwarding van de EV-poort in"
 
-#: src/muuli_wdr.cpp:2082 src/muuli_wdr.cpp:3041
+#: src/muuli_wdr.cpp:2089 src/muuli_wdr.cpp:3048
 #: src/utils/wxCas/src/wxcasprefs.cpp:167
 msgid "Password"
 msgstr "Wachtwoord"
 
-#: src/muuli_wdr.cpp:2088
+#: src/muuli_wdr.cpp:2095
 #, fuzzy
 msgid "aMule API server parameters"
 msgstr "Webserver parameters"
 
-#: src/muuli_wdr.cpp:2091
+#: src/muuli_wdr.cpp:2098
 msgid "Run amuleapi (REST API) on startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2096
+#: src/muuli_wdr.cpp:2103
 #, fuzzy
 msgid "HTTP port:"
 msgstr "TCP-poort:"
 
-#: src/muuli_wdr.cpp:2110
+#: src/muuli_wdr.cpp:2117
 msgid "The interface amuleapi's HTTP server listens on. 127.0.0.1 (default) accepts only local connections; use 0.0.0.0 or a specific IP to expose it to other hosts (set an admin password below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2113
+#: src/muuli_wdr.cpp:2120
 #, fuzzy
 msgid "Admin password"
 msgstr "Controleren van wachtwoord\n"
 
-#: src/muuli_wdr.cpp:2118 src/muuli_wdr.cpp:2149
+#: src/muuli_wdr.cpp:2125 src/muuli_wdr.cpp:2156
 msgid "Low rights password"
 msgstr "Beperkte rechten wachtwoord"
 
-#: src/muuli_wdr.cpp:2126
+#: src/muuli_wdr.cpp:2133
 msgid "Web server parameters"
 msgstr "Webserver parameters"
 
-#: src/muuli_wdr.cpp:2129
+#: src/muuli_wdr.cpp:2136
 #, fuzzy
 msgid "Run webserver on startup (deprecated)"
 msgstr "Start webserver bij het opstarten"
 
-#: src/muuli_wdr.cpp:2135
+#: src/muuli_wdr.cpp:2142
 msgid "Web template"
 msgstr "Web-template"
 
-#: src/muuli_wdr.cpp:2140
+#: src/muuli_wdr.cpp:2147
 msgid "Full rights password"
 msgstr "Alle rechten wachtwoord"
 
-#: src/muuli_wdr.cpp:2144
+#: src/muuli_wdr.cpp:2151
 msgid "Enable Low rights User"
 msgstr "Schakel gebruiker met beperkte rechten in"
 
-#: src/muuli_wdr.cpp:2163
+#: src/muuli_wdr.cpp:2170
 msgid "Enable UPnP port forwarding of the web server port"
 msgstr "Schakel UPnP portforwarding van de webserver-poort in"
 
-#: src/muuli_wdr.cpp:2168
+#: src/muuli_wdr.cpp:2175
 msgid "Web server UPnP TCP port (Optional)"
 msgstr "Web server UPnP TCP-poort (optioneel)"
 
-#: src/muuli_wdr.cpp:2176
+#: src/muuli_wdr.cpp:2183
 msgid "Page Refresh Time (in secs)"
 msgstr "Pagina verversingstijd (in seconden)"
 
-#: src/muuli_wdr.cpp:2183
+#: src/muuli_wdr.cpp:2190
 msgid "Enable Gzip compression"
 msgstr "Schakel Gzip-compressie in"
 
-#: src/muuli_wdr.cpp:2217
+#: src/muuli_wdr.cpp:2224
 #, fuzzy
 msgid "Reset page to defaults"
 msgstr "Systeemstandaard"
 
-#: src/muuli_wdr.cpp:2218
+#: src/muuli_wdr.cpp:2225
 msgid "Reset the settings on the current page to their default values."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2220 src/muuli_wdr.cpp:2306 src/ServerWnd.cpp:274
+#: src/muuli_wdr.cpp:2227 src/muuli_wdr.cpp:2313 src/ServerWnd.cpp:274
 #: src/ServerWnd.cpp:282
 msgid "OK"
 msgstr "OK"
 
-#: src/muuli_wdr.cpp:2222
+#: src/muuli_wdr.cpp:2229
 msgid "Click here to apply any changes made to the preferences."
 msgstr "Klik hier om de veranderingen gemaakt in de voorkeuren toe te passen."
 
-#: src/muuli_wdr.cpp:2225
+#: src/muuli_wdr.cpp:2232
 msgid "Reset any changes made to the preferences."
 msgstr "Maak veranderingen aan de voorkeuren ongedaan."
 
-#: src/muuli_wdr.cpp:2254
+#: src/muuli_wdr.cpp:2261
 msgid "Comment :"
 msgstr "Commentaar :"
 
-#: src/muuli_wdr.cpp:2261
+#: src/muuli_wdr.cpp:2268
 msgid "Incoming Dir :"
 msgstr "Binnenkomende map :"
 
-#: src/muuli_wdr.cpp:2270
+#: src/muuli_wdr.cpp:2277
 msgid "Change priority for new assigned files :"
 msgstr "Verander prioriteit voor nieuw toegevoegde bestanden :"
 
-#: src/muuli_wdr.cpp:2274
+#: src/muuli_wdr.cpp:2281
 msgid "Don't change"
 msgstr "Niet veranderen"
 
-#: src/muuli_wdr.cpp:2286
+#: src/muuli_wdr.cpp:2293
 msgid "Select color for this Category (currently selected) :"
 msgstr "Selecteer kleur voor deze categorie (nu geselecteerd) :"
 
-#: src/muuli_wdr.cpp:2353 src/muuli_wdr.cpp:2372 src/muuli_wdr.cpp:2394
+#: src/muuli_wdr.cpp:2360 src/muuli_wdr.cpp:2379 src/muuli_wdr.cpp:2401
 msgid "Click this button to reset the log."
 msgstr "Klik op deze knop om het logboek te wissen."
 
-#: src/muuli_wdr.cpp:2413
+#: src/muuli_wdr.cpp:2420
 msgid "Click on this button to update the servers list from URL ..."
 msgstr "Klik op deze knop om de lijst van servers te updaten van URL ..."
 
-#: src/muuli_wdr.cpp:2417
+#: src/muuli_wdr.cpp:2424
 msgid "Server list"
 msgstr "Server-lijst"
 
-#: src/muuli_wdr.cpp:2421
+#: src/muuli_wdr.cpp:2428
 msgid "Enter the url to a server.met file here and press the button to the left to update the list of known servers."
 msgstr "Voer de url naar een server.met bestand hier in en druk op de knop links om de lijst met bekende servers te vernieuwen."
 
-#: src/muuli_wdr.cpp:2426
+#: src/muuli_wdr.cpp:2433
 msgid "Add server manually: Name"
 msgstr "Voeg server handmatig toe: Naam"
 
-#: src/muuli_wdr.cpp:2429
+#: src/muuli_wdr.cpp:2436
 msgid "Enter the name of the new server here"
 msgstr "Voer hier de naam van de nieuwe server in"
 
-#: src/muuli_wdr.cpp:2431 src/ServerWnd.cpp:206
+#: src/muuli_wdr.cpp:2438 src/ServerWnd.cpp:206
 msgid "IP:Port"
 msgstr "IP:Poort"
 
-#: src/muuli_wdr.cpp:2434
+#: src/muuli_wdr.cpp:2441
 msgid "Enter the IP of the server here, using the x.x.x.x format."
 msgstr "Voer hier het IP van de server in, gebuik het x.x.x.x formaat."
 
-#: src/muuli_wdr.cpp:2440
+#: src/muuli_wdr.cpp:2447
 msgid "Enter the port of the server here."
 msgstr "Voer hier de poort van de server in."
 
-#: src/muuli_wdr.cpp:2443
+#: src/muuli_wdr.cpp:2450
 msgid "Add manually a server (fill fields to the left before) ..."
 msgstr "Voeg een server handmatig toe (vul velden links in voor) ..."
 
-#: src/muuli_wdr.cpp:2472
+#: src/muuli_wdr.cpp:2479
 msgid "aMule Log"
 msgstr "aMule log"
 
-#: src/muuli_wdr.cpp:2480
+#: src/muuli_wdr.cpp:2487
 msgid "Server Info"
 msgstr "Server-info"
 
-#: src/muuli_wdr.cpp:2484
+#: src/muuli_wdr.cpp:2491
 msgid "ED2K Info"
 msgstr "ED2K-info"
 
-#: src/muuli_wdr.cpp:2488
+#: src/muuli_wdr.cpp:2495
 msgid "Kad Info"
 msgstr "Kad info"
 
-#: src/muuli_wdr.cpp:2516
+#: src/muuli_wdr.cpp:2523
 msgid "Click on this button to update the nodes list from URL ..."
 msgstr "Klik op deze knop om de nodes-lijst te updaten van URL ..."
 
-#: src/muuli_wdr.cpp:2520
+#: src/muuli_wdr.cpp:2527
 msgid "Nodes (0)"
 msgstr "Nodes (0)"
 
-#: src/muuli_wdr.cpp:2524
+#: src/muuli_wdr.cpp:2531
 msgid "Enter the url to a nodes.dat file here and press the button to the left to update the list of known nodes."
 msgstr "Voer hier de url in naar een nodes.dat bestand en druk op de knop links om de lijst van bekende nodes te updaten."
 
-#: src/muuli_wdr.cpp:2527
+#: src/muuli_wdr.cpp:2534
 msgid "Nodes stats"
 msgstr "Nodes stats"
 
-#: src/muuli_wdr.cpp:2569
+#: src/muuli_wdr.cpp:2576
 msgid "Bootstrap"
 msgstr "Bootstrap"
 
-#: src/muuli_wdr.cpp:2572
+#: src/muuli_wdr.cpp:2579
 msgid "New node"
 msgstr "Nieuwe node"
 
-#: src/muuli_wdr.cpp:2577
+#: src/muuli_wdr.cpp:2584
 msgid "IP:"
 msgstr "IP:"
 
-#: src/muuli_wdr.cpp:2597
+#: src/muuli_wdr.cpp:2604
 msgid "Port:"
 msgstr "Poort:"
 
-#: src/muuli_wdr.cpp:2610
+#: src/muuli_wdr.cpp:2617
 msgid "Bootstrap from known clients"
 msgstr "Bootstrap van bekende clients"
 
-#: src/muuli_wdr.cpp:2612
+#: src/muuli_wdr.cpp:2619
 msgid "Disconnect Kad"
 msgstr "Verbreek verbinding met Kad"
 
-#: src/muuli_wdr.cpp:2646
+#: src/muuli_wdr.cpp:2653
 msgid "Use Secure User Identification"
 msgstr "Gebruik beveiligde gebruikersidentificatie"
 
-#: src/muuli_wdr.cpp:2648
+#: src/muuli_wdr.cpp:2655
 msgid "It is recommended to enable this option. You will not receive credits if SUI is not enabled."
 msgstr "Het is aan te raden om deze optie in te schakelen. U ontvangt geen credits indien SUI niet ingeschakeld is."
 
-#: src/muuli_wdr.cpp:2650
+#: src/muuli_wdr.cpp:2657
 msgid "Protocol Obfuscation"
 msgstr "Protocol-obfuscatie"
 
-#: src/muuli_wdr.cpp:2653
+#: src/muuli_wdr.cpp:2660
 msgid "Support Protocol Obfuscation"
 msgstr "Ondersteun protocol-obfuscatie"
 
-#: src/muuli_wdr.cpp:2655
+#: src/muuli_wdr.cpp:2662
 msgid "This option enabled Protocol Obfuscation, and makes aMule accept obfuscated connections from other clients."
 msgstr "Deze optie schakelt Protocol Obfuscatie in, en zorgt er voor dat aMule geobfusceerde verbindingen van andere clients accepteert."
 
-#: src/muuli_wdr.cpp:2657
+#: src/muuli_wdr.cpp:2664
 msgid "Use obfuscation for outgoing connections"
 msgstr "Gebruik obfuscatie voor uitgaande verbindingen"
 
-#: src/muuli_wdr.cpp:2659
+#: src/muuli_wdr.cpp:2666
 msgid "This option makes aMule use Protocol Obfuscation when connecting other clients/servers."
 msgstr "Deze optie zorgt er voor dat aMule protocol-obfuscatie gebruikt bij het verbinden met andere clients/servers."
 
-#: src/muuli_wdr.cpp:2661
+#: src/muuli_wdr.cpp:2668
 msgid "Accept only obfuscated connections"
 msgstr "Accepteer alleen geobfusceerde verbindingen"
 
-#: src/muuli_wdr.cpp:2662
+#: src/muuli_wdr.cpp:2669
 msgid "This option makes aMule only accept obfuscated connections. You will have less sources, but all your traffic will be obfuscated"
 msgstr "Deze optie zorgt er voor dat aMule alleen geobfusceerde verbindingen accepteert. U heeft minder bronnen, maar al uw verkeer is geobfusceerd"
 
-#: src/muuli_wdr.cpp:2667
+#: src/muuli_wdr.cpp:2674
 msgid "Everybody"
 msgstr "Iedereen"
 
-#: src/muuli_wdr.cpp:2669
+#: src/muuli_wdr.cpp:2676
 msgid "No one"
 msgstr "Niemand"
 
-#: src/muuli_wdr.cpp:2671
+#: src/muuli_wdr.cpp:2678
 msgid "Who can see my shared files:"
 msgstr "Wie kan mijn gedeelde bestanden zien:"
 
-#: src/muuli_wdr.cpp:2672
+#: src/muuli_wdr.cpp:2679
 msgid "Select who can request to view a list of your shared files."
 msgstr "Selecteer wie een lijst van uw gedeelde bestanden kan opvragen."
 
-#: src/muuli_wdr.cpp:2674
+#: src/muuli_wdr.cpp:2681
 msgid "IP-Filtering"
 msgstr "IP-filteren"
 
-#: src/muuli_wdr.cpp:2681
+#: src/muuli_wdr.cpp:2688
 msgid "Filter clients"
 msgstr "Filter clients"
 
-#: src/muuli_wdr.cpp:2683
+#: src/muuli_wdr.cpp:2690
 msgid "Enable filtering of the client IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "Schakel filteren van de client-IPs in het bestand ~/.aMule/ipfilter.dat in."
 
-#: src/muuli_wdr.cpp:2685
+#: src/muuli_wdr.cpp:2692
 msgid "Filter servers"
 msgstr "Filter servers"
 
-#: src/muuli_wdr.cpp:2687
+#: src/muuli_wdr.cpp:2694
 msgid "Enable filtering of the server IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "Schakel filteren van de server-IPs in het bestand ~/.aMule/ipfilter.dat in."
 
-#: src/muuli_wdr.cpp:2691
+#: src/muuli_wdr.cpp:2698
 msgid "Reload List"
 msgstr "Lijst opnieuw laden"
 
-#: src/muuli_wdr.cpp:2692
+#: src/muuli_wdr.cpp:2699
 msgid "Reload the list of IPs to filter from the file ~/.aMule/ipfilter.dat"
 msgstr "Laadt de lijst met IPs om te filteren opnieuw uit het bestand ~/.aMule/ipfilter.dat"
 
-#: src/muuli_wdr.cpp:2698
+#: src/muuli_wdr.cpp:2705
 msgid "URL:"
 msgstr "URL:"
 
-#: src/muuli_wdr.cpp:2702 src/muuli_wdr.cpp:2895
+#: src/muuli_wdr.cpp:2709 src/muuli_wdr.cpp:2902
 msgid "Update now"
 msgstr "Update nu"
 
-#: src/muuli_wdr.cpp:2705
+#: src/muuli_wdr.cpp:2712
 msgid "Auto-update ipfilter at startup"
 msgstr "Auto-update ip-filter bij het starten"
 
-#: src/muuli_wdr.cpp:2709
+#: src/muuli_wdr.cpp:2716
 msgid "Filtering Level:"
 msgstr "Niveau van filteren:"
 
-#: src/muuli_wdr.cpp:2715
+#: src/muuli_wdr.cpp:2722
 msgid "Always filter LAN IPs"
 msgstr "Filter LAN IPs altijd"
 
-#: src/muuli_wdr.cpp:2718
+#: src/muuli_wdr.cpp:2725
 msgid "Paranoid handling of non-matching IPs"
 msgstr "Paranoïde behandeling van niet-kloppende IPs"
 
-#: src/muuli_wdr.cpp:2720
+#: src/muuli_wdr.cpp:2727
 msgid "Rejects a packet when its source IP differs from the IP the client claims (an anti-spoofing check). Disable only if it causes connection problems."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2722
+#: src/muuli_wdr.cpp:2729
 msgid "Use system-wide ipfilter.dat if available"
 msgstr "Gebruik systeemwijd ipfilter.dat indien beschikbaar"
 
-#: src/muuli_wdr.cpp:2723
+#: src/muuli_wdr.cpp:2730
 #, fuzzy
 msgid "If there's no local ipfilter.dat found, allow usage of a system-wide ipfilter file."
 msgstr "Indien er geen lokaal ipfilter.dat gevonden wordt, sta gebruik van een systeemwijd ipfilter toe."
 
-#: src/muuli_wdr.cpp:2740
+#: src/muuli_wdr.cpp:2747
 msgid "Enable Online-Signature"
 msgstr "Schakel online handtekening in"
 
-#: src/muuli_wdr.cpp:2742
+#: src/muuli_wdr.cpp:2749
 msgid "Enables the writing of the OS file, which can be used by external apps to create signatures and the like."
 msgstr "Schakelt het schrijven van het OH-bestand in, die kan gebruikt worden door externe applicaties om handtekeningen en dergelijke te maken."
 
-#: src/muuli_wdr.cpp:2746
+#: src/muuli_wdr.cpp:2753
 msgid "Update Frequency (Secs):"
 msgstr "Update-frequentie (seconden):"
 
-#: src/muuli_wdr.cpp:2749
+#: src/muuli_wdr.cpp:2756
 msgid "Change the frequency (in seconds) of Online Signature updates."
 msgstr "Verander de frequentie (in seconden) van de Online Handtekening updates."
 
-#: src/muuli_wdr.cpp:2757
+#: src/muuli_wdr.cpp:2764
 msgid "Save online signature file in: "
 msgstr "Bewaar online-handtekeningbestand in: "
 
-#: src/muuli_wdr.cpp:2763
+#: src/muuli_wdr.cpp:2770
 msgid "Click here to select the directory containing the the Online Signature files."
 msgstr "Klik hier om de map te selecteren die de online-handtekening-bestanden bevat."
 
-#: src/muuli_wdr.cpp:2796
+#: src/muuli_wdr.cpp:2803
 msgid "Show country flags for clients"
 msgstr "Toon landenvlaggen voor clients"
 
-#: src/muuli_wdr.cpp:2797
+#: src/muuli_wdr.cpp:2804
 msgid "Render the country flag column in the transfers, queue and search views. Requires a valid MMDB GeoIP database (see below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2802
+#: src/muuli_wdr.cpp:2809
 #, fuzzy
 msgid "Database"
 msgstr "Datasnelheid :"
 
-#: src/muuli_wdr.cpp:2818
+#: src/muuli_wdr.cpp:2825
 #, fuzzy
 msgid "Source:"
 msgstr "Bronnen"
 
-#: src/muuli_wdr.cpp:2821
+#: src/muuli_wdr.cpp:2828
 msgid "DB-IP (free, no account)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2822
+#: src/muuli_wdr.cpp:2829
 msgid "MaxMind GeoLite2 (free, account required)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2823
+#: src/muuli_wdr.cpp:2830
 msgid "Custom URL"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2826
+#: src/muuli_wdr.cpp:2833
 msgid "Choose which provider supplies the GeoIP MMDB database. DB-IP is the default - no account required. MaxMind requires a free account + license key. Use Custom URL to point at any other MMDB host (e.g. a local mirror)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2843
+#: src/muuli_wdr.cpp:2850
 msgid ""
 "No configuration required.\n"
 "\n"
@@ -4843,11 +4857,11 @@ msgid ""
 "License: Creative Commons BY 4.0 - https://creativecommons.org/licenses/by/4.0/"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2856
+#: src/muuli_wdr.cpp:2863
 msgid "License key:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2862
+#: src/muuli_wdr.cpp:2869
 msgid ""
 "Sign up for a free MaxMind account, then generate a License Key:\n"
 "https://www.maxmind.com/en/geolite2/signup\n"
@@ -4857,225 +4871,225 @@ msgid ""
 "Requires attribution and account registration; refresh at least every 30 days."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2877
+#: src/muuli_wdr.cpp:2884
 #, fuzzy
 msgid "Download URL:"
 msgstr "Download: "
 
-#: src/muuli_wdr.cpp:2883
+#: src/muuli_wdr.cpp:2890
 msgid ""
 "Must point to an .mmdb file or a .gz / .tar.gz containing one.\n"
 "URL may include credentials (https://user:pass@host/...).\n"
 "License and attribution terms are set by the upstream URL - you are responsible."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2896
+#: src/muuli_wdr.cpp:2903
 msgid "Download the GeoIP database from the selected source."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2898
+#: src/muuli_wdr.cpp:2905
 #, fuzzy
 msgid "Auto-update on startup"
 msgstr "Auto-update ip-filter bij het starten"
 
-#: src/muuli_wdr.cpp:2899
+#: src/muuli_wdr.cpp:2906
 msgid "Re-download the GeoIP database from the selected source every time aMule starts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2922
+#: src/muuli_wdr.cpp:2929
 msgid "Filter incoming messages (except current chat):"
 msgstr "Filter binnenkomende berichten (behalve huidige chat):"
 
-#: src/muuli_wdr.cpp:2924
+#: src/muuli_wdr.cpp:2931
 msgid "Filter all messages"
 msgstr "Filter alle berichten"
 
-#: src/muuli_wdr.cpp:2926
+#: src/muuli_wdr.cpp:2933
 msgid "Filter messages from people not on your friend list"
 msgstr "Filter berichten van mensen niet op uw vriendenlijst"
 
-#: src/muuli_wdr.cpp:2928
+#: src/muuli_wdr.cpp:2935
 msgid "Filter messages from unknown clients"
 msgstr "Filter berichten van onbekende clients"
 
-#: src/muuli_wdr.cpp:2930
+#: src/muuli_wdr.cpp:2937
 msgid "Filter messages containing (use ',' as separator):"
 msgstr "Filter berichten met (gebruik ',' als scheiding):"
 
-#: src/muuli_wdr.cpp:2933 src/muuli_wdr.cpp:2944
+#: src/muuli_wdr.cpp:2940 src/muuli_wdr.cpp:2951
 msgid "add here the words amule should filter and block messages including it"
 msgstr "voeg hier de woorden toe die amule moet filteren en berichten daarmee blokkeren"
 
-#: src/muuli_wdr.cpp:2935
+#: src/muuli_wdr.cpp:2942
 msgid "Show received messages in the log"
 msgstr "Toon ontvangen berichten in het logboek"
 
-#: src/muuli_wdr.cpp:2938
+#: src/muuli_wdr.cpp:2945
 msgid "Comments"
 msgstr "Commentaren"
 
-#: src/muuli_wdr.cpp:2941
+#: src/muuli_wdr.cpp:2948
 msgid "Filter comments containing (use ',' as separator):"
 msgstr "Filter commentaren die de volgende tekens bevatten (gebruik ',' als scheiding):"
 
-#: src/muuli_wdr.cpp:2966
+#: src/muuli_wdr.cpp:2973
 msgid "Enable Proxy"
 msgstr "Schakel proxy in"
 
-#: src/muuli_wdr.cpp:2967
+#: src/muuli_wdr.cpp:2974
 msgid "Enable/disable proxy support"
 msgstr "Schakel proxy ondersteuning in/uit"
 
-#: src/muuli_wdr.cpp:2970
+#: src/muuli_wdr.cpp:2977
 msgid "Proxy type:"
 msgstr "Proxy-type:"
 
-#: src/muuli_wdr.cpp:2981
+#: src/muuli_wdr.cpp:2988
 msgid "Proxy host:"
 msgstr "Proxy-host:"
 
-#: src/muuli_wdr.cpp:2984
+#: src/muuli_wdr.cpp:2991
 msgid "The proxy host name"
 msgstr "De proxy hostnaam"
 
-#: src/muuli_wdr.cpp:2986
+#: src/muuli_wdr.cpp:2993
 msgid "Proxy port:"
 msgstr "Proxy-poort:"
 
-#: src/muuli_wdr.cpp:2989
+#: src/muuli_wdr.cpp:2996
 msgid "The proxy port"
 msgstr "De proxy poort"
 
-#: src/muuli_wdr.cpp:2991
+#: src/muuli_wdr.cpp:2998
 msgid "Enable authentication"
 msgstr "Schakel aanmelding in"
 
-#: src/muuli_wdr.cpp:2992
+#: src/muuli_wdr.cpp:2999
 msgid "Enable/disable username/password authentication"
 msgstr "Schakel gebruikersnaam/wachtwoord aanmelding in/uit"
 
-#: src/muuli_wdr.cpp:2995
+#: src/muuli_wdr.cpp:3002
 msgid "Username: "
 msgstr "Gebruikersnaam: "
 
-#: src/muuli_wdr.cpp:2998
+#: src/muuli_wdr.cpp:3005
 msgid "The username to use to connect to the proxy"
 msgstr "De gebruikersnaam is nodig om te verbinden met de proxy"
 
-#: src/muuli_wdr.cpp:3000
+#: src/muuli_wdr.cpp:3007
 msgid "Password:"
 msgstr "Wachtwoord:"
 
-#: src/muuli_wdr.cpp:3003
+#: src/muuli_wdr.cpp:3010
 msgid "The password to use to connect to the proxy"
 msgstr "Het wachtwoord nodig om te verbinden met de proxy"
 
-#: src/muuli_wdr.cpp:3022
+#: src/muuli_wdr.cpp:3029
 msgid "Connect to:"
 msgstr "Verbind met:"
 
-#: src/muuli_wdr.cpp:3031
+#: src/muuli_wdr.cpp:3038
 msgid "Login to remote amule"
 msgstr "Inloggen op amule op afstand"
 
-#: src/muuli_wdr.cpp:3036
+#: src/muuli_wdr.cpp:3043
 msgid "User name"
 msgstr "Gebruikersnaam"
 
-#: src/muuli_wdr.cpp:3047
+#: src/muuli_wdr.cpp:3054
 msgid "Remember those settings"
 msgstr "Onthoud deze instellingen"
 
-#: src/muuli_wdr.cpp:3050
+#: src/muuli_wdr.cpp:3057
 #, fuzzy
 msgid "Force ZLIB compression"
 msgstr "Gebruik Gzip-compressie"
 
-#: src/muuli_wdr.cpp:3074
+#: src/muuli_wdr.cpp:3081
 msgid "Enable Verbose Debug-Logging."
 msgstr "Schakel uitgebreide foutopsporing en logboek in."
 
-#: src/muuli_wdr.cpp:3076
+#: src/muuli_wdr.cpp:3083
 msgid "Only to Logfile"
 msgstr "Alleen naar logbestand"
 
-#: src/muuli_wdr.cpp:3078
+#: src/muuli_wdr.cpp:3085
 msgid "Message Categories:"
 msgstr "Berichtcategorieën:"
 
-#: src/muuli_wdr.cpp:3102 src/PartFileConvertDlg.cpp:160
+#: src/muuli_wdr.cpp:3109 src/PartFileConvertDlg.cpp:160
 msgid "Waiting..."
 msgstr "Wachtend..."
 
-#: src/muuli_wdr.cpp:3122
+#: src/muuli_wdr.cpp:3129
 msgid "Add imports"
 msgstr "Voeg geïmporteerden toe"
 
-#: src/muuli_wdr.cpp:3125
+#: src/muuli_wdr.cpp:3132
 msgid "Retry selected"
 msgstr "Probeer geselecteerde opnieuw"
 
-#: src/muuli_wdr.cpp:3127
+#: src/muuli_wdr.cpp:3134
 msgid "Remove selected"
 msgstr "Verwijder geselecteerde"
 
-#: src/muuli_wdr.cpp:3190
+#: src/muuli_wdr.cpp:3197
 msgid "Event Types"
 msgstr "Gebeurtenistypes"
 
-#: src/muuli_wdr.cpp:3209
+#: src/muuli_wdr.cpp:3216
 msgid "Statistics and queued clients for selected file(s) : Session / All time"
 msgstr "Statistieken en clients in wachtrij voor geselecteerd(e) bestand(en) : Sessie / Alle"
 
-#: src/muuli_wdr.cpp:3233
+#: src/muuli_wdr.cpp:3240
 msgid "Active Uploads"
 msgstr "Actieve uploads"
 
-#: src/muuli_wdr.cpp:3247
+#: src/muuli_wdr.cpp:3254
 msgid "Percent of total files"
 msgstr "Procent van alle bestanden"
 
-#: src/muuli_wdr.cpp:3299
+#: src/muuli_wdr.cpp:3306
 msgid "Show Clients for"
 msgstr "Toon clients voor"
 
-#: src/muuli_wdr.cpp:3301
+#: src/muuli_wdr.cpp:3308
 msgid "All files"
 msgstr "Alle bestanden"
 
-#: src/muuli_wdr.cpp:3304
+#: src/muuli_wdr.cpp:3311
 msgid "Selected files"
 msgstr "Geselecteerde bestanden"
 
-#: src/muuli_wdr.cpp:3307
+#: src/muuli_wdr.cpp:3314
 msgid "Active uploads only"
 msgstr "Alleen actieve uploads"
 
-#: src/muuli_wdr.cpp:3314
+#: src/muuli_wdr.cpp:3321
 msgid "Reload:"
 msgstr "Opnieuw laden:"
 
-#: src/muuli_wdr.cpp:3318
+#: src/muuli_wdr.cpp:3325
 msgid "Reload your shared files"
 msgstr "Laad uw gedeelde bestanden opnieuw"
 
-#: src/muuli_wdr.cpp:3381
+#: src/muuli_wdr.cpp:3388
 msgid "Send"
 msgstr "Verstuur"
 
-#: src/muuli_wdr.cpp:3382
+#: src/muuli_wdr.cpp:3389
 msgid "Sends the specified message."
 msgstr "Verstuurt het opgegeven bericht."
 
-#: src/muuli_wdr.cpp:3386
+#: src/muuli_wdr.cpp:3393
 msgid "Close this chat-session."
 msgstr "Sluit deze chat-sessie."
 
-#: src/muuli_wdr.cpp:3409
+#: src/muuli_wdr.cpp:3416
 msgid "Connect to any server and/or Kad"
 msgstr "Verbind met een server en/of Kad"
 
-#: src/muuli_wdr.cpp:3415 src/SharedFilesCtrl.cpp:142 src/Statistics.cpp:941
+#: src/muuli_wdr.cpp:3422 src/SharedFilesCtrl.cpp:142 src/Statistics.cpp:941
 msgid "Shared Files"
 msgstr "Gedeelde bestanden"
 
@@ -5436,188 +5450,188 @@ msgstr "Gedownload"
 msgid "ERROR: Failed to open partfile '%s'"
 msgstr "FOUT: Kon deelbestand '%s' niet openen"
 
-#: src/Preferences.cpp:673
+#: src/Preferences.cpp:674
 msgid "System default"
 msgstr "Systeemstandaard"
 
-#: src/Preferences.cpp:674
+#: src/Preferences.cpp:675
 msgid "Albanian"
 msgstr "Albanees"
 
-#: src/Preferences.cpp:675
+#: src/Preferences.cpp:676
 msgid "Arabic"
 msgstr "Arabisch"
 
-#: src/Preferences.cpp:676
+#: src/Preferences.cpp:677
 msgid "Asturian"
 msgstr "Asturisch"
 
-#: src/Preferences.cpp:677
+#: src/Preferences.cpp:678
 msgid "Basque"
 msgstr "Baskisch"
 
-#: src/Preferences.cpp:678
+#: src/Preferences.cpp:679
 msgid "Bulgarian"
 msgstr "Bulgaars"
 
-#: src/Preferences.cpp:679
+#: src/Preferences.cpp:680
 msgid "Catalan"
 msgstr "Catalaans"
 
-#: src/Preferences.cpp:680
+#: src/Preferences.cpp:681
 msgid "Chinese (Simplified)"
 msgstr "Chinees (Vereenvoudigd)"
 
-#: src/Preferences.cpp:681
+#: src/Preferences.cpp:682
 msgid "Chinese (Traditional)"
 msgstr "Chinees (Traditioneel)"
 
-#: src/Preferences.cpp:682
+#: src/Preferences.cpp:683
 msgid "Croatian"
 msgstr "Kroatisch"
 
-#: src/Preferences.cpp:683
+#: src/Preferences.cpp:684
 msgid "Czech"
 msgstr "Tsjechisch"
 
-#: src/Preferences.cpp:684
+#: src/Preferences.cpp:685
 msgid "Danish"
 msgstr "Deens"
 
-#: src/Preferences.cpp:685
+#: src/Preferences.cpp:686
 msgid "Dutch"
 msgstr "Nederlands"
 
-#: src/Preferences.cpp:686
+#: src/Preferences.cpp:687
 msgid "English (U.K.)"
 msgstr "Engels (V.K.)"
 
-#: src/Preferences.cpp:687
+#: src/Preferences.cpp:688
 #, fuzzy
 msgid "English (U.S.)"
 msgstr "Engels (V.K.)"
 
-#: src/Preferences.cpp:688
+#: src/Preferences.cpp:689
 msgid "Estonian"
 msgstr "Estonisch"
 
-#: src/Preferences.cpp:689
+#: src/Preferences.cpp:690
 msgid "Finnish"
 msgstr "Fins"
 
-#: src/Preferences.cpp:690
+#: src/Preferences.cpp:691
 msgid "French"
 msgstr "Frans"
 
-#: src/Preferences.cpp:691
+#: src/Preferences.cpp:692
 msgid "Galician"
 msgstr "Gallisch"
 
-#: src/Preferences.cpp:692
+#: src/Preferences.cpp:693
 msgid "German"
 msgstr "Duits"
 
-#: src/Preferences.cpp:693
+#: src/Preferences.cpp:694
 msgid "Greek"
 msgstr "Grieks"
 
-#: src/Preferences.cpp:694
+#: src/Preferences.cpp:695
 msgid "Hebrew"
 msgstr "Hebreeuws"
 
-#: src/Preferences.cpp:695
+#: src/Preferences.cpp:696
 msgid "Hungarian"
 msgstr "Hongaars"
 
-#: src/Preferences.cpp:696
+#: src/Preferences.cpp:697
 msgid "Italian"
 msgstr "Italiaans"
 
-#: src/Preferences.cpp:697
+#: src/Preferences.cpp:698
 msgid "Japanese"
 msgstr "Japans"
 
-#: src/Preferences.cpp:698
+#: src/Preferences.cpp:699
 msgid "Korean"
 msgstr "Koreaans"
 
-#: src/Preferences.cpp:699
+#: src/Preferences.cpp:700
 msgid "Latvian"
 msgstr ""
 
-#: src/Preferences.cpp:700
+#: src/Preferences.cpp:701
 msgid "Lithuanian"
 msgstr "Litouws"
 
-#: src/Preferences.cpp:701
+#: src/Preferences.cpp:702
 msgid "Norwegian (Nynorsk)"
 msgstr "Noors"
 
-#: src/Preferences.cpp:702
+#: src/Preferences.cpp:703
 msgid "Polish"
 msgstr "Pools"
 
-#: src/Preferences.cpp:703
+#: src/Preferences.cpp:704
 msgid "Portuguese"
 msgstr "Portugees"
 
-#: src/Preferences.cpp:704
+#: src/Preferences.cpp:705
 msgid "Portuguese (Brazilian)"
 msgstr "Portugees (Braziliaans)"
 
-#: src/Preferences.cpp:705
+#: src/Preferences.cpp:706
 msgid "Romanian"
 msgstr "Roemeens"
 
-#: src/Preferences.cpp:706
+#: src/Preferences.cpp:707
 msgid "Russian"
 msgstr "Russisch"
 
-#: src/Preferences.cpp:707
+#: src/Preferences.cpp:708
 msgid "Slovenian"
 msgstr "Sloveens"
 
-#: src/Preferences.cpp:708
+#: src/Preferences.cpp:709
 msgid "Spanish"
 msgstr "Spaans"
 
-#: src/Preferences.cpp:709
+#: src/Preferences.cpp:710
 msgid "Swedish"
 msgstr "Zweeds"
 
-#: src/Preferences.cpp:710
+#: src/Preferences.cpp:711
 msgid "Turkish"
 msgstr "Turks"
 
-#: src/Preferences.cpp:711
+#: src/Preferences.cpp:712
 msgid "Ukrainian"
 msgstr "Oekraïens"
 
-#: src/Preferences.cpp:814
+#: src/Preferences.cpp:815
 msgid "Change Language"
 msgstr "Verander taal"
 
-#: src/Preferences.cpp:878
+#: src/Preferences.cpp:879
 msgid "There are no translations installed for aMule"
 msgstr "Er zijn geen vertalingen voor aMule geïnstalleerd"
 
-#: src/Preferences.cpp:879
+#: src/Preferences.cpp:880
 msgid "No languages available"
 msgstr "Geen talen beschikbaar"
 
-#: src/Preferences.cpp:1010
+#: src/Preferences.cpp:1011
 msgid "no options available"
 msgstr "geen opties beschikbaar"
 
-#: src/Preferences.cpp:2179
+#: src/Preferences.cpp:2182
 msgid "Invalid category found, skipping"
 msgstr "Ongeldige categorie gevonden, wordt overgeslagen"
 
-#: src/Preferences.cpp:2348
+#: src/Preferences.cpp:2351
 msgid "TCP port can't be higher than 65532 due to server UDP socket being TCP+3"
 msgstr "TCP-poort kan niet hoger zijn dan 65532 omdat de server UDP-poort de TCP-poort + 3 is"
 
-#: src/Preferences.cpp:2349
+#: src/Preferences.cpp:2352
 #, c-format
 msgid "Default port will be used (%d)"
 msgstr "Standaard poort zal worden gebruikt (%d)"
@@ -6127,23 +6141,27 @@ msgstr "Laad gedeelde-bestandenlijst opnieuw."
 msgid "Shared folder"
 msgstr "Gedeelde mappen"
 
-#: src/SearchDlg.cpp:425
+#: src/SearchDlg.cpp:280
+msgid "Clear search history"
+msgstr ""
+
+#: src/SearchDlg.cpp:584
 msgid "It's impossible to search when both eD2k and Kademlia are disabled."
 msgstr "Er kan niet gezocht worden wanneer eD2k en Kademlia uitgeschakeld zijn."
 
-#: src/SearchDlg.cpp:426 src/SearchListCtrl.cpp:858
+#: src/SearchDlg.cpp:585 src/SearchListCtrl.cpp:858
 msgid "Search error"
 msgstr "Fout tijdens zoeken"
 
-#: src/SearchDlg.cpp:768
+#: src/SearchDlg.cpp:929
 msgid "Min size must be smaller than max size. Max size ignored."
 msgstr "Min grootte moet kleiner zijn dan max grootte. Max grootte wordt genegeerd."
 
-#: src/SearchDlg.cpp:769 src/SearchDlg.cpp:851
+#: src/SearchDlg.cpp:930 src/SearchDlg.cpp:1012
 msgid "Search warning"
 msgstr "Zoekwaarschuwing"
 
-#: src/SearchDlg.cpp:929 src/SearchListCtrl.cpp:735
+#: src/SearchDlg.cpp:1092 src/SearchListCtrl.cpp:735
 msgid "Main"
 msgstr "Standaard"
 

--- a/po/nl.po
+++ b/po/nl.po
@@ -12,7 +12,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-28 10:19+0200\n"
+"POT-Creation-Date: 2026-07-28 12:17+0200\n"
 "PO-Revision-Date: 2026-07-27 11:42+0000\n"
 "Last-Translator: Marcel Pol <marcel@timelord.nl>\n"
 "Language-Team: Dutch <nl@li.org>\n"
@@ -205,83 +205,83 @@ msgstr "Kon bestand ED2KLinks niet openen."
 msgid "WARNING: You can't add yourself as a source for an eD2k link while having a lowid."
 msgstr "WAARSCHUWING: U kunt uzelf niet toevoegen als bron voor een eD2k-link terwijl u een laag id hebt."
 
-#: src/amule.cpp:300
+#: src/amule.cpp:301
 msgid "Now, exiting main app..."
 msgstr "Hoofdapp wordt nu afgesloten..."
 
-#: src/amule.cpp:330
+#: src/amule.cpp:331
 #, c-format
 msgid "Terminating amuleweb instance with pid '%d' ... "
 msgstr "Amuleweb-instantie met pid '%d' wordt afgesloten ... "
 
-#: src/amule.cpp:334
+#: src/amule.cpp:335
 #, c-format
 msgid "Killing amuleweb instance with pid '%d' ... "
 msgstr "Amuleweb-instantie met pid '%d' wordt gedood ... "
 
-#: src/amule.cpp:336 src/amule.cpp:349 src/ClientRef.cpp:180
+#: src/amule.cpp:337 src/amule.cpp:350 src/ClientRef.cpp:180
 #: src/SearchDlg.cpp:1041 src/ServerListCtrl.cpp:98
 msgid "Failed"
 msgstr "Mislukt"
 
-#: src/amule.cpp:343
+#: src/amule.cpp:344
 #, fuzzy, c-format
 msgid "Terminating amuleapi instance with pid '%d' ... "
 msgstr "Amuleweb-instantie met pid '%d' wordt afgesloten ... "
 
-#: src/amule.cpp:347
+#: src/amule.cpp:348
 #, fuzzy, c-format
 msgid "Killing amuleapi instance with pid '%d' ... "
 msgstr "Amuleweb-instantie met pid '%d' wordt gedood ... "
 
-#: src/amule.cpp:355
+#: src/amule.cpp:356
 msgid "aMule OnExit: Terminating core."
 msgstr "aMule OnExit: Kern wordt afgesloten."
 
-#: src/amule.cpp:466
+#: src/amule.cpp:467
 msgid "aMule shutdown completed."
 msgstr "aMule is afgesloten."
 
-#: src/amule.cpp:470
+#: src/amule.cpp:471
 msgid "Memory debug results for aMule exit:"
 msgstr "Geheugen debug resultaten voor het afsluiten van aMule:"
 
-#: src/amule.cpp:651
+#: src/amule.cpp:652
 #, c-format
 msgid "Binding aMule's peer-to-peer traffic to interface: %s (HTTP updates use the default route)"
 msgstr ""
 
-#: src/amule.cpp:655
+#: src/amule.cpp:656
 #, c-format
 msgid "Binding all network traffic to interface: %s"
 msgstr ""
 
-#: src/amule.cpp:659
+#: src/amule.cpp:660
 #, c-format
 msgid "WARNING: configured network interface '%s' was not found - traffic is NOT bound to it and may leave via the default route. Check the interface name in Preferences."
 msgstr ""
 
-#: src/amule.cpp:665
+#: src/amule.cpp:666
 #, c-format
 msgid "WARNING: binding to network interface '%s' requires elevated privileges and was NOT applied - traffic may leave via the default route. Grant the capability (e.g. 'sudo setcap cap_net_raw+ep' on the aMule binary) or run with sufficient privileges."
 msgstr ""
 
-#: src/amule.cpp:673
+#: src/amule.cpp:674
 #, c-format
 msgid "WARNING: could not bind to network interface '%s' - traffic may leave via the default route."
 msgstr ""
 
-#: src/amule.cpp:732
+#: src/amule.cpp:733
 msgid "Your locale has been changed to System Default due to a configuration change. Sorry."
 msgstr "De taalinstelling is veranderd naar de systeemstandaard vanwege een configuratiewijziging. Sorry."
 
-#: src/amule.cpp:734 src/amule.cpp:1581 src/CatDialog.cpp:128
+#: src/amule.cpp:735 src/amule.cpp:1589 src/CatDialog.cpp:128
 #: src/CatDialog.cpp:136 src/CatDialog.cpp:149 src/ServerList.cpp:366
 #: src/ServerListCtrl.cpp:152
 msgid "Info"
 msgstr "Info"
 
-#: src/amule.cpp:741
+#: src/amule.cpp:742
 msgid ""
 "\n"
 "EC configuration"
@@ -289,74 +289,74 @@ msgstr ""
 "\n"
 "EV-configuratie"
 
-#: src/amule.cpp:744
+#: src/amule.cpp:745
 msgid "Password set and external connections enabled."
 msgstr "Wachtwoord ingesteld en externe verbindingen ingeschakeld."
 
-#: src/amule.cpp:754 src/KadDlg.cpp:176 src/KadDlg.cpp:185
-#: src/PrefsUnifiedDlg.cpp:1387 src/SharedFilesCtrl.cpp:476
+#: src/amule.cpp:755 src/KadDlg.cpp:176 src/KadDlg.cpp:185
+#: src/PrefsUnifiedDlg.cpp:1461 src/SharedFilesCtrl.cpp:476
 msgid "WARNING"
 msgstr "WAARSCHUWING"
 
-#: src/amule.cpp:991
+#: src/amule.cpp:992
 #, fuzzy
 msgid "Network bootstrap"
 msgstr "Netwerken"
 
-#: src/amule.cpp:996
+#: src/amule.cpp:997
 msgid ""
 "aMule has detected missing network bootstrap files.\n"
 "Select which ones to download:"
 msgstr ""
 
-#: src/amule.cpp:1005 src/FirstRunWizard.cpp:411
+#: src/amule.cpp:1006 src/FirstRunWizard.cpp:411
 #, fuzzy
 msgid "eD2k server list (server.met)"
 msgstr "%i server in server.met gevonden"
 
-#: src/amule.cpp:1012 src/FirstRunWizard.cpp:416
+#: src/amule.cpp:1013 src/FirstRunWizard.cpp:416
 msgid "Kad bootstrap nodes (nodes.dat)"
 msgstr ""
 
-#: src/amule.cpp:1102
+#: src/amule.cpp:1103
 #, c-format
 msgid "web server running on pid %d"
 msgstr "webserver draait met pid %d"
 
-#: src/amule.cpp:1115
+#: src/amule.cpp:1116
 #, fuzzy
 msgid "You requested to run web server on startup, but the amuleweb binary cannot be run. Please install the package containing aMule web server, or build aMule from source with -DBUILD_WEBSERVER=YES and install it."
 msgstr "U heeft ingesteld om de webserver te starten bij het opstarten, maar amuleweb kan niet gestart worden. Installeer het pakket met de aMule webserver, of compileer aMule met --enable-webserver en draai make install"
 
-#: src/amule.cpp:1120 src/amule.cpp:1177 src/amule.cpp:1291 src/amule.cpp:1593
+#: src/amule.cpp:1121 src/amule.cpp:1185 src/amule.cpp:1299 src/amule.cpp:1601
 #: src/amule-remote-gui.cpp:603 src/amule-remote-gui.cpp:671
 #: src/amule-remote-gui.cpp:709 src/amule-remote-gui.cpp:1282
 #: src/amule-remote-gui.cpp:1345 src/amule-remote-gui.cpp:1372
-#: src/DownloadQueue.cpp:1481
+#: src/DownloadQueue.cpp:1481 src/PrefsUnifiedDlg.cpp:1247
 msgid "ERROR"
 msgstr "FOUT"
 
-#: src/amule.cpp:1166
+#: src/amule.cpp:1174
 #, fuzzy, c-format
 msgid "amuleapi running on pid %d"
 msgstr "webserver draait met pid %d"
 
-#: src/amule.cpp:1172
+#: src/amule.cpp:1180
 #, fuzzy
 msgid "You requested to run amuleapi on startup, but the amuleapi binary cannot be run. Please install the package containing aMule's REST API server, or build aMule from source with -DBUILD_AMULEAPI=YES and install it."
 msgstr "U heeft ingesteld om de webserver te starten bij het opstarten, maar amuleweb kan niet gestart worden. Installeer het pakket met de aMule webserver, of compileer aMule met --enable-webserver en draai make install"
 
-#: src/amule.cpp:1259
+#: src/amule.cpp:1267
 #, c-format
 msgid "Could not bind ports to the specified address: %s"
 msgstr "Kon geen poorten koppelen aan het opgegeven adres: %s"
 
-#: src/amule.cpp:1283
+#: src/amule.cpp:1291
 #, c-format
 msgid "Port %u is not available. You will be LOWID\n"
 msgstr "Poort %u is niet beschikbaar. U krijgt een LAAG ID\n"
 
-#: src/amule.cpp:1288
+#: src/amule.cpp:1296
 #, c-format
 msgid ""
 "Port %u is not available!\n"
@@ -371,48 +371,48 @@ msgstr ""
 "\n"
 "Controleer uw netwerk en zorg ervoor dat de poort open is voor in- en uitgaand verkeer."
 
-#: src/amule.cpp:1385
+#: src/amule.cpp:1393
 msgid "Failed to create OnlineSig File"
 msgstr "Kon bestand met online handtekening niet maken"
 
-#: src/amule.cpp:1393
+#: src/amule.cpp:1401
 msgid "Failed to create aMule OnlineSig File"
 msgstr "Kon aMule OnlineHandtekening Bestand niet maken"
 
-#: src/amule.cpp:1556
+#: src/amule.cpp:1564
 msgid "The selected locale seems not to be installed on your box. (Note: I'll try to set it anyway)"
 msgstr "De gekozen taalinstelling lijkt niet geïnstalleerd te zijn op uw pc. (Let op: Ik probeer het toch in te stellen)"
 
-#: src/amule.cpp:1566
+#: src/amule.cpp:1574
 #, c-format
 msgid "This is the first time you run aMule %s"
 msgstr "Dit is de eerste keer dat u aMule %s draait"
 
-#: src/amule.cpp:1569
+#: src/amule.cpp:1577
 msgid "This version is a testing version, updated daily, and\n"
 msgstr "Dit is een testversie, dagelijks geupdatet, en\n"
 
-#: src/amule.cpp:1570
+#: src/amule.cpp:1578
 msgid "we give no warranty it won't break anything, burn your house,\n"
 msgstr "we geven geen garantie dat het niks kapot maakt of uw huis in brand steekt,\n"
 
-#: src/amule.cpp:1571
+#: src/amule.cpp:1579
 msgid "or kill your dog. But it *should* be safe to use anyway.\n"
 msgstr "of uw hond doodt. Maar het *zou* veilig moeten zijn om het te gebruiken.\n"
 
-#: src/amule.cpp:1576
+#: src/amule.cpp:1584
 msgid "More information, support and new releases can found at our homepage,\n"
 msgstr "Meer informatie, ondersteuning en niuwe versies kunnen gevonden worden op onze homepage,\n"
 
-#: src/amule.cpp:1577
+#: src/amule.cpp:1585
 msgid "at https://amule-org.github.io, or in our IRC channel #aMule at irc.libera.chat.\n"
 msgstr "op https://amule-org.github.io, of op ons IRC-kanaal #amule op irc.libera.chat.\n"
 
-#: src/amule.cpp:1579
+#: src/amule.cpp:1587
 msgid "Feel free to report any bugs to https://github.com/amule-org/amule/issues"
 msgstr "Bugs kunt u altijd melden op https://github.com/amule-org/amule/issues"
 
-#: src/amule.cpp:1591
+#: src/amule.cpp:1599
 msgid ""
 "The folder for Online Signature files you specified is INVALID!\n"
 " OnlineSignature will be DISABLED until you fix it on preferences."
@@ -420,137 +420,137 @@ msgstr ""
 "De map voor online-handtekeningbestanden die u heeft opgegeven is ONGELDIG!\n"
 " OnlineSignature is UITGESCHAKELD totdat u dit verbetert in voorkeuren."
 
-#: src/amule.cpp:1654
+#: src/amule.cpp:1662
 msgid "Server hostname notified"
 msgstr "Server-hostnaam geïnformeerd"
 
-#: src/amule.cpp:2031
+#: src/amule.cpp:2039
 #, c-format
 msgid "Disk space preallocation for file '%s' failed: %s"
 msgstr "Toewijzen schijfruimte voor bestand '%s' mislukt: %s"
 
-#: src/amule.cpp:2160
+#: src/amule.cpp:2168
 msgid "ERROR: can't open logfile"
 msgstr "FOUT: kan logbestand niet openen"
 
-#: src/amule.cpp:2164
+#: src/amule.cpp:2172
 msgid "WARNING: logfile is empty. Something is wrong."
 msgstr "WAARSCHUWING: logboekbestand is leeg. Er is iets mis."
 
-#: src/amule.cpp:2181
+#: src/amule.cpp:2189
 msgid "Log has been reset"
 msgstr "Logboek is gewist"
 
-#: src/amule.cpp:2205
+#: src/amule.cpp:2213
 #, c-format
 msgid "ServerMessage: %s"
 msgstr "Server-bericht: %s"
 
-#: src/amule.cpp:2248 src/IP2Country.cpp:220 src/IPFilter.cpp:514
+#: src/amule.cpp:2256 src/IP2Country.cpp:220 src/IPFilter.cpp:514
 #: src/ServerList.cpp:875
 #, c-format
 msgid "Skipped download of %s, because requested file is not newer."
 msgstr "Download van %s overgeslagen, omdat gevraagd bestand niet nieuwer is."
 
-#: src/amule.cpp:2251
+#: src/amule.cpp:2259
 msgid "Failed to download the nodes list."
 msgstr "Kon nodelijst niet downloaden."
 
-#: src/amule.cpp:2314
+#: src/amule.cpp:2322
 msgid "Failed to open the downloaded version check file"
 msgstr "Kon gedownload versie controle bestand niet openen"
 
-#: src/amule.cpp:2317 src/amule.cpp:2336
+#: src/amule.cpp:2325 src/amule.cpp:2344
 msgid "Corrupted version check file"
 msgstr "Beschadigd bestand voor versiecontrole"
 
-#: src/amule.cpp:2359
+#: src/amule.cpp:2367
 msgid "You are using an outdated version of aMule!"
 msgstr "U gebruikt een verouderde versie van aMule!"
 
-#: src/amule.cpp:2361
+#: src/amule.cpp:2369
 #, c-format
 msgid "Your aMule version is %i.%i.%i and the latest version is %li.%li.%li"
 msgstr "Uw aMule-versie is %i.%i.%i en de nieuwste versie is %li.%li.%li"
 
-#: src/amule.cpp:2365
+#: src/amule.cpp:2373
 msgid "The latest version can always be found at https://github.com/amule-org/amule/releases/latest"
 msgstr "De nieuwste versie kan altijd gevonden worden op https://github.com/amule-org/amule/releases/latest"
 
-#: src/amule.cpp:2368
+#: src/amule.cpp:2376
 #, c-format
 msgid "WARNING: Your aMuled version is outdated: %i.%i.%i < %li.%li.%li"
 msgstr "WAARSCHUWING: Uw aMuled-versie is verouderd: %i.%i.%i < %li.%li.%li"
 
-#: src/amule.cpp:2374
+#: src/amule.cpp:2382
 msgid "Your copy of aMule is up to date."
 msgstr "U heeft de nieuwste aMule-versie."
 
-#: src/amule.cpp:2381
+#: src/amule.cpp:2389
 msgid "Failed to download the version check file"
 msgstr "Kon bestand voor versiecontrole niet downloaden"
 
-#: src/amule.cpp:2550 src/amule-remote-gui.cpp:1133
+#: src/amule.cpp:2558 src/amule-remote-gui.cpp:1133
 #, c-format
 msgid "Users: %s | Files: %s"
 msgstr "Gebruikers: %s | Bestanden: %s"
 
-#: src/amule.cpp:2551 src/amule-remote-gui.cpp:1134
+#: src/amule.cpp:2559 src/amule-remote-gui.cpp:1134
 #, c-format
 msgid "Users: E: %s K: %s | Files: E: %s K: %s"
 msgstr "Gebruikers: E: %s K: %s | Bestanden: E: %s K: %s"
 
-#: src/amule.cpp:2565 src/amule-remote-gui.cpp:1147
+#: src/amule.cpp:2573 src/amule-remote-gui.cpp:1147
 msgid "No networks selected"
 msgstr "Geen netwerken geselecteerd"
 
-#: src/amule.cpp:2633 src/TextClient.cpp:903
+#: src/amule.cpp:2641 src/TextClient.cpp:903
 msgid "with LowID"
 msgstr "met Laag ID"
 
-#: src/amule.cpp:2633 src/TextClient.cpp:904
+#: src/amule.cpp:2641 src/TextClient.cpp:904
 msgid "with HighID"
 msgstr "met Hoog ID"
 
-#: src/amule.cpp:2635
+#: src/amule.cpp:2643
 #, c-format
 msgid "Connected to %s %s"
 msgstr "Verbonden met %s %s"
 
-#: src/amule.cpp:2640
+#: src/amule.cpp:2648
 #, c-format
 msgid "Connecting to %s"
 msgstr "Verbinden met %s"
 
-#: src/amule.cpp:2642
+#: src/amule.cpp:2650
 msgid "Disconnected from eD2k"
 msgstr "Verbinding verbroken met eD2K"
 
-#: src/amule.cpp:2651
+#: src/amule.cpp:2659
 msgid "Kad started."
 msgstr "Kad gestart."
 
-#: src/amule.cpp:2653
+#: src/amule.cpp:2661
 msgid "Kad stopped."
 msgstr "Kad gestopt."
 
-#: src/amule.cpp:2661
+#: src/amule.cpp:2669
 msgid "Connected to Kad (ok)"
 msgstr "Verbonden met Kad (ok)"
 
-#: src/amule.cpp:2663
+#: src/amule.cpp:2671
 msgid "Connected to Kad (firewalled)"
 msgstr "Verbonden met Kad (firewalled)"
 
-#: src/amule.cpp:2667
+#: src/amule.cpp:2675
 msgid "Disconnected from Kad"
 msgstr "Verbinding met Kad verbroken"
 
-#: src/amule.cpp:2699
+#: src/amule.cpp:2707
 msgid "Kad network cannot be used if UDP port is disabled on preferences, not starting."
 msgstr "Kad-netwerk kan niet gebruikt worden als de UDP-poort is uitgeschakeld in voorkeuren, wordt niet gestart."
 
-#: src/amule.cpp:2703
+#: src/amule.cpp:2711
 msgid "Kad network disabled on preferences, not connecting."
 msgstr "Kad-netwerk is uitgeschakeld in voorkeuren, wordt niet mee verbonden."
 
@@ -595,36 +595,36 @@ msgid "FATAL ERROR: Failed to create Timer"
 msgstr "FATALE FOUT: Kon Timer niet aanmaken"
 
 #: src/amuleDlg.cpp:361 src/amuleDlg.cpp:1787 src/amuleDlg.cpp:2033
-#: src/muuli_wdr.cpp:1492 src/muuli_wdr.cpp:3418
+#: src/muuli_wdr.cpp:1492 src/muuli_wdr.cpp:3449
 msgid "Networks"
 msgstr "Netwerken"
 
-#: src/amuleDlg.cpp:362 src/amuleDlg.cpp:1793 src/muuli_wdr.cpp:3419
+#: src/amuleDlg.cpp:362 src/amuleDlg.cpp:1793 src/muuli_wdr.cpp:3450
 msgid "Searches"
 msgstr "Zoeken"
 
 #: src/amuleDlg.cpp:363 src/amuleDlg.cpp:1799 src/DownloadListCtrl.cpp:740
-#: src/muuli_wdr.cpp:392 src/muuli_wdr.cpp:1585 src/muuli_wdr.cpp:3420
+#: src/muuli_wdr.cpp:392 src/muuli_wdr.cpp:1585 src/muuli_wdr.cpp:3451
 #: src/Statistics.cpp:829
 msgid "Downloads"
 msgstr "Downloads"
 
-#: src/amuleDlg.cpp:364 src/amuleDlg.cpp:1805 src/muuli_wdr.cpp:3294
+#: src/amuleDlg.cpp:364 src/amuleDlg.cpp:1805 src/muuli_wdr.cpp:3325
 msgid "Shared files"
 msgstr "Gedeelde bestanden"
 
-#: src/amuleDlg.cpp:365 src/amuleDlg.cpp:1811 src/muuli_wdr.cpp:2926
-#: src/muuli_wdr.cpp:3376 src/muuli_wdr.cpp:3423
+#: src/amuleDlg.cpp:365 src/amuleDlg.cpp:1811 src/muuli_wdr.cpp:2957
+#: src/muuli_wdr.cpp:3407 src/muuli_wdr.cpp:3454
 msgid "Messages"
 msgstr "Berichten"
 
-#: src/amuleDlg.cpp:366 src/amuleDlg.cpp:1817 src/muuli_wdr.cpp:3424
-#: src/PrefsUnifiedDlg.cpp:312 src/Statistics.cpp:779 src/Statistics.cpp:1235
+#: src/amuleDlg.cpp:366 src/amuleDlg.cpp:1817 src/muuli_wdr.cpp:3455
+#: src/PrefsUnifiedDlg.cpp:314 src/Statistics.cpp:779 src/Statistics.cpp:1235
 msgid "Statistics"
 msgstr "Statistieken"
 
-#: src/amuleDlg.cpp:368 src/amuleDlg.cpp:1824 src/muuli_wdr.cpp:3426
-#: src/PrefsUnifiedDlg.cpp:328 src/utils/wxCas/src/wxcasprefs.cpp:39
+#: src/amuleDlg.cpp:368 src/amuleDlg.cpp:1824 src/muuli_wdr.cpp:3457
+#: src/PrefsUnifiedDlg.cpp:330 src/utils/wxCas/src/wxcasprefs.cpp:39
 msgid "Preferences"
 msgstr "Voorkeuren"
 
@@ -682,8 +682,8 @@ msgstr "Kad: Uitgeschakeld"
 #: src/amuleDlg.cpp:1029 src/DownloadListCtrl.cpp:505
 #: src/DownloadListCtrl.cpp:749 src/FriendListCtrl.cpp:180
 #: src/muuli_wdr.cpp:731 src/muuli_wdr.cpp:782 src/muuli_wdr.cpp:846
-#: src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2231 src/muuli_wdr.cpp:2316
-#: src/muuli_wdr.cpp:3064 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
+#: src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2262 src/muuli_wdr.cpp:2347
+#: src/muuli_wdr.cpp:3095 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
 #: src/ServerListCtrl.cpp:606 src/TransferWnd.cpp:378
 #: src/utils/wxCas/src/wxcasprefs.cpp:235
 msgid "Cancel"
@@ -694,7 +694,7 @@ msgid "Stop the current connection attempts"
 msgstr "Beëindig de huidige verbindingspogingen"
 
 #: src/amuleDlg.cpp:1035 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976
-#: src/muuli_wdr.cpp:2454
+#: src/muuli_wdr.cpp:2485
 msgid "Disconnect"
 msgstr "Verbreek"
 
@@ -703,7 +703,7 @@ msgid "Disconnect from the currently connected networks"
 msgstr "Verbreek de huidige verbonden netwerken"
 
 #: src/amuleDlg.cpp:1041 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979
-#: src/muuli_wdr.cpp:2609 src/muuli_wdr.cpp:3061 src/muuli_wdr.cpp:3416
+#: src/muuli_wdr.cpp:2640 src/muuli_wdr.cpp:3092 src/muuli_wdr.cpp:3447
 msgid "Connect"
 msgstr "Verbinden"
 
@@ -757,7 +757,7 @@ msgstr "Bevestig afsluiten"
 msgid "Launch Command: "
 msgstr "Voer commando uit: "
 
-#: src/amuleDlg.cpp:1632 src/muuli_wdr.cpp:1978 src/Preferences.cpp:952
+#: src/amuleDlg.cpp:1632 src/muuli_wdr.cpp:1982 src/Preferences.cpp:979
 msgid "- default -"
 msgstr "- standaard -"
 
@@ -771,48 +771,48 @@ msgstr "Skinmap '%s' bestaat niet"
 msgid "WARNING: Unable to open skin file '%s' for read"
 msgstr "WAARSCHUWING: Kon skin-bestand '%s' niet openen om te lezen"
 
-#: src/amuleDlg.cpp:1791 src/muuli_wdr.cpp:3418
+#: src/amuleDlg.cpp:1791 src/muuli_wdr.cpp:3449
 msgid "Networks Window"
 msgstr "Netwerkvenster"
 
-#: src/amuleDlg.cpp:1797 src/muuli_wdr.cpp:3419
+#: src/amuleDlg.cpp:1797 src/muuli_wdr.cpp:3450
 msgid "Searches Window"
 msgstr "Zoekvenster"
 
-#: src/amuleDlg.cpp:1803 src/muuli_wdr.cpp:3420
+#: src/amuleDlg.cpp:1803 src/muuli_wdr.cpp:3451
 msgid "Downloads Window"
 msgstr "Downloadsvenster"
 
-#: src/amuleDlg.cpp:1809 src/muuli_wdr.cpp:3422
+#: src/amuleDlg.cpp:1809 src/muuli_wdr.cpp:3453
 msgid "Shared Files Window"
 msgstr "Gedeelde bestanden-venster"
 
-#: src/amuleDlg.cpp:1815 src/muuli_wdr.cpp:3423
+#: src/amuleDlg.cpp:1815 src/muuli_wdr.cpp:3454
 msgid "Messages Window"
 msgstr "Berichtenvenster"
 
-#: src/amuleDlg.cpp:1821 src/muuli_wdr.cpp:3424
+#: src/amuleDlg.cpp:1821 src/muuli_wdr.cpp:3455
 msgid "Statistics Graph Window"
 msgstr "Statistiekenvenster (Grafieken)"
 
-#: src/amuleDlg.cpp:1828 src/muuli_wdr.cpp:3426
+#: src/amuleDlg.cpp:1828 src/muuli_wdr.cpp:3457
 msgid "Preferences Settings Window"
 msgstr "Voorkeureninstellingen-venster"
 
-#: src/amuleDlg.cpp:1831 src/muuli_wdr.cpp:3427
+#: src/amuleDlg.cpp:1831 src/muuli_wdr.cpp:3458
 msgid "Import"
 msgstr "Importeer"
 
-#: src/amuleDlg.cpp:1835 src/muuli_wdr.cpp:3427
+#: src/amuleDlg.cpp:1835 src/muuli_wdr.cpp:3458
 msgid "The partfile importer tool"
 msgstr "Het deelbestand importeerprogramma"
 
-#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3428
+#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3459
 #: src/utils/aLinkCreator/src/alcframe.cpp:262
 msgid "About"
 msgstr "Over"
 
-#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3428
+#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3459
 msgid "About/Help"
 msgstr "Over/Help"
 
@@ -954,7 +954,7 @@ msgstr "Bestand niet gevonden."
 msgid "The core rejected these shared folders:%s"
 msgstr ""
 
-#: src/amule-remote-gui.cpp:1336 src/ExternalConn.cpp:2345
+#: src/amule-remote-gui.cpp:1336 src/ExternalConn.cpp:2346
 msgid "Invalid link or already on list."
 msgstr "Ongeldige link of al op de lijst."
 
@@ -970,7 +970,7 @@ msgstr "Kan map '%s' niet aanmaken voor categorie '%s', map '%s' wordt behouden.
 #: src/ClientDetailDialog.cpp:123 src/DataToText.cpp:61 src/DataToText.cpp:86
 #: src/DataToText.cpp:101 src/DataToText.cpp:136 src/DataToText.cpp:165
 #: src/DownloadListCtrl.cpp:1172 src/DownloadListCtrl.cpp:1185
-#: src/DownloadListCtrl.cpp:1196 src/ExternalConn.cpp:608
+#: src/DownloadListCtrl.cpp:1196 src/ExternalConn.cpp:609
 #: src/FileDetailDialog.cpp:203 src/FileDetailDialog.cpp:235
 #: src/FileDetailDialog.cpp:242 src/GenericClientListCtrl.cpp:1171
 #: src/GenericClientListCtrl.cpp:1182 src/GenericClientListCtrl.cpp:1192
@@ -1357,19 +1357,19 @@ msgstr "Auto [Ho]"
 msgid "Very low"
 msgstr "Heel laag"
 
-#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:743 src/muuli_wdr.cpp:2282
+#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:743 src/muuli_wdr.cpp:2313
 #: src/ServerListCtrl.cpp:263 src/ServerListCtrl.cpp:456
 #: src/SharedFilesCtrl.cpp:145
 msgid "Low"
 msgstr "Laag"
 
-#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:744 src/muuli_wdr.cpp:2283
+#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:744 src/muuli_wdr.cpp:2314
 #: src/ServerListCtrl.cpp:266 src/ServerListCtrl.cpp:457
 #: src/SharedFilesCtrl.cpp:146
 msgid "Normal"
 msgstr "Normaal"
 
-#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:745 src/muuli_wdr.cpp:2284
+#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:745 src/muuli_wdr.cpp:2315
 #: src/ServerListCtrl.cpp:269 src/ServerListCtrl.cpp:458
 #: src/SharedFilesCtrl.cpp:147
 msgid "High"
@@ -1461,7 +1461,7 @@ msgstr "Lokale server"
 msgid "Remote Server"
 msgstr "Server op Afstand"
 
-#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3181
+#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3212
 #: src/SearchDlg.cpp:119 src/TextClient.cpp:911
 msgid "Kad"
 msgstr "Kad"
@@ -1533,7 +1533,7 @@ msgstr "Deel"
 msgid "Size"
 msgstr "Grootte"
 
-#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3248
+#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3279
 msgid "Transferred"
 msgstr "Overgebracht"
 
@@ -1591,7 +1591,7 @@ msgstr ""
 "Feedback van: %s (%s)\n"
 "\n"
 
-#: src/DownloadListCtrl.cpp:746 src/muuli_wdr.cpp:2285
+#: src/DownloadListCtrl.cpp:746 src/muuli_wdr.cpp:2316
 #: src/SharedFilesCtrl.cpp:150
 msgid "Auto"
 msgstr "Auto"
@@ -1629,7 +1629,7 @@ msgid "Extended Options"
 msgstr "Uitgebreide opties"
 
 #: src/DownloadListCtrl.cpp:770 src/DownloadListCtrl.cpp:822
-#: src/muuli_wdr.cpp:1796
+#: src/muuli_wdr.cpp:1800
 msgid "Preview"
 msgstr "Voorbeeld"
 
@@ -1805,227 +1805,232 @@ msgstr[1] ""
 msgid "Invalid eD2k link! ERROR: %s"
 msgstr "Ongeldige eD2k-link! FOUT: %s"
 
-#: src/ExternalConn.cpp:379
+#: src/ExternalConn.cpp:380
 msgid "Client sent packet after authentication failed."
 msgstr "Client verstuurde pakket nadat authenticatie mislukte."
 
-#: src/ExternalConn.cpp:396
+#: src/ExternalConn.cpp:397
 msgid "External connection closed."
 msgstr "Externe verbinding gesloten."
 
-#: src/ExternalConn.cpp:473
+#: src/ExternalConn.cpp:474
 msgid "External connections disabled due to empty password!"
 msgstr "Externe verbindingen uitgeschakeld vanwege leeg wachtwoord!"
 
-#: src/ExternalConn.cpp:494
+#: src/ExternalConn.cpp:495
 msgid "External connections disabled in config file"
 msgstr "Externe verbindingen uitgeschakeld in configuratiebestand"
 
-#: src/ExternalConn.cpp:575
+#: src/ExternalConn.cpp:576
 msgid "New external connection accepted"
 msgstr "Nieuwe externe verbinding geaccepteerd"
 
-#: src/ExternalConn.cpp:578
+#: src/ExternalConn.cpp:579
 msgid "ERROR: couldn't accept a new external connection"
 msgstr "FOUT: kon nieuwe externe verbinding niet accepteren"
 
-#: src/ExternalConn.cpp:595
+#: src/ExternalConn.cpp:596
 msgid "External connection refused due to empty password in preferences!"
 msgstr "Externe verbinding geweigerd vanwege leeg wachtwoord bij voorkeuren!"
 
-#: src/ExternalConn.cpp:607
+#: src/ExternalConn.cpp:608
 #, c-format
 msgid "Connecting client: %s %s"
 msgstr "Client verbinden: %s %s"
 
-#: src/ExternalConn.cpp:609
+#: src/ExternalConn.cpp:610
 msgid "Unknown version"
 msgstr "Onbekende versie"
 
-#: src/ExternalConn.cpp:622
+#: src/ExternalConn.cpp:623
 msgid "Incorrect EC version ID, there might be binary incompatibility. Use core and remote from same snapshot."
 msgstr "Incorrecte EV-versie ID, mogelijk niet compatible. Gebruik kern en op afstand van dezelfde snapshot."
 
-#: src/ExternalConn.cpp:630
+#: src/ExternalConn.cpp:631
 msgid "You cannot connect to a release version from an arbitrary development snapshot! *sigh* possible crash prevented"
 msgstr "U kunt niet verbinden met een release-versie vanaf een willekeurig ontwikkelingssnapshot! *zucht* mogelijke crash voorkomen"
 
-#: src/ExternalConn.cpp:713
+#: src/ExternalConn.cpp:714
 msgid "Invalid protocol version."
 msgstr "Ongeldige protocolversie."
 
-#: src/ExternalConn.cpp:719
+#: src/ExternalConn.cpp:720
 msgid "Missing protocol version tag."
 msgstr "Ontbrekend label van protocolversie."
 
-#: src/ExternalConn.cpp:727
+#: src/ExternalConn.cpp:728
 msgid "Authentication failed: invalid hash specified as EC password."
 msgstr "Authenticatie mislukt: ongeldige hash opgegeven als EV-wachtwoord."
 
-#: src/ExternalConn.cpp:775
+#: src/ExternalConn.cpp:776
 msgid "Authentication failed: wrong password."
 msgstr "Authenticatie mislukt: verkeerd wachtwoord."
 
-#: src/ExternalConn.cpp:777
+#: src/ExternalConn.cpp:778
 msgid "Authentication failed: missing password."
 msgstr "Authenticatie mislukt: ontbrekend wachtwoord."
 
-#: src/ExternalConn.cpp:788
+#: src/ExternalConn.cpp:789
 msgid "Invalid request, please authenticate first."
 msgstr "Ongeldig verzoek, authenticeer eerst."
 
-#: src/ExternalConn.cpp:793
+#: src/ExternalConn.cpp:794
 msgid "Access granted."
 msgstr "Toegang verleend."
 
-#: src/ExternalConn.cpp:801
+#: src/ExternalConn.cpp:802
 #, c-format
 msgid "Sent error message \"%s\" to client."
 msgstr "Foutmelding \"%s\" verzonden naar client."
 
-#: src/ExternalConn.cpp:806
+#: src/ExternalConn.cpp:807
 #, c-format
 msgid "Unauthorized access attempt from %s. Connection closed."
 msgstr "Poging tot ongeautoriseerde toegang van %s. Verbinding gesloten."
 
-#: src/ExternalConn.cpp:1419
+#: src/ExternalConn.cpp:1420
 #, c-format
 msgid "Remote PartFile command failed: FileHash not found: %s"
 msgstr "Deelbestand-commando op afstand mislukt: Bestands-hash niet gevonden: %s"
 
-#: src/ExternalConn.cpp:1423
+#: src/ExternalConn.cpp:1424
 #, c-format
 msgid "FileHash not found: %s"
 msgstr "Bestandshash niet gevonden: %s"
 
-#: src/ExternalConn.cpp:1470 src/ExternalConn.cpp:1558
-#: src/ExternalConn.cpp:1679
+#: src/ExternalConn.cpp:1471 src/ExternalConn.cpp:1559
+#: src/ExternalConn.cpp:1680
 msgid "OOPS! OpCode processing error!"
 msgstr "OEPS! OpCode verwerkingsfout!"
 
-#: src/ExternalConn.cpp:1501
+#: src/ExternalConn.cpp:1502
 msgid "Server not added"
 msgstr "Server niet toegevoegd"
 
-#: src/ExternalConn.cpp:1520
+#: src/ExternalConn.cpp:1521
 #, c-format
 msgid "server not found: %s"
 msgstr "server niet gevonden: %s"
 
-#: src/ExternalConn.cpp:1537
+#: src/ExternalConn.cpp:1538
 msgid "need to define server to be removed"
 msgstr "moet de te verwijderen server opgeven"
 
-#: src/ExternalConn.cpp:1552
+#: src/ExternalConn.cpp:1553
 msgid "eD2k is disabled in preferences."
 msgstr "eD2K is uitgeschakeld in voorkeuren."
 
-#: src/ExternalConn.cpp:1657
+#: src/ExternalConn.cpp:1658
 #, fuzzy
 msgid "Friend not found."
 msgstr "Bestand niet gevonden."
 
-#: src/ExternalConn.cpp:1667
+#: src/ExternalConn.cpp:1668
 #, fuzzy
 msgid "Client not found."
 msgstr "Bestand niet gevonden."
 
-#: src/ExternalConn.cpp:1673
+#: src/ExternalConn.cpp:1674
 msgid "EC_TAG_FRIEND_SHARED requires EC_TAG_FRIEND or EC_TAG_CLIENT."
 msgstr ""
 
-#: src/ExternalConn.cpp:1991
+#: src/ExternalConn.cpp:1992
 msgid "WebSearch from remote interface makes no sense."
 msgstr "WebSearch vanaf afstand is zinloos."
 
-#: src/ExternalConn.cpp:2026
+#: src/ExternalConn.cpp:2027
 msgid "Search in progress. Refetch results in a moment!"
 msgstr "Bezig met zoeken. Haal de resultaten op over een momentje!"
 
-#: src/ExternalConn.cpp:2265
+#: src/ExternalConn.cpp:2266
 msgid "No points for graph."
 msgstr "Geen punten voor grafiek."
 
-#: src/ExternalConn.cpp:2275
+#: src/ExternalConn.cpp:2276
 msgid "Your client is not configured for this detail level."
 msgstr "Uw client is niet geconfigureerd voor dit niveau van details."
 
-#: src/ExternalConn.cpp:2302
+#: src/ExternalConn.cpp:2303
 msgid "External Connection: shutdown requested"
 msgstr "Externe verbinding: afsluiten aangevraagd"
 
-#: src/ExternalConn.cpp:2314
+#: src/ExternalConn.cpp:2315
 msgid "Already shutting down."
 msgstr "Al bezig met afsluiten."
 
-#: src/ExternalConn.cpp:2332
+#: src/ExternalConn.cpp:2333
 #, c-format
 msgid "ExternalConn: adding link '%s'."
 msgstr "ExterneVerb: link '%s' wordt toegevoegd."
 
-#: src/ExternalConn.cpp:2350
+#: src/ExternalConn.cpp:2351
 #, fuzzy, c-format
 msgid "%d of %d links failed (invalid or already on list)."
 msgstr "Ongeldige link of al op de lijst."
 
-#: src/ExternalConn.cpp:2373
+#: src/ExternalConn.cpp:2374
 msgid "Version check throttled; try again shortly."
 msgstr ""
 
-#: src/ExternalConn.cpp:2378
+#: src/ExternalConn.cpp:2379
 msgid "Version check is not available on this daemon."
 msgstr ""
 
-#: src/ExternalConn.cpp:2508
+#: src/ExternalConn.cpp:2509
 msgid "File not found."
 msgstr "Bestand niet gevonden."
 
-#: src/ExternalConn.cpp:2513
+#: src/ExternalConn.cpp:2514
 msgid "Invalid file name."
 msgstr "Ongeldige bestandsnaam."
 
-#: src/ExternalConn.cpp:2521
+#: src/ExternalConn.cpp:2522
 msgid "Unable to rename file."
 msgstr "Kon naam van bestand niet wijzigen."
 
-#: src/ExternalConn.cpp:2992 src/ExternalConn.cpp:3020
+#: src/ExternalConn.cpp:2839
+#, c-format
+msgid "Could not save the amuleapi password: %s"
+msgstr ""
+
+#: src/ExternalConn.cpp:3004 src/ExternalConn.cpp:3032
 msgid "Kad is disabled in preferences."
 msgstr "Kad is uitgeschakeld in voorkeuren."
 
-#: src/ExternalConn.cpp:3033
+#: src/ExternalConn.cpp:3045
 msgid "Already connected to eD2k."
 msgstr "Al verbonden met eD2K."
 
-#: src/ExternalConn.cpp:3036
+#: src/ExternalConn.cpp:3048
 msgid "Connecting to eD2k..."
 msgstr "Aan het verbinden met eD2k..."
 
-#: src/ExternalConn.cpp:3045
+#: src/ExternalConn.cpp:3057
 msgid "Already connected to Kad."
 msgstr "Al verbonden met Kad."
 
-#: src/ExternalConn.cpp:3048
+#: src/ExternalConn.cpp:3060
 msgid "Connecting to Kad..."
 msgstr "Verbinding met Kad wordt gemaakt..."
 
-#: src/ExternalConn.cpp:3055
+#: src/ExternalConn.cpp:3067
 msgid "All networks are disabled."
 msgstr "Alle netwerken zijn uitgeschakeld."
 
-#: src/ExternalConn.cpp:3064
+#: src/ExternalConn.cpp:3076
 msgid "Disconnected from eD2k."
 msgstr "Verbinding met eD2K verbroken."
 
-#: src/ExternalConn.cpp:3069
+#: src/ExternalConn.cpp:3081
 msgid "Disconnected from Kad."
 msgstr "Verbinding met Kad verbroken."
 
-#: src/ExternalConn.cpp:3078
+#: src/ExternalConn.cpp:3090
 #, c-format
 msgid "External Connection: invalid opcode received: %#x"
 msgstr "Externe verbinding: ongeldige opcode ontvangen: %#x"
 
-#: src/ExternalConn.cpp:3083
+#: src/ExternalConn.cpp:3095
 msgid "Invalid opcode (wrong protocol version?)"
 msgstr "Ongeldige opcode (verkeerde protocolversie?)"
 
@@ -2427,23 +2432,23 @@ msgid ""
 "want downloads on a different (e.g. larger) disk."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:549 src/FirstRunWizard.cpp:611 src/muuli_wdr.cpp:1708
+#: src/FirstRunWizard.cpp:549 src/FirstRunWizard.cpp:611 src/muuli_wdr.cpp:1712
 msgid "Destination folder for downloads"
 msgstr "Doelmap voor downloads"
 
 #: src/FirstRunWizard.cpp:553 src/FirstRunWizard.cpp:569 src/muuli_wdr.cpp:1349
-#: src/muuli_wdr.cpp:1366 src/muuli_wdr.cpp:1683 src/muuli_wdr.cpp:1714
-#: src/muuli_wdr.cpp:1726 src/muuli_wdr.cpp:2769
+#: src/muuli_wdr.cpp:1366 src/muuli_wdr.cpp:1687 src/muuli_wdr.cpp:1718
+#: src/muuli_wdr.cpp:1730 src/muuli_wdr.cpp:2800
 #: src/utils/aLinkCreator/src/alcframe.cpp:135
 #: src/utils/wxCas/src/wxcasprefs.cpp:52 src/utils/wxCas/src/wxcasprefs.cpp:118
 msgid "Browse"
 msgstr "Bladeren"
 
-#: src/FirstRunWizard.cpp:559 src/muuli_wdr.cpp:1719
+#: src/FirstRunWizard.cpp:559 src/muuli_wdr.cpp:1723
 msgid "(All files in this folder are shared with other peers)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:565 src/FirstRunWizard.cpp:624 src/muuli_wdr.cpp:1721
+#: src/FirstRunWizard.cpp:565 src/FirstRunWizard.cpp:624 src/muuli_wdr.cpp:1725
 msgid "Folder for temporary download files"
 msgstr "Map voor tijdelijke downloadbestanden"
 
@@ -2474,7 +2479,7 @@ msgstr "Kon niet schrijven naar vriendenlijst-bestand 'emfriends.met'!"
 msgid "CRITICAL - no client on StartChatSession"
 msgstr "KRITIEK - geen client bij StartChatSession"
 
-#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2675 src/muuli_wdr.cpp:3352
+#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2706 src/muuli_wdr.cpp:3383
 msgid "Friends"
 msgstr "Vrienden"
 
@@ -2585,8 +2590,8 @@ msgstr "Geen"
 msgid "No"
 msgstr "Nee"
 
-#: src/GenericClientListCtrl.cpp:1216 src/PrefsUnifiedDlg.cpp:2818
-#: src/PrefsUnifiedDlg.cpp:2868 src/ServerListCtrl.cpp:276
+#: src/GenericClientListCtrl.cpp:1216 src/PrefsUnifiedDlg.cpp:2898
+#: src/PrefsUnifiedDlg.cpp:2948 src/ServerListCtrl.cpp:276
 msgid "Yes"
 msgstr "Ja"
 
@@ -2755,10 +2760,10 @@ msgstr "Ongeldige poort om van te bootstrappen"
 msgid "Please fill all fields required"
 msgstr "Vul alle benodigde velden in"
 
-#: src/KadDlg.cpp:192 src/PartFile.cpp:1031 src/PrefsUnifiedDlg.cpp:1162
-#: src/PrefsUnifiedDlg.cpp:1331 src/PrefsUnifiedDlg.cpp:1589
-#: src/PrefsUnifiedDlg.cpp:1599 src/PrefsUnifiedDlg.cpp:1616
-#: src/PrefsUnifiedDlg.cpp:1658
+#: src/KadDlg.cpp:192 src/PartFile.cpp:1031 src/PrefsUnifiedDlg.cpp:1134
+#: src/PrefsUnifiedDlg.cpp:1204 src/PrefsUnifiedDlg.cpp:1405
+#: src/PrefsUnifiedDlg.cpp:1663 src/PrefsUnifiedDlg.cpp:1673
+#: src/PrefsUnifiedDlg.cpp:1690 src/PrefsUnifiedDlg.cpp:1738
 msgid "Message"
 msgstr "Bericht"
 
@@ -2860,7 +2865,7 @@ msgstr "Deelverhouding"
 msgid "Uploaded"
 msgstr "Geüpload"
 
-#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3232
+#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3263
 msgid "Requested"
 msgstr "Aangevraagd"
 
@@ -2984,7 +2989,7 @@ msgid "WARNING: "
 msgstr "WAARSCHUWING: "
 
 #: src/MuleNotebook.cpp:179 src/muuli_wdr.cpp:817 src/muuli_wdr.cpp:1229
-#: src/muuli_wdr.cpp:3136 src/muuli_wdr.cpp:3392
+#: src/muuli_wdr.cpp:3167 src/muuli_wdr.cpp:3423
 msgid "Close"
 msgstr "Sluiten"
 
@@ -3002,7 +3007,7 @@ msgid "Paste"
 msgstr "Plakken"
 
 #: src/MuleTextCtrl.cpp:89 src/muuli_wdr.cpp:358 src/muuli_wdr.cpp:757
-#: src/muuli_wdr.cpp:2359 src/muuli_wdr.cpp:2378 src/muuli_wdr.cpp:2400
+#: src/muuli_wdr.cpp:2390 src/muuli_wdr.cpp:2409 src/muuli_wdr.cpp:2431
 #: src/utils/aLinkCreator/src/alcframe.cpp:142
 msgid "Clear"
 msgstr "Wissen"
@@ -3101,7 +3106,7 @@ msgstr "Afsluiten"
 
 #: src/MuleTrayIcon.cpp:579 src/MuleTrayIcon.cpp:945 src/MuleTrayIcon.cpp:965
 #: src/muuli_wdr.cpp:1398 src/muuli_wdr.cpp:1406 src/muuli_wdr.cpp:1413
-#: src/muuli_wdr.cpp:1842 src/muuli_wdr.cpp:1848 src/OtherFunctions.cpp:91
+#: src/muuli_wdr.cpp:1846 src/muuli_wdr.cpp:1852 src/OtherFunctions.cpp:91
 #: src/StatisticsDlg.cpp:93 src/StatisticsDlg.cpp:95
 msgid "kB/s"
 msgstr "kB/s"
@@ -3344,7 +3349,7 @@ msgstr "Bytes"
 msgid "KB"
 msgstr "KB"
 
-#: src/muuli_wdr.cpp:274 src/muuli_wdr.cpp:293 src/muuli_wdr.cpp:1627
+#: src/muuli_wdr.cpp:274 src/muuli_wdr.cpp:293 src/muuli_wdr.cpp:1631
 #: src/OtherFunctions.cpp:64
 msgid "MB"
 msgstr "MB"
@@ -3361,7 +3366,7 @@ msgstr "Max grootte"
 msgid "Availability"
 msgstr "Beschikbaarheid"
 
-#: src/muuli_wdr.cpp:312 src/muuli_wdr.cpp:398 src/muuli_wdr.cpp:3297
+#: src/muuli_wdr.cpp:312 src/muuli_wdr.cpp:398 src/muuli_wdr.cpp:3328
 msgid "Filter:"
 msgstr "Filter:"
 
@@ -3424,12 +3429,12 @@ msgstr "Bestandsbronnen:"
 #: src/muuli_wdr.cpp:1160 src/muuli_wdr.cpp:1167 src/muuli_wdr.cpp:1172
 #: src/muuli_wdr.cpp:1179 src/muuli_wdr.cpp:1184 src/muuli_wdr.cpp:1191
 #: src/muuli_wdr.cpp:1205 src/muuli_wdr.cpp:1212 src/muuli_wdr.cpp:1217
-#: src/muuli_wdr.cpp:1224 src/muuli_wdr.cpp:3234 src/muuli_wdr.cpp:3242
-#: src/muuli_wdr.cpp:3250
+#: src/muuli_wdr.cpp:1224 src/muuli_wdr.cpp:3265 src/muuli_wdr.cpp:3273
+#: src/muuli_wdr.cpp:3281
 msgid "N/A"
 msgstr "N/B"
 
-#: src/muuli_wdr.cpp:508 src/muuli_wdr.cpp:1065 src/PrefsUnifiedDlg.cpp:297
+#: src/muuli_wdr.cpp:508 src/muuli_wdr.cpp:1065 src/PrefsUnifiedDlg.cpp:299
 msgid "General"
 msgstr "Algemeen"
 
@@ -3570,7 +3575,7 @@ msgstr ""
 msgid "Album :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:685 src/muuli_wdr.cpp:2254
+#: src/muuli_wdr.cpp:685 src/muuli_wdr.cpp:2285
 msgid "Title :"
 msgstr "Titel :"
 
@@ -3679,7 +3684,7 @@ msgstr "Gebruikersnaam :"
 msgid "Userhash :"
 msgstr "Gebruikershash :"
 
-#: src/muuli_wdr.cpp:895 src/muuli_wdr.cpp:1748 src/muuli_wdr.cpp:2449
+#: src/muuli_wdr.cpp:895 src/muuli_wdr.cpp:1752 src/muuli_wdr.cpp:2480
 #: src/utils/aLinkCreator/src/alcframe.cpp:137
 msgid "Add"
 msgstr "Toevoegen"
@@ -3688,15 +3693,15 @@ msgstr "Toevoegen"
 msgid "Download-Speed"
 msgstr "Downloadsnelheid"
 
-#: src/muuli_wdr.cpp:954 src/muuli_wdr.cpp:989 src/muuli_wdr.cpp:2553
+#: src/muuli_wdr.cpp:954 src/muuli_wdr.cpp:989 src/muuli_wdr.cpp:2584
 msgid "Current"
 msgstr "Huidige"
 
-#: src/muuli_wdr.cpp:962 src/muuli_wdr.cpp:997 src/muuli_wdr.cpp:2561
+#: src/muuli_wdr.cpp:962 src/muuli_wdr.cpp:997 src/muuli_wdr.cpp:2592
 msgid "Running average"
 msgstr "Lopende gemiddelde"
 
-#: src/muuli_wdr.cpp:970 src/muuli_wdr.cpp:1005 src/muuli_wdr.cpp:2569
+#: src/muuli_wdr.cpp:970 src/muuli_wdr.cpp:1005 src/muuli_wdr.cpp:2600
 msgid "Session average"
 msgstr "Sessie gemiddelde"
 
@@ -3708,7 +3713,7 @@ msgstr "Uploadsnelheid"
 msgid "Connections"
 msgstr "Verbindingen"
 
-#: src/muuli_wdr.cpp:1024 src/muuli_wdr.cpp:1867
+#: src/muuli_wdr.cpp:1024 src/muuli_wdr.cpp:1871
 msgid "Active downloads"
 msgstr "Actieve downloads"
 
@@ -3716,7 +3721,7 @@ msgstr "Actieve downloads"
 msgid "Active connections (1:1)"
 msgstr "Actieve verbinding (1:1)"
 
-#: src/muuli_wdr.cpp:1040 src/muuli_wdr.cpp:1868
+#: src/muuli_wdr.cpp:1040 src/muuli_wdr.cpp:1872
 msgid "Active uploads"
 msgstr "Actieve uploads"
 
@@ -3992,7 +3997,7 @@ msgstr "Bind lokaal adres aan IP (laat leeg voor elk):"
 msgid "Advanced users only: If you have multiple network interfaces, enter the address of the interface to which aMule should be bound."
 msgstr "Enkel voor gevorderde gebruikers: Als u meerdere netwerk-interfaces hebt, voer hier het adres in van de interface waar aMule mee verbonden moet worden."
 
-#: src/muuli_wdr.cpp:1462 src/muuli_wdr.cpp:2061
+#: src/muuli_wdr.cpp:1462 src/muuli_wdr.cpp:2065
 #, fuzzy
 msgid "Bind to network interface (empty for any):"
 msgstr "Bind lokaal adres aan IP (laat leeg voor elk):"
@@ -4009,7 +4014,7 @@ msgstr "Max bronnen per bestand aan het downloaden:"
 msgid "Max simultaneous connections:"
 msgstr "Max gelijktijdige verbindingen:"
 
-#: src/muuli_wdr.cpp:1498 src/muuli_wdr.cpp:3176
+#: src/muuli_wdr.cpp:1498 src/muuli_wdr.cpp:3207
 msgid "ED2K"
 msgstr "ED2K"
 
@@ -4101,755 +4106,778 @@ msgstr "Wijst schijfruimte toe voor nieuwe bestanden"
 msgid "For new files preallocates disk space for the whole file, thus reduces fragmentation"
 msgstr "Wijst schijfruimte toe voor nieuwe bestanden, beperkt hierdoor fragmentatie"
 
-#: src/muuli_wdr.cpp:1613
+#: src/muuli_wdr.cpp:1617
 msgid "Create new files as sparse files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1614
-msgid "A sparse file reserves its full size on disk immediately without writing real data to it -- fast, but unsupported or slow on some filesystems, and free-space accounting stays optimistic while the download is in progress. Turn this off to grow the file only as data arrives."
+#: src/muuli_wdr.cpp:1618
+msgid "Sparse part files only occupy disk space for the parts already downloaded, so free space is used up gradually as the file fills in. Turn this off to use an ordinary file instead - useful where sparse files are unsupported or slow, or where backup/de-duplication tools handle them badly. Applies only when the core runs on Windows; on Linux and macOS part files are sparse anyway and this setting has no effect."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1619
+#: src/muuli_wdr.cpp:1623
 msgid "Stop downloads when free disk space reaches "
 msgstr "Stop downloads als de vrije schijfruimte bedraagt "
 
-#: src/muuli_wdr.cpp:1620
+#: src/muuli_wdr.cpp:1624
 msgid "Select this if you want aMule to check your disk space"
 msgstr "Selecteer dit als u wilt dat aMule uw schijfruimte controleert"
 
-#: src/muuli_wdr.cpp:1624
+#: src/muuli_wdr.cpp:1628
 msgid "Enter here the min disk space desired."
 msgstr "Voer hier de gewenste min schijfruimte in."
 
-#: src/muuli_wdr.cpp:1630
+#: src/muuli_wdr.cpp:1634
 msgid "Save 10 sources on rare files (< 20 sources)"
 msgstr "Bewaar 10 bronnen van zeldzame bestanden (<20 bronnen)"
 
-#: src/muuli_wdr.cpp:1634 src/Statistics.cpp:790
+#: src/muuli_wdr.cpp:1638 src/Statistics.cpp:790
 msgid "Uploads"
 msgstr "Uploads"
 
-#: src/muuli_wdr.cpp:1637
+#: src/muuli_wdr.cpp:1641
 msgid "Add new shared files with auto priority"
 msgstr "Voeg nieuwe gedeelde bestanden toe met automatische prioriteit"
 
-#: src/muuli_wdr.cpp:1643
+#: src/muuli_wdr.cpp:1647
 msgid "Intelligent Corruption Handling (I.C.H.)"
 msgstr "Intelligente corruptieafhandling (I.C.H.)"
 
-#: src/muuli_wdr.cpp:1646
+#: src/muuli_wdr.cpp:1650
 msgid "Enable"
 msgstr "Inschakelen"
 
-#: src/muuli_wdr.cpp:1649
+#: src/muuli_wdr.cpp:1653
 msgid "Advanced I.C.H. trusts every hash (not recommended)"
 msgstr "Geavanceerde I.C.H. vertrouwt elke hash (niet aanbevolen)"
 
-#: src/muuli_wdr.cpp:1661 src/PrefsUnifiedDlg.cpp:1910
+#: src/muuli_wdr.cpp:1665 src/PrefsUnifiedDlg.cpp:1990
 msgid "Media metadata extraction"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1665
+#: src/muuli_wdr.cpp:1669
 msgid "Extract length / bitrate / codec from shared audio and video files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1667
+#: src/muuli_wdr.cpp:1671
 msgid "When enabled, aMule runs ffprobe on each shared media file to fill in the Length / Bitrate / Codec columns other clients see when they find the file in a search. Requires ffmpeg (the ffprobe binary) to be installed."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1674
+#: src/muuli_wdr.cpp:1678
 msgid "Path to ffprobe:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1679
+#: src/muuli_wdr.cpp:1683
 msgid "Full path to the ffprobe binary. Leave empty to have aMule auto-detect it on startup."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1687
+#: src/muuli_wdr.cpp:1691
 msgid "Detect"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1688
+#: src/muuli_wdr.cpp:1692
 msgid "Search the standard install locations for an ffprobe binary and fill the path field."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1712
+#: src/muuli_wdr.cpp:1716
 msgid ""
 "Completed downloads are stored here. All files in this folder are automatically shared with other peers.\n"
 "If this folder also holds files you don't want to share, point it at an aMule-only sub-folder."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1715
+#: src/muuli_wdr.cpp:1719
 msgid "Pick the folder where completed downloads will be stored. All files in that folder will be shared with other peers."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1729
+#: src/muuli_wdr.cpp:1733
 msgid "Shared folders"
 msgstr "Gedeelde mappen"
 
-#: src/muuli_wdr.cpp:1735
+#: src/muuli_wdr.cpp:1739
 msgid "(Folders shared by the core. Enter a path to add one.)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1743
+#: src/muuli_wdr.cpp:1747
 msgid "Absolute path of a folder on the core's machine, e.g. /home/user/shared"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1745 src/PrefsUnifiedDlg.cpp:2794
+#: src/muuli_wdr.cpp:1749 src/PrefsUnifiedDlg.cpp:2874
 msgid "Recursive"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1746
+#: src/muuli_wdr.cpp:1750
 msgid "Share every sub-folder underneath this one, including ones created later."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1750 src/utils/aLinkCreator/src/alcframe.cpp:141
+#: src/muuli_wdr.cpp:1754 src/utils/aLinkCreator/src/alcframe.cpp:141
 msgid "Remove"
 msgstr "Verwijder"
 
-#: src/muuli_wdr.cpp:1754
+#: src/muuli_wdr.cpp:1758
 msgid "(Right click on folder icon for recursive share)"
 msgstr "(Rechtermuisklik op mappictogram om recursief te delen)"
 
-#: src/muuli_wdr.cpp:1761
+#: src/muuli_wdr.cpp:1765
 msgid "Share hidden files"
 msgstr "Deel verborgen bestanden"
 
-#: src/muuli_wdr.cpp:1767
+#: src/muuli_wdr.cpp:1771
 msgid "Automatically rescan shared folders for changes"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1773
+#: src/muuli_wdr.cpp:1777
 msgid "Follow symbolic links in shared folders"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1779
+#: src/muuli_wdr.cpp:1783
 msgid "Exclude files matching:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1782
+#: src/muuli_wdr.cpp:1786
 msgid "Wildcard patterns separated by '|', e.g. .DS_Store|Thumbs.db|*.tmp. Files whose name matches are not shared. Matching is case-insensitive."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1786
+#: src/muuli_wdr.cpp:1790
 msgid "Patterns are regular expressions"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1787
+#: src/muuli_wdr.cpp:1791
 msgid "When set, the whole field is one regular expression ('|' is alternation). When unset, it is a list of '|'-separated wildcards."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1797
+#: src/muuli_wdr.cpp:1801
 msgid "Show how many shared files the current pattern would exclude."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1818
+#: src/muuli_wdr.cpp:1822
 msgid "Graphs"
 msgstr "Grafieken"
 
-#: src/muuli_wdr.cpp:1821 src/muuli_wdr.cpp:1883
+#: src/muuli_wdr.cpp:1825 src/muuli_wdr.cpp:1887
 msgid "Update delay : 5 secs"
 msgstr "Update-vertraging : 5 seconden"
 
-#: src/muuli_wdr.cpp:1825
+#: src/muuli_wdr.cpp:1829
 msgid "Time for average graph: 100 mins"
 msgstr "Tijd voor gemiddeldengrafiek: 100 minuten"
 
-#: src/muuli_wdr.cpp:1829
+#: src/muuli_wdr.cpp:1833
 msgid "Connections Graph Scale: 100 "
 msgstr "Schaal verbindingengrafiek: 100 "
 
-#: src/muuli_wdr.cpp:1836
+#: src/muuli_wdr.cpp:1840
 msgid "Download graph scale:"
 msgstr "Schaal downloadgrafiek:"
 
-#: src/muuli_wdr.cpp:1844
+#: src/muuli_wdr.cpp:1848
 msgid "Upload graph scale:"
 msgstr "Schaal uploadgrafiek:"
 
-#: src/muuli_wdr.cpp:1854
+#: src/muuli_wdr.cpp:1858
 #, fuzzy
 msgid "Colors: "
 msgstr "Kleuren: "
 
-#: src/muuli_wdr.cpp:1858
+#: src/muuli_wdr.cpp:1862
 msgid "Background"
 msgstr "Achtergrond"
 
-#: src/muuli_wdr.cpp:1859
+#: src/muuli_wdr.cpp:1863
 msgid "Grid"
 msgstr "Raster"
 
-#: src/muuli_wdr.cpp:1860
+#: src/muuli_wdr.cpp:1864
 msgid "Download current"
 msgstr "Huidige download"
 
-#: src/muuli_wdr.cpp:1861
+#: src/muuli_wdr.cpp:1865
 msgid "Download running average"
 msgstr "Lopend gemiddelde download"
 
-#: src/muuli_wdr.cpp:1862
+#: src/muuli_wdr.cpp:1866
 msgid "Download session average"
 msgstr "Sessie gemiddelde download"
 
-#: src/muuli_wdr.cpp:1863
+#: src/muuli_wdr.cpp:1867
 msgid "Upload current"
 msgstr "Huidige upload"
 
-#: src/muuli_wdr.cpp:1864
+#: src/muuli_wdr.cpp:1868
 msgid "Upload running average"
 msgstr "Lopend gemiddelde upload"
 
-#: src/muuli_wdr.cpp:1865
+#: src/muuli_wdr.cpp:1869
 msgid "Upload session average"
 msgstr "Sessie gemiddelde upload"
 
-#: src/muuli_wdr.cpp:1866
+#: src/muuli_wdr.cpp:1870
 msgid "Active connections"
 msgstr "Actieve verbindingen"
 
-#: src/muuli_wdr.cpp:1869
+#: src/muuli_wdr.cpp:1873
 #, fuzzy
 msgid "Systray Icon Speed Bar"
 msgstr "Systeemvak-pictogram met snelheidsbalk"
 
-#: src/muuli_wdr.cpp:1870
+#: src/muuli_wdr.cpp:1874
 msgid "Kad-nodes current"
 msgstr "Kad-nodes huidig"
 
-#: src/muuli_wdr.cpp:1871
+#: src/muuli_wdr.cpp:1875
 msgid "Kad-nodes running"
 msgstr "Kad-nodes draaiende"
 
-#: src/muuli_wdr.cpp:1872
+#: src/muuli_wdr.cpp:1876
 msgid "Kad-nodes session"
 msgstr "Kad-nodes sessie"
 
-#: src/muuli_wdr.cpp:1876 src/muuli_wdr.cpp:2303
+#: src/muuli_wdr.cpp:1880 src/muuli_wdr.cpp:2334
 msgid "Select"
 msgstr "Selecteer"
 
-#: src/muuli_wdr.cpp:1880
+#: src/muuli_wdr.cpp:1884
 msgid "Tree"
 msgstr "Boom"
 
-#: src/muuli_wdr.cpp:1890
+#: src/muuli_wdr.cpp:1894
 msgid "Number of Client Versions shown (0=unlimited)"
 msgstr "Aantal getoonde client-versies (0=onbegrensd)"
 
-#: src/muuli_wdr.cpp:1915
+#: src/muuli_wdr.cpp:1919
 msgid "!!! WARNING !!!"
 msgstr "!!! WAARSCHUWING !!!"
 
-#: src/muuli_wdr.cpp:1930
+#: src/muuli_wdr.cpp:1934
 msgid "Max new connections / 5 secs"
 msgstr "Max nieuwe verbindingen / 5 seconden"
 
-#: src/muuli_wdr.cpp:1932
+#: src/muuli_wdr.cpp:1936
 msgid "Concurrent Kad source lookups"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1934
+#: src/muuli_wdr.cpp:1938
 #, fuzzy
 msgid "Kad source re-search interval (minutes)"
 msgstr "Tijd tussen de FTP-updates in minuten"
 
-#: src/muuli_wdr.cpp:1936
+#: src/muuli_wdr.cpp:1940
 #, fuzzy
 msgid "Source re-ask interval (minutes)"
 msgstr "Tijd tussen de FTP-updates in minuten"
 
-#: src/muuli_wdr.cpp:1940
+#: src/muuli_wdr.cpp:1944
 msgid "File Buffer Size: 240000 bytes"
 msgstr "Grootte van bestandsbuffer : 240000 bytes"
 
-#: src/muuli_wdr.cpp:1944
+#: src/muuli_wdr.cpp:1948
 msgid "Use MMAP: memory-mapped file access (lower memory use)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1945
+#: src/muuli_wdr.cpp:1949
 msgid "Maps part files into memory instead of buffering them on the heap, lowering the process memory footprint. May reduce download speed on some disks; best for memory-constrained or upload-heavy hosts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1947
+#: src/muuli_wdr.cpp:1951
 msgid "Upload Queue Size: 5000 clients"
 msgstr "Grootte van uploadwachtrij: 5000 clients"
 
-#: src/muuli_wdr.cpp:1951
+#: src/muuli_wdr.cpp:1955
 msgid "Server connection refresh interval: Disable"
 msgstr "Server-verbinding verversingsinterval: Uitschakelen"
 
-#: src/muuli_wdr.cpp:1955
+#: src/muuli_wdr.cpp:1959
 msgid "Disable computer's timed standby mode"
 msgstr "Schakel standby-modus van computer uit"
 
-#: src/muuli_wdr.cpp:1974
+#: src/muuli_wdr.cpp:1978
 msgid "Skin to use: "
 msgstr "Gebruik skin: "
 
-#: src/muuli_wdr.cpp:1983
+#: src/muuli_wdr.cpp:1987
 msgid "Show \"Fast eD2k Links Handler\" in every window."
 msgstr "Toon \"Snelle eD2k-links afhandelaar\" in elk venster."
 
-#: src/muuli_wdr.cpp:1986
+#: src/muuli_wdr.cpp:1990
 msgid "Show extended info on categories tabs"
 msgstr "Geef uitgebreide informatie weer op categorie-tabs"
 
-#: src/muuli_wdr.cpp:1989
+#: src/muuli_wdr.cpp:1993
 msgid "Show application version on title"
 msgstr "Toon applicatieversie op titel"
 
-#: src/muuli_wdr.cpp:1991
+#: src/muuli_wdr.cpp:1995
 msgid "Show transfer rates on title"
 msgstr "Toon overdrachtsnelheden op titel"
 
-#: src/muuli_wdr.cpp:1993
+#: src/muuli_wdr.cpp:1997
 msgid "Before application name"
 msgstr "Voor applicatienaam"
 
-#: src/muuli_wdr.cpp:1995
+#: src/muuli_wdr.cpp:1999
 msgid "After application name"
 msgstr "Na applicatienaam"
 
-#: src/muuli_wdr.cpp:1998
+#: src/muuli_wdr.cpp:2002
 msgid "Show overhead bandwidth"
 msgstr "Toon overhead bandbreedte"
 
-#: src/muuli_wdr.cpp:2002
+#: src/muuli_wdr.cpp:2006
 msgid "Vertical toolbar orientation"
 msgstr "Verticale knoppenbalk"
 
-#: src/muuli_wdr.cpp:2004
+#: src/muuli_wdr.cpp:2008
 msgid "Live column sorting (auto-reorder rows as their values change)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2011
+#: src/muuli_wdr.cpp:2015
 msgid "Download Queue Files"
 msgstr "Downloadwachtrij bestanden"
 
-#: src/muuli_wdr.cpp:2014
+#: src/muuli_wdr.cpp:2018
 msgid "Show progress percentage"
 msgstr "Toon voortgangspercentage"
 
-#: src/muuli_wdr.cpp:2020
+#: src/muuli_wdr.cpp:2024
 msgid "Show progress bar"
 msgstr "Toon voortgangsindicator"
 
-#: src/muuli_wdr.cpp:2023
+#: src/muuli_wdr.cpp:2027
 msgid "Flat"
 msgstr "Plat"
 
-#: src/muuli_wdr.cpp:2027
+#: src/muuli_wdr.cpp:2031
 msgid "Round"
 msgstr "Rond"
 
-#: src/muuli_wdr.cpp:2045
+#: src/muuli_wdr.cpp:2049
 msgid "External Connection Parameters"
 msgstr "Externe verbinding parameters"
 
-#: src/muuli_wdr.cpp:2048
+#: src/muuli_wdr.cpp:2052
 msgid "Accept external connections"
 msgstr "Accepteer externe verbindingen"
 
-#: src/muuli_wdr.cpp:2055 src/muuli_wdr.cpp:2114
+#: src/muuli_wdr.cpp:2059 src/muuli_wdr.cpp:2118
 msgid "IP of the listening interface:"
 msgstr "IP van de luisterende interface:"
 
-#: src/muuli_wdr.cpp:2058
+#: src/muuli_wdr.cpp:2062
 msgid "Enter here a valid ip in the a.b.c.d format for the listening EC interface. An empty field or 0.0.0.0 will mean any interface."
 msgstr "Voer hier een geldig IP in het formaat a.b.c.d in van de luisterende EV-interface. Een leeg veld of 0.0.0.0 betekent elke interface."
 
-#: src/muuli_wdr.cpp:2079 src/muuli_wdr.cpp:2163
+#: src/muuli_wdr.cpp:2083 src/muuli_wdr.cpp:2194
 msgid "TCP port:"
 msgstr "TCP-poort:"
 
-#: src/muuli_wdr.cpp:2085
+#: src/muuli_wdr.cpp:2089
 msgid "Enable UPnP port forwarding on the EC port"
 msgstr "Schakel UPnP portforwarding van de EV-poort in"
 
-#: src/muuli_wdr.cpp:2089 src/muuli_wdr.cpp:3048
+#: src/muuli_wdr.cpp:2093 src/muuli_wdr.cpp:3079
 #: src/utils/wxCas/src/wxcasprefs.cpp:167
 msgid "Password"
 msgstr "Wachtwoord"
 
-#: src/muuli_wdr.cpp:2095
+#: src/muuli_wdr.cpp:2099
 #, fuzzy
 msgid "aMule API server parameters"
 msgstr "Webserver parameters"
 
-#: src/muuli_wdr.cpp:2098
+#: src/muuli_wdr.cpp:2102
 msgid "Run amuleapi (REST API) on startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2103
+#: src/muuli_wdr.cpp:2107
 #, fuzzy
 msgid "HTTP port:"
 msgstr "TCP-poort:"
 
-#: src/muuli_wdr.cpp:2117
+#: src/muuli_wdr.cpp:2121
 msgid "The interface amuleapi's HTTP server listens on. 127.0.0.1 (default) accepts only local connections; use 0.0.0.0 or a specific IP to expose it to other hosts (set an admin password below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2120
+#: src/muuli_wdr.cpp:2126
+msgid "Type a password to set or change it. Stored passwords cannot be shown, so leaving this empty keeps the current one."
+msgstr ""
+
+#: src/muuli_wdr.cpp:2128
 #, fuzzy
 msgid "Admin password"
 msgstr "Controleren van wachtwoord\n"
 
-#: src/muuli_wdr.cpp:2125 src/muuli_wdr.cpp:2156
-msgid "Low rights password"
-msgstr "Beperkte rechten wachtwoord"
+#: src/muuli_wdr.cpp:2140 src/muuli_wdr.cpp:2157 src/PrefsUnifiedDlg.cpp:1103
+#, fuzzy
+msgid "A password is set."
+msgstr "Controleren van wachtwoord\n"
 
-#: src/muuli_wdr.cpp:2133
+#: src/muuli_wdr.cpp:2144
+#, fuzzy
+msgid "Enable guest access"
+msgstr "Weiger gasttoegang"
+
+#: src/muuli_wdr.cpp:2145
+msgid "Guest sessions may read status and listings but cannot change anything. Turning this off clears the stored guest password."
+msgstr ""
+
+#: src/muuli_wdr.cpp:2149
+#, fuzzy
+msgid "Guest password"
+msgstr "Gastwachtwoord voor webserver"
+
+#: src/muuli_wdr.cpp:2164
 msgid "Web server parameters"
 msgstr "Webserver parameters"
 
-#: src/muuli_wdr.cpp:2136
+#: src/muuli_wdr.cpp:2167
 #, fuzzy
 msgid "Run webserver on startup (deprecated)"
 msgstr "Start webserver bij het opstarten"
 
-#: src/muuli_wdr.cpp:2142
+#: src/muuli_wdr.cpp:2173
 msgid "Web template"
 msgstr "Web-template"
 
-#: src/muuli_wdr.cpp:2147
+#: src/muuli_wdr.cpp:2178
 msgid "Full rights password"
 msgstr "Alle rechten wachtwoord"
 
-#: src/muuli_wdr.cpp:2151
+#: src/muuli_wdr.cpp:2182
 msgid "Enable Low rights User"
 msgstr "Schakel gebruiker met beperkte rechten in"
 
-#: src/muuli_wdr.cpp:2170
+#: src/muuli_wdr.cpp:2187
+msgid "Low rights password"
+msgstr "Beperkte rechten wachtwoord"
+
+#: src/muuli_wdr.cpp:2201
 msgid "Enable UPnP port forwarding of the web server port"
 msgstr "Schakel UPnP portforwarding van de webserver-poort in"
 
-#: src/muuli_wdr.cpp:2175
+#: src/muuli_wdr.cpp:2206
 msgid "Web server UPnP TCP port (Optional)"
 msgstr "Web server UPnP TCP-poort (optioneel)"
 
-#: src/muuli_wdr.cpp:2183
+#: src/muuli_wdr.cpp:2214
 msgid "Page Refresh Time (in secs)"
 msgstr "Pagina verversingstijd (in seconden)"
 
-#: src/muuli_wdr.cpp:2190
+#: src/muuli_wdr.cpp:2221
 msgid "Enable Gzip compression"
 msgstr "Schakel Gzip-compressie in"
 
-#: src/muuli_wdr.cpp:2224
+#: src/muuli_wdr.cpp:2255
 #, fuzzy
 msgid "Reset page to defaults"
 msgstr "Systeemstandaard"
 
-#: src/muuli_wdr.cpp:2225
+#: src/muuli_wdr.cpp:2256
 msgid "Reset the settings on the current page to their default values."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2227 src/muuli_wdr.cpp:2313 src/ServerWnd.cpp:274
+#: src/muuli_wdr.cpp:2258 src/muuli_wdr.cpp:2344 src/ServerWnd.cpp:274
 #: src/ServerWnd.cpp:282
 msgid "OK"
 msgstr "OK"
 
-#: src/muuli_wdr.cpp:2229
+#: src/muuli_wdr.cpp:2260
 msgid "Click here to apply any changes made to the preferences."
 msgstr "Klik hier om de veranderingen gemaakt in de voorkeuren toe te passen."
 
-#: src/muuli_wdr.cpp:2232
+#: src/muuli_wdr.cpp:2263
 msgid "Reset any changes made to the preferences."
 msgstr "Maak veranderingen aan de voorkeuren ongedaan."
 
-#: src/muuli_wdr.cpp:2261
+#: src/muuli_wdr.cpp:2292
 msgid "Comment :"
 msgstr "Commentaar :"
 
-#: src/muuli_wdr.cpp:2268
+#: src/muuli_wdr.cpp:2299
 msgid "Incoming Dir :"
 msgstr "Binnenkomende map :"
 
-#: src/muuli_wdr.cpp:2277
+#: src/muuli_wdr.cpp:2308
 msgid "Change priority for new assigned files :"
 msgstr "Verander prioriteit voor nieuw toegevoegde bestanden :"
 
-#: src/muuli_wdr.cpp:2281
+#: src/muuli_wdr.cpp:2312
 msgid "Don't change"
 msgstr "Niet veranderen"
 
-#: src/muuli_wdr.cpp:2293
+#: src/muuli_wdr.cpp:2324
 msgid "Select color for this Category (currently selected) :"
 msgstr "Selecteer kleur voor deze categorie (nu geselecteerd) :"
 
-#: src/muuli_wdr.cpp:2360 src/muuli_wdr.cpp:2379 src/muuli_wdr.cpp:2401
+#: src/muuli_wdr.cpp:2391 src/muuli_wdr.cpp:2410 src/muuli_wdr.cpp:2432
 msgid "Click this button to reset the log."
 msgstr "Klik op deze knop om het logboek te wissen."
 
-#: src/muuli_wdr.cpp:2420
+#: src/muuli_wdr.cpp:2451
 msgid "Click on this button to update the servers list from URL ..."
 msgstr "Klik op deze knop om de lijst van servers te updaten van URL ..."
 
-#: src/muuli_wdr.cpp:2424
+#: src/muuli_wdr.cpp:2455
 msgid "Server list"
 msgstr "Server-lijst"
 
-#: src/muuli_wdr.cpp:2428
+#: src/muuli_wdr.cpp:2459
 msgid "Enter the url to a server.met file here and press the button to the left to update the list of known servers."
 msgstr "Voer de url naar een server.met bestand hier in en druk op de knop links om de lijst met bekende servers te vernieuwen."
 
-#: src/muuli_wdr.cpp:2433
+#: src/muuli_wdr.cpp:2464
 msgid "Add server manually: Name"
 msgstr "Voeg server handmatig toe: Naam"
 
-#: src/muuli_wdr.cpp:2436
+#: src/muuli_wdr.cpp:2467
 msgid "Enter the name of the new server here"
 msgstr "Voer hier de naam van de nieuwe server in"
 
-#: src/muuli_wdr.cpp:2438 src/ServerWnd.cpp:206
+#: src/muuli_wdr.cpp:2469 src/ServerWnd.cpp:206
 msgid "IP:Port"
 msgstr "IP:Poort"
 
-#: src/muuli_wdr.cpp:2441
+#: src/muuli_wdr.cpp:2472
 msgid "Enter the IP of the server here, using the x.x.x.x format."
 msgstr "Voer hier het IP van de server in, gebuik het x.x.x.x formaat."
 
-#: src/muuli_wdr.cpp:2447
+#: src/muuli_wdr.cpp:2478
 msgid "Enter the port of the server here."
 msgstr "Voer hier de poort van de server in."
 
-#: src/muuli_wdr.cpp:2450
+#: src/muuli_wdr.cpp:2481
 msgid "Add manually a server (fill fields to the left before) ..."
 msgstr "Voeg een server handmatig toe (vul velden links in voor) ..."
 
-#: src/muuli_wdr.cpp:2479
+#: src/muuli_wdr.cpp:2510
 msgid "aMule Log"
 msgstr "aMule log"
 
-#: src/muuli_wdr.cpp:2487
+#: src/muuli_wdr.cpp:2518
 msgid "Server Info"
 msgstr "Server-info"
 
-#: src/muuli_wdr.cpp:2491
+#: src/muuli_wdr.cpp:2522
 msgid "ED2K Info"
 msgstr "ED2K-info"
 
-#: src/muuli_wdr.cpp:2495
+#: src/muuli_wdr.cpp:2526
 msgid "Kad Info"
 msgstr "Kad info"
 
-#: src/muuli_wdr.cpp:2523
+#: src/muuli_wdr.cpp:2554
 msgid "Click on this button to update the nodes list from URL ..."
 msgstr "Klik op deze knop om de nodes-lijst te updaten van URL ..."
 
-#: src/muuli_wdr.cpp:2527
+#: src/muuli_wdr.cpp:2558
 msgid "Nodes (0)"
 msgstr "Nodes (0)"
 
-#: src/muuli_wdr.cpp:2531
+#: src/muuli_wdr.cpp:2562
 msgid "Enter the url to a nodes.dat file here and press the button to the left to update the list of known nodes."
 msgstr "Voer hier de url in naar een nodes.dat bestand en druk op de knop links om de lijst van bekende nodes te updaten."
 
-#: src/muuli_wdr.cpp:2534
+#: src/muuli_wdr.cpp:2565
 msgid "Nodes stats"
 msgstr "Nodes stats"
 
-#: src/muuli_wdr.cpp:2576
+#: src/muuli_wdr.cpp:2607
 msgid "Bootstrap"
 msgstr "Bootstrap"
 
-#: src/muuli_wdr.cpp:2579
+#: src/muuli_wdr.cpp:2610
 msgid "New node"
 msgstr "Nieuwe node"
 
-#: src/muuli_wdr.cpp:2584
+#: src/muuli_wdr.cpp:2615
 msgid "IP:"
 msgstr "IP:"
 
-#: src/muuli_wdr.cpp:2604
+#: src/muuli_wdr.cpp:2635
 msgid "Port:"
 msgstr "Poort:"
 
-#: src/muuli_wdr.cpp:2617
+#: src/muuli_wdr.cpp:2648
 msgid "Bootstrap from known clients"
 msgstr "Bootstrap van bekende clients"
 
-#: src/muuli_wdr.cpp:2619
+#: src/muuli_wdr.cpp:2650
 msgid "Disconnect Kad"
 msgstr "Verbreek verbinding met Kad"
 
-#: src/muuli_wdr.cpp:2653
+#: src/muuli_wdr.cpp:2684
 msgid "Use Secure User Identification"
 msgstr "Gebruik beveiligde gebruikersidentificatie"
 
-#: src/muuli_wdr.cpp:2655
+#: src/muuli_wdr.cpp:2686
 msgid "It is recommended to enable this option. You will not receive credits if SUI is not enabled."
 msgstr "Het is aan te raden om deze optie in te schakelen. U ontvangt geen credits indien SUI niet ingeschakeld is."
 
-#: src/muuli_wdr.cpp:2657
+#: src/muuli_wdr.cpp:2688
 msgid "Protocol Obfuscation"
 msgstr "Protocol-obfuscatie"
 
-#: src/muuli_wdr.cpp:2660
+#: src/muuli_wdr.cpp:2691
 msgid "Support Protocol Obfuscation"
 msgstr "Ondersteun protocol-obfuscatie"
 
-#: src/muuli_wdr.cpp:2662
+#: src/muuli_wdr.cpp:2693
 msgid "This option enabled Protocol Obfuscation, and makes aMule accept obfuscated connections from other clients."
 msgstr "Deze optie schakelt Protocol Obfuscatie in, en zorgt er voor dat aMule geobfusceerde verbindingen van andere clients accepteert."
 
-#: src/muuli_wdr.cpp:2664
+#: src/muuli_wdr.cpp:2695
 msgid "Use obfuscation for outgoing connections"
 msgstr "Gebruik obfuscatie voor uitgaande verbindingen"
 
-#: src/muuli_wdr.cpp:2666
+#: src/muuli_wdr.cpp:2697
 msgid "This option makes aMule use Protocol Obfuscation when connecting other clients/servers."
 msgstr "Deze optie zorgt er voor dat aMule protocol-obfuscatie gebruikt bij het verbinden met andere clients/servers."
 
-#: src/muuli_wdr.cpp:2668
+#: src/muuli_wdr.cpp:2699
 msgid "Accept only obfuscated connections"
 msgstr "Accepteer alleen geobfusceerde verbindingen"
 
-#: src/muuli_wdr.cpp:2669
+#: src/muuli_wdr.cpp:2700
 msgid "This option makes aMule only accept obfuscated connections. You will have less sources, but all your traffic will be obfuscated"
 msgstr "Deze optie zorgt er voor dat aMule alleen geobfusceerde verbindingen accepteert. U heeft minder bronnen, maar al uw verkeer is geobfusceerd"
 
-#: src/muuli_wdr.cpp:2674
+#: src/muuli_wdr.cpp:2705
 msgid "Everybody"
 msgstr "Iedereen"
 
-#: src/muuli_wdr.cpp:2676
+#: src/muuli_wdr.cpp:2707
 msgid "No one"
 msgstr "Niemand"
 
-#: src/muuli_wdr.cpp:2678
+#: src/muuli_wdr.cpp:2709
 msgid "Who can see my shared files:"
 msgstr "Wie kan mijn gedeelde bestanden zien:"
 
-#: src/muuli_wdr.cpp:2679
+#: src/muuli_wdr.cpp:2710
 msgid "Select who can request to view a list of your shared files."
 msgstr "Selecteer wie een lijst van uw gedeelde bestanden kan opvragen."
 
-#: src/muuli_wdr.cpp:2681
+#: src/muuli_wdr.cpp:2712
 msgid "IP-Filtering"
 msgstr "IP-filteren"
 
-#: src/muuli_wdr.cpp:2688
+#: src/muuli_wdr.cpp:2719
 msgid "Filter clients"
 msgstr "Filter clients"
 
-#: src/muuli_wdr.cpp:2690
+#: src/muuli_wdr.cpp:2721
 msgid "Enable filtering of the client IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "Schakel filteren van de client-IPs in het bestand ~/.aMule/ipfilter.dat in."
 
-#: src/muuli_wdr.cpp:2692
+#: src/muuli_wdr.cpp:2723
 msgid "Filter servers"
 msgstr "Filter servers"
 
-#: src/muuli_wdr.cpp:2694
+#: src/muuli_wdr.cpp:2725
 msgid "Enable filtering of the server IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "Schakel filteren van de server-IPs in het bestand ~/.aMule/ipfilter.dat in."
 
-#: src/muuli_wdr.cpp:2698
+#: src/muuli_wdr.cpp:2729
 msgid "Reload List"
 msgstr "Lijst opnieuw laden"
 
-#: src/muuli_wdr.cpp:2699
+#: src/muuli_wdr.cpp:2730
 msgid "Reload the list of IPs to filter from the file ~/.aMule/ipfilter.dat"
 msgstr "Laadt de lijst met IPs om te filteren opnieuw uit het bestand ~/.aMule/ipfilter.dat"
 
-#: src/muuli_wdr.cpp:2705
+#: src/muuli_wdr.cpp:2736
 msgid "URL:"
 msgstr "URL:"
 
-#: src/muuli_wdr.cpp:2709 src/muuli_wdr.cpp:2902
+#: src/muuli_wdr.cpp:2740 src/muuli_wdr.cpp:2933
 msgid "Update now"
 msgstr "Update nu"
 
-#: src/muuli_wdr.cpp:2712
+#: src/muuli_wdr.cpp:2743
 msgid "Auto-update ipfilter at startup"
 msgstr "Auto-update ip-filter bij het starten"
 
-#: src/muuli_wdr.cpp:2716
+#: src/muuli_wdr.cpp:2747
 msgid "Filtering Level:"
 msgstr "Niveau van filteren:"
 
-#: src/muuli_wdr.cpp:2722
+#: src/muuli_wdr.cpp:2753
 msgid "Always filter LAN IPs"
 msgstr "Filter LAN IPs altijd"
 
-#: src/muuli_wdr.cpp:2725
+#: src/muuli_wdr.cpp:2756
 msgid "Paranoid handling of non-matching IPs"
 msgstr "Paranoïde behandeling van niet-kloppende IPs"
 
-#: src/muuli_wdr.cpp:2727
+#: src/muuli_wdr.cpp:2758
 msgid "Rejects a packet when its source IP differs from the IP the client claims (an anti-spoofing check). Disable only if it causes connection problems."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2729
+#: src/muuli_wdr.cpp:2760
 msgid "Use system-wide ipfilter.dat if available"
 msgstr "Gebruik systeemwijd ipfilter.dat indien beschikbaar"
 
-#: src/muuli_wdr.cpp:2730
+#: src/muuli_wdr.cpp:2761
 #, fuzzy
 msgid "If there's no local ipfilter.dat found, allow usage of a system-wide ipfilter file."
 msgstr "Indien er geen lokaal ipfilter.dat gevonden wordt, sta gebruik van een systeemwijd ipfilter toe."
 
-#: src/muuli_wdr.cpp:2747
+#: src/muuli_wdr.cpp:2778
 msgid "Enable Online-Signature"
 msgstr "Schakel online handtekening in"
 
-#: src/muuli_wdr.cpp:2749
+#: src/muuli_wdr.cpp:2780
 msgid "Enables the writing of the OS file, which can be used by external apps to create signatures and the like."
 msgstr "Schakelt het schrijven van het OH-bestand in, die kan gebruikt worden door externe applicaties om handtekeningen en dergelijke te maken."
 
-#: src/muuli_wdr.cpp:2753
+#: src/muuli_wdr.cpp:2784
 msgid "Update Frequency (Secs):"
 msgstr "Update-frequentie (seconden):"
 
-#: src/muuli_wdr.cpp:2756
+#: src/muuli_wdr.cpp:2787
 msgid "Change the frequency (in seconds) of Online Signature updates."
 msgstr "Verander de frequentie (in seconden) van de Online Handtekening updates."
 
-#: src/muuli_wdr.cpp:2764
+#: src/muuli_wdr.cpp:2795
 msgid "Save online signature file in: "
 msgstr "Bewaar online-handtekeningbestand in: "
 
-#: src/muuli_wdr.cpp:2770
+#: src/muuli_wdr.cpp:2801
 msgid "Click here to select the directory containing the the Online Signature files."
 msgstr "Klik hier om de map te selecteren die de online-handtekening-bestanden bevat."
 
-#: src/muuli_wdr.cpp:2803
+#: src/muuli_wdr.cpp:2834
 msgid "Show country flags for clients"
 msgstr "Toon landenvlaggen voor clients"
 
-#: src/muuli_wdr.cpp:2804
+#: src/muuli_wdr.cpp:2835
 msgid "Render the country flag column in the transfers, queue and search views. Requires a valid MMDB GeoIP database (see below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2809
+#: src/muuli_wdr.cpp:2840
 #, fuzzy
 msgid "Database"
 msgstr "Datasnelheid :"
 
-#: src/muuli_wdr.cpp:2825
+#: src/muuli_wdr.cpp:2856
 #, fuzzy
 msgid "Source:"
 msgstr "Bronnen"
 
-#: src/muuli_wdr.cpp:2828
+#: src/muuli_wdr.cpp:2859
 msgid "DB-IP (free, no account)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2829
+#: src/muuli_wdr.cpp:2860
 msgid "MaxMind GeoLite2 (free, account required)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2830
+#: src/muuli_wdr.cpp:2861
 msgid "Custom URL"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2833
+#: src/muuli_wdr.cpp:2864
 msgid "Choose which provider supplies the GeoIP MMDB database. DB-IP is the default - no account required. MaxMind requires a free account + license key. Use Custom URL to point at any other MMDB host (e.g. a local mirror)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2850
+#: src/muuli_wdr.cpp:2881
 msgid ""
 "No configuration required.\n"
 "\n"
@@ -4857,11 +4885,11 @@ msgid ""
 "License: Creative Commons BY 4.0 - https://creativecommons.org/licenses/by/4.0/"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2863
+#: src/muuli_wdr.cpp:2894
 msgid "License key:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2869
+#: src/muuli_wdr.cpp:2900
 msgid ""
 "Sign up for a free MaxMind account, then generate a License Key:\n"
 "https://www.maxmind.com/en/geolite2/signup\n"
@@ -4871,225 +4899,225 @@ msgid ""
 "Requires attribution and account registration; refresh at least every 30 days."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2884
+#: src/muuli_wdr.cpp:2915
 #, fuzzy
 msgid "Download URL:"
 msgstr "Download: "
 
-#: src/muuli_wdr.cpp:2890
+#: src/muuli_wdr.cpp:2921
 msgid ""
 "Must point to an .mmdb file or a .gz / .tar.gz containing one.\n"
 "URL may include credentials (https://user:pass@host/...).\n"
 "License and attribution terms are set by the upstream URL - you are responsible."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2903
+#: src/muuli_wdr.cpp:2934
 msgid "Download the GeoIP database from the selected source."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2905
+#: src/muuli_wdr.cpp:2936
 #, fuzzy
 msgid "Auto-update on startup"
 msgstr "Auto-update ip-filter bij het starten"
 
-#: src/muuli_wdr.cpp:2906
+#: src/muuli_wdr.cpp:2937
 msgid "Re-download the GeoIP database from the selected source every time aMule starts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2929
+#: src/muuli_wdr.cpp:2960
 msgid "Filter incoming messages (except current chat):"
 msgstr "Filter binnenkomende berichten (behalve huidige chat):"
 
-#: src/muuli_wdr.cpp:2931
+#: src/muuli_wdr.cpp:2962
 msgid "Filter all messages"
 msgstr "Filter alle berichten"
 
-#: src/muuli_wdr.cpp:2933
+#: src/muuli_wdr.cpp:2964
 msgid "Filter messages from people not on your friend list"
 msgstr "Filter berichten van mensen niet op uw vriendenlijst"
 
-#: src/muuli_wdr.cpp:2935
+#: src/muuli_wdr.cpp:2966
 msgid "Filter messages from unknown clients"
 msgstr "Filter berichten van onbekende clients"
 
-#: src/muuli_wdr.cpp:2937
+#: src/muuli_wdr.cpp:2968
 msgid "Filter messages containing (use ',' as separator):"
 msgstr "Filter berichten met (gebruik ',' als scheiding):"
 
-#: src/muuli_wdr.cpp:2940 src/muuli_wdr.cpp:2951
+#: src/muuli_wdr.cpp:2971 src/muuli_wdr.cpp:2982
 msgid "add here the words amule should filter and block messages including it"
 msgstr "voeg hier de woorden toe die amule moet filteren en berichten daarmee blokkeren"
 
-#: src/muuli_wdr.cpp:2942
+#: src/muuli_wdr.cpp:2973
 msgid "Show received messages in the log"
 msgstr "Toon ontvangen berichten in het logboek"
 
-#: src/muuli_wdr.cpp:2945
+#: src/muuli_wdr.cpp:2976
 msgid "Comments"
 msgstr "Commentaren"
 
-#: src/muuli_wdr.cpp:2948
+#: src/muuli_wdr.cpp:2979
 msgid "Filter comments containing (use ',' as separator):"
 msgstr "Filter commentaren die de volgende tekens bevatten (gebruik ',' als scheiding):"
 
-#: src/muuli_wdr.cpp:2973
+#: src/muuli_wdr.cpp:3004
 msgid "Enable Proxy"
 msgstr "Schakel proxy in"
 
-#: src/muuli_wdr.cpp:2974
+#: src/muuli_wdr.cpp:3005
 msgid "Enable/disable proxy support"
 msgstr "Schakel proxy ondersteuning in/uit"
 
-#: src/muuli_wdr.cpp:2977
+#: src/muuli_wdr.cpp:3008
 msgid "Proxy type:"
 msgstr "Proxy-type:"
 
-#: src/muuli_wdr.cpp:2988
+#: src/muuli_wdr.cpp:3019
 msgid "Proxy host:"
 msgstr "Proxy-host:"
 
-#: src/muuli_wdr.cpp:2991
+#: src/muuli_wdr.cpp:3022
 msgid "The proxy host name"
 msgstr "De proxy hostnaam"
 
-#: src/muuli_wdr.cpp:2993
+#: src/muuli_wdr.cpp:3024
 msgid "Proxy port:"
 msgstr "Proxy-poort:"
 
-#: src/muuli_wdr.cpp:2996
+#: src/muuli_wdr.cpp:3027
 msgid "The proxy port"
 msgstr "De proxy poort"
 
-#: src/muuli_wdr.cpp:2998
+#: src/muuli_wdr.cpp:3029
 msgid "Enable authentication"
 msgstr "Schakel aanmelding in"
 
-#: src/muuli_wdr.cpp:2999
+#: src/muuli_wdr.cpp:3030
 msgid "Enable/disable username/password authentication"
 msgstr "Schakel gebruikersnaam/wachtwoord aanmelding in/uit"
 
-#: src/muuli_wdr.cpp:3002
+#: src/muuli_wdr.cpp:3033
 msgid "Username: "
 msgstr "Gebruikersnaam: "
 
-#: src/muuli_wdr.cpp:3005
+#: src/muuli_wdr.cpp:3036
 msgid "The username to use to connect to the proxy"
 msgstr "De gebruikersnaam is nodig om te verbinden met de proxy"
 
-#: src/muuli_wdr.cpp:3007
+#: src/muuli_wdr.cpp:3038
 msgid "Password:"
 msgstr "Wachtwoord:"
 
-#: src/muuli_wdr.cpp:3010
+#: src/muuli_wdr.cpp:3041
 msgid "The password to use to connect to the proxy"
 msgstr "Het wachtwoord nodig om te verbinden met de proxy"
 
-#: src/muuli_wdr.cpp:3029
+#: src/muuli_wdr.cpp:3060
 msgid "Connect to:"
 msgstr "Verbind met:"
 
-#: src/muuli_wdr.cpp:3038
+#: src/muuli_wdr.cpp:3069
 msgid "Login to remote amule"
 msgstr "Inloggen op amule op afstand"
 
-#: src/muuli_wdr.cpp:3043
+#: src/muuli_wdr.cpp:3074
 msgid "User name"
 msgstr "Gebruikersnaam"
 
-#: src/muuli_wdr.cpp:3054
+#: src/muuli_wdr.cpp:3085
 msgid "Remember those settings"
 msgstr "Onthoud deze instellingen"
 
-#: src/muuli_wdr.cpp:3057
+#: src/muuli_wdr.cpp:3088
 #, fuzzy
 msgid "Force ZLIB compression"
 msgstr "Gebruik Gzip-compressie"
 
-#: src/muuli_wdr.cpp:3081
+#: src/muuli_wdr.cpp:3112
 msgid "Enable Verbose Debug-Logging."
 msgstr "Schakel uitgebreide foutopsporing en logboek in."
 
-#: src/muuli_wdr.cpp:3083
+#: src/muuli_wdr.cpp:3114
 msgid "Only to Logfile"
 msgstr "Alleen naar logbestand"
 
-#: src/muuli_wdr.cpp:3085
+#: src/muuli_wdr.cpp:3116
 msgid "Message Categories:"
 msgstr "Berichtcategorieën:"
 
-#: src/muuli_wdr.cpp:3109 src/PartFileConvertDlg.cpp:160
+#: src/muuli_wdr.cpp:3140 src/PartFileConvertDlg.cpp:160
 msgid "Waiting..."
 msgstr "Wachtend..."
 
-#: src/muuli_wdr.cpp:3129
+#: src/muuli_wdr.cpp:3160
 msgid "Add imports"
 msgstr "Voeg geïmporteerden toe"
 
-#: src/muuli_wdr.cpp:3132
+#: src/muuli_wdr.cpp:3163
 msgid "Retry selected"
 msgstr "Probeer geselecteerde opnieuw"
 
-#: src/muuli_wdr.cpp:3134
+#: src/muuli_wdr.cpp:3165
 msgid "Remove selected"
 msgstr "Verwijder geselecteerde"
 
-#: src/muuli_wdr.cpp:3197
+#: src/muuli_wdr.cpp:3228
 msgid "Event Types"
 msgstr "Gebeurtenistypes"
 
-#: src/muuli_wdr.cpp:3216
+#: src/muuli_wdr.cpp:3247
 msgid "Statistics and queued clients for selected file(s) : Session / All time"
 msgstr "Statistieken en clients in wachtrij voor geselecteerd(e) bestand(en) : Sessie / Alle"
 
-#: src/muuli_wdr.cpp:3240
+#: src/muuli_wdr.cpp:3271
 msgid "Active Uploads"
 msgstr "Actieve uploads"
 
-#: src/muuli_wdr.cpp:3254
+#: src/muuli_wdr.cpp:3285
 msgid "Percent of total files"
 msgstr "Procent van alle bestanden"
 
-#: src/muuli_wdr.cpp:3306
+#: src/muuli_wdr.cpp:3337
 msgid "Show Clients for"
 msgstr "Toon clients voor"
 
-#: src/muuli_wdr.cpp:3308
+#: src/muuli_wdr.cpp:3339
 msgid "All files"
 msgstr "Alle bestanden"
 
-#: src/muuli_wdr.cpp:3311
+#: src/muuli_wdr.cpp:3342
 msgid "Selected files"
 msgstr "Geselecteerde bestanden"
 
-#: src/muuli_wdr.cpp:3314
+#: src/muuli_wdr.cpp:3345
 msgid "Active uploads only"
 msgstr "Alleen actieve uploads"
 
-#: src/muuli_wdr.cpp:3321
+#: src/muuli_wdr.cpp:3352
 msgid "Reload:"
 msgstr "Opnieuw laden:"
 
-#: src/muuli_wdr.cpp:3325
+#: src/muuli_wdr.cpp:3356
 msgid "Reload your shared files"
 msgstr "Laad uw gedeelde bestanden opnieuw"
 
-#: src/muuli_wdr.cpp:3388
+#: src/muuli_wdr.cpp:3419
 msgid "Send"
 msgstr "Verstuur"
 
-#: src/muuli_wdr.cpp:3389
+#: src/muuli_wdr.cpp:3420
 msgid "Sends the specified message."
 msgstr "Verstuurt het opgegeven bericht."
 
-#: src/muuli_wdr.cpp:3393
+#: src/muuli_wdr.cpp:3424
 msgid "Close this chat-session."
 msgstr "Sluit deze chat-sessie."
 
-#: src/muuli_wdr.cpp:3416
+#: src/muuli_wdr.cpp:3447
 msgid "Connect to any server and/or Kad"
 msgstr "Verbind met een server en/of Kad"
 
-#: src/muuli_wdr.cpp:3422 src/SharedFilesCtrl.cpp:142 src/Statistics.cpp:941
+#: src/muuli_wdr.cpp:3453 src/SharedFilesCtrl.cpp:142 src/Statistics.cpp:941
 msgid "Shared Files"
 msgstr "Gedeelde bestanden"
 
@@ -5450,249 +5478,249 @@ msgstr "Gedownload"
 msgid "ERROR: Failed to open partfile '%s'"
 msgstr "FOUT: Kon deelbestand '%s' niet openen"
 
-#: src/Preferences.cpp:674
+#: src/Preferences.cpp:701
 msgid "System default"
 msgstr "Systeemstandaard"
 
-#: src/Preferences.cpp:675
+#: src/Preferences.cpp:702
 msgid "Albanian"
 msgstr "Albanees"
 
-#: src/Preferences.cpp:676
+#: src/Preferences.cpp:703
 msgid "Arabic"
 msgstr "Arabisch"
 
-#: src/Preferences.cpp:677
+#: src/Preferences.cpp:704
 msgid "Asturian"
 msgstr "Asturisch"
 
-#: src/Preferences.cpp:678
+#: src/Preferences.cpp:705
 msgid "Basque"
 msgstr "Baskisch"
 
-#: src/Preferences.cpp:679
+#: src/Preferences.cpp:706
 msgid "Bulgarian"
 msgstr "Bulgaars"
 
-#: src/Preferences.cpp:680
+#: src/Preferences.cpp:707
 msgid "Catalan"
 msgstr "Catalaans"
 
-#: src/Preferences.cpp:681
+#: src/Preferences.cpp:708
 msgid "Chinese (Simplified)"
 msgstr "Chinees (Vereenvoudigd)"
 
-#: src/Preferences.cpp:682
+#: src/Preferences.cpp:709
 msgid "Chinese (Traditional)"
 msgstr "Chinees (Traditioneel)"
 
-#: src/Preferences.cpp:683
+#: src/Preferences.cpp:710
 msgid "Croatian"
 msgstr "Kroatisch"
 
-#: src/Preferences.cpp:684
+#: src/Preferences.cpp:711
 msgid "Czech"
 msgstr "Tsjechisch"
 
-#: src/Preferences.cpp:685
+#: src/Preferences.cpp:712
 msgid "Danish"
 msgstr "Deens"
 
-#: src/Preferences.cpp:686
+#: src/Preferences.cpp:713
 msgid "Dutch"
 msgstr "Nederlands"
 
-#: src/Preferences.cpp:687
+#: src/Preferences.cpp:714
 msgid "English (U.K.)"
 msgstr "Engels (V.K.)"
 
-#: src/Preferences.cpp:688
+#: src/Preferences.cpp:715
 #, fuzzy
 msgid "English (U.S.)"
 msgstr "Engels (V.K.)"
 
-#: src/Preferences.cpp:689
+#: src/Preferences.cpp:716
 msgid "Estonian"
 msgstr "Estonisch"
 
-#: src/Preferences.cpp:690
+#: src/Preferences.cpp:717
 msgid "Finnish"
 msgstr "Fins"
 
-#: src/Preferences.cpp:691
+#: src/Preferences.cpp:718
 msgid "French"
 msgstr "Frans"
 
-#: src/Preferences.cpp:692
+#: src/Preferences.cpp:719
 msgid "Galician"
 msgstr "Gallisch"
 
-#: src/Preferences.cpp:693
+#: src/Preferences.cpp:720
 msgid "German"
 msgstr "Duits"
 
-#: src/Preferences.cpp:694
+#: src/Preferences.cpp:721
 msgid "Greek"
 msgstr "Grieks"
 
-#: src/Preferences.cpp:695
+#: src/Preferences.cpp:722
 msgid "Hebrew"
 msgstr "Hebreeuws"
 
-#: src/Preferences.cpp:696
+#: src/Preferences.cpp:723
 msgid "Hungarian"
 msgstr "Hongaars"
 
-#: src/Preferences.cpp:697
+#: src/Preferences.cpp:724
 msgid "Italian"
 msgstr "Italiaans"
 
-#: src/Preferences.cpp:698
+#: src/Preferences.cpp:725
 msgid "Japanese"
 msgstr "Japans"
 
-#: src/Preferences.cpp:699
+#: src/Preferences.cpp:726
 msgid "Korean"
 msgstr "Koreaans"
 
-#: src/Preferences.cpp:700
+#: src/Preferences.cpp:727
 msgid "Latvian"
 msgstr ""
 
-#: src/Preferences.cpp:701
+#: src/Preferences.cpp:728
 msgid "Lithuanian"
 msgstr "Litouws"
 
-#: src/Preferences.cpp:702
+#: src/Preferences.cpp:729
 msgid "Norwegian (Nynorsk)"
 msgstr "Noors"
 
-#: src/Preferences.cpp:703
+#: src/Preferences.cpp:730
 msgid "Polish"
 msgstr "Pools"
 
-#: src/Preferences.cpp:704
+#: src/Preferences.cpp:731
 msgid "Portuguese"
 msgstr "Portugees"
 
-#: src/Preferences.cpp:705
+#: src/Preferences.cpp:732
 msgid "Portuguese (Brazilian)"
 msgstr "Portugees (Braziliaans)"
 
-#: src/Preferences.cpp:706
+#: src/Preferences.cpp:733
 msgid "Romanian"
 msgstr "Roemeens"
 
-#: src/Preferences.cpp:707
+#: src/Preferences.cpp:734
 msgid "Russian"
 msgstr "Russisch"
 
-#: src/Preferences.cpp:708
+#: src/Preferences.cpp:735
 msgid "Slovenian"
 msgstr "Sloveens"
 
-#: src/Preferences.cpp:709
+#: src/Preferences.cpp:736
 msgid "Spanish"
 msgstr "Spaans"
 
-#: src/Preferences.cpp:710
+#: src/Preferences.cpp:737
 msgid "Swedish"
 msgstr "Zweeds"
 
-#: src/Preferences.cpp:711
+#: src/Preferences.cpp:738
 msgid "Turkish"
 msgstr "Turks"
 
-#: src/Preferences.cpp:712
+#: src/Preferences.cpp:739
 msgid "Ukrainian"
 msgstr "Oekraïens"
 
-#: src/Preferences.cpp:815
+#: src/Preferences.cpp:842
 msgid "Change Language"
 msgstr "Verander taal"
 
-#: src/Preferences.cpp:879
+#: src/Preferences.cpp:906
 msgid "There are no translations installed for aMule"
 msgstr "Er zijn geen vertalingen voor aMule geïnstalleerd"
 
-#: src/Preferences.cpp:880
+#: src/Preferences.cpp:907
 msgid "No languages available"
 msgstr "Geen talen beschikbaar"
 
-#: src/Preferences.cpp:1011
+#: src/Preferences.cpp:1038
 msgid "no options available"
 msgstr "geen opties beschikbaar"
 
-#: src/Preferences.cpp:2182
+#: src/Preferences.cpp:2227
 msgid "Invalid category found, skipping"
 msgstr "Ongeldige categorie gevonden, wordt overgeslagen"
 
-#: src/Preferences.cpp:2351
+#: src/Preferences.cpp:2396
 msgid "TCP port can't be higher than 65532 due to server UDP socket being TCP+3"
 msgstr "TCP-poort kan niet hoger zijn dan 65532 omdat de server UDP-poort de TCP-poort + 3 is"
 
-#: src/Preferences.cpp:2352
+#: src/Preferences.cpp:2397
 #, c-format
 msgid "Default port will be used (%d)"
 msgstr "Standaard poort zal worden gebruikt (%d)"
 
-#: src/PrefsUnifiedDlg.cpp:298 src/Statistics.cpp:866
+#: src/PrefsUnifiedDlg.cpp:300 src/Statistics.cpp:866
 msgid "Connection"
 msgstr "Verbinding"
 
-#: src/PrefsUnifiedDlg.cpp:299 src/SearchListCtrl.cpp:117
+#: src/PrefsUnifiedDlg.cpp:301 src/SearchListCtrl.cpp:117
 msgid "Directories"
 msgstr "Mappen"
 
-#: src/PrefsUnifiedDlg.cpp:300 src/Statistics.cpp:917
+#: src/PrefsUnifiedDlg.cpp:302 src/Statistics.cpp:917
 msgid "Servers"
 msgstr "Servers"
 
-#: src/PrefsUnifiedDlg.cpp:301 src/ServerListCtrl.cpp:96
+#: src/PrefsUnifiedDlg.cpp:303 src/ServerListCtrl.cpp:96
 msgid "Files"
 msgstr "Bestanden"
 
-#: src/PrefsUnifiedDlg.cpp:302
+#: src/PrefsUnifiedDlg.cpp:304
 msgid "Security"
 msgstr "Beveiliging"
 
-#: src/PrefsUnifiedDlg.cpp:303
+#: src/PrefsUnifiedDlg.cpp:305
 msgid "Interface"
 msgstr "Interface"
 
-#: src/PrefsUnifiedDlg.cpp:310
+#: src/PrefsUnifiedDlg.cpp:312
 msgid "IP2Country"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:313
+#: src/PrefsUnifiedDlg.cpp:315
 msgid "Proxy"
 msgstr "Proxy"
 
-#: src/PrefsUnifiedDlg.cpp:314
+#: src/PrefsUnifiedDlg.cpp:316
 msgid "Filters"
 msgstr "Filters"
 
-#: src/PrefsUnifiedDlg.cpp:315
+#: src/PrefsUnifiedDlg.cpp:317
 msgid "Remote Controls"
 msgstr "Besturing op afstand"
 
-#: src/PrefsUnifiedDlg.cpp:316
+#: src/PrefsUnifiedDlg.cpp:318
 msgid "Online Signature"
 msgstr "Online handtekening"
 
-#: src/PrefsUnifiedDlg.cpp:317
+#: src/PrefsUnifiedDlg.cpp:319
 msgid "Advanced"
 msgstr "Geavanceerd"
 
-#: src/PrefsUnifiedDlg.cpp:318
+#: src/PrefsUnifiedDlg.cpp:320
 msgid "Events"
 msgstr "Gebeurtenissen"
 
-#: src/PrefsUnifiedDlg.cpp:321
+#: src/PrefsUnifiedDlg.cpp:323
 msgid "Debugging"
 msgstr "Foutopsporing"
 
-#: src/PrefsUnifiedDlg.cpp:451
+#: src/PrefsUnifiedDlg.cpp:453
 msgid ""
 "The following variables will be substituted:\n"
 "    %PARTFILE - full path to the file\n"
@@ -5702,15 +5730,15 @@ msgstr ""
 "    %PARTFILE - volledig pad naar het bestand\n"
 "    %PARTNAME - alleen bestandsnaam"
 
-#: src/PrefsUnifiedDlg.cpp:472
+#: src/PrefsUnifiedDlg.cpp:474
 msgid "Tray icon support requires libayatana-appindicator3 at compile time."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:488
+#: src/PrefsUnifiedDlg.cpp:490
 msgid "Not available on Wayland: the protocol does not report when a window is minimized, so this option cannot intercept the system minimize button. Workaround: launch aMule with `GDK_BACKEND=x11` to use XWayland instead."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:534
+#: src/PrefsUnifiedDlg.cpp:536
 msgid ""
 "Do not change these setting unless you know\n"
 "what you are doing, otherwise you can easily\n"
@@ -5726,26 +5754,35 @@ msgstr ""
 "aMule zal goed draaien zonder deze instellingen\n"
 "te wijzigen."
 
-#: src/PrefsUnifiedDlg.cpp:645
+#: src/PrefsUnifiedDlg.cpp:647
 #, c-format
 msgid "Failed to connect Cfg to widget with the ID %d and key %s"
 msgstr "Kon Cfg niet verbinden met widget met ID %d en sleutel %s"
 
-#: src/PrefsUnifiedDlg.cpp:693
+#: src/PrefsUnifiedDlg.cpp:695
 #, c-format
 msgid "Failed to transfer data from Cfg to Widget with the ID %d and key %s"
 msgstr "Kon data niet overdragen van Cfg naar widget met ID %d en sleutel %s"
 
-#: src/PrefsUnifiedDlg.cpp:799
+#: src/PrefsUnifiedDlg.cpp:801
 msgid "The type of proxy you are connecting to"
 msgstr "Het type proxy waarmee u verbinding maakt"
 
-#: src/PrefsUnifiedDlg.cpp:1003
+#: src/PrefsUnifiedDlg.cpp:1020
 #, c-format
 msgid "Failed to transfer data from Widget to Cfg with the ID %d and key %s"
 msgstr "Kon data niet overdragen van Widget naar Cfg met ID %d en sleutel %s"
 
 #: src/PrefsUnifiedDlg.cpp:1103
+#, fuzzy
+msgid "No password set."
+msgstr "Controleren van wachtwoord\n"
+
+#: src/PrefsUnifiedDlg.cpp:1132
+msgid "Guest access needs a password. Type one in the guest password field, or untick Enable guest access."
+msgstr ""
+
+#: src/PrefsUnifiedDlg.cpp:1144
 msgid ""
 "aMule must be restarted to enable these changes:\n"
 "\n"
@@ -5753,41 +5790,41 @@ msgstr ""
 "aMule moet opnieuw gestart worden om deze veranderingen toe te passen:\n"
 "\n"
 
-#: src/PrefsUnifiedDlg.cpp:1110
+#: src/PrefsUnifiedDlg.cpp:1151
 msgid "- TCP port changed.\n"
 msgstr "- TCP-poort veranderd.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1115
+#: src/PrefsUnifiedDlg.cpp:1156
 msgid "- UDP port changed.\n"
 msgstr "- UDP-poort veranderd.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1120
+#: src/PrefsUnifiedDlg.cpp:1161
 #, fuzzy
 msgid "- Network interface binding changed.\n"
 msgstr "- Interface voor externe verbinding veranderd.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1125
+#: src/PrefsUnifiedDlg.cpp:1166
 msgid "- External connect port changed.\n"
 msgstr "- Poort voor externe verbinding is veranderd.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1129
+#: src/PrefsUnifiedDlg.cpp:1170
 msgid "- External connect acceptance changed.\n"
 msgstr "- Acceptatie voor externe verbinding veranderd.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1133
+#: src/PrefsUnifiedDlg.cpp:1174
 msgid "- External connect interface changed.\n"
 msgstr "- Interface voor externe verbinding veranderd.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1137
+#: src/PrefsUnifiedDlg.cpp:1178
 msgid "- Protocol obfuscation support changed.\n"
 msgstr "- Ondersteuning voor Protocol-obfuscatie is veranderd.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1151
+#: src/PrefsUnifiedDlg.cpp:1193
 #, fuzzy
 msgid "- amuleapi settings changed.\n"
 msgstr "- Taal veranderd.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1160
+#: src/PrefsUnifiedDlg.cpp:1202
 msgid ""
 "Your Auto-update server list is empty.\n"
 "'Auto-update server list at startup' will be disabled."
@@ -5795,7 +5832,7 @@ msgstr ""
 "Uw Auto-update serverlijst is leeg.\n"
 "'Auto-update serverlijst bij het opstarten' wordt uitgeschakeld."
 
-#: src/PrefsUnifiedDlg.cpp:1171
+#: src/PrefsUnifiedDlg.cpp:1213
 msgid ""
 "You have enabled external connections but have not specified a password.\n"
 "External connections cannot be enabled unless a valid password is specified."
@@ -5803,28 +5840,33 @@ msgstr ""
 "U hebt externe verbindingen ingeschakeld maar geen wachtwoord ingesteld.\n"
 "Externe verbindingen kunnen niet ingeschakeld worden tenzij een geldig wachtwoord is ingesteld."
 
-#: src/PrefsUnifiedDlg.cpp:1202
+#: src/PrefsUnifiedDlg.cpp:1246
+#, c-format
+msgid "The amuleapi password could not be saved: %s"
+msgstr ""
+
+#: src/PrefsUnifiedDlg.cpp:1276
 msgid "- Language changed.\n"
 msgstr "- Taal veranderd.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1207
+#: src/PrefsUnifiedDlg.cpp:1281
 msgid "- Temp folder changed.\n"
 msgstr "- Tijdelijke map veranderd.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1212
+#: src/PrefsUnifiedDlg.cpp:1286
 msgid "- ED2K network enabled.\n"
 msgstr "- ED2K-netwerk ingeschakeld.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1245
+#: src/PrefsUnifiedDlg.cpp:1319
 msgid "The shared-file exclusion pattern is not a valid regular expression. The filter has been left disabled."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1247 src/PrefsUnifiedDlg.cpp:1841
+#: src/PrefsUnifiedDlg.cpp:1321 src/PrefsUnifiedDlg.cpp:1921
 #, fuzzy
 msgid "Invalid regular expression"
 msgstr "Ongeldige protocolversie."
 
-#: src/PrefsUnifiedDlg.cpp:1324
+#: src/PrefsUnifiedDlg.cpp:1398
 msgid ""
 "Both eD2k and Kad network are disabled.\n"
 "You won't be able to connect until you enable at least one of them."
@@ -5832,7 +5874,7 @@ msgstr ""
 "Zowel het eD2K als het Kad-netwerk zijn uitgeschakeld.\n"
 "U kun niet verbinden tot u minimaal een netwerk inschakelt."
 
-#: src/PrefsUnifiedDlg.cpp:1329
+#: src/PrefsUnifiedDlg.cpp:1403
 msgid ""
 "Kad will not start if your UDP port is disabled.\n"
 "Enable UDP port or disable Kad."
@@ -5840,7 +5882,7 @@ msgstr ""
 "Kad zal niet starten als uw UDP-poort is uitgeschakeld.\n"
 "Schakel de UDP-poort in of schakel Kad uit."
 
-#: src/PrefsUnifiedDlg.cpp:1385
+#: src/PrefsUnifiedDlg.cpp:1459
 msgid ""
 "\n"
 "You MUST restart aMule now.\n"
@@ -5850,69 +5892,69 @@ msgstr ""
 "U MOET aMule nu opnieuw starten.\n"
 "Als u dat niet doet moet u niet klagen als er iets misgaat.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1450
+#: src/PrefsUnifiedDlg.cpp:1524
 msgid "Could not register aMule for autostart at login. The autostart store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1452
+#: src/PrefsUnifiedDlg.cpp:1526
 msgid "Could not remove the autostart-at-login entry."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1453
+#: src/PrefsUnifiedDlg.cpp:1527
 #, fuzzy
 msgid "Autostart"
 msgstr "Automatisch verversen gestart"
 
-#: src/PrefsUnifiedDlg.cpp:1468
+#: src/PrefsUnifiedDlg.cpp:1542
 msgid "Register file type"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1468
+#: src/PrefsUnifiedDlg.cpp:1542
 msgid "Register URL handler"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1476
+#: src/PrefsUnifiedDlg.cpp:1550
 #, c-format
 msgid "aMule only handles eD2k-compatible magnets. If you replace the current magnet handler (%s), BitTorrent magnet links will stop working - aMule cannot download BitTorrent content. Continue?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1481
+#: src/PrefsUnifiedDlg.cpp:1555
 #, c-format
 msgid "Another application currently opens .emulecollection files (%s). Replace it with aMule?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1486
+#: src/PrefsUnifiedDlg.cpp:1560
 #, c-format
 msgid "Another application is currently the default handler for these links (%s). Replace it with aMule?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1511
+#: src/PrefsUnifiedDlg.cpp:1585
 msgid "Could not register aMule for .emulecollection files. The registration store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1513
+#: src/PrefsUnifiedDlg.cpp:1587
 #, fuzzy
 msgid "Could not remove the file type registration."
 msgstr "Map voor tijdelijke downloadbestanden"
 
-#: src/PrefsUnifiedDlg.cpp:1515
+#: src/PrefsUnifiedDlg.cpp:1589
 msgid "Could not register aMule as the URL handler. The registration store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1517
+#: src/PrefsUnifiedDlg.cpp:1591
 msgid "Could not remove the URL handler registration."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1587 src/PrefsUnifiedDlg.cpp:1614
+#: src/PrefsUnifiedDlg.cpp:1661 src/PrefsUnifiedDlg.cpp:1688
 #, fuzzy
 msgid "The web server and aMule API require external connections to be enabled."
 msgstr "Wachtwoord ingesteld en externe verbindingen ingeschakeld."
 
-#: src/PrefsUnifiedDlg.cpp:1597
+#: src/PrefsUnifiedDlg.cpp:1671
 msgid "The aMule web server is deprecated. Consider running the aMule API instead."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1655
+#: src/PrefsUnifiedDlg.cpp:1735
 msgid ""
 "Your Auto-update servers list is in blank.\n"
 "Please fill in at least one URL to point to a valid server.met file.\n"
@@ -5922,66 +5964,66 @@ msgstr ""
 "Vul minimaal een URL naar een geldig server.met bestand in.\n"
 "Klik op de knop \"Lijst\" hiernaast om een URL in te voeren."
 
-#: src/PrefsUnifiedDlg.cpp:1796
+#: src/PrefsUnifiedDlg.cpp:1876
 msgid "Temporary files"
 msgstr "Tijdelijke bestanden"
 
-#: src/PrefsUnifiedDlg.cpp:1801
+#: src/PrefsUnifiedDlg.cpp:1881
 msgid "Incoming files"
 msgstr "Binnenkomende bestanden"
 
-#: src/PrefsUnifiedDlg.cpp:1806
+#: src/PrefsUnifiedDlg.cpp:1886
 msgid "Online Signatures"
 msgstr "Online handtekeningen"
 
-#: src/PrefsUnifiedDlg.cpp:1819
+#: src/PrefsUnifiedDlg.cpp:1899
 #, c-format
 msgid "Choose a folder for %s"
 msgstr "Kies een map voor %s"
 
-#: src/PrefsUnifiedDlg.cpp:1843
+#: src/PrefsUnifiedDlg.cpp:1923
 #, fuzzy, c-format
 msgid "Would exclude %u of %u shared file"
 msgid_plural "Would exclude %u of %u shared files"
 msgstr[0] "%i bekend gedeeld bestand gevonden"
 msgstr[1] "%i bekende gedeelde bestanden gevonden"
 
-#: src/PrefsUnifiedDlg.cpp:1860
+#: src/PrefsUnifiedDlg.cpp:1940
 msgid "Browse for videoplayer"
 msgstr "Blader naar videospeler"
 
-#: src/PrefsUnifiedDlg.cpp:1864
+#: src/PrefsUnifiedDlg.cpp:1944
 msgid "Select browser"
 msgstr "Selecteer browser"
 
-#: src/PrefsUnifiedDlg.cpp:1868
+#: src/PrefsUnifiedDlg.cpp:1948
 #, fuzzy
 msgid "Select ffprobe binary"
 msgstr "Selecteer browser"
 
-#: src/PrefsUnifiedDlg.cpp:1874
+#: src/PrefsUnifiedDlg.cpp:1954
 #, c-format
 msgid "Executable%s"
 msgstr "Uitvoerbare%s"
 
-#: src/PrefsUnifiedDlg.cpp:1908
+#: src/PrefsUnifiedDlg.cpp:1988
 msgid "ffprobe not found on PATH or in the standard install locations. Install ffmpeg (which ships ffprobe) or use Browse to pick a binary manually."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1920
+#: src/PrefsUnifiedDlg.cpp:2000
 msgid "Reset the settings on this page to their default values?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1921
+#: src/PrefsUnifiedDlg.cpp:2001
 #, fuzzy
 msgid "Reset to defaults"
 msgstr "Systeemstandaard"
 
-#: src/PrefsUnifiedDlg.cpp:1948
+#: src/PrefsUnifiedDlg.cpp:2028
 msgid "Edit server list"
 msgstr "Bewerk serverlijst"
 
-#: src/PrefsUnifiedDlg.cpp:1949
+#: src/PrefsUnifiedDlg.cpp:2029
 msgid ""
 "Add here URL's to download server.met files.\n"
 "Only one url on each line."
@@ -5989,154 +6031,154 @@ msgstr ""
 "Voeg hier URL's toe om server.met bestanden te downloaden.\n"
 "Slechts één url per regel."
 
-#: src/PrefsUnifiedDlg.cpp:2004
+#: src/PrefsUnifiedDlg.cpp:2084
 msgid "IP2Country update failed"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2149 src/PrefsUnifiedDlg.cpp:2180
+#: src/PrefsUnifiedDlg.cpp:2229 src/PrefsUnifiedDlg.cpp:2260
 msgid "Data by MaxMind GeoLite2"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2151 src/PrefsUnifiedDlg.cpp:2182
+#: src/PrefsUnifiedDlg.cpp:2231 src/PrefsUnifiedDlg.cpp:2262
 #, fuzzy
 msgid "Custom source"
 msgstr "Complete bronnen"
 
-#: src/PrefsUnifiedDlg.cpp:2153 src/PrefsUnifiedDlg.cpp:2184
+#: src/PrefsUnifiedDlg.cpp:2233 src/PrefsUnifiedDlg.cpp:2264
 msgid "Data by DB-IP.com"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2204
+#: src/PrefsUnifiedDlg.cpp:2284
 #, fuzzy, c-format
 msgid "Status: Loaded%s"
 msgstr "Status:"
 
-#: src/PrefsUnifiedDlg.cpp:2206
+#: src/PrefsUnifiedDlg.cpp:2286
 #, fuzzy, c-format
 msgid "Status: Loaded%s - %s"
 msgstr "Status:"
 
-#: src/PrefsUnifiedDlg.cpp:2210
+#: src/PrefsUnifiedDlg.cpp:2290
 msgid "Status: Failed to load - click 'Update now' to refresh."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2212
+#: src/PrefsUnifiedDlg.cpp:2292
 msgid "Status: Not found - click 'Update now' to download."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2270 src/PrefsUnifiedDlg.cpp:2294
+#: src/PrefsUnifiedDlg.cpp:2350 src/PrefsUnifiedDlg.cpp:2374
 #, c-format
 msgid "Update delay: %d second"
 msgid_plural "Update delay: %d seconds"
 msgstr[0] "Update-vertraging: %d seconde"
 msgstr[1] "Update-vertraging: %d seconden"
 
-#: src/PrefsUnifiedDlg.cpp:2278
+#: src/PrefsUnifiedDlg.cpp:2358
 #, c-format
 msgid "Time for average graph: %d minute"
 msgid_plural "Time for average graph: %d minutes"
 msgstr[0] "Tijd voor gemiddeldengrafiek: %d minuut"
 msgstr[1] "Tijd voor gemiddeldengrafiek: %d minuten"
 
-#: src/PrefsUnifiedDlg.cpp:2287
+#: src/PrefsUnifiedDlg.cpp:2367
 #, c-format
 msgid "Connections Graph Scale: %d"
 msgstr "Schaal verbindingengrafiek: %d"
 
-#: src/PrefsUnifiedDlg.cpp:2302
+#: src/PrefsUnifiedDlg.cpp:2382
 #, c-format
 msgid "File Buffer Size: %d byte"
 msgid_plural "File Buffer Size: %d bytes"
 msgstr[0] "Grootte van bestandsbuffer: %d byte"
 msgstr[1] "Grootte van bestandsbuffer: %d bytes"
 
-#: src/PrefsUnifiedDlg.cpp:2312
+#: src/PrefsUnifiedDlg.cpp:2392
 #, c-format
 msgid "Upload Queue Size: %d client"
 msgid_plural "Upload Queue Size: %d clients"
 msgstr[0] "Grootte van uploadwachtrij: %d client"
 msgstr[1] "Grootte van uploadwachtrij: %d clients"
 
-#: src/PrefsUnifiedDlg.cpp:2322
+#: src/PrefsUnifiedDlg.cpp:2402
 #, c-format
 msgid "Server connection refresh interval: %d minute"
 msgid_plural "Server connection refresh interval: %d minutes"
 msgstr[0] "Server-verbinding verversingsinterval: %d minuut"
 msgstr[1] "Server-verbinding verversingsinterval: %d minuten"
 
-#: src/PrefsUnifiedDlg.cpp:2327
+#: src/PrefsUnifiedDlg.cpp:2407
 msgid "Server connection refresh interval: Disabled"
 msgstr "Server verbinding verversingstijd: Uitgeschakeld"
 
-#: src/PrefsUnifiedDlg.cpp:2371
+#: src/PrefsUnifiedDlg.cpp:2451
 msgid "disabled"
 msgstr "uitgeschakeld"
 
-#: src/PrefsUnifiedDlg.cpp:2397
+#: src/PrefsUnifiedDlg.cpp:2477
 #, c-format
 msgid "Execute command on '%s' event"
 msgstr "Voer commando uit bij gebeurtenis '%s'"
 
-#: src/PrefsUnifiedDlg.cpp:2404
+#: src/PrefsUnifiedDlg.cpp:2484
 msgid "Enable command execution on core"
 msgstr "Schakel uitvoeren van commando's in kern in"
 
-#: src/PrefsUnifiedDlg.cpp:2416
+#: src/PrefsUnifiedDlg.cpp:2496
 msgid "Core command:"
 msgstr "Kerncommando:"
 
-#: src/PrefsUnifiedDlg.cpp:2432
+#: src/PrefsUnifiedDlg.cpp:2512
 msgid "Enable command execution on GUI"
 msgstr "Schakel uitvoeren van commando's in GUI in"
 
-#: src/PrefsUnifiedDlg.cpp:2444
+#: src/PrefsUnifiedDlg.cpp:2524
 msgid "GUI command:"
 msgstr "GUI commando:"
 
-#: src/PrefsUnifiedDlg.cpp:2460
+#: src/PrefsUnifiedDlg.cpp:2540
 msgid "The following variables will be replaced:"
 msgstr "De volgende variabelen worden vervangen:"
 
-#: src/PrefsUnifiedDlg.cpp:2628
+#: src/PrefsUnifiedDlg.cpp:2708
 msgid ""
 "The following folders look like system or sensitive locations:\n"
 "\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2633
+#: src/PrefsUnifiedDlg.cpp:2713
 msgid "Sharing them recursively will publish every file underneath on the eD2k/Kad networks. Do you really want to do this?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2636
+#: src/PrefsUnifiedDlg.cpp:2716
 #, fuzzy
 msgid "Confirm shared folders"
 msgstr "Gedeelde mappen"
 
-#: src/PrefsUnifiedDlg.cpp:2664
+#: src/PrefsUnifiedDlg.cpp:2744
 #, fuzzy
 msgid "Reloading shared files..."
 msgstr "Laad uw gedeelde bestanden opnieuw"
 
-#: src/PrefsUnifiedDlg.cpp:2665
+#: src/PrefsUnifiedDlg.cpp:2745
 msgid "Scanning for subdirectories..."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2666
+#: src/PrefsUnifiedDlg.cpp:2746
 #, fuzzy
 msgid "Updating shared folders"
 msgstr "Gedeelde mappen"
 
-#: src/PrefsUnifiedDlg.cpp:2693
+#: src/PrefsUnifiedDlg.cpp:2773
 #, c-format
 msgid "Scanned %u directories..."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2743
+#: src/PrefsUnifiedDlg.cpp:2823
 #, fuzzy, c-format
 msgid "Reloading shared files: %u files scanned"
 msgstr "Laad gedeelde-bestandenlijst opnieuw."
 
-#: src/PrefsUnifiedDlg.cpp:2793
+#: src/PrefsUnifiedDlg.cpp:2873
 #, fuzzy
 msgid "Shared folder"
 msgstr "Gedeelde mappen"

--- a/po/nn.po
+++ b/po/nn.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-28 12:17+0200\n"
+"POT-Creation-Date: 2026-07-28 13:09+0200\n"
 "PO-Revision-Date: 2026-07-27 11:42+0000\n"
 "Last-Translator: Hallvor Brunstad <Hallvor_1976@yahoo.com>\n"
 "Language-Team: <i18n-nn@lister.ping.uio.no>\n"
@@ -294,7 +294,7 @@ msgid "Password set and external connections enabled."
 msgstr "Ny ekstern kopling akseptert"
 
 #: src/amule.cpp:755 src/KadDlg.cpp:176 src/KadDlg.cpp:185
-#: src/PrefsUnifiedDlg.cpp:1461 src/SharedFilesCtrl.cpp:476
+#: src/PrefsUnifiedDlg.cpp:1470 src/SharedFilesCtrl.cpp:476
 msgid "WARNING"
 msgstr "ÅTVARING"
 
@@ -332,7 +332,7 @@ msgstr "Du freista å køyre vevtenar ved oppstart, men binærfila amuleweb kan 
 #: src/amule-remote-gui.cpp:603 src/amule-remote-gui.cpp:671
 #: src/amule-remote-gui.cpp:709 src/amule-remote-gui.cpp:1282
 #: src/amule-remote-gui.cpp:1345 src/amule-remote-gui.cpp:1372
-#: src/DownloadQueue.cpp:1481 src/PrefsUnifiedDlg.cpp:1247
+#: src/DownloadQueue.cpp:1481 src/PrefsUnifiedDlg.cpp:1256
 msgid "ERROR"
 msgstr "FEIL"
 
@@ -595,36 +595,36 @@ msgstr "Vitje https://github.com/amule-org/amule/releases/latest for å sjekke o
 msgid "FATAL ERROR: Failed to create Timer"
 msgstr "FATAL FEIL: Greidde ikkje å lage tidtakar"
 
-#: src/amuleDlg.cpp:361 src/amuleDlg.cpp:1787 src/amuleDlg.cpp:2033
-#: src/muuli_wdr.cpp:1492 src/muuli_wdr.cpp:3449
+#: src/amuleDlg.cpp:361 src/amuleDlg.cpp:1810 src/amuleDlg.cpp:2056
+#: src/muuli_wdr.cpp:1492 src/muuli_wdr.cpp:3453
 msgid "Networks"
 msgstr "Nettverk"
 
-#: src/amuleDlg.cpp:362 src/amuleDlg.cpp:1793 src/muuli_wdr.cpp:3450
+#: src/amuleDlg.cpp:362 src/amuleDlg.cpp:1816 src/muuli_wdr.cpp:3454
 msgid "Searches"
 msgstr "Søk"
 
-#: src/amuleDlg.cpp:363 src/amuleDlg.cpp:1799 src/DownloadListCtrl.cpp:740
-#: src/muuli_wdr.cpp:392 src/muuli_wdr.cpp:1585 src/muuli_wdr.cpp:3451
+#: src/amuleDlg.cpp:363 src/amuleDlg.cpp:1822 src/DownloadListCtrl.cpp:740
+#: src/muuli_wdr.cpp:392 src/muuli_wdr.cpp:1585 src/muuli_wdr.cpp:3455
 #: src/Statistics.cpp:829
 msgid "Downloads"
 msgstr "Nedlastingar"
 
-#: src/amuleDlg.cpp:364 src/amuleDlg.cpp:1805 src/muuli_wdr.cpp:3325
+#: src/amuleDlg.cpp:364 src/amuleDlg.cpp:1828 src/muuli_wdr.cpp:3329
 msgid "Shared files"
 msgstr "Delte filer"
 
-#: src/amuleDlg.cpp:365 src/amuleDlg.cpp:1811 src/muuli_wdr.cpp:2957
-#: src/muuli_wdr.cpp:3407 src/muuli_wdr.cpp:3454
+#: src/amuleDlg.cpp:365 src/amuleDlg.cpp:1834 src/muuli_wdr.cpp:2961
+#: src/muuli_wdr.cpp:3411 src/muuli_wdr.cpp:3458
 msgid "Messages"
 msgstr "Meldingar"
 
-#: src/amuleDlg.cpp:366 src/amuleDlg.cpp:1817 src/muuli_wdr.cpp:3455
+#: src/amuleDlg.cpp:366 src/amuleDlg.cpp:1840 src/muuli_wdr.cpp:3459
 #: src/PrefsUnifiedDlg.cpp:314 src/Statistics.cpp:779 src/Statistics.cpp:1235
 msgid "Statistics"
 msgstr "Statistikk"
 
-#: src/amuleDlg.cpp:368 src/amuleDlg.cpp:1824 src/muuli_wdr.cpp:3457
+#: src/amuleDlg.cpp:368 src/amuleDlg.cpp:1847 src/muuli_wdr.cpp:3461
 #: src/PrefsUnifiedDlg.cpp:330 src/utils/wxCas/src/wxcasprefs.cpp:39
 msgid "Preferences"
 msgstr "Innstillingar"
@@ -683,8 +683,8 @@ msgstr "Kad: Av"
 #: src/amuleDlg.cpp:1029 src/DownloadListCtrl.cpp:505
 #: src/DownloadListCtrl.cpp:749 src/FriendListCtrl.cpp:180
 #: src/muuli_wdr.cpp:731 src/muuli_wdr.cpp:782 src/muuli_wdr.cpp:846
-#: src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2262 src/muuli_wdr.cpp:2347
-#: src/muuli_wdr.cpp:3095 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
+#: src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2266 src/muuli_wdr.cpp:2351
+#: src/muuli_wdr.cpp:3099 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
 #: src/ServerListCtrl.cpp:606 src/TransferWnd.cpp:378
 #: src/utils/wxCas/src/wxcasprefs.cpp:235
 msgid "Cancel"
@@ -695,7 +695,7 @@ msgid "Stop the current connection attempts"
 msgstr "Stopp inneverande oppkoplingsfreistingar"
 
 #: src/amuleDlg.cpp:1035 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976
-#: src/muuli_wdr.cpp:2485
+#: src/muuli_wdr.cpp:2489
 msgid "Disconnect"
 msgstr "Kople frå"
 
@@ -704,7 +704,7 @@ msgid "Disconnect from the currently connected networks"
 msgstr "Kople frå dei aktive nettverka"
 
 #: src/amuleDlg.cpp:1041 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979
-#: src/muuli_wdr.cpp:2640 src/muuli_wdr.cpp:3092 src/muuli_wdr.cpp:3447
+#: src/muuli_wdr.cpp:2644 src/muuli_wdr.cpp:3096 src/muuli_wdr.cpp:3451
 msgid "Connect"
 msgstr "Kople til"
 
@@ -759,7 +759,7 @@ msgstr "Stadfesting av avslutting"
 msgid "Launch Command: "
 msgstr ""
 
-#: src/amuleDlg.cpp:1632 src/muuli_wdr.cpp:1982 src/Preferences.cpp:979
+#: src/amuleDlg.cpp:1632 src/muuli_wdr.cpp:1986 src/Preferences.cpp:979
 msgid "- default -"
 msgstr ""
 
@@ -773,61 +773,61 @@ msgstr "Skinnkatalogen '%s' finst ikkje"
 msgid "WARNING: Unable to open skin file '%s' for read"
 msgstr "ÅTVARING: Greidde ikkje å opne hudfila '%s' for lesing"
 
-#: src/amuleDlg.cpp:1791 src/muuli_wdr.cpp:3449
+#: src/amuleDlg.cpp:1814 src/muuli_wdr.cpp:3453
 msgid "Networks Window"
 msgstr "Nettverksavindauge"
 
-#: src/amuleDlg.cpp:1797 src/muuli_wdr.cpp:3450
+#: src/amuleDlg.cpp:1820 src/muuli_wdr.cpp:3454
 msgid "Searches Window"
 msgstr "Søkjevindauge"
 
-#: src/amuleDlg.cpp:1803 src/muuli_wdr.cpp:3451
+#: src/amuleDlg.cpp:1826 src/muuli_wdr.cpp:3455
 #, fuzzy
 msgid "Downloads Window"
 msgstr "Lastar ned"
 
-#: src/amuleDlg.cpp:1809 src/muuli_wdr.cpp:3453
+#: src/amuleDlg.cpp:1832 src/muuli_wdr.cpp:3457
 msgid "Shared Files Window"
 msgstr "Vindauge for delte filer"
 
-#: src/amuleDlg.cpp:1815 src/muuli_wdr.cpp:3454
+#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3458
 msgid "Messages Window"
 msgstr "Meldingsvindauge"
 
-#: src/amuleDlg.cpp:1821 src/muuli_wdr.cpp:3455
+#: src/amuleDlg.cpp:1844 src/muuli_wdr.cpp:3459
 msgid "Statistics Graph Window"
 msgstr "Statistikkgrafvindauge"
 
-#: src/amuleDlg.cpp:1828 src/muuli_wdr.cpp:3457
+#: src/amuleDlg.cpp:1851 src/muuli_wdr.cpp:3461
 msgid "Preferences Settings Window"
 msgstr "Innstillingsvalsvindauge"
 
-#: src/amuleDlg.cpp:1831 src/muuli_wdr.cpp:3458
+#: src/amuleDlg.cpp:1854 src/muuli_wdr.cpp:3462
 msgid "Import"
 msgstr "Importér"
 
-#: src/amuleDlg.cpp:1835 src/muuli_wdr.cpp:3458
+#: src/amuleDlg.cpp:1858 src/muuli_wdr.cpp:3462
 msgid "The partfile importer tool"
 msgstr "Verkty for delfilimport"
 
-#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3459
+#: src/amuleDlg.cpp:1861 src/muuli_wdr.cpp:3463
 #: src/utils/aLinkCreator/src/alcframe.cpp:262
 msgid "About"
 msgstr "Om"
 
-#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3459
+#: src/amuleDlg.cpp:1861 src/muuli_wdr.cpp:3463
 msgid "About/Help"
 msgstr "Om/hjelp"
 
-#: src/amuleDlg.cpp:2036
+#: src/amuleDlg.cpp:2059
 msgid "eD2k network"
 msgstr "ed2k nettverk"
 
-#: src/amuleDlg.cpp:2039
+#: src/amuleDlg.cpp:2062
 msgid "Kad network"
 msgstr "Kad nettverk"
 
-#: src/amuleDlg.cpp:2039
+#: src/amuleDlg.cpp:2062
 msgid "No network"
 msgstr "Ikkje noko nettverk"
 
@@ -1364,19 +1364,19 @@ msgstr "Auto·[Hø]"
 msgid "Very low"
 msgstr "Svært låg"
 
-#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:743 src/muuli_wdr.cpp:2313
+#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:743 src/muuli_wdr.cpp:2317
 #: src/ServerListCtrl.cpp:263 src/ServerListCtrl.cpp:456
 #: src/SharedFilesCtrl.cpp:145
 msgid "Low"
 msgstr "Låg"
 
-#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:744 src/muuli_wdr.cpp:2314
+#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:744 src/muuli_wdr.cpp:2318
 #: src/ServerListCtrl.cpp:266 src/ServerListCtrl.cpp:457
 #: src/SharedFilesCtrl.cpp:146
 msgid "Normal"
 msgstr "Vanleg"
 
-#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:745 src/muuli_wdr.cpp:2315
+#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:745 src/muuli_wdr.cpp:2319
 #: src/ServerListCtrl.cpp:269 src/ServerListCtrl.cpp:458
 #: src/SharedFilesCtrl.cpp:147
 msgid "High"
@@ -1468,7 +1468,7 @@ msgstr "Lokal tenar"
 msgid "Remote Server"
 msgstr "Fjern tenar"
 
-#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3212
+#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3216
 #: src/SearchDlg.cpp:119 src/TextClient.cpp:911
 msgid "Kad"
 msgstr "Kad"
@@ -1540,7 +1540,7 @@ msgstr ""
 msgid "Size"
 msgstr "Storleik"
 
-#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3279
+#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3283
 msgid "Transferred"
 msgstr "Overført"
 
@@ -1598,7 +1598,7 @@ msgstr ""
 "Tilbakemelding frå: %s (%s)\n"
 "\n"
 
-#: src/DownloadListCtrl.cpp:746 src/muuli_wdr.cpp:2316
+#: src/DownloadListCtrl.cpp:746 src/muuli_wdr.cpp:2320
 #: src/SharedFilesCtrl.cpp:150
 msgid "Auto"
 msgstr "Automatisk"
@@ -1636,7 +1636,7 @@ msgid "Extended Options"
 msgstr "Utvida innstillingar"
 
 #: src/DownloadListCtrl.cpp:770 src/DownloadListCtrl.cpp:822
-#: src/muuli_wdr.cpp:1800
+#: src/muuli_wdr.cpp:1804
 msgid "Preview"
 msgstr "Førehandssyning"
 
@@ -2440,23 +2440,23 @@ msgid ""
 "want downloads on a different (e.g. larger) disk."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:549 src/FirstRunWizard.cpp:611 src/muuli_wdr.cpp:1712
+#: src/FirstRunWizard.cpp:549 src/FirstRunWizard.cpp:611 src/muuli_wdr.cpp:1716
 msgid "Destination folder for downloads"
 msgstr ""
 
 #: src/FirstRunWizard.cpp:553 src/FirstRunWizard.cpp:569 src/muuli_wdr.cpp:1349
-#: src/muuli_wdr.cpp:1366 src/muuli_wdr.cpp:1687 src/muuli_wdr.cpp:1718
-#: src/muuli_wdr.cpp:1730 src/muuli_wdr.cpp:2800
+#: src/muuli_wdr.cpp:1366 src/muuli_wdr.cpp:1691 src/muuli_wdr.cpp:1722
+#: src/muuli_wdr.cpp:1734 src/muuli_wdr.cpp:2804
 #: src/utils/aLinkCreator/src/alcframe.cpp:135
 #: src/utils/wxCas/src/wxcasprefs.cpp:52 src/utils/wxCas/src/wxcasprefs.cpp:118
 msgid "Browse"
 msgstr "Bla"
 
-#: src/FirstRunWizard.cpp:559 src/muuli_wdr.cpp:1723
+#: src/FirstRunWizard.cpp:559 src/muuli_wdr.cpp:1727
 msgid "(All files in this folder are shared with other peers)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:565 src/FirstRunWizard.cpp:624 src/muuli_wdr.cpp:1725
+#: src/FirstRunWizard.cpp:565 src/FirstRunWizard.cpp:624 src/muuli_wdr.cpp:1729
 msgid "Folder for temporary download files"
 msgstr ""
 
@@ -2487,7 +2487,7 @@ msgstr "Greidde ikkje å opne venelista 'enfriends.met' for skriving!"
 msgid "CRITICAL - no client on StartChatSession"
 msgstr ""
 
-#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2706 src/muuli_wdr.cpp:3383
+#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2710 src/muuli_wdr.cpp:3387
 msgid "Friends"
 msgstr "Vener"
 
@@ -2601,8 +2601,8 @@ msgstr "Ingen"
 msgid "No"
 msgstr "Nei"
 
-#: src/GenericClientListCtrl.cpp:1216 src/PrefsUnifiedDlg.cpp:2898
-#: src/PrefsUnifiedDlg.cpp:2948 src/ServerListCtrl.cpp:276
+#: src/GenericClientListCtrl.cpp:1216 src/PrefsUnifiedDlg.cpp:2907
+#: src/PrefsUnifiedDlg.cpp:2957 src/ServerListCtrl.cpp:276
 msgid "Yes"
 msgstr "Ja"
 
@@ -2772,10 +2772,10 @@ msgstr "Ikkje gangbar port for eigenoppstart"
 msgid "Please fill all fields required"
 msgstr "Vér god å fylle ut alle naudsynte felt"
 
-#: src/KadDlg.cpp:192 src/PartFile.cpp:1031 src/PrefsUnifiedDlg.cpp:1134
-#: src/PrefsUnifiedDlg.cpp:1204 src/PrefsUnifiedDlg.cpp:1405
-#: src/PrefsUnifiedDlg.cpp:1663 src/PrefsUnifiedDlg.cpp:1673
-#: src/PrefsUnifiedDlg.cpp:1690 src/PrefsUnifiedDlg.cpp:1738
+#: src/KadDlg.cpp:192 src/PartFile.cpp:1031 src/PrefsUnifiedDlg.cpp:1143
+#: src/PrefsUnifiedDlg.cpp:1213 src/PrefsUnifiedDlg.cpp:1414
+#: src/PrefsUnifiedDlg.cpp:1672 src/PrefsUnifiedDlg.cpp:1682
+#: src/PrefsUnifiedDlg.cpp:1699 src/PrefsUnifiedDlg.cpp:1747
 msgid "Message"
 msgstr "Melding"
 
@@ -2877,7 +2877,7 @@ msgstr "Delingsrate"
 msgid "Uploaded"
 msgstr "Lasta opp"
 
-#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3263
+#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3267
 msgid "Requested"
 msgstr "Etterspurt"
 
@@ -3003,7 +3003,7 @@ msgid "WARNING: "
 msgstr "ÅTVARING: "
 
 #: src/MuleNotebook.cpp:179 src/muuli_wdr.cpp:817 src/muuli_wdr.cpp:1229
-#: src/muuli_wdr.cpp:3167 src/muuli_wdr.cpp:3423
+#: src/muuli_wdr.cpp:3171 src/muuli_wdr.cpp:3427
 msgid "Close"
 msgstr "Stengje"
 
@@ -3021,7 +3021,7 @@ msgid "Paste"
 msgstr "Lim inn"
 
 #: src/MuleTextCtrl.cpp:89 src/muuli_wdr.cpp:358 src/muuli_wdr.cpp:757
-#: src/muuli_wdr.cpp:2390 src/muuli_wdr.cpp:2409 src/muuli_wdr.cpp:2431
+#: src/muuli_wdr.cpp:2394 src/muuli_wdr.cpp:2413 src/muuli_wdr.cpp:2435
 #: src/utils/aLinkCreator/src/alcframe.cpp:142
 msgid "Clear"
 msgstr "Frigjer plass"
@@ -3120,7 +3120,7 @@ msgstr "Avslutt"
 
 #: src/MuleTrayIcon.cpp:579 src/MuleTrayIcon.cpp:945 src/MuleTrayIcon.cpp:965
 #: src/muuli_wdr.cpp:1398 src/muuli_wdr.cpp:1406 src/muuli_wdr.cpp:1413
-#: src/muuli_wdr.cpp:1846 src/muuli_wdr.cpp:1852 src/OtherFunctions.cpp:91
+#: src/muuli_wdr.cpp:1850 src/muuli_wdr.cpp:1856 src/OtherFunctions.cpp:91
 #: src/StatisticsDlg.cpp:93 src/StatisticsDlg.cpp:95
 msgid "kB/s"
 msgstr "kB/s"
@@ -3362,7 +3362,7 @@ msgstr "Bytes"
 msgid "KB"
 msgstr "KB"
 
-#: src/muuli_wdr.cpp:274 src/muuli_wdr.cpp:293 src/muuli_wdr.cpp:1631
+#: src/muuli_wdr.cpp:274 src/muuli_wdr.cpp:293 src/muuli_wdr.cpp:1635
 #: src/OtherFunctions.cpp:64
 msgid "MB"
 msgstr "MB"
@@ -3379,7 +3379,7 @@ msgstr "Maks storleik"
 msgid "Availability"
 msgstr "Tilgjenge"
 
-#: src/muuli_wdr.cpp:312 src/muuli_wdr.cpp:398 src/muuli_wdr.cpp:3328
+#: src/muuli_wdr.cpp:312 src/muuli_wdr.cpp:398 src/muuli_wdr.cpp:3332
 msgid "Filter:"
 msgstr "Filter:"
 
@@ -3443,8 +3443,8 @@ msgstr "Komplette kjelder"
 #: src/muuli_wdr.cpp:1160 src/muuli_wdr.cpp:1167 src/muuli_wdr.cpp:1172
 #: src/muuli_wdr.cpp:1179 src/muuli_wdr.cpp:1184 src/muuli_wdr.cpp:1191
 #: src/muuli_wdr.cpp:1205 src/muuli_wdr.cpp:1212 src/muuli_wdr.cpp:1217
-#: src/muuli_wdr.cpp:1224 src/muuli_wdr.cpp:3265 src/muuli_wdr.cpp:3273
-#: src/muuli_wdr.cpp:3281
+#: src/muuli_wdr.cpp:1224 src/muuli_wdr.cpp:3269 src/muuli_wdr.cpp:3277
+#: src/muuli_wdr.cpp:3285
 msgid "N/A"
 msgstr "I/T"
 
@@ -3589,7 +3589,7 @@ msgstr ""
 msgid "Album :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:685 src/muuli_wdr.cpp:2285
+#: src/muuli_wdr.cpp:685 src/muuli_wdr.cpp:2289
 msgid "Title :"
 msgstr "Tittel :"
 
@@ -3696,7 +3696,7 @@ msgstr "Brukarnamn :"
 msgid "Userhash :"
 msgstr "Brukarhash :"
 
-#: src/muuli_wdr.cpp:895 src/muuli_wdr.cpp:1752 src/muuli_wdr.cpp:2480
+#: src/muuli_wdr.cpp:895 src/muuli_wdr.cpp:1756 src/muuli_wdr.cpp:2484
 #: src/utils/aLinkCreator/src/alcframe.cpp:137
 msgid "Add"
 msgstr "Legg til"
@@ -3705,15 +3705,15 @@ msgstr "Legg til"
 msgid "Download-Speed"
 msgstr "Nedlastingsfart"
 
-#: src/muuli_wdr.cpp:954 src/muuli_wdr.cpp:989 src/muuli_wdr.cpp:2584
+#: src/muuli_wdr.cpp:954 src/muuli_wdr.cpp:989 src/muuli_wdr.cpp:2588
 msgid "Current"
 msgstr "Novérande"
 
-#: src/muuli_wdr.cpp:962 src/muuli_wdr.cpp:997 src/muuli_wdr.cpp:2592
+#: src/muuli_wdr.cpp:962 src/muuli_wdr.cpp:997 src/muuli_wdr.cpp:2596
 msgid "Running average"
 msgstr "Køyregjennomsnitt"
 
-#: src/muuli_wdr.cpp:970 src/muuli_wdr.cpp:1005 src/muuli_wdr.cpp:2600
+#: src/muuli_wdr.cpp:970 src/muuli_wdr.cpp:1005 src/muuli_wdr.cpp:2604
 msgid "Session average"
 msgstr "Gjennomsnitt økt"
 
@@ -3725,7 +3725,7 @@ msgstr "Opplastingsfart"
 msgid "Connections"
 msgstr "Koplingar"
 
-#: src/muuli_wdr.cpp:1024 src/muuli_wdr.cpp:1871
+#: src/muuli_wdr.cpp:1024 src/muuli_wdr.cpp:1875
 msgid "Active downloads"
 msgstr "Aktive nedlastingar"
 
@@ -3733,7 +3733,7 @@ msgstr "Aktive nedlastingar"
 msgid "Active connections (1:1)"
 msgstr "Aktive koplingar (1:1)"
 
-#: src/muuli_wdr.cpp:1040 src/muuli_wdr.cpp:1872
+#: src/muuli_wdr.cpp:1040 src/muuli_wdr.cpp:1876
 msgid "Active uploads"
 msgstr "Aktive opplastingar"
 
@@ -4010,7 +4010,7 @@ msgstr ""
 msgid "Advanced users only: If you have multiple network interfaces, enter the address of the interface to which aMule should be bound."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1462 src/muuli_wdr.cpp:2065
+#: src/muuli_wdr.cpp:1462 src/muuli_wdr.cpp:2069
 msgid "Bind to network interface (empty for any):"
 msgstr ""
 
@@ -4026,7 +4026,7 @@ msgstr ""
 msgid "Max simultaneous connections:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1498 src/muuli_wdr.cpp:3207
+#: src/muuli_wdr.cpp:1498 src/muuli_wdr.cpp:3211
 msgid "ED2K"
 msgstr "ED2k"
 
@@ -4118,781 +4118,781 @@ msgstr "Hent diskplass for nye filer"
 msgid "For new files preallocates disk space for the whole file, thus reduces fragmentation"
 msgstr "Hentar diskplass for heile nye filer, og reduserer fragmentering"
 
-#: src/muuli_wdr.cpp:1617
+#: src/muuli_wdr.cpp:1621
 msgid "Create new files as sparse files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1618
+#: src/muuli_wdr.cpp:1622
 msgid "Sparse part files only occupy disk space for the parts already downloaded, so free space is used up gradually as the file fills in. Turn this off to use an ordinary file instead - useful where sparse files are unsupported or slow, or where backup/de-duplication tools handle them badly. Applies only when the core runs on Windows; on Linux and macOS part files are sparse anyway and this setting has no effect."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1623
+#: src/muuli_wdr.cpp:1627
 msgid "Stop downloads when free disk space reaches "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1624
+#: src/muuli_wdr.cpp:1628
 msgid "Select this if you want aMule to check your disk space"
 msgstr "Vel denne dersom du vil at aMule skal sjekke om du har nok diskplass"
 
-#: src/muuli_wdr.cpp:1628
+#: src/muuli_wdr.cpp:1632
 msgid "Enter here the min disk space desired."
 msgstr "Skriv inn mimimum ønska diskplass."
 
-#: src/muuli_wdr.cpp:1634
+#: src/muuli_wdr.cpp:1638
 msgid "Save 10 sources on rare files (< 20 sources)"
 msgstr "Lagre 10 kjelder til sjeldne filer (< 20 kjelder)"
 
-#: src/muuli_wdr.cpp:1638 src/Statistics.cpp:790
+#: src/muuli_wdr.cpp:1642 src/Statistics.cpp:790
 msgid "Uploads"
 msgstr "Opplastingar"
 
-#: src/muuli_wdr.cpp:1641
+#: src/muuli_wdr.cpp:1645
 msgid "Add new shared files with auto priority"
 msgstr "Legg til nye delte filer med autoprioritet"
 
-#: src/muuli_wdr.cpp:1647
+#: src/muuli_wdr.cpp:1651
 msgid "Intelligent Corruption Handling (I.C.H.)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1650
+#: src/muuli_wdr.cpp:1654
 msgid "Enable"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1653
+#: src/muuli_wdr.cpp:1657
 msgid "Advanced I.C.H. trusts every hash (not recommended)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1665 src/PrefsUnifiedDlg.cpp:1990
+#: src/muuli_wdr.cpp:1669 src/PrefsUnifiedDlg.cpp:1999
 msgid "Media metadata extraction"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1669
+#: src/muuli_wdr.cpp:1673
 msgid "Extract length / bitrate / codec from shared audio and video files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1671
+#: src/muuli_wdr.cpp:1675
 msgid "When enabled, aMule runs ffprobe on each shared media file to fill in the Length / Bitrate / Codec columns other clients see when they find the file in a search. Requires ffmpeg (the ffprobe binary) to be installed."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1678
+#: src/muuli_wdr.cpp:1682
 msgid "Path to ffprobe:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1683
+#: src/muuli_wdr.cpp:1687
 msgid "Full path to the ffprobe binary. Leave empty to have aMule auto-detect it on startup."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1691
+#: src/muuli_wdr.cpp:1695
 msgid "Detect"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1692
+#: src/muuli_wdr.cpp:1696
 msgid "Search the standard install locations for an ffprobe binary and fill the path field."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1716
+#: src/muuli_wdr.cpp:1720
 msgid ""
 "Completed downloads are stored here. All files in this folder are automatically shared with other peers.\n"
 "If this folder also holds files you don't want to share, point it at an aMule-only sub-folder."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1719
+#: src/muuli_wdr.cpp:1723
 msgid "Pick the folder where completed downloads will be stored. All files in that folder will be shared with other peers."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1733
+#: src/muuli_wdr.cpp:1737
 msgid "Shared folders"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1739
+#: src/muuli_wdr.cpp:1743
 msgid "(Folders shared by the core. Enter a path to add one.)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1747
+#: src/muuli_wdr.cpp:1751
 msgid "Absolute path of a folder on the core's machine, e.g. /home/user/shared"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1749 src/PrefsUnifiedDlg.cpp:2874
+#: src/muuli_wdr.cpp:1753 src/PrefsUnifiedDlg.cpp:2883
 msgid "Recursive"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1750
+#: src/muuli_wdr.cpp:1754
 msgid "Share every sub-folder underneath this one, including ones created later."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1754 src/utils/aLinkCreator/src/alcframe.cpp:141
+#: src/muuli_wdr.cpp:1758 src/utils/aLinkCreator/src/alcframe.cpp:141
 msgid "Remove"
 msgstr "Ta bort"
 
-#: src/muuli_wdr.cpp:1758
+#: src/muuli_wdr.cpp:1762
 msgid "(Right click on folder icon for recursive share)"
 msgstr "(Høgreklikk på mappeikonet for å dele underkatalogar)"
 
-#: src/muuli_wdr.cpp:1765
+#: src/muuli_wdr.cpp:1769
 msgid "Share hidden files"
 msgstr "Dele gøymde filer"
 
-#: src/muuli_wdr.cpp:1771
+#: src/muuli_wdr.cpp:1775
 msgid "Automatically rescan shared folders for changes"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1777
+#: src/muuli_wdr.cpp:1781
 msgid "Follow symbolic links in shared folders"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1783
+#: src/muuli_wdr.cpp:1787
 msgid "Exclude files matching:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1786
+#: src/muuli_wdr.cpp:1790
 msgid "Wildcard patterns separated by '|', e.g. .DS_Store|Thumbs.db|*.tmp. Files whose name matches are not shared. Matching is case-insensitive."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1790
+#: src/muuli_wdr.cpp:1794
 msgid "Patterns are regular expressions"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1791
+#: src/muuli_wdr.cpp:1795
 msgid "When set, the whole field is one regular expression ('|' is alternation). When unset, it is a list of '|'-separated wildcards."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1801
+#: src/muuli_wdr.cpp:1805
 msgid "Show how many shared files the current pattern would exclude."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1822
+#: src/muuli_wdr.cpp:1826
 msgid "Graphs"
 msgstr "Grafar"
 
-#: src/muuli_wdr.cpp:1825 src/muuli_wdr.cpp:1887
+#: src/muuli_wdr.cpp:1829 src/muuli_wdr.cpp:1891
 msgid "Update delay : 5 secs"
 msgstr "Oppdateringsforseinking: 5 sek"
 
-#: src/muuli_wdr.cpp:1829
+#: src/muuli_wdr.cpp:1833
 msgid "Time for average graph: 100 mins"
 msgstr "Tid for gjennomsnittleg graf: 100 min"
 
-#: src/muuli_wdr.cpp:1833
+#: src/muuli_wdr.cpp:1837
 msgid "Connections Graph Scale: 100 "
 msgstr "Koplingsgrafskala: 100 "
 
-#: src/muuli_wdr.cpp:1840
+#: src/muuli_wdr.cpp:1844
 msgid "Download graph scale:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1848
+#: src/muuli_wdr.cpp:1852
 msgid "Upload graph scale:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1858
+#: src/muuli_wdr.cpp:1862
 msgid "Colors: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1862
+#: src/muuli_wdr.cpp:1866
 msgid "Background"
 msgstr "Bakgrunn"
 
-#: src/muuli_wdr.cpp:1863
+#: src/muuli_wdr.cpp:1867
 msgid "Grid"
 msgstr "Rutenett"
 
-#: src/muuli_wdr.cpp:1864
+#: src/muuli_wdr.cpp:1868
 msgid "Download current"
 msgstr "Last ned novérande"
 
-#: src/muuli_wdr.cpp:1865
+#: src/muuli_wdr.cpp:1869
 msgid "Download running average"
 msgstr "Last ned køyregjennomsnitt"
 
-#: src/muuli_wdr.cpp:1866
+#: src/muuli_wdr.cpp:1870
 msgid "Download session average"
 msgstr "Last ned øktgjennomsnitt"
 
-#: src/muuli_wdr.cpp:1867
+#: src/muuli_wdr.cpp:1871
 msgid "Upload current"
 msgstr "Opplasting no"
 
-#: src/muuli_wdr.cpp:1868
+#: src/muuli_wdr.cpp:1872
 msgid "Upload running average"
 msgstr "Gjennomsnittleg køyrande opplasting"
 
-#: src/muuli_wdr.cpp:1869
+#: src/muuli_wdr.cpp:1873
 msgid "Upload session average"
 msgstr "Gjennomsnittleg økt opplasting"
 
-#: src/muuli_wdr.cpp:1870
+#: src/muuli_wdr.cpp:1874
 msgid "Active connections"
 msgstr "Aktive koplingar"
 
-#: src/muuli_wdr.cpp:1873
+#: src/muuli_wdr.cpp:1877
 #, fuzzy
 msgid "Systray Icon Speed Bar"
 msgstr "Fartslinje i ikontrauet"
 
-#: src/muuli_wdr.cpp:1874
+#: src/muuli_wdr.cpp:1878
 msgid "Kad-nodes current"
 msgstr "Kadnodar no"
 
-#: src/muuli_wdr.cpp:1875
+#: src/muuli_wdr.cpp:1879
 msgid "Kad-nodes running"
 msgstr "Køyrande kadnodar"
 
-#: src/muuli_wdr.cpp:1876
+#: src/muuli_wdr.cpp:1880
 msgid "Kad-nodes session"
 msgstr "Kadnodar (økt)"
 
-#: src/muuli_wdr.cpp:1880 src/muuli_wdr.cpp:2334
+#: src/muuli_wdr.cpp:1884 src/muuli_wdr.cpp:2338
 msgid "Select"
 msgstr "Velje"
 
-#: src/muuli_wdr.cpp:1884
+#: src/muuli_wdr.cpp:1888
 msgid "Tree"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1894
+#: src/muuli_wdr.cpp:1898
 msgid "Number of Client Versions shown (0=unlimited)"
 msgstr "Tal på klienutgåver synt (0=uinnskrenka)"
 
-#: src/muuli_wdr.cpp:1919
+#: src/muuli_wdr.cpp:1923
 msgid "!!! WARNING !!!"
 msgstr "!!! ÅTVARING !!!"
 
-#: src/muuli_wdr.cpp:1934
+#: src/muuli_wdr.cpp:1938
 msgid "Max new connections / 5 secs"
 msgstr "Maks nye koplingar / 5 sek"
 
-#: src/muuli_wdr.cpp:1936
+#: src/muuli_wdr.cpp:1940
 msgid "Concurrent Kad source lookups"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1938
+#: src/muuli_wdr.cpp:1942
 #, fuzzy
 msgid "Kad source re-search interval (minutes)"
 msgstr "FTP oppdateringsintervall i minutt"
 
-#: src/muuli_wdr.cpp:1940
+#: src/muuli_wdr.cpp:1944
 #, fuzzy
 msgid "Source re-ask interval (minutes)"
 msgstr "FTP oppdateringsintervall i minutt"
 
-#: src/muuli_wdr.cpp:1944
+#: src/muuli_wdr.cpp:1948
 msgid "File Buffer Size: 240000 bytes"
 msgstr "Filbufferstorleik: 240000·bytes"
 
-#: src/muuli_wdr.cpp:1948
+#: src/muuli_wdr.cpp:1952
 msgid "Use MMAP: memory-mapped file access (lower memory use)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1949
+#: src/muuli_wdr.cpp:1953
 msgid "Maps part files into memory instead of buffering them on the heap, lowering the process memory footprint. May reduce download speed on some disks; best for memory-constrained or upload-heavy hosts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1951
+#: src/muuli_wdr.cpp:1955
 msgid "Upload Queue Size: 5000 clients"
 msgstr "Storleik på opplastingskø: 5000 klientar"
 
-#: src/muuli_wdr.cpp:1955
+#: src/muuli_wdr.cpp:1959
 msgid "Server connection refresh interval: Disable"
 msgstr "Oppfriskingsintervall for tenarkopling: Deaktiver"
 
-#: src/muuli_wdr.cpp:1959
+#: src/muuli_wdr.cpp:1963
 msgid "Disable computer's timed standby mode"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1978
+#: src/muuli_wdr.cpp:1982
 msgid "Skin to use: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1987
+#: src/muuli_wdr.cpp:1991
 msgid "Show \"Fast eD2k Links Handler\" in every window."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1990
+#: src/muuli_wdr.cpp:1994
 msgid "Show extended info on categories tabs"
 msgstr "Syne utvida informasjon i kategorifaneblad"
 
-#: src/muuli_wdr.cpp:1993
+#: src/muuli_wdr.cpp:1997
 #, fuzzy
 msgid "Show application version on title"
 msgstr "Syne overføringsfart i tittellinja"
 
-#: src/muuli_wdr.cpp:1995
+#: src/muuli_wdr.cpp:1999
 msgid "Show transfer rates on title"
 msgstr "Syne overføringsfart i tittellinja"
 
-#: src/muuli_wdr.cpp:1997
+#: src/muuli_wdr.cpp:2001
 msgid "Before application name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1999
+#: src/muuli_wdr.cpp:2003
 msgid "After application name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2002
+#: src/muuli_wdr.cpp:2006
 msgid "Show overhead bandwidth"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2006
+#: src/muuli_wdr.cpp:2010
 msgid "Vertical toolbar orientation"
 msgstr "Vertikal verktylinjeorientering"
 
-#: src/muuli_wdr.cpp:2008
+#: src/muuli_wdr.cpp:2012
 msgid "Live column sorting (auto-reorder rows as their values change)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2015
+#: src/muuli_wdr.cpp:2019
 msgid "Download Queue Files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2018
+#: src/muuli_wdr.cpp:2022
 msgid "Show progress percentage"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2024
+#: src/muuli_wdr.cpp:2028
 msgid "Show progress bar"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2027
+#: src/muuli_wdr.cpp:2031
 msgid "Flat"
 msgstr "Flat"
 
-#: src/muuli_wdr.cpp:2031
+#: src/muuli_wdr.cpp:2035
 msgid "Round"
 msgstr "Rund"
 
-#: src/muuli_wdr.cpp:2049
+#: src/muuli_wdr.cpp:2053
 msgid "External Connection Parameters"
 msgstr "Parameter for ekstern kopling"
 
-#: src/muuli_wdr.cpp:2052
+#: src/muuli_wdr.cpp:2056
 msgid "Accept external connections"
 msgstr "Akseptér eksterne koplingar"
 
-#: src/muuli_wdr.cpp:2059 src/muuli_wdr.cpp:2118
+#: src/muuli_wdr.cpp:2063 src/muuli_wdr.cpp:2122
 msgid "IP of the listening interface:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2062
+#: src/muuli_wdr.cpp:2066
 msgid "Enter here a valid ip in the a.b.c.d format for the listening EC interface. An empty field or 0.0.0.0 will mean any interface."
 msgstr "Skriv in ei gyldig IP i a.b.c.d format for det lyttande EC-grensesnittet. Eit tomt felt eller 0.0.0.0 betyr samtlege grensesnitt."
 
-#: src/muuli_wdr.cpp:2083 src/muuli_wdr.cpp:2194
+#: src/muuli_wdr.cpp:2087 src/muuli_wdr.cpp:2198
 msgid "TCP port:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2089
+#: src/muuli_wdr.cpp:2093
 msgid "Enable UPnP port forwarding on the EC port"
 msgstr "Aktivér UPnP-portvidaresending på EC-porten"
 
-#: src/muuli_wdr.cpp:2093 src/muuli_wdr.cpp:3079
+#: src/muuli_wdr.cpp:2097 src/muuli_wdr.cpp:3083
 #: src/utils/wxCas/src/wxcasprefs.cpp:167
 msgid "Password"
 msgstr "Passord"
 
-#: src/muuli_wdr.cpp:2099
+#: src/muuli_wdr.cpp:2103
 #, fuzzy
 msgid "aMule API server parameters"
 msgstr "Vevtenarparameter"
 
-#: src/muuli_wdr.cpp:2102
+#: src/muuli_wdr.cpp:2106
 msgid "Run amuleapi (REST API) on startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2107
+#: src/muuli_wdr.cpp:2111
 #, fuzzy
 msgid "HTTP port:"
 msgstr "TCP port: %d"
 
-#: src/muuli_wdr.cpp:2121
+#: src/muuli_wdr.cpp:2125
 msgid "The interface amuleapi's HTTP server listens on. 127.0.0.1 (default) accepts only local connections; use 0.0.0.0 or a specific IP to expose it to other hosts (set an admin password below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2126
+#: src/muuli_wdr.cpp:2130
 msgid "Type a password to set or change it. Stored passwords cannot be shown, so leaving this empty keeps the current one."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2128
+#: src/muuli_wdr.cpp:2132
 #, fuzzy
 msgid "Admin password"
 msgstr "Sjekkar passord\n"
 
-#: src/muuli_wdr.cpp:2140 src/muuli_wdr.cpp:2157 src/PrefsUnifiedDlg.cpp:1103
+#: src/muuli_wdr.cpp:2144 src/muuli_wdr.cpp:2161 src/PrefsUnifiedDlg.cpp:1112
 #, fuzzy
 msgid "A password is set."
 msgstr "Sjekkar passord\n"
 
-#: src/muuli_wdr.cpp:2144
+#: src/muuli_wdr.cpp:2148
 #, fuzzy
 msgid "Enable guest access"
 msgstr "Nekt gjestetilgang"
 
-#: src/muuli_wdr.cpp:2145
+#: src/muuli_wdr.cpp:2149
 msgid "Guest sessions may read status and listings but cannot change anything. Turning this off clears the stored guest password."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2149
+#: src/muuli_wdr.cpp:2153
 #, fuzzy
 msgid "Guest password"
 msgstr "Gjestepassord for vevtenar"
 
-#: src/muuli_wdr.cpp:2164
+#: src/muuli_wdr.cpp:2168
 msgid "Web server parameters"
 msgstr "Vevtenarparameter"
 
-#: src/muuli_wdr.cpp:2167
+#: src/muuli_wdr.cpp:2171
 msgid "Run webserver on startup (deprecated)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2173
+#: src/muuli_wdr.cpp:2177
 msgid "Web template"
 msgstr "Vevmønster"
 
-#: src/muuli_wdr.cpp:2178
+#: src/muuli_wdr.cpp:2182
 msgid "Full rights password"
 msgstr "Passord for fulle rettar"
 
-#: src/muuli_wdr.cpp:2182
+#: src/muuli_wdr.cpp:2186
 msgid "Enable Low rights User"
 msgstr "Aktivér brukar med få rettar"
 
-#: src/muuli_wdr.cpp:2187
+#: src/muuli_wdr.cpp:2191
 msgid "Low rights password"
 msgstr "Passord for låge rettar"
 
-#: src/muuli_wdr.cpp:2201
+#: src/muuli_wdr.cpp:2205
 msgid "Enable UPnP port forwarding of the web server port"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2206
+#: src/muuli_wdr.cpp:2210
 msgid "Web server UPnP TCP port (Optional)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2214
+#: src/muuli_wdr.cpp:2218
 msgid "Page Refresh Time (in secs)"
 msgstr "Sideoppfriskingstid (i sekund)"
 
-#: src/muuli_wdr.cpp:2221
+#: src/muuli_wdr.cpp:2225
 msgid "Enable Gzip compression"
 msgstr "Aktivér Gzipkompresjon"
 
-#: src/muuli_wdr.cpp:2255
+#: src/muuli_wdr.cpp:2259
 #, fuzzy
 msgid "Reset page to defaults"
 msgstr "Standardinnstillingar"
 
-#: src/muuli_wdr.cpp:2256
+#: src/muuli_wdr.cpp:2260
 msgid "Reset the settings on the current page to their default values."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2258 src/muuli_wdr.cpp:2344 src/ServerWnd.cpp:274
+#: src/muuli_wdr.cpp:2262 src/muuli_wdr.cpp:2348 src/ServerWnd.cpp:274
 #: src/ServerWnd.cpp:282
 msgid "OK"
 msgstr "OK"
 
-#: src/muuli_wdr.cpp:2260
+#: src/muuli_wdr.cpp:2264
 msgid "Click here to apply any changes made to the preferences."
 msgstr "Klikk her for å utføre samtlege endringar gjorde i innstillingar."
 
-#: src/muuli_wdr.cpp:2263
+#: src/muuli_wdr.cpp:2267
 msgid "Reset any changes made to the preferences."
 msgstr "Nullstill alle endringar i innstillingar."
 
-#: src/muuli_wdr.cpp:2292
+#: src/muuli_wdr.cpp:2296
 msgid "Comment :"
 msgstr "Kommentar :"
 
-#: src/muuli_wdr.cpp:2299
+#: src/muuli_wdr.cpp:2303
 msgid "Incoming Dir :"
 msgstr "Innkomande kat:"
 
-#: src/muuli_wdr.cpp:2308
+#: src/muuli_wdr.cpp:2312
 msgid "Change priority for new assigned files :"
 msgstr "Endre prioritet for nytileigna filer :"
 
-#: src/muuli_wdr.cpp:2312
+#: src/muuli_wdr.cpp:2316
 #, fuzzy
 msgid "Don't change"
 msgstr "Ikkje endre"
 
-#: src/muuli_wdr.cpp:2324
+#: src/muuli_wdr.cpp:2328
 msgid "Select color for this Category (currently selected) :"
 msgstr "Vel farge for denne kategprien (no valt)"
 
-#: src/muuli_wdr.cpp:2391 src/muuli_wdr.cpp:2410 src/muuli_wdr.cpp:2432
+#: src/muuli_wdr.cpp:2395 src/muuli_wdr.cpp:2414 src/muuli_wdr.cpp:2436
 msgid "Click this button to reset the log."
 msgstr "Klikk denne knappen for å nullstille loggen."
 
-#: src/muuli_wdr.cpp:2451
+#: src/muuli_wdr.cpp:2455
 msgid "Click on this button to update the servers list from URL ..."
 msgstr "Klikk på denne knappen for å oppdatere tenarlista frå nettadresse ..."
 
-#: src/muuli_wdr.cpp:2455
+#: src/muuli_wdr.cpp:2459
 msgid "Server list"
 msgstr "Tenarliste"
 
-#: src/muuli_wdr.cpp:2459
+#: src/muuli_wdr.cpp:2463
 msgid "Enter the url to a server.met file here and press the button to the left to update the list of known servers."
 msgstr "Skriv inn nettadressa til ei server.met fil her og klikk på knappen til venstre for å oppdatere tenarlista."
 
-#: src/muuli_wdr.cpp:2464
+#: src/muuli_wdr.cpp:2468
 msgid "Add server manually: Name"
 msgstr "Legg til tenar manuelt: Namn"
 
-#: src/muuli_wdr.cpp:2467
+#: src/muuli_wdr.cpp:2471
 msgid "Enter the name of the new server here"
 msgstr "Skriv inn namnet på den nye tenaren her"
 
-#: src/muuli_wdr.cpp:2469 src/ServerWnd.cpp:206
+#: src/muuli_wdr.cpp:2473 src/ServerWnd.cpp:206
 msgid "IP:Port"
 msgstr "IP:Port"
 
-#: src/muuli_wdr.cpp:2472
+#: src/muuli_wdr.cpp:2476
 msgid "Enter the IP of the server here, using the x.x.x.x format."
 msgstr "Skriv inn IP`en til tenaren her, i x.x.x.x format."
 
-#: src/muuli_wdr.cpp:2478
+#: src/muuli_wdr.cpp:2482
 msgid "Enter the port of the server here."
 msgstr "Skriv inn porten til tenaren her."
 
-#: src/muuli_wdr.cpp:2481
+#: src/muuli_wdr.cpp:2485
 msgid "Add manually a server (fill fields to the left before) ..."
 msgstr "Legg til ein tenar manuelt (fyll først ut felta til venstre) ..."
 
-#: src/muuli_wdr.cpp:2510
+#: src/muuli_wdr.cpp:2514
 msgid "aMule Log"
 msgstr "aMulelogg"
 
-#: src/muuli_wdr.cpp:2518
+#: src/muuli_wdr.cpp:2522
 msgid "Server Info"
 msgstr "Tenarinfo"
 
-#: src/muuli_wdr.cpp:2522
+#: src/muuli_wdr.cpp:2526
 msgid "ED2K Info"
 msgstr "ED2k-info"
 
-#: src/muuli_wdr.cpp:2526
+#: src/muuli_wdr.cpp:2530
 msgid "Kad Info"
 msgstr "Kad-info"
 
-#: src/muuli_wdr.cpp:2554
+#: src/muuli_wdr.cpp:2558
 msgid "Click on this button to update the nodes list from URL ..."
 msgstr "Klikk på denne knappen for å oppdatere nodelista frå internettadresse ..."
 
-#: src/muuli_wdr.cpp:2558
+#: src/muuli_wdr.cpp:2562
 msgid "Nodes (0)"
 msgstr "Nodar (0)"
 
-#: src/muuli_wdr.cpp:2562
+#: src/muuli_wdr.cpp:2566
 msgid "Enter the url to a nodes.dat file here and press the button to the left to update the list of known nodes."
 msgstr "Skriv inn internettadressa til ei nodes-dat fil her og klikk på knappen til venstre for å oppdatere lista over kjende nodar."
 
-#: src/muuli_wdr.cpp:2565
+#: src/muuli_wdr.cpp:2569
 msgid "Nodes stats"
 msgstr "Nodestatistikk"
 
-#: src/muuli_wdr.cpp:2607
+#: src/muuli_wdr.cpp:2611
 msgid "Bootstrap"
 msgstr "Eigenoppstart"
 
-#: src/muuli_wdr.cpp:2610
+#: src/muuli_wdr.cpp:2614
 msgid "New node"
 msgstr "Ny node"
 
-#: src/muuli_wdr.cpp:2615
+#: src/muuli_wdr.cpp:2619
 msgid "IP:"
 msgstr "IP:"
 
-#: src/muuli_wdr.cpp:2635
+#: src/muuli_wdr.cpp:2639
 msgid "Port:"
 msgstr "Port:"
 
-#: src/muuli_wdr.cpp:2648
+#: src/muuli_wdr.cpp:2652
 #, fuzzy
 msgid "Bootstrap from known clients"
 msgstr ""
 "Eigenoppstart frå \n"
 "kjende klientar"
 
-#: src/muuli_wdr.cpp:2650
+#: src/muuli_wdr.cpp:2654
 msgid "Disconnect Kad"
 msgstr "Kople frå Kad"
 
-#: src/muuli_wdr.cpp:2684
+#: src/muuli_wdr.cpp:2688
 msgid "Use Secure User Identification"
 msgstr "Sikker brukaridentifikasjon (SUI)"
 
-#: src/muuli_wdr.cpp:2686
+#: src/muuli_wdr.cpp:2690
 msgid "It is recommended to enable this option. You will not receive credits if SUI is not enabled."
 msgstr "Det er tilrådd å aktivere denne funksjonen. Du vil ikkje få kredittar dersom SUI ikkje er aktivert."
 
-#: src/muuli_wdr.cpp:2688
+#: src/muuli_wdr.cpp:2692
 msgid "Protocol Obfuscation"
 msgstr "Protokolltåkeleggjing"
 
-#: src/muuli_wdr.cpp:2691
+#: src/muuli_wdr.cpp:2695
 msgid "Support Protocol Obfuscation"
 msgstr "Støtte protokolltåkeleggjing"
 
-#: src/muuli_wdr.cpp:2693
+#: src/muuli_wdr.cpp:2697
 msgid "This option enabled Protocol Obfuscation, and makes aMule accept obfuscated connections from other clients."
 msgstr "Dette valet aktiverer protokolltåkeleggjing og gjer at aMule tek imot tåkelagde koplingar frå andre klientar."
 
-#: src/muuli_wdr.cpp:2695
+#: src/muuli_wdr.cpp:2699
 msgid "Use obfuscation for outgoing connections"
 msgstr "Bruk tåkeleggjing for utgåande koplingar"
 
-#: src/muuli_wdr.cpp:2697
+#: src/muuli_wdr.cpp:2701
 msgid "This option makes aMule use Protocol Obfuscation when connecting other clients/servers."
 msgstr "Dette valet får aMule til å nytte protokolltåkeleggjing ved tilkopling til andreklientar/tenarar."
 
-#: src/muuli_wdr.cpp:2699
+#: src/muuli_wdr.cpp:2703
 msgid "Accept only obfuscated connections"
 msgstr "Berre godta tåkelagde koplingar"
 
-#: src/muuli_wdr.cpp:2700
+#: src/muuli_wdr.cpp:2704
 msgid "This option makes aMule only accept obfuscated connections. You will have less sources, but all your traffic will be obfuscated"
 msgstr "Dette valet får aMule til å berre godta tåkelagde koplingar. Du vil få færre kjelder, men all trafikken din vert tåkelagd"
 
-#: src/muuli_wdr.cpp:2705
+#: src/muuli_wdr.cpp:2709
 msgid "Everybody"
 msgstr "Alle"
 
-#: src/muuli_wdr.cpp:2707
+#: src/muuli_wdr.cpp:2711
 msgid "No one"
 msgstr "Ingen"
 
-#: src/muuli_wdr.cpp:2709
+#: src/muuli_wdr.cpp:2713
 msgid "Who can see my shared files:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2710
+#: src/muuli_wdr.cpp:2714
 msgid "Select who can request to view a list of your shared files."
 msgstr "Vel kven som kan be om å sjå ei liste over dei delte filene dine."
 
-#: src/muuli_wdr.cpp:2712
+#: src/muuli_wdr.cpp:2716
 msgid "IP-Filtering"
 msgstr "IP-filtrering"
 
-#: src/muuli_wdr.cpp:2719
+#: src/muuli_wdr.cpp:2723
 msgid "Filter clients"
 msgstr "Filtrér klientar"
 
-#: src/muuli_wdr.cpp:2721
+#: src/muuli_wdr.cpp:2725
 msgid "Enable filtering of the client IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "Aktivér IP-filterring av klientar i fila ~/.aMule/ipfilter.dat."
 
-#: src/muuli_wdr.cpp:2723
+#: src/muuli_wdr.cpp:2727
 msgid "Filter servers"
 msgstr "Filtrér tenarar"
 
-#: src/muuli_wdr.cpp:2725
+#: src/muuli_wdr.cpp:2729
 msgid "Enable filtering of the server IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "Aktivér filtrering av tenarar i fila ~/.aMule/ipfilter.dat."
 
-#: src/muuli_wdr.cpp:2729
+#: src/muuli_wdr.cpp:2733
 msgid "Reload List"
 msgstr "Last om att lista"
 
-#: src/muuli_wdr.cpp:2730
+#: src/muuli_wdr.cpp:2734
 msgid "Reload the list of IPs to filter from the file ~/.aMule/ipfilter.dat"
 msgstr "Last om att lista av IP`ar å filtre frå fila ~/.aMule/ipfilter.dat"
 
-#: src/muuli_wdr.cpp:2736
+#: src/muuli_wdr.cpp:2740
 msgid "URL:"
 msgstr "Nettadresse:"
 
-#: src/muuli_wdr.cpp:2740 src/muuli_wdr.cpp:2933
+#: src/muuli_wdr.cpp:2744 src/muuli_wdr.cpp:2937
 msgid "Update now"
 msgstr "Oppdatér no"
 
-#: src/muuli_wdr.cpp:2743
+#: src/muuli_wdr.cpp:2747
 msgid "Auto-update ipfilter at startup"
 msgstr "Automatisk oppdatér ipfilter ved oppstart"
 
-#: src/muuli_wdr.cpp:2747
+#: src/muuli_wdr.cpp:2751
 msgid "Filtering Level:"
 msgstr "Filternivå:"
 
-#: src/muuli_wdr.cpp:2753
+#: src/muuli_wdr.cpp:2757
 msgid "Always filter LAN IPs"
 msgstr "Alltid filtrér LAN IP`ar"
 
-#: src/muuli_wdr.cpp:2756
+#: src/muuli_wdr.cpp:2760
 msgid "Paranoid handling of non-matching IPs"
 msgstr "Paranoid handsaming av ujamne IP`ar"
 
-#: src/muuli_wdr.cpp:2758
+#: src/muuli_wdr.cpp:2762
 msgid "Rejects a packet when its source IP differs from the IP the client claims (an anti-spoofing check). Disable only if it causes connection problems."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2760
+#: src/muuli_wdr.cpp:2764
 msgid "Use system-wide ipfilter.dat if available"
 msgstr "Bruk systemomspennande ipfilter.dat dersom tilgjengeleg"
 
-#: src/muuli_wdr.cpp:2761
+#: src/muuli_wdr.cpp:2765
 #, fuzzy
 msgid "If there's no local ipfilter.dat found, allow usage of a system-wide ipfilter file."
 msgstr "Tillat bruk av ipfilter for heile systemet dersom inga lokal ipfilter-dat vert funnen"
 
-#: src/muuli_wdr.cpp:2778
+#: src/muuli_wdr.cpp:2782
 msgid "Enable Online-Signature"
 msgstr "Aktivér nettsignatur"
 
-#: src/muuli_wdr.cpp:2780
+#: src/muuli_wdr.cpp:2784
 msgid "Enables the writing of the OS file, which can be used by external apps to create signatures and the like."
 msgstr "Aktiverer skriving av OS-fila, som kan verte nytta av eksterne program forå lage signaturar og liknande."
 
-#: src/muuli_wdr.cpp:2784
+#: src/muuli_wdr.cpp:2788
 msgid "Update Frequency (Secs):"
 msgstr "Oppdateringsfrekvens (sekund):"
 
-#: src/muuli_wdr.cpp:2787
+#: src/muuli_wdr.cpp:2791
 msgid "Change the frequency (in seconds) of Online Signature updates."
 msgstr "Endre frekvensen (i sekund) for oppdatering av nettsignaturar."
 
-#: src/muuli_wdr.cpp:2795
+#: src/muuli_wdr.cpp:2799
 msgid "Save online signature file in: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:2801
+#: src/muuli_wdr.cpp:2805
 msgid "Click here to select the directory containing the the Online Signature files."
 msgstr "Klikk her for å velje katalogen med nettsignaturfilene."
 
-#: src/muuli_wdr.cpp:2834
+#: src/muuli_wdr.cpp:2838
 msgid "Show country flags for clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2835
+#: src/muuli_wdr.cpp:2839
 msgid "Render the country flag column in the transfers, queue and search views. Requires a valid MMDB GeoIP database (see below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2840
+#: src/muuli_wdr.cpp:2844
 #, fuzzy
 msgid "Database"
 msgstr "Datasnøggleik :"
 
-#: src/muuli_wdr.cpp:2856
+#: src/muuli_wdr.cpp:2860
 #, fuzzy
 msgid "Source:"
 msgstr "Kjelder"
 
-#: src/muuli_wdr.cpp:2859
+#: src/muuli_wdr.cpp:2863
 msgid "DB-IP (free, no account)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2860
+#: src/muuli_wdr.cpp:2864
 msgid "MaxMind GeoLite2 (free, account required)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2861
+#: src/muuli_wdr.cpp:2865
 msgid "Custom URL"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2864
+#: src/muuli_wdr.cpp:2868
 msgid "Choose which provider supplies the GeoIP MMDB database. DB-IP is the default - no account required. MaxMind requires a free account + license key. Use Custom URL to point at any other MMDB host (e.g. a local mirror)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2881
+#: src/muuli_wdr.cpp:2885
 msgid ""
 "No configuration required.\n"
 "\n"
@@ -4900,11 +4900,11 @@ msgid ""
 "License: Creative Commons BY 4.0 - https://creativecommons.org/licenses/by/4.0/"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2894
+#: src/muuli_wdr.cpp:2898
 msgid "License key:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2900
+#: src/muuli_wdr.cpp:2904
 msgid ""
 "Sign up for a free MaxMind account, then generate a License Key:\n"
 "https://www.maxmind.com/en/geolite2/signup\n"
@@ -4914,232 +4914,232 @@ msgid ""
 "Requires attribution and account registration; refresh at least every 30 days."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2915
+#: src/muuli_wdr.cpp:2919
 #, fuzzy
 msgid "Download URL:"
 msgstr "Nedlasting: "
 
-#: src/muuli_wdr.cpp:2921
+#: src/muuli_wdr.cpp:2925
 msgid ""
 "Must point to an .mmdb file or a .gz / .tar.gz containing one.\n"
 "URL may include credentials (https://user:pass@host/...).\n"
 "License and attribution terms are set by the upstream URL - you are responsible."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2934
+#: src/muuli_wdr.cpp:2938
 msgid "Download the GeoIP database from the selected source."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2936
+#: src/muuli_wdr.cpp:2940
 #, fuzzy
 msgid "Auto-update on startup"
 msgstr "Automatisk oppdatér ipfilter ved oppstart"
 
-#: src/muuli_wdr.cpp:2937
+#: src/muuli_wdr.cpp:2941
 msgid "Re-download the GeoIP database from the selected source every time aMule starts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2960
+#: src/muuli_wdr.cpp:2964
 msgid "Filter incoming messages (except current chat):"
 msgstr "Filtrér innkomande meldingar (utanom novérande samtale):"
 
-#: src/muuli_wdr.cpp:2962
+#: src/muuli_wdr.cpp:2966
 msgid "Filter all messages"
 msgstr "Filtrér alle meldingar"
 
-#: src/muuli_wdr.cpp:2964
+#: src/muuli_wdr.cpp:2968
 msgid "Filter messages from people not on your friend list"
 msgstr "Filtrér meldingar frå alle som ikkje er på kameratlista"
 
-#: src/muuli_wdr.cpp:2966
+#: src/muuli_wdr.cpp:2970
 msgid "Filter messages from unknown clients"
 msgstr "Filtrér meldingar frå ukjende klientar"
 
-#: src/muuli_wdr.cpp:2968
+#: src/muuli_wdr.cpp:2972
 msgid "Filter messages containing (use ',' as separator):"
 msgstr "Filtrér meldingar som inneheld (bruk ','som skiljeteikn):"
 
-#: src/muuli_wdr.cpp:2971 src/muuli_wdr.cpp:2982
+#: src/muuli_wdr.cpp:2975 src/muuli_wdr.cpp:2986
 msgid "add here the words amule should filter and block messages including it"
 msgstr "legg til ord aMule skal filtrére og blokkere"
 
-#: src/muuli_wdr.cpp:2973
+#: src/muuli_wdr.cpp:2977
 msgid "Show received messages in the log"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2976
+#: src/muuli_wdr.cpp:2980
 msgid "Comments"
 msgstr "Kommentarar"
 
-#: src/muuli_wdr.cpp:2979
+#: src/muuli_wdr.cpp:2983
 msgid "Filter comments containing (use ',' as separator):"
 msgstr "Filtrér kommentarar som inneheld (bruk ',' som skiljeteikn):"
 
-#: src/muuli_wdr.cpp:3004
+#: src/muuli_wdr.cpp:3008
 msgid "Enable Proxy"
 msgstr "Aktivér vikar"
 
-#: src/muuli_wdr.cpp:3005
+#: src/muuli_wdr.cpp:3009
 msgid "Enable/disable proxy support"
 msgstr "Aktivere/deaktivere vikarstøtte"
 
-#: src/muuli_wdr.cpp:3008
+#: src/muuli_wdr.cpp:3012
 msgid "Proxy type:"
 msgstr "Vikartype:"
 
-#: src/muuli_wdr.cpp:3019
+#: src/muuli_wdr.cpp:3023
 msgid "Proxy host:"
 msgstr "Vikarvert:"
 
-#: src/muuli_wdr.cpp:3022
+#: src/muuli_wdr.cpp:3026
 msgid "The proxy host name"
 msgstr "Vikaren sitt vertsnamn"
 
-#: src/muuli_wdr.cpp:3024
+#: src/muuli_wdr.cpp:3028
 msgid "Proxy port:"
 msgstr "Vikarport:"
 
-#: src/muuli_wdr.cpp:3027
+#: src/muuli_wdr.cpp:3031
 msgid "The proxy port"
 msgstr "Vikarport"
 
-#: src/muuli_wdr.cpp:3029
+#: src/muuli_wdr.cpp:3033
 msgid "Enable authentication"
 msgstr "Aktivér godkjenning"
 
-#: src/muuli_wdr.cpp:3030
+#: src/muuli_wdr.cpp:3034
 msgid "Enable/disable username/password authentication"
 msgstr "Aktivér/deaktivér godkjenning av brukarnamn/passord"
 
-#: src/muuli_wdr.cpp:3033
+#: src/muuli_wdr.cpp:3037
 msgid "Username: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:3036
+#: src/muuli_wdr.cpp:3040
 msgid "The username to use to connect to the proxy"
 msgstr "Brukarnamn å nytte for å kople til vikar"
 
-#: src/muuli_wdr.cpp:3038
+#: src/muuli_wdr.cpp:3042
 msgid "Password:"
 msgstr "Passord:"
 
-#: src/muuli_wdr.cpp:3041
+#: src/muuli_wdr.cpp:3045
 msgid "The password to use to connect to the proxy"
 msgstr "Passord å nytte for å kople til vikar"
 
-#: src/muuli_wdr.cpp:3060
+#: src/muuli_wdr.cpp:3064
 msgid "Connect to:"
 msgstr "Kople til:"
 
-#: src/muuli_wdr.cpp:3069
+#: src/muuli_wdr.cpp:3073
 msgid "Login to remote amule"
 msgstr "Logge inn på fjern aMule"
 
-#: src/muuli_wdr.cpp:3074
+#: src/muuli_wdr.cpp:3078
 msgid "User name"
 msgstr "Brukarnamn"
 
-#: src/muuli_wdr.cpp:3085
+#: src/muuli_wdr.cpp:3089
 msgid "Remember those settings"
 msgstr "Hugs desse innstillingane"
 
-#: src/muuli_wdr.cpp:3088
+#: src/muuli_wdr.cpp:3092
 #, fuzzy
 msgid "Force ZLIB compression"
 msgstr "Nytt gzipkomprimering"
 
-#: src/muuli_wdr.cpp:3112
+#: src/muuli_wdr.cpp:3116
 msgid "Enable Verbose Debug-Logging."
 msgstr "Aktivér utførleg avfeilingslogg."
 
-#: src/muuli_wdr.cpp:3114
+#: src/muuli_wdr.cpp:3118
 #, fuzzy
 msgid "Only to Logfile"
 msgstr "&Opne fila"
 
-#: src/muuli_wdr.cpp:3116
+#: src/muuli_wdr.cpp:3120
 msgid "Message Categories:"
 msgstr "Meldingskategoriar:"
 
-#: src/muuli_wdr.cpp:3140 src/PartFileConvertDlg.cpp:160
+#: src/muuli_wdr.cpp:3144 src/PartFileConvertDlg.cpp:160
 msgid "Waiting..."
 msgstr "Ventar..."
 
-#: src/muuli_wdr.cpp:3160
+#: src/muuli_wdr.cpp:3164
 msgid "Add imports"
 msgstr "Importér"
 
-#: src/muuli_wdr.cpp:3163
+#: src/muuli_wdr.cpp:3167
 msgid "Retry selected"
 msgstr "Prøv om att valde"
 
-#: src/muuli_wdr.cpp:3165
+#: src/muuli_wdr.cpp:3169
 msgid "Remove selected"
 msgstr "Fjern valde"
 
-#: src/muuli_wdr.cpp:3228
+#: src/muuli_wdr.cpp:3232
 msgid "Event Types"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3247
+#: src/muuli_wdr.cpp:3251
 msgid "Statistics and queued clients for selected file(s) : Session / All time"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3271
+#: src/muuli_wdr.cpp:3275
 #, fuzzy
 msgid "Active Uploads"
 msgstr "Aktive opplastingar :"
 
-#: src/muuli_wdr.cpp:3285
+#: src/muuli_wdr.cpp:3289
 msgid "Percent of total files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3337
+#: src/muuli_wdr.cpp:3341
 #, fuzzy
 msgid "Show Clients for"
 msgstr "Syne klientar"
 
-#: src/muuli_wdr.cpp:3339
+#: src/muuli_wdr.cpp:3343
 #, fuzzy
 msgid "All files"
 msgstr "Gøyme delte filer"
 
-#: src/muuli_wdr.cpp:3342
+#: src/muuli_wdr.cpp:3346
 #, fuzzy
 msgid "Selected files"
 msgstr "Vel synsfilter"
 
-#: src/muuli_wdr.cpp:3345
+#: src/muuli_wdr.cpp:3349
 #, fuzzy
 msgid "Active uploads only"
 msgstr "Aktive opplastingar"
 
-#: src/muuli_wdr.cpp:3352
+#: src/muuli_wdr.cpp:3356
 #, fuzzy
 msgid "Reload:"
 msgstr "Last om att lista"
 
-#: src/muuli_wdr.cpp:3356
+#: src/muuli_wdr.cpp:3360
 msgid "Reload your shared files"
 msgstr "Lastar inn att delte filer"
 
-#: src/muuli_wdr.cpp:3419
+#: src/muuli_wdr.cpp:3423
 msgid "Send"
 msgstr "Send"
 
-#: src/muuli_wdr.cpp:3420
+#: src/muuli_wdr.cpp:3424
 msgid "Sends the specified message."
 msgstr "Sender meldinga."
 
-#: src/muuli_wdr.cpp:3424
+#: src/muuli_wdr.cpp:3428
 msgid "Close this chat-session."
 msgstr "Stengje denne lynmeldingsøkta."
 
-#: src/muuli_wdr.cpp:3447
+#: src/muuli_wdr.cpp:3451
 msgid "Connect to any server and/or Kad"
 msgstr "Kople til vilkårleg tenar og/eller Kad"
 
-#: src/muuli_wdr.cpp:3453 src/SharedFilesCtrl.cpp:142 src/Statistics.cpp:941
+#: src/muuli_wdr.cpp:3457 src/SharedFilesCtrl.cpp:142 src/Statistics.cpp:941
 msgid "Shared Files"
 msgstr "Delte filer"
 
@@ -5777,35 +5777,35 @@ msgstr ""
 "aMule køyrer fint utan justering av nokon av\n"
 "desse innstillingane."
 
-#: src/PrefsUnifiedDlg.cpp:647
+#: src/PrefsUnifiedDlg.cpp:656
 #, c-format
 msgid "Failed to connect Cfg to widget with the ID %d and key %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:695
+#: src/PrefsUnifiedDlg.cpp:704
 #, c-format
 msgid "Failed to transfer data from Cfg to Widget with the ID %d and key %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:801
+#: src/PrefsUnifiedDlg.cpp:810
 msgid "The type of proxy you are connecting to"
 msgstr "Typen vikar du koplar til"
 
-#: src/PrefsUnifiedDlg.cpp:1020
+#: src/PrefsUnifiedDlg.cpp:1029
 #, c-format
 msgid "Failed to transfer data from Widget to Cfg with the ID %d and key %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1103
+#: src/PrefsUnifiedDlg.cpp:1112
 #, fuzzy
 msgid "No password set."
 msgstr "Sjekkar passord\n"
 
-#: src/PrefsUnifiedDlg.cpp:1132
+#: src/PrefsUnifiedDlg.cpp:1141
 msgid "Guest access needs a password. Type one in the guest password field, or untick Enable guest access."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1144
+#: src/PrefsUnifiedDlg.cpp:1153
 msgid ""
 "aMule must be restarted to enable these changes:\n"
 "\n"
@@ -5813,51 +5813,51 @@ msgstr ""
 "aMule·treng omstart for å gjere endringane moglege:\n"
 "\n"
 
-#: src/PrefsUnifiedDlg.cpp:1151
+#: src/PrefsUnifiedDlg.cpp:1160
 msgid "- TCP port changed.\n"
 msgstr "-·TCP-porten endra.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1156
+#: src/PrefsUnifiedDlg.cpp:1165
 msgid "- UDP port changed.\n"
 msgstr "-·UDP-porten endra.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1161
+#: src/PrefsUnifiedDlg.cpp:1170
 #, fuzzy
 msgid "- Network interface binding changed.\n"
 msgstr "Ekstern kopling lukka."
 
-#: src/PrefsUnifiedDlg.cpp:1166
+#: src/PrefsUnifiedDlg.cpp:1175
 #, fuzzy
 msgid "- External connect port changed.\n"
 msgstr "Ekstern kopling lukka."
 
-#: src/PrefsUnifiedDlg.cpp:1170
+#: src/PrefsUnifiedDlg.cpp:1179
 #, fuzzy
 msgid "- External connect acceptance changed.\n"
 msgstr "Ny ekstern kopling akseptert"
 
-#: src/PrefsUnifiedDlg.cpp:1174
+#: src/PrefsUnifiedDlg.cpp:1183
 #, fuzzy
 msgid "- External connect interface changed.\n"
 msgstr "Ekstern kopling lukka."
 
-#: src/PrefsUnifiedDlg.cpp:1178
+#: src/PrefsUnifiedDlg.cpp:1187
 #, fuzzy
 msgid "- Protocol obfuscation support changed.\n"
 msgstr "Protokolltåkeleggjing"
 
-#: src/PrefsUnifiedDlg.cpp:1193
+#: src/PrefsUnifiedDlg.cpp:1202
 #, fuzzy
 msgid "- amuleapi settings changed.\n"
 msgstr "- Språk endra.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1202
+#: src/PrefsUnifiedDlg.cpp:1211
 msgid ""
 "Your Auto-update server list is empty.\n"
 "'Auto-update server list at startup' will be disabled."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1213
+#: src/PrefsUnifiedDlg.cpp:1222
 msgid ""
 "You have enabled external connections but have not specified a password.\n"
 "External connections cannot be enabled unless a valid password is specified."
@@ -5865,34 +5865,34 @@ msgstr ""
 "Du har aktivert eksterne koplingar, men har ikkje skrive inn eit passord.\n"
 "Eksterne koplingar kan ikkje aktiverast utan eit gyldig passord."
 
-#: src/PrefsUnifiedDlg.cpp:1246
+#: src/PrefsUnifiedDlg.cpp:1255
 #, c-format
 msgid "The amuleapi password could not be saved: %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1276
+#: src/PrefsUnifiedDlg.cpp:1285
 msgid "- Language changed.\n"
 msgstr "- Språk endra.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1281
+#: src/PrefsUnifiedDlg.cpp:1290
 msgid "- Temp folder changed.\n"
 msgstr "- Mellombels mappe endra.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1286
+#: src/PrefsUnifiedDlg.cpp:1295
 #, fuzzy
 msgid "- ED2K network enabled.\n"
 msgstr "Alle nettverk er deaktiverte."
 
-#: src/PrefsUnifiedDlg.cpp:1319
+#: src/PrefsUnifiedDlg.cpp:1328
 msgid "The shared-file exclusion pattern is not a valid regular expression. The filter has been left disabled."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1321 src/PrefsUnifiedDlg.cpp:1921
+#: src/PrefsUnifiedDlg.cpp:1330 src/PrefsUnifiedDlg.cpp:1930
 #, fuzzy
 msgid "Invalid regular expression"
 msgstr "Ugyldig protokullutgåve."
 
-#: src/PrefsUnifiedDlg.cpp:1398
+#: src/PrefsUnifiedDlg.cpp:1407
 msgid ""
 "Both eD2k and Kad network are disabled.\n"
 "You won't be able to connect until you enable at least one of them."
@@ -5900,7 +5900,7 @@ msgstr ""
 "Både eD2k og kadnettverket er dekativert.\n"
 "Du vil ikkje klare å kople til før du aktiverer minst eitt av dei."
 
-#: src/PrefsUnifiedDlg.cpp:1403
+#: src/PrefsUnifiedDlg.cpp:1412
 msgid ""
 "Kad will not start if your UDP port is disabled.\n"
 "Enable UDP port or disable Kad."
@@ -5908,7 +5908,7 @@ msgstr ""
 "Kad kan ikkje starte dersom UDP-porten er deaktivert.\n"
 "Aktivér UDP-porten eller deaktivér Kad."
 
-#: src/PrefsUnifiedDlg.cpp:1459
+#: src/PrefsUnifiedDlg.cpp:1468
 msgid ""
 "\n"
 "You MUST restart aMule now.\n"
@@ -5918,69 +5918,69 @@ msgstr ""
 "Du MÅ starte om att aMule no.\n"
 "Ikkje klag dersom du ikkje gjer dette og du får problem.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1524
+#: src/PrefsUnifiedDlg.cpp:1533
 msgid "Could not register aMule for autostart at login. The autostart store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1526
+#: src/PrefsUnifiedDlg.cpp:1535
 msgid "Could not remove the autostart-at-login entry."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1527
+#: src/PrefsUnifiedDlg.cpp:1536
 #, fuzzy
 msgid "Autostart"
 msgstr "Autooppfrisking starta"
 
-#: src/PrefsUnifiedDlg.cpp:1542
+#: src/PrefsUnifiedDlg.cpp:1551
 msgid "Register file type"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1542
+#: src/PrefsUnifiedDlg.cpp:1551
 msgid "Register URL handler"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1550
+#: src/PrefsUnifiedDlg.cpp:1559
 #, c-format
 msgid "aMule only handles eD2k-compatible magnets. If you replace the current magnet handler (%s), BitTorrent magnet links will stop working - aMule cannot download BitTorrent content. Continue?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1555
+#: src/PrefsUnifiedDlg.cpp:1564
 #, c-format
 msgid "Another application currently opens .emulecollection files (%s). Replace it with aMule?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1560
+#: src/PrefsUnifiedDlg.cpp:1569
 #, c-format
 msgid "Another application is currently the default handler for these links (%s). Replace it with aMule?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1585
+#: src/PrefsUnifiedDlg.cpp:1594
 msgid "Could not register aMule for .emulecollection files. The registration store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1587
+#: src/PrefsUnifiedDlg.cpp:1596
 #, fuzzy
 msgid "Could not remove the file type registration."
 msgstr "Du freistar allereie nedlasting av fila %s"
 
-#: src/PrefsUnifiedDlg.cpp:1589
+#: src/PrefsUnifiedDlg.cpp:1598
 msgid "Could not register aMule as the URL handler. The registration store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1591
+#: src/PrefsUnifiedDlg.cpp:1600
 msgid "Could not remove the URL handler registration."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1661 src/PrefsUnifiedDlg.cpp:1688
+#: src/PrefsUnifiedDlg.cpp:1670 src/PrefsUnifiedDlg.cpp:1697
 #, fuzzy
 msgid "The web server and aMule API require external connections to be enabled."
 msgstr "Ny ekstern kopling akseptert"
 
-#: src/PrefsUnifiedDlg.cpp:1671
+#: src/PrefsUnifiedDlg.cpp:1680
 msgid "The aMule web server is deprecated. Consider running the aMule API instead."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1735
+#: src/PrefsUnifiedDlg.cpp:1744
 msgid ""
 "Your Auto-update servers list is in blank.\n"
 "Please fill in at least one URL to point to a valid server.met file.\n"
@@ -5990,66 +5990,66 @@ msgstr ""
 "Vér god og fylle ut ein URL som peikar til ei gyldig server.met fil.\n"
 "Klikk på knappen \"Liste\" ved denne boksen for å skrive inn ein URL."
 
-#: src/PrefsUnifiedDlg.cpp:1876
+#: src/PrefsUnifiedDlg.cpp:1885
 msgid "Temporary files"
 msgstr "Mellombelse filer"
 
-#: src/PrefsUnifiedDlg.cpp:1881
+#: src/PrefsUnifiedDlg.cpp:1890
 msgid "Incoming files"
 msgstr "Innkomande filer"
 
-#: src/PrefsUnifiedDlg.cpp:1886
+#: src/PrefsUnifiedDlg.cpp:1895
 msgid "Online Signatures"
 msgstr "Nettsignaturar"
 
-#: src/PrefsUnifiedDlg.cpp:1899
+#: src/PrefsUnifiedDlg.cpp:1908
 #, c-format
 msgid "Choose a folder for %s"
 msgstr "Vel ei mappe for %s"
 
-#: src/PrefsUnifiedDlg.cpp:1923
+#: src/PrefsUnifiedDlg.cpp:1932
 #, fuzzy, c-format
 msgid "Would exclude %u of %u shared file"
 msgid_plural "Would exclude %u of %u shared files"
 msgstr[0] "Fann %i kjend delt fil"
 msgstr[1] "Fann %i kjende delte filer"
 
-#: src/PrefsUnifiedDlg.cpp:1940
+#: src/PrefsUnifiedDlg.cpp:1949
 msgid "Browse for videoplayer"
 msgstr "Bla etter videospelar"
 
-#: src/PrefsUnifiedDlg.cpp:1944
+#: src/PrefsUnifiedDlg.cpp:1953
 msgid "Select browser"
 msgstr "Vél nettlesar"
 
-#: src/PrefsUnifiedDlg.cpp:1948
+#: src/PrefsUnifiedDlg.cpp:1957
 #, fuzzy
 msgid "Select ffprobe binary"
 msgstr "Vél nettlesar"
 
-#: src/PrefsUnifiedDlg.cpp:1954
+#: src/PrefsUnifiedDlg.cpp:1963
 #, c-format
 msgid "Executable%s"
 msgstr "Køyrbar%s"
 
-#: src/PrefsUnifiedDlg.cpp:1988
+#: src/PrefsUnifiedDlg.cpp:1997
 msgid "ffprobe not found on PATH or in the standard install locations. Install ffmpeg (which ships ffprobe) or use Browse to pick a binary manually."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2000
+#: src/PrefsUnifiedDlg.cpp:2009
 msgid "Reset the settings on this page to their default values?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2001
+#: src/PrefsUnifiedDlg.cpp:2010
 #, fuzzy
 msgid "Reset to defaults"
 msgstr "Standardinnstillingar"
 
-#: src/PrefsUnifiedDlg.cpp:2028
+#: src/PrefsUnifiedDlg.cpp:2037
 msgid "Edit server list"
 msgstr "Handsame tenarlista"
 
-#: src/PrefsUnifiedDlg.cpp:2029
+#: src/PrefsUnifiedDlg.cpp:2038
 msgid ""
 "Add here URL's to download server.met files.\n"
 "Only one url on each line."
@@ -6057,155 +6057,155 @@ msgstr ""
 "Skriv inn URL`en for å laste ned server.met filer.\n"
 "Berre ein URL på kvar linje."
 
-#: src/PrefsUnifiedDlg.cpp:2084
+#: src/PrefsUnifiedDlg.cpp:2093
 msgid "IP2Country update failed"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2229 src/PrefsUnifiedDlg.cpp:2260
+#: src/PrefsUnifiedDlg.cpp:2238 src/PrefsUnifiedDlg.cpp:2269
 msgid "Data by MaxMind GeoLite2"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2231 src/PrefsUnifiedDlg.cpp:2262
+#: src/PrefsUnifiedDlg.cpp:2240 src/PrefsUnifiedDlg.cpp:2271
 #, fuzzy
 msgid "Custom source"
 msgstr "Komplette kjelder"
 
-#: src/PrefsUnifiedDlg.cpp:2233 src/PrefsUnifiedDlg.cpp:2264
+#: src/PrefsUnifiedDlg.cpp:2242 src/PrefsUnifiedDlg.cpp:2273
 msgid "Data by DB-IP.com"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2284
+#: src/PrefsUnifiedDlg.cpp:2293
 #, fuzzy, c-format
 msgid "Status: Loaded%s"
 msgstr "Status:"
 
-#: src/PrefsUnifiedDlg.cpp:2286
+#: src/PrefsUnifiedDlg.cpp:2295
 #, fuzzy, c-format
 msgid "Status: Loaded%s - %s"
 msgstr "Status:"
 
-#: src/PrefsUnifiedDlg.cpp:2290
+#: src/PrefsUnifiedDlg.cpp:2299
 msgid "Status: Failed to load - click 'Update now' to refresh."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2292
+#: src/PrefsUnifiedDlg.cpp:2301
 msgid "Status: Not found - click 'Update now' to download."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2350 src/PrefsUnifiedDlg.cpp:2374
+#: src/PrefsUnifiedDlg.cpp:2359 src/PrefsUnifiedDlg.cpp:2383
 #, c-format
 msgid "Update delay: %d second"
 msgid_plural "Update delay: %d seconds"
 msgstr[0] "Oppdateringspause: %d sekund"
 msgstr[1] "Oppdateringspause: %d sekund"
 
-#: src/PrefsUnifiedDlg.cpp:2358
+#: src/PrefsUnifiedDlg.cpp:2367
 #, c-format
 msgid "Time for average graph: %d minute"
 msgid_plural "Time for average graph: %d minutes"
 msgstr[0] "Tid for gjennomsnittleg graf: %d minutt"
 msgstr[1] "Tid for gjennomsnittleg graf; %d minutt"
 
-#: src/PrefsUnifiedDlg.cpp:2367
+#: src/PrefsUnifiedDlg.cpp:2376
 #, c-format
 msgid "Connections Graph Scale: %d"
 msgstr "Koplingsgrafskala: %d"
 
-#: src/PrefsUnifiedDlg.cpp:2382
+#: src/PrefsUnifiedDlg.cpp:2391
 #, c-format
 msgid "File Buffer Size: %d byte"
 msgid_plural "File Buffer Size: %d bytes"
 msgstr[0] "Filbufferstorleik: %d byte"
 msgstr[1] "Filbufferstorleik: %d bytes"
 
-#: src/PrefsUnifiedDlg.cpp:2392
+#: src/PrefsUnifiedDlg.cpp:2401
 #, c-format
 msgid "Upload Queue Size: %d client"
 msgid_plural "Upload Queue Size: %d clients"
 msgstr[0] "Opplastingskøstorleik: %d klient"
 msgstr[1] "Opplastingskøstorleik: %d klientar"
 
-#: src/PrefsUnifiedDlg.cpp:2402
+#: src/PrefsUnifiedDlg.cpp:2411
 #, c-format
 msgid "Server connection refresh interval: %d minute"
 msgid_plural "Server connection refresh interval: %d minutes"
 msgstr[0] "Oppfriskingsinterval på tenarkoplingar: %d minutt"
 msgstr[1] "Oppfriskingsinterval på tenarkoplingar: %d minutt"
 
-#: src/PrefsUnifiedDlg.cpp:2407
+#: src/PrefsUnifiedDlg.cpp:2416
 msgid "Server connection refresh interval: Disabled"
 msgstr "Oppfriskingsintervall for tenarkopling: Deaktivert"
 
-#: src/PrefsUnifiedDlg.cpp:2451
+#: src/PrefsUnifiedDlg.cpp:2460
 #, fuzzy
 msgid "disabled"
 msgstr "deaktivere"
 
-#: src/PrefsUnifiedDlg.cpp:2477
+#: src/PrefsUnifiedDlg.cpp:2486
 #, fuzzy, c-format
 msgid "Execute command on '%s' event"
 msgstr "Køyr kommando på `%s' hending"
 
-#: src/PrefsUnifiedDlg.cpp:2484
+#: src/PrefsUnifiedDlg.cpp:2493
 msgid "Enable command execution on core"
 msgstr "Aktivér kommandokøyring i kjernen"
 
-#: src/PrefsUnifiedDlg.cpp:2496
+#: src/PrefsUnifiedDlg.cpp:2505
 msgid "Core command:"
 msgstr "Kjernekommando:"
 
-#: src/PrefsUnifiedDlg.cpp:2512
+#: src/PrefsUnifiedDlg.cpp:2521
 msgid "Enable command execution on GUI"
 msgstr "Aktivér kommandokøyring på drakt"
 
-#: src/PrefsUnifiedDlg.cpp:2524
+#: src/PrefsUnifiedDlg.cpp:2533
 msgid "GUI command:"
 msgstr "Draktkommando:"
 
-#: src/PrefsUnifiedDlg.cpp:2540
+#: src/PrefsUnifiedDlg.cpp:2549
 msgid "The following variables will be replaced:"
 msgstr "Følgjande variablar vert erstatta:"
 
-#: src/PrefsUnifiedDlg.cpp:2708
+#: src/PrefsUnifiedDlg.cpp:2717
 msgid ""
 "The following folders look like system or sensitive locations:\n"
 "\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2713
+#: src/PrefsUnifiedDlg.cpp:2722
 msgid "Sharing them recursively will publish every file underneath on the eD2k/Kad networks. Do you really want to do this?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2716
+#: src/PrefsUnifiedDlg.cpp:2725
 #, fuzzy
 msgid "Confirm shared folders"
 msgstr "Lastar inn att delte filer"
 
-#: src/PrefsUnifiedDlg.cpp:2744
+#: src/PrefsUnifiedDlg.cpp:2753
 #, fuzzy
 msgid "Reloading shared files..."
 msgstr "Lastar inn att delte filer"
 
-#: src/PrefsUnifiedDlg.cpp:2745
+#: src/PrefsUnifiedDlg.cpp:2754
 msgid "Scanning for subdirectories..."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2746
+#: src/PrefsUnifiedDlg.cpp:2755
 #, fuzzy
 msgid "Updating shared folders"
 msgstr "Les mellombels mappe"
 
-#: src/PrefsUnifiedDlg.cpp:2773
+#: src/PrefsUnifiedDlg.cpp:2782
 #, c-format
 msgid "Scanned %u directories..."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2823
+#: src/PrefsUnifiedDlg.cpp:2832
 #, fuzzy, c-format
 msgid "Reloading shared files: %u files scanned"
 msgstr "Lastar inn att lista over delte filer."
 
-#: src/PrefsUnifiedDlg.cpp:2873
+#: src/PrefsUnifiedDlg.cpp:2882
 #, fuzzy
 msgid "Shared folder"
 msgstr "Delte filer"
@@ -7918,12 +7918,12 @@ msgstr "Ta bort kategori"
 msgid "Hashset requested for unknown file: %s"
 msgstr "Hashsett etterspurt for ukjend fil: %s"
 
-#: src/UploadQueue.cpp:618
+#: src/UploadQueue.cpp:627
 #, c-format
 msgid "Resuming uploads of file: %s"
 msgstr "Held fram opplastingar av fila: %s"
 
-#: src/UploadQueue.cpp:634
+#: src/UploadQueue.cpp:643
 #, c-format
 msgid "Suspending upload of file: %s"
 msgstr "Mellombels stogge opplastingar av fila: %s"

--- a/po/nn.po
+++ b/po/nn.po
@@ -10,8 +10,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-28 12:12+0200\n"
-"PO-Revision-Date: 2026-07-27 10:29+0000\n"
+"POT-Creation-Date: 2026-07-28 08:06+0200\n"
+"PO-Revision-Date: 2026-07-27 11:42+0000\n"
 "Last-Translator: Hallvor Brunstad <Hallvor_1976@yahoo.com>\n"
 "Language-Team: <i18n-nn@lister.ping.uio.no>\n"
 "Language: nn\n"
@@ -142,7 +142,7 @@ msgstr ""
 msgid "Not now"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:422 src/amuleDlg.cpp:665
+#: src/AppImageIntegration.cpp:422 src/amuleDlg.cpp:600
 msgid "Don't ask again"
 msgstr ""
 
@@ -201,162 +201,162 @@ msgstr "Greidde ikkje å opne %s·(%s)"
 msgid "WARNING: You can't add yourself as a source for an eD2k link while having a lowid."
 msgstr "ÅTVARING: Du kan ikkje leggje deg sjølv til som kjelde for ei eD2k lenkje medan du har ein lågid."
 
-#: src/amule.cpp:301
+#: src/amule.cpp:300
 #, fuzzy
 msgid "Now, exiting main app..."
 msgstr ""
 "\n"
 "Ok,·avsluttar·%s...\n"
 
-#: src/amule.cpp:331
+#: src/amule.cpp:330
 #, c-format
 msgid "Terminating amuleweb instance with pid '%d' ... "
 msgstr ""
 
-#: src/amule.cpp:335
+#: src/amule.cpp:334
 #, c-format
 msgid "Killing amuleweb instance with pid '%d' ... "
 msgstr ""
 
-#: src/amule.cpp:337 src/amule.cpp:350 src/ClientRef.cpp:180
-#: src/SearchDlg.cpp:1041 src/ServerListCtrl.cpp:98
+#: src/amule.cpp:336 src/amule.cpp:349 src/ClientRef.cpp:180
+#: src/SearchDlg.cpp:880 src/ServerListCtrl.cpp:98
 msgid "Failed"
 msgstr "Mislukka"
 
-#: src/amule.cpp:344
+#: src/amule.cpp:343
 #, c-format
 msgid "Terminating amuleapi instance with pid '%d' ... "
 msgstr ""
 
-#: src/amule.cpp:348
+#: src/amule.cpp:347
 #, c-format
 msgid "Killing amuleapi instance with pid '%d' ... "
 msgstr ""
 
-#: src/amule.cpp:356
+#: src/amule.cpp:355
 msgid "aMule OnExit: Terminating core."
 msgstr ""
 
-#: src/amule.cpp:467
+#: src/amule.cpp:466
 #, fuzzy
 msgid "aMule shutdown completed."
 msgstr "Nedlasting fullført"
 
-#: src/amule.cpp:471
+#: src/amule.cpp:470
 msgid "Memory debug results for aMule exit:"
 msgstr ""
 
-#: src/amule.cpp:652
+#: src/amule.cpp:651
 #, c-format
 msgid "Binding aMule's peer-to-peer traffic to interface: %s (HTTP updates use the default route)"
 msgstr ""
 
-#: src/amule.cpp:656
+#: src/amule.cpp:655
 #, c-format
 msgid "Binding all network traffic to interface: %s"
 msgstr ""
 
-#: src/amule.cpp:660
+#: src/amule.cpp:659
 #, c-format
 msgid "WARNING: configured network interface '%s' was not found - traffic is NOT bound to it and may leave via the default route. Check the interface name in Preferences."
 msgstr ""
 
-#: src/amule.cpp:666
+#: src/amule.cpp:665
 #, c-format
 msgid "WARNING: binding to network interface '%s' requires elevated privileges and was NOT applied - traffic may leave via the default route. Grant the capability (e.g. 'sudo setcap cap_net_raw+ep' on the aMule binary) or run with sufficient privileges."
 msgstr ""
 
-#: src/amule.cpp:674
+#: src/amule.cpp:673
 #, c-format
 msgid "WARNING: could not bind to network interface '%s' - traffic may leave via the default route."
 msgstr ""
 
-#: src/amule.cpp:733
+#: src/amule.cpp:732
 msgid "Your locale has been changed to System Default due to a configuration change. Sorry."
 msgstr "Dine lokale innstilingar har vorte endra til opprinnelege systeminnstillingar på grunn av konfigurasjonsending. Beklager."
 
-#: src/amule.cpp:735 src/amule.cpp:1589 src/CatDialog.cpp:128
+#: src/amule.cpp:734 src/amule.cpp:1581 src/CatDialog.cpp:128
 #: src/CatDialog.cpp:136 src/CatDialog.cpp:149 src/ServerList.cpp:366
 #: src/ServerListCtrl.cpp:152
 msgid "Info"
 msgstr "Info"
 
-#: src/amule.cpp:742
+#: src/amule.cpp:741
 #, fuzzy
 msgid ""
 "\n"
 "EC configuration"
 msgstr "Stadfesting av avslutting"
 
-#: src/amule.cpp:745
+#: src/amule.cpp:744
 #, fuzzy
 msgid "Password set and external connections enabled."
 msgstr "Ny ekstern kopling akseptert"
 
-#: src/amule.cpp:755 src/KadDlg.cpp:176 src/KadDlg.cpp:185
-#: src/PrefsUnifiedDlg.cpp:1461 src/SharedFilesCtrl.cpp:476
+#: src/amule.cpp:754 src/KadDlg.cpp:176 src/KadDlg.cpp:185
+#: src/PrefsUnifiedDlg.cpp:1387 src/SharedFilesCtrl.cpp:476
 msgid "WARNING"
 msgstr "ÅTVARING"
 
-#: src/amule.cpp:992
+#: src/amule.cpp:991
 #, fuzzy
 msgid "Network bootstrap"
 msgstr "Nettverk"
 
-#: src/amule.cpp:997
+#: src/amule.cpp:996
 msgid ""
 "aMule has detected missing network bootstrap files.\n"
 "Select which ones to download:"
 msgstr ""
 
-#: src/amule.cpp:1006 src/FirstRunWizard.cpp:411
+#: src/amule.cpp:1005 src/FirstRunWizard.cpp:411
 #, fuzzy
 msgid "eD2k server list (server.met)"
 msgstr "%i tenar funne i server.met"
 
-#: src/amule.cpp:1013 src/FirstRunWizard.cpp:416
+#: src/amule.cpp:1012 src/FirstRunWizard.cpp:416
 msgid "Kad bootstrap nodes (nodes.dat)"
 msgstr ""
 
-#: src/amule.cpp:1103
+#: src/amule.cpp:1102
 #, c-format
 msgid "web server running on pid %d"
 msgstr "vevtenar køyrer på pid %d"
 
-#: src/amule.cpp:1116
+#: src/amule.cpp:1115
 #, fuzzy
 msgid "You requested to run web server on startup, but the amuleweb binary cannot be run. Please install the package containing aMule web server, or build aMule from source with -DBUILD_WEBSERVER=YES and install it."
 msgstr "Du freista å køyre vevtenar ved oppstart, men binærfila amuleweb kan ikkje køyrast. Installer pakken som inneheld vevtenaren til aMule, eller kompiler aMule med --enable-webserver og køyr make install"
 
-#: src/amule.cpp:1121 src/amule.cpp:1185 src/amule.cpp:1299 src/amule.cpp:1601
+#: src/amule.cpp:1120 src/amule.cpp:1177 src/amule.cpp:1291 src/amule.cpp:1593
 #: src/amule-remote-gui.cpp:603 src/amule-remote-gui.cpp:671
 #: src/amule-remote-gui.cpp:709 src/amule-remote-gui.cpp:1282
 #: src/amule-remote-gui.cpp:1345 src/amule-remote-gui.cpp:1372
-#: src/DownloadQueue.cpp:1481 src/PrefsUnifiedDlg.cpp:1247
+#: src/DownloadQueue.cpp:1481
 msgid "ERROR"
 msgstr "FEIL"
 
-#: src/amule.cpp:1174
+#: src/amule.cpp:1166
 #, fuzzy, c-format
 msgid "amuleapi running on pid %d"
 msgstr "vevtenar køyrer på pid %d"
 
-#: src/amule.cpp:1180
+#: src/amule.cpp:1172
 #, fuzzy
 msgid "You requested to run amuleapi on startup, but the amuleapi binary cannot be run. Please install the package containing aMule's REST API server, or build aMule from source with -DBUILD_AMULEAPI=YES and install it."
 msgstr "Du freista å køyre vevtenar ved oppstart, men binærfila amuleweb kan ikkje køyrast. Installer pakken som inneheld vevtenaren til aMule, eller kompiler aMule med --enable-webserver og køyr make install"
 
-#: src/amule.cpp:1267
+#: src/amule.cpp:1259
 #, c-format
 msgid "Could not bind ports to the specified address: %s"
 msgstr "Greidde ikkje å knyte portar til adressa: %s"
 
-#: src/amule.cpp:1291
+#: src/amule.cpp:1283
 #, c-format
 msgid "Port %u is not available. You will be LOWID\n"
 msgstr "Port·%u er ikkje tilgjengeleg. Du vil få LågID\n"
 
-#: src/amule.cpp:1296
+#: src/amule.cpp:1288
 #, c-format
 msgid ""
 "Port %u is not available!\n"
@@ -371,48 +371,48 @@ msgstr ""
 "\n"
 "Sjekk nettverket ditt for å vere viss på at porten er open for inn- og utgåande trafikk."
 
-#: src/amule.cpp:1393
+#: src/amule.cpp:1385
 msgid "Failed to create OnlineSig File"
 msgstr "Greidde ikkje å lage OnlineSigfil"
 
-#: src/amule.cpp:1401
+#: src/amule.cpp:1393
 msgid "Failed to create aMule OnlineSig File"
 msgstr "Greidde ikkje å lage aMule si OnlineSigfil."
 
-#: src/amule.cpp:1564
+#: src/amule.cpp:1556
 msgid "The selected locale seems not to be installed on your box. (Note: I'll try to set it anyway)"
 msgstr "Dei valte lokale innstillingane ser ikkje ut til å vere installerte på maskina di. (Merk: Eg freistar å setje dei likevel)"
 
-#: src/amule.cpp:1574
+#: src/amule.cpp:1566
 #, c-format
 msgid "This is the first time you run aMule %s"
 msgstr "Dette er første gongen du køyrer aMule %s"
 
-#: src/amule.cpp:1577
+#: src/amule.cpp:1569
 msgid "This version is a testing version, updated daily, and\n"
 msgstr "Denne utgåva er ei testutgåve, oppdatert dagleg, og\n"
 
-#: src/amule.cpp:1578
+#: src/amule.cpp:1570
 msgid "we give no warranty it won't break anything, burn your house,\n"
 msgstr "vi gir ingen garanti for skade eller nedbrenning av huset ditt,\n"
 
-#: src/amule.cpp:1579
+#: src/amule.cpp:1571
 msgid "or kill your dog. But it *should* be safe to use anyway.\n"
 msgstr "eller drep hunden din. Men det *burde* vere trygt å nytte uansett.\n"
 
-#: src/amule.cpp:1584
+#: src/amule.cpp:1576
 msgid "More information, support and new releases can found at our homepage,\n"
 msgstr "Meir informasjon, brukarstøtte og nye utgåver kan verte funne på heimesida vår.\n"
 
-#: src/amule.cpp:1585
+#: src/amule.cpp:1577
 msgid "at https://amule-org.github.io, or in our IRC channel #aMule at irc.libera.chat.\n"
 msgstr "på https://amule-org.github.io, eller på IRC-kanalen vår #aMule·på·irc.libera.chat.\n"
 
-#: src/amule.cpp:1587
+#: src/amule.cpp:1579
 msgid "Feel free to report any bugs to https://github.com/amule-org/amule/issues"
 msgstr "Vér god å rapportere feil til https://github.com/amule-org/amule/issues"
 
-#: src/amule.cpp:1599
+#: src/amule.cpp:1591
 msgid ""
 "The folder for Online Signature files you specified is INVALID!\n"
 " OnlineSignature will be DISABLED until you fix it on preferences."
@@ -420,138 +420,138 @@ msgstr ""
 "Mappa spesifisert for nettsignaturar er UGANGBAR!\n"
 " Nettsignaturar vert DEAKTIVERT fram til du ordnar det i innstillingar."
 
-#: src/amule.cpp:1662
+#: src/amule.cpp:1654
 #, fuzzy
 msgid "Server hostname notified"
 msgstr "Tenarnamn:"
 
-#: src/amule.cpp:2039
+#: src/amule.cpp:2031
 #, c-format
 msgid "Disk space preallocation for file '%s' failed: %s"
 msgstr "Henting av diskplass for fila '%s' mislukka: %s"
 
-#: src/amule.cpp:2168
+#: src/amule.cpp:2160
 msgid "ERROR: can't open logfile"
 msgstr "FEIL: Greier ikkje å opne loggfila"
 
-#: src/amule.cpp:2172
+#: src/amule.cpp:2164
 msgid "WARNING: logfile is empty. Something is wrong."
 msgstr "ÅTVARING: loggfila er tom. Noko er gale."
 
-#: src/amule.cpp:2189
+#: src/amule.cpp:2181
 msgid "Log has been reset"
 msgstr "Loggen har vorte nullstilt"
 
-#: src/amule.cpp:2213
+#: src/amule.cpp:2205
 #, c-format
 msgid "ServerMessage: %s"
 msgstr "Tenarmelding: %s"
 
-#: src/amule.cpp:2256 src/IP2Country.cpp:220 src/IPFilter.cpp:514
+#: src/amule.cpp:2248 src/IP2Country.cpp:220 src/IPFilter.cpp:514
 #: src/ServerList.cpp:875
 #, c-format
 msgid "Skipped download of %s, because requested file is not newer."
 msgstr ""
 
-#: src/amule.cpp:2259
+#: src/amule.cpp:2251
 msgid "Failed to download the nodes list."
 msgstr "Klarte ikkje å laste ned nodelista."
 
-#: src/amule.cpp:2322
+#: src/amule.cpp:2314
 msgid "Failed to open the downloaded version check file"
 msgstr "Klarte ikkje å opne den nedlaste utgåvesjekkfila"
 
-#: src/amule.cpp:2325 src/amule.cpp:2344
+#: src/amule.cpp:2317 src/amule.cpp:2336
 msgid "Corrupted version check file"
 msgstr "Korrupt utgåvesjekkfil"
 
-#: src/amule.cpp:2367
+#: src/amule.cpp:2359
 msgid "You are using an outdated version of aMule!"
 msgstr "Du nyttar ei utdatert utgåve av aMule!"
 
-#: src/amule.cpp:2369
+#: src/amule.cpp:2361
 #, c-format
 msgid "Your aMule version is %i.%i.%i and the latest version is %li.%li.%li"
 msgstr "Di utgåve av aMule er %i.%i.%i og den siste utgåva er %li.%li.%li"
 
-#: src/amule.cpp:2373
+#: src/amule.cpp:2365
 msgid "The latest version can always be found at https://github.com/amule-org/amule/releases/latest"
 msgstr "Den siste utgåva finst alltid på https://github.com/amule-org/amule/releases/latest"
 
-#: src/amule.cpp:2376
+#: src/amule.cpp:2368
 #, c-format
 msgid "WARNING: Your aMuled version is outdated: %i.%i.%i < %li.%li.%li"
 msgstr "ÅTVARING: Utgåva di av aMule er utdatert: %i.%i.%i·<·%li.%li.%li"
 
-#: src/amule.cpp:2382
+#: src/amule.cpp:2374
 msgid "Your copy of aMule is up to date."
 msgstr "Utgåva di av aMule er oppdatert."
 
-#: src/amule.cpp:2389
+#: src/amule.cpp:2381
 msgid "Failed to download the version check file"
 msgstr "Klarte ikkje å laste ned utgåvesjekkfila"
 
-#: src/amule.cpp:2558 src/amule-remote-gui.cpp:1133
+#: src/amule.cpp:2550 src/amule-remote-gui.cpp:1133
 #, c-format
 msgid "Users: %s | Files: %s"
 msgstr "Brukarar: %s | Filer: %s"
 
-#: src/amule.cpp:2559 src/amule-remote-gui.cpp:1134
+#: src/amule.cpp:2551 src/amule-remote-gui.cpp:1134
 #, c-format
 msgid "Users: E: %s K: %s | Files: E: %s K: %s"
 msgstr "Brukarar: E %s K: %s | Filer: E: %s K: %s"
 
-#: src/amule.cpp:2573 src/amule-remote-gui.cpp:1147
+#: src/amule.cpp:2565 src/amule-remote-gui.cpp:1147
 msgid "No networks selected"
 msgstr "Ingen valde nettverk"
 
-#: src/amule.cpp:2641 src/TextClient.cpp:903
+#: src/amule.cpp:2633 src/TextClient.cpp:903
 msgid "with LowID"
 msgstr "med LågID"
 
-#: src/amule.cpp:2641 src/TextClient.cpp:904
+#: src/amule.cpp:2633 src/TextClient.cpp:904
 msgid "with HighID"
 msgstr "med HøgID"
 
-#: src/amule.cpp:2643
+#: src/amule.cpp:2635
 #, c-format
 msgid "Connected to %s %s"
 msgstr "Tilkopla %s·%s"
 
-#: src/amule.cpp:2648
+#: src/amule.cpp:2640
 #, c-format
 msgid "Connecting to %s"
 msgstr "Koplar til %s"
 
-#: src/amule.cpp:2650
+#: src/amule.cpp:2642
 msgid "Disconnected from eD2k"
 msgstr "Fråkopla eD2k"
 
-#: src/amule.cpp:2659
+#: src/amule.cpp:2651
 msgid "Kad started."
 msgstr "Kad starta."
 
-#: src/amule.cpp:2661
+#: src/amule.cpp:2653
 msgid "Kad stopped."
 msgstr "Kad stogga."
 
-#: src/amule.cpp:2669
+#: src/amule.cpp:2661
 msgid "Connected to Kad (ok)"
 msgstr "Tilkopla Kad (ok)"
 
-#: src/amule.cpp:2671
+#: src/amule.cpp:2663
 msgid "Connected to Kad (firewalled)"
 msgstr "Tilkopla Kad (brannmura)"
 
-#: src/amule.cpp:2675
+#: src/amule.cpp:2667
 msgid "Disconnected from Kad"
 msgstr "Fråkopla Kad"
 
-#: src/amule.cpp:2707
+#: src/amule.cpp:2699
 msgid "Kad network cannot be used if UDP port is disabled on preferences, not starting."
 msgstr "Kad kan ikkje nyttast dersom UDP-porten er deaktivert i innstillingar. Startar ikkje."
 
-#: src/amule.cpp:2711
+#: src/amule.cpp:2703
 msgid "Kad network disabled on preferences, not connecting."
 msgstr "Kad-nettverket er deaktivert i innstillingar. Koplar ikkje til."
 
@@ -577,68 +577,30 @@ msgstr ""
 msgid "ERROR: %s"
 msgstr "Feil: %s"
 
-#: src/amuleDlg.cpp:250
+#: src/amuleDlg.cpp:236
 #, c-format
 msgid "This is aMule %s based on eMule."
 msgstr "Dette er aMule %s basert på eMule."
 
-#: src/amuleDlg.cpp:251
+#: src/amuleDlg.cpp:237
 #, c-format
 msgid "Running on %s"
 msgstr "Køyrer på %s"
 
-#: src/amuleDlg.cpp:253
+#: src/amuleDlg.cpp:239
 msgid "Visit https://github.com/amule-org/amule/releases/latest to check if a new version is available."
 msgstr "Vitje https://github.com/amule-org/amule/releases/latest for å sjekke om ei ny utgåve er tilgjengeleg."
 
-#: src/amuleDlg.cpp:282
+#: src/amuleDlg.cpp:268
 msgid "FATAL ERROR: Failed to create Timer"
 msgstr "FATAL FEIL: Greidde ikkje å lage tidtakar"
 
-#: src/amuleDlg.cpp:361 src/amuleDlg.cpp:1810 src/amuleDlg.cpp:2056
-#: src/muuli_wdr.cpp:1492 src/muuli_wdr.cpp:3439
-msgid "Networks"
-msgstr "Nettverk"
-
-#: src/amuleDlg.cpp:362 src/amuleDlg.cpp:1816 src/muuli_wdr.cpp:3440
-msgid "Searches"
-msgstr "Søk"
-
-#: src/amuleDlg.cpp:363 src/amuleDlg.cpp:1822 src/DownloadListCtrl.cpp:740
-#: src/muuli_wdr.cpp:392 src/muuli_wdr.cpp:1585 src/muuli_wdr.cpp:3441
-#: src/Statistics.cpp:829
-msgid "Downloads"
-msgstr "Nedlastingar"
-
-#: src/amuleDlg.cpp:364 src/amuleDlg.cpp:1828 src/muuli_wdr.cpp:3315
-msgid "Shared files"
-msgstr "Delte filer"
-
-#: src/amuleDlg.cpp:365 src/amuleDlg.cpp:1834 src/muuli_wdr.cpp:2947
-#: src/muuli_wdr.cpp:3397 src/muuli_wdr.cpp:3444
-msgid "Messages"
-msgstr "Meldingar"
-
-#: src/amuleDlg.cpp:366 src/amuleDlg.cpp:1840 src/muuli_wdr.cpp:3445
-#: src/PrefsUnifiedDlg.cpp:314 src/Statistics.cpp:779 src/Statistics.cpp:1235
-msgid "Statistics"
-msgstr "Statistikk"
-
-#: src/amuleDlg.cpp:368 src/amuleDlg.cpp:1847 src/muuli_wdr.cpp:3447
-#: src/PrefsUnifiedDlg.cpp:330 src/utils/wxCas/src/wxcasprefs.cpp:39
-msgid "Preferences"
-msgstr "Innstillingar"
-
-#: src/amuleDlg.cpp:371
-msgid "Navigate"
-msgstr ""
-
-#: src/amuleDlg.cpp:657
+#: src/amuleDlg.cpp:592
 #, fuzzy
 msgid "New version available"
 msgstr "Ikkje tilgjengeleg"
 
-#: src/amuleDlg.cpp:661
+#: src/amuleDlg.cpp:596
 #, fuzzy, c-format
 msgid ""
 "A new version of aMule (%s) is available.\n"
@@ -648,186 +610,219 @@ msgid ""
 "Would you like to open the download page?"
 msgstr "Den siste utgåva finst alltid på https://github.com/amule-org/amule/releases/latest"
 
-#: src/amuleDlg.cpp:743
+#: src/amuleDlg.cpp:678
 msgid "aMule dialog destroyed"
 msgstr ""
 
-#: src/amuleDlg.cpp:766 src/DataToText.cpp:68 src/IPFilter.cpp:547
+#: src/amuleDlg.cpp:701 src/DataToText.cpp:68 src/IPFilter.cpp:547
 msgid "Connecting"
 msgstr "Koplar til"
 
-#: src/amuleDlg.cpp:958
+#: src/amuleDlg.cpp:893
 msgid "eD2k: Connecting"
 msgstr "eD2k: Koplar til"
 
-#: src/amuleDlg.cpp:962
+#: src/amuleDlg.cpp:897
 msgid "eD2k: Disconnected"
 msgstr "eD2k: Fråkopla"
 
-#: src/amuleDlg.cpp:968
+#: src/amuleDlg.cpp:903
 msgid "Kad: Firewalled"
 msgstr "Kad: Brannmura"
 
-#: src/amuleDlg.cpp:972
+#: src/amuleDlg.cpp:907
 msgid "Kad: Connected"
 msgstr "Kad: Tilkopla"
 
-#: src/amuleDlg.cpp:977
+#: src/amuleDlg.cpp:912
 msgid "Kad: Connecting"
 msgstr "Kad: Koplar til"
 
-#: src/amuleDlg.cpp:981
+#: src/amuleDlg.cpp:916
 msgid "Kad: Off"
 msgstr "Kad: Av"
 
-#: src/amuleDlg.cpp:1029 src/DownloadListCtrl.cpp:505
+#: src/amuleDlg.cpp:964 src/DownloadListCtrl.cpp:505
 #: src/DownloadListCtrl.cpp:749 src/FriendListCtrl.cpp:180
 #: src/muuli_wdr.cpp:731 src/muuli_wdr.cpp:782 src/muuli_wdr.cpp:846
-#: src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2252 src/muuli_wdr.cpp:2337
-#: src/muuli_wdr.cpp:3085 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
+#: src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2224 src/muuli_wdr.cpp:2309
+#: src/muuli_wdr.cpp:3057 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
 #: src/ServerListCtrl.cpp:606 src/TransferWnd.cpp:378
 #: src/utils/wxCas/src/wxcasprefs.cpp:235
 msgid "Cancel"
 msgstr "Avbryt"
 
-#: src/amuleDlg.cpp:1030
+#: src/amuleDlg.cpp:965
 msgid "Stop the current connection attempts"
 msgstr "Stopp inneverande oppkoplingsfreistingar"
 
-#: src/amuleDlg.cpp:1035 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976
-#: src/muuli_wdr.cpp:2475
+#: src/amuleDlg.cpp:970 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976
+#: src/muuli_wdr.cpp:2447
 msgid "Disconnect"
 msgstr "Kople frå"
 
-#: src/amuleDlg.cpp:1036
+#: src/amuleDlg.cpp:971
 msgid "Disconnect from the currently connected networks"
 msgstr "Kople frå dei aktive nettverka"
 
-#: src/amuleDlg.cpp:1041 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979
-#: src/muuli_wdr.cpp:2630 src/muuli_wdr.cpp:3082 src/muuli_wdr.cpp:3437
+#: src/amuleDlg.cpp:976 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979
+#: src/muuli_wdr.cpp:2602 src/muuli_wdr.cpp:3054 src/muuli_wdr.cpp:3409
 msgid "Connect"
 msgstr "Kople til"
 
-#: src/amuleDlg.cpp:1042
+#: src/amuleDlg.cpp:977
 msgid "Connect to the currently enabled networks"
 msgstr "Kople til dei valde nettverka"
 
-#: src/amuleDlg.cpp:1154
+#: src/amuleDlg.cpp:1089
 #, fuzzy, c-format
 msgid "Up: %.1f%s (%.1f) | Down: %.1f%s (%.1f)"
 msgstr "Opp:·%.1f(%.1f)·|·Ned:·%.1f(%.1f)"
 
-#: src/amuleDlg.cpp:1156 src/amuleDlg.cpp:1158 src/amuleDlg.cpp:1162
-#: src/amuleDlg.cpp:1164 src/amuleDlg.cpp:1175 src/amuleDlg.cpp:1177
+#: src/amuleDlg.cpp:1091 src/amuleDlg.cpp:1093 src/amuleDlg.cpp:1097
+#: src/amuleDlg.cpp:1099 src/amuleDlg.cpp:1110 src/amuleDlg.cpp:1112
 #: src/MuleTrayIcon.cpp:796 src/MuleTrayIcon.cpp:799
 #, fuzzy
 msgid " MB/s"
 msgstr "MB/s"
 
-#: src/amuleDlg.cpp:1156 src/amuleDlg.cpp:1158 src/amuleDlg.cpp:1162
-#: src/amuleDlg.cpp:1164 src/amuleDlg.cpp:1175 src/amuleDlg.cpp:1177
+#: src/amuleDlg.cpp:1091 src/amuleDlg.cpp:1093 src/amuleDlg.cpp:1097
+#: src/amuleDlg.cpp:1099 src/amuleDlg.cpp:1110 src/amuleDlg.cpp:1112
 #: src/MuleTrayIcon.cpp:796 src/MuleTrayIcon.cpp:799
 #: src/utils/wxCas/src/wxcasframe.cpp:1041
 msgid " kB/s"
 msgstr " kB/s"
 
-#: src/amuleDlg.cpp:1161
+#: src/amuleDlg.cpp:1096
 #, fuzzy, c-format
 msgid "Up: %.1f%s | Down: %.1f%s"
 msgstr "Opp:·%.1f·|·Ned:·%.1f"
 
-#: src/amuleDlg.cpp:1193
+#: src/amuleDlg.cpp:1128
 #, c-format
 msgid "aMule (%s | Connected)"
 msgstr "aMule·(%s·|·Tilkopla)"
 
-#: src/amuleDlg.cpp:1195
+#: src/amuleDlg.cpp:1130
 #, c-format
 msgid "aMule (%s | Disconnected)"
 msgstr "aMule·(%s·|·Fråkopla)"
 
-#: src/amuleDlg.cpp:1248
+#: src/amuleDlg.cpp:1183
 #, fuzzy, c-format
 msgid "Do you really want to exit %s?"
 msgstr "Vil du verkeleg avslutte aMule?"
 
-#: src/amuleDlg.cpp:1250
+#: src/amuleDlg.cpp:1185
 msgid "Exit confirmation"
 msgstr "Stadfesting av avslutting"
 
-#: src/amuleDlg.cpp:1613
+#: src/amuleDlg.cpp:1548
 msgid "Launch Command: "
 msgstr ""
 
-#: src/amuleDlg.cpp:1632 src/muuli_wdr.cpp:1972 src/Preferences.cpp:979
+#: src/amuleDlg.cpp:1567 src/muuli_wdr.cpp:1971 src/Preferences.cpp:951
 msgid "- default -"
 msgstr ""
 
-#: src/amuleDlg.cpp:1660
+#: src/amuleDlg.cpp:1595
 #, c-format
 msgid "Skin directory '%s' does not exist"
 msgstr "Skinnkatalogen '%s' finst ikkje"
 
-#: src/amuleDlg.cpp:1663
+#: src/amuleDlg.cpp:1598
 #, c-format
 msgid "WARNING: Unable to open skin file '%s' for read"
 msgstr "ÅTVARING: Greidde ikkje å opne hudfila '%s' for lesing"
 
-#: src/amuleDlg.cpp:1814 src/muuli_wdr.cpp:3439
+#: src/amuleDlg.cpp:1722 src/amuleDlg.cpp:1968 src/muuli_wdr.cpp:1485
+#: src/muuli_wdr.cpp:3411
+msgid "Networks"
+msgstr "Nettverk"
+
+#: src/amuleDlg.cpp:1726 src/muuli_wdr.cpp:3411
 msgid "Networks Window"
 msgstr "Nettverksavindauge"
 
-#: src/amuleDlg.cpp:1820 src/muuli_wdr.cpp:3440
+#: src/amuleDlg.cpp:1728 src/muuli_wdr.cpp:3412
+msgid "Searches"
+msgstr "Søk"
+
+#: src/amuleDlg.cpp:1732 src/muuli_wdr.cpp:3412
 msgid "Searches Window"
 msgstr "Søkjevindauge"
 
-#: src/amuleDlg.cpp:1826 src/muuli_wdr.cpp:3441
+#: src/amuleDlg.cpp:1734 src/DownloadListCtrl.cpp:740 src/muuli_wdr.cpp:392
+#: src/muuli_wdr.cpp:1578 src/muuli_wdr.cpp:3413 src/Statistics.cpp:829
+msgid "Downloads"
+msgstr "Nedlastingar"
+
+#: src/amuleDlg.cpp:1738 src/muuli_wdr.cpp:3413
 #, fuzzy
 msgid "Downloads Window"
 msgstr "Lastar ned"
 
-#: src/amuleDlg.cpp:1832 src/muuli_wdr.cpp:3443
+#: src/amuleDlg.cpp:1740 src/muuli_wdr.cpp:3287
+msgid "Shared files"
+msgstr "Delte filer"
+
+#: src/amuleDlg.cpp:1744 src/muuli_wdr.cpp:3415
 msgid "Shared Files Window"
 msgstr "Vindauge for delte filer"
 
-#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3444
+#: src/amuleDlg.cpp:1746 src/muuli_wdr.cpp:2919 src/muuli_wdr.cpp:3369
+#: src/muuli_wdr.cpp:3416
+msgid "Messages"
+msgstr "Meldingar"
+
+#: src/amuleDlg.cpp:1750 src/muuli_wdr.cpp:3416
 msgid "Messages Window"
 msgstr "Meldingsvindauge"
 
-#: src/amuleDlg.cpp:1844 src/muuli_wdr.cpp:3445
+#: src/amuleDlg.cpp:1752 src/muuli_wdr.cpp:3417 src/PrefsUnifiedDlg.cpp:312
+#: src/Statistics.cpp:779 src/Statistics.cpp:1235
+msgid "Statistics"
+msgstr "Statistikk"
+
+#: src/amuleDlg.cpp:1756 src/muuli_wdr.cpp:3417
 msgid "Statistics Graph Window"
 msgstr "Statistikkgrafvindauge"
 
-#: src/amuleDlg.cpp:1851 src/muuli_wdr.cpp:3447
+#: src/amuleDlg.cpp:1759 src/muuli_wdr.cpp:3419 src/PrefsUnifiedDlg.cpp:328
+#: src/utils/wxCas/src/wxcasprefs.cpp:39
+msgid "Preferences"
+msgstr "Innstillingar"
+
+#: src/amuleDlg.cpp:1763 src/muuli_wdr.cpp:3419
 msgid "Preferences Settings Window"
 msgstr "Innstillingsvalsvindauge"
 
-#: src/amuleDlg.cpp:1854 src/muuli_wdr.cpp:3448
+#: src/amuleDlg.cpp:1766 src/muuli_wdr.cpp:3420
 msgid "Import"
 msgstr "Importér"
 
-#: src/amuleDlg.cpp:1858 src/muuli_wdr.cpp:3448
+#: src/amuleDlg.cpp:1770 src/muuli_wdr.cpp:3420
 msgid "The partfile importer tool"
 msgstr "Verkty for delfilimport"
 
-#: src/amuleDlg.cpp:1861 src/muuli_wdr.cpp:3449
+#: src/amuleDlg.cpp:1773 src/muuli_wdr.cpp:3421
 #: src/utils/aLinkCreator/src/alcframe.cpp:262
 msgid "About"
 msgstr "Om"
 
-#: src/amuleDlg.cpp:1861 src/muuli_wdr.cpp:3449
+#: src/amuleDlg.cpp:1773 src/muuli_wdr.cpp:3421
 msgid "About/Help"
 msgstr "Om/hjelp"
 
-#: src/amuleDlg.cpp:2059
+#: src/amuleDlg.cpp:1971
 msgid "eD2k network"
 msgstr "ed2k nettverk"
 
-#: src/amuleDlg.cpp:2062
+#: src/amuleDlg.cpp:1974
 msgid "Kad network"
 msgstr "Kad nettverk"
 
-#: src/amuleDlg.cpp:2062
+#: src/amuleDlg.cpp:1974
 msgid "No network"
 msgstr "Ikkje noko nettverk"
 
@@ -961,7 +956,7 @@ msgstr "Fil ikkje funne."
 msgid "The core rejected these shared folders:%s"
 msgstr ""
 
-#: src/amule-remote-gui.cpp:1336 src/ExternalConn.cpp:2346
+#: src/amule-remote-gui.cpp:1336 src/ExternalConn.cpp:2345
 msgid "Invalid link or already on list."
 msgstr "Ikkje gangbar lenkje eller lenka allereie på lista."
 
@@ -977,7 +972,7 @@ msgstr ""
 #: src/ClientDetailDialog.cpp:123 src/DataToText.cpp:61 src/DataToText.cpp:86
 #: src/DataToText.cpp:101 src/DataToText.cpp:136 src/DataToText.cpp:165
 #: src/DownloadListCtrl.cpp:1172 src/DownloadListCtrl.cpp:1185
-#: src/DownloadListCtrl.cpp:1196 src/ExternalConn.cpp:609
+#: src/DownloadListCtrl.cpp:1196 src/ExternalConn.cpp:608
 #: src/FileDetailDialog.cpp:203 src/FileDetailDialog.cpp:235
 #: src/FileDetailDialog.cpp:242 src/GenericClientListCtrl.cpp:1171
 #: src/GenericClientListCtrl.cpp:1182 src/GenericClientListCtrl.cpp:1192
@@ -1364,19 +1359,19 @@ msgstr "Auto·[Hø]"
 msgid "Very low"
 msgstr "Svært låg"
 
-#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:743 src/muuli_wdr.cpp:2303
+#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:743 src/muuli_wdr.cpp:2275
 #: src/ServerListCtrl.cpp:263 src/ServerListCtrl.cpp:456
 #: src/SharedFilesCtrl.cpp:145
 msgid "Low"
 msgstr "Låg"
 
-#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:744 src/muuli_wdr.cpp:2304
+#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:744 src/muuli_wdr.cpp:2276
 #: src/ServerListCtrl.cpp:266 src/ServerListCtrl.cpp:457
 #: src/SharedFilesCtrl.cpp:146
 msgid "Normal"
 msgstr "Vanleg"
 
-#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:745 src/muuli_wdr.cpp:2305
+#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:745 src/muuli_wdr.cpp:2277
 #: src/ServerListCtrl.cpp:269 src/ServerListCtrl.cpp:458
 #: src/SharedFilesCtrl.cpp:147
 msgid "High"
@@ -1468,8 +1463,8 @@ msgstr "Lokal tenar"
 msgid "Remote Server"
 msgstr "Fjern tenar"
 
-#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3202
-#: src/SearchDlg.cpp:119 src/TextClient.cpp:911
+#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3174
+#: src/SearchDlg.cpp:111 src/TextClient.cpp:911
 msgid "Kad"
 msgstr "Kad"
 
@@ -1540,7 +1535,7 @@ msgstr ""
 msgid "Size"
 msgstr "Storleik"
 
-#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3269
+#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3241
 msgid "Transferred"
 msgstr "Overført"
 
@@ -1598,7 +1593,7 @@ msgstr ""
 "Tilbakemelding frå: %s (%s)\n"
 "\n"
 
-#: src/DownloadListCtrl.cpp:746 src/muuli_wdr.cpp:2306
+#: src/DownloadListCtrl.cpp:746 src/muuli_wdr.cpp:2278
 #: src/SharedFilesCtrl.cpp:150
 msgid "Auto"
 msgstr "Automatisk"
@@ -1636,7 +1631,7 @@ msgid "Extended Options"
 msgstr "Utvida innstillingar"
 
 #: src/DownloadListCtrl.cpp:770 src/DownloadListCtrl.cpp:822
-#: src/muuli_wdr.cpp:1790
+#: src/muuli_wdr.cpp:1789
 msgid "Preview"
 msgstr "Førehandssyning"
 
@@ -1809,237 +1804,232 @@ msgstr[1] ""
 msgid "Invalid eD2k link! ERROR: %s"
 msgstr "Ugangbar eD2k lenkje! FEIL: %s"
 
-#: src/ExternalConn.cpp:380
+#: src/ExternalConn.cpp:379
 #, fuzzy
 msgid "Client sent packet after authentication failed."
 msgstr "Godkjenning mislukka."
 
-#: src/ExternalConn.cpp:397
+#: src/ExternalConn.cpp:396
 msgid "External connection closed."
 msgstr "Ekstern kopling lukka."
 
-#: src/ExternalConn.cpp:474
+#: src/ExternalConn.cpp:473
 msgid "External connections disabled due to empty password!"
 msgstr "Eksterne koplingar deaktiverte på grunn av tomt passord!"
 
-#: src/ExternalConn.cpp:495
+#: src/ExternalConn.cpp:494
 msgid "External connections disabled in config file"
 msgstr "Eksterne koplingar deaktiverte i konfigurasjonsfila"
 
-#: src/ExternalConn.cpp:576
+#: src/ExternalConn.cpp:575
 msgid "New external connection accepted"
 msgstr "Ny ekstern kopling akseptert"
 
-#: src/ExternalConn.cpp:579
+#: src/ExternalConn.cpp:578
 msgid "ERROR: couldn't accept a new external connection"
 msgstr "FEIL: greidde ikkje å ta imot ei ny ekstern kopling"
 
-#: src/ExternalConn.cpp:596
+#: src/ExternalConn.cpp:595
 msgid "External connection refused due to empty password in preferences!"
 msgstr "Ekstern kopling nekta på grunn av tomt passord i innstillingar!"
 
-#: src/ExternalConn.cpp:608
+#: src/ExternalConn.cpp:607
 #, c-format
 msgid "Connecting client: %s %s"
 msgstr "Koplar til klient: %s %s"
 
-#: src/ExternalConn.cpp:610
+#: src/ExternalConn.cpp:609
 msgid "Unknown version"
 msgstr "Ukjend utgåve"
 
-#: src/ExternalConn.cpp:623
+#: src/ExternalConn.cpp:622
 msgid "Incorrect EC version ID, there might be binary incompatibility. Use core and remote from same snapshot."
 msgstr "Ikkje rett EC utgåve ID: det kan vere binær inkompatibilitet. Bruk core og remote frå same snapshot."
 
-#: src/ExternalConn.cpp:631
+#: src/ExternalConn.cpp:630
 #, fuzzy
 msgid "You cannot connect to a release version from an arbitrary development snapshot! *sigh* possible crash prevented"
 msgstr "Du kan ikkje kople til ei utgivingsutgåve frå ei vilkårleg SVN utgåve! *sukk* mogleg krasj unngått"
 
-#: src/ExternalConn.cpp:714
+#: src/ExternalConn.cpp:713
 msgid "Invalid protocol version."
 msgstr "Ugyldig protokullutgåve."
 
-#: src/ExternalConn.cpp:720
+#: src/ExternalConn.cpp:719
 msgid "Missing protocol version tag."
 msgstr "Manglande merkelapp for protokollutgåve."
 
-#: src/ExternalConn.cpp:728
+#: src/ExternalConn.cpp:727
 msgid "Authentication failed: invalid hash specified as EC password."
 msgstr ""
 
-#: src/ExternalConn.cpp:776
+#: src/ExternalConn.cpp:775
 #, fuzzy
 msgid "Authentication failed: wrong password."
 msgstr "Godkjenning mislukka."
 
-#: src/ExternalConn.cpp:778
+#: src/ExternalConn.cpp:777
 #, fuzzy
 msgid "Authentication failed: missing password."
 msgstr "Godkjenning mislukka."
 
-#: src/ExternalConn.cpp:789
+#: src/ExternalConn.cpp:788
 #, fuzzy
 msgid "Invalid request, please authenticate first."
 msgstr "Ugyldig etterspurnad, du treng godkjenning først."
 
-#: src/ExternalConn.cpp:794
+#: src/ExternalConn.cpp:793
 msgid "Access granted."
 msgstr "Tilgang innvilga."
 
-#: src/ExternalConn.cpp:802
+#: src/ExternalConn.cpp:801
 #, fuzzy, c-format
 msgid "Sent error message \"%s\" to client."
 msgstr "Filtrér meldingar frå ukjende klientar"
 
-#: src/ExternalConn.cpp:807
+#: src/ExternalConn.cpp:806
 #, fuzzy, c-format
 msgid "Unauthorized access attempt from %s. Connection closed."
 msgstr "Uaotorisert freisting på tilgang. Kopling lukka."
 
-#: src/ExternalConn.cpp:1420
+#: src/ExternalConn.cpp:1419
 #, c-format
 msgid "Remote PartFile command failed: FileHash not found: %s"
 msgstr "Kommando for fjern delfil mislukka: Filhash ikkje funnen: %s"
 
-#: src/ExternalConn.cpp:1424
+#: src/ExternalConn.cpp:1423
 #, c-format
 msgid "FileHash not found: %s"
 msgstr "Filhash ikkje funnen: %s"
 
-#: src/ExternalConn.cpp:1471 src/ExternalConn.cpp:1559
-#: src/ExternalConn.cpp:1680
+#: src/ExternalConn.cpp:1470 src/ExternalConn.cpp:1558
+#: src/ExternalConn.cpp:1679
 msgid "OOPS! OpCode processing error!"
 msgstr "OPS! Handsamingsfeil i OpCode!"
 
-#: src/ExternalConn.cpp:1502
+#: src/ExternalConn.cpp:1501
 msgid "Server not added"
 msgstr "Tenar ikkje lagd til"
 
-#: src/ExternalConn.cpp:1521
+#: src/ExternalConn.cpp:1520
 #, c-format
 msgid "server not found: %s"
 msgstr "tenar ikkje funnen: %s"
 
-#: src/ExternalConn.cpp:1538
+#: src/ExternalConn.cpp:1537
 msgid "need to define server to be removed"
 msgstr "treng å velje tenar for fjerning"
 
-#: src/ExternalConn.cpp:1553
+#: src/ExternalConn.cpp:1552
 msgid "eD2k is disabled in preferences."
 msgstr "eD2k er deaktivert i innstillingar"
 
-#: src/ExternalConn.cpp:1658
+#: src/ExternalConn.cpp:1657
 #, fuzzy
 msgid "Friend not found."
 msgstr "Fil ikkje funne."
 
-#: src/ExternalConn.cpp:1668
+#: src/ExternalConn.cpp:1667
 #, fuzzy
 msgid "Client not found."
 msgstr "Fil ikkje funne."
 
-#: src/ExternalConn.cpp:1674
+#: src/ExternalConn.cpp:1673
 msgid "EC_TAG_FRIEND_SHARED requires EC_TAG_FRIEND or EC_TAG_CLIENT."
 msgstr ""
 
-#: src/ExternalConn.cpp:1992
+#: src/ExternalConn.cpp:1991
 msgid "WebSearch from remote interface makes no sense."
 msgstr "Nettsøk frå fjern adresse gir ikkje meining."
 
-#: src/ExternalConn.cpp:2027
+#: src/ExternalConn.cpp:2026
 msgid "Search in progress. Refetch results in a moment!"
 msgstr "Søk i framdrift. Hentar inn att resultata om ein augneblink!"
 
-#: src/ExternalConn.cpp:2266
+#: src/ExternalConn.cpp:2265
 msgid "No points for graph."
 msgstr "Ingen punkt for graf."
 
-#: src/ExternalConn.cpp:2276
+#: src/ExternalConn.cpp:2275
 msgid "Your client is not configured for this detail level."
 msgstr "Klienten din er ikkje konfigurert for dette detaljnivået."
 
-#: src/ExternalConn.cpp:2303
+#: src/ExternalConn.cpp:2302
 msgid "External Connection: shutdown requested"
 msgstr "Ekstern kopling: avslutting etterspurt"
 
-#: src/ExternalConn.cpp:2315
+#: src/ExternalConn.cpp:2314
 msgid "Already shutting down."
 msgstr "Avsluttar allereie."
 
-#: src/ExternalConn.cpp:2333
+#: src/ExternalConn.cpp:2332
 #, c-format
 msgid "ExternalConn: adding link '%s'."
 msgstr "Eksternkopling: legg til lenkje '%s'."
 
-#: src/ExternalConn.cpp:2351
+#: src/ExternalConn.cpp:2350
 #, fuzzy, c-format
 msgid "%d of %d links failed (invalid or already on list)."
 msgstr "Ikkje gangbar lenkje eller lenka allereie på lista."
 
-#: src/ExternalConn.cpp:2374
+#: src/ExternalConn.cpp:2373
 msgid "Version check throttled; try again shortly."
 msgstr ""
 
-#: src/ExternalConn.cpp:2379
+#: src/ExternalConn.cpp:2378
 msgid "Version check is not available on this daemon."
 msgstr ""
 
-#: src/ExternalConn.cpp:2509
+#: src/ExternalConn.cpp:2508
 msgid "File not found."
 msgstr "Fil ikkje funne."
 
-#: src/ExternalConn.cpp:2514
+#: src/ExternalConn.cpp:2513
 msgid "Invalid file name."
 msgstr "Ikkje gangbart filnamn."
 
-#: src/ExternalConn.cpp:2522
+#: src/ExternalConn.cpp:2521
 msgid "Unable to rename file."
 msgstr "Ikkje i stand til å døype om fila."
 
-#: src/ExternalConn.cpp:2839
-#, c-format
-msgid "Could not save the amuleapi password: %s"
-msgstr ""
-
-#: src/ExternalConn.cpp:3004 src/ExternalConn.cpp:3032
+#: src/ExternalConn.cpp:2992 src/ExternalConn.cpp:3020
 msgid "Kad is disabled in preferences."
 msgstr "Kad er deaktivert i innstillingar."
 
-#: src/ExternalConn.cpp:3045
+#: src/ExternalConn.cpp:3033
 msgid "Already connected to eD2k."
 msgstr "Allereie tilkopla eD2k."
 
-#: src/ExternalConn.cpp:3048
+#: src/ExternalConn.cpp:3036
 msgid "Connecting to eD2k..."
 msgstr "Koplar til eD2k..."
 
-#: src/ExternalConn.cpp:3057
+#: src/ExternalConn.cpp:3045
 msgid "Already connected to Kad."
 msgstr "Allereie tilkopla Kad."
 
-#: src/ExternalConn.cpp:3060
+#: src/ExternalConn.cpp:3048
 msgid "Connecting to Kad..."
 msgstr "Koplar til Kad..."
 
-#: src/ExternalConn.cpp:3067
+#: src/ExternalConn.cpp:3055
 msgid "All networks are disabled."
 msgstr "Alle nettverk er deaktiverte."
 
-#: src/ExternalConn.cpp:3076
+#: src/ExternalConn.cpp:3064
 msgid "Disconnected from eD2k."
 msgstr "Fråkopla eD2k."
 
-#: src/ExternalConn.cpp:3081
+#: src/ExternalConn.cpp:3069
 msgid "Disconnected from Kad."
 msgstr "Fråkopla Kad."
 
-#: src/ExternalConn.cpp:3090
+#: src/ExternalConn.cpp:3078
 #, c-format
 msgid "External Connection: invalid opcode received: %#x"
 msgstr "Ekstern kopling: ugangbar opkode motteken: %#x"
 
-#: src/ExternalConn.cpp:3095
+#: src/ExternalConn.cpp:3083
 msgid "Invalid opcode (wrong protocol version?)"
 msgstr "Ikkje gangbar opkode (feil protokollutgåve?)"
 
@@ -2355,19 +2345,19 @@ msgstr ""
 msgid "eD2k"
 msgstr "eD2k"
 
-#: src/FirstRunWizard.cpp:349 src/muuli_wdr.cpp:1495
+#: src/FirstRunWizard.cpp:349 src/muuli_wdr.cpp:1488
 msgid "Kademlia"
 msgstr "Kademlia"
 
-#: src/FirstRunWizard.cpp:359 src/muuli_wdr.cpp:1423
+#: src/FirstRunWizard.cpp:359 src/muuli_wdr.cpp:1416
 msgid "Standard TCP Port "
 msgstr ""
 
-#: src/FirstRunWizard.cpp:365 src/muuli_wdr.cpp:1435
+#: src/FirstRunWizard.cpp:365 src/muuli_wdr.cpp:1428
 msgid "Extended UDP port (Kad / global search) "
 msgstr ""
 
-#: src/FirstRunWizard.cpp:377 src/muuli_wdr.cpp:1442
+#: src/FirstRunWizard.cpp:377 src/muuli_wdr.cpp:1435
 msgid "Enable UPnP for router port forwarding"
 msgstr ""
 
@@ -2394,7 +2384,7 @@ msgstr ""
 msgid "Your peer lists are already in place - nothing to download."
 msgstr "Du freistar allereie nedlasting av fila %s"
 
-#: src/FirstRunWizard.cpp:434 src/muuli_wdr.cpp:1540
+#: src/FirstRunWizard.cpp:434 src/muuli_wdr.cpp:1533
 msgid "Auto-update server list at startup"
 msgstr "Automatisk oppdatering av tenarlista ved oppstart"
 
@@ -2440,23 +2430,23 @@ msgid ""
 "want downloads on a different (e.g. larger) disk."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:549 src/FirstRunWizard.cpp:611 src/muuli_wdr.cpp:1702
+#: src/FirstRunWizard.cpp:549 src/FirstRunWizard.cpp:611 src/muuli_wdr.cpp:1701
 msgid "Destination folder for downloads"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:553 src/FirstRunWizard.cpp:569 src/muuli_wdr.cpp:1349
-#: src/muuli_wdr.cpp:1366 src/muuli_wdr.cpp:1677 src/muuli_wdr.cpp:1708
-#: src/muuli_wdr.cpp:1720 src/muuli_wdr.cpp:2790
+#: src/FirstRunWizard.cpp:553 src/FirstRunWizard.cpp:569 src/muuli_wdr.cpp:1342
+#: src/muuli_wdr.cpp:1359 src/muuli_wdr.cpp:1676 src/muuli_wdr.cpp:1707
+#: src/muuli_wdr.cpp:1719 src/muuli_wdr.cpp:2762
 #: src/utils/aLinkCreator/src/alcframe.cpp:135
 #: src/utils/wxCas/src/wxcasprefs.cpp:52 src/utils/wxCas/src/wxcasprefs.cpp:118
 msgid "Browse"
 msgstr "Bla"
 
-#: src/FirstRunWizard.cpp:559 src/muuli_wdr.cpp:1713
+#: src/FirstRunWizard.cpp:559 src/muuli_wdr.cpp:1712
 msgid "(All files in this folder are shared with other peers)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:565 src/FirstRunWizard.cpp:624 src/muuli_wdr.cpp:1715
+#: src/FirstRunWizard.cpp:565 src/FirstRunWizard.cpp:624 src/muuli_wdr.cpp:1714
 msgid "Folder for temporary download files"
 msgstr ""
 
@@ -2487,7 +2477,7 @@ msgstr "Greidde ikkje å opne venelista 'enfriends.met' for skriving!"
 msgid "CRITICAL - no client on StartChatSession"
 msgstr ""
 
-#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2696 src/muuli_wdr.cpp:3373
+#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2668 src/muuli_wdr.cpp:3345
 msgid "Friends"
 msgstr "Vener"
 
@@ -2601,8 +2591,8 @@ msgstr "Ingen"
 msgid "No"
 msgstr "Nei"
 
-#: src/GenericClientListCtrl.cpp:1216 src/PrefsUnifiedDlg.cpp:2898
-#: src/PrefsUnifiedDlg.cpp:2948 src/ServerListCtrl.cpp:276
+#: src/GenericClientListCtrl.cpp:1216 src/PrefsUnifiedDlg.cpp:2818
+#: src/PrefsUnifiedDlg.cpp:2868 src/ServerListCtrl.cpp:276
 msgid "Yes"
 msgstr "Ja"
 
@@ -2772,10 +2762,10 @@ msgstr "Ikkje gangbar port for eigenoppstart"
 msgid "Please fill all fields required"
 msgstr "Vér god å fylle ut alle naudsynte felt"
 
-#: src/KadDlg.cpp:192 src/PartFile.cpp:1031 src/PrefsUnifiedDlg.cpp:1134
-#: src/PrefsUnifiedDlg.cpp:1204 src/PrefsUnifiedDlg.cpp:1405
-#: src/PrefsUnifiedDlg.cpp:1663 src/PrefsUnifiedDlg.cpp:1673
-#: src/PrefsUnifiedDlg.cpp:1690 src/PrefsUnifiedDlg.cpp:1738
+#: src/KadDlg.cpp:192 src/PartFile.cpp:1031 src/PrefsUnifiedDlg.cpp:1162
+#: src/PrefsUnifiedDlg.cpp:1331 src/PrefsUnifiedDlg.cpp:1589
+#: src/PrefsUnifiedDlg.cpp:1599 src/PrefsUnifiedDlg.cpp:1616
+#: src/PrefsUnifiedDlg.cpp:1658
 msgid "Message"
 msgstr "Melding"
 
@@ -2877,7 +2867,7 @@ msgstr "Delingsrate"
 msgid "Uploaded"
 msgstr "Lasta opp"
 
-#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3253
+#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3225
 msgid "Requested"
 msgstr "Etterspurt"
 
@@ -3003,7 +2993,7 @@ msgid "WARNING: "
 msgstr "ÅTVARING: "
 
 #: src/MuleNotebook.cpp:179 src/muuli_wdr.cpp:817 src/muuli_wdr.cpp:1229
-#: src/muuli_wdr.cpp:3157 src/muuli_wdr.cpp:3413
+#: src/muuli_wdr.cpp:3129 src/muuli_wdr.cpp:3385
 msgid "Close"
 msgstr "Stengje"
 
@@ -3016,12 +3006,12 @@ msgstr "Klipp ut"
 msgid "Copy"
 msgstr "Kopiér"
 
-#: src/MuleTextCtrl.cpp:88 src/SearchDlg.cpp:261
+#: src/MuleTextCtrl.cpp:88
 msgid "Paste"
 msgstr "Lim inn"
 
 #: src/MuleTextCtrl.cpp:89 src/muuli_wdr.cpp:358 src/muuli_wdr.cpp:757
-#: src/muuli_wdr.cpp:2380 src/muuli_wdr.cpp:2399 src/muuli_wdr.cpp:2421
+#: src/muuli_wdr.cpp:2352 src/muuli_wdr.cpp:2371 src/muuli_wdr.cpp:2393
 #: src/utils/aLinkCreator/src/alcframe.cpp:142
 msgid "Clear"
 msgstr "Frigjer plass"
@@ -3119,8 +3109,8 @@ msgid "Exit"
 msgstr "Avslutt"
 
 #: src/MuleTrayIcon.cpp:579 src/MuleTrayIcon.cpp:945 src/MuleTrayIcon.cpp:965
-#: src/muuli_wdr.cpp:1398 src/muuli_wdr.cpp:1406 src/muuli_wdr.cpp:1413
-#: src/muuli_wdr.cpp:1836 src/muuli_wdr.cpp:1842 src/OtherFunctions.cpp:91
+#: src/muuli_wdr.cpp:1391 src/muuli_wdr.cpp:1399 src/muuli_wdr.cpp:1406
+#: src/muuli_wdr.cpp:1835 src/muuli_wdr.cpp:1841 src/OtherFunctions.cpp:91
 #: src/StatisticsDlg.cpp:93 src/StatisticsDlg.cpp:95
 msgid "kB/s"
 msgstr "kB/s"
@@ -3291,7 +3281,7 @@ msgstr "Namn:"
 msgid "Type"
 msgstr "Sort"
 
-#: src/muuli_wdr.cpp:215 src/SearchDlg.cpp:118 src/SearchListCtrl.cpp:853
+#: src/muuli_wdr.cpp:215 src/SearchDlg.cpp:110 src/SearchListCtrl.cpp:853
 msgid "Local"
 msgstr "Lokal"
 
@@ -3362,7 +3352,7 @@ msgstr "Bytes"
 msgid "KB"
 msgstr "KB"
 
-#: src/muuli_wdr.cpp:274 src/muuli_wdr.cpp:293 src/muuli_wdr.cpp:1621
+#: src/muuli_wdr.cpp:274 src/muuli_wdr.cpp:293 src/muuli_wdr.cpp:1620
 #: src/OtherFunctions.cpp:64
 msgid "MB"
 msgstr "MB"
@@ -3379,7 +3369,7 @@ msgstr "Maks storleik"
 msgid "Availability"
 msgstr "Tilgjenge"
 
-#: src/muuli_wdr.cpp:312 src/muuli_wdr.cpp:398 src/muuli_wdr.cpp:3318
+#: src/muuli_wdr.cpp:312 src/muuli_wdr.cpp:398 src/muuli_wdr.cpp:3290
 msgid "Filter:"
 msgstr "Filter:"
 
@@ -3411,7 +3401,7 @@ msgstr ""
 msgid "Stop"
 msgstr "Stopp"
 
-#: src/muuli_wdr.cpp:348 src/muuli_wdr.cpp:1392 src/SearchListCtrl.cpp:732
+#: src/muuli_wdr.cpp:348 src/muuli_wdr.cpp:1385 src/SearchListCtrl.cpp:732
 msgid "Download"
 msgstr "Nedlasting"
 
@@ -3443,12 +3433,12 @@ msgstr "Komplette kjelder"
 #: src/muuli_wdr.cpp:1160 src/muuli_wdr.cpp:1167 src/muuli_wdr.cpp:1172
 #: src/muuli_wdr.cpp:1179 src/muuli_wdr.cpp:1184 src/muuli_wdr.cpp:1191
 #: src/muuli_wdr.cpp:1205 src/muuli_wdr.cpp:1212 src/muuli_wdr.cpp:1217
-#: src/muuli_wdr.cpp:1224 src/muuli_wdr.cpp:3255 src/muuli_wdr.cpp:3263
-#: src/muuli_wdr.cpp:3271
+#: src/muuli_wdr.cpp:1224 src/muuli_wdr.cpp:3227 src/muuli_wdr.cpp:3235
+#: src/muuli_wdr.cpp:3243
 msgid "N/A"
 msgstr "I/T"
 
-#: src/muuli_wdr.cpp:508 src/muuli_wdr.cpp:1065 src/PrefsUnifiedDlg.cpp:299
+#: src/muuli_wdr.cpp:508 src/muuli_wdr.cpp:1065 src/PrefsUnifiedDlg.cpp:297
 msgid "General"
 msgstr "Generelt"
 
@@ -3589,7 +3579,7 @@ msgstr ""
 msgid "Album :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:685 src/muuli_wdr.cpp:2275
+#: src/muuli_wdr.cpp:685 src/muuli_wdr.cpp:2247
 msgid "Title :"
 msgstr "Tittel :"
 
@@ -3696,7 +3686,7 @@ msgstr "Brukarnamn :"
 msgid "Userhash :"
 msgstr "Brukarhash :"
 
-#: src/muuli_wdr.cpp:895 src/muuli_wdr.cpp:1742 src/muuli_wdr.cpp:2470
+#: src/muuli_wdr.cpp:895 src/muuli_wdr.cpp:1741 src/muuli_wdr.cpp:2442
 #: src/utils/aLinkCreator/src/alcframe.cpp:137
 msgid "Add"
 msgstr "Legg til"
@@ -3705,15 +3695,15 @@ msgstr "Legg til"
 msgid "Download-Speed"
 msgstr "Nedlastingsfart"
 
-#: src/muuli_wdr.cpp:954 src/muuli_wdr.cpp:989 src/muuli_wdr.cpp:2574
+#: src/muuli_wdr.cpp:954 src/muuli_wdr.cpp:989 src/muuli_wdr.cpp:2546
 msgid "Current"
 msgstr "Novérande"
 
-#: src/muuli_wdr.cpp:962 src/muuli_wdr.cpp:997 src/muuli_wdr.cpp:2582
+#: src/muuli_wdr.cpp:962 src/muuli_wdr.cpp:997 src/muuli_wdr.cpp:2554
 msgid "Running average"
 msgstr "Køyregjennomsnitt"
 
-#: src/muuli_wdr.cpp:970 src/muuli_wdr.cpp:1005 src/muuli_wdr.cpp:2590
+#: src/muuli_wdr.cpp:970 src/muuli_wdr.cpp:1005 src/muuli_wdr.cpp:2562
 msgid "Session average"
 msgstr "Gjennomsnitt økt"
 
@@ -3725,7 +3715,7 @@ msgstr "Opplastingsfart"
 msgid "Connections"
 msgstr "Koplingar"
 
-#: src/muuli_wdr.cpp:1024 src/muuli_wdr.cpp:1861
+#: src/muuli_wdr.cpp:1024 src/muuli_wdr.cpp:1860
 msgid "Active downloads"
 msgstr "Aktive nedlastingar"
 
@@ -3733,7 +3723,7 @@ msgstr "Aktive nedlastingar"
 msgid "Active connections (1:1)"
 msgstr "Aktive koplingar (1:1)"
 
-#: src/muuli_wdr.cpp:1040 src/muuli_wdr.cpp:1862
+#: src/muuli_wdr.cpp:1040 src/muuli_wdr.cpp:1861
 msgid "Active uploads"
 msgstr "Aktive opplastingar"
 
@@ -3850,8 +3840,8 @@ msgstr "Dette er namnet andre brukarar vil sjå når dei koplar til  maskina di.
 msgid "Language: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1257 src/muuli_wdr.cpp:1330 src/muuli_wdr.cpp:1334
-#: src/muuli_wdr.cpp:1337
+#: src/muuli_wdr.cpp:1257 src/muuli_wdr.cpp:1323 src/muuli_wdr.cpp:1327
+#: src/muuli_wdr.cpp:1330
 msgid "The delay before showing tool-tips."
 msgstr "Forseinkinga før ein syner verktytips."
 
@@ -3929,962 +3919,938 @@ msgstr ""
 msgid "Enabling this will make aMule to show notifications when finished downloading."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1323
-#, fuzzy
-msgid "Remember search history"
-msgstr "Hugs desse innstillingane"
-
-#: src/muuli_wdr.cpp:1324
-msgid "Keeps a dropdown list of your past search terms in the Search tab's Name field. This remembers the queries you typed, not the results they returned."
-msgstr ""
-
-#: src/muuli_wdr.cpp:1329
+#: src/muuli_wdr.cpp:1322
 msgid "Tooltip delay time: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1336
+#: src/muuli_wdr.cpp:1329
 msgid "seconds"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1340
+#: src/muuli_wdr.cpp:1333
 msgid "Browser Selection"
 msgstr "Nettlesarval"
 
-#: src/muuli_wdr.cpp:1346
+#: src/muuli_wdr.cpp:1339
 msgid "Enter your browser name here. Leave this field empty to use the system default browser."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1353
+#: src/muuli_wdr.cpp:1346
 msgid "Open in new tab if possible"
 msgstr "Opne nytt faneblad dersom mogleg"
 
-#: src/muuli_wdr.cpp:1355
+#: src/muuli_wdr.cpp:1348
 msgid "Open the web page in a new tab instead of in a new window when possible"
 msgstr "Opne ny nettside i nytt faneblad i staden for nytt vindauge når mogleg"
 
-#: src/muuli_wdr.cpp:1359
+#: src/muuli_wdr.cpp:1352
 msgid "Video Player"
 msgstr "Videospelar"
 
-#: src/muuli_wdr.cpp:1386
+#: src/muuli_wdr.cpp:1379
 msgid "Bandwidth limits"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1400
+#: src/muuli_wdr.cpp:1393
 msgid "Upload"
 msgstr "Opplasting"
 
-#: src/muuli_wdr.cpp:1408
+#: src/muuli_wdr.cpp:1401
 msgid "Slot Allocation"
 msgstr "Opningsdistribusjon"
 
-#: src/muuli_wdr.cpp:1417
+#: src/muuli_wdr.cpp:1410
 msgid "Ports"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1427
+#: src/muuli_wdr.cpp:1420
 msgid "This is the standard eD2k port and cannot be disabled."
 msgstr "Dette er standardporten for eD2k og kan ikkje deaktiverast"
 
-#: src/muuli_wdr.cpp:1430
+#: src/muuli_wdr.cpp:1423
 msgid "UDP port for server requests (TCP+3):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1432
+#: src/muuli_wdr.cpp:1425
 msgid "4665"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1439
+#: src/muuli_wdr.cpp:1432
 msgid "This UDP port is used for extended eD2k requests and Kad network"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1446
+#: src/muuli_wdr.cpp:1439
 msgid "UPnP TCP Port (Optional):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1456
+#: src/muuli_wdr.cpp:1449
 msgid "Bind local address to IP (empty for any):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1459
+#: src/muuli_wdr.cpp:1452
 msgid "Advanced users only: If you have multiple network interfaces, enter the address of the interface to which aMule should be bound."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1462 src/muuli_wdr.cpp:2055
+#: src/muuli_wdr.cpp:1455 src/muuli_wdr.cpp:2054
 msgid "Bind to network interface (empty for any):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1475
+#: src/muuli_wdr.cpp:1468
 msgid "Advanced users only: pin all of aMule's traffic to one network interface, chosen from the list or typed in by name (e.g. tun0, eth0, en0) or index. Unlike binding to an IP, this stops traffic leaking out via the default route - useful with a VPN. Requires no elevated privileges."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1481
+#: src/muuli_wdr.cpp:1474
 msgid "Max sources per downloading file:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1485
+#: src/muuli_wdr.cpp:1478
 msgid "Max simultaneous connections:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1498 src/muuli_wdr.cpp:3197
+#: src/muuli_wdr.cpp:1491 src/muuli_wdr.cpp:3169
 msgid "ED2K"
 msgstr "ED2k"
 
-#: src/muuli_wdr.cpp:1505
+#: src/muuli_wdr.cpp:1498
 msgid "Autoconnect on startup"
 msgstr "Automatisk tilkopling ved oppstart"
 
-#: src/muuli_wdr.cpp:1508
+#: src/muuli_wdr.cpp:1501
 msgid "Reconnect on loss"
 msgstr "Kople til dersom fråkopla"
 
-#: src/muuli_wdr.cpp:1530
+#: src/muuli_wdr.cpp:1523
 msgid "Remove dead server after"
 msgstr "Ta bort daude tenarar etter"
 
-#: src/muuli_wdr.cpp:1531
+#: src/muuli_wdr.cpp:1524
 msgid "Static servers are never removed, even when unreachable."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1535
+#: src/muuli_wdr.cpp:1528
 msgid "retries"
 msgstr "freistnader"
 
-#: src/muuli_wdr.cpp:1543
+#: src/muuli_wdr.cpp:1536
 msgid "List"
 msgstr "Liste"
 
-#: src/muuli_wdr.cpp:1546
+#: src/muuli_wdr.cpp:1539
 msgid "Update server list when connecting to a server"
 msgstr "Oppdater tenarlista ved oppkopling til ein tenar"
 
-#: src/muuli_wdr.cpp:1549
+#: src/muuli_wdr.cpp:1542
 msgid "Update server list when a client connects"
 msgstr "Oppdater tenarlista når ein klient koplar til"
 
-#: src/muuli_wdr.cpp:1552
+#: src/muuli_wdr.cpp:1545
 msgid "Use priority system"
 msgstr "Bruk prioritetssystem"
 
-#: src/muuli_wdr.cpp:1556
+#: src/muuli_wdr.cpp:1549
 msgid "Use smart LowID check on connect"
 msgstr "Bruk smart LågID sjekk ved tilkopling"
 
-#: src/muuli_wdr.cpp:1560
+#: src/muuli_wdr.cpp:1553
 msgid "Safe connect"
 msgstr "Trygg tilkopling"
 
-#: src/muuli_wdr.cpp:1564
+#: src/muuli_wdr.cpp:1557
 msgid "Autoconnect to servers in static list only"
 msgstr "Automatisk tilkopling berre til tenarar i statisk liste"
 
-#: src/muuli_wdr.cpp:1567
+#: src/muuli_wdr.cpp:1560
 msgid "Set manually added servers to High Priority"
 msgstr "Gje høg prioritet til manuelt tillagde tenarar"
 
-#: src/muuli_wdr.cpp:1588
+#: src/muuli_wdr.cpp:1581
 msgid "Add files to download in pause mode"
 msgstr "Legg filer til nedlasting i pausemodus"
 
-#: src/muuli_wdr.cpp:1590
+#: src/muuli_wdr.cpp:1583
 msgid "Add files to download with auto priority"
 msgstr "Legg filer til nedlasting med autoprioritet"
 
-#: src/muuli_wdr.cpp:1593
+#: src/muuli_wdr.cpp:1586
 msgid "Try to download first and last chunks first"
 msgstr "Prøv å laste ned første og siste del først"
 
-#: src/muuli_wdr.cpp:1597
+#: src/muuli_wdr.cpp:1590
 msgid "Endgame mode: rotate to faster sources for the final blocks"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1600
+#: src/muuli_wdr.cpp:1593
 msgid "Start next paused file when a file completes"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1603
+#: src/muuli_wdr.cpp:1596
 msgid "From the same category"
 msgstr "Frå same kategori"
 
-#: src/muuli_wdr.cpp:1605
+#: src/muuli_wdr.cpp:1598
 msgid "In alphabetic order"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1607
+#: src/muuli_wdr.cpp:1600
 msgid "Preallocate disk space for new files"
 msgstr "Hent diskplass for nye filer"
 
-#: src/muuli_wdr.cpp:1608
+#: src/muuli_wdr.cpp:1601
 msgid "For new files preallocates disk space for the whole file, thus reduces fragmentation"
 msgstr "Hentar diskplass for heile nye filer, og reduserer fragmentering"
 
-#: src/muuli_wdr.cpp:1613
+#: src/muuli_wdr.cpp:1606
+msgid "Create new files as sparse files"
+msgstr ""
+
+#: src/muuli_wdr.cpp:1607
+msgid "A sparse file reserves its full size on disk immediately without writing real data to it -- fast, but unsupported or slow on some filesystems, and free-space accounting stays optimistic while the download is in progress. Turn this off to grow the file only as data arrives."
+msgstr ""
+
+#: src/muuli_wdr.cpp:1612
 msgid "Stop downloads when free disk space reaches "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1614
+#: src/muuli_wdr.cpp:1613
 msgid "Select this if you want aMule to check your disk space"
 msgstr "Vel denne dersom du vil at aMule skal sjekke om du har nok diskplass"
 
-#: src/muuli_wdr.cpp:1618
+#: src/muuli_wdr.cpp:1617
 msgid "Enter here the min disk space desired."
 msgstr "Skriv inn mimimum ønska diskplass."
 
-#: src/muuli_wdr.cpp:1624
+#: src/muuli_wdr.cpp:1623
 msgid "Save 10 sources on rare files (< 20 sources)"
 msgstr "Lagre 10 kjelder til sjeldne filer (< 20 kjelder)"
 
-#: src/muuli_wdr.cpp:1628 src/Statistics.cpp:790
+#: src/muuli_wdr.cpp:1627 src/Statistics.cpp:790
 msgid "Uploads"
 msgstr "Opplastingar"
 
-#: src/muuli_wdr.cpp:1631
+#: src/muuli_wdr.cpp:1630
 msgid "Add new shared files with auto priority"
 msgstr "Legg til nye delte filer med autoprioritet"
 
-#: src/muuli_wdr.cpp:1637
+#: src/muuli_wdr.cpp:1636
 msgid "Intelligent Corruption Handling (I.C.H.)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1640
+#: src/muuli_wdr.cpp:1639
 msgid "Enable"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1643
+#: src/muuli_wdr.cpp:1642
 msgid "Advanced I.C.H. trusts every hash (not recommended)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1655 src/PrefsUnifiedDlg.cpp:1990
+#: src/muuli_wdr.cpp:1654 src/PrefsUnifiedDlg.cpp:1910
 msgid "Media metadata extraction"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1659
+#: src/muuli_wdr.cpp:1658
 msgid "Extract length / bitrate / codec from shared audio and video files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1661
+#: src/muuli_wdr.cpp:1660
 msgid "When enabled, aMule runs ffprobe on each shared media file to fill in the Length / Bitrate / Codec columns other clients see when they find the file in a search. Requires ffmpeg (the ffprobe binary) to be installed."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1668
+#: src/muuli_wdr.cpp:1667
 msgid "Path to ffprobe:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1673
+#: src/muuli_wdr.cpp:1672
 msgid "Full path to the ffprobe binary. Leave empty to have aMule auto-detect it on startup."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1681
+#: src/muuli_wdr.cpp:1680
 msgid "Detect"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1682
+#: src/muuli_wdr.cpp:1681
 msgid "Search the standard install locations for an ffprobe binary and fill the path field."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1706
+#: src/muuli_wdr.cpp:1705
 msgid ""
 "Completed downloads are stored here. All files in this folder are automatically shared with other peers.\n"
 "If this folder also holds files you don't want to share, point it at an aMule-only sub-folder."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1709
+#: src/muuli_wdr.cpp:1708
 msgid "Pick the folder where completed downloads will be stored. All files in that folder will be shared with other peers."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1723
+#: src/muuli_wdr.cpp:1722
 msgid "Shared folders"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1729
+#: src/muuli_wdr.cpp:1728
 msgid "(Folders shared by the core. Enter a path to add one.)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1737
+#: src/muuli_wdr.cpp:1736
 msgid "Absolute path of a folder on the core's machine, e.g. /home/user/shared"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1739 src/PrefsUnifiedDlg.cpp:2874
+#: src/muuli_wdr.cpp:1738 src/PrefsUnifiedDlg.cpp:2794
 msgid "Recursive"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1740
+#: src/muuli_wdr.cpp:1739
 msgid "Share every sub-folder underneath this one, including ones created later."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1744 src/utils/aLinkCreator/src/alcframe.cpp:141
+#: src/muuli_wdr.cpp:1743 src/utils/aLinkCreator/src/alcframe.cpp:141
 msgid "Remove"
 msgstr "Ta bort"
 
-#: src/muuli_wdr.cpp:1748
+#: src/muuli_wdr.cpp:1747
 msgid "(Right click on folder icon for recursive share)"
 msgstr "(Høgreklikk på mappeikonet for å dele underkatalogar)"
 
-#: src/muuli_wdr.cpp:1755
+#: src/muuli_wdr.cpp:1754
 msgid "Share hidden files"
 msgstr "Dele gøymde filer"
 
-#: src/muuli_wdr.cpp:1761
+#: src/muuli_wdr.cpp:1760
 msgid "Automatically rescan shared folders for changes"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1767
+#: src/muuli_wdr.cpp:1766
 msgid "Follow symbolic links in shared folders"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1773
+#: src/muuli_wdr.cpp:1772
 msgid "Exclude files matching:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1776
+#: src/muuli_wdr.cpp:1775
 msgid "Wildcard patterns separated by '|', e.g. .DS_Store|Thumbs.db|*.tmp. Files whose name matches are not shared. Matching is case-insensitive."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1780
+#: src/muuli_wdr.cpp:1779
 msgid "Patterns are regular expressions"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1781
+#: src/muuli_wdr.cpp:1780
 msgid "When set, the whole field is one regular expression ('|' is alternation). When unset, it is a list of '|'-separated wildcards."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1791
+#: src/muuli_wdr.cpp:1790
 msgid "Show how many shared files the current pattern would exclude."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1812
+#: src/muuli_wdr.cpp:1811
 msgid "Graphs"
 msgstr "Grafar"
 
-#: src/muuli_wdr.cpp:1815 src/muuli_wdr.cpp:1877
+#: src/muuli_wdr.cpp:1814 src/muuli_wdr.cpp:1876
 msgid "Update delay : 5 secs"
 msgstr "Oppdateringsforseinking: 5 sek"
 
-#: src/muuli_wdr.cpp:1819
+#: src/muuli_wdr.cpp:1818
 msgid "Time for average graph: 100 mins"
 msgstr "Tid for gjennomsnittleg graf: 100 min"
 
-#: src/muuli_wdr.cpp:1823
+#: src/muuli_wdr.cpp:1822
 msgid "Connections Graph Scale: 100 "
 msgstr "Koplingsgrafskala: 100 "
 
-#: src/muuli_wdr.cpp:1830
+#: src/muuli_wdr.cpp:1829
 msgid "Download graph scale:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1838
+#: src/muuli_wdr.cpp:1837
 msgid "Upload graph scale:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1848
+#: src/muuli_wdr.cpp:1847
 msgid "Colors: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1852
+#: src/muuli_wdr.cpp:1851
 msgid "Background"
 msgstr "Bakgrunn"
 
-#: src/muuli_wdr.cpp:1853
+#: src/muuli_wdr.cpp:1852
 msgid "Grid"
 msgstr "Rutenett"
 
-#: src/muuli_wdr.cpp:1854
+#: src/muuli_wdr.cpp:1853
 msgid "Download current"
 msgstr "Last ned novérande"
 
-#: src/muuli_wdr.cpp:1855
+#: src/muuli_wdr.cpp:1854
 msgid "Download running average"
 msgstr "Last ned køyregjennomsnitt"
 
-#: src/muuli_wdr.cpp:1856
+#: src/muuli_wdr.cpp:1855
 msgid "Download session average"
 msgstr "Last ned øktgjennomsnitt"
 
-#: src/muuli_wdr.cpp:1857
+#: src/muuli_wdr.cpp:1856
 msgid "Upload current"
 msgstr "Opplasting no"
 
-#: src/muuli_wdr.cpp:1858
+#: src/muuli_wdr.cpp:1857
 msgid "Upload running average"
 msgstr "Gjennomsnittleg køyrande opplasting"
 
-#: src/muuli_wdr.cpp:1859
+#: src/muuli_wdr.cpp:1858
 msgid "Upload session average"
 msgstr "Gjennomsnittleg økt opplasting"
 
-#: src/muuli_wdr.cpp:1860
+#: src/muuli_wdr.cpp:1859
 msgid "Active connections"
 msgstr "Aktive koplingar"
 
-#: src/muuli_wdr.cpp:1863
+#: src/muuli_wdr.cpp:1862
 #, fuzzy
 msgid "Systray Icon Speed Bar"
 msgstr "Fartslinje i ikontrauet"
 
-#: src/muuli_wdr.cpp:1864
+#: src/muuli_wdr.cpp:1863
 msgid "Kad-nodes current"
 msgstr "Kadnodar no"
 
-#: src/muuli_wdr.cpp:1865
+#: src/muuli_wdr.cpp:1864
 msgid "Kad-nodes running"
 msgstr "Køyrande kadnodar"
 
-#: src/muuli_wdr.cpp:1866
+#: src/muuli_wdr.cpp:1865
 msgid "Kad-nodes session"
 msgstr "Kadnodar (økt)"
 
-#: src/muuli_wdr.cpp:1870 src/muuli_wdr.cpp:2324
+#: src/muuli_wdr.cpp:1869 src/muuli_wdr.cpp:2296
 msgid "Select"
 msgstr "Velje"
 
-#: src/muuli_wdr.cpp:1874
+#: src/muuli_wdr.cpp:1873
 msgid "Tree"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1884
+#: src/muuli_wdr.cpp:1883
 msgid "Number of Client Versions shown (0=unlimited)"
 msgstr "Tal på klienutgåver synt (0=uinnskrenka)"
 
-#: src/muuli_wdr.cpp:1909
+#: src/muuli_wdr.cpp:1908
 msgid "!!! WARNING !!!"
 msgstr "!!! ÅTVARING !!!"
 
-#: src/muuli_wdr.cpp:1924
+#: src/muuli_wdr.cpp:1923
 msgid "Max new connections / 5 secs"
 msgstr "Maks nye koplingar / 5 sek"
 
-#: src/muuli_wdr.cpp:1926
+#: src/muuli_wdr.cpp:1925
 msgid "Concurrent Kad source lookups"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1928
+#: src/muuli_wdr.cpp:1927
 #, fuzzy
 msgid "Kad source re-search interval (minutes)"
 msgstr "FTP oppdateringsintervall i minutt"
 
-#: src/muuli_wdr.cpp:1930
+#: src/muuli_wdr.cpp:1929
 #, fuzzy
 msgid "Source re-ask interval (minutes)"
 msgstr "FTP oppdateringsintervall i minutt"
 
-#: src/muuli_wdr.cpp:1934
+#: src/muuli_wdr.cpp:1933
 msgid "File Buffer Size: 240000 bytes"
 msgstr "Filbufferstorleik: 240000·bytes"
 
-#: src/muuli_wdr.cpp:1938
+#: src/muuli_wdr.cpp:1937
 msgid "Use MMAP: memory-mapped file access (lower memory use)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1939
+#: src/muuli_wdr.cpp:1938
 msgid "Maps part files into memory instead of buffering them on the heap, lowering the process memory footprint. May reduce download speed on some disks; best for memory-constrained or upload-heavy hosts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1941
+#: src/muuli_wdr.cpp:1940
 msgid "Upload Queue Size: 5000 clients"
 msgstr "Storleik på opplastingskø: 5000 klientar"
 
-#: src/muuli_wdr.cpp:1945
+#: src/muuli_wdr.cpp:1944
 msgid "Server connection refresh interval: Disable"
 msgstr "Oppfriskingsintervall for tenarkopling: Deaktiver"
 
-#: src/muuli_wdr.cpp:1949
+#: src/muuli_wdr.cpp:1948
 msgid "Disable computer's timed standby mode"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1968
+#: src/muuli_wdr.cpp:1967
 msgid "Skin to use: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1977
+#: src/muuli_wdr.cpp:1976
 msgid "Show \"Fast eD2k Links Handler\" in every window."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1980
+#: src/muuli_wdr.cpp:1979
 msgid "Show extended info on categories tabs"
 msgstr "Syne utvida informasjon i kategorifaneblad"
 
-#: src/muuli_wdr.cpp:1983
+#: src/muuli_wdr.cpp:1982
 #, fuzzy
 msgid "Show application version on title"
 msgstr "Syne overføringsfart i tittellinja"
 
-#: src/muuli_wdr.cpp:1985
+#: src/muuli_wdr.cpp:1984
 msgid "Show transfer rates on title"
 msgstr "Syne overføringsfart i tittellinja"
 
-#: src/muuli_wdr.cpp:1987
+#: src/muuli_wdr.cpp:1986
 msgid "Before application name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1989
+#: src/muuli_wdr.cpp:1988
 msgid "After application name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1992
+#: src/muuli_wdr.cpp:1991
 msgid "Show overhead bandwidth"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1996
+#: src/muuli_wdr.cpp:1995
 msgid "Vertical toolbar orientation"
 msgstr "Vertikal verktylinjeorientering"
 
-#: src/muuli_wdr.cpp:1998
+#: src/muuli_wdr.cpp:1997
 msgid "Live column sorting (auto-reorder rows as their values change)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2005
+#: src/muuli_wdr.cpp:2004
 msgid "Download Queue Files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2008
+#: src/muuli_wdr.cpp:2007
 msgid "Show progress percentage"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2014
+#: src/muuli_wdr.cpp:2013
 msgid "Show progress bar"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2017
+#: src/muuli_wdr.cpp:2016
 msgid "Flat"
 msgstr "Flat"
 
-#: src/muuli_wdr.cpp:2021
+#: src/muuli_wdr.cpp:2020
 msgid "Round"
 msgstr "Rund"
 
-#: src/muuli_wdr.cpp:2039
+#: src/muuli_wdr.cpp:2038
 msgid "External Connection Parameters"
 msgstr "Parameter for ekstern kopling"
 
-#: src/muuli_wdr.cpp:2042
+#: src/muuli_wdr.cpp:2041
 msgid "Accept external connections"
 msgstr "Akseptér eksterne koplingar"
 
-#: src/muuli_wdr.cpp:2049 src/muuli_wdr.cpp:2108
+#: src/muuli_wdr.cpp:2048 src/muuli_wdr.cpp:2107
 msgid "IP of the listening interface:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2052
+#: src/muuli_wdr.cpp:2051
 msgid "Enter here a valid ip in the a.b.c.d format for the listening EC interface. An empty field or 0.0.0.0 will mean any interface."
 msgstr "Skriv in ei gyldig IP i a.b.c.d format for det lyttande EC-grensesnittet. Eit tomt felt eller 0.0.0.0 betyr samtlege grensesnitt."
 
-#: src/muuli_wdr.cpp:2073 src/muuli_wdr.cpp:2184
+#: src/muuli_wdr.cpp:2072 src/muuli_wdr.cpp:2156
 msgid "TCP port:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2079
+#: src/muuli_wdr.cpp:2078
 msgid "Enable UPnP port forwarding on the EC port"
 msgstr "Aktivér UPnP-portvidaresending på EC-porten"
 
-#: src/muuli_wdr.cpp:2083 src/muuli_wdr.cpp:3069
+#: src/muuli_wdr.cpp:2082 src/muuli_wdr.cpp:3041
 #: src/utils/wxCas/src/wxcasprefs.cpp:167
 msgid "Password"
 msgstr "Passord"
 
-#: src/muuli_wdr.cpp:2089
+#: src/muuli_wdr.cpp:2088
 #, fuzzy
 msgid "aMule API server parameters"
 msgstr "Vevtenarparameter"
 
-#: src/muuli_wdr.cpp:2092
+#: src/muuli_wdr.cpp:2091
 msgid "Run amuleapi (REST API) on startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2097
+#: src/muuli_wdr.cpp:2096
 #, fuzzy
 msgid "HTTP port:"
 msgstr "TCP port: %d"
 
-#: src/muuli_wdr.cpp:2111
+#: src/muuli_wdr.cpp:2110
 msgid "The interface amuleapi's HTTP server listens on. 127.0.0.1 (default) accepts only local connections; use 0.0.0.0 or a specific IP to expose it to other hosts (set an admin password below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2116
-msgid "Type a password to set or change it. Stored passwords cannot be shown, so leaving this empty keeps the current one."
-msgstr ""
-
-#: src/muuli_wdr.cpp:2118
+#: src/muuli_wdr.cpp:2113
 #, fuzzy
 msgid "Admin password"
 msgstr "Sjekkar passord\n"
 
-#: src/muuli_wdr.cpp:2130 src/muuli_wdr.cpp:2147 src/PrefsUnifiedDlg.cpp:1103
-#, fuzzy
-msgid "A password is set."
-msgstr "Sjekkar passord\n"
-
-#: src/muuli_wdr.cpp:2134
-#, fuzzy
-msgid "Enable guest access"
-msgstr "Nekt gjestetilgang"
-
-#: src/muuli_wdr.cpp:2135
-msgid "Guest sessions may read status and listings but cannot change anything. Turning this off clears the stored guest password."
-msgstr ""
-
-#: src/muuli_wdr.cpp:2139
-#, fuzzy
-msgid "Guest password"
-msgstr "Gjestepassord for vevtenar"
-
-#: src/muuli_wdr.cpp:2154
-msgid "Web server parameters"
-msgstr "Vevtenarparameter"
-
-#: src/muuli_wdr.cpp:2157
-msgid "Run webserver on startup (deprecated)"
-msgstr ""
-
-#: src/muuli_wdr.cpp:2163
-msgid "Web template"
-msgstr "Vevmønster"
-
-#: src/muuli_wdr.cpp:2168
-msgid "Full rights password"
-msgstr "Passord for fulle rettar"
-
-#: src/muuli_wdr.cpp:2172
-msgid "Enable Low rights User"
-msgstr "Aktivér brukar med få rettar"
-
-#: src/muuli_wdr.cpp:2177
+#: src/muuli_wdr.cpp:2118 src/muuli_wdr.cpp:2149
 msgid "Low rights password"
 msgstr "Passord for låge rettar"
 
-#: src/muuli_wdr.cpp:2191
+#: src/muuli_wdr.cpp:2126
+msgid "Web server parameters"
+msgstr "Vevtenarparameter"
+
+#: src/muuli_wdr.cpp:2129
+msgid "Run webserver on startup (deprecated)"
+msgstr ""
+
+#: src/muuli_wdr.cpp:2135
+msgid "Web template"
+msgstr "Vevmønster"
+
+#: src/muuli_wdr.cpp:2140
+msgid "Full rights password"
+msgstr "Passord for fulle rettar"
+
+#: src/muuli_wdr.cpp:2144
+msgid "Enable Low rights User"
+msgstr "Aktivér brukar med få rettar"
+
+#: src/muuli_wdr.cpp:2163
 msgid "Enable UPnP port forwarding of the web server port"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2196
+#: src/muuli_wdr.cpp:2168
 msgid "Web server UPnP TCP port (Optional)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2204
+#: src/muuli_wdr.cpp:2176
 msgid "Page Refresh Time (in secs)"
 msgstr "Sideoppfriskingstid (i sekund)"
 
-#: src/muuli_wdr.cpp:2211
+#: src/muuli_wdr.cpp:2183
 msgid "Enable Gzip compression"
 msgstr "Aktivér Gzipkompresjon"
 
-#: src/muuli_wdr.cpp:2245
+#: src/muuli_wdr.cpp:2217
 #, fuzzy
 msgid "Reset page to defaults"
 msgstr "Standardinnstillingar"
 
-#: src/muuli_wdr.cpp:2246
+#: src/muuli_wdr.cpp:2218
 msgid "Reset the settings on the current page to their default values."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2248 src/muuli_wdr.cpp:2334 src/ServerWnd.cpp:274
+#: src/muuli_wdr.cpp:2220 src/muuli_wdr.cpp:2306 src/ServerWnd.cpp:274
 #: src/ServerWnd.cpp:282
 msgid "OK"
 msgstr "OK"
 
-#: src/muuli_wdr.cpp:2250
+#: src/muuli_wdr.cpp:2222
 msgid "Click here to apply any changes made to the preferences."
 msgstr "Klikk her for å utføre samtlege endringar gjorde i innstillingar."
 
-#: src/muuli_wdr.cpp:2253
+#: src/muuli_wdr.cpp:2225
 msgid "Reset any changes made to the preferences."
 msgstr "Nullstill alle endringar i innstillingar."
 
-#: src/muuli_wdr.cpp:2282
+#: src/muuli_wdr.cpp:2254
 msgid "Comment :"
 msgstr "Kommentar :"
 
-#: src/muuli_wdr.cpp:2289
+#: src/muuli_wdr.cpp:2261
 msgid "Incoming Dir :"
 msgstr "Innkomande kat:"
 
-#: src/muuli_wdr.cpp:2298
+#: src/muuli_wdr.cpp:2270
 msgid "Change priority for new assigned files :"
 msgstr "Endre prioritet for nytileigna filer :"
 
-#: src/muuli_wdr.cpp:2302
+#: src/muuli_wdr.cpp:2274
 #, fuzzy
 msgid "Don't change"
 msgstr "Ikkje endre"
 
-#: src/muuli_wdr.cpp:2314
+#: src/muuli_wdr.cpp:2286
 msgid "Select color for this Category (currently selected) :"
 msgstr "Vel farge for denne kategprien (no valt)"
 
-#: src/muuli_wdr.cpp:2381 src/muuli_wdr.cpp:2400 src/muuli_wdr.cpp:2422
+#: src/muuli_wdr.cpp:2353 src/muuli_wdr.cpp:2372 src/muuli_wdr.cpp:2394
 msgid "Click this button to reset the log."
 msgstr "Klikk denne knappen for å nullstille loggen."
 
-#: src/muuli_wdr.cpp:2441
+#: src/muuli_wdr.cpp:2413
 msgid "Click on this button to update the servers list from URL ..."
 msgstr "Klikk på denne knappen for å oppdatere tenarlista frå nettadresse ..."
 
-#: src/muuli_wdr.cpp:2445
+#: src/muuli_wdr.cpp:2417
 msgid "Server list"
 msgstr "Tenarliste"
 
-#: src/muuli_wdr.cpp:2449
+#: src/muuli_wdr.cpp:2421
 msgid "Enter the url to a server.met file here and press the button to the left to update the list of known servers."
 msgstr "Skriv inn nettadressa til ei server.met fil her og klikk på knappen til venstre for å oppdatere tenarlista."
 
-#: src/muuli_wdr.cpp:2454
+#: src/muuli_wdr.cpp:2426
 msgid "Add server manually: Name"
 msgstr "Legg til tenar manuelt: Namn"
 
-#: src/muuli_wdr.cpp:2457
+#: src/muuli_wdr.cpp:2429
 msgid "Enter the name of the new server here"
 msgstr "Skriv inn namnet på den nye tenaren her"
 
-#: src/muuli_wdr.cpp:2459 src/ServerWnd.cpp:206
+#: src/muuli_wdr.cpp:2431 src/ServerWnd.cpp:206
 msgid "IP:Port"
 msgstr "IP:Port"
 
-#: src/muuli_wdr.cpp:2462
+#: src/muuli_wdr.cpp:2434
 msgid "Enter the IP of the server here, using the x.x.x.x format."
 msgstr "Skriv inn IP`en til tenaren her, i x.x.x.x format."
 
-#: src/muuli_wdr.cpp:2468
+#: src/muuli_wdr.cpp:2440
 msgid "Enter the port of the server here."
 msgstr "Skriv inn porten til tenaren her."
 
-#: src/muuli_wdr.cpp:2471
+#: src/muuli_wdr.cpp:2443
 msgid "Add manually a server (fill fields to the left before) ..."
 msgstr "Legg til ein tenar manuelt (fyll først ut felta til venstre) ..."
 
-#: src/muuli_wdr.cpp:2500
+#: src/muuli_wdr.cpp:2472
 msgid "aMule Log"
 msgstr "aMulelogg"
 
-#: src/muuli_wdr.cpp:2508
+#: src/muuli_wdr.cpp:2480
 msgid "Server Info"
 msgstr "Tenarinfo"
 
-#: src/muuli_wdr.cpp:2512
+#: src/muuli_wdr.cpp:2484
 msgid "ED2K Info"
 msgstr "ED2k-info"
 
-#: src/muuli_wdr.cpp:2516
+#: src/muuli_wdr.cpp:2488
 msgid "Kad Info"
 msgstr "Kad-info"
 
-#: src/muuli_wdr.cpp:2544
+#: src/muuli_wdr.cpp:2516
 msgid "Click on this button to update the nodes list from URL ..."
 msgstr "Klikk på denne knappen for å oppdatere nodelista frå internettadresse ..."
 
-#: src/muuli_wdr.cpp:2548
+#: src/muuli_wdr.cpp:2520
 msgid "Nodes (0)"
 msgstr "Nodar (0)"
 
-#: src/muuli_wdr.cpp:2552
+#: src/muuli_wdr.cpp:2524
 msgid "Enter the url to a nodes.dat file here and press the button to the left to update the list of known nodes."
 msgstr "Skriv inn internettadressa til ei nodes-dat fil her og klikk på knappen til venstre for å oppdatere lista over kjende nodar."
 
-#: src/muuli_wdr.cpp:2555
+#: src/muuli_wdr.cpp:2527
 msgid "Nodes stats"
 msgstr "Nodestatistikk"
 
-#: src/muuli_wdr.cpp:2597
+#: src/muuli_wdr.cpp:2569
 msgid "Bootstrap"
 msgstr "Eigenoppstart"
 
-#: src/muuli_wdr.cpp:2600
+#: src/muuli_wdr.cpp:2572
 msgid "New node"
 msgstr "Ny node"
 
-#: src/muuli_wdr.cpp:2605
+#: src/muuli_wdr.cpp:2577
 msgid "IP:"
 msgstr "IP:"
 
-#: src/muuli_wdr.cpp:2625
+#: src/muuli_wdr.cpp:2597
 msgid "Port:"
 msgstr "Port:"
 
-#: src/muuli_wdr.cpp:2638
+#: src/muuli_wdr.cpp:2610
 #, fuzzy
 msgid "Bootstrap from known clients"
 msgstr ""
 "Eigenoppstart frå \n"
 "kjende klientar"
 
-#: src/muuli_wdr.cpp:2640
+#: src/muuli_wdr.cpp:2612
 msgid "Disconnect Kad"
 msgstr "Kople frå Kad"
 
-#: src/muuli_wdr.cpp:2674
+#: src/muuli_wdr.cpp:2646
 msgid "Use Secure User Identification"
 msgstr "Sikker brukaridentifikasjon (SUI)"
 
-#: src/muuli_wdr.cpp:2676
+#: src/muuli_wdr.cpp:2648
 msgid "It is recommended to enable this option. You will not receive credits if SUI is not enabled."
 msgstr "Det er tilrådd å aktivere denne funksjonen. Du vil ikkje få kredittar dersom SUI ikkje er aktivert."
 
-#: src/muuli_wdr.cpp:2678
+#: src/muuli_wdr.cpp:2650
 msgid "Protocol Obfuscation"
 msgstr "Protokolltåkeleggjing"
 
-#: src/muuli_wdr.cpp:2681
+#: src/muuli_wdr.cpp:2653
 msgid "Support Protocol Obfuscation"
 msgstr "Støtte protokolltåkeleggjing"
 
-#: src/muuli_wdr.cpp:2683
+#: src/muuli_wdr.cpp:2655
 msgid "This option enabled Protocol Obfuscation, and makes aMule accept obfuscated connections from other clients."
 msgstr "Dette valet aktiverer protokolltåkeleggjing og gjer at aMule tek imot tåkelagde koplingar frå andre klientar."
 
-#: src/muuli_wdr.cpp:2685
+#: src/muuli_wdr.cpp:2657
 msgid "Use obfuscation for outgoing connections"
 msgstr "Bruk tåkeleggjing for utgåande koplingar"
 
-#: src/muuli_wdr.cpp:2687
+#: src/muuli_wdr.cpp:2659
 msgid "This option makes aMule use Protocol Obfuscation when connecting other clients/servers."
 msgstr "Dette valet får aMule til å nytte protokolltåkeleggjing ved tilkopling til andreklientar/tenarar."
 
-#: src/muuli_wdr.cpp:2689
+#: src/muuli_wdr.cpp:2661
 msgid "Accept only obfuscated connections"
 msgstr "Berre godta tåkelagde koplingar"
 
-#: src/muuli_wdr.cpp:2690
+#: src/muuli_wdr.cpp:2662
 msgid "This option makes aMule only accept obfuscated connections. You will have less sources, but all your traffic will be obfuscated"
 msgstr "Dette valet får aMule til å berre godta tåkelagde koplingar. Du vil få færre kjelder, men all trafikken din vert tåkelagd"
 
-#: src/muuli_wdr.cpp:2695
+#: src/muuli_wdr.cpp:2667
 msgid "Everybody"
 msgstr "Alle"
 
-#: src/muuli_wdr.cpp:2697
+#: src/muuli_wdr.cpp:2669
 msgid "No one"
 msgstr "Ingen"
 
-#: src/muuli_wdr.cpp:2699
+#: src/muuli_wdr.cpp:2671
 msgid "Who can see my shared files:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2700
+#: src/muuli_wdr.cpp:2672
 msgid "Select who can request to view a list of your shared files."
 msgstr "Vel kven som kan be om å sjå ei liste over dei delte filene dine."
 
-#: src/muuli_wdr.cpp:2702
+#: src/muuli_wdr.cpp:2674
 msgid "IP-Filtering"
 msgstr "IP-filtrering"
 
-#: src/muuli_wdr.cpp:2709
+#: src/muuli_wdr.cpp:2681
 msgid "Filter clients"
 msgstr "Filtrér klientar"
 
-#: src/muuli_wdr.cpp:2711
+#: src/muuli_wdr.cpp:2683
 msgid "Enable filtering of the client IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "Aktivér IP-filterring av klientar i fila ~/.aMule/ipfilter.dat."
 
-#: src/muuli_wdr.cpp:2713
+#: src/muuli_wdr.cpp:2685
 msgid "Filter servers"
 msgstr "Filtrér tenarar"
 
-#: src/muuli_wdr.cpp:2715
+#: src/muuli_wdr.cpp:2687
 msgid "Enable filtering of the server IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "Aktivér filtrering av tenarar i fila ~/.aMule/ipfilter.dat."
 
-#: src/muuli_wdr.cpp:2719
+#: src/muuli_wdr.cpp:2691
 msgid "Reload List"
 msgstr "Last om att lista"
 
-#: src/muuli_wdr.cpp:2720
+#: src/muuli_wdr.cpp:2692
 msgid "Reload the list of IPs to filter from the file ~/.aMule/ipfilter.dat"
 msgstr "Last om att lista av IP`ar å filtre frå fila ~/.aMule/ipfilter.dat"
 
-#: src/muuli_wdr.cpp:2726
+#: src/muuli_wdr.cpp:2698
 msgid "URL:"
 msgstr "Nettadresse:"
 
-#: src/muuli_wdr.cpp:2730 src/muuli_wdr.cpp:2923
+#: src/muuli_wdr.cpp:2702 src/muuli_wdr.cpp:2895
 msgid "Update now"
 msgstr "Oppdatér no"
 
-#: src/muuli_wdr.cpp:2733
+#: src/muuli_wdr.cpp:2705
 msgid "Auto-update ipfilter at startup"
 msgstr "Automatisk oppdatér ipfilter ved oppstart"
 
-#: src/muuli_wdr.cpp:2737
+#: src/muuli_wdr.cpp:2709
 msgid "Filtering Level:"
 msgstr "Filternivå:"
 
-#: src/muuli_wdr.cpp:2743
+#: src/muuli_wdr.cpp:2715
 msgid "Always filter LAN IPs"
 msgstr "Alltid filtrér LAN IP`ar"
 
-#: src/muuli_wdr.cpp:2746
+#: src/muuli_wdr.cpp:2718
 msgid "Paranoid handling of non-matching IPs"
 msgstr "Paranoid handsaming av ujamne IP`ar"
 
-#: src/muuli_wdr.cpp:2748
+#: src/muuli_wdr.cpp:2720
 msgid "Rejects a packet when its source IP differs from the IP the client claims (an anti-spoofing check). Disable only if it causes connection problems."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2750
+#: src/muuli_wdr.cpp:2722
 msgid "Use system-wide ipfilter.dat if available"
 msgstr "Bruk systemomspennande ipfilter.dat dersom tilgjengeleg"
 
-#: src/muuli_wdr.cpp:2751
+#: src/muuli_wdr.cpp:2723
 #, fuzzy
 msgid "If there's no local ipfilter.dat found, allow usage of a system-wide ipfilter file."
 msgstr "Tillat bruk av ipfilter for heile systemet dersom inga lokal ipfilter-dat vert funnen"
 
-#: src/muuli_wdr.cpp:2768
+#: src/muuli_wdr.cpp:2740
 msgid "Enable Online-Signature"
 msgstr "Aktivér nettsignatur"
 
-#: src/muuli_wdr.cpp:2770
+#: src/muuli_wdr.cpp:2742
 msgid "Enables the writing of the OS file, which can be used by external apps to create signatures and the like."
 msgstr "Aktiverer skriving av OS-fila, som kan verte nytta av eksterne program forå lage signaturar og liknande."
 
-#: src/muuli_wdr.cpp:2774
+#: src/muuli_wdr.cpp:2746
 msgid "Update Frequency (Secs):"
 msgstr "Oppdateringsfrekvens (sekund):"
 
-#: src/muuli_wdr.cpp:2777
+#: src/muuli_wdr.cpp:2749
 msgid "Change the frequency (in seconds) of Online Signature updates."
 msgstr "Endre frekvensen (i sekund) for oppdatering av nettsignaturar."
 
-#: src/muuli_wdr.cpp:2785
+#: src/muuli_wdr.cpp:2757
 msgid "Save online signature file in: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:2791
+#: src/muuli_wdr.cpp:2763
 msgid "Click here to select the directory containing the the Online Signature files."
 msgstr "Klikk her for å velje katalogen med nettsignaturfilene."
 
-#: src/muuli_wdr.cpp:2824
+#: src/muuli_wdr.cpp:2796
 msgid "Show country flags for clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2825
+#: src/muuli_wdr.cpp:2797
 msgid "Render the country flag column in the transfers, queue and search views. Requires a valid MMDB GeoIP database (see below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2830
+#: src/muuli_wdr.cpp:2802
 #, fuzzy
 msgid "Database"
 msgstr "Datasnøggleik :"
 
-#: src/muuli_wdr.cpp:2846
+#: src/muuli_wdr.cpp:2818
 #, fuzzy
 msgid "Source:"
 msgstr "Kjelder"
 
-#: src/muuli_wdr.cpp:2849
+#: src/muuli_wdr.cpp:2821
 msgid "DB-IP (free, no account)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2850
+#: src/muuli_wdr.cpp:2822
 msgid "MaxMind GeoLite2 (free, account required)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2851
+#: src/muuli_wdr.cpp:2823
 msgid "Custom URL"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2854
+#: src/muuli_wdr.cpp:2826
 msgid "Choose which provider supplies the GeoIP MMDB database. DB-IP is the default - no account required. MaxMind requires a free account + license key. Use Custom URL to point at any other MMDB host (e.g. a local mirror)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2871
+#: src/muuli_wdr.cpp:2843
 msgid ""
 "No configuration required.\n"
 "\n"
@@ -4892,11 +4858,11 @@ msgid ""
 "License: Creative Commons BY 4.0 - https://creativecommons.org/licenses/by/4.0/"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2884
+#: src/muuli_wdr.cpp:2856
 msgid "License key:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2890
+#: src/muuli_wdr.cpp:2862
 msgid ""
 "Sign up for a free MaxMind account, then generate a License Key:\n"
 "https://www.maxmind.com/en/geolite2/signup\n"
@@ -4906,232 +4872,232 @@ msgid ""
 "Requires attribution and account registration; refresh at least every 30 days."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2905
+#: src/muuli_wdr.cpp:2877
 #, fuzzy
 msgid "Download URL:"
 msgstr "Nedlasting: "
 
-#: src/muuli_wdr.cpp:2911
+#: src/muuli_wdr.cpp:2883
 msgid ""
 "Must point to an .mmdb file or a .gz / .tar.gz containing one.\n"
 "URL may include credentials (https://user:pass@host/...).\n"
 "License and attribution terms are set by the upstream URL - you are responsible."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2924
+#: src/muuli_wdr.cpp:2896
 msgid "Download the GeoIP database from the selected source."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2926
+#: src/muuli_wdr.cpp:2898
 #, fuzzy
 msgid "Auto-update on startup"
 msgstr "Automatisk oppdatér ipfilter ved oppstart"
 
-#: src/muuli_wdr.cpp:2927
+#: src/muuli_wdr.cpp:2899
 msgid "Re-download the GeoIP database from the selected source every time aMule starts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2950
+#: src/muuli_wdr.cpp:2922
 msgid "Filter incoming messages (except current chat):"
 msgstr "Filtrér innkomande meldingar (utanom novérande samtale):"
 
-#: src/muuli_wdr.cpp:2952
+#: src/muuli_wdr.cpp:2924
 msgid "Filter all messages"
 msgstr "Filtrér alle meldingar"
 
-#: src/muuli_wdr.cpp:2954
+#: src/muuli_wdr.cpp:2926
 msgid "Filter messages from people not on your friend list"
 msgstr "Filtrér meldingar frå alle som ikkje er på kameratlista"
 
-#: src/muuli_wdr.cpp:2956
+#: src/muuli_wdr.cpp:2928
 msgid "Filter messages from unknown clients"
 msgstr "Filtrér meldingar frå ukjende klientar"
 
-#: src/muuli_wdr.cpp:2958
+#: src/muuli_wdr.cpp:2930
 msgid "Filter messages containing (use ',' as separator):"
 msgstr "Filtrér meldingar som inneheld (bruk ','som skiljeteikn):"
 
-#: src/muuli_wdr.cpp:2961 src/muuli_wdr.cpp:2972
+#: src/muuli_wdr.cpp:2933 src/muuli_wdr.cpp:2944
 msgid "add here the words amule should filter and block messages including it"
 msgstr "legg til ord aMule skal filtrére og blokkere"
 
-#: src/muuli_wdr.cpp:2963
+#: src/muuli_wdr.cpp:2935
 msgid "Show received messages in the log"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2966
+#: src/muuli_wdr.cpp:2938
 msgid "Comments"
 msgstr "Kommentarar"
 
-#: src/muuli_wdr.cpp:2969
+#: src/muuli_wdr.cpp:2941
 msgid "Filter comments containing (use ',' as separator):"
 msgstr "Filtrér kommentarar som inneheld (bruk ',' som skiljeteikn):"
 
-#: src/muuli_wdr.cpp:2994
+#: src/muuli_wdr.cpp:2966
 msgid "Enable Proxy"
 msgstr "Aktivér vikar"
 
-#: src/muuli_wdr.cpp:2995
+#: src/muuli_wdr.cpp:2967
 msgid "Enable/disable proxy support"
 msgstr "Aktivere/deaktivere vikarstøtte"
 
-#: src/muuli_wdr.cpp:2998
+#: src/muuli_wdr.cpp:2970
 msgid "Proxy type:"
 msgstr "Vikartype:"
 
-#: src/muuli_wdr.cpp:3009
+#: src/muuli_wdr.cpp:2981
 msgid "Proxy host:"
 msgstr "Vikarvert:"
 
-#: src/muuli_wdr.cpp:3012
+#: src/muuli_wdr.cpp:2984
 msgid "The proxy host name"
 msgstr "Vikaren sitt vertsnamn"
 
-#: src/muuli_wdr.cpp:3014
+#: src/muuli_wdr.cpp:2986
 msgid "Proxy port:"
 msgstr "Vikarport:"
 
-#: src/muuli_wdr.cpp:3017
+#: src/muuli_wdr.cpp:2989
 msgid "The proxy port"
 msgstr "Vikarport"
 
-#: src/muuli_wdr.cpp:3019
+#: src/muuli_wdr.cpp:2991
 msgid "Enable authentication"
 msgstr "Aktivér godkjenning"
 
-#: src/muuli_wdr.cpp:3020
+#: src/muuli_wdr.cpp:2992
 msgid "Enable/disable username/password authentication"
 msgstr "Aktivér/deaktivér godkjenning av brukarnamn/passord"
 
-#: src/muuli_wdr.cpp:3023
+#: src/muuli_wdr.cpp:2995
 msgid "Username: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:3026
+#: src/muuli_wdr.cpp:2998
 msgid "The username to use to connect to the proxy"
 msgstr "Brukarnamn å nytte for å kople til vikar"
 
-#: src/muuli_wdr.cpp:3028
+#: src/muuli_wdr.cpp:3000
 msgid "Password:"
 msgstr "Passord:"
 
-#: src/muuli_wdr.cpp:3031
+#: src/muuli_wdr.cpp:3003
 msgid "The password to use to connect to the proxy"
 msgstr "Passord å nytte for å kople til vikar"
 
-#: src/muuli_wdr.cpp:3050
+#: src/muuli_wdr.cpp:3022
 msgid "Connect to:"
 msgstr "Kople til:"
 
-#: src/muuli_wdr.cpp:3059
+#: src/muuli_wdr.cpp:3031
 msgid "Login to remote amule"
 msgstr "Logge inn på fjern aMule"
 
-#: src/muuli_wdr.cpp:3064
+#: src/muuli_wdr.cpp:3036
 msgid "User name"
 msgstr "Brukarnamn"
 
-#: src/muuli_wdr.cpp:3075
+#: src/muuli_wdr.cpp:3047
 msgid "Remember those settings"
 msgstr "Hugs desse innstillingane"
 
-#: src/muuli_wdr.cpp:3078
+#: src/muuli_wdr.cpp:3050
 #, fuzzy
 msgid "Force ZLIB compression"
 msgstr "Nytt gzipkomprimering"
 
-#: src/muuli_wdr.cpp:3102
+#: src/muuli_wdr.cpp:3074
 msgid "Enable Verbose Debug-Logging."
 msgstr "Aktivér utførleg avfeilingslogg."
 
-#: src/muuli_wdr.cpp:3104
+#: src/muuli_wdr.cpp:3076
 #, fuzzy
 msgid "Only to Logfile"
 msgstr "&Opne fila"
 
-#: src/muuli_wdr.cpp:3106
+#: src/muuli_wdr.cpp:3078
 msgid "Message Categories:"
 msgstr "Meldingskategoriar:"
 
-#: src/muuli_wdr.cpp:3130 src/PartFileConvertDlg.cpp:160
+#: src/muuli_wdr.cpp:3102 src/PartFileConvertDlg.cpp:160
 msgid "Waiting..."
 msgstr "Ventar..."
 
-#: src/muuli_wdr.cpp:3150
+#: src/muuli_wdr.cpp:3122
 msgid "Add imports"
 msgstr "Importér"
 
-#: src/muuli_wdr.cpp:3153
+#: src/muuli_wdr.cpp:3125
 msgid "Retry selected"
 msgstr "Prøv om att valde"
 
-#: src/muuli_wdr.cpp:3155
+#: src/muuli_wdr.cpp:3127
 msgid "Remove selected"
 msgstr "Fjern valde"
 
-#: src/muuli_wdr.cpp:3218
+#: src/muuli_wdr.cpp:3190
 msgid "Event Types"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3237
+#: src/muuli_wdr.cpp:3209
 msgid "Statistics and queued clients for selected file(s) : Session / All time"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3261
+#: src/muuli_wdr.cpp:3233
 #, fuzzy
 msgid "Active Uploads"
 msgstr "Aktive opplastingar :"
 
-#: src/muuli_wdr.cpp:3275
+#: src/muuli_wdr.cpp:3247
 msgid "Percent of total files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3327
+#: src/muuli_wdr.cpp:3299
 #, fuzzy
 msgid "Show Clients for"
 msgstr "Syne klientar"
 
-#: src/muuli_wdr.cpp:3329
+#: src/muuli_wdr.cpp:3301
 #, fuzzy
 msgid "All files"
 msgstr "Gøyme delte filer"
 
-#: src/muuli_wdr.cpp:3332
+#: src/muuli_wdr.cpp:3304
 #, fuzzy
 msgid "Selected files"
 msgstr "Vel synsfilter"
 
-#: src/muuli_wdr.cpp:3335
+#: src/muuli_wdr.cpp:3307
 #, fuzzy
 msgid "Active uploads only"
 msgstr "Aktive opplastingar"
 
-#: src/muuli_wdr.cpp:3342
+#: src/muuli_wdr.cpp:3314
 #, fuzzy
 msgid "Reload:"
 msgstr "Last om att lista"
 
-#: src/muuli_wdr.cpp:3346
+#: src/muuli_wdr.cpp:3318
 msgid "Reload your shared files"
 msgstr "Lastar inn att delte filer"
 
-#: src/muuli_wdr.cpp:3409
+#: src/muuli_wdr.cpp:3381
 msgid "Send"
 msgstr "Send"
 
-#: src/muuli_wdr.cpp:3410
+#: src/muuli_wdr.cpp:3382
 msgid "Sends the specified message."
 msgstr "Sender meldinga."
 
-#: src/muuli_wdr.cpp:3414
+#: src/muuli_wdr.cpp:3386
 msgid "Close this chat-session."
 msgstr "Stengje denne lynmeldingsøkta."
 
-#: src/muuli_wdr.cpp:3437
+#: src/muuli_wdr.cpp:3409
 msgid "Connect to any server and/or Kad"
 msgstr "Kople til vilkårleg tenar og/eller Kad"
 
-#: src/muuli_wdr.cpp:3443 src/SharedFilesCtrl.cpp:142 src/Statistics.cpp:941
+#: src/muuli_wdr.cpp:3415 src/SharedFilesCtrl.cpp:142 src/Statistics.cpp:941
 msgid "Shared Files"
 msgstr "Delte filer"
 
@@ -5492,268 +5458,268 @@ msgstr "Lasta ned"
 msgid "ERROR: Failed to open partfile '%s'"
 msgstr "Feil: Greidde ikkje opne delfila '%s'"
 
-#: src/Preferences.cpp:701
+#: src/Preferences.cpp:673
 msgid "System default"
 msgstr "Standardinnstillingar"
 
-#: src/Preferences.cpp:702
+#: src/Preferences.cpp:674
 msgid "Albanian"
 msgstr "Albansk"
 
-#: src/Preferences.cpp:703
+#: src/Preferences.cpp:675
 msgid "Arabic"
 msgstr "Arabisk"
 
-#: src/Preferences.cpp:704
+#: src/Preferences.cpp:676
 #, fuzzy
 msgid "Asturian"
 msgstr "Estisk"
 
-#: src/Preferences.cpp:705
+#: src/Preferences.cpp:677
 msgid "Basque"
 msgstr "Baskisk"
 
-#: src/Preferences.cpp:706
+#: src/Preferences.cpp:678
 msgid "Bulgarian"
 msgstr "Bulgarsk"
 
-#: src/Preferences.cpp:707
+#: src/Preferences.cpp:679
 msgid "Catalan"
 msgstr "Katalansk"
 
-#: src/Preferences.cpp:708
+#: src/Preferences.cpp:680
 msgid "Chinese (Simplified)"
 msgstr "Kinesisk (forenkla)"
 
-#: src/Preferences.cpp:709
+#: src/Preferences.cpp:681
 msgid "Chinese (Traditional)"
 msgstr "Kinesisk (tradisjonell)"
 
-#: src/Preferences.cpp:710
+#: src/Preferences.cpp:682
 msgid "Croatian"
 msgstr "Kroatisk"
 
-#: src/Preferences.cpp:711
+#: src/Preferences.cpp:683
 msgid "Czech"
 msgstr "Tsjekkisk"
 
-#: src/Preferences.cpp:712
+#: src/Preferences.cpp:684
 msgid "Danish"
 msgstr "Dansk"
 
-#: src/Preferences.cpp:713
+#: src/Preferences.cpp:685
 msgid "Dutch"
 msgstr "Nederlansk"
 
-#: src/Preferences.cpp:714
+#: src/Preferences.cpp:686
 msgid "English (U.K.)"
 msgstr "Engelsk (U.K.)"
 
-#: src/Preferences.cpp:715
+#: src/Preferences.cpp:687
 #, fuzzy
 msgid "English (U.S.)"
 msgstr "Engelsk (U.K.)"
 
-#: src/Preferences.cpp:716
+#: src/Preferences.cpp:688
 msgid "Estonian"
 msgstr "Estisk"
 
-#: src/Preferences.cpp:717
+#: src/Preferences.cpp:689
 msgid "Finnish"
 msgstr "Finsk"
 
-#: src/Preferences.cpp:718
+#: src/Preferences.cpp:690
 msgid "French"
 msgstr "Fransk"
 
-#: src/Preferences.cpp:719
+#: src/Preferences.cpp:691
 msgid "Galician"
 msgstr "Galisisk"
 
-#: src/Preferences.cpp:720
+#: src/Preferences.cpp:692
 msgid "German"
 msgstr "Tysk"
 
-#: src/Preferences.cpp:721
+#: src/Preferences.cpp:693
 msgid "Greek"
 msgstr "Gresk"
 
-#: src/Preferences.cpp:722
+#: src/Preferences.cpp:694
 msgid "Hebrew"
 msgstr "Hebraisk"
 
-#: src/Preferences.cpp:723
+#: src/Preferences.cpp:695
 msgid "Hungarian"
 msgstr "Ungarsk"
 
-#: src/Preferences.cpp:724
+#: src/Preferences.cpp:696
 msgid "Italian"
 msgstr "Italiensk"
 
-#: src/Preferences.cpp:725
+#: src/Preferences.cpp:697
 msgid "Japanese"
 msgstr "Japansk"
 
-#: src/Preferences.cpp:726
+#: src/Preferences.cpp:698
 msgid "Korean"
 msgstr "Koreansk"
 
-#: src/Preferences.cpp:727
+#: src/Preferences.cpp:699
 msgid "Latvian"
 msgstr ""
 
-#: src/Preferences.cpp:728
+#: src/Preferences.cpp:700
 msgid "Lithuanian"
 msgstr "Litauisk"
 
-#: src/Preferences.cpp:729
+#: src/Preferences.cpp:701
 msgid "Norwegian (Nynorsk)"
 msgstr "Norsk (Nynorsk)"
 
-#: src/Preferences.cpp:730
+#: src/Preferences.cpp:702
 msgid "Polish"
 msgstr "Polsk"
 
-#: src/Preferences.cpp:731
+#: src/Preferences.cpp:703
 msgid "Portuguese"
 msgstr "Portugisisk"
 
-#: src/Preferences.cpp:732
+#: src/Preferences.cpp:704
 msgid "Portuguese (Brazilian)"
 msgstr "Portugisisk (Brasil)"
 
-#: src/Preferences.cpp:733
+#: src/Preferences.cpp:705
 #, fuzzy
 msgid "Romanian"
 msgstr "Albansk"
 
-#: src/Preferences.cpp:734
+#: src/Preferences.cpp:706
 msgid "Russian"
 msgstr "Russisk"
 
-#: src/Preferences.cpp:735
+#: src/Preferences.cpp:707
 msgid "Slovenian"
 msgstr "Slovensk"
 
-#: src/Preferences.cpp:736
+#: src/Preferences.cpp:708
 msgid "Spanish"
 msgstr "Spansk"
 
-#: src/Preferences.cpp:737
+#: src/Preferences.cpp:709
 msgid "Swedish"
 msgstr "Svensk"
 
-#: src/Preferences.cpp:738
+#: src/Preferences.cpp:710
 msgid "Turkish"
 msgstr "Tyrkisk"
 
-#: src/Preferences.cpp:739
+#: src/Preferences.cpp:711
 msgid "Ukrainian"
 msgstr ""
 
-#: src/Preferences.cpp:842
+#: src/Preferences.cpp:814
 #, fuzzy
 msgid "Change Language"
 msgstr "Språk"
 
-#: src/Preferences.cpp:906
+#: src/Preferences.cpp:878
 msgid "There are no translations installed for aMule"
 msgstr ""
 
-#: src/Preferences.cpp:907
+#: src/Preferences.cpp:879
 #, fuzzy
 msgid "No languages available"
 msgstr "Ikkje tilgjengeleg"
 
-#: src/Preferences.cpp:1038
+#: src/Preferences.cpp:1010
 msgid "no options available"
 msgstr ""
 
-#: src/Preferences.cpp:2226
+#: src/Preferences.cpp:2179
 msgid "Invalid category found, skipping"
 msgstr ""
 
-#: src/Preferences.cpp:2395
+#: src/Preferences.cpp:2348
 msgid "TCP port can't be higher than 65532 due to server UDP socket being TCP+3"
 msgstr "TCP port kan ikkje vere høgare enn 65532 fordi tenaren si UDPkopling er TCP+3"
 
-#: src/Preferences.cpp:2396
+#: src/Preferences.cpp:2349
 #, c-format
 msgid "Default port will be used (%d)"
 msgstr "Standardport vert nytta (%d)"
 
-#: src/PrefsUnifiedDlg.cpp:300 src/Statistics.cpp:866
+#: src/PrefsUnifiedDlg.cpp:298 src/Statistics.cpp:866
 msgid "Connection"
 msgstr "Kopling"
 
-#: src/PrefsUnifiedDlg.cpp:301 src/SearchListCtrl.cpp:117
+#: src/PrefsUnifiedDlg.cpp:299 src/SearchListCtrl.cpp:117
 msgid "Directories"
 msgstr "Katalogar"
 
-#: src/PrefsUnifiedDlg.cpp:302 src/Statistics.cpp:917
+#: src/PrefsUnifiedDlg.cpp:300 src/Statistics.cpp:917
 msgid "Servers"
 msgstr "Tenarar"
 
-#: src/PrefsUnifiedDlg.cpp:303 src/ServerListCtrl.cpp:96
+#: src/PrefsUnifiedDlg.cpp:301 src/ServerListCtrl.cpp:96
 msgid "Files"
 msgstr "Filer"
 
-#: src/PrefsUnifiedDlg.cpp:304
+#: src/PrefsUnifiedDlg.cpp:302
 msgid "Security"
 msgstr "Tryggleik"
 
-#: src/PrefsUnifiedDlg.cpp:305
+#: src/PrefsUnifiedDlg.cpp:303
 msgid "Interface"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:312
+#: src/PrefsUnifiedDlg.cpp:310
 msgid "IP2Country"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:315
+#: src/PrefsUnifiedDlg.cpp:313
 msgid "Proxy"
 msgstr "Proxy"
 
-#: src/PrefsUnifiedDlg.cpp:316
+#: src/PrefsUnifiedDlg.cpp:314
 msgid "Filters"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:317
+#: src/PrefsUnifiedDlg.cpp:315
 msgid "Remote Controls"
 msgstr "Fjernkontrollar"
 
-#: src/PrefsUnifiedDlg.cpp:318
+#: src/PrefsUnifiedDlg.cpp:316
 msgid "Online Signature"
 msgstr "Nettsignatur"
 
-#: src/PrefsUnifiedDlg.cpp:319
+#: src/PrefsUnifiedDlg.cpp:317
 msgid "Advanced"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:320
+#: src/PrefsUnifiedDlg.cpp:318
 msgid "Events"
 msgstr "Hendingar"
 
-#: src/PrefsUnifiedDlg.cpp:323
+#: src/PrefsUnifiedDlg.cpp:321
 msgid "Debugging"
 msgstr "Melde om feil"
 
-#: src/PrefsUnifiedDlg.cpp:453
+#: src/PrefsUnifiedDlg.cpp:451
 msgid ""
 "The following variables will be substituted:\n"
 "    %PARTFILE - full path to the file\n"
 "    %PARTNAME - file name only"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:474
+#: src/PrefsUnifiedDlg.cpp:472
 msgid "Tray icon support requires libayatana-appindicator3 at compile time."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:490
+#: src/PrefsUnifiedDlg.cpp:488
 msgid "Not available on Wayland: the protocol does not report when a window is minimized, so this option cannot intercept the system minimize button. Workaround: launch aMule with `GDK_BACKEND=x11` to use XWayland instead."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:536
+#: src/PrefsUnifiedDlg.cpp:534
 msgid ""
 "Do not change these setting unless you know\n"
 "what you are doing, otherwise you can easily\n"
@@ -5769,35 +5735,26 @@ msgstr ""
 "aMule køyrer fint utan justering av nokon av\n"
 "desse innstillingane."
 
-#: src/PrefsUnifiedDlg.cpp:647
+#: src/PrefsUnifiedDlg.cpp:645
 #, c-format
 msgid "Failed to connect Cfg to widget with the ID %d and key %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:695
+#: src/PrefsUnifiedDlg.cpp:693
 #, c-format
 msgid "Failed to transfer data from Cfg to Widget with the ID %d and key %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:801
+#: src/PrefsUnifiedDlg.cpp:799
 msgid "The type of proxy you are connecting to"
 msgstr "Typen vikar du koplar til"
 
-#: src/PrefsUnifiedDlg.cpp:1020
+#: src/PrefsUnifiedDlg.cpp:1003
 #, c-format
 msgid "Failed to transfer data from Widget to Cfg with the ID %d and key %s"
 msgstr ""
 
 #: src/PrefsUnifiedDlg.cpp:1103
-#, fuzzy
-msgid "No password set."
-msgstr "Sjekkar passord\n"
-
-#: src/PrefsUnifiedDlg.cpp:1132
-msgid "Guest access needs a password. Type one in the guest password field, or untick Enable guest access."
-msgstr ""
-
-#: src/PrefsUnifiedDlg.cpp:1144
 msgid ""
 "aMule must be restarted to enable these changes:\n"
 "\n"
@@ -5805,51 +5762,51 @@ msgstr ""
 "aMule·treng omstart for å gjere endringane moglege:\n"
 "\n"
 
-#: src/PrefsUnifiedDlg.cpp:1151
+#: src/PrefsUnifiedDlg.cpp:1110
 msgid "- TCP port changed.\n"
 msgstr "-·TCP-porten endra.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1156
+#: src/PrefsUnifiedDlg.cpp:1115
 msgid "- UDP port changed.\n"
 msgstr "-·UDP-porten endra.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1161
+#: src/PrefsUnifiedDlg.cpp:1120
 #, fuzzy
 msgid "- Network interface binding changed.\n"
 msgstr "Ekstern kopling lukka."
 
-#: src/PrefsUnifiedDlg.cpp:1166
+#: src/PrefsUnifiedDlg.cpp:1125
 #, fuzzy
 msgid "- External connect port changed.\n"
 msgstr "Ekstern kopling lukka."
 
-#: src/PrefsUnifiedDlg.cpp:1170
+#: src/PrefsUnifiedDlg.cpp:1129
 #, fuzzy
 msgid "- External connect acceptance changed.\n"
 msgstr "Ny ekstern kopling akseptert"
 
-#: src/PrefsUnifiedDlg.cpp:1174
+#: src/PrefsUnifiedDlg.cpp:1133
 #, fuzzy
 msgid "- External connect interface changed.\n"
 msgstr "Ekstern kopling lukka."
 
-#: src/PrefsUnifiedDlg.cpp:1178
+#: src/PrefsUnifiedDlg.cpp:1137
 #, fuzzy
 msgid "- Protocol obfuscation support changed.\n"
 msgstr "Protokolltåkeleggjing"
 
-#: src/PrefsUnifiedDlg.cpp:1193
+#: src/PrefsUnifiedDlg.cpp:1151
 #, fuzzy
 msgid "- amuleapi settings changed.\n"
 msgstr "- Språk endra.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1202
+#: src/PrefsUnifiedDlg.cpp:1160
 msgid ""
 "Your Auto-update server list is empty.\n"
 "'Auto-update server list at startup' will be disabled."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1213
+#: src/PrefsUnifiedDlg.cpp:1171
 msgid ""
 "You have enabled external connections but have not specified a password.\n"
 "External connections cannot be enabled unless a valid password is specified."
@@ -5857,34 +5814,29 @@ msgstr ""
 "Du har aktivert eksterne koplingar, men har ikkje skrive inn eit passord.\n"
 "Eksterne koplingar kan ikkje aktiverast utan eit gyldig passord."
 
-#: src/PrefsUnifiedDlg.cpp:1246
-#, c-format
-msgid "The amuleapi password could not be saved: %s"
-msgstr ""
-
-#: src/PrefsUnifiedDlg.cpp:1276
+#: src/PrefsUnifiedDlg.cpp:1202
 msgid "- Language changed.\n"
 msgstr "- Språk endra.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1281
+#: src/PrefsUnifiedDlg.cpp:1207
 msgid "- Temp folder changed.\n"
 msgstr "- Mellombels mappe endra.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1286
+#: src/PrefsUnifiedDlg.cpp:1212
 #, fuzzy
 msgid "- ED2K network enabled.\n"
 msgstr "Alle nettverk er deaktiverte."
 
-#: src/PrefsUnifiedDlg.cpp:1319
+#: src/PrefsUnifiedDlg.cpp:1245
 msgid "The shared-file exclusion pattern is not a valid regular expression. The filter has been left disabled."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1321 src/PrefsUnifiedDlg.cpp:1921
+#: src/PrefsUnifiedDlg.cpp:1247 src/PrefsUnifiedDlg.cpp:1841
 #, fuzzy
 msgid "Invalid regular expression"
 msgstr "Ugyldig protokullutgåve."
 
-#: src/PrefsUnifiedDlg.cpp:1398
+#: src/PrefsUnifiedDlg.cpp:1324
 msgid ""
 "Both eD2k and Kad network are disabled.\n"
 "You won't be able to connect until you enable at least one of them."
@@ -5892,7 +5844,7 @@ msgstr ""
 "Både eD2k og kadnettverket er dekativert.\n"
 "Du vil ikkje klare å kople til før du aktiverer minst eitt av dei."
 
-#: src/PrefsUnifiedDlg.cpp:1403
+#: src/PrefsUnifiedDlg.cpp:1329
 msgid ""
 "Kad will not start if your UDP port is disabled.\n"
 "Enable UDP port or disable Kad."
@@ -5900,7 +5852,7 @@ msgstr ""
 "Kad kan ikkje starte dersom UDP-porten er deaktivert.\n"
 "Aktivér UDP-porten eller deaktivér Kad."
 
-#: src/PrefsUnifiedDlg.cpp:1459
+#: src/PrefsUnifiedDlg.cpp:1385
 msgid ""
 "\n"
 "You MUST restart aMule now.\n"
@@ -5910,69 +5862,69 @@ msgstr ""
 "Du MÅ starte om att aMule no.\n"
 "Ikkje klag dersom du ikkje gjer dette og du får problem.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1524
+#: src/PrefsUnifiedDlg.cpp:1450
 msgid "Could not register aMule for autostart at login. The autostart store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1526
+#: src/PrefsUnifiedDlg.cpp:1452
 msgid "Could not remove the autostart-at-login entry."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1527
+#: src/PrefsUnifiedDlg.cpp:1453
 #, fuzzy
 msgid "Autostart"
 msgstr "Autooppfrisking starta"
 
-#: src/PrefsUnifiedDlg.cpp:1542
+#: src/PrefsUnifiedDlg.cpp:1468
 msgid "Register file type"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1542
+#: src/PrefsUnifiedDlg.cpp:1468
 msgid "Register URL handler"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1550
+#: src/PrefsUnifiedDlg.cpp:1476
 #, c-format
 msgid "aMule only handles eD2k-compatible magnets. If you replace the current magnet handler (%s), BitTorrent magnet links will stop working - aMule cannot download BitTorrent content. Continue?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1555
+#: src/PrefsUnifiedDlg.cpp:1481
 #, c-format
 msgid "Another application currently opens .emulecollection files (%s). Replace it with aMule?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1560
+#: src/PrefsUnifiedDlg.cpp:1486
 #, c-format
 msgid "Another application is currently the default handler for these links (%s). Replace it with aMule?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1585
+#: src/PrefsUnifiedDlg.cpp:1511
 msgid "Could not register aMule for .emulecollection files. The registration store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1587
+#: src/PrefsUnifiedDlg.cpp:1513
 #, fuzzy
 msgid "Could not remove the file type registration."
 msgstr "Du freistar allereie nedlasting av fila %s"
 
-#: src/PrefsUnifiedDlg.cpp:1589
+#: src/PrefsUnifiedDlg.cpp:1515
 msgid "Could not register aMule as the URL handler. The registration store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1591
+#: src/PrefsUnifiedDlg.cpp:1517
 msgid "Could not remove the URL handler registration."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1661 src/PrefsUnifiedDlg.cpp:1688
+#: src/PrefsUnifiedDlg.cpp:1587 src/PrefsUnifiedDlg.cpp:1614
 #, fuzzy
 msgid "The web server and aMule API require external connections to be enabled."
 msgstr "Ny ekstern kopling akseptert"
 
-#: src/PrefsUnifiedDlg.cpp:1671
+#: src/PrefsUnifiedDlg.cpp:1597
 msgid "The aMule web server is deprecated. Consider running the aMule API instead."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1735
+#: src/PrefsUnifiedDlg.cpp:1655
 msgid ""
 "Your Auto-update servers list is in blank.\n"
 "Please fill in at least one URL to point to a valid server.met file.\n"
@@ -5982,66 +5934,66 @@ msgstr ""
 "Vér god og fylle ut ein URL som peikar til ei gyldig server.met fil.\n"
 "Klikk på knappen \"Liste\" ved denne boksen for å skrive inn ein URL."
 
-#: src/PrefsUnifiedDlg.cpp:1876
+#: src/PrefsUnifiedDlg.cpp:1796
 msgid "Temporary files"
 msgstr "Mellombelse filer"
 
-#: src/PrefsUnifiedDlg.cpp:1881
+#: src/PrefsUnifiedDlg.cpp:1801
 msgid "Incoming files"
 msgstr "Innkomande filer"
 
-#: src/PrefsUnifiedDlg.cpp:1886
+#: src/PrefsUnifiedDlg.cpp:1806
 msgid "Online Signatures"
 msgstr "Nettsignaturar"
 
-#: src/PrefsUnifiedDlg.cpp:1899
+#: src/PrefsUnifiedDlg.cpp:1819
 #, c-format
 msgid "Choose a folder for %s"
 msgstr "Vel ei mappe for %s"
 
-#: src/PrefsUnifiedDlg.cpp:1923
+#: src/PrefsUnifiedDlg.cpp:1843
 #, fuzzy, c-format
 msgid "Would exclude %u of %u shared file"
 msgid_plural "Would exclude %u of %u shared files"
 msgstr[0] "Fann %i kjend delt fil"
 msgstr[1] "Fann %i kjende delte filer"
 
-#: src/PrefsUnifiedDlg.cpp:1940
+#: src/PrefsUnifiedDlg.cpp:1860
 msgid "Browse for videoplayer"
 msgstr "Bla etter videospelar"
 
-#: src/PrefsUnifiedDlg.cpp:1944
+#: src/PrefsUnifiedDlg.cpp:1864
 msgid "Select browser"
 msgstr "Vél nettlesar"
 
-#: src/PrefsUnifiedDlg.cpp:1948
+#: src/PrefsUnifiedDlg.cpp:1868
 #, fuzzy
 msgid "Select ffprobe binary"
 msgstr "Vél nettlesar"
 
-#: src/PrefsUnifiedDlg.cpp:1954
+#: src/PrefsUnifiedDlg.cpp:1874
 #, c-format
 msgid "Executable%s"
 msgstr "Køyrbar%s"
 
-#: src/PrefsUnifiedDlg.cpp:1988
+#: src/PrefsUnifiedDlg.cpp:1908
 msgid "ffprobe not found on PATH or in the standard install locations. Install ffmpeg (which ships ffprobe) or use Browse to pick a binary manually."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2000
+#: src/PrefsUnifiedDlg.cpp:1920
 msgid "Reset the settings on this page to their default values?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2001
+#: src/PrefsUnifiedDlg.cpp:1921
 #, fuzzy
 msgid "Reset to defaults"
 msgstr "Standardinnstillingar"
 
-#: src/PrefsUnifiedDlg.cpp:2028
+#: src/PrefsUnifiedDlg.cpp:1948
 msgid "Edit server list"
 msgstr "Handsame tenarlista"
 
-#: src/PrefsUnifiedDlg.cpp:2029
+#: src/PrefsUnifiedDlg.cpp:1949
 msgid ""
 "Add here URL's to download server.met files.\n"
 "Only one url on each line."
@@ -6049,181 +6001,177 @@ msgstr ""
 "Skriv inn URL`en for å laste ned server.met filer.\n"
 "Berre ein URL på kvar linje."
 
-#: src/PrefsUnifiedDlg.cpp:2084
+#: src/PrefsUnifiedDlg.cpp:2004
 msgid "IP2Country update failed"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2229 src/PrefsUnifiedDlg.cpp:2260
+#: src/PrefsUnifiedDlg.cpp:2149 src/PrefsUnifiedDlg.cpp:2180
 msgid "Data by MaxMind GeoLite2"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2231 src/PrefsUnifiedDlg.cpp:2262
+#: src/PrefsUnifiedDlg.cpp:2151 src/PrefsUnifiedDlg.cpp:2182
 #, fuzzy
 msgid "Custom source"
 msgstr "Komplette kjelder"
 
-#: src/PrefsUnifiedDlg.cpp:2233 src/PrefsUnifiedDlg.cpp:2264
+#: src/PrefsUnifiedDlg.cpp:2153 src/PrefsUnifiedDlg.cpp:2184
 msgid "Data by DB-IP.com"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2284
+#: src/PrefsUnifiedDlg.cpp:2204
 #, fuzzy, c-format
 msgid "Status: Loaded%s"
 msgstr "Status:"
 
-#: src/PrefsUnifiedDlg.cpp:2286
+#: src/PrefsUnifiedDlg.cpp:2206
 #, fuzzy, c-format
 msgid "Status: Loaded%s - %s"
 msgstr "Status:"
 
-#: src/PrefsUnifiedDlg.cpp:2290
+#: src/PrefsUnifiedDlg.cpp:2210
 msgid "Status: Failed to load - click 'Update now' to refresh."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2292
+#: src/PrefsUnifiedDlg.cpp:2212
 msgid "Status: Not found - click 'Update now' to download."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2350 src/PrefsUnifiedDlg.cpp:2374
+#: src/PrefsUnifiedDlg.cpp:2270 src/PrefsUnifiedDlg.cpp:2294
 #, c-format
 msgid "Update delay: %d second"
 msgid_plural "Update delay: %d seconds"
 msgstr[0] "Oppdateringspause: %d sekund"
 msgstr[1] "Oppdateringspause: %d sekund"
 
-#: src/PrefsUnifiedDlg.cpp:2358
+#: src/PrefsUnifiedDlg.cpp:2278
 #, c-format
 msgid "Time for average graph: %d minute"
 msgid_plural "Time for average graph: %d minutes"
 msgstr[0] "Tid for gjennomsnittleg graf: %d minutt"
 msgstr[1] "Tid for gjennomsnittleg graf; %d minutt"
 
-#: src/PrefsUnifiedDlg.cpp:2367
+#: src/PrefsUnifiedDlg.cpp:2287
 #, c-format
 msgid "Connections Graph Scale: %d"
 msgstr "Koplingsgrafskala: %d"
 
-#: src/PrefsUnifiedDlg.cpp:2382
+#: src/PrefsUnifiedDlg.cpp:2302
 #, c-format
 msgid "File Buffer Size: %d byte"
 msgid_plural "File Buffer Size: %d bytes"
 msgstr[0] "Filbufferstorleik: %d byte"
 msgstr[1] "Filbufferstorleik: %d bytes"
 
-#: src/PrefsUnifiedDlg.cpp:2392
+#: src/PrefsUnifiedDlg.cpp:2312
 #, c-format
 msgid "Upload Queue Size: %d client"
 msgid_plural "Upload Queue Size: %d clients"
 msgstr[0] "Opplastingskøstorleik: %d klient"
 msgstr[1] "Opplastingskøstorleik: %d klientar"
 
-#: src/PrefsUnifiedDlg.cpp:2402
+#: src/PrefsUnifiedDlg.cpp:2322
 #, c-format
 msgid "Server connection refresh interval: %d minute"
 msgid_plural "Server connection refresh interval: %d minutes"
 msgstr[0] "Oppfriskingsinterval på tenarkoplingar: %d minutt"
 msgstr[1] "Oppfriskingsinterval på tenarkoplingar: %d minutt"
 
-#: src/PrefsUnifiedDlg.cpp:2407
+#: src/PrefsUnifiedDlg.cpp:2327
 msgid "Server connection refresh interval: Disabled"
 msgstr "Oppfriskingsintervall for tenarkopling: Deaktivert"
 
-#: src/PrefsUnifiedDlg.cpp:2451
+#: src/PrefsUnifiedDlg.cpp:2371
 #, fuzzy
 msgid "disabled"
 msgstr "deaktivere"
 
-#: src/PrefsUnifiedDlg.cpp:2477
+#: src/PrefsUnifiedDlg.cpp:2397
 #, fuzzy, c-format
 msgid "Execute command on '%s' event"
 msgstr "Køyr kommando på `%s' hending"
 
-#: src/PrefsUnifiedDlg.cpp:2484
+#: src/PrefsUnifiedDlg.cpp:2404
 msgid "Enable command execution on core"
 msgstr "Aktivér kommandokøyring i kjernen"
 
-#: src/PrefsUnifiedDlg.cpp:2496
+#: src/PrefsUnifiedDlg.cpp:2416
 msgid "Core command:"
 msgstr "Kjernekommando:"
 
-#: src/PrefsUnifiedDlg.cpp:2512
+#: src/PrefsUnifiedDlg.cpp:2432
 msgid "Enable command execution on GUI"
 msgstr "Aktivér kommandokøyring på drakt"
 
-#: src/PrefsUnifiedDlg.cpp:2524
+#: src/PrefsUnifiedDlg.cpp:2444
 msgid "GUI command:"
 msgstr "Draktkommando:"
 
-#: src/PrefsUnifiedDlg.cpp:2540
+#: src/PrefsUnifiedDlg.cpp:2460
 msgid "The following variables will be replaced:"
 msgstr "Følgjande variablar vert erstatta:"
 
-#: src/PrefsUnifiedDlg.cpp:2708
+#: src/PrefsUnifiedDlg.cpp:2628
 msgid ""
 "The following folders look like system or sensitive locations:\n"
 "\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2713
+#: src/PrefsUnifiedDlg.cpp:2633
 msgid "Sharing them recursively will publish every file underneath on the eD2k/Kad networks. Do you really want to do this?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2716
+#: src/PrefsUnifiedDlg.cpp:2636
 #, fuzzy
 msgid "Confirm shared folders"
 msgstr "Lastar inn att delte filer"
 
-#: src/PrefsUnifiedDlg.cpp:2744
+#: src/PrefsUnifiedDlg.cpp:2664
 #, fuzzy
 msgid "Reloading shared files..."
 msgstr "Lastar inn att delte filer"
 
-#: src/PrefsUnifiedDlg.cpp:2745
+#: src/PrefsUnifiedDlg.cpp:2665
 msgid "Scanning for subdirectories..."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2746
+#: src/PrefsUnifiedDlg.cpp:2666
 #, fuzzy
 msgid "Updating shared folders"
 msgstr "Les mellombels mappe"
 
-#: src/PrefsUnifiedDlg.cpp:2773
+#: src/PrefsUnifiedDlg.cpp:2693
 #, c-format
 msgid "Scanned %u directories..."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2823
+#: src/PrefsUnifiedDlg.cpp:2743
 #, fuzzy, c-format
 msgid "Reloading shared files: %u files scanned"
 msgstr "Lastar inn att lista over delte filer."
 
-#: src/PrefsUnifiedDlg.cpp:2873
+#: src/PrefsUnifiedDlg.cpp:2793
 #, fuzzy
 msgid "Shared folder"
 msgstr "Delte filer"
 
-#: src/SearchDlg.cpp:280
-msgid "Clear search history"
-msgstr ""
-
-#: src/SearchDlg.cpp:584
+#: src/SearchDlg.cpp:425
 msgid "It's impossible to search when both eD2k and Kademlia are disabled."
 msgstr ""
 
-#: src/SearchDlg.cpp:585 src/SearchListCtrl.cpp:858
+#: src/SearchDlg.cpp:426 src/SearchListCtrl.cpp:858
 #, fuzzy
 msgid "Search error"
 msgstr "Søk"
 
-#: src/SearchDlg.cpp:929
+#: src/SearchDlg.cpp:768
 msgid "Min size must be smaller than max size. Max size ignored."
 msgstr "Min storleik må vere mindre enn maks storleik. Maks storleik ignorert."
 
-#: src/SearchDlg.cpp:930 src/SearchDlg.cpp:1012
+#: src/SearchDlg.cpp:769 src/SearchDlg.cpp:851
 msgid "Search warning"
 msgstr "Søkeåtvaring"
 
-#: src/SearchDlg.cpp:1092 src/SearchListCtrl.cpp:735
+#: src/SearchDlg.cpp:929 src/SearchListCtrl.cpp:735
 msgid "Main"
 msgstr "Hovud"
 

--- a/po/nn.po
+++ b/po/nn.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-28 08:06+0200\n"
+"POT-Creation-Date: 2026-07-28 10:19+0200\n"
 "PO-Revision-Date: 2026-07-27 11:42+0000\n"
 "Last-Translator: Hallvor Brunstad <Hallvor_1976@yahoo.com>\n"
 "Language-Team: <i18n-nn@lister.ping.uio.no>\n"
@@ -142,7 +142,7 @@ msgstr ""
 msgid "Not now"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:422 src/amuleDlg.cpp:600
+#: src/AppImageIntegration.cpp:422 src/amuleDlg.cpp:665
 msgid "Don't ask again"
 msgstr ""
 
@@ -219,7 +219,7 @@ msgid "Killing amuleweb instance with pid '%d' ... "
 msgstr ""
 
 #: src/amule.cpp:336 src/amule.cpp:349 src/ClientRef.cpp:180
-#: src/SearchDlg.cpp:880 src/ServerListCtrl.cpp:98
+#: src/SearchDlg.cpp:1041 src/ServerListCtrl.cpp:98
 msgid "Failed"
 msgstr "Mislukka"
 
@@ -577,30 +577,68 @@ msgstr ""
 msgid "ERROR: %s"
 msgstr "Feil: %s"
 
-#: src/amuleDlg.cpp:236
+#: src/amuleDlg.cpp:250
 #, c-format
 msgid "This is aMule %s based on eMule."
 msgstr "Dette er aMule %s basert på eMule."
 
-#: src/amuleDlg.cpp:237
+#: src/amuleDlg.cpp:251
 #, c-format
 msgid "Running on %s"
 msgstr "Køyrer på %s"
 
-#: src/amuleDlg.cpp:239
+#: src/amuleDlg.cpp:253
 msgid "Visit https://github.com/amule-org/amule/releases/latest to check if a new version is available."
 msgstr "Vitje https://github.com/amule-org/amule/releases/latest for å sjekke om ei ny utgåve er tilgjengeleg."
 
-#: src/amuleDlg.cpp:268
+#: src/amuleDlg.cpp:282
 msgid "FATAL ERROR: Failed to create Timer"
 msgstr "FATAL FEIL: Greidde ikkje å lage tidtakar"
 
-#: src/amuleDlg.cpp:592
+#: src/amuleDlg.cpp:361 src/amuleDlg.cpp:1787 src/amuleDlg.cpp:2033
+#: src/muuli_wdr.cpp:1492 src/muuli_wdr.cpp:3418
+msgid "Networks"
+msgstr "Nettverk"
+
+#: src/amuleDlg.cpp:362 src/amuleDlg.cpp:1793 src/muuli_wdr.cpp:3419
+msgid "Searches"
+msgstr "Søk"
+
+#: src/amuleDlg.cpp:363 src/amuleDlg.cpp:1799 src/DownloadListCtrl.cpp:740
+#: src/muuli_wdr.cpp:392 src/muuli_wdr.cpp:1585 src/muuli_wdr.cpp:3420
+#: src/Statistics.cpp:829
+msgid "Downloads"
+msgstr "Nedlastingar"
+
+#: src/amuleDlg.cpp:364 src/amuleDlg.cpp:1805 src/muuli_wdr.cpp:3294
+msgid "Shared files"
+msgstr "Delte filer"
+
+#: src/amuleDlg.cpp:365 src/amuleDlg.cpp:1811 src/muuli_wdr.cpp:2926
+#: src/muuli_wdr.cpp:3376 src/muuli_wdr.cpp:3423
+msgid "Messages"
+msgstr "Meldingar"
+
+#: src/amuleDlg.cpp:366 src/amuleDlg.cpp:1817 src/muuli_wdr.cpp:3424
+#: src/PrefsUnifiedDlg.cpp:312 src/Statistics.cpp:779 src/Statistics.cpp:1235
+msgid "Statistics"
+msgstr "Statistikk"
+
+#: src/amuleDlg.cpp:368 src/amuleDlg.cpp:1824 src/muuli_wdr.cpp:3426
+#: src/PrefsUnifiedDlg.cpp:328 src/utils/wxCas/src/wxcasprefs.cpp:39
+msgid "Preferences"
+msgstr "Innstillingar"
+
+#: src/amuleDlg.cpp:371
+msgid "Navigate"
+msgstr ""
+
+#: src/amuleDlg.cpp:657
 #, fuzzy
 msgid "New version available"
 msgstr "Ikkje tilgjengeleg"
 
-#: src/amuleDlg.cpp:596
+#: src/amuleDlg.cpp:661
 #, fuzzy, c-format
 msgid ""
 "A new version of aMule (%s) is available.\n"
@@ -610,219 +648,186 @@ msgid ""
 "Would you like to open the download page?"
 msgstr "Den siste utgåva finst alltid på https://github.com/amule-org/amule/releases/latest"
 
-#: src/amuleDlg.cpp:678
+#: src/amuleDlg.cpp:743
 msgid "aMule dialog destroyed"
 msgstr ""
 
-#: src/amuleDlg.cpp:701 src/DataToText.cpp:68 src/IPFilter.cpp:547
+#: src/amuleDlg.cpp:766 src/DataToText.cpp:68 src/IPFilter.cpp:547
 msgid "Connecting"
 msgstr "Koplar til"
 
-#: src/amuleDlg.cpp:893
+#: src/amuleDlg.cpp:958
 msgid "eD2k: Connecting"
 msgstr "eD2k: Koplar til"
 
-#: src/amuleDlg.cpp:897
+#: src/amuleDlg.cpp:962
 msgid "eD2k: Disconnected"
 msgstr "eD2k: Fråkopla"
 
-#: src/amuleDlg.cpp:903
+#: src/amuleDlg.cpp:968
 msgid "Kad: Firewalled"
 msgstr "Kad: Brannmura"
 
-#: src/amuleDlg.cpp:907
+#: src/amuleDlg.cpp:972
 msgid "Kad: Connected"
 msgstr "Kad: Tilkopla"
 
-#: src/amuleDlg.cpp:912
+#: src/amuleDlg.cpp:977
 msgid "Kad: Connecting"
 msgstr "Kad: Koplar til"
 
-#: src/amuleDlg.cpp:916
+#: src/amuleDlg.cpp:981
 msgid "Kad: Off"
 msgstr "Kad: Av"
 
-#: src/amuleDlg.cpp:964 src/DownloadListCtrl.cpp:505
+#: src/amuleDlg.cpp:1029 src/DownloadListCtrl.cpp:505
 #: src/DownloadListCtrl.cpp:749 src/FriendListCtrl.cpp:180
 #: src/muuli_wdr.cpp:731 src/muuli_wdr.cpp:782 src/muuli_wdr.cpp:846
-#: src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2224 src/muuli_wdr.cpp:2309
-#: src/muuli_wdr.cpp:3057 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
+#: src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2231 src/muuli_wdr.cpp:2316
+#: src/muuli_wdr.cpp:3064 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
 #: src/ServerListCtrl.cpp:606 src/TransferWnd.cpp:378
 #: src/utils/wxCas/src/wxcasprefs.cpp:235
 msgid "Cancel"
 msgstr "Avbryt"
 
-#: src/amuleDlg.cpp:965
+#: src/amuleDlg.cpp:1030
 msgid "Stop the current connection attempts"
 msgstr "Stopp inneverande oppkoplingsfreistingar"
 
-#: src/amuleDlg.cpp:970 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976
-#: src/muuli_wdr.cpp:2447
+#: src/amuleDlg.cpp:1035 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976
+#: src/muuli_wdr.cpp:2454
 msgid "Disconnect"
 msgstr "Kople frå"
 
-#: src/amuleDlg.cpp:971
+#: src/amuleDlg.cpp:1036
 msgid "Disconnect from the currently connected networks"
 msgstr "Kople frå dei aktive nettverka"
 
-#: src/amuleDlg.cpp:976 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979
-#: src/muuli_wdr.cpp:2602 src/muuli_wdr.cpp:3054 src/muuli_wdr.cpp:3409
+#: src/amuleDlg.cpp:1041 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979
+#: src/muuli_wdr.cpp:2609 src/muuli_wdr.cpp:3061 src/muuli_wdr.cpp:3416
 msgid "Connect"
 msgstr "Kople til"
 
-#: src/amuleDlg.cpp:977
+#: src/amuleDlg.cpp:1042
 msgid "Connect to the currently enabled networks"
 msgstr "Kople til dei valde nettverka"
 
-#: src/amuleDlg.cpp:1089
+#: src/amuleDlg.cpp:1154
 #, fuzzy, c-format
 msgid "Up: %.1f%s (%.1f) | Down: %.1f%s (%.1f)"
 msgstr "Opp:·%.1f(%.1f)·|·Ned:·%.1f(%.1f)"
 
-#: src/amuleDlg.cpp:1091 src/amuleDlg.cpp:1093 src/amuleDlg.cpp:1097
-#: src/amuleDlg.cpp:1099 src/amuleDlg.cpp:1110 src/amuleDlg.cpp:1112
+#: src/amuleDlg.cpp:1156 src/amuleDlg.cpp:1158 src/amuleDlg.cpp:1162
+#: src/amuleDlg.cpp:1164 src/amuleDlg.cpp:1175 src/amuleDlg.cpp:1177
 #: src/MuleTrayIcon.cpp:796 src/MuleTrayIcon.cpp:799
 #, fuzzy
 msgid " MB/s"
 msgstr "MB/s"
 
-#: src/amuleDlg.cpp:1091 src/amuleDlg.cpp:1093 src/amuleDlg.cpp:1097
-#: src/amuleDlg.cpp:1099 src/amuleDlg.cpp:1110 src/amuleDlg.cpp:1112
+#: src/amuleDlg.cpp:1156 src/amuleDlg.cpp:1158 src/amuleDlg.cpp:1162
+#: src/amuleDlg.cpp:1164 src/amuleDlg.cpp:1175 src/amuleDlg.cpp:1177
 #: src/MuleTrayIcon.cpp:796 src/MuleTrayIcon.cpp:799
 #: src/utils/wxCas/src/wxcasframe.cpp:1041
 msgid " kB/s"
 msgstr " kB/s"
 
-#: src/amuleDlg.cpp:1096
+#: src/amuleDlg.cpp:1161
 #, fuzzy, c-format
 msgid "Up: %.1f%s | Down: %.1f%s"
 msgstr "Opp:·%.1f·|·Ned:·%.1f"
 
-#: src/amuleDlg.cpp:1128
+#: src/amuleDlg.cpp:1193
 #, c-format
 msgid "aMule (%s | Connected)"
 msgstr "aMule·(%s·|·Tilkopla)"
 
-#: src/amuleDlg.cpp:1130
+#: src/amuleDlg.cpp:1195
 #, c-format
 msgid "aMule (%s | Disconnected)"
 msgstr "aMule·(%s·|·Fråkopla)"
 
-#: src/amuleDlg.cpp:1183
+#: src/amuleDlg.cpp:1248
 #, fuzzy, c-format
 msgid "Do you really want to exit %s?"
 msgstr "Vil du verkeleg avslutte aMule?"
 
-#: src/amuleDlg.cpp:1185
+#: src/amuleDlg.cpp:1250
 msgid "Exit confirmation"
 msgstr "Stadfesting av avslutting"
 
-#: src/amuleDlg.cpp:1548
+#: src/amuleDlg.cpp:1613
 msgid "Launch Command: "
 msgstr ""
 
-#: src/amuleDlg.cpp:1567 src/muuli_wdr.cpp:1971 src/Preferences.cpp:951
+#: src/amuleDlg.cpp:1632 src/muuli_wdr.cpp:1978 src/Preferences.cpp:952
 msgid "- default -"
 msgstr ""
 
-#: src/amuleDlg.cpp:1595
+#: src/amuleDlg.cpp:1660
 #, c-format
 msgid "Skin directory '%s' does not exist"
 msgstr "Skinnkatalogen '%s' finst ikkje"
 
-#: src/amuleDlg.cpp:1598
+#: src/amuleDlg.cpp:1663
 #, c-format
 msgid "WARNING: Unable to open skin file '%s' for read"
 msgstr "ÅTVARING: Greidde ikkje å opne hudfila '%s' for lesing"
 
-#: src/amuleDlg.cpp:1722 src/amuleDlg.cpp:1968 src/muuli_wdr.cpp:1485
-#: src/muuli_wdr.cpp:3411
-msgid "Networks"
-msgstr "Nettverk"
-
-#: src/amuleDlg.cpp:1726 src/muuli_wdr.cpp:3411
+#: src/amuleDlg.cpp:1791 src/muuli_wdr.cpp:3418
 msgid "Networks Window"
 msgstr "Nettverksavindauge"
 
-#: src/amuleDlg.cpp:1728 src/muuli_wdr.cpp:3412
-msgid "Searches"
-msgstr "Søk"
-
-#: src/amuleDlg.cpp:1732 src/muuli_wdr.cpp:3412
+#: src/amuleDlg.cpp:1797 src/muuli_wdr.cpp:3419
 msgid "Searches Window"
 msgstr "Søkjevindauge"
 
-#: src/amuleDlg.cpp:1734 src/DownloadListCtrl.cpp:740 src/muuli_wdr.cpp:392
-#: src/muuli_wdr.cpp:1578 src/muuli_wdr.cpp:3413 src/Statistics.cpp:829
-msgid "Downloads"
-msgstr "Nedlastingar"
-
-#: src/amuleDlg.cpp:1738 src/muuli_wdr.cpp:3413
+#: src/amuleDlg.cpp:1803 src/muuli_wdr.cpp:3420
 #, fuzzy
 msgid "Downloads Window"
 msgstr "Lastar ned"
 
-#: src/amuleDlg.cpp:1740 src/muuli_wdr.cpp:3287
-msgid "Shared files"
-msgstr "Delte filer"
-
-#: src/amuleDlg.cpp:1744 src/muuli_wdr.cpp:3415
+#: src/amuleDlg.cpp:1809 src/muuli_wdr.cpp:3422
 msgid "Shared Files Window"
 msgstr "Vindauge for delte filer"
 
-#: src/amuleDlg.cpp:1746 src/muuli_wdr.cpp:2919 src/muuli_wdr.cpp:3369
-#: src/muuli_wdr.cpp:3416
-msgid "Messages"
-msgstr "Meldingar"
-
-#: src/amuleDlg.cpp:1750 src/muuli_wdr.cpp:3416
+#: src/amuleDlg.cpp:1815 src/muuli_wdr.cpp:3423
 msgid "Messages Window"
 msgstr "Meldingsvindauge"
 
-#: src/amuleDlg.cpp:1752 src/muuli_wdr.cpp:3417 src/PrefsUnifiedDlg.cpp:312
-#: src/Statistics.cpp:779 src/Statistics.cpp:1235
-msgid "Statistics"
-msgstr "Statistikk"
-
-#: src/amuleDlg.cpp:1756 src/muuli_wdr.cpp:3417
+#: src/amuleDlg.cpp:1821 src/muuli_wdr.cpp:3424
 msgid "Statistics Graph Window"
 msgstr "Statistikkgrafvindauge"
 
-#: src/amuleDlg.cpp:1759 src/muuli_wdr.cpp:3419 src/PrefsUnifiedDlg.cpp:328
-#: src/utils/wxCas/src/wxcasprefs.cpp:39
-msgid "Preferences"
-msgstr "Innstillingar"
-
-#: src/amuleDlg.cpp:1763 src/muuli_wdr.cpp:3419
+#: src/amuleDlg.cpp:1828 src/muuli_wdr.cpp:3426
 msgid "Preferences Settings Window"
 msgstr "Innstillingsvalsvindauge"
 
-#: src/amuleDlg.cpp:1766 src/muuli_wdr.cpp:3420
+#: src/amuleDlg.cpp:1831 src/muuli_wdr.cpp:3427
 msgid "Import"
 msgstr "Importér"
 
-#: src/amuleDlg.cpp:1770 src/muuli_wdr.cpp:3420
+#: src/amuleDlg.cpp:1835 src/muuli_wdr.cpp:3427
 msgid "The partfile importer tool"
 msgstr "Verkty for delfilimport"
 
-#: src/amuleDlg.cpp:1773 src/muuli_wdr.cpp:3421
+#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3428
 #: src/utils/aLinkCreator/src/alcframe.cpp:262
 msgid "About"
 msgstr "Om"
 
-#: src/amuleDlg.cpp:1773 src/muuli_wdr.cpp:3421
+#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3428
 msgid "About/Help"
 msgstr "Om/hjelp"
 
-#: src/amuleDlg.cpp:1971
+#: src/amuleDlg.cpp:2036
 msgid "eD2k network"
 msgstr "ed2k nettverk"
 
-#: src/amuleDlg.cpp:1974
+#: src/amuleDlg.cpp:2039
 msgid "Kad network"
 msgstr "Kad nettverk"
 
-#: src/amuleDlg.cpp:1974
+#: src/amuleDlg.cpp:2039
 msgid "No network"
 msgstr "Ikkje noko nettverk"
 
@@ -1359,19 +1364,19 @@ msgstr "Auto·[Hø]"
 msgid "Very low"
 msgstr "Svært låg"
 
-#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:743 src/muuli_wdr.cpp:2275
+#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:743 src/muuli_wdr.cpp:2282
 #: src/ServerListCtrl.cpp:263 src/ServerListCtrl.cpp:456
 #: src/SharedFilesCtrl.cpp:145
 msgid "Low"
 msgstr "Låg"
 
-#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:744 src/muuli_wdr.cpp:2276
+#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:744 src/muuli_wdr.cpp:2283
 #: src/ServerListCtrl.cpp:266 src/ServerListCtrl.cpp:457
 #: src/SharedFilesCtrl.cpp:146
 msgid "Normal"
 msgstr "Vanleg"
 
-#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:745 src/muuli_wdr.cpp:2277
+#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:745 src/muuli_wdr.cpp:2284
 #: src/ServerListCtrl.cpp:269 src/ServerListCtrl.cpp:458
 #: src/SharedFilesCtrl.cpp:147
 msgid "High"
@@ -1463,8 +1468,8 @@ msgstr "Lokal tenar"
 msgid "Remote Server"
 msgstr "Fjern tenar"
 
-#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3174
-#: src/SearchDlg.cpp:111 src/TextClient.cpp:911
+#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3181
+#: src/SearchDlg.cpp:119 src/TextClient.cpp:911
 msgid "Kad"
 msgstr "Kad"
 
@@ -1535,7 +1540,7 @@ msgstr ""
 msgid "Size"
 msgstr "Storleik"
 
-#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3241
+#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3248
 msgid "Transferred"
 msgstr "Overført"
 
@@ -1593,7 +1598,7 @@ msgstr ""
 "Tilbakemelding frå: %s (%s)\n"
 "\n"
 
-#: src/DownloadListCtrl.cpp:746 src/muuli_wdr.cpp:2278
+#: src/DownloadListCtrl.cpp:746 src/muuli_wdr.cpp:2285
 #: src/SharedFilesCtrl.cpp:150
 msgid "Auto"
 msgstr "Automatisk"
@@ -1631,7 +1636,7 @@ msgid "Extended Options"
 msgstr "Utvida innstillingar"
 
 #: src/DownloadListCtrl.cpp:770 src/DownloadListCtrl.cpp:822
-#: src/muuli_wdr.cpp:1789
+#: src/muuli_wdr.cpp:1796
 msgid "Preview"
 msgstr "Førehandssyning"
 
@@ -2345,19 +2350,19 @@ msgstr ""
 msgid "eD2k"
 msgstr "eD2k"
 
-#: src/FirstRunWizard.cpp:349 src/muuli_wdr.cpp:1488
+#: src/FirstRunWizard.cpp:349 src/muuli_wdr.cpp:1495
 msgid "Kademlia"
 msgstr "Kademlia"
 
-#: src/FirstRunWizard.cpp:359 src/muuli_wdr.cpp:1416
+#: src/FirstRunWizard.cpp:359 src/muuli_wdr.cpp:1423
 msgid "Standard TCP Port "
 msgstr ""
 
-#: src/FirstRunWizard.cpp:365 src/muuli_wdr.cpp:1428
+#: src/FirstRunWizard.cpp:365 src/muuli_wdr.cpp:1435
 msgid "Extended UDP port (Kad / global search) "
 msgstr ""
 
-#: src/FirstRunWizard.cpp:377 src/muuli_wdr.cpp:1435
+#: src/FirstRunWizard.cpp:377 src/muuli_wdr.cpp:1442
 msgid "Enable UPnP for router port forwarding"
 msgstr ""
 
@@ -2384,7 +2389,7 @@ msgstr ""
 msgid "Your peer lists are already in place - nothing to download."
 msgstr "Du freistar allereie nedlasting av fila %s"
 
-#: src/FirstRunWizard.cpp:434 src/muuli_wdr.cpp:1533
+#: src/FirstRunWizard.cpp:434 src/muuli_wdr.cpp:1540
 msgid "Auto-update server list at startup"
 msgstr "Automatisk oppdatering av tenarlista ved oppstart"
 
@@ -2430,23 +2435,23 @@ msgid ""
 "want downloads on a different (e.g. larger) disk."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:549 src/FirstRunWizard.cpp:611 src/muuli_wdr.cpp:1701
+#: src/FirstRunWizard.cpp:549 src/FirstRunWizard.cpp:611 src/muuli_wdr.cpp:1708
 msgid "Destination folder for downloads"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:553 src/FirstRunWizard.cpp:569 src/muuli_wdr.cpp:1342
-#: src/muuli_wdr.cpp:1359 src/muuli_wdr.cpp:1676 src/muuli_wdr.cpp:1707
-#: src/muuli_wdr.cpp:1719 src/muuli_wdr.cpp:2762
+#: src/FirstRunWizard.cpp:553 src/FirstRunWizard.cpp:569 src/muuli_wdr.cpp:1349
+#: src/muuli_wdr.cpp:1366 src/muuli_wdr.cpp:1683 src/muuli_wdr.cpp:1714
+#: src/muuli_wdr.cpp:1726 src/muuli_wdr.cpp:2769
 #: src/utils/aLinkCreator/src/alcframe.cpp:135
 #: src/utils/wxCas/src/wxcasprefs.cpp:52 src/utils/wxCas/src/wxcasprefs.cpp:118
 msgid "Browse"
 msgstr "Bla"
 
-#: src/FirstRunWizard.cpp:559 src/muuli_wdr.cpp:1712
+#: src/FirstRunWizard.cpp:559 src/muuli_wdr.cpp:1719
 msgid "(All files in this folder are shared with other peers)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:565 src/FirstRunWizard.cpp:624 src/muuli_wdr.cpp:1714
+#: src/FirstRunWizard.cpp:565 src/FirstRunWizard.cpp:624 src/muuli_wdr.cpp:1721
 msgid "Folder for temporary download files"
 msgstr ""
 
@@ -2477,7 +2482,7 @@ msgstr "Greidde ikkje å opne venelista 'enfriends.met' for skriving!"
 msgid "CRITICAL - no client on StartChatSession"
 msgstr ""
 
-#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2668 src/muuli_wdr.cpp:3345
+#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2675 src/muuli_wdr.cpp:3352
 msgid "Friends"
 msgstr "Vener"
 
@@ -2867,7 +2872,7 @@ msgstr "Delingsrate"
 msgid "Uploaded"
 msgstr "Lasta opp"
 
-#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3225
+#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3232
 msgid "Requested"
 msgstr "Etterspurt"
 
@@ -2993,7 +2998,7 @@ msgid "WARNING: "
 msgstr "ÅTVARING: "
 
 #: src/MuleNotebook.cpp:179 src/muuli_wdr.cpp:817 src/muuli_wdr.cpp:1229
-#: src/muuli_wdr.cpp:3129 src/muuli_wdr.cpp:3385
+#: src/muuli_wdr.cpp:3136 src/muuli_wdr.cpp:3392
 msgid "Close"
 msgstr "Stengje"
 
@@ -3006,12 +3011,12 @@ msgstr "Klipp ut"
 msgid "Copy"
 msgstr "Kopiér"
 
-#: src/MuleTextCtrl.cpp:88
+#: src/MuleTextCtrl.cpp:88 src/SearchDlg.cpp:261
 msgid "Paste"
 msgstr "Lim inn"
 
 #: src/MuleTextCtrl.cpp:89 src/muuli_wdr.cpp:358 src/muuli_wdr.cpp:757
-#: src/muuli_wdr.cpp:2352 src/muuli_wdr.cpp:2371 src/muuli_wdr.cpp:2393
+#: src/muuli_wdr.cpp:2359 src/muuli_wdr.cpp:2378 src/muuli_wdr.cpp:2400
 #: src/utils/aLinkCreator/src/alcframe.cpp:142
 msgid "Clear"
 msgstr "Frigjer plass"
@@ -3109,8 +3114,8 @@ msgid "Exit"
 msgstr "Avslutt"
 
 #: src/MuleTrayIcon.cpp:579 src/MuleTrayIcon.cpp:945 src/MuleTrayIcon.cpp:965
-#: src/muuli_wdr.cpp:1391 src/muuli_wdr.cpp:1399 src/muuli_wdr.cpp:1406
-#: src/muuli_wdr.cpp:1835 src/muuli_wdr.cpp:1841 src/OtherFunctions.cpp:91
+#: src/muuli_wdr.cpp:1398 src/muuli_wdr.cpp:1406 src/muuli_wdr.cpp:1413
+#: src/muuli_wdr.cpp:1842 src/muuli_wdr.cpp:1848 src/OtherFunctions.cpp:91
 #: src/StatisticsDlg.cpp:93 src/StatisticsDlg.cpp:95
 msgid "kB/s"
 msgstr "kB/s"
@@ -3281,7 +3286,7 @@ msgstr "Namn:"
 msgid "Type"
 msgstr "Sort"
 
-#: src/muuli_wdr.cpp:215 src/SearchDlg.cpp:110 src/SearchListCtrl.cpp:853
+#: src/muuli_wdr.cpp:215 src/SearchDlg.cpp:118 src/SearchListCtrl.cpp:853
 msgid "Local"
 msgstr "Lokal"
 
@@ -3352,7 +3357,7 @@ msgstr "Bytes"
 msgid "KB"
 msgstr "KB"
 
-#: src/muuli_wdr.cpp:274 src/muuli_wdr.cpp:293 src/muuli_wdr.cpp:1620
+#: src/muuli_wdr.cpp:274 src/muuli_wdr.cpp:293 src/muuli_wdr.cpp:1627
 #: src/OtherFunctions.cpp:64
 msgid "MB"
 msgstr "MB"
@@ -3369,7 +3374,7 @@ msgstr "Maks storleik"
 msgid "Availability"
 msgstr "Tilgjenge"
 
-#: src/muuli_wdr.cpp:312 src/muuli_wdr.cpp:398 src/muuli_wdr.cpp:3290
+#: src/muuli_wdr.cpp:312 src/muuli_wdr.cpp:398 src/muuli_wdr.cpp:3297
 msgid "Filter:"
 msgstr "Filter:"
 
@@ -3401,7 +3406,7 @@ msgstr ""
 msgid "Stop"
 msgstr "Stopp"
 
-#: src/muuli_wdr.cpp:348 src/muuli_wdr.cpp:1385 src/SearchListCtrl.cpp:732
+#: src/muuli_wdr.cpp:348 src/muuli_wdr.cpp:1392 src/SearchListCtrl.cpp:732
 msgid "Download"
 msgstr "Nedlasting"
 
@@ -3433,8 +3438,8 @@ msgstr "Komplette kjelder"
 #: src/muuli_wdr.cpp:1160 src/muuli_wdr.cpp:1167 src/muuli_wdr.cpp:1172
 #: src/muuli_wdr.cpp:1179 src/muuli_wdr.cpp:1184 src/muuli_wdr.cpp:1191
 #: src/muuli_wdr.cpp:1205 src/muuli_wdr.cpp:1212 src/muuli_wdr.cpp:1217
-#: src/muuli_wdr.cpp:1224 src/muuli_wdr.cpp:3227 src/muuli_wdr.cpp:3235
-#: src/muuli_wdr.cpp:3243
+#: src/muuli_wdr.cpp:1224 src/muuli_wdr.cpp:3234 src/muuli_wdr.cpp:3242
+#: src/muuli_wdr.cpp:3250
 msgid "N/A"
 msgstr "I/T"
 
@@ -3579,7 +3584,7 @@ msgstr ""
 msgid "Album :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:685 src/muuli_wdr.cpp:2247
+#: src/muuli_wdr.cpp:685 src/muuli_wdr.cpp:2254
 msgid "Title :"
 msgstr "Tittel :"
 
@@ -3686,7 +3691,7 @@ msgstr "Brukarnamn :"
 msgid "Userhash :"
 msgstr "Brukarhash :"
 
-#: src/muuli_wdr.cpp:895 src/muuli_wdr.cpp:1741 src/muuli_wdr.cpp:2442
+#: src/muuli_wdr.cpp:895 src/muuli_wdr.cpp:1748 src/muuli_wdr.cpp:2449
 #: src/utils/aLinkCreator/src/alcframe.cpp:137
 msgid "Add"
 msgstr "Legg til"
@@ -3695,15 +3700,15 @@ msgstr "Legg til"
 msgid "Download-Speed"
 msgstr "Nedlastingsfart"
 
-#: src/muuli_wdr.cpp:954 src/muuli_wdr.cpp:989 src/muuli_wdr.cpp:2546
+#: src/muuli_wdr.cpp:954 src/muuli_wdr.cpp:989 src/muuli_wdr.cpp:2553
 msgid "Current"
 msgstr "Novérande"
 
-#: src/muuli_wdr.cpp:962 src/muuli_wdr.cpp:997 src/muuli_wdr.cpp:2554
+#: src/muuli_wdr.cpp:962 src/muuli_wdr.cpp:997 src/muuli_wdr.cpp:2561
 msgid "Running average"
 msgstr "Køyregjennomsnitt"
 
-#: src/muuli_wdr.cpp:970 src/muuli_wdr.cpp:1005 src/muuli_wdr.cpp:2562
+#: src/muuli_wdr.cpp:970 src/muuli_wdr.cpp:1005 src/muuli_wdr.cpp:2569
 msgid "Session average"
 msgstr "Gjennomsnitt økt"
 
@@ -3715,7 +3720,7 @@ msgstr "Opplastingsfart"
 msgid "Connections"
 msgstr "Koplingar"
 
-#: src/muuli_wdr.cpp:1024 src/muuli_wdr.cpp:1860
+#: src/muuli_wdr.cpp:1024 src/muuli_wdr.cpp:1867
 msgid "Active downloads"
 msgstr "Aktive nedlastingar"
 
@@ -3723,7 +3728,7 @@ msgstr "Aktive nedlastingar"
 msgid "Active connections (1:1)"
 msgstr "Aktive koplingar (1:1)"
 
-#: src/muuli_wdr.cpp:1040 src/muuli_wdr.cpp:1861
+#: src/muuli_wdr.cpp:1040 src/muuli_wdr.cpp:1868
 msgid "Active uploads"
 msgstr "Aktive opplastingar"
 
@@ -3840,8 +3845,8 @@ msgstr "Dette er namnet andre brukarar vil sjå når dei koplar til  maskina di.
 msgid "Language: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1257 src/muuli_wdr.cpp:1323 src/muuli_wdr.cpp:1327
-#: src/muuli_wdr.cpp:1330
+#: src/muuli_wdr.cpp:1257 src/muuli_wdr.cpp:1330 src/muuli_wdr.cpp:1334
+#: src/muuli_wdr.cpp:1337
 msgid "The delay before showing tool-tips."
 msgstr "Forseinkinga før ein syner verktytips."
 
@@ -3919,938 +3924,947 @@ msgstr ""
 msgid "Enabling this will make aMule to show notifications when finished downloading."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1322
-msgid "Tooltip delay time: "
+#: src/muuli_wdr.cpp:1323
+#, fuzzy
+msgid "Remember search history"
+msgstr "Hugs desse innstillingane"
+
+#: src/muuli_wdr.cpp:1324
+msgid "Keeps a dropdown list of your past search terms in the Search tab's Name field. This remembers the queries you typed, not the results they returned."
 msgstr ""
 
 #: src/muuli_wdr.cpp:1329
+msgid "Tooltip delay time: "
+msgstr ""
+
+#: src/muuli_wdr.cpp:1336
 msgid "seconds"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1333
+#: src/muuli_wdr.cpp:1340
 msgid "Browser Selection"
 msgstr "Nettlesarval"
 
-#: src/muuli_wdr.cpp:1339
+#: src/muuli_wdr.cpp:1346
 msgid "Enter your browser name here. Leave this field empty to use the system default browser."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1346
+#: src/muuli_wdr.cpp:1353
 msgid "Open in new tab if possible"
 msgstr "Opne nytt faneblad dersom mogleg"
 
-#: src/muuli_wdr.cpp:1348
+#: src/muuli_wdr.cpp:1355
 msgid "Open the web page in a new tab instead of in a new window when possible"
 msgstr "Opne ny nettside i nytt faneblad i staden for nytt vindauge når mogleg"
 
-#: src/muuli_wdr.cpp:1352
+#: src/muuli_wdr.cpp:1359
 msgid "Video Player"
 msgstr "Videospelar"
 
-#: src/muuli_wdr.cpp:1379
+#: src/muuli_wdr.cpp:1386
 msgid "Bandwidth limits"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1393
+#: src/muuli_wdr.cpp:1400
 msgid "Upload"
 msgstr "Opplasting"
 
-#: src/muuli_wdr.cpp:1401
+#: src/muuli_wdr.cpp:1408
 msgid "Slot Allocation"
 msgstr "Opningsdistribusjon"
 
-#: src/muuli_wdr.cpp:1410
+#: src/muuli_wdr.cpp:1417
 msgid "Ports"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1420
+#: src/muuli_wdr.cpp:1427
 msgid "This is the standard eD2k port and cannot be disabled."
 msgstr "Dette er standardporten for eD2k og kan ikkje deaktiverast"
 
-#: src/muuli_wdr.cpp:1423
+#: src/muuli_wdr.cpp:1430
 msgid "UDP port for server requests (TCP+3):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1425
+#: src/muuli_wdr.cpp:1432
 msgid "4665"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1432
+#: src/muuli_wdr.cpp:1439
 msgid "This UDP port is used for extended eD2k requests and Kad network"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1439
+#: src/muuli_wdr.cpp:1446
 msgid "UPnP TCP Port (Optional):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1449
+#: src/muuli_wdr.cpp:1456
 msgid "Bind local address to IP (empty for any):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1452
+#: src/muuli_wdr.cpp:1459
 msgid "Advanced users only: If you have multiple network interfaces, enter the address of the interface to which aMule should be bound."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1455 src/muuli_wdr.cpp:2054
+#: src/muuli_wdr.cpp:1462 src/muuli_wdr.cpp:2061
 msgid "Bind to network interface (empty for any):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1468
+#: src/muuli_wdr.cpp:1475
 msgid "Advanced users only: pin all of aMule's traffic to one network interface, chosen from the list or typed in by name (e.g. tun0, eth0, en0) or index. Unlike binding to an IP, this stops traffic leaking out via the default route - useful with a VPN. Requires no elevated privileges."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1474
+#: src/muuli_wdr.cpp:1481
 msgid "Max sources per downloading file:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1478
+#: src/muuli_wdr.cpp:1485
 msgid "Max simultaneous connections:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1491 src/muuli_wdr.cpp:3169
+#: src/muuli_wdr.cpp:1498 src/muuli_wdr.cpp:3176
 msgid "ED2K"
 msgstr "ED2k"
 
-#: src/muuli_wdr.cpp:1498
+#: src/muuli_wdr.cpp:1505
 msgid "Autoconnect on startup"
 msgstr "Automatisk tilkopling ved oppstart"
 
-#: src/muuli_wdr.cpp:1501
+#: src/muuli_wdr.cpp:1508
 msgid "Reconnect on loss"
 msgstr "Kople til dersom fråkopla"
 
-#: src/muuli_wdr.cpp:1523
+#: src/muuli_wdr.cpp:1530
 msgid "Remove dead server after"
 msgstr "Ta bort daude tenarar etter"
 
-#: src/muuli_wdr.cpp:1524
+#: src/muuli_wdr.cpp:1531
 msgid "Static servers are never removed, even when unreachable."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1528
+#: src/muuli_wdr.cpp:1535
 msgid "retries"
 msgstr "freistnader"
 
-#: src/muuli_wdr.cpp:1536
+#: src/muuli_wdr.cpp:1543
 msgid "List"
 msgstr "Liste"
 
-#: src/muuli_wdr.cpp:1539
+#: src/muuli_wdr.cpp:1546
 msgid "Update server list when connecting to a server"
 msgstr "Oppdater tenarlista ved oppkopling til ein tenar"
 
-#: src/muuli_wdr.cpp:1542
+#: src/muuli_wdr.cpp:1549
 msgid "Update server list when a client connects"
 msgstr "Oppdater tenarlista når ein klient koplar til"
 
-#: src/muuli_wdr.cpp:1545
+#: src/muuli_wdr.cpp:1552
 msgid "Use priority system"
 msgstr "Bruk prioritetssystem"
 
-#: src/muuli_wdr.cpp:1549
+#: src/muuli_wdr.cpp:1556
 msgid "Use smart LowID check on connect"
 msgstr "Bruk smart LågID sjekk ved tilkopling"
 
-#: src/muuli_wdr.cpp:1553
+#: src/muuli_wdr.cpp:1560
 msgid "Safe connect"
 msgstr "Trygg tilkopling"
 
-#: src/muuli_wdr.cpp:1557
+#: src/muuli_wdr.cpp:1564
 msgid "Autoconnect to servers in static list only"
 msgstr "Automatisk tilkopling berre til tenarar i statisk liste"
 
-#: src/muuli_wdr.cpp:1560
+#: src/muuli_wdr.cpp:1567
 msgid "Set manually added servers to High Priority"
 msgstr "Gje høg prioritet til manuelt tillagde tenarar"
 
-#: src/muuli_wdr.cpp:1581
+#: src/muuli_wdr.cpp:1588
 msgid "Add files to download in pause mode"
 msgstr "Legg filer til nedlasting i pausemodus"
 
-#: src/muuli_wdr.cpp:1583
+#: src/muuli_wdr.cpp:1590
 msgid "Add files to download with auto priority"
 msgstr "Legg filer til nedlasting med autoprioritet"
 
-#: src/muuli_wdr.cpp:1586
+#: src/muuli_wdr.cpp:1593
 msgid "Try to download first and last chunks first"
 msgstr "Prøv å laste ned første og siste del først"
 
-#: src/muuli_wdr.cpp:1590
+#: src/muuli_wdr.cpp:1597
 msgid "Endgame mode: rotate to faster sources for the final blocks"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1593
+#: src/muuli_wdr.cpp:1600
 msgid "Start next paused file when a file completes"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1596
+#: src/muuli_wdr.cpp:1603
 msgid "From the same category"
 msgstr "Frå same kategori"
 
-#: src/muuli_wdr.cpp:1598
+#: src/muuli_wdr.cpp:1605
 msgid "In alphabetic order"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1600
+#: src/muuli_wdr.cpp:1607
 msgid "Preallocate disk space for new files"
 msgstr "Hent diskplass for nye filer"
 
-#: src/muuli_wdr.cpp:1601
+#: src/muuli_wdr.cpp:1608
 msgid "For new files preallocates disk space for the whole file, thus reduces fragmentation"
 msgstr "Hentar diskplass for heile nye filer, og reduserer fragmentering"
 
-#: src/muuli_wdr.cpp:1606
+#: src/muuli_wdr.cpp:1613
 msgid "Create new files as sparse files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1607
+#: src/muuli_wdr.cpp:1614
 msgid "A sparse file reserves its full size on disk immediately without writing real data to it -- fast, but unsupported or slow on some filesystems, and free-space accounting stays optimistic while the download is in progress. Turn this off to grow the file only as data arrives."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1612
+#: src/muuli_wdr.cpp:1619
 msgid "Stop downloads when free disk space reaches "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1613
+#: src/muuli_wdr.cpp:1620
 msgid "Select this if you want aMule to check your disk space"
 msgstr "Vel denne dersom du vil at aMule skal sjekke om du har nok diskplass"
 
-#: src/muuli_wdr.cpp:1617
+#: src/muuli_wdr.cpp:1624
 msgid "Enter here the min disk space desired."
 msgstr "Skriv inn mimimum ønska diskplass."
 
-#: src/muuli_wdr.cpp:1623
+#: src/muuli_wdr.cpp:1630
 msgid "Save 10 sources on rare files (< 20 sources)"
 msgstr "Lagre 10 kjelder til sjeldne filer (< 20 kjelder)"
 
-#: src/muuli_wdr.cpp:1627 src/Statistics.cpp:790
+#: src/muuli_wdr.cpp:1634 src/Statistics.cpp:790
 msgid "Uploads"
 msgstr "Opplastingar"
 
-#: src/muuli_wdr.cpp:1630
+#: src/muuli_wdr.cpp:1637
 msgid "Add new shared files with auto priority"
 msgstr "Legg til nye delte filer med autoprioritet"
 
-#: src/muuli_wdr.cpp:1636
+#: src/muuli_wdr.cpp:1643
 msgid "Intelligent Corruption Handling (I.C.H.)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1639
+#: src/muuli_wdr.cpp:1646
 msgid "Enable"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1642
+#: src/muuli_wdr.cpp:1649
 msgid "Advanced I.C.H. trusts every hash (not recommended)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1654 src/PrefsUnifiedDlg.cpp:1910
+#: src/muuli_wdr.cpp:1661 src/PrefsUnifiedDlg.cpp:1910
 msgid "Media metadata extraction"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1658
+#: src/muuli_wdr.cpp:1665
 msgid "Extract length / bitrate / codec from shared audio and video files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1660
+#: src/muuli_wdr.cpp:1667
 msgid "When enabled, aMule runs ffprobe on each shared media file to fill in the Length / Bitrate / Codec columns other clients see when they find the file in a search. Requires ffmpeg (the ffprobe binary) to be installed."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1667
+#: src/muuli_wdr.cpp:1674
 msgid "Path to ffprobe:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1672
+#: src/muuli_wdr.cpp:1679
 msgid "Full path to the ffprobe binary. Leave empty to have aMule auto-detect it on startup."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1680
+#: src/muuli_wdr.cpp:1687
 msgid "Detect"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1681
+#: src/muuli_wdr.cpp:1688
 msgid "Search the standard install locations for an ffprobe binary and fill the path field."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1705
+#: src/muuli_wdr.cpp:1712
 msgid ""
 "Completed downloads are stored here. All files in this folder are automatically shared with other peers.\n"
 "If this folder also holds files you don't want to share, point it at an aMule-only sub-folder."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1708
+#: src/muuli_wdr.cpp:1715
 msgid "Pick the folder where completed downloads will be stored. All files in that folder will be shared with other peers."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1722
+#: src/muuli_wdr.cpp:1729
 msgid "Shared folders"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1728
+#: src/muuli_wdr.cpp:1735
 msgid "(Folders shared by the core. Enter a path to add one.)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1736
+#: src/muuli_wdr.cpp:1743
 msgid "Absolute path of a folder on the core's machine, e.g. /home/user/shared"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1738 src/PrefsUnifiedDlg.cpp:2794
+#: src/muuli_wdr.cpp:1745 src/PrefsUnifiedDlg.cpp:2794
 msgid "Recursive"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1739
+#: src/muuli_wdr.cpp:1746
 msgid "Share every sub-folder underneath this one, including ones created later."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1743 src/utils/aLinkCreator/src/alcframe.cpp:141
+#: src/muuli_wdr.cpp:1750 src/utils/aLinkCreator/src/alcframe.cpp:141
 msgid "Remove"
 msgstr "Ta bort"
 
-#: src/muuli_wdr.cpp:1747
+#: src/muuli_wdr.cpp:1754
 msgid "(Right click on folder icon for recursive share)"
 msgstr "(Høgreklikk på mappeikonet for å dele underkatalogar)"
 
-#: src/muuli_wdr.cpp:1754
+#: src/muuli_wdr.cpp:1761
 msgid "Share hidden files"
 msgstr "Dele gøymde filer"
 
-#: src/muuli_wdr.cpp:1760
+#: src/muuli_wdr.cpp:1767
 msgid "Automatically rescan shared folders for changes"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1766
+#: src/muuli_wdr.cpp:1773
 msgid "Follow symbolic links in shared folders"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1772
+#: src/muuli_wdr.cpp:1779
 msgid "Exclude files matching:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1775
+#: src/muuli_wdr.cpp:1782
 msgid "Wildcard patterns separated by '|', e.g. .DS_Store|Thumbs.db|*.tmp. Files whose name matches are not shared. Matching is case-insensitive."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1779
+#: src/muuli_wdr.cpp:1786
 msgid "Patterns are regular expressions"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1780
+#: src/muuli_wdr.cpp:1787
 msgid "When set, the whole field is one regular expression ('|' is alternation). When unset, it is a list of '|'-separated wildcards."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1790
+#: src/muuli_wdr.cpp:1797
 msgid "Show how many shared files the current pattern would exclude."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1811
+#: src/muuli_wdr.cpp:1818
 msgid "Graphs"
 msgstr "Grafar"
 
-#: src/muuli_wdr.cpp:1814 src/muuli_wdr.cpp:1876
+#: src/muuli_wdr.cpp:1821 src/muuli_wdr.cpp:1883
 msgid "Update delay : 5 secs"
 msgstr "Oppdateringsforseinking: 5 sek"
 
-#: src/muuli_wdr.cpp:1818
+#: src/muuli_wdr.cpp:1825
 msgid "Time for average graph: 100 mins"
 msgstr "Tid for gjennomsnittleg graf: 100 min"
 
-#: src/muuli_wdr.cpp:1822
+#: src/muuli_wdr.cpp:1829
 msgid "Connections Graph Scale: 100 "
 msgstr "Koplingsgrafskala: 100 "
 
-#: src/muuli_wdr.cpp:1829
+#: src/muuli_wdr.cpp:1836
 msgid "Download graph scale:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1837
+#: src/muuli_wdr.cpp:1844
 msgid "Upload graph scale:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1847
+#: src/muuli_wdr.cpp:1854
 msgid "Colors: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1851
+#: src/muuli_wdr.cpp:1858
 msgid "Background"
 msgstr "Bakgrunn"
 
-#: src/muuli_wdr.cpp:1852
+#: src/muuli_wdr.cpp:1859
 msgid "Grid"
 msgstr "Rutenett"
 
-#: src/muuli_wdr.cpp:1853
+#: src/muuli_wdr.cpp:1860
 msgid "Download current"
 msgstr "Last ned novérande"
 
-#: src/muuli_wdr.cpp:1854
+#: src/muuli_wdr.cpp:1861
 msgid "Download running average"
 msgstr "Last ned køyregjennomsnitt"
 
-#: src/muuli_wdr.cpp:1855
+#: src/muuli_wdr.cpp:1862
 msgid "Download session average"
 msgstr "Last ned øktgjennomsnitt"
 
-#: src/muuli_wdr.cpp:1856
+#: src/muuli_wdr.cpp:1863
 msgid "Upload current"
 msgstr "Opplasting no"
 
-#: src/muuli_wdr.cpp:1857
+#: src/muuli_wdr.cpp:1864
 msgid "Upload running average"
 msgstr "Gjennomsnittleg køyrande opplasting"
 
-#: src/muuli_wdr.cpp:1858
+#: src/muuli_wdr.cpp:1865
 msgid "Upload session average"
 msgstr "Gjennomsnittleg økt opplasting"
 
-#: src/muuli_wdr.cpp:1859
+#: src/muuli_wdr.cpp:1866
 msgid "Active connections"
 msgstr "Aktive koplingar"
 
-#: src/muuli_wdr.cpp:1862
+#: src/muuli_wdr.cpp:1869
 #, fuzzy
 msgid "Systray Icon Speed Bar"
 msgstr "Fartslinje i ikontrauet"
 
-#: src/muuli_wdr.cpp:1863
+#: src/muuli_wdr.cpp:1870
 msgid "Kad-nodes current"
 msgstr "Kadnodar no"
 
-#: src/muuli_wdr.cpp:1864
+#: src/muuli_wdr.cpp:1871
 msgid "Kad-nodes running"
 msgstr "Køyrande kadnodar"
 
-#: src/muuli_wdr.cpp:1865
+#: src/muuli_wdr.cpp:1872
 msgid "Kad-nodes session"
 msgstr "Kadnodar (økt)"
 
-#: src/muuli_wdr.cpp:1869 src/muuli_wdr.cpp:2296
+#: src/muuli_wdr.cpp:1876 src/muuli_wdr.cpp:2303
 msgid "Select"
 msgstr "Velje"
 
-#: src/muuli_wdr.cpp:1873
+#: src/muuli_wdr.cpp:1880
 msgid "Tree"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1883
+#: src/muuli_wdr.cpp:1890
 msgid "Number of Client Versions shown (0=unlimited)"
 msgstr "Tal på klienutgåver synt (0=uinnskrenka)"
 
-#: src/muuli_wdr.cpp:1908
+#: src/muuli_wdr.cpp:1915
 msgid "!!! WARNING !!!"
 msgstr "!!! ÅTVARING !!!"
 
-#: src/muuli_wdr.cpp:1923
+#: src/muuli_wdr.cpp:1930
 msgid "Max new connections / 5 secs"
 msgstr "Maks nye koplingar / 5 sek"
 
-#: src/muuli_wdr.cpp:1925
+#: src/muuli_wdr.cpp:1932
 msgid "Concurrent Kad source lookups"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1927
+#: src/muuli_wdr.cpp:1934
 #, fuzzy
 msgid "Kad source re-search interval (minutes)"
 msgstr "FTP oppdateringsintervall i minutt"
 
-#: src/muuli_wdr.cpp:1929
+#: src/muuli_wdr.cpp:1936
 #, fuzzy
 msgid "Source re-ask interval (minutes)"
 msgstr "FTP oppdateringsintervall i minutt"
 
-#: src/muuli_wdr.cpp:1933
+#: src/muuli_wdr.cpp:1940
 msgid "File Buffer Size: 240000 bytes"
 msgstr "Filbufferstorleik: 240000·bytes"
 
-#: src/muuli_wdr.cpp:1937
+#: src/muuli_wdr.cpp:1944
 msgid "Use MMAP: memory-mapped file access (lower memory use)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1938
+#: src/muuli_wdr.cpp:1945
 msgid "Maps part files into memory instead of buffering them on the heap, lowering the process memory footprint. May reduce download speed on some disks; best for memory-constrained or upload-heavy hosts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1940
+#: src/muuli_wdr.cpp:1947
 msgid "Upload Queue Size: 5000 clients"
 msgstr "Storleik på opplastingskø: 5000 klientar"
 
-#: src/muuli_wdr.cpp:1944
+#: src/muuli_wdr.cpp:1951
 msgid "Server connection refresh interval: Disable"
 msgstr "Oppfriskingsintervall for tenarkopling: Deaktiver"
 
-#: src/muuli_wdr.cpp:1948
+#: src/muuli_wdr.cpp:1955
 msgid "Disable computer's timed standby mode"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1967
+#: src/muuli_wdr.cpp:1974
 msgid "Skin to use: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1976
+#: src/muuli_wdr.cpp:1983
 msgid "Show \"Fast eD2k Links Handler\" in every window."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1979
+#: src/muuli_wdr.cpp:1986
 msgid "Show extended info on categories tabs"
 msgstr "Syne utvida informasjon i kategorifaneblad"
 
-#: src/muuli_wdr.cpp:1982
+#: src/muuli_wdr.cpp:1989
 #, fuzzy
 msgid "Show application version on title"
 msgstr "Syne overføringsfart i tittellinja"
 
-#: src/muuli_wdr.cpp:1984
+#: src/muuli_wdr.cpp:1991
 msgid "Show transfer rates on title"
 msgstr "Syne overføringsfart i tittellinja"
 
-#: src/muuli_wdr.cpp:1986
+#: src/muuli_wdr.cpp:1993
 msgid "Before application name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1988
+#: src/muuli_wdr.cpp:1995
 msgid "After application name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1991
+#: src/muuli_wdr.cpp:1998
 msgid "Show overhead bandwidth"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1995
+#: src/muuli_wdr.cpp:2002
 msgid "Vertical toolbar orientation"
 msgstr "Vertikal verktylinjeorientering"
 
-#: src/muuli_wdr.cpp:1997
+#: src/muuli_wdr.cpp:2004
 msgid "Live column sorting (auto-reorder rows as their values change)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2004
+#: src/muuli_wdr.cpp:2011
 msgid "Download Queue Files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2007
+#: src/muuli_wdr.cpp:2014
 msgid "Show progress percentage"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2013
+#: src/muuli_wdr.cpp:2020
 msgid "Show progress bar"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2016
+#: src/muuli_wdr.cpp:2023
 msgid "Flat"
 msgstr "Flat"
 
-#: src/muuli_wdr.cpp:2020
+#: src/muuli_wdr.cpp:2027
 msgid "Round"
 msgstr "Rund"
 
-#: src/muuli_wdr.cpp:2038
+#: src/muuli_wdr.cpp:2045
 msgid "External Connection Parameters"
 msgstr "Parameter for ekstern kopling"
 
-#: src/muuli_wdr.cpp:2041
+#: src/muuli_wdr.cpp:2048
 msgid "Accept external connections"
 msgstr "Akseptér eksterne koplingar"
 
-#: src/muuli_wdr.cpp:2048 src/muuli_wdr.cpp:2107
+#: src/muuli_wdr.cpp:2055 src/muuli_wdr.cpp:2114
 msgid "IP of the listening interface:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2051
+#: src/muuli_wdr.cpp:2058
 msgid "Enter here a valid ip in the a.b.c.d format for the listening EC interface. An empty field or 0.0.0.0 will mean any interface."
 msgstr "Skriv in ei gyldig IP i a.b.c.d format for det lyttande EC-grensesnittet. Eit tomt felt eller 0.0.0.0 betyr samtlege grensesnitt."
 
-#: src/muuli_wdr.cpp:2072 src/muuli_wdr.cpp:2156
+#: src/muuli_wdr.cpp:2079 src/muuli_wdr.cpp:2163
 msgid "TCP port:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2078
+#: src/muuli_wdr.cpp:2085
 msgid "Enable UPnP port forwarding on the EC port"
 msgstr "Aktivér UPnP-portvidaresending på EC-porten"
 
-#: src/muuli_wdr.cpp:2082 src/muuli_wdr.cpp:3041
+#: src/muuli_wdr.cpp:2089 src/muuli_wdr.cpp:3048
 #: src/utils/wxCas/src/wxcasprefs.cpp:167
 msgid "Password"
 msgstr "Passord"
 
-#: src/muuli_wdr.cpp:2088
+#: src/muuli_wdr.cpp:2095
 #, fuzzy
 msgid "aMule API server parameters"
 msgstr "Vevtenarparameter"
 
-#: src/muuli_wdr.cpp:2091
+#: src/muuli_wdr.cpp:2098
 msgid "Run amuleapi (REST API) on startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2096
+#: src/muuli_wdr.cpp:2103
 #, fuzzy
 msgid "HTTP port:"
 msgstr "TCP port: %d"
 
-#: src/muuli_wdr.cpp:2110
+#: src/muuli_wdr.cpp:2117
 msgid "The interface amuleapi's HTTP server listens on. 127.0.0.1 (default) accepts only local connections; use 0.0.0.0 or a specific IP to expose it to other hosts (set an admin password below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2113
+#: src/muuli_wdr.cpp:2120
 #, fuzzy
 msgid "Admin password"
 msgstr "Sjekkar passord\n"
 
-#: src/muuli_wdr.cpp:2118 src/muuli_wdr.cpp:2149
+#: src/muuli_wdr.cpp:2125 src/muuli_wdr.cpp:2156
 msgid "Low rights password"
 msgstr "Passord for låge rettar"
 
-#: src/muuli_wdr.cpp:2126
+#: src/muuli_wdr.cpp:2133
 msgid "Web server parameters"
 msgstr "Vevtenarparameter"
 
-#: src/muuli_wdr.cpp:2129
+#: src/muuli_wdr.cpp:2136
 msgid "Run webserver on startup (deprecated)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2135
+#: src/muuli_wdr.cpp:2142
 msgid "Web template"
 msgstr "Vevmønster"
 
-#: src/muuli_wdr.cpp:2140
+#: src/muuli_wdr.cpp:2147
 msgid "Full rights password"
 msgstr "Passord for fulle rettar"
 
-#: src/muuli_wdr.cpp:2144
+#: src/muuli_wdr.cpp:2151
 msgid "Enable Low rights User"
 msgstr "Aktivér brukar med få rettar"
 
-#: src/muuli_wdr.cpp:2163
+#: src/muuli_wdr.cpp:2170
 msgid "Enable UPnP port forwarding of the web server port"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2168
+#: src/muuli_wdr.cpp:2175
 msgid "Web server UPnP TCP port (Optional)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2176
+#: src/muuli_wdr.cpp:2183
 msgid "Page Refresh Time (in secs)"
 msgstr "Sideoppfriskingstid (i sekund)"
 
-#: src/muuli_wdr.cpp:2183
+#: src/muuli_wdr.cpp:2190
 msgid "Enable Gzip compression"
 msgstr "Aktivér Gzipkompresjon"
 
-#: src/muuli_wdr.cpp:2217
+#: src/muuli_wdr.cpp:2224
 #, fuzzy
 msgid "Reset page to defaults"
 msgstr "Standardinnstillingar"
 
-#: src/muuli_wdr.cpp:2218
+#: src/muuli_wdr.cpp:2225
 msgid "Reset the settings on the current page to their default values."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2220 src/muuli_wdr.cpp:2306 src/ServerWnd.cpp:274
+#: src/muuli_wdr.cpp:2227 src/muuli_wdr.cpp:2313 src/ServerWnd.cpp:274
 #: src/ServerWnd.cpp:282
 msgid "OK"
 msgstr "OK"
 
-#: src/muuli_wdr.cpp:2222
+#: src/muuli_wdr.cpp:2229
 msgid "Click here to apply any changes made to the preferences."
 msgstr "Klikk her for å utføre samtlege endringar gjorde i innstillingar."
 
-#: src/muuli_wdr.cpp:2225
+#: src/muuli_wdr.cpp:2232
 msgid "Reset any changes made to the preferences."
 msgstr "Nullstill alle endringar i innstillingar."
 
-#: src/muuli_wdr.cpp:2254
+#: src/muuli_wdr.cpp:2261
 msgid "Comment :"
 msgstr "Kommentar :"
 
-#: src/muuli_wdr.cpp:2261
+#: src/muuli_wdr.cpp:2268
 msgid "Incoming Dir :"
 msgstr "Innkomande kat:"
 
-#: src/muuli_wdr.cpp:2270
+#: src/muuli_wdr.cpp:2277
 msgid "Change priority for new assigned files :"
 msgstr "Endre prioritet for nytileigna filer :"
 
-#: src/muuli_wdr.cpp:2274
+#: src/muuli_wdr.cpp:2281
 #, fuzzy
 msgid "Don't change"
 msgstr "Ikkje endre"
 
-#: src/muuli_wdr.cpp:2286
+#: src/muuli_wdr.cpp:2293
 msgid "Select color for this Category (currently selected) :"
 msgstr "Vel farge for denne kategprien (no valt)"
 
-#: src/muuli_wdr.cpp:2353 src/muuli_wdr.cpp:2372 src/muuli_wdr.cpp:2394
+#: src/muuli_wdr.cpp:2360 src/muuli_wdr.cpp:2379 src/muuli_wdr.cpp:2401
 msgid "Click this button to reset the log."
 msgstr "Klikk denne knappen for å nullstille loggen."
 
-#: src/muuli_wdr.cpp:2413
+#: src/muuli_wdr.cpp:2420
 msgid "Click on this button to update the servers list from URL ..."
 msgstr "Klikk på denne knappen for å oppdatere tenarlista frå nettadresse ..."
 
-#: src/muuli_wdr.cpp:2417
+#: src/muuli_wdr.cpp:2424
 msgid "Server list"
 msgstr "Tenarliste"
 
-#: src/muuli_wdr.cpp:2421
+#: src/muuli_wdr.cpp:2428
 msgid "Enter the url to a server.met file here and press the button to the left to update the list of known servers."
 msgstr "Skriv inn nettadressa til ei server.met fil her og klikk på knappen til venstre for å oppdatere tenarlista."
 
-#: src/muuli_wdr.cpp:2426
+#: src/muuli_wdr.cpp:2433
 msgid "Add server manually: Name"
 msgstr "Legg til tenar manuelt: Namn"
 
-#: src/muuli_wdr.cpp:2429
+#: src/muuli_wdr.cpp:2436
 msgid "Enter the name of the new server here"
 msgstr "Skriv inn namnet på den nye tenaren her"
 
-#: src/muuli_wdr.cpp:2431 src/ServerWnd.cpp:206
+#: src/muuli_wdr.cpp:2438 src/ServerWnd.cpp:206
 msgid "IP:Port"
 msgstr "IP:Port"
 
-#: src/muuli_wdr.cpp:2434
+#: src/muuli_wdr.cpp:2441
 msgid "Enter the IP of the server here, using the x.x.x.x format."
 msgstr "Skriv inn IP`en til tenaren her, i x.x.x.x format."
 
-#: src/muuli_wdr.cpp:2440
+#: src/muuli_wdr.cpp:2447
 msgid "Enter the port of the server here."
 msgstr "Skriv inn porten til tenaren her."
 
-#: src/muuli_wdr.cpp:2443
+#: src/muuli_wdr.cpp:2450
 msgid "Add manually a server (fill fields to the left before) ..."
 msgstr "Legg til ein tenar manuelt (fyll først ut felta til venstre) ..."
 
-#: src/muuli_wdr.cpp:2472
+#: src/muuli_wdr.cpp:2479
 msgid "aMule Log"
 msgstr "aMulelogg"
 
-#: src/muuli_wdr.cpp:2480
+#: src/muuli_wdr.cpp:2487
 msgid "Server Info"
 msgstr "Tenarinfo"
 
-#: src/muuli_wdr.cpp:2484
+#: src/muuli_wdr.cpp:2491
 msgid "ED2K Info"
 msgstr "ED2k-info"
 
-#: src/muuli_wdr.cpp:2488
+#: src/muuli_wdr.cpp:2495
 msgid "Kad Info"
 msgstr "Kad-info"
 
-#: src/muuli_wdr.cpp:2516
+#: src/muuli_wdr.cpp:2523
 msgid "Click on this button to update the nodes list from URL ..."
 msgstr "Klikk på denne knappen for å oppdatere nodelista frå internettadresse ..."
 
-#: src/muuli_wdr.cpp:2520
+#: src/muuli_wdr.cpp:2527
 msgid "Nodes (0)"
 msgstr "Nodar (0)"
 
-#: src/muuli_wdr.cpp:2524
+#: src/muuli_wdr.cpp:2531
 msgid "Enter the url to a nodes.dat file here and press the button to the left to update the list of known nodes."
 msgstr "Skriv inn internettadressa til ei nodes-dat fil her og klikk på knappen til venstre for å oppdatere lista over kjende nodar."
 
-#: src/muuli_wdr.cpp:2527
+#: src/muuli_wdr.cpp:2534
 msgid "Nodes stats"
 msgstr "Nodestatistikk"
 
-#: src/muuli_wdr.cpp:2569
+#: src/muuli_wdr.cpp:2576
 msgid "Bootstrap"
 msgstr "Eigenoppstart"
 
-#: src/muuli_wdr.cpp:2572
+#: src/muuli_wdr.cpp:2579
 msgid "New node"
 msgstr "Ny node"
 
-#: src/muuli_wdr.cpp:2577
+#: src/muuli_wdr.cpp:2584
 msgid "IP:"
 msgstr "IP:"
 
-#: src/muuli_wdr.cpp:2597
+#: src/muuli_wdr.cpp:2604
 msgid "Port:"
 msgstr "Port:"
 
-#: src/muuli_wdr.cpp:2610
+#: src/muuli_wdr.cpp:2617
 #, fuzzy
 msgid "Bootstrap from known clients"
 msgstr ""
 "Eigenoppstart frå \n"
 "kjende klientar"
 
-#: src/muuli_wdr.cpp:2612
+#: src/muuli_wdr.cpp:2619
 msgid "Disconnect Kad"
 msgstr "Kople frå Kad"
 
-#: src/muuli_wdr.cpp:2646
+#: src/muuli_wdr.cpp:2653
 msgid "Use Secure User Identification"
 msgstr "Sikker brukaridentifikasjon (SUI)"
 
-#: src/muuli_wdr.cpp:2648
+#: src/muuli_wdr.cpp:2655
 msgid "It is recommended to enable this option. You will not receive credits if SUI is not enabled."
 msgstr "Det er tilrådd å aktivere denne funksjonen. Du vil ikkje få kredittar dersom SUI ikkje er aktivert."
 
-#: src/muuli_wdr.cpp:2650
+#: src/muuli_wdr.cpp:2657
 msgid "Protocol Obfuscation"
 msgstr "Protokolltåkeleggjing"
 
-#: src/muuli_wdr.cpp:2653
+#: src/muuli_wdr.cpp:2660
 msgid "Support Protocol Obfuscation"
 msgstr "Støtte protokolltåkeleggjing"
 
-#: src/muuli_wdr.cpp:2655
+#: src/muuli_wdr.cpp:2662
 msgid "This option enabled Protocol Obfuscation, and makes aMule accept obfuscated connections from other clients."
 msgstr "Dette valet aktiverer protokolltåkeleggjing og gjer at aMule tek imot tåkelagde koplingar frå andre klientar."
 
-#: src/muuli_wdr.cpp:2657
+#: src/muuli_wdr.cpp:2664
 msgid "Use obfuscation for outgoing connections"
 msgstr "Bruk tåkeleggjing for utgåande koplingar"
 
-#: src/muuli_wdr.cpp:2659
+#: src/muuli_wdr.cpp:2666
 msgid "This option makes aMule use Protocol Obfuscation when connecting other clients/servers."
 msgstr "Dette valet får aMule til å nytte protokolltåkeleggjing ved tilkopling til andreklientar/tenarar."
 
-#: src/muuli_wdr.cpp:2661
+#: src/muuli_wdr.cpp:2668
 msgid "Accept only obfuscated connections"
 msgstr "Berre godta tåkelagde koplingar"
 
-#: src/muuli_wdr.cpp:2662
+#: src/muuli_wdr.cpp:2669
 msgid "This option makes aMule only accept obfuscated connections. You will have less sources, but all your traffic will be obfuscated"
 msgstr "Dette valet får aMule til å berre godta tåkelagde koplingar. Du vil få færre kjelder, men all trafikken din vert tåkelagd"
 
-#: src/muuli_wdr.cpp:2667
+#: src/muuli_wdr.cpp:2674
 msgid "Everybody"
 msgstr "Alle"
 
-#: src/muuli_wdr.cpp:2669
+#: src/muuli_wdr.cpp:2676
 msgid "No one"
 msgstr "Ingen"
 
-#: src/muuli_wdr.cpp:2671
+#: src/muuli_wdr.cpp:2678
 msgid "Who can see my shared files:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2672
+#: src/muuli_wdr.cpp:2679
 msgid "Select who can request to view a list of your shared files."
 msgstr "Vel kven som kan be om å sjå ei liste over dei delte filene dine."
 
-#: src/muuli_wdr.cpp:2674
+#: src/muuli_wdr.cpp:2681
 msgid "IP-Filtering"
 msgstr "IP-filtrering"
 
-#: src/muuli_wdr.cpp:2681
+#: src/muuli_wdr.cpp:2688
 msgid "Filter clients"
 msgstr "Filtrér klientar"
 
-#: src/muuli_wdr.cpp:2683
+#: src/muuli_wdr.cpp:2690
 msgid "Enable filtering of the client IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "Aktivér IP-filterring av klientar i fila ~/.aMule/ipfilter.dat."
 
-#: src/muuli_wdr.cpp:2685
+#: src/muuli_wdr.cpp:2692
 msgid "Filter servers"
 msgstr "Filtrér tenarar"
 
-#: src/muuli_wdr.cpp:2687
+#: src/muuli_wdr.cpp:2694
 msgid "Enable filtering of the server IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "Aktivér filtrering av tenarar i fila ~/.aMule/ipfilter.dat."
 
-#: src/muuli_wdr.cpp:2691
+#: src/muuli_wdr.cpp:2698
 msgid "Reload List"
 msgstr "Last om att lista"
 
-#: src/muuli_wdr.cpp:2692
+#: src/muuli_wdr.cpp:2699
 msgid "Reload the list of IPs to filter from the file ~/.aMule/ipfilter.dat"
 msgstr "Last om att lista av IP`ar å filtre frå fila ~/.aMule/ipfilter.dat"
 
-#: src/muuli_wdr.cpp:2698
+#: src/muuli_wdr.cpp:2705
 msgid "URL:"
 msgstr "Nettadresse:"
 
-#: src/muuli_wdr.cpp:2702 src/muuli_wdr.cpp:2895
+#: src/muuli_wdr.cpp:2709 src/muuli_wdr.cpp:2902
 msgid "Update now"
 msgstr "Oppdatér no"
 
-#: src/muuli_wdr.cpp:2705
+#: src/muuli_wdr.cpp:2712
 msgid "Auto-update ipfilter at startup"
 msgstr "Automatisk oppdatér ipfilter ved oppstart"
 
-#: src/muuli_wdr.cpp:2709
+#: src/muuli_wdr.cpp:2716
 msgid "Filtering Level:"
 msgstr "Filternivå:"
 
-#: src/muuli_wdr.cpp:2715
+#: src/muuli_wdr.cpp:2722
 msgid "Always filter LAN IPs"
 msgstr "Alltid filtrér LAN IP`ar"
 
-#: src/muuli_wdr.cpp:2718
+#: src/muuli_wdr.cpp:2725
 msgid "Paranoid handling of non-matching IPs"
 msgstr "Paranoid handsaming av ujamne IP`ar"
 
-#: src/muuli_wdr.cpp:2720
+#: src/muuli_wdr.cpp:2727
 msgid "Rejects a packet when its source IP differs from the IP the client claims (an anti-spoofing check). Disable only if it causes connection problems."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2722
+#: src/muuli_wdr.cpp:2729
 msgid "Use system-wide ipfilter.dat if available"
 msgstr "Bruk systemomspennande ipfilter.dat dersom tilgjengeleg"
 
-#: src/muuli_wdr.cpp:2723
+#: src/muuli_wdr.cpp:2730
 #, fuzzy
 msgid "If there's no local ipfilter.dat found, allow usage of a system-wide ipfilter file."
 msgstr "Tillat bruk av ipfilter for heile systemet dersom inga lokal ipfilter-dat vert funnen"
 
-#: src/muuli_wdr.cpp:2740
+#: src/muuli_wdr.cpp:2747
 msgid "Enable Online-Signature"
 msgstr "Aktivér nettsignatur"
 
-#: src/muuli_wdr.cpp:2742
+#: src/muuli_wdr.cpp:2749
 msgid "Enables the writing of the OS file, which can be used by external apps to create signatures and the like."
 msgstr "Aktiverer skriving av OS-fila, som kan verte nytta av eksterne program forå lage signaturar og liknande."
 
-#: src/muuli_wdr.cpp:2746
+#: src/muuli_wdr.cpp:2753
 msgid "Update Frequency (Secs):"
 msgstr "Oppdateringsfrekvens (sekund):"
 
-#: src/muuli_wdr.cpp:2749
+#: src/muuli_wdr.cpp:2756
 msgid "Change the frequency (in seconds) of Online Signature updates."
 msgstr "Endre frekvensen (i sekund) for oppdatering av nettsignaturar."
 
-#: src/muuli_wdr.cpp:2757
+#: src/muuli_wdr.cpp:2764
 msgid "Save online signature file in: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:2763
+#: src/muuli_wdr.cpp:2770
 msgid "Click here to select the directory containing the the Online Signature files."
 msgstr "Klikk her for å velje katalogen med nettsignaturfilene."
 
-#: src/muuli_wdr.cpp:2796
+#: src/muuli_wdr.cpp:2803
 msgid "Show country flags for clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2797
+#: src/muuli_wdr.cpp:2804
 msgid "Render the country flag column in the transfers, queue and search views. Requires a valid MMDB GeoIP database (see below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2802
+#: src/muuli_wdr.cpp:2809
 #, fuzzy
 msgid "Database"
 msgstr "Datasnøggleik :"
 
-#: src/muuli_wdr.cpp:2818
+#: src/muuli_wdr.cpp:2825
 #, fuzzy
 msgid "Source:"
 msgstr "Kjelder"
 
-#: src/muuli_wdr.cpp:2821
+#: src/muuli_wdr.cpp:2828
 msgid "DB-IP (free, no account)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2822
+#: src/muuli_wdr.cpp:2829
 msgid "MaxMind GeoLite2 (free, account required)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2823
+#: src/muuli_wdr.cpp:2830
 msgid "Custom URL"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2826
+#: src/muuli_wdr.cpp:2833
 msgid "Choose which provider supplies the GeoIP MMDB database. DB-IP is the default - no account required. MaxMind requires a free account + license key. Use Custom URL to point at any other MMDB host (e.g. a local mirror)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2843
+#: src/muuli_wdr.cpp:2850
 msgid ""
 "No configuration required.\n"
 "\n"
@@ -4858,11 +4872,11 @@ msgid ""
 "License: Creative Commons BY 4.0 - https://creativecommons.org/licenses/by/4.0/"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2856
+#: src/muuli_wdr.cpp:2863
 msgid "License key:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2862
+#: src/muuli_wdr.cpp:2869
 msgid ""
 "Sign up for a free MaxMind account, then generate a License Key:\n"
 "https://www.maxmind.com/en/geolite2/signup\n"
@@ -4872,232 +4886,232 @@ msgid ""
 "Requires attribution and account registration; refresh at least every 30 days."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2877
+#: src/muuli_wdr.cpp:2884
 #, fuzzy
 msgid "Download URL:"
 msgstr "Nedlasting: "
 
-#: src/muuli_wdr.cpp:2883
+#: src/muuli_wdr.cpp:2890
 msgid ""
 "Must point to an .mmdb file or a .gz / .tar.gz containing one.\n"
 "URL may include credentials (https://user:pass@host/...).\n"
 "License and attribution terms are set by the upstream URL - you are responsible."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2896
+#: src/muuli_wdr.cpp:2903
 msgid "Download the GeoIP database from the selected source."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2898
+#: src/muuli_wdr.cpp:2905
 #, fuzzy
 msgid "Auto-update on startup"
 msgstr "Automatisk oppdatér ipfilter ved oppstart"
 
-#: src/muuli_wdr.cpp:2899
+#: src/muuli_wdr.cpp:2906
 msgid "Re-download the GeoIP database from the selected source every time aMule starts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2922
+#: src/muuli_wdr.cpp:2929
 msgid "Filter incoming messages (except current chat):"
 msgstr "Filtrér innkomande meldingar (utanom novérande samtale):"
 
-#: src/muuli_wdr.cpp:2924
+#: src/muuli_wdr.cpp:2931
 msgid "Filter all messages"
 msgstr "Filtrér alle meldingar"
 
-#: src/muuli_wdr.cpp:2926
+#: src/muuli_wdr.cpp:2933
 msgid "Filter messages from people not on your friend list"
 msgstr "Filtrér meldingar frå alle som ikkje er på kameratlista"
 
-#: src/muuli_wdr.cpp:2928
+#: src/muuli_wdr.cpp:2935
 msgid "Filter messages from unknown clients"
 msgstr "Filtrér meldingar frå ukjende klientar"
 
-#: src/muuli_wdr.cpp:2930
+#: src/muuli_wdr.cpp:2937
 msgid "Filter messages containing (use ',' as separator):"
 msgstr "Filtrér meldingar som inneheld (bruk ','som skiljeteikn):"
 
-#: src/muuli_wdr.cpp:2933 src/muuli_wdr.cpp:2944
+#: src/muuli_wdr.cpp:2940 src/muuli_wdr.cpp:2951
 msgid "add here the words amule should filter and block messages including it"
 msgstr "legg til ord aMule skal filtrére og blokkere"
 
-#: src/muuli_wdr.cpp:2935
+#: src/muuli_wdr.cpp:2942
 msgid "Show received messages in the log"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2938
+#: src/muuli_wdr.cpp:2945
 msgid "Comments"
 msgstr "Kommentarar"
 
-#: src/muuli_wdr.cpp:2941
+#: src/muuli_wdr.cpp:2948
 msgid "Filter comments containing (use ',' as separator):"
 msgstr "Filtrér kommentarar som inneheld (bruk ',' som skiljeteikn):"
 
-#: src/muuli_wdr.cpp:2966
+#: src/muuli_wdr.cpp:2973
 msgid "Enable Proxy"
 msgstr "Aktivér vikar"
 
-#: src/muuli_wdr.cpp:2967
+#: src/muuli_wdr.cpp:2974
 msgid "Enable/disable proxy support"
 msgstr "Aktivere/deaktivere vikarstøtte"
 
-#: src/muuli_wdr.cpp:2970
+#: src/muuli_wdr.cpp:2977
 msgid "Proxy type:"
 msgstr "Vikartype:"
 
-#: src/muuli_wdr.cpp:2981
+#: src/muuli_wdr.cpp:2988
 msgid "Proxy host:"
 msgstr "Vikarvert:"
 
-#: src/muuli_wdr.cpp:2984
+#: src/muuli_wdr.cpp:2991
 msgid "The proxy host name"
 msgstr "Vikaren sitt vertsnamn"
 
-#: src/muuli_wdr.cpp:2986
+#: src/muuli_wdr.cpp:2993
 msgid "Proxy port:"
 msgstr "Vikarport:"
 
-#: src/muuli_wdr.cpp:2989
+#: src/muuli_wdr.cpp:2996
 msgid "The proxy port"
 msgstr "Vikarport"
 
-#: src/muuli_wdr.cpp:2991
+#: src/muuli_wdr.cpp:2998
 msgid "Enable authentication"
 msgstr "Aktivér godkjenning"
 
-#: src/muuli_wdr.cpp:2992
+#: src/muuli_wdr.cpp:2999
 msgid "Enable/disable username/password authentication"
 msgstr "Aktivér/deaktivér godkjenning av brukarnamn/passord"
 
-#: src/muuli_wdr.cpp:2995
+#: src/muuli_wdr.cpp:3002
 msgid "Username: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:2998
+#: src/muuli_wdr.cpp:3005
 msgid "The username to use to connect to the proxy"
 msgstr "Brukarnamn å nytte for å kople til vikar"
 
-#: src/muuli_wdr.cpp:3000
+#: src/muuli_wdr.cpp:3007
 msgid "Password:"
 msgstr "Passord:"
 
-#: src/muuli_wdr.cpp:3003
+#: src/muuli_wdr.cpp:3010
 msgid "The password to use to connect to the proxy"
 msgstr "Passord å nytte for å kople til vikar"
 
-#: src/muuli_wdr.cpp:3022
+#: src/muuli_wdr.cpp:3029
 msgid "Connect to:"
 msgstr "Kople til:"
 
-#: src/muuli_wdr.cpp:3031
+#: src/muuli_wdr.cpp:3038
 msgid "Login to remote amule"
 msgstr "Logge inn på fjern aMule"
 
-#: src/muuli_wdr.cpp:3036
+#: src/muuli_wdr.cpp:3043
 msgid "User name"
 msgstr "Brukarnamn"
 
-#: src/muuli_wdr.cpp:3047
+#: src/muuli_wdr.cpp:3054
 msgid "Remember those settings"
 msgstr "Hugs desse innstillingane"
 
-#: src/muuli_wdr.cpp:3050
+#: src/muuli_wdr.cpp:3057
 #, fuzzy
 msgid "Force ZLIB compression"
 msgstr "Nytt gzipkomprimering"
 
-#: src/muuli_wdr.cpp:3074
+#: src/muuli_wdr.cpp:3081
 msgid "Enable Verbose Debug-Logging."
 msgstr "Aktivér utførleg avfeilingslogg."
 
-#: src/muuli_wdr.cpp:3076
+#: src/muuli_wdr.cpp:3083
 #, fuzzy
 msgid "Only to Logfile"
 msgstr "&Opne fila"
 
-#: src/muuli_wdr.cpp:3078
+#: src/muuli_wdr.cpp:3085
 msgid "Message Categories:"
 msgstr "Meldingskategoriar:"
 
-#: src/muuli_wdr.cpp:3102 src/PartFileConvertDlg.cpp:160
+#: src/muuli_wdr.cpp:3109 src/PartFileConvertDlg.cpp:160
 msgid "Waiting..."
 msgstr "Ventar..."
 
-#: src/muuli_wdr.cpp:3122
+#: src/muuli_wdr.cpp:3129
 msgid "Add imports"
 msgstr "Importér"
 
-#: src/muuli_wdr.cpp:3125
+#: src/muuli_wdr.cpp:3132
 msgid "Retry selected"
 msgstr "Prøv om att valde"
 
-#: src/muuli_wdr.cpp:3127
+#: src/muuli_wdr.cpp:3134
 msgid "Remove selected"
 msgstr "Fjern valde"
 
-#: src/muuli_wdr.cpp:3190
+#: src/muuli_wdr.cpp:3197
 msgid "Event Types"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3209
+#: src/muuli_wdr.cpp:3216
 msgid "Statistics and queued clients for selected file(s) : Session / All time"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3233
+#: src/muuli_wdr.cpp:3240
 #, fuzzy
 msgid "Active Uploads"
 msgstr "Aktive opplastingar :"
 
-#: src/muuli_wdr.cpp:3247
+#: src/muuli_wdr.cpp:3254
 msgid "Percent of total files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3299
+#: src/muuli_wdr.cpp:3306
 #, fuzzy
 msgid "Show Clients for"
 msgstr "Syne klientar"
 
-#: src/muuli_wdr.cpp:3301
+#: src/muuli_wdr.cpp:3308
 #, fuzzy
 msgid "All files"
 msgstr "Gøyme delte filer"
 
-#: src/muuli_wdr.cpp:3304
+#: src/muuli_wdr.cpp:3311
 #, fuzzy
 msgid "Selected files"
 msgstr "Vel synsfilter"
 
-#: src/muuli_wdr.cpp:3307
+#: src/muuli_wdr.cpp:3314
 #, fuzzy
 msgid "Active uploads only"
 msgstr "Aktive opplastingar"
 
-#: src/muuli_wdr.cpp:3314
+#: src/muuli_wdr.cpp:3321
 #, fuzzy
 msgid "Reload:"
 msgstr "Last om att lista"
 
-#: src/muuli_wdr.cpp:3318
+#: src/muuli_wdr.cpp:3325
 msgid "Reload your shared files"
 msgstr "Lastar inn att delte filer"
 
-#: src/muuli_wdr.cpp:3381
+#: src/muuli_wdr.cpp:3388
 msgid "Send"
 msgstr "Send"
 
-#: src/muuli_wdr.cpp:3382
+#: src/muuli_wdr.cpp:3389
 msgid "Sends the specified message."
 msgstr "Sender meldinga."
 
-#: src/muuli_wdr.cpp:3386
+#: src/muuli_wdr.cpp:3393
 msgid "Close this chat-session."
 msgstr "Stengje denne lynmeldingsøkta."
 
-#: src/muuli_wdr.cpp:3409
+#: src/muuli_wdr.cpp:3416
 msgid "Connect to any server and/or Kad"
 msgstr "Kople til vilkårleg tenar og/eller Kad"
 
-#: src/muuli_wdr.cpp:3415 src/SharedFilesCtrl.cpp:142 src/Statistics.cpp:941
+#: src/muuli_wdr.cpp:3422 src/SharedFilesCtrl.cpp:142 src/Statistics.cpp:941
 msgid "Shared Files"
 msgstr "Delte filer"
 
@@ -5458,192 +5472,192 @@ msgstr "Lasta ned"
 msgid "ERROR: Failed to open partfile '%s'"
 msgstr "Feil: Greidde ikkje opne delfila '%s'"
 
-#: src/Preferences.cpp:673
+#: src/Preferences.cpp:674
 msgid "System default"
 msgstr "Standardinnstillingar"
 
-#: src/Preferences.cpp:674
+#: src/Preferences.cpp:675
 msgid "Albanian"
 msgstr "Albansk"
 
-#: src/Preferences.cpp:675
+#: src/Preferences.cpp:676
 msgid "Arabic"
 msgstr "Arabisk"
 
-#: src/Preferences.cpp:676
+#: src/Preferences.cpp:677
 #, fuzzy
 msgid "Asturian"
 msgstr "Estisk"
 
-#: src/Preferences.cpp:677
+#: src/Preferences.cpp:678
 msgid "Basque"
 msgstr "Baskisk"
 
-#: src/Preferences.cpp:678
+#: src/Preferences.cpp:679
 msgid "Bulgarian"
 msgstr "Bulgarsk"
 
-#: src/Preferences.cpp:679
+#: src/Preferences.cpp:680
 msgid "Catalan"
 msgstr "Katalansk"
 
-#: src/Preferences.cpp:680
+#: src/Preferences.cpp:681
 msgid "Chinese (Simplified)"
 msgstr "Kinesisk (forenkla)"
 
-#: src/Preferences.cpp:681
+#: src/Preferences.cpp:682
 msgid "Chinese (Traditional)"
 msgstr "Kinesisk (tradisjonell)"
 
-#: src/Preferences.cpp:682
+#: src/Preferences.cpp:683
 msgid "Croatian"
 msgstr "Kroatisk"
 
-#: src/Preferences.cpp:683
+#: src/Preferences.cpp:684
 msgid "Czech"
 msgstr "Tsjekkisk"
 
-#: src/Preferences.cpp:684
+#: src/Preferences.cpp:685
 msgid "Danish"
 msgstr "Dansk"
 
-#: src/Preferences.cpp:685
+#: src/Preferences.cpp:686
 msgid "Dutch"
 msgstr "Nederlansk"
 
-#: src/Preferences.cpp:686
+#: src/Preferences.cpp:687
 msgid "English (U.K.)"
 msgstr "Engelsk (U.K.)"
 
-#: src/Preferences.cpp:687
+#: src/Preferences.cpp:688
 #, fuzzy
 msgid "English (U.S.)"
 msgstr "Engelsk (U.K.)"
 
-#: src/Preferences.cpp:688
+#: src/Preferences.cpp:689
 msgid "Estonian"
 msgstr "Estisk"
 
-#: src/Preferences.cpp:689
+#: src/Preferences.cpp:690
 msgid "Finnish"
 msgstr "Finsk"
 
-#: src/Preferences.cpp:690
+#: src/Preferences.cpp:691
 msgid "French"
 msgstr "Fransk"
 
-#: src/Preferences.cpp:691
+#: src/Preferences.cpp:692
 msgid "Galician"
 msgstr "Galisisk"
 
-#: src/Preferences.cpp:692
+#: src/Preferences.cpp:693
 msgid "German"
 msgstr "Tysk"
 
-#: src/Preferences.cpp:693
+#: src/Preferences.cpp:694
 msgid "Greek"
 msgstr "Gresk"
 
-#: src/Preferences.cpp:694
+#: src/Preferences.cpp:695
 msgid "Hebrew"
 msgstr "Hebraisk"
 
-#: src/Preferences.cpp:695
+#: src/Preferences.cpp:696
 msgid "Hungarian"
 msgstr "Ungarsk"
 
-#: src/Preferences.cpp:696
+#: src/Preferences.cpp:697
 msgid "Italian"
 msgstr "Italiensk"
 
-#: src/Preferences.cpp:697
+#: src/Preferences.cpp:698
 msgid "Japanese"
 msgstr "Japansk"
 
-#: src/Preferences.cpp:698
+#: src/Preferences.cpp:699
 msgid "Korean"
 msgstr "Koreansk"
 
-#: src/Preferences.cpp:699
+#: src/Preferences.cpp:700
 msgid "Latvian"
 msgstr ""
 
-#: src/Preferences.cpp:700
+#: src/Preferences.cpp:701
 msgid "Lithuanian"
 msgstr "Litauisk"
 
-#: src/Preferences.cpp:701
+#: src/Preferences.cpp:702
 msgid "Norwegian (Nynorsk)"
 msgstr "Norsk (Nynorsk)"
 
-#: src/Preferences.cpp:702
+#: src/Preferences.cpp:703
 msgid "Polish"
 msgstr "Polsk"
 
-#: src/Preferences.cpp:703
+#: src/Preferences.cpp:704
 msgid "Portuguese"
 msgstr "Portugisisk"
 
-#: src/Preferences.cpp:704
+#: src/Preferences.cpp:705
 msgid "Portuguese (Brazilian)"
 msgstr "Portugisisk (Brasil)"
 
-#: src/Preferences.cpp:705
+#: src/Preferences.cpp:706
 #, fuzzy
 msgid "Romanian"
 msgstr "Albansk"
 
-#: src/Preferences.cpp:706
+#: src/Preferences.cpp:707
 msgid "Russian"
 msgstr "Russisk"
 
-#: src/Preferences.cpp:707
+#: src/Preferences.cpp:708
 msgid "Slovenian"
 msgstr "Slovensk"
 
-#: src/Preferences.cpp:708
+#: src/Preferences.cpp:709
 msgid "Spanish"
 msgstr "Spansk"
 
-#: src/Preferences.cpp:709
+#: src/Preferences.cpp:710
 msgid "Swedish"
 msgstr "Svensk"
 
-#: src/Preferences.cpp:710
+#: src/Preferences.cpp:711
 msgid "Turkish"
 msgstr "Tyrkisk"
 
-#: src/Preferences.cpp:711
+#: src/Preferences.cpp:712
 msgid "Ukrainian"
 msgstr ""
 
-#: src/Preferences.cpp:814
+#: src/Preferences.cpp:815
 #, fuzzy
 msgid "Change Language"
 msgstr "Språk"
 
-#: src/Preferences.cpp:878
+#: src/Preferences.cpp:879
 msgid "There are no translations installed for aMule"
 msgstr ""
 
-#: src/Preferences.cpp:879
+#: src/Preferences.cpp:880
 #, fuzzy
 msgid "No languages available"
 msgstr "Ikkje tilgjengeleg"
 
-#: src/Preferences.cpp:1010
+#: src/Preferences.cpp:1011
 msgid "no options available"
 msgstr ""
 
-#: src/Preferences.cpp:2179
+#: src/Preferences.cpp:2182
 msgid "Invalid category found, skipping"
 msgstr ""
 
-#: src/Preferences.cpp:2348
+#: src/Preferences.cpp:2351
 msgid "TCP port can't be higher than 65532 due to server UDP socket being TCP+3"
 msgstr "TCP port kan ikkje vere høgare enn 65532 fordi tenaren si UDPkopling er TCP+3"
 
-#: src/Preferences.cpp:2349
+#: src/Preferences.cpp:2352
 #, c-format
 msgid "Default port will be used (%d)"
 msgstr "Standardport vert nytta (%d)"
@@ -6154,24 +6168,28 @@ msgstr "Lastar inn att lista over delte filer."
 msgid "Shared folder"
 msgstr "Delte filer"
 
-#: src/SearchDlg.cpp:425
+#: src/SearchDlg.cpp:280
+msgid "Clear search history"
+msgstr ""
+
+#: src/SearchDlg.cpp:584
 msgid "It's impossible to search when both eD2k and Kademlia are disabled."
 msgstr ""
 
-#: src/SearchDlg.cpp:426 src/SearchListCtrl.cpp:858
+#: src/SearchDlg.cpp:585 src/SearchListCtrl.cpp:858
 #, fuzzy
 msgid "Search error"
 msgstr "Søk"
 
-#: src/SearchDlg.cpp:768
+#: src/SearchDlg.cpp:929
 msgid "Min size must be smaller than max size. Max size ignored."
 msgstr "Min storleik må vere mindre enn maks storleik. Maks storleik ignorert."
 
-#: src/SearchDlg.cpp:769 src/SearchDlg.cpp:851
+#: src/SearchDlg.cpp:930 src/SearchDlg.cpp:1012
 msgid "Search warning"
 msgstr "Søkeåtvaring"
 
-#: src/SearchDlg.cpp:929 src/SearchListCtrl.cpp:735
+#: src/SearchDlg.cpp:1092 src/SearchListCtrl.cpp:735
 msgid "Main"
 msgstr "Hovud"
 

--- a/po/nn.po
+++ b/po/nn.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-28 10:19+0200\n"
+"POT-Creation-Date: 2026-07-28 12:17+0200\n"
 "PO-Revision-Date: 2026-07-27 11:42+0000\n"
 "Last-Translator: Hallvor Brunstad <Hallvor_1976@yahoo.com>\n"
 "Language-Team: <i18n-nn@lister.ping.uio.no>\n"
@@ -201,162 +201,162 @@ msgstr "Greidde ikkje å opne %s·(%s)"
 msgid "WARNING: You can't add yourself as a source for an eD2k link while having a lowid."
 msgstr "ÅTVARING: Du kan ikkje leggje deg sjølv til som kjelde for ei eD2k lenkje medan du har ein lågid."
 
-#: src/amule.cpp:300
+#: src/amule.cpp:301
 #, fuzzy
 msgid "Now, exiting main app..."
 msgstr ""
 "\n"
 "Ok,·avsluttar·%s...\n"
 
-#: src/amule.cpp:330
+#: src/amule.cpp:331
 #, c-format
 msgid "Terminating amuleweb instance with pid '%d' ... "
 msgstr ""
 
-#: src/amule.cpp:334
+#: src/amule.cpp:335
 #, c-format
 msgid "Killing amuleweb instance with pid '%d' ... "
 msgstr ""
 
-#: src/amule.cpp:336 src/amule.cpp:349 src/ClientRef.cpp:180
+#: src/amule.cpp:337 src/amule.cpp:350 src/ClientRef.cpp:180
 #: src/SearchDlg.cpp:1041 src/ServerListCtrl.cpp:98
 msgid "Failed"
 msgstr "Mislukka"
 
-#: src/amule.cpp:343
+#: src/amule.cpp:344
 #, c-format
 msgid "Terminating amuleapi instance with pid '%d' ... "
 msgstr ""
 
-#: src/amule.cpp:347
+#: src/amule.cpp:348
 #, c-format
 msgid "Killing amuleapi instance with pid '%d' ... "
 msgstr ""
 
-#: src/amule.cpp:355
+#: src/amule.cpp:356
 msgid "aMule OnExit: Terminating core."
 msgstr ""
 
-#: src/amule.cpp:466
+#: src/amule.cpp:467
 #, fuzzy
 msgid "aMule shutdown completed."
 msgstr "Nedlasting fullført"
 
-#: src/amule.cpp:470
+#: src/amule.cpp:471
 msgid "Memory debug results for aMule exit:"
 msgstr ""
 
-#: src/amule.cpp:651
+#: src/amule.cpp:652
 #, c-format
 msgid "Binding aMule's peer-to-peer traffic to interface: %s (HTTP updates use the default route)"
 msgstr ""
 
-#: src/amule.cpp:655
+#: src/amule.cpp:656
 #, c-format
 msgid "Binding all network traffic to interface: %s"
 msgstr ""
 
-#: src/amule.cpp:659
+#: src/amule.cpp:660
 #, c-format
 msgid "WARNING: configured network interface '%s' was not found - traffic is NOT bound to it and may leave via the default route. Check the interface name in Preferences."
 msgstr ""
 
-#: src/amule.cpp:665
+#: src/amule.cpp:666
 #, c-format
 msgid "WARNING: binding to network interface '%s' requires elevated privileges and was NOT applied - traffic may leave via the default route. Grant the capability (e.g. 'sudo setcap cap_net_raw+ep' on the aMule binary) or run with sufficient privileges."
 msgstr ""
 
-#: src/amule.cpp:673
+#: src/amule.cpp:674
 #, c-format
 msgid "WARNING: could not bind to network interface '%s' - traffic may leave via the default route."
 msgstr ""
 
-#: src/amule.cpp:732
+#: src/amule.cpp:733
 msgid "Your locale has been changed to System Default due to a configuration change. Sorry."
 msgstr "Dine lokale innstilingar har vorte endra til opprinnelege systeminnstillingar på grunn av konfigurasjonsending. Beklager."
 
-#: src/amule.cpp:734 src/amule.cpp:1581 src/CatDialog.cpp:128
+#: src/amule.cpp:735 src/amule.cpp:1589 src/CatDialog.cpp:128
 #: src/CatDialog.cpp:136 src/CatDialog.cpp:149 src/ServerList.cpp:366
 #: src/ServerListCtrl.cpp:152
 msgid "Info"
 msgstr "Info"
 
-#: src/amule.cpp:741
+#: src/amule.cpp:742
 #, fuzzy
 msgid ""
 "\n"
 "EC configuration"
 msgstr "Stadfesting av avslutting"
 
-#: src/amule.cpp:744
+#: src/amule.cpp:745
 #, fuzzy
 msgid "Password set and external connections enabled."
 msgstr "Ny ekstern kopling akseptert"
 
-#: src/amule.cpp:754 src/KadDlg.cpp:176 src/KadDlg.cpp:185
-#: src/PrefsUnifiedDlg.cpp:1387 src/SharedFilesCtrl.cpp:476
+#: src/amule.cpp:755 src/KadDlg.cpp:176 src/KadDlg.cpp:185
+#: src/PrefsUnifiedDlg.cpp:1461 src/SharedFilesCtrl.cpp:476
 msgid "WARNING"
 msgstr "ÅTVARING"
 
-#: src/amule.cpp:991
+#: src/amule.cpp:992
 #, fuzzy
 msgid "Network bootstrap"
 msgstr "Nettverk"
 
-#: src/amule.cpp:996
+#: src/amule.cpp:997
 msgid ""
 "aMule has detected missing network bootstrap files.\n"
 "Select which ones to download:"
 msgstr ""
 
-#: src/amule.cpp:1005 src/FirstRunWizard.cpp:411
+#: src/amule.cpp:1006 src/FirstRunWizard.cpp:411
 #, fuzzy
 msgid "eD2k server list (server.met)"
 msgstr "%i tenar funne i server.met"
 
-#: src/amule.cpp:1012 src/FirstRunWizard.cpp:416
+#: src/amule.cpp:1013 src/FirstRunWizard.cpp:416
 msgid "Kad bootstrap nodes (nodes.dat)"
 msgstr ""
 
-#: src/amule.cpp:1102
+#: src/amule.cpp:1103
 #, c-format
 msgid "web server running on pid %d"
 msgstr "vevtenar køyrer på pid %d"
 
-#: src/amule.cpp:1115
+#: src/amule.cpp:1116
 #, fuzzy
 msgid "You requested to run web server on startup, but the amuleweb binary cannot be run. Please install the package containing aMule web server, or build aMule from source with -DBUILD_WEBSERVER=YES and install it."
 msgstr "Du freista å køyre vevtenar ved oppstart, men binærfila amuleweb kan ikkje køyrast. Installer pakken som inneheld vevtenaren til aMule, eller kompiler aMule med --enable-webserver og køyr make install"
 
-#: src/amule.cpp:1120 src/amule.cpp:1177 src/amule.cpp:1291 src/amule.cpp:1593
+#: src/amule.cpp:1121 src/amule.cpp:1185 src/amule.cpp:1299 src/amule.cpp:1601
 #: src/amule-remote-gui.cpp:603 src/amule-remote-gui.cpp:671
 #: src/amule-remote-gui.cpp:709 src/amule-remote-gui.cpp:1282
 #: src/amule-remote-gui.cpp:1345 src/amule-remote-gui.cpp:1372
-#: src/DownloadQueue.cpp:1481
+#: src/DownloadQueue.cpp:1481 src/PrefsUnifiedDlg.cpp:1247
 msgid "ERROR"
 msgstr "FEIL"
 
-#: src/amule.cpp:1166
+#: src/amule.cpp:1174
 #, fuzzy, c-format
 msgid "amuleapi running on pid %d"
 msgstr "vevtenar køyrer på pid %d"
 
-#: src/amule.cpp:1172
+#: src/amule.cpp:1180
 #, fuzzy
 msgid "You requested to run amuleapi on startup, but the amuleapi binary cannot be run. Please install the package containing aMule's REST API server, or build aMule from source with -DBUILD_AMULEAPI=YES and install it."
 msgstr "Du freista å køyre vevtenar ved oppstart, men binærfila amuleweb kan ikkje køyrast. Installer pakken som inneheld vevtenaren til aMule, eller kompiler aMule med --enable-webserver og køyr make install"
 
-#: src/amule.cpp:1259
+#: src/amule.cpp:1267
 #, c-format
 msgid "Could not bind ports to the specified address: %s"
 msgstr "Greidde ikkje å knyte portar til adressa: %s"
 
-#: src/amule.cpp:1283
+#: src/amule.cpp:1291
 #, c-format
 msgid "Port %u is not available. You will be LOWID\n"
 msgstr "Port·%u er ikkje tilgjengeleg. Du vil få LågID\n"
 
-#: src/amule.cpp:1288
+#: src/amule.cpp:1296
 #, c-format
 msgid ""
 "Port %u is not available!\n"
@@ -371,48 +371,48 @@ msgstr ""
 "\n"
 "Sjekk nettverket ditt for å vere viss på at porten er open for inn- og utgåande trafikk."
 
-#: src/amule.cpp:1385
+#: src/amule.cpp:1393
 msgid "Failed to create OnlineSig File"
 msgstr "Greidde ikkje å lage OnlineSigfil"
 
-#: src/amule.cpp:1393
+#: src/amule.cpp:1401
 msgid "Failed to create aMule OnlineSig File"
 msgstr "Greidde ikkje å lage aMule si OnlineSigfil."
 
-#: src/amule.cpp:1556
+#: src/amule.cpp:1564
 msgid "The selected locale seems not to be installed on your box. (Note: I'll try to set it anyway)"
 msgstr "Dei valte lokale innstillingane ser ikkje ut til å vere installerte på maskina di. (Merk: Eg freistar å setje dei likevel)"
 
-#: src/amule.cpp:1566
+#: src/amule.cpp:1574
 #, c-format
 msgid "This is the first time you run aMule %s"
 msgstr "Dette er første gongen du køyrer aMule %s"
 
-#: src/amule.cpp:1569
+#: src/amule.cpp:1577
 msgid "This version is a testing version, updated daily, and\n"
 msgstr "Denne utgåva er ei testutgåve, oppdatert dagleg, og\n"
 
-#: src/amule.cpp:1570
+#: src/amule.cpp:1578
 msgid "we give no warranty it won't break anything, burn your house,\n"
 msgstr "vi gir ingen garanti for skade eller nedbrenning av huset ditt,\n"
 
-#: src/amule.cpp:1571
+#: src/amule.cpp:1579
 msgid "or kill your dog. But it *should* be safe to use anyway.\n"
 msgstr "eller drep hunden din. Men det *burde* vere trygt å nytte uansett.\n"
 
-#: src/amule.cpp:1576
+#: src/amule.cpp:1584
 msgid "More information, support and new releases can found at our homepage,\n"
 msgstr "Meir informasjon, brukarstøtte og nye utgåver kan verte funne på heimesida vår.\n"
 
-#: src/amule.cpp:1577
+#: src/amule.cpp:1585
 msgid "at https://amule-org.github.io, or in our IRC channel #aMule at irc.libera.chat.\n"
 msgstr "på https://amule-org.github.io, eller på IRC-kanalen vår #aMule·på·irc.libera.chat.\n"
 
-#: src/amule.cpp:1579
+#: src/amule.cpp:1587
 msgid "Feel free to report any bugs to https://github.com/amule-org/amule/issues"
 msgstr "Vér god å rapportere feil til https://github.com/amule-org/amule/issues"
 
-#: src/amule.cpp:1591
+#: src/amule.cpp:1599
 msgid ""
 "The folder for Online Signature files you specified is INVALID!\n"
 " OnlineSignature will be DISABLED until you fix it on preferences."
@@ -420,138 +420,138 @@ msgstr ""
 "Mappa spesifisert for nettsignaturar er UGANGBAR!\n"
 " Nettsignaturar vert DEAKTIVERT fram til du ordnar det i innstillingar."
 
-#: src/amule.cpp:1654
+#: src/amule.cpp:1662
 #, fuzzy
 msgid "Server hostname notified"
 msgstr "Tenarnamn:"
 
-#: src/amule.cpp:2031
+#: src/amule.cpp:2039
 #, c-format
 msgid "Disk space preallocation for file '%s' failed: %s"
 msgstr "Henting av diskplass for fila '%s' mislukka: %s"
 
-#: src/amule.cpp:2160
+#: src/amule.cpp:2168
 msgid "ERROR: can't open logfile"
 msgstr "FEIL: Greier ikkje å opne loggfila"
 
-#: src/amule.cpp:2164
+#: src/amule.cpp:2172
 msgid "WARNING: logfile is empty. Something is wrong."
 msgstr "ÅTVARING: loggfila er tom. Noko er gale."
 
-#: src/amule.cpp:2181
+#: src/amule.cpp:2189
 msgid "Log has been reset"
 msgstr "Loggen har vorte nullstilt"
 
-#: src/amule.cpp:2205
+#: src/amule.cpp:2213
 #, c-format
 msgid "ServerMessage: %s"
 msgstr "Tenarmelding: %s"
 
-#: src/amule.cpp:2248 src/IP2Country.cpp:220 src/IPFilter.cpp:514
+#: src/amule.cpp:2256 src/IP2Country.cpp:220 src/IPFilter.cpp:514
 #: src/ServerList.cpp:875
 #, c-format
 msgid "Skipped download of %s, because requested file is not newer."
 msgstr ""
 
-#: src/amule.cpp:2251
+#: src/amule.cpp:2259
 msgid "Failed to download the nodes list."
 msgstr "Klarte ikkje å laste ned nodelista."
 
-#: src/amule.cpp:2314
+#: src/amule.cpp:2322
 msgid "Failed to open the downloaded version check file"
 msgstr "Klarte ikkje å opne den nedlaste utgåvesjekkfila"
 
-#: src/amule.cpp:2317 src/amule.cpp:2336
+#: src/amule.cpp:2325 src/amule.cpp:2344
 msgid "Corrupted version check file"
 msgstr "Korrupt utgåvesjekkfil"
 
-#: src/amule.cpp:2359
+#: src/amule.cpp:2367
 msgid "You are using an outdated version of aMule!"
 msgstr "Du nyttar ei utdatert utgåve av aMule!"
 
-#: src/amule.cpp:2361
+#: src/amule.cpp:2369
 #, c-format
 msgid "Your aMule version is %i.%i.%i and the latest version is %li.%li.%li"
 msgstr "Di utgåve av aMule er %i.%i.%i og den siste utgåva er %li.%li.%li"
 
-#: src/amule.cpp:2365
+#: src/amule.cpp:2373
 msgid "The latest version can always be found at https://github.com/amule-org/amule/releases/latest"
 msgstr "Den siste utgåva finst alltid på https://github.com/amule-org/amule/releases/latest"
 
-#: src/amule.cpp:2368
+#: src/amule.cpp:2376
 #, c-format
 msgid "WARNING: Your aMuled version is outdated: %i.%i.%i < %li.%li.%li"
 msgstr "ÅTVARING: Utgåva di av aMule er utdatert: %i.%i.%i·<·%li.%li.%li"
 
-#: src/amule.cpp:2374
+#: src/amule.cpp:2382
 msgid "Your copy of aMule is up to date."
 msgstr "Utgåva di av aMule er oppdatert."
 
-#: src/amule.cpp:2381
+#: src/amule.cpp:2389
 msgid "Failed to download the version check file"
 msgstr "Klarte ikkje å laste ned utgåvesjekkfila"
 
-#: src/amule.cpp:2550 src/amule-remote-gui.cpp:1133
+#: src/amule.cpp:2558 src/amule-remote-gui.cpp:1133
 #, c-format
 msgid "Users: %s | Files: %s"
 msgstr "Brukarar: %s | Filer: %s"
 
-#: src/amule.cpp:2551 src/amule-remote-gui.cpp:1134
+#: src/amule.cpp:2559 src/amule-remote-gui.cpp:1134
 #, c-format
 msgid "Users: E: %s K: %s | Files: E: %s K: %s"
 msgstr "Brukarar: E %s K: %s | Filer: E: %s K: %s"
 
-#: src/amule.cpp:2565 src/amule-remote-gui.cpp:1147
+#: src/amule.cpp:2573 src/amule-remote-gui.cpp:1147
 msgid "No networks selected"
 msgstr "Ingen valde nettverk"
 
-#: src/amule.cpp:2633 src/TextClient.cpp:903
+#: src/amule.cpp:2641 src/TextClient.cpp:903
 msgid "with LowID"
 msgstr "med LågID"
 
-#: src/amule.cpp:2633 src/TextClient.cpp:904
+#: src/amule.cpp:2641 src/TextClient.cpp:904
 msgid "with HighID"
 msgstr "med HøgID"
 
-#: src/amule.cpp:2635
+#: src/amule.cpp:2643
 #, c-format
 msgid "Connected to %s %s"
 msgstr "Tilkopla %s·%s"
 
-#: src/amule.cpp:2640
+#: src/amule.cpp:2648
 #, c-format
 msgid "Connecting to %s"
 msgstr "Koplar til %s"
 
-#: src/amule.cpp:2642
+#: src/amule.cpp:2650
 msgid "Disconnected from eD2k"
 msgstr "Fråkopla eD2k"
 
-#: src/amule.cpp:2651
+#: src/amule.cpp:2659
 msgid "Kad started."
 msgstr "Kad starta."
 
-#: src/amule.cpp:2653
+#: src/amule.cpp:2661
 msgid "Kad stopped."
 msgstr "Kad stogga."
 
-#: src/amule.cpp:2661
+#: src/amule.cpp:2669
 msgid "Connected to Kad (ok)"
 msgstr "Tilkopla Kad (ok)"
 
-#: src/amule.cpp:2663
+#: src/amule.cpp:2671
 msgid "Connected to Kad (firewalled)"
 msgstr "Tilkopla Kad (brannmura)"
 
-#: src/amule.cpp:2667
+#: src/amule.cpp:2675
 msgid "Disconnected from Kad"
 msgstr "Fråkopla Kad"
 
-#: src/amule.cpp:2699
+#: src/amule.cpp:2707
 msgid "Kad network cannot be used if UDP port is disabled on preferences, not starting."
 msgstr "Kad kan ikkje nyttast dersom UDP-porten er deaktivert i innstillingar. Startar ikkje."
 
-#: src/amule.cpp:2703
+#: src/amule.cpp:2711
 msgid "Kad network disabled on preferences, not connecting."
 msgstr "Kad-nettverket er deaktivert i innstillingar. Koplar ikkje til."
 
@@ -596,36 +596,36 @@ msgid "FATAL ERROR: Failed to create Timer"
 msgstr "FATAL FEIL: Greidde ikkje å lage tidtakar"
 
 #: src/amuleDlg.cpp:361 src/amuleDlg.cpp:1787 src/amuleDlg.cpp:2033
-#: src/muuli_wdr.cpp:1492 src/muuli_wdr.cpp:3418
+#: src/muuli_wdr.cpp:1492 src/muuli_wdr.cpp:3449
 msgid "Networks"
 msgstr "Nettverk"
 
-#: src/amuleDlg.cpp:362 src/amuleDlg.cpp:1793 src/muuli_wdr.cpp:3419
+#: src/amuleDlg.cpp:362 src/amuleDlg.cpp:1793 src/muuli_wdr.cpp:3450
 msgid "Searches"
 msgstr "Søk"
 
 #: src/amuleDlg.cpp:363 src/amuleDlg.cpp:1799 src/DownloadListCtrl.cpp:740
-#: src/muuli_wdr.cpp:392 src/muuli_wdr.cpp:1585 src/muuli_wdr.cpp:3420
+#: src/muuli_wdr.cpp:392 src/muuli_wdr.cpp:1585 src/muuli_wdr.cpp:3451
 #: src/Statistics.cpp:829
 msgid "Downloads"
 msgstr "Nedlastingar"
 
-#: src/amuleDlg.cpp:364 src/amuleDlg.cpp:1805 src/muuli_wdr.cpp:3294
+#: src/amuleDlg.cpp:364 src/amuleDlg.cpp:1805 src/muuli_wdr.cpp:3325
 msgid "Shared files"
 msgstr "Delte filer"
 
-#: src/amuleDlg.cpp:365 src/amuleDlg.cpp:1811 src/muuli_wdr.cpp:2926
-#: src/muuli_wdr.cpp:3376 src/muuli_wdr.cpp:3423
+#: src/amuleDlg.cpp:365 src/amuleDlg.cpp:1811 src/muuli_wdr.cpp:2957
+#: src/muuli_wdr.cpp:3407 src/muuli_wdr.cpp:3454
 msgid "Messages"
 msgstr "Meldingar"
 
-#: src/amuleDlg.cpp:366 src/amuleDlg.cpp:1817 src/muuli_wdr.cpp:3424
-#: src/PrefsUnifiedDlg.cpp:312 src/Statistics.cpp:779 src/Statistics.cpp:1235
+#: src/amuleDlg.cpp:366 src/amuleDlg.cpp:1817 src/muuli_wdr.cpp:3455
+#: src/PrefsUnifiedDlg.cpp:314 src/Statistics.cpp:779 src/Statistics.cpp:1235
 msgid "Statistics"
 msgstr "Statistikk"
 
-#: src/amuleDlg.cpp:368 src/amuleDlg.cpp:1824 src/muuli_wdr.cpp:3426
-#: src/PrefsUnifiedDlg.cpp:328 src/utils/wxCas/src/wxcasprefs.cpp:39
+#: src/amuleDlg.cpp:368 src/amuleDlg.cpp:1824 src/muuli_wdr.cpp:3457
+#: src/PrefsUnifiedDlg.cpp:330 src/utils/wxCas/src/wxcasprefs.cpp:39
 msgid "Preferences"
 msgstr "Innstillingar"
 
@@ -683,8 +683,8 @@ msgstr "Kad: Av"
 #: src/amuleDlg.cpp:1029 src/DownloadListCtrl.cpp:505
 #: src/DownloadListCtrl.cpp:749 src/FriendListCtrl.cpp:180
 #: src/muuli_wdr.cpp:731 src/muuli_wdr.cpp:782 src/muuli_wdr.cpp:846
-#: src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2231 src/muuli_wdr.cpp:2316
-#: src/muuli_wdr.cpp:3064 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
+#: src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2262 src/muuli_wdr.cpp:2347
+#: src/muuli_wdr.cpp:3095 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
 #: src/ServerListCtrl.cpp:606 src/TransferWnd.cpp:378
 #: src/utils/wxCas/src/wxcasprefs.cpp:235
 msgid "Cancel"
@@ -695,7 +695,7 @@ msgid "Stop the current connection attempts"
 msgstr "Stopp inneverande oppkoplingsfreistingar"
 
 #: src/amuleDlg.cpp:1035 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976
-#: src/muuli_wdr.cpp:2454
+#: src/muuli_wdr.cpp:2485
 msgid "Disconnect"
 msgstr "Kople frå"
 
@@ -704,7 +704,7 @@ msgid "Disconnect from the currently connected networks"
 msgstr "Kople frå dei aktive nettverka"
 
 #: src/amuleDlg.cpp:1041 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979
-#: src/muuli_wdr.cpp:2609 src/muuli_wdr.cpp:3061 src/muuli_wdr.cpp:3416
+#: src/muuli_wdr.cpp:2640 src/muuli_wdr.cpp:3092 src/muuli_wdr.cpp:3447
 msgid "Connect"
 msgstr "Kople til"
 
@@ -759,7 +759,7 @@ msgstr "Stadfesting av avslutting"
 msgid "Launch Command: "
 msgstr ""
 
-#: src/amuleDlg.cpp:1632 src/muuli_wdr.cpp:1978 src/Preferences.cpp:952
+#: src/amuleDlg.cpp:1632 src/muuli_wdr.cpp:1982 src/Preferences.cpp:979
 msgid "- default -"
 msgstr ""
 
@@ -773,49 +773,49 @@ msgstr "Skinnkatalogen '%s' finst ikkje"
 msgid "WARNING: Unable to open skin file '%s' for read"
 msgstr "ÅTVARING: Greidde ikkje å opne hudfila '%s' for lesing"
 
-#: src/amuleDlg.cpp:1791 src/muuli_wdr.cpp:3418
+#: src/amuleDlg.cpp:1791 src/muuli_wdr.cpp:3449
 msgid "Networks Window"
 msgstr "Nettverksavindauge"
 
-#: src/amuleDlg.cpp:1797 src/muuli_wdr.cpp:3419
+#: src/amuleDlg.cpp:1797 src/muuli_wdr.cpp:3450
 msgid "Searches Window"
 msgstr "Søkjevindauge"
 
-#: src/amuleDlg.cpp:1803 src/muuli_wdr.cpp:3420
+#: src/amuleDlg.cpp:1803 src/muuli_wdr.cpp:3451
 #, fuzzy
 msgid "Downloads Window"
 msgstr "Lastar ned"
 
-#: src/amuleDlg.cpp:1809 src/muuli_wdr.cpp:3422
+#: src/amuleDlg.cpp:1809 src/muuli_wdr.cpp:3453
 msgid "Shared Files Window"
 msgstr "Vindauge for delte filer"
 
-#: src/amuleDlg.cpp:1815 src/muuli_wdr.cpp:3423
+#: src/amuleDlg.cpp:1815 src/muuli_wdr.cpp:3454
 msgid "Messages Window"
 msgstr "Meldingsvindauge"
 
-#: src/amuleDlg.cpp:1821 src/muuli_wdr.cpp:3424
+#: src/amuleDlg.cpp:1821 src/muuli_wdr.cpp:3455
 msgid "Statistics Graph Window"
 msgstr "Statistikkgrafvindauge"
 
-#: src/amuleDlg.cpp:1828 src/muuli_wdr.cpp:3426
+#: src/amuleDlg.cpp:1828 src/muuli_wdr.cpp:3457
 msgid "Preferences Settings Window"
 msgstr "Innstillingsvalsvindauge"
 
-#: src/amuleDlg.cpp:1831 src/muuli_wdr.cpp:3427
+#: src/amuleDlg.cpp:1831 src/muuli_wdr.cpp:3458
 msgid "Import"
 msgstr "Importér"
 
-#: src/amuleDlg.cpp:1835 src/muuli_wdr.cpp:3427
+#: src/amuleDlg.cpp:1835 src/muuli_wdr.cpp:3458
 msgid "The partfile importer tool"
 msgstr "Verkty for delfilimport"
 
-#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3428
+#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3459
 #: src/utils/aLinkCreator/src/alcframe.cpp:262
 msgid "About"
 msgstr "Om"
 
-#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3428
+#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3459
 msgid "About/Help"
 msgstr "Om/hjelp"
 
@@ -961,7 +961,7 @@ msgstr "Fil ikkje funne."
 msgid "The core rejected these shared folders:%s"
 msgstr ""
 
-#: src/amule-remote-gui.cpp:1336 src/ExternalConn.cpp:2345
+#: src/amule-remote-gui.cpp:1336 src/ExternalConn.cpp:2346
 msgid "Invalid link or already on list."
 msgstr "Ikkje gangbar lenkje eller lenka allereie på lista."
 
@@ -977,7 +977,7 @@ msgstr ""
 #: src/ClientDetailDialog.cpp:123 src/DataToText.cpp:61 src/DataToText.cpp:86
 #: src/DataToText.cpp:101 src/DataToText.cpp:136 src/DataToText.cpp:165
 #: src/DownloadListCtrl.cpp:1172 src/DownloadListCtrl.cpp:1185
-#: src/DownloadListCtrl.cpp:1196 src/ExternalConn.cpp:608
+#: src/DownloadListCtrl.cpp:1196 src/ExternalConn.cpp:609
 #: src/FileDetailDialog.cpp:203 src/FileDetailDialog.cpp:235
 #: src/FileDetailDialog.cpp:242 src/GenericClientListCtrl.cpp:1171
 #: src/GenericClientListCtrl.cpp:1182 src/GenericClientListCtrl.cpp:1192
@@ -1364,19 +1364,19 @@ msgstr "Auto·[Hø]"
 msgid "Very low"
 msgstr "Svært låg"
 
-#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:743 src/muuli_wdr.cpp:2282
+#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:743 src/muuli_wdr.cpp:2313
 #: src/ServerListCtrl.cpp:263 src/ServerListCtrl.cpp:456
 #: src/SharedFilesCtrl.cpp:145
 msgid "Low"
 msgstr "Låg"
 
-#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:744 src/muuli_wdr.cpp:2283
+#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:744 src/muuli_wdr.cpp:2314
 #: src/ServerListCtrl.cpp:266 src/ServerListCtrl.cpp:457
 #: src/SharedFilesCtrl.cpp:146
 msgid "Normal"
 msgstr "Vanleg"
 
-#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:745 src/muuli_wdr.cpp:2284
+#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:745 src/muuli_wdr.cpp:2315
 #: src/ServerListCtrl.cpp:269 src/ServerListCtrl.cpp:458
 #: src/SharedFilesCtrl.cpp:147
 msgid "High"
@@ -1468,7 +1468,7 @@ msgstr "Lokal tenar"
 msgid "Remote Server"
 msgstr "Fjern tenar"
 
-#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3181
+#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3212
 #: src/SearchDlg.cpp:119 src/TextClient.cpp:911
 msgid "Kad"
 msgstr "Kad"
@@ -1540,7 +1540,7 @@ msgstr ""
 msgid "Size"
 msgstr "Storleik"
 
-#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3248
+#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3279
 msgid "Transferred"
 msgstr "Overført"
 
@@ -1598,7 +1598,7 @@ msgstr ""
 "Tilbakemelding frå: %s (%s)\n"
 "\n"
 
-#: src/DownloadListCtrl.cpp:746 src/muuli_wdr.cpp:2285
+#: src/DownloadListCtrl.cpp:746 src/muuli_wdr.cpp:2316
 #: src/SharedFilesCtrl.cpp:150
 msgid "Auto"
 msgstr "Automatisk"
@@ -1636,7 +1636,7 @@ msgid "Extended Options"
 msgstr "Utvida innstillingar"
 
 #: src/DownloadListCtrl.cpp:770 src/DownloadListCtrl.cpp:822
-#: src/muuli_wdr.cpp:1796
+#: src/muuli_wdr.cpp:1800
 msgid "Preview"
 msgstr "Førehandssyning"
 
@@ -1809,232 +1809,237 @@ msgstr[1] ""
 msgid "Invalid eD2k link! ERROR: %s"
 msgstr "Ugangbar eD2k lenkje! FEIL: %s"
 
-#: src/ExternalConn.cpp:379
+#: src/ExternalConn.cpp:380
 #, fuzzy
 msgid "Client sent packet after authentication failed."
 msgstr "Godkjenning mislukka."
 
-#: src/ExternalConn.cpp:396
+#: src/ExternalConn.cpp:397
 msgid "External connection closed."
 msgstr "Ekstern kopling lukka."
 
-#: src/ExternalConn.cpp:473
+#: src/ExternalConn.cpp:474
 msgid "External connections disabled due to empty password!"
 msgstr "Eksterne koplingar deaktiverte på grunn av tomt passord!"
 
-#: src/ExternalConn.cpp:494
+#: src/ExternalConn.cpp:495
 msgid "External connections disabled in config file"
 msgstr "Eksterne koplingar deaktiverte i konfigurasjonsfila"
 
-#: src/ExternalConn.cpp:575
+#: src/ExternalConn.cpp:576
 msgid "New external connection accepted"
 msgstr "Ny ekstern kopling akseptert"
 
-#: src/ExternalConn.cpp:578
+#: src/ExternalConn.cpp:579
 msgid "ERROR: couldn't accept a new external connection"
 msgstr "FEIL: greidde ikkje å ta imot ei ny ekstern kopling"
 
-#: src/ExternalConn.cpp:595
+#: src/ExternalConn.cpp:596
 msgid "External connection refused due to empty password in preferences!"
 msgstr "Ekstern kopling nekta på grunn av tomt passord i innstillingar!"
 
-#: src/ExternalConn.cpp:607
+#: src/ExternalConn.cpp:608
 #, c-format
 msgid "Connecting client: %s %s"
 msgstr "Koplar til klient: %s %s"
 
-#: src/ExternalConn.cpp:609
+#: src/ExternalConn.cpp:610
 msgid "Unknown version"
 msgstr "Ukjend utgåve"
 
-#: src/ExternalConn.cpp:622
+#: src/ExternalConn.cpp:623
 msgid "Incorrect EC version ID, there might be binary incompatibility. Use core and remote from same snapshot."
 msgstr "Ikkje rett EC utgåve ID: det kan vere binær inkompatibilitet. Bruk core og remote frå same snapshot."
 
-#: src/ExternalConn.cpp:630
+#: src/ExternalConn.cpp:631
 #, fuzzy
 msgid "You cannot connect to a release version from an arbitrary development snapshot! *sigh* possible crash prevented"
 msgstr "Du kan ikkje kople til ei utgivingsutgåve frå ei vilkårleg SVN utgåve! *sukk* mogleg krasj unngått"
 
-#: src/ExternalConn.cpp:713
+#: src/ExternalConn.cpp:714
 msgid "Invalid protocol version."
 msgstr "Ugyldig protokullutgåve."
 
-#: src/ExternalConn.cpp:719
+#: src/ExternalConn.cpp:720
 msgid "Missing protocol version tag."
 msgstr "Manglande merkelapp for protokollutgåve."
 
-#: src/ExternalConn.cpp:727
+#: src/ExternalConn.cpp:728
 msgid "Authentication failed: invalid hash specified as EC password."
 msgstr ""
 
-#: src/ExternalConn.cpp:775
+#: src/ExternalConn.cpp:776
 #, fuzzy
 msgid "Authentication failed: wrong password."
 msgstr "Godkjenning mislukka."
 
-#: src/ExternalConn.cpp:777
+#: src/ExternalConn.cpp:778
 #, fuzzy
 msgid "Authentication failed: missing password."
 msgstr "Godkjenning mislukka."
 
-#: src/ExternalConn.cpp:788
+#: src/ExternalConn.cpp:789
 #, fuzzy
 msgid "Invalid request, please authenticate first."
 msgstr "Ugyldig etterspurnad, du treng godkjenning først."
 
-#: src/ExternalConn.cpp:793
+#: src/ExternalConn.cpp:794
 msgid "Access granted."
 msgstr "Tilgang innvilga."
 
-#: src/ExternalConn.cpp:801
+#: src/ExternalConn.cpp:802
 #, fuzzy, c-format
 msgid "Sent error message \"%s\" to client."
 msgstr "Filtrér meldingar frå ukjende klientar"
 
-#: src/ExternalConn.cpp:806
+#: src/ExternalConn.cpp:807
 #, fuzzy, c-format
 msgid "Unauthorized access attempt from %s. Connection closed."
 msgstr "Uaotorisert freisting på tilgang. Kopling lukka."
 
-#: src/ExternalConn.cpp:1419
+#: src/ExternalConn.cpp:1420
 #, c-format
 msgid "Remote PartFile command failed: FileHash not found: %s"
 msgstr "Kommando for fjern delfil mislukka: Filhash ikkje funnen: %s"
 
-#: src/ExternalConn.cpp:1423
+#: src/ExternalConn.cpp:1424
 #, c-format
 msgid "FileHash not found: %s"
 msgstr "Filhash ikkje funnen: %s"
 
-#: src/ExternalConn.cpp:1470 src/ExternalConn.cpp:1558
-#: src/ExternalConn.cpp:1679
+#: src/ExternalConn.cpp:1471 src/ExternalConn.cpp:1559
+#: src/ExternalConn.cpp:1680
 msgid "OOPS! OpCode processing error!"
 msgstr "OPS! Handsamingsfeil i OpCode!"
 
-#: src/ExternalConn.cpp:1501
+#: src/ExternalConn.cpp:1502
 msgid "Server not added"
 msgstr "Tenar ikkje lagd til"
 
-#: src/ExternalConn.cpp:1520
+#: src/ExternalConn.cpp:1521
 #, c-format
 msgid "server not found: %s"
 msgstr "tenar ikkje funnen: %s"
 
-#: src/ExternalConn.cpp:1537
+#: src/ExternalConn.cpp:1538
 msgid "need to define server to be removed"
 msgstr "treng å velje tenar for fjerning"
 
-#: src/ExternalConn.cpp:1552
+#: src/ExternalConn.cpp:1553
 msgid "eD2k is disabled in preferences."
 msgstr "eD2k er deaktivert i innstillingar"
 
-#: src/ExternalConn.cpp:1657
+#: src/ExternalConn.cpp:1658
 #, fuzzy
 msgid "Friend not found."
 msgstr "Fil ikkje funne."
 
-#: src/ExternalConn.cpp:1667
+#: src/ExternalConn.cpp:1668
 #, fuzzy
 msgid "Client not found."
 msgstr "Fil ikkje funne."
 
-#: src/ExternalConn.cpp:1673
+#: src/ExternalConn.cpp:1674
 msgid "EC_TAG_FRIEND_SHARED requires EC_TAG_FRIEND or EC_TAG_CLIENT."
 msgstr ""
 
-#: src/ExternalConn.cpp:1991
+#: src/ExternalConn.cpp:1992
 msgid "WebSearch from remote interface makes no sense."
 msgstr "Nettsøk frå fjern adresse gir ikkje meining."
 
-#: src/ExternalConn.cpp:2026
+#: src/ExternalConn.cpp:2027
 msgid "Search in progress. Refetch results in a moment!"
 msgstr "Søk i framdrift. Hentar inn att resultata om ein augneblink!"
 
-#: src/ExternalConn.cpp:2265
+#: src/ExternalConn.cpp:2266
 msgid "No points for graph."
 msgstr "Ingen punkt for graf."
 
-#: src/ExternalConn.cpp:2275
+#: src/ExternalConn.cpp:2276
 msgid "Your client is not configured for this detail level."
 msgstr "Klienten din er ikkje konfigurert for dette detaljnivået."
 
-#: src/ExternalConn.cpp:2302
+#: src/ExternalConn.cpp:2303
 msgid "External Connection: shutdown requested"
 msgstr "Ekstern kopling: avslutting etterspurt"
 
-#: src/ExternalConn.cpp:2314
+#: src/ExternalConn.cpp:2315
 msgid "Already shutting down."
 msgstr "Avsluttar allereie."
 
-#: src/ExternalConn.cpp:2332
+#: src/ExternalConn.cpp:2333
 #, c-format
 msgid "ExternalConn: adding link '%s'."
 msgstr "Eksternkopling: legg til lenkje '%s'."
 
-#: src/ExternalConn.cpp:2350
+#: src/ExternalConn.cpp:2351
 #, fuzzy, c-format
 msgid "%d of %d links failed (invalid or already on list)."
 msgstr "Ikkje gangbar lenkje eller lenka allereie på lista."
 
-#: src/ExternalConn.cpp:2373
+#: src/ExternalConn.cpp:2374
 msgid "Version check throttled; try again shortly."
 msgstr ""
 
-#: src/ExternalConn.cpp:2378
+#: src/ExternalConn.cpp:2379
 msgid "Version check is not available on this daemon."
 msgstr ""
 
-#: src/ExternalConn.cpp:2508
+#: src/ExternalConn.cpp:2509
 msgid "File not found."
 msgstr "Fil ikkje funne."
 
-#: src/ExternalConn.cpp:2513
+#: src/ExternalConn.cpp:2514
 msgid "Invalid file name."
 msgstr "Ikkje gangbart filnamn."
 
-#: src/ExternalConn.cpp:2521
+#: src/ExternalConn.cpp:2522
 msgid "Unable to rename file."
 msgstr "Ikkje i stand til å døype om fila."
 
-#: src/ExternalConn.cpp:2992 src/ExternalConn.cpp:3020
+#: src/ExternalConn.cpp:2839
+#, c-format
+msgid "Could not save the amuleapi password: %s"
+msgstr ""
+
+#: src/ExternalConn.cpp:3004 src/ExternalConn.cpp:3032
 msgid "Kad is disabled in preferences."
 msgstr "Kad er deaktivert i innstillingar."
 
-#: src/ExternalConn.cpp:3033
+#: src/ExternalConn.cpp:3045
 msgid "Already connected to eD2k."
 msgstr "Allereie tilkopla eD2k."
 
-#: src/ExternalConn.cpp:3036
+#: src/ExternalConn.cpp:3048
 msgid "Connecting to eD2k..."
 msgstr "Koplar til eD2k..."
 
-#: src/ExternalConn.cpp:3045
+#: src/ExternalConn.cpp:3057
 msgid "Already connected to Kad."
 msgstr "Allereie tilkopla Kad."
 
-#: src/ExternalConn.cpp:3048
+#: src/ExternalConn.cpp:3060
 msgid "Connecting to Kad..."
 msgstr "Koplar til Kad..."
 
-#: src/ExternalConn.cpp:3055
+#: src/ExternalConn.cpp:3067
 msgid "All networks are disabled."
 msgstr "Alle nettverk er deaktiverte."
 
-#: src/ExternalConn.cpp:3064
+#: src/ExternalConn.cpp:3076
 msgid "Disconnected from eD2k."
 msgstr "Fråkopla eD2k."
 
-#: src/ExternalConn.cpp:3069
+#: src/ExternalConn.cpp:3081
 msgid "Disconnected from Kad."
 msgstr "Fråkopla Kad."
 
-#: src/ExternalConn.cpp:3078
+#: src/ExternalConn.cpp:3090
 #, c-format
 msgid "External Connection: invalid opcode received: %#x"
 msgstr "Ekstern kopling: ugangbar opkode motteken: %#x"
 
-#: src/ExternalConn.cpp:3083
+#: src/ExternalConn.cpp:3095
 msgid "Invalid opcode (wrong protocol version?)"
 msgstr "Ikkje gangbar opkode (feil protokollutgåve?)"
 
@@ -2435,23 +2440,23 @@ msgid ""
 "want downloads on a different (e.g. larger) disk."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:549 src/FirstRunWizard.cpp:611 src/muuli_wdr.cpp:1708
+#: src/FirstRunWizard.cpp:549 src/FirstRunWizard.cpp:611 src/muuli_wdr.cpp:1712
 msgid "Destination folder for downloads"
 msgstr ""
 
 #: src/FirstRunWizard.cpp:553 src/FirstRunWizard.cpp:569 src/muuli_wdr.cpp:1349
-#: src/muuli_wdr.cpp:1366 src/muuli_wdr.cpp:1683 src/muuli_wdr.cpp:1714
-#: src/muuli_wdr.cpp:1726 src/muuli_wdr.cpp:2769
+#: src/muuli_wdr.cpp:1366 src/muuli_wdr.cpp:1687 src/muuli_wdr.cpp:1718
+#: src/muuli_wdr.cpp:1730 src/muuli_wdr.cpp:2800
 #: src/utils/aLinkCreator/src/alcframe.cpp:135
 #: src/utils/wxCas/src/wxcasprefs.cpp:52 src/utils/wxCas/src/wxcasprefs.cpp:118
 msgid "Browse"
 msgstr "Bla"
 
-#: src/FirstRunWizard.cpp:559 src/muuli_wdr.cpp:1719
+#: src/FirstRunWizard.cpp:559 src/muuli_wdr.cpp:1723
 msgid "(All files in this folder are shared with other peers)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:565 src/FirstRunWizard.cpp:624 src/muuli_wdr.cpp:1721
+#: src/FirstRunWizard.cpp:565 src/FirstRunWizard.cpp:624 src/muuli_wdr.cpp:1725
 msgid "Folder for temporary download files"
 msgstr ""
 
@@ -2482,7 +2487,7 @@ msgstr "Greidde ikkje å opne venelista 'enfriends.met' for skriving!"
 msgid "CRITICAL - no client on StartChatSession"
 msgstr ""
 
-#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2675 src/muuli_wdr.cpp:3352
+#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2706 src/muuli_wdr.cpp:3383
 msgid "Friends"
 msgstr "Vener"
 
@@ -2596,8 +2601,8 @@ msgstr "Ingen"
 msgid "No"
 msgstr "Nei"
 
-#: src/GenericClientListCtrl.cpp:1216 src/PrefsUnifiedDlg.cpp:2818
-#: src/PrefsUnifiedDlg.cpp:2868 src/ServerListCtrl.cpp:276
+#: src/GenericClientListCtrl.cpp:1216 src/PrefsUnifiedDlg.cpp:2898
+#: src/PrefsUnifiedDlg.cpp:2948 src/ServerListCtrl.cpp:276
 msgid "Yes"
 msgstr "Ja"
 
@@ -2767,10 +2772,10 @@ msgstr "Ikkje gangbar port for eigenoppstart"
 msgid "Please fill all fields required"
 msgstr "Vér god å fylle ut alle naudsynte felt"
 
-#: src/KadDlg.cpp:192 src/PartFile.cpp:1031 src/PrefsUnifiedDlg.cpp:1162
-#: src/PrefsUnifiedDlg.cpp:1331 src/PrefsUnifiedDlg.cpp:1589
-#: src/PrefsUnifiedDlg.cpp:1599 src/PrefsUnifiedDlg.cpp:1616
-#: src/PrefsUnifiedDlg.cpp:1658
+#: src/KadDlg.cpp:192 src/PartFile.cpp:1031 src/PrefsUnifiedDlg.cpp:1134
+#: src/PrefsUnifiedDlg.cpp:1204 src/PrefsUnifiedDlg.cpp:1405
+#: src/PrefsUnifiedDlg.cpp:1663 src/PrefsUnifiedDlg.cpp:1673
+#: src/PrefsUnifiedDlg.cpp:1690 src/PrefsUnifiedDlg.cpp:1738
 msgid "Message"
 msgstr "Melding"
 
@@ -2872,7 +2877,7 @@ msgstr "Delingsrate"
 msgid "Uploaded"
 msgstr "Lasta opp"
 
-#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3232
+#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3263
 msgid "Requested"
 msgstr "Etterspurt"
 
@@ -2998,7 +3003,7 @@ msgid "WARNING: "
 msgstr "ÅTVARING: "
 
 #: src/MuleNotebook.cpp:179 src/muuli_wdr.cpp:817 src/muuli_wdr.cpp:1229
-#: src/muuli_wdr.cpp:3136 src/muuli_wdr.cpp:3392
+#: src/muuli_wdr.cpp:3167 src/muuli_wdr.cpp:3423
 msgid "Close"
 msgstr "Stengje"
 
@@ -3016,7 +3021,7 @@ msgid "Paste"
 msgstr "Lim inn"
 
 #: src/MuleTextCtrl.cpp:89 src/muuli_wdr.cpp:358 src/muuli_wdr.cpp:757
-#: src/muuli_wdr.cpp:2359 src/muuli_wdr.cpp:2378 src/muuli_wdr.cpp:2400
+#: src/muuli_wdr.cpp:2390 src/muuli_wdr.cpp:2409 src/muuli_wdr.cpp:2431
 #: src/utils/aLinkCreator/src/alcframe.cpp:142
 msgid "Clear"
 msgstr "Frigjer plass"
@@ -3115,7 +3120,7 @@ msgstr "Avslutt"
 
 #: src/MuleTrayIcon.cpp:579 src/MuleTrayIcon.cpp:945 src/MuleTrayIcon.cpp:965
 #: src/muuli_wdr.cpp:1398 src/muuli_wdr.cpp:1406 src/muuli_wdr.cpp:1413
-#: src/muuli_wdr.cpp:1842 src/muuli_wdr.cpp:1848 src/OtherFunctions.cpp:91
+#: src/muuli_wdr.cpp:1846 src/muuli_wdr.cpp:1852 src/OtherFunctions.cpp:91
 #: src/StatisticsDlg.cpp:93 src/StatisticsDlg.cpp:95
 msgid "kB/s"
 msgstr "kB/s"
@@ -3357,7 +3362,7 @@ msgstr "Bytes"
 msgid "KB"
 msgstr "KB"
 
-#: src/muuli_wdr.cpp:274 src/muuli_wdr.cpp:293 src/muuli_wdr.cpp:1627
+#: src/muuli_wdr.cpp:274 src/muuli_wdr.cpp:293 src/muuli_wdr.cpp:1631
 #: src/OtherFunctions.cpp:64
 msgid "MB"
 msgstr "MB"
@@ -3374,7 +3379,7 @@ msgstr "Maks storleik"
 msgid "Availability"
 msgstr "Tilgjenge"
 
-#: src/muuli_wdr.cpp:312 src/muuli_wdr.cpp:398 src/muuli_wdr.cpp:3297
+#: src/muuli_wdr.cpp:312 src/muuli_wdr.cpp:398 src/muuli_wdr.cpp:3328
 msgid "Filter:"
 msgstr "Filter:"
 
@@ -3438,12 +3443,12 @@ msgstr "Komplette kjelder"
 #: src/muuli_wdr.cpp:1160 src/muuli_wdr.cpp:1167 src/muuli_wdr.cpp:1172
 #: src/muuli_wdr.cpp:1179 src/muuli_wdr.cpp:1184 src/muuli_wdr.cpp:1191
 #: src/muuli_wdr.cpp:1205 src/muuli_wdr.cpp:1212 src/muuli_wdr.cpp:1217
-#: src/muuli_wdr.cpp:1224 src/muuli_wdr.cpp:3234 src/muuli_wdr.cpp:3242
-#: src/muuli_wdr.cpp:3250
+#: src/muuli_wdr.cpp:1224 src/muuli_wdr.cpp:3265 src/muuli_wdr.cpp:3273
+#: src/muuli_wdr.cpp:3281
 msgid "N/A"
 msgstr "I/T"
 
-#: src/muuli_wdr.cpp:508 src/muuli_wdr.cpp:1065 src/PrefsUnifiedDlg.cpp:297
+#: src/muuli_wdr.cpp:508 src/muuli_wdr.cpp:1065 src/PrefsUnifiedDlg.cpp:299
 msgid "General"
 msgstr "Generelt"
 
@@ -3584,7 +3589,7 @@ msgstr ""
 msgid "Album :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:685 src/muuli_wdr.cpp:2254
+#: src/muuli_wdr.cpp:685 src/muuli_wdr.cpp:2285
 msgid "Title :"
 msgstr "Tittel :"
 
@@ -3691,7 +3696,7 @@ msgstr "Brukarnamn :"
 msgid "Userhash :"
 msgstr "Brukarhash :"
 
-#: src/muuli_wdr.cpp:895 src/muuli_wdr.cpp:1748 src/muuli_wdr.cpp:2449
+#: src/muuli_wdr.cpp:895 src/muuli_wdr.cpp:1752 src/muuli_wdr.cpp:2480
 #: src/utils/aLinkCreator/src/alcframe.cpp:137
 msgid "Add"
 msgstr "Legg til"
@@ -3700,15 +3705,15 @@ msgstr "Legg til"
 msgid "Download-Speed"
 msgstr "Nedlastingsfart"
 
-#: src/muuli_wdr.cpp:954 src/muuli_wdr.cpp:989 src/muuli_wdr.cpp:2553
+#: src/muuli_wdr.cpp:954 src/muuli_wdr.cpp:989 src/muuli_wdr.cpp:2584
 msgid "Current"
 msgstr "Novérande"
 
-#: src/muuli_wdr.cpp:962 src/muuli_wdr.cpp:997 src/muuli_wdr.cpp:2561
+#: src/muuli_wdr.cpp:962 src/muuli_wdr.cpp:997 src/muuli_wdr.cpp:2592
 msgid "Running average"
 msgstr "Køyregjennomsnitt"
 
-#: src/muuli_wdr.cpp:970 src/muuli_wdr.cpp:1005 src/muuli_wdr.cpp:2569
+#: src/muuli_wdr.cpp:970 src/muuli_wdr.cpp:1005 src/muuli_wdr.cpp:2600
 msgid "Session average"
 msgstr "Gjennomsnitt økt"
 
@@ -3720,7 +3725,7 @@ msgstr "Opplastingsfart"
 msgid "Connections"
 msgstr "Koplingar"
 
-#: src/muuli_wdr.cpp:1024 src/muuli_wdr.cpp:1867
+#: src/muuli_wdr.cpp:1024 src/muuli_wdr.cpp:1871
 msgid "Active downloads"
 msgstr "Aktive nedlastingar"
 
@@ -3728,7 +3733,7 @@ msgstr "Aktive nedlastingar"
 msgid "Active connections (1:1)"
 msgstr "Aktive koplingar (1:1)"
 
-#: src/muuli_wdr.cpp:1040 src/muuli_wdr.cpp:1868
+#: src/muuli_wdr.cpp:1040 src/muuli_wdr.cpp:1872
 msgid "Active uploads"
 msgstr "Aktive opplastingar"
 
@@ -4005,7 +4010,7 @@ msgstr ""
 msgid "Advanced users only: If you have multiple network interfaces, enter the address of the interface to which aMule should be bound."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1462 src/muuli_wdr.cpp:2061
+#: src/muuli_wdr.cpp:1462 src/muuli_wdr.cpp:2065
 msgid "Bind to network interface (empty for any):"
 msgstr ""
 
@@ -4021,7 +4026,7 @@ msgstr ""
 msgid "Max simultaneous connections:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1498 src/muuli_wdr.cpp:3176
+#: src/muuli_wdr.cpp:1498 src/muuli_wdr.cpp:3207
 msgid "ED2K"
 msgstr "ED2k"
 
@@ -4113,758 +4118,781 @@ msgstr "Hent diskplass for nye filer"
 msgid "For new files preallocates disk space for the whole file, thus reduces fragmentation"
 msgstr "Hentar diskplass for heile nye filer, og reduserer fragmentering"
 
-#: src/muuli_wdr.cpp:1613
+#: src/muuli_wdr.cpp:1617
 msgid "Create new files as sparse files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1614
-msgid "A sparse file reserves its full size on disk immediately without writing real data to it -- fast, but unsupported or slow on some filesystems, and free-space accounting stays optimistic while the download is in progress. Turn this off to grow the file only as data arrives."
+#: src/muuli_wdr.cpp:1618
+msgid "Sparse part files only occupy disk space for the parts already downloaded, so free space is used up gradually as the file fills in. Turn this off to use an ordinary file instead - useful where sparse files are unsupported or slow, or where backup/de-duplication tools handle them badly. Applies only when the core runs on Windows; on Linux and macOS part files are sparse anyway and this setting has no effect."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1619
+#: src/muuli_wdr.cpp:1623
 msgid "Stop downloads when free disk space reaches "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1620
+#: src/muuli_wdr.cpp:1624
 msgid "Select this if you want aMule to check your disk space"
 msgstr "Vel denne dersom du vil at aMule skal sjekke om du har nok diskplass"
 
-#: src/muuli_wdr.cpp:1624
+#: src/muuli_wdr.cpp:1628
 msgid "Enter here the min disk space desired."
 msgstr "Skriv inn mimimum ønska diskplass."
 
-#: src/muuli_wdr.cpp:1630
+#: src/muuli_wdr.cpp:1634
 msgid "Save 10 sources on rare files (< 20 sources)"
 msgstr "Lagre 10 kjelder til sjeldne filer (< 20 kjelder)"
 
-#: src/muuli_wdr.cpp:1634 src/Statistics.cpp:790
+#: src/muuli_wdr.cpp:1638 src/Statistics.cpp:790
 msgid "Uploads"
 msgstr "Opplastingar"
 
-#: src/muuli_wdr.cpp:1637
+#: src/muuli_wdr.cpp:1641
 msgid "Add new shared files with auto priority"
 msgstr "Legg til nye delte filer med autoprioritet"
 
-#: src/muuli_wdr.cpp:1643
+#: src/muuli_wdr.cpp:1647
 msgid "Intelligent Corruption Handling (I.C.H.)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1646
+#: src/muuli_wdr.cpp:1650
 msgid "Enable"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1649
+#: src/muuli_wdr.cpp:1653
 msgid "Advanced I.C.H. trusts every hash (not recommended)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1661 src/PrefsUnifiedDlg.cpp:1910
+#: src/muuli_wdr.cpp:1665 src/PrefsUnifiedDlg.cpp:1990
 msgid "Media metadata extraction"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1665
+#: src/muuli_wdr.cpp:1669
 msgid "Extract length / bitrate / codec from shared audio and video files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1667
+#: src/muuli_wdr.cpp:1671
 msgid "When enabled, aMule runs ffprobe on each shared media file to fill in the Length / Bitrate / Codec columns other clients see when they find the file in a search. Requires ffmpeg (the ffprobe binary) to be installed."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1674
+#: src/muuli_wdr.cpp:1678
 msgid "Path to ffprobe:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1679
+#: src/muuli_wdr.cpp:1683
 msgid "Full path to the ffprobe binary. Leave empty to have aMule auto-detect it on startup."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1687
+#: src/muuli_wdr.cpp:1691
 msgid "Detect"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1688
+#: src/muuli_wdr.cpp:1692
 msgid "Search the standard install locations for an ffprobe binary and fill the path field."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1712
+#: src/muuli_wdr.cpp:1716
 msgid ""
 "Completed downloads are stored here. All files in this folder are automatically shared with other peers.\n"
 "If this folder also holds files you don't want to share, point it at an aMule-only sub-folder."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1715
+#: src/muuli_wdr.cpp:1719
 msgid "Pick the folder where completed downloads will be stored. All files in that folder will be shared with other peers."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1729
+#: src/muuli_wdr.cpp:1733
 msgid "Shared folders"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1735
+#: src/muuli_wdr.cpp:1739
 msgid "(Folders shared by the core. Enter a path to add one.)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1743
+#: src/muuli_wdr.cpp:1747
 msgid "Absolute path of a folder on the core's machine, e.g. /home/user/shared"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1745 src/PrefsUnifiedDlg.cpp:2794
+#: src/muuli_wdr.cpp:1749 src/PrefsUnifiedDlg.cpp:2874
 msgid "Recursive"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1746
+#: src/muuli_wdr.cpp:1750
 msgid "Share every sub-folder underneath this one, including ones created later."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1750 src/utils/aLinkCreator/src/alcframe.cpp:141
+#: src/muuli_wdr.cpp:1754 src/utils/aLinkCreator/src/alcframe.cpp:141
 msgid "Remove"
 msgstr "Ta bort"
 
-#: src/muuli_wdr.cpp:1754
+#: src/muuli_wdr.cpp:1758
 msgid "(Right click on folder icon for recursive share)"
 msgstr "(Høgreklikk på mappeikonet for å dele underkatalogar)"
 
-#: src/muuli_wdr.cpp:1761
+#: src/muuli_wdr.cpp:1765
 msgid "Share hidden files"
 msgstr "Dele gøymde filer"
 
-#: src/muuli_wdr.cpp:1767
+#: src/muuli_wdr.cpp:1771
 msgid "Automatically rescan shared folders for changes"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1773
+#: src/muuli_wdr.cpp:1777
 msgid "Follow symbolic links in shared folders"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1779
+#: src/muuli_wdr.cpp:1783
 msgid "Exclude files matching:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1782
+#: src/muuli_wdr.cpp:1786
 msgid "Wildcard patterns separated by '|', e.g. .DS_Store|Thumbs.db|*.tmp. Files whose name matches are not shared. Matching is case-insensitive."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1786
+#: src/muuli_wdr.cpp:1790
 msgid "Patterns are regular expressions"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1787
+#: src/muuli_wdr.cpp:1791
 msgid "When set, the whole field is one regular expression ('|' is alternation). When unset, it is a list of '|'-separated wildcards."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1797
+#: src/muuli_wdr.cpp:1801
 msgid "Show how many shared files the current pattern would exclude."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1818
+#: src/muuli_wdr.cpp:1822
 msgid "Graphs"
 msgstr "Grafar"
 
-#: src/muuli_wdr.cpp:1821 src/muuli_wdr.cpp:1883
+#: src/muuli_wdr.cpp:1825 src/muuli_wdr.cpp:1887
 msgid "Update delay : 5 secs"
 msgstr "Oppdateringsforseinking: 5 sek"
 
-#: src/muuli_wdr.cpp:1825
+#: src/muuli_wdr.cpp:1829
 msgid "Time for average graph: 100 mins"
 msgstr "Tid for gjennomsnittleg graf: 100 min"
 
-#: src/muuli_wdr.cpp:1829
+#: src/muuli_wdr.cpp:1833
 msgid "Connections Graph Scale: 100 "
 msgstr "Koplingsgrafskala: 100 "
 
-#: src/muuli_wdr.cpp:1836
+#: src/muuli_wdr.cpp:1840
 msgid "Download graph scale:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1844
+#: src/muuli_wdr.cpp:1848
 msgid "Upload graph scale:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1854
+#: src/muuli_wdr.cpp:1858
 msgid "Colors: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1858
+#: src/muuli_wdr.cpp:1862
 msgid "Background"
 msgstr "Bakgrunn"
 
-#: src/muuli_wdr.cpp:1859
+#: src/muuli_wdr.cpp:1863
 msgid "Grid"
 msgstr "Rutenett"
 
-#: src/muuli_wdr.cpp:1860
+#: src/muuli_wdr.cpp:1864
 msgid "Download current"
 msgstr "Last ned novérande"
 
-#: src/muuli_wdr.cpp:1861
+#: src/muuli_wdr.cpp:1865
 msgid "Download running average"
 msgstr "Last ned køyregjennomsnitt"
 
-#: src/muuli_wdr.cpp:1862
+#: src/muuli_wdr.cpp:1866
 msgid "Download session average"
 msgstr "Last ned øktgjennomsnitt"
 
-#: src/muuli_wdr.cpp:1863
+#: src/muuli_wdr.cpp:1867
 msgid "Upload current"
 msgstr "Opplasting no"
 
-#: src/muuli_wdr.cpp:1864
+#: src/muuli_wdr.cpp:1868
 msgid "Upload running average"
 msgstr "Gjennomsnittleg køyrande opplasting"
 
-#: src/muuli_wdr.cpp:1865
+#: src/muuli_wdr.cpp:1869
 msgid "Upload session average"
 msgstr "Gjennomsnittleg økt opplasting"
 
-#: src/muuli_wdr.cpp:1866
+#: src/muuli_wdr.cpp:1870
 msgid "Active connections"
 msgstr "Aktive koplingar"
 
-#: src/muuli_wdr.cpp:1869
+#: src/muuli_wdr.cpp:1873
 #, fuzzy
 msgid "Systray Icon Speed Bar"
 msgstr "Fartslinje i ikontrauet"
 
-#: src/muuli_wdr.cpp:1870
+#: src/muuli_wdr.cpp:1874
 msgid "Kad-nodes current"
 msgstr "Kadnodar no"
 
-#: src/muuli_wdr.cpp:1871
+#: src/muuli_wdr.cpp:1875
 msgid "Kad-nodes running"
 msgstr "Køyrande kadnodar"
 
-#: src/muuli_wdr.cpp:1872
+#: src/muuli_wdr.cpp:1876
 msgid "Kad-nodes session"
 msgstr "Kadnodar (økt)"
 
-#: src/muuli_wdr.cpp:1876 src/muuli_wdr.cpp:2303
+#: src/muuli_wdr.cpp:1880 src/muuli_wdr.cpp:2334
 msgid "Select"
 msgstr "Velje"
 
-#: src/muuli_wdr.cpp:1880
+#: src/muuli_wdr.cpp:1884
 msgid "Tree"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1890
+#: src/muuli_wdr.cpp:1894
 msgid "Number of Client Versions shown (0=unlimited)"
 msgstr "Tal på klienutgåver synt (0=uinnskrenka)"
 
-#: src/muuli_wdr.cpp:1915
+#: src/muuli_wdr.cpp:1919
 msgid "!!! WARNING !!!"
 msgstr "!!! ÅTVARING !!!"
 
-#: src/muuli_wdr.cpp:1930
+#: src/muuli_wdr.cpp:1934
 msgid "Max new connections / 5 secs"
 msgstr "Maks nye koplingar / 5 sek"
 
-#: src/muuli_wdr.cpp:1932
+#: src/muuli_wdr.cpp:1936
 msgid "Concurrent Kad source lookups"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1934
+#: src/muuli_wdr.cpp:1938
 #, fuzzy
 msgid "Kad source re-search interval (minutes)"
 msgstr "FTP oppdateringsintervall i minutt"
 
-#: src/muuli_wdr.cpp:1936
+#: src/muuli_wdr.cpp:1940
 #, fuzzy
 msgid "Source re-ask interval (minutes)"
 msgstr "FTP oppdateringsintervall i minutt"
 
-#: src/muuli_wdr.cpp:1940
+#: src/muuli_wdr.cpp:1944
 msgid "File Buffer Size: 240000 bytes"
 msgstr "Filbufferstorleik: 240000·bytes"
 
-#: src/muuli_wdr.cpp:1944
+#: src/muuli_wdr.cpp:1948
 msgid "Use MMAP: memory-mapped file access (lower memory use)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1945
+#: src/muuli_wdr.cpp:1949
 msgid "Maps part files into memory instead of buffering them on the heap, lowering the process memory footprint. May reduce download speed on some disks; best for memory-constrained or upload-heavy hosts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1947
+#: src/muuli_wdr.cpp:1951
 msgid "Upload Queue Size: 5000 clients"
 msgstr "Storleik på opplastingskø: 5000 klientar"
 
-#: src/muuli_wdr.cpp:1951
+#: src/muuli_wdr.cpp:1955
 msgid "Server connection refresh interval: Disable"
 msgstr "Oppfriskingsintervall for tenarkopling: Deaktiver"
 
-#: src/muuli_wdr.cpp:1955
+#: src/muuli_wdr.cpp:1959
 msgid "Disable computer's timed standby mode"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1974
+#: src/muuli_wdr.cpp:1978
 msgid "Skin to use: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1983
+#: src/muuli_wdr.cpp:1987
 msgid "Show \"Fast eD2k Links Handler\" in every window."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1986
+#: src/muuli_wdr.cpp:1990
 msgid "Show extended info on categories tabs"
 msgstr "Syne utvida informasjon i kategorifaneblad"
 
-#: src/muuli_wdr.cpp:1989
+#: src/muuli_wdr.cpp:1993
 #, fuzzy
 msgid "Show application version on title"
 msgstr "Syne overføringsfart i tittellinja"
 
-#: src/muuli_wdr.cpp:1991
+#: src/muuli_wdr.cpp:1995
 msgid "Show transfer rates on title"
 msgstr "Syne overføringsfart i tittellinja"
 
-#: src/muuli_wdr.cpp:1993
+#: src/muuli_wdr.cpp:1997
 msgid "Before application name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1995
+#: src/muuli_wdr.cpp:1999
 msgid "After application name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1998
+#: src/muuli_wdr.cpp:2002
 msgid "Show overhead bandwidth"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2002
+#: src/muuli_wdr.cpp:2006
 msgid "Vertical toolbar orientation"
 msgstr "Vertikal verktylinjeorientering"
 
-#: src/muuli_wdr.cpp:2004
+#: src/muuli_wdr.cpp:2008
 msgid "Live column sorting (auto-reorder rows as their values change)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2011
+#: src/muuli_wdr.cpp:2015
 msgid "Download Queue Files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2014
+#: src/muuli_wdr.cpp:2018
 msgid "Show progress percentage"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2020
+#: src/muuli_wdr.cpp:2024
 msgid "Show progress bar"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2023
+#: src/muuli_wdr.cpp:2027
 msgid "Flat"
 msgstr "Flat"
 
-#: src/muuli_wdr.cpp:2027
+#: src/muuli_wdr.cpp:2031
 msgid "Round"
 msgstr "Rund"
 
-#: src/muuli_wdr.cpp:2045
+#: src/muuli_wdr.cpp:2049
 msgid "External Connection Parameters"
 msgstr "Parameter for ekstern kopling"
 
-#: src/muuli_wdr.cpp:2048
+#: src/muuli_wdr.cpp:2052
 msgid "Accept external connections"
 msgstr "Akseptér eksterne koplingar"
 
-#: src/muuli_wdr.cpp:2055 src/muuli_wdr.cpp:2114
+#: src/muuli_wdr.cpp:2059 src/muuli_wdr.cpp:2118
 msgid "IP of the listening interface:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2058
+#: src/muuli_wdr.cpp:2062
 msgid "Enter here a valid ip in the a.b.c.d format for the listening EC interface. An empty field or 0.0.0.0 will mean any interface."
 msgstr "Skriv in ei gyldig IP i a.b.c.d format for det lyttande EC-grensesnittet. Eit tomt felt eller 0.0.0.0 betyr samtlege grensesnitt."
 
-#: src/muuli_wdr.cpp:2079 src/muuli_wdr.cpp:2163
+#: src/muuli_wdr.cpp:2083 src/muuli_wdr.cpp:2194
 msgid "TCP port:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2085
+#: src/muuli_wdr.cpp:2089
 msgid "Enable UPnP port forwarding on the EC port"
 msgstr "Aktivér UPnP-portvidaresending på EC-porten"
 
-#: src/muuli_wdr.cpp:2089 src/muuli_wdr.cpp:3048
+#: src/muuli_wdr.cpp:2093 src/muuli_wdr.cpp:3079
 #: src/utils/wxCas/src/wxcasprefs.cpp:167
 msgid "Password"
 msgstr "Passord"
 
-#: src/muuli_wdr.cpp:2095
+#: src/muuli_wdr.cpp:2099
 #, fuzzy
 msgid "aMule API server parameters"
 msgstr "Vevtenarparameter"
 
-#: src/muuli_wdr.cpp:2098
+#: src/muuli_wdr.cpp:2102
 msgid "Run amuleapi (REST API) on startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2103
+#: src/muuli_wdr.cpp:2107
 #, fuzzy
 msgid "HTTP port:"
 msgstr "TCP port: %d"
 
-#: src/muuli_wdr.cpp:2117
+#: src/muuli_wdr.cpp:2121
 msgid "The interface amuleapi's HTTP server listens on. 127.0.0.1 (default) accepts only local connections; use 0.0.0.0 or a specific IP to expose it to other hosts (set an admin password below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2120
+#: src/muuli_wdr.cpp:2126
+msgid "Type a password to set or change it. Stored passwords cannot be shown, so leaving this empty keeps the current one."
+msgstr ""
+
+#: src/muuli_wdr.cpp:2128
 #, fuzzy
 msgid "Admin password"
 msgstr "Sjekkar passord\n"
 
-#: src/muuli_wdr.cpp:2125 src/muuli_wdr.cpp:2156
-msgid "Low rights password"
-msgstr "Passord for låge rettar"
+#: src/muuli_wdr.cpp:2140 src/muuli_wdr.cpp:2157 src/PrefsUnifiedDlg.cpp:1103
+#, fuzzy
+msgid "A password is set."
+msgstr "Sjekkar passord\n"
 
-#: src/muuli_wdr.cpp:2133
+#: src/muuli_wdr.cpp:2144
+#, fuzzy
+msgid "Enable guest access"
+msgstr "Nekt gjestetilgang"
+
+#: src/muuli_wdr.cpp:2145
+msgid "Guest sessions may read status and listings but cannot change anything. Turning this off clears the stored guest password."
+msgstr ""
+
+#: src/muuli_wdr.cpp:2149
+#, fuzzy
+msgid "Guest password"
+msgstr "Gjestepassord for vevtenar"
+
+#: src/muuli_wdr.cpp:2164
 msgid "Web server parameters"
 msgstr "Vevtenarparameter"
 
-#: src/muuli_wdr.cpp:2136
+#: src/muuli_wdr.cpp:2167
 msgid "Run webserver on startup (deprecated)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2142
+#: src/muuli_wdr.cpp:2173
 msgid "Web template"
 msgstr "Vevmønster"
 
-#: src/muuli_wdr.cpp:2147
+#: src/muuli_wdr.cpp:2178
 msgid "Full rights password"
 msgstr "Passord for fulle rettar"
 
-#: src/muuli_wdr.cpp:2151
+#: src/muuli_wdr.cpp:2182
 msgid "Enable Low rights User"
 msgstr "Aktivér brukar med få rettar"
 
-#: src/muuli_wdr.cpp:2170
+#: src/muuli_wdr.cpp:2187
+msgid "Low rights password"
+msgstr "Passord for låge rettar"
+
+#: src/muuli_wdr.cpp:2201
 msgid "Enable UPnP port forwarding of the web server port"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2175
+#: src/muuli_wdr.cpp:2206
 msgid "Web server UPnP TCP port (Optional)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2183
+#: src/muuli_wdr.cpp:2214
 msgid "Page Refresh Time (in secs)"
 msgstr "Sideoppfriskingstid (i sekund)"
 
-#: src/muuli_wdr.cpp:2190
+#: src/muuli_wdr.cpp:2221
 msgid "Enable Gzip compression"
 msgstr "Aktivér Gzipkompresjon"
 
-#: src/muuli_wdr.cpp:2224
+#: src/muuli_wdr.cpp:2255
 #, fuzzy
 msgid "Reset page to defaults"
 msgstr "Standardinnstillingar"
 
-#: src/muuli_wdr.cpp:2225
+#: src/muuli_wdr.cpp:2256
 msgid "Reset the settings on the current page to their default values."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2227 src/muuli_wdr.cpp:2313 src/ServerWnd.cpp:274
+#: src/muuli_wdr.cpp:2258 src/muuli_wdr.cpp:2344 src/ServerWnd.cpp:274
 #: src/ServerWnd.cpp:282
 msgid "OK"
 msgstr "OK"
 
-#: src/muuli_wdr.cpp:2229
+#: src/muuli_wdr.cpp:2260
 msgid "Click here to apply any changes made to the preferences."
 msgstr "Klikk her for å utføre samtlege endringar gjorde i innstillingar."
 
-#: src/muuli_wdr.cpp:2232
+#: src/muuli_wdr.cpp:2263
 msgid "Reset any changes made to the preferences."
 msgstr "Nullstill alle endringar i innstillingar."
 
-#: src/muuli_wdr.cpp:2261
+#: src/muuli_wdr.cpp:2292
 msgid "Comment :"
 msgstr "Kommentar :"
 
-#: src/muuli_wdr.cpp:2268
+#: src/muuli_wdr.cpp:2299
 msgid "Incoming Dir :"
 msgstr "Innkomande kat:"
 
-#: src/muuli_wdr.cpp:2277
+#: src/muuli_wdr.cpp:2308
 msgid "Change priority for new assigned files :"
 msgstr "Endre prioritet for nytileigna filer :"
 
-#: src/muuli_wdr.cpp:2281
+#: src/muuli_wdr.cpp:2312
 #, fuzzy
 msgid "Don't change"
 msgstr "Ikkje endre"
 
-#: src/muuli_wdr.cpp:2293
+#: src/muuli_wdr.cpp:2324
 msgid "Select color for this Category (currently selected) :"
 msgstr "Vel farge for denne kategprien (no valt)"
 
-#: src/muuli_wdr.cpp:2360 src/muuli_wdr.cpp:2379 src/muuli_wdr.cpp:2401
+#: src/muuli_wdr.cpp:2391 src/muuli_wdr.cpp:2410 src/muuli_wdr.cpp:2432
 msgid "Click this button to reset the log."
 msgstr "Klikk denne knappen for å nullstille loggen."
 
-#: src/muuli_wdr.cpp:2420
+#: src/muuli_wdr.cpp:2451
 msgid "Click on this button to update the servers list from URL ..."
 msgstr "Klikk på denne knappen for å oppdatere tenarlista frå nettadresse ..."
 
-#: src/muuli_wdr.cpp:2424
+#: src/muuli_wdr.cpp:2455
 msgid "Server list"
 msgstr "Tenarliste"
 
-#: src/muuli_wdr.cpp:2428
+#: src/muuli_wdr.cpp:2459
 msgid "Enter the url to a server.met file here and press the button to the left to update the list of known servers."
 msgstr "Skriv inn nettadressa til ei server.met fil her og klikk på knappen til venstre for å oppdatere tenarlista."
 
-#: src/muuli_wdr.cpp:2433
+#: src/muuli_wdr.cpp:2464
 msgid "Add server manually: Name"
 msgstr "Legg til tenar manuelt: Namn"
 
-#: src/muuli_wdr.cpp:2436
+#: src/muuli_wdr.cpp:2467
 msgid "Enter the name of the new server here"
 msgstr "Skriv inn namnet på den nye tenaren her"
 
-#: src/muuli_wdr.cpp:2438 src/ServerWnd.cpp:206
+#: src/muuli_wdr.cpp:2469 src/ServerWnd.cpp:206
 msgid "IP:Port"
 msgstr "IP:Port"
 
-#: src/muuli_wdr.cpp:2441
+#: src/muuli_wdr.cpp:2472
 msgid "Enter the IP of the server here, using the x.x.x.x format."
 msgstr "Skriv inn IP`en til tenaren her, i x.x.x.x format."
 
-#: src/muuli_wdr.cpp:2447
+#: src/muuli_wdr.cpp:2478
 msgid "Enter the port of the server here."
 msgstr "Skriv inn porten til tenaren her."
 
-#: src/muuli_wdr.cpp:2450
+#: src/muuli_wdr.cpp:2481
 msgid "Add manually a server (fill fields to the left before) ..."
 msgstr "Legg til ein tenar manuelt (fyll først ut felta til venstre) ..."
 
-#: src/muuli_wdr.cpp:2479
+#: src/muuli_wdr.cpp:2510
 msgid "aMule Log"
 msgstr "aMulelogg"
 
-#: src/muuli_wdr.cpp:2487
+#: src/muuli_wdr.cpp:2518
 msgid "Server Info"
 msgstr "Tenarinfo"
 
-#: src/muuli_wdr.cpp:2491
+#: src/muuli_wdr.cpp:2522
 msgid "ED2K Info"
 msgstr "ED2k-info"
 
-#: src/muuli_wdr.cpp:2495
+#: src/muuli_wdr.cpp:2526
 msgid "Kad Info"
 msgstr "Kad-info"
 
-#: src/muuli_wdr.cpp:2523
+#: src/muuli_wdr.cpp:2554
 msgid "Click on this button to update the nodes list from URL ..."
 msgstr "Klikk på denne knappen for å oppdatere nodelista frå internettadresse ..."
 
-#: src/muuli_wdr.cpp:2527
+#: src/muuli_wdr.cpp:2558
 msgid "Nodes (0)"
 msgstr "Nodar (0)"
 
-#: src/muuli_wdr.cpp:2531
+#: src/muuli_wdr.cpp:2562
 msgid "Enter the url to a nodes.dat file here and press the button to the left to update the list of known nodes."
 msgstr "Skriv inn internettadressa til ei nodes-dat fil her og klikk på knappen til venstre for å oppdatere lista over kjende nodar."
 
-#: src/muuli_wdr.cpp:2534
+#: src/muuli_wdr.cpp:2565
 msgid "Nodes stats"
 msgstr "Nodestatistikk"
 
-#: src/muuli_wdr.cpp:2576
+#: src/muuli_wdr.cpp:2607
 msgid "Bootstrap"
 msgstr "Eigenoppstart"
 
-#: src/muuli_wdr.cpp:2579
+#: src/muuli_wdr.cpp:2610
 msgid "New node"
 msgstr "Ny node"
 
-#: src/muuli_wdr.cpp:2584
+#: src/muuli_wdr.cpp:2615
 msgid "IP:"
 msgstr "IP:"
 
-#: src/muuli_wdr.cpp:2604
+#: src/muuli_wdr.cpp:2635
 msgid "Port:"
 msgstr "Port:"
 
-#: src/muuli_wdr.cpp:2617
+#: src/muuli_wdr.cpp:2648
 #, fuzzy
 msgid "Bootstrap from known clients"
 msgstr ""
 "Eigenoppstart frå \n"
 "kjende klientar"
 
-#: src/muuli_wdr.cpp:2619
+#: src/muuli_wdr.cpp:2650
 msgid "Disconnect Kad"
 msgstr "Kople frå Kad"
 
-#: src/muuli_wdr.cpp:2653
+#: src/muuli_wdr.cpp:2684
 msgid "Use Secure User Identification"
 msgstr "Sikker brukaridentifikasjon (SUI)"
 
-#: src/muuli_wdr.cpp:2655
+#: src/muuli_wdr.cpp:2686
 msgid "It is recommended to enable this option. You will not receive credits if SUI is not enabled."
 msgstr "Det er tilrådd å aktivere denne funksjonen. Du vil ikkje få kredittar dersom SUI ikkje er aktivert."
 
-#: src/muuli_wdr.cpp:2657
+#: src/muuli_wdr.cpp:2688
 msgid "Protocol Obfuscation"
 msgstr "Protokolltåkeleggjing"
 
-#: src/muuli_wdr.cpp:2660
+#: src/muuli_wdr.cpp:2691
 msgid "Support Protocol Obfuscation"
 msgstr "Støtte protokolltåkeleggjing"
 
-#: src/muuli_wdr.cpp:2662
+#: src/muuli_wdr.cpp:2693
 msgid "This option enabled Protocol Obfuscation, and makes aMule accept obfuscated connections from other clients."
 msgstr "Dette valet aktiverer protokolltåkeleggjing og gjer at aMule tek imot tåkelagde koplingar frå andre klientar."
 
-#: src/muuli_wdr.cpp:2664
+#: src/muuli_wdr.cpp:2695
 msgid "Use obfuscation for outgoing connections"
 msgstr "Bruk tåkeleggjing for utgåande koplingar"
 
-#: src/muuli_wdr.cpp:2666
+#: src/muuli_wdr.cpp:2697
 msgid "This option makes aMule use Protocol Obfuscation when connecting other clients/servers."
 msgstr "Dette valet får aMule til å nytte protokolltåkeleggjing ved tilkopling til andreklientar/tenarar."
 
-#: src/muuli_wdr.cpp:2668
+#: src/muuli_wdr.cpp:2699
 msgid "Accept only obfuscated connections"
 msgstr "Berre godta tåkelagde koplingar"
 
-#: src/muuli_wdr.cpp:2669
+#: src/muuli_wdr.cpp:2700
 msgid "This option makes aMule only accept obfuscated connections. You will have less sources, but all your traffic will be obfuscated"
 msgstr "Dette valet får aMule til å berre godta tåkelagde koplingar. Du vil få færre kjelder, men all trafikken din vert tåkelagd"
 
-#: src/muuli_wdr.cpp:2674
+#: src/muuli_wdr.cpp:2705
 msgid "Everybody"
 msgstr "Alle"
 
-#: src/muuli_wdr.cpp:2676
+#: src/muuli_wdr.cpp:2707
 msgid "No one"
 msgstr "Ingen"
 
-#: src/muuli_wdr.cpp:2678
+#: src/muuli_wdr.cpp:2709
 msgid "Who can see my shared files:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2679
+#: src/muuli_wdr.cpp:2710
 msgid "Select who can request to view a list of your shared files."
 msgstr "Vel kven som kan be om å sjå ei liste over dei delte filene dine."
 
-#: src/muuli_wdr.cpp:2681
+#: src/muuli_wdr.cpp:2712
 msgid "IP-Filtering"
 msgstr "IP-filtrering"
 
-#: src/muuli_wdr.cpp:2688
+#: src/muuli_wdr.cpp:2719
 msgid "Filter clients"
 msgstr "Filtrér klientar"
 
-#: src/muuli_wdr.cpp:2690
+#: src/muuli_wdr.cpp:2721
 msgid "Enable filtering of the client IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "Aktivér IP-filterring av klientar i fila ~/.aMule/ipfilter.dat."
 
-#: src/muuli_wdr.cpp:2692
+#: src/muuli_wdr.cpp:2723
 msgid "Filter servers"
 msgstr "Filtrér tenarar"
 
-#: src/muuli_wdr.cpp:2694
+#: src/muuli_wdr.cpp:2725
 msgid "Enable filtering of the server IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "Aktivér filtrering av tenarar i fila ~/.aMule/ipfilter.dat."
 
-#: src/muuli_wdr.cpp:2698
+#: src/muuli_wdr.cpp:2729
 msgid "Reload List"
 msgstr "Last om att lista"
 
-#: src/muuli_wdr.cpp:2699
+#: src/muuli_wdr.cpp:2730
 msgid "Reload the list of IPs to filter from the file ~/.aMule/ipfilter.dat"
 msgstr "Last om att lista av IP`ar å filtre frå fila ~/.aMule/ipfilter.dat"
 
-#: src/muuli_wdr.cpp:2705
+#: src/muuli_wdr.cpp:2736
 msgid "URL:"
 msgstr "Nettadresse:"
 
-#: src/muuli_wdr.cpp:2709 src/muuli_wdr.cpp:2902
+#: src/muuli_wdr.cpp:2740 src/muuli_wdr.cpp:2933
 msgid "Update now"
 msgstr "Oppdatér no"
 
-#: src/muuli_wdr.cpp:2712
+#: src/muuli_wdr.cpp:2743
 msgid "Auto-update ipfilter at startup"
 msgstr "Automatisk oppdatér ipfilter ved oppstart"
 
-#: src/muuli_wdr.cpp:2716
+#: src/muuli_wdr.cpp:2747
 msgid "Filtering Level:"
 msgstr "Filternivå:"
 
-#: src/muuli_wdr.cpp:2722
+#: src/muuli_wdr.cpp:2753
 msgid "Always filter LAN IPs"
 msgstr "Alltid filtrér LAN IP`ar"
 
-#: src/muuli_wdr.cpp:2725
+#: src/muuli_wdr.cpp:2756
 msgid "Paranoid handling of non-matching IPs"
 msgstr "Paranoid handsaming av ujamne IP`ar"
 
-#: src/muuli_wdr.cpp:2727
+#: src/muuli_wdr.cpp:2758
 msgid "Rejects a packet when its source IP differs from the IP the client claims (an anti-spoofing check). Disable only if it causes connection problems."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2729
+#: src/muuli_wdr.cpp:2760
 msgid "Use system-wide ipfilter.dat if available"
 msgstr "Bruk systemomspennande ipfilter.dat dersom tilgjengeleg"
 
-#: src/muuli_wdr.cpp:2730
+#: src/muuli_wdr.cpp:2761
 #, fuzzy
 msgid "If there's no local ipfilter.dat found, allow usage of a system-wide ipfilter file."
 msgstr "Tillat bruk av ipfilter for heile systemet dersom inga lokal ipfilter-dat vert funnen"
 
-#: src/muuli_wdr.cpp:2747
+#: src/muuli_wdr.cpp:2778
 msgid "Enable Online-Signature"
 msgstr "Aktivér nettsignatur"
 
-#: src/muuli_wdr.cpp:2749
+#: src/muuli_wdr.cpp:2780
 msgid "Enables the writing of the OS file, which can be used by external apps to create signatures and the like."
 msgstr "Aktiverer skriving av OS-fila, som kan verte nytta av eksterne program forå lage signaturar og liknande."
 
-#: src/muuli_wdr.cpp:2753
+#: src/muuli_wdr.cpp:2784
 msgid "Update Frequency (Secs):"
 msgstr "Oppdateringsfrekvens (sekund):"
 
-#: src/muuli_wdr.cpp:2756
+#: src/muuli_wdr.cpp:2787
 msgid "Change the frequency (in seconds) of Online Signature updates."
 msgstr "Endre frekvensen (i sekund) for oppdatering av nettsignaturar."
 
-#: src/muuli_wdr.cpp:2764
+#: src/muuli_wdr.cpp:2795
 msgid "Save online signature file in: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:2770
+#: src/muuli_wdr.cpp:2801
 msgid "Click here to select the directory containing the the Online Signature files."
 msgstr "Klikk her for å velje katalogen med nettsignaturfilene."
 
-#: src/muuli_wdr.cpp:2803
+#: src/muuli_wdr.cpp:2834
 msgid "Show country flags for clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2804
+#: src/muuli_wdr.cpp:2835
 msgid "Render the country flag column in the transfers, queue and search views. Requires a valid MMDB GeoIP database (see below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2809
+#: src/muuli_wdr.cpp:2840
 #, fuzzy
 msgid "Database"
 msgstr "Datasnøggleik :"
 
-#: src/muuli_wdr.cpp:2825
+#: src/muuli_wdr.cpp:2856
 #, fuzzy
 msgid "Source:"
 msgstr "Kjelder"
 
-#: src/muuli_wdr.cpp:2828
+#: src/muuli_wdr.cpp:2859
 msgid "DB-IP (free, no account)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2829
+#: src/muuli_wdr.cpp:2860
 msgid "MaxMind GeoLite2 (free, account required)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2830
+#: src/muuli_wdr.cpp:2861
 msgid "Custom URL"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2833
+#: src/muuli_wdr.cpp:2864
 msgid "Choose which provider supplies the GeoIP MMDB database. DB-IP is the default - no account required. MaxMind requires a free account + license key. Use Custom URL to point at any other MMDB host (e.g. a local mirror)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2850
+#: src/muuli_wdr.cpp:2881
 msgid ""
 "No configuration required.\n"
 "\n"
@@ -4872,11 +4900,11 @@ msgid ""
 "License: Creative Commons BY 4.0 - https://creativecommons.org/licenses/by/4.0/"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2863
+#: src/muuli_wdr.cpp:2894
 msgid "License key:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2869
+#: src/muuli_wdr.cpp:2900
 msgid ""
 "Sign up for a free MaxMind account, then generate a License Key:\n"
 "https://www.maxmind.com/en/geolite2/signup\n"
@@ -4886,232 +4914,232 @@ msgid ""
 "Requires attribution and account registration; refresh at least every 30 days."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2884
+#: src/muuli_wdr.cpp:2915
 #, fuzzy
 msgid "Download URL:"
 msgstr "Nedlasting: "
 
-#: src/muuli_wdr.cpp:2890
+#: src/muuli_wdr.cpp:2921
 msgid ""
 "Must point to an .mmdb file or a .gz / .tar.gz containing one.\n"
 "URL may include credentials (https://user:pass@host/...).\n"
 "License and attribution terms are set by the upstream URL - you are responsible."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2903
+#: src/muuli_wdr.cpp:2934
 msgid "Download the GeoIP database from the selected source."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2905
+#: src/muuli_wdr.cpp:2936
 #, fuzzy
 msgid "Auto-update on startup"
 msgstr "Automatisk oppdatér ipfilter ved oppstart"
 
-#: src/muuli_wdr.cpp:2906
+#: src/muuli_wdr.cpp:2937
 msgid "Re-download the GeoIP database from the selected source every time aMule starts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2929
+#: src/muuli_wdr.cpp:2960
 msgid "Filter incoming messages (except current chat):"
 msgstr "Filtrér innkomande meldingar (utanom novérande samtale):"
 
-#: src/muuli_wdr.cpp:2931
+#: src/muuli_wdr.cpp:2962
 msgid "Filter all messages"
 msgstr "Filtrér alle meldingar"
 
-#: src/muuli_wdr.cpp:2933
+#: src/muuli_wdr.cpp:2964
 msgid "Filter messages from people not on your friend list"
 msgstr "Filtrér meldingar frå alle som ikkje er på kameratlista"
 
-#: src/muuli_wdr.cpp:2935
+#: src/muuli_wdr.cpp:2966
 msgid "Filter messages from unknown clients"
 msgstr "Filtrér meldingar frå ukjende klientar"
 
-#: src/muuli_wdr.cpp:2937
+#: src/muuli_wdr.cpp:2968
 msgid "Filter messages containing (use ',' as separator):"
 msgstr "Filtrér meldingar som inneheld (bruk ','som skiljeteikn):"
 
-#: src/muuli_wdr.cpp:2940 src/muuli_wdr.cpp:2951
+#: src/muuli_wdr.cpp:2971 src/muuli_wdr.cpp:2982
 msgid "add here the words amule should filter and block messages including it"
 msgstr "legg til ord aMule skal filtrére og blokkere"
 
-#: src/muuli_wdr.cpp:2942
+#: src/muuli_wdr.cpp:2973
 msgid "Show received messages in the log"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2945
+#: src/muuli_wdr.cpp:2976
 msgid "Comments"
 msgstr "Kommentarar"
 
-#: src/muuli_wdr.cpp:2948
+#: src/muuli_wdr.cpp:2979
 msgid "Filter comments containing (use ',' as separator):"
 msgstr "Filtrér kommentarar som inneheld (bruk ',' som skiljeteikn):"
 
-#: src/muuli_wdr.cpp:2973
+#: src/muuli_wdr.cpp:3004
 msgid "Enable Proxy"
 msgstr "Aktivér vikar"
 
-#: src/muuli_wdr.cpp:2974
+#: src/muuli_wdr.cpp:3005
 msgid "Enable/disable proxy support"
 msgstr "Aktivere/deaktivere vikarstøtte"
 
-#: src/muuli_wdr.cpp:2977
+#: src/muuli_wdr.cpp:3008
 msgid "Proxy type:"
 msgstr "Vikartype:"
 
-#: src/muuli_wdr.cpp:2988
+#: src/muuli_wdr.cpp:3019
 msgid "Proxy host:"
 msgstr "Vikarvert:"
 
-#: src/muuli_wdr.cpp:2991
+#: src/muuli_wdr.cpp:3022
 msgid "The proxy host name"
 msgstr "Vikaren sitt vertsnamn"
 
-#: src/muuli_wdr.cpp:2993
+#: src/muuli_wdr.cpp:3024
 msgid "Proxy port:"
 msgstr "Vikarport:"
 
-#: src/muuli_wdr.cpp:2996
+#: src/muuli_wdr.cpp:3027
 msgid "The proxy port"
 msgstr "Vikarport"
 
-#: src/muuli_wdr.cpp:2998
+#: src/muuli_wdr.cpp:3029
 msgid "Enable authentication"
 msgstr "Aktivér godkjenning"
 
-#: src/muuli_wdr.cpp:2999
+#: src/muuli_wdr.cpp:3030
 msgid "Enable/disable username/password authentication"
 msgstr "Aktivér/deaktivér godkjenning av brukarnamn/passord"
 
-#: src/muuli_wdr.cpp:3002
+#: src/muuli_wdr.cpp:3033
 msgid "Username: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:3005
+#: src/muuli_wdr.cpp:3036
 msgid "The username to use to connect to the proxy"
 msgstr "Brukarnamn å nytte for å kople til vikar"
 
-#: src/muuli_wdr.cpp:3007
+#: src/muuli_wdr.cpp:3038
 msgid "Password:"
 msgstr "Passord:"
 
-#: src/muuli_wdr.cpp:3010
+#: src/muuli_wdr.cpp:3041
 msgid "The password to use to connect to the proxy"
 msgstr "Passord å nytte for å kople til vikar"
 
-#: src/muuli_wdr.cpp:3029
+#: src/muuli_wdr.cpp:3060
 msgid "Connect to:"
 msgstr "Kople til:"
 
-#: src/muuli_wdr.cpp:3038
+#: src/muuli_wdr.cpp:3069
 msgid "Login to remote amule"
 msgstr "Logge inn på fjern aMule"
 
-#: src/muuli_wdr.cpp:3043
+#: src/muuli_wdr.cpp:3074
 msgid "User name"
 msgstr "Brukarnamn"
 
-#: src/muuli_wdr.cpp:3054
+#: src/muuli_wdr.cpp:3085
 msgid "Remember those settings"
 msgstr "Hugs desse innstillingane"
 
-#: src/muuli_wdr.cpp:3057
+#: src/muuli_wdr.cpp:3088
 #, fuzzy
 msgid "Force ZLIB compression"
 msgstr "Nytt gzipkomprimering"
 
-#: src/muuli_wdr.cpp:3081
+#: src/muuli_wdr.cpp:3112
 msgid "Enable Verbose Debug-Logging."
 msgstr "Aktivér utførleg avfeilingslogg."
 
-#: src/muuli_wdr.cpp:3083
+#: src/muuli_wdr.cpp:3114
 #, fuzzy
 msgid "Only to Logfile"
 msgstr "&Opne fila"
 
-#: src/muuli_wdr.cpp:3085
+#: src/muuli_wdr.cpp:3116
 msgid "Message Categories:"
 msgstr "Meldingskategoriar:"
 
-#: src/muuli_wdr.cpp:3109 src/PartFileConvertDlg.cpp:160
+#: src/muuli_wdr.cpp:3140 src/PartFileConvertDlg.cpp:160
 msgid "Waiting..."
 msgstr "Ventar..."
 
-#: src/muuli_wdr.cpp:3129
+#: src/muuli_wdr.cpp:3160
 msgid "Add imports"
 msgstr "Importér"
 
-#: src/muuli_wdr.cpp:3132
+#: src/muuli_wdr.cpp:3163
 msgid "Retry selected"
 msgstr "Prøv om att valde"
 
-#: src/muuli_wdr.cpp:3134
+#: src/muuli_wdr.cpp:3165
 msgid "Remove selected"
 msgstr "Fjern valde"
 
-#: src/muuli_wdr.cpp:3197
+#: src/muuli_wdr.cpp:3228
 msgid "Event Types"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3216
+#: src/muuli_wdr.cpp:3247
 msgid "Statistics and queued clients for selected file(s) : Session / All time"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3240
+#: src/muuli_wdr.cpp:3271
 #, fuzzy
 msgid "Active Uploads"
 msgstr "Aktive opplastingar :"
 
-#: src/muuli_wdr.cpp:3254
+#: src/muuli_wdr.cpp:3285
 msgid "Percent of total files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3306
+#: src/muuli_wdr.cpp:3337
 #, fuzzy
 msgid "Show Clients for"
 msgstr "Syne klientar"
 
-#: src/muuli_wdr.cpp:3308
+#: src/muuli_wdr.cpp:3339
 #, fuzzy
 msgid "All files"
 msgstr "Gøyme delte filer"
 
-#: src/muuli_wdr.cpp:3311
+#: src/muuli_wdr.cpp:3342
 #, fuzzy
 msgid "Selected files"
 msgstr "Vel synsfilter"
 
-#: src/muuli_wdr.cpp:3314
+#: src/muuli_wdr.cpp:3345
 #, fuzzy
 msgid "Active uploads only"
 msgstr "Aktive opplastingar"
 
-#: src/muuli_wdr.cpp:3321
+#: src/muuli_wdr.cpp:3352
 #, fuzzy
 msgid "Reload:"
 msgstr "Last om att lista"
 
-#: src/muuli_wdr.cpp:3325
+#: src/muuli_wdr.cpp:3356
 msgid "Reload your shared files"
 msgstr "Lastar inn att delte filer"
 
-#: src/muuli_wdr.cpp:3388
+#: src/muuli_wdr.cpp:3419
 msgid "Send"
 msgstr "Send"
 
-#: src/muuli_wdr.cpp:3389
+#: src/muuli_wdr.cpp:3420
 msgid "Sends the specified message."
 msgstr "Sender meldinga."
 
-#: src/muuli_wdr.cpp:3393
+#: src/muuli_wdr.cpp:3424
 msgid "Close this chat-session."
 msgstr "Stengje denne lynmeldingsøkta."
 
-#: src/muuli_wdr.cpp:3416
+#: src/muuli_wdr.cpp:3447
 msgid "Connect to any server and/or Kad"
 msgstr "Kople til vilkårleg tenar og/eller Kad"
 
-#: src/muuli_wdr.cpp:3422 src/SharedFilesCtrl.cpp:142 src/Statistics.cpp:941
+#: src/muuli_wdr.cpp:3453 src/SharedFilesCtrl.cpp:142 src/Statistics.cpp:941
 msgid "Shared Files"
 msgstr "Delte filer"
 
@@ -5472,268 +5500,268 @@ msgstr "Lasta ned"
 msgid "ERROR: Failed to open partfile '%s'"
 msgstr "Feil: Greidde ikkje opne delfila '%s'"
 
-#: src/Preferences.cpp:674
+#: src/Preferences.cpp:701
 msgid "System default"
 msgstr "Standardinnstillingar"
 
-#: src/Preferences.cpp:675
+#: src/Preferences.cpp:702
 msgid "Albanian"
 msgstr "Albansk"
 
-#: src/Preferences.cpp:676
+#: src/Preferences.cpp:703
 msgid "Arabic"
 msgstr "Arabisk"
 
-#: src/Preferences.cpp:677
+#: src/Preferences.cpp:704
 #, fuzzy
 msgid "Asturian"
 msgstr "Estisk"
 
-#: src/Preferences.cpp:678
+#: src/Preferences.cpp:705
 msgid "Basque"
 msgstr "Baskisk"
 
-#: src/Preferences.cpp:679
+#: src/Preferences.cpp:706
 msgid "Bulgarian"
 msgstr "Bulgarsk"
 
-#: src/Preferences.cpp:680
+#: src/Preferences.cpp:707
 msgid "Catalan"
 msgstr "Katalansk"
 
-#: src/Preferences.cpp:681
+#: src/Preferences.cpp:708
 msgid "Chinese (Simplified)"
 msgstr "Kinesisk (forenkla)"
 
-#: src/Preferences.cpp:682
+#: src/Preferences.cpp:709
 msgid "Chinese (Traditional)"
 msgstr "Kinesisk (tradisjonell)"
 
-#: src/Preferences.cpp:683
+#: src/Preferences.cpp:710
 msgid "Croatian"
 msgstr "Kroatisk"
 
-#: src/Preferences.cpp:684
+#: src/Preferences.cpp:711
 msgid "Czech"
 msgstr "Tsjekkisk"
 
-#: src/Preferences.cpp:685
+#: src/Preferences.cpp:712
 msgid "Danish"
 msgstr "Dansk"
 
-#: src/Preferences.cpp:686
+#: src/Preferences.cpp:713
 msgid "Dutch"
 msgstr "Nederlansk"
 
-#: src/Preferences.cpp:687
+#: src/Preferences.cpp:714
 msgid "English (U.K.)"
 msgstr "Engelsk (U.K.)"
 
-#: src/Preferences.cpp:688
+#: src/Preferences.cpp:715
 #, fuzzy
 msgid "English (U.S.)"
 msgstr "Engelsk (U.K.)"
 
-#: src/Preferences.cpp:689
+#: src/Preferences.cpp:716
 msgid "Estonian"
 msgstr "Estisk"
 
-#: src/Preferences.cpp:690
+#: src/Preferences.cpp:717
 msgid "Finnish"
 msgstr "Finsk"
 
-#: src/Preferences.cpp:691
+#: src/Preferences.cpp:718
 msgid "French"
 msgstr "Fransk"
 
-#: src/Preferences.cpp:692
+#: src/Preferences.cpp:719
 msgid "Galician"
 msgstr "Galisisk"
 
-#: src/Preferences.cpp:693
+#: src/Preferences.cpp:720
 msgid "German"
 msgstr "Tysk"
 
-#: src/Preferences.cpp:694
+#: src/Preferences.cpp:721
 msgid "Greek"
 msgstr "Gresk"
 
-#: src/Preferences.cpp:695
+#: src/Preferences.cpp:722
 msgid "Hebrew"
 msgstr "Hebraisk"
 
-#: src/Preferences.cpp:696
+#: src/Preferences.cpp:723
 msgid "Hungarian"
 msgstr "Ungarsk"
 
-#: src/Preferences.cpp:697
+#: src/Preferences.cpp:724
 msgid "Italian"
 msgstr "Italiensk"
 
-#: src/Preferences.cpp:698
+#: src/Preferences.cpp:725
 msgid "Japanese"
 msgstr "Japansk"
 
-#: src/Preferences.cpp:699
+#: src/Preferences.cpp:726
 msgid "Korean"
 msgstr "Koreansk"
 
-#: src/Preferences.cpp:700
+#: src/Preferences.cpp:727
 msgid "Latvian"
 msgstr ""
 
-#: src/Preferences.cpp:701
+#: src/Preferences.cpp:728
 msgid "Lithuanian"
 msgstr "Litauisk"
 
-#: src/Preferences.cpp:702
+#: src/Preferences.cpp:729
 msgid "Norwegian (Nynorsk)"
 msgstr "Norsk (Nynorsk)"
 
-#: src/Preferences.cpp:703
+#: src/Preferences.cpp:730
 msgid "Polish"
 msgstr "Polsk"
 
-#: src/Preferences.cpp:704
+#: src/Preferences.cpp:731
 msgid "Portuguese"
 msgstr "Portugisisk"
 
-#: src/Preferences.cpp:705
+#: src/Preferences.cpp:732
 msgid "Portuguese (Brazilian)"
 msgstr "Portugisisk (Brasil)"
 
-#: src/Preferences.cpp:706
+#: src/Preferences.cpp:733
 #, fuzzy
 msgid "Romanian"
 msgstr "Albansk"
 
-#: src/Preferences.cpp:707
+#: src/Preferences.cpp:734
 msgid "Russian"
 msgstr "Russisk"
 
-#: src/Preferences.cpp:708
+#: src/Preferences.cpp:735
 msgid "Slovenian"
 msgstr "Slovensk"
 
-#: src/Preferences.cpp:709
+#: src/Preferences.cpp:736
 msgid "Spanish"
 msgstr "Spansk"
 
-#: src/Preferences.cpp:710
+#: src/Preferences.cpp:737
 msgid "Swedish"
 msgstr "Svensk"
 
-#: src/Preferences.cpp:711
+#: src/Preferences.cpp:738
 msgid "Turkish"
 msgstr "Tyrkisk"
 
-#: src/Preferences.cpp:712
+#: src/Preferences.cpp:739
 msgid "Ukrainian"
 msgstr ""
 
-#: src/Preferences.cpp:815
+#: src/Preferences.cpp:842
 #, fuzzy
 msgid "Change Language"
 msgstr "Språk"
 
-#: src/Preferences.cpp:879
+#: src/Preferences.cpp:906
 msgid "There are no translations installed for aMule"
 msgstr ""
 
-#: src/Preferences.cpp:880
+#: src/Preferences.cpp:907
 #, fuzzy
 msgid "No languages available"
 msgstr "Ikkje tilgjengeleg"
 
-#: src/Preferences.cpp:1011
+#: src/Preferences.cpp:1038
 msgid "no options available"
 msgstr ""
 
-#: src/Preferences.cpp:2182
+#: src/Preferences.cpp:2227
 msgid "Invalid category found, skipping"
 msgstr ""
 
-#: src/Preferences.cpp:2351
+#: src/Preferences.cpp:2396
 msgid "TCP port can't be higher than 65532 due to server UDP socket being TCP+3"
 msgstr "TCP port kan ikkje vere høgare enn 65532 fordi tenaren si UDPkopling er TCP+3"
 
-#: src/Preferences.cpp:2352
+#: src/Preferences.cpp:2397
 #, c-format
 msgid "Default port will be used (%d)"
 msgstr "Standardport vert nytta (%d)"
 
-#: src/PrefsUnifiedDlg.cpp:298 src/Statistics.cpp:866
+#: src/PrefsUnifiedDlg.cpp:300 src/Statistics.cpp:866
 msgid "Connection"
 msgstr "Kopling"
 
-#: src/PrefsUnifiedDlg.cpp:299 src/SearchListCtrl.cpp:117
+#: src/PrefsUnifiedDlg.cpp:301 src/SearchListCtrl.cpp:117
 msgid "Directories"
 msgstr "Katalogar"
 
-#: src/PrefsUnifiedDlg.cpp:300 src/Statistics.cpp:917
+#: src/PrefsUnifiedDlg.cpp:302 src/Statistics.cpp:917
 msgid "Servers"
 msgstr "Tenarar"
 
-#: src/PrefsUnifiedDlg.cpp:301 src/ServerListCtrl.cpp:96
+#: src/PrefsUnifiedDlg.cpp:303 src/ServerListCtrl.cpp:96
 msgid "Files"
 msgstr "Filer"
 
-#: src/PrefsUnifiedDlg.cpp:302
+#: src/PrefsUnifiedDlg.cpp:304
 msgid "Security"
 msgstr "Tryggleik"
 
-#: src/PrefsUnifiedDlg.cpp:303
+#: src/PrefsUnifiedDlg.cpp:305
 msgid "Interface"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:310
+#: src/PrefsUnifiedDlg.cpp:312
 msgid "IP2Country"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:313
+#: src/PrefsUnifiedDlg.cpp:315
 msgid "Proxy"
 msgstr "Proxy"
 
-#: src/PrefsUnifiedDlg.cpp:314
+#: src/PrefsUnifiedDlg.cpp:316
 msgid "Filters"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:315
+#: src/PrefsUnifiedDlg.cpp:317
 msgid "Remote Controls"
 msgstr "Fjernkontrollar"
 
-#: src/PrefsUnifiedDlg.cpp:316
+#: src/PrefsUnifiedDlg.cpp:318
 msgid "Online Signature"
 msgstr "Nettsignatur"
 
-#: src/PrefsUnifiedDlg.cpp:317
+#: src/PrefsUnifiedDlg.cpp:319
 msgid "Advanced"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:318
+#: src/PrefsUnifiedDlg.cpp:320
 msgid "Events"
 msgstr "Hendingar"
 
-#: src/PrefsUnifiedDlg.cpp:321
+#: src/PrefsUnifiedDlg.cpp:323
 msgid "Debugging"
 msgstr "Melde om feil"
 
-#: src/PrefsUnifiedDlg.cpp:451
+#: src/PrefsUnifiedDlg.cpp:453
 msgid ""
 "The following variables will be substituted:\n"
 "    %PARTFILE - full path to the file\n"
 "    %PARTNAME - file name only"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:472
+#: src/PrefsUnifiedDlg.cpp:474
 msgid "Tray icon support requires libayatana-appindicator3 at compile time."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:488
+#: src/PrefsUnifiedDlg.cpp:490
 msgid "Not available on Wayland: the protocol does not report when a window is minimized, so this option cannot intercept the system minimize button. Workaround: launch aMule with `GDK_BACKEND=x11` to use XWayland instead."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:534
+#: src/PrefsUnifiedDlg.cpp:536
 msgid ""
 "Do not change these setting unless you know\n"
 "what you are doing, otherwise you can easily\n"
@@ -5749,26 +5777,35 @@ msgstr ""
 "aMule køyrer fint utan justering av nokon av\n"
 "desse innstillingane."
 
-#: src/PrefsUnifiedDlg.cpp:645
+#: src/PrefsUnifiedDlg.cpp:647
 #, c-format
 msgid "Failed to connect Cfg to widget with the ID %d and key %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:693
+#: src/PrefsUnifiedDlg.cpp:695
 #, c-format
 msgid "Failed to transfer data from Cfg to Widget with the ID %d and key %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:799
+#: src/PrefsUnifiedDlg.cpp:801
 msgid "The type of proxy you are connecting to"
 msgstr "Typen vikar du koplar til"
 
-#: src/PrefsUnifiedDlg.cpp:1003
+#: src/PrefsUnifiedDlg.cpp:1020
 #, c-format
 msgid "Failed to transfer data from Widget to Cfg with the ID %d and key %s"
 msgstr ""
 
 #: src/PrefsUnifiedDlg.cpp:1103
+#, fuzzy
+msgid "No password set."
+msgstr "Sjekkar passord\n"
+
+#: src/PrefsUnifiedDlg.cpp:1132
+msgid "Guest access needs a password. Type one in the guest password field, or untick Enable guest access."
+msgstr ""
+
+#: src/PrefsUnifiedDlg.cpp:1144
 msgid ""
 "aMule must be restarted to enable these changes:\n"
 "\n"
@@ -5776,51 +5813,51 @@ msgstr ""
 "aMule·treng omstart for å gjere endringane moglege:\n"
 "\n"
 
-#: src/PrefsUnifiedDlg.cpp:1110
+#: src/PrefsUnifiedDlg.cpp:1151
 msgid "- TCP port changed.\n"
 msgstr "-·TCP-porten endra.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1115
+#: src/PrefsUnifiedDlg.cpp:1156
 msgid "- UDP port changed.\n"
 msgstr "-·UDP-porten endra.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1120
+#: src/PrefsUnifiedDlg.cpp:1161
 #, fuzzy
 msgid "- Network interface binding changed.\n"
 msgstr "Ekstern kopling lukka."
 
-#: src/PrefsUnifiedDlg.cpp:1125
+#: src/PrefsUnifiedDlg.cpp:1166
 #, fuzzy
 msgid "- External connect port changed.\n"
 msgstr "Ekstern kopling lukka."
 
-#: src/PrefsUnifiedDlg.cpp:1129
+#: src/PrefsUnifiedDlg.cpp:1170
 #, fuzzy
 msgid "- External connect acceptance changed.\n"
 msgstr "Ny ekstern kopling akseptert"
 
-#: src/PrefsUnifiedDlg.cpp:1133
+#: src/PrefsUnifiedDlg.cpp:1174
 #, fuzzy
 msgid "- External connect interface changed.\n"
 msgstr "Ekstern kopling lukka."
 
-#: src/PrefsUnifiedDlg.cpp:1137
+#: src/PrefsUnifiedDlg.cpp:1178
 #, fuzzy
 msgid "- Protocol obfuscation support changed.\n"
 msgstr "Protokolltåkeleggjing"
 
-#: src/PrefsUnifiedDlg.cpp:1151
+#: src/PrefsUnifiedDlg.cpp:1193
 #, fuzzy
 msgid "- amuleapi settings changed.\n"
 msgstr "- Språk endra.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1160
+#: src/PrefsUnifiedDlg.cpp:1202
 msgid ""
 "Your Auto-update server list is empty.\n"
 "'Auto-update server list at startup' will be disabled."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1171
+#: src/PrefsUnifiedDlg.cpp:1213
 msgid ""
 "You have enabled external connections but have not specified a password.\n"
 "External connections cannot be enabled unless a valid password is specified."
@@ -5828,29 +5865,34 @@ msgstr ""
 "Du har aktivert eksterne koplingar, men har ikkje skrive inn eit passord.\n"
 "Eksterne koplingar kan ikkje aktiverast utan eit gyldig passord."
 
-#: src/PrefsUnifiedDlg.cpp:1202
+#: src/PrefsUnifiedDlg.cpp:1246
+#, c-format
+msgid "The amuleapi password could not be saved: %s"
+msgstr ""
+
+#: src/PrefsUnifiedDlg.cpp:1276
 msgid "- Language changed.\n"
 msgstr "- Språk endra.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1207
+#: src/PrefsUnifiedDlg.cpp:1281
 msgid "- Temp folder changed.\n"
 msgstr "- Mellombels mappe endra.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1212
+#: src/PrefsUnifiedDlg.cpp:1286
 #, fuzzy
 msgid "- ED2K network enabled.\n"
 msgstr "Alle nettverk er deaktiverte."
 
-#: src/PrefsUnifiedDlg.cpp:1245
+#: src/PrefsUnifiedDlg.cpp:1319
 msgid "The shared-file exclusion pattern is not a valid regular expression. The filter has been left disabled."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1247 src/PrefsUnifiedDlg.cpp:1841
+#: src/PrefsUnifiedDlg.cpp:1321 src/PrefsUnifiedDlg.cpp:1921
 #, fuzzy
 msgid "Invalid regular expression"
 msgstr "Ugyldig protokullutgåve."
 
-#: src/PrefsUnifiedDlg.cpp:1324
+#: src/PrefsUnifiedDlg.cpp:1398
 msgid ""
 "Both eD2k and Kad network are disabled.\n"
 "You won't be able to connect until you enable at least one of them."
@@ -5858,7 +5900,7 @@ msgstr ""
 "Både eD2k og kadnettverket er dekativert.\n"
 "Du vil ikkje klare å kople til før du aktiverer minst eitt av dei."
 
-#: src/PrefsUnifiedDlg.cpp:1329
+#: src/PrefsUnifiedDlg.cpp:1403
 msgid ""
 "Kad will not start if your UDP port is disabled.\n"
 "Enable UDP port or disable Kad."
@@ -5866,7 +5908,7 @@ msgstr ""
 "Kad kan ikkje starte dersom UDP-porten er deaktivert.\n"
 "Aktivér UDP-porten eller deaktivér Kad."
 
-#: src/PrefsUnifiedDlg.cpp:1385
+#: src/PrefsUnifiedDlg.cpp:1459
 msgid ""
 "\n"
 "You MUST restart aMule now.\n"
@@ -5876,69 +5918,69 @@ msgstr ""
 "Du MÅ starte om att aMule no.\n"
 "Ikkje klag dersom du ikkje gjer dette og du får problem.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1450
+#: src/PrefsUnifiedDlg.cpp:1524
 msgid "Could not register aMule for autostart at login. The autostart store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1452
+#: src/PrefsUnifiedDlg.cpp:1526
 msgid "Could not remove the autostart-at-login entry."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1453
+#: src/PrefsUnifiedDlg.cpp:1527
 #, fuzzy
 msgid "Autostart"
 msgstr "Autooppfrisking starta"
 
-#: src/PrefsUnifiedDlg.cpp:1468
+#: src/PrefsUnifiedDlg.cpp:1542
 msgid "Register file type"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1468
+#: src/PrefsUnifiedDlg.cpp:1542
 msgid "Register URL handler"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1476
+#: src/PrefsUnifiedDlg.cpp:1550
 #, c-format
 msgid "aMule only handles eD2k-compatible magnets. If you replace the current magnet handler (%s), BitTorrent magnet links will stop working - aMule cannot download BitTorrent content. Continue?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1481
+#: src/PrefsUnifiedDlg.cpp:1555
 #, c-format
 msgid "Another application currently opens .emulecollection files (%s). Replace it with aMule?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1486
+#: src/PrefsUnifiedDlg.cpp:1560
 #, c-format
 msgid "Another application is currently the default handler for these links (%s). Replace it with aMule?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1511
+#: src/PrefsUnifiedDlg.cpp:1585
 msgid "Could not register aMule for .emulecollection files. The registration store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1513
+#: src/PrefsUnifiedDlg.cpp:1587
 #, fuzzy
 msgid "Could not remove the file type registration."
 msgstr "Du freistar allereie nedlasting av fila %s"
 
-#: src/PrefsUnifiedDlg.cpp:1515
+#: src/PrefsUnifiedDlg.cpp:1589
 msgid "Could not register aMule as the URL handler. The registration store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1517
+#: src/PrefsUnifiedDlg.cpp:1591
 msgid "Could not remove the URL handler registration."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1587 src/PrefsUnifiedDlg.cpp:1614
+#: src/PrefsUnifiedDlg.cpp:1661 src/PrefsUnifiedDlg.cpp:1688
 #, fuzzy
 msgid "The web server and aMule API require external connections to be enabled."
 msgstr "Ny ekstern kopling akseptert"
 
-#: src/PrefsUnifiedDlg.cpp:1597
+#: src/PrefsUnifiedDlg.cpp:1671
 msgid "The aMule web server is deprecated. Consider running the aMule API instead."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1655
+#: src/PrefsUnifiedDlg.cpp:1735
 msgid ""
 "Your Auto-update servers list is in blank.\n"
 "Please fill in at least one URL to point to a valid server.met file.\n"
@@ -5948,66 +5990,66 @@ msgstr ""
 "Vér god og fylle ut ein URL som peikar til ei gyldig server.met fil.\n"
 "Klikk på knappen \"Liste\" ved denne boksen for å skrive inn ein URL."
 
-#: src/PrefsUnifiedDlg.cpp:1796
+#: src/PrefsUnifiedDlg.cpp:1876
 msgid "Temporary files"
 msgstr "Mellombelse filer"
 
-#: src/PrefsUnifiedDlg.cpp:1801
+#: src/PrefsUnifiedDlg.cpp:1881
 msgid "Incoming files"
 msgstr "Innkomande filer"
 
-#: src/PrefsUnifiedDlg.cpp:1806
+#: src/PrefsUnifiedDlg.cpp:1886
 msgid "Online Signatures"
 msgstr "Nettsignaturar"
 
-#: src/PrefsUnifiedDlg.cpp:1819
+#: src/PrefsUnifiedDlg.cpp:1899
 #, c-format
 msgid "Choose a folder for %s"
 msgstr "Vel ei mappe for %s"
 
-#: src/PrefsUnifiedDlg.cpp:1843
+#: src/PrefsUnifiedDlg.cpp:1923
 #, fuzzy, c-format
 msgid "Would exclude %u of %u shared file"
 msgid_plural "Would exclude %u of %u shared files"
 msgstr[0] "Fann %i kjend delt fil"
 msgstr[1] "Fann %i kjende delte filer"
 
-#: src/PrefsUnifiedDlg.cpp:1860
+#: src/PrefsUnifiedDlg.cpp:1940
 msgid "Browse for videoplayer"
 msgstr "Bla etter videospelar"
 
-#: src/PrefsUnifiedDlg.cpp:1864
+#: src/PrefsUnifiedDlg.cpp:1944
 msgid "Select browser"
 msgstr "Vél nettlesar"
 
-#: src/PrefsUnifiedDlg.cpp:1868
+#: src/PrefsUnifiedDlg.cpp:1948
 #, fuzzy
 msgid "Select ffprobe binary"
 msgstr "Vél nettlesar"
 
-#: src/PrefsUnifiedDlg.cpp:1874
+#: src/PrefsUnifiedDlg.cpp:1954
 #, c-format
 msgid "Executable%s"
 msgstr "Køyrbar%s"
 
-#: src/PrefsUnifiedDlg.cpp:1908
+#: src/PrefsUnifiedDlg.cpp:1988
 msgid "ffprobe not found on PATH or in the standard install locations. Install ffmpeg (which ships ffprobe) or use Browse to pick a binary manually."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1920
+#: src/PrefsUnifiedDlg.cpp:2000
 msgid "Reset the settings on this page to their default values?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1921
+#: src/PrefsUnifiedDlg.cpp:2001
 #, fuzzy
 msgid "Reset to defaults"
 msgstr "Standardinnstillingar"
 
-#: src/PrefsUnifiedDlg.cpp:1948
+#: src/PrefsUnifiedDlg.cpp:2028
 msgid "Edit server list"
 msgstr "Handsame tenarlista"
 
-#: src/PrefsUnifiedDlg.cpp:1949
+#: src/PrefsUnifiedDlg.cpp:2029
 msgid ""
 "Add here URL's to download server.met files.\n"
 "Only one url on each line."
@@ -6015,155 +6057,155 @@ msgstr ""
 "Skriv inn URL`en for å laste ned server.met filer.\n"
 "Berre ein URL på kvar linje."
 
-#: src/PrefsUnifiedDlg.cpp:2004
+#: src/PrefsUnifiedDlg.cpp:2084
 msgid "IP2Country update failed"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2149 src/PrefsUnifiedDlg.cpp:2180
+#: src/PrefsUnifiedDlg.cpp:2229 src/PrefsUnifiedDlg.cpp:2260
 msgid "Data by MaxMind GeoLite2"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2151 src/PrefsUnifiedDlg.cpp:2182
+#: src/PrefsUnifiedDlg.cpp:2231 src/PrefsUnifiedDlg.cpp:2262
 #, fuzzy
 msgid "Custom source"
 msgstr "Komplette kjelder"
 
-#: src/PrefsUnifiedDlg.cpp:2153 src/PrefsUnifiedDlg.cpp:2184
+#: src/PrefsUnifiedDlg.cpp:2233 src/PrefsUnifiedDlg.cpp:2264
 msgid "Data by DB-IP.com"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2204
+#: src/PrefsUnifiedDlg.cpp:2284
 #, fuzzy, c-format
 msgid "Status: Loaded%s"
 msgstr "Status:"
 
-#: src/PrefsUnifiedDlg.cpp:2206
+#: src/PrefsUnifiedDlg.cpp:2286
 #, fuzzy, c-format
 msgid "Status: Loaded%s - %s"
 msgstr "Status:"
 
-#: src/PrefsUnifiedDlg.cpp:2210
+#: src/PrefsUnifiedDlg.cpp:2290
 msgid "Status: Failed to load - click 'Update now' to refresh."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2212
+#: src/PrefsUnifiedDlg.cpp:2292
 msgid "Status: Not found - click 'Update now' to download."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2270 src/PrefsUnifiedDlg.cpp:2294
+#: src/PrefsUnifiedDlg.cpp:2350 src/PrefsUnifiedDlg.cpp:2374
 #, c-format
 msgid "Update delay: %d second"
 msgid_plural "Update delay: %d seconds"
 msgstr[0] "Oppdateringspause: %d sekund"
 msgstr[1] "Oppdateringspause: %d sekund"
 
-#: src/PrefsUnifiedDlg.cpp:2278
+#: src/PrefsUnifiedDlg.cpp:2358
 #, c-format
 msgid "Time for average graph: %d minute"
 msgid_plural "Time for average graph: %d minutes"
 msgstr[0] "Tid for gjennomsnittleg graf: %d minutt"
 msgstr[1] "Tid for gjennomsnittleg graf; %d minutt"
 
-#: src/PrefsUnifiedDlg.cpp:2287
+#: src/PrefsUnifiedDlg.cpp:2367
 #, c-format
 msgid "Connections Graph Scale: %d"
 msgstr "Koplingsgrafskala: %d"
 
-#: src/PrefsUnifiedDlg.cpp:2302
+#: src/PrefsUnifiedDlg.cpp:2382
 #, c-format
 msgid "File Buffer Size: %d byte"
 msgid_plural "File Buffer Size: %d bytes"
 msgstr[0] "Filbufferstorleik: %d byte"
 msgstr[1] "Filbufferstorleik: %d bytes"
 
-#: src/PrefsUnifiedDlg.cpp:2312
+#: src/PrefsUnifiedDlg.cpp:2392
 #, c-format
 msgid "Upload Queue Size: %d client"
 msgid_plural "Upload Queue Size: %d clients"
 msgstr[0] "Opplastingskøstorleik: %d klient"
 msgstr[1] "Opplastingskøstorleik: %d klientar"
 
-#: src/PrefsUnifiedDlg.cpp:2322
+#: src/PrefsUnifiedDlg.cpp:2402
 #, c-format
 msgid "Server connection refresh interval: %d minute"
 msgid_plural "Server connection refresh interval: %d minutes"
 msgstr[0] "Oppfriskingsinterval på tenarkoplingar: %d minutt"
 msgstr[1] "Oppfriskingsinterval på tenarkoplingar: %d minutt"
 
-#: src/PrefsUnifiedDlg.cpp:2327
+#: src/PrefsUnifiedDlg.cpp:2407
 msgid "Server connection refresh interval: Disabled"
 msgstr "Oppfriskingsintervall for tenarkopling: Deaktivert"
 
-#: src/PrefsUnifiedDlg.cpp:2371
+#: src/PrefsUnifiedDlg.cpp:2451
 #, fuzzy
 msgid "disabled"
 msgstr "deaktivere"
 
-#: src/PrefsUnifiedDlg.cpp:2397
+#: src/PrefsUnifiedDlg.cpp:2477
 #, fuzzy, c-format
 msgid "Execute command on '%s' event"
 msgstr "Køyr kommando på `%s' hending"
 
-#: src/PrefsUnifiedDlg.cpp:2404
+#: src/PrefsUnifiedDlg.cpp:2484
 msgid "Enable command execution on core"
 msgstr "Aktivér kommandokøyring i kjernen"
 
-#: src/PrefsUnifiedDlg.cpp:2416
+#: src/PrefsUnifiedDlg.cpp:2496
 msgid "Core command:"
 msgstr "Kjernekommando:"
 
-#: src/PrefsUnifiedDlg.cpp:2432
+#: src/PrefsUnifiedDlg.cpp:2512
 msgid "Enable command execution on GUI"
 msgstr "Aktivér kommandokøyring på drakt"
 
-#: src/PrefsUnifiedDlg.cpp:2444
+#: src/PrefsUnifiedDlg.cpp:2524
 msgid "GUI command:"
 msgstr "Draktkommando:"
 
-#: src/PrefsUnifiedDlg.cpp:2460
+#: src/PrefsUnifiedDlg.cpp:2540
 msgid "The following variables will be replaced:"
 msgstr "Følgjande variablar vert erstatta:"
 
-#: src/PrefsUnifiedDlg.cpp:2628
+#: src/PrefsUnifiedDlg.cpp:2708
 msgid ""
 "The following folders look like system or sensitive locations:\n"
 "\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2633
+#: src/PrefsUnifiedDlg.cpp:2713
 msgid "Sharing them recursively will publish every file underneath on the eD2k/Kad networks. Do you really want to do this?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2636
+#: src/PrefsUnifiedDlg.cpp:2716
 #, fuzzy
 msgid "Confirm shared folders"
 msgstr "Lastar inn att delte filer"
 
-#: src/PrefsUnifiedDlg.cpp:2664
+#: src/PrefsUnifiedDlg.cpp:2744
 #, fuzzy
 msgid "Reloading shared files..."
 msgstr "Lastar inn att delte filer"
 
-#: src/PrefsUnifiedDlg.cpp:2665
+#: src/PrefsUnifiedDlg.cpp:2745
 msgid "Scanning for subdirectories..."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2666
+#: src/PrefsUnifiedDlg.cpp:2746
 #, fuzzy
 msgid "Updating shared folders"
 msgstr "Les mellombels mappe"
 
-#: src/PrefsUnifiedDlg.cpp:2693
+#: src/PrefsUnifiedDlg.cpp:2773
 #, c-format
 msgid "Scanned %u directories..."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2743
+#: src/PrefsUnifiedDlg.cpp:2823
 #, fuzzy, c-format
 msgid "Reloading shared files: %u files scanned"
 msgstr "Lastar inn att lista over delte filer."
 
-#: src/PrefsUnifiedDlg.cpp:2793
+#: src/PrefsUnifiedDlg.cpp:2873
 #, fuzzy
 msgid "Shared folder"
 msgstr "Delte filer"

--- a/po/pl.po
+++ b/po/pl.po
@@ -12,7 +12,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-28 10:19+0200\n"
+"POT-Creation-Date: 2026-07-28 12:17+0200\n"
 "PO-Revision-Date: 2026-07-27 11:43+0000\n"
 "Last-Translator: Michał Trzebiatowski <hippie_1968@hotmail.com>\n"
 "Language-Team: translationproject.org/team/pl.html <translation-team-pl@lists.sourceforge.net>\n"
@@ -205,83 +205,83 @@ msgstr "Nie udało się otworzyć pliku ED2KLinks."
 msgid "WARNING: You can't add yourself as a source for an eD2k link while having a lowid."
 msgstr "UWAGA: Nie możesz dodać samego siebie jako źródło linku ed2k, gdy masz lowid."
 
-#: src/amule.cpp:300
+#: src/amule.cpp:301
 msgid "Now, exiting main app..."
 msgstr "Teraz, zakańczam główną aplikację..."
 
-#: src/amule.cpp:330
+#: src/amule.cpp:331
 #, c-format
 msgid "Terminating amuleweb instance with pid '%d' ... "
 msgstr "Zakańczam instancję amuleweb z pid `%d' ... "
 
-#: src/amule.cpp:334
+#: src/amule.cpp:335
 #, c-format
 msgid "Killing amuleweb instance with pid '%d' ... "
 msgstr "Zabiłam instancję amuleweb z pid `%d' ... "
 
-#: src/amule.cpp:336 src/amule.cpp:349 src/ClientRef.cpp:180
+#: src/amule.cpp:337 src/amule.cpp:350 src/ClientRef.cpp:180
 #: src/SearchDlg.cpp:1041 src/ServerListCtrl.cpp:98
 msgid "Failed"
 msgstr "Nieudane"
 
-#: src/amule.cpp:343
+#: src/amule.cpp:344
 #, fuzzy, c-format
 msgid "Terminating amuleapi instance with pid '%d' ... "
 msgstr "Zakańczam instancję amuleweb z pid `%d' ... "
 
-#: src/amule.cpp:347
+#: src/amule.cpp:348
 #, fuzzy, c-format
 msgid "Killing amuleapi instance with pid '%d' ... "
 msgstr "Zabiłam instancję amuleweb z pid `%d' ... "
 
-#: src/amule.cpp:355
+#: src/amule.cpp:356
 msgid "aMule OnExit: Terminating core."
 msgstr "aMule OnExit: Zakończenie jądra."
 
-#: src/amule.cpp:466
+#: src/amule.cpp:467
 msgid "aMule shutdown completed."
 msgstr "Zamykanie aMule zakończone."
 
-#: src/amule.cpp:470
+#: src/amule.cpp:471
 msgid "Memory debug results for aMule exit:"
 msgstr "Wyniki debugu pamięci dla wyjścia aMule:"
 
-#: src/amule.cpp:651
+#: src/amule.cpp:652
 #, c-format
 msgid "Binding aMule's peer-to-peer traffic to interface: %s (HTTP updates use the default route)"
 msgstr ""
 
-#: src/amule.cpp:655
+#: src/amule.cpp:656
 #, c-format
 msgid "Binding all network traffic to interface: %s"
 msgstr ""
 
-#: src/amule.cpp:659
+#: src/amule.cpp:660
 #, c-format
 msgid "WARNING: configured network interface '%s' was not found - traffic is NOT bound to it and may leave via the default route. Check the interface name in Preferences."
 msgstr ""
 
-#: src/amule.cpp:665
+#: src/amule.cpp:666
 #, c-format
 msgid "WARNING: binding to network interface '%s' requires elevated privileges and was NOT applied - traffic may leave via the default route. Grant the capability (e.g. 'sudo setcap cap_net_raw+ep' on the aMule binary) or run with sufficient privileges."
 msgstr ""
 
-#: src/amule.cpp:673
+#: src/amule.cpp:674
 #, c-format
 msgid "WARNING: could not bind to network interface '%s' - traffic may leave via the default route."
 msgstr ""
 
-#: src/amule.cpp:732
+#: src/amule.cpp:733
 msgid "Your locale has been changed to System Default due to a configuration change. Sorry."
 msgstr "Twoje ustawienia lokalne zostały zmienione na domyślne systemowe w związku ze zmianą konfiguracji. Przepraszamy."
 
-#: src/amule.cpp:734 src/amule.cpp:1581 src/CatDialog.cpp:128
+#: src/amule.cpp:735 src/amule.cpp:1589 src/CatDialog.cpp:128
 #: src/CatDialog.cpp:136 src/CatDialog.cpp:149 src/ServerList.cpp:366
 #: src/ServerListCtrl.cpp:152
 msgid "Info"
 msgstr "Informacje"
 
-#: src/amule.cpp:741
+#: src/amule.cpp:742
 msgid ""
 "\n"
 "EC configuration"
@@ -289,74 +289,74 @@ msgstr ""
 "\n"
 "Konfiguracja EC"
 
-#: src/amule.cpp:744
+#: src/amule.cpp:745
 msgid "Password set and external connections enabled."
 msgstr "Ustawione hasło i włączone połączenia zewnętrzne."
 
-#: src/amule.cpp:754 src/KadDlg.cpp:176 src/KadDlg.cpp:185
-#: src/PrefsUnifiedDlg.cpp:1387 src/SharedFilesCtrl.cpp:476
+#: src/amule.cpp:755 src/KadDlg.cpp:176 src/KadDlg.cpp:185
+#: src/PrefsUnifiedDlg.cpp:1461 src/SharedFilesCtrl.cpp:476
 msgid "WARNING"
 msgstr "UWAGA"
 
-#: src/amule.cpp:991
+#: src/amule.cpp:992
 #, fuzzy
 msgid "Network bootstrap"
 msgstr "Sieci"
 
-#: src/amule.cpp:996
+#: src/amule.cpp:997
 msgid ""
 "aMule has detected missing network bootstrap files.\n"
 "Select which ones to download:"
 msgstr ""
 
-#: src/amule.cpp:1005 src/FirstRunWizard.cpp:411
+#: src/amule.cpp:1006 src/FirstRunWizard.cpp:411
 #, fuzzy
 msgid "eD2k server list (server.met)"
 msgstr "%i serwer znaleziono w server.met"
 
-#: src/amule.cpp:1012 src/FirstRunWizard.cpp:416
+#: src/amule.cpp:1013 src/FirstRunWizard.cpp:416
 msgid "Kad bootstrap nodes (nodes.dat)"
 msgstr ""
 
-#: src/amule.cpp:1102
+#: src/amule.cpp:1103
 #, c-format
 msgid "web server running on pid %d"
 msgstr "serwer sieciowy uruchomiony na pid %d"
 
-#: src/amule.cpp:1115
+#: src/amule.cpp:1116
 #, fuzzy
 msgid "You requested to run web server on startup, but the amuleweb binary cannot be run. Please install the package containing aMule web server, or build aMule from source with -DBUILD_WEBSERVER=YES and install it."
 msgstr "Zażądałeś włączenia serwera sieciowego podczas uruchomienia, ale binarki amuleweb nie mogą być uruchomione. Zainstaluj paczkę zawierającą serwer sieciowy aMule lub skompiluj aMule używając --enable-webserver i uruchom make install"
 
-#: src/amule.cpp:1120 src/amule.cpp:1177 src/amule.cpp:1291 src/amule.cpp:1593
+#: src/amule.cpp:1121 src/amule.cpp:1185 src/amule.cpp:1299 src/amule.cpp:1601
 #: src/amule-remote-gui.cpp:603 src/amule-remote-gui.cpp:671
 #: src/amule-remote-gui.cpp:709 src/amule-remote-gui.cpp:1282
 #: src/amule-remote-gui.cpp:1345 src/amule-remote-gui.cpp:1372
-#: src/DownloadQueue.cpp:1481
+#: src/DownloadQueue.cpp:1481 src/PrefsUnifiedDlg.cpp:1247
 msgid "ERROR"
 msgstr "BŁĄD"
 
-#: src/amule.cpp:1166
+#: src/amule.cpp:1174
 #, fuzzy, c-format
 msgid "amuleapi running on pid %d"
 msgstr "serwer sieciowy uruchomiony na pid %d"
 
-#: src/amule.cpp:1172
+#: src/amule.cpp:1180
 #, fuzzy
 msgid "You requested to run amuleapi on startup, but the amuleapi binary cannot be run. Please install the package containing aMule's REST API server, or build aMule from source with -DBUILD_AMULEAPI=YES and install it."
 msgstr "Zażądałeś włączenia serwera sieciowego podczas uruchomienia, ale binarki amuleweb nie mogą być uruchomione. Zainstaluj paczkę zawierającą serwer sieciowy aMule lub skompiluj aMule używając --enable-webserver i uruchom make install"
 
-#: src/amule.cpp:1259
+#: src/amule.cpp:1267
 #, c-format
 msgid "Could not bind ports to the specified address: %s"
 msgstr "Nie można było powiązać portów z określonym adresem: %s"
 
-#: src/amule.cpp:1283
+#: src/amule.cpp:1291
 #, c-format
 msgid "Port %u is not available. You will be LOWID\n"
 msgstr "Port %u jest niedostępny. Będziesz mieć LowID\n"
 
-#: src/amule.cpp:1288
+#: src/amule.cpp:1296
 #, c-format
 msgid ""
 "Port %u is not available!\n"
@@ -371,48 +371,48 @@ msgstr ""
 "\n"
 "Sprawdź swoją sieć aby mieć pewność, że port jest otwarty dla wejścia i wyjścia."
 
-#: src/amule.cpp:1385
+#: src/amule.cpp:1393
 msgid "Failed to create OnlineSig File"
 msgstr "Nie udało się utworzyć pliku podpisu online"
 
-#: src/amule.cpp:1393
+#: src/amule.cpp:1401
 msgid "Failed to create aMule OnlineSig File"
 msgstr "Nie udało się utworzyć pliku podpisu online aMule"
 
-#: src/amule.cpp:1556
+#: src/amule.cpp:1564
 msgid "The selected locale seems not to be installed on your box. (Note: I'll try to set it anyway)"
 msgstr "Wybrane lokale wydają się być niezainstalowane. (Uwaga: I tak spróbuję je ustawić)"
 
-#: src/amule.cpp:1566
+#: src/amule.cpp:1574
 #, c-format
 msgid "This is the first time you run aMule %s"
 msgstr "Po raz pierwszy uruchomiłeś aMule %s"
 
-#: src/amule.cpp:1569
+#: src/amule.cpp:1577
 msgid "This version is a testing version, updated daily, and\n"
 msgstr "Ta wersja jest aktualizowaną codziennie wersją testową i\n"
 
-#: src/amule.cpp:1570
+#: src/amule.cpp:1578
 msgid "we give no warranty it won't break anything, burn your house,\n"
 msgstr "nie dajemy żadnej gwarancji, że nie zniszczy ona niczego, nie spali twojego domu\n"
 
-#: src/amule.cpp:1571
+#: src/amule.cpp:1579
 msgid "or kill your dog. But it *should* be safe to use anyway.\n"
 msgstr "lub zabije twojego psa. *Powinna* ona jednak mimo wszystko działać poprawnie.\n"
 
-#: src/amule.cpp:1576
+#: src/amule.cpp:1584
 msgid "More information, support and new releases can found at our homepage,\n"
 msgstr "Więcej informacji, pomoc i nowe wydania znajdziesz na naszej stronie \n"
 
-#: src/amule.cpp:1577
+#: src/amule.cpp:1585
 msgid "at https://amule-org.github.io, or in our IRC channel #aMule at irc.libera.chat.\n"
 msgstr "https://amule-org.github.io lub na naszym kanale IRC: #aMule na irc.libera.chat.\n"
 
-#: src/amule.cpp:1579
+#: src/amule.cpp:1587
 msgid "Feel free to report any bugs to https://github.com/amule-org/amule/issues"
 msgstr "Nie wahaj się zgłaszać jakichkolwiek błędów na https://github.com/amule-org/amule/issues"
 
-#: src/amule.cpp:1591
+#: src/amule.cpp:1599
 msgid ""
 "The folder for Online Signature files you specified is INVALID!\n"
 " OnlineSignature will be DISABLED until you fix it on preferences."
@@ -420,137 +420,137 @@ msgstr ""
 "Katalog wybrany na pliki sygnatury online jest nieprawidłowy!\n"
 " Sygnatura online zostanie wyłączona dopóki nie poprawisz tego w preferencjach."
 
-#: src/amule.cpp:1654
+#: src/amule.cpp:1662
 msgid "Server hostname notified"
 msgstr "Zawiadomiono nazwę hostu serwera"
 
-#: src/amule.cpp:2031
+#: src/amule.cpp:2039
 #, c-format
 msgid "Disk space preallocation for file '%s' failed: %s"
 msgstr "Wstępna alokacja dysku dla pliku '%s' nie powiodła się: %s"
 
-#: src/amule.cpp:2160
+#: src/amule.cpp:2168
 msgid "ERROR: can't open logfile"
 msgstr "BŁĄD: nie mogę otworzyć pliku logów"
 
-#: src/amule.cpp:2164
+#: src/amule.cpp:2172
 msgid "WARNING: logfile is empty. Something is wrong."
 msgstr "UWAGA: plik logów jest pusty. Coś jest nie tak."
 
-#: src/amule.cpp:2181
+#: src/amule.cpp:2189
 msgid "Log has been reset"
 msgstr "Logi zostały zresetowane"
 
-#: src/amule.cpp:2205
+#: src/amule.cpp:2213
 #, c-format
 msgid "ServerMessage: %s"
 msgstr "Wiadomość z serwera: %s"
 
-#: src/amule.cpp:2248 src/IP2Country.cpp:220 src/IPFilter.cpp:514
+#: src/amule.cpp:2256 src/IP2Country.cpp:220 src/IPFilter.cpp:514
 #: src/ServerList.cpp:875
 #, c-format
 msgid "Skipped download of %s, because requested file is not newer."
 msgstr "Pominięto pobranie %s, ponieważ żądany plik nie jest nowszy."
 
-#: src/amule.cpp:2251
+#: src/amule.cpp:2259
 msgid "Failed to download the nodes list."
 msgstr "Pobieranie listy węzłów nie powiodło się."
 
-#: src/amule.cpp:2314
+#: src/amule.cpp:2322
 msgid "Failed to open the downloaded version check file"
 msgstr "Nie można otworzyć pobranego pliku kontroli wersji"
 
-#: src/amule.cpp:2317 src/amule.cpp:2336
+#: src/amule.cpp:2325 src/amule.cpp:2344
 msgid "Corrupted version check file"
 msgstr "Uszkodzony plik kontorli wersji"
 
-#: src/amule.cpp:2359
+#: src/amule.cpp:2367
 msgid "You are using an outdated version of aMule!"
 msgstr "Używasz przestarzałej wersji aMule!"
 
-#: src/amule.cpp:2361
+#: src/amule.cpp:2369
 #, c-format
 msgid "Your aMule version is %i.%i.%i and the latest version is %li.%li.%li"
 msgstr "Twoje wersja eMule to %i.%i.%i, najnowszą wersją jest %li.%li.%li"
 
-#: src/amule.cpp:2365
+#: src/amule.cpp:2373
 msgid "The latest version can always be found at https://github.com/amule-org/amule/releases/latest"
 msgstr "Najnowsza wersja jest zawsze dostępna na https://github.com/amule-org/amule/releases/latest"
 
-#: src/amule.cpp:2368
+#: src/amule.cpp:2376
 #, c-format
 msgid "WARNING: Your aMuled version is outdated: %i.%i.%i < %li.%li.%li"
 msgstr "UWAGA: Twoja wersja aMule jest przestarzała: %i.%i.%i < %li.%li.%li"
 
-#: src/amule.cpp:2374
+#: src/amule.cpp:2382
 msgid "Your copy of aMule is up to date."
 msgstr "Twoja kopia aMule jest przestarzała."
 
-#: src/amule.cpp:2381
+#: src/amule.cpp:2389
 msgid "Failed to download the version check file"
 msgstr "Nie udało się pobrać pliku kontroli wersji"
 
-#: src/amule.cpp:2550 src/amule-remote-gui.cpp:1133
+#: src/amule.cpp:2558 src/amule-remote-gui.cpp:1133
 #, c-format
 msgid "Users: %s | Files: %s"
 msgstr "Użytkowników: %s | Plików: %s"
 
-#: src/amule.cpp:2551 src/amule-remote-gui.cpp:1134
+#: src/amule.cpp:2559 src/amule-remote-gui.cpp:1134
 #, c-format
 msgid "Users: E: %s K: %s | Files: E: %s K: %s"
 msgstr "Użytkowników: E: %s K: %s | Plików: E: %s K: %s"
 
-#: src/amule.cpp:2565 src/amule-remote-gui.cpp:1147
+#: src/amule.cpp:2573 src/amule-remote-gui.cpp:1147
 msgid "No networks selected"
 msgstr "Nie wybrano sieci"
 
-#: src/amule.cpp:2633 src/TextClient.cpp:903
+#: src/amule.cpp:2641 src/TextClient.cpp:903
 msgid "with LowID"
 msgstr "z LowID"
 
-#: src/amule.cpp:2633 src/TextClient.cpp:904
+#: src/amule.cpp:2641 src/TextClient.cpp:904
 msgid "with HighID"
 msgstr "z HighID"
 
-#: src/amule.cpp:2635
+#: src/amule.cpp:2643
 #, c-format
 msgid "Connected to %s %s"
 msgstr "Połączony z %s %s"
 
-#: src/amule.cpp:2640
+#: src/amule.cpp:2648
 #, c-format
 msgid "Connecting to %s"
 msgstr "Łączenie z %s"
 
-#: src/amule.cpp:2642
+#: src/amule.cpp:2650
 msgid "Disconnected from eD2k"
 msgstr "Rozłączono z eD2k"
 
-#: src/amule.cpp:2651
+#: src/amule.cpp:2659
 msgid "Kad started."
 msgstr "Włączono Kad."
 
-#: src/amule.cpp:2653
+#: src/amule.cpp:2661
 msgid "Kad stopped."
 msgstr "Zatrzymano Kad."
 
-#: src/amule.cpp:2661
+#: src/amule.cpp:2669
 msgid "Connected to Kad (ok)"
 msgstr "Połączono z Kad (ok)"
 
-#: src/amule.cpp:2663
+#: src/amule.cpp:2671
 msgid "Connected to Kad (firewalled)"
 msgstr "Połączono z Kad (za firewallem)"
 
-#: src/amule.cpp:2667
+#: src/amule.cpp:2675
 msgid "Disconnected from Kad"
 msgstr "Rozłączono z Kad"
 
-#: src/amule.cpp:2699
+#: src/amule.cpp:2707
 msgid "Kad network cannot be used if UDP port is disabled on preferences, not starting."
 msgstr "Nie można użyć sieci Kad, jeśli port UDP jest wyłączony w preferencjach, nie włączam."
 
-#: src/amule.cpp:2703
+#: src/amule.cpp:2711
 msgid "Kad network disabled on preferences, not connecting."
 msgstr "Zablokowano sieć Kad w preferencjach, nie łączę."
 
@@ -595,36 +595,36 @@ msgid "FATAL ERROR: Failed to create Timer"
 msgstr "KRYTYCZNY BŁĄD: Nie udało się utworzyć Timera"
 
 #: src/amuleDlg.cpp:361 src/amuleDlg.cpp:1787 src/amuleDlg.cpp:2033
-#: src/muuli_wdr.cpp:1492 src/muuli_wdr.cpp:3418
+#: src/muuli_wdr.cpp:1492 src/muuli_wdr.cpp:3449
 msgid "Networks"
 msgstr "Sieci"
 
-#: src/amuleDlg.cpp:362 src/amuleDlg.cpp:1793 src/muuli_wdr.cpp:3419
+#: src/amuleDlg.cpp:362 src/amuleDlg.cpp:1793 src/muuli_wdr.cpp:3450
 msgid "Searches"
 msgstr "Szukaj"
 
 #: src/amuleDlg.cpp:363 src/amuleDlg.cpp:1799 src/DownloadListCtrl.cpp:740
-#: src/muuli_wdr.cpp:392 src/muuli_wdr.cpp:1585 src/muuli_wdr.cpp:3420
+#: src/muuli_wdr.cpp:392 src/muuli_wdr.cpp:1585 src/muuli_wdr.cpp:3451
 #: src/Statistics.cpp:829
 msgid "Downloads"
 msgstr "Pobieranie"
 
-#: src/amuleDlg.cpp:364 src/amuleDlg.cpp:1805 src/muuli_wdr.cpp:3294
+#: src/amuleDlg.cpp:364 src/amuleDlg.cpp:1805 src/muuli_wdr.cpp:3325
 msgid "Shared files"
 msgstr "Udostępnione pliki"
 
-#: src/amuleDlg.cpp:365 src/amuleDlg.cpp:1811 src/muuli_wdr.cpp:2926
-#: src/muuli_wdr.cpp:3376 src/muuli_wdr.cpp:3423
+#: src/amuleDlg.cpp:365 src/amuleDlg.cpp:1811 src/muuli_wdr.cpp:2957
+#: src/muuli_wdr.cpp:3407 src/muuli_wdr.cpp:3454
 msgid "Messages"
 msgstr "Wiadomości"
 
-#: src/amuleDlg.cpp:366 src/amuleDlg.cpp:1817 src/muuli_wdr.cpp:3424
-#: src/PrefsUnifiedDlg.cpp:312 src/Statistics.cpp:779 src/Statistics.cpp:1235
+#: src/amuleDlg.cpp:366 src/amuleDlg.cpp:1817 src/muuli_wdr.cpp:3455
+#: src/PrefsUnifiedDlg.cpp:314 src/Statistics.cpp:779 src/Statistics.cpp:1235
 msgid "Statistics"
 msgstr "Statystyki"
 
-#: src/amuleDlg.cpp:368 src/amuleDlg.cpp:1824 src/muuli_wdr.cpp:3426
-#: src/PrefsUnifiedDlg.cpp:328 src/utils/wxCas/src/wxcasprefs.cpp:39
+#: src/amuleDlg.cpp:368 src/amuleDlg.cpp:1824 src/muuli_wdr.cpp:3457
+#: src/PrefsUnifiedDlg.cpp:330 src/utils/wxCas/src/wxcasprefs.cpp:39
 msgid "Preferences"
 msgstr "Preferencje"
 
@@ -682,8 +682,8 @@ msgstr "Kad: Wyłączony"
 #: src/amuleDlg.cpp:1029 src/DownloadListCtrl.cpp:505
 #: src/DownloadListCtrl.cpp:749 src/FriendListCtrl.cpp:180
 #: src/muuli_wdr.cpp:731 src/muuli_wdr.cpp:782 src/muuli_wdr.cpp:846
-#: src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2231 src/muuli_wdr.cpp:2316
-#: src/muuli_wdr.cpp:3064 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
+#: src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2262 src/muuli_wdr.cpp:2347
+#: src/muuli_wdr.cpp:3095 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
 #: src/ServerListCtrl.cpp:606 src/TransferWnd.cpp:378
 #: src/utils/wxCas/src/wxcasprefs.cpp:235
 msgid "Cancel"
@@ -694,7 +694,7 @@ msgid "Stop the current connection attempts"
 msgstr "Zatrzymaj aktualne próby połączenia"
 
 #: src/amuleDlg.cpp:1035 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976
-#: src/muuli_wdr.cpp:2454
+#: src/muuli_wdr.cpp:2485
 msgid "Disconnect"
 msgstr "Rozłącz"
 
@@ -703,7 +703,7 @@ msgid "Disconnect from the currently connected networks"
 msgstr "Rozłącz z aktualnie połączonymi sieciami"
 
 #: src/amuleDlg.cpp:1041 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979
-#: src/muuli_wdr.cpp:2609 src/muuli_wdr.cpp:3061 src/muuli_wdr.cpp:3416
+#: src/muuli_wdr.cpp:2640 src/muuli_wdr.cpp:3092 src/muuli_wdr.cpp:3447
 msgid "Connect"
 msgstr "Podłącz"
 
@@ -758,7 +758,7 @@ msgstr "Potwierdzenie wyjścia"
 msgid "Launch Command: "
 msgstr "Uruchomienie polecenia: "
 
-#: src/amuleDlg.cpp:1632 src/muuli_wdr.cpp:1978 src/Preferences.cpp:952
+#: src/amuleDlg.cpp:1632 src/muuli_wdr.cpp:1982 src/Preferences.cpp:979
 msgid "- default -"
 msgstr "- domyślnie -"
 
@@ -772,48 +772,48 @@ msgstr "Katalog skórek '%s' nie istnieje"
 msgid "WARNING: Unable to open skin file '%s' for read"
 msgstr "OSTRZEŻENIE: Nie udało się otworzyć pliku skórki '%s' do odczytu"
 
-#: src/amuleDlg.cpp:1791 src/muuli_wdr.cpp:3418
+#: src/amuleDlg.cpp:1791 src/muuli_wdr.cpp:3449
 msgid "Networks Window"
 msgstr "Okno sieci"
 
-#: src/amuleDlg.cpp:1797 src/muuli_wdr.cpp:3419
+#: src/amuleDlg.cpp:1797 src/muuli_wdr.cpp:3450
 msgid "Searches Window"
 msgstr "Okno wyszukiwania"
 
-#: src/amuleDlg.cpp:1803 src/muuli_wdr.cpp:3420
+#: src/amuleDlg.cpp:1803 src/muuli_wdr.cpp:3451
 msgid "Downloads Window"
 msgstr "Okno pobierań"
 
-#: src/amuleDlg.cpp:1809 src/muuli_wdr.cpp:3422
+#: src/amuleDlg.cpp:1809 src/muuli_wdr.cpp:3453
 msgid "Shared Files Window"
 msgstr "Okno udostępnionych plików"
 
-#: src/amuleDlg.cpp:1815 src/muuli_wdr.cpp:3423
+#: src/amuleDlg.cpp:1815 src/muuli_wdr.cpp:3454
 msgid "Messages Window"
 msgstr "Okno wiadomości"
 
-#: src/amuleDlg.cpp:1821 src/muuli_wdr.cpp:3424
+#: src/amuleDlg.cpp:1821 src/muuli_wdr.cpp:3455
 msgid "Statistics Graph Window"
 msgstr "Okno wykresów statystyk"
 
-#: src/amuleDlg.cpp:1828 src/muuli_wdr.cpp:3426
+#: src/amuleDlg.cpp:1828 src/muuli_wdr.cpp:3457
 msgid "Preferences Settings Window"
 msgstr "Okno preferencji"
 
-#: src/amuleDlg.cpp:1831 src/muuli_wdr.cpp:3427
+#: src/amuleDlg.cpp:1831 src/muuli_wdr.cpp:3458
 msgid "Import"
 msgstr "Import"
 
-#: src/amuleDlg.cpp:1835 src/muuli_wdr.cpp:3427
+#: src/amuleDlg.cpp:1835 src/muuli_wdr.cpp:3458
 msgid "The partfile importer tool"
 msgstr "Narzędzie importowania plików części"
 
-#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3428
+#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3459
 #: src/utils/aLinkCreator/src/alcframe.cpp:262
 msgid "About"
 msgstr "Informacje o"
 
-#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3428
+#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3459
 msgid "About/Help"
 msgstr "Informacje/Pomoc"
 
@@ -955,7 +955,7 @@ msgstr "Nie znaleziono pliku."
 msgid "The core rejected these shared folders:%s"
 msgstr ""
 
-#: src/amule-remote-gui.cpp:1336 src/ExternalConn.cpp:2345
+#: src/amule-remote-gui.cpp:1336 src/ExternalConn.cpp:2346
 msgid "Invalid link or already on list."
 msgstr "Nieprawidłowy lub znajdujący się już na liście link."
 
@@ -971,7 +971,7 @@ msgstr "Nie można utworzyć katalogu '%s' dla kategorii '%s', używany jest nad
 #: src/ClientDetailDialog.cpp:123 src/DataToText.cpp:61 src/DataToText.cpp:86
 #: src/DataToText.cpp:101 src/DataToText.cpp:136 src/DataToText.cpp:165
 #: src/DownloadListCtrl.cpp:1172 src/DownloadListCtrl.cpp:1185
-#: src/DownloadListCtrl.cpp:1196 src/ExternalConn.cpp:608
+#: src/DownloadListCtrl.cpp:1196 src/ExternalConn.cpp:609
 #: src/FileDetailDialog.cpp:203 src/FileDetailDialog.cpp:235
 #: src/FileDetailDialog.cpp:242 src/GenericClientListCtrl.cpp:1171
 #: src/GenericClientListCtrl.cpp:1182 src/GenericClientListCtrl.cpp:1192
@@ -1363,19 +1363,19 @@ msgstr "Auto [Wy]"
 msgid "Very low"
 msgstr "Bardzo niski"
 
-#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:743 src/muuli_wdr.cpp:2282
+#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:743 src/muuli_wdr.cpp:2313
 #: src/ServerListCtrl.cpp:263 src/ServerListCtrl.cpp:456
 #: src/SharedFilesCtrl.cpp:145
 msgid "Low"
 msgstr "Niski"
 
-#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:744 src/muuli_wdr.cpp:2283
+#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:744 src/muuli_wdr.cpp:2314
 #: src/ServerListCtrl.cpp:266 src/ServerListCtrl.cpp:457
 #: src/SharedFilesCtrl.cpp:146
 msgid "Normal"
 msgstr "Normalny"
 
-#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:745 src/muuli_wdr.cpp:2284
+#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:745 src/muuli_wdr.cpp:2315
 #: src/ServerListCtrl.cpp:269 src/ServerListCtrl.cpp:458
 #: src/SharedFilesCtrl.cpp:147
 msgid "High"
@@ -1467,7 +1467,7 @@ msgstr "Serwer lokalny"
 msgid "Remote Server"
 msgstr "Serwer zdalny"
 
-#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3181
+#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3212
 #: src/SearchDlg.cpp:119 src/TextClient.cpp:911
 msgid "Kad"
 msgstr "Kad"
@@ -1539,7 +1539,7 @@ msgstr "Część"
 msgid "Size"
 msgstr "Rozmiar"
 
-#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3248
+#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3279
 msgid "Transferred"
 msgstr "Przesłano"
 
@@ -1597,7 +1597,7 @@ msgstr ""
 "Informacja zwrotna od:  %s (%s)\n"
 "\n"
 
-#: src/DownloadListCtrl.cpp:746 src/muuli_wdr.cpp:2285
+#: src/DownloadListCtrl.cpp:746 src/muuli_wdr.cpp:2316
 #: src/SharedFilesCtrl.cpp:150
 msgid "Auto"
 msgstr "Automatyczny"
@@ -1635,7 +1635,7 @@ msgid "Extended Options"
 msgstr "Zaawansowane opcje"
 
 #: src/DownloadListCtrl.cpp:770 src/DownloadListCtrl.cpp:822
-#: src/muuli_wdr.cpp:1796
+#: src/muuli_wdr.cpp:1800
 msgid "Preview"
 msgstr "Podgląd"
 
@@ -1812,227 +1812,232 @@ msgstr[2] ""
 msgid "Invalid eD2k link! ERROR: %s"
 msgstr "Nieprawidłowy link eD2k! BŁĄD: %s"
 
-#: src/ExternalConn.cpp:379
+#: src/ExternalConn.cpp:380
 msgid "Client sent packet after authentication failed."
 msgstr "Klient wysyła pakiet po nie udanym uwierzytelnieniu."
 
-#: src/ExternalConn.cpp:396
+#: src/ExternalConn.cpp:397
 msgid "External connection closed."
 msgstr "Zewnętrzne połączenie zamknięte."
 
-#: src/ExternalConn.cpp:473
+#: src/ExternalConn.cpp:474
 msgid "External connections disabled due to empty password!"
 msgstr "Zewnętrzne połączenia wyłączone w związku z brakiem hasła!"
 
-#: src/ExternalConn.cpp:494
+#: src/ExternalConn.cpp:495
 msgid "External connections disabled in config file"
 msgstr "Zewnętrzne połączenia wyłączone w pliku konfiguracyjnym"
 
-#: src/ExternalConn.cpp:575
+#: src/ExternalConn.cpp:576
 msgid "New external connection accepted"
 msgstr "Nowe zewnętrzne połączenie zaakceptowane"
 
-#: src/ExternalConn.cpp:578
+#: src/ExternalConn.cpp:579
 msgid "ERROR: couldn't accept a new external connection"
 msgstr "BŁĄD: nie można zaakceptować nowego połączenia zewnętrznego"
 
-#: src/ExternalConn.cpp:595
+#: src/ExternalConn.cpp:596
 msgid "External connection refused due to empty password in preferences!"
 msgstr "Zewnętrzne połączenia odrzucone, ze względu na brak hasła w preferencjach!"
 
-#: src/ExternalConn.cpp:607
+#: src/ExternalConn.cpp:608
 #, c-format
 msgid "Connecting client: %s %s"
 msgstr "Łączę z klientem: %s %s"
 
-#: src/ExternalConn.cpp:609
+#: src/ExternalConn.cpp:610
 msgid "Unknown version"
 msgstr "Nieznana wersja"
 
-#: src/ExternalConn.cpp:622
+#: src/ExternalConn.cpp:623
 msgid "Incorrect EC version ID, there might be binary incompatibility. Use core and remote from same snapshot."
 msgstr "Niepoprawny ID wersji EC, może występować niezgodność binarna. Użyj rdzenia i zdalnego z tej samej wersji."
 
-#: src/ExternalConn.cpp:630
+#: src/ExternalConn.cpp:631
 msgid "You cannot connect to a release version from an arbitrary development snapshot! *sigh* possible crash prevented"
 msgstr "Nie można połączyć się z wersją finałową z dowolnej wersji SVN! *westchnięcie* prawdopodobnie zapobiegnięto awarii"
 
-#: src/ExternalConn.cpp:713
+#: src/ExternalConn.cpp:714
 msgid "Invalid protocol version."
 msgstr "Zła wersja protokołu."
 
-#: src/ExternalConn.cpp:719
+#: src/ExternalConn.cpp:720
 msgid "Missing protocol version tag."
 msgstr "Brak znacznika wersji protokołu."
 
-#: src/ExternalConn.cpp:727
+#: src/ExternalConn.cpp:728
 msgid "Authentication failed: invalid hash specified as EC password."
 msgstr "Uwierzytelnianie nie powiodło się: nieprawidłowy skrót podany jako hasło EC."
 
-#: src/ExternalConn.cpp:775
+#: src/ExternalConn.cpp:776
 msgid "Authentication failed: wrong password."
 msgstr "Uwierzytelnianie nie powiodło się: nieprawidłowe hasło."
 
-#: src/ExternalConn.cpp:777
+#: src/ExternalConn.cpp:778
 msgid "Authentication failed: missing password."
 msgstr "Uwierzytelnianie nie powiodło się: brak hasła."
 
-#: src/ExternalConn.cpp:788
+#: src/ExternalConn.cpp:789
 msgid "Invalid request, please authenticate first."
 msgstr "Nieprawidłowe żądanie, najpierw musisz się uwierzytelnić."
 
-#: src/ExternalConn.cpp:793
+#: src/ExternalConn.cpp:794
 msgid "Access granted."
 msgstr "Dostęp udzielony."
 
-#: src/ExternalConn.cpp:801
+#: src/ExternalConn.cpp:802
 #, c-format
 msgid "Sent error message \"%s\" to client."
 msgstr "Wyślij wiadomość błędu \"%s\" do klienta."
 
-#: src/ExternalConn.cpp:806
+#: src/ExternalConn.cpp:807
 #, c-format
 msgid "Unauthorized access attempt from %s. Connection closed."
 msgstr "Próba nieautoryzowanego dostępu z %s. Połączenie zakończone."
 
-#: src/ExternalConn.cpp:1419
+#: src/ExternalConn.cpp:1420
 #, c-format
 msgid "Remote PartFile command failed: FileHash not found: %s"
 msgstr "Zdalna komenda pliku części nieudana: Skrót dla pliku nieznaleziony: %s"
 
-#: src/ExternalConn.cpp:1423
+#: src/ExternalConn.cpp:1424
 #, c-format
 msgid "FileHash not found: %s"
 msgstr "Skrót dla pliku nieznaleziony: %s"
 
-#: src/ExternalConn.cpp:1470 src/ExternalConn.cpp:1558
-#: src/ExternalConn.cpp:1679
+#: src/ExternalConn.cpp:1471 src/ExternalConn.cpp:1559
+#: src/ExternalConn.cpp:1680
 msgid "OOPS! OpCode processing error!"
 msgstr "OOPS! Błąd przetwarzania OpCode!"
 
-#: src/ExternalConn.cpp:1501
+#: src/ExternalConn.cpp:1502
 msgid "Server not added"
 msgstr "Nie dodano serwera"
 
-#: src/ExternalConn.cpp:1520
+#: src/ExternalConn.cpp:1521
 #, c-format
 msgid "server not found: %s"
 msgstr "serwer nieznaleziony: %s"
 
-#: src/ExternalConn.cpp:1537
+#: src/ExternalConn.cpp:1538
 msgid "need to define server to be removed"
 msgstr "trzeba zdefiniować serwer do usunięcia"
 
-#: src/ExternalConn.cpp:1552
+#: src/ExternalConn.cpp:1553
 msgid "eD2k is disabled in preferences."
 msgstr "eD2k jest wyłączony w preferencjach."
 
-#: src/ExternalConn.cpp:1657
+#: src/ExternalConn.cpp:1658
 #, fuzzy
 msgid "Friend not found."
 msgstr "Nie znaleziono pliku."
 
-#: src/ExternalConn.cpp:1667
+#: src/ExternalConn.cpp:1668
 #, fuzzy
 msgid "Client not found."
 msgstr "Nie znaleziono pliku."
 
-#: src/ExternalConn.cpp:1673
+#: src/ExternalConn.cpp:1674
 msgid "EC_TAG_FRIEND_SHARED requires EC_TAG_FRIEND or EC_TAG_CLIENT."
 msgstr ""
 
-#: src/ExternalConn.cpp:1991
+#: src/ExternalConn.cpp:1992
 msgid "WebSearch from remote interface makes no sense."
 msgstr "Szukanie przez WWW ze zdalnych interfejsów nie ma sensu."
 
-#: src/ExternalConn.cpp:2026
+#: src/ExternalConn.cpp:2027
 msgid "Search in progress. Refetch results in a moment!"
 msgstr "Wyszukiwanie w trakcie. Odświeżenie rezultatów za chwilę!"
 
-#: src/ExternalConn.cpp:2265
+#: src/ExternalConn.cpp:2266
 msgid "No points for graph."
 msgstr "Brak punktów dla wykresu."
 
-#: src/ExternalConn.cpp:2275
+#: src/ExternalConn.cpp:2276
 msgid "Your client is not configured for this detail level."
 msgstr "Twój klient nie jest skonfigurowany do tego poziomu szczegółów."
 
-#: src/ExternalConn.cpp:2302
+#: src/ExternalConn.cpp:2303
 msgid "External Connection: shutdown requested"
 msgstr "External Connection: żądanie zamknięcia"
 
-#: src/ExternalConn.cpp:2314
+#: src/ExternalConn.cpp:2315
 msgid "Already shutting down."
 msgstr "Już w trakcie zamykania."
 
-#: src/ExternalConn.cpp:2332
+#: src/ExternalConn.cpp:2333
 #, c-format
 msgid "ExternalConn: adding link '%s'."
 msgstr "ExternalConn: dodaję link '%s'."
 
-#: src/ExternalConn.cpp:2350
+#: src/ExternalConn.cpp:2351
 #, fuzzy, c-format
 msgid "%d of %d links failed (invalid or already on list)."
 msgstr "Nieprawidłowy lub znajdujący się już na liście link."
 
-#: src/ExternalConn.cpp:2373
+#: src/ExternalConn.cpp:2374
 msgid "Version check throttled; try again shortly."
 msgstr ""
 
-#: src/ExternalConn.cpp:2378
+#: src/ExternalConn.cpp:2379
 msgid "Version check is not available on this daemon."
 msgstr ""
 
-#: src/ExternalConn.cpp:2508
+#: src/ExternalConn.cpp:2509
 msgid "File not found."
 msgstr "Nie znaleziono pliku."
 
-#: src/ExternalConn.cpp:2513
+#: src/ExternalConn.cpp:2514
 msgid "Invalid file name."
 msgstr "Nieprawidłowa nazwa pliku."
 
-#: src/ExternalConn.cpp:2521
+#: src/ExternalConn.cpp:2522
 msgid "Unable to rename file."
 msgstr "Nie udało się zmienić nazwy pliku."
 
-#: src/ExternalConn.cpp:2992 src/ExternalConn.cpp:3020
+#: src/ExternalConn.cpp:2839
+#, c-format
+msgid "Could not save the amuleapi password: %s"
+msgstr ""
+
+#: src/ExternalConn.cpp:3004 src/ExternalConn.cpp:3032
 msgid "Kad is disabled in preferences."
 msgstr "Kad jest wyłączony w preferencjach."
 
-#: src/ExternalConn.cpp:3033
+#: src/ExternalConn.cpp:3045
 msgid "Already connected to eD2k."
 msgstr "Już podłączony do eD2k."
 
-#: src/ExternalConn.cpp:3036
+#: src/ExternalConn.cpp:3048
 msgid "Connecting to eD2k..."
 msgstr "Łączę do eD2k..."
 
-#: src/ExternalConn.cpp:3045
+#: src/ExternalConn.cpp:3057
 msgid "Already connected to Kad."
 msgstr "Już podłączony do Kad."
 
-#: src/ExternalConn.cpp:3048
+#: src/ExternalConn.cpp:3060
 msgid "Connecting to Kad..."
 msgstr "Łączę z Kad..."
 
-#: src/ExternalConn.cpp:3055
+#: src/ExternalConn.cpp:3067
 msgid "All networks are disabled."
 msgstr "Wszystkie sieci są wyłączone."
 
-#: src/ExternalConn.cpp:3064
+#: src/ExternalConn.cpp:3076
 msgid "Disconnected from eD2k."
 msgstr "Rozłącz z eD2k."
 
-#: src/ExternalConn.cpp:3069
+#: src/ExternalConn.cpp:3081
 msgid "Disconnected from Kad."
 msgstr "Rozłączono z Kad."
 
-#: src/ExternalConn.cpp:3078
+#: src/ExternalConn.cpp:3090
 #, c-format
 msgid "External Connection: invalid opcode received: %#x"
 msgstr "External Connection: otrzymano nieprawidłowy opcode: %#x"
 
-#: src/ExternalConn.cpp:3083
+#: src/ExternalConn.cpp:3095
 msgid "Invalid opcode (wrong protocol version?)"
 msgstr "Nieprawidłowy opcode (zła wersja protokołu?)"
 
@@ -2433,23 +2438,23 @@ msgid ""
 "want downloads on a different (e.g. larger) disk."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:549 src/FirstRunWizard.cpp:611 src/muuli_wdr.cpp:1708
+#: src/FirstRunWizard.cpp:549 src/FirstRunWizard.cpp:611 src/muuli_wdr.cpp:1712
 msgid "Destination folder for downloads"
 msgstr "Folder docelowy dla pobrań"
 
 #: src/FirstRunWizard.cpp:553 src/FirstRunWizard.cpp:569 src/muuli_wdr.cpp:1349
-#: src/muuli_wdr.cpp:1366 src/muuli_wdr.cpp:1683 src/muuli_wdr.cpp:1714
-#: src/muuli_wdr.cpp:1726 src/muuli_wdr.cpp:2769
+#: src/muuli_wdr.cpp:1366 src/muuli_wdr.cpp:1687 src/muuli_wdr.cpp:1718
+#: src/muuli_wdr.cpp:1730 src/muuli_wdr.cpp:2800
 #: src/utils/aLinkCreator/src/alcframe.cpp:135
 #: src/utils/wxCas/src/wxcasprefs.cpp:52 src/utils/wxCas/src/wxcasprefs.cpp:118
 msgid "Browse"
 msgstr "Przeglądaj"
 
-#: src/FirstRunWizard.cpp:559 src/muuli_wdr.cpp:1719
+#: src/FirstRunWizard.cpp:559 src/muuli_wdr.cpp:1723
 msgid "(All files in this folder are shared with other peers)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:565 src/FirstRunWizard.cpp:624 src/muuli_wdr.cpp:1721
+#: src/FirstRunWizard.cpp:565 src/FirstRunWizard.cpp:624 src/muuli_wdr.cpp:1725
 msgid "Folder for temporary download files"
 msgstr "Folder dla pobranych plików tymczasowych"
 
@@ -2480,7 +2485,7 @@ msgstr "Nie udało się otworzyć pliku listy przyjaciół 'emfriends.met' do za
 msgid "CRITICAL - no client on StartChatSession"
 msgstr "KRYTYCZNE - brak klienta przy StartChatSession"
 
-#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2675 src/muuli_wdr.cpp:3352
+#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2706 src/muuli_wdr.cpp:3383
 msgid "Friends"
 msgstr "Znajomi"
 
@@ -2591,8 +2596,8 @@ msgstr "Brak"
 msgid "No"
 msgstr "Nie"
 
-#: src/GenericClientListCtrl.cpp:1216 src/PrefsUnifiedDlg.cpp:2818
-#: src/PrefsUnifiedDlg.cpp:2868 src/ServerListCtrl.cpp:276
+#: src/GenericClientListCtrl.cpp:1216 src/PrefsUnifiedDlg.cpp:2898
+#: src/PrefsUnifiedDlg.cpp:2948 src/ServerListCtrl.cpp:276
 msgid "Yes"
 msgstr "Tak"
 
@@ -2763,10 +2768,10 @@ msgstr "Nieprawidłowy port do rozruchu"
 msgid "Please fill all fields required"
 msgstr "Proszę wypełnij wszystkie wymagane pola"
 
-#: src/KadDlg.cpp:192 src/PartFile.cpp:1031 src/PrefsUnifiedDlg.cpp:1162
-#: src/PrefsUnifiedDlg.cpp:1331 src/PrefsUnifiedDlg.cpp:1589
-#: src/PrefsUnifiedDlg.cpp:1599 src/PrefsUnifiedDlg.cpp:1616
-#: src/PrefsUnifiedDlg.cpp:1658
+#: src/KadDlg.cpp:192 src/PartFile.cpp:1031 src/PrefsUnifiedDlg.cpp:1134
+#: src/PrefsUnifiedDlg.cpp:1204 src/PrefsUnifiedDlg.cpp:1405
+#: src/PrefsUnifiedDlg.cpp:1663 src/PrefsUnifiedDlg.cpp:1673
+#: src/PrefsUnifiedDlg.cpp:1690 src/PrefsUnifiedDlg.cpp:1738
 msgid "Message"
 msgstr "Wiadomość"
 
@@ -2871,7 +2876,7 @@ msgstr "Ratio wymiany"
 msgid "Uploaded"
 msgstr "Wysłano"
 
-#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3232
+#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3263
 msgid "Requested"
 msgstr "Zażądano"
 
@@ -2995,7 +3000,7 @@ msgid "WARNING: "
 msgstr "OSTRZEŻENIE: "
 
 #: src/MuleNotebook.cpp:179 src/muuli_wdr.cpp:817 src/muuli_wdr.cpp:1229
-#: src/muuli_wdr.cpp:3136 src/muuli_wdr.cpp:3392
+#: src/muuli_wdr.cpp:3167 src/muuli_wdr.cpp:3423
 msgid "Close"
 msgstr "Zamknij"
 
@@ -3013,7 +3018,7 @@ msgid "Paste"
 msgstr "Wklej"
 
 #: src/MuleTextCtrl.cpp:89 src/muuli_wdr.cpp:358 src/muuli_wdr.cpp:757
-#: src/muuli_wdr.cpp:2359 src/muuli_wdr.cpp:2378 src/muuli_wdr.cpp:2400
+#: src/muuli_wdr.cpp:2390 src/muuli_wdr.cpp:2409 src/muuli_wdr.cpp:2431
 #: src/utils/aLinkCreator/src/alcframe.cpp:142
 msgid "Clear"
 msgstr "Wyczyść"
@@ -3112,7 +3117,7 @@ msgstr "Wyjdź"
 
 #: src/MuleTrayIcon.cpp:579 src/MuleTrayIcon.cpp:945 src/MuleTrayIcon.cpp:965
 #: src/muuli_wdr.cpp:1398 src/muuli_wdr.cpp:1406 src/muuli_wdr.cpp:1413
-#: src/muuli_wdr.cpp:1842 src/muuli_wdr.cpp:1848 src/OtherFunctions.cpp:91
+#: src/muuli_wdr.cpp:1846 src/muuli_wdr.cpp:1852 src/OtherFunctions.cpp:91
 #: src/StatisticsDlg.cpp:93 src/StatisticsDlg.cpp:95
 msgid "kB/s"
 msgstr "kB/s"
@@ -3354,7 +3359,7 @@ msgstr "Bajtów"
 msgid "KB"
 msgstr "KB"
 
-#: src/muuli_wdr.cpp:274 src/muuli_wdr.cpp:293 src/muuli_wdr.cpp:1627
+#: src/muuli_wdr.cpp:274 src/muuli_wdr.cpp:293 src/muuli_wdr.cpp:1631
 #: src/OtherFunctions.cpp:64
 msgid "MB"
 msgstr "MB"
@@ -3371,7 +3376,7 @@ msgstr "Maks. rozmiar"
 msgid "Availability"
 msgstr "Dostępność"
 
-#: src/muuli_wdr.cpp:312 src/muuli_wdr.cpp:398 src/muuli_wdr.cpp:3297
+#: src/muuli_wdr.cpp:312 src/muuli_wdr.cpp:398 src/muuli_wdr.cpp:3328
 msgid "Filter:"
 msgstr "Filtr:"
 
@@ -3434,12 +3439,12 @@ msgstr "Źródła pliku:"
 #: src/muuli_wdr.cpp:1160 src/muuli_wdr.cpp:1167 src/muuli_wdr.cpp:1172
 #: src/muuli_wdr.cpp:1179 src/muuli_wdr.cpp:1184 src/muuli_wdr.cpp:1191
 #: src/muuli_wdr.cpp:1205 src/muuli_wdr.cpp:1212 src/muuli_wdr.cpp:1217
-#: src/muuli_wdr.cpp:1224 src/muuli_wdr.cpp:3234 src/muuli_wdr.cpp:3242
-#: src/muuli_wdr.cpp:3250
+#: src/muuli_wdr.cpp:1224 src/muuli_wdr.cpp:3265 src/muuli_wdr.cpp:3273
+#: src/muuli_wdr.cpp:3281
 msgid "N/A"
 msgstr "Brak"
 
-#: src/muuli_wdr.cpp:508 src/muuli_wdr.cpp:1065 src/PrefsUnifiedDlg.cpp:297
+#: src/muuli_wdr.cpp:508 src/muuli_wdr.cpp:1065 src/PrefsUnifiedDlg.cpp:299
 msgid "General"
 msgstr "Ogólne"
 
@@ -3580,7 +3585,7 @@ msgstr ""
 msgid "Album :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:685 src/muuli_wdr.cpp:2254
+#: src/muuli_wdr.cpp:685 src/muuli_wdr.cpp:2285
 msgid "Title :"
 msgstr "Tytuł :"
 
@@ -3689,7 +3694,7 @@ msgstr "Nazwa użytkownika :"
 msgid "Userhash :"
 msgstr "Skrót użytkownika :"
 
-#: src/muuli_wdr.cpp:895 src/muuli_wdr.cpp:1748 src/muuli_wdr.cpp:2449
+#: src/muuli_wdr.cpp:895 src/muuli_wdr.cpp:1752 src/muuli_wdr.cpp:2480
 #: src/utils/aLinkCreator/src/alcframe.cpp:137
 msgid "Add"
 msgstr "Dodaj"
@@ -3698,15 +3703,15 @@ msgstr "Dodaj"
 msgid "Download-Speed"
 msgstr "Prędkość pobierania"
 
-#: src/muuli_wdr.cpp:954 src/muuli_wdr.cpp:989 src/muuli_wdr.cpp:2553
+#: src/muuli_wdr.cpp:954 src/muuli_wdr.cpp:989 src/muuli_wdr.cpp:2584
 msgid "Current"
 msgstr "Aktualna"
 
-#: src/muuli_wdr.cpp:962 src/muuli_wdr.cpp:997 src/muuli_wdr.cpp:2561
+#: src/muuli_wdr.cpp:962 src/muuli_wdr.cpp:997 src/muuli_wdr.cpp:2592
 msgid "Running average"
 msgstr "Bieżąca średnia"
 
-#: src/muuli_wdr.cpp:970 src/muuli_wdr.cpp:1005 src/muuli_wdr.cpp:2569
+#: src/muuli_wdr.cpp:970 src/muuli_wdr.cpp:1005 src/muuli_wdr.cpp:2600
 msgid "Session average"
 msgstr "Średnia sesji"
 
@@ -3718,7 +3723,7 @@ msgstr "Prędkość wysyłania"
 msgid "Connections"
 msgstr "Połączenie"
 
-#: src/muuli_wdr.cpp:1024 src/muuli_wdr.cpp:1867
+#: src/muuli_wdr.cpp:1024 src/muuli_wdr.cpp:1871
 msgid "Active downloads"
 msgstr "Aktywne pobierania"
 
@@ -3726,7 +3731,7 @@ msgstr "Aktywne pobierania"
 msgid "Active connections (1:1)"
 msgstr "Aktywnych połączeń (1:1)"
 
-#: src/muuli_wdr.cpp:1040 src/muuli_wdr.cpp:1868
+#: src/muuli_wdr.cpp:1040 src/muuli_wdr.cpp:1872
 msgid "Active uploads"
 msgstr "Aktywne wysyłania"
 
@@ -4002,7 +4007,7 @@ msgstr "Wiąż lokalne adresy z IP (puste dla każdego):"
 msgid "Advanced users only: If you have multiple network interfaces, enter the address of the interface to which aMule should be bound."
 msgstr "Tylko zaawansowani użytkownicy: Jeśli masz kilka interfejsów sieciowych, wpisz adres interfejsu do którego powiązany powinien być aMule."
 
-#: src/muuli_wdr.cpp:1462 src/muuli_wdr.cpp:2061
+#: src/muuli_wdr.cpp:1462 src/muuli_wdr.cpp:2065
 #, fuzzy
 msgid "Bind to network interface (empty for any):"
 msgstr "Wiąż lokalne adresy z IP (puste dla każdego):"
@@ -4019,7 +4024,7 @@ msgstr "Maks. ilość źródeł dla pobieranego pliku:"
 msgid "Max simultaneous connections:"
 msgstr "Maksymalne połączenia jednoczesne:"
 
-#: src/muuli_wdr.cpp:1498 src/muuli_wdr.cpp:3176
+#: src/muuli_wdr.cpp:1498 src/muuli_wdr.cpp:3207
 msgid "ED2K"
 msgstr "ED2K"
 
@@ -4111,757 +4116,780 @@ msgstr "Alokuj wstępnie przestrzeń dyskową dla nowych plików"
 msgid "For new files preallocates disk space for the whole file, thus reduces fragmentation"
 msgstr "Dla nowych plików alokuje wstępnie przestrzeń dyskową dla całego pliku redukując w ten sposób fragmentację"
 
-#: src/muuli_wdr.cpp:1613
+#: src/muuli_wdr.cpp:1617
 msgid "Create new files as sparse files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1614
-msgid "A sparse file reserves its full size on disk immediately without writing real data to it -- fast, but unsupported or slow on some filesystems, and free-space accounting stays optimistic while the download is in progress. Turn this off to grow the file only as data arrives."
+#: src/muuli_wdr.cpp:1618
+msgid "Sparse part files only occupy disk space for the parts already downloaded, so free space is used up gradually as the file fills in. Turn this off to use an ordinary file instead - useful where sparse files are unsupported or slow, or where backup/de-duplication tools handle them badly. Applies only when the core runs on Windows; on Linux and macOS part files are sparse anyway and this setting has no effect."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1619
+#: src/muuli_wdr.cpp:1623
 msgid "Stop downloads when free disk space reaches "
 msgstr "Zatrzymaj pobieranie gdy zabraknie wolnego miejsca na dysku"
 
-#: src/muuli_wdr.cpp:1620
+#: src/muuli_wdr.cpp:1624
 msgid "Select this if you want aMule to check your disk space"
 msgstr "Zaznacz jeśli chcesz, aby aMule sprawdzał Twoją przestrzeń dyskową"
 
-#: src/muuli_wdr.cpp:1624
+#: src/muuli_wdr.cpp:1628
 msgid "Enter here the min disk space desired."
 msgstr "Wpisz tu minimalną ilość miejsca na dysku."
 
-#: src/muuli_wdr.cpp:1630
+#: src/muuli_wdr.cpp:1634
 msgid "Save 10 sources on rare files (< 20 sources)"
 msgstr "Zapisz 10 źródeł dla rzadkich plików (< 20 źródeł)"
 
-#: src/muuli_wdr.cpp:1634 src/Statistics.cpp:790
+#: src/muuli_wdr.cpp:1638 src/Statistics.cpp:790
 msgid "Uploads"
 msgstr "Wysyłanie"
 
-#: src/muuli_wdr.cpp:1637
+#: src/muuli_wdr.cpp:1641
 msgid "Add new shared files with auto priority"
 msgstr "Dodaj udostępnione pliki z automatycznym priorytetem"
 
-#: src/muuli_wdr.cpp:1643
+#: src/muuli_wdr.cpp:1647
 msgid "Intelligent Corruption Handling (I.C.H.)"
 msgstr "Inteligentna obsługa uszkodzeń (I.C.H.)"
 
-#: src/muuli_wdr.cpp:1646
+#: src/muuli_wdr.cpp:1650
 msgid "Enable"
 msgstr "Włączone"
 
-#: src/muuli_wdr.cpp:1649
+#: src/muuli_wdr.cpp:1653
 msgid "Advanced I.C.H. trusts every hash (not recommended)"
 msgstr "Zaawansowane I.C.H. ufa każdemu skrótu (nie zalecane)"
 
-#: src/muuli_wdr.cpp:1661 src/PrefsUnifiedDlg.cpp:1910
+#: src/muuli_wdr.cpp:1665 src/PrefsUnifiedDlg.cpp:1990
 msgid "Media metadata extraction"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1665
+#: src/muuli_wdr.cpp:1669
 msgid "Extract length / bitrate / codec from shared audio and video files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1667
+#: src/muuli_wdr.cpp:1671
 msgid "When enabled, aMule runs ffprobe on each shared media file to fill in the Length / Bitrate / Codec columns other clients see when they find the file in a search. Requires ffmpeg (the ffprobe binary) to be installed."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1674
+#: src/muuli_wdr.cpp:1678
 msgid "Path to ffprobe:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1679
+#: src/muuli_wdr.cpp:1683
 msgid "Full path to the ffprobe binary. Leave empty to have aMule auto-detect it on startup."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1687
+#: src/muuli_wdr.cpp:1691
 msgid "Detect"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1688
+#: src/muuli_wdr.cpp:1692
 msgid "Search the standard install locations for an ffprobe binary and fill the path field."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1712
+#: src/muuli_wdr.cpp:1716
 msgid ""
 "Completed downloads are stored here. All files in this folder are automatically shared with other peers.\n"
 "If this folder also holds files you don't want to share, point it at an aMule-only sub-folder."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1715
+#: src/muuli_wdr.cpp:1719
 msgid "Pick the folder where completed downloads will be stored. All files in that folder will be shared with other peers."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1729
+#: src/muuli_wdr.cpp:1733
 msgid "Shared folders"
 msgstr "Udostępnione foldery"
 
-#: src/muuli_wdr.cpp:1735
+#: src/muuli_wdr.cpp:1739
 msgid "(Folders shared by the core. Enter a path to add one.)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1743
+#: src/muuli_wdr.cpp:1747
 msgid "Absolute path of a folder on the core's machine, e.g. /home/user/shared"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1745 src/PrefsUnifiedDlg.cpp:2794
+#: src/muuli_wdr.cpp:1749 src/PrefsUnifiedDlg.cpp:2874
 msgid "Recursive"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1746
+#: src/muuli_wdr.cpp:1750
 msgid "Share every sub-folder underneath this one, including ones created later."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1750 src/utils/aLinkCreator/src/alcframe.cpp:141
+#: src/muuli_wdr.cpp:1754 src/utils/aLinkCreator/src/alcframe.cpp:141
 msgid "Remove"
 msgstr "Usuń"
 
-#: src/muuli_wdr.cpp:1754
+#: src/muuli_wdr.cpp:1758
 msgid "(Right click on folder icon for recursive share)"
 msgstr "(Kliknij prawym przyciskiem na katalog, aby udostępnić go razem z podkatalogami)"
 
-#: src/muuli_wdr.cpp:1761
+#: src/muuli_wdr.cpp:1765
 msgid "Share hidden files"
 msgstr "Udostępnij pliki ukryte"
 
-#: src/muuli_wdr.cpp:1767
+#: src/muuli_wdr.cpp:1771
 msgid "Automatically rescan shared folders for changes"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1773
+#: src/muuli_wdr.cpp:1777
 msgid "Follow symbolic links in shared folders"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1779
+#: src/muuli_wdr.cpp:1783
 msgid "Exclude files matching:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1782
+#: src/muuli_wdr.cpp:1786
 msgid "Wildcard patterns separated by '|', e.g. .DS_Store|Thumbs.db|*.tmp. Files whose name matches are not shared. Matching is case-insensitive."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1786
+#: src/muuli_wdr.cpp:1790
 msgid "Patterns are regular expressions"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1787
+#: src/muuli_wdr.cpp:1791
 msgid "When set, the whole field is one regular expression ('|' is alternation). When unset, it is a list of '|'-separated wildcards."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1797
+#: src/muuli_wdr.cpp:1801
 msgid "Show how many shared files the current pattern would exclude."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1818
+#: src/muuli_wdr.cpp:1822
 msgid "Graphs"
 msgstr "Wykresy"
 
-#: src/muuli_wdr.cpp:1821 src/muuli_wdr.cpp:1883
+#: src/muuli_wdr.cpp:1825 src/muuli_wdr.cpp:1887
 msgid "Update delay : 5 secs"
 msgstr "Odśwież co : 5 sekund"
 
-#: src/muuli_wdr.cpp:1825
+#: src/muuli_wdr.cpp:1829
 msgid "Time for average graph: 100 mins"
 msgstr "Czas dla wykresów średnich: 100 minut"
 
-#: src/muuli_wdr.cpp:1829
+#: src/muuli_wdr.cpp:1833
 msgid "Connections Graph Scale: 100 "
 msgstr "Skala wykresu połączeń: 100"
 
-#: src/muuli_wdr.cpp:1836
+#: src/muuli_wdr.cpp:1840
 msgid "Download graph scale:"
 msgstr "Skala wykresu pobierania:"
 
-#: src/muuli_wdr.cpp:1844
+#: src/muuli_wdr.cpp:1848
 msgid "Upload graph scale:"
 msgstr "Skala wykresu przesyłania:"
 
-#: src/muuli_wdr.cpp:1854
+#: src/muuli_wdr.cpp:1858
 #, fuzzy
 msgid "Colors: "
 msgstr "Kolory: "
 
-#: src/muuli_wdr.cpp:1858
+#: src/muuli_wdr.cpp:1862
 msgid "Background"
 msgstr "Tło"
 
-#: src/muuli_wdr.cpp:1859
+#: src/muuli_wdr.cpp:1863
 msgid "Grid"
 msgstr "Siatka"
 
-#: src/muuli_wdr.cpp:1860
+#: src/muuli_wdr.cpp:1864
 msgid "Download current"
 msgstr "Aktualnie pobierane"
 
-#: src/muuli_wdr.cpp:1861
+#: src/muuli_wdr.cpp:1865
 msgid "Download running average"
 msgstr "Bieżąca średnia pobierania"
 
-#: src/muuli_wdr.cpp:1862
+#: src/muuli_wdr.cpp:1866
 msgid "Download session average"
 msgstr "Średnia pobierania sesji"
 
-#: src/muuli_wdr.cpp:1863
+#: src/muuli_wdr.cpp:1867
 msgid "Upload current"
 msgstr "Aktualnie wysyłane"
 
-#: src/muuli_wdr.cpp:1864
+#: src/muuli_wdr.cpp:1868
 msgid "Upload running average"
 msgstr "Bieżąca średnia wysyłania"
 
-#: src/muuli_wdr.cpp:1865
+#: src/muuli_wdr.cpp:1869
 msgid "Upload session average"
 msgstr "Średnia wysyłania sesji"
 
-#: src/muuli_wdr.cpp:1866
+#: src/muuli_wdr.cpp:1870
 msgid "Active connections"
 msgstr "Aktywnych połączeń"
 
-#: src/muuli_wdr.cpp:1869
+#: src/muuli_wdr.cpp:1873
 #, fuzzy
 msgid "Systray Icon Speed Bar"
 msgstr "Ikona prędkości w zasobniku systemowym"
 
-#: src/muuli_wdr.cpp:1870
+#: src/muuli_wdr.cpp:1874
 msgid "Kad-nodes current"
 msgstr "Obecne Kad-węzły "
 
-#: src/muuli_wdr.cpp:1871
+#: src/muuli_wdr.cpp:1875
 msgid "Kad-nodes running"
 msgstr "Działające Kad-węzły"
 
-#: src/muuli_wdr.cpp:1872
+#: src/muuli_wdr.cpp:1876
 msgid "Kad-nodes session"
 msgstr "Sesyjne Kad-węzły"
 
-#: src/muuli_wdr.cpp:1876 src/muuli_wdr.cpp:2303
+#: src/muuli_wdr.cpp:1880 src/muuli_wdr.cpp:2334
 msgid "Select"
 msgstr "Wybierz"
 
-#: src/muuli_wdr.cpp:1880
+#: src/muuli_wdr.cpp:1884
 msgid "Tree"
 msgstr "Drzewo"
 
-#: src/muuli_wdr.cpp:1890
+#: src/muuli_wdr.cpp:1894
 msgid "Number of Client Versions shown (0=unlimited)"
 msgstr "Liczba wyświetlanych wersji klienta (0=nieograniczona)"
 
-#: src/muuli_wdr.cpp:1915
+#: src/muuli_wdr.cpp:1919
 msgid "!!! WARNING !!!"
 msgstr "!!! UWAGA !!!"
 
-#: src/muuli_wdr.cpp:1930
+#: src/muuli_wdr.cpp:1934
 msgid "Max new connections / 5 secs"
 msgstr "Maks. nowych połączeń"
 
-#: src/muuli_wdr.cpp:1932
+#: src/muuli_wdr.cpp:1936
 msgid "Concurrent Kad source lookups"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1934
+#: src/muuli_wdr.cpp:1938
 #, fuzzy
 msgid "Kad source re-search interval (minutes)"
 msgstr "Czas pomiędzy odświeżeniami FTP w minutach"
 
-#: src/muuli_wdr.cpp:1936
+#: src/muuli_wdr.cpp:1940
 #, fuzzy
 msgid "Source re-ask interval (minutes)"
 msgstr "Czas pomiędzy odświeżeniami FTP w minutach"
 
-#: src/muuli_wdr.cpp:1940
+#: src/muuli_wdr.cpp:1944
 msgid "File Buffer Size: 240000 bytes"
 msgstr "Rozmiar bufora plików: 240000 bajtów"
 
-#: src/muuli_wdr.cpp:1944
+#: src/muuli_wdr.cpp:1948
 msgid "Use MMAP: memory-mapped file access (lower memory use)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1945
+#: src/muuli_wdr.cpp:1949
 msgid "Maps part files into memory instead of buffering them on the heap, lowering the process memory footprint. May reduce download speed on some disks; best for memory-constrained or upload-heavy hosts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1947
+#: src/muuli_wdr.cpp:1951
 msgid "Upload Queue Size: 5000 clients"
 msgstr "Rozmiar kolejki wysyłania: 5000 klientów"
 
-#: src/muuli_wdr.cpp:1951
+#: src/muuli_wdr.cpp:1955
 msgid "Server connection refresh interval: Disable"
 msgstr "Odświeżanie połączeń do serwera co: Wyłączone"
 
-#: src/muuli_wdr.cpp:1955
+#: src/muuli_wdr.cpp:1959
 msgid "Disable computer's timed standby mode"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1974
+#: src/muuli_wdr.cpp:1978
 msgid "Skin to use: "
 msgstr "Skóra do użycia:"
 
-#: src/muuli_wdr.cpp:1983
+#: src/muuli_wdr.cpp:1987
 msgid "Show \"Fast eD2k Links Handler\" in every window."
 msgstr "Pokazuj \"Szybkie wyłapywanie linków eD2K\" w każdym oknie."
 
-#: src/muuli_wdr.cpp:1986
+#: src/muuli_wdr.cpp:1990
 msgid "Show extended info on categories tabs"
 msgstr "Pokaż rozszerzone info w kartach kategorii"
 
-#: src/muuli_wdr.cpp:1989
+#: src/muuli_wdr.cpp:1993
 #, fuzzy
 msgid "Show application version on title"
 msgstr "Pokaż prędkość transferu w tytule"
 
-#: src/muuli_wdr.cpp:1991
+#: src/muuli_wdr.cpp:1995
 msgid "Show transfer rates on title"
 msgstr "Pokaż prędkość transferu w tytule"
 
-#: src/muuli_wdr.cpp:1993
+#: src/muuli_wdr.cpp:1997
 msgid "Before application name"
 msgstr "Przed nazwą aplikacji"
 
-#: src/muuli_wdr.cpp:1995
+#: src/muuli_wdr.cpp:1999
 msgid "After application name"
 msgstr "Za nazwą aplikacji"
 
-#: src/muuli_wdr.cpp:1998
+#: src/muuli_wdr.cpp:2002
 msgid "Show overhead bandwidth"
 msgstr "Pokaż narzut przepustowości"
 
-#: src/muuli_wdr.cpp:2002
+#: src/muuli_wdr.cpp:2006
 msgid "Vertical toolbar orientation"
 msgstr "Pionowa orientacja paska narzędzi"
 
-#: src/muuli_wdr.cpp:2004
+#: src/muuli_wdr.cpp:2008
 msgid "Live column sorting (auto-reorder rows as their values change)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2011
+#: src/muuli_wdr.cpp:2015
 msgid "Download Queue Files"
 msgstr "Pobierane pliki w kolejce"
 
-#: src/muuli_wdr.cpp:2014
+#: src/muuli_wdr.cpp:2018
 msgid "Show progress percentage"
 msgstr "Pokaż procent postępu"
 
-#: src/muuli_wdr.cpp:2020
+#: src/muuli_wdr.cpp:2024
 msgid "Show progress bar"
 msgstr "Pokaż pasek postępu"
 
-#: src/muuli_wdr.cpp:2023
+#: src/muuli_wdr.cpp:2027
 msgid "Flat"
 msgstr "Płaski"
 
-#: src/muuli_wdr.cpp:2027
+#: src/muuli_wdr.cpp:2031
 msgid "Round"
 msgstr "Okrągły"
 
-#: src/muuli_wdr.cpp:2045
+#: src/muuli_wdr.cpp:2049
 msgid "External Connection Parameters"
 msgstr "Parametry zewnętrznych połączeń"
 
-#: src/muuli_wdr.cpp:2048
+#: src/muuli_wdr.cpp:2052
 msgid "Accept external connections"
 msgstr "Akceptuj zewnętrzne połączenia"
 
-#: src/muuli_wdr.cpp:2055 src/muuli_wdr.cpp:2114
+#: src/muuli_wdr.cpp:2059 src/muuli_wdr.cpp:2118
 msgid "IP of the listening interface:"
 msgstr "IP z interfejsem słuchania:"
 
-#: src/muuli_wdr.cpp:2058
+#: src/muuli_wdr.cpp:2062
 msgid "Enter here a valid ip in the a.b.c.d format for the listening EC interface. An empty field or 0.0.0.0 will mean any interface."
 msgstr "Wprowadź tutaj w formacie a.b.c.d prawidłowy adres ip nasłuchującego interfejsu EC. Puste pole lub 0.0.0.0 oznacza dowolny interfejs."
 
-#: src/muuli_wdr.cpp:2079 src/muuli_wdr.cpp:2163
+#: src/muuli_wdr.cpp:2083 src/muuli_wdr.cpp:2194
 msgid "TCP port:"
 msgstr "Port TCP:"
 
-#: src/muuli_wdr.cpp:2085
+#: src/muuli_wdr.cpp:2089
 msgid "Enable UPnP port forwarding on the EC port"
 msgstr "Włącz forwarding portu UPnP na porcie EC"
 
-#: src/muuli_wdr.cpp:2089 src/muuli_wdr.cpp:3048
+#: src/muuli_wdr.cpp:2093 src/muuli_wdr.cpp:3079
 #: src/utils/wxCas/src/wxcasprefs.cpp:167
 msgid "Password"
 msgstr "Hasło"
 
-#: src/muuli_wdr.cpp:2095
+#: src/muuli_wdr.cpp:2099
 #, fuzzy
 msgid "aMule API server parameters"
 msgstr "Parametry serwera sieciowego"
 
-#: src/muuli_wdr.cpp:2098
+#: src/muuli_wdr.cpp:2102
 msgid "Run amuleapi (REST API) on startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2103
+#: src/muuli_wdr.cpp:2107
 #, fuzzy
 msgid "HTTP port:"
 msgstr "Port TCP:"
 
-#: src/muuli_wdr.cpp:2117
+#: src/muuli_wdr.cpp:2121
 msgid "The interface amuleapi's HTTP server listens on. 127.0.0.1 (default) accepts only local connections; use 0.0.0.0 or a specific IP to expose it to other hosts (set an admin password below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2120
+#: src/muuli_wdr.cpp:2126
+msgid "Type a password to set or change it. Stored passwords cannot be shown, so leaving this empty keeps the current one."
+msgstr ""
+
+#: src/muuli_wdr.cpp:2128
 #, fuzzy
 msgid "Admin password"
 msgstr "Sprawdzam hasło\n"
 
-#: src/muuli_wdr.cpp:2125 src/muuli_wdr.cpp:2156
-msgid "Low rights password"
-msgstr "Hasło niskich uprawnień"
+#: src/muuli_wdr.cpp:2140 src/muuli_wdr.cpp:2157 src/PrefsUnifiedDlg.cpp:1103
+#, fuzzy
+msgid "A password is set."
+msgstr "Sprawdzam hasło\n"
 
-#: src/muuli_wdr.cpp:2133
+#: src/muuli_wdr.cpp:2144
+#, fuzzy
+msgid "Enable guest access"
+msgstr "Zabroń dostępu gościom"
+
+#: src/muuli_wdr.cpp:2145
+msgid "Guest sessions may read status and listings but cannot change anything. Turning this off clears the stored guest password."
+msgstr ""
+
+#: src/muuli_wdr.cpp:2149
+#, fuzzy
+msgid "Guest password"
+msgstr "Hasło gościa do serwera sieciowego"
+
+#: src/muuli_wdr.cpp:2164
 msgid "Web server parameters"
 msgstr "Parametry serwera sieciowego"
 
-#: src/muuli_wdr.cpp:2136
+#: src/muuli_wdr.cpp:2167
 #, fuzzy
 msgid "Run webserver on startup (deprecated)"
 msgstr "Uruchom serwera internetowego przy starcie"
 
-#: src/muuli_wdr.cpp:2142
+#: src/muuli_wdr.cpp:2173
 msgid "Web template"
 msgstr "Szablon WWW"
 
-#: src/muuli_wdr.cpp:2147
+#: src/muuli_wdr.cpp:2178
 msgid "Full rights password"
 msgstr "Hasło pełnych uprawnień"
 
-#: src/muuli_wdr.cpp:2151
+#: src/muuli_wdr.cpp:2182
 msgid "Enable Low rights User"
 msgstr "Włącz użytkowników z niskimi uprawnieniami"
 
-#: src/muuli_wdr.cpp:2170
+#: src/muuli_wdr.cpp:2187
+msgid "Low rights password"
+msgstr "Hasło niskich uprawnień"
+
+#: src/muuli_wdr.cpp:2201
 msgid "Enable UPnP port forwarding of the web server port"
 msgstr "Włącz przekierowanie portu UPnP na port serwera internetowego"
 
-#: src/muuli_wdr.cpp:2175
+#: src/muuli_wdr.cpp:2206
 msgid "Web server UPnP TCP port (Optional)"
 msgstr "Port web serwera UPnP TCP (opcjonalnie)"
 
-#: src/muuli_wdr.cpp:2183
+#: src/muuli_wdr.cpp:2214
 msgid "Page Refresh Time (in secs)"
 msgstr "Odświeżanie strony co:  (w sekundach)"
 
-#: src/muuli_wdr.cpp:2190
+#: src/muuli_wdr.cpp:2221
 msgid "Enable Gzip compression"
 msgstr "Włącz kompresję Gzip"
 
-#: src/muuli_wdr.cpp:2224
+#: src/muuli_wdr.cpp:2255
 #, fuzzy
 msgid "Reset page to defaults"
 msgstr "Domyślny systemowy"
 
-#: src/muuli_wdr.cpp:2225
+#: src/muuli_wdr.cpp:2256
 msgid "Reset the settings on the current page to their default values."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2227 src/muuli_wdr.cpp:2313 src/ServerWnd.cpp:274
+#: src/muuli_wdr.cpp:2258 src/muuli_wdr.cpp:2344 src/ServerWnd.cpp:274
 #: src/ServerWnd.cpp:282
 msgid "OK"
 msgstr "OK"
 
-#: src/muuli_wdr.cpp:2229
+#: src/muuli_wdr.cpp:2260
 msgid "Click here to apply any changes made to the preferences."
 msgstr "Kliknij tu aby zastosować wszystkie zmiany dokonane w preferencjach."
 
-#: src/muuli_wdr.cpp:2232
+#: src/muuli_wdr.cpp:2263
 msgid "Reset any changes made to the preferences."
 msgstr "Reset wszystkich zmian dokonanych w preferencjach."
 
-#: src/muuli_wdr.cpp:2261
+#: src/muuli_wdr.cpp:2292
 msgid "Comment :"
 msgstr "Komentarz :"
 
-#: src/muuli_wdr.cpp:2268
+#: src/muuli_wdr.cpp:2299
 msgid "Incoming Dir :"
 msgstr "Katalog przychodzących :"
 
-#: src/muuli_wdr.cpp:2277
+#: src/muuli_wdr.cpp:2308
 msgid "Change priority for new assigned files :"
 msgstr "Zmień priorytet nowo przydzielonych plików :"
 
-#: src/muuli_wdr.cpp:2281
+#: src/muuli_wdr.cpp:2312
 #, fuzzy
 msgid "Don't change"
 msgstr "Nie zmieniaj"
 
-#: src/muuli_wdr.cpp:2293
+#: src/muuli_wdr.cpp:2324
 msgid "Select color for this Category (currently selected) :"
 msgstr "Wybierz kolor dla tej kategorii (aktualnie wybrany) :"
 
-#: src/muuli_wdr.cpp:2360 src/muuli_wdr.cpp:2379 src/muuli_wdr.cpp:2401
+#: src/muuli_wdr.cpp:2391 src/muuli_wdr.cpp:2410 src/muuli_wdr.cpp:2432
 msgid "Click this button to reset the log."
 msgstr "Kliknij tu aby wyczyścić logi."
 
-#: src/muuli_wdr.cpp:2420
+#: src/muuli_wdr.cpp:2451
 msgid "Click on this button to update the servers list from URL ..."
 msgstr "Kliknij na tym przycisku aby uaktualnić listę serwerów z URL-a ..."
 
-#: src/muuli_wdr.cpp:2424
+#: src/muuli_wdr.cpp:2455
 msgid "Server list"
 msgstr "Lista serwerów"
 
-#: src/muuli_wdr.cpp:2428
+#: src/muuli_wdr.cpp:2459
 msgid "Enter the url to a server.met file here and press the button to the left to update the list of known servers."
 msgstr "Wpisz tu url do pliku server.met  i przyciśnij przycisk po lewej aby zaktualizować listę znanych serwerów."
 
-#: src/muuli_wdr.cpp:2433
+#: src/muuli_wdr.cpp:2464
 msgid "Add server manually: Name"
 msgstr "Dodaj serwer ręcznie: Nazwa"
 
-#: src/muuli_wdr.cpp:2436
+#: src/muuli_wdr.cpp:2467
 msgid "Enter the name of the new server here"
 msgstr "Wpisz tu nazwę nowego serwera"
 
-#: src/muuli_wdr.cpp:2438 src/ServerWnd.cpp:206
+#: src/muuli_wdr.cpp:2469 src/ServerWnd.cpp:206
 msgid "IP:Port"
 msgstr "IP:Port"
 
-#: src/muuli_wdr.cpp:2441
+#: src/muuli_wdr.cpp:2472
 msgid "Enter the IP of the server here, using the x.x.x.x format."
 msgstr "Wpisz tu IP serwera, używając formatu x.x.x.x ."
 
-#: src/muuli_wdr.cpp:2447
+#: src/muuli_wdr.cpp:2478
 msgid "Enter the port of the server here."
 msgstr "Wpisz tu port serwera."
 
-#: src/muuli_wdr.cpp:2450
+#: src/muuli_wdr.cpp:2481
 msgid "Add manually a server (fill fields to the left before) ..."
 msgstr "Dodaj ręcznie serwer (wypełnij pola od lewej) ..."
 
-#: src/muuli_wdr.cpp:2479
+#: src/muuli_wdr.cpp:2510
 msgid "aMule Log"
 msgstr "Logi aMule"
 
-#: src/muuli_wdr.cpp:2487
+#: src/muuli_wdr.cpp:2518
 msgid "Server Info"
 msgstr "Serwer Info"
 
-#: src/muuli_wdr.cpp:2491
+#: src/muuli_wdr.cpp:2522
 msgid "ED2K Info"
 msgstr "Info eD2K"
 
-#: src/muuli_wdr.cpp:2495
+#: src/muuli_wdr.cpp:2526
 msgid "Kad Info"
 msgstr "Info Kad"
 
-#: src/muuli_wdr.cpp:2523
+#: src/muuli_wdr.cpp:2554
 msgid "Click on this button to update the nodes list from URL ..."
 msgstr "Kliknij ten przycisk, aby uaktualnić listę węzłów z adresu URL ..."
 
-#: src/muuli_wdr.cpp:2527
+#: src/muuli_wdr.cpp:2558
 msgid "Nodes (0)"
 msgstr "Węzły (0)"
 
-#: src/muuli_wdr.cpp:2531
+#: src/muuli_wdr.cpp:2562
 msgid "Enter the url to a nodes.dat file here and press the button to the left to update the list of known nodes."
 msgstr "Wprowadź tutaj url pliku nodes.dat i naciśnij przycisk z lewej, aby zaktualizować listę znanych węzłów."
 
-#: src/muuli_wdr.cpp:2534
+#: src/muuli_wdr.cpp:2565
 msgid "Nodes stats"
 msgstr "Statystyki węzłów"
 
-#: src/muuli_wdr.cpp:2576
+#: src/muuli_wdr.cpp:2607
 msgid "Bootstrap"
 msgstr "Bootstrap"
 
-#: src/muuli_wdr.cpp:2579
+#: src/muuli_wdr.cpp:2610
 msgid "New node"
 msgstr "Nowy węzeł"
 
-#: src/muuli_wdr.cpp:2584
+#: src/muuli_wdr.cpp:2615
 msgid "IP:"
 msgstr "IP:"
 
-#: src/muuli_wdr.cpp:2604
+#: src/muuli_wdr.cpp:2635
 msgid "Port:"
 msgstr "Port:"
 
-#: src/muuli_wdr.cpp:2617
+#: src/muuli_wdr.cpp:2648
 msgid "Bootstrap from known clients"
 msgstr "Rozruch od znanych klientów"
 
-#: src/muuli_wdr.cpp:2619
+#: src/muuli_wdr.cpp:2650
 msgid "Disconnect Kad"
 msgstr "Rozłącz z Kad"
 
-#: src/muuli_wdr.cpp:2653
+#: src/muuli_wdr.cpp:2684
 msgid "Use Secure User Identification"
 msgstr "Użyj bezpiecznej identyfikacji użytkownika"
 
-#: src/muuli_wdr.cpp:2655
+#: src/muuli_wdr.cpp:2686
 msgid "It is recommended to enable this option. You will not receive credits if SUI is not enabled."
 msgstr "Zalecane jest włączenie tej opcji. Nic nie zyskasz wyłączając bezpieczną identyfikację użytkownika."
 
-#: src/muuli_wdr.cpp:2657
+#: src/muuli_wdr.cpp:2688
 msgid "Protocol Obfuscation"
 msgstr "Maskowanie protokołu"
 
-#: src/muuli_wdr.cpp:2660
+#: src/muuli_wdr.cpp:2691
 msgid "Support Protocol Obfuscation"
 msgstr "Obsługa maskowania protokołu"
 
-#: src/muuli_wdr.cpp:2662
+#: src/muuli_wdr.cpp:2693
 msgid "This option enabled Protocol Obfuscation, and makes aMule accept obfuscated connections from other clients."
 msgstr "Opcja ta włącza maskowanie protokołu i powoduje, że aMule będzie akceptował zamaskowane połączenia od innych klientów."
 
-#: src/muuli_wdr.cpp:2664
+#: src/muuli_wdr.cpp:2695
 msgid "Use obfuscation for outgoing connections"
 msgstr "Użyj maskowania dla połączeń wychodzących"
 
-#: src/muuli_wdr.cpp:2666
+#: src/muuli_wdr.cpp:2697
 msgid "This option makes aMule use Protocol Obfuscation when connecting other clients/servers."
 msgstr "Opcja ta powoduje, że aMule będzie używał maskowania protokołu podczas łączenia z innymi klientami/serwerami."
 
-#: src/muuli_wdr.cpp:2668
+#: src/muuli_wdr.cpp:2699
 msgid "Accept only obfuscated connections"
 msgstr "Akceptuj tylko zamaskowane połączenia"
 
-#: src/muuli_wdr.cpp:2669
+#: src/muuli_wdr.cpp:2700
 msgid "This option makes aMule only accept obfuscated connections. You will have less sources, but all your traffic will be obfuscated"
 msgstr "Opcja ta powoduje, że aMule akceptuje tylko zamaskowane połączenia. Uzyskasz mniej źródeł, ale cały twój ruch będzie zamaskowany"
 
-#: src/muuli_wdr.cpp:2674
+#: src/muuli_wdr.cpp:2705
 msgid "Everybody"
 msgstr "Wszyscy"
 
-#: src/muuli_wdr.cpp:2676
+#: src/muuli_wdr.cpp:2707
 msgid "No one"
 msgstr "Nikt"
 
-#: src/muuli_wdr.cpp:2678
+#: src/muuli_wdr.cpp:2709
 msgid "Who can see my shared files:"
 msgstr "Kto może widzieć moje udostępnione pliki:"
 
-#: src/muuli_wdr.cpp:2679
+#: src/muuli_wdr.cpp:2710
 msgid "Select who can request to view a list of your shared files."
 msgstr "Wybierz kto może zażądać pokazania listy twoich udostępnionych plików."
 
-#: src/muuli_wdr.cpp:2681
+#: src/muuli_wdr.cpp:2712
 msgid "IP-Filtering"
 msgstr "Filtrowanie IP"
 
-#: src/muuli_wdr.cpp:2688
+#: src/muuli_wdr.cpp:2719
 msgid "Filter clients"
 msgstr "Filtruj klientów"
 
-#: src/muuli_wdr.cpp:2690
+#: src/muuli_wdr.cpp:2721
 msgid "Enable filtering of the client IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "Włącza filtrowanie IP klientów zdefiniowanych w pliku ~/.aMule/ipfilter.dat."
 
-#: src/muuli_wdr.cpp:2692
+#: src/muuli_wdr.cpp:2723
 msgid "Filter servers"
 msgstr "Filtruj serwery"
 
-#: src/muuli_wdr.cpp:2694
+#: src/muuli_wdr.cpp:2725
 msgid "Enable filtering of the server IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "Włącza filtrowanie IP serwerów zdefiniowanych w pliku ~/.aMule/ipfilter.dat."
 
-#: src/muuli_wdr.cpp:2698
+#: src/muuli_wdr.cpp:2729
 msgid "Reload List"
 msgstr "Przeładuj listę"
 
-#: src/muuli_wdr.cpp:2699
+#: src/muuli_wdr.cpp:2730
 msgid "Reload the list of IPs to filter from the file ~/.aMule/ipfilter.dat"
 msgstr "Przeładuj listę filtrowanych IP z pliku ~/.aMule/ipfilter.dat"
 
-#: src/muuli_wdr.cpp:2705
+#: src/muuli_wdr.cpp:2736
 msgid "URL:"
 msgstr "URL:"
 
-#: src/muuli_wdr.cpp:2709 src/muuli_wdr.cpp:2902
+#: src/muuli_wdr.cpp:2740 src/muuli_wdr.cpp:2933
 msgid "Update now"
 msgstr "Uaktualnij teraz"
 
-#: src/muuli_wdr.cpp:2712
+#: src/muuli_wdr.cpp:2743
 msgid "Auto-update ipfilter at startup"
 msgstr "Uaktualniaj filtr IP przy starcie"
 
-#: src/muuli_wdr.cpp:2716
+#: src/muuli_wdr.cpp:2747
 msgid "Filtering Level:"
 msgstr "Poziom filtrowania:"
 
-#: src/muuli_wdr.cpp:2722
+#: src/muuli_wdr.cpp:2753
 msgid "Always filter LAN IPs"
 msgstr "Zawsze filtruj IP z LAN"
 
-#: src/muuli_wdr.cpp:2725
+#: src/muuli_wdr.cpp:2756
 msgid "Paranoid handling of non-matching IPs"
 msgstr "Paranoidalna obsługa niepasujących IP"
 
-#: src/muuli_wdr.cpp:2727
+#: src/muuli_wdr.cpp:2758
 msgid "Rejects a packet when its source IP differs from the IP the client claims (an anti-spoofing check). Disable only if it causes connection problems."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2729
+#: src/muuli_wdr.cpp:2760
 msgid "Use system-wide ipfilter.dat if available"
 msgstr "Użyj ogólno-systemowego ipfilter.dat jeśli dostępny"
 
-#: src/muuli_wdr.cpp:2730
+#: src/muuli_wdr.cpp:2761
 #, fuzzy
 msgid "If there's no local ipfilter.dat found, allow usage of a system-wide ipfilter file."
 msgstr "Jeśli ipfilter.dat nie istnieje lokalnie, zezwól na użycie ogólno-systemowego pliku ipfilter."
 
-#: src/muuli_wdr.cpp:2747
+#: src/muuli_wdr.cpp:2778
 msgid "Enable Online-Signature"
 msgstr "Włącz podpis online"
 
-#: src/muuli_wdr.cpp:2749
+#: src/muuli_wdr.cpp:2780
 msgid "Enables the writing of the OS file, which can be used by external apps to create signatures and the like."
 msgstr "Włącza zapisywanie pliku OS, który może być użyty przez zewnętrzne aplikacje do stworzenia sygnatury itp."
 
-#: src/muuli_wdr.cpp:2753
+#: src/muuli_wdr.cpp:2784
 msgid "Update Frequency (Secs):"
 msgstr "Częstotliwość odświeżania (sek):"
 
-#: src/muuli_wdr.cpp:2756
+#: src/muuli_wdr.cpp:2787
 msgid "Change the frequency (in seconds) of Online Signature updates."
 msgstr "Zmień częstotliwość (w sekundach) aktualizacji Sygnatury Online."
 
-#: src/muuli_wdr.cpp:2764
+#: src/muuli_wdr.cpp:2795
 msgid "Save online signature file in: "
 msgstr "Zapisz podpis internetowy w pliku: "
 
-#: src/muuli_wdr.cpp:2770
+#: src/muuli_wdr.cpp:2801
 msgid "Click here to select the directory containing the the Online Signature files."
 msgstr "Kliknij tu aby wskazać katalog zawierający pliki Sygnatur Online."
 
-#: src/muuli_wdr.cpp:2803
+#: src/muuli_wdr.cpp:2834
 msgid "Show country flags for clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2804
+#: src/muuli_wdr.cpp:2835
 msgid "Render the country flag column in the transfers, queue and search views. Requires a valid MMDB GeoIP database (see below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2809
+#: src/muuli_wdr.cpp:2840
 #, fuzzy
 msgid "Database"
 msgstr "Prędkość transmisji danych :"
 
-#: src/muuli_wdr.cpp:2825
+#: src/muuli_wdr.cpp:2856
 #, fuzzy
 msgid "Source:"
 msgstr "Źródła"
 
-#: src/muuli_wdr.cpp:2828
+#: src/muuli_wdr.cpp:2859
 msgid "DB-IP (free, no account)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2829
+#: src/muuli_wdr.cpp:2860
 msgid "MaxMind GeoLite2 (free, account required)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2830
+#: src/muuli_wdr.cpp:2861
 msgid "Custom URL"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2833
+#: src/muuli_wdr.cpp:2864
 msgid "Choose which provider supplies the GeoIP MMDB database. DB-IP is the default - no account required. MaxMind requires a free account + license key. Use Custom URL to point at any other MMDB host (e.g. a local mirror)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2850
+#: src/muuli_wdr.cpp:2881
 msgid ""
 "No configuration required.\n"
 "\n"
@@ -4869,11 +4897,11 @@ msgid ""
 "License: Creative Commons BY 4.0 - https://creativecommons.org/licenses/by/4.0/"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2863
+#: src/muuli_wdr.cpp:2894
 msgid "License key:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2869
+#: src/muuli_wdr.cpp:2900
 msgid ""
 "Sign up for a free MaxMind account, then generate a License Key:\n"
 "https://www.maxmind.com/en/geolite2/signup\n"
@@ -4883,231 +4911,231 @@ msgid ""
 "Requires attribution and account registration; refresh at least every 30 days."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2884
+#: src/muuli_wdr.cpp:2915
 #, fuzzy
 msgid "Download URL:"
 msgstr "Pobranych: "
 
-#: src/muuli_wdr.cpp:2890
+#: src/muuli_wdr.cpp:2921
 msgid ""
 "Must point to an .mmdb file or a .gz / .tar.gz containing one.\n"
 "URL may include credentials (https://user:pass@host/...).\n"
 "License and attribution terms are set by the upstream URL - you are responsible."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2903
+#: src/muuli_wdr.cpp:2934
 msgid "Download the GeoIP database from the selected source."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2905
+#: src/muuli_wdr.cpp:2936
 #, fuzzy
 msgid "Auto-update on startup"
 msgstr "Uaktualniaj filtr IP przy starcie"
 
-#: src/muuli_wdr.cpp:2906
+#: src/muuli_wdr.cpp:2937
 msgid "Re-download the GeoIP database from the selected source every time aMule starts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2929
+#: src/muuli_wdr.cpp:2960
 msgid "Filter incoming messages (except current chat):"
 msgstr "Filtruj wiadomości przychodzące (za wyjątkiem aktualnej rozmowy):"
 
-#: src/muuli_wdr.cpp:2931
+#: src/muuli_wdr.cpp:2962
 msgid "Filter all messages"
 msgstr "Filtruj wszystkie wiadomości"
 
-#: src/muuli_wdr.cpp:2933
+#: src/muuli_wdr.cpp:2964
 msgid "Filter messages from people not on your friend list"
 msgstr "Filtruj wiadomości od ludzi, którzy nie są na twojej liście znajomych"
 
-#: src/muuli_wdr.cpp:2935
+#: src/muuli_wdr.cpp:2966
 msgid "Filter messages from unknown clients"
 msgstr "Filtruj wiadomości od nieznanych klientów"
 
-#: src/muuli_wdr.cpp:2937
+#: src/muuli_wdr.cpp:2968
 msgid "Filter messages containing (use ',' as separator):"
 msgstr "Filtruj wiadomości zawierające (jako separatora użyj ','):"
 
-#: src/muuli_wdr.cpp:2940 src/muuli_wdr.cpp:2951
+#: src/muuli_wdr.cpp:2971 src/muuli_wdr.cpp:2982
 msgid "add here the words amule should filter and block messages including it"
 msgstr "dodaj frazy które według których amule powinien filtrować i blokować wiadomości"
 
-#: src/muuli_wdr.cpp:2942
+#: src/muuli_wdr.cpp:2973
 msgid "Show received messages in the log"
 msgstr "Pokaż otrzymane wiadomości w dzienniku"
 
-#: src/muuli_wdr.cpp:2945
+#: src/muuli_wdr.cpp:2976
 msgid "Comments"
 msgstr "Komentarze"
 
-#: src/muuli_wdr.cpp:2948
+#: src/muuli_wdr.cpp:2979
 msgid "Filter comments containing (use ',' as separator):"
 msgstr "Filtruj komentarze zawierające (użyj ',' jako separatora):"
 
-#: src/muuli_wdr.cpp:2973
+#: src/muuli_wdr.cpp:3004
 msgid "Enable Proxy"
 msgstr "Włącz proxy"
 
-#: src/muuli_wdr.cpp:2974
+#: src/muuli_wdr.cpp:3005
 msgid "Enable/disable proxy support"
 msgstr "Włącza/Wyłącza obsługę proxy"
 
-#: src/muuli_wdr.cpp:2977
+#: src/muuli_wdr.cpp:3008
 msgid "Proxy type:"
 msgstr "Typ proxy:"
 
-#: src/muuli_wdr.cpp:2988
+#: src/muuli_wdr.cpp:3019
 msgid "Proxy host:"
 msgstr "Adres proxy:"
 
-#: src/muuli_wdr.cpp:2991
+#: src/muuli_wdr.cpp:3022
 msgid "The proxy host name"
 msgstr "Nazwa hosta proxy"
 
-#: src/muuli_wdr.cpp:2993
+#: src/muuli_wdr.cpp:3024
 msgid "Proxy port:"
 msgstr "Port proxy:"
 
-#: src/muuli_wdr.cpp:2996
+#: src/muuli_wdr.cpp:3027
 msgid "The proxy port"
 msgstr "Port serwera proxy"
 
-#: src/muuli_wdr.cpp:2998
+#: src/muuli_wdr.cpp:3029
 msgid "Enable authentication"
 msgstr "Włącz uwierzytelnianie"
 
-#: src/muuli_wdr.cpp:2999
+#: src/muuli_wdr.cpp:3030
 msgid "Enable/disable username/password authentication"
 msgstr "Włącza/Wyłącza uwierzytelnianie login/hasło"
 
-#: src/muuli_wdr.cpp:3002
+#: src/muuli_wdr.cpp:3033
 msgid "Username: "
 msgstr "Nazwa uzytkownika: "
 
-#: src/muuli_wdr.cpp:3005
+#: src/muuli_wdr.cpp:3036
 msgid "The username to use to connect to the proxy"
 msgstr "Login używany do połączeń z proxy"
 
-#: src/muuli_wdr.cpp:3007
+#: src/muuli_wdr.cpp:3038
 msgid "Password:"
 msgstr "Hasło:"
 
-#: src/muuli_wdr.cpp:3010
+#: src/muuli_wdr.cpp:3041
 msgid "The password to use to connect to the proxy"
 msgstr "Hasło używane do połączeń z proxy"
 
-#: src/muuli_wdr.cpp:3029
+#: src/muuli_wdr.cpp:3060
 msgid "Connect to:"
 msgstr "Połącz z:"
 
-#: src/muuli_wdr.cpp:3038
+#: src/muuli_wdr.cpp:3069
 msgid "Login to remote amule"
 msgstr "Login do zdalnego amule"
 
-#: src/muuli_wdr.cpp:3043
+#: src/muuli_wdr.cpp:3074
 msgid "User name"
 msgstr "Nazwa użytkownika"
 
-#: src/muuli_wdr.cpp:3054
+#: src/muuli_wdr.cpp:3085
 msgid "Remember those settings"
 msgstr "Zapamiętaj te ustawienia"
 
-#: src/muuli_wdr.cpp:3057
+#: src/muuli_wdr.cpp:3088
 #, fuzzy
 msgid "Force ZLIB compression"
 msgstr "Używaj kompresji gzip"
 
-#: src/muuli_wdr.cpp:3081
+#: src/muuli_wdr.cpp:3112
 msgid "Enable Verbose Debug-Logging."
 msgstr "Włącz gadatliwe logowanie debugowe."
 
-#: src/muuli_wdr.cpp:3083
+#: src/muuli_wdr.cpp:3114
 #, fuzzy
 msgid "Only to Logfile"
 msgstr "&Otwórz plik"
 
-#: src/muuli_wdr.cpp:3085
+#: src/muuli_wdr.cpp:3116
 msgid "Message Categories:"
 msgstr "Kategorie wiadomości:"
 
-#: src/muuli_wdr.cpp:3109 src/PartFileConvertDlg.cpp:160
+#: src/muuli_wdr.cpp:3140 src/PartFileConvertDlg.cpp:160
 msgid "Waiting..."
 msgstr "Czekam..."
 
-#: src/muuli_wdr.cpp:3129
+#: src/muuli_wdr.cpp:3160
 msgid "Add imports"
 msgstr "Dodaj importy"
 
-#: src/muuli_wdr.cpp:3132
+#: src/muuli_wdr.cpp:3163
 msgid "Retry selected"
 msgstr "Przywróć wybrane"
 
-#: src/muuli_wdr.cpp:3134
+#: src/muuli_wdr.cpp:3165
 msgid "Remove selected"
 msgstr "Usuń wybrane"
 
-#: src/muuli_wdr.cpp:3197
+#: src/muuli_wdr.cpp:3228
 msgid "Event Types"
 msgstr "Typy zdarzeń"
 
-#: src/muuli_wdr.cpp:3216
+#: src/muuli_wdr.cpp:3247
 msgid "Statistics and queued clients for selected file(s) : Session / All time"
 msgstr "Statystyki i klienty w kolejce dla wybranego plik(u-ów) : Sesja / Cały czas"
 
-#: src/muuli_wdr.cpp:3240
+#: src/muuli_wdr.cpp:3271
 msgid "Active Uploads"
 msgstr "Aktywne wysyłania"
 
-#: src/muuli_wdr.cpp:3254
+#: src/muuli_wdr.cpp:3285
 #, fuzzy
 msgid "Percent of total files"
 msgstr "procent wszystkich plików"
 
-#: src/muuli_wdr.cpp:3306
+#: src/muuli_wdr.cpp:3337
 #, fuzzy
 msgid "Show Clients for"
 msgstr "Pokaż klientów"
 
-#: src/muuli_wdr.cpp:3308
+#: src/muuli_wdr.cpp:3339
 #, fuzzy
 msgid "All files"
 msgstr "Wszystkie udostępnione pliki"
 
-#: src/muuli_wdr.cpp:3311
+#: src/muuli_wdr.cpp:3342
 #, fuzzy
 msgid "Selected files"
 msgstr "Wybierz filtr przeglądania"
 
-#: src/muuli_wdr.cpp:3314
+#: src/muuli_wdr.cpp:3345
 #, fuzzy
 msgid "Active uploads only"
 msgstr "Aktywne wysyłania"
 
-#: src/muuli_wdr.cpp:3321
+#: src/muuli_wdr.cpp:3352
 msgid "Reload:"
 msgstr "Przeładuj:"
 
-#: src/muuli_wdr.cpp:3325
+#: src/muuli_wdr.cpp:3356
 msgid "Reload your shared files"
 msgstr "Przeładuj twoje udostępnione pliki"
 
-#: src/muuli_wdr.cpp:3388
+#: src/muuli_wdr.cpp:3419
 msgid "Send"
 msgstr "Wyślij"
 
-#: src/muuli_wdr.cpp:3389
+#: src/muuli_wdr.cpp:3420
 msgid "Sends the specified message."
 msgstr "Wysyła wybraną wiadomość."
 
-#: src/muuli_wdr.cpp:3393
+#: src/muuli_wdr.cpp:3424
 msgid "Close this chat-session."
 msgstr "Zamknij tę sesję czata."
 
-#: src/muuli_wdr.cpp:3416
+#: src/muuli_wdr.cpp:3447
 msgid "Connect to any server and/or Kad"
 msgstr "Podłącz do dowolnego serwera i/lub Kad"
 
-#: src/muuli_wdr.cpp:3422 src/SharedFilesCtrl.cpp:142 src/Statistics.cpp:941
+#: src/muuli_wdr.cpp:3453 src/SharedFilesCtrl.cpp:142 src/Statistics.cpp:941
 msgid "Shared Files"
 msgstr "Udostępnione pliki"
 
@@ -5471,250 +5499,250 @@ msgstr "Pobrano"
 msgid "ERROR: Failed to open partfile '%s'"
 msgstr "BŁĄD: Nie udało się otworzyć pliku części '%s'"
 
-#: src/Preferences.cpp:674
+#: src/Preferences.cpp:701
 msgid "System default"
 msgstr "Domyślny systemowy"
 
-#: src/Preferences.cpp:675
+#: src/Preferences.cpp:702
 msgid "Albanian"
 msgstr "Albański"
 
-#: src/Preferences.cpp:676
+#: src/Preferences.cpp:703
 msgid "Arabic"
 msgstr "Arabski"
 
-#: src/Preferences.cpp:677
+#: src/Preferences.cpp:704
 msgid "Asturian"
 msgstr "Asturyjski"
 
-#: src/Preferences.cpp:678
+#: src/Preferences.cpp:705
 msgid "Basque"
 msgstr "Baskijski"
 
-#: src/Preferences.cpp:679
+#: src/Preferences.cpp:706
 msgid "Bulgarian"
 msgstr "Bułgarski"
 
-#: src/Preferences.cpp:680
+#: src/Preferences.cpp:707
 msgid "Catalan"
 msgstr "Kataloński"
 
-#: src/Preferences.cpp:681
+#: src/Preferences.cpp:708
 msgid "Chinese (Simplified)"
 msgstr "Chiński (Uproszczony)"
 
-#: src/Preferences.cpp:682
+#: src/Preferences.cpp:709
 msgid "Chinese (Traditional)"
 msgstr "Chiński (Tradycyjny)"
 
-#: src/Preferences.cpp:683
+#: src/Preferences.cpp:710
 msgid "Croatian"
 msgstr "Chorwacki"
 
-#: src/Preferences.cpp:684
+#: src/Preferences.cpp:711
 msgid "Czech"
 msgstr "Czeski"
 
-#: src/Preferences.cpp:685
+#: src/Preferences.cpp:712
 msgid "Danish"
 msgstr "Duński"
 
-#: src/Preferences.cpp:686
+#: src/Preferences.cpp:713
 msgid "Dutch"
 msgstr "Holenderski"
 
-#: src/Preferences.cpp:687
+#: src/Preferences.cpp:714
 msgid "English (U.K.)"
 msgstr "Angielski (U.K.)"
 
-#: src/Preferences.cpp:688
+#: src/Preferences.cpp:715
 #, fuzzy
 msgid "English (U.S.)"
 msgstr "Angielski (U.K.)"
 
-#: src/Preferences.cpp:689
+#: src/Preferences.cpp:716
 msgid "Estonian"
 msgstr "Estoński"
 
-#: src/Preferences.cpp:690
+#: src/Preferences.cpp:717
 msgid "Finnish"
 msgstr "Fiński"
 
-#: src/Preferences.cpp:691
+#: src/Preferences.cpp:718
 msgid "French"
 msgstr "Francuski"
 
-#: src/Preferences.cpp:692
+#: src/Preferences.cpp:719
 msgid "Galician"
 msgstr "Galicyjski"
 
-#: src/Preferences.cpp:693
+#: src/Preferences.cpp:720
 msgid "German"
 msgstr "Niemiecki"
 
-#: src/Preferences.cpp:694
+#: src/Preferences.cpp:721
 msgid "Greek"
 msgstr "Grecki"
 
-#: src/Preferences.cpp:695
+#: src/Preferences.cpp:722
 msgid "Hebrew"
 msgstr "Hebrajski"
 
-#: src/Preferences.cpp:696
+#: src/Preferences.cpp:723
 msgid "Hungarian"
 msgstr "Węgierski"
 
-#: src/Preferences.cpp:697
+#: src/Preferences.cpp:724
 msgid "Italian"
 msgstr "Włoski"
 
-#: src/Preferences.cpp:698
+#: src/Preferences.cpp:725
 msgid "Japanese"
 msgstr "Japoński"
 
-#: src/Preferences.cpp:699
+#: src/Preferences.cpp:726
 msgid "Korean"
 msgstr "Koreański"
 
-#: src/Preferences.cpp:700
+#: src/Preferences.cpp:727
 msgid "Latvian"
 msgstr ""
 
-#: src/Preferences.cpp:701
+#: src/Preferences.cpp:728
 msgid "Lithuanian"
 msgstr "Litewski"
 
-#: src/Preferences.cpp:702
+#: src/Preferences.cpp:729
 msgid "Norwegian (Nynorsk)"
 msgstr "Norweski (Nynorsk)"
 
-#: src/Preferences.cpp:703
+#: src/Preferences.cpp:730
 msgid "Polish"
 msgstr "Polski"
 
-#: src/Preferences.cpp:704
+#: src/Preferences.cpp:731
 msgid "Portuguese"
 msgstr "Portugalski"
 
-#: src/Preferences.cpp:705
+#: src/Preferences.cpp:732
 msgid "Portuguese (Brazilian)"
 msgstr "Portugalski (Brazylijski)"
 
-#: src/Preferences.cpp:706
+#: src/Preferences.cpp:733
 msgid "Romanian"
 msgstr "Rumuński"
 
-#: src/Preferences.cpp:707
+#: src/Preferences.cpp:734
 msgid "Russian"
 msgstr "Rosyjski"
 
-#: src/Preferences.cpp:708
+#: src/Preferences.cpp:735
 msgid "Slovenian"
 msgstr "Słoweński"
 
-#: src/Preferences.cpp:709
+#: src/Preferences.cpp:736
 msgid "Spanish"
 msgstr "Hiszpański"
 
-#: src/Preferences.cpp:710
+#: src/Preferences.cpp:737
 msgid "Swedish"
 msgstr "Szwedzki"
 
-#: src/Preferences.cpp:711
+#: src/Preferences.cpp:738
 msgid "Turkish"
 msgstr "Turecki"
 
-#: src/Preferences.cpp:712
+#: src/Preferences.cpp:739
 msgid "Ukrainian"
 msgstr "Ukraiński"
 
-#: src/Preferences.cpp:815
+#: src/Preferences.cpp:842
 msgid "Change Language"
 msgstr "Zmień język"
 
-#: src/Preferences.cpp:879
+#: src/Preferences.cpp:906
 msgid "There are no translations installed for aMule"
 msgstr ""
 
-#: src/Preferences.cpp:880
+#: src/Preferences.cpp:907
 #, fuzzy
 msgid "No languages available"
 msgstr "Niedostępny"
 
-#: src/Preferences.cpp:1011
+#: src/Preferences.cpp:1038
 msgid "no options available"
 msgstr "nie ma dostępnych opcji"
 
-#: src/Preferences.cpp:2182
+#: src/Preferences.cpp:2227
 msgid "Invalid category found, skipping"
 msgstr "Znaleziono nieprawidłową kategorie, pomijam"
 
-#: src/Preferences.cpp:2351
+#: src/Preferences.cpp:2396
 msgid "TCP port can't be higher than 65532 due to server UDP socket being TCP+3"
 msgstr "Port TCP nie może być większy niż 65532, gdyż gniazdo UDP serwera będzie TCP+3"
 
-#: src/Preferences.cpp:2352
+#: src/Preferences.cpp:2397
 #, c-format
 msgid "Default port will be used (%d)"
 msgstr "Zostanie użyty domyślny port (%d)"
 
-#: src/PrefsUnifiedDlg.cpp:298 src/Statistics.cpp:866
+#: src/PrefsUnifiedDlg.cpp:300 src/Statistics.cpp:866
 msgid "Connection"
 msgstr "Połączenie"
 
-#: src/PrefsUnifiedDlg.cpp:299 src/SearchListCtrl.cpp:117
+#: src/PrefsUnifiedDlg.cpp:301 src/SearchListCtrl.cpp:117
 msgid "Directories"
 msgstr "Katalogi"
 
-#: src/PrefsUnifiedDlg.cpp:300 src/Statistics.cpp:917
+#: src/PrefsUnifiedDlg.cpp:302 src/Statistics.cpp:917
 msgid "Servers"
 msgstr "Serwery"
 
-#: src/PrefsUnifiedDlg.cpp:301 src/ServerListCtrl.cpp:96
+#: src/PrefsUnifiedDlg.cpp:303 src/ServerListCtrl.cpp:96
 msgid "Files"
 msgstr "Pliki"
 
-#: src/PrefsUnifiedDlg.cpp:302
+#: src/PrefsUnifiedDlg.cpp:304
 msgid "Security"
 msgstr "Bezpieczeństwo"
 
-#: src/PrefsUnifiedDlg.cpp:303
+#: src/PrefsUnifiedDlg.cpp:305
 msgid "Interface"
 msgstr "Interfejs"
 
-#: src/PrefsUnifiedDlg.cpp:310
+#: src/PrefsUnifiedDlg.cpp:312
 msgid "IP2Country"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:313
+#: src/PrefsUnifiedDlg.cpp:315
 msgid "Proxy"
 msgstr "Proxy"
 
-#: src/PrefsUnifiedDlg.cpp:314
+#: src/PrefsUnifiedDlg.cpp:316
 msgid "Filters"
 msgstr "Filtry"
 
-#: src/PrefsUnifiedDlg.cpp:315
+#: src/PrefsUnifiedDlg.cpp:317
 msgid "Remote Controls"
 msgstr "Zdalna kontrola"
 
-#: src/PrefsUnifiedDlg.cpp:316
+#: src/PrefsUnifiedDlg.cpp:318
 msgid "Online Signature"
 msgstr "Sygnatura Online"
 
-#: src/PrefsUnifiedDlg.cpp:317
+#: src/PrefsUnifiedDlg.cpp:319
 msgid "Advanced"
 msgstr "Zawansowane"
 
-#: src/PrefsUnifiedDlg.cpp:318
+#: src/PrefsUnifiedDlg.cpp:320
 msgid "Events"
 msgstr "Zdarzenia"
 
-#: src/PrefsUnifiedDlg.cpp:321
+#: src/PrefsUnifiedDlg.cpp:323
 msgid "Debugging"
 msgstr "Debugowanie"
 
-#: src/PrefsUnifiedDlg.cpp:451
+#: src/PrefsUnifiedDlg.cpp:453
 msgid ""
 "The following variables will be substituted:\n"
 "    %PARTFILE - full path to the file\n"
@@ -5724,15 +5752,15 @@ msgstr ""
 "    %PARTFILE - pełna ścieżka do pliku\n"
 "    %PARTNAME - tylko nazwa pliku"
 
-#: src/PrefsUnifiedDlg.cpp:472
+#: src/PrefsUnifiedDlg.cpp:474
 msgid "Tray icon support requires libayatana-appindicator3 at compile time."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:488
+#: src/PrefsUnifiedDlg.cpp:490
 msgid "Not available on Wayland: the protocol does not report when a window is minimized, so this option cannot intercept the system minimize button. Workaround: launch aMule with `GDK_BACKEND=x11` to use XWayland instead."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:534
+#: src/PrefsUnifiedDlg.cpp:536
 msgid ""
 "Do not change these setting unless you know\n"
 "what you are doing, otherwise you can easily\n"
@@ -5746,26 +5774,35 @@ msgstr ""
 "\n"
 "aMule będzie działał prawidłowo bez zmiany tych ustawień."
 
-#: src/PrefsUnifiedDlg.cpp:645
+#: src/PrefsUnifiedDlg.cpp:647
 #, c-format
 msgid "Failed to connect Cfg to widget with the ID %d and key %s"
 msgstr "Błąd połączenia Cfg do widżetu z identyfikatorem %d i kluczem %s"
 
-#: src/PrefsUnifiedDlg.cpp:693
+#: src/PrefsUnifiedDlg.cpp:695
 #, c-format
 msgid "Failed to transfer data from Cfg to Widget with the ID %d and key %s"
 msgstr "Błąd przesyłania danych połączenia z Cfg do widżetu z identyfikatorem %d i kluczem %s"
 
-#: src/PrefsUnifiedDlg.cpp:799
+#: src/PrefsUnifiedDlg.cpp:801
 msgid "The type of proxy you are connecting to"
 msgstr "Typ serwera proxy do którego się łączysz"
 
-#: src/PrefsUnifiedDlg.cpp:1003
+#: src/PrefsUnifiedDlg.cpp:1020
 #, c-format
 msgid "Failed to transfer data from Widget to Cfg with the ID %d and key %s"
 msgstr "Błąd przesyłania danych połączenia z widżetu do Cfg z identyfikatorem %d i kluczem %s"
 
 #: src/PrefsUnifiedDlg.cpp:1103
+#, fuzzy
+msgid "No password set."
+msgstr "Sprawdzam hasło\n"
+
+#: src/PrefsUnifiedDlg.cpp:1132
+msgid "Guest access needs a password. Type one in the guest password field, or untick Enable guest access."
+msgstr ""
+
+#: src/PrefsUnifiedDlg.cpp:1144
 msgid ""
 "aMule must be restarted to enable these changes:\n"
 "\n"
@@ -5773,45 +5810,45 @@ msgstr ""
 "aMule musi zostać zrestartowany przed wprowadzeniem tych zmian:\n"
 "\n"
 
-#: src/PrefsUnifiedDlg.cpp:1110
+#: src/PrefsUnifiedDlg.cpp:1151
 msgid "- TCP port changed.\n"
 msgstr "- Zmieniono port TCP.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1115
+#: src/PrefsUnifiedDlg.cpp:1156
 msgid "- UDP port changed.\n"
 msgstr "- Zmieniono port UDP.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1120
+#: src/PrefsUnifiedDlg.cpp:1161
 #, fuzzy
 msgid "- Network interface binding changed.\n"
 msgstr "Zewnętrzne połączenie zamknięte."
 
-#: src/PrefsUnifiedDlg.cpp:1125
+#: src/PrefsUnifiedDlg.cpp:1166
 #, fuzzy
 msgid "- External connect port changed.\n"
 msgstr "Zewnętrzne połączenie zamknięte."
 
-#: src/PrefsUnifiedDlg.cpp:1129
+#: src/PrefsUnifiedDlg.cpp:1170
 #, fuzzy
 msgid "- External connect acceptance changed.\n"
 msgstr "Nowe zewnętrzne połączenie zaakceptowane"
 
-#: src/PrefsUnifiedDlg.cpp:1133
+#: src/PrefsUnifiedDlg.cpp:1174
 #, fuzzy
 msgid "- External connect interface changed.\n"
 msgstr "Zewnętrzne połączenie zamknięte."
 
-#: src/PrefsUnifiedDlg.cpp:1137
+#: src/PrefsUnifiedDlg.cpp:1178
 #, fuzzy
 msgid "- Protocol obfuscation support changed.\n"
 msgstr "Maskowanie protokołu"
 
-#: src/PrefsUnifiedDlg.cpp:1151
+#: src/PrefsUnifiedDlg.cpp:1193
 #, fuzzy
 msgid "- amuleapi settings changed.\n"
 msgstr "- Zmieniono język.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1160
+#: src/PrefsUnifiedDlg.cpp:1202
 msgid ""
 "Your Auto-update server list is empty.\n"
 "'Auto-update server list at startup' will be disabled."
@@ -5819,7 +5856,7 @@ msgstr ""
 "Twoja lista auto-aktualizacji serwerów jest pusta.\n"
 "'Autoaktualizacja listy serwerów przy starcie' zostanie wyłączona."
 
-#: src/PrefsUnifiedDlg.cpp:1171
+#: src/PrefsUnifiedDlg.cpp:1213
 msgid ""
 "You have enabled external connections but have not specified a password.\n"
 "External connections cannot be enabled unless a valid password is specified."
@@ -5827,28 +5864,33 @@ msgstr ""
 "Połączenia zewnętrzne zostały włączone, ale nie zostało podane hasło.\n"
 "Połączenia zewnętrzne nie mogą być włączone dopóki nie zostanie podane poprawne hasło."
 
-#: src/PrefsUnifiedDlg.cpp:1202
+#: src/PrefsUnifiedDlg.cpp:1246
+#, c-format
+msgid "The amuleapi password could not be saved: %s"
+msgstr ""
+
+#: src/PrefsUnifiedDlg.cpp:1276
 msgid "- Language changed.\n"
 msgstr "- Zmieniono język.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1207
+#: src/PrefsUnifiedDlg.cpp:1281
 msgid "- Temp folder changed.\n"
 msgstr "- Zmieniono folder tymczasowy.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1212
+#: src/PrefsUnifiedDlg.cpp:1286
 msgid "- ED2K network enabled.\n"
 msgstr "- sieć ED2K włączona.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1245
+#: src/PrefsUnifiedDlg.cpp:1319
 msgid "The shared-file exclusion pattern is not a valid regular expression. The filter has been left disabled."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1247 src/PrefsUnifiedDlg.cpp:1841
+#: src/PrefsUnifiedDlg.cpp:1321 src/PrefsUnifiedDlg.cpp:1921
 #, fuzzy
 msgid "Invalid regular expression"
 msgstr "Zła wersja protokołu."
 
-#: src/PrefsUnifiedDlg.cpp:1324
+#: src/PrefsUnifiedDlg.cpp:1398
 msgid ""
 "Both eD2k and Kad network are disabled.\n"
 "You won't be able to connect until you enable at least one of them."
@@ -5856,7 +5898,7 @@ msgstr ""
 "Zarówno sieć eD2K jak i Kad zostały wyłączone.\n"
 "Nie będzie możliwe połączenie, dopóki nie włączysz przynajmniej jednej z nich."
 
-#: src/PrefsUnifiedDlg.cpp:1329
+#: src/PrefsUnifiedDlg.cpp:1403
 msgid ""
 "Kad will not start if your UDP port is disabled.\n"
 "Enable UDP port or disable Kad."
@@ -5864,7 +5906,7 @@ msgstr ""
 "Kad nie uruchomi się, jeśli twój port UDP jest wyłączony.\n"
 "Włącz port UDP lub wyłącz Kad."
 
-#: src/PrefsUnifiedDlg.cpp:1385
+#: src/PrefsUnifiedDlg.cpp:1459
 msgid ""
 "\n"
 "You MUST restart aMule now.\n"
@@ -5874,69 +5916,69 @@ msgstr ""
 "Musisz zrestartować teraz aMule.\n"
 "Jeśli nie zrestartujesz go teraz, nie narzekaj, jeśli stanie się coś złego.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1450
+#: src/PrefsUnifiedDlg.cpp:1524
 msgid "Could not register aMule for autostart at login. The autostart store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1452
+#: src/PrefsUnifiedDlg.cpp:1526
 msgid "Could not remove the autostart-at-login entry."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1453
+#: src/PrefsUnifiedDlg.cpp:1527
 #, fuzzy
 msgid "Autostart"
 msgstr "automatyczne odświeżanie rozpoczęte"
 
-#: src/PrefsUnifiedDlg.cpp:1468
+#: src/PrefsUnifiedDlg.cpp:1542
 msgid "Register file type"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1468
+#: src/PrefsUnifiedDlg.cpp:1542
 msgid "Register URL handler"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1476
+#: src/PrefsUnifiedDlg.cpp:1550
 #, c-format
 msgid "aMule only handles eD2k-compatible magnets. If you replace the current magnet handler (%s), BitTorrent magnet links will stop working - aMule cannot download BitTorrent content. Continue?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1481
+#: src/PrefsUnifiedDlg.cpp:1555
 #, c-format
 msgid "Another application currently opens .emulecollection files (%s). Replace it with aMule?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1486
+#: src/PrefsUnifiedDlg.cpp:1560
 #, c-format
 msgid "Another application is currently the default handler for these links (%s). Replace it with aMule?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1511
+#: src/PrefsUnifiedDlg.cpp:1585
 msgid "Could not register aMule for .emulecollection files. The registration store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1513
+#: src/PrefsUnifiedDlg.cpp:1587
 #, fuzzy
 msgid "Could not remove the file type registration."
 msgstr "Folder dla pobranych plików tymczasowych"
 
-#: src/PrefsUnifiedDlg.cpp:1515
+#: src/PrefsUnifiedDlg.cpp:1589
 msgid "Could not register aMule as the URL handler. The registration store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1517
+#: src/PrefsUnifiedDlg.cpp:1591
 msgid "Could not remove the URL handler registration."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1587 src/PrefsUnifiedDlg.cpp:1614
+#: src/PrefsUnifiedDlg.cpp:1661 src/PrefsUnifiedDlg.cpp:1688
 #, fuzzy
 msgid "The web server and aMule API require external connections to be enabled."
 msgstr "Ustawione hasło i włączone połączenia zewnętrzne."
 
-#: src/PrefsUnifiedDlg.cpp:1597
+#: src/PrefsUnifiedDlg.cpp:1671
 msgid "The aMule web server is deprecated. Consider running the aMule API instead."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1655
+#: src/PrefsUnifiedDlg.cpp:1735
 msgid ""
 "Your Auto-update servers list is in blank.\n"
 "Please fill in at least one URL to point to a valid server.met file.\n"
@@ -5946,24 +5988,24 @@ msgstr ""
 "Proszę wpisać co najmniej jeden URL wskazujący poprawny plik server.met.\n"
 " Kliknij na przycisku \"Lista\", aby wpisać URL."
 
-#: src/PrefsUnifiedDlg.cpp:1796
+#: src/PrefsUnifiedDlg.cpp:1876
 msgid "Temporary files"
 msgstr "Pliki tymczasowe"
 
-#: src/PrefsUnifiedDlg.cpp:1801
+#: src/PrefsUnifiedDlg.cpp:1881
 msgid "Incoming files"
 msgstr "Pliki przychodzące"
 
-#: src/PrefsUnifiedDlg.cpp:1806
+#: src/PrefsUnifiedDlg.cpp:1886
 msgid "Online Signatures"
 msgstr "Sygnatury Online"
 
-#: src/PrefsUnifiedDlg.cpp:1819
+#: src/PrefsUnifiedDlg.cpp:1899
 #, c-format
 msgid "Choose a folder for %s"
 msgstr "Wybierz folder na %s"
 
-#: src/PrefsUnifiedDlg.cpp:1843
+#: src/PrefsUnifiedDlg.cpp:1923
 #, fuzzy, c-format
 msgid "Would exclude %u of %u shared file"
 msgid_plural "Would exclude %u of %u shared files"
@@ -5971,42 +6013,42 @@ msgstr[0] "Znaleziono %i znany udostępniony plik"
 msgstr[1] "Znaleziono %i znane udostępnionych plików"
 msgstr[2] "Znaleziono %i znanych udostępnionych plików"
 
-#: src/PrefsUnifiedDlg.cpp:1860
+#: src/PrefsUnifiedDlg.cpp:1940
 msgid "Browse for videoplayer"
 msgstr "Szukaj odtwarzacza filmów"
 
-#: src/PrefsUnifiedDlg.cpp:1864
+#: src/PrefsUnifiedDlg.cpp:1944
 msgid "Select browser"
 msgstr "Wybierz przeglądarkę"
 
-#: src/PrefsUnifiedDlg.cpp:1868
+#: src/PrefsUnifiedDlg.cpp:1948
 #, fuzzy
 msgid "Select ffprobe binary"
 msgstr "Wybierz przeglądarkę"
 
-#: src/PrefsUnifiedDlg.cpp:1874
+#: src/PrefsUnifiedDlg.cpp:1954
 #, c-format
 msgid "Executable%s"
 msgstr "Program%s"
 
-#: src/PrefsUnifiedDlg.cpp:1908
+#: src/PrefsUnifiedDlg.cpp:1988
 msgid "ffprobe not found on PATH or in the standard install locations. Install ffmpeg (which ships ffprobe) or use Browse to pick a binary manually."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1920
+#: src/PrefsUnifiedDlg.cpp:2000
 msgid "Reset the settings on this page to their default values?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1921
+#: src/PrefsUnifiedDlg.cpp:2001
 #, fuzzy
 msgid "Reset to defaults"
 msgstr "Domyślny systemowy"
 
-#: src/PrefsUnifiedDlg.cpp:1948
+#: src/PrefsUnifiedDlg.cpp:2028
 msgid "Edit server list"
 msgstr "Edytuj listę serwerów"
 
-#: src/PrefsUnifiedDlg.cpp:1949
+#: src/PrefsUnifiedDlg.cpp:2029
 msgid ""
 "Add here URL's to download server.met files.\n"
 "Only one url on each line."
@@ -6014,42 +6056,42 @@ msgstr ""
 "Dodaj jeden URL w każdej linii.\n"
 "Tylko jeden URL w każdej linii."
 
-#: src/PrefsUnifiedDlg.cpp:2004
+#: src/PrefsUnifiedDlg.cpp:2084
 msgid "IP2Country update failed"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2149 src/PrefsUnifiedDlg.cpp:2180
+#: src/PrefsUnifiedDlg.cpp:2229 src/PrefsUnifiedDlg.cpp:2260
 msgid "Data by MaxMind GeoLite2"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2151 src/PrefsUnifiedDlg.cpp:2182
+#: src/PrefsUnifiedDlg.cpp:2231 src/PrefsUnifiedDlg.cpp:2262
 #, fuzzy
 msgid "Custom source"
 msgstr "Pełne źródła"
 
-#: src/PrefsUnifiedDlg.cpp:2153 src/PrefsUnifiedDlg.cpp:2184
+#: src/PrefsUnifiedDlg.cpp:2233 src/PrefsUnifiedDlg.cpp:2264
 msgid "Data by DB-IP.com"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2204
+#: src/PrefsUnifiedDlg.cpp:2284
 #, fuzzy, c-format
 msgid "Status: Loaded%s"
 msgstr "Status:"
 
-#: src/PrefsUnifiedDlg.cpp:2206
+#: src/PrefsUnifiedDlg.cpp:2286
 #, fuzzy, c-format
 msgid "Status: Loaded%s - %s"
 msgstr "Status:"
 
-#: src/PrefsUnifiedDlg.cpp:2210
+#: src/PrefsUnifiedDlg.cpp:2290
 msgid "Status: Failed to load - click 'Update now' to refresh."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2212
+#: src/PrefsUnifiedDlg.cpp:2292
 msgid "Status: Not found - click 'Update now' to download."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2270 src/PrefsUnifiedDlg.cpp:2294
+#: src/PrefsUnifiedDlg.cpp:2350 src/PrefsUnifiedDlg.cpp:2374
 #, c-format
 msgid "Update delay: %d second"
 msgid_plural "Update delay: %d seconds"
@@ -6057,7 +6099,7 @@ msgstr[0] "Opóźnienie odświeżania: %d sekunda"
 msgstr[1] "Opóźnienie odświeżania: %d sekundy"
 msgstr[2] "Opóźnienie odświeżania: %d sekund"
 
-#: src/PrefsUnifiedDlg.cpp:2278
+#: src/PrefsUnifiedDlg.cpp:2358
 #, c-format
 msgid "Time for average graph: %d minute"
 msgid_plural "Time for average graph: %d minutes"
@@ -6065,12 +6107,12 @@ msgstr[0] "Czas dla przeciętnego wykresu: %d minuta"
 msgstr[1] "Czas dla przeciętnego wykresu: %d minuty"
 msgstr[2] "Czas dla przeciętnego wykresu: %d minut"
 
-#: src/PrefsUnifiedDlg.cpp:2287
+#: src/PrefsUnifiedDlg.cpp:2367
 #, c-format
 msgid "Connections Graph Scale: %d"
 msgstr "Skala wykresu połączeń: %d"
 
-#: src/PrefsUnifiedDlg.cpp:2302
+#: src/PrefsUnifiedDlg.cpp:2382
 #, c-format
 msgid "File Buffer Size: %d byte"
 msgid_plural "File Buffer Size: %d bytes"
@@ -6078,7 +6120,7 @@ msgstr[0] "Rozmiar bufora pliku: %d bajt"
 msgstr[1] "Rozmiar bufora pliku: %d bajty"
 msgstr[2] "Rozmiar bufora pliku: %d bajtów"
 
-#: src/PrefsUnifiedDlg.cpp:2312
+#: src/PrefsUnifiedDlg.cpp:2392
 #, c-format
 msgid "Upload Queue Size: %d client"
 msgid_plural "Upload Queue Size: %d clients"
@@ -6086,7 +6128,7 @@ msgstr[0] "Rozmiar kolejki wysyłania: %d klient"
 msgstr[1] "Rozmiar kolejki wysyłania: %d klientów"
 msgstr[2] "Rozmiar kolejki wysyłania: %d klientów"
 
-#: src/PrefsUnifiedDlg.cpp:2322
+#: src/PrefsUnifiedDlg.cpp:2402
 #, c-format
 msgid "Server connection refresh interval: %d minute"
 msgid_plural "Server connection refresh interval: %d minutes"
@@ -6094,79 +6136,79 @@ msgstr[0] "Odświeżanie połączeń do serwera co: %d minutę"
 msgstr[1] "Odświeżanie połączeń do serwera co: %d minuty"
 msgstr[2] "Odświeżanie połączeń do serwera co: %d minut"
 
-#: src/PrefsUnifiedDlg.cpp:2327
+#: src/PrefsUnifiedDlg.cpp:2407
 msgid "Server connection refresh interval: Disabled"
 msgstr "Odświeżanie połączeń do serwera co: Wyłączone"
 
-#: src/PrefsUnifiedDlg.cpp:2371
+#: src/PrefsUnifiedDlg.cpp:2451
 msgid "disabled"
 msgstr "wyłączone"
 
-#: src/PrefsUnifiedDlg.cpp:2397
+#: src/PrefsUnifiedDlg.cpp:2477
 #, fuzzy, c-format
 msgid "Execute command on '%s' event"
 msgstr "Wykonaj komendę przy wydarzeniu `%s'"
 
-#: src/PrefsUnifiedDlg.cpp:2404
+#: src/PrefsUnifiedDlg.cpp:2484
 msgid "Enable command execution on core"
 msgstr "Włącz wykonanie komendy w rdzeniu"
 
-#: src/PrefsUnifiedDlg.cpp:2416
+#: src/PrefsUnifiedDlg.cpp:2496
 msgid "Core command:"
 msgstr "Komenda rdzenia:"
 
-#: src/PrefsUnifiedDlg.cpp:2432
+#: src/PrefsUnifiedDlg.cpp:2512
 msgid "Enable command execution on GUI"
 msgstr "Włącz wykonanie komendy w GUI"
 
-#: src/PrefsUnifiedDlg.cpp:2444
+#: src/PrefsUnifiedDlg.cpp:2524
 msgid "GUI command:"
 msgstr "Komenda GUI:"
 
-#: src/PrefsUnifiedDlg.cpp:2460
+#: src/PrefsUnifiedDlg.cpp:2540
 msgid "The following variables will be replaced:"
 msgstr "Następujące zmienne zostaną zastąpione:"
 
-#: src/PrefsUnifiedDlg.cpp:2628
+#: src/PrefsUnifiedDlg.cpp:2708
 msgid ""
 "The following folders look like system or sensitive locations:\n"
 "\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2633
+#: src/PrefsUnifiedDlg.cpp:2713
 msgid "Sharing them recursively will publish every file underneath on the eD2k/Kad networks. Do you really want to do this?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2636
+#: src/PrefsUnifiedDlg.cpp:2716
 #, fuzzy
 msgid "Confirm shared folders"
 msgstr "Udostępnione foldery"
 
-#: src/PrefsUnifiedDlg.cpp:2664
+#: src/PrefsUnifiedDlg.cpp:2744
 #, fuzzy
 msgid "Reloading shared files..."
 msgstr "Przeładuj twoje udostępnione pliki"
 
-#: src/PrefsUnifiedDlg.cpp:2665
+#: src/PrefsUnifiedDlg.cpp:2745
 msgid "Scanning for subdirectories..."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2666
+#: src/PrefsUnifiedDlg.cpp:2746
 #, fuzzy
 msgid "Updating shared folders"
 msgstr "Udostępnione foldery"
 
-#: src/PrefsUnifiedDlg.cpp:2693
+#: src/PrefsUnifiedDlg.cpp:2773
 #, c-format
 msgid "Scanned %u directories..."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2743
+#: src/PrefsUnifiedDlg.cpp:2823
 #, fuzzy, c-format
 msgid "Reloading shared files: %u files scanned"
 msgstr "Przeładowuje listę udostępnionych plików."
 
-#: src/PrefsUnifiedDlg.cpp:2793
+#: src/PrefsUnifiedDlg.cpp:2873
 #, fuzzy
 msgid "Shared folder"
 msgstr "Udostępnione foldery"

--- a/po/pl.po
+++ b/po/pl.po
@@ -12,7 +12,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-28 12:17+0200\n"
+"POT-Creation-Date: 2026-07-28 13:09+0200\n"
 "PO-Revision-Date: 2026-07-27 11:43+0000\n"
 "Last-Translator: Michał Trzebiatowski <hippie_1968@hotmail.com>\n"
 "Language-Team: translationproject.org/team/pl.html <translation-team-pl@lists.sourceforge.net>\n"
@@ -294,7 +294,7 @@ msgid "Password set and external connections enabled."
 msgstr "Ustawione hasło i włączone połączenia zewnętrzne."
 
 #: src/amule.cpp:755 src/KadDlg.cpp:176 src/KadDlg.cpp:185
-#: src/PrefsUnifiedDlg.cpp:1461 src/SharedFilesCtrl.cpp:476
+#: src/PrefsUnifiedDlg.cpp:1470 src/SharedFilesCtrl.cpp:476
 msgid "WARNING"
 msgstr "UWAGA"
 
@@ -332,7 +332,7 @@ msgstr "Zażądałeś włączenia serwera sieciowego podczas uruchomienia, ale b
 #: src/amule-remote-gui.cpp:603 src/amule-remote-gui.cpp:671
 #: src/amule-remote-gui.cpp:709 src/amule-remote-gui.cpp:1282
 #: src/amule-remote-gui.cpp:1345 src/amule-remote-gui.cpp:1372
-#: src/DownloadQueue.cpp:1481 src/PrefsUnifiedDlg.cpp:1247
+#: src/DownloadQueue.cpp:1481 src/PrefsUnifiedDlg.cpp:1256
 msgid "ERROR"
 msgstr "BŁĄD"
 
@@ -594,36 +594,36 @@ msgstr "Odwiedź https://github.com/amule-org/amule/releases/latest aby sprawdzi
 msgid "FATAL ERROR: Failed to create Timer"
 msgstr "KRYTYCZNY BŁĄD: Nie udało się utworzyć Timera"
 
-#: src/amuleDlg.cpp:361 src/amuleDlg.cpp:1787 src/amuleDlg.cpp:2033
-#: src/muuli_wdr.cpp:1492 src/muuli_wdr.cpp:3449
+#: src/amuleDlg.cpp:361 src/amuleDlg.cpp:1810 src/amuleDlg.cpp:2056
+#: src/muuli_wdr.cpp:1492 src/muuli_wdr.cpp:3453
 msgid "Networks"
 msgstr "Sieci"
 
-#: src/amuleDlg.cpp:362 src/amuleDlg.cpp:1793 src/muuli_wdr.cpp:3450
+#: src/amuleDlg.cpp:362 src/amuleDlg.cpp:1816 src/muuli_wdr.cpp:3454
 msgid "Searches"
 msgstr "Szukaj"
 
-#: src/amuleDlg.cpp:363 src/amuleDlg.cpp:1799 src/DownloadListCtrl.cpp:740
-#: src/muuli_wdr.cpp:392 src/muuli_wdr.cpp:1585 src/muuli_wdr.cpp:3451
+#: src/amuleDlg.cpp:363 src/amuleDlg.cpp:1822 src/DownloadListCtrl.cpp:740
+#: src/muuli_wdr.cpp:392 src/muuli_wdr.cpp:1585 src/muuli_wdr.cpp:3455
 #: src/Statistics.cpp:829
 msgid "Downloads"
 msgstr "Pobieranie"
 
-#: src/amuleDlg.cpp:364 src/amuleDlg.cpp:1805 src/muuli_wdr.cpp:3325
+#: src/amuleDlg.cpp:364 src/amuleDlg.cpp:1828 src/muuli_wdr.cpp:3329
 msgid "Shared files"
 msgstr "Udostępnione pliki"
 
-#: src/amuleDlg.cpp:365 src/amuleDlg.cpp:1811 src/muuli_wdr.cpp:2957
-#: src/muuli_wdr.cpp:3407 src/muuli_wdr.cpp:3454
+#: src/amuleDlg.cpp:365 src/amuleDlg.cpp:1834 src/muuli_wdr.cpp:2961
+#: src/muuli_wdr.cpp:3411 src/muuli_wdr.cpp:3458
 msgid "Messages"
 msgstr "Wiadomości"
 
-#: src/amuleDlg.cpp:366 src/amuleDlg.cpp:1817 src/muuli_wdr.cpp:3455
+#: src/amuleDlg.cpp:366 src/amuleDlg.cpp:1840 src/muuli_wdr.cpp:3459
 #: src/PrefsUnifiedDlg.cpp:314 src/Statistics.cpp:779 src/Statistics.cpp:1235
 msgid "Statistics"
 msgstr "Statystyki"
 
-#: src/amuleDlg.cpp:368 src/amuleDlg.cpp:1824 src/muuli_wdr.cpp:3457
+#: src/amuleDlg.cpp:368 src/amuleDlg.cpp:1847 src/muuli_wdr.cpp:3461
 #: src/PrefsUnifiedDlg.cpp:330 src/utils/wxCas/src/wxcasprefs.cpp:39
 msgid "Preferences"
 msgstr "Preferencje"
@@ -682,8 +682,8 @@ msgstr "Kad: Wyłączony"
 #: src/amuleDlg.cpp:1029 src/DownloadListCtrl.cpp:505
 #: src/DownloadListCtrl.cpp:749 src/FriendListCtrl.cpp:180
 #: src/muuli_wdr.cpp:731 src/muuli_wdr.cpp:782 src/muuli_wdr.cpp:846
-#: src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2262 src/muuli_wdr.cpp:2347
-#: src/muuli_wdr.cpp:3095 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
+#: src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2266 src/muuli_wdr.cpp:2351
+#: src/muuli_wdr.cpp:3099 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
 #: src/ServerListCtrl.cpp:606 src/TransferWnd.cpp:378
 #: src/utils/wxCas/src/wxcasprefs.cpp:235
 msgid "Cancel"
@@ -694,7 +694,7 @@ msgid "Stop the current connection attempts"
 msgstr "Zatrzymaj aktualne próby połączenia"
 
 #: src/amuleDlg.cpp:1035 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976
-#: src/muuli_wdr.cpp:2485
+#: src/muuli_wdr.cpp:2489
 msgid "Disconnect"
 msgstr "Rozłącz"
 
@@ -703,7 +703,7 @@ msgid "Disconnect from the currently connected networks"
 msgstr "Rozłącz z aktualnie połączonymi sieciami"
 
 #: src/amuleDlg.cpp:1041 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979
-#: src/muuli_wdr.cpp:2640 src/muuli_wdr.cpp:3092 src/muuli_wdr.cpp:3447
+#: src/muuli_wdr.cpp:2644 src/muuli_wdr.cpp:3096 src/muuli_wdr.cpp:3451
 msgid "Connect"
 msgstr "Podłącz"
 
@@ -758,7 +758,7 @@ msgstr "Potwierdzenie wyjścia"
 msgid "Launch Command: "
 msgstr "Uruchomienie polecenia: "
 
-#: src/amuleDlg.cpp:1632 src/muuli_wdr.cpp:1982 src/Preferences.cpp:979
+#: src/amuleDlg.cpp:1632 src/muuli_wdr.cpp:1986 src/Preferences.cpp:979
 msgid "- default -"
 msgstr "- domyślnie -"
 
@@ -772,60 +772,60 @@ msgstr "Katalog skórek '%s' nie istnieje"
 msgid "WARNING: Unable to open skin file '%s' for read"
 msgstr "OSTRZEŻENIE: Nie udało się otworzyć pliku skórki '%s' do odczytu"
 
-#: src/amuleDlg.cpp:1791 src/muuli_wdr.cpp:3449
+#: src/amuleDlg.cpp:1814 src/muuli_wdr.cpp:3453
 msgid "Networks Window"
 msgstr "Okno sieci"
 
-#: src/amuleDlg.cpp:1797 src/muuli_wdr.cpp:3450
+#: src/amuleDlg.cpp:1820 src/muuli_wdr.cpp:3454
 msgid "Searches Window"
 msgstr "Okno wyszukiwania"
 
-#: src/amuleDlg.cpp:1803 src/muuli_wdr.cpp:3451
+#: src/amuleDlg.cpp:1826 src/muuli_wdr.cpp:3455
 msgid "Downloads Window"
 msgstr "Okno pobierań"
 
-#: src/amuleDlg.cpp:1809 src/muuli_wdr.cpp:3453
+#: src/amuleDlg.cpp:1832 src/muuli_wdr.cpp:3457
 msgid "Shared Files Window"
 msgstr "Okno udostępnionych plików"
 
-#: src/amuleDlg.cpp:1815 src/muuli_wdr.cpp:3454
+#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3458
 msgid "Messages Window"
 msgstr "Okno wiadomości"
 
-#: src/amuleDlg.cpp:1821 src/muuli_wdr.cpp:3455
+#: src/amuleDlg.cpp:1844 src/muuli_wdr.cpp:3459
 msgid "Statistics Graph Window"
 msgstr "Okno wykresów statystyk"
 
-#: src/amuleDlg.cpp:1828 src/muuli_wdr.cpp:3457
+#: src/amuleDlg.cpp:1851 src/muuli_wdr.cpp:3461
 msgid "Preferences Settings Window"
 msgstr "Okno preferencji"
 
-#: src/amuleDlg.cpp:1831 src/muuli_wdr.cpp:3458
+#: src/amuleDlg.cpp:1854 src/muuli_wdr.cpp:3462
 msgid "Import"
 msgstr "Import"
 
-#: src/amuleDlg.cpp:1835 src/muuli_wdr.cpp:3458
+#: src/amuleDlg.cpp:1858 src/muuli_wdr.cpp:3462
 msgid "The partfile importer tool"
 msgstr "Narzędzie importowania plików części"
 
-#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3459
+#: src/amuleDlg.cpp:1861 src/muuli_wdr.cpp:3463
 #: src/utils/aLinkCreator/src/alcframe.cpp:262
 msgid "About"
 msgstr "Informacje o"
 
-#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3459
+#: src/amuleDlg.cpp:1861 src/muuli_wdr.cpp:3463
 msgid "About/Help"
 msgstr "Informacje/Pomoc"
 
-#: src/amuleDlg.cpp:2036
+#: src/amuleDlg.cpp:2059
 msgid "eD2k network"
 msgstr "Sieć eD2k"
 
-#: src/amuleDlg.cpp:2039
+#: src/amuleDlg.cpp:2062
 msgid "Kad network"
 msgstr "Sieć Kad"
 
-#: src/amuleDlg.cpp:2039
+#: src/amuleDlg.cpp:2062
 msgid "No network"
 msgstr "Brak sieci"
 
@@ -1363,19 +1363,19 @@ msgstr "Auto [Wy]"
 msgid "Very low"
 msgstr "Bardzo niski"
 
-#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:743 src/muuli_wdr.cpp:2313
+#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:743 src/muuli_wdr.cpp:2317
 #: src/ServerListCtrl.cpp:263 src/ServerListCtrl.cpp:456
 #: src/SharedFilesCtrl.cpp:145
 msgid "Low"
 msgstr "Niski"
 
-#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:744 src/muuli_wdr.cpp:2314
+#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:744 src/muuli_wdr.cpp:2318
 #: src/ServerListCtrl.cpp:266 src/ServerListCtrl.cpp:457
 #: src/SharedFilesCtrl.cpp:146
 msgid "Normal"
 msgstr "Normalny"
 
-#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:745 src/muuli_wdr.cpp:2315
+#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:745 src/muuli_wdr.cpp:2319
 #: src/ServerListCtrl.cpp:269 src/ServerListCtrl.cpp:458
 #: src/SharedFilesCtrl.cpp:147
 msgid "High"
@@ -1467,7 +1467,7 @@ msgstr "Serwer lokalny"
 msgid "Remote Server"
 msgstr "Serwer zdalny"
 
-#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3212
+#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3216
 #: src/SearchDlg.cpp:119 src/TextClient.cpp:911
 msgid "Kad"
 msgstr "Kad"
@@ -1539,7 +1539,7 @@ msgstr "Część"
 msgid "Size"
 msgstr "Rozmiar"
 
-#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3279
+#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3283
 msgid "Transferred"
 msgstr "Przesłano"
 
@@ -1597,7 +1597,7 @@ msgstr ""
 "Informacja zwrotna od:  %s (%s)\n"
 "\n"
 
-#: src/DownloadListCtrl.cpp:746 src/muuli_wdr.cpp:2316
+#: src/DownloadListCtrl.cpp:746 src/muuli_wdr.cpp:2320
 #: src/SharedFilesCtrl.cpp:150
 msgid "Auto"
 msgstr "Automatyczny"
@@ -1635,7 +1635,7 @@ msgid "Extended Options"
 msgstr "Zaawansowane opcje"
 
 #: src/DownloadListCtrl.cpp:770 src/DownloadListCtrl.cpp:822
-#: src/muuli_wdr.cpp:1800
+#: src/muuli_wdr.cpp:1804
 msgid "Preview"
 msgstr "Podgląd"
 
@@ -2438,23 +2438,23 @@ msgid ""
 "want downloads on a different (e.g. larger) disk."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:549 src/FirstRunWizard.cpp:611 src/muuli_wdr.cpp:1712
+#: src/FirstRunWizard.cpp:549 src/FirstRunWizard.cpp:611 src/muuli_wdr.cpp:1716
 msgid "Destination folder for downloads"
 msgstr "Folder docelowy dla pobrań"
 
 #: src/FirstRunWizard.cpp:553 src/FirstRunWizard.cpp:569 src/muuli_wdr.cpp:1349
-#: src/muuli_wdr.cpp:1366 src/muuli_wdr.cpp:1687 src/muuli_wdr.cpp:1718
-#: src/muuli_wdr.cpp:1730 src/muuli_wdr.cpp:2800
+#: src/muuli_wdr.cpp:1366 src/muuli_wdr.cpp:1691 src/muuli_wdr.cpp:1722
+#: src/muuli_wdr.cpp:1734 src/muuli_wdr.cpp:2804
 #: src/utils/aLinkCreator/src/alcframe.cpp:135
 #: src/utils/wxCas/src/wxcasprefs.cpp:52 src/utils/wxCas/src/wxcasprefs.cpp:118
 msgid "Browse"
 msgstr "Przeglądaj"
 
-#: src/FirstRunWizard.cpp:559 src/muuli_wdr.cpp:1723
+#: src/FirstRunWizard.cpp:559 src/muuli_wdr.cpp:1727
 msgid "(All files in this folder are shared with other peers)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:565 src/FirstRunWizard.cpp:624 src/muuli_wdr.cpp:1725
+#: src/FirstRunWizard.cpp:565 src/FirstRunWizard.cpp:624 src/muuli_wdr.cpp:1729
 msgid "Folder for temporary download files"
 msgstr "Folder dla pobranych plików tymczasowych"
 
@@ -2485,7 +2485,7 @@ msgstr "Nie udało się otworzyć pliku listy przyjaciół 'emfriends.met' do za
 msgid "CRITICAL - no client on StartChatSession"
 msgstr "KRYTYCZNE - brak klienta przy StartChatSession"
 
-#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2706 src/muuli_wdr.cpp:3383
+#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2710 src/muuli_wdr.cpp:3387
 msgid "Friends"
 msgstr "Znajomi"
 
@@ -2596,8 +2596,8 @@ msgstr "Brak"
 msgid "No"
 msgstr "Nie"
 
-#: src/GenericClientListCtrl.cpp:1216 src/PrefsUnifiedDlg.cpp:2898
-#: src/PrefsUnifiedDlg.cpp:2948 src/ServerListCtrl.cpp:276
+#: src/GenericClientListCtrl.cpp:1216 src/PrefsUnifiedDlg.cpp:2907
+#: src/PrefsUnifiedDlg.cpp:2957 src/ServerListCtrl.cpp:276
 msgid "Yes"
 msgstr "Tak"
 
@@ -2768,10 +2768,10 @@ msgstr "Nieprawidłowy port do rozruchu"
 msgid "Please fill all fields required"
 msgstr "Proszę wypełnij wszystkie wymagane pola"
 
-#: src/KadDlg.cpp:192 src/PartFile.cpp:1031 src/PrefsUnifiedDlg.cpp:1134
-#: src/PrefsUnifiedDlg.cpp:1204 src/PrefsUnifiedDlg.cpp:1405
-#: src/PrefsUnifiedDlg.cpp:1663 src/PrefsUnifiedDlg.cpp:1673
-#: src/PrefsUnifiedDlg.cpp:1690 src/PrefsUnifiedDlg.cpp:1738
+#: src/KadDlg.cpp:192 src/PartFile.cpp:1031 src/PrefsUnifiedDlg.cpp:1143
+#: src/PrefsUnifiedDlg.cpp:1213 src/PrefsUnifiedDlg.cpp:1414
+#: src/PrefsUnifiedDlg.cpp:1672 src/PrefsUnifiedDlg.cpp:1682
+#: src/PrefsUnifiedDlg.cpp:1699 src/PrefsUnifiedDlg.cpp:1747
 msgid "Message"
 msgstr "Wiadomość"
 
@@ -2876,7 +2876,7 @@ msgstr "Ratio wymiany"
 msgid "Uploaded"
 msgstr "Wysłano"
 
-#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3263
+#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3267
 msgid "Requested"
 msgstr "Zażądano"
 
@@ -3000,7 +3000,7 @@ msgid "WARNING: "
 msgstr "OSTRZEŻENIE: "
 
 #: src/MuleNotebook.cpp:179 src/muuli_wdr.cpp:817 src/muuli_wdr.cpp:1229
-#: src/muuli_wdr.cpp:3167 src/muuli_wdr.cpp:3423
+#: src/muuli_wdr.cpp:3171 src/muuli_wdr.cpp:3427
 msgid "Close"
 msgstr "Zamknij"
 
@@ -3018,7 +3018,7 @@ msgid "Paste"
 msgstr "Wklej"
 
 #: src/MuleTextCtrl.cpp:89 src/muuli_wdr.cpp:358 src/muuli_wdr.cpp:757
-#: src/muuli_wdr.cpp:2390 src/muuli_wdr.cpp:2409 src/muuli_wdr.cpp:2431
+#: src/muuli_wdr.cpp:2394 src/muuli_wdr.cpp:2413 src/muuli_wdr.cpp:2435
 #: src/utils/aLinkCreator/src/alcframe.cpp:142
 msgid "Clear"
 msgstr "Wyczyść"
@@ -3117,7 +3117,7 @@ msgstr "Wyjdź"
 
 #: src/MuleTrayIcon.cpp:579 src/MuleTrayIcon.cpp:945 src/MuleTrayIcon.cpp:965
 #: src/muuli_wdr.cpp:1398 src/muuli_wdr.cpp:1406 src/muuli_wdr.cpp:1413
-#: src/muuli_wdr.cpp:1846 src/muuli_wdr.cpp:1852 src/OtherFunctions.cpp:91
+#: src/muuli_wdr.cpp:1850 src/muuli_wdr.cpp:1856 src/OtherFunctions.cpp:91
 #: src/StatisticsDlg.cpp:93 src/StatisticsDlg.cpp:95
 msgid "kB/s"
 msgstr "kB/s"
@@ -3359,7 +3359,7 @@ msgstr "Bajtów"
 msgid "KB"
 msgstr "KB"
 
-#: src/muuli_wdr.cpp:274 src/muuli_wdr.cpp:293 src/muuli_wdr.cpp:1631
+#: src/muuli_wdr.cpp:274 src/muuli_wdr.cpp:293 src/muuli_wdr.cpp:1635
 #: src/OtherFunctions.cpp:64
 msgid "MB"
 msgstr "MB"
@@ -3376,7 +3376,7 @@ msgstr "Maks. rozmiar"
 msgid "Availability"
 msgstr "Dostępność"
 
-#: src/muuli_wdr.cpp:312 src/muuli_wdr.cpp:398 src/muuli_wdr.cpp:3328
+#: src/muuli_wdr.cpp:312 src/muuli_wdr.cpp:398 src/muuli_wdr.cpp:3332
 msgid "Filter:"
 msgstr "Filtr:"
 
@@ -3439,8 +3439,8 @@ msgstr "Źródła pliku:"
 #: src/muuli_wdr.cpp:1160 src/muuli_wdr.cpp:1167 src/muuli_wdr.cpp:1172
 #: src/muuli_wdr.cpp:1179 src/muuli_wdr.cpp:1184 src/muuli_wdr.cpp:1191
 #: src/muuli_wdr.cpp:1205 src/muuli_wdr.cpp:1212 src/muuli_wdr.cpp:1217
-#: src/muuli_wdr.cpp:1224 src/muuli_wdr.cpp:3265 src/muuli_wdr.cpp:3273
-#: src/muuli_wdr.cpp:3281
+#: src/muuli_wdr.cpp:1224 src/muuli_wdr.cpp:3269 src/muuli_wdr.cpp:3277
+#: src/muuli_wdr.cpp:3285
 msgid "N/A"
 msgstr "Brak"
 
@@ -3585,7 +3585,7 @@ msgstr ""
 msgid "Album :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:685 src/muuli_wdr.cpp:2285
+#: src/muuli_wdr.cpp:685 src/muuli_wdr.cpp:2289
 msgid "Title :"
 msgstr "Tytuł :"
 
@@ -3694,7 +3694,7 @@ msgstr "Nazwa użytkownika :"
 msgid "Userhash :"
 msgstr "Skrót użytkownika :"
 
-#: src/muuli_wdr.cpp:895 src/muuli_wdr.cpp:1752 src/muuli_wdr.cpp:2480
+#: src/muuli_wdr.cpp:895 src/muuli_wdr.cpp:1756 src/muuli_wdr.cpp:2484
 #: src/utils/aLinkCreator/src/alcframe.cpp:137
 msgid "Add"
 msgstr "Dodaj"
@@ -3703,15 +3703,15 @@ msgstr "Dodaj"
 msgid "Download-Speed"
 msgstr "Prędkość pobierania"
 
-#: src/muuli_wdr.cpp:954 src/muuli_wdr.cpp:989 src/muuli_wdr.cpp:2584
+#: src/muuli_wdr.cpp:954 src/muuli_wdr.cpp:989 src/muuli_wdr.cpp:2588
 msgid "Current"
 msgstr "Aktualna"
 
-#: src/muuli_wdr.cpp:962 src/muuli_wdr.cpp:997 src/muuli_wdr.cpp:2592
+#: src/muuli_wdr.cpp:962 src/muuli_wdr.cpp:997 src/muuli_wdr.cpp:2596
 msgid "Running average"
 msgstr "Bieżąca średnia"
 
-#: src/muuli_wdr.cpp:970 src/muuli_wdr.cpp:1005 src/muuli_wdr.cpp:2600
+#: src/muuli_wdr.cpp:970 src/muuli_wdr.cpp:1005 src/muuli_wdr.cpp:2604
 msgid "Session average"
 msgstr "Średnia sesji"
 
@@ -3723,7 +3723,7 @@ msgstr "Prędkość wysyłania"
 msgid "Connections"
 msgstr "Połączenie"
 
-#: src/muuli_wdr.cpp:1024 src/muuli_wdr.cpp:1871
+#: src/muuli_wdr.cpp:1024 src/muuli_wdr.cpp:1875
 msgid "Active downloads"
 msgstr "Aktywne pobierania"
 
@@ -3731,7 +3731,7 @@ msgstr "Aktywne pobierania"
 msgid "Active connections (1:1)"
 msgstr "Aktywnych połączeń (1:1)"
 
-#: src/muuli_wdr.cpp:1040 src/muuli_wdr.cpp:1872
+#: src/muuli_wdr.cpp:1040 src/muuli_wdr.cpp:1876
 msgid "Active uploads"
 msgstr "Aktywne wysyłania"
 
@@ -4007,7 +4007,7 @@ msgstr "Wiąż lokalne adresy z IP (puste dla każdego):"
 msgid "Advanced users only: If you have multiple network interfaces, enter the address of the interface to which aMule should be bound."
 msgstr "Tylko zaawansowani użytkownicy: Jeśli masz kilka interfejsów sieciowych, wpisz adres interfejsu do którego powiązany powinien być aMule."
 
-#: src/muuli_wdr.cpp:1462 src/muuli_wdr.cpp:2065
+#: src/muuli_wdr.cpp:1462 src/muuli_wdr.cpp:2069
 #, fuzzy
 msgid "Bind to network interface (empty for any):"
 msgstr "Wiąż lokalne adresy z IP (puste dla każdego):"
@@ -4024,7 +4024,7 @@ msgstr "Maks. ilość źródeł dla pobieranego pliku:"
 msgid "Max simultaneous connections:"
 msgstr "Maksymalne połączenia jednoczesne:"
 
-#: src/muuli_wdr.cpp:1498 src/muuli_wdr.cpp:3207
+#: src/muuli_wdr.cpp:1498 src/muuli_wdr.cpp:3211
 msgid "ED2K"
 msgstr "ED2K"
 
@@ -4116,780 +4116,780 @@ msgstr "Alokuj wstępnie przestrzeń dyskową dla nowych plików"
 msgid "For new files preallocates disk space for the whole file, thus reduces fragmentation"
 msgstr "Dla nowych plików alokuje wstępnie przestrzeń dyskową dla całego pliku redukując w ten sposób fragmentację"
 
-#: src/muuli_wdr.cpp:1617
+#: src/muuli_wdr.cpp:1621
 msgid "Create new files as sparse files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1618
+#: src/muuli_wdr.cpp:1622
 msgid "Sparse part files only occupy disk space for the parts already downloaded, so free space is used up gradually as the file fills in. Turn this off to use an ordinary file instead - useful where sparse files are unsupported or slow, or where backup/de-duplication tools handle them badly. Applies only when the core runs on Windows; on Linux and macOS part files are sparse anyway and this setting has no effect."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1623
+#: src/muuli_wdr.cpp:1627
 msgid "Stop downloads when free disk space reaches "
 msgstr "Zatrzymaj pobieranie gdy zabraknie wolnego miejsca na dysku"
 
-#: src/muuli_wdr.cpp:1624
+#: src/muuli_wdr.cpp:1628
 msgid "Select this if you want aMule to check your disk space"
 msgstr "Zaznacz jeśli chcesz, aby aMule sprawdzał Twoją przestrzeń dyskową"
 
-#: src/muuli_wdr.cpp:1628
+#: src/muuli_wdr.cpp:1632
 msgid "Enter here the min disk space desired."
 msgstr "Wpisz tu minimalną ilość miejsca na dysku."
 
-#: src/muuli_wdr.cpp:1634
+#: src/muuli_wdr.cpp:1638
 msgid "Save 10 sources on rare files (< 20 sources)"
 msgstr "Zapisz 10 źródeł dla rzadkich plików (< 20 źródeł)"
 
-#: src/muuli_wdr.cpp:1638 src/Statistics.cpp:790
+#: src/muuli_wdr.cpp:1642 src/Statistics.cpp:790
 msgid "Uploads"
 msgstr "Wysyłanie"
 
-#: src/muuli_wdr.cpp:1641
+#: src/muuli_wdr.cpp:1645
 msgid "Add new shared files with auto priority"
 msgstr "Dodaj udostępnione pliki z automatycznym priorytetem"
 
-#: src/muuli_wdr.cpp:1647
+#: src/muuli_wdr.cpp:1651
 msgid "Intelligent Corruption Handling (I.C.H.)"
 msgstr "Inteligentna obsługa uszkodzeń (I.C.H.)"
 
-#: src/muuli_wdr.cpp:1650
+#: src/muuli_wdr.cpp:1654
 msgid "Enable"
 msgstr "Włączone"
 
-#: src/muuli_wdr.cpp:1653
+#: src/muuli_wdr.cpp:1657
 msgid "Advanced I.C.H. trusts every hash (not recommended)"
 msgstr "Zaawansowane I.C.H. ufa każdemu skrótu (nie zalecane)"
 
-#: src/muuli_wdr.cpp:1665 src/PrefsUnifiedDlg.cpp:1990
+#: src/muuli_wdr.cpp:1669 src/PrefsUnifiedDlg.cpp:1999
 msgid "Media metadata extraction"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1669
+#: src/muuli_wdr.cpp:1673
 msgid "Extract length / bitrate / codec from shared audio and video files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1671
+#: src/muuli_wdr.cpp:1675
 msgid "When enabled, aMule runs ffprobe on each shared media file to fill in the Length / Bitrate / Codec columns other clients see when they find the file in a search. Requires ffmpeg (the ffprobe binary) to be installed."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1678
+#: src/muuli_wdr.cpp:1682
 msgid "Path to ffprobe:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1683
+#: src/muuli_wdr.cpp:1687
 msgid "Full path to the ffprobe binary. Leave empty to have aMule auto-detect it on startup."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1691
+#: src/muuli_wdr.cpp:1695
 msgid "Detect"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1692
+#: src/muuli_wdr.cpp:1696
 msgid "Search the standard install locations for an ffprobe binary and fill the path field."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1716
+#: src/muuli_wdr.cpp:1720
 msgid ""
 "Completed downloads are stored here. All files in this folder are automatically shared with other peers.\n"
 "If this folder also holds files you don't want to share, point it at an aMule-only sub-folder."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1719
+#: src/muuli_wdr.cpp:1723
 msgid "Pick the folder where completed downloads will be stored. All files in that folder will be shared with other peers."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1733
+#: src/muuli_wdr.cpp:1737
 msgid "Shared folders"
 msgstr "Udostępnione foldery"
 
-#: src/muuli_wdr.cpp:1739
+#: src/muuli_wdr.cpp:1743
 msgid "(Folders shared by the core. Enter a path to add one.)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1747
+#: src/muuli_wdr.cpp:1751
 msgid "Absolute path of a folder on the core's machine, e.g. /home/user/shared"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1749 src/PrefsUnifiedDlg.cpp:2874
+#: src/muuli_wdr.cpp:1753 src/PrefsUnifiedDlg.cpp:2883
 msgid "Recursive"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1750
+#: src/muuli_wdr.cpp:1754
 msgid "Share every sub-folder underneath this one, including ones created later."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1754 src/utils/aLinkCreator/src/alcframe.cpp:141
+#: src/muuli_wdr.cpp:1758 src/utils/aLinkCreator/src/alcframe.cpp:141
 msgid "Remove"
 msgstr "Usuń"
 
-#: src/muuli_wdr.cpp:1758
+#: src/muuli_wdr.cpp:1762
 msgid "(Right click on folder icon for recursive share)"
 msgstr "(Kliknij prawym przyciskiem na katalog, aby udostępnić go razem z podkatalogami)"
 
-#: src/muuli_wdr.cpp:1765
+#: src/muuli_wdr.cpp:1769
 msgid "Share hidden files"
 msgstr "Udostępnij pliki ukryte"
 
-#: src/muuli_wdr.cpp:1771
+#: src/muuli_wdr.cpp:1775
 msgid "Automatically rescan shared folders for changes"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1777
+#: src/muuli_wdr.cpp:1781
 msgid "Follow symbolic links in shared folders"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1783
+#: src/muuli_wdr.cpp:1787
 msgid "Exclude files matching:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1786
+#: src/muuli_wdr.cpp:1790
 msgid "Wildcard patterns separated by '|', e.g. .DS_Store|Thumbs.db|*.tmp. Files whose name matches are not shared. Matching is case-insensitive."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1790
+#: src/muuli_wdr.cpp:1794
 msgid "Patterns are regular expressions"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1791
+#: src/muuli_wdr.cpp:1795
 msgid "When set, the whole field is one regular expression ('|' is alternation). When unset, it is a list of '|'-separated wildcards."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1801
+#: src/muuli_wdr.cpp:1805
 msgid "Show how many shared files the current pattern would exclude."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1822
+#: src/muuli_wdr.cpp:1826
 msgid "Graphs"
 msgstr "Wykresy"
 
-#: src/muuli_wdr.cpp:1825 src/muuli_wdr.cpp:1887
+#: src/muuli_wdr.cpp:1829 src/muuli_wdr.cpp:1891
 msgid "Update delay : 5 secs"
 msgstr "Odśwież co : 5 sekund"
 
-#: src/muuli_wdr.cpp:1829
+#: src/muuli_wdr.cpp:1833
 msgid "Time for average graph: 100 mins"
 msgstr "Czas dla wykresów średnich: 100 minut"
 
-#: src/muuli_wdr.cpp:1833
+#: src/muuli_wdr.cpp:1837
 msgid "Connections Graph Scale: 100 "
 msgstr "Skala wykresu połączeń: 100"
 
-#: src/muuli_wdr.cpp:1840
+#: src/muuli_wdr.cpp:1844
 msgid "Download graph scale:"
 msgstr "Skala wykresu pobierania:"
 
-#: src/muuli_wdr.cpp:1848
+#: src/muuli_wdr.cpp:1852
 msgid "Upload graph scale:"
 msgstr "Skala wykresu przesyłania:"
 
-#: src/muuli_wdr.cpp:1858
+#: src/muuli_wdr.cpp:1862
 #, fuzzy
 msgid "Colors: "
 msgstr "Kolory: "
 
-#: src/muuli_wdr.cpp:1862
+#: src/muuli_wdr.cpp:1866
 msgid "Background"
 msgstr "Tło"
 
-#: src/muuli_wdr.cpp:1863
+#: src/muuli_wdr.cpp:1867
 msgid "Grid"
 msgstr "Siatka"
 
-#: src/muuli_wdr.cpp:1864
+#: src/muuli_wdr.cpp:1868
 msgid "Download current"
 msgstr "Aktualnie pobierane"
 
-#: src/muuli_wdr.cpp:1865
+#: src/muuli_wdr.cpp:1869
 msgid "Download running average"
 msgstr "Bieżąca średnia pobierania"
 
-#: src/muuli_wdr.cpp:1866
+#: src/muuli_wdr.cpp:1870
 msgid "Download session average"
 msgstr "Średnia pobierania sesji"
 
-#: src/muuli_wdr.cpp:1867
+#: src/muuli_wdr.cpp:1871
 msgid "Upload current"
 msgstr "Aktualnie wysyłane"
 
-#: src/muuli_wdr.cpp:1868
+#: src/muuli_wdr.cpp:1872
 msgid "Upload running average"
 msgstr "Bieżąca średnia wysyłania"
 
-#: src/muuli_wdr.cpp:1869
+#: src/muuli_wdr.cpp:1873
 msgid "Upload session average"
 msgstr "Średnia wysyłania sesji"
 
-#: src/muuli_wdr.cpp:1870
+#: src/muuli_wdr.cpp:1874
 msgid "Active connections"
 msgstr "Aktywnych połączeń"
 
-#: src/muuli_wdr.cpp:1873
+#: src/muuli_wdr.cpp:1877
 #, fuzzy
 msgid "Systray Icon Speed Bar"
 msgstr "Ikona prędkości w zasobniku systemowym"
 
-#: src/muuli_wdr.cpp:1874
+#: src/muuli_wdr.cpp:1878
 msgid "Kad-nodes current"
 msgstr "Obecne Kad-węzły "
 
-#: src/muuli_wdr.cpp:1875
+#: src/muuli_wdr.cpp:1879
 msgid "Kad-nodes running"
 msgstr "Działające Kad-węzły"
 
-#: src/muuli_wdr.cpp:1876
+#: src/muuli_wdr.cpp:1880
 msgid "Kad-nodes session"
 msgstr "Sesyjne Kad-węzły"
 
-#: src/muuli_wdr.cpp:1880 src/muuli_wdr.cpp:2334
+#: src/muuli_wdr.cpp:1884 src/muuli_wdr.cpp:2338
 msgid "Select"
 msgstr "Wybierz"
 
-#: src/muuli_wdr.cpp:1884
+#: src/muuli_wdr.cpp:1888
 msgid "Tree"
 msgstr "Drzewo"
 
-#: src/muuli_wdr.cpp:1894
+#: src/muuli_wdr.cpp:1898
 msgid "Number of Client Versions shown (0=unlimited)"
 msgstr "Liczba wyświetlanych wersji klienta (0=nieograniczona)"
 
-#: src/muuli_wdr.cpp:1919
+#: src/muuli_wdr.cpp:1923
 msgid "!!! WARNING !!!"
 msgstr "!!! UWAGA !!!"
 
-#: src/muuli_wdr.cpp:1934
+#: src/muuli_wdr.cpp:1938
 msgid "Max new connections / 5 secs"
 msgstr "Maks. nowych połączeń"
 
-#: src/muuli_wdr.cpp:1936
+#: src/muuli_wdr.cpp:1940
 msgid "Concurrent Kad source lookups"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1938
+#: src/muuli_wdr.cpp:1942
 #, fuzzy
 msgid "Kad source re-search interval (minutes)"
 msgstr "Czas pomiędzy odświeżeniami FTP w minutach"
 
-#: src/muuli_wdr.cpp:1940
+#: src/muuli_wdr.cpp:1944
 #, fuzzy
 msgid "Source re-ask interval (minutes)"
 msgstr "Czas pomiędzy odświeżeniami FTP w minutach"
 
-#: src/muuli_wdr.cpp:1944
+#: src/muuli_wdr.cpp:1948
 msgid "File Buffer Size: 240000 bytes"
 msgstr "Rozmiar bufora plików: 240000 bajtów"
 
-#: src/muuli_wdr.cpp:1948
+#: src/muuli_wdr.cpp:1952
 msgid "Use MMAP: memory-mapped file access (lower memory use)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1949
+#: src/muuli_wdr.cpp:1953
 msgid "Maps part files into memory instead of buffering them on the heap, lowering the process memory footprint. May reduce download speed on some disks; best for memory-constrained or upload-heavy hosts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1951
+#: src/muuli_wdr.cpp:1955
 msgid "Upload Queue Size: 5000 clients"
 msgstr "Rozmiar kolejki wysyłania: 5000 klientów"
 
-#: src/muuli_wdr.cpp:1955
+#: src/muuli_wdr.cpp:1959
 msgid "Server connection refresh interval: Disable"
 msgstr "Odświeżanie połączeń do serwera co: Wyłączone"
 
-#: src/muuli_wdr.cpp:1959
+#: src/muuli_wdr.cpp:1963
 msgid "Disable computer's timed standby mode"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1978
+#: src/muuli_wdr.cpp:1982
 msgid "Skin to use: "
 msgstr "Skóra do użycia:"
 
-#: src/muuli_wdr.cpp:1987
+#: src/muuli_wdr.cpp:1991
 msgid "Show \"Fast eD2k Links Handler\" in every window."
 msgstr "Pokazuj \"Szybkie wyłapywanie linków eD2K\" w każdym oknie."
 
-#: src/muuli_wdr.cpp:1990
+#: src/muuli_wdr.cpp:1994
 msgid "Show extended info on categories tabs"
 msgstr "Pokaż rozszerzone info w kartach kategorii"
 
-#: src/muuli_wdr.cpp:1993
+#: src/muuli_wdr.cpp:1997
 #, fuzzy
 msgid "Show application version on title"
 msgstr "Pokaż prędkość transferu w tytule"
 
-#: src/muuli_wdr.cpp:1995
+#: src/muuli_wdr.cpp:1999
 msgid "Show transfer rates on title"
 msgstr "Pokaż prędkość transferu w tytule"
 
-#: src/muuli_wdr.cpp:1997
+#: src/muuli_wdr.cpp:2001
 msgid "Before application name"
 msgstr "Przed nazwą aplikacji"
 
-#: src/muuli_wdr.cpp:1999
+#: src/muuli_wdr.cpp:2003
 msgid "After application name"
 msgstr "Za nazwą aplikacji"
 
-#: src/muuli_wdr.cpp:2002
+#: src/muuli_wdr.cpp:2006
 msgid "Show overhead bandwidth"
 msgstr "Pokaż narzut przepustowości"
 
-#: src/muuli_wdr.cpp:2006
+#: src/muuli_wdr.cpp:2010
 msgid "Vertical toolbar orientation"
 msgstr "Pionowa orientacja paska narzędzi"
 
-#: src/muuli_wdr.cpp:2008
+#: src/muuli_wdr.cpp:2012
 msgid "Live column sorting (auto-reorder rows as their values change)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2015
+#: src/muuli_wdr.cpp:2019
 msgid "Download Queue Files"
 msgstr "Pobierane pliki w kolejce"
 
-#: src/muuli_wdr.cpp:2018
+#: src/muuli_wdr.cpp:2022
 msgid "Show progress percentage"
 msgstr "Pokaż procent postępu"
 
-#: src/muuli_wdr.cpp:2024
+#: src/muuli_wdr.cpp:2028
 msgid "Show progress bar"
 msgstr "Pokaż pasek postępu"
 
-#: src/muuli_wdr.cpp:2027
+#: src/muuli_wdr.cpp:2031
 msgid "Flat"
 msgstr "Płaski"
 
-#: src/muuli_wdr.cpp:2031
+#: src/muuli_wdr.cpp:2035
 msgid "Round"
 msgstr "Okrągły"
 
-#: src/muuli_wdr.cpp:2049
+#: src/muuli_wdr.cpp:2053
 msgid "External Connection Parameters"
 msgstr "Parametry zewnętrznych połączeń"
 
-#: src/muuli_wdr.cpp:2052
+#: src/muuli_wdr.cpp:2056
 msgid "Accept external connections"
 msgstr "Akceptuj zewnętrzne połączenia"
 
-#: src/muuli_wdr.cpp:2059 src/muuli_wdr.cpp:2118
+#: src/muuli_wdr.cpp:2063 src/muuli_wdr.cpp:2122
 msgid "IP of the listening interface:"
 msgstr "IP z interfejsem słuchania:"
 
-#: src/muuli_wdr.cpp:2062
+#: src/muuli_wdr.cpp:2066
 msgid "Enter here a valid ip in the a.b.c.d format for the listening EC interface. An empty field or 0.0.0.0 will mean any interface."
 msgstr "Wprowadź tutaj w formacie a.b.c.d prawidłowy adres ip nasłuchującego interfejsu EC. Puste pole lub 0.0.0.0 oznacza dowolny interfejs."
 
-#: src/muuli_wdr.cpp:2083 src/muuli_wdr.cpp:2194
+#: src/muuli_wdr.cpp:2087 src/muuli_wdr.cpp:2198
 msgid "TCP port:"
 msgstr "Port TCP:"
 
-#: src/muuli_wdr.cpp:2089
+#: src/muuli_wdr.cpp:2093
 msgid "Enable UPnP port forwarding on the EC port"
 msgstr "Włącz forwarding portu UPnP na porcie EC"
 
-#: src/muuli_wdr.cpp:2093 src/muuli_wdr.cpp:3079
+#: src/muuli_wdr.cpp:2097 src/muuli_wdr.cpp:3083
 #: src/utils/wxCas/src/wxcasprefs.cpp:167
 msgid "Password"
 msgstr "Hasło"
 
-#: src/muuli_wdr.cpp:2099
+#: src/muuli_wdr.cpp:2103
 #, fuzzy
 msgid "aMule API server parameters"
 msgstr "Parametry serwera sieciowego"
 
-#: src/muuli_wdr.cpp:2102
+#: src/muuli_wdr.cpp:2106
 msgid "Run amuleapi (REST API) on startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2107
+#: src/muuli_wdr.cpp:2111
 #, fuzzy
 msgid "HTTP port:"
 msgstr "Port TCP:"
 
-#: src/muuli_wdr.cpp:2121
+#: src/muuli_wdr.cpp:2125
 msgid "The interface amuleapi's HTTP server listens on. 127.0.0.1 (default) accepts only local connections; use 0.0.0.0 or a specific IP to expose it to other hosts (set an admin password below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2126
+#: src/muuli_wdr.cpp:2130
 msgid "Type a password to set or change it. Stored passwords cannot be shown, so leaving this empty keeps the current one."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2128
+#: src/muuli_wdr.cpp:2132
 #, fuzzy
 msgid "Admin password"
 msgstr "Sprawdzam hasło\n"
 
-#: src/muuli_wdr.cpp:2140 src/muuli_wdr.cpp:2157 src/PrefsUnifiedDlg.cpp:1103
+#: src/muuli_wdr.cpp:2144 src/muuli_wdr.cpp:2161 src/PrefsUnifiedDlg.cpp:1112
 #, fuzzy
 msgid "A password is set."
 msgstr "Sprawdzam hasło\n"
 
-#: src/muuli_wdr.cpp:2144
+#: src/muuli_wdr.cpp:2148
 #, fuzzy
 msgid "Enable guest access"
 msgstr "Zabroń dostępu gościom"
 
-#: src/muuli_wdr.cpp:2145
+#: src/muuli_wdr.cpp:2149
 msgid "Guest sessions may read status and listings but cannot change anything. Turning this off clears the stored guest password."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2149
+#: src/muuli_wdr.cpp:2153
 #, fuzzy
 msgid "Guest password"
 msgstr "Hasło gościa do serwera sieciowego"
 
-#: src/muuli_wdr.cpp:2164
+#: src/muuli_wdr.cpp:2168
 msgid "Web server parameters"
 msgstr "Parametry serwera sieciowego"
 
-#: src/muuli_wdr.cpp:2167
+#: src/muuli_wdr.cpp:2171
 #, fuzzy
 msgid "Run webserver on startup (deprecated)"
 msgstr "Uruchom serwera internetowego przy starcie"
 
-#: src/muuli_wdr.cpp:2173
+#: src/muuli_wdr.cpp:2177
 msgid "Web template"
 msgstr "Szablon WWW"
 
-#: src/muuli_wdr.cpp:2178
+#: src/muuli_wdr.cpp:2182
 msgid "Full rights password"
 msgstr "Hasło pełnych uprawnień"
 
-#: src/muuli_wdr.cpp:2182
+#: src/muuli_wdr.cpp:2186
 msgid "Enable Low rights User"
 msgstr "Włącz użytkowników z niskimi uprawnieniami"
 
-#: src/muuli_wdr.cpp:2187
+#: src/muuli_wdr.cpp:2191
 msgid "Low rights password"
 msgstr "Hasło niskich uprawnień"
 
-#: src/muuli_wdr.cpp:2201
+#: src/muuli_wdr.cpp:2205
 msgid "Enable UPnP port forwarding of the web server port"
 msgstr "Włącz przekierowanie portu UPnP na port serwera internetowego"
 
-#: src/muuli_wdr.cpp:2206
+#: src/muuli_wdr.cpp:2210
 msgid "Web server UPnP TCP port (Optional)"
 msgstr "Port web serwera UPnP TCP (opcjonalnie)"
 
-#: src/muuli_wdr.cpp:2214
+#: src/muuli_wdr.cpp:2218
 msgid "Page Refresh Time (in secs)"
 msgstr "Odświeżanie strony co:  (w sekundach)"
 
-#: src/muuli_wdr.cpp:2221
+#: src/muuli_wdr.cpp:2225
 msgid "Enable Gzip compression"
 msgstr "Włącz kompresję Gzip"
 
-#: src/muuli_wdr.cpp:2255
+#: src/muuli_wdr.cpp:2259
 #, fuzzy
 msgid "Reset page to defaults"
 msgstr "Domyślny systemowy"
 
-#: src/muuli_wdr.cpp:2256
+#: src/muuli_wdr.cpp:2260
 msgid "Reset the settings on the current page to their default values."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2258 src/muuli_wdr.cpp:2344 src/ServerWnd.cpp:274
+#: src/muuli_wdr.cpp:2262 src/muuli_wdr.cpp:2348 src/ServerWnd.cpp:274
 #: src/ServerWnd.cpp:282
 msgid "OK"
 msgstr "OK"
 
-#: src/muuli_wdr.cpp:2260
+#: src/muuli_wdr.cpp:2264
 msgid "Click here to apply any changes made to the preferences."
 msgstr "Kliknij tu aby zastosować wszystkie zmiany dokonane w preferencjach."
 
-#: src/muuli_wdr.cpp:2263
+#: src/muuli_wdr.cpp:2267
 msgid "Reset any changes made to the preferences."
 msgstr "Reset wszystkich zmian dokonanych w preferencjach."
 
-#: src/muuli_wdr.cpp:2292
+#: src/muuli_wdr.cpp:2296
 msgid "Comment :"
 msgstr "Komentarz :"
 
-#: src/muuli_wdr.cpp:2299
+#: src/muuli_wdr.cpp:2303
 msgid "Incoming Dir :"
 msgstr "Katalog przychodzących :"
 
-#: src/muuli_wdr.cpp:2308
+#: src/muuli_wdr.cpp:2312
 msgid "Change priority for new assigned files :"
 msgstr "Zmień priorytet nowo przydzielonych plików :"
 
-#: src/muuli_wdr.cpp:2312
+#: src/muuli_wdr.cpp:2316
 #, fuzzy
 msgid "Don't change"
 msgstr "Nie zmieniaj"
 
-#: src/muuli_wdr.cpp:2324
+#: src/muuli_wdr.cpp:2328
 msgid "Select color for this Category (currently selected) :"
 msgstr "Wybierz kolor dla tej kategorii (aktualnie wybrany) :"
 
-#: src/muuli_wdr.cpp:2391 src/muuli_wdr.cpp:2410 src/muuli_wdr.cpp:2432
+#: src/muuli_wdr.cpp:2395 src/muuli_wdr.cpp:2414 src/muuli_wdr.cpp:2436
 msgid "Click this button to reset the log."
 msgstr "Kliknij tu aby wyczyścić logi."
 
-#: src/muuli_wdr.cpp:2451
+#: src/muuli_wdr.cpp:2455
 msgid "Click on this button to update the servers list from URL ..."
 msgstr "Kliknij na tym przycisku aby uaktualnić listę serwerów z URL-a ..."
 
-#: src/muuli_wdr.cpp:2455
+#: src/muuli_wdr.cpp:2459
 msgid "Server list"
 msgstr "Lista serwerów"
 
-#: src/muuli_wdr.cpp:2459
+#: src/muuli_wdr.cpp:2463
 msgid "Enter the url to a server.met file here and press the button to the left to update the list of known servers."
 msgstr "Wpisz tu url do pliku server.met  i przyciśnij przycisk po lewej aby zaktualizować listę znanych serwerów."
 
-#: src/muuli_wdr.cpp:2464
+#: src/muuli_wdr.cpp:2468
 msgid "Add server manually: Name"
 msgstr "Dodaj serwer ręcznie: Nazwa"
 
-#: src/muuli_wdr.cpp:2467
+#: src/muuli_wdr.cpp:2471
 msgid "Enter the name of the new server here"
 msgstr "Wpisz tu nazwę nowego serwera"
 
-#: src/muuli_wdr.cpp:2469 src/ServerWnd.cpp:206
+#: src/muuli_wdr.cpp:2473 src/ServerWnd.cpp:206
 msgid "IP:Port"
 msgstr "IP:Port"
 
-#: src/muuli_wdr.cpp:2472
+#: src/muuli_wdr.cpp:2476
 msgid "Enter the IP of the server here, using the x.x.x.x format."
 msgstr "Wpisz tu IP serwera, używając formatu x.x.x.x ."
 
-#: src/muuli_wdr.cpp:2478
+#: src/muuli_wdr.cpp:2482
 msgid "Enter the port of the server here."
 msgstr "Wpisz tu port serwera."
 
-#: src/muuli_wdr.cpp:2481
+#: src/muuli_wdr.cpp:2485
 msgid "Add manually a server (fill fields to the left before) ..."
 msgstr "Dodaj ręcznie serwer (wypełnij pola od lewej) ..."
 
-#: src/muuli_wdr.cpp:2510
+#: src/muuli_wdr.cpp:2514
 msgid "aMule Log"
 msgstr "Logi aMule"
 
-#: src/muuli_wdr.cpp:2518
+#: src/muuli_wdr.cpp:2522
 msgid "Server Info"
 msgstr "Serwer Info"
 
-#: src/muuli_wdr.cpp:2522
+#: src/muuli_wdr.cpp:2526
 msgid "ED2K Info"
 msgstr "Info eD2K"
 
-#: src/muuli_wdr.cpp:2526
+#: src/muuli_wdr.cpp:2530
 msgid "Kad Info"
 msgstr "Info Kad"
 
-#: src/muuli_wdr.cpp:2554
+#: src/muuli_wdr.cpp:2558
 msgid "Click on this button to update the nodes list from URL ..."
 msgstr "Kliknij ten przycisk, aby uaktualnić listę węzłów z adresu URL ..."
 
-#: src/muuli_wdr.cpp:2558
+#: src/muuli_wdr.cpp:2562
 msgid "Nodes (0)"
 msgstr "Węzły (0)"
 
-#: src/muuli_wdr.cpp:2562
+#: src/muuli_wdr.cpp:2566
 msgid "Enter the url to a nodes.dat file here and press the button to the left to update the list of known nodes."
 msgstr "Wprowadź tutaj url pliku nodes.dat i naciśnij przycisk z lewej, aby zaktualizować listę znanych węzłów."
 
-#: src/muuli_wdr.cpp:2565
+#: src/muuli_wdr.cpp:2569
 msgid "Nodes stats"
 msgstr "Statystyki węzłów"
 
-#: src/muuli_wdr.cpp:2607
+#: src/muuli_wdr.cpp:2611
 msgid "Bootstrap"
 msgstr "Bootstrap"
 
-#: src/muuli_wdr.cpp:2610
+#: src/muuli_wdr.cpp:2614
 msgid "New node"
 msgstr "Nowy węzeł"
 
-#: src/muuli_wdr.cpp:2615
+#: src/muuli_wdr.cpp:2619
 msgid "IP:"
 msgstr "IP:"
 
-#: src/muuli_wdr.cpp:2635
+#: src/muuli_wdr.cpp:2639
 msgid "Port:"
 msgstr "Port:"
 
-#: src/muuli_wdr.cpp:2648
+#: src/muuli_wdr.cpp:2652
 msgid "Bootstrap from known clients"
 msgstr "Rozruch od znanych klientów"
 
-#: src/muuli_wdr.cpp:2650
+#: src/muuli_wdr.cpp:2654
 msgid "Disconnect Kad"
 msgstr "Rozłącz z Kad"
 
-#: src/muuli_wdr.cpp:2684
+#: src/muuli_wdr.cpp:2688
 msgid "Use Secure User Identification"
 msgstr "Użyj bezpiecznej identyfikacji użytkownika"
 
-#: src/muuli_wdr.cpp:2686
+#: src/muuli_wdr.cpp:2690
 msgid "It is recommended to enable this option. You will not receive credits if SUI is not enabled."
 msgstr "Zalecane jest włączenie tej opcji. Nic nie zyskasz wyłączając bezpieczną identyfikację użytkownika."
 
-#: src/muuli_wdr.cpp:2688
+#: src/muuli_wdr.cpp:2692
 msgid "Protocol Obfuscation"
 msgstr "Maskowanie protokołu"
 
-#: src/muuli_wdr.cpp:2691
+#: src/muuli_wdr.cpp:2695
 msgid "Support Protocol Obfuscation"
 msgstr "Obsługa maskowania protokołu"
 
-#: src/muuli_wdr.cpp:2693
+#: src/muuli_wdr.cpp:2697
 msgid "This option enabled Protocol Obfuscation, and makes aMule accept obfuscated connections from other clients."
 msgstr "Opcja ta włącza maskowanie protokołu i powoduje, że aMule będzie akceptował zamaskowane połączenia od innych klientów."
 
-#: src/muuli_wdr.cpp:2695
+#: src/muuli_wdr.cpp:2699
 msgid "Use obfuscation for outgoing connections"
 msgstr "Użyj maskowania dla połączeń wychodzących"
 
-#: src/muuli_wdr.cpp:2697
+#: src/muuli_wdr.cpp:2701
 msgid "This option makes aMule use Protocol Obfuscation when connecting other clients/servers."
 msgstr "Opcja ta powoduje, że aMule będzie używał maskowania protokołu podczas łączenia z innymi klientami/serwerami."
 
-#: src/muuli_wdr.cpp:2699
+#: src/muuli_wdr.cpp:2703
 msgid "Accept only obfuscated connections"
 msgstr "Akceptuj tylko zamaskowane połączenia"
 
-#: src/muuli_wdr.cpp:2700
+#: src/muuli_wdr.cpp:2704
 msgid "This option makes aMule only accept obfuscated connections. You will have less sources, but all your traffic will be obfuscated"
 msgstr "Opcja ta powoduje, że aMule akceptuje tylko zamaskowane połączenia. Uzyskasz mniej źródeł, ale cały twój ruch będzie zamaskowany"
 
-#: src/muuli_wdr.cpp:2705
+#: src/muuli_wdr.cpp:2709
 msgid "Everybody"
 msgstr "Wszyscy"
 
-#: src/muuli_wdr.cpp:2707
+#: src/muuli_wdr.cpp:2711
 msgid "No one"
 msgstr "Nikt"
 
-#: src/muuli_wdr.cpp:2709
+#: src/muuli_wdr.cpp:2713
 msgid "Who can see my shared files:"
 msgstr "Kto może widzieć moje udostępnione pliki:"
 
-#: src/muuli_wdr.cpp:2710
+#: src/muuli_wdr.cpp:2714
 msgid "Select who can request to view a list of your shared files."
 msgstr "Wybierz kto może zażądać pokazania listy twoich udostępnionych plików."
 
-#: src/muuli_wdr.cpp:2712
+#: src/muuli_wdr.cpp:2716
 msgid "IP-Filtering"
 msgstr "Filtrowanie IP"
 
-#: src/muuli_wdr.cpp:2719
+#: src/muuli_wdr.cpp:2723
 msgid "Filter clients"
 msgstr "Filtruj klientów"
 
-#: src/muuli_wdr.cpp:2721
+#: src/muuli_wdr.cpp:2725
 msgid "Enable filtering of the client IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "Włącza filtrowanie IP klientów zdefiniowanych w pliku ~/.aMule/ipfilter.dat."
 
-#: src/muuli_wdr.cpp:2723
+#: src/muuli_wdr.cpp:2727
 msgid "Filter servers"
 msgstr "Filtruj serwery"
 
-#: src/muuli_wdr.cpp:2725
+#: src/muuli_wdr.cpp:2729
 msgid "Enable filtering of the server IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "Włącza filtrowanie IP serwerów zdefiniowanych w pliku ~/.aMule/ipfilter.dat."
 
-#: src/muuli_wdr.cpp:2729
+#: src/muuli_wdr.cpp:2733
 msgid "Reload List"
 msgstr "Przeładuj listę"
 
-#: src/muuli_wdr.cpp:2730
+#: src/muuli_wdr.cpp:2734
 msgid "Reload the list of IPs to filter from the file ~/.aMule/ipfilter.dat"
 msgstr "Przeładuj listę filtrowanych IP z pliku ~/.aMule/ipfilter.dat"
 
-#: src/muuli_wdr.cpp:2736
+#: src/muuli_wdr.cpp:2740
 msgid "URL:"
 msgstr "URL:"
 
-#: src/muuli_wdr.cpp:2740 src/muuli_wdr.cpp:2933
+#: src/muuli_wdr.cpp:2744 src/muuli_wdr.cpp:2937
 msgid "Update now"
 msgstr "Uaktualnij teraz"
 
-#: src/muuli_wdr.cpp:2743
+#: src/muuli_wdr.cpp:2747
 msgid "Auto-update ipfilter at startup"
 msgstr "Uaktualniaj filtr IP przy starcie"
 
-#: src/muuli_wdr.cpp:2747
+#: src/muuli_wdr.cpp:2751
 msgid "Filtering Level:"
 msgstr "Poziom filtrowania:"
 
-#: src/muuli_wdr.cpp:2753
+#: src/muuli_wdr.cpp:2757
 msgid "Always filter LAN IPs"
 msgstr "Zawsze filtruj IP z LAN"
 
-#: src/muuli_wdr.cpp:2756
+#: src/muuli_wdr.cpp:2760
 msgid "Paranoid handling of non-matching IPs"
 msgstr "Paranoidalna obsługa niepasujących IP"
 
-#: src/muuli_wdr.cpp:2758
+#: src/muuli_wdr.cpp:2762
 msgid "Rejects a packet when its source IP differs from the IP the client claims (an anti-spoofing check). Disable only if it causes connection problems."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2760
+#: src/muuli_wdr.cpp:2764
 msgid "Use system-wide ipfilter.dat if available"
 msgstr "Użyj ogólno-systemowego ipfilter.dat jeśli dostępny"
 
-#: src/muuli_wdr.cpp:2761
+#: src/muuli_wdr.cpp:2765
 #, fuzzy
 msgid "If there's no local ipfilter.dat found, allow usage of a system-wide ipfilter file."
 msgstr "Jeśli ipfilter.dat nie istnieje lokalnie, zezwól na użycie ogólno-systemowego pliku ipfilter."
 
-#: src/muuli_wdr.cpp:2778
+#: src/muuli_wdr.cpp:2782
 msgid "Enable Online-Signature"
 msgstr "Włącz podpis online"
 
-#: src/muuli_wdr.cpp:2780
+#: src/muuli_wdr.cpp:2784
 msgid "Enables the writing of the OS file, which can be used by external apps to create signatures and the like."
 msgstr "Włącza zapisywanie pliku OS, który może być użyty przez zewnętrzne aplikacje do stworzenia sygnatury itp."
 
-#: src/muuli_wdr.cpp:2784
+#: src/muuli_wdr.cpp:2788
 msgid "Update Frequency (Secs):"
 msgstr "Częstotliwość odświeżania (sek):"
 
-#: src/muuli_wdr.cpp:2787
+#: src/muuli_wdr.cpp:2791
 msgid "Change the frequency (in seconds) of Online Signature updates."
 msgstr "Zmień częstotliwość (w sekundach) aktualizacji Sygnatury Online."
 
-#: src/muuli_wdr.cpp:2795
+#: src/muuli_wdr.cpp:2799
 msgid "Save online signature file in: "
 msgstr "Zapisz podpis internetowy w pliku: "
 
-#: src/muuli_wdr.cpp:2801
+#: src/muuli_wdr.cpp:2805
 msgid "Click here to select the directory containing the the Online Signature files."
 msgstr "Kliknij tu aby wskazać katalog zawierający pliki Sygnatur Online."
 
-#: src/muuli_wdr.cpp:2834
+#: src/muuli_wdr.cpp:2838
 msgid "Show country flags for clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2835
+#: src/muuli_wdr.cpp:2839
 msgid "Render the country flag column in the transfers, queue and search views. Requires a valid MMDB GeoIP database (see below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2840
+#: src/muuli_wdr.cpp:2844
 #, fuzzy
 msgid "Database"
 msgstr "Prędkość transmisji danych :"
 
-#: src/muuli_wdr.cpp:2856
+#: src/muuli_wdr.cpp:2860
 #, fuzzy
 msgid "Source:"
 msgstr "Źródła"
 
-#: src/muuli_wdr.cpp:2859
+#: src/muuli_wdr.cpp:2863
 msgid "DB-IP (free, no account)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2860
+#: src/muuli_wdr.cpp:2864
 msgid "MaxMind GeoLite2 (free, account required)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2861
+#: src/muuli_wdr.cpp:2865
 msgid "Custom URL"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2864
+#: src/muuli_wdr.cpp:2868
 msgid "Choose which provider supplies the GeoIP MMDB database. DB-IP is the default - no account required. MaxMind requires a free account + license key. Use Custom URL to point at any other MMDB host (e.g. a local mirror)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2881
+#: src/muuli_wdr.cpp:2885
 msgid ""
 "No configuration required.\n"
 "\n"
@@ -4897,11 +4897,11 @@ msgid ""
 "License: Creative Commons BY 4.0 - https://creativecommons.org/licenses/by/4.0/"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2894
+#: src/muuli_wdr.cpp:2898
 msgid "License key:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2900
+#: src/muuli_wdr.cpp:2904
 msgid ""
 "Sign up for a free MaxMind account, then generate a License Key:\n"
 "https://www.maxmind.com/en/geolite2/signup\n"
@@ -4911,231 +4911,231 @@ msgid ""
 "Requires attribution and account registration; refresh at least every 30 days."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2915
+#: src/muuli_wdr.cpp:2919
 #, fuzzy
 msgid "Download URL:"
 msgstr "Pobranych: "
 
-#: src/muuli_wdr.cpp:2921
+#: src/muuli_wdr.cpp:2925
 msgid ""
 "Must point to an .mmdb file or a .gz / .tar.gz containing one.\n"
 "URL may include credentials (https://user:pass@host/...).\n"
 "License and attribution terms are set by the upstream URL - you are responsible."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2934
+#: src/muuli_wdr.cpp:2938
 msgid "Download the GeoIP database from the selected source."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2936
+#: src/muuli_wdr.cpp:2940
 #, fuzzy
 msgid "Auto-update on startup"
 msgstr "Uaktualniaj filtr IP przy starcie"
 
-#: src/muuli_wdr.cpp:2937
+#: src/muuli_wdr.cpp:2941
 msgid "Re-download the GeoIP database from the selected source every time aMule starts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2960
+#: src/muuli_wdr.cpp:2964
 msgid "Filter incoming messages (except current chat):"
 msgstr "Filtruj wiadomości przychodzące (za wyjątkiem aktualnej rozmowy):"
 
-#: src/muuli_wdr.cpp:2962
+#: src/muuli_wdr.cpp:2966
 msgid "Filter all messages"
 msgstr "Filtruj wszystkie wiadomości"
 
-#: src/muuli_wdr.cpp:2964
+#: src/muuli_wdr.cpp:2968
 msgid "Filter messages from people not on your friend list"
 msgstr "Filtruj wiadomości od ludzi, którzy nie są na twojej liście znajomych"
 
-#: src/muuli_wdr.cpp:2966
+#: src/muuli_wdr.cpp:2970
 msgid "Filter messages from unknown clients"
 msgstr "Filtruj wiadomości od nieznanych klientów"
 
-#: src/muuli_wdr.cpp:2968
+#: src/muuli_wdr.cpp:2972
 msgid "Filter messages containing (use ',' as separator):"
 msgstr "Filtruj wiadomości zawierające (jako separatora użyj ','):"
 
-#: src/muuli_wdr.cpp:2971 src/muuli_wdr.cpp:2982
+#: src/muuli_wdr.cpp:2975 src/muuli_wdr.cpp:2986
 msgid "add here the words amule should filter and block messages including it"
 msgstr "dodaj frazy które według których amule powinien filtrować i blokować wiadomości"
 
-#: src/muuli_wdr.cpp:2973
+#: src/muuli_wdr.cpp:2977
 msgid "Show received messages in the log"
 msgstr "Pokaż otrzymane wiadomości w dzienniku"
 
-#: src/muuli_wdr.cpp:2976
+#: src/muuli_wdr.cpp:2980
 msgid "Comments"
 msgstr "Komentarze"
 
-#: src/muuli_wdr.cpp:2979
+#: src/muuli_wdr.cpp:2983
 msgid "Filter comments containing (use ',' as separator):"
 msgstr "Filtruj komentarze zawierające (użyj ',' jako separatora):"
 
-#: src/muuli_wdr.cpp:3004
+#: src/muuli_wdr.cpp:3008
 msgid "Enable Proxy"
 msgstr "Włącz proxy"
 
-#: src/muuli_wdr.cpp:3005
+#: src/muuli_wdr.cpp:3009
 msgid "Enable/disable proxy support"
 msgstr "Włącza/Wyłącza obsługę proxy"
 
-#: src/muuli_wdr.cpp:3008
+#: src/muuli_wdr.cpp:3012
 msgid "Proxy type:"
 msgstr "Typ proxy:"
 
-#: src/muuli_wdr.cpp:3019
+#: src/muuli_wdr.cpp:3023
 msgid "Proxy host:"
 msgstr "Adres proxy:"
 
-#: src/muuli_wdr.cpp:3022
+#: src/muuli_wdr.cpp:3026
 msgid "The proxy host name"
 msgstr "Nazwa hosta proxy"
 
-#: src/muuli_wdr.cpp:3024
+#: src/muuli_wdr.cpp:3028
 msgid "Proxy port:"
 msgstr "Port proxy:"
 
-#: src/muuli_wdr.cpp:3027
+#: src/muuli_wdr.cpp:3031
 msgid "The proxy port"
 msgstr "Port serwera proxy"
 
-#: src/muuli_wdr.cpp:3029
+#: src/muuli_wdr.cpp:3033
 msgid "Enable authentication"
 msgstr "Włącz uwierzytelnianie"
 
-#: src/muuli_wdr.cpp:3030
+#: src/muuli_wdr.cpp:3034
 msgid "Enable/disable username/password authentication"
 msgstr "Włącza/Wyłącza uwierzytelnianie login/hasło"
 
-#: src/muuli_wdr.cpp:3033
+#: src/muuli_wdr.cpp:3037
 msgid "Username: "
 msgstr "Nazwa uzytkownika: "
 
-#: src/muuli_wdr.cpp:3036
+#: src/muuli_wdr.cpp:3040
 msgid "The username to use to connect to the proxy"
 msgstr "Login używany do połączeń z proxy"
 
-#: src/muuli_wdr.cpp:3038
+#: src/muuli_wdr.cpp:3042
 msgid "Password:"
 msgstr "Hasło:"
 
-#: src/muuli_wdr.cpp:3041
+#: src/muuli_wdr.cpp:3045
 msgid "The password to use to connect to the proxy"
 msgstr "Hasło używane do połączeń z proxy"
 
-#: src/muuli_wdr.cpp:3060
+#: src/muuli_wdr.cpp:3064
 msgid "Connect to:"
 msgstr "Połącz z:"
 
-#: src/muuli_wdr.cpp:3069
+#: src/muuli_wdr.cpp:3073
 msgid "Login to remote amule"
 msgstr "Login do zdalnego amule"
 
-#: src/muuli_wdr.cpp:3074
+#: src/muuli_wdr.cpp:3078
 msgid "User name"
 msgstr "Nazwa użytkownika"
 
-#: src/muuli_wdr.cpp:3085
+#: src/muuli_wdr.cpp:3089
 msgid "Remember those settings"
 msgstr "Zapamiętaj te ustawienia"
 
-#: src/muuli_wdr.cpp:3088
+#: src/muuli_wdr.cpp:3092
 #, fuzzy
 msgid "Force ZLIB compression"
 msgstr "Używaj kompresji gzip"
 
-#: src/muuli_wdr.cpp:3112
+#: src/muuli_wdr.cpp:3116
 msgid "Enable Verbose Debug-Logging."
 msgstr "Włącz gadatliwe logowanie debugowe."
 
-#: src/muuli_wdr.cpp:3114
+#: src/muuli_wdr.cpp:3118
 #, fuzzy
 msgid "Only to Logfile"
 msgstr "&Otwórz plik"
 
-#: src/muuli_wdr.cpp:3116
+#: src/muuli_wdr.cpp:3120
 msgid "Message Categories:"
 msgstr "Kategorie wiadomości:"
 
-#: src/muuli_wdr.cpp:3140 src/PartFileConvertDlg.cpp:160
+#: src/muuli_wdr.cpp:3144 src/PartFileConvertDlg.cpp:160
 msgid "Waiting..."
 msgstr "Czekam..."
 
-#: src/muuli_wdr.cpp:3160
+#: src/muuli_wdr.cpp:3164
 msgid "Add imports"
 msgstr "Dodaj importy"
 
-#: src/muuli_wdr.cpp:3163
+#: src/muuli_wdr.cpp:3167
 msgid "Retry selected"
 msgstr "Przywróć wybrane"
 
-#: src/muuli_wdr.cpp:3165
+#: src/muuli_wdr.cpp:3169
 msgid "Remove selected"
 msgstr "Usuń wybrane"
 
-#: src/muuli_wdr.cpp:3228
+#: src/muuli_wdr.cpp:3232
 msgid "Event Types"
 msgstr "Typy zdarzeń"
 
-#: src/muuli_wdr.cpp:3247
+#: src/muuli_wdr.cpp:3251
 msgid "Statistics and queued clients for selected file(s) : Session / All time"
 msgstr "Statystyki i klienty w kolejce dla wybranego plik(u-ów) : Sesja / Cały czas"
 
-#: src/muuli_wdr.cpp:3271
+#: src/muuli_wdr.cpp:3275
 msgid "Active Uploads"
 msgstr "Aktywne wysyłania"
 
-#: src/muuli_wdr.cpp:3285
+#: src/muuli_wdr.cpp:3289
 #, fuzzy
 msgid "Percent of total files"
 msgstr "procent wszystkich plików"
 
-#: src/muuli_wdr.cpp:3337
+#: src/muuli_wdr.cpp:3341
 #, fuzzy
 msgid "Show Clients for"
 msgstr "Pokaż klientów"
 
-#: src/muuli_wdr.cpp:3339
+#: src/muuli_wdr.cpp:3343
 #, fuzzy
 msgid "All files"
 msgstr "Wszystkie udostępnione pliki"
 
-#: src/muuli_wdr.cpp:3342
+#: src/muuli_wdr.cpp:3346
 #, fuzzy
 msgid "Selected files"
 msgstr "Wybierz filtr przeglądania"
 
-#: src/muuli_wdr.cpp:3345
+#: src/muuli_wdr.cpp:3349
 #, fuzzy
 msgid "Active uploads only"
 msgstr "Aktywne wysyłania"
 
-#: src/muuli_wdr.cpp:3352
+#: src/muuli_wdr.cpp:3356
 msgid "Reload:"
 msgstr "Przeładuj:"
 
-#: src/muuli_wdr.cpp:3356
+#: src/muuli_wdr.cpp:3360
 msgid "Reload your shared files"
 msgstr "Przeładuj twoje udostępnione pliki"
 
-#: src/muuli_wdr.cpp:3419
+#: src/muuli_wdr.cpp:3423
 msgid "Send"
 msgstr "Wyślij"
 
-#: src/muuli_wdr.cpp:3420
+#: src/muuli_wdr.cpp:3424
 msgid "Sends the specified message."
 msgstr "Wysyła wybraną wiadomość."
 
-#: src/muuli_wdr.cpp:3424
+#: src/muuli_wdr.cpp:3428
 msgid "Close this chat-session."
 msgstr "Zamknij tę sesję czata."
 
-#: src/muuli_wdr.cpp:3447
+#: src/muuli_wdr.cpp:3451
 msgid "Connect to any server and/or Kad"
 msgstr "Podłącz do dowolnego serwera i/lub Kad"
 
-#: src/muuli_wdr.cpp:3453 src/SharedFilesCtrl.cpp:142 src/Statistics.cpp:941
+#: src/muuli_wdr.cpp:3457 src/SharedFilesCtrl.cpp:142 src/Statistics.cpp:941
 msgid "Shared Files"
 msgstr "Udostępnione pliki"
 
@@ -5774,35 +5774,35 @@ msgstr ""
 "\n"
 "aMule będzie działał prawidłowo bez zmiany tych ustawień."
 
-#: src/PrefsUnifiedDlg.cpp:647
+#: src/PrefsUnifiedDlg.cpp:656
 #, c-format
 msgid "Failed to connect Cfg to widget with the ID %d and key %s"
 msgstr "Błąd połączenia Cfg do widżetu z identyfikatorem %d i kluczem %s"
 
-#: src/PrefsUnifiedDlg.cpp:695
+#: src/PrefsUnifiedDlg.cpp:704
 #, c-format
 msgid "Failed to transfer data from Cfg to Widget with the ID %d and key %s"
 msgstr "Błąd przesyłania danych połączenia z Cfg do widżetu z identyfikatorem %d i kluczem %s"
 
-#: src/PrefsUnifiedDlg.cpp:801
+#: src/PrefsUnifiedDlg.cpp:810
 msgid "The type of proxy you are connecting to"
 msgstr "Typ serwera proxy do którego się łączysz"
 
-#: src/PrefsUnifiedDlg.cpp:1020
+#: src/PrefsUnifiedDlg.cpp:1029
 #, c-format
 msgid "Failed to transfer data from Widget to Cfg with the ID %d and key %s"
 msgstr "Błąd przesyłania danych połączenia z widżetu do Cfg z identyfikatorem %d i kluczem %s"
 
-#: src/PrefsUnifiedDlg.cpp:1103
+#: src/PrefsUnifiedDlg.cpp:1112
 #, fuzzy
 msgid "No password set."
 msgstr "Sprawdzam hasło\n"
 
-#: src/PrefsUnifiedDlg.cpp:1132
+#: src/PrefsUnifiedDlg.cpp:1141
 msgid "Guest access needs a password. Type one in the guest password field, or untick Enable guest access."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1144
+#: src/PrefsUnifiedDlg.cpp:1153
 msgid ""
 "aMule must be restarted to enable these changes:\n"
 "\n"
@@ -5810,45 +5810,45 @@ msgstr ""
 "aMule musi zostać zrestartowany przed wprowadzeniem tych zmian:\n"
 "\n"
 
-#: src/PrefsUnifiedDlg.cpp:1151
+#: src/PrefsUnifiedDlg.cpp:1160
 msgid "- TCP port changed.\n"
 msgstr "- Zmieniono port TCP.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1156
+#: src/PrefsUnifiedDlg.cpp:1165
 msgid "- UDP port changed.\n"
 msgstr "- Zmieniono port UDP.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1161
+#: src/PrefsUnifiedDlg.cpp:1170
 #, fuzzy
 msgid "- Network interface binding changed.\n"
 msgstr "Zewnętrzne połączenie zamknięte."
 
-#: src/PrefsUnifiedDlg.cpp:1166
+#: src/PrefsUnifiedDlg.cpp:1175
 #, fuzzy
 msgid "- External connect port changed.\n"
 msgstr "Zewnętrzne połączenie zamknięte."
 
-#: src/PrefsUnifiedDlg.cpp:1170
+#: src/PrefsUnifiedDlg.cpp:1179
 #, fuzzy
 msgid "- External connect acceptance changed.\n"
 msgstr "Nowe zewnętrzne połączenie zaakceptowane"
 
-#: src/PrefsUnifiedDlg.cpp:1174
+#: src/PrefsUnifiedDlg.cpp:1183
 #, fuzzy
 msgid "- External connect interface changed.\n"
 msgstr "Zewnętrzne połączenie zamknięte."
 
-#: src/PrefsUnifiedDlg.cpp:1178
+#: src/PrefsUnifiedDlg.cpp:1187
 #, fuzzy
 msgid "- Protocol obfuscation support changed.\n"
 msgstr "Maskowanie protokołu"
 
-#: src/PrefsUnifiedDlg.cpp:1193
+#: src/PrefsUnifiedDlg.cpp:1202
 #, fuzzy
 msgid "- amuleapi settings changed.\n"
 msgstr "- Zmieniono język.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1202
+#: src/PrefsUnifiedDlg.cpp:1211
 msgid ""
 "Your Auto-update server list is empty.\n"
 "'Auto-update server list at startup' will be disabled."
@@ -5856,7 +5856,7 @@ msgstr ""
 "Twoja lista auto-aktualizacji serwerów jest pusta.\n"
 "'Autoaktualizacja listy serwerów przy starcie' zostanie wyłączona."
 
-#: src/PrefsUnifiedDlg.cpp:1213
+#: src/PrefsUnifiedDlg.cpp:1222
 msgid ""
 "You have enabled external connections but have not specified a password.\n"
 "External connections cannot be enabled unless a valid password is specified."
@@ -5864,33 +5864,33 @@ msgstr ""
 "Połączenia zewnętrzne zostały włączone, ale nie zostało podane hasło.\n"
 "Połączenia zewnętrzne nie mogą być włączone dopóki nie zostanie podane poprawne hasło."
 
-#: src/PrefsUnifiedDlg.cpp:1246
+#: src/PrefsUnifiedDlg.cpp:1255
 #, c-format
 msgid "The amuleapi password could not be saved: %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1276
+#: src/PrefsUnifiedDlg.cpp:1285
 msgid "- Language changed.\n"
 msgstr "- Zmieniono język.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1281
+#: src/PrefsUnifiedDlg.cpp:1290
 msgid "- Temp folder changed.\n"
 msgstr "- Zmieniono folder tymczasowy.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1286
+#: src/PrefsUnifiedDlg.cpp:1295
 msgid "- ED2K network enabled.\n"
 msgstr "- sieć ED2K włączona.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1319
+#: src/PrefsUnifiedDlg.cpp:1328
 msgid "The shared-file exclusion pattern is not a valid regular expression. The filter has been left disabled."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1321 src/PrefsUnifiedDlg.cpp:1921
+#: src/PrefsUnifiedDlg.cpp:1330 src/PrefsUnifiedDlg.cpp:1930
 #, fuzzy
 msgid "Invalid regular expression"
 msgstr "Zła wersja protokołu."
 
-#: src/PrefsUnifiedDlg.cpp:1398
+#: src/PrefsUnifiedDlg.cpp:1407
 msgid ""
 "Both eD2k and Kad network are disabled.\n"
 "You won't be able to connect until you enable at least one of them."
@@ -5898,7 +5898,7 @@ msgstr ""
 "Zarówno sieć eD2K jak i Kad zostały wyłączone.\n"
 "Nie będzie możliwe połączenie, dopóki nie włączysz przynajmniej jednej z nich."
 
-#: src/PrefsUnifiedDlg.cpp:1403
+#: src/PrefsUnifiedDlg.cpp:1412
 msgid ""
 "Kad will not start if your UDP port is disabled.\n"
 "Enable UDP port or disable Kad."
@@ -5906,7 +5906,7 @@ msgstr ""
 "Kad nie uruchomi się, jeśli twój port UDP jest wyłączony.\n"
 "Włącz port UDP lub wyłącz Kad."
 
-#: src/PrefsUnifiedDlg.cpp:1459
+#: src/PrefsUnifiedDlg.cpp:1468
 msgid ""
 "\n"
 "You MUST restart aMule now.\n"
@@ -5916,69 +5916,69 @@ msgstr ""
 "Musisz zrestartować teraz aMule.\n"
 "Jeśli nie zrestartujesz go teraz, nie narzekaj, jeśli stanie się coś złego.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1524
+#: src/PrefsUnifiedDlg.cpp:1533
 msgid "Could not register aMule for autostart at login. The autostart store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1526
+#: src/PrefsUnifiedDlg.cpp:1535
 msgid "Could not remove the autostart-at-login entry."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1527
+#: src/PrefsUnifiedDlg.cpp:1536
 #, fuzzy
 msgid "Autostart"
 msgstr "automatyczne odświeżanie rozpoczęte"
 
-#: src/PrefsUnifiedDlg.cpp:1542
+#: src/PrefsUnifiedDlg.cpp:1551
 msgid "Register file type"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1542
+#: src/PrefsUnifiedDlg.cpp:1551
 msgid "Register URL handler"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1550
+#: src/PrefsUnifiedDlg.cpp:1559
 #, c-format
 msgid "aMule only handles eD2k-compatible magnets. If you replace the current magnet handler (%s), BitTorrent magnet links will stop working - aMule cannot download BitTorrent content. Continue?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1555
+#: src/PrefsUnifiedDlg.cpp:1564
 #, c-format
 msgid "Another application currently opens .emulecollection files (%s). Replace it with aMule?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1560
+#: src/PrefsUnifiedDlg.cpp:1569
 #, c-format
 msgid "Another application is currently the default handler for these links (%s). Replace it with aMule?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1585
+#: src/PrefsUnifiedDlg.cpp:1594
 msgid "Could not register aMule for .emulecollection files. The registration store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1587
+#: src/PrefsUnifiedDlg.cpp:1596
 #, fuzzy
 msgid "Could not remove the file type registration."
 msgstr "Folder dla pobranych plików tymczasowych"
 
-#: src/PrefsUnifiedDlg.cpp:1589
+#: src/PrefsUnifiedDlg.cpp:1598
 msgid "Could not register aMule as the URL handler. The registration store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1591
+#: src/PrefsUnifiedDlg.cpp:1600
 msgid "Could not remove the URL handler registration."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1661 src/PrefsUnifiedDlg.cpp:1688
+#: src/PrefsUnifiedDlg.cpp:1670 src/PrefsUnifiedDlg.cpp:1697
 #, fuzzy
 msgid "The web server and aMule API require external connections to be enabled."
 msgstr "Ustawione hasło i włączone połączenia zewnętrzne."
 
-#: src/PrefsUnifiedDlg.cpp:1671
+#: src/PrefsUnifiedDlg.cpp:1680
 msgid "The aMule web server is deprecated. Consider running the aMule API instead."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1735
+#: src/PrefsUnifiedDlg.cpp:1744
 msgid ""
 "Your Auto-update servers list is in blank.\n"
 "Please fill in at least one URL to point to a valid server.met file.\n"
@@ -5988,24 +5988,24 @@ msgstr ""
 "Proszę wpisać co najmniej jeden URL wskazujący poprawny plik server.met.\n"
 " Kliknij na przycisku \"Lista\", aby wpisać URL."
 
-#: src/PrefsUnifiedDlg.cpp:1876
+#: src/PrefsUnifiedDlg.cpp:1885
 msgid "Temporary files"
 msgstr "Pliki tymczasowe"
 
-#: src/PrefsUnifiedDlg.cpp:1881
+#: src/PrefsUnifiedDlg.cpp:1890
 msgid "Incoming files"
 msgstr "Pliki przychodzące"
 
-#: src/PrefsUnifiedDlg.cpp:1886
+#: src/PrefsUnifiedDlg.cpp:1895
 msgid "Online Signatures"
 msgstr "Sygnatury Online"
 
-#: src/PrefsUnifiedDlg.cpp:1899
+#: src/PrefsUnifiedDlg.cpp:1908
 #, c-format
 msgid "Choose a folder for %s"
 msgstr "Wybierz folder na %s"
 
-#: src/PrefsUnifiedDlg.cpp:1923
+#: src/PrefsUnifiedDlg.cpp:1932
 #, fuzzy, c-format
 msgid "Would exclude %u of %u shared file"
 msgid_plural "Would exclude %u of %u shared files"
@@ -6013,42 +6013,42 @@ msgstr[0] "Znaleziono %i znany udostępniony plik"
 msgstr[1] "Znaleziono %i znane udostępnionych plików"
 msgstr[2] "Znaleziono %i znanych udostępnionych plików"
 
-#: src/PrefsUnifiedDlg.cpp:1940
+#: src/PrefsUnifiedDlg.cpp:1949
 msgid "Browse for videoplayer"
 msgstr "Szukaj odtwarzacza filmów"
 
-#: src/PrefsUnifiedDlg.cpp:1944
+#: src/PrefsUnifiedDlg.cpp:1953
 msgid "Select browser"
 msgstr "Wybierz przeglądarkę"
 
-#: src/PrefsUnifiedDlg.cpp:1948
+#: src/PrefsUnifiedDlg.cpp:1957
 #, fuzzy
 msgid "Select ffprobe binary"
 msgstr "Wybierz przeglądarkę"
 
-#: src/PrefsUnifiedDlg.cpp:1954
+#: src/PrefsUnifiedDlg.cpp:1963
 #, c-format
 msgid "Executable%s"
 msgstr "Program%s"
 
-#: src/PrefsUnifiedDlg.cpp:1988
+#: src/PrefsUnifiedDlg.cpp:1997
 msgid "ffprobe not found on PATH or in the standard install locations. Install ffmpeg (which ships ffprobe) or use Browse to pick a binary manually."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2000
+#: src/PrefsUnifiedDlg.cpp:2009
 msgid "Reset the settings on this page to their default values?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2001
+#: src/PrefsUnifiedDlg.cpp:2010
 #, fuzzy
 msgid "Reset to defaults"
 msgstr "Domyślny systemowy"
 
-#: src/PrefsUnifiedDlg.cpp:2028
+#: src/PrefsUnifiedDlg.cpp:2037
 msgid "Edit server list"
 msgstr "Edytuj listę serwerów"
 
-#: src/PrefsUnifiedDlg.cpp:2029
+#: src/PrefsUnifiedDlg.cpp:2038
 msgid ""
 "Add here URL's to download server.met files.\n"
 "Only one url on each line."
@@ -6056,42 +6056,42 @@ msgstr ""
 "Dodaj jeden URL w każdej linii.\n"
 "Tylko jeden URL w każdej linii."
 
-#: src/PrefsUnifiedDlg.cpp:2084
+#: src/PrefsUnifiedDlg.cpp:2093
 msgid "IP2Country update failed"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2229 src/PrefsUnifiedDlg.cpp:2260
+#: src/PrefsUnifiedDlg.cpp:2238 src/PrefsUnifiedDlg.cpp:2269
 msgid "Data by MaxMind GeoLite2"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2231 src/PrefsUnifiedDlg.cpp:2262
+#: src/PrefsUnifiedDlg.cpp:2240 src/PrefsUnifiedDlg.cpp:2271
 #, fuzzy
 msgid "Custom source"
 msgstr "Pełne źródła"
 
-#: src/PrefsUnifiedDlg.cpp:2233 src/PrefsUnifiedDlg.cpp:2264
+#: src/PrefsUnifiedDlg.cpp:2242 src/PrefsUnifiedDlg.cpp:2273
 msgid "Data by DB-IP.com"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2284
+#: src/PrefsUnifiedDlg.cpp:2293
 #, fuzzy, c-format
 msgid "Status: Loaded%s"
 msgstr "Status:"
 
-#: src/PrefsUnifiedDlg.cpp:2286
+#: src/PrefsUnifiedDlg.cpp:2295
 #, fuzzy, c-format
 msgid "Status: Loaded%s - %s"
 msgstr "Status:"
 
-#: src/PrefsUnifiedDlg.cpp:2290
+#: src/PrefsUnifiedDlg.cpp:2299
 msgid "Status: Failed to load - click 'Update now' to refresh."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2292
+#: src/PrefsUnifiedDlg.cpp:2301
 msgid "Status: Not found - click 'Update now' to download."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2350 src/PrefsUnifiedDlg.cpp:2374
+#: src/PrefsUnifiedDlg.cpp:2359 src/PrefsUnifiedDlg.cpp:2383
 #, c-format
 msgid "Update delay: %d second"
 msgid_plural "Update delay: %d seconds"
@@ -6099,7 +6099,7 @@ msgstr[0] "Opóźnienie odświeżania: %d sekunda"
 msgstr[1] "Opóźnienie odświeżania: %d sekundy"
 msgstr[2] "Opóźnienie odświeżania: %d sekund"
 
-#: src/PrefsUnifiedDlg.cpp:2358
+#: src/PrefsUnifiedDlg.cpp:2367
 #, c-format
 msgid "Time for average graph: %d minute"
 msgid_plural "Time for average graph: %d minutes"
@@ -6107,12 +6107,12 @@ msgstr[0] "Czas dla przeciętnego wykresu: %d minuta"
 msgstr[1] "Czas dla przeciętnego wykresu: %d minuty"
 msgstr[2] "Czas dla przeciętnego wykresu: %d minut"
 
-#: src/PrefsUnifiedDlg.cpp:2367
+#: src/PrefsUnifiedDlg.cpp:2376
 #, c-format
 msgid "Connections Graph Scale: %d"
 msgstr "Skala wykresu połączeń: %d"
 
-#: src/PrefsUnifiedDlg.cpp:2382
+#: src/PrefsUnifiedDlg.cpp:2391
 #, c-format
 msgid "File Buffer Size: %d byte"
 msgid_plural "File Buffer Size: %d bytes"
@@ -6120,7 +6120,7 @@ msgstr[0] "Rozmiar bufora pliku: %d bajt"
 msgstr[1] "Rozmiar bufora pliku: %d bajty"
 msgstr[2] "Rozmiar bufora pliku: %d bajtów"
 
-#: src/PrefsUnifiedDlg.cpp:2392
+#: src/PrefsUnifiedDlg.cpp:2401
 #, c-format
 msgid "Upload Queue Size: %d client"
 msgid_plural "Upload Queue Size: %d clients"
@@ -6128,7 +6128,7 @@ msgstr[0] "Rozmiar kolejki wysyłania: %d klient"
 msgstr[1] "Rozmiar kolejki wysyłania: %d klientów"
 msgstr[2] "Rozmiar kolejki wysyłania: %d klientów"
 
-#: src/PrefsUnifiedDlg.cpp:2402
+#: src/PrefsUnifiedDlg.cpp:2411
 #, c-format
 msgid "Server connection refresh interval: %d minute"
 msgid_plural "Server connection refresh interval: %d minutes"
@@ -6136,79 +6136,79 @@ msgstr[0] "Odświeżanie połączeń do serwera co: %d minutę"
 msgstr[1] "Odświeżanie połączeń do serwera co: %d minuty"
 msgstr[2] "Odświeżanie połączeń do serwera co: %d minut"
 
-#: src/PrefsUnifiedDlg.cpp:2407
+#: src/PrefsUnifiedDlg.cpp:2416
 msgid "Server connection refresh interval: Disabled"
 msgstr "Odświeżanie połączeń do serwera co: Wyłączone"
 
-#: src/PrefsUnifiedDlg.cpp:2451
+#: src/PrefsUnifiedDlg.cpp:2460
 msgid "disabled"
 msgstr "wyłączone"
 
-#: src/PrefsUnifiedDlg.cpp:2477
+#: src/PrefsUnifiedDlg.cpp:2486
 #, fuzzy, c-format
 msgid "Execute command on '%s' event"
 msgstr "Wykonaj komendę przy wydarzeniu `%s'"
 
-#: src/PrefsUnifiedDlg.cpp:2484
+#: src/PrefsUnifiedDlg.cpp:2493
 msgid "Enable command execution on core"
 msgstr "Włącz wykonanie komendy w rdzeniu"
 
-#: src/PrefsUnifiedDlg.cpp:2496
+#: src/PrefsUnifiedDlg.cpp:2505
 msgid "Core command:"
 msgstr "Komenda rdzenia:"
 
-#: src/PrefsUnifiedDlg.cpp:2512
+#: src/PrefsUnifiedDlg.cpp:2521
 msgid "Enable command execution on GUI"
 msgstr "Włącz wykonanie komendy w GUI"
 
-#: src/PrefsUnifiedDlg.cpp:2524
+#: src/PrefsUnifiedDlg.cpp:2533
 msgid "GUI command:"
 msgstr "Komenda GUI:"
 
-#: src/PrefsUnifiedDlg.cpp:2540
+#: src/PrefsUnifiedDlg.cpp:2549
 msgid "The following variables will be replaced:"
 msgstr "Następujące zmienne zostaną zastąpione:"
 
-#: src/PrefsUnifiedDlg.cpp:2708
+#: src/PrefsUnifiedDlg.cpp:2717
 msgid ""
 "The following folders look like system or sensitive locations:\n"
 "\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2713
+#: src/PrefsUnifiedDlg.cpp:2722
 msgid "Sharing them recursively will publish every file underneath on the eD2k/Kad networks. Do you really want to do this?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2716
+#: src/PrefsUnifiedDlg.cpp:2725
 #, fuzzy
 msgid "Confirm shared folders"
 msgstr "Udostępnione foldery"
 
-#: src/PrefsUnifiedDlg.cpp:2744
+#: src/PrefsUnifiedDlg.cpp:2753
 #, fuzzy
 msgid "Reloading shared files..."
 msgstr "Przeładuj twoje udostępnione pliki"
 
-#: src/PrefsUnifiedDlg.cpp:2745
+#: src/PrefsUnifiedDlg.cpp:2754
 msgid "Scanning for subdirectories..."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2746
+#: src/PrefsUnifiedDlg.cpp:2755
 #, fuzzy
 msgid "Updating shared folders"
 msgstr "Udostępnione foldery"
 
-#: src/PrefsUnifiedDlg.cpp:2773
+#: src/PrefsUnifiedDlg.cpp:2782
 #, c-format
 msgid "Scanned %u directories..."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2823
+#: src/PrefsUnifiedDlg.cpp:2832
 #, fuzzy, c-format
 msgid "Reloading shared files: %u files scanned"
 msgstr "Przeładowuje listę udostępnionych plików."
 
-#: src/PrefsUnifiedDlg.cpp:2873
+#: src/PrefsUnifiedDlg.cpp:2882
 #, fuzzy
 msgid "Shared folder"
 msgstr "Udostępnione foldery"
@@ -7903,12 +7903,12 @@ msgstr "Usuń kategorię"
 msgid "Hashset requested for unknown file: %s"
 msgstr "Żądanie skrótu dla nieznanego pliku: %s"
 
-#: src/UploadQueue.cpp:618
+#: src/UploadQueue.cpp:627
 #, c-format
 msgid "Resuming uploads of file: %s"
 msgstr "Wznawianie wysyłania pliku: %s"
 
-#: src/UploadQueue.cpp:634
+#: src/UploadQueue.cpp:643
 #, c-format
 msgid "Suspending upload of file: %s"
 msgstr "Wstrzymywanie wysyłania pliku: %s"

--- a/po/pl.po
+++ b/po/pl.po
@@ -12,8 +12,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-28 12:12+0200\n"
-"PO-Revision-Date: 2026-07-27 10:30+0000\n"
+"POT-Creation-Date: 2026-07-28 08:06+0200\n"
+"PO-Revision-Date: 2026-07-27 11:43+0000\n"
 "Last-Translator: Michał Trzebiatowski <hippie_1968@hotmail.com>\n"
 "Language-Team: translationproject.org/team/pl.html <translation-team-pl@lists.sourceforge.net>\n"
 "Language: pl\n"
@@ -147,7 +147,7 @@ msgstr ""
 msgid "Not now"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:422 src/amuleDlg.cpp:665
+#: src/AppImageIntegration.cpp:422 src/amuleDlg.cpp:600
 msgid "Don't ask again"
 msgstr ""
 
@@ -205,83 +205,83 @@ msgstr "Nie udało się otworzyć pliku ED2KLinks."
 msgid "WARNING: You can't add yourself as a source for an eD2k link while having a lowid."
 msgstr "UWAGA: Nie możesz dodać samego siebie jako źródło linku ed2k, gdy masz lowid."
 
-#: src/amule.cpp:301
+#: src/amule.cpp:300
 msgid "Now, exiting main app..."
 msgstr "Teraz, zakańczam główną aplikację..."
 
-#: src/amule.cpp:331
+#: src/amule.cpp:330
 #, c-format
 msgid "Terminating amuleweb instance with pid '%d' ... "
 msgstr "Zakańczam instancję amuleweb z pid `%d' ... "
 
-#: src/amule.cpp:335
+#: src/amule.cpp:334
 #, c-format
 msgid "Killing amuleweb instance with pid '%d' ... "
 msgstr "Zabiłam instancję amuleweb z pid `%d' ... "
 
-#: src/amule.cpp:337 src/amule.cpp:350 src/ClientRef.cpp:180
-#: src/SearchDlg.cpp:1041 src/ServerListCtrl.cpp:98
+#: src/amule.cpp:336 src/amule.cpp:349 src/ClientRef.cpp:180
+#: src/SearchDlg.cpp:880 src/ServerListCtrl.cpp:98
 msgid "Failed"
 msgstr "Nieudane"
 
-#: src/amule.cpp:344
+#: src/amule.cpp:343
 #, fuzzy, c-format
 msgid "Terminating amuleapi instance with pid '%d' ... "
 msgstr "Zakańczam instancję amuleweb z pid `%d' ... "
 
-#: src/amule.cpp:348
+#: src/amule.cpp:347
 #, fuzzy, c-format
 msgid "Killing amuleapi instance with pid '%d' ... "
 msgstr "Zabiłam instancję amuleweb z pid `%d' ... "
 
-#: src/amule.cpp:356
+#: src/amule.cpp:355
 msgid "aMule OnExit: Terminating core."
 msgstr "aMule OnExit: Zakończenie jądra."
 
-#: src/amule.cpp:467
+#: src/amule.cpp:466
 msgid "aMule shutdown completed."
 msgstr "Zamykanie aMule zakończone."
 
-#: src/amule.cpp:471
+#: src/amule.cpp:470
 msgid "Memory debug results for aMule exit:"
 msgstr "Wyniki debugu pamięci dla wyjścia aMule:"
 
-#: src/amule.cpp:652
+#: src/amule.cpp:651
 #, c-format
 msgid "Binding aMule's peer-to-peer traffic to interface: %s (HTTP updates use the default route)"
 msgstr ""
 
-#: src/amule.cpp:656
+#: src/amule.cpp:655
 #, c-format
 msgid "Binding all network traffic to interface: %s"
 msgstr ""
 
-#: src/amule.cpp:660
+#: src/amule.cpp:659
 #, c-format
 msgid "WARNING: configured network interface '%s' was not found - traffic is NOT bound to it and may leave via the default route. Check the interface name in Preferences."
 msgstr ""
 
-#: src/amule.cpp:666
+#: src/amule.cpp:665
 #, c-format
 msgid "WARNING: binding to network interface '%s' requires elevated privileges and was NOT applied - traffic may leave via the default route. Grant the capability (e.g. 'sudo setcap cap_net_raw+ep' on the aMule binary) or run with sufficient privileges."
 msgstr ""
 
-#: src/amule.cpp:674
+#: src/amule.cpp:673
 #, c-format
 msgid "WARNING: could not bind to network interface '%s' - traffic may leave via the default route."
 msgstr ""
 
-#: src/amule.cpp:733
+#: src/amule.cpp:732
 msgid "Your locale has been changed to System Default due to a configuration change. Sorry."
 msgstr "Twoje ustawienia lokalne zostały zmienione na domyślne systemowe w związku ze zmianą konfiguracji. Przepraszamy."
 
-#: src/amule.cpp:735 src/amule.cpp:1589 src/CatDialog.cpp:128
+#: src/amule.cpp:734 src/amule.cpp:1581 src/CatDialog.cpp:128
 #: src/CatDialog.cpp:136 src/CatDialog.cpp:149 src/ServerList.cpp:366
 #: src/ServerListCtrl.cpp:152
 msgid "Info"
 msgstr "Informacje"
 
-#: src/amule.cpp:742
+#: src/amule.cpp:741
 msgid ""
 "\n"
 "EC configuration"
@@ -289,74 +289,74 @@ msgstr ""
 "\n"
 "Konfiguracja EC"
 
-#: src/amule.cpp:745
+#: src/amule.cpp:744
 msgid "Password set and external connections enabled."
 msgstr "Ustawione hasło i włączone połączenia zewnętrzne."
 
-#: src/amule.cpp:755 src/KadDlg.cpp:176 src/KadDlg.cpp:185
-#: src/PrefsUnifiedDlg.cpp:1461 src/SharedFilesCtrl.cpp:476
+#: src/amule.cpp:754 src/KadDlg.cpp:176 src/KadDlg.cpp:185
+#: src/PrefsUnifiedDlg.cpp:1387 src/SharedFilesCtrl.cpp:476
 msgid "WARNING"
 msgstr "UWAGA"
 
-#: src/amule.cpp:992
+#: src/amule.cpp:991
 #, fuzzy
 msgid "Network bootstrap"
 msgstr "Sieci"
 
-#: src/amule.cpp:997
+#: src/amule.cpp:996
 msgid ""
 "aMule has detected missing network bootstrap files.\n"
 "Select which ones to download:"
 msgstr ""
 
-#: src/amule.cpp:1006 src/FirstRunWizard.cpp:411
+#: src/amule.cpp:1005 src/FirstRunWizard.cpp:411
 #, fuzzy
 msgid "eD2k server list (server.met)"
 msgstr "%i serwer znaleziono w server.met"
 
-#: src/amule.cpp:1013 src/FirstRunWizard.cpp:416
+#: src/amule.cpp:1012 src/FirstRunWizard.cpp:416
 msgid "Kad bootstrap nodes (nodes.dat)"
 msgstr ""
 
-#: src/amule.cpp:1103
+#: src/amule.cpp:1102
 #, c-format
 msgid "web server running on pid %d"
 msgstr "serwer sieciowy uruchomiony na pid %d"
 
-#: src/amule.cpp:1116
+#: src/amule.cpp:1115
 #, fuzzy
 msgid "You requested to run web server on startup, but the amuleweb binary cannot be run. Please install the package containing aMule web server, or build aMule from source with -DBUILD_WEBSERVER=YES and install it."
 msgstr "Zażądałeś włączenia serwera sieciowego podczas uruchomienia, ale binarki amuleweb nie mogą być uruchomione. Zainstaluj paczkę zawierającą serwer sieciowy aMule lub skompiluj aMule używając --enable-webserver i uruchom make install"
 
-#: src/amule.cpp:1121 src/amule.cpp:1185 src/amule.cpp:1299 src/amule.cpp:1601
+#: src/amule.cpp:1120 src/amule.cpp:1177 src/amule.cpp:1291 src/amule.cpp:1593
 #: src/amule-remote-gui.cpp:603 src/amule-remote-gui.cpp:671
 #: src/amule-remote-gui.cpp:709 src/amule-remote-gui.cpp:1282
 #: src/amule-remote-gui.cpp:1345 src/amule-remote-gui.cpp:1372
-#: src/DownloadQueue.cpp:1481 src/PrefsUnifiedDlg.cpp:1247
+#: src/DownloadQueue.cpp:1481
 msgid "ERROR"
 msgstr "BŁĄD"
 
-#: src/amule.cpp:1174
+#: src/amule.cpp:1166
 #, fuzzy, c-format
 msgid "amuleapi running on pid %d"
 msgstr "serwer sieciowy uruchomiony na pid %d"
 
-#: src/amule.cpp:1180
+#: src/amule.cpp:1172
 #, fuzzy
 msgid "You requested to run amuleapi on startup, but the amuleapi binary cannot be run. Please install the package containing aMule's REST API server, or build aMule from source with -DBUILD_AMULEAPI=YES and install it."
 msgstr "Zażądałeś włączenia serwera sieciowego podczas uruchomienia, ale binarki amuleweb nie mogą być uruchomione. Zainstaluj paczkę zawierającą serwer sieciowy aMule lub skompiluj aMule używając --enable-webserver i uruchom make install"
 
-#: src/amule.cpp:1267
+#: src/amule.cpp:1259
 #, c-format
 msgid "Could not bind ports to the specified address: %s"
 msgstr "Nie można było powiązać portów z określonym adresem: %s"
 
-#: src/amule.cpp:1291
+#: src/amule.cpp:1283
 #, c-format
 msgid "Port %u is not available. You will be LOWID\n"
 msgstr "Port %u jest niedostępny. Będziesz mieć LowID\n"
 
-#: src/amule.cpp:1296
+#: src/amule.cpp:1288
 #, c-format
 msgid ""
 "Port %u is not available!\n"
@@ -371,48 +371,48 @@ msgstr ""
 "\n"
 "Sprawdź swoją sieć aby mieć pewność, że port jest otwarty dla wejścia i wyjścia."
 
-#: src/amule.cpp:1393
+#: src/amule.cpp:1385
 msgid "Failed to create OnlineSig File"
 msgstr "Nie udało się utworzyć pliku podpisu online"
 
-#: src/amule.cpp:1401
+#: src/amule.cpp:1393
 msgid "Failed to create aMule OnlineSig File"
 msgstr "Nie udało się utworzyć pliku podpisu online aMule"
 
-#: src/amule.cpp:1564
+#: src/amule.cpp:1556
 msgid "The selected locale seems not to be installed on your box. (Note: I'll try to set it anyway)"
 msgstr "Wybrane lokale wydają się być niezainstalowane. (Uwaga: I tak spróbuję je ustawić)"
 
-#: src/amule.cpp:1574
+#: src/amule.cpp:1566
 #, c-format
 msgid "This is the first time you run aMule %s"
 msgstr "Po raz pierwszy uruchomiłeś aMule %s"
 
-#: src/amule.cpp:1577
+#: src/amule.cpp:1569
 msgid "This version is a testing version, updated daily, and\n"
 msgstr "Ta wersja jest aktualizowaną codziennie wersją testową i\n"
 
-#: src/amule.cpp:1578
+#: src/amule.cpp:1570
 msgid "we give no warranty it won't break anything, burn your house,\n"
 msgstr "nie dajemy żadnej gwarancji, że nie zniszczy ona niczego, nie spali twojego domu\n"
 
-#: src/amule.cpp:1579
+#: src/amule.cpp:1571
 msgid "or kill your dog. But it *should* be safe to use anyway.\n"
 msgstr "lub zabije twojego psa. *Powinna* ona jednak mimo wszystko działać poprawnie.\n"
 
-#: src/amule.cpp:1584
+#: src/amule.cpp:1576
 msgid "More information, support and new releases can found at our homepage,\n"
 msgstr "Więcej informacji, pomoc i nowe wydania znajdziesz na naszej stronie \n"
 
-#: src/amule.cpp:1585
+#: src/amule.cpp:1577
 msgid "at https://amule-org.github.io, or in our IRC channel #aMule at irc.libera.chat.\n"
 msgstr "https://amule-org.github.io lub na naszym kanale IRC: #aMule na irc.libera.chat.\n"
 
-#: src/amule.cpp:1587
+#: src/amule.cpp:1579
 msgid "Feel free to report any bugs to https://github.com/amule-org/amule/issues"
 msgstr "Nie wahaj się zgłaszać jakichkolwiek błędów na https://github.com/amule-org/amule/issues"
 
-#: src/amule.cpp:1599
+#: src/amule.cpp:1591
 msgid ""
 "The folder for Online Signature files you specified is INVALID!\n"
 " OnlineSignature will be DISABLED until you fix it on preferences."
@@ -420,137 +420,137 @@ msgstr ""
 "Katalog wybrany na pliki sygnatury online jest nieprawidłowy!\n"
 " Sygnatura online zostanie wyłączona dopóki nie poprawisz tego w preferencjach."
 
-#: src/amule.cpp:1662
+#: src/amule.cpp:1654
 msgid "Server hostname notified"
 msgstr "Zawiadomiono nazwę hostu serwera"
 
-#: src/amule.cpp:2039
+#: src/amule.cpp:2031
 #, c-format
 msgid "Disk space preallocation for file '%s' failed: %s"
 msgstr "Wstępna alokacja dysku dla pliku '%s' nie powiodła się: %s"
 
-#: src/amule.cpp:2168
+#: src/amule.cpp:2160
 msgid "ERROR: can't open logfile"
 msgstr "BŁĄD: nie mogę otworzyć pliku logów"
 
-#: src/amule.cpp:2172
+#: src/amule.cpp:2164
 msgid "WARNING: logfile is empty. Something is wrong."
 msgstr "UWAGA: plik logów jest pusty. Coś jest nie tak."
 
-#: src/amule.cpp:2189
+#: src/amule.cpp:2181
 msgid "Log has been reset"
 msgstr "Logi zostały zresetowane"
 
-#: src/amule.cpp:2213
+#: src/amule.cpp:2205
 #, c-format
 msgid "ServerMessage: %s"
 msgstr "Wiadomość z serwera: %s"
 
-#: src/amule.cpp:2256 src/IP2Country.cpp:220 src/IPFilter.cpp:514
+#: src/amule.cpp:2248 src/IP2Country.cpp:220 src/IPFilter.cpp:514
 #: src/ServerList.cpp:875
 #, c-format
 msgid "Skipped download of %s, because requested file is not newer."
 msgstr "Pominięto pobranie %s, ponieważ żądany plik nie jest nowszy."
 
-#: src/amule.cpp:2259
+#: src/amule.cpp:2251
 msgid "Failed to download the nodes list."
 msgstr "Pobieranie listy węzłów nie powiodło się."
 
-#: src/amule.cpp:2322
+#: src/amule.cpp:2314
 msgid "Failed to open the downloaded version check file"
 msgstr "Nie można otworzyć pobranego pliku kontroli wersji"
 
-#: src/amule.cpp:2325 src/amule.cpp:2344
+#: src/amule.cpp:2317 src/amule.cpp:2336
 msgid "Corrupted version check file"
 msgstr "Uszkodzony plik kontorli wersji"
 
-#: src/amule.cpp:2367
+#: src/amule.cpp:2359
 msgid "You are using an outdated version of aMule!"
 msgstr "Używasz przestarzałej wersji aMule!"
 
-#: src/amule.cpp:2369
+#: src/amule.cpp:2361
 #, c-format
 msgid "Your aMule version is %i.%i.%i and the latest version is %li.%li.%li"
 msgstr "Twoje wersja eMule to %i.%i.%i, najnowszą wersją jest %li.%li.%li"
 
-#: src/amule.cpp:2373
+#: src/amule.cpp:2365
 msgid "The latest version can always be found at https://github.com/amule-org/amule/releases/latest"
 msgstr "Najnowsza wersja jest zawsze dostępna na https://github.com/amule-org/amule/releases/latest"
 
-#: src/amule.cpp:2376
+#: src/amule.cpp:2368
 #, c-format
 msgid "WARNING: Your aMuled version is outdated: %i.%i.%i < %li.%li.%li"
 msgstr "UWAGA: Twoja wersja aMule jest przestarzała: %i.%i.%i < %li.%li.%li"
 
-#: src/amule.cpp:2382
+#: src/amule.cpp:2374
 msgid "Your copy of aMule is up to date."
 msgstr "Twoja kopia aMule jest przestarzała."
 
-#: src/amule.cpp:2389
+#: src/amule.cpp:2381
 msgid "Failed to download the version check file"
 msgstr "Nie udało się pobrać pliku kontroli wersji"
 
-#: src/amule.cpp:2558 src/amule-remote-gui.cpp:1133
+#: src/amule.cpp:2550 src/amule-remote-gui.cpp:1133
 #, c-format
 msgid "Users: %s | Files: %s"
 msgstr "Użytkowników: %s | Plików: %s"
 
-#: src/amule.cpp:2559 src/amule-remote-gui.cpp:1134
+#: src/amule.cpp:2551 src/amule-remote-gui.cpp:1134
 #, c-format
 msgid "Users: E: %s K: %s | Files: E: %s K: %s"
 msgstr "Użytkowników: E: %s K: %s | Plików: E: %s K: %s"
 
-#: src/amule.cpp:2573 src/amule-remote-gui.cpp:1147
+#: src/amule.cpp:2565 src/amule-remote-gui.cpp:1147
 msgid "No networks selected"
 msgstr "Nie wybrano sieci"
 
-#: src/amule.cpp:2641 src/TextClient.cpp:903
+#: src/amule.cpp:2633 src/TextClient.cpp:903
 msgid "with LowID"
 msgstr "z LowID"
 
-#: src/amule.cpp:2641 src/TextClient.cpp:904
+#: src/amule.cpp:2633 src/TextClient.cpp:904
 msgid "with HighID"
 msgstr "z HighID"
 
-#: src/amule.cpp:2643
+#: src/amule.cpp:2635
 #, c-format
 msgid "Connected to %s %s"
 msgstr "Połączony z %s %s"
 
-#: src/amule.cpp:2648
+#: src/amule.cpp:2640
 #, c-format
 msgid "Connecting to %s"
 msgstr "Łączenie z %s"
 
-#: src/amule.cpp:2650
+#: src/amule.cpp:2642
 msgid "Disconnected from eD2k"
 msgstr "Rozłączono z eD2k"
 
-#: src/amule.cpp:2659
+#: src/amule.cpp:2651
 msgid "Kad started."
 msgstr "Włączono Kad."
 
-#: src/amule.cpp:2661
+#: src/amule.cpp:2653
 msgid "Kad stopped."
 msgstr "Zatrzymano Kad."
 
-#: src/amule.cpp:2669
+#: src/amule.cpp:2661
 msgid "Connected to Kad (ok)"
 msgstr "Połączono z Kad (ok)"
 
-#: src/amule.cpp:2671
+#: src/amule.cpp:2663
 msgid "Connected to Kad (firewalled)"
 msgstr "Połączono z Kad (za firewallem)"
 
-#: src/amule.cpp:2675
+#: src/amule.cpp:2667
 msgid "Disconnected from Kad"
 msgstr "Rozłączono z Kad"
 
-#: src/amule.cpp:2707
+#: src/amule.cpp:2699
 msgid "Kad network cannot be used if UDP port is disabled on preferences, not starting."
 msgstr "Nie można użyć sieci Kad, jeśli port UDP jest wyłączony w preferencjach, nie włączam."
 
-#: src/amule.cpp:2711
+#: src/amule.cpp:2703
 msgid "Kad network disabled on preferences, not connecting."
 msgstr "Zablokowano sieć Kad w preferencjach, nie łączę."
 
@@ -576,68 +576,30 @@ msgstr "Nie można utworzyć pliku Pid"
 msgid "ERROR: %s"
 msgstr "BŁĄD: %s"
 
-#: src/amuleDlg.cpp:250
+#: src/amuleDlg.cpp:236
 #, c-format
 msgid "This is aMule %s based on eMule."
 msgstr "To jest aMule %s oparty na eMule."
 
-#: src/amuleDlg.cpp:251
+#: src/amuleDlg.cpp:237
 #, c-format
 msgid "Running on %s"
 msgstr "Uruchomiony na %s"
 
-#: src/amuleDlg.cpp:253
+#: src/amuleDlg.cpp:239
 msgid "Visit https://github.com/amule-org/amule/releases/latest to check if a new version is available."
 msgstr "Odwiedź https://github.com/amule-org/amule/releases/latest aby sprawdzić czy jest dostępna nowa wersja."
 
-#: src/amuleDlg.cpp:282
+#: src/amuleDlg.cpp:268
 msgid "FATAL ERROR: Failed to create Timer"
 msgstr "KRYTYCZNY BŁĄD: Nie udało się utworzyć Timera"
 
-#: src/amuleDlg.cpp:361 src/amuleDlg.cpp:1810 src/amuleDlg.cpp:2056
-#: src/muuli_wdr.cpp:1492 src/muuli_wdr.cpp:3439
-msgid "Networks"
-msgstr "Sieci"
-
-#: src/amuleDlg.cpp:362 src/amuleDlg.cpp:1816 src/muuli_wdr.cpp:3440
-msgid "Searches"
-msgstr "Szukaj"
-
-#: src/amuleDlg.cpp:363 src/amuleDlg.cpp:1822 src/DownloadListCtrl.cpp:740
-#: src/muuli_wdr.cpp:392 src/muuli_wdr.cpp:1585 src/muuli_wdr.cpp:3441
-#: src/Statistics.cpp:829
-msgid "Downloads"
-msgstr "Pobieranie"
-
-#: src/amuleDlg.cpp:364 src/amuleDlg.cpp:1828 src/muuli_wdr.cpp:3315
-msgid "Shared files"
-msgstr "Udostępnione pliki"
-
-#: src/amuleDlg.cpp:365 src/amuleDlg.cpp:1834 src/muuli_wdr.cpp:2947
-#: src/muuli_wdr.cpp:3397 src/muuli_wdr.cpp:3444
-msgid "Messages"
-msgstr "Wiadomości"
-
-#: src/amuleDlg.cpp:366 src/amuleDlg.cpp:1840 src/muuli_wdr.cpp:3445
-#: src/PrefsUnifiedDlg.cpp:314 src/Statistics.cpp:779 src/Statistics.cpp:1235
-msgid "Statistics"
-msgstr "Statystyki"
-
-#: src/amuleDlg.cpp:368 src/amuleDlg.cpp:1847 src/muuli_wdr.cpp:3447
-#: src/PrefsUnifiedDlg.cpp:330 src/utils/wxCas/src/wxcasprefs.cpp:39
-msgid "Preferences"
-msgstr "Preferencje"
-
-#: src/amuleDlg.cpp:371
-msgid "Navigate"
-msgstr ""
-
-#: src/amuleDlg.cpp:657
+#: src/amuleDlg.cpp:592
 #, fuzzy
 msgid "New version available"
 msgstr "Niedostępny"
 
-#: src/amuleDlg.cpp:661
+#: src/amuleDlg.cpp:596
 #, fuzzy, c-format
 msgid ""
 "A new version of aMule (%s) is available.\n"
@@ -647,185 +609,218 @@ msgid ""
 "Would you like to open the download page?"
 msgstr "Najnowsza wersja jest zawsze dostępna na https://github.com/amule-org/amule/releases/latest"
 
-#: src/amuleDlg.cpp:743
+#: src/amuleDlg.cpp:678
 msgid "aMule dialog destroyed"
 msgstr "dialog aMule zniszczony"
 
-#: src/amuleDlg.cpp:766 src/DataToText.cpp:68 src/IPFilter.cpp:547
+#: src/amuleDlg.cpp:701 src/DataToText.cpp:68 src/IPFilter.cpp:547
 msgid "Connecting"
 msgstr "Łączenie"
 
-#: src/amuleDlg.cpp:958
+#: src/amuleDlg.cpp:893
 msgid "eD2k: Connecting"
 msgstr "eD2k: Łączenie"
 
-#: src/amuleDlg.cpp:962
+#: src/amuleDlg.cpp:897
 msgid "eD2k: Disconnected"
 msgstr "eD2k: Rozłączony"
 
-#: src/amuleDlg.cpp:968
+#: src/amuleDlg.cpp:903
 msgid "Kad: Firewalled"
 msgstr "Kad: Za firewallem"
 
-#: src/amuleDlg.cpp:972
+#: src/amuleDlg.cpp:907
 msgid "Kad: Connected"
 msgstr "Kad: Połączony"
 
-#: src/amuleDlg.cpp:977
+#: src/amuleDlg.cpp:912
 msgid "Kad: Connecting"
 msgstr "Kad: Łączenie"
 
-#: src/amuleDlg.cpp:981
+#: src/amuleDlg.cpp:916
 msgid "Kad: Off"
 msgstr "Kad: Wyłączony"
 
-#: src/amuleDlg.cpp:1029 src/DownloadListCtrl.cpp:505
+#: src/amuleDlg.cpp:964 src/DownloadListCtrl.cpp:505
 #: src/DownloadListCtrl.cpp:749 src/FriendListCtrl.cpp:180
 #: src/muuli_wdr.cpp:731 src/muuli_wdr.cpp:782 src/muuli_wdr.cpp:846
-#: src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2252 src/muuli_wdr.cpp:2337
-#: src/muuli_wdr.cpp:3085 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
+#: src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2224 src/muuli_wdr.cpp:2309
+#: src/muuli_wdr.cpp:3057 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
 #: src/ServerListCtrl.cpp:606 src/TransferWnd.cpp:378
 #: src/utils/wxCas/src/wxcasprefs.cpp:235
 msgid "Cancel"
 msgstr "Anuluj"
 
-#: src/amuleDlg.cpp:1030
+#: src/amuleDlg.cpp:965
 msgid "Stop the current connection attempts"
 msgstr "Zatrzymaj aktualne próby połączenia"
 
-#: src/amuleDlg.cpp:1035 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976
-#: src/muuli_wdr.cpp:2475
+#: src/amuleDlg.cpp:970 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976
+#: src/muuli_wdr.cpp:2447
 msgid "Disconnect"
 msgstr "Rozłącz"
 
-#: src/amuleDlg.cpp:1036
+#: src/amuleDlg.cpp:971
 msgid "Disconnect from the currently connected networks"
 msgstr "Rozłącz z aktualnie połączonymi sieciami"
 
-#: src/amuleDlg.cpp:1041 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979
-#: src/muuli_wdr.cpp:2630 src/muuli_wdr.cpp:3082 src/muuli_wdr.cpp:3437
+#: src/amuleDlg.cpp:976 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979
+#: src/muuli_wdr.cpp:2602 src/muuli_wdr.cpp:3054 src/muuli_wdr.cpp:3409
 msgid "Connect"
 msgstr "Podłącz"
 
-#: src/amuleDlg.cpp:1042
+#: src/amuleDlg.cpp:977
 msgid "Connect to the currently enabled networks"
 msgstr "Połącz z aktualnie włączonymi sieciami"
 
-#: src/amuleDlg.cpp:1154
+#: src/amuleDlg.cpp:1089
 #, fuzzy, c-format
 msgid "Up: %.1f%s (%.1f) | Down: %.1f%s (%.1f)"
 msgstr "Wysł: %.1f(%.1f) | Pobr: %.1f(%.1f)"
 
-#: src/amuleDlg.cpp:1156 src/amuleDlg.cpp:1158 src/amuleDlg.cpp:1162
-#: src/amuleDlg.cpp:1164 src/amuleDlg.cpp:1175 src/amuleDlg.cpp:1177
+#: src/amuleDlg.cpp:1091 src/amuleDlg.cpp:1093 src/amuleDlg.cpp:1097
+#: src/amuleDlg.cpp:1099 src/amuleDlg.cpp:1110 src/amuleDlg.cpp:1112
 #: src/MuleTrayIcon.cpp:796 src/MuleTrayIcon.cpp:799
 #, fuzzy
 msgid " MB/s"
 msgstr "MB/s"
 
-#: src/amuleDlg.cpp:1156 src/amuleDlg.cpp:1158 src/amuleDlg.cpp:1162
-#: src/amuleDlg.cpp:1164 src/amuleDlg.cpp:1175 src/amuleDlg.cpp:1177
+#: src/amuleDlg.cpp:1091 src/amuleDlg.cpp:1093 src/amuleDlg.cpp:1097
+#: src/amuleDlg.cpp:1099 src/amuleDlg.cpp:1110 src/amuleDlg.cpp:1112
 #: src/MuleTrayIcon.cpp:796 src/MuleTrayIcon.cpp:799
 #: src/utils/wxCas/src/wxcasframe.cpp:1041
 msgid " kB/s"
 msgstr " kB/s"
 
-#: src/amuleDlg.cpp:1161
+#: src/amuleDlg.cpp:1096
 #, fuzzy, c-format
 msgid "Up: %.1f%s | Down: %.1f%s"
 msgstr "Wysł: %.1f | Pobr: %.1f"
 
-#: src/amuleDlg.cpp:1193
+#: src/amuleDlg.cpp:1128
 #, c-format
 msgid "aMule (%s | Connected)"
 msgstr "aMule (%s | Połączony)"
 
-#: src/amuleDlg.cpp:1195
+#: src/amuleDlg.cpp:1130
 #, c-format
 msgid "aMule (%s | Disconnected)"
 msgstr "aMule (%s | Rozłączony)"
 
-#: src/amuleDlg.cpp:1248
+#: src/amuleDlg.cpp:1183
 #, c-format
 msgid "Do you really want to exit %s?"
 msgstr "Czy na pewno chcesz opuścić %s?"
 
-#: src/amuleDlg.cpp:1250
+#: src/amuleDlg.cpp:1185
 msgid "Exit confirmation"
 msgstr "Potwierdzenie wyjścia"
 
-#: src/amuleDlg.cpp:1613
+#: src/amuleDlg.cpp:1548
 msgid "Launch Command: "
 msgstr "Uruchomienie polecenia: "
 
-#: src/amuleDlg.cpp:1632 src/muuli_wdr.cpp:1972 src/Preferences.cpp:979
+#: src/amuleDlg.cpp:1567 src/muuli_wdr.cpp:1971 src/Preferences.cpp:951
 msgid "- default -"
 msgstr "- domyślnie -"
 
-#: src/amuleDlg.cpp:1660
+#: src/amuleDlg.cpp:1595
 #, c-format
 msgid "Skin directory '%s' does not exist"
 msgstr "Katalog skórek '%s' nie istnieje"
 
-#: src/amuleDlg.cpp:1663
+#: src/amuleDlg.cpp:1598
 #, c-format
 msgid "WARNING: Unable to open skin file '%s' for read"
 msgstr "OSTRZEŻENIE: Nie udało się otworzyć pliku skórki '%s' do odczytu"
 
-#: src/amuleDlg.cpp:1814 src/muuli_wdr.cpp:3439
+#: src/amuleDlg.cpp:1722 src/amuleDlg.cpp:1968 src/muuli_wdr.cpp:1485
+#: src/muuli_wdr.cpp:3411
+msgid "Networks"
+msgstr "Sieci"
+
+#: src/amuleDlg.cpp:1726 src/muuli_wdr.cpp:3411
 msgid "Networks Window"
 msgstr "Okno sieci"
 
-#: src/amuleDlg.cpp:1820 src/muuli_wdr.cpp:3440
+#: src/amuleDlg.cpp:1728 src/muuli_wdr.cpp:3412
+msgid "Searches"
+msgstr "Szukaj"
+
+#: src/amuleDlg.cpp:1732 src/muuli_wdr.cpp:3412
 msgid "Searches Window"
 msgstr "Okno wyszukiwania"
 
-#: src/amuleDlg.cpp:1826 src/muuli_wdr.cpp:3441
+#: src/amuleDlg.cpp:1734 src/DownloadListCtrl.cpp:740 src/muuli_wdr.cpp:392
+#: src/muuli_wdr.cpp:1578 src/muuli_wdr.cpp:3413 src/Statistics.cpp:829
+msgid "Downloads"
+msgstr "Pobieranie"
+
+#: src/amuleDlg.cpp:1738 src/muuli_wdr.cpp:3413
 msgid "Downloads Window"
 msgstr "Okno pobierań"
 
-#: src/amuleDlg.cpp:1832 src/muuli_wdr.cpp:3443
+#: src/amuleDlg.cpp:1740 src/muuli_wdr.cpp:3287
+msgid "Shared files"
+msgstr "Udostępnione pliki"
+
+#: src/amuleDlg.cpp:1744 src/muuli_wdr.cpp:3415
 msgid "Shared Files Window"
 msgstr "Okno udostępnionych plików"
 
-#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3444
+#: src/amuleDlg.cpp:1746 src/muuli_wdr.cpp:2919 src/muuli_wdr.cpp:3369
+#: src/muuli_wdr.cpp:3416
+msgid "Messages"
+msgstr "Wiadomości"
+
+#: src/amuleDlg.cpp:1750 src/muuli_wdr.cpp:3416
 msgid "Messages Window"
 msgstr "Okno wiadomości"
 
-#: src/amuleDlg.cpp:1844 src/muuli_wdr.cpp:3445
+#: src/amuleDlg.cpp:1752 src/muuli_wdr.cpp:3417 src/PrefsUnifiedDlg.cpp:312
+#: src/Statistics.cpp:779 src/Statistics.cpp:1235
+msgid "Statistics"
+msgstr "Statystyki"
+
+#: src/amuleDlg.cpp:1756 src/muuli_wdr.cpp:3417
 msgid "Statistics Graph Window"
 msgstr "Okno wykresów statystyk"
 
-#: src/amuleDlg.cpp:1851 src/muuli_wdr.cpp:3447
+#: src/amuleDlg.cpp:1759 src/muuli_wdr.cpp:3419 src/PrefsUnifiedDlg.cpp:328
+#: src/utils/wxCas/src/wxcasprefs.cpp:39
+msgid "Preferences"
+msgstr "Preferencje"
+
+#: src/amuleDlg.cpp:1763 src/muuli_wdr.cpp:3419
 msgid "Preferences Settings Window"
 msgstr "Okno preferencji"
 
-#: src/amuleDlg.cpp:1854 src/muuli_wdr.cpp:3448
+#: src/amuleDlg.cpp:1766 src/muuli_wdr.cpp:3420
 msgid "Import"
 msgstr "Import"
 
-#: src/amuleDlg.cpp:1858 src/muuli_wdr.cpp:3448
+#: src/amuleDlg.cpp:1770 src/muuli_wdr.cpp:3420
 msgid "The partfile importer tool"
 msgstr "Narzędzie importowania plików części"
 
-#: src/amuleDlg.cpp:1861 src/muuli_wdr.cpp:3449
+#: src/amuleDlg.cpp:1773 src/muuli_wdr.cpp:3421
 #: src/utils/aLinkCreator/src/alcframe.cpp:262
 msgid "About"
 msgstr "Informacje o"
 
-#: src/amuleDlg.cpp:1861 src/muuli_wdr.cpp:3449
+#: src/amuleDlg.cpp:1773 src/muuli_wdr.cpp:3421
 msgid "About/Help"
 msgstr "Informacje/Pomoc"
 
-#: src/amuleDlg.cpp:2059
+#: src/amuleDlg.cpp:1971
 msgid "eD2k network"
 msgstr "Sieć eD2k"
 
-#: src/amuleDlg.cpp:2062
+#: src/amuleDlg.cpp:1974
 msgid "Kad network"
 msgstr "Sieć Kad"
 
-#: src/amuleDlg.cpp:2062
+#: src/amuleDlg.cpp:1974
 msgid "No network"
 msgstr "Brak sieci"
 
@@ -955,7 +950,7 @@ msgstr "Nie znaleziono pliku."
 msgid "The core rejected these shared folders:%s"
 msgstr ""
 
-#: src/amule-remote-gui.cpp:1336 src/ExternalConn.cpp:2346
+#: src/amule-remote-gui.cpp:1336 src/ExternalConn.cpp:2345
 msgid "Invalid link or already on list."
 msgstr "Nieprawidłowy lub znajdujący się już na liście link."
 
@@ -971,7 +966,7 @@ msgstr "Nie można utworzyć katalogu '%s' dla kategorii '%s', używany jest nad
 #: src/ClientDetailDialog.cpp:123 src/DataToText.cpp:61 src/DataToText.cpp:86
 #: src/DataToText.cpp:101 src/DataToText.cpp:136 src/DataToText.cpp:165
 #: src/DownloadListCtrl.cpp:1172 src/DownloadListCtrl.cpp:1185
-#: src/DownloadListCtrl.cpp:1196 src/ExternalConn.cpp:609
+#: src/DownloadListCtrl.cpp:1196 src/ExternalConn.cpp:608
 #: src/FileDetailDialog.cpp:203 src/FileDetailDialog.cpp:235
 #: src/FileDetailDialog.cpp:242 src/GenericClientListCtrl.cpp:1171
 #: src/GenericClientListCtrl.cpp:1182 src/GenericClientListCtrl.cpp:1192
@@ -1363,19 +1358,19 @@ msgstr "Auto [Wy]"
 msgid "Very low"
 msgstr "Bardzo niski"
 
-#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:743 src/muuli_wdr.cpp:2303
+#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:743 src/muuli_wdr.cpp:2275
 #: src/ServerListCtrl.cpp:263 src/ServerListCtrl.cpp:456
 #: src/SharedFilesCtrl.cpp:145
 msgid "Low"
 msgstr "Niski"
 
-#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:744 src/muuli_wdr.cpp:2304
+#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:744 src/muuli_wdr.cpp:2276
 #: src/ServerListCtrl.cpp:266 src/ServerListCtrl.cpp:457
 #: src/SharedFilesCtrl.cpp:146
 msgid "Normal"
 msgstr "Normalny"
 
-#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:745 src/muuli_wdr.cpp:2305
+#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:745 src/muuli_wdr.cpp:2277
 #: src/ServerListCtrl.cpp:269 src/ServerListCtrl.cpp:458
 #: src/SharedFilesCtrl.cpp:147
 msgid "High"
@@ -1467,8 +1462,8 @@ msgstr "Serwer lokalny"
 msgid "Remote Server"
 msgstr "Serwer zdalny"
 
-#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3202
-#: src/SearchDlg.cpp:119 src/TextClient.cpp:911
+#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3174
+#: src/SearchDlg.cpp:111 src/TextClient.cpp:911
 msgid "Kad"
 msgstr "Kad"
 
@@ -1539,7 +1534,7 @@ msgstr "Część"
 msgid "Size"
 msgstr "Rozmiar"
 
-#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3269
+#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3241
 msgid "Transferred"
 msgstr "Przesłano"
 
@@ -1597,7 +1592,7 @@ msgstr ""
 "Informacja zwrotna od:  %s (%s)\n"
 "\n"
 
-#: src/DownloadListCtrl.cpp:746 src/muuli_wdr.cpp:2306
+#: src/DownloadListCtrl.cpp:746 src/muuli_wdr.cpp:2278
 #: src/SharedFilesCtrl.cpp:150
 msgid "Auto"
 msgstr "Automatyczny"
@@ -1635,7 +1630,7 @@ msgid "Extended Options"
 msgstr "Zaawansowane opcje"
 
 #: src/DownloadListCtrl.cpp:770 src/DownloadListCtrl.cpp:822
-#: src/muuli_wdr.cpp:1790
+#: src/muuli_wdr.cpp:1789
 msgid "Preview"
 msgstr "Podgląd"
 
@@ -1812,232 +1807,227 @@ msgstr[2] ""
 msgid "Invalid eD2k link! ERROR: %s"
 msgstr "Nieprawidłowy link eD2k! BŁĄD: %s"
 
-#: src/ExternalConn.cpp:380
+#: src/ExternalConn.cpp:379
 msgid "Client sent packet after authentication failed."
 msgstr "Klient wysyła pakiet po nie udanym uwierzytelnieniu."
 
-#: src/ExternalConn.cpp:397
+#: src/ExternalConn.cpp:396
 msgid "External connection closed."
 msgstr "Zewnętrzne połączenie zamknięte."
 
-#: src/ExternalConn.cpp:474
+#: src/ExternalConn.cpp:473
 msgid "External connections disabled due to empty password!"
 msgstr "Zewnętrzne połączenia wyłączone w związku z brakiem hasła!"
 
-#: src/ExternalConn.cpp:495
+#: src/ExternalConn.cpp:494
 msgid "External connections disabled in config file"
 msgstr "Zewnętrzne połączenia wyłączone w pliku konfiguracyjnym"
 
-#: src/ExternalConn.cpp:576
+#: src/ExternalConn.cpp:575
 msgid "New external connection accepted"
 msgstr "Nowe zewnętrzne połączenie zaakceptowane"
 
-#: src/ExternalConn.cpp:579
+#: src/ExternalConn.cpp:578
 msgid "ERROR: couldn't accept a new external connection"
 msgstr "BŁĄD: nie można zaakceptować nowego połączenia zewnętrznego"
 
-#: src/ExternalConn.cpp:596
+#: src/ExternalConn.cpp:595
 msgid "External connection refused due to empty password in preferences!"
 msgstr "Zewnętrzne połączenia odrzucone, ze względu na brak hasła w preferencjach!"
 
-#: src/ExternalConn.cpp:608
+#: src/ExternalConn.cpp:607
 #, c-format
 msgid "Connecting client: %s %s"
 msgstr "Łączę z klientem: %s %s"
 
-#: src/ExternalConn.cpp:610
+#: src/ExternalConn.cpp:609
 msgid "Unknown version"
 msgstr "Nieznana wersja"
 
-#: src/ExternalConn.cpp:623
+#: src/ExternalConn.cpp:622
 msgid "Incorrect EC version ID, there might be binary incompatibility. Use core and remote from same snapshot."
 msgstr "Niepoprawny ID wersji EC, może występować niezgodność binarna. Użyj rdzenia i zdalnego z tej samej wersji."
 
-#: src/ExternalConn.cpp:631
+#: src/ExternalConn.cpp:630
 msgid "You cannot connect to a release version from an arbitrary development snapshot! *sigh* possible crash prevented"
 msgstr "Nie można połączyć się z wersją finałową z dowolnej wersji SVN! *westchnięcie* prawdopodobnie zapobiegnięto awarii"
 
-#: src/ExternalConn.cpp:714
+#: src/ExternalConn.cpp:713
 msgid "Invalid protocol version."
 msgstr "Zła wersja protokołu."
 
-#: src/ExternalConn.cpp:720
+#: src/ExternalConn.cpp:719
 msgid "Missing protocol version tag."
 msgstr "Brak znacznika wersji protokołu."
 
-#: src/ExternalConn.cpp:728
+#: src/ExternalConn.cpp:727
 msgid "Authentication failed: invalid hash specified as EC password."
 msgstr "Uwierzytelnianie nie powiodło się: nieprawidłowy skrót podany jako hasło EC."
 
-#: src/ExternalConn.cpp:776
+#: src/ExternalConn.cpp:775
 msgid "Authentication failed: wrong password."
 msgstr "Uwierzytelnianie nie powiodło się: nieprawidłowe hasło."
 
-#: src/ExternalConn.cpp:778
+#: src/ExternalConn.cpp:777
 msgid "Authentication failed: missing password."
 msgstr "Uwierzytelnianie nie powiodło się: brak hasła."
 
-#: src/ExternalConn.cpp:789
+#: src/ExternalConn.cpp:788
 msgid "Invalid request, please authenticate first."
 msgstr "Nieprawidłowe żądanie, najpierw musisz się uwierzytelnić."
 
-#: src/ExternalConn.cpp:794
+#: src/ExternalConn.cpp:793
 msgid "Access granted."
 msgstr "Dostęp udzielony."
 
-#: src/ExternalConn.cpp:802
+#: src/ExternalConn.cpp:801
 #, c-format
 msgid "Sent error message \"%s\" to client."
 msgstr "Wyślij wiadomość błędu \"%s\" do klienta."
 
-#: src/ExternalConn.cpp:807
+#: src/ExternalConn.cpp:806
 #, c-format
 msgid "Unauthorized access attempt from %s. Connection closed."
 msgstr "Próba nieautoryzowanego dostępu z %s. Połączenie zakończone."
 
-#: src/ExternalConn.cpp:1420
+#: src/ExternalConn.cpp:1419
 #, c-format
 msgid "Remote PartFile command failed: FileHash not found: %s"
 msgstr "Zdalna komenda pliku części nieudana: Skrót dla pliku nieznaleziony: %s"
 
-#: src/ExternalConn.cpp:1424
+#: src/ExternalConn.cpp:1423
 #, c-format
 msgid "FileHash not found: %s"
 msgstr "Skrót dla pliku nieznaleziony: %s"
 
-#: src/ExternalConn.cpp:1471 src/ExternalConn.cpp:1559
-#: src/ExternalConn.cpp:1680
+#: src/ExternalConn.cpp:1470 src/ExternalConn.cpp:1558
+#: src/ExternalConn.cpp:1679
 msgid "OOPS! OpCode processing error!"
 msgstr "OOPS! Błąd przetwarzania OpCode!"
 
-#: src/ExternalConn.cpp:1502
+#: src/ExternalConn.cpp:1501
 msgid "Server not added"
 msgstr "Nie dodano serwera"
 
-#: src/ExternalConn.cpp:1521
+#: src/ExternalConn.cpp:1520
 #, c-format
 msgid "server not found: %s"
 msgstr "serwer nieznaleziony: %s"
 
-#: src/ExternalConn.cpp:1538
+#: src/ExternalConn.cpp:1537
 msgid "need to define server to be removed"
 msgstr "trzeba zdefiniować serwer do usunięcia"
 
-#: src/ExternalConn.cpp:1553
+#: src/ExternalConn.cpp:1552
 msgid "eD2k is disabled in preferences."
 msgstr "eD2k jest wyłączony w preferencjach."
 
-#: src/ExternalConn.cpp:1658
+#: src/ExternalConn.cpp:1657
 #, fuzzy
 msgid "Friend not found."
 msgstr "Nie znaleziono pliku."
 
-#: src/ExternalConn.cpp:1668
+#: src/ExternalConn.cpp:1667
 #, fuzzy
 msgid "Client not found."
 msgstr "Nie znaleziono pliku."
 
-#: src/ExternalConn.cpp:1674
+#: src/ExternalConn.cpp:1673
 msgid "EC_TAG_FRIEND_SHARED requires EC_TAG_FRIEND or EC_TAG_CLIENT."
 msgstr ""
 
-#: src/ExternalConn.cpp:1992
+#: src/ExternalConn.cpp:1991
 msgid "WebSearch from remote interface makes no sense."
 msgstr "Szukanie przez WWW ze zdalnych interfejsów nie ma sensu."
 
-#: src/ExternalConn.cpp:2027
+#: src/ExternalConn.cpp:2026
 msgid "Search in progress. Refetch results in a moment!"
 msgstr "Wyszukiwanie w trakcie. Odświeżenie rezultatów za chwilę!"
 
-#: src/ExternalConn.cpp:2266
+#: src/ExternalConn.cpp:2265
 msgid "No points for graph."
 msgstr "Brak punktów dla wykresu."
 
-#: src/ExternalConn.cpp:2276
+#: src/ExternalConn.cpp:2275
 msgid "Your client is not configured for this detail level."
 msgstr "Twój klient nie jest skonfigurowany do tego poziomu szczegółów."
 
-#: src/ExternalConn.cpp:2303
+#: src/ExternalConn.cpp:2302
 msgid "External Connection: shutdown requested"
 msgstr "External Connection: żądanie zamknięcia"
 
-#: src/ExternalConn.cpp:2315
+#: src/ExternalConn.cpp:2314
 msgid "Already shutting down."
 msgstr "Już w trakcie zamykania."
 
-#: src/ExternalConn.cpp:2333
+#: src/ExternalConn.cpp:2332
 #, c-format
 msgid "ExternalConn: adding link '%s'."
 msgstr "ExternalConn: dodaję link '%s'."
 
-#: src/ExternalConn.cpp:2351
+#: src/ExternalConn.cpp:2350
 #, fuzzy, c-format
 msgid "%d of %d links failed (invalid or already on list)."
 msgstr "Nieprawidłowy lub znajdujący się już na liście link."
 
-#: src/ExternalConn.cpp:2374
+#: src/ExternalConn.cpp:2373
 msgid "Version check throttled; try again shortly."
 msgstr ""
 
-#: src/ExternalConn.cpp:2379
+#: src/ExternalConn.cpp:2378
 msgid "Version check is not available on this daemon."
 msgstr ""
 
-#: src/ExternalConn.cpp:2509
+#: src/ExternalConn.cpp:2508
 msgid "File not found."
 msgstr "Nie znaleziono pliku."
 
-#: src/ExternalConn.cpp:2514
+#: src/ExternalConn.cpp:2513
 msgid "Invalid file name."
 msgstr "Nieprawidłowa nazwa pliku."
 
-#: src/ExternalConn.cpp:2522
+#: src/ExternalConn.cpp:2521
 msgid "Unable to rename file."
 msgstr "Nie udało się zmienić nazwy pliku."
 
-#: src/ExternalConn.cpp:2839
-#, c-format
-msgid "Could not save the amuleapi password: %s"
-msgstr ""
-
-#: src/ExternalConn.cpp:3004 src/ExternalConn.cpp:3032
+#: src/ExternalConn.cpp:2992 src/ExternalConn.cpp:3020
 msgid "Kad is disabled in preferences."
 msgstr "Kad jest wyłączony w preferencjach."
 
-#: src/ExternalConn.cpp:3045
+#: src/ExternalConn.cpp:3033
 msgid "Already connected to eD2k."
 msgstr "Już podłączony do eD2k."
 
-#: src/ExternalConn.cpp:3048
+#: src/ExternalConn.cpp:3036
 msgid "Connecting to eD2k..."
 msgstr "Łączę do eD2k..."
 
-#: src/ExternalConn.cpp:3057
+#: src/ExternalConn.cpp:3045
 msgid "Already connected to Kad."
 msgstr "Już podłączony do Kad."
 
-#: src/ExternalConn.cpp:3060
+#: src/ExternalConn.cpp:3048
 msgid "Connecting to Kad..."
 msgstr "Łączę z Kad..."
 
-#: src/ExternalConn.cpp:3067
+#: src/ExternalConn.cpp:3055
 msgid "All networks are disabled."
 msgstr "Wszystkie sieci są wyłączone."
 
-#: src/ExternalConn.cpp:3076
+#: src/ExternalConn.cpp:3064
 msgid "Disconnected from eD2k."
 msgstr "Rozłącz z eD2k."
 
-#: src/ExternalConn.cpp:3081
+#: src/ExternalConn.cpp:3069
 msgid "Disconnected from Kad."
 msgstr "Rozłączono z Kad."
 
-#: src/ExternalConn.cpp:3090
+#: src/ExternalConn.cpp:3078
 #, c-format
 msgid "External Connection: invalid opcode received: %#x"
 msgstr "External Connection: otrzymano nieprawidłowy opcode: %#x"
 
-#: src/ExternalConn.cpp:3095
+#: src/ExternalConn.cpp:3083
 msgid "Invalid opcode (wrong protocol version?)"
 msgstr "Nieprawidłowy opcode (zła wersja protokołu?)"
 
@@ -2353,19 +2343,19 @@ msgstr ""
 msgid "eD2k"
 msgstr "eD2k"
 
-#: src/FirstRunWizard.cpp:349 src/muuli_wdr.cpp:1495
+#: src/FirstRunWizard.cpp:349 src/muuli_wdr.cpp:1488
 msgid "Kademlia"
 msgstr "Kademlia"
 
-#: src/FirstRunWizard.cpp:359 src/muuli_wdr.cpp:1423
+#: src/FirstRunWizard.cpp:359 src/muuli_wdr.cpp:1416
 msgid "Standard TCP Port "
 msgstr "Standardowy port TCP "
 
-#: src/FirstRunWizard.cpp:365 src/muuli_wdr.cpp:1435
+#: src/FirstRunWizard.cpp:365 src/muuli_wdr.cpp:1428
 msgid "Extended UDP port (Kad / global search) "
 msgstr "Rozszerzony port UDP (KAD / globalne wyszukiwanie)"
 
-#: src/FirstRunWizard.cpp:377 src/muuli_wdr.cpp:1442
+#: src/FirstRunWizard.cpp:377 src/muuli_wdr.cpp:1435
 msgid "Enable UPnP for router port forwarding"
 msgstr "Włącz UPnP dla przekierowania portów routera"
 
@@ -2392,7 +2382,7 @@ msgstr ""
 msgid "Your peer lists are already in place - nothing to download."
 msgstr "Starasz się już pobierać plik %s"
 
-#: src/FirstRunWizard.cpp:434 src/muuli_wdr.cpp:1540
+#: src/FirstRunWizard.cpp:434 src/muuli_wdr.cpp:1533
 msgid "Auto-update server list at startup"
 msgstr "Autoaktualizacja listy serwerów przy starcie"
 
@@ -2438,23 +2428,23 @@ msgid ""
 "want downloads on a different (e.g. larger) disk."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:549 src/FirstRunWizard.cpp:611 src/muuli_wdr.cpp:1702
+#: src/FirstRunWizard.cpp:549 src/FirstRunWizard.cpp:611 src/muuli_wdr.cpp:1701
 msgid "Destination folder for downloads"
 msgstr "Folder docelowy dla pobrań"
 
-#: src/FirstRunWizard.cpp:553 src/FirstRunWizard.cpp:569 src/muuli_wdr.cpp:1349
-#: src/muuli_wdr.cpp:1366 src/muuli_wdr.cpp:1677 src/muuli_wdr.cpp:1708
-#: src/muuli_wdr.cpp:1720 src/muuli_wdr.cpp:2790
+#: src/FirstRunWizard.cpp:553 src/FirstRunWizard.cpp:569 src/muuli_wdr.cpp:1342
+#: src/muuli_wdr.cpp:1359 src/muuli_wdr.cpp:1676 src/muuli_wdr.cpp:1707
+#: src/muuli_wdr.cpp:1719 src/muuli_wdr.cpp:2762
 #: src/utils/aLinkCreator/src/alcframe.cpp:135
 #: src/utils/wxCas/src/wxcasprefs.cpp:52 src/utils/wxCas/src/wxcasprefs.cpp:118
 msgid "Browse"
 msgstr "Przeglądaj"
 
-#: src/FirstRunWizard.cpp:559 src/muuli_wdr.cpp:1713
+#: src/FirstRunWizard.cpp:559 src/muuli_wdr.cpp:1712
 msgid "(All files in this folder are shared with other peers)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:565 src/FirstRunWizard.cpp:624 src/muuli_wdr.cpp:1715
+#: src/FirstRunWizard.cpp:565 src/FirstRunWizard.cpp:624 src/muuli_wdr.cpp:1714
 msgid "Folder for temporary download files"
 msgstr "Folder dla pobranych plików tymczasowych"
 
@@ -2485,7 +2475,7 @@ msgstr "Nie udało się otworzyć pliku listy przyjaciół 'emfriends.met' do za
 msgid "CRITICAL - no client on StartChatSession"
 msgstr "KRYTYCZNE - brak klienta przy StartChatSession"
 
-#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2696 src/muuli_wdr.cpp:3373
+#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2668 src/muuli_wdr.cpp:3345
 msgid "Friends"
 msgstr "Znajomi"
 
@@ -2596,8 +2586,8 @@ msgstr "Brak"
 msgid "No"
 msgstr "Nie"
 
-#: src/GenericClientListCtrl.cpp:1216 src/PrefsUnifiedDlg.cpp:2898
-#: src/PrefsUnifiedDlg.cpp:2948 src/ServerListCtrl.cpp:276
+#: src/GenericClientListCtrl.cpp:1216 src/PrefsUnifiedDlg.cpp:2818
+#: src/PrefsUnifiedDlg.cpp:2868 src/ServerListCtrl.cpp:276
 msgid "Yes"
 msgstr "Tak"
 
@@ -2768,10 +2758,10 @@ msgstr "Nieprawidłowy port do rozruchu"
 msgid "Please fill all fields required"
 msgstr "Proszę wypełnij wszystkie wymagane pola"
 
-#: src/KadDlg.cpp:192 src/PartFile.cpp:1031 src/PrefsUnifiedDlg.cpp:1134
-#: src/PrefsUnifiedDlg.cpp:1204 src/PrefsUnifiedDlg.cpp:1405
-#: src/PrefsUnifiedDlg.cpp:1663 src/PrefsUnifiedDlg.cpp:1673
-#: src/PrefsUnifiedDlg.cpp:1690 src/PrefsUnifiedDlg.cpp:1738
+#: src/KadDlg.cpp:192 src/PartFile.cpp:1031 src/PrefsUnifiedDlg.cpp:1162
+#: src/PrefsUnifiedDlg.cpp:1331 src/PrefsUnifiedDlg.cpp:1589
+#: src/PrefsUnifiedDlg.cpp:1599 src/PrefsUnifiedDlg.cpp:1616
+#: src/PrefsUnifiedDlg.cpp:1658
 msgid "Message"
 msgstr "Wiadomość"
 
@@ -2876,7 +2866,7 @@ msgstr "Ratio wymiany"
 msgid "Uploaded"
 msgstr "Wysłano"
 
-#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3253
+#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3225
 msgid "Requested"
 msgstr "Zażądano"
 
@@ -3000,7 +2990,7 @@ msgid "WARNING: "
 msgstr "OSTRZEŻENIE: "
 
 #: src/MuleNotebook.cpp:179 src/muuli_wdr.cpp:817 src/muuli_wdr.cpp:1229
-#: src/muuli_wdr.cpp:3157 src/muuli_wdr.cpp:3413
+#: src/muuli_wdr.cpp:3129 src/muuli_wdr.cpp:3385
 msgid "Close"
 msgstr "Zamknij"
 
@@ -3013,12 +3003,12 @@ msgstr "Wytnij"
 msgid "Copy"
 msgstr "Kopiuj"
 
-#: src/MuleTextCtrl.cpp:88 src/SearchDlg.cpp:261
+#: src/MuleTextCtrl.cpp:88
 msgid "Paste"
 msgstr "Wklej"
 
 #: src/MuleTextCtrl.cpp:89 src/muuli_wdr.cpp:358 src/muuli_wdr.cpp:757
-#: src/muuli_wdr.cpp:2380 src/muuli_wdr.cpp:2399 src/muuli_wdr.cpp:2421
+#: src/muuli_wdr.cpp:2352 src/muuli_wdr.cpp:2371 src/muuli_wdr.cpp:2393
 #: src/utils/aLinkCreator/src/alcframe.cpp:142
 msgid "Clear"
 msgstr "Wyczyść"
@@ -3116,8 +3106,8 @@ msgid "Exit"
 msgstr "Wyjdź"
 
 #: src/MuleTrayIcon.cpp:579 src/MuleTrayIcon.cpp:945 src/MuleTrayIcon.cpp:965
-#: src/muuli_wdr.cpp:1398 src/muuli_wdr.cpp:1406 src/muuli_wdr.cpp:1413
-#: src/muuli_wdr.cpp:1836 src/muuli_wdr.cpp:1842 src/OtherFunctions.cpp:91
+#: src/muuli_wdr.cpp:1391 src/muuli_wdr.cpp:1399 src/muuli_wdr.cpp:1406
+#: src/muuli_wdr.cpp:1835 src/muuli_wdr.cpp:1841 src/OtherFunctions.cpp:91
 #: src/StatisticsDlg.cpp:93 src/StatisticsDlg.cpp:95
 msgid "kB/s"
 msgstr "kB/s"
@@ -3288,7 +3278,7 @@ msgstr "Nazwa:"
 msgid "Type"
 msgstr "Typ"
 
-#: src/muuli_wdr.cpp:215 src/SearchDlg.cpp:118 src/SearchListCtrl.cpp:853
+#: src/muuli_wdr.cpp:215 src/SearchDlg.cpp:110 src/SearchListCtrl.cpp:853
 msgid "Local"
 msgstr "Lokalne"
 
@@ -3359,7 +3349,7 @@ msgstr "Bajtów"
 msgid "KB"
 msgstr "KB"
 
-#: src/muuli_wdr.cpp:274 src/muuli_wdr.cpp:293 src/muuli_wdr.cpp:1621
+#: src/muuli_wdr.cpp:274 src/muuli_wdr.cpp:293 src/muuli_wdr.cpp:1620
 #: src/OtherFunctions.cpp:64
 msgid "MB"
 msgstr "MB"
@@ -3376,7 +3366,7 @@ msgstr "Maks. rozmiar"
 msgid "Availability"
 msgstr "Dostępność"
 
-#: src/muuli_wdr.cpp:312 src/muuli_wdr.cpp:398 src/muuli_wdr.cpp:3318
+#: src/muuli_wdr.cpp:312 src/muuli_wdr.cpp:398 src/muuli_wdr.cpp:3290
 msgid "Filter:"
 msgstr "Filtr:"
 
@@ -3408,7 +3398,7 @@ msgstr ""
 msgid "Stop"
 msgstr "Zatrzymaj"
 
-#: src/muuli_wdr.cpp:348 src/muuli_wdr.cpp:1392 src/SearchListCtrl.cpp:732
+#: src/muuli_wdr.cpp:348 src/muuli_wdr.cpp:1385 src/SearchListCtrl.cpp:732
 msgid "Download"
 msgstr "Pobieranie"
 
@@ -3439,12 +3429,12 @@ msgstr "Źródła pliku:"
 #: src/muuli_wdr.cpp:1160 src/muuli_wdr.cpp:1167 src/muuli_wdr.cpp:1172
 #: src/muuli_wdr.cpp:1179 src/muuli_wdr.cpp:1184 src/muuli_wdr.cpp:1191
 #: src/muuli_wdr.cpp:1205 src/muuli_wdr.cpp:1212 src/muuli_wdr.cpp:1217
-#: src/muuli_wdr.cpp:1224 src/muuli_wdr.cpp:3255 src/muuli_wdr.cpp:3263
-#: src/muuli_wdr.cpp:3271
+#: src/muuli_wdr.cpp:1224 src/muuli_wdr.cpp:3227 src/muuli_wdr.cpp:3235
+#: src/muuli_wdr.cpp:3243
 msgid "N/A"
 msgstr "Brak"
 
-#: src/muuli_wdr.cpp:508 src/muuli_wdr.cpp:1065 src/PrefsUnifiedDlg.cpp:299
+#: src/muuli_wdr.cpp:508 src/muuli_wdr.cpp:1065 src/PrefsUnifiedDlg.cpp:297
 msgid "General"
 msgstr "Ogólne"
 
@@ -3585,7 +3575,7 @@ msgstr ""
 msgid "Album :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:685 src/muuli_wdr.cpp:2275
+#: src/muuli_wdr.cpp:685 src/muuli_wdr.cpp:2247
 msgid "Title :"
 msgstr "Tytuł :"
 
@@ -3694,7 +3684,7 @@ msgstr "Nazwa użytkownika :"
 msgid "Userhash :"
 msgstr "Skrót użytkownika :"
 
-#: src/muuli_wdr.cpp:895 src/muuli_wdr.cpp:1742 src/muuli_wdr.cpp:2470
+#: src/muuli_wdr.cpp:895 src/muuli_wdr.cpp:1741 src/muuli_wdr.cpp:2442
 #: src/utils/aLinkCreator/src/alcframe.cpp:137
 msgid "Add"
 msgstr "Dodaj"
@@ -3703,15 +3693,15 @@ msgstr "Dodaj"
 msgid "Download-Speed"
 msgstr "Prędkość pobierania"
 
-#: src/muuli_wdr.cpp:954 src/muuli_wdr.cpp:989 src/muuli_wdr.cpp:2574
+#: src/muuli_wdr.cpp:954 src/muuli_wdr.cpp:989 src/muuli_wdr.cpp:2546
 msgid "Current"
 msgstr "Aktualna"
 
-#: src/muuli_wdr.cpp:962 src/muuli_wdr.cpp:997 src/muuli_wdr.cpp:2582
+#: src/muuli_wdr.cpp:962 src/muuli_wdr.cpp:997 src/muuli_wdr.cpp:2554
 msgid "Running average"
 msgstr "Bieżąca średnia"
 
-#: src/muuli_wdr.cpp:970 src/muuli_wdr.cpp:1005 src/muuli_wdr.cpp:2590
+#: src/muuli_wdr.cpp:970 src/muuli_wdr.cpp:1005 src/muuli_wdr.cpp:2562
 msgid "Session average"
 msgstr "Średnia sesji"
 
@@ -3723,7 +3713,7 @@ msgstr "Prędkość wysyłania"
 msgid "Connections"
 msgstr "Połączenie"
 
-#: src/muuli_wdr.cpp:1024 src/muuli_wdr.cpp:1861
+#: src/muuli_wdr.cpp:1024 src/muuli_wdr.cpp:1860
 msgid "Active downloads"
 msgstr "Aktywne pobierania"
 
@@ -3731,7 +3721,7 @@ msgstr "Aktywne pobierania"
 msgid "Active connections (1:1)"
 msgstr "Aktywnych połączeń (1:1)"
 
-#: src/muuli_wdr.cpp:1040 src/muuli_wdr.cpp:1862
+#: src/muuli_wdr.cpp:1040 src/muuli_wdr.cpp:1861
 msgid "Active uploads"
 msgstr "Aktywne wysyłania"
 
@@ -3847,8 +3837,8 @@ msgstr "To jest nazwa jaką inni użytkownicy będą widzieli łącząc się do 
 msgid "Language: "
 msgstr "Język: "
 
-#: src/muuli_wdr.cpp:1257 src/muuli_wdr.cpp:1330 src/muuli_wdr.cpp:1334
-#: src/muuli_wdr.cpp:1337
+#: src/muuli_wdr.cpp:1257 src/muuli_wdr.cpp:1323 src/muuli_wdr.cpp:1327
+#: src/muuli_wdr.cpp:1330
 msgid "The delay before showing tool-tips."
 msgstr "Opóźnienie przed pokazaniem podpowiedzi."
 
@@ -3926,962 +3916,938 @@ msgstr ""
 msgid "Enabling this will make aMule to show notifications when finished downloading."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1323
-#, fuzzy
-msgid "Remember search history"
-msgstr "Zapamiętaj te ustawienia"
-
-#: src/muuli_wdr.cpp:1324
-msgid "Keeps a dropdown list of your past search terms in the Search tab's Name field. This remembers the queries you typed, not the results they returned."
-msgstr ""
-
-#: src/muuli_wdr.cpp:1329
+#: src/muuli_wdr.cpp:1322
 msgid "Tooltip delay time: "
 msgstr "Opóźnienie tooltipów: "
 
-#: src/muuli_wdr.cpp:1336
+#: src/muuli_wdr.cpp:1329
 msgid "seconds"
 msgstr "sekund"
 
-#: src/muuli_wdr.cpp:1340
+#: src/muuli_wdr.cpp:1333
 msgid "Browser Selection"
 msgstr "Wybór przeglądarki"
 
-#: src/muuli_wdr.cpp:1346
+#: src/muuli_wdr.cpp:1339
 msgid "Enter your browser name here. Leave this field empty to use the system default browser."
 msgstr "Podaj tutaj nazwę swojej przeglądarki. Pozostaw to pole puste, aby korzystać z domyślnej przeglądarki systemu."
 
-#: src/muuli_wdr.cpp:1353
+#: src/muuli_wdr.cpp:1346
 msgid "Open in new tab if possible"
 msgstr "Otwórz w nowej karcie jeśli to możliwe"
 
-#: src/muuli_wdr.cpp:1355
+#: src/muuli_wdr.cpp:1348
 msgid "Open the web page in a new tab instead of in a new window when possible"
 msgstr "Otwórz stronę WWW w nowej karcie zamiast w nowym oknie jeśli to możliwe"
 
-#: src/muuli_wdr.cpp:1359
+#: src/muuli_wdr.cpp:1352
 msgid "Video Player"
 msgstr "Odtwarzacz filmów"
 
-#: src/muuli_wdr.cpp:1386
+#: src/muuli_wdr.cpp:1379
 msgid "Bandwidth limits"
 msgstr "Limity przepustowości"
 
-#: src/muuli_wdr.cpp:1400
+#: src/muuli_wdr.cpp:1393
 msgid "Upload"
 msgstr "Wysyłanie"
 
-#: src/muuli_wdr.cpp:1408
+#: src/muuli_wdr.cpp:1401
 msgid "Slot Allocation"
 msgstr "Przydział slotów"
 
-#: src/muuli_wdr.cpp:1417
+#: src/muuli_wdr.cpp:1410
 msgid "Ports"
 msgstr "Pporty"
 
-#: src/muuli_wdr.cpp:1427
+#: src/muuli_wdr.cpp:1420
 msgid "This is the standard eD2k port and cannot be disabled."
 msgstr "To jest standardowy port eD2k i nie może być wyłączony."
 
-#: src/muuli_wdr.cpp:1430
+#: src/muuli_wdr.cpp:1423
 msgid "UDP port for server requests (TCP+3):"
 msgstr "Port UDP dla żądań serwera (TCP+3):"
 
-#: src/muuli_wdr.cpp:1432
+#: src/muuli_wdr.cpp:1425
 msgid "4665"
 msgstr "4665"
 
-#: src/muuli_wdr.cpp:1439
+#: src/muuli_wdr.cpp:1432
 msgid "This UDP port is used for extended eD2k requests and Kad network"
 msgstr "Ten port UDP jest używany do rozszerzonych żądań ed2k i sieci KAD"
 
-#: src/muuli_wdr.cpp:1446
+#: src/muuli_wdr.cpp:1439
 msgid "UPnP TCP Port (Optional):"
 msgstr "Port UPnP TCP (opcjonalnie):"
 
-#: src/muuli_wdr.cpp:1456
+#: src/muuli_wdr.cpp:1449
 msgid "Bind local address to IP (empty for any):"
 msgstr "Wiąż lokalne adresy z IP (puste dla każdego):"
 
-#: src/muuli_wdr.cpp:1459
+#: src/muuli_wdr.cpp:1452
 msgid "Advanced users only: If you have multiple network interfaces, enter the address of the interface to which aMule should be bound."
 msgstr "Tylko zaawansowani użytkownicy: Jeśli masz kilka interfejsów sieciowych, wpisz adres interfejsu do którego powiązany powinien być aMule."
 
-#: src/muuli_wdr.cpp:1462 src/muuli_wdr.cpp:2055
+#: src/muuli_wdr.cpp:1455 src/muuli_wdr.cpp:2054
 #, fuzzy
 msgid "Bind to network interface (empty for any):"
 msgstr "Wiąż lokalne adresy z IP (puste dla każdego):"
 
-#: src/muuli_wdr.cpp:1475
+#: src/muuli_wdr.cpp:1468
 msgid "Advanced users only: pin all of aMule's traffic to one network interface, chosen from the list or typed in by name (e.g. tun0, eth0, en0) or index. Unlike binding to an IP, this stops traffic leaking out via the default route - useful with a VPN. Requires no elevated privileges."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1481
+#: src/muuli_wdr.cpp:1474
 msgid "Max sources per downloading file:"
 msgstr "Maks. ilość źródeł dla pobieranego pliku:"
 
-#: src/muuli_wdr.cpp:1485
+#: src/muuli_wdr.cpp:1478
 msgid "Max simultaneous connections:"
 msgstr "Maksymalne połączenia jednoczesne:"
 
-#: src/muuli_wdr.cpp:1498 src/muuli_wdr.cpp:3197
+#: src/muuli_wdr.cpp:1491 src/muuli_wdr.cpp:3169
 msgid "ED2K"
 msgstr "ED2K"
 
-#: src/muuli_wdr.cpp:1505
+#: src/muuli_wdr.cpp:1498
 msgid "Autoconnect on startup"
 msgstr "Automatycznie połącz przy uruchomieniu"
 
-#: src/muuli_wdr.cpp:1508
+#: src/muuli_wdr.cpp:1501
 msgid "Reconnect on loss"
 msgstr "Połącz ponownie po rozłączeniu"
 
-#: src/muuli_wdr.cpp:1530
+#: src/muuli_wdr.cpp:1523
 msgid "Remove dead server after"
 msgstr "Usuń martwe serwery po"
 
-#: src/muuli_wdr.cpp:1531
+#: src/muuli_wdr.cpp:1524
 msgid "Static servers are never removed, even when unreachable."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1535
+#: src/muuli_wdr.cpp:1528
 msgid "retries"
 msgstr "próbach"
 
-#: src/muuli_wdr.cpp:1543
+#: src/muuli_wdr.cpp:1536
 msgid "List"
 msgstr "Lista"
 
-#: src/muuli_wdr.cpp:1546
+#: src/muuli_wdr.cpp:1539
 msgid "Update server list when connecting to a server"
 msgstr "Uaktualnij listę serwerów przy połączeniu do serwera"
 
-#: src/muuli_wdr.cpp:1549
+#: src/muuli_wdr.cpp:1542
 msgid "Update server list when a client connects"
 msgstr "Uaktualnij listę serwerów przy połączeniu klienta"
 
-#: src/muuli_wdr.cpp:1552
+#: src/muuli_wdr.cpp:1545
 msgid "Use priority system"
 msgstr "Używaj systemu priorytetów"
 
-#: src/muuli_wdr.cpp:1556
+#: src/muuli_wdr.cpp:1549
 msgid "Use smart LowID check on connect"
 msgstr "Używaj inteligentnego sprawdzania LowID przy połączeniu"
 
-#: src/muuli_wdr.cpp:1560
+#: src/muuli_wdr.cpp:1553
 msgid "Safe connect"
 msgstr "Bezpieczne połączenie"
 
-#: src/muuli_wdr.cpp:1564
+#: src/muuli_wdr.cpp:1557
 msgid "Autoconnect to servers in static list only"
 msgstr "Automatyczne łączenie tylko do serwerów statycznych"
 
-#: src/muuli_wdr.cpp:1567
+#: src/muuli_wdr.cpp:1560
 msgid "Set manually added servers to High Priority"
 msgstr "Ustaw priorytet ręcznie dodanych serwerów na Wysoki"
 
-#: src/muuli_wdr.cpp:1588
+#: src/muuli_wdr.cpp:1581
 msgid "Add files to download in pause mode"
 msgstr "Dodaj pliki do pobrania w trybie wstrzymania"
 
-#: src/muuli_wdr.cpp:1590
+#: src/muuli_wdr.cpp:1583
 msgid "Add files to download with auto priority"
 msgstr "Dodaj pliki do pobrania z automatycznym priorytetem"
 
-#: src/muuli_wdr.cpp:1593
+#: src/muuli_wdr.cpp:1586
 msgid "Try to download first and last chunks first"
 msgstr "Próbuj najpierw pobrać pierwszy i ostatni kawałek"
 
-#: src/muuli_wdr.cpp:1597
+#: src/muuli_wdr.cpp:1590
 msgid "Endgame mode: rotate to faster sources for the final blocks"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1600
+#: src/muuli_wdr.cpp:1593
 msgid "Start next paused file when a file completes"
 msgstr "Zacznij następny wstrzymany plik, gdy plik gotowy"
 
-#: src/muuli_wdr.cpp:1603
+#: src/muuli_wdr.cpp:1596
 msgid "From the same category"
 msgstr "Z tej samej kategorii"
 
-#: src/muuli_wdr.cpp:1605
+#: src/muuli_wdr.cpp:1598
 msgid "In alphabetic order"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1607
+#: src/muuli_wdr.cpp:1600
 msgid "Preallocate disk space for new files"
 msgstr "Alokuj wstępnie przestrzeń dyskową dla nowych plików"
 
-#: src/muuli_wdr.cpp:1608
+#: src/muuli_wdr.cpp:1601
 msgid "For new files preallocates disk space for the whole file, thus reduces fragmentation"
 msgstr "Dla nowych plików alokuje wstępnie przestrzeń dyskową dla całego pliku redukując w ten sposób fragmentację"
 
-#: src/muuli_wdr.cpp:1613
+#: src/muuli_wdr.cpp:1606
+msgid "Create new files as sparse files"
+msgstr ""
+
+#: src/muuli_wdr.cpp:1607
+msgid "A sparse file reserves its full size on disk immediately without writing real data to it -- fast, but unsupported or slow on some filesystems, and free-space accounting stays optimistic while the download is in progress. Turn this off to grow the file only as data arrives."
+msgstr ""
+
+#: src/muuli_wdr.cpp:1612
 msgid "Stop downloads when free disk space reaches "
 msgstr "Zatrzymaj pobieranie gdy zabraknie wolnego miejsca na dysku"
 
-#: src/muuli_wdr.cpp:1614
+#: src/muuli_wdr.cpp:1613
 msgid "Select this if you want aMule to check your disk space"
 msgstr "Zaznacz jeśli chcesz, aby aMule sprawdzał Twoją przestrzeń dyskową"
 
-#: src/muuli_wdr.cpp:1618
+#: src/muuli_wdr.cpp:1617
 msgid "Enter here the min disk space desired."
 msgstr "Wpisz tu minimalną ilość miejsca na dysku."
 
-#: src/muuli_wdr.cpp:1624
+#: src/muuli_wdr.cpp:1623
 msgid "Save 10 sources on rare files (< 20 sources)"
 msgstr "Zapisz 10 źródeł dla rzadkich plików (< 20 źródeł)"
 
-#: src/muuli_wdr.cpp:1628 src/Statistics.cpp:790
+#: src/muuli_wdr.cpp:1627 src/Statistics.cpp:790
 msgid "Uploads"
 msgstr "Wysyłanie"
 
-#: src/muuli_wdr.cpp:1631
+#: src/muuli_wdr.cpp:1630
 msgid "Add new shared files with auto priority"
 msgstr "Dodaj udostępnione pliki z automatycznym priorytetem"
 
-#: src/muuli_wdr.cpp:1637
+#: src/muuli_wdr.cpp:1636
 msgid "Intelligent Corruption Handling (I.C.H.)"
 msgstr "Inteligentna obsługa uszkodzeń (I.C.H.)"
 
-#: src/muuli_wdr.cpp:1640
+#: src/muuli_wdr.cpp:1639
 msgid "Enable"
 msgstr "Włączone"
 
-#: src/muuli_wdr.cpp:1643
+#: src/muuli_wdr.cpp:1642
 msgid "Advanced I.C.H. trusts every hash (not recommended)"
 msgstr "Zaawansowane I.C.H. ufa każdemu skrótu (nie zalecane)"
 
-#: src/muuli_wdr.cpp:1655 src/PrefsUnifiedDlg.cpp:1990
+#: src/muuli_wdr.cpp:1654 src/PrefsUnifiedDlg.cpp:1910
 msgid "Media metadata extraction"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1659
+#: src/muuli_wdr.cpp:1658
 msgid "Extract length / bitrate / codec from shared audio and video files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1661
+#: src/muuli_wdr.cpp:1660
 msgid "When enabled, aMule runs ffprobe on each shared media file to fill in the Length / Bitrate / Codec columns other clients see when they find the file in a search. Requires ffmpeg (the ffprobe binary) to be installed."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1668
+#: src/muuli_wdr.cpp:1667
 msgid "Path to ffprobe:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1673
+#: src/muuli_wdr.cpp:1672
 msgid "Full path to the ffprobe binary. Leave empty to have aMule auto-detect it on startup."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1681
+#: src/muuli_wdr.cpp:1680
 msgid "Detect"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1682
+#: src/muuli_wdr.cpp:1681
 msgid "Search the standard install locations for an ffprobe binary and fill the path field."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1706
+#: src/muuli_wdr.cpp:1705
 msgid ""
 "Completed downloads are stored here. All files in this folder are automatically shared with other peers.\n"
 "If this folder also holds files you don't want to share, point it at an aMule-only sub-folder."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1709
+#: src/muuli_wdr.cpp:1708
 msgid "Pick the folder where completed downloads will be stored. All files in that folder will be shared with other peers."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1723
+#: src/muuli_wdr.cpp:1722
 msgid "Shared folders"
 msgstr "Udostępnione foldery"
 
-#: src/muuli_wdr.cpp:1729
+#: src/muuli_wdr.cpp:1728
 msgid "(Folders shared by the core. Enter a path to add one.)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1737
+#: src/muuli_wdr.cpp:1736
 msgid "Absolute path of a folder on the core's machine, e.g. /home/user/shared"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1739 src/PrefsUnifiedDlg.cpp:2874
+#: src/muuli_wdr.cpp:1738 src/PrefsUnifiedDlg.cpp:2794
 msgid "Recursive"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1740
+#: src/muuli_wdr.cpp:1739
 msgid "Share every sub-folder underneath this one, including ones created later."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1744 src/utils/aLinkCreator/src/alcframe.cpp:141
+#: src/muuli_wdr.cpp:1743 src/utils/aLinkCreator/src/alcframe.cpp:141
 msgid "Remove"
 msgstr "Usuń"
 
-#: src/muuli_wdr.cpp:1748
+#: src/muuli_wdr.cpp:1747
 msgid "(Right click on folder icon for recursive share)"
 msgstr "(Kliknij prawym przyciskiem na katalog, aby udostępnić go razem z podkatalogami)"
 
-#: src/muuli_wdr.cpp:1755
+#: src/muuli_wdr.cpp:1754
 msgid "Share hidden files"
 msgstr "Udostępnij pliki ukryte"
 
-#: src/muuli_wdr.cpp:1761
+#: src/muuli_wdr.cpp:1760
 msgid "Automatically rescan shared folders for changes"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1767
+#: src/muuli_wdr.cpp:1766
 msgid "Follow symbolic links in shared folders"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1773
+#: src/muuli_wdr.cpp:1772
 msgid "Exclude files matching:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1776
+#: src/muuli_wdr.cpp:1775
 msgid "Wildcard patterns separated by '|', e.g. .DS_Store|Thumbs.db|*.tmp. Files whose name matches are not shared. Matching is case-insensitive."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1780
+#: src/muuli_wdr.cpp:1779
 msgid "Patterns are regular expressions"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1781
+#: src/muuli_wdr.cpp:1780
 msgid "When set, the whole field is one regular expression ('|' is alternation). When unset, it is a list of '|'-separated wildcards."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1791
+#: src/muuli_wdr.cpp:1790
 msgid "Show how many shared files the current pattern would exclude."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1812
+#: src/muuli_wdr.cpp:1811
 msgid "Graphs"
 msgstr "Wykresy"
 
-#: src/muuli_wdr.cpp:1815 src/muuli_wdr.cpp:1877
+#: src/muuli_wdr.cpp:1814 src/muuli_wdr.cpp:1876
 msgid "Update delay : 5 secs"
 msgstr "Odśwież co : 5 sekund"
 
-#: src/muuli_wdr.cpp:1819
+#: src/muuli_wdr.cpp:1818
 msgid "Time for average graph: 100 mins"
 msgstr "Czas dla wykresów średnich: 100 minut"
 
-#: src/muuli_wdr.cpp:1823
+#: src/muuli_wdr.cpp:1822
 msgid "Connections Graph Scale: 100 "
 msgstr "Skala wykresu połączeń: 100"
 
-#: src/muuli_wdr.cpp:1830
+#: src/muuli_wdr.cpp:1829
 msgid "Download graph scale:"
 msgstr "Skala wykresu pobierania:"
 
-#: src/muuli_wdr.cpp:1838
+#: src/muuli_wdr.cpp:1837
 msgid "Upload graph scale:"
 msgstr "Skala wykresu przesyłania:"
 
-#: src/muuli_wdr.cpp:1848
+#: src/muuli_wdr.cpp:1847
 #, fuzzy
 msgid "Colors: "
 msgstr "Kolory: "
 
-#: src/muuli_wdr.cpp:1852
+#: src/muuli_wdr.cpp:1851
 msgid "Background"
 msgstr "Tło"
 
-#: src/muuli_wdr.cpp:1853
+#: src/muuli_wdr.cpp:1852
 msgid "Grid"
 msgstr "Siatka"
 
-#: src/muuli_wdr.cpp:1854
+#: src/muuli_wdr.cpp:1853
 msgid "Download current"
 msgstr "Aktualnie pobierane"
 
-#: src/muuli_wdr.cpp:1855
+#: src/muuli_wdr.cpp:1854
 msgid "Download running average"
 msgstr "Bieżąca średnia pobierania"
 
-#: src/muuli_wdr.cpp:1856
+#: src/muuli_wdr.cpp:1855
 msgid "Download session average"
 msgstr "Średnia pobierania sesji"
 
-#: src/muuli_wdr.cpp:1857
+#: src/muuli_wdr.cpp:1856
 msgid "Upload current"
 msgstr "Aktualnie wysyłane"
 
-#: src/muuli_wdr.cpp:1858
+#: src/muuli_wdr.cpp:1857
 msgid "Upload running average"
 msgstr "Bieżąca średnia wysyłania"
 
-#: src/muuli_wdr.cpp:1859
+#: src/muuli_wdr.cpp:1858
 msgid "Upload session average"
 msgstr "Średnia wysyłania sesji"
 
-#: src/muuli_wdr.cpp:1860
+#: src/muuli_wdr.cpp:1859
 msgid "Active connections"
 msgstr "Aktywnych połączeń"
 
-#: src/muuli_wdr.cpp:1863
+#: src/muuli_wdr.cpp:1862
 #, fuzzy
 msgid "Systray Icon Speed Bar"
 msgstr "Ikona prędkości w zasobniku systemowym"
 
-#: src/muuli_wdr.cpp:1864
+#: src/muuli_wdr.cpp:1863
 msgid "Kad-nodes current"
 msgstr "Obecne Kad-węzły "
 
-#: src/muuli_wdr.cpp:1865
+#: src/muuli_wdr.cpp:1864
 msgid "Kad-nodes running"
 msgstr "Działające Kad-węzły"
 
-#: src/muuli_wdr.cpp:1866
+#: src/muuli_wdr.cpp:1865
 msgid "Kad-nodes session"
 msgstr "Sesyjne Kad-węzły"
 
-#: src/muuli_wdr.cpp:1870 src/muuli_wdr.cpp:2324
+#: src/muuli_wdr.cpp:1869 src/muuli_wdr.cpp:2296
 msgid "Select"
 msgstr "Wybierz"
 
-#: src/muuli_wdr.cpp:1874
+#: src/muuli_wdr.cpp:1873
 msgid "Tree"
 msgstr "Drzewo"
 
-#: src/muuli_wdr.cpp:1884
+#: src/muuli_wdr.cpp:1883
 msgid "Number of Client Versions shown (0=unlimited)"
 msgstr "Liczba wyświetlanych wersji klienta (0=nieograniczona)"
 
-#: src/muuli_wdr.cpp:1909
+#: src/muuli_wdr.cpp:1908
 msgid "!!! WARNING !!!"
 msgstr "!!! UWAGA !!!"
 
-#: src/muuli_wdr.cpp:1924
+#: src/muuli_wdr.cpp:1923
 msgid "Max new connections / 5 secs"
 msgstr "Maks. nowych połączeń"
 
-#: src/muuli_wdr.cpp:1926
+#: src/muuli_wdr.cpp:1925
 msgid "Concurrent Kad source lookups"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1928
+#: src/muuli_wdr.cpp:1927
 #, fuzzy
 msgid "Kad source re-search interval (minutes)"
 msgstr "Czas pomiędzy odświeżeniami FTP w minutach"
 
-#: src/muuli_wdr.cpp:1930
+#: src/muuli_wdr.cpp:1929
 #, fuzzy
 msgid "Source re-ask interval (minutes)"
 msgstr "Czas pomiędzy odświeżeniami FTP w minutach"
 
-#: src/muuli_wdr.cpp:1934
+#: src/muuli_wdr.cpp:1933
 msgid "File Buffer Size: 240000 bytes"
 msgstr "Rozmiar bufora plików: 240000 bajtów"
 
-#: src/muuli_wdr.cpp:1938
+#: src/muuli_wdr.cpp:1937
 msgid "Use MMAP: memory-mapped file access (lower memory use)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1939
+#: src/muuli_wdr.cpp:1938
 msgid "Maps part files into memory instead of buffering them on the heap, lowering the process memory footprint. May reduce download speed on some disks; best for memory-constrained or upload-heavy hosts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1941
+#: src/muuli_wdr.cpp:1940
 msgid "Upload Queue Size: 5000 clients"
 msgstr "Rozmiar kolejki wysyłania: 5000 klientów"
 
-#: src/muuli_wdr.cpp:1945
+#: src/muuli_wdr.cpp:1944
 msgid "Server connection refresh interval: Disable"
 msgstr "Odświeżanie połączeń do serwera co: Wyłączone"
 
-#: src/muuli_wdr.cpp:1949
+#: src/muuli_wdr.cpp:1948
 msgid "Disable computer's timed standby mode"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1968
+#: src/muuli_wdr.cpp:1967
 msgid "Skin to use: "
 msgstr "Skóra do użycia:"
 
-#: src/muuli_wdr.cpp:1977
+#: src/muuli_wdr.cpp:1976
 msgid "Show \"Fast eD2k Links Handler\" in every window."
 msgstr "Pokazuj \"Szybkie wyłapywanie linków eD2K\" w każdym oknie."
 
-#: src/muuli_wdr.cpp:1980
+#: src/muuli_wdr.cpp:1979
 msgid "Show extended info on categories tabs"
 msgstr "Pokaż rozszerzone info w kartach kategorii"
 
-#: src/muuli_wdr.cpp:1983
+#: src/muuli_wdr.cpp:1982
 #, fuzzy
 msgid "Show application version on title"
 msgstr "Pokaż prędkość transferu w tytule"
 
-#: src/muuli_wdr.cpp:1985
+#: src/muuli_wdr.cpp:1984
 msgid "Show transfer rates on title"
 msgstr "Pokaż prędkość transferu w tytule"
 
-#: src/muuli_wdr.cpp:1987
+#: src/muuli_wdr.cpp:1986
 msgid "Before application name"
 msgstr "Przed nazwą aplikacji"
 
-#: src/muuli_wdr.cpp:1989
+#: src/muuli_wdr.cpp:1988
 msgid "After application name"
 msgstr "Za nazwą aplikacji"
 
-#: src/muuli_wdr.cpp:1992
+#: src/muuli_wdr.cpp:1991
 msgid "Show overhead bandwidth"
 msgstr "Pokaż narzut przepustowości"
 
-#: src/muuli_wdr.cpp:1996
+#: src/muuli_wdr.cpp:1995
 msgid "Vertical toolbar orientation"
 msgstr "Pionowa orientacja paska narzędzi"
 
-#: src/muuli_wdr.cpp:1998
+#: src/muuli_wdr.cpp:1997
 msgid "Live column sorting (auto-reorder rows as their values change)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2005
+#: src/muuli_wdr.cpp:2004
 msgid "Download Queue Files"
 msgstr "Pobierane pliki w kolejce"
 
-#: src/muuli_wdr.cpp:2008
+#: src/muuli_wdr.cpp:2007
 msgid "Show progress percentage"
 msgstr "Pokaż procent postępu"
 
-#: src/muuli_wdr.cpp:2014
+#: src/muuli_wdr.cpp:2013
 msgid "Show progress bar"
 msgstr "Pokaż pasek postępu"
 
-#: src/muuli_wdr.cpp:2017
+#: src/muuli_wdr.cpp:2016
 msgid "Flat"
 msgstr "Płaski"
 
-#: src/muuli_wdr.cpp:2021
+#: src/muuli_wdr.cpp:2020
 msgid "Round"
 msgstr "Okrągły"
 
-#: src/muuli_wdr.cpp:2039
+#: src/muuli_wdr.cpp:2038
 msgid "External Connection Parameters"
 msgstr "Parametry zewnętrznych połączeń"
 
-#: src/muuli_wdr.cpp:2042
+#: src/muuli_wdr.cpp:2041
 msgid "Accept external connections"
 msgstr "Akceptuj zewnętrzne połączenia"
 
-#: src/muuli_wdr.cpp:2049 src/muuli_wdr.cpp:2108
+#: src/muuli_wdr.cpp:2048 src/muuli_wdr.cpp:2107
 msgid "IP of the listening interface:"
 msgstr "IP z interfejsem słuchania:"
 
-#: src/muuli_wdr.cpp:2052
+#: src/muuli_wdr.cpp:2051
 msgid "Enter here a valid ip in the a.b.c.d format for the listening EC interface. An empty field or 0.0.0.0 will mean any interface."
 msgstr "Wprowadź tutaj w formacie a.b.c.d prawidłowy adres ip nasłuchującego interfejsu EC. Puste pole lub 0.0.0.0 oznacza dowolny interfejs."
 
-#: src/muuli_wdr.cpp:2073 src/muuli_wdr.cpp:2184
+#: src/muuli_wdr.cpp:2072 src/muuli_wdr.cpp:2156
 msgid "TCP port:"
 msgstr "Port TCP:"
 
-#: src/muuli_wdr.cpp:2079
+#: src/muuli_wdr.cpp:2078
 msgid "Enable UPnP port forwarding on the EC port"
 msgstr "Włącz forwarding portu UPnP na porcie EC"
 
-#: src/muuli_wdr.cpp:2083 src/muuli_wdr.cpp:3069
+#: src/muuli_wdr.cpp:2082 src/muuli_wdr.cpp:3041
 #: src/utils/wxCas/src/wxcasprefs.cpp:167
 msgid "Password"
 msgstr "Hasło"
 
-#: src/muuli_wdr.cpp:2089
+#: src/muuli_wdr.cpp:2088
 #, fuzzy
 msgid "aMule API server parameters"
 msgstr "Parametry serwera sieciowego"
 
-#: src/muuli_wdr.cpp:2092
+#: src/muuli_wdr.cpp:2091
 msgid "Run amuleapi (REST API) on startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2097
+#: src/muuli_wdr.cpp:2096
 #, fuzzy
 msgid "HTTP port:"
 msgstr "Port TCP:"
 
-#: src/muuli_wdr.cpp:2111
+#: src/muuli_wdr.cpp:2110
 msgid "The interface amuleapi's HTTP server listens on. 127.0.0.1 (default) accepts only local connections; use 0.0.0.0 or a specific IP to expose it to other hosts (set an admin password below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2116
-msgid "Type a password to set or change it. Stored passwords cannot be shown, so leaving this empty keeps the current one."
-msgstr ""
-
-#: src/muuli_wdr.cpp:2118
+#: src/muuli_wdr.cpp:2113
 #, fuzzy
 msgid "Admin password"
 msgstr "Sprawdzam hasło\n"
 
-#: src/muuli_wdr.cpp:2130 src/muuli_wdr.cpp:2147 src/PrefsUnifiedDlg.cpp:1103
-#, fuzzy
-msgid "A password is set."
-msgstr "Sprawdzam hasło\n"
+#: src/muuli_wdr.cpp:2118 src/muuli_wdr.cpp:2149
+msgid "Low rights password"
+msgstr "Hasło niskich uprawnień"
 
-#: src/muuli_wdr.cpp:2134
-#, fuzzy
-msgid "Enable guest access"
-msgstr "Zabroń dostępu gościom"
-
-#: src/muuli_wdr.cpp:2135
-msgid "Guest sessions may read status and listings but cannot change anything. Turning this off clears the stored guest password."
-msgstr ""
-
-#: src/muuli_wdr.cpp:2139
-#, fuzzy
-msgid "Guest password"
-msgstr "Hasło gościa do serwera sieciowego"
-
-#: src/muuli_wdr.cpp:2154
+#: src/muuli_wdr.cpp:2126
 msgid "Web server parameters"
 msgstr "Parametry serwera sieciowego"
 
-#: src/muuli_wdr.cpp:2157
+#: src/muuli_wdr.cpp:2129
 #, fuzzy
 msgid "Run webserver on startup (deprecated)"
 msgstr "Uruchom serwera internetowego przy starcie"
 
-#: src/muuli_wdr.cpp:2163
+#: src/muuli_wdr.cpp:2135
 msgid "Web template"
 msgstr "Szablon WWW"
 
-#: src/muuli_wdr.cpp:2168
+#: src/muuli_wdr.cpp:2140
 msgid "Full rights password"
 msgstr "Hasło pełnych uprawnień"
 
-#: src/muuli_wdr.cpp:2172
+#: src/muuli_wdr.cpp:2144
 msgid "Enable Low rights User"
 msgstr "Włącz użytkowników z niskimi uprawnieniami"
 
-#: src/muuli_wdr.cpp:2177
-msgid "Low rights password"
-msgstr "Hasło niskich uprawnień"
-
-#: src/muuli_wdr.cpp:2191
+#: src/muuli_wdr.cpp:2163
 msgid "Enable UPnP port forwarding of the web server port"
 msgstr "Włącz przekierowanie portu UPnP na port serwera internetowego"
 
-#: src/muuli_wdr.cpp:2196
+#: src/muuli_wdr.cpp:2168
 msgid "Web server UPnP TCP port (Optional)"
 msgstr "Port web serwera UPnP TCP (opcjonalnie)"
 
-#: src/muuli_wdr.cpp:2204
+#: src/muuli_wdr.cpp:2176
 msgid "Page Refresh Time (in secs)"
 msgstr "Odświeżanie strony co:  (w sekundach)"
 
-#: src/muuli_wdr.cpp:2211
+#: src/muuli_wdr.cpp:2183
 msgid "Enable Gzip compression"
 msgstr "Włącz kompresję Gzip"
 
-#: src/muuli_wdr.cpp:2245
+#: src/muuli_wdr.cpp:2217
 #, fuzzy
 msgid "Reset page to defaults"
 msgstr "Domyślny systemowy"
 
-#: src/muuli_wdr.cpp:2246
+#: src/muuli_wdr.cpp:2218
 msgid "Reset the settings on the current page to their default values."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2248 src/muuli_wdr.cpp:2334 src/ServerWnd.cpp:274
+#: src/muuli_wdr.cpp:2220 src/muuli_wdr.cpp:2306 src/ServerWnd.cpp:274
 #: src/ServerWnd.cpp:282
 msgid "OK"
 msgstr "OK"
 
-#: src/muuli_wdr.cpp:2250
+#: src/muuli_wdr.cpp:2222
 msgid "Click here to apply any changes made to the preferences."
 msgstr "Kliknij tu aby zastosować wszystkie zmiany dokonane w preferencjach."
 
-#: src/muuli_wdr.cpp:2253
+#: src/muuli_wdr.cpp:2225
 msgid "Reset any changes made to the preferences."
 msgstr "Reset wszystkich zmian dokonanych w preferencjach."
 
-#: src/muuli_wdr.cpp:2282
+#: src/muuli_wdr.cpp:2254
 msgid "Comment :"
 msgstr "Komentarz :"
 
-#: src/muuli_wdr.cpp:2289
+#: src/muuli_wdr.cpp:2261
 msgid "Incoming Dir :"
 msgstr "Katalog przychodzących :"
 
-#: src/muuli_wdr.cpp:2298
+#: src/muuli_wdr.cpp:2270
 msgid "Change priority for new assigned files :"
 msgstr "Zmień priorytet nowo przydzielonych plików :"
 
-#: src/muuli_wdr.cpp:2302
+#: src/muuli_wdr.cpp:2274
 #, fuzzy
 msgid "Don't change"
 msgstr "Nie zmieniaj"
 
-#: src/muuli_wdr.cpp:2314
+#: src/muuli_wdr.cpp:2286
 msgid "Select color for this Category (currently selected) :"
 msgstr "Wybierz kolor dla tej kategorii (aktualnie wybrany) :"
 
-#: src/muuli_wdr.cpp:2381 src/muuli_wdr.cpp:2400 src/muuli_wdr.cpp:2422
+#: src/muuli_wdr.cpp:2353 src/muuli_wdr.cpp:2372 src/muuli_wdr.cpp:2394
 msgid "Click this button to reset the log."
 msgstr "Kliknij tu aby wyczyścić logi."
 
-#: src/muuli_wdr.cpp:2441
+#: src/muuli_wdr.cpp:2413
 msgid "Click on this button to update the servers list from URL ..."
 msgstr "Kliknij na tym przycisku aby uaktualnić listę serwerów z URL-a ..."
 
-#: src/muuli_wdr.cpp:2445
+#: src/muuli_wdr.cpp:2417
 msgid "Server list"
 msgstr "Lista serwerów"
 
-#: src/muuli_wdr.cpp:2449
+#: src/muuli_wdr.cpp:2421
 msgid "Enter the url to a server.met file here and press the button to the left to update the list of known servers."
 msgstr "Wpisz tu url do pliku server.met  i przyciśnij przycisk po lewej aby zaktualizować listę znanych serwerów."
 
-#: src/muuli_wdr.cpp:2454
+#: src/muuli_wdr.cpp:2426
 msgid "Add server manually: Name"
 msgstr "Dodaj serwer ręcznie: Nazwa"
 
-#: src/muuli_wdr.cpp:2457
+#: src/muuli_wdr.cpp:2429
 msgid "Enter the name of the new server here"
 msgstr "Wpisz tu nazwę nowego serwera"
 
-#: src/muuli_wdr.cpp:2459 src/ServerWnd.cpp:206
+#: src/muuli_wdr.cpp:2431 src/ServerWnd.cpp:206
 msgid "IP:Port"
 msgstr "IP:Port"
 
-#: src/muuli_wdr.cpp:2462
+#: src/muuli_wdr.cpp:2434
 msgid "Enter the IP of the server here, using the x.x.x.x format."
 msgstr "Wpisz tu IP serwera, używając formatu x.x.x.x ."
 
-#: src/muuli_wdr.cpp:2468
+#: src/muuli_wdr.cpp:2440
 msgid "Enter the port of the server here."
 msgstr "Wpisz tu port serwera."
 
-#: src/muuli_wdr.cpp:2471
+#: src/muuli_wdr.cpp:2443
 msgid "Add manually a server (fill fields to the left before) ..."
 msgstr "Dodaj ręcznie serwer (wypełnij pola od lewej) ..."
 
-#: src/muuli_wdr.cpp:2500
+#: src/muuli_wdr.cpp:2472
 msgid "aMule Log"
 msgstr "Logi aMule"
 
-#: src/muuli_wdr.cpp:2508
+#: src/muuli_wdr.cpp:2480
 msgid "Server Info"
 msgstr "Serwer Info"
 
-#: src/muuli_wdr.cpp:2512
+#: src/muuli_wdr.cpp:2484
 msgid "ED2K Info"
 msgstr "Info eD2K"
 
-#: src/muuli_wdr.cpp:2516
+#: src/muuli_wdr.cpp:2488
 msgid "Kad Info"
 msgstr "Info Kad"
 
-#: src/muuli_wdr.cpp:2544
+#: src/muuli_wdr.cpp:2516
 msgid "Click on this button to update the nodes list from URL ..."
 msgstr "Kliknij ten przycisk, aby uaktualnić listę węzłów z adresu URL ..."
 
-#: src/muuli_wdr.cpp:2548
+#: src/muuli_wdr.cpp:2520
 msgid "Nodes (0)"
 msgstr "Węzły (0)"
 
-#: src/muuli_wdr.cpp:2552
+#: src/muuli_wdr.cpp:2524
 msgid "Enter the url to a nodes.dat file here and press the button to the left to update the list of known nodes."
 msgstr "Wprowadź tutaj url pliku nodes.dat i naciśnij przycisk z lewej, aby zaktualizować listę znanych węzłów."
 
-#: src/muuli_wdr.cpp:2555
+#: src/muuli_wdr.cpp:2527
 msgid "Nodes stats"
 msgstr "Statystyki węzłów"
 
-#: src/muuli_wdr.cpp:2597
+#: src/muuli_wdr.cpp:2569
 msgid "Bootstrap"
 msgstr "Bootstrap"
 
-#: src/muuli_wdr.cpp:2600
+#: src/muuli_wdr.cpp:2572
 msgid "New node"
 msgstr "Nowy węzeł"
 
-#: src/muuli_wdr.cpp:2605
+#: src/muuli_wdr.cpp:2577
 msgid "IP:"
 msgstr "IP:"
 
-#: src/muuli_wdr.cpp:2625
+#: src/muuli_wdr.cpp:2597
 msgid "Port:"
 msgstr "Port:"
 
-#: src/muuli_wdr.cpp:2638
+#: src/muuli_wdr.cpp:2610
 msgid "Bootstrap from known clients"
 msgstr "Rozruch od znanych klientów"
 
-#: src/muuli_wdr.cpp:2640
+#: src/muuli_wdr.cpp:2612
 msgid "Disconnect Kad"
 msgstr "Rozłącz z Kad"
 
-#: src/muuli_wdr.cpp:2674
+#: src/muuli_wdr.cpp:2646
 msgid "Use Secure User Identification"
 msgstr "Użyj bezpiecznej identyfikacji użytkownika"
 
-#: src/muuli_wdr.cpp:2676
+#: src/muuli_wdr.cpp:2648
 msgid "It is recommended to enable this option. You will not receive credits if SUI is not enabled."
 msgstr "Zalecane jest włączenie tej opcji. Nic nie zyskasz wyłączając bezpieczną identyfikację użytkownika."
 
-#: src/muuli_wdr.cpp:2678
+#: src/muuli_wdr.cpp:2650
 msgid "Protocol Obfuscation"
 msgstr "Maskowanie protokołu"
 
-#: src/muuli_wdr.cpp:2681
+#: src/muuli_wdr.cpp:2653
 msgid "Support Protocol Obfuscation"
 msgstr "Obsługa maskowania protokołu"
 
-#: src/muuli_wdr.cpp:2683
+#: src/muuli_wdr.cpp:2655
 msgid "This option enabled Protocol Obfuscation, and makes aMule accept obfuscated connections from other clients."
 msgstr "Opcja ta włącza maskowanie protokołu i powoduje, że aMule będzie akceptował zamaskowane połączenia od innych klientów."
 
-#: src/muuli_wdr.cpp:2685
+#: src/muuli_wdr.cpp:2657
 msgid "Use obfuscation for outgoing connections"
 msgstr "Użyj maskowania dla połączeń wychodzących"
 
-#: src/muuli_wdr.cpp:2687
+#: src/muuli_wdr.cpp:2659
 msgid "This option makes aMule use Protocol Obfuscation when connecting other clients/servers."
 msgstr "Opcja ta powoduje, że aMule będzie używał maskowania protokołu podczas łączenia z innymi klientami/serwerami."
 
-#: src/muuli_wdr.cpp:2689
+#: src/muuli_wdr.cpp:2661
 msgid "Accept only obfuscated connections"
 msgstr "Akceptuj tylko zamaskowane połączenia"
 
-#: src/muuli_wdr.cpp:2690
+#: src/muuli_wdr.cpp:2662
 msgid "This option makes aMule only accept obfuscated connections. You will have less sources, but all your traffic will be obfuscated"
 msgstr "Opcja ta powoduje, że aMule akceptuje tylko zamaskowane połączenia. Uzyskasz mniej źródeł, ale cały twój ruch będzie zamaskowany"
 
-#: src/muuli_wdr.cpp:2695
+#: src/muuli_wdr.cpp:2667
 msgid "Everybody"
 msgstr "Wszyscy"
 
-#: src/muuli_wdr.cpp:2697
+#: src/muuli_wdr.cpp:2669
 msgid "No one"
 msgstr "Nikt"
 
-#: src/muuli_wdr.cpp:2699
+#: src/muuli_wdr.cpp:2671
 msgid "Who can see my shared files:"
 msgstr "Kto może widzieć moje udostępnione pliki:"
 
-#: src/muuli_wdr.cpp:2700
+#: src/muuli_wdr.cpp:2672
 msgid "Select who can request to view a list of your shared files."
 msgstr "Wybierz kto może zażądać pokazania listy twoich udostępnionych plików."
 
-#: src/muuli_wdr.cpp:2702
+#: src/muuli_wdr.cpp:2674
 msgid "IP-Filtering"
 msgstr "Filtrowanie IP"
 
-#: src/muuli_wdr.cpp:2709
+#: src/muuli_wdr.cpp:2681
 msgid "Filter clients"
 msgstr "Filtruj klientów"
 
-#: src/muuli_wdr.cpp:2711
+#: src/muuli_wdr.cpp:2683
 msgid "Enable filtering of the client IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "Włącza filtrowanie IP klientów zdefiniowanych w pliku ~/.aMule/ipfilter.dat."
 
-#: src/muuli_wdr.cpp:2713
+#: src/muuli_wdr.cpp:2685
 msgid "Filter servers"
 msgstr "Filtruj serwery"
 
-#: src/muuli_wdr.cpp:2715
+#: src/muuli_wdr.cpp:2687
 msgid "Enable filtering of the server IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "Włącza filtrowanie IP serwerów zdefiniowanych w pliku ~/.aMule/ipfilter.dat."
 
-#: src/muuli_wdr.cpp:2719
+#: src/muuli_wdr.cpp:2691
 msgid "Reload List"
 msgstr "Przeładuj listę"
 
-#: src/muuli_wdr.cpp:2720
+#: src/muuli_wdr.cpp:2692
 msgid "Reload the list of IPs to filter from the file ~/.aMule/ipfilter.dat"
 msgstr "Przeładuj listę filtrowanych IP z pliku ~/.aMule/ipfilter.dat"
 
-#: src/muuli_wdr.cpp:2726
+#: src/muuli_wdr.cpp:2698
 msgid "URL:"
 msgstr "URL:"
 
-#: src/muuli_wdr.cpp:2730 src/muuli_wdr.cpp:2923
+#: src/muuli_wdr.cpp:2702 src/muuli_wdr.cpp:2895
 msgid "Update now"
 msgstr "Uaktualnij teraz"
 
-#: src/muuli_wdr.cpp:2733
+#: src/muuli_wdr.cpp:2705
 msgid "Auto-update ipfilter at startup"
 msgstr "Uaktualniaj filtr IP przy starcie"
 
-#: src/muuli_wdr.cpp:2737
+#: src/muuli_wdr.cpp:2709
 msgid "Filtering Level:"
 msgstr "Poziom filtrowania:"
 
-#: src/muuli_wdr.cpp:2743
+#: src/muuli_wdr.cpp:2715
 msgid "Always filter LAN IPs"
 msgstr "Zawsze filtruj IP z LAN"
 
-#: src/muuli_wdr.cpp:2746
+#: src/muuli_wdr.cpp:2718
 msgid "Paranoid handling of non-matching IPs"
 msgstr "Paranoidalna obsługa niepasujących IP"
 
-#: src/muuli_wdr.cpp:2748
+#: src/muuli_wdr.cpp:2720
 msgid "Rejects a packet when its source IP differs from the IP the client claims (an anti-spoofing check). Disable only if it causes connection problems."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2750
+#: src/muuli_wdr.cpp:2722
 msgid "Use system-wide ipfilter.dat if available"
 msgstr "Użyj ogólno-systemowego ipfilter.dat jeśli dostępny"
 
-#: src/muuli_wdr.cpp:2751
+#: src/muuli_wdr.cpp:2723
 #, fuzzy
 msgid "If there's no local ipfilter.dat found, allow usage of a system-wide ipfilter file."
 msgstr "Jeśli ipfilter.dat nie istnieje lokalnie, zezwól na użycie ogólno-systemowego pliku ipfilter."
 
-#: src/muuli_wdr.cpp:2768
+#: src/muuli_wdr.cpp:2740
 msgid "Enable Online-Signature"
 msgstr "Włącz podpis online"
 
-#: src/muuli_wdr.cpp:2770
+#: src/muuli_wdr.cpp:2742
 msgid "Enables the writing of the OS file, which can be used by external apps to create signatures and the like."
 msgstr "Włącza zapisywanie pliku OS, który może być użyty przez zewnętrzne aplikacje do stworzenia sygnatury itp."
 
-#: src/muuli_wdr.cpp:2774
+#: src/muuli_wdr.cpp:2746
 msgid "Update Frequency (Secs):"
 msgstr "Częstotliwość odświeżania (sek):"
 
-#: src/muuli_wdr.cpp:2777
+#: src/muuli_wdr.cpp:2749
 msgid "Change the frequency (in seconds) of Online Signature updates."
 msgstr "Zmień częstotliwość (w sekundach) aktualizacji Sygnatury Online."
 
-#: src/muuli_wdr.cpp:2785
+#: src/muuli_wdr.cpp:2757
 msgid "Save online signature file in: "
 msgstr "Zapisz podpis internetowy w pliku: "
 
-#: src/muuli_wdr.cpp:2791
+#: src/muuli_wdr.cpp:2763
 msgid "Click here to select the directory containing the the Online Signature files."
 msgstr "Kliknij tu aby wskazać katalog zawierający pliki Sygnatur Online."
 
-#: src/muuli_wdr.cpp:2824
+#: src/muuli_wdr.cpp:2796
 msgid "Show country flags for clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2825
+#: src/muuli_wdr.cpp:2797
 msgid "Render the country flag column in the transfers, queue and search views. Requires a valid MMDB GeoIP database (see below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2830
+#: src/muuli_wdr.cpp:2802
 #, fuzzy
 msgid "Database"
 msgstr "Prędkość transmisji danych :"
 
-#: src/muuli_wdr.cpp:2846
+#: src/muuli_wdr.cpp:2818
 #, fuzzy
 msgid "Source:"
 msgstr "Źródła"
 
-#: src/muuli_wdr.cpp:2849
+#: src/muuli_wdr.cpp:2821
 msgid "DB-IP (free, no account)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2850
+#: src/muuli_wdr.cpp:2822
 msgid "MaxMind GeoLite2 (free, account required)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2851
+#: src/muuli_wdr.cpp:2823
 msgid "Custom URL"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2854
+#: src/muuli_wdr.cpp:2826
 msgid "Choose which provider supplies the GeoIP MMDB database. DB-IP is the default - no account required. MaxMind requires a free account + license key. Use Custom URL to point at any other MMDB host (e.g. a local mirror)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2871
+#: src/muuli_wdr.cpp:2843
 msgid ""
 "No configuration required.\n"
 "\n"
@@ -4889,11 +4855,11 @@ msgid ""
 "License: Creative Commons BY 4.0 - https://creativecommons.org/licenses/by/4.0/"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2884
+#: src/muuli_wdr.cpp:2856
 msgid "License key:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2890
+#: src/muuli_wdr.cpp:2862
 msgid ""
 "Sign up for a free MaxMind account, then generate a License Key:\n"
 "https://www.maxmind.com/en/geolite2/signup\n"
@@ -4903,231 +4869,231 @@ msgid ""
 "Requires attribution and account registration; refresh at least every 30 days."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2905
+#: src/muuli_wdr.cpp:2877
 #, fuzzy
 msgid "Download URL:"
 msgstr "Pobranych: "
 
-#: src/muuli_wdr.cpp:2911
+#: src/muuli_wdr.cpp:2883
 msgid ""
 "Must point to an .mmdb file or a .gz / .tar.gz containing one.\n"
 "URL may include credentials (https://user:pass@host/...).\n"
 "License and attribution terms are set by the upstream URL - you are responsible."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2924
+#: src/muuli_wdr.cpp:2896
 msgid "Download the GeoIP database from the selected source."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2926
+#: src/muuli_wdr.cpp:2898
 #, fuzzy
 msgid "Auto-update on startup"
 msgstr "Uaktualniaj filtr IP przy starcie"
 
-#: src/muuli_wdr.cpp:2927
+#: src/muuli_wdr.cpp:2899
 msgid "Re-download the GeoIP database from the selected source every time aMule starts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2950
+#: src/muuli_wdr.cpp:2922
 msgid "Filter incoming messages (except current chat):"
 msgstr "Filtruj wiadomości przychodzące (za wyjątkiem aktualnej rozmowy):"
 
-#: src/muuli_wdr.cpp:2952
+#: src/muuli_wdr.cpp:2924
 msgid "Filter all messages"
 msgstr "Filtruj wszystkie wiadomości"
 
-#: src/muuli_wdr.cpp:2954
+#: src/muuli_wdr.cpp:2926
 msgid "Filter messages from people not on your friend list"
 msgstr "Filtruj wiadomości od ludzi, którzy nie są na twojej liście znajomych"
 
-#: src/muuli_wdr.cpp:2956
+#: src/muuli_wdr.cpp:2928
 msgid "Filter messages from unknown clients"
 msgstr "Filtruj wiadomości od nieznanych klientów"
 
-#: src/muuli_wdr.cpp:2958
+#: src/muuli_wdr.cpp:2930
 msgid "Filter messages containing (use ',' as separator):"
 msgstr "Filtruj wiadomości zawierające (jako separatora użyj ','):"
 
-#: src/muuli_wdr.cpp:2961 src/muuli_wdr.cpp:2972
+#: src/muuli_wdr.cpp:2933 src/muuli_wdr.cpp:2944
 msgid "add here the words amule should filter and block messages including it"
 msgstr "dodaj frazy które według których amule powinien filtrować i blokować wiadomości"
 
-#: src/muuli_wdr.cpp:2963
+#: src/muuli_wdr.cpp:2935
 msgid "Show received messages in the log"
 msgstr "Pokaż otrzymane wiadomości w dzienniku"
 
-#: src/muuli_wdr.cpp:2966
+#: src/muuli_wdr.cpp:2938
 msgid "Comments"
 msgstr "Komentarze"
 
-#: src/muuli_wdr.cpp:2969
+#: src/muuli_wdr.cpp:2941
 msgid "Filter comments containing (use ',' as separator):"
 msgstr "Filtruj komentarze zawierające (użyj ',' jako separatora):"
 
-#: src/muuli_wdr.cpp:2994
+#: src/muuli_wdr.cpp:2966
 msgid "Enable Proxy"
 msgstr "Włącz proxy"
 
-#: src/muuli_wdr.cpp:2995
+#: src/muuli_wdr.cpp:2967
 msgid "Enable/disable proxy support"
 msgstr "Włącza/Wyłącza obsługę proxy"
 
-#: src/muuli_wdr.cpp:2998
+#: src/muuli_wdr.cpp:2970
 msgid "Proxy type:"
 msgstr "Typ proxy:"
 
-#: src/muuli_wdr.cpp:3009
+#: src/muuli_wdr.cpp:2981
 msgid "Proxy host:"
 msgstr "Adres proxy:"
 
-#: src/muuli_wdr.cpp:3012
+#: src/muuli_wdr.cpp:2984
 msgid "The proxy host name"
 msgstr "Nazwa hosta proxy"
 
-#: src/muuli_wdr.cpp:3014
+#: src/muuli_wdr.cpp:2986
 msgid "Proxy port:"
 msgstr "Port proxy:"
 
-#: src/muuli_wdr.cpp:3017
+#: src/muuli_wdr.cpp:2989
 msgid "The proxy port"
 msgstr "Port serwera proxy"
 
-#: src/muuli_wdr.cpp:3019
+#: src/muuli_wdr.cpp:2991
 msgid "Enable authentication"
 msgstr "Włącz uwierzytelnianie"
 
-#: src/muuli_wdr.cpp:3020
+#: src/muuli_wdr.cpp:2992
 msgid "Enable/disable username/password authentication"
 msgstr "Włącza/Wyłącza uwierzytelnianie login/hasło"
 
-#: src/muuli_wdr.cpp:3023
+#: src/muuli_wdr.cpp:2995
 msgid "Username: "
 msgstr "Nazwa uzytkownika: "
 
-#: src/muuli_wdr.cpp:3026
+#: src/muuli_wdr.cpp:2998
 msgid "The username to use to connect to the proxy"
 msgstr "Login używany do połączeń z proxy"
 
-#: src/muuli_wdr.cpp:3028
+#: src/muuli_wdr.cpp:3000
 msgid "Password:"
 msgstr "Hasło:"
 
-#: src/muuli_wdr.cpp:3031
+#: src/muuli_wdr.cpp:3003
 msgid "The password to use to connect to the proxy"
 msgstr "Hasło używane do połączeń z proxy"
 
-#: src/muuli_wdr.cpp:3050
+#: src/muuli_wdr.cpp:3022
 msgid "Connect to:"
 msgstr "Połącz z:"
 
-#: src/muuli_wdr.cpp:3059
+#: src/muuli_wdr.cpp:3031
 msgid "Login to remote amule"
 msgstr "Login do zdalnego amule"
 
-#: src/muuli_wdr.cpp:3064
+#: src/muuli_wdr.cpp:3036
 msgid "User name"
 msgstr "Nazwa użytkownika"
 
-#: src/muuli_wdr.cpp:3075
+#: src/muuli_wdr.cpp:3047
 msgid "Remember those settings"
 msgstr "Zapamiętaj te ustawienia"
 
-#: src/muuli_wdr.cpp:3078
+#: src/muuli_wdr.cpp:3050
 #, fuzzy
 msgid "Force ZLIB compression"
 msgstr "Używaj kompresji gzip"
 
-#: src/muuli_wdr.cpp:3102
+#: src/muuli_wdr.cpp:3074
 msgid "Enable Verbose Debug-Logging."
 msgstr "Włącz gadatliwe logowanie debugowe."
 
-#: src/muuli_wdr.cpp:3104
+#: src/muuli_wdr.cpp:3076
 #, fuzzy
 msgid "Only to Logfile"
 msgstr "&Otwórz plik"
 
-#: src/muuli_wdr.cpp:3106
+#: src/muuli_wdr.cpp:3078
 msgid "Message Categories:"
 msgstr "Kategorie wiadomości:"
 
-#: src/muuli_wdr.cpp:3130 src/PartFileConvertDlg.cpp:160
+#: src/muuli_wdr.cpp:3102 src/PartFileConvertDlg.cpp:160
 msgid "Waiting..."
 msgstr "Czekam..."
 
-#: src/muuli_wdr.cpp:3150
+#: src/muuli_wdr.cpp:3122
 msgid "Add imports"
 msgstr "Dodaj importy"
 
-#: src/muuli_wdr.cpp:3153
+#: src/muuli_wdr.cpp:3125
 msgid "Retry selected"
 msgstr "Przywróć wybrane"
 
-#: src/muuli_wdr.cpp:3155
+#: src/muuli_wdr.cpp:3127
 msgid "Remove selected"
 msgstr "Usuń wybrane"
 
-#: src/muuli_wdr.cpp:3218
+#: src/muuli_wdr.cpp:3190
 msgid "Event Types"
 msgstr "Typy zdarzeń"
 
-#: src/muuli_wdr.cpp:3237
+#: src/muuli_wdr.cpp:3209
 msgid "Statistics and queued clients for selected file(s) : Session / All time"
 msgstr "Statystyki i klienty w kolejce dla wybranego plik(u-ów) : Sesja / Cały czas"
 
-#: src/muuli_wdr.cpp:3261
+#: src/muuli_wdr.cpp:3233
 msgid "Active Uploads"
 msgstr "Aktywne wysyłania"
 
-#: src/muuli_wdr.cpp:3275
+#: src/muuli_wdr.cpp:3247
 #, fuzzy
 msgid "Percent of total files"
 msgstr "procent wszystkich plików"
 
-#: src/muuli_wdr.cpp:3327
+#: src/muuli_wdr.cpp:3299
 #, fuzzy
 msgid "Show Clients for"
 msgstr "Pokaż klientów"
 
-#: src/muuli_wdr.cpp:3329
+#: src/muuli_wdr.cpp:3301
 #, fuzzy
 msgid "All files"
 msgstr "Wszystkie udostępnione pliki"
 
-#: src/muuli_wdr.cpp:3332
+#: src/muuli_wdr.cpp:3304
 #, fuzzy
 msgid "Selected files"
 msgstr "Wybierz filtr przeglądania"
 
-#: src/muuli_wdr.cpp:3335
+#: src/muuli_wdr.cpp:3307
 #, fuzzy
 msgid "Active uploads only"
 msgstr "Aktywne wysyłania"
 
-#: src/muuli_wdr.cpp:3342
+#: src/muuli_wdr.cpp:3314
 msgid "Reload:"
 msgstr "Przeładuj:"
 
-#: src/muuli_wdr.cpp:3346
+#: src/muuli_wdr.cpp:3318
 msgid "Reload your shared files"
 msgstr "Przeładuj twoje udostępnione pliki"
 
-#: src/muuli_wdr.cpp:3409
+#: src/muuli_wdr.cpp:3381
 msgid "Send"
 msgstr "Wyślij"
 
-#: src/muuli_wdr.cpp:3410
+#: src/muuli_wdr.cpp:3382
 msgid "Sends the specified message."
 msgstr "Wysyła wybraną wiadomość."
 
-#: src/muuli_wdr.cpp:3414
+#: src/muuli_wdr.cpp:3386
 msgid "Close this chat-session."
 msgstr "Zamknij tę sesję czata."
 
-#: src/muuli_wdr.cpp:3437
+#: src/muuli_wdr.cpp:3409
 msgid "Connect to any server and/or Kad"
 msgstr "Podłącz do dowolnego serwera i/lub Kad"
 
-#: src/muuli_wdr.cpp:3443 src/SharedFilesCtrl.cpp:142 src/Statistics.cpp:941
+#: src/muuli_wdr.cpp:3415 src/SharedFilesCtrl.cpp:142 src/Statistics.cpp:941
 msgid "Shared Files"
 msgstr "Udostępnione pliki"
 
@@ -5491,250 +5457,250 @@ msgstr "Pobrano"
 msgid "ERROR: Failed to open partfile '%s'"
 msgstr "BŁĄD: Nie udało się otworzyć pliku części '%s'"
 
-#: src/Preferences.cpp:701
+#: src/Preferences.cpp:673
 msgid "System default"
 msgstr "Domyślny systemowy"
 
-#: src/Preferences.cpp:702
+#: src/Preferences.cpp:674
 msgid "Albanian"
 msgstr "Albański"
 
-#: src/Preferences.cpp:703
+#: src/Preferences.cpp:675
 msgid "Arabic"
 msgstr "Arabski"
 
-#: src/Preferences.cpp:704
+#: src/Preferences.cpp:676
 msgid "Asturian"
 msgstr "Asturyjski"
 
-#: src/Preferences.cpp:705
+#: src/Preferences.cpp:677
 msgid "Basque"
 msgstr "Baskijski"
 
-#: src/Preferences.cpp:706
+#: src/Preferences.cpp:678
 msgid "Bulgarian"
 msgstr "Bułgarski"
 
-#: src/Preferences.cpp:707
+#: src/Preferences.cpp:679
 msgid "Catalan"
 msgstr "Kataloński"
 
-#: src/Preferences.cpp:708
+#: src/Preferences.cpp:680
 msgid "Chinese (Simplified)"
 msgstr "Chiński (Uproszczony)"
 
-#: src/Preferences.cpp:709
+#: src/Preferences.cpp:681
 msgid "Chinese (Traditional)"
 msgstr "Chiński (Tradycyjny)"
 
-#: src/Preferences.cpp:710
+#: src/Preferences.cpp:682
 msgid "Croatian"
 msgstr "Chorwacki"
 
-#: src/Preferences.cpp:711
+#: src/Preferences.cpp:683
 msgid "Czech"
 msgstr "Czeski"
 
-#: src/Preferences.cpp:712
+#: src/Preferences.cpp:684
 msgid "Danish"
 msgstr "Duński"
 
-#: src/Preferences.cpp:713
+#: src/Preferences.cpp:685
 msgid "Dutch"
 msgstr "Holenderski"
 
-#: src/Preferences.cpp:714
+#: src/Preferences.cpp:686
 msgid "English (U.K.)"
 msgstr "Angielski (U.K.)"
 
-#: src/Preferences.cpp:715
+#: src/Preferences.cpp:687
 #, fuzzy
 msgid "English (U.S.)"
 msgstr "Angielski (U.K.)"
 
-#: src/Preferences.cpp:716
+#: src/Preferences.cpp:688
 msgid "Estonian"
 msgstr "Estoński"
 
-#: src/Preferences.cpp:717
+#: src/Preferences.cpp:689
 msgid "Finnish"
 msgstr "Fiński"
 
-#: src/Preferences.cpp:718
+#: src/Preferences.cpp:690
 msgid "French"
 msgstr "Francuski"
 
-#: src/Preferences.cpp:719
+#: src/Preferences.cpp:691
 msgid "Galician"
 msgstr "Galicyjski"
 
-#: src/Preferences.cpp:720
+#: src/Preferences.cpp:692
 msgid "German"
 msgstr "Niemiecki"
 
-#: src/Preferences.cpp:721
+#: src/Preferences.cpp:693
 msgid "Greek"
 msgstr "Grecki"
 
-#: src/Preferences.cpp:722
+#: src/Preferences.cpp:694
 msgid "Hebrew"
 msgstr "Hebrajski"
 
-#: src/Preferences.cpp:723
+#: src/Preferences.cpp:695
 msgid "Hungarian"
 msgstr "Węgierski"
 
-#: src/Preferences.cpp:724
+#: src/Preferences.cpp:696
 msgid "Italian"
 msgstr "Włoski"
 
-#: src/Preferences.cpp:725
+#: src/Preferences.cpp:697
 msgid "Japanese"
 msgstr "Japoński"
 
-#: src/Preferences.cpp:726
+#: src/Preferences.cpp:698
 msgid "Korean"
 msgstr "Koreański"
 
-#: src/Preferences.cpp:727
+#: src/Preferences.cpp:699
 msgid "Latvian"
 msgstr ""
 
-#: src/Preferences.cpp:728
+#: src/Preferences.cpp:700
 msgid "Lithuanian"
 msgstr "Litewski"
 
-#: src/Preferences.cpp:729
+#: src/Preferences.cpp:701
 msgid "Norwegian (Nynorsk)"
 msgstr "Norweski (Nynorsk)"
 
-#: src/Preferences.cpp:730
+#: src/Preferences.cpp:702
 msgid "Polish"
 msgstr "Polski"
 
-#: src/Preferences.cpp:731
+#: src/Preferences.cpp:703
 msgid "Portuguese"
 msgstr "Portugalski"
 
-#: src/Preferences.cpp:732
+#: src/Preferences.cpp:704
 msgid "Portuguese (Brazilian)"
 msgstr "Portugalski (Brazylijski)"
 
-#: src/Preferences.cpp:733
+#: src/Preferences.cpp:705
 msgid "Romanian"
 msgstr "Rumuński"
 
-#: src/Preferences.cpp:734
+#: src/Preferences.cpp:706
 msgid "Russian"
 msgstr "Rosyjski"
 
-#: src/Preferences.cpp:735
+#: src/Preferences.cpp:707
 msgid "Slovenian"
 msgstr "Słoweński"
 
-#: src/Preferences.cpp:736
+#: src/Preferences.cpp:708
 msgid "Spanish"
 msgstr "Hiszpański"
 
-#: src/Preferences.cpp:737
+#: src/Preferences.cpp:709
 msgid "Swedish"
 msgstr "Szwedzki"
 
-#: src/Preferences.cpp:738
+#: src/Preferences.cpp:710
 msgid "Turkish"
 msgstr "Turecki"
 
-#: src/Preferences.cpp:739
+#: src/Preferences.cpp:711
 msgid "Ukrainian"
 msgstr "Ukraiński"
 
-#: src/Preferences.cpp:842
+#: src/Preferences.cpp:814
 msgid "Change Language"
 msgstr "Zmień język"
 
-#: src/Preferences.cpp:906
+#: src/Preferences.cpp:878
 msgid "There are no translations installed for aMule"
 msgstr ""
 
-#: src/Preferences.cpp:907
+#: src/Preferences.cpp:879
 #, fuzzy
 msgid "No languages available"
 msgstr "Niedostępny"
 
-#: src/Preferences.cpp:1038
+#: src/Preferences.cpp:1010
 msgid "no options available"
 msgstr "nie ma dostępnych opcji"
 
-#: src/Preferences.cpp:2226
+#: src/Preferences.cpp:2179
 msgid "Invalid category found, skipping"
 msgstr "Znaleziono nieprawidłową kategorie, pomijam"
 
-#: src/Preferences.cpp:2395
+#: src/Preferences.cpp:2348
 msgid "TCP port can't be higher than 65532 due to server UDP socket being TCP+3"
 msgstr "Port TCP nie może być większy niż 65532, gdyż gniazdo UDP serwera będzie TCP+3"
 
-#: src/Preferences.cpp:2396
+#: src/Preferences.cpp:2349
 #, c-format
 msgid "Default port will be used (%d)"
 msgstr "Zostanie użyty domyślny port (%d)"
 
-#: src/PrefsUnifiedDlg.cpp:300 src/Statistics.cpp:866
+#: src/PrefsUnifiedDlg.cpp:298 src/Statistics.cpp:866
 msgid "Connection"
 msgstr "Połączenie"
 
-#: src/PrefsUnifiedDlg.cpp:301 src/SearchListCtrl.cpp:117
+#: src/PrefsUnifiedDlg.cpp:299 src/SearchListCtrl.cpp:117
 msgid "Directories"
 msgstr "Katalogi"
 
-#: src/PrefsUnifiedDlg.cpp:302 src/Statistics.cpp:917
+#: src/PrefsUnifiedDlg.cpp:300 src/Statistics.cpp:917
 msgid "Servers"
 msgstr "Serwery"
 
-#: src/PrefsUnifiedDlg.cpp:303 src/ServerListCtrl.cpp:96
+#: src/PrefsUnifiedDlg.cpp:301 src/ServerListCtrl.cpp:96
 msgid "Files"
 msgstr "Pliki"
 
-#: src/PrefsUnifiedDlg.cpp:304
+#: src/PrefsUnifiedDlg.cpp:302
 msgid "Security"
 msgstr "Bezpieczeństwo"
 
-#: src/PrefsUnifiedDlg.cpp:305
+#: src/PrefsUnifiedDlg.cpp:303
 msgid "Interface"
 msgstr "Interfejs"
 
-#: src/PrefsUnifiedDlg.cpp:312
+#: src/PrefsUnifiedDlg.cpp:310
 msgid "IP2Country"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:315
+#: src/PrefsUnifiedDlg.cpp:313
 msgid "Proxy"
 msgstr "Proxy"
 
-#: src/PrefsUnifiedDlg.cpp:316
+#: src/PrefsUnifiedDlg.cpp:314
 msgid "Filters"
 msgstr "Filtry"
 
-#: src/PrefsUnifiedDlg.cpp:317
+#: src/PrefsUnifiedDlg.cpp:315
 msgid "Remote Controls"
 msgstr "Zdalna kontrola"
 
-#: src/PrefsUnifiedDlg.cpp:318
+#: src/PrefsUnifiedDlg.cpp:316
 msgid "Online Signature"
 msgstr "Sygnatura Online"
 
-#: src/PrefsUnifiedDlg.cpp:319
+#: src/PrefsUnifiedDlg.cpp:317
 msgid "Advanced"
 msgstr "Zawansowane"
 
-#: src/PrefsUnifiedDlg.cpp:320
+#: src/PrefsUnifiedDlg.cpp:318
 msgid "Events"
 msgstr "Zdarzenia"
 
-#: src/PrefsUnifiedDlg.cpp:323
+#: src/PrefsUnifiedDlg.cpp:321
 msgid "Debugging"
 msgstr "Debugowanie"
 
-#: src/PrefsUnifiedDlg.cpp:453
+#: src/PrefsUnifiedDlg.cpp:451
 msgid ""
 "The following variables will be substituted:\n"
 "    %PARTFILE - full path to the file\n"
@@ -5744,15 +5710,15 @@ msgstr ""
 "    %PARTFILE - pełna ścieżka do pliku\n"
 "    %PARTNAME - tylko nazwa pliku"
 
-#: src/PrefsUnifiedDlg.cpp:474
+#: src/PrefsUnifiedDlg.cpp:472
 msgid "Tray icon support requires libayatana-appindicator3 at compile time."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:490
+#: src/PrefsUnifiedDlg.cpp:488
 msgid "Not available on Wayland: the protocol does not report when a window is minimized, so this option cannot intercept the system minimize button. Workaround: launch aMule with `GDK_BACKEND=x11` to use XWayland instead."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:536
+#: src/PrefsUnifiedDlg.cpp:534
 msgid ""
 "Do not change these setting unless you know\n"
 "what you are doing, otherwise you can easily\n"
@@ -5766,35 +5732,26 @@ msgstr ""
 "\n"
 "aMule będzie działał prawidłowo bez zmiany tych ustawień."
 
-#: src/PrefsUnifiedDlg.cpp:647
+#: src/PrefsUnifiedDlg.cpp:645
 #, c-format
 msgid "Failed to connect Cfg to widget with the ID %d and key %s"
 msgstr "Błąd połączenia Cfg do widżetu z identyfikatorem %d i kluczem %s"
 
-#: src/PrefsUnifiedDlg.cpp:695
+#: src/PrefsUnifiedDlg.cpp:693
 #, c-format
 msgid "Failed to transfer data from Cfg to Widget with the ID %d and key %s"
 msgstr "Błąd przesyłania danych połączenia z Cfg do widżetu z identyfikatorem %d i kluczem %s"
 
-#: src/PrefsUnifiedDlg.cpp:801
+#: src/PrefsUnifiedDlg.cpp:799
 msgid "The type of proxy you are connecting to"
 msgstr "Typ serwera proxy do którego się łączysz"
 
-#: src/PrefsUnifiedDlg.cpp:1020
+#: src/PrefsUnifiedDlg.cpp:1003
 #, c-format
 msgid "Failed to transfer data from Widget to Cfg with the ID %d and key %s"
 msgstr "Błąd przesyłania danych połączenia z widżetu do Cfg z identyfikatorem %d i kluczem %s"
 
 #: src/PrefsUnifiedDlg.cpp:1103
-#, fuzzy
-msgid "No password set."
-msgstr "Sprawdzam hasło\n"
-
-#: src/PrefsUnifiedDlg.cpp:1132
-msgid "Guest access needs a password. Type one in the guest password field, or untick Enable guest access."
-msgstr ""
-
-#: src/PrefsUnifiedDlg.cpp:1144
 msgid ""
 "aMule must be restarted to enable these changes:\n"
 "\n"
@@ -5802,45 +5759,45 @@ msgstr ""
 "aMule musi zostać zrestartowany przed wprowadzeniem tych zmian:\n"
 "\n"
 
-#: src/PrefsUnifiedDlg.cpp:1151
+#: src/PrefsUnifiedDlg.cpp:1110
 msgid "- TCP port changed.\n"
 msgstr "- Zmieniono port TCP.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1156
+#: src/PrefsUnifiedDlg.cpp:1115
 msgid "- UDP port changed.\n"
 msgstr "- Zmieniono port UDP.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1161
+#: src/PrefsUnifiedDlg.cpp:1120
 #, fuzzy
 msgid "- Network interface binding changed.\n"
 msgstr "Zewnętrzne połączenie zamknięte."
 
-#: src/PrefsUnifiedDlg.cpp:1166
+#: src/PrefsUnifiedDlg.cpp:1125
 #, fuzzy
 msgid "- External connect port changed.\n"
 msgstr "Zewnętrzne połączenie zamknięte."
 
-#: src/PrefsUnifiedDlg.cpp:1170
+#: src/PrefsUnifiedDlg.cpp:1129
 #, fuzzy
 msgid "- External connect acceptance changed.\n"
 msgstr "Nowe zewnętrzne połączenie zaakceptowane"
 
-#: src/PrefsUnifiedDlg.cpp:1174
+#: src/PrefsUnifiedDlg.cpp:1133
 #, fuzzy
 msgid "- External connect interface changed.\n"
 msgstr "Zewnętrzne połączenie zamknięte."
 
-#: src/PrefsUnifiedDlg.cpp:1178
+#: src/PrefsUnifiedDlg.cpp:1137
 #, fuzzy
 msgid "- Protocol obfuscation support changed.\n"
 msgstr "Maskowanie protokołu"
 
-#: src/PrefsUnifiedDlg.cpp:1193
+#: src/PrefsUnifiedDlg.cpp:1151
 #, fuzzy
 msgid "- amuleapi settings changed.\n"
 msgstr "- Zmieniono język.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1202
+#: src/PrefsUnifiedDlg.cpp:1160
 msgid ""
 "Your Auto-update server list is empty.\n"
 "'Auto-update server list at startup' will be disabled."
@@ -5848,7 +5805,7 @@ msgstr ""
 "Twoja lista auto-aktualizacji serwerów jest pusta.\n"
 "'Autoaktualizacja listy serwerów przy starcie' zostanie wyłączona."
 
-#: src/PrefsUnifiedDlg.cpp:1213
+#: src/PrefsUnifiedDlg.cpp:1171
 msgid ""
 "You have enabled external connections but have not specified a password.\n"
 "External connections cannot be enabled unless a valid password is specified."
@@ -5856,33 +5813,28 @@ msgstr ""
 "Połączenia zewnętrzne zostały włączone, ale nie zostało podane hasło.\n"
 "Połączenia zewnętrzne nie mogą być włączone dopóki nie zostanie podane poprawne hasło."
 
-#: src/PrefsUnifiedDlg.cpp:1246
-#, c-format
-msgid "The amuleapi password could not be saved: %s"
-msgstr ""
-
-#: src/PrefsUnifiedDlg.cpp:1276
+#: src/PrefsUnifiedDlg.cpp:1202
 msgid "- Language changed.\n"
 msgstr "- Zmieniono język.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1281
+#: src/PrefsUnifiedDlg.cpp:1207
 msgid "- Temp folder changed.\n"
 msgstr "- Zmieniono folder tymczasowy.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1286
+#: src/PrefsUnifiedDlg.cpp:1212
 msgid "- ED2K network enabled.\n"
 msgstr "- sieć ED2K włączona.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1319
+#: src/PrefsUnifiedDlg.cpp:1245
 msgid "The shared-file exclusion pattern is not a valid regular expression. The filter has been left disabled."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1321 src/PrefsUnifiedDlg.cpp:1921
+#: src/PrefsUnifiedDlg.cpp:1247 src/PrefsUnifiedDlg.cpp:1841
 #, fuzzy
 msgid "Invalid regular expression"
 msgstr "Zła wersja protokołu."
 
-#: src/PrefsUnifiedDlg.cpp:1398
+#: src/PrefsUnifiedDlg.cpp:1324
 msgid ""
 "Both eD2k and Kad network are disabled.\n"
 "You won't be able to connect until you enable at least one of them."
@@ -5890,7 +5842,7 @@ msgstr ""
 "Zarówno sieć eD2K jak i Kad zostały wyłączone.\n"
 "Nie będzie możliwe połączenie, dopóki nie włączysz przynajmniej jednej z nich."
 
-#: src/PrefsUnifiedDlg.cpp:1403
+#: src/PrefsUnifiedDlg.cpp:1329
 msgid ""
 "Kad will not start if your UDP port is disabled.\n"
 "Enable UDP port or disable Kad."
@@ -5898,7 +5850,7 @@ msgstr ""
 "Kad nie uruchomi się, jeśli twój port UDP jest wyłączony.\n"
 "Włącz port UDP lub wyłącz Kad."
 
-#: src/PrefsUnifiedDlg.cpp:1459
+#: src/PrefsUnifiedDlg.cpp:1385
 msgid ""
 "\n"
 "You MUST restart aMule now.\n"
@@ -5908,69 +5860,69 @@ msgstr ""
 "Musisz zrestartować teraz aMule.\n"
 "Jeśli nie zrestartujesz go teraz, nie narzekaj, jeśli stanie się coś złego.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1524
+#: src/PrefsUnifiedDlg.cpp:1450
 msgid "Could not register aMule for autostart at login. The autostart store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1526
+#: src/PrefsUnifiedDlg.cpp:1452
 msgid "Could not remove the autostart-at-login entry."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1527
+#: src/PrefsUnifiedDlg.cpp:1453
 #, fuzzy
 msgid "Autostart"
 msgstr "automatyczne odświeżanie rozpoczęte"
 
-#: src/PrefsUnifiedDlg.cpp:1542
+#: src/PrefsUnifiedDlg.cpp:1468
 msgid "Register file type"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1542
+#: src/PrefsUnifiedDlg.cpp:1468
 msgid "Register URL handler"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1550
+#: src/PrefsUnifiedDlg.cpp:1476
 #, c-format
 msgid "aMule only handles eD2k-compatible magnets. If you replace the current magnet handler (%s), BitTorrent magnet links will stop working - aMule cannot download BitTorrent content. Continue?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1555
+#: src/PrefsUnifiedDlg.cpp:1481
 #, c-format
 msgid "Another application currently opens .emulecollection files (%s). Replace it with aMule?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1560
+#: src/PrefsUnifiedDlg.cpp:1486
 #, c-format
 msgid "Another application is currently the default handler for these links (%s). Replace it with aMule?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1585
+#: src/PrefsUnifiedDlg.cpp:1511
 msgid "Could not register aMule for .emulecollection files. The registration store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1587
+#: src/PrefsUnifiedDlg.cpp:1513
 #, fuzzy
 msgid "Could not remove the file type registration."
 msgstr "Folder dla pobranych plików tymczasowych"
 
-#: src/PrefsUnifiedDlg.cpp:1589
+#: src/PrefsUnifiedDlg.cpp:1515
 msgid "Could not register aMule as the URL handler. The registration store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1591
+#: src/PrefsUnifiedDlg.cpp:1517
 msgid "Could not remove the URL handler registration."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1661 src/PrefsUnifiedDlg.cpp:1688
+#: src/PrefsUnifiedDlg.cpp:1587 src/PrefsUnifiedDlg.cpp:1614
 #, fuzzy
 msgid "The web server and aMule API require external connections to be enabled."
 msgstr "Ustawione hasło i włączone połączenia zewnętrzne."
 
-#: src/PrefsUnifiedDlg.cpp:1671
+#: src/PrefsUnifiedDlg.cpp:1597
 msgid "The aMule web server is deprecated. Consider running the aMule API instead."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1735
+#: src/PrefsUnifiedDlg.cpp:1655
 msgid ""
 "Your Auto-update servers list is in blank.\n"
 "Please fill in at least one URL to point to a valid server.met file.\n"
@@ -5980,24 +5932,24 @@ msgstr ""
 "Proszę wpisać co najmniej jeden URL wskazujący poprawny plik server.met.\n"
 " Kliknij na przycisku \"Lista\", aby wpisać URL."
 
-#: src/PrefsUnifiedDlg.cpp:1876
+#: src/PrefsUnifiedDlg.cpp:1796
 msgid "Temporary files"
 msgstr "Pliki tymczasowe"
 
-#: src/PrefsUnifiedDlg.cpp:1881
+#: src/PrefsUnifiedDlg.cpp:1801
 msgid "Incoming files"
 msgstr "Pliki przychodzące"
 
-#: src/PrefsUnifiedDlg.cpp:1886
+#: src/PrefsUnifiedDlg.cpp:1806
 msgid "Online Signatures"
 msgstr "Sygnatury Online"
 
-#: src/PrefsUnifiedDlg.cpp:1899
+#: src/PrefsUnifiedDlg.cpp:1819
 #, c-format
 msgid "Choose a folder for %s"
 msgstr "Wybierz folder na %s"
 
-#: src/PrefsUnifiedDlg.cpp:1923
+#: src/PrefsUnifiedDlg.cpp:1843
 #, fuzzy, c-format
 msgid "Would exclude %u of %u shared file"
 msgid_plural "Would exclude %u of %u shared files"
@@ -6005,42 +5957,42 @@ msgstr[0] "Znaleziono %i znany udostępniony plik"
 msgstr[1] "Znaleziono %i znane udostępnionych plików"
 msgstr[2] "Znaleziono %i znanych udostępnionych plików"
 
-#: src/PrefsUnifiedDlg.cpp:1940
+#: src/PrefsUnifiedDlg.cpp:1860
 msgid "Browse for videoplayer"
 msgstr "Szukaj odtwarzacza filmów"
 
-#: src/PrefsUnifiedDlg.cpp:1944
+#: src/PrefsUnifiedDlg.cpp:1864
 msgid "Select browser"
 msgstr "Wybierz przeglądarkę"
 
-#: src/PrefsUnifiedDlg.cpp:1948
+#: src/PrefsUnifiedDlg.cpp:1868
 #, fuzzy
 msgid "Select ffprobe binary"
 msgstr "Wybierz przeglądarkę"
 
-#: src/PrefsUnifiedDlg.cpp:1954
+#: src/PrefsUnifiedDlg.cpp:1874
 #, c-format
 msgid "Executable%s"
 msgstr "Program%s"
 
-#: src/PrefsUnifiedDlg.cpp:1988
+#: src/PrefsUnifiedDlg.cpp:1908
 msgid "ffprobe not found on PATH or in the standard install locations. Install ffmpeg (which ships ffprobe) or use Browse to pick a binary manually."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2000
+#: src/PrefsUnifiedDlg.cpp:1920
 msgid "Reset the settings on this page to their default values?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2001
+#: src/PrefsUnifiedDlg.cpp:1921
 #, fuzzy
 msgid "Reset to defaults"
 msgstr "Domyślny systemowy"
 
-#: src/PrefsUnifiedDlg.cpp:2028
+#: src/PrefsUnifiedDlg.cpp:1948
 msgid "Edit server list"
 msgstr "Edytuj listę serwerów"
 
-#: src/PrefsUnifiedDlg.cpp:2029
+#: src/PrefsUnifiedDlg.cpp:1949
 msgid ""
 "Add here URL's to download server.met files.\n"
 "Only one url on each line."
@@ -6048,42 +6000,42 @@ msgstr ""
 "Dodaj jeden URL w każdej linii.\n"
 "Tylko jeden URL w każdej linii."
 
-#: src/PrefsUnifiedDlg.cpp:2084
+#: src/PrefsUnifiedDlg.cpp:2004
 msgid "IP2Country update failed"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2229 src/PrefsUnifiedDlg.cpp:2260
+#: src/PrefsUnifiedDlg.cpp:2149 src/PrefsUnifiedDlg.cpp:2180
 msgid "Data by MaxMind GeoLite2"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2231 src/PrefsUnifiedDlg.cpp:2262
+#: src/PrefsUnifiedDlg.cpp:2151 src/PrefsUnifiedDlg.cpp:2182
 #, fuzzy
 msgid "Custom source"
 msgstr "Pełne źródła"
 
-#: src/PrefsUnifiedDlg.cpp:2233 src/PrefsUnifiedDlg.cpp:2264
+#: src/PrefsUnifiedDlg.cpp:2153 src/PrefsUnifiedDlg.cpp:2184
 msgid "Data by DB-IP.com"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2284
+#: src/PrefsUnifiedDlg.cpp:2204
 #, fuzzy, c-format
 msgid "Status: Loaded%s"
 msgstr "Status:"
 
-#: src/PrefsUnifiedDlg.cpp:2286
+#: src/PrefsUnifiedDlg.cpp:2206
 #, fuzzy, c-format
 msgid "Status: Loaded%s - %s"
 msgstr "Status:"
 
-#: src/PrefsUnifiedDlg.cpp:2290
+#: src/PrefsUnifiedDlg.cpp:2210
 msgid "Status: Failed to load - click 'Update now' to refresh."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2292
+#: src/PrefsUnifiedDlg.cpp:2212
 msgid "Status: Not found - click 'Update now' to download."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2350 src/PrefsUnifiedDlg.cpp:2374
+#: src/PrefsUnifiedDlg.cpp:2270 src/PrefsUnifiedDlg.cpp:2294
 #, c-format
 msgid "Update delay: %d second"
 msgid_plural "Update delay: %d seconds"
@@ -6091,7 +6043,7 @@ msgstr[0] "Opóźnienie odświeżania: %d sekunda"
 msgstr[1] "Opóźnienie odświeżania: %d sekundy"
 msgstr[2] "Opóźnienie odświeżania: %d sekund"
 
-#: src/PrefsUnifiedDlg.cpp:2358
+#: src/PrefsUnifiedDlg.cpp:2278
 #, c-format
 msgid "Time for average graph: %d minute"
 msgid_plural "Time for average graph: %d minutes"
@@ -6099,12 +6051,12 @@ msgstr[0] "Czas dla przeciętnego wykresu: %d minuta"
 msgstr[1] "Czas dla przeciętnego wykresu: %d minuty"
 msgstr[2] "Czas dla przeciętnego wykresu: %d minut"
 
-#: src/PrefsUnifiedDlg.cpp:2367
+#: src/PrefsUnifiedDlg.cpp:2287
 #, c-format
 msgid "Connections Graph Scale: %d"
 msgstr "Skala wykresu połączeń: %d"
 
-#: src/PrefsUnifiedDlg.cpp:2382
+#: src/PrefsUnifiedDlg.cpp:2302
 #, c-format
 msgid "File Buffer Size: %d byte"
 msgid_plural "File Buffer Size: %d bytes"
@@ -6112,7 +6064,7 @@ msgstr[0] "Rozmiar bufora pliku: %d bajt"
 msgstr[1] "Rozmiar bufora pliku: %d bajty"
 msgstr[2] "Rozmiar bufora pliku: %d bajtów"
 
-#: src/PrefsUnifiedDlg.cpp:2392
+#: src/PrefsUnifiedDlg.cpp:2312
 #, c-format
 msgid "Upload Queue Size: %d client"
 msgid_plural "Upload Queue Size: %d clients"
@@ -6120,7 +6072,7 @@ msgstr[0] "Rozmiar kolejki wysyłania: %d klient"
 msgstr[1] "Rozmiar kolejki wysyłania: %d klientów"
 msgstr[2] "Rozmiar kolejki wysyłania: %d klientów"
 
-#: src/PrefsUnifiedDlg.cpp:2402
+#: src/PrefsUnifiedDlg.cpp:2322
 #, c-format
 msgid "Server connection refresh interval: %d minute"
 msgid_plural "Server connection refresh interval: %d minutes"
@@ -6128,105 +6080,101 @@ msgstr[0] "Odświeżanie połączeń do serwera co: %d minutę"
 msgstr[1] "Odświeżanie połączeń do serwera co: %d minuty"
 msgstr[2] "Odświeżanie połączeń do serwera co: %d minut"
 
-#: src/PrefsUnifiedDlg.cpp:2407
+#: src/PrefsUnifiedDlg.cpp:2327
 msgid "Server connection refresh interval: Disabled"
 msgstr "Odświeżanie połączeń do serwera co: Wyłączone"
 
-#: src/PrefsUnifiedDlg.cpp:2451
+#: src/PrefsUnifiedDlg.cpp:2371
 msgid "disabled"
 msgstr "wyłączone"
 
-#: src/PrefsUnifiedDlg.cpp:2477
+#: src/PrefsUnifiedDlg.cpp:2397
 #, fuzzy, c-format
 msgid "Execute command on '%s' event"
 msgstr "Wykonaj komendę przy wydarzeniu `%s'"
 
-#: src/PrefsUnifiedDlg.cpp:2484
+#: src/PrefsUnifiedDlg.cpp:2404
 msgid "Enable command execution on core"
 msgstr "Włącz wykonanie komendy w rdzeniu"
 
-#: src/PrefsUnifiedDlg.cpp:2496
+#: src/PrefsUnifiedDlg.cpp:2416
 msgid "Core command:"
 msgstr "Komenda rdzenia:"
 
-#: src/PrefsUnifiedDlg.cpp:2512
+#: src/PrefsUnifiedDlg.cpp:2432
 msgid "Enable command execution on GUI"
 msgstr "Włącz wykonanie komendy w GUI"
 
-#: src/PrefsUnifiedDlg.cpp:2524
+#: src/PrefsUnifiedDlg.cpp:2444
 msgid "GUI command:"
 msgstr "Komenda GUI:"
 
-#: src/PrefsUnifiedDlg.cpp:2540
+#: src/PrefsUnifiedDlg.cpp:2460
 msgid "The following variables will be replaced:"
 msgstr "Następujące zmienne zostaną zastąpione:"
 
-#: src/PrefsUnifiedDlg.cpp:2708
+#: src/PrefsUnifiedDlg.cpp:2628
 msgid ""
 "The following folders look like system or sensitive locations:\n"
 "\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2713
+#: src/PrefsUnifiedDlg.cpp:2633
 msgid "Sharing them recursively will publish every file underneath on the eD2k/Kad networks. Do you really want to do this?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2716
+#: src/PrefsUnifiedDlg.cpp:2636
 #, fuzzy
 msgid "Confirm shared folders"
 msgstr "Udostępnione foldery"
 
-#: src/PrefsUnifiedDlg.cpp:2744
+#: src/PrefsUnifiedDlg.cpp:2664
 #, fuzzy
 msgid "Reloading shared files..."
 msgstr "Przeładuj twoje udostępnione pliki"
 
-#: src/PrefsUnifiedDlg.cpp:2745
+#: src/PrefsUnifiedDlg.cpp:2665
 msgid "Scanning for subdirectories..."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2746
+#: src/PrefsUnifiedDlg.cpp:2666
 #, fuzzy
 msgid "Updating shared folders"
 msgstr "Udostępnione foldery"
 
-#: src/PrefsUnifiedDlg.cpp:2773
+#: src/PrefsUnifiedDlg.cpp:2693
 #, c-format
 msgid "Scanned %u directories..."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2823
+#: src/PrefsUnifiedDlg.cpp:2743
 #, fuzzy, c-format
 msgid "Reloading shared files: %u files scanned"
 msgstr "Przeładowuje listę udostępnionych plików."
 
-#: src/PrefsUnifiedDlg.cpp:2873
+#: src/PrefsUnifiedDlg.cpp:2793
 #, fuzzy
 msgid "Shared folder"
 msgstr "Udostępnione foldery"
 
-#: src/SearchDlg.cpp:280
-msgid "Clear search history"
-msgstr ""
-
-#: src/SearchDlg.cpp:584
+#: src/SearchDlg.cpp:425
 msgid "It's impossible to search when both eD2k and Kademlia are disabled."
 msgstr ""
 
-#: src/SearchDlg.cpp:585 src/SearchListCtrl.cpp:858
+#: src/SearchDlg.cpp:426 src/SearchListCtrl.cpp:858
 #, fuzzy
 msgid "Search error"
 msgstr "Szukaj"
 
-#: src/SearchDlg.cpp:929
+#: src/SearchDlg.cpp:768
 msgid "Min size must be smaller than max size. Max size ignored."
 msgstr "Min. rozmiar musi być mniejszy od maks. Zignorowano maks. rozmiar."
 
-#: src/SearchDlg.cpp:930 src/SearchDlg.cpp:1012
+#: src/SearchDlg.cpp:769 src/SearchDlg.cpp:851
 msgid "Search warning"
 msgstr "Ostrzeżenie wyszukiwania"
 
-#: src/SearchDlg.cpp:1092 src/SearchListCtrl.cpp:735
+#: src/SearchDlg.cpp:929 src/SearchListCtrl.cpp:735
 msgid "Main"
 msgstr "Główne"
 

--- a/po/pl.po
+++ b/po/pl.po
@@ -12,7 +12,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-28 08:06+0200\n"
+"POT-Creation-Date: 2026-07-28 10:19+0200\n"
 "PO-Revision-Date: 2026-07-27 11:43+0000\n"
 "Last-Translator: Michał Trzebiatowski <hippie_1968@hotmail.com>\n"
 "Language-Team: translationproject.org/team/pl.html <translation-team-pl@lists.sourceforge.net>\n"
@@ -147,7 +147,7 @@ msgstr ""
 msgid "Not now"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:422 src/amuleDlg.cpp:600
+#: src/AppImageIntegration.cpp:422 src/amuleDlg.cpp:665
 msgid "Don't ask again"
 msgstr ""
 
@@ -220,7 +220,7 @@ msgid "Killing amuleweb instance with pid '%d' ... "
 msgstr "Zabiłam instancję amuleweb z pid `%d' ... "
 
 #: src/amule.cpp:336 src/amule.cpp:349 src/ClientRef.cpp:180
-#: src/SearchDlg.cpp:880 src/ServerListCtrl.cpp:98
+#: src/SearchDlg.cpp:1041 src/ServerListCtrl.cpp:98
 msgid "Failed"
 msgstr "Nieudane"
 
@@ -576,30 +576,68 @@ msgstr "Nie można utworzyć pliku Pid"
 msgid "ERROR: %s"
 msgstr "BŁĄD: %s"
 
-#: src/amuleDlg.cpp:236
+#: src/amuleDlg.cpp:250
 #, c-format
 msgid "This is aMule %s based on eMule."
 msgstr "To jest aMule %s oparty na eMule."
 
-#: src/amuleDlg.cpp:237
+#: src/amuleDlg.cpp:251
 #, c-format
 msgid "Running on %s"
 msgstr "Uruchomiony na %s"
 
-#: src/amuleDlg.cpp:239
+#: src/amuleDlg.cpp:253
 msgid "Visit https://github.com/amule-org/amule/releases/latest to check if a new version is available."
 msgstr "Odwiedź https://github.com/amule-org/amule/releases/latest aby sprawdzić czy jest dostępna nowa wersja."
 
-#: src/amuleDlg.cpp:268
+#: src/amuleDlg.cpp:282
 msgid "FATAL ERROR: Failed to create Timer"
 msgstr "KRYTYCZNY BŁĄD: Nie udało się utworzyć Timera"
 
-#: src/amuleDlg.cpp:592
+#: src/amuleDlg.cpp:361 src/amuleDlg.cpp:1787 src/amuleDlg.cpp:2033
+#: src/muuli_wdr.cpp:1492 src/muuli_wdr.cpp:3418
+msgid "Networks"
+msgstr "Sieci"
+
+#: src/amuleDlg.cpp:362 src/amuleDlg.cpp:1793 src/muuli_wdr.cpp:3419
+msgid "Searches"
+msgstr "Szukaj"
+
+#: src/amuleDlg.cpp:363 src/amuleDlg.cpp:1799 src/DownloadListCtrl.cpp:740
+#: src/muuli_wdr.cpp:392 src/muuli_wdr.cpp:1585 src/muuli_wdr.cpp:3420
+#: src/Statistics.cpp:829
+msgid "Downloads"
+msgstr "Pobieranie"
+
+#: src/amuleDlg.cpp:364 src/amuleDlg.cpp:1805 src/muuli_wdr.cpp:3294
+msgid "Shared files"
+msgstr "Udostępnione pliki"
+
+#: src/amuleDlg.cpp:365 src/amuleDlg.cpp:1811 src/muuli_wdr.cpp:2926
+#: src/muuli_wdr.cpp:3376 src/muuli_wdr.cpp:3423
+msgid "Messages"
+msgstr "Wiadomości"
+
+#: src/amuleDlg.cpp:366 src/amuleDlg.cpp:1817 src/muuli_wdr.cpp:3424
+#: src/PrefsUnifiedDlg.cpp:312 src/Statistics.cpp:779 src/Statistics.cpp:1235
+msgid "Statistics"
+msgstr "Statystyki"
+
+#: src/amuleDlg.cpp:368 src/amuleDlg.cpp:1824 src/muuli_wdr.cpp:3426
+#: src/PrefsUnifiedDlg.cpp:328 src/utils/wxCas/src/wxcasprefs.cpp:39
+msgid "Preferences"
+msgstr "Preferencje"
+
+#: src/amuleDlg.cpp:371
+msgid "Navigate"
+msgstr ""
+
+#: src/amuleDlg.cpp:657
 #, fuzzy
 msgid "New version available"
 msgstr "Niedostępny"
 
-#: src/amuleDlg.cpp:596
+#: src/amuleDlg.cpp:661
 #, fuzzy, c-format
 msgid ""
 "A new version of aMule (%s) is available.\n"
@@ -609,218 +647,185 @@ msgid ""
 "Would you like to open the download page?"
 msgstr "Najnowsza wersja jest zawsze dostępna na https://github.com/amule-org/amule/releases/latest"
 
-#: src/amuleDlg.cpp:678
+#: src/amuleDlg.cpp:743
 msgid "aMule dialog destroyed"
 msgstr "dialog aMule zniszczony"
 
-#: src/amuleDlg.cpp:701 src/DataToText.cpp:68 src/IPFilter.cpp:547
+#: src/amuleDlg.cpp:766 src/DataToText.cpp:68 src/IPFilter.cpp:547
 msgid "Connecting"
 msgstr "Łączenie"
 
-#: src/amuleDlg.cpp:893
+#: src/amuleDlg.cpp:958
 msgid "eD2k: Connecting"
 msgstr "eD2k: Łączenie"
 
-#: src/amuleDlg.cpp:897
+#: src/amuleDlg.cpp:962
 msgid "eD2k: Disconnected"
 msgstr "eD2k: Rozłączony"
 
-#: src/amuleDlg.cpp:903
+#: src/amuleDlg.cpp:968
 msgid "Kad: Firewalled"
 msgstr "Kad: Za firewallem"
 
-#: src/amuleDlg.cpp:907
+#: src/amuleDlg.cpp:972
 msgid "Kad: Connected"
 msgstr "Kad: Połączony"
 
-#: src/amuleDlg.cpp:912
+#: src/amuleDlg.cpp:977
 msgid "Kad: Connecting"
 msgstr "Kad: Łączenie"
 
-#: src/amuleDlg.cpp:916
+#: src/amuleDlg.cpp:981
 msgid "Kad: Off"
 msgstr "Kad: Wyłączony"
 
-#: src/amuleDlg.cpp:964 src/DownloadListCtrl.cpp:505
+#: src/amuleDlg.cpp:1029 src/DownloadListCtrl.cpp:505
 #: src/DownloadListCtrl.cpp:749 src/FriendListCtrl.cpp:180
 #: src/muuli_wdr.cpp:731 src/muuli_wdr.cpp:782 src/muuli_wdr.cpp:846
-#: src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2224 src/muuli_wdr.cpp:2309
-#: src/muuli_wdr.cpp:3057 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
+#: src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2231 src/muuli_wdr.cpp:2316
+#: src/muuli_wdr.cpp:3064 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
 #: src/ServerListCtrl.cpp:606 src/TransferWnd.cpp:378
 #: src/utils/wxCas/src/wxcasprefs.cpp:235
 msgid "Cancel"
 msgstr "Anuluj"
 
-#: src/amuleDlg.cpp:965
+#: src/amuleDlg.cpp:1030
 msgid "Stop the current connection attempts"
 msgstr "Zatrzymaj aktualne próby połączenia"
 
-#: src/amuleDlg.cpp:970 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976
-#: src/muuli_wdr.cpp:2447
+#: src/amuleDlg.cpp:1035 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976
+#: src/muuli_wdr.cpp:2454
 msgid "Disconnect"
 msgstr "Rozłącz"
 
-#: src/amuleDlg.cpp:971
+#: src/amuleDlg.cpp:1036
 msgid "Disconnect from the currently connected networks"
 msgstr "Rozłącz z aktualnie połączonymi sieciami"
 
-#: src/amuleDlg.cpp:976 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979
-#: src/muuli_wdr.cpp:2602 src/muuli_wdr.cpp:3054 src/muuli_wdr.cpp:3409
+#: src/amuleDlg.cpp:1041 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979
+#: src/muuli_wdr.cpp:2609 src/muuli_wdr.cpp:3061 src/muuli_wdr.cpp:3416
 msgid "Connect"
 msgstr "Podłącz"
 
-#: src/amuleDlg.cpp:977
+#: src/amuleDlg.cpp:1042
 msgid "Connect to the currently enabled networks"
 msgstr "Połącz z aktualnie włączonymi sieciami"
 
-#: src/amuleDlg.cpp:1089
+#: src/amuleDlg.cpp:1154
 #, fuzzy, c-format
 msgid "Up: %.1f%s (%.1f) | Down: %.1f%s (%.1f)"
 msgstr "Wysł: %.1f(%.1f) | Pobr: %.1f(%.1f)"
 
-#: src/amuleDlg.cpp:1091 src/amuleDlg.cpp:1093 src/amuleDlg.cpp:1097
-#: src/amuleDlg.cpp:1099 src/amuleDlg.cpp:1110 src/amuleDlg.cpp:1112
+#: src/amuleDlg.cpp:1156 src/amuleDlg.cpp:1158 src/amuleDlg.cpp:1162
+#: src/amuleDlg.cpp:1164 src/amuleDlg.cpp:1175 src/amuleDlg.cpp:1177
 #: src/MuleTrayIcon.cpp:796 src/MuleTrayIcon.cpp:799
 #, fuzzy
 msgid " MB/s"
 msgstr "MB/s"
 
-#: src/amuleDlg.cpp:1091 src/amuleDlg.cpp:1093 src/amuleDlg.cpp:1097
-#: src/amuleDlg.cpp:1099 src/amuleDlg.cpp:1110 src/amuleDlg.cpp:1112
+#: src/amuleDlg.cpp:1156 src/amuleDlg.cpp:1158 src/amuleDlg.cpp:1162
+#: src/amuleDlg.cpp:1164 src/amuleDlg.cpp:1175 src/amuleDlg.cpp:1177
 #: src/MuleTrayIcon.cpp:796 src/MuleTrayIcon.cpp:799
 #: src/utils/wxCas/src/wxcasframe.cpp:1041
 msgid " kB/s"
 msgstr " kB/s"
 
-#: src/amuleDlg.cpp:1096
+#: src/amuleDlg.cpp:1161
 #, fuzzy, c-format
 msgid "Up: %.1f%s | Down: %.1f%s"
 msgstr "Wysł: %.1f | Pobr: %.1f"
 
-#: src/amuleDlg.cpp:1128
+#: src/amuleDlg.cpp:1193
 #, c-format
 msgid "aMule (%s | Connected)"
 msgstr "aMule (%s | Połączony)"
 
-#: src/amuleDlg.cpp:1130
+#: src/amuleDlg.cpp:1195
 #, c-format
 msgid "aMule (%s | Disconnected)"
 msgstr "aMule (%s | Rozłączony)"
 
-#: src/amuleDlg.cpp:1183
+#: src/amuleDlg.cpp:1248
 #, c-format
 msgid "Do you really want to exit %s?"
 msgstr "Czy na pewno chcesz opuścić %s?"
 
-#: src/amuleDlg.cpp:1185
+#: src/amuleDlg.cpp:1250
 msgid "Exit confirmation"
 msgstr "Potwierdzenie wyjścia"
 
-#: src/amuleDlg.cpp:1548
+#: src/amuleDlg.cpp:1613
 msgid "Launch Command: "
 msgstr "Uruchomienie polecenia: "
 
-#: src/amuleDlg.cpp:1567 src/muuli_wdr.cpp:1971 src/Preferences.cpp:951
+#: src/amuleDlg.cpp:1632 src/muuli_wdr.cpp:1978 src/Preferences.cpp:952
 msgid "- default -"
 msgstr "- domyślnie -"
 
-#: src/amuleDlg.cpp:1595
+#: src/amuleDlg.cpp:1660
 #, c-format
 msgid "Skin directory '%s' does not exist"
 msgstr "Katalog skórek '%s' nie istnieje"
 
-#: src/amuleDlg.cpp:1598
+#: src/amuleDlg.cpp:1663
 #, c-format
 msgid "WARNING: Unable to open skin file '%s' for read"
 msgstr "OSTRZEŻENIE: Nie udało się otworzyć pliku skórki '%s' do odczytu"
 
-#: src/amuleDlg.cpp:1722 src/amuleDlg.cpp:1968 src/muuli_wdr.cpp:1485
-#: src/muuli_wdr.cpp:3411
-msgid "Networks"
-msgstr "Sieci"
-
-#: src/amuleDlg.cpp:1726 src/muuli_wdr.cpp:3411
+#: src/amuleDlg.cpp:1791 src/muuli_wdr.cpp:3418
 msgid "Networks Window"
 msgstr "Okno sieci"
 
-#: src/amuleDlg.cpp:1728 src/muuli_wdr.cpp:3412
-msgid "Searches"
-msgstr "Szukaj"
-
-#: src/amuleDlg.cpp:1732 src/muuli_wdr.cpp:3412
+#: src/amuleDlg.cpp:1797 src/muuli_wdr.cpp:3419
 msgid "Searches Window"
 msgstr "Okno wyszukiwania"
 
-#: src/amuleDlg.cpp:1734 src/DownloadListCtrl.cpp:740 src/muuli_wdr.cpp:392
-#: src/muuli_wdr.cpp:1578 src/muuli_wdr.cpp:3413 src/Statistics.cpp:829
-msgid "Downloads"
-msgstr "Pobieranie"
-
-#: src/amuleDlg.cpp:1738 src/muuli_wdr.cpp:3413
+#: src/amuleDlg.cpp:1803 src/muuli_wdr.cpp:3420
 msgid "Downloads Window"
 msgstr "Okno pobierań"
 
-#: src/amuleDlg.cpp:1740 src/muuli_wdr.cpp:3287
-msgid "Shared files"
-msgstr "Udostępnione pliki"
-
-#: src/amuleDlg.cpp:1744 src/muuli_wdr.cpp:3415
+#: src/amuleDlg.cpp:1809 src/muuli_wdr.cpp:3422
 msgid "Shared Files Window"
 msgstr "Okno udostępnionych plików"
 
-#: src/amuleDlg.cpp:1746 src/muuli_wdr.cpp:2919 src/muuli_wdr.cpp:3369
-#: src/muuli_wdr.cpp:3416
-msgid "Messages"
-msgstr "Wiadomości"
-
-#: src/amuleDlg.cpp:1750 src/muuli_wdr.cpp:3416
+#: src/amuleDlg.cpp:1815 src/muuli_wdr.cpp:3423
 msgid "Messages Window"
 msgstr "Okno wiadomości"
 
-#: src/amuleDlg.cpp:1752 src/muuli_wdr.cpp:3417 src/PrefsUnifiedDlg.cpp:312
-#: src/Statistics.cpp:779 src/Statistics.cpp:1235
-msgid "Statistics"
-msgstr "Statystyki"
-
-#: src/amuleDlg.cpp:1756 src/muuli_wdr.cpp:3417
+#: src/amuleDlg.cpp:1821 src/muuli_wdr.cpp:3424
 msgid "Statistics Graph Window"
 msgstr "Okno wykresów statystyk"
 
-#: src/amuleDlg.cpp:1759 src/muuli_wdr.cpp:3419 src/PrefsUnifiedDlg.cpp:328
-#: src/utils/wxCas/src/wxcasprefs.cpp:39
-msgid "Preferences"
-msgstr "Preferencje"
-
-#: src/amuleDlg.cpp:1763 src/muuli_wdr.cpp:3419
+#: src/amuleDlg.cpp:1828 src/muuli_wdr.cpp:3426
 msgid "Preferences Settings Window"
 msgstr "Okno preferencji"
 
-#: src/amuleDlg.cpp:1766 src/muuli_wdr.cpp:3420
+#: src/amuleDlg.cpp:1831 src/muuli_wdr.cpp:3427
 msgid "Import"
 msgstr "Import"
 
-#: src/amuleDlg.cpp:1770 src/muuli_wdr.cpp:3420
+#: src/amuleDlg.cpp:1835 src/muuli_wdr.cpp:3427
 msgid "The partfile importer tool"
 msgstr "Narzędzie importowania plików części"
 
-#: src/amuleDlg.cpp:1773 src/muuli_wdr.cpp:3421
+#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3428
 #: src/utils/aLinkCreator/src/alcframe.cpp:262
 msgid "About"
 msgstr "Informacje o"
 
-#: src/amuleDlg.cpp:1773 src/muuli_wdr.cpp:3421
+#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3428
 msgid "About/Help"
 msgstr "Informacje/Pomoc"
 
-#: src/amuleDlg.cpp:1971
+#: src/amuleDlg.cpp:2036
 msgid "eD2k network"
 msgstr "Sieć eD2k"
 
-#: src/amuleDlg.cpp:1974
+#: src/amuleDlg.cpp:2039
 msgid "Kad network"
 msgstr "Sieć Kad"
 
-#: src/amuleDlg.cpp:1974
+#: src/amuleDlg.cpp:2039
 msgid "No network"
 msgstr "Brak sieci"
 
@@ -1358,19 +1363,19 @@ msgstr "Auto [Wy]"
 msgid "Very low"
 msgstr "Bardzo niski"
 
-#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:743 src/muuli_wdr.cpp:2275
+#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:743 src/muuli_wdr.cpp:2282
 #: src/ServerListCtrl.cpp:263 src/ServerListCtrl.cpp:456
 #: src/SharedFilesCtrl.cpp:145
 msgid "Low"
 msgstr "Niski"
 
-#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:744 src/muuli_wdr.cpp:2276
+#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:744 src/muuli_wdr.cpp:2283
 #: src/ServerListCtrl.cpp:266 src/ServerListCtrl.cpp:457
 #: src/SharedFilesCtrl.cpp:146
 msgid "Normal"
 msgstr "Normalny"
 
-#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:745 src/muuli_wdr.cpp:2277
+#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:745 src/muuli_wdr.cpp:2284
 #: src/ServerListCtrl.cpp:269 src/ServerListCtrl.cpp:458
 #: src/SharedFilesCtrl.cpp:147
 msgid "High"
@@ -1462,8 +1467,8 @@ msgstr "Serwer lokalny"
 msgid "Remote Server"
 msgstr "Serwer zdalny"
 
-#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3174
-#: src/SearchDlg.cpp:111 src/TextClient.cpp:911
+#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3181
+#: src/SearchDlg.cpp:119 src/TextClient.cpp:911
 msgid "Kad"
 msgstr "Kad"
 
@@ -1534,7 +1539,7 @@ msgstr "Część"
 msgid "Size"
 msgstr "Rozmiar"
 
-#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3241
+#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3248
 msgid "Transferred"
 msgstr "Przesłano"
 
@@ -1592,7 +1597,7 @@ msgstr ""
 "Informacja zwrotna od:  %s (%s)\n"
 "\n"
 
-#: src/DownloadListCtrl.cpp:746 src/muuli_wdr.cpp:2278
+#: src/DownloadListCtrl.cpp:746 src/muuli_wdr.cpp:2285
 #: src/SharedFilesCtrl.cpp:150
 msgid "Auto"
 msgstr "Automatyczny"
@@ -1630,7 +1635,7 @@ msgid "Extended Options"
 msgstr "Zaawansowane opcje"
 
 #: src/DownloadListCtrl.cpp:770 src/DownloadListCtrl.cpp:822
-#: src/muuli_wdr.cpp:1789
+#: src/muuli_wdr.cpp:1796
 msgid "Preview"
 msgstr "Podgląd"
 
@@ -2343,19 +2348,19 @@ msgstr ""
 msgid "eD2k"
 msgstr "eD2k"
 
-#: src/FirstRunWizard.cpp:349 src/muuli_wdr.cpp:1488
+#: src/FirstRunWizard.cpp:349 src/muuli_wdr.cpp:1495
 msgid "Kademlia"
 msgstr "Kademlia"
 
-#: src/FirstRunWizard.cpp:359 src/muuli_wdr.cpp:1416
+#: src/FirstRunWizard.cpp:359 src/muuli_wdr.cpp:1423
 msgid "Standard TCP Port "
 msgstr "Standardowy port TCP "
 
-#: src/FirstRunWizard.cpp:365 src/muuli_wdr.cpp:1428
+#: src/FirstRunWizard.cpp:365 src/muuli_wdr.cpp:1435
 msgid "Extended UDP port (Kad / global search) "
 msgstr "Rozszerzony port UDP (KAD / globalne wyszukiwanie)"
 
-#: src/FirstRunWizard.cpp:377 src/muuli_wdr.cpp:1435
+#: src/FirstRunWizard.cpp:377 src/muuli_wdr.cpp:1442
 msgid "Enable UPnP for router port forwarding"
 msgstr "Włącz UPnP dla przekierowania portów routera"
 
@@ -2382,7 +2387,7 @@ msgstr ""
 msgid "Your peer lists are already in place - nothing to download."
 msgstr "Starasz się już pobierać plik %s"
 
-#: src/FirstRunWizard.cpp:434 src/muuli_wdr.cpp:1533
+#: src/FirstRunWizard.cpp:434 src/muuli_wdr.cpp:1540
 msgid "Auto-update server list at startup"
 msgstr "Autoaktualizacja listy serwerów przy starcie"
 
@@ -2428,23 +2433,23 @@ msgid ""
 "want downloads on a different (e.g. larger) disk."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:549 src/FirstRunWizard.cpp:611 src/muuli_wdr.cpp:1701
+#: src/FirstRunWizard.cpp:549 src/FirstRunWizard.cpp:611 src/muuli_wdr.cpp:1708
 msgid "Destination folder for downloads"
 msgstr "Folder docelowy dla pobrań"
 
-#: src/FirstRunWizard.cpp:553 src/FirstRunWizard.cpp:569 src/muuli_wdr.cpp:1342
-#: src/muuli_wdr.cpp:1359 src/muuli_wdr.cpp:1676 src/muuli_wdr.cpp:1707
-#: src/muuli_wdr.cpp:1719 src/muuli_wdr.cpp:2762
+#: src/FirstRunWizard.cpp:553 src/FirstRunWizard.cpp:569 src/muuli_wdr.cpp:1349
+#: src/muuli_wdr.cpp:1366 src/muuli_wdr.cpp:1683 src/muuli_wdr.cpp:1714
+#: src/muuli_wdr.cpp:1726 src/muuli_wdr.cpp:2769
 #: src/utils/aLinkCreator/src/alcframe.cpp:135
 #: src/utils/wxCas/src/wxcasprefs.cpp:52 src/utils/wxCas/src/wxcasprefs.cpp:118
 msgid "Browse"
 msgstr "Przeglądaj"
 
-#: src/FirstRunWizard.cpp:559 src/muuli_wdr.cpp:1712
+#: src/FirstRunWizard.cpp:559 src/muuli_wdr.cpp:1719
 msgid "(All files in this folder are shared with other peers)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:565 src/FirstRunWizard.cpp:624 src/muuli_wdr.cpp:1714
+#: src/FirstRunWizard.cpp:565 src/FirstRunWizard.cpp:624 src/muuli_wdr.cpp:1721
 msgid "Folder for temporary download files"
 msgstr "Folder dla pobranych plików tymczasowych"
 
@@ -2475,7 +2480,7 @@ msgstr "Nie udało się otworzyć pliku listy przyjaciół 'emfriends.met' do za
 msgid "CRITICAL - no client on StartChatSession"
 msgstr "KRYTYCZNE - brak klienta przy StartChatSession"
 
-#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2668 src/muuli_wdr.cpp:3345
+#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2675 src/muuli_wdr.cpp:3352
 msgid "Friends"
 msgstr "Znajomi"
 
@@ -2866,7 +2871,7 @@ msgstr "Ratio wymiany"
 msgid "Uploaded"
 msgstr "Wysłano"
 
-#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3225
+#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3232
 msgid "Requested"
 msgstr "Zażądano"
 
@@ -2990,7 +2995,7 @@ msgid "WARNING: "
 msgstr "OSTRZEŻENIE: "
 
 #: src/MuleNotebook.cpp:179 src/muuli_wdr.cpp:817 src/muuli_wdr.cpp:1229
-#: src/muuli_wdr.cpp:3129 src/muuli_wdr.cpp:3385
+#: src/muuli_wdr.cpp:3136 src/muuli_wdr.cpp:3392
 msgid "Close"
 msgstr "Zamknij"
 
@@ -3003,12 +3008,12 @@ msgstr "Wytnij"
 msgid "Copy"
 msgstr "Kopiuj"
 
-#: src/MuleTextCtrl.cpp:88
+#: src/MuleTextCtrl.cpp:88 src/SearchDlg.cpp:261
 msgid "Paste"
 msgstr "Wklej"
 
 #: src/MuleTextCtrl.cpp:89 src/muuli_wdr.cpp:358 src/muuli_wdr.cpp:757
-#: src/muuli_wdr.cpp:2352 src/muuli_wdr.cpp:2371 src/muuli_wdr.cpp:2393
+#: src/muuli_wdr.cpp:2359 src/muuli_wdr.cpp:2378 src/muuli_wdr.cpp:2400
 #: src/utils/aLinkCreator/src/alcframe.cpp:142
 msgid "Clear"
 msgstr "Wyczyść"
@@ -3106,8 +3111,8 @@ msgid "Exit"
 msgstr "Wyjdź"
 
 #: src/MuleTrayIcon.cpp:579 src/MuleTrayIcon.cpp:945 src/MuleTrayIcon.cpp:965
-#: src/muuli_wdr.cpp:1391 src/muuli_wdr.cpp:1399 src/muuli_wdr.cpp:1406
-#: src/muuli_wdr.cpp:1835 src/muuli_wdr.cpp:1841 src/OtherFunctions.cpp:91
+#: src/muuli_wdr.cpp:1398 src/muuli_wdr.cpp:1406 src/muuli_wdr.cpp:1413
+#: src/muuli_wdr.cpp:1842 src/muuli_wdr.cpp:1848 src/OtherFunctions.cpp:91
 #: src/StatisticsDlg.cpp:93 src/StatisticsDlg.cpp:95
 msgid "kB/s"
 msgstr "kB/s"
@@ -3278,7 +3283,7 @@ msgstr "Nazwa:"
 msgid "Type"
 msgstr "Typ"
 
-#: src/muuli_wdr.cpp:215 src/SearchDlg.cpp:110 src/SearchListCtrl.cpp:853
+#: src/muuli_wdr.cpp:215 src/SearchDlg.cpp:118 src/SearchListCtrl.cpp:853
 msgid "Local"
 msgstr "Lokalne"
 
@@ -3349,7 +3354,7 @@ msgstr "Bajtów"
 msgid "KB"
 msgstr "KB"
 
-#: src/muuli_wdr.cpp:274 src/muuli_wdr.cpp:293 src/muuli_wdr.cpp:1620
+#: src/muuli_wdr.cpp:274 src/muuli_wdr.cpp:293 src/muuli_wdr.cpp:1627
 #: src/OtherFunctions.cpp:64
 msgid "MB"
 msgstr "MB"
@@ -3366,7 +3371,7 @@ msgstr "Maks. rozmiar"
 msgid "Availability"
 msgstr "Dostępność"
 
-#: src/muuli_wdr.cpp:312 src/muuli_wdr.cpp:398 src/muuli_wdr.cpp:3290
+#: src/muuli_wdr.cpp:312 src/muuli_wdr.cpp:398 src/muuli_wdr.cpp:3297
 msgid "Filter:"
 msgstr "Filtr:"
 
@@ -3398,7 +3403,7 @@ msgstr ""
 msgid "Stop"
 msgstr "Zatrzymaj"
 
-#: src/muuli_wdr.cpp:348 src/muuli_wdr.cpp:1385 src/SearchListCtrl.cpp:732
+#: src/muuli_wdr.cpp:348 src/muuli_wdr.cpp:1392 src/SearchListCtrl.cpp:732
 msgid "Download"
 msgstr "Pobieranie"
 
@@ -3429,8 +3434,8 @@ msgstr "Źródła pliku:"
 #: src/muuli_wdr.cpp:1160 src/muuli_wdr.cpp:1167 src/muuli_wdr.cpp:1172
 #: src/muuli_wdr.cpp:1179 src/muuli_wdr.cpp:1184 src/muuli_wdr.cpp:1191
 #: src/muuli_wdr.cpp:1205 src/muuli_wdr.cpp:1212 src/muuli_wdr.cpp:1217
-#: src/muuli_wdr.cpp:1224 src/muuli_wdr.cpp:3227 src/muuli_wdr.cpp:3235
-#: src/muuli_wdr.cpp:3243
+#: src/muuli_wdr.cpp:1224 src/muuli_wdr.cpp:3234 src/muuli_wdr.cpp:3242
+#: src/muuli_wdr.cpp:3250
 msgid "N/A"
 msgstr "Brak"
 
@@ -3575,7 +3580,7 @@ msgstr ""
 msgid "Album :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:685 src/muuli_wdr.cpp:2247
+#: src/muuli_wdr.cpp:685 src/muuli_wdr.cpp:2254
 msgid "Title :"
 msgstr "Tytuł :"
 
@@ -3684,7 +3689,7 @@ msgstr "Nazwa użytkownika :"
 msgid "Userhash :"
 msgstr "Skrót użytkownika :"
 
-#: src/muuli_wdr.cpp:895 src/muuli_wdr.cpp:1741 src/muuli_wdr.cpp:2442
+#: src/muuli_wdr.cpp:895 src/muuli_wdr.cpp:1748 src/muuli_wdr.cpp:2449
 #: src/utils/aLinkCreator/src/alcframe.cpp:137
 msgid "Add"
 msgstr "Dodaj"
@@ -3693,15 +3698,15 @@ msgstr "Dodaj"
 msgid "Download-Speed"
 msgstr "Prędkość pobierania"
 
-#: src/muuli_wdr.cpp:954 src/muuli_wdr.cpp:989 src/muuli_wdr.cpp:2546
+#: src/muuli_wdr.cpp:954 src/muuli_wdr.cpp:989 src/muuli_wdr.cpp:2553
 msgid "Current"
 msgstr "Aktualna"
 
-#: src/muuli_wdr.cpp:962 src/muuli_wdr.cpp:997 src/muuli_wdr.cpp:2554
+#: src/muuli_wdr.cpp:962 src/muuli_wdr.cpp:997 src/muuli_wdr.cpp:2561
 msgid "Running average"
 msgstr "Bieżąca średnia"
 
-#: src/muuli_wdr.cpp:970 src/muuli_wdr.cpp:1005 src/muuli_wdr.cpp:2562
+#: src/muuli_wdr.cpp:970 src/muuli_wdr.cpp:1005 src/muuli_wdr.cpp:2569
 msgid "Session average"
 msgstr "Średnia sesji"
 
@@ -3713,7 +3718,7 @@ msgstr "Prędkość wysyłania"
 msgid "Connections"
 msgstr "Połączenie"
 
-#: src/muuli_wdr.cpp:1024 src/muuli_wdr.cpp:1860
+#: src/muuli_wdr.cpp:1024 src/muuli_wdr.cpp:1867
 msgid "Active downloads"
 msgstr "Aktywne pobierania"
 
@@ -3721,7 +3726,7 @@ msgstr "Aktywne pobierania"
 msgid "Active connections (1:1)"
 msgstr "Aktywnych połączeń (1:1)"
 
-#: src/muuli_wdr.cpp:1040 src/muuli_wdr.cpp:1861
+#: src/muuli_wdr.cpp:1040 src/muuli_wdr.cpp:1868
 msgid "Active uploads"
 msgstr "Aktywne wysyłania"
 
@@ -3837,8 +3842,8 @@ msgstr "To jest nazwa jaką inni użytkownicy będą widzieli łącząc się do 
 msgid "Language: "
 msgstr "Język: "
 
-#: src/muuli_wdr.cpp:1257 src/muuli_wdr.cpp:1323 src/muuli_wdr.cpp:1327
-#: src/muuli_wdr.cpp:1330
+#: src/muuli_wdr.cpp:1257 src/muuli_wdr.cpp:1330 src/muuli_wdr.cpp:1334
+#: src/muuli_wdr.cpp:1337
 msgid "The delay before showing tool-tips."
 msgstr "Opóźnienie przed pokazaniem podpowiedzi."
 
@@ -3916,938 +3921,947 @@ msgstr ""
 msgid "Enabling this will make aMule to show notifications when finished downloading."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1322
+#: src/muuli_wdr.cpp:1323
+#, fuzzy
+msgid "Remember search history"
+msgstr "Zapamiętaj te ustawienia"
+
+#: src/muuli_wdr.cpp:1324
+msgid "Keeps a dropdown list of your past search terms in the Search tab's Name field. This remembers the queries you typed, not the results they returned."
+msgstr ""
+
+#: src/muuli_wdr.cpp:1329
 msgid "Tooltip delay time: "
 msgstr "Opóźnienie tooltipów: "
 
-#: src/muuli_wdr.cpp:1329
+#: src/muuli_wdr.cpp:1336
 msgid "seconds"
 msgstr "sekund"
 
-#: src/muuli_wdr.cpp:1333
+#: src/muuli_wdr.cpp:1340
 msgid "Browser Selection"
 msgstr "Wybór przeglądarki"
 
-#: src/muuli_wdr.cpp:1339
+#: src/muuli_wdr.cpp:1346
 msgid "Enter your browser name here. Leave this field empty to use the system default browser."
 msgstr "Podaj tutaj nazwę swojej przeglądarki. Pozostaw to pole puste, aby korzystać z domyślnej przeglądarki systemu."
 
-#: src/muuli_wdr.cpp:1346
+#: src/muuli_wdr.cpp:1353
 msgid "Open in new tab if possible"
 msgstr "Otwórz w nowej karcie jeśli to możliwe"
 
-#: src/muuli_wdr.cpp:1348
+#: src/muuli_wdr.cpp:1355
 msgid "Open the web page in a new tab instead of in a new window when possible"
 msgstr "Otwórz stronę WWW w nowej karcie zamiast w nowym oknie jeśli to możliwe"
 
-#: src/muuli_wdr.cpp:1352
+#: src/muuli_wdr.cpp:1359
 msgid "Video Player"
 msgstr "Odtwarzacz filmów"
 
-#: src/muuli_wdr.cpp:1379
+#: src/muuli_wdr.cpp:1386
 msgid "Bandwidth limits"
 msgstr "Limity przepustowości"
 
-#: src/muuli_wdr.cpp:1393
+#: src/muuli_wdr.cpp:1400
 msgid "Upload"
 msgstr "Wysyłanie"
 
-#: src/muuli_wdr.cpp:1401
+#: src/muuli_wdr.cpp:1408
 msgid "Slot Allocation"
 msgstr "Przydział slotów"
 
-#: src/muuli_wdr.cpp:1410
+#: src/muuli_wdr.cpp:1417
 msgid "Ports"
 msgstr "Pporty"
 
-#: src/muuli_wdr.cpp:1420
+#: src/muuli_wdr.cpp:1427
 msgid "This is the standard eD2k port and cannot be disabled."
 msgstr "To jest standardowy port eD2k i nie może być wyłączony."
 
-#: src/muuli_wdr.cpp:1423
+#: src/muuli_wdr.cpp:1430
 msgid "UDP port for server requests (TCP+3):"
 msgstr "Port UDP dla żądań serwera (TCP+3):"
 
-#: src/muuli_wdr.cpp:1425
+#: src/muuli_wdr.cpp:1432
 msgid "4665"
 msgstr "4665"
 
-#: src/muuli_wdr.cpp:1432
+#: src/muuli_wdr.cpp:1439
 msgid "This UDP port is used for extended eD2k requests and Kad network"
 msgstr "Ten port UDP jest używany do rozszerzonych żądań ed2k i sieci KAD"
 
-#: src/muuli_wdr.cpp:1439
+#: src/muuli_wdr.cpp:1446
 msgid "UPnP TCP Port (Optional):"
 msgstr "Port UPnP TCP (opcjonalnie):"
 
-#: src/muuli_wdr.cpp:1449
+#: src/muuli_wdr.cpp:1456
 msgid "Bind local address to IP (empty for any):"
 msgstr "Wiąż lokalne adresy z IP (puste dla każdego):"
 
-#: src/muuli_wdr.cpp:1452
+#: src/muuli_wdr.cpp:1459
 msgid "Advanced users only: If you have multiple network interfaces, enter the address of the interface to which aMule should be bound."
 msgstr "Tylko zaawansowani użytkownicy: Jeśli masz kilka interfejsów sieciowych, wpisz adres interfejsu do którego powiązany powinien być aMule."
 
-#: src/muuli_wdr.cpp:1455 src/muuli_wdr.cpp:2054
+#: src/muuli_wdr.cpp:1462 src/muuli_wdr.cpp:2061
 #, fuzzy
 msgid "Bind to network interface (empty for any):"
 msgstr "Wiąż lokalne adresy z IP (puste dla każdego):"
 
-#: src/muuli_wdr.cpp:1468
+#: src/muuli_wdr.cpp:1475
 msgid "Advanced users only: pin all of aMule's traffic to one network interface, chosen from the list or typed in by name (e.g. tun0, eth0, en0) or index. Unlike binding to an IP, this stops traffic leaking out via the default route - useful with a VPN. Requires no elevated privileges."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1474
+#: src/muuli_wdr.cpp:1481
 msgid "Max sources per downloading file:"
 msgstr "Maks. ilość źródeł dla pobieranego pliku:"
 
-#: src/muuli_wdr.cpp:1478
+#: src/muuli_wdr.cpp:1485
 msgid "Max simultaneous connections:"
 msgstr "Maksymalne połączenia jednoczesne:"
 
-#: src/muuli_wdr.cpp:1491 src/muuli_wdr.cpp:3169
+#: src/muuli_wdr.cpp:1498 src/muuli_wdr.cpp:3176
 msgid "ED2K"
 msgstr "ED2K"
 
-#: src/muuli_wdr.cpp:1498
+#: src/muuli_wdr.cpp:1505
 msgid "Autoconnect on startup"
 msgstr "Automatycznie połącz przy uruchomieniu"
 
-#: src/muuli_wdr.cpp:1501
+#: src/muuli_wdr.cpp:1508
 msgid "Reconnect on loss"
 msgstr "Połącz ponownie po rozłączeniu"
 
-#: src/muuli_wdr.cpp:1523
+#: src/muuli_wdr.cpp:1530
 msgid "Remove dead server after"
 msgstr "Usuń martwe serwery po"
 
-#: src/muuli_wdr.cpp:1524
+#: src/muuli_wdr.cpp:1531
 msgid "Static servers are never removed, even when unreachable."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1528
+#: src/muuli_wdr.cpp:1535
 msgid "retries"
 msgstr "próbach"
 
-#: src/muuli_wdr.cpp:1536
+#: src/muuli_wdr.cpp:1543
 msgid "List"
 msgstr "Lista"
 
-#: src/muuli_wdr.cpp:1539
+#: src/muuli_wdr.cpp:1546
 msgid "Update server list when connecting to a server"
 msgstr "Uaktualnij listę serwerów przy połączeniu do serwera"
 
-#: src/muuli_wdr.cpp:1542
+#: src/muuli_wdr.cpp:1549
 msgid "Update server list when a client connects"
 msgstr "Uaktualnij listę serwerów przy połączeniu klienta"
 
-#: src/muuli_wdr.cpp:1545
+#: src/muuli_wdr.cpp:1552
 msgid "Use priority system"
 msgstr "Używaj systemu priorytetów"
 
-#: src/muuli_wdr.cpp:1549
+#: src/muuli_wdr.cpp:1556
 msgid "Use smart LowID check on connect"
 msgstr "Używaj inteligentnego sprawdzania LowID przy połączeniu"
 
-#: src/muuli_wdr.cpp:1553
+#: src/muuli_wdr.cpp:1560
 msgid "Safe connect"
 msgstr "Bezpieczne połączenie"
 
-#: src/muuli_wdr.cpp:1557
+#: src/muuli_wdr.cpp:1564
 msgid "Autoconnect to servers in static list only"
 msgstr "Automatyczne łączenie tylko do serwerów statycznych"
 
-#: src/muuli_wdr.cpp:1560
+#: src/muuli_wdr.cpp:1567
 msgid "Set manually added servers to High Priority"
 msgstr "Ustaw priorytet ręcznie dodanych serwerów na Wysoki"
 
-#: src/muuli_wdr.cpp:1581
+#: src/muuli_wdr.cpp:1588
 msgid "Add files to download in pause mode"
 msgstr "Dodaj pliki do pobrania w trybie wstrzymania"
 
-#: src/muuli_wdr.cpp:1583
+#: src/muuli_wdr.cpp:1590
 msgid "Add files to download with auto priority"
 msgstr "Dodaj pliki do pobrania z automatycznym priorytetem"
 
-#: src/muuli_wdr.cpp:1586
+#: src/muuli_wdr.cpp:1593
 msgid "Try to download first and last chunks first"
 msgstr "Próbuj najpierw pobrać pierwszy i ostatni kawałek"
 
-#: src/muuli_wdr.cpp:1590
+#: src/muuli_wdr.cpp:1597
 msgid "Endgame mode: rotate to faster sources for the final blocks"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1593
+#: src/muuli_wdr.cpp:1600
 msgid "Start next paused file when a file completes"
 msgstr "Zacznij następny wstrzymany plik, gdy plik gotowy"
 
-#: src/muuli_wdr.cpp:1596
+#: src/muuli_wdr.cpp:1603
 msgid "From the same category"
 msgstr "Z tej samej kategorii"
 
-#: src/muuli_wdr.cpp:1598
+#: src/muuli_wdr.cpp:1605
 msgid "In alphabetic order"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1600
+#: src/muuli_wdr.cpp:1607
 msgid "Preallocate disk space for new files"
 msgstr "Alokuj wstępnie przestrzeń dyskową dla nowych plików"
 
-#: src/muuli_wdr.cpp:1601
+#: src/muuli_wdr.cpp:1608
 msgid "For new files preallocates disk space for the whole file, thus reduces fragmentation"
 msgstr "Dla nowych plików alokuje wstępnie przestrzeń dyskową dla całego pliku redukując w ten sposób fragmentację"
 
-#: src/muuli_wdr.cpp:1606
+#: src/muuli_wdr.cpp:1613
 msgid "Create new files as sparse files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1607
+#: src/muuli_wdr.cpp:1614
 msgid "A sparse file reserves its full size on disk immediately without writing real data to it -- fast, but unsupported or slow on some filesystems, and free-space accounting stays optimistic while the download is in progress. Turn this off to grow the file only as data arrives."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1612
+#: src/muuli_wdr.cpp:1619
 msgid "Stop downloads when free disk space reaches "
 msgstr "Zatrzymaj pobieranie gdy zabraknie wolnego miejsca na dysku"
 
-#: src/muuli_wdr.cpp:1613
+#: src/muuli_wdr.cpp:1620
 msgid "Select this if you want aMule to check your disk space"
 msgstr "Zaznacz jeśli chcesz, aby aMule sprawdzał Twoją przestrzeń dyskową"
 
-#: src/muuli_wdr.cpp:1617
+#: src/muuli_wdr.cpp:1624
 msgid "Enter here the min disk space desired."
 msgstr "Wpisz tu minimalną ilość miejsca na dysku."
 
-#: src/muuli_wdr.cpp:1623
+#: src/muuli_wdr.cpp:1630
 msgid "Save 10 sources on rare files (< 20 sources)"
 msgstr "Zapisz 10 źródeł dla rzadkich plików (< 20 źródeł)"
 
-#: src/muuli_wdr.cpp:1627 src/Statistics.cpp:790
+#: src/muuli_wdr.cpp:1634 src/Statistics.cpp:790
 msgid "Uploads"
 msgstr "Wysyłanie"
 
-#: src/muuli_wdr.cpp:1630
+#: src/muuli_wdr.cpp:1637
 msgid "Add new shared files with auto priority"
 msgstr "Dodaj udostępnione pliki z automatycznym priorytetem"
 
-#: src/muuli_wdr.cpp:1636
+#: src/muuli_wdr.cpp:1643
 msgid "Intelligent Corruption Handling (I.C.H.)"
 msgstr "Inteligentna obsługa uszkodzeń (I.C.H.)"
 
-#: src/muuli_wdr.cpp:1639
+#: src/muuli_wdr.cpp:1646
 msgid "Enable"
 msgstr "Włączone"
 
-#: src/muuli_wdr.cpp:1642
+#: src/muuli_wdr.cpp:1649
 msgid "Advanced I.C.H. trusts every hash (not recommended)"
 msgstr "Zaawansowane I.C.H. ufa każdemu skrótu (nie zalecane)"
 
-#: src/muuli_wdr.cpp:1654 src/PrefsUnifiedDlg.cpp:1910
+#: src/muuli_wdr.cpp:1661 src/PrefsUnifiedDlg.cpp:1910
 msgid "Media metadata extraction"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1658
+#: src/muuli_wdr.cpp:1665
 msgid "Extract length / bitrate / codec from shared audio and video files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1660
+#: src/muuli_wdr.cpp:1667
 msgid "When enabled, aMule runs ffprobe on each shared media file to fill in the Length / Bitrate / Codec columns other clients see when they find the file in a search. Requires ffmpeg (the ffprobe binary) to be installed."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1667
+#: src/muuli_wdr.cpp:1674
 msgid "Path to ffprobe:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1672
+#: src/muuli_wdr.cpp:1679
 msgid "Full path to the ffprobe binary. Leave empty to have aMule auto-detect it on startup."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1680
+#: src/muuli_wdr.cpp:1687
 msgid "Detect"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1681
+#: src/muuli_wdr.cpp:1688
 msgid "Search the standard install locations for an ffprobe binary and fill the path field."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1705
+#: src/muuli_wdr.cpp:1712
 msgid ""
 "Completed downloads are stored here. All files in this folder are automatically shared with other peers.\n"
 "If this folder also holds files you don't want to share, point it at an aMule-only sub-folder."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1708
+#: src/muuli_wdr.cpp:1715
 msgid "Pick the folder where completed downloads will be stored. All files in that folder will be shared with other peers."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1722
+#: src/muuli_wdr.cpp:1729
 msgid "Shared folders"
 msgstr "Udostępnione foldery"
 
-#: src/muuli_wdr.cpp:1728
+#: src/muuli_wdr.cpp:1735
 msgid "(Folders shared by the core. Enter a path to add one.)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1736
+#: src/muuli_wdr.cpp:1743
 msgid "Absolute path of a folder on the core's machine, e.g. /home/user/shared"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1738 src/PrefsUnifiedDlg.cpp:2794
+#: src/muuli_wdr.cpp:1745 src/PrefsUnifiedDlg.cpp:2794
 msgid "Recursive"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1739
+#: src/muuli_wdr.cpp:1746
 msgid "Share every sub-folder underneath this one, including ones created later."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1743 src/utils/aLinkCreator/src/alcframe.cpp:141
+#: src/muuli_wdr.cpp:1750 src/utils/aLinkCreator/src/alcframe.cpp:141
 msgid "Remove"
 msgstr "Usuń"
 
-#: src/muuli_wdr.cpp:1747
+#: src/muuli_wdr.cpp:1754
 msgid "(Right click on folder icon for recursive share)"
 msgstr "(Kliknij prawym przyciskiem na katalog, aby udostępnić go razem z podkatalogami)"
 
-#: src/muuli_wdr.cpp:1754
+#: src/muuli_wdr.cpp:1761
 msgid "Share hidden files"
 msgstr "Udostępnij pliki ukryte"
 
-#: src/muuli_wdr.cpp:1760
+#: src/muuli_wdr.cpp:1767
 msgid "Automatically rescan shared folders for changes"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1766
+#: src/muuli_wdr.cpp:1773
 msgid "Follow symbolic links in shared folders"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1772
+#: src/muuli_wdr.cpp:1779
 msgid "Exclude files matching:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1775
+#: src/muuli_wdr.cpp:1782
 msgid "Wildcard patterns separated by '|', e.g. .DS_Store|Thumbs.db|*.tmp. Files whose name matches are not shared. Matching is case-insensitive."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1779
+#: src/muuli_wdr.cpp:1786
 msgid "Patterns are regular expressions"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1780
+#: src/muuli_wdr.cpp:1787
 msgid "When set, the whole field is one regular expression ('|' is alternation). When unset, it is a list of '|'-separated wildcards."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1790
+#: src/muuli_wdr.cpp:1797
 msgid "Show how many shared files the current pattern would exclude."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1811
+#: src/muuli_wdr.cpp:1818
 msgid "Graphs"
 msgstr "Wykresy"
 
-#: src/muuli_wdr.cpp:1814 src/muuli_wdr.cpp:1876
+#: src/muuli_wdr.cpp:1821 src/muuli_wdr.cpp:1883
 msgid "Update delay : 5 secs"
 msgstr "Odśwież co : 5 sekund"
 
-#: src/muuli_wdr.cpp:1818
+#: src/muuli_wdr.cpp:1825
 msgid "Time for average graph: 100 mins"
 msgstr "Czas dla wykresów średnich: 100 minut"
 
-#: src/muuli_wdr.cpp:1822
+#: src/muuli_wdr.cpp:1829
 msgid "Connections Graph Scale: 100 "
 msgstr "Skala wykresu połączeń: 100"
 
-#: src/muuli_wdr.cpp:1829
+#: src/muuli_wdr.cpp:1836
 msgid "Download graph scale:"
 msgstr "Skala wykresu pobierania:"
 
-#: src/muuli_wdr.cpp:1837
+#: src/muuli_wdr.cpp:1844
 msgid "Upload graph scale:"
 msgstr "Skala wykresu przesyłania:"
 
-#: src/muuli_wdr.cpp:1847
+#: src/muuli_wdr.cpp:1854
 #, fuzzy
 msgid "Colors: "
 msgstr "Kolory: "
 
-#: src/muuli_wdr.cpp:1851
+#: src/muuli_wdr.cpp:1858
 msgid "Background"
 msgstr "Tło"
 
-#: src/muuli_wdr.cpp:1852
+#: src/muuli_wdr.cpp:1859
 msgid "Grid"
 msgstr "Siatka"
 
-#: src/muuli_wdr.cpp:1853
+#: src/muuli_wdr.cpp:1860
 msgid "Download current"
 msgstr "Aktualnie pobierane"
 
-#: src/muuli_wdr.cpp:1854
+#: src/muuli_wdr.cpp:1861
 msgid "Download running average"
 msgstr "Bieżąca średnia pobierania"
 
-#: src/muuli_wdr.cpp:1855
+#: src/muuli_wdr.cpp:1862
 msgid "Download session average"
 msgstr "Średnia pobierania sesji"
 
-#: src/muuli_wdr.cpp:1856
+#: src/muuli_wdr.cpp:1863
 msgid "Upload current"
 msgstr "Aktualnie wysyłane"
 
-#: src/muuli_wdr.cpp:1857
+#: src/muuli_wdr.cpp:1864
 msgid "Upload running average"
 msgstr "Bieżąca średnia wysyłania"
 
-#: src/muuli_wdr.cpp:1858
+#: src/muuli_wdr.cpp:1865
 msgid "Upload session average"
 msgstr "Średnia wysyłania sesji"
 
-#: src/muuli_wdr.cpp:1859
+#: src/muuli_wdr.cpp:1866
 msgid "Active connections"
 msgstr "Aktywnych połączeń"
 
-#: src/muuli_wdr.cpp:1862
+#: src/muuli_wdr.cpp:1869
 #, fuzzy
 msgid "Systray Icon Speed Bar"
 msgstr "Ikona prędkości w zasobniku systemowym"
 
-#: src/muuli_wdr.cpp:1863
+#: src/muuli_wdr.cpp:1870
 msgid "Kad-nodes current"
 msgstr "Obecne Kad-węzły "
 
-#: src/muuli_wdr.cpp:1864
+#: src/muuli_wdr.cpp:1871
 msgid "Kad-nodes running"
 msgstr "Działające Kad-węzły"
 
-#: src/muuli_wdr.cpp:1865
+#: src/muuli_wdr.cpp:1872
 msgid "Kad-nodes session"
 msgstr "Sesyjne Kad-węzły"
 
-#: src/muuli_wdr.cpp:1869 src/muuli_wdr.cpp:2296
+#: src/muuli_wdr.cpp:1876 src/muuli_wdr.cpp:2303
 msgid "Select"
 msgstr "Wybierz"
 
-#: src/muuli_wdr.cpp:1873
+#: src/muuli_wdr.cpp:1880
 msgid "Tree"
 msgstr "Drzewo"
 
-#: src/muuli_wdr.cpp:1883
+#: src/muuli_wdr.cpp:1890
 msgid "Number of Client Versions shown (0=unlimited)"
 msgstr "Liczba wyświetlanych wersji klienta (0=nieograniczona)"
 
-#: src/muuli_wdr.cpp:1908
+#: src/muuli_wdr.cpp:1915
 msgid "!!! WARNING !!!"
 msgstr "!!! UWAGA !!!"
 
-#: src/muuli_wdr.cpp:1923
+#: src/muuli_wdr.cpp:1930
 msgid "Max new connections / 5 secs"
 msgstr "Maks. nowych połączeń"
 
-#: src/muuli_wdr.cpp:1925
+#: src/muuli_wdr.cpp:1932
 msgid "Concurrent Kad source lookups"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1927
+#: src/muuli_wdr.cpp:1934
 #, fuzzy
 msgid "Kad source re-search interval (minutes)"
 msgstr "Czas pomiędzy odświeżeniami FTP w minutach"
 
-#: src/muuli_wdr.cpp:1929
+#: src/muuli_wdr.cpp:1936
 #, fuzzy
 msgid "Source re-ask interval (minutes)"
 msgstr "Czas pomiędzy odświeżeniami FTP w minutach"
 
-#: src/muuli_wdr.cpp:1933
+#: src/muuli_wdr.cpp:1940
 msgid "File Buffer Size: 240000 bytes"
 msgstr "Rozmiar bufora plików: 240000 bajtów"
 
-#: src/muuli_wdr.cpp:1937
+#: src/muuli_wdr.cpp:1944
 msgid "Use MMAP: memory-mapped file access (lower memory use)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1938
+#: src/muuli_wdr.cpp:1945
 msgid "Maps part files into memory instead of buffering them on the heap, lowering the process memory footprint. May reduce download speed on some disks; best for memory-constrained or upload-heavy hosts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1940
+#: src/muuli_wdr.cpp:1947
 msgid "Upload Queue Size: 5000 clients"
 msgstr "Rozmiar kolejki wysyłania: 5000 klientów"
 
-#: src/muuli_wdr.cpp:1944
+#: src/muuli_wdr.cpp:1951
 msgid "Server connection refresh interval: Disable"
 msgstr "Odświeżanie połączeń do serwera co: Wyłączone"
 
-#: src/muuli_wdr.cpp:1948
+#: src/muuli_wdr.cpp:1955
 msgid "Disable computer's timed standby mode"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1967
+#: src/muuli_wdr.cpp:1974
 msgid "Skin to use: "
 msgstr "Skóra do użycia:"
 
-#: src/muuli_wdr.cpp:1976
+#: src/muuli_wdr.cpp:1983
 msgid "Show \"Fast eD2k Links Handler\" in every window."
 msgstr "Pokazuj \"Szybkie wyłapywanie linków eD2K\" w każdym oknie."
 
-#: src/muuli_wdr.cpp:1979
+#: src/muuli_wdr.cpp:1986
 msgid "Show extended info on categories tabs"
 msgstr "Pokaż rozszerzone info w kartach kategorii"
 
-#: src/muuli_wdr.cpp:1982
+#: src/muuli_wdr.cpp:1989
 #, fuzzy
 msgid "Show application version on title"
 msgstr "Pokaż prędkość transferu w tytule"
 
-#: src/muuli_wdr.cpp:1984
+#: src/muuli_wdr.cpp:1991
 msgid "Show transfer rates on title"
 msgstr "Pokaż prędkość transferu w tytule"
 
-#: src/muuli_wdr.cpp:1986
+#: src/muuli_wdr.cpp:1993
 msgid "Before application name"
 msgstr "Przed nazwą aplikacji"
 
-#: src/muuli_wdr.cpp:1988
+#: src/muuli_wdr.cpp:1995
 msgid "After application name"
 msgstr "Za nazwą aplikacji"
 
-#: src/muuli_wdr.cpp:1991
+#: src/muuli_wdr.cpp:1998
 msgid "Show overhead bandwidth"
 msgstr "Pokaż narzut przepustowości"
 
-#: src/muuli_wdr.cpp:1995
+#: src/muuli_wdr.cpp:2002
 msgid "Vertical toolbar orientation"
 msgstr "Pionowa orientacja paska narzędzi"
 
-#: src/muuli_wdr.cpp:1997
+#: src/muuli_wdr.cpp:2004
 msgid "Live column sorting (auto-reorder rows as their values change)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2004
+#: src/muuli_wdr.cpp:2011
 msgid "Download Queue Files"
 msgstr "Pobierane pliki w kolejce"
 
-#: src/muuli_wdr.cpp:2007
+#: src/muuli_wdr.cpp:2014
 msgid "Show progress percentage"
 msgstr "Pokaż procent postępu"
 
-#: src/muuli_wdr.cpp:2013
+#: src/muuli_wdr.cpp:2020
 msgid "Show progress bar"
 msgstr "Pokaż pasek postępu"
 
-#: src/muuli_wdr.cpp:2016
+#: src/muuli_wdr.cpp:2023
 msgid "Flat"
 msgstr "Płaski"
 
-#: src/muuli_wdr.cpp:2020
+#: src/muuli_wdr.cpp:2027
 msgid "Round"
 msgstr "Okrągły"
 
-#: src/muuli_wdr.cpp:2038
+#: src/muuli_wdr.cpp:2045
 msgid "External Connection Parameters"
 msgstr "Parametry zewnętrznych połączeń"
 
-#: src/muuli_wdr.cpp:2041
+#: src/muuli_wdr.cpp:2048
 msgid "Accept external connections"
 msgstr "Akceptuj zewnętrzne połączenia"
 
-#: src/muuli_wdr.cpp:2048 src/muuli_wdr.cpp:2107
+#: src/muuli_wdr.cpp:2055 src/muuli_wdr.cpp:2114
 msgid "IP of the listening interface:"
 msgstr "IP z interfejsem słuchania:"
 
-#: src/muuli_wdr.cpp:2051
+#: src/muuli_wdr.cpp:2058
 msgid "Enter here a valid ip in the a.b.c.d format for the listening EC interface. An empty field or 0.0.0.0 will mean any interface."
 msgstr "Wprowadź tutaj w formacie a.b.c.d prawidłowy adres ip nasłuchującego interfejsu EC. Puste pole lub 0.0.0.0 oznacza dowolny interfejs."
 
-#: src/muuli_wdr.cpp:2072 src/muuli_wdr.cpp:2156
+#: src/muuli_wdr.cpp:2079 src/muuli_wdr.cpp:2163
 msgid "TCP port:"
 msgstr "Port TCP:"
 
-#: src/muuli_wdr.cpp:2078
+#: src/muuli_wdr.cpp:2085
 msgid "Enable UPnP port forwarding on the EC port"
 msgstr "Włącz forwarding portu UPnP na porcie EC"
 
-#: src/muuli_wdr.cpp:2082 src/muuli_wdr.cpp:3041
+#: src/muuli_wdr.cpp:2089 src/muuli_wdr.cpp:3048
 #: src/utils/wxCas/src/wxcasprefs.cpp:167
 msgid "Password"
 msgstr "Hasło"
 
-#: src/muuli_wdr.cpp:2088
+#: src/muuli_wdr.cpp:2095
 #, fuzzy
 msgid "aMule API server parameters"
 msgstr "Parametry serwera sieciowego"
 
-#: src/muuli_wdr.cpp:2091
+#: src/muuli_wdr.cpp:2098
 msgid "Run amuleapi (REST API) on startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2096
+#: src/muuli_wdr.cpp:2103
 #, fuzzy
 msgid "HTTP port:"
 msgstr "Port TCP:"
 
-#: src/muuli_wdr.cpp:2110
+#: src/muuli_wdr.cpp:2117
 msgid "The interface amuleapi's HTTP server listens on. 127.0.0.1 (default) accepts only local connections; use 0.0.0.0 or a specific IP to expose it to other hosts (set an admin password below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2113
+#: src/muuli_wdr.cpp:2120
 #, fuzzy
 msgid "Admin password"
 msgstr "Sprawdzam hasło\n"
 
-#: src/muuli_wdr.cpp:2118 src/muuli_wdr.cpp:2149
+#: src/muuli_wdr.cpp:2125 src/muuli_wdr.cpp:2156
 msgid "Low rights password"
 msgstr "Hasło niskich uprawnień"
 
-#: src/muuli_wdr.cpp:2126
+#: src/muuli_wdr.cpp:2133
 msgid "Web server parameters"
 msgstr "Parametry serwera sieciowego"
 
-#: src/muuli_wdr.cpp:2129
+#: src/muuli_wdr.cpp:2136
 #, fuzzy
 msgid "Run webserver on startup (deprecated)"
 msgstr "Uruchom serwera internetowego przy starcie"
 
-#: src/muuli_wdr.cpp:2135
+#: src/muuli_wdr.cpp:2142
 msgid "Web template"
 msgstr "Szablon WWW"
 
-#: src/muuli_wdr.cpp:2140
+#: src/muuli_wdr.cpp:2147
 msgid "Full rights password"
 msgstr "Hasło pełnych uprawnień"
 
-#: src/muuli_wdr.cpp:2144
+#: src/muuli_wdr.cpp:2151
 msgid "Enable Low rights User"
 msgstr "Włącz użytkowników z niskimi uprawnieniami"
 
-#: src/muuli_wdr.cpp:2163
+#: src/muuli_wdr.cpp:2170
 msgid "Enable UPnP port forwarding of the web server port"
 msgstr "Włącz przekierowanie portu UPnP na port serwera internetowego"
 
-#: src/muuli_wdr.cpp:2168
+#: src/muuli_wdr.cpp:2175
 msgid "Web server UPnP TCP port (Optional)"
 msgstr "Port web serwera UPnP TCP (opcjonalnie)"
 
-#: src/muuli_wdr.cpp:2176
+#: src/muuli_wdr.cpp:2183
 msgid "Page Refresh Time (in secs)"
 msgstr "Odświeżanie strony co:  (w sekundach)"
 
-#: src/muuli_wdr.cpp:2183
+#: src/muuli_wdr.cpp:2190
 msgid "Enable Gzip compression"
 msgstr "Włącz kompresję Gzip"
 
-#: src/muuli_wdr.cpp:2217
+#: src/muuli_wdr.cpp:2224
 #, fuzzy
 msgid "Reset page to defaults"
 msgstr "Domyślny systemowy"
 
-#: src/muuli_wdr.cpp:2218
+#: src/muuli_wdr.cpp:2225
 msgid "Reset the settings on the current page to their default values."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2220 src/muuli_wdr.cpp:2306 src/ServerWnd.cpp:274
+#: src/muuli_wdr.cpp:2227 src/muuli_wdr.cpp:2313 src/ServerWnd.cpp:274
 #: src/ServerWnd.cpp:282
 msgid "OK"
 msgstr "OK"
 
-#: src/muuli_wdr.cpp:2222
+#: src/muuli_wdr.cpp:2229
 msgid "Click here to apply any changes made to the preferences."
 msgstr "Kliknij tu aby zastosować wszystkie zmiany dokonane w preferencjach."
 
-#: src/muuli_wdr.cpp:2225
+#: src/muuli_wdr.cpp:2232
 msgid "Reset any changes made to the preferences."
 msgstr "Reset wszystkich zmian dokonanych w preferencjach."
 
-#: src/muuli_wdr.cpp:2254
+#: src/muuli_wdr.cpp:2261
 msgid "Comment :"
 msgstr "Komentarz :"
 
-#: src/muuli_wdr.cpp:2261
+#: src/muuli_wdr.cpp:2268
 msgid "Incoming Dir :"
 msgstr "Katalog przychodzących :"
 
-#: src/muuli_wdr.cpp:2270
+#: src/muuli_wdr.cpp:2277
 msgid "Change priority for new assigned files :"
 msgstr "Zmień priorytet nowo przydzielonych plików :"
 
-#: src/muuli_wdr.cpp:2274
+#: src/muuli_wdr.cpp:2281
 #, fuzzy
 msgid "Don't change"
 msgstr "Nie zmieniaj"
 
-#: src/muuli_wdr.cpp:2286
+#: src/muuli_wdr.cpp:2293
 msgid "Select color for this Category (currently selected) :"
 msgstr "Wybierz kolor dla tej kategorii (aktualnie wybrany) :"
 
-#: src/muuli_wdr.cpp:2353 src/muuli_wdr.cpp:2372 src/muuli_wdr.cpp:2394
+#: src/muuli_wdr.cpp:2360 src/muuli_wdr.cpp:2379 src/muuli_wdr.cpp:2401
 msgid "Click this button to reset the log."
 msgstr "Kliknij tu aby wyczyścić logi."
 
-#: src/muuli_wdr.cpp:2413
+#: src/muuli_wdr.cpp:2420
 msgid "Click on this button to update the servers list from URL ..."
 msgstr "Kliknij na tym przycisku aby uaktualnić listę serwerów z URL-a ..."
 
-#: src/muuli_wdr.cpp:2417
+#: src/muuli_wdr.cpp:2424
 msgid "Server list"
 msgstr "Lista serwerów"
 
-#: src/muuli_wdr.cpp:2421
+#: src/muuli_wdr.cpp:2428
 msgid "Enter the url to a server.met file here and press the button to the left to update the list of known servers."
 msgstr "Wpisz tu url do pliku server.met  i przyciśnij przycisk po lewej aby zaktualizować listę znanych serwerów."
 
-#: src/muuli_wdr.cpp:2426
+#: src/muuli_wdr.cpp:2433
 msgid "Add server manually: Name"
 msgstr "Dodaj serwer ręcznie: Nazwa"
 
-#: src/muuli_wdr.cpp:2429
+#: src/muuli_wdr.cpp:2436
 msgid "Enter the name of the new server here"
 msgstr "Wpisz tu nazwę nowego serwera"
 
-#: src/muuli_wdr.cpp:2431 src/ServerWnd.cpp:206
+#: src/muuli_wdr.cpp:2438 src/ServerWnd.cpp:206
 msgid "IP:Port"
 msgstr "IP:Port"
 
-#: src/muuli_wdr.cpp:2434
+#: src/muuli_wdr.cpp:2441
 msgid "Enter the IP of the server here, using the x.x.x.x format."
 msgstr "Wpisz tu IP serwera, używając formatu x.x.x.x ."
 
-#: src/muuli_wdr.cpp:2440
+#: src/muuli_wdr.cpp:2447
 msgid "Enter the port of the server here."
 msgstr "Wpisz tu port serwera."
 
-#: src/muuli_wdr.cpp:2443
+#: src/muuli_wdr.cpp:2450
 msgid "Add manually a server (fill fields to the left before) ..."
 msgstr "Dodaj ręcznie serwer (wypełnij pola od lewej) ..."
 
-#: src/muuli_wdr.cpp:2472
+#: src/muuli_wdr.cpp:2479
 msgid "aMule Log"
 msgstr "Logi aMule"
 
-#: src/muuli_wdr.cpp:2480
+#: src/muuli_wdr.cpp:2487
 msgid "Server Info"
 msgstr "Serwer Info"
 
-#: src/muuli_wdr.cpp:2484
+#: src/muuli_wdr.cpp:2491
 msgid "ED2K Info"
 msgstr "Info eD2K"
 
-#: src/muuli_wdr.cpp:2488
+#: src/muuli_wdr.cpp:2495
 msgid "Kad Info"
 msgstr "Info Kad"
 
-#: src/muuli_wdr.cpp:2516
+#: src/muuli_wdr.cpp:2523
 msgid "Click on this button to update the nodes list from URL ..."
 msgstr "Kliknij ten przycisk, aby uaktualnić listę węzłów z adresu URL ..."
 
-#: src/muuli_wdr.cpp:2520
+#: src/muuli_wdr.cpp:2527
 msgid "Nodes (0)"
 msgstr "Węzły (0)"
 
-#: src/muuli_wdr.cpp:2524
+#: src/muuli_wdr.cpp:2531
 msgid "Enter the url to a nodes.dat file here and press the button to the left to update the list of known nodes."
 msgstr "Wprowadź tutaj url pliku nodes.dat i naciśnij przycisk z lewej, aby zaktualizować listę znanych węzłów."
 
-#: src/muuli_wdr.cpp:2527
+#: src/muuli_wdr.cpp:2534
 msgid "Nodes stats"
 msgstr "Statystyki węzłów"
 
-#: src/muuli_wdr.cpp:2569
+#: src/muuli_wdr.cpp:2576
 msgid "Bootstrap"
 msgstr "Bootstrap"
 
-#: src/muuli_wdr.cpp:2572
+#: src/muuli_wdr.cpp:2579
 msgid "New node"
 msgstr "Nowy węzeł"
 
-#: src/muuli_wdr.cpp:2577
+#: src/muuli_wdr.cpp:2584
 msgid "IP:"
 msgstr "IP:"
 
-#: src/muuli_wdr.cpp:2597
+#: src/muuli_wdr.cpp:2604
 msgid "Port:"
 msgstr "Port:"
 
-#: src/muuli_wdr.cpp:2610
+#: src/muuli_wdr.cpp:2617
 msgid "Bootstrap from known clients"
 msgstr "Rozruch od znanych klientów"
 
-#: src/muuli_wdr.cpp:2612
+#: src/muuli_wdr.cpp:2619
 msgid "Disconnect Kad"
 msgstr "Rozłącz z Kad"
 
-#: src/muuli_wdr.cpp:2646
+#: src/muuli_wdr.cpp:2653
 msgid "Use Secure User Identification"
 msgstr "Użyj bezpiecznej identyfikacji użytkownika"
 
-#: src/muuli_wdr.cpp:2648
+#: src/muuli_wdr.cpp:2655
 msgid "It is recommended to enable this option. You will not receive credits if SUI is not enabled."
 msgstr "Zalecane jest włączenie tej opcji. Nic nie zyskasz wyłączając bezpieczną identyfikację użytkownika."
 
-#: src/muuli_wdr.cpp:2650
+#: src/muuli_wdr.cpp:2657
 msgid "Protocol Obfuscation"
 msgstr "Maskowanie protokołu"
 
-#: src/muuli_wdr.cpp:2653
+#: src/muuli_wdr.cpp:2660
 msgid "Support Protocol Obfuscation"
 msgstr "Obsługa maskowania protokołu"
 
-#: src/muuli_wdr.cpp:2655
+#: src/muuli_wdr.cpp:2662
 msgid "This option enabled Protocol Obfuscation, and makes aMule accept obfuscated connections from other clients."
 msgstr "Opcja ta włącza maskowanie protokołu i powoduje, że aMule będzie akceptował zamaskowane połączenia od innych klientów."
 
-#: src/muuli_wdr.cpp:2657
+#: src/muuli_wdr.cpp:2664
 msgid "Use obfuscation for outgoing connections"
 msgstr "Użyj maskowania dla połączeń wychodzących"
 
-#: src/muuli_wdr.cpp:2659
+#: src/muuli_wdr.cpp:2666
 msgid "This option makes aMule use Protocol Obfuscation when connecting other clients/servers."
 msgstr "Opcja ta powoduje, że aMule będzie używał maskowania protokołu podczas łączenia z innymi klientami/serwerami."
 
-#: src/muuli_wdr.cpp:2661
+#: src/muuli_wdr.cpp:2668
 msgid "Accept only obfuscated connections"
 msgstr "Akceptuj tylko zamaskowane połączenia"
 
-#: src/muuli_wdr.cpp:2662
+#: src/muuli_wdr.cpp:2669
 msgid "This option makes aMule only accept obfuscated connections. You will have less sources, but all your traffic will be obfuscated"
 msgstr "Opcja ta powoduje, że aMule akceptuje tylko zamaskowane połączenia. Uzyskasz mniej źródeł, ale cały twój ruch będzie zamaskowany"
 
-#: src/muuli_wdr.cpp:2667
+#: src/muuli_wdr.cpp:2674
 msgid "Everybody"
 msgstr "Wszyscy"
 
-#: src/muuli_wdr.cpp:2669
+#: src/muuli_wdr.cpp:2676
 msgid "No one"
 msgstr "Nikt"
 
-#: src/muuli_wdr.cpp:2671
+#: src/muuli_wdr.cpp:2678
 msgid "Who can see my shared files:"
 msgstr "Kto może widzieć moje udostępnione pliki:"
 
-#: src/muuli_wdr.cpp:2672
+#: src/muuli_wdr.cpp:2679
 msgid "Select who can request to view a list of your shared files."
 msgstr "Wybierz kto może zażądać pokazania listy twoich udostępnionych plików."
 
-#: src/muuli_wdr.cpp:2674
+#: src/muuli_wdr.cpp:2681
 msgid "IP-Filtering"
 msgstr "Filtrowanie IP"
 
-#: src/muuli_wdr.cpp:2681
+#: src/muuli_wdr.cpp:2688
 msgid "Filter clients"
 msgstr "Filtruj klientów"
 
-#: src/muuli_wdr.cpp:2683
+#: src/muuli_wdr.cpp:2690
 msgid "Enable filtering of the client IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "Włącza filtrowanie IP klientów zdefiniowanych w pliku ~/.aMule/ipfilter.dat."
 
-#: src/muuli_wdr.cpp:2685
+#: src/muuli_wdr.cpp:2692
 msgid "Filter servers"
 msgstr "Filtruj serwery"
 
-#: src/muuli_wdr.cpp:2687
+#: src/muuli_wdr.cpp:2694
 msgid "Enable filtering of the server IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "Włącza filtrowanie IP serwerów zdefiniowanych w pliku ~/.aMule/ipfilter.dat."
 
-#: src/muuli_wdr.cpp:2691
+#: src/muuli_wdr.cpp:2698
 msgid "Reload List"
 msgstr "Przeładuj listę"
 
-#: src/muuli_wdr.cpp:2692
+#: src/muuli_wdr.cpp:2699
 msgid "Reload the list of IPs to filter from the file ~/.aMule/ipfilter.dat"
 msgstr "Przeładuj listę filtrowanych IP z pliku ~/.aMule/ipfilter.dat"
 
-#: src/muuli_wdr.cpp:2698
+#: src/muuli_wdr.cpp:2705
 msgid "URL:"
 msgstr "URL:"
 
-#: src/muuli_wdr.cpp:2702 src/muuli_wdr.cpp:2895
+#: src/muuli_wdr.cpp:2709 src/muuli_wdr.cpp:2902
 msgid "Update now"
 msgstr "Uaktualnij teraz"
 
-#: src/muuli_wdr.cpp:2705
+#: src/muuli_wdr.cpp:2712
 msgid "Auto-update ipfilter at startup"
 msgstr "Uaktualniaj filtr IP przy starcie"
 
-#: src/muuli_wdr.cpp:2709
+#: src/muuli_wdr.cpp:2716
 msgid "Filtering Level:"
 msgstr "Poziom filtrowania:"
 
-#: src/muuli_wdr.cpp:2715
+#: src/muuli_wdr.cpp:2722
 msgid "Always filter LAN IPs"
 msgstr "Zawsze filtruj IP z LAN"
 
-#: src/muuli_wdr.cpp:2718
+#: src/muuli_wdr.cpp:2725
 msgid "Paranoid handling of non-matching IPs"
 msgstr "Paranoidalna obsługa niepasujących IP"
 
-#: src/muuli_wdr.cpp:2720
+#: src/muuli_wdr.cpp:2727
 msgid "Rejects a packet when its source IP differs from the IP the client claims (an anti-spoofing check). Disable only if it causes connection problems."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2722
+#: src/muuli_wdr.cpp:2729
 msgid "Use system-wide ipfilter.dat if available"
 msgstr "Użyj ogólno-systemowego ipfilter.dat jeśli dostępny"
 
-#: src/muuli_wdr.cpp:2723
+#: src/muuli_wdr.cpp:2730
 #, fuzzy
 msgid "If there's no local ipfilter.dat found, allow usage of a system-wide ipfilter file."
 msgstr "Jeśli ipfilter.dat nie istnieje lokalnie, zezwól na użycie ogólno-systemowego pliku ipfilter."
 
-#: src/muuli_wdr.cpp:2740
+#: src/muuli_wdr.cpp:2747
 msgid "Enable Online-Signature"
 msgstr "Włącz podpis online"
 
-#: src/muuli_wdr.cpp:2742
+#: src/muuli_wdr.cpp:2749
 msgid "Enables the writing of the OS file, which can be used by external apps to create signatures and the like."
 msgstr "Włącza zapisywanie pliku OS, który może być użyty przez zewnętrzne aplikacje do stworzenia sygnatury itp."
 
-#: src/muuli_wdr.cpp:2746
+#: src/muuli_wdr.cpp:2753
 msgid "Update Frequency (Secs):"
 msgstr "Częstotliwość odświeżania (sek):"
 
-#: src/muuli_wdr.cpp:2749
+#: src/muuli_wdr.cpp:2756
 msgid "Change the frequency (in seconds) of Online Signature updates."
 msgstr "Zmień częstotliwość (w sekundach) aktualizacji Sygnatury Online."
 
-#: src/muuli_wdr.cpp:2757
+#: src/muuli_wdr.cpp:2764
 msgid "Save online signature file in: "
 msgstr "Zapisz podpis internetowy w pliku: "
 
-#: src/muuli_wdr.cpp:2763
+#: src/muuli_wdr.cpp:2770
 msgid "Click here to select the directory containing the the Online Signature files."
 msgstr "Kliknij tu aby wskazać katalog zawierający pliki Sygnatur Online."
 
-#: src/muuli_wdr.cpp:2796
+#: src/muuli_wdr.cpp:2803
 msgid "Show country flags for clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2797
+#: src/muuli_wdr.cpp:2804
 msgid "Render the country flag column in the transfers, queue and search views. Requires a valid MMDB GeoIP database (see below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2802
+#: src/muuli_wdr.cpp:2809
 #, fuzzy
 msgid "Database"
 msgstr "Prędkość transmisji danych :"
 
-#: src/muuli_wdr.cpp:2818
+#: src/muuli_wdr.cpp:2825
 #, fuzzy
 msgid "Source:"
 msgstr "Źródła"
 
-#: src/muuli_wdr.cpp:2821
+#: src/muuli_wdr.cpp:2828
 msgid "DB-IP (free, no account)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2822
+#: src/muuli_wdr.cpp:2829
 msgid "MaxMind GeoLite2 (free, account required)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2823
+#: src/muuli_wdr.cpp:2830
 msgid "Custom URL"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2826
+#: src/muuli_wdr.cpp:2833
 msgid "Choose which provider supplies the GeoIP MMDB database. DB-IP is the default - no account required. MaxMind requires a free account + license key. Use Custom URL to point at any other MMDB host (e.g. a local mirror)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2843
+#: src/muuli_wdr.cpp:2850
 msgid ""
 "No configuration required.\n"
 "\n"
@@ -4855,11 +4869,11 @@ msgid ""
 "License: Creative Commons BY 4.0 - https://creativecommons.org/licenses/by/4.0/"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2856
+#: src/muuli_wdr.cpp:2863
 msgid "License key:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2862
+#: src/muuli_wdr.cpp:2869
 msgid ""
 "Sign up for a free MaxMind account, then generate a License Key:\n"
 "https://www.maxmind.com/en/geolite2/signup\n"
@@ -4869,231 +4883,231 @@ msgid ""
 "Requires attribution and account registration; refresh at least every 30 days."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2877
+#: src/muuli_wdr.cpp:2884
 #, fuzzy
 msgid "Download URL:"
 msgstr "Pobranych: "
 
-#: src/muuli_wdr.cpp:2883
+#: src/muuli_wdr.cpp:2890
 msgid ""
 "Must point to an .mmdb file or a .gz / .tar.gz containing one.\n"
 "URL may include credentials (https://user:pass@host/...).\n"
 "License and attribution terms are set by the upstream URL - you are responsible."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2896
+#: src/muuli_wdr.cpp:2903
 msgid "Download the GeoIP database from the selected source."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2898
+#: src/muuli_wdr.cpp:2905
 #, fuzzy
 msgid "Auto-update on startup"
 msgstr "Uaktualniaj filtr IP przy starcie"
 
-#: src/muuli_wdr.cpp:2899
+#: src/muuli_wdr.cpp:2906
 msgid "Re-download the GeoIP database from the selected source every time aMule starts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2922
+#: src/muuli_wdr.cpp:2929
 msgid "Filter incoming messages (except current chat):"
 msgstr "Filtruj wiadomości przychodzące (za wyjątkiem aktualnej rozmowy):"
 
-#: src/muuli_wdr.cpp:2924
+#: src/muuli_wdr.cpp:2931
 msgid "Filter all messages"
 msgstr "Filtruj wszystkie wiadomości"
 
-#: src/muuli_wdr.cpp:2926
+#: src/muuli_wdr.cpp:2933
 msgid "Filter messages from people not on your friend list"
 msgstr "Filtruj wiadomości od ludzi, którzy nie są na twojej liście znajomych"
 
-#: src/muuli_wdr.cpp:2928
+#: src/muuli_wdr.cpp:2935
 msgid "Filter messages from unknown clients"
 msgstr "Filtruj wiadomości od nieznanych klientów"
 
-#: src/muuli_wdr.cpp:2930
+#: src/muuli_wdr.cpp:2937
 msgid "Filter messages containing (use ',' as separator):"
 msgstr "Filtruj wiadomości zawierające (jako separatora użyj ','):"
 
-#: src/muuli_wdr.cpp:2933 src/muuli_wdr.cpp:2944
+#: src/muuli_wdr.cpp:2940 src/muuli_wdr.cpp:2951
 msgid "add here the words amule should filter and block messages including it"
 msgstr "dodaj frazy które według których amule powinien filtrować i blokować wiadomości"
 
-#: src/muuli_wdr.cpp:2935
+#: src/muuli_wdr.cpp:2942
 msgid "Show received messages in the log"
 msgstr "Pokaż otrzymane wiadomości w dzienniku"
 
-#: src/muuli_wdr.cpp:2938
+#: src/muuli_wdr.cpp:2945
 msgid "Comments"
 msgstr "Komentarze"
 
-#: src/muuli_wdr.cpp:2941
+#: src/muuli_wdr.cpp:2948
 msgid "Filter comments containing (use ',' as separator):"
 msgstr "Filtruj komentarze zawierające (użyj ',' jako separatora):"
 
-#: src/muuli_wdr.cpp:2966
+#: src/muuli_wdr.cpp:2973
 msgid "Enable Proxy"
 msgstr "Włącz proxy"
 
-#: src/muuli_wdr.cpp:2967
+#: src/muuli_wdr.cpp:2974
 msgid "Enable/disable proxy support"
 msgstr "Włącza/Wyłącza obsługę proxy"
 
-#: src/muuli_wdr.cpp:2970
+#: src/muuli_wdr.cpp:2977
 msgid "Proxy type:"
 msgstr "Typ proxy:"
 
-#: src/muuli_wdr.cpp:2981
+#: src/muuli_wdr.cpp:2988
 msgid "Proxy host:"
 msgstr "Adres proxy:"
 
-#: src/muuli_wdr.cpp:2984
+#: src/muuli_wdr.cpp:2991
 msgid "The proxy host name"
 msgstr "Nazwa hosta proxy"
 
-#: src/muuli_wdr.cpp:2986
+#: src/muuli_wdr.cpp:2993
 msgid "Proxy port:"
 msgstr "Port proxy:"
 
-#: src/muuli_wdr.cpp:2989
+#: src/muuli_wdr.cpp:2996
 msgid "The proxy port"
 msgstr "Port serwera proxy"
 
-#: src/muuli_wdr.cpp:2991
+#: src/muuli_wdr.cpp:2998
 msgid "Enable authentication"
 msgstr "Włącz uwierzytelnianie"
 
-#: src/muuli_wdr.cpp:2992
+#: src/muuli_wdr.cpp:2999
 msgid "Enable/disable username/password authentication"
 msgstr "Włącza/Wyłącza uwierzytelnianie login/hasło"
 
-#: src/muuli_wdr.cpp:2995
+#: src/muuli_wdr.cpp:3002
 msgid "Username: "
 msgstr "Nazwa uzytkownika: "
 
-#: src/muuli_wdr.cpp:2998
+#: src/muuli_wdr.cpp:3005
 msgid "The username to use to connect to the proxy"
 msgstr "Login używany do połączeń z proxy"
 
-#: src/muuli_wdr.cpp:3000
+#: src/muuli_wdr.cpp:3007
 msgid "Password:"
 msgstr "Hasło:"
 
-#: src/muuli_wdr.cpp:3003
+#: src/muuli_wdr.cpp:3010
 msgid "The password to use to connect to the proxy"
 msgstr "Hasło używane do połączeń z proxy"
 
-#: src/muuli_wdr.cpp:3022
+#: src/muuli_wdr.cpp:3029
 msgid "Connect to:"
 msgstr "Połącz z:"
 
-#: src/muuli_wdr.cpp:3031
+#: src/muuli_wdr.cpp:3038
 msgid "Login to remote amule"
 msgstr "Login do zdalnego amule"
 
-#: src/muuli_wdr.cpp:3036
+#: src/muuli_wdr.cpp:3043
 msgid "User name"
 msgstr "Nazwa użytkownika"
 
-#: src/muuli_wdr.cpp:3047
+#: src/muuli_wdr.cpp:3054
 msgid "Remember those settings"
 msgstr "Zapamiętaj te ustawienia"
 
-#: src/muuli_wdr.cpp:3050
+#: src/muuli_wdr.cpp:3057
 #, fuzzy
 msgid "Force ZLIB compression"
 msgstr "Używaj kompresji gzip"
 
-#: src/muuli_wdr.cpp:3074
+#: src/muuli_wdr.cpp:3081
 msgid "Enable Verbose Debug-Logging."
 msgstr "Włącz gadatliwe logowanie debugowe."
 
-#: src/muuli_wdr.cpp:3076
+#: src/muuli_wdr.cpp:3083
 #, fuzzy
 msgid "Only to Logfile"
 msgstr "&Otwórz plik"
 
-#: src/muuli_wdr.cpp:3078
+#: src/muuli_wdr.cpp:3085
 msgid "Message Categories:"
 msgstr "Kategorie wiadomości:"
 
-#: src/muuli_wdr.cpp:3102 src/PartFileConvertDlg.cpp:160
+#: src/muuli_wdr.cpp:3109 src/PartFileConvertDlg.cpp:160
 msgid "Waiting..."
 msgstr "Czekam..."
 
-#: src/muuli_wdr.cpp:3122
+#: src/muuli_wdr.cpp:3129
 msgid "Add imports"
 msgstr "Dodaj importy"
 
-#: src/muuli_wdr.cpp:3125
+#: src/muuli_wdr.cpp:3132
 msgid "Retry selected"
 msgstr "Przywróć wybrane"
 
-#: src/muuli_wdr.cpp:3127
+#: src/muuli_wdr.cpp:3134
 msgid "Remove selected"
 msgstr "Usuń wybrane"
 
-#: src/muuli_wdr.cpp:3190
+#: src/muuli_wdr.cpp:3197
 msgid "Event Types"
 msgstr "Typy zdarzeń"
 
-#: src/muuli_wdr.cpp:3209
+#: src/muuli_wdr.cpp:3216
 msgid "Statistics and queued clients for selected file(s) : Session / All time"
 msgstr "Statystyki i klienty w kolejce dla wybranego plik(u-ów) : Sesja / Cały czas"
 
-#: src/muuli_wdr.cpp:3233
+#: src/muuli_wdr.cpp:3240
 msgid "Active Uploads"
 msgstr "Aktywne wysyłania"
 
-#: src/muuli_wdr.cpp:3247
+#: src/muuli_wdr.cpp:3254
 #, fuzzy
 msgid "Percent of total files"
 msgstr "procent wszystkich plików"
 
-#: src/muuli_wdr.cpp:3299
+#: src/muuli_wdr.cpp:3306
 #, fuzzy
 msgid "Show Clients for"
 msgstr "Pokaż klientów"
 
-#: src/muuli_wdr.cpp:3301
+#: src/muuli_wdr.cpp:3308
 #, fuzzy
 msgid "All files"
 msgstr "Wszystkie udostępnione pliki"
 
-#: src/muuli_wdr.cpp:3304
+#: src/muuli_wdr.cpp:3311
 #, fuzzy
 msgid "Selected files"
 msgstr "Wybierz filtr przeglądania"
 
-#: src/muuli_wdr.cpp:3307
+#: src/muuli_wdr.cpp:3314
 #, fuzzy
 msgid "Active uploads only"
 msgstr "Aktywne wysyłania"
 
-#: src/muuli_wdr.cpp:3314
+#: src/muuli_wdr.cpp:3321
 msgid "Reload:"
 msgstr "Przeładuj:"
 
-#: src/muuli_wdr.cpp:3318
+#: src/muuli_wdr.cpp:3325
 msgid "Reload your shared files"
 msgstr "Przeładuj twoje udostępnione pliki"
 
-#: src/muuli_wdr.cpp:3381
+#: src/muuli_wdr.cpp:3388
 msgid "Send"
 msgstr "Wyślij"
 
-#: src/muuli_wdr.cpp:3382
+#: src/muuli_wdr.cpp:3389
 msgid "Sends the specified message."
 msgstr "Wysyła wybraną wiadomość."
 
-#: src/muuli_wdr.cpp:3386
+#: src/muuli_wdr.cpp:3393
 msgid "Close this chat-session."
 msgstr "Zamknij tę sesję czata."
 
-#: src/muuli_wdr.cpp:3409
+#: src/muuli_wdr.cpp:3416
 msgid "Connect to any server and/or Kad"
 msgstr "Podłącz do dowolnego serwera i/lub Kad"
 
-#: src/muuli_wdr.cpp:3415 src/SharedFilesCtrl.cpp:142 src/Statistics.cpp:941
+#: src/muuli_wdr.cpp:3422 src/SharedFilesCtrl.cpp:142 src/Statistics.cpp:941
 msgid "Shared Files"
 msgstr "Udostępnione pliki"
 
@@ -5457,189 +5471,189 @@ msgstr "Pobrano"
 msgid "ERROR: Failed to open partfile '%s'"
 msgstr "BŁĄD: Nie udało się otworzyć pliku części '%s'"
 
-#: src/Preferences.cpp:673
+#: src/Preferences.cpp:674
 msgid "System default"
 msgstr "Domyślny systemowy"
 
-#: src/Preferences.cpp:674
+#: src/Preferences.cpp:675
 msgid "Albanian"
 msgstr "Albański"
 
-#: src/Preferences.cpp:675
+#: src/Preferences.cpp:676
 msgid "Arabic"
 msgstr "Arabski"
 
-#: src/Preferences.cpp:676
+#: src/Preferences.cpp:677
 msgid "Asturian"
 msgstr "Asturyjski"
 
-#: src/Preferences.cpp:677
+#: src/Preferences.cpp:678
 msgid "Basque"
 msgstr "Baskijski"
 
-#: src/Preferences.cpp:678
+#: src/Preferences.cpp:679
 msgid "Bulgarian"
 msgstr "Bułgarski"
 
-#: src/Preferences.cpp:679
+#: src/Preferences.cpp:680
 msgid "Catalan"
 msgstr "Kataloński"
 
-#: src/Preferences.cpp:680
+#: src/Preferences.cpp:681
 msgid "Chinese (Simplified)"
 msgstr "Chiński (Uproszczony)"
 
-#: src/Preferences.cpp:681
+#: src/Preferences.cpp:682
 msgid "Chinese (Traditional)"
 msgstr "Chiński (Tradycyjny)"
 
-#: src/Preferences.cpp:682
+#: src/Preferences.cpp:683
 msgid "Croatian"
 msgstr "Chorwacki"
 
-#: src/Preferences.cpp:683
+#: src/Preferences.cpp:684
 msgid "Czech"
 msgstr "Czeski"
 
-#: src/Preferences.cpp:684
+#: src/Preferences.cpp:685
 msgid "Danish"
 msgstr "Duński"
 
-#: src/Preferences.cpp:685
+#: src/Preferences.cpp:686
 msgid "Dutch"
 msgstr "Holenderski"
 
-#: src/Preferences.cpp:686
+#: src/Preferences.cpp:687
 msgid "English (U.K.)"
 msgstr "Angielski (U.K.)"
 
-#: src/Preferences.cpp:687
+#: src/Preferences.cpp:688
 #, fuzzy
 msgid "English (U.S.)"
 msgstr "Angielski (U.K.)"
 
-#: src/Preferences.cpp:688
+#: src/Preferences.cpp:689
 msgid "Estonian"
 msgstr "Estoński"
 
-#: src/Preferences.cpp:689
+#: src/Preferences.cpp:690
 msgid "Finnish"
 msgstr "Fiński"
 
-#: src/Preferences.cpp:690
+#: src/Preferences.cpp:691
 msgid "French"
 msgstr "Francuski"
 
-#: src/Preferences.cpp:691
+#: src/Preferences.cpp:692
 msgid "Galician"
 msgstr "Galicyjski"
 
-#: src/Preferences.cpp:692
+#: src/Preferences.cpp:693
 msgid "German"
 msgstr "Niemiecki"
 
-#: src/Preferences.cpp:693
+#: src/Preferences.cpp:694
 msgid "Greek"
 msgstr "Grecki"
 
-#: src/Preferences.cpp:694
+#: src/Preferences.cpp:695
 msgid "Hebrew"
 msgstr "Hebrajski"
 
-#: src/Preferences.cpp:695
+#: src/Preferences.cpp:696
 msgid "Hungarian"
 msgstr "Węgierski"
 
-#: src/Preferences.cpp:696
+#: src/Preferences.cpp:697
 msgid "Italian"
 msgstr "Włoski"
 
-#: src/Preferences.cpp:697
+#: src/Preferences.cpp:698
 msgid "Japanese"
 msgstr "Japoński"
 
-#: src/Preferences.cpp:698
+#: src/Preferences.cpp:699
 msgid "Korean"
 msgstr "Koreański"
 
-#: src/Preferences.cpp:699
+#: src/Preferences.cpp:700
 msgid "Latvian"
 msgstr ""
 
-#: src/Preferences.cpp:700
+#: src/Preferences.cpp:701
 msgid "Lithuanian"
 msgstr "Litewski"
 
-#: src/Preferences.cpp:701
+#: src/Preferences.cpp:702
 msgid "Norwegian (Nynorsk)"
 msgstr "Norweski (Nynorsk)"
 
-#: src/Preferences.cpp:702
+#: src/Preferences.cpp:703
 msgid "Polish"
 msgstr "Polski"
 
-#: src/Preferences.cpp:703
+#: src/Preferences.cpp:704
 msgid "Portuguese"
 msgstr "Portugalski"
 
-#: src/Preferences.cpp:704
+#: src/Preferences.cpp:705
 msgid "Portuguese (Brazilian)"
 msgstr "Portugalski (Brazylijski)"
 
-#: src/Preferences.cpp:705
+#: src/Preferences.cpp:706
 msgid "Romanian"
 msgstr "Rumuński"
 
-#: src/Preferences.cpp:706
+#: src/Preferences.cpp:707
 msgid "Russian"
 msgstr "Rosyjski"
 
-#: src/Preferences.cpp:707
+#: src/Preferences.cpp:708
 msgid "Slovenian"
 msgstr "Słoweński"
 
-#: src/Preferences.cpp:708
+#: src/Preferences.cpp:709
 msgid "Spanish"
 msgstr "Hiszpański"
 
-#: src/Preferences.cpp:709
+#: src/Preferences.cpp:710
 msgid "Swedish"
 msgstr "Szwedzki"
 
-#: src/Preferences.cpp:710
+#: src/Preferences.cpp:711
 msgid "Turkish"
 msgstr "Turecki"
 
-#: src/Preferences.cpp:711
+#: src/Preferences.cpp:712
 msgid "Ukrainian"
 msgstr "Ukraiński"
 
-#: src/Preferences.cpp:814
+#: src/Preferences.cpp:815
 msgid "Change Language"
 msgstr "Zmień język"
 
-#: src/Preferences.cpp:878
+#: src/Preferences.cpp:879
 msgid "There are no translations installed for aMule"
 msgstr ""
 
-#: src/Preferences.cpp:879
+#: src/Preferences.cpp:880
 #, fuzzy
 msgid "No languages available"
 msgstr "Niedostępny"
 
-#: src/Preferences.cpp:1010
+#: src/Preferences.cpp:1011
 msgid "no options available"
 msgstr "nie ma dostępnych opcji"
 
-#: src/Preferences.cpp:2179
+#: src/Preferences.cpp:2182
 msgid "Invalid category found, skipping"
 msgstr "Znaleziono nieprawidłową kategorie, pomijam"
 
-#: src/Preferences.cpp:2348
+#: src/Preferences.cpp:2351
 msgid "TCP port can't be higher than 65532 due to server UDP socket being TCP+3"
 msgstr "Port TCP nie może być większy niż 65532, gdyż gniazdo UDP serwera będzie TCP+3"
 
-#: src/Preferences.cpp:2349
+#: src/Preferences.cpp:2352
 #, c-format
 msgid "Default port will be used (%d)"
 msgstr "Zostanie użyty domyślny port (%d)"
@@ -6157,24 +6171,28 @@ msgstr "Przeładowuje listę udostępnionych plików."
 msgid "Shared folder"
 msgstr "Udostępnione foldery"
 
-#: src/SearchDlg.cpp:425
+#: src/SearchDlg.cpp:280
+msgid "Clear search history"
+msgstr ""
+
+#: src/SearchDlg.cpp:584
 msgid "It's impossible to search when both eD2k and Kademlia are disabled."
 msgstr ""
 
-#: src/SearchDlg.cpp:426 src/SearchListCtrl.cpp:858
+#: src/SearchDlg.cpp:585 src/SearchListCtrl.cpp:858
 #, fuzzy
 msgid "Search error"
 msgstr "Szukaj"
 
-#: src/SearchDlg.cpp:768
+#: src/SearchDlg.cpp:929
 msgid "Min size must be smaller than max size. Max size ignored."
 msgstr "Min. rozmiar musi być mniejszy od maks. Zignorowano maks. rozmiar."
 
-#: src/SearchDlg.cpp:769 src/SearchDlg.cpp:851
+#: src/SearchDlg.cpp:930 src/SearchDlg.cpp:1012
 msgid "Search warning"
 msgstr "Ostrzeżenie wyszukiwania"
 
-#: src/SearchDlg.cpp:929 src/SearchListCtrl.cpp:735
+#: src/SearchDlg.cpp:1092 src/SearchListCtrl.cpp:735
 msgid "Main"
 msgstr "Główne"
 

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -15,7 +15,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-28 12:17+0200\n"
+"POT-Creation-Date: 2026-07-28 13:09+0200\n"
 "PO-Revision-Date: 2026-07-27 11:43+0000\n"
 "Last-Translator: Marcelo Jimenez <mroberto@users.sourceforge.com>\n"
 "Language-Team: Português (Brasileiro) <pt@li.org>\n"
@@ -301,7 +301,7 @@ msgid "Password set and external connections enabled."
 msgstr "Senha definida e conexões externas habilitadas."
 
 #: src/amule.cpp:755 src/KadDlg.cpp:176 src/KadDlg.cpp:185
-#: src/PrefsUnifiedDlg.cpp:1461 src/SharedFilesCtrl.cpp:476
+#: src/PrefsUnifiedDlg.cpp:1470 src/SharedFilesCtrl.cpp:476
 msgid "WARNING"
 msgstr "CUIDADO"
 
@@ -338,7 +338,7 @@ msgstr "Você pediu para rodar o servidor web na início, mas o binário do amul
 #: src/amule-remote-gui.cpp:603 src/amule-remote-gui.cpp:671
 #: src/amule-remote-gui.cpp:709 src/amule-remote-gui.cpp:1282
 #: src/amule-remote-gui.cpp:1345 src/amule-remote-gui.cpp:1372
-#: src/DownloadQueue.cpp:1481 src/PrefsUnifiedDlg.cpp:1247
+#: src/DownloadQueue.cpp:1481 src/PrefsUnifiedDlg.cpp:1256
 msgid "ERROR"
 msgstr "ERRO"
 
@@ -599,36 +599,36 @@ msgstr "Visite https://github.com/amule-org/amule/releases/latest para ver se h�
 msgid "FATAL ERROR: Failed to create Timer"
 msgstr "ERRO FATAL: Falha ao criar Timer"
 
-#: src/amuleDlg.cpp:361 src/amuleDlg.cpp:1787 src/amuleDlg.cpp:2033
-#: src/muuli_wdr.cpp:1492 src/muuli_wdr.cpp:3449
+#: src/amuleDlg.cpp:361 src/amuleDlg.cpp:1810 src/amuleDlg.cpp:2056
+#: src/muuli_wdr.cpp:1492 src/muuli_wdr.cpp:3453
 msgid "Networks"
 msgstr "Redes"
 
-#: src/amuleDlg.cpp:362 src/amuleDlg.cpp:1793 src/muuli_wdr.cpp:3450
+#: src/amuleDlg.cpp:362 src/amuleDlg.cpp:1816 src/muuli_wdr.cpp:3454
 msgid "Searches"
 msgstr "Pesquisas"
 
-#: src/amuleDlg.cpp:363 src/amuleDlg.cpp:1799 src/DownloadListCtrl.cpp:740
-#: src/muuli_wdr.cpp:392 src/muuli_wdr.cpp:1585 src/muuli_wdr.cpp:3451
+#: src/amuleDlg.cpp:363 src/amuleDlg.cpp:1822 src/DownloadListCtrl.cpp:740
+#: src/muuli_wdr.cpp:392 src/muuli_wdr.cpp:1585 src/muuli_wdr.cpp:3455
 #: src/Statistics.cpp:829
 msgid "Downloads"
 msgstr "Downloads"
 
-#: src/amuleDlg.cpp:364 src/amuleDlg.cpp:1805 src/muuli_wdr.cpp:3325
+#: src/amuleDlg.cpp:364 src/amuleDlg.cpp:1828 src/muuli_wdr.cpp:3329
 msgid "Shared files"
 msgstr "Arquivos compartilhados"
 
-#: src/amuleDlg.cpp:365 src/amuleDlg.cpp:1811 src/muuli_wdr.cpp:2957
-#: src/muuli_wdr.cpp:3407 src/muuli_wdr.cpp:3454
+#: src/amuleDlg.cpp:365 src/amuleDlg.cpp:1834 src/muuli_wdr.cpp:2961
+#: src/muuli_wdr.cpp:3411 src/muuli_wdr.cpp:3458
 msgid "Messages"
 msgstr "Mensagens"
 
-#: src/amuleDlg.cpp:366 src/amuleDlg.cpp:1817 src/muuli_wdr.cpp:3455
+#: src/amuleDlg.cpp:366 src/amuleDlg.cpp:1840 src/muuli_wdr.cpp:3459
 #: src/PrefsUnifiedDlg.cpp:314 src/Statistics.cpp:779 src/Statistics.cpp:1235
 msgid "Statistics"
 msgstr "Estatísticas"
 
-#: src/amuleDlg.cpp:368 src/amuleDlg.cpp:1824 src/muuli_wdr.cpp:3457
+#: src/amuleDlg.cpp:368 src/amuleDlg.cpp:1847 src/muuli_wdr.cpp:3461
 #: src/PrefsUnifiedDlg.cpp:330 src/utils/wxCas/src/wxcasprefs.cpp:39
 msgid "Preferences"
 msgstr "Preferências"
@@ -691,8 +691,8 @@ msgstr "Kad: Desligado"
 #: src/amuleDlg.cpp:1029 src/DownloadListCtrl.cpp:505
 #: src/DownloadListCtrl.cpp:749 src/FriendListCtrl.cpp:180
 #: src/muuli_wdr.cpp:731 src/muuli_wdr.cpp:782 src/muuli_wdr.cpp:846
-#: src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2262 src/muuli_wdr.cpp:2347
-#: src/muuli_wdr.cpp:3095 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
+#: src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2266 src/muuli_wdr.cpp:2351
+#: src/muuli_wdr.cpp:3099 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
 #: src/ServerListCtrl.cpp:606 src/TransferWnd.cpp:378
 #: src/utils/wxCas/src/wxcasprefs.cpp:235
 msgid "Cancel"
@@ -703,7 +703,7 @@ msgid "Stop the current connection attempts"
 msgstr "Cancelar as tentativas atuais de conexão"
 
 #: src/amuleDlg.cpp:1035 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976
-#: src/muuli_wdr.cpp:2485
+#: src/muuli_wdr.cpp:2489
 msgid "Disconnect"
 msgstr "Desconectar"
 
@@ -712,7 +712,7 @@ msgid "Disconnect from the currently connected networks"
 msgstr "Desconectar das redes atualmente conectadas"
 
 #: src/amuleDlg.cpp:1041 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979
-#: src/muuli_wdr.cpp:2640 src/muuli_wdr.cpp:3092 src/muuli_wdr.cpp:3447
+#: src/muuli_wdr.cpp:2644 src/muuli_wdr.cpp:3096 src/muuli_wdr.cpp:3451
 msgid "Connect"
 msgstr "Conectar"
 
@@ -766,7 +766,7 @@ msgstr "Confirmação de saída"
 msgid "Launch Command: "
 msgstr "Lançar Comando: "
 
-#: src/amuleDlg.cpp:1632 src/muuli_wdr.cpp:1982 src/Preferences.cpp:979
+#: src/amuleDlg.cpp:1632 src/muuli_wdr.cpp:1986 src/Preferences.cpp:979
 msgid "- default -"
 msgstr "- padrão -"
 
@@ -780,60 +780,60 @@ msgstr "O diretório '%s' de skins não existe"
 msgid "WARNING: Unable to open skin file '%s' for read"
 msgstr "CUIDADO: Incapaz de abrir o arquivo de pele '%s' para leitura"
 
-#: src/amuleDlg.cpp:1791 src/muuli_wdr.cpp:3449
+#: src/amuleDlg.cpp:1814 src/muuli_wdr.cpp:3453
 msgid "Networks Window"
 msgstr "Janela de redes"
 
-#: src/amuleDlg.cpp:1797 src/muuli_wdr.cpp:3450
+#: src/amuleDlg.cpp:1820 src/muuli_wdr.cpp:3454
 msgid "Searches Window"
 msgstr "Janela de Pesquisas"
 
-#: src/amuleDlg.cpp:1803 src/muuli_wdr.cpp:3451
+#: src/amuleDlg.cpp:1826 src/muuli_wdr.cpp:3455
 msgid "Downloads Window"
 msgstr "Janela de Downloads"
 
-#: src/amuleDlg.cpp:1809 src/muuli_wdr.cpp:3453
+#: src/amuleDlg.cpp:1832 src/muuli_wdr.cpp:3457
 msgid "Shared Files Window"
 msgstr "Janela de compartilhados"
 
-#: src/amuleDlg.cpp:1815 src/muuli_wdr.cpp:3454
+#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3458
 msgid "Messages Window"
 msgstr "Janela de Mensagens"
 
-#: src/amuleDlg.cpp:1821 src/muuli_wdr.cpp:3455
+#: src/amuleDlg.cpp:1844 src/muuli_wdr.cpp:3459
 msgid "Statistics Graph Window"
 msgstr "Janela de Estatísticas"
 
-#: src/amuleDlg.cpp:1828 src/muuli_wdr.cpp:3457
+#: src/amuleDlg.cpp:1851 src/muuli_wdr.cpp:3461
 msgid "Preferences Settings Window"
 msgstr "Janela de Preferências"
 
-#: src/amuleDlg.cpp:1831 src/muuli_wdr.cpp:3458
+#: src/amuleDlg.cpp:1854 src/muuli_wdr.cpp:3462
 msgid "Import"
 msgstr "Importar"
 
-#: src/amuleDlg.cpp:1835 src/muuli_wdr.cpp:3458
+#: src/amuleDlg.cpp:1858 src/muuli_wdr.cpp:3462
 msgid "The partfile importer tool"
 msgstr "Ferramenta de importação de arquivos .part"
 
-#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3459
+#: src/amuleDlg.cpp:1861 src/muuli_wdr.cpp:3463
 #: src/utils/aLinkCreator/src/alcframe.cpp:262
 msgid "About"
 msgstr "Sobre"
 
-#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3459
+#: src/amuleDlg.cpp:1861 src/muuli_wdr.cpp:3463
 msgid "About/Help"
 msgstr "Sobre/Ajuda"
 
-#: src/amuleDlg.cpp:2036
+#: src/amuleDlg.cpp:2059
 msgid "eD2k network"
 msgstr "Rede eD2k"
 
-#: src/amuleDlg.cpp:2039
+#: src/amuleDlg.cpp:2062
 msgid "Kad network"
 msgstr "rede Kad"
 
-#: src/amuleDlg.cpp:2039
+#: src/amuleDlg.cpp:2062
 msgid "No network"
 msgstr "Sem redes"
 
@@ -1366,19 +1366,19 @@ msgstr "Auto [Alto]"
 msgid "Very low"
 msgstr "Muito baixo"
 
-#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:743 src/muuli_wdr.cpp:2313
+#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:743 src/muuli_wdr.cpp:2317
 #: src/ServerListCtrl.cpp:263 src/ServerListCtrl.cpp:456
 #: src/SharedFilesCtrl.cpp:145
 msgid "Low"
 msgstr "Baixo"
 
-#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:744 src/muuli_wdr.cpp:2314
+#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:744 src/muuli_wdr.cpp:2318
 #: src/ServerListCtrl.cpp:266 src/ServerListCtrl.cpp:457
 #: src/SharedFilesCtrl.cpp:146
 msgid "Normal"
 msgstr "Normal"
 
-#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:745 src/muuli_wdr.cpp:2315
+#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:745 src/muuli_wdr.cpp:2319
 #: src/ServerListCtrl.cpp:269 src/ServerListCtrl.cpp:458
 #: src/SharedFilesCtrl.cpp:147
 msgid "High"
@@ -1470,7 +1470,7 @@ msgstr "Servidor Local"
 msgid "Remote Server"
 msgstr "Servidor Remoto"
 
-#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3212
+#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3216
 #: src/SearchDlg.cpp:119 src/TextClient.cpp:911
 msgid "Kad"
 msgstr "Kad"
@@ -1541,7 +1541,7 @@ msgstr "Parte"
 msgid "Size"
 msgstr "Tamanho"
 
-#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3279
+#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3283
 msgid "Transferred"
 msgstr "Transferido"
 
@@ -1599,7 +1599,7 @@ msgstr ""
 "Resposta de: %s (%s)\n"
 "\n"
 
-#: src/DownloadListCtrl.cpp:746 src/muuli_wdr.cpp:2316
+#: src/DownloadListCtrl.cpp:746 src/muuli_wdr.cpp:2320
 #: src/SharedFilesCtrl.cpp:150
 msgid "Auto"
 msgstr "Auto"
@@ -1637,7 +1637,7 @@ msgid "Extended Options"
 msgstr "Opções Extras"
 
 #: src/DownloadListCtrl.cpp:770 src/DownloadListCtrl.cpp:822
-#: src/muuli_wdr.cpp:1800
+#: src/muuli_wdr.cpp:1804
 msgid "Preview"
 msgstr "Pré-visualizar"
 
@@ -2436,23 +2436,23 @@ msgid ""
 "want downloads on a different (e.g. larger) disk."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:549 src/FirstRunWizard.cpp:611 src/muuli_wdr.cpp:1712
+#: src/FirstRunWizard.cpp:549 src/FirstRunWizard.cpp:611 src/muuli_wdr.cpp:1716
 msgid "Destination folder for downloads"
 msgstr "Pasta de destino para baixados"
 
 #: src/FirstRunWizard.cpp:553 src/FirstRunWizard.cpp:569 src/muuli_wdr.cpp:1349
-#: src/muuli_wdr.cpp:1366 src/muuli_wdr.cpp:1687 src/muuli_wdr.cpp:1718
-#: src/muuli_wdr.cpp:1730 src/muuli_wdr.cpp:2800
+#: src/muuli_wdr.cpp:1366 src/muuli_wdr.cpp:1691 src/muuli_wdr.cpp:1722
+#: src/muuli_wdr.cpp:1734 src/muuli_wdr.cpp:2804
 #: src/utils/aLinkCreator/src/alcframe.cpp:135
 #: src/utils/wxCas/src/wxcasprefs.cpp:52 src/utils/wxCas/src/wxcasprefs.cpp:118
 msgid "Browse"
 msgstr "Procurar"
 
-#: src/FirstRunWizard.cpp:559 src/muuli_wdr.cpp:1723
+#: src/FirstRunWizard.cpp:559 src/muuli_wdr.cpp:1727
 msgid "(All files in this folder are shared with other peers)"
 msgstr "(Todos os arquivos nesta pasta são compartilhados com outros pares)"
 
-#: src/FirstRunWizard.cpp:565 src/FirstRunWizard.cpp:624 src/muuli_wdr.cpp:1725
+#: src/FirstRunWizard.cpp:565 src/FirstRunWizard.cpp:624 src/muuli_wdr.cpp:1729
 msgid "Folder for temporary download files"
 msgstr "Pasta para arquivos temporários baixados"
 
@@ -2483,7 +2483,7 @@ msgstr "Falha em abrir lista de amigos do arquivo 'emfriends.met' para escrita!"
 msgid "CRITICAL - no client on StartChatSession"
 msgstr "CRÍTICO - nenhum cliente em StartChatSession"
 
-#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2706 src/muuli_wdr.cpp:3383
+#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2710 src/muuli_wdr.cpp:3387
 msgid "Friends"
 msgstr "Amigos"
 
@@ -2593,8 +2593,8 @@ msgstr "Nenhum"
 msgid "No"
 msgstr "Não"
 
-#: src/GenericClientListCtrl.cpp:1216 src/PrefsUnifiedDlg.cpp:2898
-#: src/PrefsUnifiedDlg.cpp:2948 src/ServerListCtrl.cpp:276
+#: src/GenericClientListCtrl.cpp:1216 src/PrefsUnifiedDlg.cpp:2907
+#: src/PrefsUnifiedDlg.cpp:2957 src/ServerListCtrl.cpp:276
 msgid "Yes"
 msgstr "Sim"
 
@@ -2763,10 +2763,10 @@ msgstr "Porta inválida para inicialização"
 msgid "Please fill all fields required"
 msgstr "Preencha todos os campos necessários"
 
-#: src/KadDlg.cpp:192 src/PartFile.cpp:1031 src/PrefsUnifiedDlg.cpp:1134
-#: src/PrefsUnifiedDlg.cpp:1204 src/PrefsUnifiedDlg.cpp:1405
-#: src/PrefsUnifiedDlg.cpp:1663 src/PrefsUnifiedDlg.cpp:1673
-#: src/PrefsUnifiedDlg.cpp:1690 src/PrefsUnifiedDlg.cpp:1738
+#: src/KadDlg.cpp:192 src/PartFile.cpp:1031 src/PrefsUnifiedDlg.cpp:1143
+#: src/PrefsUnifiedDlg.cpp:1213 src/PrefsUnifiedDlg.cpp:1414
+#: src/PrefsUnifiedDlg.cpp:1672 src/PrefsUnifiedDlg.cpp:1682
+#: src/PrefsUnifiedDlg.cpp:1699 src/PrefsUnifiedDlg.cpp:1747
 msgid "Message"
 msgstr "Mensagem"
 
@@ -2867,7 +2867,7 @@ msgstr "Taxa de compartilhamento"
 msgid "Uploaded"
 msgstr "Enviado"
 
-#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3263
+#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3267
 msgid "Requested"
 msgstr "Requisitado"
 
@@ -2990,7 +2990,7 @@ msgid "WARNING: "
 msgstr "CUIDADO: "
 
 #: src/MuleNotebook.cpp:179 src/muuli_wdr.cpp:817 src/muuli_wdr.cpp:1229
-#: src/muuli_wdr.cpp:3167 src/muuli_wdr.cpp:3423
+#: src/muuli_wdr.cpp:3171 src/muuli_wdr.cpp:3427
 msgid "Close"
 msgstr "Fechar"
 
@@ -3008,7 +3008,7 @@ msgid "Paste"
 msgstr "Colar"
 
 #: src/MuleTextCtrl.cpp:89 src/muuli_wdr.cpp:358 src/muuli_wdr.cpp:757
-#: src/muuli_wdr.cpp:2390 src/muuli_wdr.cpp:2409 src/muuli_wdr.cpp:2431
+#: src/muuli_wdr.cpp:2394 src/muuli_wdr.cpp:2413 src/muuli_wdr.cpp:2435
 #: src/utils/aLinkCreator/src/alcframe.cpp:142
 msgid "Clear"
 msgstr "Limpar"
@@ -3100,7 +3100,7 @@ msgstr "Sair"
 
 #: src/MuleTrayIcon.cpp:579 src/MuleTrayIcon.cpp:945 src/MuleTrayIcon.cpp:965
 #: src/muuli_wdr.cpp:1398 src/muuli_wdr.cpp:1406 src/muuli_wdr.cpp:1413
-#: src/muuli_wdr.cpp:1846 src/muuli_wdr.cpp:1852 src/OtherFunctions.cpp:91
+#: src/muuli_wdr.cpp:1850 src/muuli_wdr.cpp:1856 src/OtherFunctions.cpp:91
 #: src/StatisticsDlg.cpp:93 src/StatisticsDlg.cpp:95
 msgid "kB/s"
 msgstr "kB/s"
@@ -3340,7 +3340,7 @@ msgstr "Bytes"
 msgid "KB"
 msgstr "KB"
 
-#: src/muuli_wdr.cpp:274 src/muuli_wdr.cpp:293 src/muuli_wdr.cpp:1631
+#: src/muuli_wdr.cpp:274 src/muuli_wdr.cpp:293 src/muuli_wdr.cpp:1635
 #: src/OtherFunctions.cpp:64
 msgid "MB"
 msgstr "MB"
@@ -3357,7 +3357,7 @@ msgstr "Tamanho Máximo"
 msgid "Availability"
 msgstr "Disponível"
 
-#: src/muuli_wdr.cpp:312 src/muuli_wdr.cpp:398 src/muuli_wdr.cpp:3328
+#: src/muuli_wdr.cpp:312 src/muuli_wdr.cpp:398 src/muuli_wdr.cpp:3332
 msgid "Filter:"
 msgstr "Filtro:"
 
@@ -3420,8 +3420,8 @@ msgstr "Fontes de arquivos:"
 #: src/muuli_wdr.cpp:1160 src/muuli_wdr.cpp:1167 src/muuli_wdr.cpp:1172
 #: src/muuli_wdr.cpp:1179 src/muuli_wdr.cpp:1184 src/muuli_wdr.cpp:1191
 #: src/muuli_wdr.cpp:1205 src/muuli_wdr.cpp:1212 src/muuli_wdr.cpp:1217
-#: src/muuli_wdr.cpp:1224 src/muuli_wdr.cpp:3265 src/muuli_wdr.cpp:3273
-#: src/muuli_wdr.cpp:3281
+#: src/muuli_wdr.cpp:1224 src/muuli_wdr.cpp:3269 src/muuli_wdr.cpp:3277
+#: src/muuli_wdr.cpp:3285
 msgid "N/A"
 msgstr "N/A"
 
@@ -3561,7 +3561,7 @@ msgstr "Artista:"
 msgid "Album :"
 msgstr "Album:"
 
-#: src/muuli_wdr.cpp:685 src/muuli_wdr.cpp:2285
+#: src/muuli_wdr.cpp:685 src/muuli_wdr.cpp:2289
 msgid "Title :"
 msgstr "Título:"
 
@@ -3669,7 +3669,7 @@ msgstr "Usuário :"
 msgid "Userhash :"
 msgstr "Hash do usuário :"
 
-#: src/muuli_wdr.cpp:895 src/muuli_wdr.cpp:1752 src/muuli_wdr.cpp:2480
+#: src/muuli_wdr.cpp:895 src/muuli_wdr.cpp:1756 src/muuli_wdr.cpp:2484
 #: src/utils/aLinkCreator/src/alcframe.cpp:137
 msgid "Add"
 msgstr "Adicionar"
@@ -3678,15 +3678,15 @@ msgstr "Adicionar"
 msgid "Download-Speed"
 msgstr "Download (Velocidade)"
 
-#: src/muuli_wdr.cpp:954 src/muuli_wdr.cpp:989 src/muuli_wdr.cpp:2584
+#: src/muuli_wdr.cpp:954 src/muuli_wdr.cpp:989 src/muuli_wdr.cpp:2588
 msgid "Current"
 msgstr "Atual"
 
-#: src/muuli_wdr.cpp:962 src/muuli_wdr.cpp:997 src/muuli_wdr.cpp:2592
+#: src/muuli_wdr.cpp:962 src/muuli_wdr.cpp:997 src/muuli_wdr.cpp:2596
 msgid "Running average"
 msgstr "Média de execução"
 
-#: src/muuli_wdr.cpp:970 src/muuli_wdr.cpp:1005 src/muuli_wdr.cpp:2600
+#: src/muuli_wdr.cpp:970 src/muuli_wdr.cpp:1005 src/muuli_wdr.cpp:2604
 msgid "Session average"
 msgstr "Média da sessão"
 
@@ -3698,7 +3698,7 @@ msgstr "Upload (velocidade)"
 msgid "Connections"
 msgstr "Conexões"
 
-#: src/muuli_wdr.cpp:1024 src/muuli_wdr.cpp:1871
+#: src/muuli_wdr.cpp:1024 src/muuli_wdr.cpp:1875
 msgid "Active downloads"
 msgstr "Downloads ativos"
 
@@ -3706,7 +3706,7 @@ msgstr "Downloads ativos"
 msgid "Active connections (1:1)"
 msgstr "Conexões ativas (1:1)"
 
-#: src/muuli_wdr.cpp:1040 src/muuli_wdr.cpp:1872
+#: src/muuli_wdr.cpp:1040 src/muuli_wdr.cpp:1876
 msgid "Active uploads"
 msgstr "Uploads ativos"
 
@@ -3980,7 +3980,7 @@ msgstr "Casar endereço local ao IP (vazio para qualquer um):"
 msgid "Advanced users only: If you have multiple network interfaces, enter the address of the interface to which aMule should be bound."
 msgstr "Somente usuários avançados: Se você tem múltiplas interfaces de rede, insira o endereço da interface com a qual o aMule deverá conectar-se."
 
-#: src/muuli_wdr.cpp:1462 src/muuli_wdr.cpp:2065
+#: src/muuli_wdr.cpp:1462 src/muuli_wdr.cpp:2069
 msgid "Bind to network interface (empty for any):"
 msgstr "Conectar a uma interface de rede (vazio equivale a todas):"
 
@@ -3996,7 +3996,7 @@ msgstr "Máximo de fontes para arquivos baixando:"
 msgid "Max simultaneous connections:"
 msgstr "Máximo de conexões simultâneas:"
 
-#: src/muuli_wdr.cpp:1498 src/muuli_wdr.cpp:3207
+#: src/muuli_wdr.cpp:1498 src/muuli_wdr.cpp:3211
 msgid "ED2K"
 msgstr "ED2K"
 
@@ -4088,79 +4088,79 @@ msgstr "Pré-alocar espaço em disco para novos arquivos"
 msgid "For new files preallocates disk space for the whole file, thus reduces fragmentation"
 msgstr "Para novos arquivos pré-alocar espaço em disco para todo o arquivo, isso reduz fragmentação"
 
-#: src/muuli_wdr.cpp:1617
+#: src/muuli_wdr.cpp:1621
 msgid "Create new files as sparse files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1618
+#: src/muuli_wdr.cpp:1622
 msgid "Sparse part files only occupy disk space for the parts already downloaded, so free space is used up gradually as the file fills in. Turn this off to use an ordinary file instead - useful where sparse files are unsupported or slow, or where backup/de-duplication tools handle them badly. Applies only when the core runs on Windows; on Linux and macOS part files are sparse anyway and this setting has no effect."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1623
+#: src/muuli_wdr.cpp:1627
 msgid "Stop downloads when free disk space reaches "
 msgstr "Parar download quando espaço livre em disco acabar "
 
-#: src/muuli_wdr.cpp:1624
+#: src/muuli_wdr.cpp:1628
 msgid "Select this if you want aMule to check your disk space"
 msgstr "Selecione isso se você quer uqe o aMule cheque seu espaço em disco"
 
-#: src/muuli_wdr.cpp:1628
+#: src/muuli_wdr.cpp:1632
 msgid "Enter here the min disk space desired."
 msgstr "Digite aqui o espaço min. de disco desejado."
 
-#: src/muuli_wdr.cpp:1634
+#: src/muuli_wdr.cpp:1638
 msgid "Save 10 sources on rare files (< 20 sources)"
 msgstr "Salvar 10 fontes em arquivos raros (< 20 fontes)"
 
-#: src/muuli_wdr.cpp:1638 src/Statistics.cpp:790
+#: src/muuli_wdr.cpp:1642 src/Statistics.cpp:790
 msgid "Uploads"
 msgstr "Uploads"
 
-#: src/muuli_wdr.cpp:1641
+#: src/muuli_wdr.cpp:1645
 msgid "Add new shared files with auto priority"
 msgstr "Adicionar novos compartilhamentos com prioridade automática"
 
-#: src/muuli_wdr.cpp:1647
+#: src/muuli_wdr.cpp:1651
 msgid "Intelligent Corruption Handling (I.C.H.)"
 msgstr "Manuseamento Inteligente de Corrupção (I.C.H.)"
 
-#: src/muuli_wdr.cpp:1650
+#: src/muuli_wdr.cpp:1654
 msgid "Enable"
 msgstr "Habilitado"
 
-#: src/muuli_wdr.cpp:1653
+#: src/muuli_wdr.cpp:1657
 msgid "Advanced I.C.H. trusts every hash (not recommended)"
 msgstr "I.C.H. avançado confia em todo hash (não recomendado)"
 
-#: src/muuli_wdr.cpp:1665 src/PrefsUnifiedDlg.cpp:1990
+#: src/muuli_wdr.cpp:1669 src/PrefsUnifiedDlg.cpp:1999
 msgid "Media metadata extraction"
 msgstr "Extração de metadados da mídia"
 
-#: src/muuli_wdr.cpp:1669
+#: src/muuli_wdr.cpp:1673
 msgid "Extract length / bitrate / codec from shared audio and video files"
 msgstr "Extrair compeimento / taxa de bits / codec de arquivos compartilhados de audio e vídeo"
 
-#: src/muuli_wdr.cpp:1671
+#: src/muuli_wdr.cpp:1675
 msgid "When enabled, aMule runs ffprobe on each shared media file to fill in the Length / Bitrate / Codec columns other clients see when they find the file in a search. Requires ffmpeg (the ffprobe binary) to be installed."
 msgstr "Quando habilitado, o aMule roda ffprobe em cada arquivo de mídia compartilhado para preencher as colunas de Comprimento / Taxa de Bits / Codec que os outros clientes veem quando acham o arquivo em uma procura. Requer que o ffmpeg (o binário ffprobe) esteja instalado."
 
-#: src/muuli_wdr.cpp:1678
+#: src/muuli_wdr.cpp:1682
 msgid "Path to ffprobe:"
 msgstr "Caminho para ffprobe:"
 
-#: src/muuli_wdr.cpp:1683
+#: src/muuli_wdr.cpp:1687
 msgid "Full path to the ffprobe binary. Leave empty to have aMule auto-detect it on startup."
 msgstr "Caminho completo para o binário ffprobe. Deixe vazio para que o aMule detecte automaticamente quando iniciar."
 
-#: src/muuli_wdr.cpp:1691
+#: src/muuli_wdr.cpp:1695
 msgid "Detect"
 msgstr "Detectar"
 
-#: src/muuli_wdr.cpp:1692
+#: src/muuli_wdr.cpp:1696
 msgid "Search the standard install locations for an ffprobe binary and fill the path field."
 msgstr "Procura nos locais de instalação padrão por um binário do ffprobe e preenche o campo de caminho."
 
-#: src/muuli_wdr.cpp:1716
+#: src/muuli_wdr.cpp:1720
 msgid ""
 "Completed downloads are stored here. All files in this folder are automatically shared with other peers.\n"
 "If this folder also holds files you don't want to share, point it at an aMule-only sub-folder."
@@ -4168,688 +4168,688 @@ msgstr ""
 "Downloads finalizados são guardados aqui. Todos os arquivos nesta pasta são automaticamente compartilhados com outros pares.\n"
 "Se esta pasta também guarda arquivos que você não quer compartilhar, aponte para uma sub-pasta só para o aMule."
 
-#: src/muuli_wdr.cpp:1719
+#: src/muuli_wdr.cpp:1723
 msgid "Pick the folder where completed downloads will be stored. All files in that folder will be shared with other peers."
 msgstr "Escolha a pasta onde os downloads terminados serão guardados. Todos os arquivos nesta pasta serão compartilhados com outros pares."
 
-#: src/muuli_wdr.cpp:1733
+#: src/muuli_wdr.cpp:1737
 msgid "Shared folders"
 msgstr "Pastas compartilhadas"
 
-#: src/muuli_wdr.cpp:1739
+#: src/muuli_wdr.cpp:1743
 msgid "(Folders shared by the core. Enter a path to add one.)"
 msgstr "(Pastas compartilhadas pelo núcleo. Digite um caminho para adicionar uma.)"
 
-#: src/muuli_wdr.cpp:1747
+#: src/muuli_wdr.cpp:1751
 msgid "Absolute path of a folder on the core's machine, e.g. /home/user/shared"
 msgstr "Caminho absoluto de uma pasta no núcleo da máquina, e.g. /home/user/shared"
 
-#: src/muuli_wdr.cpp:1749 src/PrefsUnifiedDlg.cpp:2874
+#: src/muuli_wdr.cpp:1753 src/PrefsUnifiedDlg.cpp:2883
 msgid "Recursive"
 msgstr "Recursivo"
 
-#: src/muuli_wdr.cpp:1750
+#: src/muuli_wdr.cpp:1754
 msgid "Share every sub-folder underneath this one, including ones created later."
 msgstr "Compartilhar todas as sub-pastas dentro desta, incluindo as criadas posteriormente."
 
-#: src/muuli_wdr.cpp:1754 src/utils/aLinkCreator/src/alcframe.cpp:141
+#: src/muuli_wdr.cpp:1758 src/utils/aLinkCreator/src/alcframe.cpp:141
 msgid "Remove"
 msgstr "Remover"
 
-#: src/muuli_wdr.cpp:1758
+#: src/muuli_wdr.cpp:1762
 msgid "(Right click on folder icon for recursive share)"
 msgstr "(Botão direito na pasta para compartilhar recursivamente)"
 
-#: src/muuli_wdr.cpp:1765
+#: src/muuli_wdr.cpp:1769
 msgid "Share hidden files"
 msgstr "Compartilhar arquivos ocultos"
 
-#: src/muuli_wdr.cpp:1771
+#: src/muuli_wdr.cpp:1775
 msgid "Automatically rescan shared folders for changes"
 msgstr "Vasculha novamente automaticamente arquivos compartilhados que mudaram"
 
-#: src/muuli_wdr.cpp:1777
+#: src/muuli_wdr.cpp:1781
 msgid "Follow symbolic links in shared folders"
 msgstr "Segue links simbólicos em pastas compartilhadas"
 
-#: src/muuli_wdr.cpp:1783
+#: src/muuli_wdr.cpp:1787
 msgid "Exclude files matching:"
 msgstr "Exclui arquivos correspondendo a:"
 
-#: src/muuli_wdr.cpp:1786
+#: src/muuli_wdr.cpp:1790
 msgid "Wildcard patterns separated by '|', e.g. .DS_Store|Thumbs.db|*.tmp. Files whose name matches are not shared. Matching is case-insensitive."
 msgstr "Caracteres curinga separados por '|', e.g. .DS_Store|Thumbs.db|*.tmp. Arquivos cujos nomes corresponderem não serão compartilhados. A correspondência é sensível à letra maiúscula/minúscula."
 
-#: src/muuli_wdr.cpp:1790
+#: src/muuli_wdr.cpp:1794
 msgid "Patterns are regular expressions"
 msgstr "Padrões são expressões regulares"
 
-#: src/muuli_wdr.cpp:1791
+#: src/muuli_wdr.cpp:1795
 msgid "When set, the whole field is one regular expression ('|' is alternation). When unset, it is a list of '|'-separated wildcards."
 msgstr "Quando ligado, o campo inteiro é uma expressão regular ('|' é alternativa). Quando desligado, é uma lista de caracteres curinga separados por '|'."
 
-#: src/muuli_wdr.cpp:1801
+#: src/muuli_wdr.cpp:1805
 msgid "Show how many shared files the current pattern would exclude."
 msgstr "Mostra quantos arquivos compartilhados o padrão atual excluiria."
 
-#: src/muuli_wdr.cpp:1822
+#: src/muuli_wdr.cpp:1826
 msgid "Graphs"
 msgstr "Gráficos"
 
-#: src/muuli_wdr.cpp:1825 src/muuli_wdr.cpp:1887
+#: src/muuli_wdr.cpp:1829 src/muuli_wdr.cpp:1891
 msgid "Update delay : 5 secs"
 msgstr "Tempo de atualização: 5s"
 
-#: src/muuli_wdr.cpp:1829
+#: src/muuli_wdr.cpp:1833
 msgid "Time for average graph: 100 mins"
 msgstr "Tempo para gráfico de média: 100min"
 
-#: src/muuli_wdr.cpp:1833
+#: src/muuli_wdr.cpp:1837
 msgid "Connections Graph Scale: 100 "
 msgstr "Escala dos gráficos das conexões: 100 "
 
-#: src/muuli_wdr.cpp:1840
+#: src/muuli_wdr.cpp:1844
 msgid "Download graph scale:"
 msgstr "Escala gráfica de download:"
 
-#: src/muuli_wdr.cpp:1848
+#: src/muuli_wdr.cpp:1852
 msgid "Upload graph scale:"
 msgstr "Escala gráfica de upload:"
 
-#: src/muuli_wdr.cpp:1858
+#: src/muuli_wdr.cpp:1862
 msgid "Colors: "
 msgstr "Cores: "
 
-#: src/muuli_wdr.cpp:1862
+#: src/muuli_wdr.cpp:1866
 msgid "Background"
 msgstr "Fundo"
 
-#: src/muuli_wdr.cpp:1863
+#: src/muuli_wdr.cpp:1867
 msgid "Grid"
 msgstr "Grade"
 
-#: src/muuli_wdr.cpp:1864
+#: src/muuli_wdr.cpp:1868
 msgid "Download current"
 msgstr "Download atual"
 
-#: src/muuli_wdr.cpp:1865
+#: src/muuli_wdr.cpp:1869
 msgid "Download running average"
 msgstr "Média dos Downloads ativos"
 
-#: src/muuli_wdr.cpp:1866
+#: src/muuli_wdr.cpp:1870
 msgid "Download session average"
 msgstr "Média dos Downloads da sessão"
 
-#: src/muuli_wdr.cpp:1867
+#: src/muuli_wdr.cpp:1871
 msgid "Upload current"
 msgstr "Upload Atual"
 
-#: src/muuli_wdr.cpp:1868
+#: src/muuli_wdr.cpp:1872
 msgid "Upload running average"
 msgstr "Média dos Uploads ativos"
 
-#: src/muuli_wdr.cpp:1869
+#: src/muuli_wdr.cpp:1873
 msgid "Upload session average"
 msgstr "Média dos Uploads da sessão"
 
-#: src/muuli_wdr.cpp:1870
+#: src/muuli_wdr.cpp:1874
 msgid "Active connections"
 msgstr "Conexões ativas"
 
-#: src/muuli_wdr.cpp:1873
+#: src/muuli_wdr.cpp:1877
 msgid "Systray Icon Speed Bar"
 msgstr "Ícone de barra de velocidade"
 
-#: src/muuli_wdr.cpp:1874
+#: src/muuli_wdr.cpp:1878
 msgid "Kad-nodes current"
 msgstr "Kad-nodes atuais"
 
-#: src/muuli_wdr.cpp:1875
+#: src/muuli_wdr.cpp:1879
 msgid "Kad-nodes running"
 msgstr "Kad-nodes rodando"
 
-#: src/muuli_wdr.cpp:1876
+#: src/muuli_wdr.cpp:1880
 msgid "Kad-nodes session"
 msgstr "Sessões Kad-nodes"
 
-#: src/muuli_wdr.cpp:1880 src/muuli_wdr.cpp:2334
+#: src/muuli_wdr.cpp:1884 src/muuli_wdr.cpp:2338
 msgid "Select"
 msgstr "Selecione"
 
-#: src/muuli_wdr.cpp:1884
+#: src/muuli_wdr.cpp:1888
 msgid "Tree"
 msgstr "Árvore"
 
-#: src/muuli_wdr.cpp:1894
+#: src/muuli_wdr.cpp:1898
 msgid "Number of Client Versions shown (0=unlimited)"
 msgstr "Número de versões a exibir (0=sem limite)"
 
-#: src/muuli_wdr.cpp:1919
+#: src/muuli_wdr.cpp:1923
 msgid "!!! WARNING !!!"
 msgstr "!!! CUIDADO !!!"
 
-#: src/muuli_wdr.cpp:1934
+#: src/muuli_wdr.cpp:1938
 msgid "Max new connections / 5 secs"
 msgstr "No. Max. de conexões / 5s"
 
-#: src/muuli_wdr.cpp:1936
+#: src/muuli_wdr.cpp:1940
 msgid "Concurrent Kad source lookups"
 msgstr "Procura concorrente de fontes Kad"
 
-#: src/muuli_wdr.cpp:1938
+#: src/muuli_wdr.cpp:1942
 msgid "Kad source re-search interval (minutes)"
 msgstr "Intervalo entre novas buscas de fontes Kad (minutos)"
 
-#: src/muuli_wdr.cpp:1940
+#: src/muuli_wdr.cpp:1944
 msgid "Source re-ask interval (minutes)"
 msgstr "Intervalo entre novos pedidos de fonte (minutos)"
 
-#: src/muuli_wdr.cpp:1944
+#: src/muuli_wdr.cpp:1948
 msgid "File Buffer Size: 240000 bytes"
 msgstr "Tamanho do arquivo buffer: 240000 bytes"
 
-#: src/muuli_wdr.cpp:1948
+#: src/muuli_wdr.cpp:1952
 msgid "Use MMAP: memory-mapped file access (lower memory use)"
 msgstr "Usar MMAP: acesso de arquivo mapeado em memória (menor uso de memória)"
 
-#: src/muuli_wdr.cpp:1949
+#: src/muuli_wdr.cpp:1953
 msgid "Maps part files into memory instead of buffering them on the heap, lowering the process memory footprint. May reduce download speed on some disks; best for memory-constrained or upload-heavy hosts."
 msgstr "Mapeia arquivos part em memória ao invés de buferizá-los na heap, diminuindo a pegada de memória do processo. Pode reduzir a velocidade de download em alguns discos; melhor para hopedeiros com memória restrita ou que façam upload intensivamente."
 
-#: src/muuli_wdr.cpp:1951
+#: src/muuli_wdr.cpp:1955
 msgid "Upload Queue Size: 5000 clients"
 msgstr "Tamanho de Espera de Upload: 5000 clientes"
 
-#: src/muuli_wdr.cpp:1955
+#: src/muuli_wdr.cpp:1959
 msgid "Server connection refresh interval: Disable"
 msgstr "Atualizar conexão com servidor: desativado"
 
-#: src/muuli_wdr.cpp:1959
+#: src/muuli_wdr.cpp:1963
 msgid "Disable computer's timed standby mode"
 msgstr "Desabilitar modo timed standby do computador"
 
-#: src/muuli_wdr.cpp:1978
+#: src/muuli_wdr.cpp:1982
 msgid "Skin to use: "
 msgstr "Pele a usar: "
 
-#: src/muuli_wdr.cpp:1987
+#: src/muuli_wdr.cpp:1991
 msgid "Show \"Fast eD2k Links Handler\" in every window."
 msgstr "Mostrar \"Manipulador Veloz de Ligações eD2k\" em cada janela."
 
-#: src/muuli_wdr.cpp:1990
+#: src/muuli_wdr.cpp:1994
 msgid "Show extended info on categories tabs"
 msgstr "Mostrar info. extras nas abas de categoria"
 
-#: src/muuli_wdr.cpp:1993
+#: src/muuli_wdr.cpp:1997
 msgid "Show application version on title"
 msgstr "Exibir versão do aplicativo no título"
 
-#: src/muuli_wdr.cpp:1995
+#: src/muuli_wdr.cpp:1999
 msgid "Show transfer rates on title"
 msgstr "Exibir taxa de transferência no título"
 
-#: src/muuli_wdr.cpp:1997
+#: src/muuli_wdr.cpp:2001
 msgid "Before application name"
 msgstr "Antes do nome da aplicação"
 
-#: src/muuli_wdr.cpp:1999
+#: src/muuli_wdr.cpp:2003
 msgid "After application name"
 msgstr "Depois do nome da aplicação"
 
-#: src/muuli_wdr.cpp:2002
+#: src/muuli_wdr.cpp:2006
 msgid "Show overhead bandwidth"
 msgstr "Mostrar banda sobressalente"
 
-#: src/muuli_wdr.cpp:2006
+#: src/muuli_wdr.cpp:2010
 msgid "Vertical toolbar orientation"
 msgstr "Orientação Vertical da Barra de Ferramentas"
 
-#: src/muuli_wdr.cpp:2008
+#: src/muuli_wdr.cpp:2012
 msgid "Live column sorting (auto-reorder rows as their values change)"
 msgstr "Ordenação de coluna ao vivo (reordenamento automático das colunas conforme seus valores mudam)"
 
-#: src/muuli_wdr.cpp:2015
+#: src/muuli_wdr.cpp:2019
 msgid "Download Queue Files"
 msgstr "Fila de arquivos baixando"
 
-#: src/muuli_wdr.cpp:2018
+#: src/muuli_wdr.cpp:2022
 msgid "Show progress percentage"
 msgstr "Mostrar porcentagem do progresso"
 
-#: src/muuli_wdr.cpp:2024
+#: src/muuli_wdr.cpp:2028
 msgid "Show progress bar"
 msgstr "Mostrar barra de progresso"
 
-#: src/muuli_wdr.cpp:2027
+#: src/muuli_wdr.cpp:2031
 msgid "Flat"
 msgstr "Plana"
 
-#: src/muuli_wdr.cpp:2031
+#: src/muuli_wdr.cpp:2035
 msgid "Round"
 msgstr "Arredondada"
 
-#: src/muuli_wdr.cpp:2049
+#: src/muuli_wdr.cpp:2053
 msgid "External Connection Parameters"
 msgstr "Parâmetros de conexão externa"
 
-#: src/muuli_wdr.cpp:2052
+#: src/muuli_wdr.cpp:2056
 msgid "Accept external connections"
 msgstr "Aceitar conexões externas"
 
-#: src/muuli_wdr.cpp:2059 src/muuli_wdr.cpp:2118
+#: src/muuli_wdr.cpp:2063 src/muuli_wdr.cpp:2122
 msgid "IP of the listening interface:"
 msgstr "IP da interface ouvindo:"
 
-#: src/muuli_wdr.cpp:2062
+#: src/muuli_wdr.cpp:2066
 msgid "Enter here a valid ip in the a.b.c.d format for the listening EC interface. An empty field or 0.0.0.0 will mean any interface."
 msgstr "Informe um IP válido no formato a.b.c.d para a interface EC que ficará aguardando. Um campo vazio ou 0.0.0.0 quer dizer 'qualquer interface'."
 
-#: src/muuli_wdr.cpp:2083 src/muuli_wdr.cpp:2194
+#: src/muuli_wdr.cpp:2087 src/muuli_wdr.cpp:2198
 msgid "TCP port:"
 msgstr "Porta TCP:"
 
-#: src/muuli_wdr.cpp:2089
+#: src/muuli_wdr.cpp:2093
 msgid "Enable UPnP port forwarding on the EC port"
 msgstr "Habilitar redirecionamento de porta UPnP para porta EC"
 
-#: src/muuli_wdr.cpp:2093 src/muuli_wdr.cpp:3079
+#: src/muuli_wdr.cpp:2097 src/muuli_wdr.cpp:3083
 #: src/utils/wxCas/src/wxcasprefs.cpp:167
 msgid "Password"
 msgstr "Senha"
 
-#: src/muuli_wdr.cpp:2099
+#: src/muuli_wdr.cpp:2103
 msgid "aMule API server parameters"
 msgstr "Parâmetros do servidor da API do aMule"
 
-#: src/muuli_wdr.cpp:2102
+#: src/muuli_wdr.cpp:2106
 msgid "Run amuleapi (REST API) on startup"
 msgstr "Rodar o amuleapi (REST API) ao iniciar"
 
-#: src/muuli_wdr.cpp:2107
+#: src/muuli_wdr.cpp:2111
 msgid "HTTP port:"
 msgstr "Porta HTTP:"
 
-#: src/muuli_wdr.cpp:2121
+#: src/muuli_wdr.cpp:2125
 msgid "The interface amuleapi's HTTP server listens on. 127.0.0.1 (default) accepts only local connections; use 0.0.0.0 or a specific IP to expose it to other hosts (set an admin password below)."
 msgstr "A interface do servidor HTTP do amuleapi que escuta em 127.0.0.1 (padrão) aceita apenas conexões locais; use 0.0.0.0 or um IP específico para expô-la a outros hospedeiros (configure uma senha de administração abaixo)."
 
-#: src/muuli_wdr.cpp:2126
+#: src/muuli_wdr.cpp:2130
 msgid "Type a password to set or change it. Stored passwords cannot be shown, so leaving this empty keeps the current one."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2128
+#: src/muuli_wdr.cpp:2132
 msgid "Admin password"
 msgstr "Senha de administração"
 
-#: src/muuli_wdr.cpp:2140 src/muuli_wdr.cpp:2157 src/PrefsUnifiedDlg.cpp:1103
+#: src/muuli_wdr.cpp:2144 src/muuli_wdr.cpp:2161 src/PrefsUnifiedDlg.cpp:1112
 #, fuzzy
 msgid "A password is set."
 msgstr "Senha de administração"
 
-#: src/muuli_wdr.cpp:2144
+#: src/muuli_wdr.cpp:2148
 #, fuzzy
 msgid "Enable guest access"
 msgstr "Negar acesso restrito"
 
-#: src/muuli_wdr.cpp:2145
+#: src/muuli_wdr.cpp:2149
 msgid "Guest sessions may read status and listings but cannot change anything. Turning this off clears the stored guest password."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2149
+#: src/muuli_wdr.cpp:2153
 #, fuzzy
 msgid "Guest password"
 msgstr "Senha de visitante para servidor web"
 
-#: src/muuli_wdr.cpp:2164
+#: src/muuli_wdr.cpp:2168
 msgid "Web server parameters"
 msgstr "Parâmetros do web server"
 
-#: src/muuli_wdr.cpp:2167
+#: src/muuli_wdr.cpp:2171
 msgid "Run webserver on startup (deprecated)"
 msgstr "Rodar webserver ao iniciar (deprecado)"
 
-#: src/muuli_wdr.cpp:2173
+#: src/muuli_wdr.cpp:2177
 msgid "Web template"
 msgstr "Modelo de rede"
 
-#: src/muuli_wdr.cpp:2178
+#: src/muuli_wdr.cpp:2182
 msgid "Full rights password"
 msgstr "Password para acesso completo"
 
-#: src/muuli_wdr.cpp:2182
+#: src/muuli_wdr.cpp:2186
 msgid "Enable Low rights User"
 msgstr "Usuário com direitos limitados"
 
-#: src/muuli_wdr.cpp:2187
+#: src/muuli_wdr.cpp:2191
 msgid "Low rights password"
 msgstr "Password para acesso limitado"
 
-#: src/muuli_wdr.cpp:2201
+#: src/muuli_wdr.cpp:2205
 msgid "Enable UPnP port forwarding of the web server port"
 msgstr "Habilitar redirecionamento de porta UPnP da porta do servidor web"
 
-#: src/muuli_wdr.cpp:2206
+#: src/muuli_wdr.cpp:2210
 msgid "Web server UPnP TCP port (Optional)"
 msgstr "Porta TCP UPnP do servidor web (Opcional)"
 
-#: src/muuli_wdr.cpp:2214
+#: src/muuli_wdr.cpp:2218
 msgid "Page Refresh Time (in secs)"
 msgstr "Tempo atualização (secs)"
 
-#: src/muuli_wdr.cpp:2221
+#: src/muuli_wdr.cpp:2225
 msgid "Enable Gzip compression"
 msgstr "Ativar compactação Gzip"
 
-#: src/muuli_wdr.cpp:2255
+#: src/muuli_wdr.cpp:2259
 msgid "Reset page to defaults"
 msgstr "Retorna a página aos valores padrão"
 
-#: src/muuli_wdr.cpp:2256
+#: src/muuli_wdr.cpp:2260
 msgid "Reset the settings on the current page to their default values."
 msgstr "Reseta as configurações na página atual para seus valores padrão."
 
-#: src/muuli_wdr.cpp:2258 src/muuli_wdr.cpp:2344 src/ServerWnd.cpp:274
+#: src/muuli_wdr.cpp:2262 src/muuli_wdr.cpp:2348 src/ServerWnd.cpp:274
 #: src/ServerWnd.cpp:282
 msgid "OK"
 msgstr "OK"
 
-#: src/muuli_wdr.cpp:2260
+#: src/muuli_wdr.cpp:2264
 msgid "Click here to apply any changes made to the preferences."
 msgstr "Clique aqui para aplicar as alterações feitas."
 
-#: src/muuli_wdr.cpp:2263
+#: src/muuli_wdr.cpp:2267
 msgid "Reset any changes made to the preferences."
 msgstr "Ignora todas as alterações feitas."
 
-#: src/muuli_wdr.cpp:2292
+#: src/muuli_wdr.cpp:2296
 msgid "Comment :"
 msgstr "Comentário:"
 
-#: src/muuli_wdr.cpp:2299
+#: src/muuli_wdr.cpp:2303
 msgid "Incoming Dir :"
 msgstr "Dir incoming:"
 
-#: src/muuli_wdr.cpp:2308
+#: src/muuli_wdr.cpp:2312
 msgid "Change priority for new assigned files :"
 msgstr "Alterar prioridade para novos arquivos:"
 
-#: src/muuli_wdr.cpp:2312
+#: src/muuli_wdr.cpp:2316
 msgid "Don't change"
 msgstr "Não alterar"
 
-#: src/muuli_wdr.cpp:2324
+#: src/muuli_wdr.cpp:2328
 msgid "Select color for this Category (currently selected) :"
 msgstr "Selecione a cor para esta Categoria (selecionada):"
 
-#: src/muuli_wdr.cpp:2391 src/muuli_wdr.cpp:2410 src/muuli_wdr.cpp:2432
+#: src/muuli_wdr.cpp:2395 src/muuli_wdr.cpp:2414 src/muuli_wdr.cpp:2436
 msgid "Click this button to reset the log."
 msgstr "Clique nesse botão para limpar o log."
 
-#: src/muuli_wdr.cpp:2451
+#: src/muuli_wdr.cpp:2455
 msgid "Click on this button to update the servers list from URL ..."
 msgstr "Clique nesse botão para atualizar a lista de servidores..."
 
-#: src/muuli_wdr.cpp:2455
+#: src/muuli_wdr.cpp:2459
 msgid "Server list"
 msgstr "Lista de servidores"
 
-#: src/muuli_wdr.cpp:2459
+#: src/muuli_wdr.cpp:2463
 msgid "Enter the url to a server.met file here and press the button to the left to update the list of known servers."
 msgstr "Informe a URL com o arquivo server.met aqui e pressione o botão a esquerda para atualizar a lista de servidores."
 
-#: src/muuli_wdr.cpp:2464
+#: src/muuli_wdr.cpp:2468
 msgid "Add server manually: Name"
 msgstr "Adicionar servidor manualmente: Nome"
 
-#: src/muuli_wdr.cpp:2467
+#: src/muuli_wdr.cpp:2471
 msgid "Enter the name of the new server here"
 msgstr "Informe o nome do novo servidor aqui"
 
-#: src/muuli_wdr.cpp:2469 src/ServerWnd.cpp:206
+#: src/muuli_wdr.cpp:2473 src/ServerWnd.cpp:206
 msgid "IP:Port"
 msgstr "IP:Porta"
 
-#: src/muuli_wdr.cpp:2472
+#: src/muuli_wdr.cpp:2476
 msgid "Enter the IP of the server here, using the x.x.x.x format."
 msgstr "Informe o IP do servidor no formato x.x.x.x nesse espaço."
 
-#: src/muuli_wdr.cpp:2478
+#: src/muuli_wdr.cpp:2482
 msgid "Enter the port of the server here."
 msgstr "Informe a porta do servidor aqui."
 
-#: src/muuli_wdr.cpp:2481
+#: src/muuli_wdr.cpp:2485
 msgid "Add manually a server (fill fields to the left before) ..."
 msgstr "Adicionar manualmente um servidor (preencha os campos ao lado antes)."
 
-#: src/muuli_wdr.cpp:2510
+#: src/muuli_wdr.cpp:2514
 msgid "aMule Log"
 msgstr "Log do aMule"
 
-#: src/muuli_wdr.cpp:2518
+#: src/muuli_wdr.cpp:2522
 msgid "Server Info"
 msgstr "Informações do Servidor"
 
-#: src/muuli_wdr.cpp:2522
+#: src/muuli_wdr.cpp:2526
 msgid "ED2K Info"
 msgstr "ED2K Info"
 
-#: src/muuli_wdr.cpp:2526
+#: src/muuli_wdr.cpp:2530
 msgid "Kad Info"
 msgstr "Informação de Kad"
 
-#: src/muuli_wdr.cpp:2554
+#: src/muuli_wdr.cpp:2558
 msgid "Click on this button to update the nodes list from URL ..."
 msgstr "Clique nesse botão para atualizar a lista de nodes da URL..."
 
-#: src/muuli_wdr.cpp:2558
+#: src/muuli_wdr.cpp:2562
 msgid "Nodes (0)"
 msgstr "Nós (0)"
 
-#: src/muuli_wdr.cpp:2562
+#: src/muuli_wdr.cpp:2566
 msgid "Enter the url to a nodes.dat file here and press the button to the left to update the list of known nodes."
 msgstr "Informe uma URL para um arquivo nodes.dat e pressione o botão da esquerda para atualizar a lista de nós conhecidos."
 
-#: src/muuli_wdr.cpp:2565
+#: src/muuli_wdr.cpp:2569
 msgid "Nodes stats"
 msgstr "Estatísticas dos Nodes"
 
-#: src/muuli_wdr.cpp:2607
+#: src/muuli_wdr.cpp:2611
 msgid "Bootstrap"
 msgstr "Inicialização"
 
-#: src/muuli_wdr.cpp:2610
+#: src/muuli_wdr.cpp:2614
 msgid "New node"
 msgstr "Novo node"
 
-#: src/muuli_wdr.cpp:2615
+#: src/muuli_wdr.cpp:2619
 msgid "IP:"
 msgstr "IP:"
 
-#: src/muuli_wdr.cpp:2635
+#: src/muuli_wdr.cpp:2639
 msgid "Port:"
 msgstr "Porta:"
 
-#: src/muuli_wdr.cpp:2648
+#: src/muuli_wdr.cpp:2652
 msgid "Bootstrap from known clients"
 msgstr "Inicializando de clientes conhecidos"
 
-#: src/muuli_wdr.cpp:2650
+#: src/muuli_wdr.cpp:2654
 msgid "Disconnect Kad"
 msgstr "Desconectar da rede Kad"
 
-#: src/muuli_wdr.cpp:2684
+#: src/muuli_wdr.cpp:2688
 msgid "Use Secure User Identification"
 msgstr "Utilizar Identificação Segura de Usuário"
 
-#: src/muuli_wdr.cpp:2686
+#: src/muuli_wdr.cpp:2690
 msgid "It is recommended to enable this option. You will not receive credits if SUI is not enabled."
 msgstr "É recomendável ativar essa opção. Você não receberá seus créditos se a identificação segura não estiver ativada."
 
-#: src/muuli_wdr.cpp:2688
+#: src/muuli_wdr.cpp:2692
 msgid "Protocol Obfuscation"
 msgstr "Obscurecimento de Protocolo"
 
-#: src/muuli_wdr.cpp:2691
+#: src/muuli_wdr.cpp:2695
 msgid "Support Protocol Obfuscation"
 msgstr "Suportar Obscurecimento de Protocolo"
 
-#: src/muuli_wdr.cpp:2693
+#: src/muuli_wdr.cpp:2697
 msgid "This option enabled Protocol Obfuscation, and makes aMule accept obfuscated connections from other clients."
 msgstr "Esta opção habilita Obscurecimento de Protocolo, e faz o aMule aceitar conexões obscuras (criptografadas) de outros clientes."
 
-#: src/muuli_wdr.cpp:2695
+#: src/muuli_wdr.cpp:2699
 msgid "Use obfuscation for outgoing connections"
 msgstr "Usar obscurecimento para conexões externas"
 
-#: src/muuli_wdr.cpp:2697
+#: src/muuli_wdr.cpp:2701
 msgid "This option makes aMule use Protocol Obfuscation when connecting other clients/servers."
 msgstr "Esta opção faz o aMule usar Obscurecimento de Protocolo quando conectando outros clientes/servidores."
 
-#: src/muuli_wdr.cpp:2699
+#: src/muuli_wdr.cpp:2703
 msgid "Accept only obfuscated connections"
 msgstr "Aceitar somente conexões obscuras"
 
-#: src/muuli_wdr.cpp:2700
+#: src/muuli_wdr.cpp:2704
 msgid "This option makes aMule only accept obfuscated connections. You will have less sources, but all your traffic will be obfuscated"
 msgstr "Esta opção faz o aMule aceitar somente conexões obscurecidas. Você terá menos fontes, mas todo seu tráfego será obscurecido"
 
-#: src/muuli_wdr.cpp:2705
+#: src/muuli_wdr.cpp:2709
 msgid "Everybody"
 msgstr "Todos"
 
-#: src/muuli_wdr.cpp:2707
+#: src/muuli_wdr.cpp:2711
 msgid "No one"
 msgstr "Nenhum"
 
-#: src/muuli_wdr.cpp:2709
+#: src/muuli_wdr.cpp:2713
 msgid "Who can see my shared files:"
 msgstr "Quem pode ver meus arquivos compartilhados:"
 
-#: src/muuli_wdr.cpp:2710
+#: src/muuli_wdr.cpp:2714
 msgid "Select who can request to view a list of your shared files."
 msgstr "Selecione quem pode pedir a sua lista de compartilhamentos."
 
-#: src/muuli_wdr.cpp:2712
+#: src/muuli_wdr.cpp:2716
 msgid "IP-Filtering"
 msgstr "Filtro de IP"
 
-#: src/muuli_wdr.cpp:2719
+#: src/muuli_wdr.cpp:2723
 msgid "Filter clients"
 msgstr "Filtrar clientes"
 
-#: src/muuli_wdr.cpp:2721
+#: src/muuli_wdr.cpp:2725
 msgid "Enable filtering of the client IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "Habilitar filtragem de IPs de clientes definidos no arquivo ~/.aMule/ipfilter.dat."
 
-#: src/muuli_wdr.cpp:2723
+#: src/muuli_wdr.cpp:2727
 msgid "Filter servers"
 msgstr "Filtrar servidores"
 
-#: src/muuli_wdr.cpp:2725
+#: src/muuli_wdr.cpp:2729
 msgid "Enable filtering of the server IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "Habilitar filtragem de IPs de servidores definidos no arquivo ~/.aMule/ipfilter.dat."
 
-#: src/muuli_wdr.cpp:2729
+#: src/muuli_wdr.cpp:2733
 msgid "Reload List"
 msgstr "Recarregar lista"
 
-#: src/muuli_wdr.cpp:2730
+#: src/muuli_wdr.cpp:2734
 msgid "Reload the list of IPs to filter from the file ~/.aMule/ipfilter.dat"
 msgstr "Recarregar lista de IPs a filtrar do arquivo ~/.aMule/ipfilter.dat"
 
-#: src/muuli_wdr.cpp:2736
+#: src/muuli_wdr.cpp:2740
 msgid "URL:"
 msgstr "URL:"
 
-#: src/muuli_wdr.cpp:2740 src/muuli_wdr.cpp:2933
+#: src/muuli_wdr.cpp:2744 src/muuli_wdr.cpp:2937
 msgid "Update now"
 msgstr "Atualizar agora"
 
-#: src/muuli_wdr.cpp:2743
+#: src/muuli_wdr.cpp:2747
 msgid "Auto-update ipfilter at startup"
 msgstr "Auto-atualizar ipfilter ao iniciar"
 
-#: src/muuli_wdr.cpp:2747
+#: src/muuli_wdr.cpp:2751
 msgid "Filtering Level:"
 msgstr "Níveis de Filtro:"
 
-#: src/muuli_wdr.cpp:2753
+#: src/muuli_wdr.cpp:2757
 msgid "Always filter LAN IPs"
 msgstr "Sempre filtrar IPs de redes LAN"
 
-#: src/muuli_wdr.cpp:2756
+#: src/muuli_wdr.cpp:2760
 msgid "Paranoid handling of non-matching IPs"
 msgstr "Manuseio paranoico de IPs não-casados"
 
-#: src/muuli_wdr.cpp:2758
+#: src/muuli_wdr.cpp:2762
 msgid "Rejects a packet when its source IP differs from the IP the client claims (an anti-spoofing check). Disable only if it causes connection problems."
 msgstr "Rejeita um pacote quando o IP de sua fonte difere do IP que o cliente clama (uma checagem anti-spoofing). Desabilite apenas se causar problemas de conexão."
 
-#: src/muuli_wdr.cpp:2760
+#: src/muuli_wdr.cpp:2764
 msgid "Use system-wide ipfilter.dat if available"
 msgstr "Utilizar ipfilter.dat global se disponível"
 
-#: src/muuli_wdr.cpp:2761
+#: src/muuli_wdr.cpp:2765
 msgid "If there's no local ipfilter.dat found, allow usage of a system-wide ipfilter file."
 msgstr "Se nenhum ipfilter.dat local for encontrado, permita o uso de um arquivo global."
 
-#: src/muuli_wdr.cpp:2778
+#: src/muuli_wdr.cpp:2782
 msgid "Enable Online-Signature"
 msgstr "Ativar Assinatura Online"
 
-#: src/muuli_wdr.cpp:2780
+#: src/muuli_wdr.cpp:2784
 msgid "Enables the writing of the OS file, which can be used by external apps to create signatures and the like."
 msgstr "Habilita a gravação do arquivo, que pode ser usado por programas externos."
 
-#: src/muuli_wdr.cpp:2784
+#: src/muuli_wdr.cpp:2788
 msgid "Update Frequency (Secs):"
 msgstr "Frequência de atualização (Seg):"
 
-#: src/muuli_wdr.cpp:2787
+#: src/muuli_wdr.cpp:2791
 msgid "Change the frequency (in seconds) of Online Signature updates."
 msgstr "Alterar frequência (em segundos) da atualização da Assinatura."
 
-#: src/muuli_wdr.cpp:2795
+#: src/muuli_wdr.cpp:2799
 msgid "Save online signature file in: "
 msgstr "Salvar arquivos de assinatura online em: "
 
-#: src/muuli_wdr.cpp:2801
+#: src/muuli_wdr.cpp:2805
 msgid "Click here to select the directory containing the the Online Signature files."
 msgstr "Clique aqui para definir pasta contendo os arquivos da Assinatura Online."
 
-#: src/muuli_wdr.cpp:2834
+#: src/muuli_wdr.cpp:2838
 msgid "Show country flags for clients"
 msgstr "Mostrar bandeiras nacionais para clientes"
 
-#: src/muuli_wdr.cpp:2835
+#: src/muuli_wdr.cpp:2839
 msgid "Render the country flag column in the transfers, queue and search views. Requires a valid MMDB GeoIP database (see below)."
 msgstr "Renderiza a coluna da bandeira do país nas transferências, filas e vistas de procura. Requer um banco de dados MMDB GeoIP válido (veja abaixo)."
 
-#: src/muuli_wdr.cpp:2840
+#: src/muuli_wdr.cpp:2844
 msgid "Database"
 msgstr "Banco de Dados"
 
-#: src/muuli_wdr.cpp:2856
+#: src/muuli_wdr.cpp:2860
 msgid "Source:"
 msgstr "Fonte:"
 
-#: src/muuli_wdr.cpp:2859
+#: src/muuli_wdr.cpp:2863
 msgid "DB-IP (free, no account)"
 msgstr "DB-IP (grátis, sem conta)"
 
-#: src/muuli_wdr.cpp:2860
+#: src/muuli_wdr.cpp:2864
 msgid "MaxMind GeoLite2 (free, account required)"
 msgstr "MaxMind GeoLite2 (grátis, requer conta)"
 
-#: src/muuli_wdr.cpp:2861
+#: src/muuli_wdr.cpp:2865
 msgid "Custom URL"
 msgstr "URL Customizada"
 
-#: src/muuli_wdr.cpp:2864
+#: src/muuli_wdr.cpp:2868
 msgid "Choose which provider supplies the GeoIP MMDB database. DB-IP is the default - no account required. MaxMind requires a free account + license key. Use Custom URL to point at any other MMDB host (e.g. a local mirror)."
 msgstr "Escolha qual provedor fornece o banco de dados MMDB GeoIP. DB-IP é o padrão - não requer conta. MaxMind requer uma conta grátis + chave de licensa. Use uma URL Customizada para apontar para qualquer outro anfitrião MMDB (e.g. um espelho local)."
 
-#: src/muuli_wdr.cpp:2881
+#: src/muuli_wdr.cpp:2885
 msgid ""
 "No configuration required.\n"
 "\n"
@@ -4861,11 +4861,11 @@ msgstr ""
 "Dados de IP-to-Country por DB-IP.com - https://db-ip.com\n"
 "Licensa: Creative Commons BY 4.0 - https://creativecommons.org/licenses/by/4.0/"
 
-#: src/muuli_wdr.cpp:2894
+#: src/muuli_wdr.cpp:2898
 msgid "License key:"
 msgstr "Chave de Licensa:"
 
-#: src/muuli_wdr.cpp:2900
+#: src/muuli_wdr.cpp:2904
 msgid ""
 "Sign up for a free MaxMind account, then generate a License Key:\n"
 "https://www.maxmind.com/en/geolite2/signup\n"
@@ -4881,11 +4881,11 @@ msgstr ""
 "Licensa: MaxMind GeoLite2 EULA - https://www.maxmind.com/en/geolite2/eula\n"
 "Requer atribuição e registro de conta; renove no mínimo a cada 30 dias."
 
-#: src/muuli_wdr.cpp:2915
+#: src/muuli_wdr.cpp:2919
 msgid "Download URL:"
 msgstr "URL de Download:"
 
-#: src/muuli_wdr.cpp:2921
+#: src/muuli_wdr.cpp:2925
 msgid ""
 "Must point to an .mmdb file or a .gz / .tar.gz containing one.\n"
 "URL may include credentials (https://user:pass@host/...).\n"
@@ -4895,211 +4895,211 @@ msgstr ""
 "A URL pode incluir credenciais (https://user:pass@host/...).\n"
 "License e termos de atribuição são realizados pela URL upstream - você é responsável."
 
-#: src/muuli_wdr.cpp:2934
+#: src/muuli_wdr.cpp:2938
 msgid "Download the GeoIP database from the selected source."
 msgstr "Baixe o banco de dados GeoIP da fonte selecionada."
 
-#: src/muuli_wdr.cpp:2936
+#: src/muuli_wdr.cpp:2940
 msgid "Auto-update on startup"
 msgstr "Auto-atualizar ao iniciar"
 
-#: src/muuli_wdr.cpp:2937
+#: src/muuli_wdr.cpp:2941
 msgid "Re-download the GeoIP database from the selected source every time aMule starts."
 msgstr "Baixe novamente o banco de dados GeoIP da fonte selecionada toda vez que o aMule iniciar."
 
-#: src/muuli_wdr.cpp:2960
+#: src/muuli_wdr.cpp:2964
 msgid "Filter incoming messages (except current chat):"
 msgstr "Filtrar mensagens (Exceto chat atual):"
 
-#: src/muuli_wdr.cpp:2962
+#: src/muuli_wdr.cpp:2966
 msgid "Filter all messages"
 msgstr "Filtrar todas as mensagens"
 
-#: src/muuli_wdr.cpp:2964
+#: src/muuli_wdr.cpp:2968
 msgid "Filter messages from people not on your friend list"
 msgstr "Filtrar mensagens de pessoas que não estão em sua lista"
 
-#: src/muuli_wdr.cpp:2966
+#: src/muuli_wdr.cpp:2970
 msgid "Filter messages from unknown clients"
 msgstr "Filtrar mensagens de clientes desconhecidos"
 
-#: src/muuli_wdr.cpp:2968
+#: src/muuli_wdr.cpp:2972
 msgid "Filter messages containing (use ',' as separator):"
 msgstr "Filtrar mensagens contendo (use ',' como separador):"
 
-#: src/muuli_wdr.cpp:2971 src/muuli_wdr.cpp:2982
+#: src/muuli_wdr.cpp:2975 src/muuli_wdr.cpp:2986
 msgid "add here the words amule should filter and block messages including it"
 msgstr "adicione aqui as palavras que o amule deve filtrar e bloquear nas mensagens"
 
-#: src/muuli_wdr.cpp:2973
+#: src/muuli_wdr.cpp:2977
 msgid "Show received messages in the log"
 msgstr "Mostrar mensagens recebidas no log"
 
-#: src/muuli_wdr.cpp:2976
+#: src/muuli_wdr.cpp:2980
 msgid "Comments"
 msgstr "Comentários"
 
-#: src/muuli_wdr.cpp:2979
+#: src/muuli_wdr.cpp:2983
 msgid "Filter comments containing (use ',' as separator):"
 msgstr "Filtrar comentários contendo (use '.' como separador):"
 
-#: src/muuli_wdr.cpp:3004
+#: src/muuli_wdr.cpp:3008
 msgid "Enable Proxy"
 msgstr "Ativar proxy"
 
-#: src/muuli_wdr.cpp:3005
+#: src/muuli_wdr.cpp:3009
 msgid "Enable/disable proxy support"
 msgstr "Ativa/desativa suporte a proxy"
 
-#: src/muuli_wdr.cpp:3008
+#: src/muuli_wdr.cpp:3012
 msgid "Proxy type:"
 msgstr "Tipo de proxy:"
 
-#: src/muuli_wdr.cpp:3019
+#: src/muuli_wdr.cpp:3023
 msgid "Proxy host:"
 msgstr "Host do Proxy:"
 
-#: src/muuli_wdr.cpp:3022
+#: src/muuli_wdr.cpp:3026
 msgid "The proxy host name"
 msgstr "Nome do Host do proxy"
 
-#: src/muuli_wdr.cpp:3024
+#: src/muuli_wdr.cpp:3028
 msgid "Proxy port:"
 msgstr "Porta do Proxy:"
 
-#: src/muuli_wdr.cpp:3027
+#: src/muuli_wdr.cpp:3031
 msgid "The proxy port"
 msgstr "Porta do Proxy"
 
-#: src/muuli_wdr.cpp:3029
+#: src/muuli_wdr.cpp:3033
 msgid "Enable authentication"
 msgstr "Ativar autenticação"
 
-#: src/muuli_wdr.cpp:3030
+#: src/muuli_wdr.cpp:3034
 msgid "Enable/disable username/password authentication"
 msgstr "Ativa/Desativa autenticação por usuário/senha"
 
-#: src/muuli_wdr.cpp:3033
+#: src/muuli_wdr.cpp:3037
 msgid "Username: "
 msgstr "Nome do usuário: "
 
-#: src/muuli_wdr.cpp:3036
+#: src/muuli_wdr.cpp:3040
 msgid "The username to use to connect to the proxy"
 msgstr "Nome do usuário para conectar ao proxy"
 
-#: src/muuli_wdr.cpp:3038
+#: src/muuli_wdr.cpp:3042
 msgid "Password:"
 msgstr "Senha:"
 
-#: src/muuli_wdr.cpp:3041
+#: src/muuli_wdr.cpp:3045
 msgid "The password to use to connect to the proxy"
 msgstr "Senha utilizada para conectar ao proxy"
 
-#: src/muuli_wdr.cpp:3060
+#: src/muuli_wdr.cpp:3064
 msgid "Connect to:"
 msgstr "Conectar em:"
 
-#: src/muuli_wdr.cpp:3069
+#: src/muuli_wdr.cpp:3073
 msgid "Login to remote amule"
 msgstr "Fazer login em amule remoto"
 
-#: src/muuli_wdr.cpp:3074
+#: src/muuli_wdr.cpp:3078
 msgid "User name"
 msgstr "Usuário"
 
-#: src/muuli_wdr.cpp:3085
+#: src/muuli_wdr.cpp:3089
 msgid "Remember those settings"
 msgstr "Lembrar essas definições"
 
-#: src/muuli_wdr.cpp:3088
+#: src/muuli_wdr.cpp:3092
 msgid "Force ZLIB compression"
 msgstr "Força compressão ZLIB"
 
-#: src/muuli_wdr.cpp:3112
+#: src/muuli_wdr.cpp:3116
 msgid "Enable Verbose Debug-Logging."
 msgstr "Ativar log de debug detalhado."
 
-#: src/muuli_wdr.cpp:3114
+#: src/muuli_wdr.cpp:3118
 msgid "Only to Logfile"
 msgstr "Apenas para o arquivo de log"
 
-#: src/muuli_wdr.cpp:3116
+#: src/muuli_wdr.cpp:3120
 msgid "Message Categories:"
 msgstr "Categorias de Mensagens:"
 
-#: src/muuli_wdr.cpp:3140 src/PartFileConvertDlg.cpp:160
+#: src/muuli_wdr.cpp:3144 src/PartFileConvertDlg.cpp:160
 msgid "Waiting..."
 msgstr "Aguardando..."
 
-#: src/muuli_wdr.cpp:3160
+#: src/muuli_wdr.cpp:3164
 msgid "Add imports"
 msgstr "Adicionar importadas"
 
-#: src/muuli_wdr.cpp:3163
+#: src/muuli_wdr.cpp:3167
 msgid "Retry selected"
 msgstr "Tentar novamente selecionada"
 
-#: src/muuli_wdr.cpp:3165
+#: src/muuli_wdr.cpp:3169
 msgid "Remove selected"
 msgstr "Remover selecionada"
 
-#: src/muuli_wdr.cpp:3228
+#: src/muuli_wdr.cpp:3232
 msgid "Event Types"
 msgstr "Tipos de Eventos"
 
-#: src/muuli_wdr.cpp:3247
+#: src/muuli_wdr.cpp:3251
 msgid "Statistics and queued clients for selected file(s) : Session / All time"
 msgstr "Estatísticas e filas de clientes para arquivo(s) selecionado(s) : Sessão / Sempre"
 
-#: src/muuli_wdr.cpp:3271
+#: src/muuli_wdr.cpp:3275
 msgid "Active Uploads"
 msgstr "Uploads Ativos"
 
-#: src/muuli_wdr.cpp:3285
+#: src/muuli_wdr.cpp:3289
 msgid "Percent of total files"
 msgstr "Porcentagem de total de arquivos"
 
-#: src/muuli_wdr.cpp:3337
+#: src/muuli_wdr.cpp:3341
 msgid "Show Clients for"
 msgstr "Exibir Clientes para"
 
-#: src/muuli_wdr.cpp:3339
+#: src/muuli_wdr.cpp:3343
 msgid "All files"
 msgstr "Todos os arquivos"
 
-#: src/muuli_wdr.cpp:3342
+#: src/muuli_wdr.cpp:3346
 msgid "Selected files"
 msgstr "Arquivos selecionados"
 
-#: src/muuli_wdr.cpp:3345
+#: src/muuli_wdr.cpp:3349
 msgid "Active uploads only"
 msgstr "Somente uploads ativos"
 
-#: src/muuli_wdr.cpp:3352
+#: src/muuli_wdr.cpp:3356
 msgid "Reload:"
 msgstr "Recarregar:"
 
-#: src/muuli_wdr.cpp:3356
+#: src/muuli_wdr.cpp:3360
 msgid "Reload your shared files"
 msgstr "Atualizar lista de compartilhados"
 
-#: src/muuli_wdr.cpp:3419
+#: src/muuli_wdr.cpp:3423
 msgid "Send"
 msgstr "Enviar"
 
-#: src/muuli_wdr.cpp:3420
+#: src/muuli_wdr.cpp:3424
 msgid "Sends the specified message."
 msgstr "Enviar a mensagem especificada."
 
-#: src/muuli_wdr.cpp:3424
+#: src/muuli_wdr.cpp:3428
 msgid "Close this chat-session."
 msgstr "Encerrar sessão de Chat."
 
-#: src/muuli_wdr.cpp:3447
+#: src/muuli_wdr.cpp:3451
 msgid "Connect to any server and/or Kad"
 msgstr "Conectar a qualquer servidor e/ou Kad"
 
-#: src/muuli_wdr.cpp:3453 src/SharedFilesCtrl.cpp:142 src/Statistics.cpp:941
+#: src/muuli_wdr.cpp:3457 src/SharedFilesCtrl.cpp:142 src/Statistics.cpp:941
 msgid "Shared Files"
 msgstr "Arquivos Compartilhados"
 
@@ -5734,35 +5734,35 @@ msgstr ""
 "O aMule funciona corretamente sem qualquer tipo de\n"
 "alteração nessas opções."
 
-#: src/PrefsUnifiedDlg.cpp:647
+#: src/PrefsUnifiedDlg.cpp:656
 #, c-format
 msgid "Failed to connect Cfg to widget with the ID %d and key %s"
 msgstr "Falha ao conectar Cfg para Widget com o ID %d e senha %s"
 
-#: src/PrefsUnifiedDlg.cpp:695
+#: src/PrefsUnifiedDlg.cpp:704
 #, c-format
 msgid "Failed to transfer data from Cfg to Widget with the ID %d and key %s"
 msgstr "Falha ao transferir dado do Cfg para Widget com o ID %d e senha %s"
 
-#: src/PrefsUnifiedDlg.cpp:801
+#: src/PrefsUnifiedDlg.cpp:810
 msgid "The type of proxy you are connecting to"
 msgstr "Tipo de proxy ao qual você está conectado"
 
-#: src/PrefsUnifiedDlg.cpp:1020
+#: src/PrefsUnifiedDlg.cpp:1029
 #, c-format
 msgid "Failed to transfer data from Widget to Cfg with the ID %d and key %s"
 msgstr "Falha ao transferir dado do Widget para Cfg com o ID %d e senha %s"
 
-#: src/PrefsUnifiedDlg.cpp:1103
+#: src/PrefsUnifiedDlg.cpp:1112
 #, fuzzy
 msgid "No password set."
 msgstr "Senha de administração"
 
-#: src/PrefsUnifiedDlg.cpp:1132
+#: src/PrefsUnifiedDlg.cpp:1141
 msgid "Guest access needs a password. Type one in the guest password field, or untick Enable guest access."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1144
+#: src/PrefsUnifiedDlg.cpp:1153
 msgid ""
 "aMule must be restarted to enable these changes:\n"
 "\n"
@@ -5770,39 +5770,39 @@ msgstr ""
 "O aMule deve ser reiniciado para habilitar estas mudanças:\n"
 "\n"
 
-#: src/PrefsUnifiedDlg.cpp:1151
+#: src/PrefsUnifiedDlg.cpp:1160
 msgid "- TCP port changed.\n"
 msgstr "-Porta TCP alterada.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1156
+#: src/PrefsUnifiedDlg.cpp:1165
 msgid "- UDP port changed.\n"
 msgstr "-Porta UDP alterada.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1161
+#: src/PrefsUnifiedDlg.cpp:1170
 msgid "- Network interface binding changed.\n"
 msgstr "- Interface de conexão de rede modificada.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1166
+#: src/PrefsUnifiedDlg.cpp:1175
 msgid "- External connect port changed.\n"
 msgstr "- Porta de conexão externa modificada.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1170
+#: src/PrefsUnifiedDlg.cpp:1179
 msgid "- External connect acceptance changed.\n"
 msgstr "- Aceitação da conexão externa modificada.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1174
+#: src/PrefsUnifiedDlg.cpp:1183
 msgid "- External connect interface changed.\n"
 msgstr "- Interface de conexão externa modificada.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1178
+#: src/PrefsUnifiedDlg.cpp:1187
 msgid "- Protocol obfuscation support changed.\n"
 msgstr "- Suporte de protocolo de ofuscamento mudou.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1193
+#: src/PrefsUnifiedDlg.cpp:1202
 msgid "- amuleapi settings changed.\n"
 msgstr "- A configuração do amuleapi mudou.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1202
+#: src/PrefsUnifiedDlg.cpp:1211
 msgid ""
 "Your Auto-update server list is empty.\n"
 "'Auto-update server list at startup' will be disabled."
@@ -5810,7 +5810,7 @@ msgstr ""
 "Sua lista de Auto-atualização de servidor está vazia.\n"
 "'Auto-atualização de servidor na iniciação' será desativada."
 
-#: src/PrefsUnifiedDlg.cpp:1213
+#: src/PrefsUnifiedDlg.cpp:1222
 msgid ""
 "You have enabled external connections but have not specified a password.\n"
 "External connections cannot be enabled unless a valid password is specified."
@@ -5818,32 +5818,32 @@ msgstr ""
 "Você ativou as conexões externas mas não definiu uma senha.\n"
 "Conexões Externas só podem ser feitas se for especificada uma senha válida."
 
-#: src/PrefsUnifiedDlg.cpp:1246
+#: src/PrefsUnifiedDlg.cpp:1255
 #, c-format
 msgid "The amuleapi password could not be saved: %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1276
+#: src/PrefsUnifiedDlg.cpp:1285
 msgid "- Language changed.\n"
 msgstr "-Idioma alterado.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1281
+#: src/PrefsUnifiedDlg.cpp:1290
 msgid "- Temp folder changed.\n"
 msgstr "-Diretório temporário alterado.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1286
+#: src/PrefsUnifiedDlg.cpp:1295
 msgid "- ED2K network enabled.\n"
 msgstr "- Rede ED2K conectada.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1319
+#: src/PrefsUnifiedDlg.cpp:1328
 msgid "The shared-file exclusion pattern is not a valid regular expression. The filter has been left disabled."
 msgstr "Este padrão de exclusão de arquivos compartilhados não é uma expressão regular válida. O filtro ficou desabilitado."
 
-#: src/PrefsUnifiedDlg.cpp:1321 src/PrefsUnifiedDlg.cpp:1921
+#: src/PrefsUnifiedDlg.cpp:1330 src/PrefsUnifiedDlg.cpp:1930
 msgid "Invalid regular expression"
 msgstr "Expressão regular inválida"
 
-#: src/PrefsUnifiedDlg.cpp:1398
+#: src/PrefsUnifiedDlg.cpp:1407
 msgid ""
 "Both eD2k and Kad network are disabled.\n"
 "You won't be able to connect until you enable at least one of them."
@@ -5851,7 +5851,7 @@ msgstr ""
 "Ambas rede eD2k e Kad estão desativadas.\n"
 "Você não será capaz de conectar senão habilitar pelo menos um deles."
 
-#: src/PrefsUnifiedDlg.cpp:1403
+#: src/PrefsUnifiedDlg.cpp:1412
 msgid ""
 "Kad will not start if your UDP port is disabled.\n"
 "Enable UDP port or disable Kad."
@@ -5859,7 +5859,7 @@ msgstr ""
 "Kad não iniciará se sua porta UDP estiver desabilitada.\n"
 "Habilite a porta UDP ou desative a rede Kad."
 
-#: src/PrefsUnifiedDlg.cpp:1459
+#: src/PrefsUnifiedDlg.cpp:1468
 msgid ""
 "\n"
 "You MUST restart aMule now.\n"
@@ -5869,68 +5869,68 @@ msgstr ""
 "Você DEVE reiniciar o aMule agora.\n"
 "Se você não reiniciá-lo agora, não reclame se algo de ruim acontecer.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1524
+#: src/PrefsUnifiedDlg.cpp:1533
 msgid "Could not register aMule for autostart at login. The autostart store may be read-only."
 msgstr "Não foi possível registrar o aMule para início automático no login. A lista de autostart pode estar como apenas leitura."
 
-#: src/PrefsUnifiedDlg.cpp:1526
+#: src/PrefsUnifiedDlg.cpp:1535
 msgid "Could not remove the autostart-at-login entry."
 msgstr "Não foi possível remover a entrada de início automático no login."
 
-#: src/PrefsUnifiedDlg.cpp:1527
+#: src/PrefsUnifiedDlg.cpp:1536
 msgid "Autostart"
 msgstr "Início automático"
 
-#: src/PrefsUnifiedDlg.cpp:1542
+#: src/PrefsUnifiedDlg.cpp:1551
 msgid "Register file type"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1542
+#: src/PrefsUnifiedDlg.cpp:1551
 msgid "Register URL handler"
 msgstr "Registrar manipulador de URL"
 
-#: src/PrefsUnifiedDlg.cpp:1550
+#: src/PrefsUnifiedDlg.cpp:1559
 #, c-format
 msgid "aMule only handles eD2k-compatible magnets. If you replace the current magnet handler (%s), BitTorrent magnet links will stop working - aMule cannot download BitTorrent content. Continue?"
 msgstr "O aMule lida apenas com links magnet compatíveis com eD2k. Se você trocar o manipulador atual (%s), links magnet deBitTorrent irão parar de funcionar - o aMule não pode baixar conteúdo BitTorrent. Continuar?"
 
-#: src/PrefsUnifiedDlg.cpp:1555
+#: src/PrefsUnifiedDlg.cpp:1564
 #, fuzzy, c-format
 msgid "Another application currently opens .emulecollection files (%s). Replace it with aMule?"
 msgstr "Atualmente um outro aplicativo é o manipulador padrão para estes links (%s). Troco ele pelo aMule?"
 
-#: src/PrefsUnifiedDlg.cpp:1560
+#: src/PrefsUnifiedDlg.cpp:1569
 #, c-format
 msgid "Another application is currently the default handler for these links (%s). Replace it with aMule?"
 msgstr "Atualmente um outro aplicativo é o manipulador padrão para estes links (%s). Troco ele pelo aMule?"
 
-#: src/PrefsUnifiedDlg.cpp:1585
+#: src/PrefsUnifiedDlg.cpp:1594
 #, fuzzy
 msgid "Could not register aMule for .emulecollection files. The registration store may be read-only."
 msgstr "Não foi possível registrar o aMule como manipulador de URL. O armazenamento deve estar como \"apenas leitura\"."
 
-#: src/PrefsUnifiedDlg.cpp:1587
+#: src/PrefsUnifiedDlg.cpp:1596
 #, fuzzy
 msgid "Could not remove the file type registration."
 msgstr "Não foi possível remover o registro de manipulação de URL."
 
-#: src/PrefsUnifiedDlg.cpp:1589
+#: src/PrefsUnifiedDlg.cpp:1598
 msgid "Could not register aMule as the URL handler. The registration store may be read-only."
 msgstr "Não foi possível registrar o aMule como manipulador de URL. O armazenamento deve estar como \"apenas leitura\"."
 
-#: src/PrefsUnifiedDlg.cpp:1591
+#: src/PrefsUnifiedDlg.cpp:1600
 msgid "Could not remove the URL handler registration."
 msgstr "Não foi possível remover o registro de manipulação de URL."
 
-#: src/PrefsUnifiedDlg.cpp:1661 src/PrefsUnifiedDlg.cpp:1688
+#: src/PrefsUnifiedDlg.cpp:1670 src/PrefsUnifiedDlg.cpp:1697
 msgid "The web server and aMule API require external connections to be enabled."
 msgstr "O servidor web e o aMule API necessitam que as conexões externas estejam habilitadas."
 
-#: src/PrefsUnifiedDlg.cpp:1671
+#: src/PrefsUnifiedDlg.cpp:1680
 msgid "The aMule web server is deprecated. Consider running the aMule API instead."
 msgstr "O servidor web do aMules está deprecado. Ao invés disso, considere rodar sob a API do aMule."
 
-#: src/PrefsUnifiedDlg.cpp:1735
+#: src/PrefsUnifiedDlg.cpp:1744
 msgid ""
 "Your Auto-update servers list is in blank.\n"
 "Please fill in at least one URL to point to a valid server.met file.\n"
@@ -5940,64 +5940,64 @@ msgstr ""
 "Coloque pelo menos uma linha que aponte para um server.met válido.\n"
 "Clique no botão \"Lista\" para abrir a caixa para digitar uma URL."
 
-#: src/PrefsUnifiedDlg.cpp:1876
+#: src/PrefsUnifiedDlg.cpp:1885
 msgid "Temporary files"
 msgstr "Arquivos Temporários"
 
-#: src/PrefsUnifiedDlg.cpp:1881
+#: src/PrefsUnifiedDlg.cpp:1890
 msgid "Incoming files"
 msgstr "Arquivos Recebidos"
 
-#: src/PrefsUnifiedDlg.cpp:1886
+#: src/PrefsUnifiedDlg.cpp:1895
 msgid "Online Signatures"
 msgstr "Assinatura Online"
 
-#: src/PrefsUnifiedDlg.cpp:1899
+#: src/PrefsUnifiedDlg.cpp:1908
 #, c-format
 msgid "Choose a folder for %s"
 msgstr "Escolha uma pasta para %s"
 
-#: src/PrefsUnifiedDlg.cpp:1923
+#: src/PrefsUnifiedDlg.cpp:1932
 #, c-format
 msgid "Would exclude %u of %u shared file"
 msgid_plural "Would exclude %u of %u shared files"
 msgstr[0] "Iria excluir %u de %u arquivo compartilhado"
 msgstr[1] "Iria excluir %u de %u arquivos compartilhados"
 
-#: src/PrefsUnifiedDlg.cpp:1940
+#: src/PrefsUnifiedDlg.cpp:1949
 msgid "Browse for videoplayer"
 msgstr "Defina seu Player de Vídeo preferido"
 
-#: src/PrefsUnifiedDlg.cpp:1944
+#: src/PrefsUnifiedDlg.cpp:1953
 msgid "Select browser"
 msgstr "Selecione o Browser"
 
-#: src/PrefsUnifiedDlg.cpp:1948
+#: src/PrefsUnifiedDlg.cpp:1957
 msgid "Select ffprobe binary"
 msgstr "Selecione o binário ffprobe"
 
-#: src/PrefsUnifiedDlg.cpp:1954
+#: src/PrefsUnifiedDlg.cpp:1963
 #, c-format
 msgid "Executable%s"
 msgstr "Executável%s"
 
-#: src/PrefsUnifiedDlg.cpp:1988
+#: src/PrefsUnifiedDlg.cpp:1997
 msgid "ffprobe not found on PATH or in the standard install locations. Install ffmpeg (which ships ffprobe) or use Browse to pick a binary manually."
 msgstr "O ffprobe não foi encontrado no PATH ou nos locais padronizados de instalação. Instale o ffmpeg (que traz junto o ffprobe) ou use Browse para escolher um binário manualmente."
 
-#: src/PrefsUnifiedDlg.cpp:2000
+#: src/PrefsUnifiedDlg.cpp:2009
 msgid "Reset the settings on this page to their default values?"
 msgstr "Resetar as configurações nesta página para seus valores padrão?"
 
-#: src/PrefsUnifiedDlg.cpp:2001
+#: src/PrefsUnifiedDlg.cpp:2010
 msgid "Reset to defaults"
 msgstr "Resetar para os valores padrão"
 
-#: src/PrefsUnifiedDlg.cpp:2028
+#: src/PrefsUnifiedDlg.cpp:2037
 msgid "Edit server list"
 msgstr "Editar lista de servidores"
 
-#: src/PrefsUnifiedDlg.cpp:2029
+#: src/PrefsUnifiedDlg.cpp:2038
 msgid ""
 "Add here URL's to download server.met files.\n"
 "Only one url on each line."
@@ -6005,114 +6005,114 @@ msgstr ""
 "Adicione aqui URL's para baixar arquivo 'server.met'\n"
 "Somente uma URL por Linha."
 
-#: src/PrefsUnifiedDlg.cpp:2084
+#: src/PrefsUnifiedDlg.cpp:2093
 msgid "IP2Country update failed"
 msgstr "Falha ao atualizar IP2Country"
 
-#: src/PrefsUnifiedDlg.cpp:2229 src/PrefsUnifiedDlg.cpp:2260
+#: src/PrefsUnifiedDlg.cpp:2238 src/PrefsUnifiedDlg.cpp:2269
 msgid "Data by MaxMind GeoLite2"
 msgstr "Dados por MaxMind GeoLite2"
 
-#: src/PrefsUnifiedDlg.cpp:2231 src/PrefsUnifiedDlg.cpp:2262
+#: src/PrefsUnifiedDlg.cpp:2240 src/PrefsUnifiedDlg.cpp:2271
 msgid "Custom source"
 msgstr "Fonte customizada"
 
-#: src/PrefsUnifiedDlg.cpp:2233 src/PrefsUnifiedDlg.cpp:2264
+#: src/PrefsUnifiedDlg.cpp:2242 src/PrefsUnifiedDlg.cpp:2273
 msgid "Data by DB-IP.com"
 msgstr "Dados por DB-IP.com"
 
-#: src/PrefsUnifiedDlg.cpp:2284
+#: src/PrefsUnifiedDlg.cpp:2293
 #, c-format
 msgid "Status: Loaded%s"
 msgstr "Status: %s carregados"
 
-#: src/PrefsUnifiedDlg.cpp:2286
+#: src/PrefsUnifiedDlg.cpp:2295
 #, c-format
 msgid "Status: Loaded%s - %s"
 msgstr "Status: %s - %s carregados"
 
-#: src/PrefsUnifiedDlg.cpp:2290
+#: src/PrefsUnifiedDlg.cpp:2299
 msgid "Status: Failed to load - click 'Update now' to refresh."
 msgstr "Estado: Falha ao carregar - clique 'Atualizar agora' para refrescar."
 
-#: src/PrefsUnifiedDlg.cpp:2292
+#: src/PrefsUnifiedDlg.cpp:2301
 msgid "Status: Not found - click 'Update now' to download."
 msgstr "Estado: Não encontrado - clique 'Atualizar agora' para baixar."
 
-#: src/PrefsUnifiedDlg.cpp:2350 src/PrefsUnifiedDlg.cpp:2374
+#: src/PrefsUnifiedDlg.cpp:2359 src/PrefsUnifiedDlg.cpp:2383
 #, c-format
 msgid "Update delay: %d second"
 msgid_plural "Update delay: %d seconds"
 msgstr[0] "Delay na atualização: %d segundo"
 msgstr[1] "Delay na atualização: %d segundos"
 
-#: src/PrefsUnifiedDlg.cpp:2358
+#: src/PrefsUnifiedDlg.cpp:2367
 #, c-format
 msgid "Time for average graph: %d minute"
 msgid_plural "Time for average graph: %d minutes"
 msgstr[0] "Tempo do gráfico de média: %d minuto"
 msgstr[1] "Tempo do gráfico de média: %d minutos"
 
-#: src/PrefsUnifiedDlg.cpp:2367
+#: src/PrefsUnifiedDlg.cpp:2376
 #, c-format
 msgid "Connections Graph Scale: %d"
 msgstr "Escala do gráfico de conexões: %d"
 
-#: src/PrefsUnifiedDlg.cpp:2382
+#: src/PrefsUnifiedDlg.cpp:2391
 #, c-format
 msgid "File Buffer Size: %d byte"
 msgid_plural "File Buffer Size: %d bytes"
 msgstr[0] "Tamanho do Buffer de Arquivo: %d byte"
 msgstr[1] "Tamanho do Buffer de Arquivo: %d bytes"
 
-#: src/PrefsUnifiedDlg.cpp:2392
+#: src/PrefsUnifiedDlg.cpp:2401
 #, c-format
 msgid "Upload Queue Size: %d client"
 msgid_plural "Upload Queue Size: %d clients"
 msgstr[0] "Tamanho de Espera de Upload: %d cliente"
 msgstr[1] "Tamanho de Espera de Upload: %d clientes"
 
-#: src/PrefsUnifiedDlg.cpp:2402
+#: src/PrefsUnifiedDlg.cpp:2411
 #, c-format
 msgid "Server connection refresh interval: %d minute"
 msgid_plural "Server connection refresh interval: %d minutes"
 msgstr[0] "Atualizar conexão com servidor: %d minuto"
 msgstr[1] "Atualizar conexão com servidor: %d minutos"
 
-#: src/PrefsUnifiedDlg.cpp:2407
+#: src/PrefsUnifiedDlg.cpp:2416
 msgid "Server connection refresh interval: Disabled"
 msgstr "Intervalo para atualizar conexão no servidor: Desativado"
 
-#: src/PrefsUnifiedDlg.cpp:2451
+#: src/PrefsUnifiedDlg.cpp:2460
 msgid "disabled"
 msgstr "desativado"
 
-#: src/PrefsUnifiedDlg.cpp:2477
+#: src/PrefsUnifiedDlg.cpp:2486
 #, c-format
 msgid "Execute command on '%s' event"
 msgstr "Executar comando em evento '%s'"
 
-#: src/PrefsUnifiedDlg.cpp:2484
+#: src/PrefsUnifiedDlg.cpp:2493
 msgid "Enable command execution on core"
 msgstr "Habilitar execução de comando no núcleo"
 
-#: src/PrefsUnifiedDlg.cpp:2496
+#: src/PrefsUnifiedDlg.cpp:2505
 msgid "Core command:"
 msgstr "Comando do Núcleo:"
 
-#: src/PrefsUnifiedDlg.cpp:2512
+#: src/PrefsUnifiedDlg.cpp:2521
 msgid "Enable command execution on GUI"
 msgstr "Habilitar execução de comando na GUI"
 
-#: src/PrefsUnifiedDlg.cpp:2524
+#: src/PrefsUnifiedDlg.cpp:2533
 msgid "GUI command:"
 msgstr "Comando da GUI:"
 
-#: src/PrefsUnifiedDlg.cpp:2540
+#: src/PrefsUnifiedDlg.cpp:2549
 msgid "The following variables will be replaced:"
 msgstr "As seguinte variáveis serão substituídas:"
 
-#: src/PrefsUnifiedDlg.cpp:2708
+#: src/PrefsUnifiedDlg.cpp:2717
 msgid ""
 "The following folders look like system or sensitive locations:\n"
 "\n"
@@ -6120,37 +6120,37 @@ msgstr ""
 "As seguintes pastas parecem ser de sistema ou locais sensíveis:\n"
 "\n"
 
-#: src/PrefsUnifiedDlg.cpp:2713
+#: src/PrefsUnifiedDlg.cpp:2722
 msgid "Sharing them recursively will publish every file underneath on the eD2k/Kad networks. Do you really want to do this?"
 msgstr "Compartilha-los recursivamente vai publicar todos os arquivos sob as redes eD2k/Kad. Você realmente quer isto?"
 
-#: src/PrefsUnifiedDlg.cpp:2716
+#: src/PrefsUnifiedDlg.cpp:2725
 msgid "Confirm shared folders"
 msgstr "Confirma pastas compartilhadas"
 
-#: src/PrefsUnifiedDlg.cpp:2744
+#: src/PrefsUnifiedDlg.cpp:2753
 msgid "Reloading shared files..."
 msgstr "Recarregando lista de arquivos compartilhados..."
 
-#: src/PrefsUnifiedDlg.cpp:2745
+#: src/PrefsUnifiedDlg.cpp:2754
 msgid "Scanning for subdirectories..."
 msgstr "Procurando por subdiretórios..."
 
-#: src/PrefsUnifiedDlg.cpp:2746
+#: src/PrefsUnifiedDlg.cpp:2755
 msgid "Updating shared folders"
 msgstr "Atualizando pastas compartilhadas"
 
-#: src/PrefsUnifiedDlg.cpp:2773
+#: src/PrefsUnifiedDlg.cpp:2782
 #, c-format
 msgid "Scanned %u directories..."
 msgstr "Varridos %u diretórios..."
 
-#: src/PrefsUnifiedDlg.cpp:2823
+#: src/PrefsUnifiedDlg.cpp:2832
 #, c-format
 msgid "Reloading shared files: %u files scanned"
 msgstr "Recarregando arquivos compartilhados: %u arquivos encontrados"
 
-#: src/PrefsUnifiedDlg.cpp:2873
+#: src/PrefsUnifiedDlg.cpp:2882
 msgid "Shared folder"
 msgstr "Pasta compartilhada"
 
@@ -7837,12 +7837,12 @@ msgstr "Remover categoria"
 msgid "Hashset requested for unknown file: %s"
 msgstr "Hashset solicitado para arquivo desconhecido: %s"
 
-#: src/UploadQueue.cpp:618
+#: src/UploadQueue.cpp:627
 #, c-format
 msgid "Resuming uploads of file: %s"
 msgstr "Continuando uploads para o arquivo: %s"
 
-#: src/UploadQueue.cpp:634
+#: src/UploadQueue.cpp:643
 #, c-format
 msgid "Suspending upload of file: %s"
 msgstr "Suspendendo uploads para o arquivo: %s"

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -15,8 +15,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-28 12:12+0200\n"
-"PO-Revision-Date: 2026-07-27 10:31+0000\n"
+"POT-Creation-Date: 2026-07-28 08:06+0200\n"
+"PO-Revision-Date: 2026-07-27 11:43+0000\n"
 "Last-Translator: Marcelo Jimenez <mroberto@users.sourceforge.com>\n"
 "Language-Team: Português (Brasileiro) <pt@li.org>\n"
 "Language: pt_BR\n"
@@ -150,7 +150,7 @@ msgstr "Instalar"
 msgid "Not now"
 msgstr "Agora não"
 
-#: src/AppImageIntegration.cpp:422 src/amuleDlg.cpp:665
+#: src/AppImageIntegration.cpp:422 src/amuleDlg.cpp:600
 msgid "Don't ask again"
 msgstr "Não perguntar novamente"
 
@@ -212,83 +212,83 @@ msgstr "Falha ao abrir arquivo de Ligações ED2K."
 msgid "WARNING: You can't add yourself as a source for an eD2k link while having a lowid."
 msgstr "CUIDADO: Você não pode adicionar você mesmo como uma fonte para uma ligação eD2k quando tem um lowid."
 
-#: src/amule.cpp:301
+#: src/amule.cpp:300
 msgid "Now, exiting main app..."
 msgstr "Agora, deixando a aplicação principal..."
 
-#: src/amule.cpp:331
+#: src/amule.cpp:330
 #, c-format
 msgid "Terminating amuleweb instance with pid '%d' ... "
 msgstr "Terminando a instância do amuleweb com o pid '%d'... "
 
-#: src/amule.cpp:335
+#: src/amule.cpp:334
 #, c-format
 msgid "Killing amuleweb instance with pid '%d' ... "
 msgstr "Matando a instância do amuleweb com o pid '%d'... "
 
-#: src/amule.cpp:337 src/amule.cpp:350 src/ClientRef.cpp:180
-#: src/SearchDlg.cpp:1041 src/ServerListCtrl.cpp:98
+#: src/amule.cpp:336 src/amule.cpp:349 src/ClientRef.cpp:180
+#: src/SearchDlg.cpp:880 src/ServerListCtrl.cpp:98
 msgid "Failed"
 msgstr "Falha"
 
-#: src/amule.cpp:344
+#: src/amule.cpp:343
 #, c-format
 msgid "Terminating amuleapi instance with pid '%d' ... "
 msgstr "Terminando a instância do amuleweb com o pid '%d' ... "
 
-#: src/amule.cpp:348
+#: src/amule.cpp:347
 #, c-format
 msgid "Killing amuleapi instance with pid '%d' ... "
 msgstr "Matando a instância do amuleapi com o pid '%d'... "
 
-#: src/amule.cpp:356
+#: src/amule.cpp:355
 msgid "aMule OnExit: Terminating core."
 msgstr "aMule OnExit: Finalizando o núcleo."
 
-#: src/amule.cpp:467
+#: src/amule.cpp:466
 msgid "aMule shutdown completed."
 msgstr "Encerramento do aMule completo."
 
-#: src/amule.cpp:471
+#: src/amule.cpp:470
 msgid "Memory debug results for aMule exit:"
 msgstr "Resultados da depuração da memória para a saída do aMule:"
 
-#: src/amule.cpp:652
+#: src/amule.cpp:651
 #, c-format
 msgid "Binding aMule's peer-to-peer traffic to interface: %s (HTTP updates use the default route)"
 msgstr "Conectando o tráfego par-a-par do aMule para a interface: %s (atualizações via HTTP usam a rota padrão)"
 
-#: src/amule.cpp:656
+#: src/amule.cpp:655
 #, c-format
 msgid "Binding all network traffic to interface: %s"
 msgstr "Canectando todo o tráfego de rede à interface: %s"
 
-#: src/amule.cpp:660
+#: src/amule.cpp:659
 #, c-format
 msgid "WARNING: configured network interface '%s' was not found - traffic is NOT bound to it and may leave via the default route. Check the interface name in Preferences."
 msgstr "AVISO: a interface de rede configurada '%s' não foi encontrada - o tráfego não está conectado a ela e pode sair pela rota padrão. Confira o nome da interface em Preferências."
 
-#: src/amule.cpp:666
+#: src/amule.cpp:665
 #, c-format
 msgid "WARNING: binding to network interface '%s' requires elevated privileges and was NOT applied - traffic may leave via the default route. Grant the capability (e.g. 'sudo setcap cap_net_raw+ep' on the aMule binary) or run with sufficient privileges."
 msgstr "AVISO: para conectar-se à interface de rede '%s' são necessários privilégios elevados e NÃO FOI aplicado - o tráfego pode sair pela rota padrão. Condeda a capacidade (e.g. 'sudo setcap cap_net_raw+ep') ao binário do aMule ou rode-o com privilégios suficientes."
 
-#: src/amule.cpp:674
+#: src/amule.cpp:673
 #, c-format
 msgid "WARNING: could not bind to network interface '%s' - traffic may leave via the default route."
 msgstr "AVISO: não foi possível conectar-se à interface de rede '%s' - o tráfego pode sair pela rota padrão."
 
-#: src/amule.cpp:733
+#: src/amule.cpp:732
 msgid "Your locale has been changed to System Default due to a configuration change. Sorry."
 msgstr "Seu locale foi alterado para o padrão do Sistema devido a mudança na configuração. Desculpe."
 
-#: src/amule.cpp:735 src/amule.cpp:1589 src/CatDialog.cpp:128
+#: src/amule.cpp:734 src/amule.cpp:1581 src/CatDialog.cpp:128
 #: src/CatDialog.cpp:136 src/CatDialog.cpp:149 src/ServerList.cpp:366
 #: src/ServerListCtrl.cpp:152
 msgid "Info"
 msgstr "Info"
 
-#: src/amule.cpp:742
+#: src/amule.cpp:741
 msgid ""
 "\n"
 "EC configuration"
@@ -296,20 +296,20 @@ msgstr ""
 "\n"
 "Configuração EC"
 
-#: src/amule.cpp:745
+#: src/amule.cpp:744
 msgid "Password set and external connections enabled."
 msgstr "Senha definida e conexões externas habilitadas."
 
-#: src/amule.cpp:755 src/KadDlg.cpp:176 src/KadDlg.cpp:185
-#: src/PrefsUnifiedDlg.cpp:1461 src/SharedFilesCtrl.cpp:476
+#: src/amule.cpp:754 src/KadDlg.cpp:176 src/KadDlg.cpp:185
+#: src/PrefsUnifiedDlg.cpp:1387 src/SharedFilesCtrl.cpp:476
 msgid "WARNING"
 msgstr "CUIDADO"
 
-#: src/amule.cpp:992
+#: src/amule.cpp:991
 msgid "Network bootstrap"
 msgstr "Inicialização da Rede"
 
-#: src/amule.cpp:997
+#: src/amule.cpp:996
 msgid ""
 "aMule has detected missing network bootstrap files.\n"
 "Select which ones to download:"
@@ -317,51 +317,51 @@ msgstr ""
 "O aMule detectou que faltam arquivos de inicialização da rede.\n"
 "Selecione quais baixar:"
 
-#: src/amule.cpp:1006 src/FirstRunWizard.cpp:411
+#: src/amule.cpp:1005 src/FirstRunWizard.cpp:411
 msgid "eD2k server list (server.met)"
 msgstr "Lista de servidores eD2k (server.met)"
 
-#: src/amule.cpp:1013 src/FirstRunWizard.cpp:416
+#: src/amule.cpp:1012 src/FirstRunWizard.cpp:416
 msgid "Kad bootstrap nodes (nodes.dat)"
 msgstr "Nós de inicialização de Kad"
 
-#: src/amule.cpp:1103
+#: src/amule.cpp:1102
 #, c-format
 msgid "web server running on pid %d"
 msgstr "web server rodando no pid %d"
 
-#: src/amule.cpp:1116
+#: src/amule.cpp:1115
 msgid "You requested to run web server on startup, but the amuleweb binary cannot be run. Please install the package containing aMule web server, or build aMule from source with -DBUILD_WEBSERVER=YES and install it."
 msgstr "Você pediu para rodar o servidor web na início, mas o binário do amuleweb não pode ser rodado. Por favor instale o pacote contendo o servidro web do aMule, ou compile o aMule a partir do código fonte usando -DBUILD_WEBSERVER=YES e instale-o."
 
-#: src/amule.cpp:1121 src/amule.cpp:1185 src/amule.cpp:1299 src/amule.cpp:1601
+#: src/amule.cpp:1120 src/amule.cpp:1177 src/amule.cpp:1291 src/amule.cpp:1593
 #: src/amule-remote-gui.cpp:603 src/amule-remote-gui.cpp:671
 #: src/amule-remote-gui.cpp:709 src/amule-remote-gui.cpp:1282
 #: src/amule-remote-gui.cpp:1345 src/amule-remote-gui.cpp:1372
-#: src/DownloadQueue.cpp:1481 src/PrefsUnifiedDlg.cpp:1247
+#: src/DownloadQueue.cpp:1481
 msgid "ERROR"
 msgstr "ERRO"
 
-#: src/amule.cpp:1174
+#: src/amule.cpp:1166
 #, c-format
 msgid "amuleapi running on pid %d"
 msgstr "amuleapi rodando com pid %d"
 
-#: src/amule.cpp:1180
+#: src/amule.cpp:1172
 msgid "You requested to run amuleapi on startup, but the amuleapi binary cannot be run. Please install the package containing aMule's REST API server, or build aMule from source with -DBUILD_AMULEAPI=YES and install it."
 msgstr "Você pediu para rodar o amuleapi na início, mas o binário do amuleapi não pode ser rodado. Por favor instale o pacote contendo o servidor REST API do aMule, ou compile o aMule a partir do código fonte usando -DBUILD_WEBSERVER=YES e instale-o."
 
-#: src/amule.cpp:1267
+#: src/amule.cpp:1259
 #, c-format
 msgid "Could not bind ports to the specified address: %s"
 msgstr "Não foi possível conectar às portas desse endereço: %s"
 
-#: src/amule.cpp:1291
+#: src/amule.cpp:1283
 #, c-format
 msgid "Port %u is not available. You will be LOWID\n"
 msgstr "Porta %u não disponível. Você ficará com LOWID (id baixa)\n"
 
-#: src/amule.cpp:1296
+#: src/amule.cpp:1288
 #, c-format
 msgid ""
 "Port %u is not available!\n"
@@ -376,49 +376,49 @@ msgstr ""
 "\n"
 "Verifique sua rede para ver se essa porta está aberta para entrada e saída."
 
-#: src/amule.cpp:1393
+#: src/amule.cpp:1385
 msgid "Failed to create OnlineSig File"
 msgstr "Falha ao criar o arquivo OnlineSig"
 
-#: src/amule.cpp:1401
+#: src/amule.cpp:1393
 msgid "Failed to create aMule OnlineSig File"
 msgstr "Falha ao criar o arquivo OnlineSig do aMule"
 
 # src/amuled.cpp:1246:
-#: src/amule.cpp:1564
+#: src/amule.cpp:1556
 msgid "The selected locale seems not to be installed on your box. (Note: I'll try to set it anyway)"
 msgstr "Parece que o idioma selecionado não está instalado no seu computador. (Nota: eu irei defini-lo mesmo assim)"
 
-#: src/amule.cpp:1574
+#: src/amule.cpp:1566
 #, c-format
 msgid "This is the first time you run aMule %s"
 msgstr "Essa é a primeira vez que você executa o aMule %s"
 
-#: src/amule.cpp:1577
+#: src/amule.cpp:1569
 msgid "This version is a testing version, updated daily, and\n"
 msgstr "Essa é uma versão de testes, atualizada diariamente, e\n"
 
-#: src/amule.cpp:1578
+#: src/amule.cpp:1570
 msgid "we give no warranty it won't break anything, burn your house,\n"
 msgstr "não daremos garantia se ela quebrar algo, queimar sua casa,\n"
 
-#: src/amule.cpp:1579
+#: src/amule.cpp:1571
 msgid "or kill your dog. But it *should* be safe to use anyway.\n"
 msgstr "ou matar seu cachorro. Mas ela *deve* ser segura para uso mesmo assim.\n"
 
-#: src/amule.cpp:1584
+#: src/amule.cpp:1576
 msgid "More information, support and new releases can found at our homepage,\n"
 msgstr "Maiores informações, suporte e novas versões podem ser encontradas em nossa\n"
 
-#: src/amule.cpp:1585
+#: src/amule.cpp:1577
 msgid "at https://amule-org.github.io, or in our IRC channel #aMule at irc.libera.chat.\n"
 msgstr "homepage https://amule-org.github.io ou em nosso canal de irc #aMule na irc.libera.chat.\n"
 
-#: src/amule.cpp:1587
+#: src/amule.cpp:1579
 msgid "Feel free to report any bugs to https://github.com/amule-org/amule/issues"
 msgstr "Esteja a vontade para notificar qualquer bug em https://github.com/amule-org/amule/issues"
 
-#: src/amule.cpp:1599
+#: src/amule.cpp:1591
 msgid ""
 "The folder for Online Signature files you specified is INVALID!\n"
 " OnlineSignature will be DISABLED until you fix it on preferences."
@@ -426,137 +426,137 @@ msgstr ""
 "A pasta especificada para os arquivos da Online Signature é INVÁLIDA!\n"
 "OnlineSignature ficará DESATIVADA até você atualizar as preferências."
 
-#: src/amule.cpp:1662
+#: src/amule.cpp:1654
 msgid "Server hostname notified"
 msgstr "Nome do servidor notificado"
 
-#: src/amule.cpp:2039
+#: src/amule.cpp:2031
 #, c-format
 msgid "Disk space preallocation for file '%s' failed: %s"
 msgstr "Pré-alocação de espaço em disco para arquivo '%s' falhou: %s"
 
-#: src/amule.cpp:2168
+#: src/amule.cpp:2160
 msgid "ERROR: can't open logfile"
 msgstr "ERRO: não foi possível abrir arquivo de log"
 
-#: src/amule.cpp:2172
+#: src/amule.cpp:2164
 msgid "WARNING: logfile is empty. Something is wrong."
 msgstr "AVISO: o arquivo de log está vazio. Algo está errado."
 
-#: src/amule.cpp:2189
+#: src/amule.cpp:2181
 msgid "Log has been reset"
 msgstr "Arquivo de log resetado"
 
-#: src/amule.cpp:2213
+#: src/amule.cpp:2205
 #, c-format
 msgid "ServerMessage: %s"
 msgstr "MensagemDoServidor: %s"
 
-#: src/amule.cpp:2256 src/IP2Country.cpp:220 src/IPFilter.cpp:514
+#: src/amule.cpp:2248 src/IP2Country.cpp:220 src/IPFilter.cpp:514
 #: src/ServerList.cpp:875
 #, c-format
 msgid "Skipped download of %s, because requested file is not newer."
 msgstr "Pulando o download de %s, pois o arquivo requerido não é o mais novo."
 
-#: src/amule.cpp:2259
+#: src/amule.cpp:2251
 msgid "Failed to download the nodes list."
 msgstr "Falha ao obter a lista de nodes."
 
-#: src/amule.cpp:2322
+#: src/amule.cpp:2314
 msgid "Failed to open the downloaded version check file"
 msgstr "Falha ao abrir arquivo de versão baixado"
 
-#: src/amule.cpp:2325 src/amule.cpp:2344
+#: src/amule.cpp:2317 src/amule.cpp:2336
 msgid "Corrupted version check file"
 msgstr "Arquivo de versão corrompido"
 
-#: src/amule.cpp:2367
+#: src/amule.cpp:2359
 msgid "You are using an outdated version of aMule!"
 msgstr "Você está utilizando uma versão anterior do aMule!"
 
-#: src/amule.cpp:2369
+#: src/amule.cpp:2361
 #, c-format
 msgid "Your aMule version is %i.%i.%i and the latest version is %li.%li.%li"
 msgstr "Sua versão do aMule é %i.%i.%i e a última versão é %li.%li.%li"
 
-#: src/amule.cpp:2373
+#: src/amule.cpp:2365
 msgid "The latest version can always be found at https://github.com/amule-org/amule/releases/latest"
 msgstr "A mais recente versão pode ser obtida em https://github.com/amule-org/amule/releases/latest"
 
-#: src/amule.cpp:2376
+#: src/amule.cpp:2368
 #, c-format
 msgid "WARNING: Your aMuled version is outdated: %i.%i.%i < %li.%li.%li"
 msgstr "CUIDADO: Sua versão do aMuled esta ultrapassada: %i.%i.%i < %li.%li.%li"
 
-#: src/amule.cpp:2382
+#: src/amule.cpp:2374
 msgid "Your copy of aMule is up to date."
 msgstr "Sua cópia do aMule está em dia."
 
-#: src/amule.cpp:2389
+#: src/amule.cpp:2381
 msgid "Failed to download the version check file"
 msgstr "Falha ao baixar arquivo de controle de versão"
 
-#: src/amule.cpp:2558 src/amule-remote-gui.cpp:1133
+#: src/amule.cpp:2550 src/amule-remote-gui.cpp:1133
 #, c-format
 msgid "Users: %s | Files: %s"
 msgstr "Usuários:%s | Arquivos: %s"
 
-#: src/amule.cpp:2559 src/amule-remote-gui.cpp:1134
+#: src/amule.cpp:2551 src/amule-remote-gui.cpp:1134
 #, c-format
 msgid "Users: E: %s K: %s | Files: E: %s K: %s"
 msgstr "Usuários: E: %s K: %s | Arquivos: E: %s K: %s"
 
-#: src/amule.cpp:2573 src/amule-remote-gui.cpp:1147
+#: src/amule.cpp:2565 src/amule-remote-gui.cpp:1147
 msgid "No networks selected"
 msgstr "Nenhuma rede selecionada"
 
-#: src/amule.cpp:2641 src/TextClient.cpp:903
+#: src/amule.cpp:2633 src/TextClient.cpp:903
 msgid "with LowID"
 msgstr "com LowID"
 
-#: src/amule.cpp:2641 src/TextClient.cpp:904
+#: src/amule.cpp:2633 src/TextClient.cpp:904
 msgid "with HighID"
 msgstr "com HighID (Id alta)"
 
-#: src/amule.cpp:2643
+#: src/amule.cpp:2635
 #, c-format
 msgid "Connected to %s %s"
 msgstr "Conectado a %s %s"
 
-#: src/amule.cpp:2648
+#: src/amule.cpp:2640
 #, c-format
 msgid "Connecting to %s"
 msgstr "Conectando a %s"
 
-#: src/amule.cpp:2650
+#: src/amule.cpp:2642
 msgid "Disconnected from eD2k"
 msgstr "Desconectado de eD2k"
 
-#: src/amule.cpp:2659
+#: src/amule.cpp:2651
 msgid "Kad started."
 msgstr "Kad iniciado."
 
-#: src/amule.cpp:2661
+#: src/amule.cpp:2653
 msgid "Kad stopped."
 msgstr "Kad parado."
 
-#: src/amule.cpp:2669
+#: src/amule.cpp:2661
 msgid "Connected to Kad (ok)"
 msgstr "Conectado a rede Kad (ok)"
 
-#: src/amule.cpp:2671
+#: src/amule.cpp:2663
 msgid "Connected to Kad (firewalled)"
 msgstr "Conectado a rede Kad (sob firewall)"
 
-#: src/amule.cpp:2675
+#: src/amule.cpp:2667
 msgid "Disconnected from Kad"
 msgstr "Desconectado da rede Kad"
 
-#: src/amule.cpp:2707
+#: src/amule.cpp:2699
 msgid "Kad network cannot be used if UDP port is disabled on preferences, not starting."
 msgstr "A rede Kad não pode ser usada se a porta UDP está desabilitada em preferências, não iniciará."
 
-#: src/amule.cpp:2711
+#: src/amule.cpp:2703
 msgid "Kad network disabled on preferences, not connecting."
 msgstr "A rede Kad está desabilitada em preferências, não iniciará."
 
@@ -581,67 +581,29 @@ msgstr "Incapaz Criar Arquivo Pid"
 msgid "ERROR: %s"
 msgstr "ERRO: %s"
 
-#: src/amuleDlg.cpp:250
+#: src/amuleDlg.cpp:236
 #, c-format
 msgid "This is aMule %s based on eMule."
 msgstr "Esse é o aMule %s, baseado no eMule."
 
-#: src/amuleDlg.cpp:251
+#: src/amuleDlg.cpp:237
 #, c-format
 msgid "Running on %s"
 msgstr "Executando em %s"
 
-#: src/amuleDlg.cpp:253
+#: src/amuleDlg.cpp:239
 msgid "Visit https://github.com/amule-org/amule/releases/latest to check if a new version is available."
 msgstr "Visite https://github.com/amule-org/amule/releases/latest para ver se há nova versão disponível."
 
-#: src/amuleDlg.cpp:282
+#: src/amuleDlg.cpp:268
 msgid "FATAL ERROR: Failed to create Timer"
 msgstr "ERRO FATAL: Falha ao criar Timer"
 
-#: src/amuleDlg.cpp:361 src/amuleDlg.cpp:1810 src/amuleDlg.cpp:2056
-#: src/muuli_wdr.cpp:1492 src/muuli_wdr.cpp:3439
-msgid "Networks"
-msgstr "Redes"
-
-#: src/amuleDlg.cpp:362 src/amuleDlg.cpp:1816 src/muuli_wdr.cpp:3440
-msgid "Searches"
-msgstr "Pesquisas"
-
-#: src/amuleDlg.cpp:363 src/amuleDlg.cpp:1822 src/DownloadListCtrl.cpp:740
-#: src/muuli_wdr.cpp:392 src/muuli_wdr.cpp:1585 src/muuli_wdr.cpp:3441
-#: src/Statistics.cpp:829
-msgid "Downloads"
-msgstr "Downloads"
-
-#: src/amuleDlg.cpp:364 src/amuleDlg.cpp:1828 src/muuli_wdr.cpp:3315
-msgid "Shared files"
-msgstr "Arquivos compartilhados"
-
-#: src/amuleDlg.cpp:365 src/amuleDlg.cpp:1834 src/muuli_wdr.cpp:2947
-#: src/muuli_wdr.cpp:3397 src/muuli_wdr.cpp:3444
-msgid "Messages"
-msgstr "Mensagens"
-
-#: src/amuleDlg.cpp:366 src/amuleDlg.cpp:1840 src/muuli_wdr.cpp:3445
-#: src/PrefsUnifiedDlg.cpp:314 src/Statistics.cpp:779 src/Statistics.cpp:1235
-msgid "Statistics"
-msgstr "Estatísticas"
-
-#: src/amuleDlg.cpp:368 src/amuleDlg.cpp:1847 src/muuli_wdr.cpp:3447
-#: src/PrefsUnifiedDlg.cpp:330 src/utils/wxCas/src/wxcasprefs.cpp:39
-msgid "Preferences"
-msgstr "Preferências"
-
-#: src/amuleDlg.cpp:371
-msgid "Navigate"
-msgstr ""
-
-#: src/amuleDlg.cpp:657
+#: src/amuleDlg.cpp:592
 msgid "New version available"
 msgstr "Uma versão mais nova está disponível"
 
-#: src/amuleDlg.cpp:661
+#: src/amuleDlg.cpp:596
 #, c-format
 msgid ""
 "A new version of aMule (%s) is available.\n"
@@ -656,184 +618,217 @@ msgstr ""
 "\n"
 "Você gostaria de abrir a página de download?"
 
-#: src/amuleDlg.cpp:743
+#: src/amuleDlg.cpp:678
 msgid "aMule dialog destroyed"
 msgstr "destruído caixa de diálogo do aMule"
 
-#: src/amuleDlg.cpp:766 src/DataToText.cpp:68 src/IPFilter.cpp:547
+#: src/amuleDlg.cpp:701 src/DataToText.cpp:68 src/IPFilter.cpp:547
 msgid "Connecting"
 msgstr "Conectando"
 
-#: src/amuleDlg.cpp:958
+#: src/amuleDlg.cpp:893
 msgid "eD2k: Connecting"
 msgstr "eD2k: Conectado"
 
-#: src/amuleDlg.cpp:962
+#: src/amuleDlg.cpp:897
 msgid "eD2k: Disconnected"
 msgstr "eD2k: Desconectado"
 
-#: src/amuleDlg.cpp:968
+#: src/amuleDlg.cpp:903
 msgid "Kad: Firewalled"
 msgstr "Kad: Atrás de Firewall"
 
-#: src/amuleDlg.cpp:972
+#: src/amuleDlg.cpp:907
 msgid "Kad: Connected"
 msgstr "Kad: Conectado"
 
-#: src/amuleDlg.cpp:977
+#: src/amuleDlg.cpp:912
 msgid "Kad: Connecting"
 msgstr "Kad: Conectando"
 
-#: src/amuleDlg.cpp:981
+#: src/amuleDlg.cpp:916
 msgid "Kad: Off"
 msgstr "Kad: Desligado"
 
-#: src/amuleDlg.cpp:1029 src/DownloadListCtrl.cpp:505
+#: src/amuleDlg.cpp:964 src/DownloadListCtrl.cpp:505
 #: src/DownloadListCtrl.cpp:749 src/FriendListCtrl.cpp:180
 #: src/muuli_wdr.cpp:731 src/muuli_wdr.cpp:782 src/muuli_wdr.cpp:846
-#: src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2252 src/muuli_wdr.cpp:2337
-#: src/muuli_wdr.cpp:3085 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
+#: src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2224 src/muuli_wdr.cpp:2309
+#: src/muuli_wdr.cpp:3057 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
 #: src/ServerListCtrl.cpp:606 src/TransferWnd.cpp:378
 #: src/utils/wxCas/src/wxcasprefs.cpp:235
 msgid "Cancel"
 msgstr "Cancelar"
 
-#: src/amuleDlg.cpp:1030
+#: src/amuleDlg.cpp:965
 msgid "Stop the current connection attempts"
 msgstr "Cancelar as tentativas atuais de conexão"
 
-#: src/amuleDlg.cpp:1035 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976
-#: src/muuli_wdr.cpp:2475
+#: src/amuleDlg.cpp:970 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976
+#: src/muuli_wdr.cpp:2447
 msgid "Disconnect"
 msgstr "Desconectar"
 
-#: src/amuleDlg.cpp:1036
+#: src/amuleDlg.cpp:971
 msgid "Disconnect from the currently connected networks"
 msgstr "Desconectar das redes atualmente conectadas"
 
-#: src/amuleDlg.cpp:1041 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979
-#: src/muuli_wdr.cpp:2630 src/muuli_wdr.cpp:3082 src/muuli_wdr.cpp:3437
+#: src/amuleDlg.cpp:976 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979
+#: src/muuli_wdr.cpp:2602 src/muuli_wdr.cpp:3054 src/muuli_wdr.cpp:3409
 msgid "Connect"
 msgstr "Conectar"
 
-#: src/amuleDlg.cpp:1042
+#: src/amuleDlg.cpp:977
 msgid "Connect to the currently enabled networks"
 msgstr "Conectar às redes ativas"
 
-#: src/amuleDlg.cpp:1154
+#: src/amuleDlg.cpp:1089
 #, c-format
 msgid "Up: %.1f%s (%.1f) | Down: %.1f%s (%.1f)"
 msgstr "Up: %.1f%s (%.1f) | Down: %.1f%s (%.1f)"
 
-#: src/amuleDlg.cpp:1156 src/amuleDlg.cpp:1158 src/amuleDlg.cpp:1162
-#: src/amuleDlg.cpp:1164 src/amuleDlg.cpp:1175 src/amuleDlg.cpp:1177
+#: src/amuleDlg.cpp:1091 src/amuleDlg.cpp:1093 src/amuleDlg.cpp:1097
+#: src/amuleDlg.cpp:1099 src/amuleDlg.cpp:1110 src/amuleDlg.cpp:1112
 #: src/MuleTrayIcon.cpp:796 src/MuleTrayIcon.cpp:799
 msgid " MB/s"
 msgstr " MB/s"
 
-#: src/amuleDlg.cpp:1156 src/amuleDlg.cpp:1158 src/amuleDlg.cpp:1162
-#: src/amuleDlg.cpp:1164 src/amuleDlg.cpp:1175 src/amuleDlg.cpp:1177
+#: src/amuleDlg.cpp:1091 src/amuleDlg.cpp:1093 src/amuleDlg.cpp:1097
+#: src/amuleDlg.cpp:1099 src/amuleDlg.cpp:1110 src/amuleDlg.cpp:1112
 #: src/MuleTrayIcon.cpp:796 src/MuleTrayIcon.cpp:799
 #: src/utils/wxCas/src/wxcasframe.cpp:1041
 msgid " kB/s"
 msgstr " kB/s"
 
-#: src/amuleDlg.cpp:1161
+#: src/amuleDlg.cpp:1096
 #, c-format
 msgid "Up: %.1f%s | Down: %.1f%s"
 msgstr "Up: %.1f%s | Down: %.1f%s"
 
-#: src/amuleDlg.cpp:1193
+#: src/amuleDlg.cpp:1128
 #, c-format
 msgid "aMule (%s | Connected)"
 msgstr "aMule (%s | Conectado)"
 
-#: src/amuleDlg.cpp:1195
+#: src/amuleDlg.cpp:1130
 #, c-format
 msgid "aMule (%s | Disconnected)"
 msgstr "aMule (%s | Desconectado)"
 
-#: src/amuleDlg.cpp:1248
+#: src/amuleDlg.cpp:1183
 #, c-format
 msgid "Do you really want to exit %s?"
 msgstr "Você realmente quer sair %s?"
 
-#: src/amuleDlg.cpp:1250
+#: src/amuleDlg.cpp:1185
 msgid "Exit confirmation"
 msgstr "Confirmação de saída"
 
-#: src/amuleDlg.cpp:1613
+#: src/amuleDlg.cpp:1548
 msgid "Launch Command: "
 msgstr "Lançar Comando: "
 
-#: src/amuleDlg.cpp:1632 src/muuli_wdr.cpp:1972 src/Preferences.cpp:979
+#: src/amuleDlg.cpp:1567 src/muuli_wdr.cpp:1971 src/Preferences.cpp:951
 msgid "- default -"
 msgstr "- padrão -"
 
-#: src/amuleDlg.cpp:1660
+#: src/amuleDlg.cpp:1595
 #, c-format
 msgid "Skin directory '%s' does not exist"
 msgstr "O diretório '%s' de skins não existe"
 
-#: src/amuleDlg.cpp:1663
+#: src/amuleDlg.cpp:1598
 #, c-format
 msgid "WARNING: Unable to open skin file '%s' for read"
 msgstr "CUIDADO: Incapaz de abrir o arquivo de pele '%s' para leitura"
 
-#: src/amuleDlg.cpp:1814 src/muuli_wdr.cpp:3439
+#: src/amuleDlg.cpp:1722 src/amuleDlg.cpp:1968 src/muuli_wdr.cpp:1485
+#: src/muuli_wdr.cpp:3411
+msgid "Networks"
+msgstr "Redes"
+
+#: src/amuleDlg.cpp:1726 src/muuli_wdr.cpp:3411
 msgid "Networks Window"
 msgstr "Janela de redes"
 
-#: src/amuleDlg.cpp:1820 src/muuli_wdr.cpp:3440
+#: src/amuleDlg.cpp:1728 src/muuli_wdr.cpp:3412
+msgid "Searches"
+msgstr "Pesquisas"
+
+#: src/amuleDlg.cpp:1732 src/muuli_wdr.cpp:3412
 msgid "Searches Window"
 msgstr "Janela de Pesquisas"
 
-#: src/amuleDlg.cpp:1826 src/muuli_wdr.cpp:3441
+#: src/amuleDlg.cpp:1734 src/DownloadListCtrl.cpp:740 src/muuli_wdr.cpp:392
+#: src/muuli_wdr.cpp:1578 src/muuli_wdr.cpp:3413 src/Statistics.cpp:829
+msgid "Downloads"
+msgstr "Downloads"
+
+#: src/amuleDlg.cpp:1738 src/muuli_wdr.cpp:3413
 msgid "Downloads Window"
 msgstr "Janela de Downloads"
 
-#: src/amuleDlg.cpp:1832 src/muuli_wdr.cpp:3443
+#: src/amuleDlg.cpp:1740 src/muuli_wdr.cpp:3287
+msgid "Shared files"
+msgstr "Arquivos compartilhados"
+
+#: src/amuleDlg.cpp:1744 src/muuli_wdr.cpp:3415
 msgid "Shared Files Window"
 msgstr "Janela de compartilhados"
 
-#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3444
+#: src/amuleDlg.cpp:1746 src/muuli_wdr.cpp:2919 src/muuli_wdr.cpp:3369
+#: src/muuli_wdr.cpp:3416
+msgid "Messages"
+msgstr "Mensagens"
+
+#: src/amuleDlg.cpp:1750 src/muuli_wdr.cpp:3416
 msgid "Messages Window"
 msgstr "Janela de Mensagens"
 
-#: src/amuleDlg.cpp:1844 src/muuli_wdr.cpp:3445
+#: src/amuleDlg.cpp:1752 src/muuli_wdr.cpp:3417 src/PrefsUnifiedDlg.cpp:312
+#: src/Statistics.cpp:779 src/Statistics.cpp:1235
+msgid "Statistics"
+msgstr "Estatísticas"
+
+#: src/amuleDlg.cpp:1756 src/muuli_wdr.cpp:3417
 msgid "Statistics Graph Window"
 msgstr "Janela de Estatísticas"
 
-#: src/amuleDlg.cpp:1851 src/muuli_wdr.cpp:3447
+#: src/amuleDlg.cpp:1759 src/muuli_wdr.cpp:3419 src/PrefsUnifiedDlg.cpp:328
+#: src/utils/wxCas/src/wxcasprefs.cpp:39
+msgid "Preferences"
+msgstr "Preferências"
+
+#: src/amuleDlg.cpp:1763 src/muuli_wdr.cpp:3419
 msgid "Preferences Settings Window"
 msgstr "Janela de Preferências"
 
-#: src/amuleDlg.cpp:1854 src/muuli_wdr.cpp:3448
+#: src/amuleDlg.cpp:1766 src/muuli_wdr.cpp:3420
 msgid "Import"
 msgstr "Importar"
 
-#: src/amuleDlg.cpp:1858 src/muuli_wdr.cpp:3448
+#: src/amuleDlg.cpp:1770 src/muuli_wdr.cpp:3420
 msgid "The partfile importer tool"
 msgstr "Ferramenta de importação de arquivos .part"
 
-#: src/amuleDlg.cpp:1861 src/muuli_wdr.cpp:3449
+#: src/amuleDlg.cpp:1773 src/muuli_wdr.cpp:3421
 #: src/utils/aLinkCreator/src/alcframe.cpp:262
 msgid "About"
 msgstr "Sobre"
 
-#: src/amuleDlg.cpp:1861 src/muuli_wdr.cpp:3449
+#: src/amuleDlg.cpp:1773 src/muuli_wdr.cpp:3421
 msgid "About/Help"
 msgstr "Sobre/Ajuda"
 
-#: src/amuleDlg.cpp:2059
+#: src/amuleDlg.cpp:1971
 msgid "eD2k network"
 msgstr "Rede eD2k"
 
-#: src/amuleDlg.cpp:2062
+#: src/amuleDlg.cpp:1974
 msgid "Kad network"
 msgstr "rede Kad"
 
-#: src/amuleDlg.cpp:2062
+#: src/amuleDlg.cpp:1974
 msgid "No network"
 msgstr "Sem redes"
 
@@ -964,7 +959,7 @@ msgstr "não encontrado"
 msgid "The core rejected these shared folders:%s"
 msgstr "O núcleo rejeitou as seguintes pastas compartilhadas: %s"
 
-#: src/amule-remote-gui.cpp:1336 src/ExternalConn.cpp:2346
+#: src/amule-remote-gui.cpp:1336 src/ExternalConn.cpp:2345
 msgid "Invalid link or already on list."
 msgstr "Link inválido ou já está na lista."
 
@@ -980,7 +975,7 @@ msgstr "Incapaz criar o diretório '%s' para a categoria '%s', mantendo diretór
 #: src/ClientDetailDialog.cpp:123 src/DataToText.cpp:61 src/DataToText.cpp:86
 #: src/DataToText.cpp:101 src/DataToText.cpp:136 src/DataToText.cpp:165
 #: src/DownloadListCtrl.cpp:1172 src/DownloadListCtrl.cpp:1185
-#: src/DownloadListCtrl.cpp:1196 src/ExternalConn.cpp:609
+#: src/DownloadListCtrl.cpp:1196 src/ExternalConn.cpp:608
 #: src/FileDetailDialog.cpp:203 src/FileDetailDialog.cpp:235
 #: src/FileDetailDialog.cpp:242 src/GenericClientListCtrl.cpp:1171
 #: src/GenericClientListCtrl.cpp:1182 src/GenericClientListCtrl.cpp:1192
@@ -1366,19 +1361,19 @@ msgstr "Auto [Alto]"
 msgid "Very low"
 msgstr "Muito baixo"
 
-#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:743 src/muuli_wdr.cpp:2303
+#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:743 src/muuli_wdr.cpp:2275
 #: src/ServerListCtrl.cpp:263 src/ServerListCtrl.cpp:456
 #: src/SharedFilesCtrl.cpp:145
 msgid "Low"
 msgstr "Baixo"
 
-#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:744 src/muuli_wdr.cpp:2304
+#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:744 src/muuli_wdr.cpp:2276
 #: src/ServerListCtrl.cpp:266 src/ServerListCtrl.cpp:457
 #: src/SharedFilesCtrl.cpp:146
 msgid "Normal"
 msgstr "Normal"
 
-#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:745 src/muuli_wdr.cpp:2305
+#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:745 src/muuli_wdr.cpp:2277
 #: src/ServerListCtrl.cpp:269 src/ServerListCtrl.cpp:458
 #: src/SharedFilesCtrl.cpp:147
 msgid "High"
@@ -1470,8 +1465,8 @@ msgstr "Servidor Local"
 msgid "Remote Server"
 msgstr "Servidor Remoto"
 
-#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3202
-#: src/SearchDlg.cpp:119 src/TextClient.cpp:911
+#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3174
+#: src/SearchDlg.cpp:111 src/TextClient.cpp:911
 msgid "Kad"
 msgstr "Kad"
 
@@ -1541,7 +1536,7 @@ msgstr "Parte"
 msgid "Size"
 msgstr "Tamanho"
 
-#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3269
+#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3241
 msgid "Transferred"
 msgstr "Transferido"
 
@@ -1599,7 +1594,7 @@ msgstr ""
 "Resposta de: %s (%s)\n"
 "\n"
 
-#: src/DownloadListCtrl.cpp:746 src/muuli_wdr.cpp:2306
+#: src/DownloadListCtrl.cpp:746 src/muuli_wdr.cpp:2278
 #: src/SharedFilesCtrl.cpp:150
 msgid "Auto"
 msgstr "Auto"
@@ -1637,7 +1632,7 @@ msgid "Extended Options"
 msgstr "Opções Extras"
 
 #: src/DownloadListCtrl.cpp:770 src/DownloadListCtrl.cpp:822
-#: src/muuli_wdr.cpp:1790
+#: src/muuli_wdr.cpp:1789
 msgid "Preview"
 msgstr "Pré-visualizar"
 
@@ -1812,230 +1807,225 @@ msgstr[1] "Não foi possível adicionar %u links (veja o log para detalhes)."
 msgid "Invalid eD2k link! ERROR: %s"
 msgstr "Ligação eD2k inválida! ERRO: %s"
 
-#: src/ExternalConn.cpp:380
+#: src/ExternalConn.cpp:379
 msgid "Client sent packet after authentication failed."
 msgstr "Pacote enviado por cliente após falha na autenticação."
 
-#: src/ExternalConn.cpp:397
+#: src/ExternalConn.cpp:396
 msgid "External connection closed."
 msgstr "Conexão externa encerrada."
 
-#: src/ExternalConn.cpp:474
+#: src/ExternalConn.cpp:473
 msgid "External connections disabled due to empty password!"
 msgstr "Conexões externas desativadas por não ter sido definida uma senha!"
 
-#: src/ExternalConn.cpp:495
+#: src/ExternalConn.cpp:494
 msgid "External connections disabled in config file"
 msgstr "Conexões externas desativadas no arquivo de configuração"
 
-#: src/ExternalConn.cpp:576
+#: src/ExternalConn.cpp:575
 msgid "New external connection accepted"
 msgstr "Novas conexões externas aceitas"
 
-#: src/ExternalConn.cpp:579
+#: src/ExternalConn.cpp:578
 msgid "ERROR: couldn't accept a new external connection"
 msgstr "ERRO: Não pôde aceitar uma nova conexão externa"
 
-#: src/ExternalConn.cpp:596
+#: src/ExternalConn.cpp:595
 msgid "External connection refused due to empty password in preferences!"
 msgstr "Conexão externa recusada por não ter sido definida uma senha nas preferências!"
 
-#: src/ExternalConn.cpp:608
+#: src/ExternalConn.cpp:607
 #, c-format
 msgid "Connecting client: %s %s"
 msgstr "Cliente conectando: %s %s"
 
-#: src/ExternalConn.cpp:610
+#: src/ExternalConn.cpp:609
 msgid "Unknown version"
 msgstr "Versão desconhecida"
 
-#: src/ExternalConn.cpp:623
+#: src/ExternalConn.cpp:622
 msgid "Incorrect EC version ID, there might be binary incompatibility. Use core and remote from same snapshot."
 msgstr "Id de versão do EC incorreta, deve ser incompatibilidade binária. Use o core e o remote da mesma versão."
 
-#: src/ExternalConn.cpp:631
+#: src/ExternalConn.cpp:630
 msgid "You cannot connect to a release version from an arbitrary development snapshot! *sigh* possible crash prevented"
 msgstr "Você não pode conectar a uma versão oficial a partir de um cliente de desenvolvimento! *ufa* Possível travamento evitado"
 
-#: src/ExternalConn.cpp:714
+#: src/ExternalConn.cpp:713
 msgid "Invalid protocol version."
 msgstr "Versão do protocolo inválida."
 
-#: src/ExternalConn.cpp:720
+#: src/ExternalConn.cpp:719
 msgid "Missing protocol version tag."
 msgstr "Falta tag de versão do protocolo."
 
-#: src/ExternalConn.cpp:728
+#: src/ExternalConn.cpp:727
 msgid "Authentication failed: invalid hash specified as EC password."
 msgstr "Autenticação falhou: hash inválido especificado como senha EC."
 
-#: src/ExternalConn.cpp:776
+#: src/ExternalConn.cpp:775
 msgid "Authentication failed: wrong password."
 msgstr "Falha na autenticação: senha errada."
 
-#: src/ExternalConn.cpp:778
+#: src/ExternalConn.cpp:777
 msgid "Authentication failed: missing password."
 msgstr "Falha na autenticação: senha desconhecida."
 
-#: src/ExternalConn.cpp:789
+#: src/ExternalConn.cpp:788
 msgid "Invalid request, please authenticate first."
 msgstr "Requisição inválida, por favor autentique primeiro."
 
-#: src/ExternalConn.cpp:794
+#: src/ExternalConn.cpp:793
 msgid "Access granted."
 msgstr "Acesso liberado."
 
-#: src/ExternalConn.cpp:802
+#: src/ExternalConn.cpp:801
 #, c-format
 msgid "Sent error message \"%s\" to client."
 msgstr "Enviar mensagem de erro \"%s\" para cliente."
 
-#: src/ExternalConn.cpp:807
+#: src/ExternalConn.cpp:806
 #, c-format
 msgid "Unauthorized access attempt from %s. Connection closed."
 msgstr "Tentativa de acesso de %s não autorizado. Conexão encerrada."
 
-#: src/ExternalConn.cpp:1420
+#: src/ExternalConn.cpp:1419
 #, c-format
 msgid "Remote PartFile command failed: FileHash not found: %s"
 msgstr "Comando de PartFile remoto falhou: Filehash não encontrada: %s"
 
-#: src/ExternalConn.cpp:1424
+#: src/ExternalConn.cpp:1423
 #, c-format
 msgid "FileHash not found: %s"
 msgstr "Hash do arquivo não encontrada: %s"
 
-#: src/ExternalConn.cpp:1471 src/ExternalConn.cpp:1559
-#: src/ExternalConn.cpp:1680
+#: src/ExternalConn.cpp:1470 src/ExternalConn.cpp:1558
+#: src/ExternalConn.cpp:1679
 msgid "OOPS! OpCode processing error!"
 msgstr "OOPS! Processando erro OpCode!"
 
-#: src/ExternalConn.cpp:1502
+#: src/ExternalConn.cpp:1501
 msgid "Server not added"
 msgstr "Servidor não adicionado"
 
-#: src/ExternalConn.cpp:1521
+#: src/ExternalConn.cpp:1520
 #, c-format
 msgid "server not found: %s"
 msgstr "servidor não encontrado: %s"
 
-#: src/ExternalConn.cpp:1538
+#: src/ExternalConn.cpp:1537
 msgid "need to define server to be removed"
 msgstr "precisa definir o servidor a ser removido"
 
-#: src/ExternalConn.cpp:1553
+#: src/ExternalConn.cpp:1552
 msgid "eD2k is disabled in preferences."
 msgstr "eD2k foi desabilitado nas preferências."
 
-#: src/ExternalConn.cpp:1658
+#: src/ExternalConn.cpp:1657
 msgid "Friend not found."
 msgstr "Amigo não encontrado."
 
-#: src/ExternalConn.cpp:1668
+#: src/ExternalConn.cpp:1667
 msgid "Client not found."
 msgstr "Cliente não encontrado."
 
-#: src/ExternalConn.cpp:1674
+#: src/ExternalConn.cpp:1673
 msgid "EC_TAG_FRIEND_SHARED requires EC_TAG_FRIEND or EC_TAG_CLIENT."
 msgstr "EC_TAG_FRIEND_SHARED requer EC_TAG_FRIEND ou EC_TAG_CLIENT."
 
-#: src/ExternalConn.cpp:1992
+#: src/ExternalConn.cpp:1991
 msgid "WebSearch from remote interface makes no sense."
 msgstr "Pesquisa web pela interface remota não faz sentido."
 
-#: src/ExternalConn.cpp:2027
+#: src/ExternalConn.cpp:2026
 msgid "Search in progress. Refetch results in a moment!"
 msgstr "Pesquisa em andamento, aguarde!"
 
-#: src/ExternalConn.cpp:2266
+#: src/ExternalConn.cpp:2265
 msgid "No points for graph."
 msgstr "Sem dados para gráfico."
 
-#: src/ExternalConn.cpp:2276
+#: src/ExternalConn.cpp:2275
 msgid "Your client is not configured for this detail level."
 msgstr "Seu cliente não está configurado para esse nível de detalhes."
 
-#: src/ExternalConn.cpp:2303
+#: src/ExternalConn.cpp:2302
 msgid "External Connection: shutdown requested"
 msgstr "Conexão Externa: requerido desligar"
 
-#: src/ExternalConn.cpp:2315
+#: src/ExternalConn.cpp:2314
 msgid "Already shutting down."
 msgstr "Já estou desligando."
 
-#: src/ExternalConn.cpp:2333
+#: src/ExternalConn.cpp:2332
 #, c-format
 msgid "ExternalConn: adding link '%s'."
 msgstr "ExternalConn: adicionar link '%s'."
 
-#: src/ExternalConn.cpp:2351
+#: src/ExternalConn.cpp:2350
 #, c-format
 msgid "%d of %d links failed (invalid or already on list)."
 msgstr "%d de %d links falharam (inválidos ou já estava na lista)."
 
-#: src/ExternalConn.cpp:2374
+#: src/ExternalConn.cpp:2373
 msgid "Version check throttled; try again shortly."
 msgstr "A checagem de versão foi desacelerada; tente novamente em breve."
 
-#: src/ExternalConn.cpp:2379
+#: src/ExternalConn.cpp:2378
 msgid "Version check is not available on this daemon."
 msgstr "A checagem de versão não está disponível neste daemon."
 
-#: src/ExternalConn.cpp:2509
+#: src/ExternalConn.cpp:2508
 msgid "File not found."
 msgstr "Arquivo não encontrado."
 
-#: src/ExternalConn.cpp:2514
+#: src/ExternalConn.cpp:2513
 msgid "Invalid file name."
 msgstr "Nome de arquivo inválido."
 
-#: src/ExternalConn.cpp:2522
+#: src/ExternalConn.cpp:2521
 msgid "Unable to rename file."
 msgstr "Não foi possível renomear o arquivo."
 
-#: src/ExternalConn.cpp:2839
-#, c-format
-msgid "Could not save the amuleapi password: %s"
-msgstr ""
-
-#: src/ExternalConn.cpp:3004 src/ExternalConn.cpp:3032
+#: src/ExternalConn.cpp:2992 src/ExternalConn.cpp:3020
 msgid "Kad is disabled in preferences."
 msgstr "Kad está desativado nas preferências."
 
-#: src/ExternalConn.cpp:3045
+#: src/ExternalConn.cpp:3033
 msgid "Already connected to eD2k."
 msgstr "Já conectado em eD2k."
 
-#: src/ExternalConn.cpp:3048
+#: src/ExternalConn.cpp:3036
 msgid "Connecting to eD2k..."
 msgstr "Conectando em eD2k..."
 
-#: src/ExternalConn.cpp:3057
+#: src/ExternalConn.cpp:3045
 msgid "Already connected to Kad."
 msgstr "Já conectado a rede Kad."
 
-#: src/ExternalConn.cpp:3060
+#: src/ExternalConn.cpp:3048
 msgid "Connecting to Kad..."
 msgstr "Conectando a rede Kad..."
 
-#: src/ExternalConn.cpp:3067
+#: src/ExternalConn.cpp:3055
 msgid "All networks are disabled."
 msgstr "Todas as redes estão desabilitadas."
 
-#: src/ExternalConn.cpp:3076
+#: src/ExternalConn.cpp:3064
 msgid "Disconnected from eD2k."
 msgstr "Desconectado de eD2k."
 
-#: src/ExternalConn.cpp:3081
+#: src/ExternalConn.cpp:3069
 msgid "Disconnected from Kad."
 msgstr "Desconectado da rede Kad."
 
-#: src/ExternalConn.cpp:3090
+#: src/ExternalConn.cpp:3078
 #, c-format
 msgid "External Connection: invalid opcode received: %#x"
 msgstr "Conexão Externa:opcode recebido inválido: %#x"
 
-#: src/ExternalConn.cpp:3095
+#: src/ExternalConn.cpp:3083
 msgid "Invalid opcode (wrong protocol version?)"
 msgstr "O opcode é inválido (versão errada do protocolo?)"
 
@@ -2351,19 +2341,19 @@ msgstr ""
 msgid "eD2k"
 msgstr "eD2k"
 
-#: src/FirstRunWizard.cpp:349 src/muuli_wdr.cpp:1495
+#: src/FirstRunWizard.cpp:349 src/muuli_wdr.cpp:1488
 msgid "Kademlia"
 msgstr "Kademlia"
 
-#: src/FirstRunWizard.cpp:359 src/muuli_wdr.cpp:1423
+#: src/FirstRunWizard.cpp:359 src/muuli_wdr.cpp:1416
 msgid "Standard TCP Port "
 msgstr "Porta TCP Padrão "
 
-#: src/FirstRunWizard.cpp:365 src/muuli_wdr.cpp:1435
+#: src/FirstRunWizard.cpp:365 src/muuli_wdr.cpp:1428
 msgid "Extended UDP port (Kad / global search) "
 msgstr "Porta UDP estendida (Kad / pesquisa global) "
 
-#: src/FirstRunWizard.cpp:377 src/muuli_wdr.cpp:1442
+#: src/FirstRunWizard.cpp:377 src/muuli_wdr.cpp:1435
 msgid "Enable UPnP for router port forwarding"
 msgstr "Habilitar UPnP para redirecionamento de porta do roteador"
 
@@ -2390,7 +2380,7 @@ msgstr ""
 msgid "Your peer lists are already in place - nothing to download."
 msgstr "Ops! Você já está tentando baixar o arquivo %s"
 
-#: src/FirstRunWizard.cpp:434 src/muuli_wdr.cpp:1540
+#: src/FirstRunWizard.cpp:434 src/muuli_wdr.cpp:1533
 msgid "Auto-update server list at startup"
 msgstr "Lista de servidores auto-atualizáveis na iniciação"
 
@@ -2436,23 +2426,23 @@ msgid ""
 "want downloads on a different (e.g. larger) disk."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:549 src/FirstRunWizard.cpp:611 src/muuli_wdr.cpp:1702
+#: src/FirstRunWizard.cpp:549 src/FirstRunWizard.cpp:611 src/muuli_wdr.cpp:1701
 msgid "Destination folder for downloads"
 msgstr "Pasta de destino para baixados"
 
-#: src/FirstRunWizard.cpp:553 src/FirstRunWizard.cpp:569 src/muuli_wdr.cpp:1349
-#: src/muuli_wdr.cpp:1366 src/muuli_wdr.cpp:1677 src/muuli_wdr.cpp:1708
-#: src/muuli_wdr.cpp:1720 src/muuli_wdr.cpp:2790
+#: src/FirstRunWizard.cpp:553 src/FirstRunWizard.cpp:569 src/muuli_wdr.cpp:1342
+#: src/muuli_wdr.cpp:1359 src/muuli_wdr.cpp:1676 src/muuli_wdr.cpp:1707
+#: src/muuli_wdr.cpp:1719 src/muuli_wdr.cpp:2762
 #: src/utils/aLinkCreator/src/alcframe.cpp:135
 #: src/utils/wxCas/src/wxcasprefs.cpp:52 src/utils/wxCas/src/wxcasprefs.cpp:118
 msgid "Browse"
 msgstr "Procurar"
 
-#: src/FirstRunWizard.cpp:559 src/muuli_wdr.cpp:1713
+#: src/FirstRunWizard.cpp:559 src/muuli_wdr.cpp:1712
 msgid "(All files in this folder are shared with other peers)"
 msgstr "(Todos os arquivos nesta pasta são compartilhados com outros pares)"
 
-#: src/FirstRunWizard.cpp:565 src/FirstRunWizard.cpp:624 src/muuli_wdr.cpp:1715
+#: src/FirstRunWizard.cpp:565 src/FirstRunWizard.cpp:624 src/muuli_wdr.cpp:1714
 msgid "Folder for temporary download files"
 msgstr "Pasta para arquivos temporários baixados"
 
@@ -2483,7 +2473,7 @@ msgstr "Falha em abrir lista de amigos do arquivo 'emfriends.met' para escrita!"
 msgid "CRITICAL - no client on StartChatSession"
 msgstr "CRÍTICO - nenhum cliente em StartChatSession"
 
-#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2696 src/muuli_wdr.cpp:3373
+#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2668 src/muuli_wdr.cpp:3345
 msgid "Friends"
 msgstr "Amigos"
 
@@ -2593,8 +2583,8 @@ msgstr "Nenhum"
 msgid "No"
 msgstr "Não"
 
-#: src/GenericClientListCtrl.cpp:1216 src/PrefsUnifiedDlg.cpp:2898
-#: src/PrefsUnifiedDlg.cpp:2948 src/ServerListCtrl.cpp:276
+#: src/GenericClientListCtrl.cpp:1216 src/PrefsUnifiedDlg.cpp:2818
+#: src/PrefsUnifiedDlg.cpp:2868 src/ServerListCtrl.cpp:276
 msgid "Yes"
 msgstr "Sim"
 
@@ -2763,10 +2753,10 @@ msgstr "Porta inválida para inicialização"
 msgid "Please fill all fields required"
 msgstr "Preencha todos os campos necessários"
 
-#: src/KadDlg.cpp:192 src/PartFile.cpp:1031 src/PrefsUnifiedDlg.cpp:1134
-#: src/PrefsUnifiedDlg.cpp:1204 src/PrefsUnifiedDlg.cpp:1405
-#: src/PrefsUnifiedDlg.cpp:1663 src/PrefsUnifiedDlg.cpp:1673
-#: src/PrefsUnifiedDlg.cpp:1690 src/PrefsUnifiedDlg.cpp:1738
+#: src/KadDlg.cpp:192 src/PartFile.cpp:1031 src/PrefsUnifiedDlg.cpp:1162
+#: src/PrefsUnifiedDlg.cpp:1331 src/PrefsUnifiedDlg.cpp:1589
+#: src/PrefsUnifiedDlg.cpp:1599 src/PrefsUnifiedDlg.cpp:1616
+#: src/PrefsUnifiedDlg.cpp:1658
 msgid "Message"
 msgstr "Mensagem"
 
@@ -2867,7 +2857,7 @@ msgstr "Taxa de compartilhamento"
 msgid "Uploaded"
 msgstr "Enviado"
 
-#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3253
+#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3225
 msgid "Requested"
 msgstr "Requisitado"
 
@@ -2990,7 +2980,7 @@ msgid "WARNING: "
 msgstr "CUIDADO: "
 
 #: src/MuleNotebook.cpp:179 src/muuli_wdr.cpp:817 src/muuli_wdr.cpp:1229
-#: src/muuli_wdr.cpp:3157 src/muuli_wdr.cpp:3413
+#: src/muuli_wdr.cpp:3129 src/muuli_wdr.cpp:3385
 msgid "Close"
 msgstr "Fechar"
 
@@ -3003,12 +2993,12 @@ msgstr "Recortar"
 msgid "Copy"
 msgstr "Copiar"
 
-#: src/MuleTextCtrl.cpp:88 src/SearchDlg.cpp:261
+#: src/MuleTextCtrl.cpp:88
 msgid "Paste"
 msgstr "Colar"
 
 #: src/MuleTextCtrl.cpp:89 src/muuli_wdr.cpp:358 src/muuli_wdr.cpp:757
-#: src/muuli_wdr.cpp:2380 src/muuli_wdr.cpp:2399 src/muuli_wdr.cpp:2421
+#: src/muuli_wdr.cpp:2352 src/muuli_wdr.cpp:2371 src/muuli_wdr.cpp:2393
 #: src/utils/aLinkCreator/src/alcframe.cpp:142
 msgid "Clear"
 msgstr "Limpar"
@@ -3099,8 +3089,8 @@ msgid "Exit"
 msgstr "Sair"
 
 #: src/MuleTrayIcon.cpp:579 src/MuleTrayIcon.cpp:945 src/MuleTrayIcon.cpp:965
-#: src/muuli_wdr.cpp:1398 src/muuli_wdr.cpp:1406 src/muuli_wdr.cpp:1413
-#: src/muuli_wdr.cpp:1836 src/muuli_wdr.cpp:1842 src/OtherFunctions.cpp:91
+#: src/muuli_wdr.cpp:1391 src/muuli_wdr.cpp:1399 src/muuli_wdr.cpp:1406
+#: src/muuli_wdr.cpp:1835 src/muuli_wdr.cpp:1841 src/OtherFunctions.cpp:91
 #: src/StatisticsDlg.cpp:93 src/StatisticsDlg.cpp:95
 msgid "kB/s"
 msgstr "kB/s"
@@ -3269,7 +3259,7 @@ msgstr "Nome:"
 msgid "Type"
 msgstr "Tipo"
 
-#: src/muuli_wdr.cpp:215 src/SearchDlg.cpp:118 src/SearchListCtrl.cpp:853
+#: src/muuli_wdr.cpp:215 src/SearchDlg.cpp:110 src/SearchListCtrl.cpp:853
 msgid "Local"
 msgstr "Local"
 
@@ -3340,7 +3330,7 @@ msgstr "Bytes"
 msgid "KB"
 msgstr "KB"
 
-#: src/muuli_wdr.cpp:274 src/muuli_wdr.cpp:293 src/muuli_wdr.cpp:1621
+#: src/muuli_wdr.cpp:274 src/muuli_wdr.cpp:293 src/muuli_wdr.cpp:1620
 #: src/OtherFunctions.cpp:64
 msgid "MB"
 msgstr "MB"
@@ -3357,7 +3347,7 @@ msgstr "Tamanho Máximo"
 msgid "Availability"
 msgstr "Disponível"
 
-#: src/muuli_wdr.cpp:312 src/muuli_wdr.cpp:398 src/muuli_wdr.cpp:3318
+#: src/muuli_wdr.cpp:312 src/muuli_wdr.cpp:398 src/muuli_wdr.cpp:3290
 msgid "Filter:"
 msgstr "Filtro:"
 
@@ -3389,7 +3379,7 @@ msgstr "Pedir para pares Kad que já responderam para alargar a busca. Cada cliq
 msgid "Stop"
 msgstr "Pare"
 
-#: src/muuli_wdr.cpp:348 src/muuli_wdr.cpp:1392 src/SearchListCtrl.cpp:732
+#: src/muuli_wdr.cpp:348 src/muuli_wdr.cpp:1385 src/SearchListCtrl.cpp:732
 msgid "Download"
 msgstr "Download"
 
@@ -3420,12 +3410,12 @@ msgstr "Fontes de arquivos:"
 #: src/muuli_wdr.cpp:1160 src/muuli_wdr.cpp:1167 src/muuli_wdr.cpp:1172
 #: src/muuli_wdr.cpp:1179 src/muuli_wdr.cpp:1184 src/muuli_wdr.cpp:1191
 #: src/muuli_wdr.cpp:1205 src/muuli_wdr.cpp:1212 src/muuli_wdr.cpp:1217
-#: src/muuli_wdr.cpp:1224 src/muuli_wdr.cpp:3255 src/muuli_wdr.cpp:3263
-#: src/muuli_wdr.cpp:3271
+#: src/muuli_wdr.cpp:1224 src/muuli_wdr.cpp:3227 src/muuli_wdr.cpp:3235
+#: src/muuli_wdr.cpp:3243
 msgid "N/A"
 msgstr "N/A"
 
-#: src/muuli_wdr.cpp:508 src/muuli_wdr.cpp:1065 src/PrefsUnifiedDlg.cpp:299
+#: src/muuli_wdr.cpp:508 src/muuli_wdr.cpp:1065 src/PrefsUnifiedDlg.cpp:297
 msgid "General"
 msgstr "Geral"
 
@@ -3561,7 +3551,7 @@ msgstr "Artista:"
 msgid "Album :"
 msgstr "Album:"
 
-#: src/muuli_wdr.cpp:685 src/muuli_wdr.cpp:2275
+#: src/muuli_wdr.cpp:685 src/muuli_wdr.cpp:2247
 msgid "Title :"
 msgstr "Título:"
 
@@ -3669,7 +3659,7 @@ msgstr "Usuário :"
 msgid "Userhash :"
 msgstr "Hash do usuário :"
 
-#: src/muuli_wdr.cpp:895 src/muuli_wdr.cpp:1742 src/muuli_wdr.cpp:2470
+#: src/muuli_wdr.cpp:895 src/muuli_wdr.cpp:1741 src/muuli_wdr.cpp:2442
 #: src/utils/aLinkCreator/src/alcframe.cpp:137
 msgid "Add"
 msgstr "Adicionar"
@@ -3678,15 +3668,15 @@ msgstr "Adicionar"
 msgid "Download-Speed"
 msgstr "Download (Velocidade)"
 
-#: src/muuli_wdr.cpp:954 src/muuli_wdr.cpp:989 src/muuli_wdr.cpp:2574
+#: src/muuli_wdr.cpp:954 src/muuli_wdr.cpp:989 src/muuli_wdr.cpp:2546
 msgid "Current"
 msgstr "Atual"
 
-#: src/muuli_wdr.cpp:962 src/muuli_wdr.cpp:997 src/muuli_wdr.cpp:2582
+#: src/muuli_wdr.cpp:962 src/muuli_wdr.cpp:997 src/muuli_wdr.cpp:2554
 msgid "Running average"
 msgstr "Média de execução"
 
-#: src/muuli_wdr.cpp:970 src/muuli_wdr.cpp:1005 src/muuli_wdr.cpp:2590
+#: src/muuli_wdr.cpp:970 src/muuli_wdr.cpp:1005 src/muuli_wdr.cpp:2562
 msgid "Session average"
 msgstr "Média da sessão"
 
@@ -3698,7 +3688,7 @@ msgstr "Upload (velocidade)"
 msgid "Connections"
 msgstr "Conexões"
 
-#: src/muuli_wdr.cpp:1024 src/muuli_wdr.cpp:1861
+#: src/muuli_wdr.cpp:1024 src/muuli_wdr.cpp:1860
 msgid "Active downloads"
 msgstr "Downloads ativos"
 
@@ -3706,7 +3696,7 @@ msgstr "Downloads ativos"
 msgid "Active connections (1:1)"
 msgstr "Conexões ativas (1:1)"
 
-#: src/muuli_wdr.cpp:1040 src/muuli_wdr.cpp:1862
+#: src/muuli_wdr.cpp:1040 src/muuli_wdr.cpp:1861
 msgid "Active uploads"
 msgstr "Uploads ativos"
 
@@ -3822,8 +3812,8 @@ msgstr "Esse é o nome que os usuários verão quando se conectarem à você."
 msgid "Language: "
 msgstr "Idioma: "
 
-#: src/muuli_wdr.cpp:1257 src/muuli_wdr.cpp:1330 src/muuli_wdr.cpp:1334
-#: src/muuli_wdr.cpp:1337
+#: src/muuli_wdr.cpp:1257 src/muuli_wdr.cpp:1323 src/muuli_wdr.cpp:1327
+#: src/muuli_wdr.cpp:1330
 msgid "The delay before showing tool-tips."
 msgstr "Tempo de espera antes de mostrar as dicas."
 
@@ -3899,260 +3889,259 @@ msgstr "Mostrar as notificações quando terminar de baixar"
 msgid "Enabling this will make aMule to show notifications when finished downloading."
 msgstr "Habilitar isto vai fazer com que o aMule mostre notificações quando terminar de baixar."
 
-#: src/muuli_wdr.cpp:1323
-#, fuzzy
-msgid "Remember search history"
-msgstr "Lembrar essas definições"
-
-#: src/muuli_wdr.cpp:1324
-msgid "Keeps a dropdown list of your past search terms in the Search tab's Name field. This remembers the queries you typed, not the results they returned."
-msgstr ""
-
-#: src/muuli_wdr.cpp:1329
+#: src/muuli_wdr.cpp:1322
 msgid "Tooltip delay time: "
 msgstr "Tempo de atraso da janela de dica: "
 
-#: src/muuli_wdr.cpp:1336
+#: src/muuli_wdr.cpp:1329
 msgid "seconds"
 msgstr "segundos"
 
-#: src/muuli_wdr.cpp:1340
+#: src/muuli_wdr.cpp:1333
 msgid "Browser Selection"
 msgstr "Browser Padrão"
 
-#: src/muuli_wdr.cpp:1346
+#: src/muuli_wdr.cpp:1339
 msgid "Enter your browser name here. Leave this field empty to use the system default browser."
 msgstr "Insira o nome do seu navegador aqui. Deixe vazio para usar o navegador padrão do sistema."
 
-#: src/muuli_wdr.cpp:1353
+#: src/muuli_wdr.cpp:1346
 msgid "Open in new tab if possible"
 msgstr "Abrir em nova aba se possível"
 
-#: src/muuli_wdr.cpp:1355
+#: src/muuli_wdr.cpp:1348
 msgid "Open the web page in a new tab instead of in a new window when possible"
 msgstr "Abrir a webpage em nova aba quando possível, ao invés de uma nova janela"
 
-#: src/muuli_wdr.cpp:1359
+#: src/muuli_wdr.cpp:1352
 msgid "Video Player"
 msgstr "Player de Video"
 
-#: src/muuli_wdr.cpp:1386
+#: src/muuli_wdr.cpp:1379
 msgid "Bandwidth limits"
 msgstr "Limites de banda"
 
-#: src/muuli_wdr.cpp:1400
+#: src/muuli_wdr.cpp:1393
 msgid "Upload"
 msgstr "Upload"
 
-#: src/muuli_wdr.cpp:1408
+#: src/muuli_wdr.cpp:1401
 msgid "Slot Allocation"
 msgstr "Alocação de Slots"
 
-#: src/muuli_wdr.cpp:1417
+#: src/muuli_wdr.cpp:1410
 msgid "Ports"
 msgstr "Portas"
 
-#: src/muuli_wdr.cpp:1427
+#: src/muuli_wdr.cpp:1420
 msgid "This is the standard eD2k port and cannot be disabled."
 msgstr "Essa é a porta eD2k padrão e não pode ser desabilitada."
 
-#: src/muuli_wdr.cpp:1430
+#: src/muuli_wdr.cpp:1423
 msgid "UDP port for server requests (TCP+3):"
 msgstr "Porta UDP para requisições do servidor (TCP+3):"
 
-#: src/muuli_wdr.cpp:1432
+#: src/muuli_wdr.cpp:1425
 msgid "4665"
 msgstr "4665"
 
-#: src/muuli_wdr.cpp:1439
+#: src/muuli_wdr.cpp:1432
 msgid "This UDP port is used for extended eD2k requests and Kad network"
 msgstr "Essa porta UDP é usada para requisições eD2k estendidas e rede Kad"
 
-#: src/muuli_wdr.cpp:1446
+#: src/muuli_wdr.cpp:1439
 msgid "UPnP TCP Port (Optional):"
 msgstr "Porta TCP UPnP (Opcional):"
 
-#: src/muuli_wdr.cpp:1456
+#: src/muuli_wdr.cpp:1449
 msgid "Bind local address to IP (empty for any):"
 msgstr "Casar endereço local ao IP (vazio para qualquer um):"
 
-#: src/muuli_wdr.cpp:1459
+#: src/muuli_wdr.cpp:1452
 msgid "Advanced users only: If you have multiple network interfaces, enter the address of the interface to which aMule should be bound."
 msgstr "Somente usuários avançados: Se você tem múltiplas interfaces de rede, insira o endereço da interface com a qual o aMule deverá conectar-se."
 
-#: src/muuli_wdr.cpp:1462 src/muuli_wdr.cpp:2055
+#: src/muuli_wdr.cpp:1455 src/muuli_wdr.cpp:2054
 msgid "Bind to network interface (empty for any):"
 msgstr "Conectar a uma interface de rede (vazio equivale a todas):"
 
-#: src/muuli_wdr.cpp:1475
+#: src/muuli_wdr.cpp:1468
 msgid "Advanced users only: pin all of aMule's traffic to one network interface, chosen from the list or typed in by name (e.g. tun0, eth0, en0) or index. Unlike binding to an IP, this stops traffic leaking out via the default route - useful with a VPN. Requires no elevated privileges."
 msgstr "Apenas para usuários avançados: concentra todo tráfedo do aMule em uma interface de rede, escolhida da lista ou digitada por nome (e.g. tun0, eth0, en0) ou indice. Diferentemente da ligação por IP, isto impede que o tráfego vaze pela rota default - útil com uma VPN. Requer elevação de privilégios."
 
-#: src/muuli_wdr.cpp:1481
+#: src/muuli_wdr.cpp:1474
 msgid "Max sources per downloading file:"
 msgstr "Máximo de fontes para arquivos baixando:"
 
-#: src/muuli_wdr.cpp:1485
+#: src/muuli_wdr.cpp:1478
 msgid "Max simultaneous connections:"
 msgstr "Máximo de conexões simultâneas:"
 
-#: src/muuli_wdr.cpp:1498 src/muuli_wdr.cpp:3197
+#: src/muuli_wdr.cpp:1491 src/muuli_wdr.cpp:3169
 msgid "ED2K"
 msgstr "ED2K"
 
-#: src/muuli_wdr.cpp:1505
+#: src/muuli_wdr.cpp:1498
 msgid "Autoconnect on startup"
 msgstr "Auto-conectar ao iniciar"
 
-#: src/muuli_wdr.cpp:1508
+#: src/muuli_wdr.cpp:1501
 msgid "Reconnect on loss"
 msgstr "Reconectar ao ser desconectado"
 
-#: src/muuli_wdr.cpp:1530
+#: src/muuli_wdr.cpp:1523
 msgid "Remove dead server after"
 msgstr "Remover servidores inativos após"
 
-#: src/muuli_wdr.cpp:1531
+#: src/muuli_wdr.cpp:1524
 msgid "Static servers are never removed, even when unreachable."
 msgstr "Servidores estáticos nunca são removidos, mesmo que inalcançáveis."
 
-#: src/muuli_wdr.cpp:1535
+#: src/muuli_wdr.cpp:1528
 msgid "retries"
 msgstr "tentativas"
 
-#: src/muuli_wdr.cpp:1543
+#: src/muuli_wdr.cpp:1536
 msgid "List"
 msgstr "Lista"
 
-#: src/muuli_wdr.cpp:1546
+#: src/muuli_wdr.cpp:1539
 msgid "Update server list when connecting to a server"
 msgstr "Atualizar lista de servidores quando conectar em um servidor"
 
-#: src/muuli_wdr.cpp:1549
+#: src/muuli_wdr.cpp:1542
 msgid "Update server list when a client connects"
 msgstr "Atualizar lista de servidores quando um cliente conectar"
 
-#: src/muuli_wdr.cpp:1552
+#: src/muuli_wdr.cpp:1545
 msgid "Use priority system"
 msgstr "Usar sistema de prioridades"
 
-#: src/muuli_wdr.cpp:1556
+#: src/muuli_wdr.cpp:1549
 msgid "Use smart LowID check on connect"
 msgstr "Usar verificação inteligente de LowID ao conectar"
 
-#: src/muuli_wdr.cpp:1560
+#: src/muuli_wdr.cpp:1553
 msgid "Safe connect"
 msgstr "Conexão segura"
 
-#: src/muuli_wdr.cpp:1564
+#: src/muuli_wdr.cpp:1557
 msgid "Autoconnect to servers in static list only"
 msgstr "Auto-conectar somente em servidores da lista estática"
 
-#: src/muuli_wdr.cpp:1567
+#: src/muuli_wdr.cpp:1560
 msgid "Set manually added servers to High Priority"
 msgstr "Definir servidores adicionados manualmente com prioridade Alta"
 
-#: src/muuli_wdr.cpp:1588
+#: src/muuli_wdr.cpp:1581
 msgid "Add files to download in pause mode"
 msgstr "Adicionar novos downloads em pausa"
 
-#: src/muuli_wdr.cpp:1590
+#: src/muuli_wdr.cpp:1583
 msgid "Add files to download with auto priority"
 msgstr "Adicionar novos downloads com prioridade automática"
 
-#: src/muuli_wdr.cpp:1593
+#: src/muuli_wdr.cpp:1586
 msgid "Try to download first and last chunks first"
 msgstr "Tentar baixar o primeiro e o último pedaço do arquivo primeiro"
 
-#: src/muuli_wdr.cpp:1597
+#: src/muuli_wdr.cpp:1590
 msgid "Endgame mode: rotate to faster sources for the final blocks"
 msgstr "Modo \"Endgame\": roda para fontes mais rápidas nos blocos finais"
 
-#: src/muuli_wdr.cpp:1600
+#: src/muuli_wdr.cpp:1593
 msgid "Start next paused file when a file completes"
 msgstr "Começar o próximo arquivo pausado quando o arquivo completar"
 
-#: src/muuli_wdr.cpp:1603
+#: src/muuli_wdr.cpp:1596
 msgid "From the same category"
 msgstr "Da mesma categoria"
 
-#: src/muuli_wdr.cpp:1605
+#: src/muuli_wdr.cpp:1598
 msgid "In alphabetic order"
 msgstr "Em ordem alfabética"
 
-#: src/muuli_wdr.cpp:1607
+#: src/muuli_wdr.cpp:1600
 msgid "Preallocate disk space for new files"
 msgstr "Pré-alocar espaço em disco para novos arquivos"
 
-#: src/muuli_wdr.cpp:1608
+#: src/muuli_wdr.cpp:1601
 msgid "For new files preallocates disk space for the whole file, thus reduces fragmentation"
 msgstr "Para novos arquivos pré-alocar espaço em disco para todo o arquivo, isso reduz fragmentação"
 
-#: src/muuli_wdr.cpp:1613
+#: src/muuli_wdr.cpp:1606
+msgid "Create new files as sparse files"
+msgstr ""
+
+#: src/muuli_wdr.cpp:1607
+msgid "A sparse file reserves its full size on disk immediately without writing real data to it -- fast, but unsupported or slow on some filesystems, and free-space accounting stays optimistic while the download is in progress. Turn this off to grow the file only as data arrives."
+msgstr ""
+
+#: src/muuli_wdr.cpp:1612
 msgid "Stop downloads when free disk space reaches "
 msgstr "Parar download quando espaço livre em disco acabar "
 
-#: src/muuli_wdr.cpp:1614
+#: src/muuli_wdr.cpp:1613
 msgid "Select this if you want aMule to check your disk space"
 msgstr "Selecione isso se você quer uqe o aMule cheque seu espaço em disco"
 
-#: src/muuli_wdr.cpp:1618
+#: src/muuli_wdr.cpp:1617
 msgid "Enter here the min disk space desired."
 msgstr "Digite aqui o espaço min. de disco desejado."
 
-#: src/muuli_wdr.cpp:1624
+#: src/muuli_wdr.cpp:1623
 msgid "Save 10 sources on rare files (< 20 sources)"
 msgstr "Salvar 10 fontes em arquivos raros (< 20 fontes)"
 
-#: src/muuli_wdr.cpp:1628 src/Statistics.cpp:790
+#: src/muuli_wdr.cpp:1627 src/Statistics.cpp:790
 msgid "Uploads"
 msgstr "Uploads"
 
-#: src/muuli_wdr.cpp:1631
+#: src/muuli_wdr.cpp:1630
 msgid "Add new shared files with auto priority"
 msgstr "Adicionar novos compartilhamentos com prioridade automática"
 
-#: src/muuli_wdr.cpp:1637
+#: src/muuli_wdr.cpp:1636
 msgid "Intelligent Corruption Handling (I.C.H.)"
 msgstr "Manuseamento Inteligente de Corrupção (I.C.H.)"
 
-#: src/muuli_wdr.cpp:1640
+#: src/muuli_wdr.cpp:1639
 msgid "Enable"
 msgstr "Habilitado"
 
-#: src/muuli_wdr.cpp:1643
+#: src/muuli_wdr.cpp:1642
 msgid "Advanced I.C.H. trusts every hash (not recommended)"
 msgstr "I.C.H. avançado confia em todo hash (não recomendado)"
 
-#: src/muuli_wdr.cpp:1655 src/PrefsUnifiedDlg.cpp:1990
+#: src/muuli_wdr.cpp:1654 src/PrefsUnifiedDlg.cpp:1910
 msgid "Media metadata extraction"
 msgstr "Extração de metadados da mídia"
 
-#: src/muuli_wdr.cpp:1659
+#: src/muuli_wdr.cpp:1658
 msgid "Extract length / bitrate / codec from shared audio and video files"
 msgstr "Extrair compeimento / taxa de bits / codec de arquivos compartilhados de audio e vídeo"
 
-#: src/muuli_wdr.cpp:1661
+#: src/muuli_wdr.cpp:1660
 msgid "When enabled, aMule runs ffprobe on each shared media file to fill in the Length / Bitrate / Codec columns other clients see when they find the file in a search. Requires ffmpeg (the ffprobe binary) to be installed."
 msgstr "Quando habilitado, o aMule roda ffprobe em cada arquivo de mídia compartilhado para preencher as colunas de Comprimento / Taxa de Bits / Codec que os outros clientes veem quando acham o arquivo em uma procura. Requer que o ffmpeg (o binário ffprobe) esteja instalado."
 
-#: src/muuli_wdr.cpp:1668
+#: src/muuli_wdr.cpp:1667
 msgid "Path to ffprobe:"
 msgstr "Caminho para ffprobe:"
 
-#: src/muuli_wdr.cpp:1673
+#: src/muuli_wdr.cpp:1672
 msgid "Full path to the ffprobe binary. Leave empty to have aMule auto-detect it on startup."
 msgstr "Caminho completo para o binário ffprobe. Deixe vazio para que o aMule detecte automaticamente quando iniciar."
 
-#: src/muuli_wdr.cpp:1681
+#: src/muuli_wdr.cpp:1680
 msgid "Detect"
 msgstr "Detectar"
 
-#: src/muuli_wdr.cpp:1682
+#: src/muuli_wdr.cpp:1681
 msgid "Search the standard install locations for an ffprobe binary and fill the path field."
 msgstr "Procura nos locais de instalação padrão por um binário do ffprobe e preenche o campo de caminho."
 
-#: src/muuli_wdr.cpp:1706
+#: src/muuli_wdr.cpp:1705
 msgid ""
 "Completed downloads are stored here. All files in this folder are automatically shared with other peers.\n"
 "If this folder also holds files you don't want to share, point it at an aMule-only sub-folder."
@@ -4160,688 +4149,665 @@ msgstr ""
 "Downloads finalizados são guardados aqui. Todos os arquivos nesta pasta são automaticamente compartilhados com outros pares.\n"
 "Se esta pasta também guarda arquivos que você não quer compartilhar, aponte para uma sub-pasta só para o aMule."
 
-#: src/muuli_wdr.cpp:1709
+#: src/muuli_wdr.cpp:1708
 msgid "Pick the folder where completed downloads will be stored. All files in that folder will be shared with other peers."
 msgstr "Escolha a pasta onde os downloads terminados serão guardados. Todos os arquivos nesta pasta serão compartilhados com outros pares."
 
-#: src/muuli_wdr.cpp:1723
+#: src/muuli_wdr.cpp:1722
 msgid "Shared folders"
 msgstr "Pastas compartilhadas"
 
-#: src/muuli_wdr.cpp:1729
+#: src/muuli_wdr.cpp:1728
 msgid "(Folders shared by the core. Enter a path to add one.)"
 msgstr "(Pastas compartilhadas pelo núcleo. Digite um caminho para adicionar uma.)"
 
-#: src/muuli_wdr.cpp:1737
+#: src/muuli_wdr.cpp:1736
 msgid "Absolute path of a folder on the core's machine, e.g. /home/user/shared"
 msgstr "Caminho absoluto de uma pasta no núcleo da máquina, e.g. /home/user/shared"
 
-#: src/muuli_wdr.cpp:1739 src/PrefsUnifiedDlg.cpp:2874
+#: src/muuli_wdr.cpp:1738 src/PrefsUnifiedDlg.cpp:2794
 msgid "Recursive"
 msgstr "Recursivo"
 
-#: src/muuli_wdr.cpp:1740
+#: src/muuli_wdr.cpp:1739
 msgid "Share every sub-folder underneath this one, including ones created later."
 msgstr "Compartilhar todas as sub-pastas dentro desta, incluindo as criadas posteriormente."
 
-#: src/muuli_wdr.cpp:1744 src/utils/aLinkCreator/src/alcframe.cpp:141
+#: src/muuli_wdr.cpp:1743 src/utils/aLinkCreator/src/alcframe.cpp:141
 msgid "Remove"
 msgstr "Remover"
 
-#: src/muuli_wdr.cpp:1748
+#: src/muuli_wdr.cpp:1747
 msgid "(Right click on folder icon for recursive share)"
 msgstr "(Botão direito na pasta para compartilhar recursivamente)"
 
-#: src/muuli_wdr.cpp:1755
+#: src/muuli_wdr.cpp:1754
 msgid "Share hidden files"
 msgstr "Compartilhar arquivos ocultos"
 
-#: src/muuli_wdr.cpp:1761
+#: src/muuli_wdr.cpp:1760
 msgid "Automatically rescan shared folders for changes"
 msgstr "Vasculha novamente automaticamente arquivos compartilhados que mudaram"
 
-#: src/muuli_wdr.cpp:1767
+#: src/muuli_wdr.cpp:1766
 msgid "Follow symbolic links in shared folders"
 msgstr "Segue links simbólicos em pastas compartilhadas"
 
-#: src/muuli_wdr.cpp:1773
+#: src/muuli_wdr.cpp:1772
 msgid "Exclude files matching:"
 msgstr "Exclui arquivos correspondendo a:"
 
-#: src/muuli_wdr.cpp:1776
+#: src/muuli_wdr.cpp:1775
 msgid "Wildcard patterns separated by '|', e.g. .DS_Store|Thumbs.db|*.tmp. Files whose name matches are not shared. Matching is case-insensitive."
 msgstr "Caracteres curinga separados por '|', e.g. .DS_Store|Thumbs.db|*.tmp. Arquivos cujos nomes corresponderem não serão compartilhados. A correspondência é sensível à letra maiúscula/minúscula."
 
-#: src/muuli_wdr.cpp:1780
+#: src/muuli_wdr.cpp:1779
 msgid "Patterns are regular expressions"
 msgstr "Padrões são expressões regulares"
 
-#: src/muuli_wdr.cpp:1781
+#: src/muuli_wdr.cpp:1780
 msgid "When set, the whole field is one regular expression ('|' is alternation). When unset, it is a list of '|'-separated wildcards."
 msgstr "Quando ligado, o campo inteiro é uma expressão regular ('|' é alternativa). Quando desligado, é uma lista de caracteres curinga separados por '|'."
 
-#: src/muuli_wdr.cpp:1791
+#: src/muuli_wdr.cpp:1790
 msgid "Show how many shared files the current pattern would exclude."
 msgstr "Mostra quantos arquivos compartilhados o padrão atual excluiria."
 
-#: src/muuli_wdr.cpp:1812
+#: src/muuli_wdr.cpp:1811
 msgid "Graphs"
 msgstr "Gráficos"
 
-#: src/muuli_wdr.cpp:1815 src/muuli_wdr.cpp:1877
+#: src/muuli_wdr.cpp:1814 src/muuli_wdr.cpp:1876
 msgid "Update delay : 5 secs"
 msgstr "Tempo de atualização: 5s"
 
-#: src/muuli_wdr.cpp:1819
+#: src/muuli_wdr.cpp:1818
 msgid "Time for average graph: 100 mins"
 msgstr "Tempo para gráfico de média: 100min"
 
-#: src/muuli_wdr.cpp:1823
+#: src/muuli_wdr.cpp:1822
 msgid "Connections Graph Scale: 100 "
 msgstr "Escala dos gráficos das conexões: 100 "
 
-#: src/muuli_wdr.cpp:1830
+#: src/muuli_wdr.cpp:1829
 msgid "Download graph scale:"
 msgstr "Escala gráfica de download:"
 
-#: src/muuli_wdr.cpp:1838
+#: src/muuli_wdr.cpp:1837
 msgid "Upload graph scale:"
 msgstr "Escala gráfica de upload:"
 
-#: src/muuli_wdr.cpp:1848
+#: src/muuli_wdr.cpp:1847
 msgid "Colors: "
 msgstr "Cores: "
 
-#: src/muuli_wdr.cpp:1852
+#: src/muuli_wdr.cpp:1851
 msgid "Background"
 msgstr "Fundo"
 
-#: src/muuli_wdr.cpp:1853
+#: src/muuli_wdr.cpp:1852
 msgid "Grid"
 msgstr "Grade"
 
-#: src/muuli_wdr.cpp:1854
+#: src/muuli_wdr.cpp:1853
 msgid "Download current"
 msgstr "Download atual"
 
-#: src/muuli_wdr.cpp:1855
+#: src/muuli_wdr.cpp:1854
 msgid "Download running average"
 msgstr "Média dos Downloads ativos"
 
-#: src/muuli_wdr.cpp:1856
+#: src/muuli_wdr.cpp:1855
 msgid "Download session average"
 msgstr "Média dos Downloads da sessão"
 
-#: src/muuli_wdr.cpp:1857
+#: src/muuli_wdr.cpp:1856
 msgid "Upload current"
 msgstr "Upload Atual"
 
-#: src/muuli_wdr.cpp:1858
+#: src/muuli_wdr.cpp:1857
 msgid "Upload running average"
 msgstr "Média dos Uploads ativos"
 
-#: src/muuli_wdr.cpp:1859
+#: src/muuli_wdr.cpp:1858
 msgid "Upload session average"
 msgstr "Média dos Uploads da sessão"
 
-#: src/muuli_wdr.cpp:1860
+#: src/muuli_wdr.cpp:1859
 msgid "Active connections"
 msgstr "Conexões ativas"
 
-#: src/muuli_wdr.cpp:1863
+#: src/muuli_wdr.cpp:1862
 msgid "Systray Icon Speed Bar"
 msgstr "Ícone de barra de velocidade"
 
-#: src/muuli_wdr.cpp:1864
+#: src/muuli_wdr.cpp:1863
 msgid "Kad-nodes current"
 msgstr "Kad-nodes atuais"
 
-#: src/muuli_wdr.cpp:1865
+#: src/muuli_wdr.cpp:1864
 msgid "Kad-nodes running"
 msgstr "Kad-nodes rodando"
 
-#: src/muuli_wdr.cpp:1866
+#: src/muuli_wdr.cpp:1865
 msgid "Kad-nodes session"
 msgstr "Sessões Kad-nodes"
 
-#: src/muuli_wdr.cpp:1870 src/muuli_wdr.cpp:2324
+#: src/muuli_wdr.cpp:1869 src/muuli_wdr.cpp:2296
 msgid "Select"
 msgstr "Selecione"
 
-#: src/muuli_wdr.cpp:1874
+#: src/muuli_wdr.cpp:1873
 msgid "Tree"
 msgstr "Árvore"
 
-#: src/muuli_wdr.cpp:1884
+#: src/muuli_wdr.cpp:1883
 msgid "Number of Client Versions shown (0=unlimited)"
 msgstr "Número de versões a exibir (0=sem limite)"
 
-#: src/muuli_wdr.cpp:1909
+#: src/muuli_wdr.cpp:1908
 msgid "!!! WARNING !!!"
 msgstr "!!! CUIDADO !!!"
 
-#: src/muuli_wdr.cpp:1924
+#: src/muuli_wdr.cpp:1923
 msgid "Max new connections / 5 secs"
 msgstr "No. Max. de conexões / 5s"
 
-#: src/muuli_wdr.cpp:1926
+#: src/muuli_wdr.cpp:1925
 msgid "Concurrent Kad source lookups"
 msgstr "Procura concorrente de fontes Kad"
 
-#: src/muuli_wdr.cpp:1928
+#: src/muuli_wdr.cpp:1927
 msgid "Kad source re-search interval (minutes)"
 msgstr "Intervalo entre novas buscas de fontes Kad (minutos)"
 
-#: src/muuli_wdr.cpp:1930
+#: src/muuli_wdr.cpp:1929
 msgid "Source re-ask interval (minutes)"
 msgstr "Intervalo entre novos pedidos de fonte (minutos)"
 
-#: src/muuli_wdr.cpp:1934
+#: src/muuli_wdr.cpp:1933
 msgid "File Buffer Size: 240000 bytes"
 msgstr "Tamanho do arquivo buffer: 240000 bytes"
 
-#: src/muuli_wdr.cpp:1938
+#: src/muuli_wdr.cpp:1937
 msgid "Use MMAP: memory-mapped file access (lower memory use)"
 msgstr "Usar MMAP: acesso de arquivo mapeado em memória (menor uso de memória)"
 
-#: src/muuli_wdr.cpp:1939
+#: src/muuli_wdr.cpp:1938
 msgid "Maps part files into memory instead of buffering them on the heap, lowering the process memory footprint. May reduce download speed on some disks; best for memory-constrained or upload-heavy hosts."
 msgstr "Mapeia arquivos part em memória ao invés de buferizá-los na heap, diminuindo a pegada de memória do processo. Pode reduzir a velocidade de download em alguns discos; melhor para hopedeiros com memória restrita ou que façam upload intensivamente."
 
-#: src/muuli_wdr.cpp:1941
+#: src/muuli_wdr.cpp:1940
 msgid "Upload Queue Size: 5000 clients"
 msgstr "Tamanho de Espera de Upload: 5000 clientes"
 
-#: src/muuli_wdr.cpp:1945
+#: src/muuli_wdr.cpp:1944
 msgid "Server connection refresh interval: Disable"
 msgstr "Atualizar conexão com servidor: desativado"
 
-#: src/muuli_wdr.cpp:1949
+#: src/muuli_wdr.cpp:1948
 msgid "Disable computer's timed standby mode"
 msgstr "Desabilitar modo timed standby do computador"
 
-#: src/muuli_wdr.cpp:1968
+#: src/muuli_wdr.cpp:1967
 msgid "Skin to use: "
 msgstr "Pele a usar: "
 
-#: src/muuli_wdr.cpp:1977
+#: src/muuli_wdr.cpp:1976
 msgid "Show \"Fast eD2k Links Handler\" in every window."
 msgstr "Mostrar \"Manipulador Veloz de Ligações eD2k\" em cada janela."
 
-#: src/muuli_wdr.cpp:1980
+#: src/muuli_wdr.cpp:1979
 msgid "Show extended info on categories tabs"
 msgstr "Mostrar info. extras nas abas de categoria"
 
-#: src/muuli_wdr.cpp:1983
+#: src/muuli_wdr.cpp:1982
 msgid "Show application version on title"
 msgstr "Exibir versão do aplicativo no título"
 
-#: src/muuli_wdr.cpp:1985
+#: src/muuli_wdr.cpp:1984
 msgid "Show transfer rates on title"
 msgstr "Exibir taxa de transferência no título"
 
-#: src/muuli_wdr.cpp:1987
+#: src/muuli_wdr.cpp:1986
 msgid "Before application name"
 msgstr "Antes do nome da aplicação"
 
-#: src/muuli_wdr.cpp:1989
+#: src/muuli_wdr.cpp:1988
 msgid "After application name"
 msgstr "Depois do nome da aplicação"
 
-#: src/muuli_wdr.cpp:1992
+#: src/muuli_wdr.cpp:1991
 msgid "Show overhead bandwidth"
 msgstr "Mostrar banda sobressalente"
 
-#: src/muuli_wdr.cpp:1996
+#: src/muuli_wdr.cpp:1995
 msgid "Vertical toolbar orientation"
 msgstr "Orientação Vertical da Barra de Ferramentas"
 
-#: src/muuli_wdr.cpp:1998
+#: src/muuli_wdr.cpp:1997
 msgid "Live column sorting (auto-reorder rows as their values change)"
 msgstr "Ordenação de coluna ao vivo (reordenamento automático das colunas conforme seus valores mudam)"
 
-#: src/muuli_wdr.cpp:2005
+#: src/muuli_wdr.cpp:2004
 msgid "Download Queue Files"
 msgstr "Fila de arquivos baixando"
 
-#: src/muuli_wdr.cpp:2008
+#: src/muuli_wdr.cpp:2007
 msgid "Show progress percentage"
 msgstr "Mostrar porcentagem do progresso"
 
-#: src/muuli_wdr.cpp:2014
+#: src/muuli_wdr.cpp:2013
 msgid "Show progress bar"
 msgstr "Mostrar barra de progresso"
 
-#: src/muuli_wdr.cpp:2017
+#: src/muuli_wdr.cpp:2016
 msgid "Flat"
 msgstr "Plana"
 
-#: src/muuli_wdr.cpp:2021
+#: src/muuli_wdr.cpp:2020
 msgid "Round"
 msgstr "Arredondada"
 
-#: src/muuli_wdr.cpp:2039
+#: src/muuli_wdr.cpp:2038
 msgid "External Connection Parameters"
 msgstr "Parâmetros de conexão externa"
 
-#: src/muuli_wdr.cpp:2042
+#: src/muuli_wdr.cpp:2041
 msgid "Accept external connections"
 msgstr "Aceitar conexões externas"
 
-#: src/muuli_wdr.cpp:2049 src/muuli_wdr.cpp:2108
+#: src/muuli_wdr.cpp:2048 src/muuli_wdr.cpp:2107
 msgid "IP of the listening interface:"
 msgstr "IP da interface ouvindo:"
 
-#: src/muuli_wdr.cpp:2052
+#: src/muuli_wdr.cpp:2051
 msgid "Enter here a valid ip in the a.b.c.d format for the listening EC interface. An empty field or 0.0.0.0 will mean any interface."
 msgstr "Informe um IP válido no formato a.b.c.d para a interface EC que ficará aguardando. Um campo vazio ou 0.0.0.0 quer dizer 'qualquer interface'."
 
-#: src/muuli_wdr.cpp:2073 src/muuli_wdr.cpp:2184
+#: src/muuli_wdr.cpp:2072 src/muuli_wdr.cpp:2156
 msgid "TCP port:"
 msgstr "Porta TCP:"
 
-#: src/muuli_wdr.cpp:2079
+#: src/muuli_wdr.cpp:2078
 msgid "Enable UPnP port forwarding on the EC port"
 msgstr "Habilitar redirecionamento de porta UPnP para porta EC"
 
-#: src/muuli_wdr.cpp:2083 src/muuli_wdr.cpp:3069
+#: src/muuli_wdr.cpp:2082 src/muuli_wdr.cpp:3041
 #: src/utils/wxCas/src/wxcasprefs.cpp:167
 msgid "Password"
 msgstr "Senha"
 
-#: src/muuli_wdr.cpp:2089
+#: src/muuli_wdr.cpp:2088
 msgid "aMule API server parameters"
 msgstr "Parâmetros do servidor da API do aMule"
 
-#: src/muuli_wdr.cpp:2092
+#: src/muuli_wdr.cpp:2091
 msgid "Run amuleapi (REST API) on startup"
 msgstr "Rodar o amuleapi (REST API) ao iniciar"
 
-#: src/muuli_wdr.cpp:2097
+#: src/muuli_wdr.cpp:2096
 msgid "HTTP port:"
 msgstr "Porta HTTP:"
 
-#: src/muuli_wdr.cpp:2111
+#: src/muuli_wdr.cpp:2110
 msgid "The interface amuleapi's HTTP server listens on. 127.0.0.1 (default) accepts only local connections; use 0.0.0.0 or a specific IP to expose it to other hosts (set an admin password below)."
 msgstr "A interface do servidor HTTP do amuleapi que escuta em 127.0.0.1 (padrão) aceita apenas conexões locais; use 0.0.0.0 or um IP específico para expô-la a outros hospedeiros (configure uma senha de administração abaixo)."
 
-#: src/muuli_wdr.cpp:2116
-msgid "Type a password to set or change it. Stored passwords cannot be shown, so leaving this empty keeps the current one."
-msgstr ""
-
-#: src/muuli_wdr.cpp:2118
+#: src/muuli_wdr.cpp:2113
 msgid "Admin password"
 msgstr "Senha de administração"
 
-#: src/muuli_wdr.cpp:2130 src/muuli_wdr.cpp:2147 src/PrefsUnifiedDlg.cpp:1103
-#, fuzzy
-msgid "A password is set."
-msgstr "Senha de administração"
-
-#: src/muuli_wdr.cpp:2134
-#, fuzzy
-msgid "Enable guest access"
-msgstr "Negar acesso restrito"
-
-#: src/muuli_wdr.cpp:2135
-msgid "Guest sessions may read status and listings but cannot change anything. Turning this off clears the stored guest password."
-msgstr ""
-
-#: src/muuli_wdr.cpp:2139
-#, fuzzy
-msgid "Guest password"
-msgstr "Senha de visitante para servidor web"
-
-#: src/muuli_wdr.cpp:2154
-msgid "Web server parameters"
-msgstr "Parâmetros do web server"
-
-#: src/muuli_wdr.cpp:2157
-msgid "Run webserver on startup (deprecated)"
-msgstr "Rodar webserver ao iniciar (deprecado)"
-
-#: src/muuli_wdr.cpp:2163
-msgid "Web template"
-msgstr "Modelo de rede"
-
-#: src/muuli_wdr.cpp:2168
-msgid "Full rights password"
-msgstr "Password para acesso completo"
-
-#: src/muuli_wdr.cpp:2172
-msgid "Enable Low rights User"
-msgstr "Usuário com direitos limitados"
-
-#: src/muuli_wdr.cpp:2177
+#: src/muuli_wdr.cpp:2118 src/muuli_wdr.cpp:2149
 msgid "Low rights password"
 msgstr "Password para acesso limitado"
 
-#: src/muuli_wdr.cpp:2191
+#: src/muuli_wdr.cpp:2126
+msgid "Web server parameters"
+msgstr "Parâmetros do web server"
+
+#: src/muuli_wdr.cpp:2129
+msgid "Run webserver on startup (deprecated)"
+msgstr "Rodar webserver ao iniciar (deprecado)"
+
+#: src/muuli_wdr.cpp:2135
+msgid "Web template"
+msgstr "Modelo de rede"
+
+#: src/muuli_wdr.cpp:2140
+msgid "Full rights password"
+msgstr "Password para acesso completo"
+
+#: src/muuli_wdr.cpp:2144
+msgid "Enable Low rights User"
+msgstr "Usuário com direitos limitados"
+
+#: src/muuli_wdr.cpp:2163
 msgid "Enable UPnP port forwarding of the web server port"
 msgstr "Habilitar redirecionamento de porta UPnP da porta do servidor web"
 
-#: src/muuli_wdr.cpp:2196
+#: src/muuli_wdr.cpp:2168
 msgid "Web server UPnP TCP port (Optional)"
 msgstr "Porta TCP UPnP do servidor web (Opcional)"
 
-#: src/muuli_wdr.cpp:2204
+#: src/muuli_wdr.cpp:2176
 msgid "Page Refresh Time (in secs)"
 msgstr "Tempo atualização (secs)"
 
-#: src/muuli_wdr.cpp:2211
+#: src/muuli_wdr.cpp:2183
 msgid "Enable Gzip compression"
 msgstr "Ativar compactação Gzip"
 
-#: src/muuli_wdr.cpp:2245
+#: src/muuli_wdr.cpp:2217
 msgid "Reset page to defaults"
 msgstr "Retorna a página aos valores padrão"
 
-#: src/muuli_wdr.cpp:2246
+#: src/muuli_wdr.cpp:2218
 msgid "Reset the settings on the current page to their default values."
 msgstr "Reseta as configurações na página atual para seus valores padrão."
 
-#: src/muuli_wdr.cpp:2248 src/muuli_wdr.cpp:2334 src/ServerWnd.cpp:274
+#: src/muuli_wdr.cpp:2220 src/muuli_wdr.cpp:2306 src/ServerWnd.cpp:274
 #: src/ServerWnd.cpp:282
 msgid "OK"
 msgstr "OK"
 
-#: src/muuli_wdr.cpp:2250
+#: src/muuli_wdr.cpp:2222
 msgid "Click here to apply any changes made to the preferences."
 msgstr "Clique aqui para aplicar as alterações feitas."
 
-#: src/muuli_wdr.cpp:2253
+#: src/muuli_wdr.cpp:2225
 msgid "Reset any changes made to the preferences."
 msgstr "Ignora todas as alterações feitas."
 
-#: src/muuli_wdr.cpp:2282
+#: src/muuli_wdr.cpp:2254
 msgid "Comment :"
 msgstr "Comentário:"
 
-#: src/muuli_wdr.cpp:2289
+#: src/muuli_wdr.cpp:2261
 msgid "Incoming Dir :"
 msgstr "Dir incoming:"
 
-#: src/muuli_wdr.cpp:2298
+#: src/muuli_wdr.cpp:2270
 msgid "Change priority for new assigned files :"
 msgstr "Alterar prioridade para novos arquivos:"
 
-#: src/muuli_wdr.cpp:2302
+#: src/muuli_wdr.cpp:2274
 msgid "Don't change"
 msgstr "Não alterar"
 
-#: src/muuli_wdr.cpp:2314
+#: src/muuli_wdr.cpp:2286
 msgid "Select color for this Category (currently selected) :"
 msgstr "Selecione a cor para esta Categoria (selecionada):"
 
-#: src/muuli_wdr.cpp:2381 src/muuli_wdr.cpp:2400 src/muuli_wdr.cpp:2422
+#: src/muuli_wdr.cpp:2353 src/muuli_wdr.cpp:2372 src/muuli_wdr.cpp:2394
 msgid "Click this button to reset the log."
 msgstr "Clique nesse botão para limpar o log."
 
-#: src/muuli_wdr.cpp:2441
+#: src/muuli_wdr.cpp:2413
 msgid "Click on this button to update the servers list from URL ..."
 msgstr "Clique nesse botão para atualizar a lista de servidores..."
 
-#: src/muuli_wdr.cpp:2445
+#: src/muuli_wdr.cpp:2417
 msgid "Server list"
 msgstr "Lista de servidores"
 
-#: src/muuli_wdr.cpp:2449
+#: src/muuli_wdr.cpp:2421
 msgid "Enter the url to a server.met file here and press the button to the left to update the list of known servers."
 msgstr "Informe a URL com o arquivo server.met aqui e pressione o botão a esquerda para atualizar a lista de servidores."
 
-#: src/muuli_wdr.cpp:2454
+#: src/muuli_wdr.cpp:2426
 msgid "Add server manually: Name"
 msgstr "Adicionar servidor manualmente: Nome"
 
-#: src/muuli_wdr.cpp:2457
+#: src/muuli_wdr.cpp:2429
 msgid "Enter the name of the new server here"
 msgstr "Informe o nome do novo servidor aqui"
 
-#: src/muuli_wdr.cpp:2459 src/ServerWnd.cpp:206
+#: src/muuli_wdr.cpp:2431 src/ServerWnd.cpp:206
 msgid "IP:Port"
 msgstr "IP:Porta"
 
-#: src/muuli_wdr.cpp:2462
+#: src/muuli_wdr.cpp:2434
 msgid "Enter the IP of the server here, using the x.x.x.x format."
 msgstr "Informe o IP do servidor no formato x.x.x.x nesse espaço."
 
-#: src/muuli_wdr.cpp:2468
+#: src/muuli_wdr.cpp:2440
 msgid "Enter the port of the server here."
 msgstr "Informe a porta do servidor aqui."
 
-#: src/muuli_wdr.cpp:2471
+#: src/muuli_wdr.cpp:2443
 msgid "Add manually a server (fill fields to the left before) ..."
 msgstr "Adicionar manualmente um servidor (preencha os campos ao lado antes)."
 
-#: src/muuli_wdr.cpp:2500
+#: src/muuli_wdr.cpp:2472
 msgid "aMule Log"
 msgstr "Log do aMule"
 
-#: src/muuli_wdr.cpp:2508
+#: src/muuli_wdr.cpp:2480
 msgid "Server Info"
 msgstr "Informações do Servidor"
 
-#: src/muuli_wdr.cpp:2512
+#: src/muuli_wdr.cpp:2484
 msgid "ED2K Info"
 msgstr "ED2K Info"
 
-#: src/muuli_wdr.cpp:2516
+#: src/muuli_wdr.cpp:2488
 msgid "Kad Info"
 msgstr "Informação de Kad"
 
-#: src/muuli_wdr.cpp:2544
+#: src/muuli_wdr.cpp:2516
 msgid "Click on this button to update the nodes list from URL ..."
 msgstr "Clique nesse botão para atualizar a lista de nodes da URL..."
 
-#: src/muuli_wdr.cpp:2548
+#: src/muuli_wdr.cpp:2520
 msgid "Nodes (0)"
 msgstr "Nós (0)"
 
-#: src/muuli_wdr.cpp:2552
+#: src/muuli_wdr.cpp:2524
 msgid "Enter the url to a nodes.dat file here and press the button to the left to update the list of known nodes."
 msgstr "Informe uma URL para um arquivo nodes.dat e pressione o botão da esquerda para atualizar a lista de nós conhecidos."
 
-#: src/muuli_wdr.cpp:2555
+#: src/muuli_wdr.cpp:2527
 msgid "Nodes stats"
 msgstr "Estatísticas dos Nodes"
 
-#: src/muuli_wdr.cpp:2597
+#: src/muuli_wdr.cpp:2569
 msgid "Bootstrap"
 msgstr "Inicialização"
 
-#: src/muuli_wdr.cpp:2600
+#: src/muuli_wdr.cpp:2572
 msgid "New node"
 msgstr "Novo node"
 
-#: src/muuli_wdr.cpp:2605
+#: src/muuli_wdr.cpp:2577
 msgid "IP:"
 msgstr "IP:"
 
-#: src/muuli_wdr.cpp:2625
+#: src/muuli_wdr.cpp:2597
 msgid "Port:"
 msgstr "Porta:"
 
-#: src/muuli_wdr.cpp:2638
+#: src/muuli_wdr.cpp:2610
 msgid "Bootstrap from known clients"
 msgstr "Inicializando de clientes conhecidos"
 
-#: src/muuli_wdr.cpp:2640
+#: src/muuli_wdr.cpp:2612
 msgid "Disconnect Kad"
 msgstr "Desconectar da rede Kad"
 
-#: src/muuli_wdr.cpp:2674
+#: src/muuli_wdr.cpp:2646
 msgid "Use Secure User Identification"
 msgstr "Utilizar Identificação Segura de Usuário"
 
-#: src/muuli_wdr.cpp:2676
+#: src/muuli_wdr.cpp:2648
 msgid "It is recommended to enable this option. You will not receive credits if SUI is not enabled."
 msgstr "É recomendável ativar essa opção. Você não receberá seus créditos se a identificação segura não estiver ativada."
 
-#: src/muuli_wdr.cpp:2678
+#: src/muuli_wdr.cpp:2650
 msgid "Protocol Obfuscation"
 msgstr "Obscurecimento de Protocolo"
 
-#: src/muuli_wdr.cpp:2681
+#: src/muuli_wdr.cpp:2653
 msgid "Support Protocol Obfuscation"
 msgstr "Suportar Obscurecimento de Protocolo"
 
-#: src/muuli_wdr.cpp:2683
+#: src/muuli_wdr.cpp:2655
 msgid "This option enabled Protocol Obfuscation, and makes aMule accept obfuscated connections from other clients."
 msgstr "Esta opção habilita Obscurecimento de Protocolo, e faz o aMule aceitar conexões obscuras (criptografadas) de outros clientes."
 
-#: src/muuli_wdr.cpp:2685
+#: src/muuli_wdr.cpp:2657
 msgid "Use obfuscation for outgoing connections"
 msgstr "Usar obscurecimento para conexões externas"
 
-#: src/muuli_wdr.cpp:2687
+#: src/muuli_wdr.cpp:2659
 msgid "This option makes aMule use Protocol Obfuscation when connecting other clients/servers."
 msgstr "Esta opção faz o aMule usar Obscurecimento de Protocolo quando conectando outros clientes/servidores."
 
-#: src/muuli_wdr.cpp:2689
+#: src/muuli_wdr.cpp:2661
 msgid "Accept only obfuscated connections"
 msgstr "Aceitar somente conexões obscuras"
 
-#: src/muuli_wdr.cpp:2690
+#: src/muuli_wdr.cpp:2662
 msgid "This option makes aMule only accept obfuscated connections. You will have less sources, but all your traffic will be obfuscated"
 msgstr "Esta opção faz o aMule aceitar somente conexões obscurecidas. Você terá menos fontes, mas todo seu tráfego será obscurecido"
 
-#: src/muuli_wdr.cpp:2695
+#: src/muuli_wdr.cpp:2667
 msgid "Everybody"
 msgstr "Todos"
 
-#: src/muuli_wdr.cpp:2697
+#: src/muuli_wdr.cpp:2669
 msgid "No one"
 msgstr "Nenhum"
 
-#: src/muuli_wdr.cpp:2699
+#: src/muuli_wdr.cpp:2671
 msgid "Who can see my shared files:"
 msgstr "Quem pode ver meus arquivos compartilhados:"
 
-#: src/muuli_wdr.cpp:2700
+#: src/muuli_wdr.cpp:2672
 msgid "Select who can request to view a list of your shared files."
 msgstr "Selecione quem pode pedir a sua lista de compartilhamentos."
 
-#: src/muuli_wdr.cpp:2702
+#: src/muuli_wdr.cpp:2674
 msgid "IP-Filtering"
 msgstr "Filtro de IP"
 
-#: src/muuli_wdr.cpp:2709
+#: src/muuli_wdr.cpp:2681
 msgid "Filter clients"
 msgstr "Filtrar clientes"
 
-#: src/muuli_wdr.cpp:2711
+#: src/muuli_wdr.cpp:2683
 msgid "Enable filtering of the client IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "Habilitar filtragem de IPs de clientes definidos no arquivo ~/.aMule/ipfilter.dat."
 
-#: src/muuli_wdr.cpp:2713
+#: src/muuli_wdr.cpp:2685
 msgid "Filter servers"
 msgstr "Filtrar servidores"
 
-#: src/muuli_wdr.cpp:2715
+#: src/muuli_wdr.cpp:2687
 msgid "Enable filtering of the server IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "Habilitar filtragem de IPs de servidores definidos no arquivo ~/.aMule/ipfilter.dat."
 
-#: src/muuli_wdr.cpp:2719
+#: src/muuli_wdr.cpp:2691
 msgid "Reload List"
 msgstr "Recarregar lista"
 
-#: src/muuli_wdr.cpp:2720
+#: src/muuli_wdr.cpp:2692
 msgid "Reload the list of IPs to filter from the file ~/.aMule/ipfilter.dat"
 msgstr "Recarregar lista de IPs a filtrar do arquivo ~/.aMule/ipfilter.dat"
 
-#: src/muuli_wdr.cpp:2726
+#: src/muuli_wdr.cpp:2698
 msgid "URL:"
 msgstr "URL:"
 
-#: src/muuli_wdr.cpp:2730 src/muuli_wdr.cpp:2923
+#: src/muuli_wdr.cpp:2702 src/muuli_wdr.cpp:2895
 msgid "Update now"
 msgstr "Atualizar agora"
 
-#: src/muuli_wdr.cpp:2733
+#: src/muuli_wdr.cpp:2705
 msgid "Auto-update ipfilter at startup"
 msgstr "Auto-atualizar ipfilter ao iniciar"
 
-#: src/muuli_wdr.cpp:2737
+#: src/muuli_wdr.cpp:2709
 msgid "Filtering Level:"
 msgstr "Níveis de Filtro:"
 
-#: src/muuli_wdr.cpp:2743
+#: src/muuli_wdr.cpp:2715
 msgid "Always filter LAN IPs"
 msgstr "Sempre filtrar IPs de redes LAN"
 
-#: src/muuli_wdr.cpp:2746
+#: src/muuli_wdr.cpp:2718
 msgid "Paranoid handling of non-matching IPs"
 msgstr "Manuseio paranoico de IPs não-casados"
 
-#: src/muuli_wdr.cpp:2748
+#: src/muuli_wdr.cpp:2720
 msgid "Rejects a packet when its source IP differs from the IP the client claims (an anti-spoofing check). Disable only if it causes connection problems."
 msgstr "Rejeita um pacote quando o IP de sua fonte difere do IP que o cliente clama (uma checagem anti-spoofing). Desabilite apenas se causar problemas de conexão."
 
-#: src/muuli_wdr.cpp:2750
+#: src/muuli_wdr.cpp:2722
 msgid "Use system-wide ipfilter.dat if available"
 msgstr "Utilizar ipfilter.dat global se disponível"
 
-#: src/muuli_wdr.cpp:2751
+#: src/muuli_wdr.cpp:2723
 msgid "If there's no local ipfilter.dat found, allow usage of a system-wide ipfilter file."
 msgstr "Se nenhum ipfilter.dat local for encontrado, permita o uso de um arquivo global."
 
-#: src/muuli_wdr.cpp:2768
+#: src/muuli_wdr.cpp:2740
 msgid "Enable Online-Signature"
 msgstr "Ativar Assinatura Online"
 
-#: src/muuli_wdr.cpp:2770
+#: src/muuli_wdr.cpp:2742
 msgid "Enables the writing of the OS file, which can be used by external apps to create signatures and the like."
 msgstr "Habilita a gravação do arquivo, que pode ser usado por programas externos."
 
-#: src/muuli_wdr.cpp:2774
+#: src/muuli_wdr.cpp:2746
 msgid "Update Frequency (Secs):"
 msgstr "Frequência de atualização (Seg):"
 
-#: src/muuli_wdr.cpp:2777
+#: src/muuli_wdr.cpp:2749
 msgid "Change the frequency (in seconds) of Online Signature updates."
 msgstr "Alterar frequência (em segundos) da atualização da Assinatura."
 
-#: src/muuli_wdr.cpp:2785
+#: src/muuli_wdr.cpp:2757
 msgid "Save online signature file in: "
 msgstr "Salvar arquivos de assinatura online em: "
 
-#: src/muuli_wdr.cpp:2791
+#: src/muuli_wdr.cpp:2763
 msgid "Click here to select the directory containing the the Online Signature files."
 msgstr "Clique aqui para definir pasta contendo os arquivos da Assinatura Online."
 
-#: src/muuli_wdr.cpp:2824
+#: src/muuli_wdr.cpp:2796
 msgid "Show country flags for clients"
 msgstr "Mostrar bandeiras nacionais para clientes"
 
-#: src/muuli_wdr.cpp:2825
+#: src/muuli_wdr.cpp:2797
 msgid "Render the country flag column in the transfers, queue and search views. Requires a valid MMDB GeoIP database (see below)."
 msgstr "Renderiza a coluna da bandeira do país nas transferências, filas e vistas de procura. Requer um banco de dados MMDB GeoIP válido (veja abaixo)."
 
-#: src/muuli_wdr.cpp:2830
+#: src/muuli_wdr.cpp:2802
 msgid "Database"
 msgstr "Banco de Dados"
 
-#: src/muuli_wdr.cpp:2846
+#: src/muuli_wdr.cpp:2818
 msgid "Source:"
 msgstr "Fonte:"
 
-#: src/muuli_wdr.cpp:2849
+#: src/muuli_wdr.cpp:2821
 msgid "DB-IP (free, no account)"
 msgstr "DB-IP (grátis, sem conta)"
 
-#: src/muuli_wdr.cpp:2850
+#: src/muuli_wdr.cpp:2822
 msgid "MaxMind GeoLite2 (free, account required)"
 msgstr "MaxMind GeoLite2 (grátis, requer conta)"
 
-#: src/muuli_wdr.cpp:2851
+#: src/muuli_wdr.cpp:2823
 msgid "Custom URL"
 msgstr "URL Customizada"
 
-#: src/muuli_wdr.cpp:2854
+#: src/muuli_wdr.cpp:2826
 msgid "Choose which provider supplies the GeoIP MMDB database. DB-IP is the default - no account required. MaxMind requires a free account + license key. Use Custom URL to point at any other MMDB host (e.g. a local mirror)."
 msgstr "Escolha qual provedor fornece o banco de dados MMDB GeoIP. DB-IP é o padrão - não requer conta. MaxMind requer uma conta grátis + chave de licensa. Use uma URL Customizada para apontar para qualquer outro anfitrião MMDB (e.g. um espelho local)."
 
-#: src/muuli_wdr.cpp:2871
+#: src/muuli_wdr.cpp:2843
 msgid ""
 "No configuration required.\n"
 "\n"
@@ -4853,11 +4819,11 @@ msgstr ""
 "Dados de IP-to-Country por DB-IP.com - https://db-ip.com\n"
 "Licensa: Creative Commons BY 4.0 - https://creativecommons.org/licenses/by/4.0/"
 
-#: src/muuli_wdr.cpp:2884
+#: src/muuli_wdr.cpp:2856
 msgid "License key:"
 msgstr "Chave de Licensa:"
 
-#: src/muuli_wdr.cpp:2890
+#: src/muuli_wdr.cpp:2862
 msgid ""
 "Sign up for a free MaxMind account, then generate a License Key:\n"
 "https://www.maxmind.com/en/geolite2/signup\n"
@@ -4873,11 +4839,11 @@ msgstr ""
 "Licensa: MaxMind GeoLite2 EULA - https://www.maxmind.com/en/geolite2/eula\n"
 "Requer atribuição e registro de conta; renove no mínimo a cada 30 dias."
 
-#: src/muuli_wdr.cpp:2905
+#: src/muuli_wdr.cpp:2877
 msgid "Download URL:"
 msgstr "URL de Download:"
 
-#: src/muuli_wdr.cpp:2911
+#: src/muuli_wdr.cpp:2883
 msgid ""
 "Must point to an .mmdb file or a .gz / .tar.gz containing one.\n"
 "URL may include credentials (https://user:pass@host/...).\n"
@@ -4887,211 +4853,211 @@ msgstr ""
 "A URL pode incluir credenciais (https://user:pass@host/...).\n"
 "License e termos de atribuição são realizados pela URL upstream - você é responsável."
 
-#: src/muuli_wdr.cpp:2924
+#: src/muuli_wdr.cpp:2896
 msgid "Download the GeoIP database from the selected source."
 msgstr "Baixe o banco de dados GeoIP da fonte selecionada."
 
-#: src/muuli_wdr.cpp:2926
+#: src/muuli_wdr.cpp:2898
 msgid "Auto-update on startup"
 msgstr "Auto-atualizar ao iniciar"
 
-#: src/muuli_wdr.cpp:2927
+#: src/muuli_wdr.cpp:2899
 msgid "Re-download the GeoIP database from the selected source every time aMule starts."
 msgstr "Baixe novamente o banco de dados GeoIP da fonte selecionada toda vez que o aMule iniciar."
 
-#: src/muuli_wdr.cpp:2950
+#: src/muuli_wdr.cpp:2922
 msgid "Filter incoming messages (except current chat):"
 msgstr "Filtrar mensagens (Exceto chat atual):"
 
-#: src/muuli_wdr.cpp:2952
+#: src/muuli_wdr.cpp:2924
 msgid "Filter all messages"
 msgstr "Filtrar todas as mensagens"
 
-#: src/muuli_wdr.cpp:2954
+#: src/muuli_wdr.cpp:2926
 msgid "Filter messages from people not on your friend list"
 msgstr "Filtrar mensagens de pessoas que não estão em sua lista"
 
-#: src/muuli_wdr.cpp:2956
+#: src/muuli_wdr.cpp:2928
 msgid "Filter messages from unknown clients"
 msgstr "Filtrar mensagens de clientes desconhecidos"
 
-#: src/muuli_wdr.cpp:2958
+#: src/muuli_wdr.cpp:2930
 msgid "Filter messages containing (use ',' as separator):"
 msgstr "Filtrar mensagens contendo (use ',' como separador):"
 
-#: src/muuli_wdr.cpp:2961 src/muuli_wdr.cpp:2972
+#: src/muuli_wdr.cpp:2933 src/muuli_wdr.cpp:2944
 msgid "add here the words amule should filter and block messages including it"
 msgstr "adicione aqui as palavras que o amule deve filtrar e bloquear nas mensagens"
 
-#: src/muuli_wdr.cpp:2963
+#: src/muuli_wdr.cpp:2935
 msgid "Show received messages in the log"
 msgstr "Mostrar mensagens recebidas no log"
 
-#: src/muuli_wdr.cpp:2966
+#: src/muuli_wdr.cpp:2938
 msgid "Comments"
 msgstr "Comentários"
 
-#: src/muuli_wdr.cpp:2969
+#: src/muuli_wdr.cpp:2941
 msgid "Filter comments containing (use ',' as separator):"
 msgstr "Filtrar comentários contendo (use '.' como separador):"
 
-#: src/muuli_wdr.cpp:2994
+#: src/muuli_wdr.cpp:2966
 msgid "Enable Proxy"
 msgstr "Ativar proxy"
 
-#: src/muuli_wdr.cpp:2995
+#: src/muuli_wdr.cpp:2967
 msgid "Enable/disable proxy support"
 msgstr "Ativa/desativa suporte a proxy"
 
-#: src/muuli_wdr.cpp:2998
+#: src/muuli_wdr.cpp:2970
 msgid "Proxy type:"
 msgstr "Tipo de proxy:"
 
-#: src/muuli_wdr.cpp:3009
+#: src/muuli_wdr.cpp:2981
 msgid "Proxy host:"
 msgstr "Host do Proxy:"
 
-#: src/muuli_wdr.cpp:3012
+#: src/muuli_wdr.cpp:2984
 msgid "The proxy host name"
 msgstr "Nome do Host do proxy"
 
-#: src/muuli_wdr.cpp:3014
+#: src/muuli_wdr.cpp:2986
 msgid "Proxy port:"
 msgstr "Porta do Proxy:"
 
-#: src/muuli_wdr.cpp:3017
+#: src/muuli_wdr.cpp:2989
 msgid "The proxy port"
 msgstr "Porta do Proxy"
 
-#: src/muuli_wdr.cpp:3019
+#: src/muuli_wdr.cpp:2991
 msgid "Enable authentication"
 msgstr "Ativar autenticação"
 
-#: src/muuli_wdr.cpp:3020
+#: src/muuli_wdr.cpp:2992
 msgid "Enable/disable username/password authentication"
 msgstr "Ativa/Desativa autenticação por usuário/senha"
 
-#: src/muuli_wdr.cpp:3023
+#: src/muuli_wdr.cpp:2995
 msgid "Username: "
 msgstr "Nome do usuário: "
 
-#: src/muuli_wdr.cpp:3026
+#: src/muuli_wdr.cpp:2998
 msgid "The username to use to connect to the proxy"
 msgstr "Nome do usuário para conectar ao proxy"
 
-#: src/muuli_wdr.cpp:3028
+#: src/muuli_wdr.cpp:3000
 msgid "Password:"
 msgstr "Senha:"
 
-#: src/muuli_wdr.cpp:3031
+#: src/muuli_wdr.cpp:3003
 msgid "The password to use to connect to the proxy"
 msgstr "Senha utilizada para conectar ao proxy"
 
-#: src/muuli_wdr.cpp:3050
+#: src/muuli_wdr.cpp:3022
 msgid "Connect to:"
 msgstr "Conectar em:"
 
-#: src/muuli_wdr.cpp:3059
+#: src/muuli_wdr.cpp:3031
 msgid "Login to remote amule"
 msgstr "Fazer login em amule remoto"
 
-#: src/muuli_wdr.cpp:3064
+#: src/muuli_wdr.cpp:3036
 msgid "User name"
 msgstr "Usuário"
 
-#: src/muuli_wdr.cpp:3075
+#: src/muuli_wdr.cpp:3047
 msgid "Remember those settings"
 msgstr "Lembrar essas definições"
 
-#: src/muuli_wdr.cpp:3078
+#: src/muuli_wdr.cpp:3050
 msgid "Force ZLIB compression"
 msgstr "Força compressão ZLIB"
 
-#: src/muuli_wdr.cpp:3102
+#: src/muuli_wdr.cpp:3074
 msgid "Enable Verbose Debug-Logging."
 msgstr "Ativar log de debug detalhado."
 
-#: src/muuli_wdr.cpp:3104
+#: src/muuli_wdr.cpp:3076
 msgid "Only to Logfile"
 msgstr "Apenas para o arquivo de log"
 
-#: src/muuli_wdr.cpp:3106
+#: src/muuli_wdr.cpp:3078
 msgid "Message Categories:"
 msgstr "Categorias de Mensagens:"
 
-#: src/muuli_wdr.cpp:3130 src/PartFileConvertDlg.cpp:160
+#: src/muuli_wdr.cpp:3102 src/PartFileConvertDlg.cpp:160
 msgid "Waiting..."
 msgstr "Aguardando..."
 
-#: src/muuli_wdr.cpp:3150
+#: src/muuli_wdr.cpp:3122
 msgid "Add imports"
 msgstr "Adicionar importadas"
 
-#: src/muuli_wdr.cpp:3153
+#: src/muuli_wdr.cpp:3125
 msgid "Retry selected"
 msgstr "Tentar novamente selecionada"
 
-#: src/muuli_wdr.cpp:3155
+#: src/muuli_wdr.cpp:3127
 msgid "Remove selected"
 msgstr "Remover selecionada"
 
-#: src/muuli_wdr.cpp:3218
+#: src/muuli_wdr.cpp:3190
 msgid "Event Types"
 msgstr "Tipos de Eventos"
 
-#: src/muuli_wdr.cpp:3237
+#: src/muuli_wdr.cpp:3209
 msgid "Statistics and queued clients for selected file(s) : Session / All time"
 msgstr "Estatísticas e filas de clientes para arquivo(s) selecionado(s) : Sessão / Sempre"
 
-#: src/muuli_wdr.cpp:3261
+#: src/muuli_wdr.cpp:3233
 msgid "Active Uploads"
 msgstr "Uploads Ativos"
 
-#: src/muuli_wdr.cpp:3275
+#: src/muuli_wdr.cpp:3247
 msgid "Percent of total files"
 msgstr "Porcentagem de total de arquivos"
 
-#: src/muuli_wdr.cpp:3327
+#: src/muuli_wdr.cpp:3299
 msgid "Show Clients for"
 msgstr "Exibir Clientes para"
 
-#: src/muuli_wdr.cpp:3329
+#: src/muuli_wdr.cpp:3301
 msgid "All files"
 msgstr "Todos os arquivos"
 
-#: src/muuli_wdr.cpp:3332
+#: src/muuli_wdr.cpp:3304
 msgid "Selected files"
 msgstr "Arquivos selecionados"
 
-#: src/muuli_wdr.cpp:3335
+#: src/muuli_wdr.cpp:3307
 msgid "Active uploads only"
 msgstr "Somente uploads ativos"
 
-#: src/muuli_wdr.cpp:3342
+#: src/muuli_wdr.cpp:3314
 msgid "Reload:"
 msgstr "Recarregar:"
 
-#: src/muuli_wdr.cpp:3346
+#: src/muuli_wdr.cpp:3318
 msgid "Reload your shared files"
 msgstr "Atualizar lista de compartilhados"
 
-#: src/muuli_wdr.cpp:3409
+#: src/muuli_wdr.cpp:3381
 msgid "Send"
 msgstr "Enviar"
 
-#: src/muuli_wdr.cpp:3410
+#: src/muuli_wdr.cpp:3382
 msgid "Sends the specified message."
 msgstr "Enviar a mensagem especificada."
 
-#: src/muuli_wdr.cpp:3414
+#: src/muuli_wdr.cpp:3386
 msgid "Close this chat-session."
 msgstr "Encerrar sessão de Chat."
 
-#: src/muuli_wdr.cpp:3437
+#: src/muuli_wdr.cpp:3409
 msgid "Connect to any server and/or Kad"
 msgstr "Conectar a qualquer servidor e/ou Kad"
 
-#: src/muuli_wdr.cpp:3443 src/SharedFilesCtrl.cpp:142 src/Statistics.cpp:941
+#: src/muuli_wdr.cpp:3415 src/SharedFilesCtrl.cpp:142 src/Statistics.cpp:941
 msgid "Shared Files"
 msgstr "Arquivos Compartilhados"
 
@@ -5451,248 +5417,248 @@ msgstr "Baixado"
 msgid "ERROR: Failed to open partfile '%s'"
 msgstr "ERRO: Falha ao abrir partfile '%s'"
 
-#: src/Preferences.cpp:701
+#: src/Preferences.cpp:673
 msgid "System default"
 msgstr "Padrão do sistema"
 
-#: src/Preferences.cpp:702
+#: src/Preferences.cpp:674
 msgid "Albanian"
 msgstr "Albanês"
 
-#: src/Preferences.cpp:703
+#: src/Preferences.cpp:675
 msgid "Arabic"
 msgstr "Árabe"
 
-#: src/Preferences.cpp:704
+#: src/Preferences.cpp:676
 msgid "Asturian"
 msgstr "Asturiano"
 
-#: src/Preferences.cpp:705
+#: src/Preferences.cpp:677
 msgid "Basque"
 msgstr "Basco"
 
-#: src/Preferences.cpp:706
+#: src/Preferences.cpp:678
 msgid "Bulgarian"
 msgstr "Búlgaro"
 
-#: src/Preferences.cpp:707
+#: src/Preferences.cpp:679
 msgid "Catalan"
 msgstr "Catalão"
 
-#: src/Preferences.cpp:708
+#: src/Preferences.cpp:680
 msgid "Chinese (Simplified)"
 msgstr "Chinês (Simplificado)"
 
-#: src/Preferences.cpp:709
+#: src/Preferences.cpp:681
 msgid "Chinese (Traditional)"
 msgstr "Chinês (Tradicional)"
 
-#: src/Preferences.cpp:710
+#: src/Preferences.cpp:682
 msgid "Croatian"
 msgstr "Croácia"
 
-#: src/Preferences.cpp:711
+#: src/Preferences.cpp:683
 msgid "Czech"
 msgstr "Tcheco"
 
-#: src/Preferences.cpp:712
+#: src/Preferences.cpp:684
 msgid "Danish"
 msgstr "Dinamarquês"
 
-#: src/Preferences.cpp:713
+#: src/Preferences.cpp:685
 msgid "Dutch"
 msgstr "Holandês"
 
-#: src/Preferences.cpp:714
+#: src/Preferences.cpp:686
 msgid "English (U.K.)"
 msgstr "Inglês (UK)"
 
-#: src/Preferences.cpp:715
+#: src/Preferences.cpp:687
 msgid "English (U.S.)"
 msgstr "Inglês (U.S.)"
 
-#: src/Preferences.cpp:716
+#: src/Preferences.cpp:688
 msgid "Estonian"
 msgstr "Estônia"
 
-#: src/Preferences.cpp:717
+#: src/Preferences.cpp:689
 msgid "Finnish"
 msgstr "Finlandês"
 
-#: src/Preferences.cpp:718
+#: src/Preferences.cpp:690
 msgid "French"
 msgstr "Francês"
 
-#: src/Preferences.cpp:719
+#: src/Preferences.cpp:691
 msgid "Galician"
 msgstr "Galego"
 
-#: src/Preferences.cpp:720
+#: src/Preferences.cpp:692
 msgid "German"
 msgstr "Alemão"
 
-#: src/Preferences.cpp:721
+#: src/Preferences.cpp:693
 msgid "Greek"
 msgstr "Grego"
 
-#: src/Preferences.cpp:722
+#: src/Preferences.cpp:694
 msgid "Hebrew"
 msgstr "Hebreu"
 
-#: src/Preferences.cpp:723
+#: src/Preferences.cpp:695
 msgid "Hungarian"
 msgstr "Hungria"
 
-#: src/Preferences.cpp:724
+#: src/Preferences.cpp:696
 msgid "Italian"
 msgstr "Italiano"
 
-#: src/Preferences.cpp:725
+#: src/Preferences.cpp:697
 msgid "Japanese"
 msgstr "Japonês"
 
-#: src/Preferences.cpp:726
+#: src/Preferences.cpp:698
 msgid "Korean"
 msgstr "Coreano"
 
-#: src/Preferences.cpp:727
+#: src/Preferences.cpp:699
 msgid "Latvian"
 msgstr "Letão"
 
-#: src/Preferences.cpp:728
+#: src/Preferences.cpp:700
 msgid "Lithuanian"
 msgstr "Lituânia"
 
-#: src/Preferences.cpp:729
+#: src/Preferences.cpp:701
 msgid "Norwegian (Nynorsk)"
 msgstr "Noruega (Nynorsk)"
 
-#: src/Preferences.cpp:730
+#: src/Preferences.cpp:702
 msgid "Polish"
 msgstr "Polonês"
 
-#: src/Preferences.cpp:731
+#: src/Preferences.cpp:703
 msgid "Portuguese"
 msgstr "Português (Portugal)"
 
-#: src/Preferences.cpp:732
+#: src/Preferences.cpp:704
 msgid "Portuguese (Brazilian)"
 msgstr "Português (Brasil)"
 
-#: src/Preferences.cpp:733
+#: src/Preferences.cpp:705
 msgid "Romanian"
 msgstr "Albanês"
 
-#: src/Preferences.cpp:734
+#: src/Preferences.cpp:706
 msgid "Russian"
 msgstr "Russo"
 
-#: src/Preferences.cpp:735
+#: src/Preferences.cpp:707
 msgid "Slovenian"
 msgstr "Esloveno"
 
-#: src/Preferences.cpp:736
+#: src/Preferences.cpp:708
 msgid "Spanish"
 msgstr "Espanhol"
 
-#: src/Preferences.cpp:737
+#: src/Preferences.cpp:709
 msgid "Swedish"
 msgstr "Suécia"
 
-#: src/Preferences.cpp:738
+#: src/Preferences.cpp:710
 msgid "Turkish"
 msgstr "Turquia"
 
-#: src/Preferences.cpp:739
+#: src/Preferences.cpp:711
 msgid "Ukrainian"
 msgstr "Ucraniano"
 
-#: src/Preferences.cpp:842
+#: src/Preferences.cpp:814
 msgid "Change Language"
 msgstr "Mudar Idioma"
 
-#: src/Preferences.cpp:906
+#: src/Preferences.cpp:878
 msgid "There are no translations installed for aMule"
 msgstr "Não há traduções instaladas no aMule"
 
-#: src/Preferences.cpp:907
+#: src/Preferences.cpp:879
 msgid "No languages available"
 msgstr "Nenhum idioma disponível"
 
-#: src/Preferences.cpp:1038
+#: src/Preferences.cpp:1010
 msgid "no options available"
 msgstr "nenhuma opção disponível"
 
-#: src/Preferences.cpp:2226
+#: src/Preferences.cpp:2179
 msgid "Invalid category found, skipping"
 msgstr "Categoria inválida encontrada, pulando"
 
-#: src/Preferences.cpp:2395
+#: src/Preferences.cpp:2348
 msgid "TCP port can't be higher than 65532 due to server UDP socket being TCP+3"
 msgstr "Porta TCP não pode ser maior do que 65532, pois a UDP escuta em TCP+3"
 
-#: src/Preferences.cpp:2396
+#: src/Preferences.cpp:2349
 #, c-format
 msgid "Default port will be used (%d)"
 msgstr "Porta padrão será utilizada (%d)"
 
-#: src/PrefsUnifiedDlg.cpp:300 src/Statistics.cpp:866
+#: src/PrefsUnifiedDlg.cpp:298 src/Statistics.cpp:866
 msgid "Connection"
 msgstr "Conexão"
 
-#: src/PrefsUnifiedDlg.cpp:301 src/SearchListCtrl.cpp:117
+#: src/PrefsUnifiedDlg.cpp:299 src/SearchListCtrl.cpp:117
 msgid "Directories"
 msgstr "Diretórios"
 
-#: src/PrefsUnifiedDlg.cpp:302 src/Statistics.cpp:917
+#: src/PrefsUnifiedDlg.cpp:300 src/Statistics.cpp:917
 msgid "Servers"
 msgstr "Servidores"
 
-#: src/PrefsUnifiedDlg.cpp:303 src/ServerListCtrl.cpp:96
+#: src/PrefsUnifiedDlg.cpp:301 src/ServerListCtrl.cpp:96
 msgid "Files"
 msgstr "Arquivos"
 
-#: src/PrefsUnifiedDlg.cpp:304
+#: src/PrefsUnifiedDlg.cpp:302
 msgid "Security"
 msgstr "Segurança"
 
-#: src/PrefsUnifiedDlg.cpp:305
+#: src/PrefsUnifiedDlg.cpp:303
 msgid "Interface"
 msgstr "Interface"
 
-#: src/PrefsUnifiedDlg.cpp:312
+#: src/PrefsUnifiedDlg.cpp:310
 msgid "IP2Country"
 msgstr "IP2Country"
 
-#: src/PrefsUnifiedDlg.cpp:315
+#: src/PrefsUnifiedDlg.cpp:313
 msgid "Proxy"
 msgstr "Proxy"
 
-#: src/PrefsUnifiedDlg.cpp:316
+#: src/PrefsUnifiedDlg.cpp:314
 msgid "Filters"
 msgstr "Filtros"
 
-#: src/PrefsUnifiedDlg.cpp:317
+#: src/PrefsUnifiedDlg.cpp:315
 msgid "Remote Controls"
 msgstr "Controles remotos"
 
-#: src/PrefsUnifiedDlg.cpp:318
+#: src/PrefsUnifiedDlg.cpp:316
 msgid "Online Signature"
 msgstr "Assinatura Online"
 
-#: src/PrefsUnifiedDlg.cpp:319
+#: src/PrefsUnifiedDlg.cpp:317
 msgid "Advanced"
 msgstr "Avançado"
 
-#: src/PrefsUnifiedDlg.cpp:320
+#: src/PrefsUnifiedDlg.cpp:318
 msgid "Events"
 msgstr "Eventos"
 
-#: src/PrefsUnifiedDlg.cpp:323
+#: src/PrefsUnifiedDlg.cpp:321
 msgid "Debugging"
 msgstr "Debugando"
 
-#: src/PrefsUnifiedDlg.cpp:453
+#: src/PrefsUnifiedDlg.cpp:451
 msgid ""
 "The following variables will be substituted:\n"
 "    %PARTFILE - full path to the file\n"
@@ -5702,15 +5668,15 @@ msgstr ""
 "    %PARTFILE - caminhos completo para o arquivo\n"
 "    %PARTNAME - somente nome do arquivo"
 
-#: src/PrefsUnifiedDlg.cpp:474
+#: src/PrefsUnifiedDlg.cpp:472
 msgid "Tray icon support requires libayatana-appindicator3 at compile time."
 msgstr "O suporte para ícone da bandeja do sistema requer libayatana-appindicator3 em tempo de compilação."
 
-#: src/PrefsUnifiedDlg.cpp:490
+#: src/PrefsUnifiedDlg.cpp:488
 msgid "Not available on Wayland: the protocol does not report when a window is minimized, so this option cannot intercept the system minimize button. Workaround: launch aMule with `GDK_BACKEND=x11` to use XWayland instead."
 msgstr "Não disponível no Wayland: o protocolo não avisa quando uma janela foi minimizada, portanto esta opção não pode interceptar o botão de minimização do sistema. Alternativa: lance o aMule com `GDK_BACKEND=x11` para usar XWayland."
 
-#: src/PrefsUnifiedDlg.cpp:536
+#: src/PrefsUnifiedDlg.cpp:534
 msgid ""
 "Do not change these setting unless you know\n"
 "what you are doing, otherwise you can easily\n"
@@ -5726,35 +5692,26 @@ msgstr ""
 "O aMule funciona corretamente sem qualquer tipo de\n"
 "alteração nessas opções."
 
-#: src/PrefsUnifiedDlg.cpp:647
+#: src/PrefsUnifiedDlg.cpp:645
 #, c-format
 msgid "Failed to connect Cfg to widget with the ID %d and key %s"
 msgstr "Falha ao conectar Cfg para Widget com o ID %d e senha %s"
 
-#: src/PrefsUnifiedDlg.cpp:695
+#: src/PrefsUnifiedDlg.cpp:693
 #, c-format
 msgid "Failed to transfer data from Cfg to Widget with the ID %d and key %s"
 msgstr "Falha ao transferir dado do Cfg para Widget com o ID %d e senha %s"
 
-#: src/PrefsUnifiedDlg.cpp:801
+#: src/PrefsUnifiedDlg.cpp:799
 msgid "The type of proxy you are connecting to"
 msgstr "Tipo de proxy ao qual você está conectado"
 
-#: src/PrefsUnifiedDlg.cpp:1020
+#: src/PrefsUnifiedDlg.cpp:1003
 #, c-format
 msgid "Failed to transfer data from Widget to Cfg with the ID %d and key %s"
 msgstr "Falha ao transferir dado do Widget para Cfg com o ID %d e senha %s"
 
 #: src/PrefsUnifiedDlg.cpp:1103
-#, fuzzy
-msgid "No password set."
-msgstr "Senha de administração"
-
-#: src/PrefsUnifiedDlg.cpp:1132
-msgid "Guest access needs a password. Type one in the guest password field, or untick Enable guest access."
-msgstr ""
-
-#: src/PrefsUnifiedDlg.cpp:1144
 msgid ""
 "aMule must be restarted to enable these changes:\n"
 "\n"
@@ -5762,39 +5719,39 @@ msgstr ""
 "O aMule deve ser reiniciado para habilitar estas mudanças:\n"
 "\n"
 
-#: src/PrefsUnifiedDlg.cpp:1151
+#: src/PrefsUnifiedDlg.cpp:1110
 msgid "- TCP port changed.\n"
 msgstr "-Porta TCP alterada.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1156
+#: src/PrefsUnifiedDlg.cpp:1115
 msgid "- UDP port changed.\n"
 msgstr "-Porta UDP alterada.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1161
+#: src/PrefsUnifiedDlg.cpp:1120
 msgid "- Network interface binding changed.\n"
 msgstr "- Interface de conexão de rede modificada.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1166
+#: src/PrefsUnifiedDlg.cpp:1125
 msgid "- External connect port changed.\n"
 msgstr "- Porta de conexão externa modificada.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1170
+#: src/PrefsUnifiedDlg.cpp:1129
 msgid "- External connect acceptance changed.\n"
 msgstr "- Aceitação da conexão externa modificada.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1174
+#: src/PrefsUnifiedDlg.cpp:1133
 msgid "- External connect interface changed.\n"
 msgstr "- Interface de conexão externa modificada.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1178
+#: src/PrefsUnifiedDlg.cpp:1137
 msgid "- Protocol obfuscation support changed.\n"
 msgstr "- Suporte de protocolo de ofuscamento mudou.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1193
+#: src/PrefsUnifiedDlg.cpp:1151
 msgid "- amuleapi settings changed.\n"
 msgstr "- A configuração do amuleapi mudou.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1202
+#: src/PrefsUnifiedDlg.cpp:1160
 msgid ""
 "Your Auto-update server list is empty.\n"
 "'Auto-update server list at startup' will be disabled."
@@ -5802,7 +5759,7 @@ msgstr ""
 "Sua lista de Auto-atualização de servidor está vazia.\n"
 "'Auto-atualização de servidor na iniciação' será desativada."
 
-#: src/PrefsUnifiedDlg.cpp:1213
+#: src/PrefsUnifiedDlg.cpp:1171
 msgid ""
 "You have enabled external connections but have not specified a password.\n"
 "External connections cannot be enabled unless a valid password is specified."
@@ -5810,32 +5767,27 @@ msgstr ""
 "Você ativou as conexões externas mas não definiu uma senha.\n"
 "Conexões Externas só podem ser feitas se for especificada uma senha válida."
 
-#: src/PrefsUnifiedDlg.cpp:1246
-#, c-format
-msgid "The amuleapi password could not be saved: %s"
-msgstr ""
-
-#: src/PrefsUnifiedDlg.cpp:1276
+#: src/PrefsUnifiedDlg.cpp:1202
 msgid "- Language changed.\n"
 msgstr "-Idioma alterado.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1281
+#: src/PrefsUnifiedDlg.cpp:1207
 msgid "- Temp folder changed.\n"
 msgstr "-Diretório temporário alterado.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1286
+#: src/PrefsUnifiedDlg.cpp:1212
 msgid "- ED2K network enabled.\n"
 msgstr "- Rede ED2K conectada.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1319
+#: src/PrefsUnifiedDlg.cpp:1245
 msgid "The shared-file exclusion pattern is not a valid regular expression. The filter has been left disabled."
 msgstr "Este padrão de exclusão de arquivos compartilhados não é uma expressão regular válida. O filtro ficou desabilitado."
 
-#: src/PrefsUnifiedDlg.cpp:1321 src/PrefsUnifiedDlg.cpp:1921
+#: src/PrefsUnifiedDlg.cpp:1247 src/PrefsUnifiedDlg.cpp:1841
 msgid "Invalid regular expression"
 msgstr "Expressão regular inválida"
 
-#: src/PrefsUnifiedDlg.cpp:1398
+#: src/PrefsUnifiedDlg.cpp:1324
 msgid ""
 "Both eD2k and Kad network are disabled.\n"
 "You won't be able to connect until you enable at least one of them."
@@ -5843,7 +5795,7 @@ msgstr ""
 "Ambas rede eD2k e Kad estão desativadas.\n"
 "Você não será capaz de conectar senão habilitar pelo menos um deles."
 
-#: src/PrefsUnifiedDlg.cpp:1403
+#: src/PrefsUnifiedDlg.cpp:1329
 msgid ""
 "Kad will not start if your UDP port is disabled.\n"
 "Enable UDP port or disable Kad."
@@ -5851,7 +5803,7 @@ msgstr ""
 "Kad não iniciará se sua porta UDP estiver desabilitada.\n"
 "Habilite a porta UDP ou desative a rede Kad."
 
-#: src/PrefsUnifiedDlg.cpp:1459
+#: src/PrefsUnifiedDlg.cpp:1385
 msgid ""
 "\n"
 "You MUST restart aMule now.\n"
@@ -5861,68 +5813,68 @@ msgstr ""
 "Você DEVE reiniciar o aMule agora.\n"
 "Se você não reiniciá-lo agora, não reclame se algo de ruim acontecer.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1524
+#: src/PrefsUnifiedDlg.cpp:1450
 msgid "Could not register aMule for autostart at login. The autostart store may be read-only."
 msgstr "Não foi possível registrar o aMule para início automático no login. A lista de autostart pode estar como apenas leitura."
 
-#: src/PrefsUnifiedDlg.cpp:1526
+#: src/PrefsUnifiedDlg.cpp:1452
 msgid "Could not remove the autostart-at-login entry."
 msgstr "Não foi possível remover a entrada de início automático no login."
 
-#: src/PrefsUnifiedDlg.cpp:1527
+#: src/PrefsUnifiedDlg.cpp:1453
 msgid "Autostart"
 msgstr "Início automático"
 
-#: src/PrefsUnifiedDlg.cpp:1542
+#: src/PrefsUnifiedDlg.cpp:1468
 msgid "Register file type"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1542
+#: src/PrefsUnifiedDlg.cpp:1468
 msgid "Register URL handler"
 msgstr "Registrar manipulador de URL"
 
-#: src/PrefsUnifiedDlg.cpp:1550
+#: src/PrefsUnifiedDlg.cpp:1476
 #, c-format
 msgid "aMule only handles eD2k-compatible magnets. If you replace the current magnet handler (%s), BitTorrent magnet links will stop working - aMule cannot download BitTorrent content. Continue?"
 msgstr "O aMule lida apenas com links magnet compatíveis com eD2k. Se você trocar o manipulador atual (%s), links magnet deBitTorrent irão parar de funcionar - o aMule não pode baixar conteúdo BitTorrent. Continuar?"
 
-#: src/PrefsUnifiedDlg.cpp:1555
+#: src/PrefsUnifiedDlg.cpp:1481
 #, fuzzy, c-format
 msgid "Another application currently opens .emulecollection files (%s). Replace it with aMule?"
 msgstr "Atualmente um outro aplicativo é o manipulador padrão para estes links (%s). Troco ele pelo aMule?"
 
-#: src/PrefsUnifiedDlg.cpp:1560
+#: src/PrefsUnifiedDlg.cpp:1486
 #, c-format
 msgid "Another application is currently the default handler for these links (%s). Replace it with aMule?"
 msgstr "Atualmente um outro aplicativo é o manipulador padrão para estes links (%s). Troco ele pelo aMule?"
 
-#: src/PrefsUnifiedDlg.cpp:1585
+#: src/PrefsUnifiedDlg.cpp:1511
 #, fuzzy
 msgid "Could not register aMule for .emulecollection files. The registration store may be read-only."
 msgstr "Não foi possível registrar o aMule como manipulador de URL. O armazenamento deve estar como \"apenas leitura\"."
 
-#: src/PrefsUnifiedDlg.cpp:1587
+#: src/PrefsUnifiedDlg.cpp:1513
 #, fuzzy
 msgid "Could not remove the file type registration."
 msgstr "Não foi possível remover o registro de manipulação de URL."
 
-#: src/PrefsUnifiedDlg.cpp:1589
+#: src/PrefsUnifiedDlg.cpp:1515
 msgid "Could not register aMule as the URL handler. The registration store may be read-only."
 msgstr "Não foi possível registrar o aMule como manipulador de URL. O armazenamento deve estar como \"apenas leitura\"."
 
-#: src/PrefsUnifiedDlg.cpp:1591
+#: src/PrefsUnifiedDlg.cpp:1517
 msgid "Could not remove the URL handler registration."
 msgstr "Não foi possível remover o registro de manipulação de URL."
 
-#: src/PrefsUnifiedDlg.cpp:1661 src/PrefsUnifiedDlg.cpp:1688
+#: src/PrefsUnifiedDlg.cpp:1587 src/PrefsUnifiedDlg.cpp:1614
 msgid "The web server and aMule API require external connections to be enabled."
 msgstr "O servidor web e o aMule API necessitam que as conexões externas estejam habilitadas."
 
-#: src/PrefsUnifiedDlg.cpp:1671
+#: src/PrefsUnifiedDlg.cpp:1597
 msgid "The aMule web server is deprecated. Consider running the aMule API instead."
 msgstr "O servidor web do aMules está deprecado. Ao invés disso, considere rodar sob a API do aMule."
 
-#: src/PrefsUnifiedDlg.cpp:1735
+#: src/PrefsUnifiedDlg.cpp:1655
 msgid ""
 "Your Auto-update servers list is in blank.\n"
 "Please fill in at least one URL to point to a valid server.met file.\n"
@@ -5932,64 +5884,64 @@ msgstr ""
 "Coloque pelo menos uma linha que aponte para um server.met válido.\n"
 "Clique no botão \"Lista\" para abrir a caixa para digitar uma URL."
 
-#: src/PrefsUnifiedDlg.cpp:1876
+#: src/PrefsUnifiedDlg.cpp:1796
 msgid "Temporary files"
 msgstr "Arquivos Temporários"
 
-#: src/PrefsUnifiedDlg.cpp:1881
+#: src/PrefsUnifiedDlg.cpp:1801
 msgid "Incoming files"
 msgstr "Arquivos Recebidos"
 
-#: src/PrefsUnifiedDlg.cpp:1886
+#: src/PrefsUnifiedDlg.cpp:1806
 msgid "Online Signatures"
 msgstr "Assinatura Online"
 
-#: src/PrefsUnifiedDlg.cpp:1899
+#: src/PrefsUnifiedDlg.cpp:1819
 #, c-format
 msgid "Choose a folder for %s"
 msgstr "Escolha uma pasta para %s"
 
-#: src/PrefsUnifiedDlg.cpp:1923
+#: src/PrefsUnifiedDlg.cpp:1843
 #, c-format
 msgid "Would exclude %u of %u shared file"
 msgid_plural "Would exclude %u of %u shared files"
 msgstr[0] "Iria excluir %u de %u arquivo compartilhado"
 msgstr[1] "Iria excluir %u de %u arquivos compartilhados"
 
-#: src/PrefsUnifiedDlg.cpp:1940
+#: src/PrefsUnifiedDlg.cpp:1860
 msgid "Browse for videoplayer"
 msgstr "Defina seu Player de Vídeo preferido"
 
-#: src/PrefsUnifiedDlg.cpp:1944
+#: src/PrefsUnifiedDlg.cpp:1864
 msgid "Select browser"
 msgstr "Selecione o Browser"
 
-#: src/PrefsUnifiedDlg.cpp:1948
+#: src/PrefsUnifiedDlg.cpp:1868
 msgid "Select ffprobe binary"
 msgstr "Selecione o binário ffprobe"
 
-#: src/PrefsUnifiedDlg.cpp:1954
+#: src/PrefsUnifiedDlg.cpp:1874
 #, c-format
 msgid "Executable%s"
 msgstr "Executável%s"
 
-#: src/PrefsUnifiedDlg.cpp:1988
+#: src/PrefsUnifiedDlg.cpp:1908
 msgid "ffprobe not found on PATH or in the standard install locations. Install ffmpeg (which ships ffprobe) or use Browse to pick a binary manually."
 msgstr "O ffprobe não foi encontrado no PATH ou nos locais padronizados de instalação. Instale o ffmpeg (que traz junto o ffprobe) ou use Browse para escolher um binário manualmente."
 
-#: src/PrefsUnifiedDlg.cpp:2000
+#: src/PrefsUnifiedDlg.cpp:1920
 msgid "Reset the settings on this page to their default values?"
 msgstr "Resetar as configurações nesta página para seus valores padrão?"
 
-#: src/PrefsUnifiedDlg.cpp:2001
+#: src/PrefsUnifiedDlg.cpp:1921
 msgid "Reset to defaults"
 msgstr "Resetar para os valores padrão"
 
-#: src/PrefsUnifiedDlg.cpp:2028
+#: src/PrefsUnifiedDlg.cpp:1948
 msgid "Edit server list"
 msgstr "Editar lista de servidores"
 
-#: src/PrefsUnifiedDlg.cpp:2029
+#: src/PrefsUnifiedDlg.cpp:1949
 msgid ""
 "Add here URL's to download server.met files.\n"
 "Only one url on each line."
@@ -5997,114 +5949,114 @@ msgstr ""
 "Adicione aqui URL's para baixar arquivo 'server.met'\n"
 "Somente uma URL por Linha."
 
-#: src/PrefsUnifiedDlg.cpp:2084
+#: src/PrefsUnifiedDlg.cpp:2004
 msgid "IP2Country update failed"
 msgstr "Falha ao atualizar IP2Country"
 
-#: src/PrefsUnifiedDlg.cpp:2229 src/PrefsUnifiedDlg.cpp:2260
+#: src/PrefsUnifiedDlg.cpp:2149 src/PrefsUnifiedDlg.cpp:2180
 msgid "Data by MaxMind GeoLite2"
 msgstr "Dados por MaxMind GeoLite2"
 
-#: src/PrefsUnifiedDlg.cpp:2231 src/PrefsUnifiedDlg.cpp:2262
+#: src/PrefsUnifiedDlg.cpp:2151 src/PrefsUnifiedDlg.cpp:2182
 msgid "Custom source"
 msgstr "Fonte customizada"
 
-#: src/PrefsUnifiedDlg.cpp:2233 src/PrefsUnifiedDlg.cpp:2264
+#: src/PrefsUnifiedDlg.cpp:2153 src/PrefsUnifiedDlg.cpp:2184
 msgid "Data by DB-IP.com"
 msgstr "Dados por DB-IP.com"
 
-#: src/PrefsUnifiedDlg.cpp:2284
+#: src/PrefsUnifiedDlg.cpp:2204
 #, c-format
 msgid "Status: Loaded%s"
 msgstr "Status: %s carregados"
 
-#: src/PrefsUnifiedDlg.cpp:2286
+#: src/PrefsUnifiedDlg.cpp:2206
 #, c-format
 msgid "Status: Loaded%s - %s"
 msgstr "Status: %s - %s carregados"
 
-#: src/PrefsUnifiedDlg.cpp:2290
+#: src/PrefsUnifiedDlg.cpp:2210
 msgid "Status: Failed to load - click 'Update now' to refresh."
 msgstr "Estado: Falha ao carregar - clique 'Atualizar agora' para refrescar."
 
-#: src/PrefsUnifiedDlg.cpp:2292
+#: src/PrefsUnifiedDlg.cpp:2212
 msgid "Status: Not found - click 'Update now' to download."
 msgstr "Estado: Não encontrado - clique 'Atualizar agora' para baixar."
 
-#: src/PrefsUnifiedDlg.cpp:2350 src/PrefsUnifiedDlg.cpp:2374
+#: src/PrefsUnifiedDlg.cpp:2270 src/PrefsUnifiedDlg.cpp:2294
 #, c-format
 msgid "Update delay: %d second"
 msgid_plural "Update delay: %d seconds"
 msgstr[0] "Delay na atualização: %d segundo"
 msgstr[1] "Delay na atualização: %d segundos"
 
-#: src/PrefsUnifiedDlg.cpp:2358
+#: src/PrefsUnifiedDlg.cpp:2278
 #, c-format
 msgid "Time for average graph: %d minute"
 msgid_plural "Time for average graph: %d minutes"
 msgstr[0] "Tempo do gráfico de média: %d minuto"
 msgstr[1] "Tempo do gráfico de média: %d minutos"
 
-#: src/PrefsUnifiedDlg.cpp:2367
+#: src/PrefsUnifiedDlg.cpp:2287
 #, c-format
 msgid "Connections Graph Scale: %d"
 msgstr "Escala do gráfico de conexões: %d"
 
-#: src/PrefsUnifiedDlg.cpp:2382
+#: src/PrefsUnifiedDlg.cpp:2302
 #, c-format
 msgid "File Buffer Size: %d byte"
 msgid_plural "File Buffer Size: %d bytes"
 msgstr[0] "Tamanho do Buffer de Arquivo: %d byte"
 msgstr[1] "Tamanho do Buffer de Arquivo: %d bytes"
 
-#: src/PrefsUnifiedDlg.cpp:2392
+#: src/PrefsUnifiedDlg.cpp:2312
 #, c-format
 msgid "Upload Queue Size: %d client"
 msgid_plural "Upload Queue Size: %d clients"
 msgstr[0] "Tamanho de Espera de Upload: %d cliente"
 msgstr[1] "Tamanho de Espera de Upload: %d clientes"
 
-#: src/PrefsUnifiedDlg.cpp:2402
+#: src/PrefsUnifiedDlg.cpp:2322
 #, c-format
 msgid "Server connection refresh interval: %d minute"
 msgid_plural "Server connection refresh interval: %d minutes"
 msgstr[0] "Atualizar conexão com servidor: %d minuto"
 msgstr[1] "Atualizar conexão com servidor: %d minutos"
 
-#: src/PrefsUnifiedDlg.cpp:2407
+#: src/PrefsUnifiedDlg.cpp:2327
 msgid "Server connection refresh interval: Disabled"
 msgstr "Intervalo para atualizar conexão no servidor: Desativado"
 
-#: src/PrefsUnifiedDlg.cpp:2451
+#: src/PrefsUnifiedDlg.cpp:2371
 msgid "disabled"
 msgstr "desativado"
 
-#: src/PrefsUnifiedDlg.cpp:2477
+#: src/PrefsUnifiedDlg.cpp:2397
 #, c-format
 msgid "Execute command on '%s' event"
 msgstr "Executar comando em evento '%s'"
 
-#: src/PrefsUnifiedDlg.cpp:2484
+#: src/PrefsUnifiedDlg.cpp:2404
 msgid "Enable command execution on core"
 msgstr "Habilitar execução de comando no núcleo"
 
-#: src/PrefsUnifiedDlg.cpp:2496
+#: src/PrefsUnifiedDlg.cpp:2416
 msgid "Core command:"
 msgstr "Comando do Núcleo:"
 
-#: src/PrefsUnifiedDlg.cpp:2512
+#: src/PrefsUnifiedDlg.cpp:2432
 msgid "Enable command execution on GUI"
 msgstr "Habilitar execução de comando na GUI"
 
-#: src/PrefsUnifiedDlg.cpp:2524
+#: src/PrefsUnifiedDlg.cpp:2444
 msgid "GUI command:"
 msgstr "Comando da GUI:"
 
-#: src/PrefsUnifiedDlg.cpp:2540
+#: src/PrefsUnifiedDlg.cpp:2460
 msgid "The following variables will be replaced:"
 msgstr "As seguinte variáveis serão substituídas:"
 
-#: src/PrefsUnifiedDlg.cpp:2708
+#: src/PrefsUnifiedDlg.cpp:2628
 msgid ""
 "The following folders look like system or sensitive locations:\n"
 "\n"
@@ -6112,61 +6064,57 @@ msgstr ""
 "As seguintes pastas parecem ser de sistema ou locais sensíveis:\n"
 "\n"
 
-#: src/PrefsUnifiedDlg.cpp:2713
+#: src/PrefsUnifiedDlg.cpp:2633
 msgid "Sharing them recursively will publish every file underneath on the eD2k/Kad networks. Do you really want to do this?"
 msgstr "Compartilha-los recursivamente vai publicar todos os arquivos sob as redes eD2k/Kad. Você realmente quer isto?"
 
-#: src/PrefsUnifiedDlg.cpp:2716
+#: src/PrefsUnifiedDlg.cpp:2636
 msgid "Confirm shared folders"
 msgstr "Confirma pastas compartilhadas"
 
-#: src/PrefsUnifiedDlg.cpp:2744
+#: src/PrefsUnifiedDlg.cpp:2664
 msgid "Reloading shared files..."
 msgstr "Recarregando lista de arquivos compartilhados..."
 
-#: src/PrefsUnifiedDlg.cpp:2745
+#: src/PrefsUnifiedDlg.cpp:2665
 msgid "Scanning for subdirectories..."
 msgstr "Procurando por subdiretórios..."
 
-#: src/PrefsUnifiedDlg.cpp:2746
+#: src/PrefsUnifiedDlg.cpp:2666
 msgid "Updating shared folders"
 msgstr "Atualizando pastas compartilhadas"
 
-#: src/PrefsUnifiedDlg.cpp:2773
+#: src/PrefsUnifiedDlg.cpp:2693
 #, c-format
 msgid "Scanned %u directories..."
 msgstr "Varridos %u diretórios..."
 
-#: src/PrefsUnifiedDlg.cpp:2823
+#: src/PrefsUnifiedDlg.cpp:2743
 #, c-format
 msgid "Reloading shared files: %u files scanned"
 msgstr "Recarregando arquivos compartilhados: %u arquivos encontrados"
 
-#: src/PrefsUnifiedDlg.cpp:2873
+#: src/PrefsUnifiedDlg.cpp:2793
 msgid "Shared folder"
 msgstr "Pasta compartilhada"
 
-#: src/SearchDlg.cpp:280
-msgid "Clear search history"
-msgstr ""
-
-#: src/SearchDlg.cpp:584
+#: src/SearchDlg.cpp:425
 msgid "It's impossible to search when both eD2k and Kademlia are disabled."
 msgstr "É impossível realizar busca quando ambas eD2K e Kademlia estão desabilitadas."
 
-#: src/SearchDlg.cpp:585 src/SearchListCtrl.cpp:858
+#: src/SearchDlg.cpp:426 src/SearchListCtrl.cpp:858
 msgid "Search error"
 msgstr "Erro na busca"
 
-#: src/SearchDlg.cpp:929
+#: src/SearchDlg.cpp:768
 msgid "Min size must be smaller than max size. Max size ignored."
 msgstr "Tamanho min deve ser menor que tamanho max. Tamanho max ignorado."
 
-#: src/SearchDlg.cpp:930 src/SearchDlg.cpp:1012
+#: src/SearchDlg.cpp:769 src/SearchDlg.cpp:851
 msgid "Search warning"
 msgstr "Alerta da busca"
 
-#: src/SearchDlg.cpp:1092 src/SearchListCtrl.cpp:735
+#: src/SearchDlg.cpp:929 src/SearchListCtrl.cpp:735
 msgid "Main"
 msgstr "Principal"
 

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -15,7 +15,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-28 08:06+0200\n"
+"POT-Creation-Date: 2026-07-28 10:19+0200\n"
 "PO-Revision-Date: 2026-07-27 11:43+0000\n"
 "Last-Translator: Marcelo Jimenez <mroberto@users.sourceforge.com>\n"
 "Language-Team: Português (Brasileiro) <pt@li.org>\n"
@@ -150,7 +150,7 @@ msgstr "Instalar"
 msgid "Not now"
 msgstr "Agora não"
 
-#: src/AppImageIntegration.cpp:422 src/amuleDlg.cpp:600
+#: src/AppImageIntegration.cpp:422 src/amuleDlg.cpp:665
 msgid "Don't ask again"
 msgstr "Não perguntar novamente"
 
@@ -227,7 +227,7 @@ msgid "Killing amuleweb instance with pid '%d' ... "
 msgstr "Matando a instância do amuleweb com o pid '%d'... "
 
 #: src/amule.cpp:336 src/amule.cpp:349 src/ClientRef.cpp:180
-#: src/SearchDlg.cpp:880 src/ServerListCtrl.cpp:98
+#: src/SearchDlg.cpp:1041 src/ServerListCtrl.cpp:98
 msgid "Failed"
 msgstr "Falha"
 
@@ -581,29 +581,67 @@ msgstr "Incapaz Criar Arquivo Pid"
 msgid "ERROR: %s"
 msgstr "ERRO: %s"
 
-#: src/amuleDlg.cpp:236
+#: src/amuleDlg.cpp:250
 #, c-format
 msgid "This is aMule %s based on eMule."
 msgstr "Esse é o aMule %s, baseado no eMule."
 
-#: src/amuleDlg.cpp:237
+#: src/amuleDlg.cpp:251
 #, c-format
 msgid "Running on %s"
 msgstr "Executando em %s"
 
-#: src/amuleDlg.cpp:239
+#: src/amuleDlg.cpp:253
 msgid "Visit https://github.com/amule-org/amule/releases/latest to check if a new version is available."
 msgstr "Visite https://github.com/amule-org/amule/releases/latest para ver se há nova versão disponível."
 
-#: src/amuleDlg.cpp:268
+#: src/amuleDlg.cpp:282
 msgid "FATAL ERROR: Failed to create Timer"
 msgstr "ERRO FATAL: Falha ao criar Timer"
 
-#: src/amuleDlg.cpp:592
+#: src/amuleDlg.cpp:361 src/amuleDlg.cpp:1787 src/amuleDlg.cpp:2033
+#: src/muuli_wdr.cpp:1492 src/muuli_wdr.cpp:3418
+msgid "Networks"
+msgstr "Redes"
+
+#: src/amuleDlg.cpp:362 src/amuleDlg.cpp:1793 src/muuli_wdr.cpp:3419
+msgid "Searches"
+msgstr "Pesquisas"
+
+#: src/amuleDlg.cpp:363 src/amuleDlg.cpp:1799 src/DownloadListCtrl.cpp:740
+#: src/muuli_wdr.cpp:392 src/muuli_wdr.cpp:1585 src/muuli_wdr.cpp:3420
+#: src/Statistics.cpp:829
+msgid "Downloads"
+msgstr "Downloads"
+
+#: src/amuleDlg.cpp:364 src/amuleDlg.cpp:1805 src/muuli_wdr.cpp:3294
+msgid "Shared files"
+msgstr "Arquivos compartilhados"
+
+#: src/amuleDlg.cpp:365 src/amuleDlg.cpp:1811 src/muuli_wdr.cpp:2926
+#: src/muuli_wdr.cpp:3376 src/muuli_wdr.cpp:3423
+msgid "Messages"
+msgstr "Mensagens"
+
+#: src/amuleDlg.cpp:366 src/amuleDlg.cpp:1817 src/muuli_wdr.cpp:3424
+#: src/PrefsUnifiedDlg.cpp:312 src/Statistics.cpp:779 src/Statistics.cpp:1235
+msgid "Statistics"
+msgstr "Estatísticas"
+
+#: src/amuleDlg.cpp:368 src/amuleDlg.cpp:1824 src/muuli_wdr.cpp:3426
+#: src/PrefsUnifiedDlg.cpp:328 src/utils/wxCas/src/wxcasprefs.cpp:39
+msgid "Preferences"
+msgstr "Preferências"
+
+#: src/amuleDlg.cpp:371
+msgid "Navigate"
+msgstr ""
+
+#: src/amuleDlg.cpp:657
 msgid "New version available"
 msgstr "Uma versão mais nova está disponível"
 
-#: src/amuleDlg.cpp:596
+#: src/amuleDlg.cpp:661
 #, c-format
 msgid ""
 "A new version of aMule (%s) is available.\n"
@@ -618,217 +656,184 @@ msgstr ""
 "\n"
 "Você gostaria de abrir a página de download?"
 
-#: src/amuleDlg.cpp:678
+#: src/amuleDlg.cpp:743
 msgid "aMule dialog destroyed"
 msgstr "destruído caixa de diálogo do aMule"
 
-#: src/amuleDlg.cpp:701 src/DataToText.cpp:68 src/IPFilter.cpp:547
+#: src/amuleDlg.cpp:766 src/DataToText.cpp:68 src/IPFilter.cpp:547
 msgid "Connecting"
 msgstr "Conectando"
 
-#: src/amuleDlg.cpp:893
+#: src/amuleDlg.cpp:958
 msgid "eD2k: Connecting"
 msgstr "eD2k: Conectado"
 
-#: src/amuleDlg.cpp:897
+#: src/amuleDlg.cpp:962
 msgid "eD2k: Disconnected"
 msgstr "eD2k: Desconectado"
 
-#: src/amuleDlg.cpp:903
+#: src/amuleDlg.cpp:968
 msgid "Kad: Firewalled"
 msgstr "Kad: Atrás de Firewall"
 
-#: src/amuleDlg.cpp:907
+#: src/amuleDlg.cpp:972
 msgid "Kad: Connected"
 msgstr "Kad: Conectado"
 
-#: src/amuleDlg.cpp:912
+#: src/amuleDlg.cpp:977
 msgid "Kad: Connecting"
 msgstr "Kad: Conectando"
 
-#: src/amuleDlg.cpp:916
+#: src/amuleDlg.cpp:981
 msgid "Kad: Off"
 msgstr "Kad: Desligado"
 
-#: src/amuleDlg.cpp:964 src/DownloadListCtrl.cpp:505
+#: src/amuleDlg.cpp:1029 src/DownloadListCtrl.cpp:505
 #: src/DownloadListCtrl.cpp:749 src/FriendListCtrl.cpp:180
 #: src/muuli_wdr.cpp:731 src/muuli_wdr.cpp:782 src/muuli_wdr.cpp:846
-#: src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2224 src/muuli_wdr.cpp:2309
-#: src/muuli_wdr.cpp:3057 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
+#: src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2231 src/muuli_wdr.cpp:2316
+#: src/muuli_wdr.cpp:3064 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
 #: src/ServerListCtrl.cpp:606 src/TransferWnd.cpp:378
 #: src/utils/wxCas/src/wxcasprefs.cpp:235
 msgid "Cancel"
 msgstr "Cancelar"
 
-#: src/amuleDlg.cpp:965
+#: src/amuleDlg.cpp:1030
 msgid "Stop the current connection attempts"
 msgstr "Cancelar as tentativas atuais de conexão"
 
-#: src/amuleDlg.cpp:970 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976
-#: src/muuli_wdr.cpp:2447
+#: src/amuleDlg.cpp:1035 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976
+#: src/muuli_wdr.cpp:2454
 msgid "Disconnect"
 msgstr "Desconectar"
 
-#: src/amuleDlg.cpp:971
+#: src/amuleDlg.cpp:1036
 msgid "Disconnect from the currently connected networks"
 msgstr "Desconectar das redes atualmente conectadas"
 
-#: src/amuleDlg.cpp:976 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979
-#: src/muuli_wdr.cpp:2602 src/muuli_wdr.cpp:3054 src/muuli_wdr.cpp:3409
+#: src/amuleDlg.cpp:1041 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979
+#: src/muuli_wdr.cpp:2609 src/muuli_wdr.cpp:3061 src/muuli_wdr.cpp:3416
 msgid "Connect"
 msgstr "Conectar"
 
-#: src/amuleDlg.cpp:977
+#: src/amuleDlg.cpp:1042
 msgid "Connect to the currently enabled networks"
 msgstr "Conectar às redes ativas"
 
-#: src/amuleDlg.cpp:1089
+#: src/amuleDlg.cpp:1154
 #, c-format
 msgid "Up: %.1f%s (%.1f) | Down: %.1f%s (%.1f)"
 msgstr "Up: %.1f%s (%.1f) | Down: %.1f%s (%.1f)"
 
-#: src/amuleDlg.cpp:1091 src/amuleDlg.cpp:1093 src/amuleDlg.cpp:1097
-#: src/amuleDlg.cpp:1099 src/amuleDlg.cpp:1110 src/amuleDlg.cpp:1112
+#: src/amuleDlg.cpp:1156 src/amuleDlg.cpp:1158 src/amuleDlg.cpp:1162
+#: src/amuleDlg.cpp:1164 src/amuleDlg.cpp:1175 src/amuleDlg.cpp:1177
 #: src/MuleTrayIcon.cpp:796 src/MuleTrayIcon.cpp:799
 msgid " MB/s"
 msgstr " MB/s"
 
-#: src/amuleDlg.cpp:1091 src/amuleDlg.cpp:1093 src/amuleDlg.cpp:1097
-#: src/amuleDlg.cpp:1099 src/amuleDlg.cpp:1110 src/amuleDlg.cpp:1112
+#: src/amuleDlg.cpp:1156 src/amuleDlg.cpp:1158 src/amuleDlg.cpp:1162
+#: src/amuleDlg.cpp:1164 src/amuleDlg.cpp:1175 src/amuleDlg.cpp:1177
 #: src/MuleTrayIcon.cpp:796 src/MuleTrayIcon.cpp:799
 #: src/utils/wxCas/src/wxcasframe.cpp:1041
 msgid " kB/s"
 msgstr " kB/s"
 
-#: src/amuleDlg.cpp:1096
+#: src/amuleDlg.cpp:1161
 #, c-format
 msgid "Up: %.1f%s | Down: %.1f%s"
 msgstr "Up: %.1f%s | Down: %.1f%s"
 
-#: src/amuleDlg.cpp:1128
+#: src/amuleDlg.cpp:1193
 #, c-format
 msgid "aMule (%s | Connected)"
 msgstr "aMule (%s | Conectado)"
 
-#: src/amuleDlg.cpp:1130
+#: src/amuleDlg.cpp:1195
 #, c-format
 msgid "aMule (%s | Disconnected)"
 msgstr "aMule (%s | Desconectado)"
 
-#: src/amuleDlg.cpp:1183
+#: src/amuleDlg.cpp:1248
 #, c-format
 msgid "Do you really want to exit %s?"
 msgstr "Você realmente quer sair %s?"
 
-#: src/amuleDlg.cpp:1185
+#: src/amuleDlg.cpp:1250
 msgid "Exit confirmation"
 msgstr "Confirmação de saída"
 
-#: src/amuleDlg.cpp:1548
+#: src/amuleDlg.cpp:1613
 msgid "Launch Command: "
 msgstr "Lançar Comando: "
 
-#: src/amuleDlg.cpp:1567 src/muuli_wdr.cpp:1971 src/Preferences.cpp:951
+#: src/amuleDlg.cpp:1632 src/muuli_wdr.cpp:1978 src/Preferences.cpp:952
 msgid "- default -"
 msgstr "- padrão -"
 
-#: src/amuleDlg.cpp:1595
+#: src/amuleDlg.cpp:1660
 #, c-format
 msgid "Skin directory '%s' does not exist"
 msgstr "O diretório '%s' de skins não existe"
 
-#: src/amuleDlg.cpp:1598
+#: src/amuleDlg.cpp:1663
 #, c-format
 msgid "WARNING: Unable to open skin file '%s' for read"
 msgstr "CUIDADO: Incapaz de abrir o arquivo de pele '%s' para leitura"
 
-#: src/amuleDlg.cpp:1722 src/amuleDlg.cpp:1968 src/muuli_wdr.cpp:1485
-#: src/muuli_wdr.cpp:3411
-msgid "Networks"
-msgstr "Redes"
-
-#: src/amuleDlg.cpp:1726 src/muuli_wdr.cpp:3411
+#: src/amuleDlg.cpp:1791 src/muuli_wdr.cpp:3418
 msgid "Networks Window"
 msgstr "Janela de redes"
 
-#: src/amuleDlg.cpp:1728 src/muuli_wdr.cpp:3412
-msgid "Searches"
-msgstr "Pesquisas"
-
-#: src/amuleDlg.cpp:1732 src/muuli_wdr.cpp:3412
+#: src/amuleDlg.cpp:1797 src/muuli_wdr.cpp:3419
 msgid "Searches Window"
 msgstr "Janela de Pesquisas"
 
-#: src/amuleDlg.cpp:1734 src/DownloadListCtrl.cpp:740 src/muuli_wdr.cpp:392
-#: src/muuli_wdr.cpp:1578 src/muuli_wdr.cpp:3413 src/Statistics.cpp:829
-msgid "Downloads"
-msgstr "Downloads"
-
-#: src/amuleDlg.cpp:1738 src/muuli_wdr.cpp:3413
+#: src/amuleDlg.cpp:1803 src/muuli_wdr.cpp:3420
 msgid "Downloads Window"
 msgstr "Janela de Downloads"
 
-#: src/amuleDlg.cpp:1740 src/muuli_wdr.cpp:3287
-msgid "Shared files"
-msgstr "Arquivos compartilhados"
-
-#: src/amuleDlg.cpp:1744 src/muuli_wdr.cpp:3415
+#: src/amuleDlg.cpp:1809 src/muuli_wdr.cpp:3422
 msgid "Shared Files Window"
 msgstr "Janela de compartilhados"
 
-#: src/amuleDlg.cpp:1746 src/muuli_wdr.cpp:2919 src/muuli_wdr.cpp:3369
-#: src/muuli_wdr.cpp:3416
-msgid "Messages"
-msgstr "Mensagens"
-
-#: src/amuleDlg.cpp:1750 src/muuli_wdr.cpp:3416
+#: src/amuleDlg.cpp:1815 src/muuli_wdr.cpp:3423
 msgid "Messages Window"
 msgstr "Janela de Mensagens"
 
-#: src/amuleDlg.cpp:1752 src/muuli_wdr.cpp:3417 src/PrefsUnifiedDlg.cpp:312
-#: src/Statistics.cpp:779 src/Statistics.cpp:1235
-msgid "Statistics"
-msgstr "Estatísticas"
-
-#: src/amuleDlg.cpp:1756 src/muuli_wdr.cpp:3417
+#: src/amuleDlg.cpp:1821 src/muuli_wdr.cpp:3424
 msgid "Statistics Graph Window"
 msgstr "Janela de Estatísticas"
 
-#: src/amuleDlg.cpp:1759 src/muuli_wdr.cpp:3419 src/PrefsUnifiedDlg.cpp:328
-#: src/utils/wxCas/src/wxcasprefs.cpp:39
-msgid "Preferences"
-msgstr "Preferências"
-
-#: src/amuleDlg.cpp:1763 src/muuli_wdr.cpp:3419
+#: src/amuleDlg.cpp:1828 src/muuli_wdr.cpp:3426
 msgid "Preferences Settings Window"
 msgstr "Janela de Preferências"
 
-#: src/amuleDlg.cpp:1766 src/muuli_wdr.cpp:3420
+#: src/amuleDlg.cpp:1831 src/muuli_wdr.cpp:3427
 msgid "Import"
 msgstr "Importar"
 
-#: src/amuleDlg.cpp:1770 src/muuli_wdr.cpp:3420
+#: src/amuleDlg.cpp:1835 src/muuli_wdr.cpp:3427
 msgid "The partfile importer tool"
 msgstr "Ferramenta de importação de arquivos .part"
 
-#: src/amuleDlg.cpp:1773 src/muuli_wdr.cpp:3421
+#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3428
 #: src/utils/aLinkCreator/src/alcframe.cpp:262
 msgid "About"
 msgstr "Sobre"
 
-#: src/amuleDlg.cpp:1773 src/muuli_wdr.cpp:3421
+#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3428
 msgid "About/Help"
 msgstr "Sobre/Ajuda"
 
-#: src/amuleDlg.cpp:1971
+#: src/amuleDlg.cpp:2036
 msgid "eD2k network"
 msgstr "Rede eD2k"
 
-#: src/amuleDlg.cpp:1974
+#: src/amuleDlg.cpp:2039
 msgid "Kad network"
 msgstr "rede Kad"
 
-#: src/amuleDlg.cpp:1974
+#: src/amuleDlg.cpp:2039
 msgid "No network"
 msgstr "Sem redes"
 
@@ -1361,19 +1366,19 @@ msgstr "Auto [Alto]"
 msgid "Very low"
 msgstr "Muito baixo"
 
-#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:743 src/muuli_wdr.cpp:2275
+#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:743 src/muuli_wdr.cpp:2282
 #: src/ServerListCtrl.cpp:263 src/ServerListCtrl.cpp:456
 #: src/SharedFilesCtrl.cpp:145
 msgid "Low"
 msgstr "Baixo"
 
-#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:744 src/muuli_wdr.cpp:2276
+#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:744 src/muuli_wdr.cpp:2283
 #: src/ServerListCtrl.cpp:266 src/ServerListCtrl.cpp:457
 #: src/SharedFilesCtrl.cpp:146
 msgid "Normal"
 msgstr "Normal"
 
-#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:745 src/muuli_wdr.cpp:2277
+#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:745 src/muuli_wdr.cpp:2284
 #: src/ServerListCtrl.cpp:269 src/ServerListCtrl.cpp:458
 #: src/SharedFilesCtrl.cpp:147
 msgid "High"
@@ -1465,8 +1470,8 @@ msgstr "Servidor Local"
 msgid "Remote Server"
 msgstr "Servidor Remoto"
 
-#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3174
-#: src/SearchDlg.cpp:111 src/TextClient.cpp:911
+#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3181
+#: src/SearchDlg.cpp:119 src/TextClient.cpp:911
 msgid "Kad"
 msgstr "Kad"
 
@@ -1536,7 +1541,7 @@ msgstr "Parte"
 msgid "Size"
 msgstr "Tamanho"
 
-#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3241
+#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3248
 msgid "Transferred"
 msgstr "Transferido"
 
@@ -1594,7 +1599,7 @@ msgstr ""
 "Resposta de: %s (%s)\n"
 "\n"
 
-#: src/DownloadListCtrl.cpp:746 src/muuli_wdr.cpp:2278
+#: src/DownloadListCtrl.cpp:746 src/muuli_wdr.cpp:2285
 #: src/SharedFilesCtrl.cpp:150
 msgid "Auto"
 msgstr "Auto"
@@ -1632,7 +1637,7 @@ msgid "Extended Options"
 msgstr "Opções Extras"
 
 #: src/DownloadListCtrl.cpp:770 src/DownloadListCtrl.cpp:822
-#: src/muuli_wdr.cpp:1789
+#: src/muuli_wdr.cpp:1796
 msgid "Preview"
 msgstr "Pré-visualizar"
 
@@ -2341,19 +2346,19 @@ msgstr ""
 msgid "eD2k"
 msgstr "eD2k"
 
-#: src/FirstRunWizard.cpp:349 src/muuli_wdr.cpp:1488
+#: src/FirstRunWizard.cpp:349 src/muuli_wdr.cpp:1495
 msgid "Kademlia"
 msgstr "Kademlia"
 
-#: src/FirstRunWizard.cpp:359 src/muuli_wdr.cpp:1416
+#: src/FirstRunWizard.cpp:359 src/muuli_wdr.cpp:1423
 msgid "Standard TCP Port "
 msgstr "Porta TCP Padrão "
 
-#: src/FirstRunWizard.cpp:365 src/muuli_wdr.cpp:1428
+#: src/FirstRunWizard.cpp:365 src/muuli_wdr.cpp:1435
 msgid "Extended UDP port (Kad / global search) "
 msgstr "Porta UDP estendida (Kad / pesquisa global) "
 
-#: src/FirstRunWizard.cpp:377 src/muuli_wdr.cpp:1435
+#: src/FirstRunWizard.cpp:377 src/muuli_wdr.cpp:1442
 msgid "Enable UPnP for router port forwarding"
 msgstr "Habilitar UPnP para redirecionamento de porta do roteador"
 
@@ -2380,7 +2385,7 @@ msgstr ""
 msgid "Your peer lists are already in place - nothing to download."
 msgstr "Ops! Você já está tentando baixar o arquivo %s"
 
-#: src/FirstRunWizard.cpp:434 src/muuli_wdr.cpp:1533
+#: src/FirstRunWizard.cpp:434 src/muuli_wdr.cpp:1540
 msgid "Auto-update server list at startup"
 msgstr "Lista de servidores auto-atualizáveis na iniciação"
 
@@ -2426,23 +2431,23 @@ msgid ""
 "want downloads on a different (e.g. larger) disk."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:549 src/FirstRunWizard.cpp:611 src/muuli_wdr.cpp:1701
+#: src/FirstRunWizard.cpp:549 src/FirstRunWizard.cpp:611 src/muuli_wdr.cpp:1708
 msgid "Destination folder for downloads"
 msgstr "Pasta de destino para baixados"
 
-#: src/FirstRunWizard.cpp:553 src/FirstRunWizard.cpp:569 src/muuli_wdr.cpp:1342
-#: src/muuli_wdr.cpp:1359 src/muuli_wdr.cpp:1676 src/muuli_wdr.cpp:1707
-#: src/muuli_wdr.cpp:1719 src/muuli_wdr.cpp:2762
+#: src/FirstRunWizard.cpp:553 src/FirstRunWizard.cpp:569 src/muuli_wdr.cpp:1349
+#: src/muuli_wdr.cpp:1366 src/muuli_wdr.cpp:1683 src/muuli_wdr.cpp:1714
+#: src/muuli_wdr.cpp:1726 src/muuli_wdr.cpp:2769
 #: src/utils/aLinkCreator/src/alcframe.cpp:135
 #: src/utils/wxCas/src/wxcasprefs.cpp:52 src/utils/wxCas/src/wxcasprefs.cpp:118
 msgid "Browse"
 msgstr "Procurar"
 
-#: src/FirstRunWizard.cpp:559 src/muuli_wdr.cpp:1712
+#: src/FirstRunWizard.cpp:559 src/muuli_wdr.cpp:1719
 msgid "(All files in this folder are shared with other peers)"
 msgstr "(Todos os arquivos nesta pasta são compartilhados com outros pares)"
 
-#: src/FirstRunWizard.cpp:565 src/FirstRunWizard.cpp:624 src/muuli_wdr.cpp:1714
+#: src/FirstRunWizard.cpp:565 src/FirstRunWizard.cpp:624 src/muuli_wdr.cpp:1721
 msgid "Folder for temporary download files"
 msgstr "Pasta para arquivos temporários baixados"
 
@@ -2473,7 +2478,7 @@ msgstr "Falha em abrir lista de amigos do arquivo 'emfriends.met' para escrita!"
 msgid "CRITICAL - no client on StartChatSession"
 msgstr "CRÍTICO - nenhum cliente em StartChatSession"
 
-#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2668 src/muuli_wdr.cpp:3345
+#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2675 src/muuli_wdr.cpp:3352
 msgid "Friends"
 msgstr "Amigos"
 
@@ -2857,7 +2862,7 @@ msgstr "Taxa de compartilhamento"
 msgid "Uploaded"
 msgstr "Enviado"
 
-#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3225
+#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3232
 msgid "Requested"
 msgstr "Requisitado"
 
@@ -2980,7 +2985,7 @@ msgid "WARNING: "
 msgstr "CUIDADO: "
 
 #: src/MuleNotebook.cpp:179 src/muuli_wdr.cpp:817 src/muuli_wdr.cpp:1229
-#: src/muuli_wdr.cpp:3129 src/muuli_wdr.cpp:3385
+#: src/muuli_wdr.cpp:3136 src/muuli_wdr.cpp:3392
 msgid "Close"
 msgstr "Fechar"
 
@@ -2993,12 +2998,12 @@ msgstr "Recortar"
 msgid "Copy"
 msgstr "Copiar"
 
-#: src/MuleTextCtrl.cpp:88
+#: src/MuleTextCtrl.cpp:88 src/SearchDlg.cpp:261
 msgid "Paste"
 msgstr "Colar"
 
 #: src/MuleTextCtrl.cpp:89 src/muuli_wdr.cpp:358 src/muuli_wdr.cpp:757
-#: src/muuli_wdr.cpp:2352 src/muuli_wdr.cpp:2371 src/muuli_wdr.cpp:2393
+#: src/muuli_wdr.cpp:2359 src/muuli_wdr.cpp:2378 src/muuli_wdr.cpp:2400
 #: src/utils/aLinkCreator/src/alcframe.cpp:142
 msgid "Clear"
 msgstr "Limpar"
@@ -3089,8 +3094,8 @@ msgid "Exit"
 msgstr "Sair"
 
 #: src/MuleTrayIcon.cpp:579 src/MuleTrayIcon.cpp:945 src/MuleTrayIcon.cpp:965
-#: src/muuli_wdr.cpp:1391 src/muuli_wdr.cpp:1399 src/muuli_wdr.cpp:1406
-#: src/muuli_wdr.cpp:1835 src/muuli_wdr.cpp:1841 src/OtherFunctions.cpp:91
+#: src/muuli_wdr.cpp:1398 src/muuli_wdr.cpp:1406 src/muuli_wdr.cpp:1413
+#: src/muuli_wdr.cpp:1842 src/muuli_wdr.cpp:1848 src/OtherFunctions.cpp:91
 #: src/StatisticsDlg.cpp:93 src/StatisticsDlg.cpp:95
 msgid "kB/s"
 msgstr "kB/s"
@@ -3259,7 +3264,7 @@ msgstr "Nome:"
 msgid "Type"
 msgstr "Tipo"
 
-#: src/muuli_wdr.cpp:215 src/SearchDlg.cpp:110 src/SearchListCtrl.cpp:853
+#: src/muuli_wdr.cpp:215 src/SearchDlg.cpp:118 src/SearchListCtrl.cpp:853
 msgid "Local"
 msgstr "Local"
 
@@ -3330,7 +3335,7 @@ msgstr "Bytes"
 msgid "KB"
 msgstr "KB"
 
-#: src/muuli_wdr.cpp:274 src/muuli_wdr.cpp:293 src/muuli_wdr.cpp:1620
+#: src/muuli_wdr.cpp:274 src/muuli_wdr.cpp:293 src/muuli_wdr.cpp:1627
 #: src/OtherFunctions.cpp:64
 msgid "MB"
 msgstr "MB"
@@ -3347,7 +3352,7 @@ msgstr "Tamanho Máximo"
 msgid "Availability"
 msgstr "Disponível"
 
-#: src/muuli_wdr.cpp:312 src/muuli_wdr.cpp:398 src/muuli_wdr.cpp:3290
+#: src/muuli_wdr.cpp:312 src/muuli_wdr.cpp:398 src/muuli_wdr.cpp:3297
 msgid "Filter:"
 msgstr "Filtro:"
 
@@ -3379,7 +3384,7 @@ msgstr "Pedir para pares Kad que já responderam para alargar a busca. Cada cliq
 msgid "Stop"
 msgstr "Pare"
 
-#: src/muuli_wdr.cpp:348 src/muuli_wdr.cpp:1385 src/SearchListCtrl.cpp:732
+#: src/muuli_wdr.cpp:348 src/muuli_wdr.cpp:1392 src/SearchListCtrl.cpp:732
 msgid "Download"
 msgstr "Download"
 
@@ -3410,8 +3415,8 @@ msgstr "Fontes de arquivos:"
 #: src/muuli_wdr.cpp:1160 src/muuli_wdr.cpp:1167 src/muuli_wdr.cpp:1172
 #: src/muuli_wdr.cpp:1179 src/muuli_wdr.cpp:1184 src/muuli_wdr.cpp:1191
 #: src/muuli_wdr.cpp:1205 src/muuli_wdr.cpp:1212 src/muuli_wdr.cpp:1217
-#: src/muuli_wdr.cpp:1224 src/muuli_wdr.cpp:3227 src/muuli_wdr.cpp:3235
-#: src/muuli_wdr.cpp:3243
+#: src/muuli_wdr.cpp:1224 src/muuli_wdr.cpp:3234 src/muuli_wdr.cpp:3242
+#: src/muuli_wdr.cpp:3250
 msgid "N/A"
 msgstr "N/A"
 
@@ -3551,7 +3556,7 @@ msgstr "Artista:"
 msgid "Album :"
 msgstr "Album:"
 
-#: src/muuli_wdr.cpp:685 src/muuli_wdr.cpp:2247
+#: src/muuli_wdr.cpp:685 src/muuli_wdr.cpp:2254
 msgid "Title :"
 msgstr "Título:"
 
@@ -3659,7 +3664,7 @@ msgstr "Usuário :"
 msgid "Userhash :"
 msgstr "Hash do usuário :"
 
-#: src/muuli_wdr.cpp:895 src/muuli_wdr.cpp:1741 src/muuli_wdr.cpp:2442
+#: src/muuli_wdr.cpp:895 src/muuli_wdr.cpp:1748 src/muuli_wdr.cpp:2449
 #: src/utils/aLinkCreator/src/alcframe.cpp:137
 msgid "Add"
 msgstr "Adicionar"
@@ -3668,15 +3673,15 @@ msgstr "Adicionar"
 msgid "Download-Speed"
 msgstr "Download (Velocidade)"
 
-#: src/muuli_wdr.cpp:954 src/muuli_wdr.cpp:989 src/muuli_wdr.cpp:2546
+#: src/muuli_wdr.cpp:954 src/muuli_wdr.cpp:989 src/muuli_wdr.cpp:2553
 msgid "Current"
 msgstr "Atual"
 
-#: src/muuli_wdr.cpp:962 src/muuli_wdr.cpp:997 src/muuli_wdr.cpp:2554
+#: src/muuli_wdr.cpp:962 src/muuli_wdr.cpp:997 src/muuli_wdr.cpp:2561
 msgid "Running average"
 msgstr "Média de execução"
 
-#: src/muuli_wdr.cpp:970 src/muuli_wdr.cpp:1005 src/muuli_wdr.cpp:2562
+#: src/muuli_wdr.cpp:970 src/muuli_wdr.cpp:1005 src/muuli_wdr.cpp:2569
 msgid "Session average"
 msgstr "Média da sessão"
 
@@ -3688,7 +3693,7 @@ msgstr "Upload (velocidade)"
 msgid "Connections"
 msgstr "Conexões"
 
-#: src/muuli_wdr.cpp:1024 src/muuli_wdr.cpp:1860
+#: src/muuli_wdr.cpp:1024 src/muuli_wdr.cpp:1867
 msgid "Active downloads"
 msgstr "Downloads ativos"
 
@@ -3696,7 +3701,7 @@ msgstr "Downloads ativos"
 msgid "Active connections (1:1)"
 msgstr "Conexões ativas (1:1)"
 
-#: src/muuli_wdr.cpp:1040 src/muuli_wdr.cpp:1861
+#: src/muuli_wdr.cpp:1040 src/muuli_wdr.cpp:1868
 msgid "Active uploads"
 msgstr "Uploads ativos"
 
@@ -3812,8 +3817,8 @@ msgstr "Esse é o nome que os usuários verão quando se conectarem à você."
 msgid "Language: "
 msgstr "Idioma: "
 
-#: src/muuli_wdr.cpp:1257 src/muuli_wdr.cpp:1323 src/muuli_wdr.cpp:1327
-#: src/muuli_wdr.cpp:1330
+#: src/muuli_wdr.cpp:1257 src/muuli_wdr.cpp:1330 src/muuli_wdr.cpp:1334
+#: src/muuli_wdr.cpp:1337
 msgid "The delay before showing tool-tips."
 msgstr "Tempo de espera antes de mostrar as dicas."
 
@@ -3889,259 +3894,268 @@ msgstr "Mostrar as notificações quando terminar de baixar"
 msgid "Enabling this will make aMule to show notifications when finished downloading."
 msgstr "Habilitar isto vai fazer com que o aMule mostre notificações quando terminar de baixar."
 
-#: src/muuli_wdr.cpp:1322
+#: src/muuli_wdr.cpp:1323
+#, fuzzy
+msgid "Remember search history"
+msgstr "Lembrar essas definições"
+
+#: src/muuli_wdr.cpp:1324
+msgid "Keeps a dropdown list of your past search terms in the Search tab's Name field. This remembers the queries you typed, not the results they returned."
+msgstr ""
+
+#: src/muuli_wdr.cpp:1329
 msgid "Tooltip delay time: "
 msgstr "Tempo de atraso da janela de dica: "
 
-#: src/muuli_wdr.cpp:1329
+#: src/muuli_wdr.cpp:1336
 msgid "seconds"
 msgstr "segundos"
 
-#: src/muuli_wdr.cpp:1333
+#: src/muuli_wdr.cpp:1340
 msgid "Browser Selection"
 msgstr "Browser Padrão"
 
-#: src/muuli_wdr.cpp:1339
+#: src/muuli_wdr.cpp:1346
 msgid "Enter your browser name here. Leave this field empty to use the system default browser."
 msgstr "Insira o nome do seu navegador aqui. Deixe vazio para usar o navegador padrão do sistema."
 
-#: src/muuli_wdr.cpp:1346
+#: src/muuli_wdr.cpp:1353
 msgid "Open in new tab if possible"
 msgstr "Abrir em nova aba se possível"
 
-#: src/muuli_wdr.cpp:1348
+#: src/muuli_wdr.cpp:1355
 msgid "Open the web page in a new tab instead of in a new window when possible"
 msgstr "Abrir a webpage em nova aba quando possível, ao invés de uma nova janela"
 
-#: src/muuli_wdr.cpp:1352
+#: src/muuli_wdr.cpp:1359
 msgid "Video Player"
 msgstr "Player de Video"
 
-#: src/muuli_wdr.cpp:1379
+#: src/muuli_wdr.cpp:1386
 msgid "Bandwidth limits"
 msgstr "Limites de banda"
 
-#: src/muuli_wdr.cpp:1393
+#: src/muuli_wdr.cpp:1400
 msgid "Upload"
 msgstr "Upload"
 
-#: src/muuli_wdr.cpp:1401
+#: src/muuli_wdr.cpp:1408
 msgid "Slot Allocation"
 msgstr "Alocação de Slots"
 
-#: src/muuli_wdr.cpp:1410
+#: src/muuli_wdr.cpp:1417
 msgid "Ports"
 msgstr "Portas"
 
-#: src/muuli_wdr.cpp:1420
+#: src/muuli_wdr.cpp:1427
 msgid "This is the standard eD2k port and cannot be disabled."
 msgstr "Essa é a porta eD2k padrão e não pode ser desabilitada."
 
-#: src/muuli_wdr.cpp:1423
+#: src/muuli_wdr.cpp:1430
 msgid "UDP port for server requests (TCP+3):"
 msgstr "Porta UDP para requisições do servidor (TCP+3):"
 
-#: src/muuli_wdr.cpp:1425
+#: src/muuli_wdr.cpp:1432
 msgid "4665"
 msgstr "4665"
 
-#: src/muuli_wdr.cpp:1432
+#: src/muuli_wdr.cpp:1439
 msgid "This UDP port is used for extended eD2k requests and Kad network"
 msgstr "Essa porta UDP é usada para requisições eD2k estendidas e rede Kad"
 
-#: src/muuli_wdr.cpp:1439
+#: src/muuli_wdr.cpp:1446
 msgid "UPnP TCP Port (Optional):"
 msgstr "Porta TCP UPnP (Opcional):"
 
-#: src/muuli_wdr.cpp:1449
+#: src/muuli_wdr.cpp:1456
 msgid "Bind local address to IP (empty for any):"
 msgstr "Casar endereço local ao IP (vazio para qualquer um):"
 
-#: src/muuli_wdr.cpp:1452
+#: src/muuli_wdr.cpp:1459
 msgid "Advanced users only: If you have multiple network interfaces, enter the address of the interface to which aMule should be bound."
 msgstr "Somente usuários avançados: Se você tem múltiplas interfaces de rede, insira o endereço da interface com a qual o aMule deverá conectar-se."
 
-#: src/muuli_wdr.cpp:1455 src/muuli_wdr.cpp:2054
+#: src/muuli_wdr.cpp:1462 src/muuli_wdr.cpp:2061
 msgid "Bind to network interface (empty for any):"
 msgstr "Conectar a uma interface de rede (vazio equivale a todas):"
 
-#: src/muuli_wdr.cpp:1468
+#: src/muuli_wdr.cpp:1475
 msgid "Advanced users only: pin all of aMule's traffic to one network interface, chosen from the list or typed in by name (e.g. tun0, eth0, en0) or index. Unlike binding to an IP, this stops traffic leaking out via the default route - useful with a VPN. Requires no elevated privileges."
 msgstr "Apenas para usuários avançados: concentra todo tráfedo do aMule em uma interface de rede, escolhida da lista ou digitada por nome (e.g. tun0, eth0, en0) ou indice. Diferentemente da ligação por IP, isto impede que o tráfego vaze pela rota default - útil com uma VPN. Requer elevação de privilégios."
 
-#: src/muuli_wdr.cpp:1474
+#: src/muuli_wdr.cpp:1481
 msgid "Max sources per downloading file:"
 msgstr "Máximo de fontes para arquivos baixando:"
 
-#: src/muuli_wdr.cpp:1478
+#: src/muuli_wdr.cpp:1485
 msgid "Max simultaneous connections:"
 msgstr "Máximo de conexões simultâneas:"
 
-#: src/muuli_wdr.cpp:1491 src/muuli_wdr.cpp:3169
+#: src/muuli_wdr.cpp:1498 src/muuli_wdr.cpp:3176
 msgid "ED2K"
 msgstr "ED2K"
 
-#: src/muuli_wdr.cpp:1498
+#: src/muuli_wdr.cpp:1505
 msgid "Autoconnect on startup"
 msgstr "Auto-conectar ao iniciar"
 
-#: src/muuli_wdr.cpp:1501
+#: src/muuli_wdr.cpp:1508
 msgid "Reconnect on loss"
 msgstr "Reconectar ao ser desconectado"
 
-#: src/muuli_wdr.cpp:1523
+#: src/muuli_wdr.cpp:1530
 msgid "Remove dead server after"
 msgstr "Remover servidores inativos após"
 
-#: src/muuli_wdr.cpp:1524
+#: src/muuli_wdr.cpp:1531
 msgid "Static servers are never removed, even when unreachable."
 msgstr "Servidores estáticos nunca são removidos, mesmo que inalcançáveis."
 
-#: src/muuli_wdr.cpp:1528
+#: src/muuli_wdr.cpp:1535
 msgid "retries"
 msgstr "tentativas"
 
-#: src/muuli_wdr.cpp:1536
+#: src/muuli_wdr.cpp:1543
 msgid "List"
 msgstr "Lista"
 
-#: src/muuli_wdr.cpp:1539
+#: src/muuli_wdr.cpp:1546
 msgid "Update server list when connecting to a server"
 msgstr "Atualizar lista de servidores quando conectar em um servidor"
 
-#: src/muuli_wdr.cpp:1542
+#: src/muuli_wdr.cpp:1549
 msgid "Update server list when a client connects"
 msgstr "Atualizar lista de servidores quando um cliente conectar"
 
-#: src/muuli_wdr.cpp:1545
+#: src/muuli_wdr.cpp:1552
 msgid "Use priority system"
 msgstr "Usar sistema de prioridades"
 
-#: src/muuli_wdr.cpp:1549
+#: src/muuli_wdr.cpp:1556
 msgid "Use smart LowID check on connect"
 msgstr "Usar verificação inteligente de LowID ao conectar"
 
-#: src/muuli_wdr.cpp:1553
+#: src/muuli_wdr.cpp:1560
 msgid "Safe connect"
 msgstr "Conexão segura"
 
-#: src/muuli_wdr.cpp:1557
+#: src/muuli_wdr.cpp:1564
 msgid "Autoconnect to servers in static list only"
 msgstr "Auto-conectar somente em servidores da lista estática"
 
-#: src/muuli_wdr.cpp:1560
+#: src/muuli_wdr.cpp:1567
 msgid "Set manually added servers to High Priority"
 msgstr "Definir servidores adicionados manualmente com prioridade Alta"
 
-#: src/muuli_wdr.cpp:1581
+#: src/muuli_wdr.cpp:1588
 msgid "Add files to download in pause mode"
 msgstr "Adicionar novos downloads em pausa"
 
-#: src/muuli_wdr.cpp:1583
+#: src/muuli_wdr.cpp:1590
 msgid "Add files to download with auto priority"
 msgstr "Adicionar novos downloads com prioridade automática"
 
-#: src/muuli_wdr.cpp:1586
+#: src/muuli_wdr.cpp:1593
 msgid "Try to download first and last chunks first"
 msgstr "Tentar baixar o primeiro e o último pedaço do arquivo primeiro"
 
-#: src/muuli_wdr.cpp:1590
+#: src/muuli_wdr.cpp:1597
 msgid "Endgame mode: rotate to faster sources for the final blocks"
 msgstr "Modo \"Endgame\": roda para fontes mais rápidas nos blocos finais"
 
-#: src/muuli_wdr.cpp:1593
+#: src/muuli_wdr.cpp:1600
 msgid "Start next paused file when a file completes"
 msgstr "Começar o próximo arquivo pausado quando o arquivo completar"
 
-#: src/muuli_wdr.cpp:1596
+#: src/muuli_wdr.cpp:1603
 msgid "From the same category"
 msgstr "Da mesma categoria"
 
-#: src/muuli_wdr.cpp:1598
+#: src/muuli_wdr.cpp:1605
 msgid "In alphabetic order"
 msgstr "Em ordem alfabética"
 
-#: src/muuli_wdr.cpp:1600
+#: src/muuli_wdr.cpp:1607
 msgid "Preallocate disk space for new files"
 msgstr "Pré-alocar espaço em disco para novos arquivos"
 
-#: src/muuli_wdr.cpp:1601
+#: src/muuli_wdr.cpp:1608
 msgid "For new files preallocates disk space for the whole file, thus reduces fragmentation"
 msgstr "Para novos arquivos pré-alocar espaço em disco para todo o arquivo, isso reduz fragmentação"
 
-#: src/muuli_wdr.cpp:1606
+#: src/muuli_wdr.cpp:1613
 msgid "Create new files as sparse files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1607
+#: src/muuli_wdr.cpp:1614
 msgid "A sparse file reserves its full size on disk immediately without writing real data to it -- fast, but unsupported or slow on some filesystems, and free-space accounting stays optimistic while the download is in progress. Turn this off to grow the file only as data arrives."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1612
+#: src/muuli_wdr.cpp:1619
 msgid "Stop downloads when free disk space reaches "
 msgstr "Parar download quando espaço livre em disco acabar "
 
-#: src/muuli_wdr.cpp:1613
+#: src/muuli_wdr.cpp:1620
 msgid "Select this if you want aMule to check your disk space"
 msgstr "Selecione isso se você quer uqe o aMule cheque seu espaço em disco"
 
-#: src/muuli_wdr.cpp:1617
+#: src/muuli_wdr.cpp:1624
 msgid "Enter here the min disk space desired."
 msgstr "Digite aqui o espaço min. de disco desejado."
 
-#: src/muuli_wdr.cpp:1623
+#: src/muuli_wdr.cpp:1630
 msgid "Save 10 sources on rare files (< 20 sources)"
 msgstr "Salvar 10 fontes em arquivos raros (< 20 fontes)"
 
-#: src/muuli_wdr.cpp:1627 src/Statistics.cpp:790
+#: src/muuli_wdr.cpp:1634 src/Statistics.cpp:790
 msgid "Uploads"
 msgstr "Uploads"
 
-#: src/muuli_wdr.cpp:1630
+#: src/muuli_wdr.cpp:1637
 msgid "Add new shared files with auto priority"
 msgstr "Adicionar novos compartilhamentos com prioridade automática"
 
-#: src/muuli_wdr.cpp:1636
+#: src/muuli_wdr.cpp:1643
 msgid "Intelligent Corruption Handling (I.C.H.)"
 msgstr "Manuseamento Inteligente de Corrupção (I.C.H.)"
 
-#: src/muuli_wdr.cpp:1639
+#: src/muuli_wdr.cpp:1646
 msgid "Enable"
 msgstr "Habilitado"
 
-#: src/muuli_wdr.cpp:1642
+#: src/muuli_wdr.cpp:1649
 msgid "Advanced I.C.H. trusts every hash (not recommended)"
 msgstr "I.C.H. avançado confia em todo hash (não recomendado)"
 
-#: src/muuli_wdr.cpp:1654 src/PrefsUnifiedDlg.cpp:1910
+#: src/muuli_wdr.cpp:1661 src/PrefsUnifiedDlg.cpp:1910
 msgid "Media metadata extraction"
 msgstr "Extração de metadados da mídia"
 
-#: src/muuli_wdr.cpp:1658
+#: src/muuli_wdr.cpp:1665
 msgid "Extract length / bitrate / codec from shared audio and video files"
 msgstr "Extrair compeimento / taxa de bits / codec de arquivos compartilhados de audio e vídeo"
 
-#: src/muuli_wdr.cpp:1660
+#: src/muuli_wdr.cpp:1667
 msgid "When enabled, aMule runs ffprobe on each shared media file to fill in the Length / Bitrate / Codec columns other clients see when they find the file in a search. Requires ffmpeg (the ffprobe binary) to be installed."
 msgstr "Quando habilitado, o aMule roda ffprobe em cada arquivo de mídia compartilhado para preencher as colunas de Comprimento / Taxa de Bits / Codec que os outros clientes veem quando acham o arquivo em uma procura. Requer que o ffmpeg (o binário ffprobe) esteja instalado."
 
-#: src/muuli_wdr.cpp:1667
+#: src/muuli_wdr.cpp:1674
 msgid "Path to ffprobe:"
 msgstr "Caminho para ffprobe:"
 
-#: src/muuli_wdr.cpp:1672
+#: src/muuli_wdr.cpp:1679
 msgid "Full path to the ffprobe binary. Leave empty to have aMule auto-detect it on startup."
 msgstr "Caminho completo para o binário ffprobe. Deixe vazio para que o aMule detecte automaticamente quando iniciar."
 
-#: src/muuli_wdr.cpp:1680
+#: src/muuli_wdr.cpp:1687
 msgid "Detect"
 msgstr "Detectar"
 
-#: src/muuli_wdr.cpp:1681
+#: src/muuli_wdr.cpp:1688
 msgid "Search the standard install locations for an ffprobe binary and fill the path field."
 msgstr "Procura nos locais de instalação padrão por um binário do ffprobe e preenche o campo de caminho."
 
-#: src/muuli_wdr.cpp:1705
+#: src/muuli_wdr.cpp:1712
 msgid ""
 "Completed downloads are stored here. All files in this folder are automatically shared with other peers.\n"
 "If this folder also holds files you don't want to share, point it at an aMule-only sub-folder."
@@ -4149,665 +4163,665 @@ msgstr ""
 "Downloads finalizados são guardados aqui. Todos os arquivos nesta pasta são automaticamente compartilhados com outros pares.\n"
 "Se esta pasta também guarda arquivos que você não quer compartilhar, aponte para uma sub-pasta só para o aMule."
 
-#: src/muuli_wdr.cpp:1708
+#: src/muuli_wdr.cpp:1715
 msgid "Pick the folder where completed downloads will be stored. All files in that folder will be shared with other peers."
 msgstr "Escolha a pasta onde os downloads terminados serão guardados. Todos os arquivos nesta pasta serão compartilhados com outros pares."
 
-#: src/muuli_wdr.cpp:1722
+#: src/muuli_wdr.cpp:1729
 msgid "Shared folders"
 msgstr "Pastas compartilhadas"
 
-#: src/muuli_wdr.cpp:1728
+#: src/muuli_wdr.cpp:1735
 msgid "(Folders shared by the core. Enter a path to add one.)"
 msgstr "(Pastas compartilhadas pelo núcleo. Digite um caminho para adicionar uma.)"
 
-#: src/muuli_wdr.cpp:1736
+#: src/muuli_wdr.cpp:1743
 msgid "Absolute path of a folder on the core's machine, e.g. /home/user/shared"
 msgstr "Caminho absoluto de uma pasta no núcleo da máquina, e.g. /home/user/shared"
 
-#: src/muuli_wdr.cpp:1738 src/PrefsUnifiedDlg.cpp:2794
+#: src/muuli_wdr.cpp:1745 src/PrefsUnifiedDlg.cpp:2794
 msgid "Recursive"
 msgstr "Recursivo"
 
-#: src/muuli_wdr.cpp:1739
+#: src/muuli_wdr.cpp:1746
 msgid "Share every sub-folder underneath this one, including ones created later."
 msgstr "Compartilhar todas as sub-pastas dentro desta, incluindo as criadas posteriormente."
 
-#: src/muuli_wdr.cpp:1743 src/utils/aLinkCreator/src/alcframe.cpp:141
+#: src/muuli_wdr.cpp:1750 src/utils/aLinkCreator/src/alcframe.cpp:141
 msgid "Remove"
 msgstr "Remover"
 
-#: src/muuli_wdr.cpp:1747
+#: src/muuli_wdr.cpp:1754
 msgid "(Right click on folder icon for recursive share)"
 msgstr "(Botão direito na pasta para compartilhar recursivamente)"
 
-#: src/muuli_wdr.cpp:1754
+#: src/muuli_wdr.cpp:1761
 msgid "Share hidden files"
 msgstr "Compartilhar arquivos ocultos"
 
-#: src/muuli_wdr.cpp:1760
+#: src/muuli_wdr.cpp:1767
 msgid "Automatically rescan shared folders for changes"
 msgstr "Vasculha novamente automaticamente arquivos compartilhados que mudaram"
 
-#: src/muuli_wdr.cpp:1766
+#: src/muuli_wdr.cpp:1773
 msgid "Follow symbolic links in shared folders"
 msgstr "Segue links simbólicos em pastas compartilhadas"
 
-#: src/muuli_wdr.cpp:1772
+#: src/muuli_wdr.cpp:1779
 msgid "Exclude files matching:"
 msgstr "Exclui arquivos correspondendo a:"
 
-#: src/muuli_wdr.cpp:1775
+#: src/muuli_wdr.cpp:1782
 msgid "Wildcard patterns separated by '|', e.g. .DS_Store|Thumbs.db|*.tmp. Files whose name matches are not shared. Matching is case-insensitive."
 msgstr "Caracteres curinga separados por '|', e.g. .DS_Store|Thumbs.db|*.tmp. Arquivos cujos nomes corresponderem não serão compartilhados. A correspondência é sensível à letra maiúscula/minúscula."
 
-#: src/muuli_wdr.cpp:1779
+#: src/muuli_wdr.cpp:1786
 msgid "Patterns are regular expressions"
 msgstr "Padrões são expressões regulares"
 
-#: src/muuli_wdr.cpp:1780
+#: src/muuli_wdr.cpp:1787
 msgid "When set, the whole field is one regular expression ('|' is alternation). When unset, it is a list of '|'-separated wildcards."
 msgstr "Quando ligado, o campo inteiro é uma expressão regular ('|' é alternativa). Quando desligado, é uma lista de caracteres curinga separados por '|'."
 
-#: src/muuli_wdr.cpp:1790
+#: src/muuli_wdr.cpp:1797
 msgid "Show how many shared files the current pattern would exclude."
 msgstr "Mostra quantos arquivos compartilhados o padrão atual excluiria."
 
-#: src/muuli_wdr.cpp:1811
+#: src/muuli_wdr.cpp:1818
 msgid "Graphs"
 msgstr "Gráficos"
 
-#: src/muuli_wdr.cpp:1814 src/muuli_wdr.cpp:1876
+#: src/muuli_wdr.cpp:1821 src/muuli_wdr.cpp:1883
 msgid "Update delay : 5 secs"
 msgstr "Tempo de atualização: 5s"
 
-#: src/muuli_wdr.cpp:1818
+#: src/muuli_wdr.cpp:1825
 msgid "Time for average graph: 100 mins"
 msgstr "Tempo para gráfico de média: 100min"
 
-#: src/muuli_wdr.cpp:1822
+#: src/muuli_wdr.cpp:1829
 msgid "Connections Graph Scale: 100 "
 msgstr "Escala dos gráficos das conexões: 100 "
 
-#: src/muuli_wdr.cpp:1829
+#: src/muuli_wdr.cpp:1836
 msgid "Download graph scale:"
 msgstr "Escala gráfica de download:"
 
-#: src/muuli_wdr.cpp:1837
+#: src/muuli_wdr.cpp:1844
 msgid "Upload graph scale:"
 msgstr "Escala gráfica de upload:"
 
-#: src/muuli_wdr.cpp:1847
+#: src/muuli_wdr.cpp:1854
 msgid "Colors: "
 msgstr "Cores: "
 
-#: src/muuli_wdr.cpp:1851
+#: src/muuli_wdr.cpp:1858
 msgid "Background"
 msgstr "Fundo"
 
-#: src/muuli_wdr.cpp:1852
+#: src/muuli_wdr.cpp:1859
 msgid "Grid"
 msgstr "Grade"
 
-#: src/muuli_wdr.cpp:1853
+#: src/muuli_wdr.cpp:1860
 msgid "Download current"
 msgstr "Download atual"
 
-#: src/muuli_wdr.cpp:1854
+#: src/muuli_wdr.cpp:1861
 msgid "Download running average"
 msgstr "Média dos Downloads ativos"
 
-#: src/muuli_wdr.cpp:1855
+#: src/muuli_wdr.cpp:1862
 msgid "Download session average"
 msgstr "Média dos Downloads da sessão"
 
-#: src/muuli_wdr.cpp:1856
+#: src/muuli_wdr.cpp:1863
 msgid "Upload current"
 msgstr "Upload Atual"
 
-#: src/muuli_wdr.cpp:1857
+#: src/muuli_wdr.cpp:1864
 msgid "Upload running average"
 msgstr "Média dos Uploads ativos"
 
-#: src/muuli_wdr.cpp:1858
+#: src/muuli_wdr.cpp:1865
 msgid "Upload session average"
 msgstr "Média dos Uploads da sessão"
 
-#: src/muuli_wdr.cpp:1859
+#: src/muuli_wdr.cpp:1866
 msgid "Active connections"
 msgstr "Conexões ativas"
 
-#: src/muuli_wdr.cpp:1862
+#: src/muuli_wdr.cpp:1869
 msgid "Systray Icon Speed Bar"
 msgstr "Ícone de barra de velocidade"
 
-#: src/muuli_wdr.cpp:1863
+#: src/muuli_wdr.cpp:1870
 msgid "Kad-nodes current"
 msgstr "Kad-nodes atuais"
 
-#: src/muuli_wdr.cpp:1864
+#: src/muuli_wdr.cpp:1871
 msgid "Kad-nodes running"
 msgstr "Kad-nodes rodando"
 
-#: src/muuli_wdr.cpp:1865
+#: src/muuli_wdr.cpp:1872
 msgid "Kad-nodes session"
 msgstr "Sessões Kad-nodes"
 
-#: src/muuli_wdr.cpp:1869 src/muuli_wdr.cpp:2296
+#: src/muuli_wdr.cpp:1876 src/muuli_wdr.cpp:2303
 msgid "Select"
 msgstr "Selecione"
 
-#: src/muuli_wdr.cpp:1873
+#: src/muuli_wdr.cpp:1880
 msgid "Tree"
 msgstr "Árvore"
 
-#: src/muuli_wdr.cpp:1883
+#: src/muuli_wdr.cpp:1890
 msgid "Number of Client Versions shown (0=unlimited)"
 msgstr "Número de versões a exibir (0=sem limite)"
 
-#: src/muuli_wdr.cpp:1908
+#: src/muuli_wdr.cpp:1915
 msgid "!!! WARNING !!!"
 msgstr "!!! CUIDADO !!!"
 
-#: src/muuli_wdr.cpp:1923
+#: src/muuli_wdr.cpp:1930
 msgid "Max new connections / 5 secs"
 msgstr "No. Max. de conexões / 5s"
 
-#: src/muuli_wdr.cpp:1925
+#: src/muuli_wdr.cpp:1932
 msgid "Concurrent Kad source lookups"
 msgstr "Procura concorrente de fontes Kad"
 
-#: src/muuli_wdr.cpp:1927
+#: src/muuli_wdr.cpp:1934
 msgid "Kad source re-search interval (minutes)"
 msgstr "Intervalo entre novas buscas de fontes Kad (minutos)"
 
-#: src/muuli_wdr.cpp:1929
+#: src/muuli_wdr.cpp:1936
 msgid "Source re-ask interval (minutes)"
 msgstr "Intervalo entre novos pedidos de fonte (minutos)"
 
-#: src/muuli_wdr.cpp:1933
+#: src/muuli_wdr.cpp:1940
 msgid "File Buffer Size: 240000 bytes"
 msgstr "Tamanho do arquivo buffer: 240000 bytes"
 
-#: src/muuli_wdr.cpp:1937
+#: src/muuli_wdr.cpp:1944
 msgid "Use MMAP: memory-mapped file access (lower memory use)"
 msgstr "Usar MMAP: acesso de arquivo mapeado em memória (menor uso de memória)"
 
-#: src/muuli_wdr.cpp:1938
+#: src/muuli_wdr.cpp:1945
 msgid "Maps part files into memory instead of buffering them on the heap, lowering the process memory footprint. May reduce download speed on some disks; best for memory-constrained or upload-heavy hosts."
 msgstr "Mapeia arquivos part em memória ao invés de buferizá-los na heap, diminuindo a pegada de memória do processo. Pode reduzir a velocidade de download em alguns discos; melhor para hopedeiros com memória restrita ou que façam upload intensivamente."
 
-#: src/muuli_wdr.cpp:1940
+#: src/muuli_wdr.cpp:1947
 msgid "Upload Queue Size: 5000 clients"
 msgstr "Tamanho de Espera de Upload: 5000 clientes"
 
-#: src/muuli_wdr.cpp:1944
+#: src/muuli_wdr.cpp:1951
 msgid "Server connection refresh interval: Disable"
 msgstr "Atualizar conexão com servidor: desativado"
 
-#: src/muuli_wdr.cpp:1948
+#: src/muuli_wdr.cpp:1955
 msgid "Disable computer's timed standby mode"
 msgstr "Desabilitar modo timed standby do computador"
 
-#: src/muuli_wdr.cpp:1967
+#: src/muuli_wdr.cpp:1974
 msgid "Skin to use: "
 msgstr "Pele a usar: "
 
-#: src/muuli_wdr.cpp:1976
+#: src/muuli_wdr.cpp:1983
 msgid "Show \"Fast eD2k Links Handler\" in every window."
 msgstr "Mostrar \"Manipulador Veloz de Ligações eD2k\" em cada janela."
 
-#: src/muuli_wdr.cpp:1979
+#: src/muuli_wdr.cpp:1986
 msgid "Show extended info on categories tabs"
 msgstr "Mostrar info. extras nas abas de categoria"
 
-#: src/muuli_wdr.cpp:1982
+#: src/muuli_wdr.cpp:1989
 msgid "Show application version on title"
 msgstr "Exibir versão do aplicativo no título"
 
-#: src/muuli_wdr.cpp:1984
+#: src/muuli_wdr.cpp:1991
 msgid "Show transfer rates on title"
 msgstr "Exibir taxa de transferência no título"
 
-#: src/muuli_wdr.cpp:1986
+#: src/muuli_wdr.cpp:1993
 msgid "Before application name"
 msgstr "Antes do nome da aplicação"
 
-#: src/muuli_wdr.cpp:1988
+#: src/muuli_wdr.cpp:1995
 msgid "After application name"
 msgstr "Depois do nome da aplicação"
 
-#: src/muuli_wdr.cpp:1991
+#: src/muuli_wdr.cpp:1998
 msgid "Show overhead bandwidth"
 msgstr "Mostrar banda sobressalente"
 
-#: src/muuli_wdr.cpp:1995
+#: src/muuli_wdr.cpp:2002
 msgid "Vertical toolbar orientation"
 msgstr "Orientação Vertical da Barra de Ferramentas"
 
-#: src/muuli_wdr.cpp:1997
+#: src/muuli_wdr.cpp:2004
 msgid "Live column sorting (auto-reorder rows as their values change)"
 msgstr "Ordenação de coluna ao vivo (reordenamento automático das colunas conforme seus valores mudam)"
 
-#: src/muuli_wdr.cpp:2004
+#: src/muuli_wdr.cpp:2011
 msgid "Download Queue Files"
 msgstr "Fila de arquivos baixando"
 
-#: src/muuli_wdr.cpp:2007
+#: src/muuli_wdr.cpp:2014
 msgid "Show progress percentage"
 msgstr "Mostrar porcentagem do progresso"
 
-#: src/muuli_wdr.cpp:2013
+#: src/muuli_wdr.cpp:2020
 msgid "Show progress bar"
 msgstr "Mostrar barra de progresso"
 
-#: src/muuli_wdr.cpp:2016
+#: src/muuli_wdr.cpp:2023
 msgid "Flat"
 msgstr "Plana"
 
-#: src/muuli_wdr.cpp:2020
+#: src/muuli_wdr.cpp:2027
 msgid "Round"
 msgstr "Arredondada"
 
-#: src/muuli_wdr.cpp:2038
+#: src/muuli_wdr.cpp:2045
 msgid "External Connection Parameters"
 msgstr "Parâmetros de conexão externa"
 
-#: src/muuli_wdr.cpp:2041
+#: src/muuli_wdr.cpp:2048
 msgid "Accept external connections"
 msgstr "Aceitar conexões externas"
 
-#: src/muuli_wdr.cpp:2048 src/muuli_wdr.cpp:2107
+#: src/muuli_wdr.cpp:2055 src/muuli_wdr.cpp:2114
 msgid "IP of the listening interface:"
 msgstr "IP da interface ouvindo:"
 
-#: src/muuli_wdr.cpp:2051
+#: src/muuli_wdr.cpp:2058
 msgid "Enter here a valid ip in the a.b.c.d format for the listening EC interface. An empty field or 0.0.0.0 will mean any interface."
 msgstr "Informe um IP válido no formato a.b.c.d para a interface EC que ficará aguardando. Um campo vazio ou 0.0.0.0 quer dizer 'qualquer interface'."
 
-#: src/muuli_wdr.cpp:2072 src/muuli_wdr.cpp:2156
+#: src/muuli_wdr.cpp:2079 src/muuli_wdr.cpp:2163
 msgid "TCP port:"
 msgstr "Porta TCP:"
 
-#: src/muuli_wdr.cpp:2078
+#: src/muuli_wdr.cpp:2085
 msgid "Enable UPnP port forwarding on the EC port"
 msgstr "Habilitar redirecionamento de porta UPnP para porta EC"
 
-#: src/muuli_wdr.cpp:2082 src/muuli_wdr.cpp:3041
+#: src/muuli_wdr.cpp:2089 src/muuli_wdr.cpp:3048
 #: src/utils/wxCas/src/wxcasprefs.cpp:167
 msgid "Password"
 msgstr "Senha"
 
-#: src/muuli_wdr.cpp:2088
+#: src/muuli_wdr.cpp:2095
 msgid "aMule API server parameters"
 msgstr "Parâmetros do servidor da API do aMule"
 
-#: src/muuli_wdr.cpp:2091
+#: src/muuli_wdr.cpp:2098
 msgid "Run amuleapi (REST API) on startup"
 msgstr "Rodar o amuleapi (REST API) ao iniciar"
 
-#: src/muuli_wdr.cpp:2096
+#: src/muuli_wdr.cpp:2103
 msgid "HTTP port:"
 msgstr "Porta HTTP:"
 
-#: src/muuli_wdr.cpp:2110
+#: src/muuli_wdr.cpp:2117
 msgid "The interface amuleapi's HTTP server listens on. 127.0.0.1 (default) accepts only local connections; use 0.0.0.0 or a specific IP to expose it to other hosts (set an admin password below)."
 msgstr "A interface do servidor HTTP do amuleapi que escuta em 127.0.0.1 (padrão) aceita apenas conexões locais; use 0.0.0.0 or um IP específico para expô-la a outros hospedeiros (configure uma senha de administração abaixo)."
 
-#: src/muuli_wdr.cpp:2113
+#: src/muuli_wdr.cpp:2120
 msgid "Admin password"
 msgstr "Senha de administração"
 
-#: src/muuli_wdr.cpp:2118 src/muuli_wdr.cpp:2149
+#: src/muuli_wdr.cpp:2125 src/muuli_wdr.cpp:2156
 msgid "Low rights password"
 msgstr "Password para acesso limitado"
 
-#: src/muuli_wdr.cpp:2126
+#: src/muuli_wdr.cpp:2133
 msgid "Web server parameters"
 msgstr "Parâmetros do web server"
 
-#: src/muuli_wdr.cpp:2129
+#: src/muuli_wdr.cpp:2136
 msgid "Run webserver on startup (deprecated)"
 msgstr "Rodar webserver ao iniciar (deprecado)"
 
-#: src/muuli_wdr.cpp:2135
+#: src/muuli_wdr.cpp:2142
 msgid "Web template"
 msgstr "Modelo de rede"
 
-#: src/muuli_wdr.cpp:2140
+#: src/muuli_wdr.cpp:2147
 msgid "Full rights password"
 msgstr "Password para acesso completo"
 
-#: src/muuli_wdr.cpp:2144
+#: src/muuli_wdr.cpp:2151
 msgid "Enable Low rights User"
 msgstr "Usuário com direitos limitados"
 
-#: src/muuli_wdr.cpp:2163
+#: src/muuli_wdr.cpp:2170
 msgid "Enable UPnP port forwarding of the web server port"
 msgstr "Habilitar redirecionamento de porta UPnP da porta do servidor web"
 
-#: src/muuli_wdr.cpp:2168
+#: src/muuli_wdr.cpp:2175
 msgid "Web server UPnP TCP port (Optional)"
 msgstr "Porta TCP UPnP do servidor web (Opcional)"
 
-#: src/muuli_wdr.cpp:2176
+#: src/muuli_wdr.cpp:2183
 msgid "Page Refresh Time (in secs)"
 msgstr "Tempo atualização (secs)"
 
-#: src/muuli_wdr.cpp:2183
+#: src/muuli_wdr.cpp:2190
 msgid "Enable Gzip compression"
 msgstr "Ativar compactação Gzip"
 
-#: src/muuli_wdr.cpp:2217
+#: src/muuli_wdr.cpp:2224
 msgid "Reset page to defaults"
 msgstr "Retorna a página aos valores padrão"
 
-#: src/muuli_wdr.cpp:2218
+#: src/muuli_wdr.cpp:2225
 msgid "Reset the settings on the current page to their default values."
 msgstr "Reseta as configurações na página atual para seus valores padrão."
 
-#: src/muuli_wdr.cpp:2220 src/muuli_wdr.cpp:2306 src/ServerWnd.cpp:274
+#: src/muuli_wdr.cpp:2227 src/muuli_wdr.cpp:2313 src/ServerWnd.cpp:274
 #: src/ServerWnd.cpp:282
 msgid "OK"
 msgstr "OK"
 
-#: src/muuli_wdr.cpp:2222
+#: src/muuli_wdr.cpp:2229
 msgid "Click here to apply any changes made to the preferences."
 msgstr "Clique aqui para aplicar as alterações feitas."
 
-#: src/muuli_wdr.cpp:2225
+#: src/muuli_wdr.cpp:2232
 msgid "Reset any changes made to the preferences."
 msgstr "Ignora todas as alterações feitas."
 
-#: src/muuli_wdr.cpp:2254
+#: src/muuli_wdr.cpp:2261
 msgid "Comment :"
 msgstr "Comentário:"
 
-#: src/muuli_wdr.cpp:2261
+#: src/muuli_wdr.cpp:2268
 msgid "Incoming Dir :"
 msgstr "Dir incoming:"
 
-#: src/muuli_wdr.cpp:2270
+#: src/muuli_wdr.cpp:2277
 msgid "Change priority for new assigned files :"
 msgstr "Alterar prioridade para novos arquivos:"
 
-#: src/muuli_wdr.cpp:2274
+#: src/muuli_wdr.cpp:2281
 msgid "Don't change"
 msgstr "Não alterar"
 
-#: src/muuli_wdr.cpp:2286
+#: src/muuli_wdr.cpp:2293
 msgid "Select color for this Category (currently selected) :"
 msgstr "Selecione a cor para esta Categoria (selecionada):"
 
-#: src/muuli_wdr.cpp:2353 src/muuli_wdr.cpp:2372 src/muuli_wdr.cpp:2394
+#: src/muuli_wdr.cpp:2360 src/muuli_wdr.cpp:2379 src/muuli_wdr.cpp:2401
 msgid "Click this button to reset the log."
 msgstr "Clique nesse botão para limpar o log."
 
-#: src/muuli_wdr.cpp:2413
+#: src/muuli_wdr.cpp:2420
 msgid "Click on this button to update the servers list from URL ..."
 msgstr "Clique nesse botão para atualizar a lista de servidores..."
 
-#: src/muuli_wdr.cpp:2417
+#: src/muuli_wdr.cpp:2424
 msgid "Server list"
 msgstr "Lista de servidores"
 
-#: src/muuli_wdr.cpp:2421
+#: src/muuli_wdr.cpp:2428
 msgid "Enter the url to a server.met file here and press the button to the left to update the list of known servers."
 msgstr "Informe a URL com o arquivo server.met aqui e pressione o botão a esquerda para atualizar a lista de servidores."
 
-#: src/muuli_wdr.cpp:2426
+#: src/muuli_wdr.cpp:2433
 msgid "Add server manually: Name"
 msgstr "Adicionar servidor manualmente: Nome"
 
-#: src/muuli_wdr.cpp:2429
+#: src/muuli_wdr.cpp:2436
 msgid "Enter the name of the new server here"
 msgstr "Informe o nome do novo servidor aqui"
 
-#: src/muuli_wdr.cpp:2431 src/ServerWnd.cpp:206
+#: src/muuli_wdr.cpp:2438 src/ServerWnd.cpp:206
 msgid "IP:Port"
 msgstr "IP:Porta"
 
-#: src/muuli_wdr.cpp:2434
+#: src/muuli_wdr.cpp:2441
 msgid "Enter the IP of the server here, using the x.x.x.x format."
 msgstr "Informe o IP do servidor no formato x.x.x.x nesse espaço."
 
-#: src/muuli_wdr.cpp:2440
+#: src/muuli_wdr.cpp:2447
 msgid "Enter the port of the server here."
 msgstr "Informe a porta do servidor aqui."
 
-#: src/muuli_wdr.cpp:2443
+#: src/muuli_wdr.cpp:2450
 msgid "Add manually a server (fill fields to the left before) ..."
 msgstr "Adicionar manualmente um servidor (preencha os campos ao lado antes)."
 
-#: src/muuli_wdr.cpp:2472
+#: src/muuli_wdr.cpp:2479
 msgid "aMule Log"
 msgstr "Log do aMule"
 
-#: src/muuli_wdr.cpp:2480
+#: src/muuli_wdr.cpp:2487
 msgid "Server Info"
 msgstr "Informações do Servidor"
 
-#: src/muuli_wdr.cpp:2484
+#: src/muuli_wdr.cpp:2491
 msgid "ED2K Info"
 msgstr "ED2K Info"
 
-#: src/muuli_wdr.cpp:2488
+#: src/muuli_wdr.cpp:2495
 msgid "Kad Info"
 msgstr "Informação de Kad"
 
-#: src/muuli_wdr.cpp:2516
+#: src/muuli_wdr.cpp:2523
 msgid "Click on this button to update the nodes list from URL ..."
 msgstr "Clique nesse botão para atualizar a lista de nodes da URL..."
 
-#: src/muuli_wdr.cpp:2520
+#: src/muuli_wdr.cpp:2527
 msgid "Nodes (0)"
 msgstr "Nós (0)"
 
-#: src/muuli_wdr.cpp:2524
+#: src/muuli_wdr.cpp:2531
 msgid "Enter the url to a nodes.dat file here and press the button to the left to update the list of known nodes."
 msgstr "Informe uma URL para um arquivo nodes.dat e pressione o botão da esquerda para atualizar a lista de nós conhecidos."
 
-#: src/muuli_wdr.cpp:2527
+#: src/muuli_wdr.cpp:2534
 msgid "Nodes stats"
 msgstr "Estatísticas dos Nodes"
 
-#: src/muuli_wdr.cpp:2569
+#: src/muuli_wdr.cpp:2576
 msgid "Bootstrap"
 msgstr "Inicialização"
 
-#: src/muuli_wdr.cpp:2572
+#: src/muuli_wdr.cpp:2579
 msgid "New node"
 msgstr "Novo node"
 
-#: src/muuli_wdr.cpp:2577
+#: src/muuli_wdr.cpp:2584
 msgid "IP:"
 msgstr "IP:"
 
-#: src/muuli_wdr.cpp:2597
+#: src/muuli_wdr.cpp:2604
 msgid "Port:"
 msgstr "Porta:"
 
-#: src/muuli_wdr.cpp:2610
+#: src/muuli_wdr.cpp:2617
 msgid "Bootstrap from known clients"
 msgstr "Inicializando de clientes conhecidos"
 
-#: src/muuli_wdr.cpp:2612
+#: src/muuli_wdr.cpp:2619
 msgid "Disconnect Kad"
 msgstr "Desconectar da rede Kad"
 
-#: src/muuli_wdr.cpp:2646
+#: src/muuli_wdr.cpp:2653
 msgid "Use Secure User Identification"
 msgstr "Utilizar Identificação Segura de Usuário"
 
-#: src/muuli_wdr.cpp:2648
+#: src/muuli_wdr.cpp:2655
 msgid "It is recommended to enable this option. You will not receive credits if SUI is not enabled."
 msgstr "É recomendável ativar essa opção. Você não receberá seus créditos se a identificação segura não estiver ativada."
 
-#: src/muuli_wdr.cpp:2650
+#: src/muuli_wdr.cpp:2657
 msgid "Protocol Obfuscation"
 msgstr "Obscurecimento de Protocolo"
 
-#: src/muuli_wdr.cpp:2653
+#: src/muuli_wdr.cpp:2660
 msgid "Support Protocol Obfuscation"
 msgstr "Suportar Obscurecimento de Protocolo"
 
-#: src/muuli_wdr.cpp:2655
+#: src/muuli_wdr.cpp:2662
 msgid "This option enabled Protocol Obfuscation, and makes aMule accept obfuscated connections from other clients."
 msgstr "Esta opção habilita Obscurecimento de Protocolo, e faz o aMule aceitar conexões obscuras (criptografadas) de outros clientes."
 
-#: src/muuli_wdr.cpp:2657
+#: src/muuli_wdr.cpp:2664
 msgid "Use obfuscation for outgoing connections"
 msgstr "Usar obscurecimento para conexões externas"
 
-#: src/muuli_wdr.cpp:2659
+#: src/muuli_wdr.cpp:2666
 msgid "This option makes aMule use Protocol Obfuscation when connecting other clients/servers."
 msgstr "Esta opção faz o aMule usar Obscurecimento de Protocolo quando conectando outros clientes/servidores."
 
-#: src/muuli_wdr.cpp:2661
+#: src/muuli_wdr.cpp:2668
 msgid "Accept only obfuscated connections"
 msgstr "Aceitar somente conexões obscuras"
 
-#: src/muuli_wdr.cpp:2662
+#: src/muuli_wdr.cpp:2669
 msgid "This option makes aMule only accept obfuscated connections. You will have less sources, but all your traffic will be obfuscated"
 msgstr "Esta opção faz o aMule aceitar somente conexões obscurecidas. Você terá menos fontes, mas todo seu tráfego será obscurecido"
 
-#: src/muuli_wdr.cpp:2667
+#: src/muuli_wdr.cpp:2674
 msgid "Everybody"
 msgstr "Todos"
 
-#: src/muuli_wdr.cpp:2669
+#: src/muuli_wdr.cpp:2676
 msgid "No one"
 msgstr "Nenhum"
 
-#: src/muuli_wdr.cpp:2671
+#: src/muuli_wdr.cpp:2678
 msgid "Who can see my shared files:"
 msgstr "Quem pode ver meus arquivos compartilhados:"
 
-#: src/muuli_wdr.cpp:2672
+#: src/muuli_wdr.cpp:2679
 msgid "Select who can request to view a list of your shared files."
 msgstr "Selecione quem pode pedir a sua lista de compartilhamentos."
 
-#: src/muuli_wdr.cpp:2674
+#: src/muuli_wdr.cpp:2681
 msgid "IP-Filtering"
 msgstr "Filtro de IP"
 
-#: src/muuli_wdr.cpp:2681
+#: src/muuli_wdr.cpp:2688
 msgid "Filter clients"
 msgstr "Filtrar clientes"
 
-#: src/muuli_wdr.cpp:2683
+#: src/muuli_wdr.cpp:2690
 msgid "Enable filtering of the client IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "Habilitar filtragem de IPs de clientes definidos no arquivo ~/.aMule/ipfilter.dat."
 
-#: src/muuli_wdr.cpp:2685
+#: src/muuli_wdr.cpp:2692
 msgid "Filter servers"
 msgstr "Filtrar servidores"
 
-#: src/muuli_wdr.cpp:2687
+#: src/muuli_wdr.cpp:2694
 msgid "Enable filtering of the server IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "Habilitar filtragem de IPs de servidores definidos no arquivo ~/.aMule/ipfilter.dat."
 
-#: src/muuli_wdr.cpp:2691
+#: src/muuli_wdr.cpp:2698
 msgid "Reload List"
 msgstr "Recarregar lista"
 
-#: src/muuli_wdr.cpp:2692
+#: src/muuli_wdr.cpp:2699
 msgid "Reload the list of IPs to filter from the file ~/.aMule/ipfilter.dat"
 msgstr "Recarregar lista de IPs a filtrar do arquivo ~/.aMule/ipfilter.dat"
 
-#: src/muuli_wdr.cpp:2698
+#: src/muuli_wdr.cpp:2705
 msgid "URL:"
 msgstr "URL:"
 
-#: src/muuli_wdr.cpp:2702 src/muuli_wdr.cpp:2895
+#: src/muuli_wdr.cpp:2709 src/muuli_wdr.cpp:2902
 msgid "Update now"
 msgstr "Atualizar agora"
 
-#: src/muuli_wdr.cpp:2705
+#: src/muuli_wdr.cpp:2712
 msgid "Auto-update ipfilter at startup"
 msgstr "Auto-atualizar ipfilter ao iniciar"
 
-#: src/muuli_wdr.cpp:2709
+#: src/muuli_wdr.cpp:2716
 msgid "Filtering Level:"
 msgstr "Níveis de Filtro:"
 
-#: src/muuli_wdr.cpp:2715
+#: src/muuli_wdr.cpp:2722
 msgid "Always filter LAN IPs"
 msgstr "Sempre filtrar IPs de redes LAN"
 
-#: src/muuli_wdr.cpp:2718
+#: src/muuli_wdr.cpp:2725
 msgid "Paranoid handling of non-matching IPs"
 msgstr "Manuseio paranoico de IPs não-casados"
 
-#: src/muuli_wdr.cpp:2720
+#: src/muuli_wdr.cpp:2727
 msgid "Rejects a packet when its source IP differs from the IP the client claims (an anti-spoofing check). Disable only if it causes connection problems."
 msgstr "Rejeita um pacote quando o IP de sua fonte difere do IP que o cliente clama (uma checagem anti-spoofing). Desabilite apenas se causar problemas de conexão."
 
-#: src/muuli_wdr.cpp:2722
+#: src/muuli_wdr.cpp:2729
 msgid "Use system-wide ipfilter.dat if available"
 msgstr "Utilizar ipfilter.dat global se disponível"
 
-#: src/muuli_wdr.cpp:2723
+#: src/muuli_wdr.cpp:2730
 msgid "If there's no local ipfilter.dat found, allow usage of a system-wide ipfilter file."
 msgstr "Se nenhum ipfilter.dat local for encontrado, permita o uso de um arquivo global."
 
-#: src/muuli_wdr.cpp:2740
+#: src/muuli_wdr.cpp:2747
 msgid "Enable Online-Signature"
 msgstr "Ativar Assinatura Online"
 
-#: src/muuli_wdr.cpp:2742
+#: src/muuli_wdr.cpp:2749
 msgid "Enables the writing of the OS file, which can be used by external apps to create signatures and the like."
 msgstr "Habilita a gravação do arquivo, que pode ser usado por programas externos."
 
-#: src/muuli_wdr.cpp:2746
+#: src/muuli_wdr.cpp:2753
 msgid "Update Frequency (Secs):"
 msgstr "Frequência de atualização (Seg):"
 
-#: src/muuli_wdr.cpp:2749
+#: src/muuli_wdr.cpp:2756
 msgid "Change the frequency (in seconds) of Online Signature updates."
 msgstr "Alterar frequência (em segundos) da atualização da Assinatura."
 
-#: src/muuli_wdr.cpp:2757
+#: src/muuli_wdr.cpp:2764
 msgid "Save online signature file in: "
 msgstr "Salvar arquivos de assinatura online em: "
 
-#: src/muuli_wdr.cpp:2763
+#: src/muuli_wdr.cpp:2770
 msgid "Click here to select the directory containing the the Online Signature files."
 msgstr "Clique aqui para definir pasta contendo os arquivos da Assinatura Online."
 
-#: src/muuli_wdr.cpp:2796
+#: src/muuli_wdr.cpp:2803
 msgid "Show country flags for clients"
 msgstr "Mostrar bandeiras nacionais para clientes"
 
-#: src/muuli_wdr.cpp:2797
+#: src/muuli_wdr.cpp:2804
 msgid "Render the country flag column in the transfers, queue and search views. Requires a valid MMDB GeoIP database (see below)."
 msgstr "Renderiza a coluna da bandeira do país nas transferências, filas e vistas de procura. Requer um banco de dados MMDB GeoIP válido (veja abaixo)."
 
-#: src/muuli_wdr.cpp:2802
+#: src/muuli_wdr.cpp:2809
 msgid "Database"
 msgstr "Banco de Dados"
 
-#: src/muuli_wdr.cpp:2818
+#: src/muuli_wdr.cpp:2825
 msgid "Source:"
 msgstr "Fonte:"
 
-#: src/muuli_wdr.cpp:2821
+#: src/muuli_wdr.cpp:2828
 msgid "DB-IP (free, no account)"
 msgstr "DB-IP (grátis, sem conta)"
 
-#: src/muuli_wdr.cpp:2822
+#: src/muuli_wdr.cpp:2829
 msgid "MaxMind GeoLite2 (free, account required)"
 msgstr "MaxMind GeoLite2 (grátis, requer conta)"
 
-#: src/muuli_wdr.cpp:2823
+#: src/muuli_wdr.cpp:2830
 msgid "Custom URL"
 msgstr "URL Customizada"
 
-#: src/muuli_wdr.cpp:2826
+#: src/muuli_wdr.cpp:2833
 msgid "Choose which provider supplies the GeoIP MMDB database. DB-IP is the default - no account required. MaxMind requires a free account + license key. Use Custom URL to point at any other MMDB host (e.g. a local mirror)."
 msgstr "Escolha qual provedor fornece o banco de dados MMDB GeoIP. DB-IP é o padrão - não requer conta. MaxMind requer uma conta grátis + chave de licensa. Use uma URL Customizada para apontar para qualquer outro anfitrião MMDB (e.g. um espelho local)."
 
-#: src/muuli_wdr.cpp:2843
+#: src/muuli_wdr.cpp:2850
 msgid ""
 "No configuration required.\n"
 "\n"
@@ -4819,11 +4833,11 @@ msgstr ""
 "Dados de IP-to-Country por DB-IP.com - https://db-ip.com\n"
 "Licensa: Creative Commons BY 4.0 - https://creativecommons.org/licenses/by/4.0/"
 
-#: src/muuli_wdr.cpp:2856
+#: src/muuli_wdr.cpp:2863
 msgid "License key:"
 msgstr "Chave de Licensa:"
 
-#: src/muuli_wdr.cpp:2862
+#: src/muuli_wdr.cpp:2869
 msgid ""
 "Sign up for a free MaxMind account, then generate a License Key:\n"
 "https://www.maxmind.com/en/geolite2/signup\n"
@@ -4839,11 +4853,11 @@ msgstr ""
 "Licensa: MaxMind GeoLite2 EULA - https://www.maxmind.com/en/geolite2/eula\n"
 "Requer atribuição e registro de conta; renove no mínimo a cada 30 dias."
 
-#: src/muuli_wdr.cpp:2877
+#: src/muuli_wdr.cpp:2884
 msgid "Download URL:"
 msgstr "URL de Download:"
 
-#: src/muuli_wdr.cpp:2883
+#: src/muuli_wdr.cpp:2890
 msgid ""
 "Must point to an .mmdb file or a .gz / .tar.gz containing one.\n"
 "URL may include credentials (https://user:pass@host/...).\n"
@@ -4853,211 +4867,211 @@ msgstr ""
 "A URL pode incluir credenciais (https://user:pass@host/...).\n"
 "License e termos de atribuição são realizados pela URL upstream - você é responsável."
 
-#: src/muuli_wdr.cpp:2896
+#: src/muuli_wdr.cpp:2903
 msgid "Download the GeoIP database from the selected source."
 msgstr "Baixe o banco de dados GeoIP da fonte selecionada."
 
-#: src/muuli_wdr.cpp:2898
+#: src/muuli_wdr.cpp:2905
 msgid "Auto-update on startup"
 msgstr "Auto-atualizar ao iniciar"
 
-#: src/muuli_wdr.cpp:2899
+#: src/muuli_wdr.cpp:2906
 msgid "Re-download the GeoIP database from the selected source every time aMule starts."
 msgstr "Baixe novamente o banco de dados GeoIP da fonte selecionada toda vez que o aMule iniciar."
 
-#: src/muuli_wdr.cpp:2922
+#: src/muuli_wdr.cpp:2929
 msgid "Filter incoming messages (except current chat):"
 msgstr "Filtrar mensagens (Exceto chat atual):"
 
-#: src/muuli_wdr.cpp:2924
+#: src/muuli_wdr.cpp:2931
 msgid "Filter all messages"
 msgstr "Filtrar todas as mensagens"
 
-#: src/muuli_wdr.cpp:2926
+#: src/muuli_wdr.cpp:2933
 msgid "Filter messages from people not on your friend list"
 msgstr "Filtrar mensagens de pessoas que não estão em sua lista"
 
-#: src/muuli_wdr.cpp:2928
+#: src/muuli_wdr.cpp:2935
 msgid "Filter messages from unknown clients"
 msgstr "Filtrar mensagens de clientes desconhecidos"
 
-#: src/muuli_wdr.cpp:2930
+#: src/muuli_wdr.cpp:2937
 msgid "Filter messages containing (use ',' as separator):"
 msgstr "Filtrar mensagens contendo (use ',' como separador):"
 
-#: src/muuli_wdr.cpp:2933 src/muuli_wdr.cpp:2944
+#: src/muuli_wdr.cpp:2940 src/muuli_wdr.cpp:2951
 msgid "add here the words amule should filter and block messages including it"
 msgstr "adicione aqui as palavras que o amule deve filtrar e bloquear nas mensagens"
 
-#: src/muuli_wdr.cpp:2935
+#: src/muuli_wdr.cpp:2942
 msgid "Show received messages in the log"
 msgstr "Mostrar mensagens recebidas no log"
 
-#: src/muuli_wdr.cpp:2938
+#: src/muuli_wdr.cpp:2945
 msgid "Comments"
 msgstr "Comentários"
 
-#: src/muuli_wdr.cpp:2941
+#: src/muuli_wdr.cpp:2948
 msgid "Filter comments containing (use ',' as separator):"
 msgstr "Filtrar comentários contendo (use '.' como separador):"
 
-#: src/muuli_wdr.cpp:2966
+#: src/muuli_wdr.cpp:2973
 msgid "Enable Proxy"
 msgstr "Ativar proxy"
 
-#: src/muuli_wdr.cpp:2967
+#: src/muuli_wdr.cpp:2974
 msgid "Enable/disable proxy support"
 msgstr "Ativa/desativa suporte a proxy"
 
-#: src/muuli_wdr.cpp:2970
+#: src/muuli_wdr.cpp:2977
 msgid "Proxy type:"
 msgstr "Tipo de proxy:"
 
-#: src/muuli_wdr.cpp:2981
+#: src/muuli_wdr.cpp:2988
 msgid "Proxy host:"
 msgstr "Host do Proxy:"
 
-#: src/muuli_wdr.cpp:2984
+#: src/muuli_wdr.cpp:2991
 msgid "The proxy host name"
 msgstr "Nome do Host do proxy"
 
-#: src/muuli_wdr.cpp:2986
+#: src/muuli_wdr.cpp:2993
 msgid "Proxy port:"
 msgstr "Porta do Proxy:"
 
-#: src/muuli_wdr.cpp:2989
+#: src/muuli_wdr.cpp:2996
 msgid "The proxy port"
 msgstr "Porta do Proxy"
 
-#: src/muuli_wdr.cpp:2991
+#: src/muuli_wdr.cpp:2998
 msgid "Enable authentication"
 msgstr "Ativar autenticação"
 
-#: src/muuli_wdr.cpp:2992
+#: src/muuli_wdr.cpp:2999
 msgid "Enable/disable username/password authentication"
 msgstr "Ativa/Desativa autenticação por usuário/senha"
 
-#: src/muuli_wdr.cpp:2995
+#: src/muuli_wdr.cpp:3002
 msgid "Username: "
 msgstr "Nome do usuário: "
 
-#: src/muuli_wdr.cpp:2998
+#: src/muuli_wdr.cpp:3005
 msgid "The username to use to connect to the proxy"
 msgstr "Nome do usuário para conectar ao proxy"
 
-#: src/muuli_wdr.cpp:3000
+#: src/muuli_wdr.cpp:3007
 msgid "Password:"
 msgstr "Senha:"
 
-#: src/muuli_wdr.cpp:3003
+#: src/muuli_wdr.cpp:3010
 msgid "The password to use to connect to the proxy"
 msgstr "Senha utilizada para conectar ao proxy"
 
-#: src/muuli_wdr.cpp:3022
+#: src/muuli_wdr.cpp:3029
 msgid "Connect to:"
 msgstr "Conectar em:"
 
-#: src/muuli_wdr.cpp:3031
+#: src/muuli_wdr.cpp:3038
 msgid "Login to remote amule"
 msgstr "Fazer login em amule remoto"
 
-#: src/muuli_wdr.cpp:3036
+#: src/muuli_wdr.cpp:3043
 msgid "User name"
 msgstr "Usuário"
 
-#: src/muuli_wdr.cpp:3047
+#: src/muuli_wdr.cpp:3054
 msgid "Remember those settings"
 msgstr "Lembrar essas definições"
 
-#: src/muuli_wdr.cpp:3050
+#: src/muuli_wdr.cpp:3057
 msgid "Force ZLIB compression"
 msgstr "Força compressão ZLIB"
 
-#: src/muuli_wdr.cpp:3074
+#: src/muuli_wdr.cpp:3081
 msgid "Enable Verbose Debug-Logging."
 msgstr "Ativar log de debug detalhado."
 
-#: src/muuli_wdr.cpp:3076
+#: src/muuli_wdr.cpp:3083
 msgid "Only to Logfile"
 msgstr "Apenas para o arquivo de log"
 
-#: src/muuli_wdr.cpp:3078
+#: src/muuli_wdr.cpp:3085
 msgid "Message Categories:"
 msgstr "Categorias de Mensagens:"
 
-#: src/muuli_wdr.cpp:3102 src/PartFileConvertDlg.cpp:160
+#: src/muuli_wdr.cpp:3109 src/PartFileConvertDlg.cpp:160
 msgid "Waiting..."
 msgstr "Aguardando..."
 
-#: src/muuli_wdr.cpp:3122
+#: src/muuli_wdr.cpp:3129
 msgid "Add imports"
 msgstr "Adicionar importadas"
 
-#: src/muuli_wdr.cpp:3125
+#: src/muuli_wdr.cpp:3132
 msgid "Retry selected"
 msgstr "Tentar novamente selecionada"
 
-#: src/muuli_wdr.cpp:3127
+#: src/muuli_wdr.cpp:3134
 msgid "Remove selected"
 msgstr "Remover selecionada"
 
-#: src/muuli_wdr.cpp:3190
+#: src/muuli_wdr.cpp:3197
 msgid "Event Types"
 msgstr "Tipos de Eventos"
 
-#: src/muuli_wdr.cpp:3209
+#: src/muuli_wdr.cpp:3216
 msgid "Statistics and queued clients for selected file(s) : Session / All time"
 msgstr "Estatísticas e filas de clientes para arquivo(s) selecionado(s) : Sessão / Sempre"
 
-#: src/muuli_wdr.cpp:3233
+#: src/muuli_wdr.cpp:3240
 msgid "Active Uploads"
 msgstr "Uploads Ativos"
 
-#: src/muuli_wdr.cpp:3247
+#: src/muuli_wdr.cpp:3254
 msgid "Percent of total files"
 msgstr "Porcentagem de total de arquivos"
 
-#: src/muuli_wdr.cpp:3299
+#: src/muuli_wdr.cpp:3306
 msgid "Show Clients for"
 msgstr "Exibir Clientes para"
 
-#: src/muuli_wdr.cpp:3301
+#: src/muuli_wdr.cpp:3308
 msgid "All files"
 msgstr "Todos os arquivos"
 
-#: src/muuli_wdr.cpp:3304
+#: src/muuli_wdr.cpp:3311
 msgid "Selected files"
 msgstr "Arquivos selecionados"
 
-#: src/muuli_wdr.cpp:3307
+#: src/muuli_wdr.cpp:3314
 msgid "Active uploads only"
 msgstr "Somente uploads ativos"
 
-#: src/muuli_wdr.cpp:3314
+#: src/muuli_wdr.cpp:3321
 msgid "Reload:"
 msgstr "Recarregar:"
 
-#: src/muuli_wdr.cpp:3318
+#: src/muuli_wdr.cpp:3325
 msgid "Reload your shared files"
 msgstr "Atualizar lista de compartilhados"
 
-#: src/muuli_wdr.cpp:3381
+#: src/muuli_wdr.cpp:3388
 msgid "Send"
 msgstr "Enviar"
 
-#: src/muuli_wdr.cpp:3382
+#: src/muuli_wdr.cpp:3389
 msgid "Sends the specified message."
 msgstr "Enviar a mensagem especificada."
 
-#: src/muuli_wdr.cpp:3386
+#: src/muuli_wdr.cpp:3393
 msgid "Close this chat-session."
 msgstr "Encerrar sessão de Chat."
 
-#: src/muuli_wdr.cpp:3409
+#: src/muuli_wdr.cpp:3416
 msgid "Connect to any server and/or Kad"
 msgstr "Conectar a qualquer servidor e/ou Kad"
 
-#: src/muuli_wdr.cpp:3415 src/SharedFilesCtrl.cpp:142 src/Statistics.cpp:941
+#: src/muuli_wdr.cpp:3422 src/SharedFilesCtrl.cpp:142 src/Statistics.cpp:941
 msgid "Shared Files"
 msgstr "Arquivos Compartilhados"
 
@@ -5417,187 +5431,187 @@ msgstr "Baixado"
 msgid "ERROR: Failed to open partfile '%s'"
 msgstr "ERRO: Falha ao abrir partfile '%s'"
 
-#: src/Preferences.cpp:673
+#: src/Preferences.cpp:674
 msgid "System default"
 msgstr "Padrão do sistema"
 
-#: src/Preferences.cpp:674
+#: src/Preferences.cpp:675
 msgid "Albanian"
 msgstr "Albanês"
 
-#: src/Preferences.cpp:675
+#: src/Preferences.cpp:676
 msgid "Arabic"
 msgstr "Árabe"
 
-#: src/Preferences.cpp:676
+#: src/Preferences.cpp:677
 msgid "Asturian"
 msgstr "Asturiano"
 
-#: src/Preferences.cpp:677
+#: src/Preferences.cpp:678
 msgid "Basque"
 msgstr "Basco"
 
-#: src/Preferences.cpp:678
+#: src/Preferences.cpp:679
 msgid "Bulgarian"
 msgstr "Búlgaro"
 
-#: src/Preferences.cpp:679
+#: src/Preferences.cpp:680
 msgid "Catalan"
 msgstr "Catalão"
 
-#: src/Preferences.cpp:680
+#: src/Preferences.cpp:681
 msgid "Chinese (Simplified)"
 msgstr "Chinês (Simplificado)"
 
-#: src/Preferences.cpp:681
+#: src/Preferences.cpp:682
 msgid "Chinese (Traditional)"
 msgstr "Chinês (Tradicional)"
 
-#: src/Preferences.cpp:682
+#: src/Preferences.cpp:683
 msgid "Croatian"
 msgstr "Croácia"
 
-#: src/Preferences.cpp:683
+#: src/Preferences.cpp:684
 msgid "Czech"
 msgstr "Tcheco"
 
-#: src/Preferences.cpp:684
+#: src/Preferences.cpp:685
 msgid "Danish"
 msgstr "Dinamarquês"
 
-#: src/Preferences.cpp:685
+#: src/Preferences.cpp:686
 msgid "Dutch"
 msgstr "Holandês"
 
-#: src/Preferences.cpp:686
+#: src/Preferences.cpp:687
 msgid "English (U.K.)"
 msgstr "Inglês (UK)"
 
-#: src/Preferences.cpp:687
+#: src/Preferences.cpp:688
 msgid "English (U.S.)"
 msgstr "Inglês (U.S.)"
 
-#: src/Preferences.cpp:688
+#: src/Preferences.cpp:689
 msgid "Estonian"
 msgstr "Estônia"
 
-#: src/Preferences.cpp:689
+#: src/Preferences.cpp:690
 msgid "Finnish"
 msgstr "Finlandês"
 
-#: src/Preferences.cpp:690
+#: src/Preferences.cpp:691
 msgid "French"
 msgstr "Francês"
 
-#: src/Preferences.cpp:691
+#: src/Preferences.cpp:692
 msgid "Galician"
 msgstr "Galego"
 
-#: src/Preferences.cpp:692
+#: src/Preferences.cpp:693
 msgid "German"
 msgstr "Alemão"
 
-#: src/Preferences.cpp:693
+#: src/Preferences.cpp:694
 msgid "Greek"
 msgstr "Grego"
 
-#: src/Preferences.cpp:694
+#: src/Preferences.cpp:695
 msgid "Hebrew"
 msgstr "Hebreu"
 
-#: src/Preferences.cpp:695
+#: src/Preferences.cpp:696
 msgid "Hungarian"
 msgstr "Hungria"
 
-#: src/Preferences.cpp:696
+#: src/Preferences.cpp:697
 msgid "Italian"
 msgstr "Italiano"
 
-#: src/Preferences.cpp:697
+#: src/Preferences.cpp:698
 msgid "Japanese"
 msgstr "Japonês"
 
-#: src/Preferences.cpp:698
+#: src/Preferences.cpp:699
 msgid "Korean"
 msgstr "Coreano"
 
-#: src/Preferences.cpp:699
+#: src/Preferences.cpp:700
 msgid "Latvian"
 msgstr "Letão"
 
-#: src/Preferences.cpp:700
+#: src/Preferences.cpp:701
 msgid "Lithuanian"
 msgstr "Lituânia"
 
-#: src/Preferences.cpp:701
+#: src/Preferences.cpp:702
 msgid "Norwegian (Nynorsk)"
 msgstr "Noruega (Nynorsk)"
 
-#: src/Preferences.cpp:702
+#: src/Preferences.cpp:703
 msgid "Polish"
 msgstr "Polonês"
 
-#: src/Preferences.cpp:703
+#: src/Preferences.cpp:704
 msgid "Portuguese"
 msgstr "Português (Portugal)"
 
-#: src/Preferences.cpp:704
+#: src/Preferences.cpp:705
 msgid "Portuguese (Brazilian)"
 msgstr "Português (Brasil)"
 
-#: src/Preferences.cpp:705
+#: src/Preferences.cpp:706
 msgid "Romanian"
 msgstr "Albanês"
 
-#: src/Preferences.cpp:706
+#: src/Preferences.cpp:707
 msgid "Russian"
 msgstr "Russo"
 
-#: src/Preferences.cpp:707
+#: src/Preferences.cpp:708
 msgid "Slovenian"
 msgstr "Esloveno"
 
-#: src/Preferences.cpp:708
+#: src/Preferences.cpp:709
 msgid "Spanish"
 msgstr "Espanhol"
 
-#: src/Preferences.cpp:709
+#: src/Preferences.cpp:710
 msgid "Swedish"
 msgstr "Suécia"
 
-#: src/Preferences.cpp:710
+#: src/Preferences.cpp:711
 msgid "Turkish"
 msgstr "Turquia"
 
-#: src/Preferences.cpp:711
+#: src/Preferences.cpp:712
 msgid "Ukrainian"
 msgstr "Ucraniano"
 
-#: src/Preferences.cpp:814
+#: src/Preferences.cpp:815
 msgid "Change Language"
 msgstr "Mudar Idioma"
 
-#: src/Preferences.cpp:878
+#: src/Preferences.cpp:879
 msgid "There are no translations installed for aMule"
 msgstr "Não há traduções instaladas no aMule"
 
-#: src/Preferences.cpp:879
+#: src/Preferences.cpp:880
 msgid "No languages available"
 msgstr "Nenhum idioma disponível"
 
-#: src/Preferences.cpp:1010
+#: src/Preferences.cpp:1011
 msgid "no options available"
 msgstr "nenhuma opção disponível"
 
-#: src/Preferences.cpp:2179
+#: src/Preferences.cpp:2182
 msgid "Invalid category found, skipping"
 msgstr "Categoria inválida encontrada, pulando"
 
-#: src/Preferences.cpp:2348
+#: src/Preferences.cpp:2351
 msgid "TCP port can't be higher than 65532 due to server UDP socket being TCP+3"
 msgstr "Porta TCP não pode ser maior do que 65532, pois a UDP escuta em TCP+3"
 
-#: src/Preferences.cpp:2349
+#: src/Preferences.cpp:2352
 #, c-format
 msgid "Default port will be used (%d)"
 msgstr "Porta padrão será utilizada (%d)"
@@ -6098,23 +6112,27 @@ msgstr "Recarregando arquivos compartilhados: %u arquivos encontrados"
 msgid "Shared folder"
 msgstr "Pasta compartilhada"
 
-#: src/SearchDlg.cpp:425
+#: src/SearchDlg.cpp:280
+msgid "Clear search history"
+msgstr ""
+
+#: src/SearchDlg.cpp:584
 msgid "It's impossible to search when both eD2k and Kademlia are disabled."
 msgstr "É impossível realizar busca quando ambas eD2K e Kademlia estão desabilitadas."
 
-#: src/SearchDlg.cpp:426 src/SearchListCtrl.cpp:858
+#: src/SearchDlg.cpp:585 src/SearchListCtrl.cpp:858
 msgid "Search error"
 msgstr "Erro na busca"
 
-#: src/SearchDlg.cpp:768
+#: src/SearchDlg.cpp:929
 msgid "Min size must be smaller than max size. Max size ignored."
 msgstr "Tamanho min deve ser menor que tamanho max. Tamanho max ignorado."
 
-#: src/SearchDlg.cpp:769 src/SearchDlg.cpp:851
+#: src/SearchDlg.cpp:930 src/SearchDlg.cpp:1012
 msgid "Search warning"
 msgstr "Alerta da busca"
 
-#: src/SearchDlg.cpp:929 src/SearchListCtrl.cpp:735
+#: src/SearchDlg.cpp:1092 src/SearchListCtrl.cpp:735
 msgid "Main"
 msgstr "Principal"
 

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -15,7 +15,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-28 10:19+0200\n"
+"POT-Creation-Date: 2026-07-28 12:17+0200\n"
 "PO-Revision-Date: 2026-07-27 11:43+0000\n"
 "Last-Translator: Marcelo Jimenez <mroberto@users.sourceforge.com>\n"
 "Language-Team: Português (Brasileiro) <pt@li.org>\n"
@@ -212,83 +212,83 @@ msgstr "Falha ao abrir arquivo de Ligações ED2K."
 msgid "WARNING: You can't add yourself as a source for an eD2k link while having a lowid."
 msgstr "CUIDADO: Você não pode adicionar você mesmo como uma fonte para uma ligação eD2k quando tem um lowid."
 
-#: src/amule.cpp:300
+#: src/amule.cpp:301
 msgid "Now, exiting main app..."
 msgstr "Agora, deixando a aplicação principal..."
 
-#: src/amule.cpp:330
+#: src/amule.cpp:331
 #, c-format
 msgid "Terminating amuleweb instance with pid '%d' ... "
 msgstr "Terminando a instância do amuleweb com o pid '%d'... "
 
-#: src/amule.cpp:334
+#: src/amule.cpp:335
 #, c-format
 msgid "Killing amuleweb instance with pid '%d' ... "
 msgstr "Matando a instância do amuleweb com o pid '%d'... "
 
-#: src/amule.cpp:336 src/amule.cpp:349 src/ClientRef.cpp:180
+#: src/amule.cpp:337 src/amule.cpp:350 src/ClientRef.cpp:180
 #: src/SearchDlg.cpp:1041 src/ServerListCtrl.cpp:98
 msgid "Failed"
 msgstr "Falha"
 
-#: src/amule.cpp:343
+#: src/amule.cpp:344
 #, c-format
 msgid "Terminating amuleapi instance with pid '%d' ... "
 msgstr "Terminando a instância do amuleweb com o pid '%d' ... "
 
-#: src/amule.cpp:347
+#: src/amule.cpp:348
 #, c-format
 msgid "Killing amuleapi instance with pid '%d' ... "
 msgstr "Matando a instância do amuleapi com o pid '%d'... "
 
-#: src/amule.cpp:355
+#: src/amule.cpp:356
 msgid "aMule OnExit: Terminating core."
 msgstr "aMule OnExit: Finalizando o núcleo."
 
-#: src/amule.cpp:466
+#: src/amule.cpp:467
 msgid "aMule shutdown completed."
 msgstr "Encerramento do aMule completo."
 
-#: src/amule.cpp:470
+#: src/amule.cpp:471
 msgid "Memory debug results for aMule exit:"
 msgstr "Resultados da depuração da memória para a saída do aMule:"
 
-#: src/amule.cpp:651
+#: src/amule.cpp:652
 #, c-format
 msgid "Binding aMule's peer-to-peer traffic to interface: %s (HTTP updates use the default route)"
 msgstr "Conectando o tráfego par-a-par do aMule para a interface: %s (atualizações via HTTP usam a rota padrão)"
 
-#: src/amule.cpp:655
+#: src/amule.cpp:656
 #, c-format
 msgid "Binding all network traffic to interface: %s"
 msgstr "Canectando todo o tráfego de rede à interface: %s"
 
-#: src/amule.cpp:659
+#: src/amule.cpp:660
 #, c-format
 msgid "WARNING: configured network interface '%s' was not found - traffic is NOT bound to it and may leave via the default route. Check the interface name in Preferences."
 msgstr "AVISO: a interface de rede configurada '%s' não foi encontrada - o tráfego não está conectado a ela e pode sair pela rota padrão. Confira o nome da interface em Preferências."
 
-#: src/amule.cpp:665
+#: src/amule.cpp:666
 #, c-format
 msgid "WARNING: binding to network interface '%s' requires elevated privileges and was NOT applied - traffic may leave via the default route. Grant the capability (e.g. 'sudo setcap cap_net_raw+ep' on the aMule binary) or run with sufficient privileges."
 msgstr "AVISO: para conectar-se à interface de rede '%s' são necessários privilégios elevados e NÃO FOI aplicado - o tráfego pode sair pela rota padrão. Condeda a capacidade (e.g. 'sudo setcap cap_net_raw+ep') ao binário do aMule ou rode-o com privilégios suficientes."
 
-#: src/amule.cpp:673
+#: src/amule.cpp:674
 #, c-format
 msgid "WARNING: could not bind to network interface '%s' - traffic may leave via the default route."
 msgstr "AVISO: não foi possível conectar-se à interface de rede '%s' - o tráfego pode sair pela rota padrão."
 
-#: src/amule.cpp:732
+#: src/amule.cpp:733
 msgid "Your locale has been changed to System Default due to a configuration change. Sorry."
 msgstr "Seu locale foi alterado para o padrão do Sistema devido a mudança na configuração. Desculpe."
 
-#: src/amule.cpp:734 src/amule.cpp:1581 src/CatDialog.cpp:128
+#: src/amule.cpp:735 src/amule.cpp:1589 src/CatDialog.cpp:128
 #: src/CatDialog.cpp:136 src/CatDialog.cpp:149 src/ServerList.cpp:366
 #: src/ServerListCtrl.cpp:152
 msgid "Info"
 msgstr "Info"
 
-#: src/amule.cpp:741
+#: src/amule.cpp:742
 msgid ""
 "\n"
 "EC configuration"
@@ -296,20 +296,20 @@ msgstr ""
 "\n"
 "Configuração EC"
 
-#: src/amule.cpp:744
+#: src/amule.cpp:745
 msgid "Password set and external connections enabled."
 msgstr "Senha definida e conexões externas habilitadas."
 
-#: src/amule.cpp:754 src/KadDlg.cpp:176 src/KadDlg.cpp:185
-#: src/PrefsUnifiedDlg.cpp:1387 src/SharedFilesCtrl.cpp:476
+#: src/amule.cpp:755 src/KadDlg.cpp:176 src/KadDlg.cpp:185
+#: src/PrefsUnifiedDlg.cpp:1461 src/SharedFilesCtrl.cpp:476
 msgid "WARNING"
 msgstr "CUIDADO"
 
-#: src/amule.cpp:991
+#: src/amule.cpp:992
 msgid "Network bootstrap"
 msgstr "Inicialização da Rede"
 
-#: src/amule.cpp:996
+#: src/amule.cpp:997
 msgid ""
 "aMule has detected missing network bootstrap files.\n"
 "Select which ones to download:"
@@ -317,51 +317,51 @@ msgstr ""
 "O aMule detectou que faltam arquivos de inicialização da rede.\n"
 "Selecione quais baixar:"
 
-#: src/amule.cpp:1005 src/FirstRunWizard.cpp:411
+#: src/amule.cpp:1006 src/FirstRunWizard.cpp:411
 msgid "eD2k server list (server.met)"
 msgstr "Lista de servidores eD2k (server.met)"
 
-#: src/amule.cpp:1012 src/FirstRunWizard.cpp:416
+#: src/amule.cpp:1013 src/FirstRunWizard.cpp:416
 msgid "Kad bootstrap nodes (nodes.dat)"
 msgstr "Nós de inicialização de Kad"
 
-#: src/amule.cpp:1102
+#: src/amule.cpp:1103
 #, c-format
 msgid "web server running on pid %d"
 msgstr "web server rodando no pid %d"
 
-#: src/amule.cpp:1115
+#: src/amule.cpp:1116
 msgid "You requested to run web server on startup, but the amuleweb binary cannot be run. Please install the package containing aMule web server, or build aMule from source with -DBUILD_WEBSERVER=YES and install it."
 msgstr "Você pediu para rodar o servidor web na início, mas o binário do amuleweb não pode ser rodado. Por favor instale o pacote contendo o servidro web do aMule, ou compile o aMule a partir do código fonte usando -DBUILD_WEBSERVER=YES e instale-o."
 
-#: src/amule.cpp:1120 src/amule.cpp:1177 src/amule.cpp:1291 src/amule.cpp:1593
+#: src/amule.cpp:1121 src/amule.cpp:1185 src/amule.cpp:1299 src/amule.cpp:1601
 #: src/amule-remote-gui.cpp:603 src/amule-remote-gui.cpp:671
 #: src/amule-remote-gui.cpp:709 src/amule-remote-gui.cpp:1282
 #: src/amule-remote-gui.cpp:1345 src/amule-remote-gui.cpp:1372
-#: src/DownloadQueue.cpp:1481
+#: src/DownloadQueue.cpp:1481 src/PrefsUnifiedDlg.cpp:1247
 msgid "ERROR"
 msgstr "ERRO"
 
-#: src/amule.cpp:1166
+#: src/amule.cpp:1174
 #, c-format
 msgid "amuleapi running on pid %d"
 msgstr "amuleapi rodando com pid %d"
 
-#: src/amule.cpp:1172
+#: src/amule.cpp:1180
 msgid "You requested to run amuleapi on startup, but the amuleapi binary cannot be run. Please install the package containing aMule's REST API server, or build aMule from source with -DBUILD_AMULEAPI=YES and install it."
 msgstr "Você pediu para rodar o amuleapi na início, mas o binário do amuleapi não pode ser rodado. Por favor instale o pacote contendo o servidor REST API do aMule, ou compile o aMule a partir do código fonte usando -DBUILD_WEBSERVER=YES e instale-o."
 
-#: src/amule.cpp:1259
+#: src/amule.cpp:1267
 #, c-format
 msgid "Could not bind ports to the specified address: %s"
 msgstr "Não foi possível conectar às portas desse endereço: %s"
 
-#: src/amule.cpp:1283
+#: src/amule.cpp:1291
 #, c-format
 msgid "Port %u is not available. You will be LOWID\n"
 msgstr "Porta %u não disponível. Você ficará com LOWID (id baixa)\n"
 
-#: src/amule.cpp:1288
+#: src/amule.cpp:1296
 #, c-format
 msgid ""
 "Port %u is not available!\n"
@@ -376,49 +376,49 @@ msgstr ""
 "\n"
 "Verifique sua rede para ver se essa porta está aberta para entrada e saída."
 
-#: src/amule.cpp:1385
+#: src/amule.cpp:1393
 msgid "Failed to create OnlineSig File"
 msgstr "Falha ao criar o arquivo OnlineSig"
 
-#: src/amule.cpp:1393
+#: src/amule.cpp:1401
 msgid "Failed to create aMule OnlineSig File"
 msgstr "Falha ao criar o arquivo OnlineSig do aMule"
 
 # src/amuled.cpp:1246:
-#: src/amule.cpp:1556
+#: src/amule.cpp:1564
 msgid "The selected locale seems not to be installed on your box. (Note: I'll try to set it anyway)"
 msgstr "Parece que o idioma selecionado não está instalado no seu computador. (Nota: eu irei defini-lo mesmo assim)"
 
-#: src/amule.cpp:1566
+#: src/amule.cpp:1574
 #, c-format
 msgid "This is the first time you run aMule %s"
 msgstr "Essa é a primeira vez que você executa o aMule %s"
 
-#: src/amule.cpp:1569
+#: src/amule.cpp:1577
 msgid "This version is a testing version, updated daily, and\n"
 msgstr "Essa é uma versão de testes, atualizada diariamente, e\n"
 
-#: src/amule.cpp:1570
+#: src/amule.cpp:1578
 msgid "we give no warranty it won't break anything, burn your house,\n"
 msgstr "não daremos garantia se ela quebrar algo, queimar sua casa,\n"
 
-#: src/amule.cpp:1571
+#: src/amule.cpp:1579
 msgid "or kill your dog. But it *should* be safe to use anyway.\n"
 msgstr "ou matar seu cachorro. Mas ela *deve* ser segura para uso mesmo assim.\n"
 
-#: src/amule.cpp:1576
+#: src/amule.cpp:1584
 msgid "More information, support and new releases can found at our homepage,\n"
 msgstr "Maiores informações, suporte e novas versões podem ser encontradas em nossa\n"
 
-#: src/amule.cpp:1577
+#: src/amule.cpp:1585
 msgid "at https://amule-org.github.io, or in our IRC channel #aMule at irc.libera.chat.\n"
 msgstr "homepage https://amule-org.github.io ou em nosso canal de irc #aMule na irc.libera.chat.\n"
 
-#: src/amule.cpp:1579
+#: src/amule.cpp:1587
 msgid "Feel free to report any bugs to https://github.com/amule-org/amule/issues"
 msgstr "Esteja a vontade para notificar qualquer bug em https://github.com/amule-org/amule/issues"
 
-#: src/amule.cpp:1591
+#: src/amule.cpp:1599
 msgid ""
 "The folder for Online Signature files you specified is INVALID!\n"
 " OnlineSignature will be DISABLED until you fix it on preferences."
@@ -426,137 +426,137 @@ msgstr ""
 "A pasta especificada para os arquivos da Online Signature é INVÁLIDA!\n"
 "OnlineSignature ficará DESATIVADA até você atualizar as preferências."
 
-#: src/amule.cpp:1654
+#: src/amule.cpp:1662
 msgid "Server hostname notified"
 msgstr "Nome do servidor notificado"
 
-#: src/amule.cpp:2031
+#: src/amule.cpp:2039
 #, c-format
 msgid "Disk space preallocation for file '%s' failed: %s"
 msgstr "Pré-alocação de espaço em disco para arquivo '%s' falhou: %s"
 
-#: src/amule.cpp:2160
+#: src/amule.cpp:2168
 msgid "ERROR: can't open logfile"
 msgstr "ERRO: não foi possível abrir arquivo de log"
 
-#: src/amule.cpp:2164
+#: src/amule.cpp:2172
 msgid "WARNING: logfile is empty. Something is wrong."
 msgstr "AVISO: o arquivo de log está vazio. Algo está errado."
 
-#: src/amule.cpp:2181
+#: src/amule.cpp:2189
 msgid "Log has been reset"
 msgstr "Arquivo de log resetado"
 
-#: src/amule.cpp:2205
+#: src/amule.cpp:2213
 #, c-format
 msgid "ServerMessage: %s"
 msgstr "MensagemDoServidor: %s"
 
-#: src/amule.cpp:2248 src/IP2Country.cpp:220 src/IPFilter.cpp:514
+#: src/amule.cpp:2256 src/IP2Country.cpp:220 src/IPFilter.cpp:514
 #: src/ServerList.cpp:875
 #, c-format
 msgid "Skipped download of %s, because requested file is not newer."
 msgstr "Pulando o download de %s, pois o arquivo requerido não é o mais novo."
 
-#: src/amule.cpp:2251
+#: src/amule.cpp:2259
 msgid "Failed to download the nodes list."
 msgstr "Falha ao obter a lista de nodes."
 
-#: src/amule.cpp:2314
+#: src/amule.cpp:2322
 msgid "Failed to open the downloaded version check file"
 msgstr "Falha ao abrir arquivo de versão baixado"
 
-#: src/amule.cpp:2317 src/amule.cpp:2336
+#: src/amule.cpp:2325 src/amule.cpp:2344
 msgid "Corrupted version check file"
 msgstr "Arquivo de versão corrompido"
 
-#: src/amule.cpp:2359
+#: src/amule.cpp:2367
 msgid "You are using an outdated version of aMule!"
 msgstr "Você está utilizando uma versão anterior do aMule!"
 
-#: src/amule.cpp:2361
+#: src/amule.cpp:2369
 #, c-format
 msgid "Your aMule version is %i.%i.%i and the latest version is %li.%li.%li"
 msgstr "Sua versão do aMule é %i.%i.%i e a última versão é %li.%li.%li"
 
-#: src/amule.cpp:2365
+#: src/amule.cpp:2373
 msgid "The latest version can always be found at https://github.com/amule-org/amule/releases/latest"
 msgstr "A mais recente versão pode ser obtida em https://github.com/amule-org/amule/releases/latest"
 
-#: src/amule.cpp:2368
+#: src/amule.cpp:2376
 #, c-format
 msgid "WARNING: Your aMuled version is outdated: %i.%i.%i < %li.%li.%li"
 msgstr "CUIDADO: Sua versão do aMuled esta ultrapassada: %i.%i.%i < %li.%li.%li"
 
-#: src/amule.cpp:2374
+#: src/amule.cpp:2382
 msgid "Your copy of aMule is up to date."
 msgstr "Sua cópia do aMule está em dia."
 
-#: src/amule.cpp:2381
+#: src/amule.cpp:2389
 msgid "Failed to download the version check file"
 msgstr "Falha ao baixar arquivo de controle de versão"
 
-#: src/amule.cpp:2550 src/amule-remote-gui.cpp:1133
+#: src/amule.cpp:2558 src/amule-remote-gui.cpp:1133
 #, c-format
 msgid "Users: %s | Files: %s"
 msgstr "Usuários:%s | Arquivos: %s"
 
-#: src/amule.cpp:2551 src/amule-remote-gui.cpp:1134
+#: src/amule.cpp:2559 src/amule-remote-gui.cpp:1134
 #, c-format
 msgid "Users: E: %s K: %s | Files: E: %s K: %s"
 msgstr "Usuários: E: %s K: %s | Arquivos: E: %s K: %s"
 
-#: src/amule.cpp:2565 src/amule-remote-gui.cpp:1147
+#: src/amule.cpp:2573 src/amule-remote-gui.cpp:1147
 msgid "No networks selected"
 msgstr "Nenhuma rede selecionada"
 
-#: src/amule.cpp:2633 src/TextClient.cpp:903
+#: src/amule.cpp:2641 src/TextClient.cpp:903
 msgid "with LowID"
 msgstr "com LowID"
 
-#: src/amule.cpp:2633 src/TextClient.cpp:904
+#: src/amule.cpp:2641 src/TextClient.cpp:904
 msgid "with HighID"
 msgstr "com HighID (Id alta)"
 
-#: src/amule.cpp:2635
+#: src/amule.cpp:2643
 #, c-format
 msgid "Connected to %s %s"
 msgstr "Conectado a %s %s"
 
-#: src/amule.cpp:2640
+#: src/amule.cpp:2648
 #, c-format
 msgid "Connecting to %s"
 msgstr "Conectando a %s"
 
-#: src/amule.cpp:2642
+#: src/amule.cpp:2650
 msgid "Disconnected from eD2k"
 msgstr "Desconectado de eD2k"
 
-#: src/amule.cpp:2651
+#: src/amule.cpp:2659
 msgid "Kad started."
 msgstr "Kad iniciado."
 
-#: src/amule.cpp:2653
+#: src/amule.cpp:2661
 msgid "Kad stopped."
 msgstr "Kad parado."
 
-#: src/amule.cpp:2661
+#: src/amule.cpp:2669
 msgid "Connected to Kad (ok)"
 msgstr "Conectado a rede Kad (ok)"
 
-#: src/amule.cpp:2663
+#: src/amule.cpp:2671
 msgid "Connected to Kad (firewalled)"
 msgstr "Conectado a rede Kad (sob firewall)"
 
-#: src/amule.cpp:2667
+#: src/amule.cpp:2675
 msgid "Disconnected from Kad"
 msgstr "Desconectado da rede Kad"
 
-#: src/amule.cpp:2699
+#: src/amule.cpp:2707
 msgid "Kad network cannot be used if UDP port is disabled on preferences, not starting."
 msgstr "A rede Kad não pode ser usada se a porta UDP está desabilitada em preferências, não iniciará."
 
-#: src/amule.cpp:2703
+#: src/amule.cpp:2711
 msgid "Kad network disabled on preferences, not connecting."
 msgstr "A rede Kad está desabilitada em preferências, não iniciará."
 
@@ -600,36 +600,36 @@ msgid "FATAL ERROR: Failed to create Timer"
 msgstr "ERRO FATAL: Falha ao criar Timer"
 
 #: src/amuleDlg.cpp:361 src/amuleDlg.cpp:1787 src/amuleDlg.cpp:2033
-#: src/muuli_wdr.cpp:1492 src/muuli_wdr.cpp:3418
+#: src/muuli_wdr.cpp:1492 src/muuli_wdr.cpp:3449
 msgid "Networks"
 msgstr "Redes"
 
-#: src/amuleDlg.cpp:362 src/amuleDlg.cpp:1793 src/muuli_wdr.cpp:3419
+#: src/amuleDlg.cpp:362 src/amuleDlg.cpp:1793 src/muuli_wdr.cpp:3450
 msgid "Searches"
 msgstr "Pesquisas"
 
 #: src/amuleDlg.cpp:363 src/amuleDlg.cpp:1799 src/DownloadListCtrl.cpp:740
-#: src/muuli_wdr.cpp:392 src/muuli_wdr.cpp:1585 src/muuli_wdr.cpp:3420
+#: src/muuli_wdr.cpp:392 src/muuli_wdr.cpp:1585 src/muuli_wdr.cpp:3451
 #: src/Statistics.cpp:829
 msgid "Downloads"
 msgstr "Downloads"
 
-#: src/amuleDlg.cpp:364 src/amuleDlg.cpp:1805 src/muuli_wdr.cpp:3294
+#: src/amuleDlg.cpp:364 src/amuleDlg.cpp:1805 src/muuli_wdr.cpp:3325
 msgid "Shared files"
 msgstr "Arquivos compartilhados"
 
-#: src/amuleDlg.cpp:365 src/amuleDlg.cpp:1811 src/muuli_wdr.cpp:2926
-#: src/muuli_wdr.cpp:3376 src/muuli_wdr.cpp:3423
+#: src/amuleDlg.cpp:365 src/amuleDlg.cpp:1811 src/muuli_wdr.cpp:2957
+#: src/muuli_wdr.cpp:3407 src/muuli_wdr.cpp:3454
 msgid "Messages"
 msgstr "Mensagens"
 
-#: src/amuleDlg.cpp:366 src/amuleDlg.cpp:1817 src/muuli_wdr.cpp:3424
-#: src/PrefsUnifiedDlg.cpp:312 src/Statistics.cpp:779 src/Statistics.cpp:1235
+#: src/amuleDlg.cpp:366 src/amuleDlg.cpp:1817 src/muuli_wdr.cpp:3455
+#: src/PrefsUnifiedDlg.cpp:314 src/Statistics.cpp:779 src/Statistics.cpp:1235
 msgid "Statistics"
 msgstr "Estatísticas"
 
-#: src/amuleDlg.cpp:368 src/amuleDlg.cpp:1824 src/muuli_wdr.cpp:3426
-#: src/PrefsUnifiedDlg.cpp:328 src/utils/wxCas/src/wxcasprefs.cpp:39
+#: src/amuleDlg.cpp:368 src/amuleDlg.cpp:1824 src/muuli_wdr.cpp:3457
+#: src/PrefsUnifiedDlg.cpp:330 src/utils/wxCas/src/wxcasprefs.cpp:39
 msgid "Preferences"
 msgstr "Preferências"
 
@@ -691,8 +691,8 @@ msgstr "Kad: Desligado"
 #: src/amuleDlg.cpp:1029 src/DownloadListCtrl.cpp:505
 #: src/DownloadListCtrl.cpp:749 src/FriendListCtrl.cpp:180
 #: src/muuli_wdr.cpp:731 src/muuli_wdr.cpp:782 src/muuli_wdr.cpp:846
-#: src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2231 src/muuli_wdr.cpp:2316
-#: src/muuli_wdr.cpp:3064 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
+#: src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2262 src/muuli_wdr.cpp:2347
+#: src/muuli_wdr.cpp:3095 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
 #: src/ServerListCtrl.cpp:606 src/TransferWnd.cpp:378
 #: src/utils/wxCas/src/wxcasprefs.cpp:235
 msgid "Cancel"
@@ -703,7 +703,7 @@ msgid "Stop the current connection attempts"
 msgstr "Cancelar as tentativas atuais de conexão"
 
 #: src/amuleDlg.cpp:1035 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976
-#: src/muuli_wdr.cpp:2454
+#: src/muuli_wdr.cpp:2485
 msgid "Disconnect"
 msgstr "Desconectar"
 
@@ -712,7 +712,7 @@ msgid "Disconnect from the currently connected networks"
 msgstr "Desconectar das redes atualmente conectadas"
 
 #: src/amuleDlg.cpp:1041 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979
-#: src/muuli_wdr.cpp:2609 src/muuli_wdr.cpp:3061 src/muuli_wdr.cpp:3416
+#: src/muuli_wdr.cpp:2640 src/muuli_wdr.cpp:3092 src/muuli_wdr.cpp:3447
 msgid "Connect"
 msgstr "Conectar"
 
@@ -766,7 +766,7 @@ msgstr "Confirmação de saída"
 msgid "Launch Command: "
 msgstr "Lançar Comando: "
 
-#: src/amuleDlg.cpp:1632 src/muuli_wdr.cpp:1978 src/Preferences.cpp:952
+#: src/amuleDlg.cpp:1632 src/muuli_wdr.cpp:1982 src/Preferences.cpp:979
 msgid "- default -"
 msgstr "- padrão -"
 
@@ -780,48 +780,48 @@ msgstr "O diretório '%s' de skins não existe"
 msgid "WARNING: Unable to open skin file '%s' for read"
 msgstr "CUIDADO: Incapaz de abrir o arquivo de pele '%s' para leitura"
 
-#: src/amuleDlg.cpp:1791 src/muuli_wdr.cpp:3418
+#: src/amuleDlg.cpp:1791 src/muuli_wdr.cpp:3449
 msgid "Networks Window"
 msgstr "Janela de redes"
 
-#: src/amuleDlg.cpp:1797 src/muuli_wdr.cpp:3419
+#: src/amuleDlg.cpp:1797 src/muuli_wdr.cpp:3450
 msgid "Searches Window"
 msgstr "Janela de Pesquisas"
 
-#: src/amuleDlg.cpp:1803 src/muuli_wdr.cpp:3420
+#: src/amuleDlg.cpp:1803 src/muuli_wdr.cpp:3451
 msgid "Downloads Window"
 msgstr "Janela de Downloads"
 
-#: src/amuleDlg.cpp:1809 src/muuli_wdr.cpp:3422
+#: src/amuleDlg.cpp:1809 src/muuli_wdr.cpp:3453
 msgid "Shared Files Window"
 msgstr "Janela de compartilhados"
 
-#: src/amuleDlg.cpp:1815 src/muuli_wdr.cpp:3423
+#: src/amuleDlg.cpp:1815 src/muuli_wdr.cpp:3454
 msgid "Messages Window"
 msgstr "Janela de Mensagens"
 
-#: src/amuleDlg.cpp:1821 src/muuli_wdr.cpp:3424
+#: src/amuleDlg.cpp:1821 src/muuli_wdr.cpp:3455
 msgid "Statistics Graph Window"
 msgstr "Janela de Estatísticas"
 
-#: src/amuleDlg.cpp:1828 src/muuli_wdr.cpp:3426
+#: src/amuleDlg.cpp:1828 src/muuli_wdr.cpp:3457
 msgid "Preferences Settings Window"
 msgstr "Janela de Preferências"
 
-#: src/amuleDlg.cpp:1831 src/muuli_wdr.cpp:3427
+#: src/amuleDlg.cpp:1831 src/muuli_wdr.cpp:3458
 msgid "Import"
 msgstr "Importar"
 
-#: src/amuleDlg.cpp:1835 src/muuli_wdr.cpp:3427
+#: src/amuleDlg.cpp:1835 src/muuli_wdr.cpp:3458
 msgid "The partfile importer tool"
 msgstr "Ferramenta de importação de arquivos .part"
 
-#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3428
+#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3459
 #: src/utils/aLinkCreator/src/alcframe.cpp:262
 msgid "About"
 msgstr "Sobre"
 
-#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3428
+#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3459
 msgid "About/Help"
 msgstr "Sobre/Ajuda"
 
@@ -964,7 +964,7 @@ msgstr "não encontrado"
 msgid "The core rejected these shared folders:%s"
 msgstr "O núcleo rejeitou as seguintes pastas compartilhadas: %s"
 
-#: src/amule-remote-gui.cpp:1336 src/ExternalConn.cpp:2345
+#: src/amule-remote-gui.cpp:1336 src/ExternalConn.cpp:2346
 msgid "Invalid link or already on list."
 msgstr "Link inválido ou já está na lista."
 
@@ -980,7 +980,7 @@ msgstr "Incapaz criar o diretório '%s' para a categoria '%s', mantendo diretór
 #: src/ClientDetailDialog.cpp:123 src/DataToText.cpp:61 src/DataToText.cpp:86
 #: src/DataToText.cpp:101 src/DataToText.cpp:136 src/DataToText.cpp:165
 #: src/DownloadListCtrl.cpp:1172 src/DownloadListCtrl.cpp:1185
-#: src/DownloadListCtrl.cpp:1196 src/ExternalConn.cpp:608
+#: src/DownloadListCtrl.cpp:1196 src/ExternalConn.cpp:609
 #: src/FileDetailDialog.cpp:203 src/FileDetailDialog.cpp:235
 #: src/FileDetailDialog.cpp:242 src/GenericClientListCtrl.cpp:1171
 #: src/GenericClientListCtrl.cpp:1182 src/GenericClientListCtrl.cpp:1192
@@ -1366,19 +1366,19 @@ msgstr "Auto [Alto]"
 msgid "Very low"
 msgstr "Muito baixo"
 
-#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:743 src/muuli_wdr.cpp:2282
+#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:743 src/muuli_wdr.cpp:2313
 #: src/ServerListCtrl.cpp:263 src/ServerListCtrl.cpp:456
 #: src/SharedFilesCtrl.cpp:145
 msgid "Low"
 msgstr "Baixo"
 
-#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:744 src/muuli_wdr.cpp:2283
+#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:744 src/muuli_wdr.cpp:2314
 #: src/ServerListCtrl.cpp:266 src/ServerListCtrl.cpp:457
 #: src/SharedFilesCtrl.cpp:146
 msgid "Normal"
 msgstr "Normal"
 
-#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:745 src/muuli_wdr.cpp:2284
+#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:745 src/muuli_wdr.cpp:2315
 #: src/ServerListCtrl.cpp:269 src/ServerListCtrl.cpp:458
 #: src/SharedFilesCtrl.cpp:147
 msgid "High"
@@ -1470,7 +1470,7 @@ msgstr "Servidor Local"
 msgid "Remote Server"
 msgstr "Servidor Remoto"
 
-#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3181
+#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3212
 #: src/SearchDlg.cpp:119 src/TextClient.cpp:911
 msgid "Kad"
 msgstr "Kad"
@@ -1541,7 +1541,7 @@ msgstr "Parte"
 msgid "Size"
 msgstr "Tamanho"
 
-#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3248
+#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3279
 msgid "Transferred"
 msgstr "Transferido"
 
@@ -1599,7 +1599,7 @@ msgstr ""
 "Resposta de: %s (%s)\n"
 "\n"
 
-#: src/DownloadListCtrl.cpp:746 src/muuli_wdr.cpp:2285
+#: src/DownloadListCtrl.cpp:746 src/muuli_wdr.cpp:2316
 #: src/SharedFilesCtrl.cpp:150
 msgid "Auto"
 msgstr "Auto"
@@ -1637,7 +1637,7 @@ msgid "Extended Options"
 msgstr "Opções Extras"
 
 #: src/DownloadListCtrl.cpp:770 src/DownloadListCtrl.cpp:822
-#: src/muuli_wdr.cpp:1796
+#: src/muuli_wdr.cpp:1800
 msgid "Preview"
 msgstr "Pré-visualizar"
 
@@ -1812,225 +1812,230 @@ msgstr[1] "Não foi possível adicionar %u links (veja o log para detalhes)."
 msgid "Invalid eD2k link! ERROR: %s"
 msgstr "Ligação eD2k inválida! ERRO: %s"
 
-#: src/ExternalConn.cpp:379
+#: src/ExternalConn.cpp:380
 msgid "Client sent packet after authentication failed."
 msgstr "Pacote enviado por cliente após falha na autenticação."
 
-#: src/ExternalConn.cpp:396
+#: src/ExternalConn.cpp:397
 msgid "External connection closed."
 msgstr "Conexão externa encerrada."
 
-#: src/ExternalConn.cpp:473
+#: src/ExternalConn.cpp:474
 msgid "External connections disabled due to empty password!"
 msgstr "Conexões externas desativadas por não ter sido definida uma senha!"
 
-#: src/ExternalConn.cpp:494
+#: src/ExternalConn.cpp:495
 msgid "External connections disabled in config file"
 msgstr "Conexões externas desativadas no arquivo de configuração"
 
-#: src/ExternalConn.cpp:575
+#: src/ExternalConn.cpp:576
 msgid "New external connection accepted"
 msgstr "Novas conexões externas aceitas"
 
-#: src/ExternalConn.cpp:578
+#: src/ExternalConn.cpp:579
 msgid "ERROR: couldn't accept a new external connection"
 msgstr "ERRO: Não pôde aceitar uma nova conexão externa"
 
-#: src/ExternalConn.cpp:595
+#: src/ExternalConn.cpp:596
 msgid "External connection refused due to empty password in preferences!"
 msgstr "Conexão externa recusada por não ter sido definida uma senha nas preferências!"
 
-#: src/ExternalConn.cpp:607
+#: src/ExternalConn.cpp:608
 #, c-format
 msgid "Connecting client: %s %s"
 msgstr "Cliente conectando: %s %s"
 
-#: src/ExternalConn.cpp:609
+#: src/ExternalConn.cpp:610
 msgid "Unknown version"
 msgstr "Versão desconhecida"
 
-#: src/ExternalConn.cpp:622
+#: src/ExternalConn.cpp:623
 msgid "Incorrect EC version ID, there might be binary incompatibility. Use core and remote from same snapshot."
 msgstr "Id de versão do EC incorreta, deve ser incompatibilidade binária. Use o core e o remote da mesma versão."
 
-#: src/ExternalConn.cpp:630
+#: src/ExternalConn.cpp:631
 msgid "You cannot connect to a release version from an arbitrary development snapshot! *sigh* possible crash prevented"
 msgstr "Você não pode conectar a uma versão oficial a partir de um cliente de desenvolvimento! *ufa* Possível travamento evitado"
 
-#: src/ExternalConn.cpp:713
+#: src/ExternalConn.cpp:714
 msgid "Invalid protocol version."
 msgstr "Versão do protocolo inválida."
 
-#: src/ExternalConn.cpp:719
+#: src/ExternalConn.cpp:720
 msgid "Missing protocol version tag."
 msgstr "Falta tag de versão do protocolo."
 
-#: src/ExternalConn.cpp:727
+#: src/ExternalConn.cpp:728
 msgid "Authentication failed: invalid hash specified as EC password."
 msgstr "Autenticação falhou: hash inválido especificado como senha EC."
 
-#: src/ExternalConn.cpp:775
+#: src/ExternalConn.cpp:776
 msgid "Authentication failed: wrong password."
 msgstr "Falha na autenticação: senha errada."
 
-#: src/ExternalConn.cpp:777
+#: src/ExternalConn.cpp:778
 msgid "Authentication failed: missing password."
 msgstr "Falha na autenticação: senha desconhecida."
 
-#: src/ExternalConn.cpp:788
+#: src/ExternalConn.cpp:789
 msgid "Invalid request, please authenticate first."
 msgstr "Requisição inválida, por favor autentique primeiro."
 
-#: src/ExternalConn.cpp:793
+#: src/ExternalConn.cpp:794
 msgid "Access granted."
 msgstr "Acesso liberado."
 
-#: src/ExternalConn.cpp:801
+#: src/ExternalConn.cpp:802
 #, c-format
 msgid "Sent error message \"%s\" to client."
 msgstr "Enviar mensagem de erro \"%s\" para cliente."
 
-#: src/ExternalConn.cpp:806
+#: src/ExternalConn.cpp:807
 #, c-format
 msgid "Unauthorized access attempt from %s. Connection closed."
 msgstr "Tentativa de acesso de %s não autorizado. Conexão encerrada."
 
-#: src/ExternalConn.cpp:1419
+#: src/ExternalConn.cpp:1420
 #, c-format
 msgid "Remote PartFile command failed: FileHash not found: %s"
 msgstr "Comando de PartFile remoto falhou: Filehash não encontrada: %s"
 
-#: src/ExternalConn.cpp:1423
+#: src/ExternalConn.cpp:1424
 #, c-format
 msgid "FileHash not found: %s"
 msgstr "Hash do arquivo não encontrada: %s"
 
-#: src/ExternalConn.cpp:1470 src/ExternalConn.cpp:1558
-#: src/ExternalConn.cpp:1679
+#: src/ExternalConn.cpp:1471 src/ExternalConn.cpp:1559
+#: src/ExternalConn.cpp:1680
 msgid "OOPS! OpCode processing error!"
 msgstr "OOPS! Processando erro OpCode!"
 
-#: src/ExternalConn.cpp:1501
+#: src/ExternalConn.cpp:1502
 msgid "Server not added"
 msgstr "Servidor não adicionado"
 
-#: src/ExternalConn.cpp:1520
+#: src/ExternalConn.cpp:1521
 #, c-format
 msgid "server not found: %s"
 msgstr "servidor não encontrado: %s"
 
-#: src/ExternalConn.cpp:1537
+#: src/ExternalConn.cpp:1538
 msgid "need to define server to be removed"
 msgstr "precisa definir o servidor a ser removido"
 
-#: src/ExternalConn.cpp:1552
+#: src/ExternalConn.cpp:1553
 msgid "eD2k is disabled in preferences."
 msgstr "eD2k foi desabilitado nas preferências."
 
-#: src/ExternalConn.cpp:1657
+#: src/ExternalConn.cpp:1658
 msgid "Friend not found."
 msgstr "Amigo não encontrado."
 
-#: src/ExternalConn.cpp:1667
+#: src/ExternalConn.cpp:1668
 msgid "Client not found."
 msgstr "Cliente não encontrado."
 
-#: src/ExternalConn.cpp:1673
+#: src/ExternalConn.cpp:1674
 msgid "EC_TAG_FRIEND_SHARED requires EC_TAG_FRIEND or EC_TAG_CLIENT."
 msgstr "EC_TAG_FRIEND_SHARED requer EC_TAG_FRIEND ou EC_TAG_CLIENT."
 
-#: src/ExternalConn.cpp:1991
+#: src/ExternalConn.cpp:1992
 msgid "WebSearch from remote interface makes no sense."
 msgstr "Pesquisa web pela interface remota não faz sentido."
 
-#: src/ExternalConn.cpp:2026
+#: src/ExternalConn.cpp:2027
 msgid "Search in progress. Refetch results in a moment!"
 msgstr "Pesquisa em andamento, aguarde!"
 
-#: src/ExternalConn.cpp:2265
+#: src/ExternalConn.cpp:2266
 msgid "No points for graph."
 msgstr "Sem dados para gráfico."
 
-#: src/ExternalConn.cpp:2275
+#: src/ExternalConn.cpp:2276
 msgid "Your client is not configured for this detail level."
 msgstr "Seu cliente não está configurado para esse nível de detalhes."
 
-#: src/ExternalConn.cpp:2302
+#: src/ExternalConn.cpp:2303
 msgid "External Connection: shutdown requested"
 msgstr "Conexão Externa: requerido desligar"
 
-#: src/ExternalConn.cpp:2314
+#: src/ExternalConn.cpp:2315
 msgid "Already shutting down."
 msgstr "Já estou desligando."
 
-#: src/ExternalConn.cpp:2332
+#: src/ExternalConn.cpp:2333
 #, c-format
 msgid "ExternalConn: adding link '%s'."
 msgstr "ExternalConn: adicionar link '%s'."
 
-#: src/ExternalConn.cpp:2350
+#: src/ExternalConn.cpp:2351
 #, c-format
 msgid "%d of %d links failed (invalid or already on list)."
 msgstr "%d de %d links falharam (inválidos ou já estava na lista)."
 
-#: src/ExternalConn.cpp:2373
+#: src/ExternalConn.cpp:2374
 msgid "Version check throttled; try again shortly."
 msgstr "A checagem de versão foi desacelerada; tente novamente em breve."
 
-#: src/ExternalConn.cpp:2378
+#: src/ExternalConn.cpp:2379
 msgid "Version check is not available on this daemon."
 msgstr "A checagem de versão não está disponível neste daemon."
 
-#: src/ExternalConn.cpp:2508
+#: src/ExternalConn.cpp:2509
 msgid "File not found."
 msgstr "Arquivo não encontrado."
 
-#: src/ExternalConn.cpp:2513
+#: src/ExternalConn.cpp:2514
 msgid "Invalid file name."
 msgstr "Nome de arquivo inválido."
 
-#: src/ExternalConn.cpp:2521
+#: src/ExternalConn.cpp:2522
 msgid "Unable to rename file."
 msgstr "Não foi possível renomear o arquivo."
 
-#: src/ExternalConn.cpp:2992 src/ExternalConn.cpp:3020
+#: src/ExternalConn.cpp:2839
+#, c-format
+msgid "Could not save the amuleapi password: %s"
+msgstr ""
+
+#: src/ExternalConn.cpp:3004 src/ExternalConn.cpp:3032
 msgid "Kad is disabled in preferences."
 msgstr "Kad está desativado nas preferências."
 
-#: src/ExternalConn.cpp:3033
+#: src/ExternalConn.cpp:3045
 msgid "Already connected to eD2k."
 msgstr "Já conectado em eD2k."
 
-#: src/ExternalConn.cpp:3036
+#: src/ExternalConn.cpp:3048
 msgid "Connecting to eD2k..."
 msgstr "Conectando em eD2k..."
 
-#: src/ExternalConn.cpp:3045
+#: src/ExternalConn.cpp:3057
 msgid "Already connected to Kad."
 msgstr "Já conectado a rede Kad."
 
-#: src/ExternalConn.cpp:3048
+#: src/ExternalConn.cpp:3060
 msgid "Connecting to Kad..."
 msgstr "Conectando a rede Kad..."
 
-#: src/ExternalConn.cpp:3055
+#: src/ExternalConn.cpp:3067
 msgid "All networks are disabled."
 msgstr "Todas as redes estão desabilitadas."
 
-#: src/ExternalConn.cpp:3064
+#: src/ExternalConn.cpp:3076
 msgid "Disconnected from eD2k."
 msgstr "Desconectado de eD2k."
 
-#: src/ExternalConn.cpp:3069
+#: src/ExternalConn.cpp:3081
 msgid "Disconnected from Kad."
 msgstr "Desconectado da rede Kad."
 
-#: src/ExternalConn.cpp:3078
+#: src/ExternalConn.cpp:3090
 #, c-format
 msgid "External Connection: invalid opcode received: %#x"
 msgstr "Conexão Externa:opcode recebido inválido: %#x"
 
-#: src/ExternalConn.cpp:3083
+#: src/ExternalConn.cpp:3095
 msgid "Invalid opcode (wrong protocol version?)"
 msgstr "O opcode é inválido (versão errada do protocolo?)"
 
@@ -2431,23 +2436,23 @@ msgid ""
 "want downloads on a different (e.g. larger) disk."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:549 src/FirstRunWizard.cpp:611 src/muuli_wdr.cpp:1708
+#: src/FirstRunWizard.cpp:549 src/FirstRunWizard.cpp:611 src/muuli_wdr.cpp:1712
 msgid "Destination folder for downloads"
 msgstr "Pasta de destino para baixados"
 
 #: src/FirstRunWizard.cpp:553 src/FirstRunWizard.cpp:569 src/muuli_wdr.cpp:1349
-#: src/muuli_wdr.cpp:1366 src/muuli_wdr.cpp:1683 src/muuli_wdr.cpp:1714
-#: src/muuli_wdr.cpp:1726 src/muuli_wdr.cpp:2769
+#: src/muuli_wdr.cpp:1366 src/muuli_wdr.cpp:1687 src/muuli_wdr.cpp:1718
+#: src/muuli_wdr.cpp:1730 src/muuli_wdr.cpp:2800
 #: src/utils/aLinkCreator/src/alcframe.cpp:135
 #: src/utils/wxCas/src/wxcasprefs.cpp:52 src/utils/wxCas/src/wxcasprefs.cpp:118
 msgid "Browse"
 msgstr "Procurar"
 
-#: src/FirstRunWizard.cpp:559 src/muuli_wdr.cpp:1719
+#: src/FirstRunWizard.cpp:559 src/muuli_wdr.cpp:1723
 msgid "(All files in this folder are shared with other peers)"
 msgstr "(Todos os arquivos nesta pasta são compartilhados com outros pares)"
 
-#: src/FirstRunWizard.cpp:565 src/FirstRunWizard.cpp:624 src/muuli_wdr.cpp:1721
+#: src/FirstRunWizard.cpp:565 src/FirstRunWizard.cpp:624 src/muuli_wdr.cpp:1725
 msgid "Folder for temporary download files"
 msgstr "Pasta para arquivos temporários baixados"
 
@@ -2478,7 +2483,7 @@ msgstr "Falha em abrir lista de amigos do arquivo 'emfriends.met' para escrita!"
 msgid "CRITICAL - no client on StartChatSession"
 msgstr "CRÍTICO - nenhum cliente em StartChatSession"
 
-#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2675 src/muuli_wdr.cpp:3352
+#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2706 src/muuli_wdr.cpp:3383
 msgid "Friends"
 msgstr "Amigos"
 
@@ -2588,8 +2593,8 @@ msgstr "Nenhum"
 msgid "No"
 msgstr "Não"
 
-#: src/GenericClientListCtrl.cpp:1216 src/PrefsUnifiedDlg.cpp:2818
-#: src/PrefsUnifiedDlg.cpp:2868 src/ServerListCtrl.cpp:276
+#: src/GenericClientListCtrl.cpp:1216 src/PrefsUnifiedDlg.cpp:2898
+#: src/PrefsUnifiedDlg.cpp:2948 src/ServerListCtrl.cpp:276
 msgid "Yes"
 msgstr "Sim"
 
@@ -2758,10 +2763,10 @@ msgstr "Porta inválida para inicialização"
 msgid "Please fill all fields required"
 msgstr "Preencha todos os campos necessários"
 
-#: src/KadDlg.cpp:192 src/PartFile.cpp:1031 src/PrefsUnifiedDlg.cpp:1162
-#: src/PrefsUnifiedDlg.cpp:1331 src/PrefsUnifiedDlg.cpp:1589
-#: src/PrefsUnifiedDlg.cpp:1599 src/PrefsUnifiedDlg.cpp:1616
-#: src/PrefsUnifiedDlg.cpp:1658
+#: src/KadDlg.cpp:192 src/PartFile.cpp:1031 src/PrefsUnifiedDlg.cpp:1134
+#: src/PrefsUnifiedDlg.cpp:1204 src/PrefsUnifiedDlg.cpp:1405
+#: src/PrefsUnifiedDlg.cpp:1663 src/PrefsUnifiedDlg.cpp:1673
+#: src/PrefsUnifiedDlg.cpp:1690 src/PrefsUnifiedDlg.cpp:1738
 msgid "Message"
 msgstr "Mensagem"
 
@@ -2862,7 +2867,7 @@ msgstr "Taxa de compartilhamento"
 msgid "Uploaded"
 msgstr "Enviado"
 
-#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3232
+#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3263
 msgid "Requested"
 msgstr "Requisitado"
 
@@ -2985,7 +2990,7 @@ msgid "WARNING: "
 msgstr "CUIDADO: "
 
 #: src/MuleNotebook.cpp:179 src/muuli_wdr.cpp:817 src/muuli_wdr.cpp:1229
-#: src/muuli_wdr.cpp:3136 src/muuli_wdr.cpp:3392
+#: src/muuli_wdr.cpp:3167 src/muuli_wdr.cpp:3423
 msgid "Close"
 msgstr "Fechar"
 
@@ -3003,7 +3008,7 @@ msgid "Paste"
 msgstr "Colar"
 
 #: src/MuleTextCtrl.cpp:89 src/muuli_wdr.cpp:358 src/muuli_wdr.cpp:757
-#: src/muuli_wdr.cpp:2359 src/muuli_wdr.cpp:2378 src/muuli_wdr.cpp:2400
+#: src/muuli_wdr.cpp:2390 src/muuli_wdr.cpp:2409 src/muuli_wdr.cpp:2431
 #: src/utils/aLinkCreator/src/alcframe.cpp:142
 msgid "Clear"
 msgstr "Limpar"
@@ -3095,7 +3100,7 @@ msgstr "Sair"
 
 #: src/MuleTrayIcon.cpp:579 src/MuleTrayIcon.cpp:945 src/MuleTrayIcon.cpp:965
 #: src/muuli_wdr.cpp:1398 src/muuli_wdr.cpp:1406 src/muuli_wdr.cpp:1413
-#: src/muuli_wdr.cpp:1842 src/muuli_wdr.cpp:1848 src/OtherFunctions.cpp:91
+#: src/muuli_wdr.cpp:1846 src/muuli_wdr.cpp:1852 src/OtherFunctions.cpp:91
 #: src/StatisticsDlg.cpp:93 src/StatisticsDlg.cpp:95
 msgid "kB/s"
 msgstr "kB/s"
@@ -3335,7 +3340,7 @@ msgstr "Bytes"
 msgid "KB"
 msgstr "KB"
 
-#: src/muuli_wdr.cpp:274 src/muuli_wdr.cpp:293 src/muuli_wdr.cpp:1627
+#: src/muuli_wdr.cpp:274 src/muuli_wdr.cpp:293 src/muuli_wdr.cpp:1631
 #: src/OtherFunctions.cpp:64
 msgid "MB"
 msgstr "MB"
@@ -3352,7 +3357,7 @@ msgstr "Tamanho Máximo"
 msgid "Availability"
 msgstr "Disponível"
 
-#: src/muuli_wdr.cpp:312 src/muuli_wdr.cpp:398 src/muuli_wdr.cpp:3297
+#: src/muuli_wdr.cpp:312 src/muuli_wdr.cpp:398 src/muuli_wdr.cpp:3328
 msgid "Filter:"
 msgstr "Filtro:"
 
@@ -3415,12 +3420,12 @@ msgstr "Fontes de arquivos:"
 #: src/muuli_wdr.cpp:1160 src/muuli_wdr.cpp:1167 src/muuli_wdr.cpp:1172
 #: src/muuli_wdr.cpp:1179 src/muuli_wdr.cpp:1184 src/muuli_wdr.cpp:1191
 #: src/muuli_wdr.cpp:1205 src/muuli_wdr.cpp:1212 src/muuli_wdr.cpp:1217
-#: src/muuli_wdr.cpp:1224 src/muuli_wdr.cpp:3234 src/muuli_wdr.cpp:3242
-#: src/muuli_wdr.cpp:3250
+#: src/muuli_wdr.cpp:1224 src/muuli_wdr.cpp:3265 src/muuli_wdr.cpp:3273
+#: src/muuli_wdr.cpp:3281
 msgid "N/A"
 msgstr "N/A"
 
-#: src/muuli_wdr.cpp:508 src/muuli_wdr.cpp:1065 src/PrefsUnifiedDlg.cpp:297
+#: src/muuli_wdr.cpp:508 src/muuli_wdr.cpp:1065 src/PrefsUnifiedDlg.cpp:299
 msgid "General"
 msgstr "Geral"
 
@@ -3556,7 +3561,7 @@ msgstr "Artista:"
 msgid "Album :"
 msgstr "Album:"
 
-#: src/muuli_wdr.cpp:685 src/muuli_wdr.cpp:2254
+#: src/muuli_wdr.cpp:685 src/muuli_wdr.cpp:2285
 msgid "Title :"
 msgstr "Título:"
 
@@ -3664,7 +3669,7 @@ msgstr "Usuário :"
 msgid "Userhash :"
 msgstr "Hash do usuário :"
 
-#: src/muuli_wdr.cpp:895 src/muuli_wdr.cpp:1748 src/muuli_wdr.cpp:2449
+#: src/muuli_wdr.cpp:895 src/muuli_wdr.cpp:1752 src/muuli_wdr.cpp:2480
 #: src/utils/aLinkCreator/src/alcframe.cpp:137
 msgid "Add"
 msgstr "Adicionar"
@@ -3673,15 +3678,15 @@ msgstr "Adicionar"
 msgid "Download-Speed"
 msgstr "Download (Velocidade)"
 
-#: src/muuli_wdr.cpp:954 src/muuli_wdr.cpp:989 src/muuli_wdr.cpp:2553
+#: src/muuli_wdr.cpp:954 src/muuli_wdr.cpp:989 src/muuli_wdr.cpp:2584
 msgid "Current"
 msgstr "Atual"
 
-#: src/muuli_wdr.cpp:962 src/muuli_wdr.cpp:997 src/muuli_wdr.cpp:2561
+#: src/muuli_wdr.cpp:962 src/muuli_wdr.cpp:997 src/muuli_wdr.cpp:2592
 msgid "Running average"
 msgstr "Média de execução"
 
-#: src/muuli_wdr.cpp:970 src/muuli_wdr.cpp:1005 src/muuli_wdr.cpp:2569
+#: src/muuli_wdr.cpp:970 src/muuli_wdr.cpp:1005 src/muuli_wdr.cpp:2600
 msgid "Session average"
 msgstr "Média da sessão"
 
@@ -3693,7 +3698,7 @@ msgstr "Upload (velocidade)"
 msgid "Connections"
 msgstr "Conexões"
 
-#: src/muuli_wdr.cpp:1024 src/muuli_wdr.cpp:1867
+#: src/muuli_wdr.cpp:1024 src/muuli_wdr.cpp:1871
 msgid "Active downloads"
 msgstr "Downloads ativos"
 
@@ -3701,7 +3706,7 @@ msgstr "Downloads ativos"
 msgid "Active connections (1:1)"
 msgstr "Conexões ativas (1:1)"
 
-#: src/muuli_wdr.cpp:1040 src/muuli_wdr.cpp:1868
+#: src/muuli_wdr.cpp:1040 src/muuli_wdr.cpp:1872
 msgid "Active uploads"
 msgstr "Uploads ativos"
 
@@ -3975,7 +3980,7 @@ msgstr "Casar endereço local ao IP (vazio para qualquer um):"
 msgid "Advanced users only: If you have multiple network interfaces, enter the address of the interface to which aMule should be bound."
 msgstr "Somente usuários avançados: Se você tem múltiplas interfaces de rede, insira o endereço da interface com a qual o aMule deverá conectar-se."
 
-#: src/muuli_wdr.cpp:1462 src/muuli_wdr.cpp:2061
+#: src/muuli_wdr.cpp:1462 src/muuli_wdr.cpp:2065
 msgid "Bind to network interface (empty for any):"
 msgstr "Conectar a uma interface de rede (vazio equivale a todas):"
 
@@ -3991,7 +3996,7 @@ msgstr "Máximo de fontes para arquivos baixando:"
 msgid "Max simultaneous connections:"
 msgstr "Máximo de conexões simultâneas:"
 
-#: src/muuli_wdr.cpp:1498 src/muuli_wdr.cpp:3176
+#: src/muuli_wdr.cpp:1498 src/muuli_wdr.cpp:3207
 msgid "ED2K"
 msgstr "ED2K"
 
@@ -4083,79 +4088,79 @@ msgstr "Pré-alocar espaço em disco para novos arquivos"
 msgid "For new files preallocates disk space for the whole file, thus reduces fragmentation"
 msgstr "Para novos arquivos pré-alocar espaço em disco para todo o arquivo, isso reduz fragmentação"
 
-#: src/muuli_wdr.cpp:1613
+#: src/muuli_wdr.cpp:1617
 msgid "Create new files as sparse files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1614
-msgid "A sparse file reserves its full size on disk immediately without writing real data to it -- fast, but unsupported or slow on some filesystems, and free-space accounting stays optimistic while the download is in progress. Turn this off to grow the file only as data arrives."
+#: src/muuli_wdr.cpp:1618
+msgid "Sparse part files only occupy disk space for the parts already downloaded, so free space is used up gradually as the file fills in. Turn this off to use an ordinary file instead - useful where sparse files are unsupported or slow, or where backup/de-duplication tools handle them badly. Applies only when the core runs on Windows; on Linux and macOS part files are sparse anyway and this setting has no effect."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1619
+#: src/muuli_wdr.cpp:1623
 msgid "Stop downloads when free disk space reaches "
 msgstr "Parar download quando espaço livre em disco acabar "
 
-#: src/muuli_wdr.cpp:1620
+#: src/muuli_wdr.cpp:1624
 msgid "Select this if you want aMule to check your disk space"
 msgstr "Selecione isso se você quer uqe o aMule cheque seu espaço em disco"
 
-#: src/muuli_wdr.cpp:1624
+#: src/muuli_wdr.cpp:1628
 msgid "Enter here the min disk space desired."
 msgstr "Digite aqui o espaço min. de disco desejado."
 
-#: src/muuli_wdr.cpp:1630
+#: src/muuli_wdr.cpp:1634
 msgid "Save 10 sources on rare files (< 20 sources)"
 msgstr "Salvar 10 fontes em arquivos raros (< 20 fontes)"
 
-#: src/muuli_wdr.cpp:1634 src/Statistics.cpp:790
+#: src/muuli_wdr.cpp:1638 src/Statistics.cpp:790
 msgid "Uploads"
 msgstr "Uploads"
 
-#: src/muuli_wdr.cpp:1637
+#: src/muuli_wdr.cpp:1641
 msgid "Add new shared files with auto priority"
 msgstr "Adicionar novos compartilhamentos com prioridade automática"
 
-#: src/muuli_wdr.cpp:1643
+#: src/muuli_wdr.cpp:1647
 msgid "Intelligent Corruption Handling (I.C.H.)"
 msgstr "Manuseamento Inteligente de Corrupção (I.C.H.)"
 
-#: src/muuli_wdr.cpp:1646
+#: src/muuli_wdr.cpp:1650
 msgid "Enable"
 msgstr "Habilitado"
 
-#: src/muuli_wdr.cpp:1649
+#: src/muuli_wdr.cpp:1653
 msgid "Advanced I.C.H. trusts every hash (not recommended)"
 msgstr "I.C.H. avançado confia em todo hash (não recomendado)"
 
-#: src/muuli_wdr.cpp:1661 src/PrefsUnifiedDlg.cpp:1910
+#: src/muuli_wdr.cpp:1665 src/PrefsUnifiedDlg.cpp:1990
 msgid "Media metadata extraction"
 msgstr "Extração de metadados da mídia"
 
-#: src/muuli_wdr.cpp:1665
+#: src/muuli_wdr.cpp:1669
 msgid "Extract length / bitrate / codec from shared audio and video files"
 msgstr "Extrair compeimento / taxa de bits / codec de arquivos compartilhados de audio e vídeo"
 
-#: src/muuli_wdr.cpp:1667
+#: src/muuli_wdr.cpp:1671
 msgid "When enabled, aMule runs ffprobe on each shared media file to fill in the Length / Bitrate / Codec columns other clients see when they find the file in a search. Requires ffmpeg (the ffprobe binary) to be installed."
 msgstr "Quando habilitado, o aMule roda ffprobe em cada arquivo de mídia compartilhado para preencher as colunas de Comprimento / Taxa de Bits / Codec que os outros clientes veem quando acham o arquivo em uma procura. Requer que o ffmpeg (o binário ffprobe) esteja instalado."
 
-#: src/muuli_wdr.cpp:1674
+#: src/muuli_wdr.cpp:1678
 msgid "Path to ffprobe:"
 msgstr "Caminho para ffprobe:"
 
-#: src/muuli_wdr.cpp:1679
+#: src/muuli_wdr.cpp:1683
 msgid "Full path to the ffprobe binary. Leave empty to have aMule auto-detect it on startup."
 msgstr "Caminho completo para o binário ffprobe. Deixe vazio para que o aMule detecte automaticamente quando iniciar."
 
-#: src/muuli_wdr.cpp:1687
+#: src/muuli_wdr.cpp:1691
 msgid "Detect"
 msgstr "Detectar"
 
-#: src/muuli_wdr.cpp:1688
+#: src/muuli_wdr.cpp:1692
 msgid "Search the standard install locations for an ffprobe binary and fill the path field."
 msgstr "Procura nos locais de instalação padrão por um binário do ffprobe e preenche o campo de caminho."
 
-#: src/muuli_wdr.cpp:1712
+#: src/muuli_wdr.cpp:1716
 msgid ""
 "Completed downloads are stored here. All files in this folder are automatically shared with other peers.\n"
 "If this folder also holds files you don't want to share, point it at an aMule-only sub-folder."
@@ -4163,665 +4168,688 @@ msgstr ""
 "Downloads finalizados são guardados aqui. Todos os arquivos nesta pasta são automaticamente compartilhados com outros pares.\n"
 "Se esta pasta também guarda arquivos que você não quer compartilhar, aponte para uma sub-pasta só para o aMule."
 
-#: src/muuli_wdr.cpp:1715
+#: src/muuli_wdr.cpp:1719
 msgid "Pick the folder where completed downloads will be stored. All files in that folder will be shared with other peers."
 msgstr "Escolha a pasta onde os downloads terminados serão guardados. Todos os arquivos nesta pasta serão compartilhados com outros pares."
 
-#: src/muuli_wdr.cpp:1729
+#: src/muuli_wdr.cpp:1733
 msgid "Shared folders"
 msgstr "Pastas compartilhadas"
 
-#: src/muuli_wdr.cpp:1735
+#: src/muuli_wdr.cpp:1739
 msgid "(Folders shared by the core. Enter a path to add one.)"
 msgstr "(Pastas compartilhadas pelo núcleo. Digite um caminho para adicionar uma.)"
 
-#: src/muuli_wdr.cpp:1743
+#: src/muuli_wdr.cpp:1747
 msgid "Absolute path of a folder on the core's machine, e.g. /home/user/shared"
 msgstr "Caminho absoluto de uma pasta no núcleo da máquina, e.g. /home/user/shared"
 
-#: src/muuli_wdr.cpp:1745 src/PrefsUnifiedDlg.cpp:2794
+#: src/muuli_wdr.cpp:1749 src/PrefsUnifiedDlg.cpp:2874
 msgid "Recursive"
 msgstr "Recursivo"
 
-#: src/muuli_wdr.cpp:1746
+#: src/muuli_wdr.cpp:1750
 msgid "Share every sub-folder underneath this one, including ones created later."
 msgstr "Compartilhar todas as sub-pastas dentro desta, incluindo as criadas posteriormente."
 
-#: src/muuli_wdr.cpp:1750 src/utils/aLinkCreator/src/alcframe.cpp:141
+#: src/muuli_wdr.cpp:1754 src/utils/aLinkCreator/src/alcframe.cpp:141
 msgid "Remove"
 msgstr "Remover"
 
-#: src/muuli_wdr.cpp:1754
+#: src/muuli_wdr.cpp:1758
 msgid "(Right click on folder icon for recursive share)"
 msgstr "(Botão direito na pasta para compartilhar recursivamente)"
 
-#: src/muuli_wdr.cpp:1761
+#: src/muuli_wdr.cpp:1765
 msgid "Share hidden files"
 msgstr "Compartilhar arquivos ocultos"
 
-#: src/muuli_wdr.cpp:1767
+#: src/muuli_wdr.cpp:1771
 msgid "Automatically rescan shared folders for changes"
 msgstr "Vasculha novamente automaticamente arquivos compartilhados que mudaram"
 
-#: src/muuli_wdr.cpp:1773
+#: src/muuli_wdr.cpp:1777
 msgid "Follow symbolic links in shared folders"
 msgstr "Segue links simbólicos em pastas compartilhadas"
 
-#: src/muuli_wdr.cpp:1779
+#: src/muuli_wdr.cpp:1783
 msgid "Exclude files matching:"
 msgstr "Exclui arquivos correspondendo a:"
 
-#: src/muuli_wdr.cpp:1782
+#: src/muuli_wdr.cpp:1786
 msgid "Wildcard patterns separated by '|', e.g. .DS_Store|Thumbs.db|*.tmp. Files whose name matches are not shared. Matching is case-insensitive."
 msgstr "Caracteres curinga separados por '|', e.g. .DS_Store|Thumbs.db|*.tmp. Arquivos cujos nomes corresponderem não serão compartilhados. A correspondência é sensível à letra maiúscula/minúscula."
 
-#: src/muuli_wdr.cpp:1786
+#: src/muuli_wdr.cpp:1790
 msgid "Patterns are regular expressions"
 msgstr "Padrões são expressões regulares"
 
-#: src/muuli_wdr.cpp:1787
+#: src/muuli_wdr.cpp:1791
 msgid "When set, the whole field is one regular expression ('|' is alternation). When unset, it is a list of '|'-separated wildcards."
 msgstr "Quando ligado, o campo inteiro é uma expressão regular ('|' é alternativa). Quando desligado, é uma lista de caracteres curinga separados por '|'."
 
-#: src/muuli_wdr.cpp:1797
+#: src/muuli_wdr.cpp:1801
 msgid "Show how many shared files the current pattern would exclude."
 msgstr "Mostra quantos arquivos compartilhados o padrão atual excluiria."
 
-#: src/muuli_wdr.cpp:1818
+#: src/muuli_wdr.cpp:1822
 msgid "Graphs"
 msgstr "Gráficos"
 
-#: src/muuli_wdr.cpp:1821 src/muuli_wdr.cpp:1883
+#: src/muuli_wdr.cpp:1825 src/muuli_wdr.cpp:1887
 msgid "Update delay : 5 secs"
 msgstr "Tempo de atualização: 5s"
 
-#: src/muuli_wdr.cpp:1825
+#: src/muuli_wdr.cpp:1829
 msgid "Time for average graph: 100 mins"
 msgstr "Tempo para gráfico de média: 100min"
 
-#: src/muuli_wdr.cpp:1829
+#: src/muuli_wdr.cpp:1833
 msgid "Connections Graph Scale: 100 "
 msgstr "Escala dos gráficos das conexões: 100 "
 
-#: src/muuli_wdr.cpp:1836
+#: src/muuli_wdr.cpp:1840
 msgid "Download graph scale:"
 msgstr "Escala gráfica de download:"
 
-#: src/muuli_wdr.cpp:1844
+#: src/muuli_wdr.cpp:1848
 msgid "Upload graph scale:"
 msgstr "Escala gráfica de upload:"
 
-#: src/muuli_wdr.cpp:1854
+#: src/muuli_wdr.cpp:1858
 msgid "Colors: "
 msgstr "Cores: "
 
-#: src/muuli_wdr.cpp:1858
+#: src/muuli_wdr.cpp:1862
 msgid "Background"
 msgstr "Fundo"
 
-#: src/muuli_wdr.cpp:1859
+#: src/muuli_wdr.cpp:1863
 msgid "Grid"
 msgstr "Grade"
 
-#: src/muuli_wdr.cpp:1860
+#: src/muuli_wdr.cpp:1864
 msgid "Download current"
 msgstr "Download atual"
 
-#: src/muuli_wdr.cpp:1861
+#: src/muuli_wdr.cpp:1865
 msgid "Download running average"
 msgstr "Média dos Downloads ativos"
 
-#: src/muuli_wdr.cpp:1862
+#: src/muuli_wdr.cpp:1866
 msgid "Download session average"
 msgstr "Média dos Downloads da sessão"
 
-#: src/muuli_wdr.cpp:1863
+#: src/muuli_wdr.cpp:1867
 msgid "Upload current"
 msgstr "Upload Atual"
 
-#: src/muuli_wdr.cpp:1864
+#: src/muuli_wdr.cpp:1868
 msgid "Upload running average"
 msgstr "Média dos Uploads ativos"
 
-#: src/muuli_wdr.cpp:1865
+#: src/muuli_wdr.cpp:1869
 msgid "Upload session average"
 msgstr "Média dos Uploads da sessão"
 
-#: src/muuli_wdr.cpp:1866
+#: src/muuli_wdr.cpp:1870
 msgid "Active connections"
 msgstr "Conexões ativas"
 
-#: src/muuli_wdr.cpp:1869
+#: src/muuli_wdr.cpp:1873
 msgid "Systray Icon Speed Bar"
 msgstr "Ícone de barra de velocidade"
 
-#: src/muuli_wdr.cpp:1870
+#: src/muuli_wdr.cpp:1874
 msgid "Kad-nodes current"
 msgstr "Kad-nodes atuais"
 
-#: src/muuli_wdr.cpp:1871
+#: src/muuli_wdr.cpp:1875
 msgid "Kad-nodes running"
 msgstr "Kad-nodes rodando"
 
-#: src/muuli_wdr.cpp:1872
+#: src/muuli_wdr.cpp:1876
 msgid "Kad-nodes session"
 msgstr "Sessões Kad-nodes"
 
-#: src/muuli_wdr.cpp:1876 src/muuli_wdr.cpp:2303
+#: src/muuli_wdr.cpp:1880 src/muuli_wdr.cpp:2334
 msgid "Select"
 msgstr "Selecione"
 
-#: src/muuli_wdr.cpp:1880
+#: src/muuli_wdr.cpp:1884
 msgid "Tree"
 msgstr "Árvore"
 
-#: src/muuli_wdr.cpp:1890
+#: src/muuli_wdr.cpp:1894
 msgid "Number of Client Versions shown (0=unlimited)"
 msgstr "Número de versões a exibir (0=sem limite)"
 
-#: src/muuli_wdr.cpp:1915
+#: src/muuli_wdr.cpp:1919
 msgid "!!! WARNING !!!"
 msgstr "!!! CUIDADO !!!"
 
-#: src/muuli_wdr.cpp:1930
+#: src/muuli_wdr.cpp:1934
 msgid "Max new connections / 5 secs"
 msgstr "No. Max. de conexões / 5s"
 
-#: src/muuli_wdr.cpp:1932
+#: src/muuli_wdr.cpp:1936
 msgid "Concurrent Kad source lookups"
 msgstr "Procura concorrente de fontes Kad"
 
-#: src/muuli_wdr.cpp:1934
+#: src/muuli_wdr.cpp:1938
 msgid "Kad source re-search interval (minutes)"
 msgstr "Intervalo entre novas buscas de fontes Kad (minutos)"
 
-#: src/muuli_wdr.cpp:1936
+#: src/muuli_wdr.cpp:1940
 msgid "Source re-ask interval (minutes)"
 msgstr "Intervalo entre novos pedidos de fonte (minutos)"
 
-#: src/muuli_wdr.cpp:1940
+#: src/muuli_wdr.cpp:1944
 msgid "File Buffer Size: 240000 bytes"
 msgstr "Tamanho do arquivo buffer: 240000 bytes"
 
-#: src/muuli_wdr.cpp:1944
+#: src/muuli_wdr.cpp:1948
 msgid "Use MMAP: memory-mapped file access (lower memory use)"
 msgstr "Usar MMAP: acesso de arquivo mapeado em memória (menor uso de memória)"
 
-#: src/muuli_wdr.cpp:1945
+#: src/muuli_wdr.cpp:1949
 msgid "Maps part files into memory instead of buffering them on the heap, lowering the process memory footprint. May reduce download speed on some disks; best for memory-constrained or upload-heavy hosts."
 msgstr "Mapeia arquivos part em memória ao invés de buferizá-los na heap, diminuindo a pegada de memória do processo. Pode reduzir a velocidade de download em alguns discos; melhor para hopedeiros com memória restrita ou que façam upload intensivamente."
 
-#: src/muuli_wdr.cpp:1947
+#: src/muuli_wdr.cpp:1951
 msgid "Upload Queue Size: 5000 clients"
 msgstr "Tamanho de Espera de Upload: 5000 clientes"
 
-#: src/muuli_wdr.cpp:1951
+#: src/muuli_wdr.cpp:1955
 msgid "Server connection refresh interval: Disable"
 msgstr "Atualizar conexão com servidor: desativado"
 
-#: src/muuli_wdr.cpp:1955
+#: src/muuli_wdr.cpp:1959
 msgid "Disable computer's timed standby mode"
 msgstr "Desabilitar modo timed standby do computador"
 
-#: src/muuli_wdr.cpp:1974
+#: src/muuli_wdr.cpp:1978
 msgid "Skin to use: "
 msgstr "Pele a usar: "
 
-#: src/muuli_wdr.cpp:1983
+#: src/muuli_wdr.cpp:1987
 msgid "Show \"Fast eD2k Links Handler\" in every window."
 msgstr "Mostrar \"Manipulador Veloz de Ligações eD2k\" em cada janela."
 
-#: src/muuli_wdr.cpp:1986
+#: src/muuli_wdr.cpp:1990
 msgid "Show extended info on categories tabs"
 msgstr "Mostrar info. extras nas abas de categoria"
 
-#: src/muuli_wdr.cpp:1989
+#: src/muuli_wdr.cpp:1993
 msgid "Show application version on title"
 msgstr "Exibir versão do aplicativo no título"
 
-#: src/muuli_wdr.cpp:1991
+#: src/muuli_wdr.cpp:1995
 msgid "Show transfer rates on title"
 msgstr "Exibir taxa de transferência no título"
 
-#: src/muuli_wdr.cpp:1993
+#: src/muuli_wdr.cpp:1997
 msgid "Before application name"
 msgstr "Antes do nome da aplicação"
 
-#: src/muuli_wdr.cpp:1995
+#: src/muuli_wdr.cpp:1999
 msgid "After application name"
 msgstr "Depois do nome da aplicação"
 
-#: src/muuli_wdr.cpp:1998
+#: src/muuli_wdr.cpp:2002
 msgid "Show overhead bandwidth"
 msgstr "Mostrar banda sobressalente"
 
-#: src/muuli_wdr.cpp:2002
+#: src/muuli_wdr.cpp:2006
 msgid "Vertical toolbar orientation"
 msgstr "Orientação Vertical da Barra de Ferramentas"
 
-#: src/muuli_wdr.cpp:2004
+#: src/muuli_wdr.cpp:2008
 msgid "Live column sorting (auto-reorder rows as their values change)"
 msgstr "Ordenação de coluna ao vivo (reordenamento automático das colunas conforme seus valores mudam)"
 
-#: src/muuli_wdr.cpp:2011
+#: src/muuli_wdr.cpp:2015
 msgid "Download Queue Files"
 msgstr "Fila de arquivos baixando"
 
-#: src/muuli_wdr.cpp:2014
+#: src/muuli_wdr.cpp:2018
 msgid "Show progress percentage"
 msgstr "Mostrar porcentagem do progresso"
 
-#: src/muuli_wdr.cpp:2020
+#: src/muuli_wdr.cpp:2024
 msgid "Show progress bar"
 msgstr "Mostrar barra de progresso"
 
-#: src/muuli_wdr.cpp:2023
+#: src/muuli_wdr.cpp:2027
 msgid "Flat"
 msgstr "Plana"
 
-#: src/muuli_wdr.cpp:2027
+#: src/muuli_wdr.cpp:2031
 msgid "Round"
 msgstr "Arredondada"
 
-#: src/muuli_wdr.cpp:2045
+#: src/muuli_wdr.cpp:2049
 msgid "External Connection Parameters"
 msgstr "Parâmetros de conexão externa"
 
-#: src/muuli_wdr.cpp:2048
+#: src/muuli_wdr.cpp:2052
 msgid "Accept external connections"
 msgstr "Aceitar conexões externas"
 
-#: src/muuli_wdr.cpp:2055 src/muuli_wdr.cpp:2114
+#: src/muuli_wdr.cpp:2059 src/muuli_wdr.cpp:2118
 msgid "IP of the listening interface:"
 msgstr "IP da interface ouvindo:"
 
-#: src/muuli_wdr.cpp:2058
+#: src/muuli_wdr.cpp:2062
 msgid "Enter here a valid ip in the a.b.c.d format for the listening EC interface. An empty field or 0.0.0.0 will mean any interface."
 msgstr "Informe um IP válido no formato a.b.c.d para a interface EC que ficará aguardando. Um campo vazio ou 0.0.0.0 quer dizer 'qualquer interface'."
 
-#: src/muuli_wdr.cpp:2079 src/muuli_wdr.cpp:2163
+#: src/muuli_wdr.cpp:2083 src/muuli_wdr.cpp:2194
 msgid "TCP port:"
 msgstr "Porta TCP:"
 
-#: src/muuli_wdr.cpp:2085
+#: src/muuli_wdr.cpp:2089
 msgid "Enable UPnP port forwarding on the EC port"
 msgstr "Habilitar redirecionamento de porta UPnP para porta EC"
 
-#: src/muuli_wdr.cpp:2089 src/muuli_wdr.cpp:3048
+#: src/muuli_wdr.cpp:2093 src/muuli_wdr.cpp:3079
 #: src/utils/wxCas/src/wxcasprefs.cpp:167
 msgid "Password"
 msgstr "Senha"
 
-#: src/muuli_wdr.cpp:2095
+#: src/muuli_wdr.cpp:2099
 msgid "aMule API server parameters"
 msgstr "Parâmetros do servidor da API do aMule"
 
-#: src/muuli_wdr.cpp:2098
+#: src/muuli_wdr.cpp:2102
 msgid "Run amuleapi (REST API) on startup"
 msgstr "Rodar o amuleapi (REST API) ao iniciar"
 
-#: src/muuli_wdr.cpp:2103
+#: src/muuli_wdr.cpp:2107
 msgid "HTTP port:"
 msgstr "Porta HTTP:"
 
-#: src/muuli_wdr.cpp:2117
+#: src/muuli_wdr.cpp:2121
 msgid "The interface amuleapi's HTTP server listens on. 127.0.0.1 (default) accepts only local connections; use 0.0.0.0 or a specific IP to expose it to other hosts (set an admin password below)."
 msgstr "A interface do servidor HTTP do amuleapi que escuta em 127.0.0.1 (padrão) aceita apenas conexões locais; use 0.0.0.0 or um IP específico para expô-la a outros hospedeiros (configure uma senha de administração abaixo)."
 
-#: src/muuli_wdr.cpp:2120
+#: src/muuli_wdr.cpp:2126
+msgid "Type a password to set or change it. Stored passwords cannot be shown, so leaving this empty keeps the current one."
+msgstr ""
+
+#: src/muuli_wdr.cpp:2128
 msgid "Admin password"
 msgstr "Senha de administração"
 
-#: src/muuli_wdr.cpp:2125 src/muuli_wdr.cpp:2156
-msgid "Low rights password"
-msgstr "Password para acesso limitado"
+#: src/muuli_wdr.cpp:2140 src/muuli_wdr.cpp:2157 src/PrefsUnifiedDlg.cpp:1103
+#, fuzzy
+msgid "A password is set."
+msgstr "Senha de administração"
 
-#: src/muuli_wdr.cpp:2133
+#: src/muuli_wdr.cpp:2144
+#, fuzzy
+msgid "Enable guest access"
+msgstr "Negar acesso restrito"
+
+#: src/muuli_wdr.cpp:2145
+msgid "Guest sessions may read status and listings but cannot change anything. Turning this off clears the stored guest password."
+msgstr ""
+
+#: src/muuli_wdr.cpp:2149
+#, fuzzy
+msgid "Guest password"
+msgstr "Senha de visitante para servidor web"
+
+#: src/muuli_wdr.cpp:2164
 msgid "Web server parameters"
 msgstr "Parâmetros do web server"
 
-#: src/muuli_wdr.cpp:2136
+#: src/muuli_wdr.cpp:2167
 msgid "Run webserver on startup (deprecated)"
 msgstr "Rodar webserver ao iniciar (deprecado)"
 
-#: src/muuli_wdr.cpp:2142
+#: src/muuli_wdr.cpp:2173
 msgid "Web template"
 msgstr "Modelo de rede"
 
-#: src/muuli_wdr.cpp:2147
+#: src/muuli_wdr.cpp:2178
 msgid "Full rights password"
 msgstr "Password para acesso completo"
 
-#: src/muuli_wdr.cpp:2151
+#: src/muuli_wdr.cpp:2182
 msgid "Enable Low rights User"
 msgstr "Usuário com direitos limitados"
 
-#: src/muuli_wdr.cpp:2170
+#: src/muuli_wdr.cpp:2187
+msgid "Low rights password"
+msgstr "Password para acesso limitado"
+
+#: src/muuli_wdr.cpp:2201
 msgid "Enable UPnP port forwarding of the web server port"
 msgstr "Habilitar redirecionamento de porta UPnP da porta do servidor web"
 
-#: src/muuli_wdr.cpp:2175
+#: src/muuli_wdr.cpp:2206
 msgid "Web server UPnP TCP port (Optional)"
 msgstr "Porta TCP UPnP do servidor web (Opcional)"
 
-#: src/muuli_wdr.cpp:2183
+#: src/muuli_wdr.cpp:2214
 msgid "Page Refresh Time (in secs)"
 msgstr "Tempo atualização (secs)"
 
-#: src/muuli_wdr.cpp:2190
+#: src/muuli_wdr.cpp:2221
 msgid "Enable Gzip compression"
 msgstr "Ativar compactação Gzip"
 
-#: src/muuli_wdr.cpp:2224
+#: src/muuli_wdr.cpp:2255
 msgid "Reset page to defaults"
 msgstr "Retorna a página aos valores padrão"
 
-#: src/muuli_wdr.cpp:2225
+#: src/muuli_wdr.cpp:2256
 msgid "Reset the settings on the current page to their default values."
 msgstr "Reseta as configurações na página atual para seus valores padrão."
 
-#: src/muuli_wdr.cpp:2227 src/muuli_wdr.cpp:2313 src/ServerWnd.cpp:274
+#: src/muuli_wdr.cpp:2258 src/muuli_wdr.cpp:2344 src/ServerWnd.cpp:274
 #: src/ServerWnd.cpp:282
 msgid "OK"
 msgstr "OK"
 
-#: src/muuli_wdr.cpp:2229
+#: src/muuli_wdr.cpp:2260
 msgid "Click here to apply any changes made to the preferences."
 msgstr "Clique aqui para aplicar as alterações feitas."
 
-#: src/muuli_wdr.cpp:2232
+#: src/muuli_wdr.cpp:2263
 msgid "Reset any changes made to the preferences."
 msgstr "Ignora todas as alterações feitas."
 
-#: src/muuli_wdr.cpp:2261
+#: src/muuli_wdr.cpp:2292
 msgid "Comment :"
 msgstr "Comentário:"
 
-#: src/muuli_wdr.cpp:2268
+#: src/muuli_wdr.cpp:2299
 msgid "Incoming Dir :"
 msgstr "Dir incoming:"
 
-#: src/muuli_wdr.cpp:2277
+#: src/muuli_wdr.cpp:2308
 msgid "Change priority for new assigned files :"
 msgstr "Alterar prioridade para novos arquivos:"
 
-#: src/muuli_wdr.cpp:2281
+#: src/muuli_wdr.cpp:2312
 msgid "Don't change"
 msgstr "Não alterar"
 
-#: src/muuli_wdr.cpp:2293
+#: src/muuli_wdr.cpp:2324
 msgid "Select color for this Category (currently selected) :"
 msgstr "Selecione a cor para esta Categoria (selecionada):"
 
-#: src/muuli_wdr.cpp:2360 src/muuli_wdr.cpp:2379 src/muuli_wdr.cpp:2401
+#: src/muuli_wdr.cpp:2391 src/muuli_wdr.cpp:2410 src/muuli_wdr.cpp:2432
 msgid "Click this button to reset the log."
 msgstr "Clique nesse botão para limpar o log."
 
-#: src/muuli_wdr.cpp:2420
+#: src/muuli_wdr.cpp:2451
 msgid "Click on this button to update the servers list from URL ..."
 msgstr "Clique nesse botão para atualizar a lista de servidores..."
 
-#: src/muuli_wdr.cpp:2424
+#: src/muuli_wdr.cpp:2455
 msgid "Server list"
 msgstr "Lista de servidores"
 
-#: src/muuli_wdr.cpp:2428
+#: src/muuli_wdr.cpp:2459
 msgid "Enter the url to a server.met file here and press the button to the left to update the list of known servers."
 msgstr "Informe a URL com o arquivo server.met aqui e pressione o botão a esquerda para atualizar a lista de servidores."
 
-#: src/muuli_wdr.cpp:2433
+#: src/muuli_wdr.cpp:2464
 msgid "Add server manually: Name"
 msgstr "Adicionar servidor manualmente: Nome"
 
-#: src/muuli_wdr.cpp:2436
+#: src/muuli_wdr.cpp:2467
 msgid "Enter the name of the new server here"
 msgstr "Informe o nome do novo servidor aqui"
 
-#: src/muuli_wdr.cpp:2438 src/ServerWnd.cpp:206
+#: src/muuli_wdr.cpp:2469 src/ServerWnd.cpp:206
 msgid "IP:Port"
 msgstr "IP:Porta"
 
-#: src/muuli_wdr.cpp:2441
+#: src/muuli_wdr.cpp:2472
 msgid "Enter the IP of the server here, using the x.x.x.x format."
 msgstr "Informe o IP do servidor no formato x.x.x.x nesse espaço."
 
-#: src/muuli_wdr.cpp:2447
+#: src/muuli_wdr.cpp:2478
 msgid "Enter the port of the server here."
 msgstr "Informe a porta do servidor aqui."
 
-#: src/muuli_wdr.cpp:2450
+#: src/muuli_wdr.cpp:2481
 msgid "Add manually a server (fill fields to the left before) ..."
 msgstr "Adicionar manualmente um servidor (preencha os campos ao lado antes)."
 
-#: src/muuli_wdr.cpp:2479
+#: src/muuli_wdr.cpp:2510
 msgid "aMule Log"
 msgstr "Log do aMule"
 
-#: src/muuli_wdr.cpp:2487
+#: src/muuli_wdr.cpp:2518
 msgid "Server Info"
 msgstr "Informações do Servidor"
 
-#: src/muuli_wdr.cpp:2491
+#: src/muuli_wdr.cpp:2522
 msgid "ED2K Info"
 msgstr "ED2K Info"
 
-#: src/muuli_wdr.cpp:2495
+#: src/muuli_wdr.cpp:2526
 msgid "Kad Info"
 msgstr "Informação de Kad"
 
-#: src/muuli_wdr.cpp:2523
+#: src/muuli_wdr.cpp:2554
 msgid "Click on this button to update the nodes list from URL ..."
 msgstr "Clique nesse botão para atualizar a lista de nodes da URL..."
 
-#: src/muuli_wdr.cpp:2527
+#: src/muuli_wdr.cpp:2558
 msgid "Nodes (0)"
 msgstr "Nós (0)"
 
-#: src/muuli_wdr.cpp:2531
+#: src/muuli_wdr.cpp:2562
 msgid "Enter the url to a nodes.dat file here and press the button to the left to update the list of known nodes."
 msgstr "Informe uma URL para um arquivo nodes.dat e pressione o botão da esquerda para atualizar a lista de nós conhecidos."
 
-#: src/muuli_wdr.cpp:2534
+#: src/muuli_wdr.cpp:2565
 msgid "Nodes stats"
 msgstr "Estatísticas dos Nodes"
 
-#: src/muuli_wdr.cpp:2576
+#: src/muuli_wdr.cpp:2607
 msgid "Bootstrap"
 msgstr "Inicialização"
 
-#: src/muuli_wdr.cpp:2579
+#: src/muuli_wdr.cpp:2610
 msgid "New node"
 msgstr "Novo node"
 
-#: src/muuli_wdr.cpp:2584
+#: src/muuli_wdr.cpp:2615
 msgid "IP:"
 msgstr "IP:"
 
-#: src/muuli_wdr.cpp:2604
+#: src/muuli_wdr.cpp:2635
 msgid "Port:"
 msgstr "Porta:"
 
-#: src/muuli_wdr.cpp:2617
+#: src/muuli_wdr.cpp:2648
 msgid "Bootstrap from known clients"
 msgstr "Inicializando de clientes conhecidos"
 
-#: src/muuli_wdr.cpp:2619
+#: src/muuli_wdr.cpp:2650
 msgid "Disconnect Kad"
 msgstr "Desconectar da rede Kad"
 
-#: src/muuli_wdr.cpp:2653
+#: src/muuli_wdr.cpp:2684
 msgid "Use Secure User Identification"
 msgstr "Utilizar Identificação Segura de Usuário"
 
-#: src/muuli_wdr.cpp:2655
+#: src/muuli_wdr.cpp:2686
 msgid "It is recommended to enable this option. You will not receive credits if SUI is not enabled."
 msgstr "É recomendável ativar essa opção. Você não receberá seus créditos se a identificação segura não estiver ativada."
 
-#: src/muuli_wdr.cpp:2657
+#: src/muuli_wdr.cpp:2688
 msgid "Protocol Obfuscation"
 msgstr "Obscurecimento de Protocolo"
 
-#: src/muuli_wdr.cpp:2660
+#: src/muuli_wdr.cpp:2691
 msgid "Support Protocol Obfuscation"
 msgstr "Suportar Obscurecimento de Protocolo"
 
-#: src/muuli_wdr.cpp:2662
+#: src/muuli_wdr.cpp:2693
 msgid "This option enabled Protocol Obfuscation, and makes aMule accept obfuscated connections from other clients."
 msgstr "Esta opção habilita Obscurecimento de Protocolo, e faz o aMule aceitar conexões obscuras (criptografadas) de outros clientes."
 
-#: src/muuli_wdr.cpp:2664
+#: src/muuli_wdr.cpp:2695
 msgid "Use obfuscation for outgoing connections"
 msgstr "Usar obscurecimento para conexões externas"
 
-#: src/muuli_wdr.cpp:2666
+#: src/muuli_wdr.cpp:2697
 msgid "This option makes aMule use Protocol Obfuscation when connecting other clients/servers."
 msgstr "Esta opção faz o aMule usar Obscurecimento de Protocolo quando conectando outros clientes/servidores."
 
-#: src/muuli_wdr.cpp:2668
+#: src/muuli_wdr.cpp:2699
 msgid "Accept only obfuscated connections"
 msgstr "Aceitar somente conexões obscuras"
 
-#: src/muuli_wdr.cpp:2669
+#: src/muuli_wdr.cpp:2700
 msgid "This option makes aMule only accept obfuscated connections. You will have less sources, but all your traffic will be obfuscated"
 msgstr "Esta opção faz o aMule aceitar somente conexões obscurecidas. Você terá menos fontes, mas todo seu tráfego será obscurecido"
 
-#: src/muuli_wdr.cpp:2674
+#: src/muuli_wdr.cpp:2705
 msgid "Everybody"
 msgstr "Todos"
 
-#: src/muuli_wdr.cpp:2676
+#: src/muuli_wdr.cpp:2707
 msgid "No one"
 msgstr "Nenhum"
 
-#: src/muuli_wdr.cpp:2678
+#: src/muuli_wdr.cpp:2709
 msgid "Who can see my shared files:"
 msgstr "Quem pode ver meus arquivos compartilhados:"
 
-#: src/muuli_wdr.cpp:2679
+#: src/muuli_wdr.cpp:2710
 msgid "Select who can request to view a list of your shared files."
 msgstr "Selecione quem pode pedir a sua lista de compartilhamentos."
 
-#: src/muuli_wdr.cpp:2681
+#: src/muuli_wdr.cpp:2712
 msgid "IP-Filtering"
 msgstr "Filtro de IP"
 
-#: src/muuli_wdr.cpp:2688
+#: src/muuli_wdr.cpp:2719
 msgid "Filter clients"
 msgstr "Filtrar clientes"
 
-#: src/muuli_wdr.cpp:2690
+#: src/muuli_wdr.cpp:2721
 msgid "Enable filtering of the client IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "Habilitar filtragem de IPs de clientes definidos no arquivo ~/.aMule/ipfilter.dat."
 
-#: src/muuli_wdr.cpp:2692
+#: src/muuli_wdr.cpp:2723
 msgid "Filter servers"
 msgstr "Filtrar servidores"
 
-#: src/muuli_wdr.cpp:2694
+#: src/muuli_wdr.cpp:2725
 msgid "Enable filtering of the server IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "Habilitar filtragem de IPs de servidores definidos no arquivo ~/.aMule/ipfilter.dat."
 
-#: src/muuli_wdr.cpp:2698
+#: src/muuli_wdr.cpp:2729
 msgid "Reload List"
 msgstr "Recarregar lista"
 
-#: src/muuli_wdr.cpp:2699
+#: src/muuli_wdr.cpp:2730
 msgid "Reload the list of IPs to filter from the file ~/.aMule/ipfilter.dat"
 msgstr "Recarregar lista de IPs a filtrar do arquivo ~/.aMule/ipfilter.dat"
 
-#: src/muuli_wdr.cpp:2705
+#: src/muuli_wdr.cpp:2736
 msgid "URL:"
 msgstr "URL:"
 
-#: src/muuli_wdr.cpp:2709 src/muuli_wdr.cpp:2902
+#: src/muuli_wdr.cpp:2740 src/muuli_wdr.cpp:2933
 msgid "Update now"
 msgstr "Atualizar agora"
 
-#: src/muuli_wdr.cpp:2712
+#: src/muuli_wdr.cpp:2743
 msgid "Auto-update ipfilter at startup"
 msgstr "Auto-atualizar ipfilter ao iniciar"
 
-#: src/muuli_wdr.cpp:2716
+#: src/muuli_wdr.cpp:2747
 msgid "Filtering Level:"
 msgstr "Níveis de Filtro:"
 
-#: src/muuli_wdr.cpp:2722
+#: src/muuli_wdr.cpp:2753
 msgid "Always filter LAN IPs"
 msgstr "Sempre filtrar IPs de redes LAN"
 
-#: src/muuli_wdr.cpp:2725
+#: src/muuli_wdr.cpp:2756
 msgid "Paranoid handling of non-matching IPs"
 msgstr "Manuseio paranoico de IPs não-casados"
 
-#: src/muuli_wdr.cpp:2727
+#: src/muuli_wdr.cpp:2758
 msgid "Rejects a packet when its source IP differs from the IP the client claims (an anti-spoofing check). Disable only if it causes connection problems."
 msgstr "Rejeita um pacote quando o IP de sua fonte difere do IP que o cliente clama (uma checagem anti-spoofing). Desabilite apenas se causar problemas de conexão."
 
-#: src/muuli_wdr.cpp:2729
+#: src/muuli_wdr.cpp:2760
 msgid "Use system-wide ipfilter.dat if available"
 msgstr "Utilizar ipfilter.dat global se disponível"
 
-#: src/muuli_wdr.cpp:2730
+#: src/muuli_wdr.cpp:2761
 msgid "If there's no local ipfilter.dat found, allow usage of a system-wide ipfilter file."
 msgstr "Se nenhum ipfilter.dat local for encontrado, permita o uso de um arquivo global."
 
-#: src/muuli_wdr.cpp:2747
+#: src/muuli_wdr.cpp:2778
 msgid "Enable Online-Signature"
 msgstr "Ativar Assinatura Online"
 
-#: src/muuli_wdr.cpp:2749
+#: src/muuli_wdr.cpp:2780
 msgid "Enables the writing of the OS file, which can be used by external apps to create signatures and the like."
 msgstr "Habilita a gravação do arquivo, que pode ser usado por programas externos."
 
-#: src/muuli_wdr.cpp:2753
+#: src/muuli_wdr.cpp:2784
 msgid "Update Frequency (Secs):"
 msgstr "Frequência de atualização (Seg):"
 
-#: src/muuli_wdr.cpp:2756
+#: src/muuli_wdr.cpp:2787
 msgid "Change the frequency (in seconds) of Online Signature updates."
 msgstr "Alterar frequência (em segundos) da atualização da Assinatura."
 
-#: src/muuli_wdr.cpp:2764
+#: src/muuli_wdr.cpp:2795
 msgid "Save online signature file in: "
 msgstr "Salvar arquivos de assinatura online em: "
 
-#: src/muuli_wdr.cpp:2770
+#: src/muuli_wdr.cpp:2801
 msgid "Click here to select the directory containing the the Online Signature files."
 msgstr "Clique aqui para definir pasta contendo os arquivos da Assinatura Online."
 
-#: src/muuli_wdr.cpp:2803
+#: src/muuli_wdr.cpp:2834
 msgid "Show country flags for clients"
 msgstr "Mostrar bandeiras nacionais para clientes"
 
-#: src/muuli_wdr.cpp:2804
+#: src/muuli_wdr.cpp:2835
 msgid "Render the country flag column in the transfers, queue and search views. Requires a valid MMDB GeoIP database (see below)."
 msgstr "Renderiza a coluna da bandeira do país nas transferências, filas e vistas de procura. Requer um banco de dados MMDB GeoIP válido (veja abaixo)."
 
-#: src/muuli_wdr.cpp:2809
+#: src/muuli_wdr.cpp:2840
 msgid "Database"
 msgstr "Banco de Dados"
 
-#: src/muuli_wdr.cpp:2825
+#: src/muuli_wdr.cpp:2856
 msgid "Source:"
 msgstr "Fonte:"
 
-#: src/muuli_wdr.cpp:2828
+#: src/muuli_wdr.cpp:2859
 msgid "DB-IP (free, no account)"
 msgstr "DB-IP (grátis, sem conta)"
 
-#: src/muuli_wdr.cpp:2829
+#: src/muuli_wdr.cpp:2860
 msgid "MaxMind GeoLite2 (free, account required)"
 msgstr "MaxMind GeoLite2 (grátis, requer conta)"
 
-#: src/muuli_wdr.cpp:2830
+#: src/muuli_wdr.cpp:2861
 msgid "Custom URL"
 msgstr "URL Customizada"
 
-#: src/muuli_wdr.cpp:2833
+#: src/muuli_wdr.cpp:2864
 msgid "Choose which provider supplies the GeoIP MMDB database. DB-IP is the default - no account required. MaxMind requires a free account + license key. Use Custom URL to point at any other MMDB host (e.g. a local mirror)."
 msgstr "Escolha qual provedor fornece o banco de dados MMDB GeoIP. DB-IP é o padrão - não requer conta. MaxMind requer uma conta grátis + chave de licensa. Use uma URL Customizada para apontar para qualquer outro anfitrião MMDB (e.g. um espelho local)."
 
-#: src/muuli_wdr.cpp:2850
+#: src/muuli_wdr.cpp:2881
 msgid ""
 "No configuration required.\n"
 "\n"
@@ -4833,11 +4861,11 @@ msgstr ""
 "Dados de IP-to-Country por DB-IP.com - https://db-ip.com\n"
 "Licensa: Creative Commons BY 4.0 - https://creativecommons.org/licenses/by/4.0/"
 
-#: src/muuli_wdr.cpp:2863
+#: src/muuli_wdr.cpp:2894
 msgid "License key:"
 msgstr "Chave de Licensa:"
 
-#: src/muuli_wdr.cpp:2869
+#: src/muuli_wdr.cpp:2900
 msgid ""
 "Sign up for a free MaxMind account, then generate a License Key:\n"
 "https://www.maxmind.com/en/geolite2/signup\n"
@@ -4853,11 +4881,11 @@ msgstr ""
 "Licensa: MaxMind GeoLite2 EULA - https://www.maxmind.com/en/geolite2/eula\n"
 "Requer atribuição e registro de conta; renove no mínimo a cada 30 dias."
 
-#: src/muuli_wdr.cpp:2884
+#: src/muuli_wdr.cpp:2915
 msgid "Download URL:"
 msgstr "URL de Download:"
 
-#: src/muuli_wdr.cpp:2890
+#: src/muuli_wdr.cpp:2921
 msgid ""
 "Must point to an .mmdb file or a .gz / .tar.gz containing one.\n"
 "URL may include credentials (https://user:pass@host/...).\n"
@@ -4867,211 +4895,211 @@ msgstr ""
 "A URL pode incluir credenciais (https://user:pass@host/...).\n"
 "License e termos de atribuição são realizados pela URL upstream - você é responsável."
 
-#: src/muuli_wdr.cpp:2903
+#: src/muuli_wdr.cpp:2934
 msgid "Download the GeoIP database from the selected source."
 msgstr "Baixe o banco de dados GeoIP da fonte selecionada."
 
-#: src/muuli_wdr.cpp:2905
+#: src/muuli_wdr.cpp:2936
 msgid "Auto-update on startup"
 msgstr "Auto-atualizar ao iniciar"
 
-#: src/muuli_wdr.cpp:2906
+#: src/muuli_wdr.cpp:2937
 msgid "Re-download the GeoIP database from the selected source every time aMule starts."
 msgstr "Baixe novamente o banco de dados GeoIP da fonte selecionada toda vez que o aMule iniciar."
 
-#: src/muuli_wdr.cpp:2929
+#: src/muuli_wdr.cpp:2960
 msgid "Filter incoming messages (except current chat):"
 msgstr "Filtrar mensagens (Exceto chat atual):"
 
-#: src/muuli_wdr.cpp:2931
+#: src/muuli_wdr.cpp:2962
 msgid "Filter all messages"
 msgstr "Filtrar todas as mensagens"
 
-#: src/muuli_wdr.cpp:2933
+#: src/muuli_wdr.cpp:2964
 msgid "Filter messages from people not on your friend list"
 msgstr "Filtrar mensagens de pessoas que não estão em sua lista"
 
-#: src/muuli_wdr.cpp:2935
+#: src/muuli_wdr.cpp:2966
 msgid "Filter messages from unknown clients"
 msgstr "Filtrar mensagens de clientes desconhecidos"
 
-#: src/muuli_wdr.cpp:2937
+#: src/muuli_wdr.cpp:2968
 msgid "Filter messages containing (use ',' as separator):"
 msgstr "Filtrar mensagens contendo (use ',' como separador):"
 
-#: src/muuli_wdr.cpp:2940 src/muuli_wdr.cpp:2951
+#: src/muuli_wdr.cpp:2971 src/muuli_wdr.cpp:2982
 msgid "add here the words amule should filter and block messages including it"
 msgstr "adicione aqui as palavras que o amule deve filtrar e bloquear nas mensagens"
 
-#: src/muuli_wdr.cpp:2942
+#: src/muuli_wdr.cpp:2973
 msgid "Show received messages in the log"
 msgstr "Mostrar mensagens recebidas no log"
 
-#: src/muuli_wdr.cpp:2945
+#: src/muuli_wdr.cpp:2976
 msgid "Comments"
 msgstr "Comentários"
 
-#: src/muuli_wdr.cpp:2948
+#: src/muuli_wdr.cpp:2979
 msgid "Filter comments containing (use ',' as separator):"
 msgstr "Filtrar comentários contendo (use '.' como separador):"
 
-#: src/muuli_wdr.cpp:2973
+#: src/muuli_wdr.cpp:3004
 msgid "Enable Proxy"
 msgstr "Ativar proxy"
 
-#: src/muuli_wdr.cpp:2974
+#: src/muuli_wdr.cpp:3005
 msgid "Enable/disable proxy support"
 msgstr "Ativa/desativa suporte a proxy"
 
-#: src/muuli_wdr.cpp:2977
+#: src/muuli_wdr.cpp:3008
 msgid "Proxy type:"
 msgstr "Tipo de proxy:"
 
-#: src/muuli_wdr.cpp:2988
+#: src/muuli_wdr.cpp:3019
 msgid "Proxy host:"
 msgstr "Host do Proxy:"
 
-#: src/muuli_wdr.cpp:2991
+#: src/muuli_wdr.cpp:3022
 msgid "The proxy host name"
 msgstr "Nome do Host do proxy"
 
-#: src/muuli_wdr.cpp:2993
+#: src/muuli_wdr.cpp:3024
 msgid "Proxy port:"
 msgstr "Porta do Proxy:"
 
-#: src/muuli_wdr.cpp:2996
+#: src/muuli_wdr.cpp:3027
 msgid "The proxy port"
 msgstr "Porta do Proxy"
 
-#: src/muuli_wdr.cpp:2998
+#: src/muuli_wdr.cpp:3029
 msgid "Enable authentication"
 msgstr "Ativar autenticação"
 
-#: src/muuli_wdr.cpp:2999
+#: src/muuli_wdr.cpp:3030
 msgid "Enable/disable username/password authentication"
 msgstr "Ativa/Desativa autenticação por usuário/senha"
 
-#: src/muuli_wdr.cpp:3002
+#: src/muuli_wdr.cpp:3033
 msgid "Username: "
 msgstr "Nome do usuário: "
 
-#: src/muuli_wdr.cpp:3005
+#: src/muuli_wdr.cpp:3036
 msgid "The username to use to connect to the proxy"
 msgstr "Nome do usuário para conectar ao proxy"
 
-#: src/muuli_wdr.cpp:3007
+#: src/muuli_wdr.cpp:3038
 msgid "Password:"
 msgstr "Senha:"
 
-#: src/muuli_wdr.cpp:3010
+#: src/muuli_wdr.cpp:3041
 msgid "The password to use to connect to the proxy"
 msgstr "Senha utilizada para conectar ao proxy"
 
-#: src/muuli_wdr.cpp:3029
+#: src/muuli_wdr.cpp:3060
 msgid "Connect to:"
 msgstr "Conectar em:"
 
-#: src/muuli_wdr.cpp:3038
+#: src/muuli_wdr.cpp:3069
 msgid "Login to remote amule"
 msgstr "Fazer login em amule remoto"
 
-#: src/muuli_wdr.cpp:3043
+#: src/muuli_wdr.cpp:3074
 msgid "User name"
 msgstr "Usuário"
 
-#: src/muuli_wdr.cpp:3054
+#: src/muuli_wdr.cpp:3085
 msgid "Remember those settings"
 msgstr "Lembrar essas definições"
 
-#: src/muuli_wdr.cpp:3057
+#: src/muuli_wdr.cpp:3088
 msgid "Force ZLIB compression"
 msgstr "Força compressão ZLIB"
 
-#: src/muuli_wdr.cpp:3081
+#: src/muuli_wdr.cpp:3112
 msgid "Enable Verbose Debug-Logging."
 msgstr "Ativar log de debug detalhado."
 
-#: src/muuli_wdr.cpp:3083
+#: src/muuli_wdr.cpp:3114
 msgid "Only to Logfile"
 msgstr "Apenas para o arquivo de log"
 
-#: src/muuli_wdr.cpp:3085
+#: src/muuli_wdr.cpp:3116
 msgid "Message Categories:"
 msgstr "Categorias de Mensagens:"
 
-#: src/muuli_wdr.cpp:3109 src/PartFileConvertDlg.cpp:160
+#: src/muuli_wdr.cpp:3140 src/PartFileConvertDlg.cpp:160
 msgid "Waiting..."
 msgstr "Aguardando..."
 
-#: src/muuli_wdr.cpp:3129
+#: src/muuli_wdr.cpp:3160
 msgid "Add imports"
 msgstr "Adicionar importadas"
 
-#: src/muuli_wdr.cpp:3132
+#: src/muuli_wdr.cpp:3163
 msgid "Retry selected"
 msgstr "Tentar novamente selecionada"
 
-#: src/muuli_wdr.cpp:3134
+#: src/muuli_wdr.cpp:3165
 msgid "Remove selected"
 msgstr "Remover selecionada"
 
-#: src/muuli_wdr.cpp:3197
+#: src/muuli_wdr.cpp:3228
 msgid "Event Types"
 msgstr "Tipos de Eventos"
 
-#: src/muuli_wdr.cpp:3216
+#: src/muuli_wdr.cpp:3247
 msgid "Statistics and queued clients for selected file(s) : Session / All time"
 msgstr "Estatísticas e filas de clientes para arquivo(s) selecionado(s) : Sessão / Sempre"
 
-#: src/muuli_wdr.cpp:3240
+#: src/muuli_wdr.cpp:3271
 msgid "Active Uploads"
 msgstr "Uploads Ativos"
 
-#: src/muuli_wdr.cpp:3254
+#: src/muuli_wdr.cpp:3285
 msgid "Percent of total files"
 msgstr "Porcentagem de total de arquivos"
 
-#: src/muuli_wdr.cpp:3306
+#: src/muuli_wdr.cpp:3337
 msgid "Show Clients for"
 msgstr "Exibir Clientes para"
 
-#: src/muuli_wdr.cpp:3308
+#: src/muuli_wdr.cpp:3339
 msgid "All files"
 msgstr "Todos os arquivos"
 
-#: src/muuli_wdr.cpp:3311
+#: src/muuli_wdr.cpp:3342
 msgid "Selected files"
 msgstr "Arquivos selecionados"
 
-#: src/muuli_wdr.cpp:3314
+#: src/muuli_wdr.cpp:3345
 msgid "Active uploads only"
 msgstr "Somente uploads ativos"
 
-#: src/muuli_wdr.cpp:3321
+#: src/muuli_wdr.cpp:3352
 msgid "Reload:"
 msgstr "Recarregar:"
 
-#: src/muuli_wdr.cpp:3325
+#: src/muuli_wdr.cpp:3356
 msgid "Reload your shared files"
 msgstr "Atualizar lista de compartilhados"
 
-#: src/muuli_wdr.cpp:3388
+#: src/muuli_wdr.cpp:3419
 msgid "Send"
 msgstr "Enviar"
 
-#: src/muuli_wdr.cpp:3389
+#: src/muuli_wdr.cpp:3420
 msgid "Sends the specified message."
 msgstr "Enviar a mensagem especificada."
 
-#: src/muuli_wdr.cpp:3393
+#: src/muuli_wdr.cpp:3424
 msgid "Close this chat-session."
 msgstr "Encerrar sessão de Chat."
 
-#: src/muuli_wdr.cpp:3416
+#: src/muuli_wdr.cpp:3447
 msgid "Connect to any server and/or Kad"
 msgstr "Conectar a qualquer servidor e/ou Kad"
 
-#: src/muuli_wdr.cpp:3422 src/SharedFilesCtrl.cpp:142 src/Statistics.cpp:941
+#: src/muuli_wdr.cpp:3453 src/SharedFilesCtrl.cpp:142 src/Statistics.cpp:941
 msgid "Shared Files"
 msgstr "Arquivos Compartilhados"
 
@@ -5431,248 +5459,248 @@ msgstr "Baixado"
 msgid "ERROR: Failed to open partfile '%s'"
 msgstr "ERRO: Falha ao abrir partfile '%s'"
 
-#: src/Preferences.cpp:674
+#: src/Preferences.cpp:701
 msgid "System default"
 msgstr "Padrão do sistema"
 
-#: src/Preferences.cpp:675
+#: src/Preferences.cpp:702
 msgid "Albanian"
 msgstr "Albanês"
 
-#: src/Preferences.cpp:676
+#: src/Preferences.cpp:703
 msgid "Arabic"
 msgstr "Árabe"
 
-#: src/Preferences.cpp:677
+#: src/Preferences.cpp:704
 msgid "Asturian"
 msgstr "Asturiano"
 
-#: src/Preferences.cpp:678
+#: src/Preferences.cpp:705
 msgid "Basque"
 msgstr "Basco"
 
-#: src/Preferences.cpp:679
+#: src/Preferences.cpp:706
 msgid "Bulgarian"
 msgstr "Búlgaro"
 
-#: src/Preferences.cpp:680
+#: src/Preferences.cpp:707
 msgid "Catalan"
 msgstr "Catalão"
 
-#: src/Preferences.cpp:681
+#: src/Preferences.cpp:708
 msgid "Chinese (Simplified)"
 msgstr "Chinês (Simplificado)"
 
-#: src/Preferences.cpp:682
+#: src/Preferences.cpp:709
 msgid "Chinese (Traditional)"
 msgstr "Chinês (Tradicional)"
 
-#: src/Preferences.cpp:683
+#: src/Preferences.cpp:710
 msgid "Croatian"
 msgstr "Croácia"
 
-#: src/Preferences.cpp:684
+#: src/Preferences.cpp:711
 msgid "Czech"
 msgstr "Tcheco"
 
-#: src/Preferences.cpp:685
+#: src/Preferences.cpp:712
 msgid "Danish"
 msgstr "Dinamarquês"
 
-#: src/Preferences.cpp:686
+#: src/Preferences.cpp:713
 msgid "Dutch"
 msgstr "Holandês"
 
-#: src/Preferences.cpp:687
+#: src/Preferences.cpp:714
 msgid "English (U.K.)"
 msgstr "Inglês (UK)"
 
-#: src/Preferences.cpp:688
+#: src/Preferences.cpp:715
 msgid "English (U.S.)"
 msgstr "Inglês (U.S.)"
 
-#: src/Preferences.cpp:689
+#: src/Preferences.cpp:716
 msgid "Estonian"
 msgstr "Estônia"
 
-#: src/Preferences.cpp:690
+#: src/Preferences.cpp:717
 msgid "Finnish"
 msgstr "Finlandês"
 
-#: src/Preferences.cpp:691
+#: src/Preferences.cpp:718
 msgid "French"
 msgstr "Francês"
 
-#: src/Preferences.cpp:692
+#: src/Preferences.cpp:719
 msgid "Galician"
 msgstr "Galego"
 
-#: src/Preferences.cpp:693
+#: src/Preferences.cpp:720
 msgid "German"
 msgstr "Alemão"
 
-#: src/Preferences.cpp:694
+#: src/Preferences.cpp:721
 msgid "Greek"
 msgstr "Grego"
 
-#: src/Preferences.cpp:695
+#: src/Preferences.cpp:722
 msgid "Hebrew"
 msgstr "Hebreu"
 
-#: src/Preferences.cpp:696
+#: src/Preferences.cpp:723
 msgid "Hungarian"
 msgstr "Hungria"
 
-#: src/Preferences.cpp:697
+#: src/Preferences.cpp:724
 msgid "Italian"
 msgstr "Italiano"
 
-#: src/Preferences.cpp:698
+#: src/Preferences.cpp:725
 msgid "Japanese"
 msgstr "Japonês"
 
-#: src/Preferences.cpp:699
+#: src/Preferences.cpp:726
 msgid "Korean"
 msgstr "Coreano"
 
-#: src/Preferences.cpp:700
+#: src/Preferences.cpp:727
 msgid "Latvian"
 msgstr "Letão"
 
-#: src/Preferences.cpp:701
+#: src/Preferences.cpp:728
 msgid "Lithuanian"
 msgstr "Lituânia"
 
-#: src/Preferences.cpp:702
+#: src/Preferences.cpp:729
 msgid "Norwegian (Nynorsk)"
 msgstr "Noruega (Nynorsk)"
 
-#: src/Preferences.cpp:703
+#: src/Preferences.cpp:730
 msgid "Polish"
 msgstr "Polonês"
 
-#: src/Preferences.cpp:704
+#: src/Preferences.cpp:731
 msgid "Portuguese"
 msgstr "Português (Portugal)"
 
-#: src/Preferences.cpp:705
+#: src/Preferences.cpp:732
 msgid "Portuguese (Brazilian)"
 msgstr "Português (Brasil)"
 
-#: src/Preferences.cpp:706
+#: src/Preferences.cpp:733
 msgid "Romanian"
 msgstr "Albanês"
 
-#: src/Preferences.cpp:707
+#: src/Preferences.cpp:734
 msgid "Russian"
 msgstr "Russo"
 
-#: src/Preferences.cpp:708
+#: src/Preferences.cpp:735
 msgid "Slovenian"
 msgstr "Esloveno"
 
-#: src/Preferences.cpp:709
+#: src/Preferences.cpp:736
 msgid "Spanish"
 msgstr "Espanhol"
 
-#: src/Preferences.cpp:710
+#: src/Preferences.cpp:737
 msgid "Swedish"
 msgstr "Suécia"
 
-#: src/Preferences.cpp:711
+#: src/Preferences.cpp:738
 msgid "Turkish"
 msgstr "Turquia"
 
-#: src/Preferences.cpp:712
+#: src/Preferences.cpp:739
 msgid "Ukrainian"
 msgstr "Ucraniano"
 
-#: src/Preferences.cpp:815
+#: src/Preferences.cpp:842
 msgid "Change Language"
 msgstr "Mudar Idioma"
 
-#: src/Preferences.cpp:879
+#: src/Preferences.cpp:906
 msgid "There are no translations installed for aMule"
 msgstr "Não há traduções instaladas no aMule"
 
-#: src/Preferences.cpp:880
+#: src/Preferences.cpp:907
 msgid "No languages available"
 msgstr "Nenhum idioma disponível"
 
-#: src/Preferences.cpp:1011
+#: src/Preferences.cpp:1038
 msgid "no options available"
 msgstr "nenhuma opção disponível"
 
-#: src/Preferences.cpp:2182
+#: src/Preferences.cpp:2227
 msgid "Invalid category found, skipping"
 msgstr "Categoria inválida encontrada, pulando"
 
-#: src/Preferences.cpp:2351
+#: src/Preferences.cpp:2396
 msgid "TCP port can't be higher than 65532 due to server UDP socket being TCP+3"
 msgstr "Porta TCP não pode ser maior do que 65532, pois a UDP escuta em TCP+3"
 
-#: src/Preferences.cpp:2352
+#: src/Preferences.cpp:2397
 #, c-format
 msgid "Default port will be used (%d)"
 msgstr "Porta padrão será utilizada (%d)"
 
-#: src/PrefsUnifiedDlg.cpp:298 src/Statistics.cpp:866
+#: src/PrefsUnifiedDlg.cpp:300 src/Statistics.cpp:866
 msgid "Connection"
 msgstr "Conexão"
 
-#: src/PrefsUnifiedDlg.cpp:299 src/SearchListCtrl.cpp:117
+#: src/PrefsUnifiedDlg.cpp:301 src/SearchListCtrl.cpp:117
 msgid "Directories"
 msgstr "Diretórios"
 
-#: src/PrefsUnifiedDlg.cpp:300 src/Statistics.cpp:917
+#: src/PrefsUnifiedDlg.cpp:302 src/Statistics.cpp:917
 msgid "Servers"
 msgstr "Servidores"
 
-#: src/PrefsUnifiedDlg.cpp:301 src/ServerListCtrl.cpp:96
+#: src/PrefsUnifiedDlg.cpp:303 src/ServerListCtrl.cpp:96
 msgid "Files"
 msgstr "Arquivos"
 
-#: src/PrefsUnifiedDlg.cpp:302
+#: src/PrefsUnifiedDlg.cpp:304
 msgid "Security"
 msgstr "Segurança"
 
-#: src/PrefsUnifiedDlg.cpp:303
+#: src/PrefsUnifiedDlg.cpp:305
 msgid "Interface"
 msgstr "Interface"
 
-#: src/PrefsUnifiedDlg.cpp:310
+#: src/PrefsUnifiedDlg.cpp:312
 msgid "IP2Country"
 msgstr "IP2Country"
 
-#: src/PrefsUnifiedDlg.cpp:313
+#: src/PrefsUnifiedDlg.cpp:315
 msgid "Proxy"
 msgstr "Proxy"
 
-#: src/PrefsUnifiedDlg.cpp:314
+#: src/PrefsUnifiedDlg.cpp:316
 msgid "Filters"
 msgstr "Filtros"
 
-#: src/PrefsUnifiedDlg.cpp:315
+#: src/PrefsUnifiedDlg.cpp:317
 msgid "Remote Controls"
 msgstr "Controles remotos"
 
-#: src/PrefsUnifiedDlg.cpp:316
+#: src/PrefsUnifiedDlg.cpp:318
 msgid "Online Signature"
 msgstr "Assinatura Online"
 
-#: src/PrefsUnifiedDlg.cpp:317
+#: src/PrefsUnifiedDlg.cpp:319
 msgid "Advanced"
 msgstr "Avançado"
 
-#: src/PrefsUnifiedDlg.cpp:318
+#: src/PrefsUnifiedDlg.cpp:320
 msgid "Events"
 msgstr "Eventos"
 
-#: src/PrefsUnifiedDlg.cpp:321
+#: src/PrefsUnifiedDlg.cpp:323
 msgid "Debugging"
 msgstr "Debugando"
 
-#: src/PrefsUnifiedDlg.cpp:451
+#: src/PrefsUnifiedDlg.cpp:453
 msgid ""
 "The following variables will be substituted:\n"
 "    %PARTFILE - full path to the file\n"
@@ -5682,15 +5710,15 @@ msgstr ""
 "    %PARTFILE - caminhos completo para o arquivo\n"
 "    %PARTNAME - somente nome do arquivo"
 
-#: src/PrefsUnifiedDlg.cpp:472
+#: src/PrefsUnifiedDlg.cpp:474
 msgid "Tray icon support requires libayatana-appindicator3 at compile time."
 msgstr "O suporte para ícone da bandeja do sistema requer libayatana-appindicator3 em tempo de compilação."
 
-#: src/PrefsUnifiedDlg.cpp:488
+#: src/PrefsUnifiedDlg.cpp:490
 msgid "Not available on Wayland: the protocol does not report when a window is minimized, so this option cannot intercept the system minimize button. Workaround: launch aMule with `GDK_BACKEND=x11` to use XWayland instead."
 msgstr "Não disponível no Wayland: o protocolo não avisa quando uma janela foi minimizada, portanto esta opção não pode interceptar o botão de minimização do sistema. Alternativa: lance o aMule com `GDK_BACKEND=x11` para usar XWayland."
 
-#: src/PrefsUnifiedDlg.cpp:534
+#: src/PrefsUnifiedDlg.cpp:536
 msgid ""
 "Do not change these setting unless you know\n"
 "what you are doing, otherwise you can easily\n"
@@ -5706,26 +5734,35 @@ msgstr ""
 "O aMule funciona corretamente sem qualquer tipo de\n"
 "alteração nessas opções."
 
-#: src/PrefsUnifiedDlg.cpp:645
+#: src/PrefsUnifiedDlg.cpp:647
 #, c-format
 msgid "Failed to connect Cfg to widget with the ID %d and key %s"
 msgstr "Falha ao conectar Cfg para Widget com o ID %d e senha %s"
 
-#: src/PrefsUnifiedDlg.cpp:693
+#: src/PrefsUnifiedDlg.cpp:695
 #, c-format
 msgid "Failed to transfer data from Cfg to Widget with the ID %d and key %s"
 msgstr "Falha ao transferir dado do Cfg para Widget com o ID %d e senha %s"
 
-#: src/PrefsUnifiedDlg.cpp:799
+#: src/PrefsUnifiedDlg.cpp:801
 msgid "The type of proxy you are connecting to"
 msgstr "Tipo de proxy ao qual você está conectado"
 
-#: src/PrefsUnifiedDlg.cpp:1003
+#: src/PrefsUnifiedDlg.cpp:1020
 #, c-format
 msgid "Failed to transfer data from Widget to Cfg with the ID %d and key %s"
 msgstr "Falha ao transferir dado do Widget para Cfg com o ID %d e senha %s"
 
 #: src/PrefsUnifiedDlg.cpp:1103
+#, fuzzy
+msgid "No password set."
+msgstr "Senha de administração"
+
+#: src/PrefsUnifiedDlg.cpp:1132
+msgid "Guest access needs a password. Type one in the guest password field, or untick Enable guest access."
+msgstr ""
+
+#: src/PrefsUnifiedDlg.cpp:1144
 msgid ""
 "aMule must be restarted to enable these changes:\n"
 "\n"
@@ -5733,39 +5770,39 @@ msgstr ""
 "O aMule deve ser reiniciado para habilitar estas mudanças:\n"
 "\n"
 
-#: src/PrefsUnifiedDlg.cpp:1110
+#: src/PrefsUnifiedDlg.cpp:1151
 msgid "- TCP port changed.\n"
 msgstr "-Porta TCP alterada.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1115
+#: src/PrefsUnifiedDlg.cpp:1156
 msgid "- UDP port changed.\n"
 msgstr "-Porta UDP alterada.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1120
+#: src/PrefsUnifiedDlg.cpp:1161
 msgid "- Network interface binding changed.\n"
 msgstr "- Interface de conexão de rede modificada.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1125
+#: src/PrefsUnifiedDlg.cpp:1166
 msgid "- External connect port changed.\n"
 msgstr "- Porta de conexão externa modificada.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1129
+#: src/PrefsUnifiedDlg.cpp:1170
 msgid "- External connect acceptance changed.\n"
 msgstr "- Aceitação da conexão externa modificada.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1133
+#: src/PrefsUnifiedDlg.cpp:1174
 msgid "- External connect interface changed.\n"
 msgstr "- Interface de conexão externa modificada.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1137
+#: src/PrefsUnifiedDlg.cpp:1178
 msgid "- Protocol obfuscation support changed.\n"
 msgstr "- Suporte de protocolo de ofuscamento mudou.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1151
+#: src/PrefsUnifiedDlg.cpp:1193
 msgid "- amuleapi settings changed.\n"
 msgstr "- A configuração do amuleapi mudou.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1160
+#: src/PrefsUnifiedDlg.cpp:1202
 msgid ""
 "Your Auto-update server list is empty.\n"
 "'Auto-update server list at startup' will be disabled."
@@ -5773,7 +5810,7 @@ msgstr ""
 "Sua lista de Auto-atualização de servidor está vazia.\n"
 "'Auto-atualização de servidor na iniciação' será desativada."
 
-#: src/PrefsUnifiedDlg.cpp:1171
+#: src/PrefsUnifiedDlg.cpp:1213
 msgid ""
 "You have enabled external connections but have not specified a password.\n"
 "External connections cannot be enabled unless a valid password is specified."
@@ -5781,27 +5818,32 @@ msgstr ""
 "Você ativou as conexões externas mas não definiu uma senha.\n"
 "Conexões Externas só podem ser feitas se for especificada uma senha válida."
 
-#: src/PrefsUnifiedDlg.cpp:1202
+#: src/PrefsUnifiedDlg.cpp:1246
+#, c-format
+msgid "The amuleapi password could not be saved: %s"
+msgstr ""
+
+#: src/PrefsUnifiedDlg.cpp:1276
 msgid "- Language changed.\n"
 msgstr "-Idioma alterado.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1207
+#: src/PrefsUnifiedDlg.cpp:1281
 msgid "- Temp folder changed.\n"
 msgstr "-Diretório temporário alterado.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1212
+#: src/PrefsUnifiedDlg.cpp:1286
 msgid "- ED2K network enabled.\n"
 msgstr "- Rede ED2K conectada.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1245
+#: src/PrefsUnifiedDlg.cpp:1319
 msgid "The shared-file exclusion pattern is not a valid regular expression. The filter has been left disabled."
 msgstr "Este padrão de exclusão de arquivos compartilhados não é uma expressão regular válida. O filtro ficou desabilitado."
 
-#: src/PrefsUnifiedDlg.cpp:1247 src/PrefsUnifiedDlg.cpp:1841
+#: src/PrefsUnifiedDlg.cpp:1321 src/PrefsUnifiedDlg.cpp:1921
 msgid "Invalid regular expression"
 msgstr "Expressão regular inválida"
 
-#: src/PrefsUnifiedDlg.cpp:1324
+#: src/PrefsUnifiedDlg.cpp:1398
 msgid ""
 "Both eD2k and Kad network are disabled.\n"
 "You won't be able to connect until you enable at least one of them."
@@ -5809,7 +5851,7 @@ msgstr ""
 "Ambas rede eD2k e Kad estão desativadas.\n"
 "Você não será capaz de conectar senão habilitar pelo menos um deles."
 
-#: src/PrefsUnifiedDlg.cpp:1329
+#: src/PrefsUnifiedDlg.cpp:1403
 msgid ""
 "Kad will not start if your UDP port is disabled.\n"
 "Enable UDP port or disable Kad."
@@ -5817,7 +5859,7 @@ msgstr ""
 "Kad não iniciará se sua porta UDP estiver desabilitada.\n"
 "Habilite a porta UDP ou desative a rede Kad."
 
-#: src/PrefsUnifiedDlg.cpp:1385
+#: src/PrefsUnifiedDlg.cpp:1459
 msgid ""
 "\n"
 "You MUST restart aMule now.\n"
@@ -5827,68 +5869,68 @@ msgstr ""
 "Você DEVE reiniciar o aMule agora.\n"
 "Se você não reiniciá-lo agora, não reclame se algo de ruim acontecer.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1450
+#: src/PrefsUnifiedDlg.cpp:1524
 msgid "Could not register aMule for autostart at login. The autostart store may be read-only."
 msgstr "Não foi possível registrar o aMule para início automático no login. A lista de autostart pode estar como apenas leitura."
 
-#: src/PrefsUnifiedDlg.cpp:1452
+#: src/PrefsUnifiedDlg.cpp:1526
 msgid "Could not remove the autostart-at-login entry."
 msgstr "Não foi possível remover a entrada de início automático no login."
 
-#: src/PrefsUnifiedDlg.cpp:1453
+#: src/PrefsUnifiedDlg.cpp:1527
 msgid "Autostart"
 msgstr "Início automático"
 
-#: src/PrefsUnifiedDlg.cpp:1468
+#: src/PrefsUnifiedDlg.cpp:1542
 msgid "Register file type"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1468
+#: src/PrefsUnifiedDlg.cpp:1542
 msgid "Register URL handler"
 msgstr "Registrar manipulador de URL"
 
-#: src/PrefsUnifiedDlg.cpp:1476
+#: src/PrefsUnifiedDlg.cpp:1550
 #, c-format
 msgid "aMule only handles eD2k-compatible magnets. If you replace the current magnet handler (%s), BitTorrent magnet links will stop working - aMule cannot download BitTorrent content. Continue?"
 msgstr "O aMule lida apenas com links magnet compatíveis com eD2k. Se você trocar o manipulador atual (%s), links magnet deBitTorrent irão parar de funcionar - o aMule não pode baixar conteúdo BitTorrent. Continuar?"
 
-#: src/PrefsUnifiedDlg.cpp:1481
+#: src/PrefsUnifiedDlg.cpp:1555
 #, fuzzy, c-format
 msgid "Another application currently opens .emulecollection files (%s). Replace it with aMule?"
 msgstr "Atualmente um outro aplicativo é o manipulador padrão para estes links (%s). Troco ele pelo aMule?"
 
-#: src/PrefsUnifiedDlg.cpp:1486
+#: src/PrefsUnifiedDlg.cpp:1560
 #, c-format
 msgid "Another application is currently the default handler for these links (%s). Replace it with aMule?"
 msgstr "Atualmente um outro aplicativo é o manipulador padrão para estes links (%s). Troco ele pelo aMule?"
 
-#: src/PrefsUnifiedDlg.cpp:1511
+#: src/PrefsUnifiedDlg.cpp:1585
 #, fuzzy
 msgid "Could not register aMule for .emulecollection files. The registration store may be read-only."
 msgstr "Não foi possível registrar o aMule como manipulador de URL. O armazenamento deve estar como \"apenas leitura\"."
 
-#: src/PrefsUnifiedDlg.cpp:1513
+#: src/PrefsUnifiedDlg.cpp:1587
 #, fuzzy
 msgid "Could not remove the file type registration."
 msgstr "Não foi possível remover o registro de manipulação de URL."
 
-#: src/PrefsUnifiedDlg.cpp:1515
+#: src/PrefsUnifiedDlg.cpp:1589
 msgid "Could not register aMule as the URL handler. The registration store may be read-only."
 msgstr "Não foi possível registrar o aMule como manipulador de URL. O armazenamento deve estar como \"apenas leitura\"."
 
-#: src/PrefsUnifiedDlg.cpp:1517
+#: src/PrefsUnifiedDlg.cpp:1591
 msgid "Could not remove the URL handler registration."
 msgstr "Não foi possível remover o registro de manipulação de URL."
 
-#: src/PrefsUnifiedDlg.cpp:1587 src/PrefsUnifiedDlg.cpp:1614
+#: src/PrefsUnifiedDlg.cpp:1661 src/PrefsUnifiedDlg.cpp:1688
 msgid "The web server and aMule API require external connections to be enabled."
 msgstr "O servidor web e o aMule API necessitam que as conexões externas estejam habilitadas."
 
-#: src/PrefsUnifiedDlg.cpp:1597
+#: src/PrefsUnifiedDlg.cpp:1671
 msgid "The aMule web server is deprecated. Consider running the aMule API instead."
 msgstr "O servidor web do aMules está deprecado. Ao invés disso, considere rodar sob a API do aMule."
 
-#: src/PrefsUnifiedDlg.cpp:1655
+#: src/PrefsUnifiedDlg.cpp:1735
 msgid ""
 "Your Auto-update servers list is in blank.\n"
 "Please fill in at least one URL to point to a valid server.met file.\n"
@@ -5898,64 +5940,64 @@ msgstr ""
 "Coloque pelo menos uma linha que aponte para um server.met válido.\n"
 "Clique no botão \"Lista\" para abrir a caixa para digitar uma URL."
 
-#: src/PrefsUnifiedDlg.cpp:1796
+#: src/PrefsUnifiedDlg.cpp:1876
 msgid "Temporary files"
 msgstr "Arquivos Temporários"
 
-#: src/PrefsUnifiedDlg.cpp:1801
+#: src/PrefsUnifiedDlg.cpp:1881
 msgid "Incoming files"
 msgstr "Arquivos Recebidos"
 
-#: src/PrefsUnifiedDlg.cpp:1806
+#: src/PrefsUnifiedDlg.cpp:1886
 msgid "Online Signatures"
 msgstr "Assinatura Online"
 
-#: src/PrefsUnifiedDlg.cpp:1819
+#: src/PrefsUnifiedDlg.cpp:1899
 #, c-format
 msgid "Choose a folder for %s"
 msgstr "Escolha uma pasta para %s"
 
-#: src/PrefsUnifiedDlg.cpp:1843
+#: src/PrefsUnifiedDlg.cpp:1923
 #, c-format
 msgid "Would exclude %u of %u shared file"
 msgid_plural "Would exclude %u of %u shared files"
 msgstr[0] "Iria excluir %u de %u arquivo compartilhado"
 msgstr[1] "Iria excluir %u de %u arquivos compartilhados"
 
-#: src/PrefsUnifiedDlg.cpp:1860
+#: src/PrefsUnifiedDlg.cpp:1940
 msgid "Browse for videoplayer"
 msgstr "Defina seu Player de Vídeo preferido"
 
-#: src/PrefsUnifiedDlg.cpp:1864
+#: src/PrefsUnifiedDlg.cpp:1944
 msgid "Select browser"
 msgstr "Selecione o Browser"
 
-#: src/PrefsUnifiedDlg.cpp:1868
+#: src/PrefsUnifiedDlg.cpp:1948
 msgid "Select ffprobe binary"
 msgstr "Selecione o binário ffprobe"
 
-#: src/PrefsUnifiedDlg.cpp:1874
+#: src/PrefsUnifiedDlg.cpp:1954
 #, c-format
 msgid "Executable%s"
 msgstr "Executável%s"
 
-#: src/PrefsUnifiedDlg.cpp:1908
+#: src/PrefsUnifiedDlg.cpp:1988
 msgid "ffprobe not found on PATH or in the standard install locations. Install ffmpeg (which ships ffprobe) or use Browse to pick a binary manually."
 msgstr "O ffprobe não foi encontrado no PATH ou nos locais padronizados de instalação. Instale o ffmpeg (que traz junto o ffprobe) ou use Browse para escolher um binário manualmente."
 
-#: src/PrefsUnifiedDlg.cpp:1920
+#: src/PrefsUnifiedDlg.cpp:2000
 msgid "Reset the settings on this page to their default values?"
 msgstr "Resetar as configurações nesta página para seus valores padrão?"
 
-#: src/PrefsUnifiedDlg.cpp:1921
+#: src/PrefsUnifiedDlg.cpp:2001
 msgid "Reset to defaults"
 msgstr "Resetar para os valores padrão"
 
-#: src/PrefsUnifiedDlg.cpp:1948
+#: src/PrefsUnifiedDlg.cpp:2028
 msgid "Edit server list"
 msgstr "Editar lista de servidores"
 
-#: src/PrefsUnifiedDlg.cpp:1949
+#: src/PrefsUnifiedDlg.cpp:2029
 msgid ""
 "Add here URL's to download server.met files.\n"
 "Only one url on each line."
@@ -5963,114 +6005,114 @@ msgstr ""
 "Adicione aqui URL's para baixar arquivo 'server.met'\n"
 "Somente uma URL por Linha."
 
-#: src/PrefsUnifiedDlg.cpp:2004
+#: src/PrefsUnifiedDlg.cpp:2084
 msgid "IP2Country update failed"
 msgstr "Falha ao atualizar IP2Country"
 
-#: src/PrefsUnifiedDlg.cpp:2149 src/PrefsUnifiedDlg.cpp:2180
+#: src/PrefsUnifiedDlg.cpp:2229 src/PrefsUnifiedDlg.cpp:2260
 msgid "Data by MaxMind GeoLite2"
 msgstr "Dados por MaxMind GeoLite2"
 
-#: src/PrefsUnifiedDlg.cpp:2151 src/PrefsUnifiedDlg.cpp:2182
+#: src/PrefsUnifiedDlg.cpp:2231 src/PrefsUnifiedDlg.cpp:2262
 msgid "Custom source"
 msgstr "Fonte customizada"
 
-#: src/PrefsUnifiedDlg.cpp:2153 src/PrefsUnifiedDlg.cpp:2184
+#: src/PrefsUnifiedDlg.cpp:2233 src/PrefsUnifiedDlg.cpp:2264
 msgid "Data by DB-IP.com"
 msgstr "Dados por DB-IP.com"
 
-#: src/PrefsUnifiedDlg.cpp:2204
+#: src/PrefsUnifiedDlg.cpp:2284
 #, c-format
 msgid "Status: Loaded%s"
 msgstr "Status: %s carregados"
 
-#: src/PrefsUnifiedDlg.cpp:2206
+#: src/PrefsUnifiedDlg.cpp:2286
 #, c-format
 msgid "Status: Loaded%s - %s"
 msgstr "Status: %s - %s carregados"
 
-#: src/PrefsUnifiedDlg.cpp:2210
+#: src/PrefsUnifiedDlg.cpp:2290
 msgid "Status: Failed to load - click 'Update now' to refresh."
 msgstr "Estado: Falha ao carregar - clique 'Atualizar agora' para refrescar."
 
-#: src/PrefsUnifiedDlg.cpp:2212
+#: src/PrefsUnifiedDlg.cpp:2292
 msgid "Status: Not found - click 'Update now' to download."
 msgstr "Estado: Não encontrado - clique 'Atualizar agora' para baixar."
 
-#: src/PrefsUnifiedDlg.cpp:2270 src/PrefsUnifiedDlg.cpp:2294
+#: src/PrefsUnifiedDlg.cpp:2350 src/PrefsUnifiedDlg.cpp:2374
 #, c-format
 msgid "Update delay: %d second"
 msgid_plural "Update delay: %d seconds"
 msgstr[0] "Delay na atualização: %d segundo"
 msgstr[1] "Delay na atualização: %d segundos"
 
-#: src/PrefsUnifiedDlg.cpp:2278
+#: src/PrefsUnifiedDlg.cpp:2358
 #, c-format
 msgid "Time for average graph: %d minute"
 msgid_plural "Time for average graph: %d minutes"
 msgstr[0] "Tempo do gráfico de média: %d minuto"
 msgstr[1] "Tempo do gráfico de média: %d minutos"
 
-#: src/PrefsUnifiedDlg.cpp:2287
+#: src/PrefsUnifiedDlg.cpp:2367
 #, c-format
 msgid "Connections Graph Scale: %d"
 msgstr "Escala do gráfico de conexões: %d"
 
-#: src/PrefsUnifiedDlg.cpp:2302
+#: src/PrefsUnifiedDlg.cpp:2382
 #, c-format
 msgid "File Buffer Size: %d byte"
 msgid_plural "File Buffer Size: %d bytes"
 msgstr[0] "Tamanho do Buffer de Arquivo: %d byte"
 msgstr[1] "Tamanho do Buffer de Arquivo: %d bytes"
 
-#: src/PrefsUnifiedDlg.cpp:2312
+#: src/PrefsUnifiedDlg.cpp:2392
 #, c-format
 msgid "Upload Queue Size: %d client"
 msgid_plural "Upload Queue Size: %d clients"
 msgstr[0] "Tamanho de Espera de Upload: %d cliente"
 msgstr[1] "Tamanho de Espera de Upload: %d clientes"
 
-#: src/PrefsUnifiedDlg.cpp:2322
+#: src/PrefsUnifiedDlg.cpp:2402
 #, c-format
 msgid "Server connection refresh interval: %d minute"
 msgid_plural "Server connection refresh interval: %d minutes"
 msgstr[0] "Atualizar conexão com servidor: %d minuto"
 msgstr[1] "Atualizar conexão com servidor: %d minutos"
 
-#: src/PrefsUnifiedDlg.cpp:2327
+#: src/PrefsUnifiedDlg.cpp:2407
 msgid "Server connection refresh interval: Disabled"
 msgstr "Intervalo para atualizar conexão no servidor: Desativado"
 
-#: src/PrefsUnifiedDlg.cpp:2371
+#: src/PrefsUnifiedDlg.cpp:2451
 msgid "disabled"
 msgstr "desativado"
 
-#: src/PrefsUnifiedDlg.cpp:2397
+#: src/PrefsUnifiedDlg.cpp:2477
 #, c-format
 msgid "Execute command on '%s' event"
 msgstr "Executar comando em evento '%s'"
 
-#: src/PrefsUnifiedDlg.cpp:2404
+#: src/PrefsUnifiedDlg.cpp:2484
 msgid "Enable command execution on core"
 msgstr "Habilitar execução de comando no núcleo"
 
-#: src/PrefsUnifiedDlg.cpp:2416
+#: src/PrefsUnifiedDlg.cpp:2496
 msgid "Core command:"
 msgstr "Comando do Núcleo:"
 
-#: src/PrefsUnifiedDlg.cpp:2432
+#: src/PrefsUnifiedDlg.cpp:2512
 msgid "Enable command execution on GUI"
 msgstr "Habilitar execução de comando na GUI"
 
-#: src/PrefsUnifiedDlg.cpp:2444
+#: src/PrefsUnifiedDlg.cpp:2524
 msgid "GUI command:"
 msgstr "Comando da GUI:"
 
-#: src/PrefsUnifiedDlg.cpp:2460
+#: src/PrefsUnifiedDlg.cpp:2540
 msgid "The following variables will be replaced:"
 msgstr "As seguinte variáveis serão substituídas:"
 
-#: src/PrefsUnifiedDlg.cpp:2628
+#: src/PrefsUnifiedDlg.cpp:2708
 msgid ""
 "The following folders look like system or sensitive locations:\n"
 "\n"
@@ -6078,37 +6120,37 @@ msgstr ""
 "As seguintes pastas parecem ser de sistema ou locais sensíveis:\n"
 "\n"
 
-#: src/PrefsUnifiedDlg.cpp:2633
+#: src/PrefsUnifiedDlg.cpp:2713
 msgid "Sharing them recursively will publish every file underneath on the eD2k/Kad networks. Do you really want to do this?"
 msgstr "Compartilha-los recursivamente vai publicar todos os arquivos sob as redes eD2k/Kad. Você realmente quer isto?"
 
-#: src/PrefsUnifiedDlg.cpp:2636
+#: src/PrefsUnifiedDlg.cpp:2716
 msgid "Confirm shared folders"
 msgstr "Confirma pastas compartilhadas"
 
-#: src/PrefsUnifiedDlg.cpp:2664
+#: src/PrefsUnifiedDlg.cpp:2744
 msgid "Reloading shared files..."
 msgstr "Recarregando lista de arquivos compartilhados..."
 
-#: src/PrefsUnifiedDlg.cpp:2665
+#: src/PrefsUnifiedDlg.cpp:2745
 msgid "Scanning for subdirectories..."
 msgstr "Procurando por subdiretórios..."
 
-#: src/PrefsUnifiedDlg.cpp:2666
+#: src/PrefsUnifiedDlg.cpp:2746
 msgid "Updating shared folders"
 msgstr "Atualizando pastas compartilhadas"
 
-#: src/PrefsUnifiedDlg.cpp:2693
+#: src/PrefsUnifiedDlg.cpp:2773
 #, c-format
 msgid "Scanned %u directories..."
 msgstr "Varridos %u diretórios..."
 
-#: src/PrefsUnifiedDlg.cpp:2743
+#: src/PrefsUnifiedDlg.cpp:2823
 #, c-format
 msgid "Reloading shared files: %u files scanned"
 msgstr "Recarregando arquivos compartilhados: %u arquivos encontrados"
 
-#: src/PrefsUnifiedDlg.cpp:2793
+#: src/PrefsUnifiedDlg.cpp:2873
 msgid "Shared folder"
 msgstr "Pasta compartilhada"
 

--- a/po/pt_PT.po
+++ b/po/pt_PT.po
@@ -17,7 +17,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-28 08:06+0200\n"
+"POT-Creation-Date: 2026-07-28 10:19+0200\n"
 "PO-Revision-Date: 2026-07-27 11:44+0000\n"
 "Last-Translator: Luís Picciochi Oliveira <Pitxyoki@Gmail.com>\n"
 "Language-Team: Portuguese <traduz@debianpt.org>\n"
@@ -152,7 +152,7 @@ msgstr ""
 msgid "Not now"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:422 src/amuleDlg.cpp:600
+#: src/AppImageIntegration.cpp:422 src/amuleDlg.cpp:665
 msgid "Don't ask again"
 msgstr ""
 
@@ -225,7 +225,7 @@ msgid "Killing amuleweb instance with pid '%d' ... "
 msgstr "A matar instância do amuleweb com o pid '%d' ... "
 
 #: src/amule.cpp:336 src/amule.cpp:349 src/ClientRef.cpp:180
-#: src/SearchDlg.cpp:880 src/ServerListCtrl.cpp:98
+#: src/SearchDlg.cpp:1041 src/ServerListCtrl.cpp:98
 msgid "Failed"
 msgstr "Falhas"
 
@@ -581,30 +581,68 @@ msgstr "Não foi Possível Criar o Ficheiro de Pid"
 msgid "ERROR: %s"
 msgstr "ERRO: %s"
 
-#: src/amuleDlg.cpp:236
+#: src/amuleDlg.cpp:250
 #, c-format
 msgid "This is aMule %s based on eMule."
 msgstr "Este é o aMule %s, baseado no eMule."
 
-#: src/amuleDlg.cpp:237
+#: src/amuleDlg.cpp:251
 #, c-format
 msgid "Running on %s"
 msgstr "A correr em %s"
 
-#: src/amuleDlg.cpp:239
+#: src/amuleDlg.cpp:253
 msgid "Visit https://github.com/amule-org/amule/releases/latest to check if a new version is available."
 msgstr "Visite https://github.com/amule-org/amule/releases/latest para verificar se há novas versões."
 
-#: src/amuleDlg.cpp:268
+#: src/amuleDlg.cpp:282
 msgid "FATAL ERROR: Failed to create Timer"
 msgstr "ERRO FATAL: Falha ao criar Temporizador"
 
-#: src/amuleDlg.cpp:592
+#: src/amuleDlg.cpp:361 src/amuleDlg.cpp:1787 src/amuleDlg.cpp:2033
+#: src/muuli_wdr.cpp:1492 src/muuli_wdr.cpp:3418
+msgid "Networks"
+msgstr "Redes"
+
+#: src/amuleDlg.cpp:362 src/amuleDlg.cpp:1793 src/muuli_wdr.cpp:3419
+msgid "Searches"
+msgstr "Pesquisas"
+
+#: src/amuleDlg.cpp:363 src/amuleDlg.cpp:1799 src/DownloadListCtrl.cpp:740
+#: src/muuli_wdr.cpp:392 src/muuli_wdr.cpp:1585 src/muuli_wdr.cpp:3420
+#: src/Statistics.cpp:829
+msgid "Downloads"
+msgstr "Downloads"
+
+#: src/amuleDlg.cpp:364 src/amuleDlg.cpp:1805 src/muuli_wdr.cpp:3294
+msgid "Shared files"
+msgstr "Ficheiros partilhados"
+
+#: src/amuleDlg.cpp:365 src/amuleDlg.cpp:1811 src/muuli_wdr.cpp:2926
+#: src/muuli_wdr.cpp:3376 src/muuli_wdr.cpp:3423
+msgid "Messages"
+msgstr "Mensagens"
+
+#: src/amuleDlg.cpp:366 src/amuleDlg.cpp:1817 src/muuli_wdr.cpp:3424
+#: src/PrefsUnifiedDlg.cpp:312 src/Statistics.cpp:779 src/Statistics.cpp:1235
+msgid "Statistics"
+msgstr "Estatísticas"
+
+#: src/amuleDlg.cpp:368 src/amuleDlg.cpp:1824 src/muuli_wdr.cpp:3426
+#: src/PrefsUnifiedDlg.cpp:328 src/utils/wxCas/src/wxcasprefs.cpp:39
+msgid "Preferences"
+msgstr "Preferências"
+
+#: src/amuleDlg.cpp:371
+msgid "Navigate"
+msgstr ""
+
+#: src/amuleDlg.cpp:657
 #, fuzzy
 msgid "New version available"
 msgstr "Indisponível"
 
-#: src/amuleDlg.cpp:596
+#: src/amuleDlg.cpp:661
 #, fuzzy, c-format
 msgid ""
 "A new version of aMule (%s) is available.\n"
@@ -614,218 +652,185 @@ msgid ""
 "Would you like to open the download page?"
 msgstr "A última versão pode ser sempre encontrada em https://github.com/amule-org/amule/releases/latest"
 
-#: src/amuleDlg.cpp:678
+#: src/amuleDlg.cpp:743
 msgid "aMule dialog destroyed"
 msgstr "Caixa de diálogo do aMule destruída"
 
-#: src/amuleDlg.cpp:701 src/DataToText.cpp:68 src/IPFilter.cpp:547
+#: src/amuleDlg.cpp:766 src/DataToText.cpp:68 src/IPFilter.cpp:547
 msgid "Connecting"
 msgstr "A Ligar"
 
-#: src/amuleDlg.cpp:893
+#: src/amuleDlg.cpp:958
 msgid "eD2k: Connecting"
 msgstr "eD2k: A Ligar"
 
-#: src/amuleDlg.cpp:897
+#: src/amuleDlg.cpp:962
 msgid "eD2k: Disconnected"
 msgstr "eD2k: Desligado"
 
-#: src/amuleDlg.cpp:903
+#: src/amuleDlg.cpp:968
 msgid "Kad: Firewalled"
 msgstr "Kad: Atrás de firewall"
 
-#: src/amuleDlg.cpp:907
+#: src/amuleDlg.cpp:972
 msgid "Kad: Connected"
 msgstr "Kad: Ligado"
 
-#: src/amuleDlg.cpp:912
+#: src/amuleDlg.cpp:977
 msgid "Kad: Connecting"
 msgstr "Kad: A Ligar"
 
-#: src/amuleDlg.cpp:916
+#: src/amuleDlg.cpp:981
 msgid "Kad: Off"
 msgstr "Kad: Desligado"
 
-#: src/amuleDlg.cpp:964 src/DownloadListCtrl.cpp:505
+#: src/amuleDlg.cpp:1029 src/DownloadListCtrl.cpp:505
 #: src/DownloadListCtrl.cpp:749 src/FriendListCtrl.cpp:180
 #: src/muuli_wdr.cpp:731 src/muuli_wdr.cpp:782 src/muuli_wdr.cpp:846
-#: src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2224 src/muuli_wdr.cpp:2309
-#: src/muuli_wdr.cpp:3057 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
+#: src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2231 src/muuli_wdr.cpp:2316
+#: src/muuli_wdr.cpp:3064 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
 #: src/ServerListCtrl.cpp:606 src/TransferWnd.cpp:378
 #: src/utils/wxCas/src/wxcasprefs.cpp:235
 msgid "Cancel"
 msgstr "Cancelar"
 
-#: src/amuleDlg.cpp:965
+#: src/amuleDlg.cpp:1030
 msgid "Stop the current connection attempts"
 msgstr "Cancela as tentativas de ligação actuais"
 
-#: src/amuleDlg.cpp:970 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976
-#: src/muuli_wdr.cpp:2447
+#: src/amuleDlg.cpp:1035 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976
+#: src/muuli_wdr.cpp:2454
 msgid "Disconnect"
 msgstr "Desligar"
 
-#: src/amuleDlg.cpp:971
+#: src/amuleDlg.cpp:1036
 msgid "Disconnect from the currently connected networks"
 msgstr "Desligar das redes presentemente ligadas"
 
-#: src/amuleDlg.cpp:976 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979
-#: src/muuli_wdr.cpp:2602 src/muuli_wdr.cpp:3054 src/muuli_wdr.cpp:3409
+#: src/amuleDlg.cpp:1041 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979
+#: src/muuli_wdr.cpp:2609 src/muuli_wdr.cpp:3061 src/muuli_wdr.cpp:3416
 msgid "Connect"
 msgstr "Ligar"
 
-#: src/amuleDlg.cpp:977
+#: src/amuleDlg.cpp:1042
 msgid "Connect to the currently enabled networks"
 msgstr "Ligar às redes presentemente activadas"
 
-#: src/amuleDlg.cpp:1089
+#: src/amuleDlg.cpp:1154
 #, fuzzy, c-format
 msgid "Up: %.1f%s (%.1f) | Down: %.1f%s (%.1f)"
 msgstr "Up: %.1f(%.1f) | Down: %.1f(%.1f)"
 
-#: src/amuleDlg.cpp:1091 src/amuleDlg.cpp:1093 src/amuleDlg.cpp:1097
-#: src/amuleDlg.cpp:1099 src/amuleDlg.cpp:1110 src/amuleDlg.cpp:1112
+#: src/amuleDlg.cpp:1156 src/amuleDlg.cpp:1158 src/amuleDlg.cpp:1162
+#: src/amuleDlg.cpp:1164 src/amuleDlg.cpp:1175 src/amuleDlg.cpp:1177
 #: src/MuleTrayIcon.cpp:796 src/MuleTrayIcon.cpp:799
 #, fuzzy
 msgid " MB/s"
 msgstr "MB/s"
 
-#: src/amuleDlg.cpp:1091 src/amuleDlg.cpp:1093 src/amuleDlg.cpp:1097
-#: src/amuleDlg.cpp:1099 src/amuleDlg.cpp:1110 src/amuleDlg.cpp:1112
+#: src/amuleDlg.cpp:1156 src/amuleDlg.cpp:1158 src/amuleDlg.cpp:1162
+#: src/amuleDlg.cpp:1164 src/amuleDlg.cpp:1175 src/amuleDlg.cpp:1177
 #: src/MuleTrayIcon.cpp:796 src/MuleTrayIcon.cpp:799
 #: src/utils/wxCas/src/wxcasframe.cpp:1041
 msgid " kB/s"
 msgstr " kB/s"
 
-#: src/amuleDlg.cpp:1096
+#: src/amuleDlg.cpp:1161
 #, fuzzy, c-format
 msgid "Up: %.1f%s | Down: %.1f%s"
 msgstr "Up: %.1f | Down: %.1f"
 
-#: src/amuleDlg.cpp:1128
+#: src/amuleDlg.cpp:1193
 #, c-format
 msgid "aMule (%s | Connected)"
 msgstr "aMule (%s | Ligado)"
 
-#: src/amuleDlg.cpp:1130
+#: src/amuleDlg.cpp:1195
 #, c-format
 msgid "aMule (%s | Disconnected)"
 msgstr "aMule (%s | Desligado)"
 
-#: src/amuleDlg.cpp:1183
+#: src/amuleDlg.cpp:1248
 #, c-format
 msgid "Do you really want to exit %s?"
 msgstr "Quer mesmo fechar o %s?"
 
-#: src/amuleDlg.cpp:1185
+#: src/amuleDlg.cpp:1250
 msgid "Exit confirmation"
 msgstr "Confirmação de saída"
 
-#: src/amuleDlg.cpp:1548
+#: src/amuleDlg.cpp:1613
 msgid "Launch Command: "
 msgstr "Executar Comando: "
 
-#: src/amuleDlg.cpp:1567 src/muuli_wdr.cpp:1971 src/Preferences.cpp:951
+#: src/amuleDlg.cpp:1632 src/muuli_wdr.cpp:1978 src/Preferences.cpp:952
 msgid "- default -"
 msgstr "- predefinição -"
 
-#: src/amuleDlg.cpp:1595
+#: src/amuleDlg.cpp:1660
 #, c-format
 msgid "Skin directory '%s' does not exist"
 msgstr "Pasta para os temas '%s' não existe"
 
-#: src/amuleDlg.cpp:1598
+#: src/amuleDlg.cpp:1663
 #, c-format
 msgid "WARNING: Unable to open skin file '%s' for read"
 msgstr "AVISO: Não é possível abrir ficheiro de tema '%s' para leitura"
 
-#: src/amuleDlg.cpp:1722 src/amuleDlg.cpp:1968 src/muuli_wdr.cpp:1485
-#: src/muuli_wdr.cpp:3411
-msgid "Networks"
-msgstr "Redes"
-
-#: src/amuleDlg.cpp:1726 src/muuli_wdr.cpp:3411
+#: src/amuleDlg.cpp:1791 src/muuli_wdr.cpp:3418
 msgid "Networks Window"
 msgstr "Janela de Redes"
 
-#: src/amuleDlg.cpp:1728 src/muuli_wdr.cpp:3412
-msgid "Searches"
-msgstr "Pesquisas"
-
-#: src/amuleDlg.cpp:1732 src/muuli_wdr.cpp:3412
+#: src/amuleDlg.cpp:1797 src/muuli_wdr.cpp:3419
 msgid "Searches Window"
 msgstr "Janela de Pesquisas"
 
-#: src/amuleDlg.cpp:1734 src/DownloadListCtrl.cpp:740 src/muuli_wdr.cpp:392
-#: src/muuli_wdr.cpp:1578 src/muuli_wdr.cpp:3413 src/Statistics.cpp:829
-msgid "Downloads"
-msgstr "Downloads"
-
-#: src/amuleDlg.cpp:1738 src/muuli_wdr.cpp:3413
+#: src/amuleDlg.cpp:1803 src/muuli_wdr.cpp:3420
 msgid "Downloads Window"
 msgstr "Janela de Downloads"
 
-#: src/amuleDlg.cpp:1740 src/muuli_wdr.cpp:3287
-msgid "Shared files"
-msgstr "Ficheiros partilhados"
-
-#: src/amuleDlg.cpp:1744 src/muuli_wdr.cpp:3415
+#: src/amuleDlg.cpp:1809 src/muuli_wdr.cpp:3422
 msgid "Shared Files Window"
 msgstr "Janela de Ficheiros Partilhados"
 
-#: src/amuleDlg.cpp:1746 src/muuli_wdr.cpp:2919 src/muuli_wdr.cpp:3369
-#: src/muuli_wdr.cpp:3416
-msgid "Messages"
-msgstr "Mensagens"
-
-#: src/amuleDlg.cpp:1750 src/muuli_wdr.cpp:3416
+#: src/amuleDlg.cpp:1815 src/muuli_wdr.cpp:3423
 msgid "Messages Window"
 msgstr "Janela de Mensagens"
 
-#: src/amuleDlg.cpp:1752 src/muuli_wdr.cpp:3417 src/PrefsUnifiedDlg.cpp:312
-#: src/Statistics.cpp:779 src/Statistics.cpp:1235
-msgid "Statistics"
-msgstr "Estatísticas"
-
-#: src/amuleDlg.cpp:1756 src/muuli_wdr.cpp:3417
+#: src/amuleDlg.cpp:1821 src/muuli_wdr.cpp:3424
 msgid "Statistics Graph Window"
 msgstr "Janela de Estatísticas"
 
-#: src/amuleDlg.cpp:1759 src/muuli_wdr.cpp:3419 src/PrefsUnifiedDlg.cpp:328
-#: src/utils/wxCas/src/wxcasprefs.cpp:39
-msgid "Preferences"
-msgstr "Preferências"
-
-#: src/amuleDlg.cpp:1763 src/muuli_wdr.cpp:3419
+#: src/amuleDlg.cpp:1828 src/muuli_wdr.cpp:3426
 msgid "Preferences Settings Window"
 msgstr "Janela de Preferências"
 
-#: src/amuleDlg.cpp:1766 src/muuli_wdr.cpp:3420
+#: src/amuleDlg.cpp:1831 src/muuli_wdr.cpp:3427
 msgid "Import"
 msgstr "Importar"
 
-#: src/amuleDlg.cpp:1770 src/muuli_wdr.cpp:3420
+#: src/amuleDlg.cpp:1835 src/muuli_wdr.cpp:3427
 msgid "The partfile importer tool"
 msgstr "A ferramenta de importação de ficheiro de partes"
 
-#: src/amuleDlg.cpp:1773 src/muuli_wdr.cpp:3421
+#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3428
 #: src/utils/aLinkCreator/src/alcframe.cpp:262
 msgid "About"
 msgstr "Acerca"
 
-#: src/amuleDlg.cpp:1773 src/muuli_wdr.cpp:3421
+#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3428
 msgid "About/Help"
 msgstr "Acerca/Ajuda"
 
-#: src/amuleDlg.cpp:1971
+#: src/amuleDlg.cpp:2036
 msgid "eD2k network"
 msgstr "Rede eD2k"
 
-#: src/amuleDlg.cpp:1974
+#: src/amuleDlg.cpp:2039
 msgid "Kad network"
 msgstr "Rede Kad"
 
-#: src/amuleDlg.cpp:1974
+#: src/amuleDlg.cpp:2039
 msgid "No network"
 msgstr "Sem rede"
 
@@ -1358,19 +1363,19 @@ msgstr "Automática [Alta]"
 msgid "Very low"
 msgstr "Muito baixa"
 
-#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:743 src/muuli_wdr.cpp:2275
+#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:743 src/muuli_wdr.cpp:2282
 #: src/ServerListCtrl.cpp:263 src/ServerListCtrl.cpp:456
 #: src/SharedFilesCtrl.cpp:145
 msgid "Low"
 msgstr "Baixa"
 
-#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:744 src/muuli_wdr.cpp:2276
+#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:744 src/muuli_wdr.cpp:2283
 #: src/ServerListCtrl.cpp:266 src/ServerListCtrl.cpp:457
 #: src/SharedFilesCtrl.cpp:146
 msgid "Normal"
 msgstr "Normal"
 
-#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:745 src/muuli_wdr.cpp:2277
+#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:745 src/muuli_wdr.cpp:2284
 #: src/ServerListCtrl.cpp:269 src/ServerListCtrl.cpp:458
 #: src/SharedFilesCtrl.cpp:147
 msgid "High"
@@ -1462,8 +1467,8 @@ msgstr "Servidor Local"
 msgid "Remote Server"
 msgstr "Servidor Remoto"
 
-#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3174
-#: src/SearchDlg.cpp:111 src/TextClient.cpp:911
+#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3181
+#: src/SearchDlg.cpp:119 src/TextClient.cpp:911
 msgid "Kad"
 msgstr "Kad"
 
@@ -1534,7 +1539,7 @@ msgstr "Parte"
 msgid "Size"
 msgstr "Tamanho"
 
-#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3241
+#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3248
 msgid "Transferred"
 msgstr "Transferido"
 
@@ -1592,7 +1597,7 @@ msgstr ""
 "Comentário de: %s (%s)\n"
 "\n"
 
-#: src/DownloadListCtrl.cpp:746 src/muuli_wdr.cpp:2278
+#: src/DownloadListCtrl.cpp:746 src/muuli_wdr.cpp:2285
 #: src/SharedFilesCtrl.cpp:150
 msgid "Auto"
 msgstr "Automática"
@@ -1630,7 +1635,7 @@ msgid "Extended Options"
 msgstr "Opções Estendidas"
 
 #: src/DownloadListCtrl.cpp:770 src/DownloadListCtrl.cpp:822
-#: src/muuli_wdr.cpp:1789
+#: src/muuli_wdr.cpp:1796
 msgid "Preview"
 msgstr "Pré-visualizar"
 
@@ -2341,19 +2346,19 @@ msgstr ""
 msgid "eD2k"
 msgstr "eD2k"
 
-#: src/FirstRunWizard.cpp:349 src/muuli_wdr.cpp:1488
+#: src/FirstRunWizard.cpp:349 src/muuli_wdr.cpp:1495
 msgid "Kademlia"
 msgstr "Kademlia"
 
-#: src/FirstRunWizard.cpp:359 src/muuli_wdr.cpp:1416
+#: src/FirstRunWizard.cpp:359 src/muuli_wdr.cpp:1423
 msgid "Standard TCP Port "
 msgstr "Porto TCP Padrão "
 
-#: src/FirstRunWizard.cpp:365 src/muuli_wdr.cpp:1428
+#: src/FirstRunWizard.cpp:365 src/muuli_wdr.cpp:1435
 msgid "Extended UDP port (Kad / global search) "
 msgstr "Porto UDP estendido (Kad / pesquisa global) "
 
-#: src/FirstRunWizard.cpp:377 src/muuli_wdr.cpp:1435
+#: src/FirstRunWizard.cpp:377 src/muuli_wdr.cpp:1442
 msgid "Enable UPnP for router port forwarding"
 msgstr "Activar UPnP para encaminhamento de portos no router"
 
@@ -2380,7 +2385,7 @@ msgstr ""
 msgid "Your peer lists are already in place - nothing to download."
 msgstr "Já está a tentar transferir o ficheiro %s"
 
-#: src/FirstRunWizard.cpp:434 src/muuli_wdr.cpp:1533
+#: src/FirstRunWizard.cpp:434 src/muuli_wdr.cpp:1540
 msgid "Auto-update server list at startup"
 msgstr "Auto-actualizar lista de servidores no arranque"
 
@@ -2426,23 +2431,23 @@ msgid ""
 "want downloads on a different (e.g. larger) disk."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:549 src/FirstRunWizard.cpp:611 src/muuli_wdr.cpp:1701
+#: src/FirstRunWizard.cpp:549 src/FirstRunWizard.cpp:611 src/muuli_wdr.cpp:1708
 msgid "Destination folder for downloads"
 msgstr "Pasta de destino para downloads"
 
-#: src/FirstRunWizard.cpp:553 src/FirstRunWizard.cpp:569 src/muuli_wdr.cpp:1342
-#: src/muuli_wdr.cpp:1359 src/muuli_wdr.cpp:1676 src/muuli_wdr.cpp:1707
-#: src/muuli_wdr.cpp:1719 src/muuli_wdr.cpp:2762
+#: src/FirstRunWizard.cpp:553 src/FirstRunWizard.cpp:569 src/muuli_wdr.cpp:1349
+#: src/muuli_wdr.cpp:1366 src/muuli_wdr.cpp:1683 src/muuli_wdr.cpp:1714
+#: src/muuli_wdr.cpp:1726 src/muuli_wdr.cpp:2769
 #: src/utils/aLinkCreator/src/alcframe.cpp:135
 #: src/utils/wxCas/src/wxcasprefs.cpp:52 src/utils/wxCas/src/wxcasprefs.cpp:118
 msgid "Browse"
 msgstr "Procurar"
 
-#: src/FirstRunWizard.cpp:559 src/muuli_wdr.cpp:1712
+#: src/FirstRunWizard.cpp:559 src/muuli_wdr.cpp:1719
 msgid "(All files in this folder are shared with other peers)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:565 src/FirstRunWizard.cpp:624 src/muuli_wdr.cpp:1714
+#: src/FirstRunWizard.cpp:565 src/FirstRunWizard.cpp:624 src/muuli_wdr.cpp:1721
 msgid "Folder for temporary download files"
 msgstr "Pasta para ficheiros temporários"
 
@@ -2473,7 +2478,7 @@ msgstr "Erro ao abrir o ficheiro de lista de amigos 'emfriends.met' para escrita
 msgid "CRITICAL - no client on StartChatSession"
 msgstr "CRÍTICO - sem cliente no StartChatSession"
 
-#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2668 src/muuli_wdr.cpp:3345
+#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2675 src/muuli_wdr.cpp:3352
 msgid "Friends"
 msgstr "Amigos"
 
@@ -2859,7 +2864,7 @@ msgstr "Razão de partilha"
 msgid "Uploaded"
 msgstr "Enviado"
 
-#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3225
+#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3232
 msgid "Requested"
 msgstr "Pedido"
 
@@ -2983,7 +2988,7 @@ msgid "WARNING: "
 msgstr "AVISO: "
 
 #: src/MuleNotebook.cpp:179 src/muuli_wdr.cpp:817 src/muuli_wdr.cpp:1229
-#: src/muuli_wdr.cpp:3129 src/muuli_wdr.cpp:3385
+#: src/muuli_wdr.cpp:3136 src/muuli_wdr.cpp:3392
 msgid "Close"
 msgstr "Fechar"
 
@@ -2996,12 +3001,12 @@ msgstr "Cortar"
 msgid "Copy"
 msgstr "Copiar"
 
-#: src/MuleTextCtrl.cpp:88
+#: src/MuleTextCtrl.cpp:88 src/SearchDlg.cpp:261
 msgid "Paste"
 msgstr "Colar"
 
 #: src/MuleTextCtrl.cpp:89 src/muuli_wdr.cpp:358 src/muuli_wdr.cpp:757
-#: src/muuli_wdr.cpp:2352 src/muuli_wdr.cpp:2371 src/muuli_wdr.cpp:2393
+#: src/muuli_wdr.cpp:2359 src/muuli_wdr.cpp:2378 src/muuli_wdr.cpp:2400
 #: src/utils/aLinkCreator/src/alcframe.cpp:142
 msgid "Clear"
 msgstr "Limpar"
@@ -3099,8 +3104,8 @@ msgid "Exit"
 msgstr "Sair"
 
 #: src/MuleTrayIcon.cpp:579 src/MuleTrayIcon.cpp:945 src/MuleTrayIcon.cpp:965
-#: src/muuli_wdr.cpp:1391 src/muuli_wdr.cpp:1399 src/muuli_wdr.cpp:1406
-#: src/muuli_wdr.cpp:1835 src/muuli_wdr.cpp:1841 src/OtherFunctions.cpp:91
+#: src/muuli_wdr.cpp:1398 src/muuli_wdr.cpp:1406 src/muuli_wdr.cpp:1413
+#: src/muuli_wdr.cpp:1842 src/muuli_wdr.cpp:1848 src/OtherFunctions.cpp:91
 #: src/StatisticsDlg.cpp:93 src/StatisticsDlg.cpp:95
 msgid "kB/s"
 msgstr "kB/s"
@@ -3271,7 +3276,7 @@ msgstr "Nome:"
 msgid "Type"
 msgstr "Tipo"
 
-#: src/muuli_wdr.cpp:215 src/SearchDlg.cpp:110 src/SearchListCtrl.cpp:853
+#: src/muuli_wdr.cpp:215 src/SearchDlg.cpp:118 src/SearchListCtrl.cpp:853
 msgid "Local"
 msgstr "Local"
 
@@ -3342,7 +3347,7 @@ msgstr "Bytes"
 msgid "KB"
 msgstr "kB"
 
-#: src/muuli_wdr.cpp:274 src/muuli_wdr.cpp:293 src/muuli_wdr.cpp:1620
+#: src/muuli_wdr.cpp:274 src/muuli_wdr.cpp:293 src/muuli_wdr.cpp:1627
 #: src/OtherFunctions.cpp:64
 msgid "MB"
 msgstr "MB"
@@ -3359,7 +3364,7 @@ msgstr "Tamanho Máximo"
 msgid "Availability"
 msgstr "Disponibilidade"
 
-#: src/muuli_wdr.cpp:312 src/muuli_wdr.cpp:398 src/muuli_wdr.cpp:3290
+#: src/muuli_wdr.cpp:312 src/muuli_wdr.cpp:398 src/muuli_wdr.cpp:3297
 msgid "Filter:"
 msgstr "Filtro:"
 
@@ -3391,7 +3396,7 @@ msgstr ""
 msgid "Stop"
 msgstr "Parar"
 
-#: src/muuli_wdr.cpp:348 src/muuli_wdr.cpp:1385 src/SearchListCtrl.cpp:732
+#: src/muuli_wdr.cpp:348 src/muuli_wdr.cpp:1392 src/SearchListCtrl.cpp:732
 msgid "Download"
 msgstr "Download"
 
@@ -3422,8 +3427,8 @@ msgstr "Fontes de ficheiros:"
 #: src/muuli_wdr.cpp:1160 src/muuli_wdr.cpp:1167 src/muuli_wdr.cpp:1172
 #: src/muuli_wdr.cpp:1179 src/muuli_wdr.cpp:1184 src/muuli_wdr.cpp:1191
 #: src/muuli_wdr.cpp:1205 src/muuli_wdr.cpp:1212 src/muuli_wdr.cpp:1217
-#: src/muuli_wdr.cpp:1224 src/muuli_wdr.cpp:3227 src/muuli_wdr.cpp:3235
-#: src/muuli_wdr.cpp:3243
+#: src/muuli_wdr.cpp:1224 src/muuli_wdr.cpp:3234 src/muuli_wdr.cpp:3242
+#: src/muuli_wdr.cpp:3250
 msgid "N/A"
 msgstr "N/D"
 
@@ -3568,7 +3573,7 @@ msgstr ""
 msgid "Album :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:685 src/muuli_wdr.cpp:2247
+#: src/muuli_wdr.cpp:685 src/muuli_wdr.cpp:2254
 msgid "Title :"
 msgstr "Título :"
 
@@ -3677,7 +3682,7 @@ msgstr "Utilizador :"
 msgid "Userhash :"
 msgstr "Chave de utilizador :"
 
-#: src/muuli_wdr.cpp:895 src/muuli_wdr.cpp:1741 src/muuli_wdr.cpp:2442
+#: src/muuli_wdr.cpp:895 src/muuli_wdr.cpp:1748 src/muuli_wdr.cpp:2449
 #: src/utils/aLinkCreator/src/alcframe.cpp:137
 msgid "Add"
 msgstr "Adicionar"
@@ -3686,15 +3691,15 @@ msgstr "Adicionar"
 msgid "Download-Speed"
 msgstr "Velocidade de Download"
 
-#: src/muuli_wdr.cpp:954 src/muuli_wdr.cpp:989 src/muuli_wdr.cpp:2546
+#: src/muuli_wdr.cpp:954 src/muuli_wdr.cpp:989 src/muuli_wdr.cpp:2553
 msgid "Current"
 msgstr "Actual"
 
-#: src/muuli_wdr.cpp:962 src/muuli_wdr.cpp:997 src/muuli_wdr.cpp:2554
+#: src/muuli_wdr.cpp:962 src/muuli_wdr.cpp:997 src/muuli_wdr.cpp:2561
 msgid "Running average"
 msgstr "Média actual"
 
-#: src/muuli_wdr.cpp:970 src/muuli_wdr.cpp:1005 src/muuli_wdr.cpp:2562
+#: src/muuli_wdr.cpp:970 src/muuli_wdr.cpp:1005 src/muuli_wdr.cpp:2569
 msgid "Session average"
 msgstr "Média da sessão"
 
@@ -3706,7 +3711,7 @@ msgstr "Velocidade de Upload"
 msgid "Connections"
 msgstr "Ligações"
 
-#: src/muuli_wdr.cpp:1024 src/muuli_wdr.cpp:1860
+#: src/muuli_wdr.cpp:1024 src/muuli_wdr.cpp:1867
 msgid "Active downloads"
 msgstr "Downloads activos"
 
@@ -3714,7 +3719,7 @@ msgstr "Downloads activos"
 msgid "Active connections (1:1)"
 msgstr "Ligações activas (1:1)"
 
-#: src/muuli_wdr.cpp:1040 src/muuli_wdr.cpp:1861
+#: src/muuli_wdr.cpp:1040 src/muuli_wdr.cpp:1868
 msgid "Active uploads"
 msgstr "Uploads activos"
 
@@ -3830,8 +3835,8 @@ msgstr "Este é o nome que os outros utilizadores verão ao ligar-se a si."
 msgid "Language: "
 msgstr "Idioma: "
 
-#: src/muuli_wdr.cpp:1257 src/muuli_wdr.cpp:1323 src/muuli_wdr.cpp:1327
-#: src/muuli_wdr.cpp:1330
+#: src/muuli_wdr.cpp:1257 src/muuli_wdr.cpp:1330 src/muuli_wdr.cpp:1334
+#: src/muuli_wdr.cpp:1337
 msgid "The delay before showing tool-tips."
 msgstr "O tempo que decorre até serem mostradas as dicas."
 
@@ -3909,937 +3914,946 @@ msgstr ""
 msgid "Enabling this will make aMule to show notifications when finished downloading."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1322
+#: src/muuli_wdr.cpp:1323
+#, fuzzy
+msgid "Remember search history"
+msgstr "Lembrar estas preferências"
+
+#: src/muuli_wdr.cpp:1324
+msgid "Keeps a dropdown list of your past search terms in the Search tab's Name field. This remembers the queries you typed, not the results they returned."
+msgstr ""
+
+#: src/muuli_wdr.cpp:1329
 msgid "Tooltip delay time: "
 msgstr "Atraso de exibição de dicas: "
 
-#: src/muuli_wdr.cpp:1329
+#: src/muuli_wdr.cpp:1336
 msgid "seconds"
 msgstr "segundos"
 
-#: src/muuli_wdr.cpp:1333
+#: src/muuli_wdr.cpp:1340
 msgid "Browser Selection"
 msgstr "Selecção de Navegador"
 
-#: src/muuli_wdr.cpp:1339
+#: src/muuli_wdr.cpp:1346
 msgid "Enter your browser name here. Leave this field empty to use the system default browser."
 msgstr "Indique aqui o nome do seu browser. Deixe este campo em branco para utilizar o browser por omissão do sistema."
 
-#: src/muuli_wdr.cpp:1346
+#: src/muuli_wdr.cpp:1353
 msgid "Open in new tab if possible"
 msgstr "Abrir num novo separador se possível"
 
-#: src/muuli_wdr.cpp:1348
+#: src/muuli_wdr.cpp:1355
 msgid "Open the web page in a new tab instead of in a new window when possible"
 msgstr "Abrir a página num novo separador em vez de uma nova janela, quando possível"
 
-#: src/muuli_wdr.cpp:1352
+#: src/muuli_wdr.cpp:1359
 msgid "Video Player"
 msgstr "Leitor de vídeo"
 
-#: src/muuli_wdr.cpp:1379
+#: src/muuli_wdr.cpp:1386
 msgid "Bandwidth limits"
 msgstr "Limites de largura de banda"
 
-#: src/muuli_wdr.cpp:1393
+#: src/muuli_wdr.cpp:1400
 msgid "Upload"
 msgstr "Upload"
 
-#: src/muuli_wdr.cpp:1401
+#: src/muuli_wdr.cpp:1408
 msgid "Slot Allocation"
 msgstr "Atribuição de Ligações"
 
-#: src/muuli_wdr.cpp:1410
+#: src/muuli_wdr.cpp:1417
 msgid "Ports"
 msgstr "Portos"
 
-#: src/muuli_wdr.cpp:1420
+#: src/muuli_wdr.cpp:1427
 msgid "This is the standard eD2k port and cannot be disabled."
 msgstr "Este é o porto da eD2k por omissão e não pode ser desactivado."
 
-#: src/muuli_wdr.cpp:1423
+#: src/muuli_wdr.cpp:1430
 msgid "UDP port for server requests (TCP+3):"
 msgstr "Porto UDP para pedidos ao servidor (TCP+3):"
 
-#: src/muuli_wdr.cpp:1425
+#: src/muuli_wdr.cpp:1432
 msgid "4665"
 msgstr "4665"
 
-#: src/muuli_wdr.cpp:1432
+#: src/muuli_wdr.cpp:1439
 msgid "This UDP port is used for extended eD2k requests and Kad network"
 msgstr "Este porto UDP é usado para pedidos eD2k estendidos e para a rede Kad"
 
-#: src/muuli_wdr.cpp:1439
+#: src/muuli_wdr.cpp:1446
 msgid "UPnP TCP Port (Optional):"
 msgstr "Porto TCP UPnP (Opcional):"
 
-#: src/muuli_wdr.cpp:1449
+#: src/muuli_wdr.cpp:1456
 msgid "Bind local address to IP (empty for any):"
 msgstr "Associar endereço local ao IP (em branco para qualquer um):"
 
-#: src/muuli_wdr.cpp:1452
+#: src/muuli_wdr.cpp:1459
 msgid "Advanced users only: If you have multiple network interfaces, enter the address of the interface to which aMule should be bound."
 msgstr "Apenas para utilizadores avançados: Se possui múltiplos interfaces de rede indique o endereço do interface que o aMule deve usar."
 
-#: src/muuli_wdr.cpp:1455 src/muuli_wdr.cpp:2054
+#: src/muuli_wdr.cpp:1462 src/muuli_wdr.cpp:2061
 #, fuzzy
 msgid "Bind to network interface (empty for any):"
 msgstr "Associar endereço local ao IP (em branco para qualquer um):"
 
-#: src/muuli_wdr.cpp:1468
+#: src/muuli_wdr.cpp:1475
 msgid "Advanced users only: pin all of aMule's traffic to one network interface, chosen from the list or typed in by name (e.g. tun0, eth0, en0) or index. Unlike binding to an IP, this stops traffic leaking out via the default route - useful with a VPN. Requires no elevated privileges."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1474
+#: src/muuli_wdr.cpp:1481
 msgid "Max sources per downloading file:"
 msgstr "Máximo de fontes por ficheiro:"
 
-#: src/muuli_wdr.cpp:1478
+#: src/muuli_wdr.cpp:1485
 msgid "Max simultaneous connections:"
 msgstr "Máximo de ligações simultâneas:"
 
-#: src/muuli_wdr.cpp:1491 src/muuli_wdr.cpp:3169
+#: src/muuli_wdr.cpp:1498 src/muuli_wdr.cpp:3176
 msgid "ED2K"
 msgstr "ED2K"
 
-#: src/muuli_wdr.cpp:1498
+#: src/muuli_wdr.cpp:1505
 msgid "Autoconnect on startup"
 msgstr "Ligar automaticamente no arranque"
 
-#: src/muuli_wdr.cpp:1501
+#: src/muuli_wdr.cpp:1508
 msgid "Reconnect on loss"
 msgstr "Voltar a ligar se perder ligação"
 
-#: src/muuli_wdr.cpp:1523
+#: src/muuli_wdr.cpp:1530
 msgid "Remove dead server after"
 msgstr "Remover servidores inactivos após"
 
-#: src/muuli_wdr.cpp:1524
+#: src/muuli_wdr.cpp:1531
 msgid "Static servers are never removed, even when unreachable."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1528
+#: src/muuli_wdr.cpp:1535
 msgid "retries"
 msgstr "tentativas"
 
-#: src/muuli_wdr.cpp:1536
+#: src/muuli_wdr.cpp:1543
 msgid "List"
 msgstr "Lista"
 
-#: src/muuli_wdr.cpp:1539
+#: src/muuli_wdr.cpp:1546
 msgid "Update server list when connecting to a server"
 msgstr "Actualizar a lista de servidores quando se liga a um servidor"
 
-#: src/muuli_wdr.cpp:1542
+#: src/muuli_wdr.cpp:1549
 msgid "Update server list when a client connects"
 msgstr "Actualizar a lista de servidores quando um cliente se liga"
 
-#: src/muuli_wdr.cpp:1545
+#: src/muuli_wdr.cpp:1552
 msgid "Use priority system"
 msgstr "Usar o sistema de prioridades"
 
-#: src/muuli_wdr.cpp:1549
+#: src/muuli_wdr.cpp:1556
 msgid "Use smart LowID check on connect"
 msgstr "Usar verificação inteligente de LowID ao ligar"
 
-#: src/muuli_wdr.cpp:1553
+#: src/muuli_wdr.cpp:1560
 msgid "Safe connect"
 msgstr "Ligação segura"
 
-#: src/muuli_wdr.cpp:1557
+#: src/muuli_wdr.cpp:1564
 msgid "Autoconnect to servers in static list only"
 msgstr "Apenas ligar automaticamente a servidores estáticos"
 
-#: src/muuli_wdr.cpp:1560
+#: src/muuli_wdr.cpp:1567
 msgid "Set manually added servers to High Priority"
 msgstr "Atribuir alta prioridade a servidores adicionados manualmente"
 
-#: src/muuli_wdr.cpp:1581
+#: src/muuli_wdr.cpp:1588
 msgid "Add files to download in pause mode"
 msgstr "Adicionar ficheiros para transferir em modo de pausa"
 
-#: src/muuli_wdr.cpp:1583
+#: src/muuli_wdr.cpp:1590
 msgid "Add files to download with auto priority"
 msgstr "Adicionar ficheiros para transferir com prioridade automática"
 
-#: src/muuli_wdr.cpp:1586
+#: src/muuli_wdr.cpp:1593
 msgid "Try to download first and last chunks first"
 msgstr "Tentar receber primeiro o início e o final dos ficheiros"
 
-#: src/muuli_wdr.cpp:1590
+#: src/muuli_wdr.cpp:1597
 msgid "Endgame mode: rotate to faster sources for the final blocks"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1593
+#: src/muuli_wdr.cpp:1600
 msgid "Start next paused file when a file completes"
 msgstr "Iniciar o próximo ficheiro em pausa quando um ficheiro completa"
 
-#: src/muuli_wdr.cpp:1596
+#: src/muuli_wdr.cpp:1603
 msgid "From the same category"
 msgstr "Da mesma categoria"
 
-#: src/muuli_wdr.cpp:1598
+#: src/muuli_wdr.cpp:1605
 msgid "In alphabetic order"
 msgstr "Em ordem alfabética"
 
-#: src/muuli_wdr.cpp:1600
+#: src/muuli_wdr.cpp:1607
 msgid "Preallocate disk space for new files"
 msgstr "Reservar previamente espaço em disco para novos ficheiros"
 
-#: src/muuli_wdr.cpp:1601
+#: src/muuli_wdr.cpp:1608
 msgid "For new files preallocates disk space for the whole file, thus reduces fragmentation"
 msgstr "Para novos ficheiros, reserva o espaço em disco para o ficheiro completo, reduzindo assim a fragmentação"
 
-#: src/muuli_wdr.cpp:1606
+#: src/muuli_wdr.cpp:1613
 msgid "Create new files as sparse files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1607
+#: src/muuli_wdr.cpp:1614
 msgid "A sparse file reserves its full size on disk immediately without writing real data to it -- fast, but unsupported or slow on some filesystems, and free-space accounting stays optimistic while the download is in progress. Turn this off to grow the file only as data arrives."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1612
+#: src/muuli_wdr.cpp:1619
 msgid "Stop downloads when free disk space reaches "
 msgstr "Parar os downloads quando o espaço livre em disco atinge "
 
-#: src/muuli_wdr.cpp:1613
+#: src/muuli_wdr.cpp:1620
 msgid "Select this if you want aMule to check your disk space"
 msgstr "Seleccione se quiser que o aMule verifique o espaço em disco"
 
-#: src/muuli_wdr.cpp:1617
+#: src/muuli_wdr.cpp:1624
 msgid "Enter here the min disk space desired."
 msgstr "Insira o espaço mínimo no disco desejado."
 
-#: src/muuli_wdr.cpp:1623
+#: src/muuli_wdr.cpp:1630
 msgid "Save 10 sources on rare files (< 20 sources)"
 msgstr "Guardar 10 fontes para ficheiros raros (< 20 fontes)"
 
-#: src/muuli_wdr.cpp:1627 src/Statistics.cpp:790
+#: src/muuli_wdr.cpp:1634 src/Statistics.cpp:790
 msgid "Uploads"
 msgstr "Uploads"
 
-#: src/muuli_wdr.cpp:1630
+#: src/muuli_wdr.cpp:1637
 msgid "Add new shared files with auto priority"
 msgstr "Adicionar novos ficheiros partilhados com prioridade automática"
 
-#: src/muuli_wdr.cpp:1636
+#: src/muuli_wdr.cpp:1643
 msgid "Intelligent Corruption Handling (I.C.H.)"
 msgstr "Manipulação Inteligente de Corrupção (M.I.C.)"
 
-#: src/muuli_wdr.cpp:1639
+#: src/muuli_wdr.cpp:1646
 msgid "Enable"
 msgstr "Activar"
 
-#: src/muuli_wdr.cpp:1642
+#: src/muuli_wdr.cpp:1649
 msgid "Advanced I.C.H. trusts every hash (not recommended)"
 msgstr "M.I.C. Avançada confia em todas as chaves (não recomendado)"
 
-#: src/muuli_wdr.cpp:1654 src/PrefsUnifiedDlg.cpp:1910
+#: src/muuli_wdr.cpp:1661 src/PrefsUnifiedDlg.cpp:1910
 msgid "Media metadata extraction"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1658
+#: src/muuli_wdr.cpp:1665
 msgid "Extract length / bitrate / codec from shared audio and video files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1660
+#: src/muuli_wdr.cpp:1667
 msgid "When enabled, aMule runs ffprobe on each shared media file to fill in the Length / Bitrate / Codec columns other clients see when they find the file in a search. Requires ffmpeg (the ffprobe binary) to be installed."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1667
+#: src/muuli_wdr.cpp:1674
 msgid "Path to ffprobe:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1672
+#: src/muuli_wdr.cpp:1679
 msgid "Full path to the ffprobe binary. Leave empty to have aMule auto-detect it on startup."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1680
+#: src/muuli_wdr.cpp:1687
 msgid "Detect"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1681
+#: src/muuli_wdr.cpp:1688
 msgid "Search the standard install locations for an ffprobe binary and fill the path field."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1705
+#: src/muuli_wdr.cpp:1712
 msgid ""
 "Completed downloads are stored here. All files in this folder are automatically shared with other peers.\n"
 "If this folder also holds files you don't want to share, point it at an aMule-only sub-folder."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1708
+#: src/muuli_wdr.cpp:1715
 msgid "Pick the folder where completed downloads will be stored. All files in that folder will be shared with other peers."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1722
+#: src/muuli_wdr.cpp:1729
 msgid "Shared folders"
 msgstr "Pastas partilhadas"
 
-#: src/muuli_wdr.cpp:1728
+#: src/muuli_wdr.cpp:1735
 msgid "(Folders shared by the core. Enter a path to add one.)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1736
+#: src/muuli_wdr.cpp:1743
 msgid "Absolute path of a folder on the core's machine, e.g. /home/user/shared"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1738 src/PrefsUnifiedDlg.cpp:2794
+#: src/muuli_wdr.cpp:1745 src/PrefsUnifiedDlg.cpp:2794
 msgid "Recursive"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1739
+#: src/muuli_wdr.cpp:1746
 msgid "Share every sub-folder underneath this one, including ones created later."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1743 src/utils/aLinkCreator/src/alcframe.cpp:141
+#: src/muuli_wdr.cpp:1750 src/utils/aLinkCreator/src/alcframe.cpp:141
 msgid "Remove"
 msgstr "Remover"
 
-#: src/muuli_wdr.cpp:1747
+#: src/muuli_wdr.cpp:1754
 msgid "(Right click on folder icon for recursive share)"
 msgstr "(Clique com o botão do lado direito no ícone da pasta para partilha recursiva)"
 
-#: src/muuli_wdr.cpp:1754
+#: src/muuli_wdr.cpp:1761
 msgid "Share hidden files"
 msgstr "Partilhar ficheiros ocultos"
 
-#: src/muuli_wdr.cpp:1760
+#: src/muuli_wdr.cpp:1767
 msgid "Automatically rescan shared folders for changes"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1766
+#: src/muuli_wdr.cpp:1773
 msgid "Follow symbolic links in shared folders"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1772
+#: src/muuli_wdr.cpp:1779
 msgid "Exclude files matching:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1775
+#: src/muuli_wdr.cpp:1782
 msgid "Wildcard patterns separated by '|', e.g. .DS_Store|Thumbs.db|*.tmp. Files whose name matches are not shared. Matching is case-insensitive."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1779
+#: src/muuli_wdr.cpp:1786
 msgid "Patterns are regular expressions"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1780
+#: src/muuli_wdr.cpp:1787
 msgid "When set, the whole field is one regular expression ('|' is alternation). When unset, it is a list of '|'-separated wildcards."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1790
+#: src/muuli_wdr.cpp:1797
 msgid "Show how many shared files the current pattern would exclude."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1811
+#: src/muuli_wdr.cpp:1818
 msgid "Graphs"
 msgstr "Gráficos"
 
-#: src/muuli_wdr.cpp:1814 src/muuli_wdr.cpp:1876
+#: src/muuli_wdr.cpp:1821 src/muuli_wdr.cpp:1883
 msgid "Update delay : 5 secs"
 msgstr "Atraso de actualização: 5 segundos"
 
-#: src/muuli_wdr.cpp:1818
+#: src/muuli_wdr.cpp:1825
 msgid "Time for average graph: 100 mins"
 msgstr "Tempo para gráfico de média: 100 minutos"
 
-#: src/muuli_wdr.cpp:1822
+#: src/muuli_wdr.cpp:1829
 msgid "Connections Graph Scale: 100 "
 msgstr "Escala do Gráfico de Ligações: 100"
 
-#: src/muuli_wdr.cpp:1829
+#: src/muuli_wdr.cpp:1836
 msgid "Download graph scale:"
 msgstr "Escala do gráfico de download:"
 
-#: src/muuli_wdr.cpp:1837
+#: src/muuli_wdr.cpp:1844
 msgid "Upload graph scale:"
 msgstr "Escala do gráfico de upload"
 
-#: src/muuli_wdr.cpp:1847
+#: src/muuli_wdr.cpp:1854
 #, fuzzy
 msgid "Colors: "
 msgstr "Cores: "
 
-#: src/muuli_wdr.cpp:1851
+#: src/muuli_wdr.cpp:1858
 msgid "Background"
 msgstr "Fundo"
 
-#: src/muuli_wdr.cpp:1852
+#: src/muuli_wdr.cpp:1859
 msgid "Grid"
 msgstr "Grelha"
 
-#: src/muuli_wdr.cpp:1853
+#: src/muuli_wdr.cpp:1860
 msgid "Download current"
 msgstr "Download actual"
 
-#: src/muuli_wdr.cpp:1854
+#: src/muuli_wdr.cpp:1861
 msgid "Download running average"
 msgstr "Média actual de download"
 
-#: src/muuli_wdr.cpp:1855
+#: src/muuli_wdr.cpp:1862
 msgid "Download session average"
 msgstr "Média de download da sessão"
 
-#: src/muuli_wdr.cpp:1856
+#: src/muuli_wdr.cpp:1863
 msgid "Upload current"
 msgstr "Upload actual"
 
-#: src/muuli_wdr.cpp:1857
+#: src/muuli_wdr.cpp:1864
 msgid "Upload running average"
 msgstr "Média actual de upload"
 
-#: src/muuli_wdr.cpp:1858
+#: src/muuli_wdr.cpp:1865
 msgid "Upload session average"
 msgstr "Média de upload da sessão"
 
-#: src/muuli_wdr.cpp:1859
+#: src/muuli_wdr.cpp:1866
 msgid "Active connections"
 msgstr "Ligações activas"
 
-#: src/muuli_wdr.cpp:1862
+#: src/muuli_wdr.cpp:1869
 #, fuzzy
 msgid "Systray Icon Speed Bar"
 msgstr "Barra de velocidade no ícone da área de notificação"
 
-#: src/muuli_wdr.cpp:1863
+#: src/muuli_wdr.cpp:1870
 msgid "Kad-nodes current"
 msgstr "Nós Kad actuais"
 
-#: src/muuli_wdr.cpp:1864
+#: src/muuli_wdr.cpp:1871
 msgid "Kad-nodes running"
 msgstr "Nós Kad a executar"
 
-#: src/muuli_wdr.cpp:1865
+#: src/muuli_wdr.cpp:1872
 msgid "Kad-nodes session"
 msgstr "Nós Kad da sessão"
 
-#: src/muuli_wdr.cpp:1869 src/muuli_wdr.cpp:2296
+#: src/muuli_wdr.cpp:1876 src/muuli_wdr.cpp:2303
 msgid "Select"
 msgstr "Seleccionar"
 
-#: src/muuli_wdr.cpp:1873
+#: src/muuli_wdr.cpp:1880
 msgid "Tree"
 msgstr "Árvore"
 
-#: src/muuli_wdr.cpp:1883
+#: src/muuli_wdr.cpp:1890
 msgid "Number of Client Versions shown (0=unlimited)"
 msgstr "Número de Versões de Cliente mostradas (0=ilimitado)"
 
-#: src/muuli_wdr.cpp:1908
+#: src/muuli_wdr.cpp:1915
 msgid "!!! WARNING !!!"
 msgstr "!!! AVISO !!!"
 
-#: src/muuli_wdr.cpp:1923
+#: src/muuli_wdr.cpp:1930
 msgid "Max new connections / 5 secs"
 msgstr "Máximo de novas ligações / 5 segundos"
 
-#: src/muuli_wdr.cpp:1925
+#: src/muuli_wdr.cpp:1932
 msgid "Concurrent Kad source lookups"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1927
+#: src/muuli_wdr.cpp:1934
 #, fuzzy
 msgid "Kad source re-search interval (minutes)"
 msgstr "Intervalo de actualização do FTP em minutos"
 
-#: src/muuli_wdr.cpp:1929
+#: src/muuli_wdr.cpp:1936
 #, fuzzy
 msgid "Source re-ask interval (minutes)"
 msgstr "Intervalo de actualização do FTP em minutos"
 
-#: src/muuli_wdr.cpp:1933
+#: src/muuli_wdr.cpp:1940
 msgid "File Buffer Size: 240000 bytes"
 msgstr "Tamanho da memória temporária de ficheiro: 240000 Byte"
 
-#: src/muuli_wdr.cpp:1937
+#: src/muuli_wdr.cpp:1944
 msgid "Use MMAP: memory-mapped file access (lower memory use)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1938
+#: src/muuli_wdr.cpp:1945
 msgid "Maps part files into memory instead of buffering them on the heap, lowering the process memory footprint. May reduce download speed on some disks; best for memory-constrained or upload-heavy hosts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1940
+#: src/muuli_wdr.cpp:1947
 msgid "Upload Queue Size: 5000 clients"
 msgstr "Tamanho da Lista de Espera de Upload: 5000 clientes"
 
-#: src/muuli_wdr.cpp:1944
+#: src/muuli_wdr.cpp:1951
 msgid "Server connection refresh interval: Disable"
 msgstr "Intervalo de actualização da ligação ao servidor: Desactivado"
 
-#: src/muuli_wdr.cpp:1948
+#: src/muuli_wdr.cpp:1955
 msgid "Disable computer's timed standby mode"
 msgstr "Desactivar o modo de espera temporizado do computador"
 
-#: src/muuli_wdr.cpp:1967
+#: src/muuli_wdr.cpp:1974
 msgid "Skin to use: "
 msgstr "Tema a utilizar: "
 
-#: src/muuli_wdr.cpp:1976
+#: src/muuli_wdr.cpp:1983
 msgid "Show \"Fast eD2k Links Handler\" in every window."
 msgstr "Mostrar a barra de adição rápida de ligações eD2k em todas as janelas."
 
-#: src/muuli_wdr.cpp:1979
+#: src/muuli_wdr.cpp:1986
 msgid "Show extended info on categories tabs"
 msgstr "Mostrar informação extra nos separadores de categorias"
 
-#: src/muuli_wdr.cpp:1982
+#: src/muuli_wdr.cpp:1989
 #, fuzzy
 msgid "Show application version on title"
 msgstr "Mostrar velocidades de transferência na barra de título"
 
-#: src/muuli_wdr.cpp:1984
+#: src/muuli_wdr.cpp:1991
 msgid "Show transfer rates on title"
 msgstr "Mostrar velocidades de transferência na barra de título"
 
-#: src/muuli_wdr.cpp:1986
+#: src/muuli_wdr.cpp:1993
 msgid "Before application name"
 msgstr "Antes do nome da aplicação"
 
-#: src/muuli_wdr.cpp:1988
+#: src/muuli_wdr.cpp:1995
 msgid "After application name"
 msgstr "Depois do nome da aplicação"
 
-#: src/muuli_wdr.cpp:1991
+#: src/muuli_wdr.cpp:1998
 msgid "Show overhead bandwidth"
 msgstr "Mostrar sobrecarga na largura de banda"
 
-#: src/muuli_wdr.cpp:1995
+#: src/muuli_wdr.cpp:2002
 msgid "Vertical toolbar orientation"
 msgstr "Orientação vertical da barra de ferramentas"
 
-#: src/muuli_wdr.cpp:1997
+#: src/muuli_wdr.cpp:2004
 msgid "Live column sorting (auto-reorder rows as their values change)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2004
+#: src/muuli_wdr.cpp:2011
 msgid "Download Queue Files"
 msgstr "Ficheiros na Fila de Espera dos Downloads"
 
-#: src/muuli_wdr.cpp:2007
+#: src/muuli_wdr.cpp:2014
 msgid "Show progress percentage"
 msgstr "Mostrar percentagem de progresso"
 
-#: src/muuli_wdr.cpp:2013
+#: src/muuli_wdr.cpp:2020
 msgid "Show progress bar"
 msgstr "Mostrar barra de progresso"
 
-#: src/muuli_wdr.cpp:2016
+#: src/muuli_wdr.cpp:2023
 msgid "Flat"
 msgstr "Plana"
 
-#: src/muuli_wdr.cpp:2020
+#: src/muuli_wdr.cpp:2027
 msgid "Round"
 msgstr "Arredondada"
 
-#: src/muuli_wdr.cpp:2038
+#: src/muuli_wdr.cpp:2045
 msgid "External Connection Parameters"
 msgstr "Parâmetros de Ligação Externa"
 
-#: src/muuli_wdr.cpp:2041
+#: src/muuli_wdr.cpp:2048
 msgid "Accept external connections"
 msgstr "Aceitar ligações externas"
 
-#: src/muuli_wdr.cpp:2048 src/muuli_wdr.cpp:2107
+#: src/muuli_wdr.cpp:2055 src/muuli_wdr.cpp:2114
 msgid "IP of the listening interface:"
 msgstr "IP da interface a escutar:"
 
-#: src/muuli_wdr.cpp:2051
+#: src/muuli_wdr.cpp:2058
 msgid "Enter here a valid ip in the a.b.c.d format for the listening EC interface. An empty field or 0.0.0.0 will mean any interface."
 msgstr "Insira um endereço IP válido no formato a.b.c.d para a interface que irá aguardar as LE. Um campo vazio ou 0.0.0.0 significará qualquer interface."
 
-#: src/muuli_wdr.cpp:2072 src/muuli_wdr.cpp:2156
+#: src/muuli_wdr.cpp:2079 src/muuli_wdr.cpp:2163
 msgid "TCP port:"
 msgstr "Porto TCP:"
 
-#: src/muuli_wdr.cpp:2078
+#: src/muuli_wdr.cpp:2085
 msgid "Enable UPnP port forwarding on the EC port"
 msgstr "Activar UPnP para configuração do encaminhamento no porto das LE"
 
-#: src/muuli_wdr.cpp:2082 src/muuli_wdr.cpp:3041
+#: src/muuli_wdr.cpp:2089 src/muuli_wdr.cpp:3048
 #: src/utils/wxCas/src/wxcasprefs.cpp:167
 msgid "Password"
 msgstr "Palavra-passe"
 
-#: src/muuli_wdr.cpp:2088
+#: src/muuli_wdr.cpp:2095
 #, fuzzy
 msgid "aMule API server parameters"
 msgstr "Parâmetros do servidor web"
 
-#: src/muuli_wdr.cpp:2091
+#: src/muuli_wdr.cpp:2098
 msgid "Run amuleapi (REST API) on startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2096
+#: src/muuli_wdr.cpp:2103
 #, fuzzy
 msgid "HTTP port:"
 msgstr "Porto TCP:"
 
-#: src/muuli_wdr.cpp:2110
+#: src/muuli_wdr.cpp:2117
 msgid "The interface amuleapi's HTTP server listens on. 127.0.0.1 (default) accepts only local connections; use 0.0.0.0 or a specific IP to expose it to other hosts (set an admin password below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2113
+#: src/muuli_wdr.cpp:2120
 #, fuzzy
 msgid "Admin password"
 msgstr "A verificar a palavra-passe\n"
 
-#: src/muuli_wdr.cpp:2118 src/muuli_wdr.cpp:2149
+#: src/muuli_wdr.cpp:2125 src/muuli_wdr.cpp:2156
 msgid "Low rights password"
 msgstr "Palavra-passe para controlo reduzido"
 
-#: src/muuli_wdr.cpp:2126
+#: src/muuli_wdr.cpp:2133
 msgid "Web server parameters"
 msgstr "Parâmetros do servidor web"
 
-#: src/muuli_wdr.cpp:2129
+#: src/muuli_wdr.cpp:2136
 #, fuzzy
 msgid "Run webserver on startup (deprecated)"
 msgstr "Executar o servidor web no arranque"
 
-#: src/muuli_wdr.cpp:2135
+#: src/muuli_wdr.cpp:2142
 msgid "Web template"
 msgstr "Aspecto da página web"
 
-#: src/muuli_wdr.cpp:2140
+#: src/muuli_wdr.cpp:2147
 msgid "Full rights password"
 msgstr "Palavra-passe para controlo total"
 
-#: src/muuli_wdr.cpp:2144
+#: src/muuli_wdr.cpp:2151
 msgid "Enable Low rights User"
 msgstr "Activar utilizador com permissões reduzidas"
 
-#: src/muuli_wdr.cpp:2163
+#: src/muuli_wdr.cpp:2170
 msgid "Enable UPnP port forwarding of the web server port"
 msgstr "Activar UPnP para encaminhamento do porto do servidor web"
 
-#: src/muuli_wdr.cpp:2168
+#: src/muuli_wdr.cpp:2175
 msgid "Web server UPnP TCP port (Optional)"
 msgstr "Porto TCP UPnP do servidor web (Opcional)"
 
-#: src/muuli_wdr.cpp:2176
+#: src/muuli_wdr.cpp:2183
 msgid "Page Refresh Time (in secs)"
 msgstr "Taxa de Actualização de Páginas (em segundos)"
 
-#: src/muuli_wdr.cpp:2183
+#: src/muuli_wdr.cpp:2190
 msgid "Enable Gzip compression"
 msgstr "Activar compressão Gzip"
 
-#: src/muuli_wdr.cpp:2217
+#: src/muuli_wdr.cpp:2224
 #, fuzzy
 msgid "Reset page to defaults"
 msgstr "Predefinição do sistema"
 
-#: src/muuli_wdr.cpp:2218
+#: src/muuli_wdr.cpp:2225
 msgid "Reset the settings on the current page to their default values."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2220 src/muuli_wdr.cpp:2306 src/ServerWnd.cpp:274
+#: src/muuli_wdr.cpp:2227 src/muuli_wdr.cpp:2313 src/ServerWnd.cpp:274
 #: src/ServerWnd.cpp:282
 msgid "OK"
 msgstr "OK"
 
-#: src/muuli_wdr.cpp:2222
+#: src/muuli_wdr.cpp:2229
 msgid "Click here to apply any changes made to the preferences."
 msgstr "Clique aqui para aplicar as alterações efectuadas nas preferências."
 
-#: src/muuli_wdr.cpp:2225
+#: src/muuli_wdr.cpp:2232
 msgid "Reset any changes made to the preferences."
 msgstr "Anular as alterações efectuadas nas preferências."
 
-#: src/muuli_wdr.cpp:2254
+#: src/muuli_wdr.cpp:2261
 msgid "Comment :"
 msgstr "Comentário :"
 
-#: src/muuli_wdr.cpp:2261
+#: src/muuli_wdr.cpp:2268
 msgid "Incoming Dir :"
 msgstr "Pasta de completos :"
 
-#: src/muuli_wdr.cpp:2270
+#: src/muuli_wdr.cpp:2277
 msgid "Change priority for new assigned files :"
 msgstr "Trocar prioridade nos novos ficheiros :"
 
-#: src/muuli_wdr.cpp:2274
+#: src/muuli_wdr.cpp:2281
 msgid "Don't change"
 msgstr "Não mudar"
 
-#: src/muuli_wdr.cpp:2286
+#: src/muuli_wdr.cpp:2293
 msgid "Select color for this Category (currently selected) :"
 msgstr "Seleccionar a cor para a categoria seleccionada :"
 
-#: src/muuli_wdr.cpp:2353 src/muuli_wdr.cpp:2372 src/muuli_wdr.cpp:2394
+#: src/muuli_wdr.cpp:2360 src/muuli_wdr.cpp:2379 src/muuli_wdr.cpp:2401
 msgid "Click this button to reset the log."
 msgstr "Clique para limpar o relatório."
 
-#: src/muuli_wdr.cpp:2413
+#: src/muuli_wdr.cpp:2420
 msgid "Click on this button to update the servers list from URL ..."
 msgstr "Clique neste botão para actualizar a lista de servidores a partir do endereço ..."
 
-#: src/muuli_wdr.cpp:2417
+#: src/muuli_wdr.cpp:2424
 msgid "Server list"
 msgstr "Lista de Servidores"
 
-#: src/muuli_wdr.cpp:2421
+#: src/muuli_wdr.cpp:2428
 msgid "Enter the url to a server.met file here and press the button to the left to update the list of known servers."
 msgstr "Insira a localização de um ficheiro server.met e pressione o botão à esquerda para actualizar a lista de servidores conhecidos."
 
-#: src/muuli_wdr.cpp:2426
+#: src/muuli_wdr.cpp:2433
 msgid "Add server manually: Name"
 msgstr "Adicionar servidor manualmente: Nome"
 
-#: src/muuli_wdr.cpp:2429
+#: src/muuli_wdr.cpp:2436
 msgid "Enter the name of the new server here"
 msgstr "Insira o nome do novo servidor"
 
-#: src/muuli_wdr.cpp:2431 src/ServerWnd.cpp:206
+#: src/muuli_wdr.cpp:2438 src/ServerWnd.cpp:206
 msgid "IP:Port"
 msgstr "IP:Porto"
 
-#: src/muuli_wdr.cpp:2434
+#: src/muuli_wdr.cpp:2441
 msgid "Enter the IP of the server here, using the x.x.x.x format."
 msgstr "Insira o IP do servidor, usando o formato x.x.x.x."
 
-#: src/muuli_wdr.cpp:2440
+#: src/muuli_wdr.cpp:2447
 msgid "Enter the port of the server here."
 msgstr "Insira o porto do servidor."
 
-#: src/muuli_wdr.cpp:2443
+#: src/muuli_wdr.cpp:2450
 msgid "Add manually a server (fill fields to the left before) ..."
 msgstr "Adicionar manualmente um servidor (preencher os campos ao lado) ..."
 
-#: src/muuli_wdr.cpp:2472
+#: src/muuli_wdr.cpp:2479
 msgid "aMule Log"
 msgstr "Relatório"
 
-#: src/muuli_wdr.cpp:2480
+#: src/muuli_wdr.cpp:2487
 msgid "Server Info"
 msgstr "Informações do Servidor"
 
-#: src/muuli_wdr.cpp:2484
+#: src/muuli_wdr.cpp:2491
 msgid "ED2K Info"
 msgstr "Informação ED2K"
 
-#: src/muuli_wdr.cpp:2488
+#: src/muuli_wdr.cpp:2495
 msgid "Kad Info"
 msgstr "Informação Kad"
 
-#: src/muuli_wdr.cpp:2516
+#: src/muuli_wdr.cpp:2523
 msgid "Click on this button to update the nodes list from URL ..."
 msgstr "Clique para actualizar a lista de nós a partir do endereço ..."
 
-#: src/muuli_wdr.cpp:2520
+#: src/muuli_wdr.cpp:2527
 msgid "Nodes (0)"
 msgstr "Nós (0)"
 
-#: src/muuli_wdr.cpp:2524
+#: src/muuli_wdr.cpp:2531
 msgid "Enter the url to a nodes.dat file here and press the button to the left to update the list of known nodes."
 msgstr "Insira o endereço de um ficheiro nodes.dat e pressione o botão à esquerda para actualizar a lista de nós conhecidos."
 
-#: src/muuli_wdr.cpp:2527
+#: src/muuli_wdr.cpp:2534
 msgid "Nodes stats"
 msgstr "Estado dos nós"
 
-#: src/muuli_wdr.cpp:2569
+#: src/muuli_wdr.cpp:2576
 msgid "Bootstrap"
 msgstr "Inicialização"
 
-#: src/muuli_wdr.cpp:2572
+#: src/muuli_wdr.cpp:2579
 msgid "New node"
 msgstr "Novo nó"
 
-#: src/muuli_wdr.cpp:2577
+#: src/muuli_wdr.cpp:2584
 msgid "IP:"
 msgstr "IP:"
 
-#: src/muuli_wdr.cpp:2597
+#: src/muuli_wdr.cpp:2604
 msgid "Port:"
 msgstr "Porto:"
 
-#: src/muuli_wdr.cpp:2610
+#: src/muuli_wdr.cpp:2617
 msgid "Bootstrap from known clients"
 msgstr "Arrancar a partir de clientes conhecidos"
 
-#: src/muuli_wdr.cpp:2612
+#: src/muuli_wdr.cpp:2619
 msgid "Disconnect Kad"
 msgstr "Desligar Kad"
 
-#: src/muuli_wdr.cpp:2646
+#: src/muuli_wdr.cpp:2653
 msgid "Use Secure User Identification"
 msgstr "Utilizar Identificação Segura de Utilizador"
 
-#: src/muuli_wdr.cpp:2648
+#: src/muuli_wdr.cpp:2655
 msgid "It is recommended to enable this option. You will not receive credits if SUI is not enabled."
 msgstr "É recomendado activar esta opção. Não receberá créditos se a Identificação Segura de Utilizador não estiver activada."
 
-#: src/muuli_wdr.cpp:2650
+#: src/muuli_wdr.cpp:2657
 msgid "Protocol Obfuscation"
 msgstr "Ofuscação do Protocolo"
 
-#: src/muuli_wdr.cpp:2653
+#: src/muuli_wdr.cpp:2660
 msgid "Support Protocol Obfuscation"
 msgstr "Suportar a Ofuscação do Protocolo"
 
-#: src/muuli_wdr.cpp:2655
+#: src/muuli_wdr.cpp:2662
 msgid "This option enabled Protocol Obfuscation, and makes aMule accept obfuscated connections from other clients."
 msgstr "Esta opção activa a Ofuscação do Protocolo e faz com que o aMule aceite ligações ofuscadas de outros clientes."
 
-#: src/muuli_wdr.cpp:2657
+#: src/muuli_wdr.cpp:2664
 msgid "Use obfuscation for outgoing connections"
 msgstr "Usar ofuscação em ligações para o exterior"
 
-#: src/muuli_wdr.cpp:2659
+#: src/muuli_wdr.cpp:2666
 msgid "This option makes aMule use Protocol Obfuscation when connecting other clients/servers."
 msgstr "Esta opção faz com que o aMule use a Ofuscação do Protocolo quando ligado a outros clientes/servidores."
 
-#: src/muuli_wdr.cpp:2661
+#: src/muuli_wdr.cpp:2668
 msgid "Accept only obfuscated connections"
 msgstr "Aceitar apenas ligações ofuscadas"
 
-#: src/muuli_wdr.cpp:2662
+#: src/muuli_wdr.cpp:2669
 msgid "This option makes aMule only accept obfuscated connections. You will have less sources, but all your traffic will be obfuscated"
 msgstr "Esta opção faz com que o aMUle aceite apenas ligações ofuscadas. Terá menos fontes, mas todo o tráfego será ofuscado"
 
-#: src/muuli_wdr.cpp:2667
+#: src/muuli_wdr.cpp:2674
 msgid "Everybody"
 msgstr "Todos"
 
-#: src/muuli_wdr.cpp:2669
+#: src/muuli_wdr.cpp:2676
 msgid "No one"
 msgstr "Ninguém"
 
-#: src/muuli_wdr.cpp:2671
+#: src/muuli_wdr.cpp:2678
 msgid "Who can see my shared files:"
 msgstr "Quem pode ver os meus ficheiros partilhados:"
 
-#: src/muuli_wdr.cpp:2672
+#: src/muuli_wdr.cpp:2679
 msgid "Select who can request to view a list of your shared files."
 msgstr "Seleccione quem pode pedir a lista dos seus ficheiros partilhados."
 
-#: src/muuli_wdr.cpp:2674
+#: src/muuli_wdr.cpp:2681
 msgid "IP-Filtering"
 msgstr "Filtragem de IP"
 
-#: src/muuli_wdr.cpp:2681
+#: src/muuli_wdr.cpp:2688
 msgid "Filter clients"
 msgstr "Filtrar clientes"
 
-#: src/muuli_wdr.cpp:2683
+#: src/muuli_wdr.cpp:2690
 msgid "Enable filtering of the client IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "Activar filtragem por IPs dos clientes definidos no ficheiro ~/.aMule/ipfilter.dat."
 
-#: src/muuli_wdr.cpp:2685
+#: src/muuli_wdr.cpp:2692
 msgid "Filter servers"
 msgstr "Filtrar servidores"
 
-#: src/muuli_wdr.cpp:2687
+#: src/muuli_wdr.cpp:2694
 msgid "Enable filtering of the server IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "Activar filtragem da lista de IPs definida no ficheiro ~/.aMule/ipfilter.dat."
 
-#: src/muuli_wdr.cpp:2691
+#: src/muuli_wdr.cpp:2698
 msgid "Reload List"
 msgstr "Recarregar a lista"
 
-#: src/muuli_wdr.cpp:2692
+#: src/muuli_wdr.cpp:2699
 msgid "Reload the list of IPs to filter from the file ~/.aMule/ipfilter.dat"
 msgstr "Recarregar a lista de IPs a filtrar a partir do ficheiro ~/.aMule/ipfilter.dat"
 
-#: src/muuli_wdr.cpp:2698
+#: src/muuli_wdr.cpp:2705
 msgid "URL:"
 msgstr "URL:"
 
-#: src/muuli_wdr.cpp:2702 src/muuli_wdr.cpp:2895
+#: src/muuli_wdr.cpp:2709 src/muuli_wdr.cpp:2902
 msgid "Update now"
 msgstr "Actualizar agora"
 
-#: src/muuli_wdr.cpp:2705
+#: src/muuli_wdr.cpp:2712
 msgid "Auto-update ipfilter at startup"
 msgstr "Actualizar o filtro de IPs automaticamente no arranque"
 
-#: src/muuli_wdr.cpp:2709
+#: src/muuli_wdr.cpp:2716
 msgid "Filtering Level:"
 msgstr "Nível de filtragem:"
 
-#: src/muuli_wdr.cpp:2715
+#: src/muuli_wdr.cpp:2722
 msgid "Always filter LAN IPs"
 msgstr "Filtrar sempre endereços IP de rede local"
 
-#: src/muuli_wdr.cpp:2718
+#: src/muuli_wdr.cpp:2725
 msgid "Paranoid handling of non-matching IPs"
 msgstr "Tratamento paranóico de IPs sem correspondência"
 
-#: src/muuli_wdr.cpp:2720
+#: src/muuli_wdr.cpp:2727
 msgid "Rejects a packet when its source IP differs from the IP the client claims (an anti-spoofing check). Disable only if it causes connection problems."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2722
+#: src/muuli_wdr.cpp:2729
 msgid "Use system-wide ipfilter.dat if available"
 msgstr "Utilizar ipfilter.dat global do sistema se disponível"
 
-#: src/muuli_wdr.cpp:2723
+#: src/muuli_wdr.cpp:2730
 #, fuzzy
 msgid "If there's no local ipfilter.dat found, allow usage of a system-wide ipfilter file."
 msgstr "Se não existir um ficheiro ipfilter.dat, permitir a utilização de um ficheiro ipfilter global do sistema."
 
-#: src/muuli_wdr.cpp:2740
+#: src/muuli_wdr.cpp:2747
 msgid "Enable Online-Signature"
 msgstr "Activar Assinatura Online"
 
-#: src/muuli_wdr.cpp:2742
+#: src/muuli_wdr.cpp:2749
 msgid "Enables the writing of the OS file, which can be used by external apps to create signatures and the like."
 msgstr "Activa a escrita do ficheiro da AO, o qual pode ser usado por aplicações externas para criar assinaturas e afins."
 
-#: src/muuli_wdr.cpp:2746
+#: src/muuli_wdr.cpp:2753
 msgid "Update Frequency (Secs):"
 msgstr "Frequência de Actualização (segundos):"
 
-#: src/muuli_wdr.cpp:2749
+#: src/muuli_wdr.cpp:2756
 msgid "Change the frequency (in seconds) of Online Signature updates."
 msgstr "Alterar a frequência (em segundos) das actualizações da assinatura Online."
 
-#: src/muuli_wdr.cpp:2757
+#: src/muuli_wdr.cpp:2764
 msgid "Save online signature file in: "
 msgstr "Gravar a assinatura Online em: "
 
-#: src/muuli_wdr.cpp:2763
+#: src/muuli_wdr.cpp:2770
 msgid "Click here to select the directory containing the the Online Signature files."
 msgstr "Clique para seleccionar a pasta que contém os ficheiros de Assinatura Online"
 
-#: src/muuli_wdr.cpp:2796
+#: src/muuli_wdr.cpp:2803
 msgid "Show country flags for clients"
 msgstr "Mostrar bandeiras de países para clientes"
 
-#: src/muuli_wdr.cpp:2797
+#: src/muuli_wdr.cpp:2804
 msgid "Render the country flag column in the transfers, queue and search views. Requires a valid MMDB GeoIP database (see below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2802
+#: src/muuli_wdr.cpp:2809
 #, fuzzy
 msgid "Database"
 msgstr "Taxa de transferência :"
 
-#: src/muuli_wdr.cpp:2818
+#: src/muuli_wdr.cpp:2825
 #, fuzzy
 msgid "Source:"
 msgstr "Fontes"
 
-#: src/muuli_wdr.cpp:2821
+#: src/muuli_wdr.cpp:2828
 msgid "DB-IP (free, no account)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2822
+#: src/muuli_wdr.cpp:2829
 msgid "MaxMind GeoLite2 (free, account required)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2823
+#: src/muuli_wdr.cpp:2830
 msgid "Custom URL"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2826
+#: src/muuli_wdr.cpp:2833
 msgid "Choose which provider supplies the GeoIP MMDB database. DB-IP is the default - no account required. MaxMind requires a free account + license key. Use Custom URL to point at any other MMDB host (e.g. a local mirror)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2843
+#: src/muuli_wdr.cpp:2850
 msgid ""
 "No configuration required.\n"
 "\n"
@@ -4847,11 +4861,11 @@ msgid ""
 "License: Creative Commons BY 4.0 - https://creativecommons.org/licenses/by/4.0/"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2856
+#: src/muuli_wdr.cpp:2863
 msgid "License key:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2862
+#: src/muuli_wdr.cpp:2869
 msgid ""
 "Sign up for a free MaxMind account, then generate a License Key:\n"
 "https://www.maxmind.com/en/geolite2/signup\n"
@@ -4861,226 +4875,226 @@ msgid ""
 "Requires attribution and account registration; refresh at least every 30 days."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2877
+#: src/muuli_wdr.cpp:2884
 #, fuzzy
 msgid "Download URL:"
 msgstr "Download: "
 
-#: src/muuli_wdr.cpp:2883
+#: src/muuli_wdr.cpp:2890
 msgid ""
 "Must point to an .mmdb file or a .gz / .tar.gz containing one.\n"
 "URL may include credentials (https://user:pass@host/...).\n"
 "License and attribution terms are set by the upstream URL - you are responsible."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2896
+#: src/muuli_wdr.cpp:2903
 msgid "Download the GeoIP database from the selected source."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2898
+#: src/muuli_wdr.cpp:2905
 #, fuzzy
 msgid "Auto-update on startup"
 msgstr "Actualizar o filtro de IPs automaticamente no arranque"
 
-#: src/muuli_wdr.cpp:2899
+#: src/muuli_wdr.cpp:2906
 msgid "Re-download the GeoIP database from the selected source every time aMule starts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2922
+#: src/muuli_wdr.cpp:2929
 msgid "Filter incoming messages (except current chat):"
 msgstr "Filtrar mensagens recebidas (excepto da conversa corrente):"
 
-#: src/muuli_wdr.cpp:2924
+#: src/muuli_wdr.cpp:2931
 msgid "Filter all messages"
 msgstr "Filtrar todas as mensagens"
 
-#: src/muuli_wdr.cpp:2926
+#: src/muuli_wdr.cpp:2933
 msgid "Filter messages from people not on your friend list"
 msgstr "Filtrar mensagens de utilizadores que não pertençam à lista de amigos"
 
-#: src/muuli_wdr.cpp:2928
+#: src/muuli_wdr.cpp:2935
 msgid "Filter messages from unknown clients"
 msgstr "Filtrar mensagens de clientes desconhecidos"
 
-#: src/muuli_wdr.cpp:2930
+#: src/muuli_wdr.cpp:2937
 msgid "Filter messages containing (use ',' as separator):"
 msgstr "Filtrar mensagens que contenham (usar ',' como separador):"
 
-#: src/muuli_wdr.cpp:2933 src/muuli_wdr.cpp:2944
+#: src/muuli_wdr.cpp:2940 src/muuli_wdr.cpp:2951
 msgid "add here the words amule should filter and block messages including it"
 msgstr "adicione as palavras que o aMule deve filtrar e bloquear as mensagens que as contenham"
 
-#: src/muuli_wdr.cpp:2935
+#: src/muuli_wdr.cpp:2942
 msgid "Show received messages in the log"
 msgstr "Mostrar mensagens recebidas no relatório"
 
-#: src/muuli_wdr.cpp:2938
+#: src/muuli_wdr.cpp:2945
 msgid "Comments"
 msgstr "Comentários"
 
-#: src/muuli_wdr.cpp:2941
+#: src/muuli_wdr.cpp:2948
 msgid "Filter comments containing (use ',' as separator):"
 msgstr "Filtrar comentários que contenham (usar ',' como separador):"
 
-#: src/muuli_wdr.cpp:2966
+#: src/muuli_wdr.cpp:2973
 msgid "Enable Proxy"
 msgstr "Activar Proxy"
 
-#: src/muuli_wdr.cpp:2967
+#: src/muuli_wdr.cpp:2974
 msgid "Enable/disable proxy support"
 msgstr "Activar/desactivar o suporte de proxy"
 
-#: src/muuli_wdr.cpp:2970
+#: src/muuli_wdr.cpp:2977
 msgid "Proxy type:"
 msgstr "Tipo de proxy:"
 
-#: src/muuli_wdr.cpp:2981
+#: src/muuli_wdr.cpp:2988
 msgid "Proxy host:"
 msgstr "Servidor:"
 
-#: src/muuli_wdr.cpp:2984
+#: src/muuli_wdr.cpp:2991
 msgid "The proxy host name"
 msgstr "O nome da máquina proxy"
 
-#: src/muuli_wdr.cpp:2986
+#: src/muuli_wdr.cpp:2993
 msgid "Proxy port:"
 msgstr "Porto do proxy:"
 
-#: src/muuli_wdr.cpp:2989
+#: src/muuli_wdr.cpp:2996
 msgid "The proxy port"
 msgstr "O porto do proxy"
 
-#: src/muuli_wdr.cpp:2991
+#: src/muuli_wdr.cpp:2998
 msgid "Enable authentication"
 msgstr "Activar autenticação"
 
-#: src/muuli_wdr.cpp:2992
+#: src/muuli_wdr.cpp:2999
 msgid "Enable/disable username/password authentication"
 msgstr "Activar/desactivar autenticação utilizador/palavra-passe"
 
-#: src/muuli_wdr.cpp:2995
+#: src/muuli_wdr.cpp:3002
 msgid "Username: "
 msgstr "Utilizador: "
 
-#: src/muuli_wdr.cpp:2998
+#: src/muuli_wdr.cpp:3005
 msgid "The username to use to connect to the proxy"
 msgstr "O nome de utilizador para ligar ao proxy"
 
-#: src/muuli_wdr.cpp:3000
+#: src/muuli_wdr.cpp:3007
 msgid "Password:"
 msgstr "Palavra-passe:"
 
-#: src/muuli_wdr.cpp:3003
+#: src/muuli_wdr.cpp:3010
 msgid "The password to use to connect to the proxy"
 msgstr "A palavra-passe a usar para ligar ao proxy"
 
-#: src/muuli_wdr.cpp:3022
+#: src/muuli_wdr.cpp:3029
 msgid "Connect to:"
 msgstr "Ligar a:"
 
-#: src/muuli_wdr.cpp:3031
+#: src/muuli_wdr.cpp:3038
 msgid "Login to remote amule"
 msgstr "Autenticação remota"
 
-#: src/muuli_wdr.cpp:3036
+#: src/muuli_wdr.cpp:3043
 msgid "User name"
 msgstr "Nome de utilizador"
 
-#: src/muuli_wdr.cpp:3047
+#: src/muuli_wdr.cpp:3054
 msgid "Remember those settings"
 msgstr "Lembrar estas preferências"
 
-#: src/muuli_wdr.cpp:3050
+#: src/muuli_wdr.cpp:3057
 #, fuzzy
 msgid "Force ZLIB compression"
 msgstr "Usar compressão gzip"
 
-#: src/muuli_wdr.cpp:3074
+#: src/muuli_wdr.cpp:3081
 msgid "Enable Verbose Debug-Logging."
 msgstr "Activar Relatório detalhado para Depuração."
 
-#: src/muuli_wdr.cpp:3076
+#: src/muuli_wdr.cpp:3083
 #, fuzzy
 msgid "Only to Logfile"
 msgstr "&Abrir o ficheiro"
 
-#: src/muuli_wdr.cpp:3078
+#: src/muuli_wdr.cpp:3085
 msgid "Message Categories:"
 msgstr "Categorias de Mensagens:"
 
-#: src/muuli_wdr.cpp:3102 src/PartFileConvertDlg.cpp:160
+#: src/muuli_wdr.cpp:3109 src/PartFileConvertDlg.cpp:160
 msgid "Waiting..."
 msgstr "A aguardar..."
 
-#: src/muuli_wdr.cpp:3122
+#: src/muuli_wdr.cpp:3129
 msgid "Add imports"
 msgstr "Adicionar importações"
 
-#: src/muuli_wdr.cpp:3125
+#: src/muuli_wdr.cpp:3132
 msgid "Retry selected"
 msgstr "Reassumir seleccionados"
 
-#: src/muuli_wdr.cpp:3127
+#: src/muuli_wdr.cpp:3134
 msgid "Remove selected"
 msgstr "Remover seleccionados"
 
-#: src/muuli_wdr.cpp:3190
+#: src/muuli_wdr.cpp:3197
 msgid "Event Types"
 msgstr "Tipos de eventos"
 
-#: src/muuli_wdr.cpp:3209
+#: src/muuli_wdr.cpp:3216
 msgid "Statistics and queued clients for selected file(s) : Session / All time"
 msgstr "Estatísticas e clientes em espera para o(s) ficheiro(s) seleccionado(s) : Sessão / Desde sempre"
 
-#: src/muuli_wdr.cpp:3233
+#: src/muuli_wdr.cpp:3240
 msgid "Active Uploads"
 msgstr "Uploads Activos"
 
-#: src/muuli_wdr.cpp:3247
+#: src/muuli_wdr.cpp:3254
 msgid "Percent of total files"
 msgstr "Percentagem dos ficheiros totais"
 
-#: src/muuli_wdr.cpp:3299
+#: src/muuli_wdr.cpp:3306
 msgid "Show Clients for"
 msgstr "Mostrar Clientes para"
 
-#: src/muuli_wdr.cpp:3301
+#: src/muuli_wdr.cpp:3308
 msgid "All files"
 msgstr "Todos os ficheiros"
 
-#: src/muuli_wdr.cpp:3304
+#: src/muuli_wdr.cpp:3311
 msgid "Selected files"
 msgstr "Ficheiros seleccionados"
 
-#: src/muuli_wdr.cpp:3307
+#: src/muuli_wdr.cpp:3314
 msgid "Active uploads only"
 msgstr "Apenas os uploads activos"
 
-#: src/muuli_wdr.cpp:3314
+#: src/muuli_wdr.cpp:3321
 msgid "Reload:"
 msgstr "Recarregar:"
 
-#: src/muuli_wdr.cpp:3318
+#: src/muuli_wdr.cpp:3325
 msgid "Reload your shared files"
 msgstr "Recarregar os seus ficheiros partilhados"
 
-#: src/muuli_wdr.cpp:3381
+#: src/muuli_wdr.cpp:3388
 msgid "Send"
 msgstr "Enviar"
 
-#: src/muuli_wdr.cpp:3382
+#: src/muuli_wdr.cpp:3389
 msgid "Sends the specified message."
 msgstr "Envia a mensagem especificada."
 
-#: src/muuli_wdr.cpp:3386
+#: src/muuli_wdr.cpp:3393
 msgid "Close this chat-session."
 msgstr "Fechar esta conversa."
 
-#: src/muuli_wdr.cpp:3409
+#: src/muuli_wdr.cpp:3416
 msgid "Connect to any server and/or Kad"
 msgstr "Ligar a qualquer servidor e/ou Kad"
 
-#: src/muuli_wdr.cpp:3415 src/SharedFilesCtrl.cpp:142 src/Statistics.cpp:941
+#: src/muuli_wdr.cpp:3422 src/SharedFilesCtrl.cpp:142 src/Statistics.cpp:941
 msgid "Shared Files"
 msgstr "Ficheiros Partilhados"
 
@@ -5439,189 +5453,189 @@ msgstr "Transferido"
 msgid "ERROR: Failed to open partfile '%s'"
 msgstr "ERRO: Falhou ao abrir ficheiro de partes '%s'"
 
-#: src/Preferences.cpp:673
+#: src/Preferences.cpp:674
 msgid "System default"
 msgstr "Predefinição do sistema"
 
-#: src/Preferences.cpp:674
+#: src/Preferences.cpp:675
 msgid "Albanian"
 msgstr "Albanês"
 
-#: src/Preferences.cpp:675
+#: src/Preferences.cpp:676
 msgid "Arabic"
 msgstr "Árabe"
 
-#: src/Preferences.cpp:676
+#: src/Preferences.cpp:677
 msgid "Asturian"
 msgstr "Asturiano"
 
-#: src/Preferences.cpp:677
+#: src/Preferences.cpp:678
 msgid "Basque"
 msgstr "Basco"
 
-#: src/Preferences.cpp:678
+#: src/Preferences.cpp:679
 msgid "Bulgarian"
 msgstr "Búlgaro"
 
-#: src/Preferences.cpp:679
+#: src/Preferences.cpp:680
 msgid "Catalan"
 msgstr "Catalão"
 
-#: src/Preferences.cpp:680
+#: src/Preferences.cpp:681
 msgid "Chinese (Simplified)"
 msgstr "Chinês (Simplificado)"
 
-#: src/Preferences.cpp:681
+#: src/Preferences.cpp:682
 msgid "Chinese (Traditional)"
 msgstr "Chinês (Tradicional)"
 
-#: src/Preferences.cpp:682
+#: src/Preferences.cpp:683
 msgid "Croatian"
 msgstr "Croata"
 
-#: src/Preferences.cpp:683
+#: src/Preferences.cpp:684
 msgid "Czech"
 msgstr "Checo"
 
-#: src/Preferences.cpp:684
+#: src/Preferences.cpp:685
 msgid "Danish"
 msgstr "Dinamarquês"
 
-#: src/Preferences.cpp:685
+#: src/Preferences.cpp:686
 msgid "Dutch"
 msgstr "Holandês"
 
-#: src/Preferences.cpp:686
+#: src/Preferences.cpp:687
 msgid "English (U.K.)"
 msgstr "Inglês"
 
-#: src/Preferences.cpp:687
+#: src/Preferences.cpp:688
 #, fuzzy
 msgid "English (U.S.)"
 msgstr "Inglês"
 
-#: src/Preferences.cpp:688
+#: src/Preferences.cpp:689
 msgid "Estonian"
 msgstr "Estoniano"
 
-#: src/Preferences.cpp:689
+#: src/Preferences.cpp:690
 msgid "Finnish"
 msgstr "Finlandês"
 
-#: src/Preferences.cpp:690
+#: src/Preferences.cpp:691
 msgid "French"
 msgstr "Francês"
 
-#: src/Preferences.cpp:691
+#: src/Preferences.cpp:692
 msgid "Galician"
 msgstr "Galego"
 
-#: src/Preferences.cpp:692
+#: src/Preferences.cpp:693
 msgid "German"
 msgstr "Alemão"
 
-#: src/Preferences.cpp:693
+#: src/Preferences.cpp:694
 msgid "Greek"
 msgstr "Grego"
 
-#: src/Preferences.cpp:694
+#: src/Preferences.cpp:695
 msgid "Hebrew"
 msgstr "Hebreu"
 
-#: src/Preferences.cpp:695
+#: src/Preferences.cpp:696
 msgid "Hungarian"
 msgstr "Húngaro"
 
-#: src/Preferences.cpp:696
+#: src/Preferences.cpp:697
 msgid "Italian"
 msgstr "Italiano"
 
-#: src/Preferences.cpp:697
+#: src/Preferences.cpp:698
 msgid "Japanese"
 msgstr "Japonês"
 
-#: src/Preferences.cpp:698
+#: src/Preferences.cpp:699
 msgid "Korean"
 msgstr "Coreano"
 
-#: src/Preferences.cpp:699
+#: src/Preferences.cpp:700
 msgid "Latvian"
 msgstr ""
 
-#: src/Preferences.cpp:700
+#: src/Preferences.cpp:701
 msgid "Lithuanian"
 msgstr "Lituano"
 
-#: src/Preferences.cpp:701
+#: src/Preferences.cpp:702
 msgid "Norwegian (Nynorsk)"
 msgstr "Norueguês (Nynorsk)"
 
-#: src/Preferences.cpp:702
+#: src/Preferences.cpp:703
 msgid "Polish"
 msgstr "Polaco"
 
-#: src/Preferences.cpp:703
+#: src/Preferences.cpp:704
 msgid "Portuguese"
 msgstr "Português"
 
-#: src/Preferences.cpp:704
+#: src/Preferences.cpp:705
 msgid "Portuguese (Brazilian)"
 msgstr "Português (Brasil)"
 
-#: src/Preferences.cpp:705
+#: src/Preferences.cpp:706
 msgid "Romanian"
 msgstr "Romeno"
 
-#: src/Preferences.cpp:706
+#: src/Preferences.cpp:707
 msgid "Russian"
 msgstr "Russo"
 
-#: src/Preferences.cpp:707
+#: src/Preferences.cpp:708
 msgid "Slovenian"
 msgstr "Esloveno"
 
-#: src/Preferences.cpp:708
+#: src/Preferences.cpp:709
 msgid "Spanish"
 msgstr "Espanhol"
 
-#: src/Preferences.cpp:709
+#: src/Preferences.cpp:710
 msgid "Swedish"
 msgstr "Sueco"
 
-#: src/Preferences.cpp:710
+#: src/Preferences.cpp:711
 msgid "Turkish"
 msgstr "Turco"
 
-#: src/Preferences.cpp:711
+#: src/Preferences.cpp:712
 msgid "Ukrainian"
 msgstr "Ucraniano"
 
-#: src/Preferences.cpp:814
+#: src/Preferences.cpp:815
 msgid "Change Language"
 msgstr "Alterar Idioma"
 
-#: src/Preferences.cpp:878
+#: src/Preferences.cpp:879
 msgid "There are no translations installed for aMule"
 msgstr ""
 
-#: src/Preferences.cpp:879
+#: src/Preferences.cpp:880
 #, fuzzy
 msgid "No languages available"
 msgstr "Indisponível"
 
-#: src/Preferences.cpp:1010
+#: src/Preferences.cpp:1011
 msgid "no options available"
 msgstr "sem opções disponíveis"
 
-#: src/Preferences.cpp:2179
+#: src/Preferences.cpp:2182
 msgid "Invalid category found, skipping"
 msgstr "Categoria inválida encontrada, a ignorar"
 
-#: src/Preferences.cpp:2348
+#: src/Preferences.cpp:2351
 msgid "TCP port can't be higher than 65532 due to server UDP socket being TCP+3"
 msgstr "O porto TCP não pode ser superior a 65532 porque o socket UDP do servidor tem de ser TCP+3"
 
-#: src/Preferences.cpp:2349
+#: src/Preferences.cpp:2352
 #, c-format
 msgid "Default port will be used (%d)"
 msgstr "O porto predefinido será usado (%d)"
@@ -6132,24 +6146,28 @@ msgstr "Recarrega a lista de ficheiros partilhados."
 msgid "Shared folder"
 msgstr "Pastas partilhadas"
 
-#: src/SearchDlg.cpp:425
+#: src/SearchDlg.cpp:280
+msgid "Clear search history"
+msgstr ""
+
+#: src/SearchDlg.cpp:584
 msgid "It's impossible to search when both eD2k and Kademlia are disabled."
 msgstr ""
 
-#: src/SearchDlg.cpp:426 src/SearchListCtrl.cpp:858
+#: src/SearchDlg.cpp:585 src/SearchListCtrl.cpp:858
 #, fuzzy
 msgid "Search error"
 msgstr "Pesquisas"
 
-#: src/SearchDlg.cpp:768
+#: src/SearchDlg.cpp:929
 msgid "Min size must be smaller than max size. Max size ignored."
 msgstr "O Tamanho mínimo tem de ser menor que o tamanho máximo. Tamanho máximo ignorado."
 
-#: src/SearchDlg.cpp:769 src/SearchDlg.cpp:851
+#: src/SearchDlg.cpp:930 src/SearchDlg.cpp:1012
 msgid "Search warning"
 msgstr "Aviso de pesquisa"
 
-#: src/SearchDlg.cpp:929 src/SearchListCtrl.cpp:735
+#: src/SearchDlg.cpp:1092 src/SearchListCtrl.cpp:735
 msgid "Main"
 msgstr "Principal"
 

--- a/po/pt_PT.po
+++ b/po/pt_PT.po
@@ -17,7 +17,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-28 12:17+0200\n"
+"POT-Creation-Date: 2026-07-28 13:09+0200\n"
 "PO-Revision-Date: 2026-07-27 11:44+0000\n"
 "Last-Translator: Luís Picciochi Oliveira <Pitxyoki@Gmail.com>\n"
 "Language-Team: Portuguese <traduz@debianpt.org>\n"
@@ -299,7 +299,7 @@ msgid "Password set and external connections enabled."
 msgstr "Palavra-passe definida e permitidas as ligações externas."
 
 #: src/amule.cpp:755 src/KadDlg.cpp:176 src/KadDlg.cpp:185
-#: src/PrefsUnifiedDlg.cpp:1461 src/SharedFilesCtrl.cpp:476
+#: src/PrefsUnifiedDlg.cpp:1470 src/SharedFilesCtrl.cpp:476
 msgid "WARNING"
 msgstr "AVISO"
 
@@ -337,7 +337,7 @@ msgstr "Pediu para executar o servidor web no arranque, mas o executável não p
 #: src/amule-remote-gui.cpp:603 src/amule-remote-gui.cpp:671
 #: src/amule-remote-gui.cpp:709 src/amule-remote-gui.cpp:1282
 #: src/amule-remote-gui.cpp:1345 src/amule-remote-gui.cpp:1372
-#: src/DownloadQueue.cpp:1481 src/PrefsUnifiedDlg.cpp:1247
+#: src/DownloadQueue.cpp:1481 src/PrefsUnifiedDlg.cpp:1256
 msgid "ERROR"
 msgstr "ERRO"
 
@@ -599,36 +599,36 @@ msgstr "Visite https://github.com/amule-org/amule/releases/latest para verificar
 msgid "FATAL ERROR: Failed to create Timer"
 msgstr "ERRO FATAL: Falha ao criar Temporizador"
 
-#: src/amuleDlg.cpp:361 src/amuleDlg.cpp:1787 src/amuleDlg.cpp:2033
-#: src/muuli_wdr.cpp:1492 src/muuli_wdr.cpp:3449
+#: src/amuleDlg.cpp:361 src/amuleDlg.cpp:1810 src/amuleDlg.cpp:2056
+#: src/muuli_wdr.cpp:1492 src/muuli_wdr.cpp:3453
 msgid "Networks"
 msgstr "Redes"
 
-#: src/amuleDlg.cpp:362 src/amuleDlg.cpp:1793 src/muuli_wdr.cpp:3450
+#: src/amuleDlg.cpp:362 src/amuleDlg.cpp:1816 src/muuli_wdr.cpp:3454
 msgid "Searches"
 msgstr "Pesquisas"
 
-#: src/amuleDlg.cpp:363 src/amuleDlg.cpp:1799 src/DownloadListCtrl.cpp:740
-#: src/muuli_wdr.cpp:392 src/muuli_wdr.cpp:1585 src/muuli_wdr.cpp:3451
+#: src/amuleDlg.cpp:363 src/amuleDlg.cpp:1822 src/DownloadListCtrl.cpp:740
+#: src/muuli_wdr.cpp:392 src/muuli_wdr.cpp:1585 src/muuli_wdr.cpp:3455
 #: src/Statistics.cpp:829
 msgid "Downloads"
 msgstr "Downloads"
 
-#: src/amuleDlg.cpp:364 src/amuleDlg.cpp:1805 src/muuli_wdr.cpp:3325
+#: src/amuleDlg.cpp:364 src/amuleDlg.cpp:1828 src/muuli_wdr.cpp:3329
 msgid "Shared files"
 msgstr "Ficheiros partilhados"
 
-#: src/amuleDlg.cpp:365 src/amuleDlg.cpp:1811 src/muuli_wdr.cpp:2957
-#: src/muuli_wdr.cpp:3407 src/muuli_wdr.cpp:3454
+#: src/amuleDlg.cpp:365 src/amuleDlg.cpp:1834 src/muuli_wdr.cpp:2961
+#: src/muuli_wdr.cpp:3411 src/muuli_wdr.cpp:3458
 msgid "Messages"
 msgstr "Mensagens"
 
-#: src/amuleDlg.cpp:366 src/amuleDlg.cpp:1817 src/muuli_wdr.cpp:3455
+#: src/amuleDlg.cpp:366 src/amuleDlg.cpp:1840 src/muuli_wdr.cpp:3459
 #: src/PrefsUnifiedDlg.cpp:314 src/Statistics.cpp:779 src/Statistics.cpp:1235
 msgid "Statistics"
 msgstr "Estatísticas"
 
-#: src/amuleDlg.cpp:368 src/amuleDlg.cpp:1824 src/muuli_wdr.cpp:3457
+#: src/amuleDlg.cpp:368 src/amuleDlg.cpp:1847 src/muuli_wdr.cpp:3461
 #: src/PrefsUnifiedDlg.cpp:330 src/utils/wxCas/src/wxcasprefs.cpp:39
 msgid "Preferences"
 msgstr "Preferências"
@@ -687,8 +687,8 @@ msgstr "Kad: Desligado"
 #: src/amuleDlg.cpp:1029 src/DownloadListCtrl.cpp:505
 #: src/DownloadListCtrl.cpp:749 src/FriendListCtrl.cpp:180
 #: src/muuli_wdr.cpp:731 src/muuli_wdr.cpp:782 src/muuli_wdr.cpp:846
-#: src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2262 src/muuli_wdr.cpp:2347
-#: src/muuli_wdr.cpp:3095 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
+#: src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2266 src/muuli_wdr.cpp:2351
+#: src/muuli_wdr.cpp:3099 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
 #: src/ServerListCtrl.cpp:606 src/TransferWnd.cpp:378
 #: src/utils/wxCas/src/wxcasprefs.cpp:235
 msgid "Cancel"
@@ -699,7 +699,7 @@ msgid "Stop the current connection attempts"
 msgstr "Cancela as tentativas de ligação actuais"
 
 #: src/amuleDlg.cpp:1035 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976
-#: src/muuli_wdr.cpp:2485
+#: src/muuli_wdr.cpp:2489
 msgid "Disconnect"
 msgstr "Desligar"
 
@@ -708,7 +708,7 @@ msgid "Disconnect from the currently connected networks"
 msgstr "Desligar das redes presentemente ligadas"
 
 #: src/amuleDlg.cpp:1041 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979
-#: src/muuli_wdr.cpp:2640 src/muuli_wdr.cpp:3092 src/muuli_wdr.cpp:3447
+#: src/muuli_wdr.cpp:2644 src/muuli_wdr.cpp:3096 src/muuli_wdr.cpp:3451
 msgid "Connect"
 msgstr "Ligar"
 
@@ -763,7 +763,7 @@ msgstr "Confirmação de saída"
 msgid "Launch Command: "
 msgstr "Executar Comando: "
 
-#: src/amuleDlg.cpp:1632 src/muuli_wdr.cpp:1982 src/Preferences.cpp:979
+#: src/amuleDlg.cpp:1632 src/muuli_wdr.cpp:1986 src/Preferences.cpp:979
 msgid "- default -"
 msgstr "- predefinição -"
 
@@ -777,60 +777,60 @@ msgstr "Pasta para os temas '%s' não existe"
 msgid "WARNING: Unable to open skin file '%s' for read"
 msgstr "AVISO: Não é possível abrir ficheiro de tema '%s' para leitura"
 
-#: src/amuleDlg.cpp:1791 src/muuli_wdr.cpp:3449
+#: src/amuleDlg.cpp:1814 src/muuli_wdr.cpp:3453
 msgid "Networks Window"
 msgstr "Janela de Redes"
 
-#: src/amuleDlg.cpp:1797 src/muuli_wdr.cpp:3450
+#: src/amuleDlg.cpp:1820 src/muuli_wdr.cpp:3454
 msgid "Searches Window"
 msgstr "Janela de Pesquisas"
 
-#: src/amuleDlg.cpp:1803 src/muuli_wdr.cpp:3451
+#: src/amuleDlg.cpp:1826 src/muuli_wdr.cpp:3455
 msgid "Downloads Window"
 msgstr "Janela de Downloads"
 
-#: src/amuleDlg.cpp:1809 src/muuli_wdr.cpp:3453
+#: src/amuleDlg.cpp:1832 src/muuli_wdr.cpp:3457
 msgid "Shared Files Window"
 msgstr "Janela de Ficheiros Partilhados"
 
-#: src/amuleDlg.cpp:1815 src/muuli_wdr.cpp:3454
+#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3458
 msgid "Messages Window"
 msgstr "Janela de Mensagens"
 
-#: src/amuleDlg.cpp:1821 src/muuli_wdr.cpp:3455
+#: src/amuleDlg.cpp:1844 src/muuli_wdr.cpp:3459
 msgid "Statistics Graph Window"
 msgstr "Janela de Estatísticas"
 
-#: src/amuleDlg.cpp:1828 src/muuli_wdr.cpp:3457
+#: src/amuleDlg.cpp:1851 src/muuli_wdr.cpp:3461
 msgid "Preferences Settings Window"
 msgstr "Janela de Preferências"
 
-#: src/amuleDlg.cpp:1831 src/muuli_wdr.cpp:3458
+#: src/amuleDlg.cpp:1854 src/muuli_wdr.cpp:3462
 msgid "Import"
 msgstr "Importar"
 
-#: src/amuleDlg.cpp:1835 src/muuli_wdr.cpp:3458
+#: src/amuleDlg.cpp:1858 src/muuli_wdr.cpp:3462
 msgid "The partfile importer tool"
 msgstr "A ferramenta de importação de ficheiro de partes"
 
-#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3459
+#: src/amuleDlg.cpp:1861 src/muuli_wdr.cpp:3463
 #: src/utils/aLinkCreator/src/alcframe.cpp:262
 msgid "About"
 msgstr "Acerca"
 
-#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3459
+#: src/amuleDlg.cpp:1861 src/muuli_wdr.cpp:3463
 msgid "About/Help"
 msgstr "Acerca/Ajuda"
 
-#: src/amuleDlg.cpp:2036
+#: src/amuleDlg.cpp:2059
 msgid "eD2k network"
 msgstr "Rede eD2k"
 
-#: src/amuleDlg.cpp:2039
+#: src/amuleDlg.cpp:2062
 msgid "Kad network"
 msgstr "Rede Kad"
 
-#: src/amuleDlg.cpp:2039
+#: src/amuleDlg.cpp:2062
 msgid "No network"
 msgstr "Sem rede"
 
@@ -1363,19 +1363,19 @@ msgstr "Automática [Alta]"
 msgid "Very low"
 msgstr "Muito baixa"
 
-#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:743 src/muuli_wdr.cpp:2313
+#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:743 src/muuli_wdr.cpp:2317
 #: src/ServerListCtrl.cpp:263 src/ServerListCtrl.cpp:456
 #: src/SharedFilesCtrl.cpp:145
 msgid "Low"
 msgstr "Baixa"
 
-#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:744 src/muuli_wdr.cpp:2314
+#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:744 src/muuli_wdr.cpp:2318
 #: src/ServerListCtrl.cpp:266 src/ServerListCtrl.cpp:457
 #: src/SharedFilesCtrl.cpp:146
 msgid "Normal"
 msgstr "Normal"
 
-#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:745 src/muuli_wdr.cpp:2315
+#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:745 src/muuli_wdr.cpp:2319
 #: src/ServerListCtrl.cpp:269 src/ServerListCtrl.cpp:458
 #: src/SharedFilesCtrl.cpp:147
 msgid "High"
@@ -1467,7 +1467,7 @@ msgstr "Servidor Local"
 msgid "Remote Server"
 msgstr "Servidor Remoto"
 
-#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3212
+#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3216
 #: src/SearchDlg.cpp:119 src/TextClient.cpp:911
 msgid "Kad"
 msgstr "Kad"
@@ -1539,7 +1539,7 @@ msgstr "Parte"
 msgid "Size"
 msgstr "Tamanho"
 
-#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3279
+#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3283
 msgid "Transferred"
 msgstr "Transferido"
 
@@ -1597,7 +1597,7 @@ msgstr ""
 "Comentário de: %s (%s)\n"
 "\n"
 
-#: src/DownloadListCtrl.cpp:746 src/muuli_wdr.cpp:2316
+#: src/DownloadListCtrl.cpp:746 src/muuli_wdr.cpp:2320
 #: src/SharedFilesCtrl.cpp:150
 msgid "Auto"
 msgstr "Automática"
@@ -1635,7 +1635,7 @@ msgid "Extended Options"
 msgstr "Opções Estendidas"
 
 #: src/DownloadListCtrl.cpp:770 src/DownloadListCtrl.cpp:822
-#: src/muuli_wdr.cpp:1800
+#: src/muuli_wdr.cpp:1804
 msgid "Preview"
 msgstr "Pré-visualizar"
 
@@ -2436,23 +2436,23 @@ msgid ""
 "want downloads on a different (e.g. larger) disk."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:549 src/FirstRunWizard.cpp:611 src/muuli_wdr.cpp:1712
+#: src/FirstRunWizard.cpp:549 src/FirstRunWizard.cpp:611 src/muuli_wdr.cpp:1716
 msgid "Destination folder for downloads"
 msgstr "Pasta de destino para downloads"
 
 #: src/FirstRunWizard.cpp:553 src/FirstRunWizard.cpp:569 src/muuli_wdr.cpp:1349
-#: src/muuli_wdr.cpp:1366 src/muuli_wdr.cpp:1687 src/muuli_wdr.cpp:1718
-#: src/muuli_wdr.cpp:1730 src/muuli_wdr.cpp:2800
+#: src/muuli_wdr.cpp:1366 src/muuli_wdr.cpp:1691 src/muuli_wdr.cpp:1722
+#: src/muuli_wdr.cpp:1734 src/muuli_wdr.cpp:2804
 #: src/utils/aLinkCreator/src/alcframe.cpp:135
 #: src/utils/wxCas/src/wxcasprefs.cpp:52 src/utils/wxCas/src/wxcasprefs.cpp:118
 msgid "Browse"
 msgstr "Procurar"
 
-#: src/FirstRunWizard.cpp:559 src/muuli_wdr.cpp:1723
+#: src/FirstRunWizard.cpp:559 src/muuli_wdr.cpp:1727
 msgid "(All files in this folder are shared with other peers)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:565 src/FirstRunWizard.cpp:624 src/muuli_wdr.cpp:1725
+#: src/FirstRunWizard.cpp:565 src/FirstRunWizard.cpp:624 src/muuli_wdr.cpp:1729
 msgid "Folder for temporary download files"
 msgstr "Pasta para ficheiros temporários"
 
@@ -2483,7 +2483,7 @@ msgstr "Erro ao abrir o ficheiro de lista de amigos 'emfriends.met' para escrita
 msgid "CRITICAL - no client on StartChatSession"
 msgstr "CRÍTICO - sem cliente no StartChatSession"
 
-#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2706 src/muuli_wdr.cpp:3383
+#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2710 src/muuli_wdr.cpp:3387
 msgid "Friends"
 msgstr "Amigos"
 
@@ -2594,8 +2594,8 @@ msgstr "Nenhum"
 msgid "No"
 msgstr "Não"
 
-#: src/GenericClientListCtrl.cpp:1216 src/PrefsUnifiedDlg.cpp:2898
-#: src/PrefsUnifiedDlg.cpp:2948 src/ServerListCtrl.cpp:276
+#: src/GenericClientListCtrl.cpp:1216 src/PrefsUnifiedDlg.cpp:2907
+#: src/PrefsUnifiedDlg.cpp:2957 src/ServerListCtrl.cpp:276
 msgid "Yes"
 msgstr "Sim"
 
@@ -2764,10 +2764,10 @@ msgstr "Porto inválido para arranque"
 msgid "Please fill all fields required"
 msgstr "Por favor, preencha todos os campos pedidos"
 
-#: src/KadDlg.cpp:192 src/PartFile.cpp:1031 src/PrefsUnifiedDlg.cpp:1134
-#: src/PrefsUnifiedDlg.cpp:1204 src/PrefsUnifiedDlg.cpp:1405
-#: src/PrefsUnifiedDlg.cpp:1663 src/PrefsUnifiedDlg.cpp:1673
-#: src/PrefsUnifiedDlg.cpp:1690 src/PrefsUnifiedDlg.cpp:1738
+#: src/KadDlg.cpp:192 src/PartFile.cpp:1031 src/PrefsUnifiedDlg.cpp:1143
+#: src/PrefsUnifiedDlg.cpp:1213 src/PrefsUnifiedDlg.cpp:1414
+#: src/PrefsUnifiedDlg.cpp:1672 src/PrefsUnifiedDlg.cpp:1682
+#: src/PrefsUnifiedDlg.cpp:1699 src/PrefsUnifiedDlg.cpp:1747
 msgid "Message"
 msgstr "Mensagem"
 
@@ -2869,7 +2869,7 @@ msgstr "Razão de partilha"
 msgid "Uploaded"
 msgstr "Enviado"
 
-#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3263
+#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3267
 msgid "Requested"
 msgstr "Pedido"
 
@@ -2993,7 +2993,7 @@ msgid "WARNING: "
 msgstr "AVISO: "
 
 #: src/MuleNotebook.cpp:179 src/muuli_wdr.cpp:817 src/muuli_wdr.cpp:1229
-#: src/muuli_wdr.cpp:3167 src/muuli_wdr.cpp:3423
+#: src/muuli_wdr.cpp:3171 src/muuli_wdr.cpp:3427
 msgid "Close"
 msgstr "Fechar"
 
@@ -3011,7 +3011,7 @@ msgid "Paste"
 msgstr "Colar"
 
 #: src/MuleTextCtrl.cpp:89 src/muuli_wdr.cpp:358 src/muuli_wdr.cpp:757
-#: src/muuli_wdr.cpp:2390 src/muuli_wdr.cpp:2409 src/muuli_wdr.cpp:2431
+#: src/muuli_wdr.cpp:2394 src/muuli_wdr.cpp:2413 src/muuli_wdr.cpp:2435
 #: src/utils/aLinkCreator/src/alcframe.cpp:142
 msgid "Clear"
 msgstr "Limpar"
@@ -3110,7 +3110,7 @@ msgstr "Sair"
 
 #: src/MuleTrayIcon.cpp:579 src/MuleTrayIcon.cpp:945 src/MuleTrayIcon.cpp:965
 #: src/muuli_wdr.cpp:1398 src/muuli_wdr.cpp:1406 src/muuli_wdr.cpp:1413
-#: src/muuli_wdr.cpp:1846 src/muuli_wdr.cpp:1852 src/OtherFunctions.cpp:91
+#: src/muuli_wdr.cpp:1850 src/muuli_wdr.cpp:1856 src/OtherFunctions.cpp:91
 #: src/StatisticsDlg.cpp:93 src/StatisticsDlg.cpp:95
 msgid "kB/s"
 msgstr "kB/s"
@@ -3352,7 +3352,7 @@ msgstr "Bytes"
 msgid "KB"
 msgstr "kB"
 
-#: src/muuli_wdr.cpp:274 src/muuli_wdr.cpp:293 src/muuli_wdr.cpp:1631
+#: src/muuli_wdr.cpp:274 src/muuli_wdr.cpp:293 src/muuli_wdr.cpp:1635
 #: src/OtherFunctions.cpp:64
 msgid "MB"
 msgstr "MB"
@@ -3369,7 +3369,7 @@ msgstr "Tamanho Máximo"
 msgid "Availability"
 msgstr "Disponibilidade"
 
-#: src/muuli_wdr.cpp:312 src/muuli_wdr.cpp:398 src/muuli_wdr.cpp:3328
+#: src/muuli_wdr.cpp:312 src/muuli_wdr.cpp:398 src/muuli_wdr.cpp:3332
 msgid "Filter:"
 msgstr "Filtro:"
 
@@ -3432,8 +3432,8 @@ msgstr "Fontes de ficheiros:"
 #: src/muuli_wdr.cpp:1160 src/muuli_wdr.cpp:1167 src/muuli_wdr.cpp:1172
 #: src/muuli_wdr.cpp:1179 src/muuli_wdr.cpp:1184 src/muuli_wdr.cpp:1191
 #: src/muuli_wdr.cpp:1205 src/muuli_wdr.cpp:1212 src/muuli_wdr.cpp:1217
-#: src/muuli_wdr.cpp:1224 src/muuli_wdr.cpp:3265 src/muuli_wdr.cpp:3273
-#: src/muuli_wdr.cpp:3281
+#: src/muuli_wdr.cpp:1224 src/muuli_wdr.cpp:3269 src/muuli_wdr.cpp:3277
+#: src/muuli_wdr.cpp:3285
 msgid "N/A"
 msgstr "N/D"
 
@@ -3578,7 +3578,7 @@ msgstr ""
 msgid "Album :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:685 src/muuli_wdr.cpp:2285
+#: src/muuli_wdr.cpp:685 src/muuli_wdr.cpp:2289
 msgid "Title :"
 msgstr "Título :"
 
@@ -3687,7 +3687,7 @@ msgstr "Utilizador :"
 msgid "Userhash :"
 msgstr "Chave de utilizador :"
 
-#: src/muuli_wdr.cpp:895 src/muuli_wdr.cpp:1752 src/muuli_wdr.cpp:2480
+#: src/muuli_wdr.cpp:895 src/muuli_wdr.cpp:1756 src/muuli_wdr.cpp:2484
 #: src/utils/aLinkCreator/src/alcframe.cpp:137
 msgid "Add"
 msgstr "Adicionar"
@@ -3696,15 +3696,15 @@ msgstr "Adicionar"
 msgid "Download-Speed"
 msgstr "Velocidade de Download"
 
-#: src/muuli_wdr.cpp:954 src/muuli_wdr.cpp:989 src/muuli_wdr.cpp:2584
+#: src/muuli_wdr.cpp:954 src/muuli_wdr.cpp:989 src/muuli_wdr.cpp:2588
 msgid "Current"
 msgstr "Actual"
 
-#: src/muuli_wdr.cpp:962 src/muuli_wdr.cpp:997 src/muuli_wdr.cpp:2592
+#: src/muuli_wdr.cpp:962 src/muuli_wdr.cpp:997 src/muuli_wdr.cpp:2596
 msgid "Running average"
 msgstr "Média actual"
 
-#: src/muuli_wdr.cpp:970 src/muuli_wdr.cpp:1005 src/muuli_wdr.cpp:2600
+#: src/muuli_wdr.cpp:970 src/muuli_wdr.cpp:1005 src/muuli_wdr.cpp:2604
 msgid "Session average"
 msgstr "Média da sessão"
 
@@ -3716,7 +3716,7 @@ msgstr "Velocidade de Upload"
 msgid "Connections"
 msgstr "Ligações"
 
-#: src/muuli_wdr.cpp:1024 src/muuli_wdr.cpp:1871
+#: src/muuli_wdr.cpp:1024 src/muuli_wdr.cpp:1875
 msgid "Active downloads"
 msgstr "Downloads activos"
 
@@ -3724,7 +3724,7 @@ msgstr "Downloads activos"
 msgid "Active connections (1:1)"
 msgstr "Ligações activas (1:1)"
 
-#: src/muuli_wdr.cpp:1040 src/muuli_wdr.cpp:1872
+#: src/muuli_wdr.cpp:1040 src/muuli_wdr.cpp:1876
 msgid "Active uploads"
 msgstr "Uploads activos"
 
@@ -4000,7 +4000,7 @@ msgstr "Associar endereço local ao IP (em branco para qualquer um):"
 msgid "Advanced users only: If you have multiple network interfaces, enter the address of the interface to which aMule should be bound."
 msgstr "Apenas para utilizadores avançados: Se possui múltiplos interfaces de rede indique o endereço do interface que o aMule deve usar."
 
-#: src/muuli_wdr.cpp:1462 src/muuli_wdr.cpp:2065
+#: src/muuli_wdr.cpp:1462 src/muuli_wdr.cpp:2069
 #, fuzzy
 msgid "Bind to network interface (empty for any):"
 msgstr "Associar endereço local ao IP (em branco para qualquer um):"
@@ -4017,7 +4017,7 @@ msgstr "Máximo de fontes por ficheiro:"
 msgid "Max simultaneous connections:"
 msgstr "Máximo de ligações simultâneas:"
 
-#: src/muuli_wdr.cpp:1498 src/muuli_wdr.cpp:3207
+#: src/muuli_wdr.cpp:1498 src/muuli_wdr.cpp:3211
 msgid "ED2K"
 msgstr "ED2K"
 
@@ -4109,779 +4109,779 @@ msgstr "Reservar previamente espaço em disco para novos ficheiros"
 msgid "For new files preallocates disk space for the whole file, thus reduces fragmentation"
 msgstr "Para novos ficheiros, reserva o espaço em disco para o ficheiro completo, reduzindo assim a fragmentação"
 
-#: src/muuli_wdr.cpp:1617
+#: src/muuli_wdr.cpp:1621
 msgid "Create new files as sparse files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1618
+#: src/muuli_wdr.cpp:1622
 msgid "Sparse part files only occupy disk space for the parts already downloaded, so free space is used up gradually as the file fills in. Turn this off to use an ordinary file instead - useful where sparse files are unsupported or slow, or where backup/de-duplication tools handle them badly. Applies only when the core runs on Windows; on Linux and macOS part files are sparse anyway and this setting has no effect."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1623
+#: src/muuli_wdr.cpp:1627
 msgid "Stop downloads when free disk space reaches "
 msgstr "Parar os downloads quando o espaço livre em disco atinge "
 
-#: src/muuli_wdr.cpp:1624
+#: src/muuli_wdr.cpp:1628
 msgid "Select this if you want aMule to check your disk space"
 msgstr "Seleccione se quiser que o aMule verifique o espaço em disco"
 
-#: src/muuli_wdr.cpp:1628
+#: src/muuli_wdr.cpp:1632
 msgid "Enter here the min disk space desired."
 msgstr "Insira o espaço mínimo no disco desejado."
 
-#: src/muuli_wdr.cpp:1634
+#: src/muuli_wdr.cpp:1638
 msgid "Save 10 sources on rare files (< 20 sources)"
 msgstr "Guardar 10 fontes para ficheiros raros (< 20 fontes)"
 
-#: src/muuli_wdr.cpp:1638 src/Statistics.cpp:790
+#: src/muuli_wdr.cpp:1642 src/Statistics.cpp:790
 msgid "Uploads"
 msgstr "Uploads"
 
-#: src/muuli_wdr.cpp:1641
+#: src/muuli_wdr.cpp:1645
 msgid "Add new shared files with auto priority"
 msgstr "Adicionar novos ficheiros partilhados com prioridade automática"
 
-#: src/muuli_wdr.cpp:1647
+#: src/muuli_wdr.cpp:1651
 msgid "Intelligent Corruption Handling (I.C.H.)"
 msgstr "Manipulação Inteligente de Corrupção (M.I.C.)"
 
-#: src/muuli_wdr.cpp:1650
+#: src/muuli_wdr.cpp:1654
 msgid "Enable"
 msgstr "Activar"
 
-#: src/muuli_wdr.cpp:1653
+#: src/muuli_wdr.cpp:1657
 msgid "Advanced I.C.H. trusts every hash (not recommended)"
 msgstr "M.I.C. Avançada confia em todas as chaves (não recomendado)"
 
-#: src/muuli_wdr.cpp:1665 src/PrefsUnifiedDlg.cpp:1990
+#: src/muuli_wdr.cpp:1669 src/PrefsUnifiedDlg.cpp:1999
 msgid "Media metadata extraction"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1669
+#: src/muuli_wdr.cpp:1673
 msgid "Extract length / bitrate / codec from shared audio and video files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1671
+#: src/muuli_wdr.cpp:1675
 msgid "When enabled, aMule runs ffprobe on each shared media file to fill in the Length / Bitrate / Codec columns other clients see when they find the file in a search. Requires ffmpeg (the ffprobe binary) to be installed."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1678
+#: src/muuli_wdr.cpp:1682
 msgid "Path to ffprobe:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1683
+#: src/muuli_wdr.cpp:1687
 msgid "Full path to the ffprobe binary. Leave empty to have aMule auto-detect it on startup."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1691
+#: src/muuli_wdr.cpp:1695
 msgid "Detect"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1692
+#: src/muuli_wdr.cpp:1696
 msgid "Search the standard install locations for an ffprobe binary and fill the path field."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1716
+#: src/muuli_wdr.cpp:1720
 msgid ""
 "Completed downloads are stored here. All files in this folder are automatically shared with other peers.\n"
 "If this folder also holds files you don't want to share, point it at an aMule-only sub-folder."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1719
+#: src/muuli_wdr.cpp:1723
 msgid "Pick the folder where completed downloads will be stored. All files in that folder will be shared with other peers."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1733
+#: src/muuli_wdr.cpp:1737
 msgid "Shared folders"
 msgstr "Pastas partilhadas"
 
-#: src/muuli_wdr.cpp:1739
+#: src/muuli_wdr.cpp:1743
 msgid "(Folders shared by the core. Enter a path to add one.)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1747
+#: src/muuli_wdr.cpp:1751
 msgid "Absolute path of a folder on the core's machine, e.g. /home/user/shared"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1749 src/PrefsUnifiedDlg.cpp:2874
+#: src/muuli_wdr.cpp:1753 src/PrefsUnifiedDlg.cpp:2883
 msgid "Recursive"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1750
+#: src/muuli_wdr.cpp:1754
 msgid "Share every sub-folder underneath this one, including ones created later."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1754 src/utils/aLinkCreator/src/alcframe.cpp:141
+#: src/muuli_wdr.cpp:1758 src/utils/aLinkCreator/src/alcframe.cpp:141
 msgid "Remove"
 msgstr "Remover"
 
-#: src/muuli_wdr.cpp:1758
+#: src/muuli_wdr.cpp:1762
 msgid "(Right click on folder icon for recursive share)"
 msgstr "(Clique com o botão do lado direito no ícone da pasta para partilha recursiva)"
 
-#: src/muuli_wdr.cpp:1765
+#: src/muuli_wdr.cpp:1769
 msgid "Share hidden files"
 msgstr "Partilhar ficheiros ocultos"
 
-#: src/muuli_wdr.cpp:1771
+#: src/muuli_wdr.cpp:1775
 msgid "Automatically rescan shared folders for changes"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1777
+#: src/muuli_wdr.cpp:1781
 msgid "Follow symbolic links in shared folders"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1783
+#: src/muuli_wdr.cpp:1787
 msgid "Exclude files matching:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1786
+#: src/muuli_wdr.cpp:1790
 msgid "Wildcard patterns separated by '|', e.g. .DS_Store|Thumbs.db|*.tmp. Files whose name matches are not shared. Matching is case-insensitive."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1790
+#: src/muuli_wdr.cpp:1794
 msgid "Patterns are regular expressions"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1791
+#: src/muuli_wdr.cpp:1795
 msgid "When set, the whole field is one regular expression ('|' is alternation). When unset, it is a list of '|'-separated wildcards."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1801
+#: src/muuli_wdr.cpp:1805
 msgid "Show how many shared files the current pattern would exclude."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1822
+#: src/muuli_wdr.cpp:1826
 msgid "Graphs"
 msgstr "Gráficos"
 
-#: src/muuli_wdr.cpp:1825 src/muuli_wdr.cpp:1887
+#: src/muuli_wdr.cpp:1829 src/muuli_wdr.cpp:1891
 msgid "Update delay : 5 secs"
 msgstr "Atraso de actualização: 5 segundos"
 
-#: src/muuli_wdr.cpp:1829
+#: src/muuli_wdr.cpp:1833
 msgid "Time for average graph: 100 mins"
 msgstr "Tempo para gráfico de média: 100 minutos"
 
-#: src/muuli_wdr.cpp:1833
+#: src/muuli_wdr.cpp:1837
 msgid "Connections Graph Scale: 100 "
 msgstr "Escala do Gráfico de Ligações: 100"
 
-#: src/muuli_wdr.cpp:1840
+#: src/muuli_wdr.cpp:1844
 msgid "Download graph scale:"
 msgstr "Escala do gráfico de download:"
 
-#: src/muuli_wdr.cpp:1848
+#: src/muuli_wdr.cpp:1852
 msgid "Upload graph scale:"
 msgstr "Escala do gráfico de upload"
 
-#: src/muuli_wdr.cpp:1858
+#: src/muuli_wdr.cpp:1862
 #, fuzzy
 msgid "Colors: "
 msgstr "Cores: "
 
-#: src/muuli_wdr.cpp:1862
+#: src/muuli_wdr.cpp:1866
 msgid "Background"
 msgstr "Fundo"
 
-#: src/muuli_wdr.cpp:1863
+#: src/muuli_wdr.cpp:1867
 msgid "Grid"
 msgstr "Grelha"
 
-#: src/muuli_wdr.cpp:1864
+#: src/muuli_wdr.cpp:1868
 msgid "Download current"
 msgstr "Download actual"
 
-#: src/muuli_wdr.cpp:1865
+#: src/muuli_wdr.cpp:1869
 msgid "Download running average"
 msgstr "Média actual de download"
 
-#: src/muuli_wdr.cpp:1866
+#: src/muuli_wdr.cpp:1870
 msgid "Download session average"
 msgstr "Média de download da sessão"
 
-#: src/muuli_wdr.cpp:1867
+#: src/muuli_wdr.cpp:1871
 msgid "Upload current"
 msgstr "Upload actual"
 
-#: src/muuli_wdr.cpp:1868
+#: src/muuli_wdr.cpp:1872
 msgid "Upload running average"
 msgstr "Média actual de upload"
 
-#: src/muuli_wdr.cpp:1869
+#: src/muuli_wdr.cpp:1873
 msgid "Upload session average"
 msgstr "Média de upload da sessão"
 
-#: src/muuli_wdr.cpp:1870
+#: src/muuli_wdr.cpp:1874
 msgid "Active connections"
 msgstr "Ligações activas"
 
-#: src/muuli_wdr.cpp:1873
+#: src/muuli_wdr.cpp:1877
 #, fuzzy
 msgid "Systray Icon Speed Bar"
 msgstr "Barra de velocidade no ícone da área de notificação"
 
-#: src/muuli_wdr.cpp:1874
+#: src/muuli_wdr.cpp:1878
 msgid "Kad-nodes current"
 msgstr "Nós Kad actuais"
 
-#: src/muuli_wdr.cpp:1875
+#: src/muuli_wdr.cpp:1879
 msgid "Kad-nodes running"
 msgstr "Nós Kad a executar"
 
-#: src/muuli_wdr.cpp:1876
+#: src/muuli_wdr.cpp:1880
 msgid "Kad-nodes session"
 msgstr "Nós Kad da sessão"
 
-#: src/muuli_wdr.cpp:1880 src/muuli_wdr.cpp:2334
+#: src/muuli_wdr.cpp:1884 src/muuli_wdr.cpp:2338
 msgid "Select"
 msgstr "Seleccionar"
 
-#: src/muuli_wdr.cpp:1884
+#: src/muuli_wdr.cpp:1888
 msgid "Tree"
 msgstr "Árvore"
 
-#: src/muuli_wdr.cpp:1894
+#: src/muuli_wdr.cpp:1898
 msgid "Number of Client Versions shown (0=unlimited)"
 msgstr "Número de Versões de Cliente mostradas (0=ilimitado)"
 
-#: src/muuli_wdr.cpp:1919
+#: src/muuli_wdr.cpp:1923
 msgid "!!! WARNING !!!"
 msgstr "!!! AVISO !!!"
 
-#: src/muuli_wdr.cpp:1934
+#: src/muuli_wdr.cpp:1938
 msgid "Max new connections / 5 secs"
 msgstr "Máximo de novas ligações / 5 segundos"
 
-#: src/muuli_wdr.cpp:1936
+#: src/muuli_wdr.cpp:1940
 msgid "Concurrent Kad source lookups"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1938
+#: src/muuli_wdr.cpp:1942
 #, fuzzy
 msgid "Kad source re-search interval (minutes)"
 msgstr "Intervalo de actualização do FTP em minutos"
 
-#: src/muuli_wdr.cpp:1940
+#: src/muuli_wdr.cpp:1944
 #, fuzzy
 msgid "Source re-ask interval (minutes)"
 msgstr "Intervalo de actualização do FTP em minutos"
 
-#: src/muuli_wdr.cpp:1944
+#: src/muuli_wdr.cpp:1948
 msgid "File Buffer Size: 240000 bytes"
 msgstr "Tamanho da memória temporária de ficheiro: 240000 Byte"
 
-#: src/muuli_wdr.cpp:1948
+#: src/muuli_wdr.cpp:1952
 msgid "Use MMAP: memory-mapped file access (lower memory use)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1949
+#: src/muuli_wdr.cpp:1953
 msgid "Maps part files into memory instead of buffering them on the heap, lowering the process memory footprint. May reduce download speed on some disks; best for memory-constrained or upload-heavy hosts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1951
+#: src/muuli_wdr.cpp:1955
 msgid "Upload Queue Size: 5000 clients"
 msgstr "Tamanho da Lista de Espera de Upload: 5000 clientes"
 
-#: src/muuli_wdr.cpp:1955
+#: src/muuli_wdr.cpp:1959
 msgid "Server connection refresh interval: Disable"
 msgstr "Intervalo de actualização da ligação ao servidor: Desactivado"
 
-#: src/muuli_wdr.cpp:1959
+#: src/muuli_wdr.cpp:1963
 msgid "Disable computer's timed standby mode"
 msgstr "Desactivar o modo de espera temporizado do computador"
 
-#: src/muuli_wdr.cpp:1978
+#: src/muuli_wdr.cpp:1982
 msgid "Skin to use: "
 msgstr "Tema a utilizar: "
 
-#: src/muuli_wdr.cpp:1987
+#: src/muuli_wdr.cpp:1991
 msgid "Show \"Fast eD2k Links Handler\" in every window."
 msgstr "Mostrar a barra de adição rápida de ligações eD2k em todas as janelas."
 
-#: src/muuli_wdr.cpp:1990
+#: src/muuli_wdr.cpp:1994
 msgid "Show extended info on categories tabs"
 msgstr "Mostrar informação extra nos separadores de categorias"
 
-#: src/muuli_wdr.cpp:1993
+#: src/muuli_wdr.cpp:1997
 #, fuzzy
 msgid "Show application version on title"
 msgstr "Mostrar velocidades de transferência na barra de título"
 
-#: src/muuli_wdr.cpp:1995
+#: src/muuli_wdr.cpp:1999
 msgid "Show transfer rates on title"
 msgstr "Mostrar velocidades de transferência na barra de título"
 
-#: src/muuli_wdr.cpp:1997
+#: src/muuli_wdr.cpp:2001
 msgid "Before application name"
 msgstr "Antes do nome da aplicação"
 
-#: src/muuli_wdr.cpp:1999
+#: src/muuli_wdr.cpp:2003
 msgid "After application name"
 msgstr "Depois do nome da aplicação"
 
-#: src/muuli_wdr.cpp:2002
+#: src/muuli_wdr.cpp:2006
 msgid "Show overhead bandwidth"
 msgstr "Mostrar sobrecarga na largura de banda"
 
-#: src/muuli_wdr.cpp:2006
+#: src/muuli_wdr.cpp:2010
 msgid "Vertical toolbar orientation"
 msgstr "Orientação vertical da barra de ferramentas"
 
-#: src/muuli_wdr.cpp:2008
+#: src/muuli_wdr.cpp:2012
 msgid "Live column sorting (auto-reorder rows as their values change)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2015
+#: src/muuli_wdr.cpp:2019
 msgid "Download Queue Files"
 msgstr "Ficheiros na Fila de Espera dos Downloads"
 
-#: src/muuli_wdr.cpp:2018
+#: src/muuli_wdr.cpp:2022
 msgid "Show progress percentage"
 msgstr "Mostrar percentagem de progresso"
 
-#: src/muuli_wdr.cpp:2024
+#: src/muuli_wdr.cpp:2028
 msgid "Show progress bar"
 msgstr "Mostrar barra de progresso"
 
-#: src/muuli_wdr.cpp:2027
+#: src/muuli_wdr.cpp:2031
 msgid "Flat"
 msgstr "Plana"
 
-#: src/muuli_wdr.cpp:2031
+#: src/muuli_wdr.cpp:2035
 msgid "Round"
 msgstr "Arredondada"
 
-#: src/muuli_wdr.cpp:2049
+#: src/muuli_wdr.cpp:2053
 msgid "External Connection Parameters"
 msgstr "Parâmetros de Ligação Externa"
 
-#: src/muuli_wdr.cpp:2052
+#: src/muuli_wdr.cpp:2056
 msgid "Accept external connections"
 msgstr "Aceitar ligações externas"
 
-#: src/muuli_wdr.cpp:2059 src/muuli_wdr.cpp:2118
+#: src/muuli_wdr.cpp:2063 src/muuli_wdr.cpp:2122
 msgid "IP of the listening interface:"
 msgstr "IP da interface a escutar:"
 
-#: src/muuli_wdr.cpp:2062
+#: src/muuli_wdr.cpp:2066
 msgid "Enter here a valid ip in the a.b.c.d format for the listening EC interface. An empty field or 0.0.0.0 will mean any interface."
 msgstr "Insira um endereço IP válido no formato a.b.c.d para a interface que irá aguardar as LE. Um campo vazio ou 0.0.0.0 significará qualquer interface."
 
-#: src/muuli_wdr.cpp:2083 src/muuli_wdr.cpp:2194
+#: src/muuli_wdr.cpp:2087 src/muuli_wdr.cpp:2198
 msgid "TCP port:"
 msgstr "Porto TCP:"
 
-#: src/muuli_wdr.cpp:2089
+#: src/muuli_wdr.cpp:2093
 msgid "Enable UPnP port forwarding on the EC port"
 msgstr "Activar UPnP para configuração do encaminhamento no porto das LE"
 
-#: src/muuli_wdr.cpp:2093 src/muuli_wdr.cpp:3079
+#: src/muuli_wdr.cpp:2097 src/muuli_wdr.cpp:3083
 #: src/utils/wxCas/src/wxcasprefs.cpp:167
 msgid "Password"
 msgstr "Palavra-passe"
 
-#: src/muuli_wdr.cpp:2099
+#: src/muuli_wdr.cpp:2103
 #, fuzzy
 msgid "aMule API server parameters"
 msgstr "Parâmetros do servidor web"
 
-#: src/muuli_wdr.cpp:2102
+#: src/muuli_wdr.cpp:2106
 msgid "Run amuleapi (REST API) on startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2107
+#: src/muuli_wdr.cpp:2111
 #, fuzzy
 msgid "HTTP port:"
 msgstr "Porto TCP:"
 
-#: src/muuli_wdr.cpp:2121
+#: src/muuli_wdr.cpp:2125
 msgid "The interface amuleapi's HTTP server listens on. 127.0.0.1 (default) accepts only local connections; use 0.0.0.0 or a specific IP to expose it to other hosts (set an admin password below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2126
+#: src/muuli_wdr.cpp:2130
 msgid "Type a password to set or change it. Stored passwords cannot be shown, so leaving this empty keeps the current one."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2128
+#: src/muuli_wdr.cpp:2132
 #, fuzzy
 msgid "Admin password"
 msgstr "A verificar a palavra-passe\n"
 
-#: src/muuli_wdr.cpp:2140 src/muuli_wdr.cpp:2157 src/PrefsUnifiedDlg.cpp:1103
+#: src/muuli_wdr.cpp:2144 src/muuli_wdr.cpp:2161 src/PrefsUnifiedDlg.cpp:1112
 #, fuzzy
 msgid "A password is set."
 msgstr "A verificar a palavra-passe\n"
 
-#: src/muuli_wdr.cpp:2144
+#: src/muuli_wdr.cpp:2148
 #, fuzzy
 msgid "Enable guest access"
 msgstr "Negar acesso de convidado"
 
-#: src/muuli_wdr.cpp:2145
+#: src/muuli_wdr.cpp:2149
 msgid "Guest sessions may read status and listings but cannot change anything. Turning this off clears the stored guest password."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2149
+#: src/muuli_wdr.cpp:2153
 #, fuzzy
 msgid "Guest password"
 msgstr "Palavra-passe de convidado para o servidor web"
 
-#: src/muuli_wdr.cpp:2164
+#: src/muuli_wdr.cpp:2168
 msgid "Web server parameters"
 msgstr "Parâmetros do servidor web"
 
-#: src/muuli_wdr.cpp:2167
+#: src/muuli_wdr.cpp:2171
 #, fuzzy
 msgid "Run webserver on startup (deprecated)"
 msgstr "Executar o servidor web no arranque"
 
-#: src/muuli_wdr.cpp:2173
+#: src/muuli_wdr.cpp:2177
 msgid "Web template"
 msgstr "Aspecto da página web"
 
-#: src/muuli_wdr.cpp:2178
+#: src/muuli_wdr.cpp:2182
 msgid "Full rights password"
 msgstr "Palavra-passe para controlo total"
 
-#: src/muuli_wdr.cpp:2182
+#: src/muuli_wdr.cpp:2186
 msgid "Enable Low rights User"
 msgstr "Activar utilizador com permissões reduzidas"
 
-#: src/muuli_wdr.cpp:2187
+#: src/muuli_wdr.cpp:2191
 msgid "Low rights password"
 msgstr "Palavra-passe para controlo reduzido"
 
-#: src/muuli_wdr.cpp:2201
+#: src/muuli_wdr.cpp:2205
 msgid "Enable UPnP port forwarding of the web server port"
 msgstr "Activar UPnP para encaminhamento do porto do servidor web"
 
-#: src/muuli_wdr.cpp:2206
+#: src/muuli_wdr.cpp:2210
 msgid "Web server UPnP TCP port (Optional)"
 msgstr "Porto TCP UPnP do servidor web (Opcional)"
 
-#: src/muuli_wdr.cpp:2214
+#: src/muuli_wdr.cpp:2218
 msgid "Page Refresh Time (in secs)"
 msgstr "Taxa de Actualização de Páginas (em segundos)"
 
-#: src/muuli_wdr.cpp:2221
+#: src/muuli_wdr.cpp:2225
 msgid "Enable Gzip compression"
 msgstr "Activar compressão Gzip"
 
-#: src/muuli_wdr.cpp:2255
+#: src/muuli_wdr.cpp:2259
 #, fuzzy
 msgid "Reset page to defaults"
 msgstr "Predefinição do sistema"
 
-#: src/muuli_wdr.cpp:2256
+#: src/muuli_wdr.cpp:2260
 msgid "Reset the settings on the current page to their default values."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2258 src/muuli_wdr.cpp:2344 src/ServerWnd.cpp:274
+#: src/muuli_wdr.cpp:2262 src/muuli_wdr.cpp:2348 src/ServerWnd.cpp:274
 #: src/ServerWnd.cpp:282
 msgid "OK"
 msgstr "OK"
 
-#: src/muuli_wdr.cpp:2260
+#: src/muuli_wdr.cpp:2264
 msgid "Click here to apply any changes made to the preferences."
 msgstr "Clique aqui para aplicar as alterações efectuadas nas preferências."
 
-#: src/muuli_wdr.cpp:2263
+#: src/muuli_wdr.cpp:2267
 msgid "Reset any changes made to the preferences."
 msgstr "Anular as alterações efectuadas nas preferências."
 
-#: src/muuli_wdr.cpp:2292
+#: src/muuli_wdr.cpp:2296
 msgid "Comment :"
 msgstr "Comentário :"
 
-#: src/muuli_wdr.cpp:2299
+#: src/muuli_wdr.cpp:2303
 msgid "Incoming Dir :"
 msgstr "Pasta de completos :"
 
-#: src/muuli_wdr.cpp:2308
+#: src/muuli_wdr.cpp:2312
 msgid "Change priority for new assigned files :"
 msgstr "Trocar prioridade nos novos ficheiros :"
 
-#: src/muuli_wdr.cpp:2312
+#: src/muuli_wdr.cpp:2316
 msgid "Don't change"
 msgstr "Não mudar"
 
-#: src/muuli_wdr.cpp:2324
+#: src/muuli_wdr.cpp:2328
 msgid "Select color for this Category (currently selected) :"
 msgstr "Seleccionar a cor para a categoria seleccionada :"
 
-#: src/muuli_wdr.cpp:2391 src/muuli_wdr.cpp:2410 src/muuli_wdr.cpp:2432
+#: src/muuli_wdr.cpp:2395 src/muuli_wdr.cpp:2414 src/muuli_wdr.cpp:2436
 msgid "Click this button to reset the log."
 msgstr "Clique para limpar o relatório."
 
-#: src/muuli_wdr.cpp:2451
+#: src/muuli_wdr.cpp:2455
 msgid "Click on this button to update the servers list from URL ..."
 msgstr "Clique neste botão para actualizar a lista de servidores a partir do endereço ..."
 
-#: src/muuli_wdr.cpp:2455
+#: src/muuli_wdr.cpp:2459
 msgid "Server list"
 msgstr "Lista de Servidores"
 
-#: src/muuli_wdr.cpp:2459
+#: src/muuli_wdr.cpp:2463
 msgid "Enter the url to a server.met file here and press the button to the left to update the list of known servers."
 msgstr "Insira a localização de um ficheiro server.met e pressione o botão à esquerda para actualizar a lista de servidores conhecidos."
 
-#: src/muuli_wdr.cpp:2464
+#: src/muuli_wdr.cpp:2468
 msgid "Add server manually: Name"
 msgstr "Adicionar servidor manualmente: Nome"
 
-#: src/muuli_wdr.cpp:2467
+#: src/muuli_wdr.cpp:2471
 msgid "Enter the name of the new server here"
 msgstr "Insira o nome do novo servidor"
 
-#: src/muuli_wdr.cpp:2469 src/ServerWnd.cpp:206
+#: src/muuli_wdr.cpp:2473 src/ServerWnd.cpp:206
 msgid "IP:Port"
 msgstr "IP:Porto"
 
-#: src/muuli_wdr.cpp:2472
+#: src/muuli_wdr.cpp:2476
 msgid "Enter the IP of the server here, using the x.x.x.x format."
 msgstr "Insira o IP do servidor, usando o formato x.x.x.x."
 
-#: src/muuli_wdr.cpp:2478
+#: src/muuli_wdr.cpp:2482
 msgid "Enter the port of the server here."
 msgstr "Insira o porto do servidor."
 
-#: src/muuli_wdr.cpp:2481
+#: src/muuli_wdr.cpp:2485
 msgid "Add manually a server (fill fields to the left before) ..."
 msgstr "Adicionar manualmente um servidor (preencher os campos ao lado) ..."
 
-#: src/muuli_wdr.cpp:2510
+#: src/muuli_wdr.cpp:2514
 msgid "aMule Log"
 msgstr "Relatório"
 
-#: src/muuli_wdr.cpp:2518
+#: src/muuli_wdr.cpp:2522
 msgid "Server Info"
 msgstr "Informações do Servidor"
 
-#: src/muuli_wdr.cpp:2522
+#: src/muuli_wdr.cpp:2526
 msgid "ED2K Info"
 msgstr "Informação ED2K"
 
-#: src/muuli_wdr.cpp:2526
+#: src/muuli_wdr.cpp:2530
 msgid "Kad Info"
 msgstr "Informação Kad"
 
-#: src/muuli_wdr.cpp:2554
+#: src/muuli_wdr.cpp:2558
 msgid "Click on this button to update the nodes list from URL ..."
 msgstr "Clique para actualizar a lista de nós a partir do endereço ..."
 
-#: src/muuli_wdr.cpp:2558
+#: src/muuli_wdr.cpp:2562
 msgid "Nodes (0)"
 msgstr "Nós (0)"
 
-#: src/muuli_wdr.cpp:2562
+#: src/muuli_wdr.cpp:2566
 msgid "Enter the url to a nodes.dat file here and press the button to the left to update the list of known nodes."
 msgstr "Insira o endereço de um ficheiro nodes.dat e pressione o botão à esquerda para actualizar a lista de nós conhecidos."
 
-#: src/muuli_wdr.cpp:2565
+#: src/muuli_wdr.cpp:2569
 msgid "Nodes stats"
 msgstr "Estado dos nós"
 
-#: src/muuli_wdr.cpp:2607
+#: src/muuli_wdr.cpp:2611
 msgid "Bootstrap"
 msgstr "Inicialização"
 
-#: src/muuli_wdr.cpp:2610
+#: src/muuli_wdr.cpp:2614
 msgid "New node"
 msgstr "Novo nó"
 
-#: src/muuli_wdr.cpp:2615
+#: src/muuli_wdr.cpp:2619
 msgid "IP:"
 msgstr "IP:"
 
-#: src/muuli_wdr.cpp:2635
+#: src/muuli_wdr.cpp:2639
 msgid "Port:"
 msgstr "Porto:"
 
-#: src/muuli_wdr.cpp:2648
+#: src/muuli_wdr.cpp:2652
 msgid "Bootstrap from known clients"
 msgstr "Arrancar a partir de clientes conhecidos"
 
-#: src/muuli_wdr.cpp:2650
+#: src/muuli_wdr.cpp:2654
 msgid "Disconnect Kad"
 msgstr "Desligar Kad"
 
-#: src/muuli_wdr.cpp:2684
+#: src/muuli_wdr.cpp:2688
 msgid "Use Secure User Identification"
 msgstr "Utilizar Identificação Segura de Utilizador"
 
-#: src/muuli_wdr.cpp:2686
+#: src/muuli_wdr.cpp:2690
 msgid "It is recommended to enable this option. You will not receive credits if SUI is not enabled."
 msgstr "É recomendado activar esta opção. Não receberá créditos se a Identificação Segura de Utilizador não estiver activada."
 
-#: src/muuli_wdr.cpp:2688
+#: src/muuli_wdr.cpp:2692
 msgid "Protocol Obfuscation"
 msgstr "Ofuscação do Protocolo"
 
-#: src/muuli_wdr.cpp:2691
+#: src/muuli_wdr.cpp:2695
 msgid "Support Protocol Obfuscation"
 msgstr "Suportar a Ofuscação do Protocolo"
 
-#: src/muuli_wdr.cpp:2693
+#: src/muuli_wdr.cpp:2697
 msgid "This option enabled Protocol Obfuscation, and makes aMule accept obfuscated connections from other clients."
 msgstr "Esta opção activa a Ofuscação do Protocolo e faz com que o aMule aceite ligações ofuscadas de outros clientes."
 
-#: src/muuli_wdr.cpp:2695
+#: src/muuli_wdr.cpp:2699
 msgid "Use obfuscation for outgoing connections"
 msgstr "Usar ofuscação em ligações para o exterior"
 
-#: src/muuli_wdr.cpp:2697
+#: src/muuli_wdr.cpp:2701
 msgid "This option makes aMule use Protocol Obfuscation when connecting other clients/servers."
 msgstr "Esta opção faz com que o aMule use a Ofuscação do Protocolo quando ligado a outros clientes/servidores."
 
-#: src/muuli_wdr.cpp:2699
+#: src/muuli_wdr.cpp:2703
 msgid "Accept only obfuscated connections"
 msgstr "Aceitar apenas ligações ofuscadas"
 
-#: src/muuli_wdr.cpp:2700
+#: src/muuli_wdr.cpp:2704
 msgid "This option makes aMule only accept obfuscated connections. You will have less sources, but all your traffic will be obfuscated"
 msgstr "Esta opção faz com que o aMUle aceite apenas ligações ofuscadas. Terá menos fontes, mas todo o tráfego será ofuscado"
 
-#: src/muuli_wdr.cpp:2705
+#: src/muuli_wdr.cpp:2709
 msgid "Everybody"
 msgstr "Todos"
 
-#: src/muuli_wdr.cpp:2707
+#: src/muuli_wdr.cpp:2711
 msgid "No one"
 msgstr "Ninguém"
 
-#: src/muuli_wdr.cpp:2709
+#: src/muuli_wdr.cpp:2713
 msgid "Who can see my shared files:"
 msgstr "Quem pode ver os meus ficheiros partilhados:"
 
-#: src/muuli_wdr.cpp:2710
+#: src/muuli_wdr.cpp:2714
 msgid "Select who can request to view a list of your shared files."
 msgstr "Seleccione quem pode pedir a lista dos seus ficheiros partilhados."
 
-#: src/muuli_wdr.cpp:2712
+#: src/muuli_wdr.cpp:2716
 msgid "IP-Filtering"
 msgstr "Filtragem de IP"
 
-#: src/muuli_wdr.cpp:2719
+#: src/muuli_wdr.cpp:2723
 msgid "Filter clients"
 msgstr "Filtrar clientes"
 
-#: src/muuli_wdr.cpp:2721
+#: src/muuli_wdr.cpp:2725
 msgid "Enable filtering of the client IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "Activar filtragem por IPs dos clientes definidos no ficheiro ~/.aMule/ipfilter.dat."
 
-#: src/muuli_wdr.cpp:2723
+#: src/muuli_wdr.cpp:2727
 msgid "Filter servers"
 msgstr "Filtrar servidores"
 
-#: src/muuli_wdr.cpp:2725
+#: src/muuli_wdr.cpp:2729
 msgid "Enable filtering of the server IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "Activar filtragem da lista de IPs definida no ficheiro ~/.aMule/ipfilter.dat."
 
-#: src/muuli_wdr.cpp:2729
+#: src/muuli_wdr.cpp:2733
 msgid "Reload List"
 msgstr "Recarregar a lista"
 
-#: src/muuli_wdr.cpp:2730
+#: src/muuli_wdr.cpp:2734
 msgid "Reload the list of IPs to filter from the file ~/.aMule/ipfilter.dat"
 msgstr "Recarregar a lista de IPs a filtrar a partir do ficheiro ~/.aMule/ipfilter.dat"
 
-#: src/muuli_wdr.cpp:2736
+#: src/muuli_wdr.cpp:2740
 msgid "URL:"
 msgstr "URL:"
 
-#: src/muuli_wdr.cpp:2740 src/muuli_wdr.cpp:2933
+#: src/muuli_wdr.cpp:2744 src/muuli_wdr.cpp:2937
 msgid "Update now"
 msgstr "Actualizar agora"
 
-#: src/muuli_wdr.cpp:2743
+#: src/muuli_wdr.cpp:2747
 msgid "Auto-update ipfilter at startup"
 msgstr "Actualizar o filtro de IPs automaticamente no arranque"
 
-#: src/muuli_wdr.cpp:2747
+#: src/muuli_wdr.cpp:2751
 msgid "Filtering Level:"
 msgstr "Nível de filtragem:"
 
-#: src/muuli_wdr.cpp:2753
+#: src/muuli_wdr.cpp:2757
 msgid "Always filter LAN IPs"
 msgstr "Filtrar sempre endereços IP de rede local"
 
-#: src/muuli_wdr.cpp:2756
+#: src/muuli_wdr.cpp:2760
 msgid "Paranoid handling of non-matching IPs"
 msgstr "Tratamento paranóico de IPs sem correspondência"
 
-#: src/muuli_wdr.cpp:2758
+#: src/muuli_wdr.cpp:2762
 msgid "Rejects a packet when its source IP differs from the IP the client claims (an anti-spoofing check). Disable only if it causes connection problems."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2760
+#: src/muuli_wdr.cpp:2764
 msgid "Use system-wide ipfilter.dat if available"
 msgstr "Utilizar ipfilter.dat global do sistema se disponível"
 
-#: src/muuli_wdr.cpp:2761
+#: src/muuli_wdr.cpp:2765
 #, fuzzy
 msgid "If there's no local ipfilter.dat found, allow usage of a system-wide ipfilter file."
 msgstr "Se não existir um ficheiro ipfilter.dat, permitir a utilização de um ficheiro ipfilter global do sistema."
 
-#: src/muuli_wdr.cpp:2778
+#: src/muuli_wdr.cpp:2782
 msgid "Enable Online-Signature"
 msgstr "Activar Assinatura Online"
 
-#: src/muuli_wdr.cpp:2780
+#: src/muuli_wdr.cpp:2784
 msgid "Enables the writing of the OS file, which can be used by external apps to create signatures and the like."
 msgstr "Activa a escrita do ficheiro da AO, o qual pode ser usado por aplicações externas para criar assinaturas e afins."
 
-#: src/muuli_wdr.cpp:2784
+#: src/muuli_wdr.cpp:2788
 msgid "Update Frequency (Secs):"
 msgstr "Frequência de Actualização (segundos):"
 
-#: src/muuli_wdr.cpp:2787
+#: src/muuli_wdr.cpp:2791
 msgid "Change the frequency (in seconds) of Online Signature updates."
 msgstr "Alterar a frequência (em segundos) das actualizações da assinatura Online."
 
-#: src/muuli_wdr.cpp:2795
+#: src/muuli_wdr.cpp:2799
 msgid "Save online signature file in: "
 msgstr "Gravar a assinatura Online em: "
 
-#: src/muuli_wdr.cpp:2801
+#: src/muuli_wdr.cpp:2805
 msgid "Click here to select the directory containing the the Online Signature files."
 msgstr "Clique para seleccionar a pasta que contém os ficheiros de Assinatura Online"
 
-#: src/muuli_wdr.cpp:2834
+#: src/muuli_wdr.cpp:2838
 msgid "Show country flags for clients"
 msgstr "Mostrar bandeiras de países para clientes"
 
-#: src/muuli_wdr.cpp:2835
+#: src/muuli_wdr.cpp:2839
 msgid "Render the country flag column in the transfers, queue and search views. Requires a valid MMDB GeoIP database (see below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2840
+#: src/muuli_wdr.cpp:2844
 #, fuzzy
 msgid "Database"
 msgstr "Taxa de transferência :"
 
-#: src/muuli_wdr.cpp:2856
+#: src/muuli_wdr.cpp:2860
 #, fuzzy
 msgid "Source:"
 msgstr "Fontes"
 
-#: src/muuli_wdr.cpp:2859
+#: src/muuli_wdr.cpp:2863
 msgid "DB-IP (free, no account)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2860
+#: src/muuli_wdr.cpp:2864
 msgid "MaxMind GeoLite2 (free, account required)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2861
+#: src/muuli_wdr.cpp:2865
 msgid "Custom URL"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2864
+#: src/muuli_wdr.cpp:2868
 msgid "Choose which provider supplies the GeoIP MMDB database. DB-IP is the default - no account required. MaxMind requires a free account + license key. Use Custom URL to point at any other MMDB host (e.g. a local mirror)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2881
+#: src/muuli_wdr.cpp:2885
 msgid ""
 "No configuration required.\n"
 "\n"
@@ -4889,11 +4889,11 @@ msgid ""
 "License: Creative Commons BY 4.0 - https://creativecommons.org/licenses/by/4.0/"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2894
+#: src/muuli_wdr.cpp:2898
 msgid "License key:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2900
+#: src/muuli_wdr.cpp:2904
 msgid ""
 "Sign up for a free MaxMind account, then generate a License Key:\n"
 "https://www.maxmind.com/en/geolite2/signup\n"
@@ -4903,226 +4903,226 @@ msgid ""
 "Requires attribution and account registration; refresh at least every 30 days."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2915
+#: src/muuli_wdr.cpp:2919
 #, fuzzy
 msgid "Download URL:"
 msgstr "Download: "
 
-#: src/muuli_wdr.cpp:2921
+#: src/muuli_wdr.cpp:2925
 msgid ""
 "Must point to an .mmdb file or a .gz / .tar.gz containing one.\n"
 "URL may include credentials (https://user:pass@host/...).\n"
 "License and attribution terms are set by the upstream URL - you are responsible."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2934
+#: src/muuli_wdr.cpp:2938
 msgid "Download the GeoIP database from the selected source."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2936
+#: src/muuli_wdr.cpp:2940
 #, fuzzy
 msgid "Auto-update on startup"
 msgstr "Actualizar o filtro de IPs automaticamente no arranque"
 
-#: src/muuli_wdr.cpp:2937
+#: src/muuli_wdr.cpp:2941
 msgid "Re-download the GeoIP database from the selected source every time aMule starts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2960
+#: src/muuli_wdr.cpp:2964
 msgid "Filter incoming messages (except current chat):"
 msgstr "Filtrar mensagens recebidas (excepto da conversa corrente):"
 
-#: src/muuli_wdr.cpp:2962
+#: src/muuli_wdr.cpp:2966
 msgid "Filter all messages"
 msgstr "Filtrar todas as mensagens"
 
-#: src/muuli_wdr.cpp:2964
+#: src/muuli_wdr.cpp:2968
 msgid "Filter messages from people not on your friend list"
 msgstr "Filtrar mensagens de utilizadores que não pertençam à lista de amigos"
 
-#: src/muuli_wdr.cpp:2966
+#: src/muuli_wdr.cpp:2970
 msgid "Filter messages from unknown clients"
 msgstr "Filtrar mensagens de clientes desconhecidos"
 
-#: src/muuli_wdr.cpp:2968
+#: src/muuli_wdr.cpp:2972
 msgid "Filter messages containing (use ',' as separator):"
 msgstr "Filtrar mensagens que contenham (usar ',' como separador):"
 
-#: src/muuli_wdr.cpp:2971 src/muuli_wdr.cpp:2982
+#: src/muuli_wdr.cpp:2975 src/muuli_wdr.cpp:2986
 msgid "add here the words amule should filter and block messages including it"
 msgstr "adicione as palavras que o aMule deve filtrar e bloquear as mensagens que as contenham"
 
-#: src/muuli_wdr.cpp:2973
+#: src/muuli_wdr.cpp:2977
 msgid "Show received messages in the log"
 msgstr "Mostrar mensagens recebidas no relatório"
 
-#: src/muuli_wdr.cpp:2976
+#: src/muuli_wdr.cpp:2980
 msgid "Comments"
 msgstr "Comentários"
 
-#: src/muuli_wdr.cpp:2979
+#: src/muuli_wdr.cpp:2983
 msgid "Filter comments containing (use ',' as separator):"
 msgstr "Filtrar comentários que contenham (usar ',' como separador):"
 
-#: src/muuli_wdr.cpp:3004
+#: src/muuli_wdr.cpp:3008
 msgid "Enable Proxy"
 msgstr "Activar Proxy"
 
-#: src/muuli_wdr.cpp:3005
+#: src/muuli_wdr.cpp:3009
 msgid "Enable/disable proxy support"
 msgstr "Activar/desactivar o suporte de proxy"
 
-#: src/muuli_wdr.cpp:3008
+#: src/muuli_wdr.cpp:3012
 msgid "Proxy type:"
 msgstr "Tipo de proxy:"
 
-#: src/muuli_wdr.cpp:3019
+#: src/muuli_wdr.cpp:3023
 msgid "Proxy host:"
 msgstr "Servidor:"
 
-#: src/muuli_wdr.cpp:3022
+#: src/muuli_wdr.cpp:3026
 msgid "The proxy host name"
 msgstr "O nome da máquina proxy"
 
-#: src/muuli_wdr.cpp:3024
+#: src/muuli_wdr.cpp:3028
 msgid "Proxy port:"
 msgstr "Porto do proxy:"
 
-#: src/muuli_wdr.cpp:3027
+#: src/muuli_wdr.cpp:3031
 msgid "The proxy port"
 msgstr "O porto do proxy"
 
-#: src/muuli_wdr.cpp:3029
+#: src/muuli_wdr.cpp:3033
 msgid "Enable authentication"
 msgstr "Activar autenticação"
 
-#: src/muuli_wdr.cpp:3030
+#: src/muuli_wdr.cpp:3034
 msgid "Enable/disable username/password authentication"
 msgstr "Activar/desactivar autenticação utilizador/palavra-passe"
 
-#: src/muuli_wdr.cpp:3033
+#: src/muuli_wdr.cpp:3037
 msgid "Username: "
 msgstr "Utilizador: "
 
-#: src/muuli_wdr.cpp:3036
+#: src/muuli_wdr.cpp:3040
 msgid "The username to use to connect to the proxy"
 msgstr "O nome de utilizador para ligar ao proxy"
 
-#: src/muuli_wdr.cpp:3038
+#: src/muuli_wdr.cpp:3042
 msgid "Password:"
 msgstr "Palavra-passe:"
 
-#: src/muuli_wdr.cpp:3041
+#: src/muuli_wdr.cpp:3045
 msgid "The password to use to connect to the proxy"
 msgstr "A palavra-passe a usar para ligar ao proxy"
 
-#: src/muuli_wdr.cpp:3060
+#: src/muuli_wdr.cpp:3064
 msgid "Connect to:"
 msgstr "Ligar a:"
 
-#: src/muuli_wdr.cpp:3069
+#: src/muuli_wdr.cpp:3073
 msgid "Login to remote amule"
 msgstr "Autenticação remota"
 
-#: src/muuli_wdr.cpp:3074
+#: src/muuli_wdr.cpp:3078
 msgid "User name"
 msgstr "Nome de utilizador"
 
-#: src/muuli_wdr.cpp:3085
+#: src/muuli_wdr.cpp:3089
 msgid "Remember those settings"
 msgstr "Lembrar estas preferências"
 
-#: src/muuli_wdr.cpp:3088
+#: src/muuli_wdr.cpp:3092
 #, fuzzy
 msgid "Force ZLIB compression"
 msgstr "Usar compressão gzip"
 
-#: src/muuli_wdr.cpp:3112
+#: src/muuli_wdr.cpp:3116
 msgid "Enable Verbose Debug-Logging."
 msgstr "Activar Relatório detalhado para Depuração."
 
-#: src/muuli_wdr.cpp:3114
+#: src/muuli_wdr.cpp:3118
 #, fuzzy
 msgid "Only to Logfile"
 msgstr "&Abrir o ficheiro"
 
-#: src/muuli_wdr.cpp:3116
+#: src/muuli_wdr.cpp:3120
 msgid "Message Categories:"
 msgstr "Categorias de Mensagens:"
 
-#: src/muuli_wdr.cpp:3140 src/PartFileConvertDlg.cpp:160
+#: src/muuli_wdr.cpp:3144 src/PartFileConvertDlg.cpp:160
 msgid "Waiting..."
 msgstr "A aguardar..."
 
-#: src/muuli_wdr.cpp:3160
+#: src/muuli_wdr.cpp:3164
 msgid "Add imports"
 msgstr "Adicionar importações"
 
-#: src/muuli_wdr.cpp:3163
+#: src/muuli_wdr.cpp:3167
 msgid "Retry selected"
 msgstr "Reassumir seleccionados"
 
-#: src/muuli_wdr.cpp:3165
+#: src/muuli_wdr.cpp:3169
 msgid "Remove selected"
 msgstr "Remover seleccionados"
 
-#: src/muuli_wdr.cpp:3228
+#: src/muuli_wdr.cpp:3232
 msgid "Event Types"
 msgstr "Tipos de eventos"
 
-#: src/muuli_wdr.cpp:3247
+#: src/muuli_wdr.cpp:3251
 msgid "Statistics and queued clients for selected file(s) : Session / All time"
 msgstr "Estatísticas e clientes em espera para o(s) ficheiro(s) seleccionado(s) : Sessão / Desde sempre"
 
-#: src/muuli_wdr.cpp:3271
+#: src/muuli_wdr.cpp:3275
 msgid "Active Uploads"
 msgstr "Uploads Activos"
 
-#: src/muuli_wdr.cpp:3285
+#: src/muuli_wdr.cpp:3289
 msgid "Percent of total files"
 msgstr "Percentagem dos ficheiros totais"
 
-#: src/muuli_wdr.cpp:3337
+#: src/muuli_wdr.cpp:3341
 msgid "Show Clients for"
 msgstr "Mostrar Clientes para"
 
-#: src/muuli_wdr.cpp:3339
+#: src/muuli_wdr.cpp:3343
 msgid "All files"
 msgstr "Todos os ficheiros"
 
-#: src/muuli_wdr.cpp:3342
+#: src/muuli_wdr.cpp:3346
 msgid "Selected files"
 msgstr "Ficheiros seleccionados"
 
-#: src/muuli_wdr.cpp:3345
+#: src/muuli_wdr.cpp:3349
 msgid "Active uploads only"
 msgstr "Apenas os uploads activos"
 
-#: src/muuli_wdr.cpp:3352
+#: src/muuli_wdr.cpp:3356
 msgid "Reload:"
 msgstr "Recarregar:"
 
-#: src/muuli_wdr.cpp:3356
+#: src/muuli_wdr.cpp:3360
 msgid "Reload your shared files"
 msgstr "Recarregar os seus ficheiros partilhados"
 
-#: src/muuli_wdr.cpp:3419
+#: src/muuli_wdr.cpp:3423
 msgid "Send"
 msgstr "Enviar"
 
-#: src/muuli_wdr.cpp:3420
+#: src/muuli_wdr.cpp:3424
 msgid "Sends the specified message."
 msgstr "Envia a mensagem especificada."
 
-#: src/muuli_wdr.cpp:3424
+#: src/muuli_wdr.cpp:3428
 msgid "Close this chat-session."
 msgstr "Fechar esta conversa."
 
-#: src/muuli_wdr.cpp:3447
+#: src/muuli_wdr.cpp:3451
 msgid "Connect to any server and/or Kad"
 msgstr "Ligar a qualquer servidor e/ou Kad"
 
-#: src/muuli_wdr.cpp:3453 src/SharedFilesCtrl.cpp:142 src/Statistics.cpp:941
+#: src/muuli_wdr.cpp:3457 src/SharedFilesCtrl.cpp:142 src/Statistics.cpp:941
 msgid "Shared Files"
 msgstr "Ficheiros Partilhados"
 
@@ -5758,35 +5758,35 @@ msgstr ""
 "O aMule correrá perfeitamente sem ajustar qualquer\n"
 "uma destas opções."
 
-#: src/PrefsUnifiedDlg.cpp:647
+#: src/PrefsUnifiedDlg.cpp:656
 #, c-format
 msgid "Failed to connect Cfg to widget with the ID %d and key %s"
 msgstr "Falhou ao ligar Cfg ao widget com o ID %d e chave %s"
 
-#: src/PrefsUnifiedDlg.cpp:695
+#: src/PrefsUnifiedDlg.cpp:704
 #, c-format
 msgid "Failed to transfer data from Cfg to Widget with the ID %d and key %s"
 msgstr "Falhou ao transferir dados do Cfg para o Widget com o ID %d e chave %s"
 
-#: src/PrefsUnifiedDlg.cpp:801
+#: src/PrefsUnifiedDlg.cpp:810
 msgid "The type of proxy you are connecting to"
 msgstr "O tipo de proxy ao qual está a ligar-se"
 
-#: src/PrefsUnifiedDlg.cpp:1020
+#: src/PrefsUnifiedDlg.cpp:1029
 #, c-format
 msgid "Failed to transfer data from Widget to Cfg with the ID %d and key %s"
 msgstr "Falhou ao transferir dados do Widget para o Cfg com o ID %d e chave %s"
 
-#: src/PrefsUnifiedDlg.cpp:1103
+#: src/PrefsUnifiedDlg.cpp:1112
 #, fuzzy
 msgid "No password set."
 msgstr "A verificar a palavra-passe\n"
 
-#: src/PrefsUnifiedDlg.cpp:1132
+#: src/PrefsUnifiedDlg.cpp:1141
 msgid "Guest access needs a password. Type one in the guest password field, or untick Enable guest access."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1144
+#: src/PrefsUnifiedDlg.cpp:1153
 msgid ""
 "aMule must be restarted to enable these changes:\n"
 "\n"
@@ -5794,42 +5794,42 @@ msgstr ""
 "O aMule tem de ser reiniciado para activar estas alterações:\n"
 "\n"
 
-#: src/PrefsUnifiedDlg.cpp:1151
+#: src/PrefsUnifiedDlg.cpp:1160
 msgid "- TCP port changed.\n"
 msgstr "- Porto TCP alterado.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1156
+#: src/PrefsUnifiedDlg.cpp:1165
 msgid "- UDP port changed.\n"
 msgstr "- Porto UDP alterado.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1161
+#: src/PrefsUnifiedDlg.cpp:1170
 #, fuzzy
 msgid "- Network interface binding changed.\n"
 msgstr "- Alterada interface para ligações externas.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1166
+#: src/PrefsUnifiedDlg.cpp:1175
 msgid "- External connect port changed.\n"
 msgstr "- Porta para ligações externas alterada.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1170
+#: src/PrefsUnifiedDlg.cpp:1179
 msgid "- External connect acceptance changed.\n"
 msgstr "- Alterada a aceitação de ligações externas.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1174
+#: src/PrefsUnifiedDlg.cpp:1183
 msgid "- External connect interface changed.\n"
 msgstr "- Alterada interface para ligações externas.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1178
+#: src/PrefsUnifiedDlg.cpp:1187
 #, fuzzy
 msgid "- Protocol obfuscation support changed.\n"
 msgstr "Ofuscação do Protocolo"
 
-#: src/PrefsUnifiedDlg.cpp:1193
+#: src/PrefsUnifiedDlg.cpp:1202
 #, fuzzy
 msgid "- amuleapi settings changed.\n"
 msgstr "- O idioma foi alterado.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1202
+#: src/PrefsUnifiedDlg.cpp:1211
 msgid ""
 "Your Auto-update server list is empty.\n"
 "'Auto-update server list at startup' will be disabled."
@@ -5837,7 +5837,7 @@ msgstr ""
 "A sua lista de actualização automática de servidores está vazia.\n"
 "A 'actualização automática no arranque' será desactivada."
 
-#: src/PrefsUnifiedDlg.cpp:1213
+#: src/PrefsUnifiedDlg.cpp:1222
 msgid ""
 "You have enabled external connections but have not specified a password.\n"
 "External connections cannot be enabled unless a valid password is specified."
@@ -5845,33 +5845,33 @@ msgstr ""
 "Activou as ligações externas mas não especificou uma palavra-passe.\n"
 "As ligações externas não podem ser activadas a menos que seja especificada uma palavra-passe válida."
 
-#: src/PrefsUnifiedDlg.cpp:1246
+#: src/PrefsUnifiedDlg.cpp:1255
 #, c-format
 msgid "The amuleapi password could not be saved: %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1276
+#: src/PrefsUnifiedDlg.cpp:1285
 msgid "- Language changed.\n"
 msgstr "- O idioma foi alterado.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1281
+#: src/PrefsUnifiedDlg.cpp:1290
 msgid "- Temp folder changed.\n"
 msgstr "- A pasta Temp foi alterada.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1286
+#: src/PrefsUnifiedDlg.cpp:1295
 msgid "- ED2K network enabled.\n"
 msgstr "- Rede ED2K activada.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1319
+#: src/PrefsUnifiedDlg.cpp:1328
 msgid "The shared-file exclusion pattern is not a valid regular expression. The filter has been left disabled."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1321 src/PrefsUnifiedDlg.cpp:1921
+#: src/PrefsUnifiedDlg.cpp:1330 src/PrefsUnifiedDlg.cpp:1930
 #, fuzzy
 msgid "Invalid regular expression"
 msgstr "Versão de protocolo inválida."
 
-#: src/PrefsUnifiedDlg.cpp:1398
+#: src/PrefsUnifiedDlg.cpp:1407
 msgid ""
 "Both eD2k and Kad network are disabled.\n"
 "You won't be able to connect until you enable at least one of them."
@@ -5879,7 +5879,7 @@ msgstr ""
 "As redes eD2K e Kad estão desactivados.\n"
 "Não vai conseguir uma ligação até activar pelo menos uma deles."
 
-#: src/PrefsUnifiedDlg.cpp:1403
+#: src/PrefsUnifiedDlg.cpp:1412
 msgid ""
 "Kad will not start if your UDP port is disabled.\n"
 "Enable UDP port or disable Kad."
@@ -5887,7 +5887,7 @@ msgstr ""
 "A Kad não vai funcionar se o porto UDP estiver desactivado.\n"
 "Active o porto UDP ou desactive a Kad."
 
-#: src/PrefsUnifiedDlg.cpp:1459
+#: src/PrefsUnifiedDlg.cpp:1468
 msgid ""
 "\n"
 "You MUST restart aMule now.\n"
@@ -5897,69 +5897,69 @@ msgstr ""
 "DEVE reiniciar o aMule agora.\n"
 "Se não o fizer, não se queixe se algo grave acontecer.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1524
+#: src/PrefsUnifiedDlg.cpp:1533
 msgid "Could not register aMule for autostart at login. The autostart store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1526
+#: src/PrefsUnifiedDlg.cpp:1535
 msgid "Could not remove the autostart-at-login entry."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1527
+#: src/PrefsUnifiedDlg.cpp:1536
 #, fuzzy
 msgid "Autostart"
 msgstr "Actualização automática iniciada"
 
-#: src/PrefsUnifiedDlg.cpp:1542
+#: src/PrefsUnifiedDlg.cpp:1551
 msgid "Register file type"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1542
+#: src/PrefsUnifiedDlg.cpp:1551
 msgid "Register URL handler"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1550
+#: src/PrefsUnifiedDlg.cpp:1559
 #, c-format
 msgid "aMule only handles eD2k-compatible magnets. If you replace the current magnet handler (%s), BitTorrent magnet links will stop working - aMule cannot download BitTorrent content. Continue?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1555
+#: src/PrefsUnifiedDlg.cpp:1564
 #, c-format
 msgid "Another application currently opens .emulecollection files (%s). Replace it with aMule?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1560
+#: src/PrefsUnifiedDlg.cpp:1569
 #, c-format
 msgid "Another application is currently the default handler for these links (%s). Replace it with aMule?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1585
+#: src/PrefsUnifiedDlg.cpp:1594
 msgid "Could not register aMule for .emulecollection files. The registration store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1587
+#: src/PrefsUnifiedDlg.cpp:1596
 #, fuzzy
 msgid "Could not remove the file type registration."
 msgstr "Pasta para ficheiros temporários"
 
-#: src/PrefsUnifiedDlg.cpp:1589
+#: src/PrefsUnifiedDlg.cpp:1598
 msgid "Could not register aMule as the URL handler. The registration store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1591
+#: src/PrefsUnifiedDlg.cpp:1600
 msgid "Could not remove the URL handler registration."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1661 src/PrefsUnifiedDlg.cpp:1688
+#: src/PrefsUnifiedDlg.cpp:1670 src/PrefsUnifiedDlg.cpp:1697
 #, fuzzy
 msgid "The web server and aMule API require external connections to be enabled."
 msgstr "Palavra-passe definida e permitidas as ligações externas."
 
-#: src/PrefsUnifiedDlg.cpp:1671
+#: src/PrefsUnifiedDlg.cpp:1680
 msgid "The aMule web server is deprecated. Consider running the aMule API instead."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1735
+#: src/PrefsUnifiedDlg.cpp:1744
 msgid ""
 "Your Auto-update servers list is in blank.\n"
 "Please fill in at least one URL to point to a valid server.met file.\n"
@@ -5969,66 +5969,66 @@ msgstr ""
 "Por favor, indique pelo menos uma localização que aponte para um ficheiro server.met válido.\n"
 "Clique no botão \"Lista\" para inserir uma localização."
 
-#: src/PrefsUnifiedDlg.cpp:1876
+#: src/PrefsUnifiedDlg.cpp:1885
 msgid "Temporary files"
 msgstr "Ficheiros temporários"
 
-#: src/PrefsUnifiedDlg.cpp:1881
+#: src/PrefsUnifiedDlg.cpp:1890
 msgid "Incoming files"
 msgstr "Ficheiros recebidos"
 
-#: src/PrefsUnifiedDlg.cpp:1886
+#: src/PrefsUnifiedDlg.cpp:1895
 msgid "Online Signatures"
 msgstr "Assinaturas Online"
 
-#: src/PrefsUnifiedDlg.cpp:1899
+#: src/PrefsUnifiedDlg.cpp:1908
 #, c-format
 msgid "Choose a folder for %s"
 msgstr "Seleccione uma pasta para %s"
 
-#: src/PrefsUnifiedDlg.cpp:1923
+#: src/PrefsUnifiedDlg.cpp:1932
 #, fuzzy, c-format
 msgid "Would exclude %u of %u shared file"
 msgid_plural "Would exclude %u of %u shared files"
 msgstr[0] "Encontrado %i ficheiro partilhado conhecido"
 msgstr[1] "Encontrados %i ficheiros partilhados conhecidos"
 
-#: src/PrefsUnifiedDlg.cpp:1940
+#: src/PrefsUnifiedDlg.cpp:1949
 msgid "Browse for videoplayer"
 msgstr "Procurar leitor de vídeo"
 
-#: src/PrefsUnifiedDlg.cpp:1944
+#: src/PrefsUnifiedDlg.cpp:1953
 msgid "Select browser"
 msgstr "Seleccionar navegador"
 
-#: src/PrefsUnifiedDlg.cpp:1948
+#: src/PrefsUnifiedDlg.cpp:1957
 #, fuzzy
 msgid "Select ffprobe binary"
 msgstr "Seleccionar navegador"
 
-#: src/PrefsUnifiedDlg.cpp:1954
+#: src/PrefsUnifiedDlg.cpp:1963
 #, c-format
 msgid "Executable%s"
 msgstr "Executável%s"
 
-#: src/PrefsUnifiedDlg.cpp:1988
+#: src/PrefsUnifiedDlg.cpp:1997
 msgid "ffprobe not found on PATH or in the standard install locations. Install ffmpeg (which ships ffprobe) or use Browse to pick a binary manually."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2000
+#: src/PrefsUnifiedDlg.cpp:2009
 msgid "Reset the settings on this page to their default values?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2001
+#: src/PrefsUnifiedDlg.cpp:2010
 #, fuzzy
 msgid "Reset to defaults"
 msgstr "Predefinição do sistema"
 
-#: src/PrefsUnifiedDlg.cpp:2028
+#: src/PrefsUnifiedDlg.cpp:2037
 msgid "Edit server list"
 msgstr "Editar a lista de servidores"
 
-#: src/PrefsUnifiedDlg.cpp:2029
+#: src/PrefsUnifiedDlg.cpp:2038
 msgid ""
 "Add here URL's to download server.met files.\n"
 "Only one url on each line."
@@ -6036,154 +6036,154 @@ msgstr ""
 "Adicione localizações para obter ficheiros server.met\n"
 "Apenas uma localização por linha."
 
-#: src/PrefsUnifiedDlg.cpp:2084
+#: src/PrefsUnifiedDlg.cpp:2093
 msgid "IP2Country update failed"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2229 src/PrefsUnifiedDlg.cpp:2260
+#: src/PrefsUnifiedDlg.cpp:2238 src/PrefsUnifiedDlg.cpp:2269
 msgid "Data by MaxMind GeoLite2"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2231 src/PrefsUnifiedDlg.cpp:2262
+#: src/PrefsUnifiedDlg.cpp:2240 src/PrefsUnifiedDlg.cpp:2271
 #, fuzzy
 msgid "Custom source"
 msgstr "Fontes completas"
 
-#: src/PrefsUnifiedDlg.cpp:2233 src/PrefsUnifiedDlg.cpp:2264
+#: src/PrefsUnifiedDlg.cpp:2242 src/PrefsUnifiedDlg.cpp:2273
 msgid "Data by DB-IP.com"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2284
+#: src/PrefsUnifiedDlg.cpp:2293
 #, fuzzy, c-format
 msgid "Status: Loaded%s"
 msgstr "Estado:"
 
-#: src/PrefsUnifiedDlg.cpp:2286
+#: src/PrefsUnifiedDlg.cpp:2295
 #, fuzzy, c-format
 msgid "Status: Loaded%s - %s"
 msgstr "Estado:"
 
-#: src/PrefsUnifiedDlg.cpp:2290
+#: src/PrefsUnifiedDlg.cpp:2299
 msgid "Status: Failed to load - click 'Update now' to refresh."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2292
+#: src/PrefsUnifiedDlg.cpp:2301
 msgid "Status: Not found - click 'Update now' to download."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2350 src/PrefsUnifiedDlg.cpp:2374
+#: src/PrefsUnifiedDlg.cpp:2359 src/PrefsUnifiedDlg.cpp:2383
 #, c-format
 msgid "Update delay: %d second"
 msgid_plural "Update delay: %d seconds"
 msgstr[0] "Intervalo de actualização: %d segundo"
 msgstr[1] "Intervalo de actualização: %d segundos"
 
-#: src/PrefsUnifiedDlg.cpp:2358
+#: src/PrefsUnifiedDlg.cpp:2367
 #, c-format
 msgid "Time for average graph: %d minute"
 msgid_plural "Time for average graph: %d minutes"
 msgstr[0] "Tempo para o gráfico de média: %d minuto"
 msgstr[1] "Tempo para o gráfico de média: %d minutos"
 
-#: src/PrefsUnifiedDlg.cpp:2367
+#: src/PrefsUnifiedDlg.cpp:2376
 #, c-format
 msgid "Connections Graph Scale: %d"
 msgstr "Escala do Gráfico de Ligações: %d"
 
-#: src/PrefsUnifiedDlg.cpp:2382
+#: src/PrefsUnifiedDlg.cpp:2391
 #, c-format
 msgid "File Buffer Size: %d byte"
 msgid_plural "File Buffer Size: %d bytes"
 msgstr[0] "Tamanho de memória temporária de ficheiros: %d byte"
 msgstr[1] "Tamanho de memória temporária de ficheiros: %d bytes"
 
-#: src/PrefsUnifiedDlg.cpp:2392
+#: src/PrefsUnifiedDlg.cpp:2401
 #, c-format
 msgid "Upload Queue Size: %d client"
 msgid_plural "Upload Queue Size: %d clients"
 msgstr[0] "Tamanho da fila de espera de upload: %d cliente"
 msgstr[1] "Tamanho da fila de espera de upload: %d clientes"
 
-#: src/PrefsUnifiedDlg.cpp:2402
+#: src/PrefsUnifiedDlg.cpp:2411
 #, c-format
 msgid "Server connection refresh interval: %d minute"
 msgid_plural "Server connection refresh interval: %d minutes"
 msgstr[0] "Intervalo de actualização de ligação ao servidor: %d minuto"
 msgstr[1] "Intervalo de actualização de ligação ao servidor: %d minutos"
 
-#: src/PrefsUnifiedDlg.cpp:2407
+#: src/PrefsUnifiedDlg.cpp:2416
 msgid "Server connection refresh interval: Disabled"
 msgstr "Intervalo de actualização de ligação ao servidor: Desactivado"
 
-#: src/PrefsUnifiedDlg.cpp:2451
+#: src/PrefsUnifiedDlg.cpp:2460
 msgid "disabled"
 msgstr "desactivado"
 
-#: src/PrefsUnifiedDlg.cpp:2477
+#: src/PrefsUnifiedDlg.cpp:2486
 #, c-format
 msgid "Execute command on '%s' event"
 msgstr "Executar o comando quando ocorrer o evento '%s'"
 
-#: src/PrefsUnifiedDlg.cpp:2484
+#: src/PrefsUnifiedDlg.cpp:2493
 msgid "Enable command execution on core"
 msgstr "Activar execução de comandos no núcleo"
 
-#: src/PrefsUnifiedDlg.cpp:2496
+#: src/PrefsUnifiedDlg.cpp:2505
 msgid "Core command:"
 msgstr "Comando de núcleo:"
 
-#: src/PrefsUnifiedDlg.cpp:2512
+#: src/PrefsUnifiedDlg.cpp:2521
 msgid "Enable command execution on GUI"
 msgstr "Activar execução de comando na interface gráfica"
 
-#: src/PrefsUnifiedDlg.cpp:2524
+#: src/PrefsUnifiedDlg.cpp:2533
 msgid "GUI command:"
 msgstr "Comando da interface gráfica:"
 
-#: src/PrefsUnifiedDlg.cpp:2540
+#: src/PrefsUnifiedDlg.cpp:2549
 msgid "The following variables will be replaced:"
 msgstr "As seguintes variáveis serão substituídas:"
 
-#: src/PrefsUnifiedDlg.cpp:2708
+#: src/PrefsUnifiedDlg.cpp:2717
 msgid ""
 "The following folders look like system or sensitive locations:\n"
 "\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2713
+#: src/PrefsUnifiedDlg.cpp:2722
 msgid "Sharing them recursively will publish every file underneath on the eD2k/Kad networks. Do you really want to do this?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2716
+#: src/PrefsUnifiedDlg.cpp:2725
 #, fuzzy
 msgid "Confirm shared folders"
 msgstr "Pastas partilhadas"
 
-#: src/PrefsUnifiedDlg.cpp:2744
+#: src/PrefsUnifiedDlg.cpp:2753
 #, fuzzy
 msgid "Reloading shared files..."
 msgstr "Recarregar os seus ficheiros partilhados"
 
-#: src/PrefsUnifiedDlg.cpp:2745
+#: src/PrefsUnifiedDlg.cpp:2754
 msgid "Scanning for subdirectories..."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2746
+#: src/PrefsUnifiedDlg.cpp:2755
 #, fuzzy
 msgid "Updating shared folders"
 msgstr "Pastas partilhadas"
 
-#: src/PrefsUnifiedDlg.cpp:2773
+#: src/PrefsUnifiedDlg.cpp:2782
 #, c-format
 msgid "Scanned %u directories..."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2823
+#: src/PrefsUnifiedDlg.cpp:2832
 #, fuzzy, c-format
 msgid "Reloading shared files: %u files scanned"
 msgstr "Recarrega a lista de ficheiros partilhados."
 
-#: src/PrefsUnifiedDlg.cpp:2873
+#: src/PrefsUnifiedDlg.cpp:2882
 #, fuzzy
 msgid "Shared folder"
 msgstr "Pastas partilhadas"
@@ -7865,12 +7865,12 @@ msgstr "Remover categoria"
 msgid "Hashset requested for unknown file: %s"
 msgstr "Conjunto de chaves pedido para ficheiro desconhecido: %s"
 
-#: src/UploadQueue.cpp:618
+#: src/UploadQueue.cpp:627
 #, c-format
 msgid "Resuming uploads of file: %s"
 msgstr "A continuar uploads do ficheiro: %s"
 
-#: src/UploadQueue.cpp:634
+#: src/UploadQueue.cpp:643
 #, c-format
 msgid "Suspending upload of file: %s"
 msgstr "A suspender upload do ficheiro: %s"

--- a/po/pt_PT.po
+++ b/po/pt_PT.po
@@ -17,8 +17,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-28 12:12+0200\n"
-"PO-Revision-Date: 2026-07-27 10:31+0000\n"
+"POT-Creation-Date: 2026-07-28 08:06+0200\n"
+"PO-Revision-Date: 2026-07-27 11:44+0000\n"
 "Last-Translator: Luís Picciochi Oliveira <Pitxyoki@Gmail.com>\n"
 "Language-Team: Portuguese <traduz@debianpt.org>\n"
 "Language: pt_PT\n"
@@ -152,7 +152,7 @@ msgstr ""
 msgid "Not now"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:422 src/amuleDlg.cpp:665
+#: src/AppImageIntegration.cpp:422 src/amuleDlg.cpp:600
 msgid "Don't ask again"
 msgstr ""
 
@@ -210,83 +210,83 @@ msgstr "Falha ao abrir ficheiro de ligações eD2k."
 msgid "WARNING: You can't add yourself as a source for an eD2k link while having a lowid."
 msgstr "AVISO: Não se pode adicionar a si próprio como fonte para um link eD2k enquanto tiver lowid."
 
-#: src/amule.cpp:301
+#: src/amule.cpp:300
 msgid "Now, exiting main app..."
 msgstr "A fechar a aplicação..."
 
-#: src/amule.cpp:331
+#: src/amule.cpp:330
 #, c-format
 msgid "Terminating amuleweb instance with pid '%d' ... "
 msgstr "A terminar instância do amuleweb com o pid '%d' ... "
 
-#: src/amule.cpp:335
+#: src/amule.cpp:334
 #, c-format
 msgid "Killing amuleweb instance with pid '%d' ... "
 msgstr "A matar instância do amuleweb com o pid '%d' ... "
 
-#: src/amule.cpp:337 src/amule.cpp:350 src/ClientRef.cpp:180
-#: src/SearchDlg.cpp:1041 src/ServerListCtrl.cpp:98
+#: src/amule.cpp:336 src/amule.cpp:349 src/ClientRef.cpp:180
+#: src/SearchDlg.cpp:880 src/ServerListCtrl.cpp:98
 msgid "Failed"
 msgstr "Falhas"
 
-#: src/amule.cpp:344
+#: src/amule.cpp:343
 #, fuzzy, c-format
 msgid "Terminating amuleapi instance with pid '%d' ... "
 msgstr "A terminar instância do amuleweb com o pid '%d' ... "
 
-#: src/amule.cpp:348
+#: src/amule.cpp:347
 #, fuzzy, c-format
 msgid "Killing amuleapi instance with pid '%d' ... "
 msgstr "A matar instância do amuleweb com o pid '%d' ... "
 
-#: src/amule.cpp:356
+#: src/amule.cpp:355
 msgid "aMule OnExit: Terminating core."
 msgstr "aMule OnExit: A terminar núcleo."
 
-#: src/amule.cpp:467
+#: src/amule.cpp:466
 msgid "aMule shutdown completed."
 msgstr "aMule terminado."
 
-#: src/amule.cpp:471
+#: src/amule.cpp:470
 msgid "Memory debug results for aMule exit:"
 msgstr "Resultados da depuração de memória para a saída do aMule:"
 
-#: src/amule.cpp:652
+#: src/amule.cpp:651
 #, c-format
 msgid "Binding aMule's peer-to-peer traffic to interface: %s (HTTP updates use the default route)"
 msgstr ""
 
-#: src/amule.cpp:656
+#: src/amule.cpp:655
 #, c-format
 msgid "Binding all network traffic to interface: %s"
 msgstr ""
 
-#: src/amule.cpp:660
+#: src/amule.cpp:659
 #, c-format
 msgid "WARNING: configured network interface '%s' was not found - traffic is NOT bound to it and may leave via the default route. Check the interface name in Preferences."
 msgstr ""
 
-#: src/amule.cpp:666
+#: src/amule.cpp:665
 #, c-format
 msgid "WARNING: binding to network interface '%s' requires elevated privileges and was NOT applied - traffic may leave via the default route. Grant the capability (e.g. 'sudo setcap cap_net_raw+ep' on the aMule binary) or run with sufficient privileges."
 msgstr ""
 
-#: src/amule.cpp:674
+#: src/amule.cpp:673
 #, c-format
 msgid "WARNING: could not bind to network interface '%s' - traffic may leave via the default route."
 msgstr ""
 
-#: src/amule.cpp:733
+#: src/amule.cpp:732
 msgid "Your locale has been changed to System Default due to a configuration change. Sorry."
 msgstr "O seu idioma foi alterado para a predefinição do sistema devido a uma mudança de configuração. Desculpe."
 
-#: src/amule.cpp:735 src/amule.cpp:1589 src/CatDialog.cpp:128
+#: src/amule.cpp:734 src/amule.cpp:1581 src/CatDialog.cpp:128
 #: src/CatDialog.cpp:136 src/CatDialog.cpp:149 src/ServerList.cpp:366
 #: src/ServerListCtrl.cpp:152
 msgid "Info"
 msgstr "Informação"
 
-#: src/amule.cpp:742
+#: src/amule.cpp:741
 msgid ""
 "\n"
 "EC configuration"
@@ -294,74 +294,74 @@ msgstr ""
 "\n"
 "Configuração das LE"
 
-#: src/amule.cpp:745
+#: src/amule.cpp:744
 msgid "Password set and external connections enabled."
 msgstr "Palavra-passe definida e permitidas as ligações externas."
 
-#: src/amule.cpp:755 src/KadDlg.cpp:176 src/KadDlg.cpp:185
-#: src/PrefsUnifiedDlg.cpp:1461 src/SharedFilesCtrl.cpp:476
+#: src/amule.cpp:754 src/KadDlg.cpp:176 src/KadDlg.cpp:185
+#: src/PrefsUnifiedDlg.cpp:1387 src/SharedFilesCtrl.cpp:476
 msgid "WARNING"
 msgstr "AVISO"
 
-#: src/amule.cpp:992
+#: src/amule.cpp:991
 #, fuzzy
 msgid "Network bootstrap"
 msgstr "Redes"
 
-#: src/amule.cpp:997
+#: src/amule.cpp:996
 msgid ""
 "aMule has detected missing network bootstrap files.\n"
 "Select which ones to download:"
 msgstr ""
 
-#: src/amule.cpp:1006 src/FirstRunWizard.cpp:411
+#: src/amule.cpp:1005 src/FirstRunWizard.cpp:411
 #, fuzzy
 msgid "eD2k server list (server.met)"
 msgstr "Foi encontrado %i servidor no server.met"
 
-#: src/amule.cpp:1013 src/FirstRunWizard.cpp:416
+#: src/amule.cpp:1012 src/FirstRunWizard.cpp:416
 msgid "Kad bootstrap nodes (nodes.dat)"
 msgstr ""
 
-#: src/amule.cpp:1103
+#: src/amule.cpp:1102
 #, c-format
 msgid "web server running on pid %d"
 msgstr "servidor web a executar no pid %d"
 
-#: src/amule.cpp:1116
+#: src/amule.cpp:1115
 #, fuzzy
 msgid "You requested to run web server on startup, but the amuleweb binary cannot be run. Please install the package containing aMule web server, or build aMule from source with -DBUILD_WEBSERVER=YES and install it."
 msgstr "Pediu para executar o servidor web no arranque, mas o executável não pode ser lançado. Por favor, instale o pacote que contém o servidor web ou compile o aMule com --enable-webserver e execute make install"
 
-#: src/amule.cpp:1121 src/amule.cpp:1185 src/amule.cpp:1299 src/amule.cpp:1601
+#: src/amule.cpp:1120 src/amule.cpp:1177 src/amule.cpp:1291 src/amule.cpp:1593
 #: src/amule-remote-gui.cpp:603 src/amule-remote-gui.cpp:671
 #: src/amule-remote-gui.cpp:709 src/amule-remote-gui.cpp:1282
 #: src/amule-remote-gui.cpp:1345 src/amule-remote-gui.cpp:1372
-#: src/DownloadQueue.cpp:1481 src/PrefsUnifiedDlg.cpp:1247
+#: src/DownloadQueue.cpp:1481
 msgid "ERROR"
 msgstr "ERRO"
 
-#: src/amule.cpp:1174
+#: src/amule.cpp:1166
 #, fuzzy, c-format
 msgid "amuleapi running on pid %d"
 msgstr "servidor web a executar no pid %d"
 
-#: src/amule.cpp:1180
+#: src/amule.cpp:1172
 #, fuzzy
 msgid "You requested to run amuleapi on startup, but the amuleapi binary cannot be run. Please install the package containing aMule's REST API server, or build aMule from source with -DBUILD_AMULEAPI=YES and install it."
 msgstr "Pediu para executar o servidor web no arranque, mas o executável não pode ser lançado. Por favor, instale o pacote que contém o servidor web ou compile o aMule com --enable-webserver e execute make install"
 
-#: src/amule.cpp:1267
+#: src/amule.cpp:1259
 #, c-format
 msgid "Could not bind ports to the specified address: %s"
 msgstr "Não foi possível associar os portos ao endereço especificado: %s"
 
-#: src/amule.cpp:1291
+#: src/amule.cpp:1283
 #, c-format
 msgid "Port %u is not available. You will be LOWID\n"
 msgstr "O porto %u não está disponível. Ficará com LOWID\n"
 
-#: src/amule.cpp:1296
+#: src/amule.cpp:1288
 #, c-format
 msgid ""
 "Port %u is not available!\n"
@@ -376,48 +376,48 @@ msgstr ""
 "\n"
 "Verifique a sua rede para se certificar de que o porto está aberto para leitura e escrita."
 
-#: src/amule.cpp:1393
+#: src/amule.cpp:1385
 msgid "Failed to create OnlineSig File"
 msgstr "Erro ao criar o ficheiro da Assinatura Online"
 
-#: src/amule.cpp:1401
+#: src/amule.cpp:1393
 msgid "Failed to create aMule OnlineSig File"
 msgstr "Erro a criar o ficheiro da Assinatura Online do aMule"
 
-#: src/amule.cpp:1564
+#: src/amule.cpp:1556
 msgid "The selected locale seems not to be installed on your box. (Note: I'll try to set it anyway)"
 msgstr "O idioma seleccionado parece não estar instalado no seu computador. (Nota: de qualquer das formas, irei tentar activá-lo)"
 
-#: src/amule.cpp:1574
+#: src/amule.cpp:1566
 #, c-format
 msgid "This is the first time you run aMule %s"
 msgstr "Esta é a primeira vez que executa o aMule %s"
 
-#: src/amule.cpp:1577
+#: src/amule.cpp:1569
 msgid "This version is a testing version, updated daily, and\n"
 msgstr "Esta é uma versão de testes actualizada diariamente e\n"
 
-#: src/amule.cpp:1578
+#: src/amule.cpp:1570
 msgid "we give no warranty it won't break anything, burn your house,\n"
 msgstr "não há qualquer garantia de que não irá partir nada, pegar fogo à sua casa,\n"
 
-#: src/amule.cpp:1579
+#: src/amule.cpp:1571
 msgid "or kill your dog. But it *should* be safe to use anyway.\n"
 msgstr "ou matar o seu cão. Mas, *em princípio*, deverá ser seguro usá-lo.\n"
 
-#: src/amule.cpp:1584
+#: src/amule.cpp:1576
 msgid "More information, support and new releases can found at our homepage,\n"
 msgstr "Mais informação, suporte e novos lançamentos na nossa página,\n"
 
-#: src/amule.cpp:1585
+#: src/amule.cpp:1577
 msgid "at https://amule-org.github.io, or in our IRC channel #aMule at irc.libera.chat.\n"
 msgstr "em amule-org.github.io ou no canal de IRC #aMule em irc.libera.chat.\n"
 
-#: src/amule.cpp:1587
+#: src/amule.cpp:1579
 msgid "Feel free to report any bugs to https://github.com/amule-org/amule/issues"
 msgstr "Esteja à vontade para comunicar erros para https://github.com/amule-org/amule/issues"
 
-#: src/amule.cpp:1599
+#: src/amule.cpp:1591
 msgid ""
 "The folder for Online Signature files you specified is INVALID!\n"
 " OnlineSignature will be DISABLED until you fix it on preferences."
@@ -425,137 +425,137 @@ msgstr ""
 "A pasta para os ficheiros da Assinatura Online é INVÁLIDA!\n"
 " A Assinatura Online será DESACTIVADA até que resolva a situação nas preferências."
 
-#: src/amule.cpp:1662
+#: src/amule.cpp:1654
 msgid "Server hostname notified"
 msgstr "Servidor notificado"
 
-#: src/amule.cpp:2039
+#: src/amule.cpp:2031
 #, c-format
 msgid "Disk space preallocation for file '%s' failed: %s"
 msgstr "Reserva de espaço em disco para o ficheiro '%s' falhou: %s"
 
-#: src/amule.cpp:2168
+#: src/amule.cpp:2160
 msgid "ERROR: can't open logfile"
 msgstr "ERRO: não é possível abrir o ficheiro de relatório"
 
-#: src/amule.cpp:2172
+#: src/amule.cpp:2164
 msgid "WARNING: logfile is empty. Something is wrong."
 msgstr "AVISO: o ficheiro de relatório está vazio. Algo está mal."
 
-#: src/amule.cpp:2189
+#: src/amule.cpp:2181
 msgid "Log has been reset"
 msgstr "O relatório foi limpo"
 
-#: src/amule.cpp:2213
+#: src/amule.cpp:2205
 #, c-format
 msgid "ServerMessage: %s"
 msgstr "Mensagem do servidor: %s"
 
-#: src/amule.cpp:2256 src/IP2Country.cpp:220 src/IPFilter.cpp:514
+#: src/amule.cpp:2248 src/IP2Country.cpp:220 src/IPFilter.cpp:514
 #: src/ServerList.cpp:875
 #, c-format
 msgid "Skipped download of %s, because requested file is not newer."
 msgstr "O download de %s não foi feito porque o ficheiro requisitado não é mais recente."
 
-#: src/amule.cpp:2259
+#: src/amule.cpp:2251
 msgid "Failed to download the nodes list."
 msgstr "Falha ao transferir a lista de nós."
 
-#: src/amule.cpp:2322
+#: src/amule.cpp:2314
 msgid "Failed to open the downloaded version check file"
 msgstr "Falha ao abrir o ficheiro de verificação de versão transferido"
 
-#: src/amule.cpp:2325 src/amule.cpp:2344
+#: src/amule.cpp:2317 src/amule.cpp:2336
 msgid "Corrupted version check file"
 msgstr "Ficheiro de verificação de versão corrompido"
 
-#: src/amule.cpp:2367
+#: src/amule.cpp:2359
 msgid "You are using an outdated version of aMule!"
 msgstr "Está a usar uma versão antiga do aMule!"
 
-#: src/amule.cpp:2369
+#: src/amule.cpp:2361
 #, c-format
 msgid "Your aMule version is %i.%i.%i and the latest version is %li.%li.%li"
 msgstr "A sua versão do aMule é %i.%i.%i e a última versão é %li.%li.%li"
 
-#: src/amule.cpp:2373
+#: src/amule.cpp:2365
 msgid "The latest version can always be found at https://github.com/amule-org/amule/releases/latest"
 msgstr "A última versão pode ser sempre encontrada em https://github.com/amule-org/amule/releases/latest"
 
-#: src/amule.cpp:2376
+#: src/amule.cpp:2368
 #, c-format
 msgid "WARNING: Your aMuled version is outdated: %i.%i.%i < %li.%li.%li"
 msgstr "AVISO: A sua versão do aMuled está desactualizada: %i.%i.%i < %li.%li.%li"
 
-#: src/amule.cpp:2382
+#: src/amule.cpp:2374
 msgid "Your copy of aMule is up to date."
 msgstr "A sua cópia do aMule está actualizada."
 
-#: src/amule.cpp:2389
+#: src/amule.cpp:2381
 msgid "Failed to download the version check file"
 msgstr "Falha ao transferir o ficheiro de verificação de versão"
 
-#: src/amule.cpp:2558 src/amule-remote-gui.cpp:1133
+#: src/amule.cpp:2550 src/amule-remote-gui.cpp:1133
 #, c-format
 msgid "Users: %s | Files: %s"
 msgstr "Utilizadores: %s | Ficheiros: %s"
 
-#: src/amule.cpp:2559 src/amule-remote-gui.cpp:1134
+#: src/amule.cpp:2551 src/amule-remote-gui.cpp:1134
 #, c-format
 msgid "Users: E: %s K: %s | Files: E: %s K: %s"
 msgstr "Utilizadores: E: %s K: %s | Ficheiros: E: %s K: %s"
 
-#: src/amule.cpp:2573 src/amule-remote-gui.cpp:1147
+#: src/amule.cpp:2565 src/amule-remote-gui.cpp:1147
 msgid "No networks selected"
 msgstr "Não foram seleccionadas redes"
 
-#: src/amule.cpp:2641 src/TextClient.cpp:903
+#: src/amule.cpp:2633 src/TextClient.cpp:903
 msgid "with LowID"
 msgstr "com LowID"
 
-#: src/amule.cpp:2641 src/TextClient.cpp:904
+#: src/amule.cpp:2633 src/TextClient.cpp:904
 msgid "with HighID"
 msgstr "com HighID"
 
-#: src/amule.cpp:2643
+#: src/amule.cpp:2635
 #, c-format
 msgid "Connected to %s %s"
 msgstr "Ligado a %s %s"
 
-#: src/amule.cpp:2648
+#: src/amule.cpp:2640
 #, c-format
 msgid "Connecting to %s"
 msgstr "A ligar a %s"
 
-#: src/amule.cpp:2650
+#: src/amule.cpp:2642
 msgid "Disconnected from eD2k"
 msgstr "Desligado da eD2k"
 
-#: src/amule.cpp:2659
+#: src/amule.cpp:2651
 msgid "Kad started."
 msgstr "Kad iniciada."
 
-#: src/amule.cpp:2661
+#: src/amule.cpp:2653
 msgid "Kad stopped."
 msgstr "Kad parada."
 
-#: src/amule.cpp:2669
+#: src/amule.cpp:2661
 msgid "Connected to Kad (ok)"
 msgstr "Ligado à Kad (ok)"
 
-#: src/amule.cpp:2671
+#: src/amule.cpp:2663
 msgid "Connected to Kad (firewalled)"
 msgstr "Ligado à Kad (atrás de firewall)"
 
-#: src/amule.cpp:2675
+#: src/amule.cpp:2667
 msgid "Disconnected from Kad"
 msgstr "Desligado da Kad"
 
-#: src/amule.cpp:2707
+#: src/amule.cpp:2699
 msgid "Kad network cannot be used if UDP port is disabled on preferences, not starting."
 msgstr "A rede Kad não pode ser usada se o porto UDP estiver desactivado nas preferências, inicialização não efectuada."
 
-#: src/amule.cpp:2711
+#: src/amule.cpp:2703
 msgid "Kad network disabled on preferences, not connecting."
 msgstr "Rede Kad desligada nas preferências, a ligação não será efectuada."
 
@@ -581,68 +581,30 @@ msgstr "Não foi Possível Criar o Ficheiro de Pid"
 msgid "ERROR: %s"
 msgstr "ERRO: %s"
 
-#: src/amuleDlg.cpp:250
+#: src/amuleDlg.cpp:236
 #, c-format
 msgid "This is aMule %s based on eMule."
 msgstr "Este é o aMule %s, baseado no eMule."
 
-#: src/amuleDlg.cpp:251
+#: src/amuleDlg.cpp:237
 #, c-format
 msgid "Running on %s"
 msgstr "A correr em %s"
 
-#: src/amuleDlg.cpp:253
+#: src/amuleDlg.cpp:239
 msgid "Visit https://github.com/amule-org/amule/releases/latest to check if a new version is available."
 msgstr "Visite https://github.com/amule-org/amule/releases/latest para verificar se há novas versões."
 
-#: src/amuleDlg.cpp:282
+#: src/amuleDlg.cpp:268
 msgid "FATAL ERROR: Failed to create Timer"
 msgstr "ERRO FATAL: Falha ao criar Temporizador"
 
-#: src/amuleDlg.cpp:361 src/amuleDlg.cpp:1810 src/amuleDlg.cpp:2056
-#: src/muuli_wdr.cpp:1492 src/muuli_wdr.cpp:3439
-msgid "Networks"
-msgstr "Redes"
-
-#: src/amuleDlg.cpp:362 src/amuleDlg.cpp:1816 src/muuli_wdr.cpp:3440
-msgid "Searches"
-msgstr "Pesquisas"
-
-#: src/amuleDlg.cpp:363 src/amuleDlg.cpp:1822 src/DownloadListCtrl.cpp:740
-#: src/muuli_wdr.cpp:392 src/muuli_wdr.cpp:1585 src/muuli_wdr.cpp:3441
-#: src/Statistics.cpp:829
-msgid "Downloads"
-msgstr "Downloads"
-
-#: src/amuleDlg.cpp:364 src/amuleDlg.cpp:1828 src/muuli_wdr.cpp:3315
-msgid "Shared files"
-msgstr "Ficheiros partilhados"
-
-#: src/amuleDlg.cpp:365 src/amuleDlg.cpp:1834 src/muuli_wdr.cpp:2947
-#: src/muuli_wdr.cpp:3397 src/muuli_wdr.cpp:3444
-msgid "Messages"
-msgstr "Mensagens"
-
-#: src/amuleDlg.cpp:366 src/amuleDlg.cpp:1840 src/muuli_wdr.cpp:3445
-#: src/PrefsUnifiedDlg.cpp:314 src/Statistics.cpp:779 src/Statistics.cpp:1235
-msgid "Statistics"
-msgstr "Estatísticas"
-
-#: src/amuleDlg.cpp:368 src/amuleDlg.cpp:1847 src/muuli_wdr.cpp:3447
-#: src/PrefsUnifiedDlg.cpp:330 src/utils/wxCas/src/wxcasprefs.cpp:39
-msgid "Preferences"
-msgstr "Preferências"
-
-#: src/amuleDlg.cpp:371
-msgid "Navigate"
-msgstr ""
-
-#: src/amuleDlg.cpp:657
+#: src/amuleDlg.cpp:592
 #, fuzzy
 msgid "New version available"
 msgstr "Indisponível"
 
-#: src/amuleDlg.cpp:661
+#: src/amuleDlg.cpp:596
 #, fuzzy, c-format
 msgid ""
 "A new version of aMule (%s) is available.\n"
@@ -652,185 +614,218 @@ msgid ""
 "Would you like to open the download page?"
 msgstr "A última versão pode ser sempre encontrada em https://github.com/amule-org/amule/releases/latest"
 
-#: src/amuleDlg.cpp:743
+#: src/amuleDlg.cpp:678
 msgid "aMule dialog destroyed"
 msgstr "Caixa de diálogo do aMule destruída"
 
-#: src/amuleDlg.cpp:766 src/DataToText.cpp:68 src/IPFilter.cpp:547
+#: src/amuleDlg.cpp:701 src/DataToText.cpp:68 src/IPFilter.cpp:547
 msgid "Connecting"
 msgstr "A Ligar"
 
-#: src/amuleDlg.cpp:958
+#: src/amuleDlg.cpp:893
 msgid "eD2k: Connecting"
 msgstr "eD2k: A Ligar"
 
-#: src/amuleDlg.cpp:962
+#: src/amuleDlg.cpp:897
 msgid "eD2k: Disconnected"
 msgstr "eD2k: Desligado"
 
-#: src/amuleDlg.cpp:968
+#: src/amuleDlg.cpp:903
 msgid "Kad: Firewalled"
 msgstr "Kad: Atrás de firewall"
 
-#: src/amuleDlg.cpp:972
+#: src/amuleDlg.cpp:907
 msgid "Kad: Connected"
 msgstr "Kad: Ligado"
 
-#: src/amuleDlg.cpp:977
+#: src/amuleDlg.cpp:912
 msgid "Kad: Connecting"
 msgstr "Kad: A Ligar"
 
-#: src/amuleDlg.cpp:981
+#: src/amuleDlg.cpp:916
 msgid "Kad: Off"
 msgstr "Kad: Desligado"
 
-#: src/amuleDlg.cpp:1029 src/DownloadListCtrl.cpp:505
+#: src/amuleDlg.cpp:964 src/DownloadListCtrl.cpp:505
 #: src/DownloadListCtrl.cpp:749 src/FriendListCtrl.cpp:180
 #: src/muuli_wdr.cpp:731 src/muuli_wdr.cpp:782 src/muuli_wdr.cpp:846
-#: src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2252 src/muuli_wdr.cpp:2337
-#: src/muuli_wdr.cpp:3085 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
+#: src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2224 src/muuli_wdr.cpp:2309
+#: src/muuli_wdr.cpp:3057 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
 #: src/ServerListCtrl.cpp:606 src/TransferWnd.cpp:378
 #: src/utils/wxCas/src/wxcasprefs.cpp:235
 msgid "Cancel"
 msgstr "Cancelar"
 
-#: src/amuleDlg.cpp:1030
+#: src/amuleDlg.cpp:965
 msgid "Stop the current connection attempts"
 msgstr "Cancela as tentativas de ligação actuais"
 
-#: src/amuleDlg.cpp:1035 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976
-#: src/muuli_wdr.cpp:2475
+#: src/amuleDlg.cpp:970 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976
+#: src/muuli_wdr.cpp:2447
 msgid "Disconnect"
 msgstr "Desligar"
 
-#: src/amuleDlg.cpp:1036
+#: src/amuleDlg.cpp:971
 msgid "Disconnect from the currently connected networks"
 msgstr "Desligar das redes presentemente ligadas"
 
-#: src/amuleDlg.cpp:1041 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979
-#: src/muuli_wdr.cpp:2630 src/muuli_wdr.cpp:3082 src/muuli_wdr.cpp:3437
+#: src/amuleDlg.cpp:976 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979
+#: src/muuli_wdr.cpp:2602 src/muuli_wdr.cpp:3054 src/muuli_wdr.cpp:3409
 msgid "Connect"
 msgstr "Ligar"
 
-#: src/amuleDlg.cpp:1042
+#: src/amuleDlg.cpp:977
 msgid "Connect to the currently enabled networks"
 msgstr "Ligar às redes presentemente activadas"
 
-#: src/amuleDlg.cpp:1154
+#: src/amuleDlg.cpp:1089
 #, fuzzy, c-format
 msgid "Up: %.1f%s (%.1f) | Down: %.1f%s (%.1f)"
 msgstr "Up: %.1f(%.1f) | Down: %.1f(%.1f)"
 
-#: src/amuleDlg.cpp:1156 src/amuleDlg.cpp:1158 src/amuleDlg.cpp:1162
-#: src/amuleDlg.cpp:1164 src/amuleDlg.cpp:1175 src/amuleDlg.cpp:1177
+#: src/amuleDlg.cpp:1091 src/amuleDlg.cpp:1093 src/amuleDlg.cpp:1097
+#: src/amuleDlg.cpp:1099 src/amuleDlg.cpp:1110 src/amuleDlg.cpp:1112
 #: src/MuleTrayIcon.cpp:796 src/MuleTrayIcon.cpp:799
 #, fuzzy
 msgid " MB/s"
 msgstr "MB/s"
 
-#: src/amuleDlg.cpp:1156 src/amuleDlg.cpp:1158 src/amuleDlg.cpp:1162
-#: src/amuleDlg.cpp:1164 src/amuleDlg.cpp:1175 src/amuleDlg.cpp:1177
+#: src/amuleDlg.cpp:1091 src/amuleDlg.cpp:1093 src/amuleDlg.cpp:1097
+#: src/amuleDlg.cpp:1099 src/amuleDlg.cpp:1110 src/amuleDlg.cpp:1112
 #: src/MuleTrayIcon.cpp:796 src/MuleTrayIcon.cpp:799
 #: src/utils/wxCas/src/wxcasframe.cpp:1041
 msgid " kB/s"
 msgstr " kB/s"
 
-#: src/amuleDlg.cpp:1161
+#: src/amuleDlg.cpp:1096
 #, fuzzy, c-format
 msgid "Up: %.1f%s | Down: %.1f%s"
 msgstr "Up: %.1f | Down: %.1f"
 
-#: src/amuleDlg.cpp:1193
+#: src/amuleDlg.cpp:1128
 #, c-format
 msgid "aMule (%s | Connected)"
 msgstr "aMule (%s | Ligado)"
 
-#: src/amuleDlg.cpp:1195
+#: src/amuleDlg.cpp:1130
 #, c-format
 msgid "aMule (%s | Disconnected)"
 msgstr "aMule (%s | Desligado)"
 
-#: src/amuleDlg.cpp:1248
+#: src/amuleDlg.cpp:1183
 #, c-format
 msgid "Do you really want to exit %s?"
 msgstr "Quer mesmo fechar o %s?"
 
-#: src/amuleDlg.cpp:1250
+#: src/amuleDlg.cpp:1185
 msgid "Exit confirmation"
 msgstr "Confirmação de saída"
 
-#: src/amuleDlg.cpp:1613
+#: src/amuleDlg.cpp:1548
 msgid "Launch Command: "
 msgstr "Executar Comando: "
 
-#: src/amuleDlg.cpp:1632 src/muuli_wdr.cpp:1972 src/Preferences.cpp:979
+#: src/amuleDlg.cpp:1567 src/muuli_wdr.cpp:1971 src/Preferences.cpp:951
 msgid "- default -"
 msgstr "- predefinição -"
 
-#: src/amuleDlg.cpp:1660
+#: src/amuleDlg.cpp:1595
 #, c-format
 msgid "Skin directory '%s' does not exist"
 msgstr "Pasta para os temas '%s' não existe"
 
-#: src/amuleDlg.cpp:1663
+#: src/amuleDlg.cpp:1598
 #, c-format
 msgid "WARNING: Unable to open skin file '%s' for read"
 msgstr "AVISO: Não é possível abrir ficheiro de tema '%s' para leitura"
 
-#: src/amuleDlg.cpp:1814 src/muuli_wdr.cpp:3439
+#: src/amuleDlg.cpp:1722 src/amuleDlg.cpp:1968 src/muuli_wdr.cpp:1485
+#: src/muuli_wdr.cpp:3411
+msgid "Networks"
+msgstr "Redes"
+
+#: src/amuleDlg.cpp:1726 src/muuli_wdr.cpp:3411
 msgid "Networks Window"
 msgstr "Janela de Redes"
 
-#: src/amuleDlg.cpp:1820 src/muuli_wdr.cpp:3440
+#: src/amuleDlg.cpp:1728 src/muuli_wdr.cpp:3412
+msgid "Searches"
+msgstr "Pesquisas"
+
+#: src/amuleDlg.cpp:1732 src/muuli_wdr.cpp:3412
 msgid "Searches Window"
 msgstr "Janela de Pesquisas"
 
-#: src/amuleDlg.cpp:1826 src/muuli_wdr.cpp:3441
+#: src/amuleDlg.cpp:1734 src/DownloadListCtrl.cpp:740 src/muuli_wdr.cpp:392
+#: src/muuli_wdr.cpp:1578 src/muuli_wdr.cpp:3413 src/Statistics.cpp:829
+msgid "Downloads"
+msgstr "Downloads"
+
+#: src/amuleDlg.cpp:1738 src/muuli_wdr.cpp:3413
 msgid "Downloads Window"
 msgstr "Janela de Downloads"
 
-#: src/amuleDlg.cpp:1832 src/muuli_wdr.cpp:3443
+#: src/amuleDlg.cpp:1740 src/muuli_wdr.cpp:3287
+msgid "Shared files"
+msgstr "Ficheiros partilhados"
+
+#: src/amuleDlg.cpp:1744 src/muuli_wdr.cpp:3415
 msgid "Shared Files Window"
 msgstr "Janela de Ficheiros Partilhados"
 
-#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3444
+#: src/amuleDlg.cpp:1746 src/muuli_wdr.cpp:2919 src/muuli_wdr.cpp:3369
+#: src/muuli_wdr.cpp:3416
+msgid "Messages"
+msgstr "Mensagens"
+
+#: src/amuleDlg.cpp:1750 src/muuli_wdr.cpp:3416
 msgid "Messages Window"
 msgstr "Janela de Mensagens"
 
-#: src/amuleDlg.cpp:1844 src/muuli_wdr.cpp:3445
+#: src/amuleDlg.cpp:1752 src/muuli_wdr.cpp:3417 src/PrefsUnifiedDlg.cpp:312
+#: src/Statistics.cpp:779 src/Statistics.cpp:1235
+msgid "Statistics"
+msgstr "Estatísticas"
+
+#: src/amuleDlg.cpp:1756 src/muuli_wdr.cpp:3417
 msgid "Statistics Graph Window"
 msgstr "Janela de Estatísticas"
 
-#: src/amuleDlg.cpp:1851 src/muuli_wdr.cpp:3447
+#: src/amuleDlg.cpp:1759 src/muuli_wdr.cpp:3419 src/PrefsUnifiedDlg.cpp:328
+#: src/utils/wxCas/src/wxcasprefs.cpp:39
+msgid "Preferences"
+msgstr "Preferências"
+
+#: src/amuleDlg.cpp:1763 src/muuli_wdr.cpp:3419
 msgid "Preferences Settings Window"
 msgstr "Janela de Preferências"
 
-#: src/amuleDlg.cpp:1854 src/muuli_wdr.cpp:3448
+#: src/amuleDlg.cpp:1766 src/muuli_wdr.cpp:3420
 msgid "Import"
 msgstr "Importar"
 
-#: src/amuleDlg.cpp:1858 src/muuli_wdr.cpp:3448
+#: src/amuleDlg.cpp:1770 src/muuli_wdr.cpp:3420
 msgid "The partfile importer tool"
 msgstr "A ferramenta de importação de ficheiro de partes"
 
-#: src/amuleDlg.cpp:1861 src/muuli_wdr.cpp:3449
+#: src/amuleDlg.cpp:1773 src/muuli_wdr.cpp:3421
 #: src/utils/aLinkCreator/src/alcframe.cpp:262
 msgid "About"
 msgstr "Acerca"
 
-#: src/amuleDlg.cpp:1861 src/muuli_wdr.cpp:3449
+#: src/amuleDlg.cpp:1773 src/muuli_wdr.cpp:3421
 msgid "About/Help"
 msgstr "Acerca/Ajuda"
 
-#: src/amuleDlg.cpp:2059
+#: src/amuleDlg.cpp:1971
 msgid "eD2k network"
 msgstr "Rede eD2k"
 
-#: src/amuleDlg.cpp:2062
+#: src/amuleDlg.cpp:1974
 msgid "Kad network"
 msgstr "Rede Kad"
 
-#: src/amuleDlg.cpp:2062
+#: src/amuleDlg.cpp:1974
 msgid "No network"
 msgstr "Sem rede"
 
@@ -960,7 +955,7 @@ msgstr "Ficheiro não encontrado."
 msgid "The core rejected these shared folders:%s"
 msgstr ""
 
-#: src/amule-remote-gui.cpp:1336 src/ExternalConn.cpp:2346
+#: src/amule-remote-gui.cpp:1336 src/ExternalConn.cpp:2345
 msgid "Invalid link or already on list."
 msgstr "Ligação inválida ou já na lista."
 
@@ -976,7 +971,7 @@ msgstr "Não é possível criar o directório '%s' para a categoria '%s', a mant
 #: src/ClientDetailDialog.cpp:123 src/DataToText.cpp:61 src/DataToText.cpp:86
 #: src/DataToText.cpp:101 src/DataToText.cpp:136 src/DataToText.cpp:165
 #: src/DownloadListCtrl.cpp:1172 src/DownloadListCtrl.cpp:1185
-#: src/DownloadListCtrl.cpp:1196 src/ExternalConn.cpp:609
+#: src/DownloadListCtrl.cpp:1196 src/ExternalConn.cpp:608
 #: src/FileDetailDialog.cpp:203 src/FileDetailDialog.cpp:235
 #: src/FileDetailDialog.cpp:242 src/GenericClientListCtrl.cpp:1171
 #: src/GenericClientListCtrl.cpp:1182 src/GenericClientListCtrl.cpp:1192
@@ -1363,19 +1358,19 @@ msgstr "Automática [Alta]"
 msgid "Very low"
 msgstr "Muito baixa"
 
-#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:743 src/muuli_wdr.cpp:2303
+#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:743 src/muuli_wdr.cpp:2275
 #: src/ServerListCtrl.cpp:263 src/ServerListCtrl.cpp:456
 #: src/SharedFilesCtrl.cpp:145
 msgid "Low"
 msgstr "Baixa"
 
-#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:744 src/muuli_wdr.cpp:2304
+#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:744 src/muuli_wdr.cpp:2276
 #: src/ServerListCtrl.cpp:266 src/ServerListCtrl.cpp:457
 #: src/SharedFilesCtrl.cpp:146
 msgid "Normal"
 msgstr "Normal"
 
-#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:745 src/muuli_wdr.cpp:2305
+#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:745 src/muuli_wdr.cpp:2277
 #: src/ServerListCtrl.cpp:269 src/ServerListCtrl.cpp:458
 #: src/SharedFilesCtrl.cpp:147
 msgid "High"
@@ -1467,8 +1462,8 @@ msgstr "Servidor Local"
 msgid "Remote Server"
 msgstr "Servidor Remoto"
 
-#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3202
-#: src/SearchDlg.cpp:119 src/TextClient.cpp:911
+#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3174
+#: src/SearchDlg.cpp:111 src/TextClient.cpp:911
 msgid "Kad"
 msgstr "Kad"
 
@@ -1539,7 +1534,7 @@ msgstr "Parte"
 msgid "Size"
 msgstr "Tamanho"
 
-#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3269
+#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3241
 msgid "Transferred"
 msgstr "Transferido"
 
@@ -1597,7 +1592,7 @@ msgstr ""
 "Comentário de: %s (%s)\n"
 "\n"
 
-#: src/DownloadListCtrl.cpp:746 src/muuli_wdr.cpp:2306
+#: src/DownloadListCtrl.cpp:746 src/muuli_wdr.cpp:2278
 #: src/SharedFilesCtrl.cpp:150
 msgid "Auto"
 msgstr "Automática"
@@ -1635,7 +1630,7 @@ msgid "Extended Options"
 msgstr "Opções Estendidas"
 
 #: src/DownloadListCtrl.cpp:770 src/DownloadListCtrl.cpp:822
-#: src/muuli_wdr.cpp:1790
+#: src/muuli_wdr.cpp:1789
 msgid "Preview"
 msgstr "Pré-visualizar"
 
@@ -1810,232 +1805,227 @@ msgstr[1] ""
 msgid "Invalid eD2k link! ERROR: %s"
 msgstr "Ligação eD2k inválida! ERRO: %s"
 
-#: src/ExternalConn.cpp:380
+#: src/ExternalConn.cpp:379
 msgid "Client sent packet after authentication failed."
 msgstr "O cliente enviou um pacote depois de a autenticação ter falhado."
 
-#: src/ExternalConn.cpp:397
+#: src/ExternalConn.cpp:396
 msgid "External connection closed."
 msgstr "Ligação externa fechada."
 
-#: src/ExternalConn.cpp:474
+#: src/ExternalConn.cpp:473
 msgid "External connections disabled due to empty password!"
 msgstr "Ligações externas desactivadas devido a palavra-passe vazia!"
 
-#: src/ExternalConn.cpp:495
+#: src/ExternalConn.cpp:494
 msgid "External connections disabled in config file"
 msgstr "Ligações externas desactivadas no ficheiro de configuração"
 
-#: src/ExternalConn.cpp:576
+#: src/ExternalConn.cpp:575
 msgid "New external connection accepted"
 msgstr "Nova ligação externa aceite"
 
-#: src/ExternalConn.cpp:579
+#: src/ExternalConn.cpp:578
 msgid "ERROR: couldn't accept a new external connection"
 msgstr "ERRO: não foi possível aceitar uma nova ligação externa"
 
-#: src/ExternalConn.cpp:596
+#: src/ExternalConn.cpp:595
 msgid "External connection refused due to empty password in preferences!"
 msgstr "Ligação externa recusada devido a palavra-passe não preenchida nas preferências!"
 
-#: src/ExternalConn.cpp:608
+#: src/ExternalConn.cpp:607
 #, c-format
 msgid "Connecting client: %s %s"
 msgstr "A ligar cliente: %s %s"
 
-#: src/ExternalConn.cpp:610
+#: src/ExternalConn.cpp:609
 msgid "Unknown version"
 msgstr "Versão desconhecida"
 
-#: src/ExternalConn.cpp:623
+#: src/ExternalConn.cpp:622
 msgid "Incorrect EC version ID, there might be binary incompatibility. Use core and remote from same snapshot."
 msgstr "Versão de LE incorrecta, pode haver incompatibilidade binária. Utilize núcleo e remoto da mesma versão."
 
-#: src/ExternalConn.cpp:631
+#: src/ExternalConn.cpp:630
 msgid "You cannot connect to a release version from an arbitrary development snapshot! *sigh* possible crash prevented"
 msgstr "Não pode ligar-se a uma versão oficial a partir de uma versão de desenvolvimento arbitrária! *suspiro*... Prevenido potencial erro futuro"
 
-#: src/ExternalConn.cpp:714
+#: src/ExternalConn.cpp:713
 msgid "Invalid protocol version."
 msgstr "Versão de protocolo inválida."
 
-#: src/ExternalConn.cpp:720
+#: src/ExternalConn.cpp:719
 msgid "Missing protocol version tag."
 msgstr "Elemento de versão de protocolo em falta."
 
-#: src/ExternalConn.cpp:728
+#: src/ExternalConn.cpp:727
 msgid "Authentication failed: invalid hash specified as EC password."
 msgstr "Falha de autenticação: chave inválida indicada como palavra-passe para LE"
 
-#: src/ExternalConn.cpp:776
+#: src/ExternalConn.cpp:775
 msgid "Authentication failed: wrong password."
 msgstr "A autenticação falhou: palavra-passe errada."
 
-#: src/ExternalConn.cpp:778
+#: src/ExternalConn.cpp:777
 msgid "Authentication failed: missing password."
 msgstr "A autenticação falhou: palavra-passe em falta."
 
-#: src/ExternalConn.cpp:789
+#: src/ExternalConn.cpp:788
 msgid "Invalid request, please authenticate first."
 msgstr "Pedido inválido, deve autenticar-se primeiro."
 
-#: src/ExternalConn.cpp:794
+#: src/ExternalConn.cpp:793
 msgid "Access granted."
 msgstr "Acesso concedido."
 
-#: src/ExternalConn.cpp:802
+#: src/ExternalConn.cpp:801
 #, c-format
 msgid "Sent error message \"%s\" to client."
 msgstr "Enviada mensagem de erro \"%s\" ao cliente."
 
-#: src/ExternalConn.cpp:807
+#: src/ExternalConn.cpp:806
 #, c-format
 msgid "Unauthorized access attempt from %s. Connection closed."
 msgstr "Acesso não-autorizado de %s. Ligação fechada."
 
-#: src/ExternalConn.cpp:1420
+#: src/ExternalConn.cpp:1419
 #, c-format
 msgid "Remote PartFile command failed: FileHash not found: %s"
 msgstr "Falha no comando de ficheiro de partes remoto: Chave não encontrada: %s"
 
-#: src/ExternalConn.cpp:1424
+#: src/ExternalConn.cpp:1423
 #, c-format
 msgid "FileHash not found: %s"
 msgstr "Chave não encontrada: %s"
 
-#: src/ExternalConn.cpp:1471 src/ExternalConn.cpp:1559
-#: src/ExternalConn.cpp:1680
+#: src/ExternalConn.cpp:1470 src/ExternalConn.cpp:1558
+#: src/ExternalConn.cpp:1679
 msgid "OOPS! OpCode processing error!"
 msgstr "UPS! Erro de processamento de código de operação!"
 
-#: src/ExternalConn.cpp:1502
+#: src/ExternalConn.cpp:1501
 msgid "Server not added"
 msgstr "Servidor não adicionado"
 
-#: src/ExternalConn.cpp:1521
+#: src/ExternalConn.cpp:1520
 #, c-format
 msgid "server not found: %s"
 msgstr "servidor não encontrado: %s"
 
-#: src/ExternalConn.cpp:1538
+#: src/ExternalConn.cpp:1537
 msgid "need to define server to be removed"
 msgstr "é necessário definir o servidor a remover"
 
-#: src/ExternalConn.cpp:1553
+#: src/ExternalConn.cpp:1552
 msgid "eD2k is disabled in preferences."
 msgstr "eD2K desactivada nas preferências."
 
-#: src/ExternalConn.cpp:1658
+#: src/ExternalConn.cpp:1657
 #, fuzzy
 msgid "Friend not found."
 msgstr "Ficheiro não encontrado."
 
-#: src/ExternalConn.cpp:1668
+#: src/ExternalConn.cpp:1667
 #, fuzzy
 msgid "Client not found."
 msgstr "Ficheiro não encontrado."
 
-#: src/ExternalConn.cpp:1674
+#: src/ExternalConn.cpp:1673
 msgid "EC_TAG_FRIEND_SHARED requires EC_TAG_FRIEND or EC_TAG_CLIENT."
 msgstr ""
 
-#: src/ExternalConn.cpp:1992
+#: src/ExternalConn.cpp:1991
 msgid "WebSearch from remote interface makes no sense."
 msgstr "Pesquisa na web a partir da interface remota não faz sentido."
 
-#: src/ExternalConn.cpp:2027
+#: src/ExternalConn.cpp:2026
 msgid "Search in progress. Refetch results in a moment!"
 msgstr "A pesquisar. Resultados dentro de momentos!"
 
-#: src/ExternalConn.cpp:2266
+#: src/ExternalConn.cpp:2265
 msgid "No points for graph."
 msgstr "Sem pontos para gráfico."
 
-#: src/ExternalConn.cpp:2276
+#: src/ExternalConn.cpp:2275
 msgid "Your client is not configured for this detail level."
 msgstr "O cliente não está configurado para este nível de detalhe."
 
-#: src/ExternalConn.cpp:2303
+#: src/ExternalConn.cpp:2302
 msgid "External Connection: shutdown requested"
 msgstr "Ligação Externa: finalização pedida"
 
-#: src/ExternalConn.cpp:2315
+#: src/ExternalConn.cpp:2314
 msgid "Already shutting down."
 msgstr "Já a desligar."
 
-#: src/ExternalConn.cpp:2333
+#: src/ExternalConn.cpp:2332
 #, c-format
 msgid "ExternalConn: adding link '%s'."
 msgstr "LigaçãoExterna: a adicionar o link '%s'."
 
-#: src/ExternalConn.cpp:2351
+#: src/ExternalConn.cpp:2350
 #, fuzzy, c-format
 msgid "%d of %d links failed (invalid or already on list)."
 msgstr "Ligação inválida ou já na lista."
 
-#: src/ExternalConn.cpp:2374
+#: src/ExternalConn.cpp:2373
 msgid "Version check throttled; try again shortly."
 msgstr ""
 
-#: src/ExternalConn.cpp:2379
+#: src/ExternalConn.cpp:2378
 msgid "Version check is not available on this daemon."
 msgstr ""
 
-#: src/ExternalConn.cpp:2509
+#: src/ExternalConn.cpp:2508
 msgid "File not found."
 msgstr "Ficheiro não encontrado."
 
-#: src/ExternalConn.cpp:2514
+#: src/ExternalConn.cpp:2513
 msgid "Invalid file name."
 msgstr "Nome de ficheiro inválido."
 
-#: src/ExternalConn.cpp:2522
+#: src/ExternalConn.cpp:2521
 msgid "Unable to rename file."
 msgstr "Não é possível renomear o ficheiro."
 
-#: src/ExternalConn.cpp:2839
-#, c-format
-msgid "Could not save the amuleapi password: %s"
-msgstr ""
-
-#: src/ExternalConn.cpp:3004 src/ExternalConn.cpp:3032
+#: src/ExternalConn.cpp:2992 src/ExternalConn.cpp:3020
 msgid "Kad is disabled in preferences."
 msgstr "A Kad está desactivada nas preferências."
 
-#: src/ExternalConn.cpp:3045
+#: src/ExternalConn.cpp:3033
 msgid "Already connected to eD2k."
 msgstr "Já ligado à eD2k."
 
-#: src/ExternalConn.cpp:3048
+#: src/ExternalConn.cpp:3036
 msgid "Connecting to eD2k..."
 msgstr "A ligar à eD2k..."
 
-#: src/ExternalConn.cpp:3057
+#: src/ExternalConn.cpp:3045
 msgid "Already connected to Kad."
 msgstr "Já ligado à Kad."
 
-#: src/ExternalConn.cpp:3060
+#: src/ExternalConn.cpp:3048
 msgid "Connecting to Kad..."
 msgstr "A ligar à Kad..."
 
-#: src/ExternalConn.cpp:3067
+#: src/ExternalConn.cpp:3055
 msgid "All networks are disabled."
 msgstr "Todas as redes estão desactivadas."
 
-#: src/ExternalConn.cpp:3076
+#: src/ExternalConn.cpp:3064
 msgid "Disconnected from eD2k."
 msgstr "Desligado da eD2k."
 
-#: src/ExternalConn.cpp:3081
+#: src/ExternalConn.cpp:3069
 msgid "Disconnected from Kad."
 msgstr "Desligado da Kad."
 
-#: src/ExternalConn.cpp:3090
+#: src/ExternalConn.cpp:3078
 #, c-format
 msgid "External Connection: invalid opcode received: %#x"
 msgstr "Ligação Externa: recebido código de operação inválido: %#x"
 
-#: src/ExternalConn.cpp:3095
+#: src/ExternalConn.cpp:3083
 msgid "Invalid opcode (wrong protocol version?)"
 msgstr "Código de operação inválido (versão de protocolo errada?)"
 
@@ -2351,19 +2341,19 @@ msgstr ""
 msgid "eD2k"
 msgstr "eD2k"
 
-#: src/FirstRunWizard.cpp:349 src/muuli_wdr.cpp:1495
+#: src/FirstRunWizard.cpp:349 src/muuli_wdr.cpp:1488
 msgid "Kademlia"
 msgstr "Kademlia"
 
-#: src/FirstRunWizard.cpp:359 src/muuli_wdr.cpp:1423
+#: src/FirstRunWizard.cpp:359 src/muuli_wdr.cpp:1416
 msgid "Standard TCP Port "
 msgstr "Porto TCP Padrão "
 
-#: src/FirstRunWizard.cpp:365 src/muuli_wdr.cpp:1435
+#: src/FirstRunWizard.cpp:365 src/muuli_wdr.cpp:1428
 msgid "Extended UDP port (Kad / global search) "
 msgstr "Porto UDP estendido (Kad / pesquisa global) "
 
-#: src/FirstRunWizard.cpp:377 src/muuli_wdr.cpp:1442
+#: src/FirstRunWizard.cpp:377 src/muuli_wdr.cpp:1435
 msgid "Enable UPnP for router port forwarding"
 msgstr "Activar UPnP para encaminhamento de portos no router"
 
@@ -2390,7 +2380,7 @@ msgstr ""
 msgid "Your peer lists are already in place - nothing to download."
 msgstr "Já está a tentar transferir o ficheiro %s"
 
-#: src/FirstRunWizard.cpp:434 src/muuli_wdr.cpp:1540
+#: src/FirstRunWizard.cpp:434 src/muuli_wdr.cpp:1533
 msgid "Auto-update server list at startup"
 msgstr "Auto-actualizar lista de servidores no arranque"
 
@@ -2436,23 +2426,23 @@ msgid ""
 "want downloads on a different (e.g. larger) disk."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:549 src/FirstRunWizard.cpp:611 src/muuli_wdr.cpp:1702
+#: src/FirstRunWizard.cpp:549 src/FirstRunWizard.cpp:611 src/muuli_wdr.cpp:1701
 msgid "Destination folder for downloads"
 msgstr "Pasta de destino para downloads"
 
-#: src/FirstRunWizard.cpp:553 src/FirstRunWizard.cpp:569 src/muuli_wdr.cpp:1349
-#: src/muuli_wdr.cpp:1366 src/muuli_wdr.cpp:1677 src/muuli_wdr.cpp:1708
-#: src/muuli_wdr.cpp:1720 src/muuli_wdr.cpp:2790
+#: src/FirstRunWizard.cpp:553 src/FirstRunWizard.cpp:569 src/muuli_wdr.cpp:1342
+#: src/muuli_wdr.cpp:1359 src/muuli_wdr.cpp:1676 src/muuli_wdr.cpp:1707
+#: src/muuli_wdr.cpp:1719 src/muuli_wdr.cpp:2762
 #: src/utils/aLinkCreator/src/alcframe.cpp:135
 #: src/utils/wxCas/src/wxcasprefs.cpp:52 src/utils/wxCas/src/wxcasprefs.cpp:118
 msgid "Browse"
 msgstr "Procurar"
 
-#: src/FirstRunWizard.cpp:559 src/muuli_wdr.cpp:1713
+#: src/FirstRunWizard.cpp:559 src/muuli_wdr.cpp:1712
 msgid "(All files in this folder are shared with other peers)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:565 src/FirstRunWizard.cpp:624 src/muuli_wdr.cpp:1715
+#: src/FirstRunWizard.cpp:565 src/FirstRunWizard.cpp:624 src/muuli_wdr.cpp:1714
 msgid "Folder for temporary download files"
 msgstr "Pasta para ficheiros temporários"
 
@@ -2483,7 +2473,7 @@ msgstr "Erro ao abrir o ficheiro de lista de amigos 'emfriends.met' para escrita
 msgid "CRITICAL - no client on StartChatSession"
 msgstr "CRÍTICO - sem cliente no StartChatSession"
 
-#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2696 src/muuli_wdr.cpp:3373
+#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2668 src/muuli_wdr.cpp:3345
 msgid "Friends"
 msgstr "Amigos"
 
@@ -2594,8 +2584,8 @@ msgstr "Nenhum"
 msgid "No"
 msgstr "Não"
 
-#: src/GenericClientListCtrl.cpp:1216 src/PrefsUnifiedDlg.cpp:2898
-#: src/PrefsUnifiedDlg.cpp:2948 src/ServerListCtrl.cpp:276
+#: src/GenericClientListCtrl.cpp:1216 src/PrefsUnifiedDlg.cpp:2818
+#: src/PrefsUnifiedDlg.cpp:2868 src/ServerListCtrl.cpp:276
 msgid "Yes"
 msgstr "Sim"
 
@@ -2764,10 +2754,10 @@ msgstr "Porto inválido para arranque"
 msgid "Please fill all fields required"
 msgstr "Por favor, preencha todos os campos pedidos"
 
-#: src/KadDlg.cpp:192 src/PartFile.cpp:1031 src/PrefsUnifiedDlg.cpp:1134
-#: src/PrefsUnifiedDlg.cpp:1204 src/PrefsUnifiedDlg.cpp:1405
-#: src/PrefsUnifiedDlg.cpp:1663 src/PrefsUnifiedDlg.cpp:1673
-#: src/PrefsUnifiedDlg.cpp:1690 src/PrefsUnifiedDlg.cpp:1738
+#: src/KadDlg.cpp:192 src/PartFile.cpp:1031 src/PrefsUnifiedDlg.cpp:1162
+#: src/PrefsUnifiedDlg.cpp:1331 src/PrefsUnifiedDlg.cpp:1589
+#: src/PrefsUnifiedDlg.cpp:1599 src/PrefsUnifiedDlg.cpp:1616
+#: src/PrefsUnifiedDlg.cpp:1658
 msgid "Message"
 msgstr "Mensagem"
 
@@ -2869,7 +2859,7 @@ msgstr "Razão de partilha"
 msgid "Uploaded"
 msgstr "Enviado"
 
-#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3253
+#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3225
 msgid "Requested"
 msgstr "Pedido"
 
@@ -2993,7 +2983,7 @@ msgid "WARNING: "
 msgstr "AVISO: "
 
 #: src/MuleNotebook.cpp:179 src/muuli_wdr.cpp:817 src/muuli_wdr.cpp:1229
-#: src/muuli_wdr.cpp:3157 src/muuli_wdr.cpp:3413
+#: src/muuli_wdr.cpp:3129 src/muuli_wdr.cpp:3385
 msgid "Close"
 msgstr "Fechar"
 
@@ -3006,12 +2996,12 @@ msgstr "Cortar"
 msgid "Copy"
 msgstr "Copiar"
 
-#: src/MuleTextCtrl.cpp:88 src/SearchDlg.cpp:261
+#: src/MuleTextCtrl.cpp:88
 msgid "Paste"
 msgstr "Colar"
 
 #: src/MuleTextCtrl.cpp:89 src/muuli_wdr.cpp:358 src/muuli_wdr.cpp:757
-#: src/muuli_wdr.cpp:2380 src/muuli_wdr.cpp:2399 src/muuli_wdr.cpp:2421
+#: src/muuli_wdr.cpp:2352 src/muuli_wdr.cpp:2371 src/muuli_wdr.cpp:2393
 #: src/utils/aLinkCreator/src/alcframe.cpp:142
 msgid "Clear"
 msgstr "Limpar"
@@ -3109,8 +3099,8 @@ msgid "Exit"
 msgstr "Sair"
 
 #: src/MuleTrayIcon.cpp:579 src/MuleTrayIcon.cpp:945 src/MuleTrayIcon.cpp:965
-#: src/muuli_wdr.cpp:1398 src/muuli_wdr.cpp:1406 src/muuli_wdr.cpp:1413
-#: src/muuli_wdr.cpp:1836 src/muuli_wdr.cpp:1842 src/OtherFunctions.cpp:91
+#: src/muuli_wdr.cpp:1391 src/muuli_wdr.cpp:1399 src/muuli_wdr.cpp:1406
+#: src/muuli_wdr.cpp:1835 src/muuli_wdr.cpp:1841 src/OtherFunctions.cpp:91
 #: src/StatisticsDlg.cpp:93 src/StatisticsDlg.cpp:95
 msgid "kB/s"
 msgstr "kB/s"
@@ -3281,7 +3271,7 @@ msgstr "Nome:"
 msgid "Type"
 msgstr "Tipo"
 
-#: src/muuli_wdr.cpp:215 src/SearchDlg.cpp:118 src/SearchListCtrl.cpp:853
+#: src/muuli_wdr.cpp:215 src/SearchDlg.cpp:110 src/SearchListCtrl.cpp:853
 msgid "Local"
 msgstr "Local"
 
@@ -3352,7 +3342,7 @@ msgstr "Bytes"
 msgid "KB"
 msgstr "kB"
 
-#: src/muuli_wdr.cpp:274 src/muuli_wdr.cpp:293 src/muuli_wdr.cpp:1621
+#: src/muuli_wdr.cpp:274 src/muuli_wdr.cpp:293 src/muuli_wdr.cpp:1620
 #: src/OtherFunctions.cpp:64
 msgid "MB"
 msgstr "MB"
@@ -3369,7 +3359,7 @@ msgstr "Tamanho Máximo"
 msgid "Availability"
 msgstr "Disponibilidade"
 
-#: src/muuli_wdr.cpp:312 src/muuli_wdr.cpp:398 src/muuli_wdr.cpp:3318
+#: src/muuli_wdr.cpp:312 src/muuli_wdr.cpp:398 src/muuli_wdr.cpp:3290
 msgid "Filter:"
 msgstr "Filtro:"
 
@@ -3401,7 +3391,7 @@ msgstr ""
 msgid "Stop"
 msgstr "Parar"
 
-#: src/muuli_wdr.cpp:348 src/muuli_wdr.cpp:1392 src/SearchListCtrl.cpp:732
+#: src/muuli_wdr.cpp:348 src/muuli_wdr.cpp:1385 src/SearchListCtrl.cpp:732
 msgid "Download"
 msgstr "Download"
 
@@ -3432,12 +3422,12 @@ msgstr "Fontes de ficheiros:"
 #: src/muuli_wdr.cpp:1160 src/muuli_wdr.cpp:1167 src/muuli_wdr.cpp:1172
 #: src/muuli_wdr.cpp:1179 src/muuli_wdr.cpp:1184 src/muuli_wdr.cpp:1191
 #: src/muuli_wdr.cpp:1205 src/muuli_wdr.cpp:1212 src/muuli_wdr.cpp:1217
-#: src/muuli_wdr.cpp:1224 src/muuli_wdr.cpp:3255 src/muuli_wdr.cpp:3263
-#: src/muuli_wdr.cpp:3271
+#: src/muuli_wdr.cpp:1224 src/muuli_wdr.cpp:3227 src/muuli_wdr.cpp:3235
+#: src/muuli_wdr.cpp:3243
 msgid "N/A"
 msgstr "N/D"
 
-#: src/muuli_wdr.cpp:508 src/muuli_wdr.cpp:1065 src/PrefsUnifiedDlg.cpp:299
+#: src/muuli_wdr.cpp:508 src/muuli_wdr.cpp:1065 src/PrefsUnifiedDlg.cpp:297
 msgid "General"
 msgstr "Geral"
 
@@ -3578,7 +3568,7 @@ msgstr ""
 msgid "Album :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:685 src/muuli_wdr.cpp:2275
+#: src/muuli_wdr.cpp:685 src/muuli_wdr.cpp:2247
 msgid "Title :"
 msgstr "Título :"
 
@@ -3687,7 +3677,7 @@ msgstr "Utilizador :"
 msgid "Userhash :"
 msgstr "Chave de utilizador :"
 
-#: src/muuli_wdr.cpp:895 src/muuli_wdr.cpp:1742 src/muuli_wdr.cpp:2470
+#: src/muuli_wdr.cpp:895 src/muuli_wdr.cpp:1741 src/muuli_wdr.cpp:2442
 #: src/utils/aLinkCreator/src/alcframe.cpp:137
 msgid "Add"
 msgstr "Adicionar"
@@ -3696,15 +3686,15 @@ msgstr "Adicionar"
 msgid "Download-Speed"
 msgstr "Velocidade de Download"
 
-#: src/muuli_wdr.cpp:954 src/muuli_wdr.cpp:989 src/muuli_wdr.cpp:2574
+#: src/muuli_wdr.cpp:954 src/muuli_wdr.cpp:989 src/muuli_wdr.cpp:2546
 msgid "Current"
 msgstr "Actual"
 
-#: src/muuli_wdr.cpp:962 src/muuli_wdr.cpp:997 src/muuli_wdr.cpp:2582
+#: src/muuli_wdr.cpp:962 src/muuli_wdr.cpp:997 src/muuli_wdr.cpp:2554
 msgid "Running average"
 msgstr "Média actual"
 
-#: src/muuli_wdr.cpp:970 src/muuli_wdr.cpp:1005 src/muuli_wdr.cpp:2590
+#: src/muuli_wdr.cpp:970 src/muuli_wdr.cpp:1005 src/muuli_wdr.cpp:2562
 msgid "Session average"
 msgstr "Média da sessão"
 
@@ -3716,7 +3706,7 @@ msgstr "Velocidade de Upload"
 msgid "Connections"
 msgstr "Ligações"
 
-#: src/muuli_wdr.cpp:1024 src/muuli_wdr.cpp:1861
+#: src/muuli_wdr.cpp:1024 src/muuli_wdr.cpp:1860
 msgid "Active downloads"
 msgstr "Downloads activos"
 
@@ -3724,7 +3714,7 @@ msgstr "Downloads activos"
 msgid "Active connections (1:1)"
 msgstr "Ligações activas (1:1)"
 
-#: src/muuli_wdr.cpp:1040 src/muuli_wdr.cpp:1862
+#: src/muuli_wdr.cpp:1040 src/muuli_wdr.cpp:1861
 msgid "Active uploads"
 msgstr "Uploads activos"
 
@@ -3840,8 +3830,8 @@ msgstr "Este é o nome que os outros utilizadores verão ao ligar-se a si."
 msgid "Language: "
 msgstr "Idioma: "
 
-#: src/muuli_wdr.cpp:1257 src/muuli_wdr.cpp:1330 src/muuli_wdr.cpp:1334
-#: src/muuli_wdr.cpp:1337
+#: src/muuli_wdr.cpp:1257 src/muuli_wdr.cpp:1323 src/muuli_wdr.cpp:1327
+#: src/muuli_wdr.cpp:1330
 msgid "The delay before showing tool-tips."
 msgstr "O tempo que decorre até serem mostradas as dicas."
 
@@ -3919,961 +3909,937 @@ msgstr ""
 msgid "Enabling this will make aMule to show notifications when finished downloading."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1323
-#, fuzzy
-msgid "Remember search history"
-msgstr "Lembrar estas preferências"
-
-#: src/muuli_wdr.cpp:1324
-msgid "Keeps a dropdown list of your past search terms in the Search tab's Name field. This remembers the queries you typed, not the results they returned."
-msgstr ""
-
-#: src/muuli_wdr.cpp:1329
+#: src/muuli_wdr.cpp:1322
 msgid "Tooltip delay time: "
 msgstr "Atraso de exibição de dicas: "
 
-#: src/muuli_wdr.cpp:1336
+#: src/muuli_wdr.cpp:1329
 msgid "seconds"
 msgstr "segundos"
 
-#: src/muuli_wdr.cpp:1340
+#: src/muuli_wdr.cpp:1333
 msgid "Browser Selection"
 msgstr "Selecção de Navegador"
 
-#: src/muuli_wdr.cpp:1346
+#: src/muuli_wdr.cpp:1339
 msgid "Enter your browser name here. Leave this field empty to use the system default browser."
 msgstr "Indique aqui o nome do seu browser. Deixe este campo em branco para utilizar o browser por omissão do sistema."
 
-#: src/muuli_wdr.cpp:1353
+#: src/muuli_wdr.cpp:1346
 msgid "Open in new tab if possible"
 msgstr "Abrir num novo separador se possível"
 
-#: src/muuli_wdr.cpp:1355
+#: src/muuli_wdr.cpp:1348
 msgid "Open the web page in a new tab instead of in a new window when possible"
 msgstr "Abrir a página num novo separador em vez de uma nova janela, quando possível"
 
-#: src/muuli_wdr.cpp:1359
+#: src/muuli_wdr.cpp:1352
 msgid "Video Player"
 msgstr "Leitor de vídeo"
 
-#: src/muuli_wdr.cpp:1386
+#: src/muuli_wdr.cpp:1379
 msgid "Bandwidth limits"
 msgstr "Limites de largura de banda"
 
-#: src/muuli_wdr.cpp:1400
+#: src/muuli_wdr.cpp:1393
 msgid "Upload"
 msgstr "Upload"
 
-#: src/muuli_wdr.cpp:1408
+#: src/muuli_wdr.cpp:1401
 msgid "Slot Allocation"
 msgstr "Atribuição de Ligações"
 
-#: src/muuli_wdr.cpp:1417
+#: src/muuli_wdr.cpp:1410
 msgid "Ports"
 msgstr "Portos"
 
-#: src/muuli_wdr.cpp:1427
+#: src/muuli_wdr.cpp:1420
 msgid "This is the standard eD2k port and cannot be disabled."
 msgstr "Este é o porto da eD2k por omissão e não pode ser desactivado."
 
-#: src/muuli_wdr.cpp:1430
+#: src/muuli_wdr.cpp:1423
 msgid "UDP port for server requests (TCP+3):"
 msgstr "Porto UDP para pedidos ao servidor (TCP+3):"
 
-#: src/muuli_wdr.cpp:1432
+#: src/muuli_wdr.cpp:1425
 msgid "4665"
 msgstr "4665"
 
-#: src/muuli_wdr.cpp:1439
+#: src/muuli_wdr.cpp:1432
 msgid "This UDP port is used for extended eD2k requests and Kad network"
 msgstr "Este porto UDP é usado para pedidos eD2k estendidos e para a rede Kad"
 
-#: src/muuli_wdr.cpp:1446
+#: src/muuli_wdr.cpp:1439
 msgid "UPnP TCP Port (Optional):"
 msgstr "Porto TCP UPnP (Opcional):"
 
-#: src/muuli_wdr.cpp:1456
+#: src/muuli_wdr.cpp:1449
 msgid "Bind local address to IP (empty for any):"
 msgstr "Associar endereço local ao IP (em branco para qualquer um):"
 
-#: src/muuli_wdr.cpp:1459
+#: src/muuli_wdr.cpp:1452
 msgid "Advanced users only: If you have multiple network interfaces, enter the address of the interface to which aMule should be bound."
 msgstr "Apenas para utilizadores avançados: Se possui múltiplos interfaces de rede indique o endereço do interface que o aMule deve usar."
 
-#: src/muuli_wdr.cpp:1462 src/muuli_wdr.cpp:2055
+#: src/muuli_wdr.cpp:1455 src/muuli_wdr.cpp:2054
 #, fuzzy
 msgid "Bind to network interface (empty for any):"
 msgstr "Associar endereço local ao IP (em branco para qualquer um):"
 
-#: src/muuli_wdr.cpp:1475
+#: src/muuli_wdr.cpp:1468
 msgid "Advanced users only: pin all of aMule's traffic to one network interface, chosen from the list or typed in by name (e.g. tun0, eth0, en0) or index. Unlike binding to an IP, this stops traffic leaking out via the default route - useful with a VPN. Requires no elevated privileges."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1481
+#: src/muuli_wdr.cpp:1474
 msgid "Max sources per downloading file:"
 msgstr "Máximo de fontes por ficheiro:"
 
-#: src/muuli_wdr.cpp:1485
+#: src/muuli_wdr.cpp:1478
 msgid "Max simultaneous connections:"
 msgstr "Máximo de ligações simultâneas:"
 
-#: src/muuli_wdr.cpp:1498 src/muuli_wdr.cpp:3197
+#: src/muuli_wdr.cpp:1491 src/muuli_wdr.cpp:3169
 msgid "ED2K"
 msgstr "ED2K"
 
-#: src/muuli_wdr.cpp:1505
+#: src/muuli_wdr.cpp:1498
 msgid "Autoconnect on startup"
 msgstr "Ligar automaticamente no arranque"
 
-#: src/muuli_wdr.cpp:1508
+#: src/muuli_wdr.cpp:1501
 msgid "Reconnect on loss"
 msgstr "Voltar a ligar se perder ligação"
 
-#: src/muuli_wdr.cpp:1530
+#: src/muuli_wdr.cpp:1523
 msgid "Remove dead server after"
 msgstr "Remover servidores inactivos após"
 
-#: src/muuli_wdr.cpp:1531
+#: src/muuli_wdr.cpp:1524
 msgid "Static servers are never removed, even when unreachable."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1535
+#: src/muuli_wdr.cpp:1528
 msgid "retries"
 msgstr "tentativas"
 
-#: src/muuli_wdr.cpp:1543
+#: src/muuli_wdr.cpp:1536
 msgid "List"
 msgstr "Lista"
 
-#: src/muuli_wdr.cpp:1546
+#: src/muuli_wdr.cpp:1539
 msgid "Update server list when connecting to a server"
 msgstr "Actualizar a lista de servidores quando se liga a um servidor"
 
-#: src/muuli_wdr.cpp:1549
+#: src/muuli_wdr.cpp:1542
 msgid "Update server list when a client connects"
 msgstr "Actualizar a lista de servidores quando um cliente se liga"
 
-#: src/muuli_wdr.cpp:1552
+#: src/muuli_wdr.cpp:1545
 msgid "Use priority system"
 msgstr "Usar o sistema de prioridades"
 
-#: src/muuli_wdr.cpp:1556
+#: src/muuli_wdr.cpp:1549
 msgid "Use smart LowID check on connect"
 msgstr "Usar verificação inteligente de LowID ao ligar"
 
-#: src/muuli_wdr.cpp:1560
+#: src/muuli_wdr.cpp:1553
 msgid "Safe connect"
 msgstr "Ligação segura"
 
-#: src/muuli_wdr.cpp:1564
+#: src/muuli_wdr.cpp:1557
 msgid "Autoconnect to servers in static list only"
 msgstr "Apenas ligar automaticamente a servidores estáticos"
 
-#: src/muuli_wdr.cpp:1567
+#: src/muuli_wdr.cpp:1560
 msgid "Set manually added servers to High Priority"
 msgstr "Atribuir alta prioridade a servidores adicionados manualmente"
 
-#: src/muuli_wdr.cpp:1588
+#: src/muuli_wdr.cpp:1581
 msgid "Add files to download in pause mode"
 msgstr "Adicionar ficheiros para transferir em modo de pausa"
 
-#: src/muuli_wdr.cpp:1590
+#: src/muuli_wdr.cpp:1583
 msgid "Add files to download with auto priority"
 msgstr "Adicionar ficheiros para transferir com prioridade automática"
 
-#: src/muuli_wdr.cpp:1593
+#: src/muuli_wdr.cpp:1586
 msgid "Try to download first and last chunks first"
 msgstr "Tentar receber primeiro o início e o final dos ficheiros"
 
-#: src/muuli_wdr.cpp:1597
+#: src/muuli_wdr.cpp:1590
 msgid "Endgame mode: rotate to faster sources for the final blocks"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1600
+#: src/muuli_wdr.cpp:1593
 msgid "Start next paused file when a file completes"
 msgstr "Iniciar o próximo ficheiro em pausa quando um ficheiro completa"
 
-#: src/muuli_wdr.cpp:1603
+#: src/muuli_wdr.cpp:1596
 msgid "From the same category"
 msgstr "Da mesma categoria"
 
-#: src/muuli_wdr.cpp:1605
+#: src/muuli_wdr.cpp:1598
 msgid "In alphabetic order"
 msgstr "Em ordem alfabética"
 
-#: src/muuli_wdr.cpp:1607
+#: src/muuli_wdr.cpp:1600
 msgid "Preallocate disk space for new files"
 msgstr "Reservar previamente espaço em disco para novos ficheiros"
 
-#: src/muuli_wdr.cpp:1608
+#: src/muuli_wdr.cpp:1601
 msgid "For new files preallocates disk space for the whole file, thus reduces fragmentation"
 msgstr "Para novos ficheiros, reserva o espaço em disco para o ficheiro completo, reduzindo assim a fragmentação"
 
-#: src/muuli_wdr.cpp:1613
+#: src/muuli_wdr.cpp:1606
+msgid "Create new files as sparse files"
+msgstr ""
+
+#: src/muuli_wdr.cpp:1607
+msgid "A sparse file reserves its full size on disk immediately without writing real data to it -- fast, but unsupported or slow on some filesystems, and free-space accounting stays optimistic while the download is in progress. Turn this off to grow the file only as data arrives."
+msgstr ""
+
+#: src/muuli_wdr.cpp:1612
 msgid "Stop downloads when free disk space reaches "
 msgstr "Parar os downloads quando o espaço livre em disco atinge "
 
-#: src/muuli_wdr.cpp:1614
+#: src/muuli_wdr.cpp:1613
 msgid "Select this if you want aMule to check your disk space"
 msgstr "Seleccione se quiser que o aMule verifique o espaço em disco"
 
-#: src/muuli_wdr.cpp:1618
+#: src/muuli_wdr.cpp:1617
 msgid "Enter here the min disk space desired."
 msgstr "Insira o espaço mínimo no disco desejado."
 
-#: src/muuli_wdr.cpp:1624
+#: src/muuli_wdr.cpp:1623
 msgid "Save 10 sources on rare files (< 20 sources)"
 msgstr "Guardar 10 fontes para ficheiros raros (< 20 fontes)"
 
-#: src/muuli_wdr.cpp:1628 src/Statistics.cpp:790
+#: src/muuli_wdr.cpp:1627 src/Statistics.cpp:790
 msgid "Uploads"
 msgstr "Uploads"
 
-#: src/muuli_wdr.cpp:1631
+#: src/muuli_wdr.cpp:1630
 msgid "Add new shared files with auto priority"
 msgstr "Adicionar novos ficheiros partilhados com prioridade automática"
 
-#: src/muuli_wdr.cpp:1637
+#: src/muuli_wdr.cpp:1636
 msgid "Intelligent Corruption Handling (I.C.H.)"
 msgstr "Manipulação Inteligente de Corrupção (M.I.C.)"
 
-#: src/muuli_wdr.cpp:1640
+#: src/muuli_wdr.cpp:1639
 msgid "Enable"
 msgstr "Activar"
 
-#: src/muuli_wdr.cpp:1643
+#: src/muuli_wdr.cpp:1642
 msgid "Advanced I.C.H. trusts every hash (not recommended)"
 msgstr "M.I.C. Avançada confia em todas as chaves (não recomendado)"
 
-#: src/muuli_wdr.cpp:1655 src/PrefsUnifiedDlg.cpp:1990
+#: src/muuli_wdr.cpp:1654 src/PrefsUnifiedDlg.cpp:1910
 msgid "Media metadata extraction"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1659
+#: src/muuli_wdr.cpp:1658
 msgid "Extract length / bitrate / codec from shared audio and video files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1661
+#: src/muuli_wdr.cpp:1660
 msgid "When enabled, aMule runs ffprobe on each shared media file to fill in the Length / Bitrate / Codec columns other clients see when they find the file in a search. Requires ffmpeg (the ffprobe binary) to be installed."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1668
+#: src/muuli_wdr.cpp:1667
 msgid "Path to ffprobe:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1673
+#: src/muuli_wdr.cpp:1672
 msgid "Full path to the ffprobe binary. Leave empty to have aMule auto-detect it on startup."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1681
+#: src/muuli_wdr.cpp:1680
 msgid "Detect"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1682
+#: src/muuli_wdr.cpp:1681
 msgid "Search the standard install locations for an ffprobe binary and fill the path field."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1706
+#: src/muuli_wdr.cpp:1705
 msgid ""
 "Completed downloads are stored here. All files in this folder are automatically shared with other peers.\n"
 "If this folder also holds files you don't want to share, point it at an aMule-only sub-folder."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1709
+#: src/muuli_wdr.cpp:1708
 msgid "Pick the folder where completed downloads will be stored. All files in that folder will be shared with other peers."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1723
+#: src/muuli_wdr.cpp:1722
 msgid "Shared folders"
 msgstr "Pastas partilhadas"
 
-#: src/muuli_wdr.cpp:1729
+#: src/muuli_wdr.cpp:1728
 msgid "(Folders shared by the core. Enter a path to add one.)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1737
+#: src/muuli_wdr.cpp:1736
 msgid "Absolute path of a folder on the core's machine, e.g. /home/user/shared"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1739 src/PrefsUnifiedDlg.cpp:2874
+#: src/muuli_wdr.cpp:1738 src/PrefsUnifiedDlg.cpp:2794
 msgid "Recursive"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1740
+#: src/muuli_wdr.cpp:1739
 msgid "Share every sub-folder underneath this one, including ones created later."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1744 src/utils/aLinkCreator/src/alcframe.cpp:141
+#: src/muuli_wdr.cpp:1743 src/utils/aLinkCreator/src/alcframe.cpp:141
 msgid "Remove"
 msgstr "Remover"
 
-#: src/muuli_wdr.cpp:1748
+#: src/muuli_wdr.cpp:1747
 msgid "(Right click on folder icon for recursive share)"
 msgstr "(Clique com o botão do lado direito no ícone da pasta para partilha recursiva)"
 
-#: src/muuli_wdr.cpp:1755
+#: src/muuli_wdr.cpp:1754
 msgid "Share hidden files"
 msgstr "Partilhar ficheiros ocultos"
 
-#: src/muuli_wdr.cpp:1761
+#: src/muuli_wdr.cpp:1760
 msgid "Automatically rescan shared folders for changes"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1767
+#: src/muuli_wdr.cpp:1766
 msgid "Follow symbolic links in shared folders"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1773
+#: src/muuli_wdr.cpp:1772
 msgid "Exclude files matching:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1776
+#: src/muuli_wdr.cpp:1775
 msgid "Wildcard patterns separated by '|', e.g. .DS_Store|Thumbs.db|*.tmp. Files whose name matches are not shared. Matching is case-insensitive."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1780
+#: src/muuli_wdr.cpp:1779
 msgid "Patterns are regular expressions"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1781
+#: src/muuli_wdr.cpp:1780
 msgid "When set, the whole field is one regular expression ('|' is alternation). When unset, it is a list of '|'-separated wildcards."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1791
+#: src/muuli_wdr.cpp:1790
 msgid "Show how many shared files the current pattern would exclude."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1812
+#: src/muuli_wdr.cpp:1811
 msgid "Graphs"
 msgstr "Gráficos"
 
-#: src/muuli_wdr.cpp:1815 src/muuli_wdr.cpp:1877
+#: src/muuli_wdr.cpp:1814 src/muuli_wdr.cpp:1876
 msgid "Update delay : 5 secs"
 msgstr "Atraso de actualização: 5 segundos"
 
-#: src/muuli_wdr.cpp:1819
+#: src/muuli_wdr.cpp:1818
 msgid "Time for average graph: 100 mins"
 msgstr "Tempo para gráfico de média: 100 minutos"
 
-#: src/muuli_wdr.cpp:1823
+#: src/muuli_wdr.cpp:1822
 msgid "Connections Graph Scale: 100 "
 msgstr "Escala do Gráfico de Ligações: 100"
 
-#: src/muuli_wdr.cpp:1830
+#: src/muuli_wdr.cpp:1829
 msgid "Download graph scale:"
 msgstr "Escala do gráfico de download:"
 
-#: src/muuli_wdr.cpp:1838
+#: src/muuli_wdr.cpp:1837
 msgid "Upload graph scale:"
 msgstr "Escala do gráfico de upload"
 
-#: src/muuli_wdr.cpp:1848
+#: src/muuli_wdr.cpp:1847
 #, fuzzy
 msgid "Colors: "
 msgstr "Cores: "
 
-#: src/muuli_wdr.cpp:1852
+#: src/muuli_wdr.cpp:1851
 msgid "Background"
 msgstr "Fundo"
 
-#: src/muuli_wdr.cpp:1853
+#: src/muuli_wdr.cpp:1852
 msgid "Grid"
 msgstr "Grelha"
 
-#: src/muuli_wdr.cpp:1854
+#: src/muuli_wdr.cpp:1853
 msgid "Download current"
 msgstr "Download actual"
 
-#: src/muuli_wdr.cpp:1855
+#: src/muuli_wdr.cpp:1854
 msgid "Download running average"
 msgstr "Média actual de download"
 
-#: src/muuli_wdr.cpp:1856
+#: src/muuli_wdr.cpp:1855
 msgid "Download session average"
 msgstr "Média de download da sessão"
 
-#: src/muuli_wdr.cpp:1857
+#: src/muuli_wdr.cpp:1856
 msgid "Upload current"
 msgstr "Upload actual"
 
-#: src/muuli_wdr.cpp:1858
+#: src/muuli_wdr.cpp:1857
 msgid "Upload running average"
 msgstr "Média actual de upload"
 
-#: src/muuli_wdr.cpp:1859
+#: src/muuli_wdr.cpp:1858
 msgid "Upload session average"
 msgstr "Média de upload da sessão"
 
-#: src/muuli_wdr.cpp:1860
+#: src/muuli_wdr.cpp:1859
 msgid "Active connections"
 msgstr "Ligações activas"
 
-#: src/muuli_wdr.cpp:1863
+#: src/muuli_wdr.cpp:1862
 #, fuzzy
 msgid "Systray Icon Speed Bar"
 msgstr "Barra de velocidade no ícone da área de notificação"
 
-#: src/muuli_wdr.cpp:1864
+#: src/muuli_wdr.cpp:1863
 msgid "Kad-nodes current"
 msgstr "Nós Kad actuais"
 
-#: src/muuli_wdr.cpp:1865
+#: src/muuli_wdr.cpp:1864
 msgid "Kad-nodes running"
 msgstr "Nós Kad a executar"
 
-#: src/muuli_wdr.cpp:1866
+#: src/muuli_wdr.cpp:1865
 msgid "Kad-nodes session"
 msgstr "Nós Kad da sessão"
 
-#: src/muuli_wdr.cpp:1870 src/muuli_wdr.cpp:2324
+#: src/muuli_wdr.cpp:1869 src/muuli_wdr.cpp:2296
 msgid "Select"
 msgstr "Seleccionar"
 
-#: src/muuli_wdr.cpp:1874
+#: src/muuli_wdr.cpp:1873
 msgid "Tree"
 msgstr "Árvore"
 
-#: src/muuli_wdr.cpp:1884
+#: src/muuli_wdr.cpp:1883
 msgid "Number of Client Versions shown (0=unlimited)"
 msgstr "Número de Versões de Cliente mostradas (0=ilimitado)"
 
-#: src/muuli_wdr.cpp:1909
+#: src/muuli_wdr.cpp:1908
 msgid "!!! WARNING !!!"
 msgstr "!!! AVISO !!!"
 
-#: src/muuli_wdr.cpp:1924
+#: src/muuli_wdr.cpp:1923
 msgid "Max new connections / 5 secs"
 msgstr "Máximo de novas ligações / 5 segundos"
 
-#: src/muuli_wdr.cpp:1926
+#: src/muuli_wdr.cpp:1925
 msgid "Concurrent Kad source lookups"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1928
+#: src/muuli_wdr.cpp:1927
 #, fuzzy
 msgid "Kad source re-search interval (minutes)"
 msgstr "Intervalo de actualização do FTP em minutos"
 
-#: src/muuli_wdr.cpp:1930
+#: src/muuli_wdr.cpp:1929
 #, fuzzy
 msgid "Source re-ask interval (minutes)"
 msgstr "Intervalo de actualização do FTP em minutos"
 
-#: src/muuli_wdr.cpp:1934
+#: src/muuli_wdr.cpp:1933
 msgid "File Buffer Size: 240000 bytes"
 msgstr "Tamanho da memória temporária de ficheiro: 240000 Byte"
 
-#: src/muuli_wdr.cpp:1938
+#: src/muuli_wdr.cpp:1937
 msgid "Use MMAP: memory-mapped file access (lower memory use)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1939
+#: src/muuli_wdr.cpp:1938
 msgid "Maps part files into memory instead of buffering them on the heap, lowering the process memory footprint. May reduce download speed on some disks; best for memory-constrained or upload-heavy hosts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1941
+#: src/muuli_wdr.cpp:1940
 msgid "Upload Queue Size: 5000 clients"
 msgstr "Tamanho da Lista de Espera de Upload: 5000 clientes"
 
-#: src/muuli_wdr.cpp:1945
+#: src/muuli_wdr.cpp:1944
 msgid "Server connection refresh interval: Disable"
 msgstr "Intervalo de actualização da ligação ao servidor: Desactivado"
 
-#: src/muuli_wdr.cpp:1949
+#: src/muuli_wdr.cpp:1948
 msgid "Disable computer's timed standby mode"
 msgstr "Desactivar o modo de espera temporizado do computador"
 
-#: src/muuli_wdr.cpp:1968
+#: src/muuli_wdr.cpp:1967
 msgid "Skin to use: "
 msgstr "Tema a utilizar: "
 
-#: src/muuli_wdr.cpp:1977
+#: src/muuli_wdr.cpp:1976
 msgid "Show \"Fast eD2k Links Handler\" in every window."
 msgstr "Mostrar a barra de adição rápida de ligações eD2k em todas as janelas."
 
-#: src/muuli_wdr.cpp:1980
+#: src/muuli_wdr.cpp:1979
 msgid "Show extended info on categories tabs"
 msgstr "Mostrar informação extra nos separadores de categorias"
 
-#: src/muuli_wdr.cpp:1983
+#: src/muuli_wdr.cpp:1982
 #, fuzzy
 msgid "Show application version on title"
 msgstr "Mostrar velocidades de transferência na barra de título"
 
-#: src/muuli_wdr.cpp:1985
+#: src/muuli_wdr.cpp:1984
 msgid "Show transfer rates on title"
 msgstr "Mostrar velocidades de transferência na barra de título"
 
-#: src/muuli_wdr.cpp:1987
+#: src/muuli_wdr.cpp:1986
 msgid "Before application name"
 msgstr "Antes do nome da aplicação"
 
-#: src/muuli_wdr.cpp:1989
+#: src/muuli_wdr.cpp:1988
 msgid "After application name"
 msgstr "Depois do nome da aplicação"
 
-#: src/muuli_wdr.cpp:1992
+#: src/muuli_wdr.cpp:1991
 msgid "Show overhead bandwidth"
 msgstr "Mostrar sobrecarga na largura de banda"
 
-#: src/muuli_wdr.cpp:1996
+#: src/muuli_wdr.cpp:1995
 msgid "Vertical toolbar orientation"
 msgstr "Orientação vertical da barra de ferramentas"
 
-#: src/muuli_wdr.cpp:1998
+#: src/muuli_wdr.cpp:1997
 msgid "Live column sorting (auto-reorder rows as their values change)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2005
+#: src/muuli_wdr.cpp:2004
 msgid "Download Queue Files"
 msgstr "Ficheiros na Fila de Espera dos Downloads"
 
-#: src/muuli_wdr.cpp:2008
+#: src/muuli_wdr.cpp:2007
 msgid "Show progress percentage"
 msgstr "Mostrar percentagem de progresso"
 
-#: src/muuli_wdr.cpp:2014
+#: src/muuli_wdr.cpp:2013
 msgid "Show progress bar"
 msgstr "Mostrar barra de progresso"
 
-#: src/muuli_wdr.cpp:2017
+#: src/muuli_wdr.cpp:2016
 msgid "Flat"
 msgstr "Plana"
 
-#: src/muuli_wdr.cpp:2021
+#: src/muuli_wdr.cpp:2020
 msgid "Round"
 msgstr "Arredondada"
 
-#: src/muuli_wdr.cpp:2039
+#: src/muuli_wdr.cpp:2038
 msgid "External Connection Parameters"
 msgstr "Parâmetros de Ligação Externa"
 
-#: src/muuli_wdr.cpp:2042
+#: src/muuli_wdr.cpp:2041
 msgid "Accept external connections"
 msgstr "Aceitar ligações externas"
 
-#: src/muuli_wdr.cpp:2049 src/muuli_wdr.cpp:2108
+#: src/muuli_wdr.cpp:2048 src/muuli_wdr.cpp:2107
 msgid "IP of the listening interface:"
 msgstr "IP da interface a escutar:"
 
-#: src/muuli_wdr.cpp:2052
+#: src/muuli_wdr.cpp:2051
 msgid "Enter here a valid ip in the a.b.c.d format for the listening EC interface. An empty field or 0.0.0.0 will mean any interface."
 msgstr "Insira um endereço IP válido no formato a.b.c.d para a interface que irá aguardar as LE. Um campo vazio ou 0.0.0.0 significará qualquer interface."
 
-#: src/muuli_wdr.cpp:2073 src/muuli_wdr.cpp:2184
+#: src/muuli_wdr.cpp:2072 src/muuli_wdr.cpp:2156
 msgid "TCP port:"
 msgstr "Porto TCP:"
 
-#: src/muuli_wdr.cpp:2079
+#: src/muuli_wdr.cpp:2078
 msgid "Enable UPnP port forwarding on the EC port"
 msgstr "Activar UPnP para configuração do encaminhamento no porto das LE"
 
-#: src/muuli_wdr.cpp:2083 src/muuli_wdr.cpp:3069
+#: src/muuli_wdr.cpp:2082 src/muuli_wdr.cpp:3041
 #: src/utils/wxCas/src/wxcasprefs.cpp:167
 msgid "Password"
 msgstr "Palavra-passe"
 
-#: src/muuli_wdr.cpp:2089
+#: src/muuli_wdr.cpp:2088
 #, fuzzy
 msgid "aMule API server parameters"
 msgstr "Parâmetros do servidor web"
 
-#: src/muuli_wdr.cpp:2092
+#: src/muuli_wdr.cpp:2091
 msgid "Run amuleapi (REST API) on startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2097
+#: src/muuli_wdr.cpp:2096
 #, fuzzy
 msgid "HTTP port:"
 msgstr "Porto TCP:"
 
-#: src/muuli_wdr.cpp:2111
+#: src/muuli_wdr.cpp:2110
 msgid "The interface amuleapi's HTTP server listens on. 127.0.0.1 (default) accepts only local connections; use 0.0.0.0 or a specific IP to expose it to other hosts (set an admin password below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2116
-msgid "Type a password to set or change it. Stored passwords cannot be shown, so leaving this empty keeps the current one."
-msgstr ""
-
-#: src/muuli_wdr.cpp:2118
+#: src/muuli_wdr.cpp:2113
 #, fuzzy
 msgid "Admin password"
 msgstr "A verificar a palavra-passe\n"
 
-#: src/muuli_wdr.cpp:2130 src/muuli_wdr.cpp:2147 src/PrefsUnifiedDlg.cpp:1103
-#, fuzzy
-msgid "A password is set."
-msgstr "A verificar a palavra-passe\n"
+#: src/muuli_wdr.cpp:2118 src/muuli_wdr.cpp:2149
+msgid "Low rights password"
+msgstr "Palavra-passe para controlo reduzido"
 
-#: src/muuli_wdr.cpp:2134
-#, fuzzy
-msgid "Enable guest access"
-msgstr "Negar acesso de convidado"
-
-#: src/muuli_wdr.cpp:2135
-msgid "Guest sessions may read status and listings but cannot change anything. Turning this off clears the stored guest password."
-msgstr ""
-
-#: src/muuli_wdr.cpp:2139
-#, fuzzy
-msgid "Guest password"
-msgstr "Palavra-passe de convidado para o servidor web"
-
-#: src/muuli_wdr.cpp:2154
+#: src/muuli_wdr.cpp:2126
 msgid "Web server parameters"
 msgstr "Parâmetros do servidor web"
 
-#: src/muuli_wdr.cpp:2157
+#: src/muuli_wdr.cpp:2129
 #, fuzzy
 msgid "Run webserver on startup (deprecated)"
 msgstr "Executar o servidor web no arranque"
 
-#: src/muuli_wdr.cpp:2163
+#: src/muuli_wdr.cpp:2135
 msgid "Web template"
 msgstr "Aspecto da página web"
 
-#: src/muuli_wdr.cpp:2168
+#: src/muuli_wdr.cpp:2140
 msgid "Full rights password"
 msgstr "Palavra-passe para controlo total"
 
-#: src/muuli_wdr.cpp:2172
+#: src/muuli_wdr.cpp:2144
 msgid "Enable Low rights User"
 msgstr "Activar utilizador com permissões reduzidas"
 
-#: src/muuli_wdr.cpp:2177
-msgid "Low rights password"
-msgstr "Palavra-passe para controlo reduzido"
-
-#: src/muuli_wdr.cpp:2191
+#: src/muuli_wdr.cpp:2163
 msgid "Enable UPnP port forwarding of the web server port"
 msgstr "Activar UPnP para encaminhamento do porto do servidor web"
 
-#: src/muuli_wdr.cpp:2196
+#: src/muuli_wdr.cpp:2168
 msgid "Web server UPnP TCP port (Optional)"
 msgstr "Porto TCP UPnP do servidor web (Opcional)"
 
-#: src/muuli_wdr.cpp:2204
+#: src/muuli_wdr.cpp:2176
 msgid "Page Refresh Time (in secs)"
 msgstr "Taxa de Actualização de Páginas (em segundos)"
 
-#: src/muuli_wdr.cpp:2211
+#: src/muuli_wdr.cpp:2183
 msgid "Enable Gzip compression"
 msgstr "Activar compressão Gzip"
 
-#: src/muuli_wdr.cpp:2245
+#: src/muuli_wdr.cpp:2217
 #, fuzzy
 msgid "Reset page to defaults"
 msgstr "Predefinição do sistema"
 
-#: src/muuli_wdr.cpp:2246
+#: src/muuli_wdr.cpp:2218
 msgid "Reset the settings on the current page to their default values."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2248 src/muuli_wdr.cpp:2334 src/ServerWnd.cpp:274
+#: src/muuli_wdr.cpp:2220 src/muuli_wdr.cpp:2306 src/ServerWnd.cpp:274
 #: src/ServerWnd.cpp:282
 msgid "OK"
 msgstr "OK"
 
-#: src/muuli_wdr.cpp:2250
+#: src/muuli_wdr.cpp:2222
 msgid "Click here to apply any changes made to the preferences."
 msgstr "Clique aqui para aplicar as alterações efectuadas nas preferências."
 
-#: src/muuli_wdr.cpp:2253
+#: src/muuli_wdr.cpp:2225
 msgid "Reset any changes made to the preferences."
 msgstr "Anular as alterações efectuadas nas preferências."
 
-#: src/muuli_wdr.cpp:2282
+#: src/muuli_wdr.cpp:2254
 msgid "Comment :"
 msgstr "Comentário :"
 
-#: src/muuli_wdr.cpp:2289
+#: src/muuli_wdr.cpp:2261
 msgid "Incoming Dir :"
 msgstr "Pasta de completos :"
 
-#: src/muuli_wdr.cpp:2298
+#: src/muuli_wdr.cpp:2270
 msgid "Change priority for new assigned files :"
 msgstr "Trocar prioridade nos novos ficheiros :"
 
-#: src/muuli_wdr.cpp:2302
+#: src/muuli_wdr.cpp:2274
 msgid "Don't change"
 msgstr "Não mudar"
 
-#: src/muuli_wdr.cpp:2314
+#: src/muuli_wdr.cpp:2286
 msgid "Select color for this Category (currently selected) :"
 msgstr "Seleccionar a cor para a categoria seleccionada :"
 
-#: src/muuli_wdr.cpp:2381 src/muuli_wdr.cpp:2400 src/muuli_wdr.cpp:2422
+#: src/muuli_wdr.cpp:2353 src/muuli_wdr.cpp:2372 src/muuli_wdr.cpp:2394
 msgid "Click this button to reset the log."
 msgstr "Clique para limpar o relatório."
 
-#: src/muuli_wdr.cpp:2441
+#: src/muuli_wdr.cpp:2413
 msgid "Click on this button to update the servers list from URL ..."
 msgstr "Clique neste botão para actualizar a lista de servidores a partir do endereço ..."
 
-#: src/muuli_wdr.cpp:2445
+#: src/muuli_wdr.cpp:2417
 msgid "Server list"
 msgstr "Lista de Servidores"
 
-#: src/muuli_wdr.cpp:2449
+#: src/muuli_wdr.cpp:2421
 msgid "Enter the url to a server.met file here and press the button to the left to update the list of known servers."
 msgstr "Insira a localização de um ficheiro server.met e pressione o botão à esquerda para actualizar a lista de servidores conhecidos."
 
-#: src/muuli_wdr.cpp:2454
+#: src/muuli_wdr.cpp:2426
 msgid "Add server manually: Name"
 msgstr "Adicionar servidor manualmente: Nome"
 
-#: src/muuli_wdr.cpp:2457
+#: src/muuli_wdr.cpp:2429
 msgid "Enter the name of the new server here"
 msgstr "Insira o nome do novo servidor"
 
-#: src/muuli_wdr.cpp:2459 src/ServerWnd.cpp:206
+#: src/muuli_wdr.cpp:2431 src/ServerWnd.cpp:206
 msgid "IP:Port"
 msgstr "IP:Porto"
 
-#: src/muuli_wdr.cpp:2462
+#: src/muuli_wdr.cpp:2434
 msgid "Enter the IP of the server here, using the x.x.x.x format."
 msgstr "Insira o IP do servidor, usando o formato x.x.x.x."
 
-#: src/muuli_wdr.cpp:2468
+#: src/muuli_wdr.cpp:2440
 msgid "Enter the port of the server here."
 msgstr "Insira o porto do servidor."
 
-#: src/muuli_wdr.cpp:2471
+#: src/muuli_wdr.cpp:2443
 msgid "Add manually a server (fill fields to the left before) ..."
 msgstr "Adicionar manualmente um servidor (preencher os campos ao lado) ..."
 
-#: src/muuli_wdr.cpp:2500
+#: src/muuli_wdr.cpp:2472
 msgid "aMule Log"
 msgstr "Relatório"
 
-#: src/muuli_wdr.cpp:2508
+#: src/muuli_wdr.cpp:2480
 msgid "Server Info"
 msgstr "Informações do Servidor"
 
-#: src/muuli_wdr.cpp:2512
+#: src/muuli_wdr.cpp:2484
 msgid "ED2K Info"
 msgstr "Informação ED2K"
 
-#: src/muuli_wdr.cpp:2516
+#: src/muuli_wdr.cpp:2488
 msgid "Kad Info"
 msgstr "Informação Kad"
 
-#: src/muuli_wdr.cpp:2544
+#: src/muuli_wdr.cpp:2516
 msgid "Click on this button to update the nodes list from URL ..."
 msgstr "Clique para actualizar a lista de nós a partir do endereço ..."
 
-#: src/muuli_wdr.cpp:2548
+#: src/muuli_wdr.cpp:2520
 msgid "Nodes (0)"
 msgstr "Nós (0)"
 
-#: src/muuli_wdr.cpp:2552
+#: src/muuli_wdr.cpp:2524
 msgid "Enter the url to a nodes.dat file here and press the button to the left to update the list of known nodes."
 msgstr "Insira o endereço de um ficheiro nodes.dat e pressione o botão à esquerda para actualizar a lista de nós conhecidos."
 
-#: src/muuli_wdr.cpp:2555
+#: src/muuli_wdr.cpp:2527
 msgid "Nodes stats"
 msgstr "Estado dos nós"
 
-#: src/muuli_wdr.cpp:2597
+#: src/muuli_wdr.cpp:2569
 msgid "Bootstrap"
 msgstr "Inicialização"
 
-#: src/muuli_wdr.cpp:2600
+#: src/muuli_wdr.cpp:2572
 msgid "New node"
 msgstr "Novo nó"
 
-#: src/muuli_wdr.cpp:2605
+#: src/muuli_wdr.cpp:2577
 msgid "IP:"
 msgstr "IP:"
 
-#: src/muuli_wdr.cpp:2625
+#: src/muuli_wdr.cpp:2597
 msgid "Port:"
 msgstr "Porto:"
 
-#: src/muuli_wdr.cpp:2638
+#: src/muuli_wdr.cpp:2610
 msgid "Bootstrap from known clients"
 msgstr "Arrancar a partir de clientes conhecidos"
 
-#: src/muuli_wdr.cpp:2640
+#: src/muuli_wdr.cpp:2612
 msgid "Disconnect Kad"
 msgstr "Desligar Kad"
 
-#: src/muuli_wdr.cpp:2674
+#: src/muuli_wdr.cpp:2646
 msgid "Use Secure User Identification"
 msgstr "Utilizar Identificação Segura de Utilizador"
 
-#: src/muuli_wdr.cpp:2676
+#: src/muuli_wdr.cpp:2648
 msgid "It is recommended to enable this option. You will not receive credits if SUI is not enabled."
 msgstr "É recomendado activar esta opção. Não receberá créditos se a Identificação Segura de Utilizador não estiver activada."
 
-#: src/muuli_wdr.cpp:2678
+#: src/muuli_wdr.cpp:2650
 msgid "Protocol Obfuscation"
 msgstr "Ofuscação do Protocolo"
 
-#: src/muuli_wdr.cpp:2681
+#: src/muuli_wdr.cpp:2653
 msgid "Support Protocol Obfuscation"
 msgstr "Suportar a Ofuscação do Protocolo"
 
-#: src/muuli_wdr.cpp:2683
+#: src/muuli_wdr.cpp:2655
 msgid "This option enabled Protocol Obfuscation, and makes aMule accept obfuscated connections from other clients."
 msgstr "Esta opção activa a Ofuscação do Protocolo e faz com que o aMule aceite ligações ofuscadas de outros clientes."
 
-#: src/muuli_wdr.cpp:2685
+#: src/muuli_wdr.cpp:2657
 msgid "Use obfuscation for outgoing connections"
 msgstr "Usar ofuscação em ligações para o exterior"
 
-#: src/muuli_wdr.cpp:2687
+#: src/muuli_wdr.cpp:2659
 msgid "This option makes aMule use Protocol Obfuscation when connecting other clients/servers."
 msgstr "Esta opção faz com que o aMule use a Ofuscação do Protocolo quando ligado a outros clientes/servidores."
 
-#: src/muuli_wdr.cpp:2689
+#: src/muuli_wdr.cpp:2661
 msgid "Accept only obfuscated connections"
 msgstr "Aceitar apenas ligações ofuscadas"
 
-#: src/muuli_wdr.cpp:2690
+#: src/muuli_wdr.cpp:2662
 msgid "This option makes aMule only accept obfuscated connections. You will have less sources, but all your traffic will be obfuscated"
 msgstr "Esta opção faz com que o aMUle aceite apenas ligações ofuscadas. Terá menos fontes, mas todo o tráfego será ofuscado"
 
-#: src/muuli_wdr.cpp:2695
+#: src/muuli_wdr.cpp:2667
 msgid "Everybody"
 msgstr "Todos"
 
-#: src/muuli_wdr.cpp:2697
+#: src/muuli_wdr.cpp:2669
 msgid "No one"
 msgstr "Ninguém"
 
-#: src/muuli_wdr.cpp:2699
+#: src/muuli_wdr.cpp:2671
 msgid "Who can see my shared files:"
 msgstr "Quem pode ver os meus ficheiros partilhados:"
 
-#: src/muuli_wdr.cpp:2700
+#: src/muuli_wdr.cpp:2672
 msgid "Select who can request to view a list of your shared files."
 msgstr "Seleccione quem pode pedir a lista dos seus ficheiros partilhados."
 
-#: src/muuli_wdr.cpp:2702
+#: src/muuli_wdr.cpp:2674
 msgid "IP-Filtering"
 msgstr "Filtragem de IP"
 
-#: src/muuli_wdr.cpp:2709
+#: src/muuli_wdr.cpp:2681
 msgid "Filter clients"
 msgstr "Filtrar clientes"
 
-#: src/muuli_wdr.cpp:2711
+#: src/muuli_wdr.cpp:2683
 msgid "Enable filtering of the client IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "Activar filtragem por IPs dos clientes definidos no ficheiro ~/.aMule/ipfilter.dat."
 
-#: src/muuli_wdr.cpp:2713
+#: src/muuli_wdr.cpp:2685
 msgid "Filter servers"
 msgstr "Filtrar servidores"
 
-#: src/muuli_wdr.cpp:2715
+#: src/muuli_wdr.cpp:2687
 msgid "Enable filtering of the server IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "Activar filtragem da lista de IPs definida no ficheiro ~/.aMule/ipfilter.dat."
 
-#: src/muuli_wdr.cpp:2719
+#: src/muuli_wdr.cpp:2691
 msgid "Reload List"
 msgstr "Recarregar a lista"
 
-#: src/muuli_wdr.cpp:2720
+#: src/muuli_wdr.cpp:2692
 msgid "Reload the list of IPs to filter from the file ~/.aMule/ipfilter.dat"
 msgstr "Recarregar a lista de IPs a filtrar a partir do ficheiro ~/.aMule/ipfilter.dat"
 
-#: src/muuli_wdr.cpp:2726
+#: src/muuli_wdr.cpp:2698
 msgid "URL:"
 msgstr "URL:"
 
-#: src/muuli_wdr.cpp:2730 src/muuli_wdr.cpp:2923
+#: src/muuli_wdr.cpp:2702 src/muuli_wdr.cpp:2895
 msgid "Update now"
 msgstr "Actualizar agora"
 
-#: src/muuli_wdr.cpp:2733
+#: src/muuli_wdr.cpp:2705
 msgid "Auto-update ipfilter at startup"
 msgstr "Actualizar o filtro de IPs automaticamente no arranque"
 
-#: src/muuli_wdr.cpp:2737
+#: src/muuli_wdr.cpp:2709
 msgid "Filtering Level:"
 msgstr "Nível de filtragem:"
 
-#: src/muuli_wdr.cpp:2743
+#: src/muuli_wdr.cpp:2715
 msgid "Always filter LAN IPs"
 msgstr "Filtrar sempre endereços IP de rede local"
 
-#: src/muuli_wdr.cpp:2746
+#: src/muuli_wdr.cpp:2718
 msgid "Paranoid handling of non-matching IPs"
 msgstr "Tratamento paranóico de IPs sem correspondência"
 
-#: src/muuli_wdr.cpp:2748
+#: src/muuli_wdr.cpp:2720
 msgid "Rejects a packet when its source IP differs from the IP the client claims (an anti-spoofing check). Disable only if it causes connection problems."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2750
+#: src/muuli_wdr.cpp:2722
 msgid "Use system-wide ipfilter.dat if available"
 msgstr "Utilizar ipfilter.dat global do sistema se disponível"
 
-#: src/muuli_wdr.cpp:2751
+#: src/muuli_wdr.cpp:2723
 #, fuzzy
 msgid "If there's no local ipfilter.dat found, allow usage of a system-wide ipfilter file."
 msgstr "Se não existir um ficheiro ipfilter.dat, permitir a utilização de um ficheiro ipfilter global do sistema."
 
-#: src/muuli_wdr.cpp:2768
+#: src/muuli_wdr.cpp:2740
 msgid "Enable Online-Signature"
 msgstr "Activar Assinatura Online"
 
-#: src/muuli_wdr.cpp:2770
+#: src/muuli_wdr.cpp:2742
 msgid "Enables the writing of the OS file, which can be used by external apps to create signatures and the like."
 msgstr "Activa a escrita do ficheiro da AO, o qual pode ser usado por aplicações externas para criar assinaturas e afins."
 
-#: src/muuli_wdr.cpp:2774
+#: src/muuli_wdr.cpp:2746
 msgid "Update Frequency (Secs):"
 msgstr "Frequência de Actualização (segundos):"
 
-#: src/muuli_wdr.cpp:2777
+#: src/muuli_wdr.cpp:2749
 msgid "Change the frequency (in seconds) of Online Signature updates."
 msgstr "Alterar a frequência (em segundos) das actualizações da assinatura Online."
 
-#: src/muuli_wdr.cpp:2785
+#: src/muuli_wdr.cpp:2757
 msgid "Save online signature file in: "
 msgstr "Gravar a assinatura Online em: "
 
-#: src/muuli_wdr.cpp:2791
+#: src/muuli_wdr.cpp:2763
 msgid "Click here to select the directory containing the the Online Signature files."
 msgstr "Clique para seleccionar a pasta que contém os ficheiros de Assinatura Online"
 
-#: src/muuli_wdr.cpp:2824
+#: src/muuli_wdr.cpp:2796
 msgid "Show country flags for clients"
 msgstr "Mostrar bandeiras de países para clientes"
 
-#: src/muuli_wdr.cpp:2825
+#: src/muuli_wdr.cpp:2797
 msgid "Render the country flag column in the transfers, queue and search views. Requires a valid MMDB GeoIP database (see below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2830
+#: src/muuli_wdr.cpp:2802
 #, fuzzy
 msgid "Database"
 msgstr "Taxa de transferência :"
 
-#: src/muuli_wdr.cpp:2846
+#: src/muuli_wdr.cpp:2818
 #, fuzzy
 msgid "Source:"
 msgstr "Fontes"
 
-#: src/muuli_wdr.cpp:2849
+#: src/muuli_wdr.cpp:2821
 msgid "DB-IP (free, no account)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2850
+#: src/muuli_wdr.cpp:2822
 msgid "MaxMind GeoLite2 (free, account required)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2851
+#: src/muuli_wdr.cpp:2823
 msgid "Custom URL"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2854
+#: src/muuli_wdr.cpp:2826
 msgid "Choose which provider supplies the GeoIP MMDB database. DB-IP is the default - no account required. MaxMind requires a free account + license key. Use Custom URL to point at any other MMDB host (e.g. a local mirror)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2871
+#: src/muuli_wdr.cpp:2843
 msgid ""
 "No configuration required.\n"
 "\n"
@@ -4881,11 +4847,11 @@ msgid ""
 "License: Creative Commons BY 4.0 - https://creativecommons.org/licenses/by/4.0/"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2884
+#: src/muuli_wdr.cpp:2856
 msgid "License key:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2890
+#: src/muuli_wdr.cpp:2862
 msgid ""
 "Sign up for a free MaxMind account, then generate a License Key:\n"
 "https://www.maxmind.com/en/geolite2/signup\n"
@@ -4895,226 +4861,226 @@ msgid ""
 "Requires attribution and account registration; refresh at least every 30 days."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2905
+#: src/muuli_wdr.cpp:2877
 #, fuzzy
 msgid "Download URL:"
 msgstr "Download: "
 
-#: src/muuli_wdr.cpp:2911
+#: src/muuli_wdr.cpp:2883
 msgid ""
 "Must point to an .mmdb file or a .gz / .tar.gz containing one.\n"
 "URL may include credentials (https://user:pass@host/...).\n"
 "License and attribution terms are set by the upstream URL - you are responsible."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2924
+#: src/muuli_wdr.cpp:2896
 msgid "Download the GeoIP database from the selected source."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2926
+#: src/muuli_wdr.cpp:2898
 #, fuzzy
 msgid "Auto-update on startup"
 msgstr "Actualizar o filtro de IPs automaticamente no arranque"
 
-#: src/muuli_wdr.cpp:2927
+#: src/muuli_wdr.cpp:2899
 msgid "Re-download the GeoIP database from the selected source every time aMule starts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2950
+#: src/muuli_wdr.cpp:2922
 msgid "Filter incoming messages (except current chat):"
 msgstr "Filtrar mensagens recebidas (excepto da conversa corrente):"
 
-#: src/muuli_wdr.cpp:2952
+#: src/muuli_wdr.cpp:2924
 msgid "Filter all messages"
 msgstr "Filtrar todas as mensagens"
 
-#: src/muuli_wdr.cpp:2954
+#: src/muuli_wdr.cpp:2926
 msgid "Filter messages from people not on your friend list"
 msgstr "Filtrar mensagens de utilizadores que não pertençam à lista de amigos"
 
-#: src/muuli_wdr.cpp:2956
+#: src/muuli_wdr.cpp:2928
 msgid "Filter messages from unknown clients"
 msgstr "Filtrar mensagens de clientes desconhecidos"
 
-#: src/muuli_wdr.cpp:2958
+#: src/muuli_wdr.cpp:2930
 msgid "Filter messages containing (use ',' as separator):"
 msgstr "Filtrar mensagens que contenham (usar ',' como separador):"
 
-#: src/muuli_wdr.cpp:2961 src/muuli_wdr.cpp:2972
+#: src/muuli_wdr.cpp:2933 src/muuli_wdr.cpp:2944
 msgid "add here the words amule should filter and block messages including it"
 msgstr "adicione as palavras que o aMule deve filtrar e bloquear as mensagens que as contenham"
 
-#: src/muuli_wdr.cpp:2963
+#: src/muuli_wdr.cpp:2935
 msgid "Show received messages in the log"
 msgstr "Mostrar mensagens recebidas no relatório"
 
-#: src/muuli_wdr.cpp:2966
+#: src/muuli_wdr.cpp:2938
 msgid "Comments"
 msgstr "Comentários"
 
-#: src/muuli_wdr.cpp:2969
+#: src/muuli_wdr.cpp:2941
 msgid "Filter comments containing (use ',' as separator):"
 msgstr "Filtrar comentários que contenham (usar ',' como separador):"
 
-#: src/muuli_wdr.cpp:2994
+#: src/muuli_wdr.cpp:2966
 msgid "Enable Proxy"
 msgstr "Activar Proxy"
 
-#: src/muuli_wdr.cpp:2995
+#: src/muuli_wdr.cpp:2967
 msgid "Enable/disable proxy support"
 msgstr "Activar/desactivar o suporte de proxy"
 
-#: src/muuli_wdr.cpp:2998
+#: src/muuli_wdr.cpp:2970
 msgid "Proxy type:"
 msgstr "Tipo de proxy:"
 
-#: src/muuli_wdr.cpp:3009
+#: src/muuli_wdr.cpp:2981
 msgid "Proxy host:"
 msgstr "Servidor:"
 
-#: src/muuli_wdr.cpp:3012
+#: src/muuli_wdr.cpp:2984
 msgid "The proxy host name"
 msgstr "O nome da máquina proxy"
 
-#: src/muuli_wdr.cpp:3014
+#: src/muuli_wdr.cpp:2986
 msgid "Proxy port:"
 msgstr "Porto do proxy:"
 
-#: src/muuli_wdr.cpp:3017
+#: src/muuli_wdr.cpp:2989
 msgid "The proxy port"
 msgstr "O porto do proxy"
 
-#: src/muuli_wdr.cpp:3019
+#: src/muuli_wdr.cpp:2991
 msgid "Enable authentication"
 msgstr "Activar autenticação"
 
-#: src/muuli_wdr.cpp:3020
+#: src/muuli_wdr.cpp:2992
 msgid "Enable/disable username/password authentication"
 msgstr "Activar/desactivar autenticação utilizador/palavra-passe"
 
-#: src/muuli_wdr.cpp:3023
+#: src/muuli_wdr.cpp:2995
 msgid "Username: "
 msgstr "Utilizador: "
 
-#: src/muuli_wdr.cpp:3026
+#: src/muuli_wdr.cpp:2998
 msgid "The username to use to connect to the proxy"
 msgstr "O nome de utilizador para ligar ao proxy"
 
-#: src/muuli_wdr.cpp:3028
+#: src/muuli_wdr.cpp:3000
 msgid "Password:"
 msgstr "Palavra-passe:"
 
-#: src/muuli_wdr.cpp:3031
+#: src/muuli_wdr.cpp:3003
 msgid "The password to use to connect to the proxy"
 msgstr "A palavra-passe a usar para ligar ao proxy"
 
-#: src/muuli_wdr.cpp:3050
+#: src/muuli_wdr.cpp:3022
 msgid "Connect to:"
 msgstr "Ligar a:"
 
-#: src/muuli_wdr.cpp:3059
+#: src/muuli_wdr.cpp:3031
 msgid "Login to remote amule"
 msgstr "Autenticação remota"
 
-#: src/muuli_wdr.cpp:3064
+#: src/muuli_wdr.cpp:3036
 msgid "User name"
 msgstr "Nome de utilizador"
 
-#: src/muuli_wdr.cpp:3075
+#: src/muuli_wdr.cpp:3047
 msgid "Remember those settings"
 msgstr "Lembrar estas preferências"
 
-#: src/muuli_wdr.cpp:3078
+#: src/muuli_wdr.cpp:3050
 #, fuzzy
 msgid "Force ZLIB compression"
 msgstr "Usar compressão gzip"
 
-#: src/muuli_wdr.cpp:3102
+#: src/muuli_wdr.cpp:3074
 msgid "Enable Verbose Debug-Logging."
 msgstr "Activar Relatório detalhado para Depuração."
 
-#: src/muuli_wdr.cpp:3104
+#: src/muuli_wdr.cpp:3076
 #, fuzzy
 msgid "Only to Logfile"
 msgstr "&Abrir o ficheiro"
 
-#: src/muuli_wdr.cpp:3106
+#: src/muuli_wdr.cpp:3078
 msgid "Message Categories:"
 msgstr "Categorias de Mensagens:"
 
-#: src/muuli_wdr.cpp:3130 src/PartFileConvertDlg.cpp:160
+#: src/muuli_wdr.cpp:3102 src/PartFileConvertDlg.cpp:160
 msgid "Waiting..."
 msgstr "A aguardar..."
 
-#: src/muuli_wdr.cpp:3150
+#: src/muuli_wdr.cpp:3122
 msgid "Add imports"
 msgstr "Adicionar importações"
 
-#: src/muuli_wdr.cpp:3153
+#: src/muuli_wdr.cpp:3125
 msgid "Retry selected"
 msgstr "Reassumir seleccionados"
 
-#: src/muuli_wdr.cpp:3155
+#: src/muuli_wdr.cpp:3127
 msgid "Remove selected"
 msgstr "Remover seleccionados"
 
-#: src/muuli_wdr.cpp:3218
+#: src/muuli_wdr.cpp:3190
 msgid "Event Types"
 msgstr "Tipos de eventos"
 
-#: src/muuli_wdr.cpp:3237
+#: src/muuli_wdr.cpp:3209
 msgid "Statistics and queued clients for selected file(s) : Session / All time"
 msgstr "Estatísticas e clientes em espera para o(s) ficheiro(s) seleccionado(s) : Sessão / Desde sempre"
 
-#: src/muuli_wdr.cpp:3261
+#: src/muuli_wdr.cpp:3233
 msgid "Active Uploads"
 msgstr "Uploads Activos"
 
-#: src/muuli_wdr.cpp:3275
+#: src/muuli_wdr.cpp:3247
 msgid "Percent of total files"
 msgstr "Percentagem dos ficheiros totais"
 
-#: src/muuli_wdr.cpp:3327
+#: src/muuli_wdr.cpp:3299
 msgid "Show Clients for"
 msgstr "Mostrar Clientes para"
 
-#: src/muuli_wdr.cpp:3329
+#: src/muuli_wdr.cpp:3301
 msgid "All files"
 msgstr "Todos os ficheiros"
 
-#: src/muuli_wdr.cpp:3332
+#: src/muuli_wdr.cpp:3304
 msgid "Selected files"
 msgstr "Ficheiros seleccionados"
 
-#: src/muuli_wdr.cpp:3335
+#: src/muuli_wdr.cpp:3307
 msgid "Active uploads only"
 msgstr "Apenas os uploads activos"
 
-#: src/muuli_wdr.cpp:3342
+#: src/muuli_wdr.cpp:3314
 msgid "Reload:"
 msgstr "Recarregar:"
 
-#: src/muuli_wdr.cpp:3346
+#: src/muuli_wdr.cpp:3318
 msgid "Reload your shared files"
 msgstr "Recarregar os seus ficheiros partilhados"
 
-#: src/muuli_wdr.cpp:3409
+#: src/muuli_wdr.cpp:3381
 msgid "Send"
 msgstr "Enviar"
 
-#: src/muuli_wdr.cpp:3410
+#: src/muuli_wdr.cpp:3382
 msgid "Sends the specified message."
 msgstr "Envia a mensagem especificada."
 
-#: src/muuli_wdr.cpp:3414
+#: src/muuli_wdr.cpp:3386
 msgid "Close this chat-session."
 msgstr "Fechar esta conversa."
 
-#: src/muuli_wdr.cpp:3437
+#: src/muuli_wdr.cpp:3409
 msgid "Connect to any server and/or Kad"
 msgstr "Ligar a qualquer servidor e/ou Kad"
 
-#: src/muuli_wdr.cpp:3443 src/SharedFilesCtrl.cpp:142 src/Statistics.cpp:941
+#: src/muuli_wdr.cpp:3415 src/SharedFilesCtrl.cpp:142 src/Statistics.cpp:941
 msgid "Shared Files"
 msgstr "Ficheiros Partilhados"
 
@@ -5473,250 +5439,250 @@ msgstr "Transferido"
 msgid "ERROR: Failed to open partfile '%s'"
 msgstr "ERRO: Falhou ao abrir ficheiro de partes '%s'"
 
-#: src/Preferences.cpp:701
+#: src/Preferences.cpp:673
 msgid "System default"
 msgstr "Predefinição do sistema"
 
-#: src/Preferences.cpp:702
+#: src/Preferences.cpp:674
 msgid "Albanian"
 msgstr "Albanês"
 
-#: src/Preferences.cpp:703
+#: src/Preferences.cpp:675
 msgid "Arabic"
 msgstr "Árabe"
 
-#: src/Preferences.cpp:704
+#: src/Preferences.cpp:676
 msgid "Asturian"
 msgstr "Asturiano"
 
-#: src/Preferences.cpp:705
+#: src/Preferences.cpp:677
 msgid "Basque"
 msgstr "Basco"
 
-#: src/Preferences.cpp:706
+#: src/Preferences.cpp:678
 msgid "Bulgarian"
 msgstr "Búlgaro"
 
-#: src/Preferences.cpp:707
+#: src/Preferences.cpp:679
 msgid "Catalan"
 msgstr "Catalão"
 
-#: src/Preferences.cpp:708
+#: src/Preferences.cpp:680
 msgid "Chinese (Simplified)"
 msgstr "Chinês (Simplificado)"
 
-#: src/Preferences.cpp:709
+#: src/Preferences.cpp:681
 msgid "Chinese (Traditional)"
 msgstr "Chinês (Tradicional)"
 
-#: src/Preferences.cpp:710
+#: src/Preferences.cpp:682
 msgid "Croatian"
 msgstr "Croata"
 
-#: src/Preferences.cpp:711
+#: src/Preferences.cpp:683
 msgid "Czech"
 msgstr "Checo"
 
-#: src/Preferences.cpp:712
+#: src/Preferences.cpp:684
 msgid "Danish"
 msgstr "Dinamarquês"
 
-#: src/Preferences.cpp:713
+#: src/Preferences.cpp:685
 msgid "Dutch"
 msgstr "Holandês"
 
-#: src/Preferences.cpp:714
+#: src/Preferences.cpp:686
 msgid "English (U.K.)"
 msgstr "Inglês"
 
-#: src/Preferences.cpp:715
+#: src/Preferences.cpp:687
 #, fuzzy
 msgid "English (U.S.)"
 msgstr "Inglês"
 
-#: src/Preferences.cpp:716
+#: src/Preferences.cpp:688
 msgid "Estonian"
 msgstr "Estoniano"
 
-#: src/Preferences.cpp:717
+#: src/Preferences.cpp:689
 msgid "Finnish"
 msgstr "Finlandês"
 
-#: src/Preferences.cpp:718
+#: src/Preferences.cpp:690
 msgid "French"
 msgstr "Francês"
 
-#: src/Preferences.cpp:719
+#: src/Preferences.cpp:691
 msgid "Galician"
 msgstr "Galego"
 
-#: src/Preferences.cpp:720
+#: src/Preferences.cpp:692
 msgid "German"
 msgstr "Alemão"
 
-#: src/Preferences.cpp:721
+#: src/Preferences.cpp:693
 msgid "Greek"
 msgstr "Grego"
 
-#: src/Preferences.cpp:722
+#: src/Preferences.cpp:694
 msgid "Hebrew"
 msgstr "Hebreu"
 
-#: src/Preferences.cpp:723
+#: src/Preferences.cpp:695
 msgid "Hungarian"
 msgstr "Húngaro"
 
-#: src/Preferences.cpp:724
+#: src/Preferences.cpp:696
 msgid "Italian"
 msgstr "Italiano"
 
-#: src/Preferences.cpp:725
+#: src/Preferences.cpp:697
 msgid "Japanese"
 msgstr "Japonês"
 
-#: src/Preferences.cpp:726
+#: src/Preferences.cpp:698
 msgid "Korean"
 msgstr "Coreano"
 
-#: src/Preferences.cpp:727
+#: src/Preferences.cpp:699
 msgid "Latvian"
 msgstr ""
 
-#: src/Preferences.cpp:728
+#: src/Preferences.cpp:700
 msgid "Lithuanian"
 msgstr "Lituano"
 
-#: src/Preferences.cpp:729
+#: src/Preferences.cpp:701
 msgid "Norwegian (Nynorsk)"
 msgstr "Norueguês (Nynorsk)"
 
-#: src/Preferences.cpp:730
+#: src/Preferences.cpp:702
 msgid "Polish"
 msgstr "Polaco"
 
-#: src/Preferences.cpp:731
+#: src/Preferences.cpp:703
 msgid "Portuguese"
 msgstr "Português"
 
-#: src/Preferences.cpp:732
+#: src/Preferences.cpp:704
 msgid "Portuguese (Brazilian)"
 msgstr "Português (Brasil)"
 
-#: src/Preferences.cpp:733
+#: src/Preferences.cpp:705
 msgid "Romanian"
 msgstr "Romeno"
 
-#: src/Preferences.cpp:734
+#: src/Preferences.cpp:706
 msgid "Russian"
 msgstr "Russo"
 
-#: src/Preferences.cpp:735
+#: src/Preferences.cpp:707
 msgid "Slovenian"
 msgstr "Esloveno"
 
-#: src/Preferences.cpp:736
+#: src/Preferences.cpp:708
 msgid "Spanish"
 msgstr "Espanhol"
 
-#: src/Preferences.cpp:737
+#: src/Preferences.cpp:709
 msgid "Swedish"
 msgstr "Sueco"
 
-#: src/Preferences.cpp:738
+#: src/Preferences.cpp:710
 msgid "Turkish"
 msgstr "Turco"
 
-#: src/Preferences.cpp:739
+#: src/Preferences.cpp:711
 msgid "Ukrainian"
 msgstr "Ucraniano"
 
-#: src/Preferences.cpp:842
+#: src/Preferences.cpp:814
 msgid "Change Language"
 msgstr "Alterar Idioma"
 
-#: src/Preferences.cpp:906
+#: src/Preferences.cpp:878
 msgid "There are no translations installed for aMule"
 msgstr ""
 
-#: src/Preferences.cpp:907
+#: src/Preferences.cpp:879
 #, fuzzy
 msgid "No languages available"
 msgstr "Indisponível"
 
-#: src/Preferences.cpp:1038
+#: src/Preferences.cpp:1010
 msgid "no options available"
 msgstr "sem opções disponíveis"
 
-#: src/Preferences.cpp:2226
+#: src/Preferences.cpp:2179
 msgid "Invalid category found, skipping"
 msgstr "Categoria inválida encontrada, a ignorar"
 
-#: src/Preferences.cpp:2395
+#: src/Preferences.cpp:2348
 msgid "TCP port can't be higher than 65532 due to server UDP socket being TCP+3"
 msgstr "O porto TCP não pode ser superior a 65532 porque o socket UDP do servidor tem de ser TCP+3"
 
-#: src/Preferences.cpp:2396
+#: src/Preferences.cpp:2349
 #, c-format
 msgid "Default port will be used (%d)"
 msgstr "O porto predefinido será usado (%d)"
 
-#: src/PrefsUnifiedDlg.cpp:300 src/Statistics.cpp:866
+#: src/PrefsUnifiedDlg.cpp:298 src/Statistics.cpp:866
 msgid "Connection"
 msgstr "Ligação"
 
-#: src/PrefsUnifiedDlg.cpp:301 src/SearchListCtrl.cpp:117
+#: src/PrefsUnifiedDlg.cpp:299 src/SearchListCtrl.cpp:117
 msgid "Directories"
 msgstr "Directórios"
 
-#: src/PrefsUnifiedDlg.cpp:302 src/Statistics.cpp:917
+#: src/PrefsUnifiedDlg.cpp:300 src/Statistics.cpp:917
 msgid "Servers"
 msgstr "Servidores"
 
-#: src/PrefsUnifiedDlg.cpp:303 src/ServerListCtrl.cpp:96
+#: src/PrefsUnifiedDlg.cpp:301 src/ServerListCtrl.cpp:96
 msgid "Files"
 msgstr "Ficheiros"
 
-#: src/PrefsUnifiedDlg.cpp:304
+#: src/PrefsUnifiedDlg.cpp:302
 msgid "Security"
 msgstr "Segurança"
 
-#: src/PrefsUnifiedDlg.cpp:305
+#: src/PrefsUnifiedDlg.cpp:303
 msgid "Interface"
 msgstr "Interface"
 
-#: src/PrefsUnifiedDlg.cpp:312
+#: src/PrefsUnifiedDlg.cpp:310
 msgid "IP2Country"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:315
+#: src/PrefsUnifiedDlg.cpp:313
 msgid "Proxy"
 msgstr "Proxy"
 
-#: src/PrefsUnifiedDlg.cpp:316
+#: src/PrefsUnifiedDlg.cpp:314
 msgid "Filters"
 msgstr "Filtros"
 
-#: src/PrefsUnifiedDlg.cpp:317
+#: src/PrefsUnifiedDlg.cpp:315
 msgid "Remote Controls"
 msgstr "Controlos remotos"
 
-#: src/PrefsUnifiedDlg.cpp:318
+#: src/PrefsUnifiedDlg.cpp:316
 msgid "Online Signature"
 msgstr "Assinatura Online"
 
-#: src/PrefsUnifiedDlg.cpp:319
+#: src/PrefsUnifiedDlg.cpp:317
 msgid "Advanced"
 msgstr "Avançado"
 
-#: src/PrefsUnifiedDlg.cpp:320
+#: src/PrefsUnifiedDlg.cpp:318
 msgid "Events"
 msgstr "Eventos"
 
-#: src/PrefsUnifiedDlg.cpp:323
+#: src/PrefsUnifiedDlg.cpp:321
 msgid "Debugging"
 msgstr "Depuração"
 
-#: src/PrefsUnifiedDlg.cpp:453
+#: src/PrefsUnifiedDlg.cpp:451
 msgid ""
 "The following variables will be substituted:\n"
 "    %PARTFILE - full path to the file\n"
@@ -5726,15 +5692,15 @@ msgstr ""
 "    %PARTFILE - caminho completo do ficheiro\n"
 "    %PARTNAME - apenas o nome do ficheiro"
 
-#: src/PrefsUnifiedDlg.cpp:474
+#: src/PrefsUnifiedDlg.cpp:472
 msgid "Tray icon support requires libayatana-appindicator3 at compile time."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:490
+#: src/PrefsUnifiedDlg.cpp:488
 msgid "Not available on Wayland: the protocol does not report when a window is minimized, so this option cannot intercept the system minimize button. Workaround: launch aMule with `GDK_BACKEND=x11` to use XWayland instead."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:536
+#: src/PrefsUnifiedDlg.cpp:534
 msgid ""
 "Do not change these setting unless you know\n"
 "what you are doing, otherwise you can easily\n"
@@ -5750,35 +5716,26 @@ msgstr ""
 "O aMule correrá perfeitamente sem ajustar qualquer\n"
 "uma destas opções."
 
-#: src/PrefsUnifiedDlg.cpp:647
+#: src/PrefsUnifiedDlg.cpp:645
 #, c-format
 msgid "Failed to connect Cfg to widget with the ID %d and key %s"
 msgstr "Falhou ao ligar Cfg ao widget com o ID %d e chave %s"
 
-#: src/PrefsUnifiedDlg.cpp:695
+#: src/PrefsUnifiedDlg.cpp:693
 #, c-format
 msgid "Failed to transfer data from Cfg to Widget with the ID %d and key %s"
 msgstr "Falhou ao transferir dados do Cfg para o Widget com o ID %d e chave %s"
 
-#: src/PrefsUnifiedDlg.cpp:801
+#: src/PrefsUnifiedDlg.cpp:799
 msgid "The type of proxy you are connecting to"
 msgstr "O tipo de proxy ao qual está a ligar-se"
 
-#: src/PrefsUnifiedDlg.cpp:1020
+#: src/PrefsUnifiedDlg.cpp:1003
 #, c-format
 msgid "Failed to transfer data from Widget to Cfg with the ID %d and key %s"
 msgstr "Falhou ao transferir dados do Widget para o Cfg com o ID %d e chave %s"
 
 #: src/PrefsUnifiedDlg.cpp:1103
-#, fuzzy
-msgid "No password set."
-msgstr "A verificar a palavra-passe\n"
-
-#: src/PrefsUnifiedDlg.cpp:1132
-msgid "Guest access needs a password. Type one in the guest password field, or untick Enable guest access."
-msgstr ""
-
-#: src/PrefsUnifiedDlg.cpp:1144
 msgid ""
 "aMule must be restarted to enable these changes:\n"
 "\n"
@@ -5786,42 +5743,42 @@ msgstr ""
 "O aMule tem de ser reiniciado para activar estas alterações:\n"
 "\n"
 
-#: src/PrefsUnifiedDlg.cpp:1151
+#: src/PrefsUnifiedDlg.cpp:1110
 msgid "- TCP port changed.\n"
 msgstr "- Porto TCP alterado.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1156
+#: src/PrefsUnifiedDlg.cpp:1115
 msgid "- UDP port changed.\n"
 msgstr "- Porto UDP alterado.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1161
+#: src/PrefsUnifiedDlg.cpp:1120
 #, fuzzy
 msgid "- Network interface binding changed.\n"
 msgstr "- Alterada interface para ligações externas.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1166
+#: src/PrefsUnifiedDlg.cpp:1125
 msgid "- External connect port changed.\n"
 msgstr "- Porta para ligações externas alterada.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1170
+#: src/PrefsUnifiedDlg.cpp:1129
 msgid "- External connect acceptance changed.\n"
 msgstr "- Alterada a aceitação de ligações externas.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1174
+#: src/PrefsUnifiedDlg.cpp:1133
 msgid "- External connect interface changed.\n"
 msgstr "- Alterada interface para ligações externas.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1178
+#: src/PrefsUnifiedDlg.cpp:1137
 #, fuzzy
 msgid "- Protocol obfuscation support changed.\n"
 msgstr "Ofuscação do Protocolo"
 
-#: src/PrefsUnifiedDlg.cpp:1193
+#: src/PrefsUnifiedDlg.cpp:1151
 #, fuzzy
 msgid "- amuleapi settings changed.\n"
 msgstr "- O idioma foi alterado.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1202
+#: src/PrefsUnifiedDlg.cpp:1160
 msgid ""
 "Your Auto-update server list is empty.\n"
 "'Auto-update server list at startup' will be disabled."
@@ -5829,7 +5786,7 @@ msgstr ""
 "A sua lista de actualização automática de servidores está vazia.\n"
 "A 'actualização automática no arranque' será desactivada."
 
-#: src/PrefsUnifiedDlg.cpp:1213
+#: src/PrefsUnifiedDlg.cpp:1171
 msgid ""
 "You have enabled external connections but have not specified a password.\n"
 "External connections cannot be enabled unless a valid password is specified."
@@ -5837,33 +5794,28 @@ msgstr ""
 "Activou as ligações externas mas não especificou uma palavra-passe.\n"
 "As ligações externas não podem ser activadas a menos que seja especificada uma palavra-passe válida."
 
-#: src/PrefsUnifiedDlg.cpp:1246
-#, c-format
-msgid "The amuleapi password could not be saved: %s"
-msgstr ""
-
-#: src/PrefsUnifiedDlg.cpp:1276
+#: src/PrefsUnifiedDlg.cpp:1202
 msgid "- Language changed.\n"
 msgstr "- O idioma foi alterado.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1281
+#: src/PrefsUnifiedDlg.cpp:1207
 msgid "- Temp folder changed.\n"
 msgstr "- A pasta Temp foi alterada.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1286
+#: src/PrefsUnifiedDlg.cpp:1212
 msgid "- ED2K network enabled.\n"
 msgstr "- Rede ED2K activada.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1319
+#: src/PrefsUnifiedDlg.cpp:1245
 msgid "The shared-file exclusion pattern is not a valid regular expression. The filter has been left disabled."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1321 src/PrefsUnifiedDlg.cpp:1921
+#: src/PrefsUnifiedDlg.cpp:1247 src/PrefsUnifiedDlg.cpp:1841
 #, fuzzy
 msgid "Invalid regular expression"
 msgstr "Versão de protocolo inválida."
 
-#: src/PrefsUnifiedDlg.cpp:1398
+#: src/PrefsUnifiedDlg.cpp:1324
 msgid ""
 "Both eD2k and Kad network are disabled.\n"
 "You won't be able to connect until you enable at least one of them."
@@ -5871,7 +5823,7 @@ msgstr ""
 "As redes eD2K e Kad estão desactivados.\n"
 "Não vai conseguir uma ligação até activar pelo menos uma deles."
 
-#: src/PrefsUnifiedDlg.cpp:1403
+#: src/PrefsUnifiedDlg.cpp:1329
 msgid ""
 "Kad will not start if your UDP port is disabled.\n"
 "Enable UDP port or disable Kad."
@@ -5879,7 +5831,7 @@ msgstr ""
 "A Kad não vai funcionar se o porto UDP estiver desactivado.\n"
 "Active o porto UDP ou desactive a Kad."
 
-#: src/PrefsUnifiedDlg.cpp:1459
+#: src/PrefsUnifiedDlg.cpp:1385
 msgid ""
 "\n"
 "You MUST restart aMule now.\n"
@@ -5889,69 +5841,69 @@ msgstr ""
 "DEVE reiniciar o aMule agora.\n"
 "Se não o fizer, não se queixe se algo grave acontecer.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1524
+#: src/PrefsUnifiedDlg.cpp:1450
 msgid "Could not register aMule for autostart at login. The autostart store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1526
+#: src/PrefsUnifiedDlg.cpp:1452
 msgid "Could not remove the autostart-at-login entry."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1527
+#: src/PrefsUnifiedDlg.cpp:1453
 #, fuzzy
 msgid "Autostart"
 msgstr "Actualização automática iniciada"
 
-#: src/PrefsUnifiedDlg.cpp:1542
+#: src/PrefsUnifiedDlg.cpp:1468
 msgid "Register file type"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1542
+#: src/PrefsUnifiedDlg.cpp:1468
 msgid "Register URL handler"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1550
+#: src/PrefsUnifiedDlg.cpp:1476
 #, c-format
 msgid "aMule only handles eD2k-compatible magnets. If you replace the current magnet handler (%s), BitTorrent magnet links will stop working - aMule cannot download BitTorrent content. Continue?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1555
+#: src/PrefsUnifiedDlg.cpp:1481
 #, c-format
 msgid "Another application currently opens .emulecollection files (%s). Replace it with aMule?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1560
+#: src/PrefsUnifiedDlg.cpp:1486
 #, c-format
 msgid "Another application is currently the default handler for these links (%s). Replace it with aMule?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1585
+#: src/PrefsUnifiedDlg.cpp:1511
 msgid "Could not register aMule for .emulecollection files. The registration store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1587
+#: src/PrefsUnifiedDlg.cpp:1513
 #, fuzzy
 msgid "Could not remove the file type registration."
 msgstr "Pasta para ficheiros temporários"
 
-#: src/PrefsUnifiedDlg.cpp:1589
+#: src/PrefsUnifiedDlg.cpp:1515
 msgid "Could not register aMule as the URL handler. The registration store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1591
+#: src/PrefsUnifiedDlg.cpp:1517
 msgid "Could not remove the URL handler registration."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1661 src/PrefsUnifiedDlg.cpp:1688
+#: src/PrefsUnifiedDlg.cpp:1587 src/PrefsUnifiedDlg.cpp:1614
 #, fuzzy
 msgid "The web server and aMule API require external connections to be enabled."
 msgstr "Palavra-passe definida e permitidas as ligações externas."
 
-#: src/PrefsUnifiedDlg.cpp:1671
+#: src/PrefsUnifiedDlg.cpp:1597
 msgid "The aMule web server is deprecated. Consider running the aMule API instead."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1735
+#: src/PrefsUnifiedDlg.cpp:1655
 msgid ""
 "Your Auto-update servers list is in blank.\n"
 "Please fill in at least one URL to point to a valid server.met file.\n"
@@ -5961,66 +5913,66 @@ msgstr ""
 "Por favor, indique pelo menos uma localização que aponte para um ficheiro server.met válido.\n"
 "Clique no botão \"Lista\" para inserir uma localização."
 
-#: src/PrefsUnifiedDlg.cpp:1876
+#: src/PrefsUnifiedDlg.cpp:1796
 msgid "Temporary files"
 msgstr "Ficheiros temporários"
 
-#: src/PrefsUnifiedDlg.cpp:1881
+#: src/PrefsUnifiedDlg.cpp:1801
 msgid "Incoming files"
 msgstr "Ficheiros recebidos"
 
-#: src/PrefsUnifiedDlg.cpp:1886
+#: src/PrefsUnifiedDlg.cpp:1806
 msgid "Online Signatures"
 msgstr "Assinaturas Online"
 
-#: src/PrefsUnifiedDlg.cpp:1899
+#: src/PrefsUnifiedDlg.cpp:1819
 #, c-format
 msgid "Choose a folder for %s"
 msgstr "Seleccione uma pasta para %s"
 
-#: src/PrefsUnifiedDlg.cpp:1923
+#: src/PrefsUnifiedDlg.cpp:1843
 #, fuzzy, c-format
 msgid "Would exclude %u of %u shared file"
 msgid_plural "Would exclude %u of %u shared files"
 msgstr[0] "Encontrado %i ficheiro partilhado conhecido"
 msgstr[1] "Encontrados %i ficheiros partilhados conhecidos"
 
-#: src/PrefsUnifiedDlg.cpp:1940
+#: src/PrefsUnifiedDlg.cpp:1860
 msgid "Browse for videoplayer"
 msgstr "Procurar leitor de vídeo"
 
-#: src/PrefsUnifiedDlg.cpp:1944
+#: src/PrefsUnifiedDlg.cpp:1864
 msgid "Select browser"
 msgstr "Seleccionar navegador"
 
-#: src/PrefsUnifiedDlg.cpp:1948
+#: src/PrefsUnifiedDlg.cpp:1868
 #, fuzzy
 msgid "Select ffprobe binary"
 msgstr "Seleccionar navegador"
 
-#: src/PrefsUnifiedDlg.cpp:1954
+#: src/PrefsUnifiedDlg.cpp:1874
 #, c-format
 msgid "Executable%s"
 msgstr "Executável%s"
 
-#: src/PrefsUnifiedDlg.cpp:1988
+#: src/PrefsUnifiedDlg.cpp:1908
 msgid "ffprobe not found on PATH or in the standard install locations. Install ffmpeg (which ships ffprobe) or use Browse to pick a binary manually."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2000
+#: src/PrefsUnifiedDlg.cpp:1920
 msgid "Reset the settings on this page to their default values?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2001
+#: src/PrefsUnifiedDlg.cpp:1921
 #, fuzzy
 msgid "Reset to defaults"
 msgstr "Predefinição do sistema"
 
-#: src/PrefsUnifiedDlg.cpp:2028
+#: src/PrefsUnifiedDlg.cpp:1948
 msgid "Edit server list"
 msgstr "Editar a lista de servidores"
 
-#: src/PrefsUnifiedDlg.cpp:2029
+#: src/PrefsUnifiedDlg.cpp:1949
 msgid ""
 "Add here URL's to download server.met files.\n"
 "Only one url on each line."
@@ -6028,180 +5980,176 @@ msgstr ""
 "Adicione localizações para obter ficheiros server.met\n"
 "Apenas uma localização por linha."
 
-#: src/PrefsUnifiedDlg.cpp:2084
+#: src/PrefsUnifiedDlg.cpp:2004
 msgid "IP2Country update failed"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2229 src/PrefsUnifiedDlg.cpp:2260
+#: src/PrefsUnifiedDlg.cpp:2149 src/PrefsUnifiedDlg.cpp:2180
 msgid "Data by MaxMind GeoLite2"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2231 src/PrefsUnifiedDlg.cpp:2262
+#: src/PrefsUnifiedDlg.cpp:2151 src/PrefsUnifiedDlg.cpp:2182
 #, fuzzy
 msgid "Custom source"
 msgstr "Fontes completas"
 
-#: src/PrefsUnifiedDlg.cpp:2233 src/PrefsUnifiedDlg.cpp:2264
+#: src/PrefsUnifiedDlg.cpp:2153 src/PrefsUnifiedDlg.cpp:2184
 msgid "Data by DB-IP.com"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2284
+#: src/PrefsUnifiedDlg.cpp:2204
 #, fuzzy, c-format
 msgid "Status: Loaded%s"
 msgstr "Estado:"
 
-#: src/PrefsUnifiedDlg.cpp:2286
+#: src/PrefsUnifiedDlg.cpp:2206
 #, fuzzy, c-format
 msgid "Status: Loaded%s - %s"
 msgstr "Estado:"
 
-#: src/PrefsUnifiedDlg.cpp:2290
+#: src/PrefsUnifiedDlg.cpp:2210
 msgid "Status: Failed to load - click 'Update now' to refresh."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2292
+#: src/PrefsUnifiedDlg.cpp:2212
 msgid "Status: Not found - click 'Update now' to download."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2350 src/PrefsUnifiedDlg.cpp:2374
+#: src/PrefsUnifiedDlg.cpp:2270 src/PrefsUnifiedDlg.cpp:2294
 #, c-format
 msgid "Update delay: %d second"
 msgid_plural "Update delay: %d seconds"
 msgstr[0] "Intervalo de actualização: %d segundo"
 msgstr[1] "Intervalo de actualização: %d segundos"
 
-#: src/PrefsUnifiedDlg.cpp:2358
+#: src/PrefsUnifiedDlg.cpp:2278
 #, c-format
 msgid "Time for average graph: %d minute"
 msgid_plural "Time for average graph: %d minutes"
 msgstr[0] "Tempo para o gráfico de média: %d minuto"
 msgstr[1] "Tempo para o gráfico de média: %d minutos"
 
-#: src/PrefsUnifiedDlg.cpp:2367
+#: src/PrefsUnifiedDlg.cpp:2287
 #, c-format
 msgid "Connections Graph Scale: %d"
 msgstr "Escala do Gráfico de Ligações: %d"
 
-#: src/PrefsUnifiedDlg.cpp:2382
+#: src/PrefsUnifiedDlg.cpp:2302
 #, c-format
 msgid "File Buffer Size: %d byte"
 msgid_plural "File Buffer Size: %d bytes"
 msgstr[0] "Tamanho de memória temporária de ficheiros: %d byte"
 msgstr[1] "Tamanho de memória temporária de ficheiros: %d bytes"
 
-#: src/PrefsUnifiedDlg.cpp:2392
+#: src/PrefsUnifiedDlg.cpp:2312
 #, c-format
 msgid "Upload Queue Size: %d client"
 msgid_plural "Upload Queue Size: %d clients"
 msgstr[0] "Tamanho da fila de espera de upload: %d cliente"
 msgstr[1] "Tamanho da fila de espera de upload: %d clientes"
 
-#: src/PrefsUnifiedDlg.cpp:2402
+#: src/PrefsUnifiedDlg.cpp:2322
 #, c-format
 msgid "Server connection refresh interval: %d minute"
 msgid_plural "Server connection refresh interval: %d minutes"
 msgstr[0] "Intervalo de actualização de ligação ao servidor: %d minuto"
 msgstr[1] "Intervalo de actualização de ligação ao servidor: %d minutos"
 
-#: src/PrefsUnifiedDlg.cpp:2407
+#: src/PrefsUnifiedDlg.cpp:2327
 msgid "Server connection refresh interval: Disabled"
 msgstr "Intervalo de actualização de ligação ao servidor: Desactivado"
 
-#: src/PrefsUnifiedDlg.cpp:2451
+#: src/PrefsUnifiedDlg.cpp:2371
 msgid "disabled"
 msgstr "desactivado"
 
-#: src/PrefsUnifiedDlg.cpp:2477
+#: src/PrefsUnifiedDlg.cpp:2397
 #, c-format
 msgid "Execute command on '%s' event"
 msgstr "Executar o comando quando ocorrer o evento '%s'"
 
-#: src/PrefsUnifiedDlg.cpp:2484
+#: src/PrefsUnifiedDlg.cpp:2404
 msgid "Enable command execution on core"
 msgstr "Activar execução de comandos no núcleo"
 
-#: src/PrefsUnifiedDlg.cpp:2496
+#: src/PrefsUnifiedDlg.cpp:2416
 msgid "Core command:"
 msgstr "Comando de núcleo:"
 
-#: src/PrefsUnifiedDlg.cpp:2512
+#: src/PrefsUnifiedDlg.cpp:2432
 msgid "Enable command execution on GUI"
 msgstr "Activar execução de comando na interface gráfica"
 
-#: src/PrefsUnifiedDlg.cpp:2524
+#: src/PrefsUnifiedDlg.cpp:2444
 msgid "GUI command:"
 msgstr "Comando da interface gráfica:"
 
-#: src/PrefsUnifiedDlg.cpp:2540
+#: src/PrefsUnifiedDlg.cpp:2460
 msgid "The following variables will be replaced:"
 msgstr "As seguintes variáveis serão substituídas:"
 
-#: src/PrefsUnifiedDlg.cpp:2708
+#: src/PrefsUnifiedDlg.cpp:2628
 msgid ""
 "The following folders look like system or sensitive locations:\n"
 "\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2713
+#: src/PrefsUnifiedDlg.cpp:2633
 msgid "Sharing them recursively will publish every file underneath on the eD2k/Kad networks. Do you really want to do this?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2716
+#: src/PrefsUnifiedDlg.cpp:2636
 #, fuzzy
 msgid "Confirm shared folders"
 msgstr "Pastas partilhadas"
 
-#: src/PrefsUnifiedDlg.cpp:2744
+#: src/PrefsUnifiedDlg.cpp:2664
 #, fuzzy
 msgid "Reloading shared files..."
 msgstr "Recarregar os seus ficheiros partilhados"
 
-#: src/PrefsUnifiedDlg.cpp:2745
+#: src/PrefsUnifiedDlg.cpp:2665
 msgid "Scanning for subdirectories..."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2746
+#: src/PrefsUnifiedDlg.cpp:2666
 #, fuzzy
 msgid "Updating shared folders"
 msgstr "Pastas partilhadas"
 
-#: src/PrefsUnifiedDlg.cpp:2773
+#: src/PrefsUnifiedDlg.cpp:2693
 #, c-format
 msgid "Scanned %u directories..."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2823
+#: src/PrefsUnifiedDlg.cpp:2743
 #, fuzzy, c-format
 msgid "Reloading shared files: %u files scanned"
 msgstr "Recarrega a lista de ficheiros partilhados."
 
-#: src/PrefsUnifiedDlg.cpp:2873
+#: src/PrefsUnifiedDlg.cpp:2793
 #, fuzzy
 msgid "Shared folder"
 msgstr "Pastas partilhadas"
 
-#: src/SearchDlg.cpp:280
-msgid "Clear search history"
-msgstr ""
-
-#: src/SearchDlg.cpp:584
+#: src/SearchDlg.cpp:425
 msgid "It's impossible to search when both eD2k and Kademlia are disabled."
 msgstr ""
 
-#: src/SearchDlg.cpp:585 src/SearchListCtrl.cpp:858
+#: src/SearchDlg.cpp:426 src/SearchListCtrl.cpp:858
 #, fuzzy
 msgid "Search error"
 msgstr "Pesquisas"
 
-#: src/SearchDlg.cpp:929
+#: src/SearchDlg.cpp:768
 msgid "Min size must be smaller than max size. Max size ignored."
 msgstr "O Tamanho mínimo tem de ser menor que o tamanho máximo. Tamanho máximo ignorado."
 
-#: src/SearchDlg.cpp:930 src/SearchDlg.cpp:1012
+#: src/SearchDlg.cpp:769 src/SearchDlg.cpp:851
 msgid "Search warning"
 msgstr "Aviso de pesquisa"
 
-#: src/SearchDlg.cpp:1092 src/SearchListCtrl.cpp:735
+#: src/SearchDlg.cpp:929 src/SearchListCtrl.cpp:735
 msgid "Main"
 msgstr "Principal"
 

--- a/po/pt_PT.po
+++ b/po/pt_PT.po
@@ -17,7 +17,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-28 10:19+0200\n"
+"POT-Creation-Date: 2026-07-28 12:17+0200\n"
 "PO-Revision-Date: 2026-07-27 11:44+0000\n"
 "Last-Translator: Luís Picciochi Oliveira <Pitxyoki@Gmail.com>\n"
 "Language-Team: Portuguese <traduz@debianpt.org>\n"
@@ -210,83 +210,83 @@ msgstr "Falha ao abrir ficheiro de ligações eD2k."
 msgid "WARNING: You can't add yourself as a source for an eD2k link while having a lowid."
 msgstr "AVISO: Não se pode adicionar a si próprio como fonte para um link eD2k enquanto tiver lowid."
 
-#: src/amule.cpp:300
+#: src/amule.cpp:301
 msgid "Now, exiting main app..."
 msgstr "A fechar a aplicação..."
 
-#: src/amule.cpp:330
+#: src/amule.cpp:331
 #, c-format
 msgid "Terminating amuleweb instance with pid '%d' ... "
 msgstr "A terminar instância do amuleweb com o pid '%d' ... "
 
-#: src/amule.cpp:334
+#: src/amule.cpp:335
 #, c-format
 msgid "Killing amuleweb instance with pid '%d' ... "
 msgstr "A matar instância do amuleweb com o pid '%d' ... "
 
-#: src/amule.cpp:336 src/amule.cpp:349 src/ClientRef.cpp:180
+#: src/amule.cpp:337 src/amule.cpp:350 src/ClientRef.cpp:180
 #: src/SearchDlg.cpp:1041 src/ServerListCtrl.cpp:98
 msgid "Failed"
 msgstr "Falhas"
 
-#: src/amule.cpp:343
+#: src/amule.cpp:344
 #, fuzzy, c-format
 msgid "Terminating amuleapi instance with pid '%d' ... "
 msgstr "A terminar instância do amuleweb com o pid '%d' ... "
 
-#: src/amule.cpp:347
+#: src/amule.cpp:348
 #, fuzzy, c-format
 msgid "Killing amuleapi instance with pid '%d' ... "
 msgstr "A matar instância do amuleweb com o pid '%d' ... "
 
-#: src/amule.cpp:355
+#: src/amule.cpp:356
 msgid "aMule OnExit: Terminating core."
 msgstr "aMule OnExit: A terminar núcleo."
 
-#: src/amule.cpp:466
+#: src/amule.cpp:467
 msgid "aMule shutdown completed."
 msgstr "aMule terminado."
 
-#: src/amule.cpp:470
+#: src/amule.cpp:471
 msgid "Memory debug results for aMule exit:"
 msgstr "Resultados da depuração de memória para a saída do aMule:"
 
-#: src/amule.cpp:651
+#: src/amule.cpp:652
 #, c-format
 msgid "Binding aMule's peer-to-peer traffic to interface: %s (HTTP updates use the default route)"
 msgstr ""
 
-#: src/amule.cpp:655
+#: src/amule.cpp:656
 #, c-format
 msgid "Binding all network traffic to interface: %s"
 msgstr ""
 
-#: src/amule.cpp:659
+#: src/amule.cpp:660
 #, c-format
 msgid "WARNING: configured network interface '%s' was not found - traffic is NOT bound to it and may leave via the default route. Check the interface name in Preferences."
 msgstr ""
 
-#: src/amule.cpp:665
+#: src/amule.cpp:666
 #, c-format
 msgid "WARNING: binding to network interface '%s' requires elevated privileges and was NOT applied - traffic may leave via the default route. Grant the capability (e.g. 'sudo setcap cap_net_raw+ep' on the aMule binary) or run with sufficient privileges."
 msgstr ""
 
-#: src/amule.cpp:673
+#: src/amule.cpp:674
 #, c-format
 msgid "WARNING: could not bind to network interface '%s' - traffic may leave via the default route."
 msgstr ""
 
-#: src/amule.cpp:732
+#: src/amule.cpp:733
 msgid "Your locale has been changed to System Default due to a configuration change. Sorry."
 msgstr "O seu idioma foi alterado para a predefinição do sistema devido a uma mudança de configuração. Desculpe."
 
-#: src/amule.cpp:734 src/amule.cpp:1581 src/CatDialog.cpp:128
+#: src/amule.cpp:735 src/amule.cpp:1589 src/CatDialog.cpp:128
 #: src/CatDialog.cpp:136 src/CatDialog.cpp:149 src/ServerList.cpp:366
 #: src/ServerListCtrl.cpp:152
 msgid "Info"
 msgstr "Informação"
 
-#: src/amule.cpp:741
+#: src/amule.cpp:742
 msgid ""
 "\n"
 "EC configuration"
@@ -294,74 +294,74 @@ msgstr ""
 "\n"
 "Configuração das LE"
 
-#: src/amule.cpp:744
+#: src/amule.cpp:745
 msgid "Password set and external connections enabled."
 msgstr "Palavra-passe definida e permitidas as ligações externas."
 
-#: src/amule.cpp:754 src/KadDlg.cpp:176 src/KadDlg.cpp:185
-#: src/PrefsUnifiedDlg.cpp:1387 src/SharedFilesCtrl.cpp:476
+#: src/amule.cpp:755 src/KadDlg.cpp:176 src/KadDlg.cpp:185
+#: src/PrefsUnifiedDlg.cpp:1461 src/SharedFilesCtrl.cpp:476
 msgid "WARNING"
 msgstr "AVISO"
 
-#: src/amule.cpp:991
+#: src/amule.cpp:992
 #, fuzzy
 msgid "Network bootstrap"
 msgstr "Redes"
 
-#: src/amule.cpp:996
+#: src/amule.cpp:997
 msgid ""
 "aMule has detected missing network bootstrap files.\n"
 "Select which ones to download:"
 msgstr ""
 
-#: src/amule.cpp:1005 src/FirstRunWizard.cpp:411
+#: src/amule.cpp:1006 src/FirstRunWizard.cpp:411
 #, fuzzy
 msgid "eD2k server list (server.met)"
 msgstr "Foi encontrado %i servidor no server.met"
 
-#: src/amule.cpp:1012 src/FirstRunWizard.cpp:416
+#: src/amule.cpp:1013 src/FirstRunWizard.cpp:416
 msgid "Kad bootstrap nodes (nodes.dat)"
 msgstr ""
 
-#: src/amule.cpp:1102
+#: src/amule.cpp:1103
 #, c-format
 msgid "web server running on pid %d"
 msgstr "servidor web a executar no pid %d"
 
-#: src/amule.cpp:1115
+#: src/amule.cpp:1116
 #, fuzzy
 msgid "You requested to run web server on startup, but the amuleweb binary cannot be run. Please install the package containing aMule web server, or build aMule from source with -DBUILD_WEBSERVER=YES and install it."
 msgstr "Pediu para executar o servidor web no arranque, mas o executável não pode ser lançado. Por favor, instale o pacote que contém o servidor web ou compile o aMule com --enable-webserver e execute make install"
 
-#: src/amule.cpp:1120 src/amule.cpp:1177 src/amule.cpp:1291 src/amule.cpp:1593
+#: src/amule.cpp:1121 src/amule.cpp:1185 src/amule.cpp:1299 src/amule.cpp:1601
 #: src/amule-remote-gui.cpp:603 src/amule-remote-gui.cpp:671
 #: src/amule-remote-gui.cpp:709 src/amule-remote-gui.cpp:1282
 #: src/amule-remote-gui.cpp:1345 src/amule-remote-gui.cpp:1372
-#: src/DownloadQueue.cpp:1481
+#: src/DownloadQueue.cpp:1481 src/PrefsUnifiedDlg.cpp:1247
 msgid "ERROR"
 msgstr "ERRO"
 
-#: src/amule.cpp:1166
+#: src/amule.cpp:1174
 #, fuzzy, c-format
 msgid "amuleapi running on pid %d"
 msgstr "servidor web a executar no pid %d"
 
-#: src/amule.cpp:1172
+#: src/amule.cpp:1180
 #, fuzzy
 msgid "You requested to run amuleapi on startup, but the amuleapi binary cannot be run. Please install the package containing aMule's REST API server, or build aMule from source with -DBUILD_AMULEAPI=YES and install it."
 msgstr "Pediu para executar o servidor web no arranque, mas o executável não pode ser lançado. Por favor, instale o pacote que contém o servidor web ou compile o aMule com --enable-webserver e execute make install"
 
-#: src/amule.cpp:1259
+#: src/amule.cpp:1267
 #, c-format
 msgid "Could not bind ports to the specified address: %s"
 msgstr "Não foi possível associar os portos ao endereço especificado: %s"
 
-#: src/amule.cpp:1283
+#: src/amule.cpp:1291
 #, c-format
 msgid "Port %u is not available. You will be LOWID\n"
 msgstr "O porto %u não está disponível. Ficará com LOWID\n"
 
-#: src/amule.cpp:1288
+#: src/amule.cpp:1296
 #, c-format
 msgid ""
 "Port %u is not available!\n"
@@ -376,48 +376,48 @@ msgstr ""
 "\n"
 "Verifique a sua rede para se certificar de que o porto está aberto para leitura e escrita."
 
-#: src/amule.cpp:1385
+#: src/amule.cpp:1393
 msgid "Failed to create OnlineSig File"
 msgstr "Erro ao criar o ficheiro da Assinatura Online"
 
-#: src/amule.cpp:1393
+#: src/amule.cpp:1401
 msgid "Failed to create aMule OnlineSig File"
 msgstr "Erro a criar o ficheiro da Assinatura Online do aMule"
 
-#: src/amule.cpp:1556
+#: src/amule.cpp:1564
 msgid "The selected locale seems not to be installed on your box. (Note: I'll try to set it anyway)"
 msgstr "O idioma seleccionado parece não estar instalado no seu computador. (Nota: de qualquer das formas, irei tentar activá-lo)"
 
-#: src/amule.cpp:1566
+#: src/amule.cpp:1574
 #, c-format
 msgid "This is the first time you run aMule %s"
 msgstr "Esta é a primeira vez que executa o aMule %s"
 
-#: src/amule.cpp:1569
+#: src/amule.cpp:1577
 msgid "This version is a testing version, updated daily, and\n"
 msgstr "Esta é uma versão de testes actualizada diariamente e\n"
 
-#: src/amule.cpp:1570
+#: src/amule.cpp:1578
 msgid "we give no warranty it won't break anything, burn your house,\n"
 msgstr "não há qualquer garantia de que não irá partir nada, pegar fogo à sua casa,\n"
 
-#: src/amule.cpp:1571
+#: src/amule.cpp:1579
 msgid "or kill your dog. But it *should* be safe to use anyway.\n"
 msgstr "ou matar o seu cão. Mas, *em princípio*, deverá ser seguro usá-lo.\n"
 
-#: src/amule.cpp:1576
+#: src/amule.cpp:1584
 msgid "More information, support and new releases can found at our homepage,\n"
 msgstr "Mais informação, suporte e novos lançamentos na nossa página,\n"
 
-#: src/amule.cpp:1577
+#: src/amule.cpp:1585
 msgid "at https://amule-org.github.io, or in our IRC channel #aMule at irc.libera.chat.\n"
 msgstr "em amule-org.github.io ou no canal de IRC #aMule em irc.libera.chat.\n"
 
-#: src/amule.cpp:1579
+#: src/amule.cpp:1587
 msgid "Feel free to report any bugs to https://github.com/amule-org/amule/issues"
 msgstr "Esteja à vontade para comunicar erros para https://github.com/amule-org/amule/issues"
 
-#: src/amule.cpp:1591
+#: src/amule.cpp:1599
 msgid ""
 "The folder for Online Signature files you specified is INVALID!\n"
 " OnlineSignature will be DISABLED until you fix it on preferences."
@@ -425,137 +425,137 @@ msgstr ""
 "A pasta para os ficheiros da Assinatura Online é INVÁLIDA!\n"
 " A Assinatura Online será DESACTIVADA até que resolva a situação nas preferências."
 
-#: src/amule.cpp:1654
+#: src/amule.cpp:1662
 msgid "Server hostname notified"
 msgstr "Servidor notificado"
 
-#: src/amule.cpp:2031
+#: src/amule.cpp:2039
 #, c-format
 msgid "Disk space preallocation for file '%s' failed: %s"
 msgstr "Reserva de espaço em disco para o ficheiro '%s' falhou: %s"
 
-#: src/amule.cpp:2160
+#: src/amule.cpp:2168
 msgid "ERROR: can't open logfile"
 msgstr "ERRO: não é possível abrir o ficheiro de relatório"
 
-#: src/amule.cpp:2164
+#: src/amule.cpp:2172
 msgid "WARNING: logfile is empty. Something is wrong."
 msgstr "AVISO: o ficheiro de relatório está vazio. Algo está mal."
 
-#: src/amule.cpp:2181
+#: src/amule.cpp:2189
 msgid "Log has been reset"
 msgstr "O relatório foi limpo"
 
-#: src/amule.cpp:2205
+#: src/amule.cpp:2213
 #, c-format
 msgid "ServerMessage: %s"
 msgstr "Mensagem do servidor: %s"
 
-#: src/amule.cpp:2248 src/IP2Country.cpp:220 src/IPFilter.cpp:514
+#: src/amule.cpp:2256 src/IP2Country.cpp:220 src/IPFilter.cpp:514
 #: src/ServerList.cpp:875
 #, c-format
 msgid "Skipped download of %s, because requested file is not newer."
 msgstr "O download de %s não foi feito porque o ficheiro requisitado não é mais recente."
 
-#: src/amule.cpp:2251
+#: src/amule.cpp:2259
 msgid "Failed to download the nodes list."
 msgstr "Falha ao transferir a lista de nós."
 
-#: src/amule.cpp:2314
+#: src/amule.cpp:2322
 msgid "Failed to open the downloaded version check file"
 msgstr "Falha ao abrir o ficheiro de verificação de versão transferido"
 
-#: src/amule.cpp:2317 src/amule.cpp:2336
+#: src/amule.cpp:2325 src/amule.cpp:2344
 msgid "Corrupted version check file"
 msgstr "Ficheiro de verificação de versão corrompido"
 
-#: src/amule.cpp:2359
+#: src/amule.cpp:2367
 msgid "You are using an outdated version of aMule!"
 msgstr "Está a usar uma versão antiga do aMule!"
 
-#: src/amule.cpp:2361
+#: src/amule.cpp:2369
 #, c-format
 msgid "Your aMule version is %i.%i.%i and the latest version is %li.%li.%li"
 msgstr "A sua versão do aMule é %i.%i.%i e a última versão é %li.%li.%li"
 
-#: src/amule.cpp:2365
+#: src/amule.cpp:2373
 msgid "The latest version can always be found at https://github.com/amule-org/amule/releases/latest"
 msgstr "A última versão pode ser sempre encontrada em https://github.com/amule-org/amule/releases/latest"
 
-#: src/amule.cpp:2368
+#: src/amule.cpp:2376
 #, c-format
 msgid "WARNING: Your aMuled version is outdated: %i.%i.%i < %li.%li.%li"
 msgstr "AVISO: A sua versão do aMuled está desactualizada: %i.%i.%i < %li.%li.%li"
 
-#: src/amule.cpp:2374
+#: src/amule.cpp:2382
 msgid "Your copy of aMule is up to date."
 msgstr "A sua cópia do aMule está actualizada."
 
-#: src/amule.cpp:2381
+#: src/amule.cpp:2389
 msgid "Failed to download the version check file"
 msgstr "Falha ao transferir o ficheiro de verificação de versão"
 
-#: src/amule.cpp:2550 src/amule-remote-gui.cpp:1133
+#: src/amule.cpp:2558 src/amule-remote-gui.cpp:1133
 #, c-format
 msgid "Users: %s | Files: %s"
 msgstr "Utilizadores: %s | Ficheiros: %s"
 
-#: src/amule.cpp:2551 src/amule-remote-gui.cpp:1134
+#: src/amule.cpp:2559 src/amule-remote-gui.cpp:1134
 #, c-format
 msgid "Users: E: %s K: %s | Files: E: %s K: %s"
 msgstr "Utilizadores: E: %s K: %s | Ficheiros: E: %s K: %s"
 
-#: src/amule.cpp:2565 src/amule-remote-gui.cpp:1147
+#: src/amule.cpp:2573 src/amule-remote-gui.cpp:1147
 msgid "No networks selected"
 msgstr "Não foram seleccionadas redes"
 
-#: src/amule.cpp:2633 src/TextClient.cpp:903
+#: src/amule.cpp:2641 src/TextClient.cpp:903
 msgid "with LowID"
 msgstr "com LowID"
 
-#: src/amule.cpp:2633 src/TextClient.cpp:904
+#: src/amule.cpp:2641 src/TextClient.cpp:904
 msgid "with HighID"
 msgstr "com HighID"
 
-#: src/amule.cpp:2635
+#: src/amule.cpp:2643
 #, c-format
 msgid "Connected to %s %s"
 msgstr "Ligado a %s %s"
 
-#: src/amule.cpp:2640
+#: src/amule.cpp:2648
 #, c-format
 msgid "Connecting to %s"
 msgstr "A ligar a %s"
 
-#: src/amule.cpp:2642
+#: src/amule.cpp:2650
 msgid "Disconnected from eD2k"
 msgstr "Desligado da eD2k"
 
-#: src/amule.cpp:2651
+#: src/amule.cpp:2659
 msgid "Kad started."
 msgstr "Kad iniciada."
 
-#: src/amule.cpp:2653
+#: src/amule.cpp:2661
 msgid "Kad stopped."
 msgstr "Kad parada."
 
-#: src/amule.cpp:2661
+#: src/amule.cpp:2669
 msgid "Connected to Kad (ok)"
 msgstr "Ligado à Kad (ok)"
 
-#: src/amule.cpp:2663
+#: src/amule.cpp:2671
 msgid "Connected to Kad (firewalled)"
 msgstr "Ligado à Kad (atrás de firewall)"
 
-#: src/amule.cpp:2667
+#: src/amule.cpp:2675
 msgid "Disconnected from Kad"
 msgstr "Desligado da Kad"
 
-#: src/amule.cpp:2699
+#: src/amule.cpp:2707
 msgid "Kad network cannot be used if UDP port is disabled on preferences, not starting."
 msgstr "A rede Kad não pode ser usada se o porto UDP estiver desactivado nas preferências, inicialização não efectuada."
 
-#: src/amule.cpp:2703
+#: src/amule.cpp:2711
 msgid "Kad network disabled on preferences, not connecting."
 msgstr "Rede Kad desligada nas preferências, a ligação não será efectuada."
 
@@ -600,36 +600,36 @@ msgid "FATAL ERROR: Failed to create Timer"
 msgstr "ERRO FATAL: Falha ao criar Temporizador"
 
 #: src/amuleDlg.cpp:361 src/amuleDlg.cpp:1787 src/amuleDlg.cpp:2033
-#: src/muuli_wdr.cpp:1492 src/muuli_wdr.cpp:3418
+#: src/muuli_wdr.cpp:1492 src/muuli_wdr.cpp:3449
 msgid "Networks"
 msgstr "Redes"
 
-#: src/amuleDlg.cpp:362 src/amuleDlg.cpp:1793 src/muuli_wdr.cpp:3419
+#: src/amuleDlg.cpp:362 src/amuleDlg.cpp:1793 src/muuli_wdr.cpp:3450
 msgid "Searches"
 msgstr "Pesquisas"
 
 #: src/amuleDlg.cpp:363 src/amuleDlg.cpp:1799 src/DownloadListCtrl.cpp:740
-#: src/muuli_wdr.cpp:392 src/muuli_wdr.cpp:1585 src/muuli_wdr.cpp:3420
+#: src/muuli_wdr.cpp:392 src/muuli_wdr.cpp:1585 src/muuli_wdr.cpp:3451
 #: src/Statistics.cpp:829
 msgid "Downloads"
 msgstr "Downloads"
 
-#: src/amuleDlg.cpp:364 src/amuleDlg.cpp:1805 src/muuli_wdr.cpp:3294
+#: src/amuleDlg.cpp:364 src/amuleDlg.cpp:1805 src/muuli_wdr.cpp:3325
 msgid "Shared files"
 msgstr "Ficheiros partilhados"
 
-#: src/amuleDlg.cpp:365 src/amuleDlg.cpp:1811 src/muuli_wdr.cpp:2926
-#: src/muuli_wdr.cpp:3376 src/muuli_wdr.cpp:3423
+#: src/amuleDlg.cpp:365 src/amuleDlg.cpp:1811 src/muuli_wdr.cpp:2957
+#: src/muuli_wdr.cpp:3407 src/muuli_wdr.cpp:3454
 msgid "Messages"
 msgstr "Mensagens"
 
-#: src/amuleDlg.cpp:366 src/amuleDlg.cpp:1817 src/muuli_wdr.cpp:3424
-#: src/PrefsUnifiedDlg.cpp:312 src/Statistics.cpp:779 src/Statistics.cpp:1235
+#: src/amuleDlg.cpp:366 src/amuleDlg.cpp:1817 src/muuli_wdr.cpp:3455
+#: src/PrefsUnifiedDlg.cpp:314 src/Statistics.cpp:779 src/Statistics.cpp:1235
 msgid "Statistics"
 msgstr "Estatísticas"
 
-#: src/amuleDlg.cpp:368 src/amuleDlg.cpp:1824 src/muuli_wdr.cpp:3426
-#: src/PrefsUnifiedDlg.cpp:328 src/utils/wxCas/src/wxcasprefs.cpp:39
+#: src/amuleDlg.cpp:368 src/amuleDlg.cpp:1824 src/muuli_wdr.cpp:3457
+#: src/PrefsUnifiedDlg.cpp:330 src/utils/wxCas/src/wxcasprefs.cpp:39
 msgid "Preferences"
 msgstr "Preferências"
 
@@ -687,8 +687,8 @@ msgstr "Kad: Desligado"
 #: src/amuleDlg.cpp:1029 src/DownloadListCtrl.cpp:505
 #: src/DownloadListCtrl.cpp:749 src/FriendListCtrl.cpp:180
 #: src/muuli_wdr.cpp:731 src/muuli_wdr.cpp:782 src/muuli_wdr.cpp:846
-#: src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2231 src/muuli_wdr.cpp:2316
-#: src/muuli_wdr.cpp:3064 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
+#: src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2262 src/muuli_wdr.cpp:2347
+#: src/muuli_wdr.cpp:3095 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
 #: src/ServerListCtrl.cpp:606 src/TransferWnd.cpp:378
 #: src/utils/wxCas/src/wxcasprefs.cpp:235
 msgid "Cancel"
@@ -699,7 +699,7 @@ msgid "Stop the current connection attempts"
 msgstr "Cancela as tentativas de ligação actuais"
 
 #: src/amuleDlg.cpp:1035 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976
-#: src/muuli_wdr.cpp:2454
+#: src/muuli_wdr.cpp:2485
 msgid "Disconnect"
 msgstr "Desligar"
 
@@ -708,7 +708,7 @@ msgid "Disconnect from the currently connected networks"
 msgstr "Desligar das redes presentemente ligadas"
 
 #: src/amuleDlg.cpp:1041 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979
-#: src/muuli_wdr.cpp:2609 src/muuli_wdr.cpp:3061 src/muuli_wdr.cpp:3416
+#: src/muuli_wdr.cpp:2640 src/muuli_wdr.cpp:3092 src/muuli_wdr.cpp:3447
 msgid "Connect"
 msgstr "Ligar"
 
@@ -763,7 +763,7 @@ msgstr "Confirmação de saída"
 msgid "Launch Command: "
 msgstr "Executar Comando: "
 
-#: src/amuleDlg.cpp:1632 src/muuli_wdr.cpp:1978 src/Preferences.cpp:952
+#: src/amuleDlg.cpp:1632 src/muuli_wdr.cpp:1982 src/Preferences.cpp:979
 msgid "- default -"
 msgstr "- predefinição -"
 
@@ -777,48 +777,48 @@ msgstr "Pasta para os temas '%s' não existe"
 msgid "WARNING: Unable to open skin file '%s' for read"
 msgstr "AVISO: Não é possível abrir ficheiro de tema '%s' para leitura"
 
-#: src/amuleDlg.cpp:1791 src/muuli_wdr.cpp:3418
+#: src/amuleDlg.cpp:1791 src/muuli_wdr.cpp:3449
 msgid "Networks Window"
 msgstr "Janela de Redes"
 
-#: src/amuleDlg.cpp:1797 src/muuli_wdr.cpp:3419
+#: src/amuleDlg.cpp:1797 src/muuli_wdr.cpp:3450
 msgid "Searches Window"
 msgstr "Janela de Pesquisas"
 
-#: src/amuleDlg.cpp:1803 src/muuli_wdr.cpp:3420
+#: src/amuleDlg.cpp:1803 src/muuli_wdr.cpp:3451
 msgid "Downloads Window"
 msgstr "Janela de Downloads"
 
-#: src/amuleDlg.cpp:1809 src/muuli_wdr.cpp:3422
+#: src/amuleDlg.cpp:1809 src/muuli_wdr.cpp:3453
 msgid "Shared Files Window"
 msgstr "Janela de Ficheiros Partilhados"
 
-#: src/amuleDlg.cpp:1815 src/muuli_wdr.cpp:3423
+#: src/amuleDlg.cpp:1815 src/muuli_wdr.cpp:3454
 msgid "Messages Window"
 msgstr "Janela de Mensagens"
 
-#: src/amuleDlg.cpp:1821 src/muuli_wdr.cpp:3424
+#: src/amuleDlg.cpp:1821 src/muuli_wdr.cpp:3455
 msgid "Statistics Graph Window"
 msgstr "Janela de Estatísticas"
 
-#: src/amuleDlg.cpp:1828 src/muuli_wdr.cpp:3426
+#: src/amuleDlg.cpp:1828 src/muuli_wdr.cpp:3457
 msgid "Preferences Settings Window"
 msgstr "Janela de Preferências"
 
-#: src/amuleDlg.cpp:1831 src/muuli_wdr.cpp:3427
+#: src/amuleDlg.cpp:1831 src/muuli_wdr.cpp:3458
 msgid "Import"
 msgstr "Importar"
 
-#: src/amuleDlg.cpp:1835 src/muuli_wdr.cpp:3427
+#: src/amuleDlg.cpp:1835 src/muuli_wdr.cpp:3458
 msgid "The partfile importer tool"
 msgstr "A ferramenta de importação de ficheiro de partes"
 
-#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3428
+#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3459
 #: src/utils/aLinkCreator/src/alcframe.cpp:262
 msgid "About"
 msgstr "Acerca"
 
-#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3428
+#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3459
 msgid "About/Help"
 msgstr "Acerca/Ajuda"
 
@@ -960,7 +960,7 @@ msgstr "Ficheiro não encontrado."
 msgid "The core rejected these shared folders:%s"
 msgstr ""
 
-#: src/amule-remote-gui.cpp:1336 src/ExternalConn.cpp:2345
+#: src/amule-remote-gui.cpp:1336 src/ExternalConn.cpp:2346
 msgid "Invalid link or already on list."
 msgstr "Ligação inválida ou já na lista."
 
@@ -976,7 +976,7 @@ msgstr "Não é possível criar o directório '%s' para a categoria '%s', a mant
 #: src/ClientDetailDialog.cpp:123 src/DataToText.cpp:61 src/DataToText.cpp:86
 #: src/DataToText.cpp:101 src/DataToText.cpp:136 src/DataToText.cpp:165
 #: src/DownloadListCtrl.cpp:1172 src/DownloadListCtrl.cpp:1185
-#: src/DownloadListCtrl.cpp:1196 src/ExternalConn.cpp:608
+#: src/DownloadListCtrl.cpp:1196 src/ExternalConn.cpp:609
 #: src/FileDetailDialog.cpp:203 src/FileDetailDialog.cpp:235
 #: src/FileDetailDialog.cpp:242 src/GenericClientListCtrl.cpp:1171
 #: src/GenericClientListCtrl.cpp:1182 src/GenericClientListCtrl.cpp:1192
@@ -1363,19 +1363,19 @@ msgstr "Automática [Alta]"
 msgid "Very low"
 msgstr "Muito baixa"
 
-#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:743 src/muuli_wdr.cpp:2282
+#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:743 src/muuli_wdr.cpp:2313
 #: src/ServerListCtrl.cpp:263 src/ServerListCtrl.cpp:456
 #: src/SharedFilesCtrl.cpp:145
 msgid "Low"
 msgstr "Baixa"
 
-#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:744 src/muuli_wdr.cpp:2283
+#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:744 src/muuli_wdr.cpp:2314
 #: src/ServerListCtrl.cpp:266 src/ServerListCtrl.cpp:457
 #: src/SharedFilesCtrl.cpp:146
 msgid "Normal"
 msgstr "Normal"
 
-#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:745 src/muuli_wdr.cpp:2284
+#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:745 src/muuli_wdr.cpp:2315
 #: src/ServerListCtrl.cpp:269 src/ServerListCtrl.cpp:458
 #: src/SharedFilesCtrl.cpp:147
 msgid "High"
@@ -1467,7 +1467,7 @@ msgstr "Servidor Local"
 msgid "Remote Server"
 msgstr "Servidor Remoto"
 
-#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3181
+#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3212
 #: src/SearchDlg.cpp:119 src/TextClient.cpp:911
 msgid "Kad"
 msgstr "Kad"
@@ -1539,7 +1539,7 @@ msgstr "Parte"
 msgid "Size"
 msgstr "Tamanho"
 
-#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3248
+#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3279
 msgid "Transferred"
 msgstr "Transferido"
 
@@ -1597,7 +1597,7 @@ msgstr ""
 "Comentário de: %s (%s)\n"
 "\n"
 
-#: src/DownloadListCtrl.cpp:746 src/muuli_wdr.cpp:2285
+#: src/DownloadListCtrl.cpp:746 src/muuli_wdr.cpp:2316
 #: src/SharedFilesCtrl.cpp:150
 msgid "Auto"
 msgstr "Automática"
@@ -1635,7 +1635,7 @@ msgid "Extended Options"
 msgstr "Opções Estendidas"
 
 #: src/DownloadListCtrl.cpp:770 src/DownloadListCtrl.cpp:822
-#: src/muuli_wdr.cpp:1796
+#: src/muuli_wdr.cpp:1800
 msgid "Preview"
 msgstr "Pré-visualizar"
 
@@ -1810,227 +1810,232 @@ msgstr[1] ""
 msgid "Invalid eD2k link! ERROR: %s"
 msgstr "Ligação eD2k inválida! ERRO: %s"
 
-#: src/ExternalConn.cpp:379
+#: src/ExternalConn.cpp:380
 msgid "Client sent packet after authentication failed."
 msgstr "O cliente enviou um pacote depois de a autenticação ter falhado."
 
-#: src/ExternalConn.cpp:396
+#: src/ExternalConn.cpp:397
 msgid "External connection closed."
 msgstr "Ligação externa fechada."
 
-#: src/ExternalConn.cpp:473
+#: src/ExternalConn.cpp:474
 msgid "External connections disabled due to empty password!"
 msgstr "Ligações externas desactivadas devido a palavra-passe vazia!"
 
-#: src/ExternalConn.cpp:494
+#: src/ExternalConn.cpp:495
 msgid "External connections disabled in config file"
 msgstr "Ligações externas desactivadas no ficheiro de configuração"
 
-#: src/ExternalConn.cpp:575
+#: src/ExternalConn.cpp:576
 msgid "New external connection accepted"
 msgstr "Nova ligação externa aceite"
 
-#: src/ExternalConn.cpp:578
+#: src/ExternalConn.cpp:579
 msgid "ERROR: couldn't accept a new external connection"
 msgstr "ERRO: não foi possível aceitar uma nova ligação externa"
 
-#: src/ExternalConn.cpp:595
+#: src/ExternalConn.cpp:596
 msgid "External connection refused due to empty password in preferences!"
 msgstr "Ligação externa recusada devido a palavra-passe não preenchida nas preferências!"
 
-#: src/ExternalConn.cpp:607
+#: src/ExternalConn.cpp:608
 #, c-format
 msgid "Connecting client: %s %s"
 msgstr "A ligar cliente: %s %s"
 
-#: src/ExternalConn.cpp:609
+#: src/ExternalConn.cpp:610
 msgid "Unknown version"
 msgstr "Versão desconhecida"
 
-#: src/ExternalConn.cpp:622
+#: src/ExternalConn.cpp:623
 msgid "Incorrect EC version ID, there might be binary incompatibility. Use core and remote from same snapshot."
 msgstr "Versão de LE incorrecta, pode haver incompatibilidade binária. Utilize núcleo e remoto da mesma versão."
 
-#: src/ExternalConn.cpp:630
+#: src/ExternalConn.cpp:631
 msgid "You cannot connect to a release version from an arbitrary development snapshot! *sigh* possible crash prevented"
 msgstr "Não pode ligar-se a uma versão oficial a partir de uma versão de desenvolvimento arbitrária! *suspiro*... Prevenido potencial erro futuro"
 
-#: src/ExternalConn.cpp:713
+#: src/ExternalConn.cpp:714
 msgid "Invalid protocol version."
 msgstr "Versão de protocolo inválida."
 
-#: src/ExternalConn.cpp:719
+#: src/ExternalConn.cpp:720
 msgid "Missing protocol version tag."
 msgstr "Elemento de versão de protocolo em falta."
 
-#: src/ExternalConn.cpp:727
+#: src/ExternalConn.cpp:728
 msgid "Authentication failed: invalid hash specified as EC password."
 msgstr "Falha de autenticação: chave inválida indicada como palavra-passe para LE"
 
-#: src/ExternalConn.cpp:775
+#: src/ExternalConn.cpp:776
 msgid "Authentication failed: wrong password."
 msgstr "A autenticação falhou: palavra-passe errada."
 
-#: src/ExternalConn.cpp:777
+#: src/ExternalConn.cpp:778
 msgid "Authentication failed: missing password."
 msgstr "A autenticação falhou: palavra-passe em falta."
 
-#: src/ExternalConn.cpp:788
+#: src/ExternalConn.cpp:789
 msgid "Invalid request, please authenticate first."
 msgstr "Pedido inválido, deve autenticar-se primeiro."
 
-#: src/ExternalConn.cpp:793
+#: src/ExternalConn.cpp:794
 msgid "Access granted."
 msgstr "Acesso concedido."
 
-#: src/ExternalConn.cpp:801
+#: src/ExternalConn.cpp:802
 #, c-format
 msgid "Sent error message \"%s\" to client."
 msgstr "Enviada mensagem de erro \"%s\" ao cliente."
 
-#: src/ExternalConn.cpp:806
+#: src/ExternalConn.cpp:807
 #, c-format
 msgid "Unauthorized access attempt from %s. Connection closed."
 msgstr "Acesso não-autorizado de %s. Ligação fechada."
 
-#: src/ExternalConn.cpp:1419
+#: src/ExternalConn.cpp:1420
 #, c-format
 msgid "Remote PartFile command failed: FileHash not found: %s"
 msgstr "Falha no comando de ficheiro de partes remoto: Chave não encontrada: %s"
 
-#: src/ExternalConn.cpp:1423
+#: src/ExternalConn.cpp:1424
 #, c-format
 msgid "FileHash not found: %s"
 msgstr "Chave não encontrada: %s"
 
-#: src/ExternalConn.cpp:1470 src/ExternalConn.cpp:1558
-#: src/ExternalConn.cpp:1679
+#: src/ExternalConn.cpp:1471 src/ExternalConn.cpp:1559
+#: src/ExternalConn.cpp:1680
 msgid "OOPS! OpCode processing error!"
 msgstr "UPS! Erro de processamento de código de operação!"
 
-#: src/ExternalConn.cpp:1501
+#: src/ExternalConn.cpp:1502
 msgid "Server not added"
 msgstr "Servidor não adicionado"
 
-#: src/ExternalConn.cpp:1520
+#: src/ExternalConn.cpp:1521
 #, c-format
 msgid "server not found: %s"
 msgstr "servidor não encontrado: %s"
 
-#: src/ExternalConn.cpp:1537
+#: src/ExternalConn.cpp:1538
 msgid "need to define server to be removed"
 msgstr "é necessário definir o servidor a remover"
 
-#: src/ExternalConn.cpp:1552
+#: src/ExternalConn.cpp:1553
 msgid "eD2k is disabled in preferences."
 msgstr "eD2K desactivada nas preferências."
 
-#: src/ExternalConn.cpp:1657
+#: src/ExternalConn.cpp:1658
 #, fuzzy
 msgid "Friend not found."
 msgstr "Ficheiro não encontrado."
 
-#: src/ExternalConn.cpp:1667
+#: src/ExternalConn.cpp:1668
 #, fuzzy
 msgid "Client not found."
 msgstr "Ficheiro não encontrado."
 
-#: src/ExternalConn.cpp:1673
+#: src/ExternalConn.cpp:1674
 msgid "EC_TAG_FRIEND_SHARED requires EC_TAG_FRIEND or EC_TAG_CLIENT."
 msgstr ""
 
-#: src/ExternalConn.cpp:1991
+#: src/ExternalConn.cpp:1992
 msgid "WebSearch from remote interface makes no sense."
 msgstr "Pesquisa na web a partir da interface remota não faz sentido."
 
-#: src/ExternalConn.cpp:2026
+#: src/ExternalConn.cpp:2027
 msgid "Search in progress. Refetch results in a moment!"
 msgstr "A pesquisar. Resultados dentro de momentos!"
 
-#: src/ExternalConn.cpp:2265
+#: src/ExternalConn.cpp:2266
 msgid "No points for graph."
 msgstr "Sem pontos para gráfico."
 
-#: src/ExternalConn.cpp:2275
+#: src/ExternalConn.cpp:2276
 msgid "Your client is not configured for this detail level."
 msgstr "O cliente não está configurado para este nível de detalhe."
 
-#: src/ExternalConn.cpp:2302
+#: src/ExternalConn.cpp:2303
 msgid "External Connection: shutdown requested"
 msgstr "Ligação Externa: finalização pedida"
 
-#: src/ExternalConn.cpp:2314
+#: src/ExternalConn.cpp:2315
 msgid "Already shutting down."
 msgstr "Já a desligar."
 
-#: src/ExternalConn.cpp:2332
+#: src/ExternalConn.cpp:2333
 #, c-format
 msgid "ExternalConn: adding link '%s'."
 msgstr "LigaçãoExterna: a adicionar o link '%s'."
 
-#: src/ExternalConn.cpp:2350
+#: src/ExternalConn.cpp:2351
 #, fuzzy, c-format
 msgid "%d of %d links failed (invalid or already on list)."
 msgstr "Ligação inválida ou já na lista."
 
-#: src/ExternalConn.cpp:2373
+#: src/ExternalConn.cpp:2374
 msgid "Version check throttled; try again shortly."
 msgstr ""
 
-#: src/ExternalConn.cpp:2378
+#: src/ExternalConn.cpp:2379
 msgid "Version check is not available on this daemon."
 msgstr ""
 
-#: src/ExternalConn.cpp:2508
+#: src/ExternalConn.cpp:2509
 msgid "File not found."
 msgstr "Ficheiro não encontrado."
 
-#: src/ExternalConn.cpp:2513
+#: src/ExternalConn.cpp:2514
 msgid "Invalid file name."
 msgstr "Nome de ficheiro inválido."
 
-#: src/ExternalConn.cpp:2521
+#: src/ExternalConn.cpp:2522
 msgid "Unable to rename file."
 msgstr "Não é possível renomear o ficheiro."
 
-#: src/ExternalConn.cpp:2992 src/ExternalConn.cpp:3020
+#: src/ExternalConn.cpp:2839
+#, c-format
+msgid "Could not save the amuleapi password: %s"
+msgstr ""
+
+#: src/ExternalConn.cpp:3004 src/ExternalConn.cpp:3032
 msgid "Kad is disabled in preferences."
 msgstr "A Kad está desactivada nas preferências."
 
-#: src/ExternalConn.cpp:3033
+#: src/ExternalConn.cpp:3045
 msgid "Already connected to eD2k."
 msgstr "Já ligado à eD2k."
 
-#: src/ExternalConn.cpp:3036
+#: src/ExternalConn.cpp:3048
 msgid "Connecting to eD2k..."
 msgstr "A ligar à eD2k..."
 
-#: src/ExternalConn.cpp:3045
+#: src/ExternalConn.cpp:3057
 msgid "Already connected to Kad."
 msgstr "Já ligado à Kad."
 
-#: src/ExternalConn.cpp:3048
+#: src/ExternalConn.cpp:3060
 msgid "Connecting to Kad..."
 msgstr "A ligar à Kad..."
 
-#: src/ExternalConn.cpp:3055
+#: src/ExternalConn.cpp:3067
 msgid "All networks are disabled."
 msgstr "Todas as redes estão desactivadas."
 
-#: src/ExternalConn.cpp:3064
+#: src/ExternalConn.cpp:3076
 msgid "Disconnected from eD2k."
 msgstr "Desligado da eD2k."
 
-#: src/ExternalConn.cpp:3069
+#: src/ExternalConn.cpp:3081
 msgid "Disconnected from Kad."
 msgstr "Desligado da Kad."
 
-#: src/ExternalConn.cpp:3078
+#: src/ExternalConn.cpp:3090
 #, c-format
 msgid "External Connection: invalid opcode received: %#x"
 msgstr "Ligação Externa: recebido código de operação inválido: %#x"
 
-#: src/ExternalConn.cpp:3083
+#: src/ExternalConn.cpp:3095
 msgid "Invalid opcode (wrong protocol version?)"
 msgstr "Código de operação inválido (versão de protocolo errada?)"
 
@@ -2431,23 +2436,23 @@ msgid ""
 "want downloads on a different (e.g. larger) disk."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:549 src/FirstRunWizard.cpp:611 src/muuli_wdr.cpp:1708
+#: src/FirstRunWizard.cpp:549 src/FirstRunWizard.cpp:611 src/muuli_wdr.cpp:1712
 msgid "Destination folder for downloads"
 msgstr "Pasta de destino para downloads"
 
 #: src/FirstRunWizard.cpp:553 src/FirstRunWizard.cpp:569 src/muuli_wdr.cpp:1349
-#: src/muuli_wdr.cpp:1366 src/muuli_wdr.cpp:1683 src/muuli_wdr.cpp:1714
-#: src/muuli_wdr.cpp:1726 src/muuli_wdr.cpp:2769
+#: src/muuli_wdr.cpp:1366 src/muuli_wdr.cpp:1687 src/muuli_wdr.cpp:1718
+#: src/muuli_wdr.cpp:1730 src/muuli_wdr.cpp:2800
 #: src/utils/aLinkCreator/src/alcframe.cpp:135
 #: src/utils/wxCas/src/wxcasprefs.cpp:52 src/utils/wxCas/src/wxcasprefs.cpp:118
 msgid "Browse"
 msgstr "Procurar"
 
-#: src/FirstRunWizard.cpp:559 src/muuli_wdr.cpp:1719
+#: src/FirstRunWizard.cpp:559 src/muuli_wdr.cpp:1723
 msgid "(All files in this folder are shared with other peers)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:565 src/FirstRunWizard.cpp:624 src/muuli_wdr.cpp:1721
+#: src/FirstRunWizard.cpp:565 src/FirstRunWizard.cpp:624 src/muuli_wdr.cpp:1725
 msgid "Folder for temporary download files"
 msgstr "Pasta para ficheiros temporários"
 
@@ -2478,7 +2483,7 @@ msgstr "Erro ao abrir o ficheiro de lista de amigos 'emfriends.met' para escrita
 msgid "CRITICAL - no client on StartChatSession"
 msgstr "CRÍTICO - sem cliente no StartChatSession"
 
-#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2675 src/muuli_wdr.cpp:3352
+#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2706 src/muuli_wdr.cpp:3383
 msgid "Friends"
 msgstr "Amigos"
 
@@ -2589,8 +2594,8 @@ msgstr "Nenhum"
 msgid "No"
 msgstr "Não"
 
-#: src/GenericClientListCtrl.cpp:1216 src/PrefsUnifiedDlg.cpp:2818
-#: src/PrefsUnifiedDlg.cpp:2868 src/ServerListCtrl.cpp:276
+#: src/GenericClientListCtrl.cpp:1216 src/PrefsUnifiedDlg.cpp:2898
+#: src/PrefsUnifiedDlg.cpp:2948 src/ServerListCtrl.cpp:276
 msgid "Yes"
 msgstr "Sim"
 
@@ -2759,10 +2764,10 @@ msgstr "Porto inválido para arranque"
 msgid "Please fill all fields required"
 msgstr "Por favor, preencha todos os campos pedidos"
 
-#: src/KadDlg.cpp:192 src/PartFile.cpp:1031 src/PrefsUnifiedDlg.cpp:1162
-#: src/PrefsUnifiedDlg.cpp:1331 src/PrefsUnifiedDlg.cpp:1589
-#: src/PrefsUnifiedDlg.cpp:1599 src/PrefsUnifiedDlg.cpp:1616
-#: src/PrefsUnifiedDlg.cpp:1658
+#: src/KadDlg.cpp:192 src/PartFile.cpp:1031 src/PrefsUnifiedDlg.cpp:1134
+#: src/PrefsUnifiedDlg.cpp:1204 src/PrefsUnifiedDlg.cpp:1405
+#: src/PrefsUnifiedDlg.cpp:1663 src/PrefsUnifiedDlg.cpp:1673
+#: src/PrefsUnifiedDlg.cpp:1690 src/PrefsUnifiedDlg.cpp:1738
 msgid "Message"
 msgstr "Mensagem"
 
@@ -2864,7 +2869,7 @@ msgstr "Razão de partilha"
 msgid "Uploaded"
 msgstr "Enviado"
 
-#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3232
+#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3263
 msgid "Requested"
 msgstr "Pedido"
 
@@ -2988,7 +2993,7 @@ msgid "WARNING: "
 msgstr "AVISO: "
 
 #: src/MuleNotebook.cpp:179 src/muuli_wdr.cpp:817 src/muuli_wdr.cpp:1229
-#: src/muuli_wdr.cpp:3136 src/muuli_wdr.cpp:3392
+#: src/muuli_wdr.cpp:3167 src/muuli_wdr.cpp:3423
 msgid "Close"
 msgstr "Fechar"
 
@@ -3006,7 +3011,7 @@ msgid "Paste"
 msgstr "Colar"
 
 #: src/MuleTextCtrl.cpp:89 src/muuli_wdr.cpp:358 src/muuli_wdr.cpp:757
-#: src/muuli_wdr.cpp:2359 src/muuli_wdr.cpp:2378 src/muuli_wdr.cpp:2400
+#: src/muuli_wdr.cpp:2390 src/muuli_wdr.cpp:2409 src/muuli_wdr.cpp:2431
 #: src/utils/aLinkCreator/src/alcframe.cpp:142
 msgid "Clear"
 msgstr "Limpar"
@@ -3105,7 +3110,7 @@ msgstr "Sair"
 
 #: src/MuleTrayIcon.cpp:579 src/MuleTrayIcon.cpp:945 src/MuleTrayIcon.cpp:965
 #: src/muuli_wdr.cpp:1398 src/muuli_wdr.cpp:1406 src/muuli_wdr.cpp:1413
-#: src/muuli_wdr.cpp:1842 src/muuli_wdr.cpp:1848 src/OtherFunctions.cpp:91
+#: src/muuli_wdr.cpp:1846 src/muuli_wdr.cpp:1852 src/OtherFunctions.cpp:91
 #: src/StatisticsDlg.cpp:93 src/StatisticsDlg.cpp:95
 msgid "kB/s"
 msgstr "kB/s"
@@ -3347,7 +3352,7 @@ msgstr "Bytes"
 msgid "KB"
 msgstr "kB"
 
-#: src/muuli_wdr.cpp:274 src/muuli_wdr.cpp:293 src/muuli_wdr.cpp:1627
+#: src/muuli_wdr.cpp:274 src/muuli_wdr.cpp:293 src/muuli_wdr.cpp:1631
 #: src/OtherFunctions.cpp:64
 msgid "MB"
 msgstr "MB"
@@ -3364,7 +3369,7 @@ msgstr "Tamanho Máximo"
 msgid "Availability"
 msgstr "Disponibilidade"
 
-#: src/muuli_wdr.cpp:312 src/muuli_wdr.cpp:398 src/muuli_wdr.cpp:3297
+#: src/muuli_wdr.cpp:312 src/muuli_wdr.cpp:398 src/muuli_wdr.cpp:3328
 msgid "Filter:"
 msgstr "Filtro:"
 
@@ -3427,12 +3432,12 @@ msgstr "Fontes de ficheiros:"
 #: src/muuli_wdr.cpp:1160 src/muuli_wdr.cpp:1167 src/muuli_wdr.cpp:1172
 #: src/muuli_wdr.cpp:1179 src/muuli_wdr.cpp:1184 src/muuli_wdr.cpp:1191
 #: src/muuli_wdr.cpp:1205 src/muuli_wdr.cpp:1212 src/muuli_wdr.cpp:1217
-#: src/muuli_wdr.cpp:1224 src/muuli_wdr.cpp:3234 src/muuli_wdr.cpp:3242
-#: src/muuli_wdr.cpp:3250
+#: src/muuli_wdr.cpp:1224 src/muuli_wdr.cpp:3265 src/muuli_wdr.cpp:3273
+#: src/muuli_wdr.cpp:3281
 msgid "N/A"
 msgstr "N/D"
 
-#: src/muuli_wdr.cpp:508 src/muuli_wdr.cpp:1065 src/PrefsUnifiedDlg.cpp:297
+#: src/muuli_wdr.cpp:508 src/muuli_wdr.cpp:1065 src/PrefsUnifiedDlg.cpp:299
 msgid "General"
 msgstr "Geral"
 
@@ -3573,7 +3578,7 @@ msgstr ""
 msgid "Album :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:685 src/muuli_wdr.cpp:2254
+#: src/muuli_wdr.cpp:685 src/muuli_wdr.cpp:2285
 msgid "Title :"
 msgstr "Título :"
 
@@ -3682,7 +3687,7 @@ msgstr "Utilizador :"
 msgid "Userhash :"
 msgstr "Chave de utilizador :"
 
-#: src/muuli_wdr.cpp:895 src/muuli_wdr.cpp:1748 src/muuli_wdr.cpp:2449
+#: src/muuli_wdr.cpp:895 src/muuli_wdr.cpp:1752 src/muuli_wdr.cpp:2480
 #: src/utils/aLinkCreator/src/alcframe.cpp:137
 msgid "Add"
 msgstr "Adicionar"
@@ -3691,15 +3696,15 @@ msgstr "Adicionar"
 msgid "Download-Speed"
 msgstr "Velocidade de Download"
 
-#: src/muuli_wdr.cpp:954 src/muuli_wdr.cpp:989 src/muuli_wdr.cpp:2553
+#: src/muuli_wdr.cpp:954 src/muuli_wdr.cpp:989 src/muuli_wdr.cpp:2584
 msgid "Current"
 msgstr "Actual"
 
-#: src/muuli_wdr.cpp:962 src/muuli_wdr.cpp:997 src/muuli_wdr.cpp:2561
+#: src/muuli_wdr.cpp:962 src/muuli_wdr.cpp:997 src/muuli_wdr.cpp:2592
 msgid "Running average"
 msgstr "Média actual"
 
-#: src/muuli_wdr.cpp:970 src/muuli_wdr.cpp:1005 src/muuli_wdr.cpp:2569
+#: src/muuli_wdr.cpp:970 src/muuli_wdr.cpp:1005 src/muuli_wdr.cpp:2600
 msgid "Session average"
 msgstr "Média da sessão"
 
@@ -3711,7 +3716,7 @@ msgstr "Velocidade de Upload"
 msgid "Connections"
 msgstr "Ligações"
 
-#: src/muuli_wdr.cpp:1024 src/muuli_wdr.cpp:1867
+#: src/muuli_wdr.cpp:1024 src/muuli_wdr.cpp:1871
 msgid "Active downloads"
 msgstr "Downloads activos"
 
@@ -3719,7 +3724,7 @@ msgstr "Downloads activos"
 msgid "Active connections (1:1)"
 msgstr "Ligações activas (1:1)"
 
-#: src/muuli_wdr.cpp:1040 src/muuli_wdr.cpp:1868
+#: src/muuli_wdr.cpp:1040 src/muuli_wdr.cpp:1872
 msgid "Active uploads"
 msgstr "Uploads activos"
 
@@ -3995,7 +4000,7 @@ msgstr "Associar endereço local ao IP (em branco para qualquer um):"
 msgid "Advanced users only: If you have multiple network interfaces, enter the address of the interface to which aMule should be bound."
 msgstr "Apenas para utilizadores avançados: Se possui múltiplos interfaces de rede indique o endereço do interface que o aMule deve usar."
 
-#: src/muuli_wdr.cpp:1462 src/muuli_wdr.cpp:2061
+#: src/muuli_wdr.cpp:1462 src/muuli_wdr.cpp:2065
 #, fuzzy
 msgid "Bind to network interface (empty for any):"
 msgstr "Associar endereço local ao IP (em branco para qualquer um):"
@@ -4012,7 +4017,7 @@ msgstr "Máximo de fontes por ficheiro:"
 msgid "Max simultaneous connections:"
 msgstr "Máximo de ligações simultâneas:"
 
-#: src/muuli_wdr.cpp:1498 src/muuli_wdr.cpp:3176
+#: src/muuli_wdr.cpp:1498 src/muuli_wdr.cpp:3207
 msgid "ED2K"
 msgstr "ED2K"
 
@@ -4104,756 +4109,779 @@ msgstr "Reservar previamente espaço em disco para novos ficheiros"
 msgid "For new files preallocates disk space for the whole file, thus reduces fragmentation"
 msgstr "Para novos ficheiros, reserva o espaço em disco para o ficheiro completo, reduzindo assim a fragmentação"
 
-#: src/muuli_wdr.cpp:1613
+#: src/muuli_wdr.cpp:1617
 msgid "Create new files as sparse files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1614
-msgid "A sparse file reserves its full size on disk immediately without writing real data to it -- fast, but unsupported or slow on some filesystems, and free-space accounting stays optimistic while the download is in progress. Turn this off to grow the file only as data arrives."
+#: src/muuli_wdr.cpp:1618
+msgid "Sparse part files only occupy disk space for the parts already downloaded, so free space is used up gradually as the file fills in. Turn this off to use an ordinary file instead - useful where sparse files are unsupported or slow, or where backup/de-duplication tools handle them badly. Applies only when the core runs on Windows; on Linux and macOS part files are sparse anyway and this setting has no effect."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1619
+#: src/muuli_wdr.cpp:1623
 msgid "Stop downloads when free disk space reaches "
 msgstr "Parar os downloads quando o espaço livre em disco atinge "
 
-#: src/muuli_wdr.cpp:1620
+#: src/muuli_wdr.cpp:1624
 msgid "Select this if you want aMule to check your disk space"
 msgstr "Seleccione se quiser que o aMule verifique o espaço em disco"
 
-#: src/muuli_wdr.cpp:1624
+#: src/muuli_wdr.cpp:1628
 msgid "Enter here the min disk space desired."
 msgstr "Insira o espaço mínimo no disco desejado."
 
-#: src/muuli_wdr.cpp:1630
+#: src/muuli_wdr.cpp:1634
 msgid "Save 10 sources on rare files (< 20 sources)"
 msgstr "Guardar 10 fontes para ficheiros raros (< 20 fontes)"
 
-#: src/muuli_wdr.cpp:1634 src/Statistics.cpp:790
+#: src/muuli_wdr.cpp:1638 src/Statistics.cpp:790
 msgid "Uploads"
 msgstr "Uploads"
 
-#: src/muuli_wdr.cpp:1637
+#: src/muuli_wdr.cpp:1641
 msgid "Add new shared files with auto priority"
 msgstr "Adicionar novos ficheiros partilhados com prioridade automática"
 
-#: src/muuli_wdr.cpp:1643
+#: src/muuli_wdr.cpp:1647
 msgid "Intelligent Corruption Handling (I.C.H.)"
 msgstr "Manipulação Inteligente de Corrupção (M.I.C.)"
 
-#: src/muuli_wdr.cpp:1646
+#: src/muuli_wdr.cpp:1650
 msgid "Enable"
 msgstr "Activar"
 
-#: src/muuli_wdr.cpp:1649
+#: src/muuli_wdr.cpp:1653
 msgid "Advanced I.C.H. trusts every hash (not recommended)"
 msgstr "M.I.C. Avançada confia em todas as chaves (não recomendado)"
 
-#: src/muuli_wdr.cpp:1661 src/PrefsUnifiedDlg.cpp:1910
+#: src/muuli_wdr.cpp:1665 src/PrefsUnifiedDlg.cpp:1990
 msgid "Media metadata extraction"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1665
+#: src/muuli_wdr.cpp:1669
 msgid "Extract length / bitrate / codec from shared audio and video files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1667
+#: src/muuli_wdr.cpp:1671
 msgid "When enabled, aMule runs ffprobe on each shared media file to fill in the Length / Bitrate / Codec columns other clients see when they find the file in a search. Requires ffmpeg (the ffprobe binary) to be installed."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1674
+#: src/muuli_wdr.cpp:1678
 msgid "Path to ffprobe:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1679
+#: src/muuli_wdr.cpp:1683
 msgid "Full path to the ffprobe binary. Leave empty to have aMule auto-detect it on startup."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1687
+#: src/muuli_wdr.cpp:1691
 msgid "Detect"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1688
+#: src/muuli_wdr.cpp:1692
 msgid "Search the standard install locations for an ffprobe binary and fill the path field."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1712
+#: src/muuli_wdr.cpp:1716
 msgid ""
 "Completed downloads are stored here. All files in this folder are automatically shared with other peers.\n"
 "If this folder also holds files you don't want to share, point it at an aMule-only sub-folder."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1715
+#: src/muuli_wdr.cpp:1719
 msgid "Pick the folder where completed downloads will be stored. All files in that folder will be shared with other peers."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1729
+#: src/muuli_wdr.cpp:1733
 msgid "Shared folders"
 msgstr "Pastas partilhadas"
 
-#: src/muuli_wdr.cpp:1735
+#: src/muuli_wdr.cpp:1739
 msgid "(Folders shared by the core. Enter a path to add one.)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1743
+#: src/muuli_wdr.cpp:1747
 msgid "Absolute path of a folder on the core's machine, e.g. /home/user/shared"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1745 src/PrefsUnifiedDlg.cpp:2794
+#: src/muuli_wdr.cpp:1749 src/PrefsUnifiedDlg.cpp:2874
 msgid "Recursive"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1746
+#: src/muuli_wdr.cpp:1750
 msgid "Share every sub-folder underneath this one, including ones created later."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1750 src/utils/aLinkCreator/src/alcframe.cpp:141
+#: src/muuli_wdr.cpp:1754 src/utils/aLinkCreator/src/alcframe.cpp:141
 msgid "Remove"
 msgstr "Remover"
 
-#: src/muuli_wdr.cpp:1754
+#: src/muuli_wdr.cpp:1758
 msgid "(Right click on folder icon for recursive share)"
 msgstr "(Clique com o botão do lado direito no ícone da pasta para partilha recursiva)"
 
-#: src/muuli_wdr.cpp:1761
+#: src/muuli_wdr.cpp:1765
 msgid "Share hidden files"
 msgstr "Partilhar ficheiros ocultos"
 
-#: src/muuli_wdr.cpp:1767
+#: src/muuli_wdr.cpp:1771
 msgid "Automatically rescan shared folders for changes"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1773
+#: src/muuli_wdr.cpp:1777
 msgid "Follow symbolic links in shared folders"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1779
+#: src/muuli_wdr.cpp:1783
 msgid "Exclude files matching:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1782
+#: src/muuli_wdr.cpp:1786
 msgid "Wildcard patterns separated by '|', e.g. .DS_Store|Thumbs.db|*.tmp. Files whose name matches are not shared. Matching is case-insensitive."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1786
+#: src/muuli_wdr.cpp:1790
 msgid "Patterns are regular expressions"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1787
+#: src/muuli_wdr.cpp:1791
 msgid "When set, the whole field is one regular expression ('|' is alternation). When unset, it is a list of '|'-separated wildcards."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1797
+#: src/muuli_wdr.cpp:1801
 msgid "Show how many shared files the current pattern would exclude."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1818
+#: src/muuli_wdr.cpp:1822
 msgid "Graphs"
 msgstr "Gráficos"
 
-#: src/muuli_wdr.cpp:1821 src/muuli_wdr.cpp:1883
+#: src/muuli_wdr.cpp:1825 src/muuli_wdr.cpp:1887
 msgid "Update delay : 5 secs"
 msgstr "Atraso de actualização: 5 segundos"
 
-#: src/muuli_wdr.cpp:1825
+#: src/muuli_wdr.cpp:1829
 msgid "Time for average graph: 100 mins"
 msgstr "Tempo para gráfico de média: 100 minutos"
 
-#: src/muuli_wdr.cpp:1829
+#: src/muuli_wdr.cpp:1833
 msgid "Connections Graph Scale: 100 "
 msgstr "Escala do Gráfico de Ligações: 100"
 
-#: src/muuli_wdr.cpp:1836
+#: src/muuli_wdr.cpp:1840
 msgid "Download graph scale:"
 msgstr "Escala do gráfico de download:"
 
-#: src/muuli_wdr.cpp:1844
+#: src/muuli_wdr.cpp:1848
 msgid "Upload graph scale:"
 msgstr "Escala do gráfico de upload"
 
-#: src/muuli_wdr.cpp:1854
+#: src/muuli_wdr.cpp:1858
 #, fuzzy
 msgid "Colors: "
 msgstr "Cores: "
 
-#: src/muuli_wdr.cpp:1858
+#: src/muuli_wdr.cpp:1862
 msgid "Background"
 msgstr "Fundo"
 
-#: src/muuli_wdr.cpp:1859
+#: src/muuli_wdr.cpp:1863
 msgid "Grid"
 msgstr "Grelha"
 
-#: src/muuli_wdr.cpp:1860
+#: src/muuli_wdr.cpp:1864
 msgid "Download current"
 msgstr "Download actual"
 
-#: src/muuli_wdr.cpp:1861
+#: src/muuli_wdr.cpp:1865
 msgid "Download running average"
 msgstr "Média actual de download"
 
-#: src/muuli_wdr.cpp:1862
+#: src/muuli_wdr.cpp:1866
 msgid "Download session average"
 msgstr "Média de download da sessão"
 
-#: src/muuli_wdr.cpp:1863
+#: src/muuli_wdr.cpp:1867
 msgid "Upload current"
 msgstr "Upload actual"
 
-#: src/muuli_wdr.cpp:1864
+#: src/muuli_wdr.cpp:1868
 msgid "Upload running average"
 msgstr "Média actual de upload"
 
-#: src/muuli_wdr.cpp:1865
+#: src/muuli_wdr.cpp:1869
 msgid "Upload session average"
 msgstr "Média de upload da sessão"
 
-#: src/muuli_wdr.cpp:1866
+#: src/muuli_wdr.cpp:1870
 msgid "Active connections"
 msgstr "Ligações activas"
 
-#: src/muuli_wdr.cpp:1869
+#: src/muuli_wdr.cpp:1873
 #, fuzzy
 msgid "Systray Icon Speed Bar"
 msgstr "Barra de velocidade no ícone da área de notificação"
 
-#: src/muuli_wdr.cpp:1870
+#: src/muuli_wdr.cpp:1874
 msgid "Kad-nodes current"
 msgstr "Nós Kad actuais"
 
-#: src/muuli_wdr.cpp:1871
+#: src/muuli_wdr.cpp:1875
 msgid "Kad-nodes running"
 msgstr "Nós Kad a executar"
 
-#: src/muuli_wdr.cpp:1872
+#: src/muuli_wdr.cpp:1876
 msgid "Kad-nodes session"
 msgstr "Nós Kad da sessão"
 
-#: src/muuli_wdr.cpp:1876 src/muuli_wdr.cpp:2303
+#: src/muuli_wdr.cpp:1880 src/muuli_wdr.cpp:2334
 msgid "Select"
 msgstr "Seleccionar"
 
-#: src/muuli_wdr.cpp:1880
+#: src/muuli_wdr.cpp:1884
 msgid "Tree"
 msgstr "Árvore"
 
-#: src/muuli_wdr.cpp:1890
+#: src/muuli_wdr.cpp:1894
 msgid "Number of Client Versions shown (0=unlimited)"
 msgstr "Número de Versões de Cliente mostradas (0=ilimitado)"
 
-#: src/muuli_wdr.cpp:1915
+#: src/muuli_wdr.cpp:1919
 msgid "!!! WARNING !!!"
 msgstr "!!! AVISO !!!"
 
-#: src/muuli_wdr.cpp:1930
+#: src/muuli_wdr.cpp:1934
 msgid "Max new connections / 5 secs"
 msgstr "Máximo de novas ligações / 5 segundos"
 
-#: src/muuli_wdr.cpp:1932
+#: src/muuli_wdr.cpp:1936
 msgid "Concurrent Kad source lookups"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1934
+#: src/muuli_wdr.cpp:1938
 #, fuzzy
 msgid "Kad source re-search interval (minutes)"
 msgstr "Intervalo de actualização do FTP em minutos"
 
-#: src/muuli_wdr.cpp:1936
+#: src/muuli_wdr.cpp:1940
 #, fuzzy
 msgid "Source re-ask interval (minutes)"
 msgstr "Intervalo de actualização do FTP em minutos"
 
-#: src/muuli_wdr.cpp:1940
+#: src/muuli_wdr.cpp:1944
 msgid "File Buffer Size: 240000 bytes"
 msgstr "Tamanho da memória temporária de ficheiro: 240000 Byte"
 
-#: src/muuli_wdr.cpp:1944
+#: src/muuli_wdr.cpp:1948
 msgid "Use MMAP: memory-mapped file access (lower memory use)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1945
+#: src/muuli_wdr.cpp:1949
 msgid "Maps part files into memory instead of buffering them on the heap, lowering the process memory footprint. May reduce download speed on some disks; best for memory-constrained or upload-heavy hosts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1947
+#: src/muuli_wdr.cpp:1951
 msgid "Upload Queue Size: 5000 clients"
 msgstr "Tamanho da Lista de Espera de Upload: 5000 clientes"
 
-#: src/muuli_wdr.cpp:1951
+#: src/muuli_wdr.cpp:1955
 msgid "Server connection refresh interval: Disable"
 msgstr "Intervalo de actualização da ligação ao servidor: Desactivado"
 
-#: src/muuli_wdr.cpp:1955
+#: src/muuli_wdr.cpp:1959
 msgid "Disable computer's timed standby mode"
 msgstr "Desactivar o modo de espera temporizado do computador"
 
-#: src/muuli_wdr.cpp:1974
+#: src/muuli_wdr.cpp:1978
 msgid "Skin to use: "
 msgstr "Tema a utilizar: "
 
-#: src/muuli_wdr.cpp:1983
+#: src/muuli_wdr.cpp:1987
 msgid "Show \"Fast eD2k Links Handler\" in every window."
 msgstr "Mostrar a barra de adição rápida de ligações eD2k em todas as janelas."
 
-#: src/muuli_wdr.cpp:1986
+#: src/muuli_wdr.cpp:1990
 msgid "Show extended info on categories tabs"
 msgstr "Mostrar informação extra nos separadores de categorias"
 
-#: src/muuli_wdr.cpp:1989
+#: src/muuli_wdr.cpp:1993
 #, fuzzy
 msgid "Show application version on title"
 msgstr "Mostrar velocidades de transferência na barra de título"
 
-#: src/muuli_wdr.cpp:1991
+#: src/muuli_wdr.cpp:1995
 msgid "Show transfer rates on title"
 msgstr "Mostrar velocidades de transferência na barra de título"
 
-#: src/muuli_wdr.cpp:1993
+#: src/muuli_wdr.cpp:1997
 msgid "Before application name"
 msgstr "Antes do nome da aplicação"
 
-#: src/muuli_wdr.cpp:1995
+#: src/muuli_wdr.cpp:1999
 msgid "After application name"
 msgstr "Depois do nome da aplicação"
 
-#: src/muuli_wdr.cpp:1998
+#: src/muuli_wdr.cpp:2002
 msgid "Show overhead bandwidth"
 msgstr "Mostrar sobrecarga na largura de banda"
 
-#: src/muuli_wdr.cpp:2002
+#: src/muuli_wdr.cpp:2006
 msgid "Vertical toolbar orientation"
 msgstr "Orientação vertical da barra de ferramentas"
 
-#: src/muuli_wdr.cpp:2004
+#: src/muuli_wdr.cpp:2008
 msgid "Live column sorting (auto-reorder rows as their values change)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2011
+#: src/muuli_wdr.cpp:2015
 msgid "Download Queue Files"
 msgstr "Ficheiros na Fila de Espera dos Downloads"
 
-#: src/muuli_wdr.cpp:2014
+#: src/muuli_wdr.cpp:2018
 msgid "Show progress percentage"
 msgstr "Mostrar percentagem de progresso"
 
-#: src/muuli_wdr.cpp:2020
+#: src/muuli_wdr.cpp:2024
 msgid "Show progress bar"
 msgstr "Mostrar barra de progresso"
 
-#: src/muuli_wdr.cpp:2023
+#: src/muuli_wdr.cpp:2027
 msgid "Flat"
 msgstr "Plana"
 
-#: src/muuli_wdr.cpp:2027
+#: src/muuli_wdr.cpp:2031
 msgid "Round"
 msgstr "Arredondada"
 
-#: src/muuli_wdr.cpp:2045
+#: src/muuli_wdr.cpp:2049
 msgid "External Connection Parameters"
 msgstr "Parâmetros de Ligação Externa"
 
-#: src/muuli_wdr.cpp:2048
+#: src/muuli_wdr.cpp:2052
 msgid "Accept external connections"
 msgstr "Aceitar ligações externas"
 
-#: src/muuli_wdr.cpp:2055 src/muuli_wdr.cpp:2114
+#: src/muuli_wdr.cpp:2059 src/muuli_wdr.cpp:2118
 msgid "IP of the listening interface:"
 msgstr "IP da interface a escutar:"
 
-#: src/muuli_wdr.cpp:2058
+#: src/muuli_wdr.cpp:2062
 msgid "Enter here a valid ip in the a.b.c.d format for the listening EC interface. An empty field or 0.0.0.0 will mean any interface."
 msgstr "Insira um endereço IP válido no formato a.b.c.d para a interface que irá aguardar as LE. Um campo vazio ou 0.0.0.0 significará qualquer interface."
 
-#: src/muuli_wdr.cpp:2079 src/muuli_wdr.cpp:2163
+#: src/muuli_wdr.cpp:2083 src/muuli_wdr.cpp:2194
 msgid "TCP port:"
 msgstr "Porto TCP:"
 
-#: src/muuli_wdr.cpp:2085
+#: src/muuli_wdr.cpp:2089
 msgid "Enable UPnP port forwarding on the EC port"
 msgstr "Activar UPnP para configuração do encaminhamento no porto das LE"
 
-#: src/muuli_wdr.cpp:2089 src/muuli_wdr.cpp:3048
+#: src/muuli_wdr.cpp:2093 src/muuli_wdr.cpp:3079
 #: src/utils/wxCas/src/wxcasprefs.cpp:167
 msgid "Password"
 msgstr "Palavra-passe"
 
-#: src/muuli_wdr.cpp:2095
+#: src/muuli_wdr.cpp:2099
 #, fuzzy
 msgid "aMule API server parameters"
 msgstr "Parâmetros do servidor web"
 
-#: src/muuli_wdr.cpp:2098
+#: src/muuli_wdr.cpp:2102
 msgid "Run amuleapi (REST API) on startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2103
+#: src/muuli_wdr.cpp:2107
 #, fuzzy
 msgid "HTTP port:"
 msgstr "Porto TCP:"
 
-#: src/muuli_wdr.cpp:2117
+#: src/muuli_wdr.cpp:2121
 msgid "The interface amuleapi's HTTP server listens on. 127.0.0.1 (default) accepts only local connections; use 0.0.0.0 or a specific IP to expose it to other hosts (set an admin password below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2120
+#: src/muuli_wdr.cpp:2126
+msgid "Type a password to set or change it. Stored passwords cannot be shown, so leaving this empty keeps the current one."
+msgstr ""
+
+#: src/muuli_wdr.cpp:2128
 #, fuzzy
 msgid "Admin password"
 msgstr "A verificar a palavra-passe\n"
 
-#: src/muuli_wdr.cpp:2125 src/muuli_wdr.cpp:2156
-msgid "Low rights password"
-msgstr "Palavra-passe para controlo reduzido"
+#: src/muuli_wdr.cpp:2140 src/muuli_wdr.cpp:2157 src/PrefsUnifiedDlg.cpp:1103
+#, fuzzy
+msgid "A password is set."
+msgstr "A verificar a palavra-passe\n"
 
-#: src/muuli_wdr.cpp:2133
+#: src/muuli_wdr.cpp:2144
+#, fuzzy
+msgid "Enable guest access"
+msgstr "Negar acesso de convidado"
+
+#: src/muuli_wdr.cpp:2145
+msgid "Guest sessions may read status and listings but cannot change anything. Turning this off clears the stored guest password."
+msgstr ""
+
+#: src/muuli_wdr.cpp:2149
+#, fuzzy
+msgid "Guest password"
+msgstr "Palavra-passe de convidado para o servidor web"
+
+#: src/muuli_wdr.cpp:2164
 msgid "Web server parameters"
 msgstr "Parâmetros do servidor web"
 
-#: src/muuli_wdr.cpp:2136
+#: src/muuli_wdr.cpp:2167
 #, fuzzy
 msgid "Run webserver on startup (deprecated)"
 msgstr "Executar o servidor web no arranque"
 
-#: src/muuli_wdr.cpp:2142
+#: src/muuli_wdr.cpp:2173
 msgid "Web template"
 msgstr "Aspecto da página web"
 
-#: src/muuli_wdr.cpp:2147
+#: src/muuli_wdr.cpp:2178
 msgid "Full rights password"
 msgstr "Palavra-passe para controlo total"
 
-#: src/muuli_wdr.cpp:2151
+#: src/muuli_wdr.cpp:2182
 msgid "Enable Low rights User"
 msgstr "Activar utilizador com permissões reduzidas"
 
-#: src/muuli_wdr.cpp:2170
+#: src/muuli_wdr.cpp:2187
+msgid "Low rights password"
+msgstr "Palavra-passe para controlo reduzido"
+
+#: src/muuli_wdr.cpp:2201
 msgid "Enable UPnP port forwarding of the web server port"
 msgstr "Activar UPnP para encaminhamento do porto do servidor web"
 
-#: src/muuli_wdr.cpp:2175
+#: src/muuli_wdr.cpp:2206
 msgid "Web server UPnP TCP port (Optional)"
 msgstr "Porto TCP UPnP do servidor web (Opcional)"
 
-#: src/muuli_wdr.cpp:2183
+#: src/muuli_wdr.cpp:2214
 msgid "Page Refresh Time (in secs)"
 msgstr "Taxa de Actualização de Páginas (em segundos)"
 
-#: src/muuli_wdr.cpp:2190
+#: src/muuli_wdr.cpp:2221
 msgid "Enable Gzip compression"
 msgstr "Activar compressão Gzip"
 
-#: src/muuli_wdr.cpp:2224
+#: src/muuli_wdr.cpp:2255
 #, fuzzy
 msgid "Reset page to defaults"
 msgstr "Predefinição do sistema"
 
-#: src/muuli_wdr.cpp:2225
+#: src/muuli_wdr.cpp:2256
 msgid "Reset the settings on the current page to their default values."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2227 src/muuli_wdr.cpp:2313 src/ServerWnd.cpp:274
+#: src/muuli_wdr.cpp:2258 src/muuli_wdr.cpp:2344 src/ServerWnd.cpp:274
 #: src/ServerWnd.cpp:282
 msgid "OK"
 msgstr "OK"
 
-#: src/muuli_wdr.cpp:2229
+#: src/muuli_wdr.cpp:2260
 msgid "Click here to apply any changes made to the preferences."
 msgstr "Clique aqui para aplicar as alterações efectuadas nas preferências."
 
-#: src/muuli_wdr.cpp:2232
+#: src/muuli_wdr.cpp:2263
 msgid "Reset any changes made to the preferences."
 msgstr "Anular as alterações efectuadas nas preferências."
 
-#: src/muuli_wdr.cpp:2261
+#: src/muuli_wdr.cpp:2292
 msgid "Comment :"
 msgstr "Comentário :"
 
-#: src/muuli_wdr.cpp:2268
+#: src/muuli_wdr.cpp:2299
 msgid "Incoming Dir :"
 msgstr "Pasta de completos :"
 
-#: src/muuli_wdr.cpp:2277
+#: src/muuli_wdr.cpp:2308
 msgid "Change priority for new assigned files :"
 msgstr "Trocar prioridade nos novos ficheiros :"
 
-#: src/muuli_wdr.cpp:2281
+#: src/muuli_wdr.cpp:2312
 msgid "Don't change"
 msgstr "Não mudar"
 
-#: src/muuli_wdr.cpp:2293
+#: src/muuli_wdr.cpp:2324
 msgid "Select color for this Category (currently selected) :"
 msgstr "Seleccionar a cor para a categoria seleccionada :"
 
-#: src/muuli_wdr.cpp:2360 src/muuli_wdr.cpp:2379 src/muuli_wdr.cpp:2401
+#: src/muuli_wdr.cpp:2391 src/muuli_wdr.cpp:2410 src/muuli_wdr.cpp:2432
 msgid "Click this button to reset the log."
 msgstr "Clique para limpar o relatório."
 
-#: src/muuli_wdr.cpp:2420
+#: src/muuli_wdr.cpp:2451
 msgid "Click on this button to update the servers list from URL ..."
 msgstr "Clique neste botão para actualizar a lista de servidores a partir do endereço ..."
 
-#: src/muuli_wdr.cpp:2424
+#: src/muuli_wdr.cpp:2455
 msgid "Server list"
 msgstr "Lista de Servidores"
 
-#: src/muuli_wdr.cpp:2428
+#: src/muuli_wdr.cpp:2459
 msgid "Enter the url to a server.met file here and press the button to the left to update the list of known servers."
 msgstr "Insira a localização de um ficheiro server.met e pressione o botão à esquerda para actualizar a lista de servidores conhecidos."
 
-#: src/muuli_wdr.cpp:2433
+#: src/muuli_wdr.cpp:2464
 msgid "Add server manually: Name"
 msgstr "Adicionar servidor manualmente: Nome"
 
-#: src/muuli_wdr.cpp:2436
+#: src/muuli_wdr.cpp:2467
 msgid "Enter the name of the new server here"
 msgstr "Insira o nome do novo servidor"
 
-#: src/muuli_wdr.cpp:2438 src/ServerWnd.cpp:206
+#: src/muuli_wdr.cpp:2469 src/ServerWnd.cpp:206
 msgid "IP:Port"
 msgstr "IP:Porto"
 
-#: src/muuli_wdr.cpp:2441
+#: src/muuli_wdr.cpp:2472
 msgid "Enter the IP of the server here, using the x.x.x.x format."
 msgstr "Insira o IP do servidor, usando o formato x.x.x.x."
 
-#: src/muuli_wdr.cpp:2447
+#: src/muuli_wdr.cpp:2478
 msgid "Enter the port of the server here."
 msgstr "Insira o porto do servidor."
 
-#: src/muuli_wdr.cpp:2450
+#: src/muuli_wdr.cpp:2481
 msgid "Add manually a server (fill fields to the left before) ..."
 msgstr "Adicionar manualmente um servidor (preencher os campos ao lado) ..."
 
-#: src/muuli_wdr.cpp:2479
+#: src/muuli_wdr.cpp:2510
 msgid "aMule Log"
 msgstr "Relatório"
 
-#: src/muuli_wdr.cpp:2487
+#: src/muuli_wdr.cpp:2518
 msgid "Server Info"
 msgstr "Informações do Servidor"
 
-#: src/muuli_wdr.cpp:2491
+#: src/muuli_wdr.cpp:2522
 msgid "ED2K Info"
 msgstr "Informação ED2K"
 
-#: src/muuli_wdr.cpp:2495
+#: src/muuli_wdr.cpp:2526
 msgid "Kad Info"
 msgstr "Informação Kad"
 
-#: src/muuli_wdr.cpp:2523
+#: src/muuli_wdr.cpp:2554
 msgid "Click on this button to update the nodes list from URL ..."
 msgstr "Clique para actualizar a lista de nós a partir do endereço ..."
 
-#: src/muuli_wdr.cpp:2527
+#: src/muuli_wdr.cpp:2558
 msgid "Nodes (0)"
 msgstr "Nós (0)"
 
-#: src/muuli_wdr.cpp:2531
+#: src/muuli_wdr.cpp:2562
 msgid "Enter the url to a nodes.dat file here and press the button to the left to update the list of known nodes."
 msgstr "Insira o endereço de um ficheiro nodes.dat e pressione o botão à esquerda para actualizar a lista de nós conhecidos."
 
-#: src/muuli_wdr.cpp:2534
+#: src/muuli_wdr.cpp:2565
 msgid "Nodes stats"
 msgstr "Estado dos nós"
 
-#: src/muuli_wdr.cpp:2576
+#: src/muuli_wdr.cpp:2607
 msgid "Bootstrap"
 msgstr "Inicialização"
 
-#: src/muuli_wdr.cpp:2579
+#: src/muuli_wdr.cpp:2610
 msgid "New node"
 msgstr "Novo nó"
 
-#: src/muuli_wdr.cpp:2584
+#: src/muuli_wdr.cpp:2615
 msgid "IP:"
 msgstr "IP:"
 
-#: src/muuli_wdr.cpp:2604
+#: src/muuli_wdr.cpp:2635
 msgid "Port:"
 msgstr "Porto:"
 
-#: src/muuli_wdr.cpp:2617
+#: src/muuli_wdr.cpp:2648
 msgid "Bootstrap from known clients"
 msgstr "Arrancar a partir de clientes conhecidos"
 
-#: src/muuli_wdr.cpp:2619
+#: src/muuli_wdr.cpp:2650
 msgid "Disconnect Kad"
 msgstr "Desligar Kad"
 
-#: src/muuli_wdr.cpp:2653
+#: src/muuli_wdr.cpp:2684
 msgid "Use Secure User Identification"
 msgstr "Utilizar Identificação Segura de Utilizador"
 
-#: src/muuli_wdr.cpp:2655
+#: src/muuli_wdr.cpp:2686
 msgid "It is recommended to enable this option. You will not receive credits if SUI is not enabled."
 msgstr "É recomendado activar esta opção. Não receberá créditos se a Identificação Segura de Utilizador não estiver activada."
 
-#: src/muuli_wdr.cpp:2657
+#: src/muuli_wdr.cpp:2688
 msgid "Protocol Obfuscation"
 msgstr "Ofuscação do Protocolo"
 
-#: src/muuli_wdr.cpp:2660
+#: src/muuli_wdr.cpp:2691
 msgid "Support Protocol Obfuscation"
 msgstr "Suportar a Ofuscação do Protocolo"
 
-#: src/muuli_wdr.cpp:2662
+#: src/muuli_wdr.cpp:2693
 msgid "This option enabled Protocol Obfuscation, and makes aMule accept obfuscated connections from other clients."
 msgstr "Esta opção activa a Ofuscação do Protocolo e faz com que o aMule aceite ligações ofuscadas de outros clientes."
 
-#: src/muuli_wdr.cpp:2664
+#: src/muuli_wdr.cpp:2695
 msgid "Use obfuscation for outgoing connections"
 msgstr "Usar ofuscação em ligações para o exterior"
 
-#: src/muuli_wdr.cpp:2666
+#: src/muuli_wdr.cpp:2697
 msgid "This option makes aMule use Protocol Obfuscation when connecting other clients/servers."
 msgstr "Esta opção faz com que o aMule use a Ofuscação do Protocolo quando ligado a outros clientes/servidores."
 
-#: src/muuli_wdr.cpp:2668
+#: src/muuli_wdr.cpp:2699
 msgid "Accept only obfuscated connections"
 msgstr "Aceitar apenas ligações ofuscadas"
 
-#: src/muuli_wdr.cpp:2669
+#: src/muuli_wdr.cpp:2700
 msgid "This option makes aMule only accept obfuscated connections. You will have less sources, but all your traffic will be obfuscated"
 msgstr "Esta opção faz com que o aMUle aceite apenas ligações ofuscadas. Terá menos fontes, mas todo o tráfego será ofuscado"
 
-#: src/muuli_wdr.cpp:2674
+#: src/muuli_wdr.cpp:2705
 msgid "Everybody"
 msgstr "Todos"
 
-#: src/muuli_wdr.cpp:2676
+#: src/muuli_wdr.cpp:2707
 msgid "No one"
 msgstr "Ninguém"
 
-#: src/muuli_wdr.cpp:2678
+#: src/muuli_wdr.cpp:2709
 msgid "Who can see my shared files:"
 msgstr "Quem pode ver os meus ficheiros partilhados:"
 
-#: src/muuli_wdr.cpp:2679
+#: src/muuli_wdr.cpp:2710
 msgid "Select who can request to view a list of your shared files."
 msgstr "Seleccione quem pode pedir a lista dos seus ficheiros partilhados."
 
-#: src/muuli_wdr.cpp:2681
+#: src/muuli_wdr.cpp:2712
 msgid "IP-Filtering"
 msgstr "Filtragem de IP"
 
-#: src/muuli_wdr.cpp:2688
+#: src/muuli_wdr.cpp:2719
 msgid "Filter clients"
 msgstr "Filtrar clientes"
 
-#: src/muuli_wdr.cpp:2690
+#: src/muuli_wdr.cpp:2721
 msgid "Enable filtering of the client IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "Activar filtragem por IPs dos clientes definidos no ficheiro ~/.aMule/ipfilter.dat."
 
-#: src/muuli_wdr.cpp:2692
+#: src/muuli_wdr.cpp:2723
 msgid "Filter servers"
 msgstr "Filtrar servidores"
 
-#: src/muuli_wdr.cpp:2694
+#: src/muuli_wdr.cpp:2725
 msgid "Enable filtering of the server IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "Activar filtragem da lista de IPs definida no ficheiro ~/.aMule/ipfilter.dat."
 
-#: src/muuli_wdr.cpp:2698
+#: src/muuli_wdr.cpp:2729
 msgid "Reload List"
 msgstr "Recarregar a lista"
 
-#: src/muuli_wdr.cpp:2699
+#: src/muuli_wdr.cpp:2730
 msgid "Reload the list of IPs to filter from the file ~/.aMule/ipfilter.dat"
 msgstr "Recarregar a lista de IPs a filtrar a partir do ficheiro ~/.aMule/ipfilter.dat"
 
-#: src/muuli_wdr.cpp:2705
+#: src/muuli_wdr.cpp:2736
 msgid "URL:"
 msgstr "URL:"
 
-#: src/muuli_wdr.cpp:2709 src/muuli_wdr.cpp:2902
+#: src/muuli_wdr.cpp:2740 src/muuli_wdr.cpp:2933
 msgid "Update now"
 msgstr "Actualizar agora"
 
-#: src/muuli_wdr.cpp:2712
+#: src/muuli_wdr.cpp:2743
 msgid "Auto-update ipfilter at startup"
 msgstr "Actualizar o filtro de IPs automaticamente no arranque"
 
-#: src/muuli_wdr.cpp:2716
+#: src/muuli_wdr.cpp:2747
 msgid "Filtering Level:"
 msgstr "Nível de filtragem:"
 
-#: src/muuli_wdr.cpp:2722
+#: src/muuli_wdr.cpp:2753
 msgid "Always filter LAN IPs"
 msgstr "Filtrar sempre endereços IP de rede local"
 
-#: src/muuli_wdr.cpp:2725
+#: src/muuli_wdr.cpp:2756
 msgid "Paranoid handling of non-matching IPs"
 msgstr "Tratamento paranóico de IPs sem correspondência"
 
-#: src/muuli_wdr.cpp:2727
+#: src/muuli_wdr.cpp:2758
 msgid "Rejects a packet when its source IP differs from the IP the client claims (an anti-spoofing check). Disable only if it causes connection problems."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2729
+#: src/muuli_wdr.cpp:2760
 msgid "Use system-wide ipfilter.dat if available"
 msgstr "Utilizar ipfilter.dat global do sistema se disponível"
 
-#: src/muuli_wdr.cpp:2730
+#: src/muuli_wdr.cpp:2761
 #, fuzzy
 msgid "If there's no local ipfilter.dat found, allow usage of a system-wide ipfilter file."
 msgstr "Se não existir um ficheiro ipfilter.dat, permitir a utilização de um ficheiro ipfilter global do sistema."
 
-#: src/muuli_wdr.cpp:2747
+#: src/muuli_wdr.cpp:2778
 msgid "Enable Online-Signature"
 msgstr "Activar Assinatura Online"
 
-#: src/muuli_wdr.cpp:2749
+#: src/muuli_wdr.cpp:2780
 msgid "Enables the writing of the OS file, which can be used by external apps to create signatures and the like."
 msgstr "Activa a escrita do ficheiro da AO, o qual pode ser usado por aplicações externas para criar assinaturas e afins."
 
-#: src/muuli_wdr.cpp:2753
+#: src/muuli_wdr.cpp:2784
 msgid "Update Frequency (Secs):"
 msgstr "Frequência de Actualização (segundos):"
 
-#: src/muuli_wdr.cpp:2756
+#: src/muuli_wdr.cpp:2787
 msgid "Change the frequency (in seconds) of Online Signature updates."
 msgstr "Alterar a frequência (em segundos) das actualizações da assinatura Online."
 
-#: src/muuli_wdr.cpp:2764
+#: src/muuli_wdr.cpp:2795
 msgid "Save online signature file in: "
 msgstr "Gravar a assinatura Online em: "
 
-#: src/muuli_wdr.cpp:2770
+#: src/muuli_wdr.cpp:2801
 msgid "Click here to select the directory containing the the Online Signature files."
 msgstr "Clique para seleccionar a pasta que contém os ficheiros de Assinatura Online"
 
-#: src/muuli_wdr.cpp:2803
+#: src/muuli_wdr.cpp:2834
 msgid "Show country flags for clients"
 msgstr "Mostrar bandeiras de países para clientes"
 
-#: src/muuli_wdr.cpp:2804
+#: src/muuli_wdr.cpp:2835
 msgid "Render the country flag column in the transfers, queue and search views. Requires a valid MMDB GeoIP database (see below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2809
+#: src/muuli_wdr.cpp:2840
 #, fuzzy
 msgid "Database"
 msgstr "Taxa de transferência :"
 
-#: src/muuli_wdr.cpp:2825
+#: src/muuli_wdr.cpp:2856
 #, fuzzy
 msgid "Source:"
 msgstr "Fontes"
 
-#: src/muuli_wdr.cpp:2828
+#: src/muuli_wdr.cpp:2859
 msgid "DB-IP (free, no account)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2829
+#: src/muuli_wdr.cpp:2860
 msgid "MaxMind GeoLite2 (free, account required)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2830
+#: src/muuli_wdr.cpp:2861
 msgid "Custom URL"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2833
+#: src/muuli_wdr.cpp:2864
 msgid "Choose which provider supplies the GeoIP MMDB database. DB-IP is the default - no account required. MaxMind requires a free account + license key. Use Custom URL to point at any other MMDB host (e.g. a local mirror)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2850
+#: src/muuli_wdr.cpp:2881
 msgid ""
 "No configuration required.\n"
 "\n"
@@ -4861,11 +4889,11 @@ msgid ""
 "License: Creative Commons BY 4.0 - https://creativecommons.org/licenses/by/4.0/"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2863
+#: src/muuli_wdr.cpp:2894
 msgid "License key:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2869
+#: src/muuli_wdr.cpp:2900
 msgid ""
 "Sign up for a free MaxMind account, then generate a License Key:\n"
 "https://www.maxmind.com/en/geolite2/signup\n"
@@ -4875,226 +4903,226 @@ msgid ""
 "Requires attribution and account registration; refresh at least every 30 days."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2884
+#: src/muuli_wdr.cpp:2915
 #, fuzzy
 msgid "Download URL:"
 msgstr "Download: "
 
-#: src/muuli_wdr.cpp:2890
+#: src/muuli_wdr.cpp:2921
 msgid ""
 "Must point to an .mmdb file or a .gz / .tar.gz containing one.\n"
 "URL may include credentials (https://user:pass@host/...).\n"
 "License and attribution terms are set by the upstream URL - you are responsible."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2903
+#: src/muuli_wdr.cpp:2934
 msgid "Download the GeoIP database from the selected source."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2905
+#: src/muuli_wdr.cpp:2936
 #, fuzzy
 msgid "Auto-update on startup"
 msgstr "Actualizar o filtro de IPs automaticamente no arranque"
 
-#: src/muuli_wdr.cpp:2906
+#: src/muuli_wdr.cpp:2937
 msgid "Re-download the GeoIP database from the selected source every time aMule starts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2929
+#: src/muuli_wdr.cpp:2960
 msgid "Filter incoming messages (except current chat):"
 msgstr "Filtrar mensagens recebidas (excepto da conversa corrente):"
 
-#: src/muuli_wdr.cpp:2931
+#: src/muuli_wdr.cpp:2962
 msgid "Filter all messages"
 msgstr "Filtrar todas as mensagens"
 
-#: src/muuli_wdr.cpp:2933
+#: src/muuli_wdr.cpp:2964
 msgid "Filter messages from people not on your friend list"
 msgstr "Filtrar mensagens de utilizadores que não pertençam à lista de amigos"
 
-#: src/muuli_wdr.cpp:2935
+#: src/muuli_wdr.cpp:2966
 msgid "Filter messages from unknown clients"
 msgstr "Filtrar mensagens de clientes desconhecidos"
 
-#: src/muuli_wdr.cpp:2937
+#: src/muuli_wdr.cpp:2968
 msgid "Filter messages containing (use ',' as separator):"
 msgstr "Filtrar mensagens que contenham (usar ',' como separador):"
 
-#: src/muuli_wdr.cpp:2940 src/muuli_wdr.cpp:2951
+#: src/muuli_wdr.cpp:2971 src/muuli_wdr.cpp:2982
 msgid "add here the words amule should filter and block messages including it"
 msgstr "adicione as palavras que o aMule deve filtrar e bloquear as mensagens que as contenham"
 
-#: src/muuli_wdr.cpp:2942
+#: src/muuli_wdr.cpp:2973
 msgid "Show received messages in the log"
 msgstr "Mostrar mensagens recebidas no relatório"
 
-#: src/muuli_wdr.cpp:2945
+#: src/muuli_wdr.cpp:2976
 msgid "Comments"
 msgstr "Comentários"
 
-#: src/muuli_wdr.cpp:2948
+#: src/muuli_wdr.cpp:2979
 msgid "Filter comments containing (use ',' as separator):"
 msgstr "Filtrar comentários que contenham (usar ',' como separador):"
 
-#: src/muuli_wdr.cpp:2973
+#: src/muuli_wdr.cpp:3004
 msgid "Enable Proxy"
 msgstr "Activar Proxy"
 
-#: src/muuli_wdr.cpp:2974
+#: src/muuli_wdr.cpp:3005
 msgid "Enable/disable proxy support"
 msgstr "Activar/desactivar o suporte de proxy"
 
-#: src/muuli_wdr.cpp:2977
+#: src/muuli_wdr.cpp:3008
 msgid "Proxy type:"
 msgstr "Tipo de proxy:"
 
-#: src/muuli_wdr.cpp:2988
+#: src/muuli_wdr.cpp:3019
 msgid "Proxy host:"
 msgstr "Servidor:"
 
-#: src/muuli_wdr.cpp:2991
+#: src/muuli_wdr.cpp:3022
 msgid "The proxy host name"
 msgstr "O nome da máquina proxy"
 
-#: src/muuli_wdr.cpp:2993
+#: src/muuli_wdr.cpp:3024
 msgid "Proxy port:"
 msgstr "Porto do proxy:"
 
-#: src/muuli_wdr.cpp:2996
+#: src/muuli_wdr.cpp:3027
 msgid "The proxy port"
 msgstr "O porto do proxy"
 
-#: src/muuli_wdr.cpp:2998
+#: src/muuli_wdr.cpp:3029
 msgid "Enable authentication"
 msgstr "Activar autenticação"
 
-#: src/muuli_wdr.cpp:2999
+#: src/muuli_wdr.cpp:3030
 msgid "Enable/disable username/password authentication"
 msgstr "Activar/desactivar autenticação utilizador/palavra-passe"
 
-#: src/muuli_wdr.cpp:3002
+#: src/muuli_wdr.cpp:3033
 msgid "Username: "
 msgstr "Utilizador: "
 
-#: src/muuli_wdr.cpp:3005
+#: src/muuli_wdr.cpp:3036
 msgid "The username to use to connect to the proxy"
 msgstr "O nome de utilizador para ligar ao proxy"
 
-#: src/muuli_wdr.cpp:3007
+#: src/muuli_wdr.cpp:3038
 msgid "Password:"
 msgstr "Palavra-passe:"
 
-#: src/muuli_wdr.cpp:3010
+#: src/muuli_wdr.cpp:3041
 msgid "The password to use to connect to the proxy"
 msgstr "A palavra-passe a usar para ligar ao proxy"
 
-#: src/muuli_wdr.cpp:3029
+#: src/muuli_wdr.cpp:3060
 msgid "Connect to:"
 msgstr "Ligar a:"
 
-#: src/muuli_wdr.cpp:3038
+#: src/muuli_wdr.cpp:3069
 msgid "Login to remote amule"
 msgstr "Autenticação remota"
 
-#: src/muuli_wdr.cpp:3043
+#: src/muuli_wdr.cpp:3074
 msgid "User name"
 msgstr "Nome de utilizador"
 
-#: src/muuli_wdr.cpp:3054
+#: src/muuli_wdr.cpp:3085
 msgid "Remember those settings"
 msgstr "Lembrar estas preferências"
 
-#: src/muuli_wdr.cpp:3057
+#: src/muuli_wdr.cpp:3088
 #, fuzzy
 msgid "Force ZLIB compression"
 msgstr "Usar compressão gzip"
 
-#: src/muuli_wdr.cpp:3081
+#: src/muuli_wdr.cpp:3112
 msgid "Enable Verbose Debug-Logging."
 msgstr "Activar Relatório detalhado para Depuração."
 
-#: src/muuli_wdr.cpp:3083
+#: src/muuli_wdr.cpp:3114
 #, fuzzy
 msgid "Only to Logfile"
 msgstr "&Abrir o ficheiro"
 
-#: src/muuli_wdr.cpp:3085
+#: src/muuli_wdr.cpp:3116
 msgid "Message Categories:"
 msgstr "Categorias de Mensagens:"
 
-#: src/muuli_wdr.cpp:3109 src/PartFileConvertDlg.cpp:160
+#: src/muuli_wdr.cpp:3140 src/PartFileConvertDlg.cpp:160
 msgid "Waiting..."
 msgstr "A aguardar..."
 
-#: src/muuli_wdr.cpp:3129
+#: src/muuli_wdr.cpp:3160
 msgid "Add imports"
 msgstr "Adicionar importações"
 
-#: src/muuli_wdr.cpp:3132
+#: src/muuli_wdr.cpp:3163
 msgid "Retry selected"
 msgstr "Reassumir seleccionados"
 
-#: src/muuli_wdr.cpp:3134
+#: src/muuli_wdr.cpp:3165
 msgid "Remove selected"
 msgstr "Remover seleccionados"
 
-#: src/muuli_wdr.cpp:3197
+#: src/muuli_wdr.cpp:3228
 msgid "Event Types"
 msgstr "Tipos de eventos"
 
-#: src/muuli_wdr.cpp:3216
+#: src/muuli_wdr.cpp:3247
 msgid "Statistics and queued clients for selected file(s) : Session / All time"
 msgstr "Estatísticas e clientes em espera para o(s) ficheiro(s) seleccionado(s) : Sessão / Desde sempre"
 
-#: src/muuli_wdr.cpp:3240
+#: src/muuli_wdr.cpp:3271
 msgid "Active Uploads"
 msgstr "Uploads Activos"
 
-#: src/muuli_wdr.cpp:3254
+#: src/muuli_wdr.cpp:3285
 msgid "Percent of total files"
 msgstr "Percentagem dos ficheiros totais"
 
-#: src/muuli_wdr.cpp:3306
+#: src/muuli_wdr.cpp:3337
 msgid "Show Clients for"
 msgstr "Mostrar Clientes para"
 
-#: src/muuli_wdr.cpp:3308
+#: src/muuli_wdr.cpp:3339
 msgid "All files"
 msgstr "Todos os ficheiros"
 
-#: src/muuli_wdr.cpp:3311
+#: src/muuli_wdr.cpp:3342
 msgid "Selected files"
 msgstr "Ficheiros seleccionados"
 
-#: src/muuli_wdr.cpp:3314
+#: src/muuli_wdr.cpp:3345
 msgid "Active uploads only"
 msgstr "Apenas os uploads activos"
 
-#: src/muuli_wdr.cpp:3321
+#: src/muuli_wdr.cpp:3352
 msgid "Reload:"
 msgstr "Recarregar:"
 
-#: src/muuli_wdr.cpp:3325
+#: src/muuli_wdr.cpp:3356
 msgid "Reload your shared files"
 msgstr "Recarregar os seus ficheiros partilhados"
 
-#: src/muuli_wdr.cpp:3388
+#: src/muuli_wdr.cpp:3419
 msgid "Send"
 msgstr "Enviar"
 
-#: src/muuli_wdr.cpp:3389
+#: src/muuli_wdr.cpp:3420
 msgid "Sends the specified message."
 msgstr "Envia a mensagem especificada."
 
-#: src/muuli_wdr.cpp:3393
+#: src/muuli_wdr.cpp:3424
 msgid "Close this chat-session."
 msgstr "Fechar esta conversa."
 
-#: src/muuli_wdr.cpp:3416
+#: src/muuli_wdr.cpp:3447
 msgid "Connect to any server and/or Kad"
 msgstr "Ligar a qualquer servidor e/ou Kad"
 
-#: src/muuli_wdr.cpp:3422 src/SharedFilesCtrl.cpp:142 src/Statistics.cpp:941
+#: src/muuli_wdr.cpp:3453 src/SharedFilesCtrl.cpp:142 src/Statistics.cpp:941
 msgid "Shared Files"
 msgstr "Ficheiros Partilhados"
 
@@ -5453,250 +5481,250 @@ msgstr "Transferido"
 msgid "ERROR: Failed to open partfile '%s'"
 msgstr "ERRO: Falhou ao abrir ficheiro de partes '%s'"
 
-#: src/Preferences.cpp:674
+#: src/Preferences.cpp:701
 msgid "System default"
 msgstr "Predefinição do sistema"
 
-#: src/Preferences.cpp:675
+#: src/Preferences.cpp:702
 msgid "Albanian"
 msgstr "Albanês"
 
-#: src/Preferences.cpp:676
+#: src/Preferences.cpp:703
 msgid "Arabic"
 msgstr "Árabe"
 
-#: src/Preferences.cpp:677
+#: src/Preferences.cpp:704
 msgid "Asturian"
 msgstr "Asturiano"
 
-#: src/Preferences.cpp:678
+#: src/Preferences.cpp:705
 msgid "Basque"
 msgstr "Basco"
 
-#: src/Preferences.cpp:679
+#: src/Preferences.cpp:706
 msgid "Bulgarian"
 msgstr "Búlgaro"
 
-#: src/Preferences.cpp:680
+#: src/Preferences.cpp:707
 msgid "Catalan"
 msgstr "Catalão"
 
-#: src/Preferences.cpp:681
+#: src/Preferences.cpp:708
 msgid "Chinese (Simplified)"
 msgstr "Chinês (Simplificado)"
 
-#: src/Preferences.cpp:682
+#: src/Preferences.cpp:709
 msgid "Chinese (Traditional)"
 msgstr "Chinês (Tradicional)"
 
-#: src/Preferences.cpp:683
+#: src/Preferences.cpp:710
 msgid "Croatian"
 msgstr "Croata"
 
-#: src/Preferences.cpp:684
+#: src/Preferences.cpp:711
 msgid "Czech"
 msgstr "Checo"
 
-#: src/Preferences.cpp:685
+#: src/Preferences.cpp:712
 msgid "Danish"
 msgstr "Dinamarquês"
 
-#: src/Preferences.cpp:686
+#: src/Preferences.cpp:713
 msgid "Dutch"
 msgstr "Holandês"
 
-#: src/Preferences.cpp:687
+#: src/Preferences.cpp:714
 msgid "English (U.K.)"
 msgstr "Inglês"
 
-#: src/Preferences.cpp:688
+#: src/Preferences.cpp:715
 #, fuzzy
 msgid "English (U.S.)"
 msgstr "Inglês"
 
-#: src/Preferences.cpp:689
+#: src/Preferences.cpp:716
 msgid "Estonian"
 msgstr "Estoniano"
 
-#: src/Preferences.cpp:690
+#: src/Preferences.cpp:717
 msgid "Finnish"
 msgstr "Finlandês"
 
-#: src/Preferences.cpp:691
+#: src/Preferences.cpp:718
 msgid "French"
 msgstr "Francês"
 
-#: src/Preferences.cpp:692
+#: src/Preferences.cpp:719
 msgid "Galician"
 msgstr "Galego"
 
-#: src/Preferences.cpp:693
+#: src/Preferences.cpp:720
 msgid "German"
 msgstr "Alemão"
 
-#: src/Preferences.cpp:694
+#: src/Preferences.cpp:721
 msgid "Greek"
 msgstr "Grego"
 
-#: src/Preferences.cpp:695
+#: src/Preferences.cpp:722
 msgid "Hebrew"
 msgstr "Hebreu"
 
-#: src/Preferences.cpp:696
+#: src/Preferences.cpp:723
 msgid "Hungarian"
 msgstr "Húngaro"
 
-#: src/Preferences.cpp:697
+#: src/Preferences.cpp:724
 msgid "Italian"
 msgstr "Italiano"
 
-#: src/Preferences.cpp:698
+#: src/Preferences.cpp:725
 msgid "Japanese"
 msgstr "Japonês"
 
-#: src/Preferences.cpp:699
+#: src/Preferences.cpp:726
 msgid "Korean"
 msgstr "Coreano"
 
-#: src/Preferences.cpp:700
+#: src/Preferences.cpp:727
 msgid "Latvian"
 msgstr ""
 
-#: src/Preferences.cpp:701
+#: src/Preferences.cpp:728
 msgid "Lithuanian"
 msgstr "Lituano"
 
-#: src/Preferences.cpp:702
+#: src/Preferences.cpp:729
 msgid "Norwegian (Nynorsk)"
 msgstr "Norueguês (Nynorsk)"
 
-#: src/Preferences.cpp:703
+#: src/Preferences.cpp:730
 msgid "Polish"
 msgstr "Polaco"
 
-#: src/Preferences.cpp:704
+#: src/Preferences.cpp:731
 msgid "Portuguese"
 msgstr "Português"
 
-#: src/Preferences.cpp:705
+#: src/Preferences.cpp:732
 msgid "Portuguese (Brazilian)"
 msgstr "Português (Brasil)"
 
-#: src/Preferences.cpp:706
+#: src/Preferences.cpp:733
 msgid "Romanian"
 msgstr "Romeno"
 
-#: src/Preferences.cpp:707
+#: src/Preferences.cpp:734
 msgid "Russian"
 msgstr "Russo"
 
-#: src/Preferences.cpp:708
+#: src/Preferences.cpp:735
 msgid "Slovenian"
 msgstr "Esloveno"
 
-#: src/Preferences.cpp:709
+#: src/Preferences.cpp:736
 msgid "Spanish"
 msgstr "Espanhol"
 
-#: src/Preferences.cpp:710
+#: src/Preferences.cpp:737
 msgid "Swedish"
 msgstr "Sueco"
 
-#: src/Preferences.cpp:711
+#: src/Preferences.cpp:738
 msgid "Turkish"
 msgstr "Turco"
 
-#: src/Preferences.cpp:712
+#: src/Preferences.cpp:739
 msgid "Ukrainian"
 msgstr "Ucraniano"
 
-#: src/Preferences.cpp:815
+#: src/Preferences.cpp:842
 msgid "Change Language"
 msgstr "Alterar Idioma"
 
-#: src/Preferences.cpp:879
+#: src/Preferences.cpp:906
 msgid "There are no translations installed for aMule"
 msgstr ""
 
-#: src/Preferences.cpp:880
+#: src/Preferences.cpp:907
 #, fuzzy
 msgid "No languages available"
 msgstr "Indisponível"
 
-#: src/Preferences.cpp:1011
+#: src/Preferences.cpp:1038
 msgid "no options available"
 msgstr "sem opções disponíveis"
 
-#: src/Preferences.cpp:2182
+#: src/Preferences.cpp:2227
 msgid "Invalid category found, skipping"
 msgstr "Categoria inválida encontrada, a ignorar"
 
-#: src/Preferences.cpp:2351
+#: src/Preferences.cpp:2396
 msgid "TCP port can't be higher than 65532 due to server UDP socket being TCP+3"
 msgstr "O porto TCP não pode ser superior a 65532 porque o socket UDP do servidor tem de ser TCP+3"
 
-#: src/Preferences.cpp:2352
+#: src/Preferences.cpp:2397
 #, c-format
 msgid "Default port will be used (%d)"
 msgstr "O porto predefinido será usado (%d)"
 
-#: src/PrefsUnifiedDlg.cpp:298 src/Statistics.cpp:866
+#: src/PrefsUnifiedDlg.cpp:300 src/Statistics.cpp:866
 msgid "Connection"
 msgstr "Ligação"
 
-#: src/PrefsUnifiedDlg.cpp:299 src/SearchListCtrl.cpp:117
+#: src/PrefsUnifiedDlg.cpp:301 src/SearchListCtrl.cpp:117
 msgid "Directories"
 msgstr "Directórios"
 
-#: src/PrefsUnifiedDlg.cpp:300 src/Statistics.cpp:917
+#: src/PrefsUnifiedDlg.cpp:302 src/Statistics.cpp:917
 msgid "Servers"
 msgstr "Servidores"
 
-#: src/PrefsUnifiedDlg.cpp:301 src/ServerListCtrl.cpp:96
+#: src/PrefsUnifiedDlg.cpp:303 src/ServerListCtrl.cpp:96
 msgid "Files"
 msgstr "Ficheiros"
 
-#: src/PrefsUnifiedDlg.cpp:302
+#: src/PrefsUnifiedDlg.cpp:304
 msgid "Security"
 msgstr "Segurança"
 
-#: src/PrefsUnifiedDlg.cpp:303
+#: src/PrefsUnifiedDlg.cpp:305
 msgid "Interface"
 msgstr "Interface"
 
-#: src/PrefsUnifiedDlg.cpp:310
+#: src/PrefsUnifiedDlg.cpp:312
 msgid "IP2Country"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:313
+#: src/PrefsUnifiedDlg.cpp:315
 msgid "Proxy"
 msgstr "Proxy"
 
-#: src/PrefsUnifiedDlg.cpp:314
+#: src/PrefsUnifiedDlg.cpp:316
 msgid "Filters"
 msgstr "Filtros"
 
-#: src/PrefsUnifiedDlg.cpp:315
+#: src/PrefsUnifiedDlg.cpp:317
 msgid "Remote Controls"
 msgstr "Controlos remotos"
 
-#: src/PrefsUnifiedDlg.cpp:316
+#: src/PrefsUnifiedDlg.cpp:318
 msgid "Online Signature"
 msgstr "Assinatura Online"
 
-#: src/PrefsUnifiedDlg.cpp:317
+#: src/PrefsUnifiedDlg.cpp:319
 msgid "Advanced"
 msgstr "Avançado"
 
-#: src/PrefsUnifiedDlg.cpp:318
+#: src/PrefsUnifiedDlg.cpp:320
 msgid "Events"
 msgstr "Eventos"
 
-#: src/PrefsUnifiedDlg.cpp:321
+#: src/PrefsUnifiedDlg.cpp:323
 msgid "Debugging"
 msgstr "Depuração"
 
-#: src/PrefsUnifiedDlg.cpp:451
+#: src/PrefsUnifiedDlg.cpp:453
 msgid ""
 "The following variables will be substituted:\n"
 "    %PARTFILE - full path to the file\n"
@@ -5706,15 +5734,15 @@ msgstr ""
 "    %PARTFILE - caminho completo do ficheiro\n"
 "    %PARTNAME - apenas o nome do ficheiro"
 
-#: src/PrefsUnifiedDlg.cpp:472
+#: src/PrefsUnifiedDlg.cpp:474
 msgid "Tray icon support requires libayatana-appindicator3 at compile time."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:488
+#: src/PrefsUnifiedDlg.cpp:490
 msgid "Not available on Wayland: the protocol does not report when a window is minimized, so this option cannot intercept the system minimize button. Workaround: launch aMule with `GDK_BACKEND=x11` to use XWayland instead."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:534
+#: src/PrefsUnifiedDlg.cpp:536
 msgid ""
 "Do not change these setting unless you know\n"
 "what you are doing, otherwise you can easily\n"
@@ -5730,26 +5758,35 @@ msgstr ""
 "O aMule correrá perfeitamente sem ajustar qualquer\n"
 "uma destas opções."
 
-#: src/PrefsUnifiedDlg.cpp:645
+#: src/PrefsUnifiedDlg.cpp:647
 #, c-format
 msgid "Failed to connect Cfg to widget with the ID %d and key %s"
 msgstr "Falhou ao ligar Cfg ao widget com o ID %d e chave %s"
 
-#: src/PrefsUnifiedDlg.cpp:693
+#: src/PrefsUnifiedDlg.cpp:695
 #, c-format
 msgid "Failed to transfer data from Cfg to Widget with the ID %d and key %s"
 msgstr "Falhou ao transferir dados do Cfg para o Widget com o ID %d e chave %s"
 
-#: src/PrefsUnifiedDlg.cpp:799
+#: src/PrefsUnifiedDlg.cpp:801
 msgid "The type of proxy you are connecting to"
 msgstr "O tipo de proxy ao qual está a ligar-se"
 
-#: src/PrefsUnifiedDlg.cpp:1003
+#: src/PrefsUnifiedDlg.cpp:1020
 #, c-format
 msgid "Failed to transfer data from Widget to Cfg with the ID %d and key %s"
 msgstr "Falhou ao transferir dados do Widget para o Cfg com o ID %d e chave %s"
 
 #: src/PrefsUnifiedDlg.cpp:1103
+#, fuzzy
+msgid "No password set."
+msgstr "A verificar a palavra-passe\n"
+
+#: src/PrefsUnifiedDlg.cpp:1132
+msgid "Guest access needs a password. Type one in the guest password field, or untick Enable guest access."
+msgstr ""
+
+#: src/PrefsUnifiedDlg.cpp:1144
 msgid ""
 "aMule must be restarted to enable these changes:\n"
 "\n"
@@ -5757,42 +5794,42 @@ msgstr ""
 "O aMule tem de ser reiniciado para activar estas alterações:\n"
 "\n"
 
-#: src/PrefsUnifiedDlg.cpp:1110
+#: src/PrefsUnifiedDlg.cpp:1151
 msgid "- TCP port changed.\n"
 msgstr "- Porto TCP alterado.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1115
+#: src/PrefsUnifiedDlg.cpp:1156
 msgid "- UDP port changed.\n"
 msgstr "- Porto UDP alterado.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1120
+#: src/PrefsUnifiedDlg.cpp:1161
 #, fuzzy
 msgid "- Network interface binding changed.\n"
 msgstr "- Alterada interface para ligações externas.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1125
+#: src/PrefsUnifiedDlg.cpp:1166
 msgid "- External connect port changed.\n"
 msgstr "- Porta para ligações externas alterada.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1129
+#: src/PrefsUnifiedDlg.cpp:1170
 msgid "- External connect acceptance changed.\n"
 msgstr "- Alterada a aceitação de ligações externas.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1133
+#: src/PrefsUnifiedDlg.cpp:1174
 msgid "- External connect interface changed.\n"
 msgstr "- Alterada interface para ligações externas.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1137
+#: src/PrefsUnifiedDlg.cpp:1178
 #, fuzzy
 msgid "- Protocol obfuscation support changed.\n"
 msgstr "Ofuscação do Protocolo"
 
-#: src/PrefsUnifiedDlg.cpp:1151
+#: src/PrefsUnifiedDlg.cpp:1193
 #, fuzzy
 msgid "- amuleapi settings changed.\n"
 msgstr "- O idioma foi alterado.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1160
+#: src/PrefsUnifiedDlg.cpp:1202
 msgid ""
 "Your Auto-update server list is empty.\n"
 "'Auto-update server list at startup' will be disabled."
@@ -5800,7 +5837,7 @@ msgstr ""
 "A sua lista de actualização automática de servidores está vazia.\n"
 "A 'actualização automática no arranque' será desactivada."
 
-#: src/PrefsUnifiedDlg.cpp:1171
+#: src/PrefsUnifiedDlg.cpp:1213
 msgid ""
 "You have enabled external connections but have not specified a password.\n"
 "External connections cannot be enabled unless a valid password is specified."
@@ -5808,28 +5845,33 @@ msgstr ""
 "Activou as ligações externas mas não especificou uma palavra-passe.\n"
 "As ligações externas não podem ser activadas a menos que seja especificada uma palavra-passe válida."
 
-#: src/PrefsUnifiedDlg.cpp:1202
+#: src/PrefsUnifiedDlg.cpp:1246
+#, c-format
+msgid "The amuleapi password could not be saved: %s"
+msgstr ""
+
+#: src/PrefsUnifiedDlg.cpp:1276
 msgid "- Language changed.\n"
 msgstr "- O idioma foi alterado.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1207
+#: src/PrefsUnifiedDlg.cpp:1281
 msgid "- Temp folder changed.\n"
 msgstr "- A pasta Temp foi alterada.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1212
+#: src/PrefsUnifiedDlg.cpp:1286
 msgid "- ED2K network enabled.\n"
 msgstr "- Rede ED2K activada.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1245
+#: src/PrefsUnifiedDlg.cpp:1319
 msgid "The shared-file exclusion pattern is not a valid regular expression. The filter has been left disabled."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1247 src/PrefsUnifiedDlg.cpp:1841
+#: src/PrefsUnifiedDlg.cpp:1321 src/PrefsUnifiedDlg.cpp:1921
 #, fuzzy
 msgid "Invalid regular expression"
 msgstr "Versão de protocolo inválida."
 
-#: src/PrefsUnifiedDlg.cpp:1324
+#: src/PrefsUnifiedDlg.cpp:1398
 msgid ""
 "Both eD2k and Kad network are disabled.\n"
 "You won't be able to connect until you enable at least one of them."
@@ -5837,7 +5879,7 @@ msgstr ""
 "As redes eD2K e Kad estão desactivados.\n"
 "Não vai conseguir uma ligação até activar pelo menos uma deles."
 
-#: src/PrefsUnifiedDlg.cpp:1329
+#: src/PrefsUnifiedDlg.cpp:1403
 msgid ""
 "Kad will not start if your UDP port is disabled.\n"
 "Enable UDP port or disable Kad."
@@ -5845,7 +5887,7 @@ msgstr ""
 "A Kad não vai funcionar se o porto UDP estiver desactivado.\n"
 "Active o porto UDP ou desactive a Kad."
 
-#: src/PrefsUnifiedDlg.cpp:1385
+#: src/PrefsUnifiedDlg.cpp:1459
 msgid ""
 "\n"
 "You MUST restart aMule now.\n"
@@ -5855,69 +5897,69 @@ msgstr ""
 "DEVE reiniciar o aMule agora.\n"
 "Se não o fizer, não se queixe se algo grave acontecer.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1450
+#: src/PrefsUnifiedDlg.cpp:1524
 msgid "Could not register aMule for autostart at login. The autostart store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1452
+#: src/PrefsUnifiedDlg.cpp:1526
 msgid "Could not remove the autostart-at-login entry."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1453
+#: src/PrefsUnifiedDlg.cpp:1527
 #, fuzzy
 msgid "Autostart"
 msgstr "Actualização automática iniciada"
 
-#: src/PrefsUnifiedDlg.cpp:1468
+#: src/PrefsUnifiedDlg.cpp:1542
 msgid "Register file type"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1468
+#: src/PrefsUnifiedDlg.cpp:1542
 msgid "Register URL handler"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1476
+#: src/PrefsUnifiedDlg.cpp:1550
 #, c-format
 msgid "aMule only handles eD2k-compatible magnets. If you replace the current magnet handler (%s), BitTorrent magnet links will stop working - aMule cannot download BitTorrent content. Continue?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1481
+#: src/PrefsUnifiedDlg.cpp:1555
 #, c-format
 msgid "Another application currently opens .emulecollection files (%s). Replace it with aMule?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1486
+#: src/PrefsUnifiedDlg.cpp:1560
 #, c-format
 msgid "Another application is currently the default handler for these links (%s). Replace it with aMule?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1511
+#: src/PrefsUnifiedDlg.cpp:1585
 msgid "Could not register aMule for .emulecollection files. The registration store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1513
+#: src/PrefsUnifiedDlg.cpp:1587
 #, fuzzy
 msgid "Could not remove the file type registration."
 msgstr "Pasta para ficheiros temporários"
 
-#: src/PrefsUnifiedDlg.cpp:1515
+#: src/PrefsUnifiedDlg.cpp:1589
 msgid "Could not register aMule as the URL handler. The registration store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1517
+#: src/PrefsUnifiedDlg.cpp:1591
 msgid "Could not remove the URL handler registration."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1587 src/PrefsUnifiedDlg.cpp:1614
+#: src/PrefsUnifiedDlg.cpp:1661 src/PrefsUnifiedDlg.cpp:1688
 #, fuzzy
 msgid "The web server and aMule API require external connections to be enabled."
 msgstr "Palavra-passe definida e permitidas as ligações externas."
 
-#: src/PrefsUnifiedDlg.cpp:1597
+#: src/PrefsUnifiedDlg.cpp:1671
 msgid "The aMule web server is deprecated. Consider running the aMule API instead."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1655
+#: src/PrefsUnifiedDlg.cpp:1735
 msgid ""
 "Your Auto-update servers list is in blank.\n"
 "Please fill in at least one URL to point to a valid server.met file.\n"
@@ -5927,66 +5969,66 @@ msgstr ""
 "Por favor, indique pelo menos uma localização que aponte para um ficheiro server.met válido.\n"
 "Clique no botão \"Lista\" para inserir uma localização."
 
-#: src/PrefsUnifiedDlg.cpp:1796
+#: src/PrefsUnifiedDlg.cpp:1876
 msgid "Temporary files"
 msgstr "Ficheiros temporários"
 
-#: src/PrefsUnifiedDlg.cpp:1801
+#: src/PrefsUnifiedDlg.cpp:1881
 msgid "Incoming files"
 msgstr "Ficheiros recebidos"
 
-#: src/PrefsUnifiedDlg.cpp:1806
+#: src/PrefsUnifiedDlg.cpp:1886
 msgid "Online Signatures"
 msgstr "Assinaturas Online"
 
-#: src/PrefsUnifiedDlg.cpp:1819
+#: src/PrefsUnifiedDlg.cpp:1899
 #, c-format
 msgid "Choose a folder for %s"
 msgstr "Seleccione uma pasta para %s"
 
-#: src/PrefsUnifiedDlg.cpp:1843
+#: src/PrefsUnifiedDlg.cpp:1923
 #, fuzzy, c-format
 msgid "Would exclude %u of %u shared file"
 msgid_plural "Would exclude %u of %u shared files"
 msgstr[0] "Encontrado %i ficheiro partilhado conhecido"
 msgstr[1] "Encontrados %i ficheiros partilhados conhecidos"
 
-#: src/PrefsUnifiedDlg.cpp:1860
+#: src/PrefsUnifiedDlg.cpp:1940
 msgid "Browse for videoplayer"
 msgstr "Procurar leitor de vídeo"
 
-#: src/PrefsUnifiedDlg.cpp:1864
+#: src/PrefsUnifiedDlg.cpp:1944
 msgid "Select browser"
 msgstr "Seleccionar navegador"
 
-#: src/PrefsUnifiedDlg.cpp:1868
+#: src/PrefsUnifiedDlg.cpp:1948
 #, fuzzy
 msgid "Select ffprobe binary"
 msgstr "Seleccionar navegador"
 
-#: src/PrefsUnifiedDlg.cpp:1874
+#: src/PrefsUnifiedDlg.cpp:1954
 #, c-format
 msgid "Executable%s"
 msgstr "Executável%s"
 
-#: src/PrefsUnifiedDlg.cpp:1908
+#: src/PrefsUnifiedDlg.cpp:1988
 msgid "ffprobe not found on PATH or in the standard install locations. Install ffmpeg (which ships ffprobe) or use Browse to pick a binary manually."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1920
+#: src/PrefsUnifiedDlg.cpp:2000
 msgid "Reset the settings on this page to their default values?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1921
+#: src/PrefsUnifiedDlg.cpp:2001
 #, fuzzy
 msgid "Reset to defaults"
 msgstr "Predefinição do sistema"
 
-#: src/PrefsUnifiedDlg.cpp:1948
+#: src/PrefsUnifiedDlg.cpp:2028
 msgid "Edit server list"
 msgstr "Editar a lista de servidores"
 
-#: src/PrefsUnifiedDlg.cpp:1949
+#: src/PrefsUnifiedDlg.cpp:2029
 msgid ""
 "Add here URL's to download server.met files.\n"
 "Only one url on each line."
@@ -5994,154 +6036,154 @@ msgstr ""
 "Adicione localizações para obter ficheiros server.met\n"
 "Apenas uma localização por linha."
 
-#: src/PrefsUnifiedDlg.cpp:2004
+#: src/PrefsUnifiedDlg.cpp:2084
 msgid "IP2Country update failed"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2149 src/PrefsUnifiedDlg.cpp:2180
+#: src/PrefsUnifiedDlg.cpp:2229 src/PrefsUnifiedDlg.cpp:2260
 msgid "Data by MaxMind GeoLite2"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2151 src/PrefsUnifiedDlg.cpp:2182
+#: src/PrefsUnifiedDlg.cpp:2231 src/PrefsUnifiedDlg.cpp:2262
 #, fuzzy
 msgid "Custom source"
 msgstr "Fontes completas"
 
-#: src/PrefsUnifiedDlg.cpp:2153 src/PrefsUnifiedDlg.cpp:2184
+#: src/PrefsUnifiedDlg.cpp:2233 src/PrefsUnifiedDlg.cpp:2264
 msgid "Data by DB-IP.com"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2204
+#: src/PrefsUnifiedDlg.cpp:2284
 #, fuzzy, c-format
 msgid "Status: Loaded%s"
 msgstr "Estado:"
 
-#: src/PrefsUnifiedDlg.cpp:2206
+#: src/PrefsUnifiedDlg.cpp:2286
 #, fuzzy, c-format
 msgid "Status: Loaded%s - %s"
 msgstr "Estado:"
 
-#: src/PrefsUnifiedDlg.cpp:2210
+#: src/PrefsUnifiedDlg.cpp:2290
 msgid "Status: Failed to load - click 'Update now' to refresh."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2212
+#: src/PrefsUnifiedDlg.cpp:2292
 msgid "Status: Not found - click 'Update now' to download."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2270 src/PrefsUnifiedDlg.cpp:2294
+#: src/PrefsUnifiedDlg.cpp:2350 src/PrefsUnifiedDlg.cpp:2374
 #, c-format
 msgid "Update delay: %d second"
 msgid_plural "Update delay: %d seconds"
 msgstr[0] "Intervalo de actualização: %d segundo"
 msgstr[1] "Intervalo de actualização: %d segundos"
 
-#: src/PrefsUnifiedDlg.cpp:2278
+#: src/PrefsUnifiedDlg.cpp:2358
 #, c-format
 msgid "Time for average graph: %d minute"
 msgid_plural "Time for average graph: %d minutes"
 msgstr[0] "Tempo para o gráfico de média: %d minuto"
 msgstr[1] "Tempo para o gráfico de média: %d minutos"
 
-#: src/PrefsUnifiedDlg.cpp:2287
+#: src/PrefsUnifiedDlg.cpp:2367
 #, c-format
 msgid "Connections Graph Scale: %d"
 msgstr "Escala do Gráfico de Ligações: %d"
 
-#: src/PrefsUnifiedDlg.cpp:2302
+#: src/PrefsUnifiedDlg.cpp:2382
 #, c-format
 msgid "File Buffer Size: %d byte"
 msgid_plural "File Buffer Size: %d bytes"
 msgstr[0] "Tamanho de memória temporária de ficheiros: %d byte"
 msgstr[1] "Tamanho de memória temporária de ficheiros: %d bytes"
 
-#: src/PrefsUnifiedDlg.cpp:2312
+#: src/PrefsUnifiedDlg.cpp:2392
 #, c-format
 msgid "Upload Queue Size: %d client"
 msgid_plural "Upload Queue Size: %d clients"
 msgstr[0] "Tamanho da fila de espera de upload: %d cliente"
 msgstr[1] "Tamanho da fila de espera de upload: %d clientes"
 
-#: src/PrefsUnifiedDlg.cpp:2322
+#: src/PrefsUnifiedDlg.cpp:2402
 #, c-format
 msgid "Server connection refresh interval: %d minute"
 msgid_plural "Server connection refresh interval: %d minutes"
 msgstr[0] "Intervalo de actualização de ligação ao servidor: %d minuto"
 msgstr[1] "Intervalo de actualização de ligação ao servidor: %d minutos"
 
-#: src/PrefsUnifiedDlg.cpp:2327
+#: src/PrefsUnifiedDlg.cpp:2407
 msgid "Server connection refresh interval: Disabled"
 msgstr "Intervalo de actualização de ligação ao servidor: Desactivado"
 
-#: src/PrefsUnifiedDlg.cpp:2371
+#: src/PrefsUnifiedDlg.cpp:2451
 msgid "disabled"
 msgstr "desactivado"
 
-#: src/PrefsUnifiedDlg.cpp:2397
+#: src/PrefsUnifiedDlg.cpp:2477
 #, c-format
 msgid "Execute command on '%s' event"
 msgstr "Executar o comando quando ocorrer o evento '%s'"
 
-#: src/PrefsUnifiedDlg.cpp:2404
+#: src/PrefsUnifiedDlg.cpp:2484
 msgid "Enable command execution on core"
 msgstr "Activar execução de comandos no núcleo"
 
-#: src/PrefsUnifiedDlg.cpp:2416
+#: src/PrefsUnifiedDlg.cpp:2496
 msgid "Core command:"
 msgstr "Comando de núcleo:"
 
-#: src/PrefsUnifiedDlg.cpp:2432
+#: src/PrefsUnifiedDlg.cpp:2512
 msgid "Enable command execution on GUI"
 msgstr "Activar execução de comando na interface gráfica"
 
-#: src/PrefsUnifiedDlg.cpp:2444
+#: src/PrefsUnifiedDlg.cpp:2524
 msgid "GUI command:"
 msgstr "Comando da interface gráfica:"
 
-#: src/PrefsUnifiedDlg.cpp:2460
+#: src/PrefsUnifiedDlg.cpp:2540
 msgid "The following variables will be replaced:"
 msgstr "As seguintes variáveis serão substituídas:"
 
-#: src/PrefsUnifiedDlg.cpp:2628
+#: src/PrefsUnifiedDlg.cpp:2708
 msgid ""
 "The following folders look like system or sensitive locations:\n"
 "\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2633
+#: src/PrefsUnifiedDlg.cpp:2713
 msgid "Sharing them recursively will publish every file underneath on the eD2k/Kad networks. Do you really want to do this?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2636
+#: src/PrefsUnifiedDlg.cpp:2716
 #, fuzzy
 msgid "Confirm shared folders"
 msgstr "Pastas partilhadas"
 
-#: src/PrefsUnifiedDlg.cpp:2664
+#: src/PrefsUnifiedDlg.cpp:2744
 #, fuzzy
 msgid "Reloading shared files..."
 msgstr "Recarregar os seus ficheiros partilhados"
 
-#: src/PrefsUnifiedDlg.cpp:2665
+#: src/PrefsUnifiedDlg.cpp:2745
 msgid "Scanning for subdirectories..."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2666
+#: src/PrefsUnifiedDlg.cpp:2746
 #, fuzzy
 msgid "Updating shared folders"
 msgstr "Pastas partilhadas"
 
-#: src/PrefsUnifiedDlg.cpp:2693
+#: src/PrefsUnifiedDlg.cpp:2773
 #, c-format
 msgid "Scanned %u directories..."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2743
+#: src/PrefsUnifiedDlg.cpp:2823
 #, fuzzy, c-format
 msgid "Reloading shared files: %u files scanned"
 msgstr "Recarrega a lista de ficheiros partilhados."
 
-#: src/PrefsUnifiedDlg.cpp:2793
+#: src/PrefsUnifiedDlg.cpp:2873
 #, fuzzy
 msgid "Shared folder"
 msgstr "Pastas partilhadas"

--- a/po/ro.po
+++ b/po/ro.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-28 10:19+0200\n"
+"POT-Creation-Date: 2026-07-28 12:17+0200\n"
 "PO-Revision-Date: 2026-07-27 11:44+0000\n"
 "Last-Translator: Angelescu Constantin <titus0818@yahoo.com>\n"
 "Language-Team: English <kde-i18n-doc@kde.org>\n"
@@ -202,83 +202,83 @@ msgstr "A eșuat deschiderea fișierului legătură eD2k."
 msgid "WARNING: You can't add yourself as a source for an eD2k link while having a lowid."
 msgstr "ATENȚIE: Nu vă puteți adăuga ca sursă pentru o legătură eD2k cât timp aveți lowid."
 
-#: src/amule.cpp:300
+#: src/amule.cpp:301
 msgid "Now, exiting main app..."
 msgstr "Acum, se oprește aplicația principală..."
 
-#: src/amule.cpp:330
+#: src/amule.cpp:331
 #, c-format
 msgid "Terminating amuleweb instance with pid '%d' ... "
 msgstr "Se termină instanța amuleweb cu pid '%d' ... "
 
-#: src/amule.cpp:334
+#: src/amule.cpp:335
 #, c-format
 msgid "Killing amuleweb instance with pid '%d' ... "
 msgstr "Se omoară instanța amuleweb cu pid '%d' ... "
 
-#: src/amule.cpp:336 src/amule.cpp:349 src/ClientRef.cpp:180
+#: src/amule.cpp:337 src/amule.cpp:350 src/ClientRef.cpp:180
 #: src/SearchDlg.cpp:1041 src/ServerListCtrl.cpp:98
 msgid "Failed"
 msgstr "Eșuat"
 
-#: src/amule.cpp:343
+#: src/amule.cpp:344
 #, fuzzy, c-format
 msgid "Terminating amuleapi instance with pid '%d' ... "
 msgstr "Se termină instanța amuleweb cu pid '%d' ... "
 
-#: src/amule.cpp:347
+#: src/amule.cpp:348
 #, fuzzy, c-format
 msgid "Killing amuleapi instance with pid '%d' ... "
 msgstr "Se omoară instanța amuleweb cu pid '%d' ... "
 
-#: src/amule.cpp:355
+#: src/amule.cpp:356
 msgid "aMule OnExit: Terminating core."
 msgstr "aMule la ieșire: Se închide nucleul."
 
-#: src/amule.cpp:466
+#: src/amule.cpp:467
 msgid "aMule shutdown completed."
 msgstr "aMule închidere terminată."
 
-#: src/amule.cpp:470
+#: src/amule.cpp:471
 msgid "Memory debug results for aMule exit:"
 msgstr "Rezultatele depanării memoriei pentru ieșirea aMule:"
 
-#: src/amule.cpp:651
+#: src/amule.cpp:652
 #, c-format
 msgid "Binding aMule's peer-to-peer traffic to interface: %s (HTTP updates use the default route)"
 msgstr ""
 
-#: src/amule.cpp:655
+#: src/amule.cpp:656
 #, c-format
 msgid "Binding all network traffic to interface: %s"
 msgstr ""
 
-#: src/amule.cpp:659
+#: src/amule.cpp:660
 #, c-format
 msgid "WARNING: configured network interface '%s' was not found - traffic is NOT bound to it and may leave via the default route. Check the interface name in Preferences."
 msgstr ""
 
-#: src/amule.cpp:665
+#: src/amule.cpp:666
 #, c-format
 msgid "WARNING: binding to network interface '%s' requires elevated privileges and was NOT applied - traffic may leave via the default route. Grant the capability (e.g. 'sudo setcap cap_net_raw+ep' on the aMule binary) or run with sufficient privileges."
 msgstr ""
 
-#: src/amule.cpp:673
+#: src/amule.cpp:674
 #, c-format
 msgid "WARNING: could not bind to network interface '%s' - traffic may leave via the default route."
 msgstr ""
 
-#: src/amule.cpp:732
+#: src/amule.cpp:733
 msgid "Your locale has been changed to System Default due to a configuration change. Sorry."
 msgstr "Limba dumneavoastră a fost schimbată la cea implicită a sistemului datorită schimbării configurației. Regretăm."
 
-#: src/amule.cpp:734 src/amule.cpp:1581 src/CatDialog.cpp:128
+#: src/amule.cpp:735 src/amule.cpp:1589 src/CatDialog.cpp:128
 #: src/CatDialog.cpp:136 src/CatDialog.cpp:149 src/ServerList.cpp:366
 #: src/ServerListCtrl.cpp:152
 msgid "Info"
 msgstr "Info"
 
-#: src/amule.cpp:741
+#: src/amule.cpp:742
 msgid ""
 "\n"
 "EC configuration"
@@ -286,74 +286,74 @@ msgstr ""
 "\n"
 "configurație EC"
 
-#: src/amule.cpp:744
+#: src/amule.cpp:745
 msgid "Password set and external connections enabled."
 msgstr "Configurarea parolei și conexiunile externe sunt activate."
 
-#: src/amule.cpp:754 src/KadDlg.cpp:176 src/KadDlg.cpp:185
-#: src/PrefsUnifiedDlg.cpp:1387 src/SharedFilesCtrl.cpp:476
+#: src/amule.cpp:755 src/KadDlg.cpp:176 src/KadDlg.cpp:185
+#: src/PrefsUnifiedDlg.cpp:1461 src/SharedFilesCtrl.cpp:476
 msgid "WARNING"
 msgstr "ATENȚIE"
 
-#: src/amule.cpp:991
+#: src/amule.cpp:992
 #, fuzzy
 msgid "Network bootstrap"
 msgstr "Rețele"
 
-#: src/amule.cpp:996
+#: src/amule.cpp:997
 msgid ""
 "aMule has detected missing network bootstrap files.\n"
 "Select which ones to download:"
 msgstr ""
 
-#: src/amule.cpp:1005 src/FirstRunWizard.cpp:411
+#: src/amule.cpp:1006 src/FirstRunWizard.cpp:411
 #, fuzzy
 msgid "eD2k server list (server.met)"
 msgstr "S-a găsit %i server în server.met"
 
-#: src/amule.cpp:1012 src/FirstRunWizard.cpp:416
+#: src/amule.cpp:1013 src/FirstRunWizard.cpp:416
 msgid "Kad bootstrap nodes (nodes.dat)"
 msgstr ""
 
-#: src/amule.cpp:1102
+#: src/amule.cpp:1103
 #, c-format
 msgid "web server running on pid %d"
 msgstr "server web rulând pe pid %d"
 
-#: src/amule.cpp:1115
+#: src/amule.cpp:1116
 #, fuzzy
 msgid "You requested to run web server on startup, but the amuleweb binary cannot be run. Please install the package containing aMule web server, or build aMule from source with -DBUILD_WEBSERVER=YES and install it."
 msgstr "Ați solicitat să ruleze la pornire serverul web, dar fișierul binar amuleweb nu poate fi rulat. Instalați pachetul care conține serverul web aMule, sau compilați aMule utilizând --enable-webserver și apoi rulați make install"
 
-#: src/amule.cpp:1120 src/amule.cpp:1177 src/amule.cpp:1291 src/amule.cpp:1593
+#: src/amule.cpp:1121 src/amule.cpp:1185 src/amule.cpp:1299 src/amule.cpp:1601
 #: src/amule-remote-gui.cpp:603 src/amule-remote-gui.cpp:671
 #: src/amule-remote-gui.cpp:709 src/amule-remote-gui.cpp:1282
 #: src/amule-remote-gui.cpp:1345 src/amule-remote-gui.cpp:1372
-#: src/DownloadQueue.cpp:1481
+#: src/DownloadQueue.cpp:1481 src/PrefsUnifiedDlg.cpp:1247
 msgid "ERROR"
 msgstr "EROARE"
 
-#: src/amule.cpp:1166
+#: src/amule.cpp:1174
 #, fuzzy, c-format
 msgid "amuleapi running on pid %d"
 msgstr "server web rulând pe pid %d"
 
-#: src/amule.cpp:1172
+#: src/amule.cpp:1180
 #, fuzzy
 msgid "You requested to run amuleapi on startup, but the amuleapi binary cannot be run. Please install the package containing aMule's REST API server, or build aMule from source with -DBUILD_AMULEAPI=YES and install it."
 msgstr "Ați solicitat să ruleze la pornire serverul web, dar fișierul binar amuleweb nu poate fi rulat. Instalați pachetul care conține serverul web aMule, sau compilați aMule utilizând --enable-webserver și apoi rulați make install"
 
-#: src/amule.cpp:1259
+#: src/amule.cpp:1267
 #, c-format
 msgid "Could not bind ports to the specified address: %s"
 msgstr "Nu se pot lega porturile la adresa specificată: %s"
 
-#: src/amule.cpp:1283
+#: src/amule.cpp:1291
 #, c-format
 msgid "Port %u is not available. You will be LOWID\n"
 msgstr "Portul %u nu este disponibil. Veți fi LOWID\n"
 
-#: src/amule.cpp:1288
+#: src/amule.cpp:1296
 #, c-format
 msgid ""
 "Port %u is not available!\n"
@@ -368,48 +368,48 @@ msgstr ""
 "\n"
 "Verificați rețeaua pentru a vă asigura că portul este deschis pentru intrare și ieșire."
 
-#: src/amule.cpp:1385
+#: src/amule.cpp:1393
 msgid "Failed to create OnlineSig File"
 msgstr "A eșuat crearea fișierului Semnătură Online"
 
-#: src/amule.cpp:1393
+#: src/amule.cpp:1401
 msgid "Failed to create aMule OnlineSig File"
 msgstr "A eșuat crearea fișierului aMule Semnătură Online"
 
-#: src/amule.cpp:1556
+#: src/amule.cpp:1564
 msgid "The selected locale seems not to be installed on your box. (Note: I'll try to set it anyway)"
 msgstr "Localizarea selectată se pare că nu este instalată pe computer. (Notă: Se va încerca configurarea acesteia oricum)"
 
-#: src/amule.cpp:1566
+#: src/amule.cpp:1574
 #, c-format
 msgid "This is the first time you run aMule %s"
 msgstr "Aceasta este prima dată când rulați aMule %s"
 
-#: src/amule.cpp:1569
+#: src/amule.cpp:1577
 msgid "This version is a testing version, updated daily, and\n"
 msgstr "Această versiune este o versiune de testare, actualizată zilnic și\n"
 
-#: src/amule.cpp:1570
+#: src/amule.cpp:1578
 msgid "we give no warranty it won't break anything, burn your house,\n"
 msgstr "nu vă dăm nici un fel de garanție dacă nu se va strica nimic, ardeți-vă casa,\n"
 
-#: src/amule.cpp:1571
+#: src/amule.cpp:1579
 msgid "or kill your dog. But it *should* be safe to use anyway.\n"
 msgstr "sau omorâți-vă câinele. Dar * ar trebui să fie * sigur de utilizat oricum.\n"
 
-#: src/amule.cpp:1576
+#: src/amule.cpp:1584
 msgid "More information, support and new releases can found at our homepage,\n"
 msgstr "Mai multe informații, suport și versiuni noi pot fi găsite pe pagina noastră web,\n"
 
-#: src/amule.cpp:1577
+#: src/amule.cpp:1585
 msgid "at https://amule-org.github.io, or in our IRC channel #aMule at irc.libera.chat.\n"
 msgstr "la https://amule-org.github.io, sau în canalul nostru IRC #aMule at irc.libera.chat.\n"
 
-#: src/amule.cpp:1579
+#: src/amule.cpp:1587
 msgid "Feel free to report any bugs to https://github.com/amule-org/amule/issues"
 msgstr "Raportați orice fel de probleme la https://github.com/amule-org/amule/issues"
 
-#: src/amule.cpp:1591
+#: src/amule.cpp:1599
 msgid ""
 "The folder for Online Signature files you specified is INVALID!\n"
 " OnlineSignature will be DISABLED until you fix it on preferences."
@@ -417,137 +417,137 @@ msgstr ""
 "Dosarul specificat pentru Semnătura Online NU ESTE VALID!\n"
 "Semnătura Online va fi DEZACTIVATĂ până va fi reparată problema în preferințe."
 
-#: src/amule.cpp:1654
+#: src/amule.cpp:1662
 msgid "Server hostname notified"
 msgstr "S-a notificat numele serverului"
 
-#: src/amule.cpp:2031
+#: src/amule.cpp:2039
 #, c-format
 msgid "Disk space preallocation for file '%s' failed: %s"
 msgstr "Prealocarea spațiului pe disc pentru fișierul '%s' a eșuat: %s"
 
-#: src/amule.cpp:2160
+#: src/amule.cpp:2168
 msgid "ERROR: can't open logfile"
 msgstr "EROARE: nu se poate deschide fișierul jurnal"
 
-#: src/amule.cpp:2164
+#: src/amule.cpp:2172
 msgid "WARNING: logfile is empty. Something is wrong."
 msgstr "ATENȚIE: fișierul jurnal este gol. Ceva este greșit."
 
-#: src/amule.cpp:2181
+#: src/amule.cpp:2189
 msgid "Log has been reset"
 msgstr "Jurnalul a fost resetat"
 
-#: src/amule.cpp:2205
+#: src/amule.cpp:2213
 #, c-format
 msgid "ServerMessage: %s"
 msgstr "Mesaj server: %s"
 
-#: src/amule.cpp:2248 src/IP2Country.cpp:220 src/IPFilter.cpp:514
+#: src/amule.cpp:2256 src/IP2Country.cpp:220 src/IPFilter.cpp:514
 #: src/ServerList.cpp:875
 #, c-format
 msgid "Skipped download of %s, because requested file is not newer."
 msgstr "Se omite descărcarea a %s, fiindcă fișierul solicitat nu este mai nou."
 
-#: src/amule.cpp:2251
+#: src/amule.cpp:2259
 msgid "Failed to download the nodes list."
 msgstr "A eșuat descărcarea listei de noduri."
 
-#: src/amule.cpp:2314
+#: src/amule.cpp:2322
 msgid "Failed to open the downloaded version check file"
 msgstr "A eșuat deschiderea fișierului de verificare a versiunii"
 
-#: src/amule.cpp:2317 src/amule.cpp:2336
+#: src/amule.cpp:2325 src/amule.cpp:2344
 msgid "Corrupted version check file"
 msgstr "Fișierul de verificare a versiunii este corupt"
 
-#: src/amule.cpp:2359
+#: src/amule.cpp:2367
 msgid "You are using an outdated version of aMule!"
 msgstr "Utilizați o versiune învechită de aMule!"
 
-#: src/amule.cpp:2361
+#: src/amule.cpp:2369
 #, c-format
 msgid "Your aMule version is %i.%i.%i and the latest version is %li.%li.%li"
 msgstr "Versiunea dumneavoastră de aMule este %i.%i.%i iar ultima versiune este %li.%li.%li"
 
-#: src/amule.cpp:2365
+#: src/amule.cpp:2373
 msgid "The latest version can always be found at https://github.com/amule-org/amule/releases/latest"
 msgstr "Ultima versiune poate fi găsită mereu la https://github.com/amule-org/amule/releases/latest"
 
-#: src/amule.cpp:2368
+#: src/amule.cpp:2376
 #, c-format
 msgid "WARNING: Your aMuled version is outdated: %i.%i.%i < %li.%li.%li"
 msgstr "ATENȚIE: Versiunea dumneavoastră aMuled este învechită: %i.%i.%i < %li.%li.%li"
 
-#: src/amule.cpp:2374
+#: src/amule.cpp:2382
 msgid "Your copy of aMule is up to date."
 msgstr "Copia dumneavoastră aMule este actualizată."
 
-#: src/amule.cpp:2381
+#: src/amule.cpp:2389
 msgid "Failed to download the version check file"
 msgstr "A eșuat descărcarea fișierului de verificare a versiunii"
 
-#: src/amule.cpp:2550 src/amule-remote-gui.cpp:1133
+#: src/amule.cpp:2558 src/amule-remote-gui.cpp:1133
 #, c-format
 msgid "Users: %s | Files: %s"
 msgstr "Utilizatori: %s | Fișiere: %s"
 
-#: src/amule.cpp:2551 src/amule-remote-gui.cpp:1134
+#: src/amule.cpp:2559 src/amule-remote-gui.cpp:1134
 #, c-format
 msgid "Users: E: %s K: %s | Files: E: %s K: %s"
 msgstr "Utilizatori: E: %s K: %s | Fișiere: E: %s K: %s"
 
-#: src/amule.cpp:2565 src/amule-remote-gui.cpp:1147
+#: src/amule.cpp:2573 src/amule-remote-gui.cpp:1147
 msgid "No networks selected"
 msgstr "Nu este selectată nicio rețea"
 
-#: src/amule.cpp:2633 src/TextClient.cpp:903
+#: src/amule.cpp:2641 src/TextClient.cpp:903
 msgid "with LowID"
 msgstr "cu LowID"
 
-#: src/amule.cpp:2633 src/TextClient.cpp:904
+#: src/amule.cpp:2641 src/TextClient.cpp:904
 msgid "with HighID"
 msgstr "cu HighID"
 
-#: src/amule.cpp:2635
+#: src/amule.cpp:2643
 #, c-format
 msgid "Connected to %s %s"
 msgstr "Conectat la %s %s"
 
-#: src/amule.cpp:2640
+#: src/amule.cpp:2648
 #, c-format
 msgid "Connecting to %s"
 msgstr "Conectare la %s"
 
-#: src/amule.cpp:2642
+#: src/amule.cpp:2650
 msgid "Disconnected from eD2k"
 msgstr "Deconectat de la eD2k"
 
-#: src/amule.cpp:2651
+#: src/amule.cpp:2659
 msgid "Kad started."
 msgstr "Kad este pornit."
 
-#: src/amule.cpp:2653
+#: src/amule.cpp:2661
 msgid "Kad stopped."
 msgstr "Kad este oprit."
 
-#: src/amule.cpp:2661
+#: src/amule.cpp:2669
 msgid "Connected to Kad (ok)"
 msgstr "Conectat la Kad (ok)"
 
-#: src/amule.cpp:2663
+#: src/amule.cpp:2671
 msgid "Connected to Kad (firewalled)"
 msgstr "Conectat la Kad (prin firewall)"
 
-#: src/amule.cpp:2667
+#: src/amule.cpp:2675
 msgid "Disconnected from Kad"
 msgstr "Deconectat de la Kad"
 
-#: src/amule.cpp:2699
+#: src/amule.cpp:2707
 msgid "Kad network cannot be used if UDP port is disabled on preferences, not starting."
 msgstr "Nu se poate utiliza rețeaua Kad dacă portul UDP este dezactivat în preferințe, nu se pornește."
 
-#: src/amule.cpp:2703
+#: src/amule.cpp:2711
 msgid "Kad network disabled on preferences, not connecting."
 msgstr "Rețeaua Kad este dezactivată în preferințe, nu se conectează."
 
@@ -592,36 +592,36 @@ msgid "FATAL ERROR: Failed to create Timer"
 msgstr "EROARE FATALĂ: A eșuat crearea temporizatorului"
 
 #: src/amuleDlg.cpp:361 src/amuleDlg.cpp:1787 src/amuleDlg.cpp:2033
-#: src/muuli_wdr.cpp:1492 src/muuli_wdr.cpp:3418
+#: src/muuli_wdr.cpp:1492 src/muuli_wdr.cpp:3449
 msgid "Networks"
 msgstr "Rețele"
 
-#: src/amuleDlg.cpp:362 src/amuleDlg.cpp:1793 src/muuli_wdr.cpp:3419
+#: src/amuleDlg.cpp:362 src/amuleDlg.cpp:1793 src/muuli_wdr.cpp:3450
 msgid "Searches"
 msgstr "Căutări"
 
 #: src/amuleDlg.cpp:363 src/amuleDlg.cpp:1799 src/DownloadListCtrl.cpp:740
-#: src/muuli_wdr.cpp:392 src/muuli_wdr.cpp:1585 src/muuli_wdr.cpp:3420
+#: src/muuli_wdr.cpp:392 src/muuli_wdr.cpp:1585 src/muuli_wdr.cpp:3451
 #: src/Statistics.cpp:829
 msgid "Downloads"
 msgstr "Descărcări"
 
-#: src/amuleDlg.cpp:364 src/amuleDlg.cpp:1805 src/muuli_wdr.cpp:3294
+#: src/amuleDlg.cpp:364 src/amuleDlg.cpp:1805 src/muuli_wdr.cpp:3325
 msgid "Shared files"
 msgstr "Fișiere partajate"
 
-#: src/amuleDlg.cpp:365 src/amuleDlg.cpp:1811 src/muuli_wdr.cpp:2926
-#: src/muuli_wdr.cpp:3376 src/muuli_wdr.cpp:3423
+#: src/amuleDlg.cpp:365 src/amuleDlg.cpp:1811 src/muuli_wdr.cpp:2957
+#: src/muuli_wdr.cpp:3407 src/muuli_wdr.cpp:3454
 msgid "Messages"
 msgstr "Mesaje"
 
-#: src/amuleDlg.cpp:366 src/amuleDlg.cpp:1817 src/muuli_wdr.cpp:3424
-#: src/PrefsUnifiedDlg.cpp:312 src/Statistics.cpp:779 src/Statistics.cpp:1235
+#: src/amuleDlg.cpp:366 src/amuleDlg.cpp:1817 src/muuli_wdr.cpp:3455
+#: src/PrefsUnifiedDlg.cpp:314 src/Statistics.cpp:779 src/Statistics.cpp:1235
 msgid "Statistics"
 msgstr "Statistici"
 
-#: src/amuleDlg.cpp:368 src/amuleDlg.cpp:1824 src/muuli_wdr.cpp:3426
-#: src/PrefsUnifiedDlg.cpp:328 src/utils/wxCas/src/wxcasprefs.cpp:39
+#: src/amuleDlg.cpp:368 src/amuleDlg.cpp:1824 src/muuli_wdr.cpp:3457
+#: src/PrefsUnifiedDlg.cpp:330 src/utils/wxCas/src/wxcasprefs.cpp:39
 msgid "Preferences"
 msgstr "Preferințe"
 
@@ -679,8 +679,8 @@ msgstr "Kad: Închis"
 #: src/amuleDlg.cpp:1029 src/DownloadListCtrl.cpp:505
 #: src/DownloadListCtrl.cpp:749 src/FriendListCtrl.cpp:180
 #: src/muuli_wdr.cpp:731 src/muuli_wdr.cpp:782 src/muuli_wdr.cpp:846
-#: src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2231 src/muuli_wdr.cpp:2316
-#: src/muuli_wdr.cpp:3064 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
+#: src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2262 src/muuli_wdr.cpp:2347
+#: src/muuli_wdr.cpp:3095 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
 #: src/ServerListCtrl.cpp:606 src/TransferWnd.cpp:378
 #: src/utils/wxCas/src/wxcasprefs.cpp:235
 msgid "Cancel"
@@ -691,7 +691,7 @@ msgid "Stop the current connection attempts"
 msgstr "Oprește încercările curente de conectare"
 
 #: src/amuleDlg.cpp:1035 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976
-#: src/muuli_wdr.cpp:2454
+#: src/muuli_wdr.cpp:2485
 msgid "Disconnect"
 msgstr "Deconectează"
 
@@ -700,7 +700,7 @@ msgid "Disconnect from the currently connected networks"
 msgstr "Deconectează de la rețelele curent conectate"
 
 #: src/amuleDlg.cpp:1041 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979
-#: src/muuli_wdr.cpp:2609 src/muuli_wdr.cpp:3061 src/muuli_wdr.cpp:3416
+#: src/muuli_wdr.cpp:2640 src/muuli_wdr.cpp:3092 src/muuli_wdr.cpp:3447
 msgid "Connect"
 msgstr "Conectează"
 
@@ -755,7 +755,7 @@ msgstr "Confirmare închidere"
 msgid "Launch Command: "
 msgstr "Lansare comandă:"
 
-#: src/amuleDlg.cpp:1632 src/muuli_wdr.cpp:1978 src/Preferences.cpp:952
+#: src/amuleDlg.cpp:1632 src/muuli_wdr.cpp:1982 src/Preferences.cpp:979
 msgid "- default -"
 msgstr "- implicit -"
 
@@ -769,48 +769,48 @@ msgstr "Directorul aspectului aplicației '%s' nu există"
 msgid "WARNING: Unable to open skin file '%s' for read"
 msgstr "ATENȚIE: Nu se poate deschide fișierul aspect '%s' pentru citit"
 
-#: src/amuleDlg.cpp:1791 src/muuli_wdr.cpp:3418
+#: src/amuleDlg.cpp:1791 src/muuli_wdr.cpp:3449
 msgid "Networks Window"
 msgstr "Fereastra rețelelor"
 
-#: src/amuleDlg.cpp:1797 src/muuli_wdr.cpp:3419
+#: src/amuleDlg.cpp:1797 src/muuli_wdr.cpp:3450
 msgid "Searches Window"
 msgstr "Fereastra căutărilor"
 
-#: src/amuleDlg.cpp:1803 src/muuli_wdr.cpp:3420
+#: src/amuleDlg.cpp:1803 src/muuli_wdr.cpp:3451
 msgid "Downloads Window"
 msgstr "Fereastra descărcărilor"
 
-#: src/amuleDlg.cpp:1809 src/muuli_wdr.cpp:3422
+#: src/amuleDlg.cpp:1809 src/muuli_wdr.cpp:3453
 msgid "Shared Files Window"
 msgstr "Fereastra fișierelor partajate"
 
-#: src/amuleDlg.cpp:1815 src/muuli_wdr.cpp:3423
+#: src/amuleDlg.cpp:1815 src/muuli_wdr.cpp:3454
 msgid "Messages Window"
 msgstr "Fereastra mesajelor"
 
-#: src/amuleDlg.cpp:1821 src/muuli_wdr.cpp:3424
+#: src/amuleDlg.cpp:1821 src/muuli_wdr.cpp:3455
 msgid "Statistics Graph Window"
 msgstr "Fereastra graficului statisticilor"
 
-#: src/amuleDlg.cpp:1828 src/muuli_wdr.cpp:3426
+#: src/amuleDlg.cpp:1828 src/muuli_wdr.cpp:3457
 msgid "Preferences Settings Window"
 msgstr "Fereastra configurare preferințe"
 
-#: src/amuleDlg.cpp:1831 src/muuli_wdr.cpp:3427
+#: src/amuleDlg.cpp:1831 src/muuli_wdr.cpp:3458
 msgid "Import"
 msgstr "Importă"
 
-#: src/amuleDlg.cpp:1835 src/muuli_wdr.cpp:3427
+#: src/amuleDlg.cpp:1835 src/muuli_wdr.cpp:3458
 msgid "The partfile importer tool"
 msgstr "Unealta de importat fișiere parțiale"
 
-#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3428
+#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3459
 #: src/utils/aLinkCreator/src/alcframe.cpp:262
 msgid "About"
 msgstr "Despre"
 
-#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3428
+#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3459
 msgid "About/Help"
 msgstr "Despre/Ajutor"
 
@@ -952,7 +952,7 @@ msgstr "Fișierul nu este găsit."
 msgid "The core rejected these shared folders:%s"
 msgstr ""
 
-#: src/amule-remote-gui.cpp:1336 src/ExternalConn.cpp:2345
+#: src/amule-remote-gui.cpp:1336 src/ExternalConn.cpp:2346
 msgid "Invalid link or already on list."
 msgstr "Legătură nevalidă sau care este deja în listă."
 
@@ -968,7 +968,7 @@ msgstr "Nu se poate crea directorul '%s' pentru categoria '%s', se păstrează d
 #: src/ClientDetailDialog.cpp:123 src/DataToText.cpp:61 src/DataToText.cpp:86
 #: src/DataToText.cpp:101 src/DataToText.cpp:136 src/DataToText.cpp:165
 #: src/DownloadListCtrl.cpp:1172 src/DownloadListCtrl.cpp:1185
-#: src/DownloadListCtrl.cpp:1196 src/ExternalConn.cpp:608
+#: src/DownloadListCtrl.cpp:1196 src/ExternalConn.cpp:609
 #: src/FileDetailDialog.cpp:203 src/FileDetailDialog.cpp:235
 #: src/FileDetailDialog.cpp:242 src/GenericClientListCtrl.cpp:1171
 #: src/GenericClientListCtrl.cpp:1182 src/GenericClientListCtrl.cpp:1192
@@ -1360,19 +1360,19 @@ msgstr "Automat [În]"
 msgid "Very low"
 msgstr "Foarte joasă"
 
-#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:743 src/muuli_wdr.cpp:2282
+#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:743 src/muuli_wdr.cpp:2313
 #: src/ServerListCtrl.cpp:263 src/ServerListCtrl.cpp:456
 #: src/SharedFilesCtrl.cpp:145
 msgid "Low"
 msgstr "Joasă"
 
-#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:744 src/muuli_wdr.cpp:2283
+#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:744 src/muuli_wdr.cpp:2314
 #: src/ServerListCtrl.cpp:266 src/ServerListCtrl.cpp:457
 #: src/SharedFilesCtrl.cpp:146
 msgid "Normal"
 msgstr "Normal"
 
-#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:745 src/muuli_wdr.cpp:2284
+#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:745 src/muuli_wdr.cpp:2315
 #: src/ServerListCtrl.cpp:269 src/ServerListCtrl.cpp:458
 #: src/SharedFilesCtrl.cpp:147
 msgid "High"
@@ -1464,7 +1464,7 @@ msgstr "Server local"
 msgid "Remote Server"
 msgstr "Server distant"
 
-#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3181
+#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3212
 #: src/SearchDlg.cpp:119 src/TextClient.cpp:911
 msgid "Kad"
 msgstr "Kad"
@@ -1536,7 +1536,7 @@ msgstr "Parte"
 msgid "Size"
 msgstr "Dimensiune"
 
-#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3248
+#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3279
 msgid "Transferred"
 msgstr "Transferat"
 
@@ -1594,7 +1594,7 @@ msgstr ""
 "Feedback de la: %s (%s)\n"
 "\n"
 
-#: src/DownloadListCtrl.cpp:746 src/muuli_wdr.cpp:2285
+#: src/DownloadListCtrl.cpp:746 src/muuli_wdr.cpp:2316
 #: src/SharedFilesCtrl.cpp:150
 msgid "Auto"
 msgstr "Automat"
@@ -1632,7 +1632,7 @@ msgid "Extended Options"
 msgstr "Opțiuni extinse"
 
 #: src/DownloadListCtrl.cpp:770 src/DownloadListCtrl.cpp:822
-#: src/muuli_wdr.cpp:1796
+#: src/muuli_wdr.cpp:1800
 msgid "Preview"
 msgstr "Previzualizează"
 
@@ -1809,227 +1809,232 @@ msgstr[2] ""
 msgid "Invalid eD2k link! ERROR: %s"
 msgstr "Legătură eD2k nevalidă! EROARE: %s"
 
-#: src/ExternalConn.cpp:379
+#: src/ExternalConn.cpp:380
 msgid "Client sent packet after authentication failed."
 msgstr "Clientul a trimis pachetul după eșuarea autentificării."
 
-#: src/ExternalConn.cpp:396
+#: src/ExternalConn.cpp:397
 msgid "External connection closed."
 msgstr "Conexiune externă închisă."
 
-#: src/ExternalConn.cpp:473
+#: src/ExternalConn.cpp:474
 msgid "External connections disabled due to empty password!"
 msgstr "Conexiunile externe sunt dezactivate datorită lipsei parolei!"
 
-#: src/ExternalConn.cpp:494
+#: src/ExternalConn.cpp:495
 msgid "External connections disabled in config file"
 msgstr "Conexiunile externe sunt dezactivate în fișierul de configurare"
 
-#: src/ExternalConn.cpp:575
+#: src/ExternalConn.cpp:576
 msgid "New external connection accepted"
 msgstr "Conexiune externă nouă acceptată"
 
-#: src/ExternalConn.cpp:578
+#: src/ExternalConn.cpp:579
 msgid "ERROR: couldn't accept a new external connection"
 msgstr "EROARE: nu se poate accepta o nouă conexiune externă"
 
-#: src/ExternalConn.cpp:595
+#: src/ExternalConn.cpp:596
 msgid "External connection refused due to empty password in preferences!"
 msgstr "Conexiunea externă este refuzată datorită lipsei parolei în preferințe!"
 
-#: src/ExternalConn.cpp:607
+#: src/ExternalConn.cpp:608
 #, c-format
 msgid "Connecting client: %s %s"
 msgstr "Se conectează clientul: %s %s"
 
-#: src/ExternalConn.cpp:609
+#: src/ExternalConn.cpp:610
 msgid "Unknown version"
 msgstr "Versiune necunoscută"
 
-#: src/ExternalConn.cpp:622
+#: src/ExternalConn.cpp:623
 msgid "Incorrect EC version ID, there might be binary incompatibility. Use core and remote from same snapshot."
 msgstr "Incorecta EC versiune ID, poate fi o incompatibilitate de aplicații. Utilizați nucleul și aplicația distantă de la aceiași versiune."
 
-#: src/ExternalConn.cpp:630
+#: src/ExternalConn.cpp:631
 msgid "You cannot connect to a release version from an arbitrary development snapshot! *sigh* possible crash prevented"
 msgstr "Nu vă puteți conecta la o versiune lansată dintr-o versiune în dezvoltare arbitrară! *uf* se pot preveni disfuncțiile"
 
-#: src/ExternalConn.cpp:713
+#: src/ExternalConn.cpp:714
 msgid "Invalid protocol version."
 msgstr "Versiune protocol nevalidă."
 
-#: src/ExternalConn.cpp:719
+#: src/ExternalConn.cpp:720
 msgid "Missing protocol version tag."
 msgstr "Lipsește eticheta versiunii protocolului."
 
-#: src/ExternalConn.cpp:727
+#: src/ExternalConn.cpp:728
 msgid "Authentication failed: invalid hash specified as EC password."
 msgstr "Autentificare eșuată: indexul specificat este nevalid ca parolă EC."
 
-#: src/ExternalConn.cpp:775
+#: src/ExternalConn.cpp:776
 msgid "Authentication failed: wrong password."
 msgstr "Autentificare eșuată: parolă greșită."
 
-#: src/ExternalConn.cpp:777
+#: src/ExternalConn.cpp:778
 msgid "Authentication failed: missing password."
 msgstr "Autentificare eșuată: lipsă parolă."
 
-#: src/ExternalConn.cpp:788
+#: src/ExternalConn.cpp:789
 msgid "Invalid request, please authenticate first."
 msgstr "Solicitare nevalidă, autentificați-vă întâi."
 
-#: src/ExternalConn.cpp:793
+#: src/ExternalConn.cpp:794
 msgid "Access granted."
 msgstr "Acces asigurat."
 
-#: src/ExternalConn.cpp:801
+#: src/ExternalConn.cpp:802
 #, c-format
 msgid "Sent error message \"%s\" to client."
 msgstr "Trimite mesajul de eroare \"%s\" la client."
 
-#: src/ExternalConn.cpp:806
+#: src/ExternalConn.cpp:807
 #, c-format
 msgid "Unauthorized access attempt from %s. Connection closed."
 msgstr "Încercare neautorizată de acces de la %s. Conexiune închisă."
 
-#: src/ExternalConn.cpp:1419
+#: src/ExternalConn.cpp:1420
 #, c-format
 msgid "Remote PartFile command failed: FileHash not found: %s"
 msgstr "A eșuat comanda distantă a fișierului parțial: Nu a fost găsit fișierul index: %s"
 
-#: src/ExternalConn.cpp:1423
+#: src/ExternalConn.cpp:1424
 #, c-format
 msgid "FileHash not found: %s"
 msgstr "Indexul fișierului  nu este găsit: %s"
 
-#: src/ExternalConn.cpp:1470 src/ExternalConn.cpp:1558
-#: src/ExternalConn.cpp:1679
+#: src/ExternalConn.cpp:1471 src/ExternalConn.cpp:1559
+#: src/ExternalConn.cpp:1680
 msgid "OOPS! OpCode processing error!"
 msgstr "OOPS! Eroare la procesarea OpCode!"
 
-#: src/ExternalConn.cpp:1501
+#: src/ExternalConn.cpp:1502
 msgid "Server not added"
 msgstr "Serverul nu este adăugat"
 
-#: src/ExternalConn.cpp:1520
+#: src/ExternalConn.cpp:1521
 #, c-format
 msgid "server not found: %s"
 msgstr "serverul nu este găsit: %s"
 
-#: src/ExternalConn.cpp:1537
+#: src/ExternalConn.cpp:1538
 msgid "need to define server to be removed"
 msgstr "trebuie să definiți un server pentru a fi eliminat"
 
-#: src/ExternalConn.cpp:1552
+#: src/ExternalConn.cpp:1553
 msgid "eD2k is disabled in preferences."
 msgstr "eD2k este dezactivat în preferințe."
 
-#: src/ExternalConn.cpp:1657
+#: src/ExternalConn.cpp:1658
 #, fuzzy
 msgid "Friend not found."
 msgstr "Fișierul nu este găsit."
 
-#: src/ExternalConn.cpp:1667
+#: src/ExternalConn.cpp:1668
 #, fuzzy
 msgid "Client not found."
 msgstr "Fișierul nu este găsit."
 
-#: src/ExternalConn.cpp:1673
+#: src/ExternalConn.cpp:1674
 msgid "EC_TAG_FRIEND_SHARED requires EC_TAG_FRIEND or EC_TAG_CLIENT."
 msgstr ""
 
-#: src/ExternalConn.cpp:1991
+#: src/ExternalConn.cpp:1992
 msgid "WebSearch from remote interface makes no sense."
 msgstr "Nu are nici un sens căutarea web de pe interfața distantă."
 
-#: src/ExternalConn.cpp:2026
+#: src/ExternalConn.cpp:2027
 msgid "Search in progress. Refetch results in a moment!"
 msgstr "Căutare în desfășurare. Se readuc rezultatele imediat!"
 
-#: src/ExternalConn.cpp:2265
+#: src/ExternalConn.cpp:2266
 msgid "No points for graph."
 msgstr "Nici un punct pentru grafic."
 
-#: src/ExternalConn.cpp:2275
+#: src/ExternalConn.cpp:2276
 msgid "Your client is not configured for this detail level."
 msgstr "Clientul dumneavoastră nu este configurat pentru acest nivel detaliat."
 
-#: src/ExternalConn.cpp:2302
+#: src/ExternalConn.cpp:2303
 msgid "External Connection: shutdown requested"
 msgstr "Conexiune externă: închidere solicitată"
 
-#: src/ExternalConn.cpp:2314
+#: src/ExternalConn.cpp:2315
 msgid "Already shutting down."
 msgstr "Deja se închide."
 
-#: src/ExternalConn.cpp:2332
+#: src/ExternalConn.cpp:2333
 #, c-format
 msgid "ExternalConn: adding link '%s'."
 msgstr "Conexiune externă: se adaugă legătura '%s'."
 
-#: src/ExternalConn.cpp:2350
+#: src/ExternalConn.cpp:2351
 #, fuzzy, c-format
 msgid "%d of %d links failed (invalid or already on list)."
 msgstr "Legătură nevalidă sau care este deja în listă."
 
-#: src/ExternalConn.cpp:2373
+#: src/ExternalConn.cpp:2374
 msgid "Version check throttled; try again shortly."
 msgstr ""
 
-#: src/ExternalConn.cpp:2378
+#: src/ExternalConn.cpp:2379
 msgid "Version check is not available on this daemon."
 msgstr ""
 
-#: src/ExternalConn.cpp:2508
+#: src/ExternalConn.cpp:2509
 msgid "File not found."
 msgstr "Fișierul nu este găsit."
 
-#: src/ExternalConn.cpp:2513
+#: src/ExternalConn.cpp:2514
 msgid "Invalid file name."
 msgstr "Nume fișier nevalid."
 
-#: src/ExternalConn.cpp:2521
+#: src/ExternalConn.cpp:2522
 msgid "Unable to rename file."
 msgstr "Nu se poate redenumii fișierul."
 
-#: src/ExternalConn.cpp:2992 src/ExternalConn.cpp:3020
+#: src/ExternalConn.cpp:2839
+#, c-format
+msgid "Could not save the amuleapi password: %s"
+msgstr ""
+
+#: src/ExternalConn.cpp:3004 src/ExternalConn.cpp:3032
 msgid "Kad is disabled in preferences."
 msgstr "Kad este dezactivat din preferințe."
 
-#: src/ExternalConn.cpp:3033
+#: src/ExternalConn.cpp:3045
 msgid "Already connected to eD2k."
 msgstr "Deja este conectat la eD2k."
 
-#: src/ExternalConn.cpp:3036
+#: src/ExternalConn.cpp:3048
 msgid "Connecting to eD2k..."
 msgstr "Se conectează la eD2k..."
 
-#: src/ExternalConn.cpp:3045
+#: src/ExternalConn.cpp:3057
 msgid "Already connected to Kad."
 msgstr "Deja este conectat la Kad."
 
-#: src/ExternalConn.cpp:3048
+#: src/ExternalConn.cpp:3060
 msgid "Connecting to Kad..."
 msgstr "Se conectează la Kad..."
 
-#: src/ExternalConn.cpp:3055
+#: src/ExternalConn.cpp:3067
 msgid "All networks are disabled."
 msgstr "Toate rețelele sunt dezactivate."
 
-#: src/ExternalConn.cpp:3064
+#: src/ExternalConn.cpp:3076
 msgid "Disconnected from eD2k."
 msgstr "Deconectat de la eD2k."
 
-#: src/ExternalConn.cpp:3069
+#: src/ExternalConn.cpp:3081
 msgid "Disconnected from Kad."
 msgstr "Deconectat de la Kad."
 
-#: src/ExternalConn.cpp:3078
+#: src/ExternalConn.cpp:3090
 #, c-format
 msgid "External Connection: invalid opcode received: %#x"
 msgstr "Conexiune externă: S-a primit un opcode nevalid: %#x"
 
-#: src/ExternalConn.cpp:3083
+#: src/ExternalConn.cpp:3095
 msgid "Invalid opcode (wrong protocol version?)"
 msgstr "Opcode nevalid (versiune protocol greșită?)"
 
@@ -2428,23 +2433,23 @@ msgid ""
 "want downloads on a different (e.g. larger) disk."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:549 src/FirstRunWizard.cpp:611 src/muuli_wdr.cpp:1708
+#: src/FirstRunWizard.cpp:549 src/FirstRunWizard.cpp:611 src/muuli_wdr.cpp:1712
 msgid "Destination folder for downloads"
 msgstr "Dosar destinație pentru descărcări"
 
 #: src/FirstRunWizard.cpp:553 src/FirstRunWizard.cpp:569 src/muuli_wdr.cpp:1349
-#: src/muuli_wdr.cpp:1366 src/muuli_wdr.cpp:1683 src/muuli_wdr.cpp:1714
-#: src/muuli_wdr.cpp:1726 src/muuli_wdr.cpp:2769
+#: src/muuli_wdr.cpp:1366 src/muuli_wdr.cpp:1687 src/muuli_wdr.cpp:1718
+#: src/muuli_wdr.cpp:1730 src/muuli_wdr.cpp:2800
 #: src/utils/aLinkCreator/src/alcframe.cpp:135
 #: src/utils/wxCas/src/wxcasprefs.cpp:52 src/utils/wxCas/src/wxcasprefs.cpp:118
 msgid "Browse"
 msgstr "Navigare"
 
-#: src/FirstRunWizard.cpp:559 src/muuli_wdr.cpp:1719
+#: src/FirstRunWizard.cpp:559 src/muuli_wdr.cpp:1723
 msgid "(All files in this folder are shared with other peers)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:565 src/FirstRunWizard.cpp:624 src/muuli_wdr.cpp:1721
+#: src/FirstRunWizard.cpp:565 src/FirstRunWizard.cpp:624 src/muuli_wdr.cpp:1725
 msgid "Folder for temporary download files"
 msgstr "Dosar pentru fișiere descărcate temporar"
 
@@ -2475,7 +2480,7 @@ msgstr "A eșuat deschiderea fișierului listă prieteni 'emfriends.met' pentru 
 msgid "CRITICAL - no client on StartChatSession"
 msgstr "CRITIC - niciun client în StartChatSession"
 
-#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2675 src/muuli_wdr.cpp:3352
+#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2706 src/muuli_wdr.cpp:3383
 msgid "Friends"
 msgstr "Prieteni"
 
@@ -2586,8 +2591,8 @@ msgstr "Niciunul"
 msgid "No"
 msgstr "Nu"
 
-#: src/GenericClientListCtrl.cpp:1216 src/PrefsUnifiedDlg.cpp:2818
-#: src/PrefsUnifiedDlg.cpp:2868 src/ServerListCtrl.cpp:276
+#: src/GenericClientListCtrl.cpp:1216 src/PrefsUnifiedDlg.cpp:2898
+#: src/PrefsUnifiedDlg.cpp:2948 src/ServerListCtrl.cpp:276
 msgid "Yes"
 msgstr "Da"
 
@@ -2758,10 +2763,10 @@ msgstr "Port nevalid la bootstrap"
 msgid "Please fill all fields required"
 msgstr "Completați toate câmpurile solicitate"
 
-#: src/KadDlg.cpp:192 src/PartFile.cpp:1031 src/PrefsUnifiedDlg.cpp:1162
-#: src/PrefsUnifiedDlg.cpp:1331 src/PrefsUnifiedDlg.cpp:1589
-#: src/PrefsUnifiedDlg.cpp:1599 src/PrefsUnifiedDlg.cpp:1616
-#: src/PrefsUnifiedDlg.cpp:1658
+#: src/KadDlg.cpp:192 src/PartFile.cpp:1031 src/PrefsUnifiedDlg.cpp:1134
+#: src/PrefsUnifiedDlg.cpp:1204 src/PrefsUnifiedDlg.cpp:1405
+#: src/PrefsUnifiedDlg.cpp:1663 src/PrefsUnifiedDlg.cpp:1673
+#: src/PrefsUnifiedDlg.cpp:1690 src/PrefsUnifiedDlg.cpp:1738
 msgid "Message"
 msgstr "Mesaj"
 
@@ -2866,7 +2871,7 @@ msgstr "Rată de partajare"
 msgid "Uploaded"
 msgstr "Încărcat"
 
-#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3232
+#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3263
 msgid "Requested"
 msgstr "Cerut"
 
@@ -2990,7 +2995,7 @@ msgid "WARNING: "
 msgstr "ATENȚIE:"
 
 #: src/MuleNotebook.cpp:179 src/muuli_wdr.cpp:817 src/muuli_wdr.cpp:1229
-#: src/muuli_wdr.cpp:3136 src/muuli_wdr.cpp:3392
+#: src/muuli_wdr.cpp:3167 src/muuli_wdr.cpp:3423
 msgid "Close"
 msgstr "Închide"
 
@@ -3008,7 +3013,7 @@ msgid "Paste"
 msgstr "Lipește"
 
 #: src/MuleTextCtrl.cpp:89 src/muuli_wdr.cpp:358 src/muuli_wdr.cpp:757
-#: src/muuli_wdr.cpp:2359 src/muuli_wdr.cpp:2378 src/muuli_wdr.cpp:2400
+#: src/muuli_wdr.cpp:2390 src/muuli_wdr.cpp:2409 src/muuli_wdr.cpp:2431
 #: src/utils/aLinkCreator/src/alcframe.cpp:142
 msgid "Clear"
 msgstr "Curăță"
@@ -3107,7 +3112,7 @@ msgstr "Ieşire"
 
 #: src/MuleTrayIcon.cpp:579 src/MuleTrayIcon.cpp:945 src/MuleTrayIcon.cpp:965
 #: src/muuli_wdr.cpp:1398 src/muuli_wdr.cpp:1406 src/muuli_wdr.cpp:1413
-#: src/muuli_wdr.cpp:1842 src/muuli_wdr.cpp:1848 src/OtherFunctions.cpp:91
+#: src/muuli_wdr.cpp:1846 src/muuli_wdr.cpp:1852 src/OtherFunctions.cpp:91
 #: src/StatisticsDlg.cpp:93 src/StatisticsDlg.cpp:95
 msgid "kB/s"
 msgstr "kB/s"
@@ -3349,7 +3354,7 @@ msgstr "Baiți"
 msgid "KB"
 msgstr "KB"
 
-#: src/muuli_wdr.cpp:274 src/muuli_wdr.cpp:293 src/muuli_wdr.cpp:1627
+#: src/muuli_wdr.cpp:274 src/muuli_wdr.cpp:293 src/muuli_wdr.cpp:1631
 #: src/OtherFunctions.cpp:64
 msgid "MB"
 msgstr "MO"
@@ -3366,7 +3371,7 @@ msgstr "Dimensiune maximă"
 msgid "Availability"
 msgstr "Disponibilitate"
 
-#: src/muuli_wdr.cpp:312 src/muuli_wdr.cpp:398 src/muuli_wdr.cpp:3297
+#: src/muuli_wdr.cpp:312 src/muuli_wdr.cpp:398 src/muuli_wdr.cpp:3328
 msgid "Filter:"
 msgstr "Filtru:"
 
@@ -3429,12 +3434,12 @@ msgstr "Surse fișier:"
 #: src/muuli_wdr.cpp:1160 src/muuli_wdr.cpp:1167 src/muuli_wdr.cpp:1172
 #: src/muuli_wdr.cpp:1179 src/muuli_wdr.cpp:1184 src/muuli_wdr.cpp:1191
 #: src/muuli_wdr.cpp:1205 src/muuli_wdr.cpp:1212 src/muuli_wdr.cpp:1217
-#: src/muuli_wdr.cpp:1224 src/muuli_wdr.cpp:3234 src/muuli_wdr.cpp:3242
-#: src/muuli_wdr.cpp:3250
+#: src/muuli_wdr.cpp:1224 src/muuli_wdr.cpp:3265 src/muuli_wdr.cpp:3273
+#: src/muuli_wdr.cpp:3281
 msgid "N/A"
 msgstr "NU SE APLICĂ"
 
-#: src/muuli_wdr.cpp:508 src/muuli_wdr.cpp:1065 src/PrefsUnifiedDlg.cpp:297
+#: src/muuli_wdr.cpp:508 src/muuli_wdr.cpp:1065 src/PrefsUnifiedDlg.cpp:299
 msgid "General"
 msgstr "General"
 
@@ -3575,7 +3580,7 @@ msgstr ""
 msgid "Album :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:685 src/muuli_wdr.cpp:2254
+#: src/muuli_wdr.cpp:685 src/muuli_wdr.cpp:2285
 msgid "Title :"
 msgstr "Titlu :"
 
@@ -3684,7 +3689,7 @@ msgstr "Nume utilizator:"
 msgid "Userhash :"
 msgstr "Index utilizator :"
 
-#: src/muuli_wdr.cpp:895 src/muuli_wdr.cpp:1748 src/muuli_wdr.cpp:2449
+#: src/muuli_wdr.cpp:895 src/muuli_wdr.cpp:1752 src/muuli_wdr.cpp:2480
 #: src/utils/aLinkCreator/src/alcframe.cpp:137
 msgid "Add"
 msgstr "Adaugă"
@@ -3693,15 +3698,15 @@ msgstr "Adaugă"
 msgid "Download-Speed"
 msgstr "Viteză-descărcare"
 
-#: src/muuli_wdr.cpp:954 src/muuli_wdr.cpp:989 src/muuli_wdr.cpp:2553
+#: src/muuli_wdr.cpp:954 src/muuli_wdr.cpp:989 src/muuli_wdr.cpp:2584
 msgid "Current"
 msgstr "Curentul"
 
-#: src/muuli_wdr.cpp:962 src/muuli_wdr.cpp:997 src/muuli_wdr.cpp:2561
+#: src/muuli_wdr.cpp:962 src/muuli_wdr.cpp:997 src/muuli_wdr.cpp:2592
 msgid "Running average"
 msgstr "Medie rulare"
 
-#: src/muuli_wdr.cpp:970 src/muuli_wdr.cpp:1005 src/muuli_wdr.cpp:2569
+#: src/muuli_wdr.cpp:970 src/muuli_wdr.cpp:1005 src/muuli_wdr.cpp:2600
 msgid "Session average"
 msgstr "Medie sesiune"
 
@@ -3713,7 +3718,7 @@ msgstr "Viteză-încărcare"
 msgid "Connections"
 msgstr "Conexiuni"
 
-#: src/muuli_wdr.cpp:1024 src/muuli_wdr.cpp:1867
+#: src/muuli_wdr.cpp:1024 src/muuli_wdr.cpp:1871
 msgid "Active downloads"
 msgstr "Descărcări active"
 
@@ -3721,7 +3726,7 @@ msgstr "Descărcări active"
 msgid "Active connections (1:1)"
 msgstr "Conexiuni active (1:1)"
 
-#: src/muuli_wdr.cpp:1040 src/muuli_wdr.cpp:1868
+#: src/muuli_wdr.cpp:1040 src/muuli_wdr.cpp:1872
 msgid "Active uploads"
 msgstr "Încărcări active"
 
@@ -3997,7 +4002,7 @@ msgstr "Leagă adresa locală la IP (gol pentru oricare):"
 msgid "Advanced users only: If you have multiple network interfaces, enter the address of the interface to which aMule should be bound."
 msgstr "Numai pentru utilizatorii avansați: Dacă aveți mai multe interfețe de rețea, introduceți adresa interfeței la care aMule ar trebui să fie legat."
 
-#: src/muuli_wdr.cpp:1462 src/muuli_wdr.cpp:2061
+#: src/muuli_wdr.cpp:1462 src/muuli_wdr.cpp:2065
 #, fuzzy
 msgid "Bind to network interface (empty for any):"
 msgstr "Leagă adresa locală la IP (gol pentru oricare):"
@@ -4014,7 +4019,7 @@ msgstr "Număr maxim de surse pe fișier descărcat:"
 msgid "Max simultaneous connections:"
 msgstr "Număr maxim de conexiuni simultane:"
 
-#: src/muuli_wdr.cpp:1498 src/muuli_wdr.cpp:3176
+#: src/muuli_wdr.cpp:1498 src/muuli_wdr.cpp:3207
 msgid "ED2K"
 msgstr "ED2K"
 
@@ -4106,755 +4111,778 @@ msgstr "Prealocare spațiu pe disc pentru noile fișiere"
 msgid "For new files preallocates disk space for the whole file, thus reduces fragmentation"
 msgstr "Pentru noile fișiere se prealocă spațiu pe disc pentru întreg fișierul, astfel se reduce fragmentarea"
 
-#: src/muuli_wdr.cpp:1613
+#: src/muuli_wdr.cpp:1617
 msgid "Create new files as sparse files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1614
-msgid "A sparse file reserves its full size on disk immediately without writing real data to it -- fast, but unsupported or slow on some filesystems, and free-space accounting stays optimistic while the download is in progress. Turn this off to grow the file only as data arrives."
+#: src/muuli_wdr.cpp:1618
+msgid "Sparse part files only occupy disk space for the parts already downloaded, so free space is used up gradually as the file fills in. Turn this off to use an ordinary file instead - useful where sparse files are unsupported or slow, or where backup/de-duplication tools handle them badly. Applies only when the core runs on Windows; on Linux and macOS part files are sparse anyway and this setting has no effect."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1619
+#: src/muuli_wdr.cpp:1623
 msgid "Stop downloads when free disk space reaches "
 msgstr "Oprește descărcarea când s-a atins limita spațiului disponibil"
 
-#: src/muuli_wdr.cpp:1620
+#: src/muuli_wdr.cpp:1624
 msgid "Select this if you want aMule to check your disk space"
 msgstr "Selectați asta dacă doriți ca aMule să verifice spațiul liber pe disk"
 
-#: src/muuli_wdr.cpp:1624
+#: src/muuli_wdr.cpp:1628
 msgid "Enter here the min disk space desired."
 msgstr "Introduceți aici minimum de spațiu pe disc dorit."
 
-#: src/muuli_wdr.cpp:1630
+#: src/muuli_wdr.cpp:1634
 msgid "Save 10 sources on rare files (< 20 sources)"
 msgstr "Salvează 10 surse de fișiere rare (< 20 surse)"
 
-#: src/muuli_wdr.cpp:1634 src/Statistics.cpp:790
+#: src/muuli_wdr.cpp:1638 src/Statistics.cpp:790
 msgid "Uploads"
 msgstr "Încărcări"
 
-#: src/muuli_wdr.cpp:1637
+#: src/muuli_wdr.cpp:1641
 msgid "Add new shared files with auto priority"
 msgstr "Adaugă noile fișiere partajate cu prioritate automată"
 
-#: src/muuli_wdr.cpp:1643
+#: src/muuli_wdr.cpp:1647
 msgid "Intelligent Corruption Handling (I.C.H.)"
 msgstr "Gestionare inteligentă a fișierelor corupte (I.C.H.)"
 
-#: src/muuli_wdr.cpp:1646
+#: src/muuli_wdr.cpp:1650
 msgid "Enable"
 msgstr "Activează"
 
-#: src/muuli_wdr.cpp:1649
+#: src/muuli_wdr.cpp:1653
 msgid "Advanced I.C.H. trusts every hash (not recommended)"
 msgstr "I.C.H. avansat acordă încredere fiecărui index (nu este recomandat)"
 
-#: src/muuli_wdr.cpp:1661 src/PrefsUnifiedDlg.cpp:1910
+#: src/muuli_wdr.cpp:1665 src/PrefsUnifiedDlg.cpp:1990
 msgid "Media metadata extraction"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1665
+#: src/muuli_wdr.cpp:1669
 msgid "Extract length / bitrate / codec from shared audio and video files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1667
+#: src/muuli_wdr.cpp:1671
 msgid "When enabled, aMule runs ffprobe on each shared media file to fill in the Length / Bitrate / Codec columns other clients see when they find the file in a search. Requires ffmpeg (the ffprobe binary) to be installed."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1674
+#: src/muuli_wdr.cpp:1678
 msgid "Path to ffprobe:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1679
+#: src/muuli_wdr.cpp:1683
 msgid "Full path to the ffprobe binary. Leave empty to have aMule auto-detect it on startup."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1687
+#: src/muuli_wdr.cpp:1691
 msgid "Detect"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1688
+#: src/muuli_wdr.cpp:1692
 msgid "Search the standard install locations for an ffprobe binary and fill the path field."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1712
+#: src/muuli_wdr.cpp:1716
 msgid ""
 "Completed downloads are stored here. All files in this folder are automatically shared with other peers.\n"
 "If this folder also holds files you don't want to share, point it at an aMule-only sub-folder."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1715
+#: src/muuli_wdr.cpp:1719
 msgid "Pick the folder where completed downloads will be stored. All files in that folder will be shared with other peers."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1729
+#: src/muuli_wdr.cpp:1733
 msgid "Shared folders"
 msgstr "Dosare partajate"
 
-#: src/muuli_wdr.cpp:1735
+#: src/muuli_wdr.cpp:1739
 msgid "(Folders shared by the core. Enter a path to add one.)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1743
+#: src/muuli_wdr.cpp:1747
 msgid "Absolute path of a folder on the core's machine, e.g. /home/user/shared"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1745 src/PrefsUnifiedDlg.cpp:2794
+#: src/muuli_wdr.cpp:1749 src/PrefsUnifiedDlg.cpp:2874
 msgid "Recursive"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1746
+#: src/muuli_wdr.cpp:1750
 msgid "Share every sub-folder underneath this one, including ones created later."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1750 src/utils/aLinkCreator/src/alcframe.cpp:141
+#: src/muuli_wdr.cpp:1754 src/utils/aLinkCreator/src/alcframe.cpp:141
 msgid "Remove"
 msgstr "Elimină"
 
-#: src/muuli_wdr.cpp:1754
+#: src/muuli_wdr.cpp:1758
 msgid "(Right click on folder icon for recursive share)"
 msgstr "(Click dreapta pe miniatura dosarului pentru partajare recursivă)"
 
-#: src/muuli_wdr.cpp:1761
+#: src/muuli_wdr.cpp:1765
 msgid "Share hidden files"
 msgstr "Partajează fișierele ascunse"
 
-#: src/muuli_wdr.cpp:1767
+#: src/muuli_wdr.cpp:1771
 msgid "Automatically rescan shared folders for changes"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1773
+#: src/muuli_wdr.cpp:1777
 msgid "Follow symbolic links in shared folders"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1779
+#: src/muuli_wdr.cpp:1783
 msgid "Exclude files matching:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1782
+#: src/muuli_wdr.cpp:1786
 msgid "Wildcard patterns separated by '|', e.g. .DS_Store|Thumbs.db|*.tmp. Files whose name matches are not shared. Matching is case-insensitive."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1786
+#: src/muuli_wdr.cpp:1790
 msgid "Patterns are regular expressions"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1787
+#: src/muuli_wdr.cpp:1791
 msgid "When set, the whole field is one regular expression ('|' is alternation). When unset, it is a list of '|'-separated wildcards."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1797
+#: src/muuli_wdr.cpp:1801
 msgid "Show how many shared files the current pattern would exclude."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1818
+#: src/muuli_wdr.cpp:1822
 msgid "Graphs"
 msgstr "Grafice"
 
-#: src/muuli_wdr.cpp:1821 src/muuli_wdr.cpp:1883
+#: src/muuli_wdr.cpp:1825 src/muuli_wdr.cpp:1887
 msgid "Update delay : 5 secs"
 msgstr "Întârziere actualizare : 5 secunde"
 
-#: src/muuli_wdr.cpp:1825
+#: src/muuli_wdr.cpp:1829
 msgid "Time for average graph: 100 mins"
 msgstr "Timp pentru media graficului: 100 minute"
 
-#: src/muuli_wdr.cpp:1829
+#: src/muuli_wdr.cpp:1833
 msgid "Connections Graph Scale: 100 "
 msgstr "Scală grafic conexiuni: 100"
 
-#: src/muuli_wdr.cpp:1836
+#: src/muuli_wdr.cpp:1840
 msgid "Download graph scale:"
 msgstr "Scală grafic descărcare:"
 
-#: src/muuli_wdr.cpp:1844
+#: src/muuli_wdr.cpp:1848
 msgid "Upload graph scale:"
 msgstr "Scală grafic încărcare:"
 
-#: src/muuli_wdr.cpp:1854
+#: src/muuli_wdr.cpp:1858
 #, fuzzy
 msgid "Colors: "
 msgstr "Colori:"
 
-#: src/muuli_wdr.cpp:1858
+#: src/muuli_wdr.cpp:1862
 msgid "Background"
 msgstr "Fundal"
 
-#: src/muuli_wdr.cpp:1859
+#: src/muuli_wdr.cpp:1863
 msgid "Grid"
 msgstr "Grilă"
 
-#: src/muuli_wdr.cpp:1860
+#: src/muuli_wdr.cpp:1864
 msgid "Download current"
 msgstr "Descărcare actuală"
 
-#: src/muuli_wdr.cpp:1861
+#: src/muuli_wdr.cpp:1865
 msgid "Download running average"
 msgstr "Medie rulare descărcare"
 
-#: src/muuli_wdr.cpp:1862
+#: src/muuli_wdr.cpp:1866
 msgid "Download session average"
 msgstr "Medie descărcare pe sesiune"
 
-#: src/muuli_wdr.cpp:1863
+#: src/muuli_wdr.cpp:1867
 msgid "Upload current"
 msgstr "Încărcare actuală"
 
-#: src/muuli_wdr.cpp:1864
+#: src/muuli_wdr.cpp:1868
 msgid "Upload running average"
 msgstr "Medie rulare încărcare"
 
-#: src/muuli_wdr.cpp:1865
+#: src/muuli_wdr.cpp:1869
 msgid "Upload session average"
 msgstr "Medie încărcare pe sesiune"
 
-#: src/muuli_wdr.cpp:1866
+#: src/muuli_wdr.cpp:1870
 msgid "Active connections"
 msgstr "Conexiuni active"
 
-#: src/muuli_wdr.cpp:1869
+#: src/muuli_wdr.cpp:1873
 #, fuzzy
 msgid "Systray Icon Speed Bar"
 msgstr "Miniatură rapidă pe bara de sistem"
 
-#: src/muuli_wdr.cpp:1870
+#: src/muuli_wdr.cpp:1874
 msgid "Kad-nodes current"
 msgstr "Noduri Kad curente"
 
-#: src/muuli_wdr.cpp:1871
+#: src/muuli_wdr.cpp:1875
 msgid "Kad-nodes running"
 msgstr "Noduri Kad care rulează"
 
-#: src/muuli_wdr.cpp:1872
+#: src/muuli_wdr.cpp:1876
 msgid "Kad-nodes session"
 msgstr "Noduri Kad pe sesiune"
 
-#: src/muuli_wdr.cpp:1876 src/muuli_wdr.cpp:2303
+#: src/muuli_wdr.cpp:1880 src/muuli_wdr.cpp:2334
 msgid "Select"
 msgstr "Selectează"
 
-#: src/muuli_wdr.cpp:1880
+#: src/muuli_wdr.cpp:1884
 msgid "Tree"
 msgstr "Arbore"
 
-#: src/muuli_wdr.cpp:1890
+#: src/muuli_wdr.cpp:1894
 msgid "Number of Client Versions shown (0=unlimited)"
 msgstr "Număr de versiuni client arătate (0=nelimitat)"
 
-#: src/muuli_wdr.cpp:1915
+#: src/muuli_wdr.cpp:1919
 msgid "!!! WARNING !!!"
 msgstr "!!! ATENȚIE !!!"
 
-#: src/muuli_wdr.cpp:1930
+#: src/muuli_wdr.cpp:1934
 msgid "Max new connections / 5 secs"
 msgstr "Maxim conexiuni noi /5 secunde"
 
-#: src/muuli_wdr.cpp:1932
+#: src/muuli_wdr.cpp:1936
 msgid "Concurrent Kad source lookups"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1934
+#: src/muuli_wdr.cpp:1938
 #, fuzzy
 msgid "Kad source re-search interval (minutes)"
 msgstr "Rată interval actualizare FTP în minute"
 
-#: src/muuli_wdr.cpp:1936
+#: src/muuli_wdr.cpp:1940
 #, fuzzy
 msgid "Source re-ask interval (minutes)"
 msgstr "Rată interval actualizare FTP în minute"
 
-#: src/muuli_wdr.cpp:1940
+#: src/muuli_wdr.cpp:1944
 msgid "File Buffer Size: 240000 bytes"
 msgstr "Dimensiune fișier tampon: 240000 octeți"
 
-#: src/muuli_wdr.cpp:1944
+#: src/muuli_wdr.cpp:1948
 msgid "Use MMAP: memory-mapped file access (lower memory use)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1945
+#: src/muuli_wdr.cpp:1949
 msgid "Maps part files into memory instead of buffering them on the heap, lowering the process memory footprint. May reduce download speed on some disks; best for memory-constrained or upload-heavy hosts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1947
+#: src/muuli_wdr.cpp:1951
 msgid "Upload Queue Size: 5000 clients"
 msgstr "Dimensiune coadă încărcare: 5000 clienți"
 
-#: src/muuli_wdr.cpp:1951
+#: src/muuli_wdr.cpp:1955
 msgid "Server connection refresh interval: Disable"
 msgstr "Interval reîmprospătare conexiune server: Dezactivat"
 
-#: src/muuli_wdr.cpp:1955
+#: src/muuli_wdr.cpp:1959
 msgid "Disable computer's timed standby mode"
 msgstr "Dezactivează temporizarea modului de st-by al computerului"
 
-#: src/muuli_wdr.cpp:1974
+#: src/muuli_wdr.cpp:1978
 msgid "Skin to use: "
 msgstr "Aspect interfață de utilizat:"
 
-#: src/muuli_wdr.cpp:1983
+#: src/muuli_wdr.cpp:1987
 msgid "Show \"Fast eD2k Links Handler\" in every window."
 msgstr "Arată \"Manipulator linkuri rapide eD2k\" în fiecare fereastră."
 
-#: src/muuli_wdr.cpp:1986
+#: src/muuli_wdr.cpp:1990
 msgid "Show extended info on categories tabs"
 msgstr "Arată informații extinse în fila categoriilor"
 
-#: src/muuli_wdr.cpp:1989
+#: src/muuli_wdr.cpp:1993
 msgid "Show application version on title"
 msgstr "Arată în titlu versiunea aplicației"
 
-#: src/muuli_wdr.cpp:1991
+#: src/muuli_wdr.cpp:1995
 msgid "Show transfer rates on title"
 msgstr "Arată rata de transfer în titlu"
 
-#: src/muuli_wdr.cpp:1993
+#: src/muuli_wdr.cpp:1997
 msgid "Before application name"
 msgstr "Înaintea numelui aplicației"
 
-#: src/muuli_wdr.cpp:1995
+#: src/muuli_wdr.cpp:1999
 msgid "After application name"
 msgstr "După numele aplicației"
 
-#: src/muuli_wdr.cpp:1998
+#: src/muuli_wdr.cpp:2002
 msgid "Show overhead bandwidth"
 msgstr "Arată lățimea de bandă globală"
 
-#: src/muuli_wdr.cpp:2002
+#: src/muuli_wdr.cpp:2006
 msgid "Vertical toolbar orientation"
 msgstr "Orientare verticală a barei de unelte"
 
-#: src/muuli_wdr.cpp:2004
+#: src/muuli_wdr.cpp:2008
 msgid "Live column sorting (auto-reorder rows as their values change)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2011
+#: src/muuli_wdr.cpp:2015
 msgid "Download Queue Files"
 msgstr "Descărcare coadă fișiere"
 
-#: src/muuli_wdr.cpp:2014
+#: src/muuli_wdr.cpp:2018
 msgid "Show progress percentage"
 msgstr "Arată procentul progresului"
 
-#: src/muuli_wdr.cpp:2020
+#: src/muuli_wdr.cpp:2024
 msgid "Show progress bar"
 msgstr "Arată bara de progres"
 
-#: src/muuli_wdr.cpp:2023
+#: src/muuli_wdr.cpp:2027
 msgid "Flat"
 msgstr "Plat"
 
-#: src/muuli_wdr.cpp:2027
+#: src/muuli_wdr.cpp:2031
 msgid "Round"
 msgstr "Rotund"
 
-#: src/muuli_wdr.cpp:2045
+#: src/muuli_wdr.cpp:2049
 msgid "External Connection Parameters"
 msgstr "Parametrii conexiune externă"
 
-#: src/muuli_wdr.cpp:2048
+#: src/muuli_wdr.cpp:2052
 msgid "Accept external connections"
 msgstr "Acceptă conexiuni externe"
 
-#: src/muuli_wdr.cpp:2055 src/muuli_wdr.cpp:2114
+#: src/muuli_wdr.cpp:2059 src/muuli_wdr.cpp:2118
 msgid "IP of the listening interface:"
 msgstr "IP a interfeței de ascultare:"
 
-#: src/muuli_wdr.cpp:2058
+#: src/muuli_wdr.cpp:2062
 msgid "Enter here a valid ip in the a.b.c.d format for the listening EC interface. An empty field or 0.0.0.0 will mean any interface."
 msgstr "Introduceți aici un ip valid în formatul a.b.c.d pentru ascultarea interfeței EC. Un câmp gol sau 0.0.0.0 va însemna orice interfață."
 
-#: src/muuli_wdr.cpp:2079 src/muuli_wdr.cpp:2163
+#: src/muuli_wdr.cpp:2083 src/muuli_wdr.cpp:2194
 msgid "TCP port:"
 msgstr "port TCP:"
 
-#: src/muuli_wdr.cpp:2085
+#: src/muuli_wdr.cpp:2089
 msgid "Enable UPnP port forwarding on the EC port"
 msgstr "Activează înaintarea portului UPnP pe portul EC"
 
-#: src/muuli_wdr.cpp:2089 src/muuli_wdr.cpp:3048
+#: src/muuli_wdr.cpp:2093 src/muuli_wdr.cpp:3079
 #: src/utils/wxCas/src/wxcasprefs.cpp:167
 msgid "Password"
 msgstr "Parolă"
 
-#: src/muuli_wdr.cpp:2095
+#: src/muuli_wdr.cpp:2099
 #, fuzzy
 msgid "aMule API server parameters"
 msgstr "Parametrii server web"
 
-#: src/muuli_wdr.cpp:2098
+#: src/muuli_wdr.cpp:2102
 msgid "Run amuleapi (REST API) on startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2103
+#: src/muuli_wdr.cpp:2107
 #, fuzzy
 msgid "HTTP port:"
 msgstr "port TCP:"
 
-#: src/muuli_wdr.cpp:2117
+#: src/muuli_wdr.cpp:2121
 msgid "The interface amuleapi's HTTP server listens on. 127.0.0.1 (default) accepts only local connections; use 0.0.0.0 or a specific IP to expose it to other hosts (set an admin password below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2120
+#: src/muuli_wdr.cpp:2126
+msgid "Type a password to set or change it. Stored passwords cannot be shown, so leaving this empty keeps the current one."
+msgstr ""
+
+#: src/muuli_wdr.cpp:2128
 #, fuzzy
 msgid "Admin password"
 msgstr "Se verifică parola\n"
 
-#: src/muuli_wdr.cpp:2125 src/muuli_wdr.cpp:2156
-msgid "Low rights password"
-msgstr "Parolă cu drepturi scăzute"
+#: src/muuli_wdr.cpp:2140 src/muuli_wdr.cpp:2157 src/PrefsUnifiedDlg.cpp:1103
+#, fuzzy
+msgid "A password is set."
+msgstr "Se verifică parola\n"
 
-#: src/muuli_wdr.cpp:2133
+#: src/muuli_wdr.cpp:2144
+#, fuzzy
+msgid "Enable guest access"
+msgstr "Interzice accesul oaspeților"
+
+#: src/muuli_wdr.cpp:2145
+msgid "Guest sessions may read status and listings but cannot change anything. Turning this off clears the stored guest password."
+msgstr ""
+
+#: src/muuli_wdr.cpp:2149
+#, fuzzy
+msgid "Guest password"
+msgstr "Parola de oaspete pentru serverul web"
+
+#: src/muuli_wdr.cpp:2164
 msgid "Web server parameters"
 msgstr "Parametrii server web"
 
-#: src/muuli_wdr.cpp:2136
+#: src/muuli_wdr.cpp:2167
 #, fuzzy
 msgid "Run webserver on startup (deprecated)"
 msgstr "Rulează la pornire serverul web"
 
-#: src/muuli_wdr.cpp:2142
+#: src/muuli_wdr.cpp:2173
 msgid "Web template"
 msgstr "Șablon web"
 
-#: src/muuli_wdr.cpp:2147
+#: src/muuli_wdr.cpp:2178
 msgid "Full rights password"
 msgstr "Parolă cu drepturi depline"
 
-#: src/muuli_wdr.cpp:2151
+#: src/muuli_wdr.cpp:2182
 msgid "Enable Low rights User"
 msgstr "Activează utilizatorul cu drepturi scăzute"
 
-#: src/muuli_wdr.cpp:2170
+#: src/muuli_wdr.cpp:2187
+msgid "Low rights password"
+msgstr "Parolă cu drepturi scăzute"
+
+#: src/muuli_wdr.cpp:2201
 msgid "Enable UPnP port forwarding of the web server port"
 msgstr "Activează înaintarea portului UPnP pe portul serverului web"
 
-#: src/muuli_wdr.cpp:2175
+#: src/muuli_wdr.cpp:2206
 msgid "Web server UPnP TCP port (Optional)"
 msgstr "Port UPnP TCP server web (facultativ)"
 
-#: src/muuli_wdr.cpp:2183
+#: src/muuli_wdr.cpp:2214
 msgid "Page Refresh Time (in secs)"
 msgstr "Timp reîmprospătare pagină (în secunde)"
 
-#: src/muuli_wdr.cpp:2190
+#: src/muuli_wdr.cpp:2221
 msgid "Enable Gzip compression"
 msgstr "Activează compresia Gzip"
 
-#: src/muuli_wdr.cpp:2224
+#: src/muuli_wdr.cpp:2255
 #, fuzzy
 msgid "Reset page to defaults"
 msgstr "Valoare implicită a sistemului"
 
-#: src/muuli_wdr.cpp:2225
+#: src/muuli_wdr.cpp:2256
 msgid "Reset the settings on the current page to their default values."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2227 src/muuli_wdr.cpp:2313 src/ServerWnd.cpp:274
+#: src/muuli_wdr.cpp:2258 src/muuli_wdr.cpp:2344 src/ServerWnd.cpp:274
 #: src/ServerWnd.cpp:282
 msgid "OK"
 msgstr "Bine"
 
-#: src/muuli_wdr.cpp:2229
+#: src/muuli_wdr.cpp:2260
 msgid "Click here to apply any changes made to the preferences."
 msgstr "Apăsați aici pentru a aplica orice modificare efectuată la preferințe."
 
-#: src/muuli_wdr.cpp:2232
+#: src/muuli_wdr.cpp:2263
 msgid "Reset any changes made to the preferences."
 msgstr "Resetează orice schimbare efectuată la preferințe."
 
-#: src/muuli_wdr.cpp:2261
+#: src/muuli_wdr.cpp:2292
 msgid "Comment :"
 msgstr "Comentariu :"
 
-#: src/muuli_wdr.cpp:2268
+#: src/muuli_wdr.cpp:2299
 msgid "Incoming Dir :"
 msgstr "Director intrare :"
 
-#: src/muuli_wdr.cpp:2277
+#: src/muuli_wdr.cpp:2308
 msgid "Change priority for new assigned files :"
 msgstr "Schimbă prioritatea pentru noile fișiere alocate :"
 
-#: src/muuli_wdr.cpp:2281
+#: src/muuli_wdr.cpp:2312
 msgid "Don't change"
 msgstr "Nu modifica"
 
-#: src/muuli_wdr.cpp:2293
+#: src/muuli_wdr.cpp:2324
 msgid "Select color for this Category (currently selected) :"
 msgstr "Selectați culoarea pentru această categorie (selectată curent):"
 
-#: src/muuli_wdr.cpp:2360 src/muuli_wdr.cpp:2379 src/muuli_wdr.cpp:2401
+#: src/muuli_wdr.cpp:2391 src/muuli_wdr.cpp:2410 src/muuli_wdr.cpp:2432
 msgid "Click this button to reset the log."
 msgstr "Apăsați acest buton pentru resetarea jurnalului."
 
-#: src/muuli_wdr.cpp:2420
+#: src/muuli_wdr.cpp:2451
 msgid "Click on this button to update the servers list from URL ..."
 msgstr "Apăsați acest buton pentru a se actualiza lista serverelor din URL ..."
 
-#: src/muuli_wdr.cpp:2424
+#: src/muuli_wdr.cpp:2455
 msgid "Server list"
 msgstr "Listă server"
 
-#: src/muuli_wdr.cpp:2428
+#: src/muuli_wdr.cpp:2459
 msgid "Enter the url to a server.met file here and press the button to the left to update the list of known servers."
 msgstr "Introduceți aici adresa URL pentru un fișier server.met și apăsați butonul din stânga pentru a actualiza lista serverelor. cunoscute."
 
-#: src/muuli_wdr.cpp:2433
+#: src/muuli_wdr.cpp:2464
 msgid "Add server manually: Name"
 msgstr "Adăugare server manual: Nume"
 
-#: src/muuli_wdr.cpp:2436
+#: src/muuli_wdr.cpp:2467
 msgid "Enter the name of the new server here"
 msgstr "Introduceți aici numele noului server"
 
-#: src/muuli_wdr.cpp:2438 src/ServerWnd.cpp:206
+#: src/muuli_wdr.cpp:2469 src/ServerWnd.cpp:206
 msgid "IP:Port"
 msgstr "IP:Port"
 
-#: src/muuli_wdr.cpp:2441
+#: src/muuli_wdr.cpp:2472
 msgid "Enter the IP of the server here, using the x.x.x.x format."
 msgstr "Introduceți aici adresa IP a serverului, utilizând formatul x.x.x.x  ."
 
-#: src/muuli_wdr.cpp:2447
+#: src/muuli_wdr.cpp:2478
 msgid "Enter the port of the server here."
 msgstr "Introduceți aici portul serverului."
 
-#: src/muuli_wdr.cpp:2450
+#: src/muuli_wdr.cpp:2481
 msgid "Add manually a server (fill fields to the left before) ..."
 msgstr "Adăugați un server manual (completați întâi câmpurile din stânga) ..."
 
-#: src/muuli_wdr.cpp:2479
+#: src/muuli_wdr.cpp:2510
 msgid "aMule Log"
 msgstr "Jurnal aMule"
 
-#: src/muuli_wdr.cpp:2487
+#: src/muuli_wdr.cpp:2518
 msgid "Server Info"
 msgstr "Informație server"
 
-#: src/muuli_wdr.cpp:2491
+#: src/muuli_wdr.cpp:2522
 msgid "ED2K Info"
 msgstr "Informație eD2k"
 
-#: src/muuli_wdr.cpp:2495
+#: src/muuli_wdr.cpp:2526
 msgid "Kad Info"
 msgstr "Informație Kad"
 
-#: src/muuli_wdr.cpp:2523
+#: src/muuli_wdr.cpp:2554
 msgid "Click on this button to update the nodes list from URL ..."
 msgstr "Apăsați pe acest buton pentru a actualiza lista nodurilor din URL ..."
 
-#: src/muuli_wdr.cpp:2527
+#: src/muuli_wdr.cpp:2558
 msgid "Nodes (0)"
 msgstr "Noduri (0)"
 
-#: src/muuli_wdr.cpp:2531
+#: src/muuli_wdr.cpp:2562
 msgid "Enter the url to a nodes.dat file here and press the button to the left to update the list of known nodes."
 msgstr "Introduceți aici adresa url către un fișier nodes.dat și apăsați butonul din stânga pentru actualizarea listei nodurilor cunoscute."
 
-#: src/muuli_wdr.cpp:2534
+#: src/muuli_wdr.cpp:2565
 msgid "Nodes stats"
 msgstr "Stare noduri"
 
-#: src/muuli_wdr.cpp:2576
+#: src/muuli_wdr.cpp:2607
 msgid "Bootstrap"
 msgstr "Bootstrap"
 
-#: src/muuli_wdr.cpp:2579
+#: src/muuli_wdr.cpp:2610
 msgid "New node"
 msgstr "Nod nou"
 
-#: src/muuli_wdr.cpp:2584
+#: src/muuli_wdr.cpp:2615
 msgid "IP:"
 msgstr "IP:"
 
-#: src/muuli_wdr.cpp:2604
+#: src/muuli_wdr.cpp:2635
 msgid "Port:"
 msgstr "Port:"
 
-#: src/muuli_wdr.cpp:2617
+#: src/muuli_wdr.cpp:2648
 msgid "Bootstrap from known clients"
 msgstr "Bootstrap de la clienții cunoscuți"
 
-#: src/muuli_wdr.cpp:2619
+#: src/muuli_wdr.cpp:2650
 msgid "Disconnect Kad"
 msgstr "Deconectare Kad"
 
-#: src/muuli_wdr.cpp:2653
+#: src/muuli_wdr.cpp:2684
 msgid "Use Secure User Identification"
 msgstr "Utilizează identificarea securizată a utilizatorilor"
 
-#: src/muuli_wdr.cpp:2655
+#: src/muuli_wdr.cpp:2686
 msgid "It is recommended to enable this option. You will not receive credits if SUI is not enabled."
 msgstr "Este recomandat să activați această opțiune. Nu veți primii credite dacă SUI nu este activat."
 
-#: src/muuli_wdr.cpp:2657
+#: src/muuli_wdr.cpp:2688
 msgid "Protocol Obfuscation"
 msgstr "Protocol disimulare"
 
-#: src/muuli_wdr.cpp:2660
+#: src/muuli_wdr.cpp:2691
 msgid "Support Protocol Obfuscation"
 msgstr "Suport protocol disimulare"
 
-#: src/muuli_wdr.cpp:2662
+#: src/muuli_wdr.cpp:2693
 msgid "This option enabled Protocol Obfuscation, and makes aMule accept obfuscated connections from other clients."
 msgstr "Această opțiune activează Protocolul Disimulare, și determină aMule să accepte conexiuni disimulate de la alți clienți."
 
-#: src/muuli_wdr.cpp:2664
+#: src/muuli_wdr.cpp:2695
 msgid "Use obfuscation for outgoing connections"
 msgstr "Utilizați disimularea pentru conexiunile de ieșire"
 
-#: src/muuli_wdr.cpp:2666
+#: src/muuli_wdr.cpp:2697
 msgid "This option makes aMule use Protocol Obfuscation when connecting other clients/servers."
 msgstr "Această opțiune determină aMule să utilizeze Protocolul Disimulare când conectează alți clienți/servere."
 
-#: src/muuli_wdr.cpp:2668
+#: src/muuli_wdr.cpp:2699
 msgid "Accept only obfuscated connections"
 msgstr "Acceptă numai conexiuni disimulate"
 
-#: src/muuli_wdr.cpp:2669
+#: src/muuli_wdr.cpp:2700
 msgid "This option makes aMule only accept obfuscated connections. You will have less sources, but all your traffic will be obfuscated"
 msgstr "Această opțiune face aMule să accepte numai conexiuni disimulate. Veți avea mai puține surse, dar tot traficul va fi disimulat"
 
-#: src/muuli_wdr.cpp:2674
+#: src/muuli_wdr.cpp:2705
 msgid "Everybody"
 msgstr "Fiecare"
 
-#: src/muuli_wdr.cpp:2676
+#: src/muuli_wdr.cpp:2707
 msgid "No one"
 msgstr "Nimănui"
 
-#: src/muuli_wdr.cpp:2678
+#: src/muuli_wdr.cpp:2709
 msgid "Who can see my shared files:"
 msgstr "Cine poate vedea fișierele mele partajate:"
 
-#: src/muuli_wdr.cpp:2679
+#: src/muuli_wdr.cpp:2710
 msgid "Select who can request to view a list of your shared files."
 msgstr "Selectați cine poate solicita să vizualizeze o listă a fișierelor partajate."
 
-#: src/muuli_wdr.cpp:2681
+#: src/muuli_wdr.cpp:2712
 msgid "IP-Filtering"
 msgstr "Filtrare-IP"
 
-#: src/muuli_wdr.cpp:2688
+#: src/muuli_wdr.cpp:2719
 msgid "Filter clients"
 msgstr "Filtru clienți"
 
-#: src/muuli_wdr.cpp:2690
+#: src/muuli_wdr.cpp:2721
 msgid "Enable filtering of the client IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "Activați filtrarea IP-urilor client cum este definit în fișierul ~/.aMule/ipfilter.dat."
 
-#: src/muuli_wdr.cpp:2692
+#: src/muuli_wdr.cpp:2723
 msgid "Filter servers"
 msgstr "Filtrare servere"
 
-#: src/muuli_wdr.cpp:2694
+#: src/muuli_wdr.cpp:2725
 msgid "Enable filtering of the server IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "Activați filtrarea IP-urilor server cum este definit în fișierul ~/.aMule/ipfilter.dat."
 
-#: src/muuli_wdr.cpp:2698
+#: src/muuli_wdr.cpp:2729
 msgid "Reload List"
 msgstr "Reîncarcă lista"
 
-#: src/muuli_wdr.cpp:2699
+#: src/muuli_wdr.cpp:2730
 msgid "Reload the list of IPs to filter from the file ~/.aMule/ipfilter.dat"
 msgstr "Reîncarcă lista IP-urilor de filtrat din fișierul ~/.aMule/ipfilter.dat"
 
-#: src/muuli_wdr.cpp:2705
+#: src/muuli_wdr.cpp:2736
 msgid "URL:"
 msgstr "URL:"
 
-#: src/muuli_wdr.cpp:2709 src/muuli_wdr.cpp:2902
+#: src/muuli_wdr.cpp:2740 src/muuli_wdr.cpp:2933
 msgid "Update now"
 msgstr "Actualizează acum"
 
-#: src/muuli_wdr.cpp:2712
+#: src/muuli_wdr.cpp:2743
 msgid "Auto-update ipfilter at startup"
 msgstr "Actualizare automată filtru ip la pornire"
 
-#: src/muuli_wdr.cpp:2716
+#: src/muuli_wdr.cpp:2747
 msgid "Filtering Level:"
 msgstr "Nivel de filtrare:"
 
-#: src/muuli_wdr.cpp:2722
+#: src/muuli_wdr.cpp:2753
 msgid "Always filter LAN IPs"
 msgstr "Filtrează mereu IP-urile LAN"
 
-#: src/muuli_wdr.cpp:2725
+#: src/muuli_wdr.cpp:2756
 msgid "Paranoid handling of non-matching IPs"
 msgstr "Manipulare paranoică a IP-urilor care nu se potrivesc"
 
-#: src/muuli_wdr.cpp:2727
+#: src/muuli_wdr.cpp:2758
 msgid "Rejects a packet when its source IP differs from the IP the client claims (an anti-spoofing check). Disable only if it causes connection problems."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2729
+#: src/muuli_wdr.cpp:2760
 msgid "Use system-wide ipfilter.dat if available"
 msgstr "Utilizați în tot sistemul ipfilter.dat dacă este disponibil"
 
-#: src/muuli_wdr.cpp:2730
+#: src/muuli_wdr.cpp:2761
 #, fuzzy
 msgid "If there's no local ipfilter.dat found, allow usage of a system-wide ipfilter file."
 msgstr "Dacă nu s-a găsit local ipfilter.dat, permite utilizarea unui fișier ipfilter din sistem."
 
-#: src/muuli_wdr.cpp:2747
+#: src/muuli_wdr.cpp:2778
 msgid "Enable Online-Signature"
 msgstr "Activare semnătură online"
 
-#: src/muuli_wdr.cpp:2749
+#: src/muuli_wdr.cpp:2780
 msgid "Enables the writing of the OS file, which can be used by external apps to create signatures and the like."
 msgstr "Activați scrierea fișierului OS, care poate fi utilizat de aplicații exterioare la crearea semnăturilor și aprecierii."
 
-#: src/muuli_wdr.cpp:2753
+#: src/muuli_wdr.cpp:2784
 msgid "Update Frequency (Secs):"
 msgstr "Frecvență actualizare (secunde)"
 
-#: src/muuli_wdr.cpp:2756
+#: src/muuli_wdr.cpp:2787
 msgid "Change the frequency (in seconds) of Online Signature updates."
 msgstr "Schimbați frecvența (în secunde) a actualizărilor semnăturii online."
 
-#: src/muuli_wdr.cpp:2764
+#: src/muuli_wdr.cpp:2795
 msgid "Save online signature file in: "
 msgstr "Salvează fișierul semnăturii online în:"
 
-#: src/muuli_wdr.cpp:2770
+#: src/muuli_wdr.cpp:2801
 msgid "Click here to select the directory containing the the Online Signature files."
 msgstr "Apăsați aici pentru a selecta directorul care conține fișierele cu semnătura online."
 
-#: src/muuli_wdr.cpp:2803
+#: src/muuli_wdr.cpp:2834
 msgid "Show country flags for clients"
 msgstr "Arată steagul țării pentru clienți"
 
-#: src/muuli_wdr.cpp:2804
+#: src/muuli_wdr.cpp:2835
 msgid "Render the country flag column in the transfers, queue and search views. Requires a valid MMDB GeoIP database (see below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2809
+#: src/muuli_wdr.cpp:2840
 #, fuzzy
 msgid "Database"
 msgstr "Rată date :"
 
-#: src/muuli_wdr.cpp:2825
+#: src/muuli_wdr.cpp:2856
 #, fuzzy
 msgid "Source:"
 msgstr "Surse"
 
-#: src/muuli_wdr.cpp:2828
+#: src/muuli_wdr.cpp:2859
 msgid "DB-IP (free, no account)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2829
+#: src/muuli_wdr.cpp:2860
 msgid "MaxMind GeoLite2 (free, account required)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2830
+#: src/muuli_wdr.cpp:2861
 msgid "Custom URL"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2833
+#: src/muuli_wdr.cpp:2864
 msgid "Choose which provider supplies the GeoIP MMDB database. DB-IP is the default - no account required. MaxMind requires a free account + license key. Use Custom URL to point at any other MMDB host (e.g. a local mirror)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2850
+#: src/muuli_wdr.cpp:2881
 msgid ""
 "No configuration required.\n"
 "\n"
@@ -4862,11 +4890,11 @@ msgid ""
 "License: Creative Commons BY 4.0 - https://creativecommons.org/licenses/by/4.0/"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2863
+#: src/muuli_wdr.cpp:2894
 msgid "License key:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2869
+#: src/muuli_wdr.cpp:2900
 msgid ""
 "Sign up for a free MaxMind account, then generate a License Key:\n"
 "https://www.maxmind.com/en/geolite2/signup\n"
@@ -4876,225 +4904,225 @@ msgid ""
 "Requires attribution and account registration; refresh at least every 30 days."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2884
+#: src/muuli_wdr.cpp:2915
 #, fuzzy
 msgid "Download URL:"
 msgstr "Descărcare:"
 
-#: src/muuli_wdr.cpp:2890
+#: src/muuli_wdr.cpp:2921
 msgid ""
 "Must point to an .mmdb file or a .gz / .tar.gz containing one.\n"
 "URL may include credentials (https://user:pass@host/...).\n"
 "License and attribution terms are set by the upstream URL - you are responsible."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2903
+#: src/muuli_wdr.cpp:2934
 msgid "Download the GeoIP database from the selected source."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2905
+#: src/muuli_wdr.cpp:2936
 #, fuzzy
 msgid "Auto-update on startup"
 msgstr "Actualizare automată filtru ip la pornire"
 
-#: src/muuli_wdr.cpp:2906
+#: src/muuli_wdr.cpp:2937
 msgid "Re-download the GeoIP database from the selected source every time aMule starts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2929
+#: src/muuli_wdr.cpp:2960
 msgid "Filter incoming messages (except current chat):"
 msgstr "Filtrare mesaje de intrare (cu excepția chat-ului curent):"
 
-#: src/muuli_wdr.cpp:2931
+#: src/muuli_wdr.cpp:2962
 msgid "Filter all messages"
 msgstr "Filtrează toate mesajele"
 
-#: src/muuli_wdr.cpp:2933
+#: src/muuli_wdr.cpp:2964
 msgid "Filter messages from people not on your friend list"
 msgstr "Filtrare mesaje de la persoane care nu sunt în lista de prieteni"
 
-#: src/muuli_wdr.cpp:2935
+#: src/muuli_wdr.cpp:2966
 msgid "Filter messages from unknown clients"
 msgstr "Filtrare mesaje de la clienți necunoscuți"
 
-#: src/muuli_wdr.cpp:2937
+#: src/muuli_wdr.cpp:2968
 msgid "Filter messages containing (use ',' as separator):"
 msgstr "Filtrare mesaje conținând )utilizați ',' ca separator):"
 
-#: src/muuli_wdr.cpp:2940 src/muuli_wdr.cpp:2951
+#: src/muuli_wdr.cpp:2971 src/muuli_wdr.cpp:2982
 msgid "add here the words amule should filter and block messages including it"
 msgstr "adăugați aici cuvintele pe care amule trebuie să le filtreze și să blocheze mesajele care le includ"
 
-#: src/muuli_wdr.cpp:2942
+#: src/muuli_wdr.cpp:2973
 msgid "Show received messages in the log"
 msgstr "Arată în jurnal mesajele primite"
 
-#: src/muuli_wdr.cpp:2945
+#: src/muuli_wdr.cpp:2976
 msgid "Comments"
 msgstr "Comentarii"
 
-#: src/muuli_wdr.cpp:2948
+#: src/muuli_wdr.cpp:2979
 msgid "Filter comments containing (use ',' as separator):"
 msgstr "Filtrare comentarii conținând (utilizați ',' ca separator):"
 
-#: src/muuli_wdr.cpp:2973
+#: src/muuli_wdr.cpp:3004
 msgid "Enable Proxy"
 msgstr "Activează proxy"
 
-#: src/muuli_wdr.cpp:2974
+#: src/muuli_wdr.cpp:3005
 msgid "Enable/disable proxy support"
 msgstr "Activează/dezactivează suportul proxy"
 
-#: src/muuli_wdr.cpp:2977
+#: src/muuli_wdr.cpp:3008
 msgid "Proxy type:"
 msgstr "Tip proxy:"
 
-#: src/muuli_wdr.cpp:2988
+#: src/muuli_wdr.cpp:3019
 msgid "Proxy host:"
 msgstr "Gazdă proxy:"
 
-#: src/muuli_wdr.cpp:2991
+#: src/muuli_wdr.cpp:3022
 msgid "The proxy host name"
 msgstr "Numele de gazdă proxy"
 
-#: src/muuli_wdr.cpp:2993
+#: src/muuli_wdr.cpp:3024
 msgid "Proxy port:"
 msgstr "Port proxy:"
 
-#: src/muuli_wdr.cpp:2996
+#: src/muuli_wdr.cpp:3027
 msgid "The proxy port"
 msgstr "Portul proxy"
 
-#: src/muuli_wdr.cpp:2998
+#: src/muuli_wdr.cpp:3029
 msgid "Enable authentication"
 msgstr "Activează autentificarea"
 
-#: src/muuli_wdr.cpp:2999
+#: src/muuli_wdr.cpp:3030
 msgid "Enable/disable username/password authentication"
 msgstr "Activează/dezactivează autentificarea cu nume utilizator/parolă"
 
-#: src/muuli_wdr.cpp:3002
+#: src/muuli_wdr.cpp:3033
 msgid "Username: "
 msgstr "Utilizator:"
 
-#: src/muuli_wdr.cpp:3005
+#: src/muuli_wdr.cpp:3036
 msgid "The username to use to connect to the proxy"
 msgstr "Numele de utilizator de utilizat pentru conectarea la proxy"
 
-#: src/muuli_wdr.cpp:3007
+#: src/muuli_wdr.cpp:3038
 msgid "Password:"
 msgstr "Parolă:"
 
-#: src/muuli_wdr.cpp:3010
+#: src/muuli_wdr.cpp:3041
 msgid "The password to use to connect to the proxy"
 msgstr "Parola de utilizat pentru conectarea la proxy"
 
-#: src/muuli_wdr.cpp:3029
+#: src/muuli_wdr.cpp:3060
 msgid "Connect to:"
 msgstr "Conectează la:"
 
-#: src/muuli_wdr.cpp:3038
+#: src/muuli_wdr.cpp:3069
 msgid "Login to remote amule"
 msgstr "Autentificare la amule distant"
 
-#: src/muuli_wdr.cpp:3043
+#: src/muuli_wdr.cpp:3074
 msgid "User name"
 msgstr "Nume utilizator"
 
-#: src/muuli_wdr.cpp:3054
+#: src/muuli_wdr.cpp:3085
 msgid "Remember those settings"
 msgstr "Amintește aceste configurări"
 
-#: src/muuli_wdr.cpp:3057
+#: src/muuli_wdr.cpp:3088
 #, fuzzy
 msgid "Force ZLIB compression"
 msgstr "Utilizează compresia gzip"
 
-#: src/muuli_wdr.cpp:3081
+#: src/muuli_wdr.cpp:3112
 msgid "Enable Verbose Debug-Logging."
 msgstr "Activează jurnalizarea de depanare detaliată."
 
-#: src/muuli_wdr.cpp:3083
+#: src/muuli_wdr.cpp:3114
 msgid "Only to Logfile"
 msgstr "Numai la fișierul jurnal"
 
-#: src/muuli_wdr.cpp:3085
+#: src/muuli_wdr.cpp:3116
 msgid "Message Categories:"
 msgstr "Categorii mesaje:"
 
-#: src/muuli_wdr.cpp:3109 src/PartFileConvertDlg.cpp:160
+#: src/muuli_wdr.cpp:3140 src/PartFileConvertDlg.cpp:160
 msgid "Waiting..."
 msgstr "Așteptați..."
 
-#: src/muuli_wdr.cpp:3129
+#: src/muuli_wdr.cpp:3160
 msgid "Add imports"
 msgstr "Adaugă importurile"
 
-#: src/muuli_wdr.cpp:3132
+#: src/muuli_wdr.cpp:3163
 msgid "Retry selected"
 msgstr "Reîncearcă selectatele"
 
-#: src/muuli_wdr.cpp:3134
+#: src/muuli_wdr.cpp:3165
 msgid "Remove selected"
 msgstr "Elimină selecția"
 
-#: src/muuli_wdr.cpp:3197
+#: src/muuli_wdr.cpp:3228
 msgid "Event Types"
 msgstr "Tipuri de evenimente"
 
-#: src/muuli_wdr.cpp:3216
+#: src/muuli_wdr.cpp:3247
 msgid "Statistics and queued clients for selected file(s) : Session / All time"
 msgstr "Statistici și clienți în coadă pentru fișier(ele) selectate : Sesiune / Tot timpul"
 
-#: src/muuli_wdr.cpp:3240
+#: src/muuli_wdr.cpp:3271
 msgid "Active Uploads"
 msgstr "Încărcări active"
 
-#: src/muuli_wdr.cpp:3254
+#: src/muuli_wdr.cpp:3285
 msgid "Percent of total files"
 msgstr "Procentul din totalul fișierelor"
 
-#: src/muuli_wdr.cpp:3306
+#: src/muuli_wdr.cpp:3337
 msgid "Show Clients for"
 msgstr "Arată clienții pentru"
 
-#: src/muuli_wdr.cpp:3308
+#: src/muuli_wdr.cpp:3339
 msgid "All files"
 msgstr "Toate fișierele"
 
-#: src/muuli_wdr.cpp:3311
+#: src/muuli_wdr.cpp:3342
 msgid "Selected files"
 msgstr "Fișierele selectate"
 
-#: src/muuli_wdr.cpp:3314
+#: src/muuli_wdr.cpp:3345
 msgid "Active uploads only"
 msgstr "Numai încărcările active"
 
-#: src/muuli_wdr.cpp:3321
+#: src/muuli_wdr.cpp:3352
 msgid "Reload:"
 msgstr "Reîncarcă:"
 
-#: src/muuli_wdr.cpp:3325
+#: src/muuli_wdr.cpp:3356
 msgid "Reload your shared files"
 msgstr "Reîncărcați fișierele partajate"
 
-#: src/muuli_wdr.cpp:3388
+#: src/muuli_wdr.cpp:3419
 msgid "Send"
 msgstr "Trimite"
 
-#: src/muuli_wdr.cpp:3389
+#: src/muuli_wdr.cpp:3420
 msgid "Sends the specified message."
 msgstr "Trimite mesajul specificat"
 
-#: src/muuli_wdr.cpp:3393
+#: src/muuli_wdr.cpp:3424
 msgid "Close this chat-session."
 msgstr "Închide această sesiune de chat."
 
-#: src/muuli_wdr.cpp:3416
+#: src/muuli_wdr.cpp:3447
 msgid "Connect to any server and/or Kad"
 msgstr "Conectare la orice server și/sau Kad"
 
-#: src/muuli_wdr.cpp:3422 src/SharedFilesCtrl.cpp:142 src/Statistics.cpp:941
+#: src/muuli_wdr.cpp:3453 src/SharedFilesCtrl.cpp:142 src/Statistics.cpp:941
 msgid "Shared Files"
 msgstr "Fișiere partajate"
 
@@ -5457,249 +5485,249 @@ msgstr "Descărcat"
 msgid "ERROR: Failed to open partfile '%s'"
 msgstr "EROARE: A eșuat deschiderea fișierului parțial '%s'"
 
-#: src/Preferences.cpp:674
+#: src/Preferences.cpp:701
 msgid "System default"
 msgstr "Valoare implicită a sistemului"
 
-#: src/Preferences.cpp:675
+#: src/Preferences.cpp:702
 msgid "Albanian"
 msgstr "Albaneză"
 
-#: src/Preferences.cpp:676
+#: src/Preferences.cpp:703
 msgid "Arabic"
 msgstr "Arabă"
 
-#: src/Preferences.cpp:677
+#: src/Preferences.cpp:704
 msgid "Asturian"
 msgstr "Asturian"
 
-#: src/Preferences.cpp:678
+#: src/Preferences.cpp:705
 msgid "Basque"
 msgstr "Bască"
 
-#: src/Preferences.cpp:679
+#: src/Preferences.cpp:706
 msgid "Bulgarian"
 msgstr "Bulgară"
 
-#: src/Preferences.cpp:680
+#: src/Preferences.cpp:707
 msgid "Catalan"
 msgstr "Catalană"
 
-#: src/Preferences.cpp:681
+#: src/Preferences.cpp:708
 msgid "Chinese (Simplified)"
 msgstr "Chineză (Simplificat)"
 
-#: src/Preferences.cpp:682
+#: src/Preferences.cpp:709
 msgid "Chinese (Traditional)"
 msgstr "Chinez (tradițional)"
 
-#: src/Preferences.cpp:683
+#: src/Preferences.cpp:710
 msgid "Croatian"
 msgstr "Croată"
 
-#: src/Preferences.cpp:684
+#: src/Preferences.cpp:711
 msgid "Czech"
 msgstr "Cehă"
 
-#: src/Preferences.cpp:685
+#: src/Preferences.cpp:712
 msgid "Danish"
 msgstr "Daneză"
 
-#: src/Preferences.cpp:686
+#: src/Preferences.cpp:713
 msgid "Dutch"
 msgstr "Olandeză"
 
-#: src/Preferences.cpp:687
+#: src/Preferences.cpp:714
 msgid "English (U.K.)"
 msgstr "Englez (U.K.)"
 
-#: src/Preferences.cpp:688
+#: src/Preferences.cpp:715
 #, fuzzy
 msgid "English (U.S.)"
 msgstr "Englez (U.K.)"
 
-#: src/Preferences.cpp:689
+#: src/Preferences.cpp:716
 msgid "Estonian"
 msgstr "Estonă"
 
-#: src/Preferences.cpp:690
+#: src/Preferences.cpp:717
 msgid "Finnish"
 msgstr "Finlandeză"
 
-#: src/Preferences.cpp:691
+#: src/Preferences.cpp:718
 msgid "French"
 msgstr "Franceză"
 
-#: src/Preferences.cpp:692
+#: src/Preferences.cpp:719
 msgid "Galician"
 msgstr "Galiciană"
 
-#: src/Preferences.cpp:693
+#: src/Preferences.cpp:720
 msgid "German"
 msgstr "Germană"
 
-#: src/Preferences.cpp:694
+#: src/Preferences.cpp:721
 msgid "Greek"
 msgstr "Grecesc"
 
-#: src/Preferences.cpp:695
+#: src/Preferences.cpp:722
 msgid "Hebrew"
 msgstr "Ebraică"
 
-#: src/Preferences.cpp:696
+#: src/Preferences.cpp:723
 msgid "Hungarian"
 msgstr "Maghiară"
 
-#: src/Preferences.cpp:697
+#: src/Preferences.cpp:724
 msgid "Italian"
 msgstr "Italiană"
 
-#: src/Preferences.cpp:698
+#: src/Preferences.cpp:725
 msgid "Japanese"
 msgstr "Japoneză"
 
-#: src/Preferences.cpp:699
+#: src/Preferences.cpp:726
 msgid "Korean"
 msgstr "Koreană"
 
-#: src/Preferences.cpp:700
+#: src/Preferences.cpp:727
 msgid "Latvian"
 msgstr ""
 
-#: src/Preferences.cpp:701
+#: src/Preferences.cpp:728
 msgid "Lithuanian"
 msgstr "Lituaniană"
 
-#: src/Preferences.cpp:702
+#: src/Preferences.cpp:729
 msgid "Norwegian (Nynorsk)"
 msgstr "Norvegian"
 
-#: src/Preferences.cpp:703
+#: src/Preferences.cpp:730
 msgid "Polish"
 msgstr "Poloneză"
 
-#: src/Preferences.cpp:704
+#: src/Preferences.cpp:731
 msgid "Portuguese"
 msgstr "Portugheză"
 
-#: src/Preferences.cpp:705
+#: src/Preferences.cpp:732
 msgid "Portuguese (Brazilian)"
 msgstr "Portugheză (Brazilia)"
 
-#: src/Preferences.cpp:706
+#: src/Preferences.cpp:733
 msgid "Romanian"
 msgstr "Română"
 
-#: src/Preferences.cpp:707
+#: src/Preferences.cpp:734
 msgid "Russian"
 msgstr "Rusă"
 
-#: src/Preferences.cpp:708
+#: src/Preferences.cpp:735
 msgid "Slovenian"
 msgstr "Slovenă"
 
-#: src/Preferences.cpp:709
+#: src/Preferences.cpp:736
 msgid "Spanish"
 msgstr "Spaniolă"
 
-#: src/Preferences.cpp:710
+#: src/Preferences.cpp:737
 msgid "Swedish"
 msgstr "Suedeză"
 
-#: src/Preferences.cpp:711
+#: src/Preferences.cpp:738
 msgid "Turkish"
 msgstr "Turcă"
 
-#: src/Preferences.cpp:712
+#: src/Preferences.cpp:739
 msgid "Ukrainian"
 msgstr "Ucraineană"
 
-#: src/Preferences.cpp:815
+#: src/Preferences.cpp:842
 msgid "Change Language"
 msgstr "Schimbă limba"
 
-#: src/Preferences.cpp:879
+#: src/Preferences.cpp:906
 msgid "There are no translations installed for aMule"
 msgstr "Nu sunt instalate traduceri pentru aMule"
 
-#: src/Preferences.cpp:880
+#: src/Preferences.cpp:907
 msgid "No languages available"
 msgstr "Nu sunt limbi disponibile"
 
-#: src/Preferences.cpp:1011
+#: src/Preferences.cpp:1038
 msgid "no options available"
 msgstr "Nu sunt opțiuni disponibile"
 
-#: src/Preferences.cpp:2182
+#: src/Preferences.cpp:2227
 msgid "Invalid category found, skipping"
 msgstr "S-a găsit o categorie nevalidă, se omite"
 
-#: src/Preferences.cpp:2351
+#: src/Preferences.cpp:2396
 msgid "TCP port can't be higher than 65532 due to server UDP socket being TCP+3"
 msgstr "Portul TCP nu poate fi mai mare decât 65532 fiindcă soclul UDP al serverului trebuie să fie TCP+3"
 
-#: src/Preferences.cpp:2352
+#: src/Preferences.cpp:2397
 #, c-format
 msgid "Default port will be used (%d)"
 msgstr "Va fi folosit portul implicit (%d)"
 
-#: src/PrefsUnifiedDlg.cpp:298 src/Statistics.cpp:866
+#: src/PrefsUnifiedDlg.cpp:300 src/Statistics.cpp:866
 msgid "Connection"
 msgstr "Conexiune"
 
-#: src/PrefsUnifiedDlg.cpp:299 src/SearchListCtrl.cpp:117
+#: src/PrefsUnifiedDlg.cpp:301 src/SearchListCtrl.cpp:117
 msgid "Directories"
 msgstr "Directoare"
 
-#: src/PrefsUnifiedDlg.cpp:300 src/Statistics.cpp:917
+#: src/PrefsUnifiedDlg.cpp:302 src/Statistics.cpp:917
 msgid "Servers"
 msgstr "Servere"
 
-#: src/PrefsUnifiedDlg.cpp:301 src/ServerListCtrl.cpp:96
+#: src/PrefsUnifiedDlg.cpp:303 src/ServerListCtrl.cpp:96
 msgid "Files"
 msgstr "Fișiere"
 
-#: src/PrefsUnifiedDlg.cpp:302
+#: src/PrefsUnifiedDlg.cpp:304
 msgid "Security"
 msgstr "Securitate"
 
-#: src/PrefsUnifiedDlg.cpp:303
+#: src/PrefsUnifiedDlg.cpp:305
 msgid "Interface"
 msgstr "Interfaţă"
 
-#: src/PrefsUnifiedDlg.cpp:310
+#: src/PrefsUnifiedDlg.cpp:312
 msgid "IP2Country"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:313
+#: src/PrefsUnifiedDlg.cpp:315
 msgid "Proxy"
 msgstr "Proxy"
 
-#: src/PrefsUnifiedDlg.cpp:314
+#: src/PrefsUnifiedDlg.cpp:316
 msgid "Filters"
 msgstr "Filtre"
 
-#: src/PrefsUnifiedDlg.cpp:315
+#: src/PrefsUnifiedDlg.cpp:317
 msgid "Remote Controls"
 msgstr "Control la distanță"
 
-#: src/PrefsUnifiedDlg.cpp:316
+#: src/PrefsUnifiedDlg.cpp:318
 msgid "Online Signature"
 msgstr "Semnătură online"
 
-#: src/PrefsUnifiedDlg.cpp:317
+#: src/PrefsUnifiedDlg.cpp:319
 msgid "Advanced"
 msgstr "Avansat"
 
-#: src/PrefsUnifiedDlg.cpp:318
+#: src/PrefsUnifiedDlg.cpp:320
 msgid "Events"
 msgstr "Evenimente"
 
-#: src/PrefsUnifiedDlg.cpp:321
+#: src/PrefsUnifiedDlg.cpp:323
 msgid "Debugging"
 msgstr "Depanare"
 
-#: src/PrefsUnifiedDlg.cpp:451
+#: src/PrefsUnifiedDlg.cpp:453
 msgid ""
 "The following variables will be substituted:\n"
 "    %PARTFILE - full path to the file\n"
@@ -5709,15 +5737,15 @@ msgstr ""
 "    %PARTFILE - calea completă la fișier\n"
 "    %PARTNAME - numai nume fișier"
 
-#: src/PrefsUnifiedDlg.cpp:472
+#: src/PrefsUnifiedDlg.cpp:474
 msgid "Tray icon support requires libayatana-appindicator3 at compile time."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:488
+#: src/PrefsUnifiedDlg.cpp:490
 msgid "Not available on Wayland: the protocol does not report when a window is minimized, so this option cannot intercept the system minimize button. Workaround: launch aMule with `GDK_BACKEND=x11` to use XWayland instead."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:534
+#: src/PrefsUnifiedDlg.cpp:536
 msgid ""
 "Do not change these setting unless you know\n"
 "what you are doing, otherwise you can easily\n"
@@ -5732,26 +5760,35 @@ msgstr ""
 "aMule va rula perfect fără să ajustați nimic\n"
 "din aceste configurări."
 
-#: src/PrefsUnifiedDlg.cpp:645
+#: src/PrefsUnifiedDlg.cpp:647
 #, c-format
 msgid "Failed to connect Cfg to widget with the ID %d and key %s"
 msgstr "A eșuat conectarea Cfg la widget cu ID %d și cheia %s"
 
-#: src/PrefsUnifiedDlg.cpp:693
+#: src/PrefsUnifiedDlg.cpp:695
 #, c-format
 msgid "Failed to transfer data from Cfg to Widget with the ID %d and key %s"
 msgstr "A eșuat transferul datelor de la Cfg la widget cu ID %d și cheia %s"
 
-#: src/PrefsUnifiedDlg.cpp:799
+#: src/PrefsUnifiedDlg.cpp:801
 msgid "The type of proxy you are connecting to"
 msgstr "Tipul de proxy la care sunteți conectat"
 
-#: src/PrefsUnifiedDlg.cpp:1003
+#: src/PrefsUnifiedDlg.cpp:1020
 #, c-format
 msgid "Failed to transfer data from Widget to Cfg with the ID %d and key %s"
 msgstr "A eșuat transferul datelor de la widget la Cfg cu ID %d și cheia %s"
 
 #: src/PrefsUnifiedDlg.cpp:1103
+#, fuzzy
+msgid "No password set."
+msgstr "Se verifică parola\n"
+
+#: src/PrefsUnifiedDlg.cpp:1132
+msgid "Guest access needs a password. Type one in the guest password field, or untick Enable guest access."
+msgstr ""
+
+#: src/PrefsUnifiedDlg.cpp:1144
 msgid ""
 "aMule must be restarted to enable these changes:\n"
 "\n"
@@ -5759,41 +5796,41 @@ msgstr ""
 "aMule trebuie repornit pentru ca aceste modificări să fie activate:\n"
 "\n"
 
-#: src/PrefsUnifiedDlg.cpp:1110
+#: src/PrefsUnifiedDlg.cpp:1151
 msgid "- TCP port changed.\n"
 msgstr "- Portul TCP s-a schimbat.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1115
+#: src/PrefsUnifiedDlg.cpp:1156
 msgid "- UDP port changed.\n"
 msgstr "- Portul UDP s-a schimbat.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1120
+#: src/PrefsUnifiedDlg.cpp:1161
 #, fuzzy
 msgid "- Network interface binding changed.\n"
 msgstr "- Interfața conexiunii externe s-a schimbat.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1125
+#: src/PrefsUnifiedDlg.cpp:1166
 msgid "- External connect port changed.\n"
 msgstr "- Portul conexiunii externe s-a schimbat.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1129
+#: src/PrefsUnifiedDlg.cpp:1170
 msgid "- External connect acceptance changed.\n"
 msgstr "- Conectarea externă acceptă modificarea.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1133
+#: src/PrefsUnifiedDlg.cpp:1174
 msgid "- External connect interface changed.\n"
 msgstr "- Interfața conexiunii externe s-a schimbat.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1137
+#: src/PrefsUnifiedDlg.cpp:1178
 msgid "- Protocol obfuscation support changed.\n"
 msgstr "- Suportul protocolului disimulare s-a schimbat.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1151
+#: src/PrefsUnifiedDlg.cpp:1193
 #, fuzzy
 msgid "- amuleapi settings changed.\n"
 msgstr "- Limba s-a schimbat.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1160
+#: src/PrefsUnifiedDlg.cpp:1202
 msgid ""
 "Your Auto-update server list is empty.\n"
 "'Auto-update server list at startup' will be disabled."
@@ -5801,7 +5838,7 @@ msgstr ""
 "Lista de actualizare automată a serverelor este goală.\n"
 "'Actualizează automat lista serverelor la pornire' va fi dezactivată."
 
-#: src/PrefsUnifiedDlg.cpp:1171
+#: src/PrefsUnifiedDlg.cpp:1213
 msgid ""
 "You have enabled external connections but have not specified a password.\n"
 "External connections cannot be enabled unless a valid password is specified."
@@ -5809,28 +5846,33 @@ msgstr ""
 "Ați activat conexiunile externe dar nu ați specificat o parolă.\n"
 "Conexiunile externe nu se pot activa până ce nu va fi specificată o parolă validă."
 
-#: src/PrefsUnifiedDlg.cpp:1202
+#: src/PrefsUnifiedDlg.cpp:1246
+#, c-format
+msgid "The amuleapi password could not be saved: %s"
+msgstr ""
+
+#: src/PrefsUnifiedDlg.cpp:1276
 msgid "- Language changed.\n"
 msgstr "- Limba s-a schimbat.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1207
+#: src/PrefsUnifiedDlg.cpp:1281
 msgid "- Temp folder changed.\n"
 msgstr "- Dosarul temporar s-a schimbat.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1212
+#: src/PrefsUnifiedDlg.cpp:1286
 msgid "- ED2K network enabled.\n"
 msgstr "- Rețeaua ED2K s-a activat.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1245
+#: src/PrefsUnifiedDlg.cpp:1319
 msgid "The shared-file exclusion pattern is not a valid regular expression. The filter has been left disabled."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1247 src/PrefsUnifiedDlg.cpp:1841
+#: src/PrefsUnifiedDlg.cpp:1321 src/PrefsUnifiedDlg.cpp:1921
 #, fuzzy
 msgid "Invalid regular expression"
 msgstr "Versiune protocol nevalidă."
 
-#: src/PrefsUnifiedDlg.cpp:1324
+#: src/PrefsUnifiedDlg.cpp:1398
 msgid ""
 "Both eD2k and Kad network are disabled.\n"
 "You won't be able to connect until you enable at least one of them."
@@ -5838,7 +5880,7 @@ msgstr ""
 "Ambele rețele eD2k și Kad sunt dezactivate.\n"
 "Nu vă puteți conecta doar după ce veți activa cel puțin una dintre ele."
 
-#: src/PrefsUnifiedDlg.cpp:1329
+#: src/PrefsUnifiedDlg.cpp:1403
 msgid ""
 "Kad will not start if your UDP port is disabled.\n"
 "Enable UDP port or disable Kad."
@@ -5846,7 +5888,7 @@ msgstr ""
 "Kad nu va porni dacă portul UDP este dezactivat.\n"
 "Activați portul UDP sau dezactivați Kad."
 
-#: src/PrefsUnifiedDlg.cpp:1385
+#: src/PrefsUnifiedDlg.cpp:1459
 msgid ""
 "\n"
 "You MUST restart aMule now.\n"
@@ -5856,69 +5898,69 @@ msgstr ""
 "Trebuie să reporniți aMule acum.\n"
 "Dacă nu îl reporniți acum, nu vă plângeți dacă ceva rău se întâmplă.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1450
+#: src/PrefsUnifiedDlg.cpp:1524
 msgid "Could not register aMule for autostart at login. The autostart store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1452
+#: src/PrefsUnifiedDlg.cpp:1526
 msgid "Could not remove the autostart-at-login entry."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1453
+#: src/PrefsUnifiedDlg.cpp:1527
 #, fuzzy
 msgid "Autostart"
 msgstr "Reîmprospătarea automată pornită"
 
-#: src/PrefsUnifiedDlg.cpp:1468
+#: src/PrefsUnifiedDlg.cpp:1542
 msgid "Register file type"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1468
+#: src/PrefsUnifiedDlg.cpp:1542
 msgid "Register URL handler"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1476
+#: src/PrefsUnifiedDlg.cpp:1550
 #, c-format
 msgid "aMule only handles eD2k-compatible magnets. If you replace the current magnet handler (%s), BitTorrent magnet links will stop working - aMule cannot download BitTorrent content. Continue?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1481
+#: src/PrefsUnifiedDlg.cpp:1555
 #, c-format
 msgid "Another application currently opens .emulecollection files (%s). Replace it with aMule?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1486
+#: src/PrefsUnifiedDlg.cpp:1560
 #, c-format
 msgid "Another application is currently the default handler for these links (%s). Replace it with aMule?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1511
+#: src/PrefsUnifiedDlg.cpp:1585
 msgid "Could not register aMule for .emulecollection files. The registration store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1513
+#: src/PrefsUnifiedDlg.cpp:1587
 #, fuzzy
 msgid "Could not remove the file type registration."
 msgstr "Dosar pentru fișiere descărcate temporar"
 
-#: src/PrefsUnifiedDlg.cpp:1515
+#: src/PrefsUnifiedDlg.cpp:1589
 msgid "Could not register aMule as the URL handler. The registration store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1517
+#: src/PrefsUnifiedDlg.cpp:1591
 msgid "Could not remove the URL handler registration."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1587 src/PrefsUnifiedDlg.cpp:1614
+#: src/PrefsUnifiedDlg.cpp:1661 src/PrefsUnifiedDlg.cpp:1688
 #, fuzzy
 msgid "The web server and aMule API require external connections to be enabled."
 msgstr "Configurarea parolei și conexiunile externe sunt activate."
 
-#: src/PrefsUnifiedDlg.cpp:1597
+#: src/PrefsUnifiedDlg.cpp:1671
 msgid "The aMule web server is deprecated. Consider running the aMule API instead."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1655
+#: src/PrefsUnifiedDlg.cpp:1735
 msgid ""
 "Your Auto-update servers list is in blank.\n"
 "Please fill in at least one URL to point to a valid server.met file.\n"
@@ -5928,24 +5970,24 @@ msgstr ""
 "Introduceți în listă cel puțin o adresă URL pentru a se indica un fișier server.met valid.\n"
 "Apăsați butonul \"List\" cu această căsuță pentru a introduce o adresă URL."
 
-#: src/PrefsUnifiedDlg.cpp:1796
+#: src/PrefsUnifiedDlg.cpp:1876
 msgid "Temporary files"
 msgstr "Fișiere temporare"
 
-#: src/PrefsUnifiedDlg.cpp:1801
+#: src/PrefsUnifiedDlg.cpp:1881
 msgid "Incoming files"
 msgstr "Fișiere de intrare"
 
-#: src/PrefsUnifiedDlg.cpp:1806
+#: src/PrefsUnifiedDlg.cpp:1886
 msgid "Online Signatures"
 msgstr "Semnături online"
 
-#: src/PrefsUnifiedDlg.cpp:1819
+#: src/PrefsUnifiedDlg.cpp:1899
 #, c-format
 msgid "Choose a folder for %s"
 msgstr "Alegeți un dosar pentru %s"
 
-#: src/PrefsUnifiedDlg.cpp:1843
+#: src/PrefsUnifiedDlg.cpp:1923
 #, fuzzy, c-format
 msgid "Would exclude %u of %u shared file"
 msgid_plural "Would exclude %u of %u shared files"
@@ -5953,42 +5995,42 @@ msgstr[0] "S-a găsit %i fișier partajat cunoscut"
 msgstr[1] "S-au găsit %i fișiere partajate cunoscute"
 msgstr[2] "S-au găsit %i de fișiere partajate cunoscute"
 
-#: src/PrefsUnifiedDlg.cpp:1860
+#: src/PrefsUnifiedDlg.cpp:1940
 msgid "Browse for videoplayer"
 msgstr "Navigați pentru playerul video"
 
-#: src/PrefsUnifiedDlg.cpp:1864
+#: src/PrefsUnifiedDlg.cpp:1944
 msgid "Select browser"
 msgstr "Selectare navigator"
 
-#: src/PrefsUnifiedDlg.cpp:1868
+#: src/PrefsUnifiedDlg.cpp:1948
 #, fuzzy
 msgid "Select ffprobe binary"
 msgstr "Selectare navigator"
 
-#: src/PrefsUnifiedDlg.cpp:1874
+#: src/PrefsUnifiedDlg.cpp:1954
 #, c-format
 msgid "Executable%s"
 msgstr "Executabil%s"
 
-#: src/PrefsUnifiedDlg.cpp:1908
+#: src/PrefsUnifiedDlg.cpp:1988
 msgid "ffprobe not found on PATH or in the standard install locations. Install ffmpeg (which ships ffprobe) or use Browse to pick a binary manually."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1920
+#: src/PrefsUnifiedDlg.cpp:2000
 msgid "Reset the settings on this page to their default values?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1921
+#: src/PrefsUnifiedDlg.cpp:2001
 #, fuzzy
 msgid "Reset to defaults"
 msgstr "Valoare implicită a sistemului"
 
-#: src/PrefsUnifiedDlg.cpp:1948
+#: src/PrefsUnifiedDlg.cpp:2028
 msgid "Edit server list"
 msgstr "Editare listă server"
 
-#: src/PrefsUnifiedDlg.cpp:1949
+#: src/PrefsUnifiedDlg.cpp:2029
 msgid ""
 "Add here URL's to download server.met files.\n"
 "Only one url on each line."
@@ -5996,42 +6038,42 @@ msgstr ""
 "Adăugați aici adresele URL pentru descărcat fișierele server.met.\n"
 "Numai o singură adresă URL pe fiecare linie."
 
-#: src/PrefsUnifiedDlg.cpp:2004
+#: src/PrefsUnifiedDlg.cpp:2084
 msgid "IP2Country update failed"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2149 src/PrefsUnifiedDlg.cpp:2180
+#: src/PrefsUnifiedDlg.cpp:2229 src/PrefsUnifiedDlg.cpp:2260
 msgid "Data by MaxMind GeoLite2"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2151 src/PrefsUnifiedDlg.cpp:2182
+#: src/PrefsUnifiedDlg.cpp:2231 src/PrefsUnifiedDlg.cpp:2262
 #, fuzzy
 msgid "Custom source"
 msgstr "Surse complete"
 
-#: src/PrefsUnifiedDlg.cpp:2153 src/PrefsUnifiedDlg.cpp:2184
+#: src/PrefsUnifiedDlg.cpp:2233 src/PrefsUnifiedDlg.cpp:2264
 msgid "Data by DB-IP.com"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2204
+#: src/PrefsUnifiedDlg.cpp:2284
 #, fuzzy, c-format
 msgid "Status: Loaded%s"
 msgstr "Stare:"
 
-#: src/PrefsUnifiedDlg.cpp:2206
+#: src/PrefsUnifiedDlg.cpp:2286
 #, fuzzy, c-format
 msgid "Status: Loaded%s - %s"
 msgstr "Stare:"
 
-#: src/PrefsUnifiedDlg.cpp:2210
+#: src/PrefsUnifiedDlg.cpp:2290
 msgid "Status: Failed to load - click 'Update now' to refresh."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2212
+#: src/PrefsUnifiedDlg.cpp:2292
 msgid "Status: Not found - click 'Update now' to download."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2270 src/PrefsUnifiedDlg.cpp:2294
+#: src/PrefsUnifiedDlg.cpp:2350 src/PrefsUnifiedDlg.cpp:2374
 #, c-format
 msgid "Update delay: %d second"
 msgid_plural "Update delay: %d seconds"
@@ -6039,7 +6081,7 @@ msgstr[0] "Întârziere actualizare: %d secundă"
 msgstr[1] "Întârziere actualizare: %d secunde"
 msgstr[2] "Întârziere actualizare: %d de secunde"
 
-#: src/PrefsUnifiedDlg.cpp:2278
+#: src/PrefsUnifiedDlg.cpp:2358
 #, c-format
 msgid "Time for average graph: %d minute"
 msgid_plural "Time for average graph: %d minutes"
@@ -6047,12 +6089,12 @@ msgstr[0] "Timp pentru media graficului: %d minut"
 msgstr[1] "Timp pentru media graficului: %d minute"
 msgstr[2] "Timp pentru media graficului: %d de minute"
 
-#: src/PrefsUnifiedDlg.cpp:2287
+#: src/PrefsUnifiedDlg.cpp:2367
 #, c-format
 msgid "Connections Graph Scale: %d"
 msgstr "Scală grafic conexiuni: %d"
 
-#: src/PrefsUnifiedDlg.cpp:2302
+#: src/PrefsUnifiedDlg.cpp:2382
 #, c-format
 msgid "File Buffer Size: %d byte"
 msgid_plural "File Buffer Size: %d bytes"
@@ -6060,7 +6102,7 @@ msgstr[0] "Dimensiune fișier tampon: %d octet"
 msgstr[1] "Dimensiune fișier tampon: %d octeți"
 msgstr[2] "Dimensiune fișier tampon: %d de octeți"
 
-#: src/PrefsUnifiedDlg.cpp:2312
+#: src/PrefsUnifiedDlg.cpp:2392
 #, c-format
 msgid "Upload Queue Size: %d client"
 msgid_plural "Upload Queue Size: %d clients"
@@ -6068,7 +6110,7 @@ msgstr[0] "Dimensiune coadă încărcări: %d client"
 msgstr[1] "Dimensiune coadă încărcări: %d clienți"
 msgstr[2] "Dimensiune coadă încărcări: %d de clienți"
 
-#: src/PrefsUnifiedDlg.cpp:2322
+#: src/PrefsUnifiedDlg.cpp:2402
 #, c-format
 msgid "Server connection refresh interval: %d minute"
 msgid_plural "Server connection refresh interval: %d minutes"
@@ -6076,79 +6118,79 @@ msgstr[0] "Interval reâmprospătare conexiune server: %d minut"
 msgstr[1] "Interval reâmprospătare conexiune server: %d minute"
 msgstr[2] "Interval reâmprospătare conexiune server: %d de minute"
 
-#: src/PrefsUnifiedDlg.cpp:2327
+#: src/PrefsUnifiedDlg.cpp:2407
 msgid "Server connection refresh interval: Disabled"
 msgstr "Interval reâmprospătare conexiune server: Dezactivat"
 
-#: src/PrefsUnifiedDlg.cpp:2371
+#: src/PrefsUnifiedDlg.cpp:2451
 msgid "disabled"
 msgstr "dezactivată"
 
-#: src/PrefsUnifiedDlg.cpp:2397
+#: src/PrefsUnifiedDlg.cpp:2477
 #, c-format
 msgid "Execute command on '%s' event"
 msgstr "Execută comanda la evenimentul '%s' "
 
-#: src/PrefsUnifiedDlg.cpp:2404
+#: src/PrefsUnifiedDlg.cpp:2484
 msgid "Enable command execution on core"
 msgstr "Activați executarea de comenzi în nucleu"
 
-#: src/PrefsUnifiedDlg.cpp:2416
+#: src/PrefsUnifiedDlg.cpp:2496
 msgid "Core command:"
 msgstr "Comandă nucleu:"
 
-#: src/PrefsUnifiedDlg.cpp:2432
+#: src/PrefsUnifiedDlg.cpp:2512
 msgid "Enable command execution on GUI"
 msgstr "Activează execuția comenzi pe GUI"
 
-#: src/PrefsUnifiedDlg.cpp:2444
+#: src/PrefsUnifiedDlg.cpp:2524
 msgid "GUI command:"
 msgstr "Comandă GUI:"
 
-#: src/PrefsUnifiedDlg.cpp:2460
+#: src/PrefsUnifiedDlg.cpp:2540
 msgid "The following variables will be replaced:"
 msgstr "Următoarele variabile vor fi înlocuite:"
 
-#: src/PrefsUnifiedDlg.cpp:2628
+#: src/PrefsUnifiedDlg.cpp:2708
 msgid ""
 "The following folders look like system or sensitive locations:\n"
 "\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2633
+#: src/PrefsUnifiedDlg.cpp:2713
 msgid "Sharing them recursively will publish every file underneath on the eD2k/Kad networks. Do you really want to do this?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2636
+#: src/PrefsUnifiedDlg.cpp:2716
 #, fuzzy
 msgid "Confirm shared folders"
 msgstr "Dosare partajate"
 
-#: src/PrefsUnifiedDlg.cpp:2664
+#: src/PrefsUnifiedDlg.cpp:2744
 #, fuzzy
 msgid "Reloading shared files..."
 msgstr "Reîncărcați fișierele partajate"
 
-#: src/PrefsUnifiedDlg.cpp:2665
+#: src/PrefsUnifiedDlg.cpp:2745
 msgid "Scanning for subdirectories..."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2666
+#: src/PrefsUnifiedDlg.cpp:2746
 #, fuzzy
 msgid "Updating shared folders"
 msgstr "Dosare partajate"
 
-#: src/PrefsUnifiedDlg.cpp:2693
+#: src/PrefsUnifiedDlg.cpp:2773
 #, c-format
 msgid "Scanned %u directories..."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2743
+#: src/PrefsUnifiedDlg.cpp:2823
 #, fuzzy, c-format
 msgid "Reloading shared files: %u files scanned"
 msgstr "Reîncarcă lista fișierelor partajate."
 
-#: src/PrefsUnifiedDlg.cpp:2793
+#: src/PrefsUnifiedDlg.cpp:2873
 #, fuzzy
 msgid "Shared folder"
 msgstr "Dosare partajate"

--- a/po/ro.po
+++ b/po/ro.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-28 12:17+0200\n"
+"POT-Creation-Date: 2026-07-28 13:09+0200\n"
 "PO-Revision-Date: 2026-07-27 11:44+0000\n"
 "Last-Translator: Angelescu Constantin <titus0818@yahoo.com>\n"
 "Language-Team: English <kde-i18n-doc@kde.org>\n"
@@ -291,7 +291,7 @@ msgid "Password set and external connections enabled."
 msgstr "Configurarea parolei și conexiunile externe sunt activate."
 
 #: src/amule.cpp:755 src/KadDlg.cpp:176 src/KadDlg.cpp:185
-#: src/PrefsUnifiedDlg.cpp:1461 src/SharedFilesCtrl.cpp:476
+#: src/PrefsUnifiedDlg.cpp:1470 src/SharedFilesCtrl.cpp:476
 msgid "WARNING"
 msgstr "ATENȚIE"
 
@@ -329,7 +329,7 @@ msgstr "Ați solicitat să ruleze la pornire serverul web, dar fișierul binar a
 #: src/amule-remote-gui.cpp:603 src/amule-remote-gui.cpp:671
 #: src/amule-remote-gui.cpp:709 src/amule-remote-gui.cpp:1282
 #: src/amule-remote-gui.cpp:1345 src/amule-remote-gui.cpp:1372
-#: src/DownloadQueue.cpp:1481 src/PrefsUnifiedDlg.cpp:1247
+#: src/DownloadQueue.cpp:1481 src/PrefsUnifiedDlg.cpp:1256
 msgid "ERROR"
 msgstr "EROARE"
 
@@ -591,36 +591,36 @@ msgstr "Vizitați https://github.com/amule-org/amule/releases/latest pentru a ve
 msgid "FATAL ERROR: Failed to create Timer"
 msgstr "EROARE FATALĂ: A eșuat crearea temporizatorului"
 
-#: src/amuleDlg.cpp:361 src/amuleDlg.cpp:1787 src/amuleDlg.cpp:2033
-#: src/muuli_wdr.cpp:1492 src/muuli_wdr.cpp:3449
+#: src/amuleDlg.cpp:361 src/amuleDlg.cpp:1810 src/amuleDlg.cpp:2056
+#: src/muuli_wdr.cpp:1492 src/muuli_wdr.cpp:3453
 msgid "Networks"
 msgstr "Rețele"
 
-#: src/amuleDlg.cpp:362 src/amuleDlg.cpp:1793 src/muuli_wdr.cpp:3450
+#: src/amuleDlg.cpp:362 src/amuleDlg.cpp:1816 src/muuli_wdr.cpp:3454
 msgid "Searches"
 msgstr "Căutări"
 
-#: src/amuleDlg.cpp:363 src/amuleDlg.cpp:1799 src/DownloadListCtrl.cpp:740
-#: src/muuli_wdr.cpp:392 src/muuli_wdr.cpp:1585 src/muuli_wdr.cpp:3451
+#: src/amuleDlg.cpp:363 src/amuleDlg.cpp:1822 src/DownloadListCtrl.cpp:740
+#: src/muuli_wdr.cpp:392 src/muuli_wdr.cpp:1585 src/muuli_wdr.cpp:3455
 #: src/Statistics.cpp:829
 msgid "Downloads"
 msgstr "Descărcări"
 
-#: src/amuleDlg.cpp:364 src/amuleDlg.cpp:1805 src/muuli_wdr.cpp:3325
+#: src/amuleDlg.cpp:364 src/amuleDlg.cpp:1828 src/muuli_wdr.cpp:3329
 msgid "Shared files"
 msgstr "Fișiere partajate"
 
-#: src/amuleDlg.cpp:365 src/amuleDlg.cpp:1811 src/muuli_wdr.cpp:2957
-#: src/muuli_wdr.cpp:3407 src/muuli_wdr.cpp:3454
+#: src/amuleDlg.cpp:365 src/amuleDlg.cpp:1834 src/muuli_wdr.cpp:2961
+#: src/muuli_wdr.cpp:3411 src/muuli_wdr.cpp:3458
 msgid "Messages"
 msgstr "Mesaje"
 
-#: src/amuleDlg.cpp:366 src/amuleDlg.cpp:1817 src/muuli_wdr.cpp:3455
+#: src/amuleDlg.cpp:366 src/amuleDlg.cpp:1840 src/muuli_wdr.cpp:3459
 #: src/PrefsUnifiedDlg.cpp:314 src/Statistics.cpp:779 src/Statistics.cpp:1235
 msgid "Statistics"
 msgstr "Statistici"
 
-#: src/amuleDlg.cpp:368 src/amuleDlg.cpp:1824 src/muuli_wdr.cpp:3457
+#: src/amuleDlg.cpp:368 src/amuleDlg.cpp:1847 src/muuli_wdr.cpp:3461
 #: src/PrefsUnifiedDlg.cpp:330 src/utils/wxCas/src/wxcasprefs.cpp:39
 msgid "Preferences"
 msgstr "Preferințe"
@@ -679,8 +679,8 @@ msgstr "Kad: Închis"
 #: src/amuleDlg.cpp:1029 src/DownloadListCtrl.cpp:505
 #: src/DownloadListCtrl.cpp:749 src/FriendListCtrl.cpp:180
 #: src/muuli_wdr.cpp:731 src/muuli_wdr.cpp:782 src/muuli_wdr.cpp:846
-#: src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2262 src/muuli_wdr.cpp:2347
-#: src/muuli_wdr.cpp:3095 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
+#: src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2266 src/muuli_wdr.cpp:2351
+#: src/muuli_wdr.cpp:3099 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
 #: src/ServerListCtrl.cpp:606 src/TransferWnd.cpp:378
 #: src/utils/wxCas/src/wxcasprefs.cpp:235
 msgid "Cancel"
@@ -691,7 +691,7 @@ msgid "Stop the current connection attempts"
 msgstr "Oprește încercările curente de conectare"
 
 #: src/amuleDlg.cpp:1035 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976
-#: src/muuli_wdr.cpp:2485
+#: src/muuli_wdr.cpp:2489
 msgid "Disconnect"
 msgstr "Deconectează"
 
@@ -700,7 +700,7 @@ msgid "Disconnect from the currently connected networks"
 msgstr "Deconectează de la rețelele curent conectate"
 
 #: src/amuleDlg.cpp:1041 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979
-#: src/muuli_wdr.cpp:2640 src/muuli_wdr.cpp:3092 src/muuli_wdr.cpp:3447
+#: src/muuli_wdr.cpp:2644 src/muuli_wdr.cpp:3096 src/muuli_wdr.cpp:3451
 msgid "Connect"
 msgstr "Conectează"
 
@@ -755,7 +755,7 @@ msgstr "Confirmare închidere"
 msgid "Launch Command: "
 msgstr "Lansare comandă:"
 
-#: src/amuleDlg.cpp:1632 src/muuli_wdr.cpp:1982 src/Preferences.cpp:979
+#: src/amuleDlg.cpp:1632 src/muuli_wdr.cpp:1986 src/Preferences.cpp:979
 msgid "- default -"
 msgstr "- implicit -"
 
@@ -769,60 +769,60 @@ msgstr "Directorul aspectului aplicației '%s' nu există"
 msgid "WARNING: Unable to open skin file '%s' for read"
 msgstr "ATENȚIE: Nu se poate deschide fișierul aspect '%s' pentru citit"
 
-#: src/amuleDlg.cpp:1791 src/muuli_wdr.cpp:3449
+#: src/amuleDlg.cpp:1814 src/muuli_wdr.cpp:3453
 msgid "Networks Window"
 msgstr "Fereastra rețelelor"
 
-#: src/amuleDlg.cpp:1797 src/muuli_wdr.cpp:3450
+#: src/amuleDlg.cpp:1820 src/muuli_wdr.cpp:3454
 msgid "Searches Window"
 msgstr "Fereastra căutărilor"
 
-#: src/amuleDlg.cpp:1803 src/muuli_wdr.cpp:3451
+#: src/amuleDlg.cpp:1826 src/muuli_wdr.cpp:3455
 msgid "Downloads Window"
 msgstr "Fereastra descărcărilor"
 
-#: src/amuleDlg.cpp:1809 src/muuli_wdr.cpp:3453
+#: src/amuleDlg.cpp:1832 src/muuli_wdr.cpp:3457
 msgid "Shared Files Window"
 msgstr "Fereastra fișierelor partajate"
 
-#: src/amuleDlg.cpp:1815 src/muuli_wdr.cpp:3454
+#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3458
 msgid "Messages Window"
 msgstr "Fereastra mesajelor"
 
-#: src/amuleDlg.cpp:1821 src/muuli_wdr.cpp:3455
+#: src/amuleDlg.cpp:1844 src/muuli_wdr.cpp:3459
 msgid "Statistics Graph Window"
 msgstr "Fereastra graficului statisticilor"
 
-#: src/amuleDlg.cpp:1828 src/muuli_wdr.cpp:3457
+#: src/amuleDlg.cpp:1851 src/muuli_wdr.cpp:3461
 msgid "Preferences Settings Window"
 msgstr "Fereastra configurare preferințe"
 
-#: src/amuleDlg.cpp:1831 src/muuli_wdr.cpp:3458
+#: src/amuleDlg.cpp:1854 src/muuli_wdr.cpp:3462
 msgid "Import"
 msgstr "Importă"
 
-#: src/amuleDlg.cpp:1835 src/muuli_wdr.cpp:3458
+#: src/amuleDlg.cpp:1858 src/muuli_wdr.cpp:3462
 msgid "The partfile importer tool"
 msgstr "Unealta de importat fișiere parțiale"
 
-#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3459
+#: src/amuleDlg.cpp:1861 src/muuli_wdr.cpp:3463
 #: src/utils/aLinkCreator/src/alcframe.cpp:262
 msgid "About"
 msgstr "Despre"
 
-#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3459
+#: src/amuleDlg.cpp:1861 src/muuli_wdr.cpp:3463
 msgid "About/Help"
 msgstr "Despre/Ajutor"
 
-#: src/amuleDlg.cpp:2036
+#: src/amuleDlg.cpp:2059
 msgid "eD2k network"
 msgstr "Rețea eD2k"
 
-#: src/amuleDlg.cpp:2039
+#: src/amuleDlg.cpp:2062
 msgid "Kad network"
 msgstr "Rețea Kad"
 
-#: src/amuleDlg.cpp:2039
+#: src/amuleDlg.cpp:2062
 msgid "No network"
 msgstr "Nicio rețea"
 
@@ -1360,19 +1360,19 @@ msgstr "Automat [În]"
 msgid "Very low"
 msgstr "Foarte joasă"
 
-#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:743 src/muuli_wdr.cpp:2313
+#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:743 src/muuli_wdr.cpp:2317
 #: src/ServerListCtrl.cpp:263 src/ServerListCtrl.cpp:456
 #: src/SharedFilesCtrl.cpp:145
 msgid "Low"
 msgstr "Joasă"
 
-#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:744 src/muuli_wdr.cpp:2314
+#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:744 src/muuli_wdr.cpp:2318
 #: src/ServerListCtrl.cpp:266 src/ServerListCtrl.cpp:457
 #: src/SharedFilesCtrl.cpp:146
 msgid "Normal"
 msgstr "Normal"
 
-#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:745 src/muuli_wdr.cpp:2315
+#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:745 src/muuli_wdr.cpp:2319
 #: src/ServerListCtrl.cpp:269 src/ServerListCtrl.cpp:458
 #: src/SharedFilesCtrl.cpp:147
 msgid "High"
@@ -1464,7 +1464,7 @@ msgstr "Server local"
 msgid "Remote Server"
 msgstr "Server distant"
 
-#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3212
+#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3216
 #: src/SearchDlg.cpp:119 src/TextClient.cpp:911
 msgid "Kad"
 msgstr "Kad"
@@ -1536,7 +1536,7 @@ msgstr "Parte"
 msgid "Size"
 msgstr "Dimensiune"
 
-#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3279
+#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3283
 msgid "Transferred"
 msgstr "Transferat"
 
@@ -1594,7 +1594,7 @@ msgstr ""
 "Feedback de la: %s (%s)\n"
 "\n"
 
-#: src/DownloadListCtrl.cpp:746 src/muuli_wdr.cpp:2316
+#: src/DownloadListCtrl.cpp:746 src/muuli_wdr.cpp:2320
 #: src/SharedFilesCtrl.cpp:150
 msgid "Auto"
 msgstr "Automat"
@@ -1632,7 +1632,7 @@ msgid "Extended Options"
 msgstr "Opțiuni extinse"
 
 #: src/DownloadListCtrl.cpp:770 src/DownloadListCtrl.cpp:822
-#: src/muuli_wdr.cpp:1800
+#: src/muuli_wdr.cpp:1804
 msgid "Preview"
 msgstr "Previzualizează"
 
@@ -2433,23 +2433,23 @@ msgid ""
 "want downloads on a different (e.g. larger) disk."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:549 src/FirstRunWizard.cpp:611 src/muuli_wdr.cpp:1712
+#: src/FirstRunWizard.cpp:549 src/FirstRunWizard.cpp:611 src/muuli_wdr.cpp:1716
 msgid "Destination folder for downloads"
 msgstr "Dosar destinație pentru descărcări"
 
 #: src/FirstRunWizard.cpp:553 src/FirstRunWizard.cpp:569 src/muuli_wdr.cpp:1349
-#: src/muuli_wdr.cpp:1366 src/muuli_wdr.cpp:1687 src/muuli_wdr.cpp:1718
-#: src/muuli_wdr.cpp:1730 src/muuli_wdr.cpp:2800
+#: src/muuli_wdr.cpp:1366 src/muuli_wdr.cpp:1691 src/muuli_wdr.cpp:1722
+#: src/muuli_wdr.cpp:1734 src/muuli_wdr.cpp:2804
 #: src/utils/aLinkCreator/src/alcframe.cpp:135
 #: src/utils/wxCas/src/wxcasprefs.cpp:52 src/utils/wxCas/src/wxcasprefs.cpp:118
 msgid "Browse"
 msgstr "Navigare"
 
-#: src/FirstRunWizard.cpp:559 src/muuli_wdr.cpp:1723
+#: src/FirstRunWizard.cpp:559 src/muuli_wdr.cpp:1727
 msgid "(All files in this folder are shared with other peers)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:565 src/FirstRunWizard.cpp:624 src/muuli_wdr.cpp:1725
+#: src/FirstRunWizard.cpp:565 src/FirstRunWizard.cpp:624 src/muuli_wdr.cpp:1729
 msgid "Folder for temporary download files"
 msgstr "Dosar pentru fișiere descărcate temporar"
 
@@ -2480,7 +2480,7 @@ msgstr "A eșuat deschiderea fișierului listă prieteni 'emfriends.met' pentru 
 msgid "CRITICAL - no client on StartChatSession"
 msgstr "CRITIC - niciun client în StartChatSession"
 
-#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2706 src/muuli_wdr.cpp:3383
+#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2710 src/muuli_wdr.cpp:3387
 msgid "Friends"
 msgstr "Prieteni"
 
@@ -2591,8 +2591,8 @@ msgstr "Niciunul"
 msgid "No"
 msgstr "Nu"
 
-#: src/GenericClientListCtrl.cpp:1216 src/PrefsUnifiedDlg.cpp:2898
-#: src/PrefsUnifiedDlg.cpp:2948 src/ServerListCtrl.cpp:276
+#: src/GenericClientListCtrl.cpp:1216 src/PrefsUnifiedDlg.cpp:2907
+#: src/PrefsUnifiedDlg.cpp:2957 src/ServerListCtrl.cpp:276
 msgid "Yes"
 msgstr "Da"
 
@@ -2763,10 +2763,10 @@ msgstr "Port nevalid la bootstrap"
 msgid "Please fill all fields required"
 msgstr "Completați toate câmpurile solicitate"
 
-#: src/KadDlg.cpp:192 src/PartFile.cpp:1031 src/PrefsUnifiedDlg.cpp:1134
-#: src/PrefsUnifiedDlg.cpp:1204 src/PrefsUnifiedDlg.cpp:1405
-#: src/PrefsUnifiedDlg.cpp:1663 src/PrefsUnifiedDlg.cpp:1673
-#: src/PrefsUnifiedDlg.cpp:1690 src/PrefsUnifiedDlg.cpp:1738
+#: src/KadDlg.cpp:192 src/PartFile.cpp:1031 src/PrefsUnifiedDlg.cpp:1143
+#: src/PrefsUnifiedDlg.cpp:1213 src/PrefsUnifiedDlg.cpp:1414
+#: src/PrefsUnifiedDlg.cpp:1672 src/PrefsUnifiedDlg.cpp:1682
+#: src/PrefsUnifiedDlg.cpp:1699 src/PrefsUnifiedDlg.cpp:1747
 msgid "Message"
 msgstr "Mesaj"
 
@@ -2871,7 +2871,7 @@ msgstr "Rată de partajare"
 msgid "Uploaded"
 msgstr "Încărcat"
 
-#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3263
+#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3267
 msgid "Requested"
 msgstr "Cerut"
 
@@ -2995,7 +2995,7 @@ msgid "WARNING: "
 msgstr "ATENȚIE:"
 
 #: src/MuleNotebook.cpp:179 src/muuli_wdr.cpp:817 src/muuli_wdr.cpp:1229
-#: src/muuli_wdr.cpp:3167 src/muuli_wdr.cpp:3423
+#: src/muuli_wdr.cpp:3171 src/muuli_wdr.cpp:3427
 msgid "Close"
 msgstr "Închide"
 
@@ -3013,7 +3013,7 @@ msgid "Paste"
 msgstr "Lipește"
 
 #: src/MuleTextCtrl.cpp:89 src/muuli_wdr.cpp:358 src/muuli_wdr.cpp:757
-#: src/muuli_wdr.cpp:2390 src/muuli_wdr.cpp:2409 src/muuli_wdr.cpp:2431
+#: src/muuli_wdr.cpp:2394 src/muuli_wdr.cpp:2413 src/muuli_wdr.cpp:2435
 #: src/utils/aLinkCreator/src/alcframe.cpp:142
 msgid "Clear"
 msgstr "Curăță"
@@ -3112,7 +3112,7 @@ msgstr "Ieşire"
 
 #: src/MuleTrayIcon.cpp:579 src/MuleTrayIcon.cpp:945 src/MuleTrayIcon.cpp:965
 #: src/muuli_wdr.cpp:1398 src/muuli_wdr.cpp:1406 src/muuli_wdr.cpp:1413
-#: src/muuli_wdr.cpp:1846 src/muuli_wdr.cpp:1852 src/OtherFunctions.cpp:91
+#: src/muuli_wdr.cpp:1850 src/muuli_wdr.cpp:1856 src/OtherFunctions.cpp:91
 #: src/StatisticsDlg.cpp:93 src/StatisticsDlg.cpp:95
 msgid "kB/s"
 msgstr "kB/s"
@@ -3354,7 +3354,7 @@ msgstr "Baiți"
 msgid "KB"
 msgstr "KB"
 
-#: src/muuli_wdr.cpp:274 src/muuli_wdr.cpp:293 src/muuli_wdr.cpp:1631
+#: src/muuli_wdr.cpp:274 src/muuli_wdr.cpp:293 src/muuli_wdr.cpp:1635
 #: src/OtherFunctions.cpp:64
 msgid "MB"
 msgstr "MO"
@@ -3371,7 +3371,7 @@ msgstr "Dimensiune maximă"
 msgid "Availability"
 msgstr "Disponibilitate"
 
-#: src/muuli_wdr.cpp:312 src/muuli_wdr.cpp:398 src/muuli_wdr.cpp:3328
+#: src/muuli_wdr.cpp:312 src/muuli_wdr.cpp:398 src/muuli_wdr.cpp:3332
 msgid "Filter:"
 msgstr "Filtru:"
 
@@ -3434,8 +3434,8 @@ msgstr "Surse fișier:"
 #: src/muuli_wdr.cpp:1160 src/muuli_wdr.cpp:1167 src/muuli_wdr.cpp:1172
 #: src/muuli_wdr.cpp:1179 src/muuli_wdr.cpp:1184 src/muuli_wdr.cpp:1191
 #: src/muuli_wdr.cpp:1205 src/muuli_wdr.cpp:1212 src/muuli_wdr.cpp:1217
-#: src/muuli_wdr.cpp:1224 src/muuli_wdr.cpp:3265 src/muuli_wdr.cpp:3273
-#: src/muuli_wdr.cpp:3281
+#: src/muuli_wdr.cpp:1224 src/muuli_wdr.cpp:3269 src/muuli_wdr.cpp:3277
+#: src/muuli_wdr.cpp:3285
 msgid "N/A"
 msgstr "NU SE APLICĂ"
 
@@ -3580,7 +3580,7 @@ msgstr ""
 msgid "Album :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:685 src/muuli_wdr.cpp:2285
+#: src/muuli_wdr.cpp:685 src/muuli_wdr.cpp:2289
 msgid "Title :"
 msgstr "Titlu :"
 
@@ -3689,7 +3689,7 @@ msgstr "Nume utilizator:"
 msgid "Userhash :"
 msgstr "Index utilizator :"
 
-#: src/muuli_wdr.cpp:895 src/muuli_wdr.cpp:1752 src/muuli_wdr.cpp:2480
+#: src/muuli_wdr.cpp:895 src/muuli_wdr.cpp:1756 src/muuli_wdr.cpp:2484
 #: src/utils/aLinkCreator/src/alcframe.cpp:137
 msgid "Add"
 msgstr "Adaugă"
@@ -3698,15 +3698,15 @@ msgstr "Adaugă"
 msgid "Download-Speed"
 msgstr "Viteză-descărcare"
 
-#: src/muuli_wdr.cpp:954 src/muuli_wdr.cpp:989 src/muuli_wdr.cpp:2584
+#: src/muuli_wdr.cpp:954 src/muuli_wdr.cpp:989 src/muuli_wdr.cpp:2588
 msgid "Current"
 msgstr "Curentul"
 
-#: src/muuli_wdr.cpp:962 src/muuli_wdr.cpp:997 src/muuli_wdr.cpp:2592
+#: src/muuli_wdr.cpp:962 src/muuli_wdr.cpp:997 src/muuli_wdr.cpp:2596
 msgid "Running average"
 msgstr "Medie rulare"
 
-#: src/muuli_wdr.cpp:970 src/muuli_wdr.cpp:1005 src/muuli_wdr.cpp:2600
+#: src/muuli_wdr.cpp:970 src/muuli_wdr.cpp:1005 src/muuli_wdr.cpp:2604
 msgid "Session average"
 msgstr "Medie sesiune"
 
@@ -3718,7 +3718,7 @@ msgstr "Viteză-încărcare"
 msgid "Connections"
 msgstr "Conexiuni"
 
-#: src/muuli_wdr.cpp:1024 src/muuli_wdr.cpp:1871
+#: src/muuli_wdr.cpp:1024 src/muuli_wdr.cpp:1875
 msgid "Active downloads"
 msgstr "Descărcări active"
 
@@ -3726,7 +3726,7 @@ msgstr "Descărcări active"
 msgid "Active connections (1:1)"
 msgstr "Conexiuni active (1:1)"
 
-#: src/muuli_wdr.cpp:1040 src/muuli_wdr.cpp:1872
+#: src/muuli_wdr.cpp:1040 src/muuli_wdr.cpp:1876
 msgid "Active uploads"
 msgstr "Încărcări active"
 
@@ -4002,7 +4002,7 @@ msgstr "Leagă adresa locală la IP (gol pentru oricare):"
 msgid "Advanced users only: If you have multiple network interfaces, enter the address of the interface to which aMule should be bound."
 msgstr "Numai pentru utilizatorii avansați: Dacă aveți mai multe interfețe de rețea, introduceți adresa interfeței la care aMule ar trebui să fie legat."
 
-#: src/muuli_wdr.cpp:1462 src/muuli_wdr.cpp:2065
+#: src/muuli_wdr.cpp:1462 src/muuli_wdr.cpp:2069
 #, fuzzy
 msgid "Bind to network interface (empty for any):"
 msgstr "Leagă adresa locală la IP (gol pentru oricare):"
@@ -4019,7 +4019,7 @@ msgstr "Număr maxim de surse pe fișier descărcat:"
 msgid "Max simultaneous connections:"
 msgstr "Număr maxim de conexiuni simultane:"
 
-#: src/muuli_wdr.cpp:1498 src/muuli_wdr.cpp:3207
+#: src/muuli_wdr.cpp:1498 src/muuli_wdr.cpp:3211
 msgid "ED2K"
 msgstr "ED2K"
 
@@ -4111,778 +4111,778 @@ msgstr "Prealocare spațiu pe disc pentru noile fișiere"
 msgid "For new files preallocates disk space for the whole file, thus reduces fragmentation"
 msgstr "Pentru noile fișiere se prealocă spațiu pe disc pentru întreg fișierul, astfel se reduce fragmentarea"
 
-#: src/muuli_wdr.cpp:1617
+#: src/muuli_wdr.cpp:1621
 msgid "Create new files as sparse files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1618
+#: src/muuli_wdr.cpp:1622
 msgid "Sparse part files only occupy disk space for the parts already downloaded, so free space is used up gradually as the file fills in. Turn this off to use an ordinary file instead - useful where sparse files are unsupported or slow, or where backup/de-duplication tools handle them badly. Applies only when the core runs on Windows; on Linux and macOS part files are sparse anyway and this setting has no effect."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1623
+#: src/muuli_wdr.cpp:1627
 msgid "Stop downloads when free disk space reaches "
 msgstr "Oprește descărcarea când s-a atins limita spațiului disponibil"
 
-#: src/muuli_wdr.cpp:1624
+#: src/muuli_wdr.cpp:1628
 msgid "Select this if you want aMule to check your disk space"
 msgstr "Selectați asta dacă doriți ca aMule să verifice spațiul liber pe disk"
 
-#: src/muuli_wdr.cpp:1628
+#: src/muuli_wdr.cpp:1632
 msgid "Enter here the min disk space desired."
 msgstr "Introduceți aici minimum de spațiu pe disc dorit."
 
-#: src/muuli_wdr.cpp:1634
+#: src/muuli_wdr.cpp:1638
 msgid "Save 10 sources on rare files (< 20 sources)"
 msgstr "Salvează 10 surse de fișiere rare (< 20 surse)"
 
-#: src/muuli_wdr.cpp:1638 src/Statistics.cpp:790
+#: src/muuli_wdr.cpp:1642 src/Statistics.cpp:790
 msgid "Uploads"
 msgstr "Încărcări"
 
-#: src/muuli_wdr.cpp:1641
+#: src/muuli_wdr.cpp:1645
 msgid "Add new shared files with auto priority"
 msgstr "Adaugă noile fișiere partajate cu prioritate automată"
 
-#: src/muuli_wdr.cpp:1647
+#: src/muuli_wdr.cpp:1651
 msgid "Intelligent Corruption Handling (I.C.H.)"
 msgstr "Gestionare inteligentă a fișierelor corupte (I.C.H.)"
 
-#: src/muuli_wdr.cpp:1650
+#: src/muuli_wdr.cpp:1654
 msgid "Enable"
 msgstr "Activează"
 
-#: src/muuli_wdr.cpp:1653
+#: src/muuli_wdr.cpp:1657
 msgid "Advanced I.C.H. trusts every hash (not recommended)"
 msgstr "I.C.H. avansat acordă încredere fiecărui index (nu este recomandat)"
 
-#: src/muuli_wdr.cpp:1665 src/PrefsUnifiedDlg.cpp:1990
+#: src/muuli_wdr.cpp:1669 src/PrefsUnifiedDlg.cpp:1999
 msgid "Media metadata extraction"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1669
+#: src/muuli_wdr.cpp:1673
 msgid "Extract length / bitrate / codec from shared audio and video files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1671
+#: src/muuli_wdr.cpp:1675
 msgid "When enabled, aMule runs ffprobe on each shared media file to fill in the Length / Bitrate / Codec columns other clients see when they find the file in a search. Requires ffmpeg (the ffprobe binary) to be installed."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1678
+#: src/muuli_wdr.cpp:1682
 msgid "Path to ffprobe:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1683
+#: src/muuli_wdr.cpp:1687
 msgid "Full path to the ffprobe binary. Leave empty to have aMule auto-detect it on startup."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1691
+#: src/muuli_wdr.cpp:1695
 msgid "Detect"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1692
+#: src/muuli_wdr.cpp:1696
 msgid "Search the standard install locations for an ffprobe binary and fill the path field."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1716
+#: src/muuli_wdr.cpp:1720
 msgid ""
 "Completed downloads are stored here. All files in this folder are automatically shared with other peers.\n"
 "If this folder also holds files you don't want to share, point it at an aMule-only sub-folder."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1719
+#: src/muuli_wdr.cpp:1723
 msgid "Pick the folder where completed downloads will be stored. All files in that folder will be shared with other peers."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1733
+#: src/muuli_wdr.cpp:1737
 msgid "Shared folders"
 msgstr "Dosare partajate"
 
-#: src/muuli_wdr.cpp:1739
+#: src/muuli_wdr.cpp:1743
 msgid "(Folders shared by the core. Enter a path to add one.)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1747
+#: src/muuli_wdr.cpp:1751
 msgid "Absolute path of a folder on the core's machine, e.g. /home/user/shared"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1749 src/PrefsUnifiedDlg.cpp:2874
+#: src/muuli_wdr.cpp:1753 src/PrefsUnifiedDlg.cpp:2883
 msgid "Recursive"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1750
+#: src/muuli_wdr.cpp:1754
 msgid "Share every sub-folder underneath this one, including ones created later."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1754 src/utils/aLinkCreator/src/alcframe.cpp:141
+#: src/muuli_wdr.cpp:1758 src/utils/aLinkCreator/src/alcframe.cpp:141
 msgid "Remove"
 msgstr "Elimină"
 
-#: src/muuli_wdr.cpp:1758
+#: src/muuli_wdr.cpp:1762
 msgid "(Right click on folder icon for recursive share)"
 msgstr "(Click dreapta pe miniatura dosarului pentru partajare recursivă)"
 
-#: src/muuli_wdr.cpp:1765
+#: src/muuli_wdr.cpp:1769
 msgid "Share hidden files"
 msgstr "Partajează fișierele ascunse"
 
-#: src/muuli_wdr.cpp:1771
+#: src/muuli_wdr.cpp:1775
 msgid "Automatically rescan shared folders for changes"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1777
+#: src/muuli_wdr.cpp:1781
 msgid "Follow symbolic links in shared folders"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1783
+#: src/muuli_wdr.cpp:1787
 msgid "Exclude files matching:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1786
+#: src/muuli_wdr.cpp:1790
 msgid "Wildcard patterns separated by '|', e.g. .DS_Store|Thumbs.db|*.tmp. Files whose name matches are not shared. Matching is case-insensitive."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1790
+#: src/muuli_wdr.cpp:1794
 msgid "Patterns are regular expressions"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1791
+#: src/muuli_wdr.cpp:1795
 msgid "When set, the whole field is one regular expression ('|' is alternation). When unset, it is a list of '|'-separated wildcards."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1801
+#: src/muuli_wdr.cpp:1805
 msgid "Show how many shared files the current pattern would exclude."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1822
+#: src/muuli_wdr.cpp:1826
 msgid "Graphs"
 msgstr "Grafice"
 
-#: src/muuli_wdr.cpp:1825 src/muuli_wdr.cpp:1887
+#: src/muuli_wdr.cpp:1829 src/muuli_wdr.cpp:1891
 msgid "Update delay : 5 secs"
 msgstr "Întârziere actualizare : 5 secunde"
 
-#: src/muuli_wdr.cpp:1829
+#: src/muuli_wdr.cpp:1833
 msgid "Time for average graph: 100 mins"
 msgstr "Timp pentru media graficului: 100 minute"
 
-#: src/muuli_wdr.cpp:1833
+#: src/muuli_wdr.cpp:1837
 msgid "Connections Graph Scale: 100 "
 msgstr "Scală grafic conexiuni: 100"
 
-#: src/muuli_wdr.cpp:1840
+#: src/muuli_wdr.cpp:1844
 msgid "Download graph scale:"
 msgstr "Scală grafic descărcare:"
 
-#: src/muuli_wdr.cpp:1848
+#: src/muuli_wdr.cpp:1852
 msgid "Upload graph scale:"
 msgstr "Scală grafic încărcare:"
 
-#: src/muuli_wdr.cpp:1858
+#: src/muuli_wdr.cpp:1862
 #, fuzzy
 msgid "Colors: "
 msgstr "Colori:"
 
-#: src/muuli_wdr.cpp:1862
+#: src/muuli_wdr.cpp:1866
 msgid "Background"
 msgstr "Fundal"
 
-#: src/muuli_wdr.cpp:1863
+#: src/muuli_wdr.cpp:1867
 msgid "Grid"
 msgstr "Grilă"
 
-#: src/muuli_wdr.cpp:1864
+#: src/muuli_wdr.cpp:1868
 msgid "Download current"
 msgstr "Descărcare actuală"
 
-#: src/muuli_wdr.cpp:1865
+#: src/muuli_wdr.cpp:1869
 msgid "Download running average"
 msgstr "Medie rulare descărcare"
 
-#: src/muuli_wdr.cpp:1866
+#: src/muuli_wdr.cpp:1870
 msgid "Download session average"
 msgstr "Medie descărcare pe sesiune"
 
-#: src/muuli_wdr.cpp:1867
+#: src/muuli_wdr.cpp:1871
 msgid "Upload current"
 msgstr "Încărcare actuală"
 
-#: src/muuli_wdr.cpp:1868
+#: src/muuli_wdr.cpp:1872
 msgid "Upload running average"
 msgstr "Medie rulare încărcare"
 
-#: src/muuli_wdr.cpp:1869
+#: src/muuli_wdr.cpp:1873
 msgid "Upload session average"
 msgstr "Medie încărcare pe sesiune"
 
-#: src/muuli_wdr.cpp:1870
+#: src/muuli_wdr.cpp:1874
 msgid "Active connections"
 msgstr "Conexiuni active"
 
-#: src/muuli_wdr.cpp:1873
+#: src/muuli_wdr.cpp:1877
 #, fuzzy
 msgid "Systray Icon Speed Bar"
 msgstr "Miniatură rapidă pe bara de sistem"
 
-#: src/muuli_wdr.cpp:1874
+#: src/muuli_wdr.cpp:1878
 msgid "Kad-nodes current"
 msgstr "Noduri Kad curente"
 
-#: src/muuli_wdr.cpp:1875
+#: src/muuli_wdr.cpp:1879
 msgid "Kad-nodes running"
 msgstr "Noduri Kad care rulează"
 
-#: src/muuli_wdr.cpp:1876
+#: src/muuli_wdr.cpp:1880
 msgid "Kad-nodes session"
 msgstr "Noduri Kad pe sesiune"
 
-#: src/muuli_wdr.cpp:1880 src/muuli_wdr.cpp:2334
+#: src/muuli_wdr.cpp:1884 src/muuli_wdr.cpp:2338
 msgid "Select"
 msgstr "Selectează"
 
-#: src/muuli_wdr.cpp:1884
+#: src/muuli_wdr.cpp:1888
 msgid "Tree"
 msgstr "Arbore"
 
-#: src/muuli_wdr.cpp:1894
+#: src/muuli_wdr.cpp:1898
 msgid "Number of Client Versions shown (0=unlimited)"
 msgstr "Număr de versiuni client arătate (0=nelimitat)"
 
-#: src/muuli_wdr.cpp:1919
+#: src/muuli_wdr.cpp:1923
 msgid "!!! WARNING !!!"
 msgstr "!!! ATENȚIE !!!"
 
-#: src/muuli_wdr.cpp:1934
+#: src/muuli_wdr.cpp:1938
 msgid "Max new connections / 5 secs"
 msgstr "Maxim conexiuni noi /5 secunde"
 
-#: src/muuli_wdr.cpp:1936
+#: src/muuli_wdr.cpp:1940
 msgid "Concurrent Kad source lookups"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1938
+#: src/muuli_wdr.cpp:1942
 #, fuzzy
 msgid "Kad source re-search interval (minutes)"
 msgstr "Rată interval actualizare FTP în minute"
 
-#: src/muuli_wdr.cpp:1940
+#: src/muuli_wdr.cpp:1944
 #, fuzzy
 msgid "Source re-ask interval (minutes)"
 msgstr "Rată interval actualizare FTP în minute"
 
-#: src/muuli_wdr.cpp:1944
+#: src/muuli_wdr.cpp:1948
 msgid "File Buffer Size: 240000 bytes"
 msgstr "Dimensiune fișier tampon: 240000 octeți"
 
-#: src/muuli_wdr.cpp:1948
+#: src/muuli_wdr.cpp:1952
 msgid "Use MMAP: memory-mapped file access (lower memory use)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1949
+#: src/muuli_wdr.cpp:1953
 msgid "Maps part files into memory instead of buffering them on the heap, lowering the process memory footprint. May reduce download speed on some disks; best for memory-constrained or upload-heavy hosts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1951
+#: src/muuli_wdr.cpp:1955
 msgid "Upload Queue Size: 5000 clients"
 msgstr "Dimensiune coadă încărcare: 5000 clienți"
 
-#: src/muuli_wdr.cpp:1955
+#: src/muuli_wdr.cpp:1959
 msgid "Server connection refresh interval: Disable"
 msgstr "Interval reîmprospătare conexiune server: Dezactivat"
 
-#: src/muuli_wdr.cpp:1959
+#: src/muuli_wdr.cpp:1963
 msgid "Disable computer's timed standby mode"
 msgstr "Dezactivează temporizarea modului de st-by al computerului"
 
-#: src/muuli_wdr.cpp:1978
+#: src/muuli_wdr.cpp:1982
 msgid "Skin to use: "
 msgstr "Aspect interfață de utilizat:"
 
-#: src/muuli_wdr.cpp:1987
+#: src/muuli_wdr.cpp:1991
 msgid "Show \"Fast eD2k Links Handler\" in every window."
 msgstr "Arată \"Manipulator linkuri rapide eD2k\" în fiecare fereastră."
 
-#: src/muuli_wdr.cpp:1990
+#: src/muuli_wdr.cpp:1994
 msgid "Show extended info on categories tabs"
 msgstr "Arată informații extinse în fila categoriilor"
 
-#: src/muuli_wdr.cpp:1993
+#: src/muuli_wdr.cpp:1997
 msgid "Show application version on title"
 msgstr "Arată în titlu versiunea aplicației"
 
-#: src/muuli_wdr.cpp:1995
+#: src/muuli_wdr.cpp:1999
 msgid "Show transfer rates on title"
 msgstr "Arată rata de transfer în titlu"
 
-#: src/muuli_wdr.cpp:1997
+#: src/muuli_wdr.cpp:2001
 msgid "Before application name"
 msgstr "Înaintea numelui aplicației"
 
-#: src/muuli_wdr.cpp:1999
+#: src/muuli_wdr.cpp:2003
 msgid "After application name"
 msgstr "După numele aplicației"
 
-#: src/muuli_wdr.cpp:2002
+#: src/muuli_wdr.cpp:2006
 msgid "Show overhead bandwidth"
 msgstr "Arată lățimea de bandă globală"
 
-#: src/muuli_wdr.cpp:2006
+#: src/muuli_wdr.cpp:2010
 msgid "Vertical toolbar orientation"
 msgstr "Orientare verticală a barei de unelte"
 
-#: src/muuli_wdr.cpp:2008
+#: src/muuli_wdr.cpp:2012
 msgid "Live column sorting (auto-reorder rows as their values change)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2015
+#: src/muuli_wdr.cpp:2019
 msgid "Download Queue Files"
 msgstr "Descărcare coadă fișiere"
 
-#: src/muuli_wdr.cpp:2018
+#: src/muuli_wdr.cpp:2022
 msgid "Show progress percentage"
 msgstr "Arată procentul progresului"
 
-#: src/muuli_wdr.cpp:2024
+#: src/muuli_wdr.cpp:2028
 msgid "Show progress bar"
 msgstr "Arată bara de progres"
 
-#: src/muuli_wdr.cpp:2027
+#: src/muuli_wdr.cpp:2031
 msgid "Flat"
 msgstr "Plat"
 
-#: src/muuli_wdr.cpp:2031
+#: src/muuli_wdr.cpp:2035
 msgid "Round"
 msgstr "Rotund"
 
-#: src/muuli_wdr.cpp:2049
+#: src/muuli_wdr.cpp:2053
 msgid "External Connection Parameters"
 msgstr "Parametrii conexiune externă"
 
-#: src/muuli_wdr.cpp:2052
+#: src/muuli_wdr.cpp:2056
 msgid "Accept external connections"
 msgstr "Acceptă conexiuni externe"
 
-#: src/muuli_wdr.cpp:2059 src/muuli_wdr.cpp:2118
+#: src/muuli_wdr.cpp:2063 src/muuli_wdr.cpp:2122
 msgid "IP of the listening interface:"
 msgstr "IP a interfeței de ascultare:"
 
-#: src/muuli_wdr.cpp:2062
+#: src/muuli_wdr.cpp:2066
 msgid "Enter here a valid ip in the a.b.c.d format for the listening EC interface. An empty field or 0.0.0.0 will mean any interface."
 msgstr "Introduceți aici un ip valid în formatul a.b.c.d pentru ascultarea interfeței EC. Un câmp gol sau 0.0.0.0 va însemna orice interfață."
 
-#: src/muuli_wdr.cpp:2083 src/muuli_wdr.cpp:2194
+#: src/muuli_wdr.cpp:2087 src/muuli_wdr.cpp:2198
 msgid "TCP port:"
 msgstr "port TCP:"
 
-#: src/muuli_wdr.cpp:2089
+#: src/muuli_wdr.cpp:2093
 msgid "Enable UPnP port forwarding on the EC port"
 msgstr "Activează înaintarea portului UPnP pe portul EC"
 
-#: src/muuli_wdr.cpp:2093 src/muuli_wdr.cpp:3079
+#: src/muuli_wdr.cpp:2097 src/muuli_wdr.cpp:3083
 #: src/utils/wxCas/src/wxcasprefs.cpp:167
 msgid "Password"
 msgstr "Parolă"
 
-#: src/muuli_wdr.cpp:2099
+#: src/muuli_wdr.cpp:2103
 #, fuzzy
 msgid "aMule API server parameters"
 msgstr "Parametrii server web"
 
-#: src/muuli_wdr.cpp:2102
+#: src/muuli_wdr.cpp:2106
 msgid "Run amuleapi (REST API) on startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2107
+#: src/muuli_wdr.cpp:2111
 #, fuzzy
 msgid "HTTP port:"
 msgstr "port TCP:"
 
-#: src/muuli_wdr.cpp:2121
+#: src/muuli_wdr.cpp:2125
 msgid "The interface amuleapi's HTTP server listens on. 127.0.0.1 (default) accepts only local connections; use 0.0.0.0 or a specific IP to expose it to other hosts (set an admin password below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2126
+#: src/muuli_wdr.cpp:2130
 msgid "Type a password to set or change it. Stored passwords cannot be shown, so leaving this empty keeps the current one."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2128
+#: src/muuli_wdr.cpp:2132
 #, fuzzy
 msgid "Admin password"
 msgstr "Se verifică parola\n"
 
-#: src/muuli_wdr.cpp:2140 src/muuli_wdr.cpp:2157 src/PrefsUnifiedDlg.cpp:1103
+#: src/muuli_wdr.cpp:2144 src/muuli_wdr.cpp:2161 src/PrefsUnifiedDlg.cpp:1112
 #, fuzzy
 msgid "A password is set."
 msgstr "Se verifică parola\n"
 
-#: src/muuli_wdr.cpp:2144
+#: src/muuli_wdr.cpp:2148
 #, fuzzy
 msgid "Enable guest access"
 msgstr "Interzice accesul oaspeților"
 
-#: src/muuli_wdr.cpp:2145
+#: src/muuli_wdr.cpp:2149
 msgid "Guest sessions may read status and listings but cannot change anything. Turning this off clears the stored guest password."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2149
+#: src/muuli_wdr.cpp:2153
 #, fuzzy
 msgid "Guest password"
 msgstr "Parola de oaspete pentru serverul web"
 
-#: src/muuli_wdr.cpp:2164
+#: src/muuli_wdr.cpp:2168
 msgid "Web server parameters"
 msgstr "Parametrii server web"
 
-#: src/muuli_wdr.cpp:2167
+#: src/muuli_wdr.cpp:2171
 #, fuzzy
 msgid "Run webserver on startup (deprecated)"
 msgstr "Rulează la pornire serverul web"
 
-#: src/muuli_wdr.cpp:2173
+#: src/muuli_wdr.cpp:2177
 msgid "Web template"
 msgstr "Șablon web"
 
-#: src/muuli_wdr.cpp:2178
+#: src/muuli_wdr.cpp:2182
 msgid "Full rights password"
 msgstr "Parolă cu drepturi depline"
 
-#: src/muuli_wdr.cpp:2182
+#: src/muuli_wdr.cpp:2186
 msgid "Enable Low rights User"
 msgstr "Activează utilizatorul cu drepturi scăzute"
 
-#: src/muuli_wdr.cpp:2187
+#: src/muuli_wdr.cpp:2191
 msgid "Low rights password"
 msgstr "Parolă cu drepturi scăzute"
 
-#: src/muuli_wdr.cpp:2201
+#: src/muuli_wdr.cpp:2205
 msgid "Enable UPnP port forwarding of the web server port"
 msgstr "Activează înaintarea portului UPnP pe portul serverului web"
 
-#: src/muuli_wdr.cpp:2206
+#: src/muuli_wdr.cpp:2210
 msgid "Web server UPnP TCP port (Optional)"
 msgstr "Port UPnP TCP server web (facultativ)"
 
-#: src/muuli_wdr.cpp:2214
+#: src/muuli_wdr.cpp:2218
 msgid "Page Refresh Time (in secs)"
 msgstr "Timp reîmprospătare pagină (în secunde)"
 
-#: src/muuli_wdr.cpp:2221
+#: src/muuli_wdr.cpp:2225
 msgid "Enable Gzip compression"
 msgstr "Activează compresia Gzip"
 
-#: src/muuli_wdr.cpp:2255
+#: src/muuli_wdr.cpp:2259
 #, fuzzy
 msgid "Reset page to defaults"
 msgstr "Valoare implicită a sistemului"
 
-#: src/muuli_wdr.cpp:2256
+#: src/muuli_wdr.cpp:2260
 msgid "Reset the settings on the current page to their default values."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2258 src/muuli_wdr.cpp:2344 src/ServerWnd.cpp:274
+#: src/muuli_wdr.cpp:2262 src/muuli_wdr.cpp:2348 src/ServerWnd.cpp:274
 #: src/ServerWnd.cpp:282
 msgid "OK"
 msgstr "Bine"
 
-#: src/muuli_wdr.cpp:2260
+#: src/muuli_wdr.cpp:2264
 msgid "Click here to apply any changes made to the preferences."
 msgstr "Apăsați aici pentru a aplica orice modificare efectuată la preferințe."
 
-#: src/muuli_wdr.cpp:2263
+#: src/muuli_wdr.cpp:2267
 msgid "Reset any changes made to the preferences."
 msgstr "Resetează orice schimbare efectuată la preferințe."
 
-#: src/muuli_wdr.cpp:2292
+#: src/muuli_wdr.cpp:2296
 msgid "Comment :"
 msgstr "Comentariu :"
 
-#: src/muuli_wdr.cpp:2299
+#: src/muuli_wdr.cpp:2303
 msgid "Incoming Dir :"
 msgstr "Director intrare :"
 
-#: src/muuli_wdr.cpp:2308
+#: src/muuli_wdr.cpp:2312
 msgid "Change priority for new assigned files :"
 msgstr "Schimbă prioritatea pentru noile fișiere alocate :"
 
-#: src/muuli_wdr.cpp:2312
+#: src/muuli_wdr.cpp:2316
 msgid "Don't change"
 msgstr "Nu modifica"
 
-#: src/muuli_wdr.cpp:2324
+#: src/muuli_wdr.cpp:2328
 msgid "Select color for this Category (currently selected) :"
 msgstr "Selectați culoarea pentru această categorie (selectată curent):"
 
-#: src/muuli_wdr.cpp:2391 src/muuli_wdr.cpp:2410 src/muuli_wdr.cpp:2432
+#: src/muuli_wdr.cpp:2395 src/muuli_wdr.cpp:2414 src/muuli_wdr.cpp:2436
 msgid "Click this button to reset the log."
 msgstr "Apăsați acest buton pentru resetarea jurnalului."
 
-#: src/muuli_wdr.cpp:2451
+#: src/muuli_wdr.cpp:2455
 msgid "Click on this button to update the servers list from URL ..."
 msgstr "Apăsați acest buton pentru a se actualiza lista serverelor din URL ..."
 
-#: src/muuli_wdr.cpp:2455
+#: src/muuli_wdr.cpp:2459
 msgid "Server list"
 msgstr "Listă server"
 
-#: src/muuli_wdr.cpp:2459
+#: src/muuli_wdr.cpp:2463
 msgid "Enter the url to a server.met file here and press the button to the left to update the list of known servers."
 msgstr "Introduceți aici adresa URL pentru un fișier server.met și apăsați butonul din stânga pentru a actualiza lista serverelor. cunoscute."
 
-#: src/muuli_wdr.cpp:2464
+#: src/muuli_wdr.cpp:2468
 msgid "Add server manually: Name"
 msgstr "Adăugare server manual: Nume"
 
-#: src/muuli_wdr.cpp:2467
+#: src/muuli_wdr.cpp:2471
 msgid "Enter the name of the new server here"
 msgstr "Introduceți aici numele noului server"
 
-#: src/muuli_wdr.cpp:2469 src/ServerWnd.cpp:206
+#: src/muuli_wdr.cpp:2473 src/ServerWnd.cpp:206
 msgid "IP:Port"
 msgstr "IP:Port"
 
-#: src/muuli_wdr.cpp:2472
+#: src/muuli_wdr.cpp:2476
 msgid "Enter the IP of the server here, using the x.x.x.x format."
 msgstr "Introduceți aici adresa IP a serverului, utilizând formatul x.x.x.x  ."
 
-#: src/muuli_wdr.cpp:2478
+#: src/muuli_wdr.cpp:2482
 msgid "Enter the port of the server here."
 msgstr "Introduceți aici portul serverului."
 
-#: src/muuli_wdr.cpp:2481
+#: src/muuli_wdr.cpp:2485
 msgid "Add manually a server (fill fields to the left before) ..."
 msgstr "Adăugați un server manual (completați întâi câmpurile din stânga) ..."
 
-#: src/muuli_wdr.cpp:2510
+#: src/muuli_wdr.cpp:2514
 msgid "aMule Log"
 msgstr "Jurnal aMule"
 
-#: src/muuli_wdr.cpp:2518
+#: src/muuli_wdr.cpp:2522
 msgid "Server Info"
 msgstr "Informație server"
 
-#: src/muuli_wdr.cpp:2522
+#: src/muuli_wdr.cpp:2526
 msgid "ED2K Info"
 msgstr "Informație eD2k"
 
-#: src/muuli_wdr.cpp:2526
+#: src/muuli_wdr.cpp:2530
 msgid "Kad Info"
 msgstr "Informație Kad"
 
-#: src/muuli_wdr.cpp:2554
+#: src/muuli_wdr.cpp:2558
 msgid "Click on this button to update the nodes list from URL ..."
 msgstr "Apăsați pe acest buton pentru a actualiza lista nodurilor din URL ..."
 
-#: src/muuli_wdr.cpp:2558
+#: src/muuli_wdr.cpp:2562
 msgid "Nodes (0)"
 msgstr "Noduri (0)"
 
-#: src/muuli_wdr.cpp:2562
+#: src/muuli_wdr.cpp:2566
 msgid "Enter the url to a nodes.dat file here and press the button to the left to update the list of known nodes."
 msgstr "Introduceți aici adresa url către un fișier nodes.dat și apăsați butonul din stânga pentru actualizarea listei nodurilor cunoscute."
 
-#: src/muuli_wdr.cpp:2565
+#: src/muuli_wdr.cpp:2569
 msgid "Nodes stats"
 msgstr "Stare noduri"
 
-#: src/muuli_wdr.cpp:2607
+#: src/muuli_wdr.cpp:2611
 msgid "Bootstrap"
 msgstr "Bootstrap"
 
-#: src/muuli_wdr.cpp:2610
+#: src/muuli_wdr.cpp:2614
 msgid "New node"
 msgstr "Nod nou"
 
-#: src/muuli_wdr.cpp:2615
+#: src/muuli_wdr.cpp:2619
 msgid "IP:"
 msgstr "IP:"
 
-#: src/muuli_wdr.cpp:2635
+#: src/muuli_wdr.cpp:2639
 msgid "Port:"
 msgstr "Port:"
 
-#: src/muuli_wdr.cpp:2648
+#: src/muuli_wdr.cpp:2652
 msgid "Bootstrap from known clients"
 msgstr "Bootstrap de la clienții cunoscuți"
 
-#: src/muuli_wdr.cpp:2650
+#: src/muuli_wdr.cpp:2654
 msgid "Disconnect Kad"
 msgstr "Deconectare Kad"
 
-#: src/muuli_wdr.cpp:2684
+#: src/muuli_wdr.cpp:2688
 msgid "Use Secure User Identification"
 msgstr "Utilizează identificarea securizată a utilizatorilor"
 
-#: src/muuli_wdr.cpp:2686
+#: src/muuli_wdr.cpp:2690
 msgid "It is recommended to enable this option. You will not receive credits if SUI is not enabled."
 msgstr "Este recomandat să activați această opțiune. Nu veți primii credite dacă SUI nu este activat."
 
-#: src/muuli_wdr.cpp:2688
+#: src/muuli_wdr.cpp:2692
 msgid "Protocol Obfuscation"
 msgstr "Protocol disimulare"
 
-#: src/muuli_wdr.cpp:2691
+#: src/muuli_wdr.cpp:2695
 msgid "Support Protocol Obfuscation"
 msgstr "Suport protocol disimulare"
 
-#: src/muuli_wdr.cpp:2693
+#: src/muuli_wdr.cpp:2697
 msgid "This option enabled Protocol Obfuscation, and makes aMule accept obfuscated connections from other clients."
 msgstr "Această opțiune activează Protocolul Disimulare, și determină aMule să accepte conexiuni disimulate de la alți clienți."
 
-#: src/muuli_wdr.cpp:2695
+#: src/muuli_wdr.cpp:2699
 msgid "Use obfuscation for outgoing connections"
 msgstr "Utilizați disimularea pentru conexiunile de ieșire"
 
-#: src/muuli_wdr.cpp:2697
+#: src/muuli_wdr.cpp:2701
 msgid "This option makes aMule use Protocol Obfuscation when connecting other clients/servers."
 msgstr "Această opțiune determină aMule să utilizeze Protocolul Disimulare când conectează alți clienți/servere."
 
-#: src/muuli_wdr.cpp:2699
+#: src/muuli_wdr.cpp:2703
 msgid "Accept only obfuscated connections"
 msgstr "Acceptă numai conexiuni disimulate"
 
-#: src/muuli_wdr.cpp:2700
+#: src/muuli_wdr.cpp:2704
 msgid "This option makes aMule only accept obfuscated connections. You will have less sources, but all your traffic will be obfuscated"
 msgstr "Această opțiune face aMule să accepte numai conexiuni disimulate. Veți avea mai puține surse, dar tot traficul va fi disimulat"
 
-#: src/muuli_wdr.cpp:2705
+#: src/muuli_wdr.cpp:2709
 msgid "Everybody"
 msgstr "Fiecare"
 
-#: src/muuli_wdr.cpp:2707
+#: src/muuli_wdr.cpp:2711
 msgid "No one"
 msgstr "Nimănui"
 
-#: src/muuli_wdr.cpp:2709
+#: src/muuli_wdr.cpp:2713
 msgid "Who can see my shared files:"
 msgstr "Cine poate vedea fișierele mele partajate:"
 
-#: src/muuli_wdr.cpp:2710
+#: src/muuli_wdr.cpp:2714
 msgid "Select who can request to view a list of your shared files."
 msgstr "Selectați cine poate solicita să vizualizeze o listă a fișierelor partajate."
 
-#: src/muuli_wdr.cpp:2712
+#: src/muuli_wdr.cpp:2716
 msgid "IP-Filtering"
 msgstr "Filtrare-IP"
 
-#: src/muuli_wdr.cpp:2719
+#: src/muuli_wdr.cpp:2723
 msgid "Filter clients"
 msgstr "Filtru clienți"
 
-#: src/muuli_wdr.cpp:2721
+#: src/muuli_wdr.cpp:2725
 msgid "Enable filtering of the client IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "Activați filtrarea IP-urilor client cum este definit în fișierul ~/.aMule/ipfilter.dat."
 
-#: src/muuli_wdr.cpp:2723
+#: src/muuli_wdr.cpp:2727
 msgid "Filter servers"
 msgstr "Filtrare servere"
 
-#: src/muuli_wdr.cpp:2725
+#: src/muuli_wdr.cpp:2729
 msgid "Enable filtering of the server IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "Activați filtrarea IP-urilor server cum este definit în fișierul ~/.aMule/ipfilter.dat."
 
-#: src/muuli_wdr.cpp:2729
+#: src/muuli_wdr.cpp:2733
 msgid "Reload List"
 msgstr "Reîncarcă lista"
 
-#: src/muuli_wdr.cpp:2730
+#: src/muuli_wdr.cpp:2734
 msgid "Reload the list of IPs to filter from the file ~/.aMule/ipfilter.dat"
 msgstr "Reîncarcă lista IP-urilor de filtrat din fișierul ~/.aMule/ipfilter.dat"
 
-#: src/muuli_wdr.cpp:2736
+#: src/muuli_wdr.cpp:2740
 msgid "URL:"
 msgstr "URL:"
 
-#: src/muuli_wdr.cpp:2740 src/muuli_wdr.cpp:2933
+#: src/muuli_wdr.cpp:2744 src/muuli_wdr.cpp:2937
 msgid "Update now"
 msgstr "Actualizează acum"
 
-#: src/muuli_wdr.cpp:2743
+#: src/muuli_wdr.cpp:2747
 msgid "Auto-update ipfilter at startup"
 msgstr "Actualizare automată filtru ip la pornire"
 
-#: src/muuli_wdr.cpp:2747
+#: src/muuli_wdr.cpp:2751
 msgid "Filtering Level:"
 msgstr "Nivel de filtrare:"
 
-#: src/muuli_wdr.cpp:2753
+#: src/muuli_wdr.cpp:2757
 msgid "Always filter LAN IPs"
 msgstr "Filtrează mereu IP-urile LAN"
 
-#: src/muuli_wdr.cpp:2756
+#: src/muuli_wdr.cpp:2760
 msgid "Paranoid handling of non-matching IPs"
 msgstr "Manipulare paranoică a IP-urilor care nu se potrivesc"
 
-#: src/muuli_wdr.cpp:2758
+#: src/muuli_wdr.cpp:2762
 msgid "Rejects a packet when its source IP differs from the IP the client claims (an anti-spoofing check). Disable only if it causes connection problems."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2760
+#: src/muuli_wdr.cpp:2764
 msgid "Use system-wide ipfilter.dat if available"
 msgstr "Utilizați în tot sistemul ipfilter.dat dacă este disponibil"
 
-#: src/muuli_wdr.cpp:2761
+#: src/muuli_wdr.cpp:2765
 #, fuzzy
 msgid "If there's no local ipfilter.dat found, allow usage of a system-wide ipfilter file."
 msgstr "Dacă nu s-a găsit local ipfilter.dat, permite utilizarea unui fișier ipfilter din sistem."
 
-#: src/muuli_wdr.cpp:2778
+#: src/muuli_wdr.cpp:2782
 msgid "Enable Online-Signature"
 msgstr "Activare semnătură online"
 
-#: src/muuli_wdr.cpp:2780
+#: src/muuli_wdr.cpp:2784
 msgid "Enables the writing of the OS file, which can be used by external apps to create signatures and the like."
 msgstr "Activați scrierea fișierului OS, care poate fi utilizat de aplicații exterioare la crearea semnăturilor și aprecierii."
 
-#: src/muuli_wdr.cpp:2784
+#: src/muuli_wdr.cpp:2788
 msgid "Update Frequency (Secs):"
 msgstr "Frecvență actualizare (secunde)"
 
-#: src/muuli_wdr.cpp:2787
+#: src/muuli_wdr.cpp:2791
 msgid "Change the frequency (in seconds) of Online Signature updates."
 msgstr "Schimbați frecvența (în secunde) a actualizărilor semnăturii online."
 
-#: src/muuli_wdr.cpp:2795
+#: src/muuli_wdr.cpp:2799
 msgid "Save online signature file in: "
 msgstr "Salvează fișierul semnăturii online în:"
 
-#: src/muuli_wdr.cpp:2801
+#: src/muuli_wdr.cpp:2805
 msgid "Click here to select the directory containing the the Online Signature files."
 msgstr "Apăsați aici pentru a selecta directorul care conține fișierele cu semnătura online."
 
-#: src/muuli_wdr.cpp:2834
+#: src/muuli_wdr.cpp:2838
 msgid "Show country flags for clients"
 msgstr "Arată steagul țării pentru clienți"
 
-#: src/muuli_wdr.cpp:2835
+#: src/muuli_wdr.cpp:2839
 msgid "Render the country flag column in the transfers, queue and search views. Requires a valid MMDB GeoIP database (see below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2840
+#: src/muuli_wdr.cpp:2844
 #, fuzzy
 msgid "Database"
 msgstr "Rată date :"
 
-#: src/muuli_wdr.cpp:2856
+#: src/muuli_wdr.cpp:2860
 #, fuzzy
 msgid "Source:"
 msgstr "Surse"
 
-#: src/muuli_wdr.cpp:2859
+#: src/muuli_wdr.cpp:2863
 msgid "DB-IP (free, no account)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2860
+#: src/muuli_wdr.cpp:2864
 msgid "MaxMind GeoLite2 (free, account required)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2861
+#: src/muuli_wdr.cpp:2865
 msgid "Custom URL"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2864
+#: src/muuli_wdr.cpp:2868
 msgid "Choose which provider supplies the GeoIP MMDB database. DB-IP is the default - no account required. MaxMind requires a free account + license key. Use Custom URL to point at any other MMDB host (e.g. a local mirror)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2881
+#: src/muuli_wdr.cpp:2885
 msgid ""
 "No configuration required.\n"
 "\n"
@@ -4890,11 +4890,11 @@ msgid ""
 "License: Creative Commons BY 4.0 - https://creativecommons.org/licenses/by/4.0/"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2894
+#: src/muuli_wdr.cpp:2898
 msgid "License key:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2900
+#: src/muuli_wdr.cpp:2904
 msgid ""
 "Sign up for a free MaxMind account, then generate a License Key:\n"
 "https://www.maxmind.com/en/geolite2/signup\n"
@@ -4904,225 +4904,225 @@ msgid ""
 "Requires attribution and account registration; refresh at least every 30 days."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2915
+#: src/muuli_wdr.cpp:2919
 #, fuzzy
 msgid "Download URL:"
 msgstr "Descărcare:"
 
-#: src/muuli_wdr.cpp:2921
+#: src/muuli_wdr.cpp:2925
 msgid ""
 "Must point to an .mmdb file or a .gz / .tar.gz containing one.\n"
 "URL may include credentials (https://user:pass@host/...).\n"
 "License and attribution terms are set by the upstream URL - you are responsible."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2934
+#: src/muuli_wdr.cpp:2938
 msgid "Download the GeoIP database from the selected source."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2936
+#: src/muuli_wdr.cpp:2940
 #, fuzzy
 msgid "Auto-update on startup"
 msgstr "Actualizare automată filtru ip la pornire"
 
-#: src/muuli_wdr.cpp:2937
+#: src/muuli_wdr.cpp:2941
 msgid "Re-download the GeoIP database from the selected source every time aMule starts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2960
+#: src/muuli_wdr.cpp:2964
 msgid "Filter incoming messages (except current chat):"
 msgstr "Filtrare mesaje de intrare (cu excepția chat-ului curent):"
 
-#: src/muuli_wdr.cpp:2962
+#: src/muuli_wdr.cpp:2966
 msgid "Filter all messages"
 msgstr "Filtrează toate mesajele"
 
-#: src/muuli_wdr.cpp:2964
+#: src/muuli_wdr.cpp:2968
 msgid "Filter messages from people not on your friend list"
 msgstr "Filtrare mesaje de la persoane care nu sunt în lista de prieteni"
 
-#: src/muuli_wdr.cpp:2966
+#: src/muuli_wdr.cpp:2970
 msgid "Filter messages from unknown clients"
 msgstr "Filtrare mesaje de la clienți necunoscuți"
 
-#: src/muuli_wdr.cpp:2968
+#: src/muuli_wdr.cpp:2972
 msgid "Filter messages containing (use ',' as separator):"
 msgstr "Filtrare mesaje conținând )utilizați ',' ca separator):"
 
-#: src/muuli_wdr.cpp:2971 src/muuli_wdr.cpp:2982
+#: src/muuli_wdr.cpp:2975 src/muuli_wdr.cpp:2986
 msgid "add here the words amule should filter and block messages including it"
 msgstr "adăugați aici cuvintele pe care amule trebuie să le filtreze și să blocheze mesajele care le includ"
 
-#: src/muuli_wdr.cpp:2973
+#: src/muuli_wdr.cpp:2977
 msgid "Show received messages in the log"
 msgstr "Arată în jurnal mesajele primite"
 
-#: src/muuli_wdr.cpp:2976
+#: src/muuli_wdr.cpp:2980
 msgid "Comments"
 msgstr "Comentarii"
 
-#: src/muuli_wdr.cpp:2979
+#: src/muuli_wdr.cpp:2983
 msgid "Filter comments containing (use ',' as separator):"
 msgstr "Filtrare comentarii conținând (utilizați ',' ca separator):"
 
-#: src/muuli_wdr.cpp:3004
+#: src/muuli_wdr.cpp:3008
 msgid "Enable Proxy"
 msgstr "Activează proxy"
 
-#: src/muuli_wdr.cpp:3005
+#: src/muuli_wdr.cpp:3009
 msgid "Enable/disable proxy support"
 msgstr "Activează/dezactivează suportul proxy"
 
-#: src/muuli_wdr.cpp:3008
+#: src/muuli_wdr.cpp:3012
 msgid "Proxy type:"
 msgstr "Tip proxy:"
 
-#: src/muuli_wdr.cpp:3019
+#: src/muuli_wdr.cpp:3023
 msgid "Proxy host:"
 msgstr "Gazdă proxy:"
 
-#: src/muuli_wdr.cpp:3022
+#: src/muuli_wdr.cpp:3026
 msgid "The proxy host name"
 msgstr "Numele de gazdă proxy"
 
-#: src/muuli_wdr.cpp:3024
+#: src/muuli_wdr.cpp:3028
 msgid "Proxy port:"
 msgstr "Port proxy:"
 
-#: src/muuli_wdr.cpp:3027
+#: src/muuli_wdr.cpp:3031
 msgid "The proxy port"
 msgstr "Portul proxy"
 
-#: src/muuli_wdr.cpp:3029
+#: src/muuli_wdr.cpp:3033
 msgid "Enable authentication"
 msgstr "Activează autentificarea"
 
-#: src/muuli_wdr.cpp:3030
+#: src/muuli_wdr.cpp:3034
 msgid "Enable/disable username/password authentication"
 msgstr "Activează/dezactivează autentificarea cu nume utilizator/parolă"
 
-#: src/muuli_wdr.cpp:3033
+#: src/muuli_wdr.cpp:3037
 msgid "Username: "
 msgstr "Utilizator:"
 
-#: src/muuli_wdr.cpp:3036
+#: src/muuli_wdr.cpp:3040
 msgid "The username to use to connect to the proxy"
 msgstr "Numele de utilizator de utilizat pentru conectarea la proxy"
 
-#: src/muuli_wdr.cpp:3038
+#: src/muuli_wdr.cpp:3042
 msgid "Password:"
 msgstr "Parolă:"
 
-#: src/muuli_wdr.cpp:3041
+#: src/muuli_wdr.cpp:3045
 msgid "The password to use to connect to the proxy"
 msgstr "Parola de utilizat pentru conectarea la proxy"
 
-#: src/muuli_wdr.cpp:3060
+#: src/muuli_wdr.cpp:3064
 msgid "Connect to:"
 msgstr "Conectează la:"
 
-#: src/muuli_wdr.cpp:3069
+#: src/muuli_wdr.cpp:3073
 msgid "Login to remote amule"
 msgstr "Autentificare la amule distant"
 
-#: src/muuli_wdr.cpp:3074
+#: src/muuli_wdr.cpp:3078
 msgid "User name"
 msgstr "Nume utilizator"
 
-#: src/muuli_wdr.cpp:3085
+#: src/muuli_wdr.cpp:3089
 msgid "Remember those settings"
 msgstr "Amintește aceste configurări"
 
-#: src/muuli_wdr.cpp:3088
+#: src/muuli_wdr.cpp:3092
 #, fuzzy
 msgid "Force ZLIB compression"
 msgstr "Utilizează compresia gzip"
 
-#: src/muuli_wdr.cpp:3112
+#: src/muuli_wdr.cpp:3116
 msgid "Enable Verbose Debug-Logging."
 msgstr "Activează jurnalizarea de depanare detaliată."
 
-#: src/muuli_wdr.cpp:3114
+#: src/muuli_wdr.cpp:3118
 msgid "Only to Logfile"
 msgstr "Numai la fișierul jurnal"
 
-#: src/muuli_wdr.cpp:3116
+#: src/muuli_wdr.cpp:3120
 msgid "Message Categories:"
 msgstr "Categorii mesaje:"
 
-#: src/muuli_wdr.cpp:3140 src/PartFileConvertDlg.cpp:160
+#: src/muuli_wdr.cpp:3144 src/PartFileConvertDlg.cpp:160
 msgid "Waiting..."
 msgstr "Așteptați..."
 
-#: src/muuli_wdr.cpp:3160
+#: src/muuli_wdr.cpp:3164
 msgid "Add imports"
 msgstr "Adaugă importurile"
 
-#: src/muuli_wdr.cpp:3163
+#: src/muuli_wdr.cpp:3167
 msgid "Retry selected"
 msgstr "Reîncearcă selectatele"
 
-#: src/muuli_wdr.cpp:3165
+#: src/muuli_wdr.cpp:3169
 msgid "Remove selected"
 msgstr "Elimină selecția"
 
-#: src/muuli_wdr.cpp:3228
+#: src/muuli_wdr.cpp:3232
 msgid "Event Types"
 msgstr "Tipuri de evenimente"
 
-#: src/muuli_wdr.cpp:3247
+#: src/muuli_wdr.cpp:3251
 msgid "Statistics and queued clients for selected file(s) : Session / All time"
 msgstr "Statistici și clienți în coadă pentru fișier(ele) selectate : Sesiune / Tot timpul"
 
-#: src/muuli_wdr.cpp:3271
+#: src/muuli_wdr.cpp:3275
 msgid "Active Uploads"
 msgstr "Încărcări active"
 
-#: src/muuli_wdr.cpp:3285
+#: src/muuli_wdr.cpp:3289
 msgid "Percent of total files"
 msgstr "Procentul din totalul fișierelor"
 
-#: src/muuli_wdr.cpp:3337
+#: src/muuli_wdr.cpp:3341
 msgid "Show Clients for"
 msgstr "Arată clienții pentru"
 
-#: src/muuli_wdr.cpp:3339
+#: src/muuli_wdr.cpp:3343
 msgid "All files"
 msgstr "Toate fișierele"
 
-#: src/muuli_wdr.cpp:3342
+#: src/muuli_wdr.cpp:3346
 msgid "Selected files"
 msgstr "Fișierele selectate"
 
-#: src/muuli_wdr.cpp:3345
+#: src/muuli_wdr.cpp:3349
 msgid "Active uploads only"
 msgstr "Numai încărcările active"
 
-#: src/muuli_wdr.cpp:3352
+#: src/muuli_wdr.cpp:3356
 msgid "Reload:"
 msgstr "Reîncarcă:"
 
-#: src/muuli_wdr.cpp:3356
+#: src/muuli_wdr.cpp:3360
 msgid "Reload your shared files"
 msgstr "Reîncărcați fișierele partajate"
 
-#: src/muuli_wdr.cpp:3419
+#: src/muuli_wdr.cpp:3423
 msgid "Send"
 msgstr "Trimite"
 
-#: src/muuli_wdr.cpp:3420
+#: src/muuli_wdr.cpp:3424
 msgid "Sends the specified message."
 msgstr "Trimite mesajul specificat"
 
-#: src/muuli_wdr.cpp:3424
+#: src/muuli_wdr.cpp:3428
 msgid "Close this chat-session."
 msgstr "Închide această sesiune de chat."
 
-#: src/muuli_wdr.cpp:3447
+#: src/muuli_wdr.cpp:3451
 msgid "Connect to any server and/or Kad"
 msgstr "Conectare la orice server și/sau Kad"
 
-#: src/muuli_wdr.cpp:3453 src/SharedFilesCtrl.cpp:142 src/Statistics.cpp:941
+#: src/muuli_wdr.cpp:3457 src/SharedFilesCtrl.cpp:142 src/Statistics.cpp:941
 msgid "Shared Files"
 msgstr "Fișiere partajate"
 
@@ -5760,35 +5760,35 @@ msgstr ""
 "aMule va rula perfect fără să ajustați nimic\n"
 "din aceste configurări."
 
-#: src/PrefsUnifiedDlg.cpp:647
+#: src/PrefsUnifiedDlg.cpp:656
 #, c-format
 msgid "Failed to connect Cfg to widget with the ID %d and key %s"
 msgstr "A eșuat conectarea Cfg la widget cu ID %d și cheia %s"
 
-#: src/PrefsUnifiedDlg.cpp:695
+#: src/PrefsUnifiedDlg.cpp:704
 #, c-format
 msgid "Failed to transfer data from Cfg to Widget with the ID %d and key %s"
 msgstr "A eșuat transferul datelor de la Cfg la widget cu ID %d și cheia %s"
 
-#: src/PrefsUnifiedDlg.cpp:801
+#: src/PrefsUnifiedDlg.cpp:810
 msgid "The type of proxy you are connecting to"
 msgstr "Tipul de proxy la care sunteți conectat"
 
-#: src/PrefsUnifiedDlg.cpp:1020
+#: src/PrefsUnifiedDlg.cpp:1029
 #, c-format
 msgid "Failed to transfer data from Widget to Cfg with the ID %d and key %s"
 msgstr "A eșuat transferul datelor de la widget la Cfg cu ID %d și cheia %s"
 
-#: src/PrefsUnifiedDlg.cpp:1103
+#: src/PrefsUnifiedDlg.cpp:1112
 #, fuzzy
 msgid "No password set."
 msgstr "Se verifică parola\n"
 
-#: src/PrefsUnifiedDlg.cpp:1132
+#: src/PrefsUnifiedDlg.cpp:1141
 msgid "Guest access needs a password. Type one in the guest password field, or untick Enable guest access."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1144
+#: src/PrefsUnifiedDlg.cpp:1153
 msgid ""
 "aMule must be restarted to enable these changes:\n"
 "\n"
@@ -5796,41 +5796,41 @@ msgstr ""
 "aMule trebuie repornit pentru ca aceste modificări să fie activate:\n"
 "\n"
 
-#: src/PrefsUnifiedDlg.cpp:1151
+#: src/PrefsUnifiedDlg.cpp:1160
 msgid "- TCP port changed.\n"
 msgstr "- Portul TCP s-a schimbat.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1156
+#: src/PrefsUnifiedDlg.cpp:1165
 msgid "- UDP port changed.\n"
 msgstr "- Portul UDP s-a schimbat.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1161
+#: src/PrefsUnifiedDlg.cpp:1170
 #, fuzzy
 msgid "- Network interface binding changed.\n"
 msgstr "- Interfața conexiunii externe s-a schimbat.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1166
+#: src/PrefsUnifiedDlg.cpp:1175
 msgid "- External connect port changed.\n"
 msgstr "- Portul conexiunii externe s-a schimbat.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1170
+#: src/PrefsUnifiedDlg.cpp:1179
 msgid "- External connect acceptance changed.\n"
 msgstr "- Conectarea externă acceptă modificarea.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1174
+#: src/PrefsUnifiedDlg.cpp:1183
 msgid "- External connect interface changed.\n"
 msgstr "- Interfața conexiunii externe s-a schimbat.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1178
+#: src/PrefsUnifiedDlg.cpp:1187
 msgid "- Protocol obfuscation support changed.\n"
 msgstr "- Suportul protocolului disimulare s-a schimbat.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1193
+#: src/PrefsUnifiedDlg.cpp:1202
 #, fuzzy
 msgid "- amuleapi settings changed.\n"
 msgstr "- Limba s-a schimbat.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1202
+#: src/PrefsUnifiedDlg.cpp:1211
 msgid ""
 "Your Auto-update server list is empty.\n"
 "'Auto-update server list at startup' will be disabled."
@@ -5838,7 +5838,7 @@ msgstr ""
 "Lista de actualizare automată a serverelor este goală.\n"
 "'Actualizează automat lista serverelor la pornire' va fi dezactivată."
 
-#: src/PrefsUnifiedDlg.cpp:1213
+#: src/PrefsUnifiedDlg.cpp:1222
 msgid ""
 "You have enabled external connections but have not specified a password.\n"
 "External connections cannot be enabled unless a valid password is specified."
@@ -5846,33 +5846,33 @@ msgstr ""
 "Ați activat conexiunile externe dar nu ați specificat o parolă.\n"
 "Conexiunile externe nu se pot activa până ce nu va fi specificată o parolă validă."
 
-#: src/PrefsUnifiedDlg.cpp:1246
+#: src/PrefsUnifiedDlg.cpp:1255
 #, c-format
 msgid "The amuleapi password could not be saved: %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1276
+#: src/PrefsUnifiedDlg.cpp:1285
 msgid "- Language changed.\n"
 msgstr "- Limba s-a schimbat.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1281
+#: src/PrefsUnifiedDlg.cpp:1290
 msgid "- Temp folder changed.\n"
 msgstr "- Dosarul temporar s-a schimbat.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1286
+#: src/PrefsUnifiedDlg.cpp:1295
 msgid "- ED2K network enabled.\n"
 msgstr "- Rețeaua ED2K s-a activat.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1319
+#: src/PrefsUnifiedDlg.cpp:1328
 msgid "The shared-file exclusion pattern is not a valid regular expression. The filter has been left disabled."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1321 src/PrefsUnifiedDlg.cpp:1921
+#: src/PrefsUnifiedDlg.cpp:1330 src/PrefsUnifiedDlg.cpp:1930
 #, fuzzy
 msgid "Invalid regular expression"
 msgstr "Versiune protocol nevalidă."
 
-#: src/PrefsUnifiedDlg.cpp:1398
+#: src/PrefsUnifiedDlg.cpp:1407
 msgid ""
 "Both eD2k and Kad network are disabled.\n"
 "You won't be able to connect until you enable at least one of them."
@@ -5880,7 +5880,7 @@ msgstr ""
 "Ambele rețele eD2k și Kad sunt dezactivate.\n"
 "Nu vă puteți conecta doar după ce veți activa cel puțin una dintre ele."
 
-#: src/PrefsUnifiedDlg.cpp:1403
+#: src/PrefsUnifiedDlg.cpp:1412
 msgid ""
 "Kad will not start if your UDP port is disabled.\n"
 "Enable UDP port or disable Kad."
@@ -5888,7 +5888,7 @@ msgstr ""
 "Kad nu va porni dacă portul UDP este dezactivat.\n"
 "Activați portul UDP sau dezactivați Kad."
 
-#: src/PrefsUnifiedDlg.cpp:1459
+#: src/PrefsUnifiedDlg.cpp:1468
 msgid ""
 "\n"
 "You MUST restart aMule now.\n"
@@ -5898,69 +5898,69 @@ msgstr ""
 "Trebuie să reporniți aMule acum.\n"
 "Dacă nu îl reporniți acum, nu vă plângeți dacă ceva rău se întâmplă.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1524
+#: src/PrefsUnifiedDlg.cpp:1533
 msgid "Could not register aMule for autostart at login. The autostart store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1526
+#: src/PrefsUnifiedDlg.cpp:1535
 msgid "Could not remove the autostart-at-login entry."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1527
+#: src/PrefsUnifiedDlg.cpp:1536
 #, fuzzy
 msgid "Autostart"
 msgstr "Reîmprospătarea automată pornită"
 
-#: src/PrefsUnifiedDlg.cpp:1542
+#: src/PrefsUnifiedDlg.cpp:1551
 msgid "Register file type"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1542
+#: src/PrefsUnifiedDlg.cpp:1551
 msgid "Register URL handler"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1550
+#: src/PrefsUnifiedDlg.cpp:1559
 #, c-format
 msgid "aMule only handles eD2k-compatible magnets. If you replace the current magnet handler (%s), BitTorrent magnet links will stop working - aMule cannot download BitTorrent content. Continue?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1555
+#: src/PrefsUnifiedDlg.cpp:1564
 #, c-format
 msgid "Another application currently opens .emulecollection files (%s). Replace it with aMule?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1560
+#: src/PrefsUnifiedDlg.cpp:1569
 #, c-format
 msgid "Another application is currently the default handler for these links (%s). Replace it with aMule?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1585
+#: src/PrefsUnifiedDlg.cpp:1594
 msgid "Could not register aMule for .emulecollection files. The registration store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1587
+#: src/PrefsUnifiedDlg.cpp:1596
 #, fuzzy
 msgid "Could not remove the file type registration."
 msgstr "Dosar pentru fișiere descărcate temporar"
 
-#: src/PrefsUnifiedDlg.cpp:1589
+#: src/PrefsUnifiedDlg.cpp:1598
 msgid "Could not register aMule as the URL handler. The registration store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1591
+#: src/PrefsUnifiedDlg.cpp:1600
 msgid "Could not remove the URL handler registration."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1661 src/PrefsUnifiedDlg.cpp:1688
+#: src/PrefsUnifiedDlg.cpp:1670 src/PrefsUnifiedDlg.cpp:1697
 #, fuzzy
 msgid "The web server and aMule API require external connections to be enabled."
 msgstr "Configurarea parolei și conexiunile externe sunt activate."
 
-#: src/PrefsUnifiedDlg.cpp:1671
+#: src/PrefsUnifiedDlg.cpp:1680
 msgid "The aMule web server is deprecated. Consider running the aMule API instead."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1735
+#: src/PrefsUnifiedDlg.cpp:1744
 msgid ""
 "Your Auto-update servers list is in blank.\n"
 "Please fill in at least one URL to point to a valid server.met file.\n"
@@ -5970,24 +5970,24 @@ msgstr ""
 "Introduceți în listă cel puțin o adresă URL pentru a se indica un fișier server.met valid.\n"
 "Apăsați butonul \"List\" cu această căsuță pentru a introduce o adresă URL."
 
-#: src/PrefsUnifiedDlg.cpp:1876
+#: src/PrefsUnifiedDlg.cpp:1885
 msgid "Temporary files"
 msgstr "Fișiere temporare"
 
-#: src/PrefsUnifiedDlg.cpp:1881
+#: src/PrefsUnifiedDlg.cpp:1890
 msgid "Incoming files"
 msgstr "Fișiere de intrare"
 
-#: src/PrefsUnifiedDlg.cpp:1886
+#: src/PrefsUnifiedDlg.cpp:1895
 msgid "Online Signatures"
 msgstr "Semnături online"
 
-#: src/PrefsUnifiedDlg.cpp:1899
+#: src/PrefsUnifiedDlg.cpp:1908
 #, c-format
 msgid "Choose a folder for %s"
 msgstr "Alegeți un dosar pentru %s"
 
-#: src/PrefsUnifiedDlg.cpp:1923
+#: src/PrefsUnifiedDlg.cpp:1932
 #, fuzzy, c-format
 msgid "Would exclude %u of %u shared file"
 msgid_plural "Would exclude %u of %u shared files"
@@ -5995,42 +5995,42 @@ msgstr[0] "S-a găsit %i fișier partajat cunoscut"
 msgstr[1] "S-au găsit %i fișiere partajate cunoscute"
 msgstr[2] "S-au găsit %i de fișiere partajate cunoscute"
 
-#: src/PrefsUnifiedDlg.cpp:1940
+#: src/PrefsUnifiedDlg.cpp:1949
 msgid "Browse for videoplayer"
 msgstr "Navigați pentru playerul video"
 
-#: src/PrefsUnifiedDlg.cpp:1944
+#: src/PrefsUnifiedDlg.cpp:1953
 msgid "Select browser"
 msgstr "Selectare navigator"
 
-#: src/PrefsUnifiedDlg.cpp:1948
+#: src/PrefsUnifiedDlg.cpp:1957
 #, fuzzy
 msgid "Select ffprobe binary"
 msgstr "Selectare navigator"
 
-#: src/PrefsUnifiedDlg.cpp:1954
+#: src/PrefsUnifiedDlg.cpp:1963
 #, c-format
 msgid "Executable%s"
 msgstr "Executabil%s"
 
-#: src/PrefsUnifiedDlg.cpp:1988
+#: src/PrefsUnifiedDlg.cpp:1997
 msgid "ffprobe not found on PATH or in the standard install locations. Install ffmpeg (which ships ffprobe) or use Browse to pick a binary manually."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2000
+#: src/PrefsUnifiedDlg.cpp:2009
 msgid "Reset the settings on this page to their default values?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2001
+#: src/PrefsUnifiedDlg.cpp:2010
 #, fuzzy
 msgid "Reset to defaults"
 msgstr "Valoare implicită a sistemului"
 
-#: src/PrefsUnifiedDlg.cpp:2028
+#: src/PrefsUnifiedDlg.cpp:2037
 msgid "Edit server list"
 msgstr "Editare listă server"
 
-#: src/PrefsUnifiedDlg.cpp:2029
+#: src/PrefsUnifiedDlg.cpp:2038
 msgid ""
 "Add here URL's to download server.met files.\n"
 "Only one url on each line."
@@ -6038,42 +6038,42 @@ msgstr ""
 "Adăugați aici adresele URL pentru descărcat fișierele server.met.\n"
 "Numai o singură adresă URL pe fiecare linie."
 
-#: src/PrefsUnifiedDlg.cpp:2084
+#: src/PrefsUnifiedDlg.cpp:2093
 msgid "IP2Country update failed"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2229 src/PrefsUnifiedDlg.cpp:2260
+#: src/PrefsUnifiedDlg.cpp:2238 src/PrefsUnifiedDlg.cpp:2269
 msgid "Data by MaxMind GeoLite2"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2231 src/PrefsUnifiedDlg.cpp:2262
+#: src/PrefsUnifiedDlg.cpp:2240 src/PrefsUnifiedDlg.cpp:2271
 #, fuzzy
 msgid "Custom source"
 msgstr "Surse complete"
 
-#: src/PrefsUnifiedDlg.cpp:2233 src/PrefsUnifiedDlg.cpp:2264
+#: src/PrefsUnifiedDlg.cpp:2242 src/PrefsUnifiedDlg.cpp:2273
 msgid "Data by DB-IP.com"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2284
+#: src/PrefsUnifiedDlg.cpp:2293
 #, fuzzy, c-format
 msgid "Status: Loaded%s"
 msgstr "Stare:"
 
-#: src/PrefsUnifiedDlg.cpp:2286
+#: src/PrefsUnifiedDlg.cpp:2295
 #, fuzzy, c-format
 msgid "Status: Loaded%s - %s"
 msgstr "Stare:"
 
-#: src/PrefsUnifiedDlg.cpp:2290
+#: src/PrefsUnifiedDlg.cpp:2299
 msgid "Status: Failed to load - click 'Update now' to refresh."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2292
+#: src/PrefsUnifiedDlg.cpp:2301
 msgid "Status: Not found - click 'Update now' to download."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2350 src/PrefsUnifiedDlg.cpp:2374
+#: src/PrefsUnifiedDlg.cpp:2359 src/PrefsUnifiedDlg.cpp:2383
 #, c-format
 msgid "Update delay: %d second"
 msgid_plural "Update delay: %d seconds"
@@ -6081,7 +6081,7 @@ msgstr[0] "Întârziere actualizare: %d secundă"
 msgstr[1] "Întârziere actualizare: %d secunde"
 msgstr[2] "Întârziere actualizare: %d de secunde"
 
-#: src/PrefsUnifiedDlg.cpp:2358
+#: src/PrefsUnifiedDlg.cpp:2367
 #, c-format
 msgid "Time for average graph: %d minute"
 msgid_plural "Time for average graph: %d minutes"
@@ -6089,12 +6089,12 @@ msgstr[0] "Timp pentru media graficului: %d minut"
 msgstr[1] "Timp pentru media graficului: %d minute"
 msgstr[2] "Timp pentru media graficului: %d de minute"
 
-#: src/PrefsUnifiedDlg.cpp:2367
+#: src/PrefsUnifiedDlg.cpp:2376
 #, c-format
 msgid "Connections Graph Scale: %d"
 msgstr "Scală grafic conexiuni: %d"
 
-#: src/PrefsUnifiedDlg.cpp:2382
+#: src/PrefsUnifiedDlg.cpp:2391
 #, c-format
 msgid "File Buffer Size: %d byte"
 msgid_plural "File Buffer Size: %d bytes"
@@ -6102,7 +6102,7 @@ msgstr[0] "Dimensiune fișier tampon: %d octet"
 msgstr[1] "Dimensiune fișier tampon: %d octeți"
 msgstr[2] "Dimensiune fișier tampon: %d de octeți"
 
-#: src/PrefsUnifiedDlg.cpp:2392
+#: src/PrefsUnifiedDlg.cpp:2401
 #, c-format
 msgid "Upload Queue Size: %d client"
 msgid_plural "Upload Queue Size: %d clients"
@@ -6110,7 +6110,7 @@ msgstr[0] "Dimensiune coadă încărcări: %d client"
 msgstr[1] "Dimensiune coadă încărcări: %d clienți"
 msgstr[2] "Dimensiune coadă încărcări: %d de clienți"
 
-#: src/PrefsUnifiedDlg.cpp:2402
+#: src/PrefsUnifiedDlg.cpp:2411
 #, c-format
 msgid "Server connection refresh interval: %d minute"
 msgid_plural "Server connection refresh interval: %d minutes"
@@ -6118,79 +6118,79 @@ msgstr[0] "Interval reâmprospătare conexiune server: %d minut"
 msgstr[1] "Interval reâmprospătare conexiune server: %d minute"
 msgstr[2] "Interval reâmprospătare conexiune server: %d de minute"
 
-#: src/PrefsUnifiedDlg.cpp:2407
+#: src/PrefsUnifiedDlg.cpp:2416
 msgid "Server connection refresh interval: Disabled"
 msgstr "Interval reâmprospătare conexiune server: Dezactivat"
 
-#: src/PrefsUnifiedDlg.cpp:2451
+#: src/PrefsUnifiedDlg.cpp:2460
 msgid "disabled"
 msgstr "dezactivată"
 
-#: src/PrefsUnifiedDlg.cpp:2477
+#: src/PrefsUnifiedDlg.cpp:2486
 #, c-format
 msgid "Execute command on '%s' event"
 msgstr "Execută comanda la evenimentul '%s' "
 
-#: src/PrefsUnifiedDlg.cpp:2484
+#: src/PrefsUnifiedDlg.cpp:2493
 msgid "Enable command execution on core"
 msgstr "Activați executarea de comenzi în nucleu"
 
-#: src/PrefsUnifiedDlg.cpp:2496
+#: src/PrefsUnifiedDlg.cpp:2505
 msgid "Core command:"
 msgstr "Comandă nucleu:"
 
-#: src/PrefsUnifiedDlg.cpp:2512
+#: src/PrefsUnifiedDlg.cpp:2521
 msgid "Enable command execution on GUI"
 msgstr "Activează execuția comenzi pe GUI"
 
-#: src/PrefsUnifiedDlg.cpp:2524
+#: src/PrefsUnifiedDlg.cpp:2533
 msgid "GUI command:"
 msgstr "Comandă GUI:"
 
-#: src/PrefsUnifiedDlg.cpp:2540
+#: src/PrefsUnifiedDlg.cpp:2549
 msgid "The following variables will be replaced:"
 msgstr "Următoarele variabile vor fi înlocuite:"
 
-#: src/PrefsUnifiedDlg.cpp:2708
+#: src/PrefsUnifiedDlg.cpp:2717
 msgid ""
 "The following folders look like system or sensitive locations:\n"
 "\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2713
+#: src/PrefsUnifiedDlg.cpp:2722
 msgid "Sharing them recursively will publish every file underneath on the eD2k/Kad networks. Do you really want to do this?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2716
+#: src/PrefsUnifiedDlg.cpp:2725
 #, fuzzy
 msgid "Confirm shared folders"
 msgstr "Dosare partajate"
 
-#: src/PrefsUnifiedDlg.cpp:2744
+#: src/PrefsUnifiedDlg.cpp:2753
 #, fuzzy
 msgid "Reloading shared files..."
 msgstr "Reîncărcați fișierele partajate"
 
-#: src/PrefsUnifiedDlg.cpp:2745
+#: src/PrefsUnifiedDlg.cpp:2754
 msgid "Scanning for subdirectories..."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2746
+#: src/PrefsUnifiedDlg.cpp:2755
 #, fuzzy
 msgid "Updating shared folders"
 msgstr "Dosare partajate"
 
-#: src/PrefsUnifiedDlg.cpp:2773
+#: src/PrefsUnifiedDlg.cpp:2782
 #, c-format
 msgid "Scanned %u directories..."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2823
+#: src/PrefsUnifiedDlg.cpp:2832
 #, fuzzy, c-format
 msgid "Reloading shared files: %u files scanned"
 msgstr "Reîncarcă lista fișierelor partajate."
 
-#: src/PrefsUnifiedDlg.cpp:2873
+#: src/PrefsUnifiedDlg.cpp:2882
 #, fuzzy
 msgid "Shared folder"
 msgstr "Dosare partajate"
@@ -7880,12 +7880,12 @@ msgstr "Elimină categoria"
 msgid "Hashset requested for unknown file: %s"
 msgstr "Indexare solicitată pentru fișierul necunoscut: %s"
 
-#: src/UploadQueue.cpp:618
+#: src/UploadQueue.cpp:627
 #, c-format
 msgid "Resuming uploads of file: %s"
 msgstr "Se reia încărcarea fișierului: %s"
 
-#: src/UploadQueue.cpp:634
+#: src/UploadQueue.cpp:643
 #, c-format
 msgid "Suspending upload of file: %s"
 msgstr "Se suspendă încărcarea fișierului: %s"

--- a/po/ro.po
+++ b/po/ro.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-28 08:06+0200\n"
+"POT-Creation-Date: 2026-07-28 10:19+0200\n"
 "PO-Revision-Date: 2026-07-27 11:44+0000\n"
 "Last-Translator: Angelescu Constantin <titus0818@yahoo.com>\n"
 "Language-Team: English <kde-i18n-doc@kde.org>\n"
@@ -144,7 +144,7 @@ msgstr ""
 msgid "Not now"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:422 src/amuleDlg.cpp:600
+#: src/AppImageIntegration.cpp:422 src/amuleDlg.cpp:665
 msgid "Don't ask again"
 msgstr ""
 
@@ -217,7 +217,7 @@ msgid "Killing amuleweb instance with pid '%d' ... "
 msgstr "Se omoară instanța amuleweb cu pid '%d' ... "
 
 #: src/amule.cpp:336 src/amule.cpp:349 src/ClientRef.cpp:180
-#: src/SearchDlg.cpp:880 src/ServerListCtrl.cpp:98
+#: src/SearchDlg.cpp:1041 src/ServerListCtrl.cpp:98
 msgid "Failed"
 msgstr "Eșuat"
 
@@ -573,30 +573,68 @@ msgstr "Nu se poate crea fișierul Pid"
 msgid "ERROR: %s"
 msgstr "EROARE: %s"
 
-#: src/amuleDlg.cpp:236
+#: src/amuleDlg.cpp:250
 #, c-format
 msgid "This is aMule %s based on eMule."
 msgstr "Acesta este aMule %s bazat pe eMule."
 
-#: src/amuleDlg.cpp:237
+#: src/amuleDlg.cpp:251
 #, c-format
 msgid "Running on %s"
 msgstr "Rulând pe %s"
 
-#: src/amuleDlg.cpp:239
+#: src/amuleDlg.cpp:253
 msgid "Visit https://github.com/amule-org/amule/releases/latest to check if a new version is available."
 msgstr "Vizitați https://github.com/amule-org/amule/releases/latest pentru a verifica dacă este disponibilă o nouă versiune."
 
-#: src/amuleDlg.cpp:268
+#: src/amuleDlg.cpp:282
 msgid "FATAL ERROR: Failed to create Timer"
 msgstr "EROARE FATALĂ: A eșuat crearea temporizatorului"
 
-#: src/amuleDlg.cpp:592
+#: src/amuleDlg.cpp:361 src/amuleDlg.cpp:1787 src/amuleDlg.cpp:2033
+#: src/muuli_wdr.cpp:1492 src/muuli_wdr.cpp:3418
+msgid "Networks"
+msgstr "Rețele"
+
+#: src/amuleDlg.cpp:362 src/amuleDlg.cpp:1793 src/muuli_wdr.cpp:3419
+msgid "Searches"
+msgstr "Căutări"
+
+#: src/amuleDlg.cpp:363 src/amuleDlg.cpp:1799 src/DownloadListCtrl.cpp:740
+#: src/muuli_wdr.cpp:392 src/muuli_wdr.cpp:1585 src/muuli_wdr.cpp:3420
+#: src/Statistics.cpp:829
+msgid "Downloads"
+msgstr "Descărcări"
+
+#: src/amuleDlg.cpp:364 src/amuleDlg.cpp:1805 src/muuli_wdr.cpp:3294
+msgid "Shared files"
+msgstr "Fișiere partajate"
+
+#: src/amuleDlg.cpp:365 src/amuleDlg.cpp:1811 src/muuli_wdr.cpp:2926
+#: src/muuli_wdr.cpp:3376 src/muuli_wdr.cpp:3423
+msgid "Messages"
+msgstr "Mesaje"
+
+#: src/amuleDlg.cpp:366 src/amuleDlg.cpp:1817 src/muuli_wdr.cpp:3424
+#: src/PrefsUnifiedDlg.cpp:312 src/Statistics.cpp:779 src/Statistics.cpp:1235
+msgid "Statistics"
+msgstr "Statistici"
+
+#: src/amuleDlg.cpp:368 src/amuleDlg.cpp:1824 src/muuli_wdr.cpp:3426
+#: src/PrefsUnifiedDlg.cpp:328 src/utils/wxCas/src/wxcasprefs.cpp:39
+msgid "Preferences"
+msgstr "Preferințe"
+
+#: src/amuleDlg.cpp:371
+msgid "Navigate"
+msgstr ""
+
+#: src/amuleDlg.cpp:657
 #, fuzzy
 msgid "New version available"
 msgstr "Indisponibil"
 
-#: src/amuleDlg.cpp:596
+#: src/amuleDlg.cpp:661
 #, fuzzy, c-format
 msgid ""
 "A new version of aMule (%s) is available.\n"
@@ -606,218 +644,185 @@ msgid ""
 "Would you like to open the download page?"
 msgstr "Ultima versiune poate fi găsită mereu la https://github.com/amule-org/amule/releases/latest"
 
-#: src/amuleDlg.cpp:678
+#: src/amuleDlg.cpp:743
 msgid "aMule dialog destroyed"
 msgstr "dialogul aMule distrus"
 
-#: src/amuleDlg.cpp:701 src/DataToText.cpp:68 src/IPFilter.cpp:547
+#: src/amuleDlg.cpp:766 src/DataToText.cpp:68 src/IPFilter.cpp:547
 msgid "Connecting"
 msgstr "Se conecteză"
 
-#: src/amuleDlg.cpp:893
+#: src/amuleDlg.cpp:958
 msgid "eD2k: Connecting"
 msgstr "eD2k: Se conectează"
 
-#: src/amuleDlg.cpp:897
+#: src/amuleDlg.cpp:962
 msgid "eD2k: Disconnected"
 msgstr "eD2k: Deconectat"
 
-#: src/amuleDlg.cpp:903
+#: src/amuleDlg.cpp:968
 msgid "Kad: Firewalled"
 msgstr "Kad: Prin firewall"
 
-#: src/amuleDlg.cpp:907
+#: src/amuleDlg.cpp:972
 msgid "Kad: Connected"
 msgstr "Kad: Conectat"
 
-#: src/amuleDlg.cpp:912
+#: src/amuleDlg.cpp:977
 msgid "Kad: Connecting"
 msgstr "Kad: Se conectează"
 
-#: src/amuleDlg.cpp:916
+#: src/amuleDlg.cpp:981
 msgid "Kad: Off"
 msgstr "Kad: Închis"
 
-#: src/amuleDlg.cpp:964 src/DownloadListCtrl.cpp:505
+#: src/amuleDlg.cpp:1029 src/DownloadListCtrl.cpp:505
 #: src/DownloadListCtrl.cpp:749 src/FriendListCtrl.cpp:180
 #: src/muuli_wdr.cpp:731 src/muuli_wdr.cpp:782 src/muuli_wdr.cpp:846
-#: src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2224 src/muuli_wdr.cpp:2309
-#: src/muuli_wdr.cpp:3057 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
+#: src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2231 src/muuli_wdr.cpp:2316
+#: src/muuli_wdr.cpp:3064 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
 #: src/ServerListCtrl.cpp:606 src/TransferWnd.cpp:378
 #: src/utils/wxCas/src/wxcasprefs.cpp:235
 msgid "Cancel"
 msgstr "Anulare"
 
-#: src/amuleDlg.cpp:965
+#: src/amuleDlg.cpp:1030
 msgid "Stop the current connection attempts"
 msgstr "Oprește încercările curente de conectare"
 
-#: src/amuleDlg.cpp:970 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976
-#: src/muuli_wdr.cpp:2447
+#: src/amuleDlg.cpp:1035 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976
+#: src/muuli_wdr.cpp:2454
 msgid "Disconnect"
 msgstr "Deconectează"
 
-#: src/amuleDlg.cpp:971
+#: src/amuleDlg.cpp:1036
 msgid "Disconnect from the currently connected networks"
 msgstr "Deconectează de la rețelele curent conectate"
 
-#: src/amuleDlg.cpp:976 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979
-#: src/muuli_wdr.cpp:2602 src/muuli_wdr.cpp:3054 src/muuli_wdr.cpp:3409
+#: src/amuleDlg.cpp:1041 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979
+#: src/muuli_wdr.cpp:2609 src/muuli_wdr.cpp:3061 src/muuli_wdr.cpp:3416
 msgid "Connect"
 msgstr "Conectează"
 
-#: src/amuleDlg.cpp:977
+#: src/amuleDlg.cpp:1042
 msgid "Connect to the currently enabled networks"
 msgstr "Conectează la rețelele activate curent"
 
-#: src/amuleDlg.cpp:1089
+#: src/amuleDlg.cpp:1154
 #, fuzzy, c-format
 msgid "Up: %.1f%s (%.1f) | Down: %.1f%s (%.1f)"
 msgstr "În: %.1f(%.1f) | Desc: %.1f(%.1f)"
 
-#: src/amuleDlg.cpp:1091 src/amuleDlg.cpp:1093 src/amuleDlg.cpp:1097
-#: src/amuleDlg.cpp:1099 src/amuleDlg.cpp:1110 src/amuleDlg.cpp:1112
+#: src/amuleDlg.cpp:1156 src/amuleDlg.cpp:1158 src/amuleDlg.cpp:1162
+#: src/amuleDlg.cpp:1164 src/amuleDlg.cpp:1175 src/amuleDlg.cpp:1177
 #: src/MuleTrayIcon.cpp:796 src/MuleTrayIcon.cpp:799
 #, fuzzy
 msgid " MB/s"
 msgstr "MO/s"
 
-#: src/amuleDlg.cpp:1091 src/amuleDlg.cpp:1093 src/amuleDlg.cpp:1097
-#: src/amuleDlg.cpp:1099 src/amuleDlg.cpp:1110 src/amuleDlg.cpp:1112
+#: src/amuleDlg.cpp:1156 src/amuleDlg.cpp:1158 src/amuleDlg.cpp:1162
+#: src/amuleDlg.cpp:1164 src/amuleDlg.cpp:1175 src/amuleDlg.cpp:1177
 #: src/MuleTrayIcon.cpp:796 src/MuleTrayIcon.cpp:799
 #: src/utils/wxCas/src/wxcasframe.cpp:1041
 msgid " kB/s"
 msgstr " kB/s"
 
-#: src/amuleDlg.cpp:1096
+#: src/amuleDlg.cpp:1161
 #, fuzzy, c-format
 msgid "Up: %.1f%s | Down: %.1f%s"
 msgstr "În: %.1f | Desc: %.1f"
 
-#: src/amuleDlg.cpp:1128
+#: src/amuleDlg.cpp:1193
 #, c-format
 msgid "aMule (%s | Connected)"
 msgstr "aMule (%s | Conectat)"
 
-#: src/amuleDlg.cpp:1130
+#: src/amuleDlg.cpp:1195
 #, c-format
 msgid "aMule (%s | Disconnected)"
 msgstr "aMule (%s | Deconectat)"
 
-#: src/amuleDlg.cpp:1183
+#: src/amuleDlg.cpp:1248
 #, c-format
 msgid "Do you really want to exit %s?"
 msgstr "Sigur doriți să închideți %s?"
 
-#: src/amuleDlg.cpp:1185
+#: src/amuleDlg.cpp:1250
 msgid "Exit confirmation"
 msgstr "Confirmare închidere"
 
-#: src/amuleDlg.cpp:1548
+#: src/amuleDlg.cpp:1613
 msgid "Launch Command: "
 msgstr "Lansare comandă:"
 
-#: src/amuleDlg.cpp:1567 src/muuli_wdr.cpp:1971 src/Preferences.cpp:951
+#: src/amuleDlg.cpp:1632 src/muuli_wdr.cpp:1978 src/Preferences.cpp:952
 msgid "- default -"
 msgstr "- implicit -"
 
-#: src/amuleDlg.cpp:1595
+#: src/amuleDlg.cpp:1660
 #, c-format
 msgid "Skin directory '%s' does not exist"
 msgstr "Directorul aspectului aplicației '%s' nu există"
 
-#: src/amuleDlg.cpp:1598
+#: src/amuleDlg.cpp:1663
 #, c-format
 msgid "WARNING: Unable to open skin file '%s' for read"
 msgstr "ATENȚIE: Nu se poate deschide fișierul aspect '%s' pentru citit"
 
-#: src/amuleDlg.cpp:1722 src/amuleDlg.cpp:1968 src/muuli_wdr.cpp:1485
-#: src/muuli_wdr.cpp:3411
-msgid "Networks"
-msgstr "Rețele"
-
-#: src/amuleDlg.cpp:1726 src/muuli_wdr.cpp:3411
+#: src/amuleDlg.cpp:1791 src/muuli_wdr.cpp:3418
 msgid "Networks Window"
 msgstr "Fereastra rețelelor"
 
-#: src/amuleDlg.cpp:1728 src/muuli_wdr.cpp:3412
-msgid "Searches"
-msgstr "Căutări"
-
-#: src/amuleDlg.cpp:1732 src/muuli_wdr.cpp:3412
+#: src/amuleDlg.cpp:1797 src/muuli_wdr.cpp:3419
 msgid "Searches Window"
 msgstr "Fereastra căutărilor"
 
-#: src/amuleDlg.cpp:1734 src/DownloadListCtrl.cpp:740 src/muuli_wdr.cpp:392
-#: src/muuli_wdr.cpp:1578 src/muuli_wdr.cpp:3413 src/Statistics.cpp:829
-msgid "Downloads"
-msgstr "Descărcări"
-
-#: src/amuleDlg.cpp:1738 src/muuli_wdr.cpp:3413
+#: src/amuleDlg.cpp:1803 src/muuli_wdr.cpp:3420
 msgid "Downloads Window"
 msgstr "Fereastra descărcărilor"
 
-#: src/amuleDlg.cpp:1740 src/muuli_wdr.cpp:3287
-msgid "Shared files"
-msgstr "Fișiere partajate"
-
-#: src/amuleDlg.cpp:1744 src/muuli_wdr.cpp:3415
+#: src/amuleDlg.cpp:1809 src/muuli_wdr.cpp:3422
 msgid "Shared Files Window"
 msgstr "Fereastra fișierelor partajate"
 
-#: src/amuleDlg.cpp:1746 src/muuli_wdr.cpp:2919 src/muuli_wdr.cpp:3369
-#: src/muuli_wdr.cpp:3416
-msgid "Messages"
-msgstr "Mesaje"
-
-#: src/amuleDlg.cpp:1750 src/muuli_wdr.cpp:3416
+#: src/amuleDlg.cpp:1815 src/muuli_wdr.cpp:3423
 msgid "Messages Window"
 msgstr "Fereastra mesajelor"
 
-#: src/amuleDlg.cpp:1752 src/muuli_wdr.cpp:3417 src/PrefsUnifiedDlg.cpp:312
-#: src/Statistics.cpp:779 src/Statistics.cpp:1235
-msgid "Statistics"
-msgstr "Statistici"
-
-#: src/amuleDlg.cpp:1756 src/muuli_wdr.cpp:3417
+#: src/amuleDlg.cpp:1821 src/muuli_wdr.cpp:3424
 msgid "Statistics Graph Window"
 msgstr "Fereastra graficului statisticilor"
 
-#: src/amuleDlg.cpp:1759 src/muuli_wdr.cpp:3419 src/PrefsUnifiedDlg.cpp:328
-#: src/utils/wxCas/src/wxcasprefs.cpp:39
-msgid "Preferences"
-msgstr "Preferințe"
-
-#: src/amuleDlg.cpp:1763 src/muuli_wdr.cpp:3419
+#: src/amuleDlg.cpp:1828 src/muuli_wdr.cpp:3426
 msgid "Preferences Settings Window"
 msgstr "Fereastra configurare preferințe"
 
-#: src/amuleDlg.cpp:1766 src/muuli_wdr.cpp:3420
+#: src/amuleDlg.cpp:1831 src/muuli_wdr.cpp:3427
 msgid "Import"
 msgstr "Importă"
 
-#: src/amuleDlg.cpp:1770 src/muuli_wdr.cpp:3420
+#: src/amuleDlg.cpp:1835 src/muuli_wdr.cpp:3427
 msgid "The partfile importer tool"
 msgstr "Unealta de importat fișiere parțiale"
 
-#: src/amuleDlg.cpp:1773 src/muuli_wdr.cpp:3421
+#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3428
 #: src/utils/aLinkCreator/src/alcframe.cpp:262
 msgid "About"
 msgstr "Despre"
 
-#: src/amuleDlg.cpp:1773 src/muuli_wdr.cpp:3421
+#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3428
 msgid "About/Help"
 msgstr "Despre/Ajutor"
 
-#: src/amuleDlg.cpp:1971
+#: src/amuleDlg.cpp:2036
 msgid "eD2k network"
 msgstr "Rețea eD2k"
 
-#: src/amuleDlg.cpp:1974
+#: src/amuleDlg.cpp:2039
 msgid "Kad network"
 msgstr "Rețea Kad"
 
-#: src/amuleDlg.cpp:1974
+#: src/amuleDlg.cpp:2039
 msgid "No network"
 msgstr "Nicio rețea"
 
@@ -1355,19 +1360,19 @@ msgstr "Automat [În]"
 msgid "Very low"
 msgstr "Foarte joasă"
 
-#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:743 src/muuli_wdr.cpp:2275
+#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:743 src/muuli_wdr.cpp:2282
 #: src/ServerListCtrl.cpp:263 src/ServerListCtrl.cpp:456
 #: src/SharedFilesCtrl.cpp:145
 msgid "Low"
 msgstr "Joasă"
 
-#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:744 src/muuli_wdr.cpp:2276
+#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:744 src/muuli_wdr.cpp:2283
 #: src/ServerListCtrl.cpp:266 src/ServerListCtrl.cpp:457
 #: src/SharedFilesCtrl.cpp:146
 msgid "Normal"
 msgstr "Normal"
 
-#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:745 src/muuli_wdr.cpp:2277
+#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:745 src/muuli_wdr.cpp:2284
 #: src/ServerListCtrl.cpp:269 src/ServerListCtrl.cpp:458
 #: src/SharedFilesCtrl.cpp:147
 msgid "High"
@@ -1459,8 +1464,8 @@ msgstr "Server local"
 msgid "Remote Server"
 msgstr "Server distant"
 
-#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3174
-#: src/SearchDlg.cpp:111 src/TextClient.cpp:911
+#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3181
+#: src/SearchDlg.cpp:119 src/TextClient.cpp:911
 msgid "Kad"
 msgstr "Kad"
 
@@ -1531,7 +1536,7 @@ msgstr "Parte"
 msgid "Size"
 msgstr "Dimensiune"
 
-#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3241
+#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3248
 msgid "Transferred"
 msgstr "Transferat"
 
@@ -1589,7 +1594,7 @@ msgstr ""
 "Feedback de la: %s (%s)\n"
 "\n"
 
-#: src/DownloadListCtrl.cpp:746 src/muuli_wdr.cpp:2278
+#: src/DownloadListCtrl.cpp:746 src/muuli_wdr.cpp:2285
 #: src/SharedFilesCtrl.cpp:150
 msgid "Auto"
 msgstr "Automat"
@@ -1627,7 +1632,7 @@ msgid "Extended Options"
 msgstr "Opțiuni extinse"
 
 #: src/DownloadListCtrl.cpp:770 src/DownloadListCtrl.cpp:822
-#: src/muuli_wdr.cpp:1789
+#: src/muuli_wdr.cpp:1796
 msgid "Preview"
 msgstr "Previzualizează"
 
@@ -2338,19 +2343,19 @@ msgstr ""
 msgid "eD2k"
 msgstr "eD2k"
 
-#: src/FirstRunWizard.cpp:349 src/muuli_wdr.cpp:1488
+#: src/FirstRunWizard.cpp:349 src/muuli_wdr.cpp:1495
 msgid "Kademlia"
 msgstr "Kademlia"
 
-#: src/FirstRunWizard.cpp:359 src/muuli_wdr.cpp:1416
+#: src/FirstRunWizard.cpp:359 src/muuli_wdr.cpp:1423
 msgid "Standard TCP Port "
 msgstr "Port TCP standard"
 
-#: src/FirstRunWizard.cpp:365 src/muuli_wdr.cpp:1428
+#: src/FirstRunWizard.cpp:365 src/muuli_wdr.cpp:1435
 msgid "Extended UDP port (Kad / global search) "
 msgstr "Port UDP extins (Kad / căutare globală)"
 
-#: src/FirstRunWizard.cpp:377 src/muuli_wdr.cpp:1435
+#: src/FirstRunWizard.cpp:377 src/muuli_wdr.cpp:1442
 msgid "Enable UPnP for router port forwarding"
 msgstr "Activează UPnP pentru înaintare port ruter"
 
@@ -2377,7 +2382,7 @@ msgstr ""
 msgid "Your peer lists are already in place - nothing to download."
 msgstr "Deja încercați să descărcați fișierul %s"
 
-#: src/FirstRunWizard.cpp:434 src/muuli_wdr.cpp:1533
+#: src/FirstRunWizard.cpp:434 src/muuli_wdr.cpp:1540
 msgid "Auto-update server list at startup"
 msgstr "Actualizează automat lista serverelor la pornire"
 
@@ -2423,23 +2428,23 @@ msgid ""
 "want downloads on a different (e.g. larger) disk."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:549 src/FirstRunWizard.cpp:611 src/muuli_wdr.cpp:1701
+#: src/FirstRunWizard.cpp:549 src/FirstRunWizard.cpp:611 src/muuli_wdr.cpp:1708
 msgid "Destination folder for downloads"
 msgstr "Dosar destinație pentru descărcări"
 
-#: src/FirstRunWizard.cpp:553 src/FirstRunWizard.cpp:569 src/muuli_wdr.cpp:1342
-#: src/muuli_wdr.cpp:1359 src/muuli_wdr.cpp:1676 src/muuli_wdr.cpp:1707
-#: src/muuli_wdr.cpp:1719 src/muuli_wdr.cpp:2762
+#: src/FirstRunWizard.cpp:553 src/FirstRunWizard.cpp:569 src/muuli_wdr.cpp:1349
+#: src/muuli_wdr.cpp:1366 src/muuli_wdr.cpp:1683 src/muuli_wdr.cpp:1714
+#: src/muuli_wdr.cpp:1726 src/muuli_wdr.cpp:2769
 #: src/utils/aLinkCreator/src/alcframe.cpp:135
 #: src/utils/wxCas/src/wxcasprefs.cpp:52 src/utils/wxCas/src/wxcasprefs.cpp:118
 msgid "Browse"
 msgstr "Navigare"
 
-#: src/FirstRunWizard.cpp:559 src/muuli_wdr.cpp:1712
+#: src/FirstRunWizard.cpp:559 src/muuli_wdr.cpp:1719
 msgid "(All files in this folder are shared with other peers)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:565 src/FirstRunWizard.cpp:624 src/muuli_wdr.cpp:1714
+#: src/FirstRunWizard.cpp:565 src/FirstRunWizard.cpp:624 src/muuli_wdr.cpp:1721
 msgid "Folder for temporary download files"
 msgstr "Dosar pentru fișiere descărcate temporar"
 
@@ -2470,7 +2475,7 @@ msgstr "A eșuat deschiderea fișierului listă prieteni 'emfriends.met' pentru 
 msgid "CRITICAL - no client on StartChatSession"
 msgstr "CRITIC - niciun client în StartChatSession"
 
-#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2668 src/muuli_wdr.cpp:3345
+#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2675 src/muuli_wdr.cpp:3352
 msgid "Friends"
 msgstr "Prieteni"
 
@@ -2861,7 +2866,7 @@ msgstr "Rată de partajare"
 msgid "Uploaded"
 msgstr "Încărcat"
 
-#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3225
+#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3232
 msgid "Requested"
 msgstr "Cerut"
 
@@ -2985,7 +2990,7 @@ msgid "WARNING: "
 msgstr "ATENȚIE:"
 
 #: src/MuleNotebook.cpp:179 src/muuli_wdr.cpp:817 src/muuli_wdr.cpp:1229
-#: src/muuli_wdr.cpp:3129 src/muuli_wdr.cpp:3385
+#: src/muuli_wdr.cpp:3136 src/muuli_wdr.cpp:3392
 msgid "Close"
 msgstr "Închide"
 
@@ -2998,12 +3003,12 @@ msgstr "Taie"
 msgid "Copy"
 msgstr "Copiază"
 
-#: src/MuleTextCtrl.cpp:88
+#: src/MuleTextCtrl.cpp:88 src/SearchDlg.cpp:261
 msgid "Paste"
 msgstr "Lipește"
 
 #: src/MuleTextCtrl.cpp:89 src/muuli_wdr.cpp:358 src/muuli_wdr.cpp:757
-#: src/muuli_wdr.cpp:2352 src/muuli_wdr.cpp:2371 src/muuli_wdr.cpp:2393
+#: src/muuli_wdr.cpp:2359 src/muuli_wdr.cpp:2378 src/muuli_wdr.cpp:2400
 #: src/utils/aLinkCreator/src/alcframe.cpp:142
 msgid "Clear"
 msgstr "Curăță"
@@ -3101,8 +3106,8 @@ msgid "Exit"
 msgstr "Ieşire"
 
 #: src/MuleTrayIcon.cpp:579 src/MuleTrayIcon.cpp:945 src/MuleTrayIcon.cpp:965
-#: src/muuli_wdr.cpp:1391 src/muuli_wdr.cpp:1399 src/muuli_wdr.cpp:1406
-#: src/muuli_wdr.cpp:1835 src/muuli_wdr.cpp:1841 src/OtherFunctions.cpp:91
+#: src/muuli_wdr.cpp:1398 src/muuli_wdr.cpp:1406 src/muuli_wdr.cpp:1413
+#: src/muuli_wdr.cpp:1842 src/muuli_wdr.cpp:1848 src/OtherFunctions.cpp:91
 #: src/StatisticsDlg.cpp:93 src/StatisticsDlg.cpp:95
 msgid "kB/s"
 msgstr "kB/s"
@@ -3273,7 +3278,7 @@ msgstr "Name:"
 msgid "Type"
 msgstr "Tip"
 
-#: src/muuli_wdr.cpp:215 src/SearchDlg.cpp:110 src/SearchListCtrl.cpp:853
+#: src/muuli_wdr.cpp:215 src/SearchDlg.cpp:118 src/SearchListCtrl.cpp:853
 msgid "Local"
 msgstr "Local"
 
@@ -3344,7 +3349,7 @@ msgstr "Baiți"
 msgid "KB"
 msgstr "KB"
 
-#: src/muuli_wdr.cpp:274 src/muuli_wdr.cpp:293 src/muuli_wdr.cpp:1620
+#: src/muuli_wdr.cpp:274 src/muuli_wdr.cpp:293 src/muuli_wdr.cpp:1627
 #: src/OtherFunctions.cpp:64
 msgid "MB"
 msgstr "MO"
@@ -3361,7 +3366,7 @@ msgstr "Dimensiune maximă"
 msgid "Availability"
 msgstr "Disponibilitate"
 
-#: src/muuli_wdr.cpp:312 src/muuli_wdr.cpp:398 src/muuli_wdr.cpp:3290
+#: src/muuli_wdr.cpp:312 src/muuli_wdr.cpp:398 src/muuli_wdr.cpp:3297
 msgid "Filter:"
 msgstr "Filtru:"
 
@@ -3393,7 +3398,7 @@ msgstr ""
 msgid "Stop"
 msgstr "Oprește"
 
-#: src/muuli_wdr.cpp:348 src/muuli_wdr.cpp:1385 src/SearchListCtrl.cpp:732
+#: src/muuli_wdr.cpp:348 src/muuli_wdr.cpp:1392 src/SearchListCtrl.cpp:732
 msgid "Download"
 msgstr "Descarcă"
 
@@ -3424,8 +3429,8 @@ msgstr "Surse fișier:"
 #: src/muuli_wdr.cpp:1160 src/muuli_wdr.cpp:1167 src/muuli_wdr.cpp:1172
 #: src/muuli_wdr.cpp:1179 src/muuli_wdr.cpp:1184 src/muuli_wdr.cpp:1191
 #: src/muuli_wdr.cpp:1205 src/muuli_wdr.cpp:1212 src/muuli_wdr.cpp:1217
-#: src/muuli_wdr.cpp:1224 src/muuli_wdr.cpp:3227 src/muuli_wdr.cpp:3235
-#: src/muuli_wdr.cpp:3243
+#: src/muuli_wdr.cpp:1224 src/muuli_wdr.cpp:3234 src/muuli_wdr.cpp:3242
+#: src/muuli_wdr.cpp:3250
 msgid "N/A"
 msgstr "NU SE APLICĂ"
 
@@ -3570,7 +3575,7 @@ msgstr ""
 msgid "Album :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:685 src/muuli_wdr.cpp:2247
+#: src/muuli_wdr.cpp:685 src/muuli_wdr.cpp:2254
 msgid "Title :"
 msgstr "Titlu :"
 
@@ -3679,7 +3684,7 @@ msgstr "Nume utilizator:"
 msgid "Userhash :"
 msgstr "Index utilizator :"
 
-#: src/muuli_wdr.cpp:895 src/muuli_wdr.cpp:1741 src/muuli_wdr.cpp:2442
+#: src/muuli_wdr.cpp:895 src/muuli_wdr.cpp:1748 src/muuli_wdr.cpp:2449
 #: src/utils/aLinkCreator/src/alcframe.cpp:137
 msgid "Add"
 msgstr "Adaugă"
@@ -3688,15 +3693,15 @@ msgstr "Adaugă"
 msgid "Download-Speed"
 msgstr "Viteză-descărcare"
 
-#: src/muuli_wdr.cpp:954 src/muuli_wdr.cpp:989 src/muuli_wdr.cpp:2546
+#: src/muuli_wdr.cpp:954 src/muuli_wdr.cpp:989 src/muuli_wdr.cpp:2553
 msgid "Current"
 msgstr "Curentul"
 
-#: src/muuli_wdr.cpp:962 src/muuli_wdr.cpp:997 src/muuli_wdr.cpp:2554
+#: src/muuli_wdr.cpp:962 src/muuli_wdr.cpp:997 src/muuli_wdr.cpp:2561
 msgid "Running average"
 msgstr "Medie rulare"
 
-#: src/muuli_wdr.cpp:970 src/muuli_wdr.cpp:1005 src/muuli_wdr.cpp:2562
+#: src/muuli_wdr.cpp:970 src/muuli_wdr.cpp:1005 src/muuli_wdr.cpp:2569
 msgid "Session average"
 msgstr "Medie sesiune"
 
@@ -3708,7 +3713,7 @@ msgstr "Viteză-încărcare"
 msgid "Connections"
 msgstr "Conexiuni"
 
-#: src/muuli_wdr.cpp:1024 src/muuli_wdr.cpp:1860
+#: src/muuli_wdr.cpp:1024 src/muuli_wdr.cpp:1867
 msgid "Active downloads"
 msgstr "Descărcări active"
 
@@ -3716,7 +3721,7 @@ msgstr "Descărcări active"
 msgid "Active connections (1:1)"
 msgstr "Conexiuni active (1:1)"
 
-#: src/muuli_wdr.cpp:1040 src/muuli_wdr.cpp:1861
+#: src/muuli_wdr.cpp:1040 src/muuli_wdr.cpp:1868
 msgid "Active uploads"
 msgstr "Încărcări active"
 
@@ -3832,8 +3837,8 @@ msgstr "Acesta este numele pe care ceilalți utilizatori îl va vedea când se v
 msgid "Language: "
 msgstr "Limbă:"
 
-#: src/muuli_wdr.cpp:1257 src/muuli_wdr.cpp:1323 src/muuli_wdr.cpp:1327
-#: src/muuli_wdr.cpp:1330
+#: src/muuli_wdr.cpp:1257 src/muuli_wdr.cpp:1330 src/muuli_wdr.cpp:1334
+#: src/muuli_wdr.cpp:1337
 msgid "The delay before showing tool-tips."
 msgstr "Întârzierea afișării sfaturilor."
 
@@ -3911,936 +3916,945 @@ msgstr ""
 msgid "Enabling this will make aMule to show notifications when finished downloading."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1322
+#: src/muuli_wdr.cpp:1323
+#, fuzzy
+msgid "Remember search history"
+msgstr "Amintește aceste configurări"
+
+#: src/muuli_wdr.cpp:1324
+msgid "Keeps a dropdown list of your past search terms in the Search tab's Name field. This remembers the queries you typed, not the results they returned."
+msgstr ""
+
+#: src/muuli_wdr.cpp:1329
 msgid "Tooltip delay time: "
 msgstr "Timp de întârziere balon de ajutor:"
 
-#: src/muuli_wdr.cpp:1329
+#: src/muuli_wdr.cpp:1336
 msgid "seconds"
 msgstr "secunde"
 
-#: src/muuli_wdr.cpp:1333
+#: src/muuli_wdr.cpp:1340
 msgid "Browser Selection"
 msgstr "Selecție navigator"
 
-#: src/muuli_wdr.cpp:1339
+#: src/muuli_wdr.cpp:1346
 msgid "Enter your browser name here. Leave this field empty to use the system default browser."
 msgstr "Introduceți aici numele navigatorului. Lăsați acest câmp necompletat pentru utilizarea navigatorului implicit de sistem."
 
-#: src/muuli_wdr.cpp:1346
+#: src/muuli_wdr.cpp:1353
 msgid "Open in new tab if possible"
 msgstr "Deschide într-o fereastră nouă dacă este posibil"
 
-#: src/muuli_wdr.cpp:1348
+#: src/muuli_wdr.cpp:1355
 msgid "Open the web page in a new tab instead of in a new window when possible"
 msgstr "Deschide pagina web într-o pagină nouă în schimbul unei ferestre noi când este posibil"
 
-#: src/muuli_wdr.cpp:1352
+#: src/muuli_wdr.cpp:1359
 msgid "Video Player"
 msgstr "Player video"
 
-#: src/muuli_wdr.cpp:1379
+#: src/muuli_wdr.cpp:1386
 msgid "Bandwidth limits"
 msgstr "Limite lățime de bandă"
 
-#: src/muuli_wdr.cpp:1393
+#: src/muuli_wdr.cpp:1400
 msgid "Upload"
 msgstr "Încărcare"
 
-#: src/muuli_wdr.cpp:1401
+#: src/muuli_wdr.cpp:1408
 msgid "Slot Allocation"
 msgstr "Alocare slot"
 
-#: src/muuli_wdr.cpp:1410
+#: src/muuli_wdr.cpp:1417
 msgid "Ports"
 msgstr "Porturi"
 
-#: src/muuli_wdr.cpp:1420
+#: src/muuli_wdr.cpp:1427
 msgid "This is the standard eD2k port and cannot be disabled."
 msgstr "Acesta este portul standard eD2k și nu poate fi dezactivat."
 
-#: src/muuli_wdr.cpp:1423
+#: src/muuli_wdr.cpp:1430
 msgid "UDP port for server requests (TCP+3):"
 msgstr "Port UDP pentru cererile serverului (TCP+3)"
 
-#: src/muuli_wdr.cpp:1425
+#: src/muuli_wdr.cpp:1432
 msgid "4665"
 msgstr "4665"
 
-#: src/muuli_wdr.cpp:1432
+#: src/muuli_wdr.cpp:1439
 msgid "This UDP port is used for extended eD2k requests and Kad network"
 msgstr "Acest port UDP este utilizat pentru solicitări extinse eD2k și rețeaua Kad"
 
-#: src/muuli_wdr.cpp:1439
+#: src/muuli_wdr.cpp:1446
 msgid "UPnP TCP Port (Optional):"
 msgstr "Port UPnP TCP (facultativ):"
 
-#: src/muuli_wdr.cpp:1449
+#: src/muuli_wdr.cpp:1456
 msgid "Bind local address to IP (empty for any):"
 msgstr "Leagă adresa locală la IP (gol pentru oricare):"
 
-#: src/muuli_wdr.cpp:1452
+#: src/muuli_wdr.cpp:1459
 msgid "Advanced users only: If you have multiple network interfaces, enter the address of the interface to which aMule should be bound."
 msgstr "Numai pentru utilizatorii avansați: Dacă aveți mai multe interfețe de rețea, introduceți adresa interfeței la care aMule ar trebui să fie legat."
 
-#: src/muuli_wdr.cpp:1455 src/muuli_wdr.cpp:2054
+#: src/muuli_wdr.cpp:1462 src/muuli_wdr.cpp:2061
 #, fuzzy
 msgid "Bind to network interface (empty for any):"
 msgstr "Leagă adresa locală la IP (gol pentru oricare):"
 
-#: src/muuli_wdr.cpp:1468
+#: src/muuli_wdr.cpp:1475
 msgid "Advanced users only: pin all of aMule's traffic to one network interface, chosen from the list or typed in by name (e.g. tun0, eth0, en0) or index. Unlike binding to an IP, this stops traffic leaking out via the default route - useful with a VPN. Requires no elevated privileges."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1474
+#: src/muuli_wdr.cpp:1481
 msgid "Max sources per downloading file:"
 msgstr "Număr maxim de surse pe fișier descărcat:"
 
-#: src/muuli_wdr.cpp:1478
+#: src/muuli_wdr.cpp:1485
 msgid "Max simultaneous connections:"
 msgstr "Număr maxim de conexiuni simultane:"
 
-#: src/muuli_wdr.cpp:1491 src/muuli_wdr.cpp:3169
+#: src/muuli_wdr.cpp:1498 src/muuli_wdr.cpp:3176
 msgid "ED2K"
 msgstr "ED2K"
 
-#: src/muuli_wdr.cpp:1498
+#: src/muuli_wdr.cpp:1505
 msgid "Autoconnect on startup"
 msgstr "Conectare automată la pornire"
 
-#: src/muuli_wdr.cpp:1501
+#: src/muuli_wdr.cpp:1508
 msgid "Reconnect on loss"
 msgstr "Reconectare la pierdere"
 
-#: src/muuli_wdr.cpp:1523
+#: src/muuli_wdr.cpp:1530
 msgid "Remove dead server after"
 msgstr "Elimină serverele moarte după"
 
-#: src/muuli_wdr.cpp:1524
+#: src/muuli_wdr.cpp:1531
 msgid "Static servers are never removed, even when unreachable."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1528
+#: src/muuli_wdr.cpp:1535
 msgid "retries"
 msgstr "încercări"
 
-#: src/muuli_wdr.cpp:1536
+#: src/muuli_wdr.cpp:1543
 msgid "List"
 msgstr "Listă"
 
-#: src/muuli_wdr.cpp:1539
+#: src/muuli_wdr.cpp:1546
 msgid "Update server list when connecting to a server"
 msgstr "Actualizează lista serverelor la conectarea la un server"
 
-#: src/muuli_wdr.cpp:1542
+#: src/muuli_wdr.cpp:1549
 msgid "Update server list when a client connects"
 msgstr "Actualizează lista serverelor când se conectează un client"
 
-#: src/muuli_wdr.cpp:1545
+#: src/muuli_wdr.cpp:1552
 msgid "Use priority system"
 msgstr "Utilizează prioritatea sistemului"
 
-#: src/muuli_wdr.cpp:1549
+#: src/muuli_wdr.cpp:1556
 msgid "Use smart LowID check on connect"
 msgstr "Utilizează verificarea inteligentă LowID la conectare"
 
-#: src/muuli_wdr.cpp:1553
+#: src/muuli_wdr.cpp:1560
 msgid "Safe connect"
 msgstr "Conectare sigură"
 
-#: src/muuli_wdr.cpp:1557
+#: src/muuli_wdr.cpp:1564
 msgid "Autoconnect to servers in static list only"
 msgstr "Conectează automat numai la serverele din lista statică"
 
-#: src/muuli_wdr.cpp:1560
+#: src/muuli_wdr.cpp:1567
 msgid "Set manually added servers to High Priority"
 msgstr "Configurează serverele adăugate manual la prioritate înaltă"
 
-#: src/muuli_wdr.cpp:1581
+#: src/muuli_wdr.cpp:1588
 msgid "Add files to download in pause mode"
 msgstr "Adaugă fișiere la descărcare în modul pauză"
 
-#: src/muuli_wdr.cpp:1583
+#: src/muuli_wdr.cpp:1590
 msgid "Add files to download with auto priority"
 msgstr "Adaugă fișiere la descărcare cu prioritate automată"
 
-#: src/muuli_wdr.cpp:1586
+#: src/muuli_wdr.cpp:1593
 msgid "Try to download first and last chunks first"
 msgstr "Încearcă să descarci întâi prima și ultima bucată"
 
-#: src/muuli_wdr.cpp:1590
+#: src/muuli_wdr.cpp:1597
 msgid "Endgame mode: rotate to faster sources for the final blocks"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1593
+#: src/muuli_wdr.cpp:1600
 msgid "Start next paused file when a file completes"
 msgstr "Pornește următorul fișier pauzat când un fișier s-a terminat"
 
-#: src/muuli_wdr.cpp:1596
+#: src/muuli_wdr.cpp:1603
 msgid "From the same category"
 msgstr "Din aceeași categorie"
 
-#: src/muuli_wdr.cpp:1598
+#: src/muuli_wdr.cpp:1605
 msgid "In alphabetic order"
 msgstr "În ordine alfabetică"
 
-#: src/muuli_wdr.cpp:1600
+#: src/muuli_wdr.cpp:1607
 msgid "Preallocate disk space for new files"
 msgstr "Prealocare spațiu pe disc pentru noile fișiere"
 
-#: src/muuli_wdr.cpp:1601
+#: src/muuli_wdr.cpp:1608
 msgid "For new files preallocates disk space for the whole file, thus reduces fragmentation"
 msgstr "Pentru noile fișiere se prealocă spațiu pe disc pentru întreg fișierul, astfel se reduce fragmentarea"
 
-#: src/muuli_wdr.cpp:1606
+#: src/muuli_wdr.cpp:1613
 msgid "Create new files as sparse files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1607
+#: src/muuli_wdr.cpp:1614
 msgid "A sparse file reserves its full size on disk immediately without writing real data to it -- fast, but unsupported or slow on some filesystems, and free-space accounting stays optimistic while the download is in progress. Turn this off to grow the file only as data arrives."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1612
+#: src/muuli_wdr.cpp:1619
 msgid "Stop downloads when free disk space reaches "
 msgstr "Oprește descărcarea când s-a atins limita spațiului disponibil"
 
-#: src/muuli_wdr.cpp:1613
+#: src/muuli_wdr.cpp:1620
 msgid "Select this if you want aMule to check your disk space"
 msgstr "Selectați asta dacă doriți ca aMule să verifice spațiul liber pe disk"
 
-#: src/muuli_wdr.cpp:1617
+#: src/muuli_wdr.cpp:1624
 msgid "Enter here the min disk space desired."
 msgstr "Introduceți aici minimum de spațiu pe disc dorit."
 
-#: src/muuli_wdr.cpp:1623
+#: src/muuli_wdr.cpp:1630
 msgid "Save 10 sources on rare files (< 20 sources)"
 msgstr "Salvează 10 surse de fișiere rare (< 20 surse)"
 
-#: src/muuli_wdr.cpp:1627 src/Statistics.cpp:790
+#: src/muuli_wdr.cpp:1634 src/Statistics.cpp:790
 msgid "Uploads"
 msgstr "Încărcări"
 
-#: src/muuli_wdr.cpp:1630
+#: src/muuli_wdr.cpp:1637
 msgid "Add new shared files with auto priority"
 msgstr "Adaugă noile fișiere partajate cu prioritate automată"
 
-#: src/muuli_wdr.cpp:1636
+#: src/muuli_wdr.cpp:1643
 msgid "Intelligent Corruption Handling (I.C.H.)"
 msgstr "Gestionare inteligentă a fișierelor corupte (I.C.H.)"
 
-#: src/muuli_wdr.cpp:1639
+#: src/muuli_wdr.cpp:1646
 msgid "Enable"
 msgstr "Activează"
 
-#: src/muuli_wdr.cpp:1642
+#: src/muuli_wdr.cpp:1649
 msgid "Advanced I.C.H. trusts every hash (not recommended)"
 msgstr "I.C.H. avansat acordă încredere fiecărui index (nu este recomandat)"
 
-#: src/muuli_wdr.cpp:1654 src/PrefsUnifiedDlg.cpp:1910
+#: src/muuli_wdr.cpp:1661 src/PrefsUnifiedDlg.cpp:1910
 msgid "Media metadata extraction"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1658
+#: src/muuli_wdr.cpp:1665
 msgid "Extract length / bitrate / codec from shared audio and video files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1660
+#: src/muuli_wdr.cpp:1667
 msgid "When enabled, aMule runs ffprobe on each shared media file to fill in the Length / Bitrate / Codec columns other clients see when they find the file in a search. Requires ffmpeg (the ffprobe binary) to be installed."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1667
+#: src/muuli_wdr.cpp:1674
 msgid "Path to ffprobe:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1672
+#: src/muuli_wdr.cpp:1679
 msgid "Full path to the ffprobe binary. Leave empty to have aMule auto-detect it on startup."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1680
+#: src/muuli_wdr.cpp:1687
 msgid "Detect"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1681
+#: src/muuli_wdr.cpp:1688
 msgid "Search the standard install locations for an ffprobe binary and fill the path field."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1705
+#: src/muuli_wdr.cpp:1712
 msgid ""
 "Completed downloads are stored here. All files in this folder are automatically shared with other peers.\n"
 "If this folder also holds files you don't want to share, point it at an aMule-only sub-folder."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1708
+#: src/muuli_wdr.cpp:1715
 msgid "Pick the folder where completed downloads will be stored. All files in that folder will be shared with other peers."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1722
+#: src/muuli_wdr.cpp:1729
 msgid "Shared folders"
 msgstr "Dosare partajate"
 
-#: src/muuli_wdr.cpp:1728
+#: src/muuli_wdr.cpp:1735
 msgid "(Folders shared by the core. Enter a path to add one.)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1736
+#: src/muuli_wdr.cpp:1743
 msgid "Absolute path of a folder on the core's machine, e.g. /home/user/shared"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1738 src/PrefsUnifiedDlg.cpp:2794
+#: src/muuli_wdr.cpp:1745 src/PrefsUnifiedDlg.cpp:2794
 msgid "Recursive"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1739
+#: src/muuli_wdr.cpp:1746
 msgid "Share every sub-folder underneath this one, including ones created later."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1743 src/utils/aLinkCreator/src/alcframe.cpp:141
+#: src/muuli_wdr.cpp:1750 src/utils/aLinkCreator/src/alcframe.cpp:141
 msgid "Remove"
 msgstr "Elimină"
 
-#: src/muuli_wdr.cpp:1747
+#: src/muuli_wdr.cpp:1754
 msgid "(Right click on folder icon for recursive share)"
 msgstr "(Click dreapta pe miniatura dosarului pentru partajare recursivă)"
 
-#: src/muuli_wdr.cpp:1754
+#: src/muuli_wdr.cpp:1761
 msgid "Share hidden files"
 msgstr "Partajează fișierele ascunse"
 
-#: src/muuli_wdr.cpp:1760
+#: src/muuli_wdr.cpp:1767
 msgid "Automatically rescan shared folders for changes"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1766
+#: src/muuli_wdr.cpp:1773
 msgid "Follow symbolic links in shared folders"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1772
+#: src/muuli_wdr.cpp:1779
 msgid "Exclude files matching:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1775
+#: src/muuli_wdr.cpp:1782
 msgid "Wildcard patterns separated by '|', e.g. .DS_Store|Thumbs.db|*.tmp. Files whose name matches are not shared. Matching is case-insensitive."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1779
+#: src/muuli_wdr.cpp:1786
 msgid "Patterns are regular expressions"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1780
+#: src/muuli_wdr.cpp:1787
 msgid "When set, the whole field is one regular expression ('|' is alternation). When unset, it is a list of '|'-separated wildcards."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1790
+#: src/muuli_wdr.cpp:1797
 msgid "Show how many shared files the current pattern would exclude."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1811
+#: src/muuli_wdr.cpp:1818
 msgid "Graphs"
 msgstr "Grafice"
 
-#: src/muuli_wdr.cpp:1814 src/muuli_wdr.cpp:1876
+#: src/muuli_wdr.cpp:1821 src/muuli_wdr.cpp:1883
 msgid "Update delay : 5 secs"
 msgstr "Întârziere actualizare : 5 secunde"
 
-#: src/muuli_wdr.cpp:1818
+#: src/muuli_wdr.cpp:1825
 msgid "Time for average graph: 100 mins"
 msgstr "Timp pentru media graficului: 100 minute"
 
-#: src/muuli_wdr.cpp:1822
+#: src/muuli_wdr.cpp:1829
 msgid "Connections Graph Scale: 100 "
 msgstr "Scală grafic conexiuni: 100"
 
-#: src/muuli_wdr.cpp:1829
+#: src/muuli_wdr.cpp:1836
 msgid "Download graph scale:"
 msgstr "Scală grafic descărcare:"
 
-#: src/muuli_wdr.cpp:1837
+#: src/muuli_wdr.cpp:1844
 msgid "Upload graph scale:"
 msgstr "Scală grafic încărcare:"
 
-#: src/muuli_wdr.cpp:1847
+#: src/muuli_wdr.cpp:1854
 #, fuzzy
 msgid "Colors: "
 msgstr "Colori:"
 
-#: src/muuli_wdr.cpp:1851
+#: src/muuli_wdr.cpp:1858
 msgid "Background"
 msgstr "Fundal"
 
-#: src/muuli_wdr.cpp:1852
+#: src/muuli_wdr.cpp:1859
 msgid "Grid"
 msgstr "Grilă"
 
-#: src/muuli_wdr.cpp:1853
+#: src/muuli_wdr.cpp:1860
 msgid "Download current"
 msgstr "Descărcare actuală"
 
-#: src/muuli_wdr.cpp:1854
+#: src/muuli_wdr.cpp:1861
 msgid "Download running average"
 msgstr "Medie rulare descărcare"
 
-#: src/muuli_wdr.cpp:1855
+#: src/muuli_wdr.cpp:1862
 msgid "Download session average"
 msgstr "Medie descărcare pe sesiune"
 
-#: src/muuli_wdr.cpp:1856
+#: src/muuli_wdr.cpp:1863
 msgid "Upload current"
 msgstr "Încărcare actuală"
 
-#: src/muuli_wdr.cpp:1857
+#: src/muuli_wdr.cpp:1864
 msgid "Upload running average"
 msgstr "Medie rulare încărcare"
 
-#: src/muuli_wdr.cpp:1858
+#: src/muuli_wdr.cpp:1865
 msgid "Upload session average"
 msgstr "Medie încărcare pe sesiune"
 
-#: src/muuli_wdr.cpp:1859
+#: src/muuli_wdr.cpp:1866
 msgid "Active connections"
 msgstr "Conexiuni active"
 
-#: src/muuli_wdr.cpp:1862
+#: src/muuli_wdr.cpp:1869
 #, fuzzy
 msgid "Systray Icon Speed Bar"
 msgstr "Miniatură rapidă pe bara de sistem"
 
-#: src/muuli_wdr.cpp:1863
+#: src/muuli_wdr.cpp:1870
 msgid "Kad-nodes current"
 msgstr "Noduri Kad curente"
 
-#: src/muuli_wdr.cpp:1864
+#: src/muuli_wdr.cpp:1871
 msgid "Kad-nodes running"
 msgstr "Noduri Kad care rulează"
 
-#: src/muuli_wdr.cpp:1865
+#: src/muuli_wdr.cpp:1872
 msgid "Kad-nodes session"
 msgstr "Noduri Kad pe sesiune"
 
-#: src/muuli_wdr.cpp:1869 src/muuli_wdr.cpp:2296
+#: src/muuli_wdr.cpp:1876 src/muuli_wdr.cpp:2303
 msgid "Select"
 msgstr "Selectează"
 
-#: src/muuli_wdr.cpp:1873
+#: src/muuli_wdr.cpp:1880
 msgid "Tree"
 msgstr "Arbore"
 
-#: src/muuli_wdr.cpp:1883
+#: src/muuli_wdr.cpp:1890
 msgid "Number of Client Versions shown (0=unlimited)"
 msgstr "Număr de versiuni client arătate (0=nelimitat)"
 
-#: src/muuli_wdr.cpp:1908
+#: src/muuli_wdr.cpp:1915
 msgid "!!! WARNING !!!"
 msgstr "!!! ATENȚIE !!!"
 
-#: src/muuli_wdr.cpp:1923
+#: src/muuli_wdr.cpp:1930
 msgid "Max new connections / 5 secs"
 msgstr "Maxim conexiuni noi /5 secunde"
 
-#: src/muuli_wdr.cpp:1925
+#: src/muuli_wdr.cpp:1932
 msgid "Concurrent Kad source lookups"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1927
+#: src/muuli_wdr.cpp:1934
 #, fuzzy
 msgid "Kad source re-search interval (minutes)"
 msgstr "Rată interval actualizare FTP în minute"
 
-#: src/muuli_wdr.cpp:1929
+#: src/muuli_wdr.cpp:1936
 #, fuzzy
 msgid "Source re-ask interval (minutes)"
 msgstr "Rată interval actualizare FTP în minute"
 
-#: src/muuli_wdr.cpp:1933
+#: src/muuli_wdr.cpp:1940
 msgid "File Buffer Size: 240000 bytes"
 msgstr "Dimensiune fișier tampon: 240000 octeți"
 
-#: src/muuli_wdr.cpp:1937
+#: src/muuli_wdr.cpp:1944
 msgid "Use MMAP: memory-mapped file access (lower memory use)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1938
+#: src/muuli_wdr.cpp:1945
 msgid "Maps part files into memory instead of buffering them on the heap, lowering the process memory footprint. May reduce download speed on some disks; best for memory-constrained or upload-heavy hosts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1940
+#: src/muuli_wdr.cpp:1947
 msgid "Upload Queue Size: 5000 clients"
 msgstr "Dimensiune coadă încărcare: 5000 clienți"
 
-#: src/muuli_wdr.cpp:1944
+#: src/muuli_wdr.cpp:1951
 msgid "Server connection refresh interval: Disable"
 msgstr "Interval reîmprospătare conexiune server: Dezactivat"
 
-#: src/muuli_wdr.cpp:1948
+#: src/muuli_wdr.cpp:1955
 msgid "Disable computer's timed standby mode"
 msgstr "Dezactivează temporizarea modului de st-by al computerului"
 
-#: src/muuli_wdr.cpp:1967
+#: src/muuli_wdr.cpp:1974
 msgid "Skin to use: "
 msgstr "Aspect interfață de utilizat:"
 
-#: src/muuli_wdr.cpp:1976
+#: src/muuli_wdr.cpp:1983
 msgid "Show \"Fast eD2k Links Handler\" in every window."
 msgstr "Arată \"Manipulator linkuri rapide eD2k\" în fiecare fereastră."
 
-#: src/muuli_wdr.cpp:1979
+#: src/muuli_wdr.cpp:1986
 msgid "Show extended info on categories tabs"
 msgstr "Arată informații extinse în fila categoriilor"
 
-#: src/muuli_wdr.cpp:1982
+#: src/muuli_wdr.cpp:1989
 msgid "Show application version on title"
 msgstr "Arată în titlu versiunea aplicației"
 
-#: src/muuli_wdr.cpp:1984
+#: src/muuli_wdr.cpp:1991
 msgid "Show transfer rates on title"
 msgstr "Arată rata de transfer în titlu"
 
-#: src/muuli_wdr.cpp:1986
+#: src/muuli_wdr.cpp:1993
 msgid "Before application name"
 msgstr "Înaintea numelui aplicației"
 
-#: src/muuli_wdr.cpp:1988
+#: src/muuli_wdr.cpp:1995
 msgid "After application name"
 msgstr "După numele aplicației"
 
-#: src/muuli_wdr.cpp:1991
+#: src/muuli_wdr.cpp:1998
 msgid "Show overhead bandwidth"
 msgstr "Arată lățimea de bandă globală"
 
-#: src/muuli_wdr.cpp:1995
+#: src/muuli_wdr.cpp:2002
 msgid "Vertical toolbar orientation"
 msgstr "Orientare verticală a barei de unelte"
 
-#: src/muuli_wdr.cpp:1997
+#: src/muuli_wdr.cpp:2004
 msgid "Live column sorting (auto-reorder rows as their values change)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2004
+#: src/muuli_wdr.cpp:2011
 msgid "Download Queue Files"
 msgstr "Descărcare coadă fișiere"
 
-#: src/muuli_wdr.cpp:2007
+#: src/muuli_wdr.cpp:2014
 msgid "Show progress percentage"
 msgstr "Arată procentul progresului"
 
-#: src/muuli_wdr.cpp:2013
+#: src/muuli_wdr.cpp:2020
 msgid "Show progress bar"
 msgstr "Arată bara de progres"
 
-#: src/muuli_wdr.cpp:2016
+#: src/muuli_wdr.cpp:2023
 msgid "Flat"
 msgstr "Plat"
 
-#: src/muuli_wdr.cpp:2020
+#: src/muuli_wdr.cpp:2027
 msgid "Round"
 msgstr "Rotund"
 
-#: src/muuli_wdr.cpp:2038
+#: src/muuli_wdr.cpp:2045
 msgid "External Connection Parameters"
 msgstr "Parametrii conexiune externă"
 
-#: src/muuli_wdr.cpp:2041
+#: src/muuli_wdr.cpp:2048
 msgid "Accept external connections"
 msgstr "Acceptă conexiuni externe"
 
-#: src/muuli_wdr.cpp:2048 src/muuli_wdr.cpp:2107
+#: src/muuli_wdr.cpp:2055 src/muuli_wdr.cpp:2114
 msgid "IP of the listening interface:"
 msgstr "IP a interfeței de ascultare:"
 
-#: src/muuli_wdr.cpp:2051
+#: src/muuli_wdr.cpp:2058
 msgid "Enter here a valid ip in the a.b.c.d format for the listening EC interface. An empty field or 0.0.0.0 will mean any interface."
 msgstr "Introduceți aici un ip valid în formatul a.b.c.d pentru ascultarea interfeței EC. Un câmp gol sau 0.0.0.0 va însemna orice interfață."
 
-#: src/muuli_wdr.cpp:2072 src/muuli_wdr.cpp:2156
+#: src/muuli_wdr.cpp:2079 src/muuli_wdr.cpp:2163
 msgid "TCP port:"
 msgstr "port TCP:"
 
-#: src/muuli_wdr.cpp:2078
+#: src/muuli_wdr.cpp:2085
 msgid "Enable UPnP port forwarding on the EC port"
 msgstr "Activează înaintarea portului UPnP pe portul EC"
 
-#: src/muuli_wdr.cpp:2082 src/muuli_wdr.cpp:3041
+#: src/muuli_wdr.cpp:2089 src/muuli_wdr.cpp:3048
 #: src/utils/wxCas/src/wxcasprefs.cpp:167
 msgid "Password"
 msgstr "Parolă"
 
-#: src/muuli_wdr.cpp:2088
+#: src/muuli_wdr.cpp:2095
 #, fuzzy
 msgid "aMule API server parameters"
 msgstr "Parametrii server web"
 
-#: src/muuli_wdr.cpp:2091
+#: src/muuli_wdr.cpp:2098
 msgid "Run amuleapi (REST API) on startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2096
+#: src/muuli_wdr.cpp:2103
 #, fuzzy
 msgid "HTTP port:"
 msgstr "port TCP:"
 
-#: src/muuli_wdr.cpp:2110
+#: src/muuli_wdr.cpp:2117
 msgid "The interface amuleapi's HTTP server listens on. 127.0.0.1 (default) accepts only local connections; use 0.0.0.0 or a specific IP to expose it to other hosts (set an admin password below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2113
+#: src/muuli_wdr.cpp:2120
 #, fuzzy
 msgid "Admin password"
 msgstr "Se verifică parola\n"
 
-#: src/muuli_wdr.cpp:2118 src/muuli_wdr.cpp:2149
+#: src/muuli_wdr.cpp:2125 src/muuli_wdr.cpp:2156
 msgid "Low rights password"
 msgstr "Parolă cu drepturi scăzute"
 
-#: src/muuli_wdr.cpp:2126
+#: src/muuli_wdr.cpp:2133
 msgid "Web server parameters"
 msgstr "Parametrii server web"
 
-#: src/muuli_wdr.cpp:2129
+#: src/muuli_wdr.cpp:2136
 #, fuzzy
 msgid "Run webserver on startup (deprecated)"
 msgstr "Rulează la pornire serverul web"
 
-#: src/muuli_wdr.cpp:2135
+#: src/muuli_wdr.cpp:2142
 msgid "Web template"
 msgstr "Șablon web"
 
-#: src/muuli_wdr.cpp:2140
+#: src/muuli_wdr.cpp:2147
 msgid "Full rights password"
 msgstr "Parolă cu drepturi depline"
 
-#: src/muuli_wdr.cpp:2144
+#: src/muuli_wdr.cpp:2151
 msgid "Enable Low rights User"
 msgstr "Activează utilizatorul cu drepturi scăzute"
 
-#: src/muuli_wdr.cpp:2163
+#: src/muuli_wdr.cpp:2170
 msgid "Enable UPnP port forwarding of the web server port"
 msgstr "Activează înaintarea portului UPnP pe portul serverului web"
 
-#: src/muuli_wdr.cpp:2168
+#: src/muuli_wdr.cpp:2175
 msgid "Web server UPnP TCP port (Optional)"
 msgstr "Port UPnP TCP server web (facultativ)"
 
-#: src/muuli_wdr.cpp:2176
+#: src/muuli_wdr.cpp:2183
 msgid "Page Refresh Time (in secs)"
 msgstr "Timp reîmprospătare pagină (în secunde)"
 
-#: src/muuli_wdr.cpp:2183
+#: src/muuli_wdr.cpp:2190
 msgid "Enable Gzip compression"
 msgstr "Activează compresia Gzip"
 
-#: src/muuli_wdr.cpp:2217
+#: src/muuli_wdr.cpp:2224
 #, fuzzy
 msgid "Reset page to defaults"
 msgstr "Valoare implicită a sistemului"
 
-#: src/muuli_wdr.cpp:2218
+#: src/muuli_wdr.cpp:2225
 msgid "Reset the settings on the current page to their default values."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2220 src/muuli_wdr.cpp:2306 src/ServerWnd.cpp:274
+#: src/muuli_wdr.cpp:2227 src/muuli_wdr.cpp:2313 src/ServerWnd.cpp:274
 #: src/ServerWnd.cpp:282
 msgid "OK"
 msgstr "Bine"
 
-#: src/muuli_wdr.cpp:2222
+#: src/muuli_wdr.cpp:2229
 msgid "Click here to apply any changes made to the preferences."
 msgstr "Apăsați aici pentru a aplica orice modificare efectuată la preferințe."
 
-#: src/muuli_wdr.cpp:2225
+#: src/muuli_wdr.cpp:2232
 msgid "Reset any changes made to the preferences."
 msgstr "Resetează orice schimbare efectuată la preferințe."
 
-#: src/muuli_wdr.cpp:2254
+#: src/muuli_wdr.cpp:2261
 msgid "Comment :"
 msgstr "Comentariu :"
 
-#: src/muuli_wdr.cpp:2261
+#: src/muuli_wdr.cpp:2268
 msgid "Incoming Dir :"
 msgstr "Director intrare :"
 
-#: src/muuli_wdr.cpp:2270
+#: src/muuli_wdr.cpp:2277
 msgid "Change priority for new assigned files :"
 msgstr "Schimbă prioritatea pentru noile fișiere alocate :"
 
-#: src/muuli_wdr.cpp:2274
+#: src/muuli_wdr.cpp:2281
 msgid "Don't change"
 msgstr "Nu modifica"
 
-#: src/muuli_wdr.cpp:2286
+#: src/muuli_wdr.cpp:2293
 msgid "Select color for this Category (currently selected) :"
 msgstr "Selectați culoarea pentru această categorie (selectată curent):"
 
-#: src/muuli_wdr.cpp:2353 src/muuli_wdr.cpp:2372 src/muuli_wdr.cpp:2394
+#: src/muuli_wdr.cpp:2360 src/muuli_wdr.cpp:2379 src/muuli_wdr.cpp:2401
 msgid "Click this button to reset the log."
 msgstr "Apăsați acest buton pentru resetarea jurnalului."
 
-#: src/muuli_wdr.cpp:2413
+#: src/muuli_wdr.cpp:2420
 msgid "Click on this button to update the servers list from URL ..."
 msgstr "Apăsați acest buton pentru a se actualiza lista serverelor din URL ..."
 
-#: src/muuli_wdr.cpp:2417
+#: src/muuli_wdr.cpp:2424
 msgid "Server list"
 msgstr "Listă server"
 
-#: src/muuli_wdr.cpp:2421
+#: src/muuli_wdr.cpp:2428
 msgid "Enter the url to a server.met file here and press the button to the left to update the list of known servers."
 msgstr "Introduceți aici adresa URL pentru un fișier server.met și apăsați butonul din stânga pentru a actualiza lista serverelor. cunoscute."
 
-#: src/muuli_wdr.cpp:2426
+#: src/muuli_wdr.cpp:2433
 msgid "Add server manually: Name"
 msgstr "Adăugare server manual: Nume"
 
-#: src/muuli_wdr.cpp:2429
+#: src/muuli_wdr.cpp:2436
 msgid "Enter the name of the new server here"
 msgstr "Introduceți aici numele noului server"
 
-#: src/muuli_wdr.cpp:2431 src/ServerWnd.cpp:206
+#: src/muuli_wdr.cpp:2438 src/ServerWnd.cpp:206
 msgid "IP:Port"
 msgstr "IP:Port"
 
-#: src/muuli_wdr.cpp:2434
+#: src/muuli_wdr.cpp:2441
 msgid "Enter the IP of the server here, using the x.x.x.x format."
 msgstr "Introduceți aici adresa IP a serverului, utilizând formatul x.x.x.x  ."
 
-#: src/muuli_wdr.cpp:2440
+#: src/muuli_wdr.cpp:2447
 msgid "Enter the port of the server here."
 msgstr "Introduceți aici portul serverului."
 
-#: src/muuli_wdr.cpp:2443
+#: src/muuli_wdr.cpp:2450
 msgid "Add manually a server (fill fields to the left before) ..."
 msgstr "Adăugați un server manual (completați întâi câmpurile din stânga) ..."
 
-#: src/muuli_wdr.cpp:2472
+#: src/muuli_wdr.cpp:2479
 msgid "aMule Log"
 msgstr "Jurnal aMule"
 
-#: src/muuli_wdr.cpp:2480
+#: src/muuli_wdr.cpp:2487
 msgid "Server Info"
 msgstr "Informație server"
 
-#: src/muuli_wdr.cpp:2484
+#: src/muuli_wdr.cpp:2491
 msgid "ED2K Info"
 msgstr "Informație eD2k"
 
-#: src/muuli_wdr.cpp:2488
+#: src/muuli_wdr.cpp:2495
 msgid "Kad Info"
 msgstr "Informație Kad"
 
-#: src/muuli_wdr.cpp:2516
+#: src/muuli_wdr.cpp:2523
 msgid "Click on this button to update the nodes list from URL ..."
 msgstr "Apăsați pe acest buton pentru a actualiza lista nodurilor din URL ..."
 
-#: src/muuli_wdr.cpp:2520
+#: src/muuli_wdr.cpp:2527
 msgid "Nodes (0)"
 msgstr "Noduri (0)"
 
-#: src/muuli_wdr.cpp:2524
+#: src/muuli_wdr.cpp:2531
 msgid "Enter the url to a nodes.dat file here and press the button to the left to update the list of known nodes."
 msgstr "Introduceți aici adresa url către un fișier nodes.dat și apăsați butonul din stânga pentru actualizarea listei nodurilor cunoscute."
 
-#: src/muuli_wdr.cpp:2527
+#: src/muuli_wdr.cpp:2534
 msgid "Nodes stats"
 msgstr "Stare noduri"
 
-#: src/muuli_wdr.cpp:2569
+#: src/muuli_wdr.cpp:2576
 msgid "Bootstrap"
 msgstr "Bootstrap"
 
-#: src/muuli_wdr.cpp:2572
+#: src/muuli_wdr.cpp:2579
 msgid "New node"
 msgstr "Nod nou"
 
-#: src/muuli_wdr.cpp:2577
+#: src/muuli_wdr.cpp:2584
 msgid "IP:"
 msgstr "IP:"
 
-#: src/muuli_wdr.cpp:2597
+#: src/muuli_wdr.cpp:2604
 msgid "Port:"
 msgstr "Port:"
 
-#: src/muuli_wdr.cpp:2610
+#: src/muuli_wdr.cpp:2617
 msgid "Bootstrap from known clients"
 msgstr "Bootstrap de la clienții cunoscuți"
 
-#: src/muuli_wdr.cpp:2612
+#: src/muuli_wdr.cpp:2619
 msgid "Disconnect Kad"
 msgstr "Deconectare Kad"
 
-#: src/muuli_wdr.cpp:2646
+#: src/muuli_wdr.cpp:2653
 msgid "Use Secure User Identification"
 msgstr "Utilizează identificarea securizată a utilizatorilor"
 
-#: src/muuli_wdr.cpp:2648
+#: src/muuli_wdr.cpp:2655
 msgid "It is recommended to enable this option. You will not receive credits if SUI is not enabled."
 msgstr "Este recomandat să activați această opțiune. Nu veți primii credite dacă SUI nu este activat."
 
-#: src/muuli_wdr.cpp:2650
+#: src/muuli_wdr.cpp:2657
 msgid "Protocol Obfuscation"
 msgstr "Protocol disimulare"
 
-#: src/muuli_wdr.cpp:2653
+#: src/muuli_wdr.cpp:2660
 msgid "Support Protocol Obfuscation"
 msgstr "Suport protocol disimulare"
 
-#: src/muuli_wdr.cpp:2655
+#: src/muuli_wdr.cpp:2662
 msgid "This option enabled Protocol Obfuscation, and makes aMule accept obfuscated connections from other clients."
 msgstr "Această opțiune activează Protocolul Disimulare, și determină aMule să accepte conexiuni disimulate de la alți clienți."
 
-#: src/muuli_wdr.cpp:2657
+#: src/muuli_wdr.cpp:2664
 msgid "Use obfuscation for outgoing connections"
 msgstr "Utilizați disimularea pentru conexiunile de ieșire"
 
-#: src/muuli_wdr.cpp:2659
+#: src/muuli_wdr.cpp:2666
 msgid "This option makes aMule use Protocol Obfuscation when connecting other clients/servers."
 msgstr "Această opțiune determină aMule să utilizeze Protocolul Disimulare când conectează alți clienți/servere."
 
-#: src/muuli_wdr.cpp:2661
+#: src/muuli_wdr.cpp:2668
 msgid "Accept only obfuscated connections"
 msgstr "Acceptă numai conexiuni disimulate"
 
-#: src/muuli_wdr.cpp:2662
+#: src/muuli_wdr.cpp:2669
 msgid "This option makes aMule only accept obfuscated connections. You will have less sources, but all your traffic will be obfuscated"
 msgstr "Această opțiune face aMule să accepte numai conexiuni disimulate. Veți avea mai puține surse, dar tot traficul va fi disimulat"
 
-#: src/muuli_wdr.cpp:2667
+#: src/muuli_wdr.cpp:2674
 msgid "Everybody"
 msgstr "Fiecare"
 
-#: src/muuli_wdr.cpp:2669
+#: src/muuli_wdr.cpp:2676
 msgid "No one"
 msgstr "Nimănui"
 
-#: src/muuli_wdr.cpp:2671
+#: src/muuli_wdr.cpp:2678
 msgid "Who can see my shared files:"
 msgstr "Cine poate vedea fișierele mele partajate:"
 
-#: src/muuli_wdr.cpp:2672
+#: src/muuli_wdr.cpp:2679
 msgid "Select who can request to view a list of your shared files."
 msgstr "Selectați cine poate solicita să vizualizeze o listă a fișierelor partajate."
 
-#: src/muuli_wdr.cpp:2674
+#: src/muuli_wdr.cpp:2681
 msgid "IP-Filtering"
 msgstr "Filtrare-IP"
 
-#: src/muuli_wdr.cpp:2681
+#: src/muuli_wdr.cpp:2688
 msgid "Filter clients"
 msgstr "Filtru clienți"
 
-#: src/muuli_wdr.cpp:2683
+#: src/muuli_wdr.cpp:2690
 msgid "Enable filtering of the client IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "Activați filtrarea IP-urilor client cum este definit în fișierul ~/.aMule/ipfilter.dat."
 
-#: src/muuli_wdr.cpp:2685
+#: src/muuli_wdr.cpp:2692
 msgid "Filter servers"
 msgstr "Filtrare servere"
 
-#: src/muuli_wdr.cpp:2687
+#: src/muuli_wdr.cpp:2694
 msgid "Enable filtering of the server IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "Activați filtrarea IP-urilor server cum este definit în fișierul ~/.aMule/ipfilter.dat."
 
-#: src/muuli_wdr.cpp:2691
+#: src/muuli_wdr.cpp:2698
 msgid "Reload List"
 msgstr "Reîncarcă lista"
 
-#: src/muuli_wdr.cpp:2692
+#: src/muuli_wdr.cpp:2699
 msgid "Reload the list of IPs to filter from the file ~/.aMule/ipfilter.dat"
 msgstr "Reîncarcă lista IP-urilor de filtrat din fișierul ~/.aMule/ipfilter.dat"
 
-#: src/muuli_wdr.cpp:2698
+#: src/muuli_wdr.cpp:2705
 msgid "URL:"
 msgstr "URL:"
 
-#: src/muuli_wdr.cpp:2702 src/muuli_wdr.cpp:2895
+#: src/muuli_wdr.cpp:2709 src/muuli_wdr.cpp:2902
 msgid "Update now"
 msgstr "Actualizează acum"
 
-#: src/muuli_wdr.cpp:2705
+#: src/muuli_wdr.cpp:2712
 msgid "Auto-update ipfilter at startup"
 msgstr "Actualizare automată filtru ip la pornire"
 
-#: src/muuli_wdr.cpp:2709
+#: src/muuli_wdr.cpp:2716
 msgid "Filtering Level:"
 msgstr "Nivel de filtrare:"
 
-#: src/muuli_wdr.cpp:2715
+#: src/muuli_wdr.cpp:2722
 msgid "Always filter LAN IPs"
 msgstr "Filtrează mereu IP-urile LAN"
 
-#: src/muuli_wdr.cpp:2718
+#: src/muuli_wdr.cpp:2725
 msgid "Paranoid handling of non-matching IPs"
 msgstr "Manipulare paranoică a IP-urilor care nu se potrivesc"
 
-#: src/muuli_wdr.cpp:2720
+#: src/muuli_wdr.cpp:2727
 msgid "Rejects a packet when its source IP differs from the IP the client claims (an anti-spoofing check). Disable only if it causes connection problems."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2722
+#: src/muuli_wdr.cpp:2729
 msgid "Use system-wide ipfilter.dat if available"
 msgstr "Utilizați în tot sistemul ipfilter.dat dacă este disponibil"
 
-#: src/muuli_wdr.cpp:2723
+#: src/muuli_wdr.cpp:2730
 #, fuzzy
 msgid "If there's no local ipfilter.dat found, allow usage of a system-wide ipfilter file."
 msgstr "Dacă nu s-a găsit local ipfilter.dat, permite utilizarea unui fișier ipfilter din sistem."
 
-#: src/muuli_wdr.cpp:2740
+#: src/muuli_wdr.cpp:2747
 msgid "Enable Online-Signature"
 msgstr "Activare semnătură online"
 
-#: src/muuli_wdr.cpp:2742
+#: src/muuli_wdr.cpp:2749
 msgid "Enables the writing of the OS file, which can be used by external apps to create signatures and the like."
 msgstr "Activați scrierea fișierului OS, care poate fi utilizat de aplicații exterioare la crearea semnăturilor și aprecierii."
 
-#: src/muuli_wdr.cpp:2746
+#: src/muuli_wdr.cpp:2753
 msgid "Update Frequency (Secs):"
 msgstr "Frecvență actualizare (secunde)"
 
-#: src/muuli_wdr.cpp:2749
+#: src/muuli_wdr.cpp:2756
 msgid "Change the frequency (in seconds) of Online Signature updates."
 msgstr "Schimbați frecvența (în secunde) a actualizărilor semnăturii online."
 
-#: src/muuli_wdr.cpp:2757
+#: src/muuli_wdr.cpp:2764
 msgid "Save online signature file in: "
 msgstr "Salvează fișierul semnăturii online în:"
 
-#: src/muuli_wdr.cpp:2763
+#: src/muuli_wdr.cpp:2770
 msgid "Click here to select the directory containing the the Online Signature files."
 msgstr "Apăsați aici pentru a selecta directorul care conține fișierele cu semnătura online."
 
-#: src/muuli_wdr.cpp:2796
+#: src/muuli_wdr.cpp:2803
 msgid "Show country flags for clients"
 msgstr "Arată steagul țării pentru clienți"
 
-#: src/muuli_wdr.cpp:2797
+#: src/muuli_wdr.cpp:2804
 msgid "Render the country flag column in the transfers, queue and search views. Requires a valid MMDB GeoIP database (see below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2802
+#: src/muuli_wdr.cpp:2809
 #, fuzzy
 msgid "Database"
 msgstr "Rată date :"
 
-#: src/muuli_wdr.cpp:2818
+#: src/muuli_wdr.cpp:2825
 #, fuzzy
 msgid "Source:"
 msgstr "Surse"
 
-#: src/muuli_wdr.cpp:2821
+#: src/muuli_wdr.cpp:2828
 msgid "DB-IP (free, no account)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2822
+#: src/muuli_wdr.cpp:2829
 msgid "MaxMind GeoLite2 (free, account required)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2823
+#: src/muuli_wdr.cpp:2830
 msgid "Custom URL"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2826
+#: src/muuli_wdr.cpp:2833
 msgid "Choose which provider supplies the GeoIP MMDB database. DB-IP is the default - no account required. MaxMind requires a free account + license key. Use Custom URL to point at any other MMDB host (e.g. a local mirror)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2843
+#: src/muuli_wdr.cpp:2850
 msgid ""
 "No configuration required.\n"
 "\n"
@@ -4848,11 +4862,11 @@ msgid ""
 "License: Creative Commons BY 4.0 - https://creativecommons.org/licenses/by/4.0/"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2856
+#: src/muuli_wdr.cpp:2863
 msgid "License key:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2862
+#: src/muuli_wdr.cpp:2869
 msgid ""
 "Sign up for a free MaxMind account, then generate a License Key:\n"
 "https://www.maxmind.com/en/geolite2/signup\n"
@@ -4862,225 +4876,225 @@ msgid ""
 "Requires attribution and account registration; refresh at least every 30 days."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2877
+#: src/muuli_wdr.cpp:2884
 #, fuzzy
 msgid "Download URL:"
 msgstr "Descărcare:"
 
-#: src/muuli_wdr.cpp:2883
+#: src/muuli_wdr.cpp:2890
 msgid ""
 "Must point to an .mmdb file or a .gz / .tar.gz containing one.\n"
 "URL may include credentials (https://user:pass@host/...).\n"
 "License and attribution terms are set by the upstream URL - you are responsible."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2896
+#: src/muuli_wdr.cpp:2903
 msgid "Download the GeoIP database from the selected source."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2898
+#: src/muuli_wdr.cpp:2905
 #, fuzzy
 msgid "Auto-update on startup"
 msgstr "Actualizare automată filtru ip la pornire"
 
-#: src/muuli_wdr.cpp:2899
+#: src/muuli_wdr.cpp:2906
 msgid "Re-download the GeoIP database from the selected source every time aMule starts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2922
+#: src/muuli_wdr.cpp:2929
 msgid "Filter incoming messages (except current chat):"
 msgstr "Filtrare mesaje de intrare (cu excepția chat-ului curent):"
 
-#: src/muuli_wdr.cpp:2924
+#: src/muuli_wdr.cpp:2931
 msgid "Filter all messages"
 msgstr "Filtrează toate mesajele"
 
-#: src/muuli_wdr.cpp:2926
+#: src/muuli_wdr.cpp:2933
 msgid "Filter messages from people not on your friend list"
 msgstr "Filtrare mesaje de la persoane care nu sunt în lista de prieteni"
 
-#: src/muuli_wdr.cpp:2928
+#: src/muuli_wdr.cpp:2935
 msgid "Filter messages from unknown clients"
 msgstr "Filtrare mesaje de la clienți necunoscuți"
 
-#: src/muuli_wdr.cpp:2930
+#: src/muuli_wdr.cpp:2937
 msgid "Filter messages containing (use ',' as separator):"
 msgstr "Filtrare mesaje conținând )utilizați ',' ca separator):"
 
-#: src/muuli_wdr.cpp:2933 src/muuli_wdr.cpp:2944
+#: src/muuli_wdr.cpp:2940 src/muuli_wdr.cpp:2951
 msgid "add here the words amule should filter and block messages including it"
 msgstr "adăugați aici cuvintele pe care amule trebuie să le filtreze și să blocheze mesajele care le includ"
 
-#: src/muuli_wdr.cpp:2935
+#: src/muuli_wdr.cpp:2942
 msgid "Show received messages in the log"
 msgstr "Arată în jurnal mesajele primite"
 
-#: src/muuli_wdr.cpp:2938
+#: src/muuli_wdr.cpp:2945
 msgid "Comments"
 msgstr "Comentarii"
 
-#: src/muuli_wdr.cpp:2941
+#: src/muuli_wdr.cpp:2948
 msgid "Filter comments containing (use ',' as separator):"
 msgstr "Filtrare comentarii conținând (utilizați ',' ca separator):"
 
-#: src/muuli_wdr.cpp:2966
+#: src/muuli_wdr.cpp:2973
 msgid "Enable Proxy"
 msgstr "Activează proxy"
 
-#: src/muuli_wdr.cpp:2967
+#: src/muuli_wdr.cpp:2974
 msgid "Enable/disable proxy support"
 msgstr "Activează/dezactivează suportul proxy"
 
-#: src/muuli_wdr.cpp:2970
+#: src/muuli_wdr.cpp:2977
 msgid "Proxy type:"
 msgstr "Tip proxy:"
 
-#: src/muuli_wdr.cpp:2981
+#: src/muuli_wdr.cpp:2988
 msgid "Proxy host:"
 msgstr "Gazdă proxy:"
 
-#: src/muuli_wdr.cpp:2984
+#: src/muuli_wdr.cpp:2991
 msgid "The proxy host name"
 msgstr "Numele de gazdă proxy"
 
-#: src/muuli_wdr.cpp:2986
+#: src/muuli_wdr.cpp:2993
 msgid "Proxy port:"
 msgstr "Port proxy:"
 
-#: src/muuli_wdr.cpp:2989
+#: src/muuli_wdr.cpp:2996
 msgid "The proxy port"
 msgstr "Portul proxy"
 
-#: src/muuli_wdr.cpp:2991
+#: src/muuli_wdr.cpp:2998
 msgid "Enable authentication"
 msgstr "Activează autentificarea"
 
-#: src/muuli_wdr.cpp:2992
+#: src/muuli_wdr.cpp:2999
 msgid "Enable/disable username/password authentication"
 msgstr "Activează/dezactivează autentificarea cu nume utilizator/parolă"
 
-#: src/muuli_wdr.cpp:2995
+#: src/muuli_wdr.cpp:3002
 msgid "Username: "
 msgstr "Utilizator:"
 
-#: src/muuli_wdr.cpp:2998
+#: src/muuli_wdr.cpp:3005
 msgid "The username to use to connect to the proxy"
 msgstr "Numele de utilizator de utilizat pentru conectarea la proxy"
 
-#: src/muuli_wdr.cpp:3000
+#: src/muuli_wdr.cpp:3007
 msgid "Password:"
 msgstr "Parolă:"
 
-#: src/muuli_wdr.cpp:3003
+#: src/muuli_wdr.cpp:3010
 msgid "The password to use to connect to the proxy"
 msgstr "Parola de utilizat pentru conectarea la proxy"
 
-#: src/muuli_wdr.cpp:3022
+#: src/muuli_wdr.cpp:3029
 msgid "Connect to:"
 msgstr "Conectează la:"
 
-#: src/muuli_wdr.cpp:3031
+#: src/muuli_wdr.cpp:3038
 msgid "Login to remote amule"
 msgstr "Autentificare la amule distant"
 
-#: src/muuli_wdr.cpp:3036
+#: src/muuli_wdr.cpp:3043
 msgid "User name"
 msgstr "Nume utilizator"
 
-#: src/muuli_wdr.cpp:3047
+#: src/muuli_wdr.cpp:3054
 msgid "Remember those settings"
 msgstr "Amintește aceste configurări"
 
-#: src/muuli_wdr.cpp:3050
+#: src/muuli_wdr.cpp:3057
 #, fuzzy
 msgid "Force ZLIB compression"
 msgstr "Utilizează compresia gzip"
 
-#: src/muuli_wdr.cpp:3074
+#: src/muuli_wdr.cpp:3081
 msgid "Enable Verbose Debug-Logging."
 msgstr "Activează jurnalizarea de depanare detaliată."
 
-#: src/muuli_wdr.cpp:3076
+#: src/muuli_wdr.cpp:3083
 msgid "Only to Logfile"
 msgstr "Numai la fișierul jurnal"
 
-#: src/muuli_wdr.cpp:3078
+#: src/muuli_wdr.cpp:3085
 msgid "Message Categories:"
 msgstr "Categorii mesaje:"
 
-#: src/muuli_wdr.cpp:3102 src/PartFileConvertDlg.cpp:160
+#: src/muuli_wdr.cpp:3109 src/PartFileConvertDlg.cpp:160
 msgid "Waiting..."
 msgstr "Așteptați..."
 
-#: src/muuli_wdr.cpp:3122
+#: src/muuli_wdr.cpp:3129
 msgid "Add imports"
 msgstr "Adaugă importurile"
 
-#: src/muuli_wdr.cpp:3125
+#: src/muuli_wdr.cpp:3132
 msgid "Retry selected"
 msgstr "Reîncearcă selectatele"
 
-#: src/muuli_wdr.cpp:3127
+#: src/muuli_wdr.cpp:3134
 msgid "Remove selected"
 msgstr "Elimină selecția"
 
-#: src/muuli_wdr.cpp:3190
+#: src/muuli_wdr.cpp:3197
 msgid "Event Types"
 msgstr "Tipuri de evenimente"
 
-#: src/muuli_wdr.cpp:3209
+#: src/muuli_wdr.cpp:3216
 msgid "Statistics and queued clients for selected file(s) : Session / All time"
 msgstr "Statistici și clienți în coadă pentru fișier(ele) selectate : Sesiune / Tot timpul"
 
-#: src/muuli_wdr.cpp:3233
+#: src/muuli_wdr.cpp:3240
 msgid "Active Uploads"
 msgstr "Încărcări active"
 
-#: src/muuli_wdr.cpp:3247
+#: src/muuli_wdr.cpp:3254
 msgid "Percent of total files"
 msgstr "Procentul din totalul fișierelor"
 
-#: src/muuli_wdr.cpp:3299
+#: src/muuli_wdr.cpp:3306
 msgid "Show Clients for"
 msgstr "Arată clienții pentru"
 
-#: src/muuli_wdr.cpp:3301
+#: src/muuli_wdr.cpp:3308
 msgid "All files"
 msgstr "Toate fișierele"
 
-#: src/muuli_wdr.cpp:3304
+#: src/muuli_wdr.cpp:3311
 msgid "Selected files"
 msgstr "Fișierele selectate"
 
-#: src/muuli_wdr.cpp:3307
+#: src/muuli_wdr.cpp:3314
 msgid "Active uploads only"
 msgstr "Numai încărcările active"
 
-#: src/muuli_wdr.cpp:3314
+#: src/muuli_wdr.cpp:3321
 msgid "Reload:"
 msgstr "Reîncarcă:"
 
-#: src/muuli_wdr.cpp:3318
+#: src/muuli_wdr.cpp:3325
 msgid "Reload your shared files"
 msgstr "Reîncărcați fișierele partajate"
 
-#: src/muuli_wdr.cpp:3381
+#: src/muuli_wdr.cpp:3388
 msgid "Send"
 msgstr "Trimite"
 
-#: src/muuli_wdr.cpp:3382
+#: src/muuli_wdr.cpp:3389
 msgid "Sends the specified message."
 msgstr "Trimite mesajul specificat"
 
-#: src/muuli_wdr.cpp:3386
+#: src/muuli_wdr.cpp:3393
 msgid "Close this chat-session."
 msgstr "Închide această sesiune de chat."
 
-#: src/muuli_wdr.cpp:3409
+#: src/muuli_wdr.cpp:3416
 msgid "Connect to any server and/or Kad"
 msgstr "Conectare la orice server și/sau Kad"
 
-#: src/muuli_wdr.cpp:3415 src/SharedFilesCtrl.cpp:142 src/Statistics.cpp:941
+#: src/muuli_wdr.cpp:3422 src/SharedFilesCtrl.cpp:142 src/Statistics.cpp:941
 msgid "Shared Files"
 msgstr "Fișiere partajate"
 
@@ -5443,188 +5457,188 @@ msgstr "Descărcat"
 msgid "ERROR: Failed to open partfile '%s'"
 msgstr "EROARE: A eșuat deschiderea fișierului parțial '%s'"
 
-#: src/Preferences.cpp:673
+#: src/Preferences.cpp:674
 msgid "System default"
 msgstr "Valoare implicită a sistemului"
 
-#: src/Preferences.cpp:674
+#: src/Preferences.cpp:675
 msgid "Albanian"
 msgstr "Albaneză"
 
-#: src/Preferences.cpp:675
+#: src/Preferences.cpp:676
 msgid "Arabic"
 msgstr "Arabă"
 
-#: src/Preferences.cpp:676
+#: src/Preferences.cpp:677
 msgid "Asturian"
 msgstr "Asturian"
 
-#: src/Preferences.cpp:677
+#: src/Preferences.cpp:678
 msgid "Basque"
 msgstr "Bască"
 
-#: src/Preferences.cpp:678
+#: src/Preferences.cpp:679
 msgid "Bulgarian"
 msgstr "Bulgară"
 
-#: src/Preferences.cpp:679
+#: src/Preferences.cpp:680
 msgid "Catalan"
 msgstr "Catalană"
 
-#: src/Preferences.cpp:680
+#: src/Preferences.cpp:681
 msgid "Chinese (Simplified)"
 msgstr "Chineză (Simplificat)"
 
-#: src/Preferences.cpp:681
+#: src/Preferences.cpp:682
 msgid "Chinese (Traditional)"
 msgstr "Chinez (tradițional)"
 
-#: src/Preferences.cpp:682
+#: src/Preferences.cpp:683
 msgid "Croatian"
 msgstr "Croată"
 
-#: src/Preferences.cpp:683
+#: src/Preferences.cpp:684
 msgid "Czech"
 msgstr "Cehă"
 
-#: src/Preferences.cpp:684
+#: src/Preferences.cpp:685
 msgid "Danish"
 msgstr "Daneză"
 
-#: src/Preferences.cpp:685
+#: src/Preferences.cpp:686
 msgid "Dutch"
 msgstr "Olandeză"
 
-#: src/Preferences.cpp:686
+#: src/Preferences.cpp:687
 msgid "English (U.K.)"
 msgstr "Englez (U.K.)"
 
-#: src/Preferences.cpp:687
+#: src/Preferences.cpp:688
 #, fuzzy
 msgid "English (U.S.)"
 msgstr "Englez (U.K.)"
 
-#: src/Preferences.cpp:688
+#: src/Preferences.cpp:689
 msgid "Estonian"
 msgstr "Estonă"
 
-#: src/Preferences.cpp:689
+#: src/Preferences.cpp:690
 msgid "Finnish"
 msgstr "Finlandeză"
 
-#: src/Preferences.cpp:690
+#: src/Preferences.cpp:691
 msgid "French"
 msgstr "Franceză"
 
-#: src/Preferences.cpp:691
+#: src/Preferences.cpp:692
 msgid "Galician"
 msgstr "Galiciană"
 
-#: src/Preferences.cpp:692
+#: src/Preferences.cpp:693
 msgid "German"
 msgstr "Germană"
 
-#: src/Preferences.cpp:693
+#: src/Preferences.cpp:694
 msgid "Greek"
 msgstr "Grecesc"
 
-#: src/Preferences.cpp:694
+#: src/Preferences.cpp:695
 msgid "Hebrew"
 msgstr "Ebraică"
 
-#: src/Preferences.cpp:695
+#: src/Preferences.cpp:696
 msgid "Hungarian"
 msgstr "Maghiară"
 
-#: src/Preferences.cpp:696
+#: src/Preferences.cpp:697
 msgid "Italian"
 msgstr "Italiană"
 
-#: src/Preferences.cpp:697
+#: src/Preferences.cpp:698
 msgid "Japanese"
 msgstr "Japoneză"
 
-#: src/Preferences.cpp:698
+#: src/Preferences.cpp:699
 msgid "Korean"
 msgstr "Koreană"
 
-#: src/Preferences.cpp:699
+#: src/Preferences.cpp:700
 msgid "Latvian"
 msgstr ""
 
-#: src/Preferences.cpp:700
+#: src/Preferences.cpp:701
 msgid "Lithuanian"
 msgstr "Lituaniană"
 
-#: src/Preferences.cpp:701
+#: src/Preferences.cpp:702
 msgid "Norwegian (Nynorsk)"
 msgstr "Norvegian"
 
-#: src/Preferences.cpp:702
+#: src/Preferences.cpp:703
 msgid "Polish"
 msgstr "Poloneză"
 
-#: src/Preferences.cpp:703
+#: src/Preferences.cpp:704
 msgid "Portuguese"
 msgstr "Portugheză"
 
-#: src/Preferences.cpp:704
+#: src/Preferences.cpp:705
 msgid "Portuguese (Brazilian)"
 msgstr "Portugheză (Brazilia)"
 
-#: src/Preferences.cpp:705
+#: src/Preferences.cpp:706
 msgid "Romanian"
 msgstr "Română"
 
-#: src/Preferences.cpp:706
+#: src/Preferences.cpp:707
 msgid "Russian"
 msgstr "Rusă"
 
-#: src/Preferences.cpp:707
+#: src/Preferences.cpp:708
 msgid "Slovenian"
 msgstr "Slovenă"
 
-#: src/Preferences.cpp:708
+#: src/Preferences.cpp:709
 msgid "Spanish"
 msgstr "Spaniolă"
 
-#: src/Preferences.cpp:709
+#: src/Preferences.cpp:710
 msgid "Swedish"
 msgstr "Suedeză"
 
-#: src/Preferences.cpp:710
+#: src/Preferences.cpp:711
 msgid "Turkish"
 msgstr "Turcă"
 
-#: src/Preferences.cpp:711
+#: src/Preferences.cpp:712
 msgid "Ukrainian"
 msgstr "Ucraineană"
 
-#: src/Preferences.cpp:814
+#: src/Preferences.cpp:815
 msgid "Change Language"
 msgstr "Schimbă limba"
 
-#: src/Preferences.cpp:878
+#: src/Preferences.cpp:879
 msgid "There are no translations installed for aMule"
 msgstr "Nu sunt instalate traduceri pentru aMule"
 
-#: src/Preferences.cpp:879
+#: src/Preferences.cpp:880
 msgid "No languages available"
 msgstr "Nu sunt limbi disponibile"
 
-#: src/Preferences.cpp:1010
+#: src/Preferences.cpp:1011
 msgid "no options available"
 msgstr "Nu sunt opțiuni disponibile"
 
-#: src/Preferences.cpp:2179
+#: src/Preferences.cpp:2182
 msgid "Invalid category found, skipping"
 msgstr "S-a găsit o categorie nevalidă, se omite"
 
-#: src/Preferences.cpp:2348
+#: src/Preferences.cpp:2351
 msgid "TCP port can't be higher than 65532 due to server UDP socket being TCP+3"
 msgstr "Portul TCP nu poate fi mai mare decât 65532 fiindcă soclul UDP al serverului trebuie să fie TCP+3"
 
-#: src/Preferences.cpp:2349
+#: src/Preferences.cpp:2352
 #, c-format
 msgid "Default port will be used (%d)"
 msgstr "Va fi folosit portul implicit (%d)"
@@ -6139,24 +6153,28 @@ msgstr "Reîncarcă lista fișierelor partajate."
 msgid "Shared folder"
 msgstr "Dosare partajate"
 
-#: src/SearchDlg.cpp:425
+#: src/SearchDlg.cpp:280
+msgid "Clear search history"
+msgstr ""
+
+#: src/SearchDlg.cpp:584
 msgid "It's impossible to search when both eD2k and Kademlia are disabled."
 msgstr ""
 
-#: src/SearchDlg.cpp:426 src/SearchListCtrl.cpp:858
+#: src/SearchDlg.cpp:585 src/SearchListCtrl.cpp:858
 #, fuzzy
 msgid "Search error"
 msgstr "Căutări"
 
-#: src/SearchDlg.cpp:768
+#: src/SearchDlg.cpp:929
 msgid "Min size must be smaller than max size. Max size ignored."
 msgstr "Dimensiunea mică trebuie să fie mai mică decât dimensiunea mare. Dimensiunea maximă s-a ignorat."
 
-#: src/SearchDlg.cpp:769 src/SearchDlg.cpp:851
+#: src/SearchDlg.cpp:930 src/SearchDlg.cpp:1012
 msgid "Search warning"
 msgstr "Atenționare căutare"
 
-#: src/SearchDlg.cpp:929 src/SearchListCtrl.cpp:735
+#: src/SearchDlg.cpp:1092 src/SearchListCtrl.cpp:735
 msgid "Main"
 msgstr "Principal"
 

--- a/po/ro.po
+++ b/po/ro.po
@@ -9,8 +9,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-28 12:12+0200\n"
-"PO-Revision-Date: 2026-07-27 10:32+0000\n"
+"POT-Creation-Date: 2026-07-28 08:06+0200\n"
+"PO-Revision-Date: 2026-07-27 11:44+0000\n"
 "Last-Translator: Angelescu Constantin <titus0818@yahoo.com>\n"
 "Language-Team: English <kde-i18n-doc@kde.org>\n"
 "Language: ro\n"
@@ -144,7 +144,7 @@ msgstr ""
 msgid "Not now"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:422 src/amuleDlg.cpp:665
+#: src/AppImageIntegration.cpp:422 src/amuleDlg.cpp:600
 msgid "Don't ask again"
 msgstr ""
 
@@ -202,83 +202,83 @@ msgstr "A eșuat deschiderea fișierului legătură eD2k."
 msgid "WARNING: You can't add yourself as a source for an eD2k link while having a lowid."
 msgstr "ATENȚIE: Nu vă puteți adăuga ca sursă pentru o legătură eD2k cât timp aveți lowid."
 
-#: src/amule.cpp:301
+#: src/amule.cpp:300
 msgid "Now, exiting main app..."
 msgstr "Acum, se oprește aplicația principală..."
 
-#: src/amule.cpp:331
+#: src/amule.cpp:330
 #, c-format
 msgid "Terminating amuleweb instance with pid '%d' ... "
 msgstr "Se termină instanța amuleweb cu pid '%d' ... "
 
-#: src/amule.cpp:335
+#: src/amule.cpp:334
 #, c-format
 msgid "Killing amuleweb instance with pid '%d' ... "
 msgstr "Se omoară instanța amuleweb cu pid '%d' ... "
 
-#: src/amule.cpp:337 src/amule.cpp:350 src/ClientRef.cpp:180
-#: src/SearchDlg.cpp:1041 src/ServerListCtrl.cpp:98
+#: src/amule.cpp:336 src/amule.cpp:349 src/ClientRef.cpp:180
+#: src/SearchDlg.cpp:880 src/ServerListCtrl.cpp:98
 msgid "Failed"
 msgstr "Eșuat"
 
-#: src/amule.cpp:344
+#: src/amule.cpp:343
 #, fuzzy, c-format
 msgid "Terminating amuleapi instance with pid '%d' ... "
 msgstr "Se termină instanța amuleweb cu pid '%d' ... "
 
-#: src/amule.cpp:348
+#: src/amule.cpp:347
 #, fuzzy, c-format
 msgid "Killing amuleapi instance with pid '%d' ... "
 msgstr "Se omoară instanța amuleweb cu pid '%d' ... "
 
-#: src/amule.cpp:356
+#: src/amule.cpp:355
 msgid "aMule OnExit: Terminating core."
 msgstr "aMule la ieșire: Se închide nucleul."
 
-#: src/amule.cpp:467
+#: src/amule.cpp:466
 msgid "aMule shutdown completed."
 msgstr "aMule închidere terminată."
 
-#: src/amule.cpp:471
+#: src/amule.cpp:470
 msgid "Memory debug results for aMule exit:"
 msgstr "Rezultatele depanării memoriei pentru ieșirea aMule:"
 
-#: src/amule.cpp:652
+#: src/amule.cpp:651
 #, c-format
 msgid "Binding aMule's peer-to-peer traffic to interface: %s (HTTP updates use the default route)"
 msgstr ""
 
-#: src/amule.cpp:656
+#: src/amule.cpp:655
 #, c-format
 msgid "Binding all network traffic to interface: %s"
 msgstr ""
 
-#: src/amule.cpp:660
+#: src/amule.cpp:659
 #, c-format
 msgid "WARNING: configured network interface '%s' was not found - traffic is NOT bound to it and may leave via the default route. Check the interface name in Preferences."
 msgstr ""
 
-#: src/amule.cpp:666
+#: src/amule.cpp:665
 #, c-format
 msgid "WARNING: binding to network interface '%s' requires elevated privileges and was NOT applied - traffic may leave via the default route. Grant the capability (e.g. 'sudo setcap cap_net_raw+ep' on the aMule binary) or run with sufficient privileges."
 msgstr ""
 
-#: src/amule.cpp:674
+#: src/amule.cpp:673
 #, c-format
 msgid "WARNING: could not bind to network interface '%s' - traffic may leave via the default route."
 msgstr ""
 
-#: src/amule.cpp:733
+#: src/amule.cpp:732
 msgid "Your locale has been changed to System Default due to a configuration change. Sorry."
 msgstr "Limba dumneavoastră a fost schimbată la cea implicită a sistemului datorită schimbării configurației. Regretăm."
 
-#: src/amule.cpp:735 src/amule.cpp:1589 src/CatDialog.cpp:128
+#: src/amule.cpp:734 src/amule.cpp:1581 src/CatDialog.cpp:128
 #: src/CatDialog.cpp:136 src/CatDialog.cpp:149 src/ServerList.cpp:366
 #: src/ServerListCtrl.cpp:152
 msgid "Info"
 msgstr "Info"
 
-#: src/amule.cpp:742
+#: src/amule.cpp:741
 msgid ""
 "\n"
 "EC configuration"
@@ -286,74 +286,74 @@ msgstr ""
 "\n"
 "configurație EC"
 
-#: src/amule.cpp:745
+#: src/amule.cpp:744
 msgid "Password set and external connections enabled."
 msgstr "Configurarea parolei și conexiunile externe sunt activate."
 
-#: src/amule.cpp:755 src/KadDlg.cpp:176 src/KadDlg.cpp:185
-#: src/PrefsUnifiedDlg.cpp:1461 src/SharedFilesCtrl.cpp:476
+#: src/amule.cpp:754 src/KadDlg.cpp:176 src/KadDlg.cpp:185
+#: src/PrefsUnifiedDlg.cpp:1387 src/SharedFilesCtrl.cpp:476
 msgid "WARNING"
 msgstr "ATENȚIE"
 
-#: src/amule.cpp:992
+#: src/amule.cpp:991
 #, fuzzy
 msgid "Network bootstrap"
 msgstr "Rețele"
 
-#: src/amule.cpp:997
+#: src/amule.cpp:996
 msgid ""
 "aMule has detected missing network bootstrap files.\n"
 "Select which ones to download:"
 msgstr ""
 
-#: src/amule.cpp:1006 src/FirstRunWizard.cpp:411
+#: src/amule.cpp:1005 src/FirstRunWizard.cpp:411
 #, fuzzy
 msgid "eD2k server list (server.met)"
 msgstr "S-a găsit %i server în server.met"
 
-#: src/amule.cpp:1013 src/FirstRunWizard.cpp:416
+#: src/amule.cpp:1012 src/FirstRunWizard.cpp:416
 msgid "Kad bootstrap nodes (nodes.dat)"
 msgstr ""
 
-#: src/amule.cpp:1103
+#: src/amule.cpp:1102
 #, c-format
 msgid "web server running on pid %d"
 msgstr "server web rulând pe pid %d"
 
-#: src/amule.cpp:1116
+#: src/amule.cpp:1115
 #, fuzzy
 msgid "You requested to run web server on startup, but the amuleweb binary cannot be run. Please install the package containing aMule web server, or build aMule from source with -DBUILD_WEBSERVER=YES and install it."
 msgstr "Ați solicitat să ruleze la pornire serverul web, dar fișierul binar amuleweb nu poate fi rulat. Instalați pachetul care conține serverul web aMule, sau compilați aMule utilizând --enable-webserver și apoi rulați make install"
 
-#: src/amule.cpp:1121 src/amule.cpp:1185 src/amule.cpp:1299 src/amule.cpp:1601
+#: src/amule.cpp:1120 src/amule.cpp:1177 src/amule.cpp:1291 src/amule.cpp:1593
 #: src/amule-remote-gui.cpp:603 src/amule-remote-gui.cpp:671
 #: src/amule-remote-gui.cpp:709 src/amule-remote-gui.cpp:1282
 #: src/amule-remote-gui.cpp:1345 src/amule-remote-gui.cpp:1372
-#: src/DownloadQueue.cpp:1481 src/PrefsUnifiedDlg.cpp:1247
+#: src/DownloadQueue.cpp:1481
 msgid "ERROR"
 msgstr "EROARE"
 
-#: src/amule.cpp:1174
+#: src/amule.cpp:1166
 #, fuzzy, c-format
 msgid "amuleapi running on pid %d"
 msgstr "server web rulând pe pid %d"
 
-#: src/amule.cpp:1180
+#: src/amule.cpp:1172
 #, fuzzy
 msgid "You requested to run amuleapi on startup, but the amuleapi binary cannot be run. Please install the package containing aMule's REST API server, or build aMule from source with -DBUILD_AMULEAPI=YES and install it."
 msgstr "Ați solicitat să ruleze la pornire serverul web, dar fișierul binar amuleweb nu poate fi rulat. Instalați pachetul care conține serverul web aMule, sau compilați aMule utilizând --enable-webserver și apoi rulați make install"
 
-#: src/amule.cpp:1267
+#: src/amule.cpp:1259
 #, c-format
 msgid "Could not bind ports to the specified address: %s"
 msgstr "Nu se pot lega porturile la adresa specificată: %s"
 
-#: src/amule.cpp:1291
+#: src/amule.cpp:1283
 #, c-format
 msgid "Port %u is not available. You will be LOWID\n"
 msgstr "Portul %u nu este disponibil. Veți fi LOWID\n"
 
-#: src/amule.cpp:1296
+#: src/amule.cpp:1288
 #, c-format
 msgid ""
 "Port %u is not available!\n"
@@ -368,48 +368,48 @@ msgstr ""
 "\n"
 "Verificați rețeaua pentru a vă asigura că portul este deschis pentru intrare și ieșire."
 
-#: src/amule.cpp:1393
+#: src/amule.cpp:1385
 msgid "Failed to create OnlineSig File"
 msgstr "A eșuat crearea fișierului Semnătură Online"
 
-#: src/amule.cpp:1401
+#: src/amule.cpp:1393
 msgid "Failed to create aMule OnlineSig File"
 msgstr "A eșuat crearea fișierului aMule Semnătură Online"
 
-#: src/amule.cpp:1564
+#: src/amule.cpp:1556
 msgid "The selected locale seems not to be installed on your box. (Note: I'll try to set it anyway)"
 msgstr "Localizarea selectată se pare că nu este instalată pe computer. (Notă: Se va încerca configurarea acesteia oricum)"
 
-#: src/amule.cpp:1574
+#: src/amule.cpp:1566
 #, c-format
 msgid "This is the first time you run aMule %s"
 msgstr "Aceasta este prima dată când rulați aMule %s"
 
-#: src/amule.cpp:1577
+#: src/amule.cpp:1569
 msgid "This version is a testing version, updated daily, and\n"
 msgstr "Această versiune este o versiune de testare, actualizată zilnic și\n"
 
-#: src/amule.cpp:1578
+#: src/amule.cpp:1570
 msgid "we give no warranty it won't break anything, burn your house,\n"
 msgstr "nu vă dăm nici un fel de garanție dacă nu se va strica nimic, ardeți-vă casa,\n"
 
-#: src/amule.cpp:1579
+#: src/amule.cpp:1571
 msgid "or kill your dog. But it *should* be safe to use anyway.\n"
 msgstr "sau omorâți-vă câinele. Dar * ar trebui să fie * sigur de utilizat oricum.\n"
 
-#: src/amule.cpp:1584
+#: src/amule.cpp:1576
 msgid "More information, support and new releases can found at our homepage,\n"
 msgstr "Mai multe informații, suport și versiuni noi pot fi găsite pe pagina noastră web,\n"
 
-#: src/amule.cpp:1585
+#: src/amule.cpp:1577
 msgid "at https://amule-org.github.io, or in our IRC channel #aMule at irc.libera.chat.\n"
 msgstr "la https://amule-org.github.io, sau în canalul nostru IRC #aMule at irc.libera.chat.\n"
 
-#: src/amule.cpp:1587
+#: src/amule.cpp:1579
 msgid "Feel free to report any bugs to https://github.com/amule-org/amule/issues"
 msgstr "Raportați orice fel de probleme la https://github.com/amule-org/amule/issues"
 
-#: src/amule.cpp:1599
+#: src/amule.cpp:1591
 msgid ""
 "The folder for Online Signature files you specified is INVALID!\n"
 " OnlineSignature will be DISABLED until you fix it on preferences."
@@ -417,137 +417,137 @@ msgstr ""
 "Dosarul specificat pentru Semnătura Online NU ESTE VALID!\n"
 "Semnătura Online va fi DEZACTIVATĂ până va fi reparată problema în preferințe."
 
-#: src/amule.cpp:1662
+#: src/amule.cpp:1654
 msgid "Server hostname notified"
 msgstr "S-a notificat numele serverului"
 
-#: src/amule.cpp:2039
+#: src/amule.cpp:2031
 #, c-format
 msgid "Disk space preallocation for file '%s' failed: %s"
 msgstr "Prealocarea spațiului pe disc pentru fișierul '%s' a eșuat: %s"
 
-#: src/amule.cpp:2168
+#: src/amule.cpp:2160
 msgid "ERROR: can't open logfile"
 msgstr "EROARE: nu se poate deschide fișierul jurnal"
 
-#: src/amule.cpp:2172
+#: src/amule.cpp:2164
 msgid "WARNING: logfile is empty. Something is wrong."
 msgstr "ATENȚIE: fișierul jurnal este gol. Ceva este greșit."
 
-#: src/amule.cpp:2189
+#: src/amule.cpp:2181
 msgid "Log has been reset"
 msgstr "Jurnalul a fost resetat"
 
-#: src/amule.cpp:2213
+#: src/amule.cpp:2205
 #, c-format
 msgid "ServerMessage: %s"
 msgstr "Mesaj server: %s"
 
-#: src/amule.cpp:2256 src/IP2Country.cpp:220 src/IPFilter.cpp:514
+#: src/amule.cpp:2248 src/IP2Country.cpp:220 src/IPFilter.cpp:514
 #: src/ServerList.cpp:875
 #, c-format
 msgid "Skipped download of %s, because requested file is not newer."
 msgstr "Se omite descărcarea a %s, fiindcă fișierul solicitat nu este mai nou."
 
-#: src/amule.cpp:2259
+#: src/amule.cpp:2251
 msgid "Failed to download the nodes list."
 msgstr "A eșuat descărcarea listei de noduri."
 
-#: src/amule.cpp:2322
+#: src/amule.cpp:2314
 msgid "Failed to open the downloaded version check file"
 msgstr "A eșuat deschiderea fișierului de verificare a versiunii"
 
-#: src/amule.cpp:2325 src/amule.cpp:2344
+#: src/amule.cpp:2317 src/amule.cpp:2336
 msgid "Corrupted version check file"
 msgstr "Fișierul de verificare a versiunii este corupt"
 
-#: src/amule.cpp:2367
+#: src/amule.cpp:2359
 msgid "You are using an outdated version of aMule!"
 msgstr "Utilizați o versiune învechită de aMule!"
 
-#: src/amule.cpp:2369
+#: src/amule.cpp:2361
 #, c-format
 msgid "Your aMule version is %i.%i.%i and the latest version is %li.%li.%li"
 msgstr "Versiunea dumneavoastră de aMule este %i.%i.%i iar ultima versiune este %li.%li.%li"
 
-#: src/amule.cpp:2373
+#: src/amule.cpp:2365
 msgid "The latest version can always be found at https://github.com/amule-org/amule/releases/latest"
 msgstr "Ultima versiune poate fi găsită mereu la https://github.com/amule-org/amule/releases/latest"
 
-#: src/amule.cpp:2376
+#: src/amule.cpp:2368
 #, c-format
 msgid "WARNING: Your aMuled version is outdated: %i.%i.%i < %li.%li.%li"
 msgstr "ATENȚIE: Versiunea dumneavoastră aMuled este învechită: %i.%i.%i < %li.%li.%li"
 
-#: src/amule.cpp:2382
+#: src/amule.cpp:2374
 msgid "Your copy of aMule is up to date."
 msgstr "Copia dumneavoastră aMule este actualizată."
 
-#: src/amule.cpp:2389
+#: src/amule.cpp:2381
 msgid "Failed to download the version check file"
 msgstr "A eșuat descărcarea fișierului de verificare a versiunii"
 
-#: src/amule.cpp:2558 src/amule-remote-gui.cpp:1133
+#: src/amule.cpp:2550 src/amule-remote-gui.cpp:1133
 #, c-format
 msgid "Users: %s | Files: %s"
 msgstr "Utilizatori: %s | Fișiere: %s"
 
-#: src/amule.cpp:2559 src/amule-remote-gui.cpp:1134
+#: src/amule.cpp:2551 src/amule-remote-gui.cpp:1134
 #, c-format
 msgid "Users: E: %s K: %s | Files: E: %s K: %s"
 msgstr "Utilizatori: E: %s K: %s | Fișiere: E: %s K: %s"
 
-#: src/amule.cpp:2573 src/amule-remote-gui.cpp:1147
+#: src/amule.cpp:2565 src/amule-remote-gui.cpp:1147
 msgid "No networks selected"
 msgstr "Nu este selectată nicio rețea"
 
-#: src/amule.cpp:2641 src/TextClient.cpp:903
+#: src/amule.cpp:2633 src/TextClient.cpp:903
 msgid "with LowID"
 msgstr "cu LowID"
 
-#: src/amule.cpp:2641 src/TextClient.cpp:904
+#: src/amule.cpp:2633 src/TextClient.cpp:904
 msgid "with HighID"
 msgstr "cu HighID"
 
-#: src/amule.cpp:2643
+#: src/amule.cpp:2635
 #, c-format
 msgid "Connected to %s %s"
 msgstr "Conectat la %s %s"
 
-#: src/amule.cpp:2648
+#: src/amule.cpp:2640
 #, c-format
 msgid "Connecting to %s"
 msgstr "Conectare la %s"
 
-#: src/amule.cpp:2650
+#: src/amule.cpp:2642
 msgid "Disconnected from eD2k"
 msgstr "Deconectat de la eD2k"
 
-#: src/amule.cpp:2659
+#: src/amule.cpp:2651
 msgid "Kad started."
 msgstr "Kad este pornit."
 
-#: src/amule.cpp:2661
+#: src/amule.cpp:2653
 msgid "Kad stopped."
 msgstr "Kad este oprit."
 
-#: src/amule.cpp:2669
+#: src/amule.cpp:2661
 msgid "Connected to Kad (ok)"
 msgstr "Conectat la Kad (ok)"
 
-#: src/amule.cpp:2671
+#: src/amule.cpp:2663
 msgid "Connected to Kad (firewalled)"
 msgstr "Conectat la Kad (prin firewall)"
 
-#: src/amule.cpp:2675
+#: src/amule.cpp:2667
 msgid "Disconnected from Kad"
 msgstr "Deconectat de la Kad"
 
-#: src/amule.cpp:2707
+#: src/amule.cpp:2699
 msgid "Kad network cannot be used if UDP port is disabled on preferences, not starting."
 msgstr "Nu se poate utiliza rețeaua Kad dacă portul UDP este dezactivat în preferințe, nu se pornește."
 
-#: src/amule.cpp:2711
+#: src/amule.cpp:2703
 msgid "Kad network disabled on preferences, not connecting."
 msgstr "Rețeaua Kad este dezactivată în preferințe, nu se conectează."
 
@@ -573,68 +573,30 @@ msgstr "Nu se poate crea fișierul Pid"
 msgid "ERROR: %s"
 msgstr "EROARE: %s"
 
-#: src/amuleDlg.cpp:250
+#: src/amuleDlg.cpp:236
 #, c-format
 msgid "This is aMule %s based on eMule."
 msgstr "Acesta este aMule %s bazat pe eMule."
 
-#: src/amuleDlg.cpp:251
+#: src/amuleDlg.cpp:237
 #, c-format
 msgid "Running on %s"
 msgstr "Rulând pe %s"
 
-#: src/amuleDlg.cpp:253
+#: src/amuleDlg.cpp:239
 msgid "Visit https://github.com/amule-org/amule/releases/latest to check if a new version is available."
 msgstr "Vizitați https://github.com/amule-org/amule/releases/latest pentru a verifica dacă este disponibilă o nouă versiune."
 
-#: src/amuleDlg.cpp:282
+#: src/amuleDlg.cpp:268
 msgid "FATAL ERROR: Failed to create Timer"
 msgstr "EROARE FATALĂ: A eșuat crearea temporizatorului"
 
-#: src/amuleDlg.cpp:361 src/amuleDlg.cpp:1810 src/amuleDlg.cpp:2056
-#: src/muuli_wdr.cpp:1492 src/muuli_wdr.cpp:3439
-msgid "Networks"
-msgstr "Rețele"
-
-#: src/amuleDlg.cpp:362 src/amuleDlg.cpp:1816 src/muuli_wdr.cpp:3440
-msgid "Searches"
-msgstr "Căutări"
-
-#: src/amuleDlg.cpp:363 src/amuleDlg.cpp:1822 src/DownloadListCtrl.cpp:740
-#: src/muuli_wdr.cpp:392 src/muuli_wdr.cpp:1585 src/muuli_wdr.cpp:3441
-#: src/Statistics.cpp:829
-msgid "Downloads"
-msgstr "Descărcări"
-
-#: src/amuleDlg.cpp:364 src/amuleDlg.cpp:1828 src/muuli_wdr.cpp:3315
-msgid "Shared files"
-msgstr "Fișiere partajate"
-
-#: src/amuleDlg.cpp:365 src/amuleDlg.cpp:1834 src/muuli_wdr.cpp:2947
-#: src/muuli_wdr.cpp:3397 src/muuli_wdr.cpp:3444
-msgid "Messages"
-msgstr "Mesaje"
-
-#: src/amuleDlg.cpp:366 src/amuleDlg.cpp:1840 src/muuli_wdr.cpp:3445
-#: src/PrefsUnifiedDlg.cpp:314 src/Statistics.cpp:779 src/Statistics.cpp:1235
-msgid "Statistics"
-msgstr "Statistici"
-
-#: src/amuleDlg.cpp:368 src/amuleDlg.cpp:1847 src/muuli_wdr.cpp:3447
-#: src/PrefsUnifiedDlg.cpp:330 src/utils/wxCas/src/wxcasprefs.cpp:39
-msgid "Preferences"
-msgstr "Preferințe"
-
-#: src/amuleDlg.cpp:371
-msgid "Navigate"
-msgstr ""
-
-#: src/amuleDlg.cpp:657
+#: src/amuleDlg.cpp:592
 #, fuzzy
 msgid "New version available"
 msgstr "Indisponibil"
 
-#: src/amuleDlg.cpp:661
+#: src/amuleDlg.cpp:596
 #, fuzzy, c-format
 msgid ""
 "A new version of aMule (%s) is available.\n"
@@ -644,185 +606,218 @@ msgid ""
 "Would you like to open the download page?"
 msgstr "Ultima versiune poate fi găsită mereu la https://github.com/amule-org/amule/releases/latest"
 
-#: src/amuleDlg.cpp:743
+#: src/amuleDlg.cpp:678
 msgid "aMule dialog destroyed"
 msgstr "dialogul aMule distrus"
 
-#: src/amuleDlg.cpp:766 src/DataToText.cpp:68 src/IPFilter.cpp:547
+#: src/amuleDlg.cpp:701 src/DataToText.cpp:68 src/IPFilter.cpp:547
 msgid "Connecting"
 msgstr "Se conecteză"
 
-#: src/amuleDlg.cpp:958
+#: src/amuleDlg.cpp:893
 msgid "eD2k: Connecting"
 msgstr "eD2k: Se conectează"
 
-#: src/amuleDlg.cpp:962
+#: src/amuleDlg.cpp:897
 msgid "eD2k: Disconnected"
 msgstr "eD2k: Deconectat"
 
-#: src/amuleDlg.cpp:968
+#: src/amuleDlg.cpp:903
 msgid "Kad: Firewalled"
 msgstr "Kad: Prin firewall"
 
-#: src/amuleDlg.cpp:972
+#: src/amuleDlg.cpp:907
 msgid "Kad: Connected"
 msgstr "Kad: Conectat"
 
-#: src/amuleDlg.cpp:977
+#: src/amuleDlg.cpp:912
 msgid "Kad: Connecting"
 msgstr "Kad: Se conectează"
 
-#: src/amuleDlg.cpp:981
+#: src/amuleDlg.cpp:916
 msgid "Kad: Off"
 msgstr "Kad: Închis"
 
-#: src/amuleDlg.cpp:1029 src/DownloadListCtrl.cpp:505
+#: src/amuleDlg.cpp:964 src/DownloadListCtrl.cpp:505
 #: src/DownloadListCtrl.cpp:749 src/FriendListCtrl.cpp:180
 #: src/muuli_wdr.cpp:731 src/muuli_wdr.cpp:782 src/muuli_wdr.cpp:846
-#: src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2252 src/muuli_wdr.cpp:2337
-#: src/muuli_wdr.cpp:3085 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
+#: src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2224 src/muuli_wdr.cpp:2309
+#: src/muuli_wdr.cpp:3057 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
 #: src/ServerListCtrl.cpp:606 src/TransferWnd.cpp:378
 #: src/utils/wxCas/src/wxcasprefs.cpp:235
 msgid "Cancel"
 msgstr "Anulare"
 
-#: src/amuleDlg.cpp:1030
+#: src/amuleDlg.cpp:965
 msgid "Stop the current connection attempts"
 msgstr "Oprește încercările curente de conectare"
 
-#: src/amuleDlg.cpp:1035 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976
-#: src/muuli_wdr.cpp:2475
+#: src/amuleDlg.cpp:970 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976
+#: src/muuli_wdr.cpp:2447
 msgid "Disconnect"
 msgstr "Deconectează"
 
-#: src/amuleDlg.cpp:1036
+#: src/amuleDlg.cpp:971
 msgid "Disconnect from the currently connected networks"
 msgstr "Deconectează de la rețelele curent conectate"
 
-#: src/amuleDlg.cpp:1041 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979
-#: src/muuli_wdr.cpp:2630 src/muuli_wdr.cpp:3082 src/muuli_wdr.cpp:3437
+#: src/amuleDlg.cpp:976 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979
+#: src/muuli_wdr.cpp:2602 src/muuli_wdr.cpp:3054 src/muuli_wdr.cpp:3409
 msgid "Connect"
 msgstr "Conectează"
 
-#: src/amuleDlg.cpp:1042
+#: src/amuleDlg.cpp:977
 msgid "Connect to the currently enabled networks"
 msgstr "Conectează la rețelele activate curent"
 
-#: src/amuleDlg.cpp:1154
+#: src/amuleDlg.cpp:1089
 #, fuzzy, c-format
 msgid "Up: %.1f%s (%.1f) | Down: %.1f%s (%.1f)"
 msgstr "În: %.1f(%.1f) | Desc: %.1f(%.1f)"
 
-#: src/amuleDlg.cpp:1156 src/amuleDlg.cpp:1158 src/amuleDlg.cpp:1162
-#: src/amuleDlg.cpp:1164 src/amuleDlg.cpp:1175 src/amuleDlg.cpp:1177
+#: src/amuleDlg.cpp:1091 src/amuleDlg.cpp:1093 src/amuleDlg.cpp:1097
+#: src/amuleDlg.cpp:1099 src/amuleDlg.cpp:1110 src/amuleDlg.cpp:1112
 #: src/MuleTrayIcon.cpp:796 src/MuleTrayIcon.cpp:799
 #, fuzzy
 msgid " MB/s"
 msgstr "MO/s"
 
-#: src/amuleDlg.cpp:1156 src/amuleDlg.cpp:1158 src/amuleDlg.cpp:1162
-#: src/amuleDlg.cpp:1164 src/amuleDlg.cpp:1175 src/amuleDlg.cpp:1177
+#: src/amuleDlg.cpp:1091 src/amuleDlg.cpp:1093 src/amuleDlg.cpp:1097
+#: src/amuleDlg.cpp:1099 src/amuleDlg.cpp:1110 src/amuleDlg.cpp:1112
 #: src/MuleTrayIcon.cpp:796 src/MuleTrayIcon.cpp:799
 #: src/utils/wxCas/src/wxcasframe.cpp:1041
 msgid " kB/s"
 msgstr " kB/s"
 
-#: src/amuleDlg.cpp:1161
+#: src/amuleDlg.cpp:1096
 #, fuzzy, c-format
 msgid "Up: %.1f%s | Down: %.1f%s"
 msgstr "În: %.1f | Desc: %.1f"
 
-#: src/amuleDlg.cpp:1193
+#: src/amuleDlg.cpp:1128
 #, c-format
 msgid "aMule (%s | Connected)"
 msgstr "aMule (%s | Conectat)"
 
-#: src/amuleDlg.cpp:1195
+#: src/amuleDlg.cpp:1130
 #, c-format
 msgid "aMule (%s | Disconnected)"
 msgstr "aMule (%s | Deconectat)"
 
-#: src/amuleDlg.cpp:1248
+#: src/amuleDlg.cpp:1183
 #, c-format
 msgid "Do you really want to exit %s?"
 msgstr "Sigur doriți să închideți %s?"
 
-#: src/amuleDlg.cpp:1250
+#: src/amuleDlg.cpp:1185
 msgid "Exit confirmation"
 msgstr "Confirmare închidere"
 
-#: src/amuleDlg.cpp:1613
+#: src/amuleDlg.cpp:1548
 msgid "Launch Command: "
 msgstr "Lansare comandă:"
 
-#: src/amuleDlg.cpp:1632 src/muuli_wdr.cpp:1972 src/Preferences.cpp:979
+#: src/amuleDlg.cpp:1567 src/muuli_wdr.cpp:1971 src/Preferences.cpp:951
 msgid "- default -"
 msgstr "- implicit -"
 
-#: src/amuleDlg.cpp:1660
+#: src/amuleDlg.cpp:1595
 #, c-format
 msgid "Skin directory '%s' does not exist"
 msgstr "Directorul aspectului aplicației '%s' nu există"
 
-#: src/amuleDlg.cpp:1663
+#: src/amuleDlg.cpp:1598
 #, c-format
 msgid "WARNING: Unable to open skin file '%s' for read"
 msgstr "ATENȚIE: Nu se poate deschide fișierul aspect '%s' pentru citit"
 
-#: src/amuleDlg.cpp:1814 src/muuli_wdr.cpp:3439
+#: src/amuleDlg.cpp:1722 src/amuleDlg.cpp:1968 src/muuli_wdr.cpp:1485
+#: src/muuli_wdr.cpp:3411
+msgid "Networks"
+msgstr "Rețele"
+
+#: src/amuleDlg.cpp:1726 src/muuli_wdr.cpp:3411
 msgid "Networks Window"
 msgstr "Fereastra rețelelor"
 
-#: src/amuleDlg.cpp:1820 src/muuli_wdr.cpp:3440
+#: src/amuleDlg.cpp:1728 src/muuli_wdr.cpp:3412
+msgid "Searches"
+msgstr "Căutări"
+
+#: src/amuleDlg.cpp:1732 src/muuli_wdr.cpp:3412
 msgid "Searches Window"
 msgstr "Fereastra căutărilor"
 
-#: src/amuleDlg.cpp:1826 src/muuli_wdr.cpp:3441
+#: src/amuleDlg.cpp:1734 src/DownloadListCtrl.cpp:740 src/muuli_wdr.cpp:392
+#: src/muuli_wdr.cpp:1578 src/muuli_wdr.cpp:3413 src/Statistics.cpp:829
+msgid "Downloads"
+msgstr "Descărcări"
+
+#: src/amuleDlg.cpp:1738 src/muuli_wdr.cpp:3413
 msgid "Downloads Window"
 msgstr "Fereastra descărcărilor"
 
-#: src/amuleDlg.cpp:1832 src/muuli_wdr.cpp:3443
+#: src/amuleDlg.cpp:1740 src/muuli_wdr.cpp:3287
+msgid "Shared files"
+msgstr "Fișiere partajate"
+
+#: src/amuleDlg.cpp:1744 src/muuli_wdr.cpp:3415
 msgid "Shared Files Window"
 msgstr "Fereastra fișierelor partajate"
 
-#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3444
+#: src/amuleDlg.cpp:1746 src/muuli_wdr.cpp:2919 src/muuli_wdr.cpp:3369
+#: src/muuli_wdr.cpp:3416
+msgid "Messages"
+msgstr "Mesaje"
+
+#: src/amuleDlg.cpp:1750 src/muuli_wdr.cpp:3416
 msgid "Messages Window"
 msgstr "Fereastra mesajelor"
 
-#: src/amuleDlg.cpp:1844 src/muuli_wdr.cpp:3445
+#: src/amuleDlg.cpp:1752 src/muuli_wdr.cpp:3417 src/PrefsUnifiedDlg.cpp:312
+#: src/Statistics.cpp:779 src/Statistics.cpp:1235
+msgid "Statistics"
+msgstr "Statistici"
+
+#: src/amuleDlg.cpp:1756 src/muuli_wdr.cpp:3417
 msgid "Statistics Graph Window"
 msgstr "Fereastra graficului statisticilor"
 
-#: src/amuleDlg.cpp:1851 src/muuli_wdr.cpp:3447
+#: src/amuleDlg.cpp:1759 src/muuli_wdr.cpp:3419 src/PrefsUnifiedDlg.cpp:328
+#: src/utils/wxCas/src/wxcasprefs.cpp:39
+msgid "Preferences"
+msgstr "Preferințe"
+
+#: src/amuleDlg.cpp:1763 src/muuli_wdr.cpp:3419
 msgid "Preferences Settings Window"
 msgstr "Fereastra configurare preferințe"
 
-#: src/amuleDlg.cpp:1854 src/muuli_wdr.cpp:3448
+#: src/amuleDlg.cpp:1766 src/muuli_wdr.cpp:3420
 msgid "Import"
 msgstr "Importă"
 
-#: src/amuleDlg.cpp:1858 src/muuli_wdr.cpp:3448
+#: src/amuleDlg.cpp:1770 src/muuli_wdr.cpp:3420
 msgid "The partfile importer tool"
 msgstr "Unealta de importat fișiere parțiale"
 
-#: src/amuleDlg.cpp:1861 src/muuli_wdr.cpp:3449
+#: src/amuleDlg.cpp:1773 src/muuli_wdr.cpp:3421
 #: src/utils/aLinkCreator/src/alcframe.cpp:262
 msgid "About"
 msgstr "Despre"
 
-#: src/amuleDlg.cpp:1861 src/muuli_wdr.cpp:3449
+#: src/amuleDlg.cpp:1773 src/muuli_wdr.cpp:3421
 msgid "About/Help"
 msgstr "Despre/Ajutor"
 
-#: src/amuleDlg.cpp:2059
+#: src/amuleDlg.cpp:1971
 msgid "eD2k network"
 msgstr "Rețea eD2k"
 
-#: src/amuleDlg.cpp:2062
+#: src/amuleDlg.cpp:1974
 msgid "Kad network"
 msgstr "Rețea Kad"
 
-#: src/amuleDlg.cpp:2062
+#: src/amuleDlg.cpp:1974
 msgid "No network"
 msgstr "Nicio rețea"
 
@@ -952,7 +947,7 @@ msgstr "Fișierul nu este găsit."
 msgid "The core rejected these shared folders:%s"
 msgstr ""
 
-#: src/amule-remote-gui.cpp:1336 src/ExternalConn.cpp:2346
+#: src/amule-remote-gui.cpp:1336 src/ExternalConn.cpp:2345
 msgid "Invalid link or already on list."
 msgstr "Legătură nevalidă sau care este deja în listă."
 
@@ -968,7 +963,7 @@ msgstr "Nu se poate crea directorul '%s' pentru categoria '%s', se păstrează d
 #: src/ClientDetailDialog.cpp:123 src/DataToText.cpp:61 src/DataToText.cpp:86
 #: src/DataToText.cpp:101 src/DataToText.cpp:136 src/DataToText.cpp:165
 #: src/DownloadListCtrl.cpp:1172 src/DownloadListCtrl.cpp:1185
-#: src/DownloadListCtrl.cpp:1196 src/ExternalConn.cpp:609
+#: src/DownloadListCtrl.cpp:1196 src/ExternalConn.cpp:608
 #: src/FileDetailDialog.cpp:203 src/FileDetailDialog.cpp:235
 #: src/FileDetailDialog.cpp:242 src/GenericClientListCtrl.cpp:1171
 #: src/GenericClientListCtrl.cpp:1182 src/GenericClientListCtrl.cpp:1192
@@ -1360,19 +1355,19 @@ msgstr "Automat [În]"
 msgid "Very low"
 msgstr "Foarte joasă"
 
-#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:743 src/muuli_wdr.cpp:2303
+#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:743 src/muuli_wdr.cpp:2275
 #: src/ServerListCtrl.cpp:263 src/ServerListCtrl.cpp:456
 #: src/SharedFilesCtrl.cpp:145
 msgid "Low"
 msgstr "Joasă"
 
-#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:744 src/muuli_wdr.cpp:2304
+#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:744 src/muuli_wdr.cpp:2276
 #: src/ServerListCtrl.cpp:266 src/ServerListCtrl.cpp:457
 #: src/SharedFilesCtrl.cpp:146
 msgid "Normal"
 msgstr "Normal"
 
-#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:745 src/muuli_wdr.cpp:2305
+#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:745 src/muuli_wdr.cpp:2277
 #: src/ServerListCtrl.cpp:269 src/ServerListCtrl.cpp:458
 #: src/SharedFilesCtrl.cpp:147
 msgid "High"
@@ -1464,8 +1459,8 @@ msgstr "Server local"
 msgid "Remote Server"
 msgstr "Server distant"
 
-#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3202
-#: src/SearchDlg.cpp:119 src/TextClient.cpp:911
+#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3174
+#: src/SearchDlg.cpp:111 src/TextClient.cpp:911
 msgid "Kad"
 msgstr "Kad"
 
@@ -1536,7 +1531,7 @@ msgstr "Parte"
 msgid "Size"
 msgstr "Dimensiune"
 
-#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3269
+#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3241
 msgid "Transferred"
 msgstr "Transferat"
 
@@ -1594,7 +1589,7 @@ msgstr ""
 "Feedback de la: %s (%s)\n"
 "\n"
 
-#: src/DownloadListCtrl.cpp:746 src/muuli_wdr.cpp:2306
+#: src/DownloadListCtrl.cpp:746 src/muuli_wdr.cpp:2278
 #: src/SharedFilesCtrl.cpp:150
 msgid "Auto"
 msgstr "Automat"
@@ -1632,7 +1627,7 @@ msgid "Extended Options"
 msgstr "Opțiuni extinse"
 
 #: src/DownloadListCtrl.cpp:770 src/DownloadListCtrl.cpp:822
-#: src/muuli_wdr.cpp:1790
+#: src/muuli_wdr.cpp:1789
 msgid "Preview"
 msgstr "Previzualizează"
 
@@ -1809,232 +1804,227 @@ msgstr[2] ""
 msgid "Invalid eD2k link! ERROR: %s"
 msgstr "Legătură eD2k nevalidă! EROARE: %s"
 
-#: src/ExternalConn.cpp:380
+#: src/ExternalConn.cpp:379
 msgid "Client sent packet after authentication failed."
 msgstr "Clientul a trimis pachetul după eșuarea autentificării."
 
-#: src/ExternalConn.cpp:397
+#: src/ExternalConn.cpp:396
 msgid "External connection closed."
 msgstr "Conexiune externă închisă."
 
-#: src/ExternalConn.cpp:474
+#: src/ExternalConn.cpp:473
 msgid "External connections disabled due to empty password!"
 msgstr "Conexiunile externe sunt dezactivate datorită lipsei parolei!"
 
-#: src/ExternalConn.cpp:495
+#: src/ExternalConn.cpp:494
 msgid "External connections disabled in config file"
 msgstr "Conexiunile externe sunt dezactivate în fișierul de configurare"
 
-#: src/ExternalConn.cpp:576
+#: src/ExternalConn.cpp:575
 msgid "New external connection accepted"
 msgstr "Conexiune externă nouă acceptată"
 
-#: src/ExternalConn.cpp:579
+#: src/ExternalConn.cpp:578
 msgid "ERROR: couldn't accept a new external connection"
 msgstr "EROARE: nu se poate accepta o nouă conexiune externă"
 
-#: src/ExternalConn.cpp:596
+#: src/ExternalConn.cpp:595
 msgid "External connection refused due to empty password in preferences!"
 msgstr "Conexiunea externă este refuzată datorită lipsei parolei în preferințe!"
 
-#: src/ExternalConn.cpp:608
+#: src/ExternalConn.cpp:607
 #, c-format
 msgid "Connecting client: %s %s"
 msgstr "Se conectează clientul: %s %s"
 
-#: src/ExternalConn.cpp:610
+#: src/ExternalConn.cpp:609
 msgid "Unknown version"
 msgstr "Versiune necunoscută"
 
-#: src/ExternalConn.cpp:623
+#: src/ExternalConn.cpp:622
 msgid "Incorrect EC version ID, there might be binary incompatibility. Use core and remote from same snapshot."
 msgstr "Incorecta EC versiune ID, poate fi o incompatibilitate de aplicații. Utilizați nucleul și aplicația distantă de la aceiași versiune."
 
-#: src/ExternalConn.cpp:631
+#: src/ExternalConn.cpp:630
 msgid "You cannot connect to a release version from an arbitrary development snapshot! *sigh* possible crash prevented"
 msgstr "Nu vă puteți conecta la o versiune lansată dintr-o versiune în dezvoltare arbitrară! *uf* se pot preveni disfuncțiile"
 
-#: src/ExternalConn.cpp:714
+#: src/ExternalConn.cpp:713
 msgid "Invalid protocol version."
 msgstr "Versiune protocol nevalidă."
 
-#: src/ExternalConn.cpp:720
+#: src/ExternalConn.cpp:719
 msgid "Missing protocol version tag."
 msgstr "Lipsește eticheta versiunii protocolului."
 
-#: src/ExternalConn.cpp:728
+#: src/ExternalConn.cpp:727
 msgid "Authentication failed: invalid hash specified as EC password."
 msgstr "Autentificare eșuată: indexul specificat este nevalid ca parolă EC."
 
-#: src/ExternalConn.cpp:776
+#: src/ExternalConn.cpp:775
 msgid "Authentication failed: wrong password."
 msgstr "Autentificare eșuată: parolă greșită."
 
-#: src/ExternalConn.cpp:778
+#: src/ExternalConn.cpp:777
 msgid "Authentication failed: missing password."
 msgstr "Autentificare eșuată: lipsă parolă."
 
-#: src/ExternalConn.cpp:789
+#: src/ExternalConn.cpp:788
 msgid "Invalid request, please authenticate first."
 msgstr "Solicitare nevalidă, autentificați-vă întâi."
 
-#: src/ExternalConn.cpp:794
+#: src/ExternalConn.cpp:793
 msgid "Access granted."
 msgstr "Acces asigurat."
 
-#: src/ExternalConn.cpp:802
+#: src/ExternalConn.cpp:801
 #, c-format
 msgid "Sent error message \"%s\" to client."
 msgstr "Trimite mesajul de eroare \"%s\" la client."
 
-#: src/ExternalConn.cpp:807
+#: src/ExternalConn.cpp:806
 #, c-format
 msgid "Unauthorized access attempt from %s. Connection closed."
 msgstr "Încercare neautorizată de acces de la %s. Conexiune închisă."
 
-#: src/ExternalConn.cpp:1420
+#: src/ExternalConn.cpp:1419
 #, c-format
 msgid "Remote PartFile command failed: FileHash not found: %s"
 msgstr "A eșuat comanda distantă a fișierului parțial: Nu a fost găsit fișierul index: %s"
 
-#: src/ExternalConn.cpp:1424
+#: src/ExternalConn.cpp:1423
 #, c-format
 msgid "FileHash not found: %s"
 msgstr "Indexul fișierului  nu este găsit: %s"
 
-#: src/ExternalConn.cpp:1471 src/ExternalConn.cpp:1559
-#: src/ExternalConn.cpp:1680
+#: src/ExternalConn.cpp:1470 src/ExternalConn.cpp:1558
+#: src/ExternalConn.cpp:1679
 msgid "OOPS! OpCode processing error!"
 msgstr "OOPS! Eroare la procesarea OpCode!"
 
-#: src/ExternalConn.cpp:1502
+#: src/ExternalConn.cpp:1501
 msgid "Server not added"
 msgstr "Serverul nu este adăugat"
 
-#: src/ExternalConn.cpp:1521
+#: src/ExternalConn.cpp:1520
 #, c-format
 msgid "server not found: %s"
 msgstr "serverul nu este găsit: %s"
 
-#: src/ExternalConn.cpp:1538
+#: src/ExternalConn.cpp:1537
 msgid "need to define server to be removed"
 msgstr "trebuie să definiți un server pentru a fi eliminat"
 
-#: src/ExternalConn.cpp:1553
+#: src/ExternalConn.cpp:1552
 msgid "eD2k is disabled in preferences."
 msgstr "eD2k este dezactivat în preferințe."
 
-#: src/ExternalConn.cpp:1658
+#: src/ExternalConn.cpp:1657
 #, fuzzy
 msgid "Friend not found."
 msgstr "Fișierul nu este găsit."
 
-#: src/ExternalConn.cpp:1668
+#: src/ExternalConn.cpp:1667
 #, fuzzy
 msgid "Client not found."
 msgstr "Fișierul nu este găsit."
 
-#: src/ExternalConn.cpp:1674
+#: src/ExternalConn.cpp:1673
 msgid "EC_TAG_FRIEND_SHARED requires EC_TAG_FRIEND or EC_TAG_CLIENT."
 msgstr ""
 
-#: src/ExternalConn.cpp:1992
+#: src/ExternalConn.cpp:1991
 msgid "WebSearch from remote interface makes no sense."
 msgstr "Nu are nici un sens căutarea web de pe interfața distantă."
 
-#: src/ExternalConn.cpp:2027
+#: src/ExternalConn.cpp:2026
 msgid "Search in progress. Refetch results in a moment!"
 msgstr "Căutare în desfășurare. Se readuc rezultatele imediat!"
 
-#: src/ExternalConn.cpp:2266
+#: src/ExternalConn.cpp:2265
 msgid "No points for graph."
 msgstr "Nici un punct pentru grafic."
 
-#: src/ExternalConn.cpp:2276
+#: src/ExternalConn.cpp:2275
 msgid "Your client is not configured for this detail level."
 msgstr "Clientul dumneavoastră nu este configurat pentru acest nivel detaliat."
 
-#: src/ExternalConn.cpp:2303
+#: src/ExternalConn.cpp:2302
 msgid "External Connection: shutdown requested"
 msgstr "Conexiune externă: închidere solicitată"
 
-#: src/ExternalConn.cpp:2315
+#: src/ExternalConn.cpp:2314
 msgid "Already shutting down."
 msgstr "Deja se închide."
 
-#: src/ExternalConn.cpp:2333
+#: src/ExternalConn.cpp:2332
 #, c-format
 msgid "ExternalConn: adding link '%s'."
 msgstr "Conexiune externă: se adaugă legătura '%s'."
 
-#: src/ExternalConn.cpp:2351
+#: src/ExternalConn.cpp:2350
 #, fuzzy, c-format
 msgid "%d of %d links failed (invalid or already on list)."
 msgstr "Legătură nevalidă sau care este deja în listă."
 
-#: src/ExternalConn.cpp:2374
+#: src/ExternalConn.cpp:2373
 msgid "Version check throttled; try again shortly."
 msgstr ""
 
-#: src/ExternalConn.cpp:2379
+#: src/ExternalConn.cpp:2378
 msgid "Version check is not available on this daemon."
 msgstr ""
 
-#: src/ExternalConn.cpp:2509
+#: src/ExternalConn.cpp:2508
 msgid "File not found."
 msgstr "Fișierul nu este găsit."
 
-#: src/ExternalConn.cpp:2514
+#: src/ExternalConn.cpp:2513
 msgid "Invalid file name."
 msgstr "Nume fișier nevalid."
 
-#: src/ExternalConn.cpp:2522
+#: src/ExternalConn.cpp:2521
 msgid "Unable to rename file."
 msgstr "Nu se poate redenumii fișierul."
 
-#: src/ExternalConn.cpp:2839
-#, c-format
-msgid "Could not save the amuleapi password: %s"
-msgstr ""
-
-#: src/ExternalConn.cpp:3004 src/ExternalConn.cpp:3032
+#: src/ExternalConn.cpp:2992 src/ExternalConn.cpp:3020
 msgid "Kad is disabled in preferences."
 msgstr "Kad este dezactivat din preferințe."
 
-#: src/ExternalConn.cpp:3045
+#: src/ExternalConn.cpp:3033
 msgid "Already connected to eD2k."
 msgstr "Deja este conectat la eD2k."
 
-#: src/ExternalConn.cpp:3048
+#: src/ExternalConn.cpp:3036
 msgid "Connecting to eD2k..."
 msgstr "Se conectează la eD2k..."
 
-#: src/ExternalConn.cpp:3057
+#: src/ExternalConn.cpp:3045
 msgid "Already connected to Kad."
 msgstr "Deja este conectat la Kad."
 
-#: src/ExternalConn.cpp:3060
+#: src/ExternalConn.cpp:3048
 msgid "Connecting to Kad..."
 msgstr "Se conectează la Kad..."
 
-#: src/ExternalConn.cpp:3067
+#: src/ExternalConn.cpp:3055
 msgid "All networks are disabled."
 msgstr "Toate rețelele sunt dezactivate."
 
-#: src/ExternalConn.cpp:3076
+#: src/ExternalConn.cpp:3064
 msgid "Disconnected from eD2k."
 msgstr "Deconectat de la eD2k."
 
-#: src/ExternalConn.cpp:3081
+#: src/ExternalConn.cpp:3069
 msgid "Disconnected from Kad."
 msgstr "Deconectat de la Kad."
 
-#: src/ExternalConn.cpp:3090
+#: src/ExternalConn.cpp:3078
 #, c-format
 msgid "External Connection: invalid opcode received: %#x"
 msgstr "Conexiune externă: S-a primit un opcode nevalid: %#x"
 
-#: src/ExternalConn.cpp:3095
+#: src/ExternalConn.cpp:3083
 msgid "Invalid opcode (wrong protocol version?)"
 msgstr "Opcode nevalid (versiune protocol greșită?)"
 
@@ -2348,19 +2338,19 @@ msgstr ""
 msgid "eD2k"
 msgstr "eD2k"
 
-#: src/FirstRunWizard.cpp:349 src/muuli_wdr.cpp:1495
+#: src/FirstRunWizard.cpp:349 src/muuli_wdr.cpp:1488
 msgid "Kademlia"
 msgstr "Kademlia"
 
-#: src/FirstRunWizard.cpp:359 src/muuli_wdr.cpp:1423
+#: src/FirstRunWizard.cpp:359 src/muuli_wdr.cpp:1416
 msgid "Standard TCP Port "
 msgstr "Port TCP standard"
 
-#: src/FirstRunWizard.cpp:365 src/muuli_wdr.cpp:1435
+#: src/FirstRunWizard.cpp:365 src/muuli_wdr.cpp:1428
 msgid "Extended UDP port (Kad / global search) "
 msgstr "Port UDP extins (Kad / căutare globală)"
 
-#: src/FirstRunWizard.cpp:377 src/muuli_wdr.cpp:1442
+#: src/FirstRunWizard.cpp:377 src/muuli_wdr.cpp:1435
 msgid "Enable UPnP for router port forwarding"
 msgstr "Activează UPnP pentru înaintare port ruter"
 
@@ -2387,7 +2377,7 @@ msgstr ""
 msgid "Your peer lists are already in place - nothing to download."
 msgstr "Deja încercați să descărcați fișierul %s"
 
-#: src/FirstRunWizard.cpp:434 src/muuli_wdr.cpp:1540
+#: src/FirstRunWizard.cpp:434 src/muuli_wdr.cpp:1533
 msgid "Auto-update server list at startup"
 msgstr "Actualizează automat lista serverelor la pornire"
 
@@ -2433,23 +2423,23 @@ msgid ""
 "want downloads on a different (e.g. larger) disk."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:549 src/FirstRunWizard.cpp:611 src/muuli_wdr.cpp:1702
+#: src/FirstRunWizard.cpp:549 src/FirstRunWizard.cpp:611 src/muuli_wdr.cpp:1701
 msgid "Destination folder for downloads"
 msgstr "Dosar destinație pentru descărcări"
 
-#: src/FirstRunWizard.cpp:553 src/FirstRunWizard.cpp:569 src/muuli_wdr.cpp:1349
-#: src/muuli_wdr.cpp:1366 src/muuli_wdr.cpp:1677 src/muuli_wdr.cpp:1708
-#: src/muuli_wdr.cpp:1720 src/muuli_wdr.cpp:2790
+#: src/FirstRunWizard.cpp:553 src/FirstRunWizard.cpp:569 src/muuli_wdr.cpp:1342
+#: src/muuli_wdr.cpp:1359 src/muuli_wdr.cpp:1676 src/muuli_wdr.cpp:1707
+#: src/muuli_wdr.cpp:1719 src/muuli_wdr.cpp:2762
 #: src/utils/aLinkCreator/src/alcframe.cpp:135
 #: src/utils/wxCas/src/wxcasprefs.cpp:52 src/utils/wxCas/src/wxcasprefs.cpp:118
 msgid "Browse"
 msgstr "Navigare"
 
-#: src/FirstRunWizard.cpp:559 src/muuli_wdr.cpp:1713
+#: src/FirstRunWizard.cpp:559 src/muuli_wdr.cpp:1712
 msgid "(All files in this folder are shared with other peers)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:565 src/FirstRunWizard.cpp:624 src/muuli_wdr.cpp:1715
+#: src/FirstRunWizard.cpp:565 src/FirstRunWizard.cpp:624 src/muuli_wdr.cpp:1714
 msgid "Folder for temporary download files"
 msgstr "Dosar pentru fișiere descărcate temporar"
 
@@ -2480,7 +2470,7 @@ msgstr "A eșuat deschiderea fișierului listă prieteni 'emfriends.met' pentru 
 msgid "CRITICAL - no client on StartChatSession"
 msgstr "CRITIC - niciun client în StartChatSession"
 
-#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2696 src/muuli_wdr.cpp:3373
+#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2668 src/muuli_wdr.cpp:3345
 msgid "Friends"
 msgstr "Prieteni"
 
@@ -2591,8 +2581,8 @@ msgstr "Niciunul"
 msgid "No"
 msgstr "Nu"
 
-#: src/GenericClientListCtrl.cpp:1216 src/PrefsUnifiedDlg.cpp:2898
-#: src/PrefsUnifiedDlg.cpp:2948 src/ServerListCtrl.cpp:276
+#: src/GenericClientListCtrl.cpp:1216 src/PrefsUnifiedDlg.cpp:2818
+#: src/PrefsUnifiedDlg.cpp:2868 src/ServerListCtrl.cpp:276
 msgid "Yes"
 msgstr "Da"
 
@@ -2763,10 +2753,10 @@ msgstr "Port nevalid la bootstrap"
 msgid "Please fill all fields required"
 msgstr "Completați toate câmpurile solicitate"
 
-#: src/KadDlg.cpp:192 src/PartFile.cpp:1031 src/PrefsUnifiedDlg.cpp:1134
-#: src/PrefsUnifiedDlg.cpp:1204 src/PrefsUnifiedDlg.cpp:1405
-#: src/PrefsUnifiedDlg.cpp:1663 src/PrefsUnifiedDlg.cpp:1673
-#: src/PrefsUnifiedDlg.cpp:1690 src/PrefsUnifiedDlg.cpp:1738
+#: src/KadDlg.cpp:192 src/PartFile.cpp:1031 src/PrefsUnifiedDlg.cpp:1162
+#: src/PrefsUnifiedDlg.cpp:1331 src/PrefsUnifiedDlg.cpp:1589
+#: src/PrefsUnifiedDlg.cpp:1599 src/PrefsUnifiedDlg.cpp:1616
+#: src/PrefsUnifiedDlg.cpp:1658
 msgid "Message"
 msgstr "Mesaj"
 
@@ -2871,7 +2861,7 @@ msgstr "Rată de partajare"
 msgid "Uploaded"
 msgstr "Încărcat"
 
-#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3253
+#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3225
 msgid "Requested"
 msgstr "Cerut"
 
@@ -2995,7 +2985,7 @@ msgid "WARNING: "
 msgstr "ATENȚIE:"
 
 #: src/MuleNotebook.cpp:179 src/muuli_wdr.cpp:817 src/muuli_wdr.cpp:1229
-#: src/muuli_wdr.cpp:3157 src/muuli_wdr.cpp:3413
+#: src/muuli_wdr.cpp:3129 src/muuli_wdr.cpp:3385
 msgid "Close"
 msgstr "Închide"
 
@@ -3008,12 +2998,12 @@ msgstr "Taie"
 msgid "Copy"
 msgstr "Copiază"
 
-#: src/MuleTextCtrl.cpp:88 src/SearchDlg.cpp:261
+#: src/MuleTextCtrl.cpp:88
 msgid "Paste"
 msgstr "Lipește"
 
 #: src/MuleTextCtrl.cpp:89 src/muuli_wdr.cpp:358 src/muuli_wdr.cpp:757
-#: src/muuli_wdr.cpp:2380 src/muuli_wdr.cpp:2399 src/muuli_wdr.cpp:2421
+#: src/muuli_wdr.cpp:2352 src/muuli_wdr.cpp:2371 src/muuli_wdr.cpp:2393
 #: src/utils/aLinkCreator/src/alcframe.cpp:142
 msgid "Clear"
 msgstr "Curăță"
@@ -3111,8 +3101,8 @@ msgid "Exit"
 msgstr "Ieşire"
 
 #: src/MuleTrayIcon.cpp:579 src/MuleTrayIcon.cpp:945 src/MuleTrayIcon.cpp:965
-#: src/muuli_wdr.cpp:1398 src/muuli_wdr.cpp:1406 src/muuli_wdr.cpp:1413
-#: src/muuli_wdr.cpp:1836 src/muuli_wdr.cpp:1842 src/OtherFunctions.cpp:91
+#: src/muuli_wdr.cpp:1391 src/muuli_wdr.cpp:1399 src/muuli_wdr.cpp:1406
+#: src/muuli_wdr.cpp:1835 src/muuli_wdr.cpp:1841 src/OtherFunctions.cpp:91
 #: src/StatisticsDlg.cpp:93 src/StatisticsDlg.cpp:95
 msgid "kB/s"
 msgstr "kB/s"
@@ -3283,7 +3273,7 @@ msgstr "Name:"
 msgid "Type"
 msgstr "Tip"
 
-#: src/muuli_wdr.cpp:215 src/SearchDlg.cpp:118 src/SearchListCtrl.cpp:853
+#: src/muuli_wdr.cpp:215 src/SearchDlg.cpp:110 src/SearchListCtrl.cpp:853
 msgid "Local"
 msgstr "Local"
 
@@ -3354,7 +3344,7 @@ msgstr "Baiți"
 msgid "KB"
 msgstr "KB"
 
-#: src/muuli_wdr.cpp:274 src/muuli_wdr.cpp:293 src/muuli_wdr.cpp:1621
+#: src/muuli_wdr.cpp:274 src/muuli_wdr.cpp:293 src/muuli_wdr.cpp:1620
 #: src/OtherFunctions.cpp:64
 msgid "MB"
 msgstr "MO"
@@ -3371,7 +3361,7 @@ msgstr "Dimensiune maximă"
 msgid "Availability"
 msgstr "Disponibilitate"
 
-#: src/muuli_wdr.cpp:312 src/muuli_wdr.cpp:398 src/muuli_wdr.cpp:3318
+#: src/muuli_wdr.cpp:312 src/muuli_wdr.cpp:398 src/muuli_wdr.cpp:3290
 msgid "Filter:"
 msgstr "Filtru:"
 
@@ -3403,7 +3393,7 @@ msgstr ""
 msgid "Stop"
 msgstr "Oprește"
 
-#: src/muuli_wdr.cpp:348 src/muuli_wdr.cpp:1392 src/SearchListCtrl.cpp:732
+#: src/muuli_wdr.cpp:348 src/muuli_wdr.cpp:1385 src/SearchListCtrl.cpp:732
 msgid "Download"
 msgstr "Descarcă"
 
@@ -3434,12 +3424,12 @@ msgstr "Surse fișier:"
 #: src/muuli_wdr.cpp:1160 src/muuli_wdr.cpp:1167 src/muuli_wdr.cpp:1172
 #: src/muuli_wdr.cpp:1179 src/muuli_wdr.cpp:1184 src/muuli_wdr.cpp:1191
 #: src/muuli_wdr.cpp:1205 src/muuli_wdr.cpp:1212 src/muuli_wdr.cpp:1217
-#: src/muuli_wdr.cpp:1224 src/muuli_wdr.cpp:3255 src/muuli_wdr.cpp:3263
-#: src/muuli_wdr.cpp:3271
+#: src/muuli_wdr.cpp:1224 src/muuli_wdr.cpp:3227 src/muuli_wdr.cpp:3235
+#: src/muuli_wdr.cpp:3243
 msgid "N/A"
 msgstr "NU SE APLICĂ"
 
-#: src/muuli_wdr.cpp:508 src/muuli_wdr.cpp:1065 src/PrefsUnifiedDlg.cpp:299
+#: src/muuli_wdr.cpp:508 src/muuli_wdr.cpp:1065 src/PrefsUnifiedDlg.cpp:297
 msgid "General"
 msgstr "General"
 
@@ -3580,7 +3570,7 @@ msgstr ""
 msgid "Album :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:685 src/muuli_wdr.cpp:2275
+#: src/muuli_wdr.cpp:685 src/muuli_wdr.cpp:2247
 msgid "Title :"
 msgstr "Titlu :"
 
@@ -3689,7 +3679,7 @@ msgstr "Nume utilizator:"
 msgid "Userhash :"
 msgstr "Index utilizator :"
 
-#: src/muuli_wdr.cpp:895 src/muuli_wdr.cpp:1742 src/muuli_wdr.cpp:2470
+#: src/muuli_wdr.cpp:895 src/muuli_wdr.cpp:1741 src/muuli_wdr.cpp:2442
 #: src/utils/aLinkCreator/src/alcframe.cpp:137
 msgid "Add"
 msgstr "Adaugă"
@@ -3698,15 +3688,15 @@ msgstr "Adaugă"
 msgid "Download-Speed"
 msgstr "Viteză-descărcare"
 
-#: src/muuli_wdr.cpp:954 src/muuli_wdr.cpp:989 src/muuli_wdr.cpp:2574
+#: src/muuli_wdr.cpp:954 src/muuli_wdr.cpp:989 src/muuli_wdr.cpp:2546
 msgid "Current"
 msgstr "Curentul"
 
-#: src/muuli_wdr.cpp:962 src/muuli_wdr.cpp:997 src/muuli_wdr.cpp:2582
+#: src/muuli_wdr.cpp:962 src/muuli_wdr.cpp:997 src/muuli_wdr.cpp:2554
 msgid "Running average"
 msgstr "Medie rulare"
 
-#: src/muuli_wdr.cpp:970 src/muuli_wdr.cpp:1005 src/muuli_wdr.cpp:2590
+#: src/muuli_wdr.cpp:970 src/muuli_wdr.cpp:1005 src/muuli_wdr.cpp:2562
 msgid "Session average"
 msgstr "Medie sesiune"
 
@@ -3718,7 +3708,7 @@ msgstr "Viteză-încărcare"
 msgid "Connections"
 msgstr "Conexiuni"
 
-#: src/muuli_wdr.cpp:1024 src/muuli_wdr.cpp:1861
+#: src/muuli_wdr.cpp:1024 src/muuli_wdr.cpp:1860
 msgid "Active downloads"
 msgstr "Descărcări active"
 
@@ -3726,7 +3716,7 @@ msgstr "Descărcări active"
 msgid "Active connections (1:1)"
 msgstr "Conexiuni active (1:1)"
 
-#: src/muuli_wdr.cpp:1040 src/muuli_wdr.cpp:1862
+#: src/muuli_wdr.cpp:1040 src/muuli_wdr.cpp:1861
 msgid "Active uploads"
 msgstr "Încărcări active"
 
@@ -3842,8 +3832,8 @@ msgstr "Acesta este numele pe care ceilalți utilizatori îl va vedea când se v
 msgid "Language: "
 msgstr "Limbă:"
 
-#: src/muuli_wdr.cpp:1257 src/muuli_wdr.cpp:1330 src/muuli_wdr.cpp:1334
-#: src/muuli_wdr.cpp:1337
+#: src/muuli_wdr.cpp:1257 src/muuli_wdr.cpp:1323 src/muuli_wdr.cpp:1327
+#: src/muuli_wdr.cpp:1330
 msgid "The delay before showing tool-tips."
 msgstr "Întârzierea afișării sfaturilor."
 
@@ -3921,960 +3911,936 @@ msgstr ""
 msgid "Enabling this will make aMule to show notifications when finished downloading."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1323
-#, fuzzy
-msgid "Remember search history"
-msgstr "Amintește aceste configurări"
-
-#: src/muuli_wdr.cpp:1324
-msgid "Keeps a dropdown list of your past search terms in the Search tab's Name field. This remembers the queries you typed, not the results they returned."
-msgstr ""
-
-#: src/muuli_wdr.cpp:1329
+#: src/muuli_wdr.cpp:1322
 msgid "Tooltip delay time: "
 msgstr "Timp de întârziere balon de ajutor:"
 
-#: src/muuli_wdr.cpp:1336
+#: src/muuli_wdr.cpp:1329
 msgid "seconds"
 msgstr "secunde"
 
-#: src/muuli_wdr.cpp:1340
+#: src/muuli_wdr.cpp:1333
 msgid "Browser Selection"
 msgstr "Selecție navigator"
 
-#: src/muuli_wdr.cpp:1346
+#: src/muuli_wdr.cpp:1339
 msgid "Enter your browser name here. Leave this field empty to use the system default browser."
 msgstr "Introduceți aici numele navigatorului. Lăsați acest câmp necompletat pentru utilizarea navigatorului implicit de sistem."
 
-#: src/muuli_wdr.cpp:1353
+#: src/muuli_wdr.cpp:1346
 msgid "Open in new tab if possible"
 msgstr "Deschide într-o fereastră nouă dacă este posibil"
 
-#: src/muuli_wdr.cpp:1355
+#: src/muuli_wdr.cpp:1348
 msgid "Open the web page in a new tab instead of in a new window when possible"
 msgstr "Deschide pagina web într-o pagină nouă în schimbul unei ferestre noi când este posibil"
 
-#: src/muuli_wdr.cpp:1359
+#: src/muuli_wdr.cpp:1352
 msgid "Video Player"
 msgstr "Player video"
 
-#: src/muuli_wdr.cpp:1386
+#: src/muuli_wdr.cpp:1379
 msgid "Bandwidth limits"
 msgstr "Limite lățime de bandă"
 
-#: src/muuli_wdr.cpp:1400
+#: src/muuli_wdr.cpp:1393
 msgid "Upload"
 msgstr "Încărcare"
 
-#: src/muuli_wdr.cpp:1408
+#: src/muuli_wdr.cpp:1401
 msgid "Slot Allocation"
 msgstr "Alocare slot"
 
-#: src/muuli_wdr.cpp:1417
+#: src/muuli_wdr.cpp:1410
 msgid "Ports"
 msgstr "Porturi"
 
-#: src/muuli_wdr.cpp:1427
+#: src/muuli_wdr.cpp:1420
 msgid "This is the standard eD2k port and cannot be disabled."
 msgstr "Acesta este portul standard eD2k și nu poate fi dezactivat."
 
-#: src/muuli_wdr.cpp:1430
+#: src/muuli_wdr.cpp:1423
 msgid "UDP port for server requests (TCP+3):"
 msgstr "Port UDP pentru cererile serverului (TCP+3)"
 
-#: src/muuli_wdr.cpp:1432
+#: src/muuli_wdr.cpp:1425
 msgid "4665"
 msgstr "4665"
 
-#: src/muuli_wdr.cpp:1439
+#: src/muuli_wdr.cpp:1432
 msgid "This UDP port is used for extended eD2k requests and Kad network"
 msgstr "Acest port UDP este utilizat pentru solicitări extinse eD2k și rețeaua Kad"
 
-#: src/muuli_wdr.cpp:1446
+#: src/muuli_wdr.cpp:1439
 msgid "UPnP TCP Port (Optional):"
 msgstr "Port UPnP TCP (facultativ):"
 
-#: src/muuli_wdr.cpp:1456
+#: src/muuli_wdr.cpp:1449
 msgid "Bind local address to IP (empty for any):"
 msgstr "Leagă adresa locală la IP (gol pentru oricare):"
 
-#: src/muuli_wdr.cpp:1459
+#: src/muuli_wdr.cpp:1452
 msgid "Advanced users only: If you have multiple network interfaces, enter the address of the interface to which aMule should be bound."
 msgstr "Numai pentru utilizatorii avansați: Dacă aveți mai multe interfețe de rețea, introduceți adresa interfeței la care aMule ar trebui să fie legat."
 
-#: src/muuli_wdr.cpp:1462 src/muuli_wdr.cpp:2055
+#: src/muuli_wdr.cpp:1455 src/muuli_wdr.cpp:2054
 #, fuzzy
 msgid "Bind to network interface (empty for any):"
 msgstr "Leagă adresa locală la IP (gol pentru oricare):"
 
-#: src/muuli_wdr.cpp:1475
+#: src/muuli_wdr.cpp:1468
 msgid "Advanced users only: pin all of aMule's traffic to one network interface, chosen from the list or typed in by name (e.g. tun0, eth0, en0) or index. Unlike binding to an IP, this stops traffic leaking out via the default route - useful with a VPN. Requires no elevated privileges."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1481
+#: src/muuli_wdr.cpp:1474
 msgid "Max sources per downloading file:"
 msgstr "Număr maxim de surse pe fișier descărcat:"
 
-#: src/muuli_wdr.cpp:1485
+#: src/muuli_wdr.cpp:1478
 msgid "Max simultaneous connections:"
 msgstr "Număr maxim de conexiuni simultane:"
 
-#: src/muuli_wdr.cpp:1498 src/muuli_wdr.cpp:3197
+#: src/muuli_wdr.cpp:1491 src/muuli_wdr.cpp:3169
 msgid "ED2K"
 msgstr "ED2K"
 
-#: src/muuli_wdr.cpp:1505
+#: src/muuli_wdr.cpp:1498
 msgid "Autoconnect on startup"
 msgstr "Conectare automată la pornire"
 
-#: src/muuli_wdr.cpp:1508
+#: src/muuli_wdr.cpp:1501
 msgid "Reconnect on loss"
 msgstr "Reconectare la pierdere"
 
-#: src/muuli_wdr.cpp:1530
+#: src/muuli_wdr.cpp:1523
 msgid "Remove dead server after"
 msgstr "Elimină serverele moarte după"
 
-#: src/muuli_wdr.cpp:1531
+#: src/muuli_wdr.cpp:1524
 msgid "Static servers are never removed, even when unreachable."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1535
+#: src/muuli_wdr.cpp:1528
 msgid "retries"
 msgstr "încercări"
 
-#: src/muuli_wdr.cpp:1543
+#: src/muuli_wdr.cpp:1536
 msgid "List"
 msgstr "Listă"
 
-#: src/muuli_wdr.cpp:1546
+#: src/muuli_wdr.cpp:1539
 msgid "Update server list when connecting to a server"
 msgstr "Actualizează lista serverelor la conectarea la un server"
 
-#: src/muuli_wdr.cpp:1549
+#: src/muuli_wdr.cpp:1542
 msgid "Update server list when a client connects"
 msgstr "Actualizează lista serverelor când se conectează un client"
 
-#: src/muuli_wdr.cpp:1552
+#: src/muuli_wdr.cpp:1545
 msgid "Use priority system"
 msgstr "Utilizează prioritatea sistemului"
 
-#: src/muuli_wdr.cpp:1556
+#: src/muuli_wdr.cpp:1549
 msgid "Use smart LowID check on connect"
 msgstr "Utilizează verificarea inteligentă LowID la conectare"
 
-#: src/muuli_wdr.cpp:1560
+#: src/muuli_wdr.cpp:1553
 msgid "Safe connect"
 msgstr "Conectare sigură"
 
-#: src/muuli_wdr.cpp:1564
+#: src/muuli_wdr.cpp:1557
 msgid "Autoconnect to servers in static list only"
 msgstr "Conectează automat numai la serverele din lista statică"
 
-#: src/muuli_wdr.cpp:1567
+#: src/muuli_wdr.cpp:1560
 msgid "Set manually added servers to High Priority"
 msgstr "Configurează serverele adăugate manual la prioritate înaltă"
 
-#: src/muuli_wdr.cpp:1588
+#: src/muuli_wdr.cpp:1581
 msgid "Add files to download in pause mode"
 msgstr "Adaugă fișiere la descărcare în modul pauză"
 
-#: src/muuli_wdr.cpp:1590
+#: src/muuli_wdr.cpp:1583
 msgid "Add files to download with auto priority"
 msgstr "Adaugă fișiere la descărcare cu prioritate automată"
 
-#: src/muuli_wdr.cpp:1593
+#: src/muuli_wdr.cpp:1586
 msgid "Try to download first and last chunks first"
 msgstr "Încearcă să descarci întâi prima și ultima bucată"
 
-#: src/muuli_wdr.cpp:1597
+#: src/muuli_wdr.cpp:1590
 msgid "Endgame mode: rotate to faster sources for the final blocks"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1600
+#: src/muuli_wdr.cpp:1593
 msgid "Start next paused file when a file completes"
 msgstr "Pornește următorul fișier pauzat când un fișier s-a terminat"
 
-#: src/muuli_wdr.cpp:1603
+#: src/muuli_wdr.cpp:1596
 msgid "From the same category"
 msgstr "Din aceeași categorie"
 
-#: src/muuli_wdr.cpp:1605
+#: src/muuli_wdr.cpp:1598
 msgid "In alphabetic order"
 msgstr "În ordine alfabetică"
 
-#: src/muuli_wdr.cpp:1607
+#: src/muuli_wdr.cpp:1600
 msgid "Preallocate disk space for new files"
 msgstr "Prealocare spațiu pe disc pentru noile fișiere"
 
-#: src/muuli_wdr.cpp:1608
+#: src/muuli_wdr.cpp:1601
 msgid "For new files preallocates disk space for the whole file, thus reduces fragmentation"
 msgstr "Pentru noile fișiere se prealocă spațiu pe disc pentru întreg fișierul, astfel se reduce fragmentarea"
 
-#: src/muuli_wdr.cpp:1613
+#: src/muuli_wdr.cpp:1606
+msgid "Create new files as sparse files"
+msgstr ""
+
+#: src/muuli_wdr.cpp:1607
+msgid "A sparse file reserves its full size on disk immediately without writing real data to it -- fast, but unsupported or slow on some filesystems, and free-space accounting stays optimistic while the download is in progress. Turn this off to grow the file only as data arrives."
+msgstr ""
+
+#: src/muuli_wdr.cpp:1612
 msgid "Stop downloads when free disk space reaches "
 msgstr "Oprește descărcarea când s-a atins limita spațiului disponibil"
 
-#: src/muuli_wdr.cpp:1614
+#: src/muuli_wdr.cpp:1613
 msgid "Select this if you want aMule to check your disk space"
 msgstr "Selectați asta dacă doriți ca aMule să verifice spațiul liber pe disk"
 
-#: src/muuli_wdr.cpp:1618
+#: src/muuli_wdr.cpp:1617
 msgid "Enter here the min disk space desired."
 msgstr "Introduceți aici minimum de spațiu pe disc dorit."
 
-#: src/muuli_wdr.cpp:1624
+#: src/muuli_wdr.cpp:1623
 msgid "Save 10 sources on rare files (< 20 sources)"
 msgstr "Salvează 10 surse de fișiere rare (< 20 surse)"
 
-#: src/muuli_wdr.cpp:1628 src/Statistics.cpp:790
+#: src/muuli_wdr.cpp:1627 src/Statistics.cpp:790
 msgid "Uploads"
 msgstr "Încărcări"
 
-#: src/muuli_wdr.cpp:1631
+#: src/muuli_wdr.cpp:1630
 msgid "Add new shared files with auto priority"
 msgstr "Adaugă noile fișiere partajate cu prioritate automată"
 
-#: src/muuli_wdr.cpp:1637
+#: src/muuli_wdr.cpp:1636
 msgid "Intelligent Corruption Handling (I.C.H.)"
 msgstr "Gestionare inteligentă a fișierelor corupte (I.C.H.)"
 
-#: src/muuli_wdr.cpp:1640
+#: src/muuli_wdr.cpp:1639
 msgid "Enable"
 msgstr "Activează"
 
-#: src/muuli_wdr.cpp:1643
+#: src/muuli_wdr.cpp:1642
 msgid "Advanced I.C.H. trusts every hash (not recommended)"
 msgstr "I.C.H. avansat acordă încredere fiecărui index (nu este recomandat)"
 
-#: src/muuli_wdr.cpp:1655 src/PrefsUnifiedDlg.cpp:1990
+#: src/muuli_wdr.cpp:1654 src/PrefsUnifiedDlg.cpp:1910
 msgid "Media metadata extraction"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1659
+#: src/muuli_wdr.cpp:1658
 msgid "Extract length / bitrate / codec from shared audio and video files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1661
+#: src/muuli_wdr.cpp:1660
 msgid "When enabled, aMule runs ffprobe on each shared media file to fill in the Length / Bitrate / Codec columns other clients see when they find the file in a search. Requires ffmpeg (the ffprobe binary) to be installed."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1668
+#: src/muuli_wdr.cpp:1667
 msgid "Path to ffprobe:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1673
+#: src/muuli_wdr.cpp:1672
 msgid "Full path to the ffprobe binary. Leave empty to have aMule auto-detect it on startup."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1681
+#: src/muuli_wdr.cpp:1680
 msgid "Detect"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1682
+#: src/muuli_wdr.cpp:1681
 msgid "Search the standard install locations for an ffprobe binary and fill the path field."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1706
+#: src/muuli_wdr.cpp:1705
 msgid ""
 "Completed downloads are stored here. All files in this folder are automatically shared with other peers.\n"
 "If this folder also holds files you don't want to share, point it at an aMule-only sub-folder."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1709
+#: src/muuli_wdr.cpp:1708
 msgid "Pick the folder where completed downloads will be stored. All files in that folder will be shared with other peers."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1723
+#: src/muuli_wdr.cpp:1722
 msgid "Shared folders"
 msgstr "Dosare partajate"
 
-#: src/muuli_wdr.cpp:1729
+#: src/muuli_wdr.cpp:1728
 msgid "(Folders shared by the core. Enter a path to add one.)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1737
+#: src/muuli_wdr.cpp:1736
 msgid "Absolute path of a folder on the core's machine, e.g. /home/user/shared"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1739 src/PrefsUnifiedDlg.cpp:2874
+#: src/muuli_wdr.cpp:1738 src/PrefsUnifiedDlg.cpp:2794
 msgid "Recursive"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1740
+#: src/muuli_wdr.cpp:1739
 msgid "Share every sub-folder underneath this one, including ones created later."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1744 src/utils/aLinkCreator/src/alcframe.cpp:141
+#: src/muuli_wdr.cpp:1743 src/utils/aLinkCreator/src/alcframe.cpp:141
 msgid "Remove"
 msgstr "Elimină"
 
-#: src/muuli_wdr.cpp:1748
+#: src/muuli_wdr.cpp:1747
 msgid "(Right click on folder icon for recursive share)"
 msgstr "(Click dreapta pe miniatura dosarului pentru partajare recursivă)"
 
-#: src/muuli_wdr.cpp:1755
+#: src/muuli_wdr.cpp:1754
 msgid "Share hidden files"
 msgstr "Partajează fișierele ascunse"
 
-#: src/muuli_wdr.cpp:1761
+#: src/muuli_wdr.cpp:1760
 msgid "Automatically rescan shared folders for changes"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1767
+#: src/muuli_wdr.cpp:1766
 msgid "Follow symbolic links in shared folders"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1773
+#: src/muuli_wdr.cpp:1772
 msgid "Exclude files matching:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1776
+#: src/muuli_wdr.cpp:1775
 msgid "Wildcard patterns separated by '|', e.g. .DS_Store|Thumbs.db|*.tmp. Files whose name matches are not shared. Matching is case-insensitive."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1780
+#: src/muuli_wdr.cpp:1779
 msgid "Patterns are regular expressions"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1781
+#: src/muuli_wdr.cpp:1780
 msgid "When set, the whole field is one regular expression ('|' is alternation). When unset, it is a list of '|'-separated wildcards."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1791
+#: src/muuli_wdr.cpp:1790
 msgid "Show how many shared files the current pattern would exclude."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1812
+#: src/muuli_wdr.cpp:1811
 msgid "Graphs"
 msgstr "Grafice"
 
-#: src/muuli_wdr.cpp:1815 src/muuli_wdr.cpp:1877
+#: src/muuli_wdr.cpp:1814 src/muuli_wdr.cpp:1876
 msgid "Update delay : 5 secs"
 msgstr "Întârziere actualizare : 5 secunde"
 
-#: src/muuli_wdr.cpp:1819
+#: src/muuli_wdr.cpp:1818
 msgid "Time for average graph: 100 mins"
 msgstr "Timp pentru media graficului: 100 minute"
 
-#: src/muuli_wdr.cpp:1823
+#: src/muuli_wdr.cpp:1822
 msgid "Connections Graph Scale: 100 "
 msgstr "Scală grafic conexiuni: 100"
 
-#: src/muuli_wdr.cpp:1830
+#: src/muuli_wdr.cpp:1829
 msgid "Download graph scale:"
 msgstr "Scală grafic descărcare:"
 
-#: src/muuli_wdr.cpp:1838
+#: src/muuli_wdr.cpp:1837
 msgid "Upload graph scale:"
 msgstr "Scală grafic încărcare:"
 
-#: src/muuli_wdr.cpp:1848
+#: src/muuli_wdr.cpp:1847
 #, fuzzy
 msgid "Colors: "
 msgstr "Colori:"
 
-#: src/muuli_wdr.cpp:1852
+#: src/muuli_wdr.cpp:1851
 msgid "Background"
 msgstr "Fundal"
 
-#: src/muuli_wdr.cpp:1853
+#: src/muuli_wdr.cpp:1852
 msgid "Grid"
 msgstr "Grilă"
 
-#: src/muuli_wdr.cpp:1854
+#: src/muuli_wdr.cpp:1853
 msgid "Download current"
 msgstr "Descărcare actuală"
 
-#: src/muuli_wdr.cpp:1855
+#: src/muuli_wdr.cpp:1854
 msgid "Download running average"
 msgstr "Medie rulare descărcare"
 
-#: src/muuli_wdr.cpp:1856
+#: src/muuli_wdr.cpp:1855
 msgid "Download session average"
 msgstr "Medie descărcare pe sesiune"
 
-#: src/muuli_wdr.cpp:1857
+#: src/muuli_wdr.cpp:1856
 msgid "Upload current"
 msgstr "Încărcare actuală"
 
-#: src/muuli_wdr.cpp:1858
+#: src/muuli_wdr.cpp:1857
 msgid "Upload running average"
 msgstr "Medie rulare încărcare"
 
-#: src/muuli_wdr.cpp:1859
+#: src/muuli_wdr.cpp:1858
 msgid "Upload session average"
 msgstr "Medie încărcare pe sesiune"
 
-#: src/muuli_wdr.cpp:1860
+#: src/muuli_wdr.cpp:1859
 msgid "Active connections"
 msgstr "Conexiuni active"
 
-#: src/muuli_wdr.cpp:1863
+#: src/muuli_wdr.cpp:1862
 #, fuzzy
 msgid "Systray Icon Speed Bar"
 msgstr "Miniatură rapidă pe bara de sistem"
 
-#: src/muuli_wdr.cpp:1864
+#: src/muuli_wdr.cpp:1863
 msgid "Kad-nodes current"
 msgstr "Noduri Kad curente"
 
-#: src/muuli_wdr.cpp:1865
+#: src/muuli_wdr.cpp:1864
 msgid "Kad-nodes running"
 msgstr "Noduri Kad care rulează"
 
-#: src/muuli_wdr.cpp:1866
+#: src/muuli_wdr.cpp:1865
 msgid "Kad-nodes session"
 msgstr "Noduri Kad pe sesiune"
 
-#: src/muuli_wdr.cpp:1870 src/muuli_wdr.cpp:2324
+#: src/muuli_wdr.cpp:1869 src/muuli_wdr.cpp:2296
 msgid "Select"
 msgstr "Selectează"
 
-#: src/muuli_wdr.cpp:1874
+#: src/muuli_wdr.cpp:1873
 msgid "Tree"
 msgstr "Arbore"
 
-#: src/muuli_wdr.cpp:1884
+#: src/muuli_wdr.cpp:1883
 msgid "Number of Client Versions shown (0=unlimited)"
 msgstr "Număr de versiuni client arătate (0=nelimitat)"
 
-#: src/muuli_wdr.cpp:1909
+#: src/muuli_wdr.cpp:1908
 msgid "!!! WARNING !!!"
 msgstr "!!! ATENȚIE !!!"
 
-#: src/muuli_wdr.cpp:1924
+#: src/muuli_wdr.cpp:1923
 msgid "Max new connections / 5 secs"
 msgstr "Maxim conexiuni noi /5 secunde"
 
-#: src/muuli_wdr.cpp:1926
+#: src/muuli_wdr.cpp:1925
 msgid "Concurrent Kad source lookups"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1928
+#: src/muuli_wdr.cpp:1927
 #, fuzzy
 msgid "Kad source re-search interval (minutes)"
 msgstr "Rată interval actualizare FTP în minute"
 
-#: src/muuli_wdr.cpp:1930
+#: src/muuli_wdr.cpp:1929
 #, fuzzy
 msgid "Source re-ask interval (minutes)"
 msgstr "Rată interval actualizare FTP în minute"
 
-#: src/muuli_wdr.cpp:1934
+#: src/muuli_wdr.cpp:1933
 msgid "File Buffer Size: 240000 bytes"
 msgstr "Dimensiune fișier tampon: 240000 octeți"
 
-#: src/muuli_wdr.cpp:1938
+#: src/muuli_wdr.cpp:1937
 msgid "Use MMAP: memory-mapped file access (lower memory use)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1939
+#: src/muuli_wdr.cpp:1938
 msgid "Maps part files into memory instead of buffering them on the heap, lowering the process memory footprint. May reduce download speed on some disks; best for memory-constrained or upload-heavy hosts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1941
+#: src/muuli_wdr.cpp:1940
 msgid "Upload Queue Size: 5000 clients"
 msgstr "Dimensiune coadă încărcare: 5000 clienți"
 
-#: src/muuli_wdr.cpp:1945
+#: src/muuli_wdr.cpp:1944
 msgid "Server connection refresh interval: Disable"
 msgstr "Interval reîmprospătare conexiune server: Dezactivat"
 
-#: src/muuli_wdr.cpp:1949
+#: src/muuli_wdr.cpp:1948
 msgid "Disable computer's timed standby mode"
 msgstr "Dezactivează temporizarea modului de st-by al computerului"
 
-#: src/muuli_wdr.cpp:1968
+#: src/muuli_wdr.cpp:1967
 msgid "Skin to use: "
 msgstr "Aspect interfață de utilizat:"
 
-#: src/muuli_wdr.cpp:1977
+#: src/muuli_wdr.cpp:1976
 msgid "Show \"Fast eD2k Links Handler\" in every window."
 msgstr "Arată \"Manipulator linkuri rapide eD2k\" în fiecare fereastră."
 
-#: src/muuli_wdr.cpp:1980
+#: src/muuli_wdr.cpp:1979
 msgid "Show extended info on categories tabs"
 msgstr "Arată informații extinse în fila categoriilor"
 
-#: src/muuli_wdr.cpp:1983
+#: src/muuli_wdr.cpp:1982
 msgid "Show application version on title"
 msgstr "Arată în titlu versiunea aplicației"
 
-#: src/muuli_wdr.cpp:1985
+#: src/muuli_wdr.cpp:1984
 msgid "Show transfer rates on title"
 msgstr "Arată rata de transfer în titlu"
 
-#: src/muuli_wdr.cpp:1987
+#: src/muuli_wdr.cpp:1986
 msgid "Before application name"
 msgstr "Înaintea numelui aplicației"
 
-#: src/muuli_wdr.cpp:1989
+#: src/muuli_wdr.cpp:1988
 msgid "After application name"
 msgstr "După numele aplicației"
 
-#: src/muuli_wdr.cpp:1992
+#: src/muuli_wdr.cpp:1991
 msgid "Show overhead bandwidth"
 msgstr "Arată lățimea de bandă globală"
 
-#: src/muuli_wdr.cpp:1996
+#: src/muuli_wdr.cpp:1995
 msgid "Vertical toolbar orientation"
 msgstr "Orientare verticală a barei de unelte"
 
-#: src/muuli_wdr.cpp:1998
+#: src/muuli_wdr.cpp:1997
 msgid "Live column sorting (auto-reorder rows as their values change)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2005
+#: src/muuli_wdr.cpp:2004
 msgid "Download Queue Files"
 msgstr "Descărcare coadă fișiere"
 
-#: src/muuli_wdr.cpp:2008
+#: src/muuli_wdr.cpp:2007
 msgid "Show progress percentage"
 msgstr "Arată procentul progresului"
 
-#: src/muuli_wdr.cpp:2014
+#: src/muuli_wdr.cpp:2013
 msgid "Show progress bar"
 msgstr "Arată bara de progres"
 
-#: src/muuli_wdr.cpp:2017
+#: src/muuli_wdr.cpp:2016
 msgid "Flat"
 msgstr "Plat"
 
-#: src/muuli_wdr.cpp:2021
+#: src/muuli_wdr.cpp:2020
 msgid "Round"
 msgstr "Rotund"
 
-#: src/muuli_wdr.cpp:2039
+#: src/muuli_wdr.cpp:2038
 msgid "External Connection Parameters"
 msgstr "Parametrii conexiune externă"
 
-#: src/muuli_wdr.cpp:2042
+#: src/muuli_wdr.cpp:2041
 msgid "Accept external connections"
 msgstr "Acceptă conexiuni externe"
 
-#: src/muuli_wdr.cpp:2049 src/muuli_wdr.cpp:2108
+#: src/muuli_wdr.cpp:2048 src/muuli_wdr.cpp:2107
 msgid "IP of the listening interface:"
 msgstr "IP a interfeței de ascultare:"
 
-#: src/muuli_wdr.cpp:2052
+#: src/muuli_wdr.cpp:2051
 msgid "Enter here a valid ip in the a.b.c.d format for the listening EC interface. An empty field or 0.0.0.0 will mean any interface."
 msgstr "Introduceți aici un ip valid în formatul a.b.c.d pentru ascultarea interfeței EC. Un câmp gol sau 0.0.0.0 va însemna orice interfață."
 
-#: src/muuli_wdr.cpp:2073 src/muuli_wdr.cpp:2184
+#: src/muuli_wdr.cpp:2072 src/muuli_wdr.cpp:2156
 msgid "TCP port:"
 msgstr "port TCP:"
 
-#: src/muuli_wdr.cpp:2079
+#: src/muuli_wdr.cpp:2078
 msgid "Enable UPnP port forwarding on the EC port"
 msgstr "Activează înaintarea portului UPnP pe portul EC"
 
-#: src/muuli_wdr.cpp:2083 src/muuli_wdr.cpp:3069
+#: src/muuli_wdr.cpp:2082 src/muuli_wdr.cpp:3041
 #: src/utils/wxCas/src/wxcasprefs.cpp:167
 msgid "Password"
 msgstr "Parolă"
 
-#: src/muuli_wdr.cpp:2089
+#: src/muuli_wdr.cpp:2088
 #, fuzzy
 msgid "aMule API server parameters"
 msgstr "Parametrii server web"
 
-#: src/muuli_wdr.cpp:2092
+#: src/muuli_wdr.cpp:2091
 msgid "Run amuleapi (REST API) on startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2097
+#: src/muuli_wdr.cpp:2096
 #, fuzzy
 msgid "HTTP port:"
 msgstr "port TCP:"
 
-#: src/muuli_wdr.cpp:2111
+#: src/muuli_wdr.cpp:2110
 msgid "The interface amuleapi's HTTP server listens on. 127.0.0.1 (default) accepts only local connections; use 0.0.0.0 or a specific IP to expose it to other hosts (set an admin password below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2116
-msgid "Type a password to set or change it. Stored passwords cannot be shown, so leaving this empty keeps the current one."
-msgstr ""
-
-#: src/muuli_wdr.cpp:2118
+#: src/muuli_wdr.cpp:2113
 #, fuzzy
 msgid "Admin password"
 msgstr "Se verifică parola\n"
 
-#: src/muuli_wdr.cpp:2130 src/muuli_wdr.cpp:2147 src/PrefsUnifiedDlg.cpp:1103
-#, fuzzy
-msgid "A password is set."
-msgstr "Se verifică parola\n"
+#: src/muuli_wdr.cpp:2118 src/muuli_wdr.cpp:2149
+msgid "Low rights password"
+msgstr "Parolă cu drepturi scăzute"
 
-#: src/muuli_wdr.cpp:2134
-#, fuzzy
-msgid "Enable guest access"
-msgstr "Interzice accesul oaspeților"
-
-#: src/muuli_wdr.cpp:2135
-msgid "Guest sessions may read status and listings but cannot change anything. Turning this off clears the stored guest password."
-msgstr ""
-
-#: src/muuli_wdr.cpp:2139
-#, fuzzy
-msgid "Guest password"
-msgstr "Parola de oaspete pentru serverul web"
-
-#: src/muuli_wdr.cpp:2154
+#: src/muuli_wdr.cpp:2126
 msgid "Web server parameters"
 msgstr "Parametrii server web"
 
-#: src/muuli_wdr.cpp:2157
+#: src/muuli_wdr.cpp:2129
 #, fuzzy
 msgid "Run webserver on startup (deprecated)"
 msgstr "Rulează la pornire serverul web"
 
-#: src/muuli_wdr.cpp:2163
+#: src/muuli_wdr.cpp:2135
 msgid "Web template"
 msgstr "Șablon web"
 
-#: src/muuli_wdr.cpp:2168
+#: src/muuli_wdr.cpp:2140
 msgid "Full rights password"
 msgstr "Parolă cu drepturi depline"
 
-#: src/muuli_wdr.cpp:2172
+#: src/muuli_wdr.cpp:2144
 msgid "Enable Low rights User"
 msgstr "Activează utilizatorul cu drepturi scăzute"
 
-#: src/muuli_wdr.cpp:2177
-msgid "Low rights password"
-msgstr "Parolă cu drepturi scăzute"
-
-#: src/muuli_wdr.cpp:2191
+#: src/muuli_wdr.cpp:2163
 msgid "Enable UPnP port forwarding of the web server port"
 msgstr "Activează înaintarea portului UPnP pe portul serverului web"
 
-#: src/muuli_wdr.cpp:2196
+#: src/muuli_wdr.cpp:2168
 msgid "Web server UPnP TCP port (Optional)"
 msgstr "Port UPnP TCP server web (facultativ)"
 
-#: src/muuli_wdr.cpp:2204
+#: src/muuli_wdr.cpp:2176
 msgid "Page Refresh Time (in secs)"
 msgstr "Timp reîmprospătare pagină (în secunde)"
 
-#: src/muuli_wdr.cpp:2211
+#: src/muuli_wdr.cpp:2183
 msgid "Enable Gzip compression"
 msgstr "Activează compresia Gzip"
 
-#: src/muuli_wdr.cpp:2245
+#: src/muuli_wdr.cpp:2217
 #, fuzzy
 msgid "Reset page to defaults"
 msgstr "Valoare implicită a sistemului"
 
-#: src/muuli_wdr.cpp:2246
+#: src/muuli_wdr.cpp:2218
 msgid "Reset the settings on the current page to their default values."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2248 src/muuli_wdr.cpp:2334 src/ServerWnd.cpp:274
+#: src/muuli_wdr.cpp:2220 src/muuli_wdr.cpp:2306 src/ServerWnd.cpp:274
 #: src/ServerWnd.cpp:282
 msgid "OK"
 msgstr "Bine"
 
-#: src/muuli_wdr.cpp:2250
+#: src/muuli_wdr.cpp:2222
 msgid "Click here to apply any changes made to the preferences."
 msgstr "Apăsați aici pentru a aplica orice modificare efectuată la preferințe."
 
-#: src/muuli_wdr.cpp:2253
+#: src/muuli_wdr.cpp:2225
 msgid "Reset any changes made to the preferences."
 msgstr "Resetează orice schimbare efectuată la preferințe."
 
-#: src/muuli_wdr.cpp:2282
+#: src/muuli_wdr.cpp:2254
 msgid "Comment :"
 msgstr "Comentariu :"
 
-#: src/muuli_wdr.cpp:2289
+#: src/muuli_wdr.cpp:2261
 msgid "Incoming Dir :"
 msgstr "Director intrare :"
 
-#: src/muuli_wdr.cpp:2298
+#: src/muuli_wdr.cpp:2270
 msgid "Change priority for new assigned files :"
 msgstr "Schimbă prioritatea pentru noile fișiere alocate :"
 
-#: src/muuli_wdr.cpp:2302
+#: src/muuli_wdr.cpp:2274
 msgid "Don't change"
 msgstr "Nu modifica"
 
-#: src/muuli_wdr.cpp:2314
+#: src/muuli_wdr.cpp:2286
 msgid "Select color for this Category (currently selected) :"
 msgstr "Selectați culoarea pentru această categorie (selectată curent):"
 
-#: src/muuli_wdr.cpp:2381 src/muuli_wdr.cpp:2400 src/muuli_wdr.cpp:2422
+#: src/muuli_wdr.cpp:2353 src/muuli_wdr.cpp:2372 src/muuli_wdr.cpp:2394
 msgid "Click this button to reset the log."
 msgstr "Apăsați acest buton pentru resetarea jurnalului."
 
-#: src/muuli_wdr.cpp:2441
+#: src/muuli_wdr.cpp:2413
 msgid "Click on this button to update the servers list from URL ..."
 msgstr "Apăsați acest buton pentru a se actualiza lista serverelor din URL ..."
 
-#: src/muuli_wdr.cpp:2445
+#: src/muuli_wdr.cpp:2417
 msgid "Server list"
 msgstr "Listă server"
 
-#: src/muuli_wdr.cpp:2449
+#: src/muuli_wdr.cpp:2421
 msgid "Enter the url to a server.met file here and press the button to the left to update the list of known servers."
 msgstr "Introduceți aici adresa URL pentru un fișier server.met și apăsați butonul din stânga pentru a actualiza lista serverelor. cunoscute."
 
-#: src/muuli_wdr.cpp:2454
+#: src/muuli_wdr.cpp:2426
 msgid "Add server manually: Name"
 msgstr "Adăugare server manual: Nume"
 
-#: src/muuli_wdr.cpp:2457
+#: src/muuli_wdr.cpp:2429
 msgid "Enter the name of the new server here"
 msgstr "Introduceți aici numele noului server"
 
-#: src/muuli_wdr.cpp:2459 src/ServerWnd.cpp:206
+#: src/muuli_wdr.cpp:2431 src/ServerWnd.cpp:206
 msgid "IP:Port"
 msgstr "IP:Port"
 
-#: src/muuli_wdr.cpp:2462
+#: src/muuli_wdr.cpp:2434
 msgid "Enter the IP of the server here, using the x.x.x.x format."
 msgstr "Introduceți aici adresa IP a serverului, utilizând formatul x.x.x.x  ."
 
-#: src/muuli_wdr.cpp:2468
+#: src/muuli_wdr.cpp:2440
 msgid "Enter the port of the server here."
 msgstr "Introduceți aici portul serverului."
 
-#: src/muuli_wdr.cpp:2471
+#: src/muuli_wdr.cpp:2443
 msgid "Add manually a server (fill fields to the left before) ..."
 msgstr "Adăugați un server manual (completați întâi câmpurile din stânga) ..."
 
-#: src/muuli_wdr.cpp:2500
+#: src/muuli_wdr.cpp:2472
 msgid "aMule Log"
 msgstr "Jurnal aMule"
 
-#: src/muuli_wdr.cpp:2508
+#: src/muuli_wdr.cpp:2480
 msgid "Server Info"
 msgstr "Informație server"
 
-#: src/muuli_wdr.cpp:2512
+#: src/muuli_wdr.cpp:2484
 msgid "ED2K Info"
 msgstr "Informație eD2k"
 
-#: src/muuli_wdr.cpp:2516
+#: src/muuli_wdr.cpp:2488
 msgid "Kad Info"
 msgstr "Informație Kad"
 
-#: src/muuli_wdr.cpp:2544
+#: src/muuli_wdr.cpp:2516
 msgid "Click on this button to update the nodes list from URL ..."
 msgstr "Apăsați pe acest buton pentru a actualiza lista nodurilor din URL ..."
 
-#: src/muuli_wdr.cpp:2548
+#: src/muuli_wdr.cpp:2520
 msgid "Nodes (0)"
 msgstr "Noduri (0)"
 
-#: src/muuli_wdr.cpp:2552
+#: src/muuli_wdr.cpp:2524
 msgid "Enter the url to a nodes.dat file here and press the button to the left to update the list of known nodes."
 msgstr "Introduceți aici adresa url către un fișier nodes.dat și apăsați butonul din stânga pentru actualizarea listei nodurilor cunoscute."
 
-#: src/muuli_wdr.cpp:2555
+#: src/muuli_wdr.cpp:2527
 msgid "Nodes stats"
 msgstr "Stare noduri"
 
-#: src/muuli_wdr.cpp:2597
+#: src/muuli_wdr.cpp:2569
 msgid "Bootstrap"
 msgstr "Bootstrap"
 
-#: src/muuli_wdr.cpp:2600
+#: src/muuli_wdr.cpp:2572
 msgid "New node"
 msgstr "Nod nou"
 
-#: src/muuli_wdr.cpp:2605
+#: src/muuli_wdr.cpp:2577
 msgid "IP:"
 msgstr "IP:"
 
-#: src/muuli_wdr.cpp:2625
+#: src/muuli_wdr.cpp:2597
 msgid "Port:"
 msgstr "Port:"
 
-#: src/muuli_wdr.cpp:2638
+#: src/muuli_wdr.cpp:2610
 msgid "Bootstrap from known clients"
 msgstr "Bootstrap de la clienții cunoscuți"
 
-#: src/muuli_wdr.cpp:2640
+#: src/muuli_wdr.cpp:2612
 msgid "Disconnect Kad"
 msgstr "Deconectare Kad"
 
-#: src/muuli_wdr.cpp:2674
+#: src/muuli_wdr.cpp:2646
 msgid "Use Secure User Identification"
 msgstr "Utilizează identificarea securizată a utilizatorilor"
 
-#: src/muuli_wdr.cpp:2676
+#: src/muuli_wdr.cpp:2648
 msgid "It is recommended to enable this option. You will not receive credits if SUI is not enabled."
 msgstr "Este recomandat să activați această opțiune. Nu veți primii credite dacă SUI nu este activat."
 
-#: src/muuli_wdr.cpp:2678
+#: src/muuli_wdr.cpp:2650
 msgid "Protocol Obfuscation"
 msgstr "Protocol disimulare"
 
-#: src/muuli_wdr.cpp:2681
+#: src/muuli_wdr.cpp:2653
 msgid "Support Protocol Obfuscation"
 msgstr "Suport protocol disimulare"
 
-#: src/muuli_wdr.cpp:2683
+#: src/muuli_wdr.cpp:2655
 msgid "This option enabled Protocol Obfuscation, and makes aMule accept obfuscated connections from other clients."
 msgstr "Această opțiune activează Protocolul Disimulare, și determină aMule să accepte conexiuni disimulate de la alți clienți."
 
-#: src/muuli_wdr.cpp:2685
+#: src/muuli_wdr.cpp:2657
 msgid "Use obfuscation for outgoing connections"
 msgstr "Utilizați disimularea pentru conexiunile de ieșire"
 
-#: src/muuli_wdr.cpp:2687
+#: src/muuli_wdr.cpp:2659
 msgid "This option makes aMule use Protocol Obfuscation when connecting other clients/servers."
 msgstr "Această opțiune determină aMule să utilizeze Protocolul Disimulare când conectează alți clienți/servere."
 
-#: src/muuli_wdr.cpp:2689
+#: src/muuli_wdr.cpp:2661
 msgid "Accept only obfuscated connections"
 msgstr "Acceptă numai conexiuni disimulate"
 
-#: src/muuli_wdr.cpp:2690
+#: src/muuli_wdr.cpp:2662
 msgid "This option makes aMule only accept obfuscated connections. You will have less sources, but all your traffic will be obfuscated"
 msgstr "Această opțiune face aMule să accepte numai conexiuni disimulate. Veți avea mai puține surse, dar tot traficul va fi disimulat"
 
-#: src/muuli_wdr.cpp:2695
+#: src/muuli_wdr.cpp:2667
 msgid "Everybody"
 msgstr "Fiecare"
 
-#: src/muuli_wdr.cpp:2697
+#: src/muuli_wdr.cpp:2669
 msgid "No one"
 msgstr "Nimănui"
 
-#: src/muuli_wdr.cpp:2699
+#: src/muuli_wdr.cpp:2671
 msgid "Who can see my shared files:"
 msgstr "Cine poate vedea fișierele mele partajate:"
 
-#: src/muuli_wdr.cpp:2700
+#: src/muuli_wdr.cpp:2672
 msgid "Select who can request to view a list of your shared files."
 msgstr "Selectați cine poate solicita să vizualizeze o listă a fișierelor partajate."
 
-#: src/muuli_wdr.cpp:2702
+#: src/muuli_wdr.cpp:2674
 msgid "IP-Filtering"
 msgstr "Filtrare-IP"
 
-#: src/muuli_wdr.cpp:2709
+#: src/muuli_wdr.cpp:2681
 msgid "Filter clients"
 msgstr "Filtru clienți"
 
-#: src/muuli_wdr.cpp:2711
+#: src/muuli_wdr.cpp:2683
 msgid "Enable filtering of the client IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "Activați filtrarea IP-urilor client cum este definit în fișierul ~/.aMule/ipfilter.dat."
 
-#: src/muuli_wdr.cpp:2713
+#: src/muuli_wdr.cpp:2685
 msgid "Filter servers"
 msgstr "Filtrare servere"
 
-#: src/muuli_wdr.cpp:2715
+#: src/muuli_wdr.cpp:2687
 msgid "Enable filtering of the server IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "Activați filtrarea IP-urilor server cum este definit în fișierul ~/.aMule/ipfilter.dat."
 
-#: src/muuli_wdr.cpp:2719
+#: src/muuli_wdr.cpp:2691
 msgid "Reload List"
 msgstr "Reîncarcă lista"
 
-#: src/muuli_wdr.cpp:2720
+#: src/muuli_wdr.cpp:2692
 msgid "Reload the list of IPs to filter from the file ~/.aMule/ipfilter.dat"
 msgstr "Reîncarcă lista IP-urilor de filtrat din fișierul ~/.aMule/ipfilter.dat"
 
-#: src/muuli_wdr.cpp:2726
+#: src/muuli_wdr.cpp:2698
 msgid "URL:"
 msgstr "URL:"
 
-#: src/muuli_wdr.cpp:2730 src/muuli_wdr.cpp:2923
+#: src/muuli_wdr.cpp:2702 src/muuli_wdr.cpp:2895
 msgid "Update now"
 msgstr "Actualizează acum"
 
-#: src/muuli_wdr.cpp:2733
+#: src/muuli_wdr.cpp:2705
 msgid "Auto-update ipfilter at startup"
 msgstr "Actualizare automată filtru ip la pornire"
 
-#: src/muuli_wdr.cpp:2737
+#: src/muuli_wdr.cpp:2709
 msgid "Filtering Level:"
 msgstr "Nivel de filtrare:"
 
-#: src/muuli_wdr.cpp:2743
+#: src/muuli_wdr.cpp:2715
 msgid "Always filter LAN IPs"
 msgstr "Filtrează mereu IP-urile LAN"
 
-#: src/muuli_wdr.cpp:2746
+#: src/muuli_wdr.cpp:2718
 msgid "Paranoid handling of non-matching IPs"
 msgstr "Manipulare paranoică a IP-urilor care nu se potrivesc"
 
-#: src/muuli_wdr.cpp:2748
+#: src/muuli_wdr.cpp:2720
 msgid "Rejects a packet when its source IP differs from the IP the client claims (an anti-spoofing check). Disable only if it causes connection problems."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2750
+#: src/muuli_wdr.cpp:2722
 msgid "Use system-wide ipfilter.dat if available"
 msgstr "Utilizați în tot sistemul ipfilter.dat dacă este disponibil"
 
-#: src/muuli_wdr.cpp:2751
+#: src/muuli_wdr.cpp:2723
 #, fuzzy
 msgid "If there's no local ipfilter.dat found, allow usage of a system-wide ipfilter file."
 msgstr "Dacă nu s-a găsit local ipfilter.dat, permite utilizarea unui fișier ipfilter din sistem."
 
-#: src/muuli_wdr.cpp:2768
+#: src/muuli_wdr.cpp:2740
 msgid "Enable Online-Signature"
 msgstr "Activare semnătură online"
 
-#: src/muuli_wdr.cpp:2770
+#: src/muuli_wdr.cpp:2742
 msgid "Enables the writing of the OS file, which can be used by external apps to create signatures and the like."
 msgstr "Activați scrierea fișierului OS, care poate fi utilizat de aplicații exterioare la crearea semnăturilor și aprecierii."
 
-#: src/muuli_wdr.cpp:2774
+#: src/muuli_wdr.cpp:2746
 msgid "Update Frequency (Secs):"
 msgstr "Frecvență actualizare (secunde)"
 
-#: src/muuli_wdr.cpp:2777
+#: src/muuli_wdr.cpp:2749
 msgid "Change the frequency (in seconds) of Online Signature updates."
 msgstr "Schimbați frecvența (în secunde) a actualizărilor semnăturii online."
 
-#: src/muuli_wdr.cpp:2785
+#: src/muuli_wdr.cpp:2757
 msgid "Save online signature file in: "
 msgstr "Salvează fișierul semnăturii online în:"
 
-#: src/muuli_wdr.cpp:2791
+#: src/muuli_wdr.cpp:2763
 msgid "Click here to select the directory containing the the Online Signature files."
 msgstr "Apăsați aici pentru a selecta directorul care conține fișierele cu semnătura online."
 
-#: src/muuli_wdr.cpp:2824
+#: src/muuli_wdr.cpp:2796
 msgid "Show country flags for clients"
 msgstr "Arată steagul țării pentru clienți"
 
-#: src/muuli_wdr.cpp:2825
+#: src/muuli_wdr.cpp:2797
 msgid "Render the country flag column in the transfers, queue and search views. Requires a valid MMDB GeoIP database (see below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2830
+#: src/muuli_wdr.cpp:2802
 #, fuzzy
 msgid "Database"
 msgstr "Rată date :"
 
-#: src/muuli_wdr.cpp:2846
+#: src/muuli_wdr.cpp:2818
 #, fuzzy
 msgid "Source:"
 msgstr "Surse"
 
-#: src/muuli_wdr.cpp:2849
+#: src/muuli_wdr.cpp:2821
 msgid "DB-IP (free, no account)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2850
+#: src/muuli_wdr.cpp:2822
 msgid "MaxMind GeoLite2 (free, account required)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2851
+#: src/muuli_wdr.cpp:2823
 msgid "Custom URL"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2854
+#: src/muuli_wdr.cpp:2826
 msgid "Choose which provider supplies the GeoIP MMDB database. DB-IP is the default - no account required. MaxMind requires a free account + license key. Use Custom URL to point at any other MMDB host (e.g. a local mirror)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2871
+#: src/muuli_wdr.cpp:2843
 msgid ""
 "No configuration required.\n"
 "\n"
@@ -4882,11 +4848,11 @@ msgid ""
 "License: Creative Commons BY 4.0 - https://creativecommons.org/licenses/by/4.0/"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2884
+#: src/muuli_wdr.cpp:2856
 msgid "License key:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2890
+#: src/muuli_wdr.cpp:2862
 msgid ""
 "Sign up for a free MaxMind account, then generate a License Key:\n"
 "https://www.maxmind.com/en/geolite2/signup\n"
@@ -4896,225 +4862,225 @@ msgid ""
 "Requires attribution and account registration; refresh at least every 30 days."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2905
+#: src/muuli_wdr.cpp:2877
 #, fuzzy
 msgid "Download URL:"
 msgstr "Descărcare:"
 
-#: src/muuli_wdr.cpp:2911
+#: src/muuli_wdr.cpp:2883
 msgid ""
 "Must point to an .mmdb file or a .gz / .tar.gz containing one.\n"
 "URL may include credentials (https://user:pass@host/...).\n"
 "License and attribution terms are set by the upstream URL - you are responsible."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2924
+#: src/muuli_wdr.cpp:2896
 msgid "Download the GeoIP database from the selected source."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2926
+#: src/muuli_wdr.cpp:2898
 #, fuzzy
 msgid "Auto-update on startup"
 msgstr "Actualizare automată filtru ip la pornire"
 
-#: src/muuli_wdr.cpp:2927
+#: src/muuli_wdr.cpp:2899
 msgid "Re-download the GeoIP database from the selected source every time aMule starts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2950
+#: src/muuli_wdr.cpp:2922
 msgid "Filter incoming messages (except current chat):"
 msgstr "Filtrare mesaje de intrare (cu excepția chat-ului curent):"
 
-#: src/muuli_wdr.cpp:2952
+#: src/muuli_wdr.cpp:2924
 msgid "Filter all messages"
 msgstr "Filtrează toate mesajele"
 
-#: src/muuli_wdr.cpp:2954
+#: src/muuli_wdr.cpp:2926
 msgid "Filter messages from people not on your friend list"
 msgstr "Filtrare mesaje de la persoane care nu sunt în lista de prieteni"
 
-#: src/muuli_wdr.cpp:2956
+#: src/muuli_wdr.cpp:2928
 msgid "Filter messages from unknown clients"
 msgstr "Filtrare mesaje de la clienți necunoscuți"
 
-#: src/muuli_wdr.cpp:2958
+#: src/muuli_wdr.cpp:2930
 msgid "Filter messages containing (use ',' as separator):"
 msgstr "Filtrare mesaje conținând )utilizați ',' ca separator):"
 
-#: src/muuli_wdr.cpp:2961 src/muuli_wdr.cpp:2972
+#: src/muuli_wdr.cpp:2933 src/muuli_wdr.cpp:2944
 msgid "add here the words amule should filter and block messages including it"
 msgstr "adăugați aici cuvintele pe care amule trebuie să le filtreze și să blocheze mesajele care le includ"
 
-#: src/muuli_wdr.cpp:2963
+#: src/muuli_wdr.cpp:2935
 msgid "Show received messages in the log"
 msgstr "Arată în jurnal mesajele primite"
 
-#: src/muuli_wdr.cpp:2966
+#: src/muuli_wdr.cpp:2938
 msgid "Comments"
 msgstr "Comentarii"
 
-#: src/muuli_wdr.cpp:2969
+#: src/muuli_wdr.cpp:2941
 msgid "Filter comments containing (use ',' as separator):"
 msgstr "Filtrare comentarii conținând (utilizați ',' ca separator):"
 
-#: src/muuli_wdr.cpp:2994
+#: src/muuli_wdr.cpp:2966
 msgid "Enable Proxy"
 msgstr "Activează proxy"
 
-#: src/muuli_wdr.cpp:2995
+#: src/muuli_wdr.cpp:2967
 msgid "Enable/disable proxy support"
 msgstr "Activează/dezactivează suportul proxy"
 
-#: src/muuli_wdr.cpp:2998
+#: src/muuli_wdr.cpp:2970
 msgid "Proxy type:"
 msgstr "Tip proxy:"
 
-#: src/muuli_wdr.cpp:3009
+#: src/muuli_wdr.cpp:2981
 msgid "Proxy host:"
 msgstr "Gazdă proxy:"
 
-#: src/muuli_wdr.cpp:3012
+#: src/muuli_wdr.cpp:2984
 msgid "The proxy host name"
 msgstr "Numele de gazdă proxy"
 
-#: src/muuli_wdr.cpp:3014
+#: src/muuli_wdr.cpp:2986
 msgid "Proxy port:"
 msgstr "Port proxy:"
 
-#: src/muuli_wdr.cpp:3017
+#: src/muuli_wdr.cpp:2989
 msgid "The proxy port"
 msgstr "Portul proxy"
 
-#: src/muuli_wdr.cpp:3019
+#: src/muuli_wdr.cpp:2991
 msgid "Enable authentication"
 msgstr "Activează autentificarea"
 
-#: src/muuli_wdr.cpp:3020
+#: src/muuli_wdr.cpp:2992
 msgid "Enable/disable username/password authentication"
 msgstr "Activează/dezactivează autentificarea cu nume utilizator/parolă"
 
-#: src/muuli_wdr.cpp:3023
+#: src/muuli_wdr.cpp:2995
 msgid "Username: "
 msgstr "Utilizator:"
 
-#: src/muuli_wdr.cpp:3026
+#: src/muuli_wdr.cpp:2998
 msgid "The username to use to connect to the proxy"
 msgstr "Numele de utilizator de utilizat pentru conectarea la proxy"
 
-#: src/muuli_wdr.cpp:3028
+#: src/muuli_wdr.cpp:3000
 msgid "Password:"
 msgstr "Parolă:"
 
-#: src/muuli_wdr.cpp:3031
+#: src/muuli_wdr.cpp:3003
 msgid "The password to use to connect to the proxy"
 msgstr "Parola de utilizat pentru conectarea la proxy"
 
-#: src/muuli_wdr.cpp:3050
+#: src/muuli_wdr.cpp:3022
 msgid "Connect to:"
 msgstr "Conectează la:"
 
-#: src/muuli_wdr.cpp:3059
+#: src/muuli_wdr.cpp:3031
 msgid "Login to remote amule"
 msgstr "Autentificare la amule distant"
 
-#: src/muuli_wdr.cpp:3064
+#: src/muuli_wdr.cpp:3036
 msgid "User name"
 msgstr "Nume utilizator"
 
-#: src/muuli_wdr.cpp:3075
+#: src/muuli_wdr.cpp:3047
 msgid "Remember those settings"
 msgstr "Amintește aceste configurări"
 
-#: src/muuli_wdr.cpp:3078
+#: src/muuli_wdr.cpp:3050
 #, fuzzy
 msgid "Force ZLIB compression"
 msgstr "Utilizează compresia gzip"
 
-#: src/muuli_wdr.cpp:3102
+#: src/muuli_wdr.cpp:3074
 msgid "Enable Verbose Debug-Logging."
 msgstr "Activează jurnalizarea de depanare detaliată."
 
-#: src/muuli_wdr.cpp:3104
+#: src/muuli_wdr.cpp:3076
 msgid "Only to Logfile"
 msgstr "Numai la fișierul jurnal"
 
-#: src/muuli_wdr.cpp:3106
+#: src/muuli_wdr.cpp:3078
 msgid "Message Categories:"
 msgstr "Categorii mesaje:"
 
-#: src/muuli_wdr.cpp:3130 src/PartFileConvertDlg.cpp:160
+#: src/muuli_wdr.cpp:3102 src/PartFileConvertDlg.cpp:160
 msgid "Waiting..."
 msgstr "Așteptați..."
 
-#: src/muuli_wdr.cpp:3150
+#: src/muuli_wdr.cpp:3122
 msgid "Add imports"
 msgstr "Adaugă importurile"
 
-#: src/muuli_wdr.cpp:3153
+#: src/muuli_wdr.cpp:3125
 msgid "Retry selected"
 msgstr "Reîncearcă selectatele"
 
-#: src/muuli_wdr.cpp:3155
+#: src/muuli_wdr.cpp:3127
 msgid "Remove selected"
 msgstr "Elimină selecția"
 
-#: src/muuli_wdr.cpp:3218
+#: src/muuli_wdr.cpp:3190
 msgid "Event Types"
 msgstr "Tipuri de evenimente"
 
-#: src/muuli_wdr.cpp:3237
+#: src/muuli_wdr.cpp:3209
 msgid "Statistics and queued clients for selected file(s) : Session / All time"
 msgstr "Statistici și clienți în coadă pentru fișier(ele) selectate : Sesiune / Tot timpul"
 
-#: src/muuli_wdr.cpp:3261
+#: src/muuli_wdr.cpp:3233
 msgid "Active Uploads"
 msgstr "Încărcări active"
 
-#: src/muuli_wdr.cpp:3275
+#: src/muuli_wdr.cpp:3247
 msgid "Percent of total files"
 msgstr "Procentul din totalul fișierelor"
 
-#: src/muuli_wdr.cpp:3327
+#: src/muuli_wdr.cpp:3299
 msgid "Show Clients for"
 msgstr "Arată clienții pentru"
 
-#: src/muuli_wdr.cpp:3329
+#: src/muuli_wdr.cpp:3301
 msgid "All files"
 msgstr "Toate fișierele"
 
-#: src/muuli_wdr.cpp:3332
+#: src/muuli_wdr.cpp:3304
 msgid "Selected files"
 msgstr "Fișierele selectate"
 
-#: src/muuli_wdr.cpp:3335
+#: src/muuli_wdr.cpp:3307
 msgid "Active uploads only"
 msgstr "Numai încărcările active"
 
-#: src/muuli_wdr.cpp:3342
+#: src/muuli_wdr.cpp:3314
 msgid "Reload:"
 msgstr "Reîncarcă:"
 
-#: src/muuli_wdr.cpp:3346
+#: src/muuli_wdr.cpp:3318
 msgid "Reload your shared files"
 msgstr "Reîncărcați fișierele partajate"
 
-#: src/muuli_wdr.cpp:3409
+#: src/muuli_wdr.cpp:3381
 msgid "Send"
 msgstr "Trimite"
 
-#: src/muuli_wdr.cpp:3410
+#: src/muuli_wdr.cpp:3382
 msgid "Sends the specified message."
 msgstr "Trimite mesajul specificat"
 
-#: src/muuli_wdr.cpp:3414
+#: src/muuli_wdr.cpp:3386
 msgid "Close this chat-session."
 msgstr "Închide această sesiune de chat."
 
-#: src/muuli_wdr.cpp:3437
+#: src/muuli_wdr.cpp:3409
 msgid "Connect to any server and/or Kad"
 msgstr "Conectare la orice server și/sau Kad"
 
-#: src/muuli_wdr.cpp:3443 src/SharedFilesCtrl.cpp:142 src/Statistics.cpp:941
+#: src/muuli_wdr.cpp:3415 src/SharedFilesCtrl.cpp:142 src/Statistics.cpp:941
 msgid "Shared Files"
 msgstr "Fișiere partajate"
 
@@ -5477,249 +5443,249 @@ msgstr "Descărcat"
 msgid "ERROR: Failed to open partfile '%s'"
 msgstr "EROARE: A eșuat deschiderea fișierului parțial '%s'"
 
-#: src/Preferences.cpp:701
+#: src/Preferences.cpp:673
 msgid "System default"
 msgstr "Valoare implicită a sistemului"
 
-#: src/Preferences.cpp:702
+#: src/Preferences.cpp:674
 msgid "Albanian"
 msgstr "Albaneză"
 
-#: src/Preferences.cpp:703
+#: src/Preferences.cpp:675
 msgid "Arabic"
 msgstr "Arabă"
 
-#: src/Preferences.cpp:704
+#: src/Preferences.cpp:676
 msgid "Asturian"
 msgstr "Asturian"
 
-#: src/Preferences.cpp:705
+#: src/Preferences.cpp:677
 msgid "Basque"
 msgstr "Bască"
 
-#: src/Preferences.cpp:706
+#: src/Preferences.cpp:678
 msgid "Bulgarian"
 msgstr "Bulgară"
 
-#: src/Preferences.cpp:707
+#: src/Preferences.cpp:679
 msgid "Catalan"
 msgstr "Catalană"
 
-#: src/Preferences.cpp:708
+#: src/Preferences.cpp:680
 msgid "Chinese (Simplified)"
 msgstr "Chineză (Simplificat)"
 
-#: src/Preferences.cpp:709
+#: src/Preferences.cpp:681
 msgid "Chinese (Traditional)"
 msgstr "Chinez (tradițional)"
 
-#: src/Preferences.cpp:710
+#: src/Preferences.cpp:682
 msgid "Croatian"
 msgstr "Croată"
 
-#: src/Preferences.cpp:711
+#: src/Preferences.cpp:683
 msgid "Czech"
 msgstr "Cehă"
 
-#: src/Preferences.cpp:712
+#: src/Preferences.cpp:684
 msgid "Danish"
 msgstr "Daneză"
 
-#: src/Preferences.cpp:713
+#: src/Preferences.cpp:685
 msgid "Dutch"
 msgstr "Olandeză"
 
-#: src/Preferences.cpp:714
+#: src/Preferences.cpp:686
 msgid "English (U.K.)"
 msgstr "Englez (U.K.)"
 
-#: src/Preferences.cpp:715
+#: src/Preferences.cpp:687
 #, fuzzy
 msgid "English (U.S.)"
 msgstr "Englez (U.K.)"
 
-#: src/Preferences.cpp:716
+#: src/Preferences.cpp:688
 msgid "Estonian"
 msgstr "Estonă"
 
-#: src/Preferences.cpp:717
+#: src/Preferences.cpp:689
 msgid "Finnish"
 msgstr "Finlandeză"
 
-#: src/Preferences.cpp:718
+#: src/Preferences.cpp:690
 msgid "French"
 msgstr "Franceză"
 
-#: src/Preferences.cpp:719
+#: src/Preferences.cpp:691
 msgid "Galician"
 msgstr "Galiciană"
 
-#: src/Preferences.cpp:720
+#: src/Preferences.cpp:692
 msgid "German"
 msgstr "Germană"
 
-#: src/Preferences.cpp:721
+#: src/Preferences.cpp:693
 msgid "Greek"
 msgstr "Grecesc"
 
-#: src/Preferences.cpp:722
+#: src/Preferences.cpp:694
 msgid "Hebrew"
 msgstr "Ebraică"
 
-#: src/Preferences.cpp:723
+#: src/Preferences.cpp:695
 msgid "Hungarian"
 msgstr "Maghiară"
 
-#: src/Preferences.cpp:724
+#: src/Preferences.cpp:696
 msgid "Italian"
 msgstr "Italiană"
 
-#: src/Preferences.cpp:725
+#: src/Preferences.cpp:697
 msgid "Japanese"
 msgstr "Japoneză"
 
-#: src/Preferences.cpp:726
+#: src/Preferences.cpp:698
 msgid "Korean"
 msgstr "Koreană"
 
-#: src/Preferences.cpp:727
+#: src/Preferences.cpp:699
 msgid "Latvian"
 msgstr ""
 
-#: src/Preferences.cpp:728
+#: src/Preferences.cpp:700
 msgid "Lithuanian"
 msgstr "Lituaniană"
 
-#: src/Preferences.cpp:729
+#: src/Preferences.cpp:701
 msgid "Norwegian (Nynorsk)"
 msgstr "Norvegian"
 
-#: src/Preferences.cpp:730
+#: src/Preferences.cpp:702
 msgid "Polish"
 msgstr "Poloneză"
 
-#: src/Preferences.cpp:731
+#: src/Preferences.cpp:703
 msgid "Portuguese"
 msgstr "Portugheză"
 
-#: src/Preferences.cpp:732
+#: src/Preferences.cpp:704
 msgid "Portuguese (Brazilian)"
 msgstr "Portugheză (Brazilia)"
 
-#: src/Preferences.cpp:733
+#: src/Preferences.cpp:705
 msgid "Romanian"
 msgstr "Română"
 
-#: src/Preferences.cpp:734
+#: src/Preferences.cpp:706
 msgid "Russian"
 msgstr "Rusă"
 
-#: src/Preferences.cpp:735
+#: src/Preferences.cpp:707
 msgid "Slovenian"
 msgstr "Slovenă"
 
-#: src/Preferences.cpp:736
+#: src/Preferences.cpp:708
 msgid "Spanish"
 msgstr "Spaniolă"
 
-#: src/Preferences.cpp:737
+#: src/Preferences.cpp:709
 msgid "Swedish"
 msgstr "Suedeză"
 
-#: src/Preferences.cpp:738
+#: src/Preferences.cpp:710
 msgid "Turkish"
 msgstr "Turcă"
 
-#: src/Preferences.cpp:739
+#: src/Preferences.cpp:711
 msgid "Ukrainian"
 msgstr "Ucraineană"
 
-#: src/Preferences.cpp:842
+#: src/Preferences.cpp:814
 msgid "Change Language"
 msgstr "Schimbă limba"
 
-#: src/Preferences.cpp:906
+#: src/Preferences.cpp:878
 msgid "There are no translations installed for aMule"
 msgstr "Nu sunt instalate traduceri pentru aMule"
 
-#: src/Preferences.cpp:907
+#: src/Preferences.cpp:879
 msgid "No languages available"
 msgstr "Nu sunt limbi disponibile"
 
-#: src/Preferences.cpp:1038
+#: src/Preferences.cpp:1010
 msgid "no options available"
 msgstr "Nu sunt opțiuni disponibile"
 
-#: src/Preferences.cpp:2226
+#: src/Preferences.cpp:2179
 msgid "Invalid category found, skipping"
 msgstr "S-a găsit o categorie nevalidă, se omite"
 
-#: src/Preferences.cpp:2395
+#: src/Preferences.cpp:2348
 msgid "TCP port can't be higher than 65532 due to server UDP socket being TCP+3"
 msgstr "Portul TCP nu poate fi mai mare decât 65532 fiindcă soclul UDP al serverului trebuie să fie TCP+3"
 
-#: src/Preferences.cpp:2396
+#: src/Preferences.cpp:2349
 #, c-format
 msgid "Default port will be used (%d)"
 msgstr "Va fi folosit portul implicit (%d)"
 
-#: src/PrefsUnifiedDlg.cpp:300 src/Statistics.cpp:866
+#: src/PrefsUnifiedDlg.cpp:298 src/Statistics.cpp:866
 msgid "Connection"
 msgstr "Conexiune"
 
-#: src/PrefsUnifiedDlg.cpp:301 src/SearchListCtrl.cpp:117
+#: src/PrefsUnifiedDlg.cpp:299 src/SearchListCtrl.cpp:117
 msgid "Directories"
 msgstr "Directoare"
 
-#: src/PrefsUnifiedDlg.cpp:302 src/Statistics.cpp:917
+#: src/PrefsUnifiedDlg.cpp:300 src/Statistics.cpp:917
 msgid "Servers"
 msgstr "Servere"
 
-#: src/PrefsUnifiedDlg.cpp:303 src/ServerListCtrl.cpp:96
+#: src/PrefsUnifiedDlg.cpp:301 src/ServerListCtrl.cpp:96
 msgid "Files"
 msgstr "Fișiere"
 
-#: src/PrefsUnifiedDlg.cpp:304
+#: src/PrefsUnifiedDlg.cpp:302
 msgid "Security"
 msgstr "Securitate"
 
-#: src/PrefsUnifiedDlg.cpp:305
+#: src/PrefsUnifiedDlg.cpp:303
 msgid "Interface"
 msgstr "Interfaţă"
 
-#: src/PrefsUnifiedDlg.cpp:312
+#: src/PrefsUnifiedDlg.cpp:310
 msgid "IP2Country"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:315
+#: src/PrefsUnifiedDlg.cpp:313
 msgid "Proxy"
 msgstr "Proxy"
 
-#: src/PrefsUnifiedDlg.cpp:316
+#: src/PrefsUnifiedDlg.cpp:314
 msgid "Filters"
 msgstr "Filtre"
 
-#: src/PrefsUnifiedDlg.cpp:317
+#: src/PrefsUnifiedDlg.cpp:315
 msgid "Remote Controls"
 msgstr "Control la distanță"
 
-#: src/PrefsUnifiedDlg.cpp:318
+#: src/PrefsUnifiedDlg.cpp:316
 msgid "Online Signature"
 msgstr "Semnătură online"
 
-#: src/PrefsUnifiedDlg.cpp:319
+#: src/PrefsUnifiedDlg.cpp:317
 msgid "Advanced"
 msgstr "Avansat"
 
-#: src/PrefsUnifiedDlg.cpp:320
+#: src/PrefsUnifiedDlg.cpp:318
 msgid "Events"
 msgstr "Evenimente"
 
-#: src/PrefsUnifiedDlg.cpp:323
+#: src/PrefsUnifiedDlg.cpp:321
 msgid "Debugging"
 msgstr "Depanare"
 
-#: src/PrefsUnifiedDlg.cpp:453
+#: src/PrefsUnifiedDlg.cpp:451
 msgid ""
 "The following variables will be substituted:\n"
 "    %PARTFILE - full path to the file\n"
@@ -5729,15 +5695,15 @@ msgstr ""
 "    %PARTFILE - calea completă la fișier\n"
 "    %PARTNAME - numai nume fișier"
 
-#: src/PrefsUnifiedDlg.cpp:474
+#: src/PrefsUnifiedDlg.cpp:472
 msgid "Tray icon support requires libayatana-appindicator3 at compile time."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:490
+#: src/PrefsUnifiedDlg.cpp:488
 msgid "Not available on Wayland: the protocol does not report when a window is minimized, so this option cannot intercept the system minimize button. Workaround: launch aMule with `GDK_BACKEND=x11` to use XWayland instead."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:536
+#: src/PrefsUnifiedDlg.cpp:534
 msgid ""
 "Do not change these setting unless you know\n"
 "what you are doing, otherwise you can easily\n"
@@ -5752,35 +5718,26 @@ msgstr ""
 "aMule va rula perfect fără să ajustați nimic\n"
 "din aceste configurări."
 
-#: src/PrefsUnifiedDlg.cpp:647
+#: src/PrefsUnifiedDlg.cpp:645
 #, c-format
 msgid "Failed to connect Cfg to widget with the ID %d and key %s"
 msgstr "A eșuat conectarea Cfg la widget cu ID %d și cheia %s"
 
-#: src/PrefsUnifiedDlg.cpp:695
+#: src/PrefsUnifiedDlg.cpp:693
 #, c-format
 msgid "Failed to transfer data from Cfg to Widget with the ID %d and key %s"
 msgstr "A eșuat transferul datelor de la Cfg la widget cu ID %d și cheia %s"
 
-#: src/PrefsUnifiedDlg.cpp:801
+#: src/PrefsUnifiedDlg.cpp:799
 msgid "The type of proxy you are connecting to"
 msgstr "Tipul de proxy la care sunteți conectat"
 
-#: src/PrefsUnifiedDlg.cpp:1020
+#: src/PrefsUnifiedDlg.cpp:1003
 #, c-format
 msgid "Failed to transfer data from Widget to Cfg with the ID %d and key %s"
 msgstr "A eșuat transferul datelor de la widget la Cfg cu ID %d și cheia %s"
 
 #: src/PrefsUnifiedDlg.cpp:1103
-#, fuzzy
-msgid "No password set."
-msgstr "Se verifică parola\n"
-
-#: src/PrefsUnifiedDlg.cpp:1132
-msgid "Guest access needs a password. Type one in the guest password field, or untick Enable guest access."
-msgstr ""
-
-#: src/PrefsUnifiedDlg.cpp:1144
 msgid ""
 "aMule must be restarted to enable these changes:\n"
 "\n"
@@ -5788,41 +5745,41 @@ msgstr ""
 "aMule trebuie repornit pentru ca aceste modificări să fie activate:\n"
 "\n"
 
-#: src/PrefsUnifiedDlg.cpp:1151
+#: src/PrefsUnifiedDlg.cpp:1110
 msgid "- TCP port changed.\n"
 msgstr "- Portul TCP s-a schimbat.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1156
+#: src/PrefsUnifiedDlg.cpp:1115
 msgid "- UDP port changed.\n"
 msgstr "- Portul UDP s-a schimbat.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1161
+#: src/PrefsUnifiedDlg.cpp:1120
 #, fuzzy
 msgid "- Network interface binding changed.\n"
 msgstr "- Interfața conexiunii externe s-a schimbat.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1166
+#: src/PrefsUnifiedDlg.cpp:1125
 msgid "- External connect port changed.\n"
 msgstr "- Portul conexiunii externe s-a schimbat.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1170
+#: src/PrefsUnifiedDlg.cpp:1129
 msgid "- External connect acceptance changed.\n"
 msgstr "- Conectarea externă acceptă modificarea.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1174
+#: src/PrefsUnifiedDlg.cpp:1133
 msgid "- External connect interface changed.\n"
 msgstr "- Interfața conexiunii externe s-a schimbat.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1178
+#: src/PrefsUnifiedDlg.cpp:1137
 msgid "- Protocol obfuscation support changed.\n"
 msgstr "- Suportul protocolului disimulare s-a schimbat.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1193
+#: src/PrefsUnifiedDlg.cpp:1151
 #, fuzzy
 msgid "- amuleapi settings changed.\n"
 msgstr "- Limba s-a schimbat.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1202
+#: src/PrefsUnifiedDlg.cpp:1160
 msgid ""
 "Your Auto-update server list is empty.\n"
 "'Auto-update server list at startup' will be disabled."
@@ -5830,7 +5787,7 @@ msgstr ""
 "Lista de actualizare automată a serverelor este goală.\n"
 "'Actualizează automat lista serverelor la pornire' va fi dezactivată."
 
-#: src/PrefsUnifiedDlg.cpp:1213
+#: src/PrefsUnifiedDlg.cpp:1171
 msgid ""
 "You have enabled external connections but have not specified a password.\n"
 "External connections cannot be enabled unless a valid password is specified."
@@ -5838,33 +5795,28 @@ msgstr ""
 "Ați activat conexiunile externe dar nu ați specificat o parolă.\n"
 "Conexiunile externe nu se pot activa până ce nu va fi specificată o parolă validă."
 
-#: src/PrefsUnifiedDlg.cpp:1246
-#, c-format
-msgid "The amuleapi password could not be saved: %s"
-msgstr ""
-
-#: src/PrefsUnifiedDlg.cpp:1276
+#: src/PrefsUnifiedDlg.cpp:1202
 msgid "- Language changed.\n"
 msgstr "- Limba s-a schimbat.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1281
+#: src/PrefsUnifiedDlg.cpp:1207
 msgid "- Temp folder changed.\n"
 msgstr "- Dosarul temporar s-a schimbat.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1286
+#: src/PrefsUnifiedDlg.cpp:1212
 msgid "- ED2K network enabled.\n"
 msgstr "- Rețeaua ED2K s-a activat.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1319
+#: src/PrefsUnifiedDlg.cpp:1245
 msgid "The shared-file exclusion pattern is not a valid regular expression. The filter has been left disabled."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1321 src/PrefsUnifiedDlg.cpp:1921
+#: src/PrefsUnifiedDlg.cpp:1247 src/PrefsUnifiedDlg.cpp:1841
 #, fuzzy
 msgid "Invalid regular expression"
 msgstr "Versiune protocol nevalidă."
 
-#: src/PrefsUnifiedDlg.cpp:1398
+#: src/PrefsUnifiedDlg.cpp:1324
 msgid ""
 "Both eD2k and Kad network are disabled.\n"
 "You won't be able to connect until you enable at least one of them."
@@ -5872,7 +5824,7 @@ msgstr ""
 "Ambele rețele eD2k și Kad sunt dezactivate.\n"
 "Nu vă puteți conecta doar după ce veți activa cel puțin una dintre ele."
 
-#: src/PrefsUnifiedDlg.cpp:1403
+#: src/PrefsUnifiedDlg.cpp:1329
 msgid ""
 "Kad will not start if your UDP port is disabled.\n"
 "Enable UDP port or disable Kad."
@@ -5880,7 +5832,7 @@ msgstr ""
 "Kad nu va porni dacă portul UDP este dezactivat.\n"
 "Activați portul UDP sau dezactivați Kad."
 
-#: src/PrefsUnifiedDlg.cpp:1459
+#: src/PrefsUnifiedDlg.cpp:1385
 msgid ""
 "\n"
 "You MUST restart aMule now.\n"
@@ -5890,69 +5842,69 @@ msgstr ""
 "Trebuie să reporniți aMule acum.\n"
 "Dacă nu îl reporniți acum, nu vă plângeți dacă ceva rău se întâmplă.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1524
+#: src/PrefsUnifiedDlg.cpp:1450
 msgid "Could not register aMule for autostart at login. The autostart store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1526
+#: src/PrefsUnifiedDlg.cpp:1452
 msgid "Could not remove the autostart-at-login entry."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1527
+#: src/PrefsUnifiedDlg.cpp:1453
 #, fuzzy
 msgid "Autostart"
 msgstr "Reîmprospătarea automată pornită"
 
-#: src/PrefsUnifiedDlg.cpp:1542
+#: src/PrefsUnifiedDlg.cpp:1468
 msgid "Register file type"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1542
+#: src/PrefsUnifiedDlg.cpp:1468
 msgid "Register URL handler"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1550
+#: src/PrefsUnifiedDlg.cpp:1476
 #, c-format
 msgid "aMule only handles eD2k-compatible magnets. If you replace the current magnet handler (%s), BitTorrent magnet links will stop working - aMule cannot download BitTorrent content. Continue?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1555
+#: src/PrefsUnifiedDlg.cpp:1481
 #, c-format
 msgid "Another application currently opens .emulecollection files (%s). Replace it with aMule?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1560
+#: src/PrefsUnifiedDlg.cpp:1486
 #, c-format
 msgid "Another application is currently the default handler for these links (%s). Replace it with aMule?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1585
+#: src/PrefsUnifiedDlg.cpp:1511
 msgid "Could not register aMule for .emulecollection files. The registration store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1587
+#: src/PrefsUnifiedDlg.cpp:1513
 #, fuzzy
 msgid "Could not remove the file type registration."
 msgstr "Dosar pentru fișiere descărcate temporar"
 
-#: src/PrefsUnifiedDlg.cpp:1589
+#: src/PrefsUnifiedDlg.cpp:1515
 msgid "Could not register aMule as the URL handler. The registration store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1591
+#: src/PrefsUnifiedDlg.cpp:1517
 msgid "Could not remove the URL handler registration."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1661 src/PrefsUnifiedDlg.cpp:1688
+#: src/PrefsUnifiedDlg.cpp:1587 src/PrefsUnifiedDlg.cpp:1614
 #, fuzzy
 msgid "The web server and aMule API require external connections to be enabled."
 msgstr "Configurarea parolei și conexiunile externe sunt activate."
 
-#: src/PrefsUnifiedDlg.cpp:1671
+#: src/PrefsUnifiedDlg.cpp:1597
 msgid "The aMule web server is deprecated. Consider running the aMule API instead."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1735
+#: src/PrefsUnifiedDlg.cpp:1655
 msgid ""
 "Your Auto-update servers list is in blank.\n"
 "Please fill in at least one URL to point to a valid server.met file.\n"
@@ -5962,24 +5914,24 @@ msgstr ""
 "Introduceți în listă cel puțin o adresă URL pentru a se indica un fișier server.met valid.\n"
 "Apăsați butonul \"List\" cu această căsuță pentru a introduce o adresă URL."
 
-#: src/PrefsUnifiedDlg.cpp:1876
+#: src/PrefsUnifiedDlg.cpp:1796
 msgid "Temporary files"
 msgstr "Fișiere temporare"
 
-#: src/PrefsUnifiedDlg.cpp:1881
+#: src/PrefsUnifiedDlg.cpp:1801
 msgid "Incoming files"
 msgstr "Fișiere de intrare"
 
-#: src/PrefsUnifiedDlg.cpp:1886
+#: src/PrefsUnifiedDlg.cpp:1806
 msgid "Online Signatures"
 msgstr "Semnături online"
 
-#: src/PrefsUnifiedDlg.cpp:1899
+#: src/PrefsUnifiedDlg.cpp:1819
 #, c-format
 msgid "Choose a folder for %s"
 msgstr "Alegeți un dosar pentru %s"
 
-#: src/PrefsUnifiedDlg.cpp:1923
+#: src/PrefsUnifiedDlg.cpp:1843
 #, fuzzy, c-format
 msgid "Would exclude %u of %u shared file"
 msgid_plural "Would exclude %u of %u shared files"
@@ -5987,42 +5939,42 @@ msgstr[0] "S-a găsit %i fișier partajat cunoscut"
 msgstr[1] "S-au găsit %i fișiere partajate cunoscute"
 msgstr[2] "S-au găsit %i de fișiere partajate cunoscute"
 
-#: src/PrefsUnifiedDlg.cpp:1940
+#: src/PrefsUnifiedDlg.cpp:1860
 msgid "Browse for videoplayer"
 msgstr "Navigați pentru playerul video"
 
-#: src/PrefsUnifiedDlg.cpp:1944
+#: src/PrefsUnifiedDlg.cpp:1864
 msgid "Select browser"
 msgstr "Selectare navigator"
 
-#: src/PrefsUnifiedDlg.cpp:1948
+#: src/PrefsUnifiedDlg.cpp:1868
 #, fuzzy
 msgid "Select ffprobe binary"
 msgstr "Selectare navigator"
 
-#: src/PrefsUnifiedDlg.cpp:1954
+#: src/PrefsUnifiedDlg.cpp:1874
 #, c-format
 msgid "Executable%s"
 msgstr "Executabil%s"
 
-#: src/PrefsUnifiedDlg.cpp:1988
+#: src/PrefsUnifiedDlg.cpp:1908
 msgid "ffprobe not found on PATH or in the standard install locations. Install ffmpeg (which ships ffprobe) or use Browse to pick a binary manually."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2000
+#: src/PrefsUnifiedDlg.cpp:1920
 msgid "Reset the settings on this page to their default values?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2001
+#: src/PrefsUnifiedDlg.cpp:1921
 #, fuzzy
 msgid "Reset to defaults"
 msgstr "Valoare implicită a sistemului"
 
-#: src/PrefsUnifiedDlg.cpp:2028
+#: src/PrefsUnifiedDlg.cpp:1948
 msgid "Edit server list"
 msgstr "Editare listă server"
 
-#: src/PrefsUnifiedDlg.cpp:2029
+#: src/PrefsUnifiedDlg.cpp:1949
 msgid ""
 "Add here URL's to download server.met files.\n"
 "Only one url on each line."
@@ -6030,42 +5982,42 @@ msgstr ""
 "Adăugați aici adresele URL pentru descărcat fișierele server.met.\n"
 "Numai o singură adresă URL pe fiecare linie."
 
-#: src/PrefsUnifiedDlg.cpp:2084
+#: src/PrefsUnifiedDlg.cpp:2004
 msgid "IP2Country update failed"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2229 src/PrefsUnifiedDlg.cpp:2260
+#: src/PrefsUnifiedDlg.cpp:2149 src/PrefsUnifiedDlg.cpp:2180
 msgid "Data by MaxMind GeoLite2"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2231 src/PrefsUnifiedDlg.cpp:2262
+#: src/PrefsUnifiedDlg.cpp:2151 src/PrefsUnifiedDlg.cpp:2182
 #, fuzzy
 msgid "Custom source"
 msgstr "Surse complete"
 
-#: src/PrefsUnifiedDlg.cpp:2233 src/PrefsUnifiedDlg.cpp:2264
+#: src/PrefsUnifiedDlg.cpp:2153 src/PrefsUnifiedDlg.cpp:2184
 msgid "Data by DB-IP.com"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2284
+#: src/PrefsUnifiedDlg.cpp:2204
 #, fuzzy, c-format
 msgid "Status: Loaded%s"
 msgstr "Stare:"
 
-#: src/PrefsUnifiedDlg.cpp:2286
+#: src/PrefsUnifiedDlg.cpp:2206
 #, fuzzy, c-format
 msgid "Status: Loaded%s - %s"
 msgstr "Stare:"
 
-#: src/PrefsUnifiedDlg.cpp:2290
+#: src/PrefsUnifiedDlg.cpp:2210
 msgid "Status: Failed to load - click 'Update now' to refresh."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2292
+#: src/PrefsUnifiedDlg.cpp:2212
 msgid "Status: Not found - click 'Update now' to download."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2350 src/PrefsUnifiedDlg.cpp:2374
+#: src/PrefsUnifiedDlg.cpp:2270 src/PrefsUnifiedDlg.cpp:2294
 #, c-format
 msgid "Update delay: %d second"
 msgid_plural "Update delay: %d seconds"
@@ -6073,7 +6025,7 @@ msgstr[0] "Întârziere actualizare: %d secundă"
 msgstr[1] "Întârziere actualizare: %d secunde"
 msgstr[2] "Întârziere actualizare: %d de secunde"
 
-#: src/PrefsUnifiedDlg.cpp:2358
+#: src/PrefsUnifiedDlg.cpp:2278
 #, c-format
 msgid "Time for average graph: %d minute"
 msgid_plural "Time for average graph: %d minutes"
@@ -6081,12 +6033,12 @@ msgstr[0] "Timp pentru media graficului: %d minut"
 msgstr[1] "Timp pentru media graficului: %d minute"
 msgstr[2] "Timp pentru media graficului: %d de minute"
 
-#: src/PrefsUnifiedDlg.cpp:2367
+#: src/PrefsUnifiedDlg.cpp:2287
 #, c-format
 msgid "Connections Graph Scale: %d"
 msgstr "Scală grafic conexiuni: %d"
 
-#: src/PrefsUnifiedDlg.cpp:2382
+#: src/PrefsUnifiedDlg.cpp:2302
 #, c-format
 msgid "File Buffer Size: %d byte"
 msgid_plural "File Buffer Size: %d bytes"
@@ -6094,7 +6046,7 @@ msgstr[0] "Dimensiune fișier tampon: %d octet"
 msgstr[1] "Dimensiune fișier tampon: %d octeți"
 msgstr[2] "Dimensiune fișier tampon: %d de octeți"
 
-#: src/PrefsUnifiedDlg.cpp:2392
+#: src/PrefsUnifiedDlg.cpp:2312
 #, c-format
 msgid "Upload Queue Size: %d client"
 msgid_plural "Upload Queue Size: %d clients"
@@ -6102,7 +6054,7 @@ msgstr[0] "Dimensiune coadă încărcări: %d client"
 msgstr[1] "Dimensiune coadă încărcări: %d clienți"
 msgstr[2] "Dimensiune coadă încărcări: %d de clienți"
 
-#: src/PrefsUnifiedDlg.cpp:2402
+#: src/PrefsUnifiedDlg.cpp:2322
 #, c-format
 msgid "Server connection refresh interval: %d minute"
 msgid_plural "Server connection refresh interval: %d minutes"
@@ -6110,105 +6062,101 @@ msgstr[0] "Interval reâmprospătare conexiune server: %d minut"
 msgstr[1] "Interval reâmprospătare conexiune server: %d minute"
 msgstr[2] "Interval reâmprospătare conexiune server: %d de minute"
 
-#: src/PrefsUnifiedDlg.cpp:2407
+#: src/PrefsUnifiedDlg.cpp:2327
 msgid "Server connection refresh interval: Disabled"
 msgstr "Interval reâmprospătare conexiune server: Dezactivat"
 
-#: src/PrefsUnifiedDlg.cpp:2451
+#: src/PrefsUnifiedDlg.cpp:2371
 msgid "disabled"
 msgstr "dezactivată"
 
-#: src/PrefsUnifiedDlg.cpp:2477
+#: src/PrefsUnifiedDlg.cpp:2397
 #, c-format
 msgid "Execute command on '%s' event"
 msgstr "Execută comanda la evenimentul '%s' "
 
-#: src/PrefsUnifiedDlg.cpp:2484
+#: src/PrefsUnifiedDlg.cpp:2404
 msgid "Enable command execution on core"
 msgstr "Activați executarea de comenzi în nucleu"
 
-#: src/PrefsUnifiedDlg.cpp:2496
+#: src/PrefsUnifiedDlg.cpp:2416
 msgid "Core command:"
 msgstr "Comandă nucleu:"
 
-#: src/PrefsUnifiedDlg.cpp:2512
+#: src/PrefsUnifiedDlg.cpp:2432
 msgid "Enable command execution on GUI"
 msgstr "Activează execuția comenzi pe GUI"
 
-#: src/PrefsUnifiedDlg.cpp:2524
+#: src/PrefsUnifiedDlg.cpp:2444
 msgid "GUI command:"
 msgstr "Comandă GUI:"
 
-#: src/PrefsUnifiedDlg.cpp:2540
+#: src/PrefsUnifiedDlg.cpp:2460
 msgid "The following variables will be replaced:"
 msgstr "Următoarele variabile vor fi înlocuite:"
 
-#: src/PrefsUnifiedDlg.cpp:2708
+#: src/PrefsUnifiedDlg.cpp:2628
 msgid ""
 "The following folders look like system or sensitive locations:\n"
 "\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2713
+#: src/PrefsUnifiedDlg.cpp:2633
 msgid "Sharing them recursively will publish every file underneath on the eD2k/Kad networks. Do you really want to do this?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2716
+#: src/PrefsUnifiedDlg.cpp:2636
 #, fuzzy
 msgid "Confirm shared folders"
 msgstr "Dosare partajate"
 
-#: src/PrefsUnifiedDlg.cpp:2744
+#: src/PrefsUnifiedDlg.cpp:2664
 #, fuzzy
 msgid "Reloading shared files..."
 msgstr "Reîncărcați fișierele partajate"
 
-#: src/PrefsUnifiedDlg.cpp:2745
+#: src/PrefsUnifiedDlg.cpp:2665
 msgid "Scanning for subdirectories..."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2746
+#: src/PrefsUnifiedDlg.cpp:2666
 #, fuzzy
 msgid "Updating shared folders"
 msgstr "Dosare partajate"
 
-#: src/PrefsUnifiedDlg.cpp:2773
+#: src/PrefsUnifiedDlg.cpp:2693
 #, c-format
 msgid "Scanned %u directories..."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2823
+#: src/PrefsUnifiedDlg.cpp:2743
 #, fuzzy, c-format
 msgid "Reloading shared files: %u files scanned"
 msgstr "Reîncarcă lista fișierelor partajate."
 
-#: src/PrefsUnifiedDlg.cpp:2873
+#: src/PrefsUnifiedDlg.cpp:2793
 #, fuzzy
 msgid "Shared folder"
 msgstr "Dosare partajate"
 
-#: src/SearchDlg.cpp:280
-msgid "Clear search history"
-msgstr ""
-
-#: src/SearchDlg.cpp:584
+#: src/SearchDlg.cpp:425
 msgid "It's impossible to search when both eD2k and Kademlia are disabled."
 msgstr ""
 
-#: src/SearchDlg.cpp:585 src/SearchListCtrl.cpp:858
+#: src/SearchDlg.cpp:426 src/SearchListCtrl.cpp:858
 #, fuzzy
 msgid "Search error"
 msgstr "Căutări"
 
-#: src/SearchDlg.cpp:929
+#: src/SearchDlg.cpp:768
 msgid "Min size must be smaller than max size. Max size ignored."
 msgstr "Dimensiunea mică trebuie să fie mai mică decât dimensiunea mare. Dimensiunea maximă s-a ignorat."
 
-#: src/SearchDlg.cpp:930 src/SearchDlg.cpp:1012
+#: src/SearchDlg.cpp:769 src/SearchDlg.cpp:851
 msgid "Search warning"
 msgstr "Atenționare căutare"
 
-#: src/SearchDlg.cpp:1092 src/SearchListCtrl.cpp:735
+#: src/SearchDlg.cpp:929 src/SearchListCtrl.cpp:735
 msgid "Main"
 msgstr "Principal"
 

--- a/po/ru.po
+++ b/po/ru.po
@@ -14,7 +14,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-28 08:06+0200\n"
+"POT-Creation-Date: 2026-07-28 10:19+0200\n"
 "PO-Revision-Date: 2026-07-27 11:45+0000\n"
 "Last-Translator: Radist Morse <radist.morse@gmail.com>\n"
 "Language-Team: Russian <kde-russian@lists.kde.ru>\n"
@@ -151,7 +151,7 @@ msgstr ""
 msgid "Not now"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:422 src/amuleDlg.cpp:600
+#: src/AppImageIntegration.cpp:422 src/amuleDlg.cpp:665
 msgid "Don't ask again"
 msgstr ""
 
@@ -224,7 +224,7 @@ msgid "Killing amuleweb instance with pid '%d' ... "
 msgstr "Убиваем процесс amuleweb с pid `%d' ... "
 
 #: src/amule.cpp:336 src/amule.cpp:349 src/ClientRef.cpp:180
-#: src/SearchDlg.cpp:880 src/ServerListCtrl.cpp:98
+#: src/SearchDlg.cpp:1041 src/ServerListCtrl.cpp:98
 msgid "Failed"
 msgstr "Неудачно"
 
@@ -584,30 +584,68 @@ msgstr "Не удалось создать pid-файл"
 msgid "ERROR: %s"
 msgstr "Ошибка: %s"
 
-#: src/amuleDlg.cpp:236
+#: src/amuleDlg.cpp:250
 #, c-format
 msgid "This is aMule %s based on eMule."
 msgstr "aMule %s (основан на eMule)."
 
-#: src/amuleDlg.cpp:237
+#: src/amuleDlg.cpp:251
 #, c-format
 msgid "Running on %s"
 msgstr "Работает на %s"
 
-#: src/amuleDlg.cpp:239
+#: src/amuleDlg.cpp:253
 msgid "Visit https://github.com/amule-org/amule/releases/latest to check if a new version is available."
 msgstr "Посетите https://github.com/amule-org/amule/releases/latest для проверки наличия новой версии."
 
-#: src/amuleDlg.cpp:268
+#: src/amuleDlg.cpp:282
 msgid "FATAL ERROR: Failed to create Timer"
 msgstr "ФАТАЛЬНАЯ ОШИБКА: не удалось создать таймер"
 
-#: src/amuleDlg.cpp:592
+#: src/amuleDlg.cpp:361 src/amuleDlg.cpp:1787 src/amuleDlg.cpp:2033
+#: src/muuli_wdr.cpp:1492 src/muuli_wdr.cpp:3418
+msgid "Networks"
+msgstr "Сети"
+
+#: src/amuleDlg.cpp:362 src/amuleDlg.cpp:1793 src/muuli_wdr.cpp:3419
+msgid "Searches"
+msgstr "Поиск"
+
+#: src/amuleDlg.cpp:363 src/amuleDlg.cpp:1799 src/DownloadListCtrl.cpp:740
+#: src/muuli_wdr.cpp:392 src/muuli_wdr.cpp:1585 src/muuli_wdr.cpp:3420
+#: src/Statistics.cpp:829
+msgid "Downloads"
+msgstr "Загрузки"
+
+#: src/amuleDlg.cpp:364 src/amuleDlg.cpp:1805 src/muuli_wdr.cpp:3294
+msgid "Shared files"
+msgstr "Публикуемые файлы"
+
+#: src/amuleDlg.cpp:365 src/amuleDlg.cpp:1811 src/muuli_wdr.cpp:2926
+#: src/muuli_wdr.cpp:3376 src/muuli_wdr.cpp:3423
+msgid "Messages"
+msgstr "Сообщения"
+
+#: src/amuleDlg.cpp:366 src/amuleDlg.cpp:1817 src/muuli_wdr.cpp:3424
+#: src/PrefsUnifiedDlg.cpp:312 src/Statistics.cpp:779 src/Statistics.cpp:1235
+msgid "Statistics"
+msgstr "Статистика"
+
+#: src/amuleDlg.cpp:368 src/amuleDlg.cpp:1824 src/muuli_wdr.cpp:3426
+#: src/PrefsUnifiedDlg.cpp:328 src/utils/wxCas/src/wxcasprefs.cpp:39
+msgid "Preferences"
+msgstr "Настройки"
+
+#: src/amuleDlg.cpp:371
+msgid "Navigate"
+msgstr ""
+
+#: src/amuleDlg.cpp:657
 #, fuzzy
 msgid "New version available"
 msgstr "Недоступен"
 
-#: src/amuleDlg.cpp:596
+#: src/amuleDlg.cpp:661
 #, fuzzy, c-format
 msgid ""
 "A new version of aMule (%s) is available.\n"
@@ -617,218 +655,185 @@ msgid ""
 "Would you like to open the download page?"
 msgstr "Актуальная версия aMule всегда доступна тут:  https://github.com/amule-org/amule/releases/latest"
 
-#: src/amuleDlg.cpp:678
+#: src/amuleDlg.cpp:743
 msgid "aMule dialog destroyed"
 msgstr "диалоговое окно aMule уничтожено"
 
-#: src/amuleDlg.cpp:701 src/DataToText.cpp:68 src/IPFilter.cpp:547
+#: src/amuleDlg.cpp:766 src/DataToText.cpp:68 src/IPFilter.cpp:547
 msgid "Connecting"
 msgstr "Идет подключение"
 
-#: src/amuleDlg.cpp:893
+#: src/amuleDlg.cpp:958
 msgid "eD2k: Connecting"
 msgstr "eD2k: Соединение"
 
-#: src/amuleDlg.cpp:897
+#: src/amuleDlg.cpp:962
 msgid "eD2k: Disconnected"
 msgstr "eD2k: не соединено"
 
-#: src/amuleDlg.cpp:903
+#: src/amuleDlg.cpp:968
 msgid "Kad: Firewalled"
 msgstr "Kad: За брандмауэром"
 
-#: src/amuleDlg.cpp:907
+#: src/amuleDlg.cpp:972
 msgid "Kad: Connected"
 msgstr "Kad: Подключена"
 
-#: src/amuleDlg.cpp:912
+#: src/amuleDlg.cpp:977
 msgid "Kad: Connecting"
 msgstr "Kad: Идет подключение"
 
-#: src/amuleDlg.cpp:916
+#: src/amuleDlg.cpp:981
 msgid "Kad: Off"
 msgstr " Kad: Выключено"
 
-#: src/amuleDlg.cpp:964 src/DownloadListCtrl.cpp:505
+#: src/amuleDlg.cpp:1029 src/DownloadListCtrl.cpp:505
 #: src/DownloadListCtrl.cpp:749 src/FriendListCtrl.cpp:180
 #: src/muuli_wdr.cpp:731 src/muuli_wdr.cpp:782 src/muuli_wdr.cpp:846
-#: src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2224 src/muuli_wdr.cpp:2309
-#: src/muuli_wdr.cpp:3057 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
+#: src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2231 src/muuli_wdr.cpp:2316
+#: src/muuli_wdr.cpp:3064 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
 #: src/ServerListCtrl.cpp:606 src/TransferWnd.cpp:378
 #: src/utils/wxCas/src/wxcasprefs.cpp:235
 msgid "Cancel"
 msgstr "Отменить"
 
-#: src/amuleDlg.cpp:965
+#: src/amuleDlg.cpp:1030
 msgid "Stop the current connection attempts"
 msgstr "Прекратить попытки соединения"
 
-#: src/amuleDlg.cpp:970 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976
-#: src/muuli_wdr.cpp:2447
+#: src/amuleDlg.cpp:1035 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976
+#: src/muuli_wdr.cpp:2454
 msgid "Disconnect"
 msgstr "Отключиться"
 
-#: src/amuleDlg.cpp:971
+#: src/amuleDlg.cpp:1036
 msgid "Disconnect from the currently connected networks"
 msgstr "Отключиться от работающих сетей"
 
-#: src/amuleDlg.cpp:976 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979
-#: src/muuli_wdr.cpp:2602 src/muuli_wdr.cpp:3054 src/muuli_wdr.cpp:3409
+#: src/amuleDlg.cpp:1041 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979
+#: src/muuli_wdr.cpp:2609 src/muuli_wdr.cpp:3061 src/muuli_wdr.cpp:3416
 msgid "Connect"
 msgstr "Подключиться"
 
-#: src/amuleDlg.cpp:977
+#: src/amuleDlg.cpp:1042
 msgid "Connect to the currently enabled networks"
 msgstr "Подключиться к разрешенным сетям"
 
-#: src/amuleDlg.cpp:1089
+#: src/amuleDlg.cpp:1154
 #, fuzzy, c-format
 msgid "Up: %.1f%s (%.1f) | Down: %.1f%s (%.1f)"
 msgstr "Передача: %.1f(%.1f) | Прием: %.1f(%.1f)"
 
-#: src/amuleDlg.cpp:1091 src/amuleDlg.cpp:1093 src/amuleDlg.cpp:1097
-#: src/amuleDlg.cpp:1099 src/amuleDlg.cpp:1110 src/amuleDlg.cpp:1112
+#: src/amuleDlg.cpp:1156 src/amuleDlg.cpp:1158 src/amuleDlg.cpp:1162
+#: src/amuleDlg.cpp:1164 src/amuleDlg.cpp:1175 src/amuleDlg.cpp:1177
 #: src/MuleTrayIcon.cpp:796 src/MuleTrayIcon.cpp:799
 #, fuzzy
 msgid " MB/s"
 msgstr "МБ/с"
 
-#: src/amuleDlg.cpp:1091 src/amuleDlg.cpp:1093 src/amuleDlg.cpp:1097
-#: src/amuleDlg.cpp:1099 src/amuleDlg.cpp:1110 src/amuleDlg.cpp:1112
+#: src/amuleDlg.cpp:1156 src/amuleDlg.cpp:1158 src/amuleDlg.cpp:1162
+#: src/amuleDlg.cpp:1164 src/amuleDlg.cpp:1175 src/amuleDlg.cpp:1177
 #: src/MuleTrayIcon.cpp:796 src/MuleTrayIcon.cpp:799
 #: src/utils/wxCas/src/wxcasframe.cpp:1041
 msgid " kB/s"
 msgstr "kB/сек"
 
-#: src/amuleDlg.cpp:1096
+#: src/amuleDlg.cpp:1161
 #, fuzzy, c-format
 msgid "Up: %.1f%s | Down: %.1f%s"
 msgstr "Передача: %.1f | Прием: %.1f"
 
-#: src/amuleDlg.cpp:1128
+#: src/amuleDlg.cpp:1193
 #, c-format
 msgid "aMule (%s | Connected)"
 msgstr "aMule (%s | Подключен)"
 
-#: src/amuleDlg.cpp:1130
+#: src/amuleDlg.cpp:1195
 #, c-format
 msgid "aMule (%s | Disconnected)"
 msgstr "aMule (%s | Отключен)"
 
-#: src/amuleDlg.cpp:1183
+#: src/amuleDlg.cpp:1248
 #, c-format
 msgid "Do you really want to exit %s?"
 msgstr "Вы действительно хотите выйти из %s?"
 
-#: src/amuleDlg.cpp:1185
+#: src/amuleDlg.cpp:1250
 msgid "Exit confirmation"
 msgstr "Подтверждение выхода"
 
-#: src/amuleDlg.cpp:1548
+#: src/amuleDlg.cpp:1613
 msgid "Launch Command: "
 msgstr "Команда запуска:"
 
-#: src/amuleDlg.cpp:1567 src/muuli_wdr.cpp:1971 src/Preferences.cpp:951
+#: src/amuleDlg.cpp:1632 src/muuli_wdr.cpp:1978 src/Preferences.cpp:952
 msgid "- default -"
 msgstr "- по умолчанию -"
 
-#: src/amuleDlg.cpp:1595
+#: src/amuleDlg.cpp:1660
 #, c-format
 msgid "Skin directory '%s' does not exist"
 msgstr "Каталог с темами оформления '%s' не существует."
 
-#: src/amuleDlg.cpp:1598
+#: src/amuleDlg.cpp:1663
 #, c-format
 msgid "WARNING: Unable to open skin file '%s' for read"
 msgstr "ПРЕДУПРЕЖДЕНИЕ: невозможно открыть для чтения файл скина '%s'"
 
-#: src/amuleDlg.cpp:1722 src/amuleDlg.cpp:1968 src/muuli_wdr.cpp:1485
-#: src/muuli_wdr.cpp:3411
-msgid "Networks"
-msgstr "Сети"
-
-#: src/amuleDlg.cpp:1726 src/muuli_wdr.cpp:3411
+#: src/amuleDlg.cpp:1791 src/muuli_wdr.cpp:3418
 msgid "Networks Window"
 msgstr "Окно сетей"
 
-#: src/amuleDlg.cpp:1728 src/muuli_wdr.cpp:3412
-msgid "Searches"
-msgstr "Поиск"
-
-#: src/amuleDlg.cpp:1732 src/muuli_wdr.cpp:3412
+#: src/amuleDlg.cpp:1797 src/muuli_wdr.cpp:3419
 msgid "Searches Window"
 msgstr "Окно поиска"
 
-#: src/amuleDlg.cpp:1734 src/DownloadListCtrl.cpp:740 src/muuli_wdr.cpp:392
-#: src/muuli_wdr.cpp:1578 src/muuli_wdr.cpp:3413 src/Statistics.cpp:829
-msgid "Downloads"
-msgstr "Загрузки"
-
-#: src/amuleDlg.cpp:1738 src/muuli_wdr.cpp:3413
+#: src/amuleDlg.cpp:1803 src/muuli_wdr.cpp:3420
 msgid "Downloads Window"
 msgstr "Окно загрузки"
 
-#: src/amuleDlg.cpp:1740 src/muuli_wdr.cpp:3287
-msgid "Shared files"
-msgstr "Публикуемые файлы"
-
-#: src/amuleDlg.cpp:1744 src/muuli_wdr.cpp:3415
+#: src/amuleDlg.cpp:1809 src/muuli_wdr.cpp:3422
 msgid "Shared Files Window"
 msgstr "Окно публикуемых файлов"
 
-#: src/amuleDlg.cpp:1746 src/muuli_wdr.cpp:2919 src/muuli_wdr.cpp:3369
-#: src/muuli_wdr.cpp:3416
-msgid "Messages"
-msgstr "Сообщения"
-
-#: src/amuleDlg.cpp:1750 src/muuli_wdr.cpp:3416
+#: src/amuleDlg.cpp:1815 src/muuli_wdr.cpp:3423
 msgid "Messages Window"
 msgstr "Сообщения"
 
-#: src/amuleDlg.cpp:1752 src/muuli_wdr.cpp:3417 src/PrefsUnifiedDlg.cpp:312
-#: src/Statistics.cpp:779 src/Statistics.cpp:1235
-msgid "Statistics"
-msgstr "Статистика"
-
-#: src/amuleDlg.cpp:1756 src/muuli_wdr.cpp:3417
+#: src/amuleDlg.cpp:1821 src/muuli_wdr.cpp:3424
 msgid "Statistics Graph Window"
 msgstr "Статистика"
 
-#: src/amuleDlg.cpp:1759 src/muuli_wdr.cpp:3419 src/PrefsUnifiedDlg.cpp:328
-#: src/utils/wxCas/src/wxcasprefs.cpp:39
-msgid "Preferences"
-msgstr "Настройки"
-
-#: src/amuleDlg.cpp:1763 src/muuli_wdr.cpp:3419
+#: src/amuleDlg.cpp:1828 src/muuli_wdr.cpp:3426
 msgid "Preferences Settings Window"
 msgstr "Окно настроек клиента"
 
-#: src/amuleDlg.cpp:1766 src/muuli_wdr.cpp:3420
+#: src/amuleDlg.cpp:1831 src/muuli_wdr.cpp:3427
 msgid "Import"
 msgstr "Импорт"
 
-#: src/amuleDlg.cpp:1770 src/muuli_wdr.cpp:3420
+#: src/amuleDlg.cpp:1835 src/muuli_wdr.cpp:3427
 msgid "The partfile importer tool"
 msgstr "Инструмент импортирования частично загруженных файлов (part files)"
 
-#: src/amuleDlg.cpp:1773 src/muuli_wdr.cpp:3421
+#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3428
 #: src/utils/aLinkCreator/src/alcframe.cpp:262
 msgid "About"
 msgstr "О программе"
 
-#: src/amuleDlg.cpp:1773 src/muuli_wdr.cpp:3421
+#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3428
 msgid "About/Help"
 msgstr "О программе/Помощь"
 
-#: src/amuleDlg.cpp:1971
+#: src/amuleDlg.cpp:2036
 msgid "eD2k network"
 msgstr "Сеть eD2k"
 
-#: src/amuleDlg.cpp:1974
+#: src/amuleDlg.cpp:2039
 msgid "Kad network"
 msgstr "Сеть Kad"
 
-#: src/amuleDlg.cpp:1974
+#: src/amuleDlg.cpp:2039
 msgid "No network"
 msgstr "Нет сети"
 
@@ -1367,19 +1372,19 @@ msgstr "Авто [Выс]"
 msgid "Very low"
 msgstr "Очень низкий"
 
-#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:743 src/muuli_wdr.cpp:2275
+#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:743 src/muuli_wdr.cpp:2282
 #: src/ServerListCtrl.cpp:263 src/ServerListCtrl.cpp:456
 #: src/SharedFilesCtrl.cpp:145
 msgid "Low"
 msgstr "Низкий"
 
-#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:744 src/muuli_wdr.cpp:2276
+#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:744 src/muuli_wdr.cpp:2283
 #: src/ServerListCtrl.cpp:266 src/ServerListCtrl.cpp:457
 #: src/SharedFilesCtrl.cpp:146
 msgid "Normal"
 msgstr "Нормальный"
 
-#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:745 src/muuli_wdr.cpp:2277
+#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:745 src/muuli_wdr.cpp:2284
 #: src/ServerListCtrl.cpp:269 src/ServerListCtrl.cpp:458
 #: src/SharedFilesCtrl.cpp:147
 msgid "High"
@@ -1471,8 +1476,8 @@ msgstr "Локальный сервер"
 msgid "Remote Server"
 msgstr "Удаленный сервер"
 
-#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3174
-#: src/SearchDlg.cpp:111 src/TextClient.cpp:911
+#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3181
+#: src/SearchDlg.cpp:119 src/TextClient.cpp:911
 msgid "Kad"
 msgstr "Kad"
 
@@ -1544,7 +1549,7 @@ msgstr "Часть"
 msgid "Size"
 msgstr "Размер"
 
-#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3241
+#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3248
 msgid "Transferred"
 msgstr "Передано"
 
@@ -1602,7 +1607,7 @@ msgstr ""
 "Ответ от: %s (%s)\n"
 "\n"
 
-#: src/DownloadListCtrl.cpp:746 src/muuli_wdr.cpp:2278
+#: src/DownloadListCtrl.cpp:746 src/muuli_wdr.cpp:2285
 #: src/SharedFilesCtrl.cpp:150
 msgid "Auto"
 msgstr "Авто"
@@ -1640,7 +1645,7 @@ msgid "Extended Options"
 msgstr "Дополнительные настройки"
 
 #: src/DownloadListCtrl.cpp:770 src/DownloadListCtrl.cpp:822
-#: src/muuli_wdr.cpp:1789
+#: src/muuli_wdr.cpp:1796
 msgid "Preview"
 msgstr "Предварительный просмотр"
 
@@ -2355,19 +2360,19 @@ msgstr ""
 msgid "eD2k"
 msgstr "eD2k"
 
-#: src/FirstRunWizard.cpp:349 src/muuli_wdr.cpp:1488
+#: src/FirstRunWizard.cpp:349 src/muuli_wdr.cpp:1495
 msgid "Kademlia"
 msgstr "Kademlia"
 
-#: src/FirstRunWizard.cpp:359 src/muuli_wdr.cpp:1416
+#: src/FirstRunWizard.cpp:359 src/muuli_wdr.cpp:1423
 msgid "Standard TCP Port "
 msgstr "Стандартный порт TCP"
 
-#: src/FirstRunWizard.cpp:365 src/muuli_wdr.cpp:1428
+#: src/FirstRunWizard.cpp:365 src/muuli_wdr.cpp:1435
 msgid "Extended UDP port (Kad / global search) "
 msgstr "Дополнительный порт UDP (Kad / Глобальный поиск)"
 
-#: src/FirstRunWizard.cpp:377 src/muuli_wdr.cpp:1435
+#: src/FirstRunWizard.cpp:377 src/muuli_wdr.cpp:1442
 msgid "Enable UPnP for router port forwarding"
 msgstr "Разрешить UPnP форвардинг портов роутера"
 
@@ -2394,7 +2399,7 @@ msgstr ""
 msgid "Your peer lists are already in place - nothing to download."
 msgstr "Вы уже пытаетесь загрузить файл %s"
 
-#: src/FirstRunWizard.cpp:434 src/muuli_wdr.cpp:1533
+#: src/FirstRunWizard.cpp:434 src/muuli_wdr.cpp:1540
 msgid "Auto-update server list at startup"
 msgstr "Автоматически обновлять список серверов при запуске"
 
@@ -2440,23 +2445,23 @@ msgid ""
 "want downloads on a different (e.g. larger) disk."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:549 src/FirstRunWizard.cpp:611 src/muuli_wdr.cpp:1701
+#: src/FirstRunWizard.cpp:549 src/FirstRunWizard.cpp:611 src/muuli_wdr.cpp:1708
 msgid "Destination folder for downloads"
 msgstr "Папка для загружаемых файлов"
 
-#: src/FirstRunWizard.cpp:553 src/FirstRunWizard.cpp:569 src/muuli_wdr.cpp:1342
-#: src/muuli_wdr.cpp:1359 src/muuli_wdr.cpp:1676 src/muuli_wdr.cpp:1707
-#: src/muuli_wdr.cpp:1719 src/muuli_wdr.cpp:2762
+#: src/FirstRunWizard.cpp:553 src/FirstRunWizard.cpp:569 src/muuli_wdr.cpp:1349
+#: src/muuli_wdr.cpp:1366 src/muuli_wdr.cpp:1683 src/muuli_wdr.cpp:1714
+#: src/muuli_wdr.cpp:1726 src/muuli_wdr.cpp:2769
 #: src/utils/aLinkCreator/src/alcframe.cpp:135
 #: src/utils/wxCas/src/wxcasprefs.cpp:52 src/utils/wxCas/src/wxcasprefs.cpp:118
 msgid "Browse"
 msgstr "Открыть"
 
-#: src/FirstRunWizard.cpp:559 src/muuli_wdr.cpp:1712
+#: src/FirstRunWizard.cpp:559 src/muuli_wdr.cpp:1719
 msgid "(All files in this folder are shared with other peers)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:565 src/FirstRunWizard.cpp:624 src/muuli_wdr.cpp:1714
+#: src/FirstRunWizard.cpp:565 src/FirstRunWizard.cpp:624 src/muuli_wdr.cpp:1721
 msgid "Folder for temporary download files"
 msgstr "Папка для временных файлов"
 
@@ -2487,7 +2492,7 @@ msgstr "Не удалось открыть список друзей 'emfriends.
 msgid "CRITICAL - no client on StartChatSession"
 msgstr "КРИТИЧНО - нет клиентов на StartChatSession"
 
-#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2668 src/muuli_wdr.cpp:3345
+#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2675 src/muuli_wdr.cpp:3352
 msgid "Friends"
 msgstr "Друзья"
 
@@ -2880,7 +2885,7 @@ msgstr "Рейтинг"
 msgid "Uploaded"
 msgstr "Загружено"
 
-#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3225
+#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3232
 msgid "Requested"
 msgstr "Запрошено"
 
@@ -3004,7 +3009,7 @@ msgid "WARNING: "
 msgstr "ПРЕДУПРЕЖДЕНИЕ:"
 
 #: src/MuleNotebook.cpp:179 src/muuli_wdr.cpp:817 src/muuli_wdr.cpp:1229
-#: src/muuli_wdr.cpp:3129 src/muuli_wdr.cpp:3385
+#: src/muuli_wdr.cpp:3136 src/muuli_wdr.cpp:3392
 msgid "Close"
 msgstr "Закрыть"
 
@@ -3017,12 +3022,12 @@ msgstr "Вырезать"
 msgid "Copy"
 msgstr "Копировать"
 
-#: src/MuleTextCtrl.cpp:88
+#: src/MuleTextCtrl.cpp:88 src/SearchDlg.cpp:261
 msgid "Paste"
 msgstr "Вставить"
 
 #: src/MuleTextCtrl.cpp:89 src/muuli_wdr.cpp:358 src/muuli_wdr.cpp:757
-#: src/muuli_wdr.cpp:2352 src/muuli_wdr.cpp:2371 src/muuli_wdr.cpp:2393
+#: src/muuli_wdr.cpp:2359 src/muuli_wdr.cpp:2378 src/muuli_wdr.cpp:2400
 #: src/utils/aLinkCreator/src/alcframe.cpp:142
 msgid "Clear"
 msgstr "Очистить"
@@ -3120,8 +3125,8 @@ msgid "Exit"
 msgstr "Выйти"
 
 #: src/MuleTrayIcon.cpp:579 src/MuleTrayIcon.cpp:945 src/MuleTrayIcon.cpp:965
-#: src/muuli_wdr.cpp:1391 src/muuli_wdr.cpp:1399 src/muuli_wdr.cpp:1406
-#: src/muuli_wdr.cpp:1835 src/muuli_wdr.cpp:1841 src/OtherFunctions.cpp:91
+#: src/muuli_wdr.cpp:1398 src/muuli_wdr.cpp:1406 src/muuli_wdr.cpp:1413
+#: src/muuli_wdr.cpp:1842 src/muuli_wdr.cpp:1848 src/OtherFunctions.cpp:91
 #: src/StatisticsDlg.cpp:93 src/StatisticsDlg.cpp:95
 msgid "kB/s"
 msgstr "кБ/сек"
@@ -3296,7 +3301,7 @@ msgstr "Имя:"
 msgid "Type"
 msgstr "Тип"
 
-#: src/muuli_wdr.cpp:215 src/SearchDlg.cpp:110 src/SearchListCtrl.cpp:853
+#: src/muuli_wdr.cpp:215 src/SearchDlg.cpp:118 src/SearchListCtrl.cpp:853
 msgid "Local"
 msgstr "Локальный"
 
@@ -3367,7 +3372,7 @@ msgstr "Байт"
 msgid "KB"
 msgstr "КБ"
 
-#: src/muuli_wdr.cpp:274 src/muuli_wdr.cpp:293 src/muuli_wdr.cpp:1620
+#: src/muuli_wdr.cpp:274 src/muuli_wdr.cpp:293 src/muuli_wdr.cpp:1627
 #: src/OtherFunctions.cpp:64
 msgid "MB"
 msgstr "МБ"
@@ -3384,7 +3389,7 @@ msgstr "Макс. размер"
 msgid "Availability"
 msgstr "Доступность"
 
-#: src/muuli_wdr.cpp:312 src/muuli_wdr.cpp:398 src/muuli_wdr.cpp:3290
+#: src/muuli_wdr.cpp:312 src/muuli_wdr.cpp:398 src/muuli_wdr.cpp:3297
 msgid "Filter:"
 msgstr "Фильтр:"
 
@@ -3416,7 +3421,7 @@ msgstr ""
 msgid "Stop"
 msgstr "Остановить"
 
-#: src/muuli_wdr.cpp:348 src/muuli_wdr.cpp:1385 src/SearchListCtrl.cpp:732
+#: src/muuli_wdr.cpp:348 src/muuli_wdr.cpp:1392 src/SearchListCtrl.cpp:732
 msgid "Download"
 msgstr "Загрузка"
 
@@ -3447,8 +3452,8 @@ msgstr "Источников:"
 #: src/muuli_wdr.cpp:1160 src/muuli_wdr.cpp:1167 src/muuli_wdr.cpp:1172
 #: src/muuli_wdr.cpp:1179 src/muuli_wdr.cpp:1184 src/muuli_wdr.cpp:1191
 #: src/muuli_wdr.cpp:1205 src/muuli_wdr.cpp:1212 src/muuli_wdr.cpp:1217
-#: src/muuli_wdr.cpp:1224 src/muuli_wdr.cpp:3227 src/muuli_wdr.cpp:3235
-#: src/muuli_wdr.cpp:3243
+#: src/muuli_wdr.cpp:1224 src/muuli_wdr.cpp:3234 src/muuli_wdr.cpp:3242
+#: src/muuli_wdr.cpp:3250
 msgid "N/A"
 msgstr "N/A"
 
@@ -3593,7 +3598,7 @@ msgstr ""
 msgid "Album :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:685 src/muuli_wdr.cpp:2247
+#: src/muuli_wdr.cpp:685 src/muuli_wdr.cpp:2254
 msgid "Title :"
 msgstr "Заголовок :"
 
@@ -3704,7 +3709,7 @@ msgstr "Имя пользователя :"
 msgid "Userhash :"
 msgstr "Хеш пользователя :"
 
-#: src/muuli_wdr.cpp:895 src/muuli_wdr.cpp:1741 src/muuli_wdr.cpp:2442
+#: src/muuli_wdr.cpp:895 src/muuli_wdr.cpp:1748 src/muuli_wdr.cpp:2449
 #: src/utils/aLinkCreator/src/alcframe.cpp:137
 msgid "Add"
 msgstr "Добавить"
@@ -3713,15 +3718,15 @@ msgstr "Добавить"
 msgid "Download-Speed"
 msgstr "Скорость приема"
 
-#: src/muuli_wdr.cpp:954 src/muuli_wdr.cpp:989 src/muuli_wdr.cpp:2546
+#: src/muuli_wdr.cpp:954 src/muuli_wdr.cpp:989 src/muuli_wdr.cpp:2553
 msgid "Current"
 msgstr "Текущая"
 
-#: src/muuli_wdr.cpp:962 src/muuli_wdr.cpp:997 src/muuli_wdr.cpp:2554
+#: src/muuli_wdr.cpp:962 src/muuli_wdr.cpp:997 src/muuli_wdr.cpp:2561
 msgid "Running average"
 msgstr "Средняя за все время"
 
-#: src/muuli_wdr.cpp:970 src/muuli_wdr.cpp:1005 src/muuli_wdr.cpp:2562
+#: src/muuli_wdr.cpp:970 src/muuli_wdr.cpp:1005 src/muuli_wdr.cpp:2569
 msgid "Session average"
 msgstr "В среднем за сеанс"
 
@@ -3733,7 +3738,7 @@ msgstr "Скорость отдачи"
 msgid "Connections"
 msgstr "Соединения"
 
-#: src/muuli_wdr.cpp:1024 src/muuli_wdr.cpp:1860
+#: src/muuli_wdr.cpp:1024 src/muuli_wdr.cpp:1867
 msgid "Active downloads"
 msgstr "Активные загрузки"
 
@@ -3741,7 +3746,7 @@ msgstr "Активные загрузки"
 msgid "Active connections (1:1)"
 msgstr "Активные соединения (1:1)"
 
-#: src/muuli_wdr.cpp:1040 src/muuli_wdr.cpp:1861
+#: src/muuli_wdr.cpp:1040 src/muuli_wdr.cpp:1868
 msgid "Active uploads"
 msgstr "Активные передачи"
 
@@ -3857,8 +3862,8 @@ msgstr "Это имя, которое будет показано пользов
 msgid "Language: "
 msgstr "Язык:"
 
-#: src/muuli_wdr.cpp:1257 src/muuli_wdr.cpp:1323 src/muuli_wdr.cpp:1327
-#: src/muuli_wdr.cpp:1330
+#: src/muuli_wdr.cpp:1257 src/muuli_wdr.cpp:1330 src/muuli_wdr.cpp:1334
+#: src/muuli_wdr.cpp:1337
 msgid "The delay before showing tool-tips."
 msgstr "Задержка отображения контекстных подсказок (как эта) в секундах."
 
@@ -3936,943 +3941,952 @@ msgstr "Показывать уведомления о завершении за
 msgid "Enabling this will make aMule to show notifications when finished downloading."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1322
+#: src/muuli_wdr.cpp:1323
+#, fuzzy
+msgid "Remember search history"
+msgstr "Запомнить настройки"
+
+#: src/muuli_wdr.cpp:1324
+msgid "Keeps a dropdown list of your past search terms in the Search tab's Name field. This remembers the queries you typed, not the results they returned."
+msgstr ""
+
+#: src/muuli_wdr.cpp:1329
 msgid "Tooltip delay time: "
 msgstr "Время задержки подсказок:"
 
-#: src/muuli_wdr.cpp:1329
+#: src/muuli_wdr.cpp:1336
 msgid "seconds"
 msgstr "секунд"
 
-#: src/muuli_wdr.cpp:1333
+#: src/muuli_wdr.cpp:1340
 msgid "Browser Selection"
 msgstr "Выбор браузера"
 
-#: src/muuli_wdr.cpp:1339
+#: src/muuli_wdr.cpp:1346
 msgid "Enter your browser name here. Leave this field empty to use the system default browser."
 msgstr "Введите имя предпочитаемого браузера. Оставьте поле пустым чтобы использовать системный браузер по умолчанию."
 
-#: src/muuli_wdr.cpp:1346
+#: src/muuli_wdr.cpp:1353
 msgid "Open in new tab if possible"
 msgstr "Открывать в новой вкладке"
 
-#: src/muuli_wdr.cpp:1348
+#: src/muuli_wdr.cpp:1355
 msgid "Open the web page in a new tab instead of in a new window when possible"
 msgstr "Открывать веб-страницы в новой вкладке, а не в отдельном окне, если это возможно"
 
-#: src/muuli_wdr.cpp:1352
+#: src/muuli_wdr.cpp:1359
 msgid "Video Player"
 msgstr "Видео-проигрыватель"
 
-#: src/muuli_wdr.cpp:1379
+#: src/muuli_wdr.cpp:1386
 msgid "Bandwidth limits"
 msgstr "Ограничения загрузки"
 
-#: src/muuli_wdr.cpp:1393
+#: src/muuli_wdr.cpp:1400
 msgid "Upload"
 msgstr "Отдача"
 
-#: src/muuli_wdr.cpp:1401
+#: src/muuli_wdr.cpp:1408
 msgid "Slot Allocation"
 msgstr "Слот"
 
-#: src/muuli_wdr.cpp:1410
+#: src/muuli_wdr.cpp:1417
 msgid "Ports"
 msgstr "Порты"
 
-#: src/muuli_wdr.cpp:1420
+#: src/muuli_wdr.cpp:1427
 msgid "This is the standard eD2k port and cannot be disabled."
 msgstr "Это стандартный порт eD2k, он не может быть отключен."
 
-#: src/muuli_wdr.cpp:1423
+#: src/muuli_wdr.cpp:1430
 msgid "UDP port for server requests (TCP+3):"
 msgstr "Порт UDP для запросов сервера (TCP+3):"
 
-#: src/muuli_wdr.cpp:1425
+#: src/muuli_wdr.cpp:1432
 msgid "4665"
 msgstr "4665"
 
-#: src/muuli_wdr.cpp:1432
+#: src/muuli_wdr.cpp:1439
 msgid "This UDP port is used for extended eD2k requests and Kad network"
 msgstr "Этот порт UDP используется для дополнительных eD2k запросов и Kad"
 
-#: src/muuli_wdr.cpp:1439
+#: src/muuli_wdr.cpp:1446
 msgid "UPnP TCP Port (Optional):"
 msgstr "UPnP TCP порт (Не обязательно):"
 
-#: src/muuli_wdr.cpp:1449
+#: src/muuli_wdr.cpp:1456
 msgid "Bind local address to IP (empty for any):"
 msgstr "Закрепить локальный адрес за IP (пустой для любого):"
 
-#: src/muuli_wdr.cpp:1452
+#: src/muuli_wdr.cpp:1459
 msgid "Advanced users only: If you have multiple network interfaces, enter the address of the interface to which aMule should be bound."
 msgstr "Только для продвинутых пользователей: если у вас несколько сетевых интерфейсов введите адрес того, которым будет пользоваться aMule."
 
-#: src/muuli_wdr.cpp:1455 src/muuli_wdr.cpp:2054
+#: src/muuli_wdr.cpp:1462 src/muuli_wdr.cpp:2061
 #, fuzzy
 msgid "Bind to network interface (empty for any):"
 msgstr "Закрепить локальный адрес за IP (пустой для любого):"
 
-#: src/muuli_wdr.cpp:1468
+#: src/muuli_wdr.cpp:1475
 msgid "Advanced users only: pin all of aMule's traffic to one network interface, chosen from the list or typed in by name (e.g. tun0, eth0, en0) or index. Unlike binding to an IP, this stops traffic leaking out via the default route - useful with a VPN. Requires no elevated privileges."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1474
+#: src/muuli_wdr.cpp:1481
 msgid "Max sources per downloading file:"
 msgstr "Максимум источников на файл:"
 
-#: src/muuli_wdr.cpp:1478
+#: src/muuli_wdr.cpp:1485
 msgid "Max simultaneous connections:"
 msgstr "Максимум одновременных соединений:"
 
-#: src/muuli_wdr.cpp:1491 src/muuli_wdr.cpp:3169
+#: src/muuli_wdr.cpp:1498 src/muuli_wdr.cpp:3176
 msgid "ED2K"
 msgstr "ED2K"
 
-#: src/muuli_wdr.cpp:1498
+#: src/muuli_wdr.cpp:1505
 msgid "Autoconnect on startup"
 msgstr "Соединяться автоматически после запуска"
 
-#: src/muuli_wdr.cpp:1501
+#: src/muuli_wdr.cpp:1508
 msgid "Reconnect on loss"
 msgstr "Восстановить соединение в случае разрыва"
 
-#: src/muuli_wdr.cpp:1523
+#: src/muuli_wdr.cpp:1530
 msgid "Remove dead server after"
 msgstr "Удалить нерабочий сервер после"
 
-#: src/muuli_wdr.cpp:1524
+#: src/muuli_wdr.cpp:1531
 msgid "Static servers are never removed, even when unreachable."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1528
+#: src/muuli_wdr.cpp:1535
 msgid "retries"
 msgstr "попыток"
 
-#: src/muuli_wdr.cpp:1536
+#: src/muuli_wdr.cpp:1543
 msgid "List"
 msgstr "Список"
 
-#: src/muuli_wdr.cpp:1539
+#: src/muuli_wdr.cpp:1546
 msgid "Update server list when connecting to a server"
 msgstr "Обновлять список серверов при подключении к серверу"
 
-#: src/muuli_wdr.cpp:1542
+#: src/muuli_wdr.cpp:1549
 msgid "Update server list when a client connects"
 msgstr "Обновлять список серверов при подключении к клиенту"
 
-#: src/muuli_wdr.cpp:1545
+#: src/muuli_wdr.cpp:1552
 msgid "Use priority system"
 msgstr "Использовать систему приоритетов"
 
-#: src/muuli_wdr.cpp:1549
+#: src/muuli_wdr.cpp:1556
 msgid "Use smart LowID check on connect"
 msgstr "Проверка на LowID при подключении к серверу"
 
-#: src/muuli_wdr.cpp:1553
+#: src/muuli_wdr.cpp:1560
 msgid "Safe connect"
 msgstr "Безопасное подключение"
 
-#: src/muuli_wdr.cpp:1557
+#: src/muuli_wdr.cpp:1564
 msgid "Autoconnect to servers in static list only"
 msgstr "Автоподключение только к статическим серверам"
 
-#: src/muuli_wdr.cpp:1560
+#: src/muuli_wdr.cpp:1567
 msgid "Set manually added servers to High Priority"
 msgstr "Высокий приоритет серверов, добавленных вручную"
 
-#: src/muuli_wdr.cpp:1581
+#: src/muuli_wdr.cpp:1588
 msgid "Add files to download in pause mode"
 msgstr "Добавлять файлы на загрузку в режиме паузы"
 
-#: src/muuli_wdr.cpp:1583
+#: src/muuli_wdr.cpp:1590
 msgid "Add files to download with auto priority"
 msgstr "Добавлять файлы в загрузку с авто приоритетом"
 
-#: src/muuli_wdr.cpp:1586
+#: src/muuli_wdr.cpp:1593
 msgid "Try to download first and last chunks first"
 msgstr "Пытаться сначала загрузить первую и последнюю части"
 
-#: src/muuli_wdr.cpp:1590
+#: src/muuli_wdr.cpp:1597
 msgid "Endgame mode: rotate to faster sources for the final blocks"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1593
+#: src/muuli_wdr.cpp:1600
 msgid "Start next paused file when a file completes"
 msgstr "Возобновлять следующий файл на паузе при завершении загрузки"
 
-#: src/muuli_wdr.cpp:1596
+#: src/muuli_wdr.cpp:1603
 msgid "From the same category"
 msgstr "Из той же категории"
 
-#: src/muuli_wdr.cpp:1598
+#: src/muuli_wdr.cpp:1605
 msgid "In alphabetic order"
 msgstr "В алфавитном порядке"
 
-#: src/muuli_wdr.cpp:1600
+#: src/muuli_wdr.cpp:1607
 msgid "Preallocate disk space for new files"
 msgstr "Заранее выделять место для новых фалов"
 
-#: src/muuli_wdr.cpp:1601
+#: src/muuli_wdr.cpp:1608
 msgid "For new files preallocates disk space for the whole file, thus reduces fragmentation"
 msgstr "Сразу выделяет место под весь файл. Таким образом уменьшается фрагментация"
 
-#: src/muuli_wdr.cpp:1606
+#: src/muuli_wdr.cpp:1613
 msgid "Create new files as sparse files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1607
+#: src/muuli_wdr.cpp:1614
 msgid "A sparse file reserves its full size on disk immediately without writing real data to it -- fast, but unsupported or slow on some filesystems, and free-space accounting stays optimistic while the download is in progress. Turn this off to grow the file only as data arrives."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1612
+#: src/muuli_wdr.cpp:1619
 msgid "Stop downloads when free disk space reaches "
 msgstr "Останавливать загрузки по окончанию свободного места на диске"
 
-#: src/muuli_wdr.cpp:1613
+#: src/muuli_wdr.cpp:1620
 msgid "Select this if you want aMule to check your disk space"
 msgstr "Отметьте это если  хотите чтобы aMule проверял наличие свободного места"
 
-#: src/muuli_wdr.cpp:1617
+#: src/muuli_wdr.cpp:1624
 msgid "Enter here the min disk space desired."
 msgstr "Введите здесь минимальное количество свободного места на диске."
 
-#: src/muuli_wdr.cpp:1623
+#: src/muuli_wdr.cpp:1630
 msgid "Save 10 sources on rare files (< 20 sources)"
 msgstr "Оставлять 10 источников для редких файлов (<20 источников)"
 
-#: src/muuli_wdr.cpp:1627 src/Statistics.cpp:790
+#: src/muuli_wdr.cpp:1634 src/Statistics.cpp:790
 msgid "Uploads"
 msgstr "Отдача"
 
-#: src/muuli_wdr.cpp:1630
+#: src/muuli_wdr.cpp:1637
 msgid "Add new shared files with auto priority"
 msgstr "Добавлять новые файлы для публикации с авто приоритетом"
 
 # слишком уж частая аббривеатура. написать И.О.О. - никто не поймет
-#: src/muuli_wdr.cpp:1636
+#: src/muuli_wdr.cpp:1643
 msgid "Intelligent Corruption Handling (I.C.H.)"
 msgstr "Интеллектуальная Обработка Ошибок (I.C.H.)"
 
-#: src/muuli_wdr.cpp:1639
+#: src/muuli_wdr.cpp:1646
 msgid "Enable"
 msgstr "Разрешить"
 
-#: src/muuli_wdr.cpp:1642
+#: src/muuli_wdr.cpp:1649
 msgid "Advanced I.C.H. trusts every hash (not recommended)"
 msgstr "AICH-доверие для каждого хэша (не рекомендуется)"
 
-#: src/muuli_wdr.cpp:1654 src/PrefsUnifiedDlg.cpp:1910
+#: src/muuli_wdr.cpp:1661 src/PrefsUnifiedDlg.cpp:1910
 msgid "Media metadata extraction"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1658
+#: src/muuli_wdr.cpp:1665
 msgid "Extract length / bitrate / codec from shared audio and video files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1660
+#: src/muuli_wdr.cpp:1667
 msgid "When enabled, aMule runs ffprobe on each shared media file to fill in the Length / Bitrate / Codec columns other clients see when they find the file in a search. Requires ffmpeg (the ffprobe binary) to be installed."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1667
+#: src/muuli_wdr.cpp:1674
 msgid "Path to ffprobe:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1672
+#: src/muuli_wdr.cpp:1679
 msgid "Full path to the ffprobe binary. Leave empty to have aMule auto-detect it on startup."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1680
+#: src/muuli_wdr.cpp:1687
 msgid "Detect"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1681
+#: src/muuli_wdr.cpp:1688
 msgid "Search the standard install locations for an ffprobe binary and fill the path field."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1705
+#: src/muuli_wdr.cpp:1712
 msgid ""
 "Completed downloads are stored here. All files in this folder are automatically shared with other peers.\n"
 "If this folder also holds files you don't want to share, point it at an aMule-only sub-folder."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1708
+#: src/muuli_wdr.cpp:1715
 msgid "Pick the folder where completed downloads will be stored. All files in that folder will be shared with other peers."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1722
+#: src/muuli_wdr.cpp:1729
 msgid "Shared folders"
 msgstr "Публикуемые папки"
 
-#: src/muuli_wdr.cpp:1728
+#: src/muuli_wdr.cpp:1735
 msgid "(Folders shared by the core. Enter a path to add one.)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1736
+#: src/muuli_wdr.cpp:1743
 msgid "Absolute path of a folder on the core's machine, e.g. /home/user/shared"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1738 src/PrefsUnifiedDlg.cpp:2794
+#: src/muuli_wdr.cpp:1745 src/PrefsUnifiedDlg.cpp:2794
 msgid "Recursive"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1739
+#: src/muuli_wdr.cpp:1746
 msgid "Share every sub-folder underneath this one, including ones created later."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1743 src/utils/aLinkCreator/src/alcframe.cpp:141
+#: src/muuli_wdr.cpp:1750 src/utils/aLinkCreator/src/alcframe.cpp:141
 msgid "Remove"
 msgstr "Удалить"
 
-#: src/muuli_wdr.cpp:1747
+#: src/muuli_wdr.cpp:1754
 msgid "(Right click on folder icon for recursive share)"
 msgstr "(кликните правой кнопкой на значке каталога для рекурсивной публикации)"
 
-#: src/muuli_wdr.cpp:1754
+#: src/muuli_wdr.cpp:1761
 msgid "Share hidden files"
 msgstr "Включая скрытые файлы"
 
-#: src/muuli_wdr.cpp:1760
+#: src/muuli_wdr.cpp:1767
 msgid "Automatically rescan shared folders for changes"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1766
+#: src/muuli_wdr.cpp:1773
 msgid "Follow symbolic links in shared folders"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1772
+#: src/muuli_wdr.cpp:1779
 msgid "Exclude files matching:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1775
+#: src/muuli_wdr.cpp:1782
 msgid "Wildcard patterns separated by '|', e.g. .DS_Store|Thumbs.db|*.tmp. Files whose name matches are not shared. Matching is case-insensitive."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1779
+#: src/muuli_wdr.cpp:1786
 msgid "Patterns are regular expressions"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1780
+#: src/muuli_wdr.cpp:1787
 msgid "When set, the whole field is one regular expression ('|' is alternation). When unset, it is a list of '|'-separated wildcards."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1790
+#: src/muuli_wdr.cpp:1797
 msgid "Show how many shared files the current pattern would exclude."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1811
+#: src/muuli_wdr.cpp:1818
 msgid "Graphs"
 msgstr "Графики"
 
-#: src/muuli_wdr.cpp:1814 src/muuli_wdr.cpp:1876
+#: src/muuli_wdr.cpp:1821 src/muuli_wdr.cpp:1883
 msgid "Update delay : 5 secs"
 msgstr "Интервал обновления: 5 сек"
 
-#: src/muuli_wdr.cpp:1818
+#: src/muuli_wdr.cpp:1825
 msgid "Time for average graph: 100 mins"
 msgstr "Время для среднестатического графика: 100 минут"
 
-#: src/muuli_wdr.cpp:1822
+#: src/muuli_wdr.cpp:1829
 msgid "Connections Graph Scale: 100 "
 msgstr "Масштаб графика соединений: 100 "
 
-#: src/muuli_wdr.cpp:1829
+#: src/muuli_wdr.cpp:1836
 msgid "Download graph scale:"
 msgstr "Масштаб графика загрузки:"
 
-#: src/muuli_wdr.cpp:1837
+#: src/muuli_wdr.cpp:1844
 msgid "Upload graph scale:"
 msgstr "Масштаб графика отдачи:"
 
-#: src/muuli_wdr.cpp:1847
+#: src/muuli_wdr.cpp:1854
 #, fuzzy
 msgid "Colors: "
 msgstr "Цвета:"
 
-#: src/muuli_wdr.cpp:1851
+#: src/muuli_wdr.cpp:1858
 msgid "Background"
 msgstr "Фон"
 
-#: src/muuli_wdr.cpp:1852
+#: src/muuli_wdr.cpp:1859
 msgid "Grid"
 msgstr "Сетка"
 
-#: src/muuli_wdr.cpp:1853
+#: src/muuli_wdr.cpp:1860
 msgid "Download current"
 msgstr "Текущая загрузка"
 
-#: src/muuli_wdr.cpp:1854
+#: src/muuli_wdr.cpp:1861
 msgid "Download running average"
 msgstr "Средняя общая загрузка"
 
-#: src/muuli_wdr.cpp:1855
+#: src/muuli_wdr.cpp:1862
 msgid "Download session average"
 msgstr "Средняя загрузка за сеанс"
 
-#: src/muuli_wdr.cpp:1856
+#: src/muuli_wdr.cpp:1863
 msgid "Upload current"
 msgstr "Текущая отдача"
 
-#: src/muuli_wdr.cpp:1857
+#: src/muuli_wdr.cpp:1864
 msgid "Upload running average"
 msgstr "Средняя общая отдача"
 
-#: src/muuli_wdr.cpp:1858
+#: src/muuli_wdr.cpp:1865
 msgid "Upload session average"
 msgstr "Средняя отдача за сеанс"
 
-#: src/muuli_wdr.cpp:1859
+#: src/muuli_wdr.cpp:1866
 msgid "Active connections"
 msgstr "Активные соединения"
 
-#: src/muuli_wdr.cpp:1862
+#: src/muuli_wdr.cpp:1869
 #, fuzzy
 msgid "Systray Icon Speed Bar"
 msgstr "Скорость передачи в области уведомлений"
 
-#: src/muuli_wdr.cpp:1863
+#: src/muuli_wdr.cpp:1870
 msgid "Kad-nodes current"
 msgstr "Узлы Kad (текущие)"
 
-#: src/muuli_wdr.cpp:1864
+#: src/muuli_wdr.cpp:1871
 msgid "Kad-nodes running"
 msgstr "Узлы Kad (действующие)"
 
-#: src/muuli_wdr.cpp:1865
+#: src/muuli_wdr.cpp:1872
 msgid "Kad-nodes session"
 msgstr "Узлы Kad (сессия)"
 
-#: src/muuli_wdr.cpp:1869 src/muuli_wdr.cpp:2296
+#: src/muuli_wdr.cpp:1876 src/muuli_wdr.cpp:2303
 msgid "Select"
 msgstr "Выбрать"
 
-#: src/muuli_wdr.cpp:1873
+#: src/muuli_wdr.cpp:1880
 msgid "Tree"
 msgstr "Дерево"
 
-#: src/muuli_wdr.cpp:1883
+#: src/muuli_wdr.cpp:1890
 msgid "Number of Client Versions shown (0=unlimited)"
 msgstr "Число отображаемых версий клиентов (0=неогр.)"
 
-#: src/muuli_wdr.cpp:1908
+#: src/muuli_wdr.cpp:1915
 msgid "!!! WARNING !!!"
 msgstr "!!! ВНИМАНИЕ !!!"
 
-#: src/muuli_wdr.cpp:1923
+#: src/muuli_wdr.cpp:1930
 msgid "Max new connections / 5 secs"
 msgstr "Предел количества новых соединений за 5 секунд"
 
-#: src/muuli_wdr.cpp:1925
+#: src/muuli_wdr.cpp:1932
 msgid "Concurrent Kad source lookups"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1927
+#: src/muuli_wdr.cpp:1934
 #, fuzzy
 msgid "Kad source re-search interval (minutes)"
 msgstr "Интервал обновления через FTP в минутах"
 
-#: src/muuli_wdr.cpp:1929
+#: src/muuli_wdr.cpp:1936
 #, fuzzy
 msgid "Source re-ask interval (minutes)"
 msgstr "Интервал обновления через FTP в минутах"
 
-#: src/muuli_wdr.cpp:1933
+#: src/muuli_wdr.cpp:1940
 msgid "File Buffer Size: 240000 bytes"
 msgstr "Размер буфера: 240000 байт"
 
-#: src/muuli_wdr.cpp:1937
+#: src/muuli_wdr.cpp:1944
 msgid "Use MMAP: memory-mapped file access (lower memory use)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1938
+#: src/muuli_wdr.cpp:1945
 msgid "Maps part files into memory instead of buffering them on the heap, lowering the process memory footprint. May reduce download speed on some disks; best for memory-constrained or upload-heavy hosts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1940
+#: src/muuli_wdr.cpp:1947
 msgid "Upload Queue Size: 5000 clients"
 msgstr "Размер очереди: 5000 клиентов"
 
-#: src/muuli_wdr.cpp:1944
+#: src/muuli_wdr.cpp:1951
 msgid "Server connection refresh interval: Disable"
 msgstr "Интервал обновления соединения с сервером: Отключено"
 
-#: src/muuli_wdr.cpp:1948
+#: src/muuli_wdr.cpp:1955
 msgid "Disable computer's timed standby mode"
 msgstr "Отключить засыпание компьютера"
 
 # в LA помнится так и перевели - "шкурка", но по-моему глупо.
-#: src/muuli_wdr.cpp:1967
+#: src/muuli_wdr.cpp:1974
 msgid "Skin to use: "
 msgstr "Скин:"
 
-#: src/muuli_wdr.cpp:1976
+#: src/muuli_wdr.cpp:1983
 msgid "Show \"Fast eD2k Links Handler\" in every window."
 msgstr "Показывать строку \"быстрой загрузки\" в каждой вкладке."
 
-#: src/muuli_wdr.cpp:1979
+#: src/muuli_wdr.cpp:1986
 msgid "Show extended info on categories tabs"
 msgstr "Показывать дополнительную информацию на закладках категорий"
 
-#: src/muuli_wdr.cpp:1982
+#: src/muuli_wdr.cpp:1989
 #, fuzzy
 msgid "Show application version on title"
 msgstr "Выводить скорость передачи в заголовке"
 
-#: src/muuli_wdr.cpp:1984
+#: src/muuli_wdr.cpp:1991
 msgid "Show transfer rates on title"
 msgstr "Выводить скорость передачи в заголовке"
 
-#: src/muuli_wdr.cpp:1986
+#: src/muuli_wdr.cpp:1993
 msgid "Before application name"
 msgstr "Перед именем приложения"
 
-#: src/muuli_wdr.cpp:1988
+#: src/muuli_wdr.cpp:1995
 msgid "After application name"
 msgstr "После имени приложения"
 
-#: src/muuli_wdr.cpp:1991
+#: src/muuli_wdr.cpp:1998
 msgid "Show overhead bandwidth"
 msgstr "Показывать скорость служебного трафика"
 
-#: src/muuli_wdr.cpp:1995
+#: src/muuli_wdr.cpp:2002
 msgid "Vertical toolbar orientation"
 msgstr "Вертикальное расположение панели инструментов"
 
-#: src/muuli_wdr.cpp:1997
+#: src/muuli_wdr.cpp:2004
 msgid "Live column sorting (auto-reorder rows as their values change)"
 msgstr ""
 
 # This is the heading for the preference options regarding the files in the
 # transfer list.
-#: src/muuli_wdr.cpp:2004
+#: src/muuli_wdr.cpp:2011
 msgid "Download Queue Files"
 msgstr "Загружаемые файлы"
 
-#: src/muuli_wdr.cpp:2007
+#: src/muuli_wdr.cpp:2014
 msgid "Show progress percentage"
 msgstr "Показывать процент загрузки"
 
-#: src/muuli_wdr.cpp:2013
+#: src/muuli_wdr.cpp:2020
 msgid "Show progress bar"
 msgstr "Показывать полосу выполнения"
 
-#: src/muuli_wdr.cpp:2016
+#: src/muuli_wdr.cpp:2023
 msgid "Flat"
 msgstr "Плоская"
 
-#: src/muuli_wdr.cpp:2020
+#: src/muuli_wdr.cpp:2027
 msgid "Round"
 msgstr "Круглая"
 
-#: src/muuli_wdr.cpp:2038
+#: src/muuli_wdr.cpp:2045
 msgid "External Connection Parameters"
 msgstr "Параметры внешних соединений"
 
-#: src/muuli_wdr.cpp:2041
+#: src/muuli_wdr.cpp:2048
 msgid "Accept external connections"
 msgstr "Принимать внешние соединения"
 
-#: src/muuli_wdr.cpp:2048 src/muuli_wdr.cpp:2107
+#: src/muuli_wdr.cpp:2055 src/muuli_wdr.cpp:2114
 msgid "IP of the listening interface:"
 msgstr "IP прослушиваемого интерфейса:"
 
-#: src/muuli_wdr.cpp:2051
+#: src/muuli_wdr.cpp:2058
 msgid "Enter here a valid ip in the a.b.c.d format for the listening EC interface. An empty field or 0.0.0.0 will mean any interface."
 msgstr "Введите сюда IP в формате a.b.c.d для прослушиваемого интерфейса ВС. Пустое поле или значение 0.0.0.0 означают любой интерфейс."
 
-#: src/muuli_wdr.cpp:2072 src/muuli_wdr.cpp:2156
+#: src/muuli_wdr.cpp:2079 src/muuli_wdr.cpp:2163
 msgid "TCP port:"
 msgstr "порт TCP:"
 
-#: src/muuli_wdr.cpp:2078
+#: src/muuli_wdr.cpp:2085
 msgid "Enable UPnP port forwarding on the EC port"
 msgstr "Включить UPnP для порта ВС"
 
-#: src/muuli_wdr.cpp:2082 src/muuli_wdr.cpp:3041
+#: src/muuli_wdr.cpp:2089 src/muuli_wdr.cpp:3048
 #: src/utils/wxCas/src/wxcasprefs.cpp:167
 msgid "Password"
 msgstr "Пароль"
 
-#: src/muuli_wdr.cpp:2088
+#: src/muuli_wdr.cpp:2095
 #, fuzzy
 msgid "aMule API server parameters"
 msgstr "Параметры веб-сервера"
 
-#: src/muuli_wdr.cpp:2091
+#: src/muuli_wdr.cpp:2098
 msgid "Run amuleapi (REST API) on startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2096
+#: src/muuli_wdr.cpp:2103
 #, fuzzy
 msgid "HTTP port:"
 msgstr "порт TCP:"
 
-#: src/muuli_wdr.cpp:2110
+#: src/muuli_wdr.cpp:2117
 msgid "The interface amuleapi's HTTP server listens on. 127.0.0.1 (default) accepts only local connections; use 0.0.0.0 or a specific IP to expose it to other hosts (set an admin password below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2113
+#: src/muuli_wdr.cpp:2120
 #, fuzzy
 msgid "Admin password"
 msgstr "Проверяю пароль\n"
 
-#: src/muuli_wdr.cpp:2118 src/muuli_wdr.cpp:2149
+#: src/muuli_wdr.cpp:2125 src/muuli_wdr.cpp:2156
 msgid "Low rights password"
 msgstr "Пароль ограниченного доступа"
 
-#: src/muuli_wdr.cpp:2126
+#: src/muuli_wdr.cpp:2133
 msgid "Web server parameters"
 msgstr "Параметры веб-сервера"
 
-#: src/muuli_wdr.cpp:2129
+#: src/muuli_wdr.cpp:2136
 #, fuzzy
 msgid "Run webserver on startup (deprecated)"
 msgstr "Запускать веб-сервер при старте"
 
-#: src/muuli_wdr.cpp:2135
+#: src/muuli_wdr.cpp:2142
 msgid "Web template"
 msgstr "Веб-шаблон"
 
-#: src/muuli_wdr.cpp:2140
+#: src/muuli_wdr.cpp:2147
 msgid "Full rights password"
 msgstr "Пароль для обычного доступа"
 
-#: src/muuli_wdr.cpp:2144
+#: src/muuli_wdr.cpp:2151
 msgid "Enable Low rights User"
 msgstr "Разрешить ограниченный доступ"
 
-#: src/muuli_wdr.cpp:2163
+#: src/muuli_wdr.cpp:2170
 msgid "Enable UPnP port forwarding of the web server port"
 msgstr "Разрешить UPnP форвардинг порта веб-сервера"
 
-#: src/muuli_wdr.cpp:2168
+#: src/muuli_wdr.cpp:2175
 msgid "Web server UPnP TCP port (Optional)"
 msgstr "UPnP TCP порт веб-сервера (не обязательно):"
 
-#: src/muuli_wdr.cpp:2176
+#: src/muuli_wdr.cpp:2183
 msgid "Page Refresh Time (in secs)"
 msgstr "Период обновления страницы (в секундах)"
 
-#: src/muuli_wdr.cpp:2183
+#: src/muuli_wdr.cpp:2190
 msgid "Enable Gzip compression"
 msgstr "Включить сжатие Gzip"
 
-#: src/muuli_wdr.cpp:2217
+#: src/muuli_wdr.cpp:2224
 #, fuzzy
 msgid "Reset page to defaults"
 msgstr "Системный"
 
-#: src/muuli_wdr.cpp:2218
+#: src/muuli_wdr.cpp:2225
 msgid "Reset the settings on the current page to their default values."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2220 src/muuli_wdr.cpp:2306 src/ServerWnd.cpp:274
+#: src/muuli_wdr.cpp:2227 src/muuli_wdr.cpp:2313 src/ServerWnd.cpp:274
 #: src/ServerWnd.cpp:282
 msgid "OK"
 msgstr "ОК"
 
-#: src/muuli_wdr.cpp:2222
+#: src/muuli_wdr.cpp:2229
 msgid "Click here to apply any changes made to the preferences."
 msgstr "Кликните тут, чтобы сохранить внесенные вами изменения."
 
-#: src/muuli_wdr.cpp:2225
+#: src/muuli_wdr.cpp:2232
 msgid "Reset any changes made to the preferences."
 msgstr "Сбросить все изменения, внесенные вами."
 
-#: src/muuli_wdr.cpp:2254
+#: src/muuli_wdr.cpp:2261
 msgid "Comment :"
 msgstr "Комментарий :"
 
-#: src/muuli_wdr.cpp:2261
+#: src/muuli_wdr.cpp:2268
 msgid "Incoming Dir :"
 msgstr "Каталог загрузок:"
 
-#: src/muuli_wdr.cpp:2270
+#: src/muuli_wdr.cpp:2277
 msgid "Change priority for new assigned files :"
 msgstr "Установить приоритет для новых файлов:"
 
-#: src/muuli_wdr.cpp:2274
+#: src/muuli_wdr.cpp:2281
 msgid "Don't change"
 msgstr "Не изменять"
 
-#: src/muuli_wdr.cpp:2286
+#: src/muuli_wdr.cpp:2293
 msgid "Select color for this Category (currently selected) :"
 msgstr "Выбрать цвет для этой категории:"
 
-#: src/muuli_wdr.cpp:2353 src/muuli_wdr.cpp:2372 src/muuli_wdr.cpp:2394
+#: src/muuli_wdr.cpp:2360 src/muuli_wdr.cpp:2379 src/muuli_wdr.cpp:2401
 msgid "Click this button to reset the log."
 msgstr "Кликните тут для очистки журнала."
 
-#: src/muuli_wdr.cpp:2413
+#: src/muuli_wdr.cpp:2420
 msgid "Click on this button to update the servers list from URL ..."
 msgstr "Кликните здесь чтобы обновить список серверов через URL ..."
 
-#: src/muuli_wdr.cpp:2417
+#: src/muuli_wdr.cpp:2424
 msgid "Server list"
 msgstr "Список серверов"
 
-#: src/muuli_wdr.cpp:2421
+#: src/muuli_wdr.cpp:2428
 msgid "Enter the url to a server.met file here and press the button to the left to update the list of known servers."
 msgstr "Введите URL к файлу 'server.met' и нажмите кнопку слева для обновления списка известных серверов."
 
-#: src/muuli_wdr.cpp:2426
+#: src/muuli_wdr.cpp:2433
 msgid "Add server manually: Name"
 msgstr "Добавить сервер вручную: Имя"
 
-#: src/muuli_wdr.cpp:2429
+#: src/muuli_wdr.cpp:2436
 msgid "Enter the name of the new server here"
 msgstr "Введите имя нового сервера"
 
-#: src/muuli_wdr.cpp:2431 src/ServerWnd.cpp:206
+#: src/muuli_wdr.cpp:2438 src/ServerWnd.cpp:206
 msgid "IP:Port"
 msgstr "IP:Порт"
 
-#: src/muuli_wdr.cpp:2434
+#: src/muuli_wdr.cpp:2441
 msgid "Enter the IP of the server here, using the x.x.x.x format."
 msgstr "Введите здесь IP-адрес сервера в формате: x.x.x.x"
 
-#: src/muuli_wdr.cpp:2440
+#: src/muuli_wdr.cpp:2447
 msgid "Enter the port of the server here."
 msgstr "Введите здесь порт сервера."
 
-#: src/muuli_wdr.cpp:2443
+#: src/muuli_wdr.cpp:2450
 msgid "Add manually a server (fill fields to the left before) ..."
 msgstr "Добавить сервер (предварительно заполните поля слева) ..."
 
-#: src/muuli_wdr.cpp:2472
+#: src/muuli_wdr.cpp:2479
 msgid "aMule Log"
 msgstr "Журнал aMule"
 
-#: src/muuli_wdr.cpp:2480
+#: src/muuli_wdr.cpp:2487
 msgid "Server Info"
 msgstr "Сообщение сервера"
 
-#: src/muuli_wdr.cpp:2484
+#: src/muuli_wdr.cpp:2491
 msgid "ED2K Info"
 msgstr "Инфо ED2K"
 
-#: src/muuli_wdr.cpp:2488
+#: src/muuli_wdr.cpp:2495
 msgid "Kad Info"
 msgstr "Инфо Kad"
 
-#: src/muuli_wdr.cpp:2516
+#: src/muuli_wdr.cpp:2523
 msgid "Click on this button to update the nodes list from URL ..."
 msgstr "Нажмите на эту кнопку чтобы обновить список узлов из URL..."
 
-#: src/muuli_wdr.cpp:2520
+#: src/muuli_wdr.cpp:2527
 msgid "Nodes (0)"
 msgstr "Узлы (0)"
 
-#: src/muuli_wdr.cpp:2524
+#: src/muuli_wdr.cpp:2531
 msgid "Enter the url to a nodes.dat file here and press the button to the left to update the list of known nodes."
 msgstr "Ведите сюда URL к файлу nodes.dat и нажмите кнопку слева чтобы обновить список известных узлов."
 
-#: src/muuli_wdr.cpp:2527
+#: src/muuli_wdr.cpp:2534
 msgid "Nodes stats"
 msgstr "Статистика узлов"
 
-#: src/muuli_wdr.cpp:2569
+#: src/muuli_wdr.cpp:2576
 msgid "Bootstrap"
 msgstr "Инициализация"
 
-#: src/muuli_wdr.cpp:2572
+#: src/muuli_wdr.cpp:2579
 msgid "New node"
 msgstr "Новый узел"
 
-#: src/muuli_wdr.cpp:2577
+#: src/muuli_wdr.cpp:2584
 msgid "IP:"
 msgstr "IP:"
 
-#: src/muuli_wdr.cpp:2597
+#: src/muuli_wdr.cpp:2604
 msgid "Port:"
 msgstr "Порт:"
 
 # Похоже, bootstrap в eMule перевели как инициализация
-#: src/muuli_wdr.cpp:2610
+#: src/muuli_wdr.cpp:2617
 msgid "Bootstrap from known clients"
 msgstr "Инициализация от известных клиентов"
 
-#: src/muuli_wdr.cpp:2612
+#: src/muuli_wdr.cpp:2619
 msgid "Disconnect Kad"
 msgstr "Отключить Kad"
 
-#: src/muuli_wdr.cpp:2646
+#: src/muuli_wdr.cpp:2653
 msgid "Use Secure User Identification"
 msgstr "Использовать безопасную идентификацию пользователя"
 
 # интересно, что на самом деле подразумевалось под 'credits'
-#: src/muuli_wdr.cpp:2648
+#: src/muuli_wdr.cpp:2655
 msgid "It is recommended to enable this option. You will not receive credits if SUI is not enabled."
 msgstr "Рекомендуется включить данную опцию. Вы не будете получать рейтинга если БИП выключена."
 
-#: src/muuli_wdr.cpp:2650
+#: src/muuli_wdr.cpp:2657
 msgid "Protocol Obfuscation"
 msgstr "Вуалирование протокола"
 
-#: src/muuli_wdr.cpp:2653
+#: src/muuli_wdr.cpp:2660
 msgid "Support Protocol Obfuscation"
 msgstr "Поддержка вуалирования протокола"
 
-#: src/muuli_wdr.cpp:2655
+#: src/muuli_wdr.cpp:2662
 msgid "This option enabled Protocol Obfuscation, and makes aMule accept obfuscated connections from other clients."
 msgstr "Включает вуалирование протокола и позволяет aMule принимать завуалированные соединения от других клиентов."
 
-#: src/muuli_wdr.cpp:2657
+#: src/muuli_wdr.cpp:2664
 msgid "Use obfuscation for outgoing connections"
 msgstr "Использовать вуалирование исходящих соединений"
 
-#: src/muuli_wdr.cpp:2659
+#: src/muuli_wdr.cpp:2666
 msgid "This option makes aMule use Protocol Obfuscation when connecting other clients/servers."
 msgstr "Включает вуалирование протокола при соединении с другими клиентами и серверами."
 
-#: src/muuli_wdr.cpp:2661
+#: src/muuli_wdr.cpp:2668
 msgid "Accept only obfuscated connections"
 msgstr "Принимать только завуалированные соединения"
 
-#: src/muuli_wdr.cpp:2662
+#: src/muuli_wdr.cpp:2669
 msgid "This option makes aMule only accept obfuscated connections. You will have less sources, but all your traffic will be obfuscated"
 msgstr "aMule будет принимать только завуалированные соединения. У вас будет меньше источников, но зато весь трафик будет завуалирован."
 
-#: src/muuli_wdr.cpp:2667
+#: src/muuli_wdr.cpp:2674
 msgid "Everybody"
 msgstr "Все"
 
-#: src/muuli_wdr.cpp:2669
+#: src/muuli_wdr.cpp:2676
 msgid "No one"
 msgstr "Никто"
 
-#: src/muuli_wdr.cpp:2671
+#: src/muuli_wdr.cpp:2678
 msgid "Who can see my shared files:"
 msgstr "Кто может запрашивать публикуемые файлы:"
 
-#: src/muuli_wdr.cpp:2672
+#: src/muuli_wdr.cpp:2679
 msgid "Select who can request to view a list of your shared files."
 msgstr "Выберите, кому показывать список ваших файлов."
 
-#: src/muuli_wdr.cpp:2674
+#: src/muuli_wdr.cpp:2681
 msgid "IP-Filtering"
 msgstr "Фильтрование IP"
 
-#: src/muuli_wdr.cpp:2681
+#: src/muuli_wdr.cpp:2688
 msgid "Filter clients"
 msgstr "Фильтровать клиентов."
 
-#: src/muuli_wdr.cpp:2683
+#: src/muuli_wdr.cpp:2690
 msgid "Enable filtering of the client IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "Включает фильтрацию IP клиентов в соответствии с файлом ~/.aMule/ipfilter.dat."
 
-#: src/muuli_wdr.cpp:2685
+#: src/muuli_wdr.cpp:2692
 msgid "Filter servers"
 msgstr "Фильтровать сервера"
 
-#: src/muuli_wdr.cpp:2687
+#: src/muuli_wdr.cpp:2694
 msgid "Enable filtering of the server IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "Включает фильтрацию IP серверов в соответствии с файлом ~/.aMule/ipfilter.dat."
 
-#: src/muuli_wdr.cpp:2691
+#: src/muuli_wdr.cpp:2698
 msgid "Reload List"
 msgstr "Обновить список"
 
-#: src/muuli_wdr.cpp:2692
+#: src/muuli_wdr.cpp:2699
 msgid "Reload the list of IPs to filter from the file ~/.aMule/ipfilter.dat"
 msgstr "Прочесть список IP адресов, указанных в файле '~/.aMule/ipfilter.dat'."
 
-#: src/muuli_wdr.cpp:2698
+#: src/muuli_wdr.cpp:2705
 msgid "URL:"
 msgstr "URL:"
 
-#: src/muuli_wdr.cpp:2702 src/muuli_wdr.cpp:2895
+#: src/muuli_wdr.cpp:2709 src/muuli_wdr.cpp:2902
 msgid "Update now"
 msgstr "Обновить сейчас"
 
-#: src/muuli_wdr.cpp:2705
+#: src/muuli_wdr.cpp:2712
 msgid "Auto-update ipfilter at startup"
 msgstr "Автоматически обновлять IP-фильтр при запуске"
 
-#: src/muuli_wdr.cpp:2709
+#: src/muuli_wdr.cpp:2716
 msgid "Filtering Level:"
 msgstr "Уровень фильтрации:"
 
-#: src/muuli_wdr.cpp:2715
+#: src/muuli_wdr.cpp:2722
 msgid "Always filter LAN IPs"
 msgstr "Всегда фильтровать IP-адреса LAN"
 
-#: src/muuli_wdr.cpp:2718
+#: src/muuli_wdr.cpp:2725
 msgid "Paranoid handling of non-matching IPs"
 msgstr "Параноидная обработка несовпадающих IP "
 
-#: src/muuli_wdr.cpp:2720
+#: src/muuli_wdr.cpp:2727
 msgid "Rejects a packet when its source IP differs from the IP the client claims (an anti-spoofing check). Disable only if it causes connection problems."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2722
+#: src/muuli_wdr.cpp:2729
 msgid "Use system-wide ipfilter.dat if available"
 msgstr "Использовать системный ipfilter.dat если возможно"
 
-#: src/muuli_wdr.cpp:2723
+#: src/muuli_wdr.cpp:2730
 #, fuzzy
 msgid "If there's no local ipfilter.dat found, allow usage of a system-wide ipfilter file."
 msgstr "Если не найден локальный ipfilter.dat разрешить использовать системный"
 
-#: src/muuli_wdr.cpp:2740
+#: src/muuli_wdr.cpp:2747
 msgid "Enable Online-Signature"
 msgstr "Включить Online-подпись"
 
-#: src/muuli_wdr.cpp:2742
+#: src/muuli_wdr.cpp:2749
 msgid "Enables the writing of the OS file, which can be used by external apps to create signatures and the like."
 msgstr "Включает запись файла OS, который может использоваться другими приложениями для создания подписей."
 
-#: src/muuli_wdr.cpp:2746
+#: src/muuli_wdr.cpp:2753
 msgid "Update Frequency (Secs):"
 msgstr "Частота обновления (в секундах):"
 
-#: src/muuli_wdr.cpp:2749
+#: src/muuli_wdr.cpp:2756
 msgid "Change the frequency (in seconds) of Online Signature updates."
 msgstr "Изменить частоту обновления для Online-подписи в секундах."
 
-#: src/muuli_wdr.cpp:2757
+#: src/muuli_wdr.cpp:2764
 msgid "Save online signature file in: "
 msgstr "Сохранять Online-подпись в:"
 
-#: src/muuli_wdr.cpp:2763
+#: src/muuli_wdr.cpp:2770
 msgid "Click here to select the directory containing the the Online Signature files."
 msgstr "Кликните здесь, чтобы выбрать каталок для файлов Online-подписи."
 
-#: src/muuli_wdr.cpp:2796
+#: src/muuli_wdr.cpp:2803
 msgid "Show country flags for clients"
 msgstr "Показывать национальные флаги клиентов"
 
-#: src/muuli_wdr.cpp:2797
+#: src/muuli_wdr.cpp:2804
 msgid "Render the country flag column in the transfers, queue and search views. Requires a valid MMDB GeoIP database (see below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2802
+#: src/muuli_wdr.cpp:2809
 #, fuzzy
 msgid "Database"
 msgstr "Скорость передачи:"
 
-#: src/muuli_wdr.cpp:2818
+#: src/muuli_wdr.cpp:2825
 #, fuzzy
 msgid "Source:"
 msgstr "Источники"
 
-#: src/muuli_wdr.cpp:2821
+#: src/muuli_wdr.cpp:2828
 msgid "DB-IP (free, no account)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2822
+#: src/muuli_wdr.cpp:2829
 msgid "MaxMind GeoLite2 (free, account required)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2823
+#: src/muuli_wdr.cpp:2830
 msgid "Custom URL"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2826
+#: src/muuli_wdr.cpp:2833
 msgid "Choose which provider supplies the GeoIP MMDB database. DB-IP is the default - no account required. MaxMind requires a free account + license key. Use Custom URL to point at any other MMDB host (e.g. a local mirror)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2843
+#: src/muuli_wdr.cpp:2850
 msgid ""
 "No configuration required.\n"
 "\n"
@@ -4880,11 +4894,11 @@ msgid ""
 "License: Creative Commons BY 4.0 - https://creativecommons.org/licenses/by/4.0/"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2856
+#: src/muuli_wdr.cpp:2863
 msgid "License key:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2862
+#: src/muuli_wdr.cpp:2869
 msgid ""
 "Sign up for a free MaxMind account, then generate a License Key:\n"
 "https://www.maxmind.com/en/geolite2/signup\n"
@@ -4894,227 +4908,227 @@ msgid ""
 "Requires attribution and account registration; refresh at least every 30 days."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2877
+#: src/muuli_wdr.cpp:2884
 #, fuzzy
 msgid "Download URL:"
 msgstr "Прием: "
 
-#: src/muuli_wdr.cpp:2883
+#: src/muuli_wdr.cpp:2890
 msgid ""
 "Must point to an .mmdb file or a .gz / .tar.gz containing one.\n"
 "URL may include credentials (https://user:pass@host/...).\n"
 "License and attribution terms are set by the upstream URL - you are responsible."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2896
+#: src/muuli_wdr.cpp:2903
 msgid "Download the GeoIP database from the selected source."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2898
+#: src/muuli_wdr.cpp:2905
 #, fuzzy
 msgid "Auto-update on startup"
 msgstr "Автоматически обновлять IP-фильтр при запуске"
 
-#: src/muuli_wdr.cpp:2899
+#: src/muuli_wdr.cpp:2906
 msgid "Re-download the GeoIP database from the selected source every time aMule starts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2922
+#: src/muuli_wdr.cpp:2929
 msgid "Filter incoming messages (except current chat):"
 msgstr "Фильтровать входящие сообщения (кроме текущего чата):"
 
-#: src/muuli_wdr.cpp:2924
+#: src/muuli_wdr.cpp:2931
 msgid "Filter all messages"
 msgstr "Фильтровать все сообщения"
 
-#: src/muuli_wdr.cpp:2926
+#: src/muuli_wdr.cpp:2933
 msgid "Filter messages from people not on your friend list"
 msgstr "Фильтровать сообщения пользователей не из вашего списка друзей"
 
-#: src/muuli_wdr.cpp:2928
+#: src/muuli_wdr.cpp:2935
 msgid "Filter messages from unknown clients"
 msgstr "Фильтровать сообщения от неизвестных клиентов"
 
-#: src/muuli_wdr.cpp:2930
+#: src/muuli_wdr.cpp:2937
 msgid "Filter messages containing (use ',' as separator):"
 msgstr "Фильтровать сообщения по содержанию (используйте ',' как разделитель):"
 
-#: src/muuli_wdr.cpp:2933 src/muuli_wdr.cpp:2944
+#: src/muuli_wdr.cpp:2940 src/muuli_wdr.cpp:2951
 msgid "add here the words amule should filter and block messages including it"
 msgstr "Добавьте сюда ключевые слова, при наличии которых aMule будет отфильтровывать и блокировать входящие сообщения."
 
-#: src/muuli_wdr.cpp:2935
+#: src/muuli_wdr.cpp:2942
 msgid "Show received messages in the log"
 msgstr "Показывать полученные сообщения в логе"
 
-#: src/muuli_wdr.cpp:2938
+#: src/muuli_wdr.cpp:2945
 msgid "Comments"
 msgstr "Комментарии"
 
-#: src/muuli_wdr.cpp:2941
+#: src/muuli_wdr.cpp:2948
 msgid "Filter comments containing (use ',' as separator):"
 msgstr "Фильтровать комментарии содержащие (используйте ',' как разделитель):"
 
-#: src/muuli_wdr.cpp:2966
+#: src/muuli_wdr.cpp:2973
 msgid "Enable Proxy"
 msgstr "Использовать прокси-сервер"
 
-#: src/muuli_wdr.cpp:2967
+#: src/muuli_wdr.cpp:2974
 msgid "Enable/disable proxy support"
 msgstr "Включить/выключить поддержку прокси-сервера"
 
-#: src/muuli_wdr.cpp:2970
+#: src/muuli_wdr.cpp:2977
 msgid "Proxy type:"
 msgstr "Тип прокси-сервера:"
 
-#: src/muuli_wdr.cpp:2981
+#: src/muuli_wdr.cpp:2988
 msgid "Proxy host:"
 msgstr "Прокси-сервер:"
 
-#: src/muuli_wdr.cpp:2984
+#: src/muuli_wdr.cpp:2991
 msgid "The proxy host name"
 msgstr "Имя прокси-сервера"
 
-#: src/muuli_wdr.cpp:2986
+#: src/muuli_wdr.cpp:2993
 msgid "Proxy port:"
 msgstr "Порт:"
 
-#: src/muuli_wdr.cpp:2989
+#: src/muuli_wdr.cpp:2996
 msgid "The proxy port"
 msgstr "Порт прокси-сервера"
 
-#: src/muuli_wdr.cpp:2991
+#: src/muuli_wdr.cpp:2998
 msgid "Enable authentication"
 msgstr "Включить идентификацию"
 
-#: src/muuli_wdr.cpp:2992
+#: src/muuli_wdr.cpp:2999
 msgid "Enable/disable username/password authentication"
 msgstr "Включить/выключить использование пароля и логина"
 
-#: src/muuli_wdr.cpp:2995
+#: src/muuli_wdr.cpp:3002
 msgid "Username: "
 msgstr "Имя:"
 
-#: src/muuli_wdr.cpp:2998
+#: src/muuli_wdr.cpp:3005
 msgid "The username to use to connect to the proxy"
 msgstr "Имя пользователя для подключения к прокси-серверу"
 
-#: src/muuli_wdr.cpp:3000
+#: src/muuli_wdr.cpp:3007
 msgid "Password:"
 msgstr "Пароль:"
 
-#: src/muuli_wdr.cpp:3003
+#: src/muuli_wdr.cpp:3010
 msgid "The password to use to connect to the proxy"
 msgstr "Пароль для подключения к прокси-серверу"
 
-#: src/muuli_wdr.cpp:3022
+#: src/muuli_wdr.cpp:3029
 msgid "Connect to:"
 msgstr "Соединиться с:"
 
-#: src/muuli_wdr.cpp:3031
+#: src/muuli_wdr.cpp:3038
 msgid "Login to remote amule"
 msgstr "Войти на удаленный aMule"
 
-#: src/muuli_wdr.cpp:3036
+#: src/muuli_wdr.cpp:3043
 msgid "User name"
 msgstr "Имя пользователя"
 
-#: src/muuli_wdr.cpp:3047
+#: src/muuli_wdr.cpp:3054
 msgid "Remember those settings"
 msgstr "Запомнить настройки"
 
-#: src/muuli_wdr.cpp:3050
+#: src/muuli_wdr.cpp:3057
 #, fuzzy
 msgid "Force ZLIB compression"
 msgstr "Использовать gzip-сжатие"
 
-#: src/muuli_wdr.cpp:3074
+#: src/muuli_wdr.cpp:3081
 msgid "Enable Verbose Debug-Logging."
 msgstr "Записывать в журнал подробные сообщения отладчика."
 
-#: src/muuli_wdr.cpp:3076
+#: src/muuli_wdr.cpp:3083
 #, fuzzy
 msgid "Only to Logfile"
 msgstr "&Открыть файл"
 
-#: src/muuli_wdr.cpp:3078
+#: src/muuli_wdr.cpp:3085
 msgid "Message Categories:"
 msgstr "Категории сообщений:"
 
-#: src/muuli_wdr.cpp:3102 src/PartFileConvertDlg.cpp:160
+#: src/muuli_wdr.cpp:3109 src/PartFileConvertDlg.cpp:160
 msgid "Waiting..."
 msgstr "Ожидание..."
 
-#: src/muuli_wdr.cpp:3122
+#: src/muuli_wdr.cpp:3129
 msgid "Add imports"
 msgstr "Добавить файлы"
 
-#: src/muuli_wdr.cpp:3125
+#: src/muuli_wdr.cpp:3132
 msgid "Retry selected"
 msgstr "Перезапустить выбранное"
 
-#: src/muuli_wdr.cpp:3127
+#: src/muuli_wdr.cpp:3134
 msgid "Remove selected"
 msgstr "Удалить выбранное"
 
-#: src/muuli_wdr.cpp:3190
+#: src/muuli_wdr.cpp:3197
 msgid "Event Types"
 msgstr "Типы Событий"
 
-#: src/muuli_wdr.cpp:3209
+#: src/muuli_wdr.cpp:3216
 msgid "Statistics and queued clients for selected file(s) : Session / All time"
 msgstr "Статистика и очередь клиентов для выбранных файлов: За сессию / За все время"
 
-#: src/muuli_wdr.cpp:3233
+#: src/muuli_wdr.cpp:3240
 msgid "Active Uploads"
 msgstr "Активные загрузки"
 
-#: src/muuli_wdr.cpp:3247
+#: src/muuli_wdr.cpp:3254
 msgid "Percent of total files"
 msgstr "Процент от всех файлов"
 
-#: src/muuli_wdr.cpp:3299
+#: src/muuli_wdr.cpp:3306
 msgid "Show Clients for"
 msgstr "Показать клиентов для"
 
-#: src/muuli_wdr.cpp:3301
+#: src/muuli_wdr.cpp:3308
 msgid "All files"
 msgstr "Все файлы"
 
-#: src/muuli_wdr.cpp:3304
+#: src/muuli_wdr.cpp:3311
 msgid "Selected files"
 msgstr "Выбранные файлы"
 
-#: src/muuli_wdr.cpp:3307
+#: src/muuli_wdr.cpp:3314
 msgid "Active uploads only"
 msgstr "Только активные передачи"
 
-#: src/muuli_wdr.cpp:3314
+#: src/muuli_wdr.cpp:3321
 msgid "Reload:"
 msgstr "Обновить:"
 
-#: src/muuli_wdr.cpp:3318
+#: src/muuli_wdr.cpp:3325
 msgid "Reload your shared files"
 msgstr "Обновить список публикуемых файлов"
 
-#: src/muuli_wdr.cpp:3381
+#: src/muuli_wdr.cpp:3388
 msgid "Send"
 msgstr "Отправить"
 
-#: src/muuli_wdr.cpp:3382
+#: src/muuli_wdr.cpp:3389
 msgid "Sends the specified message."
 msgstr "Отправить данное сообщение."
 
-#: src/muuli_wdr.cpp:3386
+#: src/muuli_wdr.cpp:3393
 msgid "Close this chat-session."
 msgstr "Закрыть данный чат."
 
-#: src/muuli_wdr.cpp:3409
+#: src/muuli_wdr.cpp:3416
 msgid "Connect to any server and/or Kad"
 msgstr "Соединиться с произвольным сервером и/или Kad"
 
 # подпись в главном окне. длинная просто не влезет.
-#: src/muuli_wdr.cpp:3415 src/SharedFilesCtrl.cpp:142 src/Statistics.cpp:941
+#: src/muuli_wdr.cpp:3422 src/SharedFilesCtrl.cpp:142 src/Statistics.cpp:941
 msgid "Shared Files"
 msgstr "Файлы"
 
@@ -5480,189 +5494,189 @@ msgstr "Загружено"
 msgid "ERROR: Failed to open partfile '%s'"
 msgstr "ОШИБКА: не удалось открыть частично закаченный '%s'"
 
-#: src/Preferences.cpp:673
+#: src/Preferences.cpp:674
 msgid "System default"
 msgstr "Системный"
 
-#: src/Preferences.cpp:674
+#: src/Preferences.cpp:675
 msgid "Albanian"
 msgstr "Албанский"
 
-#: src/Preferences.cpp:675
+#: src/Preferences.cpp:676
 msgid "Arabic"
 msgstr "Арабский"
 
-#: src/Preferences.cpp:676
+#: src/Preferences.cpp:677
 msgid "Asturian"
 msgstr "Астурианский"
 
-#: src/Preferences.cpp:677
+#: src/Preferences.cpp:678
 msgid "Basque"
 msgstr "Баскский"
 
-#: src/Preferences.cpp:678
+#: src/Preferences.cpp:679
 msgid "Bulgarian"
 msgstr "Болгарский"
 
-#: src/Preferences.cpp:679
+#: src/Preferences.cpp:680
 msgid "Catalan"
 msgstr "Каталонский"
 
-#: src/Preferences.cpp:680
+#: src/Preferences.cpp:681
 msgid "Chinese (Simplified)"
 msgstr "Китайский (упрощенный)"
 
-#: src/Preferences.cpp:681
+#: src/Preferences.cpp:682
 msgid "Chinese (Traditional)"
 msgstr "Китайский (традиционный)"
 
-#: src/Preferences.cpp:682
+#: src/Preferences.cpp:683
 msgid "Croatian"
 msgstr "Хорватский"
 
-#: src/Preferences.cpp:683
+#: src/Preferences.cpp:684
 msgid "Czech"
 msgstr "Чешский"
 
-#: src/Preferences.cpp:684
+#: src/Preferences.cpp:685
 msgid "Danish"
 msgstr "Датский"
 
-#: src/Preferences.cpp:685
+#: src/Preferences.cpp:686
 msgid "Dutch"
 msgstr "Голландский"
 
-#: src/Preferences.cpp:686
+#: src/Preferences.cpp:687
 msgid "English (U.K.)"
 msgstr "Английский (Великобритания)"
 
-#: src/Preferences.cpp:687
+#: src/Preferences.cpp:688
 #, fuzzy
 msgid "English (U.S.)"
 msgstr "Английский (Великобритания)"
 
-#: src/Preferences.cpp:688
+#: src/Preferences.cpp:689
 msgid "Estonian"
 msgstr "Эстонский"
 
-#: src/Preferences.cpp:689
+#: src/Preferences.cpp:690
 msgid "Finnish"
 msgstr "Финский"
 
-#: src/Preferences.cpp:690
+#: src/Preferences.cpp:691
 msgid "French"
 msgstr "Французский"
 
-#: src/Preferences.cpp:691
+#: src/Preferences.cpp:692
 msgid "Galician"
 msgstr "Гальский"
 
-#: src/Preferences.cpp:692
+#: src/Preferences.cpp:693
 msgid "German"
 msgstr "Немецкий"
 
-#: src/Preferences.cpp:693
+#: src/Preferences.cpp:694
 msgid "Greek"
 msgstr "Греческий"
 
-#: src/Preferences.cpp:694
+#: src/Preferences.cpp:695
 msgid "Hebrew"
 msgstr "Израильский"
 
-#: src/Preferences.cpp:695
+#: src/Preferences.cpp:696
 msgid "Hungarian"
 msgstr "Венгерский"
 
-#: src/Preferences.cpp:696
+#: src/Preferences.cpp:697
 msgid "Italian"
 msgstr "Итальянский"
 
-#: src/Preferences.cpp:697
+#: src/Preferences.cpp:698
 msgid "Japanese"
 msgstr "Японский"
 
-#: src/Preferences.cpp:698
+#: src/Preferences.cpp:699
 msgid "Korean"
 msgstr "Корейский"
 
-#: src/Preferences.cpp:699
+#: src/Preferences.cpp:700
 msgid "Latvian"
 msgstr ""
 
-#: src/Preferences.cpp:700
+#: src/Preferences.cpp:701
 msgid "Lithuanian"
 msgstr "Литовский"
 
-#: src/Preferences.cpp:701
+#: src/Preferences.cpp:702
 msgid "Norwegian (Nynorsk)"
 msgstr "Норвежский (Нюнорск)"
 
-#: src/Preferences.cpp:702
+#: src/Preferences.cpp:703
 msgid "Polish"
 msgstr "Польский"
 
-#: src/Preferences.cpp:703
+#: src/Preferences.cpp:704
 msgid "Portuguese"
 msgstr "Португальский"
 
-#: src/Preferences.cpp:704
+#: src/Preferences.cpp:705
 msgid "Portuguese (Brazilian)"
 msgstr "Португальский (Бразилия)"
 
-#: src/Preferences.cpp:705
+#: src/Preferences.cpp:706
 msgid "Romanian"
 msgstr "Румынский"
 
-#: src/Preferences.cpp:706
+#: src/Preferences.cpp:707
 msgid "Russian"
 msgstr "Русский"
 
-#: src/Preferences.cpp:707
+#: src/Preferences.cpp:708
 msgid "Slovenian"
 msgstr "Словакский"
 
-#: src/Preferences.cpp:708
+#: src/Preferences.cpp:709
 msgid "Spanish"
 msgstr "Испанский"
 
-#: src/Preferences.cpp:709
+#: src/Preferences.cpp:710
 msgid "Swedish"
 msgstr "Шведский"
 
-#: src/Preferences.cpp:710
+#: src/Preferences.cpp:711
 msgid "Turkish"
 msgstr "Турецкий"
 
-#: src/Preferences.cpp:711
+#: src/Preferences.cpp:712
 msgid "Ukrainian"
 msgstr "Украинский"
 
-#: src/Preferences.cpp:814
+#: src/Preferences.cpp:815
 msgid "Change Language"
 msgstr "Изменить язык"
 
-#: src/Preferences.cpp:878
+#: src/Preferences.cpp:879
 msgid "There are no translations installed for aMule"
 msgstr ""
 
-#: src/Preferences.cpp:879
+#: src/Preferences.cpp:880
 #, fuzzy
 msgid "No languages available"
 msgstr "Недоступен"
 
-#: src/Preferences.cpp:1010
+#: src/Preferences.cpp:1011
 msgid "no options available"
 msgstr "нет доступных опций"
 
-#: src/Preferences.cpp:2179
+#: src/Preferences.cpp:2182
 msgid "Invalid category found, skipping"
 msgstr "Обнаружена неверная категория, пропускаем"
 
-#: src/Preferences.cpp:2348
+#: src/Preferences.cpp:2351
 msgid "TCP port can't be higher than 65532 due to server UDP socket being TCP+3"
 msgstr "TCP порт не может быть выше 65532, так как UDP сокет - TCP+3"
 
-#: src/Preferences.cpp:2349
+#: src/Preferences.cpp:2352
 #, c-format
 msgid "Default port will be used (%d)"
 msgstr "Используется порт по умолчанию (%d)"
@@ -6180,25 +6194,29 @@ msgstr "Обновить список публикуемых файлов."
 msgid "Shared folder"
 msgstr "Публикуемые папки"
 
-#: src/SearchDlg.cpp:425
+#: src/SearchDlg.cpp:280
+msgid "Clear search history"
+msgstr ""
+
+#: src/SearchDlg.cpp:584
 msgid "It's impossible to search when both eD2k and Kademlia are disabled."
 msgstr ""
 
-#: src/SearchDlg.cpp:426 src/SearchListCtrl.cpp:858
+#: src/SearchDlg.cpp:585 src/SearchListCtrl.cpp:858
 #, fuzzy
 msgid "Search error"
 msgstr "Поиск"
 
-#: src/SearchDlg.cpp:768
+#: src/SearchDlg.cpp:929
 msgid "Min size must be smaller than max size. Max size ignored."
 msgstr "Мин. размер должен быть меньше макс. размера. Игнорирую макс. размер."
 
-#: src/SearchDlg.cpp:769 src/SearchDlg.cpp:851
+#: src/SearchDlg.cpp:930 src/SearchDlg.cpp:1012
 msgid "Search warning"
 msgstr "Предупреждение поиска"
 
 # It's about default category to download to.
-#: src/SearchDlg.cpp:929 src/SearchListCtrl.cpp:735
+#: src/SearchDlg.cpp:1092 src/SearchListCtrl.cpp:735
 msgid "Main"
 msgstr "Общая"
 

--- a/po/ru.po
+++ b/po/ru.po
@@ -14,7 +14,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-28 12:17+0200\n"
+"POT-Creation-Date: 2026-07-28 13:09+0200\n"
 "PO-Revision-Date: 2026-07-27 11:45+0000\n"
 "Last-Translator: Radist Morse <radist.morse@gmail.com>\n"
 "Language-Team: Russian <kde-russian@lists.kde.ru>\n"
@@ -298,7 +298,7 @@ msgid "Password set and external connections enabled."
 msgstr "Пароль задан и внешние соединения разрешены."
 
 #: src/amule.cpp:755 src/KadDlg.cpp:176 src/KadDlg.cpp:185
-#: src/PrefsUnifiedDlg.cpp:1461 src/SharedFilesCtrl.cpp:476
+#: src/PrefsUnifiedDlg.cpp:1470 src/SharedFilesCtrl.cpp:476
 msgid "WARNING"
 msgstr "ПРЕДУПРЕЖДЕНИЕ"
 
@@ -336,7 +336,7 @@ msgstr "Вы хотите запускать веб-сервер при загр
 #: src/amule-remote-gui.cpp:603 src/amule-remote-gui.cpp:671
 #: src/amule-remote-gui.cpp:709 src/amule-remote-gui.cpp:1282
 #: src/amule-remote-gui.cpp:1345 src/amule-remote-gui.cpp:1372
-#: src/DownloadQueue.cpp:1481 src/PrefsUnifiedDlg.cpp:1247
+#: src/DownloadQueue.cpp:1481 src/PrefsUnifiedDlg.cpp:1256
 msgid "ERROR"
 msgstr "ОШИБКА"
 
@@ -602,36 +602,36 @@ msgstr "Посетите https://github.com/amule-org/amule/releases/latest дл
 msgid "FATAL ERROR: Failed to create Timer"
 msgstr "ФАТАЛЬНАЯ ОШИБКА: не удалось создать таймер"
 
-#: src/amuleDlg.cpp:361 src/amuleDlg.cpp:1787 src/amuleDlg.cpp:2033
-#: src/muuli_wdr.cpp:1492 src/muuli_wdr.cpp:3449
+#: src/amuleDlg.cpp:361 src/amuleDlg.cpp:1810 src/amuleDlg.cpp:2056
+#: src/muuli_wdr.cpp:1492 src/muuli_wdr.cpp:3453
 msgid "Networks"
 msgstr "Сети"
 
-#: src/amuleDlg.cpp:362 src/amuleDlg.cpp:1793 src/muuli_wdr.cpp:3450
+#: src/amuleDlg.cpp:362 src/amuleDlg.cpp:1816 src/muuli_wdr.cpp:3454
 msgid "Searches"
 msgstr "Поиск"
 
-#: src/amuleDlg.cpp:363 src/amuleDlg.cpp:1799 src/DownloadListCtrl.cpp:740
-#: src/muuli_wdr.cpp:392 src/muuli_wdr.cpp:1585 src/muuli_wdr.cpp:3451
+#: src/amuleDlg.cpp:363 src/amuleDlg.cpp:1822 src/DownloadListCtrl.cpp:740
+#: src/muuli_wdr.cpp:392 src/muuli_wdr.cpp:1585 src/muuli_wdr.cpp:3455
 #: src/Statistics.cpp:829
 msgid "Downloads"
 msgstr "Загрузки"
 
-#: src/amuleDlg.cpp:364 src/amuleDlg.cpp:1805 src/muuli_wdr.cpp:3325
+#: src/amuleDlg.cpp:364 src/amuleDlg.cpp:1828 src/muuli_wdr.cpp:3329
 msgid "Shared files"
 msgstr "Публикуемые файлы"
 
-#: src/amuleDlg.cpp:365 src/amuleDlg.cpp:1811 src/muuli_wdr.cpp:2957
-#: src/muuli_wdr.cpp:3407 src/muuli_wdr.cpp:3454
+#: src/amuleDlg.cpp:365 src/amuleDlg.cpp:1834 src/muuli_wdr.cpp:2961
+#: src/muuli_wdr.cpp:3411 src/muuli_wdr.cpp:3458
 msgid "Messages"
 msgstr "Сообщения"
 
-#: src/amuleDlg.cpp:366 src/amuleDlg.cpp:1817 src/muuli_wdr.cpp:3455
+#: src/amuleDlg.cpp:366 src/amuleDlg.cpp:1840 src/muuli_wdr.cpp:3459
 #: src/PrefsUnifiedDlg.cpp:314 src/Statistics.cpp:779 src/Statistics.cpp:1235
 msgid "Statistics"
 msgstr "Статистика"
 
-#: src/amuleDlg.cpp:368 src/amuleDlg.cpp:1824 src/muuli_wdr.cpp:3457
+#: src/amuleDlg.cpp:368 src/amuleDlg.cpp:1847 src/muuli_wdr.cpp:3461
 #: src/PrefsUnifiedDlg.cpp:330 src/utils/wxCas/src/wxcasprefs.cpp:39
 msgid "Preferences"
 msgstr "Настройки"
@@ -690,8 +690,8 @@ msgstr " Kad: Выключено"
 #: src/amuleDlg.cpp:1029 src/DownloadListCtrl.cpp:505
 #: src/DownloadListCtrl.cpp:749 src/FriendListCtrl.cpp:180
 #: src/muuli_wdr.cpp:731 src/muuli_wdr.cpp:782 src/muuli_wdr.cpp:846
-#: src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2262 src/muuli_wdr.cpp:2347
-#: src/muuli_wdr.cpp:3095 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
+#: src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2266 src/muuli_wdr.cpp:2351
+#: src/muuli_wdr.cpp:3099 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
 #: src/ServerListCtrl.cpp:606 src/TransferWnd.cpp:378
 #: src/utils/wxCas/src/wxcasprefs.cpp:235
 msgid "Cancel"
@@ -702,7 +702,7 @@ msgid "Stop the current connection attempts"
 msgstr "Прекратить попытки соединения"
 
 #: src/amuleDlg.cpp:1035 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976
-#: src/muuli_wdr.cpp:2485
+#: src/muuli_wdr.cpp:2489
 msgid "Disconnect"
 msgstr "Отключиться"
 
@@ -711,7 +711,7 @@ msgid "Disconnect from the currently connected networks"
 msgstr "Отключиться от работающих сетей"
 
 #: src/amuleDlg.cpp:1041 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979
-#: src/muuli_wdr.cpp:2640 src/muuli_wdr.cpp:3092 src/muuli_wdr.cpp:3447
+#: src/muuli_wdr.cpp:2644 src/muuli_wdr.cpp:3096 src/muuli_wdr.cpp:3451
 msgid "Connect"
 msgstr "Подключиться"
 
@@ -766,7 +766,7 @@ msgstr "Подтверждение выхода"
 msgid "Launch Command: "
 msgstr "Команда запуска:"
 
-#: src/amuleDlg.cpp:1632 src/muuli_wdr.cpp:1982 src/Preferences.cpp:979
+#: src/amuleDlg.cpp:1632 src/muuli_wdr.cpp:1986 src/Preferences.cpp:979
 msgid "- default -"
 msgstr "- по умолчанию -"
 
@@ -780,60 +780,60 @@ msgstr "Каталог с темами оформления '%s' не сущес
 msgid "WARNING: Unable to open skin file '%s' for read"
 msgstr "ПРЕДУПРЕЖДЕНИЕ: невозможно открыть для чтения файл скина '%s'"
 
-#: src/amuleDlg.cpp:1791 src/muuli_wdr.cpp:3449
+#: src/amuleDlg.cpp:1814 src/muuli_wdr.cpp:3453
 msgid "Networks Window"
 msgstr "Окно сетей"
 
-#: src/amuleDlg.cpp:1797 src/muuli_wdr.cpp:3450
+#: src/amuleDlg.cpp:1820 src/muuli_wdr.cpp:3454
 msgid "Searches Window"
 msgstr "Окно поиска"
 
-#: src/amuleDlg.cpp:1803 src/muuli_wdr.cpp:3451
+#: src/amuleDlg.cpp:1826 src/muuli_wdr.cpp:3455
 msgid "Downloads Window"
 msgstr "Окно загрузки"
 
-#: src/amuleDlg.cpp:1809 src/muuli_wdr.cpp:3453
+#: src/amuleDlg.cpp:1832 src/muuli_wdr.cpp:3457
 msgid "Shared Files Window"
 msgstr "Окно публикуемых файлов"
 
-#: src/amuleDlg.cpp:1815 src/muuli_wdr.cpp:3454
+#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3458
 msgid "Messages Window"
 msgstr "Сообщения"
 
-#: src/amuleDlg.cpp:1821 src/muuli_wdr.cpp:3455
+#: src/amuleDlg.cpp:1844 src/muuli_wdr.cpp:3459
 msgid "Statistics Graph Window"
 msgstr "Статистика"
 
-#: src/amuleDlg.cpp:1828 src/muuli_wdr.cpp:3457
+#: src/amuleDlg.cpp:1851 src/muuli_wdr.cpp:3461
 msgid "Preferences Settings Window"
 msgstr "Окно настроек клиента"
 
-#: src/amuleDlg.cpp:1831 src/muuli_wdr.cpp:3458
+#: src/amuleDlg.cpp:1854 src/muuli_wdr.cpp:3462
 msgid "Import"
 msgstr "Импорт"
 
-#: src/amuleDlg.cpp:1835 src/muuli_wdr.cpp:3458
+#: src/amuleDlg.cpp:1858 src/muuli_wdr.cpp:3462
 msgid "The partfile importer tool"
 msgstr "Инструмент импортирования частично загруженных файлов (part files)"
 
-#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3459
+#: src/amuleDlg.cpp:1861 src/muuli_wdr.cpp:3463
 #: src/utils/aLinkCreator/src/alcframe.cpp:262
 msgid "About"
 msgstr "О программе"
 
-#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3459
+#: src/amuleDlg.cpp:1861 src/muuli_wdr.cpp:3463
 msgid "About/Help"
 msgstr "О программе/Помощь"
 
-#: src/amuleDlg.cpp:2036
+#: src/amuleDlg.cpp:2059
 msgid "eD2k network"
 msgstr "Сеть eD2k"
 
-#: src/amuleDlg.cpp:2039
+#: src/amuleDlg.cpp:2062
 msgid "Kad network"
 msgstr "Сеть Kad"
 
-#: src/amuleDlg.cpp:2039
+#: src/amuleDlg.cpp:2062
 msgid "No network"
 msgstr "Нет сети"
 
@@ -1372,19 +1372,19 @@ msgstr "Авто [Выс]"
 msgid "Very low"
 msgstr "Очень низкий"
 
-#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:743 src/muuli_wdr.cpp:2313
+#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:743 src/muuli_wdr.cpp:2317
 #: src/ServerListCtrl.cpp:263 src/ServerListCtrl.cpp:456
 #: src/SharedFilesCtrl.cpp:145
 msgid "Low"
 msgstr "Низкий"
 
-#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:744 src/muuli_wdr.cpp:2314
+#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:744 src/muuli_wdr.cpp:2318
 #: src/ServerListCtrl.cpp:266 src/ServerListCtrl.cpp:457
 #: src/SharedFilesCtrl.cpp:146
 msgid "Normal"
 msgstr "Нормальный"
 
-#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:745 src/muuli_wdr.cpp:2315
+#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:745 src/muuli_wdr.cpp:2319
 #: src/ServerListCtrl.cpp:269 src/ServerListCtrl.cpp:458
 #: src/SharedFilesCtrl.cpp:147
 msgid "High"
@@ -1476,7 +1476,7 @@ msgstr "Локальный сервер"
 msgid "Remote Server"
 msgstr "Удаленный сервер"
 
-#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3212
+#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3216
 #: src/SearchDlg.cpp:119 src/TextClient.cpp:911
 msgid "Kad"
 msgstr "Kad"
@@ -1549,7 +1549,7 @@ msgstr "Часть"
 msgid "Size"
 msgstr "Размер"
 
-#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3279
+#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3283
 msgid "Transferred"
 msgstr "Передано"
 
@@ -1607,7 +1607,7 @@ msgstr ""
 "Ответ от: %s (%s)\n"
 "\n"
 
-#: src/DownloadListCtrl.cpp:746 src/muuli_wdr.cpp:2316
+#: src/DownloadListCtrl.cpp:746 src/muuli_wdr.cpp:2320
 #: src/SharedFilesCtrl.cpp:150
 msgid "Auto"
 msgstr "Авто"
@@ -1645,7 +1645,7 @@ msgid "Extended Options"
 msgstr "Дополнительные настройки"
 
 #: src/DownloadListCtrl.cpp:770 src/DownloadListCtrl.cpp:822
-#: src/muuli_wdr.cpp:1800
+#: src/muuli_wdr.cpp:1804
 msgid "Preview"
 msgstr "Предварительный просмотр"
 
@@ -2450,23 +2450,23 @@ msgid ""
 "want downloads on a different (e.g. larger) disk."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:549 src/FirstRunWizard.cpp:611 src/muuli_wdr.cpp:1712
+#: src/FirstRunWizard.cpp:549 src/FirstRunWizard.cpp:611 src/muuli_wdr.cpp:1716
 msgid "Destination folder for downloads"
 msgstr "Папка для загружаемых файлов"
 
 #: src/FirstRunWizard.cpp:553 src/FirstRunWizard.cpp:569 src/muuli_wdr.cpp:1349
-#: src/muuli_wdr.cpp:1366 src/muuli_wdr.cpp:1687 src/muuli_wdr.cpp:1718
-#: src/muuli_wdr.cpp:1730 src/muuli_wdr.cpp:2800
+#: src/muuli_wdr.cpp:1366 src/muuli_wdr.cpp:1691 src/muuli_wdr.cpp:1722
+#: src/muuli_wdr.cpp:1734 src/muuli_wdr.cpp:2804
 #: src/utils/aLinkCreator/src/alcframe.cpp:135
 #: src/utils/wxCas/src/wxcasprefs.cpp:52 src/utils/wxCas/src/wxcasprefs.cpp:118
 msgid "Browse"
 msgstr "Открыть"
 
-#: src/FirstRunWizard.cpp:559 src/muuli_wdr.cpp:1723
+#: src/FirstRunWizard.cpp:559 src/muuli_wdr.cpp:1727
 msgid "(All files in this folder are shared with other peers)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:565 src/FirstRunWizard.cpp:624 src/muuli_wdr.cpp:1725
+#: src/FirstRunWizard.cpp:565 src/FirstRunWizard.cpp:624 src/muuli_wdr.cpp:1729
 msgid "Folder for temporary download files"
 msgstr "Папка для временных файлов"
 
@@ -2497,7 +2497,7 @@ msgstr "Не удалось открыть список друзей 'emfriends.
 msgid "CRITICAL - no client on StartChatSession"
 msgstr "КРИТИЧНО - нет клиентов на StartChatSession"
 
-#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2706 src/muuli_wdr.cpp:3383
+#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2710 src/muuli_wdr.cpp:3387
 msgid "Friends"
 msgstr "Друзья"
 
@@ -2608,8 +2608,8 @@ msgstr "Нет"
 msgid "No"
 msgstr "Нет"
 
-#: src/GenericClientListCtrl.cpp:1216 src/PrefsUnifiedDlg.cpp:2898
-#: src/PrefsUnifiedDlg.cpp:2948 src/ServerListCtrl.cpp:276
+#: src/GenericClientListCtrl.cpp:1216 src/PrefsUnifiedDlg.cpp:2907
+#: src/PrefsUnifiedDlg.cpp:2957 src/ServerListCtrl.cpp:276
 msgid "Yes"
 msgstr "Да"
 
@@ -2781,10 +2781,10 @@ msgstr "Неверный порт для инициализации"
 msgid "Please fill all fields required"
 msgstr "Пожалуйста, заполните все необходимые поля"
 
-#: src/KadDlg.cpp:192 src/PartFile.cpp:1031 src/PrefsUnifiedDlg.cpp:1134
-#: src/PrefsUnifiedDlg.cpp:1204 src/PrefsUnifiedDlg.cpp:1405
-#: src/PrefsUnifiedDlg.cpp:1663 src/PrefsUnifiedDlg.cpp:1673
-#: src/PrefsUnifiedDlg.cpp:1690 src/PrefsUnifiedDlg.cpp:1738
+#: src/KadDlg.cpp:192 src/PartFile.cpp:1031 src/PrefsUnifiedDlg.cpp:1143
+#: src/PrefsUnifiedDlg.cpp:1213 src/PrefsUnifiedDlg.cpp:1414
+#: src/PrefsUnifiedDlg.cpp:1672 src/PrefsUnifiedDlg.cpp:1682
+#: src/PrefsUnifiedDlg.cpp:1699 src/PrefsUnifiedDlg.cpp:1747
 msgid "Message"
 msgstr "Сообщение"
 
@@ -2890,7 +2890,7 @@ msgstr "Рейтинг"
 msgid "Uploaded"
 msgstr "Загружено"
 
-#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3263
+#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3267
 msgid "Requested"
 msgstr "Запрошено"
 
@@ -3014,7 +3014,7 @@ msgid "WARNING: "
 msgstr "ПРЕДУПРЕЖДЕНИЕ:"
 
 #: src/MuleNotebook.cpp:179 src/muuli_wdr.cpp:817 src/muuli_wdr.cpp:1229
-#: src/muuli_wdr.cpp:3167 src/muuli_wdr.cpp:3423
+#: src/muuli_wdr.cpp:3171 src/muuli_wdr.cpp:3427
 msgid "Close"
 msgstr "Закрыть"
 
@@ -3032,7 +3032,7 @@ msgid "Paste"
 msgstr "Вставить"
 
 #: src/MuleTextCtrl.cpp:89 src/muuli_wdr.cpp:358 src/muuli_wdr.cpp:757
-#: src/muuli_wdr.cpp:2390 src/muuli_wdr.cpp:2409 src/muuli_wdr.cpp:2431
+#: src/muuli_wdr.cpp:2394 src/muuli_wdr.cpp:2413 src/muuli_wdr.cpp:2435
 #: src/utils/aLinkCreator/src/alcframe.cpp:142
 msgid "Clear"
 msgstr "Очистить"
@@ -3131,7 +3131,7 @@ msgstr "Выйти"
 
 #: src/MuleTrayIcon.cpp:579 src/MuleTrayIcon.cpp:945 src/MuleTrayIcon.cpp:965
 #: src/muuli_wdr.cpp:1398 src/muuli_wdr.cpp:1406 src/muuli_wdr.cpp:1413
-#: src/muuli_wdr.cpp:1846 src/muuli_wdr.cpp:1852 src/OtherFunctions.cpp:91
+#: src/muuli_wdr.cpp:1850 src/muuli_wdr.cpp:1856 src/OtherFunctions.cpp:91
 #: src/StatisticsDlg.cpp:93 src/StatisticsDlg.cpp:95
 msgid "kB/s"
 msgstr "кБ/сек"
@@ -3377,7 +3377,7 @@ msgstr "Байт"
 msgid "KB"
 msgstr "КБ"
 
-#: src/muuli_wdr.cpp:274 src/muuli_wdr.cpp:293 src/muuli_wdr.cpp:1631
+#: src/muuli_wdr.cpp:274 src/muuli_wdr.cpp:293 src/muuli_wdr.cpp:1635
 #: src/OtherFunctions.cpp:64
 msgid "MB"
 msgstr "МБ"
@@ -3394,7 +3394,7 @@ msgstr "Макс. размер"
 msgid "Availability"
 msgstr "Доступность"
 
-#: src/muuli_wdr.cpp:312 src/muuli_wdr.cpp:398 src/muuli_wdr.cpp:3328
+#: src/muuli_wdr.cpp:312 src/muuli_wdr.cpp:398 src/muuli_wdr.cpp:3332
 msgid "Filter:"
 msgstr "Фильтр:"
 
@@ -3457,8 +3457,8 @@ msgstr "Источников:"
 #: src/muuli_wdr.cpp:1160 src/muuli_wdr.cpp:1167 src/muuli_wdr.cpp:1172
 #: src/muuli_wdr.cpp:1179 src/muuli_wdr.cpp:1184 src/muuli_wdr.cpp:1191
 #: src/muuli_wdr.cpp:1205 src/muuli_wdr.cpp:1212 src/muuli_wdr.cpp:1217
-#: src/muuli_wdr.cpp:1224 src/muuli_wdr.cpp:3265 src/muuli_wdr.cpp:3273
-#: src/muuli_wdr.cpp:3281
+#: src/muuli_wdr.cpp:1224 src/muuli_wdr.cpp:3269 src/muuli_wdr.cpp:3277
+#: src/muuli_wdr.cpp:3285
 msgid "N/A"
 msgstr "N/A"
 
@@ -3603,7 +3603,7 @@ msgstr ""
 msgid "Album :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:685 src/muuli_wdr.cpp:2285
+#: src/muuli_wdr.cpp:685 src/muuli_wdr.cpp:2289
 msgid "Title :"
 msgstr "Заголовок :"
 
@@ -3714,7 +3714,7 @@ msgstr "Имя пользователя :"
 msgid "Userhash :"
 msgstr "Хеш пользователя :"
 
-#: src/muuli_wdr.cpp:895 src/muuli_wdr.cpp:1752 src/muuli_wdr.cpp:2480
+#: src/muuli_wdr.cpp:895 src/muuli_wdr.cpp:1756 src/muuli_wdr.cpp:2484
 #: src/utils/aLinkCreator/src/alcframe.cpp:137
 msgid "Add"
 msgstr "Добавить"
@@ -3723,15 +3723,15 @@ msgstr "Добавить"
 msgid "Download-Speed"
 msgstr "Скорость приема"
 
-#: src/muuli_wdr.cpp:954 src/muuli_wdr.cpp:989 src/muuli_wdr.cpp:2584
+#: src/muuli_wdr.cpp:954 src/muuli_wdr.cpp:989 src/muuli_wdr.cpp:2588
 msgid "Current"
 msgstr "Текущая"
 
-#: src/muuli_wdr.cpp:962 src/muuli_wdr.cpp:997 src/muuli_wdr.cpp:2592
+#: src/muuli_wdr.cpp:962 src/muuli_wdr.cpp:997 src/muuli_wdr.cpp:2596
 msgid "Running average"
 msgstr "Средняя за все время"
 
-#: src/muuli_wdr.cpp:970 src/muuli_wdr.cpp:1005 src/muuli_wdr.cpp:2600
+#: src/muuli_wdr.cpp:970 src/muuli_wdr.cpp:1005 src/muuli_wdr.cpp:2604
 msgid "Session average"
 msgstr "В среднем за сеанс"
 
@@ -3743,7 +3743,7 @@ msgstr "Скорость отдачи"
 msgid "Connections"
 msgstr "Соединения"
 
-#: src/muuli_wdr.cpp:1024 src/muuli_wdr.cpp:1871
+#: src/muuli_wdr.cpp:1024 src/muuli_wdr.cpp:1875
 msgid "Active downloads"
 msgstr "Активные загрузки"
 
@@ -3751,7 +3751,7 @@ msgstr "Активные загрузки"
 msgid "Active connections (1:1)"
 msgstr "Активные соединения (1:1)"
 
-#: src/muuli_wdr.cpp:1040 src/muuli_wdr.cpp:1872
+#: src/muuli_wdr.cpp:1040 src/muuli_wdr.cpp:1876
 msgid "Active uploads"
 msgstr "Активные передачи"
 
@@ -4027,7 +4027,7 @@ msgstr "Закрепить локальный адрес за IP (пустой �
 msgid "Advanced users only: If you have multiple network interfaces, enter the address of the interface to which aMule should be bound."
 msgstr "Только для продвинутых пользователей: если у вас несколько сетевых интерфейсов введите адрес того, которым будет пользоваться aMule."
 
-#: src/muuli_wdr.cpp:1462 src/muuli_wdr.cpp:2065
+#: src/muuli_wdr.cpp:1462 src/muuli_wdr.cpp:2069
 #, fuzzy
 msgid "Bind to network interface (empty for any):"
 msgstr "Закрепить локальный адрес за IP (пустой для любого):"
@@ -4044,7 +4044,7 @@ msgstr "Максимум источников на файл:"
 msgid "Max simultaneous connections:"
 msgstr "Максимум одновременных соединений:"
 
-#: src/muuli_wdr.cpp:1498 src/muuli_wdr.cpp:3207
+#: src/muuli_wdr.cpp:1498 src/muuli_wdr.cpp:3211
 msgid "ED2K"
 msgstr "ED2K"
 
@@ -4136,785 +4136,785 @@ msgstr "Заранее выделять место для новых фалов"
 msgid "For new files preallocates disk space for the whole file, thus reduces fragmentation"
 msgstr "Сразу выделяет место под весь файл. Таким образом уменьшается фрагментация"
 
-#: src/muuli_wdr.cpp:1617
+#: src/muuli_wdr.cpp:1621
 msgid "Create new files as sparse files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1618
+#: src/muuli_wdr.cpp:1622
 msgid "Sparse part files only occupy disk space for the parts already downloaded, so free space is used up gradually as the file fills in. Turn this off to use an ordinary file instead - useful where sparse files are unsupported or slow, or where backup/de-duplication tools handle them badly. Applies only when the core runs on Windows; on Linux and macOS part files are sparse anyway and this setting has no effect."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1623
+#: src/muuli_wdr.cpp:1627
 msgid "Stop downloads when free disk space reaches "
 msgstr "Останавливать загрузки по окончанию свободного места на диске"
 
-#: src/muuli_wdr.cpp:1624
+#: src/muuli_wdr.cpp:1628
 msgid "Select this if you want aMule to check your disk space"
 msgstr "Отметьте это если  хотите чтобы aMule проверял наличие свободного места"
 
-#: src/muuli_wdr.cpp:1628
+#: src/muuli_wdr.cpp:1632
 msgid "Enter here the min disk space desired."
 msgstr "Введите здесь минимальное количество свободного места на диске."
 
-#: src/muuli_wdr.cpp:1634
+#: src/muuli_wdr.cpp:1638
 msgid "Save 10 sources on rare files (< 20 sources)"
 msgstr "Оставлять 10 источников для редких файлов (<20 источников)"
 
-#: src/muuli_wdr.cpp:1638 src/Statistics.cpp:790
+#: src/muuli_wdr.cpp:1642 src/Statistics.cpp:790
 msgid "Uploads"
 msgstr "Отдача"
 
-#: src/muuli_wdr.cpp:1641
+#: src/muuli_wdr.cpp:1645
 msgid "Add new shared files with auto priority"
 msgstr "Добавлять новые файлы для публикации с авто приоритетом"
 
 # слишком уж частая аббривеатура. написать И.О.О. - никто не поймет
-#: src/muuli_wdr.cpp:1647
+#: src/muuli_wdr.cpp:1651
 msgid "Intelligent Corruption Handling (I.C.H.)"
 msgstr "Интеллектуальная Обработка Ошибок (I.C.H.)"
 
-#: src/muuli_wdr.cpp:1650
+#: src/muuli_wdr.cpp:1654
 msgid "Enable"
 msgstr "Разрешить"
 
-#: src/muuli_wdr.cpp:1653
+#: src/muuli_wdr.cpp:1657
 msgid "Advanced I.C.H. trusts every hash (not recommended)"
 msgstr "AICH-доверие для каждого хэша (не рекомендуется)"
 
-#: src/muuli_wdr.cpp:1665 src/PrefsUnifiedDlg.cpp:1990
+#: src/muuli_wdr.cpp:1669 src/PrefsUnifiedDlg.cpp:1999
 msgid "Media metadata extraction"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1669
+#: src/muuli_wdr.cpp:1673
 msgid "Extract length / bitrate / codec from shared audio and video files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1671
+#: src/muuli_wdr.cpp:1675
 msgid "When enabled, aMule runs ffprobe on each shared media file to fill in the Length / Bitrate / Codec columns other clients see when they find the file in a search. Requires ffmpeg (the ffprobe binary) to be installed."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1678
+#: src/muuli_wdr.cpp:1682
 msgid "Path to ffprobe:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1683
+#: src/muuli_wdr.cpp:1687
 msgid "Full path to the ffprobe binary. Leave empty to have aMule auto-detect it on startup."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1691
+#: src/muuli_wdr.cpp:1695
 msgid "Detect"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1692
+#: src/muuli_wdr.cpp:1696
 msgid "Search the standard install locations for an ffprobe binary and fill the path field."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1716
+#: src/muuli_wdr.cpp:1720
 msgid ""
 "Completed downloads are stored here. All files in this folder are automatically shared with other peers.\n"
 "If this folder also holds files you don't want to share, point it at an aMule-only sub-folder."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1719
+#: src/muuli_wdr.cpp:1723
 msgid "Pick the folder where completed downloads will be stored. All files in that folder will be shared with other peers."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1733
+#: src/muuli_wdr.cpp:1737
 msgid "Shared folders"
 msgstr "Публикуемые папки"
 
-#: src/muuli_wdr.cpp:1739
+#: src/muuli_wdr.cpp:1743
 msgid "(Folders shared by the core. Enter a path to add one.)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1747
+#: src/muuli_wdr.cpp:1751
 msgid "Absolute path of a folder on the core's machine, e.g. /home/user/shared"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1749 src/PrefsUnifiedDlg.cpp:2874
+#: src/muuli_wdr.cpp:1753 src/PrefsUnifiedDlg.cpp:2883
 msgid "Recursive"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1750
+#: src/muuli_wdr.cpp:1754
 msgid "Share every sub-folder underneath this one, including ones created later."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1754 src/utils/aLinkCreator/src/alcframe.cpp:141
+#: src/muuli_wdr.cpp:1758 src/utils/aLinkCreator/src/alcframe.cpp:141
 msgid "Remove"
 msgstr "Удалить"
 
-#: src/muuli_wdr.cpp:1758
+#: src/muuli_wdr.cpp:1762
 msgid "(Right click on folder icon for recursive share)"
 msgstr "(кликните правой кнопкой на значке каталога для рекурсивной публикации)"
 
-#: src/muuli_wdr.cpp:1765
+#: src/muuli_wdr.cpp:1769
 msgid "Share hidden files"
 msgstr "Включая скрытые файлы"
 
-#: src/muuli_wdr.cpp:1771
+#: src/muuli_wdr.cpp:1775
 msgid "Automatically rescan shared folders for changes"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1777
+#: src/muuli_wdr.cpp:1781
 msgid "Follow symbolic links in shared folders"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1783
+#: src/muuli_wdr.cpp:1787
 msgid "Exclude files matching:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1786
+#: src/muuli_wdr.cpp:1790
 msgid "Wildcard patterns separated by '|', e.g. .DS_Store|Thumbs.db|*.tmp. Files whose name matches are not shared. Matching is case-insensitive."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1790
+#: src/muuli_wdr.cpp:1794
 msgid "Patterns are regular expressions"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1791
+#: src/muuli_wdr.cpp:1795
 msgid "When set, the whole field is one regular expression ('|' is alternation). When unset, it is a list of '|'-separated wildcards."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1801
+#: src/muuli_wdr.cpp:1805
 msgid "Show how many shared files the current pattern would exclude."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1822
+#: src/muuli_wdr.cpp:1826
 msgid "Graphs"
 msgstr "Графики"
 
-#: src/muuli_wdr.cpp:1825 src/muuli_wdr.cpp:1887
+#: src/muuli_wdr.cpp:1829 src/muuli_wdr.cpp:1891
 msgid "Update delay : 5 secs"
 msgstr "Интервал обновления: 5 сек"
 
-#: src/muuli_wdr.cpp:1829
+#: src/muuli_wdr.cpp:1833
 msgid "Time for average graph: 100 mins"
 msgstr "Время для среднестатического графика: 100 минут"
 
-#: src/muuli_wdr.cpp:1833
+#: src/muuli_wdr.cpp:1837
 msgid "Connections Graph Scale: 100 "
 msgstr "Масштаб графика соединений: 100 "
 
-#: src/muuli_wdr.cpp:1840
+#: src/muuli_wdr.cpp:1844
 msgid "Download graph scale:"
 msgstr "Масштаб графика загрузки:"
 
-#: src/muuli_wdr.cpp:1848
+#: src/muuli_wdr.cpp:1852
 msgid "Upload graph scale:"
 msgstr "Масштаб графика отдачи:"
 
-#: src/muuli_wdr.cpp:1858
+#: src/muuli_wdr.cpp:1862
 #, fuzzy
 msgid "Colors: "
 msgstr "Цвета:"
 
-#: src/muuli_wdr.cpp:1862
+#: src/muuli_wdr.cpp:1866
 msgid "Background"
 msgstr "Фон"
 
-#: src/muuli_wdr.cpp:1863
+#: src/muuli_wdr.cpp:1867
 msgid "Grid"
 msgstr "Сетка"
 
-#: src/muuli_wdr.cpp:1864
+#: src/muuli_wdr.cpp:1868
 msgid "Download current"
 msgstr "Текущая загрузка"
 
-#: src/muuli_wdr.cpp:1865
+#: src/muuli_wdr.cpp:1869
 msgid "Download running average"
 msgstr "Средняя общая загрузка"
 
-#: src/muuli_wdr.cpp:1866
+#: src/muuli_wdr.cpp:1870
 msgid "Download session average"
 msgstr "Средняя загрузка за сеанс"
 
-#: src/muuli_wdr.cpp:1867
+#: src/muuli_wdr.cpp:1871
 msgid "Upload current"
 msgstr "Текущая отдача"
 
-#: src/muuli_wdr.cpp:1868
+#: src/muuli_wdr.cpp:1872
 msgid "Upload running average"
 msgstr "Средняя общая отдача"
 
-#: src/muuli_wdr.cpp:1869
+#: src/muuli_wdr.cpp:1873
 msgid "Upload session average"
 msgstr "Средняя отдача за сеанс"
 
-#: src/muuli_wdr.cpp:1870
+#: src/muuli_wdr.cpp:1874
 msgid "Active connections"
 msgstr "Активные соединения"
 
-#: src/muuli_wdr.cpp:1873
+#: src/muuli_wdr.cpp:1877
 #, fuzzy
 msgid "Systray Icon Speed Bar"
 msgstr "Скорость передачи в области уведомлений"
 
-#: src/muuli_wdr.cpp:1874
+#: src/muuli_wdr.cpp:1878
 msgid "Kad-nodes current"
 msgstr "Узлы Kad (текущие)"
 
-#: src/muuli_wdr.cpp:1875
+#: src/muuli_wdr.cpp:1879
 msgid "Kad-nodes running"
 msgstr "Узлы Kad (действующие)"
 
-#: src/muuli_wdr.cpp:1876
+#: src/muuli_wdr.cpp:1880
 msgid "Kad-nodes session"
 msgstr "Узлы Kad (сессия)"
 
-#: src/muuli_wdr.cpp:1880 src/muuli_wdr.cpp:2334
+#: src/muuli_wdr.cpp:1884 src/muuli_wdr.cpp:2338
 msgid "Select"
 msgstr "Выбрать"
 
-#: src/muuli_wdr.cpp:1884
+#: src/muuli_wdr.cpp:1888
 msgid "Tree"
 msgstr "Дерево"
 
-#: src/muuli_wdr.cpp:1894
+#: src/muuli_wdr.cpp:1898
 msgid "Number of Client Versions shown (0=unlimited)"
 msgstr "Число отображаемых версий клиентов (0=неогр.)"
 
-#: src/muuli_wdr.cpp:1919
+#: src/muuli_wdr.cpp:1923
 msgid "!!! WARNING !!!"
 msgstr "!!! ВНИМАНИЕ !!!"
 
-#: src/muuli_wdr.cpp:1934
+#: src/muuli_wdr.cpp:1938
 msgid "Max new connections / 5 secs"
 msgstr "Предел количества новых соединений за 5 секунд"
 
-#: src/muuli_wdr.cpp:1936
+#: src/muuli_wdr.cpp:1940
 msgid "Concurrent Kad source lookups"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1938
+#: src/muuli_wdr.cpp:1942
 #, fuzzy
 msgid "Kad source re-search interval (minutes)"
 msgstr "Интервал обновления через FTP в минутах"
 
-#: src/muuli_wdr.cpp:1940
+#: src/muuli_wdr.cpp:1944
 #, fuzzy
 msgid "Source re-ask interval (minutes)"
 msgstr "Интервал обновления через FTP в минутах"
 
-#: src/muuli_wdr.cpp:1944
+#: src/muuli_wdr.cpp:1948
 msgid "File Buffer Size: 240000 bytes"
 msgstr "Размер буфера: 240000 байт"
 
-#: src/muuli_wdr.cpp:1948
+#: src/muuli_wdr.cpp:1952
 msgid "Use MMAP: memory-mapped file access (lower memory use)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1949
+#: src/muuli_wdr.cpp:1953
 msgid "Maps part files into memory instead of buffering them on the heap, lowering the process memory footprint. May reduce download speed on some disks; best for memory-constrained or upload-heavy hosts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1951
+#: src/muuli_wdr.cpp:1955
 msgid "Upload Queue Size: 5000 clients"
 msgstr "Размер очереди: 5000 клиентов"
 
-#: src/muuli_wdr.cpp:1955
+#: src/muuli_wdr.cpp:1959
 msgid "Server connection refresh interval: Disable"
 msgstr "Интервал обновления соединения с сервером: Отключено"
 
-#: src/muuli_wdr.cpp:1959
+#: src/muuli_wdr.cpp:1963
 msgid "Disable computer's timed standby mode"
 msgstr "Отключить засыпание компьютера"
 
 # в LA помнится так и перевели - "шкурка", но по-моему глупо.
-#: src/muuli_wdr.cpp:1978
+#: src/muuli_wdr.cpp:1982
 msgid "Skin to use: "
 msgstr "Скин:"
 
-#: src/muuli_wdr.cpp:1987
+#: src/muuli_wdr.cpp:1991
 msgid "Show \"Fast eD2k Links Handler\" in every window."
 msgstr "Показывать строку \"быстрой загрузки\" в каждой вкладке."
 
-#: src/muuli_wdr.cpp:1990
+#: src/muuli_wdr.cpp:1994
 msgid "Show extended info on categories tabs"
 msgstr "Показывать дополнительную информацию на закладках категорий"
 
-#: src/muuli_wdr.cpp:1993
+#: src/muuli_wdr.cpp:1997
 #, fuzzy
 msgid "Show application version on title"
 msgstr "Выводить скорость передачи в заголовке"
 
-#: src/muuli_wdr.cpp:1995
+#: src/muuli_wdr.cpp:1999
 msgid "Show transfer rates on title"
 msgstr "Выводить скорость передачи в заголовке"
 
-#: src/muuli_wdr.cpp:1997
+#: src/muuli_wdr.cpp:2001
 msgid "Before application name"
 msgstr "Перед именем приложения"
 
-#: src/muuli_wdr.cpp:1999
+#: src/muuli_wdr.cpp:2003
 msgid "After application name"
 msgstr "После имени приложения"
 
-#: src/muuli_wdr.cpp:2002
+#: src/muuli_wdr.cpp:2006
 msgid "Show overhead bandwidth"
 msgstr "Показывать скорость служебного трафика"
 
-#: src/muuli_wdr.cpp:2006
+#: src/muuli_wdr.cpp:2010
 msgid "Vertical toolbar orientation"
 msgstr "Вертикальное расположение панели инструментов"
 
-#: src/muuli_wdr.cpp:2008
+#: src/muuli_wdr.cpp:2012
 msgid "Live column sorting (auto-reorder rows as their values change)"
 msgstr ""
 
 # This is the heading for the preference options regarding the files in the
 # transfer list.
-#: src/muuli_wdr.cpp:2015
+#: src/muuli_wdr.cpp:2019
 msgid "Download Queue Files"
 msgstr "Загружаемые файлы"
 
-#: src/muuli_wdr.cpp:2018
+#: src/muuli_wdr.cpp:2022
 msgid "Show progress percentage"
 msgstr "Показывать процент загрузки"
 
-#: src/muuli_wdr.cpp:2024
+#: src/muuli_wdr.cpp:2028
 msgid "Show progress bar"
 msgstr "Показывать полосу выполнения"
 
-#: src/muuli_wdr.cpp:2027
+#: src/muuli_wdr.cpp:2031
 msgid "Flat"
 msgstr "Плоская"
 
-#: src/muuli_wdr.cpp:2031
+#: src/muuli_wdr.cpp:2035
 msgid "Round"
 msgstr "Круглая"
 
-#: src/muuli_wdr.cpp:2049
+#: src/muuli_wdr.cpp:2053
 msgid "External Connection Parameters"
 msgstr "Параметры внешних соединений"
 
-#: src/muuli_wdr.cpp:2052
+#: src/muuli_wdr.cpp:2056
 msgid "Accept external connections"
 msgstr "Принимать внешние соединения"
 
-#: src/muuli_wdr.cpp:2059 src/muuli_wdr.cpp:2118
+#: src/muuli_wdr.cpp:2063 src/muuli_wdr.cpp:2122
 msgid "IP of the listening interface:"
 msgstr "IP прослушиваемого интерфейса:"
 
-#: src/muuli_wdr.cpp:2062
+#: src/muuli_wdr.cpp:2066
 msgid "Enter here a valid ip in the a.b.c.d format for the listening EC interface. An empty field or 0.0.0.0 will mean any interface."
 msgstr "Введите сюда IP в формате a.b.c.d для прослушиваемого интерфейса ВС. Пустое поле или значение 0.0.0.0 означают любой интерфейс."
 
-#: src/muuli_wdr.cpp:2083 src/muuli_wdr.cpp:2194
+#: src/muuli_wdr.cpp:2087 src/muuli_wdr.cpp:2198
 msgid "TCP port:"
 msgstr "порт TCP:"
 
-#: src/muuli_wdr.cpp:2089
+#: src/muuli_wdr.cpp:2093
 msgid "Enable UPnP port forwarding on the EC port"
 msgstr "Включить UPnP для порта ВС"
 
-#: src/muuli_wdr.cpp:2093 src/muuli_wdr.cpp:3079
+#: src/muuli_wdr.cpp:2097 src/muuli_wdr.cpp:3083
 #: src/utils/wxCas/src/wxcasprefs.cpp:167
 msgid "Password"
 msgstr "Пароль"
 
-#: src/muuli_wdr.cpp:2099
+#: src/muuli_wdr.cpp:2103
 #, fuzzy
 msgid "aMule API server parameters"
 msgstr "Параметры веб-сервера"
 
-#: src/muuli_wdr.cpp:2102
+#: src/muuli_wdr.cpp:2106
 msgid "Run amuleapi (REST API) on startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2107
+#: src/muuli_wdr.cpp:2111
 #, fuzzy
 msgid "HTTP port:"
 msgstr "порт TCP:"
 
-#: src/muuli_wdr.cpp:2121
+#: src/muuli_wdr.cpp:2125
 msgid "The interface amuleapi's HTTP server listens on. 127.0.0.1 (default) accepts only local connections; use 0.0.0.0 or a specific IP to expose it to other hosts (set an admin password below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2126
+#: src/muuli_wdr.cpp:2130
 msgid "Type a password to set or change it. Stored passwords cannot be shown, so leaving this empty keeps the current one."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2128
+#: src/muuli_wdr.cpp:2132
 #, fuzzy
 msgid "Admin password"
 msgstr "Проверяю пароль\n"
 
-#: src/muuli_wdr.cpp:2140 src/muuli_wdr.cpp:2157 src/PrefsUnifiedDlg.cpp:1103
+#: src/muuli_wdr.cpp:2144 src/muuli_wdr.cpp:2161 src/PrefsUnifiedDlg.cpp:1112
 #, fuzzy
 msgid "A password is set."
 msgstr "Проверяю пароль\n"
 
-#: src/muuli_wdr.cpp:2144
+#: src/muuli_wdr.cpp:2148
 #, fuzzy
 msgid "Enable guest access"
 msgstr "Запрещать ограниченный доступ"
 
-#: src/muuli_wdr.cpp:2145
+#: src/muuli_wdr.cpp:2149
 msgid "Guest sessions may read status and listings but cannot change anything. Turning this off clears the stored guest password."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2149
+#: src/muuli_wdr.cpp:2153
 #, fuzzy
 msgid "Guest password"
 msgstr "Пароль веб-сервера для ограниченного доступа"
 
-#: src/muuli_wdr.cpp:2164
+#: src/muuli_wdr.cpp:2168
 msgid "Web server parameters"
 msgstr "Параметры веб-сервера"
 
-#: src/muuli_wdr.cpp:2167
+#: src/muuli_wdr.cpp:2171
 #, fuzzy
 msgid "Run webserver on startup (deprecated)"
 msgstr "Запускать веб-сервер при старте"
 
-#: src/muuli_wdr.cpp:2173
+#: src/muuli_wdr.cpp:2177
 msgid "Web template"
 msgstr "Веб-шаблон"
 
-#: src/muuli_wdr.cpp:2178
+#: src/muuli_wdr.cpp:2182
 msgid "Full rights password"
 msgstr "Пароль для обычного доступа"
 
-#: src/muuli_wdr.cpp:2182
+#: src/muuli_wdr.cpp:2186
 msgid "Enable Low rights User"
 msgstr "Разрешить ограниченный доступ"
 
-#: src/muuli_wdr.cpp:2187
+#: src/muuli_wdr.cpp:2191
 msgid "Low rights password"
 msgstr "Пароль ограниченного доступа"
 
-#: src/muuli_wdr.cpp:2201
+#: src/muuli_wdr.cpp:2205
 msgid "Enable UPnP port forwarding of the web server port"
 msgstr "Разрешить UPnP форвардинг порта веб-сервера"
 
-#: src/muuli_wdr.cpp:2206
+#: src/muuli_wdr.cpp:2210
 msgid "Web server UPnP TCP port (Optional)"
 msgstr "UPnP TCP порт веб-сервера (не обязательно):"
 
-#: src/muuli_wdr.cpp:2214
+#: src/muuli_wdr.cpp:2218
 msgid "Page Refresh Time (in secs)"
 msgstr "Период обновления страницы (в секундах)"
 
-#: src/muuli_wdr.cpp:2221
+#: src/muuli_wdr.cpp:2225
 msgid "Enable Gzip compression"
 msgstr "Включить сжатие Gzip"
 
-#: src/muuli_wdr.cpp:2255
+#: src/muuli_wdr.cpp:2259
 #, fuzzy
 msgid "Reset page to defaults"
 msgstr "Системный"
 
-#: src/muuli_wdr.cpp:2256
+#: src/muuli_wdr.cpp:2260
 msgid "Reset the settings on the current page to their default values."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2258 src/muuli_wdr.cpp:2344 src/ServerWnd.cpp:274
+#: src/muuli_wdr.cpp:2262 src/muuli_wdr.cpp:2348 src/ServerWnd.cpp:274
 #: src/ServerWnd.cpp:282
 msgid "OK"
 msgstr "ОК"
 
-#: src/muuli_wdr.cpp:2260
+#: src/muuli_wdr.cpp:2264
 msgid "Click here to apply any changes made to the preferences."
 msgstr "Кликните тут, чтобы сохранить внесенные вами изменения."
 
-#: src/muuli_wdr.cpp:2263
+#: src/muuli_wdr.cpp:2267
 msgid "Reset any changes made to the preferences."
 msgstr "Сбросить все изменения, внесенные вами."
 
-#: src/muuli_wdr.cpp:2292
+#: src/muuli_wdr.cpp:2296
 msgid "Comment :"
 msgstr "Комментарий :"
 
-#: src/muuli_wdr.cpp:2299
+#: src/muuli_wdr.cpp:2303
 msgid "Incoming Dir :"
 msgstr "Каталог загрузок:"
 
-#: src/muuli_wdr.cpp:2308
+#: src/muuli_wdr.cpp:2312
 msgid "Change priority for new assigned files :"
 msgstr "Установить приоритет для новых файлов:"
 
-#: src/muuli_wdr.cpp:2312
+#: src/muuli_wdr.cpp:2316
 msgid "Don't change"
 msgstr "Не изменять"
 
-#: src/muuli_wdr.cpp:2324
+#: src/muuli_wdr.cpp:2328
 msgid "Select color for this Category (currently selected) :"
 msgstr "Выбрать цвет для этой категории:"
 
-#: src/muuli_wdr.cpp:2391 src/muuli_wdr.cpp:2410 src/muuli_wdr.cpp:2432
+#: src/muuli_wdr.cpp:2395 src/muuli_wdr.cpp:2414 src/muuli_wdr.cpp:2436
 msgid "Click this button to reset the log."
 msgstr "Кликните тут для очистки журнала."
 
-#: src/muuli_wdr.cpp:2451
+#: src/muuli_wdr.cpp:2455
 msgid "Click on this button to update the servers list from URL ..."
 msgstr "Кликните здесь чтобы обновить список серверов через URL ..."
 
-#: src/muuli_wdr.cpp:2455
+#: src/muuli_wdr.cpp:2459
 msgid "Server list"
 msgstr "Список серверов"
 
-#: src/muuli_wdr.cpp:2459
+#: src/muuli_wdr.cpp:2463
 msgid "Enter the url to a server.met file here and press the button to the left to update the list of known servers."
 msgstr "Введите URL к файлу 'server.met' и нажмите кнопку слева для обновления списка известных серверов."
 
-#: src/muuli_wdr.cpp:2464
+#: src/muuli_wdr.cpp:2468
 msgid "Add server manually: Name"
 msgstr "Добавить сервер вручную: Имя"
 
-#: src/muuli_wdr.cpp:2467
+#: src/muuli_wdr.cpp:2471
 msgid "Enter the name of the new server here"
 msgstr "Введите имя нового сервера"
 
-#: src/muuli_wdr.cpp:2469 src/ServerWnd.cpp:206
+#: src/muuli_wdr.cpp:2473 src/ServerWnd.cpp:206
 msgid "IP:Port"
 msgstr "IP:Порт"
 
-#: src/muuli_wdr.cpp:2472
+#: src/muuli_wdr.cpp:2476
 msgid "Enter the IP of the server here, using the x.x.x.x format."
 msgstr "Введите здесь IP-адрес сервера в формате: x.x.x.x"
 
-#: src/muuli_wdr.cpp:2478
+#: src/muuli_wdr.cpp:2482
 msgid "Enter the port of the server here."
 msgstr "Введите здесь порт сервера."
 
-#: src/muuli_wdr.cpp:2481
+#: src/muuli_wdr.cpp:2485
 msgid "Add manually a server (fill fields to the left before) ..."
 msgstr "Добавить сервер (предварительно заполните поля слева) ..."
 
-#: src/muuli_wdr.cpp:2510
+#: src/muuli_wdr.cpp:2514
 msgid "aMule Log"
 msgstr "Журнал aMule"
 
-#: src/muuli_wdr.cpp:2518
+#: src/muuli_wdr.cpp:2522
 msgid "Server Info"
 msgstr "Сообщение сервера"
 
-#: src/muuli_wdr.cpp:2522
+#: src/muuli_wdr.cpp:2526
 msgid "ED2K Info"
 msgstr "Инфо ED2K"
 
-#: src/muuli_wdr.cpp:2526
+#: src/muuli_wdr.cpp:2530
 msgid "Kad Info"
 msgstr "Инфо Kad"
 
-#: src/muuli_wdr.cpp:2554
+#: src/muuli_wdr.cpp:2558
 msgid "Click on this button to update the nodes list from URL ..."
 msgstr "Нажмите на эту кнопку чтобы обновить список узлов из URL..."
 
-#: src/muuli_wdr.cpp:2558
+#: src/muuli_wdr.cpp:2562
 msgid "Nodes (0)"
 msgstr "Узлы (0)"
 
-#: src/muuli_wdr.cpp:2562
+#: src/muuli_wdr.cpp:2566
 msgid "Enter the url to a nodes.dat file here and press the button to the left to update the list of known nodes."
 msgstr "Ведите сюда URL к файлу nodes.dat и нажмите кнопку слева чтобы обновить список известных узлов."
 
-#: src/muuli_wdr.cpp:2565
+#: src/muuli_wdr.cpp:2569
 msgid "Nodes stats"
 msgstr "Статистика узлов"
 
-#: src/muuli_wdr.cpp:2607
+#: src/muuli_wdr.cpp:2611
 msgid "Bootstrap"
 msgstr "Инициализация"
 
-#: src/muuli_wdr.cpp:2610
+#: src/muuli_wdr.cpp:2614
 msgid "New node"
 msgstr "Новый узел"
 
-#: src/muuli_wdr.cpp:2615
+#: src/muuli_wdr.cpp:2619
 msgid "IP:"
 msgstr "IP:"
 
-#: src/muuli_wdr.cpp:2635
+#: src/muuli_wdr.cpp:2639
 msgid "Port:"
 msgstr "Порт:"
 
 # Похоже, bootstrap в eMule перевели как инициализация
-#: src/muuli_wdr.cpp:2648
+#: src/muuli_wdr.cpp:2652
 msgid "Bootstrap from known clients"
 msgstr "Инициализация от известных клиентов"
 
-#: src/muuli_wdr.cpp:2650
+#: src/muuli_wdr.cpp:2654
 msgid "Disconnect Kad"
 msgstr "Отключить Kad"
 
-#: src/muuli_wdr.cpp:2684
+#: src/muuli_wdr.cpp:2688
 msgid "Use Secure User Identification"
 msgstr "Использовать безопасную идентификацию пользователя"
 
 # интересно, что на самом деле подразумевалось под 'credits'
-#: src/muuli_wdr.cpp:2686
+#: src/muuli_wdr.cpp:2690
 msgid "It is recommended to enable this option. You will not receive credits if SUI is not enabled."
 msgstr "Рекомендуется включить данную опцию. Вы не будете получать рейтинга если БИП выключена."
 
-#: src/muuli_wdr.cpp:2688
+#: src/muuli_wdr.cpp:2692
 msgid "Protocol Obfuscation"
 msgstr "Вуалирование протокола"
 
-#: src/muuli_wdr.cpp:2691
+#: src/muuli_wdr.cpp:2695
 msgid "Support Protocol Obfuscation"
 msgstr "Поддержка вуалирования протокола"
 
-#: src/muuli_wdr.cpp:2693
+#: src/muuli_wdr.cpp:2697
 msgid "This option enabled Protocol Obfuscation, and makes aMule accept obfuscated connections from other clients."
 msgstr "Включает вуалирование протокола и позволяет aMule принимать завуалированные соединения от других клиентов."
 
-#: src/muuli_wdr.cpp:2695
+#: src/muuli_wdr.cpp:2699
 msgid "Use obfuscation for outgoing connections"
 msgstr "Использовать вуалирование исходящих соединений"
 
-#: src/muuli_wdr.cpp:2697
+#: src/muuli_wdr.cpp:2701
 msgid "This option makes aMule use Protocol Obfuscation when connecting other clients/servers."
 msgstr "Включает вуалирование протокола при соединении с другими клиентами и серверами."
 
-#: src/muuli_wdr.cpp:2699
+#: src/muuli_wdr.cpp:2703
 msgid "Accept only obfuscated connections"
 msgstr "Принимать только завуалированные соединения"
 
-#: src/muuli_wdr.cpp:2700
+#: src/muuli_wdr.cpp:2704
 msgid "This option makes aMule only accept obfuscated connections. You will have less sources, but all your traffic will be obfuscated"
 msgstr "aMule будет принимать только завуалированные соединения. У вас будет меньше источников, но зато весь трафик будет завуалирован."
 
-#: src/muuli_wdr.cpp:2705
+#: src/muuli_wdr.cpp:2709
 msgid "Everybody"
 msgstr "Все"
 
-#: src/muuli_wdr.cpp:2707
+#: src/muuli_wdr.cpp:2711
 msgid "No one"
 msgstr "Никто"
 
-#: src/muuli_wdr.cpp:2709
+#: src/muuli_wdr.cpp:2713
 msgid "Who can see my shared files:"
 msgstr "Кто может запрашивать публикуемые файлы:"
 
-#: src/muuli_wdr.cpp:2710
+#: src/muuli_wdr.cpp:2714
 msgid "Select who can request to view a list of your shared files."
 msgstr "Выберите, кому показывать список ваших файлов."
 
-#: src/muuli_wdr.cpp:2712
+#: src/muuli_wdr.cpp:2716
 msgid "IP-Filtering"
 msgstr "Фильтрование IP"
 
-#: src/muuli_wdr.cpp:2719
+#: src/muuli_wdr.cpp:2723
 msgid "Filter clients"
 msgstr "Фильтровать клиентов."
 
-#: src/muuli_wdr.cpp:2721
+#: src/muuli_wdr.cpp:2725
 msgid "Enable filtering of the client IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "Включает фильтрацию IP клиентов в соответствии с файлом ~/.aMule/ipfilter.dat."
 
-#: src/muuli_wdr.cpp:2723
+#: src/muuli_wdr.cpp:2727
 msgid "Filter servers"
 msgstr "Фильтровать сервера"
 
-#: src/muuli_wdr.cpp:2725
+#: src/muuli_wdr.cpp:2729
 msgid "Enable filtering of the server IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "Включает фильтрацию IP серверов в соответствии с файлом ~/.aMule/ipfilter.dat."
 
-#: src/muuli_wdr.cpp:2729
+#: src/muuli_wdr.cpp:2733
 msgid "Reload List"
 msgstr "Обновить список"
 
-#: src/muuli_wdr.cpp:2730
+#: src/muuli_wdr.cpp:2734
 msgid "Reload the list of IPs to filter from the file ~/.aMule/ipfilter.dat"
 msgstr "Прочесть список IP адресов, указанных в файле '~/.aMule/ipfilter.dat'."
 
-#: src/muuli_wdr.cpp:2736
+#: src/muuli_wdr.cpp:2740
 msgid "URL:"
 msgstr "URL:"
 
-#: src/muuli_wdr.cpp:2740 src/muuli_wdr.cpp:2933
+#: src/muuli_wdr.cpp:2744 src/muuli_wdr.cpp:2937
 msgid "Update now"
 msgstr "Обновить сейчас"
 
-#: src/muuli_wdr.cpp:2743
+#: src/muuli_wdr.cpp:2747
 msgid "Auto-update ipfilter at startup"
 msgstr "Автоматически обновлять IP-фильтр при запуске"
 
-#: src/muuli_wdr.cpp:2747
+#: src/muuli_wdr.cpp:2751
 msgid "Filtering Level:"
 msgstr "Уровень фильтрации:"
 
-#: src/muuli_wdr.cpp:2753
+#: src/muuli_wdr.cpp:2757
 msgid "Always filter LAN IPs"
 msgstr "Всегда фильтровать IP-адреса LAN"
 
-#: src/muuli_wdr.cpp:2756
+#: src/muuli_wdr.cpp:2760
 msgid "Paranoid handling of non-matching IPs"
 msgstr "Параноидная обработка несовпадающих IP "
 
-#: src/muuli_wdr.cpp:2758
+#: src/muuli_wdr.cpp:2762
 msgid "Rejects a packet when its source IP differs from the IP the client claims (an anti-spoofing check). Disable only if it causes connection problems."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2760
+#: src/muuli_wdr.cpp:2764
 msgid "Use system-wide ipfilter.dat if available"
 msgstr "Использовать системный ipfilter.dat если возможно"
 
-#: src/muuli_wdr.cpp:2761
+#: src/muuli_wdr.cpp:2765
 #, fuzzy
 msgid "If there's no local ipfilter.dat found, allow usage of a system-wide ipfilter file."
 msgstr "Если не найден локальный ipfilter.dat разрешить использовать системный"
 
-#: src/muuli_wdr.cpp:2778
+#: src/muuli_wdr.cpp:2782
 msgid "Enable Online-Signature"
 msgstr "Включить Online-подпись"
 
-#: src/muuli_wdr.cpp:2780
+#: src/muuli_wdr.cpp:2784
 msgid "Enables the writing of the OS file, which can be used by external apps to create signatures and the like."
 msgstr "Включает запись файла OS, который может использоваться другими приложениями для создания подписей."
 
-#: src/muuli_wdr.cpp:2784
+#: src/muuli_wdr.cpp:2788
 msgid "Update Frequency (Secs):"
 msgstr "Частота обновления (в секундах):"
 
-#: src/muuli_wdr.cpp:2787
+#: src/muuli_wdr.cpp:2791
 msgid "Change the frequency (in seconds) of Online Signature updates."
 msgstr "Изменить частоту обновления для Online-подписи в секундах."
 
-#: src/muuli_wdr.cpp:2795
+#: src/muuli_wdr.cpp:2799
 msgid "Save online signature file in: "
 msgstr "Сохранять Online-подпись в:"
 
-#: src/muuli_wdr.cpp:2801
+#: src/muuli_wdr.cpp:2805
 msgid "Click here to select the directory containing the the Online Signature files."
 msgstr "Кликните здесь, чтобы выбрать каталок для файлов Online-подписи."
 
-#: src/muuli_wdr.cpp:2834
+#: src/muuli_wdr.cpp:2838
 msgid "Show country flags for clients"
 msgstr "Показывать национальные флаги клиентов"
 
-#: src/muuli_wdr.cpp:2835
+#: src/muuli_wdr.cpp:2839
 msgid "Render the country flag column in the transfers, queue and search views. Requires a valid MMDB GeoIP database (see below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2840
+#: src/muuli_wdr.cpp:2844
 #, fuzzy
 msgid "Database"
 msgstr "Скорость передачи:"
 
-#: src/muuli_wdr.cpp:2856
+#: src/muuli_wdr.cpp:2860
 #, fuzzy
 msgid "Source:"
 msgstr "Источники"
 
-#: src/muuli_wdr.cpp:2859
+#: src/muuli_wdr.cpp:2863
 msgid "DB-IP (free, no account)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2860
+#: src/muuli_wdr.cpp:2864
 msgid "MaxMind GeoLite2 (free, account required)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2861
+#: src/muuli_wdr.cpp:2865
 msgid "Custom URL"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2864
+#: src/muuli_wdr.cpp:2868
 msgid "Choose which provider supplies the GeoIP MMDB database. DB-IP is the default - no account required. MaxMind requires a free account + license key. Use Custom URL to point at any other MMDB host (e.g. a local mirror)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2881
+#: src/muuli_wdr.cpp:2885
 msgid ""
 "No configuration required.\n"
 "\n"
@@ -4922,11 +4922,11 @@ msgid ""
 "License: Creative Commons BY 4.0 - https://creativecommons.org/licenses/by/4.0/"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2894
+#: src/muuli_wdr.cpp:2898
 msgid "License key:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2900
+#: src/muuli_wdr.cpp:2904
 msgid ""
 "Sign up for a free MaxMind account, then generate a License Key:\n"
 "https://www.maxmind.com/en/geolite2/signup\n"
@@ -4936,227 +4936,227 @@ msgid ""
 "Requires attribution and account registration; refresh at least every 30 days."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2915
+#: src/muuli_wdr.cpp:2919
 #, fuzzy
 msgid "Download URL:"
 msgstr "Прием: "
 
-#: src/muuli_wdr.cpp:2921
+#: src/muuli_wdr.cpp:2925
 msgid ""
 "Must point to an .mmdb file or a .gz / .tar.gz containing one.\n"
 "URL may include credentials (https://user:pass@host/...).\n"
 "License and attribution terms are set by the upstream URL - you are responsible."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2934
+#: src/muuli_wdr.cpp:2938
 msgid "Download the GeoIP database from the selected source."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2936
+#: src/muuli_wdr.cpp:2940
 #, fuzzy
 msgid "Auto-update on startup"
 msgstr "Автоматически обновлять IP-фильтр при запуске"
 
-#: src/muuli_wdr.cpp:2937
+#: src/muuli_wdr.cpp:2941
 msgid "Re-download the GeoIP database from the selected source every time aMule starts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2960
+#: src/muuli_wdr.cpp:2964
 msgid "Filter incoming messages (except current chat):"
 msgstr "Фильтровать входящие сообщения (кроме текущего чата):"
 
-#: src/muuli_wdr.cpp:2962
+#: src/muuli_wdr.cpp:2966
 msgid "Filter all messages"
 msgstr "Фильтровать все сообщения"
 
-#: src/muuli_wdr.cpp:2964
+#: src/muuli_wdr.cpp:2968
 msgid "Filter messages from people not on your friend list"
 msgstr "Фильтровать сообщения пользователей не из вашего списка друзей"
 
-#: src/muuli_wdr.cpp:2966
+#: src/muuli_wdr.cpp:2970
 msgid "Filter messages from unknown clients"
 msgstr "Фильтровать сообщения от неизвестных клиентов"
 
-#: src/muuli_wdr.cpp:2968
+#: src/muuli_wdr.cpp:2972
 msgid "Filter messages containing (use ',' as separator):"
 msgstr "Фильтровать сообщения по содержанию (используйте ',' как разделитель):"
 
-#: src/muuli_wdr.cpp:2971 src/muuli_wdr.cpp:2982
+#: src/muuli_wdr.cpp:2975 src/muuli_wdr.cpp:2986
 msgid "add here the words amule should filter and block messages including it"
 msgstr "Добавьте сюда ключевые слова, при наличии которых aMule будет отфильтровывать и блокировать входящие сообщения."
 
-#: src/muuli_wdr.cpp:2973
+#: src/muuli_wdr.cpp:2977
 msgid "Show received messages in the log"
 msgstr "Показывать полученные сообщения в логе"
 
-#: src/muuli_wdr.cpp:2976
+#: src/muuli_wdr.cpp:2980
 msgid "Comments"
 msgstr "Комментарии"
 
-#: src/muuli_wdr.cpp:2979
+#: src/muuli_wdr.cpp:2983
 msgid "Filter comments containing (use ',' as separator):"
 msgstr "Фильтровать комментарии содержащие (используйте ',' как разделитель):"
 
-#: src/muuli_wdr.cpp:3004
+#: src/muuli_wdr.cpp:3008
 msgid "Enable Proxy"
 msgstr "Использовать прокси-сервер"
 
-#: src/muuli_wdr.cpp:3005
+#: src/muuli_wdr.cpp:3009
 msgid "Enable/disable proxy support"
 msgstr "Включить/выключить поддержку прокси-сервера"
 
-#: src/muuli_wdr.cpp:3008
+#: src/muuli_wdr.cpp:3012
 msgid "Proxy type:"
 msgstr "Тип прокси-сервера:"
 
-#: src/muuli_wdr.cpp:3019
+#: src/muuli_wdr.cpp:3023
 msgid "Proxy host:"
 msgstr "Прокси-сервер:"
 
-#: src/muuli_wdr.cpp:3022
+#: src/muuli_wdr.cpp:3026
 msgid "The proxy host name"
 msgstr "Имя прокси-сервера"
 
-#: src/muuli_wdr.cpp:3024
+#: src/muuli_wdr.cpp:3028
 msgid "Proxy port:"
 msgstr "Порт:"
 
-#: src/muuli_wdr.cpp:3027
+#: src/muuli_wdr.cpp:3031
 msgid "The proxy port"
 msgstr "Порт прокси-сервера"
 
-#: src/muuli_wdr.cpp:3029
+#: src/muuli_wdr.cpp:3033
 msgid "Enable authentication"
 msgstr "Включить идентификацию"
 
-#: src/muuli_wdr.cpp:3030
+#: src/muuli_wdr.cpp:3034
 msgid "Enable/disable username/password authentication"
 msgstr "Включить/выключить использование пароля и логина"
 
-#: src/muuli_wdr.cpp:3033
+#: src/muuli_wdr.cpp:3037
 msgid "Username: "
 msgstr "Имя:"
 
-#: src/muuli_wdr.cpp:3036
+#: src/muuli_wdr.cpp:3040
 msgid "The username to use to connect to the proxy"
 msgstr "Имя пользователя для подключения к прокси-серверу"
 
-#: src/muuli_wdr.cpp:3038
+#: src/muuli_wdr.cpp:3042
 msgid "Password:"
 msgstr "Пароль:"
 
-#: src/muuli_wdr.cpp:3041
+#: src/muuli_wdr.cpp:3045
 msgid "The password to use to connect to the proxy"
 msgstr "Пароль для подключения к прокси-серверу"
 
-#: src/muuli_wdr.cpp:3060
+#: src/muuli_wdr.cpp:3064
 msgid "Connect to:"
 msgstr "Соединиться с:"
 
-#: src/muuli_wdr.cpp:3069
+#: src/muuli_wdr.cpp:3073
 msgid "Login to remote amule"
 msgstr "Войти на удаленный aMule"
 
-#: src/muuli_wdr.cpp:3074
+#: src/muuli_wdr.cpp:3078
 msgid "User name"
 msgstr "Имя пользователя"
 
-#: src/muuli_wdr.cpp:3085
+#: src/muuli_wdr.cpp:3089
 msgid "Remember those settings"
 msgstr "Запомнить настройки"
 
-#: src/muuli_wdr.cpp:3088
+#: src/muuli_wdr.cpp:3092
 #, fuzzy
 msgid "Force ZLIB compression"
 msgstr "Использовать gzip-сжатие"
 
-#: src/muuli_wdr.cpp:3112
+#: src/muuli_wdr.cpp:3116
 msgid "Enable Verbose Debug-Logging."
 msgstr "Записывать в журнал подробные сообщения отладчика."
 
-#: src/muuli_wdr.cpp:3114
+#: src/muuli_wdr.cpp:3118
 #, fuzzy
 msgid "Only to Logfile"
 msgstr "&Открыть файл"
 
-#: src/muuli_wdr.cpp:3116
+#: src/muuli_wdr.cpp:3120
 msgid "Message Categories:"
 msgstr "Категории сообщений:"
 
-#: src/muuli_wdr.cpp:3140 src/PartFileConvertDlg.cpp:160
+#: src/muuli_wdr.cpp:3144 src/PartFileConvertDlg.cpp:160
 msgid "Waiting..."
 msgstr "Ожидание..."
 
-#: src/muuli_wdr.cpp:3160
+#: src/muuli_wdr.cpp:3164
 msgid "Add imports"
 msgstr "Добавить файлы"
 
-#: src/muuli_wdr.cpp:3163
+#: src/muuli_wdr.cpp:3167
 msgid "Retry selected"
 msgstr "Перезапустить выбранное"
 
-#: src/muuli_wdr.cpp:3165
+#: src/muuli_wdr.cpp:3169
 msgid "Remove selected"
 msgstr "Удалить выбранное"
 
-#: src/muuli_wdr.cpp:3228
+#: src/muuli_wdr.cpp:3232
 msgid "Event Types"
 msgstr "Типы Событий"
 
-#: src/muuli_wdr.cpp:3247
+#: src/muuli_wdr.cpp:3251
 msgid "Statistics and queued clients for selected file(s) : Session / All time"
 msgstr "Статистика и очередь клиентов для выбранных файлов: За сессию / За все время"
 
-#: src/muuli_wdr.cpp:3271
+#: src/muuli_wdr.cpp:3275
 msgid "Active Uploads"
 msgstr "Активные загрузки"
 
-#: src/muuli_wdr.cpp:3285
+#: src/muuli_wdr.cpp:3289
 msgid "Percent of total files"
 msgstr "Процент от всех файлов"
 
-#: src/muuli_wdr.cpp:3337
+#: src/muuli_wdr.cpp:3341
 msgid "Show Clients for"
 msgstr "Показать клиентов для"
 
-#: src/muuli_wdr.cpp:3339
+#: src/muuli_wdr.cpp:3343
 msgid "All files"
 msgstr "Все файлы"
 
-#: src/muuli_wdr.cpp:3342
+#: src/muuli_wdr.cpp:3346
 msgid "Selected files"
 msgstr "Выбранные файлы"
 
-#: src/muuli_wdr.cpp:3345
+#: src/muuli_wdr.cpp:3349
 msgid "Active uploads only"
 msgstr "Только активные передачи"
 
-#: src/muuli_wdr.cpp:3352
+#: src/muuli_wdr.cpp:3356
 msgid "Reload:"
 msgstr "Обновить:"
 
-#: src/muuli_wdr.cpp:3356
+#: src/muuli_wdr.cpp:3360
 msgid "Reload your shared files"
 msgstr "Обновить список публикуемых файлов"
 
-#: src/muuli_wdr.cpp:3419
+#: src/muuli_wdr.cpp:3423
 msgid "Send"
 msgstr "Отправить"
 
-#: src/muuli_wdr.cpp:3420
+#: src/muuli_wdr.cpp:3424
 msgid "Sends the specified message."
 msgstr "Отправить данное сообщение."
 
-#: src/muuli_wdr.cpp:3424
+#: src/muuli_wdr.cpp:3428
 msgid "Close this chat-session."
 msgstr "Закрыть данный чат."
 
-#: src/muuli_wdr.cpp:3447
+#: src/muuli_wdr.cpp:3451
 msgid "Connect to any server and/or Kad"
 msgstr "Соединиться с произвольным сервером и/или Kad"
 
 # подпись в главном окне. длинная просто не влезет.
-#: src/muuli_wdr.cpp:3453 src/SharedFilesCtrl.cpp:142 src/Statistics.cpp:941
+#: src/muuli_wdr.cpp:3457 src/SharedFilesCtrl.cpp:142 src/Statistics.cpp:941
 msgid "Shared Files"
 msgstr "Файлы"
 
@@ -5799,35 +5799,35 @@ msgstr ""
 "aMule будет превосходно работать и БЕЗ ИЗМЕНЕНИЯ вами\n"
 "этих настроек."
 
-#: src/PrefsUnifiedDlg.cpp:647
+#: src/PrefsUnifiedDlg.cpp:656
 #, c-format
 msgid "Failed to connect Cfg to widget with the ID %d and key %s"
 msgstr "Не удалось подключить Cfg к widget с ID %d и ключом %s"
 
-#: src/PrefsUnifiedDlg.cpp:695
+#: src/PrefsUnifiedDlg.cpp:704
 #, c-format
 msgid "Failed to transfer data from Cfg to Widget with the ID %d and key %s"
 msgstr "Не удалось передать данные из Cfg к Widget с ID %d и ключом %s"
 
-#: src/PrefsUnifiedDlg.cpp:801
+#: src/PrefsUnifiedDlg.cpp:810
 msgid "The type of proxy you are connecting to"
 msgstr "Тип прокси-сервера, который вы используете"
 
-#: src/PrefsUnifiedDlg.cpp:1020
+#: src/PrefsUnifiedDlg.cpp:1029
 #, c-format
 msgid "Failed to transfer data from Widget to Cfg with the ID %d and key %s"
 msgstr "Не удалось передать данные из Widget к Cfg с ID %d и ключом %s"
 
-#: src/PrefsUnifiedDlg.cpp:1103
+#: src/PrefsUnifiedDlg.cpp:1112
 #, fuzzy
 msgid "No password set."
 msgstr "Проверяю пароль\n"
 
-#: src/PrefsUnifiedDlg.cpp:1132
+#: src/PrefsUnifiedDlg.cpp:1141
 msgid "Guest access needs a password. Type one in the guest password field, or untick Enable guest access."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1144
+#: src/PrefsUnifiedDlg.cpp:1153
 msgid ""
 "aMule must be restarted to enable these changes:\n"
 "\n"
@@ -5835,42 +5835,42 @@ msgstr ""
 "Необходимо перезапустить aMule чтобы следующие изменения вступили в силу:\n"
 "\n"
 
-#: src/PrefsUnifiedDlg.cpp:1151
+#: src/PrefsUnifiedDlg.cpp:1160
 msgid "- TCP port changed.\n"
 msgstr "- изменен порт TCP.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1156
+#: src/PrefsUnifiedDlg.cpp:1165
 msgid "- UDP port changed.\n"
 msgstr "- изменен порт UDP.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1161
+#: src/PrefsUnifiedDlg.cpp:1170
 #, fuzzy
 msgid "- Network interface binding changed.\n"
 msgstr "- Интерфейс внешних соединений изменен.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1166
+#: src/PrefsUnifiedDlg.cpp:1175
 msgid "- External connect port changed.\n"
 msgstr "- Порт для внешних соединений изменен.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1170
+#: src/PrefsUnifiedDlg.cpp:1179
 msgid "- External connect acceptance changed.\n"
 msgstr "- Принятие внешних соединений изменено.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1174
+#: src/PrefsUnifiedDlg.cpp:1183
 msgid "- External connect interface changed.\n"
 msgstr "- Интерфейс внешних соединений изменен.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1178
+#: src/PrefsUnifiedDlg.cpp:1187
 #, fuzzy
 msgid "- Protocol obfuscation support changed.\n"
 msgstr "Вуалирование протокола"
 
-#: src/PrefsUnifiedDlg.cpp:1193
+#: src/PrefsUnifiedDlg.cpp:1202
 #, fuzzy
 msgid "- amuleapi settings changed.\n"
 msgstr "- Изменен язык.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1202
+#: src/PrefsUnifiedDlg.cpp:1211
 msgid ""
 "Your Auto-update server list is empty.\n"
 "'Auto-update server list at startup' will be disabled."
@@ -5878,7 +5878,7 @@ msgstr ""
 "Список авто обновления пуст.\n"
 "Автоматическое обновление списка серверов отключено."
 
-#: src/PrefsUnifiedDlg.cpp:1213
+#: src/PrefsUnifiedDlg.cpp:1222
 msgid ""
 "You have enabled external connections but have not specified a password.\n"
 "External connections cannot be enabled unless a valid password is specified."
@@ -5886,33 +5886,33 @@ msgstr ""
 "Вы включили внешние соединения, но не указали пароль.\n"
 "Внешние соединения нельзя включить до тех пор, пока не указан пароль."
 
-#: src/PrefsUnifiedDlg.cpp:1246
+#: src/PrefsUnifiedDlg.cpp:1255
 #, c-format
 msgid "The amuleapi password could not be saved: %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1276
+#: src/PrefsUnifiedDlg.cpp:1285
 msgid "- Language changed.\n"
 msgstr "- Изменен язык.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1281
+#: src/PrefsUnifiedDlg.cpp:1290
 msgid "- Temp folder changed.\n"
 msgstr "- Изменен временный каталог.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1286
+#: src/PrefsUnifiedDlg.cpp:1295
 msgid "- ED2K network enabled.\n"
 msgstr "- сеть eD2k включена. \n"
 
-#: src/PrefsUnifiedDlg.cpp:1319
+#: src/PrefsUnifiedDlg.cpp:1328
 msgid "The shared-file exclusion pattern is not a valid regular expression. The filter has been left disabled."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1321 src/PrefsUnifiedDlg.cpp:1921
+#: src/PrefsUnifiedDlg.cpp:1330 src/PrefsUnifiedDlg.cpp:1930
 #, fuzzy
 msgid "Invalid regular expression"
 msgstr "Недопустимая версия протокола."
 
-#: src/PrefsUnifiedDlg.cpp:1398
+#: src/PrefsUnifiedDlg.cpp:1407
 msgid ""
 "Both eD2k and Kad network are disabled.\n"
 "You won't be able to connect until you enable at least one of them."
@@ -5920,7 +5920,7 @@ msgstr ""
 "Сети eD2k и Kad обе отключены.\n"
 "Вы не сможете подсоединиться пока не подключите хотя бы одну из них."
 
-#: src/PrefsUnifiedDlg.cpp:1403
+#: src/PrefsUnifiedDlg.cpp:1412
 msgid ""
 "Kad will not start if your UDP port is disabled.\n"
 "Enable UDP port or disable Kad."
@@ -5928,7 +5928,7 @@ msgstr ""
 "Kad не будет запущена, если UDP-порт выключен.\n"
 "Включите UDP-порт или выключите Kad."
 
-#: src/PrefsUnifiedDlg.cpp:1459
+#: src/PrefsUnifiedDlg.cpp:1468
 msgid ""
 "\n"
 "You MUST restart aMule now.\n"
@@ -5938,69 +5938,69 @@ msgstr ""
 "Вам НЕОБХОДИМО перезапустить aMule немедленно.\n"
 "Иначе не жалуйтесь, если произойдет какая-нибудь неприятность.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1524
+#: src/PrefsUnifiedDlg.cpp:1533
 msgid "Could not register aMule for autostart at login. The autostart store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1526
+#: src/PrefsUnifiedDlg.cpp:1535
 msgid "Could not remove the autostart-at-login entry."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1527
+#: src/PrefsUnifiedDlg.cpp:1536
 #, fuzzy
 msgid "Autostart"
 msgstr "Автоматическое обновление начато"
 
-#: src/PrefsUnifiedDlg.cpp:1542
+#: src/PrefsUnifiedDlg.cpp:1551
 msgid "Register file type"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1542
+#: src/PrefsUnifiedDlg.cpp:1551
 msgid "Register URL handler"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1550
+#: src/PrefsUnifiedDlg.cpp:1559
 #, c-format
 msgid "aMule only handles eD2k-compatible magnets. If you replace the current magnet handler (%s), BitTorrent magnet links will stop working - aMule cannot download BitTorrent content. Continue?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1555
+#: src/PrefsUnifiedDlg.cpp:1564
 #, c-format
 msgid "Another application currently opens .emulecollection files (%s). Replace it with aMule?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1560
+#: src/PrefsUnifiedDlg.cpp:1569
 #, c-format
 msgid "Another application is currently the default handler for these links (%s). Replace it with aMule?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1585
+#: src/PrefsUnifiedDlg.cpp:1594
 msgid "Could not register aMule for .emulecollection files. The registration store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1587
+#: src/PrefsUnifiedDlg.cpp:1596
 #, fuzzy
 msgid "Could not remove the file type registration."
 msgstr "Папка для временных файлов"
 
-#: src/PrefsUnifiedDlg.cpp:1589
+#: src/PrefsUnifiedDlg.cpp:1598
 msgid "Could not register aMule as the URL handler. The registration store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1591
+#: src/PrefsUnifiedDlg.cpp:1600
 msgid "Could not remove the URL handler registration."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1661 src/PrefsUnifiedDlg.cpp:1688
+#: src/PrefsUnifiedDlg.cpp:1670 src/PrefsUnifiedDlg.cpp:1697
 #, fuzzy
 msgid "The web server and aMule API require external connections to be enabled."
 msgstr "Пароль задан и внешние соединения разрешены."
 
-#: src/PrefsUnifiedDlg.cpp:1671
+#: src/PrefsUnifiedDlg.cpp:1680
 msgid "The aMule web server is deprecated. Consider running the aMule API instead."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1735
+#: src/PrefsUnifiedDlg.cpp:1744
 msgid ""
 "Your Auto-update servers list is in blank.\n"
 "Please fill in at least one URL to point to a valid server.met file.\n"
@@ -6010,24 +6010,24 @@ msgstr ""
 "Пожалуйста, внесите в список хотя бы один URL, указывающий на корректный 'server.met'.\n"
 "Щелкните на кнопке \"Список\" чтобы ввести URL."
 
-#: src/PrefsUnifiedDlg.cpp:1876
+#: src/PrefsUnifiedDlg.cpp:1885
 msgid "Temporary files"
 msgstr "Временные файлы"
 
-#: src/PrefsUnifiedDlg.cpp:1881
+#: src/PrefsUnifiedDlg.cpp:1890
 msgid "Incoming files"
 msgstr "Входящие файлы"
 
-#: src/PrefsUnifiedDlg.cpp:1886
+#: src/PrefsUnifiedDlg.cpp:1895
 msgid "Online Signatures"
 msgstr "Online-подписи"
 
-#: src/PrefsUnifiedDlg.cpp:1899
+#: src/PrefsUnifiedDlg.cpp:1908
 #, c-format
 msgid "Choose a folder for %s"
 msgstr "Выберите каталог для %s"
 
-#: src/PrefsUnifiedDlg.cpp:1923
+#: src/PrefsUnifiedDlg.cpp:1932
 #, fuzzy, c-format
 msgid "Would exclude %u of %u shared file"
 msgid_plural "Would exclude %u of %u shared files"
@@ -6035,42 +6035,42 @@ msgstr[0] "Найден %i известный публикуемый файл."
 msgstr[1] "Найдено %i известных публикуемых файла."
 msgstr[2] "Найдено %i известных публикуемых файлов."
 
-#: src/PrefsUnifiedDlg.cpp:1940
+#: src/PrefsUnifiedDlg.cpp:1949
 msgid "Browse for videoplayer"
 msgstr "Выбрать видео-проигрыватель"
 
-#: src/PrefsUnifiedDlg.cpp:1944
+#: src/PrefsUnifiedDlg.cpp:1953
 msgid "Select browser"
 msgstr "Выберите броузер"
 
-#: src/PrefsUnifiedDlg.cpp:1948
+#: src/PrefsUnifiedDlg.cpp:1957
 #, fuzzy
 msgid "Select ffprobe binary"
 msgstr "Выберите броузер"
 
-#: src/PrefsUnifiedDlg.cpp:1954
+#: src/PrefsUnifiedDlg.cpp:1963
 #, c-format
 msgid "Executable%s"
 msgstr "Команда запуска%s"
 
-#: src/PrefsUnifiedDlg.cpp:1988
+#: src/PrefsUnifiedDlg.cpp:1997
 msgid "ffprobe not found on PATH or in the standard install locations. Install ffmpeg (which ships ffprobe) or use Browse to pick a binary manually."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2000
+#: src/PrefsUnifiedDlg.cpp:2009
 msgid "Reset the settings on this page to their default values?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2001
+#: src/PrefsUnifiedDlg.cpp:2010
 #, fuzzy
 msgid "Reset to defaults"
 msgstr "Системный"
 
-#: src/PrefsUnifiedDlg.cpp:2028
+#: src/PrefsUnifiedDlg.cpp:2037
 msgid "Edit server list"
 msgstr "Редактировать список серверов"
 
-#: src/PrefsUnifiedDlg.cpp:2029
+#: src/PrefsUnifiedDlg.cpp:2038
 msgid ""
 "Add here URL's to download server.met files.\n"
 "Only one url on each line."
@@ -6078,42 +6078,42 @@ msgstr ""
 "Впишите сюда адреса для получения файлов 'server.met'.\n"
 "Только один URL в одной строчке."
 
-#: src/PrefsUnifiedDlg.cpp:2084
+#: src/PrefsUnifiedDlg.cpp:2093
 msgid "IP2Country update failed"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2229 src/PrefsUnifiedDlg.cpp:2260
+#: src/PrefsUnifiedDlg.cpp:2238 src/PrefsUnifiedDlg.cpp:2269
 msgid "Data by MaxMind GeoLite2"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2231 src/PrefsUnifiedDlg.cpp:2262
+#: src/PrefsUnifiedDlg.cpp:2240 src/PrefsUnifiedDlg.cpp:2271
 #, fuzzy
 msgid "Custom source"
 msgstr "Полных источников"
 
-#: src/PrefsUnifiedDlg.cpp:2233 src/PrefsUnifiedDlg.cpp:2264
+#: src/PrefsUnifiedDlg.cpp:2242 src/PrefsUnifiedDlg.cpp:2273
 msgid "Data by DB-IP.com"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2284
+#: src/PrefsUnifiedDlg.cpp:2293
 #, fuzzy, c-format
 msgid "Status: Loaded%s"
 msgstr "Статус:"
 
-#: src/PrefsUnifiedDlg.cpp:2286
+#: src/PrefsUnifiedDlg.cpp:2295
 #, fuzzy, c-format
 msgid "Status: Loaded%s - %s"
 msgstr "Статус:"
 
-#: src/PrefsUnifiedDlg.cpp:2290
+#: src/PrefsUnifiedDlg.cpp:2299
 msgid "Status: Failed to load - click 'Update now' to refresh."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2292
+#: src/PrefsUnifiedDlg.cpp:2301
 msgid "Status: Not found - click 'Update now' to download."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2350 src/PrefsUnifiedDlg.cpp:2374
+#: src/PrefsUnifiedDlg.cpp:2359 src/PrefsUnifiedDlg.cpp:2383
 #, c-format
 msgid "Update delay: %d second"
 msgid_plural "Update delay: %d seconds"
@@ -6121,7 +6121,7 @@ msgstr[0] "Интервал обновления: %d с"
 msgstr[1] "Интервал обновления: %d сек"
 msgstr[2] "Интервал обновления: %d сек"
 
-#: src/PrefsUnifiedDlg.cpp:2358
+#: src/PrefsUnifiedDlg.cpp:2367
 #, c-format
 msgid "Time for average graph: %d minute"
 msgid_plural "Time for average graph: %d minutes"
@@ -6129,12 +6129,12 @@ msgstr[0] "Отрезок времени, охватывающийся граф�
 msgstr[1] "Отрезок времени, охватывающийся графиком: %d минут"
 msgstr[2] "Отрезок времени, охватывающийся графиком: %d минут"
 
-#: src/PrefsUnifiedDlg.cpp:2367
+#: src/PrefsUnifiedDlg.cpp:2376
 #, c-format
 msgid "Connections Graph Scale: %d"
 msgstr "Масштаб графика соединений: %d"
 
-#: src/PrefsUnifiedDlg.cpp:2382
+#: src/PrefsUnifiedDlg.cpp:2391
 #, c-format
 msgid "File Buffer Size: %d byte"
 msgid_plural "File Buffer Size: %d bytes"
@@ -6142,7 +6142,7 @@ msgstr[0] "Файловый буфер: %d Б"
 msgstr[1] "Размер буфера: %d байт"
 msgstr[2] "Размер буфера: %d байт"
 
-#: src/PrefsUnifiedDlg.cpp:2392
+#: src/PrefsUnifiedDlg.cpp:2401
 #, c-format
 msgid "Upload Queue Size: %d client"
 msgid_plural "Upload Queue Size: %d clients"
@@ -6150,7 +6150,7 @@ msgstr[0] "Размер очереди отдачи: %d"
 msgstr[1] "Размер очереди отдачи: %d клиентов"
 msgstr[2] "Размер очереди отдачи: %d клиентов"
 
-#: src/PrefsUnifiedDlg.cpp:2402
+#: src/PrefsUnifiedDlg.cpp:2411
 #, c-format
 msgid "Server connection refresh interval: %d minute"
 msgid_plural "Server connection refresh interval: %d minutes"
@@ -6158,80 +6158,80 @@ msgstr[0] "Частота связи с сервером: %d м"
 msgstr[1] "Интервал обновления соединения с сервером: %d минут"
 msgstr[2] "Интервал обновления соединения с сервером: %d минут"
 
-#: src/PrefsUnifiedDlg.cpp:2407
+#: src/PrefsUnifiedDlg.cpp:2416
 msgid "Server connection refresh interval: Disabled"
 msgstr "Обновление соединения с сервером: Отключено"
 
-#: src/PrefsUnifiedDlg.cpp:2451
+#: src/PrefsUnifiedDlg.cpp:2460
 msgid "disabled"
 msgstr "выключена"
 
-#: src/PrefsUnifiedDlg.cpp:2477
+#: src/PrefsUnifiedDlg.cpp:2486
 #, c-format
 msgid "Execute command on '%s' event"
 msgstr "Выполнить команду при событии '%s'"
 
-#: src/PrefsUnifiedDlg.cpp:2484
+#: src/PrefsUnifiedDlg.cpp:2493
 msgid "Enable command execution on core"
 msgstr "Включить выполнение команд в ядре"
 
-#: src/PrefsUnifiedDlg.cpp:2496
+#: src/PrefsUnifiedDlg.cpp:2505
 msgid "Core command:"
 msgstr "Команда ядра:"
 
 # никто ни в жизни не поймет переведенную аббревиатуру
-#: src/PrefsUnifiedDlg.cpp:2512
+#: src/PrefsUnifiedDlg.cpp:2521
 msgid "Enable command execution on GUI"
 msgstr "Включить выполнение команд в GUI"
 
-#: src/PrefsUnifiedDlg.cpp:2524
+#: src/PrefsUnifiedDlg.cpp:2533
 msgid "GUI command:"
 msgstr "Команда GUI:"
 
-#: src/PrefsUnifiedDlg.cpp:2540
+#: src/PrefsUnifiedDlg.cpp:2549
 msgid "The following variables will be replaced:"
 msgstr "Следующие переменные будут заменены:"
 
-#: src/PrefsUnifiedDlg.cpp:2708
+#: src/PrefsUnifiedDlg.cpp:2717
 msgid ""
 "The following folders look like system or sensitive locations:\n"
 "\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2713
+#: src/PrefsUnifiedDlg.cpp:2722
 msgid "Sharing them recursively will publish every file underneath on the eD2k/Kad networks. Do you really want to do this?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2716
+#: src/PrefsUnifiedDlg.cpp:2725
 #, fuzzy
 msgid "Confirm shared folders"
 msgstr "Публикуемые папки"
 
-#: src/PrefsUnifiedDlg.cpp:2744
+#: src/PrefsUnifiedDlg.cpp:2753
 #, fuzzy
 msgid "Reloading shared files..."
 msgstr "Обновить список публикуемых файлов"
 
-#: src/PrefsUnifiedDlg.cpp:2745
+#: src/PrefsUnifiedDlg.cpp:2754
 msgid "Scanning for subdirectories..."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2746
+#: src/PrefsUnifiedDlg.cpp:2755
 #, fuzzy
 msgid "Updating shared folders"
 msgstr "Публикуемые папки"
 
-#: src/PrefsUnifiedDlg.cpp:2773
+#: src/PrefsUnifiedDlg.cpp:2782
 #, c-format
 msgid "Scanned %u directories..."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2823
+#: src/PrefsUnifiedDlg.cpp:2832
 #, fuzzy, c-format
 msgid "Reloading shared files: %u files scanned"
 msgstr "Обновить список публикуемых файлов."
 
-#: src/PrefsUnifiedDlg.cpp:2873
+#: src/PrefsUnifiedDlg.cpp:2882
 #, fuzzy
 msgid "Shared folder"
 msgstr "Публикуемые папки"
@@ -7930,12 +7930,12 @@ msgstr "Удалить категорию"
 msgid "Hashset requested for unknown file: %s"
 msgstr "Запрошен набор хешей для неизвестного файла: %s"
 
-#: src/UploadQueue.cpp:618
+#: src/UploadQueue.cpp:627
 #, c-format
 msgid "Resuming uploads of file: %s"
 msgstr "Возобновляется отдача файла: %s"
 
-#: src/UploadQueue.cpp:634
+#: src/UploadQueue.cpp:643
 #, c-format
 msgid "Suspending upload of file: %s"
 msgstr "Приостанавливается отдача файла: %s"

--- a/po/ru.po
+++ b/po/ru.po
@@ -14,8 +14,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-28 12:12+0200\n"
-"PO-Revision-Date: 2026-07-27 10:33+0000\n"
+"POT-Creation-Date: 2026-07-28 08:06+0200\n"
+"PO-Revision-Date: 2026-07-27 11:45+0000\n"
 "Last-Translator: Radist Morse <radist.morse@gmail.com>\n"
 "Language-Team: Russian <kde-russian@lists.kde.ru>\n"
 "Language: ru\n"
@@ -151,7 +151,7 @@ msgstr ""
 msgid "Not now"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:422 src/amuleDlg.cpp:665
+#: src/AppImageIntegration.cpp:422 src/amuleDlg.cpp:600
 msgid "Don't ask again"
 msgstr ""
 
@@ -209,83 +209,83 @@ msgstr "Не удалось открыть файл ED2KLinks."
 msgid "WARNING: You can't add yourself as a source for an eD2k link while having a lowid."
 msgstr "ПРЕДУПРЕЖДЕНИЕ: Вы не можете добавить себя в качестве источника для eD2k ссылки если у вас lowid."
 
-#: src/amule.cpp:301
+#: src/amule.cpp:300
 msgid "Now, exiting main app..."
 msgstr "Выходим из основного приложения..."
 
-#: src/amule.cpp:331
+#: src/amule.cpp:330
 #, c-format
 msgid "Terminating amuleweb instance with pid '%d' ... "
 msgstr "Завершаем процесс amuleweb с pid `%d' ... "
 
-#: src/amule.cpp:335
+#: src/amule.cpp:334
 #, c-format
 msgid "Killing amuleweb instance with pid '%d' ... "
 msgstr "Убиваем процесс amuleweb с pid `%d' ... "
 
-#: src/amule.cpp:337 src/amule.cpp:350 src/ClientRef.cpp:180
-#: src/SearchDlg.cpp:1041 src/ServerListCtrl.cpp:98
+#: src/amule.cpp:336 src/amule.cpp:349 src/ClientRef.cpp:180
+#: src/SearchDlg.cpp:880 src/ServerListCtrl.cpp:98
 msgid "Failed"
 msgstr "Неудачно"
 
-#: src/amule.cpp:344
+#: src/amule.cpp:343
 #, fuzzy, c-format
 msgid "Terminating amuleapi instance with pid '%d' ... "
 msgstr "Завершаем процесс amuleweb с pid `%d' ... "
 
-#: src/amule.cpp:348
+#: src/amule.cpp:347
 #, fuzzy, c-format
 msgid "Killing amuleapi instance with pid '%d' ... "
 msgstr "Убиваем процесс amuleweb с pid `%d' ... "
 
-#: src/amule.cpp:356
+#: src/amule.cpp:355
 msgid "aMule OnExit: Terminating core."
 msgstr "aMule OnExit: Прекращаем работу ядра."
 
-#: src/amule.cpp:467
+#: src/amule.cpp:466
 msgid "aMule shutdown completed."
 msgstr "выключение aMule завершено."
 
-#: src/amule.cpp:471
+#: src/amule.cpp:470
 msgid "Memory debug results for aMule exit:"
 msgstr "Результаты дебага памяти при выходе из aMule:"
 
-#: src/amule.cpp:652
+#: src/amule.cpp:651
 #, c-format
 msgid "Binding aMule's peer-to-peer traffic to interface: %s (HTTP updates use the default route)"
 msgstr ""
 
-#: src/amule.cpp:656
+#: src/amule.cpp:655
 #, c-format
 msgid "Binding all network traffic to interface: %s"
 msgstr ""
 
-#: src/amule.cpp:660
+#: src/amule.cpp:659
 #, c-format
 msgid "WARNING: configured network interface '%s' was not found - traffic is NOT bound to it and may leave via the default route. Check the interface name in Preferences."
 msgstr ""
 
-#: src/amule.cpp:666
+#: src/amule.cpp:665
 #, c-format
 msgid "WARNING: binding to network interface '%s' requires elevated privileges and was NOT applied - traffic may leave via the default route. Grant the capability (e.g. 'sudo setcap cap_net_raw+ep' on the aMule binary) or run with sufficient privileges."
 msgstr ""
 
-#: src/amule.cpp:674
+#: src/amule.cpp:673
 #, c-format
 msgid "WARNING: could not bind to network interface '%s' - traffic may leave via the default route."
 msgstr ""
 
-#: src/amule.cpp:733
+#: src/amule.cpp:732
 msgid "Your locale has been changed to System Default due to a configuration change. Sorry."
 msgstr "В связи со сменой версии, значение вашей локали было изменено на значение по умолчанию. Извините."
 
-#: src/amule.cpp:735 src/amule.cpp:1589 src/CatDialog.cpp:128
+#: src/amule.cpp:734 src/amule.cpp:1581 src/CatDialog.cpp:128
 #: src/CatDialog.cpp:136 src/CatDialog.cpp:149 src/ServerList.cpp:366
 #: src/ServerListCtrl.cpp:152
 msgid "Info"
 msgstr "Сведения"
 
-#: src/amule.cpp:742
+#: src/amule.cpp:741
 msgid ""
 "\n"
 "EC configuration"
@@ -293,74 +293,74 @@ msgstr ""
 "\n"
 "EC конфигурация"
 
-#: src/amule.cpp:745
+#: src/amule.cpp:744
 msgid "Password set and external connections enabled."
 msgstr "Пароль задан и внешние соединения разрешены."
 
-#: src/amule.cpp:755 src/KadDlg.cpp:176 src/KadDlg.cpp:185
-#: src/PrefsUnifiedDlg.cpp:1461 src/SharedFilesCtrl.cpp:476
+#: src/amule.cpp:754 src/KadDlg.cpp:176 src/KadDlg.cpp:185
+#: src/PrefsUnifiedDlg.cpp:1387 src/SharedFilesCtrl.cpp:476
 msgid "WARNING"
 msgstr "ПРЕДУПРЕЖДЕНИЕ"
 
-#: src/amule.cpp:992
+#: src/amule.cpp:991
 #, fuzzy
 msgid "Network bootstrap"
 msgstr "Сети"
 
-#: src/amule.cpp:997
+#: src/amule.cpp:996
 msgid ""
 "aMule has detected missing network bootstrap files.\n"
 "Select which ones to download:"
 msgstr ""
 
-#: src/amule.cpp:1006 src/FirstRunWizard.cpp:411
+#: src/amule.cpp:1005 src/FirstRunWizard.cpp:411
 #, fuzzy
 msgid "eD2k server list (server.met)"
 msgstr "В файле 'server.met' найден %i сервер"
 
-#: src/amule.cpp:1013 src/FirstRunWizard.cpp:416
+#: src/amule.cpp:1012 src/FirstRunWizard.cpp:416
 msgid "Kad bootstrap nodes (nodes.dat)"
 msgstr ""
 
-#: src/amule.cpp:1103
+#: src/amule.cpp:1102
 #, c-format
 msgid "web server running on pid %d"
 msgstr "веб-сервер работает с pid %d"
 
-#: src/amule.cpp:1116
+#: src/amule.cpp:1115
 #, fuzzy
 msgid "You requested to run web server on startup, but the amuleweb binary cannot be run. Please install the package containing aMule web server, or build aMule from source with -DBUILD_WEBSERVER=YES and install it."
 msgstr "Вы хотите запускать веб-сервер при загрузке, но исполняемый файл amuleweb не может быть запущен. Установите пакет содержащий веб-сервер aMule или скомпилируйте его с опцией --enable-webserver и запустите make install"
 
-#: src/amule.cpp:1121 src/amule.cpp:1185 src/amule.cpp:1299 src/amule.cpp:1601
+#: src/amule.cpp:1120 src/amule.cpp:1177 src/amule.cpp:1291 src/amule.cpp:1593
 #: src/amule-remote-gui.cpp:603 src/amule-remote-gui.cpp:671
 #: src/amule-remote-gui.cpp:709 src/amule-remote-gui.cpp:1282
 #: src/amule-remote-gui.cpp:1345 src/amule-remote-gui.cpp:1372
-#: src/DownloadQueue.cpp:1481 src/PrefsUnifiedDlg.cpp:1247
+#: src/DownloadQueue.cpp:1481
 msgid "ERROR"
 msgstr "ОШИБКА"
 
-#: src/amule.cpp:1174
+#: src/amule.cpp:1166
 #, fuzzy, c-format
 msgid "amuleapi running on pid %d"
 msgstr "веб-сервер работает с pid %d"
 
-#: src/amule.cpp:1180
+#: src/amule.cpp:1172
 #, fuzzy
 msgid "You requested to run amuleapi on startup, but the amuleapi binary cannot be run. Please install the package containing aMule's REST API server, or build aMule from source with -DBUILD_AMULEAPI=YES and install it."
 msgstr "Вы хотите запускать веб-сервер при загрузке, но исполняемый файл amuleweb не может быть запущен. Установите пакет содержащий веб-сервер aMule или скомпилируйте его с опцией --enable-webserver и запустите make install"
 
-#: src/amule.cpp:1267
+#: src/amule.cpp:1259
 #, c-format
 msgid "Could not bind ports to the specified address: %s"
 msgstr "Невозможно связать порты с указанными адресами: %s"
 
-#: src/amule.cpp:1291
+#: src/amule.cpp:1283
 #, c-format
 msgid "Port %u is not available. You will be LOWID\n"
 msgstr "Порт %u не доступен. У вас будет LowID\n"
 
-#: src/amule.cpp:1296
+#: src/amule.cpp:1288
 #, c-format
 msgid ""
 "Port %u is not available!\n"
@@ -375,48 +375,48 @@ msgstr ""
 "\n"
 "Проверьте вашу сетевую конфигурацию, убедитесь что необходимый порт открыт."
 
-#: src/amule.cpp:1393
+#: src/amule.cpp:1385
 msgid "Failed to create OnlineSig File"
 msgstr "Не удалось создать aMule OnlineSig файл"
 
-#: src/amule.cpp:1401
+#: src/amule.cpp:1393
 msgid "Failed to create aMule OnlineSig File"
 msgstr "Не удалось создать aMule OnlineSig файл"
 
-#: src/amule.cpp:1564
+#: src/amule.cpp:1556
 msgid "The selected locale seems not to be installed on your box. (Note: I'll try to set it anyway)"
 msgstr "Выбранная локаль отсутствует в вашей системе (тем не менее, будет произведена попытка ее использовать)."
 
-#: src/amule.cpp:1574
+#: src/amule.cpp:1566
 #, c-format
 msgid "This is the first time you run aMule %s"
 msgstr "Это первый запуск aMule %s"
 
-#: src/amule.cpp:1577
+#: src/amule.cpp:1569
 msgid "This version is a testing version, updated daily, and\n"
 msgstr "Эта версия является тестовой и обновляется ежедневно.\n"
 
-#: src/amule.cpp:1578
+#: src/amule.cpp:1570
 msgid "we give no warranty it won't break anything, burn your house,\n"
 msgstr "мы не предоставляем никаких гарантий на случай каких либо повреждений, пожара \n"
 
-#: src/amule.cpp:1579
+#: src/amule.cpp:1571
 msgid "or kill your dog. But it *should* be safe to use anyway.\n"
 msgstr "или же смерти вашей любимой собачки. И все же использование ее *должно* быть безопасным. \n"
 
-#: src/amule.cpp:1584
+#: src/amule.cpp:1576
 msgid "More information, support and new releases can found at our homepage,\n"
 msgstr "Дополнительную информацию, поддержку и обновленные версии вы найдете на нашем сайте \n"
 
-#: src/amule.cpp:1585
+#: src/amule.cpp:1577
 msgid "at https://amule-org.github.io, or in our IRC channel #aMule at irc.libera.chat.\n"
 msgstr "https://amule-org.github.io, или на нашем irc-канале #aMule, находящемся на сервере irc.libera.chat. \n"
 
-#: src/amule.cpp:1587
+#: src/amule.cpp:1579
 msgid "Feel free to report any bugs to https://github.com/amule-org/amule/issues"
 msgstr "Сообщайте нам о найденных ошибках на форум https://github.com/amule-org/amule/issues"
 
-#: src/amule.cpp:1599
+#: src/amule.cpp:1591
 msgid ""
 "The folder for Online Signature files you specified is INVALID!\n"
 " OnlineSignature will be DISABLED until you fix it on preferences."
@@ -424,141 +424,141 @@ msgstr ""
 "Указан неверный каталог для файлов Online-подписей!\n"
 "Online-подписи будут отключены пока вы не исправите это в настройках."
 
-#: src/amule.cpp:1662
+#: src/amule.cpp:1654
 msgid "Server hostname notified"
 msgstr "Имя сервера подтверждено"
 
-#: src/amule.cpp:2039
+#: src/amule.cpp:2031
 #, c-format
 msgid "Disk space preallocation for file '%s' failed: %s"
 msgstr "Выделение место под файл '%s' не удалось: %s"
 
-#: src/amule.cpp:2168
+#: src/amule.cpp:2160
 msgid "ERROR: can't open logfile"
 msgstr "Ошибка: невозможно открыть файл журнала"
 
-#: src/amule.cpp:2172
+#: src/amule.cpp:2164
 msgid "WARNING: logfile is empty. Something is wrong."
 msgstr "ПРЕДУПРЕЖДЕНИЕ: файл журнала пуст. Что-то здесь не так :-("
 
-#: src/amule.cpp:2189
+#: src/amule.cpp:2181
 msgid "Log has been reset"
 msgstr "Журнал был очищен"
 
-#: src/amule.cpp:2213
+#: src/amule.cpp:2205
 #, c-format
 msgid "ServerMessage: %s"
 msgstr "Сообщение сервера: %s"
 
-#: src/amule.cpp:2256 src/IP2Country.cpp:220 src/IPFilter.cpp:514
+#: src/amule.cpp:2248 src/IP2Country.cpp:220 src/IPFilter.cpp:514
 #: src/ServerList.cpp:875
 #, c-format
 msgid "Skipped download of %s, because requested file is not newer."
 msgstr "Пропущена загрузка %s, так как запрашиваемый файл не новее."
 
-#: src/amule.cpp:2259
+#: src/amule.cpp:2251
 msgid "Failed to download the nodes list."
 msgstr "Ошибка при загрузке списка узлов."
 
-#: src/amule.cpp:2322
+#: src/amule.cpp:2314
 msgid "Failed to open the downloaded version check file"
 msgstr "Ошибка при загрузке файла контроля версии"
 
-#: src/amule.cpp:2325 src/amule.cpp:2344
+#: src/amule.cpp:2317 src/amule.cpp:2336
 msgid "Corrupted version check file"
 msgstr "Поврежден файл контроля версии"
 
-#: src/amule.cpp:2367
+#: src/amule.cpp:2359
 msgid "You are using an outdated version of aMule!"
 msgstr "Вы используете устаревшую версию aMule!"
 
-#: src/amule.cpp:2369
+#: src/amule.cpp:2361
 #, c-format
 msgid "Your aMule version is %i.%i.%i and the latest version is %li.%li.%li"
 msgstr "Версия вашего aMule - %i.%i.%i, тогда как актуальная версия - %li.%li.%li"
 
-#: src/amule.cpp:2373
+#: src/amule.cpp:2365
 msgid "The latest version can always be found at https://github.com/amule-org/amule/releases/latest"
 msgstr "Актуальная версия aMule всегда доступна тут:  https://github.com/amule-org/amule/releases/latest"
 
-#: src/amule.cpp:2376
+#: src/amule.cpp:2368
 #, c-format
 msgid "WARNING: Your aMuled version is outdated: %i.%i.%i < %li.%li.%li"
 msgstr "ВНИМАНИЕ: Версия вашего aMule устарела: %i.%i.%i < %li.%li.%li"
 
-#: src/amule.cpp:2382
+#: src/amule.cpp:2374
 msgid "Your copy of aMule is up to date."
 msgstr "Ваша копия aMule актуальна."
 
-#: src/amule.cpp:2389
+#: src/amule.cpp:2381
 msgid "Failed to download the version check file"
 msgstr "Ошибка при загрузке файла контроля версии"
 
-#: src/amule.cpp:2558 src/amule-remote-gui.cpp:1133
+#: src/amule.cpp:2550 src/amule-remote-gui.cpp:1133
 #, c-format
 msgid "Users: %s | Files: %s"
 msgstr "Польз.: %s | Файлов: %s"
 
-#: src/amule.cpp:2559 src/amule-remote-gui.cpp:1134
+#: src/amule.cpp:2551 src/amule-remote-gui.cpp:1134
 #, c-format
 msgid "Users: E: %s K: %s | Files: E: %s K: %s"
 msgstr "Польз.: E: %s K: %s | Файлов: E: %s K: %s"
 
-#: src/amule.cpp:2573 src/amule-remote-gui.cpp:1147
+#: src/amule.cpp:2565 src/amule-remote-gui.cpp:1147
 msgid "No networks selected"
 msgstr "Нет выделенной сети"
 
-#: src/amule.cpp:2641 src/TextClient.cpp:903
+#: src/amule.cpp:2633 src/TextClient.cpp:903
 msgid "with LowID"
 msgstr "LowID"
 
-#: src/amule.cpp:2641 src/TextClient.cpp:904
+#: src/amule.cpp:2633 src/TextClient.cpp:904
 msgid "with HighID"
 msgstr "HighID"
 
-#: src/amule.cpp:2643
+#: src/amule.cpp:2635
 #, c-format
 msgid "Connected to %s %s"
 msgstr "Соединен с %s %s"
 
-#: src/amule.cpp:2648
+#: src/amule.cpp:2640
 #, c-format
 msgid "Connecting to %s"
 msgstr "Подключение к %s"
 
-#: src/amule.cpp:2650
+#: src/amule.cpp:2642
 msgid "Disconnected from eD2k"
 msgstr "Отсоединен от eD2k"
 
 # Kad как сеть, или служба - поэтому в женском роде
 # да, согласен
-#: src/amule.cpp:2659
+#: src/amule.cpp:2651
 msgid "Kad started."
 msgstr "Kad запущена."
 
 # Kad как сеть, или служба - поэтому в женском роде
 # согласен
-#: src/amule.cpp:2661
+#: src/amule.cpp:2653
 msgid "Kad stopped."
 msgstr "Kad остановлена."
 
-#: src/amule.cpp:2669
+#: src/amule.cpp:2661
 msgid "Connected to Kad (ok)"
 msgstr "Подключен к Kad (норм.)"
 
-#: src/amule.cpp:2671
+#: src/amule.cpp:2663
 msgid "Connected to Kad (firewalled)"
 msgstr "Подключен к Kad (за брандмауэром)"
 
-#: src/amule.cpp:2675
+#: src/amule.cpp:2667
 msgid "Disconnected from Kad"
 msgstr "Отключился от Kad"
 
-#: src/amule.cpp:2707
+#: src/amule.cpp:2699
 msgid "Kad network cannot be used if UDP port is disabled on preferences, not starting."
 msgstr "Сеть Kad не может быть использована если порт UDP выключен в настройках. Отменяю запуск."
 
-#: src/amule.cpp:2711
+#: src/amule.cpp:2703
 msgid "Kad network disabled on preferences, not connecting."
 msgstr "Сеть Kad выключена в настройках. Отменяю соединение."
 
@@ -584,68 +584,30 @@ msgstr "Не удалось создать pid-файл"
 msgid "ERROR: %s"
 msgstr "Ошибка: %s"
 
-#: src/amuleDlg.cpp:250
+#: src/amuleDlg.cpp:236
 #, c-format
 msgid "This is aMule %s based on eMule."
 msgstr "aMule %s (основан на eMule)."
 
-#: src/amuleDlg.cpp:251
+#: src/amuleDlg.cpp:237
 #, c-format
 msgid "Running on %s"
 msgstr "Работает на %s"
 
-#: src/amuleDlg.cpp:253
+#: src/amuleDlg.cpp:239
 msgid "Visit https://github.com/amule-org/amule/releases/latest to check if a new version is available."
 msgstr "Посетите https://github.com/amule-org/amule/releases/latest для проверки наличия новой версии."
 
-#: src/amuleDlg.cpp:282
+#: src/amuleDlg.cpp:268
 msgid "FATAL ERROR: Failed to create Timer"
 msgstr "ФАТАЛЬНАЯ ОШИБКА: не удалось создать таймер"
 
-#: src/amuleDlg.cpp:361 src/amuleDlg.cpp:1810 src/amuleDlg.cpp:2056
-#: src/muuli_wdr.cpp:1492 src/muuli_wdr.cpp:3439
-msgid "Networks"
-msgstr "Сети"
-
-#: src/amuleDlg.cpp:362 src/amuleDlg.cpp:1816 src/muuli_wdr.cpp:3440
-msgid "Searches"
-msgstr "Поиск"
-
-#: src/amuleDlg.cpp:363 src/amuleDlg.cpp:1822 src/DownloadListCtrl.cpp:740
-#: src/muuli_wdr.cpp:392 src/muuli_wdr.cpp:1585 src/muuli_wdr.cpp:3441
-#: src/Statistics.cpp:829
-msgid "Downloads"
-msgstr "Загрузки"
-
-#: src/amuleDlg.cpp:364 src/amuleDlg.cpp:1828 src/muuli_wdr.cpp:3315
-msgid "Shared files"
-msgstr "Публикуемые файлы"
-
-#: src/amuleDlg.cpp:365 src/amuleDlg.cpp:1834 src/muuli_wdr.cpp:2947
-#: src/muuli_wdr.cpp:3397 src/muuli_wdr.cpp:3444
-msgid "Messages"
-msgstr "Сообщения"
-
-#: src/amuleDlg.cpp:366 src/amuleDlg.cpp:1840 src/muuli_wdr.cpp:3445
-#: src/PrefsUnifiedDlg.cpp:314 src/Statistics.cpp:779 src/Statistics.cpp:1235
-msgid "Statistics"
-msgstr "Статистика"
-
-#: src/amuleDlg.cpp:368 src/amuleDlg.cpp:1847 src/muuli_wdr.cpp:3447
-#: src/PrefsUnifiedDlg.cpp:330 src/utils/wxCas/src/wxcasprefs.cpp:39
-msgid "Preferences"
-msgstr "Настройки"
-
-#: src/amuleDlg.cpp:371
-msgid "Navigate"
-msgstr ""
-
-#: src/amuleDlg.cpp:657
+#: src/amuleDlg.cpp:592
 #, fuzzy
 msgid "New version available"
 msgstr "Недоступен"
 
-#: src/amuleDlg.cpp:661
+#: src/amuleDlg.cpp:596
 #, fuzzy, c-format
 msgid ""
 "A new version of aMule (%s) is available.\n"
@@ -655,185 +617,218 @@ msgid ""
 "Would you like to open the download page?"
 msgstr "Актуальная версия aMule всегда доступна тут:  https://github.com/amule-org/amule/releases/latest"
 
-#: src/amuleDlg.cpp:743
+#: src/amuleDlg.cpp:678
 msgid "aMule dialog destroyed"
 msgstr "диалоговое окно aMule уничтожено"
 
-#: src/amuleDlg.cpp:766 src/DataToText.cpp:68 src/IPFilter.cpp:547
+#: src/amuleDlg.cpp:701 src/DataToText.cpp:68 src/IPFilter.cpp:547
 msgid "Connecting"
 msgstr "Идет подключение"
 
-#: src/amuleDlg.cpp:958
+#: src/amuleDlg.cpp:893
 msgid "eD2k: Connecting"
 msgstr "eD2k: Соединение"
 
-#: src/amuleDlg.cpp:962
+#: src/amuleDlg.cpp:897
 msgid "eD2k: Disconnected"
 msgstr "eD2k: не соединено"
 
-#: src/amuleDlg.cpp:968
+#: src/amuleDlg.cpp:903
 msgid "Kad: Firewalled"
 msgstr "Kad: За брандмауэром"
 
-#: src/amuleDlg.cpp:972
+#: src/amuleDlg.cpp:907
 msgid "Kad: Connected"
 msgstr "Kad: Подключена"
 
-#: src/amuleDlg.cpp:977
+#: src/amuleDlg.cpp:912
 msgid "Kad: Connecting"
 msgstr "Kad: Идет подключение"
 
-#: src/amuleDlg.cpp:981
+#: src/amuleDlg.cpp:916
 msgid "Kad: Off"
 msgstr " Kad: Выключено"
 
-#: src/amuleDlg.cpp:1029 src/DownloadListCtrl.cpp:505
+#: src/amuleDlg.cpp:964 src/DownloadListCtrl.cpp:505
 #: src/DownloadListCtrl.cpp:749 src/FriendListCtrl.cpp:180
 #: src/muuli_wdr.cpp:731 src/muuli_wdr.cpp:782 src/muuli_wdr.cpp:846
-#: src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2252 src/muuli_wdr.cpp:2337
-#: src/muuli_wdr.cpp:3085 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
+#: src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2224 src/muuli_wdr.cpp:2309
+#: src/muuli_wdr.cpp:3057 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
 #: src/ServerListCtrl.cpp:606 src/TransferWnd.cpp:378
 #: src/utils/wxCas/src/wxcasprefs.cpp:235
 msgid "Cancel"
 msgstr "Отменить"
 
-#: src/amuleDlg.cpp:1030
+#: src/amuleDlg.cpp:965
 msgid "Stop the current connection attempts"
 msgstr "Прекратить попытки соединения"
 
-#: src/amuleDlg.cpp:1035 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976
-#: src/muuli_wdr.cpp:2475
+#: src/amuleDlg.cpp:970 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976
+#: src/muuli_wdr.cpp:2447
 msgid "Disconnect"
 msgstr "Отключиться"
 
-#: src/amuleDlg.cpp:1036
+#: src/amuleDlg.cpp:971
 msgid "Disconnect from the currently connected networks"
 msgstr "Отключиться от работающих сетей"
 
-#: src/amuleDlg.cpp:1041 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979
-#: src/muuli_wdr.cpp:2630 src/muuli_wdr.cpp:3082 src/muuli_wdr.cpp:3437
+#: src/amuleDlg.cpp:976 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979
+#: src/muuli_wdr.cpp:2602 src/muuli_wdr.cpp:3054 src/muuli_wdr.cpp:3409
 msgid "Connect"
 msgstr "Подключиться"
 
-#: src/amuleDlg.cpp:1042
+#: src/amuleDlg.cpp:977
 msgid "Connect to the currently enabled networks"
 msgstr "Подключиться к разрешенным сетям"
 
-#: src/amuleDlg.cpp:1154
+#: src/amuleDlg.cpp:1089
 #, fuzzy, c-format
 msgid "Up: %.1f%s (%.1f) | Down: %.1f%s (%.1f)"
 msgstr "Передача: %.1f(%.1f) | Прием: %.1f(%.1f)"
 
-#: src/amuleDlg.cpp:1156 src/amuleDlg.cpp:1158 src/amuleDlg.cpp:1162
-#: src/amuleDlg.cpp:1164 src/amuleDlg.cpp:1175 src/amuleDlg.cpp:1177
+#: src/amuleDlg.cpp:1091 src/amuleDlg.cpp:1093 src/amuleDlg.cpp:1097
+#: src/amuleDlg.cpp:1099 src/amuleDlg.cpp:1110 src/amuleDlg.cpp:1112
 #: src/MuleTrayIcon.cpp:796 src/MuleTrayIcon.cpp:799
 #, fuzzy
 msgid " MB/s"
 msgstr "МБ/с"
 
-#: src/amuleDlg.cpp:1156 src/amuleDlg.cpp:1158 src/amuleDlg.cpp:1162
-#: src/amuleDlg.cpp:1164 src/amuleDlg.cpp:1175 src/amuleDlg.cpp:1177
+#: src/amuleDlg.cpp:1091 src/amuleDlg.cpp:1093 src/amuleDlg.cpp:1097
+#: src/amuleDlg.cpp:1099 src/amuleDlg.cpp:1110 src/amuleDlg.cpp:1112
 #: src/MuleTrayIcon.cpp:796 src/MuleTrayIcon.cpp:799
 #: src/utils/wxCas/src/wxcasframe.cpp:1041
 msgid " kB/s"
 msgstr "kB/сек"
 
-#: src/amuleDlg.cpp:1161
+#: src/amuleDlg.cpp:1096
 #, fuzzy, c-format
 msgid "Up: %.1f%s | Down: %.1f%s"
 msgstr "Передача: %.1f | Прием: %.1f"
 
-#: src/amuleDlg.cpp:1193
+#: src/amuleDlg.cpp:1128
 #, c-format
 msgid "aMule (%s | Connected)"
 msgstr "aMule (%s | Подключен)"
 
-#: src/amuleDlg.cpp:1195
+#: src/amuleDlg.cpp:1130
 #, c-format
 msgid "aMule (%s | Disconnected)"
 msgstr "aMule (%s | Отключен)"
 
-#: src/amuleDlg.cpp:1248
+#: src/amuleDlg.cpp:1183
 #, c-format
 msgid "Do you really want to exit %s?"
 msgstr "Вы действительно хотите выйти из %s?"
 
-#: src/amuleDlg.cpp:1250
+#: src/amuleDlg.cpp:1185
 msgid "Exit confirmation"
 msgstr "Подтверждение выхода"
 
-#: src/amuleDlg.cpp:1613
+#: src/amuleDlg.cpp:1548
 msgid "Launch Command: "
 msgstr "Команда запуска:"
 
-#: src/amuleDlg.cpp:1632 src/muuli_wdr.cpp:1972 src/Preferences.cpp:979
+#: src/amuleDlg.cpp:1567 src/muuli_wdr.cpp:1971 src/Preferences.cpp:951
 msgid "- default -"
 msgstr "- по умолчанию -"
 
-#: src/amuleDlg.cpp:1660
+#: src/amuleDlg.cpp:1595
 #, c-format
 msgid "Skin directory '%s' does not exist"
 msgstr "Каталог с темами оформления '%s' не существует."
 
-#: src/amuleDlg.cpp:1663
+#: src/amuleDlg.cpp:1598
 #, c-format
 msgid "WARNING: Unable to open skin file '%s' for read"
 msgstr "ПРЕДУПРЕЖДЕНИЕ: невозможно открыть для чтения файл скина '%s'"
 
-#: src/amuleDlg.cpp:1814 src/muuli_wdr.cpp:3439
+#: src/amuleDlg.cpp:1722 src/amuleDlg.cpp:1968 src/muuli_wdr.cpp:1485
+#: src/muuli_wdr.cpp:3411
+msgid "Networks"
+msgstr "Сети"
+
+#: src/amuleDlg.cpp:1726 src/muuli_wdr.cpp:3411
 msgid "Networks Window"
 msgstr "Окно сетей"
 
-#: src/amuleDlg.cpp:1820 src/muuli_wdr.cpp:3440
+#: src/amuleDlg.cpp:1728 src/muuli_wdr.cpp:3412
+msgid "Searches"
+msgstr "Поиск"
+
+#: src/amuleDlg.cpp:1732 src/muuli_wdr.cpp:3412
 msgid "Searches Window"
 msgstr "Окно поиска"
 
-#: src/amuleDlg.cpp:1826 src/muuli_wdr.cpp:3441
+#: src/amuleDlg.cpp:1734 src/DownloadListCtrl.cpp:740 src/muuli_wdr.cpp:392
+#: src/muuli_wdr.cpp:1578 src/muuli_wdr.cpp:3413 src/Statistics.cpp:829
+msgid "Downloads"
+msgstr "Загрузки"
+
+#: src/amuleDlg.cpp:1738 src/muuli_wdr.cpp:3413
 msgid "Downloads Window"
 msgstr "Окно загрузки"
 
-#: src/amuleDlg.cpp:1832 src/muuli_wdr.cpp:3443
+#: src/amuleDlg.cpp:1740 src/muuli_wdr.cpp:3287
+msgid "Shared files"
+msgstr "Публикуемые файлы"
+
+#: src/amuleDlg.cpp:1744 src/muuli_wdr.cpp:3415
 msgid "Shared Files Window"
 msgstr "Окно публикуемых файлов"
 
-#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3444
+#: src/amuleDlg.cpp:1746 src/muuli_wdr.cpp:2919 src/muuli_wdr.cpp:3369
+#: src/muuli_wdr.cpp:3416
+msgid "Messages"
+msgstr "Сообщения"
+
+#: src/amuleDlg.cpp:1750 src/muuli_wdr.cpp:3416
 msgid "Messages Window"
 msgstr "Сообщения"
 
-#: src/amuleDlg.cpp:1844 src/muuli_wdr.cpp:3445
+#: src/amuleDlg.cpp:1752 src/muuli_wdr.cpp:3417 src/PrefsUnifiedDlg.cpp:312
+#: src/Statistics.cpp:779 src/Statistics.cpp:1235
+msgid "Statistics"
+msgstr "Статистика"
+
+#: src/amuleDlg.cpp:1756 src/muuli_wdr.cpp:3417
 msgid "Statistics Graph Window"
 msgstr "Статистика"
 
-#: src/amuleDlg.cpp:1851 src/muuli_wdr.cpp:3447
+#: src/amuleDlg.cpp:1759 src/muuli_wdr.cpp:3419 src/PrefsUnifiedDlg.cpp:328
+#: src/utils/wxCas/src/wxcasprefs.cpp:39
+msgid "Preferences"
+msgstr "Настройки"
+
+#: src/amuleDlg.cpp:1763 src/muuli_wdr.cpp:3419
 msgid "Preferences Settings Window"
 msgstr "Окно настроек клиента"
 
-#: src/amuleDlg.cpp:1854 src/muuli_wdr.cpp:3448
+#: src/amuleDlg.cpp:1766 src/muuli_wdr.cpp:3420
 msgid "Import"
 msgstr "Импорт"
 
-#: src/amuleDlg.cpp:1858 src/muuli_wdr.cpp:3448
+#: src/amuleDlg.cpp:1770 src/muuli_wdr.cpp:3420
 msgid "The partfile importer tool"
 msgstr "Инструмент импортирования частично загруженных файлов (part files)"
 
-#: src/amuleDlg.cpp:1861 src/muuli_wdr.cpp:3449
+#: src/amuleDlg.cpp:1773 src/muuli_wdr.cpp:3421
 #: src/utils/aLinkCreator/src/alcframe.cpp:262
 msgid "About"
 msgstr "О программе"
 
-#: src/amuleDlg.cpp:1861 src/muuli_wdr.cpp:3449
+#: src/amuleDlg.cpp:1773 src/muuli_wdr.cpp:3421
 msgid "About/Help"
 msgstr "О программе/Помощь"
 
-#: src/amuleDlg.cpp:2059
+#: src/amuleDlg.cpp:1971
 msgid "eD2k network"
 msgstr "Сеть eD2k"
 
-#: src/amuleDlg.cpp:2062
+#: src/amuleDlg.cpp:1974
 msgid "Kad network"
 msgstr "Сеть Kad"
 
-#: src/amuleDlg.cpp:2062
+#: src/amuleDlg.cpp:1974
 msgid "No network"
 msgstr "Нет сети"
 
@@ -963,7 +958,7 @@ msgstr "Файл не найден."
 msgid "The core rejected these shared folders:%s"
 msgstr ""
 
-#: src/amule-remote-gui.cpp:1336 src/ExternalConn.cpp:2346
+#: src/amule-remote-gui.cpp:1336 src/ExternalConn.cpp:2345
 msgid "Invalid link or already on list."
 msgstr "Ссылка неверна или уже в списке."
 
@@ -979,7 +974,7 @@ msgstr "Не удается создать директорию '%s' для ка
 #: src/ClientDetailDialog.cpp:123 src/DataToText.cpp:61 src/DataToText.cpp:86
 #: src/DataToText.cpp:101 src/DataToText.cpp:136 src/DataToText.cpp:165
 #: src/DownloadListCtrl.cpp:1172 src/DownloadListCtrl.cpp:1185
-#: src/DownloadListCtrl.cpp:1196 src/ExternalConn.cpp:609
+#: src/DownloadListCtrl.cpp:1196 src/ExternalConn.cpp:608
 #: src/FileDetailDialog.cpp:203 src/FileDetailDialog.cpp:235
 #: src/FileDetailDialog.cpp:242 src/GenericClientListCtrl.cpp:1171
 #: src/GenericClientListCtrl.cpp:1182 src/GenericClientListCtrl.cpp:1192
@@ -1372,19 +1367,19 @@ msgstr "Авто [Выс]"
 msgid "Very low"
 msgstr "Очень низкий"
 
-#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:743 src/muuli_wdr.cpp:2303
+#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:743 src/muuli_wdr.cpp:2275
 #: src/ServerListCtrl.cpp:263 src/ServerListCtrl.cpp:456
 #: src/SharedFilesCtrl.cpp:145
 msgid "Low"
 msgstr "Низкий"
 
-#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:744 src/muuli_wdr.cpp:2304
+#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:744 src/muuli_wdr.cpp:2276
 #: src/ServerListCtrl.cpp:266 src/ServerListCtrl.cpp:457
 #: src/SharedFilesCtrl.cpp:146
 msgid "Normal"
 msgstr "Нормальный"
 
-#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:745 src/muuli_wdr.cpp:2305
+#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:745 src/muuli_wdr.cpp:2277
 #: src/ServerListCtrl.cpp:269 src/ServerListCtrl.cpp:458
 #: src/SharedFilesCtrl.cpp:147
 msgid "High"
@@ -1476,8 +1471,8 @@ msgstr "Локальный сервер"
 msgid "Remote Server"
 msgstr "Удаленный сервер"
 
-#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3202
-#: src/SearchDlg.cpp:119 src/TextClient.cpp:911
+#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3174
+#: src/SearchDlg.cpp:111 src/TextClient.cpp:911
 msgid "Kad"
 msgstr "Kad"
 
@@ -1549,7 +1544,7 @@ msgstr "Часть"
 msgid "Size"
 msgstr "Размер"
 
-#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3269
+#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3241
 msgid "Transferred"
 msgstr "Передано"
 
@@ -1607,7 +1602,7 @@ msgstr ""
 "Ответ от: %s (%s)\n"
 "\n"
 
-#: src/DownloadListCtrl.cpp:746 src/muuli_wdr.cpp:2306
+#: src/DownloadListCtrl.cpp:746 src/muuli_wdr.cpp:2278
 #: src/SharedFilesCtrl.cpp:150
 msgid "Auto"
 msgstr "Авто"
@@ -1645,7 +1640,7 @@ msgid "Extended Options"
 msgstr "Дополнительные настройки"
 
 #: src/DownloadListCtrl.cpp:770 src/DownloadListCtrl.cpp:822
-#: src/muuli_wdr.cpp:1790
+#: src/muuli_wdr.cpp:1789
 msgid "Preview"
 msgstr "Предварительный просмотр"
 
@@ -1823,233 +1818,228 @@ msgstr[2] ""
 msgid "Invalid eD2k link! ERROR: %s"
 msgstr "Неверная eD2k ссылка! ОШИБКА: %s"
 
-#: src/ExternalConn.cpp:380
+#: src/ExternalConn.cpp:379
 msgid "Client sent packet after authentication failed."
 msgstr "Клиент послал пакет после ошибки идентификации."
 
-#: src/ExternalConn.cpp:397
+#: src/ExternalConn.cpp:396
 msgid "External connection closed."
 msgstr "Внешнее соединение закрыто."
 
-#: src/ExternalConn.cpp:474
+#: src/ExternalConn.cpp:473
 msgid "External connections disabled due to empty password!"
 msgstr "Внешние соединения выключены из-за отсутствия пароля."
 
-#: src/ExternalConn.cpp:495
+#: src/ExternalConn.cpp:494
 msgid "External connections disabled in config file"
 msgstr "Внешние соединения выключены в конфигурационном файле"
 
-#: src/ExternalConn.cpp:576
+#: src/ExternalConn.cpp:575
 msgid "New external connection accepted"
 msgstr "Принято новое внешнее соединение"
 
-#: src/ExternalConn.cpp:579
+#: src/ExternalConn.cpp:578
 msgid "ERROR: couldn't accept a new external connection"
 msgstr "ОШИБКА: невозможно принять новое внешнее соединение"
 
-#: src/ExternalConn.cpp:596
+#: src/ExternalConn.cpp:595
 msgid "External connection refused due to empty password in preferences!"
 msgstr "Отказано во внешнем соединении из-за пустого пароля"
 
-#: src/ExternalConn.cpp:608
+#: src/ExternalConn.cpp:607
 #, c-format
 msgid "Connecting client: %s %s"
 msgstr "Соединение с клиентом: %s %s"
 
-#: src/ExternalConn.cpp:610
+#: src/ExternalConn.cpp:609
 msgid "Unknown version"
 msgstr "Неизвестная версия"
 
-#: src/ExternalConn.cpp:623
+#: src/ExternalConn.cpp:622
 msgid "Incorrect EC version ID, there might be binary incompatibility. Use core and remote from same snapshot."
 msgstr "Неверный идентификатор версии ВС. Возможна бинарная несовместимость. Используйте ядро и компонент удаленного доступа одинаковой версии."
 
-#: src/ExternalConn.cpp:631
+#: src/ExternalConn.cpp:630
 msgid "You cannot connect to a release version from an arbitrary development snapshot! *sigh* possible crash prevented"
 msgstr "Вы не можете подсоединиться к релизной версии с произвольной SVN версии! Возможный сбой предотвращен"
 
-#: src/ExternalConn.cpp:714
+#: src/ExternalConn.cpp:713
 msgid "Invalid protocol version."
 msgstr "Недопустимая версия протокола."
 
-#: src/ExternalConn.cpp:720
+#: src/ExternalConn.cpp:719
 msgid "Missing protocol version tag."
 msgstr "Тег версии протокола отсутствует."
 
-#: src/ExternalConn.cpp:728
+#: src/ExternalConn.cpp:727
 msgid "Authentication failed: invalid hash specified as EC password."
 msgstr "Ошибка авторизации: в качестве EC-пароля указан неправильный хэш."
 
-#: src/ExternalConn.cpp:776
+#: src/ExternalConn.cpp:775
 msgid "Authentication failed: wrong password."
 msgstr "Ошибка идентификации: неверный пароль."
 
-#: src/ExternalConn.cpp:778
+#: src/ExternalConn.cpp:777
 msgid "Authentication failed: missing password."
 msgstr "Ошибка идентификации: пароль не задан."
 
-#: src/ExternalConn.cpp:789
+#: src/ExternalConn.cpp:788
 msgid "Invalid request, please authenticate first."
 msgstr "Неверный запрос, сначала пройдите идентификацию."
 
-#: src/ExternalConn.cpp:794
+#: src/ExternalConn.cpp:793
 msgid "Access granted."
 msgstr "Доступ получен."
 
-#: src/ExternalConn.cpp:802
+#: src/ExternalConn.cpp:801
 #, c-format
 msgid "Sent error message \"%s\" to client."
 msgstr "Клиенту отправлено сообщение об ошибке \"%s\"."
 
-#: src/ExternalConn.cpp:807
+#: src/ExternalConn.cpp:806
 #, c-format
 msgid "Unauthorized access attempt from %s. Connection closed."
 msgstr "Попытка неавторизированного доступа с %s. Соединение разорвано."
 
-#: src/ExternalConn.cpp:1420
+#: src/ExternalConn.cpp:1419
 #, c-format
 msgid "Remote PartFile command failed: FileHash not found: %s"
 msgstr "Удаленная команда PartFile не удалась: хеш файла не найден: %s"
 
-#: src/ExternalConn.cpp:1424
+#: src/ExternalConn.cpp:1423
 #, c-format
 msgid "FileHash not found: %s"
 msgstr "Хеш файла не найден: %s"
 
-#: src/ExternalConn.cpp:1471 src/ExternalConn.cpp:1559
-#: src/ExternalConn.cpp:1680
+#: src/ExternalConn.cpp:1470 src/ExternalConn.cpp:1558
+#: src/ExternalConn.cpp:1679
 msgid "OOPS! OpCode processing error!"
 msgstr "Ошибка при выполнении OpCode."
 
-#: src/ExternalConn.cpp:1502
+#: src/ExternalConn.cpp:1501
 msgid "Server not added"
 msgstr "Сервер не добавлен"
 
-#: src/ExternalConn.cpp:1521
+#: src/ExternalConn.cpp:1520
 #, c-format
 msgid "server not found: %s"
 msgstr "сервер не найден: %s"
 
-#: src/ExternalConn.cpp:1538
+#: src/ExternalConn.cpp:1537
 msgid "need to define server to be removed"
 msgstr "необходимо выделить сервер для удаления"
 
-#: src/ExternalConn.cpp:1553
+#: src/ExternalConn.cpp:1552
 msgid "eD2k is disabled in preferences."
 msgstr "Сеть eD2k отключена в настройках"
 
-#: src/ExternalConn.cpp:1658
+#: src/ExternalConn.cpp:1657
 #, fuzzy
 msgid "Friend not found."
 msgstr "Файл не найден."
 
-#: src/ExternalConn.cpp:1668
+#: src/ExternalConn.cpp:1667
 #, fuzzy
 msgid "Client not found."
 msgstr "Файл не найден."
 
-#: src/ExternalConn.cpp:1674
+#: src/ExternalConn.cpp:1673
 msgid "EC_TAG_FRIEND_SHARED requires EC_TAG_FRIEND or EC_TAG_CLIENT."
 msgstr ""
 
 # Explained by Jacobo221.
-#: src/ExternalConn.cpp:1992
+#: src/ExternalConn.cpp:1991
 msgid "WebSearch from remote interface makes no sense."
 msgstr "При удаленном использовании aMule WWW поиск бесполезен."
 
-#: src/ExternalConn.cpp:2027
+#: src/ExternalConn.cpp:2026
 msgid "Search in progress. Refetch results in a moment!"
 msgstr "Поиск запущен. Ждите результатов."
 
-#: src/ExternalConn.cpp:2266
+#: src/ExternalConn.cpp:2265
 msgid "No points for graph."
 msgstr "В графике нет точек."
 
-#: src/ExternalConn.cpp:2276
+#: src/ExternalConn.cpp:2275
 msgid "Your client is not configured for this detail level."
 msgstr "Ваш клиент не настроен на этот уровень детализации."
 
-#: src/ExternalConn.cpp:2303
+#: src/ExternalConn.cpp:2302
 msgid "External Connection: shutdown requested"
 msgstr "Внешнее соединение: запрошено выключение"
 
-#: src/ExternalConn.cpp:2315
+#: src/ExternalConn.cpp:2314
 msgid "Already shutting down."
 msgstr "Уже завершаю работу."
 
-#: src/ExternalConn.cpp:2333
+#: src/ExternalConn.cpp:2332
 #, c-format
 msgid "ExternalConn: adding link '%s'."
 msgstr "ExternalConn: добавляю ссылку '%s'."
 
-#: src/ExternalConn.cpp:2351
+#: src/ExternalConn.cpp:2350
 #, fuzzy, c-format
 msgid "%d of %d links failed (invalid or already on list)."
 msgstr "Ссылка неверна или уже в списке."
 
-#: src/ExternalConn.cpp:2374
+#: src/ExternalConn.cpp:2373
 msgid "Version check throttled; try again shortly."
 msgstr ""
 
-#: src/ExternalConn.cpp:2379
+#: src/ExternalConn.cpp:2378
 msgid "Version check is not available on this daemon."
 msgstr ""
 
-#: src/ExternalConn.cpp:2509
+#: src/ExternalConn.cpp:2508
 msgid "File not found."
 msgstr "Файл не найден."
 
-#: src/ExternalConn.cpp:2514
+#: src/ExternalConn.cpp:2513
 msgid "Invalid file name."
 msgstr "Неверное имя файла."
 
-#: src/ExternalConn.cpp:2522
+#: src/ExternalConn.cpp:2521
 msgid "Unable to rename file."
 msgstr "Невозможно переименовать файл."
 
-#: src/ExternalConn.cpp:2839
-#, c-format
-msgid "Could not save the amuleapi password: %s"
-msgstr ""
-
-#: src/ExternalConn.cpp:3004 src/ExternalConn.cpp:3032
+#: src/ExternalConn.cpp:2992 src/ExternalConn.cpp:3020
 msgid "Kad is disabled in preferences."
 msgstr "Kad выключена в настройках."
 
-#: src/ExternalConn.cpp:3045
+#: src/ExternalConn.cpp:3033
 msgid "Already connected to eD2k."
 msgstr "Уже подсоединен к сети eD2k."
 
-#: src/ExternalConn.cpp:3048
+#: src/ExternalConn.cpp:3036
 msgid "Connecting to eD2k..."
 msgstr "Подсоединение к сети eD2k..."
 
-#: src/ExternalConn.cpp:3057
+#: src/ExternalConn.cpp:3045
 msgid "Already connected to Kad."
 msgstr "Уже подключен к Kad."
 
-#: src/ExternalConn.cpp:3060
+#: src/ExternalConn.cpp:3048
 msgid "Connecting to Kad..."
 msgstr "Подключаюсь к Kad..."
 
-#: src/ExternalConn.cpp:3067
+#: src/ExternalConn.cpp:3055
 msgid "All networks are disabled."
 msgstr "Все сети выключены."
 
-#: src/ExternalConn.cpp:3076
+#: src/ExternalConn.cpp:3064
 msgid "Disconnected from eD2k."
 msgstr "Отсоединен от сети eD2k."
 
-#: src/ExternalConn.cpp:3081
+#: src/ExternalConn.cpp:3069
 msgid "Disconnected from Kad."
 msgstr "Отключен от Kad."
 
-#: src/ExternalConn.cpp:3090
+#: src/ExternalConn.cpp:3078
 #, c-format
 msgid "External Connection: invalid opcode received: %#x"
 msgstr "Внешнее соединение: получен неверный код операции: %#x"
 
-#: src/ExternalConn.cpp:3095
+#: src/ExternalConn.cpp:3083
 msgid "Invalid opcode (wrong protocol version?)"
 msgstr "Неверный opcode (Возможно, не та версия протокола)"
 
@@ -2365,19 +2355,19 @@ msgstr ""
 msgid "eD2k"
 msgstr "eD2k"
 
-#: src/FirstRunWizard.cpp:349 src/muuli_wdr.cpp:1495
+#: src/FirstRunWizard.cpp:349 src/muuli_wdr.cpp:1488
 msgid "Kademlia"
 msgstr "Kademlia"
 
-#: src/FirstRunWizard.cpp:359 src/muuli_wdr.cpp:1423
+#: src/FirstRunWizard.cpp:359 src/muuli_wdr.cpp:1416
 msgid "Standard TCP Port "
 msgstr "Стандартный порт TCP"
 
-#: src/FirstRunWizard.cpp:365 src/muuli_wdr.cpp:1435
+#: src/FirstRunWizard.cpp:365 src/muuli_wdr.cpp:1428
 msgid "Extended UDP port (Kad / global search) "
 msgstr "Дополнительный порт UDP (Kad / Глобальный поиск)"
 
-#: src/FirstRunWizard.cpp:377 src/muuli_wdr.cpp:1442
+#: src/FirstRunWizard.cpp:377 src/muuli_wdr.cpp:1435
 msgid "Enable UPnP for router port forwarding"
 msgstr "Разрешить UPnP форвардинг портов роутера"
 
@@ -2404,7 +2394,7 @@ msgstr ""
 msgid "Your peer lists are already in place - nothing to download."
 msgstr "Вы уже пытаетесь загрузить файл %s"
 
-#: src/FirstRunWizard.cpp:434 src/muuli_wdr.cpp:1540
+#: src/FirstRunWizard.cpp:434 src/muuli_wdr.cpp:1533
 msgid "Auto-update server list at startup"
 msgstr "Автоматически обновлять список серверов при запуске"
 
@@ -2450,23 +2440,23 @@ msgid ""
 "want downloads on a different (e.g. larger) disk."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:549 src/FirstRunWizard.cpp:611 src/muuli_wdr.cpp:1702
+#: src/FirstRunWizard.cpp:549 src/FirstRunWizard.cpp:611 src/muuli_wdr.cpp:1701
 msgid "Destination folder for downloads"
 msgstr "Папка для загружаемых файлов"
 
-#: src/FirstRunWizard.cpp:553 src/FirstRunWizard.cpp:569 src/muuli_wdr.cpp:1349
-#: src/muuli_wdr.cpp:1366 src/muuli_wdr.cpp:1677 src/muuli_wdr.cpp:1708
-#: src/muuli_wdr.cpp:1720 src/muuli_wdr.cpp:2790
+#: src/FirstRunWizard.cpp:553 src/FirstRunWizard.cpp:569 src/muuli_wdr.cpp:1342
+#: src/muuli_wdr.cpp:1359 src/muuli_wdr.cpp:1676 src/muuli_wdr.cpp:1707
+#: src/muuli_wdr.cpp:1719 src/muuli_wdr.cpp:2762
 #: src/utils/aLinkCreator/src/alcframe.cpp:135
 #: src/utils/wxCas/src/wxcasprefs.cpp:52 src/utils/wxCas/src/wxcasprefs.cpp:118
 msgid "Browse"
 msgstr "Открыть"
 
-#: src/FirstRunWizard.cpp:559 src/muuli_wdr.cpp:1713
+#: src/FirstRunWizard.cpp:559 src/muuli_wdr.cpp:1712
 msgid "(All files in this folder are shared with other peers)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:565 src/FirstRunWizard.cpp:624 src/muuli_wdr.cpp:1715
+#: src/FirstRunWizard.cpp:565 src/FirstRunWizard.cpp:624 src/muuli_wdr.cpp:1714
 msgid "Folder for temporary download files"
 msgstr "Папка для временных файлов"
 
@@ -2497,7 +2487,7 @@ msgstr "Не удалось открыть список друзей 'emfriends.
 msgid "CRITICAL - no client on StartChatSession"
 msgstr "КРИТИЧНО - нет клиентов на StartChatSession"
 
-#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2696 src/muuli_wdr.cpp:3373
+#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2668 src/muuli_wdr.cpp:3345
 msgid "Friends"
 msgstr "Друзья"
 
@@ -2608,8 +2598,8 @@ msgstr "Нет"
 msgid "No"
 msgstr "Нет"
 
-#: src/GenericClientListCtrl.cpp:1216 src/PrefsUnifiedDlg.cpp:2898
-#: src/PrefsUnifiedDlg.cpp:2948 src/ServerListCtrl.cpp:276
+#: src/GenericClientListCtrl.cpp:1216 src/PrefsUnifiedDlg.cpp:2818
+#: src/PrefsUnifiedDlg.cpp:2868 src/ServerListCtrl.cpp:276
 msgid "Yes"
 msgstr "Да"
 
@@ -2781,10 +2771,10 @@ msgstr "Неверный порт для инициализации"
 msgid "Please fill all fields required"
 msgstr "Пожалуйста, заполните все необходимые поля"
 
-#: src/KadDlg.cpp:192 src/PartFile.cpp:1031 src/PrefsUnifiedDlg.cpp:1134
-#: src/PrefsUnifiedDlg.cpp:1204 src/PrefsUnifiedDlg.cpp:1405
-#: src/PrefsUnifiedDlg.cpp:1663 src/PrefsUnifiedDlg.cpp:1673
-#: src/PrefsUnifiedDlg.cpp:1690 src/PrefsUnifiedDlg.cpp:1738
+#: src/KadDlg.cpp:192 src/PartFile.cpp:1031 src/PrefsUnifiedDlg.cpp:1162
+#: src/PrefsUnifiedDlg.cpp:1331 src/PrefsUnifiedDlg.cpp:1589
+#: src/PrefsUnifiedDlg.cpp:1599 src/PrefsUnifiedDlg.cpp:1616
+#: src/PrefsUnifiedDlg.cpp:1658
 msgid "Message"
 msgstr "Сообщение"
 
@@ -2890,7 +2880,7 @@ msgstr "Рейтинг"
 msgid "Uploaded"
 msgstr "Загружено"
 
-#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3253
+#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3225
 msgid "Requested"
 msgstr "Запрошено"
 
@@ -3014,7 +3004,7 @@ msgid "WARNING: "
 msgstr "ПРЕДУПРЕЖДЕНИЕ:"
 
 #: src/MuleNotebook.cpp:179 src/muuli_wdr.cpp:817 src/muuli_wdr.cpp:1229
-#: src/muuli_wdr.cpp:3157 src/muuli_wdr.cpp:3413
+#: src/muuli_wdr.cpp:3129 src/muuli_wdr.cpp:3385
 msgid "Close"
 msgstr "Закрыть"
 
@@ -3027,12 +3017,12 @@ msgstr "Вырезать"
 msgid "Copy"
 msgstr "Копировать"
 
-#: src/MuleTextCtrl.cpp:88 src/SearchDlg.cpp:261
+#: src/MuleTextCtrl.cpp:88
 msgid "Paste"
 msgstr "Вставить"
 
 #: src/MuleTextCtrl.cpp:89 src/muuli_wdr.cpp:358 src/muuli_wdr.cpp:757
-#: src/muuli_wdr.cpp:2380 src/muuli_wdr.cpp:2399 src/muuli_wdr.cpp:2421
+#: src/muuli_wdr.cpp:2352 src/muuli_wdr.cpp:2371 src/muuli_wdr.cpp:2393
 #: src/utils/aLinkCreator/src/alcframe.cpp:142
 msgid "Clear"
 msgstr "Очистить"
@@ -3130,8 +3120,8 @@ msgid "Exit"
 msgstr "Выйти"
 
 #: src/MuleTrayIcon.cpp:579 src/MuleTrayIcon.cpp:945 src/MuleTrayIcon.cpp:965
-#: src/muuli_wdr.cpp:1398 src/muuli_wdr.cpp:1406 src/muuli_wdr.cpp:1413
-#: src/muuli_wdr.cpp:1836 src/muuli_wdr.cpp:1842 src/OtherFunctions.cpp:91
+#: src/muuli_wdr.cpp:1391 src/muuli_wdr.cpp:1399 src/muuli_wdr.cpp:1406
+#: src/muuli_wdr.cpp:1835 src/muuli_wdr.cpp:1841 src/OtherFunctions.cpp:91
 #: src/StatisticsDlg.cpp:93 src/StatisticsDlg.cpp:95
 msgid "kB/s"
 msgstr "кБ/сек"
@@ -3306,7 +3296,7 @@ msgstr "Имя:"
 msgid "Type"
 msgstr "Тип"
 
-#: src/muuli_wdr.cpp:215 src/SearchDlg.cpp:118 src/SearchListCtrl.cpp:853
+#: src/muuli_wdr.cpp:215 src/SearchDlg.cpp:110 src/SearchListCtrl.cpp:853
 msgid "Local"
 msgstr "Локальный"
 
@@ -3377,7 +3367,7 @@ msgstr "Байт"
 msgid "KB"
 msgstr "КБ"
 
-#: src/muuli_wdr.cpp:274 src/muuli_wdr.cpp:293 src/muuli_wdr.cpp:1621
+#: src/muuli_wdr.cpp:274 src/muuli_wdr.cpp:293 src/muuli_wdr.cpp:1620
 #: src/OtherFunctions.cpp:64
 msgid "MB"
 msgstr "МБ"
@@ -3394,7 +3384,7 @@ msgstr "Макс. размер"
 msgid "Availability"
 msgstr "Доступность"
 
-#: src/muuli_wdr.cpp:312 src/muuli_wdr.cpp:398 src/muuli_wdr.cpp:3318
+#: src/muuli_wdr.cpp:312 src/muuli_wdr.cpp:398 src/muuli_wdr.cpp:3290
 msgid "Filter:"
 msgstr "Фильтр:"
 
@@ -3426,7 +3416,7 @@ msgstr ""
 msgid "Stop"
 msgstr "Остановить"
 
-#: src/muuli_wdr.cpp:348 src/muuli_wdr.cpp:1392 src/SearchListCtrl.cpp:732
+#: src/muuli_wdr.cpp:348 src/muuli_wdr.cpp:1385 src/SearchListCtrl.cpp:732
 msgid "Download"
 msgstr "Загрузка"
 
@@ -3457,12 +3447,12 @@ msgstr "Источников:"
 #: src/muuli_wdr.cpp:1160 src/muuli_wdr.cpp:1167 src/muuli_wdr.cpp:1172
 #: src/muuli_wdr.cpp:1179 src/muuli_wdr.cpp:1184 src/muuli_wdr.cpp:1191
 #: src/muuli_wdr.cpp:1205 src/muuli_wdr.cpp:1212 src/muuli_wdr.cpp:1217
-#: src/muuli_wdr.cpp:1224 src/muuli_wdr.cpp:3255 src/muuli_wdr.cpp:3263
-#: src/muuli_wdr.cpp:3271
+#: src/muuli_wdr.cpp:1224 src/muuli_wdr.cpp:3227 src/muuli_wdr.cpp:3235
+#: src/muuli_wdr.cpp:3243
 msgid "N/A"
 msgstr "N/A"
 
-#: src/muuli_wdr.cpp:508 src/muuli_wdr.cpp:1065 src/PrefsUnifiedDlg.cpp:299
+#: src/muuli_wdr.cpp:508 src/muuli_wdr.cpp:1065 src/PrefsUnifiedDlg.cpp:297
 msgid "General"
 msgstr "Общие"
 
@@ -3603,7 +3593,7 @@ msgstr ""
 msgid "Album :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:685 src/muuli_wdr.cpp:2275
+#: src/muuli_wdr.cpp:685 src/muuli_wdr.cpp:2247
 msgid "Title :"
 msgstr "Заголовок :"
 
@@ -3714,7 +3704,7 @@ msgstr "Имя пользователя :"
 msgid "Userhash :"
 msgstr "Хеш пользователя :"
 
-#: src/muuli_wdr.cpp:895 src/muuli_wdr.cpp:1742 src/muuli_wdr.cpp:2470
+#: src/muuli_wdr.cpp:895 src/muuli_wdr.cpp:1741 src/muuli_wdr.cpp:2442
 #: src/utils/aLinkCreator/src/alcframe.cpp:137
 msgid "Add"
 msgstr "Добавить"
@@ -3723,15 +3713,15 @@ msgstr "Добавить"
 msgid "Download-Speed"
 msgstr "Скорость приема"
 
-#: src/muuli_wdr.cpp:954 src/muuli_wdr.cpp:989 src/muuli_wdr.cpp:2574
+#: src/muuli_wdr.cpp:954 src/muuli_wdr.cpp:989 src/muuli_wdr.cpp:2546
 msgid "Current"
 msgstr "Текущая"
 
-#: src/muuli_wdr.cpp:962 src/muuli_wdr.cpp:997 src/muuli_wdr.cpp:2582
+#: src/muuli_wdr.cpp:962 src/muuli_wdr.cpp:997 src/muuli_wdr.cpp:2554
 msgid "Running average"
 msgstr "Средняя за все время"
 
-#: src/muuli_wdr.cpp:970 src/muuli_wdr.cpp:1005 src/muuli_wdr.cpp:2590
+#: src/muuli_wdr.cpp:970 src/muuli_wdr.cpp:1005 src/muuli_wdr.cpp:2562
 msgid "Session average"
 msgstr "В среднем за сеанс"
 
@@ -3743,7 +3733,7 @@ msgstr "Скорость отдачи"
 msgid "Connections"
 msgstr "Соединения"
 
-#: src/muuli_wdr.cpp:1024 src/muuli_wdr.cpp:1861
+#: src/muuli_wdr.cpp:1024 src/muuli_wdr.cpp:1860
 msgid "Active downloads"
 msgstr "Активные загрузки"
 
@@ -3751,7 +3741,7 @@ msgstr "Активные загрузки"
 msgid "Active connections (1:1)"
 msgstr "Активные соединения (1:1)"
 
-#: src/muuli_wdr.cpp:1040 src/muuli_wdr.cpp:1862
+#: src/muuli_wdr.cpp:1040 src/muuli_wdr.cpp:1861
 msgid "Active uploads"
 msgstr "Активные передачи"
 
@@ -3867,8 +3857,8 @@ msgstr "Это имя, которое будет показано пользов
 msgid "Language: "
 msgstr "Язык:"
 
-#: src/muuli_wdr.cpp:1257 src/muuli_wdr.cpp:1330 src/muuli_wdr.cpp:1334
-#: src/muuli_wdr.cpp:1337
+#: src/muuli_wdr.cpp:1257 src/muuli_wdr.cpp:1323 src/muuli_wdr.cpp:1327
+#: src/muuli_wdr.cpp:1330
 msgid "The delay before showing tool-tips."
 msgstr "Задержка отображения контекстных подсказок (как эта) в секундах."
 
@@ -3946,967 +3936,943 @@ msgstr "Показывать уведомления о завершении за
 msgid "Enabling this will make aMule to show notifications when finished downloading."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1323
-#, fuzzy
-msgid "Remember search history"
-msgstr "Запомнить настройки"
-
-#: src/muuli_wdr.cpp:1324
-msgid "Keeps a dropdown list of your past search terms in the Search tab's Name field. This remembers the queries you typed, not the results they returned."
-msgstr ""
-
-#: src/muuli_wdr.cpp:1329
+#: src/muuli_wdr.cpp:1322
 msgid "Tooltip delay time: "
 msgstr "Время задержки подсказок:"
 
-#: src/muuli_wdr.cpp:1336
+#: src/muuli_wdr.cpp:1329
 msgid "seconds"
 msgstr "секунд"
 
-#: src/muuli_wdr.cpp:1340
+#: src/muuli_wdr.cpp:1333
 msgid "Browser Selection"
 msgstr "Выбор браузера"
 
-#: src/muuli_wdr.cpp:1346
+#: src/muuli_wdr.cpp:1339
 msgid "Enter your browser name here. Leave this field empty to use the system default browser."
 msgstr "Введите имя предпочитаемого браузера. Оставьте поле пустым чтобы использовать системный браузер по умолчанию."
 
-#: src/muuli_wdr.cpp:1353
+#: src/muuli_wdr.cpp:1346
 msgid "Open in new tab if possible"
 msgstr "Открывать в новой вкладке"
 
-#: src/muuli_wdr.cpp:1355
+#: src/muuli_wdr.cpp:1348
 msgid "Open the web page in a new tab instead of in a new window when possible"
 msgstr "Открывать веб-страницы в новой вкладке, а не в отдельном окне, если это возможно"
 
-#: src/muuli_wdr.cpp:1359
+#: src/muuli_wdr.cpp:1352
 msgid "Video Player"
 msgstr "Видео-проигрыватель"
 
-#: src/muuli_wdr.cpp:1386
+#: src/muuli_wdr.cpp:1379
 msgid "Bandwidth limits"
 msgstr "Ограничения загрузки"
 
-#: src/muuli_wdr.cpp:1400
+#: src/muuli_wdr.cpp:1393
 msgid "Upload"
 msgstr "Отдача"
 
-#: src/muuli_wdr.cpp:1408
+#: src/muuli_wdr.cpp:1401
 msgid "Slot Allocation"
 msgstr "Слот"
 
-#: src/muuli_wdr.cpp:1417
+#: src/muuli_wdr.cpp:1410
 msgid "Ports"
 msgstr "Порты"
 
-#: src/muuli_wdr.cpp:1427
+#: src/muuli_wdr.cpp:1420
 msgid "This is the standard eD2k port and cannot be disabled."
 msgstr "Это стандартный порт eD2k, он не может быть отключен."
 
-#: src/muuli_wdr.cpp:1430
+#: src/muuli_wdr.cpp:1423
 msgid "UDP port for server requests (TCP+3):"
 msgstr "Порт UDP для запросов сервера (TCP+3):"
 
-#: src/muuli_wdr.cpp:1432
+#: src/muuli_wdr.cpp:1425
 msgid "4665"
 msgstr "4665"
 
-#: src/muuli_wdr.cpp:1439
+#: src/muuli_wdr.cpp:1432
 msgid "This UDP port is used for extended eD2k requests and Kad network"
 msgstr "Этот порт UDP используется для дополнительных eD2k запросов и Kad"
 
-#: src/muuli_wdr.cpp:1446
+#: src/muuli_wdr.cpp:1439
 msgid "UPnP TCP Port (Optional):"
 msgstr "UPnP TCP порт (Не обязательно):"
 
-#: src/muuli_wdr.cpp:1456
+#: src/muuli_wdr.cpp:1449
 msgid "Bind local address to IP (empty for any):"
 msgstr "Закрепить локальный адрес за IP (пустой для любого):"
 
-#: src/muuli_wdr.cpp:1459
+#: src/muuli_wdr.cpp:1452
 msgid "Advanced users only: If you have multiple network interfaces, enter the address of the interface to which aMule should be bound."
 msgstr "Только для продвинутых пользователей: если у вас несколько сетевых интерфейсов введите адрес того, которым будет пользоваться aMule."
 
-#: src/muuli_wdr.cpp:1462 src/muuli_wdr.cpp:2055
+#: src/muuli_wdr.cpp:1455 src/muuli_wdr.cpp:2054
 #, fuzzy
 msgid "Bind to network interface (empty for any):"
 msgstr "Закрепить локальный адрес за IP (пустой для любого):"
 
-#: src/muuli_wdr.cpp:1475
+#: src/muuli_wdr.cpp:1468
 msgid "Advanced users only: pin all of aMule's traffic to one network interface, chosen from the list or typed in by name (e.g. tun0, eth0, en0) or index. Unlike binding to an IP, this stops traffic leaking out via the default route - useful with a VPN. Requires no elevated privileges."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1481
+#: src/muuli_wdr.cpp:1474
 msgid "Max sources per downloading file:"
 msgstr "Максимум источников на файл:"
 
-#: src/muuli_wdr.cpp:1485
+#: src/muuli_wdr.cpp:1478
 msgid "Max simultaneous connections:"
 msgstr "Максимум одновременных соединений:"
 
-#: src/muuli_wdr.cpp:1498 src/muuli_wdr.cpp:3197
+#: src/muuli_wdr.cpp:1491 src/muuli_wdr.cpp:3169
 msgid "ED2K"
 msgstr "ED2K"
 
-#: src/muuli_wdr.cpp:1505
+#: src/muuli_wdr.cpp:1498
 msgid "Autoconnect on startup"
 msgstr "Соединяться автоматически после запуска"
 
-#: src/muuli_wdr.cpp:1508
+#: src/muuli_wdr.cpp:1501
 msgid "Reconnect on loss"
 msgstr "Восстановить соединение в случае разрыва"
 
-#: src/muuli_wdr.cpp:1530
+#: src/muuli_wdr.cpp:1523
 msgid "Remove dead server after"
 msgstr "Удалить нерабочий сервер после"
 
-#: src/muuli_wdr.cpp:1531
+#: src/muuli_wdr.cpp:1524
 msgid "Static servers are never removed, even when unreachable."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1535
+#: src/muuli_wdr.cpp:1528
 msgid "retries"
 msgstr "попыток"
 
-#: src/muuli_wdr.cpp:1543
+#: src/muuli_wdr.cpp:1536
 msgid "List"
 msgstr "Список"
 
-#: src/muuli_wdr.cpp:1546
+#: src/muuli_wdr.cpp:1539
 msgid "Update server list when connecting to a server"
 msgstr "Обновлять список серверов при подключении к серверу"
 
-#: src/muuli_wdr.cpp:1549
+#: src/muuli_wdr.cpp:1542
 msgid "Update server list when a client connects"
 msgstr "Обновлять список серверов при подключении к клиенту"
 
-#: src/muuli_wdr.cpp:1552
+#: src/muuli_wdr.cpp:1545
 msgid "Use priority system"
 msgstr "Использовать систему приоритетов"
 
-#: src/muuli_wdr.cpp:1556
+#: src/muuli_wdr.cpp:1549
 msgid "Use smart LowID check on connect"
 msgstr "Проверка на LowID при подключении к серверу"
 
-#: src/muuli_wdr.cpp:1560
+#: src/muuli_wdr.cpp:1553
 msgid "Safe connect"
 msgstr "Безопасное подключение"
 
-#: src/muuli_wdr.cpp:1564
+#: src/muuli_wdr.cpp:1557
 msgid "Autoconnect to servers in static list only"
 msgstr "Автоподключение только к статическим серверам"
 
-#: src/muuli_wdr.cpp:1567
+#: src/muuli_wdr.cpp:1560
 msgid "Set manually added servers to High Priority"
 msgstr "Высокий приоритет серверов, добавленных вручную"
 
-#: src/muuli_wdr.cpp:1588
+#: src/muuli_wdr.cpp:1581
 msgid "Add files to download in pause mode"
 msgstr "Добавлять файлы на загрузку в режиме паузы"
 
-#: src/muuli_wdr.cpp:1590
+#: src/muuli_wdr.cpp:1583
 msgid "Add files to download with auto priority"
 msgstr "Добавлять файлы в загрузку с авто приоритетом"
 
-#: src/muuli_wdr.cpp:1593
+#: src/muuli_wdr.cpp:1586
 msgid "Try to download first and last chunks first"
 msgstr "Пытаться сначала загрузить первую и последнюю части"
 
-#: src/muuli_wdr.cpp:1597
+#: src/muuli_wdr.cpp:1590
 msgid "Endgame mode: rotate to faster sources for the final blocks"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1600
+#: src/muuli_wdr.cpp:1593
 msgid "Start next paused file when a file completes"
 msgstr "Возобновлять следующий файл на паузе при завершении загрузки"
 
-#: src/muuli_wdr.cpp:1603
+#: src/muuli_wdr.cpp:1596
 msgid "From the same category"
 msgstr "Из той же категории"
 
-#: src/muuli_wdr.cpp:1605
+#: src/muuli_wdr.cpp:1598
 msgid "In alphabetic order"
 msgstr "В алфавитном порядке"
 
-#: src/muuli_wdr.cpp:1607
+#: src/muuli_wdr.cpp:1600
 msgid "Preallocate disk space for new files"
 msgstr "Заранее выделять место для новых фалов"
 
-#: src/muuli_wdr.cpp:1608
+#: src/muuli_wdr.cpp:1601
 msgid "For new files preallocates disk space for the whole file, thus reduces fragmentation"
 msgstr "Сразу выделяет место под весь файл. Таким образом уменьшается фрагментация"
 
-#: src/muuli_wdr.cpp:1613
+#: src/muuli_wdr.cpp:1606
+msgid "Create new files as sparse files"
+msgstr ""
+
+#: src/muuli_wdr.cpp:1607
+msgid "A sparse file reserves its full size on disk immediately without writing real data to it -- fast, but unsupported or slow on some filesystems, and free-space accounting stays optimistic while the download is in progress. Turn this off to grow the file only as data arrives."
+msgstr ""
+
+#: src/muuli_wdr.cpp:1612
 msgid "Stop downloads when free disk space reaches "
 msgstr "Останавливать загрузки по окончанию свободного места на диске"
 
-#: src/muuli_wdr.cpp:1614
+#: src/muuli_wdr.cpp:1613
 msgid "Select this if you want aMule to check your disk space"
 msgstr "Отметьте это если  хотите чтобы aMule проверял наличие свободного места"
 
-#: src/muuli_wdr.cpp:1618
+#: src/muuli_wdr.cpp:1617
 msgid "Enter here the min disk space desired."
 msgstr "Введите здесь минимальное количество свободного места на диске."
 
-#: src/muuli_wdr.cpp:1624
+#: src/muuli_wdr.cpp:1623
 msgid "Save 10 sources on rare files (< 20 sources)"
 msgstr "Оставлять 10 источников для редких файлов (<20 источников)"
 
-#: src/muuli_wdr.cpp:1628 src/Statistics.cpp:790
+#: src/muuli_wdr.cpp:1627 src/Statistics.cpp:790
 msgid "Uploads"
 msgstr "Отдача"
 
-#: src/muuli_wdr.cpp:1631
+#: src/muuli_wdr.cpp:1630
 msgid "Add new shared files with auto priority"
 msgstr "Добавлять новые файлы для публикации с авто приоритетом"
 
 # слишком уж частая аббривеатура. написать И.О.О. - никто не поймет
-#: src/muuli_wdr.cpp:1637
+#: src/muuli_wdr.cpp:1636
 msgid "Intelligent Corruption Handling (I.C.H.)"
 msgstr "Интеллектуальная Обработка Ошибок (I.C.H.)"
 
-#: src/muuli_wdr.cpp:1640
+#: src/muuli_wdr.cpp:1639
 msgid "Enable"
 msgstr "Разрешить"
 
-#: src/muuli_wdr.cpp:1643
+#: src/muuli_wdr.cpp:1642
 msgid "Advanced I.C.H. trusts every hash (not recommended)"
 msgstr "AICH-доверие для каждого хэша (не рекомендуется)"
 
-#: src/muuli_wdr.cpp:1655 src/PrefsUnifiedDlg.cpp:1990
+#: src/muuli_wdr.cpp:1654 src/PrefsUnifiedDlg.cpp:1910
 msgid "Media metadata extraction"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1659
+#: src/muuli_wdr.cpp:1658
 msgid "Extract length / bitrate / codec from shared audio and video files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1661
+#: src/muuli_wdr.cpp:1660
 msgid "When enabled, aMule runs ffprobe on each shared media file to fill in the Length / Bitrate / Codec columns other clients see when they find the file in a search. Requires ffmpeg (the ffprobe binary) to be installed."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1668
+#: src/muuli_wdr.cpp:1667
 msgid "Path to ffprobe:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1673
+#: src/muuli_wdr.cpp:1672
 msgid "Full path to the ffprobe binary. Leave empty to have aMule auto-detect it on startup."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1681
+#: src/muuli_wdr.cpp:1680
 msgid "Detect"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1682
+#: src/muuli_wdr.cpp:1681
 msgid "Search the standard install locations for an ffprobe binary and fill the path field."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1706
+#: src/muuli_wdr.cpp:1705
 msgid ""
 "Completed downloads are stored here. All files in this folder are automatically shared with other peers.\n"
 "If this folder also holds files you don't want to share, point it at an aMule-only sub-folder."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1709
+#: src/muuli_wdr.cpp:1708
 msgid "Pick the folder where completed downloads will be stored. All files in that folder will be shared with other peers."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1723
+#: src/muuli_wdr.cpp:1722
 msgid "Shared folders"
 msgstr "Публикуемые папки"
 
-#: src/muuli_wdr.cpp:1729
+#: src/muuli_wdr.cpp:1728
 msgid "(Folders shared by the core. Enter a path to add one.)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1737
+#: src/muuli_wdr.cpp:1736
 msgid "Absolute path of a folder on the core's machine, e.g. /home/user/shared"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1739 src/PrefsUnifiedDlg.cpp:2874
+#: src/muuli_wdr.cpp:1738 src/PrefsUnifiedDlg.cpp:2794
 msgid "Recursive"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1740
+#: src/muuli_wdr.cpp:1739
 msgid "Share every sub-folder underneath this one, including ones created later."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1744 src/utils/aLinkCreator/src/alcframe.cpp:141
+#: src/muuli_wdr.cpp:1743 src/utils/aLinkCreator/src/alcframe.cpp:141
 msgid "Remove"
 msgstr "Удалить"
 
-#: src/muuli_wdr.cpp:1748
+#: src/muuli_wdr.cpp:1747
 msgid "(Right click on folder icon for recursive share)"
 msgstr "(кликните правой кнопкой на значке каталога для рекурсивной публикации)"
 
-#: src/muuli_wdr.cpp:1755
+#: src/muuli_wdr.cpp:1754
 msgid "Share hidden files"
 msgstr "Включая скрытые файлы"
 
-#: src/muuli_wdr.cpp:1761
+#: src/muuli_wdr.cpp:1760
 msgid "Automatically rescan shared folders for changes"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1767
+#: src/muuli_wdr.cpp:1766
 msgid "Follow symbolic links in shared folders"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1773
+#: src/muuli_wdr.cpp:1772
 msgid "Exclude files matching:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1776
+#: src/muuli_wdr.cpp:1775
 msgid "Wildcard patterns separated by '|', e.g. .DS_Store|Thumbs.db|*.tmp. Files whose name matches are not shared. Matching is case-insensitive."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1780
+#: src/muuli_wdr.cpp:1779
 msgid "Patterns are regular expressions"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1781
+#: src/muuli_wdr.cpp:1780
 msgid "When set, the whole field is one regular expression ('|' is alternation). When unset, it is a list of '|'-separated wildcards."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1791
+#: src/muuli_wdr.cpp:1790
 msgid "Show how many shared files the current pattern would exclude."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1812
+#: src/muuli_wdr.cpp:1811
 msgid "Graphs"
 msgstr "Графики"
 
-#: src/muuli_wdr.cpp:1815 src/muuli_wdr.cpp:1877
+#: src/muuli_wdr.cpp:1814 src/muuli_wdr.cpp:1876
 msgid "Update delay : 5 secs"
 msgstr "Интервал обновления: 5 сек"
 
-#: src/muuli_wdr.cpp:1819
+#: src/muuli_wdr.cpp:1818
 msgid "Time for average graph: 100 mins"
 msgstr "Время для среднестатического графика: 100 минут"
 
-#: src/muuli_wdr.cpp:1823
+#: src/muuli_wdr.cpp:1822
 msgid "Connections Graph Scale: 100 "
 msgstr "Масштаб графика соединений: 100 "
 
-#: src/muuli_wdr.cpp:1830
+#: src/muuli_wdr.cpp:1829
 msgid "Download graph scale:"
 msgstr "Масштаб графика загрузки:"
 
-#: src/muuli_wdr.cpp:1838
+#: src/muuli_wdr.cpp:1837
 msgid "Upload graph scale:"
 msgstr "Масштаб графика отдачи:"
 
-#: src/muuli_wdr.cpp:1848
+#: src/muuli_wdr.cpp:1847
 #, fuzzy
 msgid "Colors: "
 msgstr "Цвета:"
 
-#: src/muuli_wdr.cpp:1852
+#: src/muuli_wdr.cpp:1851
 msgid "Background"
 msgstr "Фон"
 
-#: src/muuli_wdr.cpp:1853
+#: src/muuli_wdr.cpp:1852
 msgid "Grid"
 msgstr "Сетка"
 
-#: src/muuli_wdr.cpp:1854
+#: src/muuli_wdr.cpp:1853
 msgid "Download current"
 msgstr "Текущая загрузка"
 
-#: src/muuli_wdr.cpp:1855
+#: src/muuli_wdr.cpp:1854
 msgid "Download running average"
 msgstr "Средняя общая загрузка"
 
-#: src/muuli_wdr.cpp:1856
+#: src/muuli_wdr.cpp:1855
 msgid "Download session average"
 msgstr "Средняя загрузка за сеанс"
 
-#: src/muuli_wdr.cpp:1857
+#: src/muuli_wdr.cpp:1856
 msgid "Upload current"
 msgstr "Текущая отдача"
 
-#: src/muuli_wdr.cpp:1858
+#: src/muuli_wdr.cpp:1857
 msgid "Upload running average"
 msgstr "Средняя общая отдача"
 
-#: src/muuli_wdr.cpp:1859
+#: src/muuli_wdr.cpp:1858
 msgid "Upload session average"
 msgstr "Средняя отдача за сеанс"
 
-#: src/muuli_wdr.cpp:1860
+#: src/muuli_wdr.cpp:1859
 msgid "Active connections"
 msgstr "Активные соединения"
 
-#: src/muuli_wdr.cpp:1863
+#: src/muuli_wdr.cpp:1862
 #, fuzzy
 msgid "Systray Icon Speed Bar"
 msgstr "Скорость передачи в области уведомлений"
 
-#: src/muuli_wdr.cpp:1864
+#: src/muuli_wdr.cpp:1863
 msgid "Kad-nodes current"
 msgstr "Узлы Kad (текущие)"
 
-#: src/muuli_wdr.cpp:1865
+#: src/muuli_wdr.cpp:1864
 msgid "Kad-nodes running"
 msgstr "Узлы Kad (действующие)"
 
-#: src/muuli_wdr.cpp:1866
+#: src/muuli_wdr.cpp:1865
 msgid "Kad-nodes session"
 msgstr "Узлы Kad (сессия)"
 
-#: src/muuli_wdr.cpp:1870 src/muuli_wdr.cpp:2324
+#: src/muuli_wdr.cpp:1869 src/muuli_wdr.cpp:2296
 msgid "Select"
 msgstr "Выбрать"
 
-#: src/muuli_wdr.cpp:1874
+#: src/muuli_wdr.cpp:1873
 msgid "Tree"
 msgstr "Дерево"
 
-#: src/muuli_wdr.cpp:1884
+#: src/muuli_wdr.cpp:1883
 msgid "Number of Client Versions shown (0=unlimited)"
 msgstr "Число отображаемых версий клиентов (0=неогр.)"
 
-#: src/muuli_wdr.cpp:1909
+#: src/muuli_wdr.cpp:1908
 msgid "!!! WARNING !!!"
 msgstr "!!! ВНИМАНИЕ !!!"
 
-#: src/muuli_wdr.cpp:1924
+#: src/muuli_wdr.cpp:1923
 msgid "Max new connections / 5 secs"
 msgstr "Предел количества новых соединений за 5 секунд"
 
-#: src/muuli_wdr.cpp:1926
+#: src/muuli_wdr.cpp:1925
 msgid "Concurrent Kad source lookups"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1928
+#: src/muuli_wdr.cpp:1927
 #, fuzzy
 msgid "Kad source re-search interval (minutes)"
 msgstr "Интервал обновления через FTP в минутах"
 
-#: src/muuli_wdr.cpp:1930
+#: src/muuli_wdr.cpp:1929
 #, fuzzy
 msgid "Source re-ask interval (minutes)"
 msgstr "Интервал обновления через FTP в минутах"
 
-#: src/muuli_wdr.cpp:1934
+#: src/muuli_wdr.cpp:1933
 msgid "File Buffer Size: 240000 bytes"
 msgstr "Размер буфера: 240000 байт"
 
-#: src/muuli_wdr.cpp:1938
+#: src/muuli_wdr.cpp:1937
 msgid "Use MMAP: memory-mapped file access (lower memory use)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1939
+#: src/muuli_wdr.cpp:1938
 msgid "Maps part files into memory instead of buffering them on the heap, lowering the process memory footprint. May reduce download speed on some disks; best for memory-constrained or upload-heavy hosts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1941
+#: src/muuli_wdr.cpp:1940
 msgid "Upload Queue Size: 5000 clients"
 msgstr "Размер очереди: 5000 клиентов"
 
-#: src/muuli_wdr.cpp:1945
+#: src/muuli_wdr.cpp:1944
 msgid "Server connection refresh interval: Disable"
 msgstr "Интервал обновления соединения с сервером: Отключено"
 
-#: src/muuli_wdr.cpp:1949
+#: src/muuli_wdr.cpp:1948
 msgid "Disable computer's timed standby mode"
 msgstr "Отключить засыпание компьютера"
 
 # в LA помнится так и перевели - "шкурка", но по-моему глупо.
-#: src/muuli_wdr.cpp:1968
+#: src/muuli_wdr.cpp:1967
 msgid "Skin to use: "
 msgstr "Скин:"
 
-#: src/muuli_wdr.cpp:1977
+#: src/muuli_wdr.cpp:1976
 msgid "Show \"Fast eD2k Links Handler\" in every window."
 msgstr "Показывать строку \"быстрой загрузки\" в каждой вкладке."
 
-#: src/muuli_wdr.cpp:1980
+#: src/muuli_wdr.cpp:1979
 msgid "Show extended info on categories tabs"
 msgstr "Показывать дополнительную информацию на закладках категорий"
 
-#: src/muuli_wdr.cpp:1983
+#: src/muuli_wdr.cpp:1982
 #, fuzzy
 msgid "Show application version on title"
 msgstr "Выводить скорость передачи в заголовке"
 
-#: src/muuli_wdr.cpp:1985
+#: src/muuli_wdr.cpp:1984
 msgid "Show transfer rates on title"
 msgstr "Выводить скорость передачи в заголовке"
 
-#: src/muuli_wdr.cpp:1987
+#: src/muuli_wdr.cpp:1986
 msgid "Before application name"
 msgstr "Перед именем приложения"
 
-#: src/muuli_wdr.cpp:1989
+#: src/muuli_wdr.cpp:1988
 msgid "After application name"
 msgstr "После имени приложения"
 
-#: src/muuli_wdr.cpp:1992
+#: src/muuli_wdr.cpp:1991
 msgid "Show overhead bandwidth"
 msgstr "Показывать скорость служебного трафика"
 
-#: src/muuli_wdr.cpp:1996
+#: src/muuli_wdr.cpp:1995
 msgid "Vertical toolbar orientation"
 msgstr "Вертикальное расположение панели инструментов"
 
-#: src/muuli_wdr.cpp:1998
+#: src/muuli_wdr.cpp:1997
 msgid "Live column sorting (auto-reorder rows as their values change)"
 msgstr ""
 
 # This is the heading for the preference options regarding the files in the
 # transfer list.
-#: src/muuli_wdr.cpp:2005
+#: src/muuli_wdr.cpp:2004
 msgid "Download Queue Files"
 msgstr "Загружаемые файлы"
 
-#: src/muuli_wdr.cpp:2008
+#: src/muuli_wdr.cpp:2007
 msgid "Show progress percentage"
 msgstr "Показывать процент загрузки"
 
-#: src/muuli_wdr.cpp:2014
+#: src/muuli_wdr.cpp:2013
 msgid "Show progress bar"
 msgstr "Показывать полосу выполнения"
 
-#: src/muuli_wdr.cpp:2017
+#: src/muuli_wdr.cpp:2016
 msgid "Flat"
 msgstr "Плоская"
 
-#: src/muuli_wdr.cpp:2021
+#: src/muuli_wdr.cpp:2020
 msgid "Round"
 msgstr "Круглая"
 
-#: src/muuli_wdr.cpp:2039
+#: src/muuli_wdr.cpp:2038
 msgid "External Connection Parameters"
 msgstr "Параметры внешних соединений"
 
-#: src/muuli_wdr.cpp:2042
+#: src/muuli_wdr.cpp:2041
 msgid "Accept external connections"
 msgstr "Принимать внешние соединения"
 
-#: src/muuli_wdr.cpp:2049 src/muuli_wdr.cpp:2108
+#: src/muuli_wdr.cpp:2048 src/muuli_wdr.cpp:2107
 msgid "IP of the listening interface:"
 msgstr "IP прослушиваемого интерфейса:"
 
-#: src/muuli_wdr.cpp:2052
+#: src/muuli_wdr.cpp:2051
 msgid "Enter here a valid ip in the a.b.c.d format for the listening EC interface. An empty field or 0.0.0.0 will mean any interface."
 msgstr "Введите сюда IP в формате a.b.c.d для прослушиваемого интерфейса ВС. Пустое поле или значение 0.0.0.0 означают любой интерфейс."
 
-#: src/muuli_wdr.cpp:2073 src/muuli_wdr.cpp:2184
+#: src/muuli_wdr.cpp:2072 src/muuli_wdr.cpp:2156
 msgid "TCP port:"
 msgstr "порт TCP:"
 
-#: src/muuli_wdr.cpp:2079
+#: src/muuli_wdr.cpp:2078
 msgid "Enable UPnP port forwarding on the EC port"
 msgstr "Включить UPnP для порта ВС"
 
-#: src/muuli_wdr.cpp:2083 src/muuli_wdr.cpp:3069
+#: src/muuli_wdr.cpp:2082 src/muuli_wdr.cpp:3041
 #: src/utils/wxCas/src/wxcasprefs.cpp:167
 msgid "Password"
 msgstr "Пароль"
 
-#: src/muuli_wdr.cpp:2089
+#: src/muuli_wdr.cpp:2088
 #, fuzzy
 msgid "aMule API server parameters"
 msgstr "Параметры веб-сервера"
 
-#: src/muuli_wdr.cpp:2092
+#: src/muuli_wdr.cpp:2091
 msgid "Run amuleapi (REST API) on startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2097
+#: src/muuli_wdr.cpp:2096
 #, fuzzy
 msgid "HTTP port:"
 msgstr "порт TCP:"
 
-#: src/muuli_wdr.cpp:2111
+#: src/muuli_wdr.cpp:2110
 msgid "The interface amuleapi's HTTP server listens on. 127.0.0.1 (default) accepts only local connections; use 0.0.0.0 or a specific IP to expose it to other hosts (set an admin password below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2116
-msgid "Type a password to set or change it. Stored passwords cannot be shown, so leaving this empty keeps the current one."
-msgstr ""
-
-#: src/muuli_wdr.cpp:2118
+#: src/muuli_wdr.cpp:2113
 #, fuzzy
 msgid "Admin password"
 msgstr "Проверяю пароль\n"
 
-#: src/muuli_wdr.cpp:2130 src/muuli_wdr.cpp:2147 src/PrefsUnifiedDlg.cpp:1103
-#, fuzzy
-msgid "A password is set."
-msgstr "Проверяю пароль\n"
+#: src/muuli_wdr.cpp:2118 src/muuli_wdr.cpp:2149
+msgid "Low rights password"
+msgstr "Пароль ограниченного доступа"
 
-#: src/muuli_wdr.cpp:2134
-#, fuzzy
-msgid "Enable guest access"
-msgstr "Запрещать ограниченный доступ"
-
-#: src/muuli_wdr.cpp:2135
-msgid "Guest sessions may read status and listings but cannot change anything. Turning this off clears the stored guest password."
-msgstr ""
-
-#: src/muuli_wdr.cpp:2139
-#, fuzzy
-msgid "Guest password"
-msgstr "Пароль веб-сервера для ограниченного доступа"
-
-#: src/muuli_wdr.cpp:2154
+#: src/muuli_wdr.cpp:2126
 msgid "Web server parameters"
 msgstr "Параметры веб-сервера"
 
-#: src/muuli_wdr.cpp:2157
+#: src/muuli_wdr.cpp:2129
 #, fuzzy
 msgid "Run webserver on startup (deprecated)"
 msgstr "Запускать веб-сервер при старте"
 
-#: src/muuli_wdr.cpp:2163
+#: src/muuli_wdr.cpp:2135
 msgid "Web template"
 msgstr "Веб-шаблон"
 
-#: src/muuli_wdr.cpp:2168
+#: src/muuli_wdr.cpp:2140
 msgid "Full rights password"
 msgstr "Пароль для обычного доступа"
 
-#: src/muuli_wdr.cpp:2172
+#: src/muuli_wdr.cpp:2144
 msgid "Enable Low rights User"
 msgstr "Разрешить ограниченный доступ"
 
-#: src/muuli_wdr.cpp:2177
-msgid "Low rights password"
-msgstr "Пароль ограниченного доступа"
-
-#: src/muuli_wdr.cpp:2191
+#: src/muuli_wdr.cpp:2163
 msgid "Enable UPnP port forwarding of the web server port"
 msgstr "Разрешить UPnP форвардинг порта веб-сервера"
 
-#: src/muuli_wdr.cpp:2196
+#: src/muuli_wdr.cpp:2168
 msgid "Web server UPnP TCP port (Optional)"
 msgstr "UPnP TCP порт веб-сервера (не обязательно):"
 
-#: src/muuli_wdr.cpp:2204
+#: src/muuli_wdr.cpp:2176
 msgid "Page Refresh Time (in secs)"
 msgstr "Период обновления страницы (в секундах)"
 
-#: src/muuli_wdr.cpp:2211
+#: src/muuli_wdr.cpp:2183
 msgid "Enable Gzip compression"
 msgstr "Включить сжатие Gzip"
 
-#: src/muuli_wdr.cpp:2245
+#: src/muuli_wdr.cpp:2217
 #, fuzzy
 msgid "Reset page to defaults"
 msgstr "Системный"
 
-#: src/muuli_wdr.cpp:2246
+#: src/muuli_wdr.cpp:2218
 msgid "Reset the settings on the current page to their default values."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2248 src/muuli_wdr.cpp:2334 src/ServerWnd.cpp:274
+#: src/muuli_wdr.cpp:2220 src/muuli_wdr.cpp:2306 src/ServerWnd.cpp:274
 #: src/ServerWnd.cpp:282
 msgid "OK"
 msgstr "ОК"
 
-#: src/muuli_wdr.cpp:2250
+#: src/muuli_wdr.cpp:2222
 msgid "Click here to apply any changes made to the preferences."
 msgstr "Кликните тут, чтобы сохранить внесенные вами изменения."
 
-#: src/muuli_wdr.cpp:2253
+#: src/muuli_wdr.cpp:2225
 msgid "Reset any changes made to the preferences."
 msgstr "Сбросить все изменения, внесенные вами."
 
-#: src/muuli_wdr.cpp:2282
+#: src/muuli_wdr.cpp:2254
 msgid "Comment :"
 msgstr "Комментарий :"
 
-#: src/muuli_wdr.cpp:2289
+#: src/muuli_wdr.cpp:2261
 msgid "Incoming Dir :"
 msgstr "Каталог загрузок:"
 
-#: src/muuli_wdr.cpp:2298
+#: src/muuli_wdr.cpp:2270
 msgid "Change priority for new assigned files :"
 msgstr "Установить приоритет для новых файлов:"
 
-#: src/muuli_wdr.cpp:2302
+#: src/muuli_wdr.cpp:2274
 msgid "Don't change"
 msgstr "Не изменять"
 
-#: src/muuli_wdr.cpp:2314
+#: src/muuli_wdr.cpp:2286
 msgid "Select color for this Category (currently selected) :"
 msgstr "Выбрать цвет для этой категории:"
 
-#: src/muuli_wdr.cpp:2381 src/muuli_wdr.cpp:2400 src/muuli_wdr.cpp:2422
+#: src/muuli_wdr.cpp:2353 src/muuli_wdr.cpp:2372 src/muuli_wdr.cpp:2394
 msgid "Click this button to reset the log."
 msgstr "Кликните тут для очистки журнала."
 
-#: src/muuli_wdr.cpp:2441
+#: src/muuli_wdr.cpp:2413
 msgid "Click on this button to update the servers list from URL ..."
 msgstr "Кликните здесь чтобы обновить список серверов через URL ..."
 
-#: src/muuli_wdr.cpp:2445
+#: src/muuli_wdr.cpp:2417
 msgid "Server list"
 msgstr "Список серверов"
 
-#: src/muuli_wdr.cpp:2449
+#: src/muuli_wdr.cpp:2421
 msgid "Enter the url to a server.met file here and press the button to the left to update the list of known servers."
 msgstr "Введите URL к файлу 'server.met' и нажмите кнопку слева для обновления списка известных серверов."
 
-#: src/muuli_wdr.cpp:2454
+#: src/muuli_wdr.cpp:2426
 msgid "Add server manually: Name"
 msgstr "Добавить сервер вручную: Имя"
 
-#: src/muuli_wdr.cpp:2457
+#: src/muuli_wdr.cpp:2429
 msgid "Enter the name of the new server here"
 msgstr "Введите имя нового сервера"
 
-#: src/muuli_wdr.cpp:2459 src/ServerWnd.cpp:206
+#: src/muuli_wdr.cpp:2431 src/ServerWnd.cpp:206
 msgid "IP:Port"
 msgstr "IP:Порт"
 
-#: src/muuli_wdr.cpp:2462
+#: src/muuli_wdr.cpp:2434
 msgid "Enter the IP of the server here, using the x.x.x.x format."
 msgstr "Введите здесь IP-адрес сервера в формате: x.x.x.x"
 
-#: src/muuli_wdr.cpp:2468
+#: src/muuli_wdr.cpp:2440
 msgid "Enter the port of the server here."
 msgstr "Введите здесь порт сервера."
 
-#: src/muuli_wdr.cpp:2471
+#: src/muuli_wdr.cpp:2443
 msgid "Add manually a server (fill fields to the left before) ..."
 msgstr "Добавить сервер (предварительно заполните поля слева) ..."
 
-#: src/muuli_wdr.cpp:2500
+#: src/muuli_wdr.cpp:2472
 msgid "aMule Log"
 msgstr "Журнал aMule"
 
-#: src/muuli_wdr.cpp:2508
+#: src/muuli_wdr.cpp:2480
 msgid "Server Info"
 msgstr "Сообщение сервера"
 
-#: src/muuli_wdr.cpp:2512
+#: src/muuli_wdr.cpp:2484
 msgid "ED2K Info"
 msgstr "Инфо ED2K"
 
-#: src/muuli_wdr.cpp:2516
+#: src/muuli_wdr.cpp:2488
 msgid "Kad Info"
 msgstr "Инфо Kad"
 
-#: src/muuli_wdr.cpp:2544
+#: src/muuli_wdr.cpp:2516
 msgid "Click on this button to update the nodes list from URL ..."
 msgstr "Нажмите на эту кнопку чтобы обновить список узлов из URL..."
 
-#: src/muuli_wdr.cpp:2548
+#: src/muuli_wdr.cpp:2520
 msgid "Nodes (0)"
 msgstr "Узлы (0)"
 
-#: src/muuli_wdr.cpp:2552
+#: src/muuli_wdr.cpp:2524
 msgid "Enter the url to a nodes.dat file here and press the button to the left to update the list of known nodes."
 msgstr "Ведите сюда URL к файлу nodes.dat и нажмите кнопку слева чтобы обновить список известных узлов."
 
-#: src/muuli_wdr.cpp:2555
+#: src/muuli_wdr.cpp:2527
 msgid "Nodes stats"
 msgstr "Статистика узлов"
 
-#: src/muuli_wdr.cpp:2597
+#: src/muuli_wdr.cpp:2569
 msgid "Bootstrap"
 msgstr "Инициализация"
 
-#: src/muuli_wdr.cpp:2600
+#: src/muuli_wdr.cpp:2572
 msgid "New node"
 msgstr "Новый узел"
 
-#: src/muuli_wdr.cpp:2605
+#: src/muuli_wdr.cpp:2577
 msgid "IP:"
 msgstr "IP:"
 
-#: src/muuli_wdr.cpp:2625
+#: src/muuli_wdr.cpp:2597
 msgid "Port:"
 msgstr "Порт:"
 
 # Похоже, bootstrap в eMule перевели как инициализация
-#: src/muuli_wdr.cpp:2638
+#: src/muuli_wdr.cpp:2610
 msgid "Bootstrap from known clients"
 msgstr "Инициализация от известных клиентов"
 
-#: src/muuli_wdr.cpp:2640
+#: src/muuli_wdr.cpp:2612
 msgid "Disconnect Kad"
 msgstr "Отключить Kad"
 
-#: src/muuli_wdr.cpp:2674
+#: src/muuli_wdr.cpp:2646
 msgid "Use Secure User Identification"
 msgstr "Использовать безопасную идентификацию пользователя"
 
 # интересно, что на самом деле подразумевалось под 'credits'
-#: src/muuli_wdr.cpp:2676
+#: src/muuli_wdr.cpp:2648
 msgid "It is recommended to enable this option. You will not receive credits if SUI is not enabled."
 msgstr "Рекомендуется включить данную опцию. Вы не будете получать рейтинга если БИП выключена."
 
-#: src/muuli_wdr.cpp:2678
+#: src/muuli_wdr.cpp:2650
 msgid "Protocol Obfuscation"
 msgstr "Вуалирование протокола"
 
-#: src/muuli_wdr.cpp:2681
+#: src/muuli_wdr.cpp:2653
 msgid "Support Protocol Obfuscation"
 msgstr "Поддержка вуалирования протокола"
 
-#: src/muuli_wdr.cpp:2683
+#: src/muuli_wdr.cpp:2655
 msgid "This option enabled Protocol Obfuscation, and makes aMule accept obfuscated connections from other clients."
 msgstr "Включает вуалирование протокола и позволяет aMule принимать завуалированные соединения от других клиентов."
 
-#: src/muuli_wdr.cpp:2685
+#: src/muuli_wdr.cpp:2657
 msgid "Use obfuscation for outgoing connections"
 msgstr "Использовать вуалирование исходящих соединений"
 
-#: src/muuli_wdr.cpp:2687
+#: src/muuli_wdr.cpp:2659
 msgid "This option makes aMule use Protocol Obfuscation when connecting other clients/servers."
 msgstr "Включает вуалирование протокола при соединении с другими клиентами и серверами."
 
-#: src/muuli_wdr.cpp:2689
+#: src/muuli_wdr.cpp:2661
 msgid "Accept only obfuscated connections"
 msgstr "Принимать только завуалированные соединения"
 
-#: src/muuli_wdr.cpp:2690
+#: src/muuli_wdr.cpp:2662
 msgid "This option makes aMule only accept obfuscated connections. You will have less sources, but all your traffic will be obfuscated"
 msgstr "aMule будет принимать только завуалированные соединения. У вас будет меньше источников, но зато весь трафик будет завуалирован."
 
-#: src/muuli_wdr.cpp:2695
+#: src/muuli_wdr.cpp:2667
 msgid "Everybody"
 msgstr "Все"
 
-#: src/muuli_wdr.cpp:2697
+#: src/muuli_wdr.cpp:2669
 msgid "No one"
 msgstr "Никто"
 
-#: src/muuli_wdr.cpp:2699
+#: src/muuli_wdr.cpp:2671
 msgid "Who can see my shared files:"
 msgstr "Кто может запрашивать публикуемые файлы:"
 
-#: src/muuli_wdr.cpp:2700
+#: src/muuli_wdr.cpp:2672
 msgid "Select who can request to view a list of your shared files."
 msgstr "Выберите, кому показывать список ваших файлов."
 
-#: src/muuli_wdr.cpp:2702
+#: src/muuli_wdr.cpp:2674
 msgid "IP-Filtering"
 msgstr "Фильтрование IP"
 
-#: src/muuli_wdr.cpp:2709
+#: src/muuli_wdr.cpp:2681
 msgid "Filter clients"
 msgstr "Фильтровать клиентов."
 
-#: src/muuli_wdr.cpp:2711
+#: src/muuli_wdr.cpp:2683
 msgid "Enable filtering of the client IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "Включает фильтрацию IP клиентов в соответствии с файлом ~/.aMule/ipfilter.dat."
 
-#: src/muuli_wdr.cpp:2713
+#: src/muuli_wdr.cpp:2685
 msgid "Filter servers"
 msgstr "Фильтровать сервера"
 
-#: src/muuli_wdr.cpp:2715
+#: src/muuli_wdr.cpp:2687
 msgid "Enable filtering of the server IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "Включает фильтрацию IP серверов в соответствии с файлом ~/.aMule/ipfilter.dat."
 
-#: src/muuli_wdr.cpp:2719
+#: src/muuli_wdr.cpp:2691
 msgid "Reload List"
 msgstr "Обновить список"
 
-#: src/muuli_wdr.cpp:2720
+#: src/muuli_wdr.cpp:2692
 msgid "Reload the list of IPs to filter from the file ~/.aMule/ipfilter.dat"
 msgstr "Прочесть список IP адресов, указанных в файле '~/.aMule/ipfilter.dat'."
 
-#: src/muuli_wdr.cpp:2726
+#: src/muuli_wdr.cpp:2698
 msgid "URL:"
 msgstr "URL:"
 
-#: src/muuli_wdr.cpp:2730 src/muuli_wdr.cpp:2923
+#: src/muuli_wdr.cpp:2702 src/muuli_wdr.cpp:2895
 msgid "Update now"
 msgstr "Обновить сейчас"
 
-#: src/muuli_wdr.cpp:2733
+#: src/muuli_wdr.cpp:2705
 msgid "Auto-update ipfilter at startup"
 msgstr "Автоматически обновлять IP-фильтр при запуске"
 
-#: src/muuli_wdr.cpp:2737
+#: src/muuli_wdr.cpp:2709
 msgid "Filtering Level:"
 msgstr "Уровень фильтрации:"
 
-#: src/muuli_wdr.cpp:2743
+#: src/muuli_wdr.cpp:2715
 msgid "Always filter LAN IPs"
 msgstr "Всегда фильтровать IP-адреса LAN"
 
-#: src/muuli_wdr.cpp:2746
+#: src/muuli_wdr.cpp:2718
 msgid "Paranoid handling of non-matching IPs"
 msgstr "Параноидная обработка несовпадающих IP "
 
-#: src/muuli_wdr.cpp:2748
+#: src/muuli_wdr.cpp:2720
 msgid "Rejects a packet when its source IP differs from the IP the client claims (an anti-spoofing check). Disable only if it causes connection problems."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2750
+#: src/muuli_wdr.cpp:2722
 msgid "Use system-wide ipfilter.dat if available"
 msgstr "Использовать системный ipfilter.dat если возможно"
 
-#: src/muuli_wdr.cpp:2751
+#: src/muuli_wdr.cpp:2723
 #, fuzzy
 msgid "If there's no local ipfilter.dat found, allow usage of a system-wide ipfilter file."
 msgstr "Если не найден локальный ipfilter.dat разрешить использовать системный"
 
-#: src/muuli_wdr.cpp:2768
+#: src/muuli_wdr.cpp:2740
 msgid "Enable Online-Signature"
 msgstr "Включить Online-подпись"
 
-#: src/muuli_wdr.cpp:2770
+#: src/muuli_wdr.cpp:2742
 msgid "Enables the writing of the OS file, which can be used by external apps to create signatures and the like."
 msgstr "Включает запись файла OS, который может использоваться другими приложениями для создания подписей."
 
-#: src/muuli_wdr.cpp:2774
+#: src/muuli_wdr.cpp:2746
 msgid "Update Frequency (Secs):"
 msgstr "Частота обновления (в секундах):"
 
-#: src/muuli_wdr.cpp:2777
+#: src/muuli_wdr.cpp:2749
 msgid "Change the frequency (in seconds) of Online Signature updates."
 msgstr "Изменить частоту обновления для Online-подписи в секундах."
 
-#: src/muuli_wdr.cpp:2785
+#: src/muuli_wdr.cpp:2757
 msgid "Save online signature file in: "
 msgstr "Сохранять Online-подпись в:"
 
-#: src/muuli_wdr.cpp:2791
+#: src/muuli_wdr.cpp:2763
 msgid "Click here to select the directory containing the the Online Signature files."
 msgstr "Кликните здесь, чтобы выбрать каталок для файлов Online-подписи."
 
-#: src/muuli_wdr.cpp:2824
+#: src/muuli_wdr.cpp:2796
 msgid "Show country flags for clients"
 msgstr "Показывать национальные флаги клиентов"
 
-#: src/muuli_wdr.cpp:2825
+#: src/muuli_wdr.cpp:2797
 msgid "Render the country flag column in the transfers, queue and search views. Requires a valid MMDB GeoIP database (see below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2830
+#: src/muuli_wdr.cpp:2802
 #, fuzzy
 msgid "Database"
 msgstr "Скорость передачи:"
 
-#: src/muuli_wdr.cpp:2846
+#: src/muuli_wdr.cpp:2818
 #, fuzzy
 msgid "Source:"
 msgstr "Источники"
 
-#: src/muuli_wdr.cpp:2849
+#: src/muuli_wdr.cpp:2821
 msgid "DB-IP (free, no account)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2850
+#: src/muuli_wdr.cpp:2822
 msgid "MaxMind GeoLite2 (free, account required)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2851
+#: src/muuli_wdr.cpp:2823
 msgid "Custom URL"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2854
+#: src/muuli_wdr.cpp:2826
 msgid "Choose which provider supplies the GeoIP MMDB database. DB-IP is the default - no account required. MaxMind requires a free account + license key. Use Custom URL to point at any other MMDB host (e.g. a local mirror)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2871
+#: src/muuli_wdr.cpp:2843
 msgid ""
 "No configuration required.\n"
 "\n"
@@ -4914,11 +4880,11 @@ msgid ""
 "License: Creative Commons BY 4.0 - https://creativecommons.org/licenses/by/4.0/"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2884
+#: src/muuli_wdr.cpp:2856
 msgid "License key:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2890
+#: src/muuli_wdr.cpp:2862
 msgid ""
 "Sign up for a free MaxMind account, then generate a License Key:\n"
 "https://www.maxmind.com/en/geolite2/signup\n"
@@ -4928,227 +4894,227 @@ msgid ""
 "Requires attribution and account registration; refresh at least every 30 days."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2905
+#: src/muuli_wdr.cpp:2877
 #, fuzzy
 msgid "Download URL:"
 msgstr "Прием: "
 
-#: src/muuli_wdr.cpp:2911
+#: src/muuli_wdr.cpp:2883
 msgid ""
 "Must point to an .mmdb file or a .gz / .tar.gz containing one.\n"
 "URL may include credentials (https://user:pass@host/...).\n"
 "License and attribution terms are set by the upstream URL - you are responsible."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2924
+#: src/muuli_wdr.cpp:2896
 msgid "Download the GeoIP database from the selected source."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2926
+#: src/muuli_wdr.cpp:2898
 #, fuzzy
 msgid "Auto-update on startup"
 msgstr "Автоматически обновлять IP-фильтр при запуске"
 
-#: src/muuli_wdr.cpp:2927
+#: src/muuli_wdr.cpp:2899
 msgid "Re-download the GeoIP database from the selected source every time aMule starts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2950
+#: src/muuli_wdr.cpp:2922
 msgid "Filter incoming messages (except current chat):"
 msgstr "Фильтровать входящие сообщения (кроме текущего чата):"
 
-#: src/muuli_wdr.cpp:2952
+#: src/muuli_wdr.cpp:2924
 msgid "Filter all messages"
 msgstr "Фильтровать все сообщения"
 
-#: src/muuli_wdr.cpp:2954
+#: src/muuli_wdr.cpp:2926
 msgid "Filter messages from people not on your friend list"
 msgstr "Фильтровать сообщения пользователей не из вашего списка друзей"
 
-#: src/muuli_wdr.cpp:2956
+#: src/muuli_wdr.cpp:2928
 msgid "Filter messages from unknown clients"
 msgstr "Фильтровать сообщения от неизвестных клиентов"
 
-#: src/muuli_wdr.cpp:2958
+#: src/muuli_wdr.cpp:2930
 msgid "Filter messages containing (use ',' as separator):"
 msgstr "Фильтровать сообщения по содержанию (используйте ',' как разделитель):"
 
-#: src/muuli_wdr.cpp:2961 src/muuli_wdr.cpp:2972
+#: src/muuli_wdr.cpp:2933 src/muuli_wdr.cpp:2944
 msgid "add here the words amule should filter and block messages including it"
 msgstr "Добавьте сюда ключевые слова, при наличии которых aMule будет отфильтровывать и блокировать входящие сообщения."
 
-#: src/muuli_wdr.cpp:2963
+#: src/muuli_wdr.cpp:2935
 msgid "Show received messages in the log"
 msgstr "Показывать полученные сообщения в логе"
 
-#: src/muuli_wdr.cpp:2966
+#: src/muuli_wdr.cpp:2938
 msgid "Comments"
 msgstr "Комментарии"
 
-#: src/muuli_wdr.cpp:2969
+#: src/muuli_wdr.cpp:2941
 msgid "Filter comments containing (use ',' as separator):"
 msgstr "Фильтровать комментарии содержащие (используйте ',' как разделитель):"
 
-#: src/muuli_wdr.cpp:2994
+#: src/muuli_wdr.cpp:2966
 msgid "Enable Proxy"
 msgstr "Использовать прокси-сервер"
 
-#: src/muuli_wdr.cpp:2995
+#: src/muuli_wdr.cpp:2967
 msgid "Enable/disable proxy support"
 msgstr "Включить/выключить поддержку прокси-сервера"
 
-#: src/muuli_wdr.cpp:2998
+#: src/muuli_wdr.cpp:2970
 msgid "Proxy type:"
 msgstr "Тип прокси-сервера:"
 
-#: src/muuli_wdr.cpp:3009
+#: src/muuli_wdr.cpp:2981
 msgid "Proxy host:"
 msgstr "Прокси-сервер:"
 
-#: src/muuli_wdr.cpp:3012
+#: src/muuli_wdr.cpp:2984
 msgid "The proxy host name"
 msgstr "Имя прокси-сервера"
 
-#: src/muuli_wdr.cpp:3014
+#: src/muuli_wdr.cpp:2986
 msgid "Proxy port:"
 msgstr "Порт:"
 
-#: src/muuli_wdr.cpp:3017
+#: src/muuli_wdr.cpp:2989
 msgid "The proxy port"
 msgstr "Порт прокси-сервера"
 
-#: src/muuli_wdr.cpp:3019
+#: src/muuli_wdr.cpp:2991
 msgid "Enable authentication"
 msgstr "Включить идентификацию"
 
-#: src/muuli_wdr.cpp:3020
+#: src/muuli_wdr.cpp:2992
 msgid "Enable/disable username/password authentication"
 msgstr "Включить/выключить использование пароля и логина"
 
-#: src/muuli_wdr.cpp:3023
+#: src/muuli_wdr.cpp:2995
 msgid "Username: "
 msgstr "Имя:"
 
-#: src/muuli_wdr.cpp:3026
+#: src/muuli_wdr.cpp:2998
 msgid "The username to use to connect to the proxy"
 msgstr "Имя пользователя для подключения к прокси-серверу"
 
-#: src/muuli_wdr.cpp:3028
+#: src/muuli_wdr.cpp:3000
 msgid "Password:"
 msgstr "Пароль:"
 
-#: src/muuli_wdr.cpp:3031
+#: src/muuli_wdr.cpp:3003
 msgid "The password to use to connect to the proxy"
 msgstr "Пароль для подключения к прокси-серверу"
 
-#: src/muuli_wdr.cpp:3050
+#: src/muuli_wdr.cpp:3022
 msgid "Connect to:"
 msgstr "Соединиться с:"
 
-#: src/muuli_wdr.cpp:3059
+#: src/muuli_wdr.cpp:3031
 msgid "Login to remote amule"
 msgstr "Войти на удаленный aMule"
 
-#: src/muuli_wdr.cpp:3064
+#: src/muuli_wdr.cpp:3036
 msgid "User name"
 msgstr "Имя пользователя"
 
-#: src/muuli_wdr.cpp:3075
+#: src/muuli_wdr.cpp:3047
 msgid "Remember those settings"
 msgstr "Запомнить настройки"
 
-#: src/muuli_wdr.cpp:3078
+#: src/muuli_wdr.cpp:3050
 #, fuzzy
 msgid "Force ZLIB compression"
 msgstr "Использовать gzip-сжатие"
 
-#: src/muuli_wdr.cpp:3102
+#: src/muuli_wdr.cpp:3074
 msgid "Enable Verbose Debug-Logging."
 msgstr "Записывать в журнал подробные сообщения отладчика."
 
-#: src/muuli_wdr.cpp:3104
+#: src/muuli_wdr.cpp:3076
 #, fuzzy
 msgid "Only to Logfile"
 msgstr "&Открыть файл"
 
-#: src/muuli_wdr.cpp:3106
+#: src/muuli_wdr.cpp:3078
 msgid "Message Categories:"
 msgstr "Категории сообщений:"
 
-#: src/muuli_wdr.cpp:3130 src/PartFileConvertDlg.cpp:160
+#: src/muuli_wdr.cpp:3102 src/PartFileConvertDlg.cpp:160
 msgid "Waiting..."
 msgstr "Ожидание..."
 
-#: src/muuli_wdr.cpp:3150
+#: src/muuli_wdr.cpp:3122
 msgid "Add imports"
 msgstr "Добавить файлы"
 
-#: src/muuli_wdr.cpp:3153
+#: src/muuli_wdr.cpp:3125
 msgid "Retry selected"
 msgstr "Перезапустить выбранное"
 
-#: src/muuli_wdr.cpp:3155
+#: src/muuli_wdr.cpp:3127
 msgid "Remove selected"
 msgstr "Удалить выбранное"
 
-#: src/muuli_wdr.cpp:3218
+#: src/muuli_wdr.cpp:3190
 msgid "Event Types"
 msgstr "Типы Событий"
 
-#: src/muuli_wdr.cpp:3237
+#: src/muuli_wdr.cpp:3209
 msgid "Statistics and queued clients for selected file(s) : Session / All time"
 msgstr "Статистика и очередь клиентов для выбранных файлов: За сессию / За все время"
 
-#: src/muuli_wdr.cpp:3261
+#: src/muuli_wdr.cpp:3233
 msgid "Active Uploads"
 msgstr "Активные загрузки"
 
-#: src/muuli_wdr.cpp:3275
+#: src/muuli_wdr.cpp:3247
 msgid "Percent of total files"
 msgstr "Процент от всех файлов"
 
-#: src/muuli_wdr.cpp:3327
+#: src/muuli_wdr.cpp:3299
 msgid "Show Clients for"
 msgstr "Показать клиентов для"
 
-#: src/muuli_wdr.cpp:3329
+#: src/muuli_wdr.cpp:3301
 msgid "All files"
 msgstr "Все файлы"
 
-#: src/muuli_wdr.cpp:3332
+#: src/muuli_wdr.cpp:3304
 msgid "Selected files"
 msgstr "Выбранные файлы"
 
-#: src/muuli_wdr.cpp:3335
+#: src/muuli_wdr.cpp:3307
 msgid "Active uploads only"
 msgstr "Только активные передачи"
 
-#: src/muuli_wdr.cpp:3342
+#: src/muuli_wdr.cpp:3314
 msgid "Reload:"
 msgstr "Обновить:"
 
-#: src/muuli_wdr.cpp:3346
+#: src/muuli_wdr.cpp:3318
 msgid "Reload your shared files"
 msgstr "Обновить список публикуемых файлов"
 
-#: src/muuli_wdr.cpp:3409
+#: src/muuli_wdr.cpp:3381
 msgid "Send"
 msgstr "Отправить"
 
-#: src/muuli_wdr.cpp:3410
+#: src/muuli_wdr.cpp:3382
 msgid "Sends the specified message."
 msgstr "Отправить данное сообщение."
 
-#: src/muuli_wdr.cpp:3414
+#: src/muuli_wdr.cpp:3386
 msgid "Close this chat-session."
 msgstr "Закрыть данный чат."
 
-#: src/muuli_wdr.cpp:3437
+#: src/muuli_wdr.cpp:3409
 msgid "Connect to any server and/or Kad"
 msgstr "Соединиться с произвольным сервером и/или Kad"
 
 # подпись в главном окне. длинная просто не влезет.
-#: src/muuli_wdr.cpp:3443 src/SharedFilesCtrl.cpp:142 src/Statistics.cpp:941
+#: src/muuli_wdr.cpp:3415 src/SharedFilesCtrl.cpp:142 src/Statistics.cpp:941
 msgid "Shared Files"
 msgstr "Файлы"
 
@@ -5514,250 +5480,250 @@ msgstr "Загружено"
 msgid "ERROR: Failed to open partfile '%s'"
 msgstr "ОШИБКА: не удалось открыть частично закаченный '%s'"
 
-#: src/Preferences.cpp:701
+#: src/Preferences.cpp:673
 msgid "System default"
 msgstr "Системный"
 
-#: src/Preferences.cpp:702
+#: src/Preferences.cpp:674
 msgid "Albanian"
 msgstr "Албанский"
 
-#: src/Preferences.cpp:703
+#: src/Preferences.cpp:675
 msgid "Arabic"
 msgstr "Арабский"
 
-#: src/Preferences.cpp:704
+#: src/Preferences.cpp:676
 msgid "Asturian"
 msgstr "Астурианский"
 
-#: src/Preferences.cpp:705
+#: src/Preferences.cpp:677
 msgid "Basque"
 msgstr "Баскский"
 
-#: src/Preferences.cpp:706
+#: src/Preferences.cpp:678
 msgid "Bulgarian"
 msgstr "Болгарский"
 
-#: src/Preferences.cpp:707
+#: src/Preferences.cpp:679
 msgid "Catalan"
 msgstr "Каталонский"
 
-#: src/Preferences.cpp:708
+#: src/Preferences.cpp:680
 msgid "Chinese (Simplified)"
 msgstr "Китайский (упрощенный)"
 
-#: src/Preferences.cpp:709
+#: src/Preferences.cpp:681
 msgid "Chinese (Traditional)"
 msgstr "Китайский (традиционный)"
 
-#: src/Preferences.cpp:710
+#: src/Preferences.cpp:682
 msgid "Croatian"
 msgstr "Хорватский"
 
-#: src/Preferences.cpp:711
+#: src/Preferences.cpp:683
 msgid "Czech"
 msgstr "Чешский"
 
-#: src/Preferences.cpp:712
+#: src/Preferences.cpp:684
 msgid "Danish"
 msgstr "Датский"
 
-#: src/Preferences.cpp:713
+#: src/Preferences.cpp:685
 msgid "Dutch"
 msgstr "Голландский"
 
-#: src/Preferences.cpp:714
+#: src/Preferences.cpp:686
 msgid "English (U.K.)"
 msgstr "Английский (Великобритания)"
 
-#: src/Preferences.cpp:715
+#: src/Preferences.cpp:687
 #, fuzzy
 msgid "English (U.S.)"
 msgstr "Английский (Великобритания)"
 
-#: src/Preferences.cpp:716
+#: src/Preferences.cpp:688
 msgid "Estonian"
 msgstr "Эстонский"
 
-#: src/Preferences.cpp:717
+#: src/Preferences.cpp:689
 msgid "Finnish"
 msgstr "Финский"
 
-#: src/Preferences.cpp:718
+#: src/Preferences.cpp:690
 msgid "French"
 msgstr "Французский"
 
-#: src/Preferences.cpp:719
+#: src/Preferences.cpp:691
 msgid "Galician"
 msgstr "Гальский"
 
-#: src/Preferences.cpp:720
+#: src/Preferences.cpp:692
 msgid "German"
 msgstr "Немецкий"
 
-#: src/Preferences.cpp:721
+#: src/Preferences.cpp:693
 msgid "Greek"
 msgstr "Греческий"
 
-#: src/Preferences.cpp:722
+#: src/Preferences.cpp:694
 msgid "Hebrew"
 msgstr "Израильский"
 
-#: src/Preferences.cpp:723
+#: src/Preferences.cpp:695
 msgid "Hungarian"
 msgstr "Венгерский"
 
-#: src/Preferences.cpp:724
+#: src/Preferences.cpp:696
 msgid "Italian"
 msgstr "Итальянский"
 
-#: src/Preferences.cpp:725
+#: src/Preferences.cpp:697
 msgid "Japanese"
 msgstr "Японский"
 
-#: src/Preferences.cpp:726
+#: src/Preferences.cpp:698
 msgid "Korean"
 msgstr "Корейский"
 
-#: src/Preferences.cpp:727
+#: src/Preferences.cpp:699
 msgid "Latvian"
 msgstr ""
 
-#: src/Preferences.cpp:728
+#: src/Preferences.cpp:700
 msgid "Lithuanian"
 msgstr "Литовский"
 
-#: src/Preferences.cpp:729
+#: src/Preferences.cpp:701
 msgid "Norwegian (Nynorsk)"
 msgstr "Норвежский (Нюнорск)"
 
-#: src/Preferences.cpp:730
+#: src/Preferences.cpp:702
 msgid "Polish"
 msgstr "Польский"
 
-#: src/Preferences.cpp:731
+#: src/Preferences.cpp:703
 msgid "Portuguese"
 msgstr "Португальский"
 
-#: src/Preferences.cpp:732
+#: src/Preferences.cpp:704
 msgid "Portuguese (Brazilian)"
 msgstr "Португальский (Бразилия)"
 
-#: src/Preferences.cpp:733
+#: src/Preferences.cpp:705
 msgid "Romanian"
 msgstr "Румынский"
 
-#: src/Preferences.cpp:734
+#: src/Preferences.cpp:706
 msgid "Russian"
 msgstr "Русский"
 
-#: src/Preferences.cpp:735
+#: src/Preferences.cpp:707
 msgid "Slovenian"
 msgstr "Словакский"
 
-#: src/Preferences.cpp:736
+#: src/Preferences.cpp:708
 msgid "Spanish"
 msgstr "Испанский"
 
-#: src/Preferences.cpp:737
+#: src/Preferences.cpp:709
 msgid "Swedish"
 msgstr "Шведский"
 
-#: src/Preferences.cpp:738
+#: src/Preferences.cpp:710
 msgid "Turkish"
 msgstr "Турецкий"
 
-#: src/Preferences.cpp:739
+#: src/Preferences.cpp:711
 msgid "Ukrainian"
 msgstr "Украинский"
 
-#: src/Preferences.cpp:842
+#: src/Preferences.cpp:814
 msgid "Change Language"
 msgstr "Изменить язык"
 
-#: src/Preferences.cpp:906
+#: src/Preferences.cpp:878
 msgid "There are no translations installed for aMule"
 msgstr ""
 
-#: src/Preferences.cpp:907
+#: src/Preferences.cpp:879
 #, fuzzy
 msgid "No languages available"
 msgstr "Недоступен"
 
-#: src/Preferences.cpp:1038
+#: src/Preferences.cpp:1010
 msgid "no options available"
 msgstr "нет доступных опций"
 
-#: src/Preferences.cpp:2226
+#: src/Preferences.cpp:2179
 msgid "Invalid category found, skipping"
 msgstr "Обнаружена неверная категория, пропускаем"
 
-#: src/Preferences.cpp:2395
+#: src/Preferences.cpp:2348
 msgid "TCP port can't be higher than 65532 due to server UDP socket being TCP+3"
 msgstr "TCP порт не может быть выше 65532, так как UDP сокет - TCP+3"
 
-#: src/Preferences.cpp:2396
+#: src/Preferences.cpp:2349
 #, c-format
 msgid "Default port will be used (%d)"
 msgstr "Используется порт по умолчанию (%d)"
 
-#: src/PrefsUnifiedDlg.cpp:300 src/Statistics.cpp:866
+#: src/PrefsUnifiedDlg.cpp:298 src/Statistics.cpp:866
 msgid "Connection"
 msgstr "Соединение"
 
-#: src/PrefsUnifiedDlg.cpp:301 src/SearchListCtrl.cpp:117
+#: src/PrefsUnifiedDlg.cpp:299 src/SearchListCtrl.cpp:117
 msgid "Directories"
 msgstr "Каталоги"
 
-#: src/PrefsUnifiedDlg.cpp:302 src/Statistics.cpp:917
+#: src/PrefsUnifiedDlg.cpp:300 src/Statistics.cpp:917
 msgid "Servers"
 msgstr "Сервера"
 
-#: src/PrefsUnifiedDlg.cpp:303 src/ServerListCtrl.cpp:96
+#: src/PrefsUnifiedDlg.cpp:301 src/ServerListCtrl.cpp:96
 msgid "Files"
 msgstr "Файлы"
 
-#: src/PrefsUnifiedDlg.cpp:304
+#: src/PrefsUnifiedDlg.cpp:302
 msgid "Security"
 msgstr "Безопасность"
 
-#: src/PrefsUnifiedDlg.cpp:305
+#: src/PrefsUnifiedDlg.cpp:303
 msgid "Interface"
 msgstr "Интерфейс"
 
-#: src/PrefsUnifiedDlg.cpp:312
+#: src/PrefsUnifiedDlg.cpp:310
 msgid "IP2Country"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:315
+#: src/PrefsUnifiedDlg.cpp:313
 msgid "Proxy"
 msgstr "Прокси"
 
-#: src/PrefsUnifiedDlg.cpp:316
+#: src/PrefsUnifiedDlg.cpp:314
 msgid "Filters"
 msgstr "Фильтры"
 
-#: src/PrefsUnifiedDlg.cpp:317
+#: src/PrefsUnifiedDlg.cpp:315
 msgid "Remote Controls"
 msgstr "Удаленный контроль"
 
-#: src/PrefsUnifiedDlg.cpp:318
+#: src/PrefsUnifiedDlg.cpp:316
 msgid "Online Signature"
 msgstr "Online-подпись"
 
-#: src/PrefsUnifiedDlg.cpp:319
+#: src/PrefsUnifiedDlg.cpp:317
 msgid "Advanced"
 msgstr "Дополнительно"
 
-#: src/PrefsUnifiedDlg.cpp:320
+#: src/PrefsUnifiedDlg.cpp:318
 msgid "Events"
 msgstr "События"
 
-#: src/PrefsUnifiedDlg.cpp:323
+#: src/PrefsUnifiedDlg.cpp:321
 msgid "Debugging"
 msgstr "Отладчик"
 
-#: src/PrefsUnifiedDlg.cpp:453
+#: src/PrefsUnifiedDlg.cpp:451
 msgid ""
 "The following variables will be substituted:\n"
 "    %PARTFILE - full path to the file\n"
@@ -5767,15 +5733,15 @@ msgstr ""
 "   %PARTFILE - полный путь к файлу\n"
 "   %PARTNAME - только имя файла"
 
-#: src/PrefsUnifiedDlg.cpp:474
+#: src/PrefsUnifiedDlg.cpp:472
 msgid "Tray icon support requires libayatana-appindicator3 at compile time."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:490
+#: src/PrefsUnifiedDlg.cpp:488
 msgid "Not available on Wayland: the protocol does not report when a window is minimized, so this option cannot intercept the system minimize button. Workaround: launch aMule with `GDK_BACKEND=x11` to use XWayland instead."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:536
+#: src/PrefsUnifiedDlg.cpp:534
 msgid ""
 "Do not change these setting unless you know\n"
 "what you are doing, otherwise you can easily\n"
@@ -5791,35 +5757,26 @@ msgstr ""
 "aMule будет превосходно работать и БЕЗ ИЗМЕНЕНИЯ вами\n"
 "этих настроек."
 
-#: src/PrefsUnifiedDlg.cpp:647
+#: src/PrefsUnifiedDlg.cpp:645
 #, c-format
 msgid "Failed to connect Cfg to widget with the ID %d and key %s"
 msgstr "Не удалось подключить Cfg к widget с ID %d и ключом %s"
 
-#: src/PrefsUnifiedDlg.cpp:695
+#: src/PrefsUnifiedDlg.cpp:693
 #, c-format
 msgid "Failed to transfer data from Cfg to Widget with the ID %d and key %s"
 msgstr "Не удалось передать данные из Cfg к Widget с ID %d и ключом %s"
 
-#: src/PrefsUnifiedDlg.cpp:801
+#: src/PrefsUnifiedDlg.cpp:799
 msgid "The type of proxy you are connecting to"
 msgstr "Тип прокси-сервера, который вы используете"
 
-#: src/PrefsUnifiedDlg.cpp:1020
+#: src/PrefsUnifiedDlg.cpp:1003
 #, c-format
 msgid "Failed to transfer data from Widget to Cfg with the ID %d and key %s"
 msgstr "Не удалось передать данные из Widget к Cfg с ID %d и ключом %s"
 
 #: src/PrefsUnifiedDlg.cpp:1103
-#, fuzzy
-msgid "No password set."
-msgstr "Проверяю пароль\n"
-
-#: src/PrefsUnifiedDlg.cpp:1132
-msgid "Guest access needs a password. Type one in the guest password field, or untick Enable guest access."
-msgstr ""
-
-#: src/PrefsUnifiedDlg.cpp:1144
 msgid ""
 "aMule must be restarted to enable these changes:\n"
 "\n"
@@ -5827,42 +5784,42 @@ msgstr ""
 "Необходимо перезапустить aMule чтобы следующие изменения вступили в силу:\n"
 "\n"
 
-#: src/PrefsUnifiedDlg.cpp:1151
+#: src/PrefsUnifiedDlg.cpp:1110
 msgid "- TCP port changed.\n"
 msgstr "- изменен порт TCP.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1156
+#: src/PrefsUnifiedDlg.cpp:1115
 msgid "- UDP port changed.\n"
 msgstr "- изменен порт UDP.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1161
+#: src/PrefsUnifiedDlg.cpp:1120
 #, fuzzy
 msgid "- Network interface binding changed.\n"
 msgstr "- Интерфейс внешних соединений изменен.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1166
+#: src/PrefsUnifiedDlg.cpp:1125
 msgid "- External connect port changed.\n"
 msgstr "- Порт для внешних соединений изменен.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1170
+#: src/PrefsUnifiedDlg.cpp:1129
 msgid "- External connect acceptance changed.\n"
 msgstr "- Принятие внешних соединений изменено.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1174
+#: src/PrefsUnifiedDlg.cpp:1133
 msgid "- External connect interface changed.\n"
 msgstr "- Интерфейс внешних соединений изменен.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1178
+#: src/PrefsUnifiedDlg.cpp:1137
 #, fuzzy
 msgid "- Protocol obfuscation support changed.\n"
 msgstr "Вуалирование протокола"
 
-#: src/PrefsUnifiedDlg.cpp:1193
+#: src/PrefsUnifiedDlg.cpp:1151
 #, fuzzy
 msgid "- amuleapi settings changed.\n"
 msgstr "- Изменен язык.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1202
+#: src/PrefsUnifiedDlg.cpp:1160
 msgid ""
 "Your Auto-update server list is empty.\n"
 "'Auto-update server list at startup' will be disabled."
@@ -5870,7 +5827,7 @@ msgstr ""
 "Список авто обновления пуст.\n"
 "Автоматическое обновление списка серверов отключено."
 
-#: src/PrefsUnifiedDlg.cpp:1213
+#: src/PrefsUnifiedDlg.cpp:1171
 msgid ""
 "You have enabled external connections but have not specified a password.\n"
 "External connections cannot be enabled unless a valid password is specified."
@@ -5878,33 +5835,28 @@ msgstr ""
 "Вы включили внешние соединения, но не указали пароль.\n"
 "Внешние соединения нельзя включить до тех пор, пока не указан пароль."
 
-#: src/PrefsUnifiedDlg.cpp:1246
-#, c-format
-msgid "The amuleapi password could not be saved: %s"
-msgstr ""
-
-#: src/PrefsUnifiedDlg.cpp:1276
+#: src/PrefsUnifiedDlg.cpp:1202
 msgid "- Language changed.\n"
 msgstr "- Изменен язык.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1281
+#: src/PrefsUnifiedDlg.cpp:1207
 msgid "- Temp folder changed.\n"
 msgstr "- Изменен временный каталог.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1286
+#: src/PrefsUnifiedDlg.cpp:1212
 msgid "- ED2K network enabled.\n"
 msgstr "- сеть eD2k включена. \n"
 
-#: src/PrefsUnifiedDlg.cpp:1319
+#: src/PrefsUnifiedDlg.cpp:1245
 msgid "The shared-file exclusion pattern is not a valid regular expression. The filter has been left disabled."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1321 src/PrefsUnifiedDlg.cpp:1921
+#: src/PrefsUnifiedDlg.cpp:1247 src/PrefsUnifiedDlg.cpp:1841
 #, fuzzy
 msgid "Invalid regular expression"
 msgstr "Недопустимая версия протокола."
 
-#: src/PrefsUnifiedDlg.cpp:1398
+#: src/PrefsUnifiedDlg.cpp:1324
 msgid ""
 "Both eD2k and Kad network are disabled.\n"
 "You won't be able to connect until you enable at least one of them."
@@ -5912,7 +5864,7 @@ msgstr ""
 "Сети eD2k и Kad обе отключены.\n"
 "Вы не сможете подсоединиться пока не подключите хотя бы одну из них."
 
-#: src/PrefsUnifiedDlg.cpp:1403
+#: src/PrefsUnifiedDlg.cpp:1329
 msgid ""
 "Kad will not start if your UDP port is disabled.\n"
 "Enable UDP port or disable Kad."
@@ -5920,7 +5872,7 @@ msgstr ""
 "Kad не будет запущена, если UDP-порт выключен.\n"
 "Включите UDP-порт или выключите Kad."
 
-#: src/PrefsUnifiedDlg.cpp:1459
+#: src/PrefsUnifiedDlg.cpp:1385
 msgid ""
 "\n"
 "You MUST restart aMule now.\n"
@@ -5930,69 +5882,69 @@ msgstr ""
 "Вам НЕОБХОДИМО перезапустить aMule немедленно.\n"
 "Иначе не жалуйтесь, если произойдет какая-нибудь неприятность.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1524
+#: src/PrefsUnifiedDlg.cpp:1450
 msgid "Could not register aMule for autostart at login. The autostart store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1526
+#: src/PrefsUnifiedDlg.cpp:1452
 msgid "Could not remove the autostart-at-login entry."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1527
+#: src/PrefsUnifiedDlg.cpp:1453
 #, fuzzy
 msgid "Autostart"
 msgstr "Автоматическое обновление начато"
 
-#: src/PrefsUnifiedDlg.cpp:1542
+#: src/PrefsUnifiedDlg.cpp:1468
 msgid "Register file type"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1542
+#: src/PrefsUnifiedDlg.cpp:1468
 msgid "Register URL handler"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1550
+#: src/PrefsUnifiedDlg.cpp:1476
 #, c-format
 msgid "aMule only handles eD2k-compatible magnets. If you replace the current magnet handler (%s), BitTorrent magnet links will stop working - aMule cannot download BitTorrent content. Continue?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1555
+#: src/PrefsUnifiedDlg.cpp:1481
 #, c-format
 msgid "Another application currently opens .emulecollection files (%s). Replace it with aMule?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1560
+#: src/PrefsUnifiedDlg.cpp:1486
 #, c-format
 msgid "Another application is currently the default handler for these links (%s). Replace it with aMule?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1585
+#: src/PrefsUnifiedDlg.cpp:1511
 msgid "Could not register aMule for .emulecollection files. The registration store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1587
+#: src/PrefsUnifiedDlg.cpp:1513
 #, fuzzy
 msgid "Could not remove the file type registration."
 msgstr "Папка для временных файлов"
 
-#: src/PrefsUnifiedDlg.cpp:1589
+#: src/PrefsUnifiedDlg.cpp:1515
 msgid "Could not register aMule as the URL handler. The registration store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1591
+#: src/PrefsUnifiedDlg.cpp:1517
 msgid "Could not remove the URL handler registration."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1661 src/PrefsUnifiedDlg.cpp:1688
+#: src/PrefsUnifiedDlg.cpp:1587 src/PrefsUnifiedDlg.cpp:1614
 #, fuzzy
 msgid "The web server and aMule API require external connections to be enabled."
 msgstr "Пароль задан и внешние соединения разрешены."
 
-#: src/PrefsUnifiedDlg.cpp:1671
+#: src/PrefsUnifiedDlg.cpp:1597
 msgid "The aMule web server is deprecated. Consider running the aMule API instead."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1735
+#: src/PrefsUnifiedDlg.cpp:1655
 msgid ""
 "Your Auto-update servers list is in blank.\n"
 "Please fill in at least one URL to point to a valid server.met file.\n"
@@ -6002,24 +5954,24 @@ msgstr ""
 "Пожалуйста, внесите в список хотя бы один URL, указывающий на корректный 'server.met'.\n"
 "Щелкните на кнопке \"Список\" чтобы ввести URL."
 
-#: src/PrefsUnifiedDlg.cpp:1876
+#: src/PrefsUnifiedDlg.cpp:1796
 msgid "Temporary files"
 msgstr "Временные файлы"
 
-#: src/PrefsUnifiedDlg.cpp:1881
+#: src/PrefsUnifiedDlg.cpp:1801
 msgid "Incoming files"
 msgstr "Входящие файлы"
 
-#: src/PrefsUnifiedDlg.cpp:1886
+#: src/PrefsUnifiedDlg.cpp:1806
 msgid "Online Signatures"
 msgstr "Online-подписи"
 
-#: src/PrefsUnifiedDlg.cpp:1899
+#: src/PrefsUnifiedDlg.cpp:1819
 #, c-format
 msgid "Choose a folder for %s"
 msgstr "Выберите каталог для %s"
 
-#: src/PrefsUnifiedDlg.cpp:1923
+#: src/PrefsUnifiedDlg.cpp:1843
 #, fuzzy, c-format
 msgid "Would exclude %u of %u shared file"
 msgid_plural "Would exclude %u of %u shared files"
@@ -6027,42 +5979,42 @@ msgstr[0] "Найден %i известный публикуемый файл."
 msgstr[1] "Найдено %i известных публикуемых файла."
 msgstr[2] "Найдено %i известных публикуемых файлов."
 
-#: src/PrefsUnifiedDlg.cpp:1940
+#: src/PrefsUnifiedDlg.cpp:1860
 msgid "Browse for videoplayer"
 msgstr "Выбрать видео-проигрыватель"
 
-#: src/PrefsUnifiedDlg.cpp:1944
+#: src/PrefsUnifiedDlg.cpp:1864
 msgid "Select browser"
 msgstr "Выберите броузер"
 
-#: src/PrefsUnifiedDlg.cpp:1948
+#: src/PrefsUnifiedDlg.cpp:1868
 #, fuzzy
 msgid "Select ffprobe binary"
 msgstr "Выберите броузер"
 
-#: src/PrefsUnifiedDlg.cpp:1954
+#: src/PrefsUnifiedDlg.cpp:1874
 #, c-format
 msgid "Executable%s"
 msgstr "Команда запуска%s"
 
-#: src/PrefsUnifiedDlg.cpp:1988
+#: src/PrefsUnifiedDlg.cpp:1908
 msgid "ffprobe not found on PATH or in the standard install locations. Install ffmpeg (which ships ffprobe) or use Browse to pick a binary manually."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2000
+#: src/PrefsUnifiedDlg.cpp:1920
 msgid "Reset the settings on this page to their default values?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2001
+#: src/PrefsUnifiedDlg.cpp:1921
 #, fuzzy
 msgid "Reset to defaults"
 msgstr "Системный"
 
-#: src/PrefsUnifiedDlg.cpp:2028
+#: src/PrefsUnifiedDlg.cpp:1948
 msgid "Edit server list"
 msgstr "Редактировать список серверов"
 
-#: src/PrefsUnifiedDlg.cpp:2029
+#: src/PrefsUnifiedDlg.cpp:1949
 msgid ""
 "Add here URL's to download server.met files.\n"
 "Only one url on each line."
@@ -6070,42 +6022,42 @@ msgstr ""
 "Впишите сюда адреса для получения файлов 'server.met'.\n"
 "Только один URL в одной строчке."
 
-#: src/PrefsUnifiedDlg.cpp:2084
+#: src/PrefsUnifiedDlg.cpp:2004
 msgid "IP2Country update failed"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2229 src/PrefsUnifiedDlg.cpp:2260
+#: src/PrefsUnifiedDlg.cpp:2149 src/PrefsUnifiedDlg.cpp:2180
 msgid "Data by MaxMind GeoLite2"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2231 src/PrefsUnifiedDlg.cpp:2262
+#: src/PrefsUnifiedDlg.cpp:2151 src/PrefsUnifiedDlg.cpp:2182
 #, fuzzy
 msgid "Custom source"
 msgstr "Полных источников"
 
-#: src/PrefsUnifiedDlg.cpp:2233 src/PrefsUnifiedDlg.cpp:2264
+#: src/PrefsUnifiedDlg.cpp:2153 src/PrefsUnifiedDlg.cpp:2184
 msgid "Data by DB-IP.com"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2284
+#: src/PrefsUnifiedDlg.cpp:2204
 #, fuzzy, c-format
 msgid "Status: Loaded%s"
 msgstr "Статус:"
 
-#: src/PrefsUnifiedDlg.cpp:2286
+#: src/PrefsUnifiedDlg.cpp:2206
 #, fuzzy, c-format
 msgid "Status: Loaded%s - %s"
 msgstr "Статус:"
 
-#: src/PrefsUnifiedDlg.cpp:2290
+#: src/PrefsUnifiedDlg.cpp:2210
 msgid "Status: Failed to load - click 'Update now' to refresh."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2292
+#: src/PrefsUnifiedDlg.cpp:2212
 msgid "Status: Not found - click 'Update now' to download."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2350 src/PrefsUnifiedDlg.cpp:2374
+#: src/PrefsUnifiedDlg.cpp:2270 src/PrefsUnifiedDlg.cpp:2294
 #, c-format
 msgid "Update delay: %d second"
 msgid_plural "Update delay: %d seconds"
@@ -6113,7 +6065,7 @@ msgstr[0] "Интервал обновления: %d с"
 msgstr[1] "Интервал обновления: %d сек"
 msgstr[2] "Интервал обновления: %d сек"
 
-#: src/PrefsUnifiedDlg.cpp:2358
+#: src/PrefsUnifiedDlg.cpp:2278
 #, c-format
 msgid "Time for average graph: %d minute"
 msgid_plural "Time for average graph: %d minutes"
@@ -6121,12 +6073,12 @@ msgstr[0] "Отрезок времени, охватывающийся граф�
 msgstr[1] "Отрезок времени, охватывающийся графиком: %d минут"
 msgstr[2] "Отрезок времени, охватывающийся графиком: %d минут"
 
-#: src/PrefsUnifiedDlg.cpp:2367
+#: src/PrefsUnifiedDlg.cpp:2287
 #, c-format
 msgid "Connections Graph Scale: %d"
 msgstr "Масштаб графика соединений: %d"
 
-#: src/PrefsUnifiedDlg.cpp:2382
+#: src/PrefsUnifiedDlg.cpp:2302
 #, c-format
 msgid "File Buffer Size: %d byte"
 msgid_plural "File Buffer Size: %d bytes"
@@ -6134,7 +6086,7 @@ msgstr[0] "Файловый буфер: %d Б"
 msgstr[1] "Размер буфера: %d байт"
 msgstr[2] "Размер буфера: %d байт"
 
-#: src/PrefsUnifiedDlg.cpp:2392
+#: src/PrefsUnifiedDlg.cpp:2312
 #, c-format
 msgid "Upload Queue Size: %d client"
 msgid_plural "Upload Queue Size: %d clients"
@@ -6142,7 +6094,7 @@ msgstr[0] "Размер очереди отдачи: %d"
 msgstr[1] "Размер очереди отдачи: %d клиентов"
 msgstr[2] "Размер очереди отдачи: %d клиентов"
 
-#: src/PrefsUnifiedDlg.cpp:2402
+#: src/PrefsUnifiedDlg.cpp:2322
 #, c-format
 msgid "Server connection refresh interval: %d minute"
 msgid_plural "Server connection refresh interval: %d minutes"
@@ -6150,107 +6102,103 @@ msgstr[0] "Частота связи с сервером: %d м"
 msgstr[1] "Интервал обновления соединения с сервером: %d минут"
 msgstr[2] "Интервал обновления соединения с сервером: %d минут"
 
-#: src/PrefsUnifiedDlg.cpp:2407
+#: src/PrefsUnifiedDlg.cpp:2327
 msgid "Server connection refresh interval: Disabled"
 msgstr "Обновление соединения с сервером: Отключено"
 
-#: src/PrefsUnifiedDlg.cpp:2451
+#: src/PrefsUnifiedDlg.cpp:2371
 msgid "disabled"
 msgstr "выключена"
 
-#: src/PrefsUnifiedDlg.cpp:2477
+#: src/PrefsUnifiedDlg.cpp:2397
 #, c-format
 msgid "Execute command on '%s' event"
 msgstr "Выполнить команду при событии '%s'"
 
-#: src/PrefsUnifiedDlg.cpp:2484
+#: src/PrefsUnifiedDlg.cpp:2404
 msgid "Enable command execution on core"
 msgstr "Включить выполнение команд в ядре"
 
-#: src/PrefsUnifiedDlg.cpp:2496
+#: src/PrefsUnifiedDlg.cpp:2416
 msgid "Core command:"
 msgstr "Команда ядра:"
 
 # никто ни в жизни не поймет переведенную аббревиатуру
-#: src/PrefsUnifiedDlg.cpp:2512
+#: src/PrefsUnifiedDlg.cpp:2432
 msgid "Enable command execution on GUI"
 msgstr "Включить выполнение команд в GUI"
 
-#: src/PrefsUnifiedDlg.cpp:2524
+#: src/PrefsUnifiedDlg.cpp:2444
 msgid "GUI command:"
 msgstr "Команда GUI:"
 
-#: src/PrefsUnifiedDlg.cpp:2540
+#: src/PrefsUnifiedDlg.cpp:2460
 msgid "The following variables will be replaced:"
 msgstr "Следующие переменные будут заменены:"
 
-#: src/PrefsUnifiedDlg.cpp:2708
+#: src/PrefsUnifiedDlg.cpp:2628
 msgid ""
 "The following folders look like system or sensitive locations:\n"
 "\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2713
+#: src/PrefsUnifiedDlg.cpp:2633
 msgid "Sharing them recursively will publish every file underneath on the eD2k/Kad networks. Do you really want to do this?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2716
+#: src/PrefsUnifiedDlg.cpp:2636
 #, fuzzy
 msgid "Confirm shared folders"
 msgstr "Публикуемые папки"
 
-#: src/PrefsUnifiedDlg.cpp:2744
+#: src/PrefsUnifiedDlg.cpp:2664
 #, fuzzy
 msgid "Reloading shared files..."
 msgstr "Обновить список публикуемых файлов"
 
-#: src/PrefsUnifiedDlg.cpp:2745
+#: src/PrefsUnifiedDlg.cpp:2665
 msgid "Scanning for subdirectories..."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2746
+#: src/PrefsUnifiedDlg.cpp:2666
 #, fuzzy
 msgid "Updating shared folders"
 msgstr "Публикуемые папки"
 
-#: src/PrefsUnifiedDlg.cpp:2773
+#: src/PrefsUnifiedDlg.cpp:2693
 #, c-format
 msgid "Scanned %u directories..."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2823
+#: src/PrefsUnifiedDlg.cpp:2743
 #, fuzzy, c-format
 msgid "Reloading shared files: %u files scanned"
 msgstr "Обновить список публикуемых файлов."
 
-#: src/PrefsUnifiedDlg.cpp:2873
+#: src/PrefsUnifiedDlg.cpp:2793
 #, fuzzy
 msgid "Shared folder"
 msgstr "Публикуемые папки"
 
-#: src/SearchDlg.cpp:280
-msgid "Clear search history"
-msgstr ""
-
-#: src/SearchDlg.cpp:584
+#: src/SearchDlg.cpp:425
 msgid "It's impossible to search when both eD2k and Kademlia are disabled."
 msgstr ""
 
-#: src/SearchDlg.cpp:585 src/SearchListCtrl.cpp:858
+#: src/SearchDlg.cpp:426 src/SearchListCtrl.cpp:858
 #, fuzzy
 msgid "Search error"
 msgstr "Поиск"
 
-#: src/SearchDlg.cpp:929
+#: src/SearchDlg.cpp:768
 msgid "Min size must be smaller than max size. Max size ignored."
 msgstr "Мин. размер должен быть меньше макс. размера. Игнорирую макс. размер."
 
-#: src/SearchDlg.cpp:930 src/SearchDlg.cpp:1012
+#: src/SearchDlg.cpp:769 src/SearchDlg.cpp:851
 msgid "Search warning"
 msgstr "Предупреждение поиска"
 
 # It's about default category to download to.
-#: src/SearchDlg.cpp:1092 src/SearchListCtrl.cpp:735
+#: src/SearchDlg.cpp:929 src/SearchListCtrl.cpp:735
 msgid "Main"
 msgstr "Общая"
 

--- a/po/ru.po
+++ b/po/ru.po
@@ -14,7 +14,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-28 10:19+0200\n"
+"POT-Creation-Date: 2026-07-28 12:17+0200\n"
 "PO-Revision-Date: 2026-07-27 11:45+0000\n"
 "Last-Translator: Radist Morse <radist.morse@gmail.com>\n"
 "Language-Team: Russian <kde-russian@lists.kde.ru>\n"
@@ -209,83 +209,83 @@ msgstr "Не удалось открыть файл ED2KLinks."
 msgid "WARNING: You can't add yourself as a source for an eD2k link while having a lowid."
 msgstr "ПРЕДУПРЕЖДЕНИЕ: Вы не можете добавить себя в качестве источника для eD2k ссылки если у вас lowid."
 
-#: src/amule.cpp:300
+#: src/amule.cpp:301
 msgid "Now, exiting main app..."
 msgstr "Выходим из основного приложения..."
 
-#: src/amule.cpp:330
+#: src/amule.cpp:331
 #, c-format
 msgid "Terminating amuleweb instance with pid '%d' ... "
 msgstr "Завершаем процесс amuleweb с pid `%d' ... "
 
-#: src/amule.cpp:334
+#: src/amule.cpp:335
 #, c-format
 msgid "Killing amuleweb instance with pid '%d' ... "
 msgstr "Убиваем процесс amuleweb с pid `%d' ... "
 
-#: src/amule.cpp:336 src/amule.cpp:349 src/ClientRef.cpp:180
+#: src/amule.cpp:337 src/amule.cpp:350 src/ClientRef.cpp:180
 #: src/SearchDlg.cpp:1041 src/ServerListCtrl.cpp:98
 msgid "Failed"
 msgstr "Неудачно"
 
-#: src/amule.cpp:343
+#: src/amule.cpp:344
 #, fuzzy, c-format
 msgid "Terminating amuleapi instance with pid '%d' ... "
 msgstr "Завершаем процесс amuleweb с pid `%d' ... "
 
-#: src/amule.cpp:347
+#: src/amule.cpp:348
 #, fuzzy, c-format
 msgid "Killing amuleapi instance with pid '%d' ... "
 msgstr "Убиваем процесс amuleweb с pid `%d' ... "
 
-#: src/amule.cpp:355
+#: src/amule.cpp:356
 msgid "aMule OnExit: Terminating core."
 msgstr "aMule OnExit: Прекращаем работу ядра."
 
-#: src/amule.cpp:466
+#: src/amule.cpp:467
 msgid "aMule shutdown completed."
 msgstr "выключение aMule завершено."
 
-#: src/amule.cpp:470
+#: src/amule.cpp:471
 msgid "Memory debug results for aMule exit:"
 msgstr "Результаты дебага памяти при выходе из aMule:"
 
-#: src/amule.cpp:651
+#: src/amule.cpp:652
 #, c-format
 msgid "Binding aMule's peer-to-peer traffic to interface: %s (HTTP updates use the default route)"
 msgstr ""
 
-#: src/amule.cpp:655
+#: src/amule.cpp:656
 #, c-format
 msgid "Binding all network traffic to interface: %s"
 msgstr ""
 
-#: src/amule.cpp:659
+#: src/amule.cpp:660
 #, c-format
 msgid "WARNING: configured network interface '%s' was not found - traffic is NOT bound to it and may leave via the default route. Check the interface name in Preferences."
 msgstr ""
 
-#: src/amule.cpp:665
+#: src/amule.cpp:666
 #, c-format
 msgid "WARNING: binding to network interface '%s' requires elevated privileges and was NOT applied - traffic may leave via the default route. Grant the capability (e.g. 'sudo setcap cap_net_raw+ep' on the aMule binary) or run with sufficient privileges."
 msgstr ""
 
-#: src/amule.cpp:673
+#: src/amule.cpp:674
 #, c-format
 msgid "WARNING: could not bind to network interface '%s' - traffic may leave via the default route."
 msgstr ""
 
-#: src/amule.cpp:732
+#: src/amule.cpp:733
 msgid "Your locale has been changed to System Default due to a configuration change. Sorry."
 msgstr "В связи со сменой версии, значение вашей локали было изменено на значение по умолчанию. Извините."
 
-#: src/amule.cpp:734 src/amule.cpp:1581 src/CatDialog.cpp:128
+#: src/amule.cpp:735 src/amule.cpp:1589 src/CatDialog.cpp:128
 #: src/CatDialog.cpp:136 src/CatDialog.cpp:149 src/ServerList.cpp:366
 #: src/ServerListCtrl.cpp:152
 msgid "Info"
 msgstr "Сведения"
 
-#: src/amule.cpp:741
+#: src/amule.cpp:742
 msgid ""
 "\n"
 "EC configuration"
@@ -293,74 +293,74 @@ msgstr ""
 "\n"
 "EC конфигурация"
 
-#: src/amule.cpp:744
+#: src/amule.cpp:745
 msgid "Password set and external connections enabled."
 msgstr "Пароль задан и внешние соединения разрешены."
 
-#: src/amule.cpp:754 src/KadDlg.cpp:176 src/KadDlg.cpp:185
-#: src/PrefsUnifiedDlg.cpp:1387 src/SharedFilesCtrl.cpp:476
+#: src/amule.cpp:755 src/KadDlg.cpp:176 src/KadDlg.cpp:185
+#: src/PrefsUnifiedDlg.cpp:1461 src/SharedFilesCtrl.cpp:476
 msgid "WARNING"
 msgstr "ПРЕДУПРЕЖДЕНИЕ"
 
-#: src/amule.cpp:991
+#: src/amule.cpp:992
 #, fuzzy
 msgid "Network bootstrap"
 msgstr "Сети"
 
-#: src/amule.cpp:996
+#: src/amule.cpp:997
 msgid ""
 "aMule has detected missing network bootstrap files.\n"
 "Select which ones to download:"
 msgstr ""
 
-#: src/amule.cpp:1005 src/FirstRunWizard.cpp:411
+#: src/amule.cpp:1006 src/FirstRunWizard.cpp:411
 #, fuzzy
 msgid "eD2k server list (server.met)"
 msgstr "В файле 'server.met' найден %i сервер"
 
-#: src/amule.cpp:1012 src/FirstRunWizard.cpp:416
+#: src/amule.cpp:1013 src/FirstRunWizard.cpp:416
 msgid "Kad bootstrap nodes (nodes.dat)"
 msgstr ""
 
-#: src/amule.cpp:1102
+#: src/amule.cpp:1103
 #, c-format
 msgid "web server running on pid %d"
 msgstr "веб-сервер работает с pid %d"
 
-#: src/amule.cpp:1115
+#: src/amule.cpp:1116
 #, fuzzy
 msgid "You requested to run web server on startup, but the amuleweb binary cannot be run. Please install the package containing aMule web server, or build aMule from source with -DBUILD_WEBSERVER=YES and install it."
 msgstr "Вы хотите запускать веб-сервер при загрузке, но исполняемый файл amuleweb не может быть запущен. Установите пакет содержащий веб-сервер aMule или скомпилируйте его с опцией --enable-webserver и запустите make install"
 
-#: src/amule.cpp:1120 src/amule.cpp:1177 src/amule.cpp:1291 src/amule.cpp:1593
+#: src/amule.cpp:1121 src/amule.cpp:1185 src/amule.cpp:1299 src/amule.cpp:1601
 #: src/amule-remote-gui.cpp:603 src/amule-remote-gui.cpp:671
 #: src/amule-remote-gui.cpp:709 src/amule-remote-gui.cpp:1282
 #: src/amule-remote-gui.cpp:1345 src/amule-remote-gui.cpp:1372
-#: src/DownloadQueue.cpp:1481
+#: src/DownloadQueue.cpp:1481 src/PrefsUnifiedDlg.cpp:1247
 msgid "ERROR"
 msgstr "ОШИБКА"
 
-#: src/amule.cpp:1166
+#: src/amule.cpp:1174
 #, fuzzy, c-format
 msgid "amuleapi running on pid %d"
 msgstr "веб-сервер работает с pid %d"
 
-#: src/amule.cpp:1172
+#: src/amule.cpp:1180
 #, fuzzy
 msgid "You requested to run amuleapi on startup, but the amuleapi binary cannot be run. Please install the package containing aMule's REST API server, or build aMule from source with -DBUILD_AMULEAPI=YES and install it."
 msgstr "Вы хотите запускать веб-сервер при загрузке, но исполняемый файл amuleweb не может быть запущен. Установите пакет содержащий веб-сервер aMule или скомпилируйте его с опцией --enable-webserver и запустите make install"
 
-#: src/amule.cpp:1259
+#: src/amule.cpp:1267
 #, c-format
 msgid "Could not bind ports to the specified address: %s"
 msgstr "Невозможно связать порты с указанными адресами: %s"
 
-#: src/amule.cpp:1283
+#: src/amule.cpp:1291
 #, c-format
 msgid "Port %u is not available. You will be LOWID\n"
 msgstr "Порт %u не доступен. У вас будет LowID\n"
 
-#: src/amule.cpp:1288
+#: src/amule.cpp:1296
 #, c-format
 msgid ""
 "Port %u is not available!\n"
@@ -375,48 +375,48 @@ msgstr ""
 "\n"
 "Проверьте вашу сетевую конфигурацию, убедитесь что необходимый порт открыт."
 
-#: src/amule.cpp:1385
+#: src/amule.cpp:1393
 msgid "Failed to create OnlineSig File"
 msgstr "Не удалось создать aMule OnlineSig файл"
 
-#: src/amule.cpp:1393
+#: src/amule.cpp:1401
 msgid "Failed to create aMule OnlineSig File"
 msgstr "Не удалось создать aMule OnlineSig файл"
 
-#: src/amule.cpp:1556
+#: src/amule.cpp:1564
 msgid "The selected locale seems not to be installed on your box. (Note: I'll try to set it anyway)"
 msgstr "Выбранная локаль отсутствует в вашей системе (тем не менее, будет произведена попытка ее использовать)."
 
-#: src/amule.cpp:1566
+#: src/amule.cpp:1574
 #, c-format
 msgid "This is the first time you run aMule %s"
 msgstr "Это первый запуск aMule %s"
 
-#: src/amule.cpp:1569
+#: src/amule.cpp:1577
 msgid "This version is a testing version, updated daily, and\n"
 msgstr "Эта версия является тестовой и обновляется ежедневно.\n"
 
-#: src/amule.cpp:1570
+#: src/amule.cpp:1578
 msgid "we give no warranty it won't break anything, burn your house,\n"
 msgstr "мы не предоставляем никаких гарантий на случай каких либо повреждений, пожара \n"
 
-#: src/amule.cpp:1571
+#: src/amule.cpp:1579
 msgid "or kill your dog. But it *should* be safe to use anyway.\n"
 msgstr "или же смерти вашей любимой собачки. И все же использование ее *должно* быть безопасным. \n"
 
-#: src/amule.cpp:1576
+#: src/amule.cpp:1584
 msgid "More information, support and new releases can found at our homepage,\n"
 msgstr "Дополнительную информацию, поддержку и обновленные версии вы найдете на нашем сайте \n"
 
-#: src/amule.cpp:1577
+#: src/amule.cpp:1585
 msgid "at https://amule-org.github.io, or in our IRC channel #aMule at irc.libera.chat.\n"
 msgstr "https://amule-org.github.io, или на нашем irc-канале #aMule, находящемся на сервере irc.libera.chat. \n"
 
-#: src/amule.cpp:1579
+#: src/amule.cpp:1587
 msgid "Feel free to report any bugs to https://github.com/amule-org/amule/issues"
 msgstr "Сообщайте нам о найденных ошибках на форум https://github.com/amule-org/amule/issues"
 
-#: src/amule.cpp:1591
+#: src/amule.cpp:1599
 msgid ""
 "The folder for Online Signature files you specified is INVALID!\n"
 " OnlineSignature will be DISABLED until you fix it on preferences."
@@ -424,141 +424,141 @@ msgstr ""
 "Указан неверный каталог для файлов Online-подписей!\n"
 "Online-подписи будут отключены пока вы не исправите это в настройках."
 
-#: src/amule.cpp:1654
+#: src/amule.cpp:1662
 msgid "Server hostname notified"
 msgstr "Имя сервера подтверждено"
 
-#: src/amule.cpp:2031
+#: src/amule.cpp:2039
 #, c-format
 msgid "Disk space preallocation for file '%s' failed: %s"
 msgstr "Выделение место под файл '%s' не удалось: %s"
 
-#: src/amule.cpp:2160
+#: src/amule.cpp:2168
 msgid "ERROR: can't open logfile"
 msgstr "Ошибка: невозможно открыть файл журнала"
 
-#: src/amule.cpp:2164
+#: src/amule.cpp:2172
 msgid "WARNING: logfile is empty. Something is wrong."
 msgstr "ПРЕДУПРЕЖДЕНИЕ: файл журнала пуст. Что-то здесь не так :-("
 
-#: src/amule.cpp:2181
+#: src/amule.cpp:2189
 msgid "Log has been reset"
 msgstr "Журнал был очищен"
 
-#: src/amule.cpp:2205
+#: src/amule.cpp:2213
 #, c-format
 msgid "ServerMessage: %s"
 msgstr "Сообщение сервера: %s"
 
-#: src/amule.cpp:2248 src/IP2Country.cpp:220 src/IPFilter.cpp:514
+#: src/amule.cpp:2256 src/IP2Country.cpp:220 src/IPFilter.cpp:514
 #: src/ServerList.cpp:875
 #, c-format
 msgid "Skipped download of %s, because requested file is not newer."
 msgstr "Пропущена загрузка %s, так как запрашиваемый файл не новее."
 
-#: src/amule.cpp:2251
+#: src/amule.cpp:2259
 msgid "Failed to download the nodes list."
 msgstr "Ошибка при загрузке списка узлов."
 
-#: src/amule.cpp:2314
+#: src/amule.cpp:2322
 msgid "Failed to open the downloaded version check file"
 msgstr "Ошибка при загрузке файла контроля версии"
 
-#: src/amule.cpp:2317 src/amule.cpp:2336
+#: src/amule.cpp:2325 src/amule.cpp:2344
 msgid "Corrupted version check file"
 msgstr "Поврежден файл контроля версии"
 
-#: src/amule.cpp:2359
+#: src/amule.cpp:2367
 msgid "You are using an outdated version of aMule!"
 msgstr "Вы используете устаревшую версию aMule!"
 
-#: src/amule.cpp:2361
+#: src/amule.cpp:2369
 #, c-format
 msgid "Your aMule version is %i.%i.%i and the latest version is %li.%li.%li"
 msgstr "Версия вашего aMule - %i.%i.%i, тогда как актуальная версия - %li.%li.%li"
 
-#: src/amule.cpp:2365
+#: src/amule.cpp:2373
 msgid "The latest version can always be found at https://github.com/amule-org/amule/releases/latest"
 msgstr "Актуальная версия aMule всегда доступна тут:  https://github.com/amule-org/amule/releases/latest"
 
-#: src/amule.cpp:2368
+#: src/amule.cpp:2376
 #, c-format
 msgid "WARNING: Your aMuled version is outdated: %i.%i.%i < %li.%li.%li"
 msgstr "ВНИМАНИЕ: Версия вашего aMule устарела: %i.%i.%i < %li.%li.%li"
 
-#: src/amule.cpp:2374
+#: src/amule.cpp:2382
 msgid "Your copy of aMule is up to date."
 msgstr "Ваша копия aMule актуальна."
 
-#: src/amule.cpp:2381
+#: src/amule.cpp:2389
 msgid "Failed to download the version check file"
 msgstr "Ошибка при загрузке файла контроля версии"
 
-#: src/amule.cpp:2550 src/amule-remote-gui.cpp:1133
+#: src/amule.cpp:2558 src/amule-remote-gui.cpp:1133
 #, c-format
 msgid "Users: %s | Files: %s"
 msgstr "Польз.: %s | Файлов: %s"
 
-#: src/amule.cpp:2551 src/amule-remote-gui.cpp:1134
+#: src/amule.cpp:2559 src/amule-remote-gui.cpp:1134
 #, c-format
 msgid "Users: E: %s K: %s | Files: E: %s K: %s"
 msgstr "Польз.: E: %s K: %s | Файлов: E: %s K: %s"
 
-#: src/amule.cpp:2565 src/amule-remote-gui.cpp:1147
+#: src/amule.cpp:2573 src/amule-remote-gui.cpp:1147
 msgid "No networks selected"
 msgstr "Нет выделенной сети"
 
-#: src/amule.cpp:2633 src/TextClient.cpp:903
+#: src/amule.cpp:2641 src/TextClient.cpp:903
 msgid "with LowID"
 msgstr "LowID"
 
-#: src/amule.cpp:2633 src/TextClient.cpp:904
+#: src/amule.cpp:2641 src/TextClient.cpp:904
 msgid "with HighID"
 msgstr "HighID"
 
-#: src/amule.cpp:2635
+#: src/amule.cpp:2643
 #, c-format
 msgid "Connected to %s %s"
 msgstr "Соединен с %s %s"
 
-#: src/amule.cpp:2640
+#: src/amule.cpp:2648
 #, c-format
 msgid "Connecting to %s"
 msgstr "Подключение к %s"
 
-#: src/amule.cpp:2642
+#: src/amule.cpp:2650
 msgid "Disconnected from eD2k"
 msgstr "Отсоединен от eD2k"
 
 # Kad как сеть, или служба - поэтому в женском роде
 # да, согласен
-#: src/amule.cpp:2651
+#: src/amule.cpp:2659
 msgid "Kad started."
 msgstr "Kad запущена."
 
 # Kad как сеть, или служба - поэтому в женском роде
 # согласен
-#: src/amule.cpp:2653
+#: src/amule.cpp:2661
 msgid "Kad stopped."
 msgstr "Kad остановлена."
 
-#: src/amule.cpp:2661
+#: src/amule.cpp:2669
 msgid "Connected to Kad (ok)"
 msgstr "Подключен к Kad (норм.)"
 
-#: src/amule.cpp:2663
+#: src/amule.cpp:2671
 msgid "Connected to Kad (firewalled)"
 msgstr "Подключен к Kad (за брандмауэром)"
 
-#: src/amule.cpp:2667
+#: src/amule.cpp:2675
 msgid "Disconnected from Kad"
 msgstr "Отключился от Kad"
 
-#: src/amule.cpp:2699
+#: src/amule.cpp:2707
 msgid "Kad network cannot be used if UDP port is disabled on preferences, not starting."
 msgstr "Сеть Kad не может быть использована если порт UDP выключен в настройках. Отменяю запуск."
 
-#: src/amule.cpp:2703
+#: src/amule.cpp:2711
 msgid "Kad network disabled on preferences, not connecting."
 msgstr "Сеть Kad выключена в настройках. Отменяю соединение."
 
@@ -603,36 +603,36 @@ msgid "FATAL ERROR: Failed to create Timer"
 msgstr "ФАТАЛЬНАЯ ОШИБКА: не удалось создать таймер"
 
 #: src/amuleDlg.cpp:361 src/amuleDlg.cpp:1787 src/amuleDlg.cpp:2033
-#: src/muuli_wdr.cpp:1492 src/muuli_wdr.cpp:3418
+#: src/muuli_wdr.cpp:1492 src/muuli_wdr.cpp:3449
 msgid "Networks"
 msgstr "Сети"
 
-#: src/amuleDlg.cpp:362 src/amuleDlg.cpp:1793 src/muuli_wdr.cpp:3419
+#: src/amuleDlg.cpp:362 src/amuleDlg.cpp:1793 src/muuli_wdr.cpp:3450
 msgid "Searches"
 msgstr "Поиск"
 
 #: src/amuleDlg.cpp:363 src/amuleDlg.cpp:1799 src/DownloadListCtrl.cpp:740
-#: src/muuli_wdr.cpp:392 src/muuli_wdr.cpp:1585 src/muuli_wdr.cpp:3420
+#: src/muuli_wdr.cpp:392 src/muuli_wdr.cpp:1585 src/muuli_wdr.cpp:3451
 #: src/Statistics.cpp:829
 msgid "Downloads"
 msgstr "Загрузки"
 
-#: src/amuleDlg.cpp:364 src/amuleDlg.cpp:1805 src/muuli_wdr.cpp:3294
+#: src/amuleDlg.cpp:364 src/amuleDlg.cpp:1805 src/muuli_wdr.cpp:3325
 msgid "Shared files"
 msgstr "Публикуемые файлы"
 
-#: src/amuleDlg.cpp:365 src/amuleDlg.cpp:1811 src/muuli_wdr.cpp:2926
-#: src/muuli_wdr.cpp:3376 src/muuli_wdr.cpp:3423
+#: src/amuleDlg.cpp:365 src/amuleDlg.cpp:1811 src/muuli_wdr.cpp:2957
+#: src/muuli_wdr.cpp:3407 src/muuli_wdr.cpp:3454
 msgid "Messages"
 msgstr "Сообщения"
 
-#: src/amuleDlg.cpp:366 src/amuleDlg.cpp:1817 src/muuli_wdr.cpp:3424
-#: src/PrefsUnifiedDlg.cpp:312 src/Statistics.cpp:779 src/Statistics.cpp:1235
+#: src/amuleDlg.cpp:366 src/amuleDlg.cpp:1817 src/muuli_wdr.cpp:3455
+#: src/PrefsUnifiedDlg.cpp:314 src/Statistics.cpp:779 src/Statistics.cpp:1235
 msgid "Statistics"
 msgstr "Статистика"
 
-#: src/amuleDlg.cpp:368 src/amuleDlg.cpp:1824 src/muuli_wdr.cpp:3426
-#: src/PrefsUnifiedDlg.cpp:328 src/utils/wxCas/src/wxcasprefs.cpp:39
+#: src/amuleDlg.cpp:368 src/amuleDlg.cpp:1824 src/muuli_wdr.cpp:3457
+#: src/PrefsUnifiedDlg.cpp:330 src/utils/wxCas/src/wxcasprefs.cpp:39
 msgid "Preferences"
 msgstr "Настройки"
 
@@ -690,8 +690,8 @@ msgstr " Kad: Выключено"
 #: src/amuleDlg.cpp:1029 src/DownloadListCtrl.cpp:505
 #: src/DownloadListCtrl.cpp:749 src/FriendListCtrl.cpp:180
 #: src/muuli_wdr.cpp:731 src/muuli_wdr.cpp:782 src/muuli_wdr.cpp:846
-#: src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2231 src/muuli_wdr.cpp:2316
-#: src/muuli_wdr.cpp:3064 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
+#: src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2262 src/muuli_wdr.cpp:2347
+#: src/muuli_wdr.cpp:3095 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
 #: src/ServerListCtrl.cpp:606 src/TransferWnd.cpp:378
 #: src/utils/wxCas/src/wxcasprefs.cpp:235
 msgid "Cancel"
@@ -702,7 +702,7 @@ msgid "Stop the current connection attempts"
 msgstr "Прекратить попытки соединения"
 
 #: src/amuleDlg.cpp:1035 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976
-#: src/muuli_wdr.cpp:2454
+#: src/muuli_wdr.cpp:2485
 msgid "Disconnect"
 msgstr "Отключиться"
 
@@ -711,7 +711,7 @@ msgid "Disconnect from the currently connected networks"
 msgstr "Отключиться от работающих сетей"
 
 #: src/amuleDlg.cpp:1041 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979
-#: src/muuli_wdr.cpp:2609 src/muuli_wdr.cpp:3061 src/muuli_wdr.cpp:3416
+#: src/muuli_wdr.cpp:2640 src/muuli_wdr.cpp:3092 src/muuli_wdr.cpp:3447
 msgid "Connect"
 msgstr "Подключиться"
 
@@ -766,7 +766,7 @@ msgstr "Подтверждение выхода"
 msgid "Launch Command: "
 msgstr "Команда запуска:"
 
-#: src/amuleDlg.cpp:1632 src/muuli_wdr.cpp:1978 src/Preferences.cpp:952
+#: src/amuleDlg.cpp:1632 src/muuli_wdr.cpp:1982 src/Preferences.cpp:979
 msgid "- default -"
 msgstr "- по умолчанию -"
 
@@ -780,48 +780,48 @@ msgstr "Каталог с темами оформления '%s' не сущес
 msgid "WARNING: Unable to open skin file '%s' for read"
 msgstr "ПРЕДУПРЕЖДЕНИЕ: невозможно открыть для чтения файл скина '%s'"
 
-#: src/amuleDlg.cpp:1791 src/muuli_wdr.cpp:3418
+#: src/amuleDlg.cpp:1791 src/muuli_wdr.cpp:3449
 msgid "Networks Window"
 msgstr "Окно сетей"
 
-#: src/amuleDlg.cpp:1797 src/muuli_wdr.cpp:3419
+#: src/amuleDlg.cpp:1797 src/muuli_wdr.cpp:3450
 msgid "Searches Window"
 msgstr "Окно поиска"
 
-#: src/amuleDlg.cpp:1803 src/muuli_wdr.cpp:3420
+#: src/amuleDlg.cpp:1803 src/muuli_wdr.cpp:3451
 msgid "Downloads Window"
 msgstr "Окно загрузки"
 
-#: src/amuleDlg.cpp:1809 src/muuli_wdr.cpp:3422
+#: src/amuleDlg.cpp:1809 src/muuli_wdr.cpp:3453
 msgid "Shared Files Window"
 msgstr "Окно публикуемых файлов"
 
-#: src/amuleDlg.cpp:1815 src/muuli_wdr.cpp:3423
+#: src/amuleDlg.cpp:1815 src/muuli_wdr.cpp:3454
 msgid "Messages Window"
 msgstr "Сообщения"
 
-#: src/amuleDlg.cpp:1821 src/muuli_wdr.cpp:3424
+#: src/amuleDlg.cpp:1821 src/muuli_wdr.cpp:3455
 msgid "Statistics Graph Window"
 msgstr "Статистика"
 
-#: src/amuleDlg.cpp:1828 src/muuli_wdr.cpp:3426
+#: src/amuleDlg.cpp:1828 src/muuli_wdr.cpp:3457
 msgid "Preferences Settings Window"
 msgstr "Окно настроек клиента"
 
-#: src/amuleDlg.cpp:1831 src/muuli_wdr.cpp:3427
+#: src/amuleDlg.cpp:1831 src/muuli_wdr.cpp:3458
 msgid "Import"
 msgstr "Импорт"
 
-#: src/amuleDlg.cpp:1835 src/muuli_wdr.cpp:3427
+#: src/amuleDlg.cpp:1835 src/muuli_wdr.cpp:3458
 msgid "The partfile importer tool"
 msgstr "Инструмент импортирования частично загруженных файлов (part files)"
 
-#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3428
+#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3459
 #: src/utils/aLinkCreator/src/alcframe.cpp:262
 msgid "About"
 msgstr "О программе"
 
-#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3428
+#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3459
 msgid "About/Help"
 msgstr "О программе/Помощь"
 
@@ -963,7 +963,7 @@ msgstr "Файл не найден."
 msgid "The core rejected these shared folders:%s"
 msgstr ""
 
-#: src/amule-remote-gui.cpp:1336 src/ExternalConn.cpp:2345
+#: src/amule-remote-gui.cpp:1336 src/ExternalConn.cpp:2346
 msgid "Invalid link or already on list."
 msgstr "Ссылка неверна или уже в списке."
 
@@ -979,7 +979,7 @@ msgstr "Не удается создать директорию '%s' для ка
 #: src/ClientDetailDialog.cpp:123 src/DataToText.cpp:61 src/DataToText.cpp:86
 #: src/DataToText.cpp:101 src/DataToText.cpp:136 src/DataToText.cpp:165
 #: src/DownloadListCtrl.cpp:1172 src/DownloadListCtrl.cpp:1185
-#: src/DownloadListCtrl.cpp:1196 src/ExternalConn.cpp:608
+#: src/DownloadListCtrl.cpp:1196 src/ExternalConn.cpp:609
 #: src/FileDetailDialog.cpp:203 src/FileDetailDialog.cpp:235
 #: src/FileDetailDialog.cpp:242 src/GenericClientListCtrl.cpp:1171
 #: src/GenericClientListCtrl.cpp:1182 src/GenericClientListCtrl.cpp:1192
@@ -1372,19 +1372,19 @@ msgstr "Авто [Выс]"
 msgid "Very low"
 msgstr "Очень низкий"
 
-#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:743 src/muuli_wdr.cpp:2282
+#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:743 src/muuli_wdr.cpp:2313
 #: src/ServerListCtrl.cpp:263 src/ServerListCtrl.cpp:456
 #: src/SharedFilesCtrl.cpp:145
 msgid "Low"
 msgstr "Низкий"
 
-#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:744 src/muuli_wdr.cpp:2283
+#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:744 src/muuli_wdr.cpp:2314
 #: src/ServerListCtrl.cpp:266 src/ServerListCtrl.cpp:457
 #: src/SharedFilesCtrl.cpp:146
 msgid "Normal"
 msgstr "Нормальный"
 
-#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:745 src/muuli_wdr.cpp:2284
+#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:745 src/muuli_wdr.cpp:2315
 #: src/ServerListCtrl.cpp:269 src/ServerListCtrl.cpp:458
 #: src/SharedFilesCtrl.cpp:147
 msgid "High"
@@ -1476,7 +1476,7 @@ msgstr "Локальный сервер"
 msgid "Remote Server"
 msgstr "Удаленный сервер"
 
-#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3181
+#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3212
 #: src/SearchDlg.cpp:119 src/TextClient.cpp:911
 msgid "Kad"
 msgstr "Kad"
@@ -1549,7 +1549,7 @@ msgstr "Часть"
 msgid "Size"
 msgstr "Размер"
 
-#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3248
+#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3279
 msgid "Transferred"
 msgstr "Передано"
 
@@ -1607,7 +1607,7 @@ msgstr ""
 "Ответ от: %s (%s)\n"
 "\n"
 
-#: src/DownloadListCtrl.cpp:746 src/muuli_wdr.cpp:2285
+#: src/DownloadListCtrl.cpp:746 src/muuli_wdr.cpp:2316
 #: src/SharedFilesCtrl.cpp:150
 msgid "Auto"
 msgstr "Авто"
@@ -1645,7 +1645,7 @@ msgid "Extended Options"
 msgstr "Дополнительные настройки"
 
 #: src/DownloadListCtrl.cpp:770 src/DownloadListCtrl.cpp:822
-#: src/muuli_wdr.cpp:1796
+#: src/muuli_wdr.cpp:1800
 msgid "Preview"
 msgstr "Предварительный просмотр"
 
@@ -1823,228 +1823,233 @@ msgstr[2] ""
 msgid "Invalid eD2k link! ERROR: %s"
 msgstr "Неверная eD2k ссылка! ОШИБКА: %s"
 
-#: src/ExternalConn.cpp:379
+#: src/ExternalConn.cpp:380
 msgid "Client sent packet after authentication failed."
 msgstr "Клиент послал пакет после ошибки идентификации."
 
-#: src/ExternalConn.cpp:396
+#: src/ExternalConn.cpp:397
 msgid "External connection closed."
 msgstr "Внешнее соединение закрыто."
 
-#: src/ExternalConn.cpp:473
+#: src/ExternalConn.cpp:474
 msgid "External connections disabled due to empty password!"
 msgstr "Внешние соединения выключены из-за отсутствия пароля."
 
-#: src/ExternalConn.cpp:494
+#: src/ExternalConn.cpp:495
 msgid "External connections disabled in config file"
 msgstr "Внешние соединения выключены в конфигурационном файле"
 
-#: src/ExternalConn.cpp:575
+#: src/ExternalConn.cpp:576
 msgid "New external connection accepted"
 msgstr "Принято новое внешнее соединение"
 
-#: src/ExternalConn.cpp:578
+#: src/ExternalConn.cpp:579
 msgid "ERROR: couldn't accept a new external connection"
 msgstr "ОШИБКА: невозможно принять новое внешнее соединение"
 
-#: src/ExternalConn.cpp:595
+#: src/ExternalConn.cpp:596
 msgid "External connection refused due to empty password in preferences!"
 msgstr "Отказано во внешнем соединении из-за пустого пароля"
 
-#: src/ExternalConn.cpp:607
+#: src/ExternalConn.cpp:608
 #, c-format
 msgid "Connecting client: %s %s"
 msgstr "Соединение с клиентом: %s %s"
 
-#: src/ExternalConn.cpp:609
+#: src/ExternalConn.cpp:610
 msgid "Unknown version"
 msgstr "Неизвестная версия"
 
-#: src/ExternalConn.cpp:622
+#: src/ExternalConn.cpp:623
 msgid "Incorrect EC version ID, there might be binary incompatibility. Use core and remote from same snapshot."
 msgstr "Неверный идентификатор версии ВС. Возможна бинарная несовместимость. Используйте ядро и компонент удаленного доступа одинаковой версии."
 
-#: src/ExternalConn.cpp:630
+#: src/ExternalConn.cpp:631
 msgid "You cannot connect to a release version from an arbitrary development snapshot! *sigh* possible crash prevented"
 msgstr "Вы не можете подсоединиться к релизной версии с произвольной SVN версии! Возможный сбой предотвращен"
 
-#: src/ExternalConn.cpp:713
+#: src/ExternalConn.cpp:714
 msgid "Invalid protocol version."
 msgstr "Недопустимая версия протокола."
 
-#: src/ExternalConn.cpp:719
+#: src/ExternalConn.cpp:720
 msgid "Missing protocol version tag."
 msgstr "Тег версии протокола отсутствует."
 
-#: src/ExternalConn.cpp:727
+#: src/ExternalConn.cpp:728
 msgid "Authentication failed: invalid hash specified as EC password."
 msgstr "Ошибка авторизации: в качестве EC-пароля указан неправильный хэш."
 
-#: src/ExternalConn.cpp:775
+#: src/ExternalConn.cpp:776
 msgid "Authentication failed: wrong password."
 msgstr "Ошибка идентификации: неверный пароль."
 
-#: src/ExternalConn.cpp:777
+#: src/ExternalConn.cpp:778
 msgid "Authentication failed: missing password."
 msgstr "Ошибка идентификации: пароль не задан."
 
-#: src/ExternalConn.cpp:788
+#: src/ExternalConn.cpp:789
 msgid "Invalid request, please authenticate first."
 msgstr "Неверный запрос, сначала пройдите идентификацию."
 
-#: src/ExternalConn.cpp:793
+#: src/ExternalConn.cpp:794
 msgid "Access granted."
 msgstr "Доступ получен."
 
-#: src/ExternalConn.cpp:801
+#: src/ExternalConn.cpp:802
 #, c-format
 msgid "Sent error message \"%s\" to client."
 msgstr "Клиенту отправлено сообщение об ошибке \"%s\"."
 
-#: src/ExternalConn.cpp:806
+#: src/ExternalConn.cpp:807
 #, c-format
 msgid "Unauthorized access attempt from %s. Connection closed."
 msgstr "Попытка неавторизированного доступа с %s. Соединение разорвано."
 
-#: src/ExternalConn.cpp:1419
+#: src/ExternalConn.cpp:1420
 #, c-format
 msgid "Remote PartFile command failed: FileHash not found: %s"
 msgstr "Удаленная команда PartFile не удалась: хеш файла не найден: %s"
 
-#: src/ExternalConn.cpp:1423
+#: src/ExternalConn.cpp:1424
 #, c-format
 msgid "FileHash not found: %s"
 msgstr "Хеш файла не найден: %s"
 
-#: src/ExternalConn.cpp:1470 src/ExternalConn.cpp:1558
-#: src/ExternalConn.cpp:1679
+#: src/ExternalConn.cpp:1471 src/ExternalConn.cpp:1559
+#: src/ExternalConn.cpp:1680
 msgid "OOPS! OpCode processing error!"
 msgstr "Ошибка при выполнении OpCode."
 
-#: src/ExternalConn.cpp:1501
+#: src/ExternalConn.cpp:1502
 msgid "Server not added"
 msgstr "Сервер не добавлен"
 
-#: src/ExternalConn.cpp:1520
+#: src/ExternalConn.cpp:1521
 #, c-format
 msgid "server not found: %s"
 msgstr "сервер не найден: %s"
 
-#: src/ExternalConn.cpp:1537
+#: src/ExternalConn.cpp:1538
 msgid "need to define server to be removed"
 msgstr "необходимо выделить сервер для удаления"
 
-#: src/ExternalConn.cpp:1552
+#: src/ExternalConn.cpp:1553
 msgid "eD2k is disabled in preferences."
 msgstr "Сеть eD2k отключена в настройках"
 
-#: src/ExternalConn.cpp:1657
+#: src/ExternalConn.cpp:1658
 #, fuzzy
 msgid "Friend not found."
 msgstr "Файл не найден."
 
-#: src/ExternalConn.cpp:1667
+#: src/ExternalConn.cpp:1668
 #, fuzzy
 msgid "Client not found."
 msgstr "Файл не найден."
 
-#: src/ExternalConn.cpp:1673
+#: src/ExternalConn.cpp:1674
 msgid "EC_TAG_FRIEND_SHARED requires EC_TAG_FRIEND or EC_TAG_CLIENT."
 msgstr ""
 
 # Explained by Jacobo221.
-#: src/ExternalConn.cpp:1991
+#: src/ExternalConn.cpp:1992
 msgid "WebSearch from remote interface makes no sense."
 msgstr "При удаленном использовании aMule WWW поиск бесполезен."
 
-#: src/ExternalConn.cpp:2026
+#: src/ExternalConn.cpp:2027
 msgid "Search in progress. Refetch results in a moment!"
 msgstr "Поиск запущен. Ждите результатов."
 
-#: src/ExternalConn.cpp:2265
+#: src/ExternalConn.cpp:2266
 msgid "No points for graph."
 msgstr "В графике нет точек."
 
-#: src/ExternalConn.cpp:2275
+#: src/ExternalConn.cpp:2276
 msgid "Your client is not configured for this detail level."
 msgstr "Ваш клиент не настроен на этот уровень детализации."
 
-#: src/ExternalConn.cpp:2302
+#: src/ExternalConn.cpp:2303
 msgid "External Connection: shutdown requested"
 msgstr "Внешнее соединение: запрошено выключение"
 
-#: src/ExternalConn.cpp:2314
+#: src/ExternalConn.cpp:2315
 msgid "Already shutting down."
 msgstr "Уже завершаю работу."
 
-#: src/ExternalConn.cpp:2332
+#: src/ExternalConn.cpp:2333
 #, c-format
 msgid "ExternalConn: adding link '%s'."
 msgstr "ExternalConn: добавляю ссылку '%s'."
 
-#: src/ExternalConn.cpp:2350
+#: src/ExternalConn.cpp:2351
 #, fuzzy, c-format
 msgid "%d of %d links failed (invalid or already on list)."
 msgstr "Ссылка неверна или уже в списке."
 
-#: src/ExternalConn.cpp:2373
+#: src/ExternalConn.cpp:2374
 msgid "Version check throttled; try again shortly."
 msgstr ""
 
-#: src/ExternalConn.cpp:2378
+#: src/ExternalConn.cpp:2379
 msgid "Version check is not available on this daemon."
 msgstr ""
 
-#: src/ExternalConn.cpp:2508
+#: src/ExternalConn.cpp:2509
 msgid "File not found."
 msgstr "Файл не найден."
 
-#: src/ExternalConn.cpp:2513
+#: src/ExternalConn.cpp:2514
 msgid "Invalid file name."
 msgstr "Неверное имя файла."
 
-#: src/ExternalConn.cpp:2521
+#: src/ExternalConn.cpp:2522
 msgid "Unable to rename file."
 msgstr "Невозможно переименовать файл."
 
-#: src/ExternalConn.cpp:2992 src/ExternalConn.cpp:3020
+#: src/ExternalConn.cpp:2839
+#, c-format
+msgid "Could not save the amuleapi password: %s"
+msgstr ""
+
+#: src/ExternalConn.cpp:3004 src/ExternalConn.cpp:3032
 msgid "Kad is disabled in preferences."
 msgstr "Kad выключена в настройках."
 
-#: src/ExternalConn.cpp:3033
+#: src/ExternalConn.cpp:3045
 msgid "Already connected to eD2k."
 msgstr "Уже подсоединен к сети eD2k."
 
-#: src/ExternalConn.cpp:3036
+#: src/ExternalConn.cpp:3048
 msgid "Connecting to eD2k..."
 msgstr "Подсоединение к сети eD2k..."
 
-#: src/ExternalConn.cpp:3045
+#: src/ExternalConn.cpp:3057
 msgid "Already connected to Kad."
 msgstr "Уже подключен к Kad."
 
-#: src/ExternalConn.cpp:3048
+#: src/ExternalConn.cpp:3060
 msgid "Connecting to Kad..."
 msgstr "Подключаюсь к Kad..."
 
-#: src/ExternalConn.cpp:3055
+#: src/ExternalConn.cpp:3067
 msgid "All networks are disabled."
 msgstr "Все сети выключены."
 
-#: src/ExternalConn.cpp:3064
+#: src/ExternalConn.cpp:3076
 msgid "Disconnected from eD2k."
 msgstr "Отсоединен от сети eD2k."
 
-#: src/ExternalConn.cpp:3069
+#: src/ExternalConn.cpp:3081
 msgid "Disconnected from Kad."
 msgstr "Отключен от Kad."
 
-#: src/ExternalConn.cpp:3078
+#: src/ExternalConn.cpp:3090
 #, c-format
 msgid "External Connection: invalid opcode received: %#x"
 msgstr "Внешнее соединение: получен неверный код операции: %#x"
 
-#: src/ExternalConn.cpp:3083
+#: src/ExternalConn.cpp:3095
 msgid "Invalid opcode (wrong protocol version?)"
 msgstr "Неверный opcode (Возможно, не та версия протокола)"
 
@@ -2445,23 +2450,23 @@ msgid ""
 "want downloads on a different (e.g. larger) disk."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:549 src/FirstRunWizard.cpp:611 src/muuli_wdr.cpp:1708
+#: src/FirstRunWizard.cpp:549 src/FirstRunWizard.cpp:611 src/muuli_wdr.cpp:1712
 msgid "Destination folder for downloads"
 msgstr "Папка для загружаемых файлов"
 
 #: src/FirstRunWizard.cpp:553 src/FirstRunWizard.cpp:569 src/muuli_wdr.cpp:1349
-#: src/muuli_wdr.cpp:1366 src/muuli_wdr.cpp:1683 src/muuli_wdr.cpp:1714
-#: src/muuli_wdr.cpp:1726 src/muuli_wdr.cpp:2769
+#: src/muuli_wdr.cpp:1366 src/muuli_wdr.cpp:1687 src/muuli_wdr.cpp:1718
+#: src/muuli_wdr.cpp:1730 src/muuli_wdr.cpp:2800
 #: src/utils/aLinkCreator/src/alcframe.cpp:135
 #: src/utils/wxCas/src/wxcasprefs.cpp:52 src/utils/wxCas/src/wxcasprefs.cpp:118
 msgid "Browse"
 msgstr "Открыть"
 
-#: src/FirstRunWizard.cpp:559 src/muuli_wdr.cpp:1719
+#: src/FirstRunWizard.cpp:559 src/muuli_wdr.cpp:1723
 msgid "(All files in this folder are shared with other peers)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:565 src/FirstRunWizard.cpp:624 src/muuli_wdr.cpp:1721
+#: src/FirstRunWizard.cpp:565 src/FirstRunWizard.cpp:624 src/muuli_wdr.cpp:1725
 msgid "Folder for temporary download files"
 msgstr "Папка для временных файлов"
 
@@ -2492,7 +2497,7 @@ msgstr "Не удалось открыть список друзей 'emfriends.
 msgid "CRITICAL - no client on StartChatSession"
 msgstr "КРИТИЧНО - нет клиентов на StartChatSession"
 
-#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2675 src/muuli_wdr.cpp:3352
+#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2706 src/muuli_wdr.cpp:3383
 msgid "Friends"
 msgstr "Друзья"
 
@@ -2603,8 +2608,8 @@ msgstr "Нет"
 msgid "No"
 msgstr "Нет"
 
-#: src/GenericClientListCtrl.cpp:1216 src/PrefsUnifiedDlg.cpp:2818
-#: src/PrefsUnifiedDlg.cpp:2868 src/ServerListCtrl.cpp:276
+#: src/GenericClientListCtrl.cpp:1216 src/PrefsUnifiedDlg.cpp:2898
+#: src/PrefsUnifiedDlg.cpp:2948 src/ServerListCtrl.cpp:276
 msgid "Yes"
 msgstr "Да"
 
@@ -2776,10 +2781,10 @@ msgstr "Неверный порт для инициализации"
 msgid "Please fill all fields required"
 msgstr "Пожалуйста, заполните все необходимые поля"
 
-#: src/KadDlg.cpp:192 src/PartFile.cpp:1031 src/PrefsUnifiedDlg.cpp:1162
-#: src/PrefsUnifiedDlg.cpp:1331 src/PrefsUnifiedDlg.cpp:1589
-#: src/PrefsUnifiedDlg.cpp:1599 src/PrefsUnifiedDlg.cpp:1616
-#: src/PrefsUnifiedDlg.cpp:1658
+#: src/KadDlg.cpp:192 src/PartFile.cpp:1031 src/PrefsUnifiedDlg.cpp:1134
+#: src/PrefsUnifiedDlg.cpp:1204 src/PrefsUnifiedDlg.cpp:1405
+#: src/PrefsUnifiedDlg.cpp:1663 src/PrefsUnifiedDlg.cpp:1673
+#: src/PrefsUnifiedDlg.cpp:1690 src/PrefsUnifiedDlg.cpp:1738
 msgid "Message"
 msgstr "Сообщение"
 
@@ -2885,7 +2890,7 @@ msgstr "Рейтинг"
 msgid "Uploaded"
 msgstr "Загружено"
 
-#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3232
+#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3263
 msgid "Requested"
 msgstr "Запрошено"
 
@@ -3009,7 +3014,7 @@ msgid "WARNING: "
 msgstr "ПРЕДУПРЕЖДЕНИЕ:"
 
 #: src/MuleNotebook.cpp:179 src/muuli_wdr.cpp:817 src/muuli_wdr.cpp:1229
-#: src/muuli_wdr.cpp:3136 src/muuli_wdr.cpp:3392
+#: src/muuli_wdr.cpp:3167 src/muuli_wdr.cpp:3423
 msgid "Close"
 msgstr "Закрыть"
 
@@ -3027,7 +3032,7 @@ msgid "Paste"
 msgstr "Вставить"
 
 #: src/MuleTextCtrl.cpp:89 src/muuli_wdr.cpp:358 src/muuli_wdr.cpp:757
-#: src/muuli_wdr.cpp:2359 src/muuli_wdr.cpp:2378 src/muuli_wdr.cpp:2400
+#: src/muuli_wdr.cpp:2390 src/muuli_wdr.cpp:2409 src/muuli_wdr.cpp:2431
 #: src/utils/aLinkCreator/src/alcframe.cpp:142
 msgid "Clear"
 msgstr "Очистить"
@@ -3126,7 +3131,7 @@ msgstr "Выйти"
 
 #: src/MuleTrayIcon.cpp:579 src/MuleTrayIcon.cpp:945 src/MuleTrayIcon.cpp:965
 #: src/muuli_wdr.cpp:1398 src/muuli_wdr.cpp:1406 src/muuli_wdr.cpp:1413
-#: src/muuli_wdr.cpp:1842 src/muuli_wdr.cpp:1848 src/OtherFunctions.cpp:91
+#: src/muuli_wdr.cpp:1846 src/muuli_wdr.cpp:1852 src/OtherFunctions.cpp:91
 #: src/StatisticsDlg.cpp:93 src/StatisticsDlg.cpp:95
 msgid "kB/s"
 msgstr "кБ/сек"
@@ -3372,7 +3377,7 @@ msgstr "Байт"
 msgid "KB"
 msgstr "КБ"
 
-#: src/muuli_wdr.cpp:274 src/muuli_wdr.cpp:293 src/muuli_wdr.cpp:1627
+#: src/muuli_wdr.cpp:274 src/muuli_wdr.cpp:293 src/muuli_wdr.cpp:1631
 #: src/OtherFunctions.cpp:64
 msgid "MB"
 msgstr "МБ"
@@ -3389,7 +3394,7 @@ msgstr "Макс. размер"
 msgid "Availability"
 msgstr "Доступность"
 
-#: src/muuli_wdr.cpp:312 src/muuli_wdr.cpp:398 src/muuli_wdr.cpp:3297
+#: src/muuli_wdr.cpp:312 src/muuli_wdr.cpp:398 src/muuli_wdr.cpp:3328
 msgid "Filter:"
 msgstr "Фильтр:"
 
@@ -3452,12 +3457,12 @@ msgstr "Источников:"
 #: src/muuli_wdr.cpp:1160 src/muuli_wdr.cpp:1167 src/muuli_wdr.cpp:1172
 #: src/muuli_wdr.cpp:1179 src/muuli_wdr.cpp:1184 src/muuli_wdr.cpp:1191
 #: src/muuli_wdr.cpp:1205 src/muuli_wdr.cpp:1212 src/muuli_wdr.cpp:1217
-#: src/muuli_wdr.cpp:1224 src/muuli_wdr.cpp:3234 src/muuli_wdr.cpp:3242
-#: src/muuli_wdr.cpp:3250
+#: src/muuli_wdr.cpp:1224 src/muuli_wdr.cpp:3265 src/muuli_wdr.cpp:3273
+#: src/muuli_wdr.cpp:3281
 msgid "N/A"
 msgstr "N/A"
 
-#: src/muuli_wdr.cpp:508 src/muuli_wdr.cpp:1065 src/PrefsUnifiedDlg.cpp:297
+#: src/muuli_wdr.cpp:508 src/muuli_wdr.cpp:1065 src/PrefsUnifiedDlg.cpp:299
 msgid "General"
 msgstr "Общие"
 
@@ -3598,7 +3603,7 @@ msgstr ""
 msgid "Album :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:685 src/muuli_wdr.cpp:2254
+#: src/muuli_wdr.cpp:685 src/muuli_wdr.cpp:2285
 msgid "Title :"
 msgstr "Заголовок :"
 
@@ -3709,7 +3714,7 @@ msgstr "Имя пользователя :"
 msgid "Userhash :"
 msgstr "Хеш пользователя :"
 
-#: src/muuli_wdr.cpp:895 src/muuli_wdr.cpp:1748 src/muuli_wdr.cpp:2449
+#: src/muuli_wdr.cpp:895 src/muuli_wdr.cpp:1752 src/muuli_wdr.cpp:2480
 #: src/utils/aLinkCreator/src/alcframe.cpp:137
 msgid "Add"
 msgstr "Добавить"
@@ -3718,15 +3723,15 @@ msgstr "Добавить"
 msgid "Download-Speed"
 msgstr "Скорость приема"
 
-#: src/muuli_wdr.cpp:954 src/muuli_wdr.cpp:989 src/muuli_wdr.cpp:2553
+#: src/muuli_wdr.cpp:954 src/muuli_wdr.cpp:989 src/muuli_wdr.cpp:2584
 msgid "Current"
 msgstr "Текущая"
 
-#: src/muuli_wdr.cpp:962 src/muuli_wdr.cpp:997 src/muuli_wdr.cpp:2561
+#: src/muuli_wdr.cpp:962 src/muuli_wdr.cpp:997 src/muuli_wdr.cpp:2592
 msgid "Running average"
 msgstr "Средняя за все время"
 
-#: src/muuli_wdr.cpp:970 src/muuli_wdr.cpp:1005 src/muuli_wdr.cpp:2569
+#: src/muuli_wdr.cpp:970 src/muuli_wdr.cpp:1005 src/muuli_wdr.cpp:2600
 msgid "Session average"
 msgstr "В среднем за сеанс"
 
@@ -3738,7 +3743,7 @@ msgstr "Скорость отдачи"
 msgid "Connections"
 msgstr "Соединения"
 
-#: src/muuli_wdr.cpp:1024 src/muuli_wdr.cpp:1867
+#: src/muuli_wdr.cpp:1024 src/muuli_wdr.cpp:1871
 msgid "Active downloads"
 msgstr "Активные загрузки"
 
@@ -3746,7 +3751,7 @@ msgstr "Активные загрузки"
 msgid "Active connections (1:1)"
 msgstr "Активные соединения (1:1)"
 
-#: src/muuli_wdr.cpp:1040 src/muuli_wdr.cpp:1868
+#: src/muuli_wdr.cpp:1040 src/muuli_wdr.cpp:1872
 msgid "Active uploads"
 msgstr "Активные передачи"
 
@@ -4022,7 +4027,7 @@ msgstr "Закрепить локальный адрес за IP (пустой �
 msgid "Advanced users only: If you have multiple network interfaces, enter the address of the interface to which aMule should be bound."
 msgstr "Только для продвинутых пользователей: если у вас несколько сетевых интерфейсов введите адрес того, которым будет пользоваться aMule."
 
-#: src/muuli_wdr.cpp:1462 src/muuli_wdr.cpp:2061
+#: src/muuli_wdr.cpp:1462 src/muuli_wdr.cpp:2065
 #, fuzzy
 msgid "Bind to network interface (empty for any):"
 msgstr "Закрепить локальный адрес за IP (пустой для любого):"
@@ -4039,7 +4044,7 @@ msgstr "Максимум источников на файл:"
 msgid "Max simultaneous connections:"
 msgstr "Максимум одновременных соединений:"
 
-#: src/muuli_wdr.cpp:1498 src/muuli_wdr.cpp:3176
+#: src/muuli_wdr.cpp:1498 src/muuli_wdr.cpp:3207
 msgid "ED2K"
 msgstr "ED2K"
 
@@ -4131,762 +4136,785 @@ msgstr "Заранее выделять место для новых фалов"
 msgid "For new files preallocates disk space for the whole file, thus reduces fragmentation"
 msgstr "Сразу выделяет место под весь файл. Таким образом уменьшается фрагментация"
 
-#: src/muuli_wdr.cpp:1613
+#: src/muuli_wdr.cpp:1617
 msgid "Create new files as sparse files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1614
-msgid "A sparse file reserves its full size on disk immediately without writing real data to it -- fast, but unsupported or slow on some filesystems, and free-space accounting stays optimistic while the download is in progress. Turn this off to grow the file only as data arrives."
+#: src/muuli_wdr.cpp:1618
+msgid "Sparse part files only occupy disk space for the parts already downloaded, so free space is used up gradually as the file fills in. Turn this off to use an ordinary file instead - useful where sparse files are unsupported or slow, or where backup/de-duplication tools handle them badly. Applies only when the core runs on Windows; on Linux and macOS part files are sparse anyway and this setting has no effect."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1619
+#: src/muuli_wdr.cpp:1623
 msgid "Stop downloads when free disk space reaches "
 msgstr "Останавливать загрузки по окончанию свободного места на диске"
 
-#: src/muuli_wdr.cpp:1620
+#: src/muuli_wdr.cpp:1624
 msgid "Select this if you want aMule to check your disk space"
 msgstr "Отметьте это если  хотите чтобы aMule проверял наличие свободного места"
 
-#: src/muuli_wdr.cpp:1624
+#: src/muuli_wdr.cpp:1628
 msgid "Enter here the min disk space desired."
 msgstr "Введите здесь минимальное количество свободного места на диске."
 
-#: src/muuli_wdr.cpp:1630
+#: src/muuli_wdr.cpp:1634
 msgid "Save 10 sources on rare files (< 20 sources)"
 msgstr "Оставлять 10 источников для редких файлов (<20 источников)"
 
-#: src/muuli_wdr.cpp:1634 src/Statistics.cpp:790
+#: src/muuli_wdr.cpp:1638 src/Statistics.cpp:790
 msgid "Uploads"
 msgstr "Отдача"
 
-#: src/muuli_wdr.cpp:1637
+#: src/muuli_wdr.cpp:1641
 msgid "Add new shared files with auto priority"
 msgstr "Добавлять новые файлы для публикации с авто приоритетом"
 
 # слишком уж частая аббривеатура. написать И.О.О. - никто не поймет
-#: src/muuli_wdr.cpp:1643
+#: src/muuli_wdr.cpp:1647
 msgid "Intelligent Corruption Handling (I.C.H.)"
 msgstr "Интеллектуальная Обработка Ошибок (I.C.H.)"
 
-#: src/muuli_wdr.cpp:1646
+#: src/muuli_wdr.cpp:1650
 msgid "Enable"
 msgstr "Разрешить"
 
-#: src/muuli_wdr.cpp:1649
+#: src/muuli_wdr.cpp:1653
 msgid "Advanced I.C.H. trusts every hash (not recommended)"
 msgstr "AICH-доверие для каждого хэша (не рекомендуется)"
 
-#: src/muuli_wdr.cpp:1661 src/PrefsUnifiedDlg.cpp:1910
+#: src/muuli_wdr.cpp:1665 src/PrefsUnifiedDlg.cpp:1990
 msgid "Media metadata extraction"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1665
+#: src/muuli_wdr.cpp:1669
 msgid "Extract length / bitrate / codec from shared audio and video files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1667
+#: src/muuli_wdr.cpp:1671
 msgid "When enabled, aMule runs ffprobe on each shared media file to fill in the Length / Bitrate / Codec columns other clients see when they find the file in a search. Requires ffmpeg (the ffprobe binary) to be installed."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1674
+#: src/muuli_wdr.cpp:1678
 msgid "Path to ffprobe:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1679
+#: src/muuli_wdr.cpp:1683
 msgid "Full path to the ffprobe binary. Leave empty to have aMule auto-detect it on startup."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1687
+#: src/muuli_wdr.cpp:1691
 msgid "Detect"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1688
+#: src/muuli_wdr.cpp:1692
 msgid "Search the standard install locations for an ffprobe binary and fill the path field."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1712
+#: src/muuli_wdr.cpp:1716
 msgid ""
 "Completed downloads are stored here. All files in this folder are automatically shared with other peers.\n"
 "If this folder also holds files you don't want to share, point it at an aMule-only sub-folder."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1715
+#: src/muuli_wdr.cpp:1719
 msgid "Pick the folder where completed downloads will be stored. All files in that folder will be shared with other peers."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1729
+#: src/muuli_wdr.cpp:1733
 msgid "Shared folders"
 msgstr "Публикуемые папки"
 
-#: src/muuli_wdr.cpp:1735
+#: src/muuli_wdr.cpp:1739
 msgid "(Folders shared by the core. Enter a path to add one.)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1743
+#: src/muuli_wdr.cpp:1747
 msgid "Absolute path of a folder on the core's machine, e.g. /home/user/shared"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1745 src/PrefsUnifiedDlg.cpp:2794
+#: src/muuli_wdr.cpp:1749 src/PrefsUnifiedDlg.cpp:2874
 msgid "Recursive"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1746
+#: src/muuli_wdr.cpp:1750
 msgid "Share every sub-folder underneath this one, including ones created later."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1750 src/utils/aLinkCreator/src/alcframe.cpp:141
+#: src/muuli_wdr.cpp:1754 src/utils/aLinkCreator/src/alcframe.cpp:141
 msgid "Remove"
 msgstr "Удалить"
 
-#: src/muuli_wdr.cpp:1754
+#: src/muuli_wdr.cpp:1758
 msgid "(Right click on folder icon for recursive share)"
 msgstr "(кликните правой кнопкой на значке каталога для рекурсивной публикации)"
 
-#: src/muuli_wdr.cpp:1761
+#: src/muuli_wdr.cpp:1765
 msgid "Share hidden files"
 msgstr "Включая скрытые файлы"
 
-#: src/muuli_wdr.cpp:1767
+#: src/muuli_wdr.cpp:1771
 msgid "Automatically rescan shared folders for changes"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1773
+#: src/muuli_wdr.cpp:1777
 msgid "Follow symbolic links in shared folders"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1779
+#: src/muuli_wdr.cpp:1783
 msgid "Exclude files matching:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1782
+#: src/muuli_wdr.cpp:1786
 msgid "Wildcard patterns separated by '|', e.g. .DS_Store|Thumbs.db|*.tmp. Files whose name matches are not shared. Matching is case-insensitive."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1786
+#: src/muuli_wdr.cpp:1790
 msgid "Patterns are regular expressions"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1787
+#: src/muuli_wdr.cpp:1791
 msgid "When set, the whole field is one regular expression ('|' is alternation). When unset, it is a list of '|'-separated wildcards."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1797
+#: src/muuli_wdr.cpp:1801
 msgid "Show how many shared files the current pattern would exclude."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1818
+#: src/muuli_wdr.cpp:1822
 msgid "Graphs"
 msgstr "Графики"
 
-#: src/muuli_wdr.cpp:1821 src/muuli_wdr.cpp:1883
+#: src/muuli_wdr.cpp:1825 src/muuli_wdr.cpp:1887
 msgid "Update delay : 5 secs"
 msgstr "Интервал обновления: 5 сек"
 
-#: src/muuli_wdr.cpp:1825
+#: src/muuli_wdr.cpp:1829
 msgid "Time for average graph: 100 mins"
 msgstr "Время для среднестатического графика: 100 минут"
 
-#: src/muuli_wdr.cpp:1829
+#: src/muuli_wdr.cpp:1833
 msgid "Connections Graph Scale: 100 "
 msgstr "Масштаб графика соединений: 100 "
 
-#: src/muuli_wdr.cpp:1836
+#: src/muuli_wdr.cpp:1840
 msgid "Download graph scale:"
 msgstr "Масштаб графика загрузки:"
 
-#: src/muuli_wdr.cpp:1844
+#: src/muuli_wdr.cpp:1848
 msgid "Upload graph scale:"
 msgstr "Масштаб графика отдачи:"
 
-#: src/muuli_wdr.cpp:1854
+#: src/muuli_wdr.cpp:1858
 #, fuzzy
 msgid "Colors: "
 msgstr "Цвета:"
 
-#: src/muuli_wdr.cpp:1858
+#: src/muuli_wdr.cpp:1862
 msgid "Background"
 msgstr "Фон"
 
-#: src/muuli_wdr.cpp:1859
+#: src/muuli_wdr.cpp:1863
 msgid "Grid"
 msgstr "Сетка"
 
-#: src/muuli_wdr.cpp:1860
+#: src/muuli_wdr.cpp:1864
 msgid "Download current"
 msgstr "Текущая загрузка"
 
-#: src/muuli_wdr.cpp:1861
+#: src/muuli_wdr.cpp:1865
 msgid "Download running average"
 msgstr "Средняя общая загрузка"
 
-#: src/muuli_wdr.cpp:1862
+#: src/muuli_wdr.cpp:1866
 msgid "Download session average"
 msgstr "Средняя загрузка за сеанс"
 
-#: src/muuli_wdr.cpp:1863
+#: src/muuli_wdr.cpp:1867
 msgid "Upload current"
 msgstr "Текущая отдача"
 
-#: src/muuli_wdr.cpp:1864
+#: src/muuli_wdr.cpp:1868
 msgid "Upload running average"
 msgstr "Средняя общая отдача"
 
-#: src/muuli_wdr.cpp:1865
+#: src/muuli_wdr.cpp:1869
 msgid "Upload session average"
 msgstr "Средняя отдача за сеанс"
 
-#: src/muuli_wdr.cpp:1866
+#: src/muuli_wdr.cpp:1870
 msgid "Active connections"
 msgstr "Активные соединения"
 
-#: src/muuli_wdr.cpp:1869
+#: src/muuli_wdr.cpp:1873
 #, fuzzy
 msgid "Systray Icon Speed Bar"
 msgstr "Скорость передачи в области уведомлений"
 
-#: src/muuli_wdr.cpp:1870
+#: src/muuli_wdr.cpp:1874
 msgid "Kad-nodes current"
 msgstr "Узлы Kad (текущие)"
 
-#: src/muuli_wdr.cpp:1871
+#: src/muuli_wdr.cpp:1875
 msgid "Kad-nodes running"
 msgstr "Узлы Kad (действующие)"
 
-#: src/muuli_wdr.cpp:1872
+#: src/muuli_wdr.cpp:1876
 msgid "Kad-nodes session"
 msgstr "Узлы Kad (сессия)"
 
-#: src/muuli_wdr.cpp:1876 src/muuli_wdr.cpp:2303
+#: src/muuli_wdr.cpp:1880 src/muuli_wdr.cpp:2334
 msgid "Select"
 msgstr "Выбрать"
 
-#: src/muuli_wdr.cpp:1880
+#: src/muuli_wdr.cpp:1884
 msgid "Tree"
 msgstr "Дерево"
 
-#: src/muuli_wdr.cpp:1890
+#: src/muuli_wdr.cpp:1894
 msgid "Number of Client Versions shown (0=unlimited)"
 msgstr "Число отображаемых версий клиентов (0=неогр.)"
 
-#: src/muuli_wdr.cpp:1915
+#: src/muuli_wdr.cpp:1919
 msgid "!!! WARNING !!!"
 msgstr "!!! ВНИМАНИЕ !!!"
 
-#: src/muuli_wdr.cpp:1930
+#: src/muuli_wdr.cpp:1934
 msgid "Max new connections / 5 secs"
 msgstr "Предел количества новых соединений за 5 секунд"
 
-#: src/muuli_wdr.cpp:1932
+#: src/muuli_wdr.cpp:1936
 msgid "Concurrent Kad source lookups"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1934
+#: src/muuli_wdr.cpp:1938
 #, fuzzy
 msgid "Kad source re-search interval (minutes)"
 msgstr "Интервал обновления через FTP в минутах"
 
-#: src/muuli_wdr.cpp:1936
+#: src/muuli_wdr.cpp:1940
 #, fuzzy
 msgid "Source re-ask interval (minutes)"
 msgstr "Интервал обновления через FTP в минутах"
 
-#: src/muuli_wdr.cpp:1940
+#: src/muuli_wdr.cpp:1944
 msgid "File Buffer Size: 240000 bytes"
 msgstr "Размер буфера: 240000 байт"
 
-#: src/muuli_wdr.cpp:1944
+#: src/muuli_wdr.cpp:1948
 msgid "Use MMAP: memory-mapped file access (lower memory use)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1945
+#: src/muuli_wdr.cpp:1949
 msgid "Maps part files into memory instead of buffering them on the heap, lowering the process memory footprint. May reduce download speed on some disks; best for memory-constrained or upload-heavy hosts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1947
+#: src/muuli_wdr.cpp:1951
 msgid "Upload Queue Size: 5000 clients"
 msgstr "Размер очереди: 5000 клиентов"
 
-#: src/muuli_wdr.cpp:1951
+#: src/muuli_wdr.cpp:1955
 msgid "Server connection refresh interval: Disable"
 msgstr "Интервал обновления соединения с сервером: Отключено"
 
-#: src/muuli_wdr.cpp:1955
+#: src/muuli_wdr.cpp:1959
 msgid "Disable computer's timed standby mode"
 msgstr "Отключить засыпание компьютера"
 
 # в LA помнится так и перевели - "шкурка", но по-моему глупо.
-#: src/muuli_wdr.cpp:1974
+#: src/muuli_wdr.cpp:1978
 msgid "Skin to use: "
 msgstr "Скин:"
 
-#: src/muuli_wdr.cpp:1983
+#: src/muuli_wdr.cpp:1987
 msgid "Show \"Fast eD2k Links Handler\" in every window."
 msgstr "Показывать строку \"быстрой загрузки\" в каждой вкладке."
 
-#: src/muuli_wdr.cpp:1986
+#: src/muuli_wdr.cpp:1990
 msgid "Show extended info on categories tabs"
 msgstr "Показывать дополнительную информацию на закладках категорий"
 
-#: src/muuli_wdr.cpp:1989
+#: src/muuli_wdr.cpp:1993
 #, fuzzy
 msgid "Show application version on title"
 msgstr "Выводить скорость передачи в заголовке"
 
-#: src/muuli_wdr.cpp:1991
+#: src/muuli_wdr.cpp:1995
 msgid "Show transfer rates on title"
 msgstr "Выводить скорость передачи в заголовке"
 
-#: src/muuli_wdr.cpp:1993
+#: src/muuli_wdr.cpp:1997
 msgid "Before application name"
 msgstr "Перед именем приложения"
 
-#: src/muuli_wdr.cpp:1995
+#: src/muuli_wdr.cpp:1999
 msgid "After application name"
 msgstr "После имени приложения"
 
-#: src/muuli_wdr.cpp:1998
+#: src/muuli_wdr.cpp:2002
 msgid "Show overhead bandwidth"
 msgstr "Показывать скорость служебного трафика"
 
-#: src/muuli_wdr.cpp:2002
+#: src/muuli_wdr.cpp:2006
 msgid "Vertical toolbar orientation"
 msgstr "Вертикальное расположение панели инструментов"
 
-#: src/muuli_wdr.cpp:2004
+#: src/muuli_wdr.cpp:2008
 msgid "Live column sorting (auto-reorder rows as their values change)"
 msgstr ""
 
 # This is the heading for the preference options regarding the files in the
 # transfer list.
-#: src/muuli_wdr.cpp:2011
+#: src/muuli_wdr.cpp:2015
 msgid "Download Queue Files"
 msgstr "Загружаемые файлы"
 
-#: src/muuli_wdr.cpp:2014
+#: src/muuli_wdr.cpp:2018
 msgid "Show progress percentage"
 msgstr "Показывать процент загрузки"
 
-#: src/muuli_wdr.cpp:2020
+#: src/muuli_wdr.cpp:2024
 msgid "Show progress bar"
 msgstr "Показывать полосу выполнения"
 
-#: src/muuli_wdr.cpp:2023
+#: src/muuli_wdr.cpp:2027
 msgid "Flat"
 msgstr "Плоская"
 
-#: src/muuli_wdr.cpp:2027
+#: src/muuli_wdr.cpp:2031
 msgid "Round"
 msgstr "Круглая"
 
-#: src/muuli_wdr.cpp:2045
+#: src/muuli_wdr.cpp:2049
 msgid "External Connection Parameters"
 msgstr "Параметры внешних соединений"
 
-#: src/muuli_wdr.cpp:2048
+#: src/muuli_wdr.cpp:2052
 msgid "Accept external connections"
 msgstr "Принимать внешние соединения"
 
-#: src/muuli_wdr.cpp:2055 src/muuli_wdr.cpp:2114
+#: src/muuli_wdr.cpp:2059 src/muuli_wdr.cpp:2118
 msgid "IP of the listening interface:"
 msgstr "IP прослушиваемого интерфейса:"
 
-#: src/muuli_wdr.cpp:2058
+#: src/muuli_wdr.cpp:2062
 msgid "Enter here a valid ip in the a.b.c.d format for the listening EC interface. An empty field or 0.0.0.0 will mean any interface."
 msgstr "Введите сюда IP в формате a.b.c.d для прослушиваемого интерфейса ВС. Пустое поле или значение 0.0.0.0 означают любой интерфейс."
 
-#: src/muuli_wdr.cpp:2079 src/muuli_wdr.cpp:2163
+#: src/muuli_wdr.cpp:2083 src/muuli_wdr.cpp:2194
 msgid "TCP port:"
 msgstr "порт TCP:"
 
-#: src/muuli_wdr.cpp:2085
+#: src/muuli_wdr.cpp:2089
 msgid "Enable UPnP port forwarding on the EC port"
 msgstr "Включить UPnP для порта ВС"
 
-#: src/muuli_wdr.cpp:2089 src/muuli_wdr.cpp:3048
+#: src/muuli_wdr.cpp:2093 src/muuli_wdr.cpp:3079
 #: src/utils/wxCas/src/wxcasprefs.cpp:167
 msgid "Password"
 msgstr "Пароль"
 
-#: src/muuli_wdr.cpp:2095
+#: src/muuli_wdr.cpp:2099
 #, fuzzy
 msgid "aMule API server parameters"
 msgstr "Параметры веб-сервера"
 
-#: src/muuli_wdr.cpp:2098
+#: src/muuli_wdr.cpp:2102
 msgid "Run amuleapi (REST API) on startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2103
+#: src/muuli_wdr.cpp:2107
 #, fuzzy
 msgid "HTTP port:"
 msgstr "порт TCP:"
 
-#: src/muuli_wdr.cpp:2117
+#: src/muuli_wdr.cpp:2121
 msgid "The interface amuleapi's HTTP server listens on. 127.0.0.1 (default) accepts only local connections; use 0.0.0.0 or a specific IP to expose it to other hosts (set an admin password below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2120
+#: src/muuli_wdr.cpp:2126
+msgid "Type a password to set or change it. Stored passwords cannot be shown, so leaving this empty keeps the current one."
+msgstr ""
+
+#: src/muuli_wdr.cpp:2128
 #, fuzzy
 msgid "Admin password"
 msgstr "Проверяю пароль\n"
 
-#: src/muuli_wdr.cpp:2125 src/muuli_wdr.cpp:2156
-msgid "Low rights password"
-msgstr "Пароль ограниченного доступа"
+#: src/muuli_wdr.cpp:2140 src/muuli_wdr.cpp:2157 src/PrefsUnifiedDlg.cpp:1103
+#, fuzzy
+msgid "A password is set."
+msgstr "Проверяю пароль\n"
 
-#: src/muuli_wdr.cpp:2133
+#: src/muuli_wdr.cpp:2144
+#, fuzzy
+msgid "Enable guest access"
+msgstr "Запрещать ограниченный доступ"
+
+#: src/muuli_wdr.cpp:2145
+msgid "Guest sessions may read status and listings but cannot change anything. Turning this off clears the stored guest password."
+msgstr ""
+
+#: src/muuli_wdr.cpp:2149
+#, fuzzy
+msgid "Guest password"
+msgstr "Пароль веб-сервера для ограниченного доступа"
+
+#: src/muuli_wdr.cpp:2164
 msgid "Web server parameters"
 msgstr "Параметры веб-сервера"
 
-#: src/muuli_wdr.cpp:2136
+#: src/muuli_wdr.cpp:2167
 #, fuzzy
 msgid "Run webserver on startup (deprecated)"
 msgstr "Запускать веб-сервер при старте"
 
-#: src/muuli_wdr.cpp:2142
+#: src/muuli_wdr.cpp:2173
 msgid "Web template"
 msgstr "Веб-шаблон"
 
-#: src/muuli_wdr.cpp:2147
+#: src/muuli_wdr.cpp:2178
 msgid "Full rights password"
 msgstr "Пароль для обычного доступа"
 
-#: src/muuli_wdr.cpp:2151
+#: src/muuli_wdr.cpp:2182
 msgid "Enable Low rights User"
 msgstr "Разрешить ограниченный доступ"
 
-#: src/muuli_wdr.cpp:2170
+#: src/muuli_wdr.cpp:2187
+msgid "Low rights password"
+msgstr "Пароль ограниченного доступа"
+
+#: src/muuli_wdr.cpp:2201
 msgid "Enable UPnP port forwarding of the web server port"
 msgstr "Разрешить UPnP форвардинг порта веб-сервера"
 
-#: src/muuli_wdr.cpp:2175
+#: src/muuli_wdr.cpp:2206
 msgid "Web server UPnP TCP port (Optional)"
 msgstr "UPnP TCP порт веб-сервера (не обязательно):"
 
-#: src/muuli_wdr.cpp:2183
+#: src/muuli_wdr.cpp:2214
 msgid "Page Refresh Time (in secs)"
 msgstr "Период обновления страницы (в секундах)"
 
-#: src/muuli_wdr.cpp:2190
+#: src/muuli_wdr.cpp:2221
 msgid "Enable Gzip compression"
 msgstr "Включить сжатие Gzip"
 
-#: src/muuli_wdr.cpp:2224
+#: src/muuli_wdr.cpp:2255
 #, fuzzy
 msgid "Reset page to defaults"
 msgstr "Системный"
 
-#: src/muuli_wdr.cpp:2225
+#: src/muuli_wdr.cpp:2256
 msgid "Reset the settings on the current page to their default values."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2227 src/muuli_wdr.cpp:2313 src/ServerWnd.cpp:274
+#: src/muuli_wdr.cpp:2258 src/muuli_wdr.cpp:2344 src/ServerWnd.cpp:274
 #: src/ServerWnd.cpp:282
 msgid "OK"
 msgstr "ОК"
 
-#: src/muuli_wdr.cpp:2229
+#: src/muuli_wdr.cpp:2260
 msgid "Click here to apply any changes made to the preferences."
 msgstr "Кликните тут, чтобы сохранить внесенные вами изменения."
 
-#: src/muuli_wdr.cpp:2232
+#: src/muuli_wdr.cpp:2263
 msgid "Reset any changes made to the preferences."
 msgstr "Сбросить все изменения, внесенные вами."
 
-#: src/muuli_wdr.cpp:2261
+#: src/muuli_wdr.cpp:2292
 msgid "Comment :"
 msgstr "Комментарий :"
 
-#: src/muuli_wdr.cpp:2268
+#: src/muuli_wdr.cpp:2299
 msgid "Incoming Dir :"
 msgstr "Каталог загрузок:"
 
-#: src/muuli_wdr.cpp:2277
+#: src/muuli_wdr.cpp:2308
 msgid "Change priority for new assigned files :"
 msgstr "Установить приоритет для новых файлов:"
 
-#: src/muuli_wdr.cpp:2281
+#: src/muuli_wdr.cpp:2312
 msgid "Don't change"
 msgstr "Не изменять"
 
-#: src/muuli_wdr.cpp:2293
+#: src/muuli_wdr.cpp:2324
 msgid "Select color for this Category (currently selected) :"
 msgstr "Выбрать цвет для этой категории:"
 
-#: src/muuli_wdr.cpp:2360 src/muuli_wdr.cpp:2379 src/muuli_wdr.cpp:2401
+#: src/muuli_wdr.cpp:2391 src/muuli_wdr.cpp:2410 src/muuli_wdr.cpp:2432
 msgid "Click this button to reset the log."
 msgstr "Кликните тут для очистки журнала."
 
-#: src/muuli_wdr.cpp:2420
+#: src/muuli_wdr.cpp:2451
 msgid "Click on this button to update the servers list from URL ..."
 msgstr "Кликните здесь чтобы обновить список серверов через URL ..."
 
-#: src/muuli_wdr.cpp:2424
+#: src/muuli_wdr.cpp:2455
 msgid "Server list"
 msgstr "Список серверов"
 
-#: src/muuli_wdr.cpp:2428
+#: src/muuli_wdr.cpp:2459
 msgid "Enter the url to a server.met file here and press the button to the left to update the list of known servers."
 msgstr "Введите URL к файлу 'server.met' и нажмите кнопку слева для обновления списка известных серверов."
 
-#: src/muuli_wdr.cpp:2433
+#: src/muuli_wdr.cpp:2464
 msgid "Add server manually: Name"
 msgstr "Добавить сервер вручную: Имя"
 
-#: src/muuli_wdr.cpp:2436
+#: src/muuli_wdr.cpp:2467
 msgid "Enter the name of the new server here"
 msgstr "Введите имя нового сервера"
 
-#: src/muuli_wdr.cpp:2438 src/ServerWnd.cpp:206
+#: src/muuli_wdr.cpp:2469 src/ServerWnd.cpp:206
 msgid "IP:Port"
 msgstr "IP:Порт"
 
-#: src/muuli_wdr.cpp:2441
+#: src/muuli_wdr.cpp:2472
 msgid "Enter the IP of the server here, using the x.x.x.x format."
 msgstr "Введите здесь IP-адрес сервера в формате: x.x.x.x"
 
-#: src/muuli_wdr.cpp:2447
+#: src/muuli_wdr.cpp:2478
 msgid "Enter the port of the server here."
 msgstr "Введите здесь порт сервера."
 
-#: src/muuli_wdr.cpp:2450
+#: src/muuli_wdr.cpp:2481
 msgid "Add manually a server (fill fields to the left before) ..."
 msgstr "Добавить сервер (предварительно заполните поля слева) ..."
 
-#: src/muuli_wdr.cpp:2479
+#: src/muuli_wdr.cpp:2510
 msgid "aMule Log"
 msgstr "Журнал aMule"
 
-#: src/muuli_wdr.cpp:2487
+#: src/muuli_wdr.cpp:2518
 msgid "Server Info"
 msgstr "Сообщение сервера"
 
-#: src/muuli_wdr.cpp:2491
+#: src/muuli_wdr.cpp:2522
 msgid "ED2K Info"
 msgstr "Инфо ED2K"
 
-#: src/muuli_wdr.cpp:2495
+#: src/muuli_wdr.cpp:2526
 msgid "Kad Info"
 msgstr "Инфо Kad"
 
-#: src/muuli_wdr.cpp:2523
+#: src/muuli_wdr.cpp:2554
 msgid "Click on this button to update the nodes list from URL ..."
 msgstr "Нажмите на эту кнопку чтобы обновить список узлов из URL..."
 
-#: src/muuli_wdr.cpp:2527
+#: src/muuli_wdr.cpp:2558
 msgid "Nodes (0)"
 msgstr "Узлы (0)"
 
-#: src/muuli_wdr.cpp:2531
+#: src/muuli_wdr.cpp:2562
 msgid "Enter the url to a nodes.dat file here and press the button to the left to update the list of known nodes."
 msgstr "Ведите сюда URL к файлу nodes.dat и нажмите кнопку слева чтобы обновить список известных узлов."
 
-#: src/muuli_wdr.cpp:2534
+#: src/muuli_wdr.cpp:2565
 msgid "Nodes stats"
 msgstr "Статистика узлов"
 
-#: src/muuli_wdr.cpp:2576
+#: src/muuli_wdr.cpp:2607
 msgid "Bootstrap"
 msgstr "Инициализация"
 
-#: src/muuli_wdr.cpp:2579
+#: src/muuli_wdr.cpp:2610
 msgid "New node"
 msgstr "Новый узел"
 
-#: src/muuli_wdr.cpp:2584
+#: src/muuli_wdr.cpp:2615
 msgid "IP:"
 msgstr "IP:"
 
-#: src/muuli_wdr.cpp:2604
+#: src/muuli_wdr.cpp:2635
 msgid "Port:"
 msgstr "Порт:"
 
 # Похоже, bootstrap в eMule перевели как инициализация
-#: src/muuli_wdr.cpp:2617
+#: src/muuli_wdr.cpp:2648
 msgid "Bootstrap from known clients"
 msgstr "Инициализация от известных клиентов"
 
-#: src/muuli_wdr.cpp:2619
+#: src/muuli_wdr.cpp:2650
 msgid "Disconnect Kad"
 msgstr "Отключить Kad"
 
-#: src/muuli_wdr.cpp:2653
+#: src/muuli_wdr.cpp:2684
 msgid "Use Secure User Identification"
 msgstr "Использовать безопасную идентификацию пользователя"
 
 # интересно, что на самом деле подразумевалось под 'credits'
-#: src/muuli_wdr.cpp:2655
+#: src/muuli_wdr.cpp:2686
 msgid "It is recommended to enable this option. You will not receive credits if SUI is not enabled."
 msgstr "Рекомендуется включить данную опцию. Вы не будете получать рейтинга если БИП выключена."
 
-#: src/muuli_wdr.cpp:2657
+#: src/muuli_wdr.cpp:2688
 msgid "Protocol Obfuscation"
 msgstr "Вуалирование протокола"
 
-#: src/muuli_wdr.cpp:2660
+#: src/muuli_wdr.cpp:2691
 msgid "Support Protocol Obfuscation"
 msgstr "Поддержка вуалирования протокола"
 
-#: src/muuli_wdr.cpp:2662
+#: src/muuli_wdr.cpp:2693
 msgid "This option enabled Protocol Obfuscation, and makes aMule accept obfuscated connections from other clients."
 msgstr "Включает вуалирование протокола и позволяет aMule принимать завуалированные соединения от других клиентов."
 
-#: src/muuli_wdr.cpp:2664
+#: src/muuli_wdr.cpp:2695
 msgid "Use obfuscation for outgoing connections"
 msgstr "Использовать вуалирование исходящих соединений"
 
-#: src/muuli_wdr.cpp:2666
+#: src/muuli_wdr.cpp:2697
 msgid "This option makes aMule use Protocol Obfuscation when connecting other clients/servers."
 msgstr "Включает вуалирование протокола при соединении с другими клиентами и серверами."
 
-#: src/muuli_wdr.cpp:2668
+#: src/muuli_wdr.cpp:2699
 msgid "Accept only obfuscated connections"
 msgstr "Принимать только завуалированные соединения"
 
-#: src/muuli_wdr.cpp:2669
+#: src/muuli_wdr.cpp:2700
 msgid "This option makes aMule only accept obfuscated connections. You will have less sources, but all your traffic will be obfuscated"
 msgstr "aMule будет принимать только завуалированные соединения. У вас будет меньше источников, но зато весь трафик будет завуалирован."
 
-#: src/muuli_wdr.cpp:2674
+#: src/muuli_wdr.cpp:2705
 msgid "Everybody"
 msgstr "Все"
 
-#: src/muuli_wdr.cpp:2676
+#: src/muuli_wdr.cpp:2707
 msgid "No one"
 msgstr "Никто"
 
-#: src/muuli_wdr.cpp:2678
+#: src/muuli_wdr.cpp:2709
 msgid "Who can see my shared files:"
 msgstr "Кто может запрашивать публикуемые файлы:"
 
-#: src/muuli_wdr.cpp:2679
+#: src/muuli_wdr.cpp:2710
 msgid "Select who can request to view a list of your shared files."
 msgstr "Выберите, кому показывать список ваших файлов."
 
-#: src/muuli_wdr.cpp:2681
+#: src/muuli_wdr.cpp:2712
 msgid "IP-Filtering"
 msgstr "Фильтрование IP"
 
-#: src/muuli_wdr.cpp:2688
+#: src/muuli_wdr.cpp:2719
 msgid "Filter clients"
 msgstr "Фильтровать клиентов."
 
-#: src/muuli_wdr.cpp:2690
+#: src/muuli_wdr.cpp:2721
 msgid "Enable filtering of the client IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "Включает фильтрацию IP клиентов в соответствии с файлом ~/.aMule/ipfilter.dat."
 
-#: src/muuli_wdr.cpp:2692
+#: src/muuli_wdr.cpp:2723
 msgid "Filter servers"
 msgstr "Фильтровать сервера"
 
-#: src/muuli_wdr.cpp:2694
+#: src/muuli_wdr.cpp:2725
 msgid "Enable filtering of the server IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "Включает фильтрацию IP серверов в соответствии с файлом ~/.aMule/ipfilter.dat."
 
-#: src/muuli_wdr.cpp:2698
+#: src/muuli_wdr.cpp:2729
 msgid "Reload List"
 msgstr "Обновить список"
 
-#: src/muuli_wdr.cpp:2699
+#: src/muuli_wdr.cpp:2730
 msgid "Reload the list of IPs to filter from the file ~/.aMule/ipfilter.dat"
 msgstr "Прочесть список IP адресов, указанных в файле '~/.aMule/ipfilter.dat'."
 
-#: src/muuli_wdr.cpp:2705
+#: src/muuli_wdr.cpp:2736
 msgid "URL:"
 msgstr "URL:"
 
-#: src/muuli_wdr.cpp:2709 src/muuli_wdr.cpp:2902
+#: src/muuli_wdr.cpp:2740 src/muuli_wdr.cpp:2933
 msgid "Update now"
 msgstr "Обновить сейчас"
 
-#: src/muuli_wdr.cpp:2712
+#: src/muuli_wdr.cpp:2743
 msgid "Auto-update ipfilter at startup"
 msgstr "Автоматически обновлять IP-фильтр при запуске"
 
-#: src/muuli_wdr.cpp:2716
+#: src/muuli_wdr.cpp:2747
 msgid "Filtering Level:"
 msgstr "Уровень фильтрации:"
 
-#: src/muuli_wdr.cpp:2722
+#: src/muuli_wdr.cpp:2753
 msgid "Always filter LAN IPs"
 msgstr "Всегда фильтровать IP-адреса LAN"
 
-#: src/muuli_wdr.cpp:2725
+#: src/muuli_wdr.cpp:2756
 msgid "Paranoid handling of non-matching IPs"
 msgstr "Параноидная обработка несовпадающих IP "
 
-#: src/muuli_wdr.cpp:2727
+#: src/muuli_wdr.cpp:2758
 msgid "Rejects a packet when its source IP differs from the IP the client claims (an anti-spoofing check). Disable only if it causes connection problems."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2729
+#: src/muuli_wdr.cpp:2760
 msgid "Use system-wide ipfilter.dat if available"
 msgstr "Использовать системный ipfilter.dat если возможно"
 
-#: src/muuli_wdr.cpp:2730
+#: src/muuli_wdr.cpp:2761
 #, fuzzy
 msgid "If there's no local ipfilter.dat found, allow usage of a system-wide ipfilter file."
 msgstr "Если не найден локальный ipfilter.dat разрешить использовать системный"
 
-#: src/muuli_wdr.cpp:2747
+#: src/muuli_wdr.cpp:2778
 msgid "Enable Online-Signature"
 msgstr "Включить Online-подпись"
 
-#: src/muuli_wdr.cpp:2749
+#: src/muuli_wdr.cpp:2780
 msgid "Enables the writing of the OS file, which can be used by external apps to create signatures and the like."
 msgstr "Включает запись файла OS, который может использоваться другими приложениями для создания подписей."
 
-#: src/muuli_wdr.cpp:2753
+#: src/muuli_wdr.cpp:2784
 msgid "Update Frequency (Secs):"
 msgstr "Частота обновления (в секундах):"
 
-#: src/muuli_wdr.cpp:2756
+#: src/muuli_wdr.cpp:2787
 msgid "Change the frequency (in seconds) of Online Signature updates."
 msgstr "Изменить частоту обновления для Online-подписи в секундах."
 
-#: src/muuli_wdr.cpp:2764
+#: src/muuli_wdr.cpp:2795
 msgid "Save online signature file in: "
 msgstr "Сохранять Online-подпись в:"
 
-#: src/muuli_wdr.cpp:2770
+#: src/muuli_wdr.cpp:2801
 msgid "Click here to select the directory containing the the Online Signature files."
 msgstr "Кликните здесь, чтобы выбрать каталок для файлов Online-подписи."
 
-#: src/muuli_wdr.cpp:2803
+#: src/muuli_wdr.cpp:2834
 msgid "Show country flags for clients"
 msgstr "Показывать национальные флаги клиентов"
 
-#: src/muuli_wdr.cpp:2804
+#: src/muuli_wdr.cpp:2835
 msgid "Render the country flag column in the transfers, queue and search views. Requires a valid MMDB GeoIP database (see below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2809
+#: src/muuli_wdr.cpp:2840
 #, fuzzy
 msgid "Database"
 msgstr "Скорость передачи:"
 
-#: src/muuli_wdr.cpp:2825
+#: src/muuli_wdr.cpp:2856
 #, fuzzy
 msgid "Source:"
 msgstr "Источники"
 
-#: src/muuli_wdr.cpp:2828
+#: src/muuli_wdr.cpp:2859
 msgid "DB-IP (free, no account)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2829
+#: src/muuli_wdr.cpp:2860
 msgid "MaxMind GeoLite2 (free, account required)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2830
+#: src/muuli_wdr.cpp:2861
 msgid "Custom URL"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2833
+#: src/muuli_wdr.cpp:2864
 msgid "Choose which provider supplies the GeoIP MMDB database. DB-IP is the default - no account required. MaxMind requires a free account + license key. Use Custom URL to point at any other MMDB host (e.g. a local mirror)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2850
+#: src/muuli_wdr.cpp:2881
 msgid ""
 "No configuration required.\n"
 "\n"
@@ -4894,11 +4922,11 @@ msgid ""
 "License: Creative Commons BY 4.0 - https://creativecommons.org/licenses/by/4.0/"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2863
+#: src/muuli_wdr.cpp:2894
 msgid "License key:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2869
+#: src/muuli_wdr.cpp:2900
 msgid ""
 "Sign up for a free MaxMind account, then generate a License Key:\n"
 "https://www.maxmind.com/en/geolite2/signup\n"
@@ -4908,227 +4936,227 @@ msgid ""
 "Requires attribution and account registration; refresh at least every 30 days."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2884
+#: src/muuli_wdr.cpp:2915
 #, fuzzy
 msgid "Download URL:"
 msgstr "Прием: "
 
-#: src/muuli_wdr.cpp:2890
+#: src/muuli_wdr.cpp:2921
 msgid ""
 "Must point to an .mmdb file or a .gz / .tar.gz containing one.\n"
 "URL may include credentials (https://user:pass@host/...).\n"
 "License and attribution terms are set by the upstream URL - you are responsible."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2903
+#: src/muuli_wdr.cpp:2934
 msgid "Download the GeoIP database from the selected source."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2905
+#: src/muuli_wdr.cpp:2936
 #, fuzzy
 msgid "Auto-update on startup"
 msgstr "Автоматически обновлять IP-фильтр при запуске"
 
-#: src/muuli_wdr.cpp:2906
+#: src/muuli_wdr.cpp:2937
 msgid "Re-download the GeoIP database from the selected source every time aMule starts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2929
+#: src/muuli_wdr.cpp:2960
 msgid "Filter incoming messages (except current chat):"
 msgstr "Фильтровать входящие сообщения (кроме текущего чата):"
 
-#: src/muuli_wdr.cpp:2931
+#: src/muuli_wdr.cpp:2962
 msgid "Filter all messages"
 msgstr "Фильтровать все сообщения"
 
-#: src/muuli_wdr.cpp:2933
+#: src/muuli_wdr.cpp:2964
 msgid "Filter messages from people not on your friend list"
 msgstr "Фильтровать сообщения пользователей не из вашего списка друзей"
 
-#: src/muuli_wdr.cpp:2935
+#: src/muuli_wdr.cpp:2966
 msgid "Filter messages from unknown clients"
 msgstr "Фильтровать сообщения от неизвестных клиентов"
 
-#: src/muuli_wdr.cpp:2937
+#: src/muuli_wdr.cpp:2968
 msgid "Filter messages containing (use ',' as separator):"
 msgstr "Фильтровать сообщения по содержанию (используйте ',' как разделитель):"
 
-#: src/muuli_wdr.cpp:2940 src/muuli_wdr.cpp:2951
+#: src/muuli_wdr.cpp:2971 src/muuli_wdr.cpp:2982
 msgid "add here the words amule should filter and block messages including it"
 msgstr "Добавьте сюда ключевые слова, при наличии которых aMule будет отфильтровывать и блокировать входящие сообщения."
 
-#: src/muuli_wdr.cpp:2942
+#: src/muuli_wdr.cpp:2973
 msgid "Show received messages in the log"
 msgstr "Показывать полученные сообщения в логе"
 
-#: src/muuli_wdr.cpp:2945
+#: src/muuli_wdr.cpp:2976
 msgid "Comments"
 msgstr "Комментарии"
 
-#: src/muuli_wdr.cpp:2948
+#: src/muuli_wdr.cpp:2979
 msgid "Filter comments containing (use ',' as separator):"
 msgstr "Фильтровать комментарии содержащие (используйте ',' как разделитель):"
 
-#: src/muuli_wdr.cpp:2973
+#: src/muuli_wdr.cpp:3004
 msgid "Enable Proxy"
 msgstr "Использовать прокси-сервер"
 
-#: src/muuli_wdr.cpp:2974
+#: src/muuli_wdr.cpp:3005
 msgid "Enable/disable proxy support"
 msgstr "Включить/выключить поддержку прокси-сервера"
 
-#: src/muuli_wdr.cpp:2977
+#: src/muuli_wdr.cpp:3008
 msgid "Proxy type:"
 msgstr "Тип прокси-сервера:"
 
-#: src/muuli_wdr.cpp:2988
+#: src/muuli_wdr.cpp:3019
 msgid "Proxy host:"
 msgstr "Прокси-сервер:"
 
-#: src/muuli_wdr.cpp:2991
+#: src/muuli_wdr.cpp:3022
 msgid "The proxy host name"
 msgstr "Имя прокси-сервера"
 
-#: src/muuli_wdr.cpp:2993
+#: src/muuli_wdr.cpp:3024
 msgid "Proxy port:"
 msgstr "Порт:"
 
-#: src/muuli_wdr.cpp:2996
+#: src/muuli_wdr.cpp:3027
 msgid "The proxy port"
 msgstr "Порт прокси-сервера"
 
-#: src/muuli_wdr.cpp:2998
+#: src/muuli_wdr.cpp:3029
 msgid "Enable authentication"
 msgstr "Включить идентификацию"
 
-#: src/muuli_wdr.cpp:2999
+#: src/muuli_wdr.cpp:3030
 msgid "Enable/disable username/password authentication"
 msgstr "Включить/выключить использование пароля и логина"
 
-#: src/muuli_wdr.cpp:3002
+#: src/muuli_wdr.cpp:3033
 msgid "Username: "
 msgstr "Имя:"
 
-#: src/muuli_wdr.cpp:3005
+#: src/muuli_wdr.cpp:3036
 msgid "The username to use to connect to the proxy"
 msgstr "Имя пользователя для подключения к прокси-серверу"
 
-#: src/muuli_wdr.cpp:3007
+#: src/muuli_wdr.cpp:3038
 msgid "Password:"
 msgstr "Пароль:"
 
-#: src/muuli_wdr.cpp:3010
+#: src/muuli_wdr.cpp:3041
 msgid "The password to use to connect to the proxy"
 msgstr "Пароль для подключения к прокси-серверу"
 
-#: src/muuli_wdr.cpp:3029
+#: src/muuli_wdr.cpp:3060
 msgid "Connect to:"
 msgstr "Соединиться с:"
 
-#: src/muuli_wdr.cpp:3038
+#: src/muuli_wdr.cpp:3069
 msgid "Login to remote amule"
 msgstr "Войти на удаленный aMule"
 
-#: src/muuli_wdr.cpp:3043
+#: src/muuli_wdr.cpp:3074
 msgid "User name"
 msgstr "Имя пользователя"
 
-#: src/muuli_wdr.cpp:3054
+#: src/muuli_wdr.cpp:3085
 msgid "Remember those settings"
 msgstr "Запомнить настройки"
 
-#: src/muuli_wdr.cpp:3057
+#: src/muuli_wdr.cpp:3088
 #, fuzzy
 msgid "Force ZLIB compression"
 msgstr "Использовать gzip-сжатие"
 
-#: src/muuli_wdr.cpp:3081
+#: src/muuli_wdr.cpp:3112
 msgid "Enable Verbose Debug-Logging."
 msgstr "Записывать в журнал подробные сообщения отладчика."
 
-#: src/muuli_wdr.cpp:3083
+#: src/muuli_wdr.cpp:3114
 #, fuzzy
 msgid "Only to Logfile"
 msgstr "&Открыть файл"
 
-#: src/muuli_wdr.cpp:3085
+#: src/muuli_wdr.cpp:3116
 msgid "Message Categories:"
 msgstr "Категории сообщений:"
 
-#: src/muuli_wdr.cpp:3109 src/PartFileConvertDlg.cpp:160
+#: src/muuli_wdr.cpp:3140 src/PartFileConvertDlg.cpp:160
 msgid "Waiting..."
 msgstr "Ожидание..."
 
-#: src/muuli_wdr.cpp:3129
+#: src/muuli_wdr.cpp:3160
 msgid "Add imports"
 msgstr "Добавить файлы"
 
-#: src/muuli_wdr.cpp:3132
+#: src/muuli_wdr.cpp:3163
 msgid "Retry selected"
 msgstr "Перезапустить выбранное"
 
-#: src/muuli_wdr.cpp:3134
+#: src/muuli_wdr.cpp:3165
 msgid "Remove selected"
 msgstr "Удалить выбранное"
 
-#: src/muuli_wdr.cpp:3197
+#: src/muuli_wdr.cpp:3228
 msgid "Event Types"
 msgstr "Типы Событий"
 
-#: src/muuli_wdr.cpp:3216
+#: src/muuli_wdr.cpp:3247
 msgid "Statistics and queued clients for selected file(s) : Session / All time"
 msgstr "Статистика и очередь клиентов для выбранных файлов: За сессию / За все время"
 
-#: src/muuli_wdr.cpp:3240
+#: src/muuli_wdr.cpp:3271
 msgid "Active Uploads"
 msgstr "Активные загрузки"
 
-#: src/muuli_wdr.cpp:3254
+#: src/muuli_wdr.cpp:3285
 msgid "Percent of total files"
 msgstr "Процент от всех файлов"
 
-#: src/muuli_wdr.cpp:3306
+#: src/muuli_wdr.cpp:3337
 msgid "Show Clients for"
 msgstr "Показать клиентов для"
 
-#: src/muuli_wdr.cpp:3308
+#: src/muuli_wdr.cpp:3339
 msgid "All files"
 msgstr "Все файлы"
 
-#: src/muuli_wdr.cpp:3311
+#: src/muuli_wdr.cpp:3342
 msgid "Selected files"
 msgstr "Выбранные файлы"
 
-#: src/muuli_wdr.cpp:3314
+#: src/muuli_wdr.cpp:3345
 msgid "Active uploads only"
 msgstr "Только активные передачи"
 
-#: src/muuli_wdr.cpp:3321
+#: src/muuli_wdr.cpp:3352
 msgid "Reload:"
 msgstr "Обновить:"
 
-#: src/muuli_wdr.cpp:3325
+#: src/muuli_wdr.cpp:3356
 msgid "Reload your shared files"
 msgstr "Обновить список публикуемых файлов"
 
-#: src/muuli_wdr.cpp:3388
+#: src/muuli_wdr.cpp:3419
 msgid "Send"
 msgstr "Отправить"
 
-#: src/muuli_wdr.cpp:3389
+#: src/muuli_wdr.cpp:3420
 msgid "Sends the specified message."
 msgstr "Отправить данное сообщение."
 
-#: src/muuli_wdr.cpp:3393
+#: src/muuli_wdr.cpp:3424
 msgid "Close this chat-session."
 msgstr "Закрыть данный чат."
 
-#: src/muuli_wdr.cpp:3416
+#: src/muuli_wdr.cpp:3447
 msgid "Connect to any server and/or Kad"
 msgstr "Соединиться с произвольным сервером и/или Kad"
 
 # подпись в главном окне. длинная просто не влезет.
-#: src/muuli_wdr.cpp:3422 src/SharedFilesCtrl.cpp:142 src/Statistics.cpp:941
+#: src/muuli_wdr.cpp:3453 src/SharedFilesCtrl.cpp:142 src/Statistics.cpp:941
 msgid "Shared Files"
 msgstr "Файлы"
 
@@ -5494,250 +5522,250 @@ msgstr "Загружено"
 msgid "ERROR: Failed to open partfile '%s'"
 msgstr "ОШИБКА: не удалось открыть частично закаченный '%s'"
 
-#: src/Preferences.cpp:674
+#: src/Preferences.cpp:701
 msgid "System default"
 msgstr "Системный"
 
-#: src/Preferences.cpp:675
+#: src/Preferences.cpp:702
 msgid "Albanian"
 msgstr "Албанский"
 
-#: src/Preferences.cpp:676
+#: src/Preferences.cpp:703
 msgid "Arabic"
 msgstr "Арабский"
 
-#: src/Preferences.cpp:677
+#: src/Preferences.cpp:704
 msgid "Asturian"
 msgstr "Астурианский"
 
-#: src/Preferences.cpp:678
+#: src/Preferences.cpp:705
 msgid "Basque"
 msgstr "Баскский"
 
-#: src/Preferences.cpp:679
+#: src/Preferences.cpp:706
 msgid "Bulgarian"
 msgstr "Болгарский"
 
-#: src/Preferences.cpp:680
+#: src/Preferences.cpp:707
 msgid "Catalan"
 msgstr "Каталонский"
 
-#: src/Preferences.cpp:681
+#: src/Preferences.cpp:708
 msgid "Chinese (Simplified)"
 msgstr "Китайский (упрощенный)"
 
-#: src/Preferences.cpp:682
+#: src/Preferences.cpp:709
 msgid "Chinese (Traditional)"
 msgstr "Китайский (традиционный)"
 
-#: src/Preferences.cpp:683
+#: src/Preferences.cpp:710
 msgid "Croatian"
 msgstr "Хорватский"
 
-#: src/Preferences.cpp:684
+#: src/Preferences.cpp:711
 msgid "Czech"
 msgstr "Чешский"
 
-#: src/Preferences.cpp:685
+#: src/Preferences.cpp:712
 msgid "Danish"
 msgstr "Датский"
 
-#: src/Preferences.cpp:686
+#: src/Preferences.cpp:713
 msgid "Dutch"
 msgstr "Голландский"
 
-#: src/Preferences.cpp:687
+#: src/Preferences.cpp:714
 msgid "English (U.K.)"
 msgstr "Английский (Великобритания)"
 
-#: src/Preferences.cpp:688
+#: src/Preferences.cpp:715
 #, fuzzy
 msgid "English (U.S.)"
 msgstr "Английский (Великобритания)"
 
-#: src/Preferences.cpp:689
+#: src/Preferences.cpp:716
 msgid "Estonian"
 msgstr "Эстонский"
 
-#: src/Preferences.cpp:690
+#: src/Preferences.cpp:717
 msgid "Finnish"
 msgstr "Финский"
 
-#: src/Preferences.cpp:691
+#: src/Preferences.cpp:718
 msgid "French"
 msgstr "Французский"
 
-#: src/Preferences.cpp:692
+#: src/Preferences.cpp:719
 msgid "Galician"
 msgstr "Гальский"
 
-#: src/Preferences.cpp:693
+#: src/Preferences.cpp:720
 msgid "German"
 msgstr "Немецкий"
 
-#: src/Preferences.cpp:694
+#: src/Preferences.cpp:721
 msgid "Greek"
 msgstr "Греческий"
 
-#: src/Preferences.cpp:695
+#: src/Preferences.cpp:722
 msgid "Hebrew"
 msgstr "Израильский"
 
-#: src/Preferences.cpp:696
+#: src/Preferences.cpp:723
 msgid "Hungarian"
 msgstr "Венгерский"
 
-#: src/Preferences.cpp:697
+#: src/Preferences.cpp:724
 msgid "Italian"
 msgstr "Итальянский"
 
-#: src/Preferences.cpp:698
+#: src/Preferences.cpp:725
 msgid "Japanese"
 msgstr "Японский"
 
-#: src/Preferences.cpp:699
+#: src/Preferences.cpp:726
 msgid "Korean"
 msgstr "Корейский"
 
-#: src/Preferences.cpp:700
+#: src/Preferences.cpp:727
 msgid "Latvian"
 msgstr ""
 
-#: src/Preferences.cpp:701
+#: src/Preferences.cpp:728
 msgid "Lithuanian"
 msgstr "Литовский"
 
-#: src/Preferences.cpp:702
+#: src/Preferences.cpp:729
 msgid "Norwegian (Nynorsk)"
 msgstr "Норвежский (Нюнорск)"
 
-#: src/Preferences.cpp:703
+#: src/Preferences.cpp:730
 msgid "Polish"
 msgstr "Польский"
 
-#: src/Preferences.cpp:704
+#: src/Preferences.cpp:731
 msgid "Portuguese"
 msgstr "Португальский"
 
-#: src/Preferences.cpp:705
+#: src/Preferences.cpp:732
 msgid "Portuguese (Brazilian)"
 msgstr "Португальский (Бразилия)"
 
-#: src/Preferences.cpp:706
+#: src/Preferences.cpp:733
 msgid "Romanian"
 msgstr "Румынский"
 
-#: src/Preferences.cpp:707
+#: src/Preferences.cpp:734
 msgid "Russian"
 msgstr "Русский"
 
-#: src/Preferences.cpp:708
+#: src/Preferences.cpp:735
 msgid "Slovenian"
 msgstr "Словакский"
 
-#: src/Preferences.cpp:709
+#: src/Preferences.cpp:736
 msgid "Spanish"
 msgstr "Испанский"
 
-#: src/Preferences.cpp:710
+#: src/Preferences.cpp:737
 msgid "Swedish"
 msgstr "Шведский"
 
-#: src/Preferences.cpp:711
+#: src/Preferences.cpp:738
 msgid "Turkish"
 msgstr "Турецкий"
 
-#: src/Preferences.cpp:712
+#: src/Preferences.cpp:739
 msgid "Ukrainian"
 msgstr "Украинский"
 
-#: src/Preferences.cpp:815
+#: src/Preferences.cpp:842
 msgid "Change Language"
 msgstr "Изменить язык"
 
-#: src/Preferences.cpp:879
+#: src/Preferences.cpp:906
 msgid "There are no translations installed for aMule"
 msgstr ""
 
-#: src/Preferences.cpp:880
+#: src/Preferences.cpp:907
 #, fuzzy
 msgid "No languages available"
 msgstr "Недоступен"
 
-#: src/Preferences.cpp:1011
+#: src/Preferences.cpp:1038
 msgid "no options available"
 msgstr "нет доступных опций"
 
-#: src/Preferences.cpp:2182
+#: src/Preferences.cpp:2227
 msgid "Invalid category found, skipping"
 msgstr "Обнаружена неверная категория, пропускаем"
 
-#: src/Preferences.cpp:2351
+#: src/Preferences.cpp:2396
 msgid "TCP port can't be higher than 65532 due to server UDP socket being TCP+3"
 msgstr "TCP порт не может быть выше 65532, так как UDP сокет - TCP+3"
 
-#: src/Preferences.cpp:2352
+#: src/Preferences.cpp:2397
 #, c-format
 msgid "Default port will be used (%d)"
 msgstr "Используется порт по умолчанию (%d)"
 
-#: src/PrefsUnifiedDlg.cpp:298 src/Statistics.cpp:866
+#: src/PrefsUnifiedDlg.cpp:300 src/Statistics.cpp:866
 msgid "Connection"
 msgstr "Соединение"
 
-#: src/PrefsUnifiedDlg.cpp:299 src/SearchListCtrl.cpp:117
+#: src/PrefsUnifiedDlg.cpp:301 src/SearchListCtrl.cpp:117
 msgid "Directories"
 msgstr "Каталоги"
 
-#: src/PrefsUnifiedDlg.cpp:300 src/Statistics.cpp:917
+#: src/PrefsUnifiedDlg.cpp:302 src/Statistics.cpp:917
 msgid "Servers"
 msgstr "Сервера"
 
-#: src/PrefsUnifiedDlg.cpp:301 src/ServerListCtrl.cpp:96
+#: src/PrefsUnifiedDlg.cpp:303 src/ServerListCtrl.cpp:96
 msgid "Files"
 msgstr "Файлы"
 
-#: src/PrefsUnifiedDlg.cpp:302
+#: src/PrefsUnifiedDlg.cpp:304
 msgid "Security"
 msgstr "Безопасность"
 
-#: src/PrefsUnifiedDlg.cpp:303
+#: src/PrefsUnifiedDlg.cpp:305
 msgid "Interface"
 msgstr "Интерфейс"
 
-#: src/PrefsUnifiedDlg.cpp:310
+#: src/PrefsUnifiedDlg.cpp:312
 msgid "IP2Country"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:313
+#: src/PrefsUnifiedDlg.cpp:315
 msgid "Proxy"
 msgstr "Прокси"
 
-#: src/PrefsUnifiedDlg.cpp:314
+#: src/PrefsUnifiedDlg.cpp:316
 msgid "Filters"
 msgstr "Фильтры"
 
-#: src/PrefsUnifiedDlg.cpp:315
+#: src/PrefsUnifiedDlg.cpp:317
 msgid "Remote Controls"
 msgstr "Удаленный контроль"
 
-#: src/PrefsUnifiedDlg.cpp:316
+#: src/PrefsUnifiedDlg.cpp:318
 msgid "Online Signature"
 msgstr "Online-подпись"
 
-#: src/PrefsUnifiedDlg.cpp:317
+#: src/PrefsUnifiedDlg.cpp:319
 msgid "Advanced"
 msgstr "Дополнительно"
 
-#: src/PrefsUnifiedDlg.cpp:318
+#: src/PrefsUnifiedDlg.cpp:320
 msgid "Events"
 msgstr "События"
 
-#: src/PrefsUnifiedDlg.cpp:321
+#: src/PrefsUnifiedDlg.cpp:323
 msgid "Debugging"
 msgstr "Отладчик"
 
-#: src/PrefsUnifiedDlg.cpp:451
+#: src/PrefsUnifiedDlg.cpp:453
 msgid ""
 "The following variables will be substituted:\n"
 "    %PARTFILE - full path to the file\n"
@@ -5747,15 +5775,15 @@ msgstr ""
 "   %PARTFILE - полный путь к файлу\n"
 "   %PARTNAME - только имя файла"
 
-#: src/PrefsUnifiedDlg.cpp:472
+#: src/PrefsUnifiedDlg.cpp:474
 msgid "Tray icon support requires libayatana-appindicator3 at compile time."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:488
+#: src/PrefsUnifiedDlg.cpp:490
 msgid "Not available on Wayland: the protocol does not report when a window is minimized, so this option cannot intercept the system minimize button. Workaround: launch aMule with `GDK_BACKEND=x11` to use XWayland instead."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:534
+#: src/PrefsUnifiedDlg.cpp:536
 msgid ""
 "Do not change these setting unless you know\n"
 "what you are doing, otherwise you can easily\n"
@@ -5771,26 +5799,35 @@ msgstr ""
 "aMule будет превосходно работать и БЕЗ ИЗМЕНЕНИЯ вами\n"
 "этих настроек."
 
-#: src/PrefsUnifiedDlg.cpp:645
+#: src/PrefsUnifiedDlg.cpp:647
 #, c-format
 msgid "Failed to connect Cfg to widget with the ID %d and key %s"
 msgstr "Не удалось подключить Cfg к widget с ID %d и ключом %s"
 
-#: src/PrefsUnifiedDlg.cpp:693
+#: src/PrefsUnifiedDlg.cpp:695
 #, c-format
 msgid "Failed to transfer data from Cfg to Widget with the ID %d and key %s"
 msgstr "Не удалось передать данные из Cfg к Widget с ID %d и ключом %s"
 
-#: src/PrefsUnifiedDlg.cpp:799
+#: src/PrefsUnifiedDlg.cpp:801
 msgid "The type of proxy you are connecting to"
 msgstr "Тип прокси-сервера, который вы используете"
 
-#: src/PrefsUnifiedDlg.cpp:1003
+#: src/PrefsUnifiedDlg.cpp:1020
 #, c-format
 msgid "Failed to transfer data from Widget to Cfg with the ID %d and key %s"
 msgstr "Не удалось передать данные из Widget к Cfg с ID %d и ключом %s"
 
 #: src/PrefsUnifiedDlg.cpp:1103
+#, fuzzy
+msgid "No password set."
+msgstr "Проверяю пароль\n"
+
+#: src/PrefsUnifiedDlg.cpp:1132
+msgid "Guest access needs a password. Type one in the guest password field, or untick Enable guest access."
+msgstr ""
+
+#: src/PrefsUnifiedDlg.cpp:1144
 msgid ""
 "aMule must be restarted to enable these changes:\n"
 "\n"
@@ -5798,42 +5835,42 @@ msgstr ""
 "Необходимо перезапустить aMule чтобы следующие изменения вступили в силу:\n"
 "\n"
 
-#: src/PrefsUnifiedDlg.cpp:1110
+#: src/PrefsUnifiedDlg.cpp:1151
 msgid "- TCP port changed.\n"
 msgstr "- изменен порт TCP.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1115
+#: src/PrefsUnifiedDlg.cpp:1156
 msgid "- UDP port changed.\n"
 msgstr "- изменен порт UDP.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1120
+#: src/PrefsUnifiedDlg.cpp:1161
 #, fuzzy
 msgid "- Network interface binding changed.\n"
 msgstr "- Интерфейс внешних соединений изменен.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1125
+#: src/PrefsUnifiedDlg.cpp:1166
 msgid "- External connect port changed.\n"
 msgstr "- Порт для внешних соединений изменен.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1129
+#: src/PrefsUnifiedDlg.cpp:1170
 msgid "- External connect acceptance changed.\n"
 msgstr "- Принятие внешних соединений изменено.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1133
+#: src/PrefsUnifiedDlg.cpp:1174
 msgid "- External connect interface changed.\n"
 msgstr "- Интерфейс внешних соединений изменен.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1137
+#: src/PrefsUnifiedDlg.cpp:1178
 #, fuzzy
 msgid "- Protocol obfuscation support changed.\n"
 msgstr "Вуалирование протокола"
 
-#: src/PrefsUnifiedDlg.cpp:1151
+#: src/PrefsUnifiedDlg.cpp:1193
 #, fuzzy
 msgid "- amuleapi settings changed.\n"
 msgstr "- Изменен язык.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1160
+#: src/PrefsUnifiedDlg.cpp:1202
 msgid ""
 "Your Auto-update server list is empty.\n"
 "'Auto-update server list at startup' will be disabled."
@@ -5841,7 +5878,7 @@ msgstr ""
 "Список авто обновления пуст.\n"
 "Автоматическое обновление списка серверов отключено."
 
-#: src/PrefsUnifiedDlg.cpp:1171
+#: src/PrefsUnifiedDlg.cpp:1213
 msgid ""
 "You have enabled external connections but have not specified a password.\n"
 "External connections cannot be enabled unless a valid password is specified."
@@ -5849,28 +5886,33 @@ msgstr ""
 "Вы включили внешние соединения, но не указали пароль.\n"
 "Внешние соединения нельзя включить до тех пор, пока не указан пароль."
 
-#: src/PrefsUnifiedDlg.cpp:1202
+#: src/PrefsUnifiedDlg.cpp:1246
+#, c-format
+msgid "The amuleapi password could not be saved: %s"
+msgstr ""
+
+#: src/PrefsUnifiedDlg.cpp:1276
 msgid "- Language changed.\n"
 msgstr "- Изменен язык.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1207
+#: src/PrefsUnifiedDlg.cpp:1281
 msgid "- Temp folder changed.\n"
 msgstr "- Изменен временный каталог.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1212
+#: src/PrefsUnifiedDlg.cpp:1286
 msgid "- ED2K network enabled.\n"
 msgstr "- сеть eD2k включена. \n"
 
-#: src/PrefsUnifiedDlg.cpp:1245
+#: src/PrefsUnifiedDlg.cpp:1319
 msgid "The shared-file exclusion pattern is not a valid regular expression. The filter has been left disabled."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1247 src/PrefsUnifiedDlg.cpp:1841
+#: src/PrefsUnifiedDlg.cpp:1321 src/PrefsUnifiedDlg.cpp:1921
 #, fuzzy
 msgid "Invalid regular expression"
 msgstr "Недопустимая версия протокола."
 
-#: src/PrefsUnifiedDlg.cpp:1324
+#: src/PrefsUnifiedDlg.cpp:1398
 msgid ""
 "Both eD2k and Kad network are disabled.\n"
 "You won't be able to connect until you enable at least one of them."
@@ -5878,7 +5920,7 @@ msgstr ""
 "Сети eD2k и Kad обе отключены.\n"
 "Вы не сможете подсоединиться пока не подключите хотя бы одну из них."
 
-#: src/PrefsUnifiedDlg.cpp:1329
+#: src/PrefsUnifiedDlg.cpp:1403
 msgid ""
 "Kad will not start if your UDP port is disabled.\n"
 "Enable UDP port or disable Kad."
@@ -5886,7 +5928,7 @@ msgstr ""
 "Kad не будет запущена, если UDP-порт выключен.\n"
 "Включите UDP-порт или выключите Kad."
 
-#: src/PrefsUnifiedDlg.cpp:1385
+#: src/PrefsUnifiedDlg.cpp:1459
 msgid ""
 "\n"
 "You MUST restart aMule now.\n"
@@ -5896,69 +5938,69 @@ msgstr ""
 "Вам НЕОБХОДИМО перезапустить aMule немедленно.\n"
 "Иначе не жалуйтесь, если произойдет какая-нибудь неприятность.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1450
+#: src/PrefsUnifiedDlg.cpp:1524
 msgid "Could not register aMule for autostart at login. The autostart store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1452
+#: src/PrefsUnifiedDlg.cpp:1526
 msgid "Could not remove the autostart-at-login entry."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1453
+#: src/PrefsUnifiedDlg.cpp:1527
 #, fuzzy
 msgid "Autostart"
 msgstr "Автоматическое обновление начато"
 
-#: src/PrefsUnifiedDlg.cpp:1468
+#: src/PrefsUnifiedDlg.cpp:1542
 msgid "Register file type"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1468
+#: src/PrefsUnifiedDlg.cpp:1542
 msgid "Register URL handler"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1476
+#: src/PrefsUnifiedDlg.cpp:1550
 #, c-format
 msgid "aMule only handles eD2k-compatible magnets. If you replace the current magnet handler (%s), BitTorrent magnet links will stop working - aMule cannot download BitTorrent content. Continue?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1481
+#: src/PrefsUnifiedDlg.cpp:1555
 #, c-format
 msgid "Another application currently opens .emulecollection files (%s). Replace it with aMule?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1486
+#: src/PrefsUnifiedDlg.cpp:1560
 #, c-format
 msgid "Another application is currently the default handler for these links (%s). Replace it with aMule?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1511
+#: src/PrefsUnifiedDlg.cpp:1585
 msgid "Could not register aMule for .emulecollection files. The registration store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1513
+#: src/PrefsUnifiedDlg.cpp:1587
 #, fuzzy
 msgid "Could not remove the file type registration."
 msgstr "Папка для временных файлов"
 
-#: src/PrefsUnifiedDlg.cpp:1515
+#: src/PrefsUnifiedDlg.cpp:1589
 msgid "Could not register aMule as the URL handler. The registration store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1517
+#: src/PrefsUnifiedDlg.cpp:1591
 msgid "Could not remove the URL handler registration."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1587 src/PrefsUnifiedDlg.cpp:1614
+#: src/PrefsUnifiedDlg.cpp:1661 src/PrefsUnifiedDlg.cpp:1688
 #, fuzzy
 msgid "The web server and aMule API require external connections to be enabled."
 msgstr "Пароль задан и внешние соединения разрешены."
 
-#: src/PrefsUnifiedDlg.cpp:1597
+#: src/PrefsUnifiedDlg.cpp:1671
 msgid "The aMule web server is deprecated. Consider running the aMule API instead."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1655
+#: src/PrefsUnifiedDlg.cpp:1735
 msgid ""
 "Your Auto-update servers list is in blank.\n"
 "Please fill in at least one URL to point to a valid server.met file.\n"
@@ -5968,24 +6010,24 @@ msgstr ""
 "Пожалуйста, внесите в список хотя бы один URL, указывающий на корректный 'server.met'.\n"
 "Щелкните на кнопке \"Список\" чтобы ввести URL."
 
-#: src/PrefsUnifiedDlg.cpp:1796
+#: src/PrefsUnifiedDlg.cpp:1876
 msgid "Temporary files"
 msgstr "Временные файлы"
 
-#: src/PrefsUnifiedDlg.cpp:1801
+#: src/PrefsUnifiedDlg.cpp:1881
 msgid "Incoming files"
 msgstr "Входящие файлы"
 
-#: src/PrefsUnifiedDlg.cpp:1806
+#: src/PrefsUnifiedDlg.cpp:1886
 msgid "Online Signatures"
 msgstr "Online-подписи"
 
-#: src/PrefsUnifiedDlg.cpp:1819
+#: src/PrefsUnifiedDlg.cpp:1899
 #, c-format
 msgid "Choose a folder for %s"
 msgstr "Выберите каталог для %s"
 
-#: src/PrefsUnifiedDlg.cpp:1843
+#: src/PrefsUnifiedDlg.cpp:1923
 #, fuzzy, c-format
 msgid "Would exclude %u of %u shared file"
 msgid_plural "Would exclude %u of %u shared files"
@@ -5993,42 +6035,42 @@ msgstr[0] "Найден %i известный публикуемый файл."
 msgstr[1] "Найдено %i известных публикуемых файла."
 msgstr[2] "Найдено %i известных публикуемых файлов."
 
-#: src/PrefsUnifiedDlg.cpp:1860
+#: src/PrefsUnifiedDlg.cpp:1940
 msgid "Browse for videoplayer"
 msgstr "Выбрать видео-проигрыватель"
 
-#: src/PrefsUnifiedDlg.cpp:1864
+#: src/PrefsUnifiedDlg.cpp:1944
 msgid "Select browser"
 msgstr "Выберите броузер"
 
-#: src/PrefsUnifiedDlg.cpp:1868
+#: src/PrefsUnifiedDlg.cpp:1948
 #, fuzzy
 msgid "Select ffprobe binary"
 msgstr "Выберите броузер"
 
-#: src/PrefsUnifiedDlg.cpp:1874
+#: src/PrefsUnifiedDlg.cpp:1954
 #, c-format
 msgid "Executable%s"
 msgstr "Команда запуска%s"
 
-#: src/PrefsUnifiedDlg.cpp:1908
+#: src/PrefsUnifiedDlg.cpp:1988
 msgid "ffprobe not found on PATH or in the standard install locations. Install ffmpeg (which ships ffprobe) or use Browse to pick a binary manually."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1920
+#: src/PrefsUnifiedDlg.cpp:2000
 msgid "Reset the settings on this page to their default values?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1921
+#: src/PrefsUnifiedDlg.cpp:2001
 #, fuzzy
 msgid "Reset to defaults"
 msgstr "Системный"
 
-#: src/PrefsUnifiedDlg.cpp:1948
+#: src/PrefsUnifiedDlg.cpp:2028
 msgid "Edit server list"
 msgstr "Редактировать список серверов"
 
-#: src/PrefsUnifiedDlg.cpp:1949
+#: src/PrefsUnifiedDlg.cpp:2029
 msgid ""
 "Add here URL's to download server.met files.\n"
 "Only one url on each line."
@@ -6036,42 +6078,42 @@ msgstr ""
 "Впишите сюда адреса для получения файлов 'server.met'.\n"
 "Только один URL в одной строчке."
 
-#: src/PrefsUnifiedDlg.cpp:2004
+#: src/PrefsUnifiedDlg.cpp:2084
 msgid "IP2Country update failed"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2149 src/PrefsUnifiedDlg.cpp:2180
+#: src/PrefsUnifiedDlg.cpp:2229 src/PrefsUnifiedDlg.cpp:2260
 msgid "Data by MaxMind GeoLite2"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2151 src/PrefsUnifiedDlg.cpp:2182
+#: src/PrefsUnifiedDlg.cpp:2231 src/PrefsUnifiedDlg.cpp:2262
 #, fuzzy
 msgid "Custom source"
 msgstr "Полных источников"
 
-#: src/PrefsUnifiedDlg.cpp:2153 src/PrefsUnifiedDlg.cpp:2184
+#: src/PrefsUnifiedDlg.cpp:2233 src/PrefsUnifiedDlg.cpp:2264
 msgid "Data by DB-IP.com"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2204
+#: src/PrefsUnifiedDlg.cpp:2284
 #, fuzzy, c-format
 msgid "Status: Loaded%s"
 msgstr "Статус:"
 
-#: src/PrefsUnifiedDlg.cpp:2206
+#: src/PrefsUnifiedDlg.cpp:2286
 #, fuzzy, c-format
 msgid "Status: Loaded%s - %s"
 msgstr "Статус:"
 
-#: src/PrefsUnifiedDlg.cpp:2210
+#: src/PrefsUnifiedDlg.cpp:2290
 msgid "Status: Failed to load - click 'Update now' to refresh."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2212
+#: src/PrefsUnifiedDlg.cpp:2292
 msgid "Status: Not found - click 'Update now' to download."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2270 src/PrefsUnifiedDlg.cpp:2294
+#: src/PrefsUnifiedDlg.cpp:2350 src/PrefsUnifiedDlg.cpp:2374
 #, c-format
 msgid "Update delay: %d second"
 msgid_plural "Update delay: %d seconds"
@@ -6079,7 +6121,7 @@ msgstr[0] "Интервал обновления: %d с"
 msgstr[1] "Интервал обновления: %d сек"
 msgstr[2] "Интервал обновления: %d сек"
 
-#: src/PrefsUnifiedDlg.cpp:2278
+#: src/PrefsUnifiedDlg.cpp:2358
 #, c-format
 msgid "Time for average graph: %d minute"
 msgid_plural "Time for average graph: %d minutes"
@@ -6087,12 +6129,12 @@ msgstr[0] "Отрезок времени, охватывающийся граф�
 msgstr[1] "Отрезок времени, охватывающийся графиком: %d минут"
 msgstr[2] "Отрезок времени, охватывающийся графиком: %d минут"
 
-#: src/PrefsUnifiedDlg.cpp:2287
+#: src/PrefsUnifiedDlg.cpp:2367
 #, c-format
 msgid "Connections Graph Scale: %d"
 msgstr "Масштаб графика соединений: %d"
 
-#: src/PrefsUnifiedDlg.cpp:2302
+#: src/PrefsUnifiedDlg.cpp:2382
 #, c-format
 msgid "File Buffer Size: %d byte"
 msgid_plural "File Buffer Size: %d bytes"
@@ -6100,7 +6142,7 @@ msgstr[0] "Файловый буфер: %d Б"
 msgstr[1] "Размер буфера: %d байт"
 msgstr[2] "Размер буфера: %d байт"
 
-#: src/PrefsUnifiedDlg.cpp:2312
+#: src/PrefsUnifiedDlg.cpp:2392
 #, c-format
 msgid "Upload Queue Size: %d client"
 msgid_plural "Upload Queue Size: %d clients"
@@ -6108,7 +6150,7 @@ msgstr[0] "Размер очереди отдачи: %d"
 msgstr[1] "Размер очереди отдачи: %d клиентов"
 msgstr[2] "Размер очереди отдачи: %d клиентов"
 
-#: src/PrefsUnifiedDlg.cpp:2322
+#: src/PrefsUnifiedDlg.cpp:2402
 #, c-format
 msgid "Server connection refresh interval: %d minute"
 msgid_plural "Server connection refresh interval: %d minutes"
@@ -6116,80 +6158,80 @@ msgstr[0] "Частота связи с сервером: %d м"
 msgstr[1] "Интервал обновления соединения с сервером: %d минут"
 msgstr[2] "Интервал обновления соединения с сервером: %d минут"
 
-#: src/PrefsUnifiedDlg.cpp:2327
+#: src/PrefsUnifiedDlg.cpp:2407
 msgid "Server connection refresh interval: Disabled"
 msgstr "Обновление соединения с сервером: Отключено"
 
-#: src/PrefsUnifiedDlg.cpp:2371
+#: src/PrefsUnifiedDlg.cpp:2451
 msgid "disabled"
 msgstr "выключена"
 
-#: src/PrefsUnifiedDlg.cpp:2397
+#: src/PrefsUnifiedDlg.cpp:2477
 #, c-format
 msgid "Execute command on '%s' event"
 msgstr "Выполнить команду при событии '%s'"
 
-#: src/PrefsUnifiedDlg.cpp:2404
+#: src/PrefsUnifiedDlg.cpp:2484
 msgid "Enable command execution on core"
 msgstr "Включить выполнение команд в ядре"
 
-#: src/PrefsUnifiedDlg.cpp:2416
+#: src/PrefsUnifiedDlg.cpp:2496
 msgid "Core command:"
 msgstr "Команда ядра:"
 
 # никто ни в жизни не поймет переведенную аббревиатуру
-#: src/PrefsUnifiedDlg.cpp:2432
+#: src/PrefsUnifiedDlg.cpp:2512
 msgid "Enable command execution on GUI"
 msgstr "Включить выполнение команд в GUI"
 
-#: src/PrefsUnifiedDlg.cpp:2444
+#: src/PrefsUnifiedDlg.cpp:2524
 msgid "GUI command:"
 msgstr "Команда GUI:"
 
-#: src/PrefsUnifiedDlg.cpp:2460
+#: src/PrefsUnifiedDlg.cpp:2540
 msgid "The following variables will be replaced:"
 msgstr "Следующие переменные будут заменены:"
 
-#: src/PrefsUnifiedDlg.cpp:2628
+#: src/PrefsUnifiedDlg.cpp:2708
 msgid ""
 "The following folders look like system or sensitive locations:\n"
 "\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2633
+#: src/PrefsUnifiedDlg.cpp:2713
 msgid "Sharing them recursively will publish every file underneath on the eD2k/Kad networks. Do you really want to do this?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2636
+#: src/PrefsUnifiedDlg.cpp:2716
 #, fuzzy
 msgid "Confirm shared folders"
 msgstr "Публикуемые папки"
 
-#: src/PrefsUnifiedDlg.cpp:2664
+#: src/PrefsUnifiedDlg.cpp:2744
 #, fuzzy
 msgid "Reloading shared files..."
 msgstr "Обновить список публикуемых файлов"
 
-#: src/PrefsUnifiedDlg.cpp:2665
+#: src/PrefsUnifiedDlg.cpp:2745
 msgid "Scanning for subdirectories..."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2666
+#: src/PrefsUnifiedDlg.cpp:2746
 #, fuzzy
 msgid "Updating shared folders"
 msgstr "Публикуемые папки"
 
-#: src/PrefsUnifiedDlg.cpp:2693
+#: src/PrefsUnifiedDlg.cpp:2773
 #, c-format
 msgid "Scanned %u directories..."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2743
+#: src/PrefsUnifiedDlg.cpp:2823
 #, fuzzy, c-format
 msgid "Reloading shared files: %u files scanned"
 msgstr "Обновить список публикуемых файлов."
 
-#: src/PrefsUnifiedDlg.cpp:2793
+#: src/PrefsUnifiedDlg.cpp:2873
 #, fuzzy
 msgid "Shared folder"
 msgstr "Публикуемые папки"

--- a/po/sl.po
+++ b/po/sl.po
@@ -11,8 +11,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-28 12:12+0200\n"
-"PO-Revision-Date: 2026-07-27 10:33+0000\n"
+"POT-Creation-Date: 2026-07-28 08:06+0200\n"
+"PO-Revision-Date: 2026-07-27 11:45+0000\n"
 "Last-Translator: Jure Repinc <jlp@holodeck1.com>\n"
 "Language-Team: Slovenian\n"
 "Language: sl\n"
@@ -146,7 +146,7 @@ msgstr ""
 msgid "Not now"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:422 src/amuleDlg.cpp:665
+#: src/AppImageIntegration.cpp:422 src/amuleDlg.cpp:600
 msgid "Don't ask again"
 msgstr ""
 
@@ -204,83 +204,83 @@ msgstr "Ni bilo mogoče odpreti datoteke ED2KLinks."
 msgid "WARNING: You can't add yourself as a source for an eD2k link while having a lowid."
 msgstr "OPOZORILO: če imete nizek ID, sebe ne morete dodati kot vira za povezavo eD2k."
 
-#: src/amule.cpp:301
+#: src/amule.cpp:300
 msgid "Now, exiting main app..."
 msgstr "Sedaj, zapuščanje glavnega programa …"
 
-#: src/amule.cpp:331
+#: src/amule.cpp:330
 #, c-format
 msgid "Terminating amuleweb instance with pid '%d' ... "
 msgstr "Končanje izvoda amuleweb s PID »%d« ... "
 
-#: src/amule.cpp:335
+#: src/amule.cpp:334
 #, c-format
 msgid "Killing amuleweb instance with pid '%d' ... "
 msgstr "Ubijanje izvoda amuleweb s PID »%d« ... "
 
-#: src/amule.cpp:337 src/amule.cpp:350 src/ClientRef.cpp:180
-#: src/SearchDlg.cpp:1041 src/ServerListCtrl.cpp:98
+#: src/amule.cpp:336 src/amule.cpp:349 src/ClientRef.cpp:180
+#: src/SearchDlg.cpp:880 src/ServerListCtrl.cpp:98
 msgid "Failed"
 msgstr "Neuspeh"
 
-#: src/amule.cpp:344
+#: src/amule.cpp:343
 #, fuzzy, c-format
 msgid "Terminating amuleapi instance with pid '%d' ... "
 msgstr "Končanje izvoda amuleweb s PID »%d« ... "
 
-#: src/amule.cpp:348
+#: src/amule.cpp:347
 #, fuzzy, c-format
 msgid "Killing amuleapi instance with pid '%d' ... "
 msgstr "Ubijanje izvoda amuleweb s PID »%d« ... "
 
-#: src/amule.cpp:356
+#: src/amule.cpp:355
 msgid "aMule OnExit: Terminating core."
 msgstr "aMule OnExit: Končevanje jedra."
 
-#: src/amule.cpp:467
+#: src/amule.cpp:466
 msgid "aMule shutdown completed."
 msgstr "Zaustavitev aMule zaključena."
 
-#: src/amule.cpp:471
+#: src/amule.cpp:470
 msgid "Memory debug results for aMule exit:"
 msgstr "Rezultati razhroščevanja pomnilnika za izhod iz aMule:"
 
-#: src/amule.cpp:652
+#: src/amule.cpp:651
 #, c-format
 msgid "Binding aMule's peer-to-peer traffic to interface: %s (HTTP updates use the default route)"
 msgstr ""
 
-#: src/amule.cpp:656
+#: src/amule.cpp:655
 #, c-format
 msgid "Binding all network traffic to interface: %s"
 msgstr ""
 
-#: src/amule.cpp:660
+#: src/amule.cpp:659
 #, c-format
 msgid "WARNING: configured network interface '%s' was not found - traffic is NOT bound to it and may leave via the default route. Check the interface name in Preferences."
 msgstr ""
 
-#: src/amule.cpp:666
+#: src/amule.cpp:665
 #, c-format
 msgid "WARNING: binding to network interface '%s' requires elevated privileges and was NOT applied - traffic may leave via the default route. Grant the capability (e.g. 'sudo setcap cap_net_raw+ep' on the aMule binary) or run with sufficient privileges."
 msgstr ""
 
-#: src/amule.cpp:674
+#: src/amule.cpp:673
 #, c-format
 msgid "WARNING: could not bind to network interface '%s' - traffic may leave via the default route."
 msgstr ""
 
-#: src/amule.cpp:733
+#: src/amule.cpp:732
 msgid "Your locale has been changed to System Default due to a configuration change. Sorry."
 msgstr "Vaše področne nastavitve so bile spremenjene na sistemsko privzete zaradi spremembe v nastavitvah. Oprostite."
 
-#: src/amule.cpp:735 src/amule.cpp:1589 src/CatDialog.cpp:128
+#: src/amule.cpp:734 src/amule.cpp:1581 src/CatDialog.cpp:128
 #: src/CatDialog.cpp:136 src/CatDialog.cpp:149 src/ServerList.cpp:366
 #: src/ServerListCtrl.cpp:152
 msgid "Info"
 msgstr "Podatki"
 
-#: src/amule.cpp:742
+#: src/amule.cpp:741
 msgid ""
 "\n"
 "EC configuration"
@@ -288,74 +288,74 @@ msgstr ""
 "\n"
 "Nastavitev zunanje povezave"
 
-#: src/amule.cpp:745
+#: src/amule.cpp:744
 msgid "Password set and external connections enabled."
 msgstr "Geslo je bilo nastavljeno in zunanje povezave omogočene."
 
-#: src/amule.cpp:755 src/KadDlg.cpp:176 src/KadDlg.cpp:185
-#: src/PrefsUnifiedDlg.cpp:1461 src/SharedFilesCtrl.cpp:476
+#: src/amule.cpp:754 src/KadDlg.cpp:176 src/KadDlg.cpp:185
+#: src/PrefsUnifiedDlg.cpp:1387 src/SharedFilesCtrl.cpp:476
 msgid "WARNING"
 msgstr "OPOZORILO"
 
-#: src/amule.cpp:992
+#: src/amule.cpp:991
 #, fuzzy
 msgid "Network bootstrap"
 msgstr "Omrežja"
 
-#: src/amule.cpp:997
+#: src/amule.cpp:996
 msgid ""
 "aMule has detected missing network bootstrap files.\n"
 "Select which ones to download:"
 msgstr ""
 
-#: src/amule.cpp:1006 src/FirstRunWizard.cpp:411
+#: src/amule.cpp:1005 src/FirstRunWizard.cpp:411
 #, fuzzy
 msgid "eD2k server list (server.met)"
 msgstr "%i najdenih strežnikov v server.met"
 
-#: src/amule.cpp:1013 src/FirstRunWizard.cpp:416
+#: src/amule.cpp:1012 src/FirstRunWizard.cpp:416
 msgid "Kad bootstrap nodes (nodes.dat)"
 msgstr ""
 
-#: src/amule.cpp:1103
+#: src/amule.cpp:1102
 #, c-format
 msgid "web server running on pid %d"
 msgstr "spletni strežnik teče s PID %d"
 
-#: src/amule.cpp:1116
+#: src/amule.cpp:1115
 #, fuzzy
 msgid "You requested to run web server on startup, but the amuleweb binary cannot be run. Please install the package containing aMule web server, or build aMule from source with -DBUILD_WEBSERVER=YES and install it."
 msgstr "Zahtevali ste zagon spletnega strežnika ob zagonu programa, a programa amuleweb ni moč zagnati. Namestite paket, ki vsebuje spletni strežnik aMule, ali pa prevedite aMule z možnostjo »--enable-webserver« in ga znova namestite z »make install«."
 
-#: src/amule.cpp:1121 src/amule.cpp:1185 src/amule.cpp:1299 src/amule.cpp:1601
+#: src/amule.cpp:1120 src/amule.cpp:1177 src/amule.cpp:1291 src/amule.cpp:1593
 #: src/amule-remote-gui.cpp:603 src/amule-remote-gui.cpp:671
 #: src/amule-remote-gui.cpp:709 src/amule-remote-gui.cpp:1282
 #: src/amule-remote-gui.cpp:1345 src/amule-remote-gui.cpp:1372
-#: src/DownloadQueue.cpp:1481 src/PrefsUnifiedDlg.cpp:1247
+#: src/DownloadQueue.cpp:1481
 msgid "ERROR"
 msgstr "NAPAKA"
 
-#: src/amule.cpp:1174
+#: src/amule.cpp:1166
 #, fuzzy, c-format
 msgid "amuleapi running on pid %d"
 msgstr "spletni strežnik teče s PID %d"
 
-#: src/amule.cpp:1180
+#: src/amule.cpp:1172
 #, fuzzy
 msgid "You requested to run amuleapi on startup, but the amuleapi binary cannot be run. Please install the package containing aMule's REST API server, or build aMule from source with -DBUILD_AMULEAPI=YES and install it."
 msgstr "Zahtevali ste zagon spletnega strežnika ob zagonu programa, a programa amuleweb ni moč zagnati. Namestite paket, ki vsebuje spletni strežnik aMule, ali pa prevedite aMule z možnostjo »--enable-webserver« in ga znova namestite z »make install«."
 
-#: src/amule.cpp:1267
+#: src/amule.cpp:1259
 #, c-format
 msgid "Could not bind ports to the specified address: %s"
 msgstr "Vrat ni bilo moč povezati z navedenim naslovom: %s"
 
-#: src/amule.cpp:1291
+#: src/amule.cpp:1283
 #, c-format
 msgid "Port %u is not available. You will be LOWID\n"
 msgstr "Vrata %u niso razpoložljiva. Imeli boste nizek ID\n"
 
-#: src/amule.cpp:1296
+#: src/amule.cpp:1288
 #, c-format
 msgid ""
 "Port %u is not available!\n"
@@ -370,49 +370,49 @@ msgstr ""
 "\n"
 "Preverite omrežje in se prepričajte, da so vrata odprta za izhod in vhod."
 
-#: src/amule.cpp:1393
+#: src/amule.cpp:1385
 msgid "Failed to create OnlineSig File"
 msgstr "Ni bilo mogoče ustvariti datoteke spletnega podpisa"
 
-#: src/amule.cpp:1401
+#: src/amule.cpp:1393
 msgid "Failed to create aMule OnlineSig File"
 msgstr "Ni bilo mogoče ustvariti aMule datoteke spletnega podpisa"
 
-#: src/amule.cpp:1564
+#: src/amule.cpp:1556
 msgid "The selected locale seems not to be installed on your box. (Note: I'll try to set it anyway)"
 msgstr "Kot kaže izbrana področna nastavitev ni nameščena na vašem računalniku. (Opomba: vseeno se jo bo poskusilo nastaviti)"
 
-#: src/amule.cpp:1574
+#: src/amule.cpp:1566
 #, c-format
 msgid "This is the first time you run aMule %s"
 msgstr "To je vaš prvi zagon aMule %s"
 
-#: src/amule.cpp:1577
+#: src/amule.cpp:1569
 msgid "This version is a testing version, updated daily, and\n"
 msgstr "To je testna različica, posodobljena dnevno in\n"
 
-#: src/amule.cpp:1578
+#: src/amule.cpp:1570
 msgid "we give no warranty it won't break anything, burn your house,\n"
 msgstr "ne dajemo zagotovila, da ne bo ničesar poškodovala, zažgala vaše hiše\n"
 
-#: src/amule.cpp:1579
+#: src/amule.cpp:1571
 msgid "or kill your dog. But it *should* be safe to use anyway.\n"
 msgstr "ali ubila vašega psa. Vendar bi vseeno morala biti varna za uporabo.\n"
 
-#: src/amule.cpp:1584
+#: src/amule.cpp:1576
 msgid "More information, support and new releases can found at our homepage,\n"
 msgstr "Več informacij, podporo in nove različice, lahko najdete na naši domači strani,\n"
 
-#: src/amule.cpp:1585
+#: src/amule.cpp:1577
 msgid "at https://amule-org.github.io, or in our IRC channel #aMule at irc.libera.chat.\n"
 msgstr "na https://amule-org.github.io, ali na kanalu IRC #aMule, na strežniku irc.libera.chat.\n"
 
-#: src/amule.cpp:1587
+#: src/amule.cpp:1579
 #, fuzzy
 msgid "Feel free to report any bugs to https://github.com/amule-org/amule/issues"
 msgstr "Morebitne hrošče lahko sporočite na https://github.com/amule-org/amule/issues"
 
-#: src/amule.cpp:1599
+#: src/amule.cpp:1591
 msgid ""
 "The folder for Online Signature files you specified is INVALID!\n"
 " OnlineSignature will be DISABLED until you fix it on preferences."
@@ -420,138 +420,138 @@ msgstr ""
 "Navedena mapa za datoteke za spletni podpis je NEVELJAVNA.\n"
 "Spletni podpis bo ONEMOGOČEN, dokler težave ne odpravite v nastavitvah."
 
-#: src/amule.cpp:1662
+#: src/amule.cpp:1654
 msgid "Server hostname notified"
 msgstr "Gostitelj strežnika obveščen"
 
-#: src/amule.cpp:2039
+#: src/amule.cpp:2031
 #, c-format
 msgid "Disk space preallocation for file '%s' failed: %s"
 msgstr "Vnaprejšnja dodelitev prostora na disku za datoteko »%s« ni uspela: %s"
 
-#: src/amule.cpp:2168
+#: src/amule.cpp:2160
 msgid "ERROR: can't open logfile"
 msgstr "NAPAKA: ni mogoče odpreti dnevniške datoteke"
 
-#: src/amule.cpp:2172
+#: src/amule.cpp:2164
 msgid "WARNING: logfile is empty. Something is wrong."
 msgstr "OPOZORILO: dnevniška datoteka je prazna. Nekaj je narobe."
 
-#: src/amule.cpp:2189
+#: src/amule.cpp:2181
 msgid "Log has been reset"
 msgstr "Dnevnik je bil ponastavljen"
 
-#: src/amule.cpp:2213
+#: src/amule.cpp:2205
 #, c-format
 msgid "ServerMessage: %s"
 msgstr "Sporočilo strežnika: %s"
 
-#: src/amule.cpp:2256 src/IP2Country.cpp:220 src/IPFilter.cpp:514
+#: src/amule.cpp:2248 src/IP2Country.cpp:220 src/IPFilter.cpp:514
 #: src/ServerList.cpp:875
 #, c-format
 msgid "Skipped download of %s, because requested file is not newer."
 msgstr "Prejemanje %s je bilo preskočeno, ker zahtevana datoteka ni novejša."
 
-#: src/amule.cpp:2259
+#: src/amule.cpp:2251
 msgid "Failed to download the nodes list."
 msgstr "Ni bilo mogoče prejeti seznama vozlišč."
 
-#: src/amule.cpp:2322
+#: src/amule.cpp:2314
 msgid "Failed to open the downloaded version check file"
 msgstr "Ni bilo mogoče odpreti prejete datoteke za preverjanje različice"
 
-#: src/amule.cpp:2325 src/amule.cpp:2344
+#: src/amule.cpp:2317 src/amule.cpp:2336
 msgid "Corrupted version check file"
 msgstr "Datoteka za preverjanje različice je pokvarjena"
 
-#: src/amule.cpp:2367
+#: src/amule.cpp:2359
 msgid "You are using an outdated version of aMule!"
 msgstr "Uporabljate zastarelo različico aMule."
 
-#: src/amule.cpp:2369
+#: src/amule.cpp:2361
 #, c-format
 msgid "Your aMule version is %i.%i.%i and the latest version is %li.%li.%li"
 msgstr "Različica vaše aMule je %i.%i.%i, najnovejša različica pa je %li.%li.%li"
 
-#: src/amule.cpp:2373
+#: src/amule.cpp:2365
 #, fuzzy
 msgid "The latest version can always be found at https://github.com/amule-org/amule/releases/latest"
 msgstr "Najnovejšo različico lahko vedno najdete na https://github.com/amule-org/amule/releases/latest"
 
-#: src/amule.cpp:2376
+#: src/amule.cpp:2368
 #, c-format
 msgid "WARNING: Your aMuled version is outdated: %i.%i.%i < %li.%li.%li"
 msgstr "OPOZORILO: vaša različica aMule je zastarela: %i.%i.%i < %li.%li.%li"
 
-#: src/amule.cpp:2382
+#: src/amule.cpp:2374
 msgid "Your copy of aMule is up to date."
 msgstr "Uporabljate najnovejšo različico aMule."
 
-#: src/amule.cpp:2389
+#: src/amule.cpp:2381
 msgid "Failed to download the version check file"
 msgstr "Ni bilo mogoče prejeti datoteke za preverjanje različice"
 
-#: src/amule.cpp:2558 src/amule-remote-gui.cpp:1133
+#: src/amule.cpp:2550 src/amule-remote-gui.cpp:1133
 #, c-format
 msgid "Users: %s | Files: %s"
 msgstr "Uporabniki: %s | Datoteke: %s"
 
-#: src/amule.cpp:2559 src/amule-remote-gui.cpp:1134
+#: src/amule.cpp:2551 src/amule-remote-gui.cpp:1134
 #, c-format
 msgid "Users: E: %s K: %s | Files: E: %s K: %s"
 msgstr "Uporabniki: E: %s K: %s | Datoteke: E: %s K: %s"
 
-#: src/amule.cpp:2573 src/amule-remote-gui.cpp:1147
+#: src/amule.cpp:2565 src/amule-remote-gui.cpp:1147
 msgid "No networks selected"
 msgstr "Izbranega ni nobenega omrežja"
 
-#: src/amule.cpp:2641 src/TextClient.cpp:903
+#: src/amule.cpp:2633 src/TextClient.cpp:903
 msgid "with LowID"
 msgstr "z nizkim ID-jem"
 
-#: src/amule.cpp:2641 src/TextClient.cpp:904
+#: src/amule.cpp:2633 src/TextClient.cpp:904
 msgid "with HighID"
 msgstr "z visokim ID-jem"
 
-#: src/amule.cpp:2643
+#: src/amule.cpp:2635
 #, c-format
 msgid "Connected to %s %s"
 msgstr "Povezano na %s %s"
 
-#: src/amule.cpp:2648
+#: src/amule.cpp:2640
 #, c-format
 msgid "Connecting to %s"
 msgstr "Povezovanje z %s"
 
-#: src/amule.cpp:2650
+#: src/amule.cpp:2642
 msgid "Disconnected from eD2k"
 msgstr "Povezava z eD2k prekinjena"
 
-#: src/amule.cpp:2659
+#: src/amule.cpp:2651
 msgid "Kad started."
 msgstr "Kad zagnan."
 
-#: src/amule.cpp:2661
+#: src/amule.cpp:2653
 msgid "Kad stopped."
 msgstr "Kad ustavljen."
 
-#: src/amule.cpp:2669
+#: src/amule.cpp:2661
 msgid "Connected to Kad (ok)"
 msgstr "Povezano v Kad (v redu)"
 
-#: src/amule.cpp:2671
+#: src/amule.cpp:2663
 msgid "Connected to Kad (firewalled)"
 msgstr "Povezano v Kad (za požarnim zidom)"
 
-#: src/amule.cpp:2675
+#: src/amule.cpp:2667
 msgid "Disconnected from Kad"
 msgstr "Povezava s Kad prekinjena"
 
-#: src/amule.cpp:2707
+#: src/amule.cpp:2699
 msgid "Kad network cannot be used if UDP port is disabled on preferences, not starting."
 msgstr "Omrežja Kad ni mogoče uporabljati, če so vrata UDP onemogočena v nastavitvah. Kad ni zagnan."
 
-#: src/amule.cpp:2711
+#: src/amule.cpp:2703
 msgid "Kad network disabled on preferences, not connecting."
 msgstr "Omrežje Kad je onemogočeno v nastavitvah. Ni povezave."
 
@@ -577,69 +577,31 @@ msgstr "Ni moč ustvariti datoteke PID"
 msgid "ERROR: %s"
 msgstr "NAPAKA: %s"
 
-#: src/amuleDlg.cpp:250
+#: src/amuleDlg.cpp:236
 #, c-format
 msgid "This is aMule %s based on eMule."
 msgstr "To je aMule %s, ki temelji na eMule."
 
-#: src/amuleDlg.cpp:251
+#: src/amuleDlg.cpp:237
 #, c-format
 msgid "Running on %s"
 msgstr "Operacijski sistem: %s"
 
-#: src/amuleDlg.cpp:253
+#: src/amuleDlg.cpp:239
 #, fuzzy
 msgid "Visit https://github.com/amule-org/amule/releases/latest to check if a new version is available."
 msgstr "Obiščite https://github.com/amule-org/amule/releases/latest da preverite, če je na voljo nova različica."
 
-#: src/amuleDlg.cpp:282
+#: src/amuleDlg.cpp:268
 msgid "FATAL ERROR: Failed to create Timer"
 msgstr "USODNA NAPAKA: ustvaritev časomerilnika ni uspela"
 
-#: src/amuleDlg.cpp:361 src/amuleDlg.cpp:1810 src/amuleDlg.cpp:2056
-#: src/muuli_wdr.cpp:1492 src/muuli_wdr.cpp:3439
-msgid "Networks"
-msgstr "Omrežja"
-
-#: src/amuleDlg.cpp:362 src/amuleDlg.cpp:1816 src/muuli_wdr.cpp:3440
-msgid "Searches"
-msgstr "Iskanja"
-
-#: src/amuleDlg.cpp:363 src/amuleDlg.cpp:1822 src/DownloadListCtrl.cpp:740
-#: src/muuli_wdr.cpp:392 src/muuli_wdr.cpp:1585 src/muuli_wdr.cpp:3441
-#: src/Statistics.cpp:829
-msgid "Downloads"
-msgstr "Prejemanja"
-
-#: src/amuleDlg.cpp:364 src/amuleDlg.cpp:1828 src/muuli_wdr.cpp:3315
-msgid "Shared files"
-msgstr "Deljene datoteke"
-
-#: src/amuleDlg.cpp:365 src/amuleDlg.cpp:1834 src/muuli_wdr.cpp:2947
-#: src/muuli_wdr.cpp:3397 src/muuli_wdr.cpp:3444
-msgid "Messages"
-msgstr "Sporočila"
-
-#: src/amuleDlg.cpp:366 src/amuleDlg.cpp:1840 src/muuli_wdr.cpp:3445
-#: src/PrefsUnifiedDlg.cpp:314 src/Statistics.cpp:779 src/Statistics.cpp:1235
-msgid "Statistics"
-msgstr "Statistika"
-
-#: src/amuleDlg.cpp:368 src/amuleDlg.cpp:1847 src/muuli_wdr.cpp:3447
-#: src/PrefsUnifiedDlg.cpp:330 src/utils/wxCas/src/wxcasprefs.cpp:39
-msgid "Preferences"
-msgstr "Nastavitve"
-
-#: src/amuleDlg.cpp:371
-msgid "Navigate"
-msgstr ""
-
-#: src/amuleDlg.cpp:657
+#: src/amuleDlg.cpp:592
 #, fuzzy
 msgid "New version available"
 msgstr "Ni na voljo"
 
-#: src/amuleDlg.cpp:661
+#: src/amuleDlg.cpp:596
 #, fuzzy, c-format
 msgid ""
 "A new version of aMule (%s) is available.\n"
@@ -649,184 +611,217 @@ msgid ""
 "Would you like to open the download page?"
 msgstr "Najnovejšo različico lahko vedno najdete na https://github.com/amule-org/amule/releases/latest"
 
-#: src/amuleDlg.cpp:743
+#: src/amuleDlg.cpp:678
 msgid "aMule dialog destroyed"
 msgstr "Pogovorno okno aMule je bilo uničeno"
 
-#: src/amuleDlg.cpp:766 src/DataToText.cpp:68 src/IPFilter.cpp:547
+#: src/amuleDlg.cpp:701 src/DataToText.cpp:68 src/IPFilter.cpp:547
 msgid "Connecting"
 msgstr "Povezovanje"
 
-#: src/amuleDlg.cpp:958
+#: src/amuleDlg.cpp:893
 msgid "eD2k: Connecting"
 msgstr "eD2k: povezovanje"
 
-#: src/amuleDlg.cpp:962
+#: src/amuleDlg.cpp:897
 msgid "eD2k: Disconnected"
 msgstr "eD2k: povezava prekinjena"
 
-#: src/amuleDlg.cpp:968
+#: src/amuleDlg.cpp:903
 msgid "Kad: Firewalled"
 msgstr "Kad: za požarnim zidom"
 
-#: src/amuleDlg.cpp:972
+#: src/amuleDlg.cpp:907
 msgid "Kad: Connected"
 msgstr "Kad: povezano"
 
-#: src/amuleDlg.cpp:977
+#: src/amuleDlg.cpp:912
 msgid "Kad: Connecting"
 msgstr "Kad: povezovanje"
 
-#: src/amuleDlg.cpp:981
+#: src/amuleDlg.cpp:916
 msgid "Kad: Off"
 msgstr "Kad: izklopljen"
 
-#: src/amuleDlg.cpp:1029 src/DownloadListCtrl.cpp:505
+#: src/amuleDlg.cpp:964 src/DownloadListCtrl.cpp:505
 #: src/DownloadListCtrl.cpp:749 src/FriendListCtrl.cpp:180
 #: src/muuli_wdr.cpp:731 src/muuli_wdr.cpp:782 src/muuli_wdr.cpp:846
-#: src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2252 src/muuli_wdr.cpp:2337
-#: src/muuli_wdr.cpp:3085 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
+#: src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2224 src/muuli_wdr.cpp:2309
+#: src/muuli_wdr.cpp:3057 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
 #: src/ServerListCtrl.cpp:606 src/TransferWnd.cpp:378
 #: src/utils/wxCas/src/wxcasprefs.cpp:235
 msgid "Cancel"
 msgstr "Prekliči"
 
-#: src/amuleDlg.cpp:1030
+#: src/amuleDlg.cpp:965
 msgid "Stop the current connection attempts"
 msgstr "Ustavi trenutne poskuse povezovanja"
 
-#: src/amuleDlg.cpp:1035 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976
-#: src/muuli_wdr.cpp:2475
+#: src/amuleDlg.cpp:970 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976
+#: src/muuli_wdr.cpp:2447
 msgid "Disconnect"
 msgstr "Prekini povezave"
 
-#: src/amuleDlg.cpp:1036
+#: src/amuleDlg.cpp:971
 msgid "Disconnect from the currently connected networks"
 msgstr "Prekini povezavo s trenutno povezanimi omrežji"
 
-#: src/amuleDlg.cpp:1041 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979
-#: src/muuli_wdr.cpp:2630 src/muuli_wdr.cpp:3082 src/muuli_wdr.cpp:3437
+#: src/amuleDlg.cpp:976 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979
+#: src/muuli_wdr.cpp:2602 src/muuli_wdr.cpp:3054 src/muuli_wdr.cpp:3409
 msgid "Connect"
 msgstr "Poveži se"
 
-#: src/amuleDlg.cpp:1042
+#: src/amuleDlg.cpp:977
 msgid "Connect to the currently enabled networks"
 msgstr "Poveži se s trenutno omogočenimi omrežji"
 
-#: src/amuleDlg.cpp:1154
+#: src/amuleDlg.cpp:1089
 #, c-format
 msgid "Up: %.1f%s (%.1f) | Down: %.1f%s (%.1f)"
 msgstr "Gor: %.1f%s (%.1f) | Dol: %.1f%s (%.1f)"
 
-#: src/amuleDlg.cpp:1156 src/amuleDlg.cpp:1158 src/amuleDlg.cpp:1162
-#: src/amuleDlg.cpp:1164 src/amuleDlg.cpp:1175 src/amuleDlg.cpp:1177
+#: src/amuleDlg.cpp:1091 src/amuleDlg.cpp:1093 src/amuleDlg.cpp:1097
+#: src/amuleDlg.cpp:1099 src/amuleDlg.cpp:1110 src/amuleDlg.cpp:1112
 #: src/MuleTrayIcon.cpp:796 src/MuleTrayIcon.cpp:799
 msgid " MB/s"
 msgstr " MiB/s"
 
-#: src/amuleDlg.cpp:1156 src/amuleDlg.cpp:1158 src/amuleDlg.cpp:1162
-#: src/amuleDlg.cpp:1164 src/amuleDlg.cpp:1175 src/amuleDlg.cpp:1177
+#: src/amuleDlg.cpp:1091 src/amuleDlg.cpp:1093 src/amuleDlg.cpp:1097
+#: src/amuleDlg.cpp:1099 src/amuleDlg.cpp:1110 src/amuleDlg.cpp:1112
 #: src/MuleTrayIcon.cpp:796 src/MuleTrayIcon.cpp:799
 #: src/utils/wxCas/src/wxcasframe.cpp:1041
 msgid " kB/s"
 msgstr " kB/s"
 
-#: src/amuleDlg.cpp:1161
+#: src/amuleDlg.cpp:1096
 #, c-format
 msgid "Up: %.1f%s | Down: %.1f%s"
 msgstr "Gor: %.1f%s | Dol: %.1f%s"
 
-#: src/amuleDlg.cpp:1193
+#: src/amuleDlg.cpp:1128
 #, c-format
 msgid "aMule (%s | Connected)"
 msgstr "aMule (%s | Povezano)"
 
-#: src/amuleDlg.cpp:1195
+#: src/amuleDlg.cpp:1130
 #, c-format
 msgid "aMule (%s | Disconnected)"
 msgstr "aMule (%s | Ni povezave)"
 
-#: src/amuleDlg.cpp:1248
+#: src/amuleDlg.cpp:1183
 #, c-format
 msgid "Do you really want to exit %s?"
 msgstr "Ali res želite zapustiti %s?"
 
-#: src/amuleDlg.cpp:1250
+#: src/amuleDlg.cpp:1185
 msgid "Exit confirmation"
 msgstr "Potrditev izhoda"
 
-#: src/amuleDlg.cpp:1613
+#: src/amuleDlg.cpp:1548
 msgid "Launch Command: "
 msgstr "Zaženi ukaz: "
 
-#: src/amuleDlg.cpp:1632 src/muuli_wdr.cpp:1972 src/Preferences.cpp:979
+#: src/amuleDlg.cpp:1567 src/muuli_wdr.cpp:1971 src/Preferences.cpp:951
 msgid "- default -"
 msgstr "– privzeto –"
 
-#: src/amuleDlg.cpp:1660
+#: src/amuleDlg.cpp:1595
 #, c-format
 msgid "Skin directory '%s' does not exist"
 msgstr "Mapa za preobleke »%s« ne obstaja"
 
-#: src/amuleDlg.cpp:1663
+#: src/amuleDlg.cpp:1598
 #, c-format
 msgid "WARNING: Unable to open skin file '%s' for read"
 msgstr "OPOZORILO: datoteke s preobleko »%s« ni moč odpreti za branje"
 
-#: src/amuleDlg.cpp:1814 src/muuli_wdr.cpp:3439
+#: src/amuleDlg.cpp:1722 src/amuleDlg.cpp:1968 src/muuli_wdr.cpp:1485
+#: src/muuli_wdr.cpp:3411
+msgid "Networks"
+msgstr "Omrežja"
+
+#: src/amuleDlg.cpp:1726 src/muuli_wdr.cpp:3411
 msgid "Networks Window"
 msgstr "Okno z omrežji"
 
-#: src/amuleDlg.cpp:1820 src/muuli_wdr.cpp:3440
+#: src/amuleDlg.cpp:1728 src/muuli_wdr.cpp:3412
+msgid "Searches"
+msgstr "Iskanja"
+
+#: src/amuleDlg.cpp:1732 src/muuli_wdr.cpp:3412
 msgid "Searches Window"
 msgstr "Okno z iskanji"
 
-#: src/amuleDlg.cpp:1826 src/muuli_wdr.cpp:3441
+#: src/amuleDlg.cpp:1734 src/DownloadListCtrl.cpp:740 src/muuli_wdr.cpp:392
+#: src/muuli_wdr.cpp:1578 src/muuli_wdr.cpp:3413 src/Statistics.cpp:829
+msgid "Downloads"
+msgstr "Prejemanja"
+
+#: src/amuleDlg.cpp:1738 src/muuli_wdr.cpp:3413
 msgid "Downloads Window"
 msgstr "Okno s prejemanji"
 
-#: src/amuleDlg.cpp:1832 src/muuli_wdr.cpp:3443
+#: src/amuleDlg.cpp:1740 src/muuli_wdr.cpp:3287
+msgid "Shared files"
+msgstr "Deljene datoteke"
+
+#: src/amuleDlg.cpp:1744 src/muuli_wdr.cpp:3415
 msgid "Shared Files Window"
 msgstr "Okno z deljenimi datotekami"
 
-#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3444
+#: src/amuleDlg.cpp:1746 src/muuli_wdr.cpp:2919 src/muuli_wdr.cpp:3369
+#: src/muuli_wdr.cpp:3416
+msgid "Messages"
+msgstr "Sporočila"
+
+#: src/amuleDlg.cpp:1750 src/muuli_wdr.cpp:3416
 msgid "Messages Window"
 msgstr "Okno s sporočili"
 
-#: src/amuleDlg.cpp:1844 src/muuli_wdr.cpp:3445
+#: src/amuleDlg.cpp:1752 src/muuli_wdr.cpp:3417 src/PrefsUnifiedDlg.cpp:312
+#: src/Statistics.cpp:779 src/Statistics.cpp:1235
+msgid "Statistics"
+msgstr "Statistika"
+
+#: src/amuleDlg.cpp:1756 src/muuli_wdr.cpp:3417
 msgid "Statistics Graph Window"
 msgstr "Okno s statističnimi grafi"
 
-#: src/amuleDlg.cpp:1851 src/muuli_wdr.cpp:3447
+#: src/amuleDlg.cpp:1759 src/muuli_wdr.cpp:3419 src/PrefsUnifiedDlg.cpp:328
+#: src/utils/wxCas/src/wxcasprefs.cpp:39
+msgid "Preferences"
+msgstr "Nastavitve"
+
+#: src/amuleDlg.cpp:1763 src/muuli_wdr.cpp:3419
 msgid "Preferences Settings Window"
 msgstr "Okno z nastavitvami"
 
-#: src/amuleDlg.cpp:1854 src/muuli_wdr.cpp:3448
+#: src/amuleDlg.cpp:1766 src/muuli_wdr.cpp:3420
 msgid "Import"
 msgstr "Uvoz"
 
-#: src/amuleDlg.cpp:1858 src/muuli_wdr.cpp:3448
+#: src/amuleDlg.cpp:1770 src/muuli_wdr.cpp:3420
 msgid "The partfile importer tool"
 msgstr "Orodje za uvažanje delnih datotek"
 
-#: src/amuleDlg.cpp:1861 src/muuli_wdr.cpp:3449
+#: src/amuleDlg.cpp:1773 src/muuli_wdr.cpp:3421
 #: src/utils/aLinkCreator/src/alcframe.cpp:262
 msgid "About"
 msgstr "O programu"
 
-#: src/amuleDlg.cpp:1861 src/muuli_wdr.cpp:3449
+#: src/amuleDlg.cpp:1773 src/muuli_wdr.cpp:3421
 msgid "About/Help"
 msgstr "O programu/pomoč"
 
-#: src/amuleDlg.cpp:2059
+#: src/amuleDlg.cpp:1971
 msgid "eD2k network"
 msgstr "Omrežje eD2k"
 
-#: src/amuleDlg.cpp:2062
+#: src/amuleDlg.cpp:1974
 msgid "Kad network"
 msgstr "Omrežje Kad"
 
-#: src/amuleDlg.cpp:2062
+#: src/amuleDlg.cpp:1974
 msgid "No network"
 msgstr "Brez omrežja"
 
@@ -956,7 +951,7 @@ msgstr "Datoteke ni mogoče najti."
 msgid "The core rejected these shared folders:%s"
 msgstr ""
 
-#: src/amule-remote-gui.cpp:1336 src/ExternalConn.cpp:2346
+#: src/amule-remote-gui.cpp:1336 src/ExternalConn.cpp:2345
 msgid "Invalid link or already on list."
 msgstr "Neveljavna povezava oz. je že na seznamu."
 
@@ -972,7 +967,7 @@ msgstr "Ni moč ustvariti mape »%s« za kategorijo »%s«, obdržana bo mapa »
 #: src/ClientDetailDialog.cpp:123 src/DataToText.cpp:61 src/DataToText.cpp:86
 #: src/DataToText.cpp:101 src/DataToText.cpp:136 src/DataToText.cpp:165
 #: src/DownloadListCtrl.cpp:1172 src/DownloadListCtrl.cpp:1185
-#: src/DownloadListCtrl.cpp:1196 src/ExternalConn.cpp:609
+#: src/DownloadListCtrl.cpp:1196 src/ExternalConn.cpp:608
 #: src/FileDetailDialog.cpp:203 src/FileDetailDialog.cpp:235
 #: src/FileDetailDialog.cpp:242 src/GenericClientListCtrl.cpp:1171
 #: src/GenericClientListCtrl.cpp:1182 src/GenericClientListCtrl.cpp:1192
@@ -1369,19 +1364,19 @@ msgstr "Samod. [Vi]"
 msgid "Very low"
 msgstr "Zelo nizka"
 
-#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:743 src/muuli_wdr.cpp:2303
+#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:743 src/muuli_wdr.cpp:2275
 #: src/ServerListCtrl.cpp:263 src/ServerListCtrl.cpp:456
 #: src/SharedFilesCtrl.cpp:145
 msgid "Low"
 msgstr "Nizka"
 
-#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:744 src/muuli_wdr.cpp:2304
+#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:744 src/muuli_wdr.cpp:2276
 #: src/ServerListCtrl.cpp:266 src/ServerListCtrl.cpp:457
 #: src/SharedFilesCtrl.cpp:146
 msgid "Normal"
 msgstr "Običajna"
 
-#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:745 src/muuli_wdr.cpp:2305
+#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:745 src/muuli_wdr.cpp:2277
 #: src/ServerListCtrl.cpp:269 src/ServerListCtrl.cpp:458
 #: src/SharedFilesCtrl.cpp:147
 msgid "High"
@@ -1473,8 +1468,8 @@ msgstr "Krajevni strežnik"
 msgid "Remote Server"
 msgstr "Oddaljni strežnik"
 
-#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3202
-#: src/SearchDlg.cpp:119 src/TextClient.cpp:911
+#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3174
+#: src/SearchDlg.cpp:111 src/TextClient.cpp:911
 msgid "Kad"
 msgstr "Kad"
 
@@ -1545,7 +1540,7 @@ msgstr "Del"
 msgid "Size"
 msgstr "Velikost"
 
-#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3269
+#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3241
 msgid "Transferred"
 msgstr "Preneseno"
 
@@ -1603,7 +1598,7 @@ msgstr ""
 "Odziv od: %s (%s)\n"
 "\n"
 
-#: src/DownloadListCtrl.cpp:746 src/muuli_wdr.cpp:2306
+#: src/DownloadListCtrl.cpp:746 src/muuli_wdr.cpp:2278
 #: src/SharedFilesCtrl.cpp:150
 msgid "Auto"
 msgstr "Samod."
@@ -1641,7 +1636,7 @@ msgid "Extended Options"
 msgstr "Dodatne možnosti"
 
 #: src/DownloadListCtrl.cpp:770 src/DownloadListCtrl.cpp:822
-#: src/muuli_wdr.cpp:1790
+#: src/muuli_wdr.cpp:1789
 msgid "Preview"
 msgstr "Ogled"
 
@@ -1821,232 +1816,227 @@ msgstr[3] ""
 msgid "Invalid eD2k link! ERROR: %s"
 msgstr "Neveljavna povezava eD2k. NAPAKA: %s"
 
-#: src/ExternalConn.cpp:380
+#: src/ExternalConn.cpp:379
 msgid "Client sent packet after authentication failed."
 msgstr "Po neuspelem overjanju je odjemalec poslal paket."
 
-#: src/ExternalConn.cpp:397
+#: src/ExternalConn.cpp:396
 msgid "External connection closed."
 msgstr "Zunanja povezava se je zaprla."
 
-#: src/ExternalConn.cpp:474
+#: src/ExternalConn.cpp:473
 msgid "External connections disabled due to empty password!"
 msgstr "Zunanje povezave onemogočene zaradi praznega gesla."
 
-#: src/ExternalConn.cpp:495
+#: src/ExternalConn.cpp:494
 msgid "External connections disabled in config file"
 msgstr "Zunanje povezave onemogočene v nastavitveni datoteki"
 
-#: src/ExternalConn.cpp:576
+#: src/ExternalConn.cpp:575
 msgid "New external connection accepted"
 msgstr "Nova zunanja povezava sprejeta"
 
-#: src/ExternalConn.cpp:579
+#: src/ExternalConn.cpp:578
 msgid "ERROR: couldn't accept a new external connection"
 msgstr "NAPAKA: nove zunanje povezave ni bilo moč sprejeti"
 
-#: src/ExternalConn.cpp:596
+#: src/ExternalConn.cpp:595
 msgid "External connection refused due to empty password in preferences!"
 msgstr "Zunanja povezava zavrnjena zaradi praznega gesla v nastavitvah."
 
-#: src/ExternalConn.cpp:608
+#: src/ExternalConn.cpp:607
 #, c-format
 msgid "Connecting client: %s %s"
 msgstr "Povezovanje z odjemalcem: %s %s"
 
-#: src/ExternalConn.cpp:610
+#: src/ExternalConn.cpp:609
 msgid "Unknown version"
 msgstr "Neznana različica"
 
-#: src/ExternalConn.cpp:623
+#: src/ExternalConn.cpp:622
 msgid "Incorrect EC version ID, there might be binary incompatibility. Use core and remote from same snapshot."
 msgstr "Napačen ID različice za zunanje povezave; lahko pride do binarne nezdružljivosti. Uporabite jedro in oddaljen odjemalec iz istega posnetka."
 
-#: src/ExternalConn.cpp:631
+#: src/ExternalConn.cpp:630
 msgid "You cannot connect to a release version from an arbitrary development snapshot! *sigh* possible crash prevented"
 msgstr "Ne morete se povezati s stabilno različico iz poljubne razvojne različice. Preprečeno morebitno sesutje."
 
-#: src/ExternalConn.cpp:714
+#: src/ExternalConn.cpp:713
 msgid "Invalid protocol version."
 msgstr "Neveljavna različica protokola."
 
-#: src/ExternalConn.cpp:720
+#: src/ExternalConn.cpp:719
 msgid "Missing protocol version tag."
 msgstr "Manjka oznaka različice protokola."
 
-#: src/ExternalConn.cpp:728
+#: src/ExternalConn.cpp:727
 msgid "Authentication failed: invalid hash specified as EC password."
 msgstr "Overjanje ni uspelo: kot geslo za zunanje povezave je bila podana napačna koda."
 
-#: src/ExternalConn.cpp:776
+#: src/ExternalConn.cpp:775
 msgid "Authentication failed: wrong password."
 msgstr "Overjanje ni uspelo: napačno geslo."
 
-#: src/ExternalConn.cpp:778
+#: src/ExternalConn.cpp:777
 msgid "Authentication failed: missing password."
 msgstr "Overjanje ni uspelo: manjkajoče geslo."
 
-#: src/ExternalConn.cpp:789
+#: src/ExternalConn.cpp:788
 msgid "Invalid request, please authenticate first."
 msgstr "Neveljavna zahteva, najprej se morate overiti."
 
-#: src/ExternalConn.cpp:794
+#: src/ExternalConn.cpp:793
 msgid "Access granted."
 msgstr "Dostop dovoljen."
 
-#: src/ExternalConn.cpp:802
+#: src/ExternalConn.cpp:801
 #, c-format
 msgid "Sent error message \"%s\" to client."
 msgstr "Odjemalcu je bilo poslano sporočilo o napaki »%s«."
 
-#: src/ExternalConn.cpp:807
+#: src/ExternalConn.cpp:806
 #, c-format
 msgid "Unauthorized access attempt from %s. Connection closed."
 msgstr "Nepooblaščen poskus dostopa od %s. Povezava prekinjena."
 
-#: src/ExternalConn.cpp:1420
+#: src/ExternalConn.cpp:1419
 #, c-format
 msgid "Remote PartFile command failed: FileHash not found: %s"
 msgstr "Ukaz za oddaljeno delno datoteko ni uspel: Ni bilo mogoče najti kode datoteke: %s"
 
-#: src/ExternalConn.cpp:1424
+#: src/ExternalConn.cpp:1423
 #, c-format
 msgid "FileHash not found: %s"
 msgstr "Kode datoteke ni mogoče najti: %s"
 
-#: src/ExternalConn.cpp:1471 src/ExternalConn.cpp:1559
-#: src/ExternalConn.cpp:1680
+#: src/ExternalConn.cpp:1470 src/ExternalConn.cpp:1558
+#: src/ExternalConn.cpp:1679
 msgid "OOPS! OpCode processing error!"
 msgstr "UPS. Napaka pri obdelavi OpCode."
 
-#: src/ExternalConn.cpp:1502
+#: src/ExternalConn.cpp:1501
 msgid "Server not added"
 msgstr "Strežnik ni bil dodan"
 
-#: src/ExternalConn.cpp:1521
+#: src/ExternalConn.cpp:1520
 #, c-format
 msgid "server not found: %s"
 msgstr "strežnika ni mogoče najti: %s"
 
-#: src/ExternalConn.cpp:1538
+#: src/ExternalConn.cpp:1537
 msgid "need to define server to be removed"
 msgstr "morate navesti strežnik za odstranitev"
 
-#: src/ExternalConn.cpp:1553
+#: src/ExternalConn.cpp:1552
 msgid "eD2k is disabled in preferences."
 msgstr "eD2k je onemogočen v nastavitvah."
 
-#: src/ExternalConn.cpp:1658
+#: src/ExternalConn.cpp:1657
 #, fuzzy
 msgid "Friend not found."
 msgstr "Datoteke ni mogoče najti."
 
-#: src/ExternalConn.cpp:1668
+#: src/ExternalConn.cpp:1667
 #, fuzzy
 msgid "Client not found."
 msgstr "Datoteke ni mogoče najti."
 
-#: src/ExternalConn.cpp:1674
+#: src/ExternalConn.cpp:1673
 msgid "EC_TAG_FRIEND_SHARED requires EC_TAG_FRIEND or EC_TAG_CLIENT."
 msgstr ""
 
-#: src/ExternalConn.cpp:1992
+#: src/ExternalConn.cpp:1991
 msgid "WebSearch from remote interface makes no sense."
 msgstr "Spletno iskanje iz oddaljenega vmesnika nima smisla."
 
-#: src/ExternalConn.cpp:2027
+#: src/ExternalConn.cpp:2026
 msgid "Search in progress. Refetch results in a moment!"
 msgstr "Iskanje poteka. Ponovno poglejte za rezultati čez nekaj trenutkov."
 
-#: src/ExternalConn.cpp:2266
+#: src/ExternalConn.cpp:2265
 msgid "No points for graph."
 msgstr "Ni točk za graf."
 
-#: src/ExternalConn.cpp:2276
+#: src/ExternalConn.cpp:2275
 msgid "Your client is not configured for this detail level."
 msgstr "Vaš odjemalec ni nastavljen za to stopnjo podrobnosti."
 
-#: src/ExternalConn.cpp:2303
+#: src/ExternalConn.cpp:2302
 msgid "External Connection: shutdown requested"
 msgstr "Zunanja povezava: zahtevana zaustavitev"
 
-#: src/ExternalConn.cpp:2315
+#: src/ExternalConn.cpp:2314
 msgid "Already shutting down."
 msgstr "Ustavljanje že poteka."
 
-#: src/ExternalConn.cpp:2333
+#: src/ExternalConn.cpp:2332
 #, c-format
 msgid "ExternalConn: adding link '%s'."
 msgstr "Zunanja povezava: dodajanje povezave »%s«."
 
-#: src/ExternalConn.cpp:2351
+#: src/ExternalConn.cpp:2350
 #, fuzzy, c-format
 msgid "%d of %d links failed (invalid or already on list)."
 msgstr "Neveljavna povezava oz. je že na seznamu."
 
-#: src/ExternalConn.cpp:2374
+#: src/ExternalConn.cpp:2373
 msgid "Version check throttled; try again shortly."
 msgstr ""
 
-#: src/ExternalConn.cpp:2379
+#: src/ExternalConn.cpp:2378
 msgid "Version check is not available on this daemon."
 msgstr ""
 
-#: src/ExternalConn.cpp:2509
+#: src/ExternalConn.cpp:2508
 msgid "File not found."
 msgstr "Datoteke ni mogoče najti."
 
-#: src/ExternalConn.cpp:2514
+#: src/ExternalConn.cpp:2513
 msgid "Invalid file name."
 msgstr "Neveljavno ime datoteke."
 
-#: src/ExternalConn.cpp:2522
+#: src/ExternalConn.cpp:2521
 msgid "Unable to rename file."
 msgstr "Ni mogoče preimenovati datoteke."
 
-#: src/ExternalConn.cpp:2839
-#, c-format
-msgid "Could not save the amuleapi password: %s"
-msgstr ""
-
-#: src/ExternalConn.cpp:3004 src/ExternalConn.cpp:3032
+#: src/ExternalConn.cpp:2992 src/ExternalConn.cpp:3020
 msgid "Kad is disabled in preferences."
 msgstr "Kad je onemogočen v nastavitvah."
 
-#: src/ExternalConn.cpp:3045
+#: src/ExternalConn.cpp:3033
 msgid "Already connected to eD2k."
 msgstr "Povezava z eD2k že obstaja."
 
-#: src/ExternalConn.cpp:3048
+#: src/ExternalConn.cpp:3036
 msgid "Connecting to eD2k..."
 msgstr "Povezovanje z eD2k …"
 
-#: src/ExternalConn.cpp:3057
+#: src/ExternalConn.cpp:3045
 msgid "Already connected to Kad."
 msgstr "Povezava s Kad že obstaja."
 
-#: src/ExternalConn.cpp:3060
+#: src/ExternalConn.cpp:3048
 msgid "Connecting to Kad..."
 msgstr "Povezovanje s Kad …"
 
-#: src/ExternalConn.cpp:3067
+#: src/ExternalConn.cpp:3055
 msgid "All networks are disabled."
 msgstr "Vsa omrežja so onemogočena."
 
-#: src/ExternalConn.cpp:3076
+#: src/ExternalConn.cpp:3064
 msgid "Disconnected from eD2k."
 msgstr "Povezava z eD2k prekinjena."
 
-#: src/ExternalConn.cpp:3081
+#: src/ExternalConn.cpp:3069
 msgid "Disconnected from Kad."
 msgstr "Povezava s Kad prekinjena."
 
-#: src/ExternalConn.cpp:3090
+#: src/ExternalConn.cpp:3078
 #, c-format
 msgid "External Connection: invalid opcode received: %#x"
 msgstr "Zunanja povezava: prejeta je bila neveljavna operacijska koda: %#x"
 
-#: src/ExternalConn.cpp:3095
+#: src/ExternalConn.cpp:3083
 msgid "Invalid opcode (wrong protocol version?)"
 msgstr "Neveljavna operacijska koda (napačna različica protokola?)"
 
@@ -2362,19 +2352,19 @@ msgstr ""
 msgid "eD2k"
 msgstr "eD2k"
 
-#: src/FirstRunWizard.cpp:349 src/muuli_wdr.cpp:1495
+#: src/FirstRunWizard.cpp:349 src/muuli_wdr.cpp:1488
 msgid "Kademlia"
 msgstr "Kademlia"
 
-#: src/FirstRunWizard.cpp:359 src/muuli_wdr.cpp:1423
+#: src/FirstRunWizard.cpp:359 src/muuli_wdr.cpp:1416
 msgid "Standard TCP Port "
 msgstr "Standardna vrata TCP "
 
-#: src/FirstRunWizard.cpp:365 src/muuli_wdr.cpp:1435
+#: src/FirstRunWizard.cpp:365 src/muuli_wdr.cpp:1428
 msgid "Extended UDP port (Kad / global search) "
 msgstr "Dodatna vrata UDP (globalno/Kad iskanje) "
 
-#: src/FirstRunWizard.cpp:377 src/muuli_wdr.cpp:1442
+#: src/FirstRunWizard.cpp:377 src/muuli_wdr.cpp:1435
 msgid "Enable UPnP for router port forwarding"
 msgstr "Omogoči posredovanje vrat na usmerjevalniku"
 
@@ -2401,7 +2391,7 @@ msgstr ""
 msgid "Your peer lists are already in place - nothing to download."
 msgstr "Datoteko %s že poskušate prejemati"
 
-#: src/FirstRunWizard.cpp:434 src/muuli_wdr.cpp:1540
+#: src/FirstRunWizard.cpp:434 src/muuli_wdr.cpp:1533
 msgid "Auto-update server list at startup"
 msgstr "Ob zagonu samodejno posodobi seznam strežnikov"
 
@@ -2447,23 +2437,23 @@ msgid ""
 "want downloads on a different (e.g. larger) disk."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:549 src/FirstRunWizard.cpp:611 src/muuli_wdr.cpp:1702
+#: src/FirstRunWizard.cpp:549 src/FirstRunWizard.cpp:611 src/muuli_wdr.cpp:1701
 msgid "Destination folder for downloads"
 msgstr "Ciljna mapa za prejeto"
 
-#: src/FirstRunWizard.cpp:553 src/FirstRunWizard.cpp:569 src/muuli_wdr.cpp:1349
-#: src/muuli_wdr.cpp:1366 src/muuli_wdr.cpp:1677 src/muuli_wdr.cpp:1708
-#: src/muuli_wdr.cpp:1720 src/muuli_wdr.cpp:2790
+#: src/FirstRunWizard.cpp:553 src/FirstRunWizard.cpp:569 src/muuli_wdr.cpp:1342
+#: src/muuli_wdr.cpp:1359 src/muuli_wdr.cpp:1676 src/muuli_wdr.cpp:1707
+#: src/muuli_wdr.cpp:1719 src/muuli_wdr.cpp:2762
 #: src/utils/aLinkCreator/src/alcframe.cpp:135
 #: src/utils/wxCas/src/wxcasprefs.cpp:52 src/utils/wxCas/src/wxcasprefs.cpp:118
 msgid "Browse"
 msgstr "Brskanje"
 
-#: src/FirstRunWizard.cpp:559 src/muuli_wdr.cpp:1713
+#: src/FirstRunWizard.cpp:559 src/muuli_wdr.cpp:1712
 msgid "(All files in this folder are shared with other peers)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:565 src/FirstRunWizard.cpp:624 src/muuli_wdr.cpp:1715
+#: src/FirstRunWizard.cpp:565 src/FirstRunWizard.cpp:624 src/muuli_wdr.cpp:1714
 msgid "Folder for temporary download files"
 msgstr "Mapa za začasne datoteke prejemanj"
 
@@ -2494,7 +2484,7 @@ msgstr "Datoteke s seznamom prijateljev »emfriends.met« ni bilo moč odpreti z
 msgid "CRITICAL - no client on StartChatSession"
 msgstr "KRITIČNO – ni odjemalca za StartChatSession"
 
-#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2696 src/muuli_wdr.cpp:3373
+#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2668 src/muuli_wdr.cpp:3345
 msgid "Friends"
 msgstr "Prijatelji"
 
@@ -2605,8 +2595,8 @@ msgstr "Brez"
 msgid "No"
 msgstr "Ne"
 
-#: src/GenericClientListCtrl.cpp:1216 src/PrefsUnifiedDlg.cpp:2898
-#: src/PrefsUnifiedDlg.cpp:2948 src/ServerListCtrl.cpp:276
+#: src/GenericClientListCtrl.cpp:1216 src/PrefsUnifiedDlg.cpp:2818
+#: src/PrefsUnifiedDlg.cpp:2868 src/ServerListCtrl.cpp:276
 msgid "Yes"
 msgstr "Da"
 
@@ -2779,10 +2769,10 @@ msgstr "Neveljavna vrata za začetno nalaganje"
 msgid "Please fill all fields required"
 msgstr "Prosimo, izpolnite vsa zahtevana polja"
 
-#: src/KadDlg.cpp:192 src/PartFile.cpp:1031 src/PrefsUnifiedDlg.cpp:1134
-#: src/PrefsUnifiedDlg.cpp:1204 src/PrefsUnifiedDlg.cpp:1405
-#: src/PrefsUnifiedDlg.cpp:1663 src/PrefsUnifiedDlg.cpp:1673
-#: src/PrefsUnifiedDlg.cpp:1690 src/PrefsUnifiedDlg.cpp:1738
+#: src/KadDlg.cpp:192 src/PartFile.cpp:1031 src/PrefsUnifiedDlg.cpp:1162
+#: src/PrefsUnifiedDlg.cpp:1331 src/PrefsUnifiedDlg.cpp:1589
+#: src/PrefsUnifiedDlg.cpp:1599 src/PrefsUnifiedDlg.cpp:1616
+#: src/PrefsUnifiedDlg.cpp:1658
 msgid "Message"
 msgstr "Sporočilo"
 
@@ -2890,7 +2880,7 @@ msgstr "Delilno razmerje"
 msgid "Uploaded"
 msgstr "Poslano"
 
-#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3253
+#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3225
 msgid "Requested"
 msgstr "Zahtevano"
 
@@ -3014,7 +3004,7 @@ msgid "WARNING: "
 msgstr "OPOZORILO: "
 
 #: src/MuleNotebook.cpp:179 src/muuli_wdr.cpp:817 src/muuli_wdr.cpp:1229
-#: src/muuli_wdr.cpp:3157 src/muuli_wdr.cpp:3413
+#: src/muuli_wdr.cpp:3129 src/muuli_wdr.cpp:3385
 msgid "Close"
 msgstr "Zapri"
 
@@ -3027,12 +3017,12 @@ msgstr "Izreži"
 msgid "Copy"
 msgstr "Skopiraj"
 
-#: src/MuleTextCtrl.cpp:88 src/SearchDlg.cpp:261
+#: src/MuleTextCtrl.cpp:88
 msgid "Paste"
 msgstr "Prilepi"
 
 #: src/MuleTextCtrl.cpp:89 src/muuli_wdr.cpp:358 src/muuli_wdr.cpp:757
-#: src/muuli_wdr.cpp:2380 src/muuli_wdr.cpp:2399 src/muuli_wdr.cpp:2421
+#: src/muuli_wdr.cpp:2352 src/muuli_wdr.cpp:2371 src/muuli_wdr.cpp:2393
 #: src/utils/aLinkCreator/src/alcframe.cpp:142
 msgid "Clear"
 msgstr "Počisti"
@@ -3130,8 +3120,8 @@ msgid "Exit"
 msgstr "Končaj"
 
 #: src/MuleTrayIcon.cpp:579 src/MuleTrayIcon.cpp:945 src/MuleTrayIcon.cpp:965
-#: src/muuli_wdr.cpp:1398 src/muuli_wdr.cpp:1406 src/muuli_wdr.cpp:1413
-#: src/muuli_wdr.cpp:1836 src/muuli_wdr.cpp:1842 src/OtherFunctions.cpp:91
+#: src/muuli_wdr.cpp:1391 src/muuli_wdr.cpp:1399 src/muuli_wdr.cpp:1406
+#: src/muuli_wdr.cpp:1835 src/muuli_wdr.cpp:1841 src/OtherFunctions.cpp:91
 #: src/StatisticsDlg.cpp:93 src/StatisticsDlg.cpp:95
 msgid "kB/s"
 msgstr "kB/s"
@@ -3302,7 +3292,7 @@ msgstr "Ime:"
 msgid "Type"
 msgstr "Vrsta"
 
-#: src/muuli_wdr.cpp:215 src/SearchDlg.cpp:118 src/SearchListCtrl.cpp:853
+#: src/muuli_wdr.cpp:215 src/SearchDlg.cpp:110 src/SearchListCtrl.cpp:853
 msgid "Local"
 msgstr "Krajevno"
 
@@ -3373,7 +3363,7 @@ msgstr "Bajtov"
 msgid "KB"
 msgstr "KiB"
 
-#: src/muuli_wdr.cpp:274 src/muuli_wdr.cpp:293 src/muuli_wdr.cpp:1621
+#: src/muuli_wdr.cpp:274 src/muuli_wdr.cpp:293 src/muuli_wdr.cpp:1620
 #: src/OtherFunctions.cpp:64
 msgid "MB"
 msgstr "MiB"
@@ -3390,7 +3380,7 @@ msgstr "Maks. velikost"
 msgid "Availability"
 msgstr "Razpoložljivost"
 
-#: src/muuli_wdr.cpp:312 src/muuli_wdr.cpp:398 src/muuli_wdr.cpp:3318
+#: src/muuli_wdr.cpp:312 src/muuli_wdr.cpp:398 src/muuli_wdr.cpp:3290
 msgid "Filter:"
 msgstr "Filter:"
 
@@ -3422,7 +3412,7 @@ msgstr ""
 msgid "Stop"
 msgstr "Ustavi"
 
-#: src/muuli_wdr.cpp:348 src/muuli_wdr.cpp:1392 src/SearchListCtrl.cpp:732
+#: src/muuli_wdr.cpp:348 src/muuli_wdr.cpp:1385 src/SearchListCtrl.cpp:732
 msgid "Download"
 msgstr "Pridobi"
 
@@ -3453,12 +3443,12 @@ msgstr "Viri datoteke:"
 #: src/muuli_wdr.cpp:1160 src/muuli_wdr.cpp:1167 src/muuli_wdr.cpp:1172
 #: src/muuli_wdr.cpp:1179 src/muuli_wdr.cpp:1184 src/muuli_wdr.cpp:1191
 #: src/muuli_wdr.cpp:1205 src/muuli_wdr.cpp:1212 src/muuli_wdr.cpp:1217
-#: src/muuli_wdr.cpp:1224 src/muuli_wdr.cpp:3255 src/muuli_wdr.cpp:3263
-#: src/muuli_wdr.cpp:3271
+#: src/muuli_wdr.cpp:1224 src/muuli_wdr.cpp:3227 src/muuli_wdr.cpp:3235
+#: src/muuli_wdr.cpp:3243
 msgid "N/A"
 msgstr "Ni na voljo"
 
-#: src/muuli_wdr.cpp:508 src/muuli_wdr.cpp:1065 src/PrefsUnifiedDlg.cpp:299
+#: src/muuli_wdr.cpp:508 src/muuli_wdr.cpp:1065 src/PrefsUnifiedDlg.cpp:297
 msgid "General"
 msgstr "Splošno"
 
@@ -3599,7 +3589,7 @@ msgstr ""
 msgid "Album :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:685 src/muuli_wdr.cpp:2275
+#: src/muuli_wdr.cpp:685 src/muuli_wdr.cpp:2247
 msgid "Title :"
 msgstr "Naslov:"
 
@@ -3708,7 +3698,7 @@ msgstr "Uporabniško ime:"
 msgid "Userhash :"
 msgstr "Koda uporabnika:"
 
-#: src/muuli_wdr.cpp:895 src/muuli_wdr.cpp:1742 src/muuli_wdr.cpp:2470
+#: src/muuli_wdr.cpp:895 src/muuli_wdr.cpp:1741 src/muuli_wdr.cpp:2442
 #: src/utils/aLinkCreator/src/alcframe.cpp:137
 msgid "Add"
 msgstr "Dodaj"
@@ -3717,15 +3707,15 @@ msgstr "Dodaj"
 msgid "Download-Speed"
 msgstr "Hitrost prejemanja"
 
-#: src/muuli_wdr.cpp:954 src/muuli_wdr.cpp:989 src/muuli_wdr.cpp:2574
+#: src/muuli_wdr.cpp:954 src/muuli_wdr.cpp:989 src/muuli_wdr.cpp:2546
 msgid "Current"
 msgstr "Trenutno"
 
-#: src/muuli_wdr.cpp:962 src/muuli_wdr.cpp:997 src/muuli_wdr.cpp:2582
+#: src/muuli_wdr.cpp:962 src/muuli_wdr.cpp:997 src/muuli_wdr.cpp:2554
 msgid "Running average"
 msgstr "Trenutno povprečje"
 
-#: src/muuli_wdr.cpp:970 src/muuli_wdr.cpp:1005 src/muuli_wdr.cpp:2590
+#: src/muuli_wdr.cpp:970 src/muuli_wdr.cpp:1005 src/muuli_wdr.cpp:2562
 msgid "Session average"
 msgstr "Povprečje seje"
 
@@ -3737,7 +3727,7 @@ msgstr "Hitrost pošiljanja"
 msgid "Connections"
 msgstr "Povezave"
 
-#: src/muuli_wdr.cpp:1024 src/muuli_wdr.cpp:1861
+#: src/muuli_wdr.cpp:1024 src/muuli_wdr.cpp:1860
 msgid "Active downloads"
 msgstr "Dejavna prejemanja"
 
@@ -3745,7 +3735,7 @@ msgstr "Dejavna prejemanja"
 msgid "Active connections (1:1)"
 msgstr "Dejavne povezave (1:1)"
 
-#: src/muuli_wdr.cpp:1040 src/muuli_wdr.cpp:1862
+#: src/muuli_wdr.cpp:1040 src/muuli_wdr.cpp:1861
 msgid "Active uploads"
 msgstr "Dejavna pošiljanja"
 
@@ -3862,8 +3852,8 @@ msgstr "To je ime, ki ga vidijo ostali uporabniki, ko se povežejo z vami."
 msgid "Language: "
 msgstr "Jezik: "
 
-#: src/muuli_wdr.cpp:1257 src/muuli_wdr.cpp:1330 src/muuli_wdr.cpp:1334
-#: src/muuli_wdr.cpp:1337
+#: src/muuli_wdr.cpp:1257 src/muuli_wdr.cpp:1323 src/muuli_wdr.cpp:1327
+#: src/muuli_wdr.cpp:1330
 msgid "The delay before showing tool-tips."
 msgstr "Zakasnitev preden se pojavi namig z navodili."
 
@@ -3941,962 +3931,938 @@ msgstr "Prikaži obvestilo ob zaključku prejemanja"
 msgid "Enabling this will make aMule to show notifications when finished downloading."
 msgstr "Če to omogočite, bo aMule ob zaključku prejemanja prikazal obvestilo."
 
-#: src/muuli_wdr.cpp:1323
-#, fuzzy
-msgid "Remember search history"
-msgstr "Zapomni si te nastavitve"
-
-#: src/muuli_wdr.cpp:1324
-msgid "Keeps a dropdown list of your past search terms in the Search tab's Name field. This remembers the queries you typed, not the results they returned."
-msgstr ""
-
-#: src/muuli_wdr.cpp:1329
+#: src/muuli_wdr.cpp:1322
 msgid "Tooltip delay time: "
 msgstr "Zakasnitev namigov: "
 
-#: src/muuli_wdr.cpp:1336
+#: src/muuli_wdr.cpp:1329
 msgid "seconds"
 msgstr "sekund"
 
-#: src/muuli_wdr.cpp:1340
+#: src/muuli_wdr.cpp:1333
 msgid "Browser Selection"
 msgstr "Izbira brskalnika"
 
-#: src/muuli_wdr.cpp:1346
+#: src/muuli_wdr.cpp:1339
 msgid "Enter your browser name here. Leave this field empty to use the system default browser."
 msgstr "Sem vnesite ime brskalnika. Za uporabo privzetega sistemskega brskalnika pustite prazno."
 
-#: src/muuli_wdr.cpp:1353
+#: src/muuli_wdr.cpp:1346
 msgid "Open in new tab if possible"
 msgstr "Odpri v novem zavihku, če je mogoče"
 
-#: src/muuli_wdr.cpp:1355
+#: src/muuli_wdr.cpp:1348
 msgid "Open the web page in a new tab instead of in a new window when possible"
 msgstr "Če je mogoče, odpre stran v novem zavihku namesto v novem oknu."
 
-#: src/muuli_wdr.cpp:1359
+#: src/muuli_wdr.cpp:1352
 msgid "Video Player"
 msgstr "Video predvajalnik"
 
-#: src/muuli_wdr.cpp:1386
+#: src/muuli_wdr.cpp:1379
 msgid "Bandwidth limits"
 msgstr "Omejitve povezave"
 
-#: src/muuli_wdr.cpp:1400
+#: src/muuli_wdr.cpp:1393
 msgid "Upload"
 msgstr "Pošlji"
 
-#: src/muuli_wdr.cpp:1408
+#: src/muuli_wdr.cpp:1401
 msgid "Slot Allocation"
 msgstr "Hitrost za eno mesto"
 
-#: src/muuli_wdr.cpp:1417
+#: src/muuli_wdr.cpp:1410
 msgid "Ports"
 msgstr "Vrata"
 
-#: src/muuli_wdr.cpp:1427
+#: src/muuli_wdr.cpp:1420
 msgid "This is the standard eD2k port and cannot be disabled."
 msgstr "To so standardna vrata za eD2k in jih ni moč onemogočiti."
 
-#: src/muuli_wdr.cpp:1430
+#: src/muuli_wdr.cpp:1423
 msgid "UDP port for server requests (TCP+3):"
 msgstr "Vrata UDP za zahtevke strežnika (TCP+3):"
 
-#: src/muuli_wdr.cpp:1432
+#: src/muuli_wdr.cpp:1425
 msgid "4665"
 msgstr "4665"
 
-#: src/muuli_wdr.cpp:1439
+#: src/muuli_wdr.cpp:1432
 msgid "This UDP port is used for extended eD2k requests and Kad network"
 msgstr "Ta vrata UDP se uporabljajo za dodatne zahtevke eD2k in omrežje Kad."
 
-#: src/muuli_wdr.cpp:1446
+#: src/muuli_wdr.cpp:1439
 msgid "UPnP TCP Port (Optional):"
 msgstr "Vrata TCP za UPnP (neobvezno):"
 
-#: src/muuli_wdr.cpp:1456
+#: src/muuli_wdr.cpp:1449
 msgid "Bind local address to IP (empty for any):"
 msgstr "Krajevni naslov poveži z IP-jem (prazno za poljuben):"
 
-#: src/muuli_wdr.cpp:1459
+#: src/muuli_wdr.cpp:1452
 msgid "Advanced users only: If you have multiple network interfaces, enter the address of the interface to which aMule should be bound."
 msgstr "Samo za napredne uporabnike: če imate več omrežnih vmesnikov, vnesite naslov vmesnika, s katerim bo povezan aMule."
 
-#: src/muuli_wdr.cpp:1462 src/muuli_wdr.cpp:2055
+#: src/muuli_wdr.cpp:1455 src/muuli_wdr.cpp:2054
 #, fuzzy
 msgid "Bind to network interface (empty for any):"
 msgstr "Krajevni naslov poveži z IP-jem (prazno za poljuben):"
 
-#: src/muuli_wdr.cpp:1475
+#: src/muuli_wdr.cpp:1468
 msgid "Advanced users only: pin all of aMule's traffic to one network interface, chosen from the list or typed in by name (e.g. tun0, eth0, en0) or index. Unlike binding to an IP, this stops traffic leaking out via the default route - useful with a VPN. Requires no elevated privileges."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1481
+#: src/muuli_wdr.cpp:1474
 msgid "Max sources per downloading file:"
 msgstr "Največ virov na prejemanje:"
 
-#: src/muuli_wdr.cpp:1485
+#: src/muuli_wdr.cpp:1478
 msgid "Max simultaneous connections:"
 msgstr "Največ istočasnih povezav:"
 
-#: src/muuli_wdr.cpp:1498 src/muuli_wdr.cpp:3197
+#: src/muuli_wdr.cpp:1491 src/muuli_wdr.cpp:3169
 msgid "ED2K"
 msgstr "eD2k"
 
-#: src/muuli_wdr.cpp:1505
+#: src/muuli_wdr.cpp:1498
 msgid "Autoconnect on startup"
 msgstr "Samodejno se poveži ob zagonu"
 
-#: src/muuli_wdr.cpp:1508
+#: src/muuli_wdr.cpp:1501
 msgid "Reconnect on loss"
 msgstr "Ponovno se poveži ob prekinjeni povezavi"
 
-#: src/muuli_wdr.cpp:1530
+#: src/muuli_wdr.cpp:1523
 msgid "Remove dead server after"
 msgstr "Izbriši nedosegljiv strežnik po"
 
-#: src/muuli_wdr.cpp:1531
+#: src/muuli_wdr.cpp:1524
 msgid "Static servers are never removed, even when unreachable."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1535
+#: src/muuli_wdr.cpp:1528
 msgid "retries"
 msgstr "poskusih"
 
-#: src/muuli_wdr.cpp:1543
+#: src/muuli_wdr.cpp:1536
 msgid "List"
 msgstr "Seznam"
 
-#: src/muuli_wdr.cpp:1546
+#: src/muuli_wdr.cpp:1539
 msgid "Update server list when connecting to a server"
 msgstr "Ob povezavi na strežnik posodobi seznam strežnikov"
 
-#: src/muuli_wdr.cpp:1549
+#: src/muuli_wdr.cpp:1542
 msgid "Update server list when a client connects"
 msgstr "Ob povezavi odjemalca posodobi seznam strežnikov"
 
-#: src/muuli_wdr.cpp:1552
+#: src/muuli_wdr.cpp:1545
 msgid "Use priority system"
 msgstr "Uporabi sistem prednosti"
 
-#: src/muuli_wdr.cpp:1556
+#: src/muuli_wdr.cpp:1549
 msgid "Use smart LowID check on connect"
 msgstr "Uporabi preverjanje za nizek ID ob povezavi"
 
-#: src/muuli_wdr.cpp:1560
+#: src/muuli_wdr.cpp:1553
 msgid "Safe connect"
 msgstr "Varno povezovanje"
 
-#: src/muuli_wdr.cpp:1564
+#: src/muuli_wdr.cpp:1557
 msgid "Autoconnect to servers in static list only"
 msgstr "Samodejna povezava samo na strežnike na statičnem seznamu"
 
-#: src/muuli_wdr.cpp:1567
+#: src/muuli_wdr.cpp:1560
 msgid "Set manually added servers to High Priority"
 msgstr "Nastavi ročno dodane strežnike na visoko prednost"
 
-#: src/muuli_wdr.cpp:1588
+#: src/muuli_wdr.cpp:1581
 msgid "Add files to download in pause mode"
 msgstr "Na novo dodani prejemi naj bodo zaustavljeni"
 
-#: src/muuli_wdr.cpp:1590
+#: src/muuli_wdr.cpp:1583
 msgid "Add files to download with auto priority"
 msgstr "Na novo dodani prejemi naj imajo samodejno prednost"
 
-#: src/muuli_wdr.cpp:1593
+#: src/muuli_wdr.cpp:1586
 msgid "Try to download first and last chunks first"
 msgstr "Najprej poskusi prejeti prvi in zadnji del"
 
-#: src/muuli_wdr.cpp:1597
+#: src/muuli_wdr.cpp:1590
 msgid "Endgame mode: rotate to faster sources for the final blocks"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1600
+#: src/muuli_wdr.cpp:1593
 msgid "Start next paused file when a file completes"
 msgstr "Po zaključku datoteke začni naslednjo prekinjeno"
 
-#: src/muuli_wdr.cpp:1603
+#: src/muuli_wdr.cpp:1596
 msgid "From the same category"
 msgstr "Iz iste kategorije"
 
-#: src/muuli_wdr.cpp:1605
+#: src/muuli_wdr.cpp:1598
 msgid "In alphabetic order"
 msgstr "Po abecednem vrstnem redu"
 
-#: src/muuli_wdr.cpp:1607
+#: src/muuli_wdr.cpp:1600
 msgid "Preallocate disk space for new files"
 msgstr "Novim datotekam vnaprej dodeli prostor na disku"
 
-#: src/muuli_wdr.cpp:1608
+#: src/muuli_wdr.cpp:1601
 msgid "For new files preallocates disk space for the whole file, thus reduces fragmentation"
 msgstr "Za nove datoteke v naprej dodeli prostor na disku v velikosti celotne datoteke, kar zmanjša razdrobljenost."
 
-#: src/muuli_wdr.cpp:1613
+#: src/muuli_wdr.cpp:1606
+msgid "Create new files as sparse files"
+msgstr ""
+
+#: src/muuli_wdr.cpp:1607
+msgid "A sparse file reserves its full size on disk immediately without writing real data to it -- fast, but unsupported or slow on some filesystems, and free-space accounting stays optimistic while the download is in progress. Turn this off to grow the file only as data arrives."
+msgstr ""
+
+#: src/muuli_wdr.cpp:1612
 msgid "Stop downloads when free disk space reaches "
 msgstr "Ustavi prejemanja, ko prostor na disku doseže "
 
-#: src/muuli_wdr.cpp:1614
+#: src/muuli_wdr.cpp:1613
 msgid "Select this if you want aMule to check your disk space"
 msgstr "Izberite, če želite, da aMule preverja prostor na disku"
 
-#: src/muuli_wdr.cpp:1618
+#: src/muuli_wdr.cpp:1617
 msgid "Enter here the min disk space desired."
 msgstr "Sem vnesite min. želen prostor na disku."
 
-#: src/muuli_wdr.cpp:1624
+#: src/muuli_wdr.cpp:1623
 msgid "Save 10 sources on rare files (< 20 sources)"
 msgstr "Shrani 10 virov pri redkih datotekah (< 20 virov)"
 
-#: src/muuli_wdr.cpp:1628 src/Statistics.cpp:790
+#: src/muuli_wdr.cpp:1627 src/Statistics.cpp:790
 msgid "Uploads"
 msgstr "Pošiljanja"
 
-#: src/muuli_wdr.cpp:1631
+#: src/muuli_wdr.cpp:1630
 msgid "Add new shared files with auto priority"
 msgstr "Nove deljene datoteke naj imajo samodejno prednost"
 
-#: src/muuli_wdr.cpp:1637
+#: src/muuli_wdr.cpp:1636
 msgid "Intelligent Corruption Handling (I.C.H.)"
 msgstr "Inteligentno rokovanje s poškodbami (I.R.P.)"
 
-#: src/muuli_wdr.cpp:1640
+#: src/muuli_wdr.cpp:1639
 msgid "Enable"
 msgstr "Omogoči"
 
-#: src/muuli_wdr.cpp:1643
+#: src/muuli_wdr.cpp:1642
 msgid "Advanced I.C.H. trusts every hash (not recommended)"
 msgstr "Napredni I.R.P. zaupa vsaki kodi (ni priporočeno)"
 
-#: src/muuli_wdr.cpp:1655 src/PrefsUnifiedDlg.cpp:1990
+#: src/muuli_wdr.cpp:1654 src/PrefsUnifiedDlg.cpp:1910
 msgid "Media metadata extraction"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1659
+#: src/muuli_wdr.cpp:1658
 msgid "Extract length / bitrate / codec from shared audio and video files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1661
+#: src/muuli_wdr.cpp:1660
 msgid "When enabled, aMule runs ffprobe on each shared media file to fill in the Length / Bitrate / Codec columns other clients see when they find the file in a search. Requires ffmpeg (the ffprobe binary) to be installed."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1668
+#: src/muuli_wdr.cpp:1667
 msgid "Path to ffprobe:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1673
+#: src/muuli_wdr.cpp:1672
 msgid "Full path to the ffprobe binary. Leave empty to have aMule auto-detect it on startup."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1681
+#: src/muuli_wdr.cpp:1680
 msgid "Detect"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1682
+#: src/muuli_wdr.cpp:1681
 msgid "Search the standard install locations for an ffprobe binary and fill the path field."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1706
+#: src/muuli_wdr.cpp:1705
 msgid ""
 "Completed downloads are stored here. All files in this folder are automatically shared with other peers.\n"
 "If this folder also holds files you don't want to share, point it at an aMule-only sub-folder."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1709
+#: src/muuli_wdr.cpp:1708
 msgid "Pick the folder where completed downloads will be stored. All files in that folder will be shared with other peers."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1723
+#: src/muuli_wdr.cpp:1722
 msgid "Shared folders"
 msgstr "Deljene mape"
 
-#: src/muuli_wdr.cpp:1729
+#: src/muuli_wdr.cpp:1728
 msgid "(Folders shared by the core. Enter a path to add one.)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1737
+#: src/muuli_wdr.cpp:1736
 msgid "Absolute path of a folder on the core's machine, e.g. /home/user/shared"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1739 src/PrefsUnifiedDlg.cpp:2874
+#: src/muuli_wdr.cpp:1738 src/PrefsUnifiedDlg.cpp:2794
 msgid "Recursive"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1740
+#: src/muuli_wdr.cpp:1739
 msgid "Share every sub-folder underneath this one, including ones created later."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1744 src/utils/aLinkCreator/src/alcframe.cpp:141
+#: src/muuli_wdr.cpp:1743 src/utils/aLinkCreator/src/alcframe.cpp:141
 msgid "Remove"
 msgstr "Odstrani"
 
-#: src/muuli_wdr.cpp:1748
+#: src/muuli_wdr.cpp:1747
 msgid "(Right click on folder icon for recursive share)"
 msgstr "(desni klik na ikono mape izbere tudi podmape)"
 
-#: src/muuli_wdr.cpp:1755
+#: src/muuli_wdr.cpp:1754
 msgid "Share hidden files"
 msgstr "Deli skrite datoteke"
 
-#: src/muuli_wdr.cpp:1761
+#: src/muuli_wdr.cpp:1760
 msgid "Automatically rescan shared folders for changes"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1767
+#: src/muuli_wdr.cpp:1766
 msgid "Follow symbolic links in shared folders"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1773
+#: src/muuli_wdr.cpp:1772
 msgid "Exclude files matching:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1776
+#: src/muuli_wdr.cpp:1775
 msgid "Wildcard patterns separated by '|', e.g. .DS_Store|Thumbs.db|*.tmp. Files whose name matches are not shared. Matching is case-insensitive."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1780
+#: src/muuli_wdr.cpp:1779
 msgid "Patterns are regular expressions"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1781
+#: src/muuli_wdr.cpp:1780
 msgid "When set, the whole field is one regular expression ('|' is alternation). When unset, it is a list of '|'-separated wildcards."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1791
+#: src/muuli_wdr.cpp:1790
 msgid "Show how many shared files the current pattern would exclude."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1812
+#: src/muuli_wdr.cpp:1811
 msgid "Graphs"
 msgstr "Grafi"
 
-#: src/muuli_wdr.cpp:1815 src/muuli_wdr.cpp:1877
+#: src/muuli_wdr.cpp:1814 src/muuli_wdr.cpp:1876
 msgid "Update delay : 5 secs"
 msgstr "Zamik posodabljanja: 5 sek."
 
-#: src/muuli_wdr.cpp:1819
+#: src/muuli_wdr.cpp:1818
 msgid "Time for average graph: 100 mins"
 msgstr "Čas za graf povprečja: 100 min."
 
-#: src/muuli_wdr.cpp:1823
+#: src/muuli_wdr.cpp:1822
 msgid "Connections Graph Scale: 100 "
 msgstr "Merilo za graf povezav: 100 "
 
-#: src/muuli_wdr.cpp:1830
+#: src/muuli_wdr.cpp:1829
 msgid "Download graph scale:"
 msgstr "Merilo za graf prejemanj:"
 
-#: src/muuli_wdr.cpp:1838
+#: src/muuli_wdr.cpp:1837
 msgid "Upload graph scale:"
 msgstr "Merilo za graf pošiljanj:"
 
-#: src/muuli_wdr.cpp:1848
+#: src/muuli_wdr.cpp:1847
 #, fuzzy
 msgid "Colors: "
 msgstr "Barve: "
 
-#: src/muuli_wdr.cpp:1852
+#: src/muuli_wdr.cpp:1851
 msgid "Background"
 msgstr "Ozadje"
 
-#: src/muuli_wdr.cpp:1853
+#: src/muuli_wdr.cpp:1852
 msgid "Grid"
 msgstr "Mreža"
 
-#: src/muuli_wdr.cpp:1854
+#: src/muuli_wdr.cpp:1853
 msgid "Download current"
 msgstr "Trenutno prejemanje"
 
-#: src/muuli_wdr.cpp:1855
+#: src/muuli_wdr.cpp:1854
 msgid "Download running average"
 msgstr "Povprečje prejemanja"
 
-#: src/muuli_wdr.cpp:1856
+#: src/muuli_wdr.cpp:1855
 msgid "Download session average"
 msgstr "Povprečje seje za prejemanje"
 
-#: src/muuli_wdr.cpp:1857
+#: src/muuli_wdr.cpp:1856
 msgid "Upload current"
 msgstr "Trenutno pošiljanje"
 
-#: src/muuli_wdr.cpp:1858
+#: src/muuli_wdr.cpp:1857
 msgid "Upload running average"
 msgstr "Povprečje pošiljanja"
 
-#: src/muuli_wdr.cpp:1859
+#: src/muuli_wdr.cpp:1858
 msgid "Upload session average"
 msgstr "Povprečje seje za pošiljanje"
 
-#: src/muuli_wdr.cpp:1860
+#: src/muuli_wdr.cpp:1859
 msgid "Active connections"
 msgstr "Dejavne povezave"
 
-#: src/muuli_wdr.cpp:1863
+#: src/muuli_wdr.cpp:1862
 #, fuzzy
 msgid "Systray Icon Speed Bar"
 msgstr "Prikaz hitrosti v sistemski vrstici"
 
-#: src/muuli_wdr.cpp:1864
+#: src/muuli_wdr.cpp:1863
 msgid "Kad-nodes current"
 msgstr "Trenutna vozlišča Kad"
 
-#: src/muuli_wdr.cpp:1865
+#: src/muuli_wdr.cpp:1864
 msgid "Kad-nodes running"
 msgstr "Vozlišča Kad v teku"
 
-#: src/muuli_wdr.cpp:1866
+#: src/muuli_wdr.cpp:1865
 msgid "Kad-nodes session"
 msgstr "Vozlišča Kad te seje"
 
-#: src/muuli_wdr.cpp:1870 src/muuli_wdr.cpp:2324
+#: src/muuli_wdr.cpp:1869 src/muuli_wdr.cpp:2296
 msgid "Select"
 msgstr "Izberi"
 
-#: src/muuli_wdr.cpp:1874
+#: src/muuli_wdr.cpp:1873
 msgid "Tree"
 msgstr "Drevo"
 
-#: src/muuli_wdr.cpp:1884
+#: src/muuli_wdr.cpp:1883
 msgid "Number of Client Versions shown (0=unlimited)"
 msgstr "Število prikazanih različic odjemalcev (0 = neomejeno)"
 
-#: src/muuli_wdr.cpp:1909
+#: src/muuli_wdr.cpp:1908
 msgid "!!! WARNING !!!"
 msgstr "!!! OPOZORILO !!!"
 
-#: src/muuli_wdr.cpp:1924
+#: src/muuli_wdr.cpp:1923
 msgid "Max new connections / 5 secs"
 msgstr "Maks. novih povezav / 5 sek."
 
-#: src/muuli_wdr.cpp:1926
+#: src/muuli_wdr.cpp:1925
 msgid "Concurrent Kad source lookups"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1928
+#: src/muuli_wdr.cpp:1927
 #, fuzzy
 msgid "Kad source re-search interval (minutes)"
 msgstr "Interval med osvežitvami FTP-ja v minutah"
 
-#: src/muuli_wdr.cpp:1930
+#: src/muuli_wdr.cpp:1929
 #, fuzzy
 msgid "Source re-ask interval (minutes)"
 msgstr "Interval med osvežitvami FTP-ja v minutah"
 
-#: src/muuli_wdr.cpp:1934
+#: src/muuli_wdr.cpp:1933
 msgid "File Buffer Size: 240000 bytes"
 msgstr "Datotečni medpomnilnik: 240000 bajtov"
 
-#: src/muuli_wdr.cpp:1938
+#: src/muuli_wdr.cpp:1937
 msgid "Use MMAP: memory-mapped file access (lower memory use)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1939
+#: src/muuli_wdr.cpp:1938
 msgid "Maps part files into memory instead of buffering them on the heap, lowering the process memory footprint. May reduce download speed on some disks; best for memory-constrained or upload-heavy hosts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1941
+#: src/muuli_wdr.cpp:1940
 msgid "Upload Queue Size: 5000 clients"
 msgstr "Velikost vrste za pošiljanje: 5000 odjemalcev"
 
-#: src/muuli_wdr.cpp:1945
+#: src/muuli_wdr.cpp:1944
 msgid "Server connection refresh interval: Disable"
 msgstr "Čas med osvežitvama povezave na strežnik: onemogoči"
 
-#: src/muuli_wdr.cpp:1949
+#: src/muuli_wdr.cpp:1948
 msgid "Disable computer's timed standby mode"
 msgstr "Onemogoči prehod računalnika v pripravljenost"
 
-#: src/muuli_wdr.cpp:1968
+#: src/muuli_wdr.cpp:1967
 msgid "Skin to use: "
 msgstr "Uporabljena preobleka: "
 
-#: src/muuli_wdr.cpp:1977
+#: src/muuli_wdr.cpp:1976
 msgid "Show \"Fast eD2k Links Handler\" in every window."
 msgstr "Prikaži hitri rokovalnik s povezavami eD2k v vsakem oknu."
 
-#: src/muuli_wdr.cpp:1980
+#: src/muuli_wdr.cpp:1979
 msgid "Show extended info on categories tabs"
 msgstr "Prikaži razširjene podatke na zavihkih kategorij"
 
-#: src/muuli_wdr.cpp:1983
+#: src/muuli_wdr.cpp:1982
 msgid "Show application version on title"
 msgstr "V naslovni vrstici pokaži različico programa"
 
-#: src/muuli_wdr.cpp:1985
+#: src/muuli_wdr.cpp:1984
 msgid "Show transfer rates on title"
 msgstr "Kaži hitrosti prenosa v naslovni vrstici"
 
-#: src/muuli_wdr.cpp:1987
+#: src/muuli_wdr.cpp:1986
 msgid "Before application name"
 msgstr "Pred imenom programa"
 
-#: src/muuli_wdr.cpp:1989
+#: src/muuli_wdr.cpp:1988
 msgid "After application name"
 msgstr "Za imenom programa"
 
-#: src/muuli_wdr.cpp:1992
+#: src/muuli_wdr.cpp:1991
 msgid "Show overhead bandwidth"
 msgstr "Kaži presežek prenosov"
 
-#: src/muuli_wdr.cpp:1996
+#: src/muuli_wdr.cpp:1995
 msgid "Vertical toolbar orientation"
 msgstr "Usmeri orodjarno navpično"
 
-#: src/muuli_wdr.cpp:1998
+#: src/muuli_wdr.cpp:1997
 msgid "Live column sorting (auto-reorder rows as their values change)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2005
+#: src/muuli_wdr.cpp:2004
 msgid "Download Queue Files"
 msgstr "Datoteke v vrsti prejemanj"
 
-#: src/muuli_wdr.cpp:2008
+#: src/muuli_wdr.cpp:2007
 msgid "Show progress percentage"
 msgstr "Prikaži odstotek napredka"
 
-#: src/muuli_wdr.cpp:2014
+#: src/muuli_wdr.cpp:2013
 msgid "Show progress bar"
 msgstr "Prikaži črto napredka"
 
-#: src/muuli_wdr.cpp:2017
+#: src/muuli_wdr.cpp:2016
 msgid "Flat"
 msgstr "Plosko"
 
-#: src/muuli_wdr.cpp:2021
+#: src/muuli_wdr.cpp:2020
 msgid "Round"
 msgstr "Zaokroženo"
 
-#: src/muuli_wdr.cpp:2039
+#: src/muuli_wdr.cpp:2038
 msgid "External Connection Parameters"
 msgstr "Parametri za zunanje povezave"
 
-#: src/muuli_wdr.cpp:2042
+#: src/muuli_wdr.cpp:2041
 msgid "Accept external connections"
 msgstr "Sprejmi zunanje povezave"
 
-#: src/muuli_wdr.cpp:2049 src/muuli_wdr.cpp:2108
+#: src/muuli_wdr.cpp:2048 src/muuli_wdr.cpp:2107
 msgid "IP of the listening interface:"
 msgstr "IP vmesnika, ki posluša:"
 
-#: src/muuli_wdr.cpp:2052
+#: src/muuli_wdr.cpp:2051
 msgid "Enter here a valid ip in the a.b.c.d format for the listening EC interface. An empty field or 0.0.0.0 will mean any interface."
 msgstr "Sem vnesite veljaven IP v formatu a.b.c.d za poslušalen vmesnik. Prazno polje ali 0.0.0.0 pomeni poljuben vmesnik."
 
-#: src/muuli_wdr.cpp:2073 src/muuli_wdr.cpp:2184
+#: src/muuli_wdr.cpp:2072 src/muuli_wdr.cpp:2156
 msgid "TCP port:"
 msgstr "Vrata TCP:"
 
-#: src/muuli_wdr.cpp:2079
+#: src/muuli_wdr.cpp:2078
 msgid "Enable UPnP port forwarding on the EC port"
 msgstr "Vklopi posredovanje vrat UPnP za vrata zunanjih povezav"
 
-#: src/muuli_wdr.cpp:2083 src/muuli_wdr.cpp:3069
+#: src/muuli_wdr.cpp:2082 src/muuli_wdr.cpp:3041
 #: src/utils/wxCas/src/wxcasprefs.cpp:167
 msgid "Password"
 msgstr "Geslo"
 
-#: src/muuli_wdr.cpp:2089
+#: src/muuli_wdr.cpp:2088
 #, fuzzy
 msgid "aMule API server parameters"
 msgstr "Parametri spletnega strežnika"
 
-#: src/muuli_wdr.cpp:2092
+#: src/muuli_wdr.cpp:2091
 msgid "Run amuleapi (REST API) on startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2097
+#: src/muuli_wdr.cpp:2096
 #, fuzzy
 msgid "HTTP port:"
 msgstr "Vrata TCP:"
 
-#: src/muuli_wdr.cpp:2111
+#: src/muuli_wdr.cpp:2110
 msgid "The interface amuleapi's HTTP server listens on. 127.0.0.1 (default) accepts only local connections; use 0.0.0.0 or a specific IP to expose it to other hosts (set an admin password below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2116
-msgid "Type a password to set or change it. Stored passwords cannot be shown, so leaving this empty keeps the current one."
-msgstr ""
-
-#: src/muuli_wdr.cpp:2118
+#: src/muuli_wdr.cpp:2113
 #, fuzzy
 msgid "Admin password"
 msgstr "Preverjanje gesla\n"
 
-#: src/muuli_wdr.cpp:2130 src/muuli_wdr.cpp:2147 src/PrefsUnifiedDlg.cpp:1103
-#, fuzzy
-msgid "A password is set."
-msgstr "Preverjanje gesla\n"
+#: src/muuli_wdr.cpp:2118 src/muuli_wdr.cpp:2149
+msgid "Low rights password"
+msgstr "Geslo za nizke pravice"
 
-#: src/muuli_wdr.cpp:2134
-#, fuzzy
-msgid "Enable guest access"
-msgstr "Zavrni dostop gostom"
-
-#: src/muuli_wdr.cpp:2135
-msgid "Guest sessions may read status and listings but cannot change anything. Turning this off clears the stored guest password."
-msgstr ""
-
-#: src/muuli_wdr.cpp:2139
-#, fuzzy
-msgid "Guest password"
-msgstr "Geslo za goste na spletnem strežniku"
-
-#: src/muuli_wdr.cpp:2154
+#: src/muuli_wdr.cpp:2126
 msgid "Web server parameters"
 msgstr "Parametri spletnega strežnika"
 
-#: src/muuli_wdr.cpp:2157
+#: src/muuli_wdr.cpp:2129
 #, fuzzy
 msgid "Run webserver on startup (deprecated)"
 msgstr "Spletni strežnik zaženi ob zagonu"
 
-#: src/muuli_wdr.cpp:2163
+#: src/muuli_wdr.cpp:2135
 msgid "Web template"
 msgstr "Spletna predloga"
 
-#: src/muuli_wdr.cpp:2168
+#: src/muuli_wdr.cpp:2140
 msgid "Full rights password"
 msgstr "Geslo za vse pravice"
 
-#: src/muuli_wdr.cpp:2172
+#: src/muuli_wdr.cpp:2144
 msgid "Enable Low rights User"
 msgstr "Omogoči uporabnika z nizkimi pravicami"
 
-#: src/muuli_wdr.cpp:2177
-msgid "Low rights password"
-msgstr "Geslo za nizke pravice"
-
-#: src/muuli_wdr.cpp:2191
+#: src/muuli_wdr.cpp:2163
 msgid "Enable UPnP port forwarding of the web server port"
 msgstr "Vklopi posredovanje vrat UPnP za vrata spletnega strežnika"
 
-#: src/muuli_wdr.cpp:2196
+#: src/muuli_wdr.cpp:2168
 msgid "Web server UPnP TCP port (Optional)"
 msgstr "Vrata TCP za UPnP za spletni strežnik (neobvezno)"
 
-#: src/muuli_wdr.cpp:2204
+#: src/muuli_wdr.cpp:2176
 msgid "Page Refresh Time (in secs)"
 msgstr "Čas med osvežitvami strani (v sek.)"
 
-#: src/muuli_wdr.cpp:2211
+#: src/muuli_wdr.cpp:2183
 msgid "Enable Gzip compression"
 msgstr "Omogoči stiskanje gzip"
 
-#: src/muuli_wdr.cpp:2245
+#: src/muuli_wdr.cpp:2217
 #, fuzzy
 msgid "Reset page to defaults"
 msgstr "Sistemsko privzet"
 
-#: src/muuli_wdr.cpp:2246
+#: src/muuli_wdr.cpp:2218
 msgid "Reset the settings on the current page to their default values."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2248 src/muuli_wdr.cpp:2334 src/ServerWnd.cpp:274
+#: src/muuli_wdr.cpp:2220 src/muuli_wdr.cpp:2306 src/ServerWnd.cpp:274
 #: src/ServerWnd.cpp:282
 msgid "OK"
 msgstr "V redu"
 
-#: src/muuli_wdr.cpp:2250
+#: src/muuli_wdr.cpp:2222
 msgid "Click here to apply any changes made to the preferences."
 msgstr "Kliknite tukaj za uveljavitev sprememb v nastavitvah."
 
-#: src/muuli_wdr.cpp:2253
+#: src/muuli_wdr.cpp:2225
 msgid "Reset any changes made to the preferences."
 msgstr "Razveljavi vse spremembe v nastavitvah."
 
-#: src/muuli_wdr.cpp:2282
+#: src/muuli_wdr.cpp:2254
 msgid "Comment :"
 msgstr "Komentar:"
 
-#: src/muuli_wdr.cpp:2289
+#: src/muuli_wdr.cpp:2261
 msgid "Incoming Dir :"
 msgstr "Mapa za prejeto:"
 
-#: src/muuli_wdr.cpp:2298
+#: src/muuli_wdr.cpp:2270
 msgid "Change priority for new assigned files :"
 msgstr "Spremeni prednost novo dodeljenim datotekam:"
 
-#: src/muuli_wdr.cpp:2302
+#: src/muuli_wdr.cpp:2274
 msgid "Don't change"
 msgstr "Ne spremeni"
 
-#: src/muuli_wdr.cpp:2314
+#: src/muuli_wdr.cpp:2286
 msgid "Select color for this Category (currently selected) :"
 msgstr "Izberite barvo za to kategorijo (trenutno izbrano):"
 
-#: src/muuli_wdr.cpp:2381 src/muuli_wdr.cpp:2400 src/muuli_wdr.cpp:2422
+#: src/muuli_wdr.cpp:2353 src/muuli_wdr.cpp:2372 src/muuli_wdr.cpp:2394
 msgid "Click this button to reset the log."
 msgstr "Kliknite ta gumb, da ponastavite dnevnik."
 
-#: src/muuli_wdr.cpp:2441
+#: src/muuli_wdr.cpp:2413
 msgid "Click on this button to update the servers list from URL ..."
 msgstr "Kliknite ta gumb za posodobitev seznama strežnikov iz URL-ja."
 
-#: src/muuli_wdr.cpp:2445
+#: src/muuli_wdr.cpp:2417
 msgid "Server list"
 msgstr "Seznam strežnikov"
 
-#: src/muuli_wdr.cpp:2449
+#: src/muuli_wdr.cpp:2421
 msgid "Enter the url to a server.met file here and press the button to the left to update the list of known servers."
 msgstr "Vnesite URL do datoteke server.met in kliknite gumb na levi, da posodobite seznam strežnikov."
 
-#: src/muuli_wdr.cpp:2454
+#: src/muuli_wdr.cpp:2426
 msgid "Add server manually: Name"
 msgstr "Ročno dodaj strežnik: ime"
 
-#: src/muuli_wdr.cpp:2457
+#: src/muuli_wdr.cpp:2429
 msgid "Enter the name of the new server here"
 msgstr "Sem vnesite ime novega strežnika"
 
-#: src/muuli_wdr.cpp:2459 src/ServerWnd.cpp:206
+#: src/muuli_wdr.cpp:2431 src/ServerWnd.cpp:206
 msgid "IP:Port"
 msgstr "IP:Vrata"
 
-#: src/muuli_wdr.cpp:2462
+#: src/muuli_wdr.cpp:2434
 msgid "Enter the IP of the server here, using the x.x.x.x format."
 msgstr "Sem vnesite IP strežnika v formatu x.x.x.x."
 
-#: src/muuli_wdr.cpp:2468
+#: src/muuli_wdr.cpp:2440
 msgid "Enter the port of the server here."
 msgstr "Sem vnesite vrata strežnika."
 
-#: src/muuli_wdr.cpp:2471
+#: src/muuli_wdr.cpp:2443
 msgid "Add manually a server (fill fields to the left before) ..."
 msgstr "Ročno dodaj strežnik (najprej izpolnite vsa polja) …"
 
-#: src/muuli_wdr.cpp:2500
+#: src/muuli_wdr.cpp:2472
 msgid "aMule Log"
 msgstr "aMule dnevnik"
 
-#: src/muuli_wdr.cpp:2508
+#: src/muuli_wdr.cpp:2480
 msgid "Server Info"
 msgstr "Podatki o strežniku"
 
-#: src/muuli_wdr.cpp:2512
+#: src/muuli_wdr.cpp:2484
 msgid "ED2K Info"
 msgstr "Podatki o eD2k"
 
-#: src/muuli_wdr.cpp:2516
+#: src/muuli_wdr.cpp:2488
 msgid "Kad Info"
 msgstr "Podatki o Kad"
 
-#: src/muuli_wdr.cpp:2544
+#: src/muuli_wdr.cpp:2516
 msgid "Click on this button to update the nodes list from URL ..."
 msgstr "Kliknite ta gumb za posodobitev seznama vozlišč iz URL-ja."
 
-#: src/muuli_wdr.cpp:2548
+#: src/muuli_wdr.cpp:2520
 msgid "Nodes (0)"
 msgstr "Vozlišča (0)"
 
-#: src/muuli_wdr.cpp:2552
+#: src/muuli_wdr.cpp:2524
 msgid "Enter the url to a nodes.dat file here and press the button to the left to update the list of known nodes."
 msgstr "Vnesite URL do datoteke nodes.dat in pritisnite gumb na levi za posodobitev seznama vozlišč."
 
-#: src/muuli_wdr.cpp:2555
+#: src/muuli_wdr.cpp:2527
 msgid "Nodes stats"
 msgstr "Statistika vozlišč"
 
-#: src/muuli_wdr.cpp:2597
+#: src/muuli_wdr.cpp:2569
 msgid "Bootstrap"
 msgstr "Začetno nalaganje"
 
-#: src/muuli_wdr.cpp:2600
+#: src/muuli_wdr.cpp:2572
 msgid "New node"
 msgstr "Novo vozlišče"
 
-#: src/muuli_wdr.cpp:2605
+#: src/muuli_wdr.cpp:2577
 msgid "IP:"
 msgstr "IP:"
 
-#: src/muuli_wdr.cpp:2625
+#: src/muuli_wdr.cpp:2597
 msgid "Port:"
 msgstr "Vrata:"
 
-#: src/muuli_wdr.cpp:2638
+#: src/muuli_wdr.cpp:2610
 msgid "Bootstrap from known clients"
 msgstr ""
 "Naloži od znanih \n"
 "odjemalcev"
 
-#: src/muuli_wdr.cpp:2640
+#: src/muuli_wdr.cpp:2612
 msgid "Disconnect Kad"
 msgstr "Prekini povezavo s Kad"
 
-#: src/muuli_wdr.cpp:2674
+#: src/muuli_wdr.cpp:2646
 msgid "Use Secure User Identification"
 msgstr "Uporabi varno identifikacijo uporabnikov"
 
-#: src/muuli_wdr.cpp:2676
+#: src/muuli_wdr.cpp:2648
 msgid "It is recommended to enable this option. You will not receive credits if SUI is not enabled."
 msgstr "Priporočamo, da omogočite to možnost. Če to ni omogočeno, ne boste prejeli točk za zasluge."
 
-#: src/muuli_wdr.cpp:2678
+#: src/muuli_wdr.cpp:2650
 msgid "Protocol Obfuscation"
 msgstr "Maskiranje protokola"
 
-#: src/muuli_wdr.cpp:2681
+#: src/muuli_wdr.cpp:2653
 msgid "Support Protocol Obfuscation"
 msgstr "Omogoči maskiranje protokola"
 
-#: src/muuli_wdr.cpp:2683
+#: src/muuli_wdr.cpp:2655
 msgid "This option enabled Protocol Obfuscation, and makes aMule accept obfuscated connections from other clients."
 msgstr "Ob vklopu te možnosti, bo aMule sprejemal maskirane povezave od drugih odjemalcev."
 
-#: src/muuli_wdr.cpp:2685
+#: src/muuli_wdr.cpp:2657
 msgid "Use obfuscation for outgoing connections"
 msgstr "Uporabi maskiranje za izhodne povezave"
 
-#: src/muuli_wdr.cpp:2687
+#: src/muuli_wdr.cpp:2659
 msgid "This option makes aMule use Protocol Obfuscation when connecting other clients/servers."
 msgstr "Ob vklopu te možnosti, bo aMule uporabil maskiranje pri povezavi z drugimi odjemalci in na strežnike."
 
-#: src/muuli_wdr.cpp:2689
+#: src/muuli_wdr.cpp:2661
 msgid "Accept only obfuscated connections"
 msgstr "Dovoli samo maskirane povezave"
 
-#: src/muuli_wdr.cpp:2690
+#: src/muuli_wdr.cpp:2662
 msgid "This option makes aMule only accept obfuscated connections. You will have less sources, but all your traffic will be obfuscated"
 msgstr "Ob vklopu te možnosti, bo aMule sprejemal samo maskirane povezave. Imeli boste manj virov, vendar bodo vse povezave maskirane."
 
-#: src/muuli_wdr.cpp:2695
+#: src/muuli_wdr.cpp:2667
 msgid "Everybody"
 msgstr "Vsi"
 
-#: src/muuli_wdr.cpp:2697
+#: src/muuli_wdr.cpp:2669
 msgid "No one"
 msgstr "Nihče"
 
-#: src/muuli_wdr.cpp:2699
+#: src/muuli_wdr.cpp:2671
 msgid "Who can see my shared files:"
 msgstr "Kdo lahko vidi moje deljene datoteke:"
 
-#: src/muuli_wdr.cpp:2700
+#: src/muuli_wdr.cpp:2672
 msgid "Select who can request to view a list of your shared files."
 msgstr "Izberite, kdo lahko zahteva vaš seznam deljenih datotek."
 
-#: src/muuli_wdr.cpp:2702
+#: src/muuli_wdr.cpp:2674
 msgid "IP-Filtering"
 msgstr "Filtriranje IP-jev"
 
-#: src/muuli_wdr.cpp:2709
+#: src/muuli_wdr.cpp:2681
 msgid "Filter clients"
 msgstr "Filtriraj odjemalce"
 
-#: src/muuli_wdr.cpp:2711
+#: src/muuli_wdr.cpp:2683
 msgid "Enable filtering of the client IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "Omogoči filtriranje odjemalčevih IP-jev, določenih v datoteki ~/.aMule/ipfilter.dat."
 
-#: src/muuli_wdr.cpp:2713
+#: src/muuli_wdr.cpp:2685
 msgid "Filter servers"
 msgstr "Filtriraj strežnike"
 
-#: src/muuli_wdr.cpp:2715
+#: src/muuli_wdr.cpp:2687
 msgid "Enable filtering of the server IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "Omogoči filtriranje strežnikovih IP-jev, določenih v datoteki ~/.aMule/ipfilter.dat."
 
-#: src/muuli_wdr.cpp:2719
+#: src/muuli_wdr.cpp:2691
 msgid "Reload List"
 msgstr "Znova naloži seznam"
 
-#: src/muuli_wdr.cpp:2720
+#: src/muuli_wdr.cpp:2692
 msgid "Reload the list of IPs to filter from the file ~/.aMule/ipfilter.dat"
 msgstr "Ponovno naloži seznam IP-jev za filtriranje iz ~/.aMule/ipfilter.dat."
 
-#: src/muuli_wdr.cpp:2726
+#: src/muuli_wdr.cpp:2698
 msgid "URL:"
 msgstr "URL:"
 
-#: src/muuli_wdr.cpp:2730 src/muuli_wdr.cpp:2923
+#: src/muuli_wdr.cpp:2702 src/muuli_wdr.cpp:2895
 msgid "Update now"
 msgstr "Posodobi zdaj"
 
-#: src/muuli_wdr.cpp:2733
+#: src/muuli_wdr.cpp:2705
 msgid "Auto-update ipfilter at startup"
 msgstr "Samodejno posodobi filter IP-jev ob zagonu"
 
-#: src/muuli_wdr.cpp:2737
+#: src/muuli_wdr.cpp:2709
 msgid "Filtering Level:"
 msgstr "Stopnja filtriranja:"
 
-#: src/muuli_wdr.cpp:2743
+#: src/muuli_wdr.cpp:2715
 msgid "Always filter LAN IPs"
 msgstr "Vedno filtriraj IP-je krajevnega omrežja"
 
-#: src/muuli_wdr.cpp:2746
+#: src/muuli_wdr.cpp:2718
 msgid "Paranoid handling of non-matching IPs"
 msgstr "Paranoično rokovanje z ne-ujemajočimi IP-ji"
 
-#: src/muuli_wdr.cpp:2748
+#: src/muuli_wdr.cpp:2720
 msgid "Rejects a packet when its source IP differs from the IP the client claims (an anti-spoofing check). Disable only if it causes connection problems."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2750
+#: src/muuli_wdr.cpp:2722
 msgid "Use system-wide ipfilter.dat if available"
 msgstr "Uporabi sistemsko ipfilter.dat, če je na voljo"
 
-#: src/muuli_wdr.cpp:2751
+#: src/muuli_wdr.cpp:2723
 #, fuzzy
 msgid "If there's no local ipfilter.dat found, allow usage of a system-wide ipfilter file."
 msgstr "Če krajevne datoteke ipfilter.dat ni moč najti, omogoči uporabo sistemske datoteke."
 
-#: src/muuli_wdr.cpp:2768
+#: src/muuli_wdr.cpp:2740
 msgid "Enable Online-Signature"
 msgstr "Omogoči spletni podpis"
 
-#: src/muuli_wdr.cpp:2770
+#: src/muuli_wdr.cpp:2742
 msgid "Enables the writing of the OS file, which can be used by external apps to create signatures and the like."
 msgstr "Omogoči pisanje v datoteko spletnega podpisa, katero lahko uporabljajo zunanji programi za izdelavo podpisov in podobnih stvari."
 
-#: src/muuli_wdr.cpp:2774
+#: src/muuli_wdr.cpp:2746
 msgid "Update Frequency (Secs):"
 msgstr "Pogostost posodobitev (sek.):"
 
-#: src/muuli_wdr.cpp:2777
+#: src/muuli_wdr.cpp:2749
 msgid "Change the frequency (in seconds) of Online Signature updates."
 msgstr "Spremeni pogostost (v sekundah) posodobitev spletnega podpisa."
 
-#: src/muuli_wdr.cpp:2785
+#: src/muuli_wdr.cpp:2757
 msgid "Save online signature file in: "
 msgstr "Spletni podpis shrani v datoteko: "
 
-#: src/muuli_wdr.cpp:2791
+#: src/muuli_wdr.cpp:2763
 msgid "Click here to select the directory containing the the Online Signature files."
 msgstr "Kliknite tukaj, da nastavite mapo, ki vsebuje datoteke za spletni podpis."
 
-#: src/muuli_wdr.cpp:2824
+#: src/muuli_wdr.cpp:2796
 msgid "Show country flags for clients"
 msgstr "Prikaži zastave držav za odjemalce"
 
-#: src/muuli_wdr.cpp:2825
+#: src/muuli_wdr.cpp:2797
 msgid "Render the country flag column in the transfers, queue and search views. Requires a valid MMDB GeoIP database (see below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2830
+#: src/muuli_wdr.cpp:2802
 #, fuzzy
 msgid "Database"
 msgstr "Podatkovna hitrost:"
 
-#: src/muuli_wdr.cpp:2846
+#: src/muuli_wdr.cpp:2818
 #, fuzzy
 msgid "Source:"
 msgstr "Viri"
 
-#: src/muuli_wdr.cpp:2849
+#: src/muuli_wdr.cpp:2821
 msgid "DB-IP (free, no account)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2850
+#: src/muuli_wdr.cpp:2822
 msgid "MaxMind GeoLite2 (free, account required)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2851
+#: src/muuli_wdr.cpp:2823
 msgid "Custom URL"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2854
+#: src/muuli_wdr.cpp:2826
 msgid "Choose which provider supplies the GeoIP MMDB database. DB-IP is the default - no account required. MaxMind requires a free account + license key. Use Custom URL to point at any other MMDB host (e.g. a local mirror)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2871
+#: src/muuli_wdr.cpp:2843
 msgid ""
 "No configuration required.\n"
 "\n"
@@ -4904,11 +4870,11 @@ msgid ""
 "License: Creative Commons BY 4.0 - https://creativecommons.org/licenses/by/4.0/"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2884
+#: src/muuli_wdr.cpp:2856
 msgid "License key:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2890
+#: src/muuli_wdr.cpp:2862
 msgid ""
 "Sign up for a free MaxMind account, then generate a License Key:\n"
 "https://www.maxmind.com/en/geolite2/signup\n"
@@ -4918,225 +4884,225 @@ msgid ""
 "Requires attribution and account registration; refresh at least every 30 days."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2905
+#: src/muuli_wdr.cpp:2877
 #, fuzzy
 msgid "Download URL:"
 msgstr "Prejemanje: "
 
-#: src/muuli_wdr.cpp:2911
+#: src/muuli_wdr.cpp:2883
 msgid ""
 "Must point to an .mmdb file or a .gz / .tar.gz containing one.\n"
 "URL may include credentials (https://user:pass@host/...).\n"
 "License and attribution terms are set by the upstream URL - you are responsible."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2924
+#: src/muuli_wdr.cpp:2896
 msgid "Download the GeoIP database from the selected source."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2926
+#: src/muuli_wdr.cpp:2898
 #, fuzzy
 msgid "Auto-update on startup"
 msgstr "Samodejno posodobi filter IP-jev ob zagonu"
 
-#: src/muuli_wdr.cpp:2927
+#: src/muuli_wdr.cpp:2899
 msgid "Re-download the GeoIP database from the selected source every time aMule starts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2950
+#: src/muuli_wdr.cpp:2922
 msgid "Filter incoming messages (except current chat):"
 msgstr "Filtriraj prejeta sporočila (razen v trenutnem pogovoru):"
 
-#: src/muuli_wdr.cpp:2952
+#: src/muuli_wdr.cpp:2924
 msgid "Filter all messages"
 msgstr "Filtriraj vsa sporočila"
 
-#: src/muuli_wdr.cpp:2954
+#: src/muuli_wdr.cpp:2926
 msgid "Filter messages from people not on your friend list"
 msgstr "Filtriraj sporočila vseh, ki niso na seznamu prijateljev"
 
-#: src/muuli_wdr.cpp:2956
+#: src/muuli_wdr.cpp:2928
 msgid "Filter messages from unknown clients"
 msgstr "Filtriraj sporočila neznanih uporabnikov"
 
-#: src/muuli_wdr.cpp:2958
+#: src/muuli_wdr.cpp:2930
 msgid "Filter messages containing (use ',' as separator):"
 msgstr "Filtriraj sporočila, ki vsebujejo (uporabi »,« kot ločilnik):"
 
-#: src/muuli_wdr.cpp:2961 src/muuli_wdr.cpp:2972
+#: src/muuli_wdr.cpp:2933 src/muuli_wdr.cpp:2944
 msgid "add here the words amule should filter and block messages including it"
 msgstr "Sem dodajte besede, ki naj jih aMule filtrira, vključno s sporočili v katerih se nahajajo."
 
-#: src/muuli_wdr.cpp:2963
+#: src/muuli_wdr.cpp:2935
 msgid "Show received messages in the log"
 msgstr "Prejeta sporočila prikaži v dnevniku"
 
-#: src/muuli_wdr.cpp:2966
+#: src/muuli_wdr.cpp:2938
 msgid "Comments"
 msgstr "Komentarji"
 
-#: src/muuli_wdr.cpp:2969
+#: src/muuli_wdr.cpp:2941
 msgid "Filter comments containing (use ',' as separator):"
 msgstr "Filtriraj komentarje, ki vsebujejo (uporabi »,« kot ločilnik):"
 
-#: src/muuli_wdr.cpp:2994
+#: src/muuli_wdr.cpp:2966
 msgid "Enable Proxy"
 msgstr "Omogoči posrednika"
 
-#: src/muuli_wdr.cpp:2995
+#: src/muuli_wdr.cpp:2967
 msgid "Enable/disable proxy support"
 msgstr "Omogoči/onemogoči podporo za posrednika"
 
-#: src/muuli_wdr.cpp:2998
+#: src/muuli_wdr.cpp:2970
 msgid "Proxy type:"
 msgstr "Vrsta posrednika:"
 
-#: src/muuli_wdr.cpp:3009
+#: src/muuli_wdr.cpp:2981
 msgid "Proxy host:"
 msgstr "Gostitelj posrednika:"
 
-#: src/muuli_wdr.cpp:3012
+#: src/muuli_wdr.cpp:2984
 msgid "The proxy host name"
 msgstr "Ime gostitelja posredniškega strežnika"
 
-#: src/muuli_wdr.cpp:3014
+#: src/muuli_wdr.cpp:2986
 msgid "Proxy port:"
 msgstr "Vrata posrednika:"
 
-#: src/muuli_wdr.cpp:3017
+#: src/muuli_wdr.cpp:2989
 msgid "The proxy port"
 msgstr "Vrata posredniškega strežnika"
 
-#: src/muuli_wdr.cpp:3019
+#: src/muuli_wdr.cpp:2991
 msgid "Enable authentication"
 msgstr "Omogoči overjanje"
 
-#: src/muuli_wdr.cpp:3020
+#: src/muuli_wdr.cpp:2992
 msgid "Enable/disable username/password authentication"
 msgstr "Omogoči/onemogoči overjanje z uporabniškim imenom/geslom"
 
-#: src/muuli_wdr.cpp:3023
+#: src/muuli_wdr.cpp:2995
 msgid "Username: "
 msgstr "Uporabniško ime: "
 
-#: src/muuli_wdr.cpp:3026
+#: src/muuli_wdr.cpp:2998
 msgid "The username to use to connect to the proxy"
 msgstr "Uporabniško ime za povezavo s posrednikom"
 
-#: src/muuli_wdr.cpp:3028
+#: src/muuli_wdr.cpp:3000
 msgid "Password:"
 msgstr "Geslo:"
 
-#: src/muuli_wdr.cpp:3031
+#: src/muuli_wdr.cpp:3003
 msgid "The password to use to connect to the proxy"
 msgstr "Geslo za povezavo s posrednikom"
 
-#: src/muuli_wdr.cpp:3050
+#: src/muuli_wdr.cpp:3022
 msgid "Connect to:"
 msgstr "Poveži se z:"
 
-#: src/muuli_wdr.cpp:3059
+#: src/muuli_wdr.cpp:3031
 msgid "Login to remote amule"
 msgstr "Prijavi se pri oddaljenem aMule"
 
-#: src/muuli_wdr.cpp:3064
+#: src/muuli_wdr.cpp:3036
 msgid "User name"
 msgstr "Uporabniško ime"
 
-#: src/muuli_wdr.cpp:3075
+#: src/muuli_wdr.cpp:3047
 msgid "Remember those settings"
 msgstr "Zapomni si te nastavitve"
 
-#: src/muuli_wdr.cpp:3078
+#: src/muuli_wdr.cpp:3050
 #, fuzzy
 msgid "Force ZLIB compression"
 msgstr "Uporabi stiskanje gzip"
 
-#: src/muuli_wdr.cpp:3102
+#: src/muuli_wdr.cpp:3074
 msgid "Enable Verbose Debug-Logging."
 msgstr "Omogoči podrobno beleženje za razhroščevanje."
 
-#: src/muuli_wdr.cpp:3104
+#: src/muuli_wdr.cpp:3076
 msgid "Only to Logfile"
 msgstr "Samo v dnevniško datoteko"
 
-#: src/muuli_wdr.cpp:3106
+#: src/muuli_wdr.cpp:3078
 msgid "Message Categories:"
 msgstr "Kategorije sporočil:"
 
-#: src/muuli_wdr.cpp:3130 src/PartFileConvertDlg.cpp:160
+#: src/muuli_wdr.cpp:3102 src/PartFileConvertDlg.cpp:160
 msgid "Waiting..."
 msgstr "Čakanje …"
 
-#: src/muuli_wdr.cpp:3150
+#: src/muuli_wdr.cpp:3122
 msgid "Add imports"
 msgstr "Dodaj uvoze"
 
-#: src/muuli_wdr.cpp:3153
+#: src/muuli_wdr.cpp:3125
 msgid "Retry selected"
 msgstr "Ponovno poskusi izbrane"
 
-#: src/muuli_wdr.cpp:3155
+#: src/muuli_wdr.cpp:3127
 msgid "Remove selected"
 msgstr "Odstrani izbrane"
 
-#: src/muuli_wdr.cpp:3218
+#: src/muuli_wdr.cpp:3190
 msgid "Event Types"
 msgstr "Vrste dogodkov"
 
-#: src/muuli_wdr.cpp:3237
+#: src/muuli_wdr.cpp:3209
 msgid "Statistics and queued clients for selected file(s) : Session / All time"
 msgstr "Statistika in odjemalci v vrsti za izbrane datoteke: seja / ves čas"
 
-#: src/muuli_wdr.cpp:3261
+#: src/muuli_wdr.cpp:3233
 msgid "Active Uploads"
 msgstr "Dejavna pošiljanja"
 
-#: src/muuli_wdr.cpp:3275
+#: src/muuli_wdr.cpp:3247
 msgid "Percent of total files"
 msgstr "Odstotek vseh datotek"
 
-#: src/muuli_wdr.cpp:3327
+#: src/muuli_wdr.cpp:3299
 msgid "Show Clients for"
 msgstr "Prikaži odjemalce za"
 
-#: src/muuli_wdr.cpp:3329
+#: src/muuli_wdr.cpp:3301
 msgid "All files"
 msgstr "Vse datoteke"
 
-#: src/muuli_wdr.cpp:3332
+#: src/muuli_wdr.cpp:3304
 msgid "Selected files"
 msgstr "Izbrane datoteke"
 
-#: src/muuli_wdr.cpp:3335
+#: src/muuli_wdr.cpp:3307
 msgid "Active uploads only"
 msgstr "Samo dejavna pošiljanja"
 
-#: src/muuli_wdr.cpp:3342
+#: src/muuli_wdr.cpp:3314
 msgid "Reload:"
 msgstr "Znova naloži"
 
-#: src/muuli_wdr.cpp:3346
+#: src/muuli_wdr.cpp:3318
 msgid "Reload your shared files"
 msgstr "Ponovno naloži deljene datoteke"
 
-#: src/muuli_wdr.cpp:3409
+#: src/muuli_wdr.cpp:3381
 msgid "Send"
 msgstr "Pošlji"
 
-#: src/muuli_wdr.cpp:3410
+#: src/muuli_wdr.cpp:3382
 msgid "Sends the specified message."
 msgstr "Pošlje navedeno sporočilo."
 
-#: src/muuli_wdr.cpp:3414
+#: src/muuli_wdr.cpp:3386
 msgid "Close this chat-session."
 msgstr "Zapri to pogovorno sejo."
 
-#: src/muuli_wdr.cpp:3437
+#: src/muuli_wdr.cpp:3409
 msgid "Connect to any server and/or Kad"
 msgstr "Poveži se s poljubnim strežnikom in/ali s Kad"
 
-#: src/muuli_wdr.cpp:3443 src/SharedFilesCtrl.cpp:142 src/Statistics.cpp:941
+#: src/muuli_wdr.cpp:3415 src/SharedFilesCtrl.cpp:142 src/Statistics.cpp:941
 msgid "Shared Files"
 msgstr "Deljene datoteke"
 
@@ -5505,249 +5471,249 @@ msgstr "Prejeto"
 msgid "ERROR: Failed to open partfile '%s'"
 msgstr "NAPAKA: delne datoteke »%s« ni bilo moč odpreti"
 
-#: src/Preferences.cpp:701
+#: src/Preferences.cpp:673
 msgid "System default"
 msgstr "Sistemsko privzet"
 
-#: src/Preferences.cpp:702
+#: src/Preferences.cpp:674
 msgid "Albanian"
 msgstr "Albansko"
 
-#: src/Preferences.cpp:703
+#: src/Preferences.cpp:675
 msgid "Arabic"
 msgstr "Arabsko"
 
-#: src/Preferences.cpp:704
+#: src/Preferences.cpp:676
 msgid "Asturian"
 msgstr "Asturijsko"
 
-#: src/Preferences.cpp:705
+#: src/Preferences.cpp:677
 msgid "Basque"
 msgstr "Baskovsko"
 
-#: src/Preferences.cpp:706
+#: src/Preferences.cpp:678
 msgid "Bulgarian"
 msgstr "Bolgarsko"
 
-#: src/Preferences.cpp:707
+#: src/Preferences.cpp:679
 msgid "Catalan"
 msgstr "Katalonsko"
 
-#: src/Preferences.cpp:708
+#: src/Preferences.cpp:680
 msgid "Chinese (Simplified)"
 msgstr "Kitajsko (poenostavljeno)"
 
-#: src/Preferences.cpp:709
+#: src/Preferences.cpp:681
 msgid "Chinese (Traditional)"
 msgstr "Kitajsko (tradicionalno)"
 
-#: src/Preferences.cpp:710
+#: src/Preferences.cpp:682
 msgid "Croatian"
 msgstr "Hrvaško"
 
-#: src/Preferences.cpp:711
+#: src/Preferences.cpp:683
 msgid "Czech"
 msgstr "Češko"
 
-#: src/Preferences.cpp:712
+#: src/Preferences.cpp:684
 msgid "Danish"
 msgstr "Dansko"
 
-#: src/Preferences.cpp:713
+#: src/Preferences.cpp:685
 msgid "Dutch"
 msgstr "Nizozemsko"
 
-#: src/Preferences.cpp:714
+#: src/Preferences.cpp:686
 msgid "English (U.K.)"
 msgstr "Angleško (Z.K.)"
 
-#: src/Preferences.cpp:715
+#: src/Preferences.cpp:687
 #, fuzzy
 msgid "English (U.S.)"
 msgstr "Angleško (Z.K.)"
 
-#: src/Preferences.cpp:716
+#: src/Preferences.cpp:688
 msgid "Estonian"
 msgstr "Estonsko"
 
-#: src/Preferences.cpp:717
+#: src/Preferences.cpp:689
 msgid "Finnish"
 msgstr "Finsko"
 
-#: src/Preferences.cpp:718
+#: src/Preferences.cpp:690
 msgid "French"
 msgstr "Francosko"
 
-#: src/Preferences.cpp:719
+#: src/Preferences.cpp:691
 msgid "Galician"
 msgstr "Galicijsko"
 
-#: src/Preferences.cpp:720
+#: src/Preferences.cpp:692
 msgid "German"
 msgstr "Nemško"
 
-#: src/Preferences.cpp:721
+#: src/Preferences.cpp:693
 msgid "Greek"
 msgstr "Grško"
 
-#: src/Preferences.cpp:722
+#: src/Preferences.cpp:694
 msgid "Hebrew"
 msgstr "Hebrejsko"
 
-#: src/Preferences.cpp:723
+#: src/Preferences.cpp:695
 msgid "Hungarian"
 msgstr "Madžarsko"
 
-#: src/Preferences.cpp:724
+#: src/Preferences.cpp:696
 msgid "Italian"
 msgstr "Italijansko"
 
-#: src/Preferences.cpp:725
+#: src/Preferences.cpp:697
 msgid "Japanese"
 msgstr "Japonsko"
 
-#: src/Preferences.cpp:726
+#: src/Preferences.cpp:698
 msgid "Korean"
 msgstr "Korejsko"
 
-#: src/Preferences.cpp:727
+#: src/Preferences.cpp:699
 msgid "Latvian"
 msgstr ""
 
-#: src/Preferences.cpp:728
+#: src/Preferences.cpp:700
 msgid "Lithuanian"
 msgstr "Litvansko"
 
-#: src/Preferences.cpp:729
+#: src/Preferences.cpp:701
 msgid "Norwegian (Nynorsk)"
 msgstr "Norveško (Nynorsk)"
 
-#: src/Preferences.cpp:730
+#: src/Preferences.cpp:702
 msgid "Polish"
 msgstr "Poljsko"
 
-#: src/Preferences.cpp:731
+#: src/Preferences.cpp:703
 msgid "Portuguese"
 msgstr "Portugalsko"
 
-#: src/Preferences.cpp:732
+#: src/Preferences.cpp:704
 msgid "Portuguese (Brazilian)"
 msgstr "Portugalsko (brazilsko)"
 
-#: src/Preferences.cpp:733
+#: src/Preferences.cpp:705
 msgid "Romanian"
 msgstr "Romunsko"
 
-#: src/Preferences.cpp:734
+#: src/Preferences.cpp:706
 msgid "Russian"
 msgstr "Rusko"
 
-#: src/Preferences.cpp:735
+#: src/Preferences.cpp:707
 msgid "Slovenian"
 msgstr "Slovensko"
 
-#: src/Preferences.cpp:736
+#: src/Preferences.cpp:708
 msgid "Spanish"
 msgstr "Špansko"
 
-#: src/Preferences.cpp:737
+#: src/Preferences.cpp:709
 msgid "Swedish"
 msgstr "Švedsko"
 
-#: src/Preferences.cpp:738
+#: src/Preferences.cpp:710
 msgid "Turkish"
 msgstr "Turško"
 
-#: src/Preferences.cpp:739
+#: src/Preferences.cpp:711
 msgid "Ukrainian"
 msgstr "Ukrajinsko"
 
-#: src/Preferences.cpp:842
+#: src/Preferences.cpp:814
 msgid "Change Language"
 msgstr "Spremeni jezik"
 
-#: src/Preferences.cpp:906
+#: src/Preferences.cpp:878
 msgid "There are no translations installed for aMule"
 msgstr "Za aMule ni nameščenega nobenega prevoda"
 
-#: src/Preferences.cpp:907
+#: src/Preferences.cpp:879
 msgid "No languages available"
 msgstr "Na voljo ni nobenega jezika"
 
-#: src/Preferences.cpp:1038
+#: src/Preferences.cpp:1010
 msgid "no options available"
 msgstr "na voljo ni nobene možnosti"
 
-#: src/Preferences.cpp:2226
+#: src/Preferences.cpp:2179
 msgid "Invalid category found, skipping"
 msgstr "Najdena neveljavna kategorija, preskočena"
 
-#: src/Preferences.cpp:2395
+#: src/Preferences.cpp:2348
 msgid "TCP port can't be higher than 65532 due to server UDP socket being TCP+3"
 msgstr "Vrata TCP ne smejo biti večja od 65532, ker so vrata UDP TCP+3"
 
-#: src/Preferences.cpp:2396
+#: src/Preferences.cpp:2349
 #, c-format
 msgid "Default port will be used (%d)"
 msgstr "Uporabljena bodo privzeta vrata (%d)"
 
-#: src/PrefsUnifiedDlg.cpp:300 src/Statistics.cpp:866
+#: src/PrefsUnifiedDlg.cpp:298 src/Statistics.cpp:866
 msgid "Connection"
 msgstr "Povezava"
 
-#: src/PrefsUnifiedDlg.cpp:301 src/SearchListCtrl.cpp:117
+#: src/PrefsUnifiedDlg.cpp:299 src/SearchListCtrl.cpp:117
 msgid "Directories"
 msgstr "Mape"
 
-#: src/PrefsUnifiedDlg.cpp:302 src/Statistics.cpp:917
+#: src/PrefsUnifiedDlg.cpp:300 src/Statistics.cpp:917
 msgid "Servers"
 msgstr "Strežniki"
 
-#: src/PrefsUnifiedDlg.cpp:303 src/ServerListCtrl.cpp:96
+#: src/PrefsUnifiedDlg.cpp:301 src/ServerListCtrl.cpp:96
 msgid "Files"
 msgstr "Datoteke"
 
-#: src/PrefsUnifiedDlg.cpp:304
+#: src/PrefsUnifiedDlg.cpp:302
 msgid "Security"
 msgstr "Varnost"
 
-#: src/PrefsUnifiedDlg.cpp:305
+#: src/PrefsUnifiedDlg.cpp:303
 msgid "Interface"
 msgstr "Vmesnik"
 
-#: src/PrefsUnifiedDlg.cpp:312
+#: src/PrefsUnifiedDlg.cpp:310
 msgid "IP2Country"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:315
+#: src/PrefsUnifiedDlg.cpp:313
 msgid "Proxy"
 msgstr "Posrednik"
 
-#: src/PrefsUnifiedDlg.cpp:316
+#: src/PrefsUnifiedDlg.cpp:314
 msgid "Filters"
 msgstr "Filtri"
 
-#: src/PrefsUnifiedDlg.cpp:317
+#: src/PrefsUnifiedDlg.cpp:315
 msgid "Remote Controls"
 msgstr "Oddaljeno upravljanje"
 
-#: src/PrefsUnifiedDlg.cpp:318
+#: src/PrefsUnifiedDlg.cpp:316
 msgid "Online Signature"
 msgstr "Spletni podpis"
 
-#: src/PrefsUnifiedDlg.cpp:319
+#: src/PrefsUnifiedDlg.cpp:317
 msgid "Advanced"
 msgstr "Napredno"
 
-#: src/PrefsUnifiedDlg.cpp:320
+#: src/PrefsUnifiedDlg.cpp:318
 msgid "Events"
 msgstr "Dogodki"
 
-#: src/PrefsUnifiedDlg.cpp:323
+#: src/PrefsUnifiedDlg.cpp:321
 msgid "Debugging"
 msgstr "Razhroščevanje"
 
-#: src/PrefsUnifiedDlg.cpp:453
+#: src/PrefsUnifiedDlg.cpp:451
 msgid ""
 "The following variables will be substituted:\n"
 "    %PARTFILE - full path to the file\n"
@@ -5757,15 +5723,15 @@ msgstr ""
 "    %PARTFILE – polna pot do datoteke\n"
 "    %PARTNAME – samo ime datoteke"
 
-#: src/PrefsUnifiedDlg.cpp:474
+#: src/PrefsUnifiedDlg.cpp:472
 msgid "Tray icon support requires libayatana-appindicator3 at compile time."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:490
+#: src/PrefsUnifiedDlg.cpp:488
 msgid "Not available on Wayland: the protocol does not report when a window is minimized, so this option cannot intercept the system minimize button. Workaround: launch aMule with `GDK_BACKEND=x11` to use XWayland instead."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:536
+#: src/PrefsUnifiedDlg.cpp:534
 msgid ""
 "Do not change these setting unless you know\n"
 "what you are doing, otherwise you can easily\n"
@@ -5781,35 +5747,26 @@ msgstr ""
 "aMule bo deloval dobro tudi brez\n"
 "spreminjanja teh nastavitev."
 
-#: src/PrefsUnifiedDlg.cpp:647
+#: src/PrefsUnifiedDlg.cpp:645
 #, c-format
 msgid "Failed to connect Cfg to widget with the ID %d and key %s"
 msgstr "Nastavitve ni bilo moč povezati z gradnikom z ID-jem %d in ključem %s"
 
-#: src/PrefsUnifiedDlg.cpp:695
+#: src/PrefsUnifiedDlg.cpp:693
 #, c-format
 msgid "Failed to transfer data from Cfg to Widget with the ID %d and key %s"
 msgstr "Podatkov iz nastavitev ni bilo moč prenesti v gradnik z ID-jem %d in ključem %s."
 
-#: src/PrefsUnifiedDlg.cpp:801
+#: src/PrefsUnifiedDlg.cpp:799
 msgid "The type of proxy you are connecting to"
 msgstr "Vrsta posrednika s katerim se hočete povezati"
 
-#: src/PrefsUnifiedDlg.cpp:1020
+#: src/PrefsUnifiedDlg.cpp:1003
 #, c-format
 msgid "Failed to transfer data from Widget to Cfg with the ID %d and key %s"
 msgstr "Podatkov iz gradnika ni bilo moč prenesti v nastavitve z ID-jem %d in ključem %s."
 
 #: src/PrefsUnifiedDlg.cpp:1103
-#, fuzzy
-msgid "No password set."
-msgstr "Preverjanje gesla\n"
-
-#: src/PrefsUnifiedDlg.cpp:1132
-msgid "Guest access needs a password. Type one in the guest password field, or untick Enable guest access."
-msgstr ""
-
-#: src/PrefsUnifiedDlg.cpp:1144
 msgid ""
 "aMule must be restarted to enable these changes:\n"
 "\n"
@@ -5817,41 +5774,41 @@ msgstr ""
 "Potreben je ponoven zagon aMule za uveljavitev teh sprememb:\n"
 "\n"
 
-#: src/PrefsUnifiedDlg.cpp:1151
+#: src/PrefsUnifiedDlg.cpp:1110
 msgid "- TCP port changed.\n"
 msgstr "• Vrata TCP so spremenjena.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1156
+#: src/PrefsUnifiedDlg.cpp:1115
 msgid "- UDP port changed.\n"
 msgstr "• Vrata UDP so spremenjena.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1161
+#: src/PrefsUnifiedDlg.cpp:1120
 #, fuzzy
 msgid "- Network interface binding changed.\n"
 msgstr "• Vmesnik za zunanje povezave je spremenjen.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1166
+#: src/PrefsUnifiedDlg.cpp:1125
 msgid "- External connect port changed.\n"
 msgstr "• Vrata za zunanje povezave so spremenjena.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1170
+#: src/PrefsUnifiedDlg.cpp:1129
 msgid "- External connect acceptance changed.\n"
 msgstr "• Sprejemljivost zunanjih povezav je spremenjena.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1174
+#: src/PrefsUnifiedDlg.cpp:1133
 msgid "- External connect interface changed.\n"
 msgstr "• Vmesnik za zunanje povezave je spremenjen.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1178
+#: src/PrefsUnifiedDlg.cpp:1137
 msgid "- Protocol obfuscation support changed.\n"
 msgstr "• Podpora za maskiranje protokola je bila spremenjena.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1193
+#: src/PrefsUnifiedDlg.cpp:1151
 #, fuzzy
 msgid "- amuleapi settings changed.\n"
 msgstr "• Jezik je spremenjen.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1202
+#: src/PrefsUnifiedDlg.cpp:1160
 msgid ""
 "Your Auto-update server list is empty.\n"
 "'Auto-update server list at startup' will be disabled."
@@ -5859,7 +5816,7 @@ msgstr ""
 "Seznam za samodejno posodobitev strežnikov je prazen.\n"
 "Možnost »Ob zagonu samodejno posodobi seznam strežnikov« bo onemogočena."
 
-#: src/PrefsUnifiedDlg.cpp:1213
+#: src/PrefsUnifiedDlg.cpp:1171
 msgid ""
 "You have enabled external connections but have not specified a password.\n"
 "External connections cannot be enabled unless a valid password is specified."
@@ -5867,33 +5824,28 @@ msgstr ""
 "Omogočili ste zunanje povezave, vendar niste navedli gesla.\n"
 "Zunanje povezave ne morejo biti omogočene, dokler ne navedete veljavnega gesla."
 
-#: src/PrefsUnifiedDlg.cpp:1246
-#, c-format
-msgid "The amuleapi password could not be saved: %s"
-msgstr ""
-
-#: src/PrefsUnifiedDlg.cpp:1276
+#: src/PrefsUnifiedDlg.cpp:1202
 msgid "- Language changed.\n"
 msgstr "• Jezik je spremenjen.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1281
+#: src/PrefsUnifiedDlg.cpp:1207
 msgid "- Temp folder changed.\n"
 msgstr "• Mapa za začasne datoteke spremenjena.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1286
+#: src/PrefsUnifiedDlg.cpp:1212
 msgid "- ED2K network enabled.\n"
 msgstr "• Omrežje eD2k je omogočeno.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1319
+#: src/PrefsUnifiedDlg.cpp:1245
 msgid "The shared-file exclusion pattern is not a valid regular expression. The filter has been left disabled."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1321 src/PrefsUnifiedDlg.cpp:1921
+#: src/PrefsUnifiedDlg.cpp:1247 src/PrefsUnifiedDlg.cpp:1841
 #, fuzzy
 msgid "Invalid regular expression"
 msgstr "Neveljavna različica protokola."
 
-#: src/PrefsUnifiedDlg.cpp:1398
+#: src/PrefsUnifiedDlg.cpp:1324
 msgid ""
 "Both eD2k and Kad network are disabled.\n"
 "You won't be able to connect until you enable at least one of them."
@@ -5901,7 +5853,7 @@ msgstr ""
 "Omrežji eD2k in Kad sta onemogočeni.\n"
 "Ne boste se mogli povezati, dokler ne omogočite vsaj enega izmed njih."
 
-#: src/PrefsUnifiedDlg.cpp:1403
+#: src/PrefsUnifiedDlg.cpp:1329
 msgid ""
 "Kad will not start if your UDP port is disabled.\n"
 "Enable UDP port or disable Kad."
@@ -5909,7 +5861,7 @@ msgstr ""
 "Kad se ne bo zagnal, če so vrata UDP onemogočena.\n"
 "Omogočite vrata UDP ali pa onemogočite Kad."
 
-#: src/PrefsUnifiedDlg.cpp:1459
+#: src/PrefsUnifiedDlg.cpp:1385
 msgid ""
 "\n"
 "You MUST restart aMule now.\n"
@@ -5919,69 +5871,69 @@ msgstr ""
 "aMule morate NUJNO ponovno zagnati.\n"
 "Če tega ne storite zdaj, se ne pritožujte, če se zgodi kaj slabega.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1524
+#: src/PrefsUnifiedDlg.cpp:1450
 msgid "Could not register aMule for autostart at login. The autostart store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1526
+#: src/PrefsUnifiedDlg.cpp:1452
 msgid "Could not remove the autostart-at-login entry."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1527
+#: src/PrefsUnifiedDlg.cpp:1453
 #, fuzzy
 msgid "Autostart"
 msgstr "Samodejno osveževanje začeto"
 
-#: src/PrefsUnifiedDlg.cpp:1542
+#: src/PrefsUnifiedDlg.cpp:1468
 msgid "Register file type"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1542
+#: src/PrefsUnifiedDlg.cpp:1468
 msgid "Register URL handler"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1550
+#: src/PrefsUnifiedDlg.cpp:1476
 #, c-format
 msgid "aMule only handles eD2k-compatible magnets. If you replace the current magnet handler (%s), BitTorrent magnet links will stop working - aMule cannot download BitTorrent content. Continue?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1555
+#: src/PrefsUnifiedDlg.cpp:1481
 #, c-format
 msgid "Another application currently opens .emulecollection files (%s). Replace it with aMule?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1560
+#: src/PrefsUnifiedDlg.cpp:1486
 #, c-format
 msgid "Another application is currently the default handler for these links (%s). Replace it with aMule?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1585
+#: src/PrefsUnifiedDlg.cpp:1511
 msgid "Could not register aMule for .emulecollection files. The registration store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1587
+#: src/PrefsUnifiedDlg.cpp:1513
 #, fuzzy
 msgid "Could not remove the file type registration."
 msgstr "Mapa za začasne datoteke prejemanj"
 
-#: src/PrefsUnifiedDlg.cpp:1589
+#: src/PrefsUnifiedDlg.cpp:1515
 msgid "Could not register aMule as the URL handler. The registration store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1591
+#: src/PrefsUnifiedDlg.cpp:1517
 msgid "Could not remove the URL handler registration."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1661 src/PrefsUnifiedDlg.cpp:1688
+#: src/PrefsUnifiedDlg.cpp:1587 src/PrefsUnifiedDlg.cpp:1614
 #, fuzzy
 msgid "The web server and aMule API require external connections to be enabled."
 msgstr "Geslo je bilo nastavljeno in zunanje povezave omogočene."
 
-#: src/PrefsUnifiedDlg.cpp:1671
+#: src/PrefsUnifiedDlg.cpp:1597
 msgid "The aMule web server is deprecated. Consider running the aMule API instead."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1735
+#: src/PrefsUnifiedDlg.cpp:1655
 msgid ""
 "Your Auto-update servers list is in blank.\n"
 "Please fill in at least one URL to point to a valid server.met file.\n"
@@ -5991,24 +5943,24 @@ msgstr ""
 "Vnesite vsaj en URL do veljavne datoteke server.met.\n"
 "Kliknite na gumb »Seznam«, zraven potrditvenega polja, za vnos URL-ja."
 
-#: src/PrefsUnifiedDlg.cpp:1876
+#: src/PrefsUnifiedDlg.cpp:1796
 msgid "Temporary files"
 msgstr "Začasne datoteke"
 
-#: src/PrefsUnifiedDlg.cpp:1881
+#: src/PrefsUnifiedDlg.cpp:1801
 msgid "Incoming files"
 msgstr "Prejete datoteke"
 
-#: src/PrefsUnifiedDlg.cpp:1886
+#: src/PrefsUnifiedDlg.cpp:1806
 msgid "Online Signatures"
 msgstr "Spletni podpisi"
 
-#: src/PrefsUnifiedDlg.cpp:1899
+#: src/PrefsUnifiedDlg.cpp:1819
 #, c-format
 msgid "Choose a folder for %s"
 msgstr "Izberite mapo za %s"
 
-#: src/PrefsUnifiedDlg.cpp:1923
+#: src/PrefsUnifiedDlg.cpp:1843
 #, fuzzy, c-format
 msgid "Would exclude %u of %u shared file"
 msgid_plural "Would exclude %u of %u shared files"
@@ -6017,42 +5969,42 @@ msgstr[1] "Najdena %i znana deljena datoteka"
 msgstr[2] "Najdeni %i znani deljeni datoteki"
 msgstr[3] "Najdene %i znane deljene datoteke"
 
-#: src/PrefsUnifiedDlg.cpp:1940
+#: src/PrefsUnifiedDlg.cpp:1860
 msgid "Browse for videoplayer"
 msgstr "Prebrskajte za video predvajalnik"
 
-#: src/PrefsUnifiedDlg.cpp:1944
+#: src/PrefsUnifiedDlg.cpp:1864
 msgid "Select browser"
 msgstr "Izberite brskalnik"
 
-#: src/PrefsUnifiedDlg.cpp:1948
+#: src/PrefsUnifiedDlg.cpp:1868
 #, fuzzy
 msgid "Select ffprobe binary"
 msgstr "Izberite brskalnik"
 
-#: src/PrefsUnifiedDlg.cpp:1954
+#: src/PrefsUnifiedDlg.cpp:1874
 #, c-format
 msgid "Executable%s"
 msgstr "Izvedljiva datoteka %s"
 
-#: src/PrefsUnifiedDlg.cpp:1988
+#: src/PrefsUnifiedDlg.cpp:1908
 msgid "ffprobe not found on PATH or in the standard install locations. Install ffmpeg (which ships ffprobe) or use Browse to pick a binary manually."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2000
+#: src/PrefsUnifiedDlg.cpp:1920
 msgid "Reset the settings on this page to their default values?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2001
+#: src/PrefsUnifiedDlg.cpp:1921
 #, fuzzy
 msgid "Reset to defaults"
 msgstr "Sistemsko privzet"
 
-#: src/PrefsUnifiedDlg.cpp:2028
+#: src/PrefsUnifiedDlg.cpp:1948
 msgid "Edit server list"
 msgstr "Uredi seznam strežnikov"
 
-#: src/PrefsUnifiedDlg.cpp:2029
+#: src/PrefsUnifiedDlg.cpp:1949
 msgid ""
 "Add here URL's to download server.met files.\n"
 "Only one url on each line."
@@ -6060,42 +6012,42 @@ msgstr ""
 "Sem dodajte URL-je do datotek server.met.\n"
 "Po en URL v vsako vrstico."
 
-#: src/PrefsUnifiedDlg.cpp:2084
+#: src/PrefsUnifiedDlg.cpp:2004
 msgid "IP2Country update failed"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2229 src/PrefsUnifiedDlg.cpp:2260
+#: src/PrefsUnifiedDlg.cpp:2149 src/PrefsUnifiedDlg.cpp:2180
 msgid "Data by MaxMind GeoLite2"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2231 src/PrefsUnifiedDlg.cpp:2262
+#: src/PrefsUnifiedDlg.cpp:2151 src/PrefsUnifiedDlg.cpp:2182
 #, fuzzy
 msgid "Custom source"
 msgstr "Popolnih virov"
 
-#: src/PrefsUnifiedDlg.cpp:2233 src/PrefsUnifiedDlg.cpp:2264
+#: src/PrefsUnifiedDlg.cpp:2153 src/PrefsUnifiedDlg.cpp:2184
 msgid "Data by DB-IP.com"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2284
+#: src/PrefsUnifiedDlg.cpp:2204
 #, fuzzy, c-format
 msgid "Status: Loaded%s"
 msgstr "Stanje:"
 
-#: src/PrefsUnifiedDlg.cpp:2286
+#: src/PrefsUnifiedDlg.cpp:2206
 #, fuzzy, c-format
 msgid "Status: Loaded%s - %s"
 msgstr "Stanje:"
 
-#: src/PrefsUnifiedDlg.cpp:2290
+#: src/PrefsUnifiedDlg.cpp:2210
 msgid "Status: Failed to load - click 'Update now' to refresh."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2292
+#: src/PrefsUnifiedDlg.cpp:2212
 msgid "Status: Not found - click 'Update now' to download."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2350 src/PrefsUnifiedDlg.cpp:2374
+#: src/PrefsUnifiedDlg.cpp:2270 src/PrefsUnifiedDlg.cpp:2294
 #, c-format
 msgid "Update delay: %d second"
 msgid_plural "Update delay: %d seconds"
@@ -6104,7 +6056,7 @@ msgstr[1] "Osveži vsakih: %d sekundo"
 msgstr[2] "Osveži vsakih: %d sekundi"
 msgstr[3] "Osveži vsakih: %d sekunde"
 
-#: src/PrefsUnifiedDlg.cpp:2358
+#: src/PrefsUnifiedDlg.cpp:2278
 #, c-format
 msgid "Time for average graph: %d minute"
 msgid_plural "Time for average graph: %d minutes"
@@ -6113,12 +6065,12 @@ msgstr[1] "Čas za graf trenutnega povprečja: %i minuta"
 msgstr[2] "Čas za graf trenutnega povprečja: %i minuti"
 msgstr[3] "Čas za graf trenutnega povprečja: %i minute"
 
-#: src/PrefsUnifiedDlg.cpp:2367
+#: src/PrefsUnifiedDlg.cpp:2287
 #, c-format
 msgid "Connections Graph Scale: %d"
 msgstr "Merilo za graf povezav: %d"
 
-#: src/PrefsUnifiedDlg.cpp:2382
+#: src/PrefsUnifiedDlg.cpp:2302
 #, c-format
 msgid "File Buffer Size: %d byte"
 msgid_plural "File Buffer Size: %d bytes"
@@ -6127,7 +6079,7 @@ msgstr[1] "Datotečni medpomnilnik: %d bajt"
 msgstr[2] "Datotečni medpomnilnik: %d bajta"
 msgstr[3] "Datotečni medpomnilnik: %d bajti"
 
-#: src/PrefsUnifiedDlg.cpp:2392
+#: src/PrefsUnifiedDlg.cpp:2312
 #, c-format
 msgid "Upload Queue Size: %d client"
 msgid_plural "Upload Queue Size: %d clients"
@@ -6136,7 +6088,7 @@ msgstr[1] "Velikost vrste za pošiljanje: %d odjemalec"
 msgstr[2] "Velikost vrste za pošiljanje: %d odjemalca"
 msgstr[3] "Velikost vrste za pošiljanje: %d odjemalci"
 
-#: src/PrefsUnifiedDlg.cpp:2402
+#: src/PrefsUnifiedDlg.cpp:2322
 #, c-format
 msgid "Server connection refresh interval: %d minute"
 msgid_plural "Server connection refresh interval: %d minutes"
@@ -6145,104 +6097,100 @@ msgstr[1] "Čas med osvežitvama povezave na strežnik: %d minuta"
 msgstr[2] "Čas med osvežitvama povezave na strežnik: %d minuti"
 msgstr[3] "Čas med osvežitvama povezave na strežnik: %d minute"
 
-#: src/PrefsUnifiedDlg.cpp:2407
+#: src/PrefsUnifiedDlg.cpp:2327
 msgid "Server connection refresh interval: Disabled"
 msgstr "Čas med osvežitvama povezave na strežnik: onemogočeno"
 
-#: src/PrefsUnifiedDlg.cpp:2451
+#: src/PrefsUnifiedDlg.cpp:2371
 msgid "disabled"
 msgstr "onemogočeno"
 
-#: src/PrefsUnifiedDlg.cpp:2477
+#: src/PrefsUnifiedDlg.cpp:2397
 #, c-format
 msgid "Execute command on '%s' event"
 msgstr "Izvrši ukaz ob dogodku »%s«"
 
-#: src/PrefsUnifiedDlg.cpp:2484
+#: src/PrefsUnifiedDlg.cpp:2404
 msgid "Enable command execution on core"
 msgstr "Omogoči izvrševanje ukazov na jedru"
 
-#: src/PrefsUnifiedDlg.cpp:2496
+#: src/PrefsUnifiedDlg.cpp:2416
 msgid "Core command:"
 msgstr "Ukaz jedra:"
 
-#: src/PrefsUnifiedDlg.cpp:2512
+#: src/PrefsUnifiedDlg.cpp:2432
 msgid "Enable command execution on GUI"
 msgstr "Omogoči izvrševanje ukazov v vmesniku"
 
-#: src/PrefsUnifiedDlg.cpp:2524
+#: src/PrefsUnifiedDlg.cpp:2444
 msgid "GUI command:"
 msgstr "Ukaz vmesnika:"
 
-#: src/PrefsUnifiedDlg.cpp:2540
+#: src/PrefsUnifiedDlg.cpp:2460
 msgid "The following variables will be replaced:"
 msgstr "Sledeče spremenljivke bodo nadomeščene:"
 
-#: src/PrefsUnifiedDlg.cpp:2708
+#: src/PrefsUnifiedDlg.cpp:2628
 msgid ""
 "The following folders look like system or sensitive locations:\n"
 "\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2713
+#: src/PrefsUnifiedDlg.cpp:2633
 msgid "Sharing them recursively will publish every file underneath on the eD2k/Kad networks. Do you really want to do this?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2716
+#: src/PrefsUnifiedDlg.cpp:2636
 #, fuzzy
 msgid "Confirm shared folders"
 msgstr "Deljene mape"
 
-#: src/PrefsUnifiedDlg.cpp:2744
+#: src/PrefsUnifiedDlg.cpp:2664
 #, fuzzy
 msgid "Reloading shared files..."
 msgstr "Ponovno naloži deljene datoteke"
 
-#: src/PrefsUnifiedDlg.cpp:2745
+#: src/PrefsUnifiedDlg.cpp:2665
 msgid "Scanning for subdirectories..."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2746
+#: src/PrefsUnifiedDlg.cpp:2666
 #, fuzzy
 msgid "Updating shared folders"
 msgstr "Deljene mape"
 
-#: src/PrefsUnifiedDlg.cpp:2773
+#: src/PrefsUnifiedDlg.cpp:2693
 #, c-format
 msgid "Scanned %u directories..."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2823
+#: src/PrefsUnifiedDlg.cpp:2743
 #, fuzzy, c-format
 msgid "Reloading shared files: %u files scanned"
 msgstr "Ponovno naloži seznam deljenih datotek."
 
-#: src/PrefsUnifiedDlg.cpp:2873
+#: src/PrefsUnifiedDlg.cpp:2793
 #, fuzzy
 msgid "Shared folder"
 msgstr "Deljene mape"
 
-#: src/SearchDlg.cpp:280
-msgid "Clear search history"
-msgstr ""
-
-#: src/SearchDlg.cpp:584
+#: src/SearchDlg.cpp:425
 msgid "It's impossible to search when both eD2k and Kademlia are disabled."
 msgstr "Iskanje ni mogoče, ko sta tako eD2k kot tudi Kademlia onemogočena."
 
-#: src/SearchDlg.cpp:585 src/SearchListCtrl.cpp:858
+#: src/SearchDlg.cpp:426 src/SearchListCtrl.cpp:858
 msgid "Search error"
 msgstr "Napaka iskanja"
 
-#: src/SearchDlg.cpp:929
+#: src/SearchDlg.cpp:768
 msgid "Min size must be smaller than max size. Max size ignored."
 msgstr "Min. velikost mora biti manjša kot maks. velikost. Maks. velikost ni upoštevana."
 
-#: src/SearchDlg.cpp:930 src/SearchDlg.cpp:1012
+#: src/SearchDlg.cpp:769 src/SearchDlg.cpp:851
 msgid "Search warning"
 msgstr "Opozorilo iskanja"
 
-#: src/SearchDlg.cpp:1092 src/SearchListCtrl.cpp:735
+#: src/SearchDlg.cpp:929 src/SearchListCtrl.cpp:735
 msgid "Main"
 msgstr "Glavna"
 

--- a/po/sl.po
+++ b/po/sl.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-28 12:17+0200\n"
+"POT-Creation-Date: 2026-07-28 13:09+0200\n"
 "PO-Revision-Date: 2026-07-27 11:45+0000\n"
 "Last-Translator: Jure Repinc <jlp@holodeck1.com>\n"
 "Language-Team: Slovenian\n"
@@ -293,7 +293,7 @@ msgid "Password set and external connections enabled."
 msgstr "Geslo je bilo nastavljeno in zunanje povezave omogočene."
 
 #: src/amule.cpp:755 src/KadDlg.cpp:176 src/KadDlg.cpp:185
-#: src/PrefsUnifiedDlg.cpp:1461 src/SharedFilesCtrl.cpp:476
+#: src/PrefsUnifiedDlg.cpp:1470 src/SharedFilesCtrl.cpp:476
 msgid "WARNING"
 msgstr "OPOZORILO"
 
@@ -331,7 +331,7 @@ msgstr "Zahtevali ste zagon spletnega strežnika ob zagonu programa, a programa 
 #: src/amule-remote-gui.cpp:603 src/amule-remote-gui.cpp:671
 #: src/amule-remote-gui.cpp:709 src/amule-remote-gui.cpp:1282
 #: src/amule-remote-gui.cpp:1345 src/amule-remote-gui.cpp:1372
-#: src/DownloadQueue.cpp:1481 src/PrefsUnifiedDlg.cpp:1247
+#: src/DownloadQueue.cpp:1481 src/PrefsUnifiedDlg.cpp:1256
 msgid "ERROR"
 msgstr "NAPAKA"
 
@@ -596,36 +596,36 @@ msgstr "Obiščite https://github.com/amule-org/amule/releases/latest da preveri
 msgid "FATAL ERROR: Failed to create Timer"
 msgstr "USODNA NAPAKA: ustvaritev časomerilnika ni uspela"
 
-#: src/amuleDlg.cpp:361 src/amuleDlg.cpp:1787 src/amuleDlg.cpp:2033
-#: src/muuli_wdr.cpp:1492 src/muuli_wdr.cpp:3449
+#: src/amuleDlg.cpp:361 src/amuleDlg.cpp:1810 src/amuleDlg.cpp:2056
+#: src/muuli_wdr.cpp:1492 src/muuli_wdr.cpp:3453
 msgid "Networks"
 msgstr "Omrežja"
 
-#: src/amuleDlg.cpp:362 src/amuleDlg.cpp:1793 src/muuli_wdr.cpp:3450
+#: src/amuleDlg.cpp:362 src/amuleDlg.cpp:1816 src/muuli_wdr.cpp:3454
 msgid "Searches"
 msgstr "Iskanja"
 
-#: src/amuleDlg.cpp:363 src/amuleDlg.cpp:1799 src/DownloadListCtrl.cpp:740
-#: src/muuli_wdr.cpp:392 src/muuli_wdr.cpp:1585 src/muuli_wdr.cpp:3451
+#: src/amuleDlg.cpp:363 src/amuleDlg.cpp:1822 src/DownloadListCtrl.cpp:740
+#: src/muuli_wdr.cpp:392 src/muuli_wdr.cpp:1585 src/muuli_wdr.cpp:3455
 #: src/Statistics.cpp:829
 msgid "Downloads"
 msgstr "Prejemanja"
 
-#: src/amuleDlg.cpp:364 src/amuleDlg.cpp:1805 src/muuli_wdr.cpp:3325
+#: src/amuleDlg.cpp:364 src/amuleDlg.cpp:1828 src/muuli_wdr.cpp:3329
 msgid "Shared files"
 msgstr "Deljene datoteke"
 
-#: src/amuleDlg.cpp:365 src/amuleDlg.cpp:1811 src/muuli_wdr.cpp:2957
-#: src/muuli_wdr.cpp:3407 src/muuli_wdr.cpp:3454
+#: src/amuleDlg.cpp:365 src/amuleDlg.cpp:1834 src/muuli_wdr.cpp:2961
+#: src/muuli_wdr.cpp:3411 src/muuli_wdr.cpp:3458
 msgid "Messages"
 msgstr "Sporočila"
 
-#: src/amuleDlg.cpp:366 src/amuleDlg.cpp:1817 src/muuli_wdr.cpp:3455
+#: src/amuleDlg.cpp:366 src/amuleDlg.cpp:1840 src/muuli_wdr.cpp:3459
 #: src/PrefsUnifiedDlg.cpp:314 src/Statistics.cpp:779 src/Statistics.cpp:1235
 msgid "Statistics"
 msgstr "Statistika"
 
-#: src/amuleDlg.cpp:368 src/amuleDlg.cpp:1824 src/muuli_wdr.cpp:3457
+#: src/amuleDlg.cpp:368 src/amuleDlg.cpp:1847 src/muuli_wdr.cpp:3461
 #: src/PrefsUnifiedDlg.cpp:330 src/utils/wxCas/src/wxcasprefs.cpp:39
 msgid "Preferences"
 msgstr "Nastavitve"
@@ -684,8 +684,8 @@ msgstr "Kad: izklopljen"
 #: src/amuleDlg.cpp:1029 src/DownloadListCtrl.cpp:505
 #: src/DownloadListCtrl.cpp:749 src/FriendListCtrl.cpp:180
 #: src/muuli_wdr.cpp:731 src/muuli_wdr.cpp:782 src/muuli_wdr.cpp:846
-#: src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2262 src/muuli_wdr.cpp:2347
-#: src/muuli_wdr.cpp:3095 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
+#: src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2266 src/muuli_wdr.cpp:2351
+#: src/muuli_wdr.cpp:3099 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
 #: src/ServerListCtrl.cpp:606 src/TransferWnd.cpp:378
 #: src/utils/wxCas/src/wxcasprefs.cpp:235
 msgid "Cancel"
@@ -696,7 +696,7 @@ msgid "Stop the current connection attempts"
 msgstr "Ustavi trenutne poskuse povezovanja"
 
 #: src/amuleDlg.cpp:1035 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976
-#: src/muuli_wdr.cpp:2485
+#: src/muuli_wdr.cpp:2489
 msgid "Disconnect"
 msgstr "Prekini povezave"
 
@@ -705,7 +705,7 @@ msgid "Disconnect from the currently connected networks"
 msgstr "Prekini povezavo s trenutno povezanimi omrežji"
 
 #: src/amuleDlg.cpp:1041 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979
-#: src/muuli_wdr.cpp:2640 src/muuli_wdr.cpp:3092 src/muuli_wdr.cpp:3447
+#: src/muuli_wdr.cpp:2644 src/muuli_wdr.cpp:3096 src/muuli_wdr.cpp:3451
 msgid "Connect"
 msgstr "Poveži se"
 
@@ -759,7 +759,7 @@ msgstr "Potrditev izhoda"
 msgid "Launch Command: "
 msgstr "Zaženi ukaz: "
 
-#: src/amuleDlg.cpp:1632 src/muuli_wdr.cpp:1982 src/Preferences.cpp:979
+#: src/amuleDlg.cpp:1632 src/muuli_wdr.cpp:1986 src/Preferences.cpp:979
 msgid "- default -"
 msgstr "– privzeto –"
 
@@ -773,60 +773,60 @@ msgstr "Mapa za preobleke »%s« ne obstaja"
 msgid "WARNING: Unable to open skin file '%s' for read"
 msgstr "OPOZORILO: datoteke s preobleko »%s« ni moč odpreti za branje"
 
-#: src/amuleDlg.cpp:1791 src/muuli_wdr.cpp:3449
+#: src/amuleDlg.cpp:1814 src/muuli_wdr.cpp:3453
 msgid "Networks Window"
 msgstr "Okno z omrežji"
 
-#: src/amuleDlg.cpp:1797 src/muuli_wdr.cpp:3450
+#: src/amuleDlg.cpp:1820 src/muuli_wdr.cpp:3454
 msgid "Searches Window"
 msgstr "Okno z iskanji"
 
-#: src/amuleDlg.cpp:1803 src/muuli_wdr.cpp:3451
+#: src/amuleDlg.cpp:1826 src/muuli_wdr.cpp:3455
 msgid "Downloads Window"
 msgstr "Okno s prejemanji"
 
-#: src/amuleDlg.cpp:1809 src/muuli_wdr.cpp:3453
+#: src/amuleDlg.cpp:1832 src/muuli_wdr.cpp:3457
 msgid "Shared Files Window"
 msgstr "Okno z deljenimi datotekami"
 
-#: src/amuleDlg.cpp:1815 src/muuli_wdr.cpp:3454
+#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3458
 msgid "Messages Window"
 msgstr "Okno s sporočili"
 
-#: src/amuleDlg.cpp:1821 src/muuli_wdr.cpp:3455
+#: src/amuleDlg.cpp:1844 src/muuli_wdr.cpp:3459
 msgid "Statistics Graph Window"
 msgstr "Okno s statističnimi grafi"
 
-#: src/amuleDlg.cpp:1828 src/muuli_wdr.cpp:3457
+#: src/amuleDlg.cpp:1851 src/muuli_wdr.cpp:3461
 msgid "Preferences Settings Window"
 msgstr "Okno z nastavitvami"
 
-#: src/amuleDlg.cpp:1831 src/muuli_wdr.cpp:3458
+#: src/amuleDlg.cpp:1854 src/muuli_wdr.cpp:3462
 msgid "Import"
 msgstr "Uvoz"
 
-#: src/amuleDlg.cpp:1835 src/muuli_wdr.cpp:3458
+#: src/amuleDlg.cpp:1858 src/muuli_wdr.cpp:3462
 msgid "The partfile importer tool"
 msgstr "Orodje za uvažanje delnih datotek"
 
-#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3459
+#: src/amuleDlg.cpp:1861 src/muuli_wdr.cpp:3463
 #: src/utils/aLinkCreator/src/alcframe.cpp:262
 msgid "About"
 msgstr "O programu"
 
-#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3459
+#: src/amuleDlg.cpp:1861 src/muuli_wdr.cpp:3463
 msgid "About/Help"
 msgstr "O programu/pomoč"
 
-#: src/amuleDlg.cpp:2036
+#: src/amuleDlg.cpp:2059
 msgid "eD2k network"
 msgstr "Omrežje eD2k"
 
-#: src/amuleDlg.cpp:2039
+#: src/amuleDlg.cpp:2062
 msgid "Kad network"
 msgstr "Omrežje Kad"
 
-#: src/amuleDlg.cpp:2039
+#: src/amuleDlg.cpp:2062
 msgid "No network"
 msgstr "Brez omrežja"
 
@@ -1369,19 +1369,19 @@ msgstr "Samod. [Vi]"
 msgid "Very low"
 msgstr "Zelo nizka"
 
-#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:743 src/muuli_wdr.cpp:2313
+#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:743 src/muuli_wdr.cpp:2317
 #: src/ServerListCtrl.cpp:263 src/ServerListCtrl.cpp:456
 #: src/SharedFilesCtrl.cpp:145
 msgid "Low"
 msgstr "Nizka"
 
-#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:744 src/muuli_wdr.cpp:2314
+#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:744 src/muuli_wdr.cpp:2318
 #: src/ServerListCtrl.cpp:266 src/ServerListCtrl.cpp:457
 #: src/SharedFilesCtrl.cpp:146
 msgid "Normal"
 msgstr "Običajna"
 
-#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:745 src/muuli_wdr.cpp:2315
+#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:745 src/muuli_wdr.cpp:2319
 #: src/ServerListCtrl.cpp:269 src/ServerListCtrl.cpp:458
 #: src/SharedFilesCtrl.cpp:147
 msgid "High"
@@ -1473,7 +1473,7 @@ msgstr "Krajevni strežnik"
 msgid "Remote Server"
 msgstr "Oddaljni strežnik"
 
-#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3212
+#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3216
 #: src/SearchDlg.cpp:119 src/TextClient.cpp:911
 msgid "Kad"
 msgstr "Kad"
@@ -1545,7 +1545,7 @@ msgstr "Del"
 msgid "Size"
 msgstr "Velikost"
 
-#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3279
+#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3283
 msgid "Transferred"
 msgstr "Preneseno"
 
@@ -1603,7 +1603,7 @@ msgstr ""
 "Odziv od: %s (%s)\n"
 "\n"
 
-#: src/DownloadListCtrl.cpp:746 src/muuli_wdr.cpp:2316
+#: src/DownloadListCtrl.cpp:746 src/muuli_wdr.cpp:2320
 #: src/SharedFilesCtrl.cpp:150
 msgid "Auto"
 msgstr "Samod."
@@ -1641,7 +1641,7 @@ msgid "Extended Options"
 msgstr "Dodatne možnosti"
 
 #: src/DownloadListCtrl.cpp:770 src/DownloadListCtrl.cpp:822
-#: src/muuli_wdr.cpp:1800
+#: src/muuli_wdr.cpp:1804
 msgid "Preview"
 msgstr "Ogled"
 
@@ -2447,23 +2447,23 @@ msgid ""
 "want downloads on a different (e.g. larger) disk."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:549 src/FirstRunWizard.cpp:611 src/muuli_wdr.cpp:1712
+#: src/FirstRunWizard.cpp:549 src/FirstRunWizard.cpp:611 src/muuli_wdr.cpp:1716
 msgid "Destination folder for downloads"
 msgstr "Ciljna mapa za prejeto"
 
 #: src/FirstRunWizard.cpp:553 src/FirstRunWizard.cpp:569 src/muuli_wdr.cpp:1349
-#: src/muuli_wdr.cpp:1366 src/muuli_wdr.cpp:1687 src/muuli_wdr.cpp:1718
-#: src/muuli_wdr.cpp:1730 src/muuli_wdr.cpp:2800
+#: src/muuli_wdr.cpp:1366 src/muuli_wdr.cpp:1691 src/muuli_wdr.cpp:1722
+#: src/muuli_wdr.cpp:1734 src/muuli_wdr.cpp:2804
 #: src/utils/aLinkCreator/src/alcframe.cpp:135
 #: src/utils/wxCas/src/wxcasprefs.cpp:52 src/utils/wxCas/src/wxcasprefs.cpp:118
 msgid "Browse"
 msgstr "Brskanje"
 
-#: src/FirstRunWizard.cpp:559 src/muuli_wdr.cpp:1723
+#: src/FirstRunWizard.cpp:559 src/muuli_wdr.cpp:1727
 msgid "(All files in this folder are shared with other peers)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:565 src/FirstRunWizard.cpp:624 src/muuli_wdr.cpp:1725
+#: src/FirstRunWizard.cpp:565 src/FirstRunWizard.cpp:624 src/muuli_wdr.cpp:1729
 msgid "Folder for temporary download files"
 msgstr "Mapa za začasne datoteke prejemanj"
 
@@ -2494,7 +2494,7 @@ msgstr "Datoteke s seznamom prijateljev »emfriends.met« ni bilo moč odpreti z
 msgid "CRITICAL - no client on StartChatSession"
 msgstr "KRITIČNO – ni odjemalca za StartChatSession"
 
-#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2706 src/muuli_wdr.cpp:3383
+#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2710 src/muuli_wdr.cpp:3387
 msgid "Friends"
 msgstr "Prijatelji"
 
@@ -2605,8 +2605,8 @@ msgstr "Brez"
 msgid "No"
 msgstr "Ne"
 
-#: src/GenericClientListCtrl.cpp:1216 src/PrefsUnifiedDlg.cpp:2898
-#: src/PrefsUnifiedDlg.cpp:2948 src/ServerListCtrl.cpp:276
+#: src/GenericClientListCtrl.cpp:1216 src/PrefsUnifiedDlg.cpp:2907
+#: src/PrefsUnifiedDlg.cpp:2957 src/ServerListCtrl.cpp:276
 msgid "Yes"
 msgstr "Da"
 
@@ -2779,10 +2779,10 @@ msgstr "Neveljavna vrata za začetno nalaganje"
 msgid "Please fill all fields required"
 msgstr "Prosimo, izpolnite vsa zahtevana polja"
 
-#: src/KadDlg.cpp:192 src/PartFile.cpp:1031 src/PrefsUnifiedDlg.cpp:1134
-#: src/PrefsUnifiedDlg.cpp:1204 src/PrefsUnifiedDlg.cpp:1405
-#: src/PrefsUnifiedDlg.cpp:1663 src/PrefsUnifiedDlg.cpp:1673
-#: src/PrefsUnifiedDlg.cpp:1690 src/PrefsUnifiedDlg.cpp:1738
+#: src/KadDlg.cpp:192 src/PartFile.cpp:1031 src/PrefsUnifiedDlg.cpp:1143
+#: src/PrefsUnifiedDlg.cpp:1213 src/PrefsUnifiedDlg.cpp:1414
+#: src/PrefsUnifiedDlg.cpp:1672 src/PrefsUnifiedDlg.cpp:1682
+#: src/PrefsUnifiedDlg.cpp:1699 src/PrefsUnifiedDlg.cpp:1747
 msgid "Message"
 msgstr "Sporočilo"
 
@@ -2890,7 +2890,7 @@ msgstr "Delilno razmerje"
 msgid "Uploaded"
 msgstr "Poslano"
 
-#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3263
+#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3267
 msgid "Requested"
 msgstr "Zahtevano"
 
@@ -3014,7 +3014,7 @@ msgid "WARNING: "
 msgstr "OPOZORILO: "
 
 #: src/MuleNotebook.cpp:179 src/muuli_wdr.cpp:817 src/muuli_wdr.cpp:1229
-#: src/muuli_wdr.cpp:3167 src/muuli_wdr.cpp:3423
+#: src/muuli_wdr.cpp:3171 src/muuli_wdr.cpp:3427
 msgid "Close"
 msgstr "Zapri"
 
@@ -3032,7 +3032,7 @@ msgid "Paste"
 msgstr "Prilepi"
 
 #: src/MuleTextCtrl.cpp:89 src/muuli_wdr.cpp:358 src/muuli_wdr.cpp:757
-#: src/muuli_wdr.cpp:2390 src/muuli_wdr.cpp:2409 src/muuli_wdr.cpp:2431
+#: src/muuli_wdr.cpp:2394 src/muuli_wdr.cpp:2413 src/muuli_wdr.cpp:2435
 #: src/utils/aLinkCreator/src/alcframe.cpp:142
 msgid "Clear"
 msgstr "Počisti"
@@ -3131,7 +3131,7 @@ msgstr "Končaj"
 
 #: src/MuleTrayIcon.cpp:579 src/MuleTrayIcon.cpp:945 src/MuleTrayIcon.cpp:965
 #: src/muuli_wdr.cpp:1398 src/muuli_wdr.cpp:1406 src/muuli_wdr.cpp:1413
-#: src/muuli_wdr.cpp:1846 src/muuli_wdr.cpp:1852 src/OtherFunctions.cpp:91
+#: src/muuli_wdr.cpp:1850 src/muuli_wdr.cpp:1856 src/OtherFunctions.cpp:91
 #: src/StatisticsDlg.cpp:93 src/StatisticsDlg.cpp:95
 msgid "kB/s"
 msgstr "kB/s"
@@ -3373,7 +3373,7 @@ msgstr "Bajtov"
 msgid "KB"
 msgstr "KiB"
 
-#: src/muuli_wdr.cpp:274 src/muuli_wdr.cpp:293 src/muuli_wdr.cpp:1631
+#: src/muuli_wdr.cpp:274 src/muuli_wdr.cpp:293 src/muuli_wdr.cpp:1635
 #: src/OtherFunctions.cpp:64
 msgid "MB"
 msgstr "MiB"
@@ -3390,7 +3390,7 @@ msgstr "Maks. velikost"
 msgid "Availability"
 msgstr "Razpoložljivost"
 
-#: src/muuli_wdr.cpp:312 src/muuli_wdr.cpp:398 src/muuli_wdr.cpp:3328
+#: src/muuli_wdr.cpp:312 src/muuli_wdr.cpp:398 src/muuli_wdr.cpp:3332
 msgid "Filter:"
 msgstr "Filter:"
 
@@ -3453,8 +3453,8 @@ msgstr "Viri datoteke:"
 #: src/muuli_wdr.cpp:1160 src/muuli_wdr.cpp:1167 src/muuli_wdr.cpp:1172
 #: src/muuli_wdr.cpp:1179 src/muuli_wdr.cpp:1184 src/muuli_wdr.cpp:1191
 #: src/muuli_wdr.cpp:1205 src/muuli_wdr.cpp:1212 src/muuli_wdr.cpp:1217
-#: src/muuli_wdr.cpp:1224 src/muuli_wdr.cpp:3265 src/muuli_wdr.cpp:3273
-#: src/muuli_wdr.cpp:3281
+#: src/muuli_wdr.cpp:1224 src/muuli_wdr.cpp:3269 src/muuli_wdr.cpp:3277
+#: src/muuli_wdr.cpp:3285
 msgid "N/A"
 msgstr "Ni na voljo"
 
@@ -3599,7 +3599,7 @@ msgstr ""
 msgid "Album :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:685 src/muuli_wdr.cpp:2285
+#: src/muuli_wdr.cpp:685 src/muuli_wdr.cpp:2289
 msgid "Title :"
 msgstr "Naslov:"
 
@@ -3708,7 +3708,7 @@ msgstr "Uporabniško ime:"
 msgid "Userhash :"
 msgstr "Koda uporabnika:"
 
-#: src/muuli_wdr.cpp:895 src/muuli_wdr.cpp:1752 src/muuli_wdr.cpp:2480
+#: src/muuli_wdr.cpp:895 src/muuli_wdr.cpp:1756 src/muuli_wdr.cpp:2484
 #: src/utils/aLinkCreator/src/alcframe.cpp:137
 msgid "Add"
 msgstr "Dodaj"
@@ -3717,15 +3717,15 @@ msgstr "Dodaj"
 msgid "Download-Speed"
 msgstr "Hitrost prejemanja"
 
-#: src/muuli_wdr.cpp:954 src/muuli_wdr.cpp:989 src/muuli_wdr.cpp:2584
+#: src/muuli_wdr.cpp:954 src/muuli_wdr.cpp:989 src/muuli_wdr.cpp:2588
 msgid "Current"
 msgstr "Trenutno"
 
-#: src/muuli_wdr.cpp:962 src/muuli_wdr.cpp:997 src/muuli_wdr.cpp:2592
+#: src/muuli_wdr.cpp:962 src/muuli_wdr.cpp:997 src/muuli_wdr.cpp:2596
 msgid "Running average"
 msgstr "Trenutno povprečje"
 
-#: src/muuli_wdr.cpp:970 src/muuli_wdr.cpp:1005 src/muuli_wdr.cpp:2600
+#: src/muuli_wdr.cpp:970 src/muuli_wdr.cpp:1005 src/muuli_wdr.cpp:2604
 msgid "Session average"
 msgstr "Povprečje seje"
 
@@ -3737,7 +3737,7 @@ msgstr "Hitrost pošiljanja"
 msgid "Connections"
 msgstr "Povezave"
 
-#: src/muuli_wdr.cpp:1024 src/muuli_wdr.cpp:1871
+#: src/muuli_wdr.cpp:1024 src/muuli_wdr.cpp:1875
 msgid "Active downloads"
 msgstr "Dejavna prejemanja"
 
@@ -3745,7 +3745,7 @@ msgstr "Dejavna prejemanja"
 msgid "Active connections (1:1)"
 msgstr "Dejavne povezave (1:1)"
 
-#: src/muuli_wdr.cpp:1040 src/muuli_wdr.cpp:1872
+#: src/muuli_wdr.cpp:1040 src/muuli_wdr.cpp:1876
 msgid "Active uploads"
 msgstr "Dejavna pošiljanja"
 
@@ -4022,7 +4022,7 @@ msgstr "Krajevni naslov poveži z IP-jem (prazno za poljuben):"
 msgid "Advanced users only: If you have multiple network interfaces, enter the address of the interface to which aMule should be bound."
 msgstr "Samo za napredne uporabnike: če imate več omrežnih vmesnikov, vnesite naslov vmesnika, s katerim bo povezan aMule."
 
-#: src/muuli_wdr.cpp:1462 src/muuli_wdr.cpp:2065
+#: src/muuli_wdr.cpp:1462 src/muuli_wdr.cpp:2069
 #, fuzzy
 msgid "Bind to network interface (empty for any):"
 msgstr "Krajevni naslov poveži z IP-jem (prazno za poljuben):"
@@ -4039,7 +4039,7 @@ msgstr "Največ virov na prejemanje:"
 msgid "Max simultaneous connections:"
 msgstr "Največ istočasnih povezav:"
 
-#: src/muuli_wdr.cpp:1498 src/muuli_wdr.cpp:3207
+#: src/muuli_wdr.cpp:1498 src/muuli_wdr.cpp:3211
 msgid "ED2K"
 msgstr "eD2k"
 
@@ -4131,780 +4131,780 @@ msgstr "Novim datotekam vnaprej dodeli prostor na disku"
 msgid "For new files preallocates disk space for the whole file, thus reduces fragmentation"
 msgstr "Za nove datoteke v naprej dodeli prostor na disku v velikosti celotne datoteke, kar zmanjša razdrobljenost."
 
-#: src/muuli_wdr.cpp:1617
+#: src/muuli_wdr.cpp:1621
 msgid "Create new files as sparse files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1618
+#: src/muuli_wdr.cpp:1622
 msgid "Sparse part files only occupy disk space for the parts already downloaded, so free space is used up gradually as the file fills in. Turn this off to use an ordinary file instead - useful where sparse files are unsupported or slow, or where backup/de-duplication tools handle them badly. Applies only when the core runs on Windows; on Linux and macOS part files are sparse anyway and this setting has no effect."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1623
+#: src/muuli_wdr.cpp:1627
 msgid "Stop downloads when free disk space reaches "
 msgstr "Ustavi prejemanja, ko prostor na disku doseže "
 
-#: src/muuli_wdr.cpp:1624
+#: src/muuli_wdr.cpp:1628
 msgid "Select this if you want aMule to check your disk space"
 msgstr "Izberite, če želite, da aMule preverja prostor na disku"
 
-#: src/muuli_wdr.cpp:1628
+#: src/muuli_wdr.cpp:1632
 msgid "Enter here the min disk space desired."
 msgstr "Sem vnesite min. želen prostor na disku."
 
-#: src/muuli_wdr.cpp:1634
+#: src/muuli_wdr.cpp:1638
 msgid "Save 10 sources on rare files (< 20 sources)"
 msgstr "Shrani 10 virov pri redkih datotekah (< 20 virov)"
 
-#: src/muuli_wdr.cpp:1638 src/Statistics.cpp:790
+#: src/muuli_wdr.cpp:1642 src/Statistics.cpp:790
 msgid "Uploads"
 msgstr "Pošiljanja"
 
-#: src/muuli_wdr.cpp:1641
+#: src/muuli_wdr.cpp:1645
 msgid "Add new shared files with auto priority"
 msgstr "Nove deljene datoteke naj imajo samodejno prednost"
 
-#: src/muuli_wdr.cpp:1647
+#: src/muuli_wdr.cpp:1651
 msgid "Intelligent Corruption Handling (I.C.H.)"
 msgstr "Inteligentno rokovanje s poškodbami (I.R.P.)"
 
-#: src/muuli_wdr.cpp:1650
+#: src/muuli_wdr.cpp:1654
 msgid "Enable"
 msgstr "Omogoči"
 
-#: src/muuli_wdr.cpp:1653
+#: src/muuli_wdr.cpp:1657
 msgid "Advanced I.C.H. trusts every hash (not recommended)"
 msgstr "Napredni I.R.P. zaupa vsaki kodi (ni priporočeno)"
 
-#: src/muuli_wdr.cpp:1665 src/PrefsUnifiedDlg.cpp:1990
+#: src/muuli_wdr.cpp:1669 src/PrefsUnifiedDlg.cpp:1999
 msgid "Media metadata extraction"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1669
+#: src/muuli_wdr.cpp:1673
 msgid "Extract length / bitrate / codec from shared audio and video files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1671
+#: src/muuli_wdr.cpp:1675
 msgid "When enabled, aMule runs ffprobe on each shared media file to fill in the Length / Bitrate / Codec columns other clients see when they find the file in a search. Requires ffmpeg (the ffprobe binary) to be installed."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1678
+#: src/muuli_wdr.cpp:1682
 msgid "Path to ffprobe:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1683
+#: src/muuli_wdr.cpp:1687
 msgid "Full path to the ffprobe binary. Leave empty to have aMule auto-detect it on startup."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1691
+#: src/muuli_wdr.cpp:1695
 msgid "Detect"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1692
+#: src/muuli_wdr.cpp:1696
 msgid "Search the standard install locations for an ffprobe binary and fill the path field."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1716
+#: src/muuli_wdr.cpp:1720
 msgid ""
 "Completed downloads are stored here. All files in this folder are automatically shared with other peers.\n"
 "If this folder also holds files you don't want to share, point it at an aMule-only sub-folder."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1719
+#: src/muuli_wdr.cpp:1723
 msgid "Pick the folder where completed downloads will be stored. All files in that folder will be shared with other peers."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1733
+#: src/muuli_wdr.cpp:1737
 msgid "Shared folders"
 msgstr "Deljene mape"
 
-#: src/muuli_wdr.cpp:1739
+#: src/muuli_wdr.cpp:1743
 msgid "(Folders shared by the core. Enter a path to add one.)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1747
+#: src/muuli_wdr.cpp:1751
 msgid "Absolute path of a folder on the core's machine, e.g. /home/user/shared"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1749 src/PrefsUnifiedDlg.cpp:2874
+#: src/muuli_wdr.cpp:1753 src/PrefsUnifiedDlg.cpp:2883
 msgid "Recursive"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1750
+#: src/muuli_wdr.cpp:1754
 msgid "Share every sub-folder underneath this one, including ones created later."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1754 src/utils/aLinkCreator/src/alcframe.cpp:141
+#: src/muuli_wdr.cpp:1758 src/utils/aLinkCreator/src/alcframe.cpp:141
 msgid "Remove"
 msgstr "Odstrani"
 
-#: src/muuli_wdr.cpp:1758
+#: src/muuli_wdr.cpp:1762
 msgid "(Right click on folder icon for recursive share)"
 msgstr "(desni klik na ikono mape izbere tudi podmape)"
 
-#: src/muuli_wdr.cpp:1765
+#: src/muuli_wdr.cpp:1769
 msgid "Share hidden files"
 msgstr "Deli skrite datoteke"
 
-#: src/muuli_wdr.cpp:1771
+#: src/muuli_wdr.cpp:1775
 msgid "Automatically rescan shared folders for changes"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1777
+#: src/muuli_wdr.cpp:1781
 msgid "Follow symbolic links in shared folders"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1783
+#: src/muuli_wdr.cpp:1787
 msgid "Exclude files matching:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1786
+#: src/muuli_wdr.cpp:1790
 msgid "Wildcard patterns separated by '|', e.g. .DS_Store|Thumbs.db|*.tmp. Files whose name matches are not shared. Matching is case-insensitive."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1790
+#: src/muuli_wdr.cpp:1794
 msgid "Patterns are regular expressions"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1791
+#: src/muuli_wdr.cpp:1795
 msgid "When set, the whole field is one regular expression ('|' is alternation). When unset, it is a list of '|'-separated wildcards."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1801
+#: src/muuli_wdr.cpp:1805
 msgid "Show how many shared files the current pattern would exclude."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1822
+#: src/muuli_wdr.cpp:1826
 msgid "Graphs"
 msgstr "Grafi"
 
-#: src/muuli_wdr.cpp:1825 src/muuli_wdr.cpp:1887
+#: src/muuli_wdr.cpp:1829 src/muuli_wdr.cpp:1891
 msgid "Update delay : 5 secs"
 msgstr "Zamik posodabljanja: 5 sek."
 
-#: src/muuli_wdr.cpp:1829
+#: src/muuli_wdr.cpp:1833
 msgid "Time for average graph: 100 mins"
 msgstr "Čas za graf povprečja: 100 min."
 
-#: src/muuli_wdr.cpp:1833
+#: src/muuli_wdr.cpp:1837
 msgid "Connections Graph Scale: 100 "
 msgstr "Merilo za graf povezav: 100 "
 
-#: src/muuli_wdr.cpp:1840
+#: src/muuli_wdr.cpp:1844
 msgid "Download graph scale:"
 msgstr "Merilo za graf prejemanj:"
 
-#: src/muuli_wdr.cpp:1848
+#: src/muuli_wdr.cpp:1852
 msgid "Upload graph scale:"
 msgstr "Merilo za graf pošiljanj:"
 
-#: src/muuli_wdr.cpp:1858
+#: src/muuli_wdr.cpp:1862
 #, fuzzy
 msgid "Colors: "
 msgstr "Barve: "
 
-#: src/muuli_wdr.cpp:1862
+#: src/muuli_wdr.cpp:1866
 msgid "Background"
 msgstr "Ozadje"
 
-#: src/muuli_wdr.cpp:1863
+#: src/muuli_wdr.cpp:1867
 msgid "Grid"
 msgstr "Mreža"
 
-#: src/muuli_wdr.cpp:1864
+#: src/muuli_wdr.cpp:1868
 msgid "Download current"
 msgstr "Trenutno prejemanje"
 
-#: src/muuli_wdr.cpp:1865
+#: src/muuli_wdr.cpp:1869
 msgid "Download running average"
 msgstr "Povprečje prejemanja"
 
-#: src/muuli_wdr.cpp:1866
+#: src/muuli_wdr.cpp:1870
 msgid "Download session average"
 msgstr "Povprečje seje za prejemanje"
 
-#: src/muuli_wdr.cpp:1867
+#: src/muuli_wdr.cpp:1871
 msgid "Upload current"
 msgstr "Trenutno pošiljanje"
 
-#: src/muuli_wdr.cpp:1868
+#: src/muuli_wdr.cpp:1872
 msgid "Upload running average"
 msgstr "Povprečje pošiljanja"
 
-#: src/muuli_wdr.cpp:1869
+#: src/muuli_wdr.cpp:1873
 msgid "Upload session average"
 msgstr "Povprečje seje za pošiljanje"
 
-#: src/muuli_wdr.cpp:1870
+#: src/muuli_wdr.cpp:1874
 msgid "Active connections"
 msgstr "Dejavne povezave"
 
-#: src/muuli_wdr.cpp:1873
+#: src/muuli_wdr.cpp:1877
 #, fuzzy
 msgid "Systray Icon Speed Bar"
 msgstr "Prikaz hitrosti v sistemski vrstici"
 
-#: src/muuli_wdr.cpp:1874
+#: src/muuli_wdr.cpp:1878
 msgid "Kad-nodes current"
 msgstr "Trenutna vozlišča Kad"
 
-#: src/muuli_wdr.cpp:1875
+#: src/muuli_wdr.cpp:1879
 msgid "Kad-nodes running"
 msgstr "Vozlišča Kad v teku"
 
-#: src/muuli_wdr.cpp:1876
+#: src/muuli_wdr.cpp:1880
 msgid "Kad-nodes session"
 msgstr "Vozlišča Kad te seje"
 
-#: src/muuli_wdr.cpp:1880 src/muuli_wdr.cpp:2334
+#: src/muuli_wdr.cpp:1884 src/muuli_wdr.cpp:2338
 msgid "Select"
 msgstr "Izberi"
 
-#: src/muuli_wdr.cpp:1884
+#: src/muuli_wdr.cpp:1888
 msgid "Tree"
 msgstr "Drevo"
 
-#: src/muuli_wdr.cpp:1894
+#: src/muuli_wdr.cpp:1898
 msgid "Number of Client Versions shown (0=unlimited)"
 msgstr "Število prikazanih različic odjemalcev (0 = neomejeno)"
 
-#: src/muuli_wdr.cpp:1919
+#: src/muuli_wdr.cpp:1923
 msgid "!!! WARNING !!!"
 msgstr "!!! OPOZORILO !!!"
 
-#: src/muuli_wdr.cpp:1934
+#: src/muuli_wdr.cpp:1938
 msgid "Max new connections / 5 secs"
 msgstr "Maks. novih povezav / 5 sek."
 
-#: src/muuli_wdr.cpp:1936
+#: src/muuli_wdr.cpp:1940
 msgid "Concurrent Kad source lookups"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1938
+#: src/muuli_wdr.cpp:1942
 #, fuzzy
 msgid "Kad source re-search interval (minutes)"
 msgstr "Interval med osvežitvami FTP-ja v minutah"
 
-#: src/muuli_wdr.cpp:1940
+#: src/muuli_wdr.cpp:1944
 #, fuzzy
 msgid "Source re-ask interval (minutes)"
 msgstr "Interval med osvežitvami FTP-ja v minutah"
 
-#: src/muuli_wdr.cpp:1944
+#: src/muuli_wdr.cpp:1948
 msgid "File Buffer Size: 240000 bytes"
 msgstr "Datotečni medpomnilnik: 240000 bajtov"
 
-#: src/muuli_wdr.cpp:1948
+#: src/muuli_wdr.cpp:1952
 msgid "Use MMAP: memory-mapped file access (lower memory use)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1949
+#: src/muuli_wdr.cpp:1953
 msgid "Maps part files into memory instead of buffering them on the heap, lowering the process memory footprint. May reduce download speed on some disks; best for memory-constrained or upload-heavy hosts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1951
+#: src/muuli_wdr.cpp:1955
 msgid "Upload Queue Size: 5000 clients"
 msgstr "Velikost vrste za pošiljanje: 5000 odjemalcev"
 
-#: src/muuli_wdr.cpp:1955
+#: src/muuli_wdr.cpp:1959
 msgid "Server connection refresh interval: Disable"
 msgstr "Čas med osvežitvama povezave na strežnik: onemogoči"
 
-#: src/muuli_wdr.cpp:1959
+#: src/muuli_wdr.cpp:1963
 msgid "Disable computer's timed standby mode"
 msgstr "Onemogoči prehod računalnika v pripravljenost"
 
-#: src/muuli_wdr.cpp:1978
+#: src/muuli_wdr.cpp:1982
 msgid "Skin to use: "
 msgstr "Uporabljena preobleka: "
 
-#: src/muuli_wdr.cpp:1987
+#: src/muuli_wdr.cpp:1991
 msgid "Show \"Fast eD2k Links Handler\" in every window."
 msgstr "Prikaži hitri rokovalnik s povezavami eD2k v vsakem oknu."
 
-#: src/muuli_wdr.cpp:1990
+#: src/muuli_wdr.cpp:1994
 msgid "Show extended info on categories tabs"
 msgstr "Prikaži razširjene podatke na zavihkih kategorij"
 
-#: src/muuli_wdr.cpp:1993
+#: src/muuli_wdr.cpp:1997
 msgid "Show application version on title"
 msgstr "V naslovni vrstici pokaži različico programa"
 
-#: src/muuli_wdr.cpp:1995
+#: src/muuli_wdr.cpp:1999
 msgid "Show transfer rates on title"
 msgstr "Kaži hitrosti prenosa v naslovni vrstici"
 
-#: src/muuli_wdr.cpp:1997
+#: src/muuli_wdr.cpp:2001
 msgid "Before application name"
 msgstr "Pred imenom programa"
 
-#: src/muuli_wdr.cpp:1999
+#: src/muuli_wdr.cpp:2003
 msgid "After application name"
 msgstr "Za imenom programa"
 
-#: src/muuli_wdr.cpp:2002
+#: src/muuli_wdr.cpp:2006
 msgid "Show overhead bandwidth"
 msgstr "Kaži presežek prenosov"
 
-#: src/muuli_wdr.cpp:2006
+#: src/muuli_wdr.cpp:2010
 msgid "Vertical toolbar orientation"
 msgstr "Usmeri orodjarno navpično"
 
-#: src/muuli_wdr.cpp:2008
+#: src/muuli_wdr.cpp:2012
 msgid "Live column sorting (auto-reorder rows as their values change)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2015
+#: src/muuli_wdr.cpp:2019
 msgid "Download Queue Files"
 msgstr "Datoteke v vrsti prejemanj"
 
-#: src/muuli_wdr.cpp:2018
+#: src/muuli_wdr.cpp:2022
 msgid "Show progress percentage"
 msgstr "Prikaži odstotek napredka"
 
-#: src/muuli_wdr.cpp:2024
+#: src/muuli_wdr.cpp:2028
 msgid "Show progress bar"
 msgstr "Prikaži črto napredka"
 
-#: src/muuli_wdr.cpp:2027
+#: src/muuli_wdr.cpp:2031
 msgid "Flat"
 msgstr "Plosko"
 
-#: src/muuli_wdr.cpp:2031
+#: src/muuli_wdr.cpp:2035
 msgid "Round"
 msgstr "Zaokroženo"
 
-#: src/muuli_wdr.cpp:2049
+#: src/muuli_wdr.cpp:2053
 msgid "External Connection Parameters"
 msgstr "Parametri za zunanje povezave"
 
-#: src/muuli_wdr.cpp:2052
+#: src/muuli_wdr.cpp:2056
 msgid "Accept external connections"
 msgstr "Sprejmi zunanje povezave"
 
-#: src/muuli_wdr.cpp:2059 src/muuli_wdr.cpp:2118
+#: src/muuli_wdr.cpp:2063 src/muuli_wdr.cpp:2122
 msgid "IP of the listening interface:"
 msgstr "IP vmesnika, ki posluša:"
 
-#: src/muuli_wdr.cpp:2062
+#: src/muuli_wdr.cpp:2066
 msgid "Enter here a valid ip in the a.b.c.d format for the listening EC interface. An empty field or 0.0.0.0 will mean any interface."
 msgstr "Sem vnesite veljaven IP v formatu a.b.c.d za poslušalen vmesnik. Prazno polje ali 0.0.0.0 pomeni poljuben vmesnik."
 
-#: src/muuli_wdr.cpp:2083 src/muuli_wdr.cpp:2194
+#: src/muuli_wdr.cpp:2087 src/muuli_wdr.cpp:2198
 msgid "TCP port:"
 msgstr "Vrata TCP:"
 
-#: src/muuli_wdr.cpp:2089
+#: src/muuli_wdr.cpp:2093
 msgid "Enable UPnP port forwarding on the EC port"
 msgstr "Vklopi posredovanje vrat UPnP za vrata zunanjih povezav"
 
-#: src/muuli_wdr.cpp:2093 src/muuli_wdr.cpp:3079
+#: src/muuli_wdr.cpp:2097 src/muuli_wdr.cpp:3083
 #: src/utils/wxCas/src/wxcasprefs.cpp:167
 msgid "Password"
 msgstr "Geslo"
 
-#: src/muuli_wdr.cpp:2099
+#: src/muuli_wdr.cpp:2103
 #, fuzzy
 msgid "aMule API server parameters"
 msgstr "Parametri spletnega strežnika"
 
-#: src/muuli_wdr.cpp:2102
+#: src/muuli_wdr.cpp:2106
 msgid "Run amuleapi (REST API) on startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2107
+#: src/muuli_wdr.cpp:2111
 #, fuzzy
 msgid "HTTP port:"
 msgstr "Vrata TCP:"
 
-#: src/muuli_wdr.cpp:2121
+#: src/muuli_wdr.cpp:2125
 msgid "The interface amuleapi's HTTP server listens on. 127.0.0.1 (default) accepts only local connections; use 0.0.0.0 or a specific IP to expose it to other hosts (set an admin password below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2126
+#: src/muuli_wdr.cpp:2130
 msgid "Type a password to set or change it. Stored passwords cannot be shown, so leaving this empty keeps the current one."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2128
+#: src/muuli_wdr.cpp:2132
 #, fuzzy
 msgid "Admin password"
 msgstr "Preverjanje gesla\n"
 
-#: src/muuli_wdr.cpp:2140 src/muuli_wdr.cpp:2157 src/PrefsUnifiedDlg.cpp:1103
+#: src/muuli_wdr.cpp:2144 src/muuli_wdr.cpp:2161 src/PrefsUnifiedDlg.cpp:1112
 #, fuzzy
 msgid "A password is set."
 msgstr "Preverjanje gesla\n"
 
-#: src/muuli_wdr.cpp:2144
+#: src/muuli_wdr.cpp:2148
 #, fuzzy
 msgid "Enable guest access"
 msgstr "Zavrni dostop gostom"
 
-#: src/muuli_wdr.cpp:2145
+#: src/muuli_wdr.cpp:2149
 msgid "Guest sessions may read status and listings but cannot change anything. Turning this off clears the stored guest password."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2149
+#: src/muuli_wdr.cpp:2153
 #, fuzzy
 msgid "Guest password"
 msgstr "Geslo za goste na spletnem strežniku"
 
-#: src/muuli_wdr.cpp:2164
+#: src/muuli_wdr.cpp:2168
 msgid "Web server parameters"
 msgstr "Parametri spletnega strežnika"
 
-#: src/muuli_wdr.cpp:2167
+#: src/muuli_wdr.cpp:2171
 #, fuzzy
 msgid "Run webserver on startup (deprecated)"
 msgstr "Spletni strežnik zaženi ob zagonu"
 
-#: src/muuli_wdr.cpp:2173
+#: src/muuli_wdr.cpp:2177
 msgid "Web template"
 msgstr "Spletna predloga"
 
-#: src/muuli_wdr.cpp:2178
+#: src/muuli_wdr.cpp:2182
 msgid "Full rights password"
 msgstr "Geslo za vse pravice"
 
-#: src/muuli_wdr.cpp:2182
+#: src/muuli_wdr.cpp:2186
 msgid "Enable Low rights User"
 msgstr "Omogoči uporabnika z nizkimi pravicami"
 
-#: src/muuli_wdr.cpp:2187
+#: src/muuli_wdr.cpp:2191
 msgid "Low rights password"
 msgstr "Geslo za nizke pravice"
 
-#: src/muuli_wdr.cpp:2201
+#: src/muuli_wdr.cpp:2205
 msgid "Enable UPnP port forwarding of the web server port"
 msgstr "Vklopi posredovanje vrat UPnP za vrata spletnega strežnika"
 
-#: src/muuli_wdr.cpp:2206
+#: src/muuli_wdr.cpp:2210
 msgid "Web server UPnP TCP port (Optional)"
 msgstr "Vrata TCP za UPnP za spletni strežnik (neobvezno)"
 
-#: src/muuli_wdr.cpp:2214
+#: src/muuli_wdr.cpp:2218
 msgid "Page Refresh Time (in secs)"
 msgstr "Čas med osvežitvami strani (v sek.)"
 
-#: src/muuli_wdr.cpp:2221
+#: src/muuli_wdr.cpp:2225
 msgid "Enable Gzip compression"
 msgstr "Omogoči stiskanje gzip"
 
-#: src/muuli_wdr.cpp:2255
+#: src/muuli_wdr.cpp:2259
 #, fuzzy
 msgid "Reset page to defaults"
 msgstr "Sistemsko privzet"
 
-#: src/muuli_wdr.cpp:2256
+#: src/muuli_wdr.cpp:2260
 msgid "Reset the settings on the current page to their default values."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2258 src/muuli_wdr.cpp:2344 src/ServerWnd.cpp:274
+#: src/muuli_wdr.cpp:2262 src/muuli_wdr.cpp:2348 src/ServerWnd.cpp:274
 #: src/ServerWnd.cpp:282
 msgid "OK"
 msgstr "V redu"
 
-#: src/muuli_wdr.cpp:2260
+#: src/muuli_wdr.cpp:2264
 msgid "Click here to apply any changes made to the preferences."
 msgstr "Kliknite tukaj za uveljavitev sprememb v nastavitvah."
 
-#: src/muuli_wdr.cpp:2263
+#: src/muuli_wdr.cpp:2267
 msgid "Reset any changes made to the preferences."
 msgstr "Razveljavi vse spremembe v nastavitvah."
 
-#: src/muuli_wdr.cpp:2292
+#: src/muuli_wdr.cpp:2296
 msgid "Comment :"
 msgstr "Komentar:"
 
-#: src/muuli_wdr.cpp:2299
+#: src/muuli_wdr.cpp:2303
 msgid "Incoming Dir :"
 msgstr "Mapa za prejeto:"
 
-#: src/muuli_wdr.cpp:2308
+#: src/muuli_wdr.cpp:2312
 msgid "Change priority for new assigned files :"
 msgstr "Spremeni prednost novo dodeljenim datotekam:"
 
-#: src/muuli_wdr.cpp:2312
+#: src/muuli_wdr.cpp:2316
 msgid "Don't change"
 msgstr "Ne spremeni"
 
-#: src/muuli_wdr.cpp:2324
+#: src/muuli_wdr.cpp:2328
 msgid "Select color for this Category (currently selected) :"
 msgstr "Izberite barvo za to kategorijo (trenutno izbrano):"
 
-#: src/muuli_wdr.cpp:2391 src/muuli_wdr.cpp:2410 src/muuli_wdr.cpp:2432
+#: src/muuli_wdr.cpp:2395 src/muuli_wdr.cpp:2414 src/muuli_wdr.cpp:2436
 msgid "Click this button to reset the log."
 msgstr "Kliknite ta gumb, da ponastavite dnevnik."
 
-#: src/muuli_wdr.cpp:2451
+#: src/muuli_wdr.cpp:2455
 msgid "Click on this button to update the servers list from URL ..."
 msgstr "Kliknite ta gumb za posodobitev seznama strežnikov iz URL-ja."
 
-#: src/muuli_wdr.cpp:2455
+#: src/muuli_wdr.cpp:2459
 msgid "Server list"
 msgstr "Seznam strežnikov"
 
-#: src/muuli_wdr.cpp:2459
+#: src/muuli_wdr.cpp:2463
 msgid "Enter the url to a server.met file here and press the button to the left to update the list of known servers."
 msgstr "Vnesite URL do datoteke server.met in kliknite gumb na levi, da posodobite seznam strežnikov."
 
-#: src/muuli_wdr.cpp:2464
+#: src/muuli_wdr.cpp:2468
 msgid "Add server manually: Name"
 msgstr "Ročno dodaj strežnik: ime"
 
-#: src/muuli_wdr.cpp:2467
+#: src/muuli_wdr.cpp:2471
 msgid "Enter the name of the new server here"
 msgstr "Sem vnesite ime novega strežnika"
 
-#: src/muuli_wdr.cpp:2469 src/ServerWnd.cpp:206
+#: src/muuli_wdr.cpp:2473 src/ServerWnd.cpp:206
 msgid "IP:Port"
 msgstr "IP:Vrata"
 
-#: src/muuli_wdr.cpp:2472
+#: src/muuli_wdr.cpp:2476
 msgid "Enter the IP of the server here, using the x.x.x.x format."
 msgstr "Sem vnesite IP strežnika v formatu x.x.x.x."
 
-#: src/muuli_wdr.cpp:2478
+#: src/muuli_wdr.cpp:2482
 msgid "Enter the port of the server here."
 msgstr "Sem vnesite vrata strežnika."
 
-#: src/muuli_wdr.cpp:2481
+#: src/muuli_wdr.cpp:2485
 msgid "Add manually a server (fill fields to the left before) ..."
 msgstr "Ročno dodaj strežnik (najprej izpolnite vsa polja) …"
 
-#: src/muuli_wdr.cpp:2510
+#: src/muuli_wdr.cpp:2514
 msgid "aMule Log"
 msgstr "aMule dnevnik"
 
-#: src/muuli_wdr.cpp:2518
+#: src/muuli_wdr.cpp:2522
 msgid "Server Info"
 msgstr "Podatki o strežniku"
 
-#: src/muuli_wdr.cpp:2522
+#: src/muuli_wdr.cpp:2526
 msgid "ED2K Info"
 msgstr "Podatki o eD2k"
 
-#: src/muuli_wdr.cpp:2526
+#: src/muuli_wdr.cpp:2530
 msgid "Kad Info"
 msgstr "Podatki o Kad"
 
-#: src/muuli_wdr.cpp:2554
+#: src/muuli_wdr.cpp:2558
 msgid "Click on this button to update the nodes list from URL ..."
 msgstr "Kliknite ta gumb za posodobitev seznama vozlišč iz URL-ja."
 
-#: src/muuli_wdr.cpp:2558
+#: src/muuli_wdr.cpp:2562
 msgid "Nodes (0)"
 msgstr "Vozlišča (0)"
 
-#: src/muuli_wdr.cpp:2562
+#: src/muuli_wdr.cpp:2566
 msgid "Enter the url to a nodes.dat file here and press the button to the left to update the list of known nodes."
 msgstr "Vnesite URL do datoteke nodes.dat in pritisnite gumb na levi za posodobitev seznama vozlišč."
 
-#: src/muuli_wdr.cpp:2565
+#: src/muuli_wdr.cpp:2569
 msgid "Nodes stats"
 msgstr "Statistika vozlišč"
 
-#: src/muuli_wdr.cpp:2607
+#: src/muuli_wdr.cpp:2611
 msgid "Bootstrap"
 msgstr "Začetno nalaganje"
 
-#: src/muuli_wdr.cpp:2610
+#: src/muuli_wdr.cpp:2614
 msgid "New node"
 msgstr "Novo vozlišče"
 
-#: src/muuli_wdr.cpp:2615
+#: src/muuli_wdr.cpp:2619
 msgid "IP:"
 msgstr "IP:"
 
-#: src/muuli_wdr.cpp:2635
+#: src/muuli_wdr.cpp:2639
 msgid "Port:"
 msgstr "Vrata:"
 
-#: src/muuli_wdr.cpp:2648
+#: src/muuli_wdr.cpp:2652
 msgid "Bootstrap from known clients"
 msgstr ""
 "Naloži od znanih \n"
 "odjemalcev"
 
-#: src/muuli_wdr.cpp:2650
+#: src/muuli_wdr.cpp:2654
 msgid "Disconnect Kad"
 msgstr "Prekini povezavo s Kad"
 
-#: src/muuli_wdr.cpp:2684
+#: src/muuli_wdr.cpp:2688
 msgid "Use Secure User Identification"
 msgstr "Uporabi varno identifikacijo uporabnikov"
 
-#: src/muuli_wdr.cpp:2686
+#: src/muuli_wdr.cpp:2690
 msgid "It is recommended to enable this option. You will not receive credits if SUI is not enabled."
 msgstr "Priporočamo, da omogočite to možnost. Če to ni omogočeno, ne boste prejeli točk za zasluge."
 
-#: src/muuli_wdr.cpp:2688
+#: src/muuli_wdr.cpp:2692
 msgid "Protocol Obfuscation"
 msgstr "Maskiranje protokola"
 
-#: src/muuli_wdr.cpp:2691
+#: src/muuli_wdr.cpp:2695
 msgid "Support Protocol Obfuscation"
 msgstr "Omogoči maskiranje protokola"
 
-#: src/muuli_wdr.cpp:2693
+#: src/muuli_wdr.cpp:2697
 msgid "This option enabled Protocol Obfuscation, and makes aMule accept obfuscated connections from other clients."
 msgstr "Ob vklopu te možnosti, bo aMule sprejemal maskirane povezave od drugih odjemalcev."
 
-#: src/muuli_wdr.cpp:2695
+#: src/muuli_wdr.cpp:2699
 msgid "Use obfuscation for outgoing connections"
 msgstr "Uporabi maskiranje za izhodne povezave"
 
-#: src/muuli_wdr.cpp:2697
+#: src/muuli_wdr.cpp:2701
 msgid "This option makes aMule use Protocol Obfuscation when connecting other clients/servers."
 msgstr "Ob vklopu te možnosti, bo aMule uporabil maskiranje pri povezavi z drugimi odjemalci in na strežnike."
 
-#: src/muuli_wdr.cpp:2699
+#: src/muuli_wdr.cpp:2703
 msgid "Accept only obfuscated connections"
 msgstr "Dovoli samo maskirane povezave"
 
-#: src/muuli_wdr.cpp:2700
+#: src/muuli_wdr.cpp:2704
 msgid "This option makes aMule only accept obfuscated connections. You will have less sources, but all your traffic will be obfuscated"
 msgstr "Ob vklopu te možnosti, bo aMule sprejemal samo maskirane povezave. Imeli boste manj virov, vendar bodo vse povezave maskirane."
 
-#: src/muuli_wdr.cpp:2705
+#: src/muuli_wdr.cpp:2709
 msgid "Everybody"
 msgstr "Vsi"
 
-#: src/muuli_wdr.cpp:2707
+#: src/muuli_wdr.cpp:2711
 msgid "No one"
 msgstr "Nihče"
 
-#: src/muuli_wdr.cpp:2709
+#: src/muuli_wdr.cpp:2713
 msgid "Who can see my shared files:"
 msgstr "Kdo lahko vidi moje deljene datoteke:"
 
-#: src/muuli_wdr.cpp:2710
+#: src/muuli_wdr.cpp:2714
 msgid "Select who can request to view a list of your shared files."
 msgstr "Izberite, kdo lahko zahteva vaš seznam deljenih datotek."
 
-#: src/muuli_wdr.cpp:2712
+#: src/muuli_wdr.cpp:2716
 msgid "IP-Filtering"
 msgstr "Filtriranje IP-jev"
 
-#: src/muuli_wdr.cpp:2719
+#: src/muuli_wdr.cpp:2723
 msgid "Filter clients"
 msgstr "Filtriraj odjemalce"
 
-#: src/muuli_wdr.cpp:2721
+#: src/muuli_wdr.cpp:2725
 msgid "Enable filtering of the client IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "Omogoči filtriranje odjemalčevih IP-jev, določenih v datoteki ~/.aMule/ipfilter.dat."
 
-#: src/muuli_wdr.cpp:2723
+#: src/muuli_wdr.cpp:2727
 msgid "Filter servers"
 msgstr "Filtriraj strežnike"
 
-#: src/muuli_wdr.cpp:2725
+#: src/muuli_wdr.cpp:2729
 msgid "Enable filtering of the server IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "Omogoči filtriranje strežnikovih IP-jev, določenih v datoteki ~/.aMule/ipfilter.dat."
 
-#: src/muuli_wdr.cpp:2729
+#: src/muuli_wdr.cpp:2733
 msgid "Reload List"
 msgstr "Znova naloži seznam"
 
-#: src/muuli_wdr.cpp:2730
+#: src/muuli_wdr.cpp:2734
 msgid "Reload the list of IPs to filter from the file ~/.aMule/ipfilter.dat"
 msgstr "Ponovno naloži seznam IP-jev za filtriranje iz ~/.aMule/ipfilter.dat."
 
-#: src/muuli_wdr.cpp:2736
+#: src/muuli_wdr.cpp:2740
 msgid "URL:"
 msgstr "URL:"
 
-#: src/muuli_wdr.cpp:2740 src/muuli_wdr.cpp:2933
+#: src/muuli_wdr.cpp:2744 src/muuli_wdr.cpp:2937
 msgid "Update now"
 msgstr "Posodobi zdaj"
 
-#: src/muuli_wdr.cpp:2743
+#: src/muuli_wdr.cpp:2747
 msgid "Auto-update ipfilter at startup"
 msgstr "Samodejno posodobi filter IP-jev ob zagonu"
 
-#: src/muuli_wdr.cpp:2747
+#: src/muuli_wdr.cpp:2751
 msgid "Filtering Level:"
 msgstr "Stopnja filtriranja:"
 
-#: src/muuli_wdr.cpp:2753
+#: src/muuli_wdr.cpp:2757
 msgid "Always filter LAN IPs"
 msgstr "Vedno filtriraj IP-je krajevnega omrežja"
 
-#: src/muuli_wdr.cpp:2756
+#: src/muuli_wdr.cpp:2760
 msgid "Paranoid handling of non-matching IPs"
 msgstr "Paranoično rokovanje z ne-ujemajočimi IP-ji"
 
-#: src/muuli_wdr.cpp:2758
+#: src/muuli_wdr.cpp:2762
 msgid "Rejects a packet when its source IP differs from the IP the client claims (an anti-spoofing check). Disable only if it causes connection problems."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2760
+#: src/muuli_wdr.cpp:2764
 msgid "Use system-wide ipfilter.dat if available"
 msgstr "Uporabi sistemsko ipfilter.dat, če je na voljo"
 
-#: src/muuli_wdr.cpp:2761
+#: src/muuli_wdr.cpp:2765
 #, fuzzy
 msgid "If there's no local ipfilter.dat found, allow usage of a system-wide ipfilter file."
 msgstr "Če krajevne datoteke ipfilter.dat ni moč najti, omogoči uporabo sistemske datoteke."
 
-#: src/muuli_wdr.cpp:2778
+#: src/muuli_wdr.cpp:2782
 msgid "Enable Online-Signature"
 msgstr "Omogoči spletni podpis"
 
-#: src/muuli_wdr.cpp:2780
+#: src/muuli_wdr.cpp:2784
 msgid "Enables the writing of the OS file, which can be used by external apps to create signatures and the like."
 msgstr "Omogoči pisanje v datoteko spletnega podpisa, katero lahko uporabljajo zunanji programi za izdelavo podpisov in podobnih stvari."
 
-#: src/muuli_wdr.cpp:2784
+#: src/muuli_wdr.cpp:2788
 msgid "Update Frequency (Secs):"
 msgstr "Pogostost posodobitev (sek.):"
 
-#: src/muuli_wdr.cpp:2787
+#: src/muuli_wdr.cpp:2791
 msgid "Change the frequency (in seconds) of Online Signature updates."
 msgstr "Spremeni pogostost (v sekundah) posodobitev spletnega podpisa."
 
-#: src/muuli_wdr.cpp:2795
+#: src/muuli_wdr.cpp:2799
 msgid "Save online signature file in: "
 msgstr "Spletni podpis shrani v datoteko: "
 
-#: src/muuli_wdr.cpp:2801
+#: src/muuli_wdr.cpp:2805
 msgid "Click here to select the directory containing the the Online Signature files."
 msgstr "Kliknite tukaj, da nastavite mapo, ki vsebuje datoteke za spletni podpis."
 
-#: src/muuli_wdr.cpp:2834
+#: src/muuli_wdr.cpp:2838
 msgid "Show country flags for clients"
 msgstr "Prikaži zastave držav za odjemalce"
 
-#: src/muuli_wdr.cpp:2835
+#: src/muuli_wdr.cpp:2839
 msgid "Render the country flag column in the transfers, queue and search views. Requires a valid MMDB GeoIP database (see below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2840
+#: src/muuli_wdr.cpp:2844
 #, fuzzy
 msgid "Database"
 msgstr "Podatkovna hitrost:"
 
-#: src/muuli_wdr.cpp:2856
+#: src/muuli_wdr.cpp:2860
 #, fuzzy
 msgid "Source:"
 msgstr "Viri"
 
-#: src/muuli_wdr.cpp:2859
+#: src/muuli_wdr.cpp:2863
 msgid "DB-IP (free, no account)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2860
+#: src/muuli_wdr.cpp:2864
 msgid "MaxMind GeoLite2 (free, account required)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2861
+#: src/muuli_wdr.cpp:2865
 msgid "Custom URL"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2864
+#: src/muuli_wdr.cpp:2868
 msgid "Choose which provider supplies the GeoIP MMDB database. DB-IP is the default - no account required. MaxMind requires a free account + license key. Use Custom URL to point at any other MMDB host (e.g. a local mirror)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2881
+#: src/muuli_wdr.cpp:2885
 msgid ""
 "No configuration required.\n"
 "\n"
@@ -4912,11 +4912,11 @@ msgid ""
 "License: Creative Commons BY 4.0 - https://creativecommons.org/licenses/by/4.0/"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2894
+#: src/muuli_wdr.cpp:2898
 msgid "License key:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2900
+#: src/muuli_wdr.cpp:2904
 msgid ""
 "Sign up for a free MaxMind account, then generate a License Key:\n"
 "https://www.maxmind.com/en/geolite2/signup\n"
@@ -4926,225 +4926,225 @@ msgid ""
 "Requires attribution and account registration; refresh at least every 30 days."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2915
+#: src/muuli_wdr.cpp:2919
 #, fuzzy
 msgid "Download URL:"
 msgstr "Prejemanje: "
 
-#: src/muuli_wdr.cpp:2921
+#: src/muuli_wdr.cpp:2925
 msgid ""
 "Must point to an .mmdb file or a .gz / .tar.gz containing one.\n"
 "URL may include credentials (https://user:pass@host/...).\n"
 "License and attribution terms are set by the upstream URL - you are responsible."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2934
+#: src/muuli_wdr.cpp:2938
 msgid "Download the GeoIP database from the selected source."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2936
+#: src/muuli_wdr.cpp:2940
 #, fuzzy
 msgid "Auto-update on startup"
 msgstr "Samodejno posodobi filter IP-jev ob zagonu"
 
-#: src/muuli_wdr.cpp:2937
+#: src/muuli_wdr.cpp:2941
 msgid "Re-download the GeoIP database from the selected source every time aMule starts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2960
+#: src/muuli_wdr.cpp:2964
 msgid "Filter incoming messages (except current chat):"
 msgstr "Filtriraj prejeta sporočila (razen v trenutnem pogovoru):"
 
-#: src/muuli_wdr.cpp:2962
+#: src/muuli_wdr.cpp:2966
 msgid "Filter all messages"
 msgstr "Filtriraj vsa sporočila"
 
-#: src/muuli_wdr.cpp:2964
+#: src/muuli_wdr.cpp:2968
 msgid "Filter messages from people not on your friend list"
 msgstr "Filtriraj sporočila vseh, ki niso na seznamu prijateljev"
 
-#: src/muuli_wdr.cpp:2966
+#: src/muuli_wdr.cpp:2970
 msgid "Filter messages from unknown clients"
 msgstr "Filtriraj sporočila neznanih uporabnikov"
 
-#: src/muuli_wdr.cpp:2968
+#: src/muuli_wdr.cpp:2972
 msgid "Filter messages containing (use ',' as separator):"
 msgstr "Filtriraj sporočila, ki vsebujejo (uporabi »,« kot ločilnik):"
 
-#: src/muuli_wdr.cpp:2971 src/muuli_wdr.cpp:2982
+#: src/muuli_wdr.cpp:2975 src/muuli_wdr.cpp:2986
 msgid "add here the words amule should filter and block messages including it"
 msgstr "Sem dodajte besede, ki naj jih aMule filtrira, vključno s sporočili v katerih se nahajajo."
 
-#: src/muuli_wdr.cpp:2973
+#: src/muuli_wdr.cpp:2977
 msgid "Show received messages in the log"
 msgstr "Prejeta sporočila prikaži v dnevniku"
 
-#: src/muuli_wdr.cpp:2976
+#: src/muuli_wdr.cpp:2980
 msgid "Comments"
 msgstr "Komentarji"
 
-#: src/muuli_wdr.cpp:2979
+#: src/muuli_wdr.cpp:2983
 msgid "Filter comments containing (use ',' as separator):"
 msgstr "Filtriraj komentarje, ki vsebujejo (uporabi »,« kot ločilnik):"
 
-#: src/muuli_wdr.cpp:3004
+#: src/muuli_wdr.cpp:3008
 msgid "Enable Proxy"
 msgstr "Omogoči posrednika"
 
-#: src/muuli_wdr.cpp:3005
+#: src/muuli_wdr.cpp:3009
 msgid "Enable/disable proxy support"
 msgstr "Omogoči/onemogoči podporo za posrednika"
 
-#: src/muuli_wdr.cpp:3008
+#: src/muuli_wdr.cpp:3012
 msgid "Proxy type:"
 msgstr "Vrsta posrednika:"
 
-#: src/muuli_wdr.cpp:3019
+#: src/muuli_wdr.cpp:3023
 msgid "Proxy host:"
 msgstr "Gostitelj posrednika:"
 
-#: src/muuli_wdr.cpp:3022
+#: src/muuli_wdr.cpp:3026
 msgid "The proxy host name"
 msgstr "Ime gostitelja posredniškega strežnika"
 
-#: src/muuli_wdr.cpp:3024
+#: src/muuli_wdr.cpp:3028
 msgid "Proxy port:"
 msgstr "Vrata posrednika:"
 
-#: src/muuli_wdr.cpp:3027
+#: src/muuli_wdr.cpp:3031
 msgid "The proxy port"
 msgstr "Vrata posredniškega strežnika"
 
-#: src/muuli_wdr.cpp:3029
+#: src/muuli_wdr.cpp:3033
 msgid "Enable authentication"
 msgstr "Omogoči overjanje"
 
-#: src/muuli_wdr.cpp:3030
+#: src/muuli_wdr.cpp:3034
 msgid "Enable/disable username/password authentication"
 msgstr "Omogoči/onemogoči overjanje z uporabniškim imenom/geslom"
 
-#: src/muuli_wdr.cpp:3033
+#: src/muuli_wdr.cpp:3037
 msgid "Username: "
 msgstr "Uporabniško ime: "
 
-#: src/muuli_wdr.cpp:3036
+#: src/muuli_wdr.cpp:3040
 msgid "The username to use to connect to the proxy"
 msgstr "Uporabniško ime za povezavo s posrednikom"
 
-#: src/muuli_wdr.cpp:3038
+#: src/muuli_wdr.cpp:3042
 msgid "Password:"
 msgstr "Geslo:"
 
-#: src/muuli_wdr.cpp:3041
+#: src/muuli_wdr.cpp:3045
 msgid "The password to use to connect to the proxy"
 msgstr "Geslo za povezavo s posrednikom"
 
-#: src/muuli_wdr.cpp:3060
+#: src/muuli_wdr.cpp:3064
 msgid "Connect to:"
 msgstr "Poveži se z:"
 
-#: src/muuli_wdr.cpp:3069
+#: src/muuli_wdr.cpp:3073
 msgid "Login to remote amule"
 msgstr "Prijavi se pri oddaljenem aMule"
 
-#: src/muuli_wdr.cpp:3074
+#: src/muuli_wdr.cpp:3078
 msgid "User name"
 msgstr "Uporabniško ime"
 
-#: src/muuli_wdr.cpp:3085
+#: src/muuli_wdr.cpp:3089
 msgid "Remember those settings"
 msgstr "Zapomni si te nastavitve"
 
-#: src/muuli_wdr.cpp:3088
+#: src/muuli_wdr.cpp:3092
 #, fuzzy
 msgid "Force ZLIB compression"
 msgstr "Uporabi stiskanje gzip"
 
-#: src/muuli_wdr.cpp:3112
+#: src/muuli_wdr.cpp:3116
 msgid "Enable Verbose Debug-Logging."
 msgstr "Omogoči podrobno beleženje za razhroščevanje."
 
-#: src/muuli_wdr.cpp:3114
+#: src/muuli_wdr.cpp:3118
 msgid "Only to Logfile"
 msgstr "Samo v dnevniško datoteko"
 
-#: src/muuli_wdr.cpp:3116
+#: src/muuli_wdr.cpp:3120
 msgid "Message Categories:"
 msgstr "Kategorije sporočil:"
 
-#: src/muuli_wdr.cpp:3140 src/PartFileConvertDlg.cpp:160
+#: src/muuli_wdr.cpp:3144 src/PartFileConvertDlg.cpp:160
 msgid "Waiting..."
 msgstr "Čakanje …"
 
-#: src/muuli_wdr.cpp:3160
+#: src/muuli_wdr.cpp:3164
 msgid "Add imports"
 msgstr "Dodaj uvoze"
 
-#: src/muuli_wdr.cpp:3163
+#: src/muuli_wdr.cpp:3167
 msgid "Retry selected"
 msgstr "Ponovno poskusi izbrane"
 
-#: src/muuli_wdr.cpp:3165
+#: src/muuli_wdr.cpp:3169
 msgid "Remove selected"
 msgstr "Odstrani izbrane"
 
-#: src/muuli_wdr.cpp:3228
+#: src/muuli_wdr.cpp:3232
 msgid "Event Types"
 msgstr "Vrste dogodkov"
 
-#: src/muuli_wdr.cpp:3247
+#: src/muuli_wdr.cpp:3251
 msgid "Statistics and queued clients for selected file(s) : Session / All time"
 msgstr "Statistika in odjemalci v vrsti za izbrane datoteke: seja / ves čas"
 
-#: src/muuli_wdr.cpp:3271
+#: src/muuli_wdr.cpp:3275
 msgid "Active Uploads"
 msgstr "Dejavna pošiljanja"
 
-#: src/muuli_wdr.cpp:3285
+#: src/muuli_wdr.cpp:3289
 msgid "Percent of total files"
 msgstr "Odstotek vseh datotek"
 
-#: src/muuli_wdr.cpp:3337
+#: src/muuli_wdr.cpp:3341
 msgid "Show Clients for"
 msgstr "Prikaži odjemalce za"
 
-#: src/muuli_wdr.cpp:3339
+#: src/muuli_wdr.cpp:3343
 msgid "All files"
 msgstr "Vse datoteke"
 
-#: src/muuli_wdr.cpp:3342
+#: src/muuli_wdr.cpp:3346
 msgid "Selected files"
 msgstr "Izbrane datoteke"
 
-#: src/muuli_wdr.cpp:3345
+#: src/muuli_wdr.cpp:3349
 msgid "Active uploads only"
 msgstr "Samo dejavna pošiljanja"
 
-#: src/muuli_wdr.cpp:3352
+#: src/muuli_wdr.cpp:3356
 msgid "Reload:"
 msgstr "Znova naloži"
 
-#: src/muuli_wdr.cpp:3356
+#: src/muuli_wdr.cpp:3360
 msgid "Reload your shared files"
 msgstr "Ponovno naloži deljene datoteke"
 
-#: src/muuli_wdr.cpp:3419
+#: src/muuli_wdr.cpp:3423
 msgid "Send"
 msgstr "Pošlji"
 
-#: src/muuli_wdr.cpp:3420
+#: src/muuli_wdr.cpp:3424
 msgid "Sends the specified message."
 msgstr "Pošlje navedeno sporočilo."
 
-#: src/muuli_wdr.cpp:3424
+#: src/muuli_wdr.cpp:3428
 msgid "Close this chat-session."
 msgstr "Zapri to pogovorno sejo."
 
-#: src/muuli_wdr.cpp:3447
+#: src/muuli_wdr.cpp:3451
 msgid "Connect to any server and/or Kad"
 msgstr "Poveži se s poljubnim strežnikom in/ali s Kad"
 
-#: src/muuli_wdr.cpp:3453 src/SharedFilesCtrl.cpp:142 src/Statistics.cpp:941
+#: src/muuli_wdr.cpp:3457 src/SharedFilesCtrl.cpp:142 src/Statistics.cpp:941
 msgid "Shared Files"
 msgstr "Deljene datoteke"
 
@@ -5789,35 +5789,35 @@ msgstr ""
 "aMule bo deloval dobro tudi brez\n"
 "spreminjanja teh nastavitev."
 
-#: src/PrefsUnifiedDlg.cpp:647
+#: src/PrefsUnifiedDlg.cpp:656
 #, c-format
 msgid "Failed to connect Cfg to widget with the ID %d and key %s"
 msgstr "Nastavitve ni bilo moč povezati z gradnikom z ID-jem %d in ključem %s"
 
-#: src/PrefsUnifiedDlg.cpp:695
+#: src/PrefsUnifiedDlg.cpp:704
 #, c-format
 msgid "Failed to transfer data from Cfg to Widget with the ID %d and key %s"
 msgstr "Podatkov iz nastavitev ni bilo moč prenesti v gradnik z ID-jem %d in ključem %s."
 
-#: src/PrefsUnifiedDlg.cpp:801
+#: src/PrefsUnifiedDlg.cpp:810
 msgid "The type of proxy you are connecting to"
 msgstr "Vrsta posrednika s katerim se hočete povezati"
 
-#: src/PrefsUnifiedDlg.cpp:1020
+#: src/PrefsUnifiedDlg.cpp:1029
 #, c-format
 msgid "Failed to transfer data from Widget to Cfg with the ID %d and key %s"
 msgstr "Podatkov iz gradnika ni bilo moč prenesti v nastavitve z ID-jem %d in ključem %s."
 
-#: src/PrefsUnifiedDlg.cpp:1103
+#: src/PrefsUnifiedDlg.cpp:1112
 #, fuzzy
 msgid "No password set."
 msgstr "Preverjanje gesla\n"
 
-#: src/PrefsUnifiedDlg.cpp:1132
+#: src/PrefsUnifiedDlg.cpp:1141
 msgid "Guest access needs a password. Type one in the guest password field, or untick Enable guest access."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1144
+#: src/PrefsUnifiedDlg.cpp:1153
 msgid ""
 "aMule must be restarted to enable these changes:\n"
 "\n"
@@ -5825,41 +5825,41 @@ msgstr ""
 "Potreben je ponoven zagon aMule za uveljavitev teh sprememb:\n"
 "\n"
 
-#: src/PrefsUnifiedDlg.cpp:1151
+#: src/PrefsUnifiedDlg.cpp:1160
 msgid "- TCP port changed.\n"
 msgstr "• Vrata TCP so spremenjena.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1156
+#: src/PrefsUnifiedDlg.cpp:1165
 msgid "- UDP port changed.\n"
 msgstr "• Vrata UDP so spremenjena.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1161
+#: src/PrefsUnifiedDlg.cpp:1170
 #, fuzzy
 msgid "- Network interface binding changed.\n"
 msgstr "• Vmesnik za zunanje povezave je spremenjen.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1166
+#: src/PrefsUnifiedDlg.cpp:1175
 msgid "- External connect port changed.\n"
 msgstr "• Vrata za zunanje povezave so spremenjena.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1170
+#: src/PrefsUnifiedDlg.cpp:1179
 msgid "- External connect acceptance changed.\n"
 msgstr "• Sprejemljivost zunanjih povezav je spremenjena.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1174
+#: src/PrefsUnifiedDlg.cpp:1183
 msgid "- External connect interface changed.\n"
 msgstr "• Vmesnik za zunanje povezave je spremenjen.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1178
+#: src/PrefsUnifiedDlg.cpp:1187
 msgid "- Protocol obfuscation support changed.\n"
 msgstr "• Podpora za maskiranje protokola je bila spremenjena.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1193
+#: src/PrefsUnifiedDlg.cpp:1202
 #, fuzzy
 msgid "- amuleapi settings changed.\n"
 msgstr "• Jezik je spremenjen.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1202
+#: src/PrefsUnifiedDlg.cpp:1211
 msgid ""
 "Your Auto-update server list is empty.\n"
 "'Auto-update server list at startup' will be disabled."
@@ -5867,7 +5867,7 @@ msgstr ""
 "Seznam za samodejno posodobitev strežnikov je prazen.\n"
 "Možnost »Ob zagonu samodejno posodobi seznam strežnikov« bo onemogočena."
 
-#: src/PrefsUnifiedDlg.cpp:1213
+#: src/PrefsUnifiedDlg.cpp:1222
 msgid ""
 "You have enabled external connections but have not specified a password.\n"
 "External connections cannot be enabled unless a valid password is specified."
@@ -5875,33 +5875,33 @@ msgstr ""
 "Omogočili ste zunanje povezave, vendar niste navedli gesla.\n"
 "Zunanje povezave ne morejo biti omogočene, dokler ne navedete veljavnega gesla."
 
-#: src/PrefsUnifiedDlg.cpp:1246
+#: src/PrefsUnifiedDlg.cpp:1255
 #, c-format
 msgid "The amuleapi password could not be saved: %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1276
+#: src/PrefsUnifiedDlg.cpp:1285
 msgid "- Language changed.\n"
 msgstr "• Jezik je spremenjen.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1281
+#: src/PrefsUnifiedDlg.cpp:1290
 msgid "- Temp folder changed.\n"
 msgstr "• Mapa za začasne datoteke spremenjena.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1286
+#: src/PrefsUnifiedDlg.cpp:1295
 msgid "- ED2K network enabled.\n"
 msgstr "• Omrežje eD2k je omogočeno.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1319
+#: src/PrefsUnifiedDlg.cpp:1328
 msgid "The shared-file exclusion pattern is not a valid regular expression. The filter has been left disabled."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1321 src/PrefsUnifiedDlg.cpp:1921
+#: src/PrefsUnifiedDlg.cpp:1330 src/PrefsUnifiedDlg.cpp:1930
 #, fuzzy
 msgid "Invalid regular expression"
 msgstr "Neveljavna različica protokola."
 
-#: src/PrefsUnifiedDlg.cpp:1398
+#: src/PrefsUnifiedDlg.cpp:1407
 msgid ""
 "Both eD2k and Kad network are disabled.\n"
 "You won't be able to connect until you enable at least one of them."
@@ -5909,7 +5909,7 @@ msgstr ""
 "Omrežji eD2k in Kad sta onemogočeni.\n"
 "Ne boste se mogli povezati, dokler ne omogočite vsaj enega izmed njih."
 
-#: src/PrefsUnifiedDlg.cpp:1403
+#: src/PrefsUnifiedDlg.cpp:1412
 msgid ""
 "Kad will not start if your UDP port is disabled.\n"
 "Enable UDP port or disable Kad."
@@ -5917,7 +5917,7 @@ msgstr ""
 "Kad se ne bo zagnal, če so vrata UDP onemogočena.\n"
 "Omogočite vrata UDP ali pa onemogočite Kad."
 
-#: src/PrefsUnifiedDlg.cpp:1459
+#: src/PrefsUnifiedDlg.cpp:1468
 msgid ""
 "\n"
 "You MUST restart aMule now.\n"
@@ -5927,69 +5927,69 @@ msgstr ""
 "aMule morate NUJNO ponovno zagnati.\n"
 "Če tega ne storite zdaj, se ne pritožujte, če se zgodi kaj slabega.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1524
+#: src/PrefsUnifiedDlg.cpp:1533
 msgid "Could not register aMule for autostart at login. The autostart store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1526
+#: src/PrefsUnifiedDlg.cpp:1535
 msgid "Could not remove the autostart-at-login entry."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1527
+#: src/PrefsUnifiedDlg.cpp:1536
 #, fuzzy
 msgid "Autostart"
 msgstr "Samodejno osveževanje začeto"
 
-#: src/PrefsUnifiedDlg.cpp:1542
+#: src/PrefsUnifiedDlg.cpp:1551
 msgid "Register file type"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1542
+#: src/PrefsUnifiedDlg.cpp:1551
 msgid "Register URL handler"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1550
+#: src/PrefsUnifiedDlg.cpp:1559
 #, c-format
 msgid "aMule only handles eD2k-compatible magnets. If you replace the current magnet handler (%s), BitTorrent magnet links will stop working - aMule cannot download BitTorrent content. Continue?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1555
+#: src/PrefsUnifiedDlg.cpp:1564
 #, c-format
 msgid "Another application currently opens .emulecollection files (%s). Replace it with aMule?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1560
+#: src/PrefsUnifiedDlg.cpp:1569
 #, c-format
 msgid "Another application is currently the default handler for these links (%s). Replace it with aMule?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1585
+#: src/PrefsUnifiedDlg.cpp:1594
 msgid "Could not register aMule for .emulecollection files. The registration store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1587
+#: src/PrefsUnifiedDlg.cpp:1596
 #, fuzzy
 msgid "Could not remove the file type registration."
 msgstr "Mapa za začasne datoteke prejemanj"
 
-#: src/PrefsUnifiedDlg.cpp:1589
+#: src/PrefsUnifiedDlg.cpp:1598
 msgid "Could not register aMule as the URL handler. The registration store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1591
+#: src/PrefsUnifiedDlg.cpp:1600
 msgid "Could not remove the URL handler registration."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1661 src/PrefsUnifiedDlg.cpp:1688
+#: src/PrefsUnifiedDlg.cpp:1670 src/PrefsUnifiedDlg.cpp:1697
 #, fuzzy
 msgid "The web server and aMule API require external connections to be enabled."
 msgstr "Geslo je bilo nastavljeno in zunanje povezave omogočene."
 
-#: src/PrefsUnifiedDlg.cpp:1671
+#: src/PrefsUnifiedDlg.cpp:1680
 msgid "The aMule web server is deprecated. Consider running the aMule API instead."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1735
+#: src/PrefsUnifiedDlg.cpp:1744
 msgid ""
 "Your Auto-update servers list is in blank.\n"
 "Please fill in at least one URL to point to a valid server.met file.\n"
@@ -5999,24 +5999,24 @@ msgstr ""
 "Vnesite vsaj en URL do veljavne datoteke server.met.\n"
 "Kliknite na gumb »Seznam«, zraven potrditvenega polja, za vnos URL-ja."
 
-#: src/PrefsUnifiedDlg.cpp:1876
+#: src/PrefsUnifiedDlg.cpp:1885
 msgid "Temporary files"
 msgstr "Začasne datoteke"
 
-#: src/PrefsUnifiedDlg.cpp:1881
+#: src/PrefsUnifiedDlg.cpp:1890
 msgid "Incoming files"
 msgstr "Prejete datoteke"
 
-#: src/PrefsUnifiedDlg.cpp:1886
+#: src/PrefsUnifiedDlg.cpp:1895
 msgid "Online Signatures"
 msgstr "Spletni podpisi"
 
-#: src/PrefsUnifiedDlg.cpp:1899
+#: src/PrefsUnifiedDlg.cpp:1908
 #, c-format
 msgid "Choose a folder for %s"
 msgstr "Izberite mapo za %s"
 
-#: src/PrefsUnifiedDlg.cpp:1923
+#: src/PrefsUnifiedDlg.cpp:1932
 #, fuzzy, c-format
 msgid "Would exclude %u of %u shared file"
 msgid_plural "Would exclude %u of %u shared files"
@@ -6025,42 +6025,42 @@ msgstr[1] "Najdena %i znana deljena datoteka"
 msgstr[2] "Najdeni %i znani deljeni datoteki"
 msgstr[3] "Najdene %i znane deljene datoteke"
 
-#: src/PrefsUnifiedDlg.cpp:1940
+#: src/PrefsUnifiedDlg.cpp:1949
 msgid "Browse for videoplayer"
 msgstr "Prebrskajte za video predvajalnik"
 
-#: src/PrefsUnifiedDlg.cpp:1944
+#: src/PrefsUnifiedDlg.cpp:1953
 msgid "Select browser"
 msgstr "Izberite brskalnik"
 
-#: src/PrefsUnifiedDlg.cpp:1948
+#: src/PrefsUnifiedDlg.cpp:1957
 #, fuzzy
 msgid "Select ffprobe binary"
 msgstr "Izberite brskalnik"
 
-#: src/PrefsUnifiedDlg.cpp:1954
+#: src/PrefsUnifiedDlg.cpp:1963
 #, c-format
 msgid "Executable%s"
 msgstr "Izvedljiva datoteka %s"
 
-#: src/PrefsUnifiedDlg.cpp:1988
+#: src/PrefsUnifiedDlg.cpp:1997
 msgid "ffprobe not found on PATH or in the standard install locations. Install ffmpeg (which ships ffprobe) or use Browse to pick a binary manually."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2000
+#: src/PrefsUnifiedDlg.cpp:2009
 msgid "Reset the settings on this page to their default values?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2001
+#: src/PrefsUnifiedDlg.cpp:2010
 #, fuzzy
 msgid "Reset to defaults"
 msgstr "Sistemsko privzet"
 
-#: src/PrefsUnifiedDlg.cpp:2028
+#: src/PrefsUnifiedDlg.cpp:2037
 msgid "Edit server list"
 msgstr "Uredi seznam strežnikov"
 
-#: src/PrefsUnifiedDlg.cpp:2029
+#: src/PrefsUnifiedDlg.cpp:2038
 msgid ""
 "Add here URL's to download server.met files.\n"
 "Only one url on each line."
@@ -6068,42 +6068,42 @@ msgstr ""
 "Sem dodajte URL-je do datotek server.met.\n"
 "Po en URL v vsako vrstico."
 
-#: src/PrefsUnifiedDlg.cpp:2084
+#: src/PrefsUnifiedDlg.cpp:2093
 msgid "IP2Country update failed"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2229 src/PrefsUnifiedDlg.cpp:2260
+#: src/PrefsUnifiedDlg.cpp:2238 src/PrefsUnifiedDlg.cpp:2269
 msgid "Data by MaxMind GeoLite2"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2231 src/PrefsUnifiedDlg.cpp:2262
+#: src/PrefsUnifiedDlg.cpp:2240 src/PrefsUnifiedDlg.cpp:2271
 #, fuzzy
 msgid "Custom source"
 msgstr "Popolnih virov"
 
-#: src/PrefsUnifiedDlg.cpp:2233 src/PrefsUnifiedDlg.cpp:2264
+#: src/PrefsUnifiedDlg.cpp:2242 src/PrefsUnifiedDlg.cpp:2273
 msgid "Data by DB-IP.com"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2284
+#: src/PrefsUnifiedDlg.cpp:2293
 #, fuzzy, c-format
 msgid "Status: Loaded%s"
 msgstr "Stanje:"
 
-#: src/PrefsUnifiedDlg.cpp:2286
+#: src/PrefsUnifiedDlg.cpp:2295
 #, fuzzy, c-format
 msgid "Status: Loaded%s - %s"
 msgstr "Stanje:"
 
-#: src/PrefsUnifiedDlg.cpp:2290
+#: src/PrefsUnifiedDlg.cpp:2299
 msgid "Status: Failed to load - click 'Update now' to refresh."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2292
+#: src/PrefsUnifiedDlg.cpp:2301
 msgid "Status: Not found - click 'Update now' to download."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2350 src/PrefsUnifiedDlg.cpp:2374
+#: src/PrefsUnifiedDlg.cpp:2359 src/PrefsUnifiedDlg.cpp:2383
 #, c-format
 msgid "Update delay: %d second"
 msgid_plural "Update delay: %d seconds"
@@ -6112,7 +6112,7 @@ msgstr[1] "Osveži vsakih: %d sekundo"
 msgstr[2] "Osveži vsakih: %d sekundi"
 msgstr[3] "Osveži vsakih: %d sekunde"
 
-#: src/PrefsUnifiedDlg.cpp:2358
+#: src/PrefsUnifiedDlg.cpp:2367
 #, c-format
 msgid "Time for average graph: %d minute"
 msgid_plural "Time for average graph: %d minutes"
@@ -6121,12 +6121,12 @@ msgstr[1] "Čas za graf trenutnega povprečja: %i minuta"
 msgstr[2] "Čas za graf trenutnega povprečja: %i minuti"
 msgstr[3] "Čas za graf trenutnega povprečja: %i minute"
 
-#: src/PrefsUnifiedDlg.cpp:2367
+#: src/PrefsUnifiedDlg.cpp:2376
 #, c-format
 msgid "Connections Graph Scale: %d"
 msgstr "Merilo za graf povezav: %d"
 
-#: src/PrefsUnifiedDlg.cpp:2382
+#: src/PrefsUnifiedDlg.cpp:2391
 #, c-format
 msgid "File Buffer Size: %d byte"
 msgid_plural "File Buffer Size: %d bytes"
@@ -6135,7 +6135,7 @@ msgstr[1] "Datotečni medpomnilnik: %d bajt"
 msgstr[2] "Datotečni medpomnilnik: %d bajta"
 msgstr[3] "Datotečni medpomnilnik: %d bajti"
 
-#: src/PrefsUnifiedDlg.cpp:2392
+#: src/PrefsUnifiedDlg.cpp:2401
 #, c-format
 msgid "Upload Queue Size: %d client"
 msgid_plural "Upload Queue Size: %d clients"
@@ -6144,7 +6144,7 @@ msgstr[1] "Velikost vrste za pošiljanje: %d odjemalec"
 msgstr[2] "Velikost vrste za pošiljanje: %d odjemalca"
 msgstr[3] "Velikost vrste za pošiljanje: %d odjemalci"
 
-#: src/PrefsUnifiedDlg.cpp:2402
+#: src/PrefsUnifiedDlg.cpp:2411
 #, c-format
 msgid "Server connection refresh interval: %d minute"
 msgid_plural "Server connection refresh interval: %d minutes"
@@ -6153,79 +6153,79 @@ msgstr[1] "Čas med osvežitvama povezave na strežnik: %d minuta"
 msgstr[2] "Čas med osvežitvama povezave na strežnik: %d minuti"
 msgstr[3] "Čas med osvežitvama povezave na strežnik: %d minute"
 
-#: src/PrefsUnifiedDlg.cpp:2407
+#: src/PrefsUnifiedDlg.cpp:2416
 msgid "Server connection refresh interval: Disabled"
 msgstr "Čas med osvežitvama povezave na strežnik: onemogočeno"
 
-#: src/PrefsUnifiedDlg.cpp:2451
+#: src/PrefsUnifiedDlg.cpp:2460
 msgid "disabled"
 msgstr "onemogočeno"
 
-#: src/PrefsUnifiedDlg.cpp:2477
+#: src/PrefsUnifiedDlg.cpp:2486
 #, c-format
 msgid "Execute command on '%s' event"
 msgstr "Izvrši ukaz ob dogodku »%s«"
 
-#: src/PrefsUnifiedDlg.cpp:2484
+#: src/PrefsUnifiedDlg.cpp:2493
 msgid "Enable command execution on core"
 msgstr "Omogoči izvrševanje ukazov na jedru"
 
-#: src/PrefsUnifiedDlg.cpp:2496
+#: src/PrefsUnifiedDlg.cpp:2505
 msgid "Core command:"
 msgstr "Ukaz jedra:"
 
-#: src/PrefsUnifiedDlg.cpp:2512
+#: src/PrefsUnifiedDlg.cpp:2521
 msgid "Enable command execution on GUI"
 msgstr "Omogoči izvrševanje ukazov v vmesniku"
 
-#: src/PrefsUnifiedDlg.cpp:2524
+#: src/PrefsUnifiedDlg.cpp:2533
 msgid "GUI command:"
 msgstr "Ukaz vmesnika:"
 
-#: src/PrefsUnifiedDlg.cpp:2540
+#: src/PrefsUnifiedDlg.cpp:2549
 msgid "The following variables will be replaced:"
 msgstr "Sledeče spremenljivke bodo nadomeščene:"
 
-#: src/PrefsUnifiedDlg.cpp:2708
+#: src/PrefsUnifiedDlg.cpp:2717
 msgid ""
 "The following folders look like system or sensitive locations:\n"
 "\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2713
+#: src/PrefsUnifiedDlg.cpp:2722
 msgid "Sharing them recursively will publish every file underneath on the eD2k/Kad networks. Do you really want to do this?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2716
+#: src/PrefsUnifiedDlg.cpp:2725
 #, fuzzy
 msgid "Confirm shared folders"
 msgstr "Deljene mape"
 
-#: src/PrefsUnifiedDlg.cpp:2744
+#: src/PrefsUnifiedDlg.cpp:2753
 #, fuzzy
 msgid "Reloading shared files..."
 msgstr "Ponovno naloži deljene datoteke"
 
-#: src/PrefsUnifiedDlg.cpp:2745
+#: src/PrefsUnifiedDlg.cpp:2754
 msgid "Scanning for subdirectories..."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2746
+#: src/PrefsUnifiedDlg.cpp:2755
 #, fuzzy
 msgid "Updating shared folders"
 msgstr "Deljene mape"
 
-#: src/PrefsUnifiedDlg.cpp:2773
+#: src/PrefsUnifiedDlg.cpp:2782
 #, c-format
 msgid "Scanned %u directories..."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2823
+#: src/PrefsUnifiedDlg.cpp:2832
 #, fuzzy, c-format
 msgid "Reloading shared files: %u files scanned"
 msgstr "Ponovno naloži seznam deljenih datotek."
 
-#: src/PrefsUnifiedDlg.cpp:2873
+#: src/PrefsUnifiedDlg.cpp:2882
 #, fuzzy
 msgid "Shared folder"
 msgstr "Deljene mape"
@@ -7916,12 +7916,12 @@ msgstr "Odstrani kategorijo"
 msgid "Hashset requested for unknown file: %s"
 msgstr "Zahtevan je bil nabor kod za neznano datoteko: %s"
 
-#: src/UploadQueue.cpp:618
+#: src/UploadQueue.cpp:627
 #, c-format
 msgid "Resuming uploads of file: %s"
 msgstr "Nadaljevanje ppošiljanja za datoteko: %s"
 
-#: src/UploadQueue.cpp:634
+#: src/UploadQueue.cpp:643
 #, c-format
 msgid "Suspending upload of file: %s"
 msgstr "Ustavljanje pošiljanja za datoteko: %s"

--- a/po/sl.po
+++ b/po/sl.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-28 08:06+0200\n"
+"POT-Creation-Date: 2026-07-28 10:19+0200\n"
 "PO-Revision-Date: 2026-07-27 11:45+0000\n"
 "Last-Translator: Jure Repinc <jlp@holodeck1.com>\n"
 "Language-Team: Slovenian\n"
@@ -146,7 +146,7 @@ msgstr ""
 msgid "Not now"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:422 src/amuleDlg.cpp:600
+#: src/AppImageIntegration.cpp:422 src/amuleDlg.cpp:665
 msgid "Don't ask again"
 msgstr ""
 
@@ -219,7 +219,7 @@ msgid "Killing amuleweb instance with pid '%d' ... "
 msgstr "Ubijanje izvoda amuleweb s PID »%d« ... "
 
 #: src/amule.cpp:336 src/amule.cpp:349 src/ClientRef.cpp:180
-#: src/SearchDlg.cpp:880 src/ServerListCtrl.cpp:98
+#: src/SearchDlg.cpp:1041 src/ServerListCtrl.cpp:98
 msgid "Failed"
 msgstr "Neuspeh"
 
@@ -577,31 +577,69 @@ msgstr "Ni moč ustvariti datoteke PID"
 msgid "ERROR: %s"
 msgstr "NAPAKA: %s"
 
-#: src/amuleDlg.cpp:236
+#: src/amuleDlg.cpp:250
 #, c-format
 msgid "This is aMule %s based on eMule."
 msgstr "To je aMule %s, ki temelji na eMule."
 
-#: src/amuleDlg.cpp:237
+#: src/amuleDlg.cpp:251
 #, c-format
 msgid "Running on %s"
 msgstr "Operacijski sistem: %s"
 
-#: src/amuleDlg.cpp:239
+#: src/amuleDlg.cpp:253
 #, fuzzy
 msgid "Visit https://github.com/amule-org/amule/releases/latest to check if a new version is available."
 msgstr "Obiščite https://github.com/amule-org/amule/releases/latest da preverite, če je na voljo nova različica."
 
-#: src/amuleDlg.cpp:268
+#: src/amuleDlg.cpp:282
 msgid "FATAL ERROR: Failed to create Timer"
 msgstr "USODNA NAPAKA: ustvaritev časomerilnika ni uspela"
 
-#: src/amuleDlg.cpp:592
+#: src/amuleDlg.cpp:361 src/amuleDlg.cpp:1787 src/amuleDlg.cpp:2033
+#: src/muuli_wdr.cpp:1492 src/muuli_wdr.cpp:3418
+msgid "Networks"
+msgstr "Omrežja"
+
+#: src/amuleDlg.cpp:362 src/amuleDlg.cpp:1793 src/muuli_wdr.cpp:3419
+msgid "Searches"
+msgstr "Iskanja"
+
+#: src/amuleDlg.cpp:363 src/amuleDlg.cpp:1799 src/DownloadListCtrl.cpp:740
+#: src/muuli_wdr.cpp:392 src/muuli_wdr.cpp:1585 src/muuli_wdr.cpp:3420
+#: src/Statistics.cpp:829
+msgid "Downloads"
+msgstr "Prejemanja"
+
+#: src/amuleDlg.cpp:364 src/amuleDlg.cpp:1805 src/muuli_wdr.cpp:3294
+msgid "Shared files"
+msgstr "Deljene datoteke"
+
+#: src/amuleDlg.cpp:365 src/amuleDlg.cpp:1811 src/muuli_wdr.cpp:2926
+#: src/muuli_wdr.cpp:3376 src/muuli_wdr.cpp:3423
+msgid "Messages"
+msgstr "Sporočila"
+
+#: src/amuleDlg.cpp:366 src/amuleDlg.cpp:1817 src/muuli_wdr.cpp:3424
+#: src/PrefsUnifiedDlg.cpp:312 src/Statistics.cpp:779 src/Statistics.cpp:1235
+msgid "Statistics"
+msgstr "Statistika"
+
+#: src/amuleDlg.cpp:368 src/amuleDlg.cpp:1824 src/muuli_wdr.cpp:3426
+#: src/PrefsUnifiedDlg.cpp:328 src/utils/wxCas/src/wxcasprefs.cpp:39
+msgid "Preferences"
+msgstr "Nastavitve"
+
+#: src/amuleDlg.cpp:371
+msgid "Navigate"
+msgstr ""
+
+#: src/amuleDlg.cpp:657
 #, fuzzy
 msgid "New version available"
 msgstr "Ni na voljo"
 
-#: src/amuleDlg.cpp:596
+#: src/amuleDlg.cpp:661
 #, fuzzy, c-format
 msgid ""
 "A new version of aMule (%s) is available.\n"
@@ -611,217 +649,184 @@ msgid ""
 "Would you like to open the download page?"
 msgstr "Najnovejšo različico lahko vedno najdete na https://github.com/amule-org/amule/releases/latest"
 
-#: src/amuleDlg.cpp:678
+#: src/amuleDlg.cpp:743
 msgid "aMule dialog destroyed"
 msgstr "Pogovorno okno aMule je bilo uničeno"
 
-#: src/amuleDlg.cpp:701 src/DataToText.cpp:68 src/IPFilter.cpp:547
+#: src/amuleDlg.cpp:766 src/DataToText.cpp:68 src/IPFilter.cpp:547
 msgid "Connecting"
 msgstr "Povezovanje"
 
-#: src/amuleDlg.cpp:893
+#: src/amuleDlg.cpp:958
 msgid "eD2k: Connecting"
 msgstr "eD2k: povezovanje"
 
-#: src/amuleDlg.cpp:897
+#: src/amuleDlg.cpp:962
 msgid "eD2k: Disconnected"
 msgstr "eD2k: povezava prekinjena"
 
-#: src/amuleDlg.cpp:903
+#: src/amuleDlg.cpp:968
 msgid "Kad: Firewalled"
 msgstr "Kad: za požarnim zidom"
 
-#: src/amuleDlg.cpp:907
+#: src/amuleDlg.cpp:972
 msgid "Kad: Connected"
 msgstr "Kad: povezano"
 
-#: src/amuleDlg.cpp:912
+#: src/amuleDlg.cpp:977
 msgid "Kad: Connecting"
 msgstr "Kad: povezovanje"
 
-#: src/amuleDlg.cpp:916
+#: src/amuleDlg.cpp:981
 msgid "Kad: Off"
 msgstr "Kad: izklopljen"
 
-#: src/amuleDlg.cpp:964 src/DownloadListCtrl.cpp:505
+#: src/amuleDlg.cpp:1029 src/DownloadListCtrl.cpp:505
 #: src/DownloadListCtrl.cpp:749 src/FriendListCtrl.cpp:180
 #: src/muuli_wdr.cpp:731 src/muuli_wdr.cpp:782 src/muuli_wdr.cpp:846
-#: src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2224 src/muuli_wdr.cpp:2309
-#: src/muuli_wdr.cpp:3057 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
+#: src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2231 src/muuli_wdr.cpp:2316
+#: src/muuli_wdr.cpp:3064 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
 #: src/ServerListCtrl.cpp:606 src/TransferWnd.cpp:378
 #: src/utils/wxCas/src/wxcasprefs.cpp:235
 msgid "Cancel"
 msgstr "Prekliči"
 
-#: src/amuleDlg.cpp:965
+#: src/amuleDlg.cpp:1030
 msgid "Stop the current connection attempts"
 msgstr "Ustavi trenutne poskuse povezovanja"
 
-#: src/amuleDlg.cpp:970 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976
-#: src/muuli_wdr.cpp:2447
+#: src/amuleDlg.cpp:1035 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976
+#: src/muuli_wdr.cpp:2454
 msgid "Disconnect"
 msgstr "Prekini povezave"
 
-#: src/amuleDlg.cpp:971
+#: src/amuleDlg.cpp:1036
 msgid "Disconnect from the currently connected networks"
 msgstr "Prekini povezavo s trenutno povezanimi omrežji"
 
-#: src/amuleDlg.cpp:976 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979
-#: src/muuli_wdr.cpp:2602 src/muuli_wdr.cpp:3054 src/muuli_wdr.cpp:3409
+#: src/amuleDlg.cpp:1041 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979
+#: src/muuli_wdr.cpp:2609 src/muuli_wdr.cpp:3061 src/muuli_wdr.cpp:3416
 msgid "Connect"
 msgstr "Poveži se"
 
-#: src/amuleDlg.cpp:977
+#: src/amuleDlg.cpp:1042
 msgid "Connect to the currently enabled networks"
 msgstr "Poveži se s trenutno omogočenimi omrežji"
 
-#: src/amuleDlg.cpp:1089
+#: src/amuleDlg.cpp:1154
 #, c-format
 msgid "Up: %.1f%s (%.1f) | Down: %.1f%s (%.1f)"
 msgstr "Gor: %.1f%s (%.1f) | Dol: %.1f%s (%.1f)"
 
-#: src/amuleDlg.cpp:1091 src/amuleDlg.cpp:1093 src/amuleDlg.cpp:1097
-#: src/amuleDlg.cpp:1099 src/amuleDlg.cpp:1110 src/amuleDlg.cpp:1112
+#: src/amuleDlg.cpp:1156 src/amuleDlg.cpp:1158 src/amuleDlg.cpp:1162
+#: src/amuleDlg.cpp:1164 src/amuleDlg.cpp:1175 src/amuleDlg.cpp:1177
 #: src/MuleTrayIcon.cpp:796 src/MuleTrayIcon.cpp:799
 msgid " MB/s"
 msgstr " MiB/s"
 
-#: src/amuleDlg.cpp:1091 src/amuleDlg.cpp:1093 src/amuleDlg.cpp:1097
-#: src/amuleDlg.cpp:1099 src/amuleDlg.cpp:1110 src/amuleDlg.cpp:1112
+#: src/amuleDlg.cpp:1156 src/amuleDlg.cpp:1158 src/amuleDlg.cpp:1162
+#: src/amuleDlg.cpp:1164 src/amuleDlg.cpp:1175 src/amuleDlg.cpp:1177
 #: src/MuleTrayIcon.cpp:796 src/MuleTrayIcon.cpp:799
 #: src/utils/wxCas/src/wxcasframe.cpp:1041
 msgid " kB/s"
 msgstr " kB/s"
 
-#: src/amuleDlg.cpp:1096
+#: src/amuleDlg.cpp:1161
 #, c-format
 msgid "Up: %.1f%s | Down: %.1f%s"
 msgstr "Gor: %.1f%s | Dol: %.1f%s"
 
-#: src/amuleDlg.cpp:1128
+#: src/amuleDlg.cpp:1193
 #, c-format
 msgid "aMule (%s | Connected)"
 msgstr "aMule (%s | Povezano)"
 
-#: src/amuleDlg.cpp:1130
+#: src/amuleDlg.cpp:1195
 #, c-format
 msgid "aMule (%s | Disconnected)"
 msgstr "aMule (%s | Ni povezave)"
 
-#: src/amuleDlg.cpp:1183
+#: src/amuleDlg.cpp:1248
 #, c-format
 msgid "Do you really want to exit %s?"
 msgstr "Ali res želite zapustiti %s?"
 
-#: src/amuleDlg.cpp:1185
+#: src/amuleDlg.cpp:1250
 msgid "Exit confirmation"
 msgstr "Potrditev izhoda"
 
-#: src/amuleDlg.cpp:1548
+#: src/amuleDlg.cpp:1613
 msgid "Launch Command: "
 msgstr "Zaženi ukaz: "
 
-#: src/amuleDlg.cpp:1567 src/muuli_wdr.cpp:1971 src/Preferences.cpp:951
+#: src/amuleDlg.cpp:1632 src/muuli_wdr.cpp:1978 src/Preferences.cpp:952
 msgid "- default -"
 msgstr "– privzeto –"
 
-#: src/amuleDlg.cpp:1595
+#: src/amuleDlg.cpp:1660
 #, c-format
 msgid "Skin directory '%s' does not exist"
 msgstr "Mapa za preobleke »%s« ne obstaja"
 
-#: src/amuleDlg.cpp:1598
+#: src/amuleDlg.cpp:1663
 #, c-format
 msgid "WARNING: Unable to open skin file '%s' for read"
 msgstr "OPOZORILO: datoteke s preobleko »%s« ni moč odpreti za branje"
 
-#: src/amuleDlg.cpp:1722 src/amuleDlg.cpp:1968 src/muuli_wdr.cpp:1485
-#: src/muuli_wdr.cpp:3411
-msgid "Networks"
-msgstr "Omrežja"
-
-#: src/amuleDlg.cpp:1726 src/muuli_wdr.cpp:3411
+#: src/amuleDlg.cpp:1791 src/muuli_wdr.cpp:3418
 msgid "Networks Window"
 msgstr "Okno z omrežji"
 
-#: src/amuleDlg.cpp:1728 src/muuli_wdr.cpp:3412
-msgid "Searches"
-msgstr "Iskanja"
-
-#: src/amuleDlg.cpp:1732 src/muuli_wdr.cpp:3412
+#: src/amuleDlg.cpp:1797 src/muuli_wdr.cpp:3419
 msgid "Searches Window"
 msgstr "Okno z iskanji"
 
-#: src/amuleDlg.cpp:1734 src/DownloadListCtrl.cpp:740 src/muuli_wdr.cpp:392
-#: src/muuli_wdr.cpp:1578 src/muuli_wdr.cpp:3413 src/Statistics.cpp:829
-msgid "Downloads"
-msgstr "Prejemanja"
-
-#: src/amuleDlg.cpp:1738 src/muuli_wdr.cpp:3413
+#: src/amuleDlg.cpp:1803 src/muuli_wdr.cpp:3420
 msgid "Downloads Window"
 msgstr "Okno s prejemanji"
 
-#: src/amuleDlg.cpp:1740 src/muuli_wdr.cpp:3287
-msgid "Shared files"
-msgstr "Deljene datoteke"
-
-#: src/amuleDlg.cpp:1744 src/muuli_wdr.cpp:3415
+#: src/amuleDlg.cpp:1809 src/muuli_wdr.cpp:3422
 msgid "Shared Files Window"
 msgstr "Okno z deljenimi datotekami"
 
-#: src/amuleDlg.cpp:1746 src/muuli_wdr.cpp:2919 src/muuli_wdr.cpp:3369
-#: src/muuli_wdr.cpp:3416
-msgid "Messages"
-msgstr "Sporočila"
-
-#: src/amuleDlg.cpp:1750 src/muuli_wdr.cpp:3416
+#: src/amuleDlg.cpp:1815 src/muuli_wdr.cpp:3423
 msgid "Messages Window"
 msgstr "Okno s sporočili"
 
-#: src/amuleDlg.cpp:1752 src/muuli_wdr.cpp:3417 src/PrefsUnifiedDlg.cpp:312
-#: src/Statistics.cpp:779 src/Statistics.cpp:1235
-msgid "Statistics"
-msgstr "Statistika"
-
-#: src/amuleDlg.cpp:1756 src/muuli_wdr.cpp:3417
+#: src/amuleDlg.cpp:1821 src/muuli_wdr.cpp:3424
 msgid "Statistics Graph Window"
 msgstr "Okno s statističnimi grafi"
 
-#: src/amuleDlg.cpp:1759 src/muuli_wdr.cpp:3419 src/PrefsUnifiedDlg.cpp:328
-#: src/utils/wxCas/src/wxcasprefs.cpp:39
-msgid "Preferences"
-msgstr "Nastavitve"
-
-#: src/amuleDlg.cpp:1763 src/muuli_wdr.cpp:3419
+#: src/amuleDlg.cpp:1828 src/muuli_wdr.cpp:3426
 msgid "Preferences Settings Window"
 msgstr "Okno z nastavitvami"
 
-#: src/amuleDlg.cpp:1766 src/muuli_wdr.cpp:3420
+#: src/amuleDlg.cpp:1831 src/muuli_wdr.cpp:3427
 msgid "Import"
 msgstr "Uvoz"
 
-#: src/amuleDlg.cpp:1770 src/muuli_wdr.cpp:3420
+#: src/amuleDlg.cpp:1835 src/muuli_wdr.cpp:3427
 msgid "The partfile importer tool"
 msgstr "Orodje za uvažanje delnih datotek"
 
-#: src/amuleDlg.cpp:1773 src/muuli_wdr.cpp:3421
+#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3428
 #: src/utils/aLinkCreator/src/alcframe.cpp:262
 msgid "About"
 msgstr "O programu"
 
-#: src/amuleDlg.cpp:1773 src/muuli_wdr.cpp:3421
+#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3428
 msgid "About/Help"
 msgstr "O programu/pomoč"
 
-#: src/amuleDlg.cpp:1971
+#: src/amuleDlg.cpp:2036
 msgid "eD2k network"
 msgstr "Omrežje eD2k"
 
-#: src/amuleDlg.cpp:1974
+#: src/amuleDlg.cpp:2039
 msgid "Kad network"
 msgstr "Omrežje Kad"
 
-#: src/amuleDlg.cpp:1974
+#: src/amuleDlg.cpp:2039
 msgid "No network"
 msgstr "Brez omrežja"
 
@@ -1364,19 +1369,19 @@ msgstr "Samod. [Vi]"
 msgid "Very low"
 msgstr "Zelo nizka"
 
-#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:743 src/muuli_wdr.cpp:2275
+#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:743 src/muuli_wdr.cpp:2282
 #: src/ServerListCtrl.cpp:263 src/ServerListCtrl.cpp:456
 #: src/SharedFilesCtrl.cpp:145
 msgid "Low"
 msgstr "Nizka"
 
-#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:744 src/muuli_wdr.cpp:2276
+#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:744 src/muuli_wdr.cpp:2283
 #: src/ServerListCtrl.cpp:266 src/ServerListCtrl.cpp:457
 #: src/SharedFilesCtrl.cpp:146
 msgid "Normal"
 msgstr "Običajna"
 
-#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:745 src/muuli_wdr.cpp:2277
+#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:745 src/muuli_wdr.cpp:2284
 #: src/ServerListCtrl.cpp:269 src/ServerListCtrl.cpp:458
 #: src/SharedFilesCtrl.cpp:147
 msgid "High"
@@ -1468,8 +1473,8 @@ msgstr "Krajevni strežnik"
 msgid "Remote Server"
 msgstr "Oddaljni strežnik"
 
-#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3174
-#: src/SearchDlg.cpp:111 src/TextClient.cpp:911
+#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3181
+#: src/SearchDlg.cpp:119 src/TextClient.cpp:911
 msgid "Kad"
 msgstr "Kad"
 
@@ -1540,7 +1545,7 @@ msgstr "Del"
 msgid "Size"
 msgstr "Velikost"
 
-#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3241
+#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3248
 msgid "Transferred"
 msgstr "Preneseno"
 
@@ -1598,7 +1603,7 @@ msgstr ""
 "Odziv od: %s (%s)\n"
 "\n"
 
-#: src/DownloadListCtrl.cpp:746 src/muuli_wdr.cpp:2278
+#: src/DownloadListCtrl.cpp:746 src/muuli_wdr.cpp:2285
 #: src/SharedFilesCtrl.cpp:150
 msgid "Auto"
 msgstr "Samod."
@@ -1636,7 +1641,7 @@ msgid "Extended Options"
 msgstr "Dodatne možnosti"
 
 #: src/DownloadListCtrl.cpp:770 src/DownloadListCtrl.cpp:822
-#: src/muuli_wdr.cpp:1789
+#: src/muuli_wdr.cpp:1796
 msgid "Preview"
 msgstr "Ogled"
 
@@ -2352,19 +2357,19 @@ msgstr ""
 msgid "eD2k"
 msgstr "eD2k"
 
-#: src/FirstRunWizard.cpp:349 src/muuli_wdr.cpp:1488
+#: src/FirstRunWizard.cpp:349 src/muuli_wdr.cpp:1495
 msgid "Kademlia"
 msgstr "Kademlia"
 
-#: src/FirstRunWizard.cpp:359 src/muuli_wdr.cpp:1416
+#: src/FirstRunWizard.cpp:359 src/muuli_wdr.cpp:1423
 msgid "Standard TCP Port "
 msgstr "Standardna vrata TCP "
 
-#: src/FirstRunWizard.cpp:365 src/muuli_wdr.cpp:1428
+#: src/FirstRunWizard.cpp:365 src/muuli_wdr.cpp:1435
 msgid "Extended UDP port (Kad / global search) "
 msgstr "Dodatna vrata UDP (globalno/Kad iskanje) "
 
-#: src/FirstRunWizard.cpp:377 src/muuli_wdr.cpp:1435
+#: src/FirstRunWizard.cpp:377 src/muuli_wdr.cpp:1442
 msgid "Enable UPnP for router port forwarding"
 msgstr "Omogoči posredovanje vrat na usmerjevalniku"
 
@@ -2391,7 +2396,7 @@ msgstr ""
 msgid "Your peer lists are already in place - nothing to download."
 msgstr "Datoteko %s že poskušate prejemati"
 
-#: src/FirstRunWizard.cpp:434 src/muuli_wdr.cpp:1533
+#: src/FirstRunWizard.cpp:434 src/muuli_wdr.cpp:1540
 msgid "Auto-update server list at startup"
 msgstr "Ob zagonu samodejno posodobi seznam strežnikov"
 
@@ -2437,23 +2442,23 @@ msgid ""
 "want downloads on a different (e.g. larger) disk."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:549 src/FirstRunWizard.cpp:611 src/muuli_wdr.cpp:1701
+#: src/FirstRunWizard.cpp:549 src/FirstRunWizard.cpp:611 src/muuli_wdr.cpp:1708
 msgid "Destination folder for downloads"
 msgstr "Ciljna mapa za prejeto"
 
-#: src/FirstRunWizard.cpp:553 src/FirstRunWizard.cpp:569 src/muuli_wdr.cpp:1342
-#: src/muuli_wdr.cpp:1359 src/muuli_wdr.cpp:1676 src/muuli_wdr.cpp:1707
-#: src/muuli_wdr.cpp:1719 src/muuli_wdr.cpp:2762
+#: src/FirstRunWizard.cpp:553 src/FirstRunWizard.cpp:569 src/muuli_wdr.cpp:1349
+#: src/muuli_wdr.cpp:1366 src/muuli_wdr.cpp:1683 src/muuli_wdr.cpp:1714
+#: src/muuli_wdr.cpp:1726 src/muuli_wdr.cpp:2769
 #: src/utils/aLinkCreator/src/alcframe.cpp:135
 #: src/utils/wxCas/src/wxcasprefs.cpp:52 src/utils/wxCas/src/wxcasprefs.cpp:118
 msgid "Browse"
 msgstr "Brskanje"
 
-#: src/FirstRunWizard.cpp:559 src/muuli_wdr.cpp:1712
+#: src/FirstRunWizard.cpp:559 src/muuli_wdr.cpp:1719
 msgid "(All files in this folder are shared with other peers)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:565 src/FirstRunWizard.cpp:624 src/muuli_wdr.cpp:1714
+#: src/FirstRunWizard.cpp:565 src/FirstRunWizard.cpp:624 src/muuli_wdr.cpp:1721
 msgid "Folder for temporary download files"
 msgstr "Mapa za začasne datoteke prejemanj"
 
@@ -2484,7 +2489,7 @@ msgstr "Datoteke s seznamom prijateljev »emfriends.met« ni bilo moč odpreti z
 msgid "CRITICAL - no client on StartChatSession"
 msgstr "KRITIČNO – ni odjemalca za StartChatSession"
 
-#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2668 src/muuli_wdr.cpp:3345
+#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2675 src/muuli_wdr.cpp:3352
 msgid "Friends"
 msgstr "Prijatelji"
 
@@ -2880,7 +2885,7 @@ msgstr "Delilno razmerje"
 msgid "Uploaded"
 msgstr "Poslano"
 
-#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3225
+#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3232
 msgid "Requested"
 msgstr "Zahtevano"
 
@@ -3004,7 +3009,7 @@ msgid "WARNING: "
 msgstr "OPOZORILO: "
 
 #: src/MuleNotebook.cpp:179 src/muuli_wdr.cpp:817 src/muuli_wdr.cpp:1229
-#: src/muuli_wdr.cpp:3129 src/muuli_wdr.cpp:3385
+#: src/muuli_wdr.cpp:3136 src/muuli_wdr.cpp:3392
 msgid "Close"
 msgstr "Zapri"
 
@@ -3017,12 +3022,12 @@ msgstr "Izreži"
 msgid "Copy"
 msgstr "Skopiraj"
 
-#: src/MuleTextCtrl.cpp:88
+#: src/MuleTextCtrl.cpp:88 src/SearchDlg.cpp:261
 msgid "Paste"
 msgstr "Prilepi"
 
 #: src/MuleTextCtrl.cpp:89 src/muuli_wdr.cpp:358 src/muuli_wdr.cpp:757
-#: src/muuli_wdr.cpp:2352 src/muuli_wdr.cpp:2371 src/muuli_wdr.cpp:2393
+#: src/muuli_wdr.cpp:2359 src/muuli_wdr.cpp:2378 src/muuli_wdr.cpp:2400
 #: src/utils/aLinkCreator/src/alcframe.cpp:142
 msgid "Clear"
 msgstr "Počisti"
@@ -3120,8 +3125,8 @@ msgid "Exit"
 msgstr "Končaj"
 
 #: src/MuleTrayIcon.cpp:579 src/MuleTrayIcon.cpp:945 src/MuleTrayIcon.cpp:965
-#: src/muuli_wdr.cpp:1391 src/muuli_wdr.cpp:1399 src/muuli_wdr.cpp:1406
-#: src/muuli_wdr.cpp:1835 src/muuli_wdr.cpp:1841 src/OtherFunctions.cpp:91
+#: src/muuli_wdr.cpp:1398 src/muuli_wdr.cpp:1406 src/muuli_wdr.cpp:1413
+#: src/muuli_wdr.cpp:1842 src/muuli_wdr.cpp:1848 src/OtherFunctions.cpp:91
 #: src/StatisticsDlg.cpp:93 src/StatisticsDlg.cpp:95
 msgid "kB/s"
 msgstr "kB/s"
@@ -3292,7 +3297,7 @@ msgstr "Ime:"
 msgid "Type"
 msgstr "Vrsta"
 
-#: src/muuli_wdr.cpp:215 src/SearchDlg.cpp:110 src/SearchListCtrl.cpp:853
+#: src/muuli_wdr.cpp:215 src/SearchDlg.cpp:118 src/SearchListCtrl.cpp:853
 msgid "Local"
 msgstr "Krajevno"
 
@@ -3363,7 +3368,7 @@ msgstr "Bajtov"
 msgid "KB"
 msgstr "KiB"
 
-#: src/muuli_wdr.cpp:274 src/muuli_wdr.cpp:293 src/muuli_wdr.cpp:1620
+#: src/muuli_wdr.cpp:274 src/muuli_wdr.cpp:293 src/muuli_wdr.cpp:1627
 #: src/OtherFunctions.cpp:64
 msgid "MB"
 msgstr "MiB"
@@ -3380,7 +3385,7 @@ msgstr "Maks. velikost"
 msgid "Availability"
 msgstr "Razpoložljivost"
 
-#: src/muuli_wdr.cpp:312 src/muuli_wdr.cpp:398 src/muuli_wdr.cpp:3290
+#: src/muuli_wdr.cpp:312 src/muuli_wdr.cpp:398 src/muuli_wdr.cpp:3297
 msgid "Filter:"
 msgstr "Filter:"
 
@@ -3412,7 +3417,7 @@ msgstr ""
 msgid "Stop"
 msgstr "Ustavi"
 
-#: src/muuli_wdr.cpp:348 src/muuli_wdr.cpp:1385 src/SearchListCtrl.cpp:732
+#: src/muuli_wdr.cpp:348 src/muuli_wdr.cpp:1392 src/SearchListCtrl.cpp:732
 msgid "Download"
 msgstr "Pridobi"
 
@@ -3443,8 +3448,8 @@ msgstr "Viri datoteke:"
 #: src/muuli_wdr.cpp:1160 src/muuli_wdr.cpp:1167 src/muuli_wdr.cpp:1172
 #: src/muuli_wdr.cpp:1179 src/muuli_wdr.cpp:1184 src/muuli_wdr.cpp:1191
 #: src/muuli_wdr.cpp:1205 src/muuli_wdr.cpp:1212 src/muuli_wdr.cpp:1217
-#: src/muuli_wdr.cpp:1224 src/muuli_wdr.cpp:3227 src/muuli_wdr.cpp:3235
-#: src/muuli_wdr.cpp:3243
+#: src/muuli_wdr.cpp:1224 src/muuli_wdr.cpp:3234 src/muuli_wdr.cpp:3242
+#: src/muuli_wdr.cpp:3250
 msgid "N/A"
 msgstr "Ni na voljo"
 
@@ -3589,7 +3594,7 @@ msgstr ""
 msgid "Album :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:685 src/muuli_wdr.cpp:2247
+#: src/muuli_wdr.cpp:685 src/muuli_wdr.cpp:2254
 msgid "Title :"
 msgstr "Naslov:"
 
@@ -3698,7 +3703,7 @@ msgstr "Uporabniško ime:"
 msgid "Userhash :"
 msgstr "Koda uporabnika:"
 
-#: src/muuli_wdr.cpp:895 src/muuli_wdr.cpp:1741 src/muuli_wdr.cpp:2442
+#: src/muuli_wdr.cpp:895 src/muuli_wdr.cpp:1748 src/muuli_wdr.cpp:2449
 #: src/utils/aLinkCreator/src/alcframe.cpp:137
 msgid "Add"
 msgstr "Dodaj"
@@ -3707,15 +3712,15 @@ msgstr "Dodaj"
 msgid "Download-Speed"
 msgstr "Hitrost prejemanja"
 
-#: src/muuli_wdr.cpp:954 src/muuli_wdr.cpp:989 src/muuli_wdr.cpp:2546
+#: src/muuli_wdr.cpp:954 src/muuli_wdr.cpp:989 src/muuli_wdr.cpp:2553
 msgid "Current"
 msgstr "Trenutno"
 
-#: src/muuli_wdr.cpp:962 src/muuli_wdr.cpp:997 src/muuli_wdr.cpp:2554
+#: src/muuli_wdr.cpp:962 src/muuli_wdr.cpp:997 src/muuli_wdr.cpp:2561
 msgid "Running average"
 msgstr "Trenutno povprečje"
 
-#: src/muuli_wdr.cpp:970 src/muuli_wdr.cpp:1005 src/muuli_wdr.cpp:2562
+#: src/muuli_wdr.cpp:970 src/muuli_wdr.cpp:1005 src/muuli_wdr.cpp:2569
 msgid "Session average"
 msgstr "Povprečje seje"
 
@@ -3727,7 +3732,7 @@ msgstr "Hitrost pošiljanja"
 msgid "Connections"
 msgstr "Povezave"
 
-#: src/muuli_wdr.cpp:1024 src/muuli_wdr.cpp:1860
+#: src/muuli_wdr.cpp:1024 src/muuli_wdr.cpp:1867
 msgid "Active downloads"
 msgstr "Dejavna prejemanja"
 
@@ -3735,7 +3740,7 @@ msgstr "Dejavna prejemanja"
 msgid "Active connections (1:1)"
 msgstr "Dejavne povezave (1:1)"
 
-#: src/muuli_wdr.cpp:1040 src/muuli_wdr.cpp:1861
+#: src/muuli_wdr.cpp:1040 src/muuli_wdr.cpp:1868
 msgid "Active uploads"
 msgstr "Dejavna pošiljanja"
 
@@ -3852,8 +3857,8 @@ msgstr "To je ime, ki ga vidijo ostali uporabniki, ko se povežejo z vami."
 msgid "Language: "
 msgstr "Jezik: "
 
-#: src/muuli_wdr.cpp:1257 src/muuli_wdr.cpp:1323 src/muuli_wdr.cpp:1327
-#: src/muuli_wdr.cpp:1330
+#: src/muuli_wdr.cpp:1257 src/muuli_wdr.cpp:1330 src/muuli_wdr.cpp:1334
+#: src/muuli_wdr.cpp:1337
 msgid "The delay before showing tool-tips."
 msgstr "Zakasnitev preden se pojavi namig z navodili."
 
@@ -3931,938 +3936,947 @@ msgstr "Prikaži obvestilo ob zaključku prejemanja"
 msgid "Enabling this will make aMule to show notifications when finished downloading."
 msgstr "Če to omogočite, bo aMule ob zaključku prejemanja prikazal obvestilo."
 
-#: src/muuli_wdr.cpp:1322
+#: src/muuli_wdr.cpp:1323
+#, fuzzy
+msgid "Remember search history"
+msgstr "Zapomni si te nastavitve"
+
+#: src/muuli_wdr.cpp:1324
+msgid "Keeps a dropdown list of your past search terms in the Search tab's Name field. This remembers the queries you typed, not the results they returned."
+msgstr ""
+
+#: src/muuli_wdr.cpp:1329
 msgid "Tooltip delay time: "
 msgstr "Zakasnitev namigov: "
 
-#: src/muuli_wdr.cpp:1329
+#: src/muuli_wdr.cpp:1336
 msgid "seconds"
 msgstr "sekund"
 
-#: src/muuli_wdr.cpp:1333
+#: src/muuli_wdr.cpp:1340
 msgid "Browser Selection"
 msgstr "Izbira brskalnika"
 
-#: src/muuli_wdr.cpp:1339
+#: src/muuli_wdr.cpp:1346
 msgid "Enter your browser name here. Leave this field empty to use the system default browser."
 msgstr "Sem vnesite ime brskalnika. Za uporabo privzetega sistemskega brskalnika pustite prazno."
 
-#: src/muuli_wdr.cpp:1346
+#: src/muuli_wdr.cpp:1353
 msgid "Open in new tab if possible"
 msgstr "Odpri v novem zavihku, če je mogoče"
 
-#: src/muuli_wdr.cpp:1348
+#: src/muuli_wdr.cpp:1355
 msgid "Open the web page in a new tab instead of in a new window when possible"
 msgstr "Če je mogoče, odpre stran v novem zavihku namesto v novem oknu."
 
-#: src/muuli_wdr.cpp:1352
+#: src/muuli_wdr.cpp:1359
 msgid "Video Player"
 msgstr "Video predvajalnik"
 
-#: src/muuli_wdr.cpp:1379
+#: src/muuli_wdr.cpp:1386
 msgid "Bandwidth limits"
 msgstr "Omejitve povezave"
 
-#: src/muuli_wdr.cpp:1393
+#: src/muuli_wdr.cpp:1400
 msgid "Upload"
 msgstr "Pošlji"
 
-#: src/muuli_wdr.cpp:1401
+#: src/muuli_wdr.cpp:1408
 msgid "Slot Allocation"
 msgstr "Hitrost za eno mesto"
 
-#: src/muuli_wdr.cpp:1410
+#: src/muuli_wdr.cpp:1417
 msgid "Ports"
 msgstr "Vrata"
 
-#: src/muuli_wdr.cpp:1420
+#: src/muuli_wdr.cpp:1427
 msgid "This is the standard eD2k port and cannot be disabled."
 msgstr "To so standardna vrata za eD2k in jih ni moč onemogočiti."
 
-#: src/muuli_wdr.cpp:1423
+#: src/muuli_wdr.cpp:1430
 msgid "UDP port for server requests (TCP+3):"
 msgstr "Vrata UDP za zahtevke strežnika (TCP+3):"
 
-#: src/muuli_wdr.cpp:1425
+#: src/muuli_wdr.cpp:1432
 msgid "4665"
 msgstr "4665"
 
-#: src/muuli_wdr.cpp:1432
+#: src/muuli_wdr.cpp:1439
 msgid "This UDP port is used for extended eD2k requests and Kad network"
 msgstr "Ta vrata UDP se uporabljajo za dodatne zahtevke eD2k in omrežje Kad."
 
-#: src/muuli_wdr.cpp:1439
+#: src/muuli_wdr.cpp:1446
 msgid "UPnP TCP Port (Optional):"
 msgstr "Vrata TCP za UPnP (neobvezno):"
 
-#: src/muuli_wdr.cpp:1449
+#: src/muuli_wdr.cpp:1456
 msgid "Bind local address to IP (empty for any):"
 msgstr "Krajevni naslov poveži z IP-jem (prazno za poljuben):"
 
-#: src/muuli_wdr.cpp:1452
+#: src/muuli_wdr.cpp:1459
 msgid "Advanced users only: If you have multiple network interfaces, enter the address of the interface to which aMule should be bound."
 msgstr "Samo za napredne uporabnike: če imate več omrežnih vmesnikov, vnesite naslov vmesnika, s katerim bo povezan aMule."
 
-#: src/muuli_wdr.cpp:1455 src/muuli_wdr.cpp:2054
+#: src/muuli_wdr.cpp:1462 src/muuli_wdr.cpp:2061
 #, fuzzy
 msgid "Bind to network interface (empty for any):"
 msgstr "Krajevni naslov poveži z IP-jem (prazno za poljuben):"
 
-#: src/muuli_wdr.cpp:1468
+#: src/muuli_wdr.cpp:1475
 msgid "Advanced users only: pin all of aMule's traffic to one network interface, chosen from the list or typed in by name (e.g. tun0, eth0, en0) or index. Unlike binding to an IP, this stops traffic leaking out via the default route - useful with a VPN. Requires no elevated privileges."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1474
+#: src/muuli_wdr.cpp:1481
 msgid "Max sources per downloading file:"
 msgstr "Največ virov na prejemanje:"
 
-#: src/muuli_wdr.cpp:1478
+#: src/muuli_wdr.cpp:1485
 msgid "Max simultaneous connections:"
 msgstr "Največ istočasnih povezav:"
 
-#: src/muuli_wdr.cpp:1491 src/muuli_wdr.cpp:3169
+#: src/muuli_wdr.cpp:1498 src/muuli_wdr.cpp:3176
 msgid "ED2K"
 msgstr "eD2k"
 
-#: src/muuli_wdr.cpp:1498
+#: src/muuli_wdr.cpp:1505
 msgid "Autoconnect on startup"
 msgstr "Samodejno se poveži ob zagonu"
 
-#: src/muuli_wdr.cpp:1501
+#: src/muuli_wdr.cpp:1508
 msgid "Reconnect on loss"
 msgstr "Ponovno se poveži ob prekinjeni povezavi"
 
-#: src/muuli_wdr.cpp:1523
+#: src/muuli_wdr.cpp:1530
 msgid "Remove dead server after"
 msgstr "Izbriši nedosegljiv strežnik po"
 
-#: src/muuli_wdr.cpp:1524
+#: src/muuli_wdr.cpp:1531
 msgid "Static servers are never removed, even when unreachable."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1528
+#: src/muuli_wdr.cpp:1535
 msgid "retries"
 msgstr "poskusih"
 
-#: src/muuli_wdr.cpp:1536
+#: src/muuli_wdr.cpp:1543
 msgid "List"
 msgstr "Seznam"
 
-#: src/muuli_wdr.cpp:1539
+#: src/muuli_wdr.cpp:1546
 msgid "Update server list when connecting to a server"
 msgstr "Ob povezavi na strežnik posodobi seznam strežnikov"
 
-#: src/muuli_wdr.cpp:1542
+#: src/muuli_wdr.cpp:1549
 msgid "Update server list when a client connects"
 msgstr "Ob povezavi odjemalca posodobi seznam strežnikov"
 
-#: src/muuli_wdr.cpp:1545
+#: src/muuli_wdr.cpp:1552
 msgid "Use priority system"
 msgstr "Uporabi sistem prednosti"
 
-#: src/muuli_wdr.cpp:1549
+#: src/muuli_wdr.cpp:1556
 msgid "Use smart LowID check on connect"
 msgstr "Uporabi preverjanje za nizek ID ob povezavi"
 
-#: src/muuli_wdr.cpp:1553
+#: src/muuli_wdr.cpp:1560
 msgid "Safe connect"
 msgstr "Varno povezovanje"
 
-#: src/muuli_wdr.cpp:1557
+#: src/muuli_wdr.cpp:1564
 msgid "Autoconnect to servers in static list only"
 msgstr "Samodejna povezava samo na strežnike na statičnem seznamu"
 
-#: src/muuli_wdr.cpp:1560
+#: src/muuli_wdr.cpp:1567
 msgid "Set manually added servers to High Priority"
 msgstr "Nastavi ročno dodane strežnike na visoko prednost"
 
-#: src/muuli_wdr.cpp:1581
+#: src/muuli_wdr.cpp:1588
 msgid "Add files to download in pause mode"
 msgstr "Na novo dodani prejemi naj bodo zaustavljeni"
 
-#: src/muuli_wdr.cpp:1583
+#: src/muuli_wdr.cpp:1590
 msgid "Add files to download with auto priority"
 msgstr "Na novo dodani prejemi naj imajo samodejno prednost"
 
-#: src/muuli_wdr.cpp:1586
+#: src/muuli_wdr.cpp:1593
 msgid "Try to download first and last chunks first"
 msgstr "Najprej poskusi prejeti prvi in zadnji del"
 
-#: src/muuli_wdr.cpp:1590
+#: src/muuli_wdr.cpp:1597
 msgid "Endgame mode: rotate to faster sources for the final blocks"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1593
+#: src/muuli_wdr.cpp:1600
 msgid "Start next paused file when a file completes"
 msgstr "Po zaključku datoteke začni naslednjo prekinjeno"
 
-#: src/muuli_wdr.cpp:1596
+#: src/muuli_wdr.cpp:1603
 msgid "From the same category"
 msgstr "Iz iste kategorije"
 
-#: src/muuli_wdr.cpp:1598
+#: src/muuli_wdr.cpp:1605
 msgid "In alphabetic order"
 msgstr "Po abecednem vrstnem redu"
 
-#: src/muuli_wdr.cpp:1600
+#: src/muuli_wdr.cpp:1607
 msgid "Preallocate disk space for new files"
 msgstr "Novim datotekam vnaprej dodeli prostor na disku"
 
-#: src/muuli_wdr.cpp:1601
+#: src/muuli_wdr.cpp:1608
 msgid "For new files preallocates disk space for the whole file, thus reduces fragmentation"
 msgstr "Za nove datoteke v naprej dodeli prostor na disku v velikosti celotne datoteke, kar zmanjša razdrobljenost."
 
-#: src/muuli_wdr.cpp:1606
+#: src/muuli_wdr.cpp:1613
 msgid "Create new files as sparse files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1607
+#: src/muuli_wdr.cpp:1614
 msgid "A sparse file reserves its full size on disk immediately without writing real data to it -- fast, but unsupported or slow on some filesystems, and free-space accounting stays optimistic while the download is in progress. Turn this off to grow the file only as data arrives."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1612
+#: src/muuli_wdr.cpp:1619
 msgid "Stop downloads when free disk space reaches "
 msgstr "Ustavi prejemanja, ko prostor na disku doseže "
 
-#: src/muuli_wdr.cpp:1613
+#: src/muuli_wdr.cpp:1620
 msgid "Select this if you want aMule to check your disk space"
 msgstr "Izberite, če želite, da aMule preverja prostor na disku"
 
-#: src/muuli_wdr.cpp:1617
+#: src/muuli_wdr.cpp:1624
 msgid "Enter here the min disk space desired."
 msgstr "Sem vnesite min. želen prostor na disku."
 
-#: src/muuli_wdr.cpp:1623
+#: src/muuli_wdr.cpp:1630
 msgid "Save 10 sources on rare files (< 20 sources)"
 msgstr "Shrani 10 virov pri redkih datotekah (< 20 virov)"
 
-#: src/muuli_wdr.cpp:1627 src/Statistics.cpp:790
+#: src/muuli_wdr.cpp:1634 src/Statistics.cpp:790
 msgid "Uploads"
 msgstr "Pošiljanja"
 
-#: src/muuli_wdr.cpp:1630
+#: src/muuli_wdr.cpp:1637
 msgid "Add new shared files with auto priority"
 msgstr "Nove deljene datoteke naj imajo samodejno prednost"
 
-#: src/muuli_wdr.cpp:1636
+#: src/muuli_wdr.cpp:1643
 msgid "Intelligent Corruption Handling (I.C.H.)"
 msgstr "Inteligentno rokovanje s poškodbami (I.R.P.)"
 
-#: src/muuli_wdr.cpp:1639
+#: src/muuli_wdr.cpp:1646
 msgid "Enable"
 msgstr "Omogoči"
 
-#: src/muuli_wdr.cpp:1642
+#: src/muuli_wdr.cpp:1649
 msgid "Advanced I.C.H. trusts every hash (not recommended)"
 msgstr "Napredni I.R.P. zaupa vsaki kodi (ni priporočeno)"
 
-#: src/muuli_wdr.cpp:1654 src/PrefsUnifiedDlg.cpp:1910
+#: src/muuli_wdr.cpp:1661 src/PrefsUnifiedDlg.cpp:1910
 msgid "Media metadata extraction"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1658
+#: src/muuli_wdr.cpp:1665
 msgid "Extract length / bitrate / codec from shared audio and video files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1660
+#: src/muuli_wdr.cpp:1667
 msgid "When enabled, aMule runs ffprobe on each shared media file to fill in the Length / Bitrate / Codec columns other clients see when they find the file in a search. Requires ffmpeg (the ffprobe binary) to be installed."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1667
+#: src/muuli_wdr.cpp:1674
 msgid "Path to ffprobe:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1672
+#: src/muuli_wdr.cpp:1679
 msgid "Full path to the ffprobe binary. Leave empty to have aMule auto-detect it on startup."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1680
+#: src/muuli_wdr.cpp:1687
 msgid "Detect"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1681
+#: src/muuli_wdr.cpp:1688
 msgid "Search the standard install locations for an ffprobe binary and fill the path field."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1705
+#: src/muuli_wdr.cpp:1712
 msgid ""
 "Completed downloads are stored here. All files in this folder are automatically shared with other peers.\n"
 "If this folder also holds files you don't want to share, point it at an aMule-only sub-folder."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1708
+#: src/muuli_wdr.cpp:1715
 msgid "Pick the folder where completed downloads will be stored. All files in that folder will be shared with other peers."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1722
+#: src/muuli_wdr.cpp:1729
 msgid "Shared folders"
 msgstr "Deljene mape"
 
-#: src/muuli_wdr.cpp:1728
+#: src/muuli_wdr.cpp:1735
 msgid "(Folders shared by the core. Enter a path to add one.)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1736
+#: src/muuli_wdr.cpp:1743
 msgid "Absolute path of a folder on the core's machine, e.g. /home/user/shared"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1738 src/PrefsUnifiedDlg.cpp:2794
+#: src/muuli_wdr.cpp:1745 src/PrefsUnifiedDlg.cpp:2794
 msgid "Recursive"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1739
+#: src/muuli_wdr.cpp:1746
 msgid "Share every sub-folder underneath this one, including ones created later."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1743 src/utils/aLinkCreator/src/alcframe.cpp:141
+#: src/muuli_wdr.cpp:1750 src/utils/aLinkCreator/src/alcframe.cpp:141
 msgid "Remove"
 msgstr "Odstrani"
 
-#: src/muuli_wdr.cpp:1747
+#: src/muuli_wdr.cpp:1754
 msgid "(Right click on folder icon for recursive share)"
 msgstr "(desni klik na ikono mape izbere tudi podmape)"
 
-#: src/muuli_wdr.cpp:1754
+#: src/muuli_wdr.cpp:1761
 msgid "Share hidden files"
 msgstr "Deli skrite datoteke"
 
-#: src/muuli_wdr.cpp:1760
+#: src/muuli_wdr.cpp:1767
 msgid "Automatically rescan shared folders for changes"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1766
+#: src/muuli_wdr.cpp:1773
 msgid "Follow symbolic links in shared folders"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1772
+#: src/muuli_wdr.cpp:1779
 msgid "Exclude files matching:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1775
+#: src/muuli_wdr.cpp:1782
 msgid "Wildcard patterns separated by '|', e.g. .DS_Store|Thumbs.db|*.tmp. Files whose name matches are not shared. Matching is case-insensitive."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1779
+#: src/muuli_wdr.cpp:1786
 msgid "Patterns are regular expressions"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1780
+#: src/muuli_wdr.cpp:1787
 msgid "When set, the whole field is one regular expression ('|' is alternation). When unset, it is a list of '|'-separated wildcards."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1790
+#: src/muuli_wdr.cpp:1797
 msgid "Show how many shared files the current pattern would exclude."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1811
+#: src/muuli_wdr.cpp:1818
 msgid "Graphs"
 msgstr "Grafi"
 
-#: src/muuli_wdr.cpp:1814 src/muuli_wdr.cpp:1876
+#: src/muuli_wdr.cpp:1821 src/muuli_wdr.cpp:1883
 msgid "Update delay : 5 secs"
 msgstr "Zamik posodabljanja: 5 sek."
 
-#: src/muuli_wdr.cpp:1818
+#: src/muuli_wdr.cpp:1825
 msgid "Time for average graph: 100 mins"
 msgstr "Čas za graf povprečja: 100 min."
 
-#: src/muuli_wdr.cpp:1822
+#: src/muuli_wdr.cpp:1829
 msgid "Connections Graph Scale: 100 "
 msgstr "Merilo za graf povezav: 100 "
 
-#: src/muuli_wdr.cpp:1829
+#: src/muuli_wdr.cpp:1836
 msgid "Download graph scale:"
 msgstr "Merilo za graf prejemanj:"
 
-#: src/muuli_wdr.cpp:1837
+#: src/muuli_wdr.cpp:1844
 msgid "Upload graph scale:"
 msgstr "Merilo za graf pošiljanj:"
 
-#: src/muuli_wdr.cpp:1847
+#: src/muuli_wdr.cpp:1854
 #, fuzzy
 msgid "Colors: "
 msgstr "Barve: "
 
-#: src/muuli_wdr.cpp:1851
+#: src/muuli_wdr.cpp:1858
 msgid "Background"
 msgstr "Ozadje"
 
-#: src/muuli_wdr.cpp:1852
+#: src/muuli_wdr.cpp:1859
 msgid "Grid"
 msgstr "Mreža"
 
-#: src/muuli_wdr.cpp:1853
+#: src/muuli_wdr.cpp:1860
 msgid "Download current"
 msgstr "Trenutno prejemanje"
 
-#: src/muuli_wdr.cpp:1854
+#: src/muuli_wdr.cpp:1861
 msgid "Download running average"
 msgstr "Povprečje prejemanja"
 
-#: src/muuli_wdr.cpp:1855
+#: src/muuli_wdr.cpp:1862
 msgid "Download session average"
 msgstr "Povprečje seje za prejemanje"
 
-#: src/muuli_wdr.cpp:1856
+#: src/muuli_wdr.cpp:1863
 msgid "Upload current"
 msgstr "Trenutno pošiljanje"
 
-#: src/muuli_wdr.cpp:1857
+#: src/muuli_wdr.cpp:1864
 msgid "Upload running average"
 msgstr "Povprečje pošiljanja"
 
-#: src/muuli_wdr.cpp:1858
+#: src/muuli_wdr.cpp:1865
 msgid "Upload session average"
 msgstr "Povprečje seje za pošiljanje"
 
-#: src/muuli_wdr.cpp:1859
+#: src/muuli_wdr.cpp:1866
 msgid "Active connections"
 msgstr "Dejavne povezave"
 
-#: src/muuli_wdr.cpp:1862
+#: src/muuli_wdr.cpp:1869
 #, fuzzy
 msgid "Systray Icon Speed Bar"
 msgstr "Prikaz hitrosti v sistemski vrstici"
 
-#: src/muuli_wdr.cpp:1863
+#: src/muuli_wdr.cpp:1870
 msgid "Kad-nodes current"
 msgstr "Trenutna vozlišča Kad"
 
-#: src/muuli_wdr.cpp:1864
+#: src/muuli_wdr.cpp:1871
 msgid "Kad-nodes running"
 msgstr "Vozlišča Kad v teku"
 
-#: src/muuli_wdr.cpp:1865
+#: src/muuli_wdr.cpp:1872
 msgid "Kad-nodes session"
 msgstr "Vozlišča Kad te seje"
 
-#: src/muuli_wdr.cpp:1869 src/muuli_wdr.cpp:2296
+#: src/muuli_wdr.cpp:1876 src/muuli_wdr.cpp:2303
 msgid "Select"
 msgstr "Izberi"
 
-#: src/muuli_wdr.cpp:1873
+#: src/muuli_wdr.cpp:1880
 msgid "Tree"
 msgstr "Drevo"
 
-#: src/muuli_wdr.cpp:1883
+#: src/muuli_wdr.cpp:1890
 msgid "Number of Client Versions shown (0=unlimited)"
 msgstr "Število prikazanih različic odjemalcev (0 = neomejeno)"
 
-#: src/muuli_wdr.cpp:1908
+#: src/muuli_wdr.cpp:1915
 msgid "!!! WARNING !!!"
 msgstr "!!! OPOZORILO !!!"
 
-#: src/muuli_wdr.cpp:1923
+#: src/muuli_wdr.cpp:1930
 msgid "Max new connections / 5 secs"
 msgstr "Maks. novih povezav / 5 sek."
 
-#: src/muuli_wdr.cpp:1925
+#: src/muuli_wdr.cpp:1932
 msgid "Concurrent Kad source lookups"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1927
+#: src/muuli_wdr.cpp:1934
 #, fuzzy
 msgid "Kad source re-search interval (minutes)"
 msgstr "Interval med osvežitvami FTP-ja v minutah"
 
-#: src/muuli_wdr.cpp:1929
+#: src/muuli_wdr.cpp:1936
 #, fuzzy
 msgid "Source re-ask interval (minutes)"
 msgstr "Interval med osvežitvami FTP-ja v minutah"
 
-#: src/muuli_wdr.cpp:1933
+#: src/muuli_wdr.cpp:1940
 msgid "File Buffer Size: 240000 bytes"
 msgstr "Datotečni medpomnilnik: 240000 bajtov"
 
-#: src/muuli_wdr.cpp:1937
+#: src/muuli_wdr.cpp:1944
 msgid "Use MMAP: memory-mapped file access (lower memory use)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1938
+#: src/muuli_wdr.cpp:1945
 msgid "Maps part files into memory instead of buffering them on the heap, lowering the process memory footprint. May reduce download speed on some disks; best for memory-constrained or upload-heavy hosts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1940
+#: src/muuli_wdr.cpp:1947
 msgid "Upload Queue Size: 5000 clients"
 msgstr "Velikost vrste za pošiljanje: 5000 odjemalcev"
 
-#: src/muuli_wdr.cpp:1944
+#: src/muuli_wdr.cpp:1951
 msgid "Server connection refresh interval: Disable"
 msgstr "Čas med osvežitvama povezave na strežnik: onemogoči"
 
-#: src/muuli_wdr.cpp:1948
+#: src/muuli_wdr.cpp:1955
 msgid "Disable computer's timed standby mode"
 msgstr "Onemogoči prehod računalnika v pripravljenost"
 
-#: src/muuli_wdr.cpp:1967
+#: src/muuli_wdr.cpp:1974
 msgid "Skin to use: "
 msgstr "Uporabljena preobleka: "
 
-#: src/muuli_wdr.cpp:1976
+#: src/muuli_wdr.cpp:1983
 msgid "Show \"Fast eD2k Links Handler\" in every window."
 msgstr "Prikaži hitri rokovalnik s povezavami eD2k v vsakem oknu."
 
-#: src/muuli_wdr.cpp:1979
+#: src/muuli_wdr.cpp:1986
 msgid "Show extended info on categories tabs"
 msgstr "Prikaži razširjene podatke na zavihkih kategorij"
 
-#: src/muuli_wdr.cpp:1982
+#: src/muuli_wdr.cpp:1989
 msgid "Show application version on title"
 msgstr "V naslovni vrstici pokaži različico programa"
 
-#: src/muuli_wdr.cpp:1984
+#: src/muuli_wdr.cpp:1991
 msgid "Show transfer rates on title"
 msgstr "Kaži hitrosti prenosa v naslovni vrstici"
 
-#: src/muuli_wdr.cpp:1986
+#: src/muuli_wdr.cpp:1993
 msgid "Before application name"
 msgstr "Pred imenom programa"
 
-#: src/muuli_wdr.cpp:1988
+#: src/muuli_wdr.cpp:1995
 msgid "After application name"
 msgstr "Za imenom programa"
 
-#: src/muuli_wdr.cpp:1991
+#: src/muuli_wdr.cpp:1998
 msgid "Show overhead bandwidth"
 msgstr "Kaži presežek prenosov"
 
-#: src/muuli_wdr.cpp:1995
+#: src/muuli_wdr.cpp:2002
 msgid "Vertical toolbar orientation"
 msgstr "Usmeri orodjarno navpično"
 
-#: src/muuli_wdr.cpp:1997
+#: src/muuli_wdr.cpp:2004
 msgid "Live column sorting (auto-reorder rows as their values change)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2004
+#: src/muuli_wdr.cpp:2011
 msgid "Download Queue Files"
 msgstr "Datoteke v vrsti prejemanj"
 
-#: src/muuli_wdr.cpp:2007
+#: src/muuli_wdr.cpp:2014
 msgid "Show progress percentage"
 msgstr "Prikaži odstotek napredka"
 
-#: src/muuli_wdr.cpp:2013
+#: src/muuli_wdr.cpp:2020
 msgid "Show progress bar"
 msgstr "Prikaži črto napredka"
 
-#: src/muuli_wdr.cpp:2016
+#: src/muuli_wdr.cpp:2023
 msgid "Flat"
 msgstr "Plosko"
 
-#: src/muuli_wdr.cpp:2020
+#: src/muuli_wdr.cpp:2027
 msgid "Round"
 msgstr "Zaokroženo"
 
-#: src/muuli_wdr.cpp:2038
+#: src/muuli_wdr.cpp:2045
 msgid "External Connection Parameters"
 msgstr "Parametri za zunanje povezave"
 
-#: src/muuli_wdr.cpp:2041
+#: src/muuli_wdr.cpp:2048
 msgid "Accept external connections"
 msgstr "Sprejmi zunanje povezave"
 
-#: src/muuli_wdr.cpp:2048 src/muuli_wdr.cpp:2107
+#: src/muuli_wdr.cpp:2055 src/muuli_wdr.cpp:2114
 msgid "IP of the listening interface:"
 msgstr "IP vmesnika, ki posluša:"
 
-#: src/muuli_wdr.cpp:2051
+#: src/muuli_wdr.cpp:2058
 msgid "Enter here a valid ip in the a.b.c.d format for the listening EC interface. An empty field or 0.0.0.0 will mean any interface."
 msgstr "Sem vnesite veljaven IP v formatu a.b.c.d za poslušalen vmesnik. Prazno polje ali 0.0.0.0 pomeni poljuben vmesnik."
 
-#: src/muuli_wdr.cpp:2072 src/muuli_wdr.cpp:2156
+#: src/muuli_wdr.cpp:2079 src/muuli_wdr.cpp:2163
 msgid "TCP port:"
 msgstr "Vrata TCP:"
 
-#: src/muuli_wdr.cpp:2078
+#: src/muuli_wdr.cpp:2085
 msgid "Enable UPnP port forwarding on the EC port"
 msgstr "Vklopi posredovanje vrat UPnP za vrata zunanjih povezav"
 
-#: src/muuli_wdr.cpp:2082 src/muuli_wdr.cpp:3041
+#: src/muuli_wdr.cpp:2089 src/muuli_wdr.cpp:3048
 #: src/utils/wxCas/src/wxcasprefs.cpp:167
 msgid "Password"
 msgstr "Geslo"
 
-#: src/muuli_wdr.cpp:2088
+#: src/muuli_wdr.cpp:2095
 #, fuzzy
 msgid "aMule API server parameters"
 msgstr "Parametri spletnega strežnika"
 
-#: src/muuli_wdr.cpp:2091
+#: src/muuli_wdr.cpp:2098
 msgid "Run amuleapi (REST API) on startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2096
+#: src/muuli_wdr.cpp:2103
 #, fuzzy
 msgid "HTTP port:"
 msgstr "Vrata TCP:"
 
-#: src/muuli_wdr.cpp:2110
+#: src/muuli_wdr.cpp:2117
 msgid "The interface amuleapi's HTTP server listens on. 127.0.0.1 (default) accepts only local connections; use 0.0.0.0 or a specific IP to expose it to other hosts (set an admin password below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2113
+#: src/muuli_wdr.cpp:2120
 #, fuzzy
 msgid "Admin password"
 msgstr "Preverjanje gesla\n"
 
-#: src/muuli_wdr.cpp:2118 src/muuli_wdr.cpp:2149
+#: src/muuli_wdr.cpp:2125 src/muuli_wdr.cpp:2156
 msgid "Low rights password"
 msgstr "Geslo za nizke pravice"
 
-#: src/muuli_wdr.cpp:2126
+#: src/muuli_wdr.cpp:2133
 msgid "Web server parameters"
 msgstr "Parametri spletnega strežnika"
 
-#: src/muuli_wdr.cpp:2129
+#: src/muuli_wdr.cpp:2136
 #, fuzzy
 msgid "Run webserver on startup (deprecated)"
 msgstr "Spletni strežnik zaženi ob zagonu"
 
-#: src/muuli_wdr.cpp:2135
+#: src/muuli_wdr.cpp:2142
 msgid "Web template"
 msgstr "Spletna predloga"
 
-#: src/muuli_wdr.cpp:2140
+#: src/muuli_wdr.cpp:2147
 msgid "Full rights password"
 msgstr "Geslo za vse pravice"
 
-#: src/muuli_wdr.cpp:2144
+#: src/muuli_wdr.cpp:2151
 msgid "Enable Low rights User"
 msgstr "Omogoči uporabnika z nizkimi pravicami"
 
-#: src/muuli_wdr.cpp:2163
+#: src/muuli_wdr.cpp:2170
 msgid "Enable UPnP port forwarding of the web server port"
 msgstr "Vklopi posredovanje vrat UPnP za vrata spletnega strežnika"
 
-#: src/muuli_wdr.cpp:2168
+#: src/muuli_wdr.cpp:2175
 msgid "Web server UPnP TCP port (Optional)"
 msgstr "Vrata TCP za UPnP za spletni strežnik (neobvezno)"
 
-#: src/muuli_wdr.cpp:2176
+#: src/muuli_wdr.cpp:2183
 msgid "Page Refresh Time (in secs)"
 msgstr "Čas med osvežitvami strani (v sek.)"
 
-#: src/muuli_wdr.cpp:2183
+#: src/muuli_wdr.cpp:2190
 msgid "Enable Gzip compression"
 msgstr "Omogoči stiskanje gzip"
 
-#: src/muuli_wdr.cpp:2217
+#: src/muuli_wdr.cpp:2224
 #, fuzzy
 msgid "Reset page to defaults"
 msgstr "Sistemsko privzet"
 
-#: src/muuli_wdr.cpp:2218
+#: src/muuli_wdr.cpp:2225
 msgid "Reset the settings on the current page to their default values."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2220 src/muuli_wdr.cpp:2306 src/ServerWnd.cpp:274
+#: src/muuli_wdr.cpp:2227 src/muuli_wdr.cpp:2313 src/ServerWnd.cpp:274
 #: src/ServerWnd.cpp:282
 msgid "OK"
 msgstr "V redu"
 
-#: src/muuli_wdr.cpp:2222
+#: src/muuli_wdr.cpp:2229
 msgid "Click here to apply any changes made to the preferences."
 msgstr "Kliknite tukaj za uveljavitev sprememb v nastavitvah."
 
-#: src/muuli_wdr.cpp:2225
+#: src/muuli_wdr.cpp:2232
 msgid "Reset any changes made to the preferences."
 msgstr "Razveljavi vse spremembe v nastavitvah."
 
-#: src/muuli_wdr.cpp:2254
+#: src/muuli_wdr.cpp:2261
 msgid "Comment :"
 msgstr "Komentar:"
 
-#: src/muuli_wdr.cpp:2261
+#: src/muuli_wdr.cpp:2268
 msgid "Incoming Dir :"
 msgstr "Mapa za prejeto:"
 
-#: src/muuli_wdr.cpp:2270
+#: src/muuli_wdr.cpp:2277
 msgid "Change priority for new assigned files :"
 msgstr "Spremeni prednost novo dodeljenim datotekam:"
 
-#: src/muuli_wdr.cpp:2274
+#: src/muuli_wdr.cpp:2281
 msgid "Don't change"
 msgstr "Ne spremeni"
 
-#: src/muuli_wdr.cpp:2286
+#: src/muuli_wdr.cpp:2293
 msgid "Select color for this Category (currently selected) :"
 msgstr "Izberite barvo za to kategorijo (trenutno izbrano):"
 
-#: src/muuli_wdr.cpp:2353 src/muuli_wdr.cpp:2372 src/muuli_wdr.cpp:2394
+#: src/muuli_wdr.cpp:2360 src/muuli_wdr.cpp:2379 src/muuli_wdr.cpp:2401
 msgid "Click this button to reset the log."
 msgstr "Kliknite ta gumb, da ponastavite dnevnik."
 
-#: src/muuli_wdr.cpp:2413
+#: src/muuli_wdr.cpp:2420
 msgid "Click on this button to update the servers list from URL ..."
 msgstr "Kliknite ta gumb za posodobitev seznama strežnikov iz URL-ja."
 
-#: src/muuli_wdr.cpp:2417
+#: src/muuli_wdr.cpp:2424
 msgid "Server list"
 msgstr "Seznam strežnikov"
 
-#: src/muuli_wdr.cpp:2421
+#: src/muuli_wdr.cpp:2428
 msgid "Enter the url to a server.met file here and press the button to the left to update the list of known servers."
 msgstr "Vnesite URL do datoteke server.met in kliknite gumb na levi, da posodobite seznam strežnikov."
 
-#: src/muuli_wdr.cpp:2426
+#: src/muuli_wdr.cpp:2433
 msgid "Add server manually: Name"
 msgstr "Ročno dodaj strežnik: ime"
 
-#: src/muuli_wdr.cpp:2429
+#: src/muuli_wdr.cpp:2436
 msgid "Enter the name of the new server here"
 msgstr "Sem vnesite ime novega strežnika"
 
-#: src/muuli_wdr.cpp:2431 src/ServerWnd.cpp:206
+#: src/muuli_wdr.cpp:2438 src/ServerWnd.cpp:206
 msgid "IP:Port"
 msgstr "IP:Vrata"
 
-#: src/muuli_wdr.cpp:2434
+#: src/muuli_wdr.cpp:2441
 msgid "Enter the IP of the server here, using the x.x.x.x format."
 msgstr "Sem vnesite IP strežnika v formatu x.x.x.x."
 
-#: src/muuli_wdr.cpp:2440
+#: src/muuli_wdr.cpp:2447
 msgid "Enter the port of the server here."
 msgstr "Sem vnesite vrata strežnika."
 
-#: src/muuli_wdr.cpp:2443
+#: src/muuli_wdr.cpp:2450
 msgid "Add manually a server (fill fields to the left before) ..."
 msgstr "Ročno dodaj strežnik (najprej izpolnite vsa polja) …"
 
-#: src/muuli_wdr.cpp:2472
+#: src/muuli_wdr.cpp:2479
 msgid "aMule Log"
 msgstr "aMule dnevnik"
 
-#: src/muuli_wdr.cpp:2480
+#: src/muuli_wdr.cpp:2487
 msgid "Server Info"
 msgstr "Podatki o strežniku"
 
-#: src/muuli_wdr.cpp:2484
+#: src/muuli_wdr.cpp:2491
 msgid "ED2K Info"
 msgstr "Podatki o eD2k"
 
-#: src/muuli_wdr.cpp:2488
+#: src/muuli_wdr.cpp:2495
 msgid "Kad Info"
 msgstr "Podatki o Kad"
 
-#: src/muuli_wdr.cpp:2516
+#: src/muuli_wdr.cpp:2523
 msgid "Click on this button to update the nodes list from URL ..."
 msgstr "Kliknite ta gumb za posodobitev seznama vozlišč iz URL-ja."
 
-#: src/muuli_wdr.cpp:2520
+#: src/muuli_wdr.cpp:2527
 msgid "Nodes (0)"
 msgstr "Vozlišča (0)"
 
-#: src/muuli_wdr.cpp:2524
+#: src/muuli_wdr.cpp:2531
 msgid "Enter the url to a nodes.dat file here and press the button to the left to update the list of known nodes."
 msgstr "Vnesite URL do datoteke nodes.dat in pritisnite gumb na levi za posodobitev seznama vozlišč."
 
-#: src/muuli_wdr.cpp:2527
+#: src/muuli_wdr.cpp:2534
 msgid "Nodes stats"
 msgstr "Statistika vozlišč"
 
-#: src/muuli_wdr.cpp:2569
+#: src/muuli_wdr.cpp:2576
 msgid "Bootstrap"
 msgstr "Začetno nalaganje"
 
-#: src/muuli_wdr.cpp:2572
+#: src/muuli_wdr.cpp:2579
 msgid "New node"
 msgstr "Novo vozlišče"
 
-#: src/muuli_wdr.cpp:2577
+#: src/muuli_wdr.cpp:2584
 msgid "IP:"
 msgstr "IP:"
 
-#: src/muuli_wdr.cpp:2597
+#: src/muuli_wdr.cpp:2604
 msgid "Port:"
 msgstr "Vrata:"
 
-#: src/muuli_wdr.cpp:2610
+#: src/muuli_wdr.cpp:2617
 msgid "Bootstrap from known clients"
 msgstr ""
 "Naloži od znanih \n"
 "odjemalcev"
 
-#: src/muuli_wdr.cpp:2612
+#: src/muuli_wdr.cpp:2619
 msgid "Disconnect Kad"
 msgstr "Prekini povezavo s Kad"
 
-#: src/muuli_wdr.cpp:2646
+#: src/muuli_wdr.cpp:2653
 msgid "Use Secure User Identification"
 msgstr "Uporabi varno identifikacijo uporabnikov"
 
-#: src/muuli_wdr.cpp:2648
+#: src/muuli_wdr.cpp:2655
 msgid "It is recommended to enable this option. You will not receive credits if SUI is not enabled."
 msgstr "Priporočamo, da omogočite to možnost. Če to ni omogočeno, ne boste prejeli točk za zasluge."
 
-#: src/muuli_wdr.cpp:2650
+#: src/muuli_wdr.cpp:2657
 msgid "Protocol Obfuscation"
 msgstr "Maskiranje protokola"
 
-#: src/muuli_wdr.cpp:2653
+#: src/muuli_wdr.cpp:2660
 msgid "Support Protocol Obfuscation"
 msgstr "Omogoči maskiranje protokola"
 
-#: src/muuli_wdr.cpp:2655
+#: src/muuli_wdr.cpp:2662
 msgid "This option enabled Protocol Obfuscation, and makes aMule accept obfuscated connections from other clients."
 msgstr "Ob vklopu te možnosti, bo aMule sprejemal maskirane povezave od drugih odjemalcev."
 
-#: src/muuli_wdr.cpp:2657
+#: src/muuli_wdr.cpp:2664
 msgid "Use obfuscation for outgoing connections"
 msgstr "Uporabi maskiranje za izhodne povezave"
 
-#: src/muuli_wdr.cpp:2659
+#: src/muuli_wdr.cpp:2666
 msgid "This option makes aMule use Protocol Obfuscation when connecting other clients/servers."
 msgstr "Ob vklopu te možnosti, bo aMule uporabil maskiranje pri povezavi z drugimi odjemalci in na strežnike."
 
-#: src/muuli_wdr.cpp:2661
+#: src/muuli_wdr.cpp:2668
 msgid "Accept only obfuscated connections"
 msgstr "Dovoli samo maskirane povezave"
 
-#: src/muuli_wdr.cpp:2662
+#: src/muuli_wdr.cpp:2669
 msgid "This option makes aMule only accept obfuscated connections. You will have less sources, but all your traffic will be obfuscated"
 msgstr "Ob vklopu te možnosti, bo aMule sprejemal samo maskirane povezave. Imeli boste manj virov, vendar bodo vse povezave maskirane."
 
-#: src/muuli_wdr.cpp:2667
+#: src/muuli_wdr.cpp:2674
 msgid "Everybody"
 msgstr "Vsi"
 
-#: src/muuli_wdr.cpp:2669
+#: src/muuli_wdr.cpp:2676
 msgid "No one"
 msgstr "Nihče"
 
-#: src/muuli_wdr.cpp:2671
+#: src/muuli_wdr.cpp:2678
 msgid "Who can see my shared files:"
 msgstr "Kdo lahko vidi moje deljene datoteke:"
 
-#: src/muuli_wdr.cpp:2672
+#: src/muuli_wdr.cpp:2679
 msgid "Select who can request to view a list of your shared files."
 msgstr "Izberite, kdo lahko zahteva vaš seznam deljenih datotek."
 
-#: src/muuli_wdr.cpp:2674
+#: src/muuli_wdr.cpp:2681
 msgid "IP-Filtering"
 msgstr "Filtriranje IP-jev"
 
-#: src/muuli_wdr.cpp:2681
+#: src/muuli_wdr.cpp:2688
 msgid "Filter clients"
 msgstr "Filtriraj odjemalce"
 
-#: src/muuli_wdr.cpp:2683
+#: src/muuli_wdr.cpp:2690
 msgid "Enable filtering of the client IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "Omogoči filtriranje odjemalčevih IP-jev, določenih v datoteki ~/.aMule/ipfilter.dat."
 
-#: src/muuli_wdr.cpp:2685
+#: src/muuli_wdr.cpp:2692
 msgid "Filter servers"
 msgstr "Filtriraj strežnike"
 
-#: src/muuli_wdr.cpp:2687
+#: src/muuli_wdr.cpp:2694
 msgid "Enable filtering of the server IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "Omogoči filtriranje strežnikovih IP-jev, določenih v datoteki ~/.aMule/ipfilter.dat."
 
-#: src/muuli_wdr.cpp:2691
+#: src/muuli_wdr.cpp:2698
 msgid "Reload List"
 msgstr "Znova naloži seznam"
 
-#: src/muuli_wdr.cpp:2692
+#: src/muuli_wdr.cpp:2699
 msgid "Reload the list of IPs to filter from the file ~/.aMule/ipfilter.dat"
 msgstr "Ponovno naloži seznam IP-jev za filtriranje iz ~/.aMule/ipfilter.dat."
 
-#: src/muuli_wdr.cpp:2698
+#: src/muuli_wdr.cpp:2705
 msgid "URL:"
 msgstr "URL:"
 
-#: src/muuli_wdr.cpp:2702 src/muuli_wdr.cpp:2895
+#: src/muuli_wdr.cpp:2709 src/muuli_wdr.cpp:2902
 msgid "Update now"
 msgstr "Posodobi zdaj"
 
-#: src/muuli_wdr.cpp:2705
+#: src/muuli_wdr.cpp:2712
 msgid "Auto-update ipfilter at startup"
 msgstr "Samodejno posodobi filter IP-jev ob zagonu"
 
-#: src/muuli_wdr.cpp:2709
+#: src/muuli_wdr.cpp:2716
 msgid "Filtering Level:"
 msgstr "Stopnja filtriranja:"
 
-#: src/muuli_wdr.cpp:2715
+#: src/muuli_wdr.cpp:2722
 msgid "Always filter LAN IPs"
 msgstr "Vedno filtriraj IP-je krajevnega omrežja"
 
-#: src/muuli_wdr.cpp:2718
+#: src/muuli_wdr.cpp:2725
 msgid "Paranoid handling of non-matching IPs"
 msgstr "Paranoično rokovanje z ne-ujemajočimi IP-ji"
 
-#: src/muuli_wdr.cpp:2720
+#: src/muuli_wdr.cpp:2727
 msgid "Rejects a packet when its source IP differs from the IP the client claims (an anti-spoofing check). Disable only if it causes connection problems."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2722
+#: src/muuli_wdr.cpp:2729
 msgid "Use system-wide ipfilter.dat if available"
 msgstr "Uporabi sistemsko ipfilter.dat, če je na voljo"
 
-#: src/muuli_wdr.cpp:2723
+#: src/muuli_wdr.cpp:2730
 #, fuzzy
 msgid "If there's no local ipfilter.dat found, allow usage of a system-wide ipfilter file."
 msgstr "Če krajevne datoteke ipfilter.dat ni moč najti, omogoči uporabo sistemske datoteke."
 
-#: src/muuli_wdr.cpp:2740
+#: src/muuli_wdr.cpp:2747
 msgid "Enable Online-Signature"
 msgstr "Omogoči spletni podpis"
 
-#: src/muuli_wdr.cpp:2742
+#: src/muuli_wdr.cpp:2749
 msgid "Enables the writing of the OS file, which can be used by external apps to create signatures and the like."
 msgstr "Omogoči pisanje v datoteko spletnega podpisa, katero lahko uporabljajo zunanji programi za izdelavo podpisov in podobnih stvari."
 
-#: src/muuli_wdr.cpp:2746
+#: src/muuli_wdr.cpp:2753
 msgid "Update Frequency (Secs):"
 msgstr "Pogostost posodobitev (sek.):"
 
-#: src/muuli_wdr.cpp:2749
+#: src/muuli_wdr.cpp:2756
 msgid "Change the frequency (in seconds) of Online Signature updates."
 msgstr "Spremeni pogostost (v sekundah) posodobitev spletnega podpisa."
 
-#: src/muuli_wdr.cpp:2757
+#: src/muuli_wdr.cpp:2764
 msgid "Save online signature file in: "
 msgstr "Spletni podpis shrani v datoteko: "
 
-#: src/muuli_wdr.cpp:2763
+#: src/muuli_wdr.cpp:2770
 msgid "Click here to select the directory containing the the Online Signature files."
 msgstr "Kliknite tukaj, da nastavite mapo, ki vsebuje datoteke za spletni podpis."
 
-#: src/muuli_wdr.cpp:2796
+#: src/muuli_wdr.cpp:2803
 msgid "Show country flags for clients"
 msgstr "Prikaži zastave držav za odjemalce"
 
-#: src/muuli_wdr.cpp:2797
+#: src/muuli_wdr.cpp:2804
 msgid "Render the country flag column in the transfers, queue and search views. Requires a valid MMDB GeoIP database (see below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2802
+#: src/muuli_wdr.cpp:2809
 #, fuzzy
 msgid "Database"
 msgstr "Podatkovna hitrost:"
 
-#: src/muuli_wdr.cpp:2818
+#: src/muuli_wdr.cpp:2825
 #, fuzzy
 msgid "Source:"
 msgstr "Viri"
 
-#: src/muuli_wdr.cpp:2821
+#: src/muuli_wdr.cpp:2828
 msgid "DB-IP (free, no account)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2822
+#: src/muuli_wdr.cpp:2829
 msgid "MaxMind GeoLite2 (free, account required)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2823
+#: src/muuli_wdr.cpp:2830
 msgid "Custom URL"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2826
+#: src/muuli_wdr.cpp:2833
 msgid "Choose which provider supplies the GeoIP MMDB database. DB-IP is the default - no account required. MaxMind requires a free account + license key. Use Custom URL to point at any other MMDB host (e.g. a local mirror)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2843
+#: src/muuli_wdr.cpp:2850
 msgid ""
 "No configuration required.\n"
 "\n"
@@ -4870,11 +4884,11 @@ msgid ""
 "License: Creative Commons BY 4.0 - https://creativecommons.org/licenses/by/4.0/"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2856
+#: src/muuli_wdr.cpp:2863
 msgid "License key:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2862
+#: src/muuli_wdr.cpp:2869
 msgid ""
 "Sign up for a free MaxMind account, then generate a License Key:\n"
 "https://www.maxmind.com/en/geolite2/signup\n"
@@ -4884,225 +4898,225 @@ msgid ""
 "Requires attribution and account registration; refresh at least every 30 days."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2877
+#: src/muuli_wdr.cpp:2884
 #, fuzzy
 msgid "Download URL:"
 msgstr "Prejemanje: "
 
-#: src/muuli_wdr.cpp:2883
+#: src/muuli_wdr.cpp:2890
 msgid ""
 "Must point to an .mmdb file or a .gz / .tar.gz containing one.\n"
 "URL may include credentials (https://user:pass@host/...).\n"
 "License and attribution terms are set by the upstream URL - you are responsible."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2896
+#: src/muuli_wdr.cpp:2903
 msgid "Download the GeoIP database from the selected source."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2898
+#: src/muuli_wdr.cpp:2905
 #, fuzzy
 msgid "Auto-update on startup"
 msgstr "Samodejno posodobi filter IP-jev ob zagonu"
 
-#: src/muuli_wdr.cpp:2899
+#: src/muuli_wdr.cpp:2906
 msgid "Re-download the GeoIP database from the selected source every time aMule starts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2922
+#: src/muuli_wdr.cpp:2929
 msgid "Filter incoming messages (except current chat):"
 msgstr "Filtriraj prejeta sporočila (razen v trenutnem pogovoru):"
 
-#: src/muuli_wdr.cpp:2924
+#: src/muuli_wdr.cpp:2931
 msgid "Filter all messages"
 msgstr "Filtriraj vsa sporočila"
 
-#: src/muuli_wdr.cpp:2926
+#: src/muuli_wdr.cpp:2933
 msgid "Filter messages from people not on your friend list"
 msgstr "Filtriraj sporočila vseh, ki niso na seznamu prijateljev"
 
-#: src/muuli_wdr.cpp:2928
+#: src/muuli_wdr.cpp:2935
 msgid "Filter messages from unknown clients"
 msgstr "Filtriraj sporočila neznanih uporabnikov"
 
-#: src/muuli_wdr.cpp:2930
+#: src/muuli_wdr.cpp:2937
 msgid "Filter messages containing (use ',' as separator):"
 msgstr "Filtriraj sporočila, ki vsebujejo (uporabi »,« kot ločilnik):"
 
-#: src/muuli_wdr.cpp:2933 src/muuli_wdr.cpp:2944
+#: src/muuli_wdr.cpp:2940 src/muuli_wdr.cpp:2951
 msgid "add here the words amule should filter and block messages including it"
 msgstr "Sem dodajte besede, ki naj jih aMule filtrira, vključno s sporočili v katerih se nahajajo."
 
-#: src/muuli_wdr.cpp:2935
+#: src/muuli_wdr.cpp:2942
 msgid "Show received messages in the log"
 msgstr "Prejeta sporočila prikaži v dnevniku"
 
-#: src/muuli_wdr.cpp:2938
+#: src/muuli_wdr.cpp:2945
 msgid "Comments"
 msgstr "Komentarji"
 
-#: src/muuli_wdr.cpp:2941
+#: src/muuli_wdr.cpp:2948
 msgid "Filter comments containing (use ',' as separator):"
 msgstr "Filtriraj komentarje, ki vsebujejo (uporabi »,« kot ločilnik):"
 
-#: src/muuli_wdr.cpp:2966
+#: src/muuli_wdr.cpp:2973
 msgid "Enable Proxy"
 msgstr "Omogoči posrednika"
 
-#: src/muuli_wdr.cpp:2967
+#: src/muuli_wdr.cpp:2974
 msgid "Enable/disable proxy support"
 msgstr "Omogoči/onemogoči podporo za posrednika"
 
-#: src/muuli_wdr.cpp:2970
+#: src/muuli_wdr.cpp:2977
 msgid "Proxy type:"
 msgstr "Vrsta posrednika:"
 
-#: src/muuli_wdr.cpp:2981
+#: src/muuli_wdr.cpp:2988
 msgid "Proxy host:"
 msgstr "Gostitelj posrednika:"
 
-#: src/muuli_wdr.cpp:2984
+#: src/muuli_wdr.cpp:2991
 msgid "The proxy host name"
 msgstr "Ime gostitelja posredniškega strežnika"
 
-#: src/muuli_wdr.cpp:2986
+#: src/muuli_wdr.cpp:2993
 msgid "Proxy port:"
 msgstr "Vrata posrednika:"
 
-#: src/muuli_wdr.cpp:2989
+#: src/muuli_wdr.cpp:2996
 msgid "The proxy port"
 msgstr "Vrata posredniškega strežnika"
 
-#: src/muuli_wdr.cpp:2991
+#: src/muuli_wdr.cpp:2998
 msgid "Enable authentication"
 msgstr "Omogoči overjanje"
 
-#: src/muuli_wdr.cpp:2992
+#: src/muuli_wdr.cpp:2999
 msgid "Enable/disable username/password authentication"
 msgstr "Omogoči/onemogoči overjanje z uporabniškim imenom/geslom"
 
-#: src/muuli_wdr.cpp:2995
+#: src/muuli_wdr.cpp:3002
 msgid "Username: "
 msgstr "Uporabniško ime: "
 
-#: src/muuli_wdr.cpp:2998
+#: src/muuli_wdr.cpp:3005
 msgid "The username to use to connect to the proxy"
 msgstr "Uporabniško ime za povezavo s posrednikom"
 
-#: src/muuli_wdr.cpp:3000
+#: src/muuli_wdr.cpp:3007
 msgid "Password:"
 msgstr "Geslo:"
 
-#: src/muuli_wdr.cpp:3003
+#: src/muuli_wdr.cpp:3010
 msgid "The password to use to connect to the proxy"
 msgstr "Geslo za povezavo s posrednikom"
 
-#: src/muuli_wdr.cpp:3022
+#: src/muuli_wdr.cpp:3029
 msgid "Connect to:"
 msgstr "Poveži se z:"
 
-#: src/muuli_wdr.cpp:3031
+#: src/muuli_wdr.cpp:3038
 msgid "Login to remote amule"
 msgstr "Prijavi se pri oddaljenem aMule"
 
-#: src/muuli_wdr.cpp:3036
+#: src/muuli_wdr.cpp:3043
 msgid "User name"
 msgstr "Uporabniško ime"
 
-#: src/muuli_wdr.cpp:3047
+#: src/muuli_wdr.cpp:3054
 msgid "Remember those settings"
 msgstr "Zapomni si te nastavitve"
 
-#: src/muuli_wdr.cpp:3050
+#: src/muuli_wdr.cpp:3057
 #, fuzzy
 msgid "Force ZLIB compression"
 msgstr "Uporabi stiskanje gzip"
 
-#: src/muuli_wdr.cpp:3074
+#: src/muuli_wdr.cpp:3081
 msgid "Enable Verbose Debug-Logging."
 msgstr "Omogoči podrobno beleženje za razhroščevanje."
 
-#: src/muuli_wdr.cpp:3076
+#: src/muuli_wdr.cpp:3083
 msgid "Only to Logfile"
 msgstr "Samo v dnevniško datoteko"
 
-#: src/muuli_wdr.cpp:3078
+#: src/muuli_wdr.cpp:3085
 msgid "Message Categories:"
 msgstr "Kategorije sporočil:"
 
-#: src/muuli_wdr.cpp:3102 src/PartFileConvertDlg.cpp:160
+#: src/muuli_wdr.cpp:3109 src/PartFileConvertDlg.cpp:160
 msgid "Waiting..."
 msgstr "Čakanje …"
 
-#: src/muuli_wdr.cpp:3122
+#: src/muuli_wdr.cpp:3129
 msgid "Add imports"
 msgstr "Dodaj uvoze"
 
-#: src/muuli_wdr.cpp:3125
+#: src/muuli_wdr.cpp:3132
 msgid "Retry selected"
 msgstr "Ponovno poskusi izbrane"
 
-#: src/muuli_wdr.cpp:3127
+#: src/muuli_wdr.cpp:3134
 msgid "Remove selected"
 msgstr "Odstrani izbrane"
 
-#: src/muuli_wdr.cpp:3190
+#: src/muuli_wdr.cpp:3197
 msgid "Event Types"
 msgstr "Vrste dogodkov"
 
-#: src/muuli_wdr.cpp:3209
+#: src/muuli_wdr.cpp:3216
 msgid "Statistics and queued clients for selected file(s) : Session / All time"
 msgstr "Statistika in odjemalci v vrsti za izbrane datoteke: seja / ves čas"
 
-#: src/muuli_wdr.cpp:3233
+#: src/muuli_wdr.cpp:3240
 msgid "Active Uploads"
 msgstr "Dejavna pošiljanja"
 
-#: src/muuli_wdr.cpp:3247
+#: src/muuli_wdr.cpp:3254
 msgid "Percent of total files"
 msgstr "Odstotek vseh datotek"
 
-#: src/muuli_wdr.cpp:3299
+#: src/muuli_wdr.cpp:3306
 msgid "Show Clients for"
 msgstr "Prikaži odjemalce za"
 
-#: src/muuli_wdr.cpp:3301
+#: src/muuli_wdr.cpp:3308
 msgid "All files"
 msgstr "Vse datoteke"
 
-#: src/muuli_wdr.cpp:3304
+#: src/muuli_wdr.cpp:3311
 msgid "Selected files"
 msgstr "Izbrane datoteke"
 
-#: src/muuli_wdr.cpp:3307
+#: src/muuli_wdr.cpp:3314
 msgid "Active uploads only"
 msgstr "Samo dejavna pošiljanja"
 
-#: src/muuli_wdr.cpp:3314
+#: src/muuli_wdr.cpp:3321
 msgid "Reload:"
 msgstr "Znova naloži"
 
-#: src/muuli_wdr.cpp:3318
+#: src/muuli_wdr.cpp:3325
 msgid "Reload your shared files"
 msgstr "Ponovno naloži deljene datoteke"
 
-#: src/muuli_wdr.cpp:3381
+#: src/muuli_wdr.cpp:3388
 msgid "Send"
 msgstr "Pošlji"
 
-#: src/muuli_wdr.cpp:3382
+#: src/muuli_wdr.cpp:3389
 msgid "Sends the specified message."
 msgstr "Pošlje navedeno sporočilo."
 
-#: src/muuli_wdr.cpp:3386
+#: src/muuli_wdr.cpp:3393
 msgid "Close this chat-session."
 msgstr "Zapri to pogovorno sejo."
 
-#: src/muuli_wdr.cpp:3409
+#: src/muuli_wdr.cpp:3416
 msgid "Connect to any server and/or Kad"
 msgstr "Poveži se s poljubnim strežnikom in/ali s Kad"
 
-#: src/muuli_wdr.cpp:3415 src/SharedFilesCtrl.cpp:142 src/Statistics.cpp:941
+#: src/muuli_wdr.cpp:3422 src/SharedFilesCtrl.cpp:142 src/Statistics.cpp:941
 msgid "Shared Files"
 msgstr "Deljene datoteke"
 
@@ -5471,188 +5485,188 @@ msgstr "Prejeto"
 msgid "ERROR: Failed to open partfile '%s'"
 msgstr "NAPAKA: delne datoteke »%s« ni bilo moč odpreti"
 
-#: src/Preferences.cpp:673
+#: src/Preferences.cpp:674
 msgid "System default"
 msgstr "Sistemsko privzet"
 
-#: src/Preferences.cpp:674
+#: src/Preferences.cpp:675
 msgid "Albanian"
 msgstr "Albansko"
 
-#: src/Preferences.cpp:675
+#: src/Preferences.cpp:676
 msgid "Arabic"
 msgstr "Arabsko"
 
-#: src/Preferences.cpp:676
+#: src/Preferences.cpp:677
 msgid "Asturian"
 msgstr "Asturijsko"
 
-#: src/Preferences.cpp:677
+#: src/Preferences.cpp:678
 msgid "Basque"
 msgstr "Baskovsko"
 
-#: src/Preferences.cpp:678
+#: src/Preferences.cpp:679
 msgid "Bulgarian"
 msgstr "Bolgarsko"
 
-#: src/Preferences.cpp:679
+#: src/Preferences.cpp:680
 msgid "Catalan"
 msgstr "Katalonsko"
 
-#: src/Preferences.cpp:680
+#: src/Preferences.cpp:681
 msgid "Chinese (Simplified)"
 msgstr "Kitajsko (poenostavljeno)"
 
-#: src/Preferences.cpp:681
+#: src/Preferences.cpp:682
 msgid "Chinese (Traditional)"
 msgstr "Kitajsko (tradicionalno)"
 
-#: src/Preferences.cpp:682
+#: src/Preferences.cpp:683
 msgid "Croatian"
 msgstr "Hrvaško"
 
-#: src/Preferences.cpp:683
+#: src/Preferences.cpp:684
 msgid "Czech"
 msgstr "Češko"
 
-#: src/Preferences.cpp:684
+#: src/Preferences.cpp:685
 msgid "Danish"
 msgstr "Dansko"
 
-#: src/Preferences.cpp:685
+#: src/Preferences.cpp:686
 msgid "Dutch"
 msgstr "Nizozemsko"
 
-#: src/Preferences.cpp:686
+#: src/Preferences.cpp:687
 msgid "English (U.K.)"
 msgstr "Angleško (Z.K.)"
 
-#: src/Preferences.cpp:687
+#: src/Preferences.cpp:688
 #, fuzzy
 msgid "English (U.S.)"
 msgstr "Angleško (Z.K.)"
 
-#: src/Preferences.cpp:688
+#: src/Preferences.cpp:689
 msgid "Estonian"
 msgstr "Estonsko"
 
-#: src/Preferences.cpp:689
+#: src/Preferences.cpp:690
 msgid "Finnish"
 msgstr "Finsko"
 
-#: src/Preferences.cpp:690
+#: src/Preferences.cpp:691
 msgid "French"
 msgstr "Francosko"
 
-#: src/Preferences.cpp:691
+#: src/Preferences.cpp:692
 msgid "Galician"
 msgstr "Galicijsko"
 
-#: src/Preferences.cpp:692
+#: src/Preferences.cpp:693
 msgid "German"
 msgstr "Nemško"
 
-#: src/Preferences.cpp:693
+#: src/Preferences.cpp:694
 msgid "Greek"
 msgstr "Grško"
 
-#: src/Preferences.cpp:694
+#: src/Preferences.cpp:695
 msgid "Hebrew"
 msgstr "Hebrejsko"
 
-#: src/Preferences.cpp:695
+#: src/Preferences.cpp:696
 msgid "Hungarian"
 msgstr "Madžarsko"
 
-#: src/Preferences.cpp:696
+#: src/Preferences.cpp:697
 msgid "Italian"
 msgstr "Italijansko"
 
-#: src/Preferences.cpp:697
+#: src/Preferences.cpp:698
 msgid "Japanese"
 msgstr "Japonsko"
 
-#: src/Preferences.cpp:698
+#: src/Preferences.cpp:699
 msgid "Korean"
 msgstr "Korejsko"
 
-#: src/Preferences.cpp:699
+#: src/Preferences.cpp:700
 msgid "Latvian"
 msgstr ""
 
-#: src/Preferences.cpp:700
+#: src/Preferences.cpp:701
 msgid "Lithuanian"
 msgstr "Litvansko"
 
-#: src/Preferences.cpp:701
+#: src/Preferences.cpp:702
 msgid "Norwegian (Nynorsk)"
 msgstr "Norveško (Nynorsk)"
 
-#: src/Preferences.cpp:702
+#: src/Preferences.cpp:703
 msgid "Polish"
 msgstr "Poljsko"
 
-#: src/Preferences.cpp:703
+#: src/Preferences.cpp:704
 msgid "Portuguese"
 msgstr "Portugalsko"
 
-#: src/Preferences.cpp:704
+#: src/Preferences.cpp:705
 msgid "Portuguese (Brazilian)"
 msgstr "Portugalsko (brazilsko)"
 
-#: src/Preferences.cpp:705
+#: src/Preferences.cpp:706
 msgid "Romanian"
 msgstr "Romunsko"
 
-#: src/Preferences.cpp:706
+#: src/Preferences.cpp:707
 msgid "Russian"
 msgstr "Rusko"
 
-#: src/Preferences.cpp:707
+#: src/Preferences.cpp:708
 msgid "Slovenian"
 msgstr "Slovensko"
 
-#: src/Preferences.cpp:708
+#: src/Preferences.cpp:709
 msgid "Spanish"
 msgstr "Špansko"
 
-#: src/Preferences.cpp:709
+#: src/Preferences.cpp:710
 msgid "Swedish"
 msgstr "Švedsko"
 
-#: src/Preferences.cpp:710
+#: src/Preferences.cpp:711
 msgid "Turkish"
 msgstr "Turško"
 
-#: src/Preferences.cpp:711
+#: src/Preferences.cpp:712
 msgid "Ukrainian"
 msgstr "Ukrajinsko"
 
-#: src/Preferences.cpp:814
+#: src/Preferences.cpp:815
 msgid "Change Language"
 msgstr "Spremeni jezik"
 
-#: src/Preferences.cpp:878
+#: src/Preferences.cpp:879
 msgid "There are no translations installed for aMule"
 msgstr "Za aMule ni nameščenega nobenega prevoda"
 
-#: src/Preferences.cpp:879
+#: src/Preferences.cpp:880
 msgid "No languages available"
 msgstr "Na voljo ni nobenega jezika"
 
-#: src/Preferences.cpp:1010
+#: src/Preferences.cpp:1011
 msgid "no options available"
 msgstr "na voljo ni nobene možnosti"
 
-#: src/Preferences.cpp:2179
+#: src/Preferences.cpp:2182
 msgid "Invalid category found, skipping"
 msgstr "Najdena neveljavna kategorija, preskočena"
 
-#: src/Preferences.cpp:2348
+#: src/Preferences.cpp:2351
 msgid "TCP port can't be higher than 65532 due to server UDP socket being TCP+3"
 msgstr "Vrata TCP ne smejo biti večja od 65532, ker so vrata UDP TCP+3"
 
-#: src/Preferences.cpp:2349
+#: src/Preferences.cpp:2352
 #, c-format
 msgid "Default port will be used (%d)"
 msgstr "Uporabljena bodo privzeta vrata (%d)"
@@ -6174,23 +6188,27 @@ msgstr "Ponovno naloži seznam deljenih datotek."
 msgid "Shared folder"
 msgstr "Deljene mape"
 
-#: src/SearchDlg.cpp:425
+#: src/SearchDlg.cpp:280
+msgid "Clear search history"
+msgstr ""
+
+#: src/SearchDlg.cpp:584
 msgid "It's impossible to search when both eD2k and Kademlia are disabled."
 msgstr "Iskanje ni mogoče, ko sta tako eD2k kot tudi Kademlia onemogočena."
 
-#: src/SearchDlg.cpp:426 src/SearchListCtrl.cpp:858
+#: src/SearchDlg.cpp:585 src/SearchListCtrl.cpp:858
 msgid "Search error"
 msgstr "Napaka iskanja"
 
-#: src/SearchDlg.cpp:768
+#: src/SearchDlg.cpp:929
 msgid "Min size must be smaller than max size. Max size ignored."
 msgstr "Min. velikost mora biti manjša kot maks. velikost. Maks. velikost ni upoštevana."
 
-#: src/SearchDlg.cpp:769 src/SearchDlg.cpp:851
+#: src/SearchDlg.cpp:930 src/SearchDlg.cpp:1012
 msgid "Search warning"
 msgstr "Opozorilo iskanja"
 
-#: src/SearchDlg.cpp:929 src/SearchListCtrl.cpp:735
+#: src/SearchDlg.cpp:1092 src/SearchListCtrl.cpp:735
 msgid "Main"
 msgstr "Glavna"
 

--- a/po/sl.po
+++ b/po/sl.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-28 10:19+0200\n"
+"POT-Creation-Date: 2026-07-28 12:17+0200\n"
 "PO-Revision-Date: 2026-07-27 11:45+0000\n"
 "Last-Translator: Jure Repinc <jlp@holodeck1.com>\n"
 "Language-Team: Slovenian\n"
@@ -204,83 +204,83 @@ msgstr "Ni bilo mogoče odpreti datoteke ED2KLinks."
 msgid "WARNING: You can't add yourself as a source for an eD2k link while having a lowid."
 msgstr "OPOZORILO: če imete nizek ID, sebe ne morete dodati kot vira za povezavo eD2k."
 
-#: src/amule.cpp:300
+#: src/amule.cpp:301
 msgid "Now, exiting main app..."
 msgstr "Sedaj, zapuščanje glavnega programa …"
 
-#: src/amule.cpp:330
+#: src/amule.cpp:331
 #, c-format
 msgid "Terminating amuleweb instance with pid '%d' ... "
 msgstr "Končanje izvoda amuleweb s PID »%d« ... "
 
-#: src/amule.cpp:334
+#: src/amule.cpp:335
 #, c-format
 msgid "Killing amuleweb instance with pid '%d' ... "
 msgstr "Ubijanje izvoda amuleweb s PID »%d« ... "
 
-#: src/amule.cpp:336 src/amule.cpp:349 src/ClientRef.cpp:180
+#: src/amule.cpp:337 src/amule.cpp:350 src/ClientRef.cpp:180
 #: src/SearchDlg.cpp:1041 src/ServerListCtrl.cpp:98
 msgid "Failed"
 msgstr "Neuspeh"
 
-#: src/amule.cpp:343
+#: src/amule.cpp:344
 #, fuzzy, c-format
 msgid "Terminating amuleapi instance with pid '%d' ... "
 msgstr "Končanje izvoda amuleweb s PID »%d« ... "
 
-#: src/amule.cpp:347
+#: src/amule.cpp:348
 #, fuzzy, c-format
 msgid "Killing amuleapi instance with pid '%d' ... "
 msgstr "Ubijanje izvoda amuleweb s PID »%d« ... "
 
-#: src/amule.cpp:355
+#: src/amule.cpp:356
 msgid "aMule OnExit: Terminating core."
 msgstr "aMule OnExit: Končevanje jedra."
 
-#: src/amule.cpp:466
+#: src/amule.cpp:467
 msgid "aMule shutdown completed."
 msgstr "Zaustavitev aMule zaključena."
 
-#: src/amule.cpp:470
+#: src/amule.cpp:471
 msgid "Memory debug results for aMule exit:"
 msgstr "Rezultati razhroščevanja pomnilnika za izhod iz aMule:"
 
-#: src/amule.cpp:651
+#: src/amule.cpp:652
 #, c-format
 msgid "Binding aMule's peer-to-peer traffic to interface: %s (HTTP updates use the default route)"
 msgstr ""
 
-#: src/amule.cpp:655
+#: src/amule.cpp:656
 #, c-format
 msgid "Binding all network traffic to interface: %s"
 msgstr ""
 
-#: src/amule.cpp:659
+#: src/amule.cpp:660
 #, c-format
 msgid "WARNING: configured network interface '%s' was not found - traffic is NOT bound to it and may leave via the default route. Check the interface name in Preferences."
 msgstr ""
 
-#: src/amule.cpp:665
+#: src/amule.cpp:666
 #, c-format
 msgid "WARNING: binding to network interface '%s' requires elevated privileges and was NOT applied - traffic may leave via the default route. Grant the capability (e.g. 'sudo setcap cap_net_raw+ep' on the aMule binary) or run with sufficient privileges."
 msgstr ""
 
-#: src/amule.cpp:673
+#: src/amule.cpp:674
 #, c-format
 msgid "WARNING: could not bind to network interface '%s' - traffic may leave via the default route."
 msgstr ""
 
-#: src/amule.cpp:732
+#: src/amule.cpp:733
 msgid "Your locale has been changed to System Default due to a configuration change. Sorry."
 msgstr "Vaše področne nastavitve so bile spremenjene na sistemsko privzete zaradi spremembe v nastavitvah. Oprostite."
 
-#: src/amule.cpp:734 src/amule.cpp:1581 src/CatDialog.cpp:128
+#: src/amule.cpp:735 src/amule.cpp:1589 src/CatDialog.cpp:128
 #: src/CatDialog.cpp:136 src/CatDialog.cpp:149 src/ServerList.cpp:366
 #: src/ServerListCtrl.cpp:152
 msgid "Info"
 msgstr "Podatki"
 
-#: src/amule.cpp:741
+#: src/amule.cpp:742
 msgid ""
 "\n"
 "EC configuration"
@@ -288,74 +288,74 @@ msgstr ""
 "\n"
 "Nastavitev zunanje povezave"
 
-#: src/amule.cpp:744
+#: src/amule.cpp:745
 msgid "Password set and external connections enabled."
 msgstr "Geslo je bilo nastavljeno in zunanje povezave omogočene."
 
-#: src/amule.cpp:754 src/KadDlg.cpp:176 src/KadDlg.cpp:185
-#: src/PrefsUnifiedDlg.cpp:1387 src/SharedFilesCtrl.cpp:476
+#: src/amule.cpp:755 src/KadDlg.cpp:176 src/KadDlg.cpp:185
+#: src/PrefsUnifiedDlg.cpp:1461 src/SharedFilesCtrl.cpp:476
 msgid "WARNING"
 msgstr "OPOZORILO"
 
-#: src/amule.cpp:991
+#: src/amule.cpp:992
 #, fuzzy
 msgid "Network bootstrap"
 msgstr "Omrežja"
 
-#: src/amule.cpp:996
+#: src/amule.cpp:997
 msgid ""
 "aMule has detected missing network bootstrap files.\n"
 "Select which ones to download:"
 msgstr ""
 
-#: src/amule.cpp:1005 src/FirstRunWizard.cpp:411
+#: src/amule.cpp:1006 src/FirstRunWizard.cpp:411
 #, fuzzy
 msgid "eD2k server list (server.met)"
 msgstr "%i najdenih strežnikov v server.met"
 
-#: src/amule.cpp:1012 src/FirstRunWizard.cpp:416
+#: src/amule.cpp:1013 src/FirstRunWizard.cpp:416
 msgid "Kad bootstrap nodes (nodes.dat)"
 msgstr ""
 
-#: src/amule.cpp:1102
+#: src/amule.cpp:1103
 #, c-format
 msgid "web server running on pid %d"
 msgstr "spletni strežnik teče s PID %d"
 
-#: src/amule.cpp:1115
+#: src/amule.cpp:1116
 #, fuzzy
 msgid "You requested to run web server on startup, but the amuleweb binary cannot be run. Please install the package containing aMule web server, or build aMule from source with -DBUILD_WEBSERVER=YES and install it."
 msgstr "Zahtevali ste zagon spletnega strežnika ob zagonu programa, a programa amuleweb ni moč zagnati. Namestite paket, ki vsebuje spletni strežnik aMule, ali pa prevedite aMule z možnostjo »--enable-webserver« in ga znova namestite z »make install«."
 
-#: src/amule.cpp:1120 src/amule.cpp:1177 src/amule.cpp:1291 src/amule.cpp:1593
+#: src/amule.cpp:1121 src/amule.cpp:1185 src/amule.cpp:1299 src/amule.cpp:1601
 #: src/amule-remote-gui.cpp:603 src/amule-remote-gui.cpp:671
 #: src/amule-remote-gui.cpp:709 src/amule-remote-gui.cpp:1282
 #: src/amule-remote-gui.cpp:1345 src/amule-remote-gui.cpp:1372
-#: src/DownloadQueue.cpp:1481
+#: src/DownloadQueue.cpp:1481 src/PrefsUnifiedDlg.cpp:1247
 msgid "ERROR"
 msgstr "NAPAKA"
 
-#: src/amule.cpp:1166
+#: src/amule.cpp:1174
 #, fuzzy, c-format
 msgid "amuleapi running on pid %d"
 msgstr "spletni strežnik teče s PID %d"
 
-#: src/amule.cpp:1172
+#: src/amule.cpp:1180
 #, fuzzy
 msgid "You requested to run amuleapi on startup, but the amuleapi binary cannot be run. Please install the package containing aMule's REST API server, or build aMule from source with -DBUILD_AMULEAPI=YES and install it."
 msgstr "Zahtevali ste zagon spletnega strežnika ob zagonu programa, a programa amuleweb ni moč zagnati. Namestite paket, ki vsebuje spletni strežnik aMule, ali pa prevedite aMule z možnostjo »--enable-webserver« in ga znova namestite z »make install«."
 
-#: src/amule.cpp:1259
+#: src/amule.cpp:1267
 #, c-format
 msgid "Could not bind ports to the specified address: %s"
 msgstr "Vrat ni bilo moč povezati z navedenim naslovom: %s"
 
-#: src/amule.cpp:1283
+#: src/amule.cpp:1291
 #, c-format
 msgid "Port %u is not available. You will be LOWID\n"
 msgstr "Vrata %u niso razpoložljiva. Imeli boste nizek ID\n"
 
-#: src/amule.cpp:1288
+#: src/amule.cpp:1296
 #, c-format
 msgid ""
 "Port %u is not available!\n"
@@ -370,49 +370,49 @@ msgstr ""
 "\n"
 "Preverite omrežje in se prepričajte, da so vrata odprta za izhod in vhod."
 
-#: src/amule.cpp:1385
+#: src/amule.cpp:1393
 msgid "Failed to create OnlineSig File"
 msgstr "Ni bilo mogoče ustvariti datoteke spletnega podpisa"
 
-#: src/amule.cpp:1393
+#: src/amule.cpp:1401
 msgid "Failed to create aMule OnlineSig File"
 msgstr "Ni bilo mogoče ustvariti aMule datoteke spletnega podpisa"
 
-#: src/amule.cpp:1556
+#: src/amule.cpp:1564
 msgid "The selected locale seems not to be installed on your box. (Note: I'll try to set it anyway)"
 msgstr "Kot kaže izbrana področna nastavitev ni nameščena na vašem računalniku. (Opomba: vseeno se jo bo poskusilo nastaviti)"
 
-#: src/amule.cpp:1566
+#: src/amule.cpp:1574
 #, c-format
 msgid "This is the first time you run aMule %s"
 msgstr "To je vaš prvi zagon aMule %s"
 
-#: src/amule.cpp:1569
+#: src/amule.cpp:1577
 msgid "This version is a testing version, updated daily, and\n"
 msgstr "To je testna različica, posodobljena dnevno in\n"
 
-#: src/amule.cpp:1570
+#: src/amule.cpp:1578
 msgid "we give no warranty it won't break anything, burn your house,\n"
 msgstr "ne dajemo zagotovila, da ne bo ničesar poškodovala, zažgala vaše hiše\n"
 
-#: src/amule.cpp:1571
+#: src/amule.cpp:1579
 msgid "or kill your dog. But it *should* be safe to use anyway.\n"
 msgstr "ali ubila vašega psa. Vendar bi vseeno morala biti varna za uporabo.\n"
 
-#: src/amule.cpp:1576
+#: src/amule.cpp:1584
 msgid "More information, support and new releases can found at our homepage,\n"
 msgstr "Več informacij, podporo in nove različice, lahko najdete na naši domači strani,\n"
 
-#: src/amule.cpp:1577
+#: src/amule.cpp:1585
 msgid "at https://amule-org.github.io, or in our IRC channel #aMule at irc.libera.chat.\n"
 msgstr "na https://amule-org.github.io, ali na kanalu IRC #aMule, na strežniku irc.libera.chat.\n"
 
-#: src/amule.cpp:1579
+#: src/amule.cpp:1587
 #, fuzzy
 msgid "Feel free to report any bugs to https://github.com/amule-org/amule/issues"
 msgstr "Morebitne hrošče lahko sporočite na https://github.com/amule-org/amule/issues"
 
-#: src/amule.cpp:1591
+#: src/amule.cpp:1599
 msgid ""
 "The folder for Online Signature files you specified is INVALID!\n"
 " OnlineSignature will be DISABLED until you fix it on preferences."
@@ -420,138 +420,138 @@ msgstr ""
 "Navedena mapa za datoteke za spletni podpis je NEVELJAVNA.\n"
 "Spletni podpis bo ONEMOGOČEN, dokler težave ne odpravite v nastavitvah."
 
-#: src/amule.cpp:1654
+#: src/amule.cpp:1662
 msgid "Server hostname notified"
 msgstr "Gostitelj strežnika obveščen"
 
-#: src/amule.cpp:2031
+#: src/amule.cpp:2039
 #, c-format
 msgid "Disk space preallocation for file '%s' failed: %s"
 msgstr "Vnaprejšnja dodelitev prostora na disku za datoteko »%s« ni uspela: %s"
 
-#: src/amule.cpp:2160
+#: src/amule.cpp:2168
 msgid "ERROR: can't open logfile"
 msgstr "NAPAKA: ni mogoče odpreti dnevniške datoteke"
 
-#: src/amule.cpp:2164
+#: src/amule.cpp:2172
 msgid "WARNING: logfile is empty. Something is wrong."
 msgstr "OPOZORILO: dnevniška datoteka je prazna. Nekaj je narobe."
 
-#: src/amule.cpp:2181
+#: src/amule.cpp:2189
 msgid "Log has been reset"
 msgstr "Dnevnik je bil ponastavljen"
 
-#: src/amule.cpp:2205
+#: src/amule.cpp:2213
 #, c-format
 msgid "ServerMessage: %s"
 msgstr "Sporočilo strežnika: %s"
 
-#: src/amule.cpp:2248 src/IP2Country.cpp:220 src/IPFilter.cpp:514
+#: src/amule.cpp:2256 src/IP2Country.cpp:220 src/IPFilter.cpp:514
 #: src/ServerList.cpp:875
 #, c-format
 msgid "Skipped download of %s, because requested file is not newer."
 msgstr "Prejemanje %s je bilo preskočeno, ker zahtevana datoteka ni novejša."
 
-#: src/amule.cpp:2251
+#: src/amule.cpp:2259
 msgid "Failed to download the nodes list."
 msgstr "Ni bilo mogoče prejeti seznama vozlišč."
 
-#: src/amule.cpp:2314
+#: src/amule.cpp:2322
 msgid "Failed to open the downloaded version check file"
 msgstr "Ni bilo mogoče odpreti prejete datoteke za preverjanje različice"
 
-#: src/amule.cpp:2317 src/amule.cpp:2336
+#: src/amule.cpp:2325 src/amule.cpp:2344
 msgid "Corrupted version check file"
 msgstr "Datoteka za preverjanje različice je pokvarjena"
 
-#: src/amule.cpp:2359
+#: src/amule.cpp:2367
 msgid "You are using an outdated version of aMule!"
 msgstr "Uporabljate zastarelo različico aMule."
 
-#: src/amule.cpp:2361
+#: src/amule.cpp:2369
 #, c-format
 msgid "Your aMule version is %i.%i.%i and the latest version is %li.%li.%li"
 msgstr "Različica vaše aMule je %i.%i.%i, najnovejša različica pa je %li.%li.%li"
 
-#: src/amule.cpp:2365
+#: src/amule.cpp:2373
 #, fuzzy
 msgid "The latest version can always be found at https://github.com/amule-org/amule/releases/latest"
 msgstr "Najnovejšo različico lahko vedno najdete na https://github.com/amule-org/amule/releases/latest"
 
-#: src/amule.cpp:2368
+#: src/amule.cpp:2376
 #, c-format
 msgid "WARNING: Your aMuled version is outdated: %i.%i.%i < %li.%li.%li"
 msgstr "OPOZORILO: vaša različica aMule je zastarela: %i.%i.%i < %li.%li.%li"
 
-#: src/amule.cpp:2374
+#: src/amule.cpp:2382
 msgid "Your copy of aMule is up to date."
 msgstr "Uporabljate najnovejšo različico aMule."
 
-#: src/amule.cpp:2381
+#: src/amule.cpp:2389
 msgid "Failed to download the version check file"
 msgstr "Ni bilo mogoče prejeti datoteke za preverjanje različice"
 
-#: src/amule.cpp:2550 src/amule-remote-gui.cpp:1133
+#: src/amule.cpp:2558 src/amule-remote-gui.cpp:1133
 #, c-format
 msgid "Users: %s | Files: %s"
 msgstr "Uporabniki: %s | Datoteke: %s"
 
-#: src/amule.cpp:2551 src/amule-remote-gui.cpp:1134
+#: src/amule.cpp:2559 src/amule-remote-gui.cpp:1134
 #, c-format
 msgid "Users: E: %s K: %s | Files: E: %s K: %s"
 msgstr "Uporabniki: E: %s K: %s | Datoteke: E: %s K: %s"
 
-#: src/amule.cpp:2565 src/amule-remote-gui.cpp:1147
+#: src/amule.cpp:2573 src/amule-remote-gui.cpp:1147
 msgid "No networks selected"
 msgstr "Izbranega ni nobenega omrežja"
 
-#: src/amule.cpp:2633 src/TextClient.cpp:903
+#: src/amule.cpp:2641 src/TextClient.cpp:903
 msgid "with LowID"
 msgstr "z nizkim ID-jem"
 
-#: src/amule.cpp:2633 src/TextClient.cpp:904
+#: src/amule.cpp:2641 src/TextClient.cpp:904
 msgid "with HighID"
 msgstr "z visokim ID-jem"
 
-#: src/amule.cpp:2635
+#: src/amule.cpp:2643
 #, c-format
 msgid "Connected to %s %s"
 msgstr "Povezano na %s %s"
 
-#: src/amule.cpp:2640
+#: src/amule.cpp:2648
 #, c-format
 msgid "Connecting to %s"
 msgstr "Povezovanje z %s"
 
-#: src/amule.cpp:2642
+#: src/amule.cpp:2650
 msgid "Disconnected from eD2k"
 msgstr "Povezava z eD2k prekinjena"
 
-#: src/amule.cpp:2651
+#: src/amule.cpp:2659
 msgid "Kad started."
 msgstr "Kad zagnan."
 
-#: src/amule.cpp:2653
+#: src/amule.cpp:2661
 msgid "Kad stopped."
 msgstr "Kad ustavljen."
 
-#: src/amule.cpp:2661
+#: src/amule.cpp:2669
 msgid "Connected to Kad (ok)"
 msgstr "Povezano v Kad (v redu)"
 
-#: src/amule.cpp:2663
+#: src/amule.cpp:2671
 msgid "Connected to Kad (firewalled)"
 msgstr "Povezano v Kad (za požarnim zidom)"
 
-#: src/amule.cpp:2667
+#: src/amule.cpp:2675
 msgid "Disconnected from Kad"
 msgstr "Povezava s Kad prekinjena"
 
-#: src/amule.cpp:2699
+#: src/amule.cpp:2707
 msgid "Kad network cannot be used if UDP port is disabled on preferences, not starting."
 msgstr "Omrežja Kad ni mogoče uporabljati, če so vrata UDP onemogočena v nastavitvah. Kad ni zagnan."
 
-#: src/amule.cpp:2703
+#: src/amule.cpp:2711
 msgid "Kad network disabled on preferences, not connecting."
 msgstr "Omrežje Kad je onemogočeno v nastavitvah. Ni povezave."
 
@@ -597,36 +597,36 @@ msgid "FATAL ERROR: Failed to create Timer"
 msgstr "USODNA NAPAKA: ustvaritev časomerilnika ni uspela"
 
 #: src/amuleDlg.cpp:361 src/amuleDlg.cpp:1787 src/amuleDlg.cpp:2033
-#: src/muuli_wdr.cpp:1492 src/muuli_wdr.cpp:3418
+#: src/muuli_wdr.cpp:1492 src/muuli_wdr.cpp:3449
 msgid "Networks"
 msgstr "Omrežja"
 
-#: src/amuleDlg.cpp:362 src/amuleDlg.cpp:1793 src/muuli_wdr.cpp:3419
+#: src/amuleDlg.cpp:362 src/amuleDlg.cpp:1793 src/muuli_wdr.cpp:3450
 msgid "Searches"
 msgstr "Iskanja"
 
 #: src/amuleDlg.cpp:363 src/amuleDlg.cpp:1799 src/DownloadListCtrl.cpp:740
-#: src/muuli_wdr.cpp:392 src/muuli_wdr.cpp:1585 src/muuli_wdr.cpp:3420
+#: src/muuli_wdr.cpp:392 src/muuli_wdr.cpp:1585 src/muuli_wdr.cpp:3451
 #: src/Statistics.cpp:829
 msgid "Downloads"
 msgstr "Prejemanja"
 
-#: src/amuleDlg.cpp:364 src/amuleDlg.cpp:1805 src/muuli_wdr.cpp:3294
+#: src/amuleDlg.cpp:364 src/amuleDlg.cpp:1805 src/muuli_wdr.cpp:3325
 msgid "Shared files"
 msgstr "Deljene datoteke"
 
-#: src/amuleDlg.cpp:365 src/amuleDlg.cpp:1811 src/muuli_wdr.cpp:2926
-#: src/muuli_wdr.cpp:3376 src/muuli_wdr.cpp:3423
+#: src/amuleDlg.cpp:365 src/amuleDlg.cpp:1811 src/muuli_wdr.cpp:2957
+#: src/muuli_wdr.cpp:3407 src/muuli_wdr.cpp:3454
 msgid "Messages"
 msgstr "Sporočila"
 
-#: src/amuleDlg.cpp:366 src/amuleDlg.cpp:1817 src/muuli_wdr.cpp:3424
-#: src/PrefsUnifiedDlg.cpp:312 src/Statistics.cpp:779 src/Statistics.cpp:1235
+#: src/amuleDlg.cpp:366 src/amuleDlg.cpp:1817 src/muuli_wdr.cpp:3455
+#: src/PrefsUnifiedDlg.cpp:314 src/Statistics.cpp:779 src/Statistics.cpp:1235
 msgid "Statistics"
 msgstr "Statistika"
 
-#: src/amuleDlg.cpp:368 src/amuleDlg.cpp:1824 src/muuli_wdr.cpp:3426
-#: src/PrefsUnifiedDlg.cpp:328 src/utils/wxCas/src/wxcasprefs.cpp:39
+#: src/amuleDlg.cpp:368 src/amuleDlg.cpp:1824 src/muuli_wdr.cpp:3457
+#: src/PrefsUnifiedDlg.cpp:330 src/utils/wxCas/src/wxcasprefs.cpp:39
 msgid "Preferences"
 msgstr "Nastavitve"
 
@@ -684,8 +684,8 @@ msgstr "Kad: izklopljen"
 #: src/amuleDlg.cpp:1029 src/DownloadListCtrl.cpp:505
 #: src/DownloadListCtrl.cpp:749 src/FriendListCtrl.cpp:180
 #: src/muuli_wdr.cpp:731 src/muuli_wdr.cpp:782 src/muuli_wdr.cpp:846
-#: src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2231 src/muuli_wdr.cpp:2316
-#: src/muuli_wdr.cpp:3064 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
+#: src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2262 src/muuli_wdr.cpp:2347
+#: src/muuli_wdr.cpp:3095 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
 #: src/ServerListCtrl.cpp:606 src/TransferWnd.cpp:378
 #: src/utils/wxCas/src/wxcasprefs.cpp:235
 msgid "Cancel"
@@ -696,7 +696,7 @@ msgid "Stop the current connection attempts"
 msgstr "Ustavi trenutne poskuse povezovanja"
 
 #: src/amuleDlg.cpp:1035 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976
-#: src/muuli_wdr.cpp:2454
+#: src/muuli_wdr.cpp:2485
 msgid "Disconnect"
 msgstr "Prekini povezave"
 
@@ -705,7 +705,7 @@ msgid "Disconnect from the currently connected networks"
 msgstr "Prekini povezavo s trenutno povezanimi omrežji"
 
 #: src/amuleDlg.cpp:1041 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979
-#: src/muuli_wdr.cpp:2609 src/muuli_wdr.cpp:3061 src/muuli_wdr.cpp:3416
+#: src/muuli_wdr.cpp:2640 src/muuli_wdr.cpp:3092 src/muuli_wdr.cpp:3447
 msgid "Connect"
 msgstr "Poveži se"
 
@@ -759,7 +759,7 @@ msgstr "Potrditev izhoda"
 msgid "Launch Command: "
 msgstr "Zaženi ukaz: "
 
-#: src/amuleDlg.cpp:1632 src/muuli_wdr.cpp:1978 src/Preferences.cpp:952
+#: src/amuleDlg.cpp:1632 src/muuli_wdr.cpp:1982 src/Preferences.cpp:979
 msgid "- default -"
 msgstr "– privzeto –"
 
@@ -773,48 +773,48 @@ msgstr "Mapa za preobleke »%s« ne obstaja"
 msgid "WARNING: Unable to open skin file '%s' for read"
 msgstr "OPOZORILO: datoteke s preobleko »%s« ni moč odpreti za branje"
 
-#: src/amuleDlg.cpp:1791 src/muuli_wdr.cpp:3418
+#: src/amuleDlg.cpp:1791 src/muuli_wdr.cpp:3449
 msgid "Networks Window"
 msgstr "Okno z omrežji"
 
-#: src/amuleDlg.cpp:1797 src/muuli_wdr.cpp:3419
+#: src/amuleDlg.cpp:1797 src/muuli_wdr.cpp:3450
 msgid "Searches Window"
 msgstr "Okno z iskanji"
 
-#: src/amuleDlg.cpp:1803 src/muuli_wdr.cpp:3420
+#: src/amuleDlg.cpp:1803 src/muuli_wdr.cpp:3451
 msgid "Downloads Window"
 msgstr "Okno s prejemanji"
 
-#: src/amuleDlg.cpp:1809 src/muuli_wdr.cpp:3422
+#: src/amuleDlg.cpp:1809 src/muuli_wdr.cpp:3453
 msgid "Shared Files Window"
 msgstr "Okno z deljenimi datotekami"
 
-#: src/amuleDlg.cpp:1815 src/muuli_wdr.cpp:3423
+#: src/amuleDlg.cpp:1815 src/muuli_wdr.cpp:3454
 msgid "Messages Window"
 msgstr "Okno s sporočili"
 
-#: src/amuleDlg.cpp:1821 src/muuli_wdr.cpp:3424
+#: src/amuleDlg.cpp:1821 src/muuli_wdr.cpp:3455
 msgid "Statistics Graph Window"
 msgstr "Okno s statističnimi grafi"
 
-#: src/amuleDlg.cpp:1828 src/muuli_wdr.cpp:3426
+#: src/amuleDlg.cpp:1828 src/muuli_wdr.cpp:3457
 msgid "Preferences Settings Window"
 msgstr "Okno z nastavitvami"
 
-#: src/amuleDlg.cpp:1831 src/muuli_wdr.cpp:3427
+#: src/amuleDlg.cpp:1831 src/muuli_wdr.cpp:3458
 msgid "Import"
 msgstr "Uvoz"
 
-#: src/amuleDlg.cpp:1835 src/muuli_wdr.cpp:3427
+#: src/amuleDlg.cpp:1835 src/muuli_wdr.cpp:3458
 msgid "The partfile importer tool"
 msgstr "Orodje za uvažanje delnih datotek"
 
-#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3428
+#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3459
 #: src/utils/aLinkCreator/src/alcframe.cpp:262
 msgid "About"
 msgstr "O programu"
 
-#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3428
+#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3459
 msgid "About/Help"
 msgstr "O programu/pomoč"
 
@@ -956,7 +956,7 @@ msgstr "Datoteke ni mogoče najti."
 msgid "The core rejected these shared folders:%s"
 msgstr ""
 
-#: src/amule-remote-gui.cpp:1336 src/ExternalConn.cpp:2345
+#: src/amule-remote-gui.cpp:1336 src/ExternalConn.cpp:2346
 msgid "Invalid link or already on list."
 msgstr "Neveljavna povezava oz. je že na seznamu."
 
@@ -972,7 +972,7 @@ msgstr "Ni moč ustvariti mape »%s« za kategorijo »%s«, obdržana bo mapa »
 #: src/ClientDetailDialog.cpp:123 src/DataToText.cpp:61 src/DataToText.cpp:86
 #: src/DataToText.cpp:101 src/DataToText.cpp:136 src/DataToText.cpp:165
 #: src/DownloadListCtrl.cpp:1172 src/DownloadListCtrl.cpp:1185
-#: src/DownloadListCtrl.cpp:1196 src/ExternalConn.cpp:608
+#: src/DownloadListCtrl.cpp:1196 src/ExternalConn.cpp:609
 #: src/FileDetailDialog.cpp:203 src/FileDetailDialog.cpp:235
 #: src/FileDetailDialog.cpp:242 src/GenericClientListCtrl.cpp:1171
 #: src/GenericClientListCtrl.cpp:1182 src/GenericClientListCtrl.cpp:1192
@@ -1369,19 +1369,19 @@ msgstr "Samod. [Vi]"
 msgid "Very low"
 msgstr "Zelo nizka"
 
-#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:743 src/muuli_wdr.cpp:2282
+#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:743 src/muuli_wdr.cpp:2313
 #: src/ServerListCtrl.cpp:263 src/ServerListCtrl.cpp:456
 #: src/SharedFilesCtrl.cpp:145
 msgid "Low"
 msgstr "Nizka"
 
-#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:744 src/muuli_wdr.cpp:2283
+#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:744 src/muuli_wdr.cpp:2314
 #: src/ServerListCtrl.cpp:266 src/ServerListCtrl.cpp:457
 #: src/SharedFilesCtrl.cpp:146
 msgid "Normal"
 msgstr "Običajna"
 
-#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:745 src/muuli_wdr.cpp:2284
+#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:745 src/muuli_wdr.cpp:2315
 #: src/ServerListCtrl.cpp:269 src/ServerListCtrl.cpp:458
 #: src/SharedFilesCtrl.cpp:147
 msgid "High"
@@ -1473,7 +1473,7 @@ msgstr "Krajevni strežnik"
 msgid "Remote Server"
 msgstr "Oddaljni strežnik"
 
-#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3181
+#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3212
 #: src/SearchDlg.cpp:119 src/TextClient.cpp:911
 msgid "Kad"
 msgstr "Kad"
@@ -1545,7 +1545,7 @@ msgstr "Del"
 msgid "Size"
 msgstr "Velikost"
 
-#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3248
+#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3279
 msgid "Transferred"
 msgstr "Preneseno"
 
@@ -1603,7 +1603,7 @@ msgstr ""
 "Odziv od: %s (%s)\n"
 "\n"
 
-#: src/DownloadListCtrl.cpp:746 src/muuli_wdr.cpp:2285
+#: src/DownloadListCtrl.cpp:746 src/muuli_wdr.cpp:2316
 #: src/SharedFilesCtrl.cpp:150
 msgid "Auto"
 msgstr "Samod."
@@ -1641,7 +1641,7 @@ msgid "Extended Options"
 msgstr "Dodatne možnosti"
 
 #: src/DownloadListCtrl.cpp:770 src/DownloadListCtrl.cpp:822
-#: src/muuli_wdr.cpp:1796
+#: src/muuli_wdr.cpp:1800
 msgid "Preview"
 msgstr "Ogled"
 
@@ -1821,227 +1821,232 @@ msgstr[3] ""
 msgid "Invalid eD2k link! ERROR: %s"
 msgstr "Neveljavna povezava eD2k. NAPAKA: %s"
 
-#: src/ExternalConn.cpp:379
+#: src/ExternalConn.cpp:380
 msgid "Client sent packet after authentication failed."
 msgstr "Po neuspelem overjanju je odjemalec poslal paket."
 
-#: src/ExternalConn.cpp:396
+#: src/ExternalConn.cpp:397
 msgid "External connection closed."
 msgstr "Zunanja povezava se je zaprla."
 
-#: src/ExternalConn.cpp:473
+#: src/ExternalConn.cpp:474
 msgid "External connections disabled due to empty password!"
 msgstr "Zunanje povezave onemogočene zaradi praznega gesla."
 
-#: src/ExternalConn.cpp:494
+#: src/ExternalConn.cpp:495
 msgid "External connections disabled in config file"
 msgstr "Zunanje povezave onemogočene v nastavitveni datoteki"
 
-#: src/ExternalConn.cpp:575
+#: src/ExternalConn.cpp:576
 msgid "New external connection accepted"
 msgstr "Nova zunanja povezava sprejeta"
 
-#: src/ExternalConn.cpp:578
+#: src/ExternalConn.cpp:579
 msgid "ERROR: couldn't accept a new external connection"
 msgstr "NAPAKA: nove zunanje povezave ni bilo moč sprejeti"
 
-#: src/ExternalConn.cpp:595
+#: src/ExternalConn.cpp:596
 msgid "External connection refused due to empty password in preferences!"
 msgstr "Zunanja povezava zavrnjena zaradi praznega gesla v nastavitvah."
 
-#: src/ExternalConn.cpp:607
+#: src/ExternalConn.cpp:608
 #, c-format
 msgid "Connecting client: %s %s"
 msgstr "Povezovanje z odjemalcem: %s %s"
 
-#: src/ExternalConn.cpp:609
+#: src/ExternalConn.cpp:610
 msgid "Unknown version"
 msgstr "Neznana različica"
 
-#: src/ExternalConn.cpp:622
+#: src/ExternalConn.cpp:623
 msgid "Incorrect EC version ID, there might be binary incompatibility. Use core and remote from same snapshot."
 msgstr "Napačen ID različice za zunanje povezave; lahko pride do binarne nezdružljivosti. Uporabite jedro in oddaljen odjemalec iz istega posnetka."
 
-#: src/ExternalConn.cpp:630
+#: src/ExternalConn.cpp:631
 msgid "You cannot connect to a release version from an arbitrary development snapshot! *sigh* possible crash prevented"
 msgstr "Ne morete se povezati s stabilno različico iz poljubne razvojne različice. Preprečeno morebitno sesutje."
 
-#: src/ExternalConn.cpp:713
+#: src/ExternalConn.cpp:714
 msgid "Invalid protocol version."
 msgstr "Neveljavna različica protokola."
 
-#: src/ExternalConn.cpp:719
+#: src/ExternalConn.cpp:720
 msgid "Missing protocol version tag."
 msgstr "Manjka oznaka različice protokola."
 
-#: src/ExternalConn.cpp:727
+#: src/ExternalConn.cpp:728
 msgid "Authentication failed: invalid hash specified as EC password."
 msgstr "Overjanje ni uspelo: kot geslo za zunanje povezave je bila podana napačna koda."
 
-#: src/ExternalConn.cpp:775
+#: src/ExternalConn.cpp:776
 msgid "Authentication failed: wrong password."
 msgstr "Overjanje ni uspelo: napačno geslo."
 
-#: src/ExternalConn.cpp:777
+#: src/ExternalConn.cpp:778
 msgid "Authentication failed: missing password."
 msgstr "Overjanje ni uspelo: manjkajoče geslo."
 
-#: src/ExternalConn.cpp:788
+#: src/ExternalConn.cpp:789
 msgid "Invalid request, please authenticate first."
 msgstr "Neveljavna zahteva, najprej se morate overiti."
 
-#: src/ExternalConn.cpp:793
+#: src/ExternalConn.cpp:794
 msgid "Access granted."
 msgstr "Dostop dovoljen."
 
-#: src/ExternalConn.cpp:801
+#: src/ExternalConn.cpp:802
 #, c-format
 msgid "Sent error message \"%s\" to client."
 msgstr "Odjemalcu je bilo poslano sporočilo o napaki »%s«."
 
-#: src/ExternalConn.cpp:806
+#: src/ExternalConn.cpp:807
 #, c-format
 msgid "Unauthorized access attempt from %s. Connection closed."
 msgstr "Nepooblaščen poskus dostopa od %s. Povezava prekinjena."
 
-#: src/ExternalConn.cpp:1419
+#: src/ExternalConn.cpp:1420
 #, c-format
 msgid "Remote PartFile command failed: FileHash not found: %s"
 msgstr "Ukaz za oddaljeno delno datoteko ni uspel: Ni bilo mogoče najti kode datoteke: %s"
 
-#: src/ExternalConn.cpp:1423
+#: src/ExternalConn.cpp:1424
 #, c-format
 msgid "FileHash not found: %s"
 msgstr "Kode datoteke ni mogoče najti: %s"
 
-#: src/ExternalConn.cpp:1470 src/ExternalConn.cpp:1558
-#: src/ExternalConn.cpp:1679
+#: src/ExternalConn.cpp:1471 src/ExternalConn.cpp:1559
+#: src/ExternalConn.cpp:1680
 msgid "OOPS! OpCode processing error!"
 msgstr "UPS. Napaka pri obdelavi OpCode."
 
-#: src/ExternalConn.cpp:1501
+#: src/ExternalConn.cpp:1502
 msgid "Server not added"
 msgstr "Strežnik ni bil dodan"
 
-#: src/ExternalConn.cpp:1520
+#: src/ExternalConn.cpp:1521
 #, c-format
 msgid "server not found: %s"
 msgstr "strežnika ni mogoče najti: %s"
 
-#: src/ExternalConn.cpp:1537
+#: src/ExternalConn.cpp:1538
 msgid "need to define server to be removed"
 msgstr "morate navesti strežnik za odstranitev"
 
-#: src/ExternalConn.cpp:1552
+#: src/ExternalConn.cpp:1553
 msgid "eD2k is disabled in preferences."
 msgstr "eD2k je onemogočen v nastavitvah."
 
-#: src/ExternalConn.cpp:1657
+#: src/ExternalConn.cpp:1658
 #, fuzzy
 msgid "Friend not found."
 msgstr "Datoteke ni mogoče najti."
 
-#: src/ExternalConn.cpp:1667
+#: src/ExternalConn.cpp:1668
 #, fuzzy
 msgid "Client not found."
 msgstr "Datoteke ni mogoče najti."
 
-#: src/ExternalConn.cpp:1673
+#: src/ExternalConn.cpp:1674
 msgid "EC_TAG_FRIEND_SHARED requires EC_TAG_FRIEND or EC_TAG_CLIENT."
 msgstr ""
 
-#: src/ExternalConn.cpp:1991
+#: src/ExternalConn.cpp:1992
 msgid "WebSearch from remote interface makes no sense."
 msgstr "Spletno iskanje iz oddaljenega vmesnika nima smisla."
 
-#: src/ExternalConn.cpp:2026
+#: src/ExternalConn.cpp:2027
 msgid "Search in progress. Refetch results in a moment!"
 msgstr "Iskanje poteka. Ponovno poglejte za rezultati čez nekaj trenutkov."
 
-#: src/ExternalConn.cpp:2265
+#: src/ExternalConn.cpp:2266
 msgid "No points for graph."
 msgstr "Ni točk za graf."
 
-#: src/ExternalConn.cpp:2275
+#: src/ExternalConn.cpp:2276
 msgid "Your client is not configured for this detail level."
 msgstr "Vaš odjemalec ni nastavljen za to stopnjo podrobnosti."
 
-#: src/ExternalConn.cpp:2302
+#: src/ExternalConn.cpp:2303
 msgid "External Connection: shutdown requested"
 msgstr "Zunanja povezava: zahtevana zaustavitev"
 
-#: src/ExternalConn.cpp:2314
+#: src/ExternalConn.cpp:2315
 msgid "Already shutting down."
 msgstr "Ustavljanje že poteka."
 
-#: src/ExternalConn.cpp:2332
+#: src/ExternalConn.cpp:2333
 #, c-format
 msgid "ExternalConn: adding link '%s'."
 msgstr "Zunanja povezava: dodajanje povezave »%s«."
 
-#: src/ExternalConn.cpp:2350
+#: src/ExternalConn.cpp:2351
 #, fuzzy, c-format
 msgid "%d of %d links failed (invalid or already on list)."
 msgstr "Neveljavna povezava oz. je že na seznamu."
 
-#: src/ExternalConn.cpp:2373
+#: src/ExternalConn.cpp:2374
 msgid "Version check throttled; try again shortly."
 msgstr ""
 
-#: src/ExternalConn.cpp:2378
+#: src/ExternalConn.cpp:2379
 msgid "Version check is not available on this daemon."
 msgstr ""
 
-#: src/ExternalConn.cpp:2508
+#: src/ExternalConn.cpp:2509
 msgid "File not found."
 msgstr "Datoteke ni mogoče najti."
 
-#: src/ExternalConn.cpp:2513
+#: src/ExternalConn.cpp:2514
 msgid "Invalid file name."
 msgstr "Neveljavno ime datoteke."
 
-#: src/ExternalConn.cpp:2521
+#: src/ExternalConn.cpp:2522
 msgid "Unable to rename file."
 msgstr "Ni mogoče preimenovati datoteke."
 
-#: src/ExternalConn.cpp:2992 src/ExternalConn.cpp:3020
+#: src/ExternalConn.cpp:2839
+#, c-format
+msgid "Could not save the amuleapi password: %s"
+msgstr ""
+
+#: src/ExternalConn.cpp:3004 src/ExternalConn.cpp:3032
 msgid "Kad is disabled in preferences."
 msgstr "Kad je onemogočen v nastavitvah."
 
-#: src/ExternalConn.cpp:3033
+#: src/ExternalConn.cpp:3045
 msgid "Already connected to eD2k."
 msgstr "Povezava z eD2k že obstaja."
 
-#: src/ExternalConn.cpp:3036
+#: src/ExternalConn.cpp:3048
 msgid "Connecting to eD2k..."
 msgstr "Povezovanje z eD2k …"
 
-#: src/ExternalConn.cpp:3045
+#: src/ExternalConn.cpp:3057
 msgid "Already connected to Kad."
 msgstr "Povezava s Kad že obstaja."
 
-#: src/ExternalConn.cpp:3048
+#: src/ExternalConn.cpp:3060
 msgid "Connecting to Kad..."
 msgstr "Povezovanje s Kad …"
 
-#: src/ExternalConn.cpp:3055
+#: src/ExternalConn.cpp:3067
 msgid "All networks are disabled."
 msgstr "Vsa omrežja so onemogočena."
 
-#: src/ExternalConn.cpp:3064
+#: src/ExternalConn.cpp:3076
 msgid "Disconnected from eD2k."
 msgstr "Povezava z eD2k prekinjena."
 
-#: src/ExternalConn.cpp:3069
+#: src/ExternalConn.cpp:3081
 msgid "Disconnected from Kad."
 msgstr "Povezava s Kad prekinjena."
 
-#: src/ExternalConn.cpp:3078
+#: src/ExternalConn.cpp:3090
 #, c-format
 msgid "External Connection: invalid opcode received: %#x"
 msgstr "Zunanja povezava: prejeta je bila neveljavna operacijska koda: %#x"
 
-#: src/ExternalConn.cpp:3083
+#: src/ExternalConn.cpp:3095
 msgid "Invalid opcode (wrong protocol version?)"
 msgstr "Neveljavna operacijska koda (napačna različica protokola?)"
 
@@ -2442,23 +2447,23 @@ msgid ""
 "want downloads on a different (e.g. larger) disk."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:549 src/FirstRunWizard.cpp:611 src/muuli_wdr.cpp:1708
+#: src/FirstRunWizard.cpp:549 src/FirstRunWizard.cpp:611 src/muuli_wdr.cpp:1712
 msgid "Destination folder for downloads"
 msgstr "Ciljna mapa za prejeto"
 
 #: src/FirstRunWizard.cpp:553 src/FirstRunWizard.cpp:569 src/muuli_wdr.cpp:1349
-#: src/muuli_wdr.cpp:1366 src/muuli_wdr.cpp:1683 src/muuli_wdr.cpp:1714
-#: src/muuli_wdr.cpp:1726 src/muuli_wdr.cpp:2769
+#: src/muuli_wdr.cpp:1366 src/muuli_wdr.cpp:1687 src/muuli_wdr.cpp:1718
+#: src/muuli_wdr.cpp:1730 src/muuli_wdr.cpp:2800
 #: src/utils/aLinkCreator/src/alcframe.cpp:135
 #: src/utils/wxCas/src/wxcasprefs.cpp:52 src/utils/wxCas/src/wxcasprefs.cpp:118
 msgid "Browse"
 msgstr "Brskanje"
 
-#: src/FirstRunWizard.cpp:559 src/muuli_wdr.cpp:1719
+#: src/FirstRunWizard.cpp:559 src/muuli_wdr.cpp:1723
 msgid "(All files in this folder are shared with other peers)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:565 src/FirstRunWizard.cpp:624 src/muuli_wdr.cpp:1721
+#: src/FirstRunWizard.cpp:565 src/FirstRunWizard.cpp:624 src/muuli_wdr.cpp:1725
 msgid "Folder for temporary download files"
 msgstr "Mapa za začasne datoteke prejemanj"
 
@@ -2489,7 +2494,7 @@ msgstr "Datoteke s seznamom prijateljev »emfriends.met« ni bilo moč odpreti z
 msgid "CRITICAL - no client on StartChatSession"
 msgstr "KRITIČNO – ni odjemalca za StartChatSession"
 
-#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2675 src/muuli_wdr.cpp:3352
+#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2706 src/muuli_wdr.cpp:3383
 msgid "Friends"
 msgstr "Prijatelji"
 
@@ -2600,8 +2605,8 @@ msgstr "Brez"
 msgid "No"
 msgstr "Ne"
 
-#: src/GenericClientListCtrl.cpp:1216 src/PrefsUnifiedDlg.cpp:2818
-#: src/PrefsUnifiedDlg.cpp:2868 src/ServerListCtrl.cpp:276
+#: src/GenericClientListCtrl.cpp:1216 src/PrefsUnifiedDlg.cpp:2898
+#: src/PrefsUnifiedDlg.cpp:2948 src/ServerListCtrl.cpp:276
 msgid "Yes"
 msgstr "Da"
 
@@ -2774,10 +2779,10 @@ msgstr "Neveljavna vrata za začetno nalaganje"
 msgid "Please fill all fields required"
 msgstr "Prosimo, izpolnite vsa zahtevana polja"
 
-#: src/KadDlg.cpp:192 src/PartFile.cpp:1031 src/PrefsUnifiedDlg.cpp:1162
-#: src/PrefsUnifiedDlg.cpp:1331 src/PrefsUnifiedDlg.cpp:1589
-#: src/PrefsUnifiedDlg.cpp:1599 src/PrefsUnifiedDlg.cpp:1616
-#: src/PrefsUnifiedDlg.cpp:1658
+#: src/KadDlg.cpp:192 src/PartFile.cpp:1031 src/PrefsUnifiedDlg.cpp:1134
+#: src/PrefsUnifiedDlg.cpp:1204 src/PrefsUnifiedDlg.cpp:1405
+#: src/PrefsUnifiedDlg.cpp:1663 src/PrefsUnifiedDlg.cpp:1673
+#: src/PrefsUnifiedDlg.cpp:1690 src/PrefsUnifiedDlg.cpp:1738
 msgid "Message"
 msgstr "Sporočilo"
 
@@ -2885,7 +2890,7 @@ msgstr "Delilno razmerje"
 msgid "Uploaded"
 msgstr "Poslano"
 
-#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3232
+#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3263
 msgid "Requested"
 msgstr "Zahtevano"
 
@@ -3009,7 +3014,7 @@ msgid "WARNING: "
 msgstr "OPOZORILO: "
 
 #: src/MuleNotebook.cpp:179 src/muuli_wdr.cpp:817 src/muuli_wdr.cpp:1229
-#: src/muuli_wdr.cpp:3136 src/muuli_wdr.cpp:3392
+#: src/muuli_wdr.cpp:3167 src/muuli_wdr.cpp:3423
 msgid "Close"
 msgstr "Zapri"
 
@@ -3027,7 +3032,7 @@ msgid "Paste"
 msgstr "Prilepi"
 
 #: src/MuleTextCtrl.cpp:89 src/muuli_wdr.cpp:358 src/muuli_wdr.cpp:757
-#: src/muuli_wdr.cpp:2359 src/muuli_wdr.cpp:2378 src/muuli_wdr.cpp:2400
+#: src/muuli_wdr.cpp:2390 src/muuli_wdr.cpp:2409 src/muuli_wdr.cpp:2431
 #: src/utils/aLinkCreator/src/alcframe.cpp:142
 msgid "Clear"
 msgstr "Počisti"
@@ -3126,7 +3131,7 @@ msgstr "Končaj"
 
 #: src/MuleTrayIcon.cpp:579 src/MuleTrayIcon.cpp:945 src/MuleTrayIcon.cpp:965
 #: src/muuli_wdr.cpp:1398 src/muuli_wdr.cpp:1406 src/muuli_wdr.cpp:1413
-#: src/muuli_wdr.cpp:1842 src/muuli_wdr.cpp:1848 src/OtherFunctions.cpp:91
+#: src/muuli_wdr.cpp:1846 src/muuli_wdr.cpp:1852 src/OtherFunctions.cpp:91
 #: src/StatisticsDlg.cpp:93 src/StatisticsDlg.cpp:95
 msgid "kB/s"
 msgstr "kB/s"
@@ -3368,7 +3373,7 @@ msgstr "Bajtov"
 msgid "KB"
 msgstr "KiB"
 
-#: src/muuli_wdr.cpp:274 src/muuli_wdr.cpp:293 src/muuli_wdr.cpp:1627
+#: src/muuli_wdr.cpp:274 src/muuli_wdr.cpp:293 src/muuli_wdr.cpp:1631
 #: src/OtherFunctions.cpp:64
 msgid "MB"
 msgstr "MiB"
@@ -3385,7 +3390,7 @@ msgstr "Maks. velikost"
 msgid "Availability"
 msgstr "Razpoložljivost"
 
-#: src/muuli_wdr.cpp:312 src/muuli_wdr.cpp:398 src/muuli_wdr.cpp:3297
+#: src/muuli_wdr.cpp:312 src/muuli_wdr.cpp:398 src/muuli_wdr.cpp:3328
 msgid "Filter:"
 msgstr "Filter:"
 
@@ -3448,12 +3453,12 @@ msgstr "Viri datoteke:"
 #: src/muuli_wdr.cpp:1160 src/muuli_wdr.cpp:1167 src/muuli_wdr.cpp:1172
 #: src/muuli_wdr.cpp:1179 src/muuli_wdr.cpp:1184 src/muuli_wdr.cpp:1191
 #: src/muuli_wdr.cpp:1205 src/muuli_wdr.cpp:1212 src/muuli_wdr.cpp:1217
-#: src/muuli_wdr.cpp:1224 src/muuli_wdr.cpp:3234 src/muuli_wdr.cpp:3242
-#: src/muuli_wdr.cpp:3250
+#: src/muuli_wdr.cpp:1224 src/muuli_wdr.cpp:3265 src/muuli_wdr.cpp:3273
+#: src/muuli_wdr.cpp:3281
 msgid "N/A"
 msgstr "Ni na voljo"
 
-#: src/muuli_wdr.cpp:508 src/muuli_wdr.cpp:1065 src/PrefsUnifiedDlg.cpp:297
+#: src/muuli_wdr.cpp:508 src/muuli_wdr.cpp:1065 src/PrefsUnifiedDlg.cpp:299
 msgid "General"
 msgstr "Splošno"
 
@@ -3594,7 +3599,7 @@ msgstr ""
 msgid "Album :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:685 src/muuli_wdr.cpp:2254
+#: src/muuli_wdr.cpp:685 src/muuli_wdr.cpp:2285
 msgid "Title :"
 msgstr "Naslov:"
 
@@ -3703,7 +3708,7 @@ msgstr "Uporabniško ime:"
 msgid "Userhash :"
 msgstr "Koda uporabnika:"
 
-#: src/muuli_wdr.cpp:895 src/muuli_wdr.cpp:1748 src/muuli_wdr.cpp:2449
+#: src/muuli_wdr.cpp:895 src/muuli_wdr.cpp:1752 src/muuli_wdr.cpp:2480
 #: src/utils/aLinkCreator/src/alcframe.cpp:137
 msgid "Add"
 msgstr "Dodaj"
@@ -3712,15 +3717,15 @@ msgstr "Dodaj"
 msgid "Download-Speed"
 msgstr "Hitrost prejemanja"
 
-#: src/muuli_wdr.cpp:954 src/muuli_wdr.cpp:989 src/muuli_wdr.cpp:2553
+#: src/muuli_wdr.cpp:954 src/muuli_wdr.cpp:989 src/muuli_wdr.cpp:2584
 msgid "Current"
 msgstr "Trenutno"
 
-#: src/muuli_wdr.cpp:962 src/muuli_wdr.cpp:997 src/muuli_wdr.cpp:2561
+#: src/muuli_wdr.cpp:962 src/muuli_wdr.cpp:997 src/muuli_wdr.cpp:2592
 msgid "Running average"
 msgstr "Trenutno povprečje"
 
-#: src/muuli_wdr.cpp:970 src/muuli_wdr.cpp:1005 src/muuli_wdr.cpp:2569
+#: src/muuli_wdr.cpp:970 src/muuli_wdr.cpp:1005 src/muuli_wdr.cpp:2600
 msgid "Session average"
 msgstr "Povprečje seje"
 
@@ -3732,7 +3737,7 @@ msgstr "Hitrost pošiljanja"
 msgid "Connections"
 msgstr "Povezave"
 
-#: src/muuli_wdr.cpp:1024 src/muuli_wdr.cpp:1867
+#: src/muuli_wdr.cpp:1024 src/muuli_wdr.cpp:1871
 msgid "Active downloads"
 msgstr "Dejavna prejemanja"
 
@@ -3740,7 +3745,7 @@ msgstr "Dejavna prejemanja"
 msgid "Active connections (1:1)"
 msgstr "Dejavne povezave (1:1)"
 
-#: src/muuli_wdr.cpp:1040 src/muuli_wdr.cpp:1868
+#: src/muuli_wdr.cpp:1040 src/muuli_wdr.cpp:1872
 msgid "Active uploads"
 msgstr "Dejavna pošiljanja"
 
@@ -4017,7 +4022,7 @@ msgstr "Krajevni naslov poveži z IP-jem (prazno za poljuben):"
 msgid "Advanced users only: If you have multiple network interfaces, enter the address of the interface to which aMule should be bound."
 msgstr "Samo za napredne uporabnike: če imate več omrežnih vmesnikov, vnesite naslov vmesnika, s katerim bo povezan aMule."
 
-#: src/muuli_wdr.cpp:1462 src/muuli_wdr.cpp:2061
+#: src/muuli_wdr.cpp:1462 src/muuli_wdr.cpp:2065
 #, fuzzy
 msgid "Bind to network interface (empty for any):"
 msgstr "Krajevni naslov poveži z IP-jem (prazno za poljuben):"
@@ -4034,7 +4039,7 @@ msgstr "Največ virov na prejemanje:"
 msgid "Max simultaneous connections:"
 msgstr "Največ istočasnih povezav:"
 
-#: src/muuli_wdr.cpp:1498 src/muuli_wdr.cpp:3176
+#: src/muuli_wdr.cpp:1498 src/muuli_wdr.cpp:3207
 msgid "ED2K"
 msgstr "eD2k"
 
@@ -4126,757 +4131,780 @@ msgstr "Novim datotekam vnaprej dodeli prostor na disku"
 msgid "For new files preallocates disk space for the whole file, thus reduces fragmentation"
 msgstr "Za nove datoteke v naprej dodeli prostor na disku v velikosti celotne datoteke, kar zmanjša razdrobljenost."
 
-#: src/muuli_wdr.cpp:1613
+#: src/muuli_wdr.cpp:1617
 msgid "Create new files as sparse files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1614
-msgid "A sparse file reserves its full size on disk immediately without writing real data to it -- fast, but unsupported or slow on some filesystems, and free-space accounting stays optimistic while the download is in progress. Turn this off to grow the file only as data arrives."
+#: src/muuli_wdr.cpp:1618
+msgid "Sparse part files only occupy disk space for the parts already downloaded, so free space is used up gradually as the file fills in. Turn this off to use an ordinary file instead - useful where sparse files are unsupported or slow, or where backup/de-duplication tools handle them badly. Applies only when the core runs on Windows; on Linux and macOS part files are sparse anyway and this setting has no effect."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1619
+#: src/muuli_wdr.cpp:1623
 msgid "Stop downloads when free disk space reaches "
 msgstr "Ustavi prejemanja, ko prostor na disku doseže "
 
-#: src/muuli_wdr.cpp:1620
+#: src/muuli_wdr.cpp:1624
 msgid "Select this if you want aMule to check your disk space"
 msgstr "Izberite, če želite, da aMule preverja prostor na disku"
 
-#: src/muuli_wdr.cpp:1624
+#: src/muuli_wdr.cpp:1628
 msgid "Enter here the min disk space desired."
 msgstr "Sem vnesite min. želen prostor na disku."
 
-#: src/muuli_wdr.cpp:1630
+#: src/muuli_wdr.cpp:1634
 msgid "Save 10 sources on rare files (< 20 sources)"
 msgstr "Shrani 10 virov pri redkih datotekah (< 20 virov)"
 
-#: src/muuli_wdr.cpp:1634 src/Statistics.cpp:790
+#: src/muuli_wdr.cpp:1638 src/Statistics.cpp:790
 msgid "Uploads"
 msgstr "Pošiljanja"
 
-#: src/muuli_wdr.cpp:1637
+#: src/muuli_wdr.cpp:1641
 msgid "Add new shared files with auto priority"
 msgstr "Nove deljene datoteke naj imajo samodejno prednost"
 
-#: src/muuli_wdr.cpp:1643
+#: src/muuli_wdr.cpp:1647
 msgid "Intelligent Corruption Handling (I.C.H.)"
 msgstr "Inteligentno rokovanje s poškodbami (I.R.P.)"
 
-#: src/muuli_wdr.cpp:1646
+#: src/muuli_wdr.cpp:1650
 msgid "Enable"
 msgstr "Omogoči"
 
-#: src/muuli_wdr.cpp:1649
+#: src/muuli_wdr.cpp:1653
 msgid "Advanced I.C.H. trusts every hash (not recommended)"
 msgstr "Napredni I.R.P. zaupa vsaki kodi (ni priporočeno)"
 
-#: src/muuli_wdr.cpp:1661 src/PrefsUnifiedDlg.cpp:1910
+#: src/muuli_wdr.cpp:1665 src/PrefsUnifiedDlg.cpp:1990
 msgid "Media metadata extraction"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1665
+#: src/muuli_wdr.cpp:1669
 msgid "Extract length / bitrate / codec from shared audio and video files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1667
+#: src/muuli_wdr.cpp:1671
 msgid "When enabled, aMule runs ffprobe on each shared media file to fill in the Length / Bitrate / Codec columns other clients see when they find the file in a search. Requires ffmpeg (the ffprobe binary) to be installed."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1674
+#: src/muuli_wdr.cpp:1678
 msgid "Path to ffprobe:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1679
+#: src/muuli_wdr.cpp:1683
 msgid "Full path to the ffprobe binary. Leave empty to have aMule auto-detect it on startup."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1687
+#: src/muuli_wdr.cpp:1691
 msgid "Detect"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1688
+#: src/muuli_wdr.cpp:1692
 msgid "Search the standard install locations for an ffprobe binary and fill the path field."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1712
+#: src/muuli_wdr.cpp:1716
 msgid ""
 "Completed downloads are stored here. All files in this folder are automatically shared with other peers.\n"
 "If this folder also holds files you don't want to share, point it at an aMule-only sub-folder."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1715
+#: src/muuli_wdr.cpp:1719
 msgid "Pick the folder where completed downloads will be stored. All files in that folder will be shared with other peers."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1729
+#: src/muuli_wdr.cpp:1733
 msgid "Shared folders"
 msgstr "Deljene mape"
 
-#: src/muuli_wdr.cpp:1735
+#: src/muuli_wdr.cpp:1739
 msgid "(Folders shared by the core. Enter a path to add one.)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1743
+#: src/muuli_wdr.cpp:1747
 msgid "Absolute path of a folder on the core's machine, e.g. /home/user/shared"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1745 src/PrefsUnifiedDlg.cpp:2794
+#: src/muuli_wdr.cpp:1749 src/PrefsUnifiedDlg.cpp:2874
 msgid "Recursive"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1746
+#: src/muuli_wdr.cpp:1750
 msgid "Share every sub-folder underneath this one, including ones created later."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1750 src/utils/aLinkCreator/src/alcframe.cpp:141
+#: src/muuli_wdr.cpp:1754 src/utils/aLinkCreator/src/alcframe.cpp:141
 msgid "Remove"
 msgstr "Odstrani"
 
-#: src/muuli_wdr.cpp:1754
+#: src/muuli_wdr.cpp:1758
 msgid "(Right click on folder icon for recursive share)"
 msgstr "(desni klik na ikono mape izbere tudi podmape)"
 
-#: src/muuli_wdr.cpp:1761
+#: src/muuli_wdr.cpp:1765
 msgid "Share hidden files"
 msgstr "Deli skrite datoteke"
 
-#: src/muuli_wdr.cpp:1767
+#: src/muuli_wdr.cpp:1771
 msgid "Automatically rescan shared folders for changes"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1773
+#: src/muuli_wdr.cpp:1777
 msgid "Follow symbolic links in shared folders"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1779
+#: src/muuli_wdr.cpp:1783
 msgid "Exclude files matching:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1782
+#: src/muuli_wdr.cpp:1786
 msgid "Wildcard patterns separated by '|', e.g. .DS_Store|Thumbs.db|*.tmp. Files whose name matches are not shared. Matching is case-insensitive."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1786
+#: src/muuli_wdr.cpp:1790
 msgid "Patterns are regular expressions"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1787
+#: src/muuli_wdr.cpp:1791
 msgid "When set, the whole field is one regular expression ('|' is alternation). When unset, it is a list of '|'-separated wildcards."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1797
+#: src/muuli_wdr.cpp:1801
 msgid "Show how many shared files the current pattern would exclude."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1818
+#: src/muuli_wdr.cpp:1822
 msgid "Graphs"
 msgstr "Grafi"
 
-#: src/muuli_wdr.cpp:1821 src/muuli_wdr.cpp:1883
+#: src/muuli_wdr.cpp:1825 src/muuli_wdr.cpp:1887
 msgid "Update delay : 5 secs"
 msgstr "Zamik posodabljanja: 5 sek."
 
-#: src/muuli_wdr.cpp:1825
+#: src/muuli_wdr.cpp:1829
 msgid "Time for average graph: 100 mins"
 msgstr "Čas za graf povprečja: 100 min."
 
-#: src/muuli_wdr.cpp:1829
+#: src/muuli_wdr.cpp:1833
 msgid "Connections Graph Scale: 100 "
 msgstr "Merilo za graf povezav: 100 "
 
-#: src/muuli_wdr.cpp:1836
+#: src/muuli_wdr.cpp:1840
 msgid "Download graph scale:"
 msgstr "Merilo za graf prejemanj:"
 
-#: src/muuli_wdr.cpp:1844
+#: src/muuli_wdr.cpp:1848
 msgid "Upload graph scale:"
 msgstr "Merilo za graf pošiljanj:"
 
-#: src/muuli_wdr.cpp:1854
+#: src/muuli_wdr.cpp:1858
 #, fuzzy
 msgid "Colors: "
 msgstr "Barve: "
 
-#: src/muuli_wdr.cpp:1858
+#: src/muuli_wdr.cpp:1862
 msgid "Background"
 msgstr "Ozadje"
 
-#: src/muuli_wdr.cpp:1859
+#: src/muuli_wdr.cpp:1863
 msgid "Grid"
 msgstr "Mreža"
 
-#: src/muuli_wdr.cpp:1860
+#: src/muuli_wdr.cpp:1864
 msgid "Download current"
 msgstr "Trenutno prejemanje"
 
-#: src/muuli_wdr.cpp:1861
+#: src/muuli_wdr.cpp:1865
 msgid "Download running average"
 msgstr "Povprečje prejemanja"
 
-#: src/muuli_wdr.cpp:1862
+#: src/muuli_wdr.cpp:1866
 msgid "Download session average"
 msgstr "Povprečje seje za prejemanje"
 
-#: src/muuli_wdr.cpp:1863
+#: src/muuli_wdr.cpp:1867
 msgid "Upload current"
 msgstr "Trenutno pošiljanje"
 
-#: src/muuli_wdr.cpp:1864
+#: src/muuli_wdr.cpp:1868
 msgid "Upload running average"
 msgstr "Povprečje pošiljanja"
 
-#: src/muuli_wdr.cpp:1865
+#: src/muuli_wdr.cpp:1869
 msgid "Upload session average"
 msgstr "Povprečje seje za pošiljanje"
 
-#: src/muuli_wdr.cpp:1866
+#: src/muuli_wdr.cpp:1870
 msgid "Active connections"
 msgstr "Dejavne povezave"
 
-#: src/muuli_wdr.cpp:1869
+#: src/muuli_wdr.cpp:1873
 #, fuzzy
 msgid "Systray Icon Speed Bar"
 msgstr "Prikaz hitrosti v sistemski vrstici"
 
-#: src/muuli_wdr.cpp:1870
+#: src/muuli_wdr.cpp:1874
 msgid "Kad-nodes current"
 msgstr "Trenutna vozlišča Kad"
 
-#: src/muuli_wdr.cpp:1871
+#: src/muuli_wdr.cpp:1875
 msgid "Kad-nodes running"
 msgstr "Vozlišča Kad v teku"
 
-#: src/muuli_wdr.cpp:1872
+#: src/muuli_wdr.cpp:1876
 msgid "Kad-nodes session"
 msgstr "Vozlišča Kad te seje"
 
-#: src/muuli_wdr.cpp:1876 src/muuli_wdr.cpp:2303
+#: src/muuli_wdr.cpp:1880 src/muuli_wdr.cpp:2334
 msgid "Select"
 msgstr "Izberi"
 
-#: src/muuli_wdr.cpp:1880
+#: src/muuli_wdr.cpp:1884
 msgid "Tree"
 msgstr "Drevo"
 
-#: src/muuli_wdr.cpp:1890
+#: src/muuli_wdr.cpp:1894
 msgid "Number of Client Versions shown (0=unlimited)"
 msgstr "Število prikazanih različic odjemalcev (0 = neomejeno)"
 
-#: src/muuli_wdr.cpp:1915
+#: src/muuli_wdr.cpp:1919
 msgid "!!! WARNING !!!"
 msgstr "!!! OPOZORILO !!!"
 
-#: src/muuli_wdr.cpp:1930
+#: src/muuli_wdr.cpp:1934
 msgid "Max new connections / 5 secs"
 msgstr "Maks. novih povezav / 5 sek."
 
-#: src/muuli_wdr.cpp:1932
+#: src/muuli_wdr.cpp:1936
 msgid "Concurrent Kad source lookups"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1934
+#: src/muuli_wdr.cpp:1938
 #, fuzzy
 msgid "Kad source re-search interval (minutes)"
 msgstr "Interval med osvežitvami FTP-ja v minutah"
 
-#: src/muuli_wdr.cpp:1936
+#: src/muuli_wdr.cpp:1940
 #, fuzzy
 msgid "Source re-ask interval (minutes)"
 msgstr "Interval med osvežitvami FTP-ja v minutah"
 
-#: src/muuli_wdr.cpp:1940
+#: src/muuli_wdr.cpp:1944
 msgid "File Buffer Size: 240000 bytes"
 msgstr "Datotečni medpomnilnik: 240000 bajtov"
 
-#: src/muuli_wdr.cpp:1944
+#: src/muuli_wdr.cpp:1948
 msgid "Use MMAP: memory-mapped file access (lower memory use)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1945
+#: src/muuli_wdr.cpp:1949
 msgid "Maps part files into memory instead of buffering them on the heap, lowering the process memory footprint. May reduce download speed on some disks; best for memory-constrained or upload-heavy hosts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1947
+#: src/muuli_wdr.cpp:1951
 msgid "Upload Queue Size: 5000 clients"
 msgstr "Velikost vrste za pošiljanje: 5000 odjemalcev"
 
-#: src/muuli_wdr.cpp:1951
+#: src/muuli_wdr.cpp:1955
 msgid "Server connection refresh interval: Disable"
 msgstr "Čas med osvežitvama povezave na strežnik: onemogoči"
 
-#: src/muuli_wdr.cpp:1955
+#: src/muuli_wdr.cpp:1959
 msgid "Disable computer's timed standby mode"
 msgstr "Onemogoči prehod računalnika v pripravljenost"
 
-#: src/muuli_wdr.cpp:1974
+#: src/muuli_wdr.cpp:1978
 msgid "Skin to use: "
 msgstr "Uporabljena preobleka: "
 
-#: src/muuli_wdr.cpp:1983
+#: src/muuli_wdr.cpp:1987
 msgid "Show \"Fast eD2k Links Handler\" in every window."
 msgstr "Prikaži hitri rokovalnik s povezavami eD2k v vsakem oknu."
 
-#: src/muuli_wdr.cpp:1986
+#: src/muuli_wdr.cpp:1990
 msgid "Show extended info on categories tabs"
 msgstr "Prikaži razširjene podatke na zavihkih kategorij"
 
-#: src/muuli_wdr.cpp:1989
+#: src/muuli_wdr.cpp:1993
 msgid "Show application version on title"
 msgstr "V naslovni vrstici pokaži različico programa"
 
-#: src/muuli_wdr.cpp:1991
+#: src/muuli_wdr.cpp:1995
 msgid "Show transfer rates on title"
 msgstr "Kaži hitrosti prenosa v naslovni vrstici"
 
-#: src/muuli_wdr.cpp:1993
+#: src/muuli_wdr.cpp:1997
 msgid "Before application name"
 msgstr "Pred imenom programa"
 
-#: src/muuli_wdr.cpp:1995
+#: src/muuli_wdr.cpp:1999
 msgid "After application name"
 msgstr "Za imenom programa"
 
-#: src/muuli_wdr.cpp:1998
+#: src/muuli_wdr.cpp:2002
 msgid "Show overhead bandwidth"
 msgstr "Kaži presežek prenosov"
 
-#: src/muuli_wdr.cpp:2002
+#: src/muuli_wdr.cpp:2006
 msgid "Vertical toolbar orientation"
 msgstr "Usmeri orodjarno navpično"
 
-#: src/muuli_wdr.cpp:2004
+#: src/muuli_wdr.cpp:2008
 msgid "Live column sorting (auto-reorder rows as their values change)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2011
+#: src/muuli_wdr.cpp:2015
 msgid "Download Queue Files"
 msgstr "Datoteke v vrsti prejemanj"
 
-#: src/muuli_wdr.cpp:2014
+#: src/muuli_wdr.cpp:2018
 msgid "Show progress percentage"
 msgstr "Prikaži odstotek napredka"
 
-#: src/muuli_wdr.cpp:2020
+#: src/muuli_wdr.cpp:2024
 msgid "Show progress bar"
 msgstr "Prikaži črto napredka"
 
-#: src/muuli_wdr.cpp:2023
+#: src/muuli_wdr.cpp:2027
 msgid "Flat"
 msgstr "Plosko"
 
-#: src/muuli_wdr.cpp:2027
+#: src/muuli_wdr.cpp:2031
 msgid "Round"
 msgstr "Zaokroženo"
 
-#: src/muuli_wdr.cpp:2045
+#: src/muuli_wdr.cpp:2049
 msgid "External Connection Parameters"
 msgstr "Parametri za zunanje povezave"
 
-#: src/muuli_wdr.cpp:2048
+#: src/muuli_wdr.cpp:2052
 msgid "Accept external connections"
 msgstr "Sprejmi zunanje povezave"
 
-#: src/muuli_wdr.cpp:2055 src/muuli_wdr.cpp:2114
+#: src/muuli_wdr.cpp:2059 src/muuli_wdr.cpp:2118
 msgid "IP of the listening interface:"
 msgstr "IP vmesnika, ki posluša:"
 
-#: src/muuli_wdr.cpp:2058
+#: src/muuli_wdr.cpp:2062
 msgid "Enter here a valid ip in the a.b.c.d format for the listening EC interface. An empty field or 0.0.0.0 will mean any interface."
 msgstr "Sem vnesite veljaven IP v formatu a.b.c.d za poslušalen vmesnik. Prazno polje ali 0.0.0.0 pomeni poljuben vmesnik."
 
-#: src/muuli_wdr.cpp:2079 src/muuli_wdr.cpp:2163
+#: src/muuli_wdr.cpp:2083 src/muuli_wdr.cpp:2194
 msgid "TCP port:"
 msgstr "Vrata TCP:"
 
-#: src/muuli_wdr.cpp:2085
+#: src/muuli_wdr.cpp:2089
 msgid "Enable UPnP port forwarding on the EC port"
 msgstr "Vklopi posredovanje vrat UPnP za vrata zunanjih povezav"
 
-#: src/muuli_wdr.cpp:2089 src/muuli_wdr.cpp:3048
+#: src/muuli_wdr.cpp:2093 src/muuli_wdr.cpp:3079
 #: src/utils/wxCas/src/wxcasprefs.cpp:167
 msgid "Password"
 msgstr "Geslo"
 
-#: src/muuli_wdr.cpp:2095
+#: src/muuli_wdr.cpp:2099
 #, fuzzy
 msgid "aMule API server parameters"
 msgstr "Parametri spletnega strežnika"
 
-#: src/muuli_wdr.cpp:2098
+#: src/muuli_wdr.cpp:2102
 msgid "Run amuleapi (REST API) on startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2103
+#: src/muuli_wdr.cpp:2107
 #, fuzzy
 msgid "HTTP port:"
 msgstr "Vrata TCP:"
 
-#: src/muuli_wdr.cpp:2117
+#: src/muuli_wdr.cpp:2121
 msgid "The interface amuleapi's HTTP server listens on. 127.0.0.1 (default) accepts only local connections; use 0.0.0.0 or a specific IP to expose it to other hosts (set an admin password below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2120
+#: src/muuli_wdr.cpp:2126
+msgid "Type a password to set or change it. Stored passwords cannot be shown, so leaving this empty keeps the current one."
+msgstr ""
+
+#: src/muuli_wdr.cpp:2128
 #, fuzzy
 msgid "Admin password"
 msgstr "Preverjanje gesla\n"
 
-#: src/muuli_wdr.cpp:2125 src/muuli_wdr.cpp:2156
-msgid "Low rights password"
-msgstr "Geslo za nizke pravice"
+#: src/muuli_wdr.cpp:2140 src/muuli_wdr.cpp:2157 src/PrefsUnifiedDlg.cpp:1103
+#, fuzzy
+msgid "A password is set."
+msgstr "Preverjanje gesla\n"
 
-#: src/muuli_wdr.cpp:2133
+#: src/muuli_wdr.cpp:2144
+#, fuzzy
+msgid "Enable guest access"
+msgstr "Zavrni dostop gostom"
+
+#: src/muuli_wdr.cpp:2145
+msgid "Guest sessions may read status and listings but cannot change anything. Turning this off clears the stored guest password."
+msgstr ""
+
+#: src/muuli_wdr.cpp:2149
+#, fuzzy
+msgid "Guest password"
+msgstr "Geslo za goste na spletnem strežniku"
+
+#: src/muuli_wdr.cpp:2164
 msgid "Web server parameters"
 msgstr "Parametri spletnega strežnika"
 
-#: src/muuli_wdr.cpp:2136
+#: src/muuli_wdr.cpp:2167
 #, fuzzy
 msgid "Run webserver on startup (deprecated)"
 msgstr "Spletni strežnik zaženi ob zagonu"
 
-#: src/muuli_wdr.cpp:2142
+#: src/muuli_wdr.cpp:2173
 msgid "Web template"
 msgstr "Spletna predloga"
 
-#: src/muuli_wdr.cpp:2147
+#: src/muuli_wdr.cpp:2178
 msgid "Full rights password"
 msgstr "Geslo za vse pravice"
 
-#: src/muuli_wdr.cpp:2151
+#: src/muuli_wdr.cpp:2182
 msgid "Enable Low rights User"
 msgstr "Omogoči uporabnika z nizkimi pravicami"
 
-#: src/muuli_wdr.cpp:2170
+#: src/muuli_wdr.cpp:2187
+msgid "Low rights password"
+msgstr "Geslo za nizke pravice"
+
+#: src/muuli_wdr.cpp:2201
 msgid "Enable UPnP port forwarding of the web server port"
 msgstr "Vklopi posredovanje vrat UPnP za vrata spletnega strežnika"
 
-#: src/muuli_wdr.cpp:2175
+#: src/muuli_wdr.cpp:2206
 msgid "Web server UPnP TCP port (Optional)"
 msgstr "Vrata TCP za UPnP za spletni strežnik (neobvezno)"
 
-#: src/muuli_wdr.cpp:2183
+#: src/muuli_wdr.cpp:2214
 msgid "Page Refresh Time (in secs)"
 msgstr "Čas med osvežitvami strani (v sek.)"
 
-#: src/muuli_wdr.cpp:2190
+#: src/muuli_wdr.cpp:2221
 msgid "Enable Gzip compression"
 msgstr "Omogoči stiskanje gzip"
 
-#: src/muuli_wdr.cpp:2224
+#: src/muuli_wdr.cpp:2255
 #, fuzzy
 msgid "Reset page to defaults"
 msgstr "Sistemsko privzet"
 
-#: src/muuli_wdr.cpp:2225
+#: src/muuli_wdr.cpp:2256
 msgid "Reset the settings on the current page to their default values."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2227 src/muuli_wdr.cpp:2313 src/ServerWnd.cpp:274
+#: src/muuli_wdr.cpp:2258 src/muuli_wdr.cpp:2344 src/ServerWnd.cpp:274
 #: src/ServerWnd.cpp:282
 msgid "OK"
 msgstr "V redu"
 
-#: src/muuli_wdr.cpp:2229
+#: src/muuli_wdr.cpp:2260
 msgid "Click here to apply any changes made to the preferences."
 msgstr "Kliknite tukaj za uveljavitev sprememb v nastavitvah."
 
-#: src/muuli_wdr.cpp:2232
+#: src/muuli_wdr.cpp:2263
 msgid "Reset any changes made to the preferences."
 msgstr "Razveljavi vse spremembe v nastavitvah."
 
-#: src/muuli_wdr.cpp:2261
+#: src/muuli_wdr.cpp:2292
 msgid "Comment :"
 msgstr "Komentar:"
 
-#: src/muuli_wdr.cpp:2268
+#: src/muuli_wdr.cpp:2299
 msgid "Incoming Dir :"
 msgstr "Mapa za prejeto:"
 
-#: src/muuli_wdr.cpp:2277
+#: src/muuli_wdr.cpp:2308
 msgid "Change priority for new assigned files :"
 msgstr "Spremeni prednost novo dodeljenim datotekam:"
 
-#: src/muuli_wdr.cpp:2281
+#: src/muuli_wdr.cpp:2312
 msgid "Don't change"
 msgstr "Ne spremeni"
 
-#: src/muuli_wdr.cpp:2293
+#: src/muuli_wdr.cpp:2324
 msgid "Select color for this Category (currently selected) :"
 msgstr "Izberite barvo za to kategorijo (trenutno izbrano):"
 
-#: src/muuli_wdr.cpp:2360 src/muuli_wdr.cpp:2379 src/muuli_wdr.cpp:2401
+#: src/muuli_wdr.cpp:2391 src/muuli_wdr.cpp:2410 src/muuli_wdr.cpp:2432
 msgid "Click this button to reset the log."
 msgstr "Kliknite ta gumb, da ponastavite dnevnik."
 
-#: src/muuli_wdr.cpp:2420
+#: src/muuli_wdr.cpp:2451
 msgid "Click on this button to update the servers list from URL ..."
 msgstr "Kliknite ta gumb za posodobitev seznama strežnikov iz URL-ja."
 
-#: src/muuli_wdr.cpp:2424
+#: src/muuli_wdr.cpp:2455
 msgid "Server list"
 msgstr "Seznam strežnikov"
 
-#: src/muuli_wdr.cpp:2428
+#: src/muuli_wdr.cpp:2459
 msgid "Enter the url to a server.met file here and press the button to the left to update the list of known servers."
 msgstr "Vnesite URL do datoteke server.met in kliknite gumb na levi, da posodobite seznam strežnikov."
 
-#: src/muuli_wdr.cpp:2433
+#: src/muuli_wdr.cpp:2464
 msgid "Add server manually: Name"
 msgstr "Ročno dodaj strežnik: ime"
 
-#: src/muuli_wdr.cpp:2436
+#: src/muuli_wdr.cpp:2467
 msgid "Enter the name of the new server here"
 msgstr "Sem vnesite ime novega strežnika"
 
-#: src/muuli_wdr.cpp:2438 src/ServerWnd.cpp:206
+#: src/muuli_wdr.cpp:2469 src/ServerWnd.cpp:206
 msgid "IP:Port"
 msgstr "IP:Vrata"
 
-#: src/muuli_wdr.cpp:2441
+#: src/muuli_wdr.cpp:2472
 msgid "Enter the IP of the server here, using the x.x.x.x format."
 msgstr "Sem vnesite IP strežnika v formatu x.x.x.x."
 
-#: src/muuli_wdr.cpp:2447
+#: src/muuli_wdr.cpp:2478
 msgid "Enter the port of the server here."
 msgstr "Sem vnesite vrata strežnika."
 
-#: src/muuli_wdr.cpp:2450
+#: src/muuli_wdr.cpp:2481
 msgid "Add manually a server (fill fields to the left before) ..."
 msgstr "Ročno dodaj strežnik (najprej izpolnite vsa polja) …"
 
-#: src/muuli_wdr.cpp:2479
+#: src/muuli_wdr.cpp:2510
 msgid "aMule Log"
 msgstr "aMule dnevnik"
 
-#: src/muuli_wdr.cpp:2487
+#: src/muuli_wdr.cpp:2518
 msgid "Server Info"
 msgstr "Podatki o strežniku"
 
-#: src/muuli_wdr.cpp:2491
+#: src/muuli_wdr.cpp:2522
 msgid "ED2K Info"
 msgstr "Podatki o eD2k"
 
-#: src/muuli_wdr.cpp:2495
+#: src/muuli_wdr.cpp:2526
 msgid "Kad Info"
 msgstr "Podatki o Kad"
 
-#: src/muuli_wdr.cpp:2523
+#: src/muuli_wdr.cpp:2554
 msgid "Click on this button to update the nodes list from URL ..."
 msgstr "Kliknite ta gumb za posodobitev seznama vozlišč iz URL-ja."
 
-#: src/muuli_wdr.cpp:2527
+#: src/muuli_wdr.cpp:2558
 msgid "Nodes (0)"
 msgstr "Vozlišča (0)"
 
-#: src/muuli_wdr.cpp:2531
+#: src/muuli_wdr.cpp:2562
 msgid "Enter the url to a nodes.dat file here and press the button to the left to update the list of known nodes."
 msgstr "Vnesite URL do datoteke nodes.dat in pritisnite gumb na levi za posodobitev seznama vozlišč."
 
-#: src/muuli_wdr.cpp:2534
+#: src/muuli_wdr.cpp:2565
 msgid "Nodes stats"
 msgstr "Statistika vozlišč"
 
-#: src/muuli_wdr.cpp:2576
+#: src/muuli_wdr.cpp:2607
 msgid "Bootstrap"
 msgstr "Začetno nalaganje"
 
-#: src/muuli_wdr.cpp:2579
+#: src/muuli_wdr.cpp:2610
 msgid "New node"
 msgstr "Novo vozlišče"
 
-#: src/muuli_wdr.cpp:2584
+#: src/muuli_wdr.cpp:2615
 msgid "IP:"
 msgstr "IP:"
 
-#: src/muuli_wdr.cpp:2604
+#: src/muuli_wdr.cpp:2635
 msgid "Port:"
 msgstr "Vrata:"
 
-#: src/muuli_wdr.cpp:2617
+#: src/muuli_wdr.cpp:2648
 msgid "Bootstrap from known clients"
 msgstr ""
 "Naloži od znanih \n"
 "odjemalcev"
 
-#: src/muuli_wdr.cpp:2619
+#: src/muuli_wdr.cpp:2650
 msgid "Disconnect Kad"
 msgstr "Prekini povezavo s Kad"
 
-#: src/muuli_wdr.cpp:2653
+#: src/muuli_wdr.cpp:2684
 msgid "Use Secure User Identification"
 msgstr "Uporabi varno identifikacijo uporabnikov"
 
-#: src/muuli_wdr.cpp:2655
+#: src/muuli_wdr.cpp:2686
 msgid "It is recommended to enable this option. You will not receive credits if SUI is not enabled."
 msgstr "Priporočamo, da omogočite to možnost. Če to ni omogočeno, ne boste prejeli točk za zasluge."
 
-#: src/muuli_wdr.cpp:2657
+#: src/muuli_wdr.cpp:2688
 msgid "Protocol Obfuscation"
 msgstr "Maskiranje protokola"
 
-#: src/muuli_wdr.cpp:2660
+#: src/muuli_wdr.cpp:2691
 msgid "Support Protocol Obfuscation"
 msgstr "Omogoči maskiranje protokola"
 
-#: src/muuli_wdr.cpp:2662
+#: src/muuli_wdr.cpp:2693
 msgid "This option enabled Protocol Obfuscation, and makes aMule accept obfuscated connections from other clients."
 msgstr "Ob vklopu te možnosti, bo aMule sprejemal maskirane povezave od drugih odjemalcev."
 
-#: src/muuli_wdr.cpp:2664
+#: src/muuli_wdr.cpp:2695
 msgid "Use obfuscation for outgoing connections"
 msgstr "Uporabi maskiranje za izhodne povezave"
 
-#: src/muuli_wdr.cpp:2666
+#: src/muuli_wdr.cpp:2697
 msgid "This option makes aMule use Protocol Obfuscation when connecting other clients/servers."
 msgstr "Ob vklopu te možnosti, bo aMule uporabil maskiranje pri povezavi z drugimi odjemalci in na strežnike."
 
-#: src/muuli_wdr.cpp:2668
+#: src/muuli_wdr.cpp:2699
 msgid "Accept only obfuscated connections"
 msgstr "Dovoli samo maskirane povezave"
 
-#: src/muuli_wdr.cpp:2669
+#: src/muuli_wdr.cpp:2700
 msgid "This option makes aMule only accept obfuscated connections. You will have less sources, but all your traffic will be obfuscated"
 msgstr "Ob vklopu te možnosti, bo aMule sprejemal samo maskirane povezave. Imeli boste manj virov, vendar bodo vse povezave maskirane."
 
-#: src/muuli_wdr.cpp:2674
+#: src/muuli_wdr.cpp:2705
 msgid "Everybody"
 msgstr "Vsi"
 
-#: src/muuli_wdr.cpp:2676
+#: src/muuli_wdr.cpp:2707
 msgid "No one"
 msgstr "Nihče"
 
-#: src/muuli_wdr.cpp:2678
+#: src/muuli_wdr.cpp:2709
 msgid "Who can see my shared files:"
 msgstr "Kdo lahko vidi moje deljene datoteke:"
 
-#: src/muuli_wdr.cpp:2679
+#: src/muuli_wdr.cpp:2710
 msgid "Select who can request to view a list of your shared files."
 msgstr "Izberite, kdo lahko zahteva vaš seznam deljenih datotek."
 
-#: src/muuli_wdr.cpp:2681
+#: src/muuli_wdr.cpp:2712
 msgid "IP-Filtering"
 msgstr "Filtriranje IP-jev"
 
-#: src/muuli_wdr.cpp:2688
+#: src/muuli_wdr.cpp:2719
 msgid "Filter clients"
 msgstr "Filtriraj odjemalce"
 
-#: src/muuli_wdr.cpp:2690
+#: src/muuli_wdr.cpp:2721
 msgid "Enable filtering of the client IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "Omogoči filtriranje odjemalčevih IP-jev, določenih v datoteki ~/.aMule/ipfilter.dat."
 
-#: src/muuli_wdr.cpp:2692
+#: src/muuli_wdr.cpp:2723
 msgid "Filter servers"
 msgstr "Filtriraj strežnike"
 
-#: src/muuli_wdr.cpp:2694
+#: src/muuli_wdr.cpp:2725
 msgid "Enable filtering of the server IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "Omogoči filtriranje strežnikovih IP-jev, določenih v datoteki ~/.aMule/ipfilter.dat."
 
-#: src/muuli_wdr.cpp:2698
+#: src/muuli_wdr.cpp:2729
 msgid "Reload List"
 msgstr "Znova naloži seznam"
 
-#: src/muuli_wdr.cpp:2699
+#: src/muuli_wdr.cpp:2730
 msgid "Reload the list of IPs to filter from the file ~/.aMule/ipfilter.dat"
 msgstr "Ponovno naloži seznam IP-jev za filtriranje iz ~/.aMule/ipfilter.dat."
 
-#: src/muuli_wdr.cpp:2705
+#: src/muuli_wdr.cpp:2736
 msgid "URL:"
 msgstr "URL:"
 
-#: src/muuli_wdr.cpp:2709 src/muuli_wdr.cpp:2902
+#: src/muuli_wdr.cpp:2740 src/muuli_wdr.cpp:2933
 msgid "Update now"
 msgstr "Posodobi zdaj"
 
-#: src/muuli_wdr.cpp:2712
+#: src/muuli_wdr.cpp:2743
 msgid "Auto-update ipfilter at startup"
 msgstr "Samodejno posodobi filter IP-jev ob zagonu"
 
-#: src/muuli_wdr.cpp:2716
+#: src/muuli_wdr.cpp:2747
 msgid "Filtering Level:"
 msgstr "Stopnja filtriranja:"
 
-#: src/muuli_wdr.cpp:2722
+#: src/muuli_wdr.cpp:2753
 msgid "Always filter LAN IPs"
 msgstr "Vedno filtriraj IP-je krajevnega omrežja"
 
-#: src/muuli_wdr.cpp:2725
+#: src/muuli_wdr.cpp:2756
 msgid "Paranoid handling of non-matching IPs"
 msgstr "Paranoično rokovanje z ne-ujemajočimi IP-ji"
 
-#: src/muuli_wdr.cpp:2727
+#: src/muuli_wdr.cpp:2758
 msgid "Rejects a packet when its source IP differs from the IP the client claims (an anti-spoofing check). Disable only if it causes connection problems."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2729
+#: src/muuli_wdr.cpp:2760
 msgid "Use system-wide ipfilter.dat if available"
 msgstr "Uporabi sistemsko ipfilter.dat, če je na voljo"
 
-#: src/muuli_wdr.cpp:2730
+#: src/muuli_wdr.cpp:2761
 #, fuzzy
 msgid "If there's no local ipfilter.dat found, allow usage of a system-wide ipfilter file."
 msgstr "Če krajevne datoteke ipfilter.dat ni moč najti, omogoči uporabo sistemske datoteke."
 
-#: src/muuli_wdr.cpp:2747
+#: src/muuli_wdr.cpp:2778
 msgid "Enable Online-Signature"
 msgstr "Omogoči spletni podpis"
 
-#: src/muuli_wdr.cpp:2749
+#: src/muuli_wdr.cpp:2780
 msgid "Enables the writing of the OS file, which can be used by external apps to create signatures and the like."
 msgstr "Omogoči pisanje v datoteko spletnega podpisa, katero lahko uporabljajo zunanji programi za izdelavo podpisov in podobnih stvari."
 
-#: src/muuli_wdr.cpp:2753
+#: src/muuli_wdr.cpp:2784
 msgid "Update Frequency (Secs):"
 msgstr "Pogostost posodobitev (sek.):"
 
-#: src/muuli_wdr.cpp:2756
+#: src/muuli_wdr.cpp:2787
 msgid "Change the frequency (in seconds) of Online Signature updates."
 msgstr "Spremeni pogostost (v sekundah) posodobitev spletnega podpisa."
 
-#: src/muuli_wdr.cpp:2764
+#: src/muuli_wdr.cpp:2795
 msgid "Save online signature file in: "
 msgstr "Spletni podpis shrani v datoteko: "
 
-#: src/muuli_wdr.cpp:2770
+#: src/muuli_wdr.cpp:2801
 msgid "Click here to select the directory containing the the Online Signature files."
 msgstr "Kliknite tukaj, da nastavite mapo, ki vsebuje datoteke za spletni podpis."
 
-#: src/muuli_wdr.cpp:2803
+#: src/muuli_wdr.cpp:2834
 msgid "Show country flags for clients"
 msgstr "Prikaži zastave držav za odjemalce"
 
-#: src/muuli_wdr.cpp:2804
+#: src/muuli_wdr.cpp:2835
 msgid "Render the country flag column in the transfers, queue and search views. Requires a valid MMDB GeoIP database (see below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2809
+#: src/muuli_wdr.cpp:2840
 #, fuzzy
 msgid "Database"
 msgstr "Podatkovna hitrost:"
 
-#: src/muuli_wdr.cpp:2825
+#: src/muuli_wdr.cpp:2856
 #, fuzzy
 msgid "Source:"
 msgstr "Viri"
 
-#: src/muuli_wdr.cpp:2828
+#: src/muuli_wdr.cpp:2859
 msgid "DB-IP (free, no account)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2829
+#: src/muuli_wdr.cpp:2860
 msgid "MaxMind GeoLite2 (free, account required)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2830
+#: src/muuli_wdr.cpp:2861
 msgid "Custom URL"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2833
+#: src/muuli_wdr.cpp:2864
 msgid "Choose which provider supplies the GeoIP MMDB database. DB-IP is the default - no account required. MaxMind requires a free account + license key. Use Custom URL to point at any other MMDB host (e.g. a local mirror)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2850
+#: src/muuli_wdr.cpp:2881
 msgid ""
 "No configuration required.\n"
 "\n"
@@ -4884,11 +4912,11 @@ msgid ""
 "License: Creative Commons BY 4.0 - https://creativecommons.org/licenses/by/4.0/"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2863
+#: src/muuli_wdr.cpp:2894
 msgid "License key:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2869
+#: src/muuli_wdr.cpp:2900
 msgid ""
 "Sign up for a free MaxMind account, then generate a License Key:\n"
 "https://www.maxmind.com/en/geolite2/signup\n"
@@ -4898,225 +4926,225 @@ msgid ""
 "Requires attribution and account registration; refresh at least every 30 days."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2884
+#: src/muuli_wdr.cpp:2915
 #, fuzzy
 msgid "Download URL:"
 msgstr "Prejemanje: "
 
-#: src/muuli_wdr.cpp:2890
+#: src/muuli_wdr.cpp:2921
 msgid ""
 "Must point to an .mmdb file or a .gz / .tar.gz containing one.\n"
 "URL may include credentials (https://user:pass@host/...).\n"
 "License and attribution terms are set by the upstream URL - you are responsible."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2903
+#: src/muuli_wdr.cpp:2934
 msgid "Download the GeoIP database from the selected source."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2905
+#: src/muuli_wdr.cpp:2936
 #, fuzzy
 msgid "Auto-update on startup"
 msgstr "Samodejno posodobi filter IP-jev ob zagonu"
 
-#: src/muuli_wdr.cpp:2906
+#: src/muuli_wdr.cpp:2937
 msgid "Re-download the GeoIP database from the selected source every time aMule starts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2929
+#: src/muuli_wdr.cpp:2960
 msgid "Filter incoming messages (except current chat):"
 msgstr "Filtriraj prejeta sporočila (razen v trenutnem pogovoru):"
 
-#: src/muuli_wdr.cpp:2931
+#: src/muuli_wdr.cpp:2962
 msgid "Filter all messages"
 msgstr "Filtriraj vsa sporočila"
 
-#: src/muuli_wdr.cpp:2933
+#: src/muuli_wdr.cpp:2964
 msgid "Filter messages from people not on your friend list"
 msgstr "Filtriraj sporočila vseh, ki niso na seznamu prijateljev"
 
-#: src/muuli_wdr.cpp:2935
+#: src/muuli_wdr.cpp:2966
 msgid "Filter messages from unknown clients"
 msgstr "Filtriraj sporočila neznanih uporabnikov"
 
-#: src/muuli_wdr.cpp:2937
+#: src/muuli_wdr.cpp:2968
 msgid "Filter messages containing (use ',' as separator):"
 msgstr "Filtriraj sporočila, ki vsebujejo (uporabi »,« kot ločilnik):"
 
-#: src/muuli_wdr.cpp:2940 src/muuli_wdr.cpp:2951
+#: src/muuli_wdr.cpp:2971 src/muuli_wdr.cpp:2982
 msgid "add here the words amule should filter and block messages including it"
 msgstr "Sem dodajte besede, ki naj jih aMule filtrira, vključno s sporočili v katerih se nahajajo."
 
-#: src/muuli_wdr.cpp:2942
+#: src/muuli_wdr.cpp:2973
 msgid "Show received messages in the log"
 msgstr "Prejeta sporočila prikaži v dnevniku"
 
-#: src/muuli_wdr.cpp:2945
+#: src/muuli_wdr.cpp:2976
 msgid "Comments"
 msgstr "Komentarji"
 
-#: src/muuli_wdr.cpp:2948
+#: src/muuli_wdr.cpp:2979
 msgid "Filter comments containing (use ',' as separator):"
 msgstr "Filtriraj komentarje, ki vsebujejo (uporabi »,« kot ločilnik):"
 
-#: src/muuli_wdr.cpp:2973
+#: src/muuli_wdr.cpp:3004
 msgid "Enable Proxy"
 msgstr "Omogoči posrednika"
 
-#: src/muuli_wdr.cpp:2974
+#: src/muuli_wdr.cpp:3005
 msgid "Enable/disable proxy support"
 msgstr "Omogoči/onemogoči podporo za posrednika"
 
-#: src/muuli_wdr.cpp:2977
+#: src/muuli_wdr.cpp:3008
 msgid "Proxy type:"
 msgstr "Vrsta posrednika:"
 
-#: src/muuli_wdr.cpp:2988
+#: src/muuli_wdr.cpp:3019
 msgid "Proxy host:"
 msgstr "Gostitelj posrednika:"
 
-#: src/muuli_wdr.cpp:2991
+#: src/muuli_wdr.cpp:3022
 msgid "The proxy host name"
 msgstr "Ime gostitelja posredniškega strežnika"
 
-#: src/muuli_wdr.cpp:2993
+#: src/muuli_wdr.cpp:3024
 msgid "Proxy port:"
 msgstr "Vrata posrednika:"
 
-#: src/muuli_wdr.cpp:2996
+#: src/muuli_wdr.cpp:3027
 msgid "The proxy port"
 msgstr "Vrata posredniškega strežnika"
 
-#: src/muuli_wdr.cpp:2998
+#: src/muuli_wdr.cpp:3029
 msgid "Enable authentication"
 msgstr "Omogoči overjanje"
 
-#: src/muuli_wdr.cpp:2999
+#: src/muuli_wdr.cpp:3030
 msgid "Enable/disable username/password authentication"
 msgstr "Omogoči/onemogoči overjanje z uporabniškim imenom/geslom"
 
-#: src/muuli_wdr.cpp:3002
+#: src/muuli_wdr.cpp:3033
 msgid "Username: "
 msgstr "Uporabniško ime: "
 
-#: src/muuli_wdr.cpp:3005
+#: src/muuli_wdr.cpp:3036
 msgid "The username to use to connect to the proxy"
 msgstr "Uporabniško ime za povezavo s posrednikom"
 
-#: src/muuli_wdr.cpp:3007
+#: src/muuli_wdr.cpp:3038
 msgid "Password:"
 msgstr "Geslo:"
 
-#: src/muuli_wdr.cpp:3010
+#: src/muuli_wdr.cpp:3041
 msgid "The password to use to connect to the proxy"
 msgstr "Geslo za povezavo s posrednikom"
 
-#: src/muuli_wdr.cpp:3029
+#: src/muuli_wdr.cpp:3060
 msgid "Connect to:"
 msgstr "Poveži se z:"
 
-#: src/muuli_wdr.cpp:3038
+#: src/muuli_wdr.cpp:3069
 msgid "Login to remote amule"
 msgstr "Prijavi se pri oddaljenem aMule"
 
-#: src/muuli_wdr.cpp:3043
+#: src/muuli_wdr.cpp:3074
 msgid "User name"
 msgstr "Uporabniško ime"
 
-#: src/muuli_wdr.cpp:3054
+#: src/muuli_wdr.cpp:3085
 msgid "Remember those settings"
 msgstr "Zapomni si te nastavitve"
 
-#: src/muuli_wdr.cpp:3057
+#: src/muuli_wdr.cpp:3088
 #, fuzzy
 msgid "Force ZLIB compression"
 msgstr "Uporabi stiskanje gzip"
 
-#: src/muuli_wdr.cpp:3081
+#: src/muuli_wdr.cpp:3112
 msgid "Enable Verbose Debug-Logging."
 msgstr "Omogoči podrobno beleženje za razhroščevanje."
 
-#: src/muuli_wdr.cpp:3083
+#: src/muuli_wdr.cpp:3114
 msgid "Only to Logfile"
 msgstr "Samo v dnevniško datoteko"
 
-#: src/muuli_wdr.cpp:3085
+#: src/muuli_wdr.cpp:3116
 msgid "Message Categories:"
 msgstr "Kategorije sporočil:"
 
-#: src/muuli_wdr.cpp:3109 src/PartFileConvertDlg.cpp:160
+#: src/muuli_wdr.cpp:3140 src/PartFileConvertDlg.cpp:160
 msgid "Waiting..."
 msgstr "Čakanje …"
 
-#: src/muuli_wdr.cpp:3129
+#: src/muuli_wdr.cpp:3160
 msgid "Add imports"
 msgstr "Dodaj uvoze"
 
-#: src/muuli_wdr.cpp:3132
+#: src/muuli_wdr.cpp:3163
 msgid "Retry selected"
 msgstr "Ponovno poskusi izbrane"
 
-#: src/muuli_wdr.cpp:3134
+#: src/muuli_wdr.cpp:3165
 msgid "Remove selected"
 msgstr "Odstrani izbrane"
 
-#: src/muuli_wdr.cpp:3197
+#: src/muuli_wdr.cpp:3228
 msgid "Event Types"
 msgstr "Vrste dogodkov"
 
-#: src/muuli_wdr.cpp:3216
+#: src/muuli_wdr.cpp:3247
 msgid "Statistics and queued clients for selected file(s) : Session / All time"
 msgstr "Statistika in odjemalci v vrsti za izbrane datoteke: seja / ves čas"
 
-#: src/muuli_wdr.cpp:3240
+#: src/muuli_wdr.cpp:3271
 msgid "Active Uploads"
 msgstr "Dejavna pošiljanja"
 
-#: src/muuli_wdr.cpp:3254
+#: src/muuli_wdr.cpp:3285
 msgid "Percent of total files"
 msgstr "Odstotek vseh datotek"
 
-#: src/muuli_wdr.cpp:3306
+#: src/muuli_wdr.cpp:3337
 msgid "Show Clients for"
 msgstr "Prikaži odjemalce za"
 
-#: src/muuli_wdr.cpp:3308
+#: src/muuli_wdr.cpp:3339
 msgid "All files"
 msgstr "Vse datoteke"
 
-#: src/muuli_wdr.cpp:3311
+#: src/muuli_wdr.cpp:3342
 msgid "Selected files"
 msgstr "Izbrane datoteke"
 
-#: src/muuli_wdr.cpp:3314
+#: src/muuli_wdr.cpp:3345
 msgid "Active uploads only"
 msgstr "Samo dejavna pošiljanja"
 
-#: src/muuli_wdr.cpp:3321
+#: src/muuli_wdr.cpp:3352
 msgid "Reload:"
 msgstr "Znova naloži"
 
-#: src/muuli_wdr.cpp:3325
+#: src/muuli_wdr.cpp:3356
 msgid "Reload your shared files"
 msgstr "Ponovno naloži deljene datoteke"
 
-#: src/muuli_wdr.cpp:3388
+#: src/muuli_wdr.cpp:3419
 msgid "Send"
 msgstr "Pošlji"
 
-#: src/muuli_wdr.cpp:3389
+#: src/muuli_wdr.cpp:3420
 msgid "Sends the specified message."
 msgstr "Pošlje navedeno sporočilo."
 
-#: src/muuli_wdr.cpp:3393
+#: src/muuli_wdr.cpp:3424
 msgid "Close this chat-session."
 msgstr "Zapri to pogovorno sejo."
 
-#: src/muuli_wdr.cpp:3416
+#: src/muuli_wdr.cpp:3447
 msgid "Connect to any server and/or Kad"
 msgstr "Poveži se s poljubnim strežnikom in/ali s Kad"
 
-#: src/muuli_wdr.cpp:3422 src/SharedFilesCtrl.cpp:142 src/Statistics.cpp:941
+#: src/muuli_wdr.cpp:3453 src/SharedFilesCtrl.cpp:142 src/Statistics.cpp:941
 msgid "Shared Files"
 msgstr "Deljene datoteke"
 
@@ -5485,249 +5513,249 @@ msgstr "Prejeto"
 msgid "ERROR: Failed to open partfile '%s'"
 msgstr "NAPAKA: delne datoteke »%s« ni bilo moč odpreti"
 
-#: src/Preferences.cpp:674
+#: src/Preferences.cpp:701
 msgid "System default"
 msgstr "Sistemsko privzet"
 
-#: src/Preferences.cpp:675
+#: src/Preferences.cpp:702
 msgid "Albanian"
 msgstr "Albansko"
 
-#: src/Preferences.cpp:676
+#: src/Preferences.cpp:703
 msgid "Arabic"
 msgstr "Arabsko"
 
-#: src/Preferences.cpp:677
+#: src/Preferences.cpp:704
 msgid "Asturian"
 msgstr "Asturijsko"
 
-#: src/Preferences.cpp:678
+#: src/Preferences.cpp:705
 msgid "Basque"
 msgstr "Baskovsko"
 
-#: src/Preferences.cpp:679
+#: src/Preferences.cpp:706
 msgid "Bulgarian"
 msgstr "Bolgarsko"
 
-#: src/Preferences.cpp:680
+#: src/Preferences.cpp:707
 msgid "Catalan"
 msgstr "Katalonsko"
 
-#: src/Preferences.cpp:681
+#: src/Preferences.cpp:708
 msgid "Chinese (Simplified)"
 msgstr "Kitajsko (poenostavljeno)"
 
-#: src/Preferences.cpp:682
+#: src/Preferences.cpp:709
 msgid "Chinese (Traditional)"
 msgstr "Kitajsko (tradicionalno)"
 
-#: src/Preferences.cpp:683
+#: src/Preferences.cpp:710
 msgid "Croatian"
 msgstr "Hrvaško"
 
-#: src/Preferences.cpp:684
+#: src/Preferences.cpp:711
 msgid "Czech"
 msgstr "Češko"
 
-#: src/Preferences.cpp:685
+#: src/Preferences.cpp:712
 msgid "Danish"
 msgstr "Dansko"
 
-#: src/Preferences.cpp:686
+#: src/Preferences.cpp:713
 msgid "Dutch"
 msgstr "Nizozemsko"
 
-#: src/Preferences.cpp:687
+#: src/Preferences.cpp:714
 msgid "English (U.K.)"
 msgstr "Angleško (Z.K.)"
 
-#: src/Preferences.cpp:688
+#: src/Preferences.cpp:715
 #, fuzzy
 msgid "English (U.S.)"
 msgstr "Angleško (Z.K.)"
 
-#: src/Preferences.cpp:689
+#: src/Preferences.cpp:716
 msgid "Estonian"
 msgstr "Estonsko"
 
-#: src/Preferences.cpp:690
+#: src/Preferences.cpp:717
 msgid "Finnish"
 msgstr "Finsko"
 
-#: src/Preferences.cpp:691
+#: src/Preferences.cpp:718
 msgid "French"
 msgstr "Francosko"
 
-#: src/Preferences.cpp:692
+#: src/Preferences.cpp:719
 msgid "Galician"
 msgstr "Galicijsko"
 
-#: src/Preferences.cpp:693
+#: src/Preferences.cpp:720
 msgid "German"
 msgstr "Nemško"
 
-#: src/Preferences.cpp:694
+#: src/Preferences.cpp:721
 msgid "Greek"
 msgstr "Grško"
 
-#: src/Preferences.cpp:695
+#: src/Preferences.cpp:722
 msgid "Hebrew"
 msgstr "Hebrejsko"
 
-#: src/Preferences.cpp:696
+#: src/Preferences.cpp:723
 msgid "Hungarian"
 msgstr "Madžarsko"
 
-#: src/Preferences.cpp:697
+#: src/Preferences.cpp:724
 msgid "Italian"
 msgstr "Italijansko"
 
-#: src/Preferences.cpp:698
+#: src/Preferences.cpp:725
 msgid "Japanese"
 msgstr "Japonsko"
 
-#: src/Preferences.cpp:699
+#: src/Preferences.cpp:726
 msgid "Korean"
 msgstr "Korejsko"
 
-#: src/Preferences.cpp:700
+#: src/Preferences.cpp:727
 msgid "Latvian"
 msgstr ""
 
-#: src/Preferences.cpp:701
+#: src/Preferences.cpp:728
 msgid "Lithuanian"
 msgstr "Litvansko"
 
-#: src/Preferences.cpp:702
+#: src/Preferences.cpp:729
 msgid "Norwegian (Nynorsk)"
 msgstr "Norveško (Nynorsk)"
 
-#: src/Preferences.cpp:703
+#: src/Preferences.cpp:730
 msgid "Polish"
 msgstr "Poljsko"
 
-#: src/Preferences.cpp:704
+#: src/Preferences.cpp:731
 msgid "Portuguese"
 msgstr "Portugalsko"
 
-#: src/Preferences.cpp:705
+#: src/Preferences.cpp:732
 msgid "Portuguese (Brazilian)"
 msgstr "Portugalsko (brazilsko)"
 
-#: src/Preferences.cpp:706
+#: src/Preferences.cpp:733
 msgid "Romanian"
 msgstr "Romunsko"
 
-#: src/Preferences.cpp:707
+#: src/Preferences.cpp:734
 msgid "Russian"
 msgstr "Rusko"
 
-#: src/Preferences.cpp:708
+#: src/Preferences.cpp:735
 msgid "Slovenian"
 msgstr "Slovensko"
 
-#: src/Preferences.cpp:709
+#: src/Preferences.cpp:736
 msgid "Spanish"
 msgstr "Špansko"
 
-#: src/Preferences.cpp:710
+#: src/Preferences.cpp:737
 msgid "Swedish"
 msgstr "Švedsko"
 
-#: src/Preferences.cpp:711
+#: src/Preferences.cpp:738
 msgid "Turkish"
 msgstr "Turško"
 
-#: src/Preferences.cpp:712
+#: src/Preferences.cpp:739
 msgid "Ukrainian"
 msgstr "Ukrajinsko"
 
-#: src/Preferences.cpp:815
+#: src/Preferences.cpp:842
 msgid "Change Language"
 msgstr "Spremeni jezik"
 
-#: src/Preferences.cpp:879
+#: src/Preferences.cpp:906
 msgid "There are no translations installed for aMule"
 msgstr "Za aMule ni nameščenega nobenega prevoda"
 
-#: src/Preferences.cpp:880
+#: src/Preferences.cpp:907
 msgid "No languages available"
 msgstr "Na voljo ni nobenega jezika"
 
-#: src/Preferences.cpp:1011
+#: src/Preferences.cpp:1038
 msgid "no options available"
 msgstr "na voljo ni nobene možnosti"
 
-#: src/Preferences.cpp:2182
+#: src/Preferences.cpp:2227
 msgid "Invalid category found, skipping"
 msgstr "Najdena neveljavna kategorija, preskočena"
 
-#: src/Preferences.cpp:2351
+#: src/Preferences.cpp:2396
 msgid "TCP port can't be higher than 65532 due to server UDP socket being TCP+3"
 msgstr "Vrata TCP ne smejo biti večja od 65532, ker so vrata UDP TCP+3"
 
-#: src/Preferences.cpp:2352
+#: src/Preferences.cpp:2397
 #, c-format
 msgid "Default port will be used (%d)"
 msgstr "Uporabljena bodo privzeta vrata (%d)"
 
-#: src/PrefsUnifiedDlg.cpp:298 src/Statistics.cpp:866
+#: src/PrefsUnifiedDlg.cpp:300 src/Statistics.cpp:866
 msgid "Connection"
 msgstr "Povezava"
 
-#: src/PrefsUnifiedDlg.cpp:299 src/SearchListCtrl.cpp:117
+#: src/PrefsUnifiedDlg.cpp:301 src/SearchListCtrl.cpp:117
 msgid "Directories"
 msgstr "Mape"
 
-#: src/PrefsUnifiedDlg.cpp:300 src/Statistics.cpp:917
+#: src/PrefsUnifiedDlg.cpp:302 src/Statistics.cpp:917
 msgid "Servers"
 msgstr "Strežniki"
 
-#: src/PrefsUnifiedDlg.cpp:301 src/ServerListCtrl.cpp:96
+#: src/PrefsUnifiedDlg.cpp:303 src/ServerListCtrl.cpp:96
 msgid "Files"
 msgstr "Datoteke"
 
-#: src/PrefsUnifiedDlg.cpp:302
+#: src/PrefsUnifiedDlg.cpp:304
 msgid "Security"
 msgstr "Varnost"
 
-#: src/PrefsUnifiedDlg.cpp:303
+#: src/PrefsUnifiedDlg.cpp:305
 msgid "Interface"
 msgstr "Vmesnik"
 
-#: src/PrefsUnifiedDlg.cpp:310
+#: src/PrefsUnifiedDlg.cpp:312
 msgid "IP2Country"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:313
+#: src/PrefsUnifiedDlg.cpp:315
 msgid "Proxy"
 msgstr "Posrednik"
 
-#: src/PrefsUnifiedDlg.cpp:314
+#: src/PrefsUnifiedDlg.cpp:316
 msgid "Filters"
 msgstr "Filtri"
 
-#: src/PrefsUnifiedDlg.cpp:315
+#: src/PrefsUnifiedDlg.cpp:317
 msgid "Remote Controls"
 msgstr "Oddaljeno upravljanje"
 
-#: src/PrefsUnifiedDlg.cpp:316
+#: src/PrefsUnifiedDlg.cpp:318
 msgid "Online Signature"
 msgstr "Spletni podpis"
 
-#: src/PrefsUnifiedDlg.cpp:317
+#: src/PrefsUnifiedDlg.cpp:319
 msgid "Advanced"
 msgstr "Napredno"
 
-#: src/PrefsUnifiedDlg.cpp:318
+#: src/PrefsUnifiedDlg.cpp:320
 msgid "Events"
 msgstr "Dogodki"
 
-#: src/PrefsUnifiedDlg.cpp:321
+#: src/PrefsUnifiedDlg.cpp:323
 msgid "Debugging"
 msgstr "Razhroščevanje"
 
-#: src/PrefsUnifiedDlg.cpp:451
+#: src/PrefsUnifiedDlg.cpp:453
 msgid ""
 "The following variables will be substituted:\n"
 "    %PARTFILE - full path to the file\n"
@@ -5737,15 +5765,15 @@ msgstr ""
 "    %PARTFILE – polna pot do datoteke\n"
 "    %PARTNAME – samo ime datoteke"
 
-#: src/PrefsUnifiedDlg.cpp:472
+#: src/PrefsUnifiedDlg.cpp:474
 msgid "Tray icon support requires libayatana-appindicator3 at compile time."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:488
+#: src/PrefsUnifiedDlg.cpp:490
 msgid "Not available on Wayland: the protocol does not report when a window is minimized, so this option cannot intercept the system minimize button. Workaround: launch aMule with `GDK_BACKEND=x11` to use XWayland instead."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:534
+#: src/PrefsUnifiedDlg.cpp:536
 msgid ""
 "Do not change these setting unless you know\n"
 "what you are doing, otherwise you can easily\n"
@@ -5761,26 +5789,35 @@ msgstr ""
 "aMule bo deloval dobro tudi brez\n"
 "spreminjanja teh nastavitev."
 
-#: src/PrefsUnifiedDlg.cpp:645
+#: src/PrefsUnifiedDlg.cpp:647
 #, c-format
 msgid "Failed to connect Cfg to widget with the ID %d and key %s"
 msgstr "Nastavitve ni bilo moč povezati z gradnikom z ID-jem %d in ključem %s"
 
-#: src/PrefsUnifiedDlg.cpp:693
+#: src/PrefsUnifiedDlg.cpp:695
 #, c-format
 msgid "Failed to transfer data from Cfg to Widget with the ID %d and key %s"
 msgstr "Podatkov iz nastavitev ni bilo moč prenesti v gradnik z ID-jem %d in ključem %s."
 
-#: src/PrefsUnifiedDlg.cpp:799
+#: src/PrefsUnifiedDlg.cpp:801
 msgid "The type of proxy you are connecting to"
 msgstr "Vrsta posrednika s katerim se hočete povezati"
 
-#: src/PrefsUnifiedDlg.cpp:1003
+#: src/PrefsUnifiedDlg.cpp:1020
 #, c-format
 msgid "Failed to transfer data from Widget to Cfg with the ID %d and key %s"
 msgstr "Podatkov iz gradnika ni bilo moč prenesti v nastavitve z ID-jem %d in ključem %s."
 
 #: src/PrefsUnifiedDlg.cpp:1103
+#, fuzzy
+msgid "No password set."
+msgstr "Preverjanje gesla\n"
+
+#: src/PrefsUnifiedDlg.cpp:1132
+msgid "Guest access needs a password. Type one in the guest password field, or untick Enable guest access."
+msgstr ""
+
+#: src/PrefsUnifiedDlg.cpp:1144
 msgid ""
 "aMule must be restarted to enable these changes:\n"
 "\n"
@@ -5788,41 +5825,41 @@ msgstr ""
 "Potreben je ponoven zagon aMule za uveljavitev teh sprememb:\n"
 "\n"
 
-#: src/PrefsUnifiedDlg.cpp:1110
+#: src/PrefsUnifiedDlg.cpp:1151
 msgid "- TCP port changed.\n"
 msgstr "• Vrata TCP so spremenjena.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1115
+#: src/PrefsUnifiedDlg.cpp:1156
 msgid "- UDP port changed.\n"
 msgstr "• Vrata UDP so spremenjena.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1120
+#: src/PrefsUnifiedDlg.cpp:1161
 #, fuzzy
 msgid "- Network interface binding changed.\n"
 msgstr "• Vmesnik za zunanje povezave je spremenjen.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1125
+#: src/PrefsUnifiedDlg.cpp:1166
 msgid "- External connect port changed.\n"
 msgstr "• Vrata za zunanje povezave so spremenjena.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1129
+#: src/PrefsUnifiedDlg.cpp:1170
 msgid "- External connect acceptance changed.\n"
 msgstr "• Sprejemljivost zunanjih povezav je spremenjena.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1133
+#: src/PrefsUnifiedDlg.cpp:1174
 msgid "- External connect interface changed.\n"
 msgstr "• Vmesnik za zunanje povezave je spremenjen.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1137
+#: src/PrefsUnifiedDlg.cpp:1178
 msgid "- Protocol obfuscation support changed.\n"
 msgstr "• Podpora za maskiranje protokola je bila spremenjena.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1151
+#: src/PrefsUnifiedDlg.cpp:1193
 #, fuzzy
 msgid "- amuleapi settings changed.\n"
 msgstr "• Jezik je spremenjen.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1160
+#: src/PrefsUnifiedDlg.cpp:1202
 msgid ""
 "Your Auto-update server list is empty.\n"
 "'Auto-update server list at startup' will be disabled."
@@ -5830,7 +5867,7 @@ msgstr ""
 "Seznam za samodejno posodobitev strežnikov je prazen.\n"
 "Možnost »Ob zagonu samodejno posodobi seznam strežnikov« bo onemogočena."
 
-#: src/PrefsUnifiedDlg.cpp:1171
+#: src/PrefsUnifiedDlg.cpp:1213
 msgid ""
 "You have enabled external connections but have not specified a password.\n"
 "External connections cannot be enabled unless a valid password is specified."
@@ -5838,28 +5875,33 @@ msgstr ""
 "Omogočili ste zunanje povezave, vendar niste navedli gesla.\n"
 "Zunanje povezave ne morejo biti omogočene, dokler ne navedete veljavnega gesla."
 
-#: src/PrefsUnifiedDlg.cpp:1202
+#: src/PrefsUnifiedDlg.cpp:1246
+#, c-format
+msgid "The amuleapi password could not be saved: %s"
+msgstr ""
+
+#: src/PrefsUnifiedDlg.cpp:1276
 msgid "- Language changed.\n"
 msgstr "• Jezik je spremenjen.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1207
+#: src/PrefsUnifiedDlg.cpp:1281
 msgid "- Temp folder changed.\n"
 msgstr "• Mapa za začasne datoteke spremenjena.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1212
+#: src/PrefsUnifiedDlg.cpp:1286
 msgid "- ED2K network enabled.\n"
 msgstr "• Omrežje eD2k je omogočeno.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1245
+#: src/PrefsUnifiedDlg.cpp:1319
 msgid "The shared-file exclusion pattern is not a valid regular expression. The filter has been left disabled."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1247 src/PrefsUnifiedDlg.cpp:1841
+#: src/PrefsUnifiedDlg.cpp:1321 src/PrefsUnifiedDlg.cpp:1921
 #, fuzzy
 msgid "Invalid regular expression"
 msgstr "Neveljavna različica protokola."
 
-#: src/PrefsUnifiedDlg.cpp:1324
+#: src/PrefsUnifiedDlg.cpp:1398
 msgid ""
 "Both eD2k and Kad network are disabled.\n"
 "You won't be able to connect until you enable at least one of them."
@@ -5867,7 +5909,7 @@ msgstr ""
 "Omrežji eD2k in Kad sta onemogočeni.\n"
 "Ne boste se mogli povezati, dokler ne omogočite vsaj enega izmed njih."
 
-#: src/PrefsUnifiedDlg.cpp:1329
+#: src/PrefsUnifiedDlg.cpp:1403
 msgid ""
 "Kad will not start if your UDP port is disabled.\n"
 "Enable UDP port or disable Kad."
@@ -5875,7 +5917,7 @@ msgstr ""
 "Kad se ne bo zagnal, če so vrata UDP onemogočena.\n"
 "Omogočite vrata UDP ali pa onemogočite Kad."
 
-#: src/PrefsUnifiedDlg.cpp:1385
+#: src/PrefsUnifiedDlg.cpp:1459
 msgid ""
 "\n"
 "You MUST restart aMule now.\n"
@@ -5885,69 +5927,69 @@ msgstr ""
 "aMule morate NUJNO ponovno zagnati.\n"
 "Če tega ne storite zdaj, se ne pritožujte, če se zgodi kaj slabega.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1450
+#: src/PrefsUnifiedDlg.cpp:1524
 msgid "Could not register aMule for autostart at login. The autostart store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1452
+#: src/PrefsUnifiedDlg.cpp:1526
 msgid "Could not remove the autostart-at-login entry."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1453
+#: src/PrefsUnifiedDlg.cpp:1527
 #, fuzzy
 msgid "Autostart"
 msgstr "Samodejno osveževanje začeto"
 
-#: src/PrefsUnifiedDlg.cpp:1468
+#: src/PrefsUnifiedDlg.cpp:1542
 msgid "Register file type"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1468
+#: src/PrefsUnifiedDlg.cpp:1542
 msgid "Register URL handler"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1476
+#: src/PrefsUnifiedDlg.cpp:1550
 #, c-format
 msgid "aMule only handles eD2k-compatible magnets. If you replace the current magnet handler (%s), BitTorrent magnet links will stop working - aMule cannot download BitTorrent content. Continue?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1481
+#: src/PrefsUnifiedDlg.cpp:1555
 #, c-format
 msgid "Another application currently opens .emulecollection files (%s). Replace it with aMule?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1486
+#: src/PrefsUnifiedDlg.cpp:1560
 #, c-format
 msgid "Another application is currently the default handler for these links (%s). Replace it with aMule?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1511
+#: src/PrefsUnifiedDlg.cpp:1585
 msgid "Could not register aMule for .emulecollection files. The registration store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1513
+#: src/PrefsUnifiedDlg.cpp:1587
 #, fuzzy
 msgid "Could not remove the file type registration."
 msgstr "Mapa za začasne datoteke prejemanj"
 
-#: src/PrefsUnifiedDlg.cpp:1515
+#: src/PrefsUnifiedDlg.cpp:1589
 msgid "Could not register aMule as the URL handler. The registration store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1517
+#: src/PrefsUnifiedDlg.cpp:1591
 msgid "Could not remove the URL handler registration."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1587 src/PrefsUnifiedDlg.cpp:1614
+#: src/PrefsUnifiedDlg.cpp:1661 src/PrefsUnifiedDlg.cpp:1688
 #, fuzzy
 msgid "The web server and aMule API require external connections to be enabled."
 msgstr "Geslo je bilo nastavljeno in zunanje povezave omogočene."
 
-#: src/PrefsUnifiedDlg.cpp:1597
+#: src/PrefsUnifiedDlg.cpp:1671
 msgid "The aMule web server is deprecated. Consider running the aMule API instead."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1655
+#: src/PrefsUnifiedDlg.cpp:1735
 msgid ""
 "Your Auto-update servers list is in blank.\n"
 "Please fill in at least one URL to point to a valid server.met file.\n"
@@ -5957,24 +5999,24 @@ msgstr ""
 "Vnesite vsaj en URL do veljavne datoteke server.met.\n"
 "Kliknite na gumb »Seznam«, zraven potrditvenega polja, za vnos URL-ja."
 
-#: src/PrefsUnifiedDlg.cpp:1796
+#: src/PrefsUnifiedDlg.cpp:1876
 msgid "Temporary files"
 msgstr "Začasne datoteke"
 
-#: src/PrefsUnifiedDlg.cpp:1801
+#: src/PrefsUnifiedDlg.cpp:1881
 msgid "Incoming files"
 msgstr "Prejete datoteke"
 
-#: src/PrefsUnifiedDlg.cpp:1806
+#: src/PrefsUnifiedDlg.cpp:1886
 msgid "Online Signatures"
 msgstr "Spletni podpisi"
 
-#: src/PrefsUnifiedDlg.cpp:1819
+#: src/PrefsUnifiedDlg.cpp:1899
 #, c-format
 msgid "Choose a folder for %s"
 msgstr "Izberite mapo za %s"
 
-#: src/PrefsUnifiedDlg.cpp:1843
+#: src/PrefsUnifiedDlg.cpp:1923
 #, fuzzy, c-format
 msgid "Would exclude %u of %u shared file"
 msgid_plural "Would exclude %u of %u shared files"
@@ -5983,42 +6025,42 @@ msgstr[1] "Najdena %i znana deljena datoteka"
 msgstr[2] "Najdeni %i znani deljeni datoteki"
 msgstr[3] "Najdene %i znane deljene datoteke"
 
-#: src/PrefsUnifiedDlg.cpp:1860
+#: src/PrefsUnifiedDlg.cpp:1940
 msgid "Browse for videoplayer"
 msgstr "Prebrskajte za video predvajalnik"
 
-#: src/PrefsUnifiedDlg.cpp:1864
+#: src/PrefsUnifiedDlg.cpp:1944
 msgid "Select browser"
 msgstr "Izberite brskalnik"
 
-#: src/PrefsUnifiedDlg.cpp:1868
+#: src/PrefsUnifiedDlg.cpp:1948
 #, fuzzy
 msgid "Select ffprobe binary"
 msgstr "Izberite brskalnik"
 
-#: src/PrefsUnifiedDlg.cpp:1874
+#: src/PrefsUnifiedDlg.cpp:1954
 #, c-format
 msgid "Executable%s"
 msgstr "Izvedljiva datoteka %s"
 
-#: src/PrefsUnifiedDlg.cpp:1908
+#: src/PrefsUnifiedDlg.cpp:1988
 msgid "ffprobe not found on PATH or in the standard install locations. Install ffmpeg (which ships ffprobe) or use Browse to pick a binary manually."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1920
+#: src/PrefsUnifiedDlg.cpp:2000
 msgid "Reset the settings on this page to their default values?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1921
+#: src/PrefsUnifiedDlg.cpp:2001
 #, fuzzy
 msgid "Reset to defaults"
 msgstr "Sistemsko privzet"
 
-#: src/PrefsUnifiedDlg.cpp:1948
+#: src/PrefsUnifiedDlg.cpp:2028
 msgid "Edit server list"
 msgstr "Uredi seznam strežnikov"
 
-#: src/PrefsUnifiedDlg.cpp:1949
+#: src/PrefsUnifiedDlg.cpp:2029
 msgid ""
 "Add here URL's to download server.met files.\n"
 "Only one url on each line."
@@ -6026,42 +6068,42 @@ msgstr ""
 "Sem dodajte URL-je do datotek server.met.\n"
 "Po en URL v vsako vrstico."
 
-#: src/PrefsUnifiedDlg.cpp:2004
+#: src/PrefsUnifiedDlg.cpp:2084
 msgid "IP2Country update failed"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2149 src/PrefsUnifiedDlg.cpp:2180
+#: src/PrefsUnifiedDlg.cpp:2229 src/PrefsUnifiedDlg.cpp:2260
 msgid "Data by MaxMind GeoLite2"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2151 src/PrefsUnifiedDlg.cpp:2182
+#: src/PrefsUnifiedDlg.cpp:2231 src/PrefsUnifiedDlg.cpp:2262
 #, fuzzy
 msgid "Custom source"
 msgstr "Popolnih virov"
 
-#: src/PrefsUnifiedDlg.cpp:2153 src/PrefsUnifiedDlg.cpp:2184
+#: src/PrefsUnifiedDlg.cpp:2233 src/PrefsUnifiedDlg.cpp:2264
 msgid "Data by DB-IP.com"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2204
+#: src/PrefsUnifiedDlg.cpp:2284
 #, fuzzy, c-format
 msgid "Status: Loaded%s"
 msgstr "Stanje:"
 
-#: src/PrefsUnifiedDlg.cpp:2206
+#: src/PrefsUnifiedDlg.cpp:2286
 #, fuzzy, c-format
 msgid "Status: Loaded%s - %s"
 msgstr "Stanje:"
 
-#: src/PrefsUnifiedDlg.cpp:2210
+#: src/PrefsUnifiedDlg.cpp:2290
 msgid "Status: Failed to load - click 'Update now' to refresh."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2212
+#: src/PrefsUnifiedDlg.cpp:2292
 msgid "Status: Not found - click 'Update now' to download."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2270 src/PrefsUnifiedDlg.cpp:2294
+#: src/PrefsUnifiedDlg.cpp:2350 src/PrefsUnifiedDlg.cpp:2374
 #, c-format
 msgid "Update delay: %d second"
 msgid_plural "Update delay: %d seconds"
@@ -6070,7 +6112,7 @@ msgstr[1] "Osveži vsakih: %d sekundo"
 msgstr[2] "Osveži vsakih: %d sekundi"
 msgstr[3] "Osveži vsakih: %d sekunde"
 
-#: src/PrefsUnifiedDlg.cpp:2278
+#: src/PrefsUnifiedDlg.cpp:2358
 #, c-format
 msgid "Time for average graph: %d minute"
 msgid_plural "Time for average graph: %d minutes"
@@ -6079,12 +6121,12 @@ msgstr[1] "Čas za graf trenutnega povprečja: %i minuta"
 msgstr[2] "Čas za graf trenutnega povprečja: %i minuti"
 msgstr[3] "Čas za graf trenutnega povprečja: %i minute"
 
-#: src/PrefsUnifiedDlg.cpp:2287
+#: src/PrefsUnifiedDlg.cpp:2367
 #, c-format
 msgid "Connections Graph Scale: %d"
 msgstr "Merilo za graf povezav: %d"
 
-#: src/PrefsUnifiedDlg.cpp:2302
+#: src/PrefsUnifiedDlg.cpp:2382
 #, c-format
 msgid "File Buffer Size: %d byte"
 msgid_plural "File Buffer Size: %d bytes"
@@ -6093,7 +6135,7 @@ msgstr[1] "Datotečni medpomnilnik: %d bajt"
 msgstr[2] "Datotečni medpomnilnik: %d bajta"
 msgstr[3] "Datotečni medpomnilnik: %d bajti"
 
-#: src/PrefsUnifiedDlg.cpp:2312
+#: src/PrefsUnifiedDlg.cpp:2392
 #, c-format
 msgid "Upload Queue Size: %d client"
 msgid_plural "Upload Queue Size: %d clients"
@@ -6102,7 +6144,7 @@ msgstr[1] "Velikost vrste za pošiljanje: %d odjemalec"
 msgstr[2] "Velikost vrste za pošiljanje: %d odjemalca"
 msgstr[3] "Velikost vrste za pošiljanje: %d odjemalci"
 
-#: src/PrefsUnifiedDlg.cpp:2322
+#: src/PrefsUnifiedDlg.cpp:2402
 #, c-format
 msgid "Server connection refresh interval: %d minute"
 msgid_plural "Server connection refresh interval: %d minutes"
@@ -6111,79 +6153,79 @@ msgstr[1] "Čas med osvežitvama povezave na strežnik: %d minuta"
 msgstr[2] "Čas med osvežitvama povezave na strežnik: %d minuti"
 msgstr[3] "Čas med osvežitvama povezave na strežnik: %d minute"
 
-#: src/PrefsUnifiedDlg.cpp:2327
+#: src/PrefsUnifiedDlg.cpp:2407
 msgid "Server connection refresh interval: Disabled"
 msgstr "Čas med osvežitvama povezave na strežnik: onemogočeno"
 
-#: src/PrefsUnifiedDlg.cpp:2371
+#: src/PrefsUnifiedDlg.cpp:2451
 msgid "disabled"
 msgstr "onemogočeno"
 
-#: src/PrefsUnifiedDlg.cpp:2397
+#: src/PrefsUnifiedDlg.cpp:2477
 #, c-format
 msgid "Execute command on '%s' event"
 msgstr "Izvrši ukaz ob dogodku »%s«"
 
-#: src/PrefsUnifiedDlg.cpp:2404
+#: src/PrefsUnifiedDlg.cpp:2484
 msgid "Enable command execution on core"
 msgstr "Omogoči izvrševanje ukazov na jedru"
 
-#: src/PrefsUnifiedDlg.cpp:2416
+#: src/PrefsUnifiedDlg.cpp:2496
 msgid "Core command:"
 msgstr "Ukaz jedra:"
 
-#: src/PrefsUnifiedDlg.cpp:2432
+#: src/PrefsUnifiedDlg.cpp:2512
 msgid "Enable command execution on GUI"
 msgstr "Omogoči izvrševanje ukazov v vmesniku"
 
-#: src/PrefsUnifiedDlg.cpp:2444
+#: src/PrefsUnifiedDlg.cpp:2524
 msgid "GUI command:"
 msgstr "Ukaz vmesnika:"
 
-#: src/PrefsUnifiedDlg.cpp:2460
+#: src/PrefsUnifiedDlg.cpp:2540
 msgid "The following variables will be replaced:"
 msgstr "Sledeče spremenljivke bodo nadomeščene:"
 
-#: src/PrefsUnifiedDlg.cpp:2628
+#: src/PrefsUnifiedDlg.cpp:2708
 msgid ""
 "The following folders look like system or sensitive locations:\n"
 "\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2633
+#: src/PrefsUnifiedDlg.cpp:2713
 msgid "Sharing them recursively will publish every file underneath on the eD2k/Kad networks. Do you really want to do this?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2636
+#: src/PrefsUnifiedDlg.cpp:2716
 #, fuzzy
 msgid "Confirm shared folders"
 msgstr "Deljene mape"
 
-#: src/PrefsUnifiedDlg.cpp:2664
+#: src/PrefsUnifiedDlg.cpp:2744
 #, fuzzy
 msgid "Reloading shared files..."
 msgstr "Ponovno naloži deljene datoteke"
 
-#: src/PrefsUnifiedDlg.cpp:2665
+#: src/PrefsUnifiedDlg.cpp:2745
 msgid "Scanning for subdirectories..."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2666
+#: src/PrefsUnifiedDlg.cpp:2746
 #, fuzzy
 msgid "Updating shared folders"
 msgstr "Deljene mape"
 
-#: src/PrefsUnifiedDlg.cpp:2693
+#: src/PrefsUnifiedDlg.cpp:2773
 #, c-format
 msgid "Scanned %u directories..."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2743
+#: src/PrefsUnifiedDlg.cpp:2823
 #, fuzzy, c-format
 msgid "Reloading shared files: %u files scanned"
 msgstr "Ponovno naloži seznam deljenih datotek."
 
-#: src/PrefsUnifiedDlg.cpp:2793
+#: src/PrefsUnifiedDlg.cpp:2873
 #, fuzzy
 msgid "Shared folder"
 msgstr "Deljene mape"

--- a/po/sq.po
+++ b/po/sq.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-28 12:17+0200\n"
+"POT-Creation-Date: 2026-07-28 13:09+0200\n"
 "PO-Revision-Date: 2026-07-27 11:45+0000\n"
 "Last-Translator: Fation <dj_barthezz@linuxmail.org lushnja_corps@hotmail.Language-Team:\n"
 "Language: sq\n"
@@ -293,7 +293,7 @@ msgid "Password set and external connections enabled."
 msgstr "U pranua nje lidhje e jashtme e re"
 
 #: src/amule.cpp:755 src/KadDlg.cpp:176 src/KadDlg.cpp:185
-#: src/PrefsUnifiedDlg.cpp:1461 src/SharedFilesCtrl.cpp:476
+#: src/PrefsUnifiedDlg.cpp:1470 src/SharedFilesCtrl.cpp:476
 msgid "WARNING"
 msgstr "KUJDES"
 
@@ -330,7 +330,7 @@ msgstr ""
 #: src/amule-remote-gui.cpp:603 src/amule-remote-gui.cpp:671
 #: src/amule-remote-gui.cpp:709 src/amule-remote-gui.cpp:1282
 #: src/amule-remote-gui.cpp:1345 src/amule-remote-gui.cpp:1372
-#: src/DownloadQueue.cpp:1481 src/PrefsUnifiedDlg.cpp:1247
+#: src/DownloadQueue.cpp:1481 src/PrefsUnifiedDlg.cpp:1256
 msgid "ERROR"
 msgstr ""
 
@@ -592,36 +592,36 @@ msgstr "Vizitoni https://github.com/amule-org/amule/releases/latest per te kontr
 msgid "FATAL ERROR: Failed to create Timer"
 msgstr ""
 
-#: src/amuleDlg.cpp:361 src/amuleDlg.cpp:1787 src/amuleDlg.cpp:2033
-#: src/muuli_wdr.cpp:1492 src/muuli_wdr.cpp:3449
+#: src/amuleDlg.cpp:361 src/amuleDlg.cpp:1810 src/amuleDlg.cpp:2056
+#: src/muuli_wdr.cpp:1492 src/muuli_wdr.cpp:3453
 msgid "Networks"
 msgstr "Rrjetet"
 
-#: src/amuleDlg.cpp:362 src/amuleDlg.cpp:1793 src/muuli_wdr.cpp:3450
+#: src/amuleDlg.cpp:362 src/amuleDlg.cpp:1816 src/muuli_wdr.cpp:3454
 msgid "Searches"
 msgstr "Kerkimet"
 
-#: src/amuleDlg.cpp:363 src/amuleDlg.cpp:1799 src/DownloadListCtrl.cpp:740
-#: src/muuli_wdr.cpp:392 src/muuli_wdr.cpp:1585 src/muuli_wdr.cpp:3451
+#: src/amuleDlg.cpp:363 src/amuleDlg.cpp:1822 src/DownloadListCtrl.cpp:740
+#: src/muuli_wdr.cpp:392 src/muuli_wdr.cpp:1585 src/muuli_wdr.cpp:3455
 #: src/Statistics.cpp:829
 msgid "Downloads"
 msgstr "Shkarkime"
 
-#: src/amuleDlg.cpp:364 src/amuleDlg.cpp:1805 src/muuli_wdr.cpp:3325
+#: src/amuleDlg.cpp:364 src/amuleDlg.cpp:1828 src/muuli_wdr.cpp:3329
 msgid "Shared files"
 msgstr ""
 
-#: src/amuleDlg.cpp:365 src/amuleDlg.cpp:1811 src/muuli_wdr.cpp:2957
-#: src/muuli_wdr.cpp:3407 src/muuli_wdr.cpp:3454
+#: src/amuleDlg.cpp:365 src/amuleDlg.cpp:1834 src/muuli_wdr.cpp:2961
+#: src/muuli_wdr.cpp:3411 src/muuli_wdr.cpp:3458
 msgid "Messages"
 msgstr "Mesazhe"
 
-#: src/amuleDlg.cpp:366 src/amuleDlg.cpp:1817 src/muuli_wdr.cpp:3455
+#: src/amuleDlg.cpp:366 src/amuleDlg.cpp:1840 src/muuli_wdr.cpp:3459
 #: src/PrefsUnifiedDlg.cpp:314 src/Statistics.cpp:779 src/Statistics.cpp:1235
 msgid "Statistics"
 msgstr "Statistikat"
 
-#: src/amuleDlg.cpp:368 src/amuleDlg.cpp:1824 src/muuli_wdr.cpp:3457
+#: src/amuleDlg.cpp:368 src/amuleDlg.cpp:1847 src/muuli_wdr.cpp:3461
 #: src/PrefsUnifiedDlg.cpp:330 src/utils/wxCas/src/wxcasprefs.cpp:39
 msgid "Preferences"
 msgstr "Preferencat"
@@ -680,8 +680,8 @@ msgstr "Kad: Fikur"
 #: src/amuleDlg.cpp:1029 src/DownloadListCtrl.cpp:505
 #: src/DownloadListCtrl.cpp:749 src/FriendListCtrl.cpp:180
 #: src/muuli_wdr.cpp:731 src/muuli_wdr.cpp:782 src/muuli_wdr.cpp:846
-#: src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2262 src/muuli_wdr.cpp:2347
-#: src/muuli_wdr.cpp:3095 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
+#: src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2266 src/muuli_wdr.cpp:2351
+#: src/muuli_wdr.cpp:3099 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
 #: src/ServerListCtrl.cpp:606 src/TransferWnd.cpp:378
 #: src/utils/wxCas/src/wxcasprefs.cpp:235
 msgid "Cancel"
@@ -692,7 +692,7 @@ msgid "Stop the current connection attempts"
 msgstr "Ndalo tentativat e lidhjes qe po behen"
 
 #: src/amuleDlg.cpp:1035 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976
-#: src/muuli_wdr.cpp:2485
+#: src/muuli_wdr.cpp:2489
 msgid "Disconnect"
 msgstr "Shkeputu"
 
@@ -701,7 +701,7 @@ msgid "Disconnect from the currently connected networks"
 msgstr "Shkeputu nga rrjetet e lidhura"
 
 #: src/amuleDlg.cpp:1041 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979
-#: src/muuli_wdr.cpp:2640 src/muuli_wdr.cpp:3092 src/muuli_wdr.cpp:3447
+#: src/muuli_wdr.cpp:2644 src/muuli_wdr.cpp:3096 src/muuli_wdr.cpp:3451
 msgid "Connect"
 msgstr "Lidhu"
 
@@ -756,7 +756,7 @@ msgstr "Konfirmimi i daljes"
 msgid "Launch Command: "
 msgstr ""
 
-#: src/amuleDlg.cpp:1632 src/muuli_wdr.cpp:1982 src/Preferences.cpp:979
+#: src/amuleDlg.cpp:1632 src/muuli_wdr.cpp:1986 src/Preferences.cpp:979
 msgid "- default -"
 msgstr ""
 
@@ -770,61 +770,61 @@ msgstr "Direktoria e skin '%s' nuk ekziston"
 msgid "WARNING: Unable to open skin file '%s' for read"
 msgstr ""
 
-#: src/amuleDlg.cpp:1791 src/muuli_wdr.cpp:3449
+#: src/amuleDlg.cpp:1814 src/muuli_wdr.cpp:3453
 msgid "Networks Window"
 msgstr "Dritaret e rrjeteve"
 
-#: src/amuleDlg.cpp:1797 src/muuli_wdr.cpp:3450
+#: src/amuleDlg.cpp:1820 src/muuli_wdr.cpp:3454
 msgid "Searches Window"
 msgstr "Dritaret e kerkimeve"
 
-#: src/amuleDlg.cpp:1803 src/muuli_wdr.cpp:3451
+#: src/amuleDlg.cpp:1826 src/muuli_wdr.cpp:3455
 #, fuzzy
 msgid "Downloads Window"
 msgstr "Duke shkarkuar"
 
-#: src/amuleDlg.cpp:1809 src/muuli_wdr.cpp:3453
+#: src/amuleDlg.cpp:1832 src/muuli_wdr.cpp:3457
 msgid "Shared Files Window"
 msgstr "Dritarja e faileve te ndara"
 
-#: src/amuleDlg.cpp:1815 src/muuli_wdr.cpp:3454
+#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3458
 msgid "Messages Window"
 msgstr "Dritarja e mesazheve"
 
-#: src/amuleDlg.cpp:1821 src/muuli_wdr.cpp:3455
+#: src/amuleDlg.cpp:1844 src/muuli_wdr.cpp:3459
 msgid "Statistics Graph Window"
 msgstr "Dritarja e grafikut te statistikave"
 
-#: src/amuleDlg.cpp:1828 src/muuli_wdr.cpp:3457
+#: src/amuleDlg.cpp:1851 src/muuli_wdr.cpp:3461
 msgid "Preferences Settings Window"
 msgstr "Dritarja e rregullimeve te preferencave"
 
-#: src/amuleDlg.cpp:1831 src/muuli_wdr.cpp:3458
+#: src/amuleDlg.cpp:1854 src/muuli_wdr.cpp:3462
 msgid "Import"
 msgstr "Importimi"
 
-#: src/amuleDlg.cpp:1835 src/muuli_wdr.cpp:3458
+#: src/amuleDlg.cpp:1858 src/muuli_wdr.cpp:3462
 msgid "The partfile importer tool"
 msgstr "Veglat per importimin e pjeseve te faileve"
 
-#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3459
+#: src/amuleDlg.cpp:1861 src/muuli_wdr.cpp:3463
 #: src/utils/aLinkCreator/src/alcframe.cpp:262
 msgid "About"
 msgstr "Rreth"
 
-#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3459
+#: src/amuleDlg.cpp:1861 src/muuli_wdr.cpp:3463
 msgid "About/Help"
 msgstr "Rreth/Ndihme"
 
-#: src/amuleDlg.cpp:2036
+#: src/amuleDlg.cpp:2059
 msgid "eD2k network"
 msgstr ""
 
-#: src/amuleDlg.cpp:2039
+#: src/amuleDlg.cpp:2062
 msgid "Kad network"
 msgstr "Rrjeti Kad"
 
-#: src/amuleDlg.cpp:2039
+#: src/amuleDlg.cpp:2062
 msgid "No network"
 msgstr "Nuk ka rrjet"
 
@@ -1361,19 +1361,19 @@ msgstr "Automatike [Larte]"
 msgid "Very low"
 msgstr "Shume ngadale"
 
-#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:743 src/muuli_wdr.cpp:2313
+#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:743 src/muuli_wdr.cpp:2317
 #: src/ServerListCtrl.cpp:263 src/ServerListCtrl.cpp:456
 #: src/SharedFilesCtrl.cpp:145
 msgid "Low"
 msgstr "Ngadale"
 
-#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:744 src/muuli_wdr.cpp:2314
+#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:744 src/muuli_wdr.cpp:2318
 #: src/ServerListCtrl.cpp:266 src/ServerListCtrl.cpp:457
 #: src/SharedFilesCtrl.cpp:146
 msgid "Normal"
 msgstr "Normale"
 
-#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:745 src/muuli_wdr.cpp:2315
+#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:745 src/muuli_wdr.cpp:2319
 #: src/ServerListCtrl.cpp:269 src/ServerListCtrl.cpp:458
 #: src/SharedFilesCtrl.cpp:147
 msgid "High"
@@ -1465,7 +1465,7 @@ msgstr "Server Lokal"
 msgid "Remote Server"
 msgstr "Server i larget"
 
-#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3212
+#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3216
 #: src/SearchDlg.cpp:119 src/TextClient.cpp:911
 msgid "Kad"
 msgstr "Kad"
@@ -1537,7 +1537,7 @@ msgstr ""
 msgid "Size"
 msgstr "Madhesia"
 
-#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3279
+#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3283
 msgid "Transferred"
 msgstr "Te transferuara"
 
@@ -1593,7 +1593,7 @@ msgid ""
 "\n"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:746 src/muuli_wdr.cpp:2316
+#: src/DownloadListCtrl.cpp:746 src/muuli_wdr.cpp:2320
 #: src/SharedFilesCtrl.cpp:150
 msgid "Auto"
 msgstr "Automatike"
@@ -1631,7 +1631,7 @@ msgid "Extended Options"
 msgstr "Opsione te Avancuara"
 
 #: src/DownloadListCtrl.cpp:770 src/DownloadListCtrl.cpp:822
-#: src/muuli_wdr.cpp:1800
+#: src/muuli_wdr.cpp:1804
 msgid "Preview"
 msgstr "Parashikim"
 
@@ -2434,23 +2434,23 @@ msgid ""
 "want downloads on a different (e.g. larger) disk."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:549 src/FirstRunWizard.cpp:611 src/muuli_wdr.cpp:1712
+#: src/FirstRunWizard.cpp:549 src/FirstRunWizard.cpp:611 src/muuli_wdr.cpp:1716
 msgid "Destination folder for downloads"
 msgstr ""
 
 #: src/FirstRunWizard.cpp:553 src/FirstRunWizard.cpp:569 src/muuli_wdr.cpp:1349
-#: src/muuli_wdr.cpp:1366 src/muuli_wdr.cpp:1687 src/muuli_wdr.cpp:1718
-#: src/muuli_wdr.cpp:1730 src/muuli_wdr.cpp:2800
+#: src/muuli_wdr.cpp:1366 src/muuli_wdr.cpp:1691 src/muuli_wdr.cpp:1722
+#: src/muuli_wdr.cpp:1734 src/muuli_wdr.cpp:2804
 #: src/utils/aLinkCreator/src/alcframe.cpp:135
 #: src/utils/wxCas/src/wxcasprefs.cpp:52 src/utils/wxCas/src/wxcasprefs.cpp:118
 msgid "Browse"
 msgstr "Shfleto"
 
-#: src/FirstRunWizard.cpp:559 src/muuli_wdr.cpp:1723
+#: src/FirstRunWizard.cpp:559 src/muuli_wdr.cpp:1727
 msgid "(All files in this folder are shared with other peers)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:565 src/FirstRunWizard.cpp:624 src/muuli_wdr.cpp:1725
+#: src/FirstRunWizard.cpp:565 src/FirstRunWizard.cpp:624 src/muuli_wdr.cpp:1729
 msgid "Folder for temporary download files"
 msgstr ""
 
@@ -2481,7 +2481,7 @@ msgstr ""
 msgid "CRITICAL - no client on StartChatSession"
 msgstr ""
 
-#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2706 src/muuli_wdr.cpp:3383
+#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2710 src/muuli_wdr.cpp:3387
 msgid "Friends"
 msgstr "Shkoket"
 
@@ -2595,8 +2595,8 @@ msgstr "Asnjeri"
 msgid "No"
 msgstr "Jo"
 
-#: src/GenericClientListCtrl.cpp:1216 src/PrefsUnifiedDlg.cpp:2898
-#: src/PrefsUnifiedDlg.cpp:2948 src/ServerListCtrl.cpp:276
+#: src/GenericClientListCtrl.cpp:1216 src/PrefsUnifiedDlg.cpp:2907
+#: src/PrefsUnifiedDlg.cpp:2957 src/ServerListCtrl.cpp:276
 msgid "Yes"
 msgstr "Po"
 
@@ -2766,10 +2766,10 @@ msgstr "Porte e pavlefshme per bootstrap"
 msgid "Please fill all fields required"
 msgstr "Ju lutem plotesoni te gjitha fushat e kerkuara"
 
-#: src/KadDlg.cpp:192 src/PartFile.cpp:1031 src/PrefsUnifiedDlg.cpp:1134
-#: src/PrefsUnifiedDlg.cpp:1204 src/PrefsUnifiedDlg.cpp:1405
-#: src/PrefsUnifiedDlg.cpp:1663 src/PrefsUnifiedDlg.cpp:1673
-#: src/PrefsUnifiedDlg.cpp:1690 src/PrefsUnifiedDlg.cpp:1738
+#: src/KadDlg.cpp:192 src/PartFile.cpp:1031 src/PrefsUnifiedDlg.cpp:1143
+#: src/PrefsUnifiedDlg.cpp:1213 src/PrefsUnifiedDlg.cpp:1414
+#: src/PrefsUnifiedDlg.cpp:1672 src/PrefsUnifiedDlg.cpp:1682
+#: src/PrefsUnifiedDlg.cpp:1699 src/PrefsUnifiedDlg.cpp:1747
 msgid "Message"
 msgstr "Mesazh"
 
@@ -2871,7 +2871,7 @@ msgstr ""
 msgid "Uploaded"
 msgstr ""
 
-#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3263
+#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3267
 msgid "Requested"
 msgstr ""
 
@@ -2997,7 +2997,7 @@ msgid "WARNING: "
 msgstr ""
 
 #: src/MuleNotebook.cpp:179 src/muuli_wdr.cpp:817 src/muuli_wdr.cpp:1229
-#: src/muuli_wdr.cpp:3167 src/muuli_wdr.cpp:3423
+#: src/muuli_wdr.cpp:3171 src/muuli_wdr.cpp:3427
 msgid "Close"
 msgstr "Mbylle"
 
@@ -3015,7 +3015,7 @@ msgid "Paste"
 msgstr "Ngjit"
 
 #: src/MuleTextCtrl.cpp:89 src/muuli_wdr.cpp:358 src/muuli_wdr.cpp:757
-#: src/muuli_wdr.cpp:2390 src/muuli_wdr.cpp:2409 src/muuli_wdr.cpp:2431
+#: src/muuli_wdr.cpp:2394 src/muuli_wdr.cpp:2413 src/muuli_wdr.cpp:2435
 #: src/utils/aLinkCreator/src/alcframe.cpp:142
 msgid "Clear"
 msgstr "Pastro"
@@ -3113,7 +3113,7 @@ msgstr "Dlje"
 
 #: src/MuleTrayIcon.cpp:579 src/MuleTrayIcon.cpp:945 src/MuleTrayIcon.cpp:965
 #: src/muuli_wdr.cpp:1398 src/muuli_wdr.cpp:1406 src/muuli_wdr.cpp:1413
-#: src/muuli_wdr.cpp:1846 src/muuli_wdr.cpp:1852 src/OtherFunctions.cpp:91
+#: src/muuli_wdr.cpp:1850 src/muuli_wdr.cpp:1856 src/OtherFunctions.cpp:91
 #: src/StatisticsDlg.cpp:93 src/StatisticsDlg.cpp:95
 msgid "kB/s"
 msgstr "kB/s"
@@ -3355,7 +3355,7 @@ msgstr "Bytes"
 msgid "KB"
 msgstr "KB"
 
-#: src/muuli_wdr.cpp:274 src/muuli_wdr.cpp:293 src/muuli_wdr.cpp:1631
+#: src/muuli_wdr.cpp:274 src/muuli_wdr.cpp:293 src/muuli_wdr.cpp:1635
 #: src/OtherFunctions.cpp:64
 msgid "MB"
 msgstr "MB"
@@ -3372,7 +3372,7 @@ msgstr "Madhesia Maksimale"
 msgid "Availability"
 msgstr "Te disponueshem"
 
-#: src/muuli_wdr.cpp:312 src/muuli_wdr.cpp:398 src/muuli_wdr.cpp:3328
+#: src/muuli_wdr.cpp:312 src/muuli_wdr.cpp:398 src/muuli_wdr.cpp:3332
 msgid "Filter:"
 msgstr "Filteri:"
 
@@ -3436,8 +3436,8 @@ msgstr "Burime te gjetura :"
 #: src/muuli_wdr.cpp:1160 src/muuli_wdr.cpp:1167 src/muuli_wdr.cpp:1172
 #: src/muuli_wdr.cpp:1179 src/muuli_wdr.cpp:1184 src/muuli_wdr.cpp:1191
 #: src/muuli_wdr.cpp:1205 src/muuli_wdr.cpp:1212 src/muuli_wdr.cpp:1217
-#: src/muuli_wdr.cpp:1224 src/muuli_wdr.cpp:3265 src/muuli_wdr.cpp:3273
-#: src/muuli_wdr.cpp:3281
+#: src/muuli_wdr.cpp:1224 src/muuli_wdr.cpp:3269 src/muuli_wdr.cpp:3277
+#: src/muuli_wdr.cpp:3285
 msgid "N/A"
 msgstr "N/A"
 
@@ -3582,7 +3582,7 @@ msgstr ""
 msgid "Album :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:685 src/muuli_wdr.cpp:2285
+#: src/muuli_wdr.cpp:685 src/muuli_wdr.cpp:2289
 msgid "Title :"
 msgstr "Titulli :"
 
@@ -3689,7 +3689,7 @@ msgstr "Emri i Perdoruesit :"
 msgid "Userhash :"
 msgstr "Userhash :"
 
-#: src/muuli_wdr.cpp:895 src/muuli_wdr.cpp:1752 src/muuli_wdr.cpp:2480
+#: src/muuli_wdr.cpp:895 src/muuli_wdr.cpp:1756 src/muuli_wdr.cpp:2484
 #: src/utils/aLinkCreator/src/alcframe.cpp:137
 msgid "Add"
 msgstr "Shto"
@@ -3698,15 +3698,15 @@ msgstr "Shto"
 msgid "Download-Speed"
 msgstr "Shpejtesia-Shkarkimit"
 
-#: src/muuli_wdr.cpp:954 src/muuli_wdr.cpp:989 src/muuli_wdr.cpp:2584
+#: src/muuli_wdr.cpp:954 src/muuli_wdr.cpp:989 src/muuli_wdr.cpp:2588
 msgid "Current"
 msgstr "Aktualisht"
 
-#: src/muuli_wdr.cpp:962 src/muuli_wdr.cpp:997 src/muuli_wdr.cpp:2592
+#: src/muuli_wdr.cpp:962 src/muuli_wdr.cpp:997 src/muuli_wdr.cpp:2596
 msgid "Running average"
 msgstr "Mesatarja e Punes"
 
-#: src/muuli_wdr.cpp:970 src/muuli_wdr.cpp:1005 src/muuli_wdr.cpp:2600
+#: src/muuli_wdr.cpp:970 src/muuli_wdr.cpp:1005 src/muuli_wdr.cpp:2604
 msgid "Session average"
 msgstr "Mesatarja e Sesionit"
 
@@ -3718,7 +3718,7 @@ msgstr "Shpejtesia-Ngarkimit"
 msgid "Connections"
 msgstr "Lidhjet"
 
-#: src/muuli_wdr.cpp:1024 src/muuli_wdr.cpp:1871
+#: src/muuli_wdr.cpp:1024 src/muuli_wdr.cpp:1875
 msgid "Active downloads"
 msgstr "Shkarkime Aktive"
 
@@ -3726,7 +3726,7 @@ msgstr "Shkarkime Aktive"
 msgid "Active connections (1:1)"
 msgstr "Lidhje Aktive (1:1)"
 
-#: src/muuli_wdr.cpp:1040 src/muuli_wdr.cpp:1872
+#: src/muuli_wdr.cpp:1040 src/muuli_wdr.cpp:1876
 msgid "Active uploads"
 msgstr "Ngarkime Aktive"
 
@@ -4003,7 +4003,7 @@ msgstr ""
 msgid "Advanced users only: If you have multiple network interfaces, enter the address of the interface to which aMule should be bound."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1462 src/muuli_wdr.cpp:2065
+#: src/muuli_wdr.cpp:1462 src/muuli_wdr.cpp:2069
 msgid "Bind to network interface (empty for any):"
 msgstr ""
 
@@ -4019,7 +4019,7 @@ msgstr ""
 msgid "Max simultaneous connections:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1498 src/muuli_wdr.cpp:3207
+#: src/muuli_wdr.cpp:1498 src/muuli_wdr.cpp:3211
 msgid "ED2K"
 msgstr "ED2K"
 
@@ -4111,780 +4111,780 @@ msgstr ""
 msgid "For new files preallocates disk space for the whole file, thus reduces fragmentation"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1617
+#: src/muuli_wdr.cpp:1621
 msgid "Create new files as sparse files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1618
+#: src/muuli_wdr.cpp:1622
 msgid "Sparse part files only occupy disk space for the parts already downloaded, so free space is used up gradually as the file fills in. Turn this off to use an ordinary file instead - useful where sparse files are unsupported or slow, or where backup/de-duplication tools handle them badly. Applies only when the core runs on Windows; on Linux and macOS part files are sparse anyway and this setting has no effect."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1623
+#: src/muuli_wdr.cpp:1627
 msgid "Stop downloads when free disk space reaches "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1624
+#: src/muuli_wdr.cpp:1628
 msgid "Select this if you want aMule to check your disk space"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1628
+#: src/muuli_wdr.cpp:1632
 msgid "Enter here the min disk space desired."
 msgstr "Futni ketu hapesiren minimale qe deshironi per diskun."
 
-#: src/muuli_wdr.cpp:1634
+#: src/muuli_wdr.cpp:1638
 msgid "Save 10 sources on rare files (< 20 sources)"
 msgstr "Shpeto 10 burime per failet e rralla (< 20 burime)"
 
-#: src/muuli_wdr.cpp:1638 src/Statistics.cpp:790
+#: src/muuli_wdr.cpp:1642 src/Statistics.cpp:790
 msgid "Uploads"
 msgstr "Ngarkimi"
 
-#: src/muuli_wdr.cpp:1641
+#: src/muuli_wdr.cpp:1645
 msgid "Add new shared files with auto priority"
 msgstr "Shto faile te reja te ndara me prioritet automatik"
 
-#: src/muuli_wdr.cpp:1647
+#: src/muuli_wdr.cpp:1651
 msgid "Intelligent Corruption Handling (I.C.H.)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1650
+#: src/muuli_wdr.cpp:1654
 msgid "Enable"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1653
+#: src/muuli_wdr.cpp:1657
 msgid "Advanced I.C.H. trusts every hash (not recommended)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1665 src/PrefsUnifiedDlg.cpp:1990
+#: src/muuli_wdr.cpp:1669 src/PrefsUnifiedDlg.cpp:1999
 msgid "Media metadata extraction"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1669
+#: src/muuli_wdr.cpp:1673
 msgid "Extract length / bitrate / codec from shared audio and video files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1671
+#: src/muuli_wdr.cpp:1675
 msgid "When enabled, aMule runs ffprobe on each shared media file to fill in the Length / Bitrate / Codec columns other clients see when they find the file in a search. Requires ffmpeg (the ffprobe binary) to be installed."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1678
+#: src/muuli_wdr.cpp:1682
 msgid "Path to ffprobe:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1683
+#: src/muuli_wdr.cpp:1687
 msgid "Full path to the ffprobe binary. Leave empty to have aMule auto-detect it on startup."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1691
+#: src/muuli_wdr.cpp:1695
 msgid "Detect"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1692
+#: src/muuli_wdr.cpp:1696
 msgid "Search the standard install locations for an ffprobe binary and fill the path field."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1716
+#: src/muuli_wdr.cpp:1720
 msgid ""
 "Completed downloads are stored here. All files in this folder are automatically shared with other peers.\n"
 "If this folder also holds files you don't want to share, point it at an aMule-only sub-folder."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1719
+#: src/muuli_wdr.cpp:1723
 msgid "Pick the folder where completed downloads will be stored. All files in that folder will be shared with other peers."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1733
+#: src/muuli_wdr.cpp:1737
 msgid "Shared folders"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1739
+#: src/muuli_wdr.cpp:1743
 msgid "(Folders shared by the core. Enter a path to add one.)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1747
+#: src/muuli_wdr.cpp:1751
 msgid "Absolute path of a folder on the core's machine, e.g. /home/user/shared"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1749 src/PrefsUnifiedDlg.cpp:2874
+#: src/muuli_wdr.cpp:1753 src/PrefsUnifiedDlg.cpp:2883
 msgid "Recursive"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1750
+#: src/muuli_wdr.cpp:1754
 msgid "Share every sub-folder underneath this one, including ones created later."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1754 src/utils/aLinkCreator/src/alcframe.cpp:141
+#: src/muuli_wdr.cpp:1758 src/utils/aLinkCreator/src/alcframe.cpp:141
 msgid "Remove"
 msgstr "Hiq"
 
-#: src/muuli_wdr.cpp:1758
+#: src/muuli_wdr.cpp:1762
 msgid "(Right click on folder icon for recursive share)"
 msgstr "( Klikoni me butonin e djathte ne ikonene e karteles per te ndare ne menyre rekursive)"
 
-#: src/muuli_wdr.cpp:1765
+#: src/muuli_wdr.cpp:1769
 msgid "Share hidden files"
 msgstr "Nda failet e fshehur"
 
-#: src/muuli_wdr.cpp:1771
+#: src/muuli_wdr.cpp:1775
 msgid "Automatically rescan shared folders for changes"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1777
+#: src/muuli_wdr.cpp:1781
 msgid "Follow symbolic links in shared folders"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1783
+#: src/muuli_wdr.cpp:1787
 msgid "Exclude files matching:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1786
+#: src/muuli_wdr.cpp:1790
 msgid "Wildcard patterns separated by '|', e.g. .DS_Store|Thumbs.db|*.tmp. Files whose name matches are not shared. Matching is case-insensitive."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1790
+#: src/muuli_wdr.cpp:1794
 msgid "Patterns are regular expressions"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1791
+#: src/muuli_wdr.cpp:1795
 msgid "When set, the whole field is one regular expression ('|' is alternation). When unset, it is a list of '|'-separated wildcards."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1801
+#: src/muuli_wdr.cpp:1805
 msgid "Show how many shared files the current pattern would exclude."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1822
+#: src/muuli_wdr.cpp:1826
 msgid "Graphs"
 msgstr "Grafiket"
 
-#: src/muuli_wdr.cpp:1825 src/muuli_wdr.cpp:1887
+#: src/muuli_wdr.cpp:1829 src/muuli_wdr.cpp:1891
 msgid "Update delay : 5 secs"
 msgstr "Intervali i azhornimit : 5 sek"
 
-#: src/muuli_wdr.cpp:1829
+#: src/muuli_wdr.cpp:1833
 msgid "Time for average graph: 100 mins"
 msgstr "Intervali grafik i vlerave mesatare: 100 minuta"
 
-#: src/muuli_wdr.cpp:1833
+#: src/muuli_wdr.cpp:1837
 msgid "Connections Graph Scale: 100 "
 msgstr "Shkalla grafike e lidhjeve: 100 "
 
-#: src/muuli_wdr.cpp:1840
+#: src/muuli_wdr.cpp:1844
 msgid "Download graph scale:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1848
+#: src/muuli_wdr.cpp:1852
 msgid "Upload graph scale:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1858
+#: src/muuli_wdr.cpp:1862
 msgid "Colors: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1862
+#: src/muuli_wdr.cpp:1866
 msgid "Background"
 msgstr "Sfondi"
 
-#: src/muuli_wdr.cpp:1863
+#: src/muuli_wdr.cpp:1867
 msgid "Grid"
 msgstr "Zgara"
 
-#: src/muuli_wdr.cpp:1864
+#: src/muuli_wdr.cpp:1868
 msgid "Download current"
 msgstr "Shkarkimi aktual"
 
-#: src/muuli_wdr.cpp:1865
+#: src/muuli_wdr.cpp:1869
 msgid "Download running average"
 msgstr "Mesatarja e shkarkimeve ne punim"
 
-#: src/muuli_wdr.cpp:1866
+#: src/muuli_wdr.cpp:1870
 msgid "Download session average"
 msgstr "Mesatarja e sesioneve te shkarkimit"
 
-#: src/muuli_wdr.cpp:1867
+#: src/muuli_wdr.cpp:1871
 msgid "Upload current"
 msgstr "Ngarkimi aktual"
 
-#: src/muuli_wdr.cpp:1868
+#: src/muuli_wdr.cpp:1872
 msgid "Upload running average"
 msgstr "Mesatarja e ngarkimit ne punim"
 
-#: src/muuli_wdr.cpp:1869
+#: src/muuli_wdr.cpp:1873
 msgid "Upload session average"
 msgstr "Mesatarja e sesionit te ngarkimeve"
 
-#: src/muuli_wdr.cpp:1870
+#: src/muuli_wdr.cpp:1874
 msgid "Active connections"
 msgstr "Lidhjet aktive"
 
-#: src/muuli_wdr.cpp:1873
+#: src/muuli_wdr.cpp:1877
 #, fuzzy
 msgid "Systray Icon Speed Bar"
 msgstr "Ikona e Speedbar-it ne Systray"
 
-#: src/muuli_wdr.cpp:1874
+#: src/muuli_wdr.cpp:1878
 msgid "Kad-nodes current"
 msgstr "Nyjet e Kad aktuale"
 
-#: src/muuli_wdr.cpp:1875
+#: src/muuli_wdr.cpp:1879
 msgid "Kad-nodes running"
 msgstr "Nyjet e Kad jane duke punuar"
 
-#: src/muuli_wdr.cpp:1876
+#: src/muuli_wdr.cpp:1880
 msgid "Kad-nodes session"
 msgstr "Sesioni i Nyjeve te Kad"
 
-#: src/muuli_wdr.cpp:1880 src/muuli_wdr.cpp:2334
+#: src/muuli_wdr.cpp:1884 src/muuli_wdr.cpp:2338
 msgid "Select"
 msgstr "Zgjidh"
 
-#: src/muuli_wdr.cpp:1884
+#: src/muuli_wdr.cpp:1888
 msgid "Tree"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1894
+#: src/muuli_wdr.cpp:1898
 msgid "Number of Client Versions shown (0=unlimited)"
 msgstr "Numera te treguar te versioneve te klienteve (0= pa kufij)"
 
-#: src/muuli_wdr.cpp:1919
+#: src/muuli_wdr.cpp:1923
 msgid "!!! WARNING !!!"
 msgstr "!!! KUJDES !!!"
 
-#: src/muuli_wdr.cpp:1934
+#: src/muuli_wdr.cpp:1938
 msgid "Max new connections / 5 secs"
 msgstr "Lidhe maksimale te reja / 5 sek"
 
-#: src/muuli_wdr.cpp:1936
+#: src/muuli_wdr.cpp:1940
 msgid "Concurrent Kad source lookups"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1938
+#: src/muuli_wdr.cpp:1942
 #, fuzzy
 msgid "Kad source re-search interval (minutes)"
 msgstr "Intervali i rifreskimit te FTP-se ne minuta"
 
-#: src/muuli_wdr.cpp:1940
+#: src/muuli_wdr.cpp:1944
 #, fuzzy
 msgid "Source re-ask interval (minutes)"
 msgstr "Intervali i rifreskimit te FTP-se ne minuta"
 
-#: src/muuli_wdr.cpp:1944
+#: src/muuli_wdr.cpp:1948
 msgid "File Buffer Size: 240000 bytes"
 msgstr "Madhesia e Buffer-it te failit: 240000 bytes"
 
-#: src/muuli_wdr.cpp:1948
+#: src/muuli_wdr.cpp:1952
 msgid "Use MMAP: memory-mapped file access (lower memory use)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1949
+#: src/muuli_wdr.cpp:1953
 msgid "Maps part files into memory instead of buffering them on the heap, lowering the process memory footprint. May reduce download speed on some disks; best for memory-constrained or upload-heavy hosts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1951
+#: src/muuli_wdr.cpp:1955
 msgid "Upload Queue Size: 5000 clients"
 msgstr "Madhesia e Radhes ne Ngarkim: 5000 klienta"
 
-#: src/muuli_wdr.cpp:1955
+#: src/muuli_wdr.cpp:1959
 msgid "Server connection refresh interval: Disable"
 msgstr "Interval i azhornimit te lidhjes se serverit: C'aktivizuar"
 
-#: src/muuli_wdr.cpp:1959
+#: src/muuli_wdr.cpp:1963
 msgid "Disable computer's timed standby mode"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1978
+#: src/muuli_wdr.cpp:1982
 msgid "Skin to use: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1987
+#: src/muuli_wdr.cpp:1991
 msgid "Show \"Fast eD2k Links Handler\" in every window."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1990
+#: src/muuli_wdr.cpp:1994
 msgid "Show extended info on categories tabs"
 msgstr "Trego informacion te zgjeruar ne tabelat e kategorive"
 
-#: src/muuli_wdr.cpp:1993
+#: src/muuli_wdr.cpp:1997
 #, fuzzy
 msgid "Show application version on title"
 msgstr "Trego shpejtesine e transferimit ne titull"
 
-#: src/muuli_wdr.cpp:1995
+#: src/muuli_wdr.cpp:1999
 msgid "Show transfer rates on title"
 msgstr "Trego shpejtesine e transferimit ne titull"
 
-#: src/muuli_wdr.cpp:1997
+#: src/muuli_wdr.cpp:2001
 msgid "Before application name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1999
+#: src/muuli_wdr.cpp:2003
 msgid "After application name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2002
+#: src/muuli_wdr.cpp:2006
 msgid "Show overhead bandwidth"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2006
+#: src/muuli_wdr.cpp:2010
 msgid "Vertical toolbar orientation"
 msgstr "Orientim Vertikal i toolbar-it"
 
-#: src/muuli_wdr.cpp:2008
+#: src/muuli_wdr.cpp:2012
 msgid "Live column sorting (auto-reorder rows as their values change)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2015
+#: src/muuli_wdr.cpp:2019
 msgid "Download Queue Files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2018
+#: src/muuli_wdr.cpp:2022
 msgid "Show progress percentage"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2024
+#: src/muuli_wdr.cpp:2028
 msgid "Show progress bar"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2027
+#: src/muuli_wdr.cpp:2031
 msgid "Flat"
 msgstr "E sheshte"
 
-#: src/muuli_wdr.cpp:2031
+#: src/muuli_wdr.cpp:2035
 msgid "Round"
 msgstr "E rrumbullakosur"
 
-#: src/muuli_wdr.cpp:2049
+#: src/muuli_wdr.cpp:2053
 msgid "External Connection Parameters"
 msgstr "Parametrat e Lidhjeve te Jashtme"
 
-#: src/muuli_wdr.cpp:2052
+#: src/muuli_wdr.cpp:2056
 msgid "Accept external connections"
 msgstr "Prano lidhje te jashtme"
 
-#: src/muuli_wdr.cpp:2059 src/muuli_wdr.cpp:2118
+#: src/muuli_wdr.cpp:2063 src/muuli_wdr.cpp:2122
 msgid "IP of the listening interface:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2062
+#: src/muuli_wdr.cpp:2066
 msgid "Enter here a valid ip in the a.b.c.d format for the listening EC interface. An empty field or 0.0.0.0 will mean any interface."
 msgstr "Futni ketu nje ip te vlefshem ne formatin a.b.c.d per te degjuar nderfaqesin EC. Nje fushe boshe ose 0.0.0.0 do te nenkuptoje cdo nderfaqe."
 
-#: src/muuli_wdr.cpp:2083 src/muuli_wdr.cpp:2194
+#: src/muuli_wdr.cpp:2087 src/muuli_wdr.cpp:2198
 msgid "TCP port:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2089
+#: src/muuli_wdr.cpp:2093
 msgid "Enable UPnP port forwarding on the EC port"
 msgstr "Aktivizo port forwarding UPnP tek porta EC"
 
-#: src/muuli_wdr.cpp:2093 src/muuli_wdr.cpp:3079
+#: src/muuli_wdr.cpp:2097 src/muuli_wdr.cpp:3083
 #: src/utils/wxCas/src/wxcasprefs.cpp:167
 msgid "Password"
 msgstr "Fjalekalim"
 
-#: src/muuli_wdr.cpp:2099
+#: src/muuli_wdr.cpp:2103
 msgid "aMule API server parameters"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2102
+#: src/muuli_wdr.cpp:2106
 msgid "Run amuleapi (REST API) on startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2107
+#: src/muuli_wdr.cpp:2111
 #, fuzzy
 msgid "HTTP port:"
 msgstr "Porta e Proksit:"
 
-#: src/muuli_wdr.cpp:2121
+#: src/muuli_wdr.cpp:2125
 msgid "The interface amuleapi's HTTP server listens on. 127.0.0.1 (default) accepts only local connections; use 0.0.0.0 or a specific IP to expose it to other hosts (set an admin password below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2126
+#: src/muuli_wdr.cpp:2130
 msgid "Type a password to set or change it. Stored passwords cannot be shown, so leaving this empty keeps the current one."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2128
+#: src/muuli_wdr.cpp:2132
 #, fuzzy
 msgid "Admin password"
 msgstr "Duke kerkuar fjalekalimin\n"
 
-#: src/muuli_wdr.cpp:2140 src/muuli_wdr.cpp:2157 src/PrefsUnifiedDlg.cpp:1103
+#: src/muuli_wdr.cpp:2144 src/muuli_wdr.cpp:2161 src/PrefsUnifiedDlg.cpp:1112
 #, fuzzy
 msgid "A password is set."
 msgstr "Duke kerkuar fjalekalimin\n"
 
-#: src/muuli_wdr.cpp:2144
+#: src/muuli_wdr.cpp:2148
 #, fuzzy
 msgid "Enable guest access"
 msgstr "Ndalo hyrjen e guest-ve"
 
-#: src/muuli_wdr.cpp:2145
+#: src/muuli_wdr.cpp:2149
 msgid "Guest sessions may read status and listings but cannot change anything. Turning this off clears the stored guest password."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2149
+#: src/muuli_wdr.cpp:2153
 #, fuzzy
 msgid "Guest password"
 msgstr "Fjalekalim per te drejta komplete"
 
-#: src/muuli_wdr.cpp:2164
+#: src/muuli_wdr.cpp:2168
 msgid "Web server parameters"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2167
+#: src/muuli_wdr.cpp:2171
 msgid "Run webserver on startup (deprecated)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2173
+#: src/muuli_wdr.cpp:2177
 msgid "Web template"
 msgstr "Modeli Web"
 
-#: src/muuli_wdr.cpp:2178
+#: src/muuli_wdr.cpp:2182
 msgid "Full rights password"
 msgstr "Fjalekalim per te drejta komplete"
 
-#: src/muuli_wdr.cpp:2182
+#: src/muuli_wdr.cpp:2186
 msgid "Enable Low rights User"
 msgstr "Aktivizo Perdorues me te drejta te kufizuara"
 
-#: src/muuli_wdr.cpp:2187
+#: src/muuli_wdr.cpp:2191
 msgid "Low rights password"
 msgstr "Fjalekalim per te drejta te kufizuara"
 
-#: src/muuli_wdr.cpp:2201
+#: src/muuli_wdr.cpp:2205
 msgid "Enable UPnP port forwarding of the web server port"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2206
+#: src/muuli_wdr.cpp:2210
 msgid "Web server UPnP TCP port (Optional)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2214
+#: src/muuli_wdr.cpp:2218
 msgid "Page Refresh Time (in secs)"
 msgstr "Koha e Rifreskimit te Faqes (ne sek)"
 
-#: src/muuli_wdr.cpp:2221
+#: src/muuli_wdr.cpp:2225
 msgid "Enable Gzip compression"
 msgstr "Aktivizo kompresimin Gzip"
 
-#: src/muuli_wdr.cpp:2255
+#: src/muuli_wdr.cpp:2259
 #, fuzzy
 msgid "Reset page to defaults"
 msgstr "E vendosur nga sistemi"
 
-#: src/muuli_wdr.cpp:2256
+#: src/muuli_wdr.cpp:2260
 msgid "Reset the settings on the current page to their default values."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2258 src/muuli_wdr.cpp:2344 src/ServerWnd.cpp:274
+#: src/muuli_wdr.cpp:2262 src/muuli_wdr.cpp:2348 src/ServerWnd.cpp:274
 #: src/ServerWnd.cpp:282
 msgid "OK"
 msgstr "Ne rregull"
 
-#: src/muuli_wdr.cpp:2260
+#: src/muuli_wdr.cpp:2264
 msgid "Click here to apply any changes made to the preferences."
 msgstr "Kliko ketu per te bere aktive ndryshimet qe u bene tek Preferencat."
 
-#: src/muuli_wdr.cpp:2263
+#: src/muuli_wdr.cpp:2267
 msgid "Reset any changes made to the preferences."
 msgstr "Rikthe ne gjendjen e meparshme ndryshimet te bera tek Preferencat."
 
-#: src/muuli_wdr.cpp:2292
+#: src/muuli_wdr.cpp:2296
 msgid "Comment :"
 msgstr "Komente :"
 
-#: src/muuli_wdr.cpp:2299
+#: src/muuli_wdr.cpp:2303
 msgid "Incoming Dir :"
 msgstr "Direktoria e Hyrjeve :"
 
-#: src/muuli_wdr.cpp:2308
+#: src/muuli_wdr.cpp:2312
 msgid "Change priority for new assigned files :"
 msgstr "Nderro perparesine per failet e reja te caktuara :"
 
-#: src/muuli_wdr.cpp:2312
+#: src/muuli_wdr.cpp:2316
 #, fuzzy
 msgid "Don't change"
 msgstr "Mos nderro"
 
-#: src/muuli_wdr.cpp:2324
+#: src/muuli_wdr.cpp:2328
 msgid "Select color for this Category (currently selected) :"
 msgstr "Zgjidh ngjyren per kete kategori (e zgjedhur aktualisht) :"
 
-#: src/muuli_wdr.cpp:2391 src/muuli_wdr.cpp:2410 src/muuli_wdr.cpp:2432
+#: src/muuli_wdr.cpp:2395 src/muuli_wdr.cpp:2414 src/muuli_wdr.cpp:2436
 msgid "Click this button to reset the log."
 msgstr "Kliko ne kete buton per te resetuar log-un."
 
-#: src/muuli_wdr.cpp:2451
+#: src/muuli_wdr.cpp:2455
 msgid "Click on this button to update the servers list from URL ..."
 msgstr "Kliko ne kete buton per te azhornuar listen e serverave nga URL ..."
 
-#: src/muuli_wdr.cpp:2455
+#: src/muuli_wdr.cpp:2459
 msgid "Server list"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2459
+#: src/muuli_wdr.cpp:2463
 msgid "Enter the url to a server.met file here and press the button to the left to update the list of known servers."
 msgstr "Futni url tek nje fail server.met dhe shtypni butonin ne te majte per te azhornuar listen e serverave te njohur."
 
-#: src/muuli_wdr.cpp:2464
+#: src/muuli_wdr.cpp:2468
 msgid "Add server manually: Name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2467
+#: src/muuli_wdr.cpp:2471
 msgid "Enter the name of the new server here"
 msgstr "Futni emrin e serverit te ri ketu"
 
-#: src/muuli_wdr.cpp:2469 src/ServerWnd.cpp:206
+#: src/muuli_wdr.cpp:2473 src/ServerWnd.cpp:206
 msgid "IP:Port"
 msgstr "IP:Porta"
 
-#: src/muuli_wdr.cpp:2472
+#: src/muuli_wdr.cpp:2476
 msgid "Enter the IP of the server here, using the x.x.x.x format."
 msgstr "Futni IP-ne e serverit ketu. duke perdorur formatin x.x.x.x."
 
-#: src/muuli_wdr.cpp:2478
+#: src/muuli_wdr.cpp:2482
 msgid "Enter the port of the server here."
 msgstr "Futni porten e serverit ketu."
 
-#: src/muuli_wdr.cpp:2481
+#: src/muuli_wdr.cpp:2485
 msgid "Add manually a server (fill fields to the left before) ..."
 msgstr "Shto ne menyre manuale nje server (mbushni fushen ne te majte me pare) ..."
 
-#: src/muuli_wdr.cpp:2510
+#: src/muuli_wdr.cpp:2514
 msgid "aMule Log"
 msgstr "Log i aMule"
 
-#: src/muuli_wdr.cpp:2518
+#: src/muuli_wdr.cpp:2522
 msgid "Server Info"
 msgstr "Informacion mbi serverin"
 
-#: src/muuli_wdr.cpp:2522
+#: src/muuli_wdr.cpp:2526
 msgid "ED2K Info"
 msgstr "Informacioni i ED2K"
 
-#: src/muuli_wdr.cpp:2526
+#: src/muuli_wdr.cpp:2530
 msgid "Kad Info"
 msgstr "Informacioni i Kad"
 
-#: src/muuli_wdr.cpp:2554
+#: src/muuli_wdr.cpp:2558
 msgid "Click on this button to update the nodes list from URL ..."
 msgstr "Kliko ne kete buton per te azhornuar listen e nyjeve nga URL ..."
 
-#: src/muuli_wdr.cpp:2558
+#: src/muuli_wdr.cpp:2562
 msgid "Nodes (0)"
 msgstr "Nyjet (0)"
 
-#: src/muuli_wdr.cpp:2562
+#: src/muuli_wdr.cpp:2566
 msgid "Enter the url to a nodes.dat file here and press the button to the left to update the list of known nodes."
 msgstr "Fut url e nje faili nodes.dat dhe shtyp butonin ne te majte per te azhornuar listen e nyjeve te njohura."
 
-#: src/muuli_wdr.cpp:2565
+#: src/muuli_wdr.cpp:2569
 msgid "Nodes stats"
 msgstr "Statistikat e Nyjeve"
 
-#: src/muuli_wdr.cpp:2607
+#: src/muuli_wdr.cpp:2611
 msgid "Bootstrap"
 msgstr "Bootstrap"
 
-#: src/muuli_wdr.cpp:2610
+#: src/muuli_wdr.cpp:2614
 msgid "New node"
 msgstr "Nyje e re"
 
-#: src/muuli_wdr.cpp:2615
+#: src/muuli_wdr.cpp:2619
 msgid "IP:"
 msgstr "IP:"
 
-#: src/muuli_wdr.cpp:2635
+#: src/muuli_wdr.cpp:2639
 msgid "Port:"
 msgstr "Porta:"
 
-#: src/muuli_wdr.cpp:2648
+#: src/muuli_wdr.cpp:2652
 #, fuzzy
 msgid "Bootstrap from known clients"
 msgstr ""
 "Bootstrap nga \n"
 "kliente te njohur"
 
-#: src/muuli_wdr.cpp:2650
+#: src/muuli_wdr.cpp:2654
 msgid "Disconnect Kad"
 msgstr "Shkeput Kad"
 
-#: src/muuli_wdr.cpp:2684
+#: src/muuli_wdr.cpp:2688
 msgid "Use Secure User Identification"
 msgstr "Perdor Identifikimin e Sigurte te Perdoruesve"
 
-#: src/muuli_wdr.cpp:2686
+#: src/muuli_wdr.cpp:2690
 msgid "It is recommended to enable this option. You will not receive credits if SUI is not enabled."
 msgstr "Eshte e rekomandueshme qe ta lejoni kete opsion. Ju nuk mund te merrni kredite nqs SUI nuk eshte i aktivizuar."
 
-#: src/muuli_wdr.cpp:2688
+#: src/muuli_wdr.cpp:2692
 msgid "Protocol Obfuscation"
 msgstr "Protokolli i Turbullimit"
 
-#: src/muuli_wdr.cpp:2691
+#: src/muuli_wdr.cpp:2695
 msgid "Support Protocol Obfuscation"
 msgstr "Mbeshtet Protokollin e Turbullimit"
 
-#: src/muuli_wdr.cpp:2693
+#: src/muuli_wdr.cpp:2697
 msgid "This option enabled Protocol Obfuscation, and makes aMule accept obfuscated connections from other clients."
 msgstr "Ky opsion lejon Protokollin e Turbullimit, dhe ben qe aMule te pranoje lidhje te turbulluara nga kliente te tjere."
 
-#: src/muuli_wdr.cpp:2695
+#: src/muuli_wdr.cpp:2699
 msgid "Use obfuscation for outgoing connections"
 msgstr "Perdor turbullimin per lidhjet ne dalje"
 
-#: src/muuli_wdr.cpp:2697
+#: src/muuli_wdr.cpp:2701
 msgid "This option makes aMule use Protocol Obfuscation when connecting other clients/servers."
 msgstr "Ky opsion lejon aMule-n qe te perdori protokollin e turbullimit kur lidhet me klientet/serverat e tjere."
 
-#: src/muuli_wdr.cpp:2699
+#: src/muuli_wdr.cpp:2703
 msgid "Accept only obfuscated connections"
 msgstr "Prano vetem lidhje te turbulluara"
 
-#: src/muuli_wdr.cpp:2700
+#: src/muuli_wdr.cpp:2704
 msgid "This option makes aMule only accept obfuscated connections. You will have less sources, but all your traffic will be obfuscated"
 msgstr "Ky opsion e ben aMule-n qe te lejoje lidhje te turbulluara. Ju do te keni me pak burime, por i gjithe trafiku juaj do te turbullohet"
 
-#: src/muuli_wdr.cpp:2705
+#: src/muuli_wdr.cpp:2709
 msgid "Everybody"
 msgstr "Te gjithe"
 
-#: src/muuli_wdr.cpp:2707
+#: src/muuli_wdr.cpp:2711
 msgid "No one"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2709
+#: src/muuli_wdr.cpp:2713
 msgid "Who can see my shared files:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2710
+#: src/muuli_wdr.cpp:2714
 msgid "Select who can request to view a list of your shared files."
 msgstr "Zgjidh se kush ka kerkuar te shikoje listene faileve qe ju keni ndare."
 
-#: src/muuli_wdr.cpp:2712
+#: src/muuli_wdr.cpp:2716
 msgid "IP-Filtering"
 msgstr "Filtrimi-IP"
 
-#: src/muuli_wdr.cpp:2719
+#: src/muuli_wdr.cpp:2723
 msgid "Filter clients"
 msgstr "Filtro klientet"
 
-#: src/muuli_wdr.cpp:2721
+#: src/muuli_wdr.cpp:2725
 msgid "Enable filtering of the client IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "Lejo filtrimin e IP-ve te klientave te percaktuar ne failin ~/.aMule/ipfilter.dat."
 
-#: src/muuli_wdr.cpp:2723
+#: src/muuli_wdr.cpp:2727
 msgid "Filter servers"
 msgstr "Filtron Serverat"
 
-#: src/muuli_wdr.cpp:2725
+#: src/muuli_wdr.cpp:2729
 msgid "Enable filtering of the server IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "Lejo filtrimin e IP-ve te serverave te percaktuara ne failin ~/.aMule/ipfilter.dat."
 
-#: src/muuli_wdr.cpp:2729
+#: src/muuli_wdr.cpp:2733
 msgid "Reload List"
 msgstr "Lista e Ringarkimeve"
 
-#: src/muuli_wdr.cpp:2730
+#: src/muuli_wdr.cpp:2734
 msgid "Reload the list of IPs to filter from the file ~/.aMule/ipfilter.dat"
 msgstr "Ringarko listen e IP-ve per te filtruar nga faili ~/.aMule/ipfilter.dat"
 
-#: src/muuli_wdr.cpp:2736
+#: src/muuli_wdr.cpp:2740
 msgid "URL:"
 msgstr "URL:"
 
-#: src/muuli_wdr.cpp:2740 src/muuli_wdr.cpp:2933
+#: src/muuli_wdr.cpp:2744 src/muuli_wdr.cpp:2937
 msgid "Update now"
 msgstr "Azhorno tani"
 
-#: src/muuli_wdr.cpp:2743
+#: src/muuli_wdr.cpp:2747
 msgid "Auto-update ipfilter at startup"
 msgstr "Azhornim-Automatik i ipfilter sapo te ndizet"
 
-#: src/muuli_wdr.cpp:2747
+#: src/muuli_wdr.cpp:2751
 msgid "Filtering Level:"
 msgstr "Niveli i Filtrimit:"
 
-#: src/muuli_wdr.cpp:2753
+#: src/muuli_wdr.cpp:2757
 msgid "Always filter LAN IPs"
 msgstr "Gjithmone filtro IP-te LAN"
 
-#: src/muuli_wdr.cpp:2756
+#: src/muuli_wdr.cpp:2760
 msgid "Paranoid handling of non-matching IPs"
 msgstr "Perdorim Paranoik te IP-ve qe nuk korrespondojne"
 
-#: src/muuli_wdr.cpp:2758
+#: src/muuli_wdr.cpp:2762
 msgid "Rejects a packet when its source IP differs from the IP the client claims (an anti-spoofing check). Disable only if it causes connection problems."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2760
+#: src/muuli_wdr.cpp:2764
 msgid "Use system-wide ipfilter.dat if available"
 msgstr "Perdor ipfilter.dat te sistemit nqs eshte i disponueshem"
 
-#: src/muuli_wdr.cpp:2761
+#: src/muuli_wdr.cpp:2765
 #, fuzzy
 msgid "If there's no local ipfilter.dat found, allow usage of a system-wide ipfilter file."
 msgstr "Nese nuk eshte gjetur ndonje ipfilter.dat lokal, lejo perdorimin e failit ipfilter te sistemit."
 
-#: src/muuli_wdr.cpp:2778
+#: src/muuli_wdr.cpp:2782
 msgid "Enable Online-Signature"
 msgstr "Lejo Firmen-Online"
 
-#: src/muuli_wdr.cpp:2780
+#: src/muuli_wdr.cpp:2784
 msgid "Enables the writing of the OS file, which can be used by external apps to create signatures and the like."
 msgstr "Lejon shkrimin e faileve OS, qe mund te perdorren nga aplikacione te jashtme per te krijuar firma dhe te ngjashme."
 
-#: src/muuli_wdr.cpp:2784
+#: src/muuli_wdr.cpp:2788
 msgid "Update Frequency (Secs):"
 msgstr "Frekuenca e azhornimeve (sek):"
 
-#: src/muuli_wdr.cpp:2787
+#: src/muuli_wdr.cpp:2791
 msgid "Change the frequency (in seconds) of Online Signature updates."
 msgstr "Nderron frekuqncen (ne sekonda) te azhornimit te Firmes Online."
 
-#: src/muuli_wdr.cpp:2795
+#: src/muuli_wdr.cpp:2799
 msgid "Save online signature file in: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:2801
+#: src/muuli_wdr.cpp:2805
 msgid "Click here to select the directory containing the the Online Signature files."
 msgstr "Shtypni ketu per te zgjedhur direktorine qe permban failet e Firmes Online."
 
-#: src/muuli_wdr.cpp:2834
+#: src/muuli_wdr.cpp:2838
 msgid "Show country flags for clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2835
+#: src/muuli_wdr.cpp:2839
 msgid "Render the country flag column in the transfers, queue and search views. Requires a valid MMDB GeoIP database (see below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2840
+#: src/muuli_wdr.cpp:2844
 #, fuzzy
 msgid "Database"
 msgstr "Shpejtesia :"
 
-#: src/muuli_wdr.cpp:2856
+#: src/muuli_wdr.cpp:2860
 #, fuzzy
 msgid "Source:"
 msgstr "Burime"
 
-#: src/muuli_wdr.cpp:2859
+#: src/muuli_wdr.cpp:2863
 msgid "DB-IP (free, no account)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2860
+#: src/muuli_wdr.cpp:2864
 msgid "MaxMind GeoLite2 (free, account required)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2861
+#: src/muuli_wdr.cpp:2865
 msgid "Custom URL"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2864
+#: src/muuli_wdr.cpp:2868
 msgid "Choose which provider supplies the GeoIP MMDB database. DB-IP is the default - no account required. MaxMind requires a free account + license key. Use Custom URL to point at any other MMDB host (e.g. a local mirror)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2881
+#: src/muuli_wdr.cpp:2885
 msgid ""
 "No configuration required.\n"
 "\n"
@@ -4892,11 +4892,11 @@ msgid ""
 "License: Creative Commons BY 4.0 - https://creativecommons.org/licenses/by/4.0/"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2894
+#: src/muuli_wdr.cpp:2898
 msgid "License key:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2900
+#: src/muuli_wdr.cpp:2904
 msgid ""
 "Sign up for a free MaxMind account, then generate a License Key:\n"
 "https://www.maxmind.com/en/geolite2/signup\n"
@@ -4906,232 +4906,232 @@ msgid ""
 "Requires attribution and account registration; refresh at least every 30 days."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2915
+#: src/muuli_wdr.cpp:2919
 #, fuzzy
 msgid "Download URL:"
 msgstr "Shkarkim: "
 
-#: src/muuli_wdr.cpp:2921
+#: src/muuli_wdr.cpp:2925
 msgid ""
 "Must point to an .mmdb file or a .gz / .tar.gz containing one.\n"
 "URL may include credentials (https://user:pass@host/...).\n"
 "License and attribution terms are set by the upstream URL - you are responsible."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2934
+#: src/muuli_wdr.cpp:2938
 msgid "Download the GeoIP database from the selected source."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2936
+#: src/muuli_wdr.cpp:2940
 #, fuzzy
 msgid "Auto-update on startup"
 msgstr "Azhornim-Automatik i ipfilter sapo te ndizet"
 
-#: src/muuli_wdr.cpp:2937
+#: src/muuli_wdr.cpp:2941
 msgid "Re-download the GeoIP database from the selected source every time aMule starts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2960
+#: src/muuli_wdr.cpp:2964
 msgid "Filter incoming messages (except current chat):"
 msgstr "Filtron mesazhet ne hyrje (pervec chatit qe po zhvilloni):"
 
-#: src/muuli_wdr.cpp:2962
+#: src/muuli_wdr.cpp:2966
 msgid "Filter all messages"
 msgstr "Filtron te gjithe mesazhet"
 
-#: src/muuli_wdr.cpp:2964
+#: src/muuli_wdr.cpp:2968
 msgid "Filter messages from people not on your friend list"
 msgstr "Filtron mesazhet nga njerezit qe nuk ndohen ne listen e miqve tuaj"
 
-#: src/muuli_wdr.cpp:2966
+#: src/muuli_wdr.cpp:2970
 msgid "Filter messages from unknown clients"
 msgstr "Filtron mesazhet nga klienta t èanjohur"
 
-#: src/muuli_wdr.cpp:2968
+#: src/muuli_wdr.cpp:2972
 msgid "Filter messages containing (use ',' as separator):"
 msgstr "Filtron mesazhet qe permbajne (perdor ',' si nje ndarese):"
 
-#: src/muuli_wdr.cpp:2971 src/muuli_wdr.cpp:2982
+#: src/muuli_wdr.cpp:2975 src/muuli_wdr.cpp:2986
 msgid "add here the words amule should filter and block messages including it"
 msgstr "shto ketu fjalet qe aMule do te filtroje duke bllokuar mesazhet qe ato mbajne"
 
-#: src/muuli_wdr.cpp:2973
+#: src/muuli_wdr.cpp:2977
 msgid "Show received messages in the log"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2976
+#: src/muuli_wdr.cpp:2980
 msgid "Comments"
 msgstr "Komente"
 
-#: src/muuli_wdr.cpp:2979
+#: src/muuli_wdr.cpp:2983
 msgid "Filter comments containing (use ',' as separator):"
 msgstr "Komente e filtrave permbajne (perdor ',' si nje ndarese):"
 
-#: src/muuli_wdr.cpp:3004
+#: src/muuli_wdr.cpp:3008
 msgid "Enable Proxy"
 msgstr "Aktivizo Proksin(Proxy)"
 
-#: src/muuli_wdr.cpp:3005
+#: src/muuli_wdr.cpp:3009
 msgid "Enable/disable proxy support"
 msgstr "Aktivizo/C'aktivizo mbeshtetjen e Proksit(Proxy)"
 
-#: src/muuli_wdr.cpp:3008
+#: src/muuli_wdr.cpp:3012
 msgid "Proxy type:"
 msgstr "Lloji i Proksit(Proxy):"
 
-#: src/muuli_wdr.cpp:3019
+#: src/muuli_wdr.cpp:3023
 msgid "Proxy host:"
 msgstr "Hosti i Proksit(Proxy)"
 
-#: src/muuli_wdr.cpp:3022
+#: src/muuli_wdr.cpp:3026
 msgid "The proxy host name"
 msgstr "Host Name i Proksit(Proxy)"
 
-#: src/muuli_wdr.cpp:3024
+#: src/muuli_wdr.cpp:3028
 msgid "Proxy port:"
 msgstr "Porta e Proksit:"
 
-#: src/muuli_wdr.cpp:3027
+#: src/muuli_wdr.cpp:3031
 msgid "The proxy port"
 msgstr "Porta e Proksit(Proxy)"
 
-#: src/muuli_wdr.cpp:3029
+#: src/muuli_wdr.cpp:3033
 msgid "Enable authentication"
 msgstr "Aktivizo njohjen"
 
-#: src/muuli_wdr.cpp:3030
+#: src/muuli_wdr.cpp:3034
 msgid "Enable/disable username/password authentication"
 msgstr "Aktivizo/C'aktivizo emri i perdoruesit/njohja e fjalekalimit"
 
-#: src/muuli_wdr.cpp:3033
+#: src/muuli_wdr.cpp:3037
 msgid "Username: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:3036
+#: src/muuli_wdr.cpp:3040
 msgid "The username to use to connect to the proxy"
 msgstr "Emri i perdorimit qe do perdoret per tu lidhur tek Proksi(Proxy)"
 
-#: src/muuli_wdr.cpp:3038
+#: src/muuli_wdr.cpp:3042
 msgid "Password:"
 msgstr "Fjalekalimi:"
 
-#: src/muuli_wdr.cpp:3041
+#: src/muuli_wdr.cpp:3045
 msgid "The password to use to connect to the proxy"
 msgstr "Fjalekalimi per te perdorur per tu lidhur tek Proksi(Proxy)"
 
-#: src/muuli_wdr.cpp:3060
+#: src/muuli_wdr.cpp:3064
 msgid "Connect to:"
 msgstr "Lidhu me:"
 
-#: src/muuli_wdr.cpp:3069
+#: src/muuli_wdr.cpp:3073
 msgid "Login to remote amule"
 msgstr "Futu tek Remote i aMule"
 
-#: src/muuli_wdr.cpp:3074
+#: src/muuli_wdr.cpp:3078
 msgid "User name"
 msgstr "Emri i Perdoruesit"
 
-#: src/muuli_wdr.cpp:3085
+#: src/muuli_wdr.cpp:3089
 msgid "Remember those settings"
 msgstr "Mbaji mend keto rregullime"
 
-#: src/muuli_wdr.cpp:3088
+#: src/muuli_wdr.cpp:3092
 #, fuzzy
 msgid "Force ZLIB compression"
 msgstr "Perdor kompresimin gzip"
 
-#: src/muuli_wdr.cpp:3112
+#: src/muuli_wdr.cpp:3116
 msgid "Enable Verbose Debug-Logging."
 msgstr "Aktivizon logging-un e detajuar te mesazheve te debug-ut."
 
-#: src/muuli_wdr.cpp:3114
+#: src/muuli_wdr.cpp:3118
 #, fuzzy
 msgid "Only to Logfile"
 msgstr "&Hap failin"
 
-#: src/muuli_wdr.cpp:3116
+#: src/muuli_wdr.cpp:3120
 msgid "Message Categories:"
 msgstr "Kategorite e Mesazheve:"
 
-#: src/muuli_wdr.cpp:3140 src/PartFileConvertDlg.cpp:160
+#: src/muuli_wdr.cpp:3144 src/PartFileConvertDlg.cpp:160
 msgid "Waiting..."
 msgstr "Ne pritje..."
 
-#: src/muuli_wdr.cpp:3160
+#: src/muuli_wdr.cpp:3164
 msgid "Add imports"
 msgstr "Shton importimet"
 
-#: src/muuli_wdr.cpp:3163
+#: src/muuli_wdr.cpp:3167
 msgid "Retry selected"
 msgstr "Provoji perseri te perzgjedhurit"
 
-#: src/muuli_wdr.cpp:3165
+#: src/muuli_wdr.cpp:3169
 msgid "Remove selected"
 msgstr "Zhvendos te perzgjedhurat"
 
-#: src/muuli_wdr.cpp:3228
+#: src/muuli_wdr.cpp:3232
 msgid "Event Types"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3247
+#: src/muuli_wdr.cpp:3251
 msgid "Statistics and queued clients for selected file(s) : Session / All time"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3271
+#: src/muuli_wdr.cpp:3275
 #, fuzzy
 msgid "Active Uploads"
 msgstr "Ngarkime Aktive :"
 
-#: src/muuli_wdr.cpp:3285
+#: src/muuli_wdr.cpp:3289
 msgid "Percent of total files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3337
+#: src/muuli_wdr.cpp:3341
 #, fuzzy
 msgid "Show Clients for"
 msgstr "Trego klientet"
 
-#: src/muuli_wdr.cpp:3339
+#: src/muuli_wdr.cpp:3343
 #, fuzzy
 msgid "All files"
 msgstr "Fshih failet e ndara"
 
-#: src/muuli_wdr.cpp:3342
+#: src/muuli_wdr.cpp:3346
 #, fuzzy
 msgid "Selected files"
 msgstr "Zgjidh filtrin e shikimit"
 
-#: src/muuli_wdr.cpp:3345
+#: src/muuli_wdr.cpp:3349
 #, fuzzy
 msgid "Active uploads only"
 msgstr "Ngarkime Aktive"
 
-#: src/muuli_wdr.cpp:3352
+#: src/muuli_wdr.cpp:3356
 #, fuzzy
 msgid "Reload:"
 msgstr "Lista e Ringarkimeve"
 
-#: src/muuli_wdr.cpp:3356
+#: src/muuli_wdr.cpp:3360
 msgid "Reload your shared files"
 msgstr "Ringarko failet e ndara"
 
-#: src/muuli_wdr.cpp:3419
+#: src/muuli_wdr.cpp:3423
 msgid "Send"
 msgstr "Dergo"
 
-#: src/muuli_wdr.cpp:3420
+#: src/muuli_wdr.cpp:3424
 msgid "Sends the specified message."
 msgstr "Dergo mesazhin e specifikuar."
 
-#: src/muuli_wdr.cpp:3424
+#: src/muuli_wdr.cpp:3428
 msgid "Close this chat-session."
 msgstr "Mbylle kete sesion chati."
 
-#: src/muuli_wdr.cpp:3447
+#: src/muuli_wdr.cpp:3451
 msgid "Connect to any server and/or Kad"
 msgstr "Lidhu me ndonje server dhe/ose Kad"
 
-#: src/muuli_wdr.cpp:3453 src/SharedFilesCtrl.cpp:142 src/Statistics.cpp:941
+#: src/muuli_wdr.cpp:3457 src/SharedFilesCtrl.cpp:142 src/Statistics.cpp:941
 msgid "Shared Files"
 msgstr "File te ndara"
 
@@ -5769,35 +5769,35 @@ msgstr ""
 "aMule do te punoje ne rregull pa modifikuarr asnje nga\n"
 "keto rregullime"
 
-#: src/PrefsUnifiedDlg.cpp:647
+#: src/PrefsUnifiedDlg.cpp:656
 #, c-format
 msgid "Failed to connect Cfg to widget with the ID %d and key %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:695
+#: src/PrefsUnifiedDlg.cpp:704
 #, c-format
 msgid "Failed to transfer data from Cfg to Widget with the ID %d and key %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:801
+#: src/PrefsUnifiedDlg.cpp:810
 msgid "The type of proxy you are connecting to"
 msgstr "Lloji i Proksit(Proxy) qe ju po lidheni"
 
-#: src/PrefsUnifiedDlg.cpp:1020
+#: src/PrefsUnifiedDlg.cpp:1029
 #, c-format
 msgid "Failed to transfer data from Widget to Cfg with the ID %d and key %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1103
+#: src/PrefsUnifiedDlg.cpp:1112
 #, fuzzy
 msgid "No password set."
 msgstr "Duke kerkuar fjalekalimin\n"
 
-#: src/PrefsUnifiedDlg.cpp:1132
+#: src/PrefsUnifiedDlg.cpp:1141
 msgid "Guest access needs a password. Type one in the guest password field, or untick Enable guest access."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1144
+#: src/PrefsUnifiedDlg.cpp:1153
 msgid ""
 "aMule must be restarted to enable these changes:\n"
 "\n"
@@ -5805,51 +5805,51 @@ msgstr ""
 "aMule duhet qe te ristartohet qe keto ndryshime te aplikohen:\n"
 " \n"
 
-#: src/PrefsUnifiedDlg.cpp:1151
+#: src/PrefsUnifiedDlg.cpp:1160
 msgid "- TCP port changed.\n"
 msgstr "Porta TCP eshte ndryshuar.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1156
+#: src/PrefsUnifiedDlg.cpp:1165
 msgid "- UDP port changed.\n"
 msgstr "Porta UDP eshte ndryshuar.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1161
+#: src/PrefsUnifiedDlg.cpp:1170
 #, fuzzy
 msgid "- Network interface binding changed.\n"
 msgstr "Lidhja e jashtme u mbyll."
 
-#: src/PrefsUnifiedDlg.cpp:1166
+#: src/PrefsUnifiedDlg.cpp:1175
 #, fuzzy
 msgid "- External connect port changed.\n"
 msgstr "Lidhja e jashtme u mbyll."
 
-#: src/PrefsUnifiedDlg.cpp:1170
+#: src/PrefsUnifiedDlg.cpp:1179
 #, fuzzy
 msgid "- External connect acceptance changed.\n"
 msgstr "U pranua nje lidhje e jashtme e re"
 
-#: src/PrefsUnifiedDlg.cpp:1174
+#: src/PrefsUnifiedDlg.cpp:1183
 #, fuzzy
 msgid "- External connect interface changed.\n"
 msgstr "Lidhja e jashtme u mbyll."
 
-#: src/PrefsUnifiedDlg.cpp:1178
+#: src/PrefsUnifiedDlg.cpp:1187
 #, fuzzy
 msgid "- Protocol obfuscation support changed.\n"
 msgstr "Protokolli i Turbullimit"
 
-#: src/PrefsUnifiedDlg.cpp:1193
+#: src/PrefsUnifiedDlg.cpp:1202
 #, fuzzy
 msgid "- amuleapi settings changed.\n"
 msgstr "- Gjuha ndryshoi.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1202
+#: src/PrefsUnifiedDlg.cpp:1211
 msgid ""
 "Your Auto-update server list is empty.\n"
 "'Auto-update server list at startup' will be disabled."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1213
+#: src/PrefsUnifiedDlg.cpp:1222
 msgid ""
 "You have enabled external connections but have not specified a password.\n"
 "External connections cannot be enabled unless a valid password is specified."
@@ -5857,40 +5857,40 @@ msgstr ""
 "Ju keni lejuar lidhjet e jashtme por nuk keni specifikuar nje fjalekalim.\n"
 "Lidhjet e jashtme nuk mund te lejohen derisa te specifikohet nje fjalekalim."
 
-#: src/PrefsUnifiedDlg.cpp:1246
+#: src/PrefsUnifiedDlg.cpp:1255
 #, c-format
 msgid "The amuleapi password could not be saved: %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1276
+#: src/PrefsUnifiedDlg.cpp:1285
 msgid "- Language changed.\n"
 msgstr "- Gjuha ndryshoi.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1281
+#: src/PrefsUnifiedDlg.cpp:1290
 msgid "- Temp folder changed.\n"
 msgstr "Kartela Temp ndryshoi.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1286
+#: src/PrefsUnifiedDlg.cpp:1295
 #, fuzzy
 msgid "- ED2K network enabled.\n"
 msgstr "Te gjithe rrjetet jane c'aktivizuar."
 
-#: src/PrefsUnifiedDlg.cpp:1319
+#: src/PrefsUnifiedDlg.cpp:1328
 msgid "The shared-file exclusion pattern is not a valid regular expression. The filter has been left disabled."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1321 src/PrefsUnifiedDlg.cpp:1921
+#: src/PrefsUnifiedDlg.cpp:1330 src/PrefsUnifiedDlg.cpp:1930
 #, fuzzy
 msgid "Invalid regular expression"
 msgstr "Version protokoli jo i rregullt."
 
-#: src/PrefsUnifiedDlg.cpp:1398
+#: src/PrefsUnifiedDlg.cpp:1407
 msgid ""
 "Both eD2k and Kad network are disabled.\n"
 "You won't be able to connect until you enable at least one of them."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1403
+#: src/PrefsUnifiedDlg.cpp:1412
 msgid ""
 "Kad will not start if your UDP port is disabled.\n"
 "Enable UDP port or disable Kad."
@@ -5898,7 +5898,7 @@ msgstr ""
 "Kad nuk mund te filloje nqs porta juaj UDP eshte c'aktivizuar.\n"
 "Aktivizoni porten UDP ose c'aktivizoni Kad-in."
 
-#: src/PrefsUnifiedDlg.cpp:1459
+#: src/PrefsUnifiedDlg.cpp:1468
 msgid ""
 "\n"
 "You MUST restart aMule now.\n"
@@ -5908,69 +5908,69 @@ msgstr ""
 "Ju duhet te ristartoni aMule-n tani.\n"
 "Nqs nuk e ristartoni tani mos u anko nqs te ndodh dicka e keqe.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1524
+#: src/PrefsUnifiedDlg.cpp:1533
 msgid "Could not register aMule for autostart at login. The autostart store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1526
+#: src/PrefsUnifiedDlg.cpp:1535
 msgid "Could not remove the autostart-at-login entry."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1527
+#: src/PrefsUnifiedDlg.cpp:1536
 #, fuzzy
 msgid "Autostart"
 msgstr "Rifreskimi Automatik filloi"
 
-#: src/PrefsUnifiedDlg.cpp:1542
+#: src/PrefsUnifiedDlg.cpp:1551
 msgid "Register file type"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1542
+#: src/PrefsUnifiedDlg.cpp:1551
 msgid "Register URL handler"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1550
+#: src/PrefsUnifiedDlg.cpp:1559
 #, c-format
 msgid "aMule only handles eD2k-compatible magnets. If you replace the current magnet handler (%s), BitTorrent magnet links will stop working - aMule cannot download BitTorrent content. Continue?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1555
+#: src/PrefsUnifiedDlg.cpp:1564
 #, c-format
 msgid "Another application currently opens .emulecollection files (%s). Replace it with aMule?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1560
+#: src/PrefsUnifiedDlg.cpp:1569
 #, c-format
 msgid "Another application is currently the default handler for these links (%s). Replace it with aMule?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1585
+#: src/PrefsUnifiedDlg.cpp:1594
 msgid "Could not register aMule for .emulecollection files. The registration store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1587
+#: src/PrefsUnifiedDlg.cpp:1596
 #, fuzzy
 msgid "Could not remove the file type registration."
 msgstr "Jeni duke u perpjekur te shkarkoni edhe njehere tjeter kete fail %s"
 
-#: src/PrefsUnifiedDlg.cpp:1589
+#: src/PrefsUnifiedDlg.cpp:1598
 msgid "Could not register aMule as the URL handler. The registration store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1591
+#: src/PrefsUnifiedDlg.cpp:1600
 msgid "Could not remove the URL handler registration."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1661 src/PrefsUnifiedDlg.cpp:1688
+#: src/PrefsUnifiedDlg.cpp:1670 src/PrefsUnifiedDlg.cpp:1697
 #, fuzzy
 msgid "The web server and aMule API require external connections to be enabled."
 msgstr "U pranua nje lidhje e jashtme e re"
 
-#: src/PrefsUnifiedDlg.cpp:1671
+#: src/PrefsUnifiedDlg.cpp:1680
 msgid "The aMule web server is deprecated. Consider running the aMule API instead."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1735
+#: src/PrefsUnifiedDlg.cpp:1744
 msgid ""
 "Your Auto-update servers list is in blank.\n"
 "Please fill in at least one URL to point to a valid server.met file.\n"
@@ -5980,66 +5980,66 @@ msgstr ""
 "Ju lutem mbushni te pakten nje URL te vlefshme ne failin e server.met.\n"
 "Klikoni ne butonin \"List\" per te futur nje URL."
 
-#: src/PrefsUnifiedDlg.cpp:1876
+#: src/PrefsUnifiedDlg.cpp:1885
 msgid "Temporary files"
 msgstr "Failet e perkohshme"
 
-#: src/PrefsUnifiedDlg.cpp:1881
+#: src/PrefsUnifiedDlg.cpp:1890
 msgid "Incoming files"
 msgstr "Failet e shkarkuara"
 
-#: src/PrefsUnifiedDlg.cpp:1886
+#: src/PrefsUnifiedDlg.cpp:1895
 msgid "Online Signatures"
 msgstr "Firma online"
 
-#: src/PrefsUnifiedDlg.cpp:1899
+#: src/PrefsUnifiedDlg.cpp:1908
 #, c-format
 msgid "Choose a folder for %s"
 msgstr "Zgjidhni nje kartele per %s"
 
-#: src/PrefsUnifiedDlg.cpp:1923
+#: src/PrefsUnifiedDlg.cpp:1932
 #, fuzzy, c-format
 msgid "Would exclude %u of %u shared file"
 msgid_plural "Would exclude %u of %u shared files"
 msgstr[0] "U gjend %i fail i njohur i ndare"
 msgstr[1] "U gjenden %i faile te njohura te ndara"
 
-#: src/PrefsUnifiedDlg.cpp:1940
+#: src/PrefsUnifiedDlg.cpp:1949
 msgid "Browse for videoplayer"
 msgstr "Shfletoni per nje videoplayer"
 
-#: src/PrefsUnifiedDlg.cpp:1944
+#: src/PrefsUnifiedDlg.cpp:1953
 msgid "Select browser"
 msgstr "Perzgjidhni shfletuesin"
 
-#: src/PrefsUnifiedDlg.cpp:1948
+#: src/PrefsUnifiedDlg.cpp:1957
 #, fuzzy
 msgid "Select ffprobe binary"
 msgstr "Perzgjidhni shfletuesin"
 
-#: src/PrefsUnifiedDlg.cpp:1954
+#: src/PrefsUnifiedDlg.cpp:1963
 #, c-format
 msgid "Executable%s"
 msgstr "Te ekzekutueshme%s"
 
-#: src/PrefsUnifiedDlg.cpp:1988
+#: src/PrefsUnifiedDlg.cpp:1997
 msgid "ffprobe not found on PATH or in the standard install locations. Install ffmpeg (which ships ffprobe) or use Browse to pick a binary manually."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2000
+#: src/PrefsUnifiedDlg.cpp:2009
 msgid "Reset the settings on this page to their default values?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2001
+#: src/PrefsUnifiedDlg.cpp:2010
 #, fuzzy
 msgid "Reset to defaults"
 msgstr "E vendosur nga sistemi"
 
-#: src/PrefsUnifiedDlg.cpp:2028
+#: src/PrefsUnifiedDlg.cpp:2037
 msgid "Edit server list"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2029
+#: src/PrefsUnifiedDlg.cpp:2038
 msgid ""
 "Add here URL's to download server.met files.\n"
 "Only one url on each line."
@@ -6047,155 +6047,155 @@ msgstr ""
 "Futni ketu URL-te per te shkarkuar failet server.met.\n"
 "Vetem nga nje URL per c'do linje."
 
-#: src/PrefsUnifiedDlg.cpp:2084
+#: src/PrefsUnifiedDlg.cpp:2093
 msgid "IP2Country update failed"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2229 src/PrefsUnifiedDlg.cpp:2260
+#: src/PrefsUnifiedDlg.cpp:2238 src/PrefsUnifiedDlg.cpp:2269
 msgid "Data by MaxMind GeoLite2"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2231 src/PrefsUnifiedDlg.cpp:2262
+#: src/PrefsUnifiedDlg.cpp:2240 src/PrefsUnifiedDlg.cpp:2271
 #, fuzzy
 msgid "Custom source"
 msgstr "Burime te kompletuara"
 
-#: src/PrefsUnifiedDlg.cpp:2233 src/PrefsUnifiedDlg.cpp:2264
+#: src/PrefsUnifiedDlg.cpp:2242 src/PrefsUnifiedDlg.cpp:2273
 msgid "Data by DB-IP.com"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2284
+#: src/PrefsUnifiedDlg.cpp:2293
 #, fuzzy, c-format
 msgid "Status: Loaded%s"
 msgstr "Statusi:"
 
-#: src/PrefsUnifiedDlg.cpp:2286
+#: src/PrefsUnifiedDlg.cpp:2295
 #, fuzzy, c-format
 msgid "Status: Loaded%s - %s"
 msgstr "Statusi:"
 
-#: src/PrefsUnifiedDlg.cpp:2290
+#: src/PrefsUnifiedDlg.cpp:2299
 msgid "Status: Failed to load - click 'Update now' to refresh."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2292
+#: src/PrefsUnifiedDlg.cpp:2301
 msgid "Status: Not found - click 'Update now' to download."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2350 src/PrefsUnifiedDlg.cpp:2374
+#: src/PrefsUnifiedDlg.cpp:2359 src/PrefsUnifiedDlg.cpp:2383
 #, c-format
 msgid "Update delay: %d second"
 msgid_plural "Update delay: %d seconds"
 msgstr[0] "Intervali i azhornimit: %d sekonde"
 msgstr[1] "Intervali i azhornimit: %d sekonda"
 
-#: src/PrefsUnifiedDlg.cpp:2358
+#: src/PrefsUnifiedDlg.cpp:2367
 #, c-format
 msgid "Time for average graph: %d minute"
 msgid_plural "Time for average graph: %d minutes"
 msgstr[0] "Koha per mesataren grafike: %d minute"
 msgstr[1] "Koha per mesataren grafike: %d minuta"
 
-#: src/PrefsUnifiedDlg.cpp:2367
+#: src/PrefsUnifiedDlg.cpp:2376
 #, c-format
 msgid "Connections Graph Scale: %d"
 msgstr "Shkalla grafike e lidhjeve: %d"
 
-#: src/PrefsUnifiedDlg.cpp:2382
+#: src/PrefsUnifiedDlg.cpp:2391
 #, c-format
 msgid "File Buffer Size: %d byte"
 msgid_plural "File Buffer Size: %d bytes"
 msgstr[0] "Madhesia buffer e failit: %d byte"
 msgstr[1] "Madesia Buffer e failit: %d bytes"
 
-#: src/PrefsUnifiedDlg.cpp:2392
+#: src/PrefsUnifiedDlg.cpp:2401
 #, c-format
 msgid "Upload Queue Size: %d client"
 msgid_plural "Upload Queue Size: %d clients"
 msgstr[0] "Madhesia e radhes se ngarkimit: %d klienti"
 msgstr[1] "Madhesia e radhes se ngarkimit: %d klientet"
 
-#: src/PrefsUnifiedDlg.cpp:2402
+#: src/PrefsUnifiedDlg.cpp:2411
 #, c-format
 msgid "Server connection refresh interval: %d minute"
 msgid_plural "Server connection refresh interval: %d minutes"
 msgstr[0] "Intervali i rifreskimit te lidhjeve te serverit: %d minute"
 msgstr[1] "Intervali i rifreskimit te lidhjeve te serverit: %d minuta"
 
-#: src/PrefsUnifiedDlg.cpp:2407
+#: src/PrefsUnifiedDlg.cpp:2416
 msgid "Server connection refresh interval: Disabled"
 msgstr "Intervali i rifreskimit te lidhjeve te serverit: I c'aktivizuar"
 
-#: src/PrefsUnifiedDlg.cpp:2451
+#: src/PrefsUnifiedDlg.cpp:2460
 #, fuzzy
 msgid "disabled"
 msgstr "c'aktivizo"
 
-#: src/PrefsUnifiedDlg.cpp:2477
+#: src/PrefsUnifiedDlg.cpp:2486
 #, fuzzy, c-format
 msgid "Execute command on '%s' event"
 msgstr "Ekzekuto komanden ne kete ngjarje `%s' "
 
-#: src/PrefsUnifiedDlg.cpp:2484
+#: src/PrefsUnifiedDlg.cpp:2493
 msgid "Enable command execution on core"
 msgstr "Lejo ekzekutimin e komandes ne core"
 
-#: src/PrefsUnifiedDlg.cpp:2496
+#: src/PrefsUnifiedDlg.cpp:2505
 msgid "Core command:"
 msgstr "KOmanda Core:"
 
-#: src/PrefsUnifiedDlg.cpp:2512
+#: src/PrefsUnifiedDlg.cpp:2521
 msgid "Enable command execution on GUI"
 msgstr "Lejo ekzekutimin e komandes ne GUI"
 
-#: src/PrefsUnifiedDlg.cpp:2524
+#: src/PrefsUnifiedDlg.cpp:2533
 msgid "GUI command:"
 msgstr "Komanda GUI:"
 
-#: src/PrefsUnifiedDlg.cpp:2540
+#: src/PrefsUnifiedDlg.cpp:2549
 msgid "The following variables will be replaced:"
 msgstr "Variacionet qe vijojne do te rivendosen:"
 
-#: src/PrefsUnifiedDlg.cpp:2708
+#: src/PrefsUnifiedDlg.cpp:2717
 msgid ""
 "The following folders look like system or sensitive locations:\n"
 "\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2713
+#: src/PrefsUnifiedDlg.cpp:2722
 msgid "Sharing them recursively will publish every file underneath on the eD2k/Kad networks. Do you really want to do this?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2716
+#: src/PrefsUnifiedDlg.cpp:2725
 #, fuzzy
 msgid "Confirm shared folders"
 msgstr "Ringarko failet e ndara"
 
-#: src/PrefsUnifiedDlg.cpp:2744
+#: src/PrefsUnifiedDlg.cpp:2753
 #, fuzzy
 msgid "Reloading shared files..."
 msgstr "Ringarko failet e ndara"
 
-#: src/PrefsUnifiedDlg.cpp:2745
+#: src/PrefsUnifiedDlg.cpp:2754
 msgid "Scanning for subdirectories..."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2746
+#: src/PrefsUnifiedDlg.cpp:2755
 #, fuzzy
 msgid "Updating shared folders"
 msgstr "Duke lexuar kartelen temp"
 
-#: src/PrefsUnifiedDlg.cpp:2773
+#: src/PrefsUnifiedDlg.cpp:2782
 #, c-format
 msgid "Scanned %u directories..."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2823
+#: src/PrefsUnifiedDlg.cpp:2832
 #, fuzzy, c-format
 msgid "Reloading shared files: %u files scanned"
 msgstr "Ringarko listen e faileve te ndara."
 
-#: src/PrefsUnifiedDlg.cpp:2873
+#: src/PrefsUnifiedDlg.cpp:2882
 #, fuzzy
 msgid "Shared folder"
 msgstr "File te ndara"
@@ -7897,12 +7897,12 @@ msgstr "Zhvendos kategorine"
 msgid "Hashset requested for unknown file: %s"
 msgstr "Kerkohet Hashset-i per failin e panjohur: %s"
 
-#: src/UploadQueue.cpp:618
+#: src/UploadQueue.cpp:627
 #, c-format
 msgid "Resuming uploads of file: %s"
 msgstr "Rimarrja e ngarkimeve te failit: %s"
 
-#: src/UploadQueue.cpp:634
+#: src/UploadQueue.cpp:643
 #, c-format
 msgid "Suspending upload of file: %s"
 msgstr "Duke pezulluar ngarkimin e failit: %s"

--- a/po/sq.po
+++ b/po/sq.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-28 10:19+0200\n"
+"POT-Creation-Date: 2026-07-28 12:17+0200\n"
 "PO-Revision-Date: 2026-07-27 11:45+0000\n"
 "Last-Translator: Fation <dj_barthezz@linuxmail.org lushnja_corps@hotmail.Language-Team:\n"
 "Language: sq\n"
@@ -200,160 +200,160 @@ msgstr "Deshtoi ne hapjen %s (%s)"
 msgid "WARNING: You can't add yourself as a source for an eD2k link while having a lowid."
 msgstr ""
 
-#: src/amule.cpp:300
+#: src/amule.cpp:301
 #, fuzzy
 msgid "Now, exiting main app..."
 msgstr ""
 "\n"
 "Ne rregull, duke dalur %s...\n"
 
-#: src/amule.cpp:330
+#: src/amule.cpp:331
 #, c-format
 msgid "Terminating amuleweb instance with pid '%d' ... "
 msgstr ""
 
-#: src/amule.cpp:334
+#: src/amule.cpp:335
 #, c-format
 msgid "Killing amuleweb instance with pid '%d' ... "
 msgstr ""
 
-#: src/amule.cpp:336 src/amule.cpp:349 src/ClientRef.cpp:180
+#: src/amule.cpp:337 src/amule.cpp:350 src/ClientRef.cpp:180
 #: src/SearchDlg.cpp:1041 src/ServerListCtrl.cpp:98
 msgid "Failed"
 msgstr "E Deshtuar"
 
-#: src/amule.cpp:343
+#: src/amule.cpp:344
 #, c-format
 msgid "Terminating amuleapi instance with pid '%d' ... "
 msgstr ""
 
-#: src/amule.cpp:347
+#: src/amule.cpp:348
 #, c-format
 msgid "Killing amuleapi instance with pid '%d' ... "
 msgstr ""
 
-#: src/amule.cpp:355
+#: src/amule.cpp:356
 msgid "aMule OnExit: Terminating core."
 msgstr ""
 
-#: src/amule.cpp:466
+#: src/amule.cpp:467
 #, fuzzy
 msgid "aMule shutdown completed."
 msgstr "Shkarkimi Perfundoi"
 
-#: src/amule.cpp:470
+#: src/amule.cpp:471
 msgid "Memory debug results for aMule exit:"
 msgstr ""
 
-#: src/amule.cpp:651
+#: src/amule.cpp:652
 #, c-format
 msgid "Binding aMule's peer-to-peer traffic to interface: %s (HTTP updates use the default route)"
 msgstr ""
 
-#: src/amule.cpp:655
+#: src/amule.cpp:656
 #, c-format
 msgid "Binding all network traffic to interface: %s"
 msgstr ""
 
-#: src/amule.cpp:659
+#: src/amule.cpp:660
 #, c-format
 msgid "WARNING: configured network interface '%s' was not found - traffic is NOT bound to it and may leave via the default route. Check the interface name in Preferences."
 msgstr ""
 
-#: src/amule.cpp:665
+#: src/amule.cpp:666
 #, c-format
 msgid "WARNING: binding to network interface '%s' requires elevated privileges and was NOT applied - traffic may leave via the default route. Grant the capability (e.g. 'sudo setcap cap_net_raw+ep' on the aMule binary) or run with sufficient privileges."
 msgstr ""
 
-#: src/amule.cpp:673
+#: src/amule.cpp:674
 #, c-format
 msgid "WARNING: could not bind to network interface '%s' - traffic may leave via the default route."
 msgstr ""
 
-#: src/amule.cpp:732
+#: src/amule.cpp:733
 msgid "Your locale has been changed to System Default due to a configuration change. Sorry."
 msgstr "Vendndodhja juaj eshte ndryshuar tek System Default i pershtatur per nje nderrim konfigurimi. Me vjen keq."
 
-#: src/amule.cpp:734 src/amule.cpp:1581 src/CatDialog.cpp:128
+#: src/amule.cpp:735 src/amule.cpp:1589 src/CatDialog.cpp:128
 #: src/CatDialog.cpp:136 src/CatDialog.cpp:149 src/ServerList.cpp:366
 #: src/ServerListCtrl.cpp:152
 msgid "Info"
 msgstr "Informacion"
 
-#: src/amule.cpp:741
+#: src/amule.cpp:742
 #, fuzzy
 msgid ""
 "\n"
 "EC configuration"
 msgstr "Konfirmimi i daljes"
 
-#: src/amule.cpp:744
+#: src/amule.cpp:745
 #, fuzzy
 msgid "Password set and external connections enabled."
 msgstr "U pranua nje lidhje e jashtme e re"
 
-#: src/amule.cpp:754 src/KadDlg.cpp:176 src/KadDlg.cpp:185
-#: src/PrefsUnifiedDlg.cpp:1387 src/SharedFilesCtrl.cpp:476
+#: src/amule.cpp:755 src/KadDlg.cpp:176 src/KadDlg.cpp:185
+#: src/PrefsUnifiedDlg.cpp:1461 src/SharedFilesCtrl.cpp:476
 msgid "WARNING"
 msgstr "KUJDES"
 
-#: src/amule.cpp:991
+#: src/amule.cpp:992
 #, fuzzy
 msgid "Network bootstrap"
 msgstr "Rrjetet"
 
-#: src/amule.cpp:996
+#: src/amule.cpp:997
 msgid ""
 "aMule has detected missing network bootstrap files.\n"
 "Select which ones to download:"
 msgstr ""
 
-#: src/amule.cpp:1005 src/FirstRunWizard.cpp:411
+#: src/amule.cpp:1006 src/FirstRunWizard.cpp:411
 #, fuzzy
 msgid "eD2k server list (server.met)"
 msgstr "%i u gjet server ne server.met"
 
-#: src/amule.cpp:1012 src/FirstRunWizard.cpp:416
+#: src/amule.cpp:1013 src/FirstRunWizard.cpp:416
 msgid "Kad bootstrap nodes (nodes.dat)"
 msgstr ""
 
-#: src/amule.cpp:1102
+#: src/amule.cpp:1103
 #, c-format
 msgid "web server running on pid %d"
 msgstr ""
 
-#: src/amule.cpp:1115
+#: src/amule.cpp:1116
 msgid "You requested to run web server on startup, but the amuleweb binary cannot be run. Please install the package containing aMule web server, or build aMule from source with -DBUILD_WEBSERVER=YES and install it."
 msgstr ""
 
-#: src/amule.cpp:1120 src/amule.cpp:1177 src/amule.cpp:1291 src/amule.cpp:1593
+#: src/amule.cpp:1121 src/amule.cpp:1185 src/amule.cpp:1299 src/amule.cpp:1601
 #: src/amule-remote-gui.cpp:603 src/amule-remote-gui.cpp:671
 #: src/amule-remote-gui.cpp:709 src/amule-remote-gui.cpp:1282
 #: src/amule-remote-gui.cpp:1345 src/amule-remote-gui.cpp:1372
-#: src/DownloadQueue.cpp:1481
+#: src/DownloadQueue.cpp:1481 src/PrefsUnifiedDlg.cpp:1247
 msgid "ERROR"
 msgstr ""
 
-#: src/amule.cpp:1166
+#: src/amule.cpp:1174
 #, fuzzy, c-format
 msgid "amuleapi running on pid %d"
 msgstr "aMule eshte duke punuar"
 
-#: src/amule.cpp:1172
+#: src/amule.cpp:1180
 msgid "You requested to run amuleapi on startup, but the amuleapi binary cannot be run. Please install the package containing aMule's REST API server, or build aMule from source with -DBUILD_AMULEAPI=YES and install it."
 msgstr ""
 
-#: src/amule.cpp:1259
+#: src/amule.cpp:1267
 #, c-format
 msgid "Could not bind ports to the specified address: %s"
 msgstr "Nuk mund te lidh portat tek adresa e dhene: %s"
 
-#: src/amule.cpp:1283
+#: src/amule.cpp:1291
 #, c-format
 msgid "Port %u is not available. You will be LOWID\n"
 msgstr "Porta %u nuk eshte me vlere. Ju do te keni ID te ulet\n"
 
-#: src/amule.cpp:1288
+#: src/amule.cpp:1296
 #, c-format
 msgid ""
 "Port %u is not available!\n"
@@ -368,48 +368,48 @@ msgstr ""
 "\n"
 "KOntrolloni rrjetin tuaj per tu siguruar qe porta eshte hapur per hyrje dhe dalje."
 
-#: src/amule.cpp:1385
+#: src/amule.cpp:1393
 msgid "Failed to create OnlineSig File"
 msgstr "Deshtoi te krijoje failin per Firmen Online"
 
-#: src/amule.cpp:1393
+#: src/amule.cpp:1401
 msgid "Failed to create aMule OnlineSig File"
 msgstr "Deshtoi te krijoje failin per Firmen Online te aMule-s"
 
-#: src/amule.cpp:1556
+#: src/amule.cpp:1564
 msgid "The selected locale seems not to be installed on your box. (Note: I'll try to set it anyway)"
 msgstr "Vendi i zgjedur duket se nuk do te instalohet ne kutine tuaj. (Shenim: Une do te mundohem ta vendos ate)"
 
-#: src/amule.cpp:1566
+#: src/amule.cpp:1574
 #, c-format
 msgid "This is the first time you run aMule %s"
 msgstr "Kjo eshte hera e pare qe ju po persorni aMule %s"
 
-#: src/amule.cpp:1569
+#: src/amule.cpp:1577
 msgid "This version is a testing version, updated daily, and\n"
 msgstr "Ky eshte nje version per testim,i azhornuar per dite, dhe\n"
 
-#: src/amule.cpp:1570
+#: src/amule.cpp:1578
 msgid "we give no warranty it won't break anything, burn your house,\n"
 msgstr "ne nuk japim siguri per te ai nuk do te thyej asgje,nuk do te djegi shtepine tuaj,\n"
 
-#: src/amule.cpp:1571
+#: src/amule.cpp:1579
 msgid "or kill your dog. But it *should* be safe to use anyway.\n"
 msgstr "ose te vrasi qenin tuaj. Por ai *do te* behet i sigurte per tu perdorur.\n"
 
-#: src/amule.cpp:1576
+#: src/amule.cpp:1584
 msgid "More information, support and new releases can found at our homepage,\n"
 msgstr "Me shume informacion,mbeshtetje dhe leshime te reja do ti gjeni tek faqet tona,\n"
 
-#: src/amule.cpp:1577
+#: src/amule.cpp:1585
 msgid "at https://amule-org.github.io, or in our IRC channel #aMule at irc.libera.chat.\n"
 msgstr "tek amule-org.github.io ose ne kanalin tone IRC #amule tek irc.libera.chat.\n"
 
-#: src/amule.cpp:1579
+#: src/amule.cpp:1587
 msgid "Feel free to report any bugs to https://github.com/amule-org/amule/issues"
 msgstr "Raportoni cdo gabim tek https://github.com/amule-org/amule/issues"
 
-#: src/amule.cpp:1591
+#: src/amule.cpp:1599
 msgid ""
 "The folder for Online Signature files you specified is INVALID!\n"
 " OnlineSignature will be DISABLED until you fix it on preferences."
@@ -417,138 +417,138 @@ msgstr ""
 "Kartela e faileve per Firmen Online qe ju specifikuat eshte e PAVLERE!\n"
 " Firma Online do te C'AKTIVIZOHET deri sa ju ta rregulloni tek Preferencat."
 
-#: src/amule.cpp:1654
+#: src/amule.cpp:1662
 #, fuzzy
 msgid "Server hostname notified"
 msgstr "Emri i Serverit:"
 
-#: src/amule.cpp:2031
+#: src/amule.cpp:2039
 #, c-format
 msgid "Disk space preallocation for file '%s' failed: %s"
 msgstr ""
 
-#: src/amule.cpp:2160
+#: src/amule.cpp:2168
 msgid "ERROR: can't open logfile"
 msgstr "GABIM: nuk mund te hapet logfile"
 
-#: src/amule.cpp:2164
+#: src/amule.cpp:2172
 msgid "WARNING: logfile is empty. Something is wrong."
 msgstr "KUJDES: faili i log-ve eshte bosh. Dicka nuk shkon."
 
-#: src/amule.cpp:2181
+#: src/amule.cpp:2189
 msgid "Log has been reset"
 msgstr "Faili i Log eshte risetuar"
 
-#: src/amule.cpp:2205
+#: src/amule.cpp:2213
 #, c-format
 msgid "ServerMessage: %s"
 msgstr "Mesazhe nga Serveri: %s"
 
-#: src/amule.cpp:2248 src/IP2Country.cpp:220 src/IPFilter.cpp:514
+#: src/amule.cpp:2256 src/IP2Country.cpp:220 src/IPFilter.cpp:514
 #: src/ServerList.cpp:875
 #, c-format
 msgid "Skipped download of %s, because requested file is not newer."
 msgstr ""
 
-#: src/amule.cpp:2251
+#: src/amule.cpp:2259
 msgid "Failed to download the nodes list."
 msgstr "Deshtoi ne shkarkimin e listave nod."
 
-#: src/amule.cpp:2314
+#: src/amule.cpp:2322
 msgid "Failed to open the downloaded version check file"
 msgstr "Deshtoi te hapi failin per kontrollin e versionit qe sapo shkarkuat"
 
-#: src/amule.cpp:2317 src/amule.cpp:2336
+#: src/amule.cpp:2325 src/amule.cpp:2344
 msgid "Corrupted version check file"
 msgstr "Fili per kontrollin e versionit eshte i demtuar"
 
-#: src/amule.cpp:2359
+#: src/amule.cpp:2367
 msgid "You are using an outdated version of aMule!"
 msgstr "Ju po perdorni nje version te vjeter te aMule!"
 
-#: src/amule.cpp:2361
+#: src/amule.cpp:2369
 #, c-format
 msgid "Your aMule version is %i.%i.%i and the latest version is %li.%li.%li"
 msgstr "Versioni juaj i amUle eshte %i.%i-%i dhe versioni i fundit eshte %li.%li.%li"
 
-#: src/amule.cpp:2365
+#: src/amule.cpp:2373
 msgid "The latest version can always be found at https://github.com/amule-org/amule/releases/latest"
 msgstr "Versioni i fundit mund te gjendet gjithmone tek https://github.com/amule-org/amule/releases/latest"
 
-#: src/amule.cpp:2368
+#: src/amule.cpp:2376
 #, c-format
 msgid "WARNING: Your aMuled version is outdated: %i.%i.%i < %li.%li.%li"
 msgstr "KUJDES: Versioni juaj i aMule-s eshte i vjeteruar: %i.%i-%i < %li.%li.%li"
 
-#: src/amule.cpp:2374
+#: src/amule.cpp:2382
 msgid "Your copy of aMule is up to date."
 msgstr "Kopja juaj e aMule eshte azhornuar."
 
-#: src/amule.cpp:2381
+#: src/amule.cpp:2389
 msgid "Failed to download the version check file"
 msgstr "Deshtoi ne shkarkimin e failit per kontrollin e versionit"
 
-#: src/amule.cpp:2550 src/amule-remote-gui.cpp:1133
+#: src/amule.cpp:2558 src/amule-remote-gui.cpp:1133
 #, c-format
 msgid "Users: %s | Files: %s"
 msgstr ""
 
-#: src/amule.cpp:2551 src/amule-remote-gui.cpp:1134
+#: src/amule.cpp:2559 src/amule-remote-gui.cpp:1134
 #, c-format
 msgid "Users: E: %s K: %s | Files: E: %s K: %s"
 msgstr ""
 
-#: src/amule.cpp:2565 src/amule-remote-gui.cpp:1147
+#: src/amule.cpp:2573 src/amule-remote-gui.cpp:1147
 msgid "No networks selected"
 msgstr ""
 
-#: src/amule.cpp:2633 src/TextClient.cpp:903
+#: src/amule.cpp:2641 src/TextClient.cpp:903
 msgid "with LowID"
 msgstr "me ID te ulet"
 
-#: src/amule.cpp:2633 src/TextClient.cpp:904
+#: src/amule.cpp:2641 src/TextClient.cpp:904
 msgid "with HighID"
 msgstr "me ID te larte"
 
-#: src/amule.cpp:2635
+#: src/amule.cpp:2643
 #, c-format
 msgid "Connected to %s %s"
 msgstr "I lidhur tek %s %s"
 
-#: src/amule.cpp:2640
+#: src/amule.cpp:2648
 #, c-format
 msgid "Connecting to %s"
 msgstr "Duke u lidhur tek %s"
 
-#: src/amule.cpp:2642
+#: src/amule.cpp:2650
 msgid "Disconnected from eD2k"
 msgstr ""
 
-#: src/amule.cpp:2651
+#: src/amule.cpp:2659
 msgid "Kad started."
 msgstr "Kad filloi."
 
-#: src/amule.cpp:2653
+#: src/amule.cpp:2661
 msgid "Kad stopped."
 msgstr "Kad u ndalua."
 
-#: src/amule.cpp:2661
+#: src/amule.cpp:2669
 msgid "Connected to Kad (ok)"
 msgstr "I lidhur ne Kad (Ne rregull)"
 
-#: src/amule.cpp:2663
+#: src/amule.cpp:2671
 msgid "Connected to Kad (firewalled)"
 msgstr "I lidhur ne Kad (Me firewall)"
 
-#: src/amule.cpp:2667
+#: src/amule.cpp:2675
 msgid "Disconnected from Kad"
 msgstr "I shkeputur nga Kad"
 
-#: src/amule.cpp:2699
+#: src/amule.cpp:2707
 msgid "Kad network cannot be used if UDP port is disabled on preferences, not starting."
 msgstr "Rrjeti Kad nuk mund te perdoret nqs porta UDP eshte c'aktivizuar tek Preferencat, nuk po filloj."
 
-#: src/amule.cpp:2703
+#: src/amule.cpp:2711
 msgid "Kad network disabled on preferences, not connecting."
 msgstr "Rrjeti Kad eshte c'aktivizuar tek Preferencat,nuk eshte duke u lidhur."
 
@@ -593,36 +593,36 @@ msgid "FATAL ERROR: Failed to create Timer"
 msgstr ""
 
 #: src/amuleDlg.cpp:361 src/amuleDlg.cpp:1787 src/amuleDlg.cpp:2033
-#: src/muuli_wdr.cpp:1492 src/muuli_wdr.cpp:3418
+#: src/muuli_wdr.cpp:1492 src/muuli_wdr.cpp:3449
 msgid "Networks"
 msgstr "Rrjetet"
 
-#: src/amuleDlg.cpp:362 src/amuleDlg.cpp:1793 src/muuli_wdr.cpp:3419
+#: src/amuleDlg.cpp:362 src/amuleDlg.cpp:1793 src/muuli_wdr.cpp:3450
 msgid "Searches"
 msgstr "Kerkimet"
 
 #: src/amuleDlg.cpp:363 src/amuleDlg.cpp:1799 src/DownloadListCtrl.cpp:740
-#: src/muuli_wdr.cpp:392 src/muuli_wdr.cpp:1585 src/muuli_wdr.cpp:3420
+#: src/muuli_wdr.cpp:392 src/muuli_wdr.cpp:1585 src/muuli_wdr.cpp:3451
 #: src/Statistics.cpp:829
 msgid "Downloads"
 msgstr "Shkarkime"
 
-#: src/amuleDlg.cpp:364 src/amuleDlg.cpp:1805 src/muuli_wdr.cpp:3294
+#: src/amuleDlg.cpp:364 src/amuleDlg.cpp:1805 src/muuli_wdr.cpp:3325
 msgid "Shared files"
 msgstr ""
 
-#: src/amuleDlg.cpp:365 src/amuleDlg.cpp:1811 src/muuli_wdr.cpp:2926
-#: src/muuli_wdr.cpp:3376 src/muuli_wdr.cpp:3423
+#: src/amuleDlg.cpp:365 src/amuleDlg.cpp:1811 src/muuli_wdr.cpp:2957
+#: src/muuli_wdr.cpp:3407 src/muuli_wdr.cpp:3454
 msgid "Messages"
 msgstr "Mesazhe"
 
-#: src/amuleDlg.cpp:366 src/amuleDlg.cpp:1817 src/muuli_wdr.cpp:3424
-#: src/PrefsUnifiedDlg.cpp:312 src/Statistics.cpp:779 src/Statistics.cpp:1235
+#: src/amuleDlg.cpp:366 src/amuleDlg.cpp:1817 src/muuli_wdr.cpp:3455
+#: src/PrefsUnifiedDlg.cpp:314 src/Statistics.cpp:779 src/Statistics.cpp:1235
 msgid "Statistics"
 msgstr "Statistikat"
 
-#: src/amuleDlg.cpp:368 src/amuleDlg.cpp:1824 src/muuli_wdr.cpp:3426
-#: src/PrefsUnifiedDlg.cpp:328 src/utils/wxCas/src/wxcasprefs.cpp:39
+#: src/amuleDlg.cpp:368 src/amuleDlg.cpp:1824 src/muuli_wdr.cpp:3457
+#: src/PrefsUnifiedDlg.cpp:330 src/utils/wxCas/src/wxcasprefs.cpp:39
 msgid "Preferences"
 msgstr "Preferencat"
 
@@ -680,8 +680,8 @@ msgstr "Kad: Fikur"
 #: src/amuleDlg.cpp:1029 src/DownloadListCtrl.cpp:505
 #: src/DownloadListCtrl.cpp:749 src/FriendListCtrl.cpp:180
 #: src/muuli_wdr.cpp:731 src/muuli_wdr.cpp:782 src/muuli_wdr.cpp:846
-#: src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2231 src/muuli_wdr.cpp:2316
-#: src/muuli_wdr.cpp:3064 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
+#: src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2262 src/muuli_wdr.cpp:2347
+#: src/muuli_wdr.cpp:3095 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
 #: src/ServerListCtrl.cpp:606 src/TransferWnd.cpp:378
 #: src/utils/wxCas/src/wxcasprefs.cpp:235
 msgid "Cancel"
@@ -692,7 +692,7 @@ msgid "Stop the current connection attempts"
 msgstr "Ndalo tentativat e lidhjes qe po behen"
 
 #: src/amuleDlg.cpp:1035 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976
-#: src/muuli_wdr.cpp:2454
+#: src/muuli_wdr.cpp:2485
 msgid "Disconnect"
 msgstr "Shkeputu"
 
@@ -701,7 +701,7 @@ msgid "Disconnect from the currently connected networks"
 msgstr "Shkeputu nga rrjetet e lidhura"
 
 #: src/amuleDlg.cpp:1041 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979
-#: src/muuli_wdr.cpp:2609 src/muuli_wdr.cpp:3061 src/muuli_wdr.cpp:3416
+#: src/muuli_wdr.cpp:2640 src/muuli_wdr.cpp:3092 src/muuli_wdr.cpp:3447
 msgid "Connect"
 msgstr "Lidhu"
 
@@ -756,7 +756,7 @@ msgstr "Konfirmimi i daljes"
 msgid "Launch Command: "
 msgstr ""
 
-#: src/amuleDlg.cpp:1632 src/muuli_wdr.cpp:1978 src/Preferences.cpp:952
+#: src/amuleDlg.cpp:1632 src/muuli_wdr.cpp:1982 src/Preferences.cpp:979
 msgid "- default -"
 msgstr ""
 
@@ -770,49 +770,49 @@ msgstr "Direktoria e skin '%s' nuk ekziston"
 msgid "WARNING: Unable to open skin file '%s' for read"
 msgstr ""
 
-#: src/amuleDlg.cpp:1791 src/muuli_wdr.cpp:3418
+#: src/amuleDlg.cpp:1791 src/muuli_wdr.cpp:3449
 msgid "Networks Window"
 msgstr "Dritaret e rrjeteve"
 
-#: src/amuleDlg.cpp:1797 src/muuli_wdr.cpp:3419
+#: src/amuleDlg.cpp:1797 src/muuli_wdr.cpp:3450
 msgid "Searches Window"
 msgstr "Dritaret e kerkimeve"
 
-#: src/amuleDlg.cpp:1803 src/muuli_wdr.cpp:3420
+#: src/amuleDlg.cpp:1803 src/muuli_wdr.cpp:3451
 #, fuzzy
 msgid "Downloads Window"
 msgstr "Duke shkarkuar"
 
-#: src/amuleDlg.cpp:1809 src/muuli_wdr.cpp:3422
+#: src/amuleDlg.cpp:1809 src/muuli_wdr.cpp:3453
 msgid "Shared Files Window"
 msgstr "Dritarja e faileve te ndara"
 
-#: src/amuleDlg.cpp:1815 src/muuli_wdr.cpp:3423
+#: src/amuleDlg.cpp:1815 src/muuli_wdr.cpp:3454
 msgid "Messages Window"
 msgstr "Dritarja e mesazheve"
 
-#: src/amuleDlg.cpp:1821 src/muuli_wdr.cpp:3424
+#: src/amuleDlg.cpp:1821 src/muuli_wdr.cpp:3455
 msgid "Statistics Graph Window"
 msgstr "Dritarja e grafikut te statistikave"
 
-#: src/amuleDlg.cpp:1828 src/muuli_wdr.cpp:3426
+#: src/amuleDlg.cpp:1828 src/muuli_wdr.cpp:3457
 msgid "Preferences Settings Window"
 msgstr "Dritarja e rregullimeve te preferencave"
 
-#: src/amuleDlg.cpp:1831 src/muuli_wdr.cpp:3427
+#: src/amuleDlg.cpp:1831 src/muuli_wdr.cpp:3458
 msgid "Import"
 msgstr "Importimi"
 
-#: src/amuleDlg.cpp:1835 src/muuli_wdr.cpp:3427
+#: src/amuleDlg.cpp:1835 src/muuli_wdr.cpp:3458
 msgid "The partfile importer tool"
 msgstr "Veglat per importimin e pjeseve te faileve"
 
-#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3428
+#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3459
 #: src/utils/aLinkCreator/src/alcframe.cpp:262
 msgid "About"
 msgstr "Rreth"
 
-#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3428
+#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3459
 msgid "About/Help"
 msgstr "Rreth/Ndihme"
 
@@ -958,7 +958,7 @@ msgstr "Faili nuk u gjete."
 msgid "The core rejected these shared folders:%s"
 msgstr ""
 
-#: src/amule-remote-gui.cpp:1336 src/ExternalConn.cpp:2345
+#: src/amule-remote-gui.cpp:1336 src/ExternalConn.cpp:2346
 msgid "Invalid link or already on list."
 msgstr "Link i pavlere ose qe eshte ne liste."
 
@@ -974,7 +974,7 @@ msgstr ""
 #: src/ClientDetailDialog.cpp:123 src/DataToText.cpp:61 src/DataToText.cpp:86
 #: src/DataToText.cpp:101 src/DataToText.cpp:136 src/DataToText.cpp:165
 #: src/DownloadListCtrl.cpp:1172 src/DownloadListCtrl.cpp:1185
-#: src/DownloadListCtrl.cpp:1196 src/ExternalConn.cpp:608
+#: src/DownloadListCtrl.cpp:1196 src/ExternalConn.cpp:609
 #: src/FileDetailDialog.cpp:203 src/FileDetailDialog.cpp:235
 #: src/FileDetailDialog.cpp:242 src/GenericClientListCtrl.cpp:1171
 #: src/GenericClientListCtrl.cpp:1182 src/GenericClientListCtrl.cpp:1192
@@ -1361,19 +1361,19 @@ msgstr "Automatike [Larte]"
 msgid "Very low"
 msgstr "Shume ngadale"
 
-#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:743 src/muuli_wdr.cpp:2282
+#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:743 src/muuli_wdr.cpp:2313
 #: src/ServerListCtrl.cpp:263 src/ServerListCtrl.cpp:456
 #: src/SharedFilesCtrl.cpp:145
 msgid "Low"
 msgstr "Ngadale"
 
-#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:744 src/muuli_wdr.cpp:2283
+#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:744 src/muuli_wdr.cpp:2314
 #: src/ServerListCtrl.cpp:266 src/ServerListCtrl.cpp:457
 #: src/SharedFilesCtrl.cpp:146
 msgid "Normal"
 msgstr "Normale"
 
-#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:745 src/muuli_wdr.cpp:2284
+#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:745 src/muuli_wdr.cpp:2315
 #: src/ServerListCtrl.cpp:269 src/ServerListCtrl.cpp:458
 #: src/SharedFilesCtrl.cpp:147
 msgid "High"
@@ -1465,7 +1465,7 @@ msgstr "Server Lokal"
 msgid "Remote Server"
 msgstr "Server i larget"
 
-#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3181
+#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3212
 #: src/SearchDlg.cpp:119 src/TextClient.cpp:911
 msgid "Kad"
 msgstr "Kad"
@@ -1537,7 +1537,7 @@ msgstr ""
 msgid "Size"
 msgstr "Madhesia"
 
-#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3248
+#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3279
 msgid "Transferred"
 msgstr "Te transferuara"
 
@@ -1593,7 +1593,7 @@ msgid ""
 "\n"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:746 src/muuli_wdr.cpp:2285
+#: src/DownloadListCtrl.cpp:746 src/muuli_wdr.cpp:2316
 #: src/SharedFilesCtrl.cpp:150
 msgid "Auto"
 msgstr "Automatike"
@@ -1631,7 +1631,7 @@ msgid "Extended Options"
 msgstr "Opsione te Avancuara"
 
 #: src/DownloadListCtrl.cpp:770 src/DownloadListCtrl.cpp:822
-#: src/muuli_wdr.cpp:1796
+#: src/muuli_wdr.cpp:1800
 msgid "Preview"
 msgstr "Parashikim"
 
@@ -1804,232 +1804,237 @@ msgstr[1] ""
 msgid "Invalid eD2k link! ERROR: %s"
 msgstr ""
 
-#: src/ExternalConn.cpp:379
+#: src/ExternalConn.cpp:380
 #, fuzzy
 msgid "Client sent packet after authentication failed."
 msgstr "Autentifikimi deshtoi."
 
-#: src/ExternalConn.cpp:396
+#: src/ExternalConn.cpp:397
 msgid "External connection closed."
 msgstr "Lidhja e jashtme u mbyll."
 
-#: src/ExternalConn.cpp:473
+#: src/ExternalConn.cpp:474
 msgid "External connections disabled due to empty password!"
 msgstr "LIdhjet e jashtme u c'aktivizuan sepse fjalekalimi ishte bosh|"
 
-#: src/ExternalConn.cpp:494
+#: src/ExternalConn.cpp:495
 msgid "External connections disabled in config file"
 msgstr "Lidhjet e jashtme u c'aktivizuan ne failin e konfigurimeve"
 
-#: src/ExternalConn.cpp:575
+#: src/ExternalConn.cpp:576
 msgid "New external connection accepted"
 msgstr "U pranua nje lidhje e jashtme e re"
 
-#: src/ExternalConn.cpp:578
+#: src/ExternalConn.cpp:579
 msgid "ERROR: couldn't accept a new external connection"
 msgstr ""
 
-#: src/ExternalConn.cpp:595
+#: src/ExternalConn.cpp:596
 msgid "External connection refused due to empty password in preferences!"
 msgstr "Lidhja e jashtme nuk u pranua sepse fjalekalimi tek preferencat ishte bosh!"
 
-#: src/ExternalConn.cpp:607
+#: src/ExternalConn.cpp:608
 #, c-format
 msgid "Connecting client: %s %s"
 msgstr "Duke lidhur klientin: %s %s"
 
-#: src/ExternalConn.cpp:609
+#: src/ExternalConn.cpp:610
 msgid "Unknown version"
 msgstr "Version i panjohur"
 
-#: src/ExternalConn.cpp:622
+#: src/ExternalConn.cpp:623
 msgid "Incorrect EC version ID, there might be binary incompatibility. Use core and remote from same snapshot."
 msgstr "ID-ja i versionit EC jo korrekt,duhet te kete mospershtatje binaresh. Perdor Core dhe Remote nga i njejti Snapshot."
 
-#: src/ExternalConn.cpp:630
+#: src/ExternalConn.cpp:631
 #, fuzzy
 msgid "You cannot connect to a release version from an arbitrary development snapshot! *sigh* possible crash prevented"
 msgstr "NUk mund te lidheni me nje version SVN tek nje version i perfunduar ne menyre arbitrare| *sigh* crash i mundshem u evitua"
 
-#: src/ExternalConn.cpp:713
+#: src/ExternalConn.cpp:714
 msgid "Invalid protocol version."
 msgstr "Version protokoli jo i rregullt."
 
-#: src/ExternalConn.cpp:719
+#: src/ExternalConn.cpp:720
 msgid "Missing protocol version tag."
 msgstr "Munfon tag-u i versionit te protokolit."
 
-#: src/ExternalConn.cpp:727
+#: src/ExternalConn.cpp:728
 msgid "Authentication failed: invalid hash specified as EC password."
 msgstr ""
 
-#: src/ExternalConn.cpp:775
+#: src/ExternalConn.cpp:776
 #, fuzzy
 msgid "Authentication failed: wrong password."
 msgstr "Autentifikimi deshtoi."
 
-#: src/ExternalConn.cpp:777
+#: src/ExternalConn.cpp:778
 #, fuzzy
 msgid "Authentication failed: missing password."
 msgstr "Autentifikimi deshtoi."
 
-#: src/ExternalConn.cpp:788
+#: src/ExternalConn.cpp:789
 #, fuzzy
 msgid "Invalid request, please authenticate first."
 msgstr "Kerkese jo e rregullt, fillimisht duhet te identifikoheni."
 
-#: src/ExternalConn.cpp:793
+#: src/ExternalConn.cpp:794
 msgid "Access granted."
 msgstr "Hyrja lejohet."
 
-#: src/ExternalConn.cpp:801
+#: src/ExternalConn.cpp:802
 #, fuzzy, c-format
 msgid "Sent error message \"%s\" to client."
 msgstr "Filtron mesazhet nga klienta t èanjohur"
 
-#: src/ExternalConn.cpp:806
+#: src/ExternalConn.cpp:807
 #, fuzzy, c-format
 msgid "Unauthorized access attempt from %s. Connection closed."
 msgstr "Tentative per hyrje e paautorizuar. Lidhja u mbyll."
 
-#: src/ExternalConn.cpp:1419
+#: src/ExternalConn.cpp:1420
 #, c-format
 msgid "Remote PartFile command failed: FileHash not found: %s"
 msgstr "Komanda e Remote per pjeset e faileve deshtoi: Nuk u gjet FileHash: %s"
 
-#: src/ExternalConn.cpp:1423
+#: src/ExternalConn.cpp:1424
 #, c-format
 msgid "FileHash not found: %s"
 msgstr "Nuk u gjet FileHash: %s"
 
-#: src/ExternalConn.cpp:1470 src/ExternalConn.cpp:1558
-#: src/ExternalConn.cpp:1679
+#: src/ExternalConn.cpp:1471 src/ExternalConn.cpp:1559
+#: src/ExternalConn.cpp:1680
 msgid "OOPS! OpCode processing error!"
 msgstr "OOPS! Gabim ne procesimin e OpCode|"
 
-#: src/ExternalConn.cpp:1501
+#: src/ExternalConn.cpp:1502
 msgid "Server not added"
 msgstr "Serveri nuk u shtua"
 
-#: src/ExternalConn.cpp:1520
+#: src/ExternalConn.cpp:1521
 #, c-format
 msgid "server not found: %s"
 msgstr "Serveri nuk u gjend: %s"
 
-#: src/ExternalConn.cpp:1537
+#: src/ExternalConn.cpp:1538
 msgid "need to define server to be removed"
 msgstr "nevojitet percaktimi i serverit qe do te levizet"
 
-#: src/ExternalConn.cpp:1552
+#: src/ExternalConn.cpp:1553
 msgid "eD2k is disabled in preferences."
 msgstr ""
 
-#: src/ExternalConn.cpp:1657
+#: src/ExternalConn.cpp:1658
 #, fuzzy
 msgid "Friend not found."
 msgstr "Faili nuk u gjete."
 
-#: src/ExternalConn.cpp:1667
+#: src/ExternalConn.cpp:1668
 #, fuzzy
 msgid "Client not found."
 msgstr "Faili nuk u gjete."
 
-#: src/ExternalConn.cpp:1673
+#: src/ExternalConn.cpp:1674
 msgid "EC_TAG_FRIEND_SHARED requires EC_TAG_FRIEND or EC_TAG_CLIENT."
 msgstr ""
 
-#: src/ExternalConn.cpp:1991
+#: src/ExternalConn.cpp:1992
 msgid "WebSearch from remote interface makes no sense."
 msgstr "Kerkimi WebSearch nga Remote eshte i kote."
 
-#: src/ExternalConn.cpp:2026
+#: src/ExternalConn.cpp:2027
 msgid "Search in progress. Refetch results in a moment!"
 msgstr "Kerkimi vazhdon. Rezultate ne ardhje!"
 
-#: src/ExternalConn.cpp:2265
+#: src/ExternalConn.cpp:2266
 msgid "No points for graph."
 msgstr "NUk ka pika per grafike."
 
-#: src/ExternalConn.cpp:2275
+#: src/ExternalConn.cpp:2276
 msgid "Your client is not configured for this detail level."
 msgstr "Klienti juaj nuk eshte i konfiguruar per kete nivel detaji."
 
-#: src/ExternalConn.cpp:2302
+#: src/ExternalConn.cpp:2303
 msgid "External Connection: shutdown requested"
 msgstr ""
 
-#: src/ExternalConn.cpp:2314
+#: src/ExternalConn.cpp:2315
 msgid "Already shutting down."
 msgstr "Jam duke dalur."
 
-#: src/ExternalConn.cpp:2332
+#: src/ExternalConn.cpp:2333
 #, c-format
 msgid "ExternalConn: adding link '%s'."
 msgstr "Lidhje e jashtme: Duke shtuar linkun '%s'."
 
-#: src/ExternalConn.cpp:2350
+#: src/ExternalConn.cpp:2351
 #, fuzzy, c-format
 msgid "%d of %d links failed (invalid or already on list)."
 msgstr "Link i pavlere ose qe eshte ne liste."
 
-#: src/ExternalConn.cpp:2373
+#: src/ExternalConn.cpp:2374
 msgid "Version check throttled; try again shortly."
 msgstr ""
 
-#: src/ExternalConn.cpp:2378
+#: src/ExternalConn.cpp:2379
 msgid "Version check is not available on this daemon."
 msgstr ""
 
-#: src/ExternalConn.cpp:2508
+#: src/ExternalConn.cpp:2509
 msgid "File not found."
 msgstr "Faili nuk u gjete."
 
-#: src/ExternalConn.cpp:2513
+#: src/ExternalConn.cpp:2514
 msgid "Invalid file name."
 msgstr "Emri i failit i pavlere."
 
-#: src/ExternalConn.cpp:2521
+#: src/ExternalConn.cpp:2522
 msgid "Unable to rename file."
 msgstr "E pamundur te riemeroje failin."
 
-#: src/ExternalConn.cpp:2992 src/ExternalConn.cpp:3020
+#: src/ExternalConn.cpp:2839
+#, c-format
+msgid "Could not save the amuleapi password: %s"
+msgstr ""
+
+#: src/ExternalConn.cpp:3004 src/ExternalConn.cpp:3032
 msgid "Kad is disabled in preferences."
 msgstr "Kad-i eshte c'aktivizuar tek Preferencat."
 
-#: src/ExternalConn.cpp:3033
+#: src/ExternalConn.cpp:3045
 msgid "Already connected to eD2k."
 msgstr ""
 
-#: src/ExternalConn.cpp:3036
+#: src/ExternalConn.cpp:3048
 msgid "Connecting to eD2k..."
 msgstr ""
 
-#: src/ExternalConn.cpp:3045
+#: src/ExternalConn.cpp:3057
 msgid "Already connected to Kad."
 msgstr "Jam i lidhur ne Kad."
 
-#: src/ExternalConn.cpp:3048
+#: src/ExternalConn.cpp:3060
 msgid "Connecting to Kad..."
 msgstr "Duke u lidhur me Kad..."
 
-#: src/ExternalConn.cpp:3055
+#: src/ExternalConn.cpp:3067
 msgid "All networks are disabled."
 msgstr "Te gjithe rrjetet jane c'aktivizuar."
 
-#: src/ExternalConn.cpp:3064
+#: src/ExternalConn.cpp:3076
 msgid "Disconnected from eD2k."
 msgstr ""
 
-#: src/ExternalConn.cpp:3069
+#: src/ExternalConn.cpp:3081
 msgid "Disconnected from Kad."
 msgstr "I shkeputur nga Kad."
 
-#: src/ExternalConn.cpp:3078
+#: src/ExternalConn.cpp:3090
 #, c-format
 msgid "External Connection: invalid opcode received: %#x"
 msgstr ""
 
-#: src/ExternalConn.cpp:3083
+#: src/ExternalConn.cpp:3095
 msgid "Invalid opcode (wrong protocol version?)"
 msgstr "OpCode e pavlere (version protokoli i gabuar?)"
 
@@ -2429,23 +2434,23 @@ msgid ""
 "want downloads on a different (e.g. larger) disk."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:549 src/FirstRunWizard.cpp:611 src/muuli_wdr.cpp:1708
+#: src/FirstRunWizard.cpp:549 src/FirstRunWizard.cpp:611 src/muuli_wdr.cpp:1712
 msgid "Destination folder for downloads"
 msgstr ""
 
 #: src/FirstRunWizard.cpp:553 src/FirstRunWizard.cpp:569 src/muuli_wdr.cpp:1349
-#: src/muuli_wdr.cpp:1366 src/muuli_wdr.cpp:1683 src/muuli_wdr.cpp:1714
-#: src/muuli_wdr.cpp:1726 src/muuli_wdr.cpp:2769
+#: src/muuli_wdr.cpp:1366 src/muuli_wdr.cpp:1687 src/muuli_wdr.cpp:1718
+#: src/muuli_wdr.cpp:1730 src/muuli_wdr.cpp:2800
 #: src/utils/aLinkCreator/src/alcframe.cpp:135
 #: src/utils/wxCas/src/wxcasprefs.cpp:52 src/utils/wxCas/src/wxcasprefs.cpp:118
 msgid "Browse"
 msgstr "Shfleto"
 
-#: src/FirstRunWizard.cpp:559 src/muuli_wdr.cpp:1719
+#: src/FirstRunWizard.cpp:559 src/muuli_wdr.cpp:1723
 msgid "(All files in this folder are shared with other peers)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:565 src/FirstRunWizard.cpp:624 src/muuli_wdr.cpp:1721
+#: src/FirstRunWizard.cpp:565 src/FirstRunWizard.cpp:624 src/muuli_wdr.cpp:1725
 msgid "Folder for temporary download files"
 msgstr ""
 
@@ -2476,7 +2481,7 @@ msgstr ""
 msgid "CRITICAL - no client on StartChatSession"
 msgstr ""
 
-#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2675 src/muuli_wdr.cpp:3352
+#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2706 src/muuli_wdr.cpp:3383
 msgid "Friends"
 msgstr "Shkoket"
 
@@ -2590,8 +2595,8 @@ msgstr "Asnjeri"
 msgid "No"
 msgstr "Jo"
 
-#: src/GenericClientListCtrl.cpp:1216 src/PrefsUnifiedDlg.cpp:2818
-#: src/PrefsUnifiedDlg.cpp:2868 src/ServerListCtrl.cpp:276
+#: src/GenericClientListCtrl.cpp:1216 src/PrefsUnifiedDlg.cpp:2898
+#: src/PrefsUnifiedDlg.cpp:2948 src/ServerListCtrl.cpp:276
 msgid "Yes"
 msgstr "Po"
 
@@ -2761,10 +2766,10 @@ msgstr "Porte e pavlefshme per bootstrap"
 msgid "Please fill all fields required"
 msgstr "Ju lutem plotesoni te gjitha fushat e kerkuara"
 
-#: src/KadDlg.cpp:192 src/PartFile.cpp:1031 src/PrefsUnifiedDlg.cpp:1162
-#: src/PrefsUnifiedDlg.cpp:1331 src/PrefsUnifiedDlg.cpp:1589
-#: src/PrefsUnifiedDlg.cpp:1599 src/PrefsUnifiedDlg.cpp:1616
-#: src/PrefsUnifiedDlg.cpp:1658
+#: src/KadDlg.cpp:192 src/PartFile.cpp:1031 src/PrefsUnifiedDlg.cpp:1134
+#: src/PrefsUnifiedDlg.cpp:1204 src/PrefsUnifiedDlg.cpp:1405
+#: src/PrefsUnifiedDlg.cpp:1663 src/PrefsUnifiedDlg.cpp:1673
+#: src/PrefsUnifiedDlg.cpp:1690 src/PrefsUnifiedDlg.cpp:1738
 msgid "Message"
 msgstr "Mesazh"
 
@@ -2866,7 +2871,7 @@ msgstr ""
 msgid "Uploaded"
 msgstr ""
 
-#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3232
+#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3263
 msgid "Requested"
 msgstr ""
 
@@ -2992,7 +2997,7 @@ msgid "WARNING: "
 msgstr ""
 
 #: src/MuleNotebook.cpp:179 src/muuli_wdr.cpp:817 src/muuli_wdr.cpp:1229
-#: src/muuli_wdr.cpp:3136 src/muuli_wdr.cpp:3392
+#: src/muuli_wdr.cpp:3167 src/muuli_wdr.cpp:3423
 msgid "Close"
 msgstr "Mbylle"
 
@@ -3010,7 +3015,7 @@ msgid "Paste"
 msgstr "Ngjit"
 
 #: src/MuleTextCtrl.cpp:89 src/muuli_wdr.cpp:358 src/muuli_wdr.cpp:757
-#: src/muuli_wdr.cpp:2359 src/muuli_wdr.cpp:2378 src/muuli_wdr.cpp:2400
+#: src/muuli_wdr.cpp:2390 src/muuli_wdr.cpp:2409 src/muuli_wdr.cpp:2431
 #: src/utils/aLinkCreator/src/alcframe.cpp:142
 msgid "Clear"
 msgstr "Pastro"
@@ -3108,7 +3113,7 @@ msgstr "Dlje"
 
 #: src/MuleTrayIcon.cpp:579 src/MuleTrayIcon.cpp:945 src/MuleTrayIcon.cpp:965
 #: src/muuli_wdr.cpp:1398 src/muuli_wdr.cpp:1406 src/muuli_wdr.cpp:1413
-#: src/muuli_wdr.cpp:1842 src/muuli_wdr.cpp:1848 src/OtherFunctions.cpp:91
+#: src/muuli_wdr.cpp:1846 src/muuli_wdr.cpp:1852 src/OtherFunctions.cpp:91
 #: src/StatisticsDlg.cpp:93 src/StatisticsDlg.cpp:95
 msgid "kB/s"
 msgstr "kB/s"
@@ -3350,7 +3355,7 @@ msgstr "Bytes"
 msgid "KB"
 msgstr "KB"
 
-#: src/muuli_wdr.cpp:274 src/muuli_wdr.cpp:293 src/muuli_wdr.cpp:1627
+#: src/muuli_wdr.cpp:274 src/muuli_wdr.cpp:293 src/muuli_wdr.cpp:1631
 #: src/OtherFunctions.cpp:64
 msgid "MB"
 msgstr "MB"
@@ -3367,7 +3372,7 @@ msgstr "Madhesia Maksimale"
 msgid "Availability"
 msgstr "Te disponueshem"
 
-#: src/muuli_wdr.cpp:312 src/muuli_wdr.cpp:398 src/muuli_wdr.cpp:3297
+#: src/muuli_wdr.cpp:312 src/muuli_wdr.cpp:398 src/muuli_wdr.cpp:3328
 msgid "Filter:"
 msgstr "Filteri:"
 
@@ -3431,12 +3436,12 @@ msgstr "Burime te gjetura :"
 #: src/muuli_wdr.cpp:1160 src/muuli_wdr.cpp:1167 src/muuli_wdr.cpp:1172
 #: src/muuli_wdr.cpp:1179 src/muuli_wdr.cpp:1184 src/muuli_wdr.cpp:1191
 #: src/muuli_wdr.cpp:1205 src/muuli_wdr.cpp:1212 src/muuli_wdr.cpp:1217
-#: src/muuli_wdr.cpp:1224 src/muuli_wdr.cpp:3234 src/muuli_wdr.cpp:3242
-#: src/muuli_wdr.cpp:3250
+#: src/muuli_wdr.cpp:1224 src/muuli_wdr.cpp:3265 src/muuli_wdr.cpp:3273
+#: src/muuli_wdr.cpp:3281
 msgid "N/A"
 msgstr "N/A"
 
-#: src/muuli_wdr.cpp:508 src/muuli_wdr.cpp:1065 src/PrefsUnifiedDlg.cpp:297
+#: src/muuli_wdr.cpp:508 src/muuli_wdr.cpp:1065 src/PrefsUnifiedDlg.cpp:299
 msgid "General"
 msgstr "Te pergjithshme"
 
@@ -3577,7 +3582,7 @@ msgstr ""
 msgid "Album :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:685 src/muuli_wdr.cpp:2254
+#: src/muuli_wdr.cpp:685 src/muuli_wdr.cpp:2285
 msgid "Title :"
 msgstr "Titulli :"
 
@@ -3684,7 +3689,7 @@ msgstr "Emri i Perdoruesit :"
 msgid "Userhash :"
 msgstr "Userhash :"
 
-#: src/muuli_wdr.cpp:895 src/muuli_wdr.cpp:1748 src/muuli_wdr.cpp:2449
+#: src/muuli_wdr.cpp:895 src/muuli_wdr.cpp:1752 src/muuli_wdr.cpp:2480
 #: src/utils/aLinkCreator/src/alcframe.cpp:137
 msgid "Add"
 msgstr "Shto"
@@ -3693,15 +3698,15 @@ msgstr "Shto"
 msgid "Download-Speed"
 msgstr "Shpejtesia-Shkarkimit"
 
-#: src/muuli_wdr.cpp:954 src/muuli_wdr.cpp:989 src/muuli_wdr.cpp:2553
+#: src/muuli_wdr.cpp:954 src/muuli_wdr.cpp:989 src/muuli_wdr.cpp:2584
 msgid "Current"
 msgstr "Aktualisht"
 
-#: src/muuli_wdr.cpp:962 src/muuli_wdr.cpp:997 src/muuli_wdr.cpp:2561
+#: src/muuli_wdr.cpp:962 src/muuli_wdr.cpp:997 src/muuli_wdr.cpp:2592
 msgid "Running average"
 msgstr "Mesatarja e Punes"
 
-#: src/muuli_wdr.cpp:970 src/muuli_wdr.cpp:1005 src/muuli_wdr.cpp:2569
+#: src/muuli_wdr.cpp:970 src/muuli_wdr.cpp:1005 src/muuli_wdr.cpp:2600
 msgid "Session average"
 msgstr "Mesatarja e Sesionit"
 
@@ -3713,7 +3718,7 @@ msgstr "Shpejtesia-Ngarkimit"
 msgid "Connections"
 msgstr "Lidhjet"
 
-#: src/muuli_wdr.cpp:1024 src/muuli_wdr.cpp:1867
+#: src/muuli_wdr.cpp:1024 src/muuli_wdr.cpp:1871
 msgid "Active downloads"
 msgstr "Shkarkime Aktive"
 
@@ -3721,7 +3726,7 @@ msgstr "Shkarkime Aktive"
 msgid "Active connections (1:1)"
 msgstr "Lidhje Aktive (1:1)"
 
-#: src/muuli_wdr.cpp:1040 src/muuli_wdr.cpp:1868
+#: src/muuli_wdr.cpp:1040 src/muuli_wdr.cpp:1872
 msgid "Active uploads"
 msgstr "Ngarkime Aktive"
 
@@ -3998,7 +4003,7 @@ msgstr ""
 msgid "Advanced users only: If you have multiple network interfaces, enter the address of the interface to which aMule should be bound."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1462 src/muuli_wdr.cpp:2061
+#: src/muuli_wdr.cpp:1462 src/muuli_wdr.cpp:2065
 msgid "Bind to network interface (empty for any):"
 msgstr ""
 
@@ -4014,7 +4019,7 @@ msgstr ""
 msgid "Max simultaneous connections:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1498 src/muuli_wdr.cpp:3176
+#: src/muuli_wdr.cpp:1498 src/muuli_wdr.cpp:3207
 msgid "ED2K"
 msgstr "ED2K"
 
@@ -4106,757 +4111,780 @@ msgstr ""
 msgid "For new files preallocates disk space for the whole file, thus reduces fragmentation"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1613
+#: src/muuli_wdr.cpp:1617
 msgid "Create new files as sparse files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1614
-msgid "A sparse file reserves its full size on disk immediately without writing real data to it -- fast, but unsupported or slow on some filesystems, and free-space accounting stays optimistic while the download is in progress. Turn this off to grow the file only as data arrives."
+#: src/muuli_wdr.cpp:1618
+msgid "Sparse part files only occupy disk space for the parts already downloaded, so free space is used up gradually as the file fills in. Turn this off to use an ordinary file instead - useful where sparse files are unsupported or slow, or where backup/de-duplication tools handle them badly. Applies only when the core runs on Windows; on Linux and macOS part files are sparse anyway and this setting has no effect."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1619
+#: src/muuli_wdr.cpp:1623
 msgid "Stop downloads when free disk space reaches "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1620
+#: src/muuli_wdr.cpp:1624
 msgid "Select this if you want aMule to check your disk space"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1624
+#: src/muuli_wdr.cpp:1628
 msgid "Enter here the min disk space desired."
 msgstr "Futni ketu hapesiren minimale qe deshironi per diskun."
 
-#: src/muuli_wdr.cpp:1630
+#: src/muuli_wdr.cpp:1634
 msgid "Save 10 sources on rare files (< 20 sources)"
 msgstr "Shpeto 10 burime per failet e rralla (< 20 burime)"
 
-#: src/muuli_wdr.cpp:1634 src/Statistics.cpp:790
+#: src/muuli_wdr.cpp:1638 src/Statistics.cpp:790
 msgid "Uploads"
 msgstr "Ngarkimi"
 
-#: src/muuli_wdr.cpp:1637
+#: src/muuli_wdr.cpp:1641
 msgid "Add new shared files with auto priority"
 msgstr "Shto faile te reja te ndara me prioritet automatik"
 
-#: src/muuli_wdr.cpp:1643
+#: src/muuli_wdr.cpp:1647
 msgid "Intelligent Corruption Handling (I.C.H.)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1646
+#: src/muuli_wdr.cpp:1650
 msgid "Enable"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1649
+#: src/muuli_wdr.cpp:1653
 msgid "Advanced I.C.H. trusts every hash (not recommended)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1661 src/PrefsUnifiedDlg.cpp:1910
+#: src/muuli_wdr.cpp:1665 src/PrefsUnifiedDlg.cpp:1990
 msgid "Media metadata extraction"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1665
+#: src/muuli_wdr.cpp:1669
 msgid "Extract length / bitrate / codec from shared audio and video files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1667
+#: src/muuli_wdr.cpp:1671
 msgid "When enabled, aMule runs ffprobe on each shared media file to fill in the Length / Bitrate / Codec columns other clients see when they find the file in a search. Requires ffmpeg (the ffprobe binary) to be installed."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1674
+#: src/muuli_wdr.cpp:1678
 msgid "Path to ffprobe:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1679
+#: src/muuli_wdr.cpp:1683
 msgid "Full path to the ffprobe binary. Leave empty to have aMule auto-detect it on startup."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1687
+#: src/muuli_wdr.cpp:1691
 msgid "Detect"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1688
+#: src/muuli_wdr.cpp:1692
 msgid "Search the standard install locations for an ffprobe binary and fill the path field."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1712
+#: src/muuli_wdr.cpp:1716
 msgid ""
 "Completed downloads are stored here. All files in this folder are automatically shared with other peers.\n"
 "If this folder also holds files you don't want to share, point it at an aMule-only sub-folder."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1715
+#: src/muuli_wdr.cpp:1719
 msgid "Pick the folder where completed downloads will be stored. All files in that folder will be shared with other peers."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1729
+#: src/muuli_wdr.cpp:1733
 msgid "Shared folders"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1735
+#: src/muuli_wdr.cpp:1739
 msgid "(Folders shared by the core. Enter a path to add one.)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1743
+#: src/muuli_wdr.cpp:1747
 msgid "Absolute path of a folder on the core's machine, e.g. /home/user/shared"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1745 src/PrefsUnifiedDlg.cpp:2794
+#: src/muuli_wdr.cpp:1749 src/PrefsUnifiedDlg.cpp:2874
 msgid "Recursive"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1746
+#: src/muuli_wdr.cpp:1750
 msgid "Share every sub-folder underneath this one, including ones created later."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1750 src/utils/aLinkCreator/src/alcframe.cpp:141
+#: src/muuli_wdr.cpp:1754 src/utils/aLinkCreator/src/alcframe.cpp:141
 msgid "Remove"
 msgstr "Hiq"
 
-#: src/muuli_wdr.cpp:1754
+#: src/muuli_wdr.cpp:1758
 msgid "(Right click on folder icon for recursive share)"
 msgstr "( Klikoni me butonin e djathte ne ikonene e karteles per te ndare ne menyre rekursive)"
 
-#: src/muuli_wdr.cpp:1761
+#: src/muuli_wdr.cpp:1765
 msgid "Share hidden files"
 msgstr "Nda failet e fshehur"
 
-#: src/muuli_wdr.cpp:1767
+#: src/muuli_wdr.cpp:1771
 msgid "Automatically rescan shared folders for changes"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1773
+#: src/muuli_wdr.cpp:1777
 msgid "Follow symbolic links in shared folders"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1779
+#: src/muuli_wdr.cpp:1783
 msgid "Exclude files matching:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1782
+#: src/muuli_wdr.cpp:1786
 msgid "Wildcard patterns separated by '|', e.g. .DS_Store|Thumbs.db|*.tmp. Files whose name matches are not shared. Matching is case-insensitive."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1786
+#: src/muuli_wdr.cpp:1790
 msgid "Patterns are regular expressions"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1787
+#: src/muuli_wdr.cpp:1791
 msgid "When set, the whole field is one regular expression ('|' is alternation). When unset, it is a list of '|'-separated wildcards."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1797
+#: src/muuli_wdr.cpp:1801
 msgid "Show how many shared files the current pattern would exclude."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1818
+#: src/muuli_wdr.cpp:1822
 msgid "Graphs"
 msgstr "Grafiket"
 
-#: src/muuli_wdr.cpp:1821 src/muuli_wdr.cpp:1883
+#: src/muuli_wdr.cpp:1825 src/muuli_wdr.cpp:1887
 msgid "Update delay : 5 secs"
 msgstr "Intervali i azhornimit : 5 sek"
 
-#: src/muuli_wdr.cpp:1825
+#: src/muuli_wdr.cpp:1829
 msgid "Time for average graph: 100 mins"
 msgstr "Intervali grafik i vlerave mesatare: 100 minuta"
 
-#: src/muuli_wdr.cpp:1829
+#: src/muuli_wdr.cpp:1833
 msgid "Connections Graph Scale: 100 "
 msgstr "Shkalla grafike e lidhjeve: 100 "
 
-#: src/muuli_wdr.cpp:1836
+#: src/muuli_wdr.cpp:1840
 msgid "Download graph scale:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1844
+#: src/muuli_wdr.cpp:1848
 msgid "Upload graph scale:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1854
+#: src/muuli_wdr.cpp:1858
 msgid "Colors: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1858
+#: src/muuli_wdr.cpp:1862
 msgid "Background"
 msgstr "Sfondi"
 
-#: src/muuli_wdr.cpp:1859
+#: src/muuli_wdr.cpp:1863
 msgid "Grid"
 msgstr "Zgara"
 
-#: src/muuli_wdr.cpp:1860
+#: src/muuli_wdr.cpp:1864
 msgid "Download current"
 msgstr "Shkarkimi aktual"
 
-#: src/muuli_wdr.cpp:1861
+#: src/muuli_wdr.cpp:1865
 msgid "Download running average"
 msgstr "Mesatarja e shkarkimeve ne punim"
 
-#: src/muuli_wdr.cpp:1862
+#: src/muuli_wdr.cpp:1866
 msgid "Download session average"
 msgstr "Mesatarja e sesioneve te shkarkimit"
 
-#: src/muuli_wdr.cpp:1863
+#: src/muuli_wdr.cpp:1867
 msgid "Upload current"
 msgstr "Ngarkimi aktual"
 
-#: src/muuli_wdr.cpp:1864
+#: src/muuli_wdr.cpp:1868
 msgid "Upload running average"
 msgstr "Mesatarja e ngarkimit ne punim"
 
-#: src/muuli_wdr.cpp:1865
+#: src/muuli_wdr.cpp:1869
 msgid "Upload session average"
 msgstr "Mesatarja e sesionit te ngarkimeve"
 
-#: src/muuli_wdr.cpp:1866
+#: src/muuli_wdr.cpp:1870
 msgid "Active connections"
 msgstr "Lidhjet aktive"
 
-#: src/muuli_wdr.cpp:1869
+#: src/muuli_wdr.cpp:1873
 #, fuzzy
 msgid "Systray Icon Speed Bar"
 msgstr "Ikona e Speedbar-it ne Systray"
 
-#: src/muuli_wdr.cpp:1870
+#: src/muuli_wdr.cpp:1874
 msgid "Kad-nodes current"
 msgstr "Nyjet e Kad aktuale"
 
-#: src/muuli_wdr.cpp:1871
+#: src/muuli_wdr.cpp:1875
 msgid "Kad-nodes running"
 msgstr "Nyjet e Kad jane duke punuar"
 
-#: src/muuli_wdr.cpp:1872
+#: src/muuli_wdr.cpp:1876
 msgid "Kad-nodes session"
 msgstr "Sesioni i Nyjeve te Kad"
 
-#: src/muuli_wdr.cpp:1876 src/muuli_wdr.cpp:2303
+#: src/muuli_wdr.cpp:1880 src/muuli_wdr.cpp:2334
 msgid "Select"
 msgstr "Zgjidh"
 
-#: src/muuli_wdr.cpp:1880
+#: src/muuli_wdr.cpp:1884
 msgid "Tree"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1890
+#: src/muuli_wdr.cpp:1894
 msgid "Number of Client Versions shown (0=unlimited)"
 msgstr "Numera te treguar te versioneve te klienteve (0= pa kufij)"
 
-#: src/muuli_wdr.cpp:1915
+#: src/muuli_wdr.cpp:1919
 msgid "!!! WARNING !!!"
 msgstr "!!! KUJDES !!!"
 
-#: src/muuli_wdr.cpp:1930
+#: src/muuli_wdr.cpp:1934
 msgid "Max new connections / 5 secs"
 msgstr "Lidhe maksimale te reja / 5 sek"
 
-#: src/muuli_wdr.cpp:1932
+#: src/muuli_wdr.cpp:1936
 msgid "Concurrent Kad source lookups"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1934
+#: src/muuli_wdr.cpp:1938
 #, fuzzy
 msgid "Kad source re-search interval (minutes)"
 msgstr "Intervali i rifreskimit te FTP-se ne minuta"
 
-#: src/muuli_wdr.cpp:1936
+#: src/muuli_wdr.cpp:1940
 #, fuzzy
 msgid "Source re-ask interval (minutes)"
 msgstr "Intervali i rifreskimit te FTP-se ne minuta"
 
-#: src/muuli_wdr.cpp:1940
+#: src/muuli_wdr.cpp:1944
 msgid "File Buffer Size: 240000 bytes"
 msgstr "Madhesia e Buffer-it te failit: 240000 bytes"
 
-#: src/muuli_wdr.cpp:1944
+#: src/muuli_wdr.cpp:1948
 msgid "Use MMAP: memory-mapped file access (lower memory use)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1945
+#: src/muuli_wdr.cpp:1949
 msgid "Maps part files into memory instead of buffering them on the heap, lowering the process memory footprint. May reduce download speed on some disks; best for memory-constrained or upload-heavy hosts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1947
+#: src/muuli_wdr.cpp:1951
 msgid "Upload Queue Size: 5000 clients"
 msgstr "Madhesia e Radhes ne Ngarkim: 5000 klienta"
 
-#: src/muuli_wdr.cpp:1951
+#: src/muuli_wdr.cpp:1955
 msgid "Server connection refresh interval: Disable"
 msgstr "Interval i azhornimit te lidhjes se serverit: C'aktivizuar"
 
-#: src/muuli_wdr.cpp:1955
+#: src/muuli_wdr.cpp:1959
 msgid "Disable computer's timed standby mode"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1974
+#: src/muuli_wdr.cpp:1978
 msgid "Skin to use: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1983
+#: src/muuli_wdr.cpp:1987
 msgid "Show \"Fast eD2k Links Handler\" in every window."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1986
+#: src/muuli_wdr.cpp:1990
 msgid "Show extended info on categories tabs"
 msgstr "Trego informacion te zgjeruar ne tabelat e kategorive"
 
-#: src/muuli_wdr.cpp:1989
+#: src/muuli_wdr.cpp:1993
 #, fuzzy
 msgid "Show application version on title"
 msgstr "Trego shpejtesine e transferimit ne titull"
 
-#: src/muuli_wdr.cpp:1991
+#: src/muuli_wdr.cpp:1995
 msgid "Show transfer rates on title"
 msgstr "Trego shpejtesine e transferimit ne titull"
 
-#: src/muuli_wdr.cpp:1993
+#: src/muuli_wdr.cpp:1997
 msgid "Before application name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1995
+#: src/muuli_wdr.cpp:1999
 msgid "After application name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1998
+#: src/muuli_wdr.cpp:2002
 msgid "Show overhead bandwidth"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2002
+#: src/muuli_wdr.cpp:2006
 msgid "Vertical toolbar orientation"
 msgstr "Orientim Vertikal i toolbar-it"
 
-#: src/muuli_wdr.cpp:2004
+#: src/muuli_wdr.cpp:2008
 msgid "Live column sorting (auto-reorder rows as their values change)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2011
+#: src/muuli_wdr.cpp:2015
 msgid "Download Queue Files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2014
+#: src/muuli_wdr.cpp:2018
 msgid "Show progress percentage"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2020
+#: src/muuli_wdr.cpp:2024
 msgid "Show progress bar"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2023
+#: src/muuli_wdr.cpp:2027
 msgid "Flat"
 msgstr "E sheshte"
 
-#: src/muuli_wdr.cpp:2027
+#: src/muuli_wdr.cpp:2031
 msgid "Round"
 msgstr "E rrumbullakosur"
 
-#: src/muuli_wdr.cpp:2045
+#: src/muuli_wdr.cpp:2049
 msgid "External Connection Parameters"
 msgstr "Parametrat e Lidhjeve te Jashtme"
 
-#: src/muuli_wdr.cpp:2048
+#: src/muuli_wdr.cpp:2052
 msgid "Accept external connections"
 msgstr "Prano lidhje te jashtme"
 
-#: src/muuli_wdr.cpp:2055 src/muuli_wdr.cpp:2114
+#: src/muuli_wdr.cpp:2059 src/muuli_wdr.cpp:2118
 msgid "IP of the listening interface:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2058
+#: src/muuli_wdr.cpp:2062
 msgid "Enter here a valid ip in the a.b.c.d format for the listening EC interface. An empty field or 0.0.0.0 will mean any interface."
 msgstr "Futni ketu nje ip te vlefshem ne formatin a.b.c.d per te degjuar nderfaqesin EC. Nje fushe boshe ose 0.0.0.0 do te nenkuptoje cdo nderfaqe."
 
-#: src/muuli_wdr.cpp:2079 src/muuli_wdr.cpp:2163
+#: src/muuli_wdr.cpp:2083 src/muuli_wdr.cpp:2194
 msgid "TCP port:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2085
+#: src/muuli_wdr.cpp:2089
 msgid "Enable UPnP port forwarding on the EC port"
 msgstr "Aktivizo port forwarding UPnP tek porta EC"
 
-#: src/muuli_wdr.cpp:2089 src/muuli_wdr.cpp:3048
+#: src/muuli_wdr.cpp:2093 src/muuli_wdr.cpp:3079
 #: src/utils/wxCas/src/wxcasprefs.cpp:167
 msgid "Password"
 msgstr "Fjalekalim"
 
-#: src/muuli_wdr.cpp:2095
+#: src/muuli_wdr.cpp:2099
 msgid "aMule API server parameters"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2098
+#: src/muuli_wdr.cpp:2102
 msgid "Run amuleapi (REST API) on startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2103
+#: src/muuli_wdr.cpp:2107
 #, fuzzy
 msgid "HTTP port:"
 msgstr "Porta e Proksit:"
 
-#: src/muuli_wdr.cpp:2117
+#: src/muuli_wdr.cpp:2121
 msgid "The interface amuleapi's HTTP server listens on. 127.0.0.1 (default) accepts only local connections; use 0.0.0.0 or a specific IP to expose it to other hosts (set an admin password below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2120
+#: src/muuli_wdr.cpp:2126
+msgid "Type a password to set or change it. Stored passwords cannot be shown, so leaving this empty keeps the current one."
+msgstr ""
+
+#: src/muuli_wdr.cpp:2128
 #, fuzzy
 msgid "Admin password"
 msgstr "Duke kerkuar fjalekalimin\n"
 
-#: src/muuli_wdr.cpp:2125 src/muuli_wdr.cpp:2156
-msgid "Low rights password"
-msgstr "Fjalekalim per te drejta te kufizuara"
+#: src/muuli_wdr.cpp:2140 src/muuli_wdr.cpp:2157 src/PrefsUnifiedDlg.cpp:1103
+#, fuzzy
+msgid "A password is set."
+msgstr "Duke kerkuar fjalekalimin\n"
 
-#: src/muuli_wdr.cpp:2133
+#: src/muuli_wdr.cpp:2144
+#, fuzzy
+msgid "Enable guest access"
+msgstr "Ndalo hyrjen e guest-ve"
+
+#: src/muuli_wdr.cpp:2145
+msgid "Guest sessions may read status and listings but cannot change anything. Turning this off clears the stored guest password."
+msgstr ""
+
+#: src/muuli_wdr.cpp:2149
+#, fuzzy
+msgid "Guest password"
+msgstr "Fjalekalim per te drejta komplete"
+
+#: src/muuli_wdr.cpp:2164
 msgid "Web server parameters"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2136
+#: src/muuli_wdr.cpp:2167
 msgid "Run webserver on startup (deprecated)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2142
+#: src/muuli_wdr.cpp:2173
 msgid "Web template"
 msgstr "Modeli Web"
 
-#: src/muuli_wdr.cpp:2147
+#: src/muuli_wdr.cpp:2178
 msgid "Full rights password"
 msgstr "Fjalekalim per te drejta komplete"
 
-#: src/muuli_wdr.cpp:2151
+#: src/muuli_wdr.cpp:2182
 msgid "Enable Low rights User"
 msgstr "Aktivizo Perdorues me te drejta te kufizuara"
 
-#: src/muuli_wdr.cpp:2170
+#: src/muuli_wdr.cpp:2187
+msgid "Low rights password"
+msgstr "Fjalekalim per te drejta te kufizuara"
+
+#: src/muuli_wdr.cpp:2201
 msgid "Enable UPnP port forwarding of the web server port"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2175
+#: src/muuli_wdr.cpp:2206
 msgid "Web server UPnP TCP port (Optional)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2183
+#: src/muuli_wdr.cpp:2214
 msgid "Page Refresh Time (in secs)"
 msgstr "Koha e Rifreskimit te Faqes (ne sek)"
 
-#: src/muuli_wdr.cpp:2190
+#: src/muuli_wdr.cpp:2221
 msgid "Enable Gzip compression"
 msgstr "Aktivizo kompresimin Gzip"
 
-#: src/muuli_wdr.cpp:2224
+#: src/muuli_wdr.cpp:2255
 #, fuzzy
 msgid "Reset page to defaults"
 msgstr "E vendosur nga sistemi"
 
-#: src/muuli_wdr.cpp:2225
+#: src/muuli_wdr.cpp:2256
 msgid "Reset the settings on the current page to their default values."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2227 src/muuli_wdr.cpp:2313 src/ServerWnd.cpp:274
+#: src/muuli_wdr.cpp:2258 src/muuli_wdr.cpp:2344 src/ServerWnd.cpp:274
 #: src/ServerWnd.cpp:282
 msgid "OK"
 msgstr "Ne rregull"
 
-#: src/muuli_wdr.cpp:2229
+#: src/muuli_wdr.cpp:2260
 msgid "Click here to apply any changes made to the preferences."
 msgstr "Kliko ketu per te bere aktive ndryshimet qe u bene tek Preferencat."
 
-#: src/muuli_wdr.cpp:2232
+#: src/muuli_wdr.cpp:2263
 msgid "Reset any changes made to the preferences."
 msgstr "Rikthe ne gjendjen e meparshme ndryshimet te bera tek Preferencat."
 
-#: src/muuli_wdr.cpp:2261
+#: src/muuli_wdr.cpp:2292
 msgid "Comment :"
 msgstr "Komente :"
 
-#: src/muuli_wdr.cpp:2268
+#: src/muuli_wdr.cpp:2299
 msgid "Incoming Dir :"
 msgstr "Direktoria e Hyrjeve :"
 
-#: src/muuli_wdr.cpp:2277
+#: src/muuli_wdr.cpp:2308
 msgid "Change priority for new assigned files :"
 msgstr "Nderro perparesine per failet e reja te caktuara :"
 
-#: src/muuli_wdr.cpp:2281
+#: src/muuli_wdr.cpp:2312
 #, fuzzy
 msgid "Don't change"
 msgstr "Mos nderro"
 
-#: src/muuli_wdr.cpp:2293
+#: src/muuli_wdr.cpp:2324
 msgid "Select color for this Category (currently selected) :"
 msgstr "Zgjidh ngjyren per kete kategori (e zgjedhur aktualisht) :"
 
-#: src/muuli_wdr.cpp:2360 src/muuli_wdr.cpp:2379 src/muuli_wdr.cpp:2401
+#: src/muuli_wdr.cpp:2391 src/muuli_wdr.cpp:2410 src/muuli_wdr.cpp:2432
 msgid "Click this button to reset the log."
 msgstr "Kliko ne kete buton per te resetuar log-un."
 
-#: src/muuli_wdr.cpp:2420
+#: src/muuli_wdr.cpp:2451
 msgid "Click on this button to update the servers list from URL ..."
 msgstr "Kliko ne kete buton per te azhornuar listen e serverave nga URL ..."
 
-#: src/muuli_wdr.cpp:2424
+#: src/muuli_wdr.cpp:2455
 msgid "Server list"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2428
+#: src/muuli_wdr.cpp:2459
 msgid "Enter the url to a server.met file here and press the button to the left to update the list of known servers."
 msgstr "Futni url tek nje fail server.met dhe shtypni butonin ne te majte per te azhornuar listen e serverave te njohur."
 
-#: src/muuli_wdr.cpp:2433
+#: src/muuli_wdr.cpp:2464
 msgid "Add server manually: Name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2436
+#: src/muuli_wdr.cpp:2467
 msgid "Enter the name of the new server here"
 msgstr "Futni emrin e serverit te ri ketu"
 
-#: src/muuli_wdr.cpp:2438 src/ServerWnd.cpp:206
+#: src/muuli_wdr.cpp:2469 src/ServerWnd.cpp:206
 msgid "IP:Port"
 msgstr "IP:Porta"
 
-#: src/muuli_wdr.cpp:2441
+#: src/muuli_wdr.cpp:2472
 msgid "Enter the IP of the server here, using the x.x.x.x format."
 msgstr "Futni IP-ne e serverit ketu. duke perdorur formatin x.x.x.x."
 
-#: src/muuli_wdr.cpp:2447
+#: src/muuli_wdr.cpp:2478
 msgid "Enter the port of the server here."
 msgstr "Futni porten e serverit ketu."
 
-#: src/muuli_wdr.cpp:2450
+#: src/muuli_wdr.cpp:2481
 msgid "Add manually a server (fill fields to the left before) ..."
 msgstr "Shto ne menyre manuale nje server (mbushni fushen ne te majte me pare) ..."
 
-#: src/muuli_wdr.cpp:2479
+#: src/muuli_wdr.cpp:2510
 msgid "aMule Log"
 msgstr "Log i aMule"
 
-#: src/muuli_wdr.cpp:2487
+#: src/muuli_wdr.cpp:2518
 msgid "Server Info"
 msgstr "Informacion mbi serverin"
 
-#: src/muuli_wdr.cpp:2491
+#: src/muuli_wdr.cpp:2522
 msgid "ED2K Info"
 msgstr "Informacioni i ED2K"
 
-#: src/muuli_wdr.cpp:2495
+#: src/muuli_wdr.cpp:2526
 msgid "Kad Info"
 msgstr "Informacioni i Kad"
 
-#: src/muuli_wdr.cpp:2523
+#: src/muuli_wdr.cpp:2554
 msgid "Click on this button to update the nodes list from URL ..."
 msgstr "Kliko ne kete buton per te azhornuar listen e nyjeve nga URL ..."
 
-#: src/muuli_wdr.cpp:2527
+#: src/muuli_wdr.cpp:2558
 msgid "Nodes (0)"
 msgstr "Nyjet (0)"
 
-#: src/muuli_wdr.cpp:2531
+#: src/muuli_wdr.cpp:2562
 msgid "Enter the url to a nodes.dat file here and press the button to the left to update the list of known nodes."
 msgstr "Fut url e nje faili nodes.dat dhe shtyp butonin ne te majte per te azhornuar listen e nyjeve te njohura."
 
-#: src/muuli_wdr.cpp:2534
+#: src/muuli_wdr.cpp:2565
 msgid "Nodes stats"
 msgstr "Statistikat e Nyjeve"
 
-#: src/muuli_wdr.cpp:2576
+#: src/muuli_wdr.cpp:2607
 msgid "Bootstrap"
 msgstr "Bootstrap"
 
-#: src/muuli_wdr.cpp:2579
+#: src/muuli_wdr.cpp:2610
 msgid "New node"
 msgstr "Nyje e re"
 
-#: src/muuli_wdr.cpp:2584
+#: src/muuli_wdr.cpp:2615
 msgid "IP:"
 msgstr "IP:"
 
-#: src/muuli_wdr.cpp:2604
+#: src/muuli_wdr.cpp:2635
 msgid "Port:"
 msgstr "Porta:"
 
-#: src/muuli_wdr.cpp:2617
+#: src/muuli_wdr.cpp:2648
 #, fuzzy
 msgid "Bootstrap from known clients"
 msgstr ""
 "Bootstrap nga \n"
 "kliente te njohur"
 
-#: src/muuli_wdr.cpp:2619
+#: src/muuli_wdr.cpp:2650
 msgid "Disconnect Kad"
 msgstr "Shkeput Kad"
 
-#: src/muuli_wdr.cpp:2653
+#: src/muuli_wdr.cpp:2684
 msgid "Use Secure User Identification"
 msgstr "Perdor Identifikimin e Sigurte te Perdoruesve"
 
-#: src/muuli_wdr.cpp:2655
+#: src/muuli_wdr.cpp:2686
 msgid "It is recommended to enable this option. You will not receive credits if SUI is not enabled."
 msgstr "Eshte e rekomandueshme qe ta lejoni kete opsion. Ju nuk mund te merrni kredite nqs SUI nuk eshte i aktivizuar."
 
-#: src/muuli_wdr.cpp:2657
+#: src/muuli_wdr.cpp:2688
 msgid "Protocol Obfuscation"
 msgstr "Protokolli i Turbullimit"
 
-#: src/muuli_wdr.cpp:2660
+#: src/muuli_wdr.cpp:2691
 msgid "Support Protocol Obfuscation"
 msgstr "Mbeshtet Protokollin e Turbullimit"
 
-#: src/muuli_wdr.cpp:2662
+#: src/muuli_wdr.cpp:2693
 msgid "This option enabled Protocol Obfuscation, and makes aMule accept obfuscated connections from other clients."
 msgstr "Ky opsion lejon Protokollin e Turbullimit, dhe ben qe aMule te pranoje lidhje te turbulluara nga kliente te tjere."
 
-#: src/muuli_wdr.cpp:2664
+#: src/muuli_wdr.cpp:2695
 msgid "Use obfuscation for outgoing connections"
 msgstr "Perdor turbullimin per lidhjet ne dalje"
 
-#: src/muuli_wdr.cpp:2666
+#: src/muuli_wdr.cpp:2697
 msgid "This option makes aMule use Protocol Obfuscation when connecting other clients/servers."
 msgstr "Ky opsion lejon aMule-n qe te perdori protokollin e turbullimit kur lidhet me klientet/serverat e tjere."
 
-#: src/muuli_wdr.cpp:2668
+#: src/muuli_wdr.cpp:2699
 msgid "Accept only obfuscated connections"
 msgstr "Prano vetem lidhje te turbulluara"
 
-#: src/muuli_wdr.cpp:2669
+#: src/muuli_wdr.cpp:2700
 msgid "This option makes aMule only accept obfuscated connections. You will have less sources, but all your traffic will be obfuscated"
 msgstr "Ky opsion e ben aMule-n qe te lejoje lidhje te turbulluara. Ju do te keni me pak burime, por i gjithe trafiku juaj do te turbullohet"
 
-#: src/muuli_wdr.cpp:2674
+#: src/muuli_wdr.cpp:2705
 msgid "Everybody"
 msgstr "Te gjithe"
 
-#: src/muuli_wdr.cpp:2676
+#: src/muuli_wdr.cpp:2707
 msgid "No one"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2678
+#: src/muuli_wdr.cpp:2709
 msgid "Who can see my shared files:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2679
+#: src/muuli_wdr.cpp:2710
 msgid "Select who can request to view a list of your shared files."
 msgstr "Zgjidh se kush ka kerkuar te shikoje listene faileve qe ju keni ndare."
 
-#: src/muuli_wdr.cpp:2681
+#: src/muuli_wdr.cpp:2712
 msgid "IP-Filtering"
 msgstr "Filtrimi-IP"
 
-#: src/muuli_wdr.cpp:2688
+#: src/muuli_wdr.cpp:2719
 msgid "Filter clients"
 msgstr "Filtro klientet"
 
-#: src/muuli_wdr.cpp:2690
+#: src/muuli_wdr.cpp:2721
 msgid "Enable filtering of the client IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "Lejo filtrimin e IP-ve te klientave te percaktuar ne failin ~/.aMule/ipfilter.dat."
 
-#: src/muuli_wdr.cpp:2692
+#: src/muuli_wdr.cpp:2723
 msgid "Filter servers"
 msgstr "Filtron Serverat"
 
-#: src/muuli_wdr.cpp:2694
+#: src/muuli_wdr.cpp:2725
 msgid "Enable filtering of the server IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "Lejo filtrimin e IP-ve te serverave te percaktuara ne failin ~/.aMule/ipfilter.dat."
 
-#: src/muuli_wdr.cpp:2698
+#: src/muuli_wdr.cpp:2729
 msgid "Reload List"
 msgstr "Lista e Ringarkimeve"
 
-#: src/muuli_wdr.cpp:2699
+#: src/muuli_wdr.cpp:2730
 msgid "Reload the list of IPs to filter from the file ~/.aMule/ipfilter.dat"
 msgstr "Ringarko listen e IP-ve per te filtruar nga faili ~/.aMule/ipfilter.dat"
 
-#: src/muuli_wdr.cpp:2705
+#: src/muuli_wdr.cpp:2736
 msgid "URL:"
 msgstr "URL:"
 
-#: src/muuli_wdr.cpp:2709 src/muuli_wdr.cpp:2902
+#: src/muuli_wdr.cpp:2740 src/muuli_wdr.cpp:2933
 msgid "Update now"
 msgstr "Azhorno tani"
 
-#: src/muuli_wdr.cpp:2712
+#: src/muuli_wdr.cpp:2743
 msgid "Auto-update ipfilter at startup"
 msgstr "Azhornim-Automatik i ipfilter sapo te ndizet"
 
-#: src/muuli_wdr.cpp:2716
+#: src/muuli_wdr.cpp:2747
 msgid "Filtering Level:"
 msgstr "Niveli i Filtrimit:"
 
-#: src/muuli_wdr.cpp:2722
+#: src/muuli_wdr.cpp:2753
 msgid "Always filter LAN IPs"
 msgstr "Gjithmone filtro IP-te LAN"
 
-#: src/muuli_wdr.cpp:2725
+#: src/muuli_wdr.cpp:2756
 msgid "Paranoid handling of non-matching IPs"
 msgstr "Perdorim Paranoik te IP-ve qe nuk korrespondojne"
 
-#: src/muuli_wdr.cpp:2727
+#: src/muuli_wdr.cpp:2758
 msgid "Rejects a packet when its source IP differs from the IP the client claims (an anti-spoofing check). Disable only if it causes connection problems."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2729
+#: src/muuli_wdr.cpp:2760
 msgid "Use system-wide ipfilter.dat if available"
 msgstr "Perdor ipfilter.dat te sistemit nqs eshte i disponueshem"
 
-#: src/muuli_wdr.cpp:2730
+#: src/muuli_wdr.cpp:2761
 #, fuzzy
 msgid "If there's no local ipfilter.dat found, allow usage of a system-wide ipfilter file."
 msgstr "Nese nuk eshte gjetur ndonje ipfilter.dat lokal, lejo perdorimin e failit ipfilter te sistemit."
 
-#: src/muuli_wdr.cpp:2747
+#: src/muuli_wdr.cpp:2778
 msgid "Enable Online-Signature"
 msgstr "Lejo Firmen-Online"
 
-#: src/muuli_wdr.cpp:2749
+#: src/muuli_wdr.cpp:2780
 msgid "Enables the writing of the OS file, which can be used by external apps to create signatures and the like."
 msgstr "Lejon shkrimin e faileve OS, qe mund te perdorren nga aplikacione te jashtme per te krijuar firma dhe te ngjashme."
 
-#: src/muuli_wdr.cpp:2753
+#: src/muuli_wdr.cpp:2784
 msgid "Update Frequency (Secs):"
 msgstr "Frekuenca e azhornimeve (sek):"
 
-#: src/muuli_wdr.cpp:2756
+#: src/muuli_wdr.cpp:2787
 msgid "Change the frequency (in seconds) of Online Signature updates."
 msgstr "Nderron frekuqncen (ne sekonda) te azhornimit te Firmes Online."
 
-#: src/muuli_wdr.cpp:2764
+#: src/muuli_wdr.cpp:2795
 msgid "Save online signature file in: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:2770
+#: src/muuli_wdr.cpp:2801
 msgid "Click here to select the directory containing the the Online Signature files."
 msgstr "Shtypni ketu per te zgjedhur direktorine qe permban failet e Firmes Online."
 
-#: src/muuli_wdr.cpp:2803
+#: src/muuli_wdr.cpp:2834
 msgid "Show country flags for clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2804
+#: src/muuli_wdr.cpp:2835
 msgid "Render the country flag column in the transfers, queue and search views. Requires a valid MMDB GeoIP database (see below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2809
+#: src/muuli_wdr.cpp:2840
 #, fuzzy
 msgid "Database"
 msgstr "Shpejtesia :"
 
-#: src/muuli_wdr.cpp:2825
+#: src/muuli_wdr.cpp:2856
 #, fuzzy
 msgid "Source:"
 msgstr "Burime"
 
-#: src/muuli_wdr.cpp:2828
+#: src/muuli_wdr.cpp:2859
 msgid "DB-IP (free, no account)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2829
+#: src/muuli_wdr.cpp:2860
 msgid "MaxMind GeoLite2 (free, account required)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2830
+#: src/muuli_wdr.cpp:2861
 msgid "Custom URL"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2833
+#: src/muuli_wdr.cpp:2864
 msgid "Choose which provider supplies the GeoIP MMDB database. DB-IP is the default - no account required. MaxMind requires a free account + license key. Use Custom URL to point at any other MMDB host (e.g. a local mirror)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2850
+#: src/muuli_wdr.cpp:2881
 msgid ""
 "No configuration required.\n"
 "\n"
@@ -4864,11 +4892,11 @@ msgid ""
 "License: Creative Commons BY 4.0 - https://creativecommons.org/licenses/by/4.0/"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2863
+#: src/muuli_wdr.cpp:2894
 msgid "License key:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2869
+#: src/muuli_wdr.cpp:2900
 msgid ""
 "Sign up for a free MaxMind account, then generate a License Key:\n"
 "https://www.maxmind.com/en/geolite2/signup\n"
@@ -4878,232 +4906,232 @@ msgid ""
 "Requires attribution and account registration; refresh at least every 30 days."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2884
+#: src/muuli_wdr.cpp:2915
 #, fuzzy
 msgid "Download URL:"
 msgstr "Shkarkim: "
 
-#: src/muuli_wdr.cpp:2890
+#: src/muuli_wdr.cpp:2921
 msgid ""
 "Must point to an .mmdb file or a .gz / .tar.gz containing one.\n"
 "URL may include credentials (https://user:pass@host/...).\n"
 "License and attribution terms are set by the upstream URL - you are responsible."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2903
+#: src/muuli_wdr.cpp:2934
 msgid "Download the GeoIP database from the selected source."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2905
+#: src/muuli_wdr.cpp:2936
 #, fuzzy
 msgid "Auto-update on startup"
 msgstr "Azhornim-Automatik i ipfilter sapo te ndizet"
 
-#: src/muuli_wdr.cpp:2906
+#: src/muuli_wdr.cpp:2937
 msgid "Re-download the GeoIP database from the selected source every time aMule starts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2929
+#: src/muuli_wdr.cpp:2960
 msgid "Filter incoming messages (except current chat):"
 msgstr "Filtron mesazhet ne hyrje (pervec chatit qe po zhvilloni):"
 
-#: src/muuli_wdr.cpp:2931
+#: src/muuli_wdr.cpp:2962
 msgid "Filter all messages"
 msgstr "Filtron te gjithe mesazhet"
 
-#: src/muuli_wdr.cpp:2933
+#: src/muuli_wdr.cpp:2964
 msgid "Filter messages from people not on your friend list"
 msgstr "Filtron mesazhet nga njerezit qe nuk ndohen ne listen e miqve tuaj"
 
-#: src/muuli_wdr.cpp:2935
+#: src/muuli_wdr.cpp:2966
 msgid "Filter messages from unknown clients"
 msgstr "Filtron mesazhet nga klienta t èanjohur"
 
-#: src/muuli_wdr.cpp:2937
+#: src/muuli_wdr.cpp:2968
 msgid "Filter messages containing (use ',' as separator):"
 msgstr "Filtron mesazhet qe permbajne (perdor ',' si nje ndarese):"
 
-#: src/muuli_wdr.cpp:2940 src/muuli_wdr.cpp:2951
+#: src/muuli_wdr.cpp:2971 src/muuli_wdr.cpp:2982
 msgid "add here the words amule should filter and block messages including it"
 msgstr "shto ketu fjalet qe aMule do te filtroje duke bllokuar mesazhet qe ato mbajne"
 
-#: src/muuli_wdr.cpp:2942
+#: src/muuli_wdr.cpp:2973
 msgid "Show received messages in the log"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2945
+#: src/muuli_wdr.cpp:2976
 msgid "Comments"
 msgstr "Komente"
 
-#: src/muuli_wdr.cpp:2948
+#: src/muuli_wdr.cpp:2979
 msgid "Filter comments containing (use ',' as separator):"
 msgstr "Komente e filtrave permbajne (perdor ',' si nje ndarese):"
 
-#: src/muuli_wdr.cpp:2973
+#: src/muuli_wdr.cpp:3004
 msgid "Enable Proxy"
 msgstr "Aktivizo Proksin(Proxy)"
 
-#: src/muuli_wdr.cpp:2974
+#: src/muuli_wdr.cpp:3005
 msgid "Enable/disable proxy support"
 msgstr "Aktivizo/C'aktivizo mbeshtetjen e Proksit(Proxy)"
 
-#: src/muuli_wdr.cpp:2977
+#: src/muuli_wdr.cpp:3008
 msgid "Proxy type:"
 msgstr "Lloji i Proksit(Proxy):"
 
-#: src/muuli_wdr.cpp:2988
+#: src/muuli_wdr.cpp:3019
 msgid "Proxy host:"
 msgstr "Hosti i Proksit(Proxy)"
 
-#: src/muuli_wdr.cpp:2991
+#: src/muuli_wdr.cpp:3022
 msgid "The proxy host name"
 msgstr "Host Name i Proksit(Proxy)"
 
-#: src/muuli_wdr.cpp:2993
+#: src/muuli_wdr.cpp:3024
 msgid "Proxy port:"
 msgstr "Porta e Proksit:"
 
-#: src/muuli_wdr.cpp:2996
+#: src/muuli_wdr.cpp:3027
 msgid "The proxy port"
 msgstr "Porta e Proksit(Proxy)"
 
-#: src/muuli_wdr.cpp:2998
+#: src/muuli_wdr.cpp:3029
 msgid "Enable authentication"
 msgstr "Aktivizo njohjen"
 
-#: src/muuli_wdr.cpp:2999
+#: src/muuli_wdr.cpp:3030
 msgid "Enable/disable username/password authentication"
 msgstr "Aktivizo/C'aktivizo emri i perdoruesit/njohja e fjalekalimit"
 
-#: src/muuli_wdr.cpp:3002
+#: src/muuli_wdr.cpp:3033
 msgid "Username: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:3005
+#: src/muuli_wdr.cpp:3036
 msgid "The username to use to connect to the proxy"
 msgstr "Emri i perdorimit qe do perdoret per tu lidhur tek Proksi(Proxy)"
 
-#: src/muuli_wdr.cpp:3007
+#: src/muuli_wdr.cpp:3038
 msgid "Password:"
 msgstr "Fjalekalimi:"
 
-#: src/muuli_wdr.cpp:3010
+#: src/muuli_wdr.cpp:3041
 msgid "The password to use to connect to the proxy"
 msgstr "Fjalekalimi per te perdorur per tu lidhur tek Proksi(Proxy)"
 
-#: src/muuli_wdr.cpp:3029
+#: src/muuli_wdr.cpp:3060
 msgid "Connect to:"
 msgstr "Lidhu me:"
 
-#: src/muuli_wdr.cpp:3038
+#: src/muuli_wdr.cpp:3069
 msgid "Login to remote amule"
 msgstr "Futu tek Remote i aMule"
 
-#: src/muuli_wdr.cpp:3043
+#: src/muuli_wdr.cpp:3074
 msgid "User name"
 msgstr "Emri i Perdoruesit"
 
-#: src/muuli_wdr.cpp:3054
+#: src/muuli_wdr.cpp:3085
 msgid "Remember those settings"
 msgstr "Mbaji mend keto rregullime"
 
-#: src/muuli_wdr.cpp:3057
+#: src/muuli_wdr.cpp:3088
 #, fuzzy
 msgid "Force ZLIB compression"
 msgstr "Perdor kompresimin gzip"
 
-#: src/muuli_wdr.cpp:3081
+#: src/muuli_wdr.cpp:3112
 msgid "Enable Verbose Debug-Logging."
 msgstr "Aktivizon logging-un e detajuar te mesazheve te debug-ut."
 
-#: src/muuli_wdr.cpp:3083
+#: src/muuli_wdr.cpp:3114
 #, fuzzy
 msgid "Only to Logfile"
 msgstr "&Hap failin"
 
-#: src/muuli_wdr.cpp:3085
+#: src/muuli_wdr.cpp:3116
 msgid "Message Categories:"
 msgstr "Kategorite e Mesazheve:"
 
-#: src/muuli_wdr.cpp:3109 src/PartFileConvertDlg.cpp:160
+#: src/muuli_wdr.cpp:3140 src/PartFileConvertDlg.cpp:160
 msgid "Waiting..."
 msgstr "Ne pritje..."
 
-#: src/muuli_wdr.cpp:3129
+#: src/muuli_wdr.cpp:3160
 msgid "Add imports"
 msgstr "Shton importimet"
 
-#: src/muuli_wdr.cpp:3132
+#: src/muuli_wdr.cpp:3163
 msgid "Retry selected"
 msgstr "Provoji perseri te perzgjedhurit"
 
-#: src/muuli_wdr.cpp:3134
+#: src/muuli_wdr.cpp:3165
 msgid "Remove selected"
 msgstr "Zhvendos te perzgjedhurat"
 
-#: src/muuli_wdr.cpp:3197
+#: src/muuli_wdr.cpp:3228
 msgid "Event Types"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3216
+#: src/muuli_wdr.cpp:3247
 msgid "Statistics and queued clients for selected file(s) : Session / All time"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3240
+#: src/muuli_wdr.cpp:3271
 #, fuzzy
 msgid "Active Uploads"
 msgstr "Ngarkime Aktive :"
 
-#: src/muuli_wdr.cpp:3254
+#: src/muuli_wdr.cpp:3285
 msgid "Percent of total files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3306
+#: src/muuli_wdr.cpp:3337
 #, fuzzy
 msgid "Show Clients for"
 msgstr "Trego klientet"
 
-#: src/muuli_wdr.cpp:3308
+#: src/muuli_wdr.cpp:3339
 #, fuzzy
 msgid "All files"
 msgstr "Fshih failet e ndara"
 
-#: src/muuli_wdr.cpp:3311
+#: src/muuli_wdr.cpp:3342
 #, fuzzy
 msgid "Selected files"
 msgstr "Zgjidh filtrin e shikimit"
 
-#: src/muuli_wdr.cpp:3314
+#: src/muuli_wdr.cpp:3345
 #, fuzzy
 msgid "Active uploads only"
 msgstr "Ngarkime Aktive"
 
-#: src/muuli_wdr.cpp:3321
+#: src/muuli_wdr.cpp:3352
 #, fuzzy
 msgid "Reload:"
 msgstr "Lista e Ringarkimeve"
 
-#: src/muuli_wdr.cpp:3325
+#: src/muuli_wdr.cpp:3356
 msgid "Reload your shared files"
 msgstr "Ringarko failet e ndara"
 
-#: src/muuli_wdr.cpp:3388
+#: src/muuli_wdr.cpp:3419
 msgid "Send"
 msgstr "Dergo"
 
-#: src/muuli_wdr.cpp:3389
+#: src/muuli_wdr.cpp:3420
 msgid "Sends the specified message."
 msgstr "Dergo mesazhin e specifikuar."
 
-#: src/muuli_wdr.cpp:3393
+#: src/muuli_wdr.cpp:3424
 msgid "Close this chat-session."
 msgstr "Mbylle kete sesion chati."
 
-#: src/muuli_wdr.cpp:3416
+#: src/muuli_wdr.cpp:3447
 msgid "Connect to any server and/or Kad"
 msgstr "Lidhu me ndonje server dhe/ose Kad"
 
-#: src/muuli_wdr.cpp:3422 src/SharedFilesCtrl.cpp:142 src/Statistics.cpp:941
+#: src/muuli_wdr.cpp:3453 src/SharedFilesCtrl.cpp:142 src/Statistics.cpp:941
 msgid "Shared Files"
 msgstr "File te ndara"
 
@@ -5464,268 +5492,268 @@ msgstr ""
 msgid "ERROR: Failed to open partfile '%s'"
 msgstr ""
 
-#: src/Preferences.cpp:674
+#: src/Preferences.cpp:701
 msgid "System default"
 msgstr "E vendosur nga sistemi"
 
-#: src/Preferences.cpp:675
+#: src/Preferences.cpp:702
 msgid "Albanian"
 msgstr "Shqip"
 
-#: src/Preferences.cpp:676
+#: src/Preferences.cpp:703
 msgid "Arabic"
 msgstr "Arabe"
 
-#: src/Preferences.cpp:677
+#: src/Preferences.cpp:704
 #, fuzzy
 msgid "Asturian"
 msgstr "Estoneze"
 
-#: src/Preferences.cpp:678
+#: src/Preferences.cpp:705
 msgid "Basque"
 msgstr "Baske"
 
-#: src/Preferences.cpp:679
+#: src/Preferences.cpp:706
 msgid "Bulgarian"
 msgstr "Bullgare"
 
-#: src/Preferences.cpp:680
+#: src/Preferences.cpp:707
 msgid "Catalan"
 msgstr "Katallanase"
 
-#: src/Preferences.cpp:681
+#: src/Preferences.cpp:708
 msgid "Chinese (Simplified)"
 msgstr "Kineze (E thjeshtesuar)"
 
-#: src/Preferences.cpp:682
+#: src/Preferences.cpp:709
 msgid "Chinese (Traditional)"
 msgstr "KIneze (Tradicionale)"
 
-#: src/Preferences.cpp:683
+#: src/Preferences.cpp:710
 msgid "Croatian"
 msgstr "Kroate"
 
-#: src/Preferences.cpp:684
+#: src/Preferences.cpp:711
 msgid "Czech"
 msgstr "Ceke"
 
-#: src/Preferences.cpp:685
+#: src/Preferences.cpp:712
 msgid "Danish"
 msgstr "Daneze"
 
-#: src/Preferences.cpp:686
+#: src/Preferences.cpp:713
 msgid "Dutch"
 msgstr "Holandeze"
 
-#: src/Preferences.cpp:687
+#: src/Preferences.cpp:714
 msgid "English (U.K.)"
 msgstr "Anglisht (G.B.)"
 
-#: src/Preferences.cpp:688
+#: src/Preferences.cpp:715
 #, fuzzy
 msgid "English (U.S.)"
 msgstr "Anglisht (G.B.)"
 
-#: src/Preferences.cpp:689
+#: src/Preferences.cpp:716
 msgid "Estonian"
 msgstr "Estoneze"
 
-#: src/Preferences.cpp:690
+#: src/Preferences.cpp:717
 msgid "Finnish"
 msgstr "Finlandeze"
 
-#: src/Preferences.cpp:691
+#: src/Preferences.cpp:718
 msgid "French"
 msgstr "Frengjisht"
 
-#: src/Preferences.cpp:692
+#: src/Preferences.cpp:719
 msgid "Galician"
 msgstr "Galiciane"
 
-#: src/Preferences.cpp:693
+#: src/Preferences.cpp:720
 msgid "German"
 msgstr "Gjermanisht"
 
-#: src/Preferences.cpp:694
+#: src/Preferences.cpp:721
 msgid "Greek"
 msgstr "Greqisht"
 
-#: src/Preferences.cpp:695
+#: src/Preferences.cpp:722
 msgid "Hebrew"
 msgstr "Cifut"
 
-#: src/Preferences.cpp:696
+#: src/Preferences.cpp:723
 msgid "Hungarian"
 msgstr "Hungarisht"
 
-#: src/Preferences.cpp:697
+#: src/Preferences.cpp:724
 msgid "Italian"
 msgstr "Italiane"
 
-#: src/Preferences.cpp:698
+#: src/Preferences.cpp:725
 msgid "Japanese"
 msgstr "Japonisht"
 
-#: src/Preferences.cpp:699
+#: src/Preferences.cpp:726
 msgid "Korean"
 msgstr "Koreane"
 
-#: src/Preferences.cpp:700
+#: src/Preferences.cpp:727
 msgid "Latvian"
 msgstr ""
 
-#: src/Preferences.cpp:701
+#: src/Preferences.cpp:728
 msgid "Lithuanian"
 msgstr "Lituane"
 
-#: src/Preferences.cpp:702
+#: src/Preferences.cpp:729
 msgid "Norwegian (Nynorsk)"
 msgstr "Norvegjeze (Nynorsk)"
 
-#: src/Preferences.cpp:703
+#: src/Preferences.cpp:730
 msgid "Polish"
 msgstr "Polake"
 
-#: src/Preferences.cpp:704
+#: src/Preferences.cpp:731
 msgid "Portuguese"
 msgstr "Portugeze"
 
-#: src/Preferences.cpp:705
+#: src/Preferences.cpp:732
 msgid "Portuguese (Brazilian)"
 msgstr "Portugeze (Braziliane)"
 
-#: src/Preferences.cpp:706
+#: src/Preferences.cpp:733
 #, fuzzy
 msgid "Romanian"
 msgstr "Shqip"
 
-#: src/Preferences.cpp:707
+#: src/Preferences.cpp:734
 msgid "Russian"
 msgstr "Ruse"
 
-#: src/Preferences.cpp:708
+#: src/Preferences.cpp:735
 msgid "Slovenian"
 msgstr "Sllovene"
 
-#: src/Preferences.cpp:709
+#: src/Preferences.cpp:736
 msgid "Spanish"
 msgstr "Spanjolle"
 
-#: src/Preferences.cpp:710
+#: src/Preferences.cpp:737
 msgid "Swedish"
 msgstr "Suedeze"
 
-#: src/Preferences.cpp:711
+#: src/Preferences.cpp:738
 msgid "Turkish"
 msgstr "Turqisht"
 
-#: src/Preferences.cpp:712
+#: src/Preferences.cpp:739
 msgid "Ukrainian"
 msgstr ""
 
-#: src/Preferences.cpp:815
+#: src/Preferences.cpp:842
 #, fuzzy
 msgid "Change Language"
 msgstr "Gjuha"
 
-#: src/Preferences.cpp:879
+#: src/Preferences.cpp:906
 msgid "There are no translations installed for aMule"
 msgstr ""
 
-#: src/Preferences.cpp:880
+#: src/Preferences.cpp:907
 #, fuzzy
 msgid "No languages available"
 msgstr "Nuk eshte ne dispozicion"
 
-#: src/Preferences.cpp:1011
+#: src/Preferences.cpp:1038
 msgid "no options available"
 msgstr ""
 
-#: src/Preferences.cpp:2182
+#: src/Preferences.cpp:2227
 msgid "Invalid category found, skipping"
 msgstr ""
 
-#: src/Preferences.cpp:2351
+#: src/Preferences.cpp:2396
 msgid "TCP port can't be higher than 65532 due to server UDP socket being TCP+3"
 msgstr "Porta TCP nuk mund te jene me te medha se 65532  sepse socket i UDP eshte fiksuar ne TCP+3"
 
-#: src/Preferences.cpp:2352
+#: src/Preferences.cpp:2397
 #, c-format
 msgid "Default port will be used (%d)"
 msgstr "Do te perdoret porta e vendosur (%d)"
 
-#: src/PrefsUnifiedDlg.cpp:298 src/Statistics.cpp:866
+#: src/PrefsUnifiedDlg.cpp:300 src/Statistics.cpp:866
 msgid "Connection"
 msgstr "Lidhje"
 
-#: src/PrefsUnifiedDlg.cpp:299 src/SearchListCtrl.cpp:117
+#: src/PrefsUnifiedDlg.cpp:301 src/SearchListCtrl.cpp:117
 msgid "Directories"
 msgstr "Direktorite"
 
-#: src/PrefsUnifiedDlg.cpp:300 src/Statistics.cpp:917
+#: src/PrefsUnifiedDlg.cpp:302 src/Statistics.cpp:917
 msgid "Servers"
 msgstr "Servera"
 
-#: src/PrefsUnifiedDlg.cpp:301 src/ServerListCtrl.cpp:96
+#: src/PrefsUnifiedDlg.cpp:303 src/ServerListCtrl.cpp:96
 msgid "Files"
 msgstr "Failet"
 
-#: src/PrefsUnifiedDlg.cpp:302
+#: src/PrefsUnifiedDlg.cpp:304
 msgid "Security"
 msgstr "Sigurimi"
 
-#: src/PrefsUnifiedDlg.cpp:303
+#: src/PrefsUnifiedDlg.cpp:305
 msgid "Interface"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:310
+#: src/PrefsUnifiedDlg.cpp:312
 msgid "IP2Country"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:313
+#: src/PrefsUnifiedDlg.cpp:315
 msgid "Proxy"
 msgstr "Proksi"
 
-#: src/PrefsUnifiedDlg.cpp:314
+#: src/PrefsUnifiedDlg.cpp:316
 msgid "Filters"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:315
+#: src/PrefsUnifiedDlg.cpp:317
 msgid "Remote Controls"
 msgstr "Kontrollet e remote"
 
-#: src/PrefsUnifiedDlg.cpp:316
+#: src/PrefsUnifiedDlg.cpp:318
 msgid "Online Signature"
 msgstr "Firma online"
 
-#: src/PrefsUnifiedDlg.cpp:317
+#: src/PrefsUnifiedDlg.cpp:319
 msgid "Advanced"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:318
+#: src/PrefsUnifiedDlg.cpp:320
 msgid "Events"
 msgstr "Ngjarje"
 
-#: src/PrefsUnifiedDlg.cpp:321
+#: src/PrefsUnifiedDlg.cpp:323
 msgid "Debugging"
 msgstr "Debug"
 
-#: src/PrefsUnifiedDlg.cpp:451
+#: src/PrefsUnifiedDlg.cpp:453
 msgid ""
 "The following variables will be substituted:\n"
 "    %PARTFILE - full path to the file\n"
 "    %PARTNAME - file name only"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:472
+#: src/PrefsUnifiedDlg.cpp:474
 msgid "Tray icon support requires libayatana-appindicator3 at compile time."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:488
+#: src/PrefsUnifiedDlg.cpp:490
 msgid "Not available on Wayland: the protocol does not report when a window is minimized, so this option cannot intercept the system minimize button. Workaround: launch aMule with `GDK_BACKEND=x11` to use XWayland instead."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:534
+#: src/PrefsUnifiedDlg.cpp:536
 msgid ""
 "Do not change these setting unless you know\n"
 "what you are doing, otherwise you can easily\n"
@@ -5741,26 +5769,35 @@ msgstr ""
 "aMule do te punoje ne rregull pa modifikuarr asnje nga\n"
 "keto rregullime"
 
-#: src/PrefsUnifiedDlg.cpp:645
+#: src/PrefsUnifiedDlg.cpp:647
 #, c-format
 msgid "Failed to connect Cfg to widget with the ID %d and key %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:693
+#: src/PrefsUnifiedDlg.cpp:695
 #, c-format
 msgid "Failed to transfer data from Cfg to Widget with the ID %d and key %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:799
+#: src/PrefsUnifiedDlg.cpp:801
 msgid "The type of proxy you are connecting to"
 msgstr "Lloji i Proksit(Proxy) qe ju po lidheni"
 
-#: src/PrefsUnifiedDlg.cpp:1003
+#: src/PrefsUnifiedDlg.cpp:1020
 #, c-format
 msgid "Failed to transfer data from Widget to Cfg with the ID %d and key %s"
 msgstr ""
 
 #: src/PrefsUnifiedDlg.cpp:1103
+#, fuzzy
+msgid "No password set."
+msgstr "Duke kerkuar fjalekalimin\n"
+
+#: src/PrefsUnifiedDlg.cpp:1132
+msgid "Guest access needs a password. Type one in the guest password field, or untick Enable guest access."
+msgstr ""
+
+#: src/PrefsUnifiedDlg.cpp:1144
 msgid ""
 "aMule must be restarted to enable these changes:\n"
 "\n"
@@ -5768,51 +5805,51 @@ msgstr ""
 "aMule duhet qe te ristartohet qe keto ndryshime te aplikohen:\n"
 " \n"
 
-#: src/PrefsUnifiedDlg.cpp:1110
+#: src/PrefsUnifiedDlg.cpp:1151
 msgid "- TCP port changed.\n"
 msgstr "Porta TCP eshte ndryshuar.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1115
+#: src/PrefsUnifiedDlg.cpp:1156
 msgid "- UDP port changed.\n"
 msgstr "Porta UDP eshte ndryshuar.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1120
+#: src/PrefsUnifiedDlg.cpp:1161
 #, fuzzy
 msgid "- Network interface binding changed.\n"
 msgstr "Lidhja e jashtme u mbyll."
 
-#: src/PrefsUnifiedDlg.cpp:1125
+#: src/PrefsUnifiedDlg.cpp:1166
 #, fuzzy
 msgid "- External connect port changed.\n"
 msgstr "Lidhja e jashtme u mbyll."
 
-#: src/PrefsUnifiedDlg.cpp:1129
+#: src/PrefsUnifiedDlg.cpp:1170
 #, fuzzy
 msgid "- External connect acceptance changed.\n"
 msgstr "U pranua nje lidhje e jashtme e re"
 
-#: src/PrefsUnifiedDlg.cpp:1133
+#: src/PrefsUnifiedDlg.cpp:1174
 #, fuzzy
 msgid "- External connect interface changed.\n"
 msgstr "Lidhja e jashtme u mbyll."
 
-#: src/PrefsUnifiedDlg.cpp:1137
+#: src/PrefsUnifiedDlg.cpp:1178
 #, fuzzy
 msgid "- Protocol obfuscation support changed.\n"
 msgstr "Protokolli i Turbullimit"
 
-#: src/PrefsUnifiedDlg.cpp:1151
+#: src/PrefsUnifiedDlg.cpp:1193
 #, fuzzy
 msgid "- amuleapi settings changed.\n"
 msgstr "- Gjuha ndryshoi.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1160
+#: src/PrefsUnifiedDlg.cpp:1202
 msgid ""
 "Your Auto-update server list is empty.\n"
 "'Auto-update server list at startup' will be disabled."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1171
+#: src/PrefsUnifiedDlg.cpp:1213
 msgid ""
 "You have enabled external connections but have not specified a password.\n"
 "External connections cannot be enabled unless a valid password is specified."
@@ -5820,35 +5857,40 @@ msgstr ""
 "Ju keni lejuar lidhjet e jashtme por nuk keni specifikuar nje fjalekalim.\n"
 "Lidhjet e jashtme nuk mund te lejohen derisa te specifikohet nje fjalekalim."
 
-#: src/PrefsUnifiedDlg.cpp:1202
+#: src/PrefsUnifiedDlg.cpp:1246
+#, c-format
+msgid "The amuleapi password could not be saved: %s"
+msgstr ""
+
+#: src/PrefsUnifiedDlg.cpp:1276
 msgid "- Language changed.\n"
 msgstr "- Gjuha ndryshoi.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1207
+#: src/PrefsUnifiedDlg.cpp:1281
 msgid "- Temp folder changed.\n"
 msgstr "Kartela Temp ndryshoi.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1212
+#: src/PrefsUnifiedDlg.cpp:1286
 #, fuzzy
 msgid "- ED2K network enabled.\n"
 msgstr "Te gjithe rrjetet jane c'aktivizuar."
 
-#: src/PrefsUnifiedDlg.cpp:1245
+#: src/PrefsUnifiedDlg.cpp:1319
 msgid "The shared-file exclusion pattern is not a valid regular expression. The filter has been left disabled."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1247 src/PrefsUnifiedDlg.cpp:1841
+#: src/PrefsUnifiedDlg.cpp:1321 src/PrefsUnifiedDlg.cpp:1921
 #, fuzzy
 msgid "Invalid regular expression"
 msgstr "Version protokoli jo i rregullt."
 
-#: src/PrefsUnifiedDlg.cpp:1324
+#: src/PrefsUnifiedDlg.cpp:1398
 msgid ""
 "Both eD2k and Kad network are disabled.\n"
 "You won't be able to connect until you enable at least one of them."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1329
+#: src/PrefsUnifiedDlg.cpp:1403
 msgid ""
 "Kad will not start if your UDP port is disabled.\n"
 "Enable UDP port or disable Kad."
@@ -5856,7 +5898,7 @@ msgstr ""
 "Kad nuk mund te filloje nqs porta juaj UDP eshte c'aktivizuar.\n"
 "Aktivizoni porten UDP ose c'aktivizoni Kad-in."
 
-#: src/PrefsUnifiedDlg.cpp:1385
+#: src/PrefsUnifiedDlg.cpp:1459
 msgid ""
 "\n"
 "You MUST restart aMule now.\n"
@@ -5866,69 +5908,69 @@ msgstr ""
 "Ju duhet te ristartoni aMule-n tani.\n"
 "Nqs nuk e ristartoni tani mos u anko nqs te ndodh dicka e keqe.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1450
+#: src/PrefsUnifiedDlg.cpp:1524
 msgid "Could not register aMule for autostart at login. The autostart store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1452
+#: src/PrefsUnifiedDlg.cpp:1526
 msgid "Could not remove the autostart-at-login entry."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1453
+#: src/PrefsUnifiedDlg.cpp:1527
 #, fuzzy
 msgid "Autostart"
 msgstr "Rifreskimi Automatik filloi"
 
-#: src/PrefsUnifiedDlg.cpp:1468
+#: src/PrefsUnifiedDlg.cpp:1542
 msgid "Register file type"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1468
+#: src/PrefsUnifiedDlg.cpp:1542
 msgid "Register URL handler"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1476
+#: src/PrefsUnifiedDlg.cpp:1550
 #, c-format
 msgid "aMule only handles eD2k-compatible magnets. If you replace the current magnet handler (%s), BitTorrent magnet links will stop working - aMule cannot download BitTorrent content. Continue?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1481
+#: src/PrefsUnifiedDlg.cpp:1555
 #, c-format
 msgid "Another application currently opens .emulecollection files (%s). Replace it with aMule?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1486
+#: src/PrefsUnifiedDlg.cpp:1560
 #, c-format
 msgid "Another application is currently the default handler for these links (%s). Replace it with aMule?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1511
+#: src/PrefsUnifiedDlg.cpp:1585
 msgid "Could not register aMule for .emulecollection files. The registration store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1513
+#: src/PrefsUnifiedDlg.cpp:1587
 #, fuzzy
 msgid "Could not remove the file type registration."
 msgstr "Jeni duke u perpjekur te shkarkoni edhe njehere tjeter kete fail %s"
 
-#: src/PrefsUnifiedDlg.cpp:1515
+#: src/PrefsUnifiedDlg.cpp:1589
 msgid "Could not register aMule as the URL handler. The registration store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1517
+#: src/PrefsUnifiedDlg.cpp:1591
 msgid "Could not remove the URL handler registration."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1587 src/PrefsUnifiedDlg.cpp:1614
+#: src/PrefsUnifiedDlg.cpp:1661 src/PrefsUnifiedDlg.cpp:1688
 #, fuzzy
 msgid "The web server and aMule API require external connections to be enabled."
 msgstr "U pranua nje lidhje e jashtme e re"
 
-#: src/PrefsUnifiedDlg.cpp:1597
+#: src/PrefsUnifiedDlg.cpp:1671
 msgid "The aMule web server is deprecated. Consider running the aMule API instead."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1655
+#: src/PrefsUnifiedDlg.cpp:1735
 msgid ""
 "Your Auto-update servers list is in blank.\n"
 "Please fill in at least one URL to point to a valid server.met file.\n"
@@ -5938,66 +5980,66 @@ msgstr ""
 "Ju lutem mbushni te pakten nje URL te vlefshme ne failin e server.met.\n"
 "Klikoni ne butonin \"List\" per te futur nje URL."
 
-#: src/PrefsUnifiedDlg.cpp:1796
+#: src/PrefsUnifiedDlg.cpp:1876
 msgid "Temporary files"
 msgstr "Failet e perkohshme"
 
-#: src/PrefsUnifiedDlg.cpp:1801
+#: src/PrefsUnifiedDlg.cpp:1881
 msgid "Incoming files"
 msgstr "Failet e shkarkuara"
 
-#: src/PrefsUnifiedDlg.cpp:1806
+#: src/PrefsUnifiedDlg.cpp:1886
 msgid "Online Signatures"
 msgstr "Firma online"
 
-#: src/PrefsUnifiedDlg.cpp:1819
+#: src/PrefsUnifiedDlg.cpp:1899
 #, c-format
 msgid "Choose a folder for %s"
 msgstr "Zgjidhni nje kartele per %s"
 
-#: src/PrefsUnifiedDlg.cpp:1843
+#: src/PrefsUnifiedDlg.cpp:1923
 #, fuzzy, c-format
 msgid "Would exclude %u of %u shared file"
 msgid_plural "Would exclude %u of %u shared files"
 msgstr[0] "U gjend %i fail i njohur i ndare"
 msgstr[1] "U gjenden %i faile te njohura te ndara"
 
-#: src/PrefsUnifiedDlg.cpp:1860
+#: src/PrefsUnifiedDlg.cpp:1940
 msgid "Browse for videoplayer"
 msgstr "Shfletoni per nje videoplayer"
 
-#: src/PrefsUnifiedDlg.cpp:1864
+#: src/PrefsUnifiedDlg.cpp:1944
 msgid "Select browser"
 msgstr "Perzgjidhni shfletuesin"
 
-#: src/PrefsUnifiedDlg.cpp:1868
+#: src/PrefsUnifiedDlg.cpp:1948
 #, fuzzy
 msgid "Select ffprobe binary"
 msgstr "Perzgjidhni shfletuesin"
 
-#: src/PrefsUnifiedDlg.cpp:1874
+#: src/PrefsUnifiedDlg.cpp:1954
 #, c-format
 msgid "Executable%s"
 msgstr "Te ekzekutueshme%s"
 
-#: src/PrefsUnifiedDlg.cpp:1908
+#: src/PrefsUnifiedDlg.cpp:1988
 msgid "ffprobe not found on PATH or in the standard install locations. Install ffmpeg (which ships ffprobe) or use Browse to pick a binary manually."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1920
+#: src/PrefsUnifiedDlg.cpp:2000
 msgid "Reset the settings on this page to their default values?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1921
+#: src/PrefsUnifiedDlg.cpp:2001
 #, fuzzy
 msgid "Reset to defaults"
 msgstr "E vendosur nga sistemi"
 
-#: src/PrefsUnifiedDlg.cpp:1948
+#: src/PrefsUnifiedDlg.cpp:2028
 msgid "Edit server list"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1949
+#: src/PrefsUnifiedDlg.cpp:2029
 msgid ""
 "Add here URL's to download server.met files.\n"
 "Only one url on each line."
@@ -6005,155 +6047,155 @@ msgstr ""
 "Futni ketu URL-te per te shkarkuar failet server.met.\n"
 "Vetem nga nje URL per c'do linje."
 
-#: src/PrefsUnifiedDlg.cpp:2004
+#: src/PrefsUnifiedDlg.cpp:2084
 msgid "IP2Country update failed"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2149 src/PrefsUnifiedDlg.cpp:2180
+#: src/PrefsUnifiedDlg.cpp:2229 src/PrefsUnifiedDlg.cpp:2260
 msgid "Data by MaxMind GeoLite2"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2151 src/PrefsUnifiedDlg.cpp:2182
+#: src/PrefsUnifiedDlg.cpp:2231 src/PrefsUnifiedDlg.cpp:2262
 #, fuzzy
 msgid "Custom source"
 msgstr "Burime te kompletuara"
 
-#: src/PrefsUnifiedDlg.cpp:2153 src/PrefsUnifiedDlg.cpp:2184
+#: src/PrefsUnifiedDlg.cpp:2233 src/PrefsUnifiedDlg.cpp:2264
 msgid "Data by DB-IP.com"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2204
+#: src/PrefsUnifiedDlg.cpp:2284
 #, fuzzy, c-format
 msgid "Status: Loaded%s"
 msgstr "Statusi:"
 
-#: src/PrefsUnifiedDlg.cpp:2206
+#: src/PrefsUnifiedDlg.cpp:2286
 #, fuzzy, c-format
 msgid "Status: Loaded%s - %s"
 msgstr "Statusi:"
 
-#: src/PrefsUnifiedDlg.cpp:2210
+#: src/PrefsUnifiedDlg.cpp:2290
 msgid "Status: Failed to load - click 'Update now' to refresh."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2212
+#: src/PrefsUnifiedDlg.cpp:2292
 msgid "Status: Not found - click 'Update now' to download."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2270 src/PrefsUnifiedDlg.cpp:2294
+#: src/PrefsUnifiedDlg.cpp:2350 src/PrefsUnifiedDlg.cpp:2374
 #, c-format
 msgid "Update delay: %d second"
 msgid_plural "Update delay: %d seconds"
 msgstr[0] "Intervali i azhornimit: %d sekonde"
 msgstr[1] "Intervali i azhornimit: %d sekonda"
 
-#: src/PrefsUnifiedDlg.cpp:2278
+#: src/PrefsUnifiedDlg.cpp:2358
 #, c-format
 msgid "Time for average graph: %d minute"
 msgid_plural "Time for average graph: %d minutes"
 msgstr[0] "Koha per mesataren grafike: %d minute"
 msgstr[1] "Koha per mesataren grafike: %d minuta"
 
-#: src/PrefsUnifiedDlg.cpp:2287
+#: src/PrefsUnifiedDlg.cpp:2367
 #, c-format
 msgid "Connections Graph Scale: %d"
 msgstr "Shkalla grafike e lidhjeve: %d"
 
-#: src/PrefsUnifiedDlg.cpp:2302
+#: src/PrefsUnifiedDlg.cpp:2382
 #, c-format
 msgid "File Buffer Size: %d byte"
 msgid_plural "File Buffer Size: %d bytes"
 msgstr[0] "Madhesia buffer e failit: %d byte"
 msgstr[1] "Madesia Buffer e failit: %d bytes"
 
-#: src/PrefsUnifiedDlg.cpp:2312
+#: src/PrefsUnifiedDlg.cpp:2392
 #, c-format
 msgid "Upload Queue Size: %d client"
 msgid_plural "Upload Queue Size: %d clients"
 msgstr[0] "Madhesia e radhes se ngarkimit: %d klienti"
 msgstr[1] "Madhesia e radhes se ngarkimit: %d klientet"
 
-#: src/PrefsUnifiedDlg.cpp:2322
+#: src/PrefsUnifiedDlg.cpp:2402
 #, c-format
 msgid "Server connection refresh interval: %d minute"
 msgid_plural "Server connection refresh interval: %d minutes"
 msgstr[0] "Intervali i rifreskimit te lidhjeve te serverit: %d minute"
 msgstr[1] "Intervali i rifreskimit te lidhjeve te serverit: %d minuta"
 
-#: src/PrefsUnifiedDlg.cpp:2327
+#: src/PrefsUnifiedDlg.cpp:2407
 msgid "Server connection refresh interval: Disabled"
 msgstr "Intervali i rifreskimit te lidhjeve te serverit: I c'aktivizuar"
 
-#: src/PrefsUnifiedDlg.cpp:2371
+#: src/PrefsUnifiedDlg.cpp:2451
 #, fuzzy
 msgid "disabled"
 msgstr "c'aktivizo"
 
-#: src/PrefsUnifiedDlg.cpp:2397
+#: src/PrefsUnifiedDlg.cpp:2477
 #, fuzzy, c-format
 msgid "Execute command on '%s' event"
 msgstr "Ekzekuto komanden ne kete ngjarje `%s' "
 
-#: src/PrefsUnifiedDlg.cpp:2404
+#: src/PrefsUnifiedDlg.cpp:2484
 msgid "Enable command execution on core"
 msgstr "Lejo ekzekutimin e komandes ne core"
 
-#: src/PrefsUnifiedDlg.cpp:2416
+#: src/PrefsUnifiedDlg.cpp:2496
 msgid "Core command:"
 msgstr "KOmanda Core:"
 
-#: src/PrefsUnifiedDlg.cpp:2432
+#: src/PrefsUnifiedDlg.cpp:2512
 msgid "Enable command execution on GUI"
 msgstr "Lejo ekzekutimin e komandes ne GUI"
 
-#: src/PrefsUnifiedDlg.cpp:2444
+#: src/PrefsUnifiedDlg.cpp:2524
 msgid "GUI command:"
 msgstr "Komanda GUI:"
 
-#: src/PrefsUnifiedDlg.cpp:2460
+#: src/PrefsUnifiedDlg.cpp:2540
 msgid "The following variables will be replaced:"
 msgstr "Variacionet qe vijojne do te rivendosen:"
 
-#: src/PrefsUnifiedDlg.cpp:2628
+#: src/PrefsUnifiedDlg.cpp:2708
 msgid ""
 "The following folders look like system or sensitive locations:\n"
 "\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2633
+#: src/PrefsUnifiedDlg.cpp:2713
 msgid "Sharing them recursively will publish every file underneath on the eD2k/Kad networks. Do you really want to do this?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2636
+#: src/PrefsUnifiedDlg.cpp:2716
 #, fuzzy
 msgid "Confirm shared folders"
 msgstr "Ringarko failet e ndara"
 
-#: src/PrefsUnifiedDlg.cpp:2664
+#: src/PrefsUnifiedDlg.cpp:2744
 #, fuzzy
 msgid "Reloading shared files..."
 msgstr "Ringarko failet e ndara"
 
-#: src/PrefsUnifiedDlg.cpp:2665
+#: src/PrefsUnifiedDlg.cpp:2745
 msgid "Scanning for subdirectories..."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2666
+#: src/PrefsUnifiedDlg.cpp:2746
 #, fuzzy
 msgid "Updating shared folders"
 msgstr "Duke lexuar kartelen temp"
 
-#: src/PrefsUnifiedDlg.cpp:2693
+#: src/PrefsUnifiedDlg.cpp:2773
 #, c-format
 msgid "Scanned %u directories..."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2743
+#: src/PrefsUnifiedDlg.cpp:2823
 #, fuzzy, c-format
 msgid "Reloading shared files: %u files scanned"
 msgstr "Ringarko listen e faileve te ndara."
 
-#: src/PrefsUnifiedDlg.cpp:2793
+#: src/PrefsUnifiedDlg.cpp:2873
 #, fuzzy
 msgid "Shared folder"
 msgstr "File te ndara"

--- a/po/sq.po
+++ b/po/sq.po
@@ -10,8 +10,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-28 12:12+0200\n"
-"PO-Revision-Date: 2026-07-27 10:34+0000\n"
+"POT-Creation-Date: 2026-07-28 08:06+0200\n"
+"PO-Revision-Date: 2026-07-27 11:45+0000\n"
 "Last-Translator: Fation <dj_barthezz@linuxmail.org lushnja_corps@hotmail.Language-Team:\n"
 "Language: sq\n"
 "MIME-Version: 1.0\n"
@@ -141,7 +141,7 @@ msgstr ""
 msgid "Not now"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:422 src/amuleDlg.cpp:665
+#: src/AppImageIntegration.cpp:422 src/amuleDlg.cpp:600
 msgid "Don't ask again"
 msgstr ""
 
@@ -200,160 +200,160 @@ msgstr "Deshtoi ne hapjen %s (%s)"
 msgid "WARNING: You can't add yourself as a source for an eD2k link while having a lowid."
 msgstr ""
 
-#: src/amule.cpp:301
+#: src/amule.cpp:300
 #, fuzzy
 msgid "Now, exiting main app..."
 msgstr ""
 "\n"
 "Ne rregull, duke dalur %s...\n"
 
-#: src/amule.cpp:331
+#: src/amule.cpp:330
 #, c-format
 msgid "Terminating amuleweb instance with pid '%d' ... "
 msgstr ""
 
-#: src/amule.cpp:335
+#: src/amule.cpp:334
 #, c-format
 msgid "Killing amuleweb instance with pid '%d' ... "
 msgstr ""
 
-#: src/amule.cpp:337 src/amule.cpp:350 src/ClientRef.cpp:180
-#: src/SearchDlg.cpp:1041 src/ServerListCtrl.cpp:98
+#: src/amule.cpp:336 src/amule.cpp:349 src/ClientRef.cpp:180
+#: src/SearchDlg.cpp:880 src/ServerListCtrl.cpp:98
 msgid "Failed"
 msgstr "E Deshtuar"
 
-#: src/amule.cpp:344
+#: src/amule.cpp:343
 #, c-format
 msgid "Terminating amuleapi instance with pid '%d' ... "
 msgstr ""
 
-#: src/amule.cpp:348
+#: src/amule.cpp:347
 #, c-format
 msgid "Killing amuleapi instance with pid '%d' ... "
 msgstr ""
 
-#: src/amule.cpp:356
+#: src/amule.cpp:355
 msgid "aMule OnExit: Terminating core."
 msgstr ""
 
-#: src/amule.cpp:467
+#: src/amule.cpp:466
 #, fuzzy
 msgid "aMule shutdown completed."
 msgstr "Shkarkimi Perfundoi"
 
-#: src/amule.cpp:471
+#: src/amule.cpp:470
 msgid "Memory debug results for aMule exit:"
 msgstr ""
 
-#: src/amule.cpp:652
+#: src/amule.cpp:651
 #, c-format
 msgid "Binding aMule's peer-to-peer traffic to interface: %s (HTTP updates use the default route)"
 msgstr ""
 
-#: src/amule.cpp:656
+#: src/amule.cpp:655
 #, c-format
 msgid "Binding all network traffic to interface: %s"
 msgstr ""
 
-#: src/amule.cpp:660
+#: src/amule.cpp:659
 #, c-format
 msgid "WARNING: configured network interface '%s' was not found - traffic is NOT bound to it and may leave via the default route. Check the interface name in Preferences."
 msgstr ""
 
-#: src/amule.cpp:666
+#: src/amule.cpp:665
 #, c-format
 msgid "WARNING: binding to network interface '%s' requires elevated privileges and was NOT applied - traffic may leave via the default route. Grant the capability (e.g. 'sudo setcap cap_net_raw+ep' on the aMule binary) or run with sufficient privileges."
 msgstr ""
 
-#: src/amule.cpp:674
+#: src/amule.cpp:673
 #, c-format
 msgid "WARNING: could not bind to network interface '%s' - traffic may leave via the default route."
 msgstr ""
 
-#: src/amule.cpp:733
+#: src/amule.cpp:732
 msgid "Your locale has been changed to System Default due to a configuration change. Sorry."
 msgstr "Vendndodhja juaj eshte ndryshuar tek System Default i pershtatur per nje nderrim konfigurimi. Me vjen keq."
 
-#: src/amule.cpp:735 src/amule.cpp:1589 src/CatDialog.cpp:128
+#: src/amule.cpp:734 src/amule.cpp:1581 src/CatDialog.cpp:128
 #: src/CatDialog.cpp:136 src/CatDialog.cpp:149 src/ServerList.cpp:366
 #: src/ServerListCtrl.cpp:152
 msgid "Info"
 msgstr "Informacion"
 
-#: src/amule.cpp:742
+#: src/amule.cpp:741
 #, fuzzy
 msgid ""
 "\n"
 "EC configuration"
 msgstr "Konfirmimi i daljes"
 
-#: src/amule.cpp:745
+#: src/amule.cpp:744
 #, fuzzy
 msgid "Password set and external connections enabled."
 msgstr "U pranua nje lidhje e jashtme e re"
 
-#: src/amule.cpp:755 src/KadDlg.cpp:176 src/KadDlg.cpp:185
-#: src/PrefsUnifiedDlg.cpp:1461 src/SharedFilesCtrl.cpp:476
+#: src/amule.cpp:754 src/KadDlg.cpp:176 src/KadDlg.cpp:185
+#: src/PrefsUnifiedDlg.cpp:1387 src/SharedFilesCtrl.cpp:476
 msgid "WARNING"
 msgstr "KUJDES"
 
-#: src/amule.cpp:992
+#: src/amule.cpp:991
 #, fuzzy
 msgid "Network bootstrap"
 msgstr "Rrjetet"
 
-#: src/amule.cpp:997
+#: src/amule.cpp:996
 msgid ""
 "aMule has detected missing network bootstrap files.\n"
 "Select which ones to download:"
 msgstr ""
 
-#: src/amule.cpp:1006 src/FirstRunWizard.cpp:411
+#: src/amule.cpp:1005 src/FirstRunWizard.cpp:411
 #, fuzzy
 msgid "eD2k server list (server.met)"
 msgstr "%i u gjet server ne server.met"
 
-#: src/amule.cpp:1013 src/FirstRunWizard.cpp:416
+#: src/amule.cpp:1012 src/FirstRunWizard.cpp:416
 msgid "Kad bootstrap nodes (nodes.dat)"
 msgstr ""
 
-#: src/amule.cpp:1103
+#: src/amule.cpp:1102
 #, c-format
 msgid "web server running on pid %d"
 msgstr ""
 
-#: src/amule.cpp:1116
+#: src/amule.cpp:1115
 msgid "You requested to run web server on startup, but the amuleweb binary cannot be run. Please install the package containing aMule web server, or build aMule from source with -DBUILD_WEBSERVER=YES and install it."
 msgstr ""
 
-#: src/amule.cpp:1121 src/amule.cpp:1185 src/amule.cpp:1299 src/amule.cpp:1601
+#: src/amule.cpp:1120 src/amule.cpp:1177 src/amule.cpp:1291 src/amule.cpp:1593
 #: src/amule-remote-gui.cpp:603 src/amule-remote-gui.cpp:671
 #: src/amule-remote-gui.cpp:709 src/amule-remote-gui.cpp:1282
 #: src/amule-remote-gui.cpp:1345 src/amule-remote-gui.cpp:1372
-#: src/DownloadQueue.cpp:1481 src/PrefsUnifiedDlg.cpp:1247
+#: src/DownloadQueue.cpp:1481
 msgid "ERROR"
 msgstr ""
 
-#: src/amule.cpp:1174
+#: src/amule.cpp:1166
 #, fuzzy, c-format
 msgid "amuleapi running on pid %d"
 msgstr "aMule eshte duke punuar"
 
-#: src/amule.cpp:1180
+#: src/amule.cpp:1172
 msgid "You requested to run amuleapi on startup, but the amuleapi binary cannot be run. Please install the package containing aMule's REST API server, or build aMule from source with -DBUILD_AMULEAPI=YES and install it."
 msgstr ""
 
-#: src/amule.cpp:1267
+#: src/amule.cpp:1259
 #, c-format
 msgid "Could not bind ports to the specified address: %s"
 msgstr "Nuk mund te lidh portat tek adresa e dhene: %s"
 
-#: src/amule.cpp:1291
+#: src/amule.cpp:1283
 #, c-format
 msgid "Port %u is not available. You will be LOWID\n"
 msgstr "Porta %u nuk eshte me vlere. Ju do te keni ID te ulet\n"
 
-#: src/amule.cpp:1296
+#: src/amule.cpp:1288
 #, c-format
 msgid ""
 "Port %u is not available!\n"
@@ -368,48 +368,48 @@ msgstr ""
 "\n"
 "KOntrolloni rrjetin tuaj per tu siguruar qe porta eshte hapur per hyrje dhe dalje."
 
-#: src/amule.cpp:1393
+#: src/amule.cpp:1385
 msgid "Failed to create OnlineSig File"
 msgstr "Deshtoi te krijoje failin per Firmen Online"
 
-#: src/amule.cpp:1401
+#: src/amule.cpp:1393
 msgid "Failed to create aMule OnlineSig File"
 msgstr "Deshtoi te krijoje failin per Firmen Online te aMule-s"
 
-#: src/amule.cpp:1564
+#: src/amule.cpp:1556
 msgid "The selected locale seems not to be installed on your box. (Note: I'll try to set it anyway)"
 msgstr "Vendi i zgjedur duket se nuk do te instalohet ne kutine tuaj. (Shenim: Une do te mundohem ta vendos ate)"
 
-#: src/amule.cpp:1574
+#: src/amule.cpp:1566
 #, c-format
 msgid "This is the first time you run aMule %s"
 msgstr "Kjo eshte hera e pare qe ju po persorni aMule %s"
 
-#: src/amule.cpp:1577
+#: src/amule.cpp:1569
 msgid "This version is a testing version, updated daily, and\n"
 msgstr "Ky eshte nje version per testim,i azhornuar per dite, dhe\n"
 
-#: src/amule.cpp:1578
+#: src/amule.cpp:1570
 msgid "we give no warranty it won't break anything, burn your house,\n"
 msgstr "ne nuk japim siguri per te ai nuk do te thyej asgje,nuk do te djegi shtepine tuaj,\n"
 
-#: src/amule.cpp:1579
+#: src/amule.cpp:1571
 msgid "or kill your dog. But it *should* be safe to use anyway.\n"
 msgstr "ose te vrasi qenin tuaj. Por ai *do te* behet i sigurte per tu perdorur.\n"
 
-#: src/amule.cpp:1584
+#: src/amule.cpp:1576
 msgid "More information, support and new releases can found at our homepage,\n"
 msgstr "Me shume informacion,mbeshtetje dhe leshime te reja do ti gjeni tek faqet tona,\n"
 
-#: src/amule.cpp:1585
+#: src/amule.cpp:1577
 msgid "at https://amule-org.github.io, or in our IRC channel #aMule at irc.libera.chat.\n"
 msgstr "tek amule-org.github.io ose ne kanalin tone IRC #amule tek irc.libera.chat.\n"
 
-#: src/amule.cpp:1587
+#: src/amule.cpp:1579
 msgid "Feel free to report any bugs to https://github.com/amule-org/amule/issues"
 msgstr "Raportoni cdo gabim tek https://github.com/amule-org/amule/issues"
 
-#: src/amule.cpp:1599
+#: src/amule.cpp:1591
 msgid ""
 "The folder for Online Signature files you specified is INVALID!\n"
 " OnlineSignature will be DISABLED until you fix it on preferences."
@@ -417,138 +417,138 @@ msgstr ""
 "Kartela e faileve per Firmen Online qe ju specifikuat eshte e PAVLERE!\n"
 " Firma Online do te C'AKTIVIZOHET deri sa ju ta rregulloni tek Preferencat."
 
-#: src/amule.cpp:1662
+#: src/amule.cpp:1654
 #, fuzzy
 msgid "Server hostname notified"
 msgstr "Emri i Serverit:"
 
-#: src/amule.cpp:2039
+#: src/amule.cpp:2031
 #, c-format
 msgid "Disk space preallocation for file '%s' failed: %s"
 msgstr ""
 
-#: src/amule.cpp:2168
+#: src/amule.cpp:2160
 msgid "ERROR: can't open logfile"
 msgstr "GABIM: nuk mund te hapet logfile"
 
-#: src/amule.cpp:2172
+#: src/amule.cpp:2164
 msgid "WARNING: logfile is empty. Something is wrong."
 msgstr "KUJDES: faili i log-ve eshte bosh. Dicka nuk shkon."
 
-#: src/amule.cpp:2189
+#: src/amule.cpp:2181
 msgid "Log has been reset"
 msgstr "Faili i Log eshte risetuar"
 
-#: src/amule.cpp:2213
+#: src/amule.cpp:2205
 #, c-format
 msgid "ServerMessage: %s"
 msgstr "Mesazhe nga Serveri: %s"
 
-#: src/amule.cpp:2256 src/IP2Country.cpp:220 src/IPFilter.cpp:514
+#: src/amule.cpp:2248 src/IP2Country.cpp:220 src/IPFilter.cpp:514
 #: src/ServerList.cpp:875
 #, c-format
 msgid "Skipped download of %s, because requested file is not newer."
 msgstr ""
 
-#: src/amule.cpp:2259
+#: src/amule.cpp:2251
 msgid "Failed to download the nodes list."
 msgstr "Deshtoi ne shkarkimin e listave nod."
 
-#: src/amule.cpp:2322
+#: src/amule.cpp:2314
 msgid "Failed to open the downloaded version check file"
 msgstr "Deshtoi te hapi failin per kontrollin e versionit qe sapo shkarkuat"
 
-#: src/amule.cpp:2325 src/amule.cpp:2344
+#: src/amule.cpp:2317 src/amule.cpp:2336
 msgid "Corrupted version check file"
 msgstr "Fili per kontrollin e versionit eshte i demtuar"
 
-#: src/amule.cpp:2367
+#: src/amule.cpp:2359
 msgid "You are using an outdated version of aMule!"
 msgstr "Ju po perdorni nje version te vjeter te aMule!"
 
-#: src/amule.cpp:2369
+#: src/amule.cpp:2361
 #, c-format
 msgid "Your aMule version is %i.%i.%i and the latest version is %li.%li.%li"
 msgstr "Versioni juaj i amUle eshte %i.%i-%i dhe versioni i fundit eshte %li.%li.%li"
 
-#: src/amule.cpp:2373
+#: src/amule.cpp:2365
 msgid "The latest version can always be found at https://github.com/amule-org/amule/releases/latest"
 msgstr "Versioni i fundit mund te gjendet gjithmone tek https://github.com/amule-org/amule/releases/latest"
 
-#: src/amule.cpp:2376
+#: src/amule.cpp:2368
 #, c-format
 msgid "WARNING: Your aMuled version is outdated: %i.%i.%i < %li.%li.%li"
 msgstr "KUJDES: Versioni juaj i aMule-s eshte i vjeteruar: %i.%i-%i < %li.%li.%li"
 
-#: src/amule.cpp:2382
+#: src/amule.cpp:2374
 msgid "Your copy of aMule is up to date."
 msgstr "Kopja juaj e aMule eshte azhornuar."
 
-#: src/amule.cpp:2389
+#: src/amule.cpp:2381
 msgid "Failed to download the version check file"
 msgstr "Deshtoi ne shkarkimin e failit per kontrollin e versionit"
 
-#: src/amule.cpp:2558 src/amule-remote-gui.cpp:1133
+#: src/amule.cpp:2550 src/amule-remote-gui.cpp:1133
 #, c-format
 msgid "Users: %s | Files: %s"
 msgstr ""
 
-#: src/amule.cpp:2559 src/amule-remote-gui.cpp:1134
+#: src/amule.cpp:2551 src/amule-remote-gui.cpp:1134
 #, c-format
 msgid "Users: E: %s K: %s | Files: E: %s K: %s"
 msgstr ""
 
-#: src/amule.cpp:2573 src/amule-remote-gui.cpp:1147
+#: src/amule.cpp:2565 src/amule-remote-gui.cpp:1147
 msgid "No networks selected"
 msgstr ""
 
-#: src/amule.cpp:2641 src/TextClient.cpp:903
+#: src/amule.cpp:2633 src/TextClient.cpp:903
 msgid "with LowID"
 msgstr "me ID te ulet"
 
-#: src/amule.cpp:2641 src/TextClient.cpp:904
+#: src/amule.cpp:2633 src/TextClient.cpp:904
 msgid "with HighID"
 msgstr "me ID te larte"
 
-#: src/amule.cpp:2643
+#: src/amule.cpp:2635
 #, c-format
 msgid "Connected to %s %s"
 msgstr "I lidhur tek %s %s"
 
-#: src/amule.cpp:2648
+#: src/amule.cpp:2640
 #, c-format
 msgid "Connecting to %s"
 msgstr "Duke u lidhur tek %s"
 
-#: src/amule.cpp:2650
+#: src/amule.cpp:2642
 msgid "Disconnected from eD2k"
 msgstr ""
 
-#: src/amule.cpp:2659
+#: src/amule.cpp:2651
 msgid "Kad started."
 msgstr "Kad filloi."
 
-#: src/amule.cpp:2661
+#: src/amule.cpp:2653
 msgid "Kad stopped."
 msgstr "Kad u ndalua."
 
-#: src/amule.cpp:2669
+#: src/amule.cpp:2661
 msgid "Connected to Kad (ok)"
 msgstr "I lidhur ne Kad (Ne rregull)"
 
-#: src/amule.cpp:2671
+#: src/amule.cpp:2663
 msgid "Connected to Kad (firewalled)"
 msgstr "I lidhur ne Kad (Me firewall)"
 
-#: src/amule.cpp:2675
+#: src/amule.cpp:2667
 msgid "Disconnected from Kad"
 msgstr "I shkeputur nga Kad"
 
-#: src/amule.cpp:2707
+#: src/amule.cpp:2699
 msgid "Kad network cannot be used if UDP port is disabled on preferences, not starting."
 msgstr "Rrjeti Kad nuk mund te perdoret nqs porta UDP eshte c'aktivizuar tek Preferencat, nuk po filloj."
 
-#: src/amule.cpp:2711
+#: src/amule.cpp:2703
 msgid "Kad network disabled on preferences, not connecting."
 msgstr "Rrjeti Kad eshte c'aktivizuar tek Preferencat,nuk eshte duke u lidhur."
 
@@ -574,68 +574,30 @@ msgstr ""
 msgid "ERROR: %s"
 msgstr "GABIM: %s"
 
-#: src/amuleDlg.cpp:250
+#: src/amuleDlg.cpp:236
 #, c-format
 msgid "This is aMule %s based on eMule."
 msgstr "Kjo eshte aMule %s dhe bazohet ne eMule."
 
-#: src/amuleDlg.cpp:251
+#: src/amuleDlg.cpp:237
 #, c-format
 msgid "Running on %s"
 msgstr "Duke punuar ne %s"
 
-#: src/amuleDlg.cpp:253
+#: src/amuleDlg.cpp:239
 msgid "Visit https://github.com/amule-org/amule/releases/latest to check if a new version is available."
 msgstr "Vizitoni https://github.com/amule-org/amule/releases/latest per te kontrolluar nqs eshte ne dispozicion nje version i ri."
 
-#: src/amuleDlg.cpp:282
+#: src/amuleDlg.cpp:268
 msgid "FATAL ERROR: Failed to create Timer"
 msgstr ""
 
-#: src/amuleDlg.cpp:361 src/amuleDlg.cpp:1810 src/amuleDlg.cpp:2056
-#: src/muuli_wdr.cpp:1492 src/muuli_wdr.cpp:3439
-msgid "Networks"
-msgstr "Rrjetet"
-
-#: src/amuleDlg.cpp:362 src/amuleDlg.cpp:1816 src/muuli_wdr.cpp:3440
-msgid "Searches"
-msgstr "Kerkimet"
-
-#: src/amuleDlg.cpp:363 src/amuleDlg.cpp:1822 src/DownloadListCtrl.cpp:740
-#: src/muuli_wdr.cpp:392 src/muuli_wdr.cpp:1585 src/muuli_wdr.cpp:3441
-#: src/Statistics.cpp:829
-msgid "Downloads"
-msgstr "Shkarkime"
-
-#: src/amuleDlg.cpp:364 src/amuleDlg.cpp:1828 src/muuli_wdr.cpp:3315
-msgid "Shared files"
-msgstr ""
-
-#: src/amuleDlg.cpp:365 src/amuleDlg.cpp:1834 src/muuli_wdr.cpp:2947
-#: src/muuli_wdr.cpp:3397 src/muuli_wdr.cpp:3444
-msgid "Messages"
-msgstr "Mesazhe"
-
-#: src/amuleDlg.cpp:366 src/amuleDlg.cpp:1840 src/muuli_wdr.cpp:3445
-#: src/PrefsUnifiedDlg.cpp:314 src/Statistics.cpp:779 src/Statistics.cpp:1235
-msgid "Statistics"
-msgstr "Statistikat"
-
-#: src/amuleDlg.cpp:368 src/amuleDlg.cpp:1847 src/muuli_wdr.cpp:3447
-#: src/PrefsUnifiedDlg.cpp:330 src/utils/wxCas/src/wxcasprefs.cpp:39
-msgid "Preferences"
-msgstr "Preferencat"
-
-#: src/amuleDlg.cpp:371
-msgid "Navigate"
-msgstr ""
-
-#: src/amuleDlg.cpp:657
+#: src/amuleDlg.cpp:592
 #, fuzzy
 msgid "New version available"
 msgstr "Nuk eshte ne dispozicion"
 
-#: src/amuleDlg.cpp:661
+#: src/amuleDlg.cpp:596
 #, fuzzy, c-format
 msgid ""
 "A new version of aMule (%s) is available.\n"
@@ -645,186 +607,219 @@ msgid ""
 "Would you like to open the download page?"
 msgstr "Versioni i fundit mund te gjendet gjithmone tek https://github.com/amule-org/amule/releases/latest"
 
-#: src/amuleDlg.cpp:743
+#: src/amuleDlg.cpp:678
 msgid "aMule dialog destroyed"
 msgstr ""
 
-#: src/amuleDlg.cpp:766 src/DataToText.cpp:68 src/IPFilter.cpp:547
+#: src/amuleDlg.cpp:701 src/DataToText.cpp:68 src/IPFilter.cpp:547
 msgid "Connecting"
 msgstr "Duke u lòidhur"
 
-#: src/amuleDlg.cpp:958
+#: src/amuleDlg.cpp:893
 msgid "eD2k: Connecting"
 msgstr ""
 
-#: src/amuleDlg.cpp:962
+#: src/amuleDlg.cpp:897
 msgid "eD2k: Disconnected"
 msgstr ""
 
-#: src/amuleDlg.cpp:968
+#: src/amuleDlg.cpp:903
 msgid "Kad: Firewalled"
 msgstr "Kad: Me Firewall"
 
-#: src/amuleDlg.cpp:972
+#: src/amuleDlg.cpp:907
 msgid "Kad: Connected"
 msgstr "Kad: I lidhur"
 
-#: src/amuleDlg.cpp:977
+#: src/amuleDlg.cpp:912
 msgid "Kad: Connecting"
 msgstr "Kad: Po lidhet"
 
-#: src/amuleDlg.cpp:981
+#: src/amuleDlg.cpp:916
 msgid "Kad: Off"
 msgstr "Kad: Fikur"
 
-#: src/amuleDlg.cpp:1029 src/DownloadListCtrl.cpp:505
+#: src/amuleDlg.cpp:964 src/DownloadListCtrl.cpp:505
 #: src/DownloadListCtrl.cpp:749 src/FriendListCtrl.cpp:180
 #: src/muuli_wdr.cpp:731 src/muuli_wdr.cpp:782 src/muuli_wdr.cpp:846
-#: src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2252 src/muuli_wdr.cpp:2337
-#: src/muuli_wdr.cpp:3085 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
+#: src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2224 src/muuli_wdr.cpp:2309
+#: src/muuli_wdr.cpp:3057 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
 #: src/ServerListCtrl.cpp:606 src/TransferWnd.cpp:378
 #: src/utils/wxCas/src/wxcasprefs.cpp:235
 msgid "Cancel"
 msgstr "Fshij"
 
-#: src/amuleDlg.cpp:1030
+#: src/amuleDlg.cpp:965
 msgid "Stop the current connection attempts"
 msgstr "Ndalo tentativat e lidhjes qe po behen"
 
-#: src/amuleDlg.cpp:1035 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976
-#: src/muuli_wdr.cpp:2475
+#: src/amuleDlg.cpp:970 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976
+#: src/muuli_wdr.cpp:2447
 msgid "Disconnect"
 msgstr "Shkeputu"
 
-#: src/amuleDlg.cpp:1036
+#: src/amuleDlg.cpp:971
 msgid "Disconnect from the currently connected networks"
 msgstr "Shkeputu nga rrjetet e lidhura"
 
-#: src/amuleDlg.cpp:1041 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979
-#: src/muuli_wdr.cpp:2630 src/muuli_wdr.cpp:3082 src/muuli_wdr.cpp:3437
+#: src/amuleDlg.cpp:976 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979
+#: src/muuli_wdr.cpp:2602 src/muuli_wdr.cpp:3054 src/muuli_wdr.cpp:3409
 msgid "Connect"
 msgstr "Lidhu"
 
-#: src/amuleDlg.cpp:1042
+#: src/amuleDlg.cpp:977
 msgid "Connect to the currently enabled networks"
 msgstr "Lidhu tek rrjetet"
 
-#: src/amuleDlg.cpp:1154
+#: src/amuleDlg.cpp:1089
 #, fuzzy, c-format
 msgid "Up: %.1f%s (%.1f) | Down: %.1f%s (%.1f)"
 msgstr "Larte: %.1f(%.1f) | Poshte: %.1f(%.1f)"
 
-#: src/amuleDlg.cpp:1156 src/amuleDlg.cpp:1158 src/amuleDlg.cpp:1162
-#: src/amuleDlg.cpp:1164 src/amuleDlg.cpp:1175 src/amuleDlg.cpp:1177
+#: src/amuleDlg.cpp:1091 src/amuleDlg.cpp:1093 src/amuleDlg.cpp:1097
+#: src/amuleDlg.cpp:1099 src/amuleDlg.cpp:1110 src/amuleDlg.cpp:1112
 #: src/MuleTrayIcon.cpp:796 src/MuleTrayIcon.cpp:799
 #, fuzzy
 msgid " MB/s"
 msgstr "MB/s"
 
-#: src/amuleDlg.cpp:1156 src/amuleDlg.cpp:1158 src/amuleDlg.cpp:1162
-#: src/amuleDlg.cpp:1164 src/amuleDlg.cpp:1175 src/amuleDlg.cpp:1177
+#: src/amuleDlg.cpp:1091 src/amuleDlg.cpp:1093 src/amuleDlg.cpp:1097
+#: src/amuleDlg.cpp:1099 src/amuleDlg.cpp:1110 src/amuleDlg.cpp:1112
 #: src/MuleTrayIcon.cpp:796 src/MuleTrayIcon.cpp:799
 #: src/utils/wxCas/src/wxcasframe.cpp:1041
 msgid " kB/s"
 msgstr " kB/s"
 
-#: src/amuleDlg.cpp:1161
+#: src/amuleDlg.cpp:1096
 #, fuzzy, c-format
 msgid "Up: %.1f%s | Down: %.1f%s"
 msgstr "Larte: %.1f | Poshte: %.1f"
 
-#: src/amuleDlg.cpp:1193
+#: src/amuleDlg.cpp:1128
 #, c-format
 msgid "aMule (%s | Connected)"
 msgstr "aMule (%s | e lidhur)"
 
-#: src/amuleDlg.cpp:1195
+#: src/amuleDlg.cpp:1130
 #, c-format
 msgid "aMule (%s | Disconnected)"
 msgstr "aMule (%s | e shkeputur)"
 
-#: src/amuleDlg.cpp:1248
+#: src/amuleDlg.cpp:1183
 #, fuzzy, c-format
 msgid "Do you really want to exit %s?"
 msgstr "Vertet deshironi qe te dilni nga aMule?"
 
-#: src/amuleDlg.cpp:1250
+#: src/amuleDlg.cpp:1185
 msgid "Exit confirmation"
 msgstr "Konfirmimi i daljes"
 
-#: src/amuleDlg.cpp:1613
+#: src/amuleDlg.cpp:1548
 msgid "Launch Command: "
 msgstr ""
 
-#: src/amuleDlg.cpp:1632 src/muuli_wdr.cpp:1972 src/Preferences.cpp:979
+#: src/amuleDlg.cpp:1567 src/muuli_wdr.cpp:1971 src/Preferences.cpp:951
 msgid "- default -"
 msgstr ""
 
-#: src/amuleDlg.cpp:1660
+#: src/amuleDlg.cpp:1595
 #, c-format
 msgid "Skin directory '%s' does not exist"
 msgstr "Direktoria e skin '%s' nuk ekziston"
 
-#: src/amuleDlg.cpp:1663
+#: src/amuleDlg.cpp:1598
 #, c-format
 msgid "WARNING: Unable to open skin file '%s' for read"
 msgstr ""
 
-#: src/amuleDlg.cpp:1814 src/muuli_wdr.cpp:3439
+#: src/amuleDlg.cpp:1722 src/amuleDlg.cpp:1968 src/muuli_wdr.cpp:1485
+#: src/muuli_wdr.cpp:3411
+msgid "Networks"
+msgstr "Rrjetet"
+
+#: src/amuleDlg.cpp:1726 src/muuli_wdr.cpp:3411
 msgid "Networks Window"
 msgstr "Dritaret e rrjeteve"
 
-#: src/amuleDlg.cpp:1820 src/muuli_wdr.cpp:3440
+#: src/amuleDlg.cpp:1728 src/muuli_wdr.cpp:3412
+msgid "Searches"
+msgstr "Kerkimet"
+
+#: src/amuleDlg.cpp:1732 src/muuli_wdr.cpp:3412
 msgid "Searches Window"
 msgstr "Dritaret e kerkimeve"
 
-#: src/amuleDlg.cpp:1826 src/muuli_wdr.cpp:3441
+#: src/amuleDlg.cpp:1734 src/DownloadListCtrl.cpp:740 src/muuli_wdr.cpp:392
+#: src/muuli_wdr.cpp:1578 src/muuli_wdr.cpp:3413 src/Statistics.cpp:829
+msgid "Downloads"
+msgstr "Shkarkime"
+
+#: src/amuleDlg.cpp:1738 src/muuli_wdr.cpp:3413
 #, fuzzy
 msgid "Downloads Window"
 msgstr "Duke shkarkuar"
 
-#: src/amuleDlg.cpp:1832 src/muuli_wdr.cpp:3443
+#: src/amuleDlg.cpp:1740 src/muuli_wdr.cpp:3287
+msgid "Shared files"
+msgstr ""
+
+#: src/amuleDlg.cpp:1744 src/muuli_wdr.cpp:3415
 msgid "Shared Files Window"
 msgstr "Dritarja e faileve te ndara"
 
-#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3444
+#: src/amuleDlg.cpp:1746 src/muuli_wdr.cpp:2919 src/muuli_wdr.cpp:3369
+#: src/muuli_wdr.cpp:3416
+msgid "Messages"
+msgstr "Mesazhe"
+
+#: src/amuleDlg.cpp:1750 src/muuli_wdr.cpp:3416
 msgid "Messages Window"
 msgstr "Dritarja e mesazheve"
 
-#: src/amuleDlg.cpp:1844 src/muuli_wdr.cpp:3445
+#: src/amuleDlg.cpp:1752 src/muuli_wdr.cpp:3417 src/PrefsUnifiedDlg.cpp:312
+#: src/Statistics.cpp:779 src/Statistics.cpp:1235
+msgid "Statistics"
+msgstr "Statistikat"
+
+#: src/amuleDlg.cpp:1756 src/muuli_wdr.cpp:3417
 msgid "Statistics Graph Window"
 msgstr "Dritarja e grafikut te statistikave"
 
-#: src/amuleDlg.cpp:1851 src/muuli_wdr.cpp:3447
+#: src/amuleDlg.cpp:1759 src/muuli_wdr.cpp:3419 src/PrefsUnifiedDlg.cpp:328
+#: src/utils/wxCas/src/wxcasprefs.cpp:39
+msgid "Preferences"
+msgstr "Preferencat"
+
+#: src/amuleDlg.cpp:1763 src/muuli_wdr.cpp:3419
 msgid "Preferences Settings Window"
 msgstr "Dritarja e rregullimeve te preferencave"
 
-#: src/amuleDlg.cpp:1854 src/muuli_wdr.cpp:3448
+#: src/amuleDlg.cpp:1766 src/muuli_wdr.cpp:3420
 msgid "Import"
 msgstr "Importimi"
 
-#: src/amuleDlg.cpp:1858 src/muuli_wdr.cpp:3448
+#: src/amuleDlg.cpp:1770 src/muuli_wdr.cpp:3420
 msgid "The partfile importer tool"
 msgstr "Veglat per importimin e pjeseve te faileve"
 
-#: src/amuleDlg.cpp:1861 src/muuli_wdr.cpp:3449
+#: src/amuleDlg.cpp:1773 src/muuli_wdr.cpp:3421
 #: src/utils/aLinkCreator/src/alcframe.cpp:262
 msgid "About"
 msgstr "Rreth"
 
-#: src/amuleDlg.cpp:1861 src/muuli_wdr.cpp:3449
+#: src/amuleDlg.cpp:1773 src/muuli_wdr.cpp:3421
 msgid "About/Help"
 msgstr "Rreth/Ndihme"
 
-#: src/amuleDlg.cpp:2059
+#: src/amuleDlg.cpp:1971
 msgid "eD2k network"
 msgstr ""
 
-#: src/amuleDlg.cpp:2062
+#: src/amuleDlg.cpp:1974
 msgid "Kad network"
 msgstr "Rrjeti Kad"
 
-#: src/amuleDlg.cpp:2062
+#: src/amuleDlg.cpp:1974
 msgid "No network"
 msgstr "Nuk ka rrjet"
 
@@ -958,7 +953,7 @@ msgstr "Faili nuk u gjete."
 msgid "The core rejected these shared folders:%s"
 msgstr ""
 
-#: src/amule-remote-gui.cpp:1336 src/ExternalConn.cpp:2346
+#: src/amule-remote-gui.cpp:1336 src/ExternalConn.cpp:2345
 msgid "Invalid link or already on list."
 msgstr "Link i pavlere ose qe eshte ne liste."
 
@@ -974,7 +969,7 @@ msgstr ""
 #: src/ClientDetailDialog.cpp:123 src/DataToText.cpp:61 src/DataToText.cpp:86
 #: src/DataToText.cpp:101 src/DataToText.cpp:136 src/DataToText.cpp:165
 #: src/DownloadListCtrl.cpp:1172 src/DownloadListCtrl.cpp:1185
-#: src/DownloadListCtrl.cpp:1196 src/ExternalConn.cpp:609
+#: src/DownloadListCtrl.cpp:1196 src/ExternalConn.cpp:608
 #: src/FileDetailDialog.cpp:203 src/FileDetailDialog.cpp:235
 #: src/FileDetailDialog.cpp:242 src/GenericClientListCtrl.cpp:1171
 #: src/GenericClientListCtrl.cpp:1182 src/GenericClientListCtrl.cpp:1192
@@ -1361,19 +1356,19 @@ msgstr "Automatike [Larte]"
 msgid "Very low"
 msgstr "Shume ngadale"
 
-#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:743 src/muuli_wdr.cpp:2303
+#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:743 src/muuli_wdr.cpp:2275
 #: src/ServerListCtrl.cpp:263 src/ServerListCtrl.cpp:456
 #: src/SharedFilesCtrl.cpp:145
 msgid "Low"
 msgstr "Ngadale"
 
-#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:744 src/muuli_wdr.cpp:2304
+#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:744 src/muuli_wdr.cpp:2276
 #: src/ServerListCtrl.cpp:266 src/ServerListCtrl.cpp:457
 #: src/SharedFilesCtrl.cpp:146
 msgid "Normal"
 msgstr "Normale"
 
-#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:745 src/muuli_wdr.cpp:2305
+#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:745 src/muuli_wdr.cpp:2277
 #: src/ServerListCtrl.cpp:269 src/ServerListCtrl.cpp:458
 #: src/SharedFilesCtrl.cpp:147
 msgid "High"
@@ -1465,8 +1460,8 @@ msgstr "Server Lokal"
 msgid "Remote Server"
 msgstr "Server i larget"
 
-#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3202
-#: src/SearchDlg.cpp:119 src/TextClient.cpp:911
+#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3174
+#: src/SearchDlg.cpp:111 src/TextClient.cpp:911
 msgid "Kad"
 msgstr "Kad"
 
@@ -1537,7 +1532,7 @@ msgstr ""
 msgid "Size"
 msgstr "Madhesia"
 
-#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3269
+#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3241
 msgid "Transferred"
 msgstr "Te transferuara"
 
@@ -1593,7 +1588,7 @@ msgid ""
 "\n"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:746 src/muuli_wdr.cpp:2306
+#: src/DownloadListCtrl.cpp:746 src/muuli_wdr.cpp:2278
 #: src/SharedFilesCtrl.cpp:150
 msgid "Auto"
 msgstr "Automatike"
@@ -1631,7 +1626,7 @@ msgid "Extended Options"
 msgstr "Opsione te Avancuara"
 
 #: src/DownloadListCtrl.cpp:770 src/DownloadListCtrl.cpp:822
-#: src/muuli_wdr.cpp:1790
+#: src/muuli_wdr.cpp:1789
 msgid "Preview"
 msgstr "Parashikim"
 
@@ -1804,237 +1799,232 @@ msgstr[1] ""
 msgid "Invalid eD2k link! ERROR: %s"
 msgstr ""
 
-#: src/ExternalConn.cpp:380
+#: src/ExternalConn.cpp:379
 #, fuzzy
 msgid "Client sent packet after authentication failed."
 msgstr "Autentifikimi deshtoi."
 
-#: src/ExternalConn.cpp:397
+#: src/ExternalConn.cpp:396
 msgid "External connection closed."
 msgstr "Lidhja e jashtme u mbyll."
 
-#: src/ExternalConn.cpp:474
+#: src/ExternalConn.cpp:473
 msgid "External connections disabled due to empty password!"
 msgstr "LIdhjet e jashtme u c'aktivizuan sepse fjalekalimi ishte bosh|"
 
-#: src/ExternalConn.cpp:495
+#: src/ExternalConn.cpp:494
 msgid "External connections disabled in config file"
 msgstr "Lidhjet e jashtme u c'aktivizuan ne failin e konfigurimeve"
 
-#: src/ExternalConn.cpp:576
+#: src/ExternalConn.cpp:575
 msgid "New external connection accepted"
 msgstr "U pranua nje lidhje e jashtme e re"
 
-#: src/ExternalConn.cpp:579
+#: src/ExternalConn.cpp:578
 msgid "ERROR: couldn't accept a new external connection"
 msgstr ""
 
-#: src/ExternalConn.cpp:596
+#: src/ExternalConn.cpp:595
 msgid "External connection refused due to empty password in preferences!"
 msgstr "Lidhja e jashtme nuk u pranua sepse fjalekalimi tek preferencat ishte bosh!"
 
-#: src/ExternalConn.cpp:608
+#: src/ExternalConn.cpp:607
 #, c-format
 msgid "Connecting client: %s %s"
 msgstr "Duke lidhur klientin: %s %s"
 
-#: src/ExternalConn.cpp:610
+#: src/ExternalConn.cpp:609
 msgid "Unknown version"
 msgstr "Version i panjohur"
 
-#: src/ExternalConn.cpp:623
+#: src/ExternalConn.cpp:622
 msgid "Incorrect EC version ID, there might be binary incompatibility. Use core and remote from same snapshot."
 msgstr "ID-ja i versionit EC jo korrekt,duhet te kete mospershtatje binaresh. Perdor Core dhe Remote nga i njejti Snapshot."
 
-#: src/ExternalConn.cpp:631
+#: src/ExternalConn.cpp:630
 #, fuzzy
 msgid "You cannot connect to a release version from an arbitrary development snapshot! *sigh* possible crash prevented"
 msgstr "NUk mund te lidheni me nje version SVN tek nje version i perfunduar ne menyre arbitrare| *sigh* crash i mundshem u evitua"
 
-#: src/ExternalConn.cpp:714
+#: src/ExternalConn.cpp:713
 msgid "Invalid protocol version."
 msgstr "Version protokoli jo i rregullt."
 
-#: src/ExternalConn.cpp:720
+#: src/ExternalConn.cpp:719
 msgid "Missing protocol version tag."
 msgstr "Munfon tag-u i versionit te protokolit."
 
-#: src/ExternalConn.cpp:728
+#: src/ExternalConn.cpp:727
 msgid "Authentication failed: invalid hash specified as EC password."
 msgstr ""
 
-#: src/ExternalConn.cpp:776
+#: src/ExternalConn.cpp:775
 #, fuzzy
 msgid "Authentication failed: wrong password."
 msgstr "Autentifikimi deshtoi."
 
-#: src/ExternalConn.cpp:778
+#: src/ExternalConn.cpp:777
 #, fuzzy
 msgid "Authentication failed: missing password."
 msgstr "Autentifikimi deshtoi."
 
-#: src/ExternalConn.cpp:789
+#: src/ExternalConn.cpp:788
 #, fuzzy
 msgid "Invalid request, please authenticate first."
 msgstr "Kerkese jo e rregullt, fillimisht duhet te identifikoheni."
 
-#: src/ExternalConn.cpp:794
+#: src/ExternalConn.cpp:793
 msgid "Access granted."
 msgstr "Hyrja lejohet."
 
-#: src/ExternalConn.cpp:802
+#: src/ExternalConn.cpp:801
 #, fuzzy, c-format
 msgid "Sent error message \"%s\" to client."
 msgstr "Filtron mesazhet nga klienta t èanjohur"
 
-#: src/ExternalConn.cpp:807
+#: src/ExternalConn.cpp:806
 #, fuzzy, c-format
 msgid "Unauthorized access attempt from %s. Connection closed."
 msgstr "Tentative per hyrje e paautorizuar. Lidhja u mbyll."
 
-#: src/ExternalConn.cpp:1420
+#: src/ExternalConn.cpp:1419
 #, c-format
 msgid "Remote PartFile command failed: FileHash not found: %s"
 msgstr "Komanda e Remote per pjeset e faileve deshtoi: Nuk u gjet FileHash: %s"
 
-#: src/ExternalConn.cpp:1424
+#: src/ExternalConn.cpp:1423
 #, c-format
 msgid "FileHash not found: %s"
 msgstr "Nuk u gjet FileHash: %s"
 
-#: src/ExternalConn.cpp:1471 src/ExternalConn.cpp:1559
-#: src/ExternalConn.cpp:1680
+#: src/ExternalConn.cpp:1470 src/ExternalConn.cpp:1558
+#: src/ExternalConn.cpp:1679
 msgid "OOPS! OpCode processing error!"
 msgstr "OOPS! Gabim ne procesimin e OpCode|"
 
-#: src/ExternalConn.cpp:1502
+#: src/ExternalConn.cpp:1501
 msgid "Server not added"
 msgstr "Serveri nuk u shtua"
 
-#: src/ExternalConn.cpp:1521
+#: src/ExternalConn.cpp:1520
 #, c-format
 msgid "server not found: %s"
 msgstr "Serveri nuk u gjend: %s"
 
-#: src/ExternalConn.cpp:1538
+#: src/ExternalConn.cpp:1537
 msgid "need to define server to be removed"
 msgstr "nevojitet percaktimi i serverit qe do te levizet"
 
-#: src/ExternalConn.cpp:1553
+#: src/ExternalConn.cpp:1552
 msgid "eD2k is disabled in preferences."
 msgstr ""
 
-#: src/ExternalConn.cpp:1658
+#: src/ExternalConn.cpp:1657
 #, fuzzy
 msgid "Friend not found."
 msgstr "Faili nuk u gjete."
 
-#: src/ExternalConn.cpp:1668
+#: src/ExternalConn.cpp:1667
 #, fuzzy
 msgid "Client not found."
 msgstr "Faili nuk u gjete."
 
-#: src/ExternalConn.cpp:1674
+#: src/ExternalConn.cpp:1673
 msgid "EC_TAG_FRIEND_SHARED requires EC_TAG_FRIEND or EC_TAG_CLIENT."
 msgstr ""
 
-#: src/ExternalConn.cpp:1992
+#: src/ExternalConn.cpp:1991
 msgid "WebSearch from remote interface makes no sense."
 msgstr "Kerkimi WebSearch nga Remote eshte i kote."
 
-#: src/ExternalConn.cpp:2027
+#: src/ExternalConn.cpp:2026
 msgid "Search in progress. Refetch results in a moment!"
 msgstr "Kerkimi vazhdon. Rezultate ne ardhje!"
 
-#: src/ExternalConn.cpp:2266
+#: src/ExternalConn.cpp:2265
 msgid "No points for graph."
 msgstr "NUk ka pika per grafike."
 
-#: src/ExternalConn.cpp:2276
+#: src/ExternalConn.cpp:2275
 msgid "Your client is not configured for this detail level."
 msgstr "Klienti juaj nuk eshte i konfiguruar per kete nivel detaji."
 
-#: src/ExternalConn.cpp:2303
+#: src/ExternalConn.cpp:2302
 msgid "External Connection: shutdown requested"
 msgstr ""
 
-#: src/ExternalConn.cpp:2315
+#: src/ExternalConn.cpp:2314
 msgid "Already shutting down."
 msgstr "Jam duke dalur."
 
-#: src/ExternalConn.cpp:2333
+#: src/ExternalConn.cpp:2332
 #, c-format
 msgid "ExternalConn: adding link '%s'."
 msgstr "Lidhje e jashtme: Duke shtuar linkun '%s'."
 
-#: src/ExternalConn.cpp:2351
+#: src/ExternalConn.cpp:2350
 #, fuzzy, c-format
 msgid "%d of %d links failed (invalid or already on list)."
 msgstr "Link i pavlere ose qe eshte ne liste."
 
-#: src/ExternalConn.cpp:2374
+#: src/ExternalConn.cpp:2373
 msgid "Version check throttled; try again shortly."
 msgstr ""
 
-#: src/ExternalConn.cpp:2379
+#: src/ExternalConn.cpp:2378
 msgid "Version check is not available on this daemon."
 msgstr ""
 
-#: src/ExternalConn.cpp:2509
+#: src/ExternalConn.cpp:2508
 msgid "File not found."
 msgstr "Faili nuk u gjete."
 
-#: src/ExternalConn.cpp:2514
+#: src/ExternalConn.cpp:2513
 msgid "Invalid file name."
 msgstr "Emri i failit i pavlere."
 
-#: src/ExternalConn.cpp:2522
+#: src/ExternalConn.cpp:2521
 msgid "Unable to rename file."
 msgstr "E pamundur te riemeroje failin."
 
-#: src/ExternalConn.cpp:2839
-#, c-format
-msgid "Could not save the amuleapi password: %s"
-msgstr ""
-
-#: src/ExternalConn.cpp:3004 src/ExternalConn.cpp:3032
+#: src/ExternalConn.cpp:2992 src/ExternalConn.cpp:3020
 msgid "Kad is disabled in preferences."
 msgstr "Kad-i eshte c'aktivizuar tek Preferencat."
 
-#: src/ExternalConn.cpp:3045
+#: src/ExternalConn.cpp:3033
 msgid "Already connected to eD2k."
 msgstr ""
 
-#: src/ExternalConn.cpp:3048
+#: src/ExternalConn.cpp:3036
 msgid "Connecting to eD2k..."
 msgstr ""
 
-#: src/ExternalConn.cpp:3057
+#: src/ExternalConn.cpp:3045
 msgid "Already connected to Kad."
 msgstr "Jam i lidhur ne Kad."
 
-#: src/ExternalConn.cpp:3060
+#: src/ExternalConn.cpp:3048
 msgid "Connecting to Kad..."
 msgstr "Duke u lidhur me Kad..."
 
-#: src/ExternalConn.cpp:3067
+#: src/ExternalConn.cpp:3055
 msgid "All networks are disabled."
 msgstr "Te gjithe rrjetet jane c'aktivizuar."
 
-#: src/ExternalConn.cpp:3076
+#: src/ExternalConn.cpp:3064
 msgid "Disconnected from eD2k."
 msgstr ""
 
-#: src/ExternalConn.cpp:3081
+#: src/ExternalConn.cpp:3069
 msgid "Disconnected from Kad."
 msgstr "I shkeputur nga Kad."
 
-#: src/ExternalConn.cpp:3090
+#: src/ExternalConn.cpp:3078
 #, c-format
 msgid "External Connection: invalid opcode received: %#x"
 msgstr ""
 
-#: src/ExternalConn.cpp:3095
+#: src/ExternalConn.cpp:3083
 msgid "Invalid opcode (wrong protocol version?)"
 msgstr "OpCode e pavlere (version protokoli i gabuar?)"
 
@@ -2349,19 +2339,19 @@ msgstr ""
 msgid "eD2k"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:349 src/muuli_wdr.cpp:1495
+#: src/FirstRunWizard.cpp:349 src/muuli_wdr.cpp:1488
 msgid "Kademlia"
 msgstr "Kademlia"
 
-#: src/FirstRunWizard.cpp:359 src/muuli_wdr.cpp:1423
+#: src/FirstRunWizard.cpp:359 src/muuli_wdr.cpp:1416
 msgid "Standard TCP Port "
 msgstr ""
 
-#: src/FirstRunWizard.cpp:365 src/muuli_wdr.cpp:1435
+#: src/FirstRunWizard.cpp:365 src/muuli_wdr.cpp:1428
 msgid "Extended UDP port (Kad / global search) "
 msgstr ""
 
-#: src/FirstRunWizard.cpp:377 src/muuli_wdr.cpp:1442
+#: src/FirstRunWizard.cpp:377 src/muuli_wdr.cpp:1435
 msgid "Enable UPnP for router port forwarding"
 msgstr ""
 
@@ -2388,7 +2378,7 @@ msgstr ""
 msgid "Your peer lists are already in place - nothing to download."
 msgstr "Jeni duke u perpjekur te shkarkoni edhe njehere tjeter kete fail %s"
 
-#: src/FirstRunWizard.cpp:434 src/muuli_wdr.cpp:1540
+#: src/FirstRunWizard.cpp:434 src/muuli_wdr.cpp:1533
 msgid "Auto-update server list at startup"
 msgstr ""
 
@@ -2434,23 +2424,23 @@ msgid ""
 "want downloads on a different (e.g. larger) disk."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:549 src/FirstRunWizard.cpp:611 src/muuli_wdr.cpp:1702
+#: src/FirstRunWizard.cpp:549 src/FirstRunWizard.cpp:611 src/muuli_wdr.cpp:1701
 msgid "Destination folder for downloads"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:553 src/FirstRunWizard.cpp:569 src/muuli_wdr.cpp:1349
-#: src/muuli_wdr.cpp:1366 src/muuli_wdr.cpp:1677 src/muuli_wdr.cpp:1708
-#: src/muuli_wdr.cpp:1720 src/muuli_wdr.cpp:2790
+#: src/FirstRunWizard.cpp:553 src/FirstRunWizard.cpp:569 src/muuli_wdr.cpp:1342
+#: src/muuli_wdr.cpp:1359 src/muuli_wdr.cpp:1676 src/muuli_wdr.cpp:1707
+#: src/muuli_wdr.cpp:1719 src/muuli_wdr.cpp:2762
 #: src/utils/aLinkCreator/src/alcframe.cpp:135
 #: src/utils/wxCas/src/wxcasprefs.cpp:52 src/utils/wxCas/src/wxcasprefs.cpp:118
 msgid "Browse"
 msgstr "Shfleto"
 
-#: src/FirstRunWizard.cpp:559 src/muuli_wdr.cpp:1713
+#: src/FirstRunWizard.cpp:559 src/muuli_wdr.cpp:1712
 msgid "(All files in this folder are shared with other peers)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:565 src/FirstRunWizard.cpp:624 src/muuli_wdr.cpp:1715
+#: src/FirstRunWizard.cpp:565 src/FirstRunWizard.cpp:624 src/muuli_wdr.cpp:1714
 msgid "Folder for temporary download files"
 msgstr ""
 
@@ -2481,7 +2471,7 @@ msgstr ""
 msgid "CRITICAL - no client on StartChatSession"
 msgstr ""
 
-#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2696 src/muuli_wdr.cpp:3373
+#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2668 src/muuli_wdr.cpp:3345
 msgid "Friends"
 msgstr "Shkoket"
 
@@ -2595,8 +2585,8 @@ msgstr "Asnjeri"
 msgid "No"
 msgstr "Jo"
 
-#: src/GenericClientListCtrl.cpp:1216 src/PrefsUnifiedDlg.cpp:2898
-#: src/PrefsUnifiedDlg.cpp:2948 src/ServerListCtrl.cpp:276
+#: src/GenericClientListCtrl.cpp:1216 src/PrefsUnifiedDlg.cpp:2818
+#: src/PrefsUnifiedDlg.cpp:2868 src/ServerListCtrl.cpp:276
 msgid "Yes"
 msgstr "Po"
 
@@ -2766,10 +2756,10 @@ msgstr "Porte e pavlefshme per bootstrap"
 msgid "Please fill all fields required"
 msgstr "Ju lutem plotesoni te gjitha fushat e kerkuara"
 
-#: src/KadDlg.cpp:192 src/PartFile.cpp:1031 src/PrefsUnifiedDlg.cpp:1134
-#: src/PrefsUnifiedDlg.cpp:1204 src/PrefsUnifiedDlg.cpp:1405
-#: src/PrefsUnifiedDlg.cpp:1663 src/PrefsUnifiedDlg.cpp:1673
-#: src/PrefsUnifiedDlg.cpp:1690 src/PrefsUnifiedDlg.cpp:1738
+#: src/KadDlg.cpp:192 src/PartFile.cpp:1031 src/PrefsUnifiedDlg.cpp:1162
+#: src/PrefsUnifiedDlg.cpp:1331 src/PrefsUnifiedDlg.cpp:1589
+#: src/PrefsUnifiedDlg.cpp:1599 src/PrefsUnifiedDlg.cpp:1616
+#: src/PrefsUnifiedDlg.cpp:1658
 msgid "Message"
 msgstr "Mesazh"
 
@@ -2871,7 +2861,7 @@ msgstr ""
 msgid "Uploaded"
 msgstr ""
 
-#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3253
+#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3225
 msgid "Requested"
 msgstr ""
 
@@ -2997,7 +2987,7 @@ msgid "WARNING: "
 msgstr ""
 
 #: src/MuleNotebook.cpp:179 src/muuli_wdr.cpp:817 src/muuli_wdr.cpp:1229
-#: src/muuli_wdr.cpp:3157 src/muuli_wdr.cpp:3413
+#: src/muuli_wdr.cpp:3129 src/muuli_wdr.cpp:3385
 msgid "Close"
 msgstr "Mbylle"
 
@@ -3010,12 +3000,12 @@ msgstr "Ndaj"
 msgid "Copy"
 msgstr "Kopjo"
 
-#: src/MuleTextCtrl.cpp:88 src/SearchDlg.cpp:261
+#: src/MuleTextCtrl.cpp:88
 msgid "Paste"
 msgstr "Ngjit"
 
 #: src/MuleTextCtrl.cpp:89 src/muuli_wdr.cpp:358 src/muuli_wdr.cpp:757
-#: src/muuli_wdr.cpp:2380 src/muuli_wdr.cpp:2399 src/muuli_wdr.cpp:2421
+#: src/muuli_wdr.cpp:2352 src/muuli_wdr.cpp:2371 src/muuli_wdr.cpp:2393
 #: src/utils/aLinkCreator/src/alcframe.cpp:142
 msgid "Clear"
 msgstr "Pastro"
@@ -3112,8 +3102,8 @@ msgid "Exit"
 msgstr "Dlje"
 
 #: src/MuleTrayIcon.cpp:579 src/MuleTrayIcon.cpp:945 src/MuleTrayIcon.cpp:965
-#: src/muuli_wdr.cpp:1398 src/muuli_wdr.cpp:1406 src/muuli_wdr.cpp:1413
-#: src/muuli_wdr.cpp:1836 src/muuli_wdr.cpp:1842 src/OtherFunctions.cpp:91
+#: src/muuli_wdr.cpp:1391 src/muuli_wdr.cpp:1399 src/muuli_wdr.cpp:1406
+#: src/muuli_wdr.cpp:1835 src/muuli_wdr.cpp:1841 src/OtherFunctions.cpp:91
 #: src/StatisticsDlg.cpp:93 src/StatisticsDlg.cpp:95
 msgid "kB/s"
 msgstr "kB/s"
@@ -3284,7 +3274,7 @@ msgstr "Emri:"
 msgid "Type"
 msgstr "Tipi"
 
-#: src/muuli_wdr.cpp:215 src/SearchDlg.cpp:118 src/SearchListCtrl.cpp:853
+#: src/muuli_wdr.cpp:215 src/SearchDlg.cpp:110 src/SearchListCtrl.cpp:853
 msgid "Local"
 msgstr "Lokale"
 
@@ -3355,7 +3345,7 @@ msgstr "Bytes"
 msgid "KB"
 msgstr "KB"
 
-#: src/muuli_wdr.cpp:274 src/muuli_wdr.cpp:293 src/muuli_wdr.cpp:1621
+#: src/muuli_wdr.cpp:274 src/muuli_wdr.cpp:293 src/muuli_wdr.cpp:1620
 #: src/OtherFunctions.cpp:64
 msgid "MB"
 msgstr "MB"
@@ -3372,7 +3362,7 @@ msgstr "Madhesia Maksimale"
 msgid "Availability"
 msgstr "Te disponueshem"
 
-#: src/muuli_wdr.cpp:312 src/muuli_wdr.cpp:398 src/muuli_wdr.cpp:3318
+#: src/muuli_wdr.cpp:312 src/muuli_wdr.cpp:398 src/muuli_wdr.cpp:3290
 msgid "Filter:"
 msgstr "Filteri:"
 
@@ -3404,7 +3394,7 @@ msgstr ""
 msgid "Stop"
 msgstr "Ndalo"
 
-#: src/muuli_wdr.cpp:348 src/muuli_wdr.cpp:1392 src/SearchListCtrl.cpp:732
+#: src/muuli_wdr.cpp:348 src/muuli_wdr.cpp:1385 src/SearchListCtrl.cpp:732
 msgid "Download"
 msgstr "Shkarkime"
 
@@ -3436,12 +3426,12 @@ msgstr "Burime te gjetura :"
 #: src/muuli_wdr.cpp:1160 src/muuli_wdr.cpp:1167 src/muuli_wdr.cpp:1172
 #: src/muuli_wdr.cpp:1179 src/muuli_wdr.cpp:1184 src/muuli_wdr.cpp:1191
 #: src/muuli_wdr.cpp:1205 src/muuli_wdr.cpp:1212 src/muuli_wdr.cpp:1217
-#: src/muuli_wdr.cpp:1224 src/muuli_wdr.cpp:3255 src/muuli_wdr.cpp:3263
-#: src/muuli_wdr.cpp:3271
+#: src/muuli_wdr.cpp:1224 src/muuli_wdr.cpp:3227 src/muuli_wdr.cpp:3235
+#: src/muuli_wdr.cpp:3243
 msgid "N/A"
 msgstr "N/A"
 
-#: src/muuli_wdr.cpp:508 src/muuli_wdr.cpp:1065 src/PrefsUnifiedDlg.cpp:299
+#: src/muuli_wdr.cpp:508 src/muuli_wdr.cpp:1065 src/PrefsUnifiedDlg.cpp:297
 msgid "General"
 msgstr "Te pergjithshme"
 
@@ -3582,7 +3572,7 @@ msgstr ""
 msgid "Album :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:685 src/muuli_wdr.cpp:2275
+#: src/muuli_wdr.cpp:685 src/muuli_wdr.cpp:2247
 msgid "Title :"
 msgstr "Titulli :"
 
@@ -3689,7 +3679,7 @@ msgstr "Emri i Perdoruesit :"
 msgid "Userhash :"
 msgstr "Userhash :"
 
-#: src/muuli_wdr.cpp:895 src/muuli_wdr.cpp:1742 src/muuli_wdr.cpp:2470
+#: src/muuli_wdr.cpp:895 src/muuli_wdr.cpp:1741 src/muuli_wdr.cpp:2442
 #: src/utils/aLinkCreator/src/alcframe.cpp:137
 msgid "Add"
 msgstr "Shto"
@@ -3698,15 +3688,15 @@ msgstr "Shto"
 msgid "Download-Speed"
 msgstr "Shpejtesia-Shkarkimit"
 
-#: src/muuli_wdr.cpp:954 src/muuli_wdr.cpp:989 src/muuli_wdr.cpp:2574
+#: src/muuli_wdr.cpp:954 src/muuli_wdr.cpp:989 src/muuli_wdr.cpp:2546
 msgid "Current"
 msgstr "Aktualisht"
 
-#: src/muuli_wdr.cpp:962 src/muuli_wdr.cpp:997 src/muuli_wdr.cpp:2582
+#: src/muuli_wdr.cpp:962 src/muuli_wdr.cpp:997 src/muuli_wdr.cpp:2554
 msgid "Running average"
 msgstr "Mesatarja e Punes"
 
-#: src/muuli_wdr.cpp:970 src/muuli_wdr.cpp:1005 src/muuli_wdr.cpp:2590
+#: src/muuli_wdr.cpp:970 src/muuli_wdr.cpp:1005 src/muuli_wdr.cpp:2562
 msgid "Session average"
 msgstr "Mesatarja e Sesionit"
 
@@ -3718,7 +3708,7 @@ msgstr "Shpejtesia-Ngarkimit"
 msgid "Connections"
 msgstr "Lidhjet"
 
-#: src/muuli_wdr.cpp:1024 src/muuli_wdr.cpp:1861
+#: src/muuli_wdr.cpp:1024 src/muuli_wdr.cpp:1860
 msgid "Active downloads"
 msgstr "Shkarkime Aktive"
 
@@ -3726,7 +3716,7 @@ msgstr "Shkarkime Aktive"
 msgid "Active connections (1:1)"
 msgstr "Lidhje Aktive (1:1)"
 
-#: src/muuli_wdr.cpp:1040 src/muuli_wdr.cpp:1862
+#: src/muuli_wdr.cpp:1040 src/muuli_wdr.cpp:1861
 msgid "Active uploads"
 msgstr "Ngarkime Aktive"
 
@@ -3843,8 +3833,8 @@ msgstr "Ky eshte emri qe te tjeret do te shohin kur te lidhen tek ju."
 msgid "Language: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1257 src/muuli_wdr.cpp:1330 src/muuli_wdr.cpp:1334
-#: src/muuli_wdr.cpp:1337
+#: src/muuli_wdr.cpp:1257 src/muuli_wdr.cpp:1323 src/muuli_wdr.cpp:1327
+#: src/muuli_wdr.cpp:1330
 msgid "The delay before showing tool-tips."
 msgstr "Interval kohor para se te tregohen sugjerimet."
 
@@ -3922,961 +3912,937 @@ msgstr ""
 msgid "Enabling this will make aMule to show notifications when finished downloading."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1323
-#, fuzzy
-msgid "Remember search history"
-msgstr "Mbaji mend keto rregullime"
-
-#: src/muuli_wdr.cpp:1324
-msgid "Keeps a dropdown list of your past search terms in the Search tab's Name field. This remembers the queries you typed, not the results they returned."
-msgstr ""
-
-#: src/muuli_wdr.cpp:1329
+#: src/muuli_wdr.cpp:1322
 msgid "Tooltip delay time: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1336
+#: src/muuli_wdr.cpp:1329
 msgid "seconds"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1340
+#: src/muuli_wdr.cpp:1333
 msgid "Browser Selection"
 msgstr "Zgjedhesi i shfletuesit"
 
-#: src/muuli_wdr.cpp:1346
+#: src/muuli_wdr.cpp:1339
 msgid "Enter your browser name here. Leave this field empty to use the system default browser."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1353
+#: src/muuli_wdr.cpp:1346
 msgid "Open in new tab if possible"
 msgstr "Hape ne nje faqe te re nqs eshte e mundur"
 
-#: src/muuli_wdr.cpp:1355
+#: src/muuli_wdr.cpp:1348
 msgid "Open the web page in a new tab instead of in a new window when possible"
 msgstr "Nqs eshte e mundur hape faqen e re te web-it ne nje faqe tjeter te re"
 
-#: src/muuli_wdr.cpp:1359
+#: src/muuli_wdr.cpp:1352
 msgid "Video Player"
 msgstr "Video Player"
 
-#: src/muuli_wdr.cpp:1386
+#: src/muuli_wdr.cpp:1379
 msgid "Bandwidth limits"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1400
+#: src/muuli_wdr.cpp:1393
 msgid "Upload"
 msgstr "Ngarkim"
 
-#: src/muuli_wdr.cpp:1408
+#: src/muuli_wdr.cpp:1401
 msgid "Slot Allocation"
 msgstr "Vendndodhja e slotit"
 
-#: src/muuli_wdr.cpp:1417
+#: src/muuli_wdr.cpp:1410
 msgid "Ports"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1427
+#: src/muuli_wdr.cpp:1420
 msgid "This is the standard eD2k port and cannot be disabled."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1430
+#: src/muuli_wdr.cpp:1423
 msgid "UDP port for server requests (TCP+3):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1432
+#: src/muuli_wdr.cpp:1425
 msgid "4665"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1439
+#: src/muuli_wdr.cpp:1432
 msgid "This UDP port is used for extended eD2k requests and Kad network"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1446
+#: src/muuli_wdr.cpp:1439
 msgid "UPnP TCP Port (Optional):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1456
+#: src/muuli_wdr.cpp:1449
 msgid "Bind local address to IP (empty for any):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1459
+#: src/muuli_wdr.cpp:1452
 msgid "Advanced users only: If you have multiple network interfaces, enter the address of the interface to which aMule should be bound."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1462 src/muuli_wdr.cpp:2055
+#: src/muuli_wdr.cpp:1455 src/muuli_wdr.cpp:2054
 msgid "Bind to network interface (empty for any):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1475
+#: src/muuli_wdr.cpp:1468
 msgid "Advanced users only: pin all of aMule's traffic to one network interface, chosen from the list or typed in by name (e.g. tun0, eth0, en0) or index. Unlike binding to an IP, this stops traffic leaking out via the default route - useful with a VPN. Requires no elevated privileges."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1481
+#: src/muuli_wdr.cpp:1474
 msgid "Max sources per downloading file:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1485
+#: src/muuli_wdr.cpp:1478
 msgid "Max simultaneous connections:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1498 src/muuli_wdr.cpp:3197
+#: src/muuli_wdr.cpp:1491 src/muuli_wdr.cpp:3169
 msgid "ED2K"
 msgstr "ED2K"
 
-#: src/muuli_wdr.cpp:1505
+#: src/muuli_wdr.cpp:1498
 msgid "Autoconnect on startup"
 msgstr "Lidje automatike sapo programi te hapet"
 
-#: src/muuli_wdr.cpp:1508
+#: src/muuli_wdr.cpp:1501
 msgid "Reconnect on loss"
 msgstr "Rilidhu mbas humbjes se lidhjes"
 
-#: src/muuli_wdr.cpp:1530
+#: src/muuli_wdr.cpp:1523
 msgid "Remove dead server after"
 msgstr "Largo serverat e papune mbas"
 
-#: src/muuli_wdr.cpp:1531
+#: src/muuli_wdr.cpp:1524
 msgid "Static servers are never removed, even when unreachable."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1535
+#: src/muuli_wdr.cpp:1528
 msgid "retries"
 msgstr "tentativa"
 
-#: src/muuli_wdr.cpp:1543
+#: src/muuli_wdr.cpp:1536
 msgid "List"
 msgstr "Lista"
 
-#: src/muuli_wdr.cpp:1546
+#: src/muuli_wdr.cpp:1539
 msgid "Update server list when connecting to a server"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1549
+#: src/muuli_wdr.cpp:1542
 msgid "Update server list when a client connects"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1552
+#: src/muuli_wdr.cpp:1545
 msgid "Use priority system"
 msgstr "Perdor sistemin e prioritetit"
 
-#: src/muuli_wdr.cpp:1556
+#: src/muuli_wdr.cpp:1549
 msgid "Use smart LowID check on connect"
 msgstr "Perdor kontrollin e zgjuar per ID e ulet kur lidhesh"
 
-#: src/muuli_wdr.cpp:1560
+#: src/muuli_wdr.cpp:1553
 msgid "Safe connect"
 msgstr "Lidhje e sigurte"
 
-#: src/muuli_wdr.cpp:1564
+#: src/muuli_wdr.cpp:1557
 msgid "Autoconnect to servers in static list only"
 msgstr "Lidhu automatikisht vetem me serverat e qendrueshem"
 
-#: src/muuli_wdr.cpp:1567
+#: src/muuli_wdr.cpp:1560
 msgid "Set manually added servers to High Priority"
 msgstr "Vendosni ne menyre manuale serverat e shtuar ne Prioritet te Larte"
 
-#: src/muuli_wdr.cpp:1588
+#: src/muuli_wdr.cpp:1581
 msgid "Add files to download in pause mode"
 msgstr "Shto failet tek shkarkimi duke i vene ne pushim"
 
-#: src/muuli_wdr.cpp:1590
+#: src/muuli_wdr.cpp:1583
 msgid "Add files to download with auto priority"
 msgstr "Shto failet tek shkarkimi me prioritet automatik"
 
-#: src/muuli_wdr.cpp:1593
+#: src/muuli_wdr.cpp:1586
 msgid "Try to download first and last chunks first"
 msgstr "Mundohu te shkarkosh pjesen e pare dhe te fundit te failit"
 
-#: src/muuli_wdr.cpp:1597
+#: src/muuli_wdr.cpp:1590
 msgid "Endgame mode: rotate to faster sources for the final blocks"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1600
+#: src/muuli_wdr.cpp:1593
 msgid "Start next paused file when a file completes"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1603
+#: src/muuli_wdr.cpp:1596
 msgid "From the same category"
 msgstr "Nga e njejta kategori"
 
-#: src/muuli_wdr.cpp:1605
+#: src/muuli_wdr.cpp:1598
 msgid "In alphabetic order"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1607
+#: src/muuli_wdr.cpp:1600
 msgid "Preallocate disk space for new files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1608
+#: src/muuli_wdr.cpp:1601
 msgid "For new files preallocates disk space for the whole file, thus reduces fragmentation"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1613
+#: src/muuli_wdr.cpp:1606
+msgid "Create new files as sparse files"
+msgstr ""
+
+#: src/muuli_wdr.cpp:1607
+msgid "A sparse file reserves its full size on disk immediately without writing real data to it -- fast, but unsupported or slow on some filesystems, and free-space accounting stays optimistic while the download is in progress. Turn this off to grow the file only as data arrives."
+msgstr ""
+
+#: src/muuli_wdr.cpp:1612
 msgid "Stop downloads when free disk space reaches "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1614
+#: src/muuli_wdr.cpp:1613
 msgid "Select this if you want aMule to check your disk space"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1618
+#: src/muuli_wdr.cpp:1617
 msgid "Enter here the min disk space desired."
 msgstr "Futni ketu hapesiren minimale qe deshironi per diskun."
 
-#: src/muuli_wdr.cpp:1624
+#: src/muuli_wdr.cpp:1623
 msgid "Save 10 sources on rare files (< 20 sources)"
 msgstr "Shpeto 10 burime per failet e rralla (< 20 burime)"
 
-#: src/muuli_wdr.cpp:1628 src/Statistics.cpp:790
+#: src/muuli_wdr.cpp:1627 src/Statistics.cpp:790
 msgid "Uploads"
 msgstr "Ngarkimi"
 
-#: src/muuli_wdr.cpp:1631
+#: src/muuli_wdr.cpp:1630
 msgid "Add new shared files with auto priority"
 msgstr "Shto faile te reja te ndara me prioritet automatik"
 
-#: src/muuli_wdr.cpp:1637
+#: src/muuli_wdr.cpp:1636
 msgid "Intelligent Corruption Handling (I.C.H.)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1640
+#: src/muuli_wdr.cpp:1639
 msgid "Enable"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1643
+#: src/muuli_wdr.cpp:1642
 msgid "Advanced I.C.H. trusts every hash (not recommended)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1655 src/PrefsUnifiedDlg.cpp:1990
+#: src/muuli_wdr.cpp:1654 src/PrefsUnifiedDlg.cpp:1910
 msgid "Media metadata extraction"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1659
+#: src/muuli_wdr.cpp:1658
 msgid "Extract length / bitrate / codec from shared audio and video files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1661
+#: src/muuli_wdr.cpp:1660
 msgid "When enabled, aMule runs ffprobe on each shared media file to fill in the Length / Bitrate / Codec columns other clients see when they find the file in a search. Requires ffmpeg (the ffprobe binary) to be installed."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1668
+#: src/muuli_wdr.cpp:1667
 msgid "Path to ffprobe:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1673
+#: src/muuli_wdr.cpp:1672
 msgid "Full path to the ffprobe binary. Leave empty to have aMule auto-detect it on startup."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1681
+#: src/muuli_wdr.cpp:1680
 msgid "Detect"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1682
+#: src/muuli_wdr.cpp:1681
 msgid "Search the standard install locations for an ffprobe binary and fill the path field."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1706
+#: src/muuli_wdr.cpp:1705
 msgid ""
 "Completed downloads are stored here. All files in this folder are automatically shared with other peers.\n"
 "If this folder also holds files you don't want to share, point it at an aMule-only sub-folder."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1709
+#: src/muuli_wdr.cpp:1708
 msgid "Pick the folder where completed downloads will be stored. All files in that folder will be shared with other peers."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1723
+#: src/muuli_wdr.cpp:1722
 msgid "Shared folders"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1729
+#: src/muuli_wdr.cpp:1728
 msgid "(Folders shared by the core. Enter a path to add one.)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1737
+#: src/muuli_wdr.cpp:1736
 msgid "Absolute path of a folder on the core's machine, e.g. /home/user/shared"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1739 src/PrefsUnifiedDlg.cpp:2874
+#: src/muuli_wdr.cpp:1738 src/PrefsUnifiedDlg.cpp:2794
 msgid "Recursive"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1740
+#: src/muuli_wdr.cpp:1739
 msgid "Share every sub-folder underneath this one, including ones created later."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1744 src/utils/aLinkCreator/src/alcframe.cpp:141
+#: src/muuli_wdr.cpp:1743 src/utils/aLinkCreator/src/alcframe.cpp:141
 msgid "Remove"
 msgstr "Hiq"
 
-#: src/muuli_wdr.cpp:1748
+#: src/muuli_wdr.cpp:1747
 msgid "(Right click on folder icon for recursive share)"
 msgstr "( Klikoni me butonin e djathte ne ikonene e karteles per te ndare ne menyre rekursive)"
 
-#: src/muuli_wdr.cpp:1755
+#: src/muuli_wdr.cpp:1754
 msgid "Share hidden files"
 msgstr "Nda failet e fshehur"
 
-#: src/muuli_wdr.cpp:1761
+#: src/muuli_wdr.cpp:1760
 msgid "Automatically rescan shared folders for changes"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1767
+#: src/muuli_wdr.cpp:1766
 msgid "Follow symbolic links in shared folders"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1773
+#: src/muuli_wdr.cpp:1772
 msgid "Exclude files matching:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1776
+#: src/muuli_wdr.cpp:1775
 msgid "Wildcard patterns separated by '|', e.g. .DS_Store|Thumbs.db|*.tmp. Files whose name matches are not shared. Matching is case-insensitive."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1780
+#: src/muuli_wdr.cpp:1779
 msgid "Patterns are regular expressions"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1781
+#: src/muuli_wdr.cpp:1780
 msgid "When set, the whole field is one regular expression ('|' is alternation). When unset, it is a list of '|'-separated wildcards."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1791
+#: src/muuli_wdr.cpp:1790
 msgid "Show how many shared files the current pattern would exclude."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1812
+#: src/muuli_wdr.cpp:1811
 msgid "Graphs"
 msgstr "Grafiket"
 
-#: src/muuli_wdr.cpp:1815 src/muuli_wdr.cpp:1877
+#: src/muuli_wdr.cpp:1814 src/muuli_wdr.cpp:1876
 msgid "Update delay : 5 secs"
 msgstr "Intervali i azhornimit : 5 sek"
 
-#: src/muuli_wdr.cpp:1819
+#: src/muuli_wdr.cpp:1818
 msgid "Time for average graph: 100 mins"
 msgstr "Intervali grafik i vlerave mesatare: 100 minuta"
 
-#: src/muuli_wdr.cpp:1823
+#: src/muuli_wdr.cpp:1822
 msgid "Connections Graph Scale: 100 "
 msgstr "Shkalla grafike e lidhjeve: 100 "
 
-#: src/muuli_wdr.cpp:1830
+#: src/muuli_wdr.cpp:1829
 msgid "Download graph scale:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1838
+#: src/muuli_wdr.cpp:1837
 msgid "Upload graph scale:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1848
+#: src/muuli_wdr.cpp:1847
 msgid "Colors: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1852
+#: src/muuli_wdr.cpp:1851
 msgid "Background"
 msgstr "Sfondi"
 
-#: src/muuli_wdr.cpp:1853
+#: src/muuli_wdr.cpp:1852
 msgid "Grid"
 msgstr "Zgara"
 
-#: src/muuli_wdr.cpp:1854
+#: src/muuli_wdr.cpp:1853
 msgid "Download current"
 msgstr "Shkarkimi aktual"
 
-#: src/muuli_wdr.cpp:1855
+#: src/muuli_wdr.cpp:1854
 msgid "Download running average"
 msgstr "Mesatarja e shkarkimeve ne punim"
 
-#: src/muuli_wdr.cpp:1856
+#: src/muuli_wdr.cpp:1855
 msgid "Download session average"
 msgstr "Mesatarja e sesioneve te shkarkimit"
 
-#: src/muuli_wdr.cpp:1857
+#: src/muuli_wdr.cpp:1856
 msgid "Upload current"
 msgstr "Ngarkimi aktual"
 
-#: src/muuli_wdr.cpp:1858
+#: src/muuli_wdr.cpp:1857
 msgid "Upload running average"
 msgstr "Mesatarja e ngarkimit ne punim"
 
-#: src/muuli_wdr.cpp:1859
+#: src/muuli_wdr.cpp:1858
 msgid "Upload session average"
 msgstr "Mesatarja e sesionit te ngarkimeve"
 
-#: src/muuli_wdr.cpp:1860
+#: src/muuli_wdr.cpp:1859
 msgid "Active connections"
 msgstr "Lidhjet aktive"
 
-#: src/muuli_wdr.cpp:1863
+#: src/muuli_wdr.cpp:1862
 #, fuzzy
 msgid "Systray Icon Speed Bar"
 msgstr "Ikona e Speedbar-it ne Systray"
 
-#: src/muuli_wdr.cpp:1864
+#: src/muuli_wdr.cpp:1863
 msgid "Kad-nodes current"
 msgstr "Nyjet e Kad aktuale"
 
-#: src/muuli_wdr.cpp:1865
+#: src/muuli_wdr.cpp:1864
 msgid "Kad-nodes running"
 msgstr "Nyjet e Kad jane duke punuar"
 
-#: src/muuli_wdr.cpp:1866
+#: src/muuli_wdr.cpp:1865
 msgid "Kad-nodes session"
 msgstr "Sesioni i Nyjeve te Kad"
 
-#: src/muuli_wdr.cpp:1870 src/muuli_wdr.cpp:2324
+#: src/muuli_wdr.cpp:1869 src/muuli_wdr.cpp:2296
 msgid "Select"
 msgstr "Zgjidh"
 
-#: src/muuli_wdr.cpp:1874
+#: src/muuli_wdr.cpp:1873
 msgid "Tree"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1884
+#: src/muuli_wdr.cpp:1883
 msgid "Number of Client Versions shown (0=unlimited)"
 msgstr "Numera te treguar te versioneve te klienteve (0= pa kufij)"
 
-#: src/muuli_wdr.cpp:1909
+#: src/muuli_wdr.cpp:1908
 msgid "!!! WARNING !!!"
 msgstr "!!! KUJDES !!!"
 
-#: src/muuli_wdr.cpp:1924
+#: src/muuli_wdr.cpp:1923
 msgid "Max new connections / 5 secs"
 msgstr "Lidhe maksimale te reja / 5 sek"
 
-#: src/muuli_wdr.cpp:1926
+#: src/muuli_wdr.cpp:1925
 msgid "Concurrent Kad source lookups"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1928
+#: src/muuli_wdr.cpp:1927
 #, fuzzy
 msgid "Kad source re-search interval (minutes)"
 msgstr "Intervali i rifreskimit te FTP-se ne minuta"
 
-#: src/muuli_wdr.cpp:1930
+#: src/muuli_wdr.cpp:1929
 #, fuzzy
 msgid "Source re-ask interval (minutes)"
 msgstr "Intervali i rifreskimit te FTP-se ne minuta"
 
-#: src/muuli_wdr.cpp:1934
+#: src/muuli_wdr.cpp:1933
 msgid "File Buffer Size: 240000 bytes"
 msgstr "Madhesia e Buffer-it te failit: 240000 bytes"
 
-#: src/muuli_wdr.cpp:1938
+#: src/muuli_wdr.cpp:1937
 msgid "Use MMAP: memory-mapped file access (lower memory use)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1939
+#: src/muuli_wdr.cpp:1938
 msgid "Maps part files into memory instead of buffering them on the heap, lowering the process memory footprint. May reduce download speed on some disks; best for memory-constrained or upload-heavy hosts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1941
+#: src/muuli_wdr.cpp:1940
 msgid "Upload Queue Size: 5000 clients"
 msgstr "Madhesia e Radhes ne Ngarkim: 5000 klienta"
 
-#: src/muuli_wdr.cpp:1945
+#: src/muuli_wdr.cpp:1944
 msgid "Server connection refresh interval: Disable"
 msgstr "Interval i azhornimit te lidhjes se serverit: C'aktivizuar"
 
-#: src/muuli_wdr.cpp:1949
+#: src/muuli_wdr.cpp:1948
 msgid "Disable computer's timed standby mode"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1968
+#: src/muuli_wdr.cpp:1967
 msgid "Skin to use: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1977
+#: src/muuli_wdr.cpp:1976
 msgid "Show \"Fast eD2k Links Handler\" in every window."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1980
+#: src/muuli_wdr.cpp:1979
 msgid "Show extended info on categories tabs"
 msgstr "Trego informacion te zgjeruar ne tabelat e kategorive"
 
-#: src/muuli_wdr.cpp:1983
+#: src/muuli_wdr.cpp:1982
 #, fuzzy
 msgid "Show application version on title"
 msgstr "Trego shpejtesine e transferimit ne titull"
 
-#: src/muuli_wdr.cpp:1985
+#: src/muuli_wdr.cpp:1984
 msgid "Show transfer rates on title"
 msgstr "Trego shpejtesine e transferimit ne titull"
 
-#: src/muuli_wdr.cpp:1987
+#: src/muuli_wdr.cpp:1986
 msgid "Before application name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1989
+#: src/muuli_wdr.cpp:1988
 msgid "After application name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1992
+#: src/muuli_wdr.cpp:1991
 msgid "Show overhead bandwidth"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1996
+#: src/muuli_wdr.cpp:1995
 msgid "Vertical toolbar orientation"
 msgstr "Orientim Vertikal i toolbar-it"
 
-#: src/muuli_wdr.cpp:1998
+#: src/muuli_wdr.cpp:1997
 msgid "Live column sorting (auto-reorder rows as their values change)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2005
+#: src/muuli_wdr.cpp:2004
 msgid "Download Queue Files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2008
+#: src/muuli_wdr.cpp:2007
 msgid "Show progress percentage"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2014
+#: src/muuli_wdr.cpp:2013
 msgid "Show progress bar"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2017
+#: src/muuli_wdr.cpp:2016
 msgid "Flat"
 msgstr "E sheshte"
 
-#: src/muuli_wdr.cpp:2021
+#: src/muuli_wdr.cpp:2020
 msgid "Round"
 msgstr "E rrumbullakosur"
 
-#: src/muuli_wdr.cpp:2039
+#: src/muuli_wdr.cpp:2038
 msgid "External Connection Parameters"
 msgstr "Parametrat e Lidhjeve te Jashtme"
 
-#: src/muuli_wdr.cpp:2042
+#: src/muuli_wdr.cpp:2041
 msgid "Accept external connections"
 msgstr "Prano lidhje te jashtme"
 
-#: src/muuli_wdr.cpp:2049 src/muuli_wdr.cpp:2108
+#: src/muuli_wdr.cpp:2048 src/muuli_wdr.cpp:2107
 msgid "IP of the listening interface:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2052
+#: src/muuli_wdr.cpp:2051
 msgid "Enter here a valid ip in the a.b.c.d format for the listening EC interface. An empty field or 0.0.0.0 will mean any interface."
 msgstr "Futni ketu nje ip te vlefshem ne formatin a.b.c.d per te degjuar nderfaqesin EC. Nje fushe boshe ose 0.0.0.0 do te nenkuptoje cdo nderfaqe."
 
-#: src/muuli_wdr.cpp:2073 src/muuli_wdr.cpp:2184
+#: src/muuli_wdr.cpp:2072 src/muuli_wdr.cpp:2156
 msgid "TCP port:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2079
+#: src/muuli_wdr.cpp:2078
 msgid "Enable UPnP port forwarding on the EC port"
 msgstr "Aktivizo port forwarding UPnP tek porta EC"
 
-#: src/muuli_wdr.cpp:2083 src/muuli_wdr.cpp:3069
+#: src/muuli_wdr.cpp:2082 src/muuli_wdr.cpp:3041
 #: src/utils/wxCas/src/wxcasprefs.cpp:167
 msgid "Password"
 msgstr "Fjalekalim"
 
-#: src/muuli_wdr.cpp:2089
+#: src/muuli_wdr.cpp:2088
 msgid "aMule API server parameters"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2092
+#: src/muuli_wdr.cpp:2091
 msgid "Run amuleapi (REST API) on startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2097
+#: src/muuli_wdr.cpp:2096
 #, fuzzy
 msgid "HTTP port:"
 msgstr "Porta e Proksit:"
 
-#: src/muuli_wdr.cpp:2111
+#: src/muuli_wdr.cpp:2110
 msgid "The interface amuleapi's HTTP server listens on. 127.0.0.1 (default) accepts only local connections; use 0.0.0.0 or a specific IP to expose it to other hosts (set an admin password below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2116
-msgid "Type a password to set or change it. Stored passwords cannot be shown, so leaving this empty keeps the current one."
-msgstr ""
-
-#: src/muuli_wdr.cpp:2118
+#: src/muuli_wdr.cpp:2113
 #, fuzzy
 msgid "Admin password"
 msgstr "Duke kerkuar fjalekalimin\n"
 
-#: src/muuli_wdr.cpp:2130 src/muuli_wdr.cpp:2147 src/PrefsUnifiedDlg.cpp:1103
-#, fuzzy
-msgid "A password is set."
-msgstr "Duke kerkuar fjalekalimin\n"
-
-#: src/muuli_wdr.cpp:2134
-#, fuzzy
-msgid "Enable guest access"
-msgstr "Ndalo hyrjen e guest-ve"
-
-#: src/muuli_wdr.cpp:2135
-msgid "Guest sessions may read status and listings but cannot change anything. Turning this off clears the stored guest password."
-msgstr ""
-
-#: src/muuli_wdr.cpp:2139
-#, fuzzy
-msgid "Guest password"
-msgstr "Fjalekalim per te drejta komplete"
-
-#: src/muuli_wdr.cpp:2154
-msgid "Web server parameters"
-msgstr ""
-
-#: src/muuli_wdr.cpp:2157
-msgid "Run webserver on startup (deprecated)"
-msgstr ""
-
-#: src/muuli_wdr.cpp:2163
-msgid "Web template"
-msgstr "Modeli Web"
-
-#: src/muuli_wdr.cpp:2168
-msgid "Full rights password"
-msgstr "Fjalekalim per te drejta komplete"
-
-#: src/muuli_wdr.cpp:2172
-msgid "Enable Low rights User"
-msgstr "Aktivizo Perdorues me te drejta te kufizuara"
-
-#: src/muuli_wdr.cpp:2177
+#: src/muuli_wdr.cpp:2118 src/muuli_wdr.cpp:2149
 msgid "Low rights password"
 msgstr "Fjalekalim per te drejta te kufizuara"
 
-#: src/muuli_wdr.cpp:2191
+#: src/muuli_wdr.cpp:2126
+msgid "Web server parameters"
+msgstr ""
+
+#: src/muuli_wdr.cpp:2129
+msgid "Run webserver on startup (deprecated)"
+msgstr ""
+
+#: src/muuli_wdr.cpp:2135
+msgid "Web template"
+msgstr "Modeli Web"
+
+#: src/muuli_wdr.cpp:2140
+msgid "Full rights password"
+msgstr "Fjalekalim per te drejta komplete"
+
+#: src/muuli_wdr.cpp:2144
+msgid "Enable Low rights User"
+msgstr "Aktivizo Perdorues me te drejta te kufizuara"
+
+#: src/muuli_wdr.cpp:2163
 msgid "Enable UPnP port forwarding of the web server port"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2196
+#: src/muuli_wdr.cpp:2168
 msgid "Web server UPnP TCP port (Optional)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2204
+#: src/muuli_wdr.cpp:2176
 msgid "Page Refresh Time (in secs)"
 msgstr "Koha e Rifreskimit te Faqes (ne sek)"
 
-#: src/muuli_wdr.cpp:2211
+#: src/muuli_wdr.cpp:2183
 msgid "Enable Gzip compression"
 msgstr "Aktivizo kompresimin Gzip"
 
-#: src/muuli_wdr.cpp:2245
+#: src/muuli_wdr.cpp:2217
 #, fuzzy
 msgid "Reset page to defaults"
 msgstr "E vendosur nga sistemi"
 
-#: src/muuli_wdr.cpp:2246
+#: src/muuli_wdr.cpp:2218
 msgid "Reset the settings on the current page to their default values."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2248 src/muuli_wdr.cpp:2334 src/ServerWnd.cpp:274
+#: src/muuli_wdr.cpp:2220 src/muuli_wdr.cpp:2306 src/ServerWnd.cpp:274
 #: src/ServerWnd.cpp:282
 msgid "OK"
 msgstr "Ne rregull"
 
-#: src/muuli_wdr.cpp:2250
+#: src/muuli_wdr.cpp:2222
 msgid "Click here to apply any changes made to the preferences."
 msgstr "Kliko ketu per te bere aktive ndryshimet qe u bene tek Preferencat."
 
-#: src/muuli_wdr.cpp:2253
+#: src/muuli_wdr.cpp:2225
 msgid "Reset any changes made to the preferences."
 msgstr "Rikthe ne gjendjen e meparshme ndryshimet te bera tek Preferencat."
 
-#: src/muuli_wdr.cpp:2282
+#: src/muuli_wdr.cpp:2254
 msgid "Comment :"
 msgstr "Komente :"
 
-#: src/muuli_wdr.cpp:2289
+#: src/muuli_wdr.cpp:2261
 msgid "Incoming Dir :"
 msgstr "Direktoria e Hyrjeve :"
 
-#: src/muuli_wdr.cpp:2298
+#: src/muuli_wdr.cpp:2270
 msgid "Change priority for new assigned files :"
 msgstr "Nderro perparesine per failet e reja te caktuara :"
 
-#: src/muuli_wdr.cpp:2302
+#: src/muuli_wdr.cpp:2274
 #, fuzzy
 msgid "Don't change"
 msgstr "Mos nderro"
 
-#: src/muuli_wdr.cpp:2314
+#: src/muuli_wdr.cpp:2286
 msgid "Select color for this Category (currently selected) :"
 msgstr "Zgjidh ngjyren per kete kategori (e zgjedhur aktualisht) :"
 
-#: src/muuli_wdr.cpp:2381 src/muuli_wdr.cpp:2400 src/muuli_wdr.cpp:2422
+#: src/muuli_wdr.cpp:2353 src/muuli_wdr.cpp:2372 src/muuli_wdr.cpp:2394
 msgid "Click this button to reset the log."
 msgstr "Kliko ne kete buton per te resetuar log-un."
 
-#: src/muuli_wdr.cpp:2441
+#: src/muuli_wdr.cpp:2413
 msgid "Click on this button to update the servers list from URL ..."
 msgstr "Kliko ne kete buton per te azhornuar listen e serverave nga URL ..."
 
-#: src/muuli_wdr.cpp:2445
+#: src/muuli_wdr.cpp:2417
 msgid "Server list"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2449
+#: src/muuli_wdr.cpp:2421
 msgid "Enter the url to a server.met file here and press the button to the left to update the list of known servers."
 msgstr "Futni url tek nje fail server.met dhe shtypni butonin ne te majte per te azhornuar listen e serverave te njohur."
 
-#: src/muuli_wdr.cpp:2454
+#: src/muuli_wdr.cpp:2426
 msgid "Add server manually: Name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2457
+#: src/muuli_wdr.cpp:2429
 msgid "Enter the name of the new server here"
 msgstr "Futni emrin e serverit te ri ketu"
 
-#: src/muuli_wdr.cpp:2459 src/ServerWnd.cpp:206
+#: src/muuli_wdr.cpp:2431 src/ServerWnd.cpp:206
 msgid "IP:Port"
 msgstr "IP:Porta"
 
-#: src/muuli_wdr.cpp:2462
+#: src/muuli_wdr.cpp:2434
 msgid "Enter the IP of the server here, using the x.x.x.x format."
 msgstr "Futni IP-ne e serverit ketu. duke perdorur formatin x.x.x.x."
 
-#: src/muuli_wdr.cpp:2468
+#: src/muuli_wdr.cpp:2440
 msgid "Enter the port of the server here."
 msgstr "Futni porten e serverit ketu."
 
-#: src/muuli_wdr.cpp:2471
+#: src/muuli_wdr.cpp:2443
 msgid "Add manually a server (fill fields to the left before) ..."
 msgstr "Shto ne menyre manuale nje server (mbushni fushen ne te majte me pare) ..."
 
-#: src/muuli_wdr.cpp:2500
+#: src/muuli_wdr.cpp:2472
 msgid "aMule Log"
 msgstr "Log i aMule"
 
-#: src/muuli_wdr.cpp:2508
+#: src/muuli_wdr.cpp:2480
 msgid "Server Info"
 msgstr "Informacion mbi serverin"
 
-#: src/muuli_wdr.cpp:2512
+#: src/muuli_wdr.cpp:2484
 msgid "ED2K Info"
 msgstr "Informacioni i ED2K"
 
-#: src/muuli_wdr.cpp:2516
+#: src/muuli_wdr.cpp:2488
 msgid "Kad Info"
 msgstr "Informacioni i Kad"
 
-#: src/muuli_wdr.cpp:2544
+#: src/muuli_wdr.cpp:2516
 msgid "Click on this button to update the nodes list from URL ..."
 msgstr "Kliko ne kete buton per te azhornuar listen e nyjeve nga URL ..."
 
-#: src/muuli_wdr.cpp:2548
+#: src/muuli_wdr.cpp:2520
 msgid "Nodes (0)"
 msgstr "Nyjet (0)"
 
-#: src/muuli_wdr.cpp:2552
+#: src/muuli_wdr.cpp:2524
 msgid "Enter the url to a nodes.dat file here and press the button to the left to update the list of known nodes."
 msgstr "Fut url e nje faili nodes.dat dhe shtyp butonin ne te majte per te azhornuar listen e nyjeve te njohura."
 
-#: src/muuli_wdr.cpp:2555
+#: src/muuli_wdr.cpp:2527
 msgid "Nodes stats"
 msgstr "Statistikat e Nyjeve"
 
-#: src/muuli_wdr.cpp:2597
+#: src/muuli_wdr.cpp:2569
 msgid "Bootstrap"
 msgstr "Bootstrap"
 
-#: src/muuli_wdr.cpp:2600
+#: src/muuli_wdr.cpp:2572
 msgid "New node"
 msgstr "Nyje e re"
 
-#: src/muuli_wdr.cpp:2605
+#: src/muuli_wdr.cpp:2577
 msgid "IP:"
 msgstr "IP:"
 
-#: src/muuli_wdr.cpp:2625
+#: src/muuli_wdr.cpp:2597
 msgid "Port:"
 msgstr "Porta:"
 
-#: src/muuli_wdr.cpp:2638
+#: src/muuli_wdr.cpp:2610
 #, fuzzy
 msgid "Bootstrap from known clients"
 msgstr ""
 "Bootstrap nga \n"
 "kliente te njohur"
 
-#: src/muuli_wdr.cpp:2640
+#: src/muuli_wdr.cpp:2612
 msgid "Disconnect Kad"
 msgstr "Shkeput Kad"
 
-#: src/muuli_wdr.cpp:2674
+#: src/muuli_wdr.cpp:2646
 msgid "Use Secure User Identification"
 msgstr "Perdor Identifikimin e Sigurte te Perdoruesve"
 
-#: src/muuli_wdr.cpp:2676
+#: src/muuli_wdr.cpp:2648
 msgid "It is recommended to enable this option. You will not receive credits if SUI is not enabled."
 msgstr "Eshte e rekomandueshme qe ta lejoni kete opsion. Ju nuk mund te merrni kredite nqs SUI nuk eshte i aktivizuar."
 
-#: src/muuli_wdr.cpp:2678
+#: src/muuli_wdr.cpp:2650
 msgid "Protocol Obfuscation"
 msgstr "Protokolli i Turbullimit"
 
-#: src/muuli_wdr.cpp:2681
+#: src/muuli_wdr.cpp:2653
 msgid "Support Protocol Obfuscation"
 msgstr "Mbeshtet Protokollin e Turbullimit"
 
-#: src/muuli_wdr.cpp:2683
+#: src/muuli_wdr.cpp:2655
 msgid "This option enabled Protocol Obfuscation, and makes aMule accept obfuscated connections from other clients."
 msgstr "Ky opsion lejon Protokollin e Turbullimit, dhe ben qe aMule te pranoje lidhje te turbulluara nga kliente te tjere."
 
-#: src/muuli_wdr.cpp:2685
+#: src/muuli_wdr.cpp:2657
 msgid "Use obfuscation for outgoing connections"
 msgstr "Perdor turbullimin per lidhjet ne dalje"
 
-#: src/muuli_wdr.cpp:2687
+#: src/muuli_wdr.cpp:2659
 msgid "This option makes aMule use Protocol Obfuscation when connecting other clients/servers."
 msgstr "Ky opsion lejon aMule-n qe te perdori protokollin e turbullimit kur lidhet me klientet/serverat e tjere."
 
-#: src/muuli_wdr.cpp:2689
+#: src/muuli_wdr.cpp:2661
 msgid "Accept only obfuscated connections"
 msgstr "Prano vetem lidhje te turbulluara"
 
-#: src/muuli_wdr.cpp:2690
+#: src/muuli_wdr.cpp:2662
 msgid "This option makes aMule only accept obfuscated connections. You will have less sources, but all your traffic will be obfuscated"
 msgstr "Ky opsion e ben aMule-n qe te lejoje lidhje te turbulluara. Ju do te keni me pak burime, por i gjithe trafiku juaj do te turbullohet"
 
-#: src/muuli_wdr.cpp:2695
+#: src/muuli_wdr.cpp:2667
 msgid "Everybody"
 msgstr "Te gjithe"
 
-#: src/muuli_wdr.cpp:2697
+#: src/muuli_wdr.cpp:2669
 msgid "No one"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2699
+#: src/muuli_wdr.cpp:2671
 msgid "Who can see my shared files:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2700
+#: src/muuli_wdr.cpp:2672
 msgid "Select who can request to view a list of your shared files."
 msgstr "Zgjidh se kush ka kerkuar te shikoje listene faileve qe ju keni ndare."
 
-#: src/muuli_wdr.cpp:2702
+#: src/muuli_wdr.cpp:2674
 msgid "IP-Filtering"
 msgstr "Filtrimi-IP"
 
-#: src/muuli_wdr.cpp:2709
+#: src/muuli_wdr.cpp:2681
 msgid "Filter clients"
 msgstr "Filtro klientet"
 
-#: src/muuli_wdr.cpp:2711
+#: src/muuli_wdr.cpp:2683
 msgid "Enable filtering of the client IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "Lejo filtrimin e IP-ve te klientave te percaktuar ne failin ~/.aMule/ipfilter.dat."
 
-#: src/muuli_wdr.cpp:2713
+#: src/muuli_wdr.cpp:2685
 msgid "Filter servers"
 msgstr "Filtron Serverat"
 
-#: src/muuli_wdr.cpp:2715
+#: src/muuli_wdr.cpp:2687
 msgid "Enable filtering of the server IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "Lejo filtrimin e IP-ve te serverave te percaktuara ne failin ~/.aMule/ipfilter.dat."
 
-#: src/muuli_wdr.cpp:2719
+#: src/muuli_wdr.cpp:2691
 msgid "Reload List"
 msgstr "Lista e Ringarkimeve"
 
-#: src/muuli_wdr.cpp:2720
+#: src/muuli_wdr.cpp:2692
 msgid "Reload the list of IPs to filter from the file ~/.aMule/ipfilter.dat"
 msgstr "Ringarko listen e IP-ve per te filtruar nga faili ~/.aMule/ipfilter.dat"
 
-#: src/muuli_wdr.cpp:2726
+#: src/muuli_wdr.cpp:2698
 msgid "URL:"
 msgstr "URL:"
 
-#: src/muuli_wdr.cpp:2730 src/muuli_wdr.cpp:2923
+#: src/muuli_wdr.cpp:2702 src/muuli_wdr.cpp:2895
 msgid "Update now"
 msgstr "Azhorno tani"
 
-#: src/muuli_wdr.cpp:2733
+#: src/muuli_wdr.cpp:2705
 msgid "Auto-update ipfilter at startup"
 msgstr "Azhornim-Automatik i ipfilter sapo te ndizet"
 
-#: src/muuli_wdr.cpp:2737
+#: src/muuli_wdr.cpp:2709
 msgid "Filtering Level:"
 msgstr "Niveli i Filtrimit:"
 
-#: src/muuli_wdr.cpp:2743
+#: src/muuli_wdr.cpp:2715
 msgid "Always filter LAN IPs"
 msgstr "Gjithmone filtro IP-te LAN"
 
-#: src/muuli_wdr.cpp:2746
+#: src/muuli_wdr.cpp:2718
 msgid "Paranoid handling of non-matching IPs"
 msgstr "Perdorim Paranoik te IP-ve qe nuk korrespondojne"
 
-#: src/muuli_wdr.cpp:2748
+#: src/muuli_wdr.cpp:2720
 msgid "Rejects a packet when its source IP differs from the IP the client claims (an anti-spoofing check). Disable only if it causes connection problems."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2750
+#: src/muuli_wdr.cpp:2722
 msgid "Use system-wide ipfilter.dat if available"
 msgstr "Perdor ipfilter.dat te sistemit nqs eshte i disponueshem"
 
-#: src/muuli_wdr.cpp:2751
+#: src/muuli_wdr.cpp:2723
 #, fuzzy
 msgid "If there's no local ipfilter.dat found, allow usage of a system-wide ipfilter file."
 msgstr "Nese nuk eshte gjetur ndonje ipfilter.dat lokal, lejo perdorimin e failit ipfilter te sistemit."
 
-#: src/muuli_wdr.cpp:2768
+#: src/muuli_wdr.cpp:2740
 msgid "Enable Online-Signature"
 msgstr "Lejo Firmen-Online"
 
-#: src/muuli_wdr.cpp:2770
+#: src/muuli_wdr.cpp:2742
 msgid "Enables the writing of the OS file, which can be used by external apps to create signatures and the like."
 msgstr "Lejon shkrimin e faileve OS, qe mund te perdorren nga aplikacione te jashtme per te krijuar firma dhe te ngjashme."
 
-#: src/muuli_wdr.cpp:2774
+#: src/muuli_wdr.cpp:2746
 msgid "Update Frequency (Secs):"
 msgstr "Frekuenca e azhornimeve (sek):"
 
-#: src/muuli_wdr.cpp:2777
+#: src/muuli_wdr.cpp:2749
 msgid "Change the frequency (in seconds) of Online Signature updates."
 msgstr "Nderron frekuqncen (ne sekonda) te azhornimit te Firmes Online."
 
-#: src/muuli_wdr.cpp:2785
+#: src/muuli_wdr.cpp:2757
 msgid "Save online signature file in: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:2791
+#: src/muuli_wdr.cpp:2763
 msgid "Click here to select the directory containing the the Online Signature files."
 msgstr "Shtypni ketu per te zgjedhur direktorine qe permban failet e Firmes Online."
 
-#: src/muuli_wdr.cpp:2824
+#: src/muuli_wdr.cpp:2796
 msgid "Show country flags for clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2825
+#: src/muuli_wdr.cpp:2797
 msgid "Render the country flag column in the transfers, queue and search views. Requires a valid MMDB GeoIP database (see below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2830
+#: src/muuli_wdr.cpp:2802
 #, fuzzy
 msgid "Database"
 msgstr "Shpejtesia :"
 
-#: src/muuli_wdr.cpp:2846
+#: src/muuli_wdr.cpp:2818
 #, fuzzy
 msgid "Source:"
 msgstr "Burime"
 
-#: src/muuli_wdr.cpp:2849
+#: src/muuli_wdr.cpp:2821
 msgid "DB-IP (free, no account)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2850
+#: src/muuli_wdr.cpp:2822
 msgid "MaxMind GeoLite2 (free, account required)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2851
+#: src/muuli_wdr.cpp:2823
 msgid "Custom URL"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2854
+#: src/muuli_wdr.cpp:2826
 msgid "Choose which provider supplies the GeoIP MMDB database. DB-IP is the default - no account required. MaxMind requires a free account + license key. Use Custom URL to point at any other MMDB host (e.g. a local mirror)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2871
+#: src/muuli_wdr.cpp:2843
 msgid ""
 "No configuration required.\n"
 "\n"
@@ -4884,11 +4850,11 @@ msgid ""
 "License: Creative Commons BY 4.0 - https://creativecommons.org/licenses/by/4.0/"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2884
+#: src/muuli_wdr.cpp:2856
 msgid "License key:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2890
+#: src/muuli_wdr.cpp:2862
 msgid ""
 "Sign up for a free MaxMind account, then generate a License Key:\n"
 "https://www.maxmind.com/en/geolite2/signup\n"
@@ -4898,232 +4864,232 @@ msgid ""
 "Requires attribution and account registration; refresh at least every 30 days."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2905
+#: src/muuli_wdr.cpp:2877
 #, fuzzy
 msgid "Download URL:"
 msgstr "Shkarkim: "
 
-#: src/muuli_wdr.cpp:2911
+#: src/muuli_wdr.cpp:2883
 msgid ""
 "Must point to an .mmdb file or a .gz / .tar.gz containing one.\n"
 "URL may include credentials (https://user:pass@host/...).\n"
 "License and attribution terms are set by the upstream URL - you are responsible."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2924
+#: src/muuli_wdr.cpp:2896
 msgid "Download the GeoIP database from the selected source."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2926
+#: src/muuli_wdr.cpp:2898
 #, fuzzy
 msgid "Auto-update on startup"
 msgstr "Azhornim-Automatik i ipfilter sapo te ndizet"
 
-#: src/muuli_wdr.cpp:2927
+#: src/muuli_wdr.cpp:2899
 msgid "Re-download the GeoIP database from the selected source every time aMule starts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2950
+#: src/muuli_wdr.cpp:2922
 msgid "Filter incoming messages (except current chat):"
 msgstr "Filtron mesazhet ne hyrje (pervec chatit qe po zhvilloni):"
 
-#: src/muuli_wdr.cpp:2952
+#: src/muuli_wdr.cpp:2924
 msgid "Filter all messages"
 msgstr "Filtron te gjithe mesazhet"
 
-#: src/muuli_wdr.cpp:2954
+#: src/muuli_wdr.cpp:2926
 msgid "Filter messages from people not on your friend list"
 msgstr "Filtron mesazhet nga njerezit qe nuk ndohen ne listen e miqve tuaj"
 
-#: src/muuli_wdr.cpp:2956
+#: src/muuli_wdr.cpp:2928
 msgid "Filter messages from unknown clients"
 msgstr "Filtron mesazhet nga klienta t èanjohur"
 
-#: src/muuli_wdr.cpp:2958
+#: src/muuli_wdr.cpp:2930
 msgid "Filter messages containing (use ',' as separator):"
 msgstr "Filtron mesazhet qe permbajne (perdor ',' si nje ndarese):"
 
-#: src/muuli_wdr.cpp:2961 src/muuli_wdr.cpp:2972
+#: src/muuli_wdr.cpp:2933 src/muuli_wdr.cpp:2944
 msgid "add here the words amule should filter and block messages including it"
 msgstr "shto ketu fjalet qe aMule do te filtroje duke bllokuar mesazhet qe ato mbajne"
 
-#: src/muuli_wdr.cpp:2963
+#: src/muuli_wdr.cpp:2935
 msgid "Show received messages in the log"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2966
+#: src/muuli_wdr.cpp:2938
 msgid "Comments"
 msgstr "Komente"
 
-#: src/muuli_wdr.cpp:2969
+#: src/muuli_wdr.cpp:2941
 msgid "Filter comments containing (use ',' as separator):"
 msgstr "Komente e filtrave permbajne (perdor ',' si nje ndarese):"
 
-#: src/muuli_wdr.cpp:2994
+#: src/muuli_wdr.cpp:2966
 msgid "Enable Proxy"
 msgstr "Aktivizo Proksin(Proxy)"
 
-#: src/muuli_wdr.cpp:2995
+#: src/muuli_wdr.cpp:2967
 msgid "Enable/disable proxy support"
 msgstr "Aktivizo/C'aktivizo mbeshtetjen e Proksit(Proxy)"
 
-#: src/muuli_wdr.cpp:2998
+#: src/muuli_wdr.cpp:2970
 msgid "Proxy type:"
 msgstr "Lloji i Proksit(Proxy):"
 
-#: src/muuli_wdr.cpp:3009
+#: src/muuli_wdr.cpp:2981
 msgid "Proxy host:"
 msgstr "Hosti i Proksit(Proxy)"
 
-#: src/muuli_wdr.cpp:3012
+#: src/muuli_wdr.cpp:2984
 msgid "The proxy host name"
 msgstr "Host Name i Proksit(Proxy)"
 
-#: src/muuli_wdr.cpp:3014
+#: src/muuli_wdr.cpp:2986
 msgid "Proxy port:"
 msgstr "Porta e Proksit:"
 
-#: src/muuli_wdr.cpp:3017
+#: src/muuli_wdr.cpp:2989
 msgid "The proxy port"
 msgstr "Porta e Proksit(Proxy)"
 
-#: src/muuli_wdr.cpp:3019
+#: src/muuli_wdr.cpp:2991
 msgid "Enable authentication"
 msgstr "Aktivizo njohjen"
 
-#: src/muuli_wdr.cpp:3020
+#: src/muuli_wdr.cpp:2992
 msgid "Enable/disable username/password authentication"
 msgstr "Aktivizo/C'aktivizo emri i perdoruesit/njohja e fjalekalimit"
 
-#: src/muuli_wdr.cpp:3023
+#: src/muuli_wdr.cpp:2995
 msgid "Username: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:3026
+#: src/muuli_wdr.cpp:2998
 msgid "The username to use to connect to the proxy"
 msgstr "Emri i perdorimit qe do perdoret per tu lidhur tek Proksi(Proxy)"
 
-#: src/muuli_wdr.cpp:3028
+#: src/muuli_wdr.cpp:3000
 msgid "Password:"
 msgstr "Fjalekalimi:"
 
-#: src/muuli_wdr.cpp:3031
+#: src/muuli_wdr.cpp:3003
 msgid "The password to use to connect to the proxy"
 msgstr "Fjalekalimi per te perdorur per tu lidhur tek Proksi(Proxy)"
 
-#: src/muuli_wdr.cpp:3050
+#: src/muuli_wdr.cpp:3022
 msgid "Connect to:"
 msgstr "Lidhu me:"
 
-#: src/muuli_wdr.cpp:3059
+#: src/muuli_wdr.cpp:3031
 msgid "Login to remote amule"
 msgstr "Futu tek Remote i aMule"
 
-#: src/muuli_wdr.cpp:3064
+#: src/muuli_wdr.cpp:3036
 msgid "User name"
 msgstr "Emri i Perdoruesit"
 
-#: src/muuli_wdr.cpp:3075
+#: src/muuli_wdr.cpp:3047
 msgid "Remember those settings"
 msgstr "Mbaji mend keto rregullime"
 
-#: src/muuli_wdr.cpp:3078
+#: src/muuli_wdr.cpp:3050
 #, fuzzy
 msgid "Force ZLIB compression"
 msgstr "Perdor kompresimin gzip"
 
-#: src/muuli_wdr.cpp:3102
+#: src/muuli_wdr.cpp:3074
 msgid "Enable Verbose Debug-Logging."
 msgstr "Aktivizon logging-un e detajuar te mesazheve te debug-ut."
 
-#: src/muuli_wdr.cpp:3104
+#: src/muuli_wdr.cpp:3076
 #, fuzzy
 msgid "Only to Logfile"
 msgstr "&Hap failin"
 
-#: src/muuli_wdr.cpp:3106
+#: src/muuli_wdr.cpp:3078
 msgid "Message Categories:"
 msgstr "Kategorite e Mesazheve:"
 
-#: src/muuli_wdr.cpp:3130 src/PartFileConvertDlg.cpp:160
+#: src/muuli_wdr.cpp:3102 src/PartFileConvertDlg.cpp:160
 msgid "Waiting..."
 msgstr "Ne pritje..."
 
-#: src/muuli_wdr.cpp:3150
+#: src/muuli_wdr.cpp:3122
 msgid "Add imports"
 msgstr "Shton importimet"
 
-#: src/muuli_wdr.cpp:3153
+#: src/muuli_wdr.cpp:3125
 msgid "Retry selected"
 msgstr "Provoji perseri te perzgjedhurit"
 
-#: src/muuli_wdr.cpp:3155
+#: src/muuli_wdr.cpp:3127
 msgid "Remove selected"
 msgstr "Zhvendos te perzgjedhurat"
 
-#: src/muuli_wdr.cpp:3218
+#: src/muuli_wdr.cpp:3190
 msgid "Event Types"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3237
+#: src/muuli_wdr.cpp:3209
 msgid "Statistics and queued clients for selected file(s) : Session / All time"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3261
+#: src/muuli_wdr.cpp:3233
 #, fuzzy
 msgid "Active Uploads"
 msgstr "Ngarkime Aktive :"
 
-#: src/muuli_wdr.cpp:3275
+#: src/muuli_wdr.cpp:3247
 msgid "Percent of total files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3327
+#: src/muuli_wdr.cpp:3299
 #, fuzzy
 msgid "Show Clients for"
 msgstr "Trego klientet"
 
-#: src/muuli_wdr.cpp:3329
+#: src/muuli_wdr.cpp:3301
 #, fuzzy
 msgid "All files"
 msgstr "Fshih failet e ndara"
 
-#: src/muuli_wdr.cpp:3332
+#: src/muuli_wdr.cpp:3304
 #, fuzzy
 msgid "Selected files"
 msgstr "Zgjidh filtrin e shikimit"
 
-#: src/muuli_wdr.cpp:3335
+#: src/muuli_wdr.cpp:3307
 #, fuzzy
 msgid "Active uploads only"
 msgstr "Ngarkime Aktive"
 
-#: src/muuli_wdr.cpp:3342
+#: src/muuli_wdr.cpp:3314
 #, fuzzy
 msgid "Reload:"
 msgstr "Lista e Ringarkimeve"
 
-#: src/muuli_wdr.cpp:3346
+#: src/muuli_wdr.cpp:3318
 msgid "Reload your shared files"
 msgstr "Ringarko failet e ndara"
 
-#: src/muuli_wdr.cpp:3409
+#: src/muuli_wdr.cpp:3381
 msgid "Send"
 msgstr "Dergo"
 
-#: src/muuli_wdr.cpp:3410
+#: src/muuli_wdr.cpp:3382
 msgid "Sends the specified message."
 msgstr "Dergo mesazhin e specifikuar."
 
-#: src/muuli_wdr.cpp:3414
+#: src/muuli_wdr.cpp:3386
 msgid "Close this chat-session."
 msgstr "Mbylle kete sesion chati."
 
-#: src/muuli_wdr.cpp:3437
+#: src/muuli_wdr.cpp:3409
 msgid "Connect to any server and/or Kad"
 msgstr "Lidhu me ndonje server dhe/ose Kad"
 
-#: src/muuli_wdr.cpp:3443 src/SharedFilesCtrl.cpp:142 src/Statistics.cpp:941
+#: src/muuli_wdr.cpp:3415 src/SharedFilesCtrl.cpp:142 src/Statistics.cpp:941
 msgid "Shared Files"
 msgstr "File te ndara"
 
@@ -5484,268 +5450,268 @@ msgstr ""
 msgid "ERROR: Failed to open partfile '%s'"
 msgstr ""
 
-#: src/Preferences.cpp:701
+#: src/Preferences.cpp:673
 msgid "System default"
 msgstr "E vendosur nga sistemi"
 
-#: src/Preferences.cpp:702
+#: src/Preferences.cpp:674
 msgid "Albanian"
 msgstr "Shqip"
 
-#: src/Preferences.cpp:703
+#: src/Preferences.cpp:675
 msgid "Arabic"
 msgstr "Arabe"
 
-#: src/Preferences.cpp:704
+#: src/Preferences.cpp:676
 #, fuzzy
 msgid "Asturian"
 msgstr "Estoneze"
 
-#: src/Preferences.cpp:705
+#: src/Preferences.cpp:677
 msgid "Basque"
 msgstr "Baske"
 
-#: src/Preferences.cpp:706
+#: src/Preferences.cpp:678
 msgid "Bulgarian"
 msgstr "Bullgare"
 
-#: src/Preferences.cpp:707
+#: src/Preferences.cpp:679
 msgid "Catalan"
 msgstr "Katallanase"
 
-#: src/Preferences.cpp:708
+#: src/Preferences.cpp:680
 msgid "Chinese (Simplified)"
 msgstr "Kineze (E thjeshtesuar)"
 
-#: src/Preferences.cpp:709
+#: src/Preferences.cpp:681
 msgid "Chinese (Traditional)"
 msgstr "KIneze (Tradicionale)"
 
-#: src/Preferences.cpp:710
+#: src/Preferences.cpp:682
 msgid "Croatian"
 msgstr "Kroate"
 
-#: src/Preferences.cpp:711
+#: src/Preferences.cpp:683
 msgid "Czech"
 msgstr "Ceke"
 
-#: src/Preferences.cpp:712
+#: src/Preferences.cpp:684
 msgid "Danish"
 msgstr "Daneze"
 
-#: src/Preferences.cpp:713
+#: src/Preferences.cpp:685
 msgid "Dutch"
 msgstr "Holandeze"
 
-#: src/Preferences.cpp:714
+#: src/Preferences.cpp:686
 msgid "English (U.K.)"
 msgstr "Anglisht (G.B.)"
 
-#: src/Preferences.cpp:715
+#: src/Preferences.cpp:687
 #, fuzzy
 msgid "English (U.S.)"
 msgstr "Anglisht (G.B.)"
 
-#: src/Preferences.cpp:716
+#: src/Preferences.cpp:688
 msgid "Estonian"
 msgstr "Estoneze"
 
-#: src/Preferences.cpp:717
+#: src/Preferences.cpp:689
 msgid "Finnish"
 msgstr "Finlandeze"
 
-#: src/Preferences.cpp:718
+#: src/Preferences.cpp:690
 msgid "French"
 msgstr "Frengjisht"
 
-#: src/Preferences.cpp:719
+#: src/Preferences.cpp:691
 msgid "Galician"
 msgstr "Galiciane"
 
-#: src/Preferences.cpp:720
+#: src/Preferences.cpp:692
 msgid "German"
 msgstr "Gjermanisht"
 
-#: src/Preferences.cpp:721
+#: src/Preferences.cpp:693
 msgid "Greek"
 msgstr "Greqisht"
 
-#: src/Preferences.cpp:722
+#: src/Preferences.cpp:694
 msgid "Hebrew"
 msgstr "Cifut"
 
-#: src/Preferences.cpp:723
+#: src/Preferences.cpp:695
 msgid "Hungarian"
 msgstr "Hungarisht"
 
-#: src/Preferences.cpp:724
+#: src/Preferences.cpp:696
 msgid "Italian"
 msgstr "Italiane"
 
-#: src/Preferences.cpp:725
+#: src/Preferences.cpp:697
 msgid "Japanese"
 msgstr "Japonisht"
 
-#: src/Preferences.cpp:726
+#: src/Preferences.cpp:698
 msgid "Korean"
 msgstr "Koreane"
 
-#: src/Preferences.cpp:727
+#: src/Preferences.cpp:699
 msgid "Latvian"
 msgstr ""
 
-#: src/Preferences.cpp:728
+#: src/Preferences.cpp:700
 msgid "Lithuanian"
 msgstr "Lituane"
 
-#: src/Preferences.cpp:729
+#: src/Preferences.cpp:701
 msgid "Norwegian (Nynorsk)"
 msgstr "Norvegjeze (Nynorsk)"
 
-#: src/Preferences.cpp:730
+#: src/Preferences.cpp:702
 msgid "Polish"
 msgstr "Polake"
 
-#: src/Preferences.cpp:731
+#: src/Preferences.cpp:703
 msgid "Portuguese"
 msgstr "Portugeze"
 
-#: src/Preferences.cpp:732
+#: src/Preferences.cpp:704
 msgid "Portuguese (Brazilian)"
 msgstr "Portugeze (Braziliane)"
 
-#: src/Preferences.cpp:733
+#: src/Preferences.cpp:705
 #, fuzzy
 msgid "Romanian"
 msgstr "Shqip"
 
-#: src/Preferences.cpp:734
+#: src/Preferences.cpp:706
 msgid "Russian"
 msgstr "Ruse"
 
-#: src/Preferences.cpp:735
+#: src/Preferences.cpp:707
 msgid "Slovenian"
 msgstr "Sllovene"
 
-#: src/Preferences.cpp:736
+#: src/Preferences.cpp:708
 msgid "Spanish"
 msgstr "Spanjolle"
 
-#: src/Preferences.cpp:737
+#: src/Preferences.cpp:709
 msgid "Swedish"
 msgstr "Suedeze"
 
-#: src/Preferences.cpp:738
+#: src/Preferences.cpp:710
 msgid "Turkish"
 msgstr "Turqisht"
 
-#: src/Preferences.cpp:739
+#: src/Preferences.cpp:711
 msgid "Ukrainian"
 msgstr ""
 
-#: src/Preferences.cpp:842
+#: src/Preferences.cpp:814
 #, fuzzy
 msgid "Change Language"
 msgstr "Gjuha"
 
-#: src/Preferences.cpp:906
+#: src/Preferences.cpp:878
 msgid "There are no translations installed for aMule"
 msgstr ""
 
-#: src/Preferences.cpp:907
+#: src/Preferences.cpp:879
 #, fuzzy
 msgid "No languages available"
 msgstr "Nuk eshte ne dispozicion"
 
-#: src/Preferences.cpp:1038
+#: src/Preferences.cpp:1010
 msgid "no options available"
 msgstr ""
 
-#: src/Preferences.cpp:2226
+#: src/Preferences.cpp:2179
 msgid "Invalid category found, skipping"
 msgstr ""
 
-#: src/Preferences.cpp:2395
+#: src/Preferences.cpp:2348
 msgid "TCP port can't be higher than 65532 due to server UDP socket being TCP+3"
 msgstr "Porta TCP nuk mund te jene me te medha se 65532  sepse socket i UDP eshte fiksuar ne TCP+3"
 
-#: src/Preferences.cpp:2396
+#: src/Preferences.cpp:2349
 #, c-format
 msgid "Default port will be used (%d)"
 msgstr "Do te perdoret porta e vendosur (%d)"
 
-#: src/PrefsUnifiedDlg.cpp:300 src/Statistics.cpp:866
+#: src/PrefsUnifiedDlg.cpp:298 src/Statistics.cpp:866
 msgid "Connection"
 msgstr "Lidhje"
 
-#: src/PrefsUnifiedDlg.cpp:301 src/SearchListCtrl.cpp:117
+#: src/PrefsUnifiedDlg.cpp:299 src/SearchListCtrl.cpp:117
 msgid "Directories"
 msgstr "Direktorite"
 
-#: src/PrefsUnifiedDlg.cpp:302 src/Statistics.cpp:917
+#: src/PrefsUnifiedDlg.cpp:300 src/Statistics.cpp:917
 msgid "Servers"
 msgstr "Servera"
 
-#: src/PrefsUnifiedDlg.cpp:303 src/ServerListCtrl.cpp:96
+#: src/PrefsUnifiedDlg.cpp:301 src/ServerListCtrl.cpp:96
 msgid "Files"
 msgstr "Failet"
 
-#: src/PrefsUnifiedDlg.cpp:304
+#: src/PrefsUnifiedDlg.cpp:302
 msgid "Security"
 msgstr "Sigurimi"
 
-#: src/PrefsUnifiedDlg.cpp:305
+#: src/PrefsUnifiedDlg.cpp:303
 msgid "Interface"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:312
+#: src/PrefsUnifiedDlg.cpp:310
 msgid "IP2Country"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:315
+#: src/PrefsUnifiedDlg.cpp:313
 msgid "Proxy"
 msgstr "Proksi"
 
-#: src/PrefsUnifiedDlg.cpp:316
+#: src/PrefsUnifiedDlg.cpp:314
 msgid "Filters"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:317
+#: src/PrefsUnifiedDlg.cpp:315
 msgid "Remote Controls"
 msgstr "Kontrollet e remote"
 
-#: src/PrefsUnifiedDlg.cpp:318
+#: src/PrefsUnifiedDlg.cpp:316
 msgid "Online Signature"
 msgstr "Firma online"
 
-#: src/PrefsUnifiedDlg.cpp:319
+#: src/PrefsUnifiedDlg.cpp:317
 msgid "Advanced"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:320
+#: src/PrefsUnifiedDlg.cpp:318
 msgid "Events"
 msgstr "Ngjarje"
 
-#: src/PrefsUnifiedDlg.cpp:323
+#: src/PrefsUnifiedDlg.cpp:321
 msgid "Debugging"
 msgstr "Debug"
 
-#: src/PrefsUnifiedDlg.cpp:453
+#: src/PrefsUnifiedDlg.cpp:451
 msgid ""
 "The following variables will be substituted:\n"
 "    %PARTFILE - full path to the file\n"
 "    %PARTNAME - file name only"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:474
+#: src/PrefsUnifiedDlg.cpp:472
 msgid "Tray icon support requires libayatana-appindicator3 at compile time."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:490
+#: src/PrefsUnifiedDlg.cpp:488
 msgid "Not available on Wayland: the protocol does not report when a window is minimized, so this option cannot intercept the system minimize button. Workaround: launch aMule with `GDK_BACKEND=x11` to use XWayland instead."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:536
+#: src/PrefsUnifiedDlg.cpp:534
 msgid ""
 "Do not change these setting unless you know\n"
 "what you are doing, otherwise you can easily\n"
@@ -5761,35 +5727,26 @@ msgstr ""
 "aMule do te punoje ne rregull pa modifikuarr asnje nga\n"
 "keto rregullime"
 
-#: src/PrefsUnifiedDlg.cpp:647
+#: src/PrefsUnifiedDlg.cpp:645
 #, c-format
 msgid "Failed to connect Cfg to widget with the ID %d and key %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:695
+#: src/PrefsUnifiedDlg.cpp:693
 #, c-format
 msgid "Failed to transfer data from Cfg to Widget with the ID %d and key %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:801
+#: src/PrefsUnifiedDlg.cpp:799
 msgid "The type of proxy you are connecting to"
 msgstr "Lloji i Proksit(Proxy) qe ju po lidheni"
 
-#: src/PrefsUnifiedDlg.cpp:1020
+#: src/PrefsUnifiedDlg.cpp:1003
 #, c-format
 msgid "Failed to transfer data from Widget to Cfg with the ID %d and key %s"
 msgstr ""
 
 #: src/PrefsUnifiedDlg.cpp:1103
-#, fuzzy
-msgid "No password set."
-msgstr "Duke kerkuar fjalekalimin\n"
-
-#: src/PrefsUnifiedDlg.cpp:1132
-msgid "Guest access needs a password. Type one in the guest password field, or untick Enable guest access."
-msgstr ""
-
-#: src/PrefsUnifiedDlg.cpp:1144
 msgid ""
 "aMule must be restarted to enable these changes:\n"
 "\n"
@@ -5797,51 +5754,51 @@ msgstr ""
 "aMule duhet qe te ristartohet qe keto ndryshime te aplikohen:\n"
 " \n"
 
-#: src/PrefsUnifiedDlg.cpp:1151
+#: src/PrefsUnifiedDlg.cpp:1110
 msgid "- TCP port changed.\n"
 msgstr "Porta TCP eshte ndryshuar.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1156
+#: src/PrefsUnifiedDlg.cpp:1115
 msgid "- UDP port changed.\n"
 msgstr "Porta UDP eshte ndryshuar.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1161
+#: src/PrefsUnifiedDlg.cpp:1120
 #, fuzzy
 msgid "- Network interface binding changed.\n"
 msgstr "Lidhja e jashtme u mbyll."
 
-#: src/PrefsUnifiedDlg.cpp:1166
+#: src/PrefsUnifiedDlg.cpp:1125
 #, fuzzy
 msgid "- External connect port changed.\n"
 msgstr "Lidhja e jashtme u mbyll."
 
-#: src/PrefsUnifiedDlg.cpp:1170
+#: src/PrefsUnifiedDlg.cpp:1129
 #, fuzzy
 msgid "- External connect acceptance changed.\n"
 msgstr "U pranua nje lidhje e jashtme e re"
 
-#: src/PrefsUnifiedDlg.cpp:1174
+#: src/PrefsUnifiedDlg.cpp:1133
 #, fuzzy
 msgid "- External connect interface changed.\n"
 msgstr "Lidhja e jashtme u mbyll."
 
-#: src/PrefsUnifiedDlg.cpp:1178
+#: src/PrefsUnifiedDlg.cpp:1137
 #, fuzzy
 msgid "- Protocol obfuscation support changed.\n"
 msgstr "Protokolli i Turbullimit"
 
-#: src/PrefsUnifiedDlg.cpp:1193
+#: src/PrefsUnifiedDlg.cpp:1151
 #, fuzzy
 msgid "- amuleapi settings changed.\n"
 msgstr "- Gjuha ndryshoi.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1202
+#: src/PrefsUnifiedDlg.cpp:1160
 msgid ""
 "Your Auto-update server list is empty.\n"
 "'Auto-update server list at startup' will be disabled."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1213
+#: src/PrefsUnifiedDlg.cpp:1171
 msgid ""
 "You have enabled external connections but have not specified a password.\n"
 "External connections cannot be enabled unless a valid password is specified."
@@ -5849,40 +5806,35 @@ msgstr ""
 "Ju keni lejuar lidhjet e jashtme por nuk keni specifikuar nje fjalekalim.\n"
 "Lidhjet e jashtme nuk mund te lejohen derisa te specifikohet nje fjalekalim."
 
-#: src/PrefsUnifiedDlg.cpp:1246
-#, c-format
-msgid "The amuleapi password could not be saved: %s"
-msgstr ""
-
-#: src/PrefsUnifiedDlg.cpp:1276
+#: src/PrefsUnifiedDlg.cpp:1202
 msgid "- Language changed.\n"
 msgstr "- Gjuha ndryshoi.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1281
+#: src/PrefsUnifiedDlg.cpp:1207
 msgid "- Temp folder changed.\n"
 msgstr "Kartela Temp ndryshoi.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1286
+#: src/PrefsUnifiedDlg.cpp:1212
 #, fuzzy
 msgid "- ED2K network enabled.\n"
 msgstr "Te gjithe rrjetet jane c'aktivizuar."
 
-#: src/PrefsUnifiedDlg.cpp:1319
+#: src/PrefsUnifiedDlg.cpp:1245
 msgid "The shared-file exclusion pattern is not a valid regular expression. The filter has been left disabled."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1321 src/PrefsUnifiedDlg.cpp:1921
+#: src/PrefsUnifiedDlg.cpp:1247 src/PrefsUnifiedDlg.cpp:1841
 #, fuzzy
 msgid "Invalid regular expression"
 msgstr "Version protokoli jo i rregullt."
 
-#: src/PrefsUnifiedDlg.cpp:1398
+#: src/PrefsUnifiedDlg.cpp:1324
 msgid ""
 "Both eD2k and Kad network are disabled.\n"
 "You won't be able to connect until you enable at least one of them."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1403
+#: src/PrefsUnifiedDlg.cpp:1329
 msgid ""
 "Kad will not start if your UDP port is disabled.\n"
 "Enable UDP port or disable Kad."
@@ -5890,7 +5842,7 @@ msgstr ""
 "Kad nuk mund te filloje nqs porta juaj UDP eshte c'aktivizuar.\n"
 "Aktivizoni porten UDP ose c'aktivizoni Kad-in."
 
-#: src/PrefsUnifiedDlg.cpp:1459
+#: src/PrefsUnifiedDlg.cpp:1385
 msgid ""
 "\n"
 "You MUST restart aMule now.\n"
@@ -5900,69 +5852,69 @@ msgstr ""
 "Ju duhet te ristartoni aMule-n tani.\n"
 "Nqs nuk e ristartoni tani mos u anko nqs te ndodh dicka e keqe.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1524
+#: src/PrefsUnifiedDlg.cpp:1450
 msgid "Could not register aMule for autostart at login. The autostart store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1526
+#: src/PrefsUnifiedDlg.cpp:1452
 msgid "Could not remove the autostart-at-login entry."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1527
+#: src/PrefsUnifiedDlg.cpp:1453
 #, fuzzy
 msgid "Autostart"
 msgstr "Rifreskimi Automatik filloi"
 
-#: src/PrefsUnifiedDlg.cpp:1542
+#: src/PrefsUnifiedDlg.cpp:1468
 msgid "Register file type"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1542
+#: src/PrefsUnifiedDlg.cpp:1468
 msgid "Register URL handler"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1550
+#: src/PrefsUnifiedDlg.cpp:1476
 #, c-format
 msgid "aMule only handles eD2k-compatible magnets. If you replace the current magnet handler (%s), BitTorrent magnet links will stop working - aMule cannot download BitTorrent content. Continue?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1555
+#: src/PrefsUnifiedDlg.cpp:1481
 #, c-format
 msgid "Another application currently opens .emulecollection files (%s). Replace it with aMule?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1560
+#: src/PrefsUnifiedDlg.cpp:1486
 #, c-format
 msgid "Another application is currently the default handler for these links (%s). Replace it with aMule?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1585
+#: src/PrefsUnifiedDlg.cpp:1511
 msgid "Could not register aMule for .emulecollection files. The registration store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1587
+#: src/PrefsUnifiedDlg.cpp:1513
 #, fuzzy
 msgid "Could not remove the file type registration."
 msgstr "Jeni duke u perpjekur te shkarkoni edhe njehere tjeter kete fail %s"
 
-#: src/PrefsUnifiedDlg.cpp:1589
+#: src/PrefsUnifiedDlg.cpp:1515
 msgid "Could not register aMule as the URL handler. The registration store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1591
+#: src/PrefsUnifiedDlg.cpp:1517
 msgid "Could not remove the URL handler registration."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1661 src/PrefsUnifiedDlg.cpp:1688
+#: src/PrefsUnifiedDlg.cpp:1587 src/PrefsUnifiedDlg.cpp:1614
 #, fuzzy
 msgid "The web server and aMule API require external connections to be enabled."
 msgstr "U pranua nje lidhje e jashtme e re"
 
-#: src/PrefsUnifiedDlg.cpp:1671
+#: src/PrefsUnifiedDlg.cpp:1597
 msgid "The aMule web server is deprecated. Consider running the aMule API instead."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1735
+#: src/PrefsUnifiedDlg.cpp:1655
 msgid ""
 "Your Auto-update servers list is in blank.\n"
 "Please fill in at least one URL to point to a valid server.met file.\n"
@@ -5972,66 +5924,66 @@ msgstr ""
 "Ju lutem mbushni te pakten nje URL te vlefshme ne failin e server.met.\n"
 "Klikoni ne butonin \"List\" per te futur nje URL."
 
-#: src/PrefsUnifiedDlg.cpp:1876
+#: src/PrefsUnifiedDlg.cpp:1796
 msgid "Temporary files"
 msgstr "Failet e perkohshme"
 
-#: src/PrefsUnifiedDlg.cpp:1881
+#: src/PrefsUnifiedDlg.cpp:1801
 msgid "Incoming files"
 msgstr "Failet e shkarkuara"
 
-#: src/PrefsUnifiedDlg.cpp:1886
+#: src/PrefsUnifiedDlg.cpp:1806
 msgid "Online Signatures"
 msgstr "Firma online"
 
-#: src/PrefsUnifiedDlg.cpp:1899
+#: src/PrefsUnifiedDlg.cpp:1819
 #, c-format
 msgid "Choose a folder for %s"
 msgstr "Zgjidhni nje kartele per %s"
 
-#: src/PrefsUnifiedDlg.cpp:1923
+#: src/PrefsUnifiedDlg.cpp:1843
 #, fuzzy, c-format
 msgid "Would exclude %u of %u shared file"
 msgid_plural "Would exclude %u of %u shared files"
 msgstr[0] "U gjend %i fail i njohur i ndare"
 msgstr[1] "U gjenden %i faile te njohura te ndara"
 
-#: src/PrefsUnifiedDlg.cpp:1940
+#: src/PrefsUnifiedDlg.cpp:1860
 msgid "Browse for videoplayer"
 msgstr "Shfletoni per nje videoplayer"
 
-#: src/PrefsUnifiedDlg.cpp:1944
+#: src/PrefsUnifiedDlg.cpp:1864
 msgid "Select browser"
 msgstr "Perzgjidhni shfletuesin"
 
-#: src/PrefsUnifiedDlg.cpp:1948
+#: src/PrefsUnifiedDlg.cpp:1868
 #, fuzzy
 msgid "Select ffprobe binary"
 msgstr "Perzgjidhni shfletuesin"
 
-#: src/PrefsUnifiedDlg.cpp:1954
+#: src/PrefsUnifiedDlg.cpp:1874
 #, c-format
 msgid "Executable%s"
 msgstr "Te ekzekutueshme%s"
 
-#: src/PrefsUnifiedDlg.cpp:1988
+#: src/PrefsUnifiedDlg.cpp:1908
 msgid "ffprobe not found on PATH or in the standard install locations. Install ffmpeg (which ships ffprobe) or use Browse to pick a binary manually."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2000
+#: src/PrefsUnifiedDlg.cpp:1920
 msgid "Reset the settings on this page to their default values?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2001
+#: src/PrefsUnifiedDlg.cpp:1921
 #, fuzzy
 msgid "Reset to defaults"
 msgstr "E vendosur nga sistemi"
 
-#: src/PrefsUnifiedDlg.cpp:2028
+#: src/PrefsUnifiedDlg.cpp:1948
 msgid "Edit server list"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2029
+#: src/PrefsUnifiedDlg.cpp:1949
 msgid ""
 "Add here URL's to download server.met files.\n"
 "Only one url on each line."
@@ -6039,181 +5991,177 @@ msgstr ""
 "Futni ketu URL-te per te shkarkuar failet server.met.\n"
 "Vetem nga nje URL per c'do linje."
 
-#: src/PrefsUnifiedDlg.cpp:2084
+#: src/PrefsUnifiedDlg.cpp:2004
 msgid "IP2Country update failed"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2229 src/PrefsUnifiedDlg.cpp:2260
+#: src/PrefsUnifiedDlg.cpp:2149 src/PrefsUnifiedDlg.cpp:2180
 msgid "Data by MaxMind GeoLite2"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2231 src/PrefsUnifiedDlg.cpp:2262
+#: src/PrefsUnifiedDlg.cpp:2151 src/PrefsUnifiedDlg.cpp:2182
 #, fuzzy
 msgid "Custom source"
 msgstr "Burime te kompletuara"
 
-#: src/PrefsUnifiedDlg.cpp:2233 src/PrefsUnifiedDlg.cpp:2264
+#: src/PrefsUnifiedDlg.cpp:2153 src/PrefsUnifiedDlg.cpp:2184
 msgid "Data by DB-IP.com"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2284
+#: src/PrefsUnifiedDlg.cpp:2204
 #, fuzzy, c-format
 msgid "Status: Loaded%s"
 msgstr "Statusi:"
 
-#: src/PrefsUnifiedDlg.cpp:2286
+#: src/PrefsUnifiedDlg.cpp:2206
 #, fuzzy, c-format
 msgid "Status: Loaded%s - %s"
 msgstr "Statusi:"
 
-#: src/PrefsUnifiedDlg.cpp:2290
+#: src/PrefsUnifiedDlg.cpp:2210
 msgid "Status: Failed to load - click 'Update now' to refresh."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2292
+#: src/PrefsUnifiedDlg.cpp:2212
 msgid "Status: Not found - click 'Update now' to download."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2350 src/PrefsUnifiedDlg.cpp:2374
+#: src/PrefsUnifiedDlg.cpp:2270 src/PrefsUnifiedDlg.cpp:2294
 #, c-format
 msgid "Update delay: %d second"
 msgid_plural "Update delay: %d seconds"
 msgstr[0] "Intervali i azhornimit: %d sekonde"
 msgstr[1] "Intervali i azhornimit: %d sekonda"
 
-#: src/PrefsUnifiedDlg.cpp:2358
+#: src/PrefsUnifiedDlg.cpp:2278
 #, c-format
 msgid "Time for average graph: %d minute"
 msgid_plural "Time for average graph: %d minutes"
 msgstr[0] "Koha per mesataren grafike: %d minute"
 msgstr[1] "Koha per mesataren grafike: %d minuta"
 
-#: src/PrefsUnifiedDlg.cpp:2367
+#: src/PrefsUnifiedDlg.cpp:2287
 #, c-format
 msgid "Connections Graph Scale: %d"
 msgstr "Shkalla grafike e lidhjeve: %d"
 
-#: src/PrefsUnifiedDlg.cpp:2382
+#: src/PrefsUnifiedDlg.cpp:2302
 #, c-format
 msgid "File Buffer Size: %d byte"
 msgid_plural "File Buffer Size: %d bytes"
 msgstr[0] "Madhesia buffer e failit: %d byte"
 msgstr[1] "Madesia Buffer e failit: %d bytes"
 
-#: src/PrefsUnifiedDlg.cpp:2392
+#: src/PrefsUnifiedDlg.cpp:2312
 #, c-format
 msgid "Upload Queue Size: %d client"
 msgid_plural "Upload Queue Size: %d clients"
 msgstr[0] "Madhesia e radhes se ngarkimit: %d klienti"
 msgstr[1] "Madhesia e radhes se ngarkimit: %d klientet"
 
-#: src/PrefsUnifiedDlg.cpp:2402
+#: src/PrefsUnifiedDlg.cpp:2322
 #, c-format
 msgid "Server connection refresh interval: %d minute"
 msgid_plural "Server connection refresh interval: %d minutes"
 msgstr[0] "Intervali i rifreskimit te lidhjeve te serverit: %d minute"
 msgstr[1] "Intervali i rifreskimit te lidhjeve te serverit: %d minuta"
 
-#: src/PrefsUnifiedDlg.cpp:2407
+#: src/PrefsUnifiedDlg.cpp:2327
 msgid "Server connection refresh interval: Disabled"
 msgstr "Intervali i rifreskimit te lidhjeve te serverit: I c'aktivizuar"
 
-#: src/PrefsUnifiedDlg.cpp:2451
+#: src/PrefsUnifiedDlg.cpp:2371
 #, fuzzy
 msgid "disabled"
 msgstr "c'aktivizo"
 
-#: src/PrefsUnifiedDlg.cpp:2477
+#: src/PrefsUnifiedDlg.cpp:2397
 #, fuzzy, c-format
 msgid "Execute command on '%s' event"
 msgstr "Ekzekuto komanden ne kete ngjarje `%s' "
 
-#: src/PrefsUnifiedDlg.cpp:2484
+#: src/PrefsUnifiedDlg.cpp:2404
 msgid "Enable command execution on core"
 msgstr "Lejo ekzekutimin e komandes ne core"
 
-#: src/PrefsUnifiedDlg.cpp:2496
+#: src/PrefsUnifiedDlg.cpp:2416
 msgid "Core command:"
 msgstr "KOmanda Core:"
 
-#: src/PrefsUnifiedDlg.cpp:2512
+#: src/PrefsUnifiedDlg.cpp:2432
 msgid "Enable command execution on GUI"
 msgstr "Lejo ekzekutimin e komandes ne GUI"
 
-#: src/PrefsUnifiedDlg.cpp:2524
+#: src/PrefsUnifiedDlg.cpp:2444
 msgid "GUI command:"
 msgstr "Komanda GUI:"
 
-#: src/PrefsUnifiedDlg.cpp:2540
+#: src/PrefsUnifiedDlg.cpp:2460
 msgid "The following variables will be replaced:"
 msgstr "Variacionet qe vijojne do te rivendosen:"
 
-#: src/PrefsUnifiedDlg.cpp:2708
+#: src/PrefsUnifiedDlg.cpp:2628
 msgid ""
 "The following folders look like system or sensitive locations:\n"
 "\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2713
+#: src/PrefsUnifiedDlg.cpp:2633
 msgid "Sharing them recursively will publish every file underneath on the eD2k/Kad networks. Do you really want to do this?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2716
+#: src/PrefsUnifiedDlg.cpp:2636
 #, fuzzy
 msgid "Confirm shared folders"
 msgstr "Ringarko failet e ndara"
 
-#: src/PrefsUnifiedDlg.cpp:2744
+#: src/PrefsUnifiedDlg.cpp:2664
 #, fuzzy
 msgid "Reloading shared files..."
 msgstr "Ringarko failet e ndara"
 
-#: src/PrefsUnifiedDlg.cpp:2745
+#: src/PrefsUnifiedDlg.cpp:2665
 msgid "Scanning for subdirectories..."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2746
+#: src/PrefsUnifiedDlg.cpp:2666
 #, fuzzy
 msgid "Updating shared folders"
 msgstr "Duke lexuar kartelen temp"
 
-#: src/PrefsUnifiedDlg.cpp:2773
+#: src/PrefsUnifiedDlg.cpp:2693
 #, c-format
 msgid "Scanned %u directories..."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2823
+#: src/PrefsUnifiedDlg.cpp:2743
 #, fuzzy, c-format
 msgid "Reloading shared files: %u files scanned"
 msgstr "Ringarko listen e faileve te ndara."
 
-#: src/PrefsUnifiedDlg.cpp:2873
+#: src/PrefsUnifiedDlg.cpp:2793
 #, fuzzy
 msgid "Shared folder"
 msgstr "File te ndara"
 
-#: src/SearchDlg.cpp:280
-msgid "Clear search history"
-msgstr ""
-
-#: src/SearchDlg.cpp:584
+#: src/SearchDlg.cpp:425
 msgid "It's impossible to search when both eD2k and Kademlia are disabled."
 msgstr ""
 
-#: src/SearchDlg.cpp:585 src/SearchListCtrl.cpp:858
+#: src/SearchDlg.cpp:426 src/SearchListCtrl.cpp:858
 #, fuzzy
 msgid "Search error"
 msgstr "Kerkimet"
 
-#: src/SearchDlg.cpp:929
+#: src/SearchDlg.cpp:768
 msgid "Min size must be smaller than max size. Max size ignored."
 msgstr "Masa minimale duhet te jete me e vogel se masa maksimale.Po injoroj Masen Maksimale.."
 
-#: src/SearchDlg.cpp:930 src/SearchDlg.cpp:1012
+#: src/SearchDlg.cpp:769 src/SearchDlg.cpp:851
 msgid "Search warning"
 msgstr "PoParalajmerim per kerkim"
 
-#: src/SearchDlg.cpp:1092 src/SearchListCtrl.cpp:735
+#: src/SearchDlg.cpp:929 src/SearchListCtrl.cpp:735
 msgid "Main"
 msgstr "Kryesore"
 

--- a/po/sq.po
+++ b/po/sq.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-28 08:06+0200\n"
+"POT-Creation-Date: 2026-07-28 10:19+0200\n"
 "PO-Revision-Date: 2026-07-27 11:45+0000\n"
 "Last-Translator: Fation <dj_barthezz@linuxmail.org lushnja_corps@hotmail.Language-Team:\n"
 "Language: sq\n"
@@ -141,7 +141,7 @@ msgstr ""
 msgid "Not now"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:422 src/amuleDlg.cpp:600
+#: src/AppImageIntegration.cpp:422 src/amuleDlg.cpp:665
 msgid "Don't ask again"
 msgstr ""
 
@@ -218,7 +218,7 @@ msgid "Killing amuleweb instance with pid '%d' ... "
 msgstr ""
 
 #: src/amule.cpp:336 src/amule.cpp:349 src/ClientRef.cpp:180
-#: src/SearchDlg.cpp:880 src/ServerListCtrl.cpp:98
+#: src/SearchDlg.cpp:1041 src/ServerListCtrl.cpp:98
 msgid "Failed"
 msgstr "E Deshtuar"
 
@@ -574,30 +574,68 @@ msgstr ""
 msgid "ERROR: %s"
 msgstr "GABIM: %s"
 
-#: src/amuleDlg.cpp:236
+#: src/amuleDlg.cpp:250
 #, c-format
 msgid "This is aMule %s based on eMule."
 msgstr "Kjo eshte aMule %s dhe bazohet ne eMule."
 
-#: src/amuleDlg.cpp:237
+#: src/amuleDlg.cpp:251
 #, c-format
 msgid "Running on %s"
 msgstr "Duke punuar ne %s"
 
-#: src/amuleDlg.cpp:239
+#: src/amuleDlg.cpp:253
 msgid "Visit https://github.com/amule-org/amule/releases/latest to check if a new version is available."
 msgstr "Vizitoni https://github.com/amule-org/amule/releases/latest per te kontrolluar nqs eshte ne dispozicion nje version i ri."
 
-#: src/amuleDlg.cpp:268
+#: src/amuleDlg.cpp:282
 msgid "FATAL ERROR: Failed to create Timer"
 msgstr ""
 
-#: src/amuleDlg.cpp:592
+#: src/amuleDlg.cpp:361 src/amuleDlg.cpp:1787 src/amuleDlg.cpp:2033
+#: src/muuli_wdr.cpp:1492 src/muuli_wdr.cpp:3418
+msgid "Networks"
+msgstr "Rrjetet"
+
+#: src/amuleDlg.cpp:362 src/amuleDlg.cpp:1793 src/muuli_wdr.cpp:3419
+msgid "Searches"
+msgstr "Kerkimet"
+
+#: src/amuleDlg.cpp:363 src/amuleDlg.cpp:1799 src/DownloadListCtrl.cpp:740
+#: src/muuli_wdr.cpp:392 src/muuli_wdr.cpp:1585 src/muuli_wdr.cpp:3420
+#: src/Statistics.cpp:829
+msgid "Downloads"
+msgstr "Shkarkime"
+
+#: src/amuleDlg.cpp:364 src/amuleDlg.cpp:1805 src/muuli_wdr.cpp:3294
+msgid "Shared files"
+msgstr ""
+
+#: src/amuleDlg.cpp:365 src/amuleDlg.cpp:1811 src/muuli_wdr.cpp:2926
+#: src/muuli_wdr.cpp:3376 src/muuli_wdr.cpp:3423
+msgid "Messages"
+msgstr "Mesazhe"
+
+#: src/amuleDlg.cpp:366 src/amuleDlg.cpp:1817 src/muuli_wdr.cpp:3424
+#: src/PrefsUnifiedDlg.cpp:312 src/Statistics.cpp:779 src/Statistics.cpp:1235
+msgid "Statistics"
+msgstr "Statistikat"
+
+#: src/amuleDlg.cpp:368 src/amuleDlg.cpp:1824 src/muuli_wdr.cpp:3426
+#: src/PrefsUnifiedDlg.cpp:328 src/utils/wxCas/src/wxcasprefs.cpp:39
+msgid "Preferences"
+msgstr "Preferencat"
+
+#: src/amuleDlg.cpp:371
+msgid "Navigate"
+msgstr ""
+
+#: src/amuleDlg.cpp:657
 #, fuzzy
 msgid "New version available"
 msgstr "Nuk eshte ne dispozicion"
 
-#: src/amuleDlg.cpp:596
+#: src/amuleDlg.cpp:661
 #, fuzzy, c-format
 msgid ""
 "A new version of aMule (%s) is available.\n"
@@ -607,219 +645,186 @@ msgid ""
 "Would you like to open the download page?"
 msgstr "Versioni i fundit mund te gjendet gjithmone tek https://github.com/amule-org/amule/releases/latest"
 
-#: src/amuleDlg.cpp:678
+#: src/amuleDlg.cpp:743
 msgid "aMule dialog destroyed"
 msgstr ""
 
-#: src/amuleDlg.cpp:701 src/DataToText.cpp:68 src/IPFilter.cpp:547
+#: src/amuleDlg.cpp:766 src/DataToText.cpp:68 src/IPFilter.cpp:547
 msgid "Connecting"
 msgstr "Duke u lòidhur"
 
-#: src/amuleDlg.cpp:893
+#: src/amuleDlg.cpp:958
 msgid "eD2k: Connecting"
 msgstr ""
 
-#: src/amuleDlg.cpp:897
+#: src/amuleDlg.cpp:962
 msgid "eD2k: Disconnected"
 msgstr ""
 
-#: src/amuleDlg.cpp:903
+#: src/amuleDlg.cpp:968
 msgid "Kad: Firewalled"
 msgstr "Kad: Me Firewall"
 
-#: src/amuleDlg.cpp:907
+#: src/amuleDlg.cpp:972
 msgid "Kad: Connected"
 msgstr "Kad: I lidhur"
 
-#: src/amuleDlg.cpp:912
+#: src/amuleDlg.cpp:977
 msgid "Kad: Connecting"
 msgstr "Kad: Po lidhet"
 
-#: src/amuleDlg.cpp:916
+#: src/amuleDlg.cpp:981
 msgid "Kad: Off"
 msgstr "Kad: Fikur"
 
-#: src/amuleDlg.cpp:964 src/DownloadListCtrl.cpp:505
+#: src/amuleDlg.cpp:1029 src/DownloadListCtrl.cpp:505
 #: src/DownloadListCtrl.cpp:749 src/FriendListCtrl.cpp:180
 #: src/muuli_wdr.cpp:731 src/muuli_wdr.cpp:782 src/muuli_wdr.cpp:846
-#: src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2224 src/muuli_wdr.cpp:2309
-#: src/muuli_wdr.cpp:3057 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
+#: src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2231 src/muuli_wdr.cpp:2316
+#: src/muuli_wdr.cpp:3064 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
 #: src/ServerListCtrl.cpp:606 src/TransferWnd.cpp:378
 #: src/utils/wxCas/src/wxcasprefs.cpp:235
 msgid "Cancel"
 msgstr "Fshij"
 
-#: src/amuleDlg.cpp:965
+#: src/amuleDlg.cpp:1030
 msgid "Stop the current connection attempts"
 msgstr "Ndalo tentativat e lidhjes qe po behen"
 
-#: src/amuleDlg.cpp:970 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976
-#: src/muuli_wdr.cpp:2447
+#: src/amuleDlg.cpp:1035 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976
+#: src/muuli_wdr.cpp:2454
 msgid "Disconnect"
 msgstr "Shkeputu"
 
-#: src/amuleDlg.cpp:971
+#: src/amuleDlg.cpp:1036
 msgid "Disconnect from the currently connected networks"
 msgstr "Shkeputu nga rrjetet e lidhura"
 
-#: src/amuleDlg.cpp:976 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979
-#: src/muuli_wdr.cpp:2602 src/muuli_wdr.cpp:3054 src/muuli_wdr.cpp:3409
+#: src/amuleDlg.cpp:1041 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979
+#: src/muuli_wdr.cpp:2609 src/muuli_wdr.cpp:3061 src/muuli_wdr.cpp:3416
 msgid "Connect"
 msgstr "Lidhu"
 
-#: src/amuleDlg.cpp:977
+#: src/amuleDlg.cpp:1042
 msgid "Connect to the currently enabled networks"
 msgstr "Lidhu tek rrjetet"
 
-#: src/amuleDlg.cpp:1089
+#: src/amuleDlg.cpp:1154
 #, fuzzy, c-format
 msgid "Up: %.1f%s (%.1f) | Down: %.1f%s (%.1f)"
 msgstr "Larte: %.1f(%.1f) | Poshte: %.1f(%.1f)"
 
-#: src/amuleDlg.cpp:1091 src/amuleDlg.cpp:1093 src/amuleDlg.cpp:1097
-#: src/amuleDlg.cpp:1099 src/amuleDlg.cpp:1110 src/amuleDlg.cpp:1112
+#: src/amuleDlg.cpp:1156 src/amuleDlg.cpp:1158 src/amuleDlg.cpp:1162
+#: src/amuleDlg.cpp:1164 src/amuleDlg.cpp:1175 src/amuleDlg.cpp:1177
 #: src/MuleTrayIcon.cpp:796 src/MuleTrayIcon.cpp:799
 #, fuzzy
 msgid " MB/s"
 msgstr "MB/s"
 
-#: src/amuleDlg.cpp:1091 src/amuleDlg.cpp:1093 src/amuleDlg.cpp:1097
-#: src/amuleDlg.cpp:1099 src/amuleDlg.cpp:1110 src/amuleDlg.cpp:1112
+#: src/amuleDlg.cpp:1156 src/amuleDlg.cpp:1158 src/amuleDlg.cpp:1162
+#: src/amuleDlg.cpp:1164 src/amuleDlg.cpp:1175 src/amuleDlg.cpp:1177
 #: src/MuleTrayIcon.cpp:796 src/MuleTrayIcon.cpp:799
 #: src/utils/wxCas/src/wxcasframe.cpp:1041
 msgid " kB/s"
 msgstr " kB/s"
 
-#: src/amuleDlg.cpp:1096
+#: src/amuleDlg.cpp:1161
 #, fuzzy, c-format
 msgid "Up: %.1f%s | Down: %.1f%s"
 msgstr "Larte: %.1f | Poshte: %.1f"
 
-#: src/amuleDlg.cpp:1128
+#: src/amuleDlg.cpp:1193
 #, c-format
 msgid "aMule (%s | Connected)"
 msgstr "aMule (%s | e lidhur)"
 
-#: src/amuleDlg.cpp:1130
+#: src/amuleDlg.cpp:1195
 #, c-format
 msgid "aMule (%s | Disconnected)"
 msgstr "aMule (%s | e shkeputur)"
 
-#: src/amuleDlg.cpp:1183
+#: src/amuleDlg.cpp:1248
 #, fuzzy, c-format
 msgid "Do you really want to exit %s?"
 msgstr "Vertet deshironi qe te dilni nga aMule?"
 
-#: src/amuleDlg.cpp:1185
+#: src/amuleDlg.cpp:1250
 msgid "Exit confirmation"
 msgstr "Konfirmimi i daljes"
 
-#: src/amuleDlg.cpp:1548
+#: src/amuleDlg.cpp:1613
 msgid "Launch Command: "
 msgstr ""
 
-#: src/amuleDlg.cpp:1567 src/muuli_wdr.cpp:1971 src/Preferences.cpp:951
+#: src/amuleDlg.cpp:1632 src/muuli_wdr.cpp:1978 src/Preferences.cpp:952
 msgid "- default -"
 msgstr ""
 
-#: src/amuleDlg.cpp:1595
+#: src/amuleDlg.cpp:1660
 #, c-format
 msgid "Skin directory '%s' does not exist"
 msgstr "Direktoria e skin '%s' nuk ekziston"
 
-#: src/amuleDlg.cpp:1598
+#: src/amuleDlg.cpp:1663
 #, c-format
 msgid "WARNING: Unable to open skin file '%s' for read"
 msgstr ""
 
-#: src/amuleDlg.cpp:1722 src/amuleDlg.cpp:1968 src/muuli_wdr.cpp:1485
-#: src/muuli_wdr.cpp:3411
-msgid "Networks"
-msgstr "Rrjetet"
-
-#: src/amuleDlg.cpp:1726 src/muuli_wdr.cpp:3411
+#: src/amuleDlg.cpp:1791 src/muuli_wdr.cpp:3418
 msgid "Networks Window"
 msgstr "Dritaret e rrjeteve"
 
-#: src/amuleDlg.cpp:1728 src/muuli_wdr.cpp:3412
-msgid "Searches"
-msgstr "Kerkimet"
-
-#: src/amuleDlg.cpp:1732 src/muuli_wdr.cpp:3412
+#: src/amuleDlg.cpp:1797 src/muuli_wdr.cpp:3419
 msgid "Searches Window"
 msgstr "Dritaret e kerkimeve"
 
-#: src/amuleDlg.cpp:1734 src/DownloadListCtrl.cpp:740 src/muuli_wdr.cpp:392
-#: src/muuli_wdr.cpp:1578 src/muuli_wdr.cpp:3413 src/Statistics.cpp:829
-msgid "Downloads"
-msgstr "Shkarkime"
-
-#: src/amuleDlg.cpp:1738 src/muuli_wdr.cpp:3413
+#: src/amuleDlg.cpp:1803 src/muuli_wdr.cpp:3420
 #, fuzzy
 msgid "Downloads Window"
 msgstr "Duke shkarkuar"
 
-#: src/amuleDlg.cpp:1740 src/muuli_wdr.cpp:3287
-msgid "Shared files"
-msgstr ""
-
-#: src/amuleDlg.cpp:1744 src/muuli_wdr.cpp:3415
+#: src/amuleDlg.cpp:1809 src/muuli_wdr.cpp:3422
 msgid "Shared Files Window"
 msgstr "Dritarja e faileve te ndara"
 
-#: src/amuleDlg.cpp:1746 src/muuli_wdr.cpp:2919 src/muuli_wdr.cpp:3369
-#: src/muuli_wdr.cpp:3416
-msgid "Messages"
-msgstr "Mesazhe"
-
-#: src/amuleDlg.cpp:1750 src/muuli_wdr.cpp:3416
+#: src/amuleDlg.cpp:1815 src/muuli_wdr.cpp:3423
 msgid "Messages Window"
 msgstr "Dritarja e mesazheve"
 
-#: src/amuleDlg.cpp:1752 src/muuli_wdr.cpp:3417 src/PrefsUnifiedDlg.cpp:312
-#: src/Statistics.cpp:779 src/Statistics.cpp:1235
-msgid "Statistics"
-msgstr "Statistikat"
-
-#: src/amuleDlg.cpp:1756 src/muuli_wdr.cpp:3417
+#: src/amuleDlg.cpp:1821 src/muuli_wdr.cpp:3424
 msgid "Statistics Graph Window"
 msgstr "Dritarja e grafikut te statistikave"
 
-#: src/amuleDlg.cpp:1759 src/muuli_wdr.cpp:3419 src/PrefsUnifiedDlg.cpp:328
-#: src/utils/wxCas/src/wxcasprefs.cpp:39
-msgid "Preferences"
-msgstr "Preferencat"
-
-#: src/amuleDlg.cpp:1763 src/muuli_wdr.cpp:3419
+#: src/amuleDlg.cpp:1828 src/muuli_wdr.cpp:3426
 msgid "Preferences Settings Window"
 msgstr "Dritarja e rregullimeve te preferencave"
 
-#: src/amuleDlg.cpp:1766 src/muuli_wdr.cpp:3420
+#: src/amuleDlg.cpp:1831 src/muuli_wdr.cpp:3427
 msgid "Import"
 msgstr "Importimi"
 
-#: src/amuleDlg.cpp:1770 src/muuli_wdr.cpp:3420
+#: src/amuleDlg.cpp:1835 src/muuli_wdr.cpp:3427
 msgid "The partfile importer tool"
 msgstr "Veglat per importimin e pjeseve te faileve"
 
-#: src/amuleDlg.cpp:1773 src/muuli_wdr.cpp:3421
+#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3428
 #: src/utils/aLinkCreator/src/alcframe.cpp:262
 msgid "About"
 msgstr "Rreth"
 
-#: src/amuleDlg.cpp:1773 src/muuli_wdr.cpp:3421
+#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3428
 msgid "About/Help"
 msgstr "Rreth/Ndihme"
 
-#: src/amuleDlg.cpp:1971
+#: src/amuleDlg.cpp:2036
 msgid "eD2k network"
 msgstr ""
 
-#: src/amuleDlg.cpp:1974
+#: src/amuleDlg.cpp:2039
 msgid "Kad network"
 msgstr "Rrjeti Kad"
 
-#: src/amuleDlg.cpp:1974
+#: src/amuleDlg.cpp:2039
 msgid "No network"
 msgstr "Nuk ka rrjet"
 
@@ -1356,19 +1361,19 @@ msgstr "Automatike [Larte]"
 msgid "Very low"
 msgstr "Shume ngadale"
 
-#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:743 src/muuli_wdr.cpp:2275
+#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:743 src/muuli_wdr.cpp:2282
 #: src/ServerListCtrl.cpp:263 src/ServerListCtrl.cpp:456
 #: src/SharedFilesCtrl.cpp:145
 msgid "Low"
 msgstr "Ngadale"
 
-#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:744 src/muuli_wdr.cpp:2276
+#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:744 src/muuli_wdr.cpp:2283
 #: src/ServerListCtrl.cpp:266 src/ServerListCtrl.cpp:457
 #: src/SharedFilesCtrl.cpp:146
 msgid "Normal"
 msgstr "Normale"
 
-#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:745 src/muuli_wdr.cpp:2277
+#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:745 src/muuli_wdr.cpp:2284
 #: src/ServerListCtrl.cpp:269 src/ServerListCtrl.cpp:458
 #: src/SharedFilesCtrl.cpp:147
 msgid "High"
@@ -1460,8 +1465,8 @@ msgstr "Server Lokal"
 msgid "Remote Server"
 msgstr "Server i larget"
 
-#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3174
-#: src/SearchDlg.cpp:111 src/TextClient.cpp:911
+#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3181
+#: src/SearchDlg.cpp:119 src/TextClient.cpp:911
 msgid "Kad"
 msgstr "Kad"
 
@@ -1532,7 +1537,7 @@ msgstr ""
 msgid "Size"
 msgstr "Madhesia"
 
-#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3241
+#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3248
 msgid "Transferred"
 msgstr "Te transferuara"
 
@@ -1588,7 +1593,7 @@ msgid ""
 "\n"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:746 src/muuli_wdr.cpp:2278
+#: src/DownloadListCtrl.cpp:746 src/muuli_wdr.cpp:2285
 #: src/SharedFilesCtrl.cpp:150
 msgid "Auto"
 msgstr "Automatike"
@@ -1626,7 +1631,7 @@ msgid "Extended Options"
 msgstr "Opsione te Avancuara"
 
 #: src/DownloadListCtrl.cpp:770 src/DownloadListCtrl.cpp:822
-#: src/muuli_wdr.cpp:1789
+#: src/muuli_wdr.cpp:1796
 msgid "Preview"
 msgstr "Parashikim"
 
@@ -2339,19 +2344,19 @@ msgstr ""
 msgid "eD2k"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:349 src/muuli_wdr.cpp:1488
+#: src/FirstRunWizard.cpp:349 src/muuli_wdr.cpp:1495
 msgid "Kademlia"
 msgstr "Kademlia"
 
-#: src/FirstRunWizard.cpp:359 src/muuli_wdr.cpp:1416
+#: src/FirstRunWizard.cpp:359 src/muuli_wdr.cpp:1423
 msgid "Standard TCP Port "
 msgstr ""
 
-#: src/FirstRunWizard.cpp:365 src/muuli_wdr.cpp:1428
+#: src/FirstRunWizard.cpp:365 src/muuli_wdr.cpp:1435
 msgid "Extended UDP port (Kad / global search) "
 msgstr ""
 
-#: src/FirstRunWizard.cpp:377 src/muuli_wdr.cpp:1435
+#: src/FirstRunWizard.cpp:377 src/muuli_wdr.cpp:1442
 msgid "Enable UPnP for router port forwarding"
 msgstr ""
 
@@ -2378,7 +2383,7 @@ msgstr ""
 msgid "Your peer lists are already in place - nothing to download."
 msgstr "Jeni duke u perpjekur te shkarkoni edhe njehere tjeter kete fail %s"
 
-#: src/FirstRunWizard.cpp:434 src/muuli_wdr.cpp:1533
+#: src/FirstRunWizard.cpp:434 src/muuli_wdr.cpp:1540
 msgid "Auto-update server list at startup"
 msgstr ""
 
@@ -2424,23 +2429,23 @@ msgid ""
 "want downloads on a different (e.g. larger) disk."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:549 src/FirstRunWizard.cpp:611 src/muuli_wdr.cpp:1701
+#: src/FirstRunWizard.cpp:549 src/FirstRunWizard.cpp:611 src/muuli_wdr.cpp:1708
 msgid "Destination folder for downloads"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:553 src/FirstRunWizard.cpp:569 src/muuli_wdr.cpp:1342
-#: src/muuli_wdr.cpp:1359 src/muuli_wdr.cpp:1676 src/muuli_wdr.cpp:1707
-#: src/muuli_wdr.cpp:1719 src/muuli_wdr.cpp:2762
+#: src/FirstRunWizard.cpp:553 src/FirstRunWizard.cpp:569 src/muuli_wdr.cpp:1349
+#: src/muuli_wdr.cpp:1366 src/muuli_wdr.cpp:1683 src/muuli_wdr.cpp:1714
+#: src/muuli_wdr.cpp:1726 src/muuli_wdr.cpp:2769
 #: src/utils/aLinkCreator/src/alcframe.cpp:135
 #: src/utils/wxCas/src/wxcasprefs.cpp:52 src/utils/wxCas/src/wxcasprefs.cpp:118
 msgid "Browse"
 msgstr "Shfleto"
 
-#: src/FirstRunWizard.cpp:559 src/muuli_wdr.cpp:1712
+#: src/FirstRunWizard.cpp:559 src/muuli_wdr.cpp:1719
 msgid "(All files in this folder are shared with other peers)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:565 src/FirstRunWizard.cpp:624 src/muuli_wdr.cpp:1714
+#: src/FirstRunWizard.cpp:565 src/FirstRunWizard.cpp:624 src/muuli_wdr.cpp:1721
 msgid "Folder for temporary download files"
 msgstr ""
 
@@ -2471,7 +2476,7 @@ msgstr ""
 msgid "CRITICAL - no client on StartChatSession"
 msgstr ""
 
-#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2668 src/muuli_wdr.cpp:3345
+#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2675 src/muuli_wdr.cpp:3352
 msgid "Friends"
 msgstr "Shkoket"
 
@@ -2861,7 +2866,7 @@ msgstr ""
 msgid "Uploaded"
 msgstr ""
 
-#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3225
+#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3232
 msgid "Requested"
 msgstr ""
 
@@ -2987,7 +2992,7 @@ msgid "WARNING: "
 msgstr ""
 
 #: src/MuleNotebook.cpp:179 src/muuli_wdr.cpp:817 src/muuli_wdr.cpp:1229
-#: src/muuli_wdr.cpp:3129 src/muuli_wdr.cpp:3385
+#: src/muuli_wdr.cpp:3136 src/muuli_wdr.cpp:3392
 msgid "Close"
 msgstr "Mbylle"
 
@@ -3000,12 +3005,12 @@ msgstr "Ndaj"
 msgid "Copy"
 msgstr "Kopjo"
 
-#: src/MuleTextCtrl.cpp:88
+#: src/MuleTextCtrl.cpp:88 src/SearchDlg.cpp:261
 msgid "Paste"
 msgstr "Ngjit"
 
 #: src/MuleTextCtrl.cpp:89 src/muuli_wdr.cpp:358 src/muuli_wdr.cpp:757
-#: src/muuli_wdr.cpp:2352 src/muuli_wdr.cpp:2371 src/muuli_wdr.cpp:2393
+#: src/muuli_wdr.cpp:2359 src/muuli_wdr.cpp:2378 src/muuli_wdr.cpp:2400
 #: src/utils/aLinkCreator/src/alcframe.cpp:142
 msgid "Clear"
 msgstr "Pastro"
@@ -3102,8 +3107,8 @@ msgid "Exit"
 msgstr "Dlje"
 
 #: src/MuleTrayIcon.cpp:579 src/MuleTrayIcon.cpp:945 src/MuleTrayIcon.cpp:965
-#: src/muuli_wdr.cpp:1391 src/muuli_wdr.cpp:1399 src/muuli_wdr.cpp:1406
-#: src/muuli_wdr.cpp:1835 src/muuli_wdr.cpp:1841 src/OtherFunctions.cpp:91
+#: src/muuli_wdr.cpp:1398 src/muuli_wdr.cpp:1406 src/muuli_wdr.cpp:1413
+#: src/muuli_wdr.cpp:1842 src/muuli_wdr.cpp:1848 src/OtherFunctions.cpp:91
 #: src/StatisticsDlg.cpp:93 src/StatisticsDlg.cpp:95
 msgid "kB/s"
 msgstr "kB/s"
@@ -3274,7 +3279,7 @@ msgstr "Emri:"
 msgid "Type"
 msgstr "Tipi"
 
-#: src/muuli_wdr.cpp:215 src/SearchDlg.cpp:110 src/SearchListCtrl.cpp:853
+#: src/muuli_wdr.cpp:215 src/SearchDlg.cpp:118 src/SearchListCtrl.cpp:853
 msgid "Local"
 msgstr "Lokale"
 
@@ -3345,7 +3350,7 @@ msgstr "Bytes"
 msgid "KB"
 msgstr "KB"
 
-#: src/muuli_wdr.cpp:274 src/muuli_wdr.cpp:293 src/muuli_wdr.cpp:1620
+#: src/muuli_wdr.cpp:274 src/muuli_wdr.cpp:293 src/muuli_wdr.cpp:1627
 #: src/OtherFunctions.cpp:64
 msgid "MB"
 msgstr "MB"
@@ -3362,7 +3367,7 @@ msgstr "Madhesia Maksimale"
 msgid "Availability"
 msgstr "Te disponueshem"
 
-#: src/muuli_wdr.cpp:312 src/muuli_wdr.cpp:398 src/muuli_wdr.cpp:3290
+#: src/muuli_wdr.cpp:312 src/muuli_wdr.cpp:398 src/muuli_wdr.cpp:3297
 msgid "Filter:"
 msgstr "Filteri:"
 
@@ -3394,7 +3399,7 @@ msgstr ""
 msgid "Stop"
 msgstr "Ndalo"
 
-#: src/muuli_wdr.cpp:348 src/muuli_wdr.cpp:1385 src/SearchListCtrl.cpp:732
+#: src/muuli_wdr.cpp:348 src/muuli_wdr.cpp:1392 src/SearchListCtrl.cpp:732
 msgid "Download"
 msgstr "Shkarkime"
 
@@ -3426,8 +3431,8 @@ msgstr "Burime te gjetura :"
 #: src/muuli_wdr.cpp:1160 src/muuli_wdr.cpp:1167 src/muuli_wdr.cpp:1172
 #: src/muuli_wdr.cpp:1179 src/muuli_wdr.cpp:1184 src/muuli_wdr.cpp:1191
 #: src/muuli_wdr.cpp:1205 src/muuli_wdr.cpp:1212 src/muuli_wdr.cpp:1217
-#: src/muuli_wdr.cpp:1224 src/muuli_wdr.cpp:3227 src/muuli_wdr.cpp:3235
-#: src/muuli_wdr.cpp:3243
+#: src/muuli_wdr.cpp:1224 src/muuli_wdr.cpp:3234 src/muuli_wdr.cpp:3242
+#: src/muuli_wdr.cpp:3250
 msgid "N/A"
 msgstr "N/A"
 
@@ -3572,7 +3577,7 @@ msgstr ""
 msgid "Album :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:685 src/muuli_wdr.cpp:2247
+#: src/muuli_wdr.cpp:685 src/muuli_wdr.cpp:2254
 msgid "Title :"
 msgstr "Titulli :"
 
@@ -3679,7 +3684,7 @@ msgstr "Emri i Perdoruesit :"
 msgid "Userhash :"
 msgstr "Userhash :"
 
-#: src/muuli_wdr.cpp:895 src/muuli_wdr.cpp:1741 src/muuli_wdr.cpp:2442
+#: src/muuli_wdr.cpp:895 src/muuli_wdr.cpp:1748 src/muuli_wdr.cpp:2449
 #: src/utils/aLinkCreator/src/alcframe.cpp:137
 msgid "Add"
 msgstr "Shto"
@@ -3688,15 +3693,15 @@ msgstr "Shto"
 msgid "Download-Speed"
 msgstr "Shpejtesia-Shkarkimit"
 
-#: src/muuli_wdr.cpp:954 src/muuli_wdr.cpp:989 src/muuli_wdr.cpp:2546
+#: src/muuli_wdr.cpp:954 src/muuli_wdr.cpp:989 src/muuli_wdr.cpp:2553
 msgid "Current"
 msgstr "Aktualisht"
 
-#: src/muuli_wdr.cpp:962 src/muuli_wdr.cpp:997 src/muuli_wdr.cpp:2554
+#: src/muuli_wdr.cpp:962 src/muuli_wdr.cpp:997 src/muuli_wdr.cpp:2561
 msgid "Running average"
 msgstr "Mesatarja e Punes"
 
-#: src/muuli_wdr.cpp:970 src/muuli_wdr.cpp:1005 src/muuli_wdr.cpp:2562
+#: src/muuli_wdr.cpp:970 src/muuli_wdr.cpp:1005 src/muuli_wdr.cpp:2569
 msgid "Session average"
 msgstr "Mesatarja e Sesionit"
 
@@ -3708,7 +3713,7 @@ msgstr "Shpejtesia-Ngarkimit"
 msgid "Connections"
 msgstr "Lidhjet"
 
-#: src/muuli_wdr.cpp:1024 src/muuli_wdr.cpp:1860
+#: src/muuli_wdr.cpp:1024 src/muuli_wdr.cpp:1867
 msgid "Active downloads"
 msgstr "Shkarkime Aktive"
 
@@ -3716,7 +3721,7 @@ msgstr "Shkarkime Aktive"
 msgid "Active connections (1:1)"
 msgstr "Lidhje Aktive (1:1)"
 
-#: src/muuli_wdr.cpp:1040 src/muuli_wdr.cpp:1861
+#: src/muuli_wdr.cpp:1040 src/muuli_wdr.cpp:1868
 msgid "Active uploads"
 msgstr "Ngarkime Aktive"
 
@@ -3833,8 +3838,8 @@ msgstr "Ky eshte emri qe te tjeret do te shohin kur te lidhen tek ju."
 msgid "Language: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1257 src/muuli_wdr.cpp:1323 src/muuli_wdr.cpp:1327
-#: src/muuli_wdr.cpp:1330
+#: src/muuli_wdr.cpp:1257 src/muuli_wdr.cpp:1330 src/muuli_wdr.cpp:1334
+#: src/muuli_wdr.cpp:1337
 msgid "The delay before showing tool-tips."
 msgstr "Interval kohor para se te tregohen sugjerimet."
 
@@ -3912,937 +3917,946 @@ msgstr ""
 msgid "Enabling this will make aMule to show notifications when finished downloading."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1322
-msgid "Tooltip delay time: "
+#: src/muuli_wdr.cpp:1323
+#, fuzzy
+msgid "Remember search history"
+msgstr "Mbaji mend keto rregullime"
+
+#: src/muuli_wdr.cpp:1324
+msgid "Keeps a dropdown list of your past search terms in the Search tab's Name field. This remembers the queries you typed, not the results they returned."
 msgstr ""
 
 #: src/muuli_wdr.cpp:1329
+msgid "Tooltip delay time: "
+msgstr ""
+
+#: src/muuli_wdr.cpp:1336
 msgid "seconds"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1333
+#: src/muuli_wdr.cpp:1340
 msgid "Browser Selection"
 msgstr "Zgjedhesi i shfletuesit"
 
-#: src/muuli_wdr.cpp:1339
+#: src/muuli_wdr.cpp:1346
 msgid "Enter your browser name here. Leave this field empty to use the system default browser."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1346
+#: src/muuli_wdr.cpp:1353
 msgid "Open in new tab if possible"
 msgstr "Hape ne nje faqe te re nqs eshte e mundur"
 
-#: src/muuli_wdr.cpp:1348
+#: src/muuli_wdr.cpp:1355
 msgid "Open the web page in a new tab instead of in a new window when possible"
 msgstr "Nqs eshte e mundur hape faqen e re te web-it ne nje faqe tjeter te re"
 
-#: src/muuli_wdr.cpp:1352
+#: src/muuli_wdr.cpp:1359
 msgid "Video Player"
 msgstr "Video Player"
 
-#: src/muuli_wdr.cpp:1379
+#: src/muuli_wdr.cpp:1386
 msgid "Bandwidth limits"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1393
+#: src/muuli_wdr.cpp:1400
 msgid "Upload"
 msgstr "Ngarkim"
 
-#: src/muuli_wdr.cpp:1401
+#: src/muuli_wdr.cpp:1408
 msgid "Slot Allocation"
 msgstr "Vendndodhja e slotit"
 
-#: src/muuli_wdr.cpp:1410
+#: src/muuli_wdr.cpp:1417
 msgid "Ports"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1420
+#: src/muuli_wdr.cpp:1427
 msgid "This is the standard eD2k port and cannot be disabled."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1423
+#: src/muuli_wdr.cpp:1430
 msgid "UDP port for server requests (TCP+3):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1425
+#: src/muuli_wdr.cpp:1432
 msgid "4665"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1432
+#: src/muuli_wdr.cpp:1439
 msgid "This UDP port is used for extended eD2k requests and Kad network"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1439
+#: src/muuli_wdr.cpp:1446
 msgid "UPnP TCP Port (Optional):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1449
+#: src/muuli_wdr.cpp:1456
 msgid "Bind local address to IP (empty for any):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1452
+#: src/muuli_wdr.cpp:1459
 msgid "Advanced users only: If you have multiple network interfaces, enter the address of the interface to which aMule should be bound."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1455 src/muuli_wdr.cpp:2054
+#: src/muuli_wdr.cpp:1462 src/muuli_wdr.cpp:2061
 msgid "Bind to network interface (empty for any):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1468
+#: src/muuli_wdr.cpp:1475
 msgid "Advanced users only: pin all of aMule's traffic to one network interface, chosen from the list or typed in by name (e.g. tun0, eth0, en0) or index. Unlike binding to an IP, this stops traffic leaking out via the default route - useful with a VPN. Requires no elevated privileges."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1474
+#: src/muuli_wdr.cpp:1481
 msgid "Max sources per downloading file:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1478
+#: src/muuli_wdr.cpp:1485
 msgid "Max simultaneous connections:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1491 src/muuli_wdr.cpp:3169
+#: src/muuli_wdr.cpp:1498 src/muuli_wdr.cpp:3176
 msgid "ED2K"
 msgstr "ED2K"
 
-#: src/muuli_wdr.cpp:1498
+#: src/muuli_wdr.cpp:1505
 msgid "Autoconnect on startup"
 msgstr "Lidje automatike sapo programi te hapet"
 
-#: src/muuli_wdr.cpp:1501
+#: src/muuli_wdr.cpp:1508
 msgid "Reconnect on loss"
 msgstr "Rilidhu mbas humbjes se lidhjes"
 
-#: src/muuli_wdr.cpp:1523
+#: src/muuli_wdr.cpp:1530
 msgid "Remove dead server after"
 msgstr "Largo serverat e papune mbas"
 
-#: src/muuli_wdr.cpp:1524
+#: src/muuli_wdr.cpp:1531
 msgid "Static servers are never removed, even when unreachable."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1528
+#: src/muuli_wdr.cpp:1535
 msgid "retries"
 msgstr "tentativa"
 
-#: src/muuli_wdr.cpp:1536
+#: src/muuli_wdr.cpp:1543
 msgid "List"
 msgstr "Lista"
 
-#: src/muuli_wdr.cpp:1539
+#: src/muuli_wdr.cpp:1546
 msgid "Update server list when connecting to a server"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1542
+#: src/muuli_wdr.cpp:1549
 msgid "Update server list when a client connects"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1545
+#: src/muuli_wdr.cpp:1552
 msgid "Use priority system"
 msgstr "Perdor sistemin e prioritetit"
 
-#: src/muuli_wdr.cpp:1549
+#: src/muuli_wdr.cpp:1556
 msgid "Use smart LowID check on connect"
 msgstr "Perdor kontrollin e zgjuar per ID e ulet kur lidhesh"
 
-#: src/muuli_wdr.cpp:1553
+#: src/muuli_wdr.cpp:1560
 msgid "Safe connect"
 msgstr "Lidhje e sigurte"
 
-#: src/muuli_wdr.cpp:1557
+#: src/muuli_wdr.cpp:1564
 msgid "Autoconnect to servers in static list only"
 msgstr "Lidhu automatikisht vetem me serverat e qendrueshem"
 
-#: src/muuli_wdr.cpp:1560
+#: src/muuli_wdr.cpp:1567
 msgid "Set manually added servers to High Priority"
 msgstr "Vendosni ne menyre manuale serverat e shtuar ne Prioritet te Larte"
 
-#: src/muuli_wdr.cpp:1581
+#: src/muuli_wdr.cpp:1588
 msgid "Add files to download in pause mode"
 msgstr "Shto failet tek shkarkimi duke i vene ne pushim"
 
-#: src/muuli_wdr.cpp:1583
+#: src/muuli_wdr.cpp:1590
 msgid "Add files to download with auto priority"
 msgstr "Shto failet tek shkarkimi me prioritet automatik"
 
-#: src/muuli_wdr.cpp:1586
+#: src/muuli_wdr.cpp:1593
 msgid "Try to download first and last chunks first"
 msgstr "Mundohu te shkarkosh pjesen e pare dhe te fundit te failit"
 
-#: src/muuli_wdr.cpp:1590
+#: src/muuli_wdr.cpp:1597
 msgid "Endgame mode: rotate to faster sources for the final blocks"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1593
+#: src/muuli_wdr.cpp:1600
 msgid "Start next paused file when a file completes"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1596
+#: src/muuli_wdr.cpp:1603
 msgid "From the same category"
 msgstr "Nga e njejta kategori"
 
-#: src/muuli_wdr.cpp:1598
+#: src/muuli_wdr.cpp:1605
 msgid "In alphabetic order"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1600
+#: src/muuli_wdr.cpp:1607
 msgid "Preallocate disk space for new files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1601
+#: src/muuli_wdr.cpp:1608
 msgid "For new files preallocates disk space for the whole file, thus reduces fragmentation"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1606
+#: src/muuli_wdr.cpp:1613
 msgid "Create new files as sparse files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1607
+#: src/muuli_wdr.cpp:1614
 msgid "A sparse file reserves its full size on disk immediately without writing real data to it -- fast, but unsupported or slow on some filesystems, and free-space accounting stays optimistic while the download is in progress. Turn this off to grow the file only as data arrives."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1612
+#: src/muuli_wdr.cpp:1619
 msgid "Stop downloads when free disk space reaches "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1613
+#: src/muuli_wdr.cpp:1620
 msgid "Select this if you want aMule to check your disk space"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1617
+#: src/muuli_wdr.cpp:1624
 msgid "Enter here the min disk space desired."
 msgstr "Futni ketu hapesiren minimale qe deshironi per diskun."
 
-#: src/muuli_wdr.cpp:1623
+#: src/muuli_wdr.cpp:1630
 msgid "Save 10 sources on rare files (< 20 sources)"
 msgstr "Shpeto 10 burime per failet e rralla (< 20 burime)"
 
-#: src/muuli_wdr.cpp:1627 src/Statistics.cpp:790
+#: src/muuli_wdr.cpp:1634 src/Statistics.cpp:790
 msgid "Uploads"
 msgstr "Ngarkimi"
 
-#: src/muuli_wdr.cpp:1630
+#: src/muuli_wdr.cpp:1637
 msgid "Add new shared files with auto priority"
 msgstr "Shto faile te reja te ndara me prioritet automatik"
 
-#: src/muuli_wdr.cpp:1636
+#: src/muuli_wdr.cpp:1643
 msgid "Intelligent Corruption Handling (I.C.H.)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1639
+#: src/muuli_wdr.cpp:1646
 msgid "Enable"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1642
+#: src/muuli_wdr.cpp:1649
 msgid "Advanced I.C.H. trusts every hash (not recommended)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1654 src/PrefsUnifiedDlg.cpp:1910
+#: src/muuli_wdr.cpp:1661 src/PrefsUnifiedDlg.cpp:1910
 msgid "Media metadata extraction"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1658
+#: src/muuli_wdr.cpp:1665
 msgid "Extract length / bitrate / codec from shared audio and video files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1660
+#: src/muuli_wdr.cpp:1667
 msgid "When enabled, aMule runs ffprobe on each shared media file to fill in the Length / Bitrate / Codec columns other clients see when they find the file in a search. Requires ffmpeg (the ffprobe binary) to be installed."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1667
+#: src/muuli_wdr.cpp:1674
 msgid "Path to ffprobe:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1672
+#: src/muuli_wdr.cpp:1679
 msgid "Full path to the ffprobe binary. Leave empty to have aMule auto-detect it on startup."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1680
+#: src/muuli_wdr.cpp:1687
 msgid "Detect"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1681
+#: src/muuli_wdr.cpp:1688
 msgid "Search the standard install locations for an ffprobe binary and fill the path field."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1705
+#: src/muuli_wdr.cpp:1712
 msgid ""
 "Completed downloads are stored here. All files in this folder are automatically shared with other peers.\n"
 "If this folder also holds files you don't want to share, point it at an aMule-only sub-folder."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1708
+#: src/muuli_wdr.cpp:1715
 msgid "Pick the folder where completed downloads will be stored. All files in that folder will be shared with other peers."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1722
+#: src/muuli_wdr.cpp:1729
 msgid "Shared folders"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1728
+#: src/muuli_wdr.cpp:1735
 msgid "(Folders shared by the core. Enter a path to add one.)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1736
+#: src/muuli_wdr.cpp:1743
 msgid "Absolute path of a folder on the core's machine, e.g. /home/user/shared"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1738 src/PrefsUnifiedDlg.cpp:2794
+#: src/muuli_wdr.cpp:1745 src/PrefsUnifiedDlg.cpp:2794
 msgid "Recursive"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1739
+#: src/muuli_wdr.cpp:1746
 msgid "Share every sub-folder underneath this one, including ones created later."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1743 src/utils/aLinkCreator/src/alcframe.cpp:141
+#: src/muuli_wdr.cpp:1750 src/utils/aLinkCreator/src/alcframe.cpp:141
 msgid "Remove"
 msgstr "Hiq"
 
-#: src/muuli_wdr.cpp:1747
+#: src/muuli_wdr.cpp:1754
 msgid "(Right click on folder icon for recursive share)"
 msgstr "( Klikoni me butonin e djathte ne ikonene e karteles per te ndare ne menyre rekursive)"
 
-#: src/muuli_wdr.cpp:1754
+#: src/muuli_wdr.cpp:1761
 msgid "Share hidden files"
 msgstr "Nda failet e fshehur"
 
-#: src/muuli_wdr.cpp:1760
+#: src/muuli_wdr.cpp:1767
 msgid "Automatically rescan shared folders for changes"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1766
+#: src/muuli_wdr.cpp:1773
 msgid "Follow symbolic links in shared folders"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1772
+#: src/muuli_wdr.cpp:1779
 msgid "Exclude files matching:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1775
+#: src/muuli_wdr.cpp:1782
 msgid "Wildcard patterns separated by '|', e.g. .DS_Store|Thumbs.db|*.tmp. Files whose name matches are not shared. Matching is case-insensitive."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1779
+#: src/muuli_wdr.cpp:1786
 msgid "Patterns are regular expressions"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1780
+#: src/muuli_wdr.cpp:1787
 msgid "When set, the whole field is one regular expression ('|' is alternation). When unset, it is a list of '|'-separated wildcards."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1790
+#: src/muuli_wdr.cpp:1797
 msgid "Show how many shared files the current pattern would exclude."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1811
+#: src/muuli_wdr.cpp:1818
 msgid "Graphs"
 msgstr "Grafiket"
 
-#: src/muuli_wdr.cpp:1814 src/muuli_wdr.cpp:1876
+#: src/muuli_wdr.cpp:1821 src/muuli_wdr.cpp:1883
 msgid "Update delay : 5 secs"
 msgstr "Intervali i azhornimit : 5 sek"
 
-#: src/muuli_wdr.cpp:1818
+#: src/muuli_wdr.cpp:1825
 msgid "Time for average graph: 100 mins"
 msgstr "Intervali grafik i vlerave mesatare: 100 minuta"
 
-#: src/muuli_wdr.cpp:1822
+#: src/muuli_wdr.cpp:1829
 msgid "Connections Graph Scale: 100 "
 msgstr "Shkalla grafike e lidhjeve: 100 "
 
-#: src/muuli_wdr.cpp:1829
+#: src/muuli_wdr.cpp:1836
 msgid "Download graph scale:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1837
+#: src/muuli_wdr.cpp:1844
 msgid "Upload graph scale:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1847
+#: src/muuli_wdr.cpp:1854
 msgid "Colors: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1851
+#: src/muuli_wdr.cpp:1858
 msgid "Background"
 msgstr "Sfondi"
 
-#: src/muuli_wdr.cpp:1852
+#: src/muuli_wdr.cpp:1859
 msgid "Grid"
 msgstr "Zgara"
 
-#: src/muuli_wdr.cpp:1853
+#: src/muuli_wdr.cpp:1860
 msgid "Download current"
 msgstr "Shkarkimi aktual"
 
-#: src/muuli_wdr.cpp:1854
+#: src/muuli_wdr.cpp:1861
 msgid "Download running average"
 msgstr "Mesatarja e shkarkimeve ne punim"
 
-#: src/muuli_wdr.cpp:1855
+#: src/muuli_wdr.cpp:1862
 msgid "Download session average"
 msgstr "Mesatarja e sesioneve te shkarkimit"
 
-#: src/muuli_wdr.cpp:1856
+#: src/muuli_wdr.cpp:1863
 msgid "Upload current"
 msgstr "Ngarkimi aktual"
 
-#: src/muuli_wdr.cpp:1857
+#: src/muuli_wdr.cpp:1864
 msgid "Upload running average"
 msgstr "Mesatarja e ngarkimit ne punim"
 
-#: src/muuli_wdr.cpp:1858
+#: src/muuli_wdr.cpp:1865
 msgid "Upload session average"
 msgstr "Mesatarja e sesionit te ngarkimeve"
 
-#: src/muuli_wdr.cpp:1859
+#: src/muuli_wdr.cpp:1866
 msgid "Active connections"
 msgstr "Lidhjet aktive"
 
-#: src/muuli_wdr.cpp:1862
+#: src/muuli_wdr.cpp:1869
 #, fuzzy
 msgid "Systray Icon Speed Bar"
 msgstr "Ikona e Speedbar-it ne Systray"
 
-#: src/muuli_wdr.cpp:1863
+#: src/muuli_wdr.cpp:1870
 msgid "Kad-nodes current"
 msgstr "Nyjet e Kad aktuale"
 
-#: src/muuli_wdr.cpp:1864
+#: src/muuli_wdr.cpp:1871
 msgid "Kad-nodes running"
 msgstr "Nyjet e Kad jane duke punuar"
 
-#: src/muuli_wdr.cpp:1865
+#: src/muuli_wdr.cpp:1872
 msgid "Kad-nodes session"
 msgstr "Sesioni i Nyjeve te Kad"
 
-#: src/muuli_wdr.cpp:1869 src/muuli_wdr.cpp:2296
+#: src/muuli_wdr.cpp:1876 src/muuli_wdr.cpp:2303
 msgid "Select"
 msgstr "Zgjidh"
 
-#: src/muuli_wdr.cpp:1873
+#: src/muuli_wdr.cpp:1880
 msgid "Tree"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1883
+#: src/muuli_wdr.cpp:1890
 msgid "Number of Client Versions shown (0=unlimited)"
 msgstr "Numera te treguar te versioneve te klienteve (0= pa kufij)"
 
-#: src/muuli_wdr.cpp:1908
+#: src/muuli_wdr.cpp:1915
 msgid "!!! WARNING !!!"
 msgstr "!!! KUJDES !!!"
 
-#: src/muuli_wdr.cpp:1923
+#: src/muuli_wdr.cpp:1930
 msgid "Max new connections / 5 secs"
 msgstr "Lidhe maksimale te reja / 5 sek"
 
-#: src/muuli_wdr.cpp:1925
+#: src/muuli_wdr.cpp:1932
 msgid "Concurrent Kad source lookups"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1927
+#: src/muuli_wdr.cpp:1934
 #, fuzzy
 msgid "Kad source re-search interval (minutes)"
 msgstr "Intervali i rifreskimit te FTP-se ne minuta"
 
-#: src/muuli_wdr.cpp:1929
+#: src/muuli_wdr.cpp:1936
 #, fuzzy
 msgid "Source re-ask interval (minutes)"
 msgstr "Intervali i rifreskimit te FTP-se ne minuta"
 
-#: src/muuli_wdr.cpp:1933
+#: src/muuli_wdr.cpp:1940
 msgid "File Buffer Size: 240000 bytes"
 msgstr "Madhesia e Buffer-it te failit: 240000 bytes"
 
-#: src/muuli_wdr.cpp:1937
+#: src/muuli_wdr.cpp:1944
 msgid "Use MMAP: memory-mapped file access (lower memory use)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1938
+#: src/muuli_wdr.cpp:1945
 msgid "Maps part files into memory instead of buffering them on the heap, lowering the process memory footprint. May reduce download speed on some disks; best for memory-constrained or upload-heavy hosts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1940
+#: src/muuli_wdr.cpp:1947
 msgid "Upload Queue Size: 5000 clients"
 msgstr "Madhesia e Radhes ne Ngarkim: 5000 klienta"
 
-#: src/muuli_wdr.cpp:1944
+#: src/muuli_wdr.cpp:1951
 msgid "Server connection refresh interval: Disable"
 msgstr "Interval i azhornimit te lidhjes se serverit: C'aktivizuar"
 
-#: src/muuli_wdr.cpp:1948
+#: src/muuli_wdr.cpp:1955
 msgid "Disable computer's timed standby mode"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1967
+#: src/muuli_wdr.cpp:1974
 msgid "Skin to use: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1976
+#: src/muuli_wdr.cpp:1983
 msgid "Show \"Fast eD2k Links Handler\" in every window."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1979
+#: src/muuli_wdr.cpp:1986
 msgid "Show extended info on categories tabs"
 msgstr "Trego informacion te zgjeruar ne tabelat e kategorive"
 
-#: src/muuli_wdr.cpp:1982
+#: src/muuli_wdr.cpp:1989
 #, fuzzy
 msgid "Show application version on title"
 msgstr "Trego shpejtesine e transferimit ne titull"
 
-#: src/muuli_wdr.cpp:1984
+#: src/muuli_wdr.cpp:1991
 msgid "Show transfer rates on title"
 msgstr "Trego shpejtesine e transferimit ne titull"
 
-#: src/muuli_wdr.cpp:1986
+#: src/muuli_wdr.cpp:1993
 msgid "Before application name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1988
+#: src/muuli_wdr.cpp:1995
 msgid "After application name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1991
+#: src/muuli_wdr.cpp:1998
 msgid "Show overhead bandwidth"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1995
+#: src/muuli_wdr.cpp:2002
 msgid "Vertical toolbar orientation"
 msgstr "Orientim Vertikal i toolbar-it"
 
-#: src/muuli_wdr.cpp:1997
+#: src/muuli_wdr.cpp:2004
 msgid "Live column sorting (auto-reorder rows as their values change)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2004
+#: src/muuli_wdr.cpp:2011
 msgid "Download Queue Files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2007
+#: src/muuli_wdr.cpp:2014
 msgid "Show progress percentage"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2013
+#: src/muuli_wdr.cpp:2020
 msgid "Show progress bar"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2016
+#: src/muuli_wdr.cpp:2023
 msgid "Flat"
 msgstr "E sheshte"
 
-#: src/muuli_wdr.cpp:2020
+#: src/muuli_wdr.cpp:2027
 msgid "Round"
 msgstr "E rrumbullakosur"
 
-#: src/muuli_wdr.cpp:2038
+#: src/muuli_wdr.cpp:2045
 msgid "External Connection Parameters"
 msgstr "Parametrat e Lidhjeve te Jashtme"
 
-#: src/muuli_wdr.cpp:2041
+#: src/muuli_wdr.cpp:2048
 msgid "Accept external connections"
 msgstr "Prano lidhje te jashtme"
 
-#: src/muuli_wdr.cpp:2048 src/muuli_wdr.cpp:2107
+#: src/muuli_wdr.cpp:2055 src/muuli_wdr.cpp:2114
 msgid "IP of the listening interface:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2051
+#: src/muuli_wdr.cpp:2058
 msgid "Enter here a valid ip in the a.b.c.d format for the listening EC interface. An empty field or 0.0.0.0 will mean any interface."
 msgstr "Futni ketu nje ip te vlefshem ne formatin a.b.c.d per te degjuar nderfaqesin EC. Nje fushe boshe ose 0.0.0.0 do te nenkuptoje cdo nderfaqe."
 
-#: src/muuli_wdr.cpp:2072 src/muuli_wdr.cpp:2156
+#: src/muuli_wdr.cpp:2079 src/muuli_wdr.cpp:2163
 msgid "TCP port:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2078
+#: src/muuli_wdr.cpp:2085
 msgid "Enable UPnP port forwarding on the EC port"
 msgstr "Aktivizo port forwarding UPnP tek porta EC"
 
-#: src/muuli_wdr.cpp:2082 src/muuli_wdr.cpp:3041
+#: src/muuli_wdr.cpp:2089 src/muuli_wdr.cpp:3048
 #: src/utils/wxCas/src/wxcasprefs.cpp:167
 msgid "Password"
 msgstr "Fjalekalim"
 
-#: src/muuli_wdr.cpp:2088
+#: src/muuli_wdr.cpp:2095
 msgid "aMule API server parameters"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2091
+#: src/muuli_wdr.cpp:2098
 msgid "Run amuleapi (REST API) on startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2096
+#: src/muuli_wdr.cpp:2103
 #, fuzzy
 msgid "HTTP port:"
 msgstr "Porta e Proksit:"
 
-#: src/muuli_wdr.cpp:2110
+#: src/muuli_wdr.cpp:2117
 msgid "The interface amuleapi's HTTP server listens on. 127.0.0.1 (default) accepts only local connections; use 0.0.0.0 or a specific IP to expose it to other hosts (set an admin password below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2113
+#: src/muuli_wdr.cpp:2120
 #, fuzzy
 msgid "Admin password"
 msgstr "Duke kerkuar fjalekalimin\n"
 
-#: src/muuli_wdr.cpp:2118 src/muuli_wdr.cpp:2149
+#: src/muuli_wdr.cpp:2125 src/muuli_wdr.cpp:2156
 msgid "Low rights password"
 msgstr "Fjalekalim per te drejta te kufizuara"
 
-#: src/muuli_wdr.cpp:2126
+#: src/muuli_wdr.cpp:2133
 msgid "Web server parameters"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2129
+#: src/muuli_wdr.cpp:2136
 msgid "Run webserver on startup (deprecated)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2135
+#: src/muuli_wdr.cpp:2142
 msgid "Web template"
 msgstr "Modeli Web"
 
-#: src/muuli_wdr.cpp:2140
+#: src/muuli_wdr.cpp:2147
 msgid "Full rights password"
 msgstr "Fjalekalim per te drejta komplete"
 
-#: src/muuli_wdr.cpp:2144
+#: src/muuli_wdr.cpp:2151
 msgid "Enable Low rights User"
 msgstr "Aktivizo Perdorues me te drejta te kufizuara"
 
-#: src/muuli_wdr.cpp:2163
+#: src/muuli_wdr.cpp:2170
 msgid "Enable UPnP port forwarding of the web server port"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2168
+#: src/muuli_wdr.cpp:2175
 msgid "Web server UPnP TCP port (Optional)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2176
+#: src/muuli_wdr.cpp:2183
 msgid "Page Refresh Time (in secs)"
 msgstr "Koha e Rifreskimit te Faqes (ne sek)"
 
-#: src/muuli_wdr.cpp:2183
+#: src/muuli_wdr.cpp:2190
 msgid "Enable Gzip compression"
 msgstr "Aktivizo kompresimin Gzip"
 
-#: src/muuli_wdr.cpp:2217
+#: src/muuli_wdr.cpp:2224
 #, fuzzy
 msgid "Reset page to defaults"
 msgstr "E vendosur nga sistemi"
 
-#: src/muuli_wdr.cpp:2218
+#: src/muuli_wdr.cpp:2225
 msgid "Reset the settings on the current page to their default values."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2220 src/muuli_wdr.cpp:2306 src/ServerWnd.cpp:274
+#: src/muuli_wdr.cpp:2227 src/muuli_wdr.cpp:2313 src/ServerWnd.cpp:274
 #: src/ServerWnd.cpp:282
 msgid "OK"
 msgstr "Ne rregull"
 
-#: src/muuli_wdr.cpp:2222
+#: src/muuli_wdr.cpp:2229
 msgid "Click here to apply any changes made to the preferences."
 msgstr "Kliko ketu per te bere aktive ndryshimet qe u bene tek Preferencat."
 
-#: src/muuli_wdr.cpp:2225
+#: src/muuli_wdr.cpp:2232
 msgid "Reset any changes made to the preferences."
 msgstr "Rikthe ne gjendjen e meparshme ndryshimet te bera tek Preferencat."
 
-#: src/muuli_wdr.cpp:2254
+#: src/muuli_wdr.cpp:2261
 msgid "Comment :"
 msgstr "Komente :"
 
-#: src/muuli_wdr.cpp:2261
+#: src/muuli_wdr.cpp:2268
 msgid "Incoming Dir :"
 msgstr "Direktoria e Hyrjeve :"
 
-#: src/muuli_wdr.cpp:2270
+#: src/muuli_wdr.cpp:2277
 msgid "Change priority for new assigned files :"
 msgstr "Nderro perparesine per failet e reja te caktuara :"
 
-#: src/muuli_wdr.cpp:2274
+#: src/muuli_wdr.cpp:2281
 #, fuzzy
 msgid "Don't change"
 msgstr "Mos nderro"
 
-#: src/muuli_wdr.cpp:2286
+#: src/muuli_wdr.cpp:2293
 msgid "Select color for this Category (currently selected) :"
 msgstr "Zgjidh ngjyren per kete kategori (e zgjedhur aktualisht) :"
 
-#: src/muuli_wdr.cpp:2353 src/muuli_wdr.cpp:2372 src/muuli_wdr.cpp:2394
+#: src/muuli_wdr.cpp:2360 src/muuli_wdr.cpp:2379 src/muuli_wdr.cpp:2401
 msgid "Click this button to reset the log."
 msgstr "Kliko ne kete buton per te resetuar log-un."
 
-#: src/muuli_wdr.cpp:2413
+#: src/muuli_wdr.cpp:2420
 msgid "Click on this button to update the servers list from URL ..."
 msgstr "Kliko ne kete buton per te azhornuar listen e serverave nga URL ..."
 
-#: src/muuli_wdr.cpp:2417
+#: src/muuli_wdr.cpp:2424
 msgid "Server list"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2421
+#: src/muuli_wdr.cpp:2428
 msgid "Enter the url to a server.met file here and press the button to the left to update the list of known servers."
 msgstr "Futni url tek nje fail server.met dhe shtypni butonin ne te majte per te azhornuar listen e serverave te njohur."
 
-#: src/muuli_wdr.cpp:2426
+#: src/muuli_wdr.cpp:2433
 msgid "Add server manually: Name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2429
+#: src/muuli_wdr.cpp:2436
 msgid "Enter the name of the new server here"
 msgstr "Futni emrin e serverit te ri ketu"
 
-#: src/muuli_wdr.cpp:2431 src/ServerWnd.cpp:206
+#: src/muuli_wdr.cpp:2438 src/ServerWnd.cpp:206
 msgid "IP:Port"
 msgstr "IP:Porta"
 
-#: src/muuli_wdr.cpp:2434
+#: src/muuli_wdr.cpp:2441
 msgid "Enter the IP of the server here, using the x.x.x.x format."
 msgstr "Futni IP-ne e serverit ketu. duke perdorur formatin x.x.x.x."
 
-#: src/muuli_wdr.cpp:2440
+#: src/muuli_wdr.cpp:2447
 msgid "Enter the port of the server here."
 msgstr "Futni porten e serverit ketu."
 
-#: src/muuli_wdr.cpp:2443
+#: src/muuli_wdr.cpp:2450
 msgid "Add manually a server (fill fields to the left before) ..."
 msgstr "Shto ne menyre manuale nje server (mbushni fushen ne te majte me pare) ..."
 
-#: src/muuli_wdr.cpp:2472
+#: src/muuli_wdr.cpp:2479
 msgid "aMule Log"
 msgstr "Log i aMule"
 
-#: src/muuli_wdr.cpp:2480
+#: src/muuli_wdr.cpp:2487
 msgid "Server Info"
 msgstr "Informacion mbi serverin"
 
-#: src/muuli_wdr.cpp:2484
+#: src/muuli_wdr.cpp:2491
 msgid "ED2K Info"
 msgstr "Informacioni i ED2K"
 
-#: src/muuli_wdr.cpp:2488
+#: src/muuli_wdr.cpp:2495
 msgid "Kad Info"
 msgstr "Informacioni i Kad"
 
-#: src/muuli_wdr.cpp:2516
+#: src/muuli_wdr.cpp:2523
 msgid "Click on this button to update the nodes list from URL ..."
 msgstr "Kliko ne kete buton per te azhornuar listen e nyjeve nga URL ..."
 
-#: src/muuli_wdr.cpp:2520
+#: src/muuli_wdr.cpp:2527
 msgid "Nodes (0)"
 msgstr "Nyjet (0)"
 
-#: src/muuli_wdr.cpp:2524
+#: src/muuli_wdr.cpp:2531
 msgid "Enter the url to a nodes.dat file here and press the button to the left to update the list of known nodes."
 msgstr "Fut url e nje faili nodes.dat dhe shtyp butonin ne te majte per te azhornuar listen e nyjeve te njohura."
 
-#: src/muuli_wdr.cpp:2527
+#: src/muuli_wdr.cpp:2534
 msgid "Nodes stats"
 msgstr "Statistikat e Nyjeve"
 
-#: src/muuli_wdr.cpp:2569
+#: src/muuli_wdr.cpp:2576
 msgid "Bootstrap"
 msgstr "Bootstrap"
 
-#: src/muuli_wdr.cpp:2572
+#: src/muuli_wdr.cpp:2579
 msgid "New node"
 msgstr "Nyje e re"
 
-#: src/muuli_wdr.cpp:2577
+#: src/muuli_wdr.cpp:2584
 msgid "IP:"
 msgstr "IP:"
 
-#: src/muuli_wdr.cpp:2597
+#: src/muuli_wdr.cpp:2604
 msgid "Port:"
 msgstr "Porta:"
 
-#: src/muuli_wdr.cpp:2610
+#: src/muuli_wdr.cpp:2617
 #, fuzzy
 msgid "Bootstrap from known clients"
 msgstr ""
 "Bootstrap nga \n"
 "kliente te njohur"
 
-#: src/muuli_wdr.cpp:2612
+#: src/muuli_wdr.cpp:2619
 msgid "Disconnect Kad"
 msgstr "Shkeput Kad"
 
-#: src/muuli_wdr.cpp:2646
+#: src/muuli_wdr.cpp:2653
 msgid "Use Secure User Identification"
 msgstr "Perdor Identifikimin e Sigurte te Perdoruesve"
 
-#: src/muuli_wdr.cpp:2648
+#: src/muuli_wdr.cpp:2655
 msgid "It is recommended to enable this option. You will not receive credits if SUI is not enabled."
 msgstr "Eshte e rekomandueshme qe ta lejoni kete opsion. Ju nuk mund te merrni kredite nqs SUI nuk eshte i aktivizuar."
 
-#: src/muuli_wdr.cpp:2650
+#: src/muuli_wdr.cpp:2657
 msgid "Protocol Obfuscation"
 msgstr "Protokolli i Turbullimit"
 
-#: src/muuli_wdr.cpp:2653
+#: src/muuli_wdr.cpp:2660
 msgid "Support Protocol Obfuscation"
 msgstr "Mbeshtet Protokollin e Turbullimit"
 
-#: src/muuli_wdr.cpp:2655
+#: src/muuli_wdr.cpp:2662
 msgid "This option enabled Protocol Obfuscation, and makes aMule accept obfuscated connections from other clients."
 msgstr "Ky opsion lejon Protokollin e Turbullimit, dhe ben qe aMule te pranoje lidhje te turbulluara nga kliente te tjere."
 
-#: src/muuli_wdr.cpp:2657
+#: src/muuli_wdr.cpp:2664
 msgid "Use obfuscation for outgoing connections"
 msgstr "Perdor turbullimin per lidhjet ne dalje"
 
-#: src/muuli_wdr.cpp:2659
+#: src/muuli_wdr.cpp:2666
 msgid "This option makes aMule use Protocol Obfuscation when connecting other clients/servers."
 msgstr "Ky opsion lejon aMule-n qe te perdori protokollin e turbullimit kur lidhet me klientet/serverat e tjere."
 
-#: src/muuli_wdr.cpp:2661
+#: src/muuli_wdr.cpp:2668
 msgid "Accept only obfuscated connections"
 msgstr "Prano vetem lidhje te turbulluara"
 
-#: src/muuli_wdr.cpp:2662
+#: src/muuli_wdr.cpp:2669
 msgid "This option makes aMule only accept obfuscated connections. You will have less sources, but all your traffic will be obfuscated"
 msgstr "Ky opsion e ben aMule-n qe te lejoje lidhje te turbulluara. Ju do te keni me pak burime, por i gjithe trafiku juaj do te turbullohet"
 
-#: src/muuli_wdr.cpp:2667
+#: src/muuli_wdr.cpp:2674
 msgid "Everybody"
 msgstr "Te gjithe"
 
-#: src/muuli_wdr.cpp:2669
+#: src/muuli_wdr.cpp:2676
 msgid "No one"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2671
+#: src/muuli_wdr.cpp:2678
 msgid "Who can see my shared files:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2672
+#: src/muuli_wdr.cpp:2679
 msgid "Select who can request to view a list of your shared files."
 msgstr "Zgjidh se kush ka kerkuar te shikoje listene faileve qe ju keni ndare."
 
-#: src/muuli_wdr.cpp:2674
+#: src/muuli_wdr.cpp:2681
 msgid "IP-Filtering"
 msgstr "Filtrimi-IP"
 
-#: src/muuli_wdr.cpp:2681
+#: src/muuli_wdr.cpp:2688
 msgid "Filter clients"
 msgstr "Filtro klientet"
 
-#: src/muuli_wdr.cpp:2683
+#: src/muuli_wdr.cpp:2690
 msgid "Enable filtering of the client IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "Lejo filtrimin e IP-ve te klientave te percaktuar ne failin ~/.aMule/ipfilter.dat."
 
-#: src/muuli_wdr.cpp:2685
+#: src/muuli_wdr.cpp:2692
 msgid "Filter servers"
 msgstr "Filtron Serverat"
 
-#: src/muuli_wdr.cpp:2687
+#: src/muuli_wdr.cpp:2694
 msgid "Enable filtering of the server IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "Lejo filtrimin e IP-ve te serverave te percaktuara ne failin ~/.aMule/ipfilter.dat."
 
-#: src/muuli_wdr.cpp:2691
+#: src/muuli_wdr.cpp:2698
 msgid "Reload List"
 msgstr "Lista e Ringarkimeve"
 
-#: src/muuli_wdr.cpp:2692
+#: src/muuli_wdr.cpp:2699
 msgid "Reload the list of IPs to filter from the file ~/.aMule/ipfilter.dat"
 msgstr "Ringarko listen e IP-ve per te filtruar nga faili ~/.aMule/ipfilter.dat"
 
-#: src/muuli_wdr.cpp:2698
+#: src/muuli_wdr.cpp:2705
 msgid "URL:"
 msgstr "URL:"
 
-#: src/muuli_wdr.cpp:2702 src/muuli_wdr.cpp:2895
+#: src/muuli_wdr.cpp:2709 src/muuli_wdr.cpp:2902
 msgid "Update now"
 msgstr "Azhorno tani"
 
-#: src/muuli_wdr.cpp:2705
+#: src/muuli_wdr.cpp:2712
 msgid "Auto-update ipfilter at startup"
 msgstr "Azhornim-Automatik i ipfilter sapo te ndizet"
 
-#: src/muuli_wdr.cpp:2709
+#: src/muuli_wdr.cpp:2716
 msgid "Filtering Level:"
 msgstr "Niveli i Filtrimit:"
 
-#: src/muuli_wdr.cpp:2715
+#: src/muuli_wdr.cpp:2722
 msgid "Always filter LAN IPs"
 msgstr "Gjithmone filtro IP-te LAN"
 
-#: src/muuli_wdr.cpp:2718
+#: src/muuli_wdr.cpp:2725
 msgid "Paranoid handling of non-matching IPs"
 msgstr "Perdorim Paranoik te IP-ve qe nuk korrespondojne"
 
-#: src/muuli_wdr.cpp:2720
+#: src/muuli_wdr.cpp:2727
 msgid "Rejects a packet when its source IP differs from the IP the client claims (an anti-spoofing check). Disable only if it causes connection problems."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2722
+#: src/muuli_wdr.cpp:2729
 msgid "Use system-wide ipfilter.dat if available"
 msgstr "Perdor ipfilter.dat te sistemit nqs eshte i disponueshem"
 
-#: src/muuli_wdr.cpp:2723
+#: src/muuli_wdr.cpp:2730
 #, fuzzy
 msgid "If there's no local ipfilter.dat found, allow usage of a system-wide ipfilter file."
 msgstr "Nese nuk eshte gjetur ndonje ipfilter.dat lokal, lejo perdorimin e failit ipfilter te sistemit."
 
-#: src/muuli_wdr.cpp:2740
+#: src/muuli_wdr.cpp:2747
 msgid "Enable Online-Signature"
 msgstr "Lejo Firmen-Online"
 
-#: src/muuli_wdr.cpp:2742
+#: src/muuli_wdr.cpp:2749
 msgid "Enables the writing of the OS file, which can be used by external apps to create signatures and the like."
 msgstr "Lejon shkrimin e faileve OS, qe mund te perdorren nga aplikacione te jashtme per te krijuar firma dhe te ngjashme."
 
-#: src/muuli_wdr.cpp:2746
+#: src/muuli_wdr.cpp:2753
 msgid "Update Frequency (Secs):"
 msgstr "Frekuenca e azhornimeve (sek):"
 
-#: src/muuli_wdr.cpp:2749
+#: src/muuli_wdr.cpp:2756
 msgid "Change the frequency (in seconds) of Online Signature updates."
 msgstr "Nderron frekuqncen (ne sekonda) te azhornimit te Firmes Online."
 
-#: src/muuli_wdr.cpp:2757
+#: src/muuli_wdr.cpp:2764
 msgid "Save online signature file in: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:2763
+#: src/muuli_wdr.cpp:2770
 msgid "Click here to select the directory containing the the Online Signature files."
 msgstr "Shtypni ketu per te zgjedhur direktorine qe permban failet e Firmes Online."
 
-#: src/muuli_wdr.cpp:2796
+#: src/muuli_wdr.cpp:2803
 msgid "Show country flags for clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2797
+#: src/muuli_wdr.cpp:2804
 msgid "Render the country flag column in the transfers, queue and search views. Requires a valid MMDB GeoIP database (see below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2802
+#: src/muuli_wdr.cpp:2809
 #, fuzzy
 msgid "Database"
 msgstr "Shpejtesia :"
 
-#: src/muuli_wdr.cpp:2818
+#: src/muuli_wdr.cpp:2825
 #, fuzzy
 msgid "Source:"
 msgstr "Burime"
 
-#: src/muuli_wdr.cpp:2821
+#: src/muuli_wdr.cpp:2828
 msgid "DB-IP (free, no account)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2822
+#: src/muuli_wdr.cpp:2829
 msgid "MaxMind GeoLite2 (free, account required)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2823
+#: src/muuli_wdr.cpp:2830
 msgid "Custom URL"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2826
+#: src/muuli_wdr.cpp:2833
 msgid "Choose which provider supplies the GeoIP MMDB database. DB-IP is the default - no account required. MaxMind requires a free account + license key. Use Custom URL to point at any other MMDB host (e.g. a local mirror)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2843
+#: src/muuli_wdr.cpp:2850
 msgid ""
 "No configuration required.\n"
 "\n"
@@ -4850,11 +4864,11 @@ msgid ""
 "License: Creative Commons BY 4.0 - https://creativecommons.org/licenses/by/4.0/"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2856
+#: src/muuli_wdr.cpp:2863
 msgid "License key:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2862
+#: src/muuli_wdr.cpp:2869
 msgid ""
 "Sign up for a free MaxMind account, then generate a License Key:\n"
 "https://www.maxmind.com/en/geolite2/signup\n"
@@ -4864,232 +4878,232 @@ msgid ""
 "Requires attribution and account registration; refresh at least every 30 days."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2877
+#: src/muuli_wdr.cpp:2884
 #, fuzzy
 msgid "Download URL:"
 msgstr "Shkarkim: "
 
-#: src/muuli_wdr.cpp:2883
+#: src/muuli_wdr.cpp:2890
 msgid ""
 "Must point to an .mmdb file or a .gz / .tar.gz containing one.\n"
 "URL may include credentials (https://user:pass@host/...).\n"
 "License and attribution terms are set by the upstream URL - you are responsible."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2896
+#: src/muuli_wdr.cpp:2903
 msgid "Download the GeoIP database from the selected source."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2898
+#: src/muuli_wdr.cpp:2905
 #, fuzzy
 msgid "Auto-update on startup"
 msgstr "Azhornim-Automatik i ipfilter sapo te ndizet"
 
-#: src/muuli_wdr.cpp:2899
+#: src/muuli_wdr.cpp:2906
 msgid "Re-download the GeoIP database from the selected source every time aMule starts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2922
+#: src/muuli_wdr.cpp:2929
 msgid "Filter incoming messages (except current chat):"
 msgstr "Filtron mesazhet ne hyrje (pervec chatit qe po zhvilloni):"
 
-#: src/muuli_wdr.cpp:2924
+#: src/muuli_wdr.cpp:2931
 msgid "Filter all messages"
 msgstr "Filtron te gjithe mesazhet"
 
-#: src/muuli_wdr.cpp:2926
+#: src/muuli_wdr.cpp:2933
 msgid "Filter messages from people not on your friend list"
 msgstr "Filtron mesazhet nga njerezit qe nuk ndohen ne listen e miqve tuaj"
 
-#: src/muuli_wdr.cpp:2928
+#: src/muuli_wdr.cpp:2935
 msgid "Filter messages from unknown clients"
 msgstr "Filtron mesazhet nga klienta t èanjohur"
 
-#: src/muuli_wdr.cpp:2930
+#: src/muuli_wdr.cpp:2937
 msgid "Filter messages containing (use ',' as separator):"
 msgstr "Filtron mesazhet qe permbajne (perdor ',' si nje ndarese):"
 
-#: src/muuli_wdr.cpp:2933 src/muuli_wdr.cpp:2944
+#: src/muuli_wdr.cpp:2940 src/muuli_wdr.cpp:2951
 msgid "add here the words amule should filter and block messages including it"
 msgstr "shto ketu fjalet qe aMule do te filtroje duke bllokuar mesazhet qe ato mbajne"
 
-#: src/muuli_wdr.cpp:2935
+#: src/muuli_wdr.cpp:2942
 msgid "Show received messages in the log"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2938
+#: src/muuli_wdr.cpp:2945
 msgid "Comments"
 msgstr "Komente"
 
-#: src/muuli_wdr.cpp:2941
+#: src/muuli_wdr.cpp:2948
 msgid "Filter comments containing (use ',' as separator):"
 msgstr "Komente e filtrave permbajne (perdor ',' si nje ndarese):"
 
-#: src/muuli_wdr.cpp:2966
+#: src/muuli_wdr.cpp:2973
 msgid "Enable Proxy"
 msgstr "Aktivizo Proksin(Proxy)"
 
-#: src/muuli_wdr.cpp:2967
+#: src/muuli_wdr.cpp:2974
 msgid "Enable/disable proxy support"
 msgstr "Aktivizo/C'aktivizo mbeshtetjen e Proksit(Proxy)"
 
-#: src/muuli_wdr.cpp:2970
+#: src/muuli_wdr.cpp:2977
 msgid "Proxy type:"
 msgstr "Lloji i Proksit(Proxy):"
 
-#: src/muuli_wdr.cpp:2981
+#: src/muuli_wdr.cpp:2988
 msgid "Proxy host:"
 msgstr "Hosti i Proksit(Proxy)"
 
-#: src/muuli_wdr.cpp:2984
+#: src/muuli_wdr.cpp:2991
 msgid "The proxy host name"
 msgstr "Host Name i Proksit(Proxy)"
 
-#: src/muuli_wdr.cpp:2986
+#: src/muuli_wdr.cpp:2993
 msgid "Proxy port:"
 msgstr "Porta e Proksit:"
 
-#: src/muuli_wdr.cpp:2989
+#: src/muuli_wdr.cpp:2996
 msgid "The proxy port"
 msgstr "Porta e Proksit(Proxy)"
 
-#: src/muuli_wdr.cpp:2991
+#: src/muuli_wdr.cpp:2998
 msgid "Enable authentication"
 msgstr "Aktivizo njohjen"
 
-#: src/muuli_wdr.cpp:2992
+#: src/muuli_wdr.cpp:2999
 msgid "Enable/disable username/password authentication"
 msgstr "Aktivizo/C'aktivizo emri i perdoruesit/njohja e fjalekalimit"
 
-#: src/muuli_wdr.cpp:2995
+#: src/muuli_wdr.cpp:3002
 msgid "Username: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:2998
+#: src/muuli_wdr.cpp:3005
 msgid "The username to use to connect to the proxy"
 msgstr "Emri i perdorimit qe do perdoret per tu lidhur tek Proksi(Proxy)"
 
-#: src/muuli_wdr.cpp:3000
+#: src/muuli_wdr.cpp:3007
 msgid "Password:"
 msgstr "Fjalekalimi:"
 
-#: src/muuli_wdr.cpp:3003
+#: src/muuli_wdr.cpp:3010
 msgid "The password to use to connect to the proxy"
 msgstr "Fjalekalimi per te perdorur per tu lidhur tek Proksi(Proxy)"
 
-#: src/muuli_wdr.cpp:3022
+#: src/muuli_wdr.cpp:3029
 msgid "Connect to:"
 msgstr "Lidhu me:"
 
-#: src/muuli_wdr.cpp:3031
+#: src/muuli_wdr.cpp:3038
 msgid "Login to remote amule"
 msgstr "Futu tek Remote i aMule"
 
-#: src/muuli_wdr.cpp:3036
+#: src/muuli_wdr.cpp:3043
 msgid "User name"
 msgstr "Emri i Perdoruesit"
 
-#: src/muuli_wdr.cpp:3047
+#: src/muuli_wdr.cpp:3054
 msgid "Remember those settings"
 msgstr "Mbaji mend keto rregullime"
 
-#: src/muuli_wdr.cpp:3050
+#: src/muuli_wdr.cpp:3057
 #, fuzzy
 msgid "Force ZLIB compression"
 msgstr "Perdor kompresimin gzip"
 
-#: src/muuli_wdr.cpp:3074
+#: src/muuli_wdr.cpp:3081
 msgid "Enable Verbose Debug-Logging."
 msgstr "Aktivizon logging-un e detajuar te mesazheve te debug-ut."
 
-#: src/muuli_wdr.cpp:3076
+#: src/muuli_wdr.cpp:3083
 #, fuzzy
 msgid "Only to Logfile"
 msgstr "&Hap failin"
 
-#: src/muuli_wdr.cpp:3078
+#: src/muuli_wdr.cpp:3085
 msgid "Message Categories:"
 msgstr "Kategorite e Mesazheve:"
 
-#: src/muuli_wdr.cpp:3102 src/PartFileConvertDlg.cpp:160
+#: src/muuli_wdr.cpp:3109 src/PartFileConvertDlg.cpp:160
 msgid "Waiting..."
 msgstr "Ne pritje..."
 
-#: src/muuli_wdr.cpp:3122
+#: src/muuli_wdr.cpp:3129
 msgid "Add imports"
 msgstr "Shton importimet"
 
-#: src/muuli_wdr.cpp:3125
+#: src/muuli_wdr.cpp:3132
 msgid "Retry selected"
 msgstr "Provoji perseri te perzgjedhurit"
 
-#: src/muuli_wdr.cpp:3127
+#: src/muuli_wdr.cpp:3134
 msgid "Remove selected"
 msgstr "Zhvendos te perzgjedhurat"
 
-#: src/muuli_wdr.cpp:3190
+#: src/muuli_wdr.cpp:3197
 msgid "Event Types"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3209
+#: src/muuli_wdr.cpp:3216
 msgid "Statistics and queued clients for selected file(s) : Session / All time"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3233
+#: src/muuli_wdr.cpp:3240
 #, fuzzy
 msgid "Active Uploads"
 msgstr "Ngarkime Aktive :"
 
-#: src/muuli_wdr.cpp:3247
+#: src/muuli_wdr.cpp:3254
 msgid "Percent of total files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3299
+#: src/muuli_wdr.cpp:3306
 #, fuzzy
 msgid "Show Clients for"
 msgstr "Trego klientet"
 
-#: src/muuli_wdr.cpp:3301
+#: src/muuli_wdr.cpp:3308
 #, fuzzy
 msgid "All files"
 msgstr "Fshih failet e ndara"
 
-#: src/muuli_wdr.cpp:3304
+#: src/muuli_wdr.cpp:3311
 #, fuzzy
 msgid "Selected files"
 msgstr "Zgjidh filtrin e shikimit"
 
-#: src/muuli_wdr.cpp:3307
+#: src/muuli_wdr.cpp:3314
 #, fuzzy
 msgid "Active uploads only"
 msgstr "Ngarkime Aktive"
 
-#: src/muuli_wdr.cpp:3314
+#: src/muuli_wdr.cpp:3321
 #, fuzzy
 msgid "Reload:"
 msgstr "Lista e Ringarkimeve"
 
-#: src/muuli_wdr.cpp:3318
+#: src/muuli_wdr.cpp:3325
 msgid "Reload your shared files"
 msgstr "Ringarko failet e ndara"
 
-#: src/muuli_wdr.cpp:3381
+#: src/muuli_wdr.cpp:3388
 msgid "Send"
 msgstr "Dergo"
 
-#: src/muuli_wdr.cpp:3382
+#: src/muuli_wdr.cpp:3389
 msgid "Sends the specified message."
 msgstr "Dergo mesazhin e specifikuar."
 
-#: src/muuli_wdr.cpp:3386
+#: src/muuli_wdr.cpp:3393
 msgid "Close this chat-session."
 msgstr "Mbylle kete sesion chati."
 
-#: src/muuli_wdr.cpp:3409
+#: src/muuli_wdr.cpp:3416
 msgid "Connect to any server and/or Kad"
 msgstr "Lidhu me ndonje server dhe/ose Kad"
 
-#: src/muuli_wdr.cpp:3415 src/SharedFilesCtrl.cpp:142 src/Statistics.cpp:941
+#: src/muuli_wdr.cpp:3422 src/SharedFilesCtrl.cpp:142 src/Statistics.cpp:941
 msgid "Shared Files"
 msgstr "File te ndara"
 
@@ -5450,192 +5464,192 @@ msgstr ""
 msgid "ERROR: Failed to open partfile '%s'"
 msgstr ""
 
-#: src/Preferences.cpp:673
+#: src/Preferences.cpp:674
 msgid "System default"
 msgstr "E vendosur nga sistemi"
 
-#: src/Preferences.cpp:674
+#: src/Preferences.cpp:675
 msgid "Albanian"
 msgstr "Shqip"
 
-#: src/Preferences.cpp:675
+#: src/Preferences.cpp:676
 msgid "Arabic"
 msgstr "Arabe"
 
-#: src/Preferences.cpp:676
+#: src/Preferences.cpp:677
 #, fuzzy
 msgid "Asturian"
 msgstr "Estoneze"
 
-#: src/Preferences.cpp:677
+#: src/Preferences.cpp:678
 msgid "Basque"
 msgstr "Baske"
 
-#: src/Preferences.cpp:678
+#: src/Preferences.cpp:679
 msgid "Bulgarian"
 msgstr "Bullgare"
 
-#: src/Preferences.cpp:679
+#: src/Preferences.cpp:680
 msgid "Catalan"
 msgstr "Katallanase"
 
-#: src/Preferences.cpp:680
+#: src/Preferences.cpp:681
 msgid "Chinese (Simplified)"
 msgstr "Kineze (E thjeshtesuar)"
 
-#: src/Preferences.cpp:681
+#: src/Preferences.cpp:682
 msgid "Chinese (Traditional)"
 msgstr "KIneze (Tradicionale)"
 
-#: src/Preferences.cpp:682
+#: src/Preferences.cpp:683
 msgid "Croatian"
 msgstr "Kroate"
 
-#: src/Preferences.cpp:683
+#: src/Preferences.cpp:684
 msgid "Czech"
 msgstr "Ceke"
 
-#: src/Preferences.cpp:684
+#: src/Preferences.cpp:685
 msgid "Danish"
 msgstr "Daneze"
 
-#: src/Preferences.cpp:685
+#: src/Preferences.cpp:686
 msgid "Dutch"
 msgstr "Holandeze"
 
-#: src/Preferences.cpp:686
+#: src/Preferences.cpp:687
 msgid "English (U.K.)"
 msgstr "Anglisht (G.B.)"
 
-#: src/Preferences.cpp:687
+#: src/Preferences.cpp:688
 #, fuzzy
 msgid "English (U.S.)"
 msgstr "Anglisht (G.B.)"
 
-#: src/Preferences.cpp:688
+#: src/Preferences.cpp:689
 msgid "Estonian"
 msgstr "Estoneze"
 
-#: src/Preferences.cpp:689
+#: src/Preferences.cpp:690
 msgid "Finnish"
 msgstr "Finlandeze"
 
-#: src/Preferences.cpp:690
+#: src/Preferences.cpp:691
 msgid "French"
 msgstr "Frengjisht"
 
-#: src/Preferences.cpp:691
+#: src/Preferences.cpp:692
 msgid "Galician"
 msgstr "Galiciane"
 
-#: src/Preferences.cpp:692
+#: src/Preferences.cpp:693
 msgid "German"
 msgstr "Gjermanisht"
 
-#: src/Preferences.cpp:693
+#: src/Preferences.cpp:694
 msgid "Greek"
 msgstr "Greqisht"
 
-#: src/Preferences.cpp:694
+#: src/Preferences.cpp:695
 msgid "Hebrew"
 msgstr "Cifut"
 
-#: src/Preferences.cpp:695
+#: src/Preferences.cpp:696
 msgid "Hungarian"
 msgstr "Hungarisht"
 
-#: src/Preferences.cpp:696
+#: src/Preferences.cpp:697
 msgid "Italian"
 msgstr "Italiane"
 
-#: src/Preferences.cpp:697
+#: src/Preferences.cpp:698
 msgid "Japanese"
 msgstr "Japonisht"
 
-#: src/Preferences.cpp:698
+#: src/Preferences.cpp:699
 msgid "Korean"
 msgstr "Koreane"
 
-#: src/Preferences.cpp:699
+#: src/Preferences.cpp:700
 msgid "Latvian"
 msgstr ""
 
-#: src/Preferences.cpp:700
+#: src/Preferences.cpp:701
 msgid "Lithuanian"
 msgstr "Lituane"
 
-#: src/Preferences.cpp:701
+#: src/Preferences.cpp:702
 msgid "Norwegian (Nynorsk)"
 msgstr "Norvegjeze (Nynorsk)"
 
-#: src/Preferences.cpp:702
+#: src/Preferences.cpp:703
 msgid "Polish"
 msgstr "Polake"
 
-#: src/Preferences.cpp:703
+#: src/Preferences.cpp:704
 msgid "Portuguese"
 msgstr "Portugeze"
 
-#: src/Preferences.cpp:704
+#: src/Preferences.cpp:705
 msgid "Portuguese (Brazilian)"
 msgstr "Portugeze (Braziliane)"
 
-#: src/Preferences.cpp:705
+#: src/Preferences.cpp:706
 #, fuzzy
 msgid "Romanian"
 msgstr "Shqip"
 
-#: src/Preferences.cpp:706
+#: src/Preferences.cpp:707
 msgid "Russian"
 msgstr "Ruse"
 
-#: src/Preferences.cpp:707
+#: src/Preferences.cpp:708
 msgid "Slovenian"
 msgstr "Sllovene"
 
-#: src/Preferences.cpp:708
+#: src/Preferences.cpp:709
 msgid "Spanish"
 msgstr "Spanjolle"
 
-#: src/Preferences.cpp:709
+#: src/Preferences.cpp:710
 msgid "Swedish"
 msgstr "Suedeze"
 
-#: src/Preferences.cpp:710
+#: src/Preferences.cpp:711
 msgid "Turkish"
 msgstr "Turqisht"
 
-#: src/Preferences.cpp:711
+#: src/Preferences.cpp:712
 msgid "Ukrainian"
 msgstr ""
 
-#: src/Preferences.cpp:814
+#: src/Preferences.cpp:815
 #, fuzzy
 msgid "Change Language"
 msgstr "Gjuha"
 
-#: src/Preferences.cpp:878
+#: src/Preferences.cpp:879
 msgid "There are no translations installed for aMule"
 msgstr ""
 
-#: src/Preferences.cpp:879
+#: src/Preferences.cpp:880
 #, fuzzy
 msgid "No languages available"
 msgstr "Nuk eshte ne dispozicion"
 
-#: src/Preferences.cpp:1010
+#: src/Preferences.cpp:1011
 msgid "no options available"
 msgstr ""
 
-#: src/Preferences.cpp:2179
+#: src/Preferences.cpp:2182
 msgid "Invalid category found, skipping"
 msgstr ""
 
-#: src/Preferences.cpp:2348
+#: src/Preferences.cpp:2351
 msgid "TCP port can't be higher than 65532 due to server UDP socket being TCP+3"
 msgstr "Porta TCP nuk mund te jene me te medha se 65532  sepse socket i UDP eshte fiksuar ne TCP+3"
 
-#: src/Preferences.cpp:2349
+#: src/Preferences.cpp:2352
 #, c-format
 msgid "Default port will be used (%d)"
 msgstr "Do te perdoret porta e vendosur (%d)"
@@ -6144,24 +6158,28 @@ msgstr "Ringarko listen e faileve te ndara."
 msgid "Shared folder"
 msgstr "File te ndara"
 
-#: src/SearchDlg.cpp:425
+#: src/SearchDlg.cpp:280
+msgid "Clear search history"
+msgstr ""
+
+#: src/SearchDlg.cpp:584
 msgid "It's impossible to search when both eD2k and Kademlia are disabled."
 msgstr ""
 
-#: src/SearchDlg.cpp:426 src/SearchListCtrl.cpp:858
+#: src/SearchDlg.cpp:585 src/SearchListCtrl.cpp:858
 #, fuzzy
 msgid "Search error"
 msgstr "Kerkimet"
 
-#: src/SearchDlg.cpp:768
+#: src/SearchDlg.cpp:929
 msgid "Min size must be smaller than max size. Max size ignored."
 msgstr "Masa minimale duhet te jete me e vogel se masa maksimale.Po injoroj Masen Maksimale.."
 
-#: src/SearchDlg.cpp:769 src/SearchDlg.cpp:851
+#: src/SearchDlg.cpp:930 src/SearchDlg.cpp:1012
 msgid "Search warning"
 msgstr "PoParalajmerim per kerkim"
 
-#: src/SearchDlg.cpp:929 src/SearchListCtrl.cpp:735
+#: src/SearchDlg.cpp:1092 src/SearchListCtrl.cpp:735
 msgid "Main"
 msgstr "Kryesore"
 

--- a/po/sv.po
+++ b/po/sv.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-28 08:06+0200\n"
+"POT-Creation-Date: 2026-07-28 10:19+0200\n"
 "PO-Revision-Date: 2026-07-27 11:46+0000\n"
 "Last-Translator: raffe <raffe@localhost.se>\n"
 "Language-Team: Swedish <tp-sv@listor.tp-sv.se>\n"
@@ -144,7 +144,7 @@ msgstr ""
 msgid "Not now"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:422 src/amuleDlg.cpp:600
+#: src/AppImageIntegration.cpp:422 src/amuleDlg.cpp:665
 msgid "Don't ask again"
 msgstr ""
 
@@ -217,7 +217,7 @@ msgid "Killing amuleweb instance with pid '%d' ... "
 msgstr "Dödar amuleweb-instansen med pid '%d' ... "
 
 #: src/amule.cpp:336 src/amule.cpp:349 src/ClientRef.cpp:180
-#: src/SearchDlg.cpp:880 src/ServerListCtrl.cpp:98
+#: src/SearchDlg.cpp:1041 src/ServerListCtrl.cpp:98
 msgid "Failed"
 msgstr "Misslyckades"
 
@@ -573,30 +573,68 @@ msgstr "Kan inte skapa Pid-fil"
 msgid "ERROR: %s"
 msgstr "FEL: %s"
 
-#: src/amuleDlg.cpp:236
+#: src/amuleDlg.cpp:250
 #, c-format
 msgid "This is aMule %s based on eMule."
 msgstr "Det här är aMule %s baserad på eMule."
 
-#: src/amuleDlg.cpp:237
+#: src/amuleDlg.cpp:251
 #, c-format
 msgid "Running on %s"
 msgstr "Kör på %s"
 
-#: src/amuleDlg.cpp:239
+#: src/amuleDlg.cpp:253
 msgid "Visit https://github.com/amule-org/amule/releases/latest to check if a new version is available."
 msgstr "Besök https://github.com/amule-org/amule/releases/latest för att se om en ny version finns tillgänglig."
 
-#: src/amuleDlg.cpp:268
+#: src/amuleDlg.cpp:282
 msgid "FATAL ERROR: Failed to create Timer"
 msgstr "ALLVARLIGT FEL: Kunde inte skapa Timer"
 
-#: src/amuleDlg.cpp:592
+#: src/amuleDlg.cpp:361 src/amuleDlg.cpp:1787 src/amuleDlg.cpp:2033
+#: src/muuli_wdr.cpp:1492 src/muuli_wdr.cpp:3418
+msgid "Networks"
+msgstr "Nätverk"
+
+#: src/amuleDlg.cpp:362 src/amuleDlg.cpp:1793 src/muuli_wdr.cpp:3419
+msgid "Searches"
+msgstr "Sökningar"
+
+#: src/amuleDlg.cpp:363 src/amuleDlg.cpp:1799 src/DownloadListCtrl.cpp:740
+#: src/muuli_wdr.cpp:392 src/muuli_wdr.cpp:1585 src/muuli_wdr.cpp:3420
+#: src/Statistics.cpp:829
+msgid "Downloads"
+msgstr "Hämtningar"
+
+#: src/amuleDlg.cpp:364 src/amuleDlg.cpp:1805 src/muuli_wdr.cpp:3294
+msgid "Shared files"
+msgstr "Delade filer"
+
+#: src/amuleDlg.cpp:365 src/amuleDlg.cpp:1811 src/muuli_wdr.cpp:2926
+#: src/muuli_wdr.cpp:3376 src/muuli_wdr.cpp:3423
+msgid "Messages"
+msgstr "Meddelanden"
+
+#: src/amuleDlg.cpp:366 src/amuleDlg.cpp:1817 src/muuli_wdr.cpp:3424
+#: src/PrefsUnifiedDlg.cpp:312 src/Statistics.cpp:779 src/Statistics.cpp:1235
+msgid "Statistics"
+msgstr "Statistik"
+
+#: src/amuleDlg.cpp:368 src/amuleDlg.cpp:1824 src/muuli_wdr.cpp:3426
+#: src/PrefsUnifiedDlg.cpp:328 src/utils/wxCas/src/wxcasprefs.cpp:39
+msgid "Preferences"
+msgstr "Inställningar"
+
+#: src/amuleDlg.cpp:371
+msgid "Navigate"
+msgstr ""
+
+#: src/amuleDlg.cpp:657
 #, fuzzy
 msgid "New version available"
 msgstr "Inte tillgänglig"
 
-#: src/amuleDlg.cpp:596
+#: src/amuleDlg.cpp:661
 #, fuzzy, c-format
 msgid ""
 "A new version of aMule (%s) is available.\n"
@@ -606,218 +644,185 @@ msgid ""
 "Would you like to open the download page?"
 msgstr "Den senaste versionen kan alltid hittas på https://github.com/amule-org/amule/releases/latest"
 
-#: src/amuleDlg.cpp:678
+#: src/amuleDlg.cpp:743
 msgid "aMule dialog destroyed"
 msgstr "aMule-dialog avslutad"
 
-#: src/amuleDlg.cpp:701 src/DataToText.cpp:68 src/IPFilter.cpp:547
+#: src/amuleDlg.cpp:766 src/DataToText.cpp:68 src/IPFilter.cpp:547
 msgid "Connecting"
 msgstr "Ansluter"
 
-#: src/amuleDlg.cpp:893
+#: src/amuleDlg.cpp:958
 msgid "eD2k: Connecting"
 msgstr "eD2k: Ansluter"
 
-#: src/amuleDlg.cpp:897
+#: src/amuleDlg.cpp:962
 msgid "eD2k: Disconnected"
 msgstr "eD2k: Frånkopplad"
 
-#: src/amuleDlg.cpp:903
+#: src/amuleDlg.cpp:968
 msgid "Kad: Firewalled"
 msgstr "Kad: Via brandvägg"
 
-#: src/amuleDlg.cpp:907
+#: src/amuleDlg.cpp:972
 msgid "Kad: Connected"
 msgstr "Kad: Ansluten"
 
-#: src/amuleDlg.cpp:912
+#: src/amuleDlg.cpp:977
 msgid "Kad: Connecting"
 msgstr "Kad: Ansluter"
 
-#: src/amuleDlg.cpp:916
+#: src/amuleDlg.cpp:981
 msgid "Kad: Off"
 msgstr "Kad: Av"
 
-#: src/amuleDlg.cpp:964 src/DownloadListCtrl.cpp:505
+#: src/amuleDlg.cpp:1029 src/DownloadListCtrl.cpp:505
 #: src/DownloadListCtrl.cpp:749 src/FriendListCtrl.cpp:180
 #: src/muuli_wdr.cpp:731 src/muuli_wdr.cpp:782 src/muuli_wdr.cpp:846
-#: src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2224 src/muuli_wdr.cpp:2309
-#: src/muuli_wdr.cpp:3057 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
+#: src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2231 src/muuli_wdr.cpp:2316
+#: src/muuli_wdr.cpp:3064 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
 #: src/ServerListCtrl.cpp:606 src/TransferWnd.cpp:378
 #: src/utils/wxCas/src/wxcasprefs.cpp:235
 msgid "Cancel"
 msgstr "Avbryt"
 
-#: src/amuleDlg.cpp:965
+#: src/amuleDlg.cpp:1030
 msgid "Stop the current connection attempts"
 msgstr "Stoppa de nuvarande anslutningsförsöken"
 
-#: src/amuleDlg.cpp:970 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976
-#: src/muuli_wdr.cpp:2447
+#: src/amuleDlg.cpp:1035 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976
+#: src/muuli_wdr.cpp:2454
 msgid "Disconnect"
 msgstr "Koppla från"
 
-#: src/amuleDlg.cpp:971
+#: src/amuleDlg.cpp:1036
 msgid "Disconnect from the currently connected networks"
 msgstr "Koppla från de nätverk som nu är anslutna."
 
-#: src/amuleDlg.cpp:976 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979
-#: src/muuli_wdr.cpp:2602 src/muuli_wdr.cpp:3054 src/muuli_wdr.cpp:3409
+#: src/amuleDlg.cpp:1041 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979
+#: src/muuli_wdr.cpp:2609 src/muuli_wdr.cpp:3061 src/muuli_wdr.cpp:3416
 msgid "Connect"
 msgstr "Anslut"
 
-#: src/amuleDlg.cpp:977
+#: src/amuleDlg.cpp:1042
 msgid "Connect to the currently enabled networks"
 msgstr "Anslut till de nätverk som är aktiverade."
 
-#: src/amuleDlg.cpp:1089
+#: src/amuleDlg.cpp:1154
 #, fuzzy, c-format
 msgid "Up: %.1f%s (%.1f) | Down: %.1f%s (%.1f)"
 msgstr "Upp: %.1f(%.1f) | Ner: %.1f(%.1f)"
 
-#: src/amuleDlg.cpp:1091 src/amuleDlg.cpp:1093 src/amuleDlg.cpp:1097
-#: src/amuleDlg.cpp:1099 src/amuleDlg.cpp:1110 src/amuleDlg.cpp:1112
+#: src/amuleDlg.cpp:1156 src/amuleDlg.cpp:1158 src/amuleDlg.cpp:1162
+#: src/amuleDlg.cpp:1164 src/amuleDlg.cpp:1175 src/amuleDlg.cpp:1177
 #: src/MuleTrayIcon.cpp:796 src/MuleTrayIcon.cpp:799
 #, fuzzy
 msgid " MB/s"
 msgstr "MB/s"
 
-#: src/amuleDlg.cpp:1091 src/amuleDlg.cpp:1093 src/amuleDlg.cpp:1097
-#: src/amuleDlg.cpp:1099 src/amuleDlg.cpp:1110 src/amuleDlg.cpp:1112
+#: src/amuleDlg.cpp:1156 src/amuleDlg.cpp:1158 src/amuleDlg.cpp:1162
+#: src/amuleDlg.cpp:1164 src/amuleDlg.cpp:1175 src/amuleDlg.cpp:1177
 #: src/MuleTrayIcon.cpp:796 src/MuleTrayIcon.cpp:799
 #: src/utils/wxCas/src/wxcasframe.cpp:1041
 msgid " kB/s"
 msgstr " kB/s"
 
-#: src/amuleDlg.cpp:1096
+#: src/amuleDlg.cpp:1161
 #, fuzzy, c-format
 msgid "Up: %.1f%s | Down: %.1f%s"
 msgstr "Upp: %.1f | Ner: %.1f"
 
-#: src/amuleDlg.cpp:1128
+#: src/amuleDlg.cpp:1193
 #, c-format
 msgid "aMule (%s | Connected)"
 msgstr "aMule (%s | Ansluten)"
 
-#: src/amuleDlg.cpp:1130
+#: src/amuleDlg.cpp:1195
 #, c-format
 msgid "aMule (%s | Disconnected)"
 msgstr "aMule (%s | Frånkopplad)"
 
-#: src/amuleDlg.cpp:1183
+#: src/amuleDlg.cpp:1248
 #, c-format
 msgid "Do you really want to exit %s?"
 msgstr "Vill du verkligen avsluta %s?"
 
-#: src/amuleDlg.cpp:1185
+#: src/amuleDlg.cpp:1250
 msgid "Exit confirmation"
 msgstr "Bekräfta avslutning"
 
-#: src/amuleDlg.cpp:1548
+#: src/amuleDlg.cpp:1613
 msgid "Launch Command: "
 msgstr "Kör kommando:"
 
-#: src/amuleDlg.cpp:1567 src/muuli_wdr.cpp:1971 src/Preferences.cpp:951
+#: src/amuleDlg.cpp:1632 src/muuli_wdr.cpp:1978 src/Preferences.cpp:952
 msgid "- default -"
 msgstr "- standard -"
 
-#: src/amuleDlg.cpp:1595
+#: src/amuleDlg.cpp:1660
 #, c-format
 msgid "Skin directory '%s' does not exist"
 msgstr "Skin-mappen '%s' finns inte"
 
-#: src/amuleDlg.cpp:1598
+#: src/amuleDlg.cpp:1663
 #, c-format
 msgid "WARNING: Unable to open skin file '%s' for read"
 msgstr "Varning: Kan inte öppna skin-filen '%s' för läsning"
 
-#: src/amuleDlg.cpp:1722 src/amuleDlg.cpp:1968 src/muuli_wdr.cpp:1485
-#: src/muuli_wdr.cpp:3411
-msgid "Networks"
-msgstr "Nätverk"
-
-#: src/amuleDlg.cpp:1726 src/muuli_wdr.cpp:3411
+#: src/amuleDlg.cpp:1791 src/muuli_wdr.cpp:3418
 msgid "Networks Window"
 msgstr "Nätverksfönster"
 
-#: src/amuleDlg.cpp:1728 src/muuli_wdr.cpp:3412
-msgid "Searches"
-msgstr "Sökningar"
-
-#: src/amuleDlg.cpp:1732 src/muuli_wdr.cpp:3412
+#: src/amuleDlg.cpp:1797 src/muuli_wdr.cpp:3419
 msgid "Searches Window"
 msgstr "Sökfönster"
 
-#: src/amuleDlg.cpp:1734 src/DownloadListCtrl.cpp:740 src/muuli_wdr.cpp:392
-#: src/muuli_wdr.cpp:1578 src/muuli_wdr.cpp:3413 src/Statistics.cpp:829
-msgid "Downloads"
-msgstr "Hämtningar"
-
-#: src/amuleDlg.cpp:1738 src/muuli_wdr.cpp:3413
+#: src/amuleDlg.cpp:1803 src/muuli_wdr.cpp:3420
 msgid "Downloads Window"
 msgstr "Hämtningsfönster"
 
-#: src/amuleDlg.cpp:1740 src/muuli_wdr.cpp:3287
-msgid "Shared files"
-msgstr "Delade filer"
-
-#: src/amuleDlg.cpp:1744 src/muuli_wdr.cpp:3415
+#: src/amuleDlg.cpp:1809 src/muuli_wdr.cpp:3422
 msgid "Shared Files Window"
 msgstr "Delade filer-fönster"
 
-#: src/amuleDlg.cpp:1746 src/muuli_wdr.cpp:2919 src/muuli_wdr.cpp:3369
-#: src/muuli_wdr.cpp:3416
-msgid "Messages"
-msgstr "Meddelanden"
-
-#: src/amuleDlg.cpp:1750 src/muuli_wdr.cpp:3416
+#: src/amuleDlg.cpp:1815 src/muuli_wdr.cpp:3423
 msgid "Messages Window"
 msgstr "Meddelandefönster"
 
-#: src/amuleDlg.cpp:1752 src/muuli_wdr.cpp:3417 src/PrefsUnifiedDlg.cpp:312
-#: src/Statistics.cpp:779 src/Statistics.cpp:1235
-msgid "Statistics"
-msgstr "Statistik"
-
-#: src/amuleDlg.cpp:1756 src/muuli_wdr.cpp:3417
+#: src/amuleDlg.cpp:1821 src/muuli_wdr.cpp:3424
 msgid "Statistics Graph Window"
 msgstr "Statistiksgrafsfönster"
 
-#: src/amuleDlg.cpp:1759 src/muuli_wdr.cpp:3419 src/PrefsUnifiedDlg.cpp:328
-#: src/utils/wxCas/src/wxcasprefs.cpp:39
-msgid "Preferences"
-msgstr "Inställningar"
-
-#: src/amuleDlg.cpp:1763 src/muuli_wdr.cpp:3419
+#: src/amuleDlg.cpp:1828 src/muuli_wdr.cpp:3426
 msgid "Preferences Settings Window"
 msgstr "Inställningsfönster"
 
-#: src/amuleDlg.cpp:1766 src/muuli_wdr.cpp:3420
+#: src/amuleDlg.cpp:1831 src/muuli_wdr.cpp:3427
 msgid "Import"
 msgstr "Importera"
 
-#: src/amuleDlg.cpp:1770 src/muuli_wdr.cpp:3420
+#: src/amuleDlg.cpp:1835 src/muuli_wdr.cpp:3427
 msgid "The partfile importer tool"
 msgstr "Partfile-importerings-verktyget"
 
-#: src/amuleDlg.cpp:1773 src/muuli_wdr.cpp:3421
+#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3428
 #: src/utils/aLinkCreator/src/alcframe.cpp:262
 msgid "About"
 msgstr "Om"
 
-#: src/amuleDlg.cpp:1773 src/muuli_wdr.cpp:3421
+#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3428
 msgid "About/Help"
 msgstr "Om/Hjälp"
 
-#: src/amuleDlg.cpp:1971
+#: src/amuleDlg.cpp:2036
 msgid "eD2k network"
 msgstr "eD2k-nätverk"
 
-#: src/amuleDlg.cpp:1974
+#: src/amuleDlg.cpp:2039
 msgid "Kad network"
 msgstr "Kad-nätverk"
 
-#: src/amuleDlg.cpp:1974
+#: src/amuleDlg.cpp:2039
 msgid "No network"
 msgstr "Inget nätverk"
 
@@ -1350,19 +1355,19 @@ msgstr "Auto [Hö]"
 msgid "Very low"
 msgstr "Mycket låg"
 
-#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:743 src/muuli_wdr.cpp:2275
+#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:743 src/muuli_wdr.cpp:2282
 #: src/ServerListCtrl.cpp:263 src/ServerListCtrl.cpp:456
 #: src/SharedFilesCtrl.cpp:145
 msgid "Low"
 msgstr "Låg"
 
-#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:744 src/muuli_wdr.cpp:2276
+#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:744 src/muuli_wdr.cpp:2283
 #: src/ServerListCtrl.cpp:266 src/ServerListCtrl.cpp:457
 #: src/SharedFilesCtrl.cpp:146
 msgid "Normal"
 msgstr "Normal"
 
-#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:745 src/muuli_wdr.cpp:2277
+#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:745 src/muuli_wdr.cpp:2284
 #: src/ServerListCtrl.cpp:269 src/ServerListCtrl.cpp:458
 #: src/SharedFilesCtrl.cpp:147
 msgid "High"
@@ -1454,8 +1459,8 @@ msgstr "Lokal server"
 msgid "Remote Server"
 msgstr "Fjärrserver"
 
-#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3174
-#: src/SearchDlg.cpp:111 src/TextClient.cpp:911
+#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3181
+#: src/SearchDlg.cpp:119 src/TextClient.cpp:911
 msgid "Kad"
 msgstr "Kad"
 
@@ -1526,7 +1531,7 @@ msgstr "Del"
 msgid "Size"
 msgstr "Storlek"
 
-#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3241
+#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3248
 msgid "Transferred"
 msgstr "Överfört"
 
@@ -1584,7 +1589,7 @@ msgstr ""
 "Återkoppling från: %s (%s)\n"
 "\n"
 
-#: src/DownloadListCtrl.cpp:746 src/muuli_wdr.cpp:2278
+#: src/DownloadListCtrl.cpp:746 src/muuli_wdr.cpp:2285
 #: src/SharedFilesCtrl.cpp:150
 msgid "Auto"
 msgstr "Auto"
@@ -1622,7 +1627,7 @@ msgid "Extended Options"
 msgstr "Utökade inställningar"
 
 #: src/DownloadListCtrl.cpp:770 src/DownloadListCtrl.cpp:822
-#: src/muuli_wdr.cpp:1789
+#: src/muuli_wdr.cpp:1796
 msgid "Preview"
 msgstr "Förhandsgranska"
 
@@ -2333,19 +2338,19 @@ msgstr ""
 msgid "eD2k"
 msgstr "eD2k"
 
-#: src/FirstRunWizard.cpp:349 src/muuli_wdr.cpp:1488
+#: src/FirstRunWizard.cpp:349 src/muuli_wdr.cpp:1495
 msgid "Kademlia"
 msgstr "Kademlia"
 
-#: src/FirstRunWizard.cpp:359 src/muuli_wdr.cpp:1416
+#: src/FirstRunWizard.cpp:359 src/muuli_wdr.cpp:1423
 msgid "Standard TCP Port "
 msgstr "Standard TCP-port "
 
-#: src/FirstRunWizard.cpp:365 src/muuli_wdr.cpp:1428
+#: src/FirstRunWizard.cpp:365 src/muuli_wdr.cpp:1435
 msgid "Extended UDP port (Kad / global search) "
 msgstr "Utökad UDP-port (Kad / global sökning) "
 
-#: src/FirstRunWizard.cpp:377 src/muuli_wdr.cpp:1435
+#: src/FirstRunWizard.cpp:377 src/muuli_wdr.cpp:1442
 msgid "Enable UPnP for router port forwarding"
 msgstr "Aktivera UPnP för vidarebefordring av routerport"
 
@@ -2372,7 +2377,7 @@ msgstr ""
 msgid "Your peer lists are already in place - nothing to download."
 msgstr "Du försöker redan hämta filen %s"
 
-#: src/FirstRunWizard.cpp:434 src/muuli_wdr.cpp:1533
+#: src/FirstRunWizard.cpp:434 src/muuli_wdr.cpp:1540
 msgid "Auto-update server list at startup"
 msgstr "Auto-uppdatera serverlistan vid start"
 
@@ -2418,23 +2423,23 @@ msgid ""
 "want downloads on a different (e.g. larger) disk."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:549 src/FirstRunWizard.cpp:611 src/muuli_wdr.cpp:1701
+#: src/FirstRunWizard.cpp:549 src/FirstRunWizard.cpp:611 src/muuli_wdr.cpp:1708
 msgid "Destination folder for downloads"
 msgstr "Målmapp för hämtningar"
 
-#: src/FirstRunWizard.cpp:553 src/FirstRunWizard.cpp:569 src/muuli_wdr.cpp:1342
-#: src/muuli_wdr.cpp:1359 src/muuli_wdr.cpp:1676 src/muuli_wdr.cpp:1707
-#: src/muuli_wdr.cpp:1719 src/muuli_wdr.cpp:2762
+#: src/FirstRunWizard.cpp:553 src/FirstRunWizard.cpp:569 src/muuli_wdr.cpp:1349
+#: src/muuli_wdr.cpp:1366 src/muuli_wdr.cpp:1683 src/muuli_wdr.cpp:1714
+#: src/muuli_wdr.cpp:1726 src/muuli_wdr.cpp:2769
 #: src/utils/aLinkCreator/src/alcframe.cpp:135
 #: src/utils/wxCas/src/wxcasprefs.cpp:52 src/utils/wxCas/src/wxcasprefs.cpp:118
 msgid "Browse"
 msgstr "Bläddra"
 
-#: src/FirstRunWizard.cpp:559 src/muuli_wdr.cpp:1712
+#: src/FirstRunWizard.cpp:559 src/muuli_wdr.cpp:1719
 msgid "(All files in this folder are shared with other peers)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:565 src/FirstRunWizard.cpp:624 src/muuli_wdr.cpp:1714
+#: src/FirstRunWizard.cpp:565 src/FirstRunWizard.cpp:624 src/muuli_wdr.cpp:1721
 msgid "Folder for temporary download files"
 msgstr "Mapp för temporära nerladdningsfiler"
 
@@ -2465,7 +2470,7 @@ msgstr "Kunde inte öppna vän-list-filen 'emfriends.met' för skrivning!"
 msgid "CRITICAL - no client on StartChatSession"
 msgstr "KRITISKT - ingen klient för StartChatSession"
 
-#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2668 src/muuli_wdr.cpp:3345
+#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2675 src/muuli_wdr.cpp:3352
 msgid "Friends"
 msgstr "Vänner"
 
@@ -2851,7 +2856,7 @@ msgstr "Dela-förhållande"
 msgid "Uploaded"
 msgstr "Uppladdad"
 
-#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3225
+#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3232
 msgid "Requested"
 msgstr "Begärda"
 
@@ -2975,7 +2980,7 @@ msgid "WARNING: "
 msgstr "VARNING: "
 
 #: src/MuleNotebook.cpp:179 src/muuli_wdr.cpp:817 src/muuli_wdr.cpp:1229
-#: src/muuli_wdr.cpp:3129 src/muuli_wdr.cpp:3385
+#: src/muuli_wdr.cpp:3136 src/muuli_wdr.cpp:3392
 msgid "Close"
 msgstr "Stäng"
 
@@ -2988,12 +2993,12 @@ msgstr "Klipp ut"
 msgid "Copy"
 msgstr "Kopiera"
 
-#: src/MuleTextCtrl.cpp:88
+#: src/MuleTextCtrl.cpp:88 src/SearchDlg.cpp:261
 msgid "Paste"
 msgstr "Klistra in"
 
 #: src/MuleTextCtrl.cpp:89 src/muuli_wdr.cpp:358 src/muuli_wdr.cpp:757
-#: src/muuli_wdr.cpp:2352 src/muuli_wdr.cpp:2371 src/muuli_wdr.cpp:2393
+#: src/muuli_wdr.cpp:2359 src/muuli_wdr.cpp:2378 src/muuli_wdr.cpp:2400
 #: src/utils/aLinkCreator/src/alcframe.cpp:142
 msgid "Clear"
 msgstr "Töm"
@@ -3091,8 +3096,8 @@ msgid "Exit"
 msgstr "Avsluta"
 
 #: src/MuleTrayIcon.cpp:579 src/MuleTrayIcon.cpp:945 src/MuleTrayIcon.cpp:965
-#: src/muuli_wdr.cpp:1391 src/muuli_wdr.cpp:1399 src/muuli_wdr.cpp:1406
-#: src/muuli_wdr.cpp:1835 src/muuli_wdr.cpp:1841 src/OtherFunctions.cpp:91
+#: src/muuli_wdr.cpp:1398 src/muuli_wdr.cpp:1406 src/muuli_wdr.cpp:1413
+#: src/muuli_wdr.cpp:1842 src/muuli_wdr.cpp:1848 src/OtherFunctions.cpp:91
 #: src/StatisticsDlg.cpp:93 src/StatisticsDlg.cpp:95
 msgid "kB/s"
 msgstr "kB/s"
@@ -3263,7 +3268,7 @@ msgstr "Namn:"
 msgid "Type"
 msgstr "Typ"
 
-#: src/muuli_wdr.cpp:215 src/SearchDlg.cpp:110 src/SearchListCtrl.cpp:853
+#: src/muuli_wdr.cpp:215 src/SearchDlg.cpp:118 src/SearchListCtrl.cpp:853
 msgid "Local"
 msgstr "Lokal"
 
@@ -3334,7 +3339,7 @@ msgstr "Bytes"
 msgid "KB"
 msgstr "KB"
 
-#: src/muuli_wdr.cpp:274 src/muuli_wdr.cpp:293 src/muuli_wdr.cpp:1620
+#: src/muuli_wdr.cpp:274 src/muuli_wdr.cpp:293 src/muuli_wdr.cpp:1627
 #: src/OtherFunctions.cpp:64
 msgid "MB"
 msgstr "MB"
@@ -3351,7 +3356,7 @@ msgstr "Max storlek"
 msgid "Availability"
 msgstr "Tillgänglighet"
 
-#: src/muuli_wdr.cpp:312 src/muuli_wdr.cpp:398 src/muuli_wdr.cpp:3290
+#: src/muuli_wdr.cpp:312 src/muuli_wdr.cpp:398 src/muuli_wdr.cpp:3297
 msgid "Filter:"
 msgstr "Filter:"
 
@@ -3383,7 +3388,7 @@ msgstr ""
 msgid "Stop"
 msgstr "Stoppa"
 
-#: src/muuli_wdr.cpp:348 src/muuli_wdr.cpp:1385 src/SearchListCtrl.cpp:732
+#: src/muuli_wdr.cpp:348 src/muuli_wdr.cpp:1392 src/SearchListCtrl.cpp:732
 msgid "Download"
 msgstr "Hämta"
 
@@ -3414,8 +3419,8 @@ msgstr "Filkällor:"
 #: src/muuli_wdr.cpp:1160 src/muuli_wdr.cpp:1167 src/muuli_wdr.cpp:1172
 #: src/muuli_wdr.cpp:1179 src/muuli_wdr.cpp:1184 src/muuli_wdr.cpp:1191
 #: src/muuli_wdr.cpp:1205 src/muuli_wdr.cpp:1212 src/muuli_wdr.cpp:1217
-#: src/muuli_wdr.cpp:1224 src/muuli_wdr.cpp:3227 src/muuli_wdr.cpp:3235
-#: src/muuli_wdr.cpp:3243
+#: src/muuli_wdr.cpp:1224 src/muuli_wdr.cpp:3234 src/muuli_wdr.cpp:3242
+#: src/muuli_wdr.cpp:3250
 msgid "N/A"
 msgstr "N/A"
 
@@ -3560,7 +3565,7 @@ msgstr ""
 msgid "Album :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:685 src/muuli_wdr.cpp:2247
+#: src/muuli_wdr.cpp:685 src/muuli_wdr.cpp:2254
 msgid "Title :"
 msgstr "Titel :"
 
@@ -3669,7 +3674,7 @@ msgstr "Användarnamn :"
 msgid "Userhash :"
 msgstr "Userhash:"
 
-#: src/muuli_wdr.cpp:895 src/muuli_wdr.cpp:1741 src/muuli_wdr.cpp:2442
+#: src/muuli_wdr.cpp:895 src/muuli_wdr.cpp:1748 src/muuli_wdr.cpp:2449
 #: src/utils/aLinkCreator/src/alcframe.cpp:137
 msgid "Add"
 msgstr "Lägg till"
@@ -3678,15 +3683,15 @@ msgstr "Lägg till"
 msgid "Download-Speed"
 msgstr "Nedladdningshastighet"
 
-#: src/muuli_wdr.cpp:954 src/muuli_wdr.cpp:989 src/muuli_wdr.cpp:2546
+#: src/muuli_wdr.cpp:954 src/muuli_wdr.cpp:989 src/muuli_wdr.cpp:2553
 msgid "Current"
 msgstr "Aktuell"
 
-#: src/muuli_wdr.cpp:962 src/muuli_wdr.cpp:997 src/muuli_wdr.cpp:2554
+#: src/muuli_wdr.cpp:962 src/muuli_wdr.cpp:997 src/muuli_wdr.cpp:2561
 msgid "Running average"
 msgstr "Löpande medelvärde"
 
-#: src/muuli_wdr.cpp:970 src/muuli_wdr.cpp:1005 src/muuli_wdr.cpp:2562
+#: src/muuli_wdr.cpp:970 src/muuli_wdr.cpp:1005 src/muuli_wdr.cpp:2569
 msgid "Session average"
 msgstr "Sessionens genomsnittliga"
 
@@ -3698,7 +3703,7 @@ msgstr "Uppladdningshastighet"
 msgid "Connections"
 msgstr "Anslutningar"
 
-#: src/muuli_wdr.cpp:1024 src/muuli_wdr.cpp:1860
+#: src/muuli_wdr.cpp:1024 src/muuli_wdr.cpp:1867
 msgid "Active downloads"
 msgstr "Aktiva hämtningar"
 
@@ -3706,7 +3711,7 @@ msgstr "Aktiva hämtningar"
 msgid "Active connections (1:1)"
 msgstr "Aktiva anslutningar (1:1)"
 
-#: src/muuli_wdr.cpp:1040 src/muuli_wdr.cpp:1861
+#: src/muuli_wdr.cpp:1040 src/muuli_wdr.cpp:1868
 msgid "Active uploads"
 msgstr "Aktiva uppladdningar"
 
@@ -3822,8 +3827,8 @@ msgstr "Detta är det namn som andra användare ser när du ansluter till dig."
 msgid "Language: "
 msgstr "Språk: "
 
-#: src/muuli_wdr.cpp:1257 src/muuli_wdr.cpp:1323 src/muuli_wdr.cpp:1327
-#: src/muuli_wdr.cpp:1330
+#: src/muuli_wdr.cpp:1257 src/muuli_wdr.cpp:1330 src/muuli_wdr.cpp:1334
+#: src/muuli_wdr.cpp:1337
 msgid "The delay before showing tool-tips."
 msgstr "Fördröjningen innan visning av verktygstips."
 
@@ -3901,936 +3906,945 @@ msgstr ""
 msgid "Enabling this will make aMule to show notifications when finished downloading."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1322
+#: src/muuli_wdr.cpp:1323
+#, fuzzy
+msgid "Remember search history"
+msgstr "Kom ihåg dessa inställningar"
+
+#: src/muuli_wdr.cpp:1324
+msgid "Keeps a dropdown list of your past search terms in the Search tab's Name field. This remembers the queries you typed, not the results they returned."
+msgstr ""
+
+#: src/muuli_wdr.cpp:1329
 msgid "Tooltip delay time: "
 msgstr "Tooltip fördröjningstid: "
 
-#: src/muuli_wdr.cpp:1329
+#: src/muuli_wdr.cpp:1336
 msgid "seconds"
 msgstr "sekunder"
 
-#: src/muuli_wdr.cpp:1333
+#: src/muuli_wdr.cpp:1340
 msgid "Browser Selection"
 msgstr "Webbläsarval"
 
-#: src/muuli_wdr.cpp:1339
+#: src/muuli_wdr.cpp:1346
 msgid "Enter your browser name here. Leave this field empty to use the system default browser."
 msgstr "Ange din webbläsares namn här. Lämna detta fält tomt för att använda systemets standardwebbläsare."
 
-#: src/muuli_wdr.cpp:1346
+#: src/muuli_wdr.cpp:1353
 msgid "Open in new tab if possible"
 msgstr "Öppna i ny flik om möjligt"
 
-#: src/muuli_wdr.cpp:1348
+#: src/muuli_wdr.cpp:1355
 msgid "Open the web page in a new tab instead of in a new window when possible"
 msgstr "Öppna webbsidan i en ny flik istället för ett nytt fönster när det är möjligt"
 
-#: src/muuli_wdr.cpp:1352
+#: src/muuli_wdr.cpp:1359
 msgid "Video Player"
 msgstr "Videouppspelare"
 
-#: src/muuli_wdr.cpp:1379
+#: src/muuli_wdr.cpp:1386
 msgid "Bandwidth limits"
 msgstr "Bandbreddsbegränsningar"
 
-#: src/muuli_wdr.cpp:1393
+#: src/muuli_wdr.cpp:1400
 msgid "Upload"
 msgstr "Ladda upp"
 
-#: src/muuli_wdr.cpp:1401
+#: src/muuli_wdr.cpp:1408
 msgid "Slot Allocation"
 msgstr "Spårallokering"
 
-#: src/muuli_wdr.cpp:1410
+#: src/muuli_wdr.cpp:1417
 msgid "Ports"
 msgstr "Portar"
 
-#: src/muuli_wdr.cpp:1420
+#: src/muuli_wdr.cpp:1427
 msgid "This is the standard eD2k port and cannot be disabled."
 msgstr "Detta är standard ed2k-port och kan inte avaktiveras."
 
-#: src/muuli_wdr.cpp:1423
+#: src/muuli_wdr.cpp:1430
 msgid "UDP port for server requests (TCP+3):"
 msgstr "UDP-port för serverförfrågningar (TCP+3):"
 
-#: src/muuli_wdr.cpp:1425
+#: src/muuli_wdr.cpp:1432
 msgid "4665"
 msgstr "4665"
 
-#: src/muuli_wdr.cpp:1432
+#: src/muuli_wdr.cpp:1439
 msgid "This UDP port is used for extended eD2k requests and Kad network"
 msgstr "Denna UDP-port används under utökade ed2k-förfrågningar och Kadnätverk"
 
-#: src/muuli_wdr.cpp:1439
+#: src/muuli_wdr.cpp:1446
 msgid "UPnP TCP Port (Optional):"
 msgstr "UPnP TCP-port (tillval):"
 
-#: src/muuli_wdr.cpp:1449
+#: src/muuli_wdr.cpp:1456
 msgid "Bind local address to IP (empty for any):"
 msgstr "Bind lokal adress till IP (tom för alla):"
 
-#: src/muuli_wdr.cpp:1452
+#: src/muuli_wdr.cpp:1459
 msgid "Advanced users only: If you have multiple network interfaces, enter the address of the interface to which aMule should be bound."
 msgstr "Endast avancerade användare: Om du har flera nätverksgränssnitt, ange adressen för gränssnittet till vilket aMule ska bindas."
 
-#: src/muuli_wdr.cpp:1455 src/muuli_wdr.cpp:2054
+#: src/muuli_wdr.cpp:1462 src/muuli_wdr.cpp:2061
 #, fuzzy
 msgid "Bind to network interface (empty for any):"
 msgstr "Bind lokal adress till IP (tom för alla):"
 
-#: src/muuli_wdr.cpp:1468
+#: src/muuli_wdr.cpp:1475
 msgid "Advanced users only: pin all of aMule's traffic to one network interface, chosen from the list or typed in by name (e.g. tun0, eth0, en0) or index. Unlike binding to an IP, this stops traffic leaking out via the default route - useful with a VPN. Requires no elevated privileges."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1474
+#: src/muuli_wdr.cpp:1481
 msgid "Max sources per downloading file:"
 msgstr "Max källor per hämtad fil:"
 
-#: src/muuli_wdr.cpp:1478
+#: src/muuli_wdr.cpp:1485
 msgid "Max simultaneous connections:"
 msgstr "Max samtidiga anslutningar:"
 
-#: src/muuli_wdr.cpp:1491 src/muuli_wdr.cpp:3169
+#: src/muuli_wdr.cpp:1498 src/muuli_wdr.cpp:3176
 msgid "ED2K"
 msgstr "ED2K"
 
-#: src/muuli_wdr.cpp:1498
+#: src/muuli_wdr.cpp:1505
 msgid "Autoconnect on startup"
 msgstr "Autoanslut vid start"
 
-#: src/muuli_wdr.cpp:1501
+#: src/muuli_wdr.cpp:1508
 msgid "Reconnect on loss"
 msgstr "Återanslut vid nedkoppling"
 
-#: src/muuli_wdr.cpp:1523
+#: src/muuli_wdr.cpp:1530
 msgid "Remove dead server after"
 msgstr "Ta bort död server efter"
 
-#: src/muuli_wdr.cpp:1524
+#: src/muuli_wdr.cpp:1531
 msgid "Static servers are never removed, even when unreachable."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1528
+#: src/muuli_wdr.cpp:1535
 msgid "retries"
 msgstr "försök"
 
-#: src/muuli_wdr.cpp:1536
+#: src/muuli_wdr.cpp:1543
 msgid "List"
 msgstr "Lista"
 
-#: src/muuli_wdr.cpp:1539
+#: src/muuli_wdr.cpp:1546
 msgid "Update server list when connecting to a server"
 msgstr "Uppdatera serverlistan vid anslutning till en server"
 
-#: src/muuli_wdr.cpp:1542
+#: src/muuli_wdr.cpp:1549
 msgid "Update server list when a client connects"
 msgstr "Uppdatera serverlistan när en klient ansluter"
 
-#: src/muuli_wdr.cpp:1545
+#: src/muuli_wdr.cpp:1552
 msgid "Use priority system"
 msgstr "Använd prioriteringssystem"
 
-#: src/muuli_wdr.cpp:1549
+#: src/muuli_wdr.cpp:1556
 msgid "Use smart LowID check on connect"
 msgstr "Använda smart LowID kontroll vid anslutning"
 
-#: src/muuli_wdr.cpp:1553
+#: src/muuli_wdr.cpp:1560
 msgid "Safe connect"
 msgstr "Säker anslutning"
 
-#: src/muuli_wdr.cpp:1557
+#: src/muuli_wdr.cpp:1564
 msgid "Autoconnect to servers in static list only"
 msgstr "Autoanslut endast till servrar i statisk-listan"
 
-#: src/muuli_wdr.cpp:1560
+#: src/muuli_wdr.cpp:1567
 msgid "Set manually added servers to High Priority"
 msgstr "Ställ in hög prioritet på manuellt tillagda servrar"
 
-#: src/muuli_wdr.cpp:1581
+#: src/muuli_wdr.cpp:1588
 msgid "Add files to download in pause mode"
 msgstr "Lägg till filer för nerladdning i pausläge"
 
-#: src/muuli_wdr.cpp:1583
+#: src/muuli_wdr.cpp:1590
 msgid "Add files to download with auto priority"
 msgstr "Lägg till filer för nerladdning med automatisk prioritet"
 
-#: src/muuli_wdr.cpp:1586
+#: src/muuli_wdr.cpp:1593
 msgid "Try to download first and last chunks first"
 msgstr "Försök att hämta första och sista bitarna först"
 
-#: src/muuli_wdr.cpp:1590
+#: src/muuli_wdr.cpp:1597
 msgid "Endgame mode: rotate to faster sources for the final blocks"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1593
+#: src/muuli_wdr.cpp:1600
 msgid "Start next paused file when a file completes"
 msgstr "Börja nästa pausade fil när en fil är klar"
 
-#: src/muuli_wdr.cpp:1596
+#: src/muuli_wdr.cpp:1603
 msgid "From the same category"
 msgstr "Från samma kategori"
 
-#: src/muuli_wdr.cpp:1598
+#: src/muuli_wdr.cpp:1605
 msgid "In alphabetic order"
 msgstr "I alfabetisk ordning"
 
-#: src/muuli_wdr.cpp:1600
+#: src/muuli_wdr.cpp:1607
 msgid "Preallocate disk space for new files"
 msgstr "Förallokera diskutrymme för nya filer"
 
-#: src/muuli_wdr.cpp:1601
+#: src/muuli_wdr.cpp:1608
 msgid "For new files preallocates disk space for the whole file, thus reduces fragmentation"
 msgstr "För nya filer förallokeras diskutrymme för hela filen, detta minskar fragmentering"
 
-#: src/muuli_wdr.cpp:1606
+#: src/muuli_wdr.cpp:1613
 msgid "Create new files as sparse files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1607
+#: src/muuli_wdr.cpp:1614
 msgid "A sparse file reserves its full size on disk immediately without writing real data to it -- fast, but unsupported or slow on some filesystems, and free-space accounting stays optimistic while the download is in progress. Turn this off to grow the file only as data arrives."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1612
+#: src/muuli_wdr.cpp:1619
 msgid "Stop downloads when free disk space reaches "
 msgstr "Stoppa nedladdningar när ledigt diskutrymme når "
 
-#: src/muuli_wdr.cpp:1613
+#: src/muuli_wdr.cpp:1620
 msgid "Select this if you want aMule to check your disk space"
 msgstr "Välj detta om du vill aMule att kontrollera diskutrymmet"
 
-#: src/muuli_wdr.cpp:1617
+#: src/muuli_wdr.cpp:1624
 msgid "Enter here the min disk space desired."
 msgstr "Ange här min diskutrymme."
 
-#: src/muuli_wdr.cpp:1623
+#: src/muuli_wdr.cpp:1630
 msgid "Save 10 sources on rare files (< 20 sources)"
 msgstr "Spara 10 källor för sällsynta filer (<20 källor)"
 
-#: src/muuli_wdr.cpp:1627 src/Statistics.cpp:790
+#: src/muuli_wdr.cpp:1634 src/Statistics.cpp:790
 msgid "Uploads"
 msgstr "Uppladdningar"
 
-#: src/muuli_wdr.cpp:1630
+#: src/muuli_wdr.cpp:1637
 msgid "Add new shared files with auto priority"
 msgstr "Lägg till nya delade filer med automatisk prioritet"
 
-#: src/muuli_wdr.cpp:1636
+#: src/muuli_wdr.cpp:1643
 msgid "Intelligent Corruption Handling (I.C.H.)"
 msgstr "Intelligent Corruption Handling (I.C.H.)"
 
-#: src/muuli_wdr.cpp:1639
+#: src/muuli_wdr.cpp:1646
 msgid "Enable"
 msgstr "Aktivera"
 
-#: src/muuli_wdr.cpp:1642
+#: src/muuli_wdr.cpp:1649
 msgid "Advanced I.C.H. trusts every hash (not recommended)"
 msgstr "Avancerad I.C.H. litar på varje hash (rekommenderas inte)"
 
-#: src/muuli_wdr.cpp:1654 src/PrefsUnifiedDlg.cpp:1910
+#: src/muuli_wdr.cpp:1661 src/PrefsUnifiedDlg.cpp:1910
 msgid "Media metadata extraction"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1658
+#: src/muuli_wdr.cpp:1665
 msgid "Extract length / bitrate / codec from shared audio and video files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1660
+#: src/muuli_wdr.cpp:1667
 msgid "When enabled, aMule runs ffprobe on each shared media file to fill in the Length / Bitrate / Codec columns other clients see when they find the file in a search. Requires ffmpeg (the ffprobe binary) to be installed."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1667
+#: src/muuli_wdr.cpp:1674
 msgid "Path to ffprobe:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1672
+#: src/muuli_wdr.cpp:1679
 msgid "Full path to the ffprobe binary. Leave empty to have aMule auto-detect it on startup."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1680
+#: src/muuli_wdr.cpp:1687
 msgid "Detect"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1681
+#: src/muuli_wdr.cpp:1688
 msgid "Search the standard install locations for an ffprobe binary and fill the path field."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1705
+#: src/muuli_wdr.cpp:1712
 msgid ""
 "Completed downloads are stored here. All files in this folder are automatically shared with other peers.\n"
 "If this folder also holds files you don't want to share, point it at an aMule-only sub-folder."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1708
+#: src/muuli_wdr.cpp:1715
 msgid "Pick the folder where completed downloads will be stored. All files in that folder will be shared with other peers."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1722
+#: src/muuli_wdr.cpp:1729
 msgid "Shared folders"
 msgstr "Delade mappar"
 
-#: src/muuli_wdr.cpp:1728
+#: src/muuli_wdr.cpp:1735
 msgid "(Folders shared by the core. Enter a path to add one.)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1736
+#: src/muuli_wdr.cpp:1743
 msgid "Absolute path of a folder on the core's machine, e.g. /home/user/shared"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1738 src/PrefsUnifiedDlg.cpp:2794
+#: src/muuli_wdr.cpp:1745 src/PrefsUnifiedDlg.cpp:2794
 msgid "Recursive"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1739
+#: src/muuli_wdr.cpp:1746
 msgid "Share every sub-folder underneath this one, including ones created later."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1743 src/utils/aLinkCreator/src/alcframe.cpp:141
+#: src/muuli_wdr.cpp:1750 src/utils/aLinkCreator/src/alcframe.cpp:141
 msgid "Remove"
 msgstr "Ta bort"
 
-#: src/muuli_wdr.cpp:1747
+#: src/muuli_wdr.cpp:1754
 msgid "(Right click on folder icon for recursive share)"
 msgstr "(Högerklicka på mappikonen för rekursiv delning)"
 
-#: src/muuli_wdr.cpp:1754
+#: src/muuli_wdr.cpp:1761
 msgid "Share hidden files"
 msgstr "Dela ut dolda filer"
 
-#: src/muuli_wdr.cpp:1760
+#: src/muuli_wdr.cpp:1767
 msgid "Automatically rescan shared folders for changes"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1766
+#: src/muuli_wdr.cpp:1773
 msgid "Follow symbolic links in shared folders"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1772
+#: src/muuli_wdr.cpp:1779
 msgid "Exclude files matching:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1775
+#: src/muuli_wdr.cpp:1782
 msgid "Wildcard patterns separated by '|', e.g. .DS_Store|Thumbs.db|*.tmp. Files whose name matches are not shared. Matching is case-insensitive."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1779
+#: src/muuli_wdr.cpp:1786
 msgid "Patterns are regular expressions"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1780
+#: src/muuli_wdr.cpp:1787
 msgid "When set, the whole field is one regular expression ('|' is alternation). When unset, it is a list of '|'-separated wildcards."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1790
+#: src/muuli_wdr.cpp:1797
 msgid "Show how many shared files the current pattern would exclude."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1811
+#: src/muuli_wdr.cpp:1818
 msgid "Graphs"
 msgstr "Diagram"
 
-#: src/muuli_wdr.cpp:1814 src/muuli_wdr.cpp:1876
+#: src/muuli_wdr.cpp:1821 src/muuli_wdr.cpp:1883
 msgid "Update delay : 5 secs"
 msgstr "Uppdateringsfördröjning: 5 sekunder"
 
-#: src/muuli_wdr.cpp:1818
+#: src/muuli_wdr.cpp:1825
 msgid "Time for average graph: 100 mins"
 msgstr "Tid för genomsnittlig graf: 100 minuter"
 
-#: src/muuli_wdr.cpp:1822
+#: src/muuli_wdr.cpp:1829
 msgid "Connections Graph Scale: 100 "
 msgstr "Anslutningar Diagramskala: 100 "
 
-#: src/muuli_wdr.cpp:1829
+#: src/muuli_wdr.cpp:1836
 msgid "Download graph scale:"
 msgstr "Hämtningsgrafskala:"
 
-#: src/muuli_wdr.cpp:1837
+#: src/muuli_wdr.cpp:1844
 msgid "Upload graph scale:"
 msgstr "Uppladdningsgraf-skala:"
 
-#: src/muuli_wdr.cpp:1847
+#: src/muuli_wdr.cpp:1854
 #, fuzzy
 msgid "Colors: "
 msgstr "Färger: "
 
-#: src/muuli_wdr.cpp:1851
+#: src/muuli_wdr.cpp:1858
 msgid "Background"
 msgstr "Bakgrund"
 
-#: src/muuli_wdr.cpp:1852
+#: src/muuli_wdr.cpp:1859
 msgid "Grid"
 msgstr "Rutnät"
 
-#: src/muuli_wdr.cpp:1853
+#: src/muuli_wdr.cpp:1860
 msgid "Download current"
 msgstr "Hämtning nu"
 
-#: src/muuli_wdr.cpp:1854
+#: src/muuli_wdr.cpp:1861
 msgid "Download running average"
 msgstr "Hämtningar nu, medelvärde"
 
-#: src/muuli_wdr.cpp:1855
+#: src/muuli_wdr.cpp:1862
 msgid "Download session average"
 msgstr "Hämtningar session, genomsnittlig"
 
-#: src/muuli_wdr.cpp:1856
+#: src/muuli_wdr.cpp:1863
 msgid "Upload current"
 msgstr "Hämtningar nu"
 
-#: src/muuli_wdr.cpp:1857
+#: src/muuli_wdr.cpp:1864
 msgid "Upload running average"
 msgstr "Hämtningar nu, medelvärde"
 
-#: src/muuli_wdr.cpp:1858
+#: src/muuli_wdr.cpp:1865
 msgid "Upload session average"
 msgstr "Uppladdningsession, genomsnittlig"
 
-#: src/muuli_wdr.cpp:1859
+#: src/muuli_wdr.cpp:1866
 msgid "Active connections"
 msgstr "Aktiva anslutningar"
 
-#: src/muuli_wdr.cpp:1862
+#: src/muuli_wdr.cpp:1869
 #, fuzzy
 msgid "Systray Icon Speed Bar"
 msgstr "Systray Ikon Speedbar"
 
-#: src/muuli_wdr.cpp:1863
+#: src/muuli_wdr.cpp:1870
 msgid "Kad-nodes current"
 msgstr "Kad-noder nuvarande"
 
-#: src/muuli_wdr.cpp:1864
+#: src/muuli_wdr.cpp:1871
 msgid "Kad-nodes running"
 msgstr "Kad-noder körs"
 
-#: src/muuli_wdr.cpp:1865
+#: src/muuli_wdr.cpp:1872
 msgid "Kad-nodes session"
 msgstr "Kad-noder session"
 
-#: src/muuli_wdr.cpp:1869 src/muuli_wdr.cpp:2296
+#: src/muuli_wdr.cpp:1876 src/muuli_wdr.cpp:2303
 msgid "Select"
 msgstr "Välj"
 
-#: src/muuli_wdr.cpp:1873
+#: src/muuli_wdr.cpp:1880
 msgid "Tree"
 msgstr "Träd"
 
-#: src/muuli_wdr.cpp:1883
+#: src/muuli_wdr.cpp:1890
 msgid "Number of Client Versions shown (0=unlimited)"
 msgstr "Antal klientversioner visas (0 = obegränsat)"
 
-#: src/muuli_wdr.cpp:1908
+#: src/muuli_wdr.cpp:1915
 msgid "!!! WARNING !!!"
 msgstr "!!! VARNING !!!"
 
-#: src/muuli_wdr.cpp:1923
+#: src/muuli_wdr.cpp:1930
 msgid "Max new connections / 5 secs"
 msgstr "Max nya anslutningar / 5 sek"
 
-#: src/muuli_wdr.cpp:1925
+#: src/muuli_wdr.cpp:1932
 msgid "Concurrent Kad source lookups"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1927
+#: src/muuli_wdr.cpp:1934
 #, fuzzy
 msgid "Kad source re-search interval (minutes)"
 msgstr "FTP-uppdateringshastighetsintervall i minuter"
 
-#: src/muuli_wdr.cpp:1929
+#: src/muuli_wdr.cpp:1936
 #, fuzzy
 msgid "Source re-ask interval (minutes)"
 msgstr "FTP-uppdateringshastighetsintervall i minuter"
 
-#: src/muuli_wdr.cpp:1933
+#: src/muuli_wdr.cpp:1940
 msgid "File Buffer Size: 240000 bytes"
 msgstr "Filbuffertstorlek: 240000 bytes"
 
-#: src/muuli_wdr.cpp:1937
+#: src/muuli_wdr.cpp:1944
 msgid "Use MMAP: memory-mapped file access (lower memory use)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1938
+#: src/muuli_wdr.cpp:1945
 msgid "Maps part files into memory instead of buffering them on the heap, lowering the process memory footprint. May reduce download speed on some disks; best for memory-constrained or upload-heavy hosts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1940
+#: src/muuli_wdr.cpp:1947
 msgid "Upload Queue Size: 5000 clients"
 msgstr "Uppladdningsköstorlek: 5000 klienter"
 
-#: src/muuli_wdr.cpp:1944
+#: src/muuli_wdr.cpp:1951
 msgid "Server connection refresh interval: Disable"
 msgstr "Serveranslutningsuppdateringsintervall: Inaktivera"
 
-#: src/muuli_wdr.cpp:1948
+#: src/muuli_wdr.cpp:1955
 msgid "Disable computer's timed standby mode"
 msgstr "Inaktivera datorns inställda standby-läge"
 
-#: src/muuli_wdr.cpp:1967
+#: src/muuli_wdr.cpp:1974
 msgid "Skin to use: "
 msgstr "Skin att använda: "
 
-#: src/muuli_wdr.cpp:1976
+#: src/muuli_wdr.cpp:1983
 msgid "Show \"Fast eD2k Links Handler\" in every window."
 msgstr "Visa \"Snabb eD2k-Länkhanterare\" i varje fönster."
 
-#: src/muuli_wdr.cpp:1979
+#: src/muuli_wdr.cpp:1986
 msgid "Show extended info on categories tabs"
 msgstr "Visa utökad information på kategoriflikar"
 
-#: src/muuli_wdr.cpp:1982
+#: src/muuli_wdr.cpp:1989
 msgid "Show application version on title"
 msgstr "Visa programversionen på titel"
 
-#: src/muuli_wdr.cpp:1984
+#: src/muuli_wdr.cpp:1991
 msgid "Show transfer rates on title"
 msgstr "Visa överföringshastigheter på titel"
 
-#: src/muuli_wdr.cpp:1986
+#: src/muuli_wdr.cpp:1993
 msgid "Before application name"
 msgstr "Före programnamn"
 
-#: src/muuli_wdr.cpp:1988
+#: src/muuli_wdr.cpp:1995
 msgid "After application name"
 msgstr "Efter programnamn"
 
-#: src/muuli_wdr.cpp:1991
+#: src/muuli_wdr.cpp:1998
 msgid "Show overhead bandwidth"
 msgstr "Visa overheadsbandbredd"
 
-#: src/muuli_wdr.cpp:1995
+#: src/muuli_wdr.cpp:2002
 msgid "Vertical toolbar orientation"
 msgstr "Vertikal verktygsfältsorientering"
 
-#: src/muuli_wdr.cpp:1997
+#: src/muuli_wdr.cpp:2004
 msgid "Live column sorting (auto-reorder rows as their values change)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2004
+#: src/muuli_wdr.cpp:2011
 msgid "Download Queue Files"
 msgstr "Nedladdningsköfiler"
 
-#: src/muuli_wdr.cpp:2007
+#: src/muuli_wdr.cpp:2014
 msgid "Show progress percentage"
 msgstr "Visa framsteg i procent"
 
-#: src/muuli_wdr.cpp:2013
+#: src/muuli_wdr.cpp:2020
 msgid "Show progress bar"
 msgstr "Visa förloppsindikator"
 
-#: src/muuli_wdr.cpp:2016
+#: src/muuli_wdr.cpp:2023
 msgid "Flat"
 msgstr "Platt"
 
-#: src/muuli_wdr.cpp:2020
+#: src/muuli_wdr.cpp:2027
 msgid "Round"
 msgstr "Rund"
 
-#: src/muuli_wdr.cpp:2038
+#: src/muuli_wdr.cpp:2045
 msgid "External Connection Parameters"
 msgstr "Externa Anslutningsparametrar "
 
-#: src/muuli_wdr.cpp:2041
+#: src/muuli_wdr.cpp:2048
 msgid "Accept external connections"
 msgstr "Acceptera externa anslutningar"
 
-#: src/muuli_wdr.cpp:2048 src/muuli_wdr.cpp:2107
+#: src/muuli_wdr.cpp:2055 src/muuli_wdr.cpp:2114
 msgid "IP of the listening interface:"
 msgstr "IP för lyssningsgränssnitt:"
 
-#: src/muuli_wdr.cpp:2051
+#: src/muuli_wdr.cpp:2058
 msgid "Enter here a valid ip in the a.b.c.d format for the listening EC interface. An empty field or 0.0.0.0 will mean any interface."
 msgstr "Ange här en giltig ip i ABCD format för att lyssna EC-gränssnittet. Ett tomt fält eller 0.0.0.0 kommer att innebära alla gränssnitt."
 
-#: src/muuli_wdr.cpp:2072 src/muuli_wdr.cpp:2156
+#: src/muuli_wdr.cpp:2079 src/muuli_wdr.cpp:2163
 msgid "TCP port:"
 msgstr "TCP-port:"
 
-#: src/muuli_wdr.cpp:2078
+#: src/muuli_wdr.cpp:2085
 msgid "Enable UPnP port forwarding on the EC port"
 msgstr "Aktivera UPnP-portforwarding på EC-port"
 
-#: src/muuli_wdr.cpp:2082 src/muuli_wdr.cpp:3041
+#: src/muuli_wdr.cpp:2089 src/muuli_wdr.cpp:3048
 #: src/utils/wxCas/src/wxcasprefs.cpp:167
 msgid "Password"
 msgstr "Lösenord"
 
-#: src/muuli_wdr.cpp:2088
+#: src/muuli_wdr.cpp:2095
 #, fuzzy
 msgid "aMule API server parameters"
 msgstr "Webbserverparametrar"
 
-#: src/muuli_wdr.cpp:2091
+#: src/muuli_wdr.cpp:2098
 msgid "Run amuleapi (REST API) on startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2096
+#: src/muuli_wdr.cpp:2103
 #, fuzzy
 msgid "HTTP port:"
 msgstr "TCP-port:"
 
-#: src/muuli_wdr.cpp:2110
+#: src/muuli_wdr.cpp:2117
 msgid "The interface amuleapi's HTTP server listens on. 127.0.0.1 (default) accepts only local connections; use 0.0.0.0 or a specific IP to expose it to other hosts (set an admin password below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2113
+#: src/muuli_wdr.cpp:2120
 #, fuzzy
 msgid "Admin password"
 msgstr "Kontrollerar lösenord\n"
 
-#: src/muuli_wdr.cpp:2118 src/muuli_wdr.cpp:2149
+#: src/muuli_wdr.cpp:2125 src/muuli_wdr.cpp:2156
 msgid "Low rights password"
 msgstr "Låga rättigheterslösenord"
 
-#: src/muuli_wdr.cpp:2126
+#: src/muuli_wdr.cpp:2133
 msgid "Web server parameters"
 msgstr "Webbserverparametrar"
 
-#: src/muuli_wdr.cpp:2129
+#: src/muuli_wdr.cpp:2136
 #, fuzzy
 msgid "Run webserver on startup (deprecated)"
 msgstr "Kör webbserver vid start"
 
-#: src/muuli_wdr.cpp:2135
+#: src/muuli_wdr.cpp:2142
 msgid "Web template"
 msgstr "Web mall"
 
-#: src/muuli_wdr.cpp:2140
+#: src/muuli_wdr.cpp:2147
 msgid "Full rights password"
 msgstr "Fullständiga rättigheterslösenord"
 
-#: src/muuli_wdr.cpp:2144
+#: src/muuli_wdr.cpp:2151
 msgid "Enable Low rights User"
 msgstr "Aktivera låga användarrättigheter"
 
-#: src/muuli_wdr.cpp:2163
+#: src/muuli_wdr.cpp:2170
 msgid "Enable UPnP port forwarding of the web server port"
 msgstr "Aktivera UPnP-port-forwarding för webbserverport"
 
-#: src/muuli_wdr.cpp:2168
+#: src/muuli_wdr.cpp:2175
 msgid "Web server UPnP TCP port (Optional)"
 msgstr "Webbserverns UPnP TCP-port (tillval)"
 
-#: src/muuli_wdr.cpp:2176
+#: src/muuli_wdr.cpp:2183
 msgid "Page Refresh Time (in secs)"
 msgstr "Siduppdateringstid (i sek)"
 
-#: src/muuli_wdr.cpp:2183
+#: src/muuli_wdr.cpp:2190
 msgid "Enable Gzip compression"
 msgstr "Aktivera Gzip-komprimering"
 
-#: src/muuli_wdr.cpp:2217
+#: src/muuli_wdr.cpp:2224
 #, fuzzy
 msgid "Reset page to defaults"
 msgstr "Systemets standard"
 
-#: src/muuli_wdr.cpp:2218
+#: src/muuli_wdr.cpp:2225
 msgid "Reset the settings on the current page to their default values."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2220 src/muuli_wdr.cpp:2306 src/ServerWnd.cpp:274
+#: src/muuli_wdr.cpp:2227 src/muuli_wdr.cpp:2313 src/ServerWnd.cpp:274
 #: src/ServerWnd.cpp:282
 msgid "OK"
 msgstr "OK"
 
-#: src/muuli_wdr.cpp:2222
+#: src/muuli_wdr.cpp:2229
 msgid "Click here to apply any changes made to the preferences."
 msgstr "Klicka här för att tillämpa eventuella ändringar i inställningarna."
 
-#: src/muuli_wdr.cpp:2225
+#: src/muuli_wdr.cpp:2232
 msgid "Reset any changes made to the preferences."
 msgstr "Återställ eventuella ändringar i inställningarna."
 
-#: src/muuli_wdr.cpp:2254
+#: src/muuli_wdr.cpp:2261
 msgid "Comment :"
 msgstr "Kommentar :"
 
-#: src/muuli_wdr.cpp:2261
+#: src/muuli_wdr.cpp:2268
 msgid "Incoming Dir :"
 msgstr "Inkommande mapp:"
 
-#: src/muuli_wdr.cpp:2270
+#: src/muuli_wdr.cpp:2277
 msgid "Change priority for new assigned files :"
 msgstr "Ändra prioritet för nya tilldelade filer:"
 
-#: src/muuli_wdr.cpp:2274
+#: src/muuli_wdr.cpp:2281
 msgid "Don't change"
 msgstr "Ändra inte"
 
-#: src/muuli_wdr.cpp:2286
+#: src/muuli_wdr.cpp:2293
 msgid "Select color for this Category (currently selected) :"
 msgstr "Välj färg för denna kategori (den valda):"
 
-#: src/muuli_wdr.cpp:2353 src/muuli_wdr.cpp:2372 src/muuli_wdr.cpp:2394
+#: src/muuli_wdr.cpp:2360 src/muuli_wdr.cpp:2379 src/muuli_wdr.cpp:2401
 msgid "Click this button to reset the log."
 msgstr "Klicka på den här knappen för att återställa loggen."
 
-#: src/muuli_wdr.cpp:2413
+#: src/muuli_wdr.cpp:2420
 msgid "Click on this button to update the servers list from URL ..."
 msgstr "Klicka på knappen för att uppdatera servrerlistan från URL ..."
 
-#: src/muuli_wdr.cpp:2417
+#: src/muuli_wdr.cpp:2424
 msgid "Server list"
 msgstr "Serverlista"
 
-#: src/muuli_wdr.cpp:2421
+#: src/muuli_wdr.cpp:2428
 msgid "Enter the url to a server.met file here and press the button to the left to update the list of known servers."
 msgstr "Ange URL till en server.met-fil här och tryck på knappen till vänster för att uppdatera listan över kända servrar."
 
-#: src/muuli_wdr.cpp:2426
+#: src/muuli_wdr.cpp:2433
 msgid "Add server manually: Name"
 msgstr "Lägg till server manuellt: Namn"
 
-#: src/muuli_wdr.cpp:2429
+#: src/muuli_wdr.cpp:2436
 msgid "Enter the name of the new server here"
 msgstr "Skriv in namnet på den nya servern här"
 
-#: src/muuli_wdr.cpp:2431 src/ServerWnd.cpp:206
+#: src/muuli_wdr.cpp:2438 src/ServerWnd.cpp:206
 msgid "IP:Port"
 msgstr "IP:Port"
 
-#: src/muuli_wdr.cpp:2434
+#: src/muuli_wdr.cpp:2441
 msgid "Enter the IP of the server here, using the x.x.x.x format."
 msgstr "Ange IP på servern här, med hjälp av xxxx format."
 
-#: src/muuli_wdr.cpp:2440
+#: src/muuli_wdr.cpp:2447
 msgid "Enter the port of the server here."
 msgstr "Ange porten på servern här."
 
-#: src/muuli_wdr.cpp:2443
+#: src/muuli_wdr.cpp:2450
 msgid "Add manually a server (fill fields to the left before) ..."
 msgstr "Lägg manuellt till en server (fyll fälten till vänster innan) ..."
 
-#: src/muuli_wdr.cpp:2472
+#: src/muuli_wdr.cpp:2479
 msgid "aMule Log"
 msgstr "aMule-logg"
 
-#: src/muuli_wdr.cpp:2480
+#: src/muuli_wdr.cpp:2487
 msgid "Server Info"
 msgstr "Serverinformation"
 
-#: src/muuli_wdr.cpp:2484
+#: src/muuli_wdr.cpp:2491
 msgid "ED2K Info"
 msgstr "ED2K-info"
 
-#: src/muuli_wdr.cpp:2488
+#: src/muuli_wdr.cpp:2495
 msgid "Kad Info"
 msgstr "Kad-info"
 
-#: src/muuli_wdr.cpp:2516
+#: src/muuli_wdr.cpp:2523
 msgid "Click on this button to update the nodes list from URL ..."
 msgstr "Klicka på knappen för att uppdatera nodlistan från URL ..."
 
-#: src/muuli_wdr.cpp:2520
+#: src/muuli_wdr.cpp:2527
 msgid "Nodes (0)"
 msgstr "Noder (0)"
 
-#: src/muuli_wdr.cpp:2524
+#: src/muuli_wdr.cpp:2531
 msgid "Enter the url to a nodes.dat file here and press the button to the left to update the list of known nodes."
 msgstr "Ange URL till en nodes.dat fil här och tryck på knappen till vänster för att uppdatera listan över kända noder."
 
-#: src/muuli_wdr.cpp:2527
+#: src/muuli_wdr.cpp:2534
 msgid "Nodes stats"
 msgstr "Nodstatistik"
 
-#: src/muuli_wdr.cpp:2569
+#: src/muuli_wdr.cpp:2576
 msgid "Bootstrap"
 msgstr "Bootstrap"
 
-#: src/muuli_wdr.cpp:2572
+#: src/muuli_wdr.cpp:2579
 msgid "New node"
 msgstr "Ny nod"
 
-#: src/muuli_wdr.cpp:2577
+#: src/muuli_wdr.cpp:2584
 msgid "IP:"
 msgstr "IP:"
 
-#: src/muuli_wdr.cpp:2597
+#: src/muuli_wdr.cpp:2604
 msgid "Port:"
 msgstr "Port:"
 
-#: src/muuli_wdr.cpp:2610
+#: src/muuli_wdr.cpp:2617
 msgid "Bootstrap from known clients"
 msgstr "Bootstrap från kända klienter"
 
-#: src/muuli_wdr.cpp:2612
+#: src/muuli_wdr.cpp:2619
 msgid "Disconnect Kad"
 msgstr "Koppla från Kad"
 
-#: src/muuli_wdr.cpp:2646
+#: src/muuli_wdr.cpp:2653
 msgid "Use Secure User Identification"
 msgstr "Använd säker användarIdentifiering"
 
-#: src/muuli_wdr.cpp:2648
+#: src/muuli_wdr.cpp:2655
 msgid "It is recommended to enable this option. You will not receive credits if SUI is not enabled."
 msgstr "Det rekommenderas att aktivera det här alternativet. Du kommer inte att få poäng om SUI är inte aktiverat."
 
-#: src/muuli_wdr.cpp:2650
+#: src/muuli_wdr.cpp:2657
 msgid "Protocol Obfuscation"
 msgstr "Protokollfördunkling"
 
-#: src/muuli_wdr.cpp:2653
+#: src/muuli_wdr.cpp:2660
 msgid "Support Protocol Obfuscation"
 msgstr "Stöd protokollfördunkling"
 
-#: src/muuli_wdr.cpp:2655
+#: src/muuli_wdr.cpp:2662
 msgid "This option enabled Protocol Obfuscation, and makes aMule accept obfuscated connections from other clients."
 msgstr "Det här alternativet aktiverat protokollffördunkling och låter aMule acceptera dålda anslutningar från andra klienter."
 
-#: src/muuli_wdr.cpp:2657
+#: src/muuli_wdr.cpp:2664
 msgid "Use obfuscation for outgoing connections"
 msgstr "Använd obfuscation (fördunkling) för utgående anslutningar"
 
-#: src/muuli_wdr.cpp:2659
+#: src/muuli_wdr.cpp:2666
 msgid "This option makes aMule use Protocol Obfuscation when connecting other clients/servers."
 msgstr "Det här alternativet gör aMule använder protokoll-Obfuscation (fördunkling) vid anslutning till andra klienter/servrar."
 
-#: src/muuli_wdr.cpp:2661
+#: src/muuli_wdr.cpp:2668
 msgid "Accept only obfuscated connections"
 msgstr "Accepterar endast fördunklade anslutningar"
 
-#: src/muuli_wdr.cpp:2662
+#: src/muuli_wdr.cpp:2669
 msgid "This option makes aMule only accept obfuscated connections. You will have less sources, but all your traffic will be obfuscated"
 msgstr "Det här alternativet gör aMule endast acceptera fördunklade anslutningar. Du kommer att ha mindre källor, men all din trafik kommer att döljas"
 
-#: src/muuli_wdr.cpp:2667
+#: src/muuli_wdr.cpp:2674
 msgid "Everybody"
 msgstr "Alla"
 
-#: src/muuli_wdr.cpp:2669
+#: src/muuli_wdr.cpp:2676
 msgid "No one"
 msgstr "Ingen."
 
-#: src/muuli_wdr.cpp:2671
+#: src/muuli_wdr.cpp:2678
 msgid "Who can see my shared files:"
 msgstr "Vem kan se mina delade filer:"
 
-#: src/muuli_wdr.cpp:2672
+#: src/muuli_wdr.cpp:2679
 msgid "Select who can request to view a list of your shared files."
 msgstr "Välj vem som kan begära att få se en lista över dina delade filer."
 
-#: src/muuli_wdr.cpp:2674
+#: src/muuli_wdr.cpp:2681
 msgid "IP-Filtering"
 msgstr "IP-filtrering"
 
-#: src/muuli_wdr.cpp:2681
+#: src/muuli_wdr.cpp:2688
 msgid "Filter clients"
 msgstr "Filtrera klienter"
 
-#: src/muuli_wdr.cpp:2683
+#: src/muuli_wdr.cpp:2690
 msgid "Enable filtering of the client IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "Aktivera filtrering av klient-IP:n definierade i filen ~/.aMule/ipfilter.dat."
 
-#: src/muuli_wdr.cpp:2685
+#: src/muuli_wdr.cpp:2692
 msgid "Filter servers"
 msgstr "Filtrera servrar"
 
-#: src/muuli_wdr.cpp:2687
+#: src/muuli_wdr.cpp:2694
 msgid "Enable filtering of the server IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "Aktivera filtrering av server-IP:n definierade i filen ~/.aMule/ipfilter.dat."
 
-#: src/muuli_wdr.cpp:2691
+#: src/muuli_wdr.cpp:2698
 msgid "Reload List"
 msgstr "Återladda lista"
 
-#: src/muuli_wdr.cpp:2692
+#: src/muuli_wdr.cpp:2699
 msgid "Reload the list of IPs to filter from the file ~/.aMule/ipfilter.dat"
 msgstr "Återladda listan över IP-adresser att filtrera bort från filen ~/.aMule/ipfilter.dat"
 
-#: src/muuli_wdr.cpp:2698
+#: src/muuli_wdr.cpp:2705
 msgid "URL:"
 msgstr "URL:"
 
-#: src/muuli_wdr.cpp:2702 src/muuli_wdr.cpp:2895
+#: src/muuli_wdr.cpp:2709 src/muuli_wdr.cpp:2902
 msgid "Update now"
 msgstr "Uppdatera nu"
 
-#: src/muuli_wdr.cpp:2705
+#: src/muuli_wdr.cpp:2712
 msgid "Auto-update ipfilter at startup"
 msgstr "Auto-uppdatering av ipfilter vid start"
 
-#: src/muuli_wdr.cpp:2709
+#: src/muuli_wdr.cpp:2716
 msgid "Filtering Level:"
 msgstr "Filtreringsnivå:"
 
-#: src/muuli_wdr.cpp:2715
+#: src/muuli_wdr.cpp:2722
 msgid "Always filter LAN IPs"
 msgstr "Filtrera alltid LAN-IP-adresser"
 
-#: src/muuli_wdr.cpp:2718
+#: src/muuli_wdr.cpp:2725
 msgid "Paranoid handling of non-matching IPs"
 msgstr "Paranoid hantering av icke-matchande IP"
 
-#: src/muuli_wdr.cpp:2720
+#: src/muuli_wdr.cpp:2727
 msgid "Rejects a packet when its source IP differs from the IP the client claims (an anti-spoofing check). Disable only if it causes connection problems."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2722
+#: src/muuli_wdr.cpp:2729
 msgid "Use system-wide ipfilter.dat if available"
 msgstr "Använd systemvidd ipfilter.dat om sådan finns"
 
-#: src/muuli_wdr.cpp:2723
+#: src/muuli_wdr.cpp:2730
 #, fuzzy
 msgid "If there's no local ipfilter.dat found, allow usage of a system-wide ipfilter file."
 msgstr "Om det inte en lokal ipfilter.dat hittas, tillåt användning av systemvidd ipfilterfil."
 
-#: src/muuli_wdr.cpp:2740
+#: src/muuli_wdr.cpp:2747
 msgid "Enable Online-Signature"
 msgstr "Aktivera Onlinesignaturer"
 
-#: src/muuli_wdr.cpp:2742
+#: src/muuli_wdr.cpp:2749
 msgid "Enables the writing of the OS file, which can be used by external apps to create signatures and the like."
 msgstr "Möjliggör skrivning av OS-filen, som kan användas av externa program för att skapa signaturer och liknande."
 
-#: src/muuli_wdr.cpp:2746
+#: src/muuli_wdr.cpp:2753
 msgid "Update Frequency (Secs):"
 msgstr "Uppdateringsfrekvens (Sek):"
 
-#: src/muuli_wdr.cpp:2749
+#: src/muuli_wdr.cpp:2756
 msgid "Change the frequency (in seconds) of Online Signature updates."
 msgstr "Ändra frekvensen (i sekunder) av OnlineSignaturuppdateringar."
 
-#: src/muuli_wdr.cpp:2757
+#: src/muuli_wdr.cpp:2764
 msgid "Save online signature file in: "
 msgstr "Spara onlinesignaturfil i: "
 
-#: src/muuli_wdr.cpp:2763
+#: src/muuli_wdr.cpp:2770
 msgid "Click here to select the directory containing the the Online Signature files."
 msgstr "Klicka här för att välja den katalog som innehåller onlineSignaturFilerna."
 
-#: src/muuli_wdr.cpp:2796
+#: src/muuli_wdr.cpp:2803
 msgid "Show country flags for clients"
 msgstr "Visa landsflagger för klienter"
 
-#: src/muuli_wdr.cpp:2797
+#: src/muuli_wdr.cpp:2804
 msgid "Render the country flag column in the transfers, queue and search views. Requires a valid MMDB GeoIP database (see below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2802
+#: src/muuli_wdr.cpp:2809
 #, fuzzy
 msgid "Database"
 msgstr "Datahastighet :"
 
-#: src/muuli_wdr.cpp:2818
+#: src/muuli_wdr.cpp:2825
 #, fuzzy
 msgid "Source:"
 msgstr "Källor"
 
-#: src/muuli_wdr.cpp:2821
+#: src/muuli_wdr.cpp:2828
 msgid "DB-IP (free, no account)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2822
+#: src/muuli_wdr.cpp:2829
 msgid "MaxMind GeoLite2 (free, account required)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2823
+#: src/muuli_wdr.cpp:2830
 msgid "Custom URL"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2826
+#: src/muuli_wdr.cpp:2833
 msgid "Choose which provider supplies the GeoIP MMDB database. DB-IP is the default - no account required. MaxMind requires a free account + license key. Use Custom URL to point at any other MMDB host (e.g. a local mirror)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2843
+#: src/muuli_wdr.cpp:2850
 msgid ""
 "No configuration required.\n"
 "\n"
@@ -4838,11 +4852,11 @@ msgid ""
 "License: Creative Commons BY 4.0 - https://creativecommons.org/licenses/by/4.0/"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2856
+#: src/muuli_wdr.cpp:2863
 msgid "License key:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2862
+#: src/muuli_wdr.cpp:2869
 msgid ""
 "Sign up for a free MaxMind account, then generate a License Key:\n"
 "https://www.maxmind.com/en/geolite2/signup\n"
@@ -4852,225 +4866,225 @@ msgid ""
 "Requires attribution and account registration; refresh at least every 30 days."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2877
+#: src/muuli_wdr.cpp:2884
 #, fuzzy
 msgid "Download URL:"
 msgstr "Hämta: "
 
-#: src/muuli_wdr.cpp:2883
+#: src/muuli_wdr.cpp:2890
 msgid ""
 "Must point to an .mmdb file or a .gz / .tar.gz containing one.\n"
 "URL may include credentials (https://user:pass@host/...).\n"
 "License and attribution terms are set by the upstream URL - you are responsible."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2896
+#: src/muuli_wdr.cpp:2903
 msgid "Download the GeoIP database from the selected source."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2898
+#: src/muuli_wdr.cpp:2905
 #, fuzzy
 msgid "Auto-update on startup"
 msgstr "Auto-uppdatering av ipfilter vid start"
 
-#: src/muuli_wdr.cpp:2899
+#: src/muuli_wdr.cpp:2906
 msgid "Re-download the GeoIP database from the selected source every time aMule starts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2922
+#: src/muuli_wdr.cpp:2929
 msgid "Filter incoming messages (except current chat):"
 msgstr "Filtrera inkommande meddelanden (utom nuvarande chatt):"
 
-#: src/muuli_wdr.cpp:2924
+#: src/muuli_wdr.cpp:2931
 msgid "Filter all messages"
 msgstr "Filtrera alla meddelanden"
 
-#: src/muuli_wdr.cpp:2926
+#: src/muuli_wdr.cpp:2933
 msgid "Filter messages from people not on your friend list"
 msgstr "Filtrera meddelanden från folk som inte finns i din kompislista"
 
-#: src/muuli_wdr.cpp:2928
+#: src/muuli_wdr.cpp:2935
 msgid "Filter messages from unknown clients"
 msgstr "Filtrera meddelanden från okända klienter"
 
-#: src/muuli_wdr.cpp:2930
+#: src/muuli_wdr.cpp:2937
 msgid "Filter messages containing (use ',' as separator):"
 msgstr "Filtrera meddelanden som innehåller (använd ',' som separator):"
 
-#: src/muuli_wdr.cpp:2933 src/muuli_wdr.cpp:2944
+#: src/muuli_wdr.cpp:2940 src/muuli_wdr.cpp:2951
 msgid "add here the words amule should filter and block messages including it"
 msgstr "skriv här orden amule ska filtrera och blockera meddelanden med dem"
 
-#: src/muuli_wdr.cpp:2935
+#: src/muuli_wdr.cpp:2942
 msgid "Show received messages in the log"
 msgstr "Visa mottagna meddelanden i loggen"
 
-#: src/muuli_wdr.cpp:2938
+#: src/muuli_wdr.cpp:2945
 msgid "Comments"
 msgstr "Kommentarer"
 
-#: src/muuli_wdr.cpp:2941
+#: src/muuli_wdr.cpp:2948
 msgid "Filter comments containing (use ',' as separator):"
 msgstr "Filtrera kommentarer som innehåller (använd ',' som separator):"
 
-#: src/muuli_wdr.cpp:2966
+#: src/muuli_wdr.cpp:2973
 msgid "Enable Proxy"
 msgstr "Aktivera proxy"
 
-#: src/muuli_wdr.cpp:2967
+#: src/muuli_wdr.cpp:2974
 msgid "Enable/disable proxy support"
 msgstr "Aktivera/inaktivera proxy-stöd"
 
-#: src/muuli_wdr.cpp:2970
+#: src/muuli_wdr.cpp:2977
 msgid "Proxy type:"
 msgstr "Proxytyp:"
 
-#: src/muuli_wdr.cpp:2981
+#: src/muuli_wdr.cpp:2988
 msgid "Proxy host:"
 msgstr "Proxyserver:"
 
-#: src/muuli_wdr.cpp:2984
+#: src/muuli_wdr.cpp:2991
 msgid "The proxy host name"
 msgstr "Proxyserverns värdnamn"
 
-#: src/muuli_wdr.cpp:2986
+#: src/muuli_wdr.cpp:2993
 msgid "Proxy port:"
 msgstr "Proxyport:"
 
-#: src/muuli_wdr.cpp:2989
+#: src/muuli_wdr.cpp:2996
 msgid "The proxy port"
 msgstr "Proxyporten"
 
-#: src/muuli_wdr.cpp:2991
+#: src/muuli_wdr.cpp:2998
 msgid "Enable authentication"
 msgstr "Aktivera autentisering"
 
-#: src/muuli_wdr.cpp:2992
+#: src/muuli_wdr.cpp:2999
 msgid "Enable/disable username/password authentication"
 msgstr "Aktivera/inaktivera användarnamn/lösenordsautentisering"
 
-#: src/muuli_wdr.cpp:2995
+#: src/muuli_wdr.cpp:3002
 msgid "Username: "
 msgstr "Användarnamn: "
 
-#: src/muuli_wdr.cpp:2998
+#: src/muuli_wdr.cpp:3005
 msgid "The username to use to connect to the proxy"
 msgstr "Användarnamnet som ska användas för att ansluta till proxyn"
 
-#: src/muuli_wdr.cpp:3000
+#: src/muuli_wdr.cpp:3007
 msgid "Password:"
 msgstr "Lösenord:"
 
-#: src/muuli_wdr.cpp:3003
+#: src/muuli_wdr.cpp:3010
 msgid "The password to use to connect to the proxy"
 msgstr "Lösenordet som ska användas för att ansluta till proxyn"
 
-#: src/muuli_wdr.cpp:3022
+#: src/muuli_wdr.cpp:3029
 msgid "Connect to:"
 msgstr "Anslut till:"
 
-#: src/muuli_wdr.cpp:3031
+#: src/muuli_wdr.cpp:3038
 msgid "Login to remote amule"
 msgstr "Logga in på fjärr-amule"
 
-#: src/muuli_wdr.cpp:3036
+#: src/muuli_wdr.cpp:3043
 msgid "User name"
 msgstr "Användarnamn"
 
-#: src/muuli_wdr.cpp:3047
+#: src/muuli_wdr.cpp:3054
 msgid "Remember those settings"
 msgstr "Kom ihåg dessa inställningar"
 
-#: src/muuli_wdr.cpp:3050
+#: src/muuli_wdr.cpp:3057
 #, fuzzy
 msgid "Force ZLIB compression"
 msgstr "Använd gzip-komprimering"
 
-#: src/muuli_wdr.cpp:3074
+#: src/muuli_wdr.cpp:3081
 msgid "Enable Verbose Debug-Logging."
 msgstr "Aktivera Utförlig Debug-loggning."
 
-#: src/muuli_wdr.cpp:3076
+#: src/muuli_wdr.cpp:3083
 msgid "Only to Logfile"
 msgstr "Endast till loggfil"
 
-#: src/muuli_wdr.cpp:3078
+#: src/muuli_wdr.cpp:3085
 msgid "Message Categories:"
 msgstr "Meddelandekategorier:"
 
-#: src/muuli_wdr.cpp:3102 src/PartFileConvertDlg.cpp:160
+#: src/muuli_wdr.cpp:3109 src/PartFileConvertDlg.cpp:160
 msgid "Waiting..."
 msgstr "Väntar..."
 
-#: src/muuli_wdr.cpp:3122
+#: src/muuli_wdr.cpp:3129
 msgid "Add imports"
 msgstr "Lägg till importer"
 
-#: src/muuli_wdr.cpp:3125
+#: src/muuli_wdr.cpp:3132
 msgid "Retry selected"
 msgstr "Återförsök den valda"
 
-#: src/muuli_wdr.cpp:3127
+#: src/muuli_wdr.cpp:3134
 msgid "Remove selected"
 msgstr "Ta bort vald"
 
-#: src/muuli_wdr.cpp:3190
+#: src/muuli_wdr.cpp:3197
 msgid "Event Types"
 msgstr "Händelsetyper"
 
-#: src/muuli_wdr.cpp:3209
+#: src/muuli_wdr.cpp:3216
 msgid "Statistics and queued clients for selected file(s) : Session / All time"
 msgstr "Statistik och köade klienter för vald fil(er): Session / All tid"
 
-#: src/muuli_wdr.cpp:3233
+#: src/muuli_wdr.cpp:3240
 msgid "Active Uploads"
 msgstr "Aktiva uppladdningar"
 
-#: src/muuli_wdr.cpp:3247
+#: src/muuli_wdr.cpp:3254
 msgid "Percent of total files"
 msgstr "Procent av den totala filer"
 
-#: src/muuli_wdr.cpp:3299
+#: src/muuli_wdr.cpp:3306
 msgid "Show Clients for"
 msgstr "Visa klienter för"
 
-#: src/muuli_wdr.cpp:3301
+#: src/muuli_wdr.cpp:3308
 msgid "All files"
 msgstr "Alla filer"
 
-#: src/muuli_wdr.cpp:3304
+#: src/muuli_wdr.cpp:3311
 msgid "Selected files"
 msgstr "Valda filer"
 
-#: src/muuli_wdr.cpp:3307
+#: src/muuli_wdr.cpp:3314
 msgid "Active uploads only"
 msgstr "Endast aktiva uppladdningar"
 
-#: src/muuli_wdr.cpp:3314
+#: src/muuli_wdr.cpp:3321
 msgid "Reload:"
 msgstr "Återladda:"
 
-#: src/muuli_wdr.cpp:3318
+#: src/muuli_wdr.cpp:3325
 msgid "Reload your shared files"
 msgstr "Återladda dina delade filer"
 
-#: src/muuli_wdr.cpp:3381
+#: src/muuli_wdr.cpp:3388
 msgid "Send"
 msgstr "Skicka"
 
-#: src/muuli_wdr.cpp:3382
+#: src/muuli_wdr.cpp:3389
 msgid "Sends the specified message."
 msgstr "Skickar det specificerade meddelandet."
 
-#: src/muuli_wdr.cpp:3386
+#: src/muuli_wdr.cpp:3393
 msgid "Close this chat-session."
 msgstr "Stäng denna chat-session."
 
-#: src/muuli_wdr.cpp:3409
+#: src/muuli_wdr.cpp:3416
 msgid "Connect to any server and/or Kad"
 msgstr "Anslut till någon server och/eller Kad"
 
-#: src/muuli_wdr.cpp:3415 src/SharedFilesCtrl.cpp:142 src/Statistics.cpp:941
+#: src/muuli_wdr.cpp:3422 src/SharedFilesCtrl.cpp:142 src/Statistics.cpp:941
 msgid "Shared Files"
 msgstr "Utdelade filer"
 
@@ -5429,188 +5443,188 @@ msgstr "Nedladdad"
 msgid "ERROR: Failed to open partfile '%s'"
 msgstr "FEL: Det gick inte att öppna partfile ' %s '"
 
-#: src/Preferences.cpp:673
+#: src/Preferences.cpp:674
 msgid "System default"
 msgstr "Systemets standard"
 
-#: src/Preferences.cpp:674
+#: src/Preferences.cpp:675
 msgid "Albanian"
 msgstr "Albansk"
 
-#: src/Preferences.cpp:675
+#: src/Preferences.cpp:676
 msgid "Arabic"
 msgstr "Arabiska"
 
-#: src/Preferences.cpp:676
+#: src/Preferences.cpp:677
 msgid "Asturian"
 msgstr "Asturiska"
 
-#: src/Preferences.cpp:677
+#: src/Preferences.cpp:678
 msgid "Basque"
 msgstr "Baskiska"
 
-#: src/Preferences.cpp:678
+#: src/Preferences.cpp:679
 msgid "Bulgarian"
 msgstr "Bulgariska"
 
-#: src/Preferences.cpp:679
+#: src/Preferences.cpp:680
 msgid "Catalan"
 msgstr "Katalanska"
 
-#: src/Preferences.cpp:680
+#: src/Preferences.cpp:681
 msgid "Chinese (Simplified)"
 msgstr "Kinesiska (Förenklad)"
 
-#: src/Preferences.cpp:681
+#: src/Preferences.cpp:682
 msgid "Chinese (Traditional)"
 msgstr "Kinesiska (Traditionell)"
 
-#: src/Preferences.cpp:682
+#: src/Preferences.cpp:683
 msgid "Croatian"
 msgstr "Kroatiska"
 
-#: src/Preferences.cpp:683
+#: src/Preferences.cpp:684
 msgid "Czech"
 msgstr "Checkiska"
 
-#: src/Preferences.cpp:684
+#: src/Preferences.cpp:685
 msgid "Danish"
 msgstr "Danska"
 
-#: src/Preferences.cpp:685
+#: src/Preferences.cpp:686
 msgid "Dutch"
 msgstr "Nederländska"
 
-#: src/Preferences.cpp:686
+#: src/Preferences.cpp:687
 msgid "English (U.K.)"
 msgstr "Engelska (Storbritannien)"
 
-#: src/Preferences.cpp:687
+#: src/Preferences.cpp:688
 #, fuzzy
 msgid "English (U.S.)"
 msgstr "Engelska (Storbritannien)"
 
-#: src/Preferences.cpp:688
+#: src/Preferences.cpp:689
 msgid "Estonian"
 msgstr "Estniska"
 
-#: src/Preferences.cpp:689
+#: src/Preferences.cpp:690
 msgid "Finnish"
 msgstr "Finska"
 
-#: src/Preferences.cpp:690
+#: src/Preferences.cpp:691
 msgid "French"
 msgstr "Franska"
 
-#: src/Preferences.cpp:691
+#: src/Preferences.cpp:692
 msgid "Galician"
 msgstr "Galiciska"
 
-#: src/Preferences.cpp:692
+#: src/Preferences.cpp:693
 msgid "German"
 msgstr "Tyska"
 
-#: src/Preferences.cpp:693
+#: src/Preferences.cpp:694
 msgid "Greek"
 msgstr "Grekisk"
 
-#: src/Preferences.cpp:694
+#: src/Preferences.cpp:695
 msgid "Hebrew"
 msgstr "Hebreiska"
 
-#: src/Preferences.cpp:695
+#: src/Preferences.cpp:696
 msgid "Hungarian"
 msgstr "Ungerska"
 
-#: src/Preferences.cpp:696
+#: src/Preferences.cpp:697
 msgid "Italian"
 msgstr "Italienska"
 
-#: src/Preferences.cpp:697
+#: src/Preferences.cpp:698
 msgid "Japanese"
 msgstr "Japanska"
 
-#: src/Preferences.cpp:698
+#: src/Preferences.cpp:699
 msgid "Korean"
 msgstr "Koreanska"
 
-#: src/Preferences.cpp:699
+#: src/Preferences.cpp:700
 msgid "Latvian"
 msgstr ""
 
-#: src/Preferences.cpp:700
+#: src/Preferences.cpp:701
 msgid "Lithuanian"
 msgstr "Litauisk"
 
-#: src/Preferences.cpp:701
+#: src/Preferences.cpp:702
 msgid "Norwegian (Nynorsk)"
 msgstr "Norska (nynorsk)"
 
-#: src/Preferences.cpp:702
+#: src/Preferences.cpp:703
 msgid "Polish"
 msgstr "Polska"
 
-#: src/Preferences.cpp:703
+#: src/Preferences.cpp:704
 msgid "Portuguese"
 msgstr "Portugisiska"
 
-#: src/Preferences.cpp:704
+#: src/Preferences.cpp:705
 msgid "Portuguese (Brazilian)"
 msgstr "Portugisiska (Brasilien)"
 
-#: src/Preferences.cpp:705
+#: src/Preferences.cpp:706
 msgid "Romanian"
 msgstr "Romänska"
 
-#: src/Preferences.cpp:706
+#: src/Preferences.cpp:707
 msgid "Russian"
 msgstr "Ryska"
 
-#: src/Preferences.cpp:707
+#: src/Preferences.cpp:708
 msgid "Slovenian"
 msgstr "Slovenska"
 
-#: src/Preferences.cpp:708
+#: src/Preferences.cpp:709
 msgid "Spanish"
 msgstr "Spanska"
 
-#: src/Preferences.cpp:709
+#: src/Preferences.cpp:710
 msgid "Swedish"
 msgstr "Svenska"
 
-#: src/Preferences.cpp:710
+#: src/Preferences.cpp:711
 msgid "Turkish"
 msgstr "Turkiska"
 
-#: src/Preferences.cpp:711
+#: src/Preferences.cpp:712
 msgid "Ukrainian"
 msgstr "Ukraina"
 
-#: src/Preferences.cpp:814
+#: src/Preferences.cpp:815
 msgid "Change Language"
 msgstr "Byt språk"
 
-#: src/Preferences.cpp:878
+#: src/Preferences.cpp:879
 msgid "There are no translations installed for aMule"
 msgstr "Det finns inga översättningar installerade för aMule"
 
-#: src/Preferences.cpp:879
+#: src/Preferences.cpp:880
 msgid "No languages available"
 msgstr "Inga språk tillgängliga"
 
-#: src/Preferences.cpp:1010
+#: src/Preferences.cpp:1011
 msgid "no options available"
 msgstr "Inga alternativ tillgängliga"
 
-#: src/Preferences.cpp:2179
+#: src/Preferences.cpp:2182
 msgid "Invalid category found, skipping"
 msgstr "Ogiltig kategori hittad, hoppar över"
 
-#: src/Preferences.cpp:2348
+#: src/Preferences.cpp:2351
 msgid "TCP port can't be higher than 65532 due to server UDP socket being TCP+3"
 msgstr "TCP-port kan inte vara högre än 65532 på grund av server UDP-socket är TCP+3"
 
-#: src/Preferences.cpp:2349
+#: src/Preferences.cpp:2352
 #, c-format
 msgid "Default port will be used (%d)"
 msgstr "Standardporten kommer att användas ( %d )"
@@ -6120,24 +6134,28 @@ msgstr "Ladda om listan med delade filer."
 msgid "Shared folder"
 msgstr "Delade mappar"
 
-#: src/SearchDlg.cpp:425
+#: src/SearchDlg.cpp:280
+msgid "Clear search history"
+msgstr ""
+
+#: src/SearchDlg.cpp:584
 msgid "It's impossible to search when both eD2k and Kademlia are disabled."
 msgstr ""
 
-#: src/SearchDlg.cpp:426 src/SearchListCtrl.cpp:858
+#: src/SearchDlg.cpp:585 src/SearchListCtrl.cpp:858
 #, fuzzy
 msgid "Search error"
 msgstr "Sökningar"
 
-#: src/SearchDlg.cpp:768
+#: src/SearchDlg.cpp:929
 msgid "Min size must be smaller than max size. Max size ignored."
 msgstr "Min storlek måste vara mindre än max storlek. Max storlek ignoreras."
 
-#: src/SearchDlg.cpp:769 src/SearchDlg.cpp:851
+#: src/SearchDlg.cpp:930 src/SearchDlg.cpp:1012
 msgid "Search warning"
 msgstr "Sökvarning"
 
-#: src/SearchDlg.cpp:929 src/SearchListCtrl.cpp:735
+#: src/SearchDlg.cpp:1092 src/SearchListCtrl.cpp:735
 msgid "Main"
 msgstr "Huvud"
 

--- a/po/sv.po
+++ b/po/sv.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-28 10:19+0200\n"
+"POT-Creation-Date: 2026-07-28 12:17+0200\n"
 "PO-Revision-Date: 2026-07-27 11:46+0000\n"
 "Last-Translator: raffe <raffe@localhost.se>\n"
 "Language-Team: Swedish <tp-sv@listor.tp-sv.se>\n"
@@ -202,83 +202,83 @@ msgstr "Kunde inte öppna ED2KLinks-filen"
 msgid "WARNING: You can't add yourself as a source for an eD2k link while having a lowid."
 msgstr "VARNING: Du kan inte lägga till dig själv som källa för en eD2k-länk när du har lowid."
 
-#: src/amule.cpp:300
+#: src/amule.cpp:301
 msgid "Now, exiting main app..."
 msgstr "Nu, avslutar huvudapplikationen..."
 
-#: src/amule.cpp:330
+#: src/amule.cpp:331
 #, c-format
 msgid "Terminating amuleweb instance with pid '%d' ... "
 msgstr "Avslutar  amuleweb-instansen med pid '%d' ... "
 
-#: src/amule.cpp:334
+#: src/amule.cpp:335
 #, c-format
 msgid "Killing amuleweb instance with pid '%d' ... "
 msgstr "Dödar amuleweb-instansen med pid '%d' ... "
 
-#: src/amule.cpp:336 src/amule.cpp:349 src/ClientRef.cpp:180
+#: src/amule.cpp:337 src/amule.cpp:350 src/ClientRef.cpp:180
 #: src/SearchDlg.cpp:1041 src/ServerListCtrl.cpp:98
 msgid "Failed"
 msgstr "Misslyckades"
 
-#: src/amule.cpp:343
+#: src/amule.cpp:344
 #, fuzzy, c-format
 msgid "Terminating amuleapi instance with pid '%d' ... "
 msgstr "Avslutar  amuleweb-instansen med pid '%d' ... "
 
-#: src/amule.cpp:347
+#: src/amule.cpp:348
 #, fuzzy, c-format
 msgid "Killing amuleapi instance with pid '%d' ... "
 msgstr "Dödar amuleweb-instansen med pid '%d' ... "
 
-#: src/amule.cpp:355
+#: src/amule.cpp:356
 msgid "aMule OnExit: Terminating core."
 msgstr "aMule VidAvslut: Avslutar huvudprogrammet."
 
-#: src/amule.cpp:466
+#: src/amule.cpp:467
 msgid "aMule shutdown completed."
 msgstr "aMules avslutning slutförd"
 
-#: src/amule.cpp:470
+#: src/amule.cpp:471
 msgid "Memory debug results for aMule exit:"
 msgstr "Minnes-debug-resultat för aMules avslut"
 
-#: src/amule.cpp:651
+#: src/amule.cpp:652
 #, c-format
 msgid "Binding aMule's peer-to-peer traffic to interface: %s (HTTP updates use the default route)"
 msgstr ""
 
-#: src/amule.cpp:655
+#: src/amule.cpp:656
 #, c-format
 msgid "Binding all network traffic to interface: %s"
 msgstr ""
 
-#: src/amule.cpp:659
+#: src/amule.cpp:660
 #, c-format
 msgid "WARNING: configured network interface '%s' was not found - traffic is NOT bound to it and may leave via the default route. Check the interface name in Preferences."
 msgstr ""
 
-#: src/amule.cpp:665
+#: src/amule.cpp:666
 #, c-format
 msgid "WARNING: binding to network interface '%s' requires elevated privileges and was NOT applied - traffic may leave via the default route. Grant the capability (e.g. 'sudo setcap cap_net_raw+ep' on the aMule binary) or run with sufficient privileges."
 msgstr ""
 
-#: src/amule.cpp:673
+#: src/amule.cpp:674
 #, c-format
 msgid "WARNING: could not bind to network interface '%s' - traffic may leave via the default route."
 msgstr ""
 
-#: src/amule.cpp:732
+#: src/amule.cpp:733
 msgid "Your locale has been changed to System Default due to a configuration change. Sorry."
 msgstr "Din plats har ändrats till systemets standard på grund av en konfigurationsändring. Ledsen."
 
-#: src/amule.cpp:734 src/amule.cpp:1581 src/CatDialog.cpp:128
+#: src/amule.cpp:735 src/amule.cpp:1589 src/CatDialog.cpp:128
 #: src/CatDialog.cpp:136 src/CatDialog.cpp:149 src/ServerList.cpp:366
 #: src/ServerListCtrl.cpp:152
 msgid "Info"
 msgstr "Info"
 
-#: src/amule.cpp:741
+#: src/amule.cpp:742
 msgid ""
 "\n"
 "EC configuration"
@@ -286,74 +286,74 @@ msgstr ""
 "\n"
 "EC-konfiguration"
 
-#: src/amule.cpp:744
+#: src/amule.cpp:745
 msgid "Password set and external connections enabled."
 msgstr "Lösenord sparad och extern anslutning aktiverad."
 
-#: src/amule.cpp:754 src/KadDlg.cpp:176 src/KadDlg.cpp:185
-#: src/PrefsUnifiedDlg.cpp:1387 src/SharedFilesCtrl.cpp:476
+#: src/amule.cpp:755 src/KadDlg.cpp:176 src/KadDlg.cpp:185
+#: src/PrefsUnifiedDlg.cpp:1461 src/SharedFilesCtrl.cpp:476
 msgid "WARNING"
 msgstr "VARNING"
 
-#: src/amule.cpp:991
+#: src/amule.cpp:992
 #, fuzzy
 msgid "Network bootstrap"
 msgstr "Nätverk"
 
-#: src/amule.cpp:996
+#: src/amule.cpp:997
 msgid ""
 "aMule has detected missing network bootstrap files.\n"
 "Select which ones to download:"
 msgstr ""
 
-#: src/amule.cpp:1005 src/FirstRunWizard.cpp:411
+#: src/amule.cpp:1006 src/FirstRunWizard.cpp:411
 #, fuzzy
 msgid "eD2k server list (server.met)"
 msgstr "%i server hittad i server.met"
 
-#: src/amule.cpp:1012 src/FirstRunWizard.cpp:416
+#: src/amule.cpp:1013 src/FirstRunWizard.cpp:416
 msgid "Kad bootstrap nodes (nodes.dat)"
 msgstr ""
 
-#: src/amule.cpp:1102
+#: src/amule.cpp:1103
 #, c-format
 msgid "web server running on pid %d"
 msgstr "webbservern kör på pid %d"
 
-#: src/amule.cpp:1115
+#: src/amule.cpp:1116
 #, fuzzy
 msgid "You requested to run web server on startup, but the amuleweb binary cannot be run. Please install the package containing aMule web server, or build aMule from source with -DBUILD_WEBSERVER=YES and install it."
 msgstr "Du vill köra webbservern vid uppstart, men binärfilen amuleweb kan inte köras. Vänligen installera paketet med aMule webservern eller compilera aMule med --enable-webserver och kör make install"
 
-#: src/amule.cpp:1120 src/amule.cpp:1177 src/amule.cpp:1291 src/amule.cpp:1593
+#: src/amule.cpp:1121 src/amule.cpp:1185 src/amule.cpp:1299 src/amule.cpp:1601
 #: src/amule-remote-gui.cpp:603 src/amule-remote-gui.cpp:671
 #: src/amule-remote-gui.cpp:709 src/amule-remote-gui.cpp:1282
 #: src/amule-remote-gui.cpp:1345 src/amule-remote-gui.cpp:1372
-#: src/DownloadQueue.cpp:1481
+#: src/DownloadQueue.cpp:1481 src/PrefsUnifiedDlg.cpp:1247
 msgid "ERROR"
 msgstr "FEL"
 
-#: src/amule.cpp:1166
+#: src/amule.cpp:1174
 #, fuzzy, c-format
 msgid "amuleapi running on pid %d"
 msgstr "webbservern kör på pid %d"
 
-#: src/amule.cpp:1172
+#: src/amule.cpp:1180
 #, fuzzy
 msgid "You requested to run amuleapi on startup, but the amuleapi binary cannot be run. Please install the package containing aMule's REST API server, or build aMule from source with -DBUILD_AMULEAPI=YES and install it."
 msgstr "Du vill köra webbservern vid uppstart, men binärfilen amuleweb kan inte köras. Vänligen installera paketet med aMule webservern eller compilera aMule med --enable-webserver och kör make install"
 
-#: src/amule.cpp:1259
+#: src/amule.cpp:1267
 #, c-format
 msgid "Could not bind ports to the specified address: %s"
 msgstr "Kunde inte binda portarna till specificerad adress: %s"
 
-#: src/amule.cpp:1283
+#: src/amule.cpp:1291
 #, c-format
 msgid "Port %u is not available. You will be LOWID\n"
 msgstr "Port %u är inte tillgänglig. Du kommer att bli LOWID\n"
 
-#: src/amule.cpp:1288
+#: src/amule.cpp:1296
 #, c-format
 msgid ""
 "Port %u is not available!\n"
@@ -368,48 +368,48 @@ msgstr ""
 "\n"
 "Kontrollera ditt nätverk för att se att porten är öppen för ut och in-trafik."
 
-#: src/amule.cpp:1385
+#: src/amule.cpp:1393
 msgid "Failed to create OnlineSig File"
 msgstr "Misslyckades med att skapa OnlineSig-fil"
 
-#: src/amule.cpp:1393
+#: src/amule.cpp:1401
 msgid "Failed to create aMule OnlineSig File"
 msgstr "Misslyckades med att skapa aMule OnlineSig-fil"
 
-#: src/amule.cpp:1556
+#: src/amule.cpp:1564
 msgid "The selected locale seems not to be installed on your box. (Note: I'll try to set it anyway)"
 msgstr "Den valda platsen verkar inte vara installerad på din burk. (OBS: Jag försöker ändå)"
 
-#: src/amule.cpp:1566
+#: src/amule.cpp:1574
 #, c-format
 msgid "This is the first time you run aMule %s"
 msgstr "Det här är första gången du kör aMule %s"
 
-#: src/amule.cpp:1569
+#: src/amule.cpp:1577
 msgid "This version is a testing version, updated daily, and\n"
 msgstr "Den här versionen är en testversion, uppdateras dagligen, och\n"
 
-#: src/amule.cpp:1570
+#: src/amule.cpp:1578
 msgid "we give no warranty it won't break anything, burn your house,\n"
 msgstr "vi ger inga garantier att den inte förstör allt, bränner ner huset,\n"
 
-#: src/amule.cpp:1571
+#: src/amule.cpp:1579
 msgid "or kill your dog. But it *should* be safe to use anyway.\n"
 msgstr "eller dödar din hund. Men den *bör* vara säker att använda.\n"
 
-#: src/amule.cpp:1576
+#: src/amule.cpp:1584
 msgid "More information, support and new releases can found at our homepage,\n"
 msgstr "Mer information, support och nya versioner kan hittas på vår hemsida,\n"
 
-#: src/amule.cpp:1577
+#: src/amule.cpp:1585
 msgid "at https://amule-org.github.io, or in our IRC channel #aMule at irc.libera.chat.\n"
 msgstr "https://amule-org.github.io, eller i vår IRC-kanal #aMule på irc.libera.chat.\n"
 
-#: src/amule.cpp:1579
+#: src/amule.cpp:1587
 msgid "Feel free to report any bugs to https://github.com/amule-org/amule/issues"
 msgstr "Rapportera gärna eventuella fel på https://github.com/amule-org/amule/issues"
 
-#: src/amule.cpp:1591
+#: src/amule.cpp:1599
 msgid ""
 "The folder for Online Signature files you specified is INVALID!\n"
 " OnlineSignature will be DISABLED until you fix it on preferences."
@@ -417,137 +417,137 @@ msgstr ""
 "Katalogen för Online Signaturefiler som du angav är OGILTIG!\n"
 " OnlineSignatur kommer vara INAKTIVERAD tills du ändrar inställningarna."
 
-#: src/amule.cpp:1654
+#: src/amule.cpp:1662
 msgid "Server hostname notified"
 msgstr "Serverns hostname underrättad"
 
-#: src/amule.cpp:2031
+#: src/amule.cpp:2039
 #, c-format
 msgid "Disk space preallocation for file '%s' failed: %s"
 msgstr "Förallokerad diskutrymme för filen '%s' misslyckades: %s"
 
-#: src/amule.cpp:2160
+#: src/amule.cpp:2168
 msgid "ERROR: can't open logfile"
 msgstr "FEL: kan inte öppna loggfilen"
 
-#: src/amule.cpp:2164
+#: src/amule.cpp:2172
 msgid "WARNING: logfile is empty. Something is wrong."
 msgstr "VARNING: loggfilen är tom. Någonting är fel."
 
-#: src/amule.cpp:2181
+#: src/amule.cpp:2189
 msgid "Log has been reset"
 msgstr "Loggen har nollställts"
 
-#: src/amule.cpp:2205
+#: src/amule.cpp:2213
 #, c-format
 msgid "ServerMessage: %s"
 msgstr "Servermeddelande: %s"
 
-#: src/amule.cpp:2248 src/IP2Country.cpp:220 src/IPFilter.cpp:514
+#: src/amule.cpp:2256 src/IP2Country.cpp:220 src/IPFilter.cpp:514
 #: src/ServerList.cpp:875
 #, c-format
 msgid "Skipped download of %s, because requested file is not newer."
 msgstr "Avslutade nerladdningen av %s eftersom begärd fil inte är nyare."
 
-#: src/amule.cpp:2251
+#: src/amule.cpp:2259
 msgid "Failed to download the nodes list."
 msgstr "Misslyckades med att hämta nodlistan."
 
-#: src/amule.cpp:2314
+#: src/amule.cpp:2322
 msgid "Failed to open the downloaded version check file"
 msgstr "Misslyckades med att öppna den hämtade versionskontrollfilen"
 
-#: src/amule.cpp:2317 src/amule.cpp:2336
+#: src/amule.cpp:2325 src/amule.cpp:2344
 msgid "Corrupted version check file"
 msgstr "Korrupt versionskontrollfil"
 
-#: src/amule.cpp:2359
+#: src/amule.cpp:2367
 msgid "You are using an outdated version of aMule!"
 msgstr "Du använder en gammal version av aMule!"
 
-#: src/amule.cpp:2361
+#: src/amule.cpp:2369
 #, c-format
 msgid "Your aMule version is %i.%i.%i and the latest version is %li.%li.%li"
 msgstr "Din aMuleversion är %i.%i.%i och den senaste versionen är %li.%li.%li"
 
-#: src/amule.cpp:2365
+#: src/amule.cpp:2373
 msgid "The latest version can always be found at https://github.com/amule-org/amule/releases/latest"
 msgstr "Den senaste versionen kan alltid hittas på https://github.com/amule-org/amule/releases/latest"
 
-#: src/amule.cpp:2368
+#: src/amule.cpp:2376
 #, c-format
 msgid "WARNING: Your aMuled version is outdated: %i.%i.%i < %li.%li.%li"
 msgstr "VARNING: Din version av aMuled är gammal: %i.%i.%i < %li.%li.%li"
 
-#: src/amule.cpp:2374
+#: src/amule.cpp:2382
 msgid "Your copy of aMule is up to date."
 msgstr "Din version av aMule är den senaste."
 
-#: src/amule.cpp:2381
+#: src/amule.cpp:2389
 msgid "Failed to download the version check file"
 msgstr "Misslyckades med att hämta versionskontrollfilen"
 
-#: src/amule.cpp:2550 src/amule-remote-gui.cpp:1133
+#: src/amule.cpp:2558 src/amule-remote-gui.cpp:1133
 #, c-format
 msgid "Users: %s | Files: %s"
 msgstr "Användare: %s | Filer: %s"
 
-#: src/amule.cpp:2551 src/amule-remote-gui.cpp:1134
+#: src/amule.cpp:2559 src/amule-remote-gui.cpp:1134
 #, c-format
 msgid "Users: E: %s K: %s | Files: E: %s K: %s"
 msgstr "Användare: E: %s K: %s | Filer: E: %s K: %s"
 
-#: src/amule.cpp:2565 src/amule-remote-gui.cpp:1147
+#: src/amule.cpp:2573 src/amule-remote-gui.cpp:1147
 msgid "No networks selected"
 msgstr "Inga nätverk valda"
 
-#: src/amule.cpp:2633 src/TextClient.cpp:903
+#: src/amule.cpp:2641 src/TextClient.cpp:903
 msgid "with LowID"
 msgstr "med LowID"
 
-#: src/amule.cpp:2633 src/TextClient.cpp:904
+#: src/amule.cpp:2641 src/TextClient.cpp:904
 msgid "with HighID"
 msgstr "med HighID"
 
-#: src/amule.cpp:2635
+#: src/amule.cpp:2643
 #, c-format
 msgid "Connected to %s %s"
 msgstr "Ansluten till %s %s"
 
-#: src/amule.cpp:2640
+#: src/amule.cpp:2648
 #, c-format
 msgid "Connecting to %s"
 msgstr "Ansluter till %s"
 
-#: src/amule.cpp:2642
+#: src/amule.cpp:2650
 msgid "Disconnected from eD2k"
 msgstr "Frånkopplad från eD2k"
 
-#: src/amule.cpp:2651
+#: src/amule.cpp:2659
 msgid "Kad started."
 msgstr "Kad startad."
 
-#: src/amule.cpp:2653
+#: src/amule.cpp:2661
 msgid "Kad stopped."
 msgstr "Kad stoppad."
 
-#: src/amule.cpp:2661
+#: src/amule.cpp:2669
 msgid "Connected to Kad (ok)"
 msgstr "Ansluten till Kad (ok)"
 
-#: src/amule.cpp:2663
+#: src/amule.cpp:2671
 msgid "Connected to Kad (firewalled)"
 msgstr "Ansluten till Kad (brandvägg)"
 
-#: src/amule.cpp:2667
+#: src/amule.cpp:2675
 msgid "Disconnected from Kad"
 msgstr "Frånkopplad från Kad"
 
-#: src/amule.cpp:2699
+#: src/amule.cpp:2707
 msgid "Kad network cannot be used if UDP port is disabled on preferences, not starting."
 msgstr "Kadnätverket kan inte användas om UDP-porten är inaktiverad i inställningarna, startar inte."
 
-#: src/amule.cpp:2703
+#: src/amule.cpp:2711
 msgid "Kad network disabled on preferences, not connecting."
 msgstr "Kadnätverket är inaktiverad i inställningarna, ansluter inte."
 
@@ -592,36 +592,36 @@ msgid "FATAL ERROR: Failed to create Timer"
 msgstr "ALLVARLIGT FEL: Kunde inte skapa Timer"
 
 #: src/amuleDlg.cpp:361 src/amuleDlg.cpp:1787 src/amuleDlg.cpp:2033
-#: src/muuli_wdr.cpp:1492 src/muuli_wdr.cpp:3418
+#: src/muuli_wdr.cpp:1492 src/muuli_wdr.cpp:3449
 msgid "Networks"
 msgstr "Nätverk"
 
-#: src/amuleDlg.cpp:362 src/amuleDlg.cpp:1793 src/muuli_wdr.cpp:3419
+#: src/amuleDlg.cpp:362 src/amuleDlg.cpp:1793 src/muuli_wdr.cpp:3450
 msgid "Searches"
 msgstr "Sökningar"
 
 #: src/amuleDlg.cpp:363 src/amuleDlg.cpp:1799 src/DownloadListCtrl.cpp:740
-#: src/muuli_wdr.cpp:392 src/muuli_wdr.cpp:1585 src/muuli_wdr.cpp:3420
+#: src/muuli_wdr.cpp:392 src/muuli_wdr.cpp:1585 src/muuli_wdr.cpp:3451
 #: src/Statistics.cpp:829
 msgid "Downloads"
 msgstr "Hämtningar"
 
-#: src/amuleDlg.cpp:364 src/amuleDlg.cpp:1805 src/muuli_wdr.cpp:3294
+#: src/amuleDlg.cpp:364 src/amuleDlg.cpp:1805 src/muuli_wdr.cpp:3325
 msgid "Shared files"
 msgstr "Delade filer"
 
-#: src/amuleDlg.cpp:365 src/amuleDlg.cpp:1811 src/muuli_wdr.cpp:2926
-#: src/muuli_wdr.cpp:3376 src/muuli_wdr.cpp:3423
+#: src/amuleDlg.cpp:365 src/amuleDlg.cpp:1811 src/muuli_wdr.cpp:2957
+#: src/muuli_wdr.cpp:3407 src/muuli_wdr.cpp:3454
 msgid "Messages"
 msgstr "Meddelanden"
 
-#: src/amuleDlg.cpp:366 src/amuleDlg.cpp:1817 src/muuli_wdr.cpp:3424
-#: src/PrefsUnifiedDlg.cpp:312 src/Statistics.cpp:779 src/Statistics.cpp:1235
+#: src/amuleDlg.cpp:366 src/amuleDlg.cpp:1817 src/muuli_wdr.cpp:3455
+#: src/PrefsUnifiedDlg.cpp:314 src/Statistics.cpp:779 src/Statistics.cpp:1235
 msgid "Statistics"
 msgstr "Statistik"
 
-#: src/amuleDlg.cpp:368 src/amuleDlg.cpp:1824 src/muuli_wdr.cpp:3426
-#: src/PrefsUnifiedDlg.cpp:328 src/utils/wxCas/src/wxcasprefs.cpp:39
+#: src/amuleDlg.cpp:368 src/amuleDlg.cpp:1824 src/muuli_wdr.cpp:3457
+#: src/PrefsUnifiedDlg.cpp:330 src/utils/wxCas/src/wxcasprefs.cpp:39
 msgid "Preferences"
 msgstr "Inställningar"
 
@@ -679,8 +679,8 @@ msgstr "Kad: Av"
 #: src/amuleDlg.cpp:1029 src/DownloadListCtrl.cpp:505
 #: src/DownloadListCtrl.cpp:749 src/FriendListCtrl.cpp:180
 #: src/muuli_wdr.cpp:731 src/muuli_wdr.cpp:782 src/muuli_wdr.cpp:846
-#: src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2231 src/muuli_wdr.cpp:2316
-#: src/muuli_wdr.cpp:3064 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
+#: src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2262 src/muuli_wdr.cpp:2347
+#: src/muuli_wdr.cpp:3095 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
 #: src/ServerListCtrl.cpp:606 src/TransferWnd.cpp:378
 #: src/utils/wxCas/src/wxcasprefs.cpp:235
 msgid "Cancel"
@@ -691,7 +691,7 @@ msgid "Stop the current connection attempts"
 msgstr "Stoppa de nuvarande anslutningsförsöken"
 
 #: src/amuleDlg.cpp:1035 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976
-#: src/muuli_wdr.cpp:2454
+#: src/muuli_wdr.cpp:2485
 msgid "Disconnect"
 msgstr "Koppla från"
 
@@ -700,7 +700,7 @@ msgid "Disconnect from the currently connected networks"
 msgstr "Koppla från de nätverk som nu är anslutna."
 
 #: src/amuleDlg.cpp:1041 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979
-#: src/muuli_wdr.cpp:2609 src/muuli_wdr.cpp:3061 src/muuli_wdr.cpp:3416
+#: src/muuli_wdr.cpp:2640 src/muuli_wdr.cpp:3092 src/muuli_wdr.cpp:3447
 msgid "Connect"
 msgstr "Anslut"
 
@@ -755,7 +755,7 @@ msgstr "Bekräfta avslutning"
 msgid "Launch Command: "
 msgstr "Kör kommando:"
 
-#: src/amuleDlg.cpp:1632 src/muuli_wdr.cpp:1978 src/Preferences.cpp:952
+#: src/amuleDlg.cpp:1632 src/muuli_wdr.cpp:1982 src/Preferences.cpp:979
 msgid "- default -"
 msgstr "- standard -"
 
@@ -769,48 +769,48 @@ msgstr "Skin-mappen '%s' finns inte"
 msgid "WARNING: Unable to open skin file '%s' for read"
 msgstr "Varning: Kan inte öppna skin-filen '%s' för läsning"
 
-#: src/amuleDlg.cpp:1791 src/muuli_wdr.cpp:3418
+#: src/amuleDlg.cpp:1791 src/muuli_wdr.cpp:3449
 msgid "Networks Window"
 msgstr "Nätverksfönster"
 
-#: src/amuleDlg.cpp:1797 src/muuli_wdr.cpp:3419
+#: src/amuleDlg.cpp:1797 src/muuli_wdr.cpp:3450
 msgid "Searches Window"
 msgstr "Sökfönster"
 
-#: src/amuleDlg.cpp:1803 src/muuli_wdr.cpp:3420
+#: src/amuleDlg.cpp:1803 src/muuli_wdr.cpp:3451
 msgid "Downloads Window"
 msgstr "Hämtningsfönster"
 
-#: src/amuleDlg.cpp:1809 src/muuli_wdr.cpp:3422
+#: src/amuleDlg.cpp:1809 src/muuli_wdr.cpp:3453
 msgid "Shared Files Window"
 msgstr "Delade filer-fönster"
 
-#: src/amuleDlg.cpp:1815 src/muuli_wdr.cpp:3423
+#: src/amuleDlg.cpp:1815 src/muuli_wdr.cpp:3454
 msgid "Messages Window"
 msgstr "Meddelandefönster"
 
-#: src/amuleDlg.cpp:1821 src/muuli_wdr.cpp:3424
+#: src/amuleDlg.cpp:1821 src/muuli_wdr.cpp:3455
 msgid "Statistics Graph Window"
 msgstr "Statistiksgrafsfönster"
 
-#: src/amuleDlg.cpp:1828 src/muuli_wdr.cpp:3426
+#: src/amuleDlg.cpp:1828 src/muuli_wdr.cpp:3457
 msgid "Preferences Settings Window"
 msgstr "Inställningsfönster"
 
-#: src/amuleDlg.cpp:1831 src/muuli_wdr.cpp:3427
+#: src/amuleDlg.cpp:1831 src/muuli_wdr.cpp:3458
 msgid "Import"
 msgstr "Importera"
 
-#: src/amuleDlg.cpp:1835 src/muuli_wdr.cpp:3427
+#: src/amuleDlg.cpp:1835 src/muuli_wdr.cpp:3458
 msgid "The partfile importer tool"
 msgstr "Partfile-importerings-verktyget"
 
-#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3428
+#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3459
 #: src/utils/aLinkCreator/src/alcframe.cpp:262
 msgid "About"
 msgstr "Om"
 
-#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3428
+#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3459
 msgid "About/Help"
 msgstr "Om/Hjälp"
 
@@ -952,7 +952,7 @@ msgstr "Filen hittades inte."
 msgid "The core rejected these shared folders:%s"
 msgstr ""
 
-#: src/amule-remote-gui.cpp:1336 src/ExternalConn.cpp:2345
+#: src/amule-remote-gui.cpp:1336 src/ExternalConn.cpp:2346
 msgid "Invalid link or already on list."
 msgstr "Felaktig länk eller redan i listan."
 
@@ -968,7 +968,7 @@ msgstr "Kan inte skapa mappen '%s' för kategori '%s', behåller mappen '%s'."
 #: src/ClientDetailDialog.cpp:123 src/DataToText.cpp:61 src/DataToText.cpp:86
 #: src/DataToText.cpp:101 src/DataToText.cpp:136 src/DataToText.cpp:165
 #: src/DownloadListCtrl.cpp:1172 src/DownloadListCtrl.cpp:1185
-#: src/DownloadListCtrl.cpp:1196 src/ExternalConn.cpp:608
+#: src/DownloadListCtrl.cpp:1196 src/ExternalConn.cpp:609
 #: src/FileDetailDialog.cpp:203 src/FileDetailDialog.cpp:235
 #: src/FileDetailDialog.cpp:242 src/GenericClientListCtrl.cpp:1171
 #: src/GenericClientListCtrl.cpp:1182 src/GenericClientListCtrl.cpp:1192
@@ -1355,19 +1355,19 @@ msgstr "Auto [Hö]"
 msgid "Very low"
 msgstr "Mycket låg"
 
-#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:743 src/muuli_wdr.cpp:2282
+#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:743 src/muuli_wdr.cpp:2313
 #: src/ServerListCtrl.cpp:263 src/ServerListCtrl.cpp:456
 #: src/SharedFilesCtrl.cpp:145
 msgid "Low"
 msgstr "Låg"
 
-#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:744 src/muuli_wdr.cpp:2283
+#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:744 src/muuli_wdr.cpp:2314
 #: src/ServerListCtrl.cpp:266 src/ServerListCtrl.cpp:457
 #: src/SharedFilesCtrl.cpp:146
 msgid "Normal"
 msgstr "Normal"
 
-#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:745 src/muuli_wdr.cpp:2284
+#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:745 src/muuli_wdr.cpp:2315
 #: src/ServerListCtrl.cpp:269 src/ServerListCtrl.cpp:458
 #: src/SharedFilesCtrl.cpp:147
 msgid "High"
@@ -1459,7 +1459,7 @@ msgstr "Lokal server"
 msgid "Remote Server"
 msgstr "Fjärrserver"
 
-#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3181
+#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3212
 #: src/SearchDlg.cpp:119 src/TextClient.cpp:911
 msgid "Kad"
 msgstr "Kad"
@@ -1531,7 +1531,7 @@ msgstr "Del"
 msgid "Size"
 msgstr "Storlek"
 
-#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3248
+#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3279
 msgid "Transferred"
 msgstr "Överfört"
 
@@ -1589,7 +1589,7 @@ msgstr ""
 "Återkoppling från: %s (%s)\n"
 "\n"
 
-#: src/DownloadListCtrl.cpp:746 src/muuli_wdr.cpp:2285
+#: src/DownloadListCtrl.cpp:746 src/muuli_wdr.cpp:2316
 #: src/SharedFilesCtrl.cpp:150
 msgid "Auto"
 msgstr "Auto"
@@ -1627,7 +1627,7 @@ msgid "Extended Options"
 msgstr "Utökade inställningar"
 
 #: src/DownloadListCtrl.cpp:770 src/DownloadListCtrl.cpp:822
-#: src/muuli_wdr.cpp:1796
+#: src/muuli_wdr.cpp:1800
 msgid "Preview"
 msgstr "Förhandsgranska"
 
@@ -1802,227 +1802,232 @@ msgstr[1] ""
 msgid "Invalid eD2k link! ERROR: %s"
 msgstr "Felaktig eD2k-länk! FEL: %s"
 
-#: src/ExternalConn.cpp:379
+#: src/ExternalConn.cpp:380
 msgid "Client sent packet after authentication failed."
 msgstr "Klienten skickade paket efter att autentisering misslyckades. "
 
-#: src/ExternalConn.cpp:396
+#: src/ExternalConn.cpp:397
 msgid "External connection closed."
 msgstr "Extern anslutning stängd."
 
-#: src/ExternalConn.cpp:473
+#: src/ExternalConn.cpp:474
 msgid "External connections disabled due to empty password!"
 msgstr "Externa anslutningar inaktiverade pga. tomt lösenord!"
 
-#: src/ExternalConn.cpp:494
+#: src/ExternalConn.cpp:495
 msgid "External connections disabled in config file"
 msgstr "Externa anslutningar inaktiverade i konfigfilen"
 
-#: src/ExternalConn.cpp:575
+#: src/ExternalConn.cpp:576
 msgid "New external connection accepted"
 msgstr "Ny extern anslutning accepterad"
 
-#: src/ExternalConn.cpp:578
+#: src/ExternalConn.cpp:579
 msgid "ERROR: couldn't accept a new external connection"
 msgstr "FEL: Kunde inte acceptera ny extern anslutning"
 
-#: src/ExternalConn.cpp:595
+#: src/ExternalConn.cpp:596
 msgid "External connection refused due to empty password in preferences!"
 msgstr "Extern anslutning nekad pga. tomt lösenord i inställningarna!"
 
-#: src/ExternalConn.cpp:607
+#: src/ExternalConn.cpp:608
 #, c-format
 msgid "Connecting client: %s %s"
 msgstr "Ansluter klient: %s %s"
 
-#: src/ExternalConn.cpp:609
+#: src/ExternalConn.cpp:610
 msgid "Unknown version"
 msgstr "Okänd version"
 
-#: src/ExternalConn.cpp:622
+#: src/ExternalConn.cpp:623
 msgid "Incorrect EC version ID, there might be binary incompatibility. Use core and remote from same snapshot."
 msgstr "Fel EC-versions-ID, kanske är det inkompatibla binärfiler. Använd core och remote från samma snapshot."
 
-#: src/ExternalConn.cpp:630
+#: src/ExternalConn.cpp:631
 msgid "You cannot connect to a release version from an arbitrary development snapshot! *sigh* possible crash prevented"
 msgstr "Du kan inte ansluta en release-version från en godtycklig utvecklings-snapshot! *suck* Trolig krasch förhindrad "
 
-#: src/ExternalConn.cpp:713
+#: src/ExternalConn.cpp:714
 msgid "Invalid protocol version."
 msgstr "Fel protokoll-version"
 
-#: src/ExternalConn.cpp:719
+#: src/ExternalConn.cpp:720
 msgid "Missing protocol version tag."
 msgstr "Saknar tag för protokoll-version"
 
-#: src/ExternalConn.cpp:727
+#: src/ExternalConn.cpp:728
 msgid "Authentication failed: invalid hash specified as EC password."
 msgstr "Autentisering misslyckades: fel hash specificerad som EC-lösenord"
 
-#: src/ExternalConn.cpp:775
+#: src/ExternalConn.cpp:776
 msgid "Authentication failed: wrong password."
 msgstr "Autentisering misslyckades: fel lösenord"
 
-#: src/ExternalConn.cpp:777
+#: src/ExternalConn.cpp:778
 msgid "Authentication failed: missing password."
 msgstr "Autentisering misslyckades: saknar lösenord"
 
-#: src/ExternalConn.cpp:788
+#: src/ExternalConn.cpp:789
 msgid "Invalid request, please authenticate first."
 msgstr "Felaktig begäran, vänligen autentisera först."
 
-#: src/ExternalConn.cpp:793
+#: src/ExternalConn.cpp:794
 msgid "Access granted."
 msgstr "Tillgång beviljad."
 
-#: src/ExternalConn.cpp:801
+#: src/ExternalConn.cpp:802
 #, c-format
 msgid "Sent error message \"%s\" to client."
 msgstr "Skickade felmeddelandet \"%s\" till klienten."
 
-#: src/ExternalConn.cpp:806
+#: src/ExternalConn.cpp:807
 #, c-format
 msgid "Unauthorized access attempt from %s. Connection closed."
 msgstr "Obehörigt åtkomstförsök från %s. Anslutning stängd."
 
-#: src/ExternalConn.cpp:1419
+#: src/ExternalConn.cpp:1420
 #, c-format
 msgid "Remote PartFile command failed: FileHash not found: %s"
 msgstr "Extern PartFile kommando misslyckades: FileHash hittades inte: %s"
 
-#: src/ExternalConn.cpp:1423
+#: src/ExternalConn.cpp:1424
 #, c-format
 msgid "FileHash not found: %s"
 msgstr "FileHash hittades inte: %s"
 
-#: src/ExternalConn.cpp:1470 src/ExternalConn.cpp:1558
-#: src/ExternalConn.cpp:1679
+#: src/ExternalConn.cpp:1471 src/ExternalConn.cpp:1559
+#: src/ExternalConn.cpp:1680
 msgid "OOPS! OpCode processing error!"
 msgstr "HOPPSAN!  OpCode-bearbetningsfel!"
 
-#: src/ExternalConn.cpp:1501
+#: src/ExternalConn.cpp:1502
 msgid "Server not added"
 msgstr "Server inte inlaggd"
 
-#: src/ExternalConn.cpp:1520
+#: src/ExternalConn.cpp:1521
 #, c-format
 msgid "server not found: %s"
 msgstr "server inte hittad: %s"
 
-#: src/ExternalConn.cpp:1537
+#: src/ExternalConn.cpp:1538
 msgid "need to define server to be removed"
 msgstr "måste definiera server som ska tas bort"
 
-#: src/ExternalConn.cpp:1552
+#: src/ExternalConn.cpp:1553
 msgid "eD2k is disabled in preferences."
 msgstr "eD2k är inaktiverad i inställningarna."
 
-#: src/ExternalConn.cpp:1657
+#: src/ExternalConn.cpp:1658
 #, fuzzy
 msgid "Friend not found."
 msgstr "Filen hittades inte."
 
-#: src/ExternalConn.cpp:1667
+#: src/ExternalConn.cpp:1668
 #, fuzzy
 msgid "Client not found."
 msgstr "Filen hittades inte."
 
-#: src/ExternalConn.cpp:1673
+#: src/ExternalConn.cpp:1674
 msgid "EC_TAG_FRIEND_SHARED requires EC_TAG_FRIEND or EC_TAG_CLIENT."
 msgstr ""
 
-#: src/ExternalConn.cpp:1991
+#: src/ExternalConn.cpp:1992
 msgid "WebSearch from remote interface makes no sense."
 msgstr "Websök från fjärrgränssnitt är meningslöst."
 
-#: src/ExternalConn.cpp:2026
+#: src/ExternalConn.cpp:2027
 msgid "Search in progress. Refetch results in a moment!"
 msgstr "Sök pågår. Visar snart svaren!"
 
-#: src/ExternalConn.cpp:2265
+#: src/ExternalConn.cpp:2266
 msgid "No points for graph."
 msgstr "Inga poäng för graf."
 
-#: src/ExternalConn.cpp:2275
+#: src/ExternalConn.cpp:2276
 msgid "Your client is not configured for this detail level."
 msgstr "Din klient är inte konfigurerad för denna detaljnivå."
 
-#: src/ExternalConn.cpp:2302
+#: src/ExternalConn.cpp:2303
 msgid "External Connection: shutdown requested"
 msgstr "Extern Anslutning: avstängning begärd"
 
-#: src/ExternalConn.cpp:2314
+#: src/ExternalConn.cpp:2315
 msgid "Already shutting down."
 msgstr "Håller redan på att stänga ner."
 
-#: src/ExternalConn.cpp:2332
+#: src/ExternalConn.cpp:2333
 #, c-format
 msgid "ExternalConn: adding link '%s'."
 msgstr "ExternalConn: lägger till länk '%s'."
 
-#: src/ExternalConn.cpp:2350
+#: src/ExternalConn.cpp:2351
 #, fuzzy, c-format
 msgid "%d of %d links failed (invalid or already on list)."
 msgstr "Felaktig länk eller redan i listan."
 
-#: src/ExternalConn.cpp:2373
+#: src/ExternalConn.cpp:2374
 msgid "Version check throttled; try again shortly."
 msgstr ""
 
-#: src/ExternalConn.cpp:2378
+#: src/ExternalConn.cpp:2379
 msgid "Version check is not available on this daemon."
 msgstr ""
 
-#: src/ExternalConn.cpp:2508
+#: src/ExternalConn.cpp:2509
 msgid "File not found."
 msgstr "Filen hittades inte."
 
-#: src/ExternalConn.cpp:2513
+#: src/ExternalConn.cpp:2514
 msgid "Invalid file name."
 msgstr "Ogiltigt filnamn."
 
-#: src/ExternalConn.cpp:2521
+#: src/ExternalConn.cpp:2522
 msgid "Unable to rename file."
 msgstr "Kunde inte byta namn på fil."
 
-#: src/ExternalConn.cpp:2992 src/ExternalConn.cpp:3020
+#: src/ExternalConn.cpp:2839
+#, c-format
+msgid "Could not save the amuleapi password: %s"
+msgstr ""
+
+#: src/ExternalConn.cpp:3004 src/ExternalConn.cpp:3032
 msgid "Kad is disabled in preferences."
 msgstr "Kad inaktiverad i inställningarna."
 
-#: src/ExternalConn.cpp:3033
+#: src/ExternalConn.cpp:3045
 msgid "Already connected to eD2k."
 msgstr "Redan ansluten till eD2k."
 
-#: src/ExternalConn.cpp:3036
+#: src/ExternalConn.cpp:3048
 msgid "Connecting to eD2k..."
 msgstr "Ansluter till eD2k..."
 
-#: src/ExternalConn.cpp:3045
+#: src/ExternalConn.cpp:3057
 msgid "Already connected to Kad."
 msgstr "Redan ansluten till Kad."
 
-#: src/ExternalConn.cpp:3048
+#: src/ExternalConn.cpp:3060
 msgid "Connecting to Kad..."
 msgstr "Ansluter till Kad..."
 
-#: src/ExternalConn.cpp:3055
+#: src/ExternalConn.cpp:3067
 msgid "All networks are disabled."
 msgstr "Alla nätverk är inaktiverade."
 
-#: src/ExternalConn.cpp:3064
+#: src/ExternalConn.cpp:3076
 msgid "Disconnected from eD2k."
 msgstr "Koppla ifrån eD2k."
 
-#: src/ExternalConn.cpp:3069
+#: src/ExternalConn.cpp:3081
 msgid "Disconnected from Kad."
 msgstr "Frånkopplad från Kad."
 
-#: src/ExternalConn.cpp:3078
+#: src/ExternalConn.cpp:3090
 #, c-format
 msgid "External Connection: invalid opcode received: %#x"
 msgstr "Extern anlutning: Felaktig opcode mottagen: %#x"
 
-#: src/ExternalConn.cpp:3083
+#: src/ExternalConn.cpp:3095
 msgid "Invalid opcode (wrong protocol version?)"
 msgstr "Felaktig opcode (fel protokollversion?)"
 
@@ -2423,23 +2428,23 @@ msgid ""
 "want downloads on a different (e.g. larger) disk."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:549 src/FirstRunWizard.cpp:611 src/muuli_wdr.cpp:1708
+#: src/FirstRunWizard.cpp:549 src/FirstRunWizard.cpp:611 src/muuli_wdr.cpp:1712
 msgid "Destination folder for downloads"
 msgstr "Målmapp för hämtningar"
 
 #: src/FirstRunWizard.cpp:553 src/FirstRunWizard.cpp:569 src/muuli_wdr.cpp:1349
-#: src/muuli_wdr.cpp:1366 src/muuli_wdr.cpp:1683 src/muuli_wdr.cpp:1714
-#: src/muuli_wdr.cpp:1726 src/muuli_wdr.cpp:2769
+#: src/muuli_wdr.cpp:1366 src/muuli_wdr.cpp:1687 src/muuli_wdr.cpp:1718
+#: src/muuli_wdr.cpp:1730 src/muuli_wdr.cpp:2800
 #: src/utils/aLinkCreator/src/alcframe.cpp:135
 #: src/utils/wxCas/src/wxcasprefs.cpp:52 src/utils/wxCas/src/wxcasprefs.cpp:118
 msgid "Browse"
 msgstr "Bläddra"
 
-#: src/FirstRunWizard.cpp:559 src/muuli_wdr.cpp:1719
+#: src/FirstRunWizard.cpp:559 src/muuli_wdr.cpp:1723
 msgid "(All files in this folder are shared with other peers)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:565 src/FirstRunWizard.cpp:624 src/muuli_wdr.cpp:1721
+#: src/FirstRunWizard.cpp:565 src/FirstRunWizard.cpp:624 src/muuli_wdr.cpp:1725
 msgid "Folder for temporary download files"
 msgstr "Mapp för temporära nerladdningsfiler"
 
@@ -2470,7 +2475,7 @@ msgstr "Kunde inte öppna vän-list-filen 'emfriends.met' för skrivning!"
 msgid "CRITICAL - no client on StartChatSession"
 msgstr "KRITISKT - ingen klient för StartChatSession"
 
-#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2675 src/muuli_wdr.cpp:3352
+#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2706 src/muuli_wdr.cpp:3383
 msgid "Friends"
 msgstr "Vänner"
 
@@ -2581,8 +2586,8 @@ msgstr "Ingen"
 msgid "No"
 msgstr "Nej"
 
-#: src/GenericClientListCtrl.cpp:1216 src/PrefsUnifiedDlg.cpp:2818
-#: src/PrefsUnifiedDlg.cpp:2868 src/ServerListCtrl.cpp:276
+#: src/GenericClientListCtrl.cpp:1216 src/PrefsUnifiedDlg.cpp:2898
+#: src/PrefsUnifiedDlg.cpp:2948 src/ServerListCtrl.cpp:276
 msgid "Yes"
 msgstr "Ja"
 
@@ -2751,10 +2756,10 @@ msgstr "Ogiltig port till bootstrap"
 msgid "Please fill all fields required"
 msgstr "Fyll i alla fält som krävs"
 
-#: src/KadDlg.cpp:192 src/PartFile.cpp:1031 src/PrefsUnifiedDlg.cpp:1162
-#: src/PrefsUnifiedDlg.cpp:1331 src/PrefsUnifiedDlg.cpp:1589
-#: src/PrefsUnifiedDlg.cpp:1599 src/PrefsUnifiedDlg.cpp:1616
-#: src/PrefsUnifiedDlg.cpp:1658
+#: src/KadDlg.cpp:192 src/PartFile.cpp:1031 src/PrefsUnifiedDlg.cpp:1134
+#: src/PrefsUnifiedDlg.cpp:1204 src/PrefsUnifiedDlg.cpp:1405
+#: src/PrefsUnifiedDlg.cpp:1663 src/PrefsUnifiedDlg.cpp:1673
+#: src/PrefsUnifiedDlg.cpp:1690 src/PrefsUnifiedDlg.cpp:1738
 msgid "Message"
 msgstr "Meddelande"
 
@@ -2856,7 +2861,7 @@ msgstr "Dela-förhållande"
 msgid "Uploaded"
 msgstr "Uppladdad"
 
-#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3232
+#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3263
 msgid "Requested"
 msgstr "Begärda"
 
@@ -2980,7 +2985,7 @@ msgid "WARNING: "
 msgstr "VARNING: "
 
 #: src/MuleNotebook.cpp:179 src/muuli_wdr.cpp:817 src/muuli_wdr.cpp:1229
-#: src/muuli_wdr.cpp:3136 src/muuli_wdr.cpp:3392
+#: src/muuli_wdr.cpp:3167 src/muuli_wdr.cpp:3423
 msgid "Close"
 msgstr "Stäng"
 
@@ -2998,7 +3003,7 @@ msgid "Paste"
 msgstr "Klistra in"
 
 #: src/MuleTextCtrl.cpp:89 src/muuli_wdr.cpp:358 src/muuli_wdr.cpp:757
-#: src/muuli_wdr.cpp:2359 src/muuli_wdr.cpp:2378 src/muuli_wdr.cpp:2400
+#: src/muuli_wdr.cpp:2390 src/muuli_wdr.cpp:2409 src/muuli_wdr.cpp:2431
 #: src/utils/aLinkCreator/src/alcframe.cpp:142
 msgid "Clear"
 msgstr "Töm"
@@ -3097,7 +3102,7 @@ msgstr "Avsluta"
 
 #: src/MuleTrayIcon.cpp:579 src/MuleTrayIcon.cpp:945 src/MuleTrayIcon.cpp:965
 #: src/muuli_wdr.cpp:1398 src/muuli_wdr.cpp:1406 src/muuli_wdr.cpp:1413
-#: src/muuli_wdr.cpp:1842 src/muuli_wdr.cpp:1848 src/OtherFunctions.cpp:91
+#: src/muuli_wdr.cpp:1846 src/muuli_wdr.cpp:1852 src/OtherFunctions.cpp:91
 #: src/StatisticsDlg.cpp:93 src/StatisticsDlg.cpp:95
 msgid "kB/s"
 msgstr "kB/s"
@@ -3339,7 +3344,7 @@ msgstr "Bytes"
 msgid "KB"
 msgstr "KB"
 
-#: src/muuli_wdr.cpp:274 src/muuli_wdr.cpp:293 src/muuli_wdr.cpp:1627
+#: src/muuli_wdr.cpp:274 src/muuli_wdr.cpp:293 src/muuli_wdr.cpp:1631
 #: src/OtherFunctions.cpp:64
 msgid "MB"
 msgstr "MB"
@@ -3356,7 +3361,7 @@ msgstr "Max storlek"
 msgid "Availability"
 msgstr "Tillgänglighet"
 
-#: src/muuli_wdr.cpp:312 src/muuli_wdr.cpp:398 src/muuli_wdr.cpp:3297
+#: src/muuli_wdr.cpp:312 src/muuli_wdr.cpp:398 src/muuli_wdr.cpp:3328
 msgid "Filter:"
 msgstr "Filter:"
 
@@ -3419,12 +3424,12 @@ msgstr "Filkällor:"
 #: src/muuli_wdr.cpp:1160 src/muuli_wdr.cpp:1167 src/muuli_wdr.cpp:1172
 #: src/muuli_wdr.cpp:1179 src/muuli_wdr.cpp:1184 src/muuli_wdr.cpp:1191
 #: src/muuli_wdr.cpp:1205 src/muuli_wdr.cpp:1212 src/muuli_wdr.cpp:1217
-#: src/muuli_wdr.cpp:1224 src/muuli_wdr.cpp:3234 src/muuli_wdr.cpp:3242
-#: src/muuli_wdr.cpp:3250
+#: src/muuli_wdr.cpp:1224 src/muuli_wdr.cpp:3265 src/muuli_wdr.cpp:3273
+#: src/muuli_wdr.cpp:3281
 msgid "N/A"
 msgstr "N/A"
 
-#: src/muuli_wdr.cpp:508 src/muuli_wdr.cpp:1065 src/PrefsUnifiedDlg.cpp:297
+#: src/muuli_wdr.cpp:508 src/muuli_wdr.cpp:1065 src/PrefsUnifiedDlg.cpp:299
 msgid "General"
 msgstr "Allmänt"
 
@@ -3565,7 +3570,7 @@ msgstr ""
 msgid "Album :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:685 src/muuli_wdr.cpp:2254
+#: src/muuli_wdr.cpp:685 src/muuli_wdr.cpp:2285
 msgid "Title :"
 msgstr "Titel :"
 
@@ -3674,7 +3679,7 @@ msgstr "Användarnamn :"
 msgid "Userhash :"
 msgstr "Userhash:"
 
-#: src/muuli_wdr.cpp:895 src/muuli_wdr.cpp:1748 src/muuli_wdr.cpp:2449
+#: src/muuli_wdr.cpp:895 src/muuli_wdr.cpp:1752 src/muuli_wdr.cpp:2480
 #: src/utils/aLinkCreator/src/alcframe.cpp:137
 msgid "Add"
 msgstr "Lägg till"
@@ -3683,15 +3688,15 @@ msgstr "Lägg till"
 msgid "Download-Speed"
 msgstr "Nedladdningshastighet"
 
-#: src/muuli_wdr.cpp:954 src/muuli_wdr.cpp:989 src/muuli_wdr.cpp:2553
+#: src/muuli_wdr.cpp:954 src/muuli_wdr.cpp:989 src/muuli_wdr.cpp:2584
 msgid "Current"
 msgstr "Aktuell"
 
-#: src/muuli_wdr.cpp:962 src/muuli_wdr.cpp:997 src/muuli_wdr.cpp:2561
+#: src/muuli_wdr.cpp:962 src/muuli_wdr.cpp:997 src/muuli_wdr.cpp:2592
 msgid "Running average"
 msgstr "Löpande medelvärde"
 
-#: src/muuli_wdr.cpp:970 src/muuli_wdr.cpp:1005 src/muuli_wdr.cpp:2569
+#: src/muuli_wdr.cpp:970 src/muuli_wdr.cpp:1005 src/muuli_wdr.cpp:2600
 msgid "Session average"
 msgstr "Sessionens genomsnittliga"
 
@@ -3703,7 +3708,7 @@ msgstr "Uppladdningshastighet"
 msgid "Connections"
 msgstr "Anslutningar"
 
-#: src/muuli_wdr.cpp:1024 src/muuli_wdr.cpp:1867
+#: src/muuli_wdr.cpp:1024 src/muuli_wdr.cpp:1871
 msgid "Active downloads"
 msgstr "Aktiva hämtningar"
 
@@ -3711,7 +3716,7 @@ msgstr "Aktiva hämtningar"
 msgid "Active connections (1:1)"
 msgstr "Aktiva anslutningar (1:1)"
 
-#: src/muuli_wdr.cpp:1040 src/muuli_wdr.cpp:1868
+#: src/muuli_wdr.cpp:1040 src/muuli_wdr.cpp:1872
 msgid "Active uploads"
 msgstr "Aktiva uppladdningar"
 
@@ -3987,7 +3992,7 @@ msgstr "Bind lokal adress till IP (tom för alla):"
 msgid "Advanced users only: If you have multiple network interfaces, enter the address of the interface to which aMule should be bound."
 msgstr "Endast avancerade användare: Om du har flera nätverksgränssnitt, ange adressen för gränssnittet till vilket aMule ska bindas."
 
-#: src/muuli_wdr.cpp:1462 src/muuli_wdr.cpp:2061
+#: src/muuli_wdr.cpp:1462 src/muuli_wdr.cpp:2065
 #, fuzzy
 msgid "Bind to network interface (empty for any):"
 msgstr "Bind lokal adress till IP (tom för alla):"
@@ -4004,7 +4009,7 @@ msgstr "Max källor per hämtad fil:"
 msgid "Max simultaneous connections:"
 msgstr "Max samtidiga anslutningar:"
 
-#: src/muuli_wdr.cpp:1498 src/muuli_wdr.cpp:3176
+#: src/muuli_wdr.cpp:1498 src/muuli_wdr.cpp:3207
 msgid "ED2K"
 msgstr "ED2K"
 
@@ -4096,755 +4101,778 @@ msgstr "Förallokera diskutrymme för nya filer"
 msgid "For new files preallocates disk space for the whole file, thus reduces fragmentation"
 msgstr "För nya filer förallokeras diskutrymme för hela filen, detta minskar fragmentering"
 
-#: src/muuli_wdr.cpp:1613
+#: src/muuli_wdr.cpp:1617
 msgid "Create new files as sparse files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1614
-msgid "A sparse file reserves its full size on disk immediately without writing real data to it -- fast, but unsupported or slow on some filesystems, and free-space accounting stays optimistic while the download is in progress. Turn this off to grow the file only as data arrives."
+#: src/muuli_wdr.cpp:1618
+msgid "Sparse part files only occupy disk space for the parts already downloaded, so free space is used up gradually as the file fills in. Turn this off to use an ordinary file instead - useful where sparse files are unsupported or slow, or where backup/de-duplication tools handle them badly. Applies only when the core runs on Windows; on Linux and macOS part files are sparse anyway and this setting has no effect."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1619
+#: src/muuli_wdr.cpp:1623
 msgid "Stop downloads when free disk space reaches "
 msgstr "Stoppa nedladdningar när ledigt diskutrymme når "
 
-#: src/muuli_wdr.cpp:1620
+#: src/muuli_wdr.cpp:1624
 msgid "Select this if you want aMule to check your disk space"
 msgstr "Välj detta om du vill aMule att kontrollera diskutrymmet"
 
-#: src/muuli_wdr.cpp:1624
+#: src/muuli_wdr.cpp:1628
 msgid "Enter here the min disk space desired."
 msgstr "Ange här min diskutrymme."
 
-#: src/muuli_wdr.cpp:1630
+#: src/muuli_wdr.cpp:1634
 msgid "Save 10 sources on rare files (< 20 sources)"
 msgstr "Spara 10 källor för sällsynta filer (<20 källor)"
 
-#: src/muuli_wdr.cpp:1634 src/Statistics.cpp:790
+#: src/muuli_wdr.cpp:1638 src/Statistics.cpp:790
 msgid "Uploads"
 msgstr "Uppladdningar"
 
-#: src/muuli_wdr.cpp:1637
+#: src/muuli_wdr.cpp:1641
 msgid "Add new shared files with auto priority"
 msgstr "Lägg till nya delade filer med automatisk prioritet"
 
-#: src/muuli_wdr.cpp:1643
+#: src/muuli_wdr.cpp:1647
 msgid "Intelligent Corruption Handling (I.C.H.)"
 msgstr "Intelligent Corruption Handling (I.C.H.)"
 
-#: src/muuli_wdr.cpp:1646
+#: src/muuli_wdr.cpp:1650
 msgid "Enable"
 msgstr "Aktivera"
 
-#: src/muuli_wdr.cpp:1649
+#: src/muuli_wdr.cpp:1653
 msgid "Advanced I.C.H. trusts every hash (not recommended)"
 msgstr "Avancerad I.C.H. litar på varje hash (rekommenderas inte)"
 
-#: src/muuli_wdr.cpp:1661 src/PrefsUnifiedDlg.cpp:1910
+#: src/muuli_wdr.cpp:1665 src/PrefsUnifiedDlg.cpp:1990
 msgid "Media metadata extraction"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1665
+#: src/muuli_wdr.cpp:1669
 msgid "Extract length / bitrate / codec from shared audio and video files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1667
+#: src/muuli_wdr.cpp:1671
 msgid "When enabled, aMule runs ffprobe on each shared media file to fill in the Length / Bitrate / Codec columns other clients see when they find the file in a search. Requires ffmpeg (the ffprobe binary) to be installed."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1674
+#: src/muuli_wdr.cpp:1678
 msgid "Path to ffprobe:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1679
+#: src/muuli_wdr.cpp:1683
 msgid "Full path to the ffprobe binary. Leave empty to have aMule auto-detect it on startup."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1687
+#: src/muuli_wdr.cpp:1691
 msgid "Detect"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1688
+#: src/muuli_wdr.cpp:1692
 msgid "Search the standard install locations for an ffprobe binary and fill the path field."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1712
+#: src/muuli_wdr.cpp:1716
 msgid ""
 "Completed downloads are stored here. All files in this folder are automatically shared with other peers.\n"
 "If this folder also holds files you don't want to share, point it at an aMule-only sub-folder."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1715
+#: src/muuli_wdr.cpp:1719
 msgid "Pick the folder where completed downloads will be stored. All files in that folder will be shared with other peers."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1729
+#: src/muuli_wdr.cpp:1733
 msgid "Shared folders"
 msgstr "Delade mappar"
 
-#: src/muuli_wdr.cpp:1735
+#: src/muuli_wdr.cpp:1739
 msgid "(Folders shared by the core. Enter a path to add one.)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1743
+#: src/muuli_wdr.cpp:1747
 msgid "Absolute path of a folder on the core's machine, e.g. /home/user/shared"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1745 src/PrefsUnifiedDlg.cpp:2794
+#: src/muuli_wdr.cpp:1749 src/PrefsUnifiedDlg.cpp:2874
 msgid "Recursive"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1746
+#: src/muuli_wdr.cpp:1750
 msgid "Share every sub-folder underneath this one, including ones created later."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1750 src/utils/aLinkCreator/src/alcframe.cpp:141
+#: src/muuli_wdr.cpp:1754 src/utils/aLinkCreator/src/alcframe.cpp:141
 msgid "Remove"
 msgstr "Ta bort"
 
-#: src/muuli_wdr.cpp:1754
+#: src/muuli_wdr.cpp:1758
 msgid "(Right click on folder icon for recursive share)"
 msgstr "(Högerklicka på mappikonen för rekursiv delning)"
 
-#: src/muuli_wdr.cpp:1761
+#: src/muuli_wdr.cpp:1765
 msgid "Share hidden files"
 msgstr "Dela ut dolda filer"
 
-#: src/muuli_wdr.cpp:1767
+#: src/muuli_wdr.cpp:1771
 msgid "Automatically rescan shared folders for changes"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1773
+#: src/muuli_wdr.cpp:1777
 msgid "Follow symbolic links in shared folders"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1779
+#: src/muuli_wdr.cpp:1783
 msgid "Exclude files matching:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1782
+#: src/muuli_wdr.cpp:1786
 msgid "Wildcard patterns separated by '|', e.g. .DS_Store|Thumbs.db|*.tmp. Files whose name matches are not shared. Matching is case-insensitive."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1786
+#: src/muuli_wdr.cpp:1790
 msgid "Patterns are regular expressions"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1787
+#: src/muuli_wdr.cpp:1791
 msgid "When set, the whole field is one regular expression ('|' is alternation). When unset, it is a list of '|'-separated wildcards."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1797
+#: src/muuli_wdr.cpp:1801
 msgid "Show how many shared files the current pattern would exclude."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1818
+#: src/muuli_wdr.cpp:1822
 msgid "Graphs"
 msgstr "Diagram"
 
-#: src/muuli_wdr.cpp:1821 src/muuli_wdr.cpp:1883
+#: src/muuli_wdr.cpp:1825 src/muuli_wdr.cpp:1887
 msgid "Update delay : 5 secs"
 msgstr "Uppdateringsfördröjning: 5 sekunder"
 
-#: src/muuli_wdr.cpp:1825
+#: src/muuli_wdr.cpp:1829
 msgid "Time for average graph: 100 mins"
 msgstr "Tid för genomsnittlig graf: 100 minuter"
 
-#: src/muuli_wdr.cpp:1829
+#: src/muuli_wdr.cpp:1833
 msgid "Connections Graph Scale: 100 "
 msgstr "Anslutningar Diagramskala: 100 "
 
-#: src/muuli_wdr.cpp:1836
+#: src/muuli_wdr.cpp:1840
 msgid "Download graph scale:"
 msgstr "Hämtningsgrafskala:"
 
-#: src/muuli_wdr.cpp:1844
+#: src/muuli_wdr.cpp:1848
 msgid "Upload graph scale:"
 msgstr "Uppladdningsgraf-skala:"
 
-#: src/muuli_wdr.cpp:1854
+#: src/muuli_wdr.cpp:1858
 #, fuzzy
 msgid "Colors: "
 msgstr "Färger: "
 
-#: src/muuli_wdr.cpp:1858
+#: src/muuli_wdr.cpp:1862
 msgid "Background"
 msgstr "Bakgrund"
 
-#: src/muuli_wdr.cpp:1859
+#: src/muuli_wdr.cpp:1863
 msgid "Grid"
 msgstr "Rutnät"
 
-#: src/muuli_wdr.cpp:1860
+#: src/muuli_wdr.cpp:1864
 msgid "Download current"
 msgstr "Hämtning nu"
 
-#: src/muuli_wdr.cpp:1861
+#: src/muuli_wdr.cpp:1865
 msgid "Download running average"
 msgstr "Hämtningar nu, medelvärde"
 
-#: src/muuli_wdr.cpp:1862
+#: src/muuli_wdr.cpp:1866
 msgid "Download session average"
 msgstr "Hämtningar session, genomsnittlig"
 
-#: src/muuli_wdr.cpp:1863
+#: src/muuli_wdr.cpp:1867
 msgid "Upload current"
 msgstr "Hämtningar nu"
 
-#: src/muuli_wdr.cpp:1864
+#: src/muuli_wdr.cpp:1868
 msgid "Upload running average"
 msgstr "Hämtningar nu, medelvärde"
 
-#: src/muuli_wdr.cpp:1865
+#: src/muuli_wdr.cpp:1869
 msgid "Upload session average"
 msgstr "Uppladdningsession, genomsnittlig"
 
-#: src/muuli_wdr.cpp:1866
+#: src/muuli_wdr.cpp:1870
 msgid "Active connections"
 msgstr "Aktiva anslutningar"
 
-#: src/muuli_wdr.cpp:1869
+#: src/muuli_wdr.cpp:1873
 #, fuzzy
 msgid "Systray Icon Speed Bar"
 msgstr "Systray Ikon Speedbar"
 
-#: src/muuli_wdr.cpp:1870
+#: src/muuli_wdr.cpp:1874
 msgid "Kad-nodes current"
 msgstr "Kad-noder nuvarande"
 
-#: src/muuli_wdr.cpp:1871
+#: src/muuli_wdr.cpp:1875
 msgid "Kad-nodes running"
 msgstr "Kad-noder körs"
 
-#: src/muuli_wdr.cpp:1872
+#: src/muuli_wdr.cpp:1876
 msgid "Kad-nodes session"
 msgstr "Kad-noder session"
 
-#: src/muuli_wdr.cpp:1876 src/muuli_wdr.cpp:2303
+#: src/muuli_wdr.cpp:1880 src/muuli_wdr.cpp:2334
 msgid "Select"
 msgstr "Välj"
 
-#: src/muuli_wdr.cpp:1880
+#: src/muuli_wdr.cpp:1884
 msgid "Tree"
 msgstr "Träd"
 
-#: src/muuli_wdr.cpp:1890
+#: src/muuli_wdr.cpp:1894
 msgid "Number of Client Versions shown (0=unlimited)"
 msgstr "Antal klientversioner visas (0 = obegränsat)"
 
-#: src/muuli_wdr.cpp:1915
+#: src/muuli_wdr.cpp:1919
 msgid "!!! WARNING !!!"
 msgstr "!!! VARNING !!!"
 
-#: src/muuli_wdr.cpp:1930
+#: src/muuli_wdr.cpp:1934
 msgid "Max new connections / 5 secs"
 msgstr "Max nya anslutningar / 5 sek"
 
-#: src/muuli_wdr.cpp:1932
+#: src/muuli_wdr.cpp:1936
 msgid "Concurrent Kad source lookups"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1934
+#: src/muuli_wdr.cpp:1938
 #, fuzzy
 msgid "Kad source re-search interval (minutes)"
 msgstr "FTP-uppdateringshastighetsintervall i minuter"
 
-#: src/muuli_wdr.cpp:1936
+#: src/muuli_wdr.cpp:1940
 #, fuzzy
 msgid "Source re-ask interval (minutes)"
 msgstr "FTP-uppdateringshastighetsintervall i minuter"
 
-#: src/muuli_wdr.cpp:1940
+#: src/muuli_wdr.cpp:1944
 msgid "File Buffer Size: 240000 bytes"
 msgstr "Filbuffertstorlek: 240000 bytes"
 
-#: src/muuli_wdr.cpp:1944
+#: src/muuli_wdr.cpp:1948
 msgid "Use MMAP: memory-mapped file access (lower memory use)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1945
+#: src/muuli_wdr.cpp:1949
 msgid "Maps part files into memory instead of buffering them on the heap, lowering the process memory footprint. May reduce download speed on some disks; best for memory-constrained or upload-heavy hosts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1947
+#: src/muuli_wdr.cpp:1951
 msgid "Upload Queue Size: 5000 clients"
 msgstr "Uppladdningsköstorlek: 5000 klienter"
 
-#: src/muuli_wdr.cpp:1951
+#: src/muuli_wdr.cpp:1955
 msgid "Server connection refresh interval: Disable"
 msgstr "Serveranslutningsuppdateringsintervall: Inaktivera"
 
-#: src/muuli_wdr.cpp:1955
+#: src/muuli_wdr.cpp:1959
 msgid "Disable computer's timed standby mode"
 msgstr "Inaktivera datorns inställda standby-läge"
 
-#: src/muuli_wdr.cpp:1974
+#: src/muuli_wdr.cpp:1978
 msgid "Skin to use: "
 msgstr "Skin att använda: "
 
-#: src/muuli_wdr.cpp:1983
+#: src/muuli_wdr.cpp:1987
 msgid "Show \"Fast eD2k Links Handler\" in every window."
 msgstr "Visa \"Snabb eD2k-Länkhanterare\" i varje fönster."
 
-#: src/muuli_wdr.cpp:1986
+#: src/muuli_wdr.cpp:1990
 msgid "Show extended info on categories tabs"
 msgstr "Visa utökad information på kategoriflikar"
 
-#: src/muuli_wdr.cpp:1989
+#: src/muuli_wdr.cpp:1993
 msgid "Show application version on title"
 msgstr "Visa programversionen på titel"
 
-#: src/muuli_wdr.cpp:1991
+#: src/muuli_wdr.cpp:1995
 msgid "Show transfer rates on title"
 msgstr "Visa överföringshastigheter på titel"
 
-#: src/muuli_wdr.cpp:1993
+#: src/muuli_wdr.cpp:1997
 msgid "Before application name"
 msgstr "Före programnamn"
 
-#: src/muuli_wdr.cpp:1995
+#: src/muuli_wdr.cpp:1999
 msgid "After application name"
 msgstr "Efter programnamn"
 
-#: src/muuli_wdr.cpp:1998
+#: src/muuli_wdr.cpp:2002
 msgid "Show overhead bandwidth"
 msgstr "Visa overheadsbandbredd"
 
-#: src/muuli_wdr.cpp:2002
+#: src/muuli_wdr.cpp:2006
 msgid "Vertical toolbar orientation"
 msgstr "Vertikal verktygsfältsorientering"
 
-#: src/muuli_wdr.cpp:2004
+#: src/muuli_wdr.cpp:2008
 msgid "Live column sorting (auto-reorder rows as their values change)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2011
+#: src/muuli_wdr.cpp:2015
 msgid "Download Queue Files"
 msgstr "Nedladdningsköfiler"
 
-#: src/muuli_wdr.cpp:2014
+#: src/muuli_wdr.cpp:2018
 msgid "Show progress percentage"
 msgstr "Visa framsteg i procent"
 
-#: src/muuli_wdr.cpp:2020
+#: src/muuli_wdr.cpp:2024
 msgid "Show progress bar"
 msgstr "Visa förloppsindikator"
 
-#: src/muuli_wdr.cpp:2023
+#: src/muuli_wdr.cpp:2027
 msgid "Flat"
 msgstr "Platt"
 
-#: src/muuli_wdr.cpp:2027
+#: src/muuli_wdr.cpp:2031
 msgid "Round"
 msgstr "Rund"
 
-#: src/muuli_wdr.cpp:2045
+#: src/muuli_wdr.cpp:2049
 msgid "External Connection Parameters"
 msgstr "Externa Anslutningsparametrar "
 
-#: src/muuli_wdr.cpp:2048
+#: src/muuli_wdr.cpp:2052
 msgid "Accept external connections"
 msgstr "Acceptera externa anslutningar"
 
-#: src/muuli_wdr.cpp:2055 src/muuli_wdr.cpp:2114
+#: src/muuli_wdr.cpp:2059 src/muuli_wdr.cpp:2118
 msgid "IP of the listening interface:"
 msgstr "IP för lyssningsgränssnitt:"
 
-#: src/muuli_wdr.cpp:2058
+#: src/muuli_wdr.cpp:2062
 msgid "Enter here a valid ip in the a.b.c.d format for the listening EC interface. An empty field or 0.0.0.0 will mean any interface."
 msgstr "Ange här en giltig ip i ABCD format för att lyssna EC-gränssnittet. Ett tomt fält eller 0.0.0.0 kommer att innebära alla gränssnitt."
 
-#: src/muuli_wdr.cpp:2079 src/muuli_wdr.cpp:2163
+#: src/muuli_wdr.cpp:2083 src/muuli_wdr.cpp:2194
 msgid "TCP port:"
 msgstr "TCP-port:"
 
-#: src/muuli_wdr.cpp:2085
+#: src/muuli_wdr.cpp:2089
 msgid "Enable UPnP port forwarding on the EC port"
 msgstr "Aktivera UPnP-portforwarding på EC-port"
 
-#: src/muuli_wdr.cpp:2089 src/muuli_wdr.cpp:3048
+#: src/muuli_wdr.cpp:2093 src/muuli_wdr.cpp:3079
 #: src/utils/wxCas/src/wxcasprefs.cpp:167
 msgid "Password"
 msgstr "Lösenord"
 
-#: src/muuli_wdr.cpp:2095
+#: src/muuli_wdr.cpp:2099
 #, fuzzy
 msgid "aMule API server parameters"
 msgstr "Webbserverparametrar"
 
-#: src/muuli_wdr.cpp:2098
+#: src/muuli_wdr.cpp:2102
 msgid "Run amuleapi (REST API) on startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2103
+#: src/muuli_wdr.cpp:2107
 #, fuzzy
 msgid "HTTP port:"
 msgstr "TCP-port:"
 
-#: src/muuli_wdr.cpp:2117
+#: src/muuli_wdr.cpp:2121
 msgid "The interface amuleapi's HTTP server listens on. 127.0.0.1 (default) accepts only local connections; use 0.0.0.0 or a specific IP to expose it to other hosts (set an admin password below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2120
+#: src/muuli_wdr.cpp:2126
+msgid "Type a password to set or change it. Stored passwords cannot be shown, so leaving this empty keeps the current one."
+msgstr ""
+
+#: src/muuli_wdr.cpp:2128
 #, fuzzy
 msgid "Admin password"
 msgstr "Kontrollerar lösenord\n"
 
-#: src/muuli_wdr.cpp:2125 src/muuli_wdr.cpp:2156
-msgid "Low rights password"
-msgstr "Låga rättigheterslösenord"
+#: src/muuli_wdr.cpp:2140 src/muuli_wdr.cpp:2157 src/PrefsUnifiedDlg.cpp:1103
+#, fuzzy
+msgid "A password is set."
+msgstr "Kontrollerar lösenord\n"
 
-#: src/muuli_wdr.cpp:2133
+#: src/muuli_wdr.cpp:2144
+#, fuzzy
+msgid "Enable guest access"
+msgstr "Neka gäståtkomst"
+
+#: src/muuli_wdr.cpp:2145
+msgid "Guest sessions may read status and listings but cannot change anything. Turning this off clears the stored guest password."
+msgstr ""
+
+#: src/muuli_wdr.cpp:2149
+#, fuzzy
+msgid "Guest password"
+msgstr "Gästlösenord för webbservern"
+
+#: src/muuli_wdr.cpp:2164
 msgid "Web server parameters"
 msgstr "Webbserverparametrar"
 
-#: src/muuli_wdr.cpp:2136
+#: src/muuli_wdr.cpp:2167
 #, fuzzy
 msgid "Run webserver on startup (deprecated)"
 msgstr "Kör webbserver vid start"
 
-#: src/muuli_wdr.cpp:2142
+#: src/muuli_wdr.cpp:2173
 msgid "Web template"
 msgstr "Web mall"
 
-#: src/muuli_wdr.cpp:2147
+#: src/muuli_wdr.cpp:2178
 msgid "Full rights password"
 msgstr "Fullständiga rättigheterslösenord"
 
-#: src/muuli_wdr.cpp:2151
+#: src/muuli_wdr.cpp:2182
 msgid "Enable Low rights User"
 msgstr "Aktivera låga användarrättigheter"
 
-#: src/muuli_wdr.cpp:2170
+#: src/muuli_wdr.cpp:2187
+msgid "Low rights password"
+msgstr "Låga rättigheterslösenord"
+
+#: src/muuli_wdr.cpp:2201
 msgid "Enable UPnP port forwarding of the web server port"
 msgstr "Aktivera UPnP-port-forwarding för webbserverport"
 
-#: src/muuli_wdr.cpp:2175
+#: src/muuli_wdr.cpp:2206
 msgid "Web server UPnP TCP port (Optional)"
 msgstr "Webbserverns UPnP TCP-port (tillval)"
 
-#: src/muuli_wdr.cpp:2183
+#: src/muuli_wdr.cpp:2214
 msgid "Page Refresh Time (in secs)"
 msgstr "Siduppdateringstid (i sek)"
 
-#: src/muuli_wdr.cpp:2190
+#: src/muuli_wdr.cpp:2221
 msgid "Enable Gzip compression"
 msgstr "Aktivera Gzip-komprimering"
 
-#: src/muuli_wdr.cpp:2224
+#: src/muuli_wdr.cpp:2255
 #, fuzzy
 msgid "Reset page to defaults"
 msgstr "Systemets standard"
 
-#: src/muuli_wdr.cpp:2225
+#: src/muuli_wdr.cpp:2256
 msgid "Reset the settings on the current page to their default values."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2227 src/muuli_wdr.cpp:2313 src/ServerWnd.cpp:274
+#: src/muuli_wdr.cpp:2258 src/muuli_wdr.cpp:2344 src/ServerWnd.cpp:274
 #: src/ServerWnd.cpp:282
 msgid "OK"
 msgstr "OK"
 
-#: src/muuli_wdr.cpp:2229
+#: src/muuli_wdr.cpp:2260
 msgid "Click here to apply any changes made to the preferences."
 msgstr "Klicka här för att tillämpa eventuella ändringar i inställningarna."
 
-#: src/muuli_wdr.cpp:2232
+#: src/muuli_wdr.cpp:2263
 msgid "Reset any changes made to the preferences."
 msgstr "Återställ eventuella ändringar i inställningarna."
 
-#: src/muuli_wdr.cpp:2261
+#: src/muuli_wdr.cpp:2292
 msgid "Comment :"
 msgstr "Kommentar :"
 
-#: src/muuli_wdr.cpp:2268
+#: src/muuli_wdr.cpp:2299
 msgid "Incoming Dir :"
 msgstr "Inkommande mapp:"
 
-#: src/muuli_wdr.cpp:2277
+#: src/muuli_wdr.cpp:2308
 msgid "Change priority for new assigned files :"
 msgstr "Ändra prioritet för nya tilldelade filer:"
 
-#: src/muuli_wdr.cpp:2281
+#: src/muuli_wdr.cpp:2312
 msgid "Don't change"
 msgstr "Ändra inte"
 
-#: src/muuli_wdr.cpp:2293
+#: src/muuli_wdr.cpp:2324
 msgid "Select color for this Category (currently selected) :"
 msgstr "Välj färg för denna kategori (den valda):"
 
-#: src/muuli_wdr.cpp:2360 src/muuli_wdr.cpp:2379 src/muuli_wdr.cpp:2401
+#: src/muuli_wdr.cpp:2391 src/muuli_wdr.cpp:2410 src/muuli_wdr.cpp:2432
 msgid "Click this button to reset the log."
 msgstr "Klicka på den här knappen för att återställa loggen."
 
-#: src/muuli_wdr.cpp:2420
+#: src/muuli_wdr.cpp:2451
 msgid "Click on this button to update the servers list from URL ..."
 msgstr "Klicka på knappen för att uppdatera servrerlistan från URL ..."
 
-#: src/muuli_wdr.cpp:2424
+#: src/muuli_wdr.cpp:2455
 msgid "Server list"
 msgstr "Serverlista"
 
-#: src/muuli_wdr.cpp:2428
+#: src/muuli_wdr.cpp:2459
 msgid "Enter the url to a server.met file here and press the button to the left to update the list of known servers."
 msgstr "Ange URL till en server.met-fil här och tryck på knappen till vänster för att uppdatera listan över kända servrar."
 
-#: src/muuli_wdr.cpp:2433
+#: src/muuli_wdr.cpp:2464
 msgid "Add server manually: Name"
 msgstr "Lägg till server manuellt: Namn"
 
-#: src/muuli_wdr.cpp:2436
+#: src/muuli_wdr.cpp:2467
 msgid "Enter the name of the new server here"
 msgstr "Skriv in namnet på den nya servern här"
 
-#: src/muuli_wdr.cpp:2438 src/ServerWnd.cpp:206
+#: src/muuli_wdr.cpp:2469 src/ServerWnd.cpp:206
 msgid "IP:Port"
 msgstr "IP:Port"
 
-#: src/muuli_wdr.cpp:2441
+#: src/muuli_wdr.cpp:2472
 msgid "Enter the IP of the server here, using the x.x.x.x format."
 msgstr "Ange IP på servern här, med hjälp av xxxx format."
 
-#: src/muuli_wdr.cpp:2447
+#: src/muuli_wdr.cpp:2478
 msgid "Enter the port of the server here."
 msgstr "Ange porten på servern här."
 
-#: src/muuli_wdr.cpp:2450
+#: src/muuli_wdr.cpp:2481
 msgid "Add manually a server (fill fields to the left before) ..."
 msgstr "Lägg manuellt till en server (fyll fälten till vänster innan) ..."
 
-#: src/muuli_wdr.cpp:2479
+#: src/muuli_wdr.cpp:2510
 msgid "aMule Log"
 msgstr "aMule-logg"
 
-#: src/muuli_wdr.cpp:2487
+#: src/muuli_wdr.cpp:2518
 msgid "Server Info"
 msgstr "Serverinformation"
 
-#: src/muuli_wdr.cpp:2491
+#: src/muuli_wdr.cpp:2522
 msgid "ED2K Info"
 msgstr "ED2K-info"
 
-#: src/muuli_wdr.cpp:2495
+#: src/muuli_wdr.cpp:2526
 msgid "Kad Info"
 msgstr "Kad-info"
 
-#: src/muuli_wdr.cpp:2523
+#: src/muuli_wdr.cpp:2554
 msgid "Click on this button to update the nodes list from URL ..."
 msgstr "Klicka på knappen för att uppdatera nodlistan från URL ..."
 
-#: src/muuli_wdr.cpp:2527
+#: src/muuli_wdr.cpp:2558
 msgid "Nodes (0)"
 msgstr "Noder (0)"
 
-#: src/muuli_wdr.cpp:2531
+#: src/muuli_wdr.cpp:2562
 msgid "Enter the url to a nodes.dat file here and press the button to the left to update the list of known nodes."
 msgstr "Ange URL till en nodes.dat fil här och tryck på knappen till vänster för att uppdatera listan över kända noder."
 
-#: src/muuli_wdr.cpp:2534
+#: src/muuli_wdr.cpp:2565
 msgid "Nodes stats"
 msgstr "Nodstatistik"
 
-#: src/muuli_wdr.cpp:2576
+#: src/muuli_wdr.cpp:2607
 msgid "Bootstrap"
 msgstr "Bootstrap"
 
-#: src/muuli_wdr.cpp:2579
+#: src/muuli_wdr.cpp:2610
 msgid "New node"
 msgstr "Ny nod"
 
-#: src/muuli_wdr.cpp:2584
+#: src/muuli_wdr.cpp:2615
 msgid "IP:"
 msgstr "IP:"
 
-#: src/muuli_wdr.cpp:2604
+#: src/muuli_wdr.cpp:2635
 msgid "Port:"
 msgstr "Port:"
 
-#: src/muuli_wdr.cpp:2617
+#: src/muuli_wdr.cpp:2648
 msgid "Bootstrap from known clients"
 msgstr "Bootstrap från kända klienter"
 
-#: src/muuli_wdr.cpp:2619
+#: src/muuli_wdr.cpp:2650
 msgid "Disconnect Kad"
 msgstr "Koppla från Kad"
 
-#: src/muuli_wdr.cpp:2653
+#: src/muuli_wdr.cpp:2684
 msgid "Use Secure User Identification"
 msgstr "Använd säker användarIdentifiering"
 
-#: src/muuli_wdr.cpp:2655
+#: src/muuli_wdr.cpp:2686
 msgid "It is recommended to enable this option. You will not receive credits if SUI is not enabled."
 msgstr "Det rekommenderas att aktivera det här alternativet. Du kommer inte att få poäng om SUI är inte aktiverat."
 
-#: src/muuli_wdr.cpp:2657
+#: src/muuli_wdr.cpp:2688
 msgid "Protocol Obfuscation"
 msgstr "Protokollfördunkling"
 
-#: src/muuli_wdr.cpp:2660
+#: src/muuli_wdr.cpp:2691
 msgid "Support Protocol Obfuscation"
 msgstr "Stöd protokollfördunkling"
 
-#: src/muuli_wdr.cpp:2662
+#: src/muuli_wdr.cpp:2693
 msgid "This option enabled Protocol Obfuscation, and makes aMule accept obfuscated connections from other clients."
 msgstr "Det här alternativet aktiverat protokollffördunkling och låter aMule acceptera dålda anslutningar från andra klienter."
 
-#: src/muuli_wdr.cpp:2664
+#: src/muuli_wdr.cpp:2695
 msgid "Use obfuscation for outgoing connections"
 msgstr "Använd obfuscation (fördunkling) för utgående anslutningar"
 
-#: src/muuli_wdr.cpp:2666
+#: src/muuli_wdr.cpp:2697
 msgid "This option makes aMule use Protocol Obfuscation when connecting other clients/servers."
 msgstr "Det här alternativet gör aMule använder protokoll-Obfuscation (fördunkling) vid anslutning till andra klienter/servrar."
 
-#: src/muuli_wdr.cpp:2668
+#: src/muuli_wdr.cpp:2699
 msgid "Accept only obfuscated connections"
 msgstr "Accepterar endast fördunklade anslutningar"
 
-#: src/muuli_wdr.cpp:2669
+#: src/muuli_wdr.cpp:2700
 msgid "This option makes aMule only accept obfuscated connections. You will have less sources, but all your traffic will be obfuscated"
 msgstr "Det här alternativet gör aMule endast acceptera fördunklade anslutningar. Du kommer att ha mindre källor, men all din trafik kommer att döljas"
 
-#: src/muuli_wdr.cpp:2674
+#: src/muuli_wdr.cpp:2705
 msgid "Everybody"
 msgstr "Alla"
 
-#: src/muuli_wdr.cpp:2676
+#: src/muuli_wdr.cpp:2707
 msgid "No one"
 msgstr "Ingen."
 
-#: src/muuli_wdr.cpp:2678
+#: src/muuli_wdr.cpp:2709
 msgid "Who can see my shared files:"
 msgstr "Vem kan se mina delade filer:"
 
-#: src/muuli_wdr.cpp:2679
+#: src/muuli_wdr.cpp:2710
 msgid "Select who can request to view a list of your shared files."
 msgstr "Välj vem som kan begära att få se en lista över dina delade filer."
 
-#: src/muuli_wdr.cpp:2681
+#: src/muuli_wdr.cpp:2712
 msgid "IP-Filtering"
 msgstr "IP-filtrering"
 
-#: src/muuli_wdr.cpp:2688
+#: src/muuli_wdr.cpp:2719
 msgid "Filter clients"
 msgstr "Filtrera klienter"
 
-#: src/muuli_wdr.cpp:2690
+#: src/muuli_wdr.cpp:2721
 msgid "Enable filtering of the client IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "Aktivera filtrering av klient-IP:n definierade i filen ~/.aMule/ipfilter.dat."
 
-#: src/muuli_wdr.cpp:2692
+#: src/muuli_wdr.cpp:2723
 msgid "Filter servers"
 msgstr "Filtrera servrar"
 
-#: src/muuli_wdr.cpp:2694
+#: src/muuli_wdr.cpp:2725
 msgid "Enable filtering of the server IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "Aktivera filtrering av server-IP:n definierade i filen ~/.aMule/ipfilter.dat."
 
-#: src/muuli_wdr.cpp:2698
+#: src/muuli_wdr.cpp:2729
 msgid "Reload List"
 msgstr "Återladda lista"
 
-#: src/muuli_wdr.cpp:2699
+#: src/muuli_wdr.cpp:2730
 msgid "Reload the list of IPs to filter from the file ~/.aMule/ipfilter.dat"
 msgstr "Återladda listan över IP-adresser att filtrera bort från filen ~/.aMule/ipfilter.dat"
 
-#: src/muuli_wdr.cpp:2705
+#: src/muuli_wdr.cpp:2736
 msgid "URL:"
 msgstr "URL:"
 
-#: src/muuli_wdr.cpp:2709 src/muuli_wdr.cpp:2902
+#: src/muuli_wdr.cpp:2740 src/muuli_wdr.cpp:2933
 msgid "Update now"
 msgstr "Uppdatera nu"
 
-#: src/muuli_wdr.cpp:2712
+#: src/muuli_wdr.cpp:2743
 msgid "Auto-update ipfilter at startup"
 msgstr "Auto-uppdatering av ipfilter vid start"
 
-#: src/muuli_wdr.cpp:2716
+#: src/muuli_wdr.cpp:2747
 msgid "Filtering Level:"
 msgstr "Filtreringsnivå:"
 
-#: src/muuli_wdr.cpp:2722
+#: src/muuli_wdr.cpp:2753
 msgid "Always filter LAN IPs"
 msgstr "Filtrera alltid LAN-IP-adresser"
 
-#: src/muuli_wdr.cpp:2725
+#: src/muuli_wdr.cpp:2756
 msgid "Paranoid handling of non-matching IPs"
 msgstr "Paranoid hantering av icke-matchande IP"
 
-#: src/muuli_wdr.cpp:2727
+#: src/muuli_wdr.cpp:2758
 msgid "Rejects a packet when its source IP differs from the IP the client claims (an anti-spoofing check). Disable only if it causes connection problems."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2729
+#: src/muuli_wdr.cpp:2760
 msgid "Use system-wide ipfilter.dat if available"
 msgstr "Använd systemvidd ipfilter.dat om sådan finns"
 
-#: src/muuli_wdr.cpp:2730
+#: src/muuli_wdr.cpp:2761
 #, fuzzy
 msgid "If there's no local ipfilter.dat found, allow usage of a system-wide ipfilter file."
 msgstr "Om det inte en lokal ipfilter.dat hittas, tillåt användning av systemvidd ipfilterfil."
 
-#: src/muuli_wdr.cpp:2747
+#: src/muuli_wdr.cpp:2778
 msgid "Enable Online-Signature"
 msgstr "Aktivera Onlinesignaturer"
 
-#: src/muuli_wdr.cpp:2749
+#: src/muuli_wdr.cpp:2780
 msgid "Enables the writing of the OS file, which can be used by external apps to create signatures and the like."
 msgstr "Möjliggör skrivning av OS-filen, som kan användas av externa program för att skapa signaturer och liknande."
 
-#: src/muuli_wdr.cpp:2753
+#: src/muuli_wdr.cpp:2784
 msgid "Update Frequency (Secs):"
 msgstr "Uppdateringsfrekvens (Sek):"
 
-#: src/muuli_wdr.cpp:2756
+#: src/muuli_wdr.cpp:2787
 msgid "Change the frequency (in seconds) of Online Signature updates."
 msgstr "Ändra frekvensen (i sekunder) av OnlineSignaturuppdateringar."
 
-#: src/muuli_wdr.cpp:2764
+#: src/muuli_wdr.cpp:2795
 msgid "Save online signature file in: "
 msgstr "Spara onlinesignaturfil i: "
 
-#: src/muuli_wdr.cpp:2770
+#: src/muuli_wdr.cpp:2801
 msgid "Click here to select the directory containing the the Online Signature files."
 msgstr "Klicka här för att välja den katalog som innehåller onlineSignaturFilerna."
 
-#: src/muuli_wdr.cpp:2803
+#: src/muuli_wdr.cpp:2834
 msgid "Show country flags for clients"
 msgstr "Visa landsflagger för klienter"
 
-#: src/muuli_wdr.cpp:2804
+#: src/muuli_wdr.cpp:2835
 msgid "Render the country flag column in the transfers, queue and search views. Requires a valid MMDB GeoIP database (see below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2809
+#: src/muuli_wdr.cpp:2840
 #, fuzzy
 msgid "Database"
 msgstr "Datahastighet :"
 
-#: src/muuli_wdr.cpp:2825
+#: src/muuli_wdr.cpp:2856
 #, fuzzy
 msgid "Source:"
 msgstr "Källor"
 
-#: src/muuli_wdr.cpp:2828
+#: src/muuli_wdr.cpp:2859
 msgid "DB-IP (free, no account)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2829
+#: src/muuli_wdr.cpp:2860
 msgid "MaxMind GeoLite2 (free, account required)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2830
+#: src/muuli_wdr.cpp:2861
 msgid "Custom URL"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2833
+#: src/muuli_wdr.cpp:2864
 msgid "Choose which provider supplies the GeoIP MMDB database. DB-IP is the default - no account required. MaxMind requires a free account + license key. Use Custom URL to point at any other MMDB host (e.g. a local mirror)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2850
+#: src/muuli_wdr.cpp:2881
 msgid ""
 "No configuration required.\n"
 "\n"
@@ -4852,11 +4880,11 @@ msgid ""
 "License: Creative Commons BY 4.0 - https://creativecommons.org/licenses/by/4.0/"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2863
+#: src/muuli_wdr.cpp:2894
 msgid "License key:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2869
+#: src/muuli_wdr.cpp:2900
 msgid ""
 "Sign up for a free MaxMind account, then generate a License Key:\n"
 "https://www.maxmind.com/en/geolite2/signup\n"
@@ -4866,225 +4894,225 @@ msgid ""
 "Requires attribution and account registration; refresh at least every 30 days."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2884
+#: src/muuli_wdr.cpp:2915
 #, fuzzy
 msgid "Download URL:"
 msgstr "Hämta: "
 
-#: src/muuli_wdr.cpp:2890
+#: src/muuli_wdr.cpp:2921
 msgid ""
 "Must point to an .mmdb file or a .gz / .tar.gz containing one.\n"
 "URL may include credentials (https://user:pass@host/...).\n"
 "License and attribution terms are set by the upstream URL - you are responsible."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2903
+#: src/muuli_wdr.cpp:2934
 msgid "Download the GeoIP database from the selected source."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2905
+#: src/muuli_wdr.cpp:2936
 #, fuzzy
 msgid "Auto-update on startup"
 msgstr "Auto-uppdatering av ipfilter vid start"
 
-#: src/muuli_wdr.cpp:2906
+#: src/muuli_wdr.cpp:2937
 msgid "Re-download the GeoIP database from the selected source every time aMule starts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2929
+#: src/muuli_wdr.cpp:2960
 msgid "Filter incoming messages (except current chat):"
 msgstr "Filtrera inkommande meddelanden (utom nuvarande chatt):"
 
-#: src/muuli_wdr.cpp:2931
+#: src/muuli_wdr.cpp:2962
 msgid "Filter all messages"
 msgstr "Filtrera alla meddelanden"
 
-#: src/muuli_wdr.cpp:2933
+#: src/muuli_wdr.cpp:2964
 msgid "Filter messages from people not on your friend list"
 msgstr "Filtrera meddelanden från folk som inte finns i din kompislista"
 
-#: src/muuli_wdr.cpp:2935
+#: src/muuli_wdr.cpp:2966
 msgid "Filter messages from unknown clients"
 msgstr "Filtrera meddelanden från okända klienter"
 
-#: src/muuli_wdr.cpp:2937
+#: src/muuli_wdr.cpp:2968
 msgid "Filter messages containing (use ',' as separator):"
 msgstr "Filtrera meddelanden som innehåller (använd ',' som separator):"
 
-#: src/muuli_wdr.cpp:2940 src/muuli_wdr.cpp:2951
+#: src/muuli_wdr.cpp:2971 src/muuli_wdr.cpp:2982
 msgid "add here the words amule should filter and block messages including it"
 msgstr "skriv här orden amule ska filtrera och blockera meddelanden med dem"
 
-#: src/muuli_wdr.cpp:2942
+#: src/muuli_wdr.cpp:2973
 msgid "Show received messages in the log"
 msgstr "Visa mottagna meddelanden i loggen"
 
-#: src/muuli_wdr.cpp:2945
+#: src/muuli_wdr.cpp:2976
 msgid "Comments"
 msgstr "Kommentarer"
 
-#: src/muuli_wdr.cpp:2948
+#: src/muuli_wdr.cpp:2979
 msgid "Filter comments containing (use ',' as separator):"
 msgstr "Filtrera kommentarer som innehåller (använd ',' som separator):"
 
-#: src/muuli_wdr.cpp:2973
+#: src/muuli_wdr.cpp:3004
 msgid "Enable Proxy"
 msgstr "Aktivera proxy"
 
-#: src/muuli_wdr.cpp:2974
+#: src/muuli_wdr.cpp:3005
 msgid "Enable/disable proxy support"
 msgstr "Aktivera/inaktivera proxy-stöd"
 
-#: src/muuli_wdr.cpp:2977
+#: src/muuli_wdr.cpp:3008
 msgid "Proxy type:"
 msgstr "Proxytyp:"
 
-#: src/muuli_wdr.cpp:2988
+#: src/muuli_wdr.cpp:3019
 msgid "Proxy host:"
 msgstr "Proxyserver:"
 
-#: src/muuli_wdr.cpp:2991
+#: src/muuli_wdr.cpp:3022
 msgid "The proxy host name"
 msgstr "Proxyserverns värdnamn"
 
-#: src/muuli_wdr.cpp:2993
+#: src/muuli_wdr.cpp:3024
 msgid "Proxy port:"
 msgstr "Proxyport:"
 
-#: src/muuli_wdr.cpp:2996
+#: src/muuli_wdr.cpp:3027
 msgid "The proxy port"
 msgstr "Proxyporten"
 
-#: src/muuli_wdr.cpp:2998
+#: src/muuli_wdr.cpp:3029
 msgid "Enable authentication"
 msgstr "Aktivera autentisering"
 
-#: src/muuli_wdr.cpp:2999
+#: src/muuli_wdr.cpp:3030
 msgid "Enable/disable username/password authentication"
 msgstr "Aktivera/inaktivera användarnamn/lösenordsautentisering"
 
-#: src/muuli_wdr.cpp:3002
+#: src/muuli_wdr.cpp:3033
 msgid "Username: "
 msgstr "Användarnamn: "
 
-#: src/muuli_wdr.cpp:3005
+#: src/muuli_wdr.cpp:3036
 msgid "The username to use to connect to the proxy"
 msgstr "Användarnamnet som ska användas för att ansluta till proxyn"
 
-#: src/muuli_wdr.cpp:3007
+#: src/muuli_wdr.cpp:3038
 msgid "Password:"
 msgstr "Lösenord:"
 
-#: src/muuli_wdr.cpp:3010
+#: src/muuli_wdr.cpp:3041
 msgid "The password to use to connect to the proxy"
 msgstr "Lösenordet som ska användas för att ansluta till proxyn"
 
-#: src/muuli_wdr.cpp:3029
+#: src/muuli_wdr.cpp:3060
 msgid "Connect to:"
 msgstr "Anslut till:"
 
-#: src/muuli_wdr.cpp:3038
+#: src/muuli_wdr.cpp:3069
 msgid "Login to remote amule"
 msgstr "Logga in på fjärr-amule"
 
-#: src/muuli_wdr.cpp:3043
+#: src/muuli_wdr.cpp:3074
 msgid "User name"
 msgstr "Användarnamn"
 
-#: src/muuli_wdr.cpp:3054
+#: src/muuli_wdr.cpp:3085
 msgid "Remember those settings"
 msgstr "Kom ihåg dessa inställningar"
 
-#: src/muuli_wdr.cpp:3057
+#: src/muuli_wdr.cpp:3088
 #, fuzzy
 msgid "Force ZLIB compression"
 msgstr "Använd gzip-komprimering"
 
-#: src/muuli_wdr.cpp:3081
+#: src/muuli_wdr.cpp:3112
 msgid "Enable Verbose Debug-Logging."
 msgstr "Aktivera Utförlig Debug-loggning."
 
-#: src/muuli_wdr.cpp:3083
+#: src/muuli_wdr.cpp:3114
 msgid "Only to Logfile"
 msgstr "Endast till loggfil"
 
-#: src/muuli_wdr.cpp:3085
+#: src/muuli_wdr.cpp:3116
 msgid "Message Categories:"
 msgstr "Meddelandekategorier:"
 
-#: src/muuli_wdr.cpp:3109 src/PartFileConvertDlg.cpp:160
+#: src/muuli_wdr.cpp:3140 src/PartFileConvertDlg.cpp:160
 msgid "Waiting..."
 msgstr "Väntar..."
 
-#: src/muuli_wdr.cpp:3129
+#: src/muuli_wdr.cpp:3160
 msgid "Add imports"
 msgstr "Lägg till importer"
 
-#: src/muuli_wdr.cpp:3132
+#: src/muuli_wdr.cpp:3163
 msgid "Retry selected"
 msgstr "Återförsök den valda"
 
-#: src/muuli_wdr.cpp:3134
+#: src/muuli_wdr.cpp:3165
 msgid "Remove selected"
 msgstr "Ta bort vald"
 
-#: src/muuli_wdr.cpp:3197
+#: src/muuli_wdr.cpp:3228
 msgid "Event Types"
 msgstr "Händelsetyper"
 
-#: src/muuli_wdr.cpp:3216
+#: src/muuli_wdr.cpp:3247
 msgid "Statistics and queued clients for selected file(s) : Session / All time"
 msgstr "Statistik och köade klienter för vald fil(er): Session / All tid"
 
-#: src/muuli_wdr.cpp:3240
+#: src/muuli_wdr.cpp:3271
 msgid "Active Uploads"
 msgstr "Aktiva uppladdningar"
 
-#: src/muuli_wdr.cpp:3254
+#: src/muuli_wdr.cpp:3285
 msgid "Percent of total files"
 msgstr "Procent av den totala filer"
 
-#: src/muuli_wdr.cpp:3306
+#: src/muuli_wdr.cpp:3337
 msgid "Show Clients for"
 msgstr "Visa klienter för"
 
-#: src/muuli_wdr.cpp:3308
+#: src/muuli_wdr.cpp:3339
 msgid "All files"
 msgstr "Alla filer"
 
-#: src/muuli_wdr.cpp:3311
+#: src/muuli_wdr.cpp:3342
 msgid "Selected files"
 msgstr "Valda filer"
 
-#: src/muuli_wdr.cpp:3314
+#: src/muuli_wdr.cpp:3345
 msgid "Active uploads only"
 msgstr "Endast aktiva uppladdningar"
 
-#: src/muuli_wdr.cpp:3321
+#: src/muuli_wdr.cpp:3352
 msgid "Reload:"
 msgstr "Återladda:"
 
-#: src/muuli_wdr.cpp:3325
+#: src/muuli_wdr.cpp:3356
 msgid "Reload your shared files"
 msgstr "Återladda dina delade filer"
 
-#: src/muuli_wdr.cpp:3388
+#: src/muuli_wdr.cpp:3419
 msgid "Send"
 msgstr "Skicka"
 
-#: src/muuli_wdr.cpp:3389
+#: src/muuli_wdr.cpp:3420
 msgid "Sends the specified message."
 msgstr "Skickar det specificerade meddelandet."
 
-#: src/muuli_wdr.cpp:3393
+#: src/muuli_wdr.cpp:3424
 msgid "Close this chat-session."
 msgstr "Stäng denna chat-session."
 
-#: src/muuli_wdr.cpp:3416
+#: src/muuli_wdr.cpp:3447
 msgid "Connect to any server and/or Kad"
 msgstr "Anslut till någon server och/eller Kad"
 
-#: src/muuli_wdr.cpp:3422 src/SharedFilesCtrl.cpp:142 src/Statistics.cpp:941
+#: src/muuli_wdr.cpp:3453 src/SharedFilesCtrl.cpp:142 src/Statistics.cpp:941
 msgid "Shared Files"
 msgstr "Utdelade filer"
 
@@ -5443,249 +5471,249 @@ msgstr "Nedladdad"
 msgid "ERROR: Failed to open partfile '%s'"
 msgstr "FEL: Det gick inte att öppna partfile ' %s '"
 
-#: src/Preferences.cpp:674
+#: src/Preferences.cpp:701
 msgid "System default"
 msgstr "Systemets standard"
 
-#: src/Preferences.cpp:675
+#: src/Preferences.cpp:702
 msgid "Albanian"
 msgstr "Albansk"
 
-#: src/Preferences.cpp:676
+#: src/Preferences.cpp:703
 msgid "Arabic"
 msgstr "Arabiska"
 
-#: src/Preferences.cpp:677
+#: src/Preferences.cpp:704
 msgid "Asturian"
 msgstr "Asturiska"
 
-#: src/Preferences.cpp:678
+#: src/Preferences.cpp:705
 msgid "Basque"
 msgstr "Baskiska"
 
-#: src/Preferences.cpp:679
+#: src/Preferences.cpp:706
 msgid "Bulgarian"
 msgstr "Bulgariska"
 
-#: src/Preferences.cpp:680
+#: src/Preferences.cpp:707
 msgid "Catalan"
 msgstr "Katalanska"
 
-#: src/Preferences.cpp:681
+#: src/Preferences.cpp:708
 msgid "Chinese (Simplified)"
 msgstr "Kinesiska (Förenklad)"
 
-#: src/Preferences.cpp:682
+#: src/Preferences.cpp:709
 msgid "Chinese (Traditional)"
 msgstr "Kinesiska (Traditionell)"
 
-#: src/Preferences.cpp:683
+#: src/Preferences.cpp:710
 msgid "Croatian"
 msgstr "Kroatiska"
 
-#: src/Preferences.cpp:684
+#: src/Preferences.cpp:711
 msgid "Czech"
 msgstr "Checkiska"
 
-#: src/Preferences.cpp:685
+#: src/Preferences.cpp:712
 msgid "Danish"
 msgstr "Danska"
 
-#: src/Preferences.cpp:686
+#: src/Preferences.cpp:713
 msgid "Dutch"
 msgstr "Nederländska"
 
-#: src/Preferences.cpp:687
+#: src/Preferences.cpp:714
 msgid "English (U.K.)"
 msgstr "Engelska (Storbritannien)"
 
-#: src/Preferences.cpp:688
+#: src/Preferences.cpp:715
 #, fuzzy
 msgid "English (U.S.)"
 msgstr "Engelska (Storbritannien)"
 
-#: src/Preferences.cpp:689
+#: src/Preferences.cpp:716
 msgid "Estonian"
 msgstr "Estniska"
 
-#: src/Preferences.cpp:690
+#: src/Preferences.cpp:717
 msgid "Finnish"
 msgstr "Finska"
 
-#: src/Preferences.cpp:691
+#: src/Preferences.cpp:718
 msgid "French"
 msgstr "Franska"
 
-#: src/Preferences.cpp:692
+#: src/Preferences.cpp:719
 msgid "Galician"
 msgstr "Galiciska"
 
-#: src/Preferences.cpp:693
+#: src/Preferences.cpp:720
 msgid "German"
 msgstr "Tyska"
 
-#: src/Preferences.cpp:694
+#: src/Preferences.cpp:721
 msgid "Greek"
 msgstr "Grekisk"
 
-#: src/Preferences.cpp:695
+#: src/Preferences.cpp:722
 msgid "Hebrew"
 msgstr "Hebreiska"
 
-#: src/Preferences.cpp:696
+#: src/Preferences.cpp:723
 msgid "Hungarian"
 msgstr "Ungerska"
 
-#: src/Preferences.cpp:697
+#: src/Preferences.cpp:724
 msgid "Italian"
 msgstr "Italienska"
 
-#: src/Preferences.cpp:698
+#: src/Preferences.cpp:725
 msgid "Japanese"
 msgstr "Japanska"
 
-#: src/Preferences.cpp:699
+#: src/Preferences.cpp:726
 msgid "Korean"
 msgstr "Koreanska"
 
-#: src/Preferences.cpp:700
+#: src/Preferences.cpp:727
 msgid "Latvian"
 msgstr ""
 
-#: src/Preferences.cpp:701
+#: src/Preferences.cpp:728
 msgid "Lithuanian"
 msgstr "Litauisk"
 
-#: src/Preferences.cpp:702
+#: src/Preferences.cpp:729
 msgid "Norwegian (Nynorsk)"
 msgstr "Norska (nynorsk)"
 
-#: src/Preferences.cpp:703
+#: src/Preferences.cpp:730
 msgid "Polish"
 msgstr "Polska"
 
-#: src/Preferences.cpp:704
+#: src/Preferences.cpp:731
 msgid "Portuguese"
 msgstr "Portugisiska"
 
-#: src/Preferences.cpp:705
+#: src/Preferences.cpp:732
 msgid "Portuguese (Brazilian)"
 msgstr "Portugisiska (Brasilien)"
 
-#: src/Preferences.cpp:706
+#: src/Preferences.cpp:733
 msgid "Romanian"
 msgstr "Romänska"
 
-#: src/Preferences.cpp:707
+#: src/Preferences.cpp:734
 msgid "Russian"
 msgstr "Ryska"
 
-#: src/Preferences.cpp:708
+#: src/Preferences.cpp:735
 msgid "Slovenian"
 msgstr "Slovenska"
 
-#: src/Preferences.cpp:709
+#: src/Preferences.cpp:736
 msgid "Spanish"
 msgstr "Spanska"
 
-#: src/Preferences.cpp:710
+#: src/Preferences.cpp:737
 msgid "Swedish"
 msgstr "Svenska"
 
-#: src/Preferences.cpp:711
+#: src/Preferences.cpp:738
 msgid "Turkish"
 msgstr "Turkiska"
 
-#: src/Preferences.cpp:712
+#: src/Preferences.cpp:739
 msgid "Ukrainian"
 msgstr "Ukraina"
 
-#: src/Preferences.cpp:815
+#: src/Preferences.cpp:842
 msgid "Change Language"
 msgstr "Byt språk"
 
-#: src/Preferences.cpp:879
+#: src/Preferences.cpp:906
 msgid "There are no translations installed for aMule"
 msgstr "Det finns inga översättningar installerade för aMule"
 
-#: src/Preferences.cpp:880
+#: src/Preferences.cpp:907
 msgid "No languages available"
 msgstr "Inga språk tillgängliga"
 
-#: src/Preferences.cpp:1011
+#: src/Preferences.cpp:1038
 msgid "no options available"
 msgstr "Inga alternativ tillgängliga"
 
-#: src/Preferences.cpp:2182
+#: src/Preferences.cpp:2227
 msgid "Invalid category found, skipping"
 msgstr "Ogiltig kategori hittad, hoppar över"
 
-#: src/Preferences.cpp:2351
+#: src/Preferences.cpp:2396
 msgid "TCP port can't be higher than 65532 due to server UDP socket being TCP+3"
 msgstr "TCP-port kan inte vara högre än 65532 på grund av server UDP-socket är TCP+3"
 
-#: src/Preferences.cpp:2352
+#: src/Preferences.cpp:2397
 #, c-format
 msgid "Default port will be used (%d)"
 msgstr "Standardporten kommer att användas ( %d )"
 
-#: src/PrefsUnifiedDlg.cpp:298 src/Statistics.cpp:866
+#: src/PrefsUnifiedDlg.cpp:300 src/Statistics.cpp:866
 msgid "Connection"
 msgstr "Anslutning"
 
-#: src/PrefsUnifiedDlg.cpp:299 src/SearchListCtrl.cpp:117
+#: src/PrefsUnifiedDlg.cpp:301 src/SearchListCtrl.cpp:117
 msgid "Directories"
 msgstr "Kataloger"
 
-#: src/PrefsUnifiedDlg.cpp:300 src/Statistics.cpp:917
+#: src/PrefsUnifiedDlg.cpp:302 src/Statistics.cpp:917
 msgid "Servers"
 msgstr "Servrar"
 
-#: src/PrefsUnifiedDlg.cpp:301 src/ServerListCtrl.cpp:96
+#: src/PrefsUnifiedDlg.cpp:303 src/ServerListCtrl.cpp:96
 msgid "Files"
 msgstr "Filer"
 
-#: src/PrefsUnifiedDlg.cpp:302
+#: src/PrefsUnifiedDlg.cpp:304
 msgid "Security"
 msgstr "Säkerhet"
 
-#: src/PrefsUnifiedDlg.cpp:303
+#: src/PrefsUnifiedDlg.cpp:305
 msgid "Interface"
 msgstr "Gränssnitt"
 
-#: src/PrefsUnifiedDlg.cpp:310
+#: src/PrefsUnifiedDlg.cpp:312
 msgid "IP2Country"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:313
+#: src/PrefsUnifiedDlg.cpp:315
 msgid "Proxy"
 msgstr "Proxy"
 
-#: src/PrefsUnifiedDlg.cpp:314
+#: src/PrefsUnifiedDlg.cpp:316
 msgid "Filters"
 msgstr "Filter"
 
-#: src/PrefsUnifiedDlg.cpp:315
+#: src/PrefsUnifiedDlg.cpp:317
 msgid "Remote Controls"
 msgstr "Fjärrkontroller"
 
-#: src/PrefsUnifiedDlg.cpp:316
+#: src/PrefsUnifiedDlg.cpp:318
 msgid "Online Signature"
 msgstr "Onlinesignatur"
 
-#: src/PrefsUnifiedDlg.cpp:317
+#: src/PrefsUnifiedDlg.cpp:319
 msgid "Advanced"
 msgstr "Avancerad"
 
-#: src/PrefsUnifiedDlg.cpp:318
+#: src/PrefsUnifiedDlg.cpp:320
 msgid "Events"
 msgstr "Händelser"
 
-#: src/PrefsUnifiedDlg.cpp:321
+#: src/PrefsUnifiedDlg.cpp:323
 msgid "Debugging"
 msgstr "Felsökning"
 
-#: src/PrefsUnifiedDlg.cpp:451
+#: src/PrefsUnifiedDlg.cpp:453
 msgid ""
 "The following variables will be substituted:\n"
 "    %PARTFILE - full path to the file\n"
@@ -5695,15 +5723,15 @@ msgstr ""
 "    %PARTFILE - hela sökvägen till filen\n"
 "    %PARTNAME - endast filnamnet"
 
-#: src/PrefsUnifiedDlg.cpp:472
+#: src/PrefsUnifiedDlg.cpp:474
 msgid "Tray icon support requires libayatana-appindicator3 at compile time."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:488
+#: src/PrefsUnifiedDlg.cpp:490
 msgid "Not available on Wayland: the protocol does not report when a window is minimized, so this option cannot intercept the system minimize button. Workaround: launch aMule with `GDK_BACKEND=x11` to use XWayland instead."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:534
+#: src/PrefsUnifiedDlg.cpp:536
 msgid ""
 "Do not change these setting unless you know\n"
 "what you are doing, otherwise you can easily\n"
@@ -5719,26 +5747,35 @@ msgstr ""
 "aMule kommer fungera bra utan att justera några av\n"
 "dessa inställningar."
 
-#: src/PrefsUnifiedDlg.cpp:645
+#: src/PrefsUnifiedDlg.cpp:647
 #, c-format
 msgid "Failed to connect Cfg to widget with the ID %d and key %s"
 msgstr "Det gick inte att ansluta Cfg till widget med ID %d och nyckel %s"
 
-#: src/PrefsUnifiedDlg.cpp:693
+#: src/PrefsUnifiedDlg.cpp:695
 #, c-format
 msgid "Failed to transfer data from Cfg to Widget with the ID %d and key %s"
 msgstr "Det gick inte att överföra data från Cfg till widget med ID %d och nyckel %s"
 
-#: src/PrefsUnifiedDlg.cpp:799
+#: src/PrefsUnifiedDlg.cpp:801
 msgid "The type of proxy you are connecting to"
 msgstr "Den typen av proxy du ansluter till"
 
-#: src/PrefsUnifiedDlg.cpp:1003
+#: src/PrefsUnifiedDlg.cpp:1020
 #, c-format
 msgid "Failed to transfer data from Widget to Cfg with the ID %d and key %s"
 msgstr "Det gick inte att överföra data från widget till Cfg med ID %d och nyckel %s"
 
 #: src/PrefsUnifiedDlg.cpp:1103
+#, fuzzy
+msgid "No password set."
+msgstr "Kontrollerar lösenord\n"
+
+#: src/PrefsUnifiedDlg.cpp:1132
+msgid "Guest access needs a password. Type one in the guest password field, or untick Enable guest access."
+msgstr ""
+
+#: src/PrefsUnifiedDlg.cpp:1144
 msgid ""
 "aMule must be restarted to enable these changes:\n"
 "\n"
@@ -5746,41 +5783,41 @@ msgstr ""
 "aMule måste startas om för att aktivera dessa ändringar:\n"
 "\n"
 
-#: src/PrefsUnifiedDlg.cpp:1110
+#: src/PrefsUnifiedDlg.cpp:1151
 msgid "- TCP port changed.\n"
 msgstr "- TCP-port ändrad.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1115
+#: src/PrefsUnifiedDlg.cpp:1156
 msgid "- UDP port changed.\n"
 msgstr "- UDP-port ändrad.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1120
+#: src/PrefsUnifiedDlg.cpp:1161
 #, fuzzy
 msgid "- Network interface binding changed.\n"
 msgstr "- Extern anslutningsgränssnitt ändrad.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1125
+#: src/PrefsUnifiedDlg.cpp:1166
 msgid "- External connect port changed.\n"
 msgstr "- Extern anslutningsport ändrad.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1129
+#: src/PrefsUnifiedDlg.cpp:1170
 msgid "- External connect acceptance changed.\n"
 msgstr "- Extern anslutningsacceptans ändrades.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1133
+#: src/PrefsUnifiedDlg.cpp:1174
 msgid "- External connect interface changed.\n"
 msgstr "- Extern anslutningsgränssnitt ändrad.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1137
+#: src/PrefsUnifiedDlg.cpp:1178
 msgid "- Protocol obfuscation support changed.\n"
 msgstr "- Stöd för fördunkling av protokoll ändrad.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1151
+#: src/PrefsUnifiedDlg.cpp:1193
 #, fuzzy
 msgid "- amuleapi settings changed.\n"
 msgstr "- Språk ändrat.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1160
+#: src/PrefsUnifiedDlg.cpp:1202
 msgid ""
 "Your Auto-update server list is empty.\n"
 "'Auto-update server list at startup' will be disabled."
@@ -5788,7 +5825,7 @@ msgstr ""
 "Din automatiska uppdateringsserverlista är tom.\n"
 "'Auto-uppdateringsserverlista vid start' inaktiveras."
 
-#: src/PrefsUnifiedDlg.cpp:1171
+#: src/PrefsUnifiedDlg.cpp:1213
 msgid ""
 "You have enabled external connections but have not specified a password.\n"
 "External connections cannot be enabled unless a valid password is specified."
@@ -5796,28 +5833,33 @@ msgstr ""
 "Du har aktiverat externa anslutningar men har inte angett ett lösenord.\n"
 "External anslutningar kan inte aktiveras om inte ett giltigt lösenord anges."
 
-#: src/PrefsUnifiedDlg.cpp:1202
+#: src/PrefsUnifiedDlg.cpp:1246
+#, c-format
+msgid "The amuleapi password could not be saved: %s"
+msgstr ""
+
+#: src/PrefsUnifiedDlg.cpp:1276
 msgid "- Language changed.\n"
 msgstr "- Språk ändrat.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1207
+#: src/PrefsUnifiedDlg.cpp:1281
 msgid "- Temp folder changed.\n"
 msgstr "- Mappen Temp ändrades.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1212
+#: src/PrefsUnifiedDlg.cpp:1286
 msgid "- ED2K network enabled.\n"
 msgstr "- ED2K-nätverk aktiverad.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1245
+#: src/PrefsUnifiedDlg.cpp:1319
 msgid "The shared-file exclusion pattern is not a valid regular expression. The filter has been left disabled."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1247 src/PrefsUnifiedDlg.cpp:1841
+#: src/PrefsUnifiedDlg.cpp:1321 src/PrefsUnifiedDlg.cpp:1921
 #, fuzzy
 msgid "Invalid regular expression"
 msgstr "Fel protokoll-version"
 
-#: src/PrefsUnifiedDlg.cpp:1324
+#: src/PrefsUnifiedDlg.cpp:1398
 msgid ""
 "Both eD2k and Kad network are disabled.\n"
 "You won't be able to connect until you enable at least one of them."
@@ -5825,7 +5867,7 @@ msgstr ""
 "Både eD2k- och Kad-nätverk är inaktiverade.\n"
 "Du kommer inte att kunna ansluta förrän du aktiverar åtminstone en av dem."
 
-#: src/PrefsUnifiedDlg.cpp:1329
+#: src/PrefsUnifiedDlg.cpp:1403
 msgid ""
 "Kad will not start if your UDP port is disabled.\n"
 "Enable UDP port or disable Kad."
@@ -5833,7 +5875,7 @@ msgstr ""
 "Kad startar inte om din UDP-port är inaktiverad.\n"
 "Aktivra UDP-port eller inaktivera Kad."
 
-#: src/PrefsUnifiedDlg.cpp:1385
+#: src/PrefsUnifiedDlg.cpp:1459
 msgid ""
 "\n"
 "You MUST restart aMule now.\n"
@@ -5843,69 +5885,69 @@ msgstr ""
 "Du MÅSTE starta om aMule nu.\n"
 "Om du inte startar nu, klaga inte om något dåligt händer.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1450
+#: src/PrefsUnifiedDlg.cpp:1524
 msgid "Could not register aMule for autostart at login. The autostart store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1452
+#: src/PrefsUnifiedDlg.cpp:1526
 msgid "Could not remove the autostart-at-login entry."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1453
+#: src/PrefsUnifiedDlg.cpp:1527
 #, fuzzy
 msgid "Autostart"
 msgstr "Auto Refresh startad"
 
-#: src/PrefsUnifiedDlg.cpp:1468
+#: src/PrefsUnifiedDlg.cpp:1542
 msgid "Register file type"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1468
+#: src/PrefsUnifiedDlg.cpp:1542
 msgid "Register URL handler"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1476
+#: src/PrefsUnifiedDlg.cpp:1550
 #, c-format
 msgid "aMule only handles eD2k-compatible magnets. If you replace the current magnet handler (%s), BitTorrent magnet links will stop working - aMule cannot download BitTorrent content. Continue?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1481
+#: src/PrefsUnifiedDlg.cpp:1555
 #, c-format
 msgid "Another application currently opens .emulecollection files (%s). Replace it with aMule?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1486
+#: src/PrefsUnifiedDlg.cpp:1560
 #, c-format
 msgid "Another application is currently the default handler for these links (%s). Replace it with aMule?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1511
+#: src/PrefsUnifiedDlg.cpp:1585
 msgid "Could not register aMule for .emulecollection files. The registration store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1513
+#: src/PrefsUnifiedDlg.cpp:1587
 #, fuzzy
 msgid "Could not remove the file type registration."
 msgstr "Mapp för temporära nerladdningsfiler"
 
-#: src/PrefsUnifiedDlg.cpp:1515
+#: src/PrefsUnifiedDlg.cpp:1589
 msgid "Could not register aMule as the URL handler. The registration store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1517
+#: src/PrefsUnifiedDlg.cpp:1591
 msgid "Could not remove the URL handler registration."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1587 src/PrefsUnifiedDlg.cpp:1614
+#: src/PrefsUnifiedDlg.cpp:1661 src/PrefsUnifiedDlg.cpp:1688
 #, fuzzy
 msgid "The web server and aMule API require external connections to be enabled."
 msgstr "Lösenord sparad och extern anslutning aktiverad."
 
-#: src/PrefsUnifiedDlg.cpp:1597
+#: src/PrefsUnifiedDlg.cpp:1671
 msgid "The aMule web server is deprecated. Consider running the aMule API instead."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1655
+#: src/PrefsUnifiedDlg.cpp:1735
 msgid ""
 "Your Auto-update servers list is in blank.\n"
 "Please fill in at least one URL to point to a valid server.met file.\n"
@@ -5915,66 +5957,66 @@ msgstr ""
 "Vänligen fylla i åtminstone en URL för att peka på en giltig server.met-fil.\n"
 "Klicka på knappen \"lista\" i denna kryssruta för att ange en URL."
 
-#: src/PrefsUnifiedDlg.cpp:1796
+#: src/PrefsUnifiedDlg.cpp:1876
 msgid "Temporary files"
 msgstr "Temporära filer"
 
-#: src/PrefsUnifiedDlg.cpp:1801
+#: src/PrefsUnifiedDlg.cpp:1881
 msgid "Incoming files"
 msgstr "Inkommande filer"
 
-#: src/PrefsUnifiedDlg.cpp:1806
+#: src/PrefsUnifiedDlg.cpp:1886
 msgid "Online Signatures"
 msgstr "Online-signaturer"
 
-#: src/PrefsUnifiedDlg.cpp:1819
+#: src/PrefsUnifiedDlg.cpp:1899
 #, c-format
 msgid "Choose a folder for %s"
 msgstr "Välj en mapp för %s"
 
-#: src/PrefsUnifiedDlg.cpp:1843
+#: src/PrefsUnifiedDlg.cpp:1923
 #, fuzzy, c-format
 msgid "Would exclude %u of %u shared file"
 msgid_plural "Would exclude %u of %u shared files"
 msgstr[0] "Hittade %i känd delad fil"
 msgstr[1] "Hittade %i kända delad filer"
 
-#: src/PrefsUnifiedDlg.cpp:1860
+#: src/PrefsUnifiedDlg.cpp:1940
 msgid "Browse for videoplayer"
 msgstr "Bläddra efter videospelare"
 
-#: src/PrefsUnifiedDlg.cpp:1864
+#: src/PrefsUnifiedDlg.cpp:1944
 msgid "Select browser"
 msgstr "Välj webbläsare"
 
-#: src/PrefsUnifiedDlg.cpp:1868
+#: src/PrefsUnifiedDlg.cpp:1948
 #, fuzzy
 msgid "Select ffprobe binary"
 msgstr "Välj webbläsare"
 
-#: src/PrefsUnifiedDlg.cpp:1874
+#: src/PrefsUnifiedDlg.cpp:1954
 #, c-format
 msgid "Executable%s"
 msgstr "Körbar %s"
 
-#: src/PrefsUnifiedDlg.cpp:1908
+#: src/PrefsUnifiedDlg.cpp:1988
 msgid "ffprobe not found on PATH or in the standard install locations. Install ffmpeg (which ships ffprobe) or use Browse to pick a binary manually."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1920
+#: src/PrefsUnifiedDlg.cpp:2000
 msgid "Reset the settings on this page to their default values?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1921
+#: src/PrefsUnifiedDlg.cpp:2001
 #, fuzzy
 msgid "Reset to defaults"
 msgstr "Systemets standard"
 
-#: src/PrefsUnifiedDlg.cpp:1948
+#: src/PrefsUnifiedDlg.cpp:2028
 msgid "Edit server list"
 msgstr "Redigera serverlista"
 
-#: src/PrefsUnifiedDlg.cpp:1949
+#: src/PrefsUnifiedDlg.cpp:2029
 msgid ""
 "Add here URL's to download server.met files.\n"
 "Only one url on each line."
@@ -5982,154 +6024,154 @@ msgstr ""
 "Lägg här URL för att hämta server.met filer.\n"
 "Endast en webbadress på varje rad."
 
-#: src/PrefsUnifiedDlg.cpp:2004
+#: src/PrefsUnifiedDlg.cpp:2084
 msgid "IP2Country update failed"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2149 src/PrefsUnifiedDlg.cpp:2180
+#: src/PrefsUnifiedDlg.cpp:2229 src/PrefsUnifiedDlg.cpp:2260
 msgid "Data by MaxMind GeoLite2"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2151 src/PrefsUnifiedDlg.cpp:2182
+#: src/PrefsUnifiedDlg.cpp:2231 src/PrefsUnifiedDlg.cpp:2262
 #, fuzzy
 msgid "Custom source"
 msgstr "Kompletta källor"
 
-#: src/PrefsUnifiedDlg.cpp:2153 src/PrefsUnifiedDlg.cpp:2184
+#: src/PrefsUnifiedDlg.cpp:2233 src/PrefsUnifiedDlg.cpp:2264
 msgid "Data by DB-IP.com"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2204
+#: src/PrefsUnifiedDlg.cpp:2284
 #, fuzzy, c-format
 msgid "Status: Loaded%s"
 msgstr "Status:"
 
-#: src/PrefsUnifiedDlg.cpp:2206
+#: src/PrefsUnifiedDlg.cpp:2286
 #, fuzzy, c-format
 msgid "Status: Loaded%s - %s"
 msgstr "Status:"
 
-#: src/PrefsUnifiedDlg.cpp:2210
+#: src/PrefsUnifiedDlg.cpp:2290
 msgid "Status: Failed to load - click 'Update now' to refresh."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2212
+#: src/PrefsUnifiedDlg.cpp:2292
 msgid "Status: Not found - click 'Update now' to download."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2270 src/PrefsUnifiedDlg.cpp:2294
+#: src/PrefsUnifiedDlg.cpp:2350 src/PrefsUnifiedDlg.cpp:2374
 #, c-format
 msgid "Update delay: %d second"
 msgid_plural "Update delay: %d seconds"
 msgstr[0] "Uppdateringsfördröjning: %d sekund"
 msgstr[1] "Uppdateringsfördröjning: %d sekunder"
 
-#: src/PrefsUnifiedDlg.cpp:2278
+#: src/PrefsUnifiedDlg.cpp:2358
 #, c-format
 msgid "Time for average graph: %d minute"
 msgid_plural "Time for average graph: %d minutes"
 msgstr[0] "Tid för genomsnittlig graf: %d minut"
 msgstr[1] "Tid för genomsnittlig graf: %d minuter"
 
-#: src/PrefsUnifiedDlg.cpp:2287
+#: src/PrefsUnifiedDlg.cpp:2367
 #, c-format
 msgid "Connections Graph Scale: %d"
 msgstr "Anslutningsdiagramskala: %d"
 
-#: src/PrefsUnifiedDlg.cpp:2302
+#: src/PrefsUnifiedDlg.cpp:2382
 #, c-format
 msgid "File Buffer Size: %d byte"
 msgid_plural "File Buffer Size: %d bytes"
 msgstr[0] "Filbuffertstorlek: %d byte"
 msgstr[1] "Filbuffertstorlek: %d bytes"
 
-#: src/PrefsUnifiedDlg.cpp:2312
+#: src/PrefsUnifiedDlg.cpp:2392
 #, c-format
 msgid "Upload Queue Size: %d client"
 msgid_plural "Upload Queue Size: %d clients"
 msgstr[0] "Uppladdningsköstorlek: %d klient"
 msgstr[1] "Uppladdningsköstorlek: %d klienter"
 
-#: src/PrefsUnifiedDlg.cpp:2322
+#: src/PrefsUnifiedDlg.cpp:2402
 #, c-format
 msgid "Server connection refresh interval: %d minute"
 msgid_plural "Server connection refresh interval: %d minutes"
 msgstr[0] "Serveranslutninguppdateringsintervall: %d minut"
 msgstr[1] "Serveranslutninguppdateringsintervall: %d minuter"
 
-#: src/PrefsUnifiedDlg.cpp:2327
+#: src/PrefsUnifiedDlg.cpp:2407
 msgid "Server connection refresh interval: Disabled"
 msgstr "Serveranslutningsuppdateringsintervall: Inaktiverad"
 
-#: src/PrefsUnifiedDlg.cpp:2371
+#: src/PrefsUnifiedDlg.cpp:2451
 msgid "disabled"
 msgstr "inaktiverad"
 
-#: src/PrefsUnifiedDlg.cpp:2397
+#: src/PrefsUnifiedDlg.cpp:2477
 #, c-format
 msgid "Execute command on '%s' event"
 msgstr "Exekvera kommando på '%s' händelse"
 
-#: src/PrefsUnifiedDlg.cpp:2404
+#: src/PrefsUnifiedDlg.cpp:2484
 msgid "Enable command execution on core"
 msgstr "Aktivera kommandokörning på kärnan"
 
-#: src/PrefsUnifiedDlg.cpp:2416
+#: src/PrefsUnifiedDlg.cpp:2496
 msgid "Core command:"
 msgstr "Kommando till kärnan:"
 
-#: src/PrefsUnifiedDlg.cpp:2432
+#: src/PrefsUnifiedDlg.cpp:2512
 msgid "Enable command execution on GUI"
 msgstr "Aktivera kommandokörning via GUI"
 
-#: src/PrefsUnifiedDlg.cpp:2444
+#: src/PrefsUnifiedDlg.cpp:2524
 msgid "GUI command:"
 msgstr "GUI kommando:"
 
-#: src/PrefsUnifiedDlg.cpp:2460
+#: src/PrefsUnifiedDlg.cpp:2540
 msgid "The following variables will be replaced:"
 msgstr "Följande variabler kommer att ersättas:"
 
-#: src/PrefsUnifiedDlg.cpp:2628
+#: src/PrefsUnifiedDlg.cpp:2708
 msgid ""
 "The following folders look like system or sensitive locations:\n"
 "\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2633
+#: src/PrefsUnifiedDlg.cpp:2713
 msgid "Sharing them recursively will publish every file underneath on the eD2k/Kad networks. Do you really want to do this?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2636
+#: src/PrefsUnifiedDlg.cpp:2716
 #, fuzzy
 msgid "Confirm shared folders"
 msgstr "Delade mappar"
 
-#: src/PrefsUnifiedDlg.cpp:2664
+#: src/PrefsUnifiedDlg.cpp:2744
 #, fuzzy
 msgid "Reloading shared files..."
 msgstr "Återladda dina delade filer"
 
-#: src/PrefsUnifiedDlg.cpp:2665
+#: src/PrefsUnifiedDlg.cpp:2745
 msgid "Scanning for subdirectories..."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2666
+#: src/PrefsUnifiedDlg.cpp:2746
 #, fuzzy
 msgid "Updating shared folders"
 msgstr "Delade mappar"
 
-#: src/PrefsUnifiedDlg.cpp:2693
+#: src/PrefsUnifiedDlg.cpp:2773
 #, c-format
 msgid "Scanned %u directories..."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2743
+#: src/PrefsUnifiedDlg.cpp:2823
 #, fuzzy, c-format
 msgid "Reloading shared files: %u files scanned"
 msgstr "Ladda om listan med delade filer."
 
-#: src/PrefsUnifiedDlg.cpp:2793
+#: src/PrefsUnifiedDlg.cpp:2873
 #, fuzzy
 msgid "Shared folder"
 msgstr "Delade mappar"

--- a/po/sv.po
+++ b/po/sv.po
@@ -9,8 +9,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-28 12:12+0200\n"
-"PO-Revision-Date: 2026-07-27 10:35+0000\n"
+"POT-Creation-Date: 2026-07-28 08:06+0200\n"
+"PO-Revision-Date: 2026-07-27 11:46+0000\n"
 "Last-Translator: raffe <raffe@localhost.se>\n"
 "Language-Team: Swedish <tp-sv@listor.tp-sv.se>\n"
 "Language: sv\n"
@@ -144,7 +144,7 @@ msgstr ""
 msgid "Not now"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:422 src/amuleDlg.cpp:665
+#: src/AppImageIntegration.cpp:422 src/amuleDlg.cpp:600
 msgid "Don't ask again"
 msgstr ""
 
@@ -202,83 +202,83 @@ msgstr "Kunde inte öppna ED2KLinks-filen"
 msgid "WARNING: You can't add yourself as a source for an eD2k link while having a lowid."
 msgstr "VARNING: Du kan inte lägga till dig själv som källa för en eD2k-länk när du har lowid."
 
-#: src/amule.cpp:301
+#: src/amule.cpp:300
 msgid "Now, exiting main app..."
 msgstr "Nu, avslutar huvudapplikationen..."
 
-#: src/amule.cpp:331
+#: src/amule.cpp:330
 #, c-format
 msgid "Terminating amuleweb instance with pid '%d' ... "
 msgstr "Avslutar  amuleweb-instansen med pid '%d' ... "
 
-#: src/amule.cpp:335
+#: src/amule.cpp:334
 #, c-format
 msgid "Killing amuleweb instance with pid '%d' ... "
 msgstr "Dödar amuleweb-instansen med pid '%d' ... "
 
-#: src/amule.cpp:337 src/amule.cpp:350 src/ClientRef.cpp:180
-#: src/SearchDlg.cpp:1041 src/ServerListCtrl.cpp:98
+#: src/amule.cpp:336 src/amule.cpp:349 src/ClientRef.cpp:180
+#: src/SearchDlg.cpp:880 src/ServerListCtrl.cpp:98
 msgid "Failed"
 msgstr "Misslyckades"
 
-#: src/amule.cpp:344
+#: src/amule.cpp:343
 #, fuzzy, c-format
 msgid "Terminating amuleapi instance with pid '%d' ... "
 msgstr "Avslutar  amuleweb-instansen med pid '%d' ... "
 
-#: src/amule.cpp:348
+#: src/amule.cpp:347
 #, fuzzy, c-format
 msgid "Killing amuleapi instance with pid '%d' ... "
 msgstr "Dödar amuleweb-instansen med pid '%d' ... "
 
-#: src/amule.cpp:356
+#: src/amule.cpp:355
 msgid "aMule OnExit: Terminating core."
 msgstr "aMule VidAvslut: Avslutar huvudprogrammet."
 
-#: src/amule.cpp:467
+#: src/amule.cpp:466
 msgid "aMule shutdown completed."
 msgstr "aMules avslutning slutförd"
 
-#: src/amule.cpp:471
+#: src/amule.cpp:470
 msgid "Memory debug results for aMule exit:"
 msgstr "Minnes-debug-resultat för aMules avslut"
 
-#: src/amule.cpp:652
+#: src/amule.cpp:651
 #, c-format
 msgid "Binding aMule's peer-to-peer traffic to interface: %s (HTTP updates use the default route)"
 msgstr ""
 
-#: src/amule.cpp:656
+#: src/amule.cpp:655
 #, c-format
 msgid "Binding all network traffic to interface: %s"
 msgstr ""
 
-#: src/amule.cpp:660
+#: src/amule.cpp:659
 #, c-format
 msgid "WARNING: configured network interface '%s' was not found - traffic is NOT bound to it and may leave via the default route. Check the interface name in Preferences."
 msgstr ""
 
-#: src/amule.cpp:666
+#: src/amule.cpp:665
 #, c-format
 msgid "WARNING: binding to network interface '%s' requires elevated privileges and was NOT applied - traffic may leave via the default route. Grant the capability (e.g. 'sudo setcap cap_net_raw+ep' on the aMule binary) or run with sufficient privileges."
 msgstr ""
 
-#: src/amule.cpp:674
+#: src/amule.cpp:673
 #, c-format
 msgid "WARNING: could not bind to network interface '%s' - traffic may leave via the default route."
 msgstr ""
 
-#: src/amule.cpp:733
+#: src/amule.cpp:732
 msgid "Your locale has been changed to System Default due to a configuration change. Sorry."
 msgstr "Din plats har ändrats till systemets standard på grund av en konfigurationsändring. Ledsen."
 
-#: src/amule.cpp:735 src/amule.cpp:1589 src/CatDialog.cpp:128
+#: src/amule.cpp:734 src/amule.cpp:1581 src/CatDialog.cpp:128
 #: src/CatDialog.cpp:136 src/CatDialog.cpp:149 src/ServerList.cpp:366
 #: src/ServerListCtrl.cpp:152
 msgid "Info"
 msgstr "Info"
 
-#: src/amule.cpp:742
+#: src/amule.cpp:741
 msgid ""
 "\n"
 "EC configuration"
@@ -286,74 +286,74 @@ msgstr ""
 "\n"
 "EC-konfiguration"
 
-#: src/amule.cpp:745
+#: src/amule.cpp:744
 msgid "Password set and external connections enabled."
 msgstr "Lösenord sparad och extern anslutning aktiverad."
 
-#: src/amule.cpp:755 src/KadDlg.cpp:176 src/KadDlg.cpp:185
-#: src/PrefsUnifiedDlg.cpp:1461 src/SharedFilesCtrl.cpp:476
+#: src/amule.cpp:754 src/KadDlg.cpp:176 src/KadDlg.cpp:185
+#: src/PrefsUnifiedDlg.cpp:1387 src/SharedFilesCtrl.cpp:476
 msgid "WARNING"
 msgstr "VARNING"
 
-#: src/amule.cpp:992
+#: src/amule.cpp:991
 #, fuzzy
 msgid "Network bootstrap"
 msgstr "Nätverk"
 
-#: src/amule.cpp:997
+#: src/amule.cpp:996
 msgid ""
 "aMule has detected missing network bootstrap files.\n"
 "Select which ones to download:"
 msgstr ""
 
-#: src/amule.cpp:1006 src/FirstRunWizard.cpp:411
+#: src/amule.cpp:1005 src/FirstRunWizard.cpp:411
 #, fuzzy
 msgid "eD2k server list (server.met)"
 msgstr "%i server hittad i server.met"
 
-#: src/amule.cpp:1013 src/FirstRunWizard.cpp:416
+#: src/amule.cpp:1012 src/FirstRunWizard.cpp:416
 msgid "Kad bootstrap nodes (nodes.dat)"
 msgstr ""
 
-#: src/amule.cpp:1103
+#: src/amule.cpp:1102
 #, c-format
 msgid "web server running on pid %d"
 msgstr "webbservern kör på pid %d"
 
-#: src/amule.cpp:1116
+#: src/amule.cpp:1115
 #, fuzzy
 msgid "You requested to run web server on startup, but the amuleweb binary cannot be run. Please install the package containing aMule web server, or build aMule from source with -DBUILD_WEBSERVER=YES and install it."
 msgstr "Du vill köra webbservern vid uppstart, men binärfilen amuleweb kan inte köras. Vänligen installera paketet med aMule webservern eller compilera aMule med --enable-webserver och kör make install"
 
-#: src/amule.cpp:1121 src/amule.cpp:1185 src/amule.cpp:1299 src/amule.cpp:1601
+#: src/amule.cpp:1120 src/amule.cpp:1177 src/amule.cpp:1291 src/amule.cpp:1593
 #: src/amule-remote-gui.cpp:603 src/amule-remote-gui.cpp:671
 #: src/amule-remote-gui.cpp:709 src/amule-remote-gui.cpp:1282
 #: src/amule-remote-gui.cpp:1345 src/amule-remote-gui.cpp:1372
-#: src/DownloadQueue.cpp:1481 src/PrefsUnifiedDlg.cpp:1247
+#: src/DownloadQueue.cpp:1481
 msgid "ERROR"
 msgstr "FEL"
 
-#: src/amule.cpp:1174
+#: src/amule.cpp:1166
 #, fuzzy, c-format
 msgid "amuleapi running on pid %d"
 msgstr "webbservern kör på pid %d"
 
-#: src/amule.cpp:1180
+#: src/amule.cpp:1172
 #, fuzzy
 msgid "You requested to run amuleapi on startup, but the amuleapi binary cannot be run. Please install the package containing aMule's REST API server, or build aMule from source with -DBUILD_AMULEAPI=YES and install it."
 msgstr "Du vill köra webbservern vid uppstart, men binärfilen amuleweb kan inte köras. Vänligen installera paketet med aMule webservern eller compilera aMule med --enable-webserver och kör make install"
 
-#: src/amule.cpp:1267
+#: src/amule.cpp:1259
 #, c-format
 msgid "Could not bind ports to the specified address: %s"
 msgstr "Kunde inte binda portarna till specificerad adress: %s"
 
-#: src/amule.cpp:1291
+#: src/amule.cpp:1283
 #, c-format
 msgid "Port %u is not available. You will be LOWID\n"
 msgstr "Port %u är inte tillgänglig. Du kommer att bli LOWID\n"
 
-#: src/amule.cpp:1296
+#: src/amule.cpp:1288
 #, c-format
 msgid ""
 "Port %u is not available!\n"
@@ -368,48 +368,48 @@ msgstr ""
 "\n"
 "Kontrollera ditt nätverk för att se att porten är öppen för ut och in-trafik."
 
-#: src/amule.cpp:1393
+#: src/amule.cpp:1385
 msgid "Failed to create OnlineSig File"
 msgstr "Misslyckades med att skapa OnlineSig-fil"
 
-#: src/amule.cpp:1401
+#: src/amule.cpp:1393
 msgid "Failed to create aMule OnlineSig File"
 msgstr "Misslyckades med att skapa aMule OnlineSig-fil"
 
-#: src/amule.cpp:1564
+#: src/amule.cpp:1556
 msgid "The selected locale seems not to be installed on your box. (Note: I'll try to set it anyway)"
 msgstr "Den valda platsen verkar inte vara installerad på din burk. (OBS: Jag försöker ändå)"
 
-#: src/amule.cpp:1574
+#: src/amule.cpp:1566
 #, c-format
 msgid "This is the first time you run aMule %s"
 msgstr "Det här är första gången du kör aMule %s"
 
-#: src/amule.cpp:1577
+#: src/amule.cpp:1569
 msgid "This version is a testing version, updated daily, and\n"
 msgstr "Den här versionen är en testversion, uppdateras dagligen, och\n"
 
-#: src/amule.cpp:1578
+#: src/amule.cpp:1570
 msgid "we give no warranty it won't break anything, burn your house,\n"
 msgstr "vi ger inga garantier att den inte förstör allt, bränner ner huset,\n"
 
-#: src/amule.cpp:1579
+#: src/amule.cpp:1571
 msgid "or kill your dog. But it *should* be safe to use anyway.\n"
 msgstr "eller dödar din hund. Men den *bör* vara säker att använda.\n"
 
-#: src/amule.cpp:1584
+#: src/amule.cpp:1576
 msgid "More information, support and new releases can found at our homepage,\n"
 msgstr "Mer information, support och nya versioner kan hittas på vår hemsida,\n"
 
-#: src/amule.cpp:1585
+#: src/amule.cpp:1577
 msgid "at https://amule-org.github.io, or in our IRC channel #aMule at irc.libera.chat.\n"
 msgstr "https://amule-org.github.io, eller i vår IRC-kanal #aMule på irc.libera.chat.\n"
 
-#: src/amule.cpp:1587
+#: src/amule.cpp:1579
 msgid "Feel free to report any bugs to https://github.com/amule-org/amule/issues"
 msgstr "Rapportera gärna eventuella fel på https://github.com/amule-org/amule/issues"
 
-#: src/amule.cpp:1599
+#: src/amule.cpp:1591
 msgid ""
 "The folder for Online Signature files you specified is INVALID!\n"
 " OnlineSignature will be DISABLED until you fix it on preferences."
@@ -417,137 +417,137 @@ msgstr ""
 "Katalogen för Online Signaturefiler som du angav är OGILTIG!\n"
 " OnlineSignatur kommer vara INAKTIVERAD tills du ändrar inställningarna."
 
-#: src/amule.cpp:1662
+#: src/amule.cpp:1654
 msgid "Server hostname notified"
 msgstr "Serverns hostname underrättad"
 
-#: src/amule.cpp:2039
+#: src/amule.cpp:2031
 #, c-format
 msgid "Disk space preallocation for file '%s' failed: %s"
 msgstr "Förallokerad diskutrymme för filen '%s' misslyckades: %s"
 
-#: src/amule.cpp:2168
+#: src/amule.cpp:2160
 msgid "ERROR: can't open logfile"
 msgstr "FEL: kan inte öppna loggfilen"
 
-#: src/amule.cpp:2172
+#: src/amule.cpp:2164
 msgid "WARNING: logfile is empty. Something is wrong."
 msgstr "VARNING: loggfilen är tom. Någonting är fel."
 
-#: src/amule.cpp:2189
+#: src/amule.cpp:2181
 msgid "Log has been reset"
 msgstr "Loggen har nollställts"
 
-#: src/amule.cpp:2213
+#: src/amule.cpp:2205
 #, c-format
 msgid "ServerMessage: %s"
 msgstr "Servermeddelande: %s"
 
-#: src/amule.cpp:2256 src/IP2Country.cpp:220 src/IPFilter.cpp:514
+#: src/amule.cpp:2248 src/IP2Country.cpp:220 src/IPFilter.cpp:514
 #: src/ServerList.cpp:875
 #, c-format
 msgid "Skipped download of %s, because requested file is not newer."
 msgstr "Avslutade nerladdningen av %s eftersom begärd fil inte är nyare."
 
-#: src/amule.cpp:2259
+#: src/amule.cpp:2251
 msgid "Failed to download the nodes list."
 msgstr "Misslyckades med att hämta nodlistan."
 
-#: src/amule.cpp:2322
+#: src/amule.cpp:2314
 msgid "Failed to open the downloaded version check file"
 msgstr "Misslyckades med att öppna den hämtade versionskontrollfilen"
 
-#: src/amule.cpp:2325 src/amule.cpp:2344
+#: src/amule.cpp:2317 src/amule.cpp:2336
 msgid "Corrupted version check file"
 msgstr "Korrupt versionskontrollfil"
 
-#: src/amule.cpp:2367
+#: src/amule.cpp:2359
 msgid "You are using an outdated version of aMule!"
 msgstr "Du använder en gammal version av aMule!"
 
-#: src/amule.cpp:2369
+#: src/amule.cpp:2361
 #, c-format
 msgid "Your aMule version is %i.%i.%i and the latest version is %li.%li.%li"
 msgstr "Din aMuleversion är %i.%i.%i och den senaste versionen är %li.%li.%li"
 
-#: src/amule.cpp:2373
+#: src/amule.cpp:2365
 msgid "The latest version can always be found at https://github.com/amule-org/amule/releases/latest"
 msgstr "Den senaste versionen kan alltid hittas på https://github.com/amule-org/amule/releases/latest"
 
-#: src/amule.cpp:2376
+#: src/amule.cpp:2368
 #, c-format
 msgid "WARNING: Your aMuled version is outdated: %i.%i.%i < %li.%li.%li"
 msgstr "VARNING: Din version av aMuled är gammal: %i.%i.%i < %li.%li.%li"
 
-#: src/amule.cpp:2382
+#: src/amule.cpp:2374
 msgid "Your copy of aMule is up to date."
 msgstr "Din version av aMule är den senaste."
 
-#: src/amule.cpp:2389
+#: src/amule.cpp:2381
 msgid "Failed to download the version check file"
 msgstr "Misslyckades med att hämta versionskontrollfilen"
 
-#: src/amule.cpp:2558 src/amule-remote-gui.cpp:1133
+#: src/amule.cpp:2550 src/amule-remote-gui.cpp:1133
 #, c-format
 msgid "Users: %s | Files: %s"
 msgstr "Användare: %s | Filer: %s"
 
-#: src/amule.cpp:2559 src/amule-remote-gui.cpp:1134
+#: src/amule.cpp:2551 src/amule-remote-gui.cpp:1134
 #, c-format
 msgid "Users: E: %s K: %s | Files: E: %s K: %s"
 msgstr "Användare: E: %s K: %s | Filer: E: %s K: %s"
 
-#: src/amule.cpp:2573 src/amule-remote-gui.cpp:1147
+#: src/amule.cpp:2565 src/amule-remote-gui.cpp:1147
 msgid "No networks selected"
 msgstr "Inga nätverk valda"
 
-#: src/amule.cpp:2641 src/TextClient.cpp:903
+#: src/amule.cpp:2633 src/TextClient.cpp:903
 msgid "with LowID"
 msgstr "med LowID"
 
-#: src/amule.cpp:2641 src/TextClient.cpp:904
+#: src/amule.cpp:2633 src/TextClient.cpp:904
 msgid "with HighID"
 msgstr "med HighID"
 
-#: src/amule.cpp:2643
+#: src/amule.cpp:2635
 #, c-format
 msgid "Connected to %s %s"
 msgstr "Ansluten till %s %s"
 
-#: src/amule.cpp:2648
+#: src/amule.cpp:2640
 #, c-format
 msgid "Connecting to %s"
 msgstr "Ansluter till %s"
 
-#: src/amule.cpp:2650
+#: src/amule.cpp:2642
 msgid "Disconnected from eD2k"
 msgstr "Frånkopplad från eD2k"
 
-#: src/amule.cpp:2659
+#: src/amule.cpp:2651
 msgid "Kad started."
 msgstr "Kad startad."
 
-#: src/amule.cpp:2661
+#: src/amule.cpp:2653
 msgid "Kad stopped."
 msgstr "Kad stoppad."
 
-#: src/amule.cpp:2669
+#: src/amule.cpp:2661
 msgid "Connected to Kad (ok)"
 msgstr "Ansluten till Kad (ok)"
 
-#: src/amule.cpp:2671
+#: src/amule.cpp:2663
 msgid "Connected to Kad (firewalled)"
 msgstr "Ansluten till Kad (brandvägg)"
 
-#: src/amule.cpp:2675
+#: src/amule.cpp:2667
 msgid "Disconnected from Kad"
 msgstr "Frånkopplad från Kad"
 
-#: src/amule.cpp:2707
+#: src/amule.cpp:2699
 msgid "Kad network cannot be used if UDP port is disabled on preferences, not starting."
 msgstr "Kadnätverket kan inte användas om UDP-porten är inaktiverad i inställningarna, startar inte."
 
-#: src/amule.cpp:2711
+#: src/amule.cpp:2703
 msgid "Kad network disabled on preferences, not connecting."
 msgstr "Kadnätverket är inaktiverad i inställningarna, ansluter inte."
 
@@ -573,68 +573,30 @@ msgstr "Kan inte skapa Pid-fil"
 msgid "ERROR: %s"
 msgstr "FEL: %s"
 
-#: src/amuleDlg.cpp:250
+#: src/amuleDlg.cpp:236
 #, c-format
 msgid "This is aMule %s based on eMule."
 msgstr "Det här är aMule %s baserad på eMule."
 
-#: src/amuleDlg.cpp:251
+#: src/amuleDlg.cpp:237
 #, c-format
 msgid "Running on %s"
 msgstr "Kör på %s"
 
-#: src/amuleDlg.cpp:253
+#: src/amuleDlg.cpp:239
 msgid "Visit https://github.com/amule-org/amule/releases/latest to check if a new version is available."
 msgstr "Besök https://github.com/amule-org/amule/releases/latest för att se om en ny version finns tillgänglig."
 
-#: src/amuleDlg.cpp:282
+#: src/amuleDlg.cpp:268
 msgid "FATAL ERROR: Failed to create Timer"
 msgstr "ALLVARLIGT FEL: Kunde inte skapa Timer"
 
-#: src/amuleDlg.cpp:361 src/amuleDlg.cpp:1810 src/amuleDlg.cpp:2056
-#: src/muuli_wdr.cpp:1492 src/muuli_wdr.cpp:3439
-msgid "Networks"
-msgstr "Nätverk"
-
-#: src/amuleDlg.cpp:362 src/amuleDlg.cpp:1816 src/muuli_wdr.cpp:3440
-msgid "Searches"
-msgstr "Sökningar"
-
-#: src/amuleDlg.cpp:363 src/amuleDlg.cpp:1822 src/DownloadListCtrl.cpp:740
-#: src/muuli_wdr.cpp:392 src/muuli_wdr.cpp:1585 src/muuli_wdr.cpp:3441
-#: src/Statistics.cpp:829
-msgid "Downloads"
-msgstr "Hämtningar"
-
-#: src/amuleDlg.cpp:364 src/amuleDlg.cpp:1828 src/muuli_wdr.cpp:3315
-msgid "Shared files"
-msgstr "Delade filer"
-
-#: src/amuleDlg.cpp:365 src/amuleDlg.cpp:1834 src/muuli_wdr.cpp:2947
-#: src/muuli_wdr.cpp:3397 src/muuli_wdr.cpp:3444
-msgid "Messages"
-msgstr "Meddelanden"
-
-#: src/amuleDlg.cpp:366 src/amuleDlg.cpp:1840 src/muuli_wdr.cpp:3445
-#: src/PrefsUnifiedDlg.cpp:314 src/Statistics.cpp:779 src/Statistics.cpp:1235
-msgid "Statistics"
-msgstr "Statistik"
-
-#: src/amuleDlg.cpp:368 src/amuleDlg.cpp:1847 src/muuli_wdr.cpp:3447
-#: src/PrefsUnifiedDlg.cpp:330 src/utils/wxCas/src/wxcasprefs.cpp:39
-msgid "Preferences"
-msgstr "Inställningar"
-
-#: src/amuleDlg.cpp:371
-msgid "Navigate"
-msgstr ""
-
-#: src/amuleDlg.cpp:657
+#: src/amuleDlg.cpp:592
 #, fuzzy
 msgid "New version available"
 msgstr "Inte tillgänglig"
 
-#: src/amuleDlg.cpp:661
+#: src/amuleDlg.cpp:596
 #, fuzzy, c-format
 msgid ""
 "A new version of aMule (%s) is available.\n"
@@ -644,185 +606,218 @@ msgid ""
 "Would you like to open the download page?"
 msgstr "Den senaste versionen kan alltid hittas på https://github.com/amule-org/amule/releases/latest"
 
-#: src/amuleDlg.cpp:743
+#: src/amuleDlg.cpp:678
 msgid "aMule dialog destroyed"
 msgstr "aMule-dialog avslutad"
 
-#: src/amuleDlg.cpp:766 src/DataToText.cpp:68 src/IPFilter.cpp:547
+#: src/amuleDlg.cpp:701 src/DataToText.cpp:68 src/IPFilter.cpp:547
 msgid "Connecting"
 msgstr "Ansluter"
 
-#: src/amuleDlg.cpp:958
+#: src/amuleDlg.cpp:893
 msgid "eD2k: Connecting"
 msgstr "eD2k: Ansluter"
 
-#: src/amuleDlg.cpp:962
+#: src/amuleDlg.cpp:897
 msgid "eD2k: Disconnected"
 msgstr "eD2k: Frånkopplad"
 
-#: src/amuleDlg.cpp:968
+#: src/amuleDlg.cpp:903
 msgid "Kad: Firewalled"
 msgstr "Kad: Via brandvägg"
 
-#: src/amuleDlg.cpp:972
+#: src/amuleDlg.cpp:907
 msgid "Kad: Connected"
 msgstr "Kad: Ansluten"
 
-#: src/amuleDlg.cpp:977
+#: src/amuleDlg.cpp:912
 msgid "Kad: Connecting"
 msgstr "Kad: Ansluter"
 
-#: src/amuleDlg.cpp:981
+#: src/amuleDlg.cpp:916
 msgid "Kad: Off"
 msgstr "Kad: Av"
 
-#: src/amuleDlg.cpp:1029 src/DownloadListCtrl.cpp:505
+#: src/amuleDlg.cpp:964 src/DownloadListCtrl.cpp:505
 #: src/DownloadListCtrl.cpp:749 src/FriendListCtrl.cpp:180
 #: src/muuli_wdr.cpp:731 src/muuli_wdr.cpp:782 src/muuli_wdr.cpp:846
-#: src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2252 src/muuli_wdr.cpp:2337
-#: src/muuli_wdr.cpp:3085 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
+#: src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2224 src/muuli_wdr.cpp:2309
+#: src/muuli_wdr.cpp:3057 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
 #: src/ServerListCtrl.cpp:606 src/TransferWnd.cpp:378
 #: src/utils/wxCas/src/wxcasprefs.cpp:235
 msgid "Cancel"
 msgstr "Avbryt"
 
-#: src/amuleDlg.cpp:1030
+#: src/amuleDlg.cpp:965
 msgid "Stop the current connection attempts"
 msgstr "Stoppa de nuvarande anslutningsförsöken"
 
-#: src/amuleDlg.cpp:1035 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976
-#: src/muuli_wdr.cpp:2475
+#: src/amuleDlg.cpp:970 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976
+#: src/muuli_wdr.cpp:2447
 msgid "Disconnect"
 msgstr "Koppla från"
 
-#: src/amuleDlg.cpp:1036
+#: src/amuleDlg.cpp:971
 msgid "Disconnect from the currently connected networks"
 msgstr "Koppla från de nätverk som nu är anslutna."
 
-#: src/amuleDlg.cpp:1041 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979
-#: src/muuli_wdr.cpp:2630 src/muuli_wdr.cpp:3082 src/muuli_wdr.cpp:3437
+#: src/amuleDlg.cpp:976 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979
+#: src/muuli_wdr.cpp:2602 src/muuli_wdr.cpp:3054 src/muuli_wdr.cpp:3409
 msgid "Connect"
 msgstr "Anslut"
 
-#: src/amuleDlg.cpp:1042
+#: src/amuleDlg.cpp:977
 msgid "Connect to the currently enabled networks"
 msgstr "Anslut till de nätverk som är aktiverade."
 
-#: src/amuleDlg.cpp:1154
+#: src/amuleDlg.cpp:1089
 #, fuzzy, c-format
 msgid "Up: %.1f%s (%.1f) | Down: %.1f%s (%.1f)"
 msgstr "Upp: %.1f(%.1f) | Ner: %.1f(%.1f)"
 
-#: src/amuleDlg.cpp:1156 src/amuleDlg.cpp:1158 src/amuleDlg.cpp:1162
-#: src/amuleDlg.cpp:1164 src/amuleDlg.cpp:1175 src/amuleDlg.cpp:1177
+#: src/amuleDlg.cpp:1091 src/amuleDlg.cpp:1093 src/amuleDlg.cpp:1097
+#: src/amuleDlg.cpp:1099 src/amuleDlg.cpp:1110 src/amuleDlg.cpp:1112
 #: src/MuleTrayIcon.cpp:796 src/MuleTrayIcon.cpp:799
 #, fuzzy
 msgid " MB/s"
 msgstr "MB/s"
 
-#: src/amuleDlg.cpp:1156 src/amuleDlg.cpp:1158 src/amuleDlg.cpp:1162
-#: src/amuleDlg.cpp:1164 src/amuleDlg.cpp:1175 src/amuleDlg.cpp:1177
+#: src/amuleDlg.cpp:1091 src/amuleDlg.cpp:1093 src/amuleDlg.cpp:1097
+#: src/amuleDlg.cpp:1099 src/amuleDlg.cpp:1110 src/amuleDlg.cpp:1112
 #: src/MuleTrayIcon.cpp:796 src/MuleTrayIcon.cpp:799
 #: src/utils/wxCas/src/wxcasframe.cpp:1041
 msgid " kB/s"
 msgstr " kB/s"
 
-#: src/amuleDlg.cpp:1161
+#: src/amuleDlg.cpp:1096
 #, fuzzy, c-format
 msgid "Up: %.1f%s | Down: %.1f%s"
 msgstr "Upp: %.1f | Ner: %.1f"
 
-#: src/amuleDlg.cpp:1193
+#: src/amuleDlg.cpp:1128
 #, c-format
 msgid "aMule (%s | Connected)"
 msgstr "aMule (%s | Ansluten)"
 
-#: src/amuleDlg.cpp:1195
+#: src/amuleDlg.cpp:1130
 #, c-format
 msgid "aMule (%s | Disconnected)"
 msgstr "aMule (%s | Frånkopplad)"
 
-#: src/amuleDlg.cpp:1248
+#: src/amuleDlg.cpp:1183
 #, c-format
 msgid "Do you really want to exit %s?"
 msgstr "Vill du verkligen avsluta %s?"
 
-#: src/amuleDlg.cpp:1250
+#: src/amuleDlg.cpp:1185
 msgid "Exit confirmation"
 msgstr "Bekräfta avslutning"
 
-#: src/amuleDlg.cpp:1613
+#: src/amuleDlg.cpp:1548
 msgid "Launch Command: "
 msgstr "Kör kommando:"
 
-#: src/amuleDlg.cpp:1632 src/muuli_wdr.cpp:1972 src/Preferences.cpp:979
+#: src/amuleDlg.cpp:1567 src/muuli_wdr.cpp:1971 src/Preferences.cpp:951
 msgid "- default -"
 msgstr "- standard -"
 
-#: src/amuleDlg.cpp:1660
+#: src/amuleDlg.cpp:1595
 #, c-format
 msgid "Skin directory '%s' does not exist"
 msgstr "Skin-mappen '%s' finns inte"
 
-#: src/amuleDlg.cpp:1663
+#: src/amuleDlg.cpp:1598
 #, c-format
 msgid "WARNING: Unable to open skin file '%s' for read"
 msgstr "Varning: Kan inte öppna skin-filen '%s' för läsning"
 
-#: src/amuleDlg.cpp:1814 src/muuli_wdr.cpp:3439
+#: src/amuleDlg.cpp:1722 src/amuleDlg.cpp:1968 src/muuli_wdr.cpp:1485
+#: src/muuli_wdr.cpp:3411
+msgid "Networks"
+msgstr "Nätverk"
+
+#: src/amuleDlg.cpp:1726 src/muuli_wdr.cpp:3411
 msgid "Networks Window"
 msgstr "Nätverksfönster"
 
-#: src/amuleDlg.cpp:1820 src/muuli_wdr.cpp:3440
+#: src/amuleDlg.cpp:1728 src/muuli_wdr.cpp:3412
+msgid "Searches"
+msgstr "Sökningar"
+
+#: src/amuleDlg.cpp:1732 src/muuli_wdr.cpp:3412
 msgid "Searches Window"
 msgstr "Sökfönster"
 
-#: src/amuleDlg.cpp:1826 src/muuli_wdr.cpp:3441
+#: src/amuleDlg.cpp:1734 src/DownloadListCtrl.cpp:740 src/muuli_wdr.cpp:392
+#: src/muuli_wdr.cpp:1578 src/muuli_wdr.cpp:3413 src/Statistics.cpp:829
+msgid "Downloads"
+msgstr "Hämtningar"
+
+#: src/amuleDlg.cpp:1738 src/muuli_wdr.cpp:3413
 msgid "Downloads Window"
 msgstr "Hämtningsfönster"
 
-#: src/amuleDlg.cpp:1832 src/muuli_wdr.cpp:3443
+#: src/amuleDlg.cpp:1740 src/muuli_wdr.cpp:3287
+msgid "Shared files"
+msgstr "Delade filer"
+
+#: src/amuleDlg.cpp:1744 src/muuli_wdr.cpp:3415
 msgid "Shared Files Window"
 msgstr "Delade filer-fönster"
 
-#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3444
+#: src/amuleDlg.cpp:1746 src/muuli_wdr.cpp:2919 src/muuli_wdr.cpp:3369
+#: src/muuli_wdr.cpp:3416
+msgid "Messages"
+msgstr "Meddelanden"
+
+#: src/amuleDlg.cpp:1750 src/muuli_wdr.cpp:3416
 msgid "Messages Window"
 msgstr "Meddelandefönster"
 
-#: src/amuleDlg.cpp:1844 src/muuli_wdr.cpp:3445
+#: src/amuleDlg.cpp:1752 src/muuli_wdr.cpp:3417 src/PrefsUnifiedDlg.cpp:312
+#: src/Statistics.cpp:779 src/Statistics.cpp:1235
+msgid "Statistics"
+msgstr "Statistik"
+
+#: src/amuleDlg.cpp:1756 src/muuli_wdr.cpp:3417
 msgid "Statistics Graph Window"
 msgstr "Statistiksgrafsfönster"
 
-#: src/amuleDlg.cpp:1851 src/muuli_wdr.cpp:3447
+#: src/amuleDlg.cpp:1759 src/muuli_wdr.cpp:3419 src/PrefsUnifiedDlg.cpp:328
+#: src/utils/wxCas/src/wxcasprefs.cpp:39
+msgid "Preferences"
+msgstr "Inställningar"
+
+#: src/amuleDlg.cpp:1763 src/muuli_wdr.cpp:3419
 msgid "Preferences Settings Window"
 msgstr "Inställningsfönster"
 
-#: src/amuleDlg.cpp:1854 src/muuli_wdr.cpp:3448
+#: src/amuleDlg.cpp:1766 src/muuli_wdr.cpp:3420
 msgid "Import"
 msgstr "Importera"
 
-#: src/amuleDlg.cpp:1858 src/muuli_wdr.cpp:3448
+#: src/amuleDlg.cpp:1770 src/muuli_wdr.cpp:3420
 msgid "The partfile importer tool"
 msgstr "Partfile-importerings-verktyget"
 
-#: src/amuleDlg.cpp:1861 src/muuli_wdr.cpp:3449
+#: src/amuleDlg.cpp:1773 src/muuli_wdr.cpp:3421
 #: src/utils/aLinkCreator/src/alcframe.cpp:262
 msgid "About"
 msgstr "Om"
 
-#: src/amuleDlg.cpp:1861 src/muuli_wdr.cpp:3449
+#: src/amuleDlg.cpp:1773 src/muuli_wdr.cpp:3421
 msgid "About/Help"
 msgstr "Om/Hjälp"
 
-#: src/amuleDlg.cpp:2059
+#: src/amuleDlg.cpp:1971
 msgid "eD2k network"
 msgstr "eD2k-nätverk"
 
-#: src/amuleDlg.cpp:2062
+#: src/amuleDlg.cpp:1974
 msgid "Kad network"
 msgstr "Kad-nätverk"
 
-#: src/amuleDlg.cpp:2062
+#: src/amuleDlg.cpp:1974
 msgid "No network"
 msgstr "Inget nätverk"
 
@@ -952,7 +947,7 @@ msgstr "Filen hittades inte."
 msgid "The core rejected these shared folders:%s"
 msgstr ""
 
-#: src/amule-remote-gui.cpp:1336 src/ExternalConn.cpp:2346
+#: src/amule-remote-gui.cpp:1336 src/ExternalConn.cpp:2345
 msgid "Invalid link or already on list."
 msgstr "Felaktig länk eller redan i listan."
 
@@ -968,7 +963,7 @@ msgstr "Kan inte skapa mappen '%s' för kategori '%s', behåller mappen '%s'."
 #: src/ClientDetailDialog.cpp:123 src/DataToText.cpp:61 src/DataToText.cpp:86
 #: src/DataToText.cpp:101 src/DataToText.cpp:136 src/DataToText.cpp:165
 #: src/DownloadListCtrl.cpp:1172 src/DownloadListCtrl.cpp:1185
-#: src/DownloadListCtrl.cpp:1196 src/ExternalConn.cpp:609
+#: src/DownloadListCtrl.cpp:1196 src/ExternalConn.cpp:608
 #: src/FileDetailDialog.cpp:203 src/FileDetailDialog.cpp:235
 #: src/FileDetailDialog.cpp:242 src/GenericClientListCtrl.cpp:1171
 #: src/GenericClientListCtrl.cpp:1182 src/GenericClientListCtrl.cpp:1192
@@ -1355,19 +1350,19 @@ msgstr "Auto [Hö]"
 msgid "Very low"
 msgstr "Mycket låg"
 
-#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:743 src/muuli_wdr.cpp:2303
+#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:743 src/muuli_wdr.cpp:2275
 #: src/ServerListCtrl.cpp:263 src/ServerListCtrl.cpp:456
 #: src/SharedFilesCtrl.cpp:145
 msgid "Low"
 msgstr "Låg"
 
-#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:744 src/muuli_wdr.cpp:2304
+#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:744 src/muuli_wdr.cpp:2276
 #: src/ServerListCtrl.cpp:266 src/ServerListCtrl.cpp:457
 #: src/SharedFilesCtrl.cpp:146
 msgid "Normal"
 msgstr "Normal"
 
-#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:745 src/muuli_wdr.cpp:2305
+#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:745 src/muuli_wdr.cpp:2277
 #: src/ServerListCtrl.cpp:269 src/ServerListCtrl.cpp:458
 #: src/SharedFilesCtrl.cpp:147
 msgid "High"
@@ -1459,8 +1454,8 @@ msgstr "Lokal server"
 msgid "Remote Server"
 msgstr "Fjärrserver"
 
-#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3202
-#: src/SearchDlg.cpp:119 src/TextClient.cpp:911
+#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3174
+#: src/SearchDlg.cpp:111 src/TextClient.cpp:911
 msgid "Kad"
 msgstr "Kad"
 
@@ -1531,7 +1526,7 @@ msgstr "Del"
 msgid "Size"
 msgstr "Storlek"
 
-#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3269
+#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3241
 msgid "Transferred"
 msgstr "Överfört"
 
@@ -1589,7 +1584,7 @@ msgstr ""
 "Återkoppling från: %s (%s)\n"
 "\n"
 
-#: src/DownloadListCtrl.cpp:746 src/muuli_wdr.cpp:2306
+#: src/DownloadListCtrl.cpp:746 src/muuli_wdr.cpp:2278
 #: src/SharedFilesCtrl.cpp:150
 msgid "Auto"
 msgstr "Auto"
@@ -1627,7 +1622,7 @@ msgid "Extended Options"
 msgstr "Utökade inställningar"
 
 #: src/DownloadListCtrl.cpp:770 src/DownloadListCtrl.cpp:822
-#: src/muuli_wdr.cpp:1790
+#: src/muuli_wdr.cpp:1789
 msgid "Preview"
 msgstr "Förhandsgranska"
 
@@ -1802,232 +1797,227 @@ msgstr[1] ""
 msgid "Invalid eD2k link! ERROR: %s"
 msgstr "Felaktig eD2k-länk! FEL: %s"
 
-#: src/ExternalConn.cpp:380
+#: src/ExternalConn.cpp:379
 msgid "Client sent packet after authentication failed."
 msgstr "Klienten skickade paket efter att autentisering misslyckades. "
 
-#: src/ExternalConn.cpp:397
+#: src/ExternalConn.cpp:396
 msgid "External connection closed."
 msgstr "Extern anslutning stängd."
 
-#: src/ExternalConn.cpp:474
+#: src/ExternalConn.cpp:473
 msgid "External connections disabled due to empty password!"
 msgstr "Externa anslutningar inaktiverade pga. tomt lösenord!"
 
-#: src/ExternalConn.cpp:495
+#: src/ExternalConn.cpp:494
 msgid "External connections disabled in config file"
 msgstr "Externa anslutningar inaktiverade i konfigfilen"
 
-#: src/ExternalConn.cpp:576
+#: src/ExternalConn.cpp:575
 msgid "New external connection accepted"
 msgstr "Ny extern anslutning accepterad"
 
-#: src/ExternalConn.cpp:579
+#: src/ExternalConn.cpp:578
 msgid "ERROR: couldn't accept a new external connection"
 msgstr "FEL: Kunde inte acceptera ny extern anslutning"
 
-#: src/ExternalConn.cpp:596
+#: src/ExternalConn.cpp:595
 msgid "External connection refused due to empty password in preferences!"
 msgstr "Extern anslutning nekad pga. tomt lösenord i inställningarna!"
 
-#: src/ExternalConn.cpp:608
+#: src/ExternalConn.cpp:607
 #, c-format
 msgid "Connecting client: %s %s"
 msgstr "Ansluter klient: %s %s"
 
-#: src/ExternalConn.cpp:610
+#: src/ExternalConn.cpp:609
 msgid "Unknown version"
 msgstr "Okänd version"
 
-#: src/ExternalConn.cpp:623
+#: src/ExternalConn.cpp:622
 msgid "Incorrect EC version ID, there might be binary incompatibility. Use core and remote from same snapshot."
 msgstr "Fel EC-versions-ID, kanske är det inkompatibla binärfiler. Använd core och remote från samma snapshot."
 
-#: src/ExternalConn.cpp:631
+#: src/ExternalConn.cpp:630
 msgid "You cannot connect to a release version from an arbitrary development snapshot! *sigh* possible crash prevented"
 msgstr "Du kan inte ansluta en release-version från en godtycklig utvecklings-snapshot! *suck* Trolig krasch förhindrad "
 
-#: src/ExternalConn.cpp:714
+#: src/ExternalConn.cpp:713
 msgid "Invalid protocol version."
 msgstr "Fel protokoll-version"
 
-#: src/ExternalConn.cpp:720
+#: src/ExternalConn.cpp:719
 msgid "Missing protocol version tag."
 msgstr "Saknar tag för protokoll-version"
 
-#: src/ExternalConn.cpp:728
+#: src/ExternalConn.cpp:727
 msgid "Authentication failed: invalid hash specified as EC password."
 msgstr "Autentisering misslyckades: fel hash specificerad som EC-lösenord"
 
-#: src/ExternalConn.cpp:776
+#: src/ExternalConn.cpp:775
 msgid "Authentication failed: wrong password."
 msgstr "Autentisering misslyckades: fel lösenord"
 
-#: src/ExternalConn.cpp:778
+#: src/ExternalConn.cpp:777
 msgid "Authentication failed: missing password."
 msgstr "Autentisering misslyckades: saknar lösenord"
 
-#: src/ExternalConn.cpp:789
+#: src/ExternalConn.cpp:788
 msgid "Invalid request, please authenticate first."
 msgstr "Felaktig begäran, vänligen autentisera först."
 
-#: src/ExternalConn.cpp:794
+#: src/ExternalConn.cpp:793
 msgid "Access granted."
 msgstr "Tillgång beviljad."
 
-#: src/ExternalConn.cpp:802
+#: src/ExternalConn.cpp:801
 #, c-format
 msgid "Sent error message \"%s\" to client."
 msgstr "Skickade felmeddelandet \"%s\" till klienten."
 
-#: src/ExternalConn.cpp:807
+#: src/ExternalConn.cpp:806
 #, c-format
 msgid "Unauthorized access attempt from %s. Connection closed."
 msgstr "Obehörigt åtkomstförsök från %s. Anslutning stängd."
 
-#: src/ExternalConn.cpp:1420
+#: src/ExternalConn.cpp:1419
 #, c-format
 msgid "Remote PartFile command failed: FileHash not found: %s"
 msgstr "Extern PartFile kommando misslyckades: FileHash hittades inte: %s"
 
-#: src/ExternalConn.cpp:1424
+#: src/ExternalConn.cpp:1423
 #, c-format
 msgid "FileHash not found: %s"
 msgstr "FileHash hittades inte: %s"
 
-#: src/ExternalConn.cpp:1471 src/ExternalConn.cpp:1559
-#: src/ExternalConn.cpp:1680
+#: src/ExternalConn.cpp:1470 src/ExternalConn.cpp:1558
+#: src/ExternalConn.cpp:1679
 msgid "OOPS! OpCode processing error!"
 msgstr "HOPPSAN!  OpCode-bearbetningsfel!"
 
-#: src/ExternalConn.cpp:1502
+#: src/ExternalConn.cpp:1501
 msgid "Server not added"
 msgstr "Server inte inlaggd"
 
-#: src/ExternalConn.cpp:1521
+#: src/ExternalConn.cpp:1520
 #, c-format
 msgid "server not found: %s"
 msgstr "server inte hittad: %s"
 
-#: src/ExternalConn.cpp:1538
+#: src/ExternalConn.cpp:1537
 msgid "need to define server to be removed"
 msgstr "måste definiera server som ska tas bort"
 
-#: src/ExternalConn.cpp:1553
+#: src/ExternalConn.cpp:1552
 msgid "eD2k is disabled in preferences."
 msgstr "eD2k är inaktiverad i inställningarna."
 
-#: src/ExternalConn.cpp:1658
+#: src/ExternalConn.cpp:1657
 #, fuzzy
 msgid "Friend not found."
 msgstr "Filen hittades inte."
 
-#: src/ExternalConn.cpp:1668
+#: src/ExternalConn.cpp:1667
 #, fuzzy
 msgid "Client not found."
 msgstr "Filen hittades inte."
 
-#: src/ExternalConn.cpp:1674
+#: src/ExternalConn.cpp:1673
 msgid "EC_TAG_FRIEND_SHARED requires EC_TAG_FRIEND or EC_TAG_CLIENT."
 msgstr ""
 
-#: src/ExternalConn.cpp:1992
+#: src/ExternalConn.cpp:1991
 msgid "WebSearch from remote interface makes no sense."
 msgstr "Websök från fjärrgränssnitt är meningslöst."
 
-#: src/ExternalConn.cpp:2027
+#: src/ExternalConn.cpp:2026
 msgid "Search in progress. Refetch results in a moment!"
 msgstr "Sök pågår. Visar snart svaren!"
 
-#: src/ExternalConn.cpp:2266
+#: src/ExternalConn.cpp:2265
 msgid "No points for graph."
 msgstr "Inga poäng för graf."
 
-#: src/ExternalConn.cpp:2276
+#: src/ExternalConn.cpp:2275
 msgid "Your client is not configured for this detail level."
 msgstr "Din klient är inte konfigurerad för denna detaljnivå."
 
-#: src/ExternalConn.cpp:2303
+#: src/ExternalConn.cpp:2302
 msgid "External Connection: shutdown requested"
 msgstr "Extern Anslutning: avstängning begärd"
 
-#: src/ExternalConn.cpp:2315
+#: src/ExternalConn.cpp:2314
 msgid "Already shutting down."
 msgstr "Håller redan på att stänga ner."
 
-#: src/ExternalConn.cpp:2333
+#: src/ExternalConn.cpp:2332
 #, c-format
 msgid "ExternalConn: adding link '%s'."
 msgstr "ExternalConn: lägger till länk '%s'."
 
-#: src/ExternalConn.cpp:2351
+#: src/ExternalConn.cpp:2350
 #, fuzzy, c-format
 msgid "%d of %d links failed (invalid or already on list)."
 msgstr "Felaktig länk eller redan i listan."
 
-#: src/ExternalConn.cpp:2374
+#: src/ExternalConn.cpp:2373
 msgid "Version check throttled; try again shortly."
 msgstr ""
 
-#: src/ExternalConn.cpp:2379
+#: src/ExternalConn.cpp:2378
 msgid "Version check is not available on this daemon."
 msgstr ""
 
-#: src/ExternalConn.cpp:2509
+#: src/ExternalConn.cpp:2508
 msgid "File not found."
 msgstr "Filen hittades inte."
 
-#: src/ExternalConn.cpp:2514
+#: src/ExternalConn.cpp:2513
 msgid "Invalid file name."
 msgstr "Ogiltigt filnamn."
 
-#: src/ExternalConn.cpp:2522
+#: src/ExternalConn.cpp:2521
 msgid "Unable to rename file."
 msgstr "Kunde inte byta namn på fil."
 
-#: src/ExternalConn.cpp:2839
-#, c-format
-msgid "Could not save the amuleapi password: %s"
-msgstr ""
-
-#: src/ExternalConn.cpp:3004 src/ExternalConn.cpp:3032
+#: src/ExternalConn.cpp:2992 src/ExternalConn.cpp:3020
 msgid "Kad is disabled in preferences."
 msgstr "Kad inaktiverad i inställningarna."
 
-#: src/ExternalConn.cpp:3045
+#: src/ExternalConn.cpp:3033
 msgid "Already connected to eD2k."
 msgstr "Redan ansluten till eD2k."
 
-#: src/ExternalConn.cpp:3048
+#: src/ExternalConn.cpp:3036
 msgid "Connecting to eD2k..."
 msgstr "Ansluter till eD2k..."
 
-#: src/ExternalConn.cpp:3057
+#: src/ExternalConn.cpp:3045
 msgid "Already connected to Kad."
 msgstr "Redan ansluten till Kad."
 
-#: src/ExternalConn.cpp:3060
+#: src/ExternalConn.cpp:3048
 msgid "Connecting to Kad..."
 msgstr "Ansluter till Kad..."
 
-#: src/ExternalConn.cpp:3067
+#: src/ExternalConn.cpp:3055
 msgid "All networks are disabled."
 msgstr "Alla nätverk är inaktiverade."
 
-#: src/ExternalConn.cpp:3076
+#: src/ExternalConn.cpp:3064
 msgid "Disconnected from eD2k."
 msgstr "Koppla ifrån eD2k."
 
-#: src/ExternalConn.cpp:3081
+#: src/ExternalConn.cpp:3069
 msgid "Disconnected from Kad."
 msgstr "Frånkopplad från Kad."
 
-#: src/ExternalConn.cpp:3090
+#: src/ExternalConn.cpp:3078
 #, c-format
 msgid "External Connection: invalid opcode received: %#x"
 msgstr "Extern anlutning: Felaktig opcode mottagen: %#x"
 
-#: src/ExternalConn.cpp:3095
+#: src/ExternalConn.cpp:3083
 msgid "Invalid opcode (wrong protocol version?)"
 msgstr "Felaktig opcode (fel protokollversion?)"
 
@@ -2343,19 +2333,19 @@ msgstr ""
 msgid "eD2k"
 msgstr "eD2k"
 
-#: src/FirstRunWizard.cpp:349 src/muuli_wdr.cpp:1495
+#: src/FirstRunWizard.cpp:349 src/muuli_wdr.cpp:1488
 msgid "Kademlia"
 msgstr "Kademlia"
 
-#: src/FirstRunWizard.cpp:359 src/muuli_wdr.cpp:1423
+#: src/FirstRunWizard.cpp:359 src/muuli_wdr.cpp:1416
 msgid "Standard TCP Port "
 msgstr "Standard TCP-port "
 
-#: src/FirstRunWizard.cpp:365 src/muuli_wdr.cpp:1435
+#: src/FirstRunWizard.cpp:365 src/muuli_wdr.cpp:1428
 msgid "Extended UDP port (Kad / global search) "
 msgstr "Utökad UDP-port (Kad / global sökning) "
 
-#: src/FirstRunWizard.cpp:377 src/muuli_wdr.cpp:1442
+#: src/FirstRunWizard.cpp:377 src/muuli_wdr.cpp:1435
 msgid "Enable UPnP for router port forwarding"
 msgstr "Aktivera UPnP för vidarebefordring av routerport"
 
@@ -2382,7 +2372,7 @@ msgstr ""
 msgid "Your peer lists are already in place - nothing to download."
 msgstr "Du försöker redan hämta filen %s"
 
-#: src/FirstRunWizard.cpp:434 src/muuli_wdr.cpp:1540
+#: src/FirstRunWizard.cpp:434 src/muuli_wdr.cpp:1533
 msgid "Auto-update server list at startup"
 msgstr "Auto-uppdatera serverlistan vid start"
 
@@ -2428,23 +2418,23 @@ msgid ""
 "want downloads on a different (e.g. larger) disk."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:549 src/FirstRunWizard.cpp:611 src/muuli_wdr.cpp:1702
+#: src/FirstRunWizard.cpp:549 src/FirstRunWizard.cpp:611 src/muuli_wdr.cpp:1701
 msgid "Destination folder for downloads"
 msgstr "Målmapp för hämtningar"
 
-#: src/FirstRunWizard.cpp:553 src/FirstRunWizard.cpp:569 src/muuli_wdr.cpp:1349
-#: src/muuli_wdr.cpp:1366 src/muuli_wdr.cpp:1677 src/muuli_wdr.cpp:1708
-#: src/muuli_wdr.cpp:1720 src/muuli_wdr.cpp:2790
+#: src/FirstRunWizard.cpp:553 src/FirstRunWizard.cpp:569 src/muuli_wdr.cpp:1342
+#: src/muuli_wdr.cpp:1359 src/muuli_wdr.cpp:1676 src/muuli_wdr.cpp:1707
+#: src/muuli_wdr.cpp:1719 src/muuli_wdr.cpp:2762
 #: src/utils/aLinkCreator/src/alcframe.cpp:135
 #: src/utils/wxCas/src/wxcasprefs.cpp:52 src/utils/wxCas/src/wxcasprefs.cpp:118
 msgid "Browse"
 msgstr "Bläddra"
 
-#: src/FirstRunWizard.cpp:559 src/muuli_wdr.cpp:1713
+#: src/FirstRunWizard.cpp:559 src/muuli_wdr.cpp:1712
 msgid "(All files in this folder are shared with other peers)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:565 src/FirstRunWizard.cpp:624 src/muuli_wdr.cpp:1715
+#: src/FirstRunWizard.cpp:565 src/FirstRunWizard.cpp:624 src/muuli_wdr.cpp:1714
 msgid "Folder for temporary download files"
 msgstr "Mapp för temporära nerladdningsfiler"
 
@@ -2475,7 +2465,7 @@ msgstr "Kunde inte öppna vän-list-filen 'emfriends.met' för skrivning!"
 msgid "CRITICAL - no client on StartChatSession"
 msgstr "KRITISKT - ingen klient för StartChatSession"
 
-#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2696 src/muuli_wdr.cpp:3373
+#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2668 src/muuli_wdr.cpp:3345
 msgid "Friends"
 msgstr "Vänner"
 
@@ -2586,8 +2576,8 @@ msgstr "Ingen"
 msgid "No"
 msgstr "Nej"
 
-#: src/GenericClientListCtrl.cpp:1216 src/PrefsUnifiedDlg.cpp:2898
-#: src/PrefsUnifiedDlg.cpp:2948 src/ServerListCtrl.cpp:276
+#: src/GenericClientListCtrl.cpp:1216 src/PrefsUnifiedDlg.cpp:2818
+#: src/PrefsUnifiedDlg.cpp:2868 src/ServerListCtrl.cpp:276
 msgid "Yes"
 msgstr "Ja"
 
@@ -2756,10 +2746,10 @@ msgstr "Ogiltig port till bootstrap"
 msgid "Please fill all fields required"
 msgstr "Fyll i alla fält som krävs"
 
-#: src/KadDlg.cpp:192 src/PartFile.cpp:1031 src/PrefsUnifiedDlg.cpp:1134
-#: src/PrefsUnifiedDlg.cpp:1204 src/PrefsUnifiedDlg.cpp:1405
-#: src/PrefsUnifiedDlg.cpp:1663 src/PrefsUnifiedDlg.cpp:1673
-#: src/PrefsUnifiedDlg.cpp:1690 src/PrefsUnifiedDlg.cpp:1738
+#: src/KadDlg.cpp:192 src/PartFile.cpp:1031 src/PrefsUnifiedDlg.cpp:1162
+#: src/PrefsUnifiedDlg.cpp:1331 src/PrefsUnifiedDlg.cpp:1589
+#: src/PrefsUnifiedDlg.cpp:1599 src/PrefsUnifiedDlg.cpp:1616
+#: src/PrefsUnifiedDlg.cpp:1658
 msgid "Message"
 msgstr "Meddelande"
 
@@ -2861,7 +2851,7 @@ msgstr "Dela-förhållande"
 msgid "Uploaded"
 msgstr "Uppladdad"
 
-#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3253
+#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3225
 msgid "Requested"
 msgstr "Begärda"
 
@@ -2985,7 +2975,7 @@ msgid "WARNING: "
 msgstr "VARNING: "
 
 #: src/MuleNotebook.cpp:179 src/muuli_wdr.cpp:817 src/muuli_wdr.cpp:1229
-#: src/muuli_wdr.cpp:3157 src/muuli_wdr.cpp:3413
+#: src/muuli_wdr.cpp:3129 src/muuli_wdr.cpp:3385
 msgid "Close"
 msgstr "Stäng"
 
@@ -2998,12 +2988,12 @@ msgstr "Klipp ut"
 msgid "Copy"
 msgstr "Kopiera"
 
-#: src/MuleTextCtrl.cpp:88 src/SearchDlg.cpp:261
+#: src/MuleTextCtrl.cpp:88
 msgid "Paste"
 msgstr "Klistra in"
 
 #: src/MuleTextCtrl.cpp:89 src/muuli_wdr.cpp:358 src/muuli_wdr.cpp:757
-#: src/muuli_wdr.cpp:2380 src/muuli_wdr.cpp:2399 src/muuli_wdr.cpp:2421
+#: src/muuli_wdr.cpp:2352 src/muuli_wdr.cpp:2371 src/muuli_wdr.cpp:2393
 #: src/utils/aLinkCreator/src/alcframe.cpp:142
 msgid "Clear"
 msgstr "Töm"
@@ -3101,8 +3091,8 @@ msgid "Exit"
 msgstr "Avsluta"
 
 #: src/MuleTrayIcon.cpp:579 src/MuleTrayIcon.cpp:945 src/MuleTrayIcon.cpp:965
-#: src/muuli_wdr.cpp:1398 src/muuli_wdr.cpp:1406 src/muuli_wdr.cpp:1413
-#: src/muuli_wdr.cpp:1836 src/muuli_wdr.cpp:1842 src/OtherFunctions.cpp:91
+#: src/muuli_wdr.cpp:1391 src/muuli_wdr.cpp:1399 src/muuli_wdr.cpp:1406
+#: src/muuli_wdr.cpp:1835 src/muuli_wdr.cpp:1841 src/OtherFunctions.cpp:91
 #: src/StatisticsDlg.cpp:93 src/StatisticsDlg.cpp:95
 msgid "kB/s"
 msgstr "kB/s"
@@ -3273,7 +3263,7 @@ msgstr "Namn:"
 msgid "Type"
 msgstr "Typ"
 
-#: src/muuli_wdr.cpp:215 src/SearchDlg.cpp:118 src/SearchListCtrl.cpp:853
+#: src/muuli_wdr.cpp:215 src/SearchDlg.cpp:110 src/SearchListCtrl.cpp:853
 msgid "Local"
 msgstr "Lokal"
 
@@ -3344,7 +3334,7 @@ msgstr "Bytes"
 msgid "KB"
 msgstr "KB"
 
-#: src/muuli_wdr.cpp:274 src/muuli_wdr.cpp:293 src/muuli_wdr.cpp:1621
+#: src/muuli_wdr.cpp:274 src/muuli_wdr.cpp:293 src/muuli_wdr.cpp:1620
 #: src/OtherFunctions.cpp:64
 msgid "MB"
 msgstr "MB"
@@ -3361,7 +3351,7 @@ msgstr "Max storlek"
 msgid "Availability"
 msgstr "Tillgänglighet"
 
-#: src/muuli_wdr.cpp:312 src/muuli_wdr.cpp:398 src/muuli_wdr.cpp:3318
+#: src/muuli_wdr.cpp:312 src/muuli_wdr.cpp:398 src/muuli_wdr.cpp:3290
 msgid "Filter:"
 msgstr "Filter:"
 
@@ -3393,7 +3383,7 @@ msgstr ""
 msgid "Stop"
 msgstr "Stoppa"
 
-#: src/muuli_wdr.cpp:348 src/muuli_wdr.cpp:1392 src/SearchListCtrl.cpp:732
+#: src/muuli_wdr.cpp:348 src/muuli_wdr.cpp:1385 src/SearchListCtrl.cpp:732
 msgid "Download"
 msgstr "Hämta"
 
@@ -3424,12 +3414,12 @@ msgstr "Filkällor:"
 #: src/muuli_wdr.cpp:1160 src/muuli_wdr.cpp:1167 src/muuli_wdr.cpp:1172
 #: src/muuli_wdr.cpp:1179 src/muuli_wdr.cpp:1184 src/muuli_wdr.cpp:1191
 #: src/muuli_wdr.cpp:1205 src/muuli_wdr.cpp:1212 src/muuli_wdr.cpp:1217
-#: src/muuli_wdr.cpp:1224 src/muuli_wdr.cpp:3255 src/muuli_wdr.cpp:3263
-#: src/muuli_wdr.cpp:3271
+#: src/muuli_wdr.cpp:1224 src/muuli_wdr.cpp:3227 src/muuli_wdr.cpp:3235
+#: src/muuli_wdr.cpp:3243
 msgid "N/A"
 msgstr "N/A"
 
-#: src/muuli_wdr.cpp:508 src/muuli_wdr.cpp:1065 src/PrefsUnifiedDlg.cpp:299
+#: src/muuli_wdr.cpp:508 src/muuli_wdr.cpp:1065 src/PrefsUnifiedDlg.cpp:297
 msgid "General"
 msgstr "Allmänt"
 
@@ -3570,7 +3560,7 @@ msgstr ""
 msgid "Album :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:685 src/muuli_wdr.cpp:2275
+#: src/muuli_wdr.cpp:685 src/muuli_wdr.cpp:2247
 msgid "Title :"
 msgstr "Titel :"
 
@@ -3679,7 +3669,7 @@ msgstr "Användarnamn :"
 msgid "Userhash :"
 msgstr "Userhash:"
 
-#: src/muuli_wdr.cpp:895 src/muuli_wdr.cpp:1742 src/muuli_wdr.cpp:2470
+#: src/muuli_wdr.cpp:895 src/muuli_wdr.cpp:1741 src/muuli_wdr.cpp:2442
 #: src/utils/aLinkCreator/src/alcframe.cpp:137
 msgid "Add"
 msgstr "Lägg till"
@@ -3688,15 +3678,15 @@ msgstr "Lägg till"
 msgid "Download-Speed"
 msgstr "Nedladdningshastighet"
 
-#: src/muuli_wdr.cpp:954 src/muuli_wdr.cpp:989 src/muuli_wdr.cpp:2574
+#: src/muuli_wdr.cpp:954 src/muuli_wdr.cpp:989 src/muuli_wdr.cpp:2546
 msgid "Current"
 msgstr "Aktuell"
 
-#: src/muuli_wdr.cpp:962 src/muuli_wdr.cpp:997 src/muuli_wdr.cpp:2582
+#: src/muuli_wdr.cpp:962 src/muuli_wdr.cpp:997 src/muuli_wdr.cpp:2554
 msgid "Running average"
 msgstr "Löpande medelvärde"
 
-#: src/muuli_wdr.cpp:970 src/muuli_wdr.cpp:1005 src/muuli_wdr.cpp:2590
+#: src/muuli_wdr.cpp:970 src/muuli_wdr.cpp:1005 src/muuli_wdr.cpp:2562
 msgid "Session average"
 msgstr "Sessionens genomsnittliga"
 
@@ -3708,7 +3698,7 @@ msgstr "Uppladdningshastighet"
 msgid "Connections"
 msgstr "Anslutningar"
 
-#: src/muuli_wdr.cpp:1024 src/muuli_wdr.cpp:1861
+#: src/muuli_wdr.cpp:1024 src/muuli_wdr.cpp:1860
 msgid "Active downloads"
 msgstr "Aktiva hämtningar"
 
@@ -3716,7 +3706,7 @@ msgstr "Aktiva hämtningar"
 msgid "Active connections (1:1)"
 msgstr "Aktiva anslutningar (1:1)"
 
-#: src/muuli_wdr.cpp:1040 src/muuli_wdr.cpp:1862
+#: src/muuli_wdr.cpp:1040 src/muuli_wdr.cpp:1861
 msgid "Active uploads"
 msgstr "Aktiva uppladdningar"
 
@@ -3832,8 +3822,8 @@ msgstr "Detta är det namn som andra användare ser när du ansluter till dig."
 msgid "Language: "
 msgstr "Språk: "
 
-#: src/muuli_wdr.cpp:1257 src/muuli_wdr.cpp:1330 src/muuli_wdr.cpp:1334
-#: src/muuli_wdr.cpp:1337
+#: src/muuli_wdr.cpp:1257 src/muuli_wdr.cpp:1323 src/muuli_wdr.cpp:1327
+#: src/muuli_wdr.cpp:1330
 msgid "The delay before showing tool-tips."
 msgstr "Fördröjningen innan visning av verktygstips."
 
@@ -3911,960 +3901,936 @@ msgstr ""
 msgid "Enabling this will make aMule to show notifications when finished downloading."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1323
-#, fuzzy
-msgid "Remember search history"
-msgstr "Kom ihåg dessa inställningar"
-
-#: src/muuli_wdr.cpp:1324
-msgid "Keeps a dropdown list of your past search terms in the Search tab's Name field. This remembers the queries you typed, not the results they returned."
-msgstr ""
-
-#: src/muuli_wdr.cpp:1329
+#: src/muuli_wdr.cpp:1322
 msgid "Tooltip delay time: "
 msgstr "Tooltip fördröjningstid: "
 
-#: src/muuli_wdr.cpp:1336
+#: src/muuli_wdr.cpp:1329
 msgid "seconds"
 msgstr "sekunder"
 
-#: src/muuli_wdr.cpp:1340
+#: src/muuli_wdr.cpp:1333
 msgid "Browser Selection"
 msgstr "Webbläsarval"
 
-#: src/muuli_wdr.cpp:1346
+#: src/muuli_wdr.cpp:1339
 msgid "Enter your browser name here. Leave this field empty to use the system default browser."
 msgstr "Ange din webbläsares namn här. Lämna detta fält tomt för att använda systemets standardwebbläsare."
 
-#: src/muuli_wdr.cpp:1353
+#: src/muuli_wdr.cpp:1346
 msgid "Open in new tab if possible"
 msgstr "Öppna i ny flik om möjligt"
 
-#: src/muuli_wdr.cpp:1355
+#: src/muuli_wdr.cpp:1348
 msgid "Open the web page in a new tab instead of in a new window when possible"
 msgstr "Öppna webbsidan i en ny flik istället för ett nytt fönster när det är möjligt"
 
-#: src/muuli_wdr.cpp:1359
+#: src/muuli_wdr.cpp:1352
 msgid "Video Player"
 msgstr "Videouppspelare"
 
-#: src/muuli_wdr.cpp:1386
+#: src/muuli_wdr.cpp:1379
 msgid "Bandwidth limits"
 msgstr "Bandbreddsbegränsningar"
 
-#: src/muuli_wdr.cpp:1400
+#: src/muuli_wdr.cpp:1393
 msgid "Upload"
 msgstr "Ladda upp"
 
-#: src/muuli_wdr.cpp:1408
+#: src/muuli_wdr.cpp:1401
 msgid "Slot Allocation"
 msgstr "Spårallokering"
 
-#: src/muuli_wdr.cpp:1417
+#: src/muuli_wdr.cpp:1410
 msgid "Ports"
 msgstr "Portar"
 
-#: src/muuli_wdr.cpp:1427
+#: src/muuli_wdr.cpp:1420
 msgid "This is the standard eD2k port and cannot be disabled."
 msgstr "Detta är standard ed2k-port och kan inte avaktiveras."
 
-#: src/muuli_wdr.cpp:1430
+#: src/muuli_wdr.cpp:1423
 msgid "UDP port for server requests (TCP+3):"
 msgstr "UDP-port för serverförfrågningar (TCP+3):"
 
-#: src/muuli_wdr.cpp:1432
+#: src/muuli_wdr.cpp:1425
 msgid "4665"
 msgstr "4665"
 
-#: src/muuli_wdr.cpp:1439
+#: src/muuli_wdr.cpp:1432
 msgid "This UDP port is used for extended eD2k requests and Kad network"
 msgstr "Denna UDP-port används under utökade ed2k-förfrågningar och Kadnätverk"
 
-#: src/muuli_wdr.cpp:1446
+#: src/muuli_wdr.cpp:1439
 msgid "UPnP TCP Port (Optional):"
 msgstr "UPnP TCP-port (tillval):"
 
-#: src/muuli_wdr.cpp:1456
+#: src/muuli_wdr.cpp:1449
 msgid "Bind local address to IP (empty for any):"
 msgstr "Bind lokal adress till IP (tom för alla):"
 
-#: src/muuli_wdr.cpp:1459
+#: src/muuli_wdr.cpp:1452
 msgid "Advanced users only: If you have multiple network interfaces, enter the address of the interface to which aMule should be bound."
 msgstr "Endast avancerade användare: Om du har flera nätverksgränssnitt, ange adressen för gränssnittet till vilket aMule ska bindas."
 
-#: src/muuli_wdr.cpp:1462 src/muuli_wdr.cpp:2055
+#: src/muuli_wdr.cpp:1455 src/muuli_wdr.cpp:2054
 #, fuzzy
 msgid "Bind to network interface (empty for any):"
 msgstr "Bind lokal adress till IP (tom för alla):"
 
-#: src/muuli_wdr.cpp:1475
+#: src/muuli_wdr.cpp:1468
 msgid "Advanced users only: pin all of aMule's traffic to one network interface, chosen from the list or typed in by name (e.g. tun0, eth0, en0) or index. Unlike binding to an IP, this stops traffic leaking out via the default route - useful with a VPN. Requires no elevated privileges."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1481
+#: src/muuli_wdr.cpp:1474
 msgid "Max sources per downloading file:"
 msgstr "Max källor per hämtad fil:"
 
-#: src/muuli_wdr.cpp:1485
+#: src/muuli_wdr.cpp:1478
 msgid "Max simultaneous connections:"
 msgstr "Max samtidiga anslutningar:"
 
-#: src/muuli_wdr.cpp:1498 src/muuli_wdr.cpp:3197
+#: src/muuli_wdr.cpp:1491 src/muuli_wdr.cpp:3169
 msgid "ED2K"
 msgstr "ED2K"
 
-#: src/muuli_wdr.cpp:1505
+#: src/muuli_wdr.cpp:1498
 msgid "Autoconnect on startup"
 msgstr "Autoanslut vid start"
 
-#: src/muuli_wdr.cpp:1508
+#: src/muuli_wdr.cpp:1501
 msgid "Reconnect on loss"
 msgstr "Återanslut vid nedkoppling"
 
-#: src/muuli_wdr.cpp:1530
+#: src/muuli_wdr.cpp:1523
 msgid "Remove dead server after"
 msgstr "Ta bort död server efter"
 
-#: src/muuli_wdr.cpp:1531
+#: src/muuli_wdr.cpp:1524
 msgid "Static servers are never removed, even when unreachable."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1535
+#: src/muuli_wdr.cpp:1528
 msgid "retries"
 msgstr "försök"
 
-#: src/muuli_wdr.cpp:1543
+#: src/muuli_wdr.cpp:1536
 msgid "List"
 msgstr "Lista"
 
-#: src/muuli_wdr.cpp:1546
+#: src/muuli_wdr.cpp:1539
 msgid "Update server list when connecting to a server"
 msgstr "Uppdatera serverlistan vid anslutning till en server"
 
-#: src/muuli_wdr.cpp:1549
+#: src/muuli_wdr.cpp:1542
 msgid "Update server list when a client connects"
 msgstr "Uppdatera serverlistan när en klient ansluter"
 
-#: src/muuli_wdr.cpp:1552
+#: src/muuli_wdr.cpp:1545
 msgid "Use priority system"
 msgstr "Använd prioriteringssystem"
 
-#: src/muuli_wdr.cpp:1556
+#: src/muuli_wdr.cpp:1549
 msgid "Use smart LowID check on connect"
 msgstr "Använda smart LowID kontroll vid anslutning"
 
-#: src/muuli_wdr.cpp:1560
+#: src/muuli_wdr.cpp:1553
 msgid "Safe connect"
 msgstr "Säker anslutning"
 
-#: src/muuli_wdr.cpp:1564
+#: src/muuli_wdr.cpp:1557
 msgid "Autoconnect to servers in static list only"
 msgstr "Autoanslut endast till servrar i statisk-listan"
 
-#: src/muuli_wdr.cpp:1567
+#: src/muuli_wdr.cpp:1560
 msgid "Set manually added servers to High Priority"
 msgstr "Ställ in hög prioritet på manuellt tillagda servrar"
 
-#: src/muuli_wdr.cpp:1588
+#: src/muuli_wdr.cpp:1581
 msgid "Add files to download in pause mode"
 msgstr "Lägg till filer för nerladdning i pausläge"
 
-#: src/muuli_wdr.cpp:1590
+#: src/muuli_wdr.cpp:1583
 msgid "Add files to download with auto priority"
 msgstr "Lägg till filer för nerladdning med automatisk prioritet"
 
-#: src/muuli_wdr.cpp:1593
+#: src/muuli_wdr.cpp:1586
 msgid "Try to download first and last chunks first"
 msgstr "Försök att hämta första och sista bitarna först"
 
-#: src/muuli_wdr.cpp:1597
+#: src/muuli_wdr.cpp:1590
 msgid "Endgame mode: rotate to faster sources for the final blocks"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1600
+#: src/muuli_wdr.cpp:1593
 msgid "Start next paused file when a file completes"
 msgstr "Börja nästa pausade fil när en fil är klar"
 
-#: src/muuli_wdr.cpp:1603
+#: src/muuli_wdr.cpp:1596
 msgid "From the same category"
 msgstr "Från samma kategori"
 
-#: src/muuli_wdr.cpp:1605
+#: src/muuli_wdr.cpp:1598
 msgid "In alphabetic order"
 msgstr "I alfabetisk ordning"
 
-#: src/muuli_wdr.cpp:1607
+#: src/muuli_wdr.cpp:1600
 msgid "Preallocate disk space for new files"
 msgstr "Förallokera diskutrymme för nya filer"
 
-#: src/muuli_wdr.cpp:1608
+#: src/muuli_wdr.cpp:1601
 msgid "For new files preallocates disk space for the whole file, thus reduces fragmentation"
 msgstr "För nya filer förallokeras diskutrymme för hela filen, detta minskar fragmentering"
 
-#: src/muuli_wdr.cpp:1613
+#: src/muuli_wdr.cpp:1606
+msgid "Create new files as sparse files"
+msgstr ""
+
+#: src/muuli_wdr.cpp:1607
+msgid "A sparse file reserves its full size on disk immediately without writing real data to it -- fast, but unsupported or slow on some filesystems, and free-space accounting stays optimistic while the download is in progress. Turn this off to grow the file only as data arrives."
+msgstr ""
+
+#: src/muuli_wdr.cpp:1612
 msgid "Stop downloads when free disk space reaches "
 msgstr "Stoppa nedladdningar när ledigt diskutrymme når "
 
-#: src/muuli_wdr.cpp:1614
+#: src/muuli_wdr.cpp:1613
 msgid "Select this if you want aMule to check your disk space"
 msgstr "Välj detta om du vill aMule att kontrollera diskutrymmet"
 
-#: src/muuli_wdr.cpp:1618
+#: src/muuli_wdr.cpp:1617
 msgid "Enter here the min disk space desired."
 msgstr "Ange här min diskutrymme."
 
-#: src/muuli_wdr.cpp:1624
+#: src/muuli_wdr.cpp:1623
 msgid "Save 10 sources on rare files (< 20 sources)"
 msgstr "Spara 10 källor för sällsynta filer (<20 källor)"
 
-#: src/muuli_wdr.cpp:1628 src/Statistics.cpp:790
+#: src/muuli_wdr.cpp:1627 src/Statistics.cpp:790
 msgid "Uploads"
 msgstr "Uppladdningar"
 
-#: src/muuli_wdr.cpp:1631
+#: src/muuli_wdr.cpp:1630
 msgid "Add new shared files with auto priority"
 msgstr "Lägg till nya delade filer med automatisk prioritet"
 
-#: src/muuli_wdr.cpp:1637
+#: src/muuli_wdr.cpp:1636
 msgid "Intelligent Corruption Handling (I.C.H.)"
 msgstr "Intelligent Corruption Handling (I.C.H.)"
 
-#: src/muuli_wdr.cpp:1640
+#: src/muuli_wdr.cpp:1639
 msgid "Enable"
 msgstr "Aktivera"
 
-#: src/muuli_wdr.cpp:1643
+#: src/muuli_wdr.cpp:1642
 msgid "Advanced I.C.H. trusts every hash (not recommended)"
 msgstr "Avancerad I.C.H. litar på varje hash (rekommenderas inte)"
 
-#: src/muuli_wdr.cpp:1655 src/PrefsUnifiedDlg.cpp:1990
+#: src/muuli_wdr.cpp:1654 src/PrefsUnifiedDlg.cpp:1910
 msgid "Media metadata extraction"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1659
+#: src/muuli_wdr.cpp:1658
 msgid "Extract length / bitrate / codec from shared audio and video files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1661
+#: src/muuli_wdr.cpp:1660
 msgid "When enabled, aMule runs ffprobe on each shared media file to fill in the Length / Bitrate / Codec columns other clients see when they find the file in a search. Requires ffmpeg (the ffprobe binary) to be installed."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1668
+#: src/muuli_wdr.cpp:1667
 msgid "Path to ffprobe:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1673
+#: src/muuli_wdr.cpp:1672
 msgid "Full path to the ffprobe binary. Leave empty to have aMule auto-detect it on startup."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1681
+#: src/muuli_wdr.cpp:1680
 msgid "Detect"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1682
+#: src/muuli_wdr.cpp:1681
 msgid "Search the standard install locations for an ffprobe binary and fill the path field."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1706
+#: src/muuli_wdr.cpp:1705
 msgid ""
 "Completed downloads are stored here. All files in this folder are automatically shared with other peers.\n"
 "If this folder also holds files you don't want to share, point it at an aMule-only sub-folder."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1709
+#: src/muuli_wdr.cpp:1708
 msgid "Pick the folder where completed downloads will be stored. All files in that folder will be shared with other peers."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1723
+#: src/muuli_wdr.cpp:1722
 msgid "Shared folders"
 msgstr "Delade mappar"
 
-#: src/muuli_wdr.cpp:1729
+#: src/muuli_wdr.cpp:1728
 msgid "(Folders shared by the core. Enter a path to add one.)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1737
+#: src/muuli_wdr.cpp:1736
 msgid "Absolute path of a folder on the core's machine, e.g. /home/user/shared"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1739 src/PrefsUnifiedDlg.cpp:2874
+#: src/muuli_wdr.cpp:1738 src/PrefsUnifiedDlg.cpp:2794
 msgid "Recursive"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1740
+#: src/muuli_wdr.cpp:1739
 msgid "Share every sub-folder underneath this one, including ones created later."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1744 src/utils/aLinkCreator/src/alcframe.cpp:141
+#: src/muuli_wdr.cpp:1743 src/utils/aLinkCreator/src/alcframe.cpp:141
 msgid "Remove"
 msgstr "Ta bort"
 
-#: src/muuli_wdr.cpp:1748
+#: src/muuli_wdr.cpp:1747
 msgid "(Right click on folder icon for recursive share)"
 msgstr "(Högerklicka på mappikonen för rekursiv delning)"
 
-#: src/muuli_wdr.cpp:1755
+#: src/muuli_wdr.cpp:1754
 msgid "Share hidden files"
 msgstr "Dela ut dolda filer"
 
-#: src/muuli_wdr.cpp:1761
+#: src/muuli_wdr.cpp:1760
 msgid "Automatically rescan shared folders for changes"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1767
+#: src/muuli_wdr.cpp:1766
 msgid "Follow symbolic links in shared folders"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1773
+#: src/muuli_wdr.cpp:1772
 msgid "Exclude files matching:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1776
+#: src/muuli_wdr.cpp:1775
 msgid "Wildcard patterns separated by '|', e.g. .DS_Store|Thumbs.db|*.tmp. Files whose name matches are not shared. Matching is case-insensitive."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1780
+#: src/muuli_wdr.cpp:1779
 msgid "Patterns are regular expressions"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1781
+#: src/muuli_wdr.cpp:1780
 msgid "When set, the whole field is one regular expression ('|' is alternation). When unset, it is a list of '|'-separated wildcards."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1791
+#: src/muuli_wdr.cpp:1790
 msgid "Show how many shared files the current pattern would exclude."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1812
+#: src/muuli_wdr.cpp:1811
 msgid "Graphs"
 msgstr "Diagram"
 
-#: src/muuli_wdr.cpp:1815 src/muuli_wdr.cpp:1877
+#: src/muuli_wdr.cpp:1814 src/muuli_wdr.cpp:1876
 msgid "Update delay : 5 secs"
 msgstr "Uppdateringsfördröjning: 5 sekunder"
 
-#: src/muuli_wdr.cpp:1819
+#: src/muuli_wdr.cpp:1818
 msgid "Time for average graph: 100 mins"
 msgstr "Tid för genomsnittlig graf: 100 minuter"
 
-#: src/muuli_wdr.cpp:1823
+#: src/muuli_wdr.cpp:1822
 msgid "Connections Graph Scale: 100 "
 msgstr "Anslutningar Diagramskala: 100 "
 
-#: src/muuli_wdr.cpp:1830
+#: src/muuli_wdr.cpp:1829
 msgid "Download graph scale:"
 msgstr "Hämtningsgrafskala:"
 
-#: src/muuli_wdr.cpp:1838
+#: src/muuli_wdr.cpp:1837
 msgid "Upload graph scale:"
 msgstr "Uppladdningsgraf-skala:"
 
-#: src/muuli_wdr.cpp:1848
+#: src/muuli_wdr.cpp:1847
 #, fuzzy
 msgid "Colors: "
 msgstr "Färger: "
 
-#: src/muuli_wdr.cpp:1852
+#: src/muuli_wdr.cpp:1851
 msgid "Background"
 msgstr "Bakgrund"
 
-#: src/muuli_wdr.cpp:1853
+#: src/muuli_wdr.cpp:1852
 msgid "Grid"
 msgstr "Rutnät"
 
-#: src/muuli_wdr.cpp:1854
+#: src/muuli_wdr.cpp:1853
 msgid "Download current"
 msgstr "Hämtning nu"
 
-#: src/muuli_wdr.cpp:1855
+#: src/muuli_wdr.cpp:1854
 msgid "Download running average"
 msgstr "Hämtningar nu, medelvärde"
 
-#: src/muuli_wdr.cpp:1856
+#: src/muuli_wdr.cpp:1855
 msgid "Download session average"
 msgstr "Hämtningar session, genomsnittlig"
 
-#: src/muuli_wdr.cpp:1857
+#: src/muuli_wdr.cpp:1856
 msgid "Upload current"
 msgstr "Hämtningar nu"
 
-#: src/muuli_wdr.cpp:1858
+#: src/muuli_wdr.cpp:1857
 msgid "Upload running average"
 msgstr "Hämtningar nu, medelvärde"
 
-#: src/muuli_wdr.cpp:1859
+#: src/muuli_wdr.cpp:1858
 msgid "Upload session average"
 msgstr "Uppladdningsession, genomsnittlig"
 
-#: src/muuli_wdr.cpp:1860
+#: src/muuli_wdr.cpp:1859
 msgid "Active connections"
 msgstr "Aktiva anslutningar"
 
-#: src/muuli_wdr.cpp:1863
+#: src/muuli_wdr.cpp:1862
 #, fuzzy
 msgid "Systray Icon Speed Bar"
 msgstr "Systray Ikon Speedbar"
 
-#: src/muuli_wdr.cpp:1864
+#: src/muuli_wdr.cpp:1863
 msgid "Kad-nodes current"
 msgstr "Kad-noder nuvarande"
 
-#: src/muuli_wdr.cpp:1865
+#: src/muuli_wdr.cpp:1864
 msgid "Kad-nodes running"
 msgstr "Kad-noder körs"
 
-#: src/muuli_wdr.cpp:1866
+#: src/muuli_wdr.cpp:1865
 msgid "Kad-nodes session"
 msgstr "Kad-noder session"
 
-#: src/muuli_wdr.cpp:1870 src/muuli_wdr.cpp:2324
+#: src/muuli_wdr.cpp:1869 src/muuli_wdr.cpp:2296
 msgid "Select"
 msgstr "Välj"
 
-#: src/muuli_wdr.cpp:1874
+#: src/muuli_wdr.cpp:1873
 msgid "Tree"
 msgstr "Träd"
 
-#: src/muuli_wdr.cpp:1884
+#: src/muuli_wdr.cpp:1883
 msgid "Number of Client Versions shown (0=unlimited)"
 msgstr "Antal klientversioner visas (0 = obegränsat)"
 
-#: src/muuli_wdr.cpp:1909
+#: src/muuli_wdr.cpp:1908
 msgid "!!! WARNING !!!"
 msgstr "!!! VARNING !!!"
 
-#: src/muuli_wdr.cpp:1924
+#: src/muuli_wdr.cpp:1923
 msgid "Max new connections / 5 secs"
 msgstr "Max nya anslutningar / 5 sek"
 
-#: src/muuli_wdr.cpp:1926
+#: src/muuli_wdr.cpp:1925
 msgid "Concurrent Kad source lookups"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1928
+#: src/muuli_wdr.cpp:1927
 #, fuzzy
 msgid "Kad source re-search interval (minutes)"
 msgstr "FTP-uppdateringshastighetsintervall i minuter"
 
-#: src/muuli_wdr.cpp:1930
+#: src/muuli_wdr.cpp:1929
 #, fuzzy
 msgid "Source re-ask interval (minutes)"
 msgstr "FTP-uppdateringshastighetsintervall i minuter"
 
-#: src/muuli_wdr.cpp:1934
+#: src/muuli_wdr.cpp:1933
 msgid "File Buffer Size: 240000 bytes"
 msgstr "Filbuffertstorlek: 240000 bytes"
 
-#: src/muuli_wdr.cpp:1938
+#: src/muuli_wdr.cpp:1937
 msgid "Use MMAP: memory-mapped file access (lower memory use)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1939
+#: src/muuli_wdr.cpp:1938
 msgid "Maps part files into memory instead of buffering them on the heap, lowering the process memory footprint. May reduce download speed on some disks; best for memory-constrained or upload-heavy hosts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1941
+#: src/muuli_wdr.cpp:1940
 msgid "Upload Queue Size: 5000 clients"
 msgstr "Uppladdningsköstorlek: 5000 klienter"
 
-#: src/muuli_wdr.cpp:1945
+#: src/muuli_wdr.cpp:1944
 msgid "Server connection refresh interval: Disable"
 msgstr "Serveranslutningsuppdateringsintervall: Inaktivera"
 
-#: src/muuli_wdr.cpp:1949
+#: src/muuli_wdr.cpp:1948
 msgid "Disable computer's timed standby mode"
 msgstr "Inaktivera datorns inställda standby-läge"
 
-#: src/muuli_wdr.cpp:1968
+#: src/muuli_wdr.cpp:1967
 msgid "Skin to use: "
 msgstr "Skin att använda: "
 
-#: src/muuli_wdr.cpp:1977
+#: src/muuli_wdr.cpp:1976
 msgid "Show \"Fast eD2k Links Handler\" in every window."
 msgstr "Visa \"Snabb eD2k-Länkhanterare\" i varje fönster."
 
-#: src/muuli_wdr.cpp:1980
+#: src/muuli_wdr.cpp:1979
 msgid "Show extended info on categories tabs"
 msgstr "Visa utökad information på kategoriflikar"
 
-#: src/muuli_wdr.cpp:1983
+#: src/muuli_wdr.cpp:1982
 msgid "Show application version on title"
 msgstr "Visa programversionen på titel"
 
-#: src/muuli_wdr.cpp:1985
+#: src/muuli_wdr.cpp:1984
 msgid "Show transfer rates on title"
 msgstr "Visa överföringshastigheter på titel"
 
-#: src/muuli_wdr.cpp:1987
+#: src/muuli_wdr.cpp:1986
 msgid "Before application name"
 msgstr "Före programnamn"
 
-#: src/muuli_wdr.cpp:1989
+#: src/muuli_wdr.cpp:1988
 msgid "After application name"
 msgstr "Efter programnamn"
 
-#: src/muuli_wdr.cpp:1992
+#: src/muuli_wdr.cpp:1991
 msgid "Show overhead bandwidth"
 msgstr "Visa overheadsbandbredd"
 
-#: src/muuli_wdr.cpp:1996
+#: src/muuli_wdr.cpp:1995
 msgid "Vertical toolbar orientation"
 msgstr "Vertikal verktygsfältsorientering"
 
-#: src/muuli_wdr.cpp:1998
+#: src/muuli_wdr.cpp:1997
 msgid "Live column sorting (auto-reorder rows as their values change)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2005
+#: src/muuli_wdr.cpp:2004
 msgid "Download Queue Files"
 msgstr "Nedladdningsköfiler"
 
-#: src/muuli_wdr.cpp:2008
+#: src/muuli_wdr.cpp:2007
 msgid "Show progress percentage"
 msgstr "Visa framsteg i procent"
 
-#: src/muuli_wdr.cpp:2014
+#: src/muuli_wdr.cpp:2013
 msgid "Show progress bar"
 msgstr "Visa förloppsindikator"
 
-#: src/muuli_wdr.cpp:2017
+#: src/muuli_wdr.cpp:2016
 msgid "Flat"
 msgstr "Platt"
 
-#: src/muuli_wdr.cpp:2021
+#: src/muuli_wdr.cpp:2020
 msgid "Round"
 msgstr "Rund"
 
-#: src/muuli_wdr.cpp:2039
+#: src/muuli_wdr.cpp:2038
 msgid "External Connection Parameters"
 msgstr "Externa Anslutningsparametrar "
 
-#: src/muuli_wdr.cpp:2042
+#: src/muuli_wdr.cpp:2041
 msgid "Accept external connections"
 msgstr "Acceptera externa anslutningar"
 
-#: src/muuli_wdr.cpp:2049 src/muuli_wdr.cpp:2108
+#: src/muuli_wdr.cpp:2048 src/muuli_wdr.cpp:2107
 msgid "IP of the listening interface:"
 msgstr "IP för lyssningsgränssnitt:"
 
-#: src/muuli_wdr.cpp:2052
+#: src/muuli_wdr.cpp:2051
 msgid "Enter here a valid ip in the a.b.c.d format for the listening EC interface. An empty field or 0.0.0.0 will mean any interface."
 msgstr "Ange här en giltig ip i ABCD format för att lyssna EC-gränssnittet. Ett tomt fält eller 0.0.0.0 kommer att innebära alla gränssnitt."
 
-#: src/muuli_wdr.cpp:2073 src/muuli_wdr.cpp:2184
+#: src/muuli_wdr.cpp:2072 src/muuli_wdr.cpp:2156
 msgid "TCP port:"
 msgstr "TCP-port:"
 
-#: src/muuli_wdr.cpp:2079
+#: src/muuli_wdr.cpp:2078
 msgid "Enable UPnP port forwarding on the EC port"
 msgstr "Aktivera UPnP-portforwarding på EC-port"
 
-#: src/muuli_wdr.cpp:2083 src/muuli_wdr.cpp:3069
+#: src/muuli_wdr.cpp:2082 src/muuli_wdr.cpp:3041
 #: src/utils/wxCas/src/wxcasprefs.cpp:167
 msgid "Password"
 msgstr "Lösenord"
 
-#: src/muuli_wdr.cpp:2089
+#: src/muuli_wdr.cpp:2088
 #, fuzzy
 msgid "aMule API server parameters"
 msgstr "Webbserverparametrar"
 
-#: src/muuli_wdr.cpp:2092
+#: src/muuli_wdr.cpp:2091
 msgid "Run amuleapi (REST API) on startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2097
+#: src/muuli_wdr.cpp:2096
 #, fuzzy
 msgid "HTTP port:"
 msgstr "TCP-port:"
 
-#: src/muuli_wdr.cpp:2111
+#: src/muuli_wdr.cpp:2110
 msgid "The interface amuleapi's HTTP server listens on. 127.0.0.1 (default) accepts only local connections; use 0.0.0.0 or a specific IP to expose it to other hosts (set an admin password below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2116
-msgid "Type a password to set or change it. Stored passwords cannot be shown, so leaving this empty keeps the current one."
-msgstr ""
-
-#: src/muuli_wdr.cpp:2118
+#: src/muuli_wdr.cpp:2113
 #, fuzzy
 msgid "Admin password"
 msgstr "Kontrollerar lösenord\n"
 
-#: src/muuli_wdr.cpp:2130 src/muuli_wdr.cpp:2147 src/PrefsUnifiedDlg.cpp:1103
-#, fuzzy
-msgid "A password is set."
-msgstr "Kontrollerar lösenord\n"
+#: src/muuli_wdr.cpp:2118 src/muuli_wdr.cpp:2149
+msgid "Low rights password"
+msgstr "Låga rättigheterslösenord"
 
-#: src/muuli_wdr.cpp:2134
-#, fuzzy
-msgid "Enable guest access"
-msgstr "Neka gäståtkomst"
-
-#: src/muuli_wdr.cpp:2135
-msgid "Guest sessions may read status and listings but cannot change anything. Turning this off clears the stored guest password."
-msgstr ""
-
-#: src/muuli_wdr.cpp:2139
-#, fuzzy
-msgid "Guest password"
-msgstr "Gästlösenord för webbservern"
-
-#: src/muuli_wdr.cpp:2154
+#: src/muuli_wdr.cpp:2126
 msgid "Web server parameters"
 msgstr "Webbserverparametrar"
 
-#: src/muuli_wdr.cpp:2157
+#: src/muuli_wdr.cpp:2129
 #, fuzzy
 msgid "Run webserver on startup (deprecated)"
 msgstr "Kör webbserver vid start"
 
-#: src/muuli_wdr.cpp:2163
+#: src/muuli_wdr.cpp:2135
 msgid "Web template"
 msgstr "Web mall"
 
-#: src/muuli_wdr.cpp:2168
+#: src/muuli_wdr.cpp:2140
 msgid "Full rights password"
 msgstr "Fullständiga rättigheterslösenord"
 
-#: src/muuli_wdr.cpp:2172
+#: src/muuli_wdr.cpp:2144
 msgid "Enable Low rights User"
 msgstr "Aktivera låga användarrättigheter"
 
-#: src/muuli_wdr.cpp:2177
-msgid "Low rights password"
-msgstr "Låga rättigheterslösenord"
-
-#: src/muuli_wdr.cpp:2191
+#: src/muuli_wdr.cpp:2163
 msgid "Enable UPnP port forwarding of the web server port"
 msgstr "Aktivera UPnP-port-forwarding för webbserverport"
 
-#: src/muuli_wdr.cpp:2196
+#: src/muuli_wdr.cpp:2168
 msgid "Web server UPnP TCP port (Optional)"
 msgstr "Webbserverns UPnP TCP-port (tillval)"
 
-#: src/muuli_wdr.cpp:2204
+#: src/muuli_wdr.cpp:2176
 msgid "Page Refresh Time (in secs)"
 msgstr "Siduppdateringstid (i sek)"
 
-#: src/muuli_wdr.cpp:2211
+#: src/muuli_wdr.cpp:2183
 msgid "Enable Gzip compression"
 msgstr "Aktivera Gzip-komprimering"
 
-#: src/muuli_wdr.cpp:2245
+#: src/muuli_wdr.cpp:2217
 #, fuzzy
 msgid "Reset page to defaults"
 msgstr "Systemets standard"
 
-#: src/muuli_wdr.cpp:2246
+#: src/muuli_wdr.cpp:2218
 msgid "Reset the settings on the current page to their default values."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2248 src/muuli_wdr.cpp:2334 src/ServerWnd.cpp:274
+#: src/muuli_wdr.cpp:2220 src/muuli_wdr.cpp:2306 src/ServerWnd.cpp:274
 #: src/ServerWnd.cpp:282
 msgid "OK"
 msgstr "OK"
 
-#: src/muuli_wdr.cpp:2250
+#: src/muuli_wdr.cpp:2222
 msgid "Click here to apply any changes made to the preferences."
 msgstr "Klicka här för att tillämpa eventuella ändringar i inställningarna."
 
-#: src/muuli_wdr.cpp:2253
+#: src/muuli_wdr.cpp:2225
 msgid "Reset any changes made to the preferences."
 msgstr "Återställ eventuella ändringar i inställningarna."
 
-#: src/muuli_wdr.cpp:2282
+#: src/muuli_wdr.cpp:2254
 msgid "Comment :"
 msgstr "Kommentar :"
 
-#: src/muuli_wdr.cpp:2289
+#: src/muuli_wdr.cpp:2261
 msgid "Incoming Dir :"
 msgstr "Inkommande mapp:"
 
-#: src/muuli_wdr.cpp:2298
+#: src/muuli_wdr.cpp:2270
 msgid "Change priority for new assigned files :"
 msgstr "Ändra prioritet för nya tilldelade filer:"
 
-#: src/muuli_wdr.cpp:2302
+#: src/muuli_wdr.cpp:2274
 msgid "Don't change"
 msgstr "Ändra inte"
 
-#: src/muuli_wdr.cpp:2314
+#: src/muuli_wdr.cpp:2286
 msgid "Select color for this Category (currently selected) :"
 msgstr "Välj färg för denna kategori (den valda):"
 
-#: src/muuli_wdr.cpp:2381 src/muuli_wdr.cpp:2400 src/muuli_wdr.cpp:2422
+#: src/muuli_wdr.cpp:2353 src/muuli_wdr.cpp:2372 src/muuli_wdr.cpp:2394
 msgid "Click this button to reset the log."
 msgstr "Klicka på den här knappen för att återställa loggen."
 
-#: src/muuli_wdr.cpp:2441
+#: src/muuli_wdr.cpp:2413
 msgid "Click on this button to update the servers list from URL ..."
 msgstr "Klicka på knappen för att uppdatera servrerlistan från URL ..."
 
-#: src/muuli_wdr.cpp:2445
+#: src/muuli_wdr.cpp:2417
 msgid "Server list"
 msgstr "Serverlista"
 
-#: src/muuli_wdr.cpp:2449
+#: src/muuli_wdr.cpp:2421
 msgid "Enter the url to a server.met file here and press the button to the left to update the list of known servers."
 msgstr "Ange URL till en server.met-fil här och tryck på knappen till vänster för att uppdatera listan över kända servrar."
 
-#: src/muuli_wdr.cpp:2454
+#: src/muuli_wdr.cpp:2426
 msgid "Add server manually: Name"
 msgstr "Lägg till server manuellt: Namn"
 
-#: src/muuli_wdr.cpp:2457
+#: src/muuli_wdr.cpp:2429
 msgid "Enter the name of the new server here"
 msgstr "Skriv in namnet på den nya servern här"
 
-#: src/muuli_wdr.cpp:2459 src/ServerWnd.cpp:206
+#: src/muuli_wdr.cpp:2431 src/ServerWnd.cpp:206
 msgid "IP:Port"
 msgstr "IP:Port"
 
-#: src/muuli_wdr.cpp:2462
+#: src/muuli_wdr.cpp:2434
 msgid "Enter the IP of the server here, using the x.x.x.x format."
 msgstr "Ange IP på servern här, med hjälp av xxxx format."
 
-#: src/muuli_wdr.cpp:2468
+#: src/muuli_wdr.cpp:2440
 msgid "Enter the port of the server here."
 msgstr "Ange porten på servern här."
 
-#: src/muuli_wdr.cpp:2471
+#: src/muuli_wdr.cpp:2443
 msgid "Add manually a server (fill fields to the left before) ..."
 msgstr "Lägg manuellt till en server (fyll fälten till vänster innan) ..."
 
-#: src/muuli_wdr.cpp:2500
+#: src/muuli_wdr.cpp:2472
 msgid "aMule Log"
 msgstr "aMule-logg"
 
-#: src/muuli_wdr.cpp:2508
+#: src/muuli_wdr.cpp:2480
 msgid "Server Info"
 msgstr "Serverinformation"
 
-#: src/muuli_wdr.cpp:2512
+#: src/muuli_wdr.cpp:2484
 msgid "ED2K Info"
 msgstr "ED2K-info"
 
-#: src/muuli_wdr.cpp:2516
+#: src/muuli_wdr.cpp:2488
 msgid "Kad Info"
 msgstr "Kad-info"
 
-#: src/muuli_wdr.cpp:2544
+#: src/muuli_wdr.cpp:2516
 msgid "Click on this button to update the nodes list from URL ..."
 msgstr "Klicka på knappen för att uppdatera nodlistan från URL ..."
 
-#: src/muuli_wdr.cpp:2548
+#: src/muuli_wdr.cpp:2520
 msgid "Nodes (0)"
 msgstr "Noder (0)"
 
-#: src/muuli_wdr.cpp:2552
+#: src/muuli_wdr.cpp:2524
 msgid "Enter the url to a nodes.dat file here and press the button to the left to update the list of known nodes."
 msgstr "Ange URL till en nodes.dat fil här och tryck på knappen till vänster för att uppdatera listan över kända noder."
 
-#: src/muuli_wdr.cpp:2555
+#: src/muuli_wdr.cpp:2527
 msgid "Nodes stats"
 msgstr "Nodstatistik"
 
-#: src/muuli_wdr.cpp:2597
+#: src/muuli_wdr.cpp:2569
 msgid "Bootstrap"
 msgstr "Bootstrap"
 
-#: src/muuli_wdr.cpp:2600
+#: src/muuli_wdr.cpp:2572
 msgid "New node"
 msgstr "Ny nod"
 
-#: src/muuli_wdr.cpp:2605
+#: src/muuli_wdr.cpp:2577
 msgid "IP:"
 msgstr "IP:"
 
-#: src/muuli_wdr.cpp:2625
+#: src/muuli_wdr.cpp:2597
 msgid "Port:"
 msgstr "Port:"
 
-#: src/muuli_wdr.cpp:2638
+#: src/muuli_wdr.cpp:2610
 msgid "Bootstrap from known clients"
 msgstr "Bootstrap från kända klienter"
 
-#: src/muuli_wdr.cpp:2640
+#: src/muuli_wdr.cpp:2612
 msgid "Disconnect Kad"
 msgstr "Koppla från Kad"
 
-#: src/muuli_wdr.cpp:2674
+#: src/muuli_wdr.cpp:2646
 msgid "Use Secure User Identification"
 msgstr "Använd säker användarIdentifiering"
 
-#: src/muuli_wdr.cpp:2676
+#: src/muuli_wdr.cpp:2648
 msgid "It is recommended to enable this option. You will not receive credits if SUI is not enabled."
 msgstr "Det rekommenderas att aktivera det här alternativet. Du kommer inte att få poäng om SUI är inte aktiverat."
 
-#: src/muuli_wdr.cpp:2678
+#: src/muuli_wdr.cpp:2650
 msgid "Protocol Obfuscation"
 msgstr "Protokollfördunkling"
 
-#: src/muuli_wdr.cpp:2681
+#: src/muuli_wdr.cpp:2653
 msgid "Support Protocol Obfuscation"
 msgstr "Stöd protokollfördunkling"
 
-#: src/muuli_wdr.cpp:2683
+#: src/muuli_wdr.cpp:2655
 msgid "This option enabled Protocol Obfuscation, and makes aMule accept obfuscated connections from other clients."
 msgstr "Det här alternativet aktiverat protokollffördunkling och låter aMule acceptera dålda anslutningar från andra klienter."
 
-#: src/muuli_wdr.cpp:2685
+#: src/muuli_wdr.cpp:2657
 msgid "Use obfuscation for outgoing connections"
 msgstr "Använd obfuscation (fördunkling) för utgående anslutningar"
 
-#: src/muuli_wdr.cpp:2687
+#: src/muuli_wdr.cpp:2659
 msgid "This option makes aMule use Protocol Obfuscation when connecting other clients/servers."
 msgstr "Det här alternativet gör aMule använder protokoll-Obfuscation (fördunkling) vid anslutning till andra klienter/servrar."
 
-#: src/muuli_wdr.cpp:2689
+#: src/muuli_wdr.cpp:2661
 msgid "Accept only obfuscated connections"
 msgstr "Accepterar endast fördunklade anslutningar"
 
-#: src/muuli_wdr.cpp:2690
+#: src/muuli_wdr.cpp:2662
 msgid "This option makes aMule only accept obfuscated connections. You will have less sources, but all your traffic will be obfuscated"
 msgstr "Det här alternativet gör aMule endast acceptera fördunklade anslutningar. Du kommer att ha mindre källor, men all din trafik kommer att döljas"
 
-#: src/muuli_wdr.cpp:2695
+#: src/muuli_wdr.cpp:2667
 msgid "Everybody"
 msgstr "Alla"
 
-#: src/muuli_wdr.cpp:2697
+#: src/muuli_wdr.cpp:2669
 msgid "No one"
 msgstr "Ingen."
 
-#: src/muuli_wdr.cpp:2699
+#: src/muuli_wdr.cpp:2671
 msgid "Who can see my shared files:"
 msgstr "Vem kan se mina delade filer:"
 
-#: src/muuli_wdr.cpp:2700
+#: src/muuli_wdr.cpp:2672
 msgid "Select who can request to view a list of your shared files."
 msgstr "Välj vem som kan begära att få se en lista över dina delade filer."
 
-#: src/muuli_wdr.cpp:2702
+#: src/muuli_wdr.cpp:2674
 msgid "IP-Filtering"
 msgstr "IP-filtrering"
 
-#: src/muuli_wdr.cpp:2709
+#: src/muuli_wdr.cpp:2681
 msgid "Filter clients"
 msgstr "Filtrera klienter"
 
-#: src/muuli_wdr.cpp:2711
+#: src/muuli_wdr.cpp:2683
 msgid "Enable filtering of the client IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "Aktivera filtrering av klient-IP:n definierade i filen ~/.aMule/ipfilter.dat."
 
-#: src/muuli_wdr.cpp:2713
+#: src/muuli_wdr.cpp:2685
 msgid "Filter servers"
 msgstr "Filtrera servrar"
 
-#: src/muuli_wdr.cpp:2715
+#: src/muuli_wdr.cpp:2687
 msgid "Enable filtering of the server IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "Aktivera filtrering av server-IP:n definierade i filen ~/.aMule/ipfilter.dat."
 
-#: src/muuli_wdr.cpp:2719
+#: src/muuli_wdr.cpp:2691
 msgid "Reload List"
 msgstr "Återladda lista"
 
-#: src/muuli_wdr.cpp:2720
+#: src/muuli_wdr.cpp:2692
 msgid "Reload the list of IPs to filter from the file ~/.aMule/ipfilter.dat"
 msgstr "Återladda listan över IP-adresser att filtrera bort från filen ~/.aMule/ipfilter.dat"
 
-#: src/muuli_wdr.cpp:2726
+#: src/muuli_wdr.cpp:2698
 msgid "URL:"
 msgstr "URL:"
 
-#: src/muuli_wdr.cpp:2730 src/muuli_wdr.cpp:2923
+#: src/muuli_wdr.cpp:2702 src/muuli_wdr.cpp:2895
 msgid "Update now"
 msgstr "Uppdatera nu"
 
-#: src/muuli_wdr.cpp:2733
+#: src/muuli_wdr.cpp:2705
 msgid "Auto-update ipfilter at startup"
 msgstr "Auto-uppdatering av ipfilter vid start"
 
-#: src/muuli_wdr.cpp:2737
+#: src/muuli_wdr.cpp:2709
 msgid "Filtering Level:"
 msgstr "Filtreringsnivå:"
 
-#: src/muuli_wdr.cpp:2743
+#: src/muuli_wdr.cpp:2715
 msgid "Always filter LAN IPs"
 msgstr "Filtrera alltid LAN-IP-adresser"
 
-#: src/muuli_wdr.cpp:2746
+#: src/muuli_wdr.cpp:2718
 msgid "Paranoid handling of non-matching IPs"
 msgstr "Paranoid hantering av icke-matchande IP"
 
-#: src/muuli_wdr.cpp:2748
+#: src/muuli_wdr.cpp:2720
 msgid "Rejects a packet when its source IP differs from the IP the client claims (an anti-spoofing check). Disable only if it causes connection problems."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2750
+#: src/muuli_wdr.cpp:2722
 msgid "Use system-wide ipfilter.dat if available"
 msgstr "Använd systemvidd ipfilter.dat om sådan finns"
 
-#: src/muuli_wdr.cpp:2751
+#: src/muuli_wdr.cpp:2723
 #, fuzzy
 msgid "If there's no local ipfilter.dat found, allow usage of a system-wide ipfilter file."
 msgstr "Om det inte en lokal ipfilter.dat hittas, tillåt användning av systemvidd ipfilterfil."
 
-#: src/muuli_wdr.cpp:2768
+#: src/muuli_wdr.cpp:2740
 msgid "Enable Online-Signature"
 msgstr "Aktivera Onlinesignaturer"
 
-#: src/muuli_wdr.cpp:2770
+#: src/muuli_wdr.cpp:2742
 msgid "Enables the writing of the OS file, which can be used by external apps to create signatures and the like."
 msgstr "Möjliggör skrivning av OS-filen, som kan användas av externa program för att skapa signaturer och liknande."
 
-#: src/muuli_wdr.cpp:2774
+#: src/muuli_wdr.cpp:2746
 msgid "Update Frequency (Secs):"
 msgstr "Uppdateringsfrekvens (Sek):"
 
-#: src/muuli_wdr.cpp:2777
+#: src/muuli_wdr.cpp:2749
 msgid "Change the frequency (in seconds) of Online Signature updates."
 msgstr "Ändra frekvensen (i sekunder) av OnlineSignaturuppdateringar."
 
-#: src/muuli_wdr.cpp:2785
+#: src/muuli_wdr.cpp:2757
 msgid "Save online signature file in: "
 msgstr "Spara onlinesignaturfil i: "
 
-#: src/muuli_wdr.cpp:2791
+#: src/muuli_wdr.cpp:2763
 msgid "Click here to select the directory containing the the Online Signature files."
 msgstr "Klicka här för att välja den katalog som innehåller onlineSignaturFilerna."
 
-#: src/muuli_wdr.cpp:2824
+#: src/muuli_wdr.cpp:2796
 msgid "Show country flags for clients"
 msgstr "Visa landsflagger för klienter"
 
-#: src/muuli_wdr.cpp:2825
+#: src/muuli_wdr.cpp:2797
 msgid "Render the country flag column in the transfers, queue and search views. Requires a valid MMDB GeoIP database (see below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2830
+#: src/muuli_wdr.cpp:2802
 #, fuzzy
 msgid "Database"
 msgstr "Datahastighet :"
 
-#: src/muuli_wdr.cpp:2846
+#: src/muuli_wdr.cpp:2818
 #, fuzzy
 msgid "Source:"
 msgstr "Källor"
 
-#: src/muuli_wdr.cpp:2849
+#: src/muuli_wdr.cpp:2821
 msgid "DB-IP (free, no account)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2850
+#: src/muuli_wdr.cpp:2822
 msgid "MaxMind GeoLite2 (free, account required)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2851
+#: src/muuli_wdr.cpp:2823
 msgid "Custom URL"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2854
+#: src/muuli_wdr.cpp:2826
 msgid "Choose which provider supplies the GeoIP MMDB database. DB-IP is the default - no account required. MaxMind requires a free account + license key. Use Custom URL to point at any other MMDB host (e.g. a local mirror)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2871
+#: src/muuli_wdr.cpp:2843
 msgid ""
 "No configuration required.\n"
 "\n"
@@ -4872,11 +4838,11 @@ msgid ""
 "License: Creative Commons BY 4.0 - https://creativecommons.org/licenses/by/4.0/"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2884
+#: src/muuli_wdr.cpp:2856
 msgid "License key:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2890
+#: src/muuli_wdr.cpp:2862
 msgid ""
 "Sign up for a free MaxMind account, then generate a License Key:\n"
 "https://www.maxmind.com/en/geolite2/signup\n"
@@ -4886,225 +4852,225 @@ msgid ""
 "Requires attribution and account registration; refresh at least every 30 days."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2905
+#: src/muuli_wdr.cpp:2877
 #, fuzzy
 msgid "Download URL:"
 msgstr "Hämta: "
 
-#: src/muuli_wdr.cpp:2911
+#: src/muuli_wdr.cpp:2883
 msgid ""
 "Must point to an .mmdb file or a .gz / .tar.gz containing one.\n"
 "URL may include credentials (https://user:pass@host/...).\n"
 "License and attribution terms are set by the upstream URL - you are responsible."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2924
+#: src/muuli_wdr.cpp:2896
 msgid "Download the GeoIP database from the selected source."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2926
+#: src/muuli_wdr.cpp:2898
 #, fuzzy
 msgid "Auto-update on startup"
 msgstr "Auto-uppdatering av ipfilter vid start"
 
-#: src/muuli_wdr.cpp:2927
+#: src/muuli_wdr.cpp:2899
 msgid "Re-download the GeoIP database from the selected source every time aMule starts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2950
+#: src/muuli_wdr.cpp:2922
 msgid "Filter incoming messages (except current chat):"
 msgstr "Filtrera inkommande meddelanden (utom nuvarande chatt):"
 
-#: src/muuli_wdr.cpp:2952
+#: src/muuli_wdr.cpp:2924
 msgid "Filter all messages"
 msgstr "Filtrera alla meddelanden"
 
-#: src/muuli_wdr.cpp:2954
+#: src/muuli_wdr.cpp:2926
 msgid "Filter messages from people not on your friend list"
 msgstr "Filtrera meddelanden från folk som inte finns i din kompislista"
 
-#: src/muuli_wdr.cpp:2956
+#: src/muuli_wdr.cpp:2928
 msgid "Filter messages from unknown clients"
 msgstr "Filtrera meddelanden från okända klienter"
 
-#: src/muuli_wdr.cpp:2958
+#: src/muuli_wdr.cpp:2930
 msgid "Filter messages containing (use ',' as separator):"
 msgstr "Filtrera meddelanden som innehåller (använd ',' som separator):"
 
-#: src/muuli_wdr.cpp:2961 src/muuli_wdr.cpp:2972
+#: src/muuli_wdr.cpp:2933 src/muuli_wdr.cpp:2944
 msgid "add here the words amule should filter and block messages including it"
 msgstr "skriv här orden amule ska filtrera och blockera meddelanden med dem"
 
-#: src/muuli_wdr.cpp:2963
+#: src/muuli_wdr.cpp:2935
 msgid "Show received messages in the log"
 msgstr "Visa mottagna meddelanden i loggen"
 
-#: src/muuli_wdr.cpp:2966
+#: src/muuli_wdr.cpp:2938
 msgid "Comments"
 msgstr "Kommentarer"
 
-#: src/muuli_wdr.cpp:2969
+#: src/muuli_wdr.cpp:2941
 msgid "Filter comments containing (use ',' as separator):"
 msgstr "Filtrera kommentarer som innehåller (använd ',' som separator):"
 
-#: src/muuli_wdr.cpp:2994
+#: src/muuli_wdr.cpp:2966
 msgid "Enable Proxy"
 msgstr "Aktivera proxy"
 
-#: src/muuli_wdr.cpp:2995
+#: src/muuli_wdr.cpp:2967
 msgid "Enable/disable proxy support"
 msgstr "Aktivera/inaktivera proxy-stöd"
 
-#: src/muuli_wdr.cpp:2998
+#: src/muuli_wdr.cpp:2970
 msgid "Proxy type:"
 msgstr "Proxytyp:"
 
-#: src/muuli_wdr.cpp:3009
+#: src/muuli_wdr.cpp:2981
 msgid "Proxy host:"
 msgstr "Proxyserver:"
 
-#: src/muuli_wdr.cpp:3012
+#: src/muuli_wdr.cpp:2984
 msgid "The proxy host name"
 msgstr "Proxyserverns värdnamn"
 
-#: src/muuli_wdr.cpp:3014
+#: src/muuli_wdr.cpp:2986
 msgid "Proxy port:"
 msgstr "Proxyport:"
 
-#: src/muuli_wdr.cpp:3017
+#: src/muuli_wdr.cpp:2989
 msgid "The proxy port"
 msgstr "Proxyporten"
 
-#: src/muuli_wdr.cpp:3019
+#: src/muuli_wdr.cpp:2991
 msgid "Enable authentication"
 msgstr "Aktivera autentisering"
 
-#: src/muuli_wdr.cpp:3020
+#: src/muuli_wdr.cpp:2992
 msgid "Enable/disable username/password authentication"
 msgstr "Aktivera/inaktivera användarnamn/lösenordsautentisering"
 
-#: src/muuli_wdr.cpp:3023
+#: src/muuli_wdr.cpp:2995
 msgid "Username: "
 msgstr "Användarnamn: "
 
-#: src/muuli_wdr.cpp:3026
+#: src/muuli_wdr.cpp:2998
 msgid "The username to use to connect to the proxy"
 msgstr "Användarnamnet som ska användas för att ansluta till proxyn"
 
-#: src/muuli_wdr.cpp:3028
+#: src/muuli_wdr.cpp:3000
 msgid "Password:"
 msgstr "Lösenord:"
 
-#: src/muuli_wdr.cpp:3031
+#: src/muuli_wdr.cpp:3003
 msgid "The password to use to connect to the proxy"
 msgstr "Lösenordet som ska användas för att ansluta till proxyn"
 
-#: src/muuli_wdr.cpp:3050
+#: src/muuli_wdr.cpp:3022
 msgid "Connect to:"
 msgstr "Anslut till:"
 
-#: src/muuli_wdr.cpp:3059
+#: src/muuli_wdr.cpp:3031
 msgid "Login to remote amule"
 msgstr "Logga in på fjärr-amule"
 
-#: src/muuli_wdr.cpp:3064
+#: src/muuli_wdr.cpp:3036
 msgid "User name"
 msgstr "Användarnamn"
 
-#: src/muuli_wdr.cpp:3075
+#: src/muuli_wdr.cpp:3047
 msgid "Remember those settings"
 msgstr "Kom ihåg dessa inställningar"
 
-#: src/muuli_wdr.cpp:3078
+#: src/muuli_wdr.cpp:3050
 #, fuzzy
 msgid "Force ZLIB compression"
 msgstr "Använd gzip-komprimering"
 
-#: src/muuli_wdr.cpp:3102
+#: src/muuli_wdr.cpp:3074
 msgid "Enable Verbose Debug-Logging."
 msgstr "Aktivera Utförlig Debug-loggning."
 
-#: src/muuli_wdr.cpp:3104
+#: src/muuli_wdr.cpp:3076
 msgid "Only to Logfile"
 msgstr "Endast till loggfil"
 
-#: src/muuli_wdr.cpp:3106
+#: src/muuli_wdr.cpp:3078
 msgid "Message Categories:"
 msgstr "Meddelandekategorier:"
 
-#: src/muuli_wdr.cpp:3130 src/PartFileConvertDlg.cpp:160
+#: src/muuli_wdr.cpp:3102 src/PartFileConvertDlg.cpp:160
 msgid "Waiting..."
 msgstr "Väntar..."
 
-#: src/muuli_wdr.cpp:3150
+#: src/muuli_wdr.cpp:3122
 msgid "Add imports"
 msgstr "Lägg till importer"
 
-#: src/muuli_wdr.cpp:3153
+#: src/muuli_wdr.cpp:3125
 msgid "Retry selected"
 msgstr "Återförsök den valda"
 
-#: src/muuli_wdr.cpp:3155
+#: src/muuli_wdr.cpp:3127
 msgid "Remove selected"
 msgstr "Ta bort vald"
 
-#: src/muuli_wdr.cpp:3218
+#: src/muuli_wdr.cpp:3190
 msgid "Event Types"
 msgstr "Händelsetyper"
 
-#: src/muuli_wdr.cpp:3237
+#: src/muuli_wdr.cpp:3209
 msgid "Statistics and queued clients for selected file(s) : Session / All time"
 msgstr "Statistik och köade klienter för vald fil(er): Session / All tid"
 
-#: src/muuli_wdr.cpp:3261
+#: src/muuli_wdr.cpp:3233
 msgid "Active Uploads"
 msgstr "Aktiva uppladdningar"
 
-#: src/muuli_wdr.cpp:3275
+#: src/muuli_wdr.cpp:3247
 msgid "Percent of total files"
 msgstr "Procent av den totala filer"
 
-#: src/muuli_wdr.cpp:3327
+#: src/muuli_wdr.cpp:3299
 msgid "Show Clients for"
 msgstr "Visa klienter för"
 
-#: src/muuli_wdr.cpp:3329
+#: src/muuli_wdr.cpp:3301
 msgid "All files"
 msgstr "Alla filer"
 
-#: src/muuli_wdr.cpp:3332
+#: src/muuli_wdr.cpp:3304
 msgid "Selected files"
 msgstr "Valda filer"
 
-#: src/muuli_wdr.cpp:3335
+#: src/muuli_wdr.cpp:3307
 msgid "Active uploads only"
 msgstr "Endast aktiva uppladdningar"
 
-#: src/muuli_wdr.cpp:3342
+#: src/muuli_wdr.cpp:3314
 msgid "Reload:"
 msgstr "Återladda:"
 
-#: src/muuli_wdr.cpp:3346
+#: src/muuli_wdr.cpp:3318
 msgid "Reload your shared files"
 msgstr "Återladda dina delade filer"
 
-#: src/muuli_wdr.cpp:3409
+#: src/muuli_wdr.cpp:3381
 msgid "Send"
 msgstr "Skicka"
 
-#: src/muuli_wdr.cpp:3410
+#: src/muuli_wdr.cpp:3382
 msgid "Sends the specified message."
 msgstr "Skickar det specificerade meddelandet."
 
-#: src/muuli_wdr.cpp:3414
+#: src/muuli_wdr.cpp:3386
 msgid "Close this chat-session."
 msgstr "Stäng denna chat-session."
 
-#: src/muuli_wdr.cpp:3437
+#: src/muuli_wdr.cpp:3409
 msgid "Connect to any server and/or Kad"
 msgstr "Anslut till någon server och/eller Kad"
 
-#: src/muuli_wdr.cpp:3443 src/SharedFilesCtrl.cpp:142 src/Statistics.cpp:941
+#: src/muuli_wdr.cpp:3415 src/SharedFilesCtrl.cpp:142 src/Statistics.cpp:941
 msgid "Shared Files"
 msgstr "Utdelade filer"
 
@@ -5463,249 +5429,249 @@ msgstr "Nedladdad"
 msgid "ERROR: Failed to open partfile '%s'"
 msgstr "FEL: Det gick inte att öppna partfile ' %s '"
 
-#: src/Preferences.cpp:701
+#: src/Preferences.cpp:673
 msgid "System default"
 msgstr "Systemets standard"
 
-#: src/Preferences.cpp:702
+#: src/Preferences.cpp:674
 msgid "Albanian"
 msgstr "Albansk"
 
-#: src/Preferences.cpp:703
+#: src/Preferences.cpp:675
 msgid "Arabic"
 msgstr "Arabiska"
 
-#: src/Preferences.cpp:704
+#: src/Preferences.cpp:676
 msgid "Asturian"
 msgstr "Asturiska"
 
-#: src/Preferences.cpp:705
+#: src/Preferences.cpp:677
 msgid "Basque"
 msgstr "Baskiska"
 
-#: src/Preferences.cpp:706
+#: src/Preferences.cpp:678
 msgid "Bulgarian"
 msgstr "Bulgariska"
 
-#: src/Preferences.cpp:707
+#: src/Preferences.cpp:679
 msgid "Catalan"
 msgstr "Katalanska"
 
-#: src/Preferences.cpp:708
+#: src/Preferences.cpp:680
 msgid "Chinese (Simplified)"
 msgstr "Kinesiska (Förenklad)"
 
-#: src/Preferences.cpp:709
+#: src/Preferences.cpp:681
 msgid "Chinese (Traditional)"
 msgstr "Kinesiska (Traditionell)"
 
-#: src/Preferences.cpp:710
+#: src/Preferences.cpp:682
 msgid "Croatian"
 msgstr "Kroatiska"
 
-#: src/Preferences.cpp:711
+#: src/Preferences.cpp:683
 msgid "Czech"
 msgstr "Checkiska"
 
-#: src/Preferences.cpp:712
+#: src/Preferences.cpp:684
 msgid "Danish"
 msgstr "Danska"
 
-#: src/Preferences.cpp:713
+#: src/Preferences.cpp:685
 msgid "Dutch"
 msgstr "Nederländska"
 
-#: src/Preferences.cpp:714
+#: src/Preferences.cpp:686
 msgid "English (U.K.)"
 msgstr "Engelska (Storbritannien)"
 
-#: src/Preferences.cpp:715
+#: src/Preferences.cpp:687
 #, fuzzy
 msgid "English (U.S.)"
 msgstr "Engelska (Storbritannien)"
 
-#: src/Preferences.cpp:716
+#: src/Preferences.cpp:688
 msgid "Estonian"
 msgstr "Estniska"
 
-#: src/Preferences.cpp:717
+#: src/Preferences.cpp:689
 msgid "Finnish"
 msgstr "Finska"
 
-#: src/Preferences.cpp:718
+#: src/Preferences.cpp:690
 msgid "French"
 msgstr "Franska"
 
-#: src/Preferences.cpp:719
+#: src/Preferences.cpp:691
 msgid "Galician"
 msgstr "Galiciska"
 
-#: src/Preferences.cpp:720
+#: src/Preferences.cpp:692
 msgid "German"
 msgstr "Tyska"
 
-#: src/Preferences.cpp:721
+#: src/Preferences.cpp:693
 msgid "Greek"
 msgstr "Grekisk"
 
-#: src/Preferences.cpp:722
+#: src/Preferences.cpp:694
 msgid "Hebrew"
 msgstr "Hebreiska"
 
-#: src/Preferences.cpp:723
+#: src/Preferences.cpp:695
 msgid "Hungarian"
 msgstr "Ungerska"
 
-#: src/Preferences.cpp:724
+#: src/Preferences.cpp:696
 msgid "Italian"
 msgstr "Italienska"
 
-#: src/Preferences.cpp:725
+#: src/Preferences.cpp:697
 msgid "Japanese"
 msgstr "Japanska"
 
-#: src/Preferences.cpp:726
+#: src/Preferences.cpp:698
 msgid "Korean"
 msgstr "Koreanska"
 
-#: src/Preferences.cpp:727
+#: src/Preferences.cpp:699
 msgid "Latvian"
 msgstr ""
 
-#: src/Preferences.cpp:728
+#: src/Preferences.cpp:700
 msgid "Lithuanian"
 msgstr "Litauisk"
 
-#: src/Preferences.cpp:729
+#: src/Preferences.cpp:701
 msgid "Norwegian (Nynorsk)"
 msgstr "Norska (nynorsk)"
 
-#: src/Preferences.cpp:730
+#: src/Preferences.cpp:702
 msgid "Polish"
 msgstr "Polska"
 
-#: src/Preferences.cpp:731
+#: src/Preferences.cpp:703
 msgid "Portuguese"
 msgstr "Portugisiska"
 
-#: src/Preferences.cpp:732
+#: src/Preferences.cpp:704
 msgid "Portuguese (Brazilian)"
 msgstr "Portugisiska (Brasilien)"
 
-#: src/Preferences.cpp:733
+#: src/Preferences.cpp:705
 msgid "Romanian"
 msgstr "Romänska"
 
-#: src/Preferences.cpp:734
+#: src/Preferences.cpp:706
 msgid "Russian"
 msgstr "Ryska"
 
-#: src/Preferences.cpp:735
+#: src/Preferences.cpp:707
 msgid "Slovenian"
 msgstr "Slovenska"
 
-#: src/Preferences.cpp:736
+#: src/Preferences.cpp:708
 msgid "Spanish"
 msgstr "Spanska"
 
-#: src/Preferences.cpp:737
+#: src/Preferences.cpp:709
 msgid "Swedish"
 msgstr "Svenska"
 
-#: src/Preferences.cpp:738
+#: src/Preferences.cpp:710
 msgid "Turkish"
 msgstr "Turkiska"
 
-#: src/Preferences.cpp:739
+#: src/Preferences.cpp:711
 msgid "Ukrainian"
 msgstr "Ukraina"
 
-#: src/Preferences.cpp:842
+#: src/Preferences.cpp:814
 msgid "Change Language"
 msgstr "Byt språk"
 
-#: src/Preferences.cpp:906
+#: src/Preferences.cpp:878
 msgid "There are no translations installed for aMule"
 msgstr "Det finns inga översättningar installerade för aMule"
 
-#: src/Preferences.cpp:907
+#: src/Preferences.cpp:879
 msgid "No languages available"
 msgstr "Inga språk tillgängliga"
 
-#: src/Preferences.cpp:1038
+#: src/Preferences.cpp:1010
 msgid "no options available"
 msgstr "Inga alternativ tillgängliga"
 
-#: src/Preferences.cpp:2226
+#: src/Preferences.cpp:2179
 msgid "Invalid category found, skipping"
 msgstr "Ogiltig kategori hittad, hoppar över"
 
-#: src/Preferences.cpp:2395
+#: src/Preferences.cpp:2348
 msgid "TCP port can't be higher than 65532 due to server UDP socket being TCP+3"
 msgstr "TCP-port kan inte vara högre än 65532 på grund av server UDP-socket är TCP+3"
 
-#: src/Preferences.cpp:2396
+#: src/Preferences.cpp:2349
 #, c-format
 msgid "Default port will be used (%d)"
 msgstr "Standardporten kommer att användas ( %d )"
 
-#: src/PrefsUnifiedDlg.cpp:300 src/Statistics.cpp:866
+#: src/PrefsUnifiedDlg.cpp:298 src/Statistics.cpp:866
 msgid "Connection"
 msgstr "Anslutning"
 
-#: src/PrefsUnifiedDlg.cpp:301 src/SearchListCtrl.cpp:117
+#: src/PrefsUnifiedDlg.cpp:299 src/SearchListCtrl.cpp:117
 msgid "Directories"
 msgstr "Kataloger"
 
-#: src/PrefsUnifiedDlg.cpp:302 src/Statistics.cpp:917
+#: src/PrefsUnifiedDlg.cpp:300 src/Statistics.cpp:917
 msgid "Servers"
 msgstr "Servrar"
 
-#: src/PrefsUnifiedDlg.cpp:303 src/ServerListCtrl.cpp:96
+#: src/PrefsUnifiedDlg.cpp:301 src/ServerListCtrl.cpp:96
 msgid "Files"
 msgstr "Filer"
 
-#: src/PrefsUnifiedDlg.cpp:304
+#: src/PrefsUnifiedDlg.cpp:302
 msgid "Security"
 msgstr "Säkerhet"
 
-#: src/PrefsUnifiedDlg.cpp:305
+#: src/PrefsUnifiedDlg.cpp:303
 msgid "Interface"
 msgstr "Gränssnitt"
 
-#: src/PrefsUnifiedDlg.cpp:312
+#: src/PrefsUnifiedDlg.cpp:310
 msgid "IP2Country"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:315
+#: src/PrefsUnifiedDlg.cpp:313
 msgid "Proxy"
 msgstr "Proxy"
 
-#: src/PrefsUnifiedDlg.cpp:316
+#: src/PrefsUnifiedDlg.cpp:314
 msgid "Filters"
 msgstr "Filter"
 
-#: src/PrefsUnifiedDlg.cpp:317
+#: src/PrefsUnifiedDlg.cpp:315
 msgid "Remote Controls"
 msgstr "Fjärrkontroller"
 
-#: src/PrefsUnifiedDlg.cpp:318
+#: src/PrefsUnifiedDlg.cpp:316
 msgid "Online Signature"
 msgstr "Onlinesignatur"
 
-#: src/PrefsUnifiedDlg.cpp:319
+#: src/PrefsUnifiedDlg.cpp:317
 msgid "Advanced"
 msgstr "Avancerad"
 
-#: src/PrefsUnifiedDlg.cpp:320
+#: src/PrefsUnifiedDlg.cpp:318
 msgid "Events"
 msgstr "Händelser"
 
-#: src/PrefsUnifiedDlg.cpp:323
+#: src/PrefsUnifiedDlg.cpp:321
 msgid "Debugging"
 msgstr "Felsökning"
 
-#: src/PrefsUnifiedDlg.cpp:453
+#: src/PrefsUnifiedDlg.cpp:451
 msgid ""
 "The following variables will be substituted:\n"
 "    %PARTFILE - full path to the file\n"
@@ -5715,15 +5681,15 @@ msgstr ""
 "    %PARTFILE - hela sökvägen till filen\n"
 "    %PARTNAME - endast filnamnet"
 
-#: src/PrefsUnifiedDlg.cpp:474
+#: src/PrefsUnifiedDlg.cpp:472
 msgid "Tray icon support requires libayatana-appindicator3 at compile time."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:490
+#: src/PrefsUnifiedDlg.cpp:488
 msgid "Not available on Wayland: the protocol does not report when a window is minimized, so this option cannot intercept the system minimize button. Workaround: launch aMule with `GDK_BACKEND=x11` to use XWayland instead."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:536
+#: src/PrefsUnifiedDlg.cpp:534
 msgid ""
 "Do not change these setting unless you know\n"
 "what you are doing, otherwise you can easily\n"
@@ -5739,35 +5705,26 @@ msgstr ""
 "aMule kommer fungera bra utan att justera några av\n"
 "dessa inställningar."
 
-#: src/PrefsUnifiedDlg.cpp:647
+#: src/PrefsUnifiedDlg.cpp:645
 #, c-format
 msgid "Failed to connect Cfg to widget with the ID %d and key %s"
 msgstr "Det gick inte att ansluta Cfg till widget med ID %d och nyckel %s"
 
-#: src/PrefsUnifiedDlg.cpp:695
+#: src/PrefsUnifiedDlg.cpp:693
 #, c-format
 msgid "Failed to transfer data from Cfg to Widget with the ID %d and key %s"
 msgstr "Det gick inte att överföra data från Cfg till widget med ID %d och nyckel %s"
 
-#: src/PrefsUnifiedDlg.cpp:801
+#: src/PrefsUnifiedDlg.cpp:799
 msgid "The type of proxy you are connecting to"
 msgstr "Den typen av proxy du ansluter till"
 
-#: src/PrefsUnifiedDlg.cpp:1020
+#: src/PrefsUnifiedDlg.cpp:1003
 #, c-format
 msgid "Failed to transfer data from Widget to Cfg with the ID %d and key %s"
 msgstr "Det gick inte att överföra data från widget till Cfg med ID %d och nyckel %s"
 
 #: src/PrefsUnifiedDlg.cpp:1103
-#, fuzzy
-msgid "No password set."
-msgstr "Kontrollerar lösenord\n"
-
-#: src/PrefsUnifiedDlg.cpp:1132
-msgid "Guest access needs a password. Type one in the guest password field, or untick Enable guest access."
-msgstr ""
-
-#: src/PrefsUnifiedDlg.cpp:1144
 msgid ""
 "aMule must be restarted to enable these changes:\n"
 "\n"
@@ -5775,41 +5732,41 @@ msgstr ""
 "aMule måste startas om för att aktivera dessa ändringar:\n"
 "\n"
 
-#: src/PrefsUnifiedDlg.cpp:1151
+#: src/PrefsUnifiedDlg.cpp:1110
 msgid "- TCP port changed.\n"
 msgstr "- TCP-port ändrad.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1156
+#: src/PrefsUnifiedDlg.cpp:1115
 msgid "- UDP port changed.\n"
 msgstr "- UDP-port ändrad.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1161
+#: src/PrefsUnifiedDlg.cpp:1120
 #, fuzzy
 msgid "- Network interface binding changed.\n"
 msgstr "- Extern anslutningsgränssnitt ändrad.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1166
+#: src/PrefsUnifiedDlg.cpp:1125
 msgid "- External connect port changed.\n"
 msgstr "- Extern anslutningsport ändrad.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1170
+#: src/PrefsUnifiedDlg.cpp:1129
 msgid "- External connect acceptance changed.\n"
 msgstr "- Extern anslutningsacceptans ändrades.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1174
+#: src/PrefsUnifiedDlg.cpp:1133
 msgid "- External connect interface changed.\n"
 msgstr "- Extern anslutningsgränssnitt ändrad.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1178
+#: src/PrefsUnifiedDlg.cpp:1137
 msgid "- Protocol obfuscation support changed.\n"
 msgstr "- Stöd för fördunkling av protokoll ändrad.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1193
+#: src/PrefsUnifiedDlg.cpp:1151
 #, fuzzy
 msgid "- amuleapi settings changed.\n"
 msgstr "- Språk ändrat.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1202
+#: src/PrefsUnifiedDlg.cpp:1160
 msgid ""
 "Your Auto-update server list is empty.\n"
 "'Auto-update server list at startup' will be disabled."
@@ -5817,7 +5774,7 @@ msgstr ""
 "Din automatiska uppdateringsserverlista är tom.\n"
 "'Auto-uppdateringsserverlista vid start' inaktiveras."
 
-#: src/PrefsUnifiedDlg.cpp:1213
+#: src/PrefsUnifiedDlg.cpp:1171
 msgid ""
 "You have enabled external connections but have not specified a password.\n"
 "External connections cannot be enabled unless a valid password is specified."
@@ -5825,33 +5782,28 @@ msgstr ""
 "Du har aktiverat externa anslutningar men har inte angett ett lösenord.\n"
 "External anslutningar kan inte aktiveras om inte ett giltigt lösenord anges."
 
-#: src/PrefsUnifiedDlg.cpp:1246
-#, c-format
-msgid "The amuleapi password could not be saved: %s"
-msgstr ""
-
-#: src/PrefsUnifiedDlg.cpp:1276
+#: src/PrefsUnifiedDlg.cpp:1202
 msgid "- Language changed.\n"
 msgstr "- Språk ändrat.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1281
+#: src/PrefsUnifiedDlg.cpp:1207
 msgid "- Temp folder changed.\n"
 msgstr "- Mappen Temp ändrades.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1286
+#: src/PrefsUnifiedDlg.cpp:1212
 msgid "- ED2K network enabled.\n"
 msgstr "- ED2K-nätverk aktiverad.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1319
+#: src/PrefsUnifiedDlg.cpp:1245
 msgid "The shared-file exclusion pattern is not a valid regular expression. The filter has been left disabled."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1321 src/PrefsUnifiedDlg.cpp:1921
+#: src/PrefsUnifiedDlg.cpp:1247 src/PrefsUnifiedDlg.cpp:1841
 #, fuzzy
 msgid "Invalid regular expression"
 msgstr "Fel protokoll-version"
 
-#: src/PrefsUnifiedDlg.cpp:1398
+#: src/PrefsUnifiedDlg.cpp:1324
 msgid ""
 "Both eD2k and Kad network are disabled.\n"
 "You won't be able to connect until you enable at least one of them."
@@ -5859,7 +5811,7 @@ msgstr ""
 "Både eD2k- och Kad-nätverk är inaktiverade.\n"
 "Du kommer inte att kunna ansluta förrän du aktiverar åtminstone en av dem."
 
-#: src/PrefsUnifiedDlg.cpp:1403
+#: src/PrefsUnifiedDlg.cpp:1329
 msgid ""
 "Kad will not start if your UDP port is disabled.\n"
 "Enable UDP port or disable Kad."
@@ -5867,7 +5819,7 @@ msgstr ""
 "Kad startar inte om din UDP-port är inaktiverad.\n"
 "Aktivra UDP-port eller inaktivera Kad."
 
-#: src/PrefsUnifiedDlg.cpp:1459
+#: src/PrefsUnifiedDlg.cpp:1385
 msgid ""
 "\n"
 "You MUST restart aMule now.\n"
@@ -5877,69 +5829,69 @@ msgstr ""
 "Du MÅSTE starta om aMule nu.\n"
 "Om du inte startar nu, klaga inte om något dåligt händer.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1524
+#: src/PrefsUnifiedDlg.cpp:1450
 msgid "Could not register aMule for autostart at login. The autostart store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1526
+#: src/PrefsUnifiedDlg.cpp:1452
 msgid "Could not remove the autostart-at-login entry."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1527
+#: src/PrefsUnifiedDlg.cpp:1453
 #, fuzzy
 msgid "Autostart"
 msgstr "Auto Refresh startad"
 
-#: src/PrefsUnifiedDlg.cpp:1542
+#: src/PrefsUnifiedDlg.cpp:1468
 msgid "Register file type"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1542
+#: src/PrefsUnifiedDlg.cpp:1468
 msgid "Register URL handler"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1550
+#: src/PrefsUnifiedDlg.cpp:1476
 #, c-format
 msgid "aMule only handles eD2k-compatible magnets. If you replace the current magnet handler (%s), BitTorrent magnet links will stop working - aMule cannot download BitTorrent content. Continue?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1555
+#: src/PrefsUnifiedDlg.cpp:1481
 #, c-format
 msgid "Another application currently opens .emulecollection files (%s). Replace it with aMule?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1560
+#: src/PrefsUnifiedDlg.cpp:1486
 #, c-format
 msgid "Another application is currently the default handler for these links (%s). Replace it with aMule?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1585
+#: src/PrefsUnifiedDlg.cpp:1511
 msgid "Could not register aMule for .emulecollection files. The registration store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1587
+#: src/PrefsUnifiedDlg.cpp:1513
 #, fuzzy
 msgid "Could not remove the file type registration."
 msgstr "Mapp för temporära nerladdningsfiler"
 
-#: src/PrefsUnifiedDlg.cpp:1589
+#: src/PrefsUnifiedDlg.cpp:1515
 msgid "Could not register aMule as the URL handler. The registration store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1591
+#: src/PrefsUnifiedDlg.cpp:1517
 msgid "Could not remove the URL handler registration."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1661 src/PrefsUnifiedDlg.cpp:1688
+#: src/PrefsUnifiedDlg.cpp:1587 src/PrefsUnifiedDlg.cpp:1614
 #, fuzzy
 msgid "The web server and aMule API require external connections to be enabled."
 msgstr "Lösenord sparad och extern anslutning aktiverad."
 
-#: src/PrefsUnifiedDlg.cpp:1671
+#: src/PrefsUnifiedDlg.cpp:1597
 msgid "The aMule web server is deprecated. Consider running the aMule API instead."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1735
+#: src/PrefsUnifiedDlg.cpp:1655
 msgid ""
 "Your Auto-update servers list is in blank.\n"
 "Please fill in at least one URL to point to a valid server.met file.\n"
@@ -5949,66 +5901,66 @@ msgstr ""
 "Vänligen fylla i åtminstone en URL för att peka på en giltig server.met-fil.\n"
 "Klicka på knappen \"lista\" i denna kryssruta för att ange en URL."
 
-#: src/PrefsUnifiedDlg.cpp:1876
+#: src/PrefsUnifiedDlg.cpp:1796
 msgid "Temporary files"
 msgstr "Temporära filer"
 
-#: src/PrefsUnifiedDlg.cpp:1881
+#: src/PrefsUnifiedDlg.cpp:1801
 msgid "Incoming files"
 msgstr "Inkommande filer"
 
-#: src/PrefsUnifiedDlg.cpp:1886
+#: src/PrefsUnifiedDlg.cpp:1806
 msgid "Online Signatures"
 msgstr "Online-signaturer"
 
-#: src/PrefsUnifiedDlg.cpp:1899
+#: src/PrefsUnifiedDlg.cpp:1819
 #, c-format
 msgid "Choose a folder for %s"
 msgstr "Välj en mapp för %s"
 
-#: src/PrefsUnifiedDlg.cpp:1923
+#: src/PrefsUnifiedDlg.cpp:1843
 #, fuzzy, c-format
 msgid "Would exclude %u of %u shared file"
 msgid_plural "Would exclude %u of %u shared files"
 msgstr[0] "Hittade %i känd delad fil"
 msgstr[1] "Hittade %i kända delad filer"
 
-#: src/PrefsUnifiedDlg.cpp:1940
+#: src/PrefsUnifiedDlg.cpp:1860
 msgid "Browse for videoplayer"
 msgstr "Bläddra efter videospelare"
 
-#: src/PrefsUnifiedDlg.cpp:1944
+#: src/PrefsUnifiedDlg.cpp:1864
 msgid "Select browser"
 msgstr "Välj webbläsare"
 
-#: src/PrefsUnifiedDlg.cpp:1948
+#: src/PrefsUnifiedDlg.cpp:1868
 #, fuzzy
 msgid "Select ffprobe binary"
 msgstr "Välj webbläsare"
 
-#: src/PrefsUnifiedDlg.cpp:1954
+#: src/PrefsUnifiedDlg.cpp:1874
 #, c-format
 msgid "Executable%s"
 msgstr "Körbar %s"
 
-#: src/PrefsUnifiedDlg.cpp:1988
+#: src/PrefsUnifiedDlg.cpp:1908
 msgid "ffprobe not found on PATH or in the standard install locations. Install ffmpeg (which ships ffprobe) or use Browse to pick a binary manually."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2000
+#: src/PrefsUnifiedDlg.cpp:1920
 msgid "Reset the settings on this page to their default values?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2001
+#: src/PrefsUnifiedDlg.cpp:1921
 #, fuzzy
 msgid "Reset to defaults"
 msgstr "Systemets standard"
 
-#: src/PrefsUnifiedDlg.cpp:2028
+#: src/PrefsUnifiedDlg.cpp:1948
 msgid "Edit server list"
 msgstr "Redigera serverlista"
 
-#: src/PrefsUnifiedDlg.cpp:2029
+#: src/PrefsUnifiedDlg.cpp:1949
 msgid ""
 "Add here URL's to download server.met files.\n"
 "Only one url on each line."
@@ -6016,180 +5968,176 @@ msgstr ""
 "Lägg här URL för att hämta server.met filer.\n"
 "Endast en webbadress på varje rad."
 
-#: src/PrefsUnifiedDlg.cpp:2084
+#: src/PrefsUnifiedDlg.cpp:2004
 msgid "IP2Country update failed"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2229 src/PrefsUnifiedDlg.cpp:2260
+#: src/PrefsUnifiedDlg.cpp:2149 src/PrefsUnifiedDlg.cpp:2180
 msgid "Data by MaxMind GeoLite2"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2231 src/PrefsUnifiedDlg.cpp:2262
+#: src/PrefsUnifiedDlg.cpp:2151 src/PrefsUnifiedDlg.cpp:2182
 #, fuzzy
 msgid "Custom source"
 msgstr "Kompletta källor"
 
-#: src/PrefsUnifiedDlg.cpp:2233 src/PrefsUnifiedDlg.cpp:2264
+#: src/PrefsUnifiedDlg.cpp:2153 src/PrefsUnifiedDlg.cpp:2184
 msgid "Data by DB-IP.com"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2284
+#: src/PrefsUnifiedDlg.cpp:2204
 #, fuzzy, c-format
 msgid "Status: Loaded%s"
 msgstr "Status:"
 
-#: src/PrefsUnifiedDlg.cpp:2286
+#: src/PrefsUnifiedDlg.cpp:2206
 #, fuzzy, c-format
 msgid "Status: Loaded%s - %s"
 msgstr "Status:"
 
-#: src/PrefsUnifiedDlg.cpp:2290
+#: src/PrefsUnifiedDlg.cpp:2210
 msgid "Status: Failed to load - click 'Update now' to refresh."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2292
+#: src/PrefsUnifiedDlg.cpp:2212
 msgid "Status: Not found - click 'Update now' to download."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2350 src/PrefsUnifiedDlg.cpp:2374
+#: src/PrefsUnifiedDlg.cpp:2270 src/PrefsUnifiedDlg.cpp:2294
 #, c-format
 msgid "Update delay: %d second"
 msgid_plural "Update delay: %d seconds"
 msgstr[0] "Uppdateringsfördröjning: %d sekund"
 msgstr[1] "Uppdateringsfördröjning: %d sekunder"
 
-#: src/PrefsUnifiedDlg.cpp:2358
+#: src/PrefsUnifiedDlg.cpp:2278
 #, c-format
 msgid "Time for average graph: %d minute"
 msgid_plural "Time for average graph: %d minutes"
 msgstr[0] "Tid för genomsnittlig graf: %d minut"
 msgstr[1] "Tid för genomsnittlig graf: %d minuter"
 
-#: src/PrefsUnifiedDlg.cpp:2367
+#: src/PrefsUnifiedDlg.cpp:2287
 #, c-format
 msgid "Connections Graph Scale: %d"
 msgstr "Anslutningsdiagramskala: %d"
 
-#: src/PrefsUnifiedDlg.cpp:2382
+#: src/PrefsUnifiedDlg.cpp:2302
 #, c-format
 msgid "File Buffer Size: %d byte"
 msgid_plural "File Buffer Size: %d bytes"
 msgstr[0] "Filbuffertstorlek: %d byte"
 msgstr[1] "Filbuffertstorlek: %d bytes"
 
-#: src/PrefsUnifiedDlg.cpp:2392
+#: src/PrefsUnifiedDlg.cpp:2312
 #, c-format
 msgid "Upload Queue Size: %d client"
 msgid_plural "Upload Queue Size: %d clients"
 msgstr[0] "Uppladdningsköstorlek: %d klient"
 msgstr[1] "Uppladdningsköstorlek: %d klienter"
 
-#: src/PrefsUnifiedDlg.cpp:2402
+#: src/PrefsUnifiedDlg.cpp:2322
 #, c-format
 msgid "Server connection refresh interval: %d minute"
 msgid_plural "Server connection refresh interval: %d minutes"
 msgstr[0] "Serveranslutninguppdateringsintervall: %d minut"
 msgstr[1] "Serveranslutninguppdateringsintervall: %d minuter"
 
-#: src/PrefsUnifiedDlg.cpp:2407
+#: src/PrefsUnifiedDlg.cpp:2327
 msgid "Server connection refresh interval: Disabled"
 msgstr "Serveranslutningsuppdateringsintervall: Inaktiverad"
 
-#: src/PrefsUnifiedDlg.cpp:2451
+#: src/PrefsUnifiedDlg.cpp:2371
 msgid "disabled"
 msgstr "inaktiverad"
 
-#: src/PrefsUnifiedDlg.cpp:2477
+#: src/PrefsUnifiedDlg.cpp:2397
 #, c-format
 msgid "Execute command on '%s' event"
 msgstr "Exekvera kommando på '%s' händelse"
 
-#: src/PrefsUnifiedDlg.cpp:2484
+#: src/PrefsUnifiedDlg.cpp:2404
 msgid "Enable command execution on core"
 msgstr "Aktivera kommandokörning på kärnan"
 
-#: src/PrefsUnifiedDlg.cpp:2496
+#: src/PrefsUnifiedDlg.cpp:2416
 msgid "Core command:"
 msgstr "Kommando till kärnan:"
 
-#: src/PrefsUnifiedDlg.cpp:2512
+#: src/PrefsUnifiedDlg.cpp:2432
 msgid "Enable command execution on GUI"
 msgstr "Aktivera kommandokörning via GUI"
 
-#: src/PrefsUnifiedDlg.cpp:2524
+#: src/PrefsUnifiedDlg.cpp:2444
 msgid "GUI command:"
 msgstr "GUI kommando:"
 
-#: src/PrefsUnifiedDlg.cpp:2540
+#: src/PrefsUnifiedDlg.cpp:2460
 msgid "The following variables will be replaced:"
 msgstr "Följande variabler kommer att ersättas:"
 
-#: src/PrefsUnifiedDlg.cpp:2708
+#: src/PrefsUnifiedDlg.cpp:2628
 msgid ""
 "The following folders look like system or sensitive locations:\n"
 "\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2713
+#: src/PrefsUnifiedDlg.cpp:2633
 msgid "Sharing them recursively will publish every file underneath on the eD2k/Kad networks. Do you really want to do this?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2716
+#: src/PrefsUnifiedDlg.cpp:2636
 #, fuzzy
 msgid "Confirm shared folders"
 msgstr "Delade mappar"
 
-#: src/PrefsUnifiedDlg.cpp:2744
+#: src/PrefsUnifiedDlg.cpp:2664
 #, fuzzy
 msgid "Reloading shared files..."
 msgstr "Återladda dina delade filer"
 
-#: src/PrefsUnifiedDlg.cpp:2745
+#: src/PrefsUnifiedDlg.cpp:2665
 msgid "Scanning for subdirectories..."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2746
+#: src/PrefsUnifiedDlg.cpp:2666
 #, fuzzy
 msgid "Updating shared folders"
 msgstr "Delade mappar"
 
-#: src/PrefsUnifiedDlg.cpp:2773
+#: src/PrefsUnifiedDlg.cpp:2693
 #, c-format
 msgid "Scanned %u directories..."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2823
+#: src/PrefsUnifiedDlg.cpp:2743
 #, fuzzy, c-format
 msgid "Reloading shared files: %u files scanned"
 msgstr "Ladda om listan med delade filer."
 
-#: src/PrefsUnifiedDlg.cpp:2873
+#: src/PrefsUnifiedDlg.cpp:2793
 #, fuzzy
 msgid "Shared folder"
 msgstr "Delade mappar"
 
-#: src/SearchDlg.cpp:280
-msgid "Clear search history"
-msgstr ""
-
-#: src/SearchDlg.cpp:584
+#: src/SearchDlg.cpp:425
 msgid "It's impossible to search when both eD2k and Kademlia are disabled."
 msgstr ""
 
-#: src/SearchDlg.cpp:585 src/SearchListCtrl.cpp:858
+#: src/SearchDlg.cpp:426 src/SearchListCtrl.cpp:858
 #, fuzzy
 msgid "Search error"
 msgstr "Sökningar"
 
-#: src/SearchDlg.cpp:929
+#: src/SearchDlg.cpp:768
 msgid "Min size must be smaller than max size. Max size ignored."
 msgstr "Min storlek måste vara mindre än max storlek. Max storlek ignoreras."
 
-#: src/SearchDlg.cpp:930 src/SearchDlg.cpp:1012
+#: src/SearchDlg.cpp:769 src/SearchDlg.cpp:851
 msgid "Search warning"
 msgstr "Sökvarning"
 
-#: src/SearchDlg.cpp:1092 src/SearchListCtrl.cpp:735
+#: src/SearchDlg.cpp:929 src/SearchListCtrl.cpp:735
 msgid "Main"
 msgstr "Huvud"
 

--- a/po/sv.po
+++ b/po/sv.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-28 12:17+0200\n"
+"POT-Creation-Date: 2026-07-28 13:09+0200\n"
 "PO-Revision-Date: 2026-07-27 11:46+0000\n"
 "Last-Translator: raffe <raffe@localhost.se>\n"
 "Language-Team: Swedish <tp-sv@listor.tp-sv.se>\n"
@@ -291,7 +291,7 @@ msgid "Password set and external connections enabled."
 msgstr "Lösenord sparad och extern anslutning aktiverad."
 
 #: src/amule.cpp:755 src/KadDlg.cpp:176 src/KadDlg.cpp:185
-#: src/PrefsUnifiedDlg.cpp:1461 src/SharedFilesCtrl.cpp:476
+#: src/PrefsUnifiedDlg.cpp:1470 src/SharedFilesCtrl.cpp:476
 msgid "WARNING"
 msgstr "VARNING"
 
@@ -329,7 +329,7 @@ msgstr "Du vill köra webbservern vid uppstart, men binärfilen amuleweb kan int
 #: src/amule-remote-gui.cpp:603 src/amule-remote-gui.cpp:671
 #: src/amule-remote-gui.cpp:709 src/amule-remote-gui.cpp:1282
 #: src/amule-remote-gui.cpp:1345 src/amule-remote-gui.cpp:1372
-#: src/DownloadQueue.cpp:1481 src/PrefsUnifiedDlg.cpp:1247
+#: src/DownloadQueue.cpp:1481 src/PrefsUnifiedDlg.cpp:1256
 msgid "ERROR"
 msgstr "FEL"
 
@@ -591,36 +591,36 @@ msgstr "Besök https://github.com/amule-org/amule/releases/latest för att se om
 msgid "FATAL ERROR: Failed to create Timer"
 msgstr "ALLVARLIGT FEL: Kunde inte skapa Timer"
 
-#: src/amuleDlg.cpp:361 src/amuleDlg.cpp:1787 src/amuleDlg.cpp:2033
-#: src/muuli_wdr.cpp:1492 src/muuli_wdr.cpp:3449
+#: src/amuleDlg.cpp:361 src/amuleDlg.cpp:1810 src/amuleDlg.cpp:2056
+#: src/muuli_wdr.cpp:1492 src/muuli_wdr.cpp:3453
 msgid "Networks"
 msgstr "Nätverk"
 
-#: src/amuleDlg.cpp:362 src/amuleDlg.cpp:1793 src/muuli_wdr.cpp:3450
+#: src/amuleDlg.cpp:362 src/amuleDlg.cpp:1816 src/muuli_wdr.cpp:3454
 msgid "Searches"
 msgstr "Sökningar"
 
-#: src/amuleDlg.cpp:363 src/amuleDlg.cpp:1799 src/DownloadListCtrl.cpp:740
-#: src/muuli_wdr.cpp:392 src/muuli_wdr.cpp:1585 src/muuli_wdr.cpp:3451
+#: src/amuleDlg.cpp:363 src/amuleDlg.cpp:1822 src/DownloadListCtrl.cpp:740
+#: src/muuli_wdr.cpp:392 src/muuli_wdr.cpp:1585 src/muuli_wdr.cpp:3455
 #: src/Statistics.cpp:829
 msgid "Downloads"
 msgstr "Hämtningar"
 
-#: src/amuleDlg.cpp:364 src/amuleDlg.cpp:1805 src/muuli_wdr.cpp:3325
+#: src/amuleDlg.cpp:364 src/amuleDlg.cpp:1828 src/muuli_wdr.cpp:3329
 msgid "Shared files"
 msgstr "Delade filer"
 
-#: src/amuleDlg.cpp:365 src/amuleDlg.cpp:1811 src/muuli_wdr.cpp:2957
-#: src/muuli_wdr.cpp:3407 src/muuli_wdr.cpp:3454
+#: src/amuleDlg.cpp:365 src/amuleDlg.cpp:1834 src/muuli_wdr.cpp:2961
+#: src/muuli_wdr.cpp:3411 src/muuli_wdr.cpp:3458
 msgid "Messages"
 msgstr "Meddelanden"
 
-#: src/amuleDlg.cpp:366 src/amuleDlg.cpp:1817 src/muuli_wdr.cpp:3455
+#: src/amuleDlg.cpp:366 src/amuleDlg.cpp:1840 src/muuli_wdr.cpp:3459
 #: src/PrefsUnifiedDlg.cpp:314 src/Statistics.cpp:779 src/Statistics.cpp:1235
 msgid "Statistics"
 msgstr "Statistik"
 
-#: src/amuleDlg.cpp:368 src/amuleDlg.cpp:1824 src/muuli_wdr.cpp:3457
+#: src/amuleDlg.cpp:368 src/amuleDlg.cpp:1847 src/muuli_wdr.cpp:3461
 #: src/PrefsUnifiedDlg.cpp:330 src/utils/wxCas/src/wxcasprefs.cpp:39
 msgid "Preferences"
 msgstr "Inställningar"
@@ -679,8 +679,8 @@ msgstr "Kad: Av"
 #: src/amuleDlg.cpp:1029 src/DownloadListCtrl.cpp:505
 #: src/DownloadListCtrl.cpp:749 src/FriendListCtrl.cpp:180
 #: src/muuli_wdr.cpp:731 src/muuli_wdr.cpp:782 src/muuli_wdr.cpp:846
-#: src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2262 src/muuli_wdr.cpp:2347
-#: src/muuli_wdr.cpp:3095 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
+#: src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2266 src/muuli_wdr.cpp:2351
+#: src/muuli_wdr.cpp:3099 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
 #: src/ServerListCtrl.cpp:606 src/TransferWnd.cpp:378
 #: src/utils/wxCas/src/wxcasprefs.cpp:235
 msgid "Cancel"
@@ -691,7 +691,7 @@ msgid "Stop the current connection attempts"
 msgstr "Stoppa de nuvarande anslutningsförsöken"
 
 #: src/amuleDlg.cpp:1035 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976
-#: src/muuli_wdr.cpp:2485
+#: src/muuli_wdr.cpp:2489
 msgid "Disconnect"
 msgstr "Koppla från"
 
@@ -700,7 +700,7 @@ msgid "Disconnect from the currently connected networks"
 msgstr "Koppla från de nätverk som nu är anslutna."
 
 #: src/amuleDlg.cpp:1041 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979
-#: src/muuli_wdr.cpp:2640 src/muuli_wdr.cpp:3092 src/muuli_wdr.cpp:3447
+#: src/muuli_wdr.cpp:2644 src/muuli_wdr.cpp:3096 src/muuli_wdr.cpp:3451
 msgid "Connect"
 msgstr "Anslut"
 
@@ -755,7 +755,7 @@ msgstr "Bekräfta avslutning"
 msgid "Launch Command: "
 msgstr "Kör kommando:"
 
-#: src/amuleDlg.cpp:1632 src/muuli_wdr.cpp:1982 src/Preferences.cpp:979
+#: src/amuleDlg.cpp:1632 src/muuli_wdr.cpp:1986 src/Preferences.cpp:979
 msgid "- default -"
 msgstr "- standard -"
 
@@ -769,60 +769,60 @@ msgstr "Skin-mappen '%s' finns inte"
 msgid "WARNING: Unable to open skin file '%s' for read"
 msgstr "Varning: Kan inte öppna skin-filen '%s' för läsning"
 
-#: src/amuleDlg.cpp:1791 src/muuli_wdr.cpp:3449
+#: src/amuleDlg.cpp:1814 src/muuli_wdr.cpp:3453
 msgid "Networks Window"
 msgstr "Nätverksfönster"
 
-#: src/amuleDlg.cpp:1797 src/muuli_wdr.cpp:3450
+#: src/amuleDlg.cpp:1820 src/muuli_wdr.cpp:3454
 msgid "Searches Window"
 msgstr "Sökfönster"
 
-#: src/amuleDlg.cpp:1803 src/muuli_wdr.cpp:3451
+#: src/amuleDlg.cpp:1826 src/muuli_wdr.cpp:3455
 msgid "Downloads Window"
 msgstr "Hämtningsfönster"
 
-#: src/amuleDlg.cpp:1809 src/muuli_wdr.cpp:3453
+#: src/amuleDlg.cpp:1832 src/muuli_wdr.cpp:3457
 msgid "Shared Files Window"
 msgstr "Delade filer-fönster"
 
-#: src/amuleDlg.cpp:1815 src/muuli_wdr.cpp:3454
+#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3458
 msgid "Messages Window"
 msgstr "Meddelandefönster"
 
-#: src/amuleDlg.cpp:1821 src/muuli_wdr.cpp:3455
+#: src/amuleDlg.cpp:1844 src/muuli_wdr.cpp:3459
 msgid "Statistics Graph Window"
 msgstr "Statistiksgrafsfönster"
 
-#: src/amuleDlg.cpp:1828 src/muuli_wdr.cpp:3457
+#: src/amuleDlg.cpp:1851 src/muuli_wdr.cpp:3461
 msgid "Preferences Settings Window"
 msgstr "Inställningsfönster"
 
-#: src/amuleDlg.cpp:1831 src/muuli_wdr.cpp:3458
+#: src/amuleDlg.cpp:1854 src/muuli_wdr.cpp:3462
 msgid "Import"
 msgstr "Importera"
 
-#: src/amuleDlg.cpp:1835 src/muuli_wdr.cpp:3458
+#: src/amuleDlg.cpp:1858 src/muuli_wdr.cpp:3462
 msgid "The partfile importer tool"
 msgstr "Partfile-importerings-verktyget"
 
-#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3459
+#: src/amuleDlg.cpp:1861 src/muuli_wdr.cpp:3463
 #: src/utils/aLinkCreator/src/alcframe.cpp:262
 msgid "About"
 msgstr "Om"
 
-#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3459
+#: src/amuleDlg.cpp:1861 src/muuli_wdr.cpp:3463
 msgid "About/Help"
 msgstr "Om/Hjälp"
 
-#: src/amuleDlg.cpp:2036
+#: src/amuleDlg.cpp:2059
 msgid "eD2k network"
 msgstr "eD2k-nätverk"
 
-#: src/amuleDlg.cpp:2039
+#: src/amuleDlg.cpp:2062
 msgid "Kad network"
 msgstr "Kad-nätverk"
 
-#: src/amuleDlg.cpp:2039
+#: src/amuleDlg.cpp:2062
 msgid "No network"
 msgstr "Inget nätverk"
 
@@ -1355,19 +1355,19 @@ msgstr "Auto [Hö]"
 msgid "Very low"
 msgstr "Mycket låg"
 
-#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:743 src/muuli_wdr.cpp:2313
+#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:743 src/muuli_wdr.cpp:2317
 #: src/ServerListCtrl.cpp:263 src/ServerListCtrl.cpp:456
 #: src/SharedFilesCtrl.cpp:145
 msgid "Low"
 msgstr "Låg"
 
-#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:744 src/muuli_wdr.cpp:2314
+#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:744 src/muuli_wdr.cpp:2318
 #: src/ServerListCtrl.cpp:266 src/ServerListCtrl.cpp:457
 #: src/SharedFilesCtrl.cpp:146
 msgid "Normal"
 msgstr "Normal"
 
-#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:745 src/muuli_wdr.cpp:2315
+#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:745 src/muuli_wdr.cpp:2319
 #: src/ServerListCtrl.cpp:269 src/ServerListCtrl.cpp:458
 #: src/SharedFilesCtrl.cpp:147
 msgid "High"
@@ -1459,7 +1459,7 @@ msgstr "Lokal server"
 msgid "Remote Server"
 msgstr "Fjärrserver"
 
-#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3212
+#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3216
 #: src/SearchDlg.cpp:119 src/TextClient.cpp:911
 msgid "Kad"
 msgstr "Kad"
@@ -1531,7 +1531,7 @@ msgstr "Del"
 msgid "Size"
 msgstr "Storlek"
 
-#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3279
+#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3283
 msgid "Transferred"
 msgstr "Överfört"
 
@@ -1589,7 +1589,7 @@ msgstr ""
 "Återkoppling från: %s (%s)\n"
 "\n"
 
-#: src/DownloadListCtrl.cpp:746 src/muuli_wdr.cpp:2316
+#: src/DownloadListCtrl.cpp:746 src/muuli_wdr.cpp:2320
 #: src/SharedFilesCtrl.cpp:150
 msgid "Auto"
 msgstr "Auto"
@@ -1627,7 +1627,7 @@ msgid "Extended Options"
 msgstr "Utökade inställningar"
 
 #: src/DownloadListCtrl.cpp:770 src/DownloadListCtrl.cpp:822
-#: src/muuli_wdr.cpp:1800
+#: src/muuli_wdr.cpp:1804
 msgid "Preview"
 msgstr "Förhandsgranska"
 
@@ -2428,23 +2428,23 @@ msgid ""
 "want downloads on a different (e.g. larger) disk."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:549 src/FirstRunWizard.cpp:611 src/muuli_wdr.cpp:1712
+#: src/FirstRunWizard.cpp:549 src/FirstRunWizard.cpp:611 src/muuli_wdr.cpp:1716
 msgid "Destination folder for downloads"
 msgstr "Målmapp för hämtningar"
 
 #: src/FirstRunWizard.cpp:553 src/FirstRunWizard.cpp:569 src/muuli_wdr.cpp:1349
-#: src/muuli_wdr.cpp:1366 src/muuli_wdr.cpp:1687 src/muuli_wdr.cpp:1718
-#: src/muuli_wdr.cpp:1730 src/muuli_wdr.cpp:2800
+#: src/muuli_wdr.cpp:1366 src/muuli_wdr.cpp:1691 src/muuli_wdr.cpp:1722
+#: src/muuli_wdr.cpp:1734 src/muuli_wdr.cpp:2804
 #: src/utils/aLinkCreator/src/alcframe.cpp:135
 #: src/utils/wxCas/src/wxcasprefs.cpp:52 src/utils/wxCas/src/wxcasprefs.cpp:118
 msgid "Browse"
 msgstr "Bläddra"
 
-#: src/FirstRunWizard.cpp:559 src/muuli_wdr.cpp:1723
+#: src/FirstRunWizard.cpp:559 src/muuli_wdr.cpp:1727
 msgid "(All files in this folder are shared with other peers)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:565 src/FirstRunWizard.cpp:624 src/muuli_wdr.cpp:1725
+#: src/FirstRunWizard.cpp:565 src/FirstRunWizard.cpp:624 src/muuli_wdr.cpp:1729
 msgid "Folder for temporary download files"
 msgstr "Mapp för temporära nerladdningsfiler"
 
@@ -2475,7 +2475,7 @@ msgstr "Kunde inte öppna vän-list-filen 'emfriends.met' för skrivning!"
 msgid "CRITICAL - no client on StartChatSession"
 msgstr "KRITISKT - ingen klient för StartChatSession"
 
-#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2706 src/muuli_wdr.cpp:3383
+#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2710 src/muuli_wdr.cpp:3387
 msgid "Friends"
 msgstr "Vänner"
 
@@ -2586,8 +2586,8 @@ msgstr "Ingen"
 msgid "No"
 msgstr "Nej"
 
-#: src/GenericClientListCtrl.cpp:1216 src/PrefsUnifiedDlg.cpp:2898
-#: src/PrefsUnifiedDlg.cpp:2948 src/ServerListCtrl.cpp:276
+#: src/GenericClientListCtrl.cpp:1216 src/PrefsUnifiedDlg.cpp:2907
+#: src/PrefsUnifiedDlg.cpp:2957 src/ServerListCtrl.cpp:276
 msgid "Yes"
 msgstr "Ja"
 
@@ -2756,10 +2756,10 @@ msgstr "Ogiltig port till bootstrap"
 msgid "Please fill all fields required"
 msgstr "Fyll i alla fält som krävs"
 
-#: src/KadDlg.cpp:192 src/PartFile.cpp:1031 src/PrefsUnifiedDlg.cpp:1134
-#: src/PrefsUnifiedDlg.cpp:1204 src/PrefsUnifiedDlg.cpp:1405
-#: src/PrefsUnifiedDlg.cpp:1663 src/PrefsUnifiedDlg.cpp:1673
-#: src/PrefsUnifiedDlg.cpp:1690 src/PrefsUnifiedDlg.cpp:1738
+#: src/KadDlg.cpp:192 src/PartFile.cpp:1031 src/PrefsUnifiedDlg.cpp:1143
+#: src/PrefsUnifiedDlg.cpp:1213 src/PrefsUnifiedDlg.cpp:1414
+#: src/PrefsUnifiedDlg.cpp:1672 src/PrefsUnifiedDlg.cpp:1682
+#: src/PrefsUnifiedDlg.cpp:1699 src/PrefsUnifiedDlg.cpp:1747
 msgid "Message"
 msgstr "Meddelande"
 
@@ -2861,7 +2861,7 @@ msgstr "Dela-förhållande"
 msgid "Uploaded"
 msgstr "Uppladdad"
 
-#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3263
+#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3267
 msgid "Requested"
 msgstr "Begärda"
 
@@ -2985,7 +2985,7 @@ msgid "WARNING: "
 msgstr "VARNING: "
 
 #: src/MuleNotebook.cpp:179 src/muuli_wdr.cpp:817 src/muuli_wdr.cpp:1229
-#: src/muuli_wdr.cpp:3167 src/muuli_wdr.cpp:3423
+#: src/muuli_wdr.cpp:3171 src/muuli_wdr.cpp:3427
 msgid "Close"
 msgstr "Stäng"
 
@@ -3003,7 +3003,7 @@ msgid "Paste"
 msgstr "Klistra in"
 
 #: src/MuleTextCtrl.cpp:89 src/muuli_wdr.cpp:358 src/muuli_wdr.cpp:757
-#: src/muuli_wdr.cpp:2390 src/muuli_wdr.cpp:2409 src/muuli_wdr.cpp:2431
+#: src/muuli_wdr.cpp:2394 src/muuli_wdr.cpp:2413 src/muuli_wdr.cpp:2435
 #: src/utils/aLinkCreator/src/alcframe.cpp:142
 msgid "Clear"
 msgstr "Töm"
@@ -3102,7 +3102,7 @@ msgstr "Avsluta"
 
 #: src/MuleTrayIcon.cpp:579 src/MuleTrayIcon.cpp:945 src/MuleTrayIcon.cpp:965
 #: src/muuli_wdr.cpp:1398 src/muuli_wdr.cpp:1406 src/muuli_wdr.cpp:1413
-#: src/muuli_wdr.cpp:1846 src/muuli_wdr.cpp:1852 src/OtherFunctions.cpp:91
+#: src/muuli_wdr.cpp:1850 src/muuli_wdr.cpp:1856 src/OtherFunctions.cpp:91
 #: src/StatisticsDlg.cpp:93 src/StatisticsDlg.cpp:95
 msgid "kB/s"
 msgstr "kB/s"
@@ -3344,7 +3344,7 @@ msgstr "Bytes"
 msgid "KB"
 msgstr "KB"
 
-#: src/muuli_wdr.cpp:274 src/muuli_wdr.cpp:293 src/muuli_wdr.cpp:1631
+#: src/muuli_wdr.cpp:274 src/muuli_wdr.cpp:293 src/muuli_wdr.cpp:1635
 #: src/OtherFunctions.cpp:64
 msgid "MB"
 msgstr "MB"
@@ -3361,7 +3361,7 @@ msgstr "Max storlek"
 msgid "Availability"
 msgstr "Tillgänglighet"
 
-#: src/muuli_wdr.cpp:312 src/muuli_wdr.cpp:398 src/muuli_wdr.cpp:3328
+#: src/muuli_wdr.cpp:312 src/muuli_wdr.cpp:398 src/muuli_wdr.cpp:3332
 msgid "Filter:"
 msgstr "Filter:"
 
@@ -3424,8 +3424,8 @@ msgstr "Filkällor:"
 #: src/muuli_wdr.cpp:1160 src/muuli_wdr.cpp:1167 src/muuli_wdr.cpp:1172
 #: src/muuli_wdr.cpp:1179 src/muuli_wdr.cpp:1184 src/muuli_wdr.cpp:1191
 #: src/muuli_wdr.cpp:1205 src/muuli_wdr.cpp:1212 src/muuli_wdr.cpp:1217
-#: src/muuli_wdr.cpp:1224 src/muuli_wdr.cpp:3265 src/muuli_wdr.cpp:3273
-#: src/muuli_wdr.cpp:3281
+#: src/muuli_wdr.cpp:1224 src/muuli_wdr.cpp:3269 src/muuli_wdr.cpp:3277
+#: src/muuli_wdr.cpp:3285
 msgid "N/A"
 msgstr "N/A"
 
@@ -3570,7 +3570,7 @@ msgstr ""
 msgid "Album :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:685 src/muuli_wdr.cpp:2285
+#: src/muuli_wdr.cpp:685 src/muuli_wdr.cpp:2289
 msgid "Title :"
 msgstr "Titel :"
 
@@ -3679,7 +3679,7 @@ msgstr "Användarnamn :"
 msgid "Userhash :"
 msgstr "Userhash:"
 
-#: src/muuli_wdr.cpp:895 src/muuli_wdr.cpp:1752 src/muuli_wdr.cpp:2480
+#: src/muuli_wdr.cpp:895 src/muuli_wdr.cpp:1756 src/muuli_wdr.cpp:2484
 #: src/utils/aLinkCreator/src/alcframe.cpp:137
 msgid "Add"
 msgstr "Lägg till"
@@ -3688,15 +3688,15 @@ msgstr "Lägg till"
 msgid "Download-Speed"
 msgstr "Nedladdningshastighet"
 
-#: src/muuli_wdr.cpp:954 src/muuli_wdr.cpp:989 src/muuli_wdr.cpp:2584
+#: src/muuli_wdr.cpp:954 src/muuli_wdr.cpp:989 src/muuli_wdr.cpp:2588
 msgid "Current"
 msgstr "Aktuell"
 
-#: src/muuli_wdr.cpp:962 src/muuli_wdr.cpp:997 src/muuli_wdr.cpp:2592
+#: src/muuli_wdr.cpp:962 src/muuli_wdr.cpp:997 src/muuli_wdr.cpp:2596
 msgid "Running average"
 msgstr "Löpande medelvärde"
 
-#: src/muuli_wdr.cpp:970 src/muuli_wdr.cpp:1005 src/muuli_wdr.cpp:2600
+#: src/muuli_wdr.cpp:970 src/muuli_wdr.cpp:1005 src/muuli_wdr.cpp:2604
 msgid "Session average"
 msgstr "Sessionens genomsnittliga"
 
@@ -3708,7 +3708,7 @@ msgstr "Uppladdningshastighet"
 msgid "Connections"
 msgstr "Anslutningar"
 
-#: src/muuli_wdr.cpp:1024 src/muuli_wdr.cpp:1871
+#: src/muuli_wdr.cpp:1024 src/muuli_wdr.cpp:1875
 msgid "Active downloads"
 msgstr "Aktiva hämtningar"
 
@@ -3716,7 +3716,7 @@ msgstr "Aktiva hämtningar"
 msgid "Active connections (1:1)"
 msgstr "Aktiva anslutningar (1:1)"
 
-#: src/muuli_wdr.cpp:1040 src/muuli_wdr.cpp:1872
+#: src/muuli_wdr.cpp:1040 src/muuli_wdr.cpp:1876
 msgid "Active uploads"
 msgstr "Aktiva uppladdningar"
 
@@ -3992,7 +3992,7 @@ msgstr "Bind lokal adress till IP (tom för alla):"
 msgid "Advanced users only: If you have multiple network interfaces, enter the address of the interface to which aMule should be bound."
 msgstr "Endast avancerade användare: Om du har flera nätverksgränssnitt, ange adressen för gränssnittet till vilket aMule ska bindas."
 
-#: src/muuli_wdr.cpp:1462 src/muuli_wdr.cpp:2065
+#: src/muuli_wdr.cpp:1462 src/muuli_wdr.cpp:2069
 #, fuzzy
 msgid "Bind to network interface (empty for any):"
 msgstr "Bind lokal adress till IP (tom för alla):"
@@ -4009,7 +4009,7 @@ msgstr "Max källor per hämtad fil:"
 msgid "Max simultaneous connections:"
 msgstr "Max samtidiga anslutningar:"
 
-#: src/muuli_wdr.cpp:1498 src/muuli_wdr.cpp:3207
+#: src/muuli_wdr.cpp:1498 src/muuli_wdr.cpp:3211
 msgid "ED2K"
 msgstr "ED2K"
 
@@ -4101,778 +4101,778 @@ msgstr "Förallokera diskutrymme för nya filer"
 msgid "For new files preallocates disk space for the whole file, thus reduces fragmentation"
 msgstr "För nya filer förallokeras diskutrymme för hela filen, detta minskar fragmentering"
 
-#: src/muuli_wdr.cpp:1617
+#: src/muuli_wdr.cpp:1621
 msgid "Create new files as sparse files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1618
+#: src/muuli_wdr.cpp:1622
 msgid "Sparse part files only occupy disk space for the parts already downloaded, so free space is used up gradually as the file fills in. Turn this off to use an ordinary file instead - useful where sparse files are unsupported or slow, or where backup/de-duplication tools handle them badly. Applies only when the core runs on Windows; on Linux and macOS part files are sparse anyway and this setting has no effect."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1623
+#: src/muuli_wdr.cpp:1627
 msgid "Stop downloads when free disk space reaches "
 msgstr "Stoppa nedladdningar när ledigt diskutrymme når "
 
-#: src/muuli_wdr.cpp:1624
+#: src/muuli_wdr.cpp:1628
 msgid "Select this if you want aMule to check your disk space"
 msgstr "Välj detta om du vill aMule att kontrollera diskutrymmet"
 
-#: src/muuli_wdr.cpp:1628
+#: src/muuli_wdr.cpp:1632
 msgid "Enter here the min disk space desired."
 msgstr "Ange här min diskutrymme."
 
-#: src/muuli_wdr.cpp:1634
+#: src/muuli_wdr.cpp:1638
 msgid "Save 10 sources on rare files (< 20 sources)"
 msgstr "Spara 10 källor för sällsynta filer (<20 källor)"
 
-#: src/muuli_wdr.cpp:1638 src/Statistics.cpp:790
+#: src/muuli_wdr.cpp:1642 src/Statistics.cpp:790
 msgid "Uploads"
 msgstr "Uppladdningar"
 
-#: src/muuli_wdr.cpp:1641
+#: src/muuli_wdr.cpp:1645
 msgid "Add new shared files with auto priority"
 msgstr "Lägg till nya delade filer med automatisk prioritet"
 
-#: src/muuli_wdr.cpp:1647
+#: src/muuli_wdr.cpp:1651
 msgid "Intelligent Corruption Handling (I.C.H.)"
 msgstr "Intelligent Corruption Handling (I.C.H.)"
 
-#: src/muuli_wdr.cpp:1650
+#: src/muuli_wdr.cpp:1654
 msgid "Enable"
 msgstr "Aktivera"
 
-#: src/muuli_wdr.cpp:1653
+#: src/muuli_wdr.cpp:1657
 msgid "Advanced I.C.H. trusts every hash (not recommended)"
 msgstr "Avancerad I.C.H. litar på varje hash (rekommenderas inte)"
 
-#: src/muuli_wdr.cpp:1665 src/PrefsUnifiedDlg.cpp:1990
+#: src/muuli_wdr.cpp:1669 src/PrefsUnifiedDlg.cpp:1999
 msgid "Media metadata extraction"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1669
+#: src/muuli_wdr.cpp:1673
 msgid "Extract length / bitrate / codec from shared audio and video files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1671
+#: src/muuli_wdr.cpp:1675
 msgid "When enabled, aMule runs ffprobe on each shared media file to fill in the Length / Bitrate / Codec columns other clients see when they find the file in a search. Requires ffmpeg (the ffprobe binary) to be installed."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1678
+#: src/muuli_wdr.cpp:1682
 msgid "Path to ffprobe:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1683
+#: src/muuli_wdr.cpp:1687
 msgid "Full path to the ffprobe binary. Leave empty to have aMule auto-detect it on startup."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1691
+#: src/muuli_wdr.cpp:1695
 msgid "Detect"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1692
+#: src/muuli_wdr.cpp:1696
 msgid "Search the standard install locations for an ffprobe binary and fill the path field."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1716
+#: src/muuli_wdr.cpp:1720
 msgid ""
 "Completed downloads are stored here. All files in this folder are automatically shared with other peers.\n"
 "If this folder also holds files you don't want to share, point it at an aMule-only sub-folder."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1719
+#: src/muuli_wdr.cpp:1723
 msgid "Pick the folder where completed downloads will be stored. All files in that folder will be shared with other peers."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1733
+#: src/muuli_wdr.cpp:1737
 msgid "Shared folders"
 msgstr "Delade mappar"
 
-#: src/muuli_wdr.cpp:1739
+#: src/muuli_wdr.cpp:1743
 msgid "(Folders shared by the core. Enter a path to add one.)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1747
+#: src/muuli_wdr.cpp:1751
 msgid "Absolute path of a folder on the core's machine, e.g. /home/user/shared"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1749 src/PrefsUnifiedDlg.cpp:2874
+#: src/muuli_wdr.cpp:1753 src/PrefsUnifiedDlg.cpp:2883
 msgid "Recursive"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1750
+#: src/muuli_wdr.cpp:1754
 msgid "Share every sub-folder underneath this one, including ones created later."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1754 src/utils/aLinkCreator/src/alcframe.cpp:141
+#: src/muuli_wdr.cpp:1758 src/utils/aLinkCreator/src/alcframe.cpp:141
 msgid "Remove"
 msgstr "Ta bort"
 
-#: src/muuli_wdr.cpp:1758
+#: src/muuli_wdr.cpp:1762
 msgid "(Right click on folder icon for recursive share)"
 msgstr "(Högerklicka på mappikonen för rekursiv delning)"
 
-#: src/muuli_wdr.cpp:1765
+#: src/muuli_wdr.cpp:1769
 msgid "Share hidden files"
 msgstr "Dela ut dolda filer"
 
-#: src/muuli_wdr.cpp:1771
+#: src/muuli_wdr.cpp:1775
 msgid "Automatically rescan shared folders for changes"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1777
+#: src/muuli_wdr.cpp:1781
 msgid "Follow symbolic links in shared folders"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1783
+#: src/muuli_wdr.cpp:1787
 msgid "Exclude files matching:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1786
+#: src/muuli_wdr.cpp:1790
 msgid "Wildcard patterns separated by '|', e.g. .DS_Store|Thumbs.db|*.tmp. Files whose name matches are not shared. Matching is case-insensitive."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1790
+#: src/muuli_wdr.cpp:1794
 msgid "Patterns are regular expressions"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1791
+#: src/muuli_wdr.cpp:1795
 msgid "When set, the whole field is one regular expression ('|' is alternation). When unset, it is a list of '|'-separated wildcards."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1801
+#: src/muuli_wdr.cpp:1805
 msgid "Show how many shared files the current pattern would exclude."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1822
+#: src/muuli_wdr.cpp:1826
 msgid "Graphs"
 msgstr "Diagram"
 
-#: src/muuli_wdr.cpp:1825 src/muuli_wdr.cpp:1887
+#: src/muuli_wdr.cpp:1829 src/muuli_wdr.cpp:1891
 msgid "Update delay : 5 secs"
 msgstr "Uppdateringsfördröjning: 5 sekunder"
 
-#: src/muuli_wdr.cpp:1829
+#: src/muuli_wdr.cpp:1833
 msgid "Time for average graph: 100 mins"
 msgstr "Tid för genomsnittlig graf: 100 minuter"
 
-#: src/muuli_wdr.cpp:1833
+#: src/muuli_wdr.cpp:1837
 msgid "Connections Graph Scale: 100 "
 msgstr "Anslutningar Diagramskala: 100 "
 
-#: src/muuli_wdr.cpp:1840
+#: src/muuli_wdr.cpp:1844
 msgid "Download graph scale:"
 msgstr "Hämtningsgrafskala:"
 
-#: src/muuli_wdr.cpp:1848
+#: src/muuli_wdr.cpp:1852
 msgid "Upload graph scale:"
 msgstr "Uppladdningsgraf-skala:"
 
-#: src/muuli_wdr.cpp:1858
+#: src/muuli_wdr.cpp:1862
 #, fuzzy
 msgid "Colors: "
 msgstr "Färger: "
 
-#: src/muuli_wdr.cpp:1862
+#: src/muuli_wdr.cpp:1866
 msgid "Background"
 msgstr "Bakgrund"
 
-#: src/muuli_wdr.cpp:1863
+#: src/muuli_wdr.cpp:1867
 msgid "Grid"
 msgstr "Rutnät"
 
-#: src/muuli_wdr.cpp:1864
+#: src/muuli_wdr.cpp:1868
 msgid "Download current"
 msgstr "Hämtning nu"
 
-#: src/muuli_wdr.cpp:1865
+#: src/muuli_wdr.cpp:1869
 msgid "Download running average"
 msgstr "Hämtningar nu, medelvärde"
 
-#: src/muuli_wdr.cpp:1866
+#: src/muuli_wdr.cpp:1870
 msgid "Download session average"
 msgstr "Hämtningar session, genomsnittlig"
 
-#: src/muuli_wdr.cpp:1867
+#: src/muuli_wdr.cpp:1871
 msgid "Upload current"
 msgstr "Hämtningar nu"
 
-#: src/muuli_wdr.cpp:1868
+#: src/muuli_wdr.cpp:1872
 msgid "Upload running average"
 msgstr "Hämtningar nu, medelvärde"
 
-#: src/muuli_wdr.cpp:1869
+#: src/muuli_wdr.cpp:1873
 msgid "Upload session average"
 msgstr "Uppladdningsession, genomsnittlig"
 
-#: src/muuli_wdr.cpp:1870
+#: src/muuli_wdr.cpp:1874
 msgid "Active connections"
 msgstr "Aktiva anslutningar"
 
-#: src/muuli_wdr.cpp:1873
+#: src/muuli_wdr.cpp:1877
 #, fuzzy
 msgid "Systray Icon Speed Bar"
 msgstr "Systray Ikon Speedbar"
 
-#: src/muuli_wdr.cpp:1874
+#: src/muuli_wdr.cpp:1878
 msgid "Kad-nodes current"
 msgstr "Kad-noder nuvarande"
 
-#: src/muuli_wdr.cpp:1875
+#: src/muuli_wdr.cpp:1879
 msgid "Kad-nodes running"
 msgstr "Kad-noder körs"
 
-#: src/muuli_wdr.cpp:1876
+#: src/muuli_wdr.cpp:1880
 msgid "Kad-nodes session"
 msgstr "Kad-noder session"
 
-#: src/muuli_wdr.cpp:1880 src/muuli_wdr.cpp:2334
+#: src/muuli_wdr.cpp:1884 src/muuli_wdr.cpp:2338
 msgid "Select"
 msgstr "Välj"
 
-#: src/muuli_wdr.cpp:1884
+#: src/muuli_wdr.cpp:1888
 msgid "Tree"
 msgstr "Träd"
 
-#: src/muuli_wdr.cpp:1894
+#: src/muuli_wdr.cpp:1898
 msgid "Number of Client Versions shown (0=unlimited)"
 msgstr "Antal klientversioner visas (0 = obegränsat)"
 
-#: src/muuli_wdr.cpp:1919
+#: src/muuli_wdr.cpp:1923
 msgid "!!! WARNING !!!"
 msgstr "!!! VARNING !!!"
 
-#: src/muuli_wdr.cpp:1934
+#: src/muuli_wdr.cpp:1938
 msgid "Max new connections / 5 secs"
 msgstr "Max nya anslutningar / 5 sek"
 
-#: src/muuli_wdr.cpp:1936
+#: src/muuli_wdr.cpp:1940
 msgid "Concurrent Kad source lookups"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1938
+#: src/muuli_wdr.cpp:1942
 #, fuzzy
 msgid "Kad source re-search interval (minutes)"
 msgstr "FTP-uppdateringshastighetsintervall i minuter"
 
-#: src/muuli_wdr.cpp:1940
+#: src/muuli_wdr.cpp:1944
 #, fuzzy
 msgid "Source re-ask interval (minutes)"
 msgstr "FTP-uppdateringshastighetsintervall i minuter"
 
-#: src/muuli_wdr.cpp:1944
+#: src/muuli_wdr.cpp:1948
 msgid "File Buffer Size: 240000 bytes"
 msgstr "Filbuffertstorlek: 240000 bytes"
 
-#: src/muuli_wdr.cpp:1948
+#: src/muuli_wdr.cpp:1952
 msgid "Use MMAP: memory-mapped file access (lower memory use)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1949
+#: src/muuli_wdr.cpp:1953
 msgid "Maps part files into memory instead of buffering them on the heap, lowering the process memory footprint. May reduce download speed on some disks; best for memory-constrained or upload-heavy hosts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1951
+#: src/muuli_wdr.cpp:1955
 msgid "Upload Queue Size: 5000 clients"
 msgstr "Uppladdningsköstorlek: 5000 klienter"
 
-#: src/muuli_wdr.cpp:1955
+#: src/muuli_wdr.cpp:1959
 msgid "Server connection refresh interval: Disable"
 msgstr "Serveranslutningsuppdateringsintervall: Inaktivera"
 
-#: src/muuli_wdr.cpp:1959
+#: src/muuli_wdr.cpp:1963
 msgid "Disable computer's timed standby mode"
 msgstr "Inaktivera datorns inställda standby-läge"
 
-#: src/muuli_wdr.cpp:1978
+#: src/muuli_wdr.cpp:1982
 msgid "Skin to use: "
 msgstr "Skin att använda: "
 
-#: src/muuli_wdr.cpp:1987
+#: src/muuli_wdr.cpp:1991
 msgid "Show \"Fast eD2k Links Handler\" in every window."
 msgstr "Visa \"Snabb eD2k-Länkhanterare\" i varje fönster."
 
-#: src/muuli_wdr.cpp:1990
+#: src/muuli_wdr.cpp:1994
 msgid "Show extended info on categories tabs"
 msgstr "Visa utökad information på kategoriflikar"
 
-#: src/muuli_wdr.cpp:1993
+#: src/muuli_wdr.cpp:1997
 msgid "Show application version on title"
 msgstr "Visa programversionen på titel"
 
-#: src/muuli_wdr.cpp:1995
+#: src/muuli_wdr.cpp:1999
 msgid "Show transfer rates on title"
 msgstr "Visa överföringshastigheter på titel"
 
-#: src/muuli_wdr.cpp:1997
+#: src/muuli_wdr.cpp:2001
 msgid "Before application name"
 msgstr "Före programnamn"
 
-#: src/muuli_wdr.cpp:1999
+#: src/muuli_wdr.cpp:2003
 msgid "After application name"
 msgstr "Efter programnamn"
 
-#: src/muuli_wdr.cpp:2002
+#: src/muuli_wdr.cpp:2006
 msgid "Show overhead bandwidth"
 msgstr "Visa overheadsbandbredd"
 
-#: src/muuli_wdr.cpp:2006
+#: src/muuli_wdr.cpp:2010
 msgid "Vertical toolbar orientation"
 msgstr "Vertikal verktygsfältsorientering"
 
-#: src/muuli_wdr.cpp:2008
+#: src/muuli_wdr.cpp:2012
 msgid "Live column sorting (auto-reorder rows as their values change)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2015
+#: src/muuli_wdr.cpp:2019
 msgid "Download Queue Files"
 msgstr "Nedladdningsköfiler"
 
-#: src/muuli_wdr.cpp:2018
+#: src/muuli_wdr.cpp:2022
 msgid "Show progress percentage"
 msgstr "Visa framsteg i procent"
 
-#: src/muuli_wdr.cpp:2024
+#: src/muuli_wdr.cpp:2028
 msgid "Show progress bar"
 msgstr "Visa förloppsindikator"
 
-#: src/muuli_wdr.cpp:2027
+#: src/muuli_wdr.cpp:2031
 msgid "Flat"
 msgstr "Platt"
 
-#: src/muuli_wdr.cpp:2031
+#: src/muuli_wdr.cpp:2035
 msgid "Round"
 msgstr "Rund"
 
-#: src/muuli_wdr.cpp:2049
+#: src/muuli_wdr.cpp:2053
 msgid "External Connection Parameters"
 msgstr "Externa Anslutningsparametrar "
 
-#: src/muuli_wdr.cpp:2052
+#: src/muuli_wdr.cpp:2056
 msgid "Accept external connections"
 msgstr "Acceptera externa anslutningar"
 
-#: src/muuli_wdr.cpp:2059 src/muuli_wdr.cpp:2118
+#: src/muuli_wdr.cpp:2063 src/muuli_wdr.cpp:2122
 msgid "IP of the listening interface:"
 msgstr "IP för lyssningsgränssnitt:"
 
-#: src/muuli_wdr.cpp:2062
+#: src/muuli_wdr.cpp:2066
 msgid "Enter here a valid ip in the a.b.c.d format for the listening EC interface. An empty field or 0.0.0.0 will mean any interface."
 msgstr "Ange här en giltig ip i ABCD format för att lyssna EC-gränssnittet. Ett tomt fält eller 0.0.0.0 kommer att innebära alla gränssnitt."
 
-#: src/muuli_wdr.cpp:2083 src/muuli_wdr.cpp:2194
+#: src/muuli_wdr.cpp:2087 src/muuli_wdr.cpp:2198
 msgid "TCP port:"
 msgstr "TCP-port:"
 
-#: src/muuli_wdr.cpp:2089
+#: src/muuli_wdr.cpp:2093
 msgid "Enable UPnP port forwarding on the EC port"
 msgstr "Aktivera UPnP-portforwarding på EC-port"
 
-#: src/muuli_wdr.cpp:2093 src/muuli_wdr.cpp:3079
+#: src/muuli_wdr.cpp:2097 src/muuli_wdr.cpp:3083
 #: src/utils/wxCas/src/wxcasprefs.cpp:167
 msgid "Password"
 msgstr "Lösenord"
 
-#: src/muuli_wdr.cpp:2099
+#: src/muuli_wdr.cpp:2103
 #, fuzzy
 msgid "aMule API server parameters"
 msgstr "Webbserverparametrar"
 
-#: src/muuli_wdr.cpp:2102
+#: src/muuli_wdr.cpp:2106
 msgid "Run amuleapi (REST API) on startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2107
+#: src/muuli_wdr.cpp:2111
 #, fuzzy
 msgid "HTTP port:"
 msgstr "TCP-port:"
 
-#: src/muuli_wdr.cpp:2121
+#: src/muuli_wdr.cpp:2125
 msgid "The interface amuleapi's HTTP server listens on. 127.0.0.1 (default) accepts only local connections; use 0.0.0.0 or a specific IP to expose it to other hosts (set an admin password below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2126
+#: src/muuli_wdr.cpp:2130
 msgid "Type a password to set or change it. Stored passwords cannot be shown, so leaving this empty keeps the current one."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2128
+#: src/muuli_wdr.cpp:2132
 #, fuzzy
 msgid "Admin password"
 msgstr "Kontrollerar lösenord\n"
 
-#: src/muuli_wdr.cpp:2140 src/muuli_wdr.cpp:2157 src/PrefsUnifiedDlg.cpp:1103
+#: src/muuli_wdr.cpp:2144 src/muuli_wdr.cpp:2161 src/PrefsUnifiedDlg.cpp:1112
 #, fuzzy
 msgid "A password is set."
 msgstr "Kontrollerar lösenord\n"
 
-#: src/muuli_wdr.cpp:2144
+#: src/muuli_wdr.cpp:2148
 #, fuzzy
 msgid "Enable guest access"
 msgstr "Neka gäståtkomst"
 
-#: src/muuli_wdr.cpp:2145
+#: src/muuli_wdr.cpp:2149
 msgid "Guest sessions may read status and listings but cannot change anything. Turning this off clears the stored guest password."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2149
+#: src/muuli_wdr.cpp:2153
 #, fuzzy
 msgid "Guest password"
 msgstr "Gästlösenord för webbservern"
 
-#: src/muuli_wdr.cpp:2164
+#: src/muuli_wdr.cpp:2168
 msgid "Web server parameters"
 msgstr "Webbserverparametrar"
 
-#: src/muuli_wdr.cpp:2167
+#: src/muuli_wdr.cpp:2171
 #, fuzzy
 msgid "Run webserver on startup (deprecated)"
 msgstr "Kör webbserver vid start"
 
-#: src/muuli_wdr.cpp:2173
+#: src/muuli_wdr.cpp:2177
 msgid "Web template"
 msgstr "Web mall"
 
-#: src/muuli_wdr.cpp:2178
+#: src/muuli_wdr.cpp:2182
 msgid "Full rights password"
 msgstr "Fullständiga rättigheterslösenord"
 
-#: src/muuli_wdr.cpp:2182
+#: src/muuli_wdr.cpp:2186
 msgid "Enable Low rights User"
 msgstr "Aktivera låga användarrättigheter"
 
-#: src/muuli_wdr.cpp:2187
+#: src/muuli_wdr.cpp:2191
 msgid "Low rights password"
 msgstr "Låga rättigheterslösenord"
 
-#: src/muuli_wdr.cpp:2201
+#: src/muuli_wdr.cpp:2205
 msgid "Enable UPnP port forwarding of the web server port"
 msgstr "Aktivera UPnP-port-forwarding för webbserverport"
 
-#: src/muuli_wdr.cpp:2206
+#: src/muuli_wdr.cpp:2210
 msgid "Web server UPnP TCP port (Optional)"
 msgstr "Webbserverns UPnP TCP-port (tillval)"
 
-#: src/muuli_wdr.cpp:2214
+#: src/muuli_wdr.cpp:2218
 msgid "Page Refresh Time (in secs)"
 msgstr "Siduppdateringstid (i sek)"
 
-#: src/muuli_wdr.cpp:2221
+#: src/muuli_wdr.cpp:2225
 msgid "Enable Gzip compression"
 msgstr "Aktivera Gzip-komprimering"
 
-#: src/muuli_wdr.cpp:2255
+#: src/muuli_wdr.cpp:2259
 #, fuzzy
 msgid "Reset page to defaults"
 msgstr "Systemets standard"
 
-#: src/muuli_wdr.cpp:2256
+#: src/muuli_wdr.cpp:2260
 msgid "Reset the settings on the current page to their default values."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2258 src/muuli_wdr.cpp:2344 src/ServerWnd.cpp:274
+#: src/muuli_wdr.cpp:2262 src/muuli_wdr.cpp:2348 src/ServerWnd.cpp:274
 #: src/ServerWnd.cpp:282
 msgid "OK"
 msgstr "OK"
 
-#: src/muuli_wdr.cpp:2260
+#: src/muuli_wdr.cpp:2264
 msgid "Click here to apply any changes made to the preferences."
 msgstr "Klicka här för att tillämpa eventuella ändringar i inställningarna."
 
-#: src/muuli_wdr.cpp:2263
+#: src/muuli_wdr.cpp:2267
 msgid "Reset any changes made to the preferences."
 msgstr "Återställ eventuella ändringar i inställningarna."
 
-#: src/muuli_wdr.cpp:2292
+#: src/muuli_wdr.cpp:2296
 msgid "Comment :"
 msgstr "Kommentar :"
 
-#: src/muuli_wdr.cpp:2299
+#: src/muuli_wdr.cpp:2303
 msgid "Incoming Dir :"
 msgstr "Inkommande mapp:"
 
-#: src/muuli_wdr.cpp:2308
+#: src/muuli_wdr.cpp:2312
 msgid "Change priority for new assigned files :"
 msgstr "Ändra prioritet för nya tilldelade filer:"
 
-#: src/muuli_wdr.cpp:2312
+#: src/muuli_wdr.cpp:2316
 msgid "Don't change"
 msgstr "Ändra inte"
 
-#: src/muuli_wdr.cpp:2324
+#: src/muuli_wdr.cpp:2328
 msgid "Select color for this Category (currently selected) :"
 msgstr "Välj färg för denna kategori (den valda):"
 
-#: src/muuli_wdr.cpp:2391 src/muuli_wdr.cpp:2410 src/muuli_wdr.cpp:2432
+#: src/muuli_wdr.cpp:2395 src/muuli_wdr.cpp:2414 src/muuli_wdr.cpp:2436
 msgid "Click this button to reset the log."
 msgstr "Klicka på den här knappen för att återställa loggen."
 
-#: src/muuli_wdr.cpp:2451
+#: src/muuli_wdr.cpp:2455
 msgid "Click on this button to update the servers list from URL ..."
 msgstr "Klicka på knappen för att uppdatera servrerlistan från URL ..."
 
-#: src/muuli_wdr.cpp:2455
+#: src/muuli_wdr.cpp:2459
 msgid "Server list"
 msgstr "Serverlista"
 
-#: src/muuli_wdr.cpp:2459
+#: src/muuli_wdr.cpp:2463
 msgid "Enter the url to a server.met file here and press the button to the left to update the list of known servers."
 msgstr "Ange URL till en server.met-fil här och tryck på knappen till vänster för att uppdatera listan över kända servrar."
 
-#: src/muuli_wdr.cpp:2464
+#: src/muuli_wdr.cpp:2468
 msgid "Add server manually: Name"
 msgstr "Lägg till server manuellt: Namn"
 
-#: src/muuli_wdr.cpp:2467
+#: src/muuli_wdr.cpp:2471
 msgid "Enter the name of the new server here"
 msgstr "Skriv in namnet på den nya servern här"
 
-#: src/muuli_wdr.cpp:2469 src/ServerWnd.cpp:206
+#: src/muuli_wdr.cpp:2473 src/ServerWnd.cpp:206
 msgid "IP:Port"
 msgstr "IP:Port"
 
-#: src/muuli_wdr.cpp:2472
+#: src/muuli_wdr.cpp:2476
 msgid "Enter the IP of the server here, using the x.x.x.x format."
 msgstr "Ange IP på servern här, med hjälp av xxxx format."
 
-#: src/muuli_wdr.cpp:2478
+#: src/muuli_wdr.cpp:2482
 msgid "Enter the port of the server here."
 msgstr "Ange porten på servern här."
 
-#: src/muuli_wdr.cpp:2481
+#: src/muuli_wdr.cpp:2485
 msgid "Add manually a server (fill fields to the left before) ..."
 msgstr "Lägg manuellt till en server (fyll fälten till vänster innan) ..."
 
-#: src/muuli_wdr.cpp:2510
+#: src/muuli_wdr.cpp:2514
 msgid "aMule Log"
 msgstr "aMule-logg"
 
-#: src/muuli_wdr.cpp:2518
+#: src/muuli_wdr.cpp:2522
 msgid "Server Info"
 msgstr "Serverinformation"
 
-#: src/muuli_wdr.cpp:2522
+#: src/muuli_wdr.cpp:2526
 msgid "ED2K Info"
 msgstr "ED2K-info"
 
-#: src/muuli_wdr.cpp:2526
+#: src/muuli_wdr.cpp:2530
 msgid "Kad Info"
 msgstr "Kad-info"
 
-#: src/muuli_wdr.cpp:2554
+#: src/muuli_wdr.cpp:2558
 msgid "Click on this button to update the nodes list from URL ..."
 msgstr "Klicka på knappen för att uppdatera nodlistan från URL ..."
 
-#: src/muuli_wdr.cpp:2558
+#: src/muuli_wdr.cpp:2562
 msgid "Nodes (0)"
 msgstr "Noder (0)"
 
-#: src/muuli_wdr.cpp:2562
+#: src/muuli_wdr.cpp:2566
 msgid "Enter the url to a nodes.dat file here and press the button to the left to update the list of known nodes."
 msgstr "Ange URL till en nodes.dat fil här och tryck på knappen till vänster för att uppdatera listan över kända noder."
 
-#: src/muuli_wdr.cpp:2565
+#: src/muuli_wdr.cpp:2569
 msgid "Nodes stats"
 msgstr "Nodstatistik"
 
-#: src/muuli_wdr.cpp:2607
+#: src/muuli_wdr.cpp:2611
 msgid "Bootstrap"
 msgstr "Bootstrap"
 
-#: src/muuli_wdr.cpp:2610
+#: src/muuli_wdr.cpp:2614
 msgid "New node"
 msgstr "Ny nod"
 
-#: src/muuli_wdr.cpp:2615
+#: src/muuli_wdr.cpp:2619
 msgid "IP:"
 msgstr "IP:"
 
-#: src/muuli_wdr.cpp:2635
+#: src/muuli_wdr.cpp:2639
 msgid "Port:"
 msgstr "Port:"
 
-#: src/muuli_wdr.cpp:2648
+#: src/muuli_wdr.cpp:2652
 msgid "Bootstrap from known clients"
 msgstr "Bootstrap från kända klienter"
 
-#: src/muuli_wdr.cpp:2650
+#: src/muuli_wdr.cpp:2654
 msgid "Disconnect Kad"
 msgstr "Koppla från Kad"
 
-#: src/muuli_wdr.cpp:2684
+#: src/muuli_wdr.cpp:2688
 msgid "Use Secure User Identification"
 msgstr "Använd säker användarIdentifiering"
 
-#: src/muuli_wdr.cpp:2686
+#: src/muuli_wdr.cpp:2690
 msgid "It is recommended to enable this option. You will not receive credits if SUI is not enabled."
 msgstr "Det rekommenderas att aktivera det här alternativet. Du kommer inte att få poäng om SUI är inte aktiverat."
 
-#: src/muuli_wdr.cpp:2688
+#: src/muuli_wdr.cpp:2692
 msgid "Protocol Obfuscation"
 msgstr "Protokollfördunkling"
 
-#: src/muuli_wdr.cpp:2691
+#: src/muuli_wdr.cpp:2695
 msgid "Support Protocol Obfuscation"
 msgstr "Stöd protokollfördunkling"
 
-#: src/muuli_wdr.cpp:2693
+#: src/muuli_wdr.cpp:2697
 msgid "This option enabled Protocol Obfuscation, and makes aMule accept obfuscated connections from other clients."
 msgstr "Det här alternativet aktiverat protokollffördunkling och låter aMule acceptera dålda anslutningar från andra klienter."
 
-#: src/muuli_wdr.cpp:2695
+#: src/muuli_wdr.cpp:2699
 msgid "Use obfuscation for outgoing connections"
 msgstr "Använd obfuscation (fördunkling) för utgående anslutningar"
 
-#: src/muuli_wdr.cpp:2697
+#: src/muuli_wdr.cpp:2701
 msgid "This option makes aMule use Protocol Obfuscation when connecting other clients/servers."
 msgstr "Det här alternativet gör aMule använder protokoll-Obfuscation (fördunkling) vid anslutning till andra klienter/servrar."
 
-#: src/muuli_wdr.cpp:2699
+#: src/muuli_wdr.cpp:2703
 msgid "Accept only obfuscated connections"
 msgstr "Accepterar endast fördunklade anslutningar"
 
-#: src/muuli_wdr.cpp:2700
+#: src/muuli_wdr.cpp:2704
 msgid "This option makes aMule only accept obfuscated connections. You will have less sources, but all your traffic will be obfuscated"
 msgstr "Det här alternativet gör aMule endast acceptera fördunklade anslutningar. Du kommer att ha mindre källor, men all din trafik kommer att döljas"
 
-#: src/muuli_wdr.cpp:2705
+#: src/muuli_wdr.cpp:2709
 msgid "Everybody"
 msgstr "Alla"
 
-#: src/muuli_wdr.cpp:2707
+#: src/muuli_wdr.cpp:2711
 msgid "No one"
 msgstr "Ingen."
 
-#: src/muuli_wdr.cpp:2709
+#: src/muuli_wdr.cpp:2713
 msgid "Who can see my shared files:"
 msgstr "Vem kan se mina delade filer:"
 
-#: src/muuli_wdr.cpp:2710
+#: src/muuli_wdr.cpp:2714
 msgid "Select who can request to view a list of your shared files."
 msgstr "Välj vem som kan begära att få se en lista över dina delade filer."
 
-#: src/muuli_wdr.cpp:2712
+#: src/muuli_wdr.cpp:2716
 msgid "IP-Filtering"
 msgstr "IP-filtrering"
 
-#: src/muuli_wdr.cpp:2719
+#: src/muuli_wdr.cpp:2723
 msgid "Filter clients"
 msgstr "Filtrera klienter"
 
-#: src/muuli_wdr.cpp:2721
+#: src/muuli_wdr.cpp:2725
 msgid "Enable filtering of the client IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "Aktivera filtrering av klient-IP:n definierade i filen ~/.aMule/ipfilter.dat."
 
-#: src/muuli_wdr.cpp:2723
+#: src/muuli_wdr.cpp:2727
 msgid "Filter servers"
 msgstr "Filtrera servrar"
 
-#: src/muuli_wdr.cpp:2725
+#: src/muuli_wdr.cpp:2729
 msgid "Enable filtering of the server IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "Aktivera filtrering av server-IP:n definierade i filen ~/.aMule/ipfilter.dat."
 
-#: src/muuli_wdr.cpp:2729
+#: src/muuli_wdr.cpp:2733
 msgid "Reload List"
 msgstr "Återladda lista"
 
-#: src/muuli_wdr.cpp:2730
+#: src/muuli_wdr.cpp:2734
 msgid "Reload the list of IPs to filter from the file ~/.aMule/ipfilter.dat"
 msgstr "Återladda listan över IP-adresser att filtrera bort från filen ~/.aMule/ipfilter.dat"
 
-#: src/muuli_wdr.cpp:2736
+#: src/muuli_wdr.cpp:2740
 msgid "URL:"
 msgstr "URL:"
 
-#: src/muuli_wdr.cpp:2740 src/muuli_wdr.cpp:2933
+#: src/muuli_wdr.cpp:2744 src/muuli_wdr.cpp:2937
 msgid "Update now"
 msgstr "Uppdatera nu"
 
-#: src/muuli_wdr.cpp:2743
+#: src/muuli_wdr.cpp:2747
 msgid "Auto-update ipfilter at startup"
 msgstr "Auto-uppdatering av ipfilter vid start"
 
-#: src/muuli_wdr.cpp:2747
+#: src/muuli_wdr.cpp:2751
 msgid "Filtering Level:"
 msgstr "Filtreringsnivå:"
 
-#: src/muuli_wdr.cpp:2753
+#: src/muuli_wdr.cpp:2757
 msgid "Always filter LAN IPs"
 msgstr "Filtrera alltid LAN-IP-adresser"
 
-#: src/muuli_wdr.cpp:2756
+#: src/muuli_wdr.cpp:2760
 msgid "Paranoid handling of non-matching IPs"
 msgstr "Paranoid hantering av icke-matchande IP"
 
-#: src/muuli_wdr.cpp:2758
+#: src/muuli_wdr.cpp:2762
 msgid "Rejects a packet when its source IP differs from the IP the client claims (an anti-spoofing check). Disable only if it causes connection problems."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2760
+#: src/muuli_wdr.cpp:2764
 msgid "Use system-wide ipfilter.dat if available"
 msgstr "Använd systemvidd ipfilter.dat om sådan finns"
 
-#: src/muuli_wdr.cpp:2761
+#: src/muuli_wdr.cpp:2765
 #, fuzzy
 msgid "If there's no local ipfilter.dat found, allow usage of a system-wide ipfilter file."
 msgstr "Om det inte en lokal ipfilter.dat hittas, tillåt användning av systemvidd ipfilterfil."
 
-#: src/muuli_wdr.cpp:2778
+#: src/muuli_wdr.cpp:2782
 msgid "Enable Online-Signature"
 msgstr "Aktivera Onlinesignaturer"
 
-#: src/muuli_wdr.cpp:2780
+#: src/muuli_wdr.cpp:2784
 msgid "Enables the writing of the OS file, which can be used by external apps to create signatures and the like."
 msgstr "Möjliggör skrivning av OS-filen, som kan användas av externa program för att skapa signaturer och liknande."
 
-#: src/muuli_wdr.cpp:2784
+#: src/muuli_wdr.cpp:2788
 msgid "Update Frequency (Secs):"
 msgstr "Uppdateringsfrekvens (Sek):"
 
-#: src/muuli_wdr.cpp:2787
+#: src/muuli_wdr.cpp:2791
 msgid "Change the frequency (in seconds) of Online Signature updates."
 msgstr "Ändra frekvensen (i sekunder) av OnlineSignaturuppdateringar."
 
-#: src/muuli_wdr.cpp:2795
+#: src/muuli_wdr.cpp:2799
 msgid "Save online signature file in: "
 msgstr "Spara onlinesignaturfil i: "
 
-#: src/muuli_wdr.cpp:2801
+#: src/muuli_wdr.cpp:2805
 msgid "Click here to select the directory containing the the Online Signature files."
 msgstr "Klicka här för att välja den katalog som innehåller onlineSignaturFilerna."
 
-#: src/muuli_wdr.cpp:2834
+#: src/muuli_wdr.cpp:2838
 msgid "Show country flags for clients"
 msgstr "Visa landsflagger för klienter"
 
-#: src/muuli_wdr.cpp:2835
+#: src/muuli_wdr.cpp:2839
 msgid "Render the country flag column in the transfers, queue and search views. Requires a valid MMDB GeoIP database (see below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2840
+#: src/muuli_wdr.cpp:2844
 #, fuzzy
 msgid "Database"
 msgstr "Datahastighet :"
 
-#: src/muuli_wdr.cpp:2856
+#: src/muuli_wdr.cpp:2860
 #, fuzzy
 msgid "Source:"
 msgstr "Källor"
 
-#: src/muuli_wdr.cpp:2859
+#: src/muuli_wdr.cpp:2863
 msgid "DB-IP (free, no account)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2860
+#: src/muuli_wdr.cpp:2864
 msgid "MaxMind GeoLite2 (free, account required)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2861
+#: src/muuli_wdr.cpp:2865
 msgid "Custom URL"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2864
+#: src/muuli_wdr.cpp:2868
 msgid "Choose which provider supplies the GeoIP MMDB database. DB-IP is the default - no account required. MaxMind requires a free account + license key. Use Custom URL to point at any other MMDB host (e.g. a local mirror)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2881
+#: src/muuli_wdr.cpp:2885
 msgid ""
 "No configuration required.\n"
 "\n"
@@ -4880,11 +4880,11 @@ msgid ""
 "License: Creative Commons BY 4.0 - https://creativecommons.org/licenses/by/4.0/"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2894
+#: src/muuli_wdr.cpp:2898
 msgid "License key:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2900
+#: src/muuli_wdr.cpp:2904
 msgid ""
 "Sign up for a free MaxMind account, then generate a License Key:\n"
 "https://www.maxmind.com/en/geolite2/signup\n"
@@ -4894,225 +4894,225 @@ msgid ""
 "Requires attribution and account registration; refresh at least every 30 days."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2915
+#: src/muuli_wdr.cpp:2919
 #, fuzzy
 msgid "Download URL:"
 msgstr "Hämta: "
 
-#: src/muuli_wdr.cpp:2921
+#: src/muuli_wdr.cpp:2925
 msgid ""
 "Must point to an .mmdb file or a .gz / .tar.gz containing one.\n"
 "URL may include credentials (https://user:pass@host/...).\n"
 "License and attribution terms are set by the upstream URL - you are responsible."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2934
+#: src/muuli_wdr.cpp:2938
 msgid "Download the GeoIP database from the selected source."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2936
+#: src/muuli_wdr.cpp:2940
 #, fuzzy
 msgid "Auto-update on startup"
 msgstr "Auto-uppdatering av ipfilter vid start"
 
-#: src/muuli_wdr.cpp:2937
+#: src/muuli_wdr.cpp:2941
 msgid "Re-download the GeoIP database from the selected source every time aMule starts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2960
+#: src/muuli_wdr.cpp:2964
 msgid "Filter incoming messages (except current chat):"
 msgstr "Filtrera inkommande meddelanden (utom nuvarande chatt):"
 
-#: src/muuli_wdr.cpp:2962
+#: src/muuli_wdr.cpp:2966
 msgid "Filter all messages"
 msgstr "Filtrera alla meddelanden"
 
-#: src/muuli_wdr.cpp:2964
+#: src/muuli_wdr.cpp:2968
 msgid "Filter messages from people not on your friend list"
 msgstr "Filtrera meddelanden från folk som inte finns i din kompislista"
 
-#: src/muuli_wdr.cpp:2966
+#: src/muuli_wdr.cpp:2970
 msgid "Filter messages from unknown clients"
 msgstr "Filtrera meddelanden från okända klienter"
 
-#: src/muuli_wdr.cpp:2968
+#: src/muuli_wdr.cpp:2972
 msgid "Filter messages containing (use ',' as separator):"
 msgstr "Filtrera meddelanden som innehåller (använd ',' som separator):"
 
-#: src/muuli_wdr.cpp:2971 src/muuli_wdr.cpp:2982
+#: src/muuli_wdr.cpp:2975 src/muuli_wdr.cpp:2986
 msgid "add here the words amule should filter and block messages including it"
 msgstr "skriv här orden amule ska filtrera och blockera meddelanden med dem"
 
-#: src/muuli_wdr.cpp:2973
+#: src/muuli_wdr.cpp:2977
 msgid "Show received messages in the log"
 msgstr "Visa mottagna meddelanden i loggen"
 
-#: src/muuli_wdr.cpp:2976
+#: src/muuli_wdr.cpp:2980
 msgid "Comments"
 msgstr "Kommentarer"
 
-#: src/muuli_wdr.cpp:2979
+#: src/muuli_wdr.cpp:2983
 msgid "Filter comments containing (use ',' as separator):"
 msgstr "Filtrera kommentarer som innehåller (använd ',' som separator):"
 
-#: src/muuli_wdr.cpp:3004
+#: src/muuli_wdr.cpp:3008
 msgid "Enable Proxy"
 msgstr "Aktivera proxy"
 
-#: src/muuli_wdr.cpp:3005
+#: src/muuli_wdr.cpp:3009
 msgid "Enable/disable proxy support"
 msgstr "Aktivera/inaktivera proxy-stöd"
 
-#: src/muuli_wdr.cpp:3008
+#: src/muuli_wdr.cpp:3012
 msgid "Proxy type:"
 msgstr "Proxytyp:"
 
-#: src/muuli_wdr.cpp:3019
+#: src/muuli_wdr.cpp:3023
 msgid "Proxy host:"
 msgstr "Proxyserver:"
 
-#: src/muuli_wdr.cpp:3022
+#: src/muuli_wdr.cpp:3026
 msgid "The proxy host name"
 msgstr "Proxyserverns värdnamn"
 
-#: src/muuli_wdr.cpp:3024
+#: src/muuli_wdr.cpp:3028
 msgid "Proxy port:"
 msgstr "Proxyport:"
 
-#: src/muuli_wdr.cpp:3027
+#: src/muuli_wdr.cpp:3031
 msgid "The proxy port"
 msgstr "Proxyporten"
 
-#: src/muuli_wdr.cpp:3029
+#: src/muuli_wdr.cpp:3033
 msgid "Enable authentication"
 msgstr "Aktivera autentisering"
 
-#: src/muuli_wdr.cpp:3030
+#: src/muuli_wdr.cpp:3034
 msgid "Enable/disable username/password authentication"
 msgstr "Aktivera/inaktivera användarnamn/lösenordsautentisering"
 
-#: src/muuli_wdr.cpp:3033
+#: src/muuli_wdr.cpp:3037
 msgid "Username: "
 msgstr "Användarnamn: "
 
-#: src/muuli_wdr.cpp:3036
+#: src/muuli_wdr.cpp:3040
 msgid "The username to use to connect to the proxy"
 msgstr "Användarnamnet som ska användas för att ansluta till proxyn"
 
-#: src/muuli_wdr.cpp:3038
+#: src/muuli_wdr.cpp:3042
 msgid "Password:"
 msgstr "Lösenord:"
 
-#: src/muuli_wdr.cpp:3041
+#: src/muuli_wdr.cpp:3045
 msgid "The password to use to connect to the proxy"
 msgstr "Lösenordet som ska användas för att ansluta till proxyn"
 
-#: src/muuli_wdr.cpp:3060
+#: src/muuli_wdr.cpp:3064
 msgid "Connect to:"
 msgstr "Anslut till:"
 
-#: src/muuli_wdr.cpp:3069
+#: src/muuli_wdr.cpp:3073
 msgid "Login to remote amule"
 msgstr "Logga in på fjärr-amule"
 
-#: src/muuli_wdr.cpp:3074
+#: src/muuli_wdr.cpp:3078
 msgid "User name"
 msgstr "Användarnamn"
 
-#: src/muuli_wdr.cpp:3085
+#: src/muuli_wdr.cpp:3089
 msgid "Remember those settings"
 msgstr "Kom ihåg dessa inställningar"
 
-#: src/muuli_wdr.cpp:3088
+#: src/muuli_wdr.cpp:3092
 #, fuzzy
 msgid "Force ZLIB compression"
 msgstr "Använd gzip-komprimering"
 
-#: src/muuli_wdr.cpp:3112
+#: src/muuli_wdr.cpp:3116
 msgid "Enable Verbose Debug-Logging."
 msgstr "Aktivera Utförlig Debug-loggning."
 
-#: src/muuli_wdr.cpp:3114
+#: src/muuli_wdr.cpp:3118
 msgid "Only to Logfile"
 msgstr "Endast till loggfil"
 
-#: src/muuli_wdr.cpp:3116
+#: src/muuli_wdr.cpp:3120
 msgid "Message Categories:"
 msgstr "Meddelandekategorier:"
 
-#: src/muuli_wdr.cpp:3140 src/PartFileConvertDlg.cpp:160
+#: src/muuli_wdr.cpp:3144 src/PartFileConvertDlg.cpp:160
 msgid "Waiting..."
 msgstr "Väntar..."
 
-#: src/muuli_wdr.cpp:3160
+#: src/muuli_wdr.cpp:3164
 msgid "Add imports"
 msgstr "Lägg till importer"
 
-#: src/muuli_wdr.cpp:3163
+#: src/muuli_wdr.cpp:3167
 msgid "Retry selected"
 msgstr "Återförsök den valda"
 
-#: src/muuli_wdr.cpp:3165
+#: src/muuli_wdr.cpp:3169
 msgid "Remove selected"
 msgstr "Ta bort vald"
 
-#: src/muuli_wdr.cpp:3228
+#: src/muuli_wdr.cpp:3232
 msgid "Event Types"
 msgstr "Händelsetyper"
 
-#: src/muuli_wdr.cpp:3247
+#: src/muuli_wdr.cpp:3251
 msgid "Statistics and queued clients for selected file(s) : Session / All time"
 msgstr "Statistik och köade klienter för vald fil(er): Session / All tid"
 
-#: src/muuli_wdr.cpp:3271
+#: src/muuli_wdr.cpp:3275
 msgid "Active Uploads"
 msgstr "Aktiva uppladdningar"
 
-#: src/muuli_wdr.cpp:3285
+#: src/muuli_wdr.cpp:3289
 msgid "Percent of total files"
 msgstr "Procent av den totala filer"
 
-#: src/muuli_wdr.cpp:3337
+#: src/muuli_wdr.cpp:3341
 msgid "Show Clients for"
 msgstr "Visa klienter för"
 
-#: src/muuli_wdr.cpp:3339
+#: src/muuli_wdr.cpp:3343
 msgid "All files"
 msgstr "Alla filer"
 
-#: src/muuli_wdr.cpp:3342
+#: src/muuli_wdr.cpp:3346
 msgid "Selected files"
 msgstr "Valda filer"
 
-#: src/muuli_wdr.cpp:3345
+#: src/muuli_wdr.cpp:3349
 msgid "Active uploads only"
 msgstr "Endast aktiva uppladdningar"
 
-#: src/muuli_wdr.cpp:3352
+#: src/muuli_wdr.cpp:3356
 msgid "Reload:"
 msgstr "Återladda:"
 
-#: src/muuli_wdr.cpp:3356
+#: src/muuli_wdr.cpp:3360
 msgid "Reload your shared files"
 msgstr "Återladda dina delade filer"
 
-#: src/muuli_wdr.cpp:3419
+#: src/muuli_wdr.cpp:3423
 msgid "Send"
 msgstr "Skicka"
 
-#: src/muuli_wdr.cpp:3420
+#: src/muuli_wdr.cpp:3424
 msgid "Sends the specified message."
 msgstr "Skickar det specificerade meddelandet."
 
-#: src/muuli_wdr.cpp:3424
+#: src/muuli_wdr.cpp:3428
 msgid "Close this chat-session."
 msgstr "Stäng denna chat-session."
 
-#: src/muuli_wdr.cpp:3447
+#: src/muuli_wdr.cpp:3451
 msgid "Connect to any server and/or Kad"
 msgstr "Anslut till någon server och/eller Kad"
 
-#: src/muuli_wdr.cpp:3453 src/SharedFilesCtrl.cpp:142 src/Statistics.cpp:941
+#: src/muuli_wdr.cpp:3457 src/SharedFilesCtrl.cpp:142 src/Statistics.cpp:941
 msgid "Shared Files"
 msgstr "Utdelade filer"
 
@@ -5747,35 +5747,35 @@ msgstr ""
 "aMule kommer fungera bra utan att justera några av\n"
 "dessa inställningar."
 
-#: src/PrefsUnifiedDlg.cpp:647
+#: src/PrefsUnifiedDlg.cpp:656
 #, c-format
 msgid "Failed to connect Cfg to widget with the ID %d and key %s"
 msgstr "Det gick inte att ansluta Cfg till widget med ID %d och nyckel %s"
 
-#: src/PrefsUnifiedDlg.cpp:695
+#: src/PrefsUnifiedDlg.cpp:704
 #, c-format
 msgid "Failed to transfer data from Cfg to Widget with the ID %d and key %s"
 msgstr "Det gick inte att överföra data från Cfg till widget med ID %d och nyckel %s"
 
-#: src/PrefsUnifiedDlg.cpp:801
+#: src/PrefsUnifiedDlg.cpp:810
 msgid "The type of proxy you are connecting to"
 msgstr "Den typen av proxy du ansluter till"
 
-#: src/PrefsUnifiedDlg.cpp:1020
+#: src/PrefsUnifiedDlg.cpp:1029
 #, c-format
 msgid "Failed to transfer data from Widget to Cfg with the ID %d and key %s"
 msgstr "Det gick inte att överföra data från widget till Cfg med ID %d och nyckel %s"
 
-#: src/PrefsUnifiedDlg.cpp:1103
+#: src/PrefsUnifiedDlg.cpp:1112
 #, fuzzy
 msgid "No password set."
 msgstr "Kontrollerar lösenord\n"
 
-#: src/PrefsUnifiedDlg.cpp:1132
+#: src/PrefsUnifiedDlg.cpp:1141
 msgid "Guest access needs a password. Type one in the guest password field, or untick Enable guest access."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1144
+#: src/PrefsUnifiedDlg.cpp:1153
 msgid ""
 "aMule must be restarted to enable these changes:\n"
 "\n"
@@ -5783,41 +5783,41 @@ msgstr ""
 "aMule måste startas om för att aktivera dessa ändringar:\n"
 "\n"
 
-#: src/PrefsUnifiedDlg.cpp:1151
+#: src/PrefsUnifiedDlg.cpp:1160
 msgid "- TCP port changed.\n"
 msgstr "- TCP-port ändrad.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1156
+#: src/PrefsUnifiedDlg.cpp:1165
 msgid "- UDP port changed.\n"
 msgstr "- UDP-port ändrad.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1161
+#: src/PrefsUnifiedDlg.cpp:1170
 #, fuzzy
 msgid "- Network interface binding changed.\n"
 msgstr "- Extern anslutningsgränssnitt ändrad.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1166
+#: src/PrefsUnifiedDlg.cpp:1175
 msgid "- External connect port changed.\n"
 msgstr "- Extern anslutningsport ändrad.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1170
+#: src/PrefsUnifiedDlg.cpp:1179
 msgid "- External connect acceptance changed.\n"
 msgstr "- Extern anslutningsacceptans ändrades.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1174
+#: src/PrefsUnifiedDlg.cpp:1183
 msgid "- External connect interface changed.\n"
 msgstr "- Extern anslutningsgränssnitt ändrad.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1178
+#: src/PrefsUnifiedDlg.cpp:1187
 msgid "- Protocol obfuscation support changed.\n"
 msgstr "- Stöd för fördunkling av protokoll ändrad.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1193
+#: src/PrefsUnifiedDlg.cpp:1202
 #, fuzzy
 msgid "- amuleapi settings changed.\n"
 msgstr "- Språk ändrat.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1202
+#: src/PrefsUnifiedDlg.cpp:1211
 msgid ""
 "Your Auto-update server list is empty.\n"
 "'Auto-update server list at startup' will be disabled."
@@ -5825,7 +5825,7 @@ msgstr ""
 "Din automatiska uppdateringsserverlista är tom.\n"
 "'Auto-uppdateringsserverlista vid start' inaktiveras."
 
-#: src/PrefsUnifiedDlg.cpp:1213
+#: src/PrefsUnifiedDlg.cpp:1222
 msgid ""
 "You have enabled external connections but have not specified a password.\n"
 "External connections cannot be enabled unless a valid password is specified."
@@ -5833,33 +5833,33 @@ msgstr ""
 "Du har aktiverat externa anslutningar men har inte angett ett lösenord.\n"
 "External anslutningar kan inte aktiveras om inte ett giltigt lösenord anges."
 
-#: src/PrefsUnifiedDlg.cpp:1246
+#: src/PrefsUnifiedDlg.cpp:1255
 #, c-format
 msgid "The amuleapi password could not be saved: %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1276
+#: src/PrefsUnifiedDlg.cpp:1285
 msgid "- Language changed.\n"
 msgstr "- Språk ändrat.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1281
+#: src/PrefsUnifiedDlg.cpp:1290
 msgid "- Temp folder changed.\n"
 msgstr "- Mappen Temp ändrades.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1286
+#: src/PrefsUnifiedDlg.cpp:1295
 msgid "- ED2K network enabled.\n"
 msgstr "- ED2K-nätverk aktiverad.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1319
+#: src/PrefsUnifiedDlg.cpp:1328
 msgid "The shared-file exclusion pattern is not a valid regular expression. The filter has been left disabled."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1321 src/PrefsUnifiedDlg.cpp:1921
+#: src/PrefsUnifiedDlg.cpp:1330 src/PrefsUnifiedDlg.cpp:1930
 #, fuzzy
 msgid "Invalid regular expression"
 msgstr "Fel protokoll-version"
 
-#: src/PrefsUnifiedDlg.cpp:1398
+#: src/PrefsUnifiedDlg.cpp:1407
 msgid ""
 "Both eD2k and Kad network are disabled.\n"
 "You won't be able to connect until you enable at least one of them."
@@ -5867,7 +5867,7 @@ msgstr ""
 "Både eD2k- och Kad-nätverk är inaktiverade.\n"
 "Du kommer inte att kunna ansluta förrän du aktiverar åtminstone en av dem."
 
-#: src/PrefsUnifiedDlg.cpp:1403
+#: src/PrefsUnifiedDlg.cpp:1412
 msgid ""
 "Kad will not start if your UDP port is disabled.\n"
 "Enable UDP port or disable Kad."
@@ -5875,7 +5875,7 @@ msgstr ""
 "Kad startar inte om din UDP-port är inaktiverad.\n"
 "Aktivra UDP-port eller inaktivera Kad."
 
-#: src/PrefsUnifiedDlg.cpp:1459
+#: src/PrefsUnifiedDlg.cpp:1468
 msgid ""
 "\n"
 "You MUST restart aMule now.\n"
@@ -5885,69 +5885,69 @@ msgstr ""
 "Du MÅSTE starta om aMule nu.\n"
 "Om du inte startar nu, klaga inte om något dåligt händer.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1524
+#: src/PrefsUnifiedDlg.cpp:1533
 msgid "Could not register aMule for autostart at login. The autostart store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1526
+#: src/PrefsUnifiedDlg.cpp:1535
 msgid "Could not remove the autostart-at-login entry."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1527
+#: src/PrefsUnifiedDlg.cpp:1536
 #, fuzzy
 msgid "Autostart"
 msgstr "Auto Refresh startad"
 
-#: src/PrefsUnifiedDlg.cpp:1542
+#: src/PrefsUnifiedDlg.cpp:1551
 msgid "Register file type"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1542
+#: src/PrefsUnifiedDlg.cpp:1551
 msgid "Register URL handler"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1550
+#: src/PrefsUnifiedDlg.cpp:1559
 #, c-format
 msgid "aMule only handles eD2k-compatible magnets. If you replace the current magnet handler (%s), BitTorrent magnet links will stop working - aMule cannot download BitTorrent content. Continue?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1555
+#: src/PrefsUnifiedDlg.cpp:1564
 #, c-format
 msgid "Another application currently opens .emulecollection files (%s). Replace it with aMule?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1560
+#: src/PrefsUnifiedDlg.cpp:1569
 #, c-format
 msgid "Another application is currently the default handler for these links (%s). Replace it with aMule?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1585
+#: src/PrefsUnifiedDlg.cpp:1594
 msgid "Could not register aMule for .emulecollection files. The registration store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1587
+#: src/PrefsUnifiedDlg.cpp:1596
 #, fuzzy
 msgid "Could not remove the file type registration."
 msgstr "Mapp för temporära nerladdningsfiler"
 
-#: src/PrefsUnifiedDlg.cpp:1589
+#: src/PrefsUnifiedDlg.cpp:1598
 msgid "Could not register aMule as the URL handler. The registration store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1591
+#: src/PrefsUnifiedDlg.cpp:1600
 msgid "Could not remove the URL handler registration."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1661 src/PrefsUnifiedDlg.cpp:1688
+#: src/PrefsUnifiedDlg.cpp:1670 src/PrefsUnifiedDlg.cpp:1697
 #, fuzzy
 msgid "The web server and aMule API require external connections to be enabled."
 msgstr "Lösenord sparad och extern anslutning aktiverad."
 
-#: src/PrefsUnifiedDlg.cpp:1671
+#: src/PrefsUnifiedDlg.cpp:1680
 msgid "The aMule web server is deprecated. Consider running the aMule API instead."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1735
+#: src/PrefsUnifiedDlg.cpp:1744
 msgid ""
 "Your Auto-update servers list is in blank.\n"
 "Please fill in at least one URL to point to a valid server.met file.\n"
@@ -5957,66 +5957,66 @@ msgstr ""
 "Vänligen fylla i åtminstone en URL för att peka på en giltig server.met-fil.\n"
 "Klicka på knappen \"lista\" i denna kryssruta för att ange en URL."
 
-#: src/PrefsUnifiedDlg.cpp:1876
+#: src/PrefsUnifiedDlg.cpp:1885
 msgid "Temporary files"
 msgstr "Temporära filer"
 
-#: src/PrefsUnifiedDlg.cpp:1881
+#: src/PrefsUnifiedDlg.cpp:1890
 msgid "Incoming files"
 msgstr "Inkommande filer"
 
-#: src/PrefsUnifiedDlg.cpp:1886
+#: src/PrefsUnifiedDlg.cpp:1895
 msgid "Online Signatures"
 msgstr "Online-signaturer"
 
-#: src/PrefsUnifiedDlg.cpp:1899
+#: src/PrefsUnifiedDlg.cpp:1908
 #, c-format
 msgid "Choose a folder for %s"
 msgstr "Välj en mapp för %s"
 
-#: src/PrefsUnifiedDlg.cpp:1923
+#: src/PrefsUnifiedDlg.cpp:1932
 #, fuzzy, c-format
 msgid "Would exclude %u of %u shared file"
 msgid_plural "Would exclude %u of %u shared files"
 msgstr[0] "Hittade %i känd delad fil"
 msgstr[1] "Hittade %i kända delad filer"
 
-#: src/PrefsUnifiedDlg.cpp:1940
+#: src/PrefsUnifiedDlg.cpp:1949
 msgid "Browse for videoplayer"
 msgstr "Bläddra efter videospelare"
 
-#: src/PrefsUnifiedDlg.cpp:1944
+#: src/PrefsUnifiedDlg.cpp:1953
 msgid "Select browser"
 msgstr "Välj webbläsare"
 
-#: src/PrefsUnifiedDlg.cpp:1948
+#: src/PrefsUnifiedDlg.cpp:1957
 #, fuzzy
 msgid "Select ffprobe binary"
 msgstr "Välj webbläsare"
 
-#: src/PrefsUnifiedDlg.cpp:1954
+#: src/PrefsUnifiedDlg.cpp:1963
 #, c-format
 msgid "Executable%s"
 msgstr "Körbar %s"
 
-#: src/PrefsUnifiedDlg.cpp:1988
+#: src/PrefsUnifiedDlg.cpp:1997
 msgid "ffprobe not found on PATH or in the standard install locations. Install ffmpeg (which ships ffprobe) or use Browse to pick a binary manually."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2000
+#: src/PrefsUnifiedDlg.cpp:2009
 msgid "Reset the settings on this page to their default values?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2001
+#: src/PrefsUnifiedDlg.cpp:2010
 #, fuzzy
 msgid "Reset to defaults"
 msgstr "Systemets standard"
 
-#: src/PrefsUnifiedDlg.cpp:2028
+#: src/PrefsUnifiedDlg.cpp:2037
 msgid "Edit server list"
 msgstr "Redigera serverlista"
 
-#: src/PrefsUnifiedDlg.cpp:2029
+#: src/PrefsUnifiedDlg.cpp:2038
 msgid ""
 "Add here URL's to download server.met files.\n"
 "Only one url on each line."
@@ -6024,154 +6024,154 @@ msgstr ""
 "Lägg här URL för att hämta server.met filer.\n"
 "Endast en webbadress på varje rad."
 
-#: src/PrefsUnifiedDlg.cpp:2084
+#: src/PrefsUnifiedDlg.cpp:2093
 msgid "IP2Country update failed"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2229 src/PrefsUnifiedDlg.cpp:2260
+#: src/PrefsUnifiedDlg.cpp:2238 src/PrefsUnifiedDlg.cpp:2269
 msgid "Data by MaxMind GeoLite2"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2231 src/PrefsUnifiedDlg.cpp:2262
+#: src/PrefsUnifiedDlg.cpp:2240 src/PrefsUnifiedDlg.cpp:2271
 #, fuzzy
 msgid "Custom source"
 msgstr "Kompletta källor"
 
-#: src/PrefsUnifiedDlg.cpp:2233 src/PrefsUnifiedDlg.cpp:2264
+#: src/PrefsUnifiedDlg.cpp:2242 src/PrefsUnifiedDlg.cpp:2273
 msgid "Data by DB-IP.com"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2284
+#: src/PrefsUnifiedDlg.cpp:2293
 #, fuzzy, c-format
 msgid "Status: Loaded%s"
 msgstr "Status:"
 
-#: src/PrefsUnifiedDlg.cpp:2286
+#: src/PrefsUnifiedDlg.cpp:2295
 #, fuzzy, c-format
 msgid "Status: Loaded%s - %s"
 msgstr "Status:"
 
-#: src/PrefsUnifiedDlg.cpp:2290
+#: src/PrefsUnifiedDlg.cpp:2299
 msgid "Status: Failed to load - click 'Update now' to refresh."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2292
+#: src/PrefsUnifiedDlg.cpp:2301
 msgid "Status: Not found - click 'Update now' to download."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2350 src/PrefsUnifiedDlg.cpp:2374
+#: src/PrefsUnifiedDlg.cpp:2359 src/PrefsUnifiedDlg.cpp:2383
 #, c-format
 msgid "Update delay: %d second"
 msgid_plural "Update delay: %d seconds"
 msgstr[0] "Uppdateringsfördröjning: %d sekund"
 msgstr[1] "Uppdateringsfördröjning: %d sekunder"
 
-#: src/PrefsUnifiedDlg.cpp:2358
+#: src/PrefsUnifiedDlg.cpp:2367
 #, c-format
 msgid "Time for average graph: %d minute"
 msgid_plural "Time for average graph: %d minutes"
 msgstr[0] "Tid för genomsnittlig graf: %d minut"
 msgstr[1] "Tid för genomsnittlig graf: %d minuter"
 
-#: src/PrefsUnifiedDlg.cpp:2367
+#: src/PrefsUnifiedDlg.cpp:2376
 #, c-format
 msgid "Connections Graph Scale: %d"
 msgstr "Anslutningsdiagramskala: %d"
 
-#: src/PrefsUnifiedDlg.cpp:2382
+#: src/PrefsUnifiedDlg.cpp:2391
 #, c-format
 msgid "File Buffer Size: %d byte"
 msgid_plural "File Buffer Size: %d bytes"
 msgstr[0] "Filbuffertstorlek: %d byte"
 msgstr[1] "Filbuffertstorlek: %d bytes"
 
-#: src/PrefsUnifiedDlg.cpp:2392
+#: src/PrefsUnifiedDlg.cpp:2401
 #, c-format
 msgid "Upload Queue Size: %d client"
 msgid_plural "Upload Queue Size: %d clients"
 msgstr[0] "Uppladdningsköstorlek: %d klient"
 msgstr[1] "Uppladdningsköstorlek: %d klienter"
 
-#: src/PrefsUnifiedDlg.cpp:2402
+#: src/PrefsUnifiedDlg.cpp:2411
 #, c-format
 msgid "Server connection refresh interval: %d minute"
 msgid_plural "Server connection refresh interval: %d minutes"
 msgstr[0] "Serveranslutninguppdateringsintervall: %d minut"
 msgstr[1] "Serveranslutninguppdateringsintervall: %d minuter"
 
-#: src/PrefsUnifiedDlg.cpp:2407
+#: src/PrefsUnifiedDlg.cpp:2416
 msgid "Server connection refresh interval: Disabled"
 msgstr "Serveranslutningsuppdateringsintervall: Inaktiverad"
 
-#: src/PrefsUnifiedDlg.cpp:2451
+#: src/PrefsUnifiedDlg.cpp:2460
 msgid "disabled"
 msgstr "inaktiverad"
 
-#: src/PrefsUnifiedDlg.cpp:2477
+#: src/PrefsUnifiedDlg.cpp:2486
 #, c-format
 msgid "Execute command on '%s' event"
 msgstr "Exekvera kommando på '%s' händelse"
 
-#: src/PrefsUnifiedDlg.cpp:2484
+#: src/PrefsUnifiedDlg.cpp:2493
 msgid "Enable command execution on core"
 msgstr "Aktivera kommandokörning på kärnan"
 
-#: src/PrefsUnifiedDlg.cpp:2496
+#: src/PrefsUnifiedDlg.cpp:2505
 msgid "Core command:"
 msgstr "Kommando till kärnan:"
 
-#: src/PrefsUnifiedDlg.cpp:2512
+#: src/PrefsUnifiedDlg.cpp:2521
 msgid "Enable command execution on GUI"
 msgstr "Aktivera kommandokörning via GUI"
 
-#: src/PrefsUnifiedDlg.cpp:2524
+#: src/PrefsUnifiedDlg.cpp:2533
 msgid "GUI command:"
 msgstr "GUI kommando:"
 
-#: src/PrefsUnifiedDlg.cpp:2540
+#: src/PrefsUnifiedDlg.cpp:2549
 msgid "The following variables will be replaced:"
 msgstr "Följande variabler kommer att ersättas:"
 
-#: src/PrefsUnifiedDlg.cpp:2708
+#: src/PrefsUnifiedDlg.cpp:2717
 msgid ""
 "The following folders look like system or sensitive locations:\n"
 "\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2713
+#: src/PrefsUnifiedDlg.cpp:2722
 msgid "Sharing them recursively will publish every file underneath on the eD2k/Kad networks. Do you really want to do this?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2716
+#: src/PrefsUnifiedDlg.cpp:2725
 #, fuzzy
 msgid "Confirm shared folders"
 msgstr "Delade mappar"
 
-#: src/PrefsUnifiedDlg.cpp:2744
+#: src/PrefsUnifiedDlg.cpp:2753
 #, fuzzy
 msgid "Reloading shared files..."
 msgstr "Återladda dina delade filer"
 
-#: src/PrefsUnifiedDlg.cpp:2745
+#: src/PrefsUnifiedDlg.cpp:2754
 msgid "Scanning for subdirectories..."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2746
+#: src/PrefsUnifiedDlg.cpp:2755
 #, fuzzy
 msgid "Updating shared folders"
 msgstr "Delade mappar"
 
-#: src/PrefsUnifiedDlg.cpp:2773
+#: src/PrefsUnifiedDlg.cpp:2782
 #, c-format
 msgid "Scanned %u directories..."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2823
+#: src/PrefsUnifiedDlg.cpp:2832
 #, fuzzy, c-format
 msgid "Reloading shared files: %u files scanned"
 msgstr "Ladda om listan med delade filer."
 
-#: src/PrefsUnifiedDlg.cpp:2873
+#: src/PrefsUnifiedDlg.cpp:2882
 #, fuzzy
 msgid "Shared folder"
 msgstr "Delade mappar"
@@ -7853,12 +7853,12 @@ msgstr "Ta bort kategori"
 msgid "Hashset requested for unknown file: %s"
 msgstr "HashSet begärd för okänd fil: %s"
 
-#: src/UploadQueue.cpp:618
+#: src/UploadQueue.cpp:627
 #, c-format
 msgid "Resuming uploads of file: %s"
 msgstr "Återupptar uppladdning av filen: %s"
 
-#: src/UploadQueue.cpp:634
+#: src/UploadQueue.cpp:643
 #, c-format
 msgid "Suspending upload of file: %s"
 msgstr "Uppskjuter uppladdning av filen: %s"

--- a/po/ta.po
+++ b/po/ta.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-28 10:19+0200\n"
+"POT-Creation-Date: 2026-07-28 12:17+0200\n"
 "PO-Revision-Date: 2026-07-27 11:50+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: none\n"
@@ -188,152 +188,152 @@ msgstr ""
 msgid "WARNING: You can't add yourself as a source for an eD2k link while having a lowid."
 msgstr ""
 
-#: src/amule.cpp:300
+#: src/amule.cpp:301
 msgid "Now, exiting main app..."
 msgstr ""
 
-#: src/amule.cpp:330
+#: src/amule.cpp:331
 #, c-format
 msgid "Terminating amuleweb instance with pid '%d' ... "
 msgstr ""
 
-#: src/amule.cpp:334
+#: src/amule.cpp:335
 #, c-format
 msgid "Killing amuleweb instance with pid '%d' ... "
 msgstr ""
 
-#: src/amule.cpp:336 src/amule.cpp:349 src/ClientRef.cpp:180
+#: src/amule.cpp:337 src/amule.cpp:350 src/ClientRef.cpp:180
 #: src/SearchDlg.cpp:1041 src/ServerListCtrl.cpp:98
 msgid "Failed"
 msgstr ""
 
-#: src/amule.cpp:343
+#: src/amule.cpp:344
 #, c-format
 msgid "Terminating amuleapi instance with pid '%d' ... "
 msgstr ""
 
-#: src/amule.cpp:347
+#: src/amule.cpp:348
 #, c-format
 msgid "Killing amuleapi instance with pid '%d' ... "
 msgstr ""
 
-#: src/amule.cpp:355
+#: src/amule.cpp:356
 msgid "aMule OnExit: Terminating core."
 msgstr ""
 
-#: src/amule.cpp:466
+#: src/amule.cpp:467
 msgid "aMule shutdown completed."
 msgstr ""
 
-#: src/amule.cpp:470
+#: src/amule.cpp:471
 msgid "Memory debug results for aMule exit:"
 msgstr ""
 
-#: src/amule.cpp:651
+#: src/amule.cpp:652
 #, c-format
 msgid "Binding aMule's peer-to-peer traffic to interface: %s (HTTP updates use the default route)"
 msgstr ""
 
-#: src/amule.cpp:655
+#: src/amule.cpp:656
 #, c-format
 msgid "Binding all network traffic to interface: %s"
 msgstr ""
 
-#: src/amule.cpp:659
+#: src/amule.cpp:660
 #, c-format
 msgid "WARNING: configured network interface '%s' was not found - traffic is NOT bound to it and may leave via the default route. Check the interface name in Preferences."
 msgstr ""
 
-#: src/amule.cpp:665
+#: src/amule.cpp:666
 #, c-format
 msgid "WARNING: binding to network interface '%s' requires elevated privileges and was NOT applied - traffic may leave via the default route. Grant the capability (e.g. 'sudo setcap cap_net_raw+ep' on the aMule binary) or run with sufficient privileges."
 msgstr ""
 
-#: src/amule.cpp:673
+#: src/amule.cpp:674
 #, c-format
 msgid "WARNING: could not bind to network interface '%s' - traffic may leave via the default route."
 msgstr ""
 
-#: src/amule.cpp:732
+#: src/amule.cpp:733
 msgid "Your locale has been changed to System Default due to a configuration change. Sorry."
 msgstr ""
 
-#: src/amule.cpp:734 src/amule.cpp:1581 src/CatDialog.cpp:128
+#: src/amule.cpp:735 src/amule.cpp:1589 src/CatDialog.cpp:128
 #: src/CatDialog.cpp:136 src/CatDialog.cpp:149 src/ServerList.cpp:366
 #: src/ServerListCtrl.cpp:152
 msgid "Info"
 msgstr ""
 
-#: src/amule.cpp:741
+#: src/amule.cpp:742
 msgid ""
 "\n"
 "EC configuration"
 msgstr ""
 
-#: src/amule.cpp:744
+#: src/amule.cpp:745
 msgid "Password set and external connections enabled."
 msgstr ""
 
-#: src/amule.cpp:754 src/KadDlg.cpp:176 src/KadDlg.cpp:185
-#: src/PrefsUnifiedDlg.cpp:1387 src/SharedFilesCtrl.cpp:476
+#: src/amule.cpp:755 src/KadDlg.cpp:176 src/KadDlg.cpp:185
+#: src/PrefsUnifiedDlg.cpp:1461 src/SharedFilesCtrl.cpp:476
 msgid "WARNING"
 msgstr ""
 
-#: src/amule.cpp:991
+#: src/amule.cpp:992
 msgid "Network bootstrap"
 msgstr ""
 
-#: src/amule.cpp:996
+#: src/amule.cpp:997
 msgid ""
 "aMule has detected missing network bootstrap files.\n"
 "Select which ones to download:"
 msgstr ""
 
-#: src/amule.cpp:1005 src/FirstRunWizard.cpp:411
+#: src/amule.cpp:1006 src/FirstRunWizard.cpp:411
 msgid "eD2k server list (server.met)"
 msgstr ""
 
-#: src/amule.cpp:1012 src/FirstRunWizard.cpp:416
+#: src/amule.cpp:1013 src/FirstRunWizard.cpp:416
 msgid "Kad bootstrap nodes (nodes.dat)"
 msgstr ""
 
-#: src/amule.cpp:1102
+#: src/amule.cpp:1103
 #, c-format
 msgid "web server running on pid %d"
 msgstr ""
 
-#: src/amule.cpp:1115
+#: src/amule.cpp:1116
 msgid "You requested to run web server on startup, but the amuleweb binary cannot be run. Please install the package containing aMule web server, or build aMule from source with -DBUILD_WEBSERVER=YES and install it."
 msgstr ""
 
-#: src/amule.cpp:1120 src/amule.cpp:1177 src/amule.cpp:1291 src/amule.cpp:1593
+#: src/amule.cpp:1121 src/amule.cpp:1185 src/amule.cpp:1299 src/amule.cpp:1601
 #: src/amule-remote-gui.cpp:603 src/amule-remote-gui.cpp:671
 #: src/amule-remote-gui.cpp:709 src/amule-remote-gui.cpp:1282
 #: src/amule-remote-gui.cpp:1345 src/amule-remote-gui.cpp:1372
-#: src/DownloadQueue.cpp:1481
+#: src/DownloadQueue.cpp:1481 src/PrefsUnifiedDlg.cpp:1247
 msgid "ERROR"
 msgstr ""
 
-#: src/amule.cpp:1166
+#: src/amule.cpp:1174
 #, c-format
 msgid "amuleapi running on pid %d"
 msgstr ""
 
-#: src/amule.cpp:1172
+#: src/amule.cpp:1180
 msgid "You requested to run amuleapi on startup, but the amuleapi binary cannot be run. Please install the package containing aMule's REST API server, or build aMule from source with -DBUILD_AMULEAPI=YES and install it."
 msgstr ""
 
-#: src/amule.cpp:1259
+#: src/amule.cpp:1267
 #, c-format
 msgid "Could not bind ports to the specified address: %s"
 msgstr ""
 
-#: src/amule.cpp:1283
+#: src/amule.cpp:1291
 #, c-format
 msgid "Port %u is not available. You will be LOWID\n"
 msgstr ""
 
-#: src/amule.cpp:1288
+#: src/amule.cpp:1296
 #, c-format
 msgid ""
 "Port %u is not available!\n"
@@ -343,184 +343,184 @@ msgid ""
 "Check your network to make sure the port is open for output and input."
 msgstr ""
 
-#: src/amule.cpp:1385
+#: src/amule.cpp:1393
 msgid "Failed to create OnlineSig File"
 msgstr ""
 
-#: src/amule.cpp:1393
+#: src/amule.cpp:1401
 msgid "Failed to create aMule OnlineSig File"
 msgstr ""
 
-#: src/amule.cpp:1556
+#: src/amule.cpp:1564
 msgid "The selected locale seems not to be installed on your box. (Note: I'll try to set it anyway)"
 msgstr ""
 
-#: src/amule.cpp:1566
+#: src/amule.cpp:1574
 #, c-format
 msgid "This is the first time you run aMule %s"
 msgstr ""
 
-#: src/amule.cpp:1569
+#: src/amule.cpp:1577
 msgid "This version is a testing version, updated daily, and\n"
 msgstr ""
 
-#: src/amule.cpp:1570
+#: src/amule.cpp:1578
 msgid "we give no warranty it won't break anything, burn your house,\n"
 msgstr ""
 
-#: src/amule.cpp:1571
+#: src/amule.cpp:1579
 msgid "or kill your dog. But it *should* be safe to use anyway.\n"
 msgstr ""
 
-#: src/amule.cpp:1576
+#: src/amule.cpp:1584
 msgid "More information, support and new releases can found at our homepage,\n"
 msgstr ""
 
-#: src/amule.cpp:1577
+#: src/amule.cpp:1585
 msgid "at https://amule-org.github.io, or in our IRC channel #aMule at irc.libera.chat.\n"
 msgstr ""
 
-#: src/amule.cpp:1579
+#: src/amule.cpp:1587
 msgid "Feel free to report any bugs to https://github.com/amule-org/amule/issues"
 msgstr ""
 
-#: src/amule.cpp:1591
+#: src/amule.cpp:1599
 msgid ""
 "The folder for Online Signature files you specified is INVALID!\n"
 " OnlineSignature will be DISABLED until you fix it on preferences."
 msgstr ""
 
-#: src/amule.cpp:1654
+#: src/amule.cpp:1662
 msgid "Server hostname notified"
 msgstr ""
 
-#: src/amule.cpp:2031
+#: src/amule.cpp:2039
 #, c-format
 msgid "Disk space preallocation for file '%s' failed: %s"
 msgstr ""
 
-#: src/amule.cpp:2160
+#: src/amule.cpp:2168
 msgid "ERROR: can't open logfile"
 msgstr ""
 
-#: src/amule.cpp:2164
+#: src/amule.cpp:2172
 msgid "WARNING: logfile is empty. Something is wrong."
 msgstr ""
 
-#: src/amule.cpp:2181
+#: src/amule.cpp:2189
 msgid "Log has been reset"
 msgstr ""
 
-#: src/amule.cpp:2205
+#: src/amule.cpp:2213
 #, c-format
 msgid "ServerMessage: %s"
 msgstr ""
 
-#: src/amule.cpp:2248 src/IP2Country.cpp:220 src/IPFilter.cpp:514
+#: src/amule.cpp:2256 src/IP2Country.cpp:220 src/IPFilter.cpp:514
 #: src/ServerList.cpp:875
 #, c-format
 msgid "Skipped download of %s, because requested file is not newer."
 msgstr ""
 
-#: src/amule.cpp:2251
+#: src/amule.cpp:2259
 msgid "Failed to download the nodes list."
 msgstr ""
 
-#: src/amule.cpp:2314
+#: src/amule.cpp:2322
 msgid "Failed to open the downloaded version check file"
 msgstr ""
 
-#: src/amule.cpp:2317 src/amule.cpp:2336
+#: src/amule.cpp:2325 src/amule.cpp:2344
 msgid "Corrupted version check file"
 msgstr ""
 
-#: src/amule.cpp:2359
+#: src/amule.cpp:2367
 msgid "You are using an outdated version of aMule!"
 msgstr ""
 
-#: src/amule.cpp:2361
+#: src/amule.cpp:2369
 #, c-format
 msgid "Your aMule version is %i.%i.%i and the latest version is %li.%li.%li"
 msgstr ""
 
-#: src/amule.cpp:2365
+#: src/amule.cpp:2373
 msgid "The latest version can always be found at https://github.com/amule-org/amule/releases/latest"
 msgstr ""
 
-#: src/amule.cpp:2368
+#: src/amule.cpp:2376
 #, c-format
 msgid "WARNING: Your aMuled version is outdated: %i.%i.%i < %li.%li.%li"
 msgstr ""
 
-#: src/amule.cpp:2374
+#: src/amule.cpp:2382
 msgid "Your copy of aMule is up to date."
 msgstr ""
 
-#: src/amule.cpp:2381
+#: src/amule.cpp:2389
 msgid "Failed to download the version check file"
 msgstr ""
 
-#: src/amule.cpp:2550 src/amule-remote-gui.cpp:1133
+#: src/amule.cpp:2558 src/amule-remote-gui.cpp:1133
 #, c-format
 msgid "Users: %s | Files: %s"
 msgstr ""
 
-#: src/amule.cpp:2551 src/amule-remote-gui.cpp:1134
+#: src/amule.cpp:2559 src/amule-remote-gui.cpp:1134
 #, c-format
 msgid "Users: E: %s K: %s | Files: E: %s K: %s"
 msgstr ""
 
-#: src/amule.cpp:2565 src/amule-remote-gui.cpp:1147
+#: src/amule.cpp:2573 src/amule-remote-gui.cpp:1147
 msgid "No networks selected"
 msgstr ""
 
-#: src/amule.cpp:2633 src/TextClient.cpp:903
+#: src/amule.cpp:2641 src/TextClient.cpp:903
 msgid "with LowID"
 msgstr ""
 
-#: src/amule.cpp:2633 src/TextClient.cpp:904
+#: src/amule.cpp:2641 src/TextClient.cpp:904
 msgid "with HighID"
 msgstr ""
 
-#: src/amule.cpp:2635
+#: src/amule.cpp:2643
 #, c-format
 msgid "Connected to %s %s"
 msgstr ""
 
-#: src/amule.cpp:2640
+#: src/amule.cpp:2648
 #, c-format
 msgid "Connecting to %s"
 msgstr ""
 
-#: src/amule.cpp:2642
+#: src/amule.cpp:2650
 msgid "Disconnected from eD2k"
 msgstr ""
 
-#: src/amule.cpp:2651
+#: src/amule.cpp:2659
 msgid "Kad started."
 msgstr ""
 
-#: src/amule.cpp:2653
+#: src/amule.cpp:2661
 msgid "Kad stopped."
 msgstr ""
 
-#: src/amule.cpp:2661
+#: src/amule.cpp:2669
 msgid "Connected to Kad (ok)"
 msgstr ""
 
-#: src/amule.cpp:2663
+#: src/amule.cpp:2671
 msgid "Connected to Kad (firewalled)"
 msgstr ""
 
-#: src/amule.cpp:2667
+#: src/amule.cpp:2675
 msgid "Disconnected from Kad"
 msgstr ""
 
-#: src/amule.cpp:2699
+#: src/amule.cpp:2707
 msgid "Kad network cannot be used if UDP port is disabled on preferences, not starting."
 msgstr ""
 
-#: src/amule.cpp:2703
+#: src/amule.cpp:2711
 msgid "Kad network disabled on preferences, not connecting."
 msgstr ""
 
@@ -564,36 +564,36 @@ msgid "FATAL ERROR: Failed to create Timer"
 msgstr ""
 
 #: src/amuleDlg.cpp:361 src/amuleDlg.cpp:1787 src/amuleDlg.cpp:2033
-#: src/muuli_wdr.cpp:1492 src/muuli_wdr.cpp:3418
+#: src/muuli_wdr.cpp:1492 src/muuli_wdr.cpp:3449
 msgid "Networks"
 msgstr ""
 
-#: src/amuleDlg.cpp:362 src/amuleDlg.cpp:1793 src/muuli_wdr.cpp:3419
+#: src/amuleDlg.cpp:362 src/amuleDlg.cpp:1793 src/muuli_wdr.cpp:3450
 msgid "Searches"
 msgstr ""
 
 #: src/amuleDlg.cpp:363 src/amuleDlg.cpp:1799 src/DownloadListCtrl.cpp:740
-#: src/muuli_wdr.cpp:392 src/muuli_wdr.cpp:1585 src/muuli_wdr.cpp:3420
+#: src/muuli_wdr.cpp:392 src/muuli_wdr.cpp:1585 src/muuli_wdr.cpp:3451
 #: src/Statistics.cpp:829
 msgid "Downloads"
 msgstr ""
 
-#: src/amuleDlg.cpp:364 src/amuleDlg.cpp:1805 src/muuli_wdr.cpp:3294
+#: src/amuleDlg.cpp:364 src/amuleDlg.cpp:1805 src/muuli_wdr.cpp:3325
 msgid "Shared files"
 msgstr ""
 
-#: src/amuleDlg.cpp:365 src/amuleDlg.cpp:1811 src/muuli_wdr.cpp:2926
-#: src/muuli_wdr.cpp:3376 src/muuli_wdr.cpp:3423
+#: src/amuleDlg.cpp:365 src/amuleDlg.cpp:1811 src/muuli_wdr.cpp:2957
+#: src/muuli_wdr.cpp:3407 src/muuli_wdr.cpp:3454
 msgid "Messages"
 msgstr ""
 
-#: src/amuleDlg.cpp:366 src/amuleDlg.cpp:1817 src/muuli_wdr.cpp:3424
-#: src/PrefsUnifiedDlg.cpp:312 src/Statistics.cpp:779 src/Statistics.cpp:1235
+#: src/amuleDlg.cpp:366 src/amuleDlg.cpp:1817 src/muuli_wdr.cpp:3455
+#: src/PrefsUnifiedDlg.cpp:314 src/Statistics.cpp:779 src/Statistics.cpp:1235
 msgid "Statistics"
 msgstr ""
 
-#: src/amuleDlg.cpp:368 src/amuleDlg.cpp:1824 src/muuli_wdr.cpp:3426
-#: src/PrefsUnifiedDlg.cpp:328 src/utils/wxCas/src/wxcasprefs.cpp:39
+#: src/amuleDlg.cpp:368 src/amuleDlg.cpp:1824 src/muuli_wdr.cpp:3457
+#: src/PrefsUnifiedDlg.cpp:330 src/utils/wxCas/src/wxcasprefs.cpp:39
 msgid "Preferences"
 msgstr ""
 
@@ -650,8 +650,8 @@ msgstr ""
 #: src/amuleDlg.cpp:1029 src/DownloadListCtrl.cpp:505
 #: src/DownloadListCtrl.cpp:749 src/FriendListCtrl.cpp:180
 #: src/muuli_wdr.cpp:731 src/muuli_wdr.cpp:782 src/muuli_wdr.cpp:846
-#: src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2231 src/muuli_wdr.cpp:2316
-#: src/muuli_wdr.cpp:3064 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
+#: src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2262 src/muuli_wdr.cpp:2347
+#: src/muuli_wdr.cpp:3095 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
 #: src/ServerListCtrl.cpp:606 src/TransferWnd.cpp:378
 #: src/utils/wxCas/src/wxcasprefs.cpp:235
 msgid "Cancel"
@@ -662,7 +662,7 @@ msgid "Stop the current connection attempts"
 msgstr ""
 
 #: src/amuleDlg.cpp:1035 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976
-#: src/muuli_wdr.cpp:2454
+#: src/muuli_wdr.cpp:2485
 msgid "Disconnect"
 msgstr ""
 
@@ -671,7 +671,7 @@ msgid "Disconnect from the currently connected networks"
 msgstr ""
 
 #: src/amuleDlg.cpp:1041 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979
-#: src/muuli_wdr.cpp:2609 src/muuli_wdr.cpp:3061 src/muuli_wdr.cpp:3416
+#: src/muuli_wdr.cpp:2640 src/muuli_wdr.cpp:3092 src/muuli_wdr.cpp:3447
 msgid "Connect"
 msgstr ""
 
@@ -725,7 +725,7 @@ msgstr ""
 msgid "Launch Command: "
 msgstr ""
 
-#: src/amuleDlg.cpp:1632 src/muuli_wdr.cpp:1978 src/Preferences.cpp:952
+#: src/amuleDlg.cpp:1632 src/muuli_wdr.cpp:1982 src/Preferences.cpp:979
 msgid "- default -"
 msgstr ""
 
@@ -739,48 +739,48 @@ msgstr ""
 msgid "WARNING: Unable to open skin file '%s' for read"
 msgstr ""
 
-#: src/amuleDlg.cpp:1791 src/muuli_wdr.cpp:3418
+#: src/amuleDlg.cpp:1791 src/muuli_wdr.cpp:3449
 msgid "Networks Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1797 src/muuli_wdr.cpp:3419
+#: src/amuleDlg.cpp:1797 src/muuli_wdr.cpp:3450
 msgid "Searches Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1803 src/muuli_wdr.cpp:3420
+#: src/amuleDlg.cpp:1803 src/muuli_wdr.cpp:3451
 msgid "Downloads Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1809 src/muuli_wdr.cpp:3422
+#: src/amuleDlg.cpp:1809 src/muuli_wdr.cpp:3453
 msgid "Shared Files Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1815 src/muuli_wdr.cpp:3423
+#: src/amuleDlg.cpp:1815 src/muuli_wdr.cpp:3454
 msgid "Messages Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1821 src/muuli_wdr.cpp:3424
+#: src/amuleDlg.cpp:1821 src/muuli_wdr.cpp:3455
 msgid "Statistics Graph Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1828 src/muuli_wdr.cpp:3426
+#: src/amuleDlg.cpp:1828 src/muuli_wdr.cpp:3457
 msgid "Preferences Settings Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1831 src/muuli_wdr.cpp:3427
+#: src/amuleDlg.cpp:1831 src/muuli_wdr.cpp:3458
 msgid "Import"
 msgstr ""
 
-#: src/amuleDlg.cpp:1835 src/muuli_wdr.cpp:3427
+#: src/amuleDlg.cpp:1835 src/muuli_wdr.cpp:3458
 msgid "The partfile importer tool"
 msgstr ""
 
-#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3428
+#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3459
 #: src/utils/aLinkCreator/src/alcframe.cpp:262
 msgid "About"
 msgstr ""
 
-#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3428
+#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3459
 msgid "About/Help"
 msgstr ""
 
@@ -917,7 +917,7 @@ msgstr ""
 msgid "The core rejected these shared folders:%s"
 msgstr ""
 
-#: src/amule-remote-gui.cpp:1336 src/ExternalConn.cpp:2345
+#: src/amule-remote-gui.cpp:1336 src/ExternalConn.cpp:2346
 msgid "Invalid link or already on list."
 msgstr ""
 
@@ -933,7 +933,7 @@ msgstr ""
 #: src/ClientDetailDialog.cpp:123 src/DataToText.cpp:61 src/DataToText.cpp:86
 #: src/DataToText.cpp:101 src/DataToText.cpp:136 src/DataToText.cpp:165
 #: src/DownloadListCtrl.cpp:1172 src/DownloadListCtrl.cpp:1185
-#: src/DownloadListCtrl.cpp:1196 src/ExternalConn.cpp:608
+#: src/DownloadListCtrl.cpp:1196 src/ExternalConn.cpp:609
 #: src/FileDetailDialog.cpp:203 src/FileDetailDialog.cpp:235
 #: src/FileDetailDialog.cpp:242 src/GenericClientListCtrl.cpp:1171
 #: src/GenericClientListCtrl.cpp:1182 src/GenericClientListCtrl.cpp:1192
@@ -1319,19 +1319,19 @@ msgstr ""
 msgid "Very low"
 msgstr ""
 
-#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:743 src/muuli_wdr.cpp:2282
+#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:743 src/muuli_wdr.cpp:2313
 #: src/ServerListCtrl.cpp:263 src/ServerListCtrl.cpp:456
 #: src/SharedFilesCtrl.cpp:145
 msgid "Low"
 msgstr ""
 
-#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:744 src/muuli_wdr.cpp:2283
+#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:744 src/muuli_wdr.cpp:2314
 #: src/ServerListCtrl.cpp:266 src/ServerListCtrl.cpp:457
 #: src/SharedFilesCtrl.cpp:146
 msgid "Normal"
 msgstr ""
 
-#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:745 src/muuli_wdr.cpp:2284
+#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:745 src/muuli_wdr.cpp:2315
 #: src/ServerListCtrl.cpp:269 src/ServerListCtrl.cpp:458
 #: src/SharedFilesCtrl.cpp:147
 msgid "High"
@@ -1423,7 +1423,7 @@ msgstr ""
 msgid "Remote Server"
 msgstr ""
 
-#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3181
+#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3212
 #: src/SearchDlg.cpp:119 src/TextClient.cpp:911
 msgid "Kad"
 msgstr "காட்"
@@ -1494,7 +1494,7 @@ msgstr ""
 msgid "Size"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3248
+#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3279
 msgid "Transferred"
 msgstr ""
 
@@ -1550,7 +1550,7 @@ msgid ""
 "\n"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:746 src/muuli_wdr.cpp:2285
+#: src/DownloadListCtrl.cpp:746 src/muuli_wdr.cpp:2316
 #: src/SharedFilesCtrl.cpp:150
 msgid "Auto"
 msgstr ""
@@ -1588,7 +1588,7 @@ msgid "Extended Options"
 msgstr ""
 
 #: src/DownloadListCtrl.cpp:770 src/DownloadListCtrl.cpp:822
-#: src/muuli_wdr.cpp:1796
+#: src/muuli_wdr.cpp:1800
 msgid "Preview"
 msgstr ""
 
@@ -1761,225 +1761,230 @@ msgstr[1] ""
 msgid "Invalid eD2k link! ERROR: %s"
 msgstr ""
 
-#: src/ExternalConn.cpp:379
+#: src/ExternalConn.cpp:380
 msgid "Client sent packet after authentication failed."
 msgstr ""
 
-#: src/ExternalConn.cpp:396
+#: src/ExternalConn.cpp:397
 msgid "External connection closed."
 msgstr ""
 
-#: src/ExternalConn.cpp:473
+#: src/ExternalConn.cpp:474
 msgid "External connections disabled due to empty password!"
 msgstr ""
 
-#: src/ExternalConn.cpp:494
+#: src/ExternalConn.cpp:495
 msgid "External connections disabled in config file"
 msgstr ""
 
-#: src/ExternalConn.cpp:575
+#: src/ExternalConn.cpp:576
 msgid "New external connection accepted"
 msgstr ""
 
-#: src/ExternalConn.cpp:578
+#: src/ExternalConn.cpp:579
 msgid "ERROR: couldn't accept a new external connection"
 msgstr ""
 
-#: src/ExternalConn.cpp:595
+#: src/ExternalConn.cpp:596
 msgid "External connection refused due to empty password in preferences!"
 msgstr ""
 
-#: src/ExternalConn.cpp:607
+#: src/ExternalConn.cpp:608
 #, c-format
 msgid "Connecting client: %s %s"
 msgstr ""
 
-#: src/ExternalConn.cpp:609
+#: src/ExternalConn.cpp:610
 msgid "Unknown version"
 msgstr ""
 
-#: src/ExternalConn.cpp:622
+#: src/ExternalConn.cpp:623
 msgid "Incorrect EC version ID, there might be binary incompatibility. Use core and remote from same snapshot."
 msgstr ""
 
-#: src/ExternalConn.cpp:630
+#: src/ExternalConn.cpp:631
 msgid "You cannot connect to a release version from an arbitrary development snapshot! *sigh* possible crash prevented"
 msgstr ""
 
-#: src/ExternalConn.cpp:713
+#: src/ExternalConn.cpp:714
 msgid "Invalid protocol version."
 msgstr ""
 
-#: src/ExternalConn.cpp:719
+#: src/ExternalConn.cpp:720
 msgid "Missing protocol version tag."
 msgstr ""
 
-#: src/ExternalConn.cpp:727
+#: src/ExternalConn.cpp:728
 msgid "Authentication failed: invalid hash specified as EC password."
 msgstr ""
 
-#: src/ExternalConn.cpp:775
+#: src/ExternalConn.cpp:776
 msgid "Authentication failed: wrong password."
 msgstr ""
 
-#: src/ExternalConn.cpp:777
+#: src/ExternalConn.cpp:778
 msgid "Authentication failed: missing password."
 msgstr ""
 
-#: src/ExternalConn.cpp:788
+#: src/ExternalConn.cpp:789
 msgid "Invalid request, please authenticate first."
 msgstr ""
 
-#: src/ExternalConn.cpp:793
+#: src/ExternalConn.cpp:794
 msgid "Access granted."
 msgstr ""
 
-#: src/ExternalConn.cpp:801
+#: src/ExternalConn.cpp:802
 #, c-format
 msgid "Sent error message \"%s\" to client."
 msgstr ""
 
-#: src/ExternalConn.cpp:806
+#: src/ExternalConn.cpp:807
 #, c-format
 msgid "Unauthorized access attempt from %s. Connection closed."
 msgstr ""
 
-#: src/ExternalConn.cpp:1419
+#: src/ExternalConn.cpp:1420
 #, c-format
 msgid "Remote PartFile command failed: FileHash not found: %s"
 msgstr ""
 
-#: src/ExternalConn.cpp:1423
+#: src/ExternalConn.cpp:1424
 #, c-format
 msgid "FileHash not found: %s"
 msgstr ""
 
-#: src/ExternalConn.cpp:1470 src/ExternalConn.cpp:1558
-#: src/ExternalConn.cpp:1679
+#: src/ExternalConn.cpp:1471 src/ExternalConn.cpp:1559
+#: src/ExternalConn.cpp:1680
 msgid "OOPS! OpCode processing error!"
 msgstr ""
 
-#: src/ExternalConn.cpp:1501
+#: src/ExternalConn.cpp:1502
 msgid "Server not added"
 msgstr ""
 
-#: src/ExternalConn.cpp:1520
+#: src/ExternalConn.cpp:1521
 #, c-format
 msgid "server not found: %s"
 msgstr ""
 
-#: src/ExternalConn.cpp:1537
+#: src/ExternalConn.cpp:1538
 msgid "need to define server to be removed"
 msgstr ""
 
-#: src/ExternalConn.cpp:1552
+#: src/ExternalConn.cpp:1553
 msgid "eD2k is disabled in preferences."
 msgstr ""
 
-#: src/ExternalConn.cpp:1657
+#: src/ExternalConn.cpp:1658
 msgid "Friend not found."
 msgstr ""
 
-#: src/ExternalConn.cpp:1667
+#: src/ExternalConn.cpp:1668
 msgid "Client not found."
 msgstr ""
 
-#: src/ExternalConn.cpp:1673
+#: src/ExternalConn.cpp:1674
 msgid "EC_TAG_FRIEND_SHARED requires EC_TAG_FRIEND or EC_TAG_CLIENT."
 msgstr ""
 
-#: src/ExternalConn.cpp:1991
+#: src/ExternalConn.cpp:1992
 msgid "WebSearch from remote interface makes no sense."
 msgstr ""
 
-#: src/ExternalConn.cpp:2026
+#: src/ExternalConn.cpp:2027
 msgid "Search in progress. Refetch results in a moment!"
 msgstr ""
 
-#: src/ExternalConn.cpp:2265
+#: src/ExternalConn.cpp:2266
 msgid "No points for graph."
 msgstr ""
 
-#: src/ExternalConn.cpp:2275
+#: src/ExternalConn.cpp:2276
 msgid "Your client is not configured for this detail level."
 msgstr ""
 
-#: src/ExternalConn.cpp:2302
+#: src/ExternalConn.cpp:2303
 msgid "External Connection: shutdown requested"
 msgstr ""
 
-#: src/ExternalConn.cpp:2314
+#: src/ExternalConn.cpp:2315
 msgid "Already shutting down."
 msgstr ""
 
-#: src/ExternalConn.cpp:2332
+#: src/ExternalConn.cpp:2333
 #, c-format
 msgid "ExternalConn: adding link '%s'."
 msgstr ""
 
-#: src/ExternalConn.cpp:2350
+#: src/ExternalConn.cpp:2351
 #, c-format
 msgid "%d of %d links failed (invalid or already on list)."
 msgstr ""
 
-#: src/ExternalConn.cpp:2373
+#: src/ExternalConn.cpp:2374
 msgid "Version check throttled; try again shortly."
 msgstr ""
 
-#: src/ExternalConn.cpp:2378
+#: src/ExternalConn.cpp:2379
 msgid "Version check is not available on this daemon."
 msgstr ""
 
-#: src/ExternalConn.cpp:2508
+#: src/ExternalConn.cpp:2509
 msgid "File not found."
 msgstr ""
 
-#: src/ExternalConn.cpp:2513
+#: src/ExternalConn.cpp:2514
 msgid "Invalid file name."
 msgstr ""
 
-#: src/ExternalConn.cpp:2521
+#: src/ExternalConn.cpp:2522
 msgid "Unable to rename file."
 msgstr ""
 
-#: src/ExternalConn.cpp:2992 src/ExternalConn.cpp:3020
+#: src/ExternalConn.cpp:2839
+#, c-format
+msgid "Could not save the amuleapi password: %s"
+msgstr ""
+
+#: src/ExternalConn.cpp:3004 src/ExternalConn.cpp:3032
 msgid "Kad is disabled in preferences."
 msgstr ""
 
-#: src/ExternalConn.cpp:3033
+#: src/ExternalConn.cpp:3045
 msgid "Already connected to eD2k."
 msgstr ""
 
-#: src/ExternalConn.cpp:3036
+#: src/ExternalConn.cpp:3048
 msgid "Connecting to eD2k..."
 msgstr ""
 
-#: src/ExternalConn.cpp:3045
+#: src/ExternalConn.cpp:3057
 msgid "Already connected to Kad."
 msgstr ""
 
-#: src/ExternalConn.cpp:3048
+#: src/ExternalConn.cpp:3060
 msgid "Connecting to Kad..."
 msgstr ""
 
-#: src/ExternalConn.cpp:3055
+#: src/ExternalConn.cpp:3067
 msgid "All networks are disabled."
 msgstr ""
 
-#: src/ExternalConn.cpp:3064
+#: src/ExternalConn.cpp:3076
 msgid "Disconnected from eD2k."
 msgstr ""
 
-#: src/ExternalConn.cpp:3069
+#: src/ExternalConn.cpp:3081
 msgid "Disconnected from Kad."
 msgstr ""
 
-#: src/ExternalConn.cpp:3078
+#: src/ExternalConn.cpp:3090
 #, c-format
 msgid "External Connection: invalid opcode received: %#x"
 msgstr ""
 
-#: src/ExternalConn.cpp:3083
+#: src/ExternalConn.cpp:3095
 msgid "Invalid opcode (wrong protocol version?)"
 msgstr ""
 
@@ -2349,23 +2354,23 @@ msgid ""
 "want downloads on a different (e.g. larger) disk."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:549 src/FirstRunWizard.cpp:611 src/muuli_wdr.cpp:1708
+#: src/FirstRunWizard.cpp:549 src/FirstRunWizard.cpp:611 src/muuli_wdr.cpp:1712
 msgid "Destination folder for downloads"
 msgstr ""
 
 #: src/FirstRunWizard.cpp:553 src/FirstRunWizard.cpp:569 src/muuli_wdr.cpp:1349
-#: src/muuli_wdr.cpp:1366 src/muuli_wdr.cpp:1683 src/muuli_wdr.cpp:1714
-#: src/muuli_wdr.cpp:1726 src/muuli_wdr.cpp:2769
+#: src/muuli_wdr.cpp:1366 src/muuli_wdr.cpp:1687 src/muuli_wdr.cpp:1718
+#: src/muuli_wdr.cpp:1730 src/muuli_wdr.cpp:2800
 #: src/utils/aLinkCreator/src/alcframe.cpp:135
 #: src/utils/wxCas/src/wxcasprefs.cpp:52 src/utils/wxCas/src/wxcasprefs.cpp:118
 msgid "Browse"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:559 src/muuli_wdr.cpp:1719
+#: src/FirstRunWizard.cpp:559 src/muuli_wdr.cpp:1723
 msgid "(All files in this folder are shared with other peers)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:565 src/FirstRunWizard.cpp:624 src/muuli_wdr.cpp:1721
+#: src/FirstRunWizard.cpp:565 src/FirstRunWizard.cpp:624 src/muuli_wdr.cpp:1725
 msgid "Folder for temporary download files"
 msgstr ""
 
@@ -2396,7 +2401,7 @@ msgstr ""
 msgid "CRITICAL - no client on StartChatSession"
 msgstr ""
 
-#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2675 src/muuli_wdr.cpp:3352
+#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2706 src/muuli_wdr.cpp:3383
 msgid "Friends"
 msgstr ""
 
@@ -2502,8 +2507,8 @@ msgstr ""
 msgid "No"
 msgstr ""
 
-#: src/GenericClientListCtrl.cpp:1216 src/PrefsUnifiedDlg.cpp:2818
-#: src/PrefsUnifiedDlg.cpp:2868 src/ServerListCtrl.cpp:276
+#: src/GenericClientListCtrl.cpp:1216 src/PrefsUnifiedDlg.cpp:2898
+#: src/PrefsUnifiedDlg.cpp:2948 src/ServerListCtrl.cpp:276
 msgid "Yes"
 msgstr ""
 
@@ -2670,10 +2675,10 @@ msgstr ""
 msgid "Please fill all fields required"
 msgstr ""
 
-#: src/KadDlg.cpp:192 src/PartFile.cpp:1031 src/PrefsUnifiedDlg.cpp:1162
-#: src/PrefsUnifiedDlg.cpp:1331 src/PrefsUnifiedDlg.cpp:1589
-#: src/PrefsUnifiedDlg.cpp:1599 src/PrefsUnifiedDlg.cpp:1616
-#: src/PrefsUnifiedDlg.cpp:1658
+#: src/KadDlg.cpp:192 src/PartFile.cpp:1031 src/PrefsUnifiedDlg.cpp:1134
+#: src/PrefsUnifiedDlg.cpp:1204 src/PrefsUnifiedDlg.cpp:1405
+#: src/PrefsUnifiedDlg.cpp:1663 src/PrefsUnifiedDlg.cpp:1673
+#: src/PrefsUnifiedDlg.cpp:1690 src/PrefsUnifiedDlg.cpp:1738
 msgid "Message"
 msgstr ""
 
@@ -2774,7 +2779,7 @@ msgstr ""
 msgid "Uploaded"
 msgstr ""
 
-#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3232
+#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3263
 msgid "Requested"
 msgstr ""
 
@@ -2897,7 +2902,7 @@ msgid "WARNING: "
 msgstr ""
 
 #: src/MuleNotebook.cpp:179 src/muuli_wdr.cpp:817 src/muuli_wdr.cpp:1229
-#: src/muuli_wdr.cpp:3136 src/muuli_wdr.cpp:3392
+#: src/muuli_wdr.cpp:3167 src/muuli_wdr.cpp:3423
 msgid "Close"
 msgstr ""
 
@@ -2915,7 +2920,7 @@ msgid "Paste"
 msgstr ""
 
 #: src/MuleTextCtrl.cpp:89 src/muuli_wdr.cpp:358 src/muuli_wdr.cpp:757
-#: src/muuli_wdr.cpp:2359 src/muuli_wdr.cpp:2378 src/muuli_wdr.cpp:2400
+#: src/muuli_wdr.cpp:2390 src/muuli_wdr.cpp:2409 src/muuli_wdr.cpp:2431
 #: src/utils/aLinkCreator/src/alcframe.cpp:142
 msgid "Clear"
 msgstr ""
@@ -3007,7 +3012,7 @@ msgstr ""
 
 #: src/MuleTrayIcon.cpp:579 src/MuleTrayIcon.cpp:945 src/MuleTrayIcon.cpp:965
 #: src/muuli_wdr.cpp:1398 src/muuli_wdr.cpp:1406 src/muuli_wdr.cpp:1413
-#: src/muuli_wdr.cpp:1842 src/muuli_wdr.cpp:1848 src/OtherFunctions.cpp:91
+#: src/muuli_wdr.cpp:1846 src/muuli_wdr.cpp:1852 src/OtherFunctions.cpp:91
 #: src/StatisticsDlg.cpp:93 src/StatisticsDlg.cpp:95
 msgid "kB/s"
 msgstr ""
@@ -3247,7 +3252,7 @@ msgstr ""
 msgid "KB"
 msgstr ""
 
-#: src/muuli_wdr.cpp:274 src/muuli_wdr.cpp:293 src/muuli_wdr.cpp:1627
+#: src/muuli_wdr.cpp:274 src/muuli_wdr.cpp:293 src/muuli_wdr.cpp:1631
 #: src/OtherFunctions.cpp:64
 msgid "MB"
 msgstr ""
@@ -3264,7 +3269,7 @@ msgstr ""
 msgid "Availability"
 msgstr ""
 
-#: src/muuli_wdr.cpp:312 src/muuli_wdr.cpp:398 src/muuli_wdr.cpp:3297
+#: src/muuli_wdr.cpp:312 src/muuli_wdr.cpp:398 src/muuli_wdr.cpp:3328
 msgid "Filter:"
 msgstr ""
 
@@ -3327,12 +3332,12 @@ msgstr ""
 #: src/muuli_wdr.cpp:1160 src/muuli_wdr.cpp:1167 src/muuli_wdr.cpp:1172
 #: src/muuli_wdr.cpp:1179 src/muuli_wdr.cpp:1184 src/muuli_wdr.cpp:1191
 #: src/muuli_wdr.cpp:1205 src/muuli_wdr.cpp:1212 src/muuli_wdr.cpp:1217
-#: src/muuli_wdr.cpp:1224 src/muuli_wdr.cpp:3234 src/muuli_wdr.cpp:3242
-#: src/muuli_wdr.cpp:3250
+#: src/muuli_wdr.cpp:1224 src/muuli_wdr.cpp:3265 src/muuli_wdr.cpp:3273
+#: src/muuli_wdr.cpp:3281
 msgid "N/A"
 msgstr ""
 
-#: src/muuli_wdr.cpp:508 src/muuli_wdr.cpp:1065 src/PrefsUnifiedDlg.cpp:297
+#: src/muuli_wdr.cpp:508 src/muuli_wdr.cpp:1065 src/PrefsUnifiedDlg.cpp:299
 msgid "General"
 msgstr ""
 
@@ -3468,7 +3473,7 @@ msgstr ""
 msgid "Album :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:685 src/muuli_wdr.cpp:2254
+#: src/muuli_wdr.cpp:685 src/muuli_wdr.cpp:2285
 msgid "Title :"
 msgstr ""
 
@@ -3574,7 +3579,7 @@ msgstr ""
 msgid "Userhash :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:895 src/muuli_wdr.cpp:1748 src/muuli_wdr.cpp:2449
+#: src/muuli_wdr.cpp:895 src/muuli_wdr.cpp:1752 src/muuli_wdr.cpp:2480
 #: src/utils/aLinkCreator/src/alcframe.cpp:137
 msgid "Add"
 msgstr ""
@@ -3583,15 +3588,15 @@ msgstr ""
 msgid "Download-Speed"
 msgstr ""
 
-#: src/muuli_wdr.cpp:954 src/muuli_wdr.cpp:989 src/muuli_wdr.cpp:2553
+#: src/muuli_wdr.cpp:954 src/muuli_wdr.cpp:989 src/muuli_wdr.cpp:2584
 msgid "Current"
 msgstr ""
 
-#: src/muuli_wdr.cpp:962 src/muuli_wdr.cpp:997 src/muuli_wdr.cpp:2561
+#: src/muuli_wdr.cpp:962 src/muuli_wdr.cpp:997 src/muuli_wdr.cpp:2592
 msgid "Running average"
 msgstr ""
 
-#: src/muuli_wdr.cpp:970 src/muuli_wdr.cpp:1005 src/muuli_wdr.cpp:2569
+#: src/muuli_wdr.cpp:970 src/muuli_wdr.cpp:1005 src/muuli_wdr.cpp:2600
 msgid "Session average"
 msgstr ""
 
@@ -3603,7 +3608,7 @@ msgstr ""
 msgid "Connections"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1024 src/muuli_wdr.cpp:1867
+#: src/muuli_wdr.cpp:1024 src/muuli_wdr.cpp:1871
 msgid "Active downloads"
 msgstr ""
 
@@ -3611,7 +3616,7 @@ msgstr ""
 msgid "Active connections (1:1)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1040 src/muuli_wdr.cpp:1868
+#: src/muuli_wdr.cpp:1040 src/muuli_wdr.cpp:1872
 msgid "Active uploads"
 msgstr ""
 
@@ -3884,7 +3889,7 @@ msgstr ""
 msgid "Advanced users only: If you have multiple network interfaces, enter the address of the interface to which aMule should be bound."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1462 src/muuli_wdr.cpp:2061
+#: src/muuli_wdr.cpp:1462 src/muuli_wdr.cpp:2065
 msgid "Bind to network interface (empty for any):"
 msgstr ""
 
@@ -3900,7 +3905,7 @@ msgstr ""
 msgid "Max simultaneous connections:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1498 src/muuli_wdr.cpp:3176
+#: src/muuli_wdr.cpp:1498 src/muuli_wdr.cpp:3207
 msgid "ED2K"
 msgstr ""
 
@@ -3992,743 +3997,763 @@ msgstr ""
 msgid "For new files preallocates disk space for the whole file, thus reduces fragmentation"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1613
+#: src/muuli_wdr.cpp:1617
 msgid "Create new files as sparse files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1614
-msgid "A sparse file reserves its full size on disk immediately without writing real data to it -- fast, but unsupported or slow on some filesystems, and free-space accounting stays optimistic while the download is in progress. Turn this off to grow the file only as data arrives."
+#: src/muuli_wdr.cpp:1618
+msgid "Sparse part files only occupy disk space for the parts already downloaded, so free space is used up gradually as the file fills in. Turn this off to use an ordinary file instead - useful where sparse files are unsupported or slow, or where backup/de-duplication tools handle them badly. Applies only when the core runs on Windows; on Linux and macOS part files are sparse anyway and this setting has no effect."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1619
+#: src/muuli_wdr.cpp:1623
 msgid "Stop downloads when free disk space reaches "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1620
+#: src/muuli_wdr.cpp:1624
 msgid "Select this if you want aMule to check your disk space"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1624
+#: src/muuli_wdr.cpp:1628
 msgid "Enter here the min disk space desired."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1630
+#: src/muuli_wdr.cpp:1634
 msgid "Save 10 sources on rare files (< 20 sources)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1634 src/Statistics.cpp:790
+#: src/muuli_wdr.cpp:1638 src/Statistics.cpp:790
 msgid "Uploads"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1637
+#: src/muuli_wdr.cpp:1641
 msgid "Add new shared files with auto priority"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1643
+#: src/muuli_wdr.cpp:1647
 msgid "Intelligent Corruption Handling (I.C.H.)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1646
+#: src/muuli_wdr.cpp:1650
 msgid "Enable"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1649
+#: src/muuli_wdr.cpp:1653
 msgid "Advanced I.C.H. trusts every hash (not recommended)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1661 src/PrefsUnifiedDlg.cpp:1910
+#: src/muuli_wdr.cpp:1665 src/PrefsUnifiedDlg.cpp:1990
 msgid "Media metadata extraction"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1665
+#: src/muuli_wdr.cpp:1669
 msgid "Extract length / bitrate / codec from shared audio and video files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1667
+#: src/muuli_wdr.cpp:1671
 msgid "When enabled, aMule runs ffprobe on each shared media file to fill in the Length / Bitrate / Codec columns other clients see when they find the file in a search. Requires ffmpeg (the ffprobe binary) to be installed."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1674
+#: src/muuli_wdr.cpp:1678
 msgid "Path to ffprobe:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1679
+#: src/muuli_wdr.cpp:1683
 msgid "Full path to the ffprobe binary. Leave empty to have aMule auto-detect it on startup."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1687
+#: src/muuli_wdr.cpp:1691
 msgid "Detect"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1688
+#: src/muuli_wdr.cpp:1692
 msgid "Search the standard install locations for an ffprobe binary and fill the path field."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1712
+#: src/muuli_wdr.cpp:1716
 msgid ""
 "Completed downloads are stored here. All files in this folder are automatically shared with other peers.\n"
 "If this folder also holds files you don't want to share, point it at an aMule-only sub-folder."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1715
+#: src/muuli_wdr.cpp:1719
 msgid "Pick the folder where completed downloads will be stored. All files in that folder will be shared with other peers."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1729
+#: src/muuli_wdr.cpp:1733
 msgid "Shared folders"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1735
+#: src/muuli_wdr.cpp:1739
 msgid "(Folders shared by the core. Enter a path to add one.)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1743
+#: src/muuli_wdr.cpp:1747
 msgid "Absolute path of a folder on the core's machine, e.g. /home/user/shared"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1745 src/PrefsUnifiedDlg.cpp:2794
+#: src/muuli_wdr.cpp:1749 src/PrefsUnifiedDlg.cpp:2874
 msgid "Recursive"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1746
+#: src/muuli_wdr.cpp:1750
 msgid "Share every sub-folder underneath this one, including ones created later."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1750 src/utils/aLinkCreator/src/alcframe.cpp:141
+#: src/muuli_wdr.cpp:1754 src/utils/aLinkCreator/src/alcframe.cpp:141
 msgid "Remove"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1754
+#: src/muuli_wdr.cpp:1758
 msgid "(Right click on folder icon for recursive share)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1761
+#: src/muuli_wdr.cpp:1765
 msgid "Share hidden files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1767
+#: src/muuli_wdr.cpp:1771
 msgid "Automatically rescan shared folders for changes"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1773
+#: src/muuli_wdr.cpp:1777
 msgid "Follow symbolic links in shared folders"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1779
+#: src/muuli_wdr.cpp:1783
 msgid "Exclude files matching:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1782
+#: src/muuli_wdr.cpp:1786
 msgid "Wildcard patterns separated by '|', e.g. .DS_Store|Thumbs.db|*.tmp. Files whose name matches are not shared. Matching is case-insensitive."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1786
+#: src/muuli_wdr.cpp:1790
 msgid "Patterns are regular expressions"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1787
+#: src/muuli_wdr.cpp:1791
 msgid "When set, the whole field is one regular expression ('|' is alternation). When unset, it is a list of '|'-separated wildcards."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1797
+#: src/muuli_wdr.cpp:1801
 msgid "Show how many shared files the current pattern would exclude."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1818
+#: src/muuli_wdr.cpp:1822
 msgid "Graphs"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1821 src/muuli_wdr.cpp:1883
+#: src/muuli_wdr.cpp:1825 src/muuli_wdr.cpp:1887
 msgid "Update delay : 5 secs"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1825
+#: src/muuli_wdr.cpp:1829
 msgid "Time for average graph: 100 mins"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1829
+#: src/muuli_wdr.cpp:1833
 msgid "Connections Graph Scale: 100 "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1836
+#: src/muuli_wdr.cpp:1840
 msgid "Download graph scale:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1844
+#: src/muuli_wdr.cpp:1848
 msgid "Upload graph scale:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1854
+#: src/muuli_wdr.cpp:1858
 msgid "Colors: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1858
+#: src/muuli_wdr.cpp:1862
 msgid "Background"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1859
+#: src/muuli_wdr.cpp:1863
 msgid "Grid"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1860
+#: src/muuli_wdr.cpp:1864
 msgid "Download current"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1861
+#: src/muuli_wdr.cpp:1865
 msgid "Download running average"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1862
+#: src/muuli_wdr.cpp:1866
 msgid "Download session average"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1863
+#: src/muuli_wdr.cpp:1867
 msgid "Upload current"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1864
+#: src/muuli_wdr.cpp:1868
 msgid "Upload running average"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1865
+#: src/muuli_wdr.cpp:1869
 msgid "Upload session average"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1866
+#: src/muuli_wdr.cpp:1870
 msgid "Active connections"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1869
+#: src/muuli_wdr.cpp:1873
 msgid "Systray Icon Speed Bar"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1870
+#: src/muuli_wdr.cpp:1874
 msgid "Kad-nodes current"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1871
+#: src/muuli_wdr.cpp:1875
 msgid "Kad-nodes running"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1872
+#: src/muuli_wdr.cpp:1876
 msgid "Kad-nodes session"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1876 src/muuli_wdr.cpp:2303
+#: src/muuli_wdr.cpp:1880 src/muuli_wdr.cpp:2334
 msgid "Select"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1880
+#: src/muuli_wdr.cpp:1884
 msgid "Tree"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1890
+#: src/muuli_wdr.cpp:1894
 msgid "Number of Client Versions shown (0=unlimited)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1915
+#: src/muuli_wdr.cpp:1919
 msgid "!!! WARNING !!!"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1930
+#: src/muuli_wdr.cpp:1934
 msgid "Max new connections / 5 secs"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1932
+#: src/muuli_wdr.cpp:1936
 msgid "Concurrent Kad source lookups"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1934
+#: src/muuli_wdr.cpp:1938
 msgid "Kad source re-search interval (minutes)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1936
+#: src/muuli_wdr.cpp:1940
 msgid "Source re-ask interval (minutes)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1940
+#: src/muuli_wdr.cpp:1944
 msgid "File Buffer Size: 240000 bytes"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1944
+#: src/muuli_wdr.cpp:1948
 msgid "Use MMAP: memory-mapped file access (lower memory use)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1945
+#: src/muuli_wdr.cpp:1949
 msgid "Maps part files into memory instead of buffering them on the heap, lowering the process memory footprint. May reduce download speed on some disks; best for memory-constrained or upload-heavy hosts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1947
+#: src/muuli_wdr.cpp:1951
 msgid "Upload Queue Size: 5000 clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1951
+#: src/muuli_wdr.cpp:1955
 msgid "Server connection refresh interval: Disable"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1955
+#: src/muuli_wdr.cpp:1959
 msgid "Disable computer's timed standby mode"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1974
+#: src/muuli_wdr.cpp:1978
 msgid "Skin to use: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1983
+#: src/muuli_wdr.cpp:1987
 msgid "Show \"Fast eD2k Links Handler\" in every window."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1986
+#: src/muuli_wdr.cpp:1990
 msgid "Show extended info on categories tabs"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1989
+#: src/muuli_wdr.cpp:1993
 msgid "Show application version on title"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1991
+#: src/muuli_wdr.cpp:1995
 msgid "Show transfer rates on title"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1993
+#: src/muuli_wdr.cpp:1997
 msgid "Before application name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1995
+#: src/muuli_wdr.cpp:1999
 msgid "After application name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1998
+#: src/muuli_wdr.cpp:2002
 msgid "Show overhead bandwidth"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2002
+#: src/muuli_wdr.cpp:2006
 msgid "Vertical toolbar orientation"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2004
+#: src/muuli_wdr.cpp:2008
 msgid "Live column sorting (auto-reorder rows as their values change)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2011
+#: src/muuli_wdr.cpp:2015
 msgid "Download Queue Files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2014
+#: src/muuli_wdr.cpp:2018
 msgid "Show progress percentage"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2020
+#: src/muuli_wdr.cpp:2024
 msgid "Show progress bar"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2023
+#: src/muuli_wdr.cpp:2027
 msgid "Flat"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2027
+#: src/muuli_wdr.cpp:2031
 msgid "Round"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2045
+#: src/muuli_wdr.cpp:2049
 msgid "External Connection Parameters"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2048
+#: src/muuli_wdr.cpp:2052
 msgid "Accept external connections"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2055 src/muuli_wdr.cpp:2114
+#: src/muuli_wdr.cpp:2059 src/muuli_wdr.cpp:2118
 msgid "IP of the listening interface:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2058
+#: src/muuli_wdr.cpp:2062
 msgid "Enter here a valid ip in the a.b.c.d format for the listening EC interface. An empty field or 0.0.0.0 will mean any interface."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2079 src/muuli_wdr.cpp:2163
+#: src/muuli_wdr.cpp:2083 src/muuli_wdr.cpp:2194
 msgid "TCP port:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2085
+#: src/muuli_wdr.cpp:2089
 msgid "Enable UPnP port forwarding on the EC port"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2089 src/muuli_wdr.cpp:3048
+#: src/muuli_wdr.cpp:2093 src/muuli_wdr.cpp:3079
 #: src/utils/wxCas/src/wxcasprefs.cpp:167
 msgid "Password"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2095
+#: src/muuli_wdr.cpp:2099
 msgid "aMule API server parameters"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2098
+#: src/muuli_wdr.cpp:2102
 msgid "Run amuleapi (REST API) on startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2103
+#: src/muuli_wdr.cpp:2107
 msgid "HTTP port:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2117
+#: src/muuli_wdr.cpp:2121
 msgid "The interface amuleapi's HTTP server listens on. 127.0.0.1 (default) accepts only local connections; use 0.0.0.0 or a specific IP to expose it to other hosts (set an admin password below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2120
+#: src/muuli_wdr.cpp:2126
+msgid "Type a password to set or change it. Stored passwords cannot be shown, so leaving this empty keeps the current one."
+msgstr ""
+
+#: src/muuli_wdr.cpp:2128
 msgid "Admin password"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2125 src/muuli_wdr.cpp:2156
-msgid "Low rights password"
+#: src/muuli_wdr.cpp:2140 src/muuli_wdr.cpp:2157 src/PrefsUnifiedDlg.cpp:1103
+msgid "A password is set."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2133
+#: src/muuli_wdr.cpp:2144
+msgid "Enable guest access"
+msgstr ""
+
+#: src/muuli_wdr.cpp:2145
+msgid "Guest sessions may read status and listings but cannot change anything. Turning this off clears the stored guest password."
+msgstr ""
+
+#: src/muuli_wdr.cpp:2149
+msgid "Guest password"
+msgstr ""
+
+#: src/muuli_wdr.cpp:2164
 msgid "Web server parameters"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2136
+#: src/muuli_wdr.cpp:2167
 msgid "Run webserver on startup (deprecated)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2142
+#: src/muuli_wdr.cpp:2173
 msgid "Web template"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2147
+#: src/muuli_wdr.cpp:2178
 msgid "Full rights password"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2151
+#: src/muuli_wdr.cpp:2182
 msgid "Enable Low rights User"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2170
+#: src/muuli_wdr.cpp:2187
+msgid "Low rights password"
+msgstr ""
+
+#: src/muuli_wdr.cpp:2201
 msgid "Enable UPnP port forwarding of the web server port"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2175
+#: src/muuli_wdr.cpp:2206
 msgid "Web server UPnP TCP port (Optional)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2183
+#: src/muuli_wdr.cpp:2214
 msgid "Page Refresh Time (in secs)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2190
+#: src/muuli_wdr.cpp:2221
 msgid "Enable Gzip compression"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2224
+#: src/muuli_wdr.cpp:2255
 msgid "Reset page to defaults"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2225
+#: src/muuli_wdr.cpp:2256
 msgid "Reset the settings on the current page to their default values."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2227 src/muuli_wdr.cpp:2313 src/ServerWnd.cpp:274
+#: src/muuli_wdr.cpp:2258 src/muuli_wdr.cpp:2344 src/ServerWnd.cpp:274
 #: src/ServerWnd.cpp:282
 msgid "OK"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2229
+#: src/muuli_wdr.cpp:2260
 msgid "Click here to apply any changes made to the preferences."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2232
+#: src/muuli_wdr.cpp:2263
 msgid "Reset any changes made to the preferences."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2261
+#: src/muuli_wdr.cpp:2292
 msgid "Comment :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2268
+#: src/muuli_wdr.cpp:2299
 msgid "Incoming Dir :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2277
+#: src/muuli_wdr.cpp:2308
 msgid "Change priority for new assigned files :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2281
+#: src/muuli_wdr.cpp:2312
 msgid "Don't change"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2293
+#: src/muuli_wdr.cpp:2324
 msgid "Select color for this Category (currently selected) :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2360 src/muuli_wdr.cpp:2379 src/muuli_wdr.cpp:2401
+#: src/muuli_wdr.cpp:2391 src/muuli_wdr.cpp:2410 src/muuli_wdr.cpp:2432
 msgid "Click this button to reset the log."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2420
+#: src/muuli_wdr.cpp:2451
 msgid "Click on this button to update the servers list from URL ..."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2424
+#: src/muuli_wdr.cpp:2455
 msgid "Server list"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2428
+#: src/muuli_wdr.cpp:2459
 msgid "Enter the url to a server.met file here and press the button to the left to update the list of known servers."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2433
+#: src/muuli_wdr.cpp:2464
 msgid "Add server manually: Name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2436
+#: src/muuli_wdr.cpp:2467
 msgid "Enter the name of the new server here"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2438 src/ServerWnd.cpp:206
+#: src/muuli_wdr.cpp:2469 src/ServerWnd.cpp:206
 msgid "IP:Port"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2441
+#: src/muuli_wdr.cpp:2472
 msgid "Enter the IP of the server here, using the x.x.x.x format."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2447
+#: src/muuli_wdr.cpp:2478
 msgid "Enter the port of the server here."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2450
+#: src/muuli_wdr.cpp:2481
 msgid "Add manually a server (fill fields to the left before) ..."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2479
+#: src/muuli_wdr.cpp:2510
 msgid "aMule Log"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2487
+#: src/muuli_wdr.cpp:2518
 msgid "Server Info"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2491
+#: src/muuli_wdr.cpp:2522
 msgid "ED2K Info"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2495
+#: src/muuli_wdr.cpp:2526
 msgid "Kad Info"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2523
+#: src/muuli_wdr.cpp:2554
 msgid "Click on this button to update the nodes list from URL ..."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2527
+#: src/muuli_wdr.cpp:2558
 msgid "Nodes (0)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2531
+#: src/muuli_wdr.cpp:2562
 msgid "Enter the url to a nodes.dat file here and press the button to the left to update the list of known nodes."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2534
+#: src/muuli_wdr.cpp:2565
 msgid "Nodes stats"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2576
+#: src/muuli_wdr.cpp:2607
 msgid "Bootstrap"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2579
+#: src/muuli_wdr.cpp:2610
 msgid "New node"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2584
+#: src/muuli_wdr.cpp:2615
 msgid "IP:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2604
+#: src/muuli_wdr.cpp:2635
 msgid "Port:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2617
+#: src/muuli_wdr.cpp:2648
 msgid "Bootstrap from known clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2619
+#: src/muuli_wdr.cpp:2650
 msgid "Disconnect Kad"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2653
+#: src/muuli_wdr.cpp:2684
 msgid "Use Secure User Identification"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2655
+#: src/muuli_wdr.cpp:2686
 msgid "It is recommended to enable this option. You will not receive credits if SUI is not enabled."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2657
+#: src/muuli_wdr.cpp:2688
 msgid "Protocol Obfuscation"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2660
+#: src/muuli_wdr.cpp:2691
 msgid "Support Protocol Obfuscation"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2662
+#: src/muuli_wdr.cpp:2693
 msgid "This option enabled Protocol Obfuscation, and makes aMule accept obfuscated connections from other clients."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2664
+#: src/muuli_wdr.cpp:2695
 msgid "Use obfuscation for outgoing connections"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2666
+#: src/muuli_wdr.cpp:2697
 msgid "This option makes aMule use Protocol Obfuscation when connecting other clients/servers."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2668
+#: src/muuli_wdr.cpp:2699
 msgid "Accept only obfuscated connections"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2669
+#: src/muuli_wdr.cpp:2700
 msgid "This option makes aMule only accept obfuscated connections. You will have less sources, but all your traffic will be obfuscated"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2674
+#: src/muuli_wdr.cpp:2705
 msgid "Everybody"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2676
+#: src/muuli_wdr.cpp:2707
 msgid "No one"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2678
+#: src/muuli_wdr.cpp:2709
 msgid "Who can see my shared files:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2679
+#: src/muuli_wdr.cpp:2710
 msgid "Select who can request to view a list of your shared files."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2681
+#: src/muuli_wdr.cpp:2712
 msgid "IP-Filtering"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2688
+#: src/muuli_wdr.cpp:2719
 msgid "Filter clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2690
+#: src/muuli_wdr.cpp:2721
 msgid "Enable filtering of the client IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2692
+#: src/muuli_wdr.cpp:2723
 msgid "Filter servers"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2694
+#: src/muuli_wdr.cpp:2725
 msgid "Enable filtering of the server IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2698
+#: src/muuli_wdr.cpp:2729
 msgid "Reload List"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2699
+#: src/muuli_wdr.cpp:2730
 msgid "Reload the list of IPs to filter from the file ~/.aMule/ipfilter.dat"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2705
+#: src/muuli_wdr.cpp:2736
 msgid "URL:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2709 src/muuli_wdr.cpp:2902
+#: src/muuli_wdr.cpp:2740 src/muuli_wdr.cpp:2933
 msgid "Update now"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2712
+#: src/muuli_wdr.cpp:2743
 msgid "Auto-update ipfilter at startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2716
+#: src/muuli_wdr.cpp:2747
 msgid "Filtering Level:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2722
+#: src/muuli_wdr.cpp:2753
 msgid "Always filter LAN IPs"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2725
+#: src/muuli_wdr.cpp:2756
 msgid "Paranoid handling of non-matching IPs"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2727
+#: src/muuli_wdr.cpp:2758
 msgid "Rejects a packet when its source IP differs from the IP the client claims (an anti-spoofing check). Disable only if it causes connection problems."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2729
+#: src/muuli_wdr.cpp:2760
 msgid "Use system-wide ipfilter.dat if available"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2730
+#: src/muuli_wdr.cpp:2761
 msgid "If there's no local ipfilter.dat found, allow usage of a system-wide ipfilter file."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2747
+#: src/muuli_wdr.cpp:2778
 msgid "Enable Online-Signature"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2749
+#: src/muuli_wdr.cpp:2780
 msgid "Enables the writing of the OS file, which can be used by external apps to create signatures and the like."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2753
+#: src/muuli_wdr.cpp:2784
 msgid "Update Frequency (Secs):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2756
+#: src/muuli_wdr.cpp:2787
 msgid "Change the frequency (in seconds) of Online Signature updates."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2764
+#: src/muuli_wdr.cpp:2795
 msgid "Save online signature file in: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:2770
+#: src/muuli_wdr.cpp:2801
 msgid "Click here to select the directory containing the the Online Signature files."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2803
+#: src/muuli_wdr.cpp:2834
 msgid "Show country flags for clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2804
+#: src/muuli_wdr.cpp:2835
 msgid "Render the country flag column in the transfers, queue and search views. Requires a valid MMDB GeoIP database (see below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2809
+#: src/muuli_wdr.cpp:2840
 msgid "Database"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2825
+#: src/muuli_wdr.cpp:2856
 msgid "Source:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2828
+#: src/muuli_wdr.cpp:2859
 msgid "DB-IP (free, no account)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2829
+#: src/muuli_wdr.cpp:2860
 msgid "MaxMind GeoLite2 (free, account required)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2830
+#: src/muuli_wdr.cpp:2861
 msgid "Custom URL"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2833
+#: src/muuli_wdr.cpp:2864
 msgid "Choose which provider supplies the GeoIP MMDB database. DB-IP is the default - no account required. MaxMind requires a free account + license key. Use Custom URL to point at any other MMDB host (e.g. a local mirror)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2850
+#: src/muuli_wdr.cpp:2881
 msgid ""
 "No configuration required.\n"
 "\n"
@@ -4736,11 +4761,11 @@ msgid ""
 "License: Creative Commons BY 4.0 - https://creativecommons.org/licenses/by/4.0/"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2863
+#: src/muuli_wdr.cpp:2894
 msgid "License key:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2869
+#: src/muuli_wdr.cpp:2900
 msgid ""
 "Sign up for a free MaxMind account, then generate a License Key:\n"
 "https://www.maxmind.com/en/geolite2/signup\n"
@@ -4750,222 +4775,222 @@ msgid ""
 "Requires attribution and account registration; refresh at least every 30 days."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2884
+#: src/muuli_wdr.cpp:2915
 msgid "Download URL:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2890
+#: src/muuli_wdr.cpp:2921
 msgid ""
 "Must point to an .mmdb file or a .gz / .tar.gz containing one.\n"
 "URL may include credentials (https://user:pass@host/...).\n"
 "License and attribution terms are set by the upstream URL - you are responsible."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2903
+#: src/muuli_wdr.cpp:2934
 msgid "Download the GeoIP database from the selected source."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2905
+#: src/muuli_wdr.cpp:2936
 msgid "Auto-update on startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2906
+#: src/muuli_wdr.cpp:2937
 msgid "Re-download the GeoIP database from the selected source every time aMule starts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2929
+#: src/muuli_wdr.cpp:2960
 msgid "Filter incoming messages (except current chat):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2931
+#: src/muuli_wdr.cpp:2962
 msgid "Filter all messages"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2933
+#: src/muuli_wdr.cpp:2964
 msgid "Filter messages from people not on your friend list"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2935
+#: src/muuli_wdr.cpp:2966
 msgid "Filter messages from unknown clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2937
+#: src/muuli_wdr.cpp:2968
 msgid "Filter messages containing (use ',' as separator):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2940 src/muuli_wdr.cpp:2951
+#: src/muuli_wdr.cpp:2971 src/muuli_wdr.cpp:2982
 msgid "add here the words amule should filter and block messages including it"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2942
+#: src/muuli_wdr.cpp:2973
 msgid "Show received messages in the log"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2945
+#: src/muuli_wdr.cpp:2976
 msgid "Comments"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2948
+#: src/muuli_wdr.cpp:2979
 msgid "Filter comments containing (use ',' as separator):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2973
+#: src/muuli_wdr.cpp:3004
 msgid "Enable Proxy"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2974
+#: src/muuli_wdr.cpp:3005
 msgid "Enable/disable proxy support"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2977
+#: src/muuli_wdr.cpp:3008
 msgid "Proxy type:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2988
+#: src/muuli_wdr.cpp:3019
 msgid "Proxy host:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2991
+#: src/muuli_wdr.cpp:3022
 msgid "The proxy host name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2993
+#: src/muuli_wdr.cpp:3024
 msgid "Proxy port:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2996
+#: src/muuli_wdr.cpp:3027
 msgid "The proxy port"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2998
+#: src/muuli_wdr.cpp:3029
 msgid "Enable authentication"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2999
+#: src/muuli_wdr.cpp:3030
 msgid "Enable/disable username/password authentication"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3002
+#: src/muuli_wdr.cpp:3033
 msgid "Username: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:3005
+#: src/muuli_wdr.cpp:3036
 msgid "The username to use to connect to the proxy"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3007
+#: src/muuli_wdr.cpp:3038
 msgid "Password:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3010
+#: src/muuli_wdr.cpp:3041
 msgid "The password to use to connect to the proxy"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3029
+#: src/muuli_wdr.cpp:3060
 msgid "Connect to:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3038
+#: src/muuli_wdr.cpp:3069
 msgid "Login to remote amule"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3043
+#: src/muuli_wdr.cpp:3074
 msgid "User name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3054
+#: src/muuli_wdr.cpp:3085
 msgid "Remember those settings"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3057
+#: src/muuli_wdr.cpp:3088
 msgid "Force ZLIB compression"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3081
+#: src/muuli_wdr.cpp:3112
 msgid "Enable Verbose Debug-Logging."
 msgstr ""
 
-#: src/muuli_wdr.cpp:3083
+#: src/muuli_wdr.cpp:3114
 msgid "Only to Logfile"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3085
+#: src/muuli_wdr.cpp:3116
 msgid "Message Categories:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3109 src/PartFileConvertDlg.cpp:160
+#: src/muuli_wdr.cpp:3140 src/PartFileConvertDlg.cpp:160
 msgid "Waiting..."
 msgstr ""
 
-#: src/muuli_wdr.cpp:3129
+#: src/muuli_wdr.cpp:3160
 msgid "Add imports"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3132
+#: src/muuli_wdr.cpp:3163
 msgid "Retry selected"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3134
+#: src/muuli_wdr.cpp:3165
 msgid "Remove selected"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3197
+#: src/muuli_wdr.cpp:3228
 msgid "Event Types"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3216
+#: src/muuli_wdr.cpp:3247
 msgid "Statistics and queued clients for selected file(s) : Session / All time"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3240
+#: src/muuli_wdr.cpp:3271
 msgid "Active Uploads"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3254
+#: src/muuli_wdr.cpp:3285
 msgid "Percent of total files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3306
+#: src/muuli_wdr.cpp:3337
 msgid "Show Clients for"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3308
+#: src/muuli_wdr.cpp:3339
 msgid "All files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3311
+#: src/muuli_wdr.cpp:3342
 msgid "Selected files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3314
+#: src/muuli_wdr.cpp:3345
 msgid "Active uploads only"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3321
+#: src/muuli_wdr.cpp:3352
 msgid "Reload:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3325
+#: src/muuli_wdr.cpp:3356
 msgid "Reload your shared files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3388
+#: src/muuli_wdr.cpp:3419
 msgid "Send"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3389
+#: src/muuli_wdr.cpp:3420
 msgid "Sends the specified message."
 msgstr ""
 
-#: src/muuli_wdr.cpp:3393
+#: src/muuli_wdr.cpp:3424
 msgid "Close this chat-session."
 msgstr ""
 
-#: src/muuli_wdr.cpp:3416
+#: src/muuli_wdr.cpp:3447
 msgid "Connect to any server and/or Kad"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3422 src/SharedFilesCtrl.cpp:142 src/Statistics.cpp:941
+#: src/muuli_wdr.cpp:3453 src/SharedFilesCtrl.cpp:142 src/Statistics.cpp:941
 msgid "Shared Files"
 msgstr ""
 
@@ -5323,263 +5348,263 @@ msgstr ""
 msgid "ERROR: Failed to open partfile '%s'"
 msgstr ""
 
-#: src/Preferences.cpp:674
+#: src/Preferences.cpp:701
 msgid "System default"
 msgstr ""
 
-#: src/Preferences.cpp:675
+#: src/Preferences.cpp:702
 msgid "Albanian"
 msgstr ""
 
-#: src/Preferences.cpp:676
+#: src/Preferences.cpp:703
 msgid "Arabic"
 msgstr ""
 
-#: src/Preferences.cpp:677
+#: src/Preferences.cpp:704
 msgid "Asturian"
 msgstr ""
 
-#: src/Preferences.cpp:678
+#: src/Preferences.cpp:705
 msgid "Basque"
 msgstr ""
 
-#: src/Preferences.cpp:679
+#: src/Preferences.cpp:706
 msgid "Bulgarian"
 msgstr ""
 
-#: src/Preferences.cpp:680
+#: src/Preferences.cpp:707
 msgid "Catalan"
 msgstr ""
 
-#: src/Preferences.cpp:681
+#: src/Preferences.cpp:708
 msgid "Chinese (Simplified)"
 msgstr ""
 
-#: src/Preferences.cpp:682
+#: src/Preferences.cpp:709
 msgid "Chinese (Traditional)"
 msgstr ""
 
-#: src/Preferences.cpp:683
+#: src/Preferences.cpp:710
 msgid "Croatian"
 msgstr ""
 
-#: src/Preferences.cpp:684
+#: src/Preferences.cpp:711
 msgid "Czech"
 msgstr ""
 
-#: src/Preferences.cpp:685
+#: src/Preferences.cpp:712
 msgid "Danish"
 msgstr ""
 
-#: src/Preferences.cpp:686
+#: src/Preferences.cpp:713
 msgid "Dutch"
 msgstr ""
 
-#: src/Preferences.cpp:687
+#: src/Preferences.cpp:714
 msgid "English (U.K.)"
 msgstr ""
 
-#: src/Preferences.cpp:688
+#: src/Preferences.cpp:715
 msgid "English (U.S.)"
 msgstr ""
 
-#: src/Preferences.cpp:689
+#: src/Preferences.cpp:716
 msgid "Estonian"
 msgstr ""
 
-#: src/Preferences.cpp:690
+#: src/Preferences.cpp:717
 msgid "Finnish"
 msgstr ""
 
-#: src/Preferences.cpp:691
+#: src/Preferences.cpp:718
 msgid "French"
 msgstr ""
 
-#: src/Preferences.cpp:692
+#: src/Preferences.cpp:719
 msgid "Galician"
 msgstr ""
 
-#: src/Preferences.cpp:693
+#: src/Preferences.cpp:720
 msgid "German"
 msgstr ""
 
-#: src/Preferences.cpp:694
+#: src/Preferences.cpp:721
 msgid "Greek"
 msgstr ""
 
-#: src/Preferences.cpp:695
+#: src/Preferences.cpp:722
 msgid "Hebrew"
 msgstr ""
 
-#: src/Preferences.cpp:696
+#: src/Preferences.cpp:723
 msgid "Hungarian"
 msgstr ""
 
-#: src/Preferences.cpp:697
+#: src/Preferences.cpp:724
 msgid "Italian"
 msgstr ""
 
-#: src/Preferences.cpp:698
+#: src/Preferences.cpp:725
 msgid "Japanese"
 msgstr ""
 
-#: src/Preferences.cpp:699
+#: src/Preferences.cpp:726
 msgid "Korean"
 msgstr ""
 
-#: src/Preferences.cpp:700
+#: src/Preferences.cpp:727
 msgid "Latvian"
 msgstr ""
 
-#: src/Preferences.cpp:701
+#: src/Preferences.cpp:728
 msgid "Lithuanian"
 msgstr ""
 
-#: src/Preferences.cpp:702
+#: src/Preferences.cpp:729
 msgid "Norwegian (Nynorsk)"
 msgstr ""
 
-#: src/Preferences.cpp:703
+#: src/Preferences.cpp:730
 msgid "Polish"
 msgstr ""
 
-#: src/Preferences.cpp:704
+#: src/Preferences.cpp:731
 msgid "Portuguese"
 msgstr ""
 
-#: src/Preferences.cpp:705
+#: src/Preferences.cpp:732
 msgid "Portuguese (Brazilian)"
 msgstr ""
 
-#: src/Preferences.cpp:706
+#: src/Preferences.cpp:733
 msgid "Romanian"
 msgstr ""
 
-#: src/Preferences.cpp:707
+#: src/Preferences.cpp:734
 msgid "Russian"
 msgstr ""
 
-#: src/Preferences.cpp:708
+#: src/Preferences.cpp:735
 msgid "Slovenian"
 msgstr ""
 
-#: src/Preferences.cpp:709
+#: src/Preferences.cpp:736
 msgid "Spanish"
 msgstr ""
 
-#: src/Preferences.cpp:710
+#: src/Preferences.cpp:737
 msgid "Swedish"
 msgstr ""
 
-#: src/Preferences.cpp:711
+#: src/Preferences.cpp:738
 msgid "Turkish"
 msgstr ""
 
-#: src/Preferences.cpp:712
+#: src/Preferences.cpp:739
 msgid "Ukrainian"
 msgstr ""
 
-#: src/Preferences.cpp:815
+#: src/Preferences.cpp:842
 msgid "Change Language"
 msgstr ""
 
-#: src/Preferences.cpp:879
+#: src/Preferences.cpp:906
 msgid "There are no translations installed for aMule"
 msgstr ""
 
-#: src/Preferences.cpp:880
+#: src/Preferences.cpp:907
 msgid "No languages available"
 msgstr ""
 
-#: src/Preferences.cpp:1011
+#: src/Preferences.cpp:1038
 msgid "no options available"
 msgstr ""
 
-#: src/Preferences.cpp:2182
+#: src/Preferences.cpp:2227
 msgid "Invalid category found, skipping"
 msgstr ""
 
-#: src/Preferences.cpp:2351
+#: src/Preferences.cpp:2396
 msgid "TCP port can't be higher than 65532 due to server UDP socket being TCP+3"
 msgstr ""
 
-#: src/Preferences.cpp:2352
+#: src/Preferences.cpp:2397
 #, c-format
 msgid "Default port will be used (%d)"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:298 src/Statistics.cpp:866
+#: src/PrefsUnifiedDlg.cpp:300 src/Statistics.cpp:866
 msgid "Connection"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:299 src/SearchListCtrl.cpp:117
+#: src/PrefsUnifiedDlg.cpp:301 src/SearchListCtrl.cpp:117
 msgid "Directories"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:300 src/Statistics.cpp:917
+#: src/PrefsUnifiedDlg.cpp:302 src/Statistics.cpp:917
 msgid "Servers"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:301 src/ServerListCtrl.cpp:96
+#: src/PrefsUnifiedDlg.cpp:303 src/ServerListCtrl.cpp:96
 msgid "Files"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:302
+#: src/PrefsUnifiedDlg.cpp:304
 msgid "Security"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:303
+#: src/PrefsUnifiedDlg.cpp:305
 msgid "Interface"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:310
+#: src/PrefsUnifiedDlg.cpp:312
 msgid "IP2Country"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:313
+#: src/PrefsUnifiedDlg.cpp:315
 msgid "Proxy"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:314
+#: src/PrefsUnifiedDlg.cpp:316
 msgid "Filters"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:315
+#: src/PrefsUnifiedDlg.cpp:317
 msgid "Remote Controls"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:316
+#: src/PrefsUnifiedDlg.cpp:318
 msgid "Online Signature"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:317
+#: src/PrefsUnifiedDlg.cpp:319
 msgid "Advanced"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:318
+#: src/PrefsUnifiedDlg.cpp:320
 msgid "Events"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:321
+#: src/PrefsUnifiedDlg.cpp:323
 msgid "Debugging"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:451
+#: src/PrefsUnifiedDlg.cpp:453
 msgid ""
 "The following variables will be substituted:\n"
 "    %PARTFILE - full path to the file\n"
 "    %PARTNAME - file name only"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:472
+#: src/PrefsUnifiedDlg.cpp:474
 msgid "Tray icon support requires libayatana-appindicator3 at compile time."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:488
+#: src/PrefsUnifiedDlg.cpp:490
 msgid "Not available on Wayland: the protocol does not report when a window is minimized, so this option cannot intercept the system minimize button. Workaround: launch aMule with `GDK_BACKEND=x11` to use XWayland instead."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:534
+#: src/PrefsUnifiedDlg.cpp:536
 msgid ""
 "Do not change these setting unless you know\n"
 "what you are doing, otherwise you can easily\n"
@@ -5589,387 +5614,400 @@ msgid ""
 "these settings."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:645
+#: src/PrefsUnifiedDlg.cpp:647
 #, c-format
 msgid "Failed to connect Cfg to widget with the ID %d and key %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:693
+#: src/PrefsUnifiedDlg.cpp:695
 #, c-format
 msgid "Failed to transfer data from Cfg to Widget with the ID %d and key %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:799
+#: src/PrefsUnifiedDlg.cpp:801
 msgid "The type of proxy you are connecting to"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1003
+#: src/PrefsUnifiedDlg.cpp:1020
 #, c-format
 msgid "Failed to transfer data from Widget to Cfg with the ID %d and key %s"
 msgstr ""
 
 #: src/PrefsUnifiedDlg.cpp:1103
+msgid "No password set."
+msgstr ""
+
+#: src/PrefsUnifiedDlg.cpp:1132
+msgid "Guest access needs a password. Type one in the guest password field, or untick Enable guest access."
+msgstr ""
+
+#: src/PrefsUnifiedDlg.cpp:1144
 msgid ""
 "aMule must be restarted to enable these changes:\n"
 "\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1110
+#: src/PrefsUnifiedDlg.cpp:1151
 msgid "- TCP port changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1115
+#: src/PrefsUnifiedDlg.cpp:1156
 msgid "- UDP port changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1120
+#: src/PrefsUnifiedDlg.cpp:1161
 msgid "- Network interface binding changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1125
+#: src/PrefsUnifiedDlg.cpp:1166
 msgid "- External connect port changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1129
+#: src/PrefsUnifiedDlg.cpp:1170
 msgid "- External connect acceptance changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1133
+#: src/PrefsUnifiedDlg.cpp:1174
 msgid "- External connect interface changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1137
+#: src/PrefsUnifiedDlg.cpp:1178
 msgid "- Protocol obfuscation support changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1151
+#: src/PrefsUnifiedDlg.cpp:1193
 msgid "- amuleapi settings changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1160
+#: src/PrefsUnifiedDlg.cpp:1202
 msgid ""
 "Your Auto-update server list is empty.\n"
 "'Auto-update server list at startup' will be disabled."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1171
+#: src/PrefsUnifiedDlg.cpp:1213
 msgid ""
 "You have enabled external connections but have not specified a password.\n"
 "External connections cannot be enabled unless a valid password is specified."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1202
+#: src/PrefsUnifiedDlg.cpp:1246
+#, c-format
+msgid "The amuleapi password could not be saved: %s"
+msgstr ""
+
+#: src/PrefsUnifiedDlg.cpp:1276
 msgid "- Language changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1207
+#: src/PrefsUnifiedDlg.cpp:1281
 msgid "- Temp folder changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1212
+#: src/PrefsUnifiedDlg.cpp:1286
 msgid "- ED2K network enabled.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1245
+#: src/PrefsUnifiedDlg.cpp:1319
 msgid "The shared-file exclusion pattern is not a valid regular expression. The filter has been left disabled."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1247 src/PrefsUnifiedDlg.cpp:1841
+#: src/PrefsUnifiedDlg.cpp:1321 src/PrefsUnifiedDlg.cpp:1921
 msgid "Invalid regular expression"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1324
+#: src/PrefsUnifiedDlg.cpp:1398
 msgid ""
 "Both eD2k and Kad network are disabled.\n"
 "You won't be able to connect until you enable at least one of them."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1329
+#: src/PrefsUnifiedDlg.cpp:1403
 msgid ""
 "Kad will not start if your UDP port is disabled.\n"
 "Enable UDP port or disable Kad."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1385
+#: src/PrefsUnifiedDlg.cpp:1459
 msgid ""
 "\n"
 "You MUST restart aMule now.\n"
 "If you do not restart now, don't complain if anything bad happens.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1450
+#: src/PrefsUnifiedDlg.cpp:1524
 msgid "Could not register aMule for autostart at login. The autostart store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1452
+#: src/PrefsUnifiedDlg.cpp:1526
 msgid "Could not remove the autostart-at-login entry."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1453
+#: src/PrefsUnifiedDlg.cpp:1527
 msgid "Autostart"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1468
+#: src/PrefsUnifiedDlg.cpp:1542
 msgid "Register file type"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1468
+#: src/PrefsUnifiedDlg.cpp:1542
 msgid "Register URL handler"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1476
+#: src/PrefsUnifiedDlg.cpp:1550
 #, c-format
 msgid "aMule only handles eD2k-compatible magnets. If you replace the current magnet handler (%s), BitTorrent magnet links will stop working - aMule cannot download BitTorrent content. Continue?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1481
+#: src/PrefsUnifiedDlg.cpp:1555
 #, c-format
 msgid "Another application currently opens .emulecollection files (%s). Replace it with aMule?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1486
+#: src/PrefsUnifiedDlg.cpp:1560
 #, c-format
 msgid "Another application is currently the default handler for these links (%s). Replace it with aMule?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1511
+#: src/PrefsUnifiedDlg.cpp:1585
 msgid "Could not register aMule for .emulecollection files. The registration store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1513
+#: src/PrefsUnifiedDlg.cpp:1587
 msgid "Could not remove the file type registration."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1515
+#: src/PrefsUnifiedDlg.cpp:1589
 msgid "Could not register aMule as the URL handler. The registration store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1517
+#: src/PrefsUnifiedDlg.cpp:1591
 msgid "Could not remove the URL handler registration."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1587 src/PrefsUnifiedDlg.cpp:1614
+#: src/PrefsUnifiedDlg.cpp:1661 src/PrefsUnifiedDlg.cpp:1688
 msgid "The web server and aMule API require external connections to be enabled."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1597
+#: src/PrefsUnifiedDlg.cpp:1671
 msgid "The aMule web server is deprecated. Consider running the aMule API instead."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1655
+#: src/PrefsUnifiedDlg.cpp:1735
 msgid ""
 "Your Auto-update servers list is in blank.\n"
 "Please fill in at least one URL to point to a valid server.met file.\n"
 "Click on the button \"List\" by this checkbox to enter an URL."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1796
+#: src/PrefsUnifiedDlg.cpp:1876
 msgid "Temporary files"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1801
+#: src/PrefsUnifiedDlg.cpp:1881
 msgid "Incoming files"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1806
+#: src/PrefsUnifiedDlg.cpp:1886
 msgid "Online Signatures"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1819
+#: src/PrefsUnifiedDlg.cpp:1899
 #, c-format
 msgid "Choose a folder for %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1843
+#: src/PrefsUnifiedDlg.cpp:1923
 #, c-format
 msgid "Would exclude %u of %u shared file"
 msgid_plural "Would exclude %u of %u shared files"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/PrefsUnifiedDlg.cpp:1860
+#: src/PrefsUnifiedDlg.cpp:1940
 msgid "Browse for videoplayer"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1864
+#: src/PrefsUnifiedDlg.cpp:1944
 msgid "Select browser"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1868
+#: src/PrefsUnifiedDlg.cpp:1948
 msgid "Select ffprobe binary"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1874
+#: src/PrefsUnifiedDlg.cpp:1954
 #, c-format
 msgid "Executable%s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1908
+#: src/PrefsUnifiedDlg.cpp:1988
 msgid "ffprobe not found on PATH or in the standard install locations. Install ffmpeg (which ships ffprobe) or use Browse to pick a binary manually."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1920
+#: src/PrefsUnifiedDlg.cpp:2000
 msgid "Reset the settings on this page to their default values?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1921
+#: src/PrefsUnifiedDlg.cpp:2001
 msgid "Reset to defaults"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1948
+#: src/PrefsUnifiedDlg.cpp:2028
 msgid "Edit server list"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1949
+#: src/PrefsUnifiedDlg.cpp:2029
 msgid ""
 "Add here URL's to download server.met files.\n"
 "Only one url on each line."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2004
+#: src/PrefsUnifiedDlg.cpp:2084
 msgid "IP2Country update failed"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2149 src/PrefsUnifiedDlg.cpp:2180
+#: src/PrefsUnifiedDlg.cpp:2229 src/PrefsUnifiedDlg.cpp:2260
 msgid "Data by MaxMind GeoLite2"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2151 src/PrefsUnifiedDlg.cpp:2182
+#: src/PrefsUnifiedDlg.cpp:2231 src/PrefsUnifiedDlg.cpp:2262
 msgid "Custom source"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2153 src/PrefsUnifiedDlg.cpp:2184
+#: src/PrefsUnifiedDlg.cpp:2233 src/PrefsUnifiedDlg.cpp:2264
 msgid "Data by DB-IP.com"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2204
+#: src/PrefsUnifiedDlg.cpp:2284
 #, c-format
 msgid "Status: Loaded%s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2206
+#: src/PrefsUnifiedDlg.cpp:2286
 #, c-format
 msgid "Status: Loaded%s - %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2210
+#: src/PrefsUnifiedDlg.cpp:2290
 msgid "Status: Failed to load - click 'Update now' to refresh."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2212
+#: src/PrefsUnifiedDlg.cpp:2292
 msgid "Status: Not found - click 'Update now' to download."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2270 src/PrefsUnifiedDlg.cpp:2294
+#: src/PrefsUnifiedDlg.cpp:2350 src/PrefsUnifiedDlg.cpp:2374
 #, c-format
 msgid "Update delay: %d second"
 msgid_plural "Update delay: %d seconds"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/PrefsUnifiedDlg.cpp:2278
+#: src/PrefsUnifiedDlg.cpp:2358
 #, c-format
 msgid "Time for average graph: %d minute"
 msgid_plural "Time for average graph: %d minutes"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/PrefsUnifiedDlg.cpp:2287
+#: src/PrefsUnifiedDlg.cpp:2367
 #, c-format
 msgid "Connections Graph Scale: %d"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2302
+#: src/PrefsUnifiedDlg.cpp:2382
 #, c-format
 msgid "File Buffer Size: %d byte"
 msgid_plural "File Buffer Size: %d bytes"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/PrefsUnifiedDlg.cpp:2312
+#: src/PrefsUnifiedDlg.cpp:2392
 #, c-format
 msgid "Upload Queue Size: %d client"
 msgid_plural "Upload Queue Size: %d clients"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/PrefsUnifiedDlg.cpp:2322
+#: src/PrefsUnifiedDlg.cpp:2402
 #, c-format
 msgid "Server connection refresh interval: %d minute"
 msgid_plural "Server connection refresh interval: %d minutes"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/PrefsUnifiedDlg.cpp:2327
+#: src/PrefsUnifiedDlg.cpp:2407
 msgid "Server connection refresh interval: Disabled"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2371
+#: src/PrefsUnifiedDlg.cpp:2451
 msgid "disabled"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2397
+#: src/PrefsUnifiedDlg.cpp:2477
 #, c-format
 msgid "Execute command on '%s' event"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2404
+#: src/PrefsUnifiedDlg.cpp:2484
 msgid "Enable command execution on core"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2416
+#: src/PrefsUnifiedDlg.cpp:2496
 msgid "Core command:"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2432
+#: src/PrefsUnifiedDlg.cpp:2512
 msgid "Enable command execution on GUI"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2444
+#: src/PrefsUnifiedDlg.cpp:2524
 msgid "GUI command:"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2460
+#: src/PrefsUnifiedDlg.cpp:2540
 msgid "The following variables will be replaced:"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2628
+#: src/PrefsUnifiedDlg.cpp:2708
 msgid ""
 "The following folders look like system or sensitive locations:\n"
 "\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2633
+#: src/PrefsUnifiedDlg.cpp:2713
 msgid "Sharing them recursively will publish every file underneath on the eD2k/Kad networks. Do you really want to do this?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2636
+#: src/PrefsUnifiedDlg.cpp:2716
 msgid "Confirm shared folders"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2664
+#: src/PrefsUnifiedDlg.cpp:2744
 msgid "Reloading shared files..."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2665
+#: src/PrefsUnifiedDlg.cpp:2745
 msgid "Scanning for subdirectories..."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2666
+#: src/PrefsUnifiedDlg.cpp:2746
 msgid "Updating shared folders"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2693
+#: src/PrefsUnifiedDlg.cpp:2773
 #, c-format
 msgid "Scanned %u directories..."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2743
+#: src/PrefsUnifiedDlg.cpp:2823
 #, c-format
 msgid "Reloading shared files: %u files scanned"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2793
+#: src/PrefsUnifiedDlg.cpp:2873
 msgid "Shared folder"
 msgstr ""
 

--- a/po/ta.po
+++ b/po/ta.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-28 12:17+0200\n"
+"POT-Creation-Date: 2026-07-28 13:09+0200\n"
 "PO-Revision-Date: 2026-07-27 11:50+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: none\n"
@@ -275,7 +275,7 @@ msgid "Password set and external connections enabled."
 msgstr ""
 
 #: src/amule.cpp:755 src/KadDlg.cpp:176 src/KadDlg.cpp:185
-#: src/PrefsUnifiedDlg.cpp:1461 src/SharedFilesCtrl.cpp:476
+#: src/PrefsUnifiedDlg.cpp:1470 src/SharedFilesCtrl.cpp:476
 msgid "WARNING"
 msgstr ""
 
@@ -310,7 +310,7 @@ msgstr ""
 #: src/amule-remote-gui.cpp:603 src/amule-remote-gui.cpp:671
 #: src/amule-remote-gui.cpp:709 src/amule-remote-gui.cpp:1282
 #: src/amule-remote-gui.cpp:1345 src/amule-remote-gui.cpp:1372
-#: src/DownloadQueue.cpp:1481 src/PrefsUnifiedDlg.cpp:1247
+#: src/DownloadQueue.cpp:1481 src/PrefsUnifiedDlg.cpp:1256
 msgid "ERROR"
 msgstr ""
 
@@ -563,36 +563,36 @@ msgstr ""
 msgid "FATAL ERROR: Failed to create Timer"
 msgstr ""
 
-#: src/amuleDlg.cpp:361 src/amuleDlg.cpp:1787 src/amuleDlg.cpp:2033
-#: src/muuli_wdr.cpp:1492 src/muuli_wdr.cpp:3449
+#: src/amuleDlg.cpp:361 src/amuleDlg.cpp:1810 src/amuleDlg.cpp:2056
+#: src/muuli_wdr.cpp:1492 src/muuli_wdr.cpp:3453
 msgid "Networks"
 msgstr ""
 
-#: src/amuleDlg.cpp:362 src/amuleDlg.cpp:1793 src/muuli_wdr.cpp:3450
+#: src/amuleDlg.cpp:362 src/amuleDlg.cpp:1816 src/muuli_wdr.cpp:3454
 msgid "Searches"
 msgstr ""
 
-#: src/amuleDlg.cpp:363 src/amuleDlg.cpp:1799 src/DownloadListCtrl.cpp:740
-#: src/muuli_wdr.cpp:392 src/muuli_wdr.cpp:1585 src/muuli_wdr.cpp:3451
+#: src/amuleDlg.cpp:363 src/amuleDlg.cpp:1822 src/DownloadListCtrl.cpp:740
+#: src/muuli_wdr.cpp:392 src/muuli_wdr.cpp:1585 src/muuli_wdr.cpp:3455
 #: src/Statistics.cpp:829
 msgid "Downloads"
 msgstr ""
 
-#: src/amuleDlg.cpp:364 src/amuleDlg.cpp:1805 src/muuli_wdr.cpp:3325
+#: src/amuleDlg.cpp:364 src/amuleDlg.cpp:1828 src/muuli_wdr.cpp:3329
 msgid "Shared files"
 msgstr ""
 
-#: src/amuleDlg.cpp:365 src/amuleDlg.cpp:1811 src/muuli_wdr.cpp:2957
-#: src/muuli_wdr.cpp:3407 src/muuli_wdr.cpp:3454
+#: src/amuleDlg.cpp:365 src/amuleDlg.cpp:1834 src/muuli_wdr.cpp:2961
+#: src/muuli_wdr.cpp:3411 src/muuli_wdr.cpp:3458
 msgid "Messages"
 msgstr ""
 
-#: src/amuleDlg.cpp:366 src/amuleDlg.cpp:1817 src/muuli_wdr.cpp:3455
+#: src/amuleDlg.cpp:366 src/amuleDlg.cpp:1840 src/muuli_wdr.cpp:3459
 #: src/PrefsUnifiedDlg.cpp:314 src/Statistics.cpp:779 src/Statistics.cpp:1235
 msgid "Statistics"
 msgstr ""
 
-#: src/amuleDlg.cpp:368 src/amuleDlg.cpp:1824 src/muuli_wdr.cpp:3457
+#: src/amuleDlg.cpp:368 src/amuleDlg.cpp:1847 src/muuli_wdr.cpp:3461
 #: src/PrefsUnifiedDlg.cpp:330 src/utils/wxCas/src/wxcasprefs.cpp:39
 msgid "Preferences"
 msgstr ""
@@ -650,8 +650,8 @@ msgstr ""
 #: src/amuleDlg.cpp:1029 src/DownloadListCtrl.cpp:505
 #: src/DownloadListCtrl.cpp:749 src/FriendListCtrl.cpp:180
 #: src/muuli_wdr.cpp:731 src/muuli_wdr.cpp:782 src/muuli_wdr.cpp:846
-#: src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2262 src/muuli_wdr.cpp:2347
-#: src/muuli_wdr.cpp:3095 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
+#: src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2266 src/muuli_wdr.cpp:2351
+#: src/muuli_wdr.cpp:3099 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
 #: src/ServerListCtrl.cpp:606 src/TransferWnd.cpp:378
 #: src/utils/wxCas/src/wxcasprefs.cpp:235
 msgid "Cancel"
@@ -662,7 +662,7 @@ msgid "Stop the current connection attempts"
 msgstr ""
 
 #: src/amuleDlg.cpp:1035 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976
-#: src/muuli_wdr.cpp:2485
+#: src/muuli_wdr.cpp:2489
 msgid "Disconnect"
 msgstr ""
 
@@ -671,7 +671,7 @@ msgid "Disconnect from the currently connected networks"
 msgstr ""
 
 #: src/amuleDlg.cpp:1041 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979
-#: src/muuli_wdr.cpp:2640 src/muuli_wdr.cpp:3092 src/muuli_wdr.cpp:3447
+#: src/muuli_wdr.cpp:2644 src/muuli_wdr.cpp:3096 src/muuli_wdr.cpp:3451
 msgid "Connect"
 msgstr ""
 
@@ -725,7 +725,7 @@ msgstr ""
 msgid "Launch Command: "
 msgstr ""
 
-#: src/amuleDlg.cpp:1632 src/muuli_wdr.cpp:1982 src/Preferences.cpp:979
+#: src/amuleDlg.cpp:1632 src/muuli_wdr.cpp:1986 src/Preferences.cpp:979
 msgid "- default -"
 msgstr ""
 
@@ -739,60 +739,60 @@ msgstr ""
 msgid "WARNING: Unable to open skin file '%s' for read"
 msgstr ""
 
-#: src/amuleDlg.cpp:1791 src/muuli_wdr.cpp:3449
+#: src/amuleDlg.cpp:1814 src/muuli_wdr.cpp:3453
 msgid "Networks Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1797 src/muuli_wdr.cpp:3450
+#: src/amuleDlg.cpp:1820 src/muuli_wdr.cpp:3454
 msgid "Searches Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1803 src/muuli_wdr.cpp:3451
+#: src/amuleDlg.cpp:1826 src/muuli_wdr.cpp:3455
 msgid "Downloads Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1809 src/muuli_wdr.cpp:3453
+#: src/amuleDlg.cpp:1832 src/muuli_wdr.cpp:3457
 msgid "Shared Files Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1815 src/muuli_wdr.cpp:3454
+#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3458
 msgid "Messages Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1821 src/muuli_wdr.cpp:3455
+#: src/amuleDlg.cpp:1844 src/muuli_wdr.cpp:3459
 msgid "Statistics Graph Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1828 src/muuli_wdr.cpp:3457
+#: src/amuleDlg.cpp:1851 src/muuli_wdr.cpp:3461
 msgid "Preferences Settings Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1831 src/muuli_wdr.cpp:3458
+#: src/amuleDlg.cpp:1854 src/muuli_wdr.cpp:3462
 msgid "Import"
 msgstr ""
 
-#: src/amuleDlg.cpp:1835 src/muuli_wdr.cpp:3458
+#: src/amuleDlg.cpp:1858 src/muuli_wdr.cpp:3462
 msgid "The partfile importer tool"
 msgstr ""
 
-#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3459
+#: src/amuleDlg.cpp:1861 src/muuli_wdr.cpp:3463
 #: src/utils/aLinkCreator/src/alcframe.cpp:262
 msgid "About"
 msgstr ""
 
-#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3459
+#: src/amuleDlg.cpp:1861 src/muuli_wdr.cpp:3463
 msgid "About/Help"
 msgstr ""
 
-#: src/amuleDlg.cpp:2036
+#: src/amuleDlg.cpp:2059
 msgid "eD2k network"
 msgstr ""
 
-#: src/amuleDlg.cpp:2039
+#: src/amuleDlg.cpp:2062
 msgid "Kad network"
 msgstr ""
 
-#: src/amuleDlg.cpp:2039
+#: src/amuleDlg.cpp:2062
 msgid "No network"
 msgstr ""
 
@@ -1319,19 +1319,19 @@ msgstr ""
 msgid "Very low"
 msgstr ""
 
-#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:743 src/muuli_wdr.cpp:2313
+#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:743 src/muuli_wdr.cpp:2317
 #: src/ServerListCtrl.cpp:263 src/ServerListCtrl.cpp:456
 #: src/SharedFilesCtrl.cpp:145
 msgid "Low"
 msgstr ""
 
-#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:744 src/muuli_wdr.cpp:2314
+#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:744 src/muuli_wdr.cpp:2318
 #: src/ServerListCtrl.cpp:266 src/ServerListCtrl.cpp:457
 #: src/SharedFilesCtrl.cpp:146
 msgid "Normal"
 msgstr ""
 
-#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:745 src/muuli_wdr.cpp:2315
+#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:745 src/muuli_wdr.cpp:2319
 #: src/ServerListCtrl.cpp:269 src/ServerListCtrl.cpp:458
 #: src/SharedFilesCtrl.cpp:147
 msgid "High"
@@ -1423,7 +1423,7 @@ msgstr ""
 msgid "Remote Server"
 msgstr ""
 
-#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3212
+#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3216
 #: src/SearchDlg.cpp:119 src/TextClient.cpp:911
 msgid "Kad"
 msgstr "காட்"
@@ -1494,7 +1494,7 @@ msgstr ""
 msgid "Size"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3279
+#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3283
 msgid "Transferred"
 msgstr ""
 
@@ -1550,7 +1550,7 @@ msgid ""
 "\n"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:746 src/muuli_wdr.cpp:2316
+#: src/DownloadListCtrl.cpp:746 src/muuli_wdr.cpp:2320
 #: src/SharedFilesCtrl.cpp:150
 msgid "Auto"
 msgstr ""
@@ -1588,7 +1588,7 @@ msgid "Extended Options"
 msgstr ""
 
 #: src/DownloadListCtrl.cpp:770 src/DownloadListCtrl.cpp:822
-#: src/muuli_wdr.cpp:1800
+#: src/muuli_wdr.cpp:1804
 msgid "Preview"
 msgstr ""
 
@@ -2354,23 +2354,23 @@ msgid ""
 "want downloads on a different (e.g. larger) disk."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:549 src/FirstRunWizard.cpp:611 src/muuli_wdr.cpp:1712
+#: src/FirstRunWizard.cpp:549 src/FirstRunWizard.cpp:611 src/muuli_wdr.cpp:1716
 msgid "Destination folder for downloads"
 msgstr ""
 
 #: src/FirstRunWizard.cpp:553 src/FirstRunWizard.cpp:569 src/muuli_wdr.cpp:1349
-#: src/muuli_wdr.cpp:1366 src/muuli_wdr.cpp:1687 src/muuli_wdr.cpp:1718
-#: src/muuli_wdr.cpp:1730 src/muuli_wdr.cpp:2800
+#: src/muuli_wdr.cpp:1366 src/muuli_wdr.cpp:1691 src/muuli_wdr.cpp:1722
+#: src/muuli_wdr.cpp:1734 src/muuli_wdr.cpp:2804
 #: src/utils/aLinkCreator/src/alcframe.cpp:135
 #: src/utils/wxCas/src/wxcasprefs.cpp:52 src/utils/wxCas/src/wxcasprefs.cpp:118
 msgid "Browse"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:559 src/muuli_wdr.cpp:1723
+#: src/FirstRunWizard.cpp:559 src/muuli_wdr.cpp:1727
 msgid "(All files in this folder are shared with other peers)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:565 src/FirstRunWizard.cpp:624 src/muuli_wdr.cpp:1725
+#: src/FirstRunWizard.cpp:565 src/FirstRunWizard.cpp:624 src/muuli_wdr.cpp:1729
 msgid "Folder for temporary download files"
 msgstr ""
 
@@ -2401,7 +2401,7 @@ msgstr ""
 msgid "CRITICAL - no client on StartChatSession"
 msgstr ""
 
-#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2706 src/muuli_wdr.cpp:3383
+#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2710 src/muuli_wdr.cpp:3387
 msgid "Friends"
 msgstr ""
 
@@ -2507,8 +2507,8 @@ msgstr ""
 msgid "No"
 msgstr ""
 
-#: src/GenericClientListCtrl.cpp:1216 src/PrefsUnifiedDlg.cpp:2898
-#: src/PrefsUnifiedDlg.cpp:2948 src/ServerListCtrl.cpp:276
+#: src/GenericClientListCtrl.cpp:1216 src/PrefsUnifiedDlg.cpp:2907
+#: src/PrefsUnifiedDlg.cpp:2957 src/ServerListCtrl.cpp:276
 msgid "Yes"
 msgstr ""
 
@@ -2675,10 +2675,10 @@ msgstr ""
 msgid "Please fill all fields required"
 msgstr ""
 
-#: src/KadDlg.cpp:192 src/PartFile.cpp:1031 src/PrefsUnifiedDlg.cpp:1134
-#: src/PrefsUnifiedDlg.cpp:1204 src/PrefsUnifiedDlg.cpp:1405
-#: src/PrefsUnifiedDlg.cpp:1663 src/PrefsUnifiedDlg.cpp:1673
-#: src/PrefsUnifiedDlg.cpp:1690 src/PrefsUnifiedDlg.cpp:1738
+#: src/KadDlg.cpp:192 src/PartFile.cpp:1031 src/PrefsUnifiedDlg.cpp:1143
+#: src/PrefsUnifiedDlg.cpp:1213 src/PrefsUnifiedDlg.cpp:1414
+#: src/PrefsUnifiedDlg.cpp:1672 src/PrefsUnifiedDlg.cpp:1682
+#: src/PrefsUnifiedDlg.cpp:1699 src/PrefsUnifiedDlg.cpp:1747
 msgid "Message"
 msgstr ""
 
@@ -2779,7 +2779,7 @@ msgstr ""
 msgid "Uploaded"
 msgstr ""
 
-#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3263
+#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3267
 msgid "Requested"
 msgstr ""
 
@@ -2902,7 +2902,7 @@ msgid "WARNING: "
 msgstr ""
 
 #: src/MuleNotebook.cpp:179 src/muuli_wdr.cpp:817 src/muuli_wdr.cpp:1229
-#: src/muuli_wdr.cpp:3167 src/muuli_wdr.cpp:3423
+#: src/muuli_wdr.cpp:3171 src/muuli_wdr.cpp:3427
 msgid "Close"
 msgstr ""
 
@@ -2920,7 +2920,7 @@ msgid "Paste"
 msgstr ""
 
 #: src/MuleTextCtrl.cpp:89 src/muuli_wdr.cpp:358 src/muuli_wdr.cpp:757
-#: src/muuli_wdr.cpp:2390 src/muuli_wdr.cpp:2409 src/muuli_wdr.cpp:2431
+#: src/muuli_wdr.cpp:2394 src/muuli_wdr.cpp:2413 src/muuli_wdr.cpp:2435
 #: src/utils/aLinkCreator/src/alcframe.cpp:142
 msgid "Clear"
 msgstr ""
@@ -3012,7 +3012,7 @@ msgstr ""
 
 #: src/MuleTrayIcon.cpp:579 src/MuleTrayIcon.cpp:945 src/MuleTrayIcon.cpp:965
 #: src/muuli_wdr.cpp:1398 src/muuli_wdr.cpp:1406 src/muuli_wdr.cpp:1413
-#: src/muuli_wdr.cpp:1846 src/muuli_wdr.cpp:1852 src/OtherFunctions.cpp:91
+#: src/muuli_wdr.cpp:1850 src/muuli_wdr.cpp:1856 src/OtherFunctions.cpp:91
 #: src/StatisticsDlg.cpp:93 src/StatisticsDlg.cpp:95
 msgid "kB/s"
 msgstr ""
@@ -3252,7 +3252,7 @@ msgstr ""
 msgid "KB"
 msgstr ""
 
-#: src/muuli_wdr.cpp:274 src/muuli_wdr.cpp:293 src/muuli_wdr.cpp:1631
+#: src/muuli_wdr.cpp:274 src/muuli_wdr.cpp:293 src/muuli_wdr.cpp:1635
 #: src/OtherFunctions.cpp:64
 msgid "MB"
 msgstr ""
@@ -3269,7 +3269,7 @@ msgstr ""
 msgid "Availability"
 msgstr ""
 
-#: src/muuli_wdr.cpp:312 src/muuli_wdr.cpp:398 src/muuli_wdr.cpp:3328
+#: src/muuli_wdr.cpp:312 src/muuli_wdr.cpp:398 src/muuli_wdr.cpp:3332
 msgid "Filter:"
 msgstr ""
 
@@ -3332,8 +3332,8 @@ msgstr ""
 #: src/muuli_wdr.cpp:1160 src/muuli_wdr.cpp:1167 src/muuli_wdr.cpp:1172
 #: src/muuli_wdr.cpp:1179 src/muuli_wdr.cpp:1184 src/muuli_wdr.cpp:1191
 #: src/muuli_wdr.cpp:1205 src/muuli_wdr.cpp:1212 src/muuli_wdr.cpp:1217
-#: src/muuli_wdr.cpp:1224 src/muuli_wdr.cpp:3265 src/muuli_wdr.cpp:3273
-#: src/muuli_wdr.cpp:3281
+#: src/muuli_wdr.cpp:1224 src/muuli_wdr.cpp:3269 src/muuli_wdr.cpp:3277
+#: src/muuli_wdr.cpp:3285
 msgid "N/A"
 msgstr ""
 
@@ -3473,7 +3473,7 @@ msgstr ""
 msgid "Album :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:685 src/muuli_wdr.cpp:2285
+#: src/muuli_wdr.cpp:685 src/muuli_wdr.cpp:2289
 msgid "Title :"
 msgstr ""
 
@@ -3579,7 +3579,7 @@ msgstr ""
 msgid "Userhash :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:895 src/muuli_wdr.cpp:1752 src/muuli_wdr.cpp:2480
+#: src/muuli_wdr.cpp:895 src/muuli_wdr.cpp:1756 src/muuli_wdr.cpp:2484
 #: src/utils/aLinkCreator/src/alcframe.cpp:137
 msgid "Add"
 msgstr ""
@@ -3588,15 +3588,15 @@ msgstr ""
 msgid "Download-Speed"
 msgstr ""
 
-#: src/muuli_wdr.cpp:954 src/muuli_wdr.cpp:989 src/muuli_wdr.cpp:2584
+#: src/muuli_wdr.cpp:954 src/muuli_wdr.cpp:989 src/muuli_wdr.cpp:2588
 msgid "Current"
 msgstr ""
 
-#: src/muuli_wdr.cpp:962 src/muuli_wdr.cpp:997 src/muuli_wdr.cpp:2592
+#: src/muuli_wdr.cpp:962 src/muuli_wdr.cpp:997 src/muuli_wdr.cpp:2596
 msgid "Running average"
 msgstr ""
 
-#: src/muuli_wdr.cpp:970 src/muuli_wdr.cpp:1005 src/muuli_wdr.cpp:2600
+#: src/muuli_wdr.cpp:970 src/muuli_wdr.cpp:1005 src/muuli_wdr.cpp:2604
 msgid "Session average"
 msgstr ""
 
@@ -3608,7 +3608,7 @@ msgstr ""
 msgid "Connections"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1024 src/muuli_wdr.cpp:1871
+#: src/muuli_wdr.cpp:1024 src/muuli_wdr.cpp:1875
 msgid "Active downloads"
 msgstr ""
 
@@ -3616,7 +3616,7 @@ msgstr ""
 msgid "Active connections (1:1)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1040 src/muuli_wdr.cpp:1872
+#: src/muuli_wdr.cpp:1040 src/muuli_wdr.cpp:1876
 msgid "Active uploads"
 msgstr ""
 
@@ -3889,7 +3889,7 @@ msgstr ""
 msgid "Advanced users only: If you have multiple network interfaces, enter the address of the interface to which aMule should be bound."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1462 src/muuli_wdr.cpp:2065
+#: src/muuli_wdr.cpp:1462 src/muuli_wdr.cpp:2069
 msgid "Bind to network interface (empty for any):"
 msgstr ""
 
@@ -3905,7 +3905,7 @@ msgstr ""
 msgid "Max simultaneous connections:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1498 src/muuli_wdr.cpp:3207
+#: src/muuli_wdr.cpp:1498 src/muuli_wdr.cpp:3211
 msgid "ED2K"
 msgstr ""
 
@@ -3997,763 +3997,763 @@ msgstr ""
 msgid "For new files preallocates disk space for the whole file, thus reduces fragmentation"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1617
+#: src/muuli_wdr.cpp:1621
 msgid "Create new files as sparse files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1618
+#: src/muuli_wdr.cpp:1622
 msgid "Sparse part files only occupy disk space for the parts already downloaded, so free space is used up gradually as the file fills in. Turn this off to use an ordinary file instead - useful where sparse files are unsupported or slow, or where backup/de-duplication tools handle them badly. Applies only when the core runs on Windows; on Linux and macOS part files are sparse anyway and this setting has no effect."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1623
+#: src/muuli_wdr.cpp:1627
 msgid "Stop downloads when free disk space reaches "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1624
+#: src/muuli_wdr.cpp:1628
 msgid "Select this if you want aMule to check your disk space"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1628
+#: src/muuli_wdr.cpp:1632
 msgid "Enter here the min disk space desired."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1634
+#: src/muuli_wdr.cpp:1638
 msgid "Save 10 sources on rare files (< 20 sources)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1638 src/Statistics.cpp:790
+#: src/muuli_wdr.cpp:1642 src/Statistics.cpp:790
 msgid "Uploads"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1641
+#: src/muuli_wdr.cpp:1645
 msgid "Add new shared files with auto priority"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1647
+#: src/muuli_wdr.cpp:1651
 msgid "Intelligent Corruption Handling (I.C.H.)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1650
+#: src/muuli_wdr.cpp:1654
 msgid "Enable"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1653
+#: src/muuli_wdr.cpp:1657
 msgid "Advanced I.C.H. trusts every hash (not recommended)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1665 src/PrefsUnifiedDlg.cpp:1990
+#: src/muuli_wdr.cpp:1669 src/PrefsUnifiedDlg.cpp:1999
 msgid "Media metadata extraction"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1669
+#: src/muuli_wdr.cpp:1673
 msgid "Extract length / bitrate / codec from shared audio and video files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1671
+#: src/muuli_wdr.cpp:1675
 msgid "When enabled, aMule runs ffprobe on each shared media file to fill in the Length / Bitrate / Codec columns other clients see when they find the file in a search. Requires ffmpeg (the ffprobe binary) to be installed."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1678
+#: src/muuli_wdr.cpp:1682
 msgid "Path to ffprobe:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1683
+#: src/muuli_wdr.cpp:1687
 msgid "Full path to the ffprobe binary. Leave empty to have aMule auto-detect it on startup."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1691
+#: src/muuli_wdr.cpp:1695
 msgid "Detect"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1692
+#: src/muuli_wdr.cpp:1696
 msgid "Search the standard install locations for an ffprobe binary and fill the path field."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1716
+#: src/muuli_wdr.cpp:1720
 msgid ""
 "Completed downloads are stored here. All files in this folder are automatically shared with other peers.\n"
 "If this folder also holds files you don't want to share, point it at an aMule-only sub-folder."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1719
+#: src/muuli_wdr.cpp:1723
 msgid "Pick the folder where completed downloads will be stored. All files in that folder will be shared with other peers."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1733
+#: src/muuli_wdr.cpp:1737
 msgid "Shared folders"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1739
+#: src/muuli_wdr.cpp:1743
 msgid "(Folders shared by the core. Enter a path to add one.)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1747
+#: src/muuli_wdr.cpp:1751
 msgid "Absolute path of a folder on the core's machine, e.g. /home/user/shared"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1749 src/PrefsUnifiedDlg.cpp:2874
+#: src/muuli_wdr.cpp:1753 src/PrefsUnifiedDlg.cpp:2883
 msgid "Recursive"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1750
+#: src/muuli_wdr.cpp:1754
 msgid "Share every sub-folder underneath this one, including ones created later."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1754 src/utils/aLinkCreator/src/alcframe.cpp:141
+#: src/muuli_wdr.cpp:1758 src/utils/aLinkCreator/src/alcframe.cpp:141
 msgid "Remove"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1758
+#: src/muuli_wdr.cpp:1762
 msgid "(Right click on folder icon for recursive share)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1765
+#: src/muuli_wdr.cpp:1769
 msgid "Share hidden files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1771
+#: src/muuli_wdr.cpp:1775
 msgid "Automatically rescan shared folders for changes"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1777
+#: src/muuli_wdr.cpp:1781
 msgid "Follow symbolic links in shared folders"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1783
+#: src/muuli_wdr.cpp:1787
 msgid "Exclude files matching:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1786
+#: src/muuli_wdr.cpp:1790
 msgid "Wildcard patterns separated by '|', e.g. .DS_Store|Thumbs.db|*.tmp. Files whose name matches are not shared. Matching is case-insensitive."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1790
+#: src/muuli_wdr.cpp:1794
 msgid "Patterns are regular expressions"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1791
+#: src/muuli_wdr.cpp:1795
 msgid "When set, the whole field is one regular expression ('|' is alternation). When unset, it is a list of '|'-separated wildcards."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1801
+#: src/muuli_wdr.cpp:1805
 msgid "Show how many shared files the current pattern would exclude."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1822
+#: src/muuli_wdr.cpp:1826
 msgid "Graphs"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1825 src/muuli_wdr.cpp:1887
+#: src/muuli_wdr.cpp:1829 src/muuli_wdr.cpp:1891
 msgid "Update delay : 5 secs"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1829
+#: src/muuli_wdr.cpp:1833
 msgid "Time for average graph: 100 mins"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1833
+#: src/muuli_wdr.cpp:1837
 msgid "Connections Graph Scale: 100 "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1840
+#: src/muuli_wdr.cpp:1844
 msgid "Download graph scale:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1848
+#: src/muuli_wdr.cpp:1852
 msgid "Upload graph scale:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1858
+#: src/muuli_wdr.cpp:1862
 msgid "Colors: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1862
+#: src/muuli_wdr.cpp:1866
 msgid "Background"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1863
+#: src/muuli_wdr.cpp:1867
 msgid "Grid"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1864
+#: src/muuli_wdr.cpp:1868
 msgid "Download current"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1865
+#: src/muuli_wdr.cpp:1869
 msgid "Download running average"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1866
+#: src/muuli_wdr.cpp:1870
 msgid "Download session average"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1867
+#: src/muuli_wdr.cpp:1871
 msgid "Upload current"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1868
+#: src/muuli_wdr.cpp:1872
 msgid "Upload running average"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1869
+#: src/muuli_wdr.cpp:1873
 msgid "Upload session average"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1870
+#: src/muuli_wdr.cpp:1874
 msgid "Active connections"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1873
+#: src/muuli_wdr.cpp:1877
 msgid "Systray Icon Speed Bar"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1874
+#: src/muuli_wdr.cpp:1878
 msgid "Kad-nodes current"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1875
+#: src/muuli_wdr.cpp:1879
 msgid "Kad-nodes running"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1876
+#: src/muuli_wdr.cpp:1880
 msgid "Kad-nodes session"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1880 src/muuli_wdr.cpp:2334
+#: src/muuli_wdr.cpp:1884 src/muuli_wdr.cpp:2338
 msgid "Select"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1884
+#: src/muuli_wdr.cpp:1888
 msgid "Tree"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1894
+#: src/muuli_wdr.cpp:1898
 msgid "Number of Client Versions shown (0=unlimited)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1919
+#: src/muuli_wdr.cpp:1923
 msgid "!!! WARNING !!!"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1934
+#: src/muuli_wdr.cpp:1938
 msgid "Max new connections / 5 secs"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1936
+#: src/muuli_wdr.cpp:1940
 msgid "Concurrent Kad source lookups"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1938
+#: src/muuli_wdr.cpp:1942
 msgid "Kad source re-search interval (minutes)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1940
+#: src/muuli_wdr.cpp:1944
 msgid "Source re-ask interval (minutes)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1944
+#: src/muuli_wdr.cpp:1948
 msgid "File Buffer Size: 240000 bytes"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1948
+#: src/muuli_wdr.cpp:1952
 msgid "Use MMAP: memory-mapped file access (lower memory use)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1949
+#: src/muuli_wdr.cpp:1953
 msgid "Maps part files into memory instead of buffering them on the heap, lowering the process memory footprint. May reduce download speed on some disks; best for memory-constrained or upload-heavy hosts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1951
+#: src/muuli_wdr.cpp:1955
 msgid "Upload Queue Size: 5000 clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1955
+#: src/muuli_wdr.cpp:1959
 msgid "Server connection refresh interval: Disable"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1959
+#: src/muuli_wdr.cpp:1963
 msgid "Disable computer's timed standby mode"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1978
+#: src/muuli_wdr.cpp:1982
 msgid "Skin to use: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1987
+#: src/muuli_wdr.cpp:1991
 msgid "Show \"Fast eD2k Links Handler\" in every window."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1990
+#: src/muuli_wdr.cpp:1994
 msgid "Show extended info on categories tabs"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1993
+#: src/muuli_wdr.cpp:1997
 msgid "Show application version on title"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1995
+#: src/muuli_wdr.cpp:1999
 msgid "Show transfer rates on title"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1997
+#: src/muuli_wdr.cpp:2001
 msgid "Before application name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1999
+#: src/muuli_wdr.cpp:2003
 msgid "After application name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2002
+#: src/muuli_wdr.cpp:2006
 msgid "Show overhead bandwidth"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2006
+#: src/muuli_wdr.cpp:2010
 msgid "Vertical toolbar orientation"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2008
+#: src/muuli_wdr.cpp:2012
 msgid "Live column sorting (auto-reorder rows as their values change)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2015
+#: src/muuli_wdr.cpp:2019
 msgid "Download Queue Files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2018
+#: src/muuli_wdr.cpp:2022
 msgid "Show progress percentage"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2024
+#: src/muuli_wdr.cpp:2028
 msgid "Show progress bar"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2027
+#: src/muuli_wdr.cpp:2031
 msgid "Flat"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2031
+#: src/muuli_wdr.cpp:2035
 msgid "Round"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2049
+#: src/muuli_wdr.cpp:2053
 msgid "External Connection Parameters"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2052
+#: src/muuli_wdr.cpp:2056
 msgid "Accept external connections"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2059 src/muuli_wdr.cpp:2118
+#: src/muuli_wdr.cpp:2063 src/muuli_wdr.cpp:2122
 msgid "IP of the listening interface:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2062
+#: src/muuli_wdr.cpp:2066
 msgid "Enter here a valid ip in the a.b.c.d format for the listening EC interface. An empty field or 0.0.0.0 will mean any interface."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2083 src/muuli_wdr.cpp:2194
+#: src/muuli_wdr.cpp:2087 src/muuli_wdr.cpp:2198
 msgid "TCP port:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2089
+#: src/muuli_wdr.cpp:2093
 msgid "Enable UPnP port forwarding on the EC port"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2093 src/muuli_wdr.cpp:3079
+#: src/muuli_wdr.cpp:2097 src/muuli_wdr.cpp:3083
 #: src/utils/wxCas/src/wxcasprefs.cpp:167
 msgid "Password"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2099
+#: src/muuli_wdr.cpp:2103
 msgid "aMule API server parameters"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2102
+#: src/muuli_wdr.cpp:2106
 msgid "Run amuleapi (REST API) on startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2107
+#: src/muuli_wdr.cpp:2111
 msgid "HTTP port:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2121
+#: src/muuli_wdr.cpp:2125
 msgid "The interface amuleapi's HTTP server listens on. 127.0.0.1 (default) accepts only local connections; use 0.0.0.0 or a specific IP to expose it to other hosts (set an admin password below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2126
+#: src/muuli_wdr.cpp:2130
 msgid "Type a password to set or change it. Stored passwords cannot be shown, so leaving this empty keeps the current one."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2128
+#: src/muuli_wdr.cpp:2132
 msgid "Admin password"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2140 src/muuli_wdr.cpp:2157 src/PrefsUnifiedDlg.cpp:1103
+#: src/muuli_wdr.cpp:2144 src/muuli_wdr.cpp:2161 src/PrefsUnifiedDlg.cpp:1112
 msgid "A password is set."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2144
+#: src/muuli_wdr.cpp:2148
 msgid "Enable guest access"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2145
+#: src/muuli_wdr.cpp:2149
 msgid "Guest sessions may read status and listings but cannot change anything. Turning this off clears the stored guest password."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2149
+#: src/muuli_wdr.cpp:2153
 msgid "Guest password"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2164
+#: src/muuli_wdr.cpp:2168
 msgid "Web server parameters"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2167
+#: src/muuli_wdr.cpp:2171
 msgid "Run webserver on startup (deprecated)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2173
+#: src/muuli_wdr.cpp:2177
 msgid "Web template"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2178
+#: src/muuli_wdr.cpp:2182
 msgid "Full rights password"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2182
+#: src/muuli_wdr.cpp:2186
 msgid "Enable Low rights User"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2187
+#: src/muuli_wdr.cpp:2191
 msgid "Low rights password"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2201
+#: src/muuli_wdr.cpp:2205
 msgid "Enable UPnP port forwarding of the web server port"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2206
+#: src/muuli_wdr.cpp:2210
 msgid "Web server UPnP TCP port (Optional)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2214
+#: src/muuli_wdr.cpp:2218
 msgid "Page Refresh Time (in secs)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2221
+#: src/muuli_wdr.cpp:2225
 msgid "Enable Gzip compression"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2255
+#: src/muuli_wdr.cpp:2259
 msgid "Reset page to defaults"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2256
+#: src/muuli_wdr.cpp:2260
 msgid "Reset the settings on the current page to their default values."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2258 src/muuli_wdr.cpp:2344 src/ServerWnd.cpp:274
+#: src/muuli_wdr.cpp:2262 src/muuli_wdr.cpp:2348 src/ServerWnd.cpp:274
 #: src/ServerWnd.cpp:282
 msgid "OK"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2260
+#: src/muuli_wdr.cpp:2264
 msgid "Click here to apply any changes made to the preferences."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2263
+#: src/muuli_wdr.cpp:2267
 msgid "Reset any changes made to the preferences."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2292
+#: src/muuli_wdr.cpp:2296
 msgid "Comment :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2299
+#: src/muuli_wdr.cpp:2303
 msgid "Incoming Dir :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2308
+#: src/muuli_wdr.cpp:2312
 msgid "Change priority for new assigned files :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2312
+#: src/muuli_wdr.cpp:2316
 msgid "Don't change"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2324
+#: src/muuli_wdr.cpp:2328
 msgid "Select color for this Category (currently selected) :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2391 src/muuli_wdr.cpp:2410 src/muuli_wdr.cpp:2432
+#: src/muuli_wdr.cpp:2395 src/muuli_wdr.cpp:2414 src/muuli_wdr.cpp:2436
 msgid "Click this button to reset the log."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2451
+#: src/muuli_wdr.cpp:2455
 msgid "Click on this button to update the servers list from URL ..."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2455
+#: src/muuli_wdr.cpp:2459
 msgid "Server list"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2459
+#: src/muuli_wdr.cpp:2463
 msgid "Enter the url to a server.met file here and press the button to the left to update the list of known servers."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2464
+#: src/muuli_wdr.cpp:2468
 msgid "Add server manually: Name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2467
+#: src/muuli_wdr.cpp:2471
 msgid "Enter the name of the new server here"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2469 src/ServerWnd.cpp:206
+#: src/muuli_wdr.cpp:2473 src/ServerWnd.cpp:206
 msgid "IP:Port"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2472
+#: src/muuli_wdr.cpp:2476
 msgid "Enter the IP of the server here, using the x.x.x.x format."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2478
+#: src/muuli_wdr.cpp:2482
 msgid "Enter the port of the server here."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2481
+#: src/muuli_wdr.cpp:2485
 msgid "Add manually a server (fill fields to the left before) ..."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2510
+#: src/muuli_wdr.cpp:2514
 msgid "aMule Log"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2518
+#: src/muuli_wdr.cpp:2522
 msgid "Server Info"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2522
+#: src/muuli_wdr.cpp:2526
 msgid "ED2K Info"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2526
+#: src/muuli_wdr.cpp:2530
 msgid "Kad Info"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2554
+#: src/muuli_wdr.cpp:2558
 msgid "Click on this button to update the nodes list from URL ..."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2558
+#: src/muuli_wdr.cpp:2562
 msgid "Nodes (0)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2562
+#: src/muuli_wdr.cpp:2566
 msgid "Enter the url to a nodes.dat file here and press the button to the left to update the list of known nodes."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2565
+#: src/muuli_wdr.cpp:2569
 msgid "Nodes stats"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2607
+#: src/muuli_wdr.cpp:2611
 msgid "Bootstrap"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2610
+#: src/muuli_wdr.cpp:2614
 msgid "New node"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2615
+#: src/muuli_wdr.cpp:2619
 msgid "IP:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2635
+#: src/muuli_wdr.cpp:2639
 msgid "Port:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2648
+#: src/muuli_wdr.cpp:2652
 msgid "Bootstrap from known clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2650
+#: src/muuli_wdr.cpp:2654
 msgid "Disconnect Kad"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2684
+#: src/muuli_wdr.cpp:2688
 msgid "Use Secure User Identification"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2686
+#: src/muuli_wdr.cpp:2690
 msgid "It is recommended to enable this option. You will not receive credits if SUI is not enabled."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2688
+#: src/muuli_wdr.cpp:2692
 msgid "Protocol Obfuscation"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2691
+#: src/muuli_wdr.cpp:2695
 msgid "Support Protocol Obfuscation"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2693
+#: src/muuli_wdr.cpp:2697
 msgid "This option enabled Protocol Obfuscation, and makes aMule accept obfuscated connections from other clients."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2695
+#: src/muuli_wdr.cpp:2699
 msgid "Use obfuscation for outgoing connections"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2697
+#: src/muuli_wdr.cpp:2701
 msgid "This option makes aMule use Protocol Obfuscation when connecting other clients/servers."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2699
+#: src/muuli_wdr.cpp:2703
 msgid "Accept only obfuscated connections"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2700
+#: src/muuli_wdr.cpp:2704
 msgid "This option makes aMule only accept obfuscated connections. You will have less sources, but all your traffic will be obfuscated"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2705
+#: src/muuli_wdr.cpp:2709
 msgid "Everybody"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2707
+#: src/muuli_wdr.cpp:2711
 msgid "No one"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2709
+#: src/muuli_wdr.cpp:2713
 msgid "Who can see my shared files:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2710
+#: src/muuli_wdr.cpp:2714
 msgid "Select who can request to view a list of your shared files."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2712
+#: src/muuli_wdr.cpp:2716
 msgid "IP-Filtering"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2719
+#: src/muuli_wdr.cpp:2723
 msgid "Filter clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2721
+#: src/muuli_wdr.cpp:2725
 msgid "Enable filtering of the client IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2723
+#: src/muuli_wdr.cpp:2727
 msgid "Filter servers"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2725
+#: src/muuli_wdr.cpp:2729
 msgid "Enable filtering of the server IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2729
+#: src/muuli_wdr.cpp:2733
 msgid "Reload List"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2730
+#: src/muuli_wdr.cpp:2734
 msgid "Reload the list of IPs to filter from the file ~/.aMule/ipfilter.dat"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2736
+#: src/muuli_wdr.cpp:2740
 msgid "URL:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2740 src/muuli_wdr.cpp:2933
+#: src/muuli_wdr.cpp:2744 src/muuli_wdr.cpp:2937
 msgid "Update now"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2743
+#: src/muuli_wdr.cpp:2747
 msgid "Auto-update ipfilter at startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2747
+#: src/muuli_wdr.cpp:2751
 msgid "Filtering Level:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2753
+#: src/muuli_wdr.cpp:2757
 msgid "Always filter LAN IPs"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2756
+#: src/muuli_wdr.cpp:2760
 msgid "Paranoid handling of non-matching IPs"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2758
+#: src/muuli_wdr.cpp:2762
 msgid "Rejects a packet when its source IP differs from the IP the client claims (an anti-spoofing check). Disable only if it causes connection problems."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2760
+#: src/muuli_wdr.cpp:2764
 msgid "Use system-wide ipfilter.dat if available"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2761
+#: src/muuli_wdr.cpp:2765
 msgid "If there's no local ipfilter.dat found, allow usage of a system-wide ipfilter file."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2778
+#: src/muuli_wdr.cpp:2782
 msgid "Enable Online-Signature"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2780
+#: src/muuli_wdr.cpp:2784
 msgid "Enables the writing of the OS file, which can be used by external apps to create signatures and the like."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2784
+#: src/muuli_wdr.cpp:2788
 msgid "Update Frequency (Secs):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2787
+#: src/muuli_wdr.cpp:2791
 msgid "Change the frequency (in seconds) of Online Signature updates."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2795
+#: src/muuli_wdr.cpp:2799
 msgid "Save online signature file in: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:2801
+#: src/muuli_wdr.cpp:2805
 msgid "Click here to select the directory containing the the Online Signature files."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2834
+#: src/muuli_wdr.cpp:2838
 msgid "Show country flags for clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2835
+#: src/muuli_wdr.cpp:2839
 msgid "Render the country flag column in the transfers, queue and search views. Requires a valid MMDB GeoIP database (see below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2840
+#: src/muuli_wdr.cpp:2844
 msgid "Database"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2856
+#: src/muuli_wdr.cpp:2860
 msgid "Source:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2859
+#: src/muuli_wdr.cpp:2863
 msgid "DB-IP (free, no account)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2860
+#: src/muuli_wdr.cpp:2864
 msgid "MaxMind GeoLite2 (free, account required)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2861
+#: src/muuli_wdr.cpp:2865
 msgid "Custom URL"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2864
+#: src/muuli_wdr.cpp:2868
 msgid "Choose which provider supplies the GeoIP MMDB database. DB-IP is the default - no account required. MaxMind requires a free account + license key. Use Custom URL to point at any other MMDB host (e.g. a local mirror)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2881
+#: src/muuli_wdr.cpp:2885
 msgid ""
 "No configuration required.\n"
 "\n"
@@ -4761,11 +4761,11 @@ msgid ""
 "License: Creative Commons BY 4.0 - https://creativecommons.org/licenses/by/4.0/"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2894
+#: src/muuli_wdr.cpp:2898
 msgid "License key:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2900
+#: src/muuli_wdr.cpp:2904
 msgid ""
 "Sign up for a free MaxMind account, then generate a License Key:\n"
 "https://www.maxmind.com/en/geolite2/signup\n"
@@ -4775,222 +4775,222 @@ msgid ""
 "Requires attribution and account registration; refresh at least every 30 days."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2915
+#: src/muuli_wdr.cpp:2919
 msgid "Download URL:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2921
+#: src/muuli_wdr.cpp:2925
 msgid ""
 "Must point to an .mmdb file or a .gz / .tar.gz containing one.\n"
 "URL may include credentials (https://user:pass@host/...).\n"
 "License and attribution terms are set by the upstream URL - you are responsible."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2934
+#: src/muuli_wdr.cpp:2938
 msgid "Download the GeoIP database from the selected source."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2936
+#: src/muuli_wdr.cpp:2940
 msgid "Auto-update on startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2937
+#: src/muuli_wdr.cpp:2941
 msgid "Re-download the GeoIP database from the selected source every time aMule starts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2960
+#: src/muuli_wdr.cpp:2964
 msgid "Filter incoming messages (except current chat):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2962
+#: src/muuli_wdr.cpp:2966
 msgid "Filter all messages"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2964
+#: src/muuli_wdr.cpp:2968
 msgid "Filter messages from people not on your friend list"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2966
+#: src/muuli_wdr.cpp:2970
 msgid "Filter messages from unknown clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2968
+#: src/muuli_wdr.cpp:2972
 msgid "Filter messages containing (use ',' as separator):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2971 src/muuli_wdr.cpp:2982
+#: src/muuli_wdr.cpp:2975 src/muuli_wdr.cpp:2986
 msgid "add here the words amule should filter and block messages including it"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2973
+#: src/muuli_wdr.cpp:2977
 msgid "Show received messages in the log"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2976
+#: src/muuli_wdr.cpp:2980
 msgid "Comments"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2979
+#: src/muuli_wdr.cpp:2983
 msgid "Filter comments containing (use ',' as separator):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3004
+#: src/muuli_wdr.cpp:3008
 msgid "Enable Proxy"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3005
+#: src/muuli_wdr.cpp:3009
 msgid "Enable/disable proxy support"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3008
+#: src/muuli_wdr.cpp:3012
 msgid "Proxy type:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3019
+#: src/muuli_wdr.cpp:3023
 msgid "Proxy host:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3022
+#: src/muuli_wdr.cpp:3026
 msgid "The proxy host name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3024
+#: src/muuli_wdr.cpp:3028
 msgid "Proxy port:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3027
+#: src/muuli_wdr.cpp:3031
 msgid "The proxy port"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3029
+#: src/muuli_wdr.cpp:3033
 msgid "Enable authentication"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3030
+#: src/muuli_wdr.cpp:3034
 msgid "Enable/disable username/password authentication"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3033
+#: src/muuli_wdr.cpp:3037
 msgid "Username: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:3036
+#: src/muuli_wdr.cpp:3040
 msgid "The username to use to connect to the proxy"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3038
+#: src/muuli_wdr.cpp:3042
 msgid "Password:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3041
+#: src/muuli_wdr.cpp:3045
 msgid "The password to use to connect to the proxy"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3060
+#: src/muuli_wdr.cpp:3064
 msgid "Connect to:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3069
+#: src/muuli_wdr.cpp:3073
 msgid "Login to remote amule"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3074
+#: src/muuli_wdr.cpp:3078
 msgid "User name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3085
+#: src/muuli_wdr.cpp:3089
 msgid "Remember those settings"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3088
+#: src/muuli_wdr.cpp:3092
 msgid "Force ZLIB compression"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3112
+#: src/muuli_wdr.cpp:3116
 msgid "Enable Verbose Debug-Logging."
 msgstr ""
 
-#: src/muuli_wdr.cpp:3114
+#: src/muuli_wdr.cpp:3118
 msgid "Only to Logfile"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3116
+#: src/muuli_wdr.cpp:3120
 msgid "Message Categories:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3140 src/PartFileConvertDlg.cpp:160
+#: src/muuli_wdr.cpp:3144 src/PartFileConvertDlg.cpp:160
 msgid "Waiting..."
 msgstr ""
 
-#: src/muuli_wdr.cpp:3160
+#: src/muuli_wdr.cpp:3164
 msgid "Add imports"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3163
+#: src/muuli_wdr.cpp:3167
 msgid "Retry selected"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3165
+#: src/muuli_wdr.cpp:3169
 msgid "Remove selected"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3228
+#: src/muuli_wdr.cpp:3232
 msgid "Event Types"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3247
+#: src/muuli_wdr.cpp:3251
 msgid "Statistics and queued clients for selected file(s) : Session / All time"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3271
+#: src/muuli_wdr.cpp:3275
 msgid "Active Uploads"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3285
+#: src/muuli_wdr.cpp:3289
 msgid "Percent of total files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3337
+#: src/muuli_wdr.cpp:3341
 msgid "Show Clients for"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3339
+#: src/muuli_wdr.cpp:3343
 msgid "All files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3342
+#: src/muuli_wdr.cpp:3346
 msgid "Selected files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3345
+#: src/muuli_wdr.cpp:3349
 msgid "Active uploads only"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3352
+#: src/muuli_wdr.cpp:3356
 msgid "Reload:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3356
+#: src/muuli_wdr.cpp:3360
 msgid "Reload your shared files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3419
+#: src/muuli_wdr.cpp:3423
 msgid "Send"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3420
+#: src/muuli_wdr.cpp:3424
 msgid "Sends the specified message."
 msgstr ""
 
-#: src/muuli_wdr.cpp:3424
+#: src/muuli_wdr.cpp:3428
 msgid "Close this chat-session."
 msgstr ""
 
-#: src/muuli_wdr.cpp:3447
+#: src/muuli_wdr.cpp:3451
 msgid "Connect to any server and/or Kad"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3453 src/SharedFilesCtrl.cpp:142 src/Statistics.cpp:941
+#: src/muuli_wdr.cpp:3457 src/SharedFilesCtrl.cpp:142 src/Statistics.cpp:941
 msgid "Shared Files"
 msgstr ""
 
@@ -5614,400 +5614,400 @@ msgid ""
 "these settings."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:647
+#: src/PrefsUnifiedDlg.cpp:656
 #, c-format
 msgid "Failed to connect Cfg to widget with the ID %d and key %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:695
+#: src/PrefsUnifiedDlg.cpp:704
 #, c-format
 msgid "Failed to transfer data from Cfg to Widget with the ID %d and key %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:801
+#: src/PrefsUnifiedDlg.cpp:810
 msgid "The type of proxy you are connecting to"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1020
+#: src/PrefsUnifiedDlg.cpp:1029
 #, c-format
 msgid "Failed to transfer data from Widget to Cfg with the ID %d and key %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1103
+#: src/PrefsUnifiedDlg.cpp:1112
 msgid "No password set."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1132
+#: src/PrefsUnifiedDlg.cpp:1141
 msgid "Guest access needs a password. Type one in the guest password field, or untick Enable guest access."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1144
+#: src/PrefsUnifiedDlg.cpp:1153
 msgid ""
 "aMule must be restarted to enable these changes:\n"
 "\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1151
+#: src/PrefsUnifiedDlg.cpp:1160
 msgid "- TCP port changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1156
+#: src/PrefsUnifiedDlg.cpp:1165
 msgid "- UDP port changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1161
+#: src/PrefsUnifiedDlg.cpp:1170
 msgid "- Network interface binding changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1166
+#: src/PrefsUnifiedDlg.cpp:1175
 msgid "- External connect port changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1170
+#: src/PrefsUnifiedDlg.cpp:1179
 msgid "- External connect acceptance changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1174
+#: src/PrefsUnifiedDlg.cpp:1183
 msgid "- External connect interface changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1178
+#: src/PrefsUnifiedDlg.cpp:1187
 msgid "- Protocol obfuscation support changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1193
+#: src/PrefsUnifiedDlg.cpp:1202
 msgid "- amuleapi settings changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1202
+#: src/PrefsUnifiedDlg.cpp:1211
 msgid ""
 "Your Auto-update server list is empty.\n"
 "'Auto-update server list at startup' will be disabled."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1213
+#: src/PrefsUnifiedDlg.cpp:1222
 msgid ""
 "You have enabled external connections but have not specified a password.\n"
 "External connections cannot be enabled unless a valid password is specified."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1246
+#: src/PrefsUnifiedDlg.cpp:1255
 #, c-format
 msgid "The amuleapi password could not be saved: %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1276
+#: src/PrefsUnifiedDlg.cpp:1285
 msgid "- Language changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1281
+#: src/PrefsUnifiedDlg.cpp:1290
 msgid "- Temp folder changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1286
+#: src/PrefsUnifiedDlg.cpp:1295
 msgid "- ED2K network enabled.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1319
+#: src/PrefsUnifiedDlg.cpp:1328
 msgid "The shared-file exclusion pattern is not a valid regular expression. The filter has been left disabled."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1321 src/PrefsUnifiedDlg.cpp:1921
+#: src/PrefsUnifiedDlg.cpp:1330 src/PrefsUnifiedDlg.cpp:1930
 msgid "Invalid regular expression"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1398
+#: src/PrefsUnifiedDlg.cpp:1407
 msgid ""
 "Both eD2k and Kad network are disabled.\n"
 "You won't be able to connect until you enable at least one of them."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1403
+#: src/PrefsUnifiedDlg.cpp:1412
 msgid ""
 "Kad will not start if your UDP port is disabled.\n"
 "Enable UDP port or disable Kad."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1459
+#: src/PrefsUnifiedDlg.cpp:1468
 msgid ""
 "\n"
 "You MUST restart aMule now.\n"
 "If you do not restart now, don't complain if anything bad happens.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1524
+#: src/PrefsUnifiedDlg.cpp:1533
 msgid "Could not register aMule for autostart at login. The autostart store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1526
+#: src/PrefsUnifiedDlg.cpp:1535
 msgid "Could not remove the autostart-at-login entry."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1527
+#: src/PrefsUnifiedDlg.cpp:1536
 msgid "Autostart"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1542
+#: src/PrefsUnifiedDlg.cpp:1551
 msgid "Register file type"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1542
+#: src/PrefsUnifiedDlg.cpp:1551
 msgid "Register URL handler"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1550
+#: src/PrefsUnifiedDlg.cpp:1559
 #, c-format
 msgid "aMule only handles eD2k-compatible magnets. If you replace the current magnet handler (%s), BitTorrent magnet links will stop working - aMule cannot download BitTorrent content. Continue?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1555
+#: src/PrefsUnifiedDlg.cpp:1564
 #, c-format
 msgid "Another application currently opens .emulecollection files (%s). Replace it with aMule?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1560
+#: src/PrefsUnifiedDlg.cpp:1569
 #, c-format
 msgid "Another application is currently the default handler for these links (%s). Replace it with aMule?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1585
+#: src/PrefsUnifiedDlg.cpp:1594
 msgid "Could not register aMule for .emulecollection files. The registration store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1587
+#: src/PrefsUnifiedDlg.cpp:1596
 msgid "Could not remove the file type registration."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1589
+#: src/PrefsUnifiedDlg.cpp:1598
 msgid "Could not register aMule as the URL handler. The registration store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1591
+#: src/PrefsUnifiedDlg.cpp:1600
 msgid "Could not remove the URL handler registration."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1661 src/PrefsUnifiedDlg.cpp:1688
+#: src/PrefsUnifiedDlg.cpp:1670 src/PrefsUnifiedDlg.cpp:1697
 msgid "The web server and aMule API require external connections to be enabled."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1671
+#: src/PrefsUnifiedDlg.cpp:1680
 msgid "The aMule web server is deprecated. Consider running the aMule API instead."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1735
+#: src/PrefsUnifiedDlg.cpp:1744
 msgid ""
 "Your Auto-update servers list is in blank.\n"
 "Please fill in at least one URL to point to a valid server.met file.\n"
 "Click on the button \"List\" by this checkbox to enter an URL."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1876
+#: src/PrefsUnifiedDlg.cpp:1885
 msgid "Temporary files"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1881
+#: src/PrefsUnifiedDlg.cpp:1890
 msgid "Incoming files"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1886
+#: src/PrefsUnifiedDlg.cpp:1895
 msgid "Online Signatures"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1899
+#: src/PrefsUnifiedDlg.cpp:1908
 #, c-format
 msgid "Choose a folder for %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1923
+#: src/PrefsUnifiedDlg.cpp:1932
 #, c-format
 msgid "Would exclude %u of %u shared file"
 msgid_plural "Would exclude %u of %u shared files"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/PrefsUnifiedDlg.cpp:1940
+#: src/PrefsUnifiedDlg.cpp:1949
 msgid "Browse for videoplayer"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1944
+#: src/PrefsUnifiedDlg.cpp:1953
 msgid "Select browser"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1948
+#: src/PrefsUnifiedDlg.cpp:1957
 msgid "Select ffprobe binary"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1954
+#: src/PrefsUnifiedDlg.cpp:1963
 #, c-format
 msgid "Executable%s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1988
+#: src/PrefsUnifiedDlg.cpp:1997
 msgid "ffprobe not found on PATH or in the standard install locations. Install ffmpeg (which ships ffprobe) or use Browse to pick a binary manually."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2000
+#: src/PrefsUnifiedDlg.cpp:2009
 msgid "Reset the settings on this page to their default values?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2001
+#: src/PrefsUnifiedDlg.cpp:2010
 msgid "Reset to defaults"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2028
+#: src/PrefsUnifiedDlg.cpp:2037
 msgid "Edit server list"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2029
+#: src/PrefsUnifiedDlg.cpp:2038
 msgid ""
 "Add here URL's to download server.met files.\n"
 "Only one url on each line."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2084
+#: src/PrefsUnifiedDlg.cpp:2093
 msgid "IP2Country update failed"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2229 src/PrefsUnifiedDlg.cpp:2260
+#: src/PrefsUnifiedDlg.cpp:2238 src/PrefsUnifiedDlg.cpp:2269
 msgid "Data by MaxMind GeoLite2"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2231 src/PrefsUnifiedDlg.cpp:2262
+#: src/PrefsUnifiedDlg.cpp:2240 src/PrefsUnifiedDlg.cpp:2271
 msgid "Custom source"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2233 src/PrefsUnifiedDlg.cpp:2264
+#: src/PrefsUnifiedDlg.cpp:2242 src/PrefsUnifiedDlg.cpp:2273
 msgid "Data by DB-IP.com"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2284
+#: src/PrefsUnifiedDlg.cpp:2293
 #, c-format
 msgid "Status: Loaded%s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2286
+#: src/PrefsUnifiedDlg.cpp:2295
 #, c-format
 msgid "Status: Loaded%s - %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2290
+#: src/PrefsUnifiedDlg.cpp:2299
 msgid "Status: Failed to load - click 'Update now' to refresh."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2292
+#: src/PrefsUnifiedDlg.cpp:2301
 msgid "Status: Not found - click 'Update now' to download."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2350 src/PrefsUnifiedDlg.cpp:2374
+#: src/PrefsUnifiedDlg.cpp:2359 src/PrefsUnifiedDlg.cpp:2383
 #, c-format
 msgid "Update delay: %d second"
 msgid_plural "Update delay: %d seconds"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/PrefsUnifiedDlg.cpp:2358
+#: src/PrefsUnifiedDlg.cpp:2367
 #, c-format
 msgid "Time for average graph: %d minute"
 msgid_plural "Time for average graph: %d minutes"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/PrefsUnifiedDlg.cpp:2367
+#: src/PrefsUnifiedDlg.cpp:2376
 #, c-format
 msgid "Connections Graph Scale: %d"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2382
+#: src/PrefsUnifiedDlg.cpp:2391
 #, c-format
 msgid "File Buffer Size: %d byte"
 msgid_plural "File Buffer Size: %d bytes"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/PrefsUnifiedDlg.cpp:2392
+#: src/PrefsUnifiedDlg.cpp:2401
 #, c-format
 msgid "Upload Queue Size: %d client"
 msgid_plural "Upload Queue Size: %d clients"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/PrefsUnifiedDlg.cpp:2402
+#: src/PrefsUnifiedDlg.cpp:2411
 #, c-format
 msgid "Server connection refresh interval: %d minute"
 msgid_plural "Server connection refresh interval: %d minutes"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/PrefsUnifiedDlg.cpp:2407
+#: src/PrefsUnifiedDlg.cpp:2416
 msgid "Server connection refresh interval: Disabled"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2451
+#: src/PrefsUnifiedDlg.cpp:2460
 msgid "disabled"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2477
+#: src/PrefsUnifiedDlg.cpp:2486
 #, c-format
 msgid "Execute command on '%s' event"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2484
+#: src/PrefsUnifiedDlg.cpp:2493
 msgid "Enable command execution on core"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2496
+#: src/PrefsUnifiedDlg.cpp:2505
 msgid "Core command:"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2512
+#: src/PrefsUnifiedDlg.cpp:2521
 msgid "Enable command execution on GUI"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2524
+#: src/PrefsUnifiedDlg.cpp:2533
 msgid "GUI command:"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2540
+#: src/PrefsUnifiedDlg.cpp:2549
 msgid "The following variables will be replaced:"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2708
+#: src/PrefsUnifiedDlg.cpp:2717
 msgid ""
 "The following folders look like system or sensitive locations:\n"
 "\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2713
+#: src/PrefsUnifiedDlg.cpp:2722
 msgid "Sharing them recursively will publish every file underneath on the eD2k/Kad networks. Do you really want to do this?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2716
+#: src/PrefsUnifiedDlg.cpp:2725
 msgid "Confirm shared folders"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2744
+#: src/PrefsUnifiedDlg.cpp:2753
 msgid "Reloading shared files..."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2745
+#: src/PrefsUnifiedDlg.cpp:2754
 msgid "Scanning for subdirectories..."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2746
+#: src/PrefsUnifiedDlg.cpp:2755
 msgid "Updating shared folders"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2773
+#: src/PrefsUnifiedDlg.cpp:2782
 #, c-format
 msgid "Scanned %u directories..."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2823
+#: src/PrefsUnifiedDlg.cpp:2832
 #, c-format
 msgid "Reloading shared files: %u files scanned"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2873
+#: src/PrefsUnifiedDlg.cpp:2882
 msgid "Shared folder"
 msgstr ""
 
@@ -7635,12 +7635,12 @@ msgstr ""
 msgid "Hashset requested for unknown file: %s"
 msgstr ""
 
-#: src/UploadQueue.cpp:618
+#: src/UploadQueue.cpp:627
 #, c-format
 msgid "Resuming uploads of file: %s"
 msgstr ""
 
-#: src/UploadQueue.cpp:634
+#: src/UploadQueue.cpp:643
 #, c-format
 msgid "Suspending upload of file: %s"
 msgstr ""

--- a/po/ta.po
+++ b/po/ta.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-28 08:06+0200\n"
+"POT-Creation-Date: 2026-07-28 10:19+0200\n"
 "PO-Revision-Date: 2026-07-27 11:50+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: none\n"
@@ -131,7 +131,7 @@ msgstr ""
 msgid "Not now"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:422 src/amuleDlg.cpp:600
+#: src/AppImageIntegration.cpp:422 src/amuleDlg.cpp:665
 msgid "Don't ask again"
 msgstr ""
 
@@ -203,7 +203,7 @@ msgid "Killing amuleweb instance with pid '%d' ... "
 msgstr ""
 
 #: src/amule.cpp:336 src/amule.cpp:349 src/ClientRef.cpp:180
-#: src/SearchDlg.cpp:880 src/ServerListCtrl.cpp:98
+#: src/SearchDlg.cpp:1041 src/ServerListCtrl.cpp:98
 msgid "Failed"
 msgstr ""
 
@@ -545,29 +545,67 @@ msgstr ""
 msgid "ERROR: %s"
 msgstr ""
 
-#: src/amuleDlg.cpp:236
+#: src/amuleDlg.cpp:250
 #, c-format
 msgid "This is aMule %s based on eMule."
 msgstr ""
 
-#: src/amuleDlg.cpp:237
+#: src/amuleDlg.cpp:251
 #, c-format
 msgid "Running on %s"
 msgstr ""
 
-#: src/amuleDlg.cpp:239
+#: src/amuleDlg.cpp:253
 msgid "Visit https://github.com/amule-org/amule/releases/latest to check if a new version is available."
 msgstr ""
 
-#: src/amuleDlg.cpp:268
+#: src/amuleDlg.cpp:282
 msgid "FATAL ERROR: Failed to create Timer"
 msgstr ""
 
-#: src/amuleDlg.cpp:592
+#: src/amuleDlg.cpp:361 src/amuleDlg.cpp:1787 src/amuleDlg.cpp:2033
+#: src/muuli_wdr.cpp:1492 src/muuli_wdr.cpp:3418
+msgid "Networks"
+msgstr ""
+
+#: src/amuleDlg.cpp:362 src/amuleDlg.cpp:1793 src/muuli_wdr.cpp:3419
+msgid "Searches"
+msgstr ""
+
+#: src/amuleDlg.cpp:363 src/amuleDlg.cpp:1799 src/DownloadListCtrl.cpp:740
+#: src/muuli_wdr.cpp:392 src/muuli_wdr.cpp:1585 src/muuli_wdr.cpp:3420
+#: src/Statistics.cpp:829
+msgid "Downloads"
+msgstr ""
+
+#: src/amuleDlg.cpp:364 src/amuleDlg.cpp:1805 src/muuli_wdr.cpp:3294
+msgid "Shared files"
+msgstr ""
+
+#: src/amuleDlg.cpp:365 src/amuleDlg.cpp:1811 src/muuli_wdr.cpp:2926
+#: src/muuli_wdr.cpp:3376 src/muuli_wdr.cpp:3423
+msgid "Messages"
+msgstr ""
+
+#: src/amuleDlg.cpp:366 src/amuleDlg.cpp:1817 src/muuli_wdr.cpp:3424
+#: src/PrefsUnifiedDlg.cpp:312 src/Statistics.cpp:779 src/Statistics.cpp:1235
+msgid "Statistics"
+msgstr ""
+
+#: src/amuleDlg.cpp:368 src/amuleDlg.cpp:1824 src/muuli_wdr.cpp:3426
+#: src/PrefsUnifiedDlg.cpp:328 src/utils/wxCas/src/wxcasprefs.cpp:39
+msgid "Preferences"
+msgstr ""
+
+#: src/amuleDlg.cpp:371
+msgid "Navigate"
+msgstr ""
+
+#: src/amuleDlg.cpp:657
 msgid "New version available"
 msgstr ""
 
-#: src/amuleDlg.cpp:596
+#: src/amuleDlg.cpp:661
 #, c-format
 msgid ""
 "A new version of aMule (%s) is available.\n"
@@ -577,217 +615,184 @@ msgid ""
 "Would you like to open the download page?"
 msgstr ""
 
-#: src/amuleDlg.cpp:678
+#: src/amuleDlg.cpp:743
 msgid "aMule dialog destroyed"
 msgstr ""
 
-#: src/amuleDlg.cpp:701 src/DataToText.cpp:68 src/IPFilter.cpp:547
+#: src/amuleDlg.cpp:766 src/DataToText.cpp:68 src/IPFilter.cpp:547
 msgid "Connecting"
 msgstr ""
 
-#: src/amuleDlg.cpp:893
+#: src/amuleDlg.cpp:958
 msgid "eD2k: Connecting"
 msgstr ""
 
-#: src/amuleDlg.cpp:897
+#: src/amuleDlg.cpp:962
 msgid "eD2k: Disconnected"
 msgstr ""
 
-#: src/amuleDlg.cpp:903
+#: src/amuleDlg.cpp:968
 msgid "Kad: Firewalled"
 msgstr ""
 
-#: src/amuleDlg.cpp:907
+#: src/amuleDlg.cpp:972
 msgid "Kad: Connected"
 msgstr ""
 
-#: src/amuleDlg.cpp:912
+#: src/amuleDlg.cpp:977
 msgid "Kad: Connecting"
 msgstr ""
 
-#: src/amuleDlg.cpp:916
+#: src/amuleDlg.cpp:981
 msgid "Kad: Off"
 msgstr ""
 
-#: src/amuleDlg.cpp:964 src/DownloadListCtrl.cpp:505
+#: src/amuleDlg.cpp:1029 src/DownloadListCtrl.cpp:505
 #: src/DownloadListCtrl.cpp:749 src/FriendListCtrl.cpp:180
 #: src/muuli_wdr.cpp:731 src/muuli_wdr.cpp:782 src/muuli_wdr.cpp:846
-#: src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2224 src/muuli_wdr.cpp:2309
-#: src/muuli_wdr.cpp:3057 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
+#: src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2231 src/muuli_wdr.cpp:2316
+#: src/muuli_wdr.cpp:3064 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
 #: src/ServerListCtrl.cpp:606 src/TransferWnd.cpp:378
 #: src/utils/wxCas/src/wxcasprefs.cpp:235
 msgid "Cancel"
 msgstr ""
 
-#: src/amuleDlg.cpp:965
+#: src/amuleDlg.cpp:1030
 msgid "Stop the current connection attempts"
 msgstr ""
 
-#: src/amuleDlg.cpp:970 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976
-#: src/muuli_wdr.cpp:2447
+#: src/amuleDlg.cpp:1035 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976
+#: src/muuli_wdr.cpp:2454
 msgid "Disconnect"
 msgstr ""
 
-#: src/amuleDlg.cpp:971
+#: src/amuleDlg.cpp:1036
 msgid "Disconnect from the currently connected networks"
 msgstr ""
 
-#: src/amuleDlg.cpp:976 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979
-#: src/muuli_wdr.cpp:2602 src/muuli_wdr.cpp:3054 src/muuli_wdr.cpp:3409
+#: src/amuleDlg.cpp:1041 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979
+#: src/muuli_wdr.cpp:2609 src/muuli_wdr.cpp:3061 src/muuli_wdr.cpp:3416
 msgid "Connect"
 msgstr ""
 
-#: src/amuleDlg.cpp:977
+#: src/amuleDlg.cpp:1042
 msgid "Connect to the currently enabled networks"
 msgstr ""
 
-#: src/amuleDlg.cpp:1089
+#: src/amuleDlg.cpp:1154
 #, c-format
 msgid "Up: %.1f%s (%.1f) | Down: %.1f%s (%.1f)"
 msgstr ""
 
-#: src/amuleDlg.cpp:1091 src/amuleDlg.cpp:1093 src/amuleDlg.cpp:1097
-#: src/amuleDlg.cpp:1099 src/amuleDlg.cpp:1110 src/amuleDlg.cpp:1112
+#: src/amuleDlg.cpp:1156 src/amuleDlg.cpp:1158 src/amuleDlg.cpp:1162
+#: src/amuleDlg.cpp:1164 src/amuleDlg.cpp:1175 src/amuleDlg.cpp:1177
 #: src/MuleTrayIcon.cpp:796 src/MuleTrayIcon.cpp:799
 msgid " MB/s"
 msgstr ""
 
-#: src/amuleDlg.cpp:1091 src/amuleDlg.cpp:1093 src/amuleDlg.cpp:1097
-#: src/amuleDlg.cpp:1099 src/amuleDlg.cpp:1110 src/amuleDlg.cpp:1112
+#: src/amuleDlg.cpp:1156 src/amuleDlg.cpp:1158 src/amuleDlg.cpp:1162
+#: src/amuleDlg.cpp:1164 src/amuleDlg.cpp:1175 src/amuleDlg.cpp:1177
 #: src/MuleTrayIcon.cpp:796 src/MuleTrayIcon.cpp:799
 #: src/utils/wxCas/src/wxcasframe.cpp:1041
 msgid " kB/s"
 msgstr ""
 
-#: src/amuleDlg.cpp:1096
+#: src/amuleDlg.cpp:1161
 #, c-format
 msgid "Up: %.1f%s | Down: %.1f%s"
 msgstr ""
 
-#: src/amuleDlg.cpp:1128
+#: src/amuleDlg.cpp:1193
 #, c-format
 msgid "aMule (%s | Connected)"
 msgstr ""
 
-#: src/amuleDlg.cpp:1130
+#: src/amuleDlg.cpp:1195
 #, c-format
 msgid "aMule (%s | Disconnected)"
 msgstr ""
 
-#: src/amuleDlg.cpp:1183
+#: src/amuleDlg.cpp:1248
 #, c-format
 msgid "Do you really want to exit %s?"
 msgstr ""
 
-#: src/amuleDlg.cpp:1185
+#: src/amuleDlg.cpp:1250
 msgid "Exit confirmation"
 msgstr ""
 
-#: src/amuleDlg.cpp:1548
+#: src/amuleDlg.cpp:1613
 msgid "Launch Command: "
 msgstr ""
 
-#: src/amuleDlg.cpp:1567 src/muuli_wdr.cpp:1971 src/Preferences.cpp:951
+#: src/amuleDlg.cpp:1632 src/muuli_wdr.cpp:1978 src/Preferences.cpp:952
 msgid "- default -"
 msgstr ""
 
-#: src/amuleDlg.cpp:1595
+#: src/amuleDlg.cpp:1660
 #, c-format
 msgid "Skin directory '%s' does not exist"
 msgstr ""
 
-#: src/amuleDlg.cpp:1598
+#: src/amuleDlg.cpp:1663
 #, c-format
 msgid "WARNING: Unable to open skin file '%s' for read"
 msgstr ""
 
-#: src/amuleDlg.cpp:1722 src/amuleDlg.cpp:1968 src/muuli_wdr.cpp:1485
-#: src/muuli_wdr.cpp:3411
-msgid "Networks"
-msgstr ""
-
-#: src/amuleDlg.cpp:1726 src/muuli_wdr.cpp:3411
+#: src/amuleDlg.cpp:1791 src/muuli_wdr.cpp:3418
 msgid "Networks Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1728 src/muuli_wdr.cpp:3412
-msgid "Searches"
-msgstr ""
-
-#: src/amuleDlg.cpp:1732 src/muuli_wdr.cpp:3412
+#: src/amuleDlg.cpp:1797 src/muuli_wdr.cpp:3419
 msgid "Searches Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1734 src/DownloadListCtrl.cpp:740 src/muuli_wdr.cpp:392
-#: src/muuli_wdr.cpp:1578 src/muuli_wdr.cpp:3413 src/Statistics.cpp:829
-msgid "Downloads"
-msgstr ""
-
-#: src/amuleDlg.cpp:1738 src/muuli_wdr.cpp:3413
+#: src/amuleDlg.cpp:1803 src/muuli_wdr.cpp:3420
 msgid "Downloads Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1740 src/muuli_wdr.cpp:3287
-msgid "Shared files"
-msgstr ""
-
-#: src/amuleDlg.cpp:1744 src/muuli_wdr.cpp:3415
+#: src/amuleDlg.cpp:1809 src/muuli_wdr.cpp:3422
 msgid "Shared Files Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1746 src/muuli_wdr.cpp:2919 src/muuli_wdr.cpp:3369
-#: src/muuli_wdr.cpp:3416
-msgid "Messages"
-msgstr ""
-
-#: src/amuleDlg.cpp:1750 src/muuli_wdr.cpp:3416
+#: src/amuleDlg.cpp:1815 src/muuli_wdr.cpp:3423
 msgid "Messages Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1752 src/muuli_wdr.cpp:3417 src/PrefsUnifiedDlg.cpp:312
-#: src/Statistics.cpp:779 src/Statistics.cpp:1235
-msgid "Statistics"
-msgstr ""
-
-#: src/amuleDlg.cpp:1756 src/muuli_wdr.cpp:3417
+#: src/amuleDlg.cpp:1821 src/muuli_wdr.cpp:3424
 msgid "Statistics Graph Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1759 src/muuli_wdr.cpp:3419 src/PrefsUnifiedDlg.cpp:328
-#: src/utils/wxCas/src/wxcasprefs.cpp:39
-msgid "Preferences"
-msgstr ""
-
-#: src/amuleDlg.cpp:1763 src/muuli_wdr.cpp:3419
+#: src/amuleDlg.cpp:1828 src/muuli_wdr.cpp:3426
 msgid "Preferences Settings Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1766 src/muuli_wdr.cpp:3420
+#: src/amuleDlg.cpp:1831 src/muuli_wdr.cpp:3427
 msgid "Import"
 msgstr ""
 
-#: src/amuleDlg.cpp:1770 src/muuli_wdr.cpp:3420
+#: src/amuleDlg.cpp:1835 src/muuli_wdr.cpp:3427
 msgid "The partfile importer tool"
 msgstr ""
 
-#: src/amuleDlg.cpp:1773 src/muuli_wdr.cpp:3421
+#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3428
 #: src/utils/aLinkCreator/src/alcframe.cpp:262
 msgid "About"
 msgstr ""
 
-#: src/amuleDlg.cpp:1773 src/muuli_wdr.cpp:3421
+#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3428
 msgid "About/Help"
 msgstr ""
 
-#: src/amuleDlg.cpp:1971
+#: src/amuleDlg.cpp:2036
 msgid "eD2k network"
 msgstr ""
 
-#: src/amuleDlg.cpp:1974
+#: src/amuleDlg.cpp:2039
 msgid "Kad network"
 msgstr ""
 
-#: src/amuleDlg.cpp:1974
+#: src/amuleDlg.cpp:2039
 msgid "No network"
 msgstr ""
 
@@ -1314,19 +1319,19 @@ msgstr ""
 msgid "Very low"
 msgstr ""
 
-#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:743 src/muuli_wdr.cpp:2275
+#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:743 src/muuli_wdr.cpp:2282
 #: src/ServerListCtrl.cpp:263 src/ServerListCtrl.cpp:456
 #: src/SharedFilesCtrl.cpp:145
 msgid "Low"
 msgstr ""
 
-#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:744 src/muuli_wdr.cpp:2276
+#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:744 src/muuli_wdr.cpp:2283
 #: src/ServerListCtrl.cpp:266 src/ServerListCtrl.cpp:457
 #: src/SharedFilesCtrl.cpp:146
 msgid "Normal"
 msgstr ""
 
-#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:745 src/muuli_wdr.cpp:2277
+#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:745 src/muuli_wdr.cpp:2284
 #: src/ServerListCtrl.cpp:269 src/ServerListCtrl.cpp:458
 #: src/SharedFilesCtrl.cpp:147
 msgid "High"
@@ -1418,8 +1423,8 @@ msgstr ""
 msgid "Remote Server"
 msgstr ""
 
-#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3174
-#: src/SearchDlg.cpp:111 src/TextClient.cpp:911
+#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3181
+#: src/SearchDlg.cpp:119 src/TextClient.cpp:911
 msgid "Kad"
 msgstr "காட்"
 
@@ -1489,7 +1494,7 @@ msgstr ""
 msgid "Size"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3241
+#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3248
 msgid "Transferred"
 msgstr ""
 
@@ -1545,7 +1550,7 @@ msgid ""
 "\n"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:746 src/muuli_wdr.cpp:2278
+#: src/DownloadListCtrl.cpp:746 src/muuli_wdr.cpp:2285
 #: src/SharedFilesCtrl.cpp:150
 msgid "Auto"
 msgstr ""
@@ -1583,7 +1588,7 @@ msgid "Extended Options"
 msgstr ""
 
 #: src/DownloadListCtrl.cpp:770 src/DownloadListCtrl.cpp:822
-#: src/muuli_wdr.cpp:1789
+#: src/muuli_wdr.cpp:1796
 msgid "Preview"
 msgstr ""
 
@@ -2261,19 +2266,19 @@ msgstr ""
 msgid "eD2k"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:349 src/muuli_wdr.cpp:1488
+#: src/FirstRunWizard.cpp:349 src/muuli_wdr.cpp:1495
 msgid "Kademlia"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:359 src/muuli_wdr.cpp:1416
+#: src/FirstRunWizard.cpp:359 src/muuli_wdr.cpp:1423
 msgid "Standard TCP Port "
 msgstr ""
 
-#: src/FirstRunWizard.cpp:365 src/muuli_wdr.cpp:1428
+#: src/FirstRunWizard.cpp:365 src/muuli_wdr.cpp:1435
 msgid "Extended UDP port (Kad / global search) "
 msgstr ""
 
-#: src/FirstRunWizard.cpp:377 src/muuli_wdr.cpp:1435
+#: src/FirstRunWizard.cpp:377 src/muuli_wdr.cpp:1442
 msgid "Enable UPnP for router port forwarding"
 msgstr ""
 
@@ -2298,7 +2303,7 @@ msgstr ""
 msgid "Your peer lists are already in place - nothing to download."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:434 src/muuli_wdr.cpp:1533
+#: src/FirstRunWizard.cpp:434 src/muuli_wdr.cpp:1540
 msgid "Auto-update server list at startup"
 msgstr ""
 
@@ -2344,23 +2349,23 @@ msgid ""
 "want downloads on a different (e.g. larger) disk."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:549 src/FirstRunWizard.cpp:611 src/muuli_wdr.cpp:1701
+#: src/FirstRunWizard.cpp:549 src/FirstRunWizard.cpp:611 src/muuli_wdr.cpp:1708
 msgid "Destination folder for downloads"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:553 src/FirstRunWizard.cpp:569 src/muuli_wdr.cpp:1342
-#: src/muuli_wdr.cpp:1359 src/muuli_wdr.cpp:1676 src/muuli_wdr.cpp:1707
-#: src/muuli_wdr.cpp:1719 src/muuli_wdr.cpp:2762
+#: src/FirstRunWizard.cpp:553 src/FirstRunWizard.cpp:569 src/muuli_wdr.cpp:1349
+#: src/muuli_wdr.cpp:1366 src/muuli_wdr.cpp:1683 src/muuli_wdr.cpp:1714
+#: src/muuli_wdr.cpp:1726 src/muuli_wdr.cpp:2769
 #: src/utils/aLinkCreator/src/alcframe.cpp:135
 #: src/utils/wxCas/src/wxcasprefs.cpp:52 src/utils/wxCas/src/wxcasprefs.cpp:118
 msgid "Browse"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:559 src/muuli_wdr.cpp:1712
+#: src/FirstRunWizard.cpp:559 src/muuli_wdr.cpp:1719
 msgid "(All files in this folder are shared with other peers)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:565 src/FirstRunWizard.cpp:624 src/muuli_wdr.cpp:1714
+#: src/FirstRunWizard.cpp:565 src/FirstRunWizard.cpp:624 src/muuli_wdr.cpp:1721
 msgid "Folder for temporary download files"
 msgstr ""
 
@@ -2391,7 +2396,7 @@ msgstr ""
 msgid "CRITICAL - no client on StartChatSession"
 msgstr ""
 
-#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2668 src/muuli_wdr.cpp:3345
+#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2675 src/muuli_wdr.cpp:3352
 msgid "Friends"
 msgstr ""
 
@@ -2769,7 +2774,7 @@ msgstr ""
 msgid "Uploaded"
 msgstr ""
 
-#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3225
+#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3232
 msgid "Requested"
 msgstr ""
 
@@ -2892,7 +2897,7 @@ msgid "WARNING: "
 msgstr ""
 
 #: src/MuleNotebook.cpp:179 src/muuli_wdr.cpp:817 src/muuli_wdr.cpp:1229
-#: src/muuli_wdr.cpp:3129 src/muuli_wdr.cpp:3385
+#: src/muuli_wdr.cpp:3136 src/muuli_wdr.cpp:3392
 msgid "Close"
 msgstr ""
 
@@ -2905,12 +2910,12 @@ msgstr ""
 msgid "Copy"
 msgstr ""
 
-#: src/MuleTextCtrl.cpp:88
+#: src/MuleTextCtrl.cpp:88 src/SearchDlg.cpp:261
 msgid "Paste"
 msgstr ""
 
 #: src/MuleTextCtrl.cpp:89 src/muuli_wdr.cpp:358 src/muuli_wdr.cpp:757
-#: src/muuli_wdr.cpp:2352 src/muuli_wdr.cpp:2371 src/muuli_wdr.cpp:2393
+#: src/muuli_wdr.cpp:2359 src/muuli_wdr.cpp:2378 src/muuli_wdr.cpp:2400
 #: src/utils/aLinkCreator/src/alcframe.cpp:142
 msgid "Clear"
 msgstr ""
@@ -3001,8 +3006,8 @@ msgid "Exit"
 msgstr ""
 
 #: src/MuleTrayIcon.cpp:579 src/MuleTrayIcon.cpp:945 src/MuleTrayIcon.cpp:965
-#: src/muuli_wdr.cpp:1391 src/muuli_wdr.cpp:1399 src/muuli_wdr.cpp:1406
-#: src/muuli_wdr.cpp:1835 src/muuli_wdr.cpp:1841 src/OtherFunctions.cpp:91
+#: src/muuli_wdr.cpp:1398 src/muuli_wdr.cpp:1406 src/muuli_wdr.cpp:1413
+#: src/muuli_wdr.cpp:1842 src/muuli_wdr.cpp:1848 src/OtherFunctions.cpp:91
 #: src/StatisticsDlg.cpp:93 src/StatisticsDlg.cpp:95
 msgid "kB/s"
 msgstr ""
@@ -3171,7 +3176,7 @@ msgstr ""
 msgid "Type"
 msgstr ""
 
-#: src/muuli_wdr.cpp:215 src/SearchDlg.cpp:110 src/SearchListCtrl.cpp:853
+#: src/muuli_wdr.cpp:215 src/SearchDlg.cpp:118 src/SearchListCtrl.cpp:853
 msgid "Local"
 msgstr ""
 
@@ -3242,7 +3247,7 @@ msgstr ""
 msgid "KB"
 msgstr ""
 
-#: src/muuli_wdr.cpp:274 src/muuli_wdr.cpp:293 src/muuli_wdr.cpp:1620
+#: src/muuli_wdr.cpp:274 src/muuli_wdr.cpp:293 src/muuli_wdr.cpp:1627
 #: src/OtherFunctions.cpp:64
 msgid "MB"
 msgstr ""
@@ -3259,7 +3264,7 @@ msgstr ""
 msgid "Availability"
 msgstr ""
 
-#: src/muuli_wdr.cpp:312 src/muuli_wdr.cpp:398 src/muuli_wdr.cpp:3290
+#: src/muuli_wdr.cpp:312 src/muuli_wdr.cpp:398 src/muuli_wdr.cpp:3297
 msgid "Filter:"
 msgstr ""
 
@@ -3291,7 +3296,7 @@ msgstr ""
 msgid "Stop"
 msgstr ""
 
-#: src/muuli_wdr.cpp:348 src/muuli_wdr.cpp:1385 src/SearchListCtrl.cpp:732
+#: src/muuli_wdr.cpp:348 src/muuli_wdr.cpp:1392 src/SearchListCtrl.cpp:732
 msgid "Download"
 msgstr ""
 
@@ -3322,8 +3327,8 @@ msgstr ""
 #: src/muuli_wdr.cpp:1160 src/muuli_wdr.cpp:1167 src/muuli_wdr.cpp:1172
 #: src/muuli_wdr.cpp:1179 src/muuli_wdr.cpp:1184 src/muuli_wdr.cpp:1191
 #: src/muuli_wdr.cpp:1205 src/muuli_wdr.cpp:1212 src/muuli_wdr.cpp:1217
-#: src/muuli_wdr.cpp:1224 src/muuli_wdr.cpp:3227 src/muuli_wdr.cpp:3235
-#: src/muuli_wdr.cpp:3243
+#: src/muuli_wdr.cpp:1224 src/muuli_wdr.cpp:3234 src/muuli_wdr.cpp:3242
+#: src/muuli_wdr.cpp:3250
 msgid "N/A"
 msgstr ""
 
@@ -3463,7 +3468,7 @@ msgstr ""
 msgid "Album :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:685 src/muuli_wdr.cpp:2247
+#: src/muuli_wdr.cpp:685 src/muuli_wdr.cpp:2254
 msgid "Title :"
 msgstr ""
 
@@ -3569,7 +3574,7 @@ msgstr ""
 msgid "Userhash :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:895 src/muuli_wdr.cpp:1741 src/muuli_wdr.cpp:2442
+#: src/muuli_wdr.cpp:895 src/muuli_wdr.cpp:1748 src/muuli_wdr.cpp:2449
 #: src/utils/aLinkCreator/src/alcframe.cpp:137
 msgid "Add"
 msgstr ""
@@ -3578,15 +3583,15 @@ msgstr ""
 msgid "Download-Speed"
 msgstr ""
 
-#: src/muuli_wdr.cpp:954 src/muuli_wdr.cpp:989 src/muuli_wdr.cpp:2546
+#: src/muuli_wdr.cpp:954 src/muuli_wdr.cpp:989 src/muuli_wdr.cpp:2553
 msgid "Current"
 msgstr ""
 
-#: src/muuli_wdr.cpp:962 src/muuli_wdr.cpp:997 src/muuli_wdr.cpp:2554
+#: src/muuli_wdr.cpp:962 src/muuli_wdr.cpp:997 src/muuli_wdr.cpp:2561
 msgid "Running average"
 msgstr ""
 
-#: src/muuli_wdr.cpp:970 src/muuli_wdr.cpp:1005 src/muuli_wdr.cpp:2562
+#: src/muuli_wdr.cpp:970 src/muuli_wdr.cpp:1005 src/muuli_wdr.cpp:2569
 msgid "Session average"
 msgstr ""
 
@@ -3598,7 +3603,7 @@ msgstr ""
 msgid "Connections"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1024 src/muuli_wdr.cpp:1860
+#: src/muuli_wdr.cpp:1024 src/muuli_wdr.cpp:1867
 msgid "Active downloads"
 msgstr ""
 
@@ -3606,7 +3611,7 @@ msgstr ""
 msgid "Active connections (1:1)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1040 src/muuli_wdr.cpp:1861
+#: src/muuli_wdr.cpp:1040 src/muuli_wdr.cpp:1868
 msgid "Active uploads"
 msgstr ""
 
@@ -3722,8 +3727,8 @@ msgstr ""
 msgid "Language: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1257 src/muuli_wdr.cpp:1323 src/muuli_wdr.cpp:1327
-#: src/muuli_wdr.cpp:1330
+#: src/muuli_wdr.cpp:1257 src/muuli_wdr.cpp:1330 src/muuli_wdr.cpp:1334
+#: src/muuli_wdr.cpp:1337
 msgid "The delay before showing tool-tips."
 msgstr ""
 
@@ -3799,923 +3804,931 @@ msgstr ""
 msgid "Enabling this will make aMule to show notifications when finished downloading."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1322
-msgid "Tooltip delay time: "
+#: src/muuli_wdr.cpp:1323
+msgid "Remember search history"
+msgstr ""
+
+#: src/muuli_wdr.cpp:1324
+msgid "Keeps a dropdown list of your past search terms in the Search tab's Name field. This remembers the queries you typed, not the results they returned."
 msgstr ""
 
 #: src/muuli_wdr.cpp:1329
+msgid "Tooltip delay time: "
+msgstr ""
+
+#: src/muuli_wdr.cpp:1336
 msgid "seconds"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1333
+#: src/muuli_wdr.cpp:1340
 msgid "Browser Selection"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1339
+#: src/muuli_wdr.cpp:1346
 msgid "Enter your browser name here. Leave this field empty to use the system default browser."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1346
+#: src/muuli_wdr.cpp:1353
 msgid "Open in new tab if possible"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1348
+#: src/muuli_wdr.cpp:1355
 msgid "Open the web page in a new tab instead of in a new window when possible"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1352
+#: src/muuli_wdr.cpp:1359
 msgid "Video Player"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1379
+#: src/muuli_wdr.cpp:1386
 msgid "Bandwidth limits"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1393
+#: src/muuli_wdr.cpp:1400
 msgid "Upload"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1401
+#: src/muuli_wdr.cpp:1408
 msgid "Slot Allocation"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1410
+#: src/muuli_wdr.cpp:1417
 msgid "Ports"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1420
+#: src/muuli_wdr.cpp:1427
 msgid "This is the standard eD2k port and cannot be disabled."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1423
+#: src/muuli_wdr.cpp:1430
 msgid "UDP port for server requests (TCP+3):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1425
+#: src/muuli_wdr.cpp:1432
 msgid "4665"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1432
+#: src/muuli_wdr.cpp:1439
 msgid "This UDP port is used for extended eD2k requests and Kad network"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1439
+#: src/muuli_wdr.cpp:1446
 msgid "UPnP TCP Port (Optional):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1449
+#: src/muuli_wdr.cpp:1456
 msgid "Bind local address to IP (empty for any):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1452
+#: src/muuli_wdr.cpp:1459
 msgid "Advanced users only: If you have multiple network interfaces, enter the address of the interface to which aMule should be bound."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1455 src/muuli_wdr.cpp:2054
+#: src/muuli_wdr.cpp:1462 src/muuli_wdr.cpp:2061
 msgid "Bind to network interface (empty for any):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1468
+#: src/muuli_wdr.cpp:1475
 msgid "Advanced users only: pin all of aMule's traffic to one network interface, chosen from the list or typed in by name (e.g. tun0, eth0, en0) or index. Unlike binding to an IP, this stops traffic leaking out via the default route - useful with a VPN. Requires no elevated privileges."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1474
+#: src/muuli_wdr.cpp:1481
 msgid "Max sources per downloading file:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1478
+#: src/muuli_wdr.cpp:1485
 msgid "Max simultaneous connections:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1491 src/muuli_wdr.cpp:3169
+#: src/muuli_wdr.cpp:1498 src/muuli_wdr.cpp:3176
 msgid "ED2K"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1498
+#: src/muuli_wdr.cpp:1505
 msgid "Autoconnect on startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1501
+#: src/muuli_wdr.cpp:1508
 msgid "Reconnect on loss"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1523
+#: src/muuli_wdr.cpp:1530
 msgid "Remove dead server after"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1524
+#: src/muuli_wdr.cpp:1531
 msgid "Static servers are never removed, even when unreachable."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1528
+#: src/muuli_wdr.cpp:1535
 msgid "retries"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1536
+#: src/muuli_wdr.cpp:1543
 msgid "List"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1539
+#: src/muuli_wdr.cpp:1546
 msgid "Update server list when connecting to a server"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1542
+#: src/muuli_wdr.cpp:1549
 msgid "Update server list when a client connects"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1545
+#: src/muuli_wdr.cpp:1552
 msgid "Use priority system"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1549
+#: src/muuli_wdr.cpp:1556
 msgid "Use smart LowID check on connect"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1553
+#: src/muuli_wdr.cpp:1560
 msgid "Safe connect"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1557
+#: src/muuli_wdr.cpp:1564
 msgid "Autoconnect to servers in static list only"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1560
+#: src/muuli_wdr.cpp:1567
 msgid "Set manually added servers to High Priority"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1581
+#: src/muuli_wdr.cpp:1588
 msgid "Add files to download in pause mode"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1583
+#: src/muuli_wdr.cpp:1590
 msgid "Add files to download with auto priority"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1586
+#: src/muuli_wdr.cpp:1593
 msgid "Try to download first and last chunks first"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1590
+#: src/muuli_wdr.cpp:1597
 msgid "Endgame mode: rotate to faster sources for the final blocks"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1593
+#: src/muuli_wdr.cpp:1600
 msgid "Start next paused file when a file completes"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1596
+#: src/muuli_wdr.cpp:1603
 msgid "From the same category"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1598
+#: src/muuli_wdr.cpp:1605
 msgid "In alphabetic order"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1600
+#: src/muuli_wdr.cpp:1607
 msgid "Preallocate disk space for new files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1601
+#: src/muuli_wdr.cpp:1608
 msgid "For new files preallocates disk space for the whole file, thus reduces fragmentation"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1606
+#: src/muuli_wdr.cpp:1613
 msgid "Create new files as sparse files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1607
+#: src/muuli_wdr.cpp:1614
 msgid "A sparse file reserves its full size on disk immediately without writing real data to it -- fast, but unsupported or slow on some filesystems, and free-space accounting stays optimistic while the download is in progress. Turn this off to grow the file only as data arrives."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1612
+#: src/muuli_wdr.cpp:1619
 msgid "Stop downloads when free disk space reaches "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1613
+#: src/muuli_wdr.cpp:1620
 msgid "Select this if you want aMule to check your disk space"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1617
+#: src/muuli_wdr.cpp:1624
 msgid "Enter here the min disk space desired."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1623
+#: src/muuli_wdr.cpp:1630
 msgid "Save 10 sources on rare files (< 20 sources)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1627 src/Statistics.cpp:790
+#: src/muuli_wdr.cpp:1634 src/Statistics.cpp:790
 msgid "Uploads"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1630
+#: src/muuli_wdr.cpp:1637
 msgid "Add new shared files with auto priority"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1636
+#: src/muuli_wdr.cpp:1643
 msgid "Intelligent Corruption Handling (I.C.H.)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1639
+#: src/muuli_wdr.cpp:1646
 msgid "Enable"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1642
+#: src/muuli_wdr.cpp:1649
 msgid "Advanced I.C.H. trusts every hash (not recommended)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1654 src/PrefsUnifiedDlg.cpp:1910
+#: src/muuli_wdr.cpp:1661 src/PrefsUnifiedDlg.cpp:1910
 msgid "Media metadata extraction"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1658
+#: src/muuli_wdr.cpp:1665
 msgid "Extract length / bitrate / codec from shared audio and video files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1660
+#: src/muuli_wdr.cpp:1667
 msgid "When enabled, aMule runs ffprobe on each shared media file to fill in the Length / Bitrate / Codec columns other clients see when they find the file in a search. Requires ffmpeg (the ffprobe binary) to be installed."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1667
+#: src/muuli_wdr.cpp:1674
 msgid "Path to ffprobe:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1672
+#: src/muuli_wdr.cpp:1679
 msgid "Full path to the ffprobe binary. Leave empty to have aMule auto-detect it on startup."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1680
+#: src/muuli_wdr.cpp:1687
 msgid "Detect"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1681
+#: src/muuli_wdr.cpp:1688
 msgid "Search the standard install locations for an ffprobe binary and fill the path field."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1705
+#: src/muuli_wdr.cpp:1712
 msgid ""
 "Completed downloads are stored here. All files in this folder are automatically shared with other peers.\n"
 "If this folder also holds files you don't want to share, point it at an aMule-only sub-folder."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1708
+#: src/muuli_wdr.cpp:1715
 msgid "Pick the folder where completed downloads will be stored. All files in that folder will be shared with other peers."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1722
+#: src/muuli_wdr.cpp:1729
 msgid "Shared folders"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1728
+#: src/muuli_wdr.cpp:1735
 msgid "(Folders shared by the core. Enter a path to add one.)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1736
+#: src/muuli_wdr.cpp:1743
 msgid "Absolute path of a folder on the core's machine, e.g. /home/user/shared"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1738 src/PrefsUnifiedDlg.cpp:2794
+#: src/muuli_wdr.cpp:1745 src/PrefsUnifiedDlg.cpp:2794
 msgid "Recursive"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1739
+#: src/muuli_wdr.cpp:1746
 msgid "Share every sub-folder underneath this one, including ones created later."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1743 src/utils/aLinkCreator/src/alcframe.cpp:141
+#: src/muuli_wdr.cpp:1750 src/utils/aLinkCreator/src/alcframe.cpp:141
 msgid "Remove"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1747
+#: src/muuli_wdr.cpp:1754
 msgid "(Right click on folder icon for recursive share)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1754
+#: src/muuli_wdr.cpp:1761
 msgid "Share hidden files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1760
+#: src/muuli_wdr.cpp:1767
 msgid "Automatically rescan shared folders for changes"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1766
+#: src/muuli_wdr.cpp:1773
 msgid "Follow symbolic links in shared folders"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1772
+#: src/muuli_wdr.cpp:1779
 msgid "Exclude files matching:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1775
+#: src/muuli_wdr.cpp:1782
 msgid "Wildcard patterns separated by '|', e.g. .DS_Store|Thumbs.db|*.tmp. Files whose name matches are not shared. Matching is case-insensitive."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1779
+#: src/muuli_wdr.cpp:1786
 msgid "Patterns are regular expressions"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1780
+#: src/muuli_wdr.cpp:1787
 msgid "When set, the whole field is one regular expression ('|' is alternation). When unset, it is a list of '|'-separated wildcards."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1790
+#: src/muuli_wdr.cpp:1797
 msgid "Show how many shared files the current pattern would exclude."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1811
+#: src/muuli_wdr.cpp:1818
 msgid "Graphs"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1814 src/muuli_wdr.cpp:1876
+#: src/muuli_wdr.cpp:1821 src/muuli_wdr.cpp:1883
 msgid "Update delay : 5 secs"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1818
+#: src/muuli_wdr.cpp:1825
 msgid "Time for average graph: 100 mins"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1822
+#: src/muuli_wdr.cpp:1829
 msgid "Connections Graph Scale: 100 "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1829
+#: src/muuli_wdr.cpp:1836
 msgid "Download graph scale:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1837
+#: src/muuli_wdr.cpp:1844
 msgid "Upload graph scale:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1847
+#: src/muuli_wdr.cpp:1854
 msgid "Colors: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1851
+#: src/muuli_wdr.cpp:1858
 msgid "Background"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1852
+#: src/muuli_wdr.cpp:1859
 msgid "Grid"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1853
+#: src/muuli_wdr.cpp:1860
 msgid "Download current"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1854
+#: src/muuli_wdr.cpp:1861
 msgid "Download running average"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1855
+#: src/muuli_wdr.cpp:1862
 msgid "Download session average"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1856
+#: src/muuli_wdr.cpp:1863
 msgid "Upload current"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1857
+#: src/muuli_wdr.cpp:1864
 msgid "Upload running average"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1858
+#: src/muuli_wdr.cpp:1865
 msgid "Upload session average"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1859
+#: src/muuli_wdr.cpp:1866
 msgid "Active connections"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1862
+#: src/muuli_wdr.cpp:1869
 msgid "Systray Icon Speed Bar"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1863
+#: src/muuli_wdr.cpp:1870
 msgid "Kad-nodes current"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1864
+#: src/muuli_wdr.cpp:1871
 msgid "Kad-nodes running"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1865
+#: src/muuli_wdr.cpp:1872
 msgid "Kad-nodes session"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1869 src/muuli_wdr.cpp:2296
+#: src/muuli_wdr.cpp:1876 src/muuli_wdr.cpp:2303
 msgid "Select"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1873
+#: src/muuli_wdr.cpp:1880
 msgid "Tree"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1883
+#: src/muuli_wdr.cpp:1890
 msgid "Number of Client Versions shown (0=unlimited)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1908
+#: src/muuli_wdr.cpp:1915
 msgid "!!! WARNING !!!"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1923
+#: src/muuli_wdr.cpp:1930
 msgid "Max new connections / 5 secs"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1925
+#: src/muuli_wdr.cpp:1932
 msgid "Concurrent Kad source lookups"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1927
+#: src/muuli_wdr.cpp:1934
 msgid "Kad source re-search interval (minutes)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1929
+#: src/muuli_wdr.cpp:1936
 msgid "Source re-ask interval (minutes)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1933
+#: src/muuli_wdr.cpp:1940
 msgid "File Buffer Size: 240000 bytes"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1937
+#: src/muuli_wdr.cpp:1944
 msgid "Use MMAP: memory-mapped file access (lower memory use)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1938
+#: src/muuli_wdr.cpp:1945
 msgid "Maps part files into memory instead of buffering them on the heap, lowering the process memory footprint. May reduce download speed on some disks; best for memory-constrained or upload-heavy hosts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1940
+#: src/muuli_wdr.cpp:1947
 msgid "Upload Queue Size: 5000 clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1944
+#: src/muuli_wdr.cpp:1951
 msgid "Server connection refresh interval: Disable"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1948
+#: src/muuli_wdr.cpp:1955
 msgid "Disable computer's timed standby mode"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1967
+#: src/muuli_wdr.cpp:1974
 msgid "Skin to use: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1976
+#: src/muuli_wdr.cpp:1983
 msgid "Show \"Fast eD2k Links Handler\" in every window."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1979
+#: src/muuli_wdr.cpp:1986
 msgid "Show extended info on categories tabs"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1982
+#: src/muuli_wdr.cpp:1989
 msgid "Show application version on title"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1984
+#: src/muuli_wdr.cpp:1991
 msgid "Show transfer rates on title"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1986
+#: src/muuli_wdr.cpp:1993
 msgid "Before application name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1988
+#: src/muuli_wdr.cpp:1995
 msgid "After application name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1991
+#: src/muuli_wdr.cpp:1998
 msgid "Show overhead bandwidth"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1995
+#: src/muuli_wdr.cpp:2002
 msgid "Vertical toolbar orientation"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1997
+#: src/muuli_wdr.cpp:2004
 msgid "Live column sorting (auto-reorder rows as their values change)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2004
+#: src/muuli_wdr.cpp:2011
 msgid "Download Queue Files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2007
+#: src/muuli_wdr.cpp:2014
 msgid "Show progress percentage"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2013
+#: src/muuli_wdr.cpp:2020
 msgid "Show progress bar"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2016
+#: src/muuli_wdr.cpp:2023
 msgid "Flat"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2020
+#: src/muuli_wdr.cpp:2027
 msgid "Round"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2038
+#: src/muuli_wdr.cpp:2045
 msgid "External Connection Parameters"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2041
+#: src/muuli_wdr.cpp:2048
 msgid "Accept external connections"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2048 src/muuli_wdr.cpp:2107
+#: src/muuli_wdr.cpp:2055 src/muuli_wdr.cpp:2114
 msgid "IP of the listening interface:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2051
+#: src/muuli_wdr.cpp:2058
 msgid "Enter here a valid ip in the a.b.c.d format for the listening EC interface. An empty field or 0.0.0.0 will mean any interface."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2072 src/muuli_wdr.cpp:2156
+#: src/muuli_wdr.cpp:2079 src/muuli_wdr.cpp:2163
 msgid "TCP port:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2078
+#: src/muuli_wdr.cpp:2085
 msgid "Enable UPnP port forwarding on the EC port"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2082 src/muuli_wdr.cpp:3041
+#: src/muuli_wdr.cpp:2089 src/muuli_wdr.cpp:3048
 #: src/utils/wxCas/src/wxcasprefs.cpp:167
 msgid "Password"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2088
+#: src/muuli_wdr.cpp:2095
 msgid "aMule API server parameters"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2091
+#: src/muuli_wdr.cpp:2098
 msgid "Run amuleapi (REST API) on startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2096
+#: src/muuli_wdr.cpp:2103
 msgid "HTTP port:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2110
+#: src/muuli_wdr.cpp:2117
 msgid "The interface amuleapi's HTTP server listens on. 127.0.0.1 (default) accepts only local connections; use 0.0.0.0 or a specific IP to expose it to other hosts (set an admin password below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2113
+#: src/muuli_wdr.cpp:2120
 msgid "Admin password"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2118 src/muuli_wdr.cpp:2149
+#: src/muuli_wdr.cpp:2125 src/muuli_wdr.cpp:2156
 msgid "Low rights password"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2126
+#: src/muuli_wdr.cpp:2133
 msgid "Web server parameters"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2129
+#: src/muuli_wdr.cpp:2136
 msgid "Run webserver on startup (deprecated)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2135
+#: src/muuli_wdr.cpp:2142
 msgid "Web template"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2140
+#: src/muuli_wdr.cpp:2147
 msgid "Full rights password"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2144
+#: src/muuli_wdr.cpp:2151
 msgid "Enable Low rights User"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2163
+#: src/muuli_wdr.cpp:2170
 msgid "Enable UPnP port forwarding of the web server port"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2168
+#: src/muuli_wdr.cpp:2175
 msgid "Web server UPnP TCP port (Optional)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2176
+#: src/muuli_wdr.cpp:2183
 msgid "Page Refresh Time (in secs)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2183
+#: src/muuli_wdr.cpp:2190
 msgid "Enable Gzip compression"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2217
+#: src/muuli_wdr.cpp:2224
 msgid "Reset page to defaults"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2218
+#: src/muuli_wdr.cpp:2225
 msgid "Reset the settings on the current page to their default values."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2220 src/muuli_wdr.cpp:2306 src/ServerWnd.cpp:274
+#: src/muuli_wdr.cpp:2227 src/muuli_wdr.cpp:2313 src/ServerWnd.cpp:274
 #: src/ServerWnd.cpp:282
 msgid "OK"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2222
+#: src/muuli_wdr.cpp:2229
 msgid "Click here to apply any changes made to the preferences."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2225
+#: src/muuli_wdr.cpp:2232
 msgid "Reset any changes made to the preferences."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2254
+#: src/muuli_wdr.cpp:2261
 msgid "Comment :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2261
+#: src/muuli_wdr.cpp:2268
 msgid "Incoming Dir :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2270
+#: src/muuli_wdr.cpp:2277
 msgid "Change priority for new assigned files :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2274
+#: src/muuli_wdr.cpp:2281
 msgid "Don't change"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2286
+#: src/muuli_wdr.cpp:2293
 msgid "Select color for this Category (currently selected) :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2353 src/muuli_wdr.cpp:2372 src/muuli_wdr.cpp:2394
+#: src/muuli_wdr.cpp:2360 src/muuli_wdr.cpp:2379 src/muuli_wdr.cpp:2401
 msgid "Click this button to reset the log."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2413
+#: src/muuli_wdr.cpp:2420
 msgid "Click on this button to update the servers list from URL ..."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2417
+#: src/muuli_wdr.cpp:2424
 msgid "Server list"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2421
+#: src/muuli_wdr.cpp:2428
 msgid "Enter the url to a server.met file here and press the button to the left to update the list of known servers."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2426
+#: src/muuli_wdr.cpp:2433
 msgid "Add server manually: Name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2429
+#: src/muuli_wdr.cpp:2436
 msgid "Enter the name of the new server here"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2431 src/ServerWnd.cpp:206
+#: src/muuli_wdr.cpp:2438 src/ServerWnd.cpp:206
 msgid "IP:Port"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2434
+#: src/muuli_wdr.cpp:2441
 msgid "Enter the IP of the server here, using the x.x.x.x format."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2440
+#: src/muuli_wdr.cpp:2447
 msgid "Enter the port of the server here."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2443
+#: src/muuli_wdr.cpp:2450
 msgid "Add manually a server (fill fields to the left before) ..."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2472
+#: src/muuli_wdr.cpp:2479
 msgid "aMule Log"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2480
+#: src/muuli_wdr.cpp:2487
 msgid "Server Info"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2484
+#: src/muuli_wdr.cpp:2491
 msgid "ED2K Info"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2488
+#: src/muuli_wdr.cpp:2495
 msgid "Kad Info"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2516
+#: src/muuli_wdr.cpp:2523
 msgid "Click on this button to update the nodes list from URL ..."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2520
+#: src/muuli_wdr.cpp:2527
 msgid "Nodes (0)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2524
+#: src/muuli_wdr.cpp:2531
 msgid "Enter the url to a nodes.dat file here and press the button to the left to update the list of known nodes."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2527
+#: src/muuli_wdr.cpp:2534
 msgid "Nodes stats"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2569
+#: src/muuli_wdr.cpp:2576
 msgid "Bootstrap"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2572
+#: src/muuli_wdr.cpp:2579
 msgid "New node"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2577
+#: src/muuli_wdr.cpp:2584
 msgid "IP:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2597
+#: src/muuli_wdr.cpp:2604
 msgid "Port:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2610
+#: src/muuli_wdr.cpp:2617
 msgid "Bootstrap from known clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2612
+#: src/muuli_wdr.cpp:2619
 msgid "Disconnect Kad"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2646
+#: src/muuli_wdr.cpp:2653
 msgid "Use Secure User Identification"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2648
+#: src/muuli_wdr.cpp:2655
 msgid "It is recommended to enable this option. You will not receive credits if SUI is not enabled."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2650
+#: src/muuli_wdr.cpp:2657
 msgid "Protocol Obfuscation"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2653
+#: src/muuli_wdr.cpp:2660
 msgid "Support Protocol Obfuscation"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2655
+#: src/muuli_wdr.cpp:2662
 msgid "This option enabled Protocol Obfuscation, and makes aMule accept obfuscated connections from other clients."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2657
+#: src/muuli_wdr.cpp:2664
 msgid "Use obfuscation for outgoing connections"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2659
+#: src/muuli_wdr.cpp:2666
 msgid "This option makes aMule use Protocol Obfuscation when connecting other clients/servers."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2661
+#: src/muuli_wdr.cpp:2668
 msgid "Accept only obfuscated connections"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2662
+#: src/muuli_wdr.cpp:2669
 msgid "This option makes aMule only accept obfuscated connections. You will have less sources, but all your traffic will be obfuscated"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2667
+#: src/muuli_wdr.cpp:2674
 msgid "Everybody"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2669
+#: src/muuli_wdr.cpp:2676
 msgid "No one"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2671
+#: src/muuli_wdr.cpp:2678
 msgid "Who can see my shared files:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2672
+#: src/muuli_wdr.cpp:2679
 msgid "Select who can request to view a list of your shared files."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2674
+#: src/muuli_wdr.cpp:2681
 msgid "IP-Filtering"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2681
+#: src/muuli_wdr.cpp:2688
 msgid "Filter clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2683
+#: src/muuli_wdr.cpp:2690
 msgid "Enable filtering of the client IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2685
+#: src/muuli_wdr.cpp:2692
 msgid "Filter servers"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2687
+#: src/muuli_wdr.cpp:2694
 msgid "Enable filtering of the server IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2691
+#: src/muuli_wdr.cpp:2698
 msgid "Reload List"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2692
+#: src/muuli_wdr.cpp:2699
 msgid "Reload the list of IPs to filter from the file ~/.aMule/ipfilter.dat"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2698
+#: src/muuli_wdr.cpp:2705
 msgid "URL:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2702 src/muuli_wdr.cpp:2895
+#: src/muuli_wdr.cpp:2709 src/muuli_wdr.cpp:2902
 msgid "Update now"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2705
+#: src/muuli_wdr.cpp:2712
 msgid "Auto-update ipfilter at startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2709
+#: src/muuli_wdr.cpp:2716
 msgid "Filtering Level:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2715
+#: src/muuli_wdr.cpp:2722
 msgid "Always filter LAN IPs"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2718
+#: src/muuli_wdr.cpp:2725
 msgid "Paranoid handling of non-matching IPs"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2720
+#: src/muuli_wdr.cpp:2727
 msgid "Rejects a packet when its source IP differs from the IP the client claims (an anti-spoofing check). Disable only if it causes connection problems."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2722
+#: src/muuli_wdr.cpp:2729
 msgid "Use system-wide ipfilter.dat if available"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2723
+#: src/muuli_wdr.cpp:2730
 msgid "If there's no local ipfilter.dat found, allow usage of a system-wide ipfilter file."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2740
+#: src/muuli_wdr.cpp:2747
 msgid "Enable Online-Signature"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2742
+#: src/muuli_wdr.cpp:2749
 msgid "Enables the writing of the OS file, which can be used by external apps to create signatures and the like."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2746
+#: src/muuli_wdr.cpp:2753
 msgid "Update Frequency (Secs):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2749
+#: src/muuli_wdr.cpp:2756
 msgid "Change the frequency (in seconds) of Online Signature updates."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2757
+#: src/muuli_wdr.cpp:2764
 msgid "Save online signature file in: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:2763
+#: src/muuli_wdr.cpp:2770
 msgid "Click here to select the directory containing the the Online Signature files."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2796
+#: src/muuli_wdr.cpp:2803
 msgid "Show country flags for clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2797
+#: src/muuli_wdr.cpp:2804
 msgid "Render the country flag column in the transfers, queue and search views. Requires a valid MMDB GeoIP database (see below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2802
+#: src/muuli_wdr.cpp:2809
 msgid "Database"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2818
+#: src/muuli_wdr.cpp:2825
 msgid "Source:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2821
+#: src/muuli_wdr.cpp:2828
 msgid "DB-IP (free, no account)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2822
+#: src/muuli_wdr.cpp:2829
 msgid "MaxMind GeoLite2 (free, account required)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2823
+#: src/muuli_wdr.cpp:2830
 msgid "Custom URL"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2826
+#: src/muuli_wdr.cpp:2833
 msgid "Choose which provider supplies the GeoIP MMDB database. DB-IP is the default - no account required. MaxMind requires a free account + license key. Use Custom URL to point at any other MMDB host (e.g. a local mirror)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2843
+#: src/muuli_wdr.cpp:2850
 msgid ""
 "No configuration required.\n"
 "\n"
@@ -4723,11 +4736,11 @@ msgid ""
 "License: Creative Commons BY 4.0 - https://creativecommons.org/licenses/by/4.0/"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2856
+#: src/muuli_wdr.cpp:2863
 msgid "License key:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2862
+#: src/muuli_wdr.cpp:2869
 msgid ""
 "Sign up for a free MaxMind account, then generate a License Key:\n"
 "https://www.maxmind.com/en/geolite2/signup\n"
@@ -4737,222 +4750,222 @@ msgid ""
 "Requires attribution and account registration; refresh at least every 30 days."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2877
+#: src/muuli_wdr.cpp:2884
 msgid "Download URL:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2883
+#: src/muuli_wdr.cpp:2890
 msgid ""
 "Must point to an .mmdb file or a .gz / .tar.gz containing one.\n"
 "URL may include credentials (https://user:pass@host/...).\n"
 "License and attribution terms are set by the upstream URL - you are responsible."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2896
+#: src/muuli_wdr.cpp:2903
 msgid "Download the GeoIP database from the selected source."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2898
+#: src/muuli_wdr.cpp:2905
 msgid "Auto-update on startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2899
+#: src/muuli_wdr.cpp:2906
 msgid "Re-download the GeoIP database from the selected source every time aMule starts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2922
+#: src/muuli_wdr.cpp:2929
 msgid "Filter incoming messages (except current chat):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2924
+#: src/muuli_wdr.cpp:2931
 msgid "Filter all messages"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2926
+#: src/muuli_wdr.cpp:2933
 msgid "Filter messages from people not on your friend list"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2928
+#: src/muuli_wdr.cpp:2935
 msgid "Filter messages from unknown clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2930
+#: src/muuli_wdr.cpp:2937
 msgid "Filter messages containing (use ',' as separator):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2933 src/muuli_wdr.cpp:2944
+#: src/muuli_wdr.cpp:2940 src/muuli_wdr.cpp:2951
 msgid "add here the words amule should filter and block messages including it"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2935
+#: src/muuli_wdr.cpp:2942
 msgid "Show received messages in the log"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2938
+#: src/muuli_wdr.cpp:2945
 msgid "Comments"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2941
+#: src/muuli_wdr.cpp:2948
 msgid "Filter comments containing (use ',' as separator):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2966
+#: src/muuli_wdr.cpp:2973
 msgid "Enable Proxy"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2967
+#: src/muuli_wdr.cpp:2974
 msgid "Enable/disable proxy support"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2970
+#: src/muuli_wdr.cpp:2977
 msgid "Proxy type:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2981
+#: src/muuli_wdr.cpp:2988
 msgid "Proxy host:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2984
+#: src/muuli_wdr.cpp:2991
 msgid "The proxy host name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2986
+#: src/muuli_wdr.cpp:2993
 msgid "Proxy port:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2989
+#: src/muuli_wdr.cpp:2996
 msgid "The proxy port"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2991
+#: src/muuli_wdr.cpp:2998
 msgid "Enable authentication"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2992
+#: src/muuli_wdr.cpp:2999
 msgid "Enable/disable username/password authentication"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2995
+#: src/muuli_wdr.cpp:3002
 msgid "Username: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:2998
+#: src/muuli_wdr.cpp:3005
 msgid "The username to use to connect to the proxy"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3000
+#: src/muuli_wdr.cpp:3007
 msgid "Password:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3003
+#: src/muuli_wdr.cpp:3010
 msgid "The password to use to connect to the proxy"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3022
+#: src/muuli_wdr.cpp:3029
 msgid "Connect to:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3031
+#: src/muuli_wdr.cpp:3038
 msgid "Login to remote amule"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3036
+#: src/muuli_wdr.cpp:3043
 msgid "User name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3047
+#: src/muuli_wdr.cpp:3054
 msgid "Remember those settings"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3050
+#: src/muuli_wdr.cpp:3057
 msgid "Force ZLIB compression"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3074
+#: src/muuli_wdr.cpp:3081
 msgid "Enable Verbose Debug-Logging."
 msgstr ""
 
-#: src/muuli_wdr.cpp:3076
+#: src/muuli_wdr.cpp:3083
 msgid "Only to Logfile"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3078
+#: src/muuli_wdr.cpp:3085
 msgid "Message Categories:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3102 src/PartFileConvertDlg.cpp:160
+#: src/muuli_wdr.cpp:3109 src/PartFileConvertDlg.cpp:160
 msgid "Waiting..."
 msgstr ""
 
-#: src/muuli_wdr.cpp:3122
+#: src/muuli_wdr.cpp:3129
 msgid "Add imports"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3125
+#: src/muuli_wdr.cpp:3132
 msgid "Retry selected"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3127
+#: src/muuli_wdr.cpp:3134
 msgid "Remove selected"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3190
+#: src/muuli_wdr.cpp:3197
 msgid "Event Types"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3209
+#: src/muuli_wdr.cpp:3216
 msgid "Statistics and queued clients for selected file(s) : Session / All time"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3233
+#: src/muuli_wdr.cpp:3240
 msgid "Active Uploads"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3247
+#: src/muuli_wdr.cpp:3254
 msgid "Percent of total files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3299
+#: src/muuli_wdr.cpp:3306
 msgid "Show Clients for"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3301
+#: src/muuli_wdr.cpp:3308
 msgid "All files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3304
+#: src/muuli_wdr.cpp:3311
 msgid "Selected files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3307
+#: src/muuli_wdr.cpp:3314
 msgid "Active uploads only"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3314
+#: src/muuli_wdr.cpp:3321
 msgid "Reload:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3318
+#: src/muuli_wdr.cpp:3325
 msgid "Reload your shared files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3381
+#: src/muuli_wdr.cpp:3388
 msgid "Send"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3382
+#: src/muuli_wdr.cpp:3389
 msgid "Sends the specified message."
 msgstr ""
 
-#: src/muuli_wdr.cpp:3386
+#: src/muuli_wdr.cpp:3393
 msgid "Close this chat-session."
 msgstr ""
 
-#: src/muuli_wdr.cpp:3409
+#: src/muuli_wdr.cpp:3416
 msgid "Connect to any server and/or Kad"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3415 src/SharedFilesCtrl.cpp:142 src/Statistics.cpp:941
+#: src/muuli_wdr.cpp:3422 src/SharedFilesCtrl.cpp:142 src/Statistics.cpp:941
 msgid "Shared Files"
 msgstr ""
 
@@ -5310,187 +5323,187 @@ msgstr ""
 msgid "ERROR: Failed to open partfile '%s'"
 msgstr ""
 
-#: src/Preferences.cpp:673
+#: src/Preferences.cpp:674
 msgid "System default"
 msgstr ""
 
-#: src/Preferences.cpp:674
+#: src/Preferences.cpp:675
 msgid "Albanian"
 msgstr ""
 
-#: src/Preferences.cpp:675
+#: src/Preferences.cpp:676
 msgid "Arabic"
 msgstr ""
 
-#: src/Preferences.cpp:676
+#: src/Preferences.cpp:677
 msgid "Asturian"
 msgstr ""
 
-#: src/Preferences.cpp:677
+#: src/Preferences.cpp:678
 msgid "Basque"
 msgstr ""
 
-#: src/Preferences.cpp:678
+#: src/Preferences.cpp:679
 msgid "Bulgarian"
 msgstr ""
 
-#: src/Preferences.cpp:679
+#: src/Preferences.cpp:680
 msgid "Catalan"
 msgstr ""
 
-#: src/Preferences.cpp:680
+#: src/Preferences.cpp:681
 msgid "Chinese (Simplified)"
 msgstr ""
 
-#: src/Preferences.cpp:681
+#: src/Preferences.cpp:682
 msgid "Chinese (Traditional)"
 msgstr ""
 
-#: src/Preferences.cpp:682
+#: src/Preferences.cpp:683
 msgid "Croatian"
 msgstr ""
 
-#: src/Preferences.cpp:683
+#: src/Preferences.cpp:684
 msgid "Czech"
 msgstr ""
 
-#: src/Preferences.cpp:684
+#: src/Preferences.cpp:685
 msgid "Danish"
 msgstr ""
 
-#: src/Preferences.cpp:685
+#: src/Preferences.cpp:686
 msgid "Dutch"
 msgstr ""
 
-#: src/Preferences.cpp:686
+#: src/Preferences.cpp:687
 msgid "English (U.K.)"
 msgstr ""
 
-#: src/Preferences.cpp:687
+#: src/Preferences.cpp:688
 msgid "English (U.S.)"
 msgstr ""
 
-#: src/Preferences.cpp:688
+#: src/Preferences.cpp:689
 msgid "Estonian"
 msgstr ""
 
-#: src/Preferences.cpp:689
+#: src/Preferences.cpp:690
 msgid "Finnish"
 msgstr ""
 
-#: src/Preferences.cpp:690
+#: src/Preferences.cpp:691
 msgid "French"
 msgstr ""
 
-#: src/Preferences.cpp:691
+#: src/Preferences.cpp:692
 msgid "Galician"
 msgstr ""
 
-#: src/Preferences.cpp:692
+#: src/Preferences.cpp:693
 msgid "German"
 msgstr ""
 
-#: src/Preferences.cpp:693
+#: src/Preferences.cpp:694
 msgid "Greek"
 msgstr ""
 
-#: src/Preferences.cpp:694
+#: src/Preferences.cpp:695
 msgid "Hebrew"
 msgstr ""
 
-#: src/Preferences.cpp:695
+#: src/Preferences.cpp:696
 msgid "Hungarian"
 msgstr ""
 
-#: src/Preferences.cpp:696
+#: src/Preferences.cpp:697
 msgid "Italian"
 msgstr ""
 
-#: src/Preferences.cpp:697
+#: src/Preferences.cpp:698
 msgid "Japanese"
 msgstr ""
 
-#: src/Preferences.cpp:698
+#: src/Preferences.cpp:699
 msgid "Korean"
 msgstr ""
 
-#: src/Preferences.cpp:699
+#: src/Preferences.cpp:700
 msgid "Latvian"
 msgstr ""
 
-#: src/Preferences.cpp:700
+#: src/Preferences.cpp:701
 msgid "Lithuanian"
 msgstr ""
 
-#: src/Preferences.cpp:701
+#: src/Preferences.cpp:702
 msgid "Norwegian (Nynorsk)"
 msgstr ""
 
-#: src/Preferences.cpp:702
+#: src/Preferences.cpp:703
 msgid "Polish"
 msgstr ""
 
-#: src/Preferences.cpp:703
+#: src/Preferences.cpp:704
 msgid "Portuguese"
 msgstr ""
 
-#: src/Preferences.cpp:704
+#: src/Preferences.cpp:705
 msgid "Portuguese (Brazilian)"
 msgstr ""
 
-#: src/Preferences.cpp:705
+#: src/Preferences.cpp:706
 msgid "Romanian"
 msgstr ""
 
-#: src/Preferences.cpp:706
+#: src/Preferences.cpp:707
 msgid "Russian"
 msgstr ""
 
-#: src/Preferences.cpp:707
+#: src/Preferences.cpp:708
 msgid "Slovenian"
 msgstr ""
 
-#: src/Preferences.cpp:708
+#: src/Preferences.cpp:709
 msgid "Spanish"
 msgstr ""
 
-#: src/Preferences.cpp:709
+#: src/Preferences.cpp:710
 msgid "Swedish"
 msgstr ""
 
-#: src/Preferences.cpp:710
+#: src/Preferences.cpp:711
 msgid "Turkish"
 msgstr ""
 
-#: src/Preferences.cpp:711
+#: src/Preferences.cpp:712
 msgid "Ukrainian"
 msgstr ""
 
-#: src/Preferences.cpp:814
+#: src/Preferences.cpp:815
 msgid "Change Language"
 msgstr ""
 
-#: src/Preferences.cpp:878
+#: src/Preferences.cpp:879
 msgid "There are no translations installed for aMule"
 msgstr ""
 
-#: src/Preferences.cpp:879
+#: src/Preferences.cpp:880
 msgid "No languages available"
 msgstr ""
 
-#: src/Preferences.cpp:1010
+#: src/Preferences.cpp:1011
 msgid "no options available"
 msgstr ""
 
-#: src/Preferences.cpp:2179
+#: src/Preferences.cpp:2182
 msgid "Invalid category found, skipping"
 msgstr ""
 
-#: src/Preferences.cpp:2348
+#: src/Preferences.cpp:2351
 msgid "TCP port can't be higher than 65532 due to server UDP socket being TCP+3"
 msgstr ""
 
-#: src/Preferences.cpp:2349
+#: src/Preferences.cpp:2352
 #, c-format
 msgid "Default port will be used (%d)"
 msgstr ""
@@ -5960,23 +5973,27 @@ msgstr ""
 msgid "Shared folder"
 msgstr ""
 
-#: src/SearchDlg.cpp:425
+#: src/SearchDlg.cpp:280
+msgid "Clear search history"
+msgstr ""
+
+#: src/SearchDlg.cpp:584
 msgid "It's impossible to search when both eD2k and Kademlia are disabled."
 msgstr ""
 
-#: src/SearchDlg.cpp:426 src/SearchListCtrl.cpp:858
+#: src/SearchDlg.cpp:585 src/SearchListCtrl.cpp:858
 msgid "Search error"
 msgstr ""
 
-#: src/SearchDlg.cpp:768
+#: src/SearchDlg.cpp:929
 msgid "Min size must be smaller than max size. Max size ignored."
 msgstr ""
 
-#: src/SearchDlg.cpp:769 src/SearchDlg.cpp:851
+#: src/SearchDlg.cpp:930 src/SearchDlg.cpp:1012
 msgid "Search warning"
 msgstr ""
 
-#: src/SearchDlg.cpp:929 src/SearchListCtrl.cpp:735
+#: src/SearchDlg.cpp:1092 src/SearchListCtrl.cpp:735
 msgid "Main"
 msgstr ""
 

--- a/po/ta.po
+++ b/po/ta.po
@@ -7,8 +7,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-28 12:12+0200\n"
-"PO-Revision-Date: 2026-07-27 10:40+0000\n"
+"POT-Creation-Date: 2026-07-28 08:06+0200\n"
+"PO-Revision-Date: 2026-07-27 11:50+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: none\n"
 "Language: ta\n"
@@ -131,7 +131,7 @@ msgstr ""
 msgid "Not now"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:422 src/amuleDlg.cpp:665
+#: src/AppImageIntegration.cpp:422 src/amuleDlg.cpp:600
 msgid "Don't ask again"
 msgstr ""
 
@@ -188,152 +188,152 @@ msgstr ""
 msgid "WARNING: You can't add yourself as a source for an eD2k link while having a lowid."
 msgstr ""
 
-#: src/amule.cpp:301
+#: src/amule.cpp:300
 msgid "Now, exiting main app..."
 msgstr ""
 
-#: src/amule.cpp:331
+#: src/amule.cpp:330
 #, c-format
 msgid "Terminating amuleweb instance with pid '%d' ... "
 msgstr ""
 
-#: src/amule.cpp:335
+#: src/amule.cpp:334
 #, c-format
 msgid "Killing amuleweb instance with pid '%d' ... "
 msgstr ""
 
-#: src/amule.cpp:337 src/amule.cpp:350 src/ClientRef.cpp:180
-#: src/SearchDlg.cpp:1041 src/ServerListCtrl.cpp:98
+#: src/amule.cpp:336 src/amule.cpp:349 src/ClientRef.cpp:180
+#: src/SearchDlg.cpp:880 src/ServerListCtrl.cpp:98
 msgid "Failed"
 msgstr ""
 
-#: src/amule.cpp:344
+#: src/amule.cpp:343
 #, c-format
 msgid "Terminating amuleapi instance with pid '%d' ... "
 msgstr ""
 
-#: src/amule.cpp:348
+#: src/amule.cpp:347
 #, c-format
 msgid "Killing amuleapi instance with pid '%d' ... "
 msgstr ""
 
-#: src/amule.cpp:356
+#: src/amule.cpp:355
 msgid "aMule OnExit: Terminating core."
 msgstr ""
 
-#: src/amule.cpp:467
+#: src/amule.cpp:466
 msgid "aMule shutdown completed."
 msgstr ""
 
-#: src/amule.cpp:471
+#: src/amule.cpp:470
 msgid "Memory debug results for aMule exit:"
 msgstr ""
 
-#: src/amule.cpp:652
+#: src/amule.cpp:651
 #, c-format
 msgid "Binding aMule's peer-to-peer traffic to interface: %s (HTTP updates use the default route)"
 msgstr ""
 
-#: src/amule.cpp:656
+#: src/amule.cpp:655
 #, c-format
 msgid "Binding all network traffic to interface: %s"
 msgstr ""
 
-#: src/amule.cpp:660
+#: src/amule.cpp:659
 #, c-format
 msgid "WARNING: configured network interface '%s' was not found - traffic is NOT bound to it and may leave via the default route. Check the interface name in Preferences."
 msgstr ""
 
-#: src/amule.cpp:666
+#: src/amule.cpp:665
 #, c-format
 msgid "WARNING: binding to network interface '%s' requires elevated privileges and was NOT applied - traffic may leave via the default route. Grant the capability (e.g. 'sudo setcap cap_net_raw+ep' on the aMule binary) or run with sufficient privileges."
 msgstr ""
 
-#: src/amule.cpp:674
+#: src/amule.cpp:673
 #, c-format
 msgid "WARNING: could not bind to network interface '%s' - traffic may leave via the default route."
 msgstr ""
 
-#: src/amule.cpp:733
+#: src/amule.cpp:732
 msgid "Your locale has been changed to System Default due to a configuration change. Sorry."
 msgstr ""
 
-#: src/amule.cpp:735 src/amule.cpp:1589 src/CatDialog.cpp:128
+#: src/amule.cpp:734 src/amule.cpp:1581 src/CatDialog.cpp:128
 #: src/CatDialog.cpp:136 src/CatDialog.cpp:149 src/ServerList.cpp:366
 #: src/ServerListCtrl.cpp:152
 msgid "Info"
 msgstr ""
 
-#: src/amule.cpp:742
+#: src/amule.cpp:741
 msgid ""
 "\n"
 "EC configuration"
 msgstr ""
 
-#: src/amule.cpp:745
+#: src/amule.cpp:744
 msgid "Password set and external connections enabled."
 msgstr ""
 
-#: src/amule.cpp:755 src/KadDlg.cpp:176 src/KadDlg.cpp:185
-#: src/PrefsUnifiedDlg.cpp:1461 src/SharedFilesCtrl.cpp:476
+#: src/amule.cpp:754 src/KadDlg.cpp:176 src/KadDlg.cpp:185
+#: src/PrefsUnifiedDlg.cpp:1387 src/SharedFilesCtrl.cpp:476
 msgid "WARNING"
 msgstr ""
 
-#: src/amule.cpp:992
+#: src/amule.cpp:991
 msgid "Network bootstrap"
 msgstr ""
 
-#: src/amule.cpp:997
+#: src/amule.cpp:996
 msgid ""
 "aMule has detected missing network bootstrap files.\n"
 "Select which ones to download:"
 msgstr ""
 
-#: src/amule.cpp:1006 src/FirstRunWizard.cpp:411
+#: src/amule.cpp:1005 src/FirstRunWizard.cpp:411
 msgid "eD2k server list (server.met)"
 msgstr ""
 
-#: src/amule.cpp:1013 src/FirstRunWizard.cpp:416
+#: src/amule.cpp:1012 src/FirstRunWizard.cpp:416
 msgid "Kad bootstrap nodes (nodes.dat)"
 msgstr ""
 
-#: src/amule.cpp:1103
+#: src/amule.cpp:1102
 #, c-format
 msgid "web server running on pid %d"
 msgstr ""
 
-#: src/amule.cpp:1116
+#: src/amule.cpp:1115
 msgid "You requested to run web server on startup, but the amuleweb binary cannot be run. Please install the package containing aMule web server, or build aMule from source with -DBUILD_WEBSERVER=YES and install it."
 msgstr ""
 
-#: src/amule.cpp:1121 src/amule.cpp:1185 src/amule.cpp:1299 src/amule.cpp:1601
+#: src/amule.cpp:1120 src/amule.cpp:1177 src/amule.cpp:1291 src/amule.cpp:1593
 #: src/amule-remote-gui.cpp:603 src/amule-remote-gui.cpp:671
 #: src/amule-remote-gui.cpp:709 src/amule-remote-gui.cpp:1282
 #: src/amule-remote-gui.cpp:1345 src/amule-remote-gui.cpp:1372
-#: src/DownloadQueue.cpp:1481 src/PrefsUnifiedDlg.cpp:1247
+#: src/DownloadQueue.cpp:1481
 msgid "ERROR"
 msgstr ""
 
-#: src/amule.cpp:1174
+#: src/amule.cpp:1166
 #, c-format
 msgid "amuleapi running on pid %d"
 msgstr ""
 
-#: src/amule.cpp:1180
+#: src/amule.cpp:1172
 msgid "You requested to run amuleapi on startup, but the amuleapi binary cannot be run. Please install the package containing aMule's REST API server, or build aMule from source with -DBUILD_AMULEAPI=YES and install it."
 msgstr ""
 
-#: src/amule.cpp:1267
+#: src/amule.cpp:1259
 #, c-format
 msgid "Could not bind ports to the specified address: %s"
 msgstr ""
 
-#: src/amule.cpp:1291
+#: src/amule.cpp:1283
 #, c-format
 msgid "Port %u is not available. You will be LOWID\n"
 msgstr ""
 
-#: src/amule.cpp:1296
+#: src/amule.cpp:1288
 #, c-format
 msgid ""
 "Port %u is not available!\n"
@@ -343,184 +343,184 @@ msgid ""
 "Check your network to make sure the port is open for output and input."
 msgstr ""
 
-#: src/amule.cpp:1393
+#: src/amule.cpp:1385
 msgid "Failed to create OnlineSig File"
 msgstr ""
 
-#: src/amule.cpp:1401
+#: src/amule.cpp:1393
 msgid "Failed to create aMule OnlineSig File"
 msgstr ""
 
-#: src/amule.cpp:1564
+#: src/amule.cpp:1556
 msgid "The selected locale seems not to be installed on your box. (Note: I'll try to set it anyway)"
 msgstr ""
 
-#: src/amule.cpp:1574
+#: src/amule.cpp:1566
 #, c-format
 msgid "This is the first time you run aMule %s"
 msgstr ""
 
-#: src/amule.cpp:1577
+#: src/amule.cpp:1569
 msgid "This version is a testing version, updated daily, and\n"
 msgstr ""
 
-#: src/amule.cpp:1578
+#: src/amule.cpp:1570
 msgid "we give no warranty it won't break anything, burn your house,\n"
 msgstr ""
 
-#: src/amule.cpp:1579
+#: src/amule.cpp:1571
 msgid "or kill your dog. But it *should* be safe to use anyway.\n"
 msgstr ""
 
-#: src/amule.cpp:1584
+#: src/amule.cpp:1576
 msgid "More information, support and new releases can found at our homepage,\n"
 msgstr ""
 
-#: src/amule.cpp:1585
+#: src/amule.cpp:1577
 msgid "at https://amule-org.github.io, or in our IRC channel #aMule at irc.libera.chat.\n"
 msgstr ""
 
-#: src/amule.cpp:1587
+#: src/amule.cpp:1579
 msgid "Feel free to report any bugs to https://github.com/amule-org/amule/issues"
 msgstr ""
 
-#: src/amule.cpp:1599
+#: src/amule.cpp:1591
 msgid ""
 "The folder for Online Signature files you specified is INVALID!\n"
 " OnlineSignature will be DISABLED until you fix it on preferences."
 msgstr ""
 
-#: src/amule.cpp:1662
+#: src/amule.cpp:1654
 msgid "Server hostname notified"
 msgstr ""
 
-#: src/amule.cpp:2039
+#: src/amule.cpp:2031
 #, c-format
 msgid "Disk space preallocation for file '%s' failed: %s"
 msgstr ""
 
-#: src/amule.cpp:2168
+#: src/amule.cpp:2160
 msgid "ERROR: can't open logfile"
 msgstr ""
 
-#: src/amule.cpp:2172
+#: src/amule.cpp:2164
 msgid "WARNING: logfile is empty. Something is wrong."
 msgstr ""
 
-#: src/amule.cpp:2189
+#: src/amule.cpp:2181
 msgid "Log has been reset"
 msgstr ""
 
-#: src/amule.cpp:2213
+#: src/amule.cpp:2205
 #, c-format
 msgid "ServerMessage: %s"
 msgstr ""
 
-#: src/amule.cpp:2256 src/IP2Country.cpp:220 src/IPFilter.cpp:514
+#: src/amule.cpp:2248 src/IP2Country.cpp:220 src/IPFilter.cpp:514
 #: src/ServerList.cpp:875
 #, c-format
 msgid "Skipped download of %s, because requested file is not newer."
 msgstr ""
 
-#: src/amule.cpp:2259
+#: src/amule.cpp:2251
 msgid "Failed to download the nodes list."
 msgstr ""
 
-#: src/amule.cpp:2322
+#: src/amule.cpp:2314
 msgid "Failed to open the downloaded version check file"
 msgstr ""
 
-#: src/amule.cpp:2325 src/amule.cpp:2344
+#: src/amule.cpp:2317 src/amule.cpp:2336
 msgid "Corrupted version check file"
 msgstr ""
 
-#: src/amule.cpp:2367
+#: src/amule.cpp:2359
 msgid "You are using an outdated version of aMule!"
 msgstr ""
 
-#: src/amule.cpp:2369
+#: src/amule.cpp:2361
 #, c-format
 msgid "Your aMule version is %i.%i.%i and the latest version is %li.%li.%li"
 msgstr ""
 
-#: src/amule.cpp:2373
+#: src/amule.cpp:2365
 msgid "The latest version can always be found at https://github.com/amule-org/amule/releases/latest"
 msgstr ""
 
-#: src/amule.cpp:2376
+#: src/amule.cpp:2368
 #, c-format
 msgid "WARNING: Your aMuled version is outdated: %i.%i.%i < %li.%li.%li"
 msgstr ""
 
-#: src/amule.cpp:2382
+#: src/amule.cpp:2374
 msgid "Your copy of aMule is up to date."
 msgstr ""
 
-#: src/amule.cpp:2389
+#: src/amule.cpp:2381
 msgid "Failed to download the version check file"
 msgstr ""
 
-#: src/amule.cpp:2558 src/amule-remote-gui.cpp:1133
+#: src/amule.cpp:2550 src/amule-remote-gui.cpp:1133
 #, c-format
 msgid "Users: %s | Files: %s"
 msgstr ""
 
-#: src/amule.cpp:2559 src/amule-remote-gui.cpp:1134
+#: src/amule.cpp:2551 src/amule-remote-gui.cpp:1134
 #, c-format
 msgid "Users: E: %s K: %s | Files: E: %s K: %s"
 msgstr ""
 
-#: src/amule.cpp:2573 src/amule-remote-gui.cpp:1147
+#: src/amule.cpp:2565 src/amule-remote-gui.cpp:1147
 msgid "No networks selected"
 msgstr ""
 
-#: src/amule.cpp:2641 src/TextClient.cpp:903
+#: src/amule.cpp:2633 src/TextClient.cpp:903
 msgid "with LowID"
 msgstr ""
 
-#: src/amule.cpp:2641 src/TextClient.cpp:904
+#: src/amule.cpp:2633 src/TextClient.cpp:904
 msgid "with HighID"
 msgstr ""
 
-#: src/amule.cpp:2643
+#: src/amule.cpp:2635
 #, c-format
 msgid "Connected to %s %s"
 msgstr ""
 
-#: src/amule.cpp:2648
+#: src/amule.cpp:2640
 #, c-format
 msgid "Connecting to %s"
 msgstr ""
 
-#: src/amule.cpp:2650
+#: src/amule.cpp:2642
 msgid "Disconnected from eD2k"
 msgstr ""
 
-#: src/amule.cpp:2659
+#: src/amule.cpp:2651
 msgid "Kad started."
 msgstr ""
 
-#: src/amule.cpp:2661
+#: src/amule.cpp:2653
 msgid "Kad stopped."
 msgstr ""
 
-#: src/amule.cpp:2669
+#: src/amule.cpp:2661
 msgid "Connected to Kad (ok)"
 msgstr ""
 
-#: src/amule.cpp:2671
+#: src/amule.cpp:2663
 msgid "Connected to Kad (firewalled)"
 msgstr ""
 
-#: src/amule.cpp:2675
+#: src/amule.cpp:2667
 msgid "Disconnected from Kad"
 msgstr ""
 
-#: src/amule.cpp:2707
+#: src/amule.cpp:2699
 msgid "Kad network cannot be used if UDP port is disabled on preferences, not starting."
 msgstr ""
 
-#: src/amule.cpp:2711
+#: src/amule.cpp:2703
 msgid "Kad network disabled on preferences, not connecting."
 msgstr ""
 
@@ -545,67 +545,29 @@ msgstr ""
 msgid "ERROR: %s"
 msgstr ""
 
-#: src/amuleDlg.cpp:250
+#: src/amuleDlg.cpp:236
 #, c-format
 msgid "This is aMule %s based on eMule."
 msgstr ""
 
-#: src/amuleDlg.cpp:251
+#: src/amuleDlg.cpp:237
 #, c-format
 msgid "Running on %s"
 msgstr ""
 
-#: src/amuleDlg.cpp:253
+#: src/amuleDlg.cpp:239
 msgid "Visit https://github.com/amule-org/amule/releases/latest to check if a new version is available."
 msgstr ""
 
-#: src/amuleDlg.cpp:282
+#: src/amuleDlg.cpp:268
 msgid "FATAL ERROR: Failed to create Timer"
 msgstr ""
 
-#: src/amuleDlg.cpp:361 src/amuleDlg.cpp:1810 src/amuleDlg.cpp:2056
-#: src/muuli_wdr.cpp:1492 src/muuli_wdr.cpp:3439
-msgid "Networks"
-msgstr ""
-
-#: src/amuleDlg.cpp:362 src/amuleDlg.cpp:1816 src/muuli_wdr.cpp:3440
-msgid "Searches"
-msgstr ""
-
-#: src/amuleDlg.cpp:363 src/amuleDlg.cpp:1822 src/DownloadListCtrl.cpp:740
-#: src/muuli_wdr.cpp:392 src/muuli_wdr.cpp:1585 src/muuli_wdr.cpp:3441
-#: src/Statistics.cpp:829
-msgid "Downloads"
-msgstr ""
-
-#: src/amuleDlg.cpp:364 src/amuleDlg.cpp:1828 src/muuli_wdr.cpp:3315
-msgid "Shared files"
-msgstr ""
-
-#: src/amuleDlg.cpp:365 src/amuleDlg.cpp:1834 src/muuli_wdr.cpp:2947
-#: src/muuli_wdr.cpp:3397 src/muuli_wdr.cpp:3444
-msgid "Messages"
-msgstr ""
-
-#: src/amuleDlg.cpp:366 src/amuleDlg.cpp:1840 src/muuli_wdr.cpp:3445
-#: src/PrefsUnifiedDlg.cpp:314 src/Statistics.cpp:779 src/Statistics.cpp:1235
-msgid "Statistics"
-msgstr ""
-
-#: src/amuleDlg.cpp:368 src/amuleDlg.cpp:1847 src/muuli_wdr.cpp:3447
-#: src/PrefsUnifiedDlg.cpp:330 src/utils/wxCas/src/wxcasprefs.cpp:39
-msgid "Preferences"
-msgstr ""
-
-#: src/amuleDlg.cpp:371
-msgid "Navigate"
-msgstr ""
-
-#: src/amuleDlg.cpp:657
+#: src/amuleDlg.cpp:592
 msgid "New version available"
 msgstr ""
 
-#: src/amuleDlg.cpp:661
+#: src/amuleDlg.cpp:596
 #, c-format
 msgid ""
 "A new version of aMule (%s) is available.\n"
@@ -615,184 +577,217 @@ msgid ""
 "Would you like to open the download page?"
 msgstr ""
 
-#: src/amuleDlg.cpp:743
+#: src/amuleDlg.cpp:678
 msgid "aMule dialog destroyed"
 msgstr ""
 
-#: src/amuleDlg.cpp:766 src/DataToText.cpp:68 src/IPFilter.cpp:547
+#: src/amuleDlg.cpp:701 src/DataToText.cpp:68 src/IPFilter.cpp:547
 msgid "Connecting"
 msgstr ""
 
-#: src/amuleDlg.cpp:958
+#: src/amuleDlg.cpp:893
 msgid "eD2k: Connecting"
 msgstr ""
 
-#: src/amuleDlg.cpp:962
+#: src/amuleDlg.cpp:897
 msgid "eD2k: Disconnected"
 msgstr ""
 
-#: src/amuleDlg.cpp:968
+#: src/amuleDlg.cpp:903
 msgid "Kad: Firewalled"
 msgstr ""
 
-#: src/amuleDlg.cpp:972
+#: src/amuleDlg.cpp:907
 msgid "Kad: Connected"
 msgstr ""
 
-#: src/amuleDlg.cpp:977
+#: src/amuleDlg.cpp:912
 msgid "Kad: Connecting"
 msgstr ""
 
-#: src/amuleDlg.cpp:981
+#: src/amuleDlg.cpp:916
 msgid "Kad: Off"
 msgstr ""
 
-#: src/amuleDlg.cpp:1029 src/DownloadListCtrl.cpp:505
+#: src/amuleDlg.cpp:964 src/DownloadListCtrl.cpp:505
 #: src/DownloadListCtrl.cpp:749 src/FriendListCtrl.cpp:180
 #: src/muuli_wdr.cpp:731 src/muuli_wdr.cpp:782 src/muuli_wdr.cpp:846
-#: src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2252 src/muuli_wdr.cpp:2337
-#: src/muuli_wdr.cpp:3085 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
+#: src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2224 src/muuli_wdr.cpp:2309
+#: src/muuli_wdr.cpp:3057 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
 #: src/ServerListCtrl.cpp:606 src/TransferWnd.cpp:378
 #: src/utils/wxCas/src/wxcasprefs.cpp:235
 msgid "Cancel"
 msgstr ""
 
-#: src/amuleDlg.cpp:1030
+#: src/amuleDlg.cpp:965
 msgid "Stop the current connection attempts"
 msgstr ""
 
-#: src/amuleDlg.cpp:1035 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976
-#: src/muuli_wdr.cpp:2475
+#: src/amuleDlg.cpp:970 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976
+#: src/muuli_wdr.cpp:2447
 msgid "Disconnect"
 msgstr ""
 
-#: src/amuleDlg.cpp:1036
+#: src/amuleDlg.cpp:971
 msgid "Disconnect from the currently connected networks"
 msgstr ""
 
-#: src/amuleDlg.cpp:1041 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979
-#: src/muuli_wdr.cpp:2630 src/muuli_wdr.cpp:3082 src/muuli_wdr.cpp:3437
+#: src/amuleDlg.cpp:976 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979
+#: src/muuli_wdr.cpp:2602 src/muuli_wdr.cpp:3054 src/muuli_wdr.cpp:3409
 msgid "Connect"
 msgstr ""
 
-#: src/amuleDlg.cpp:1042
+#: src/amuleDlg.cpp:977
 msgid "Connect to the currently enabled networks"
 msgstr ""
 
-#: src/amuleDlg.cpp:1154
+#: src/amuleDlg.cpp:1089
 #, c-format
 msgid "Up: %.1f%s (%.1f) | Down: %.1f%s (%.1f)"
 msgstr ""
 
-#: src/amuleDlg.cpp:1156 src/amuleDlg.cpp:1158 src/amuleDlg.cpp:1162
-#: src/amuleDlg.cpp:1164 src/amuleDlg.cpp:1175 src/amuleDlg.cpp:1177
+#: src/amuleDlg.cpp:1091 src/amuleDlg.cpp:1093 src/amuleDlg.cpp:1097
+#: src/amuleDlg.cpp:1099 src/amuleDlg.cpp:1110 src/amuleDlg.cpp:1112
 #: src/MuleTrayIcon.cpp:796 src/MuleTrayIcon.cpp:799
 msgid " MB/s"
 msgstr ""
 
-#: src/amuleDlg.cpp:1156 src/amuleDlg.cpp:1158 src/amuleDlg.cpp:1162
-#: src/amuleDlg.cpp:1164 src/amuleDlg.cpp:1175 src/amuleDlg.cpp:1177
+#: src/amuleDlg.cpp:1091 src/amuleDlg.cpp:1093 src/amuleDlg.cpp:1097
+#: src/amuleDlg.cpp:1099 src/amuleDlg.cpp:1110 src/amuleDlg.cpp:1112
 #: src/MuleTrayIcon.cpp:796 src/MuleTrayIcon.cpp:799
 #: src/utils/wxCas/src/wxcasframe.cpp:1041
 msgid " kB/s"
 msgstr ""
 
-#: src/amuleDlg.cpp:1161
+#: src/amuleDlg.cpp:1096
 #, c-format
 msgid "Up: %.1f%s | Down: %.1f%s"
 msgstr ""
 
-#: src/amuleDlg.cpp:1193
+#: src/amuleDlg.cpp:1128
 #, c-format
 msgid "aMule (%s | Connected)"
 msgstr ""
 
-#: src/amuleDlg.cpp:1195
+#: src/amuleDlg.cpp:1130
 #, c-format
 msgid "aMule (%s | Disconnected)"
 msgstr ""
 
-#: src/amuleDlg.cpp:1248
+#: src/amuleDlg.cpp:1183
 #, c-format
 msgid "Do you really want to exit %s?"
 msgstr ""
 
-#: src/amuleDlg.cpp:1250
+#: src/amuleDlg.cpp:1185
 msgid "Exit confirmation"
 msgstr ""
 
-#: src/amuleDlg.cpp:1613
+#: src/amuleDlg.cpp:1548
 msgid "Launch Command: "
 msgstr ""
 
-#: src/amuleDlg.cpp:1632 src/muuli_wdr.cpp:1972 src/Preferences.cpp:979
+#: src/amuleDlg.cpp:1567 src/muuli_wdr.cpp:1971 src/Preferences.cpp:951
 msgid "- default -"
 msgstr ""
 
-#: src/amuleDlg.cpp:1660
+#: src/amuleDlg.cpp:1595
 #, c-format
 msgid "Skin directory '%s' does not exist"
 msgstr ""
 
-#: src/amuleDlg.cpp:1663
+#: src/amuleDlg.cpp:1598
 #, c-format
 msgid "WARNING: Unable to open skin file '%s' for read"
 msgstr ""
 
-#: src/amuleDlg.cpp:1814 src/muuli_wdr.cpp:3439
+#: src/amuleDlg.cpp:1722 src/amuleDlg.cpp:1968 src/muuli_wdr.cpp:1485
+#: src/muuli_wdr.cpp:3411
+msgid "Networks"
+msgstr ""
+
+#: src/amuleDlg.cpp:1726 src/muuli_wdr.cpp:3411
 msgid "Networks Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1820 src/muuli_wdr.cpp:3440
+#: src/amuleDlg.cpp:1728 src/muuli_wdr.cpp:3412
+msgid "Searches"
+msgstr ""
+
+#: src/amuleDlg.cpp:1732 src/muuli_wdr.cpp:3412
 msgid "Searches Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1826 src/muuli_wdr.cpp:3441
+#: src/amuleDlg.cpp:1734 src/DownloadListCtrl.cpp:740 src/muuli_wdr.cpp:392
+#: src/muuli_wdr.cpp:1578 src/muuli_wdr.cpp:3413 src/Statistics.cpp:829
+msgid "Downloads"
+msgstr ""
+
+#: src/amuleDlg.cpp:1738 src/muuli_wdr.cpp:3413
 msgid "Downloads Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1832 src/muuli_wdr.cpp:3443
+#: src/amuleDlg.cpp:1740 src/muuli_wdr.cpp:3287
+msgid "Shared files"
+msgstr ""
+
+#: src/amuleDlg.cpp:1744 src/muuli_wdr.cpp:3415
 msgid "Shared Files Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3444
+#: src/amuleDlg.cpp:1746 src/muuli_wdr.cpp:2919 src/muuli_wdr.cpp:3369
+#: src/muuli_wdr.cpp:3416
+msgid "Messages"
+msgstr ""
+
+#: src/amuleDlg.cpp:1750 src/muuli_wdr.cpp:3416
 msgid "Messages Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1844 src/muuli_wdr.cpp:3445
+#: src/amuleDlg.cpp:1752 src/muuli_wdr.cpp:3417 src/PrefsUnifiedDlg.cpp:312
+#: src/Statistics.cpp:779 src/Statistics.cpp:1235
+msgid "Statistics"
+msgstr ""
+
+#: src/amuleDlg.cpp:1756 src/muuli_wdr.cpp:3417
 msgid "Statistics Graph Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1851 src/muuli_wdr.cpp:3447
+#: src/amuleDlg.cpp:1759 src/muuli_wdr.cpp:3419 src/PrefsUnifiedDlg.cpp:328
+#: src/utils/wxCas/src/wxcasprefs.cpp:39
+msgid "Preferences"
+msgstr ""
+
+#: src/amuleDlg.cpp:1763 src/muuli_wdr.cpp:3419
 msgid "Preferences Settings Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1854 src/muuli_wdr.cpp:3448
+#: src/amuleDlg.cpp:1766 src/muuli_wdr.cpp:3420
 msgid "Import"
 msgstr ""
 
-#: src/amuleDlg.cpp:1858 src/muuli_wdr.cpp:3448
+#: src/amuleDlg.cpp:1770 src/muuli_wdr.cpp:3420
 msgid "The partfile importer tool"
 msgstr ""
 
-#: src/amuleDlg.cpp:1861 src/muuli_wdr.cpp:3449
+#: src/amuleDlg.cpp:1773 src/muuli_wdr.cpp:3421
 #: src/utils/aLinkCreator/src/alcframe.cpp:262
 msgid "About"
 msgstr ""
 
-#: src/amuleDlg.cpp:1861 src/muuli_wdr.cpp:3449
+#: src/amuleDlg.cpp:1773 src/muuli_wdr.cpp:3421
 msgid "About/Help"
 msgstr ""
 
-#: src/amuleDlg.cpp:2059
+#: src/amuleDlg.cpp:1971
 msgid "eD2k network"
 msgstr ""
 
-#: src/amuleDlg.cpp:2062
+#: src/amuleDlg.cpp:1974
 msgid "Kad network"
 msgstr ""
 
-#: src/amuleDlg.cpp:2062
+#: src/amuleDlg.cpp:1974
 msgid "No network"
 msgstr ""
 
@@ -917,7 +912,7 @@ msgstr ""
 msgid "The core rejected these shared folders:%s"
 msgstr ""
 
-#: src/amule-remote-gui.cpp:1336 src/ExternalConn.cpp:2346
+#: src/amule-remote-gui.cpp:1336 src/ExternalConn.cpp:2345
 msgid "Invalid link or already on list."
 msgstr ""
 
@@ -933,7 +928,7 @@ msgstr ""
 #: src/ClientDetailDialog.cpp:123 src/DataToText.cpp:61 src/DataToText.cpp:86
 #: src/DataToText.cpp:101 src/DataToText.cpp:136 src/DataToText.cpp:165
 #: src/DownloadListCtrl.cpp:1172 src/DownloadListCtrl.cpp:1185
-#: src/DownloadListCtrl.cpp:1196 src/ExternalConn.cpp:609
+#: src/DownloadListCtrl.cpp:1196 src/ExternalConn.cpp:608
 #: src/FileDetailDialog.cpp:203 src/FileDetailDialog.cpp:235
 #: src/FileDetailDialog.cpp:242 src/GenericClientListCtrl.cpp:1171
 #: src/GenericClientListCtrl.cpp:1182 src/GenericClientListCtrl.cpp:1192
@@ -1319,19 +1314,19 @@ msgstr ""
 msgid "Very low"
 msgstr ""
 
-#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:743 src/muuli_wdr.cpp:2303
+#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:743 src/muuli_wdr.cpp:2275
 #: src/ServerListCtrl.cpp:263 src/ServerListCtrl.cpp:456
 #: src/SharedFilesCtrl.cpp:145
 msgid "Low"
 msgstr ""
 
-#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:744 src/muuli_wdr.cpp:2304
+#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:744 src/muuli_wdr.cpp:2276
 #: src/ServerListCtrl.cpp:266 src/ServerListCtrl.cpp:457
 #: src/SharedFilesCtrl.cpp:146
 msgid "Normal"
 msgstr ""
 
-#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:745 src/muuli_wdr.cpp:2305
+#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:745 src/muuli_wdr.cpp:2277
 #: src/ServerListCtrl.cpp:269 src/ServerListCtrl.cpp:458
 #: src/SharedFilesCtrl.cpp:147
 msgid "High"
@@ -1423,8 +1418,8 @@ msgstr ""
 msgid "Remote Server"
 msgstr ""
 
-#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3202
-#: src/SearchDlg.cpp:119 src/TextClient.cpp:911
+#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3174
+#: src/SearchDlg.cpp:111 src/TextClient.cpp:911
 msgid "Kad"
 msgstr "காட்"
 
@@ -1494,7 +1489,7 @@ msgstr ""
 msgid "Size"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3269
+#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3241
 msgid "Transferred"
 msgstr ""
 
@@ -1550,7 +1545,7 @@ msgid ""
 "\n"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:746 src/muuli_wdr.cpp:2306
+#: src/DownloadListCtrl.cpp:746 src/muuli_wdr.cpp:2278
 #: src/SharedFilesCtrl.cpp:150
 msgid "Auto"
 msgstr ""
@@ -1588,7 +1583,7 @@ msgid "Extended Options"
 msgstr ""
 
 #: src/DownloadListCtrl.cpp:770 src/DownloadListCtrl.cpp:822
-#: src/muuli_wdr.cpp:1790
+#: src/muuli_wdr.cpp:1789
 msgid "Preview"
 msgstr ""
 
@@ -1761,230 +1756,225 @@ msgstr[1] ""
 msgid "Invalid eD2k link! ERROR: %s"
 msgstr ""
 
-#: src/ExternalConn.cpp:380
+#: src/ExternalConn.cpp:379
 msgid "Client sent packet after authentication failed."
 msgstr ""
 
-#: src/ExternalConn.cpp:397
+#: src/ExternalConn.cpp:396
 msgid "External connection closed."
 msgstr ""
 
-#: src/ExternalConn.cpp:474
+#: src/ExternalConn.cpp:473
 msgid "External connections disabled due to empty password!"
 msgstr ""
 
-#: src/ExternalConn.cpp:495
+#: src/ExternalConn.cpp:494
 msgid "External connections disabled in config file"
 msgstr ""
 
-#: src/ExternalConn.cpp:576
+#: src/ExternalConn.cpp:575
 msgid "New external connection accepted"
 msgstr ""
 
-#: src/ExternalConn.cpp:579
+#: src/ExternalConn.cpp:578
 msgid "ERROR: couldn't accept a new external connection"
 msgstr ""
 
-#: src/ExternalConn.cpp:596
+#: src/ExternalConn.cpp:595
 msgid "External connection refused due to empty password in preferences!"
 msgstr ""
 
-#: src/ExternalConn.cpp:608
+#: src/ExternalConn.cpp:607
 #, c-format
 msgid "Connecting client: %s %s"
 msgstr ""
 
-#: src/ExternalConn.cpp:610
+#: src/ExternalConn.cpp:609
 msgid "Unknown version"
 msgstr ""
 
-#: src/ExternalConn.cpp:623
+#: src/ExternalConn.cpp:622
 msgid "Incorrect EC version ID, there might be binary incompatibility. Use core and remote from same snapshot."
 msgstr ""
 
-#: src/ExternalConn.cpp:631
+#: src/ExternalConn.cpp:630
 msgid "You cannot connect to a release version from an arbitrary development snapshot! *sigh* possible crash prevented"
 msgstr ""
 
-#: src/ExternalConn.cpp:714
+#: src/ExternalConn.cpp:713
 msgid "Invalid protocol version."
 msgstr ""
 
-#: src/ExternalConn.cpp:720
+#: src/ExternalConn.cpp:719
 msgid "Missing protocol version tag."
 msgstr ""
 
-#: src/ExternalConn.cpp:728
+#: src/ExternalConn.cpp:727
 msgid "Authentication failed: invalid hash specified as EC password."
 msgstr ""
 
-#: src/ExternalConn.cpp:776
+#: src/ExternalConn.cpp:775
 msgid "Authentication failed: wrong password."
 msgstr ""
 
-#: src/ExternalConn.cpp:778
+#: src/ExternalConn.cpp:777
 msgid "Authentication failed: missing password."
 msgstr ""
 
-#: src/ExternalConn.cpp:789
+#: src/ExternalConn.cpp:788
 msgid "Invalid request, please authenticate first."
 msgstr ""
 
-#: src/ExternalConn.cpp:794
+#: src/ExternalConn.cpp:793
 msgid "Access granted."
 msgstr ""
 
-#: src/ExternalConn.cpp:802
+#: src/ExternalConn.cpp:801
 #, c-format
 msgid "Sent error message \"%s\" to client."
 msgstr ""
 
-#: src/ExternalConn.cpp:807
+#: src/ExternalConn.cpp:806
 #, c-format
 msgid "Unauthorized access attempt from %s. Connection closed."
 msgstr ""
 
-#: src/ExternalConn.cpp:1420
+#: src/ExternalConn.cpp:1419
 #, c-format
 msgid "Remote PartFile command failed: FileHash not found: %s"
 msgstr ""
 
-#: src/ExternalConn.cpp:1424
+#: src/ExternalConn.cpp:1423
 #, c-format
 msgid "FileHash not found: %s"
 msgstr ""
 
-#: src/ExternalConn.cpp:1471 src/ExternalConn.cpp:1559
-#: src/ExternalConn.cpp:1680
+#: src/ExternalConn.cpp:1470 src/ExternalConn.cpp:1558
+#: src/ExternalConn.cpp:1679
 msgid "OOPS! OpCode processing error!"
 msgstr ""
 
-#: src/ExternalConn.cpp:1502
+#: src/ExternalConn.cpp:1501
 msgid "Server not added"
 msgstr ""
 
-#: src/ExternalConn.cpp:1521
+#: src/ExternalConn.cpp:1520
 #, c-format
 msgid "server not found: %s"
 msgstr ""
 
-#: src/ExternalConn.cpp:1538
+#: src/ExternalConn.cpp:1537
 msgid "need to define server to be removed"
 msgstr ""
 
-#: src/ExternalConn.cpp:1553
+#: src/ExternalConn.cpp:1552
 msgid "eD2k is disabled in preferences."
 msgstr ""
 
-#: src/ExternalConn.cpp:1658
+#: src/ExternalConn.cpp:1657
 msgid "Friend not found."
 msgstr ""
 
-#: src/ExternalConn.cpp:1668
+#: src/ExternalConn.cpp:1667
 msgid "Client not found."
 msgstr ""
 
-#: src/ExternalConn.cpp:1674
+#: src/ExternalConn.cpp:1673
 msgid "EC_TAG_FRIEND_SHARED requires EC_TAG_FRIEND or EC_TAG_CLIENT."
 msgstr ""
 
-#: src/ExternalConn.cpp:1992
+#: src/ExternalConn.cpp:1991
 msgid "WebSearch from remote interface makes no sense."
 msgstr ""
 
-#: src/ExternalConn.cpp:2027
+#: src/ExternalConn.cpp:2026
 msgid "Search in progress. Refetch results in a moment!"
 msgstr ""
 
-#: src/ExternalConn.cpp:2266
+#: src/ExternalConn.cpp:2265
 msgid "No points for graph."
 msgstr ""
 
-#: src/ExternalConn.cpp:2276
+#: src/ExternalConn.cpp:2275
 msgid "Your client is not configured for this detail level."
 msgstr ""
 
-#: src/ExternalConn.cpp:2303
+#: src/ExternalConn.cpp:2302
 msgid "External Connection: shutdown requested"
 msgstr ""
 
-#: src/ExternalConn.cpp:2315
+#: src/ExternalConn.cpp:2314
 msgid "Already shutting down."
 msgstr ""
 
-#: src/ExternalConn.cpp:2333
+#: src/ExternalConn.cpp:2332
 #, c-format
 msgid "ExternalConn: adding link '%s'."
 msgstr ""
 
-#: src/ExternalConn.cpp:2351
+#: src/ExternalConn.cpp:2350
 #, c-format
 msgid "%d of %d links failed (invalid or already on list)."
 msgstr ""
 
-#: src/ExternalConn.cpp:2374
+#: src/ExternalConn.cpp:2373
 msgid "Version check throttled; try again shortly."
 msgstr ""
 
-#: src/ExternalConn.cpp:2379
+#: src/ExternalConn.cpp:2378
 msgid "Version check is not available on this daemon."
 msgstr ""
 
-#: src/ExternalConn.cpp:2509
+#: src/ExternalConn.cpp:2508
 msgid "File not found."
 msgstr ""
 
-#: src/ExternalConn.cpp:2514
+#: src/ExternalConn.cpp:2513
 msgid "Invalid file name."
 msgstr ""
 
-#: src/ExternalConn.cpp:2522
+#: src/ExternalConn.cpp:2521
 msgid "Unable to rename file."
 msgstr ""
 
-#: src/ExternalConn.cpp:2839
-#, c-format
-msgid "Could not save the amuleapi password: %s"
-msgstr ""
-
-#: src/ExternalConn.cpp:3004 src/ExternalConn.cpp:3032
+#: src/ExternalConn.cpp:2992 src/ExternalConn.cpp:3020
 msgid "Kad is disabled in preferences."
 msgstr ""
 
-#: src/ExternalConn.cpp:3045
+#: src/ExternalConn.cpp:3033
 msgid "Already connected to eD2k."
 msgstr ""
 
-#: src/ExternalConn.cpp:3048
+#: src/ExternalConn.cpp:3036
 msgid "Connecting to eD2k..."
 msgstr ""
 
-#: src/ExternalConn.cpp:3057
+#: src/ExternalConn.cpp:3045
 msgid "Already connected to Kad."
 msgstr ""
 
-#: src/ExternalConn.cpp:3060
+#: src/ExternalConn.cpp:3048
 msgid "Connecting to Kad..."
 msgstr ""
 
-#: src/ExternalConn.cpp:3067
+#: src/ExternalConn.cpp:3055
 msgid "All networks are disabled."
 msgstr ""
 
-#: src/ExternalConn.cpp:3076
+#: src/ExternalConn.cpp:3064
 msgid "Disconnected from eD2k."
 msgstr ""
 
-#: src/ExternalConn.cpp:3081
+#: src/ExternalConn.cpp:3069
 msgid "Disconnected from Kad."
 msgstr ""
 
-#: src/ExternalConn.cpp:3090
+#: src/ExternalConn.cpp:3078
 #, c-format
 msgid "External Connection: invalid opcode received: %#x"
 msgstr ""
 
-#: src/ExternalConn.cpp:3095
+#: src/ExternalConn.cpp:3083
 msgid "Invalid opcode (wrong protocol version?)"
 msgstr ""
 
@@ -2271,19 +2261,19 @@ msgstr ""
 msgid "eD2k"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:349 src/muuli_wdr.cpp:1495
+#: src/FirstRunWizard.cpp:349 src/muuli_wdr.cpp:1488
 msgid "Kademlia"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:359 src/muuli_wdr.cpp:1423
+#: src/FirstRunWizard.cpp:359 src/muuli_wdr.cpp:1416
 msgid "Standard TCP Port "
 msgstr ""
 
-#: src/FirstRunWizard.cpp:365 src/muuli_wdr.cpp:1435
+#: src/FirstRunWizard.cpp:365 src/muuli_wdr.cpp:1428
 msgid "Extended UDP port (Kad / global search) "
 msgstr ""
 
-#: src/FirstRunWizard.cpp:377 src/muuli_wdr.cpp:1442
+#: src/FirstRunWizard.cpp:377 src/muuli_wdr.cpp:1435
 msgid "Enable UPnP for router port forwarding"
 msgstr ""
 
@@ -2308,7 +2298,7 @@ msgstr ""
 msgid "Your peer lists are already in place - nothing to download."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:434 src/muuli_wdr.cpp:1540
+#: src/FirstRunWizard.cpp:434 src/muuli_wdr.cpp:1533
 msgid "Auto-update server list at startup"
 msgstr ""
 
@@ -2354,23 +2344,23 @@ msgid ""
 "want downloads on a different (e.g. larger) disk."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:549 src/FirstRunWizard.cpp:611 src/muuli_wdr.cpp:1702
+#: src/FirstRunWizard.cpp:549 src/FirstRunWizard.cpp:611 src/muuli_wdr.cpp:1701
 msgid "Destination folder for downloads"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:553 src/FirstRunWizard.cpp:569 src/muuli_wdr.cpp:1349
-#: src/muuli_wdr.cpp:1366 src/muuli_wdr.cpp:1677 src/muuli_wdr.cpp:1708
-#: src/muuli_wdr.cpp:1720 src/muuli_wdr.cpp:2790
+#: src/FirstRunWizard.cpp:553 src/FirstRunWizard.cpp:569 src/muuli_wdr.cpp:1342
+#: src/muuli_wdr.cpp:1359 src/muuli_wdr.cpp:1676 src/muuli_wdr.cpp:1707
+#: src/muuli_wdr.cpp:1719 src/muuli_wdr.cpp:2762
 #: src/utils/aLinkCreator/src/alcframe.cpp:135
 #: src/utils/wxCas/src/wxcasprefs.cpp:52 src/utils/wxCas/src/wxcasprefs.cpp:118
 msgid "Browse"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:559 src/muuli_wdr.cpp:1713
+#: src/FirstRunWizard.cpp:559 src/muuli_wdr.cpp:1712
 msgid "(All files in this folder are shared with other peers)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:565 src/FirstRunWizard.cpp:624 src/muuli_wdr.cpp:1715
+#: src/FirstRunWizard.cpp:565 src/FirstRunWizard.cpp:624 src/muuli_wdr.cpp:1714
 msgid "Folder for temporary download files"
 msgstr ""
 
@@ -2401,7 +2391,7 @@ msgstr ""
 msgid "CRITICAL - no client on StartChatSession"
 msgstr ""
 
-#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2696 src/muuli_wdr.cpp:3373
+#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2668 src/muuli_wdr.cpp:3345
 msgid "Friends"
 msgstr ""
 
@@ -2507,8 +2497,8 @@ msgstr ""
 msgid "No"
 msgstr ""
 
-#: src/GenericClientListCtrl.cpp:1216 src/PrefsUnifiedDlg.cpp:2898
-#: src/PrefsUnifiedDlg.cpp:2948 src/ServerListCtrl.cpp:276
+#: src/GenericClientListCtrl.cpp:1216 src/PrefsUnifiedDlg.cpp:2818
+#: src/PrefsUnifiedDlg.cpp:2868 src/ServerListCtrl.cpp:276
 msgid "Yes"
 msgstr ""
 
@@ -2675,10 +2665,10 @@ msgstr ""
 msgid "Please fill all fields required"
 msgstr ""
 
-#: src/KadDlg.cpp:192 src/PartFile.cpp:1031 src/PrefsUnifiedDlg.cpp:1134
-#: src/PrefsUnifiedDlg.cpp:1204 src/PrefsUnifiedDlg.cpp:1405
-#: src/PrefsUnifiedDlg.cpp:1663 src/PrefsUnifiedDlg.cpp:1673
-#: src/PrefsUnifiedDlg.cpp:1690 src/PrefsUnifiedDlg.cpp:1738
+#: src/KadDlg.cpp:192 src/PartFile.cpp:1031 src/PrefsUnifiedDlg.cpp:1162
+#: src/PrefsUnifiedDlg.cpp:1331 src/PrefsUnifiedDlg.cpp:1589
+#: src/PrefsUnifiedDlg.cpp:1599 src/PrefsUnifiedDlg.cpp:1616
+#: src/PrefsUnifiedDlg.cpp:1658
 msgid "Message"
 msgstr ""
 
@@ -2779,7 +2769,7 @@ msgstr ""
 msgid "Uploaded"
 msgstr ""
 
-#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3253
+#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3225
 msgid "Requested"
 msgstr ""
 
@@ -2902,7 +2892,7 @@ msgid "WARNING: "
 msgstr ""
 
 #: src/MuleNotebook.cpp:179 src/muuli_wdr.cpp:817 src/muuli_wdr.cpp:1229
-#: src/muuli_wdr.cpp:3157 src/muuli_wdr.cpp:3413
+#: src/muuli_wdr.cpp:3129 src/muuli_wdr.cpp:3385
 msgid "Close"
 msgstr ""
 
@@ -2915,12 +2905,12 @@ msgstr ""
 msgid "Copy"
 msgstr ""
 
-#: src/MuleTextCtrl.cpp:88 src/SearchDlg.cpp:261
+#: src/MuleTextCtrl.cpp:88
 msgid "Paste"
 msgstr ""
 
 #: src/MuleTextCtrl.cpp:89 src/muuli_wdr.cpp:358 src/muuli_wdr.cpp:757
-#: src/muuli_wdr.cpp:2380 src/muuli_wdr.cpp:2399 src/muuli_wdr.cpp:2421
+#: src/muuli_wdr.cpp:2352 src/muuli_wdr.cpp:2371 src/muuli_wdr.cpp:2393
 #: src/utils/aLinkCreator/src/alcframe.cpp:142
 msgid "Clear"
 msgstr ""
@@ -3011,8 +3001,8 @@ msgid "Exit"
 msgstr ""
 
 #: src/MuleTrayIcon.cpp:579 src/MuleTrayIcon.cpp:945 src/MuleTrayIcon.cpp:965
-#: src/muuli_wdr.cpp:1398 src/muuli_wdr.cpp:1406 src/muuli_wdr.cpp:1413
-#: src/muuli_wdr.cpp:1836 src/muuli_wdr.cpp:1842 src/OtherFunctions.cpp:91
+#: src/muuli_wdr.cpp:1391 src/muuli_wdr.cpp:1399 src/muuli_wdr.cpp:1406
+#: src/muuli_wdr.cpp:1835 src/muuli_wdr.cpp:1841 src/OtherFunctions.cpp:91
 #: src/StatisticsDlg.cpp:93 src/StatisticsDlg.cpp:95
 msgid "kB/s"
 msgstr ""
@@ -3181,7 +3171,7 @@ msgstr ""
 msgid "Type"
 msgstr ""
 
-#: src/muuli_wdr.cpp:215 src/SearchDlg.cpp:118 src/SearchListCtrl.cpp:853
+#: src/muuli_wdr.cpp:215 src/SearchDlg.cpp:110 src/SearchListCtrl.cpp:853
 msgid "Local"
 msgstr ""
 
@@ -3252,7 +3242,7 @@ msgstr ""
 msgid "KB"
 msgstr ""
 
-#: src/muuli_wdr.cpp:274 src/muuli_wdr.cpp:293 src/muuli_wdr.cpp:1621
+#: src/muuli_wdr.cpp:274 src/muuli_wdr.cpp:293 src/muuli_wdr.cpp:1620
 #: src/OtherFunctions.cpp:64
 msgid "MB"
 msgstr ""
@@ -3269,7 +3259,7 @@ msgstr ""
 msgid "Availability"
 msgstr ""
 
-#: src/muuli_wdr.cpp:312 src/muuli_wdr.cpp:398 src/muuli_wdr.cpp:3318
+#: src/muuli_wdr.cpp:312 src/muuli_wdr.cpp:398 src/muuli_wdr.cpp:3290
 msgid "Filter:"
 msgstr ""
 
@@ -3301,7 +3291,7 @@ msgstr ""
 msgid "Stop"
 msgstr ""
 
-#: src/muuli_wdr.cpp:348 src/muuli_wdr.cpp:1392 src/SearchListCtrl.cpp:732
+#: src/muuli_wdr.cpp:348 src/muuli_wdr.cpp:1385 src/SearchListCtrl.cpp:732
 msgid "Download"
 msgstr ""
 
@@ -3332,12 +3322,12 @@ msgstr ""
 #: src/muuli_wdr.cpp:1160 src/muuli_wdr.cpp:1167 src/muuli_wdr.cpp:1172
 #: src/muuli_wdr.cpp:1179 src/muuli_wdr.cpp:1184 src/muuli_wdr.cpp:1191
 #: src/muuli_wdr.cpp:1205 src/muuli_wdr.cpp:1212 src/muuli_wdr.cpp:1217
-#: src/muuli_wdr.cpp:1224 src/muuli_wdr.cpp:3255 src/muuli_wdr.cpp:3263
-#: src/muuli_wdr.cpp:3271
+#: src/muuli_wdr.cpp:1224 src/muuli_wdr.cpp:3227 src/muuli_wdr.cpp:3235
+#: src/muuli_wdr.cpp:3243
 msgid "N/A"
 msgstr ""
 
-#: src/muuli_wdr.cpp:508 src/muuli_wdr.cpp:1065 src/PrefsUnifiedDlg.cpp:299
+#: src/muuli_wdr.cpp:508 src/muuli_wdr.cpp:1065 src/PrefsUnifiedDlg.cpp:297
 msgid "General"
 msgstr ""
 
@@ -3473,7 +3463,7 @@ msgstr ""
 msgid "Album :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:685 src/muuli_wdr.cpp:2275
+#: src/muuli_wdr.cpp:685 src/muuli_wdr.cpp:2247
 msgid "Title :"
 msgstr ""
 
@@ -3579,7 +3569,7 @@ msgstr ""
 msgid "Userhash :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:895 src/muuli_wdr.cpp:1742 src/muuli_wdr.cpp:2470
+#: src/muuli_wdr.cpp:895 src/muuli_wdr.cpp:1741 src/muuli_wdr.cpp:2442
 #: src/utils/aLinkCreator/src/alcframe.cpp:137
 msgid "Add"
 msgstr ""
@@ -3588,15 +3578,15 @@ msgstr ""
 msgid "Download-Speed"
 msgstr ""
 
-#: src/muuli_wdr.cpp:954 src/muuli_wdr.cpp:989 src/muuli_wdr.cpp:2574
+#: src/muuli_wdr.cpp:954 src/muuli_wdr.cpp:989 src/muuli_wdr.cpp:2546
 msgid "Current"
 msgstr ""
 
-#: src/muuli_wdr.cpp:962 src/muuli_wdr.cpp:997 src/muuli_wdr.cpp:2582
+#: src/muuli_wdr.cpp:962 src/muuli_wdr.cpp:997 src/muuli_wdr.cpp:2554
 msgid "Running average"
 msgstr ""
 
-#: src/muuli_wdr.cpp:970 src/muuli_wdr.cpp:1005 src/muuli_wdr.cpp:2590
+#: src/muuli_wdr.cpp:970 src/muuli_wdr.cpp:1005 src/muuli_wdr.cpp:2562
 msgid "Session average"
 msgstr ""
 
@@ -3608,7 +3598,7 @@ msgstr ""
 msgid "Connections"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1024 src/muuli_wdr.cpp:1861
+#: src/muuli_wdr.cpp:1024 src/muuli_wdr.cpp:1860
 msgid "Active downloads"
 msgstr ""
 
@@ -3616,7 +3606,7 @@ msgstr ""
 msgid "Active connections (1:1)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1040 src/muuli_wdr.cpp:1862
+#: src/muuli_wdr.cpp:1040 src/muuli_wdr.cpp:1861
 msgid "Active uploads"
 msgstr ""
 
@@ -3732,8 +3722,8 @@ msgstr ""
 msgid "Language: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1257 src/muuli_wdr.cpp:1330 src/muuli_wdr.cpp:1334
-#: src/muuli_wdr.cpp:1337
+#: src/muuli_wdr.cpp:1257 src/muuli_wdr.cpp:1323 src/muuli_wdr.cpp:1327
+#: src/muuli_wdr.cpp:1330
 msgid "The delay before showing tool-tips."
 msgstr ""
 
@@ -3809,943 +3799,923 @@ msgstr ""
 msgid "Enabling this will make aMule to show notifications when finished downloading."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1323
-msgid "Remember search history"
-msgstr ""
-
-#: src/muuli_wdr.cpp:1324
-msgid "Keeps a dropdown list of your past search terms in the Search tab's Name field. This remembers the queries you typed, not the results they returned."
-msgstr ""
-
-#: src/muuli_wdr.cpp:1329
+#: src/muuli_wdr.cpp:1322
 msgid "Tooltip delay time: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1336
+#: src/muuli_wdr.cpp:1329
 msgid "seconds"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1340
+#: src/muuli_wdr.cpp:1333
 msgid "Browser Selection"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1346
+#: src/muuli_wdr.cpp:1339
 msgid "Enter your browser name here. Leave this field empty to use the system default browser."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1353
+#: src/muuli_wdr.cpp:1346
 msgid "Open in new tab if possible"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1355
+#: src/muuli_wdr.cpp:1348
 msgid "Open the web page in a new tab instead of in a new window when possible"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1359
+#: src/muuli_wdr.cpp:1352
 msgid "Video Player"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1386
+#: src/muuli_wdr.cpp:1379
 msgid "Bandwidth limits"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1400
+#: src/muuli_wdr.cpp:1393
 msgid "Upload"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1408
+#: src/muuli_wdr.cpp:1401
 msgid "Slot Allocation"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1417
+#: src/muuli_wdr.cpp:1410
 msgid "Ports"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1427
+#: src/muuli_wdr.cpp:1420
 msgid "This is the standard eD2k port and cannot be disabled."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1430
+#: src/muuli_wdr.cpp:1423
 msgid "UDP port for server requests (TCP+3):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1432
+#: src/muuli_wdr.cpp:1425
 msgid "4665"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1439
+#: src/muuli_wdr.cpp:1432
 msgid "This UDP port is used for extended eD2k requests and Kad network"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1446
+#: src/muuli_wdr.cpp:1439
 msgid "UPnP TCP Port (Optional):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1456
+#: src/muuli_wdr.cpp:1449
 msgid "Bind local address to IP (empty for any):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1459
+#: src/muuli_wdr.cpp:1452
 msgid "Advanced users only: If you have multiple network interfaces, enter the address of the interface to which aMule should be bound."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1462 src/muuli_wdr.cpp:2055
+#: src/muuli_wdr.cpp:1455 src/muuli_wdr.cpp:2054
 msgid "Bind to network interface (empty for any):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1475
+#: src/muuli_wdr.cpp:1468
 msgid "Advanced users only: pin all of aMule's traffic to one network interface, chosen from the list or typed in by name (e.g. tun0, eth0, en0) or index. Unlike binding to an IP, this stops traffic leaking out via the default route - useful with a VPN. Requires no elevated privileges."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1481
+#: src/muuli_wdr.cpp:1474
 msgid "Max sources per downloading file:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1485
+#: src/muuli_wdr.cpp:1478
 msgid "Max simultaneous connections:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1498 src/muuli_wdr.cpp:3197
+#: src/muuli_wdr.cpp:1491 src/muuli_wdr.cpp:3169
 msgid "ED2K"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1505
+#: src/muuli_wdr.cpp:1498
 msgid "Autoconnect on startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1508
+#: src/muuli_wdr.cpp:1501
 msgid "Reconnect on loss"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1530
+#: src/muuli_wdr.cpp:1523
 msgid "Remove dead server after"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1531
+#: src/muuli_wdr.cpp:1524
 msgid "Static servers are never removed, even when unreachable."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1535
+#: src/muuli_wdr.cpp:1528
 msgid "retries"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1543
+#: src/muuli_wdr.cpp:1536
 msgid "List"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1546
+#: src/muuli_wdr.cpp:1539
 msgid "Update server list when connecting to a server"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1549
+#: src/muuli_wdr.cpp:1542
 msgid "Update server list when a client connects"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1552
+#: src/muuli_wdr.cpp:1545
 msgid "Use priority system"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1556
+#: src/muuli_wdr.cpp:1549
 msgid "Use smart LowID check on connect"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1560
+#: src/muuli_wdr.cpp:1553
 msgid "Safe connect"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1564
+#: src/muuli_wdr.cpp:1557
 msgid "Autoconnect to servers in static list only"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1567
+#: src/muuli_wdr.cpp:1560
 msgid "Set manually added servers to High Priority"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1588
+#: src/muuli_wdr.cpp:1581
 msgid "Add files to download in pause mode"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1590
+#: src/muuli_wdr.cpp:1583
 msgid "Add files to download with auto priority"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1593
+#: src/muuli_wdr.cpp:1586
 msgid "Try to download first and last chunks first"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1597
+#: src/muuli_wdr.cpp:1590
 msgid "Endgame mode: rotate to faster sources for the final blocks"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1600
+#: src/muuli_wdr.cpp:1593
 msgid "Start next paused file when a file completes"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1603
+#: src/muuli_wdr.cpp:1596
 msgid "From the same category"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1605
+#: src/muuli_wdr.cpp:1598
 msgid "In alphabetic order"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1607
+#: src/muuli_wdr.cpp:1600
 msgid "Preallocate disk space for new files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1608
+#: src/muuli_wdr.cpp:1601
 msgid "For new files preallocates disk space for the whole file, thus reduces fragmentation"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1613
+#: src/muuli_wdr.cpp:1606
+msgid "Create new files as sparse files"
+msgstr ""
+
+#: src/muuli_wdr.cpp:1607
+msgid "A sparse file reserves its full size on disk immediately without writing real data to it -- fast, but unsupported or slow on some filesystems, and free-space accounting stays optimistic while the download is in progress. Turn this off to grow the file only as data arrives."
+msgstr ""
+
+#: src/muuli_wdr.cpp:1612
 msgid "Stop downloads when free disk space reaches "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1614
+#: src/muuli_wdr.cpp:1613
 msgid "Select this if you want aMule to check your disk space"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1618
+#: src/muuli_wdr.cpp:1617
 msgid "Enter here the min disk space desired."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1624
+#: src/muuli_wdr.cpp:1623
 msgid "Save 10 sources on rare files (< 20 sources)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1628 src/Statistics.cpp:790
+#: src/muuli_wdr.cpp:1627 src/Statistics.cpp:790
 msgid "Uploads"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1631
+#: src/muuli_wdr.cpp:1630
 msgid "Add new shared files with auto priority"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1637
+#: src/muuli_wdr.cpp:1636
 msgid "Intelligent Corruption Handling (I.C.H.)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1640
+#: src/muuli_wdr.cpp:1639
 msgid "Enable"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1643
+#: src/muuli_wdr.cpp:1642
 msgid "Advanced I.C.H. trusts every hash (not recommended)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1655 src/PrefsUnifiedDlg.cpp:1990
+#: src/muuli_wdr.cpp:1654 src/PrefsUnifiedDlg.cpp:1910
 msgid "Media metadata extraction"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1659
+#: src/muuli_wdr.cpp:1658
 msgid "Extract length / bitrate / codec from shared audio and video files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1661
+#: src/muuli_wdr.cpp:1660
 msgid "When enabled, aMule runs ffprobe on each shared media file to fill in the Length / Bitrate / Codec columns other clients see when they find the file in a search. Requires ffmpeg (the ffprobe binary) to be installed."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1668
+#: src/muuli_wdr.cpp:1667
 msgid "Path to ffprobe:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1673
+#: src/muuli_wdr.cpp:1672
 msgid "Full path to the ffprobe binary. Leave empty to have aMule auto-detect it on startup."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1681
+#: src/muuli_wdr.cpp:1680
 msgid "Detect"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1682
+#: src/muuli_wdr.cpp:1681
 msgid "Search the standard install locations for an ffprobe binary and fill the path field."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1706
+#: src/muuli_wdr.cpp:1705
 msgid ""
 "Completed downloads are stored here. All files in this folder are automatically shared with other peers.\n"
 "If this folder also holds files you don't want to share, point it at an aMule-only sub-folder."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1709
+#: src/muuli_wdr.cpp:1708
 msgid "Pick the folder where completed downloads will be stored. All files in that folder will be shared with other peers."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1723
+#: src/muuli_wdr.cpp:1722
 msgid "Shared folders"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1729
+#: src/muuli_wdr.cpp:1728
 msgid "(Folders shared by the core. Enter a path to add one.)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1737
+#: src/muuli_wdr.cpp:1736
 msgid "Absolute path of a folder on the core's machine, e.g. /home/user/shared"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1739 src/PrefsUnifiedDlg.cpp:2874
+#: src/muuli_wdr.cpp:1738 src/PrefsUnifiedDlg.cpp:2794
 msgid "Recursive"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1740
+#: src/muuli_wdr.cpp:1739
 msgid "Share every sub-folder underneath this one, including ones created later."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1744 src/utils/aLinkCreator/src/alcframe.cpp:141
+#: src/muuli_wdr.cpp:1743 src/utils/aLinkCreator/src/alcframe.cpp:141
 msgid "Remove"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1748
+#: src/muuli_wdr.cpp:1747
 msgid "(Right click on folder icon for recursive share)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1755
+#: src/muuli_wdr.cpp:1754
 msgid "Share hidden files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1761
+#: src/muuli_wdr.cpp:1760
 msgid "Automatically rescan shared folders for changes"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1767
+#: src/muuli_wdr.cpp:1766
 msgid "Follow symbolic links in shared folders"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1773
+#: src/muuli_wdr.cpp:1772
 msgid "Exclude files matching:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1776
+#: src/muuli_wdr.cpp:1775
 msgid "Wildcard patterns separated by '|', e.g. .DS_Store|Thumbs.db|*.tmp. Files whose name matches are not shared. Matching is case-insensitive."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1780
+#: src/muuli_wdr.cpp:1779
 msgid "Patterns are regular expressions"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1781
+#: src/muuli_wdr.cpp:1780
 msgid "When set, the whole field is one regular expression ('|' is alternation). When unset, it is a list of '|'-separated wildcards."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1791
+#: src/muuli_wdr.cpp:1790
 msgid "Show how many shared files the current pattern would exclude."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1812
+#: src/muuli_wdr.cpp:1811
 msgid "Graphs"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1815 src/muuli_wdr.cpp:1877
+#: src/muuli_wdr.cpp:1814 src/muuli_wdr.cpp:1876
 msgid "Update delay : 5 secs"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1819
+#: src/muuli_wdr.cpp:1818
 msgid "Time for average graph: 100 mins"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1823
+#: src/muuli_wdr.cpp:1822
 msgid "Connections Graph Scale: 100 "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1830
+#: src/muuli_wdr.cpp:1829
 msgid "Download graph scale:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1838
+#: src/muuli_wdr.cpp:1837
 msgid "Upload graph scale:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1848
+#: src/muuli_wdr.cpp:1847
 msgid "Colors: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1852
+#: src/muuli_wdr.cpp:1851
 msgid "Background"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1853
+#: src/muuli_wdr.cpp:1852
 msgid "Grid"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1854
+#: src/muuli_wdr.cpp:1853
 msgid "Download current"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1855
+#: src/muuli_wdr.cpp:1854
 msgid "Download running average"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1856
+#: src/muuli_wdr.cpp:1855
 msgid "Download session average"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1857
+#: src/muuli_wdr.cpp:1856
 msgid "Upload current"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1858
+#: src/muuli_wdr.cpp:1857
 msgid "Upload running average"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1859
+#: src/muuli_wdr.cpp:1858
 msgid "Upload session average"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1860
+#: src/muuli_wdr.cpp:1859
 msgid "Active connections"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1863
+#: src/muuli_wdr.cpp:1862
 msgid "Systray Icon Speed Bar"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1864
+#: src/muuli_wdr.cpp:1863
 msgid "Kad-nodes current"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1865
+#: src/muuli_wdr.cpp:1864
 msgid "Kad-nodes running"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1866
+#: src/muuli_wdr.cpp:1865
 msgid "Kad-nodes session"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1870 src/muuli_wdr.cpp:2324
+#: src/muuli_wdr.cpp:1869 src/muuli_wdr.cpp:2296
 msgid "Select"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1874
+#: src/muuli_wdr.cpp:1873
 msgid "Tree"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1884
+#: src/muuli_wdr.cpp:1883
 msgid "Number of Client Versions shown (0=unlimited)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1909
+#: src/muuli_wdr.cpp:1908
 msgid "!!! WARNING !!!"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1924
+#: src/muuli_wdr.cpp:1923
 msgid "Max new connections / 5 secs"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1926
+#: src/muuli_wdr.cpp:1925
 msgid "Concurrent Kad source lookups"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1928
+#: src/muuli_wdr.cpp:1927
 msgid "Kad source re-search interval (minutes)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1930
+#: src/muuli_wdr.cpp:1929
 msgid "Source re-ask interval (minutes)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1934
+#: src/muuli_wdr.cpp:1933
 msgid "File Buffer Size: 240000 bytes"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1938
+#: src/muuli_wdr.cpp:1937
 msgid "Use MMAP: memory-mapped file access (lower memory use)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1939
+#: src/muuli_wdr.cpp:1938
 msgid "Maps part files into memory instead of buffering them on the heap, lowering the process memory footprint. May reduce download speed on some disks; best for memory-constrained or upload-heavy hosts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1941
+#: src/muuli_wdr.cpp:1940
 msgid "Upload Queue Size: 5000 clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1945
+#: src/muuli_wdr.cpp:1944
 msgid "Server connection refresh interval: Disable"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1949
+#: src/muuli_wdr.cpp:1948
 msgid "Disable computer's timed standby mode"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1968
+#: src/muuli_wdr.cpp:1967
 msgid "Skin to use: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1977
+#: src/muuli_wdr.cpp:1976
 msgid "Show \"Fast eD2k Links Handler\" in every window."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1980
+#: src/muuli_wdr.cpp:1979
 msgid "Show extended info on categories tabs"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1983
+#: src/muuli_wdr.cpp:1982
 msgid "Show application version on title"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1985
+#: src/muuli_wdr.cpp:1984
 msgid "Show transfer rates on title"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1987
+#: src/muuli_wdr.cpp:1986
 msgid "Before application name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1989
+#: src/muuli_wdr.cpp:1988
 msgid "After application name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1992
+#: src/muuli_wdr.cpp:1991
 msgid "Show overhead bandwidth"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1996
+#: src/muuli_wdr.cpp:1995
 msgid "Vertical toolbar orientation"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1998
+#: src/muuli_wdr.cpp:1997
 msgid "Live column sorting (auto-reorder rows as their values change)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2005
+#: src/muuli_wdr.cpp:2004
 msgid "Download Queue Files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2008
+#: src/muuli_wdr.cpp:2007
 msgid "Show progress percentage"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2014
+#: src/muuli_wdr.cpp:2013
 msgid "Show progress bar"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2017
+#: src/muuli_wdr.cpp:2016
 msgid "Flat"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2021
+#: src/muuli_wdr.cpp:2020
 msgid "Round"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2039
+#: src/muuli_wdr.cpp:2038
 msgid "External Connection Parameters"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2042
+#: src/muuli_wdr.cpp:2041
 msgid "Accept external connections"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2049 src/muuli_wdr.cpp:2108
+#: src/muuli_wdr.cpp:2048 src/muuli_wdr.cpp:2107
 msgid "IP of the listening interface:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2052
+#: src/muuli_wdr.cpp:2051
 msgid "Enter here a valid ip in the a.b.c.d format for the listening EC interface. An empty field or 0.0.0.0 will mean any interface."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2073 src/muuli_wdr.cpp:2184
+#: src/muuli_wdr.cpp:2072 src/muuli_wdr.cpp:2156
 msgid "TCP port:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2079
+#: src/muuli_wdr.cpp:2078
 msgid "Enable UPnP port forwarding on the EC port"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2083 src/muuli_wdr.cpp:3069
+#: src/muuli_wdr.cpp:2082 src/muuli_wdr.cpp:3041
 #: src/utils/wxCas/src/wxcasprefs.cpp:167
 msgid "Password"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2089
+#: src/muuli_wdr.cpp:2088
 msgid "aMule API server parameters"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2092
+#: src/muuli_wdr.cpp:2091
 msgid "Run amuleapi (REST API) on startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2097
+#: src/muuli_wdr.cpp:2096
 msgid "HTTP port:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2111
+#: src/muuli_wdr.cpp:2110
 msgid "The interface amuleapi's HTTP server listens on. 127.0.0.1 (default) accepts only local connections; use 0.0.0.0 or a specific IP to expose it to other hosts (set an admin password below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2116
-msgid "Type a password to set or change it. Stored passwords cannot be shown, so leaving this empty keeps the current one."
-msgstr ""
-
-#: src/muuli_wdr.cpp:2118
+#: src/muuli_wdr.cpp:2113
 msgid "Admin password"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2130 src/muuli_wdr.cpp:2147 src/PrefsUnifiedDlg.cpp:1103
-msgid "A password is set."
-msgstr ""
-
-#: src/muuli_wdr.cpp:2134
-msgid "Enable guest access"
-msgstr ""
-
-#: src/muuli_wdr.cpp:2135
-msgid "Guest sessions may read status and listings but cannot change anything. Turning this off clears the stored guest password."
-msgstr ""
-
-#: src/muuli_wdr.cpp:2139
-msgid "Guest password"
-msgstr ""
-
-#: src/muuli_wdr.cpp:2154
-msgid "Web server parameters"
-msgstr ""
-
-#: src/muuli_wdr.cpp:2157
-msgid "Run webserver on startup (deprecated)"
-msgstr ""
-
-#: src/muuli_wdr.cpp:2163
-msgid "Web template"
-msgstr ""
-
-#: src/muuli_wdr.cpp:2168
-msgid "Full rights password"
-msgstr ""
-
-#: src/muuli_wdr.cpp:2172
-msgid "Enable Low rights User"
-msgstr ""
-
-#: src/muuli_wdr.cpp:2177
+#: src/muuli_wdr.cpp:2118 src/muuli_wdr.cpp:2149
 msgid "Low rights password"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2191
+#: src/muuli_wdr.cpp:2126
+msgid "Web server parameters"
+msgstr ""
+
+#: src/muuli_wdr.cpp:2129
+msgid "Run webserver on startup (deprecated)"
+msgstr ""
+
+#: src/muuli_wdr.cpp:2135
+msgid "Web template"
+msgstr ""
+
+#: src/muuli_wdr.cpp:2140
+msgid "Full rights password"
+msgstr ""
+
+#: src/muuli_wdr.cpp:2144
+msgid "Enable Low rights User"
+msgstr ""
+
+#: src/muuli_wdr.cpp:2163
 msgid "Enable UPnP port forwarding of the web server port"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2196
+#: src/muuli_wdr.cpp:2168
 msgid "Web server UPnP TCP port (Optional)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2204
+#: src/muuli_wdr.cpp:2176
 msgid "Page Refresh Time (in secs)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2211
+#: src/muuli_wdr.cpp:2183
 msgid "Enable Gzip compression"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2245
+#: src/muuli_wdr.cpp:2217
 msgid "Reset page to defaults"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2246
+#: src/muuli_wdr.cpp:2218
 msgid "Reset the settings on the current page to their default values."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2248 src/muuli_wdr.cpp:2334 src/ServerWnd.cpp:274
+#: src/muuli_wdr.cpp:2220 src/muuli_wdr.cpp:2306 src/ServerWnd.cpp:274
 #: src/ServerWnd.cpp:282
 msgid "OK"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2250
+#: src/muuli_wdr.cpp:2222
 msgid "Click here to apply any changes made to the preferences."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2253
+#: src/muuli_wdr.cpp:2225
 msgid "Reset any changes made to the preferences."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2282
+#: src/muuli_wdr.cpp:2254
 msgid "Comment :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2289
+#: src/muuli_wdr.cpp:2261
 msgid "Incoming Dir :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2298
+#: src/muuli_wdr.cpp:2270
 msgid "Change priority for new assigned files :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2302
+#: src/muuli_wdr.cpp:2274
 msgid "Don't change"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2314
+#: src/muuli_wdr.cpp:2286
 msgid "Select color for this Category (currently selected) :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2381 src/muuli_wdr.cpp:2400 src/muuli_wdr.cpp:2422
+#: src/muuli_wdr.cpp:2353 src/muuli_wdr.cpp:2372 src/muuli_wdr.cpp:2394
 msgid "Click this button to reset the log."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2441
+#: src/muuli_wdr.cpp:2413
 msgid "Click on this button to update the servers list from URL ..."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2445
+#: src/muuli_wdr.cpp:2417
 msgid "Server list"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2449
+#: src/muuli_wdr.cpp:2421
 msgid "Enter the url to a server.met file here and press the button to the left to update the list of known servers."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2454
+#: src/muuli_wdr.cpp:2426
 msgid "Add server manually: Name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2457
+#: src/muuli_wdr.cpp:2429
 msgid "Enter the name of the new server here"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2459 src/ServerWnd.cpp:206
+#: src/muuli_wdr.cpp:2431 src/ServerWnd.cpp:206
 msgid "IP:Port"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2462
+#: src/muuli_wdr.cpp:2434
 msgid "Enter the IP of the server here, using the x.x.x.x format."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2468
+#: src/muuli_wdr.cpp:2440
 msgid "Enter the port of the server here."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2471
+#: src/muuli_wdr.cpp:2443
 msgid "Add manually a server (fill fields to the left before) ..."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2500
+#: src/muuli_wdr.cpp:2472
 msgid "aMule Log"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2508
+#: src/muuli_wdr.cpp:2480
 msgid "Server Info"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2512
+#: src/muuli_wdr.cpp:2484
 msgid "ED2K Info"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2516
+#: src/muuli_wdr.cpp:2488
 msgid "Kad Info"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2544
+#: src/muuli_wdr.cpp:2516
 msgid "Click on this button to update the nodes list from URL ..."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2548
+#: src/muuli_wdr.cpp:2520
 msgid "Nodes (0)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2552
+#: src/muuli_wdr.cpp:2524
 msgid "Enter the url to a nodes.dat file here and press the button to the left to update the list of known nodes."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2555
+#: src/muuli_wdr.cpp:2527
 msgid "Nodes stats"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2597
+#: src/muuli_wdr.cpp:2569
 msgid "Bootstrap"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2600
+#: src/muuli_wdr.cpp:2572
 msgid "New node"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2605
+#: src/muuli_wdr.cpp:2577
 msgid "IP:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2625
+#: src/muuli_wdr.cpp:2597
 msgid "Port:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2638
+#: src/muuli_wdr.cpp:2610
 msgid "Bootstrap from known clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2640
+#: src/muuli_wdr.cpp:2612
 msgid "Disconnect Kad"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2674
+#: src/muuli_wdr.cpp:2646
 msgid "Use Secure User Identification"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2676
+#: src/muuli_wdr.cpp:2648
 msgid "It is recommended to enable this option. You will not receive credits if SUI is not enabled."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2678
+#: src/muuli_wdr.cpp:2650
 msgid "Protocol Obfuscation"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2681
+#: src/muuli_wdr.cpp:2653
 msgid "Support Protocol Obfuscation"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2683
+#: src/muuli_wdr.cpp:2655
 msgid "This option enabled Protocol Obfuscation, and makes aMule accept obfuscated connections from other clients."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2685
+#: src/muuli_wdr.cpp:2657
 msgid "Use obfuscation for outgoing connections"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2687
+#: src/muuli_wdr.cpp:2659
 msgid "This option makes aMule use Protocol Obfuscation when connecting other clients/servers."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2689
+#: src/muuli_wdr.cpp:2661
 msgid "Accept only obfuscated connections"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2690
+#: src/muuli_wdr.cpp:2662
 msgid "This option makes aMule only accept obfuscated connections. You will have less sources, but all your traffic will be obfuscated"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2695
+#: src/muuli_wdr.cpp:2667
 msgid "Everybody"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2697
+#: src/muuli_wdr.cpp:2669
 msgid "No one"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2699
+#: src/muuli_wdr.cpp:2671
 msgid "Who can see my shared files:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2700
+#: src/muuli_wdr.cpp:2672
 msgid "Select who can request to view a list of your shared files."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2702
+#: src/muuli_wdr.cpp:2674
 msgid "IP-Filtering"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2709
+#: src/muuli_wdr.cpp:2681
 msgid "Filter clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2711
+#: src/muuli_wdr.cpp:2683
 msgid "Enable filtering of the client IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2713
+#: src/muuli_wdr.cpp:2685
 msgid "Filter servers"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2715
+#: src/muuli_wdr.cpp:2687
 msgid "Enable filtering of the server IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2719
+#: src/muuli_wdr.cpp:2691
 msgid "Reload List"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2720
+#: src/muuli_wdr.cpp:2692
 msgid "Reload the list of IPs to filter from the file ~/.aMule/ipfilter.dat"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2726
+#: src/muuli_wdr.cpp:2698
 msgid "URL:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2730 src/muuli_wdr.cpp:2923
+#: src/muuli_wdr.cpp:2702 src/muuli_wdr.cpp:2895
 msgid "Update now"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2733
+#: src/muuli_wdr.cpp:2705
 msgid "Auto-update ipfilter at startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2737
+#: src/muuli_wdr.cpp:2709
 msgid "Filtering Level:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2743
+#: src/muuli_wdr.cpp:2715
 msgid "Always filter LAN IPs"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2746
+#: src/muuli_wdr.cpp:2718
 msgid "Paranoid handling of non-matching IPs"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2748
+#: src/muuli_wdr.cpp:2720
 msgid "Rejects a packet when its source IP differs from the IP the client claims (an anti-spoofing check). Disable only if it causes connection problems."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2750
+#: src/muuli_wdr.cpp:2722
 msgid "Use system-wide ipfilter.dat if available"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2751
+#: src/muuli_wdr.cpp:2723
 msgid "If there's no local ipfilter.dat found, allow usage of a system-wide ipfilter file."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2768
+#: src/muuli_wdr.cpp:2740
 msgid "Enable Online-Signature"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2770
+#: src/muuli_wdr.cpp:2742
 msgid "Enables the writing of the OS file, which can be used by external apps to create signatures and the like."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2774
+#: src/muuli_wdr.cpp:2746
 msgid "Update Frequency (Secs):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2777
+#: src/muuli_wdr.cpp:2749
 msgid "Change the frequency (in seconds) of Online Signature updates."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2785
+#: src/muuli_wdr.cpp:2757
 msgid "Save online signature file in: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:2791
+#: src/muuli_wdr.cpp:2763
 msgid "Click here to select the directory containing the the Online Signature files."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2824
+#: src/muuli_wdr.cpp:2796
 msgid "Show country flags for clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2825
+#: src/muuli_wdr.cpp:2797
 msgid "Render the country flag column in the transfers, queue and search views. Requires a valid MMDB GeoIP database (see below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2830
+#: src/muuli_wdr.cpp:2802
 msgid "Database"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2846
+#: src/muuli_wdr.cpp:2818
 msgid "Source:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2849
+#: src/muuli_wdr.cpp:2821
 msgid "DB-IP (free, no account)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2850
+#: src/muuli_wdr.cpp:2822
 msgid "MaxMind GeoLite2 (free, account required)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2851
+#: src/muuli_wdr.cpp:2823
 msgid "Custom URL"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2854
+#: src/muuli_wdr.cpp:2826
 msgid "Choose which provider supplies the GeoIP MMDB database. DB-IP is the default - no account required. MaxMind requires a free account + license key. Use Custom URL to point at any other MMDB host (e.g. a local mirror)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2871
+#: src/muuli_wdr.cpp:2843
 msgid ""
 "No configuration required.\n"
 "\n"
@@ -4753,11 +4723,11 @@ msgid ""
 "License: Creative Commons BY 4.0 - https://creativecommons.org/licenses/by/4.0/"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2884
+#: src/muuli_wdr.cpp:2856
 msgid "License key:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2890
+#: src/muuli_wdr.cpp:2862
 msgid ""
 "Sign up for a free MaxMind account, then generate a License Key:\n"
 "https://www.maxmind.com/en/geolite2/signup\n"
@@ -4767,222 +4737,222 @@ msgid ""
 "Requires attribution and account registration; refresh at least every 30 days."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2905
+#: src/muuli_wdr.cpp:2877
 msgid "Download URL:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2911
+#: src/muuli_wdr.cpp:2883
 msgid ""
 "Must point to an .mmdb file or a .gz / .tar.gz containing one.\n"
 "URL may include credentials (https://user:pass@host/...).\n"
 "License and attribution terms are set by the upstream URL - you are responsible."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2924
+#: src/muuli_wdr.cpp:2896
 msgid "Download the GeoIP database from the selected source."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2926
+#: src/muuli_wdr.cpp:2898
 msgid "Auto-update on startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2927
+#: src/muuli_wdr.cpp:2899
 msgid "Re-download the GeoIP database from the selected source every time aMule starts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2950
+#: src/muuli_wdr.cpp:2922
 msgid "Filter incoming messages (except current chat):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2952
+#: src/muuli_wdr.cpp:2924
 msgid "Filter all messages"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2954
+#: src/muuli_wdr.cpp:2926
 msgid "Filter messages from people not on your friend list"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2956
+#: src/muuli_wdr.cpp:2928
 msgid "Filter messages from unknown clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2958
+#: src/muuli_wdr.cpp:2930
 msgid "Filter messages containing (use ',' as separator):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2961 src/muuli_wdr.cpp:2972
+#: src/muuli_wdr.cpp:2933 src/muuli_wdr.cpp:2944
 msgid "add here the words amule should filter and block messages including it"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2963
+#: src/muuli_wdr.cpp:2935
 msgid "Show received messages in the log"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2966
+#: src/muuli_wdr.cpp:2938
 msgid "Comments"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2969
+#: src/muuli_wdr.cpp:2941
 msgid "Filter comments containing (use ',' as separator):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2994
+#: src/muuli_wdr.cpp:2966
 msgid "Enable Proxy"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2995
+#: src/muuli_wdr.cpp:2967
 msgid "Enable/disable proxy support"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2998
+#: src/muuli_wdr.cpp:2970
 msgid "Proxy type:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3009
+#: src/muuli_wdr.cpp:2981
 msgid "Proxy host:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3012
+#: src/muuli_wdr.cpp:2984
 msgid "The proxy host name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3014
+#: src/muuli_wdr.cpp:2986
 msgid "Proxy port:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3017
+#: src/muuli_wdr.cpp:2989
 msgid "The proxy port"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3019
+#: src/muuli_wdr.cpp:2991
 msgid "Enable authentication"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3020
+#: src/muuli_wdr.cpp:2992
 msgid "Enable/disable username/password authentication"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3023
+#: src/muuli_wdr.cpp:2995
 msgid "Username: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:3026
+#: src/muuli_wdr.cpp:2998
 msgid "The username to use to connect to the proxy"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3028
+#: src/muuli_wdr.cpp:3000
 msgid "Password:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3031
+#: src/muuli_wdr.cpp:3003
 msgid "The password to use to connect to the proxy"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3050
+#: src/muuli_wdr.cpp:3022
 msgid "Connect to:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3059
+#: src/muuli_wdr.cpp:3031
 msgid "Login to remote amule"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3064
+#: src/muuli_wdr.cpp:3036
 msgid "User name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3075
+#: src/muuli_wdr.cpp:3047
 msgid "Remember those settings"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3078
+#: src/muuli_wdr.cpp:3050
 msgid "Force ZLIB compression"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3102
+#: src/muuli_wdr.cpp:3074
 msgid "Enable Verbose Debug-Logging."
 msgstr ""
 
-#: src/muuli_wdr.cpp:3104
+#: src/muuli_wdr.cpp:3076
 msgid "Only to Logfile"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3106
+#: src/muuli_wdr.cpp:3078
 msgid "Message Categories:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3130 src/PartFileConvertDlg.cpp:160
+#: src/muuli_wdr.cpp:3102 src/PartFileConvertDlg.cpp:160
 msgid "Waiting..."
 msgstr ""
 
-#: src/muuli_wdr.cpp:3150
+#: src/muuli_wdr.cpp:3122
 msgid "Add imports"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3153
+#: src/muuli_wdr.cpp:3125
 msgid "Retry selected"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3155
+#: src/muuli_wdr.cpp:3127
 msgid "Remove selected"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3218
+#: src/muuli_wdr.cpp:3190
 msgid "Event Types"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3237
+#: src/muuli_wdr.cpp:3209
 msgid "Statistics and queued clients for selected file(s) : Session / All time"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3261
+#: src/muuli_wdr.cpp:3233
 msgid "Active Uploads"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3275
+#: src/muuli_wdr.cpp:3247
 msgid "Percent of total files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3327
+#: src/muuli_wdr.cpp:3299
 msgid "Show Clients for"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3329
+#: src/muuli_wdr.cpp:3301
 msgid "All files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3332
+#: src/muuli_wdr.cpp:3304
 msgid "Selected files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3335
+#: src/muuli_wdr.cpp:3307
 msgid "Active uploads only"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3342
+#: src/muuli_wdr.cpp:3314
 msgid "Reload:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3346
+#: src/muuli_wdr.cpp:3318
 msgid "Reload your shared files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3409
+#: src/muuli_wdr.cpp:3381
 msgid "Send"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3410
+#: src/muuli_wdr.cpp:3382
 msgid "Sends the specified message."
 msgstr ""
 
-#: src/muuli_wdr.cpp:3414
+#: src/muuli_wdr.cpp:3386
 msgid "Close this chat-session."
 msgstr ""
 
-#: src/muuli_wdr.cpp:3437
+#: src/muuli_wdr.cpp:3409
 msgid "Connect to any server and/or Kad"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3443 src/SharedFilesCtrl.cpp:142 src/Statistics.cpp:941
+#: src/muuli_wdr.cpp:3415 src/SharedFilesCtrl.cpp:142 src/Statistics.cpp:941
 msgid "Shared Files"
 msgstr ""
 
@@ -5340,263 +5310,263 @@ msgstr ""
 msgid "ERROR: Failed to open partfile '%s'"
 msgstr ""
 
-#: src/Preferences.cpp:701
+#: src/Preferences.cpp:673
 msgid "System default"
 msgstr ""
 
-#: src/Preferences.cpp:702
+#: src/Preferences.cpp:674
 msgid "Albanian"
 msgstr ""
 
-#: src/Preferences.cpp:703
+#: src/Preferences.cpp:675
 msgid "Arabic"
 msgstr ""
 
-#: src/Preferences.cpp:704
+#: src/Preferences.cpp:676
 msgid "Asturian"
 msgstr ""
 
-#: src/Preferences.cpp:705
+#: src/Preferences.cpp:677
 msgid "Basque"
 msgstr ""
 
-#: src/Preferences.cpp:706
+#: src/Preferences.cpp:678
 msgid "Bulgarian"
 msgstr ""
 
-#: src/Preferences.cpp:707
+#: src/Preferences.cpp:679
 msgid "Catalan"
 msgstr ""
 
-#: src/Preferences.cpp:708
+#: src/Preferences.cpp:680
 msgid "Chinese (Simplified)"
 msgstr ""
 
-#: src/Preferences.cpp:709
+#: src/Preferences.cpp:681
 msgid "Chinese (Traditional)"
 msgstr ""
 
-#: src/Preferences.cpp:710
+#: src/Preferences.cpp:682
 msgid "Croatian"
 msgstr ""
 
-#: src/Preferences.cpp:711
+#: src/Preferences.cpp:683
 msgid "Czech"
 msgstr ""
 
-#: src/Preferences.cpp:712
+#: src/Preferences.cpp:684
 msgid "Danish"
 msgstr ""
 
-#: src/Preferences.cpp:713
+#: src/Preferences.cpp:685
 msgid "Dutch"
 msgstr ""
 
-#: src/Preferences.cpp:714
+#: src/Preferences.cpp:686
 msgid "English (U.K.)"
 msgstr ""
 
-#: src/Preferences.cpp:715
+#: src/Preferences.cpp:687
 msgid "English (U.S.)"
 msgstr ""
 
-#: src/Preferences.cpp:716
+#: src/Preferences.cpp:688
 msgid "Estonian"
 msgstr ""
 
-#: src/Preferences.cpp:717
+#: src/Preferences.cpp:689
 msgid "Finnish"
 msgstr ""
 
-#: src/Preferences.cpp:718
+#: src/Preferences.cpp:690
 msgid "French"
 msgstr ""
 
-#: src/Preferences.cpp:719
+#: src/Preferences.cpp:691
 msgid "Galician"
 msgstr ""
 
-#: src/Preferences.cpp:720
+#: src/Preferences.cpp:692
 msgid "German"
 msgstr ""
 
-#: src/Preferences.cpp:721
+#: src/Preferences.cpp:693
 msgid "Greek"
 msgstr ""
 
-#: src/Preferences.cpp:722
+#: src/Preferences.cpp:694
 msgid "Hebrew"
 msgstr ""
 
-#: src/Preferences.cpp:723
+#: src/Preferences.cpp:695
 msgid "Hungarian"
 msgstr ""
 
-#: src/Preferences.cpp:724
+#: src/Preferences.cpp:696
 msgid "Italian"
 msgstr ""
 
-#: src/Preferences.cpp:725
+#: src/Preferences.cpp:697
 msgid "Japanese"
 msgstr ""
 
-#: src/Preferences.cpp:726
+#: src/Preferences.cpp:698
 msgid "Korean"
 msgstr ""
 
-#: src/Preferences.cpp:727
+#: src/Preferences.cpp:699
 msgid "Latvian"
 msgstr ""
 
-#: src/Preferences.cpp:728
+#: src/Preferences.cpp:700
 msgid "Lithuanian"
 msgstr ""
 
-#: src/Preferences.cpp:729
+#: src/Preferences.cpp:701
 msgid "Norwegian (Nynorsk)"
 msgstr ""
 
-#: src/Preferences.cpp:730
+#: src/Preferences.cpp:702
 msgid "Polish"
 msgstr ""
 
-#: src/Preferences.cpp:731
+#: src/Preferences.cpp:703
 msgid "Portuguese"
 msgstr ""
 
-#: src/Preferences.cpp:732
+#: src/Preferences.cpp:704
 msgid "Portuguese (Brazilian)"
 msgstr ""
 
-#: src/Preferences.cpp:733
+#: src/Preferences.cpp:705
 msgid "Romanian"
 msgstr ""
 
-#: src/Preferences.cpp:734
+#: src/Preferences.cpp:706
 msgid "Russian"
 msgstr ""
 
-#: src/Preferences.cpp:735
+#: src/Preferences.cpp:707
 msgid "Slovenian"
 msgstr ""
 
-#: src/Preferences.cpp:736
+#: src/Preferences.cpp:708
 msgid "Spanish"
 msgstr ""
 
-#: src/Preferences.cpp:737
+#: src/Preferences.cpp:709
 msgid "Swedish"
 msgstr ""
 
-#: src/Preferences.cpp:738
+#: src/Preferences.cpp:710
 msgid "Turkish"
 msgstr ""
 
-#: src/Preferences.cpp:739
+#: src/Preferences.cpp:711
 msgid "Ukrainian"
 msgstr ""
 
-#: src/Preferences.cpp:842
+#: src/Preferences.cpp:814
 msgid "Change Language"
 msgstr ""
 
-#: src/Preferences.cpp:906
+#: src/Preferences.cpp:878
 msgid "There are no translations installed for aMule"
 msgstr ""
 
-#: src/Preferences.cpp:907
+#: src/Preferences.cpp:879
 msgid "No languages available"
 msgstr ""
 
-#: src/Preferences.cpp:1038
+#: src/Preferences.cpp:1010
 msgid "no options available"
 msgstr ""
 
-#: src/Preferences.cpp:2226
+#: src/Preferences.cpp:2179
 msgid "Invalid category found, skipping"
 msgstr ""
 
-#: src/Preferences.cpp:2395
+#: src/Preferences.cpp:2348
 msgid "TCP port can't be higher than 65532 due to server UDP socket being TCP+3"
 msgstr ""
 
-#: src/Preferences.cpp:2396
+#: src/Preferences.cpp:2349
 #, c-format
 msgid "Default port will be used (%d)"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:300 src/Statistics.cpp:866
+#: src/PrefsUnifiedDlg.cpp:298 src/Statistics.cpp:866
 msgid "Connection"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:301 src/SearchListCtrl.cpp:117
+#: src/PrefsUnifiedDlg.cpp:299 src/SearchListCtrl.cpp:117
 msgid "Directories"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:302 src/Statistics.cpp:917
+#: src/PrefsUnifiedDlg.cpp:300 src/Statistics.cpp:917
 msgid "Servers"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:303 src/ServerListCtrl.cpp:96
+#: src/PrefsUnifiedDlg.cpp:301 src/ServerListCtrl.cpp:96
 msgid "Files"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:304
+#: src/PrefsUnifiedDlg.cpp:302
 msgid "Security"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:305
+#: src/PrefsUnifiedDlg.cpp:303
 msgid "Interface"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:312
+#: src/PrefsUnifiedDlg.cpp:310
 msgid "IP2Country"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:315
+#: src/PrefsUnifiedDlg.cpp:313
 msgid "Proxy"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:316
+#: src/PrefsUnifiedDlg.cpp:314
 msgid "Filters"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:317
+#: src/PrefsUnifiedDlg.cpp:315
 msgid "Remote Controls"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:318
+#: src/PrefsUnifiedDlg.cpp:316
 msgid "Online Signature"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:319
+#: src/PrefsUnifiedDlg.cpp:317
 msgid "Advanced"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:320
+#: src/PrefsUnifiedDlg.cpp:318
 msgid "Events"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:323
+#: src/PrefsUnifiedDlg.cpp:321
 msgid "Debugging"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:453
+#: src/PrefsUnifiedDlg.cpp:451
 msgid ""
 "The following variables will be substituted:\n"
 "    %PARTFILE - full path to the file\n"
 "    %PARTNAME - file name only"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:474
+#: src/PrefsUnifiedDlg.cpp:472
 msgid "Tray icon support requires libayatana-appindicator3 at compile time."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:490
+#: src/PrefsUnifiedDlg.cpp:488
 msgid "Not available on Wayland: the protocol does not report when a window is minimized, so this option cannot intercept the system minimize button. Workaround: launch aMule with `GDK_BACKEND=x11` to use XWayland instead."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:536
+#: src/PrefsUnifiedDlg.cpp:534
 msgid ""
 "Do not change these setting unless you know\n"
 "what you are doing, otherwise you can easily\n"
@@ -5606,424 +5576,407 @@ msgid ""
 "these settings."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:647
+#: src/PrefsUnifiedDlg.cpp:645
 #, c-format
 msgid "Failed to connect Cfg to widget with the ID %d and key %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:695
+#: src/PrefsUnifiedDlg.cpp:693
 #, c-format
 msgid "Failed to transfer data from Cfg to Widget with the ID %d and key %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:801
+#: src/PrefsUnifiedDlg.cpp:799
 msgid "The type of proxy you are connecting to"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1020
+#: src/PrefsUnifiedDlg.cpp:1003
 #, c-format
 msgid "Failed to transfer data from Widget to Cfg with the ID %d and key %s"
 msgstr ""
 
 #: src/PrefsUnifiedDlg.cpp:1103
-msgid "No password set."
-msgstr ""
-
-#: src/PrefsUnifiedDlg.cpp:1132
-msgid "Guest access needs a password. Type one in the guest password field, or untick Enable guest access."
-msgstr ""
-
-#: src/PrefsUnifiedDlg.cpp:1144
 msgid ""
 "aMule must be restarted to enable these changes:\n"
 "\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1151
+#: src/PrefsUnifiedDlg.cpp:1110
 msgid "- TCP port changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1156
+#: src/PrefsUnifiedDlg.cpp:1115
 msgid "- UDP port changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1161
+#: src/PrefsUnifiedDlg.cpp:1120
 msgid "- Network interface binding changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1166
+#: src/PrefsUnifiedDlg.cpp:1125
 msgid "- External connect port changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1170
+#: src/PrefsUnifiedDlg.cpp:1129
 msgid "- External connect acceptance changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1174
+#: src/PrefsUnifiedDlg.cpp:1133
 msgid "- External connect interface changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1178
+#: src/PrefsUnifiedDlg.cpp:1137
 msgid "- Protocol obfuscation support changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1193
+#: src/PrefsUnifiedDlg.cpp:1151
 msgid "- amuleapi settings changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1202
+#: src/PrefsUnifiedDlg.cpp:1160
 msgid ""
 "Your Auto-update server list is empty.\n"
 "'Auto-update server list at startup' will be disabled."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1213
+#: src/PrefsUnifiedDlg.cpp:1171
 msgid ""
 "You have enabled external connections but have not specified a password.\n"
 "External connections cannot be enabled unless a valid password is specified."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1246
-#, c-format
-msgid "The amuleapi password could not be saved: %s"
-msgstr ""
-
-#: src/PrefsUnifiedDlg.cpp:1276
+#: src/PrefsUnifiedDlg.cpp:1202
 msgid "- Language changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1281
+#: src/PrefsUnifiedDlg.cpp:1207
 msgid "- Temp folder changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1286
+#: src/PrefsUnifiedDlg.cpp:1212
 msgid "- ED2K network enabled.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1319
+#: src/PrefsUnifiedDlg.cpp:1245
 msgid "The shared-file exclusion pattern is not a valid regular expression. The filter has been left disabled."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1321 src/PrefsUnifiedDlg.cpp:1921
+#: src/PrefsUnifiedDlg.cpp:1247 src/PrefsUnifiedDlg.cpp:1841
 msgid "Invalid regular expression"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1398
+#: src/PrefsUnifiedDlg.cpp:1324
 msgid ""
 "Both eD2k and Kad network are disabled.\n"
 "You won't be able to connect until you enable at least one of them."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1403
+#: src/PrefsUnifiedDlg.cpp:1329
 msgid ""
 "Kad will not start if your UDP port is disabled.\n"
 "Enable UDP port or disable Kad."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1459
+#: src/PrefsUnifiedDlg.cpp:1385
 msgid ""
 "\n"
 "You MUST restart aMule now.\n"
 "If you do not restart now, don't complain if anything bad happens.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1524
+#: src/PrefsUnifiedDlg.cpp:1450
 msgid "Could not register aMule for autostart at login. The autostart store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1526
+#: src/PrefsUnifiedDlg.cpp:1452
 msgid "Could not remove the autostart-at-login entry."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1527
+#: src/PrefsUnifiedDlg.cpp:1453
 msgid "Autostart"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1542
+#: src/PrefsUnifiedDlg.cpp:1468
 msgid "Register file type"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1542
+#: src/PrefsUnifiedDlg.cpp:1468
 msgid "Register URL handler"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1550
+#: src/PrefsUnifiedDlg.cpp:1476
 #, c-format
 msgid "aMule only handles eD2k-compatible magnets. If you replace the current magnet handler (%s), BitTorrent magnet links will stop working - aMule cannot download BitTorrent content. Continue?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1555
+#: src/PrefsUnifiedDlg.cpp:1481
 #, c-format
 msgid "Another application currently opens .emulecollection files (%s). Replace it with aMule?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1560
+#: src/PrefsUnifiedDlg.cpp:1486
 #, c-format
 msgid "Another application is currently the default handler for these links (%s). Replace it with aMule?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1585
+#: src/PrefsUnifiedDlg.cpp:1511
 msgid "Could not register aMule for .emulecollection files. The registration store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1587
+#: src/PrefsUnifiedDlg.cpp:1513
 msgid "Could not remove the file type registration."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1589
+#: src/PrefsUnifiedDlg.cpp:1515
 msgid "Could not register aMule as the URL handler. The registration store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1591
+#: src/PrefsUnifiedDlg.cpp:1517
 msgid "Could not remove the URL handler registration."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1661 src/PrefsUnifiedDlg.cpp:1688
+#: src/PrefsUnifiedDlg.cpp:1587 src/PrefsUnifiedDlg.cpp:1614
 msgid "The web server and aMule API require external connections to be enabled."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1671
+#: src/PrefsUnifiedDlg.cpp:1597
 msgid "The aMule web server is deprecated. Consider running the aMule API instead."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1735
+#: src/PrefsUnifiedDlg.cpp:1655
 msgid ""
 "Your Auto-update servers list is in blank.\n"
 "Please fill in at least one URL to point to a valid server.met file.\n"
 "Click on the button \"List\" by this checkbox to enter an URL."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1876
+#: src/PrefsUnifiedDlg.cpp:1796
 msgid "Temporary files"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1881
+#: src/PrefsUnifiedDlg.cpp:1801
 msgid "Incoming files"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1886
+#: src/PrefsUnifiedDlg.cpp:1806
 msgid "Online Signatures"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1899
+#: src/PrefsUnifiedDlg.cpp:1819
 #, c-format
 msgid "Choose a folder for %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1923
+#: src/PrefsUnifiedDlg.cpp:1843
 #, c-format
 msgid "Would exclude %u of %u shared file"
 msgid_plural "Would exclude %u of %u shared files"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/PrefsUnifiedDlg.cpp:1940
+#: src/PrefsUnifiedDlg.cpp:1860
 msgid "Browse for videoplayer"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1944
+#: src/PrefsUnifiedDlg.cpp:1864
 msgid "Select browser"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1948
+#: src/PrefsUnifiedDlg.cpp:1868
 msgid "Select ffprobe binary"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1954
+#: src/PrefsUnifiedDlg.cpp:1874
 #, c-format
 msgid "Executable%s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1988
+#: src/PrefsUnifiedDlg.cpp:1908
 msgid "ffprobe not found on PATH or in the standard install locations. Install ffmpeg (which ships ffprobe) or use Browse to pick a binary manually."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2000
+#: src/PrefsUnifiedDlg.cpp:1920
 msgid "Reset the settings on this page to their default values?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2001
+#: src/PrefsUnifiedDlg.cpp:1921
 msgid "Reset to defaults"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2028
+#: src/PrefsUnifiedDlg.cpp:1948
 msgid "Edit server list"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2029
+#: src/PrefsUnifiedDlg.cpp:1949
 msgid ""
 "Add here URL's to download server.met files.\n"
 "Only one url on each line."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2084
+#: src/PrefsUnifiedDlg.cpp:2004
 msgid "IP2Country update failed"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2229 src/PrefsUnifiedDlg.cpp:2260
+#: src/PrefsUnifiedDlg.cpp:2149 src/PrefsUnifiedDlg.cpp:2180
 msgid "Data by MaxMind GeoLite2"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2231 src/PrefsUnifiedDlg.cpp:2262
+#: src/PrefsUnifiedDlg.cpp:2151 src/PrefsUnifiedDlg.cpp:2182
 msgid "Custom source"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2233 src/PrefsUnifiedDlg.cpp:2264
+#: src/PrefsUnifiedDlg.cpp:2153 src/PrefsUnifiedDlg.cpp:2184
 msgid "Data by DB-IP.com"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2284
+#: src/PrefsUnifiedDlg.cpp:2204
 #, c-format
 msgid "Status: Loaded%s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2286
+#: src/PrefsUnifiedDlg.cpp:2206
 #, c-format
 msgid "Status: Loaded%s - %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2290
+#: src/PrefsUnifiedDlg.cpp:2210
 msgid "Status: Failed to load - click 'Update now' to refresh."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2292
+#: src/PrefsUnifiedDlg.cpp:2212
 msgid "Status: Not found - click 'Update now' to download."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2350 src/PrefsUnifiedDlg.cpp:2374
+#: src/PrefsUnifiedDlg.cpp:2270 src/PrefsUnifiedDlg.cpp:2294
 #, c-format
 msgid "Update delay: %d second"
 msgid_plural "Update delay: %d seconds"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/PrefsUnifiedDlg.cpp:2358
+#: src/PrefsUnifiedDlg.cpp:2278
 #, c-format
 msgid "Time for average graph: %d minute"
 msgid_plural "Time for average graph: %d minutes"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/PrefsUnifiedDlg.cpp:2367
+#: src/PrefsUnifiedDlg.cpp:2287
 #, c-format
 msgid "Connections Graph Scale: %d"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2382
+#: src/PrefsUnifiedDlg.cpp:2302
 #, c-format
 msgid "File Buffer Size: %d byte"
 msgid_plural "File Buffer Size: %d bytes"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/PrefsUnifiedDlg.cpp:2392
+#: src/PrefsUnifiedDlg.cpp:2312
 #, c-format
 msgid "Upload Queue Size: %d client"
 msgid_plural "Upload Queue Size: %d clients"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/PrefsUnifiedDlg.cpp:2402
+#: src/PrefsUnifiedDlg.cpp:2322
 #, c-format
 msgid "Server connection refresh interval: %d minute"
 msgid_plural "Server connection refresh interval: %d minutes"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/PrefsUnifiedDlg.cpp:2407
+#: src/PrefsUnifiedDlg.cpp:2327
 msgid "Server connection refresh interval: Disabled"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2451
+#: src/PrefsUnifiedDlg.cpp:2371
 msgid "disabled"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2477
+#: src/PrefsUnifiedDlg.cpp:2397
 #, c-format
 msgid "Execute command on '%s' event"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2484
+#: src/PrefsUnifiedDlg.cpp:2404
 msgid "Enable command execution on core"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2496
+#: src/PrefsUnifiedDlg.cpp:2416
 msgid "Core command:"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2512
+#: src/PrefsUnifiedDlg.cpp:2432
 msgid "Enable command execution on GUI"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2524
+#: src/PrefsUnifiedDlg.cpp:2444
 msgid "GUI command:"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2540
+#: src/PrefsUnifiedDlg.cpp:2460
 msgid "The following variables will be replaced:"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2708
+#: src/PrefsUnifiedDlg.cpp:2628
 msgid ""
 "The following folders look like system or sensitive locations:\n"
 "\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2713
+#: src/PrefsUnifiedDlg.cpp:2633
 msgid "Sharing them recursively will publish every file underneath on the eD2k/Kad networks. Do you really want to do this?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2716
+#: src/PrefsUnifiedDlg.cpp:2636
 msgid "Confirm shared folders"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2744
+#: src/PrefsUnifiedDlg.cpp:2664
 msgid "Reloading shared files..."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2745
+#: src/PrefsUnifiedDlg.cpp:2665
 msgid "Scanning for subdirectories..."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2746
+#: src/PrefsUnifiedDlg.cpp:2666
 msgid "Updating shared folders"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2773
+#: src/PrefsUnifiedDlg.cpp:2693
 #, c-format
 msgid "Scanned %u directories..."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2823
+#: src/PrefsUnifiedDlg.cpp:2743
 #, c-format
 msgid "Reloading shared files: %u files scanned"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2873
+#: src/PrefsUnifiedDlg.cpp:2793
 msgid "Shared folder"
 msgstr ""
 
-#: src/SearchDlg.cpp:280
-msgid "Clear search history"
-msgstr ""
-
-#: src/SearchDlg.cpp:584
+#: src/SearchDlg.cpp:425
 msgid "It's impossible to search when both eD2k and Kademlia are disabled."
 msgstr ""
 
-#: src/SearchDlg.cpp:585 src/SearchListCtrl.cpp:858
+#: src/SearchDlg.cpp:426 src/SearchListCtrl.cpp:858
 msgid "Search error"
 msgstr ""
 
-#: src/SearchDlg.cpp:929
+#: src/SearchDlg.cpp:768
 msgid "Min size must be smaller than max size. Max size ignored."
 msgstr ""
 
-#: src/SearchDlg.cpp:930 src/SearchDlg.cpp:1012
+#: src/SearchDlg.cpp:769 src/SearchDlg.cpp:851
 msgid "Search warning"
 msgstr ""
 
-#: src/SearchDlg.cpp:1092 src/SearchListCtrl.cpp:735
+#: src/SearchDlg.cpp:929 src/SearchListCtrl.cpp:735
 msgid "Main"
 msgstr ""
 

--- a/po/tr.po
+++ b/po/tr.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-28 10:19+0200\n"
+"POT-Creation-Date: 2026-07-28 12:17+0200\n"
 "PO-Revision-Date: 2026-07-27 11:47+0000\n"
 "Last-Translator: \n"
 "Language-Team: Turkish <li@li.org>\n"
@@ -205,83 +205,83 @@ msgstr "ED2KBağlantı dosyası açılamadı."
 msgid "WARNING: You can't add yourself as a source for an eD2k link while having a lowid."
 msgstr "UYARI: DüşükID olduğunuz sürece kendinizi bir kaynak olarak eD2k bağlantılarına ekleyemezsiniz."
 
-#: src/amule.cpp:300
+#: src/amule.cpp:301
 msgid "Now, exiting main app..."
 msgstr "Ana uygulamadan çıkılıyor…"
 
-#: src/amule.cpp:330
+#: src/amule.cpp:331
 #, c-format
 msgid "Terminating amuleweb instance with pid '%d' ... "
 msgstr "Amuleweb oturumu pid `%d' ile sonlandırılıyor… "
 
-#: src/amule.cpp:334
+#: src/amule.cpp:335
 #, c-format
 msgid "Killing amuleweb instance with pid '%d' ... "
 msgstr "pid `%d' ile ilişkili amuleweb oturumu öldürülüyor… "
 
-#: src/amule.cpp:336 src/amule.cpp:349 src/ClientRef.cpp:180
+#: src/amule.cpp:337 src/amule.cpp:350 src/ClientRef.cpp:180
 #: src/SearchDlg.cpp:1041 src/ServerListCtrl.cpp:98
 msgid "Failed"
 msgstr "Başarısız"
 
-#: src/amule.cpp:343
+#: src/amule.cpp:344
 #, c-format
 msgid "Terminating amuleapi instance with pid '%d' ... "
 msgstr "'%d' pid'sine sahip amuleapi oturumu sonlandırılıyor… "
 
-#: src/amule.cpp:347
+#: src/amule.cpp:348
 #, c-format
 msgid "Killing amuleapi instance with pid '%d' ... "
 msgstr "pid `%d' ile ilişkili amuleapi oturumu sonlandırılıyor… "
 
-#: src/amule.cpp:355
+#: src/amule.cpp:356
 msgid "aMule OnExit: Terminating core."
 msgstr "aMule Çıkışında: Çekirdek imha ediliyor."
 
-#: src/amule.cpp:466
+#: src/amule.cpp:467
 msgid "aMule shutdown completed."
 msgstr "aMule kapatılma işlemi tamamlandı."
 
-#: src/amule.cpp:470
+#: src/amule.cpp:471
 msgid "Memory debug results for aMule exit:"
 msgstr "aMule çıkışı için hafıza hata raporlama sonuçları:"
 
-#: src/amule.cpp:651
+#: src/amule.cpp:652
 #, c-format
 msgid "Binding aMule's peer-to-peer traffic to interface: %s (HTTP updates use the default route)"
 msgstr "aMule eşten eşe trafiği şu arayüze bağlanıyor: %s (HTTP güncellemeleri varsayılan yolu kullanır)"
 
-#: src/amule.cpp:655
+#: src/amule.cpp:656
 #, c-format
 msgid "Binding all network traffic to interface: %s"
 msgstr "Tüm ağ trafiği şu arayüze bağlanıyor: %s"
 
-#: src/amule.cpp:659
+#: src/amule.cpp:660
 #, c-format
 msgid "WARNING: configured network interface '%s' was not found - traffic is NOT bound to it and may leave via the default route. Check the interface name in Preferences."
 msgstr "İKAZ: yapılandırılmış ağ arayüzü '%s' bulunamadı - trafik ona bağlı DEĞİL ve varsayılan yol ile dışarı çıkabilir. Arayüz ismini Tercihler'de kontrol edin."
 
-#: src/amule.cpp:665
+#: src/amule.cpp:666
 #, c-format
 msgid "WARNING: binding to network interface '%s' requires elevated privileges and was NOT applied - traffic may leave via the default route. Grant the capability (e.g. 'sudo setcap cap_net_raw+ep' on the aMule binary) or run with sufficient privileges."
 msgstr "İKAZ: '%s' ağ arayüzüne bağlamak yüksek izinler gerektirmektedir ve UYGULANMAMIŞTIR - trafik varsayılan yol ile dışarı çıkabilir. Gerekli yeteneği tanıyın (mesela aMule ikili dosyası üzerinde 'sudo setcap cap_net_raw+ep' komutunu kullanarak) veya yeterli imtiyazlarla çalıştırın."
 
-#: src/amule.cpp:673
+#: src/amule.cpp:674
 #, c-format
 msgid "WARNING: could not bind to network interface '%s' - traffic may leave via the default route."
 msgstr "İKAZ: '%s' ağ arayüzüne bağlama yapılamadı - trafik varsayılan yoldan dışarı çıkabilir."
 
-#: src/amule.cpp:732
+#: src/amule.cpp:733
 msgid "Your locale has been changed to System Default due to a configuration change. Sorry."
 msgstr "Bir yapılandırma değişikliği nedeniyle dil ayarınız 'Sistem Varsayılanı'na çevrildi. Üzgünüm. Vallahi…"
 
-#: src/amule.cpp:734 src/amule.cpp:1581 src/CatDialog.cpp:128
+#: src/amule.cpp:735 src/amule.cpp:1589 src/CatDialog.cpp:128
 #: src/CatDialog.cpp:136 src/CatDialog.cpp:149 src/ServerList.cpp:366
 #: src/ServerListCtrl.cpp:152
 msgid "Info"
 msgstr "Bilgi"
 
-#: src/amule.cpp:741
+#: src/amule.cpp:742
 msgid ""
 "\n"
 "EC configuration"
@@ -289,20 +289,20 @@ msgstr ""
 "\n"
 "EC yapılandırması"
 
-#: src/amule.cpp:744
+#: src/amule.cpp:745
 msgid "Password set and external connections enabled."
 msgstr "Parola ayarlandı ve dış bağlantılar etkinleştirildi."
 
-#: src/amule.cpp:754 src/KadDlg.cpp:176 src/KadDlg.cpp:185
-#: src/PrefsUnifiedDlg.cpp:1387 src/SharedFilesCtrl.cpp:476
+#: src/amule.cpp:755 src/KadDlg.cpp:176 src/KadDlg.cpp:185
+#: src/PrefsUnifiedDlg.cpp:1461 src/SharedFilesCtrl.cpp:476
 msgid "WARNING"
 msgstr "UYARI"
 
-#: src/amule.cpp:991
+#: src/amule.cpp:992
 msgid "Network bootstrap"
 msgstr "Ağ başlatması"
 
-#: src/amule.cpp:996
+#: src/amule.cpp:997
 msgid ""
 "aMule has detected missing network bootstrap files.\n"
 "Select which ones to download:"
@@ -310,51 +310,51 @@ msgstr ""
 "aMule, eksik ağ başlatma dosyaları olduğunu tespit etti.\n"
 "Hangilerinin indirileceklerini seçin:"
 
-#: src/amule.cpp:1005 src/FirstRunWizard.cpp:411
+#: src/amule.cpp:1006 src/FirstRunWizard.cpp:411
 msgid "eD2k server list (server.met)"
 msgstr "eD2k sunucu listesi (server.met)"
 
-#: src/amule.cpp:1012 src/FirstRunWizard.cpp:416
+#: src/amule.cpp:1013 src/FirstRunWizard.cpp:416
 msgid "Kad bootstrap nodes (nodes.dat)"
 msgstr "Kad başlangıç düğümleri (nodes.dat)"
 
-#: src/amule.cpp:1102
+#: src/amule.cpp:1103
 #, c-format
 msgid "web server running on pid %d"
 msgstr "web sunucusu pid %d üzerinde çalışıyor"
 
-#: src/amule.cpp:1115
+#: src/amule.cpp:1116
 msgid "You requested to run web server on startup, but the amuleweb binary cannot be run. Please install the package containing aMule web server, or build aMule from source with -DBUILD_WEBSERVER=YES and install it."
 msgstr "Web sunucusunun başlangıçta çalışmasını istediniz, fakat amuleweb ikilisi çalıştırılamıyor. Lütfen aMule web sunucusunu içeren paketi yükleyin veya aMule' yi -DBUILD_WEBSERVER=YES seçeneği ile derleyin ve kurun."
 
-#: src/amule.cpp:1120 src/amule.cpp:1177 src/amule.cpp:1291 src/amule.cpp:1593
+#: src/amule.cpp:1121 src/amule.cpp:1185 src/amule.cpp:1299 src/amule.cpp:1601
 #: src/amule-remote-gui.cpp:603 src/amule-remote-gui.cpp:671
 #: src/amule-remote-gui.cpp:709 src/amule-remote-gui.cpp:1282
 #: src/amule-remote-gui.cpp:1345 src/amule-remote-gui.cpp:1372
-#: src/DownloadQueue.cpp:1481
+#: src/DownloadQueue.cpp:1481 src/PrefsUnifiedDlg.cpp:1247
 msgid "ERROR"
 msgstr "HATA"
 
-#: src/amule.cpp:1166
+#: src/amule.cpp:1174
 #, c-format
 msgid "amuleapi running on pid %d"
 msgstr "amuleapi pid %d üzerinde çalışıyor"
 
-#: src/amule.cpp:1172
+#: src/amule.cpp:1180
 msgid "You requested to run amuleapi on startup, but the amuleapi binary cannot be run. Please install the package containing aMule's REST API server, or build aMule from source with -DBUILD_AMULEAPI=YES and install it."
 msgstr "amuleapi'nın başlangıçta çalışmasını istediniz, fakat amuleapi ikilisi çalıştırılamıyor. Lütfen aMule REST API sunucusunu içeren paketi yükleyin veya aMule' yi -DBUILD_AMULEAPI=YES seçeneği ile derleyin ve kurun."
 
-#: src/amule.cpp:1259
+#: src/amule.cpp:1267
 #, c-format
 msgid "Could not bind ports to the specified address: %s"
 msgstr "Belirtilen şu adrese portlar bağlanamıyor: %s"
 
-#: src/amule.cpp:1283
+#: src/amule.cpp:1291
 #, c-format
 msgid "Port %u is not available. You will be LOWID\n"
 msgstr "Port. %u kullanılamıyor. DÜŞÜKID alacaksınız.\n"
 
-#: src/amule.cpp:1288
+#: src/amule.cpp:1296
 #, c-format
 msgid ""
 "Port %u is not available!\n"
@@ -369,48 +369,48 @@ msgstr ""
 "\n"
 "Ağ ayarlarınıza göz atarak portun giriş ve çıkışlar için açık olup olmadığını denetleyiniz."
 
-#: src/amule.cpp:1385
+#: src/amule.cpp:1393
 msgid "Failed to create OnlineSig File"
 msgstr "Çevrim içi İmza dosyası oluşturma başarısız."
 
-#: src/amule.cpp:1393
+#: src/amule.cpp:1401
 msgid "Failed to create aMule OnlineSig File"
 msgstr "aMule Çevrim içi İmza dosyası oluşturma başarısız."
 
-#: src/amule.cpp:1556
+#: src/amule.cpp:1564
 msgid "The selected locale seems not to be installed on your box. (Note: I'll try to set it anyway)"
 msgstr "Seçilen yerelleştirme görünüşe göre bilgisayarınızda yüklü değil. (Not: Bunu yine de yapmaya çalışacağım)"
 
-#: src/amule.cpp:1566
+#: src/amule.cpp:1574
 #, c-format
 msgid "This is the first time you run aMule %s"
 msgstr "Hoş geldiniz! aMule %s sürümünü ilk kez kullanıyorsunuz."
 
-#: src/amule.cpp:1569
+#: src/amule.cpp:1577
 msgid "This version is a testing version, updated daily, and\n"
 msgstr "Bu sürüm bir deneme sürümü, her gün güncellenir ve\n"
 
-#: src/amule.cpp:1570
+#: src/amule.cpp:1578
 msgid "we give no warranty it won't break anything, burn your house,\n"
 msgstr "bir şeyleri bozmayacağını veya evinizi yakmayacağını \n"
 
-#: src/amule.cpp:1571
+#: src/amule.cpp:1579
 msgid "or kill your dog. But it *should* be safe to use anyway.\n"
 msgstr "yahut da köpeğinizi öldürmeyeceğini garanti edemeyiz. Fakat bir *sorun* yaratmayacağını da umuyoruz.\n"
 
-#: src/amule.cpp:1576
+#: src/amule.cpp:1584
 msgid "More information, support and new releases can found at our homepage,\n"
 msgstr "Daha fazla bilgi, destek ve yeni sürümler ana sayfamızda bulunabilir\n"
 
-#: src/amule.cpp:1577
+#: src/amule.cpp:1585
 msgid "at https://amule-org.github.io, or in our IRC channel #aMule at irc.libera.chat.\n"
 msgstr "https://amule-org.github.io veya IRC kanalımız: irc.libera.chat sunucusunda #aMule \n"
 
-#: src/amule.cpp:1579
+#: src/amule.cpp:1587
 msgid "Feel free to report any bugs to https://github.com/amule-org/amule/issues"
 msgstr "Her türlü hatayı bize bildirmekten çekinmeyin https://github.com/amule-org/amule/issues"
 
-#: src/amule.cpp:1591
+#: src/amule.cpp:1599
 msgid ""
 "The folder for Online Signature files you specified is INVALID!\n"
 " OnlineSignature will be DISABLED until you fix it on preferences."
@@ -418,137 +418,137 @@ msgstr ""
 "Belirlediğiniz Çevrim içi İmza dosyaları dizini GEÇERSİZ!\n"
 " Çevrim içi İmza, ayarlarınızda düzeltene kadar DEVRE DIŞI bırakıldı."
 
-#: src/amule.cpp:1654
+#: src/amule.cpp:1662
 msgid "Server hostname notified"
 msgstr "Sunucu makine adı uyarıldı"
 
-#: src/amule.cpp:2031
+#: src/amule.cpp:2039
 #, c-format
 msgid "Disk space preallocation for file '%s' failed: %s"
 msgstr "%s dosyası için diskte yer ayırma başarısız oldu: %s"
 
-#: src/amule.cpp:2160
+#: src/amule.cpp:2168
 msgid "ERROR: can't open logfile"
 msgstr "HATA: Günlük dosyası açılamıyor."
 
-#: src/amule.cpp:2164
+#: src/amule.cpp:2172
 msgid "WARNING: logfile is empty. Something is wrong."
 msgstr "UYARI: Günlük dosyası boş, bir şeyler yanlış."
 
-#: src/amule.cpp:2181
+#: src/amule.cpp:2189
 msgid "Log has been reset"
 msgstr "Günlük kaydı silindi"
 
-#: src/amule.cpp:2205
+#: src/amule.cpp:2213
 #, c-format
 msgid "ServerMessage: %s"
 msgstr "Sunucu İletisi: %s"
 
-#: src/amule.cpp:2248 src/IP2Country.cpp:220 src/IPFilter.cpp:514
+#: src/amule.cpp:2256 src/IP2Country.cpp:220 src/IPFilter.cpp:514
 #: src/ServerList.cpp:875
 #, c-format
 msgid "Skipped download of %s, because requested file is not newer."
 msgstr "%s indirilmeyecek; çünkü istenen dosya yeni değil."
 
-#: src/amule.cpp:2251
+#: src/amule.cpp:2259
 msgid "Failed to download the nodes list."
 msgstr "Nod listesini indirme başarısız."
 
-#: src/amule.cpp:2314
+#: src/amule.cpp:2322
 msgid "Failed to open the downloaded version check file"
 msgstr "İndirilen sürüm denetleme dosyasını açma başarısız oldu."
 
-#: src/amule.cpp:2317 src/amule.cpp:2336
+#: src/amule.cpp:2325 src/amule.cpp:2344
 msgid "Corrupted version check file"
 msgstr "Bozuk sürüm denetleme dosyası"
 
-#: src/amule.cpp:2359
+#: src/amule.cpp:2367
 msgid "You are using an outdated version of aMule!"
 msgstr "aMule'nin eski bir sürümünü kullanıyorsunuz!"
 
-#: src/amule.cpp:2361
+#: src/amule.cpp:2369
 #, c-format
 msgid "Your aMule version is %i.%i.%i and the latest version is %li.%li.%li"
 msgstr "aMule sürümünüz %i.%i.%i ve en güncel sürüm %li.%li.%li"
 
-#: src/amule.cpp:2365
+#: src/amule.cpp:2373
 msgid "The latest version can always be found at https://github.com/amule-org/amule/releases/latest"
 msgstr "En güncel sürüm her zaman https://github.com/amule-org/amule/releases/latest adresinde bulunabilir."
 
-#: src/amule.cpp:2368
+#: src/amule.cpp:2376
 #, c-format
 msgid "WARNING: Your aMuled version is outdated: %i.%i.%i < %li.%li.%li"
 msgstr "UYARI: aMuled sürümünüz eski: %i.%i.%i < %li.%li.%li"
 
-#: src/amule.cpp:2374
+#: src/amule.cpp:2382
 msgid "Your copy of aMule is up to date."
 msgstr "aMule sürümünüz güncel."
 
-#: src/amule.cpp:2381
+#: src/amule.cpp:2389
 msgid "Failed to download the version check file"
 msgstr "Sürüm denetleme dosyasını indirme başarısız oldu."
 
-#: src/amule.cpp:2550 src/amule-remote-gui.cpp:1133
+#: src/amule.cpp:2558 src/amule-remote-gui.cpp:1133
 #, c-format
 msgid "Users: %s | Files: %s"
 msgstr "Kullanıcılar: %s | Dosyalar: %s"
 
-#: src/amule.cpp:2551 src/amule-remote-gui.cpp:1134
+#: src/amule.cpp:2559 src/amule-remote-gui.cpp:1134
 #, c-format
 msgid "Users: E: %s K: %s | Files: E: %s K: %s"
 msgstr "Kullanıcılar: E: %s K: %s | Dosyalar: E: %s K: %s"
 
-#: src/amule.cpp:2565 src/amule-remote-gui.cpp:1147
+#: src/amule.cpp:2573 src/amule-remote-gui.cpp:1147
 msgid "No networks selected"
 msgstr "Hiç bir ağ seçilmedi"
 
-#: src/amule.cpp:2633 src/TextClient.cpp:903
+#: src/amule.cpp:2641 src/TextClient.cpp:903
 msgid "with LowID"
 msgstr "DüşükID ile"
 
-#: src/amule.cpp:2633 src/TextClient.cpp:904
+#: src/amule.cpp:2641 src/TextClient.cpp:904
 msgid "with HighID"
 msgstr "YüksekID ile"
 
-#: src/amule.cpp:2635
+#: src/amule.cpp:2643
 #, c-format
 msgid "Connected to %s %s"
 msgstr "Bağlandı: %s %s"
 
-#: src/amule.cpp:2640
+#: src/amule.cpp:2648
 #, c-format
 msgid "Connecting to %s"
 msgstr "Bağlanıyor: %s"
 
-#: src/amule.cpp:2642
+#: src/amule.cpp:2650
 msgid "Disconnected from eD2k"
 msgstr "eD2k Bağlantısı kesildi"
 
-#: src/amule.cpp:2651
+#: src/amule.cpp:2659
 msgid "Kad started."
 msgstr "Kademlia başladı."
 
-#: src/amule.cpp:2653
+#: src/amule.cpp:2661
 msgid "Kad stopped."
 msgstr "Kademlia durdu."
 
-#: src/amule.cpp:2661
+#: src/amule.cpp:2669
 msgid "Connected to Kad (ok)"
 msgstr "Kademlia ağına bağlanıldı (tamam)"
 
-#: src/amule.cpp:2663
+#: src/amule.cpp:2671
 msgid "Connected to Kad (firewalled)"
 msgstr "Kademlia ağına bağlanıldı (Güvenlik duvarı arkasında)"
 
-#: src/amule.cpp:2667
+#: src/amule.cpp:2675
 msgid "Disconnected from Kad"
 msgstr "Kademlia bağlantısı kesildi."
 
-#: src/amule.cpp:2699
+#: src/amule.cpp:2707
 msgid "Kad network cannot be used if UDP port is disabled on preferences, not starting."
 msgstr "UDP portu ayarlarda devre dışı bırakılmışsa Kad ağı kullanılamaz. Başlatılmıyor."
 
-#: src/amule.cpp:2703
+#: src/amule.cpp:2711
 msgid "Kad network disabled on preferences, not connecting."
 msgstr "Kad ağı ayarlarda devre dışı bırakılmış, bağlanılmıyor."
 
@@ -592,36 +592,36 @@ msgid "FATAL ERROR: Failed to create Timer"
 msgstr "ÖNEMLİ HATA: Zamanlayıcı oluşturulamadı"
 
 #: src/amuleDlg.cpp:361 src/amuleDlg.cpp:1787 src/amuleDlg.cpp:2033
-#: src/muuli_wdr.cpp:1492 src/muuli_wdr.cpp:3418
+#: src/muuli_wdr.cpp:1492 src/muuli_wdr.cpp:3449
 msgid "Networks"
 msgstr "Ağlar"
 
-#: src/amuleDlg.cpp:362 src/amuleDlg.cpp:1793 src/muuli_wdr.cpp:3419
+#: src/amuleDlg.cpp:362 src/amuleDlg.cpp:1793 src/muuli_wdr.cpp:3450
 msgid "Searches"
 msgstr "Aramalar"
 
 #: src/amuleDlg.cpp:363 src/amuleDlg.cpp:1799 src/DownloadListCtrl.cpp:740
-#: src/muuli_wdr.cpp:392 src/muuli_wdr.cpp:1585 src/muuli_wdr.cpp:3420
+#: src/muuli_wdr.cpp:392 src/muuli_wdr.cpp:1585 src/muuli_wdr.cpp:3451
 #: src/Statistics.cpp:829
 msgid "Downloads"
 msgstr "İndirmeler"
 
-#: src/amuleDlg.cpp:364 src/amuleDlg.cpp:1805 src/muuli_wdr.cpp:3294
+#: src/amuleDlg.cpp:364 src/amuleDlg.cpp:1805 src/muuli_wdr.cpp:3325
 msgid "Shared files"
 msgstr "Paylaşılan dosyalar"
 
-#: src/amuleDlg.cpp:365 src/amuleDlg.cpp:1811 src/muuli_wdr.cpp:2926
-#: src/muuli_wdr.cpp:3376 src/muuli_wdr.cpp:3423
+#: src/amuleDlg.cpp:365 src/amuleDlg.cpp:1811 src/muuli_wdr.cpp:2957
+#: src/muuli_wdr.cpp:3407 src/muuli_wdr.cpp:3454
 msgid "Messages"
 msgstr "Sohbet"
 
-#: src/amuleDlg.cpp:366 src/amuleDlg.cpp:1817 src/muuli_wdr.cpp:3424
-#: src/PrefsUnifiedDlg.cpp:312 src/Statistics.cpp:779 src/Statistics.cpp:1235
+#: src/amuleDlg.cpp:366 src/amuleDlg.cpp:1817 src/muuli_wdr.cpp:3455
+#: src/PrefsUnifiedDlg.cpp:314 src/Statistics.cpp:779 src/Statistics.cpp:1235
 msgid "Statistics"
 msgstr "İstatistikler"
 
-#: src/amuleDlg.cpp:368 src/amuleDlg.cpp:1824 src/muuli_wdr.cpp:3426
-#: src/PrefsUnifiedDlg.cpp:328 src/utils/wxCas/src/wxcasprefs.cpp:39
+#: src/amuleDlg.cpp:368 src/amuleDlg.cpp:1824 src/muuli_wdr.cpp:3457
+#: src/PrefsUnifiedDlg.cpp:330 src/utils/wxCas/src/wxcasprefs.cpp:39
 msgid "Preferences"
 msgstr "Ayarlar"
 
@@ -683,8 +683,8 @@ msgstr "Kad: Kapalı"
 #: src/amuleDlg.cpp:1029 src/DownloadListCtrl.cpp:505
 #: src/DownloadListCtrl.cpp:749 src/FriendListCtrl.cpp:180
 #: src/muuli_wdr.cpp:731 src/muuli_wdr.cpp:782 src/muuli_wdr.cpp:846
-#: src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2231 src/muuli_wdr.cpp:2316
-#: src/muuli_wdr.cpp:3064 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
+#: src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2262 src/muuli_wdr.cpp:2347
+#: src/muuli_wdr.cpp:3095 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
 #: src/ServerListCtrl.cpp:606 src/TransferWnd.cpp:378
 #: src/utils/wxCas/src/wxcasprefs.cpp:235
 msgid "Cancel"
@@ -695,7 +695,7 @@ msgid "Stop the current connection attempts"
 msgstr "Durdur"
 
 #: src/amuleDlg.cpp:1035 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976
-#: src/muuli_wdr.cpp:2454
+#: src/muuli_wdr.cpp:2485
 msgid "Disconnect"
 msgstr "Bağlantıyı Kes"
 
@@ -704,7 +704,7 @@ msgid "Disconnect from the currently connected networks"
 msgstr "Bağlanılmış olan ağlar ile bağlantıyı Kes"
 
 #: src/amuleDlg.cpp:1041 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979
-#: src/muuli_wdr.cpp:2609 src/muuli_wdr.cpp:3061 src/muuli_wdr.cpp:3416
+#: src/muuli_wdr.cpp:2640 src/muuli_wdr.cpp:3092 src/muuli_wdr.cpp:3447
 msgid "Connect"
 msgstr "Bağlan"
 
@@ -758,7 +758,7 @@ msgstr "Çıkışı onaylayınız"
 msgid "Launch Command: "
 msgstr "Çalıştırma Komutu: "
 
-#: src/amuleDlg.cpp:1632 src/muuli_wdr.cpp:1978 src/Preferences.cpp:952
+#: src/amuleDlg.cpp:1632 src/muuli_wdr.cpp:1982 src/Preferences.cpp:979
 msgid "- default -"
 msgstr "- ön tanımlı -"
 
@@ -772,48 +772,48 @@ msgstr "Kaplama dizini '%s' yok"
 msgid "WARNING: Unable to open skin file '%s' for read"
 msgstr "UYARI: Kaplama dosyası '%s' okuma için açılamıyor"
 
-#: src/amuleDlg.cpp:1791 src/muuli_wdr.cpp:3418
+#: src/amuleDlg.cpp:1791 src/muuli_wdr.cpp:3449
 msgid "Networks Window"
 msgstr "Ağ Penceresi"
 
-#: src/amuleDlg.cpp:1797 src/muuli_wdr.cpp:3419
+#: src/amuleDlg.cpp:1797 src/muuli_wdr.cpp:3450
 msgid "Searches Window"
 msgstr "Arama Penceresi"
 
-#: src/amuleDlg.cpp:1803 src/muuli_wdr.cpp:3420
+#: src/amuleDlg.cpp:1803 src/muuli_wdr.cpp:3451
 msgid "Downloads Window"
 msgstr "İndirme Penceresi"
 
-#: src/amuleDlg.cpp:1809 src/muuli_wdr.cpp:3422
+#: src/amuleDlg.cpp:1809 src/muuli_wdr.cpp:3453
 msgid "Shared Files Window"
 msgstr "Paylaşılan Dosya Penceresi"
 
-#: src/amuleDlg.cpp:1815 src/muuli_wdr.cpp:3423
+#: src/amuleDlg.cpp:1815 src/muuli_wdr.cpp:3454
 msgid "Messages Window"
 msgstr "Sohbet Penceresi"
 
-#: src/amuleDlg.cpp:1821 src/muuli_wdr.cpp:3424
+#: src/amuleDlg.cpp:1821 src/muuli_wdr.cpp:3455
 msgid "Statistics Graph Window"
 msgstr "İstatistik Grafik Penceresi"
 
-#: src/amuleDlg.cpp:1828 src/muuli_wdr.cpp:3426
+#: src/amuleDlg.cpp:1828 src/muuli_wdr.cpp:3457
 msgid "Preferences Settings Window"
 msgstr "Ayar Penceresi"
 
-#: src/amuleDlg.cpp:1831 src/muuli_wdr.cpp:3427
+#: src/amuleDlg.cpp:1831 src/muuli_wdr.cpp:3458
 msgid "Import"
 msgstr "İçe Aktar"
 
-#: src/amuleDlg.cpp:1835 src/muuli_wdr.cpp:3427
+#: src/amuleDlg.cpp:1835 src/muuli_wdr.cpp:3458
 msgid "The partfile importer tool"
 msgstr "Parça dosyası içe aktarım aracı"
 
-#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3428
+#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3459
 #: src/utils/aLinkCreator/src/alcframe.cpp:262
 msgid "About"
 msgstr "Hakkında"
 
-#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3428
+#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3459
 msgid "About/Help"
 msgstr "Hakkında/Yardım"
 
@@ -956,7 +956,7 @@ msgstr "bulunamadı"
 msgid "The core rejected these shared folders:%s"
 msgstr "Çekirdek şu paylaşılan dizinleri reddetti: %s"
 
-#: src/amule-remote-gui.cpp:1336 src/ExternalConn.cpp:2345
+#: src/amule-remote-gui.cpp:1336 src/ExternalConn.cpp:2346
 msgid "Invalid link or already on list."
 msgstr "Geçersiz bağlantı veya zaten listede mevcut."
 
@@ -972,7 +972,7 @@ msgstr "'%s' dizini '%s' sınıfı için oluşturulamadı. '%s' dizini kullanıl
 #: src/ClientDetailDialog.cpp:123 src/DataToText.cpp:61 src/DataToText.cpp:86
 #: src/DataToText.cpp:101 src/DataToText.cpp:136 src/DataToText.cpp:165
 #: src/DownloadListCtrl.cpp:1172 src/DownloadListCtrl.cpp:1185
-#: src/DownloadListCtrl.cpp:1196 src/ExternalConn.cpp:608
+#: src/DownloadListCtrl.cpp:1196 src/ExternalConn.cpp:609
 #: src/FileDetailDialog.cpp:203 src/FileDetailDialog.cpp:235
 #: src/FileDetailDialog.cpp:242 src/GenericClientListCtrl.cpp:1171
 #: src/GenericClientListCtrl.cpp:1182 src/GenericClientListCtrl.cpp:1192
@@ -1358,19 +1358,19 @@ msgstr "Oto (Yük)"
 msgid "Very low"
 msgstr "Çok düşük"
 
-#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:743 src/muuli_wdr.cpp:2282
+#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:743 src/muuli_wdr.cpp:2313
 #: src/ServerListCtrl.cpp:263 src/ServerListCtrl.cpp:456
 #: src/SharedFilesCtrl.cpp:145
 msgid "Low"
 msgstr "Düşük"
 
-#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:744 src/muuli_wdr.cpp:2283
+#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:744 src/muuli_wdr.cpp:2314
 #: src/ServerListCtrl.cpp:266 src/ServerListCtrl.cpp:457
 #: src/SharedFilesCtrl.cpp:146
 msgid "Normal"
 msgstr "Normal"
 
-#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:745 src/muuli_wdr.cpp:2284
+#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:745 src/muuli_wdr.cpp:2315
 #: src/ServerListCtrl.cpp:269 src/ServerListCtrl.cpp:458
 #: src/SharedFilesCtrl.cpp:147
 msgid "High"
@@ -1462,7 +1462,7 @@ msgstr "Sunucu"
 msgid "Remote Server"
 msgstr "Uzak Sunucu"
 
-#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3181
+#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3212
 #: src/SearchDlg.cpp:119 src/TextClient.cpp:911
 msgid "Kad"
 msgstr "Kad"
@@ -1533,7 +1533,7 @@ msgstr "Parça"
 msgid "Size"
 msgstr "Boyut"
 
-#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3248
+#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3279
 msgid "Transferred"
 msgstr "Aktarıldı"
 
@@ -1591,7 +1591,7 @@ msgstr ""
 "Geri besleme: %s (%s)\n"
 "\n"
 
-#: src/DownloadListCtrl.cpp:746 src/muuli_wdr.cpp:2285
+#: src/DownloadListCtrl.cpp:746 src/muuli_wdr.cpp:2316
 #: src/SharedFilesCtrl.cpp:150
 msgid "Auto"
 msgstr "Otomatik"
@@ -1629,7 +1629,7 @@ msgid "Extended Options"
 msgstr "Genişletilmiş Seçenekler"
 
 #: src/DownloadListCtrl.cpp:770 src/DownloadListCtrl.cpp:822
-#: src/muuli_wdr.cpp:1796
+#: src/muuli_wdr.cpp:1800
 msgid "Preview"
 msgstr "Ön İzleme"
 
@@ -1804,225 +1804,230 @@ msgstr[1] "%u bağlantı eklenemedi (teferruatlar için kütüğe bakın)."
 msgid "Invalid eD2k link! ERROR: %s"
 msgstr "Geçersiz eD2k bağlantısı! HATA: %s"
 
-#: src/ExternalConn.cpp:379
+#: src/ExternalConn.cpp:380
 msgid "Client sent packet after authentication failed."
 msgstr "Kimlik kanıtlamadan sonra istemci tarafından gönderilen paket başarısız."
 
-#: src/ExternalConn.cpp:396
+#: src/ExternalConn.cpp:397
 msgid "External connection closed."
 msgstr "Dışarıdan bağlantı kesildi."
 
-#: src/ExternalConn.cpp:473
+#: src/ExternalConn.cpp:474
 msgid "External connections disabled due to empty password!"
 msgstr "Boş şifre sebebiyle dışarıdan bağlantı devre dışı!"
 
-#: src/ExternalConn.cpp:494
+#: src/ExternalConn.cpp:495
 msgid "External connections disabled in config file"
 msgstr "Yapılandırma dosyasında dışarıdan bağlantılar devre dışı bırakılmış."
 
-#: src/ExternalConn.cpp:575
+#: src/ExternalConn.cpp:576
 msgid "New external connection accepted"
 msgstr "Yeni dışarıdan bağlantı kabul edildi"
 
-#: src/ExternalConn.cpp:578
+#: src/ExternalConn.cpp:579
 msgid "ERROR: couldn't accept a new external connection"
 msgstr "HATA: yeni bir dış bağlantı kabul edilemiyor"
 
-#: src/ExternalConn.cpp:595
+#: src/ExternalConn.cpp:596
 msgid "External connection refused due to empty password in preferences!"
 msgstr "Ayarlardaki boş şifre sebebiyle dışarıdan bağlantılar reddedildi!"
 
-#: src/ExternalConn.cpp:607
+#: src/ExternalConn.cpp:608
 #, c-format
 msgid "Connecting client: %s %s"
 msgstr "Kullanıcıya bağlanılıyor: %s %s"
 
-#: src/ExternalConn.cpp:609
+#: src/ExternalConn.cpp:610
 msgid "Unknown version"
 msgstr "Bilinmeyen sürüm"
 
-#: src/ExternalConn.cpp:622
+#: src/ExternalConn.cpp:623
 msgid "Incorrect EC version ID, there might be binary incompatibility. Use core and remote from same snapshot."
 msgstr "Yanlış EC sürüm ID, bir çift uyumsuzluğu olabilir. Aynı görüntüden çekirdek ve uzak kullanınız."
 
-#: src/ExternalConn.cpp:630
+#: src/ExternalConn.cpp:631
 msgid "You cannot connect to a release version from an arbitrary development snapshot! *sigh* possible crash prevented"
 msgstr "Bir geliştirme sürümünden dengeli bir sürüme bağlanamazsınız! *muhtemel* bir çökme önlendi"
 
-#: src/ExternalConn.cpp:713
+#: src/ExternalConn.cpp:714
 msgid "Invalid protocol version."
 msgstr "Geçersiz protokol sürümü."
 
-#: src/ExternalConn.cpp:719
+#: src/ExternalConn.cpp:720
 msgid "Missing protocol version tag."
 msgstr "Kayıp protokol sürüm eki."
 
-#: src/ExternalConn.cpp:727
+#: src/ExternalConn.cpp:728
 msgid "Authentication failed: invalid hash specified as EC password."
 msgstr "Kimlik doğrulama başarısız oldu: EC parolası olarak geçersiz adresleme girildi."
 
-#: src/ExternalConn.cpp:775
+#: src/ExternalConn.cpp:776
 msgid "Authentication failed: wrong password."
 msgstr "Kimlik doğrulama başarısız oldu: yanlış parola."
 
-#: src/ExternalConn.cpp:777
+#: src/ExternalConn.cpp:778
 msgid "Authentication failed: missing password."
 msgstr "Kimlik doğrulama başarısız oldu: kayıp parola."
 
-#: src/ExternalConn.cpp:788
+#: src/ExternalConn.cpp:789
 msgid "Invalid request, please authenticate first."
 msgstr "Geçersiz istem, öncelikle doğrulatmanız lazım."
 
-#: src/ExternalConn.cpp:793
+#: src/ExternalConn.cpp:794
 msgid "Access granted."
 msgstr "Giriş izni verildi."
 
-#: src/ExternalConn.cpp:801
+#: src/ExternalConn.cpp:802
 #, c-format
 msgid "Sent error message \"%s\" to client."
 msgstr "\"%s\" hata iletisi istemciye gönderildi."
 
-#: src/ExternalConn.cpp:806
+#: src/ExternalConn.cpp:807
 #, c-format
 msgid "Unauthorized access attempt from %s. Connection closed."
 msgstr "%s üzerinden yetkilendirilmemiş giriş denemesi. Bağlantı kesildi."
 
-#: src/ExternalConn.cpp:1419
+#: src/ExternalConn.cpp:1420
 #, c-format
 msgid "Remote PartFile command failed: FileHash not found: %s"
 msgstr "Uzak Parça Dosyası komutu başarısız: Dosya Adreslemesi bulunamadı: %s"
 
-#: src/ExternalConn.cpp:1423
+#: src/ExternalConn.cpp:1424
 #, c-format
 msgid "FileHash not found: %s"
 msgstr "Dosya adreslemesi bulunamadı: %s"
 
-#: src/ExternalConn.cpp:1470 src/ExternalConn.cpp:1558
-#: src/ExternalConn.cpp:1679
+#: src/ExternalConn.cpp:1471 src/ExternalConn.cpp:1559
+#: src/ExternalConn.cpp:1680
 msgid "OOPS! OpCode processing error!"
 msgstr "Aman aman! OpCode işleme hatası!"
 
-#: src/ExternalConn.cpp:1501
+#: src/ExternalConn.cpp:1502
 msgid "Server not added"
 msgstr "Sunucu eklenmedi."
 
-#: src/ExternalConn.cpp:1520
+#: src/ExternalConn.cpp:1521
 #, c-format
 msgid "server not found: %s"
 msgstr "sunucu bulunamadı: %s"
 
-#: src/ExternalConn.cpp:1537
+#: src/ExternalConn.cpp:1538
 msgid "need to define server to be removed"
 msgstr "çıkarılacak sunucunun tanımlanması gerekli"
 
-#: src/ExternalConn.cpp:1552
+#: src/ExternalConn.cpp:1553
 msgid "eD2k is disabled in preferences."
 msgstr "eD2k ayarlarda devre dışı bırakılmış."
 
-#: src/ExternalConn.cpp:1657
+#: src/ExternalConn.cpp:1658
 msgid "Friend not found."
 msgstr "Arkadaş bulunamadı."
 
-#: src/ExternalConn.cpp:1667
+#: src/ExternalConn.cpp:1668
 msgid "Client not found."
 msgstr "İstemci bulunamadı."
 
-#: src/ExternalConn.cpp:1673
+#: src/ExternalConn.cpp:1674
 msgid "EC_TAG_FRIEND_SHARED requires EC_TAG_FRIEND or EC_TAG_CLIENT."
 msgstr "EC_TAG_FRIEND_SHARED, EC_TAG_FRIEND veya EC_TAG_CLIENT gerektirir."
 
-#: src/ExternalConn.cpp:1991
+#: src/ExternalConn.cpp:1992
 msgid "WebSearch from remote interface makes no sense."
 msgstr "Uzak arayüzden Web araması yapmak anlamsız."
 
-#: src/ExternalConn.cpp:2026
+#: src/ExternalConn.cpp:2027
 msgid "Search in progress. Refetch results in a moment!"
 msgstr "Arama sürüyor. Bir dakikaya sonuçlanır!"
 
-#: src/ExternalConn.cpp:2265
+#: src/ExternalConn.cpp:2266
 msgid "No points for graph."
 msgstr "Grafik için hiç nokta yok."
 
-#: src/ExternalConn.cpp:2275
+#: src/ExternalConn.cpp:2276
 msgid "Your client is not configured for this detail level."
 msgstr "Yazılımınız bu ayrıntı düzeyi için yapılandırılmamış."
 
-#: src/ExternalConn.cpp:2302
+#: src/ExternalConn.cpp:2303
 msgid "External Connection: shutdown requested"
 msgstr "Bağlantı kapat"
 
-#: src/ExternalConn.cpp:2314
+#: src/ExternalConn.cpp:2315
 msgid "Already shutting down."
 msgstr "Zaten kapatılıyor."
 
-#: src/ExternalConn.cpp:2332
+#: src/ExternalConn.cpp:2333
 #, c-format
 msgid "ExternalConn: adding link '%s'."
 msgstr "Dışarıdan Bağ.:'%s' bağlantısı ekleniyor."
 
-#: src/ExternalConn.cpp:2350
+#: src/ExternalConn.cpp:2351
 #, c-format
 msgid "%d of %d links failed (invalid or already on list)."
 msgstr "%d bağlantı, ki toplam %d üzerinden, başarısız oldu (geçersiz veya zaten listede)."
 
-#: src/ExternalConn.cpp:2373
+#: src/ExternalConn.cpp:2374
 msgid "Version check throttled; try again shortly."
 msgstr "Sürüm kontrolü sınırlandırıldı; kısa bir süre sonra tekrar deneyin."
 
-#: src/ExternalConn.cpp:2378
+#: src/ExternalConn.cpp:2379
 msgid "Version check is not available on this daemon."
 msgstr "Bu daemon üzerinde sürüm kontrolü mevcut değildir."
 
-#: src/ExternalConn.cpp:2508
+#: src/ExternalConn.cpp:2509
 msgid "File not found."
 msgstr "Dosya bulunamadı."
 
-#: src/ExternalConn.cpp:2513
+#: src/ExternalConn.cpp:2514
 msgid "Invalid file name."
 msgstr "Geçersiz dosya adı."
 
-#: src/ExternalConn.cpp:2521
+#: src/ExternalConn.cpp:2522
 msgid "Unable to rename file."
 msgstr "Dosya yeniden adlandırılamıyor."
 
-#: src/ExternalConn.cpp:2992 src/ExternalConn.cpp:3020
+#: src/ExternalConn.cpp:2839
+#, c-format
+msgid "Could not save the amuleapi password: %s"
+msgstr ""
+
+#: src/ExternalConn.cpp:3004 src/ExternalConn.cpp:3032
 msgid "Kad is disabled in preferences."
 msgstr "Kad ayarlarda devre dışı bırakılmış."
 
-#: src/ExternalConn.cpp:3033
+#: src/ExternalConn.cpp:3045
 msgid "Already connected to eD2k."
 msgstr "eD2k ağına zaten bağlandı."
 
-#: src/ExternalConn.cpp:3036
+#: src/ExternalConn.cpp:3048
 msgid "Connecting to eD2k..."
 msgstr "eD2k ağına bağlanıyor…"
 
-#: src/ExternalConn.cpp:3045
+#: src/ExternalConn.cpp:3057
 msgid "Already connected to Kad."
 msgstr "Kad zaten bağlı."
 
-#: src/ExternalConn.cpp:3048
+#: src/ExternalConn.cpp:3060
 msgid "Connecting to Kad..."
 msgstr "Kad ağına bağlanıyor…"
 
-#: src/ExternalConn.cpp:3055
+#: src/ExternalConn.cpp:3067
 msgid "All networks are disabled."
 msgstr "Bütün ağlar devre dışı."
 
-#: src/ExternalConn.cpp:3064
+#: src/ExternalConn.cpp:3076
 msgid "Disconnected from eD2k."
 msgstr "eD2k ağından bağlantı kesildi."
 
-#: src/ExternalConn.cpp:3069
+#: src/ExternalConn.cpp:3081
 msgid "Disconnected from Kad."
 msgstr "Kad ağından bağlantı kesildi."
 
-#: src/ExternalConn.cpp:3078
+#: src/ExternalConn.cpp:3090
 #, c-format
 msgid "External Connection: invalid opcode received: %#x"
 msgstr "Dış Bağlantı: geçersiz opcode alındı: %#x"
 
-#: src/ExternalConn.cpp:3083
+#: src/ExternalConn.cpp:3095
 msgid "Invalid opcode (wrong protocol version?)"
 msgstr "Geçersiz opcode (yanlış protokol sürümü mü?)"
 
@@ -2423,23 +2428,23 @@ msgid ""
 "want downloads on a different (e.g. larger) disk."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:549 src/FirstRunWizard.cpp:611 src/muuli_wdr.cpp:1708
+#: src/FirstRunWizard.cpp:549 src/FirstRunWizard.cpp:611 src/muuli_wdr.cpp:1712
 msgid "Destination folder for downloads"
 msgstr "İndirmeler için hedef dizin"
 
 #: src/FirstRunWizard.cpp:553 src/FirstRunWizard.cpp:569 src/muuli_wdr.cpp:1349
-#: src/muuli_wdr.cpp:1366 src/muuli_wdr.cpp:1683 src/muuli_wdr.cpp:1714
-#: src/muuli_wdr.cpp:1726 src/muuli_wdr.cpp:2769
+#: src/muuli_wdr.cpp:1366 src/muuli_wdr.cpp:1687 src/muuli_wdr.cpp:1718
+#: src/muuli_wdr.cpp:1730 src/muuli_wdr.cpp:2800
 #: src/utils/aLinkCreator/src/alcframe.cpp:135
 #: src/utils/wxCas/src/wxcasprefs.cpp:52 src/utils/wxCas/src/wxcasprefs.cpp:118
 msgid "Browse"
 msgstr "Göz at"
 
-#: src/FirstRunWizard.cpp:559 src/muuli_wdr.cpp:1719
+#: src/FirstRunWizard.cpp:559 src/muuli_wdr.cpp:1723
 msgid "(All files in this folder are shared with other peers)"
 msgstr "(Bu dizindeki tüm dosyalar diğer eşler ile paylaşılmaktadır)"
 
-#: src/FirstRunWizard.cpp:565 src/FirstRunWizard.cpp:624 src/muuli_wdr.cpp:1721
+#: src/FirstRunWizard.cpp:565 src/FirstRunWizard.cpp:624 src/muuli_wdr.cpp:1725
 msgid "Folder for temporary download files"
 msgstr "Geçici dosyalar için dizin"
 
@@ -2470,7 +2475,7 @@ msgstr "Arkadaş listesi 'emfriends.met' dosyasına yazılamıyor!"
 msgid "CRITICAL - no client on StartChatSession"
 msgstr "KRİTİK - SohbetOturumunuBaşlat' ta istemci yok"
 
-#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2675 src/muuli_wdr.cpp:3352
+#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2706 src/muuli_wdr.cpp:3383
 msgid "Friends"
 msgstr "Arkadaşlar"
 
@@ -2580,8 +2585,8 @@ msgstr "Yok"
 msgid "No"
 msgstr "Hayır"
 
-#: src/GenericClientListCtrl.cpp:1216 src/PrefsUnifiedDlg.cpp:2818
-#: src/PrefsUnifiedDlg.cpp:2868 src/ServerListCtrl.cpp:276
+#: src/GenericClientListCtrl.cpp:1216 src/PrefsUnifiedDlg.cpp:2898
+#: src/PrefsUnifiedDlg.cpp:2948 src/ServerListCtrl.cpp:276
 msgid "Yes"
 msgstr "Evet"
 
@@ -2750,10 +2755,10 @@ msgstr "Ön yükleme için geçersiz port"
 msgid "Please fill all fields required"
 msgstr "İstenilen tüm alanları doldurunuz."
 
-#: src/KadDlg.cpp:192 src/PartFile.cpp:1031 src/PrefsUnifiedDlg.cpp:1162
-#: src/PrefsUnifiedDlg.cpp:1331 src/PrefsUnifiedDlg.cpp:1589
-#: src/PrefsUnifiedDlg.cpp:1599 src/PrefsUnifiedDlg.cpp:1616
-#: src/PrefsUnifiedDlg.cpp:1658
+#: src/KadDlg.cpp:192 src/PartFile.cpp:1031 src/PrefsUnifiedDlg.cpp:1134
+#: src/PrefsUnifiedDlg.cpp:1204 src/PrefsUnifiedDlg.cpp:1405
+#: src/PrefsUnifiedDlg.cpp:1663 src/PrefsUnifiedDlg.cpp:1673
+#: src/PrefsUnifiedDlg.cpp:1690 src/PrefsUnifiedDlg.cpp:1738
 msgid "Message"
 msgstr "İleti"
 
@@ -2854,7 +2859,7 @@ msgstr "Paylaşım oranı"
 msgid "Uploaded"
 msgstr "Gönderilen"
 
-#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3232
+#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3263
 msgid "Requested"
 msgstr "İstenen"
 
@@ -2977,7 +2982,7 @@ msgid "WARNING: "
 msgstr "UYARI: "
 
 #: src/MuleNotebook.cpp:179 src/muuli_wdr.cpp:817 src/muuli_wdr.cpp:1229
-#: src/muuli_wdr.cpp:3136 src/muuli_wdr.cpp:3392
+#: src/muuli_wdr.cpp:3167 src/muuli_wdr.cpp:3423
 msgid "Close"
 msgstr "Kapat"
 
@@ -2995,7 +3000,7 @@ msgid "Paste"
 msgstr "Yapıştır"
 
 #: src/MuleTextCtrl.cpp:89 src/muuli_wdr.cpp:358 src/muuli_wdr.cpp:757
-#: src/muuli_wdr.cpp:2359 src/muuli_wdr.cpp:2378 src/muuli_wdr.cpp:2400
+#: src/muuli_wdr.cpp:2390 src/muuli_wdr.cpp:2409 src/muuli_wdr.cpp:2431
 #: src/utils/aLinkCreator/src/alcframe.cpp:142
 msgid "Clear"
 msgstr "Temizle"
@@ -3087,7 +3092,7 @@ msgstr "Çıkış"
 
 #: src/MuleTrayIcon.cpp:579 src/MuleTrayIcon.cpp:945 src/MuleTrayIcon.cpp:965
 #: src/muuli_wdr.cpp:1398 src/muuli_wdr.cpp:1406 src/muuli_wdr.cpp:1413
-#: src/muuli_wdr.cpp:1842 src/muuli_wdr.cpp:1848 src/OtherFunctions.cpp:91
+#: src/muuli_wdr.cpp:1846 src/muuli_wdr.cpp:1852 src/OtherFunctions.cpp:91
 #: src/StatisticsDlg.cpp:93 src/StatisticsDlg.cpp:95
 msgid "kB/s"
 msgstr "kB/s"
@@ -3327,7 +3332,7 @@ msgstr "Bayt"
 msgid "KB"
 msgstr "KB"
 
-#: src/muuli_wdr.cpp:274 src/muuli_wdr.cpp:293 src/muuli_wdr.cpp:1627
+#: src/muuli_wdr.cpp:274 src/muuli_wdr.cpp:293 src/muuli_wdr.cpp:1631
 #: src/OtherFunctions.cpp:64
 msgid "MB"
 msgstr "MB"
@@ -3344,7 +3349,7 @@ msgstr "En Fazla Boyut"
 msgid "Availability"
 msgstr "Uygunluk"
 
-#: src/muuli_wdr.cpp:312 src/muuli_wdr.cpp:398 src/muuli_wdr.cpp:3297
+#: src/muuli_wdr.cpp:312 src/muuli_wdr.cpp:398 src/muuli_wdr.cpp:3328
 msgid "Filter:"
 msgstr "Süz:"
 
@@ -3407,12 +3412,12 @@ msgstr "Dosya kaynakları:"
 #: src/muuli_wdr.cpp:1160 src/muuli_wdr.cpp:1167 src/muuli_wdr.cpp:1172
 #: src/muuli_wdr.cpp:1179 src/muuli_wdr.cpp:1184 src/muuli_wdr.cpp:1191
 #: src/muuli_wdr.cpp:1205 src/muuli_wdr.cpp:1212 src/muuli_wdr.cpp:1217
-#: src/muuli_wdr.cpp:1224 src/muuli_wdr.cpp:3234 src/muuli_wdr.cpp:3242
-#: src/muuli_wdr.cpp:3250
+#: src/muuli_wdr.cpp:1224 src/muuli_wdr.cpp:3265 src/muuli_wdr.cpp:3273
+#: src/muuli_wdr.cpp:3281
 msgid "N/A"
 msgstr "N/A"
 
-#: src/muuli_wdr.cpp:508 src/muuli_wdr.cpp:1065 src/PrefsUnifiedDlg.cpp:297
+#: src/muuli_wdr.cpp:508 src/muuli_wdr.cpp:1065 src/PrefsUnifiedDlg.cpp:299
 msgid "General"
 msgstr "Genel"
 
@@ -3548,7 +3553,7 @@ msgstr "Sanatçı:"
 msgid "Album :"
 msgstr "Albüm:"
 
-#: src/muuli_wdr.cpp:685 src/muuli_wdr.cpp:2254
+#: src/muuli_wdr.cpp:685 src/muuli_wdr.cpp:2285
 msgid "Title :"
 msgstr "Başlık :"
 
@@ -3656,7 +3661,7 @@ msgstr "Kullanıcı Adı :"
 msgid "Userhash :"
 msgstr "Kullanıcı Adreslemesi :"
 
-#: src/muuli_wdr.cpp:895 src/muuli_wdr.cpp:1748 src/muuli_wdr.cpp:2449
+#: src/muuli_wdr.cpp:895 src/muuli_wdr.cpp:1752 src/muuli_wdr.cpp:2480
 #: src/utils/aLinkCreator/src/alcframe.cpp:137
 msgid "Add"
 msgstr "Ekle"
@@ -3665,15 +3670,15 @@ msgstr "Ekle"
 msgid "Download-Speed"
 msgstr "İndirme Hızı"
 
-#: src/muuli_wdr.cpp:954 src/muuli_wdr.cpp:989 src/muuli_wdr.cpp:2553
+#: src/muuli_wdr.cpp:954 src/muuli_wdr.cpp:989 src/muuli_wdr.cpp:2584
 msgid "Current"
 msgstr "Şimdiki"
 
-#: src/muuli_wdr.cpp:962 src/muuli_wdr.cpp:997 src/muuli_wdr.cpp:2561
+#: src/muuli_wdr.cpp:962 src/muuli_wdr.cpp:997 src/muuli_wdr.cpp:2592
 msgid "Running average"
 msgstr "Çalışma ortalaması"
 
-#: src/muuli_wdr.cpp:970 src/muuli_wdr.cpp:1005 src/muuli_wdr.cpp:2569
+#: src/muuli_wdr.cpp:970 src/muuli_wdr.cpp:1005 src/muuli_wdr.cpp:2600
 msgid "Session average"
 msgstr "Oturum ortalaması"
 
@@ -3685,7 +3690,7 @@ msgstr "Gönderim Hızı"
 msgid "Connections"
 msgstr "Bağlantılar"
 
-#: src/muuli_wdr.cpp:1024 src/muuli_wdr.cpp:1867
+#: src/muuli_wdr.cpp:1024 src/muuli_wdr.cpp:1871
 msgid "Active downloads"
 msgstr "Aktif İndirmeler"
 
@@ -3693,7 +3698,7 @@ msgstr "Aktif İndirmeler"
 msgid "Active connections (1:1)"
 msgstr "Aktif Bağlantılar (1:1)"
 
-#: src/muuli_wdr.cpp:1040 src/muuli_wdr.cpp:1868
+#: src/muuli_wdr.cpp:1040 src/muuli_wdr.cpp:1872
 msgid "Active uploads"
 msgstr "Aktif Göndermeler"
 
@@ -3967,7 +3972,7 @@ msgstr "Yerel adresi IP' ye bağla (herhangi biri için boş bırakın):"
 msgid "Advanced users only: If you have multiple network interfaces, enter the address of the interface to which aMule should be bound."
 msgstr "Sadece ileri düzey kullanıcılar: Birden fazla ağ arayüzünüz varsa; aMule'nin izleyeceği arayüz adresini giriniz."
 
-#: src/muuli_wdr.cpp:1462 src/muuli_wdr.cpp:2061
+#: src/muuli_wdr.cpp:1462 src/muuli_wdr.cpp:2065
 msgid "Bind to network interface (empty for any):"
 msgstr "Ağ arayüzüne bağla (herhangi biri için boş bırakın):"
 
@@ -3983,7 +3988,7 @@ msgstr "İndirilen dosya başına en fazla kaynak sayısı:"
 msgid "Max simultaneous connections:"
 msgstr "En cazla eş bağlantı sayısı:"
 
-#: src/muuli_wdr.cpp:1498 src/muuli_wdr.cpp:3176
+#: src/muuli_wdr.cpp:1498 src/muuli_wdr.cpp:3207
 msgid "ED2K"
 msgstr "ED2K"
 
@@ -4075,79 +4080,79 @@ msgstr "Yeni dosyalar için diskte yer ayır"
 msgid "For new files preallocates disk space for the whole file, thus reduces fragmentation"
 msgstr "Yeni dosyalarda, dosyanın tamamı için sabit diskte yer ayrılarak parçalanma azaltılır"
 
-#: src/muuli_wdr.cpp:1613
+#: src/muuli_wdr.cpp:1617
 msgid "Create new files as sparse files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1614
-msgid "A sparse file reserves its full size on disk immediately without writing real data to it -- fast, but unsupported or slow on some filesystems, and free-space accounting stays optimistic while the download is in progress. Turn this off to grow the file only as data arrives."
+#: src/muuli_wdr.cpp:1618
+msgid "Sparse part files only occupy disk space for the parts already downloaded, so free space is used up gradually as the file fills in. Turn this off to use an ordinary file instead - useful where sparse files are unsupported or slow, or where backup/de-duplication tools handle them badly. Applies only when the core runs on Windows; on Linux and macOS part files are sparse anyway and this setting has no effect."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1619
+#: src/muuli_wdr.cpp:1623
 msgid "Stop downloads when free disk space reaches "
 msgstr "Boş disk alanı şu kadar kaldığında aktarımları durdur "
 
-#: src/muuli_wdr.cpp:1620
+#: src/muuli_wdr.cpp:1624
 msgid "Select this if you want aMule to check your disk space"
 msgstr "aMule'nin diskteki alanı denetlemesini istiyorsanız bunu seçiniz."
 
-#: src/muuli_wdr.cpp:1624
+#: src/muuli_wdr.cpp:1628
 msgid "Enter here the min disk space desired."
 msgstr "Buraya istenilen en az disk alanını giriniz."
 
-#: src/muuli_wdr.cpp:1630
+#: src/muuli_wdr.cpp:1634
 msgid "Save 10 sources on rare files (< 20 sources)"
 msgstr "Nadir bulunan dosyalarda 10 kaynak sakla (<20 kaynak)"
 
-#: src/muuli_wdr.cpp:1634 src/Statistics.cpp:790
+#: src/muuli_wdr.cpp:1638 src/Statistics.cpp:790
 msgid "Uploads"
 msgstr "Gönderilenler"
 
-#: src/muuli_wdr.cpp:1637
+#: src/muuli_wdr.cpp:1641
 msgid "Add new shared files with auto priority"
 msgstr "Dosyaları paylaşılanlara otomatik öncelikle ekle"
 
-#: src/muuli_wdr.cpp:1643
+#: src/muuli_wdr.cpp:1647
 msgid "Intelligent Corruption Handling (I.C.H.)"
 msgstr "Akıllı Bozulma Yakalayıcısı (I.C.H.)"
 
-#: src/muuli_wdr.cpp:1646
+#: src/muuli_wdr.cpp:1650
 msgid "Enable"
 msgstr "Etkinleştir"
 
-#: src/muuli_wdr.cpp:1649
+#: src/muuli_wdr.cpp:1653
 msgid "Advanced I.C.H. trusts every hash (not recommended)"
 msgstr "Gelişmiş I.C.H. her adreslemeye güvensin. ( önerilmez )"
 
-#: src/muuli_wdr.cpp:1661 src/PrefsUnifiedDlg.cpp:1910
+#: src/muuli_wdr.cpp:1665 src/PrefsUnifiedDlg.cpp:1990
 msgid "Media metadata extraction"
 msgstr "Ortam üst verisi çıkarımı"
 
-#: src/muuli_wdr.cpp:1665
+#: src/muuli_wdr.cpp:1669
 msgid "Extract length / bitrate / codec from shared audio and video files"
 msgstr "Süre / bit hızı / kodlama bilgilerini paylaşılan ses ve video dosyalarından çıkar"
 
-#: src/muuli_wdr.cpp:1667
+#: src/muuli_wdr.cpp:1671
 msgid "When enabled, aMule runs ffprobe on each shared media file to fill in the Length / Bitrate / Codec columns other clients see when they find the file in a search. Requires ffmpeg (the ffprobe binary) to be installed."
 msgstr "Etkinleştirildiğinde, dosyayı bir aramada bulan diğer istemcilerin gördükleri Süre / Bit Akışı / Kodlama sütunlarını doldurmak için aMule her paylaşılan ortam dosyası üzerinde ffprobe çalıştırır. ffmpeg (ffprobe ikilisi) kurulumu gerektirir."
 
-#: src/muuli_wdr.cpp:1674
+#: src/muuli_wdr.cpp:1678
 msgid "Path to ffprobe:"
 msgstr "ffprobe yolu:"
 
-#: src/muuli_wdr.cpp:1679
+#: src/muuli_wdr.cpp:1683
 msgid "Full path to the ffprobe binary. Leave empty to have aMule auto-detect it on startup."
 msgstr "ffprobe ikilisi için tam yol. aMule tarafından başlangıçta otomatik olarak tespit edilmesi için boş bırakın."
 
-#: src/muuli_wdr.cpp:1687
+#: src/muuli_wdr.cpp:1691
 msgid "Detect"
 msgstr "Tespit et"
 
-#: src/muuli_wdr.cpp:1688
+#: src/muuli_wdr.cpp:1692
 msgid "Search the standard install locations for an ffprobe binary and fill the path field."
 msgstr "Bir ffprobe ikilisi için standart kurulum konumlarını ara ve yol alanını doldur."
 
-#: src/muuli_wdr.cpp:1712
+#: src/muuli_wdr.cpp:1716
 msgid ""
 "Completed downloads are stored here. All files in this folder are automatically shared with other peers.\n"
 "If this folder also holds files you don't want to share, point it at an aMule-only sub-folder."
@@ -4155,665 +4160,688 @@ msgstr ""
 "Tamamlanmış indirmeler burada muhafaza edilir. Bu dizindeki tüm dosyalar otomatik olarak diğer eşler ile paylaşılır.\n"
 "Şayet bu dizin paylaşmak istemediğiniz dosyalar da içeriyorsa, aMule'e özel bir alt dizini seçin."
 
-#: src/muuli_wdr.cpp:1715
+#: src/muuli_wdr.cpp:1719
 msgid "Pick the folder where completed downloads will be stored. All files in that folder will be shared with other peers."
 msgstr "Tamamlanmış indirmelerin muhafaza edilecekleri dizini seçin. Bu dizindeki tüm dosyalar diğer eşler ile paylaşılacaktır."
 
-#: src/muuli_wdr.cpp:1729
+#: src/muuli_wdr.cpp:1733
 msgid "Shared folders"
 msgstr "Paylaşılan dizinler"
 
-#: src/muuli_wdr.cpp:1735
+#: src/muuli_wdr.cpp:1739
 msgid "(Folders shared by the core. Enter a path to add one.)"
 msgstr "(Çekirdek tarafından paylaşılan dizinler. Bir dizin eklemek için yol ilave edin.)"
 
-#: src/muuli_wdr.cpp:1743
+#: src/muuli_wdr.cpp:1747
 msgid "Absolute path of a folder on the core's machine, e.g. /home/user/shared"
 msgstr "Çekirdeğin makinesinde bir dizinin mutlak yolu, mesela /home/rumuz/shared"
 
-#: src/muuli_wdr.cpp:1745 src/PrefsUnifiedDlg.cpp:2794
+#: src/muuli_wdr.cpp:1749 src/PrefsUnifiedDlg.cpp:2874
 msgid "Recursive"
 msgstr "Özyinelemeli"
 
-#: src/muuli_wdr.cpp:1746
+#: src/muuli_wdr.cpp:1750
 msgid "Share every sub-folder underneath this one, including ones created later."
 msgstr "Bunun altındaki tüm alt dizinleri paylaş, ki buna daha sonra oluşturulacak dizinler de dahildir."
 
-#: src/muuli_wdr.cpp:1750 src/utils/aLinkCreator/src/alcframe.cpp:141
+#: src/muuli_wdr.cpp:1754 src/utils/aLinkCreator/src/alcframe.cpp:141
 msgid "Remove"
 msgstr "Çıkar"
 
-#: src/muuli_wdr.cpp:1754
+#: src/muuli_wdr.cpp:1758
 msgid "(Right click on folder icon for recursive share)"
 msgstr "(Özyinelemeli paylaşım için dizin simgesine sağ tıklayınız.)"
 
-#: src/muuli_wdr.cpp:1761
+#: src/muuli_wdr.cpp:1765
 msgid "Share hidden files"
 msgstr "Gizli dosyaları paylaş"
 
-#: src/muuli_wdr.cpp:1767
+#: src/muuli_wdr.cpp:1771
 msgid "Automatically rescan shared folders for changes"
 msgstr "Paylaşılan dizinleri değişiklikler için otomatik olarak tekrar tara"
 
-#: src/muuli_wdr.cpp:1773
+#: src/muuli_wdr.cpp:1777
 msgid "Follow symbolic links in shared folders"
 msgstr "Paylaşılan dizinlerdeki simgesel bağlantıları takip et"
 
-#: src/muuli_wdr.cpp:1779
+#: src/muuli_wdr.cpp:1783
 msgid "Exclude files matching:"
 msgstr "Şununla eşleşen dosyaları dışla:"
 
-#: src/muuli_wdr.cpp:1782
+#: src/muuli_wdr.cpp:1786
 msgid "Wildcard patterns separated by '|', e.g. .DS_Store|Thumbs.db|*.tmp. Files whose name matches are not shared. Matching is case-insensitive."
 msgstr "'|' ile ayrılmış joker karakterli örüntüler (mesela .DS_Store|Thumbs.db|*.tmp). İsmi eşleşen dosyalar paylaşılmaz. Eşleştirme sırasında büyük/küçük harf ayrımı yapılmaz."
 
-#: src/muuli_wdr.cpp:1786
+#: src/muuli_wdr.cpp:1790
 msgid "Patterns are regular expressions"
 msgstr "Örüntüler düzenli ifadelerdir"
 
-#: src/muuli_wdr.cpp:1787
+#: src/muuli_wdr.cpp:1791
 msgid "When set, the whole field is one regular expression ('|' is alternation). When unset, it is a list of '|'-separated wildcards."
 msgstr "Etkinleştirildiğinde, tüm alan tek bir düzenli ifadedir ('|' alternatifler içindir). Devre dışı bırakıldığında, '|' ile ayrılmış jokerler listesidir."
 
-#: src/muuli_wdr.cpp:1797
+#: src/muuli_wdr.cpp:1801
 msgid "Show how many shared files the current pattern would exclude."
 msgstr "Güncel örüntünün kaç paylaşılan dosyayı dışlayacağını göster."
 
-#: src/muuli_wdr.cpp:1818
+#: src/muuli_wdr.cpp:1822
 msgid "Graphs"
 msgstr "Grafikler"
 
-#: src/muuli_wdr.cpp:1821 src/muuli_wdr.cpp:1883
+#: src/muuli_wdr.cpp:1825 src/muuli_wdr.cpp:1887
 msgid "Update delay : 5 secs"
 msgstr "Güncelleme gecikmesi: 5 sn"
 
-#: src/muuli_wdr.cpp:1825
+#: src/muuli_wdr.cpp:1829
 msgid "Time for average graph: 100 mins"
 msgstr "Ortalama grafiği için süre: 100 dk"
 
-#: src/muuli_wdr.cpp:1829
+#: src/muuli_wdr.cpp:1833
 msgid "Connections Graph Scale: 100 "
 msgstr "Bağlantı Grafik Ölçüsü: 100 "
 
-#: src/muuli_wdr.cpp:1836
+#: src/muuli_wdr.cpp:1840
 msgid "Download graph scale:"
 msgstr "İndirme grafik ölçüsü:"
 
-#: src/muuli_wdr.cpp:1844
+#: src/muuli_wdr.cpp:1848
 msgid "Upload graph scale:"
 msgstr "Gönderme grafik ölçüsü:"
 
-#: src/muuli_wdr.cpp:1854
+#: src/muuli_wdr.cpp:1858
 msgid "Colors: "
 msgstr "Renkler: "
 
-#: src/muuli_wdr.cpp:1858
+#: src/muuli_wdr.cpp:1862
 msgid "Background"
 msgstr "Arka plan"
 
-#: src/muuli_wdr.cpp:1859
+#: src/muuli_wdr.cpp:1863
 msgid "Grid"
 msgstr "Izgara"
 
-#: src/muuli_wdr.cpp:1860
+#: src/muuli_wdr.cpp:1864
 msgid "Download current"
 msgstr "Şu anki aktarımlar"
 
-#: src/muuli_wdr.cpp:1861
+#: src/muuli_wdr.cpp:1865
 msgid "Download running average"
 msgstr "Aktarım çalışma ortalaması"
 
-#: src/muuli_wdr.cpp:1862
+#: src/muuli_wdr.cpp:1866
 msgid "Download session average"
 msgstr "Aktarım oturum ortalaması"
 
-#: src/muuli_wdr.cpp:1863
+#: src/muuli_wdr.cpp:1867
 msgid "Upload current"
 msgstr "Şu anki gönderme"
 
-#: src/muuli_wdr.cpp:1864
+#: src/muuli_wdr.cpp:1868
 msgid "Upload running average"
 msgstr "Gönderme çalışma Ortalaması"
 
-#: src/muuli_wdr.cpp:1865
+#: src/muuli_wdr.cpp:1869
 msgid "Upload session average"
 msgstr "Gönderme oturum ortalaması"
 
-#: src/muuli_wdr.cpp:1866
+#: src/muuli_wdr.cpp:1870
 msgid "Active connections"
 msgstr "Aktif bağlantılar"
 
-#: src/muuli_wdr.cpp:1869
+#: src/muuli_wdr.cpp:1873
 msgid "Systray Icon Speed Bar"
 msgstr "Sistem Tepsisi İkonu Hız Göstergesi"
 
-#: src/muuli_wdr.cpp:1870
+#: src/muuli_wdr.cpp:1874
 msgid "Kad-nodes current"
 msgstr "Şu anki Kad düğümleri"
 
-#: src/muuli_wdr.cpp:1871
+#: src/muuli_wdr.cpp:1875
 msgid "Kad-nodes running"
 msgstr "İşlemdeki Kad-düğümleri"
 
-#: src/muuli_wdr.cpp:1872
+#: src/muuli_wdr.cpp:1876
 msgid "Kad-nodes session"
 msgstr "Oturumdaki Kad-düğümleri"
 
-#: src/muuli_wdr.cpp:1876 src/muuli_wdr.cpp:2303
+#: src/muuli_wdr.cpp:1880 src/muuli_wdr.cpp:2334
 msgid "Select"
 msgstr "Seçiniz"
 
-#: src/muuli_wdr.cpp:1880
+#: src/muuli_wdr.cpp:1884
 msgid "Tree"
 msgstr "Ağaç"
 
-#: src/muuli_wdr.cpp:1890
+#: src/muuli_wdr.cpp:1894
 msgid "Number of Client Versions shown (0=unlimited)"
 msgstr "Gösterilen Yazılım Sürümü Sayısı (0=sınırsız)"
 
-#: src/muuli_wdr.cpp:1915
+#: src/muuli_wdr.cpp:1919
 msgid "!!! WARNING !!!"
 msgstr "!!! UYARI !!!"
 
-#: src/muuli_wdr.cpp:1930
+#: src/muuli_wdr.cpp:1934
 msgid "Max new connections / 5 secs"
 msgstr "En fazla yeni bağlantı / 5 sn"
 
-#: src/muuli_wdr.cpp:1932
+#: src/muuli_wdr.cpp:1936
 msgid "Concurrent Kad source lookups"
 msgstr "Eşzamanlı Kad kaynak aramaları"
 
-#: src/muuli_wdr.cpp:1934
+#: src/muuli_wdr.cpp:1938
 msgid "Kad source re-search interval (minutes)"
 msgstr "Kad kaynak tekrar arama zaman aralığı (dakika)"
 
-#: src/muuli_wdr.cpp:1936
+#: src/muuli_wdr.cpp:1940
 msgid "Source re-ask interval (minutes)"
 msgstr "Kaynaklara tekrar sorma zaman aralığı (dakika)"
 
-#: src/muuli_wdr.cpp:1940
+#: src/muuli_wdr.cpp:1944
 msgid "File Buffer Size: 240000 bytes"
 msgstr "Dosya Tampon Boyutu: 240000 bayt"
 
-#: src/muuli_wdr.cpp:1944
+#: src/muuli_wdr.cpp:1948
 msgid "Use MMAP: memory-mapped file access (lower memory use)"
 msgstr "MMAP kullan: \"memory-mapped file access\" yani bellek eşlemeli dosya erişimi (daha az bellek kullanır)"
 
-#: src/muuli_wdr.cpp:1945
+#: src/muuli_wdr.cpp:1949
 msgid "Maps part files into memory instead of buffering them on the heap, lowering the process memory footprint. May reduce download speed on some disks; best for memory-constrained or upload-heavy hosts."
 msgstr "Yığın üzerinde tampona almak yerine kısmi dosyaları bellekte eşleştirir, böylece sürecin bellek ayak izini azaltır. Bazı disklerde indirme hızını düşürebilir; belleği sınırlı veya çok fazla gönderide bulunan makineler için idealdir."
 
-#: src/muuli_wdr.cpp:1947
+#: src/muuli_wdr.cpp:1951
 msgid "Upload Queue Size: 5000 clients"
 msgstr "Gönderme Sıra Boyutu: 5000 kullanıcı"
 
-#: src/muuli_wdr.cpp:1951
+#: src/muuli_wdr.cpp:1955
 msgid "Server connection refresh interval: Disable"
 msgstr "Sunucu bağlantısı yenileme sıklığı: devre dışı"
 
-#: src/muuli_wdr.cpp:1955
+#: src/muuli_wdr.cpp:1959
 msgid "Disable computer's timed standby mode"
 msgstr "Bilgisayarın devre dışı kalma kipini etkisiz hale getir"
 
-#: src/muuli_wdr.cpp:1974
+#: src/muuli_wdr.cpp:1978
 msgid "Skin to use: "
 msgstr "Kullanılacak kaplama: "
 
-#: src/muuli_wdr.cpp:1983
+#: src/muuli_wdr.cpp:1987
 msgid "Show \"Fast eD2k Links Handler\" in every window."
 msgstr "\"Hızlı eD2k Bağlantı Yakalayıcısı\"nı her pencerede göster.."
 
-#: src/muuli_wdr.cpp:1986
+#: src/muuli_wdr.cpp:1990
 msgid "Show extended info on categories tabs"
 msgstr "Sınıf sekmelerinde genişletilmiş bilgi göster."
 
-#: src/muuli_wdr.cpp:1989
+#: src/muuli_wdr.cpp:1993
 msgid "Show application version on title"
 msgstr "Başlık çubuğunda uygulama sürümünü göster"
 
-#: src/muuli_wdr.cpp:1991
+#: src/muuli_wdr.cpp:1995
 msgid "Show transfer rates on title"
 msgstr "Başlık çubuğunda aktarım oranlarını göster."
 
-#: src/muuli_wdr.cpp:1993
+#: src/muuli_wdr.cpp:1997
 msgid "Before application name"
 msgstr "Uygulama adından önce"
 
-#: src/muuli_wdr.cpp:1995
+#: src/muuli_wdr.cpp:1999
 msgid "After application name"
 msgstr "Uygulama adından sonra"
 
-#: src/muuli_wdr.cpp:1998
+#: src/muuli_wdr.cpp:2002
 msgid "Show overhead bandwidth"
 msgstr "Ek yük ağ genişliğini göster"
 
-#: src/muuli_wdr.cpp:2002
+#: src/muuli_wdr.cpp:2006
 msgid "Vertical toolbar orientation"
 msgstr "Dikey araç çubuğu yerleşimi"
 
-#: src/muuli_wdr.cpp:2004
+#: src/muuli_wdr.cpp:2008
 msgid "Live column sorting (auto-reorder rows as their values change)"
 msgstr "Naklen sütun düzenleme (değerleri değiştikçe satırları otomatik olarak tekrar sırala)"
 
-#: src/muuli_wdr.cpp:2011
+#: src/muuli_wdr.cpp:2015
 msgid "Download Queue Files"
 msgstr "Sıradaki Dosyaları İndir"
 
-#: src/muuli_wdr.cpp:2014
+#: src/muuli_wdr.cpp:2018
 msgid "Show progress percentage"
 msgstr "İşlem yüzdesini göster"
 
-#: src/muuli_wdr.cpp:2020
+#: src/muuli_wdr.cpp:2024
 msgid "Show progress bar"
 msgstr "İşlem çubuğunu göster"
 
-#: src/muuli_wdr.cpp:2023
+#: src/muuli_wdr.cpp:2027
 msgid "Flat"
 msgstr "Düz"
 
-#: src/muuli_wdr.cpp:2027
+#: src/muuli_wdr.cpp:2031
 msgid "Round"
 msgstr "Yuvarlatılmış"
 
-#: src/muuli_wdr.cpp:2045
+#: src/muuli_wdr.cpp:2049
 msgid "External Connection Parameters"
 msgstr "Dışarıdan Bağlantı Parametreleri"
 
-#: src/muuli_wdr.cpp:2048
+#: src/muuli_wdr.cpp:2052
 msgid "Accept external connections"
 msgstr "Dışarıdan bağlantıları kabul et."
 
-#: src/muuli_wdr.cpp:2055 src/muuli_wdr.cpp:2114
+#: src/muuli_wdr.cpp:2059 src/muuli_wdr.cpp:2118
 msgid "IP of the listening interface:"
 msgstr "Dinlenen arayüzün IP' si:"
 
-#: src/muuli_wdr.cpp:2058
+#: src/muuli_wdr.cpp:2062
 msgid "Enter here a valid ip in the a.b.c.d format for the listening EC interface. An empty field or 0.0.0.0 will mean any interface."
 msgstr "Dinleme EC arayüzü için a.b.c.d biçiminde geçerli bir ip giriniz. Boş bırakılan alan veya 0.0.0.0 arayüz yok demektir."
 
-#: src/muuli_wdr.cpp:2079 src/muuli_wdr.cpp:2163
+#: src/muuli_wdr.cpp:2083 src/muuli_wdr.cpp:2194
 msgid "TCP port:"
 msgstr "TCP portu:"
 
-#: src/muuli_wdr.cpp:2085
+#: src/muuli_wdr.cpp:2089
 msgid "Enable UPnP port forwarding on the EC port"
 msgstr "EC portuna UPnP port yönlendirmesi etkin."
 
-#: src/muuli_wdr.cpp:2089 src/muuli_wdr.cpp:3048
+#: src/muuli_wdr.cpp:2093 src/muuli_wdr.cpp:3079
 #: src/utils/wxCas/src/wxcasprefs.cpp:167
 msgid "Password"
 msgstr "Şifre"
 
-#: src/muuli_wdr.cpp:2095
+#: src/muuli_wdr.cpp:2099
 msgid "aMule API server parameters"
 msgstr "aMule API sunucusu parametreleri"
 
-#: src/muuli_wdr.cpp:2098
+#: src/muuli_wdr.cpp:2102
 msgid "Run amuleapi (REST API) on startup"
 msgstr "Başlangıçta amuleapi (REST API) çalıştır"
 
-#: src/muuli_wdr.cpp:2103
+#: src/muuli_wdr.cpp:2107
 msgid "HTTP port:"
 msgstr "HTTP bağlantı noktası:"
 
-#: src/muuli_wdr.cpp:2117
+#: src/muuli_wdr.cpp:2121
 msgid "The interface amuleapi's HTTP server listens on. 127.0.0.1 (default) accepts only local connections; use 0.0.0.0 or a specific IP to expose it to other hosts (set an admin password below)."
 msgstr "amuleapi HTTP sunucusunun dinlediği arayüz. 127.0.0.1 (varsayılan) sadece yerel bağlantıları kabul eder; onu başka makinelere açmak için 0.0.0.0 veya belirli bir IP kullanın (aşağıda bir yönetici parolası tanımlayın)."
 
-#: src/muuli_wdr.cpp:2120
+#: src/muuli_wdr.cpp:2126
+msgid "Type a password to set or change it. Stored passwords cannot be shown, so leaving this empty keeps the current one."
+msgstr ""
+
+#: src/muuli_wdr.cpp:2128
 msgid "Admin password"
 msgstr "Yönetici parolası"
 
-#: src/muuli_wdr.cpp:2125 src/muuli_wdr.cpp:2156
-msgid "Low rights password"
-msgstr "Düşük hak şifresi"
+#: src/muuli_wdr.cpp:2140 src/muuli_wdr.cpp:2157 src/PrefsUnifiedDlg.cpp:1103
+#, fuzzy
+msgid "A password is set."
+msgstr "Yönetici parolası"
 
-#: src/muuli_wdr.cpp:2133
+#: src/muuli_wdr.cpp:2144
+#, fuzzy
+msgid "Enable guest access"
+msgstr "Konuk girişini reddet"
+
+#: src/muuli_wdr.cpp:2145
+msgid "Guest sessions may read status and listings but cannot change anything. Turning this off clears the stored guest password."
+msgstr ""
+
+#: src/muuli_wdr.cpp:2149
+#, fuzzy
+msgid "Guest password"
+msgstr "Web sunucusu için konuk parolası"
+
+#: src/muuli_wdr.cpp:2164
 msgid "Web server parameters"
 msgstr "Web sunucusu değerleri"
 
-#: src/muuli_wdr.cpp:2136
+#: src/muuli_wdr.cpp:2167
 msgid "Run webserver on startup (deprecated)"
 msgstr "Başlangıçta web sunucusunu başlat (eskimiş)"
 
-#: src/muuli_wdr.cpp:2142
+#: src/muuli_wdr.cpp:2173
 msgid "Web template"
 msgstr "Web şablonu"
 
-#: src/muuli_wdr.cpp:2147
+#: src/muuli_wdr.cpp:2178
 msgid "Full rights password"
 msgstr "Tam hak şifresi"
 
-#: src/muuli_wdr.cpp:2151
+#: src/muuli_wdr.cpp:2182
 msgid "Enable Low rights User"
 msgstr "Düşük hakka sahip kullanıcıyı etkin kıl."
 
-#: src/muuli_wdr.cpp:2170
+#: src/muuli_wdr.cpp:2187
+msgid "Low rights password"
+msgstr "Düşük hak şifresi"
+
+#: src/muuli_wdr.cpp:2201
 msgid "Enable UPnP port forwarding of the web server port"
 msgstr "Web sunucu portunun UPnp port iletimini etkinleştir"
 
-#: src/muuli_wdr.cpp:2175
+#: src/muuli_wdr.cpp:2206
 msgid "Web server UPnP TCP port (Optional)"
 msgstr "Web sunucusu UPnp TCP portu (İsteğe bağlı)"
 
-#: src/muuli_wdr.cpp:2183
+#: src/muuli_wdr.cpp:2214
 msgid "Page Refresh Time (in secs)"
 msgstr "Sayfa yenileme zamanı (sn)"
 
-#: src/muuli_wdr.cpp:2190
+#: src/muuli_wdr.cpp:2221
 msgid "Enable Gzip compression"
 msgstr "Gzip sıkıştırmayı etkinleştir."
 
-#: src/muuli_wdr.cpp:2224
+#: src/muuli_wdr.cpp:2255
 msgid "Reset page to defaults"
 msgstr "Sayfayı varsayılan değerlere sıfırla"
 
-#: src/muuli_wdr.cpp:2225
+#: src/muuli_wdr.cpp:2256
 msgid "Reset the settings on the current page to their default values."
 msgstr "Güncel sayfadaki ayarları varsayılan değerlerine sıfırla."
 
-#: src/muuli_wdr.cpp:2227 src/muuli_wdr.cpp:2313 src/ServerWnd.cpp:274
+#: src/muuli_wdr.cpp:2258 src/muuli_wdr.cpp:2344 src/ServerWnd.cpp:274
 #: src/ServerWnd.cpp:282
 msgid "OK"
 msgstr "Tamam"
 
-#: src/muuli_wdr.cpp:2229
+#: src/muuli_wdr.cpp:2260
 msgid "Click here to apply any changes made to the preferences."
 msgstr "Ayarlarda yapılan değişikliklerin uygulanması için buraya tıklayınız."
 
-#: src/muuli_wdr.cpp:2232
+#: src/muuli_wdr.cpp:2263
 msgid "Reset any changes made to the preferences."
 msgstr "Ayarlarda yapılan değişiklikleri sil."
 
-#: src/muuli_wdr.cpp:2261
+#: src/muuli_wdr.cpp:2292
 msgid "Comment :"
 msgstr "Yorum:"
 
-#: src/muuli_wdr.cpp:2268
+#: src/muuli_wdr.cpp:2299
 msgid "Incoming Dir :"
 msgstr "Gelen Dosyalar Dizini :"
 
-#: src/muuli_wdr.cpp:2277
+#: src/muuli_wdr.cpp:2308
 msgid "Change priority for new assigned files :"
 msgstr "Yeni eklenen dosyalar için öncelikleri değiştir:"
 
-#: src/muuli_wdr.cpp:2281
+#: src/muuli_wdr.cpp:2312
 msgid "Don't change"
 msgstr "Değiştirme"
 
-#: src/muuli_wdr.cpp:2293
+#: src/muuli_wdr.cpp:2324
 msgid "Select color for this Category (currently selected) :"
 msgstr "Bu sınıf için renk seçiniz (varsayılan) :"
 
-#: src/muuli_wdr.cpp:2360 src/muuli_wdr.cpp:2379 src/muuli_wdr.cpp:2401
+#: src/muuli_wdr.cpp:2391 src/muuli_wdr.cpp:2410 src/muuli_wdr.cpp:2432
 msgid "Click this button to reset the log."
 msgstr "Günlük kayıtlarını silmek için bu düğmeye basınız."
 
-#: src/muuli_wdr.cpp:2420
+#: src/muuli_wdr.cpp:2451
 msgid "Click on this button to update the servers list from URL ..."
 msgstr "Sunucu listesini İnternet'den güncellemek için bu düğmeye basınız…"
 
-#: src/muuli_wdr.cpp:2424
+#: src/muuli_wdr.cpp:2455
 msgid "Server list"
 msgstr "Sunucu"
 
-#: src/muuli_wdr.cpp:2428
+#: src/muuli_wdr.cpp:2459
 msgid "Enter the url to a server.met file here and press the button to the left to update the list of known servers."
 msgstr "Adresi server.met dosyasına buradan giriniz. Sonra, bilinen sunucuları güncellemek için soldaki düğmeye tıklayınız."
 
-#: src/muuli_wdr.cpp:2433
+#: src/muuli_wdr.cpp:2464
 msgid "Add server manually: Name"
 msgstr "Sunucuyu elle ekle: İsim"
 
-#: src/muuli_wdr.cpp:2436
+#: src/muuli_wdr.cpp:2467
 msgid "Enter the name of the new server here"
 msgstr "Yeni sunucunun adını buraya giriniz."
 
-#: src/muuli_wdr.cpp:2438 src/ServerWnd.cpp:206
+#: src/muuli_wdr.cpp:2469 src/ServerWnd.cpp:206
 msgid "IP:Port"
 msgstr "IP:Port"
 
-#: src/muuli_wdr.cpp:2441
+#: src/muuli_wdr.cpp:2472
 msgid "Enter the IP of the server here, using the x.x.x.x format."
 msgstr "Yeni sunucun IP numarasını x.x.x.x biçiminde buraya giriniz."
 
-#: src/muuli_wdr.cpp:2447
+#: src/muuli_wdr.cpp:2478
 msgid "Enter the port of the server here."
 msgstr "Sunucunu portunu buraya giriniz."
 
-#: src/muuli_wdr.cpp:2450
+#: src/muuli_wdr.cpp:2481
 msgid "Add manually a server (fill fields to the left before) ..."
 msgstr "Sunucuyu elle ekle (önce soldaki alanları doldurunuz) …"
 
-#: src/muuli_wdr.cpp:2479
+#: src/muuli_wdr.cpp:2510
 msgid "aMule Log"
 msgstr "aMule Günlüğü"
 
-#: src/muuli_wdr.cpp:2487
+#: src/muuli_wdr.cpp:2518
 msgid "Server Info"
 msgstr "Sunucu Bilgisi"
 
-#: src/muuli_wdr.cpp:2491
+#: src/muuli_wdr.cpp:2522
 msgid "ED2K Info"
 msgstr "ED2K Bilgileri"
 
-#: src/muuli_wdr.cpp:2495
+#: src/muuli_wdr.cpp:2526
 msgid "Kad Info"
 msgstr "Kademlia Bilgileri"
 
-#: src/muuli_wdr.cpp:2523
+#: src/muuli_wdr.cpp:2554
 msgid "Click on this button to update the nodes list from URL ..."
 msgstr "Düğüm listesini İnternet'den güncellemek için bu düğmeye tıklayınız."
 
-#: src/muuli_wdr.cpp:2527
+#: src/muuli_wdr.cpp:2558
 msgid "Nodes (0)"
 msgstr "Düğümler (0)"
 
-#: src/muuli_wdr.cpp:2531
+#: src/muuli_wdr.cpp:2562
 msgid "Enter the url to a nodes.dat file here and press the button to the left to update the list of known nodes."
 msgstr "Bilinen düğümleri güncellemek için buraya adresi giriniz ve soldaki düğmeye tıklayınız."
 
-#: src/muuli_wdr.cpp:2534
+#: src/muuli_wdr.cpp:2565
 msgid "Nodes stats"
 msgstr "Düğüm istatistikleri"
 
-#: src/muuli_wdr.cpp:2576
+#: src/muuli_wdr.cpp:2607
 msgid "Bootstrap"
 msgstr "Ön Yükleme"
 
-#: src/muuli_wdr.cpp:2579
+#: src/muuli_wdr.cpp:2610
 msgid "New node"
 msgstr "Yeni düğüm"
 
-#: src/muuli_wdr.cpp:2584
+#: src/muuli_wdr.cpp:2615
 msgid "IP:"
 msgstr "IP:"
 
-#: src/muuli_wdr.cpp:2604
+#: src/muuli_wdr.cpp:2635
 msgid "Port:"
 msgstr "Port:"
 
-#: src/muuli_wdr.cpp:2617
+#: src/muuli_wdr.cpp:2648
 msgid "Bootstrap from known clients"
 msgstr "Bilinen kullanıcılardan Ön Yükleme"
 
-#: src/muuli_wdr.cpp:2619
+#: src/muuli_wdr.cpp:2650
 msgid "Disconnect Kad"
 msgstr "Kad Bağlantısını Kes"
 
-#: src/muuli_wdr.cpp:2653
+#: src/muuli_wdr.cpp:2684
 msgid "Use Secure User Identification"
 msgstr "Güvenli Kullanıcı Kimlik Doğrulamasını Kullan"
 
-#: src/muuli_wdr.cpp:2655
+#: src/muuli_wdr.cpp:2686
 msgid "It is recommended to enable this option. You will not receive credits if SUI is not enabled."
 msgstr "Bu seçeneği aktifleştirmeniz önerilir. SUI aktif değilse, kredi alamazsınız."
 
-#: src/muuli_wdr.cpp:2657
+#: src/muuli_wdr.cpp:2688
 msgid "Protocol Obfuscation"
 msgstr "Protokol Gizleme"
 
-#: src/muuli_wdr.cpp:2660
+#: src/muuli_wdr.cpp:2691
 msgid "Support Protocol Obfuscation"
 msgstr "Protokol Gizleme etkin"
 
-#: src/muuli_wdr.cpp:2662
+#: src/muuli_wdr.cpp:2693
 msgid "This option enabled Protocol Obfuscation, and makes aMule accept obfuscated connections from other clients."
 msgstr "Bu seçenek Protokol Gizleme'yi etkinleştirir ve aMule'nin gizlenmiş bağlantıları kabul etmesini sağlar."
 
-#: src/muuli_wdr.cpp:2664
+#: src/muuli_wdr.cpp:2695
 msgid "Use obfuscation for outgoing connections"
 msgstr "Giden bağlantılar için gizleme kullan"
 
-#: src/muuli_wdr.cpp:2666
+#: src/muuli_wdr.cpp:2697
 msgid "This option makes aMule use Protocol Obfuscation when connecting other clients/servers."
 msgstr "Bu seçenek diğer kullanıcı veya sunucularla olan bağlantılarda Protokol Gizleme'yi etkinleştirir."
 
-#: src/muuli_wdr.cpp:2668
+#: src/muuli_wdr.cpp:2699
 msgid "Accept only obfuscated connections"
 msgstr "Sadece gizlenmiş bağlantıları kabul et"
 
-#: src/muuli_wdr.cpp:2669
+#: src/muuli_wdr.cpp:2700
 msgid "This option makes aMule only accept obfuscated connections. You will have less sources, but all your traffic will be obfuscated"
 msgstr "Bu seçenek aMule'nin sadece gizlenmiş bağlantıları kabul etmesini sağlar. Daha az kaynak bulursunuz; ancak tüm trafiğiniz de karartılmış olur."
 
-#: src/muuli_wdr.cpp:2674
+#: src/muuli_wdr.cpp:2705
 msgid "Everybody"
 msgstr "Herkes"
 
-#: src/muuli_wdr.cpp:2676
+#: src/muuli_wdr.cpp:2707
 msgid "No one"
 msgstr "Hiç kimse"
 
-#: src/muuli_wdr.cpp:2678
+#: src/muuli_wdr.cpp:2709
 msgid "Who can see my shared files:"
 msgstr "Paylaşılan dosyalarımı kim görebilir:"
 
-#: src/muuli_wdr.cpp:2679
+#: src/muuli_wdr.cpp:2710
 msgid "Select who can request to view a list of your shared files."
 msgstr "Paylaşılan dosyalarınızı kime göstereceğinizi seçiniz."
 
-#: src/muuli_wdr.cpp:2681
+#: src/muuli_wdr.cpp:2712
 msgid "IP-Filtering"
 msgstr "IP_Süzme"
 
-#: src/muuli_wdr.cpp:2688
+#: src/muuli_wdr.cpp:2719
 msgid "Filter clients"
 msgstr "Kullanıcıları Süz"
 
-#: src/muuli_wdr.cpp:2690
+#: src/muuli_wdr.cpp:2721
 msgid "Enable filtering of the client IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "~/.aMule/ipfilter.dat dosyasında tanımlanan kullanıcı IP'lerini süzmeyi etkinleştir."
 
-#: src/muuli_wdr.cpp:2692
+#: src/muuli_wdr.cpp:2723
 msgid "Filter servers"
 msgstr "Sunucuları süz"
 
-#: src/muuli_wdr.cpp:2694
+#: src/muuli_wdr.cpp:2725
 msgid "Enable filtering of the server IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "~/.aMule/ipfilter.dat dosyasında tanımlanan sunucu IP'lerini süzmeyi etkinleştir."
 
-#: src/muuli_wdr.cpp:2698
+#: src/muuli_wdr.cpp:2729
 msgid "Reload List"
 msgstr "Listeyi yeniden yükle"
 
-#: src/muuli_wdr.cpp:2699
+#: src/muuli_wdr.cpp:2730
 msgid "Reload the list of IPs to filter from the file ~/.aMule/ipfilter.dat"
 msgstr "~/.aMule/ipfilter.dat dosyasından IP'leri süzgece yeniden yükle."
 
-#: src/muuli_wdr.cpp:2705
+#: src/muuli_wdr.cpp:2736
 msgid "URL:"
 msgstr "Adres:"
 
-#: src/muuli_wdr.cpp:2709 src/muuli_wdr.cpp:2902
+#: src/muuli_wdr.cpp:2740 src/muuli_wdr.cpp:2933
 msgid "Update now"
 msgstr "Şimdi güncelle"
 
-#: src/muuli_wdr.cpp:2712
+#: src/muuli_wdr.cpp:2743
 msgid "Auto-update ipfilter at startup"
 msgstr "Ip süzgecini başlangıçta otomatikman güncelle."
 
-#: src/muuli_wdr.cpp:2716
+#: src/muuli_wdr.cpp:2747
 msgid "Filtering Level:"
 msgstr "Süzme Seviyesi:"
 
-#: src/muuli_wdr.cpp:2722
+#: src/muuli_wdr.cpp:2753
 msgid "Always filter LAN IPs"
 msgstr "Her zaman LAN IP'lerini süz."
 
-#: src/muuli_wdr.cpp:2725
+#: src/muuli_wdr.cpp:2756
 msgid "Paranoid handling of non-matching IPs"
 msgstr "Uyuşmayan IP'lere şüpheci yaklaşım."
 
-#: src/muuli_wdr.cpp:2727
+#: src/muuli_wdr.cpp:2758
 msgid "Rejects a packet when its source IP differs from the IP the client claims (an anti-spoofing check). Disable only if it causes connection problems."
 msgstr "İstemcinin sahip olduğunu iddia ettiği IP, kaynak IP'den farklı olduğunda paketi reddeder (sahtekarlık önleyici kontrol). Sadece bağlantı sorunları oluşturuyorsa devre dışı bırakın."
 
-#: src/muuli_wdr.cpp:2729
+#: src/muuli_wdr.cpp:2760
 msgid "Use system-wide ipfilter.dat if available"
 msgstr "Varsa, sistem geneli ipfilter.dat kullan"
 
-#: src/muuli_wdr.cpp:2730
+#: src/muuli_wdr.cpp:2761
 msgid "If there's no local ipfilter.dat found, allow usage of a system-wide ipfilter file."
 msgstr "Yerel bir ipfilter.dat dosyası bulunamazsa, sistem geneli ipfilter kullanımına izin ver."
 
-#: src/muuli_wdr.cpp:2747
+#: src/muuli_wdr.cpp:2778
 msgid "Enable Online-Signature"
 msgstr "Çevrimiçi-İmza' yı Etkinleştir"
 
-#: src/muuli_wdr.cpp:2749
+#: src/muuli_wdr.cpp:2780
 msgid "Enables the writing of the OS file, which can be used by external apps to create signatures and the like."
 msgstr "Diğer uygulamaların imzalar ve benzerlerini oluşturabilmesi için kullanabileceği Çev.İmza dosyasını yazmayı etkinleştirir."
 
-#: src/muuli_wdr.cpp:2753
+#: src/muuli_wdr.cpp:2784
 msgid "Update Frequency (Secs):"
 msgstr "Güncelleme Sıklığı (Sn.):"
 
-#: src/muuli_wdr.cpp:2756
+#: src/muuli_wdr.cpp:2787
 msgid "Change the frequency (in seconds) of Online Signature updates."
 msgstr "Çevrim içi İmza güncellemeleri için (saniye bazında) sıklığı değiştirir."
 
-#: src/muuli_wdr.cpp:2764
+#: src/muuli_wdr.cpp:2795
 msgid "Save online signature file in: "
 msgstr "Çevrim içi imza dosyasını buraya sakla: "
 
-#: src/muuli_wdr.cpp:2770
+#: src/muuli_wdr.cpp:2801
 msgid "Click here to select the directory containing the the Online Signature files."
 msgstr "Çevrim içi İmza dosyalarını içeren dizini seçiniz."
 
-#: src/muuli_wdr.cpp:2803
+#: src/muuli_wdr.cpp:2834
 msgid "Show country flags for clients"
 msgstr "İstemciler için ülke bayraklarını göster"
 
-#: src/muuli_wdr.cpp:2804
+#: src/muuli_wdr.cpp:2835
 msgid "Render the country flag column in the transfers, queue and search views. Requires a valid MMDB GeoIP database (see below)."
 msgstr "Transferler, kuyruklar ve arama görünümlerinde ülkelerin bayrakları sütununu görüntüle. Geçerli bir MMDB GeoIP veri tabanı gerektirir (aşağıya bakınız)."
 
-#: src/muuli_wdr.cpp:2809
+#: src/muuli_wdr.cpp:2840
 msgid "Database"
 msgstr "Veri Tabanı"
 
-#: src/muuli_wdr.cpp:2825
+#: src/muuli_wdr.cpp:2856
 msgid "Source:"
 msgstr "Kaynak:"
 
-#: src/muuli_wdr.cpp:2828
+#: src/muuli_wdr.cpp:2859
 msgid "DB-IP (free, no account)"
 msgstr "DB-IP (ücretsiz, hesap gerektirmez)"
 
-#: src/muuli_wdr.cpp:2829
+#: src/muuli_wdr.cpp:2860
 msgid "MaxMind GeoLite2 (free, account required)"
 msgstr "MaxMind GeoLite2 (ücretsiz, hesap gerektirir)"
 
-#: src/muuli_wdr.cpp:2830
+#: src/muuli_wdr.cpp:2861
 msgid "Custom URL"
 msgstr "Kişiselleştirilmiş URL"
 
-#: src/muuli_wdr.cpp:2833
+#: src/muuli_wdr.cpp:2864
 msgid "Choose which provider supplies the GeoIP MMDB database. DB-IP is the default - no account required. MaxMind requires a free account + license key. Use Custom URL to point at any other MMDB host (e.g. a local mirror)."
 msgstr "Hangi tedarikçinin GeoIP MMDB veri tabanını sağlayacağını seçin. DB-IP varsayılan değerdir - hesap gerektirmez. MaxMind ücretsiz bir hesap + lisans anahtarı gerektirir. Herhangi başka bir MMDB makinesine (mesela yerel bir yansıya) yönlendirme yapmak için kişiselleştirilmiş URL kullanın."
 
-#: src/muuli_wdr.cpp:2850
+#: src/muuli_wdr.cpp:2881
 msgid ""
 "No configuration required.\n"
 "\n"
@@ -4825,11 +4853,11 @@ msgstr ""
 "IP-Ülke verileri DB-IP.com tarafından sağlanmaktadır - https://db-ip.com\n"
 "Lisans: Creative Commons Atıf 4.0 - https://creativecommons.org/licenses/by/4.0/deed.tr"
 
-#: src/muuli_wdr.cpp:2863
+#: src/muuli_wdr.cpp:2894
 msgid "License key:"
 msgstr "Lisans anahtarı:"
 
-#: src/muuli_wdr.cpp:2869
+#: src/muuli_wdr.cpp:2900
 msgid ""
 "Sign up for a free MaxMind account, then generate a License Key:\n"
 "https://www.maxmind.com/en/geolite2/signup\n"
@@ -4845,11 +4873,11 @@ msgstr ""
 "Lisans: MaxMind GeoLite2 Kullanıcı Lisans Anlaşması - https://www.maxmind.com/en/geolite2/eula\n"
 "Atıf ve hesap oluşturulması gerektirir; en az her 30 günde bir güncelleyin."
 
-#: src/muuli_wdr.cpp:2884
+#: src/muuli_wdr.cpp:2915
 msgid "Download URL:"
 msgstr "İndirme Bağlantısı:"
 
-#: src/muuli_wdr.cpp:2890
+#: src/muuli_wdr.cpp:2921
 msgid ""
 "Must point to an .mmdb file or a .gz / .tar.gz containing one.\n"
 "URL may include credentials (https://user:pass@host/...).\n"
@@ -4859,211 +4887,211 @@ msgstr ""
 "Bağlantı kimlik doğrulama bilgileri içerebilir (https://kullanıcı:parola@makine/…)\n"
 "Lisans ve atıf koşulları kaynak URL tarafından belirlenir - bunlardan siz sorumlu olursunuz."
 
-#: src/muuli_wdr.cpp:2903
+#: src/muuli_wdr.cpp:2934
 msgid "Download the GeoIP database from the selected source."
 msgstr "Seçili kaynaktan GeoIP veri tabanını indir."
 
-#: src/muuli_wdr.cpp:2905
+#: src/muuli_wdr.cpp:2936
 msgid "Auto-update on startup"
 msgstr "Başlangıçta otomatik olarak güncelle"
 
-#: src/muuli_wdr.cpp:2906
+#: src/muuli_wdr.cpp:2937
 msgid "Re-download the GeoIP database from the selected source every time aMule starts."
 msgstr "aMule her başladığında, GeoIP veri tabanını seçili kaynaktan tekrar indir."
 
-#: src/muuli_wdr.cpp:2929
+#: src/muuli_wdr.cpp:2960
 msgid "Filter incoming messages (except current chat):"
 msgstr "Gelen iletileri süz (o anki sohbet dışında):"
 
-#: src/muuli_wdr.cpp:2931
+#: src/muuli_wdr.cpp:2962
 msgid "Filter all messages"
 msgstr "Hepsini süz."
 
-#: src/muuli_wdr.cpp:2933
+#: src/muuli_wdr.cpp:2964
 msgid "Filter messages from people not on your friend list"
 msgstr "Arkadaş listesindekiler dışında herkesi süz."
 
-#: src/muuli_wdr.cpp:2935
+#: src/muuli_wdr.cpp:2966
 msgid "Filter messages from unknown clients"
 msgstr "Bilinmeyen yazılımlardan gelenleri süz."
 
-#: src/muuli_wdr.cpp:2937
+#: src/muuli_wdr.cpp:2968
 msgid "Filter messages containing (use ',' as separator):"
 msgstr "Şu içerikteki iletileri süz (ayraç olarak ',' kullanınız.):"
 
-#: src/muuli_wdr.cpp:2940 src/muuli_wdr.cpp:2951
+#: src/muuli_wdr.cpp:2971 src/muuli_wdr.cpp:2982
 msgid "add here the words amule should filter and block messages including it"
 msgstr "buraya ekleyeceğiniz sözcükleri içeren iletiler aMule tarafından engellenir."
 
-#: src/muuli_wdr.cpp:2942
+#: src/muuli_wdr.cpp:2973
 msgid "Show received messages in the log"
 msgstr "Günlükte alınan iletileri göster"
 
-#: src/muuli_wdr.cpp:2945
+#: src/muuli_wdr.cpp:2976
 msgid "Comments"
 msgstr "Yorumlar"
 
-#: src/muuli_wdr.cpp:2948
+#: src/muuli_wdr.cpp:2979
 msgid "Filter comments containing (use ',' as separator):"
 msgstr "Şu içerikteki iletileri süz (ayraç olarak ',' kullanınız.):"
 
-#: src/muuli_wdr.cpp:2973
+#: src/muuli_wdr.cpp:3004
 msgid "Enable Proxy"
 msgstr "Vekil sunucuyu Etkinleştir."
 
-#: src/muuli_wdr.cpp:2974
+#: src/muuli_wdr.cpp:3005
 msgid "Enable/disable proxy support"
 msgstr "Vekil sunucu desteğini etkinleştir/devre dışı bırak"
 
-#: src/muuli_wdr.cpp:2977
+#: src/muuli_wdr.cpp:3008
 msgid "Proxy type:"
 msgstr "Vekil sunucu Türü:"
 
-#: src/muuli_wdr.cpp:2988
+#: src/muuli_wdr.cpp:3019
 msgid "Proxy host:"
 msgstr "Vekil sunucu makine:"
 
-#: src/muuli_wdr.cpp:2991
+#: src/muuli_wdr.cpp:3022
 msgid "The proxy host name"
 msgstr "Vekil sunucu makine adı"
 
-#: src/muuli_wdr.cpp:2993
+#: src/muuli_wdr.cpp:3024
 msgid "Proxy port:"
 msgstr "Vekil sunucu Portu:"
 
-#: src/muuli_wdr.cpp:2996
+#: src/muuli_wdr.cpp:3027
 msgid "The proxy port"
 msgstr "Vekil sunucu portu"
 
-#: src/muuli_wdr.cpp:2998
+#: src/muuli_wdr.cpp:3029
 msgid "Enable authentication"
 msgstr "Yetkilendirmeyi etkinleştir."
 
-#: src/muuli_wdr.cpp:2999
+#: src/muuli_wdr.cpp:3030
 msgid "Enable/disable username/password authentication"
 msgstr "Kullanıcı adı/şifre yetkilendirmeyi etkinleştir/devre dışı bırak."
 
-#: src/muuli_wdr.cpp:3002
+#: src/muuli_wdr.cpp:3033
 msgid "Username: "
 msgstr "Kullanıcı adı: "
 
-#: src/muuli_wdr.cpp:3005
+#: src/muuli_wdr.cpp:3036
 msgid "The username to use to connect to the proxy"
 msgstr "Vekil sunucuya bağlanmak için gerekli kullanıcı adı"
 
-#: src/muuli_wdr.cpp:3007
+#: src/muuli_wdr.cpp:3038
 msgid "Password:"
 msgstr "Şifre:"
 
-#: src/muuli_wdr.cpp:3010
+#: src/muuli_wdr.cpp:3041
 msgid "The password to use to connect to the proxy"
 msgstr "Vekil sunucuya bağlanmak için gerekli şifre"
 
-#: src/muuli_wdr.cpp:3029
+#: src/muuli_wdr.cpp:3060
 msgid "Connect to:"
 msgstr "Bağlan:"
 
-#: src/muuli_wdr.cpp:3038
+#: src/muuli_wdr.cpp:3069
 msgid "Login to remote amule"
 msgstr "Uzaktan aMule'ye giriş yapınız."
 
-#: src/muuli_wdr.cpp:3043
+#: src/muuli_wdr.cpp:3074
 msgid "User name"
 msgstr "Kullanıcı adı"
 
-#: src/muuli_wdr.cpp:3054
+#: src/muuli_wdr.cpp:3085
 msgid "Remember those settings"
 msgstr "Bu ayarları hatırla"
 
-#: src/muuli_wdr.cpp:3057
+#: src/muuli_wdr.cpp:3088
 msgid "Force ZLIB compression"
 msgstr "ZLIB sıkıştırmasını zorla"
 
-#: src/muuli_wdr.cpp:3081
+#: src/muuli_wdr.cpp:3112
 msgid "Enable Verbose Debug-Logging."
 msgstr "Fazladan Hata Çıktısı Kaydını Etkinleştir."
 
-#: src/muuli_wdr.cpp:3083
+#: src/muuli_wdr.cpp:3114
 msgid "Only to Logfile"
 msgstr "Sadece Kütük Dosyasına"
 
-#: src/muuli_wdr.cpp:3085
+#: src/muuli_wdr.cpp:3116
 msgid "Message Categories:"
 msgstr "İleti Sınıfları:"
 
-#: src/muuli_wdr.cpp:3109 src/PartFileConvertDlg.cpp:160
+#: src/muuli_wdr.cpp:3140 src/PartFileConvertDlg.cpp:160
 msgid "Waiting..."
 msgstr "Bekliyor…"
 
-#: src/muuli_wdr.cpp:3129
+#: src/muuli_wdr.cpp:3160
 msgid "Add imports"
 msgstr "İçe aktarımları ekle"
 
-#: src/muuli_wdr.cpp:3132
+#: src/muuli_wdr.cpp:3163
 msgid "Retry selected"
 msgstr "Seçileni tekrar dene"
 
-#: src/muuli_wdr.cpp:3134
+#: src/muuli_wdr.cpp:3165
 msgid "Remove selected"
 msgstr "Seçileni çıkar"
 
-#: src/muuli_wdr.cpp:3197
+#: src/muuli_wdr.cpp:3228
 msgid "Event Types"
 msgstr "Olay Türleri"
 
-#: src/muuli_wdr.cpp:3216
+#: src/muuli_wdr.cpp:3247
 msgid "Statistics and queued clients for selected file(s) : Session / All time"
 msgstr "Seçili dosya(lar) için kuyruktaki istemciler ve istatistikler: Oturum / Bütün zamanlar"
 
-#: src/muuli_wdr.cpp:3240
+#: src/muuli_wdr.cpp:3271
 msgid "Active Uploads"
 msgstr "Etkin Göndermeler"
 
-#: src/muuli_wdr.cpp:3254
+#: src/muuli_wdr.cpp:3285
 msgid "Percent of total files"
 msgstr "Toplam dosyaların yüzdesi"
 
-#: src/muuli_wdr.cpp:3306
+#: src/muuli_wdr.cpp:3337
 msgid "Show Clients for"
 msgstr "Kullanıcıları Göster"
 
-#: src/muuli_wdr.cpp:3308
+#: src/muuli_wdr.cpp:3339
 msgid "All files"
 msgstr "Tüm dosyalar"
 
-#: src/muuli_wdr.cpp:3311
+#: src/muuli_wdr.cpp:3342
 msgid "Selected files"
 msgstr "Seçilen dosyalar"
 
-#: src/muuli_wdr.cpp:3314
+#: src/muuli_wdr.cpp:3345
 msgid "Active uploads only"
 msgstr "Sadece aktif Göndermeler"
 
-#: src/muuli_wdr.cpp:3321
+#: src/muuli_wdr.cpp:3352
 msgid "Reload:"
 msgstr "Yeniden yükle:"
 
-#: src/muuli_wdr.cpp:3325
+#: src/muuli_wdr.cpp:3356
 msgid "Reload your shared files"
 msgstr "Paylaşılan dosyalarınızı yeniden yükleyin"
 
-#: src/muuli_wdr.cpp:3388
+#: src/muuli_wdr.cpp:3419
 msgid "Send"
 msgstr "Gönder"
 
-#: src/muuli_wdr.cpp:3389
+#: src/muuli_wdr.cpp:3420
 msgid "Sends the specified message."
 msgstr "Belirlenen iletiyi gönderir."
 
-#: src/muuli_wdr.cpp:3393
+#: src/muuli_wdr.cpp:3424
 msgid "Close this chat-session."
 msgstr "Bu sohbet oturumunu kapatır."
 
-#: src/muuli_wdr.cpp:3416
+#: src/muuli_wdr.cpp:3447
 msgid "Connect to any server and/or Kad"
 msgstr "Herhangi bir sunucuya ve/veya Kad'a bağlan."
 
-#: src/muuli_wdr.cpp:3422 src/SharedFilesCtrl.cpp:142 src/Statistics.cpp:941
+#: src/muuli_wdr.cpp:3453 src/SharedFilesCtrl.cpp:142 src/Statistics.cpp:941
 msgid "Shared Files"
 msgstr "Paylaşılan Dosyalar"
 
@@ -5423,248 +5451,248 @@ msgstr "İndirildi"
 msgid "ERROR: Failed to open partfile '%s'"
 msgstr "HATA: Parça dosyası '%s' açılamıyor"
 
-#: src/Preferences.cpp:674
+#: src/Preferences.cpp:701
 msgid "System default"
 msgstr "Sistem öntanımlısı"
 
-#: src/Preferences.cpp:675
+#: src/Preferences.cpp:702
 msgid "Albanian"
 msgstr "Arnavutça"
 
-#: src/Preferences.cpp:676
+#: src/Preferences.cpp:703
 msgid "Arabic"
 msgstr "Arapça"
 
-#: src/Preferences.cpp:677
+#: src/Preferences.cpp:704
 msgid "Asturian"
 msgstr "Asturyasça"
 
-#: src/Preferences.cpp:678
+#: src/Preferences.cpp:705
 msgid "Basque"
 msgstr "Baskça"
 
-#: src/Preferences.cpp:679
+#: src/Preferences.cpp:706
 msgid "Bulgarian"
 msgstr "Bulgarca"
 
-#: src/Preferences.cpp:680
+#: src/Preferences.cpp:707
 msgid "Catalan"
 msgstr "Katalanca"
 
-#: src/Preferences.cpp:681
+#: src/Preferences.cpp:708
 msgid "Chinese (Simplified)"
 msgstr "Çince (Basitleştirilmiş)"
 
-#: src/Preferences.cpp:682
+#: src/Preferences.cpp:709
 msgid "Chinese (Traditional)"
 msgstr "Çince (Geleneksel)"
 
-#: src/Preferences.cpp:683
+#: src/Preferences.cpp:710
 msgid "Croatian"
 msgstr "Hırvatça"
 
-#: src/Preferences.cpp:684
+#: src/Preferences.cpp:711
 msgid "Czech"
 msgstr "Çekçe"
 
-#: src/Preferences.cpp:685
+#: src/Preferences.cpp:712
 msgid "Danish"
 msgstr "Danca"
 
-#: src/Preferences.cpp:686
+#: src/Preferences.cpp:713
 msgid "Dutch"
 msgstr "Felemenkçe"
 
-#: src/Preferences.cpp:687
+#: src/Preferences.cpp:714
 msgid "English (U.K.)"
 msgstr "İngilizce (U.K)"
 
-#: src/Preferences.cpp:688
+#: src/Preferences.cpp:715
 msgid "English (U.S.)"
 msgstr "İngilizce (ABD)"
 
-#: src/Preferences.cpp:689
+#: src/Preferences.cpp:716
 msgid "Estonian"
 msgstr "Estonca"
 
-#: src/Preferences.cpp:690
+#: src/Preferences.cpp:717
 msgid "Finnish"
 msgstr "Fince"
 
-#: src/Preferences.cpp:691
+#: src/Preferences.cpp:718
 msgid "French"
 msgstr "Fransızca"
 
-#: src/Preferences.cpp:692
+#: src/Preferences.cpp:719
 msgid "Galician"
 msgstr "Galce"
 
-#: src/Preferences.cpp:693
+#: src/Preferences.cpp:720
 msgid "German"
 msgstr "Almanca"
 
-#: src/Preferences.cpp:694
+#: src/Preferences.cpp:721
 msgid "Greek"
 msgstr "Yunanca"
 
-#: src/Preferences.cpp:695
+#: src/Preferences.cpp:722
 msgid "Hebrew"
 msgstr "İbranice"
 
-#: src/Preferences.cpp:696
+#: src/Preferences.cpp:723
 msgid "Hungarian"
 msgstr "Macarca"
 
-#: src/Preferences.cpp:697
+#: src/Preferences.cpp:724
 msgid "Italian"
 msgstr "İtalyanca"
 
-#: src/Preferences.cpp:698
+#: src/Preferences.cpp:725
 msgid "Japanese"
 msgstr "Japonca"
 
-#: src/Preferences.cpp:699
+#: src/Preferences.cpp:726
 msgid "Korean"
 msgstr "Korece"
 
-#: src/Preferences.cpp:700
+#: src/Preferences.cpp:727
 msgid "Latvian"
 msgstr "Letonca"
 
-#: src/Preferences.cpp:701
+#: src/Preferences.cpp:728
 msgid "Lithuanian"
 msgstr "Litvanyaca"
 
-#: src/Preferences.cpp:702
+#: src/Preferences.cpp:729
 msgid "Norwegian (Nynorsk)"
 msgstr "Norveççe (Nynorsk)"
 
-#: src/Preferences.cpp:703
+#: src/Preferences.cpp:730
 msgid "Polish"
 msgstr "Lehçe"
 
-#: src/Preferences.cpp:704
+#: src/Preferences.cpp:731
 msgid "Portuguese"
 msgstr "Portekizce"
 
-#: src/Preferences.cpp:705
+#: src/Preferences.cpp:732
 msgid "Portuguese (Brazilian)"
 msgstr "Portekizce (Brezilya)"
 
-#: src/Preferences.cpp:706
+#: src/Preferences.cpp:733
 msgid "Romanian"
 msgstr "Rumence"
 
-#: src/Preferences.cpp:707
+#: src/Preferences.cpp:734
 msgid "Russian"
 msgstr "Rusça"
 
-#: src/Preferences.cpp:708
+#: src/Preferences.cpp:735
 msgid "Slovenian"
 msgstr "Slovence"
 
-#: src/Preferences.cpp:709
+#: src/Preferences.cpp:736
 msgid "Spanish"
 msgstr "İspanyolca"
 
-#: src/Preferences.cpp:710
+#: src/Preferences.cpp:737
 msgid "Swedish"
 msgstr "İsveççe"
 
-#: src/Preferences.cpp:711
+#: src/Preferences.cpp:738
 msgid "Turkish"
 msgstr "Türkçe"
 
-#: src/Preferences.cpp:712
+#: src/Preferences.cpp:739
 msgid "Ukrainian"
 msgstr "Ukraynaca"
 
-#: src/Preferences.cpp:815
+#: src/Preferences.cpp:842
 msgid "Change Language"
 msgstr "Dili Değiştirin"
 
-#: src/Preferences.cpp:879
+#: src/Preferences.cpp:906
 msgid "There are no translations installed for aMule"
 msgstr "aMule tercümeleri kurulu değildir"
 
-#: src/Preferences.cpp:880
+#: src/Preferences.cpp:907
 msgid "No languages available"
 msgstr "Diller mevcut değil"
 
-#: src/Preferences.cpp:1011
+#: src/Preferences.cpp:1038
 msgid "no options available"
 msgstr "mevcut seçenek yok"
 
-#: src/Preferences.cpp:2182
+#: src/Preferences.cpp:2227
 msgid "Invalid category found, skipping"
 msgstr "Geçersiz sınıf bulundu, atlanıyor"
 
-#: src/Preferences.cpp:2351
+#: src/Preferences.cpp:2396
 msgid "TCP port can't be higher than 65532 due to server UDP socket being TCP+3"
 msgstr "TCP portu numarası, UDP soketi TCP+3 olduğundan 65532' den yüksek olamaz"
 
-#: src/Preferences.cpp:2352
+#: src/Preferences.cpp:2397
 #, c-format
 msgid "Default port will be used (%d)"
 msgstr "Varsayılan port kullanılacak (%d)"
 
-#: src/PrefsUnifiedDlg.cpp:298 src/Statistics.cpp:866
+#: src/PrefsUnifiedDlg.cpp:300 src/Statistics.cpp:866
 msgid "Connection"
 msgstr "Bağlantı"
 
-#: src/PrefsUnifiedDlg.cpp:299 src/SearchListCtrl.cpp:117
+#: src/PrefsUnifiedDlg.cpp:301 src/SearchListCtrl.cpp:117
 msgid "Directories"
 msgstr "Dizinler"
 
-#: src/PrefsUnifiedDlg.cpp:300 src/Statistics.cpp:917
+#: src/PrefsUnifiedDlg.cpp:302 src/Statistics.cpp:917
 msgid "Servers"
 msgstr "Sunucular"
 
-#: src/PrefsUnifiedDlg.cpp:301 src/ServerListCtrl.cpp:96
+#: src/PrefsUnifiedDlg.cpp:303 src/ServerListCtrl.cpp:96
 msgid "Files"
 msgstr "Dosyalar"
 
-#: src/PrefsUnifiedDlg.cpp:302
+#: src/PrefsUnifiedDlg.cpp:304
 msgid "Security"
 msgstr "Güvenlik"
 
-#: src/PrefsUnifiedDlg.cpp:303
+#: src/PrefsUnifiedDlg.cpp:305
 msgid "Interface"
 msgstr "Arayüz"
 
-#: src/PrefsUnifiedDlg.cpp:310
+#: src/PrefsUnifiedDlg.cpp:312
 msgid "IP2Country"
 msgstr "IP2Country"
 
-#: src/PrefsUnifiedDlg.cpp:313
+#: src/PrefsUnifiedDlg.cpp:315
 msgid "Proxy"
 msgstr "Vekil sunucu"
 
-#: src/PrefsUnifiedDlg.cpp:314
+#: src/PrefsUnifiedDlg.cpp:316
 msgid "Filters"
 msgstr "Süzgeçler"
 
-#: src/PrefsUnifiedDlg.cpp:315
+#: src/PrefsUnifiedDlg.cpp:317
 msgid "Remote Controls"
 msgstr "Uzak Denetimler"
 
-#: src/PrefsUnifiedDlg.cpp:316
+#: src/PrefsUnifiedDlg.cpp:318
 msgid "Online Signature"
 msgstr "Çevrimiçi İmza"
 
-#: src/PrefsUnifiedDlg.cpp:317
+#: src/PrefsUnifiedDlg.cpp:319
 msgid "Advanced"
 msgstr "Gelişmiş"
 
-#: src/PrefsUnifiedDlg.cpp:318
+#: src/PrefsUnifiedDlg.cpp:320
 msgid "Events"
 msgstr "Olaylar"
 
-#: src/PrefsUnifiedDlg.cpp:321
+#: src/PrefsUnifiedDlg.cpp:323
 msgid "Debugging"
 msgstr "Hata Çıktısı"
 
-#: src/PrefsUnifiedDlg.cpp:451
+#: src/PrefsUnifiedDlg.cpp:453
 msgid ""
 "The following variables will be substituted:\n"
 "    %PARTFILE - full path to the file\n"
@@ -5674,15 +5702,15 @@ msgstr ""
 "    %PARTFILE - dosyanın tam yolu\n"
 "    %PARTNAME - dosyanın sadece adı"
 
-#: src/PrefsUnifiedDlg.cpp:472
+#: src/PrefsUnifiedDlg.cpp:474
 msgid "Tray icon support requires libayatana-appindicator3 at compile time."
 msgstr "Sistem tepsisi ikon desteği, derleme esnasında libayatana-appindicator3'e ihtiyaç duyar."
 
-#: src/PrefsUnifiedDlg.cpp:488
+#: src/PrefsUnifiedDlg.cpp:490
 msgid "Not available on Wayland: the protocol does not report when a window is minimized, so this option cannot intercept the system minimize button. Workaround: launch aMule with `GDK_BACKEND=x11` to use XWayland instead."
 msgstr "Wayland ile kullanılamaz: protokol bir pencere küçültüldüğünde bunu iletmez, yani bu seçenek sistemin küçült düğmesi tıklamasını yakalayamaz. Çözüm: yerine XWayland kullanmak için aMule'ü `GDK_BACKEND=x11` ile başlatın."
 
-#: src/PrefsUnifiedDlg.cpp:534
+#: src/PrefsUnifiedDlg.cpp:536
 msgid ""
 "Do not change these setting unless you know\n"
 "what you are doing, otherwise you can easily\n"
@@ -5698,26 +5726,35 @@ msgstr ""
 "Bu ayarlarla oynanmasa da\n"
 "aMule gayet iyi işleyecektir."
 
-#: src/PrefsUnifiedDlg.cpp:645
+#: src/PrefsUnifiedDlg.cpp:647
 #, c-format
 msgid "Failed to connect Cfg to widget with the ID %d and key %s"
 msgstr "Cfg %d Kimliği ve %s anahtarı ile parçacığa bağlanamadı"
 
-#: src/PrefsUnifiedDlg.cpp:693
+#: src/PrefsUnifiedDlg.cpp:695
 #, c-format
 msgid "Failed to transfer data from Cfg to Widget with the ID %d and key %s"
 msgstr "Cfg' den %d Kimliği ve %s anahtarı ile Parçacığa veri aktarılamadı"
 
-#: src/PrefsUnifiedDlg.cpp:799
+#: src/PrefsUnifiedDlg.cpp:801
 msgid "The type of proxy you are connecting to"
 msgstr "Bağlanacağınız vekil sunucu türü"
 
-#: src/PrefsUnifiedDlg.cpp:1003
+#: src/PrefsUnifiedDlg.cpp:1020
 #, c-format
 msgid "Failed to transfer data from Widget to Cfg with the ID %d and key %s"
 msgstr "Parçacıktan %d Kimliği ve %s anahtarı ile Cfg' ye veri aktarılamadı"
 
 #: src/PrefsUnifiedDlg.cpp:1103
+#, fuzzy
+msgid "No password set."
+msgstr "Yönetici parolası"
+
+#: src/PrefsUnifiedDlg.cpp:1132
+msgid "Guest access needs a password. Type one in the guest password field, or untick Enable guest access."
+msgstr ""
+
+#: src/PrefsUnifiedDlg.cpp:1144
 msgid ""
 "aMule must be restarted to enable these changes:\n"
 "\n"
@@ -5725,39 +5762,39 @@ msgstr ""
 "Değişikliklerin uygulanması için, aMule yeniden başlatılmalı\n"
 "\n"
 
-#: src/PrefsUnifiedDlg.cpp:1110
+#: src/PrefsUnifiedDlg.cpp:1151
 msgid "- TCP port changed.\n"
 msgstr "- TCP portu değişti.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1115
+#: src/PrefsUnifiedDlg.cpp:1156
 msgid "- UDP port changed.\n"
 msgstr "- UDP Portu değişti.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1120
+#: src/PrefsUnifiedDlg.cpp:1161
 msgid "- Network interface binding changed.\n"
 msgstr "- Ağ arayüz bağlaması değişti.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1125
+#: src/PrefsUnifiedDlg.cpp:1166
 msgid "- External connect port changed.\n"
 msgstr "- Dışarıdan bağlantı portu değişti.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1129
+#: src/PrefsUnifiedDlg.cpp:1170
 msgid "- External connect acceptance changed.\n"
 msgstr "- Dışarıdan bağlantı kabul edilme işlemi değişti.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1133
+#: src/PrefsUnifiedDlg.cpp:1174
 msgid "- External connect interface changed.\n"
 msgstr "- Dışarıdan bağlantı arayüzü değişti.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1137
+#: src/PrefsUnifiedDlg.cpp:1178
 msgid "- Protocol obfuscation support changed.\n"
 msgstr "- Protokol gizleme desteği değişti.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1151
+#: src/PrefsUnifiedDlg.cpp:1193
 msgid "- amuleapi settings changed.\n"
 msgstr "- amuleapi ayarları değişti.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1160
+#: src/PrefsUnifiedDlg.cpp:1202
 msgid ""
 "Your Auto-update server list is empty.\n"
 "'Auto-update server list at startup' will be disabled."
@@ -5765,7 +5802,7 @@ msgstr ""
 "Otomatik Sunucu güncelleme listeniz boş.\n"
 "'Sunucu listesini başlangıçta otomatikman güncelle' devre dışı bırakılacak."
 
-#: src/PrefsUnifiedDlg.cpp:1171
+#: src/PrefsUnifiedDlg.cpp:1213
 msgid ""
 "You have enabled external connections but have not specified a password.\n"
 "External connections cannot be enabled unless a valid password is specified."
@@ -5773,27 +5810,32 @@ msgstr ""
 "Dışarıdan bağlantıları aktifleştirmiş ama bir şifre belirlememişsiniz.\n"
 "Geçerli bir şifre belirlenmedikçe dışarıdan bağlantılar devre dışı kalacaktır."
 
-#: src/PrefsUnifiedDlg.cpp:1202
+#: src/PrefsUnifiedDlg.cpp:1246
+#, c-format
+msgid "The amuleapi password could not be saved: %s"
+msgstr ""
+
+#: src/PrefsUnifiedDlg.cpp:1276
 msgid "- Language changed.\n"
 msgstr "- Dil ayarları değişti.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1207
+#: src/PrefsUnifiedDlg.cpp:1281
 msgid "- Temp folder changed.\n"
 msgstr "- Geçici Dosyalar dizini değişti.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1212
+#: src/PrefsUnifiedDlg.cpp:1286
 msgid "- ED2K network enabled.\n"
 msgstr "- ED2K ağı etkinleştirildi.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1245
+#: src/PrefsUnifiedDlg.cpp:1319
 msgid "The shared-file exclusion pattern is not a valid regular expression. The filter has been left disabled."
 msgstr "Paylaşılan dosya dışlama örüntüsü geçerli bir düzenli ifade değil. Filtre devre dışı olarak bırakıldı."
 
-#: src/PrefsUnifiedDlg.cpp:1247 src/PrefsUnifiedDlg.cpp:1841
+#: src/PrefsUnifiedDlg.cpp:1321 src/PrefsUnifiedDlg.cpp:1921
 msgid "Invalid regular expression"
 msgstr "Geçersiz düzenli ifade"
 
-#: src/PrefsUnifiedDlg.cpp:1324
+#: src/PrefsUnifiedDlg.cpp:1398
 msgid ""
 "Both eD2k and Kad network are disabled.\n"
 "You won't be able to connect until you enable at least one of them."
@@ -5801,7 +5843,7 @@ msgstr ""
 "Hem eD2k hem de Kad ağları devre dışı bırakılmış.\n"
 "En az birini etkinleştirmeden bağlanamayacaksınız."
 
-#: src/PrefsUnifiedDlg.cpp:1329
+#: src/PrefsUnifiedDlg.cpp:1403
 msgid ""
 "Kad will not start if your UDP port is disabled.\n"
 "Enable UDP port or disable Kad."
@@ -5809,7 +5851,7 @@ msgstr ""
 "UDP portu devre dışı bırakılmışsa Kad başlamayacaktır.\n"
 "UDP portu açın veya Kademlia'yı devre dışı bırakın."
 
-#: src/PrefsUnifiedDlg.cpp:1385
+#: src/PrefsUnifiedDlg.cpp:1459
 msgid ""
 "\n"
 "You MUST restart aMule now.\n"
@@ -5819,68 +5861,68 @@ msgstr ""
 "aMule' yi ŞİMDİ yeniden başlatmalısınız.\n"
 "Şimdi yeniden başlatmazsanız, kötü şeyler olabilir.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1450
+#: src/PrefsUnifiedDlg.cpp:1524
 msgid "Could not register aMule for autostart at login. The autostart store may be read-only."
 msgstr "Oturum açıldığında otomatik başlatma için aMule kaydedilemedi. Otomatik başlatma deposu salt okunur olabilir."
 
-#: src/PrefsUnifiedDlg.cpp:1452
+#: src/PrefsUnifiedDlg.cpp:1526
 msgid "Could not remove the autostart-at-login entry."
 msgstr "Oturum açılışında otomatik başlatma unsuru kaldırılamadı."
 
-#: src/PrefsUnifiedDlg.cpp:1453
+#: src/PrefsUnifiedDlg.cpp:1527
 msgid "Autostart"
 msgstr "Otomatik başlatma"
 
-#: src/PrefsUnifiedDlg.cpp:1468
+#: src/PrefsUnifiedDlg.cpp:1542
 msgid "Register file type"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1468
+#: src/PrefsUnifiedDlg.cpp:1542
 msgid "Register URL handler"
 msgstr "URL yöneticisini kaydet"
 
-#: src/PrefsUnifiedDlg.cpp:1476
+#: src/PrefsUnifiedDlg.cpp:1550
 #, c-format
 msgid "aMule only handles eD2k-compatible magnets. If you replace the current magnet handler (%s), BitTorrent magnet links will stop working - aMule cannot download BitTorrent content. Continue?"
 msgstr "aMule, sadece eD2k uyumlu magnet'leri işler. Şayet güncel magnet yöneticisinin (%s) yerine onu koyarsanız, BitTorrent magnet bağlantıları artık çalışmayacaktır - aMule BitTorrent içeriği indiremez. Devam edilsin mi?"
 
-#: src/PrefsUnifiedDlg.cpp:1481
+#: src/PrefsUnifiedDlg.cpp:1555
 #, fuzzy, c-format
 msgid "Another application currently opens .emulecollection files (%s). Replace it with aMule?"
 msgstr "Başka bir uygulama güncel olarak bu bağlantıların yöneticisidir (%s). Yerine aMule konsun mu?"
 
-#: src/PrefsUnifiedDlg.cpp:1486
+#: src/PrefsUnifiedDlg.cpp:1560
 #, c-format
 msgid "Another application is currently the default handler for these links (%s). Replace it with aMule?"
 msgstr "Başka bir uygulama güncel olarak bu bağlantıların yöneticisidir (%s). Yerine aMule konsun mu?"
 
-#: src/PrefsUnifiedDlg.cpp:1511
+#: src/PrefsUnifiedDlg.cpp:1585
 #, fuzzy
 msgid "Could not register aMule for .emulecollection files. The registration store may be read-only."
 msgstr "aMule, URL yöneticisi olarak kaydedilemedi. Kayıt deposu salt okunur olabilir."
 
-#: src/PrefsUnifiedDlg.cpp:1513
+#: src/PrefsUnifiedDlg.cpp:1587
 #, fuzzy
 msgid "Could not remove the file type registration."
 msgstr "URL yönetim kaydı kaldırılamadı."
 
-#: src/PrefsUnifiedDlg.cpp:1515
+#: src/PrefsUnifiedDlg.cpp:1589
 msgid "Could not register aMule as the URL handler. The registration store may be read-only."
 msgstr "aMule, URL yöneticisi olarak kaydedilemedi. Kayıt deposu salt okunur olabilir."
 
-#: src/PrefsUnifiedDlg.cpp:1517
+#: src/PrefsUnifiedDlg.cpp:1591
 msgid "Could not remove the URL handler registration."
 msgstr "URL yönetim kaydı kaldırılamadı."
 
-#: src/PrefsUnifiedDlg.cpp:1587 src/PrefsUnifiedDlg.cpp:1614
+#: src/PrefsUnifiedDlg.cpp:1661 src/PrefsUnifiedDlg.cpp:1688
 msgid "The web server and aMule API require external connections to be enabled."
 msgstr "Web sunucusu ve aMule API, dış bağlantıların etkinleştirilmiş olmalarına ihtiyaç duyar."
 
-#: src/PrefsUnifiedDlg.cpp:1597
+#: src/PrefsUnifiedDlg.cpp:1671
 msgid "The aMule web server is deprecated. Consider running the aMule API instead."
 msgstr "aMule Web sunucusu eskimiştir. Yerine aMule API çalıştırmayı değerlendirin."
 
-#: src/PrefsUnifiedDlg.cpp:1655
+#: src/PrefsUnifiedDlg.cpp:1735
 msgid ""
 "Your Auto-update servers list is in blank.\n"
 "Please fill in at least one URL to point to a valid server.met file.\n"
@@ -5890,64 +5932,64 @@ msgstr ""
 "Lütfen geçerli bir server.met dosyasını gösteren en az bir adres yazınız.\n"
 "Bir adres girmek için bu kutucuğun yanındaki \"Liste\" düğmesine basınız."
 
-#: src/PrefsUnifiedDlg.cpp:1796
+#: src/PrefsUnifiedDlg.cpp:1876
 msgid "Temporary files"
 msgstr "Geçici dosya(lar)"
 
-#: src/PrefsUnifiedDlg.cpp:1801
+#: src/PrefsUnifiedDlg.cpp:1881
 msgid "Incoming files"
 msgstr "Gelen dosya(lar)"
 
-#: src/PrefsUnifiedDlg.cpp:1806
+#: src/PrefsUnifiedDlg.cpp:1886
 msgid "Online Signatures"
 msgstr "Çevrimiçi İmzalar"
 
-#: src/PrefsUnifiedDlg.cpp:1819
+#: src/PrefsUnifiedDlg.cpp:1899
 #, c-format
 msgid "Choose a folder for %s"
 msgstr "%s için bir dizin seçiniz."
 
-#: src/PrefsUnifiedDlg.cpp:1843
+#: src/PrefsUnifiedDlg.cpp:1923
 #, c-format
 msgid "Would exclude %u of %u shared file"
 msgid_plural "Would exclude %u of %u shared files"
 msgstr[0] "%u dosya, ki %u üzerinde dışlanırdı"
 msgstr[1] "%u dosya, ki %u üzerinde dışlanırdı"
 
-#: src/PrefsUnifiedDlg.cpp:1860
+#: src/PrefsUnifiedDlg.cpp:1940
 msgid "Browse for videoplayer"
 msgstr "Ortam Çalıcısı için göz at"
 
-#: src/PrefsUnifiedDlg.cpp:1864
+#: src/PrefsUnifiedDlg.cpp:1944
 msgid "Select browser"
 msgstr "Tarayıcı Seçiniz"
 
-#: src/PrefsUnifiedDlg.cpp:1868
+#: src/PrefsUnifiedDlg.cpp:1948
 msgid "Select ffprobe binary"
 msgstr "ffprobe ikilisi seçin"
 
-#: src/PrefsUnifiedDlg.cpp:1874
+#: src/PrefsUnifiedDlg.cpp:1954
 #, c-format
 msgid "Executable%s"
 msgstr "Çalıştırılabilir %s"
 
-#: src/PrefsUnifiedDlg.cpp:1908
+#: src/PrefsUnifiedDlg.cpp:1988
 msgid "ffprobe not found on PATH or in the standard install locations. Install ffmpeg (which ships ffprobe) or use Browse to pick a binary manually."
 msgstr "ffprobe, PATH veya standart kurulum konumlarında bulunamadı. ffmepg kurun (ffprobe'u sağlar) veya el ile bir ikili seçmek için Tara düğmesine tıklayın."
 
-#: src/PrefsUnifiedDlg.cpp:1920
+#: src/PrefsUnifiedDlg.cpp:2000
 msgid "Reset the settings on this page to their default values?"
 msgstr "Bu sayfadaki ayarlar varsayılan değerlerine sıfırlansınlar mı?"
 
-#: src/PrefsUnifiedDlg.cpp:1921
+#: src/PrefsUnifiedDlg.cpp:2001
 msgid "Reset to defaults"
 msgstr "Varsayılanlara sıfırla"
 
-#: src/PrefsUnifiedDlg.cpp:1948
+#: src/PrefsUnifiedDlg.cpp:2028
 msgid "Edit server list"
 msgstr "Sunucu listesini düzenle"
 
-#: src/PrefsUnifiedDlg.cpp:1949
+#: src/PrefsUnifiedDlg.cpp:2029
 msgid ""
 "Add here URL's to download server.met files.\n"
 "Only one url on each line."
@@ -5955,114 +5997,114 @@ msgstr ""
 "Server.met dosyasını indirmek için buraya bağlantı adresi girin.\n"
 "Her satıra sadece bir adres yazılmalıdır."
 
-#: src/PrefsUnifiedDlg.cpp:2004
+#: src/PrefsUnifiedDlg.cpp:2084
 msgid "IP2Country update failed"
 msgstr "IP2Country güncellemesi başarısız oldu"
 
-#: src/PrefsUnifiedDlg.cpp:2149 src/PrefsUnifiedDlg.cpp:2180
+#: src/PrefsUnifiedDlg.cpp:2229 src/PrefsUnifiedDlg.cpp:2260
 msgid "Data by MaxMind GeoLite2"
 msgstr "Veriler MaxMind GeoLite2 tarafından sağlanmıştır"
 
-#: src/PrefsUnifiedDlg.cpp:2151 src/PrefsUnifiedDlg.cpp:2182
+#: src/PrefsUnifiedDlg.cpp:2231 src/PrefsUnifiedDlg.cpp:2262
 msgid "Custom source"
 msgstr "Kişiselleştirilmiş kaynak"
 
-#: src/PrefsUnifiedDlg.cpp:2153 src/PrefsUnifiedDlg.cpp:2184
+#: src/PrefsUnifiedDlg.cpp:2233 src/PrefsUnifiedDlg.cpp:2264
 msgid "Data by DB-IP.com"
 msgstr "Veriler DB-IP.com tarafından sağlanmıştır"
 
-#: src/PrefsUnifiedDlg.cpp:2204
+#: src/PrefsUnifiedDlg.cpp:2284
 #, c-format
 msgid "Status: Loaded%s"
 msgstr "Durum: %s yüklendi"
 
-#: src/PrefsUnifiedDlg.cpp:2206
+#: src/PrefsUnifiedDlg.cpp:2286
 #, c-format
 msgid "Status: Loaded%s - %s"
 msgstr "Durum: %s - %s yüklendi"
 
-#: src/PrefsUnifiedDlg.cpp:2210
+#: src/PrefsUnifiedDlg.cpp:2290
 msgid "Status: Failed to load - click 'Update now' to refresh."
 msgstr "Durum: yükleme başarısız oldu - güncellemek için 'Şimdi güncelle' düğmesine tıklayın."
 
-#: src/PrefsUnifiedDlg.cpp:2212
+#: src/PrefsUnifiedDlg.cpp:2292
 msgid "Status: Not found - click 'Update now' to download."
 msgstr "Durum: bulunamadı - indirmek için 'Şimdi güncelle' düğmesine tıklayın."
 
-#: src/PrefsUnifiedDlg.cpp:2270 src/PrefsUnifiedDlg.cpp:2294
+#: src/PrefsUnifiedDlg.cpp:2350 src/PrefsUnifiedDlg.cpp:2374
 #, c-format
 msgid "Update delay: %d second"
 msgid_plural "Update delay: %d seconds"
 msgstr[0] "Güncelleme gecikmesi: %d saniye"
 msgstr[1] "Güncelleme gecikmesi: %d saniye"
 
-#: src/PrefsUnifiedDlg.cpp:2278
+#: src/PrefsUnifiedDlg.cpp:2358
 #, c-format
 msgid "Time for average graph: %d minute"
 msgid_plural "Time for average graph: %d minutes"
 msgstr[0] "Ortalama grafiği için süre: %d dakika"
 msgstr[1] "Ortalama grafiği için süre: %d dakika"
 
-#: src/PrefsUnifiedDlg.cpp:2287
+#: src/PrefsUnifiedDlg.cpp:2367
 #, c-format
 msgid "Connections Graph Scale: %d"
 msgstr "Bağlantı Grafik Ölçüsü: %d"
 
-#: src/PrefsUnifiedDlg.cpp:2302
+#: src/PrefsUnifiedDlg.cpp:2382
 #, c-format
 msgid "File Buffer Size: %d byte"
 msgid_plural "File Buffer Size: %d bytes"
 msgstr[0] "Dosya Alım Boyutu: %d bayt"
 msgstr[1] "Dosya Alım Boyutu: %d bayt"
 
-#: src/PrefsUnifiedDlg.cpp:2312
+#: src/PrefsUnifiedDlg.cpp:2392
 #, c-format
 msgid "Upload Queue Size: %d client"
 msgid_plural "Upload Queue Size: %d clients"
 msgstr[0] "Gönderme Sıra Boyutu: %d kullanıcı"
 msgstr[1] "Gönderme Sıra Boyutu: %d kullanıcı"
 
-#: src/PrefsUnifiedDlg.cpp:2322
+#: src/PrefsUnifiedDlg.cpp:2402
 #, c-format
 msgid "Server connection refresh interval: %d minute"
 msgid_plural "Server connection refresh interval: %d minutes"
 msgstr[0] "Sunucu bağlantısı yenileme sıklığı: %d dakika"
 msgstr[1] "Sunucu bağlantısı yenileme sıklığı: %d dakika"
 
-#: src/PrefsUnifiedDlg.cpp:2327
+#: src/PrefsUnifiedDlg.cpp:2407
 msgid "Server connection refresh interval: Disabled"
 msgstr "Sunucu bağlantısı yenileme döngüsü: Devre dışı"
 
-#: src/PrefsUnifiedDlg.cpp:2371
+#: src/PrefsUnifiedDlg.cpp:2451
 msgid "disabled"
 msgstr "devre dışı"
 
-#: src/PrefsUnifiedDlg.cpp:2397
+#: src/PrefsUnifiedDlg.cpp:2477
 #, c-format
 msgid "Execute command on '%s' event"
 msgstr "'%s' olayında komut çalıştır."
 
-#: src/PrefsUnifiedDlg.cpp:2404
+#: src/PrefsUnifiedDlg.cpp:2484
 msgid "Enable command execution on core"
 msgstr "Çekirdekte komut çalıştırmayı aktifleştir."
 
-#: src/PrefsUnifiedDlg.cpp:2416
+#: src/PrefsUnifiedDlg.cpp:2496
 msgid "Core command:"
 msgstr "Çekirdek komutu:"
 
-#: src/PrefsUnifiedDlg.cpp:2432
+#: src/PrefsUnifiedDlg.cpp:2512
 msgid "Enable command execution on GUI"
 msgstr "Arayüzde komut çalıştırmayı etkinleştir."
 
-#: src/PrefsUnifiedDlg.cpp:2444
+#: src/PrefsUnifiedDlg.cpp:2524
 msgid "GUI command:"
 msgstr "Arayüz komutu:"
 
-#: src/PrefsUnifiedDlg.cpp:2460
+#: src/PrefsUnifiedDlg.cpp:2540
 msgid "The following variables will be replaced:"
 msgstr "Şu girdiler değiştirilecek:"
 
-#: src/PrefsUnifiedDlg.cpp:2628
+#: src/PrefsUnifiedDlg.cpp:2708
 msgid ""
 "The following folders look like system or sensitive locations:\n"
 "\n"
@@ -6070,37 +6112,37 @@ msgstr ""
 "Şu dizinler sistem dizinleri veya hassas konumlar gibi görünüyor:\n"
 "\n"
 
-#: src/PrefsUnifiedDlg.cpp:2633
+#: src/PrefsUnifiedDlg.cpp:2713
 msgid "Sharing them recursively will publish every file underneath on the eD2k/Kad networks. Do you really want to do this?"
 msgstr "Bunları yinelemeli olarak paylaşmanız, kapsadıkları her dosyayı eD2k/Kad ağlarında yayınlayacaktır. Bunu hakikaten yapmak istiyor musunuz?"
 
-#: src/PrefsUnifiedDlg.cpp:2636
+#: src/PrefsUnifiedDlg.cpp:2716
 msgid "Confirm shared folders"
 msgstr "Paylaşılan dizinleri teyit et"
 
-#: src/PrefsUnifiedDlg.cpp:2664
+#: src/PrefsUnifiedDlg.cpp:2744
 msgid "Reloading shared files..."
 msgstr "Paylaşılan dosyalar yeniden yükleniyor…"
 
-#: src/PrefsUnifiedDlg.cpp:2665
+#: src/PrefsUnifiedDlg.cpp:2745
 msgid "Scanning for subdirectories..."
 msgstr "Alt dizinler taranıyor…"
 
-#: src/PrefsUnifiedDlg.cpp:2666
+#: src/PrefsUnifiedDlg.cpp:2746
 msgid "Updating shared folders"
 msgstr "Paylaşılan dizinler güncelleniyor"
 
-#: src/PrefsUnifiedDlg.cpp:2693
+#: src/PrefsUnifiedDlg.cpp:2773
 #, c-format
 msgid "Scanned %u directories..."
 msgstr "%u dizin tarandı…"
 
-#: src/PrefsUnifiedDlg.cpp:2743
+#: src/PrefsUnifiedDlg.cpp:2823
 #, c-format
 msgid "Reloading shared files: %u files scanned"
 msgstr "Paylaşılmış dosyalar yeniden yükleniyor: %u dosya tarandı"
 
-#: src/PrefsUnifiedDlg.cpp:2793
+#: src/PrefsUnifiedDlg.cpp:2873
 msgid "Shared folder"
 msgstr "Paylaşılan dizin"
 

--- a/po/tr.po
+++ b/po/tr.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-28 08:06+0200\n"
+"POT-Creation-Date: 2026-07-28 10:19+0200\n"
 "PO-Revision-Date: 2026-07-27 11:47+0000\n"
 "Last-Translator: \n"
 "Language-Team: Turkish <li@li.org>\n"
@@ -143,7 +143,7 @@ msgstr "Kur"
 msgid "Not now"
 msgstr "Şimdi değil"
 
-#: src/AppImageIntegration.cpp:422 src/amuleDlg.cpp:600
+#: src/AppImageIntegration.cpp:422 src/amuleDlg.cpp:665
 msgid "Don't ask again"
 msgstr "Tekrar sorma"
 
@@ -220,7 +220,7 @@ msgid "Killing amuleweb instance with pid '%d' ... "
 msgstr "pid `%d' ile ilişkili amuleweb oturumu öldürülüyor… "
 
 #: src/amule.cpp:336 src/amule.cpp:349 src/ClientRef.cpp:180
-#: src/SearchDlg.cpp:880 src/ServerListCtrl.cpp:98
+#: src/SearchDlg.cpp:1041 src/ServerListCtrl.cpp:98
 msgid "Failed"
 msgstr "Başarısız"
 
@@ -573,29 +573,67 @@ msgstr "Pid dosyası oluşturulamıyor"
 msgid "ERROR: %s"
 msgstr "HATA: %s"
 
-#: src/amuleDlg.cpp:236
+#: src/amuleDlg.cpp:250
 #, c-format
 msgid "This is aMule %s based on eMule."
 msgstr "Bu, eMule üzerine kurulu olan aMule %s yazılımıdır."
 
-#: src/amuleDlg.cpp:237
+#: src/amuleDlg.cpp:251
 #, c-format
 msgid "Running on %s"
 msgstr "%s üzerinde çalışıyor"
 
-#: src/amuleDlg.cpp:239
+#: src/amuleDlg.cpp:253
 msgid "Visit https://github.com/amule-org/amule/releases/latest to check if a new version is available."
 msgstr "Yeni sürüm denetimi için https://github.com/amule-org/amule/releases/latest adresini ziyaret ediniz."
 
-#: src/amuleDlg.cpp:268
+#: src/amuleDlg.cpp:282
 msgid "FATAL ERROR: Failed to create Timer"
 msgstr "ÖNEMLİ HATA: Zamanlayıcı oluşturulamadı"
 
-#: src/amuleDlg.cpp:592
+#: src/amuleDlg.cpp:361 src/amuleDlg.cpp:1787 src/amuleDlg.cpp:2033
+#: src/muuli_wdr.cpp:1492 src/muuli_wdr.cpp:3418
+msgid "Networks"
+msgstr "Ağlar"
+
+#: src/amuleDlg.cpp:362 src/amuleDlg.cpp:1793 src/muuli_wdr.cpp:3419
+msgid "Searches"
+msgstr "Aramalar"
+
+#: src/amuleDlg.cpp:363 src/amuleDlg.cpp:1799 src/DownloadListCtrl.cpp:740
+#: src/muuli_wdr.cpp:392 src/muuli_wdr.cpp:1585 src/muuli_wdr.cpp:3420
+#: src/Statistics.cpp:829
+msgid "Downloads"
+msgstr "İndirmeler"
+
+#: src/amuleDlg.cpp:364 src/amuleDlg.cpp:1805 src/muuli_wdr.cpp:3294
+msgid "Shared files"
+msgstr "Paylaşılan dosyalar"
+
+#: src/amuleDlg.cpp:365 src/amuleDlg.cpp:1811 src/muuli_wdr.cpp:2926
+#: src/muuli_wdr.cpp:3376 src/muuli_wdr.cpp:3423
+msgid "Messages"
+msgstr "Sohbet"
+
+#: src/amuleDlg.cpp:366 src/amuleDlg.cpp:1817 src/muuli_wdr.cpp:3424
+#: src/PrefsUnifiedDlg.cpp:312 src/Statistics.cpp:779 src/Statistics.cpp:1235
+msgid "Statistics"
+msgstr "İstatistikler"
+
+#: src/amuleDlg.cpp:368 src/amuleDlg.cpp:1824 src/muuli_wdr.cpp:3426
+#: src/PrefsUnifiedDlg.cpp:328 src/utils/wxCas/src/wxcasprefs.cpp:39
+msgid "Preferences"
+msgstr "Ayarlar"
+
+#: src/amuleDlg.cpp:371
+msgid "Navigate"
+msgstr ""
+
+#: src/amuleDlg.cpp:657
 msgid "New version available"
 msgstr "Yeni bir sürüm mevcuttur"
 
-#: src/amuleDlg.cpp:596
+#: src/amuleDlg.cpp:661
 #, c-format
 msgid ""
 "A new version of aMule (%s) is available.\n"
@@ -610,217 +648,184 @@ msgstr ""
 "\n"
 "İndirme sayfasını açmak ister misiniz?"
 
-#: src/amuleDlg.cpp:678
+#: src/amuleDlg.cpp:743
 msgid "aMule dialog destroyed"
 msgstr "aMule diyaloğu imha edildi"
 
-#: src/amuleDlg.cpp:701 src/DataToText.cpp:68 src/IPFilter.cpp:547
+#: src/amuleDlg.cpp:766 src/DataToText.cpp:68 src/IPFilter.cpp:547
 msgid "Connecting"
 msgstr "Bağlanıyor"
 
-#: src/amuleDlg.cpp:893
+#: src/amuleDlg.cpp:958
 msgid "eD2k: Connecting"
 msgstr "eD2k: Bağlanıyor"
 
-#: src/amuleDlg.cpp:897
+#: src/amuleDlg.cpp:962
 msgid "eD2k: Disconnected"
 msgstr "eD2k: Bağlantı kesildi"
 
-#: src/amuleDlg.cpp:903
+#: src/amuleDlg.cpp:968
 msgid "Kad: Firewalled"
 msgstr "Kad: Güvenlik Duvarı"
 
-#: src/amuleDlg.cpp:907
+#: src/amuleDlg.cpp:972
 msgid "Kad: Connected"
 msgstr "Kad: Bağlandı"
 
-#: src/amuleDlg.cpp:912
+#: src/amuleDlg.cpp:977
 msgid "Kad: Connecting"
 msgstr "Kad: Bağlanıyor"
 
-#: src/amuleDlg.cpp:916
+#: src/amuleDlg.cpp:981
 msgid "Kad: Off"
 msgstr "Kad: Kapalı"
 
-#: src/amuleDlg.cpp:964 src/DownloadListCtrl.cpp:505
+#: src/amuleDlg.cpp:1029 src/DownloadListCtrl.cpp:505
 #: src/DownloadListCtrl.cpp:749 src/FriendListCtrl.cpp:180
 #: src/muuli_wdr.cpp:731 src/muuli_wdr.cpp:782 src/muuli_wdr.cpp:846
-#: src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2224 src/muuli_wdr.cpp:2309
-#: src/muuli_wdr.cpp:3057 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
+#: src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2231 src/muuli_wdr.cpp:2316
+#: src/muuli_wdr.cpp:3064 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
 #: src/ServerListCtrl.cpp:606 src/TransferWnd.cpp:378
 #: src/utils/wxCas/src/wxcasprefs.cpp:235
 msgid "Cancel"
 msgstr "İptal"
 
-#: src/amuleDlg.cpp:965
+#: src/amuleDlg.cpp:1030
 msgid "Stop the current connection attempts"
 msgstr "Durdur"
 
-#: src/amuleDlg.cpp:970 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976
-#: src/muuli_wdr.cpp:2447
+#: src/amuleDlg.cpp:1035 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976
+#: src/muuli_wdr.cpp:2454
 msgid "Disconnect"
 msgstr "Bağlantıyı Kes"
 
-#: src/amuleDlg.cpp:971
+#: src/amuleDlg.cpp:1036
 msgid "Disconnect from the currently connected networks"
 msgstr "Bağlanılmış olan ağlar ile bağlantıyı Kes"
 
-#: src/amuleDlg.cpp:976 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979
-#: src/muuli_wdr.cpp:2602 src/muuli_wdr.cpp:3054 src/muuli_wdr.cpp:3409
+#: src/amuleDlg.cpp:1041 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979
+#: src/muuli_wdr.cpp:2609 src/muuli_wdr.cpp:3061 src/muuli_wdr.cpp:3416
 msgid "Connect"
 msgstr "Bağlan"
 
-#: src/amuleDlg.cpp:977
+#: src/amuleDlg.cpp:1042
 msgid "Connect to the currently enabled networks"
 msgstr "Etkinleştirilmiş olan ağlara bağlan"
 
-#: src/amuleDlg.cpp:1089
+#: src/amuleDlg.cpp:1154
 #, c-format
 msgid "Up: %.1f%s (%.1f) | Down: %.1f%s (%.1f)"
 msgstr "Gön: %.1f%s (%.1f) | İnd: %.1f%s (%.1f)"
 
-#: src/amuleDlg.cpp:1091 src/amuleDlg.cpp:1093 src/amuleDlg.cpp:1097
-#: src/amuleDlg.cpp:1099 src/amuleDlg.cpp:1110 src/amuleDlg.cpp:1112
+#: src/amuleDlg.cpp:1156 src/amuleDlg.cpp:1158 src/amuleDlg.cpp:1162
+#: src/amuleDlg.cpp:1164 src/amuleDlg.cpp:1175 src/amuleDlg.cpp:1177
 #: src/MuleTrayIcon.cpp:796 src/MuleTrayIcon.cpp:799
 msgid " MB/s"
 msgstr " MB/s"
 
-#: src/amuleDlg.cpp:1091 src/amuleDlg.cpp:1093 src/amuleDlg.cpp:1097
-#: src/amuleDlg.cpp:1099 src/amuleDlg.cpp:1110 src/amuleDlg.cpp:1112
+#: src/amuleDlg.cpp:1156 src/amuleDlg.cpp:1158 src/amuleDlg.cpp:1162
+#: src/amuleDlg.cpp:1164 src/amuleDlg.cpp:1175 src/amuleDlg.cpp:1177
 #: src/MuleTrayIcon.cpp:796 src/MuleTrayIcon.cpp:799
 #: src/utils/wxCas/src/wxcasframe.cpp:1041
 msgid " kB/s"
 msgstr " kB/sn"
 
-#: src/amuleDlg.cpp:1096
+#: src/amuleDlg.cpp:1161
 #, c-format
 msgid "Up: %.1f%s | Down: %.1f%s"
 msgstr "Gön: %.1f%s | İnd: %.1f%s"
 
-#: src/amuleDlg.cpp:1128
+#: src/amuleDlg.cpp:1193
 #, c-format
 msgid "aMule (%s | Connected)"
 msgstr "aMule (%s | Bağlandı)"
 
-#: src/amuleDlg.cpp:1130
+#: src/amuleDlg.cpp:1195
 #, c-format
 msgid "aMule (%s | Disconnected)"
 msgstr "aMule (%s | Bağlantı kesildi)"
 
-#: src/amuleDlg.cpp:1183
+#: src/amuleDlg.cpp:1248
 #, c-format
 msgid "Do you really want to exit %s?"
 msgstr "%s üzerinden çıkmayı gerçekten istiyor musunuz?"
 
-#: src/amuleDlg.cpp:1185
+#: src/amuleDlg.cpp:1250
 msgid "Exit confirmation"
 msgstr "Çıkışı onaylayınız"
 
-#: src/amuleDlg.cpp:1548
+#: src/amuleDlg.cpp:1613
 msgid "Launch Command: "
 msgstr "Çalıştırma Komutu: "
 
-#: src/amuleDlg.cpp:1567 src/muuli_wdr.cpp:1971 src/Preferences.cpp:951
+#: src/amuleDlg.cpp:1632 src/muuli_wdr.cpp:1978 src/Preferences.cpp:952
 msgid "- default -"
 msgstr "- ön tanımlı -"
 
-#: src/amuleDlg.cpp:1595
+#: src/amuleDlg.cpp:1660
 #, c-format
 msgid "Skin directory '%s' does not exist"
 msgstr "Kaplama dizini '%s' yok"
 
-#: src/amuleDlg.cpp:1598
+#: src/amuleDlg.cpp:1663
 #, c-format
 msgid "WARNING: Unable to open skin file '%s' for read"
 msgstr "UYARI: Kaplama dosyası '%s' okuma için açılamıyor"
 
-#: src/amuleDlg.cpp:1722 src/amuleDlg.cpp:1968 src/muuli_wdr.cpp:1485
-#: src/muuli_wdr.cpp:3411
-msgid "Networks"
-msgstr "Ağlar"
-
-#: src/amuleDlg.cpp:1726 src/muuli_wdr.cpp:3411
+#: src/amuleDlg.cpp:1791 src/muuli_wdr.cpp:3418
 msgid "Networks Window"
 msgstr "Ağ Penceresi"
 
-#: src/amuleDlg.cpp:1728 src/muuli_wdr.cpp:3412
-msgid "Searches"
-msgstr "Aramalar"
-
-#: src/amuleDlg.cpp:1732 src/muuli_wdr.cpp:3412
+#: src/amuleDlg.cpp:1797 src/muuli_wdr.cpp:3419
 msgid "Searches Window"
 msgstr "Arama Penceresi"
 
-#: src/amuleDlg.cpp:1734 src/DownloadListCtrl.cpp:740 src/muuli_wdr.cpp:392
-#: src/muuli_wdr.cpp:1578 src/muuli_wdr.cpp:3413 src/Statistics.cpp:829
-msgid "Downloads"
-msgstr "İndirmeler"
-
-#: src/amuleDlg.cpp:1738 src/muuli_wdr.cpp:3413
+#: src/amuleDlg.cpp:1803 src/muuli_wdr.cpp:3420
 msgid "Downloads Window"
 msgstr "İndirme Penceresi"
 
-#: src/amuleDlg.cpp:1740 src/muuli_wdr.cpp:3287
-msgid "Shared files"
-msgstr "Paylaşılan dosyalar"
-
-#: src/amuleDlg.cpp:1744 src/muuli_wdr.cpp:3415
+#: src/amuleDlg.cpp:1809 src/muuli_wdr.cpp:3422
 msgid "Shared Files Window"
 msgstr "Paylaşılan Dosya Penceresi"
 
-#: src/amuleDlg.cpp:1746 src/muuli_wdr.cpp:2919 src/muuli_wdr.cpp:3369
-#: src/muuli_wdr.cpp:3416
-msgid "Messages"
-msgstr "Sohbet"
-
-#: src/amuleDlg.cpp:1750 src/muuli_wdr.cpp:3416
+#: src/amuleDlg.cpp:1815 src/muuli_wdr.cpp:3423
 msgid "Messages Window"
 msgstr "Sohbet Penceresi"
 
-#: src/amuleDlg.cpp:1752 src/muuli_wdr.cpp:3417 src/PrefsUnifiedDlg.cpp:312
-#: src/Statistics.cpp:779 src/Statistics.cpp:1235
-msgid "Statistics"
-msgstr "İstatistikler"
-
-#: src/amuleDlg.cpp:1756 src/muuli_wdr.cpp:3417
+#: src/amuleDlg.cpp:1821 src/muuli_wdr.cpp:3424
 msgid "Statistics Graph Window"
 msgstr "İstatistik Grafik Penceresi"
 
-#: src/amuleDlg.cpp:1759 src/muuli_wdr.cpp:3419 src/PrefsUnifiedDlg.cpp:328
-#: src/utils/wxCas/src/wxcasprefs.cpp:39
-msgid "Preferences"
-msgstr "Ayarlar"
-
-#: src/amuleDlg.cpp:1763 src/muuli_wdr.cpp:3419
+#: src/amuleDlg.cpp:1828 src/muuli_wdr.cpp:3426
 msgid "Preferences Settings Window"
 msgstr "Ayar Penceresi"
 
-#: src/amuleDlg.cpp:1766 src/muuli_wdr.cpp:3420
+#: src/amuleDlg.cpp:1831 src/muuli_wdr.cpp:3427
 msgid "Import"
 msgstr "İçe Aktar"
 
-#: src/amuleDlg.cpp:1770 src/muuli_wdr.cpp:3420
+#: src/amuleDlg.cpp:1835 src/muuli_wdr.cpp:3427
 msgid "The partfile importer tool"
 msgstr "Parça dosyası içe aktarım aracı"
 
-#: src/amuleDlg.cpp:1773 src/muuli_wdr.cpp:3421
+#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3428
 #: src/utils/aLinkCreator/src/alcframe.cpp:262
 msgid "About"
 msgstr "Hakkında"
 
-#: src/amuleDlg.cpp:1773 src/muuli_wdr.cpp:3421
+#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3428
 msgid "About/Help"
 msgstr "Hakkında/Yardım"
 
-#: src/amuleDlg.cpp:1971
+#: src/amuleDlg.cpp:2036
 msgid "eD2k network"
 msgstr "eD2k ağı"
 
-#: src/amuleDlg.cpp:1974
+#: src/amuleDlg.cpp:2039
 msgid "Kad network"
 msgstr "Kademlia ağı"
 
-#: src/amuleDlg.cpp:1974
+#: src/amuleDlg.cpp:2039
 msgid "No network"
 msgstr "Ağ yok"
 
@@ -1353,19 +1358,19 @@ msgstr "Oto (Yük)"
 msgid "Very low"
 msgstr "Çok düşük"
 
-#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:743 src/muuli_wdr.cpp:2275
+#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:743 src/muuli_wdr.cpp:2282
 #: src/ServerListCtrl.cpp:263 src/ServerListCtrl.cpp:456
 #: src/SharedFilesCtrl.cpp:145
 msgid "Low"
 msgstr "Düşük"
 
-#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:744 src/muuli_wdr.cpp:2276
+#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:744 src/muuli_wdr.cpp:2283
 #: src/ServerListCtrl.cpp:266 src/ServerListCtrl.cpp:457
 #: src/SharedFilesCtrl.cpp:146
 msgid "Normal"
 msgstr "Normal"
 
-#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:745 src/muuli_wdr.cpp:2277
+#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:745 src/muuli_wdr.cpp:2284
 #: src/ServerListCtrl.cpp:269 src/ServerListCtrl.cpp:458
 #: src/SharedFilesCtrl.cpp:147
 msgid "High"
@@ -1457,8 +1462,8 @@ msgstr "Sunucu"
 msgid "Remote Server"
 msgstr "Uzak Sunucu"
 
-#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3174
-#: src/SearchDlg.cpp:111 src/TextClient.cpp:911
+#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3181
+#: src/SearchDlg.cpp:119 src/TextClient.cpp:911
 msgid "Kad"
 msgstr "Kad"
 
@@ -1528,7 +1533,7 @@ msgstr "Parça"
 msgid "Size"
 msgstr "Boyut"
 
-#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3241
+#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3248
 msgid "Transferred"
 msgstr "Aktarıldı"
 
@@ -1586,7 +1591,7 @@ msgstr ""
 "Geri besleme: %s (%s)\n"
 "\n"
 
-#: src/DownloadListCtrl.cpp:746 src/muuli_wdr.cpp:2278
+#: src/DownloadListCtrl.cpp:746 src/muuli_wdr.cpp:2285
 #: src/SharedFilesCtrl.cpp:150
 msgid "Auto"
 msgstr "Otomatik"
@@ -1624,7 +1629,7 @@ msgid "Extended Options"
 msgstr "Genişletilmiş Seçenekler"
 
 #: src/DownloadListCtrl.cpp:770 src/DownloadListCtrl.cpp:822
-#: src/muuli_wdr.cpp:1789
+#: src/muuli_wdr.cpp:1796
 msgid "Preview"
 msgstr "Ön İzleme"
 
@@ -2333,19 +2338,19 @@ msgstr ""
 msgid "eD2k"
 msgstr "eD2k"
 
-#: src/FirstRunWizard.cpp:349 src/muuli_wdr.cpp:1488
+#: src/FirstRunWizard.cpp:349 src/muuli_wdr.cpp:1495
 msgid "Kademlia"
 msgstr "Kademlia"
 
-#: src/FirstRunWizard.cpp:359 src/muuli_wdr.cpp:1416
+#: src/FirstRunWizard.cpp:359 src/muuli_wdr.cpp:1423
 msgid "Standard TCP Port "
 msgstr "Standart TCP Portu "
 
-#: src/FirstRunWizard.cpp:365 src/muuli_wdr.cpp:1428
+#: src/FirstRunWizard.cpp:365 src/muuli_wdr.cpp:1435
 msgid "Extended UDP port (Kad / global search) "
 msgstr "Genişletilmiş UDP portu (Kad / Genel arama) "
 
-#: src/FirstRunWizard.cpp:377 src/muuli_wdr.cpp:1435
+#: src/FirstRunWizard.cpp:377 src/muuli_wdr.cpp:1442
 msgid "Enable UPnP for router port forwarding"
 msgstr "Yönlendirici port iletimi için UPnP'yi etkinleştir"
 
@@ -2372,7 +2377,7 @@ msgstr ""
 msgid "Your peer lists are already in place - nothing to download."
 msgstr "%s dosyasını indirmeyi zaten deniyorsunuz"
 
-#: src/FirstRunWizard.cpp:434 src/muuli_wdr.cpp:1533
+#: src/FirstRunWizard.cpp:434 src/muuli_wdr.cpp:1540
 msgid "Auto-update server list at startup"
 msgstr "Otomatik başlangıç"
 
@@ -2418,23 +2423,23 @@ msgid ""
 "want downloads on a different (e.g. larger) disk."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:549 src/FirstRunWizard.cpp:611 src/muuli_wdr.cpp:1701
+#: src/FirstRunWizard.cpp:549 src/FirstRunWizard.cpp:611 src/muuli_wdr.cpp:1708
 msgid "Destination folder for downloads"
 msgstr "İndirmeler için hedef dizin"
 
-#: src/FirstRunWizard.cpp:553 src/FirstRunWizard.cpp:569 src/muuli_wdr.cpp:1342
-#: src/muuli_wdr.cpp:1359 src/muuli_wdr.cpp:1676 src/muuli_wdr.cpp:1707
-#: src/muuli_wdr.cpp:1719 src/muuli_wdr.cpp:2762
+#: src/FirstRunWizard.cpp:553 src/FirstRunWizard.cpp:569 src/muuli_wdr.cpp:1349
+#: src/muuli_wdr.cpp:1366 src/muuli_wdr.cpp:1683 src/muuli_wdr.cpp:1714
+#: src/muuli_wdr.cpp:1726 src/muuli_wdr.cpp:2769
 #: src/utils/aLinkCreator/src/alcframe.cpp:135
 #: src/utils/wxCas/src/wxcasprefs.cpp:52 src/utils/wxCas/src/wxcasprefs.cpp:118
 msgid "Browse"
 msgstr "Göz at"
 
-#: src/FirstRunWizard.cpp:559 src/muuli_wdr.cpp:1712
+#: src/FirstRunWizard.cpp:559 src/muuli_wdr.cpp:1719
 msgid "(All files in this folder are shared with other peers)"
 msgstr "(Bu dizindeki tüm dosyalar diğer eşler ile paylaşılmaktadır)"
 
-#: src/FirstRunWizard.cpp:565 src/FirstRunWizard.cpp:624 src/muuli_wdr.cpp:1714
+#: src/FirstRunWizard.cpp:565 src/FirstRunWizard.cpp:624 src/muuli_wdr.cpp:1721
 msgid "Folder for temporary download files"
 msgstr "Geçici dosyalar için dizin"
 
@@ -2465,7 +2470,7 @@ msgstr "Arkadaş listesi 'emfriends.met' dosyasına yazılamıyor!"
 msgid "CRITICAL - no client on StartChatSession"
 msgstr "KRİTİK - SohbetOturumunuBaşlat' ta istemci yok"
 
-#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2668 src/muuli_wdr.cpp:3345
+#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2675 src/muuli_wdr.cpp:3352
 msgid "Friends"
 msgstr "Arkadaşlar"
 
@@ -2849,7 +2854,7 @@ msgstr "Paylaşım oranı"
 msgid "Uploaded"
 msgstr "Gönderilen"
 
-#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3225
+#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3232
 msgid "Requested"
 msgstr "İstenen"
 
@@ -2972,7 +2977,7 @@ msgid "WARNING: "
 msgstr "UYARI: "
 
 #: src/MuleNotebook.cpp:179 src/muuli_wdr.cpp:817 src/muuli_wdr.cpp:1229
-#: src/muuli_wdr.cpp:3129 src/muuli_wdr.cpp:3385
+#: src/muuli_wdr.cpp:3136 src/muuli_wdr.cpp:3392
 msgid "Close"
 msgstr "Kapat"
 
@@ -2985,12 +2990,12 @@ msgstr "Kes"
 msgid "Copy"
 msgstr "Kopyala"
 
-#: src/MuleTextCtrl.cpp:88
+#: src/MuleTextCtrl.cpp:88 src/SearchDlg.cpp:261
 msgid "Paste"
 msgstr "Yapıştır"
 
 #: src/MuleTextCtrl.cpp:89 src/muuli_wdr.cpp:358 src/muuli_wdr.cpp:757
-#: src/muuli_wdr.cpp:2352 src/muuli_wdr.cpp:2371 src/muuli_wdr.cpp:2393
+#: src/muuli_wdr.cpp:2359 src/muuli_wdr.cpp:2378 src/muuli_wdr.cpp:2400
 #: src/utils/aLinkCreator/src/alcframe.cpp:142
 msgid "Clear"
 msgstr "Temizle"
@@ -3081,8 +3086,8 @@ msgid "Exit"
 msgstr "Çıkış"
 
 #: src/MuleTrayIcon.cpp:579 src/MuleTrayIcon.cpp:945 src/MuleTrayIcon.cpp:965
-#: src/muuli_wdr.cpp:1391 src/muuli_wdr.cpp:1399 src/muuli_wdr.cpp:1406
-#: src/muuli_wdr.cpp:1835 src/muuli_wdr.cpp:1841 src/OtherFunctions.cpp:91
+#: src/muuli_wdr.cpp:1398 src/muuli_wdr.cpp:1406 src/muuli_wdr.cpp:1413
+#: src/muuli_wdr.cpp:1842 src/muuli_wdr.cpp:1848 src/OtherFunctions.cpp:91
 #: src/StatisticsDlg.cpp:93 src/StatisticsDlg.cpp:95
 msgid "kB/s"
 msgstr "kB/s"
@@ -3251,7 +3256,7 @@ msgstr "Ad:"
 msgid "Type"
 msgstr "Tür"
 
-#: src/muuli_wdr.cpp:215 src/SearchDlg.cpp:110 src/SearchListCtrl.cpp:853
+#: src/muuli_wdr.cpp:215 src/SearchDlg.cpp:118 src/SearchListCtrl.cpp:853
 msgid "Local"
 msgstr "Sunucu"
 
@@ -3322,7 +3327,7 @@ msgstr "Bayt"
 msgid "KB"
 msgstr "KB"
 
-#: src/muuli_wdr.cpp:274 src/muuli_wdr.cpp:293 src/muuli_wdr.cpp:1620
+#: src/muuli_wdr.cpp:274 src/muuli_wdr.cpp:293 src/muuli_wdr.cpp:1627
 #: src/OtherFunctions.cpp:64
 msgid "MB"
 msgstr "MB"
@@ -3339,7 +3344,7 @@ msgstr "En Fazla Boyut"
 msgid "Availability"
 msgstr "Uygunluk"
 
-#: src/muuli_wdr.cpp:312 src/muuli_wdr.cpp:398 src/muuli_wdr.cpp:3290
+#: src/muuli_wdr.cpp:312 src/muuli_wdr.cpp:398 src/muuli_wdr.cpp:3297
 msgid "Filter:"
 msgstr "Süz:"
 
@@ -3371,7 +3376,7 @@ msgstr "Zaten cevap vermiş Kad eşlerinden aramayı genişletmelerini iste. Ara
 msgid "Stop"
 msgstr "Durdur"
 
-#: src/muuli_wdr.cpp:348 src/muuli_wdr.cpp:1385 src/SearchListCtrl.cpp:732
+#: src/muuli_wdr.cpp:348 src/muuli_wdr.cpp:1392 src/SearchListCtrl.cpp:732
 msgid "Download"
 msgstr "İndir"
 
@@ -3402,8 +3407,8 @@ msgstr "Dosya kaynakları:"
 #: src/muuli_wdr.cpp:1160 src/muuli_wdr.cpp:1167 src/muuli_wdr.cpp:1172
 #: src/muuli_wdr.cpp:1179 src/muuli_wdr.cpp:1184 src/muuli_wdr.cpp:1191
 #: src/muuli_wdr.cpp:1205 src/muuli_wdr.cpp:1212 src/muuli_wdr.cpp:1217
-#: src/muuli_wdr.cpp:1224 src/muuli_wdr.cpp:3227 src/muuli_wdr.cpp:3235
-#: src/muuli_wdr.cpp:3243
+#: src/muuli_wdr.cpp:1224 src/muuli_wdr.cpp:3234 src/muuli_wdr.cpp:3242
+#: src/muuli_wdr.cpp:3250
 msgid "N/A"
 msgstr "N/A"
 
@@ -3543,7 +3548,7 @@ msgstr "Sanatçı:"
 msgid "Album :"
 msgstr "Albüm:"
 
-#: src/muuli_wdr.cpp:685 src/muuli_wdr.cpp:2247
+#: src/muuli_wdr.cpp:685 src/muuli_wdr.cpp:2254
 msgid "Title :"
 msgstr "Başlık :"
 
@@ -3651,7 +3656,7 @@ msgstr "Kullanıcı Adı :"
 msgid "Userhash :"
 msgstr "Kullanıcı Adreslemesi :"
 
-#: src/muuli_wdr.cpp:895 src/muuli_wdr.cpp:1741 src/muuli_wdr.cpp:2442
+#: src/muuli_wdr.cpp:895 src/muuli_wdr.cpp:1748 src/muuli_wdr.cpp:2449
 #: src/utils/aLinkCreator/src/alcframe.cpp:137
 msgid "Add"
 msgstr "Ekle"
@@ -3660,15 +3665,15 @@ msgstr "Ekle"
 msgid "Download-Speed"
 msgstr "İndirme Hızı"
 
-#: src/muuli_wdr.cpp:954 src/muuli_wdr.cpp:989 src/muuli_wdr.cpp:2546
+#: src/muuli_wdr.cpp:954 src/muuli_wdr.cpp:989 src/muuli_wdr.cpp:2553
 msgid "Current"
 msgstr "Şimdiki"
 
-#: src/muuli_wdr.cpp:962 src/muuli_wdr.cpp:997 src/muuli_wdr.cpp:2554
+#: src/muuli_wdr.cpp:962 src/muuli_wdr.cpp:997 src/muuli_wdr.cpp:2561
 msgid "Running average"
 msgstr "Çalışma ortalaması"
 
-#: src/muuli_wdr.cpp:970 src/muuli_wdr.cpp:1005 src/muuli_wdr.cpp:2562
+#: src/muuli_wdr.cpp:970 src/muuli_wdr.cpp:1005 src/muuli_wdr.cpp:2569
 msgid "Session average"
 msgstr "Oturum ortalaması"
 
@@ -3680,7 +3685,7 @@ msgstr "Gönderim Hızı"
 msgid "Connections"
 msgstr "Bağlantılar"
 
-#: src/muuli_wdr.cpp:1024 src/muuli_wdr.cpp:1860
+#: src/muuli_wdr.cpp:1024 src/muuli_wdr.cpp:1867
 msgid "Active downloads"
 msgstr "Aktif İndirmeler"
 
@@ -3688,7 +3693,7 @@ msgstr "Aktif İndirmeler"
 msgid "Active connections (1:1)"
 msgstr "Aktif Bağlantılar (1:1)"
 
-#: src/muuli_wdr.cpp:1040 src/muuli_wdr.cpp:1861
+#: src/muuli_wdr.cpp:1040 src/muuli_wdr.cpp:1868
 msgid "Active uploads"
 msgstr "Aktif Göndermeler"
 
@@ -3804,8 +3809,8 @@ msgstr "Bağlandığınızda diğerlerinin göreceği isminiz budur."
 msgid "Language: "
 msgstr "Dil: "
 
-#: src/muuli_wdr.cpp:1257 src/muuli_wdr.cpp:1323 src/muuli_wdr.cpp:1327
-#: src/muuli_wdr.cpp:1330
+#: src/muuli_wdr.cpp:1257 src/muuli_wdr.cpp:1330 src/muuli_wdr.cpp:1334
+#: src/muuli_wdr.cpp:1337
 msgid "The delay before showing tool-tips."
 msgstr "İpuçlarını göstermeden önce geçecek süreyi belirler."
 
@@ -3881,259 +3886,268 @@ msgstr "İndirme sona erdiğinde bildirimleri göster"
 msgid "Enabling this will make aMule to show notifications when finished downloading."
 msgstr "Bu şık etkinleştirilirse, indirmeler sona erdiğinde aMule bildirimleri gösterecektir."
 
-#: src/muuli_wdr.cpp:1322
+#: src/muuli_wdr.cpp:1323
+#, fuzzy
+msgid "Remember search history"
+msgstr "Bu ayarları hatırla"
+
+#: src/muuli_wdr.cpp:1324
+msgid "Keeps a dropdown list of your past search terms in the Search tab's Name field. This remembers the queries you typed, not the results they returned."
+msgstr ""
+
+#: src/muuli_wdr.cpp:1329
 msgid "Tooltip delay time: "
 msgstr "İpucu gecikme süresi: "
 
-#: src/muuli_wdr.cpp:1329
+#: src/muuli_wdr.cpp:1336
 msgid "seconds"
 msgstr "saniye"
 
-#: src/muuli_wdr.cpp:1333
+#: src/muuli_wdr.cpp:1340
 msgid "Browser Selection"
 msgstr "Tarayıcı Seçimi"
 
-#: src/muuli_wdr.cpp:1339
+#: src/muuli_wdr.cpp:1346
 msgid "Enter your browser name here. Leave this field empty to use the system default browser."
 msgstr "Tarayıcı adını buraya giriniz. Sisteminizin ön tanımlı tarayıcısını kullanmak için boş bırakınız."
 
-#: src/muuli_wdr.cpp:1346
+#: src/muuli_wdr.cpp:1353
 msgid "Open in new tab if possible"
 msgstr "Mümkünse yeni sekmede aç"
 
-#: src/muuli_wdr.cpp:1348
+#: src/muuli_wdr.cpp:1355
 msgid "Open the web page in a new tab instead of in a new window when possible"
 msgstr "Web sayfasını, yeni pencere yerine mümkünse yeni sekmede açar."
 
-#: src/muuli_wdr.cpp:1352
+#: src/muuli_wdr.cpp:1359
 msgid "Video Player"
 msgstr "Ortam Çalıcısı"
 
-#: src/muuli_wdr.cpp:1379
+#: src/muuli_wdr.cpp:1386
 msgid "Bandwidth limits"
 msgstr "Bağlantı sınırları"
 
-#: src/muuli_wdr.cpp:1393
+#: src/muuli_wdr.cpp:1400
 msgid "Upload"
 msgstr "Gönderme"
 
-#: src/muuli_wdr.cpp:1401
+#: src/muuli_wdr.cpp:1408
 msgid "Slot Allocation"
 msgstr "Slot Tahsis Boyutu"
 
-#: src/muuli_wdr.cpp:1410
+#: src/muuli_wdr.cpp:1417
 msgid "Ports"
 msgstr "Portlar"
 
-#: src/muuli_wdr.cpp:1420
+#: src/muuli_wdr.cpp:1427
 msgid "This is the standard eD2k port and cannot be disabled."
 msgstr "Bu, standart eD2k bağlantı noktasıdır ve devre dışı bırakılamaz."
 
-#: src/muuli_wdr.cpp:1423
+#: src/muuli_wdr.cpp:1430
 msgid "UDP port for server requests (TCP+3):"
 msgstr "Sunucu istemleri için UDP Portu (TCP+3):"
 
-#: src/muuli_wdr.cpp:1425
+#: src/muuli_wdr.cpp:1432
 msgid "4665"
 msgstr "4665"
 
-#: src/muuli_wdr.cpp:1432
+#: src/muuli_wdr.cpp:1439
 msgid "This UDP port is used for extended eD2k requests and Kad network"
 msgstr "Bu UDP portu genişletilmiş eD2k istemleri ve Kad ağı için kullanılır"
 
-#: src/muuli_wdr.cpp:1439
+#: src/muuli_wdr.cpp:1446
 msgid "UPnP TCP Port (Optional):"
 msgstr "UPnP TCP Portu (İsteğe bağlı):"
 
-#: src/muuli_wdr.cpp:1449
+#: src/muuli_wdr.cpp:1456
 msgid "Bind local address to IP (empty for any):"
 msgstr "Yerel adresi IP' ye bağla (herhangi biri için boş bırakın):"
 
-#: src/muuli_wdr.cpp:1452
+#: src/muuli_wdr.cpp:1459
 msgid "Advanced users only: If you have multiple network interfaces, enter the address of the interface to which aMule should be bound."
 msgstr "Sadece ileri düzey kullanıcılar: Birden fazla ağ arayüzünüz varsa; aMule'nin izleyeceği arayüz adresini giriniz."
 
-#: src/muuli_wdr.cpp:1455 src/muuli_wdr.cpp:2054
+#: src/muuli_wdr.cpp:1462 src/muuli_wdr.cpp:2061
 msgid "Bind to network interface (empty for any):"
 msgstr "Ağ arayüzüne bağla (herhangi biri için boş bırakın):"
 
-#: src/muuli_wdr.cpp:1468
+#: src/muuli_wdr.cpp:1475
 msgid "Advanced users only: pin all of aMule's traffic to one network interface, chosen from the list or typed in by name (e.g. tun0, eth0, en0) or index. Unlike binding to an IP, this stops traffic leaking out via the default route - useful with a VPN. Requires no elevated privileges."
 msgstr "Sadece ileri seviye kullanıcılar için: tüm aMule trafiğini listeden seçilmiş veya ismi (mesela tun0, eth0, en0) ya da endeksi yazılmış tek bir ağ arayüzüne sabitle. Bir IP adresine sabitlemenin aksine bu, trafiğin varsayılan yoldan sızmasını engeller - VPN'ler ile faydalıdır. Yüksek izinlere ihtiyaç duymaz."
 
-#: src/muuli_wdr.cpp:1474
+#: src/muuli_wdr.cpp:1481
 msgid "Max sources per downloading file:"
 msgstr "İndirilen dosya başına en fazla kaynak sayısı:"
 
-#: src/muuli_wdr.cpp:1478
+#: src/muuli_wdr.cpp:1485
 msgid "Max simultaneous connections:"
 msgstr "En cazla eş bağlantı sayısı:"
 
-#: src/muuli_wdr.cpp:1491 src/muuli_wdr.cpp:3169
+#: src/muuli_wdr.cpp:1498 src/muuli_wdr.cpp:3176
 msgid "ED2K"
 msgstr "ED2K"
 
-#: src/muuli_wdr.cpp:1498
+#: src/muuli_wdr.cpp:1505
 msgid "Autoconnect on startup"
 msgstr "Başlangıçta otomatik bağlan"
 
-#: src/muuli_wdr.cpp:1501
+#: src/muuli_wdr.cpp:1508
 msgid "Reconnect on loss"
 msgstr "Bağlantı koptuğunda yeniden bağlan"
 
-#: src/muuli_wdr.cpp:1523
+#: src/muuli_wdr.cpp:1530
 msgid "Remove dead server after"
 msgstr "Ölü sunucuları"
 
-#: src/muuli_wdr.cpp:1524
+#: src/muuli_wdr.cpp:1531
 msgid "Static servers are never removed, even when unreachable."
 msgstr "Statik sunucular hiçbir zaman kaldırılmazlar, ulaşılamaz oldukları zaman dahi."
 
-#: src/muuli_wdr.cpp:1528
+#: src/muuli_wdr.cpp:1535
 msgid "retries"
 msgstr "denemeden sonra kaldır"
 
-#: src/muuli_wdr.cpp:1536
+#: src/muuli_wdr.cpp:1543
 msgid "List"
 msgstr "Liste"
 
-#: src/muuli_wdr.cpp:1539
+#: src/muuli_wdr.cpp:1546
 msgid "Update server list when connecting to a server"
 msgstr "Bir sunucuya bağlandığında sunucu listesini güncelle"
 
-#: src/muuli_wdr.cpp:1542
+#: src/muuli_wdr.cpp:1549
 msgid "Update server list when a client connects"
 msgstr "Bir kullanıcı bağlandığında sunucu listesini güncelle"
 
-#: src/muuli_wdr.cpp:1545
+#: src/muuli_wdr.cpp:1552
 msgid "Use priority system"
 msgstr "Öncelik sistemini kullan"
 
-#: src/muuli_wdr.cpp:1549
+#: src/muuli_wdr.cpp:1556
 msgid "Use smart LowID check on connect"
 msgstr "Bağlanırken akıllı DüşükID denetimi yap"
 
-#: src/muuli_wdr.cpp:1553
+#: src/muuli_wdr.cpp:1560
 msgid "Safe connect"
 msgstr "Güvenli Bağlantı"
 
-#: src/muuli_wdr.cpp:1557
+#: src/muuli_wdr.cpp:1564
 msgid "Autoconnect to servers in static list only"
 msgstr "Sadece statik listesindeki sunuculara otomatikman bağlan"
 
-#: src/muuli_wdr.cpp:1560
+#: src/muuli_wdr.cpp:1567
 msgid "Set manually added servers to High Priority"
 msgstr "Elle eklenmiş sunuculara Yüksek Öncelik ata"
 
-#: src/muuli_wdr.cpp:1581
+#: src/muuli_wdr.cpp:1588
 msgid "Add files to download in pause mode"
 msgstr "Dosyaları aktarımlara duraklatılmış kipte ekle"
 
-#: src/muuli_wdr.cpp:1583
+#: src/muuli_wdr.cpp:1590
 msgid "Add files to download with auto priority"
 msgstr "Dosyaları, aktarımlara otomatik öncelikle ekle"
 
-#: src/muuli_wdr.cpp:1586
+#: src/muuli_wdr.cpp:1593
 msgid "Try to download first and last chunks first"
 msgstr "İlk ve son parçaları en önce indirmeye çalış"
 
-#: src/muuli_wdr.cpp:1590
+#: src/muuli_wdr.cpp:1597
 msgid "Endgame mode: rotate to faster sources for the final blocks"
 msgstr "\"Endgame\" kipi: son bloklar için hızlı kaynaklara geç"
 
-#: src/muuli_wdr.cpp:1593
+#: src/muuli_wdr.cpp:1600
 msgid "Start next paused file when a file completes"
 msgstr "Bir dosya tamamlandığında duraklatılan sonraki dosyaya başla"
 
-#: src/muuli_wdr.cpp:1596
+#: src/muuli_wdr.cpp:1603
 msgid "From the same category"
 msgstr "Aynı sınıftan"
 
-#: src/muuli_wdr.cpp:1598
+#: src/muuli_wdr.cpp:1605
 msgid "In alphabetic order"
 msgstr "Alfabetik sırayla"
 
-#: src/muuli_wdr.cpp:1600
+#: src/muuli_wdr.cpp:1607
 msgid "Preallocate disk space for new files"
 msgstr "Yeni dosyalar için diskte yer ayır"
 
-#: src/muuli_wdr.cpp:1601
+#: src/muuli_wdr.cpp:1608
 msgid "For new files preallocates disk space for the whole file, thus reduces fragmentation"
 msgstr "Yeni dosyalarda, dosyanın tamamı için sabit diskte yer ayrılarak parçalanma azaltılır"
 
-#: src/muuli_wdr.cpp:1606
+#: src/muuli_wdr.cpp:1613
 msgid "Create new files as sparse files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1607
+#: src/muuli_wdr.cpp:1614
 msgid "A sparse file reserves its full size on disk immediately without writing real data to it -- fast, but unsupported or slow on some filesystems, and free-space accounting stays optimistic while the download is in progress. Turn this off to grow the file only as data arrives."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1612
+#: src/muuli_wdr.cpp:1619
 msgid "Stop downloads when free disk space reaches "
 msgstr "Boş disk alanı şu kadar kaldığında aktarımları durdur "
 
-#: src/muuli_wdr.cpp:1613
+#: src/muuli_wdr.cpp:1620
 msgid "Select this if you want aMule to check your disk space"
 msgstr "aMule'nin diskteki alanı denetlemesini istiyorsanız bunu seçiniz."
 
-#: src/muuli_wdr.cpp:1617
+#: src/muuli_wdr.cpp:1624
 msgid "Enter here the min disk space desired."
 msgstr "Buraya istenilen en az disk alanını giriniz."
 
-#: src/muuli_wdr.cpp:1623
+#: src/muuli_wdr.cpp:1630
 msgid "Save 10 sources on rare files (< 20 sources)"
 msgstr "Nadir bulunan dosyalarda 10 kaynak sakla (<20 kaynak)"
 
-#: src/muuli_wdr.cpp:1627 src/Statistics.cpp:790
+#: src/muuli_wdr.cpp:1634 src/Statistics.cpp:790
 msgid "Uploads"
 msgstr "Gönderilenler"
 
-#: src/muuli_wdr.cpp:1630
+#: src/muuli_wdr.cpp:1637
 msgid "Add new shared files with auto priority"
 msgstr "Dosyaları paylaşılanlara otomatik öncelikle ekle"
 
-#: src/muuli_wdr.cpp:1636
+#: src/muuli_wdr.cpp:1643
 msgid "Intelligent Corruption Handling (I.C.H.)"
 msgstr "Akıllı Bozulma Yakalayıcısı (I.C.H.)"
 
-#: src/muuli_wdr.cpp:1639
+#: src/muuli_wdr.cpp:1646
 msgid "Enable"
 msgstr "Etkinleştir"
 
-#: src/muuli_wdr.cpp:1642
+#: src/muuli_wdr.cpp:1649
 msgid "Advanced I.C.H. trusts every hash (not recommended)"
 msgstr "Gelişmiş I.C.H. her adreslemeye güvensin. ( önerilmez )"
 
-#: src/muuli_wdr.cpp:1654 src/PrefsUnifiedDlg.cpp:1910
+#: src/muuli_wdr.cpp:1661 src/PrefsUnifiedDlg.cpp:1910
 msgid "Media metadata extraction"
 msgstr "Ortam üst verisi çıkarımı"
 
-#: src/muuli_wdr.cpp:1658
+#: src/muuli_wdr.cpp:1665
 msgid "Extract length / bitrate / codec from shared audio and video files"
 msgstr "Süre / bit hızı / kodlama bilgilerini paylaşılan ses ve video dosyalarından çıkar"
 
-#: src/muuli_wdr.cpp:1660
+#: src/muuli_wdr.cpp:1667
 msgid "When enabled, aMule runs ffprobe on each shared media file to fill in the Length / Bitrate / Codec columns other clients see when they find the file in a search. Requires ffmpeg (the ffprobe binary) to be installed."
 msgstr "Etkinleştirildiğinde, dosyayı bir aramada bulan diğer istemcilerin gördükleri Süre / Bit Akışı / Kodlama sütunlarını doldurmak için aMule her paylaşılan ortam dosyası üzerinde ffprobe çalıştırır. ffmpeg (ffprobe ikilisi) kurulumu gerektirir."
 
-#: src/muuli_wdr.cpp:1667
+#: src/muuli_wdr.cpp:1674
 msgid "Path to ffprobe:"
 msgstr "ffprobe yolu:"
 
-#: src/muuli_wdr.cpp:1672
+#: src/muuli_wdr.cpp:1679
 msgid "Full path to the ffprobe binary. Leave empty to have aMule auto-detect it on startup."
 msgstr "ffprobe ikilisi için tam yol. aMule tarafından başlangıçta otomatik olarak tespit edilmesi için boş bırakın."
 
-#: src/muuli_wdr.cpp:1680
+#: src/muuli_wdr.cpp:1687
 msgid "Detect"
 msgstr "Tespit et"
 
-#: src/muuli_wdr.cpp:1681
+#: src/muuli_wdr.cpp:1688
 msgid "Search the standard install locations for an ffprobe binary and fill the path field."
 msgstr "Bir ffprobe ikilisi için standart kurulum konumlarını ara ve yol alanını doldur."
 
-#: src/muuli_wdr.cpp:1705
+#: src/muuli_wdr.cpp:1712
 msgid ""
 "Completed downloads are stored here. All files in this folder are automatically shared with other peers.\n"
 "If this folder also holds files you don't want to share, point it at an aMule-only sub-folder."
@@ -4141,665 +4155,665 @@ msgstr ""
 "Tamamlanmış indirmeler burada muhafaza edilir. Bu dizindeki tüm dosyalar otomatik olarak diğer eşler ile paylaşılır.\n"
 "Şayet bu dizin paylaşmak istemediğiniz dosyalar da içeriyorsa, aMule'e özel bir alt dizini seçin."
 
-#: src/muuli_wdr.cpp:1708
+#: src/muuli_wdr.cpp:1715
 msgid "Pick the folder where completed downloads will be stored. All files in that folder will be shared with other peers."
 msgstr "Tamamlanmış indirmelerin muhafaza edilecekleri dizini seçin. Bu dizindeki tüm dosyalar diğer eşler ile paylaşılacaktır."
 
-#: src/muuli_wdr.cpp:1722
+#: src/muuli_wdr.cpp:1729
 msgid "Shared folders"
 msgstr "Paylaşılan dizinler"
 
-#: src/muuli_wdr.cpp:1728
+#: src/muuli_wdr.cpp:1735
 msgid "(Folders shared by the core. Enter a path to add one.)"
 msgstr "(Çekirdek tarafından paylaşılan dizinler. Bir dizin eklemek için yol ilave edin.)"
 
-#: src/muuli_wdr.cpp:1736
+#: src/muuli_wdr.cpp:1743
 msgid "Absolute path of a folder on the core's machine, e.g. /home/user/shared"
 msgstr "Çekirdeğin makinesinde bir dizinin mutlak yolu, mesela /home/rumuz/shared"
 
-#: src/muuli_wdr.cpp:1738 src/PrefsUnifiedDlg.cpp:2794
+#: src/muuli_wdr.cpp:1745 src/PrefsUnifiedDlg.cpp:2794
 msgid "Recursive"
 msgstr "Özyinelemeli"
 
-#: src/muuli_wdr.cpp:1739
+#: src/muuli_wdr.cpp:1746
 msgid "Share every sub-folder underneath this one, including ones created later."
 msgstr "Bunun altındaki tüm alt dizinleri paylaş, ki buna daha sonra oluşturulacak dizinler de dahildir."
 
-#: src/muuli_wdr.cpp:1743 src/utils/aLinkCreator/src/alcframe.cpp:141
+#: src/muuli_wdr.cpp:1750 src/utils/aLinkCreator/src/alcframe.cpp:141
 msgid "Remove"
 msgstr "Çıkar"
 
-#: src/muuli_wdr.cpp:1747
+#: src/muuli_wdr.cpp:1754
 msgid "(Right click on folder icon for recursive share)"
 msgstr "(Özyinelemeli paylaşım için dizin simgesine sağ tıklayınız.)"
 
-#: src/muuli_wdr.cpp:1754
+#: src/muuli_wdr.cpp:1761
 msgid "Share hidden files"
 msgstr "Gizli dosyaları paylaş"
 
-#: src/muuli_wdr.cpp:1760
+#: src/muuli_wdr.cpp:1767
 msgid "Automatically rescan shared folders for changes"
 msgstr "Paylaşılan dizinleri değişiklikler için otomatik olarak tekrar tara"
 
-#: src/muuli_wdr.cpp:1766
+#: src/muuli_wdr.cpp:1773
 msgid "Follow symbolic links in shared folders"
 msgstr "Paylaşılan dizinlerdeki simgesel bağlantıları takip et"
 
-#: src/muuli_wdr.cpp:1772
+#: src/muuli_wdr.cpp:1779
 msgid "Exclude files matching:"
 msgstr "Şununla eşleşen dosyaları dışla:"
 
-#: src/muuli_wdr.cpp:1775
+#: src/muuli_wdr.cpp:1782
 msgid "Wildcard patterns separated by '|', e.g. .DS_Store|Thumbs.db|*.tmp. Files whose name matches are not shared. Matching is case-insensitive."
 msgstr "'|' ile ayrılmış joker karakterli örüntüler (mesela .DS_Store|Thumbs.db|*.tmp). İsmi eşleşen dosyalar paylaşılmaz. Eşleştirme sırasında büyük/küçük harf ayrımı yapılmaz."
 
-#: src/muuli_wdr.cpp:1779
+#: src/muuli_wdr.cpp:1786
 msgid "Patterns are regular expressions"
 msgstr "Örüntüler düzenli ifadelerdir"
 
-#: src/muuli_wdr.cpp:1780
+#: src/muuli_wdr.cpp:1787
 msgid "When set, the whole field is one regular expression ('|' is alternation). When unset, it is a list of '|'-separated wildcards."
 msgstr "Etkinleştirildiğinde, tüm alan tek bir düzenli ifadedir ('|' alternatifler içindir). Devre dışı bırakıldığında, '|' ile ayrılmış jokerler listesidir."
 
-#: src/muuli_wdr.cpp:1790
+#: src/muuli_wdr.cpp:1797
 msgid "Show how many shared files the current pattern would exclude."
 msgstr "Güncel örüntünün kaç paylaşılan dosyayı dışlayacağını göster."
 
-#: src/muuli_wdr.cpp:1811
+#: src/muuli_wdr.cpp:1818
 msgid "Graphs"
 msgstr "Grafikler"
 
-#: src/muuli_wdr.cpp:1814 src/muuli_wdr.cpp:1876
+#: src/muuli_wdr.cpp:1821 src/muuli_wdr.cpp:1883
 msgid "Update delay : 5 secs"
 msgstr "Güncelleme gecikmesi: 5 sn"
 
-#: src/muuli_wdr.cpp:1818
+#: src/muuli_wdr.cpp:1825
 msgid "Time for average graph: 100 mins"
 msgstr "Ortalama grafiği için süre: 100 dk"
 
-#: src/muuli_wdr.cpp:1822
+#: src/muuli_wdr.cpp:1829
 msgid "Connections Graph Scale: 100 "
 msgstr "Bağlantı Grafik Ölçüsü: 100 "
 
-#: src/muuli_wdr.cpp:1829
+#: src/muuli_wdr.cpp:1836
 msgid "Download graph scale:"
 msgstr "İndirme grafik ölçüsü:"
 
-#: src/muuli_wdr.cpp:1837
+#: src/muuli_wdr.cpp:1844
 msgid "Upload graph scale:"
 msgstr "Gönderme grafik ölçüsü:"
 
-#: src/muuli_wdr.cpp:1847
+#: src/muuli_wdr.cpp:1854
 msgid "Colors: "
 msgstr "Renkler: "
 
-#: src/muuli_wdr.cpp:1851
+#: src/muuli_wdr.cpp:1858
 msgid "Background"
 msgstr "Arka plan"
 
-#: src/muuli_wdr.cpp:1852
+#: src/muuli_wdr.cpp:1859
 msgid "Grid"
 msgstr "Izgara"
 
-#: src/muuli_wdr.cpp:1853
+#: src/muuli_wdr.cpp:1860
 msgid "Download current"
 msgstr "Şu anki aktarımlar"
 
-#: src/muuli_wdr.cpp:1854
+#: src/muuli_wdr.cpp:1861
 msgid "Download running average"
 msgstr "Aktarım çalışma ortalaması"
 
-#: src/muuli_wdr.cpp:1855
+#: src/muuli_wdr.cpp:1862
 msgid "Download session average"
 msgstr "Aktarım oturum ortalaması"
 
-#: src/muuli_wdr.cpp:1856
+#: src/muuli_wdr.cpp:1863
 msgid "Upload current"
 msgstr "Şu anki gönderme"
 
-#: src/muuli_wdr.cpp:1857
+#: src/muuli_wdr.cpp:1864
 msgid "Upload running average"
 msgstr "Gönderme çalışma Ortalaması"
 
-#: src/muuli_wdr.cpp:1858
+#: src/muuli_wdr.cpp:1865
 msgid "Upload session average"
 msgstr "Gönderme oturum ortalaması"
 
-#: src/muuli_wdr.cpp:1859
+#: src/muuli_wdr.cpp:1866
 msgid "Active connections"
 msgstr "Aktif bağlantılar"
 
-#: src/muuli_wdr.cpp:1862
+#: src/muuli_wdr.cpp:1869
 msgid "Systray Icon Speed Bar"
 msgstr "Sistem Tepsisi İkonu Hız Göstergesi"
 
-#: src/muuli_wdr.cpp:1863
+#: src/muuli_wdr.cpp:1870
 msgid "Kad-nodes current"
 msgstr "Şu anki Kad düğümleri"
 
-#: src/muuli_wdr.cpp:1864
+#: src/muuli_wdr.cpp:1871
 msgid "Kad-nodes running"
 msgstr "İşlemdeki Kad-düğümleri"
 
-#: src/muuli_wdr.cpp:1865
+#: src/muuli_wdr.cpp:1872
 msgid "Kad-nodes session"
 msgstr "Oturumdaki Kad-düğümleri"
 
-#: src/muuli_wdr.cpp:1869 src/muuli_wdr.cpp:2296
+#: src/muuli_wdr.cpp:1876 src/muuli_wdr.cpp:2303
 msgid "Select"
 msgstr "Seçiniz"
 
-#: src/muuli_wdr.cpp:1873
+#: src/muuli_wdr.cpp:1880
 msgid "Tree"
 msgstr "Ağaç"
 
-#: src/muuli_wdr.cpp:1883
+#: src/muuli_wdr.cpp:1890
 msgid "Number of Client Versions shown (0=unlimited)"
 msgstr "Gösterilen Yazılım Sürümü Sayısı (0=sınırsız)"
 
-#: src/muuli_wdr.cpp:1908
+#: src/muuli_wdr.cpp:1915
 msgid "!!! WARNING !!!"
 msgstr "!!! UYARI !!!"
 
-#: src/muuli_wdr.cpp:1923
+#: src/muuli_wdr.cpp:1930
 msgid "Max new connections / 5 secs"
 msgstr "En fazla yeni bağlantı / 5 sn"
 
-#: src/muuli_wdr.cpp:1925
+#: src/muuli_wdr.cpp:1932
 msgid "Concurrent Kad source lookups"
 msgstr "Eşzamanlı Kad kaynak aramaları"
 
-#: src/muuli_wdr.cpp:1927
+#: src/muuli_wdr.cpp:1934
 msgid "Kad source re-search interval (minutes)"
 msgstr "Kad kaynak tekrar arama zaman aralığı (dakika)"
 
-#: src/muuli_wdr.cpp:1929
+#: src/muuli_wdr.cpp:1936
 msgid "Source re-ask interval (minutes)"
 msgstr "Kaynaklara tekrar sorma zaman aralığı (dakika)"
 
-#: src/muuli_wdr.cpp:1933
+#: src/muuli_wdr.cpp:1940
 msgid "File Buffer Size: 240000 bytes"
 msgstr "Dosya Tampon Boyutu: 240000 bayt"
 
-#: src/muuli_wdr.cpp:1937
+#: src/muuli_wdr.cpp:1944
 msgid "Use MMAP: memory-mapped file access (lower memory use)"
 msgstr "MMAP kullan: \"memory-mapped file access\" yani bellek eşlemeli dosya erişimi (daha az bellek kullanır)"
 
-#: src/muuli_wdr.cpp:1938
+#: src/muuli_wdr.cpp:1945
 msgid "Maps part files into memory instead of buffering them on the heap, lowering the process memory footprint. May reduce download speed on some disks; best for memory-constrained or upload-heavy hosts."
 msgstr "Yığın üzerinde tampona almak yerine kısmi dosyaları bellekte eşleştirir, böylece sürecin bellek ayak izini azaltır. Bazı disklerde indirme hızını düşürebilir; belleği sınırlı veya çok fazla gönderide bulunan makineler için idealdir."
 
-#: src/muuli_wdr.cpp:1940
+#: src/muuli_wdr.cpp:1947
 msgid "Upload Queue Size: 5000 clients"
 msgstr "Gönderme Sıra Boyutu: 5000 kullanıcı"
 
-#: src/muuli_wdr.cpp:1944
+#: src/muuli_wdr.cpp:1951
 msgid "Server connection refresh interval: Disable"
 msgstr "Sunucu bağlantısı yenileme sıklığı: devre dışı"
 
-#: src/muuli_wdr.cpp:1948
+#: src/muuli_wdr.cpp:1955
 msgid "Disable computer's timed standby mode"
 msgstr "Bilgisayarın devre dışı kalma kipini etkisiz hale getir"
 
-#: src/muuli_wdr.cpp:1967
+#: src/muuli_wdr.cpp:1974
 msgid "Skin to use: "
 msgstr "Kullanılacak kaplama: "
 
-#: src/muuli_wdr.cpp:1976
+#: src/muuli_wdr.cpp:1983
 msgid "Show \"Fast eD2k Links Handler\" in every window."
 msgstr "\"Hızlı eD2k Bağlantı Yakalayıcısı\"nı her pencerede göster.."
 
-#: src/muuli_wdr.cpp:1979
+#: src/muuli_wdr.cpp:1986
 msgid "Show extended info on categories tabs"
 msgstr "Sınıf sekmelerinde genişletilmiş bilgi göster."
 
-#: src/muuli_wdr.cpp:1982
+#: src/muuli_wdr.cpp:1989
 msgid "Show application version on title"
 msgstr "Başlık çubuğunda uygulama sürümünü göster"
 
-#: src/muuli_wdr.cpp:1984
+#: src/muuli_wdr.cpp:1991
 msgid "Show transfer rates on title"
 msgstr "Başlık çubuğunda aktarım oranlarını göster."
 
-#: src/muuli_wdr.cpp:1986
+#: src/muuli_wdr.cpp:1993
 msgid "Before application name"
 msgstr "Uygulama adından önce"
 
-#: src/muuli_wdr.cpp:1988
+#: src/muuli_wdr.cpp:1995
 msgid "After application name"
 msgstr "Uygulama adından sonra"
 
-#: src/muuli_wdr.cpp:1991
+#: src/muuli_wdr.cpp:1998
 msgid "Show overhead bandwidth"
 msgstr "Ek yük ağ genişliğini göster"
 
-#: src/muuli_wdr.cpp:1995
+#: src/muuli_wdr.cpp:2002
 msgid "Vertical toolbar orientation"
 msgstr "Dikey araç çubuğu yerleşimi"
 
-#: src/muuli_wdr.cpp:1997
+#: src/muuli_wdr.cpp:2004
 msgid "Live column sorting (auto-reorder rows as their values change)"
 msgstr "Naklen sütun düzenleme (değerleri değiştikçe satırları otomatik olarak tekrar sırala)"
 
-#: src/muuli_wdr.cpp:2004
+#: src/muuli_wdr.cpp:2011
 msgid "Download Queue Files"
 msgstr "Sıradaki Dosyaları İndir"
 
-#: src/muuli_wdr.cpp:2007
+#: src/muuli_wdr.cpp:2014
 msgid "Show progress percentage"
 msgstr "İşlem yüzdesini göster"
 
-#: src/muuli_wdr.cpp:2013
+#: src/muuli_wdr.cpp:2020
 msgid "Show progress bar"
 msgstr "İşlem çubuğunu göster"
 
-#: src/muuli_wdr.cpp:2016
+#: src/muuli_wdr.cpp:2023
 msgid "Flat"
 msgstr "Düz"
 
-#: src/muuli_wdr.cpp:2020
+#: src/muuli_wdr.cpp:2027
 msgid "Round"
 msgstr "Yuvarlatılmış"
 
-#: src/muuli_wdr.cpp:2038
+#: src/muuli_wdr.cpp:2045
 msgid "External Connection Parameters"
 msgstr "Dışarıdan Bağlantı Parametreleri"
 
-#: src/muuli_wdr.cpp:2041
+#: src/muuli_wdr.cpp:2048
 msgid "Accept external connections"
 msgstr "Dışarıdan bağlantıları kabul et."
 
-#: src/muuli_wdr.cpp:2048 src/muuli_wdr.cpp:2107
+#: src/muuli_wdr.cpp:2055 src/muuli_wdr.cpp:2114
 msgid "IP of the listening interface:"
 msgstr "Dinlenen arayüzün IP' si:"
 
-#: src/muuli_wdr.cpp:2051
+#: src/muuli_wdr.cpp:2058
 msgid "Enter here a valid ip in the a.b.c.d format for the listening EC interface. An empty field or 0.0.0.0 will mean any interface."
 msgstr "Dinleme EC arayüzü için a.b.c.d biçiminde geçerli bir ip giriniz. Boş bırakılan alan veya 0.0.0.0 arayüz yok demektir."
 
-#: src/muuli_wdr.cpp:2072 src/muuli_wdr.cpp:2156
+#: src/muuli_wdr.cpp:2079 src/muuli_wdr.cpp:2163
 msgid "TCP port:"
 msgstr "TCP portu:"
 
-#: src/muuli_wdr.cpp:2078
+#: src/muuli_wdr.cpp:2085
 msgid "Enable UPnP port forwarding on the EC port"
 msgstr "EC portuna UPnP port yönlendirmesi etkin."
 
-#: src/muuli_wdr.cpp:2082 src/muuli_wdr.cpp:3041
+#: src/muuli_wdr.cpp:2089 src/muuli_wdr.cpp:3048
 #: src/utils/wxCas/src/wxcasprefs.cpp:167
 msgid "Password"
 msgstr "Şifre"
 
-#: src/muuli_wdr.cpp:2088
+#: src/muuli_wdr.cpp:2095
 msgid "aMule API server parameters"
 msgstr "aMule API sunucusu parametreleri"
 
-#: src/muuli_wdr.cpp:2091
+#: src/muuli_wdr.cpp:2098
 msgid "Run amuleapi (REST API) on startup"
 msgstr "Başlangıçta amuleapi (REST API) çalıştır"
 
-#: src/muuli_wdr.cpp:2096
+#: src/muuli_wdr.cpp:2103
 msgid "HTTP port:"
 msgstr "HTTP bağlantı noktası:"
 
-#: src/muuli_wdr.cpp:2110
+#: src/muuli_wdr.cpp:2117
 msgid "The interface amuleapi's HTTP server listens on. 127.0.0.1 (default) accepts only local connections; use 0.0.0.0 or a specific IP to expose it to other hosts (set an admin password below)."
 msgstr "amuleapi HTTP sunucusunun dinlediği arayüz. 127.0.0.1 (varsayılan) sadece yerel bağlantıları kabul eder; onu başka makinelere açmak için 0.0.0.0 veya belirli bir IP kullanın (aşağıda bir yönetici parolası tanımlayın)."
 
-#: src/muuli_wdr.cpp:2113
+#: src/muuli_wdr.cpp:2120
 msgid "Admin password"
 msgstr "Yönetici parolası"
 
-#: src/muuli_wdr.cpp:2118 src/muuli_wdr.cpp:2149
+#: src/muuli_wdr.cpp:2125 src/muuli_wdr.cpp:2156
 msgid "Low rights password"
 msgstr "Düşük hak şifresi"
 
-#: src/muuli_wdr.cpp:2126
+#: src/muuli_wdr.cpp:2133
 msgid "Web server parameters"
 msgstr "Web sunucusu değerleri"
 
-#: src/muuli_wdr.cpp:2129
+#: src/muuli_wdr.cpp:2136
 msgid "Run webserver on startup (deprecated)"
 msgstr "Başlangıçta web sunucusunu başlat (eskimiş)"
 
-#: src/muuli_wdr.cpp:2135
+#: src/muuli_wdr.cpp:2142
 msgid "Web template"
 msgstr "Web şablonu"
 
-#: src/muuli_wdr.cpp:2140
+#: src/muuli_wdr.cpp:2147
 msgid "Full rights password"
 msgstr "Tam hak şifresi"
 
-#: src/muuli_wdr.cpp:2144
+#: src/muuli_wdr.cpp:2151
 msgid "Enable Low rights User"
 msgstr "Düşük hakka sahip kullanıcıyı etkin kıl."
 
-#: src/muuli_wdr.cpp:2163
+#: src/muuli_wdr.cpp:2170
 msgid "Enable UPnP port forwarding of the web server port"
 msgstr "Web sunucu portunun UPnp port iletimini etkinleştir"
 
-#: src/muuli_wdr.cpp:2168
+#: src/muuli_wdr.cpp:2175
 msgid "Web server UPnP TCP port (Optional)"
 msgstr "Web sunucusu UPnp TCP portu (İsteğe bağlı)"
 
-#: src/muuli_wdr.cpp:2176
+#: src/muuli_wdr.cpp:2183
 msgid "Page Refresh Time (in secs)"
 msgstr "Sayfa yenileme zamanı (sn)"
 
-#: src/muuli_wdr.cpp:2183
+#: src/muuli_wdr.cpp:2190
 msgid "Enable Gzip compression"
 msgstr "Gzip sıkıştırmayı etkinleştir."
 
-#: src/muuli_wdr.cpp:2217
+#: src/muuli_wdr.cpp:2224
 msgid "Reset page to defaults"
 msgstr "Sayfayı varsayılan değerlere sıfırla"
 
-#: src/muuli_wdr.cpp:2218
+#: src/muuli_wdr.cpp:2225
 msgid "Reset the settings on the current page to their default values."
 msgstr "Güncel sayfadaki ayarları varsayılan değerlerine sıfırla."
 
-#: src/muuli_wdr.cpp:2220 src/muuli_wdr.cpp:2306 src/ServerWnd.cpp:274
+#: src/muuli_wdr.cpp:2227 src/muuli_wdr.cpp:2313 src/ServerWnd.cpp:274
 #: src/ServerWnd.cpp:282
 msgid "OK"
 msgstr "Tamam"
 
-#: src/muuli_wdr.cpp:2222
+#: src/muuli_wdr.cpp:2229
 msgid "Click here to apply any changes made to the preferences."
 msgstr "Ayarlarda yapılan değişikliklerin uygulanması için buraya tıklayınız."
 
-#: src/muuli_wdr.cpp:2225
+#: src/muuli_wdr.cpp:2232
 msgid "Reset any changes made to the preferences."
 msgstr "Ayarlarda yapılan değişiklikleri sil."
 
-#: src/muuli_wdr.cpp:2254
+#: src/muuli_wdr.cpp:2261
 msgid "Comment :"
 msgstr "Yorum:"
 
-#: src/muuli_wdr.cpp:2261
+#: src/muuli_wdr.cpp:2268
 msgid "Incoming Dir :"
 msgstr "Gelen Dosyalar Dizini :"
 
-#: src/muuli_wdr.cpp:2270
+#: src/muuli_wdr.cpp:2277
 msgid "Change priority for new assigned files :"
 msgstr "Yeni eklenen dosyalar için öncelikleri değiştir:"
 
-#: src/muuli_wdr.cpp:2274
+#: src/muuli_wdr.cpp:2281
 msgid "Don't change"
 msgstr "Değiştirme"
 
-#: src/muuli_wdr.cpp:2286
+#: src/muuli_wdr.cpp:2293
 msgid "Select color for this Category (currently selected) :"
 msgstr "Bu sınıf için renk seçiniz (varsayılan) :"
 
-#: src/muuli_wdr.cpp:2353 src/muuli_wdr.cpp:2372 src/muuli_wdr.cpp:2394
+#: src/muuli_wdr.cpp:2360 src/muuli_wdr.cpp:2379 src/muuli_wdr.cpp:2401
 msgid "Click this button to reset the log."
 msgstr "Günlük kayıtlarını silmek için bu düğmeye basınız."
 
-#: src/muuli_wdr.cpp:2413
+#: src/muuli_wdr.cpp:2420
 msgid "Click on this button to update the servers list from URL ..."
 msgstr "Sunucu listesini İnternet'den güncellemek için bu düğmeye basınız…"
 
-#: src/muuli_wdr.cpp:2417
+#: src/muuli_wdr.cpp:2424
 msgid "Server list"
 msgstr "Sunucu"
 
-#: src/muuli_wdr.cpp:2421
+#: src/muuli_wdr.cpp:2428
 msgid "Enter the url to a server.met file here and press the button to the left to update the list of known servers."
 msgstr "Adresi server.met dosyasına buradan giriniz. Sonra, bilinen sunucuları güncellemek için soldaki düğmeye tıklayınız."
 
-#: src/muuli_wdr.cpp:2426
+#: src/muuli_wdr.cpp:2433
 msgid "Add server manually: Name"
 msgstr "Sunucuyu elle ekle: İsim"
 
-#: src/muuli_wdr.cpp:2429
+#: src/muuli_wdr.cpp:2436
 msgid "Enter the name of the new server here"
 msgstr "Yeni sunucunun adını buraya giriniz."
 
-#: src/muuli_wdr.cpp:2431 src/ServerWnd.cpp:206
+#: src/muuli_wdr.cpp:2438 src/ServerWnd.cpp:206
 msgid "IP:Port"
 msgstr "IP:Port"
 
-#: src/muuli_wdr.cpp:2434
+#: src/muuli_wdr.cpp:2441
 msgid "Enter the IP of the server here, using the x.x.x.x format."
 msgstr "Yeni sunucun IP numarasını x.x.x.x biçiminde buraya giriniz."
 
-#: src/muuli_wdr.cpp:2440
+#: src/muuli_wdr.cpp:2447
 msgid "Enter the port of the server here."
 msgstr "Sunucunu portunu buraya giriniz."
 
-#: src/muuli_wdr.cpp:2443
+#: src/muuli_wdr.cpp:2450
 msgid "Add manually a server (fill fields to the left before) ..."
 msgstr "Sunucuyu elle ekle (önce soldaki alanları doldurunuz) …"
 
-#: src/muuli_wdr.cpp:2472
+#: src/muuli_wdr.cpp:2479
 msgid "aMule Log"
 msgstr "aMule Günlüğü"
 
-#: src/muuli_wdr.cpp:2480
+#: src/muuli_wdr.cpp:2487
 msgid "Server Info"
 msgstr "Sunucu Bilgisi"
 
-#: src/muuli_wdr.cpp:2484
+#: src/muuli_wdr.cpp:2491
 msgid "ED2K Info"
 msgstr "ED2K Bilgileri"
 
-#: src/muuli_wdr.cpp:2488
+#: src/muuli_wdr.cpp:2495
 msgid "Kad Info"
 msgstr "Kademlia Bilgileri"
 
-#: src/muuli_wdr.cpp:2516
+#: src/muuli_wdr.cpp:2523
 msgid "Click on this button to update the nodes list from URL ..."
 msgstr "Düğüm listesini İnternet'den güncellemek için bu düğmeye tıklayınız."
 
-#: src/muuli_wdr.cpp:2520
+#: src/muuli_wdr.cpp:2527
 msgid "Nodes (0)"
 msgstr "Düğümler (0)"
 
-#: src/muuli_wdr.cpp:2524
+#: src/muuli_wdr.cpp:2531
 msgid "Enter the url to a nodes.dat file here and press the button to the left to update the list of known nodes."
 msgstr "Bilinen düğümleri güncellemek için buraya adresi giriniz ve soldaki düğmeye tıklayınız."
 
-#: src/muuli_wdr.cpp:2527
+#: src/muuli_wdr.cpp:2534
 msgid "Nodes stats"
 msgstr "Düğüm istatistikleri"
 
-#: src/muuli_wdr.cpp:2569
+#: src/muuli_wdr.cpp:2576
 msgid "Bootstrap"
 msgstr "Ön Yükleme"
 
-#: src/muuli_wdr.cpp:2572
+#: src/muuli_wdr.cpp:2579
 msgid "New node"
 msgstr "Yeni düğüm"
 
-#: src/muuli_wdr.cpp:2577
+#: src/muuli_wdr.cpp:2584
 msgid "IP:"
 msgstr "IP:"
 
-#: src/muuli_wdr.cpp:2597
+#: src/muuli_wdr.cpp:2604
 msgid "Port:"
 msgstr "Port:"
 
-#: src/muuli_wdr.cpp:2610
+#: src/muuli_wdr.cpp:2617
 msgid "Bootstrap from known clients"
 msgstr "Bilinen kullanıcılardan Ön Yükleme"
 
-#: src/muuli_wdr.cpp:2612
+#: src/muuli_wdr.cpp:2619
 msgid "Disconnect Kad"
 msgstr "Kad Bağlantısını Kes"
 
-#: src/muuli_wdr.cpp:2646
+#: src/muuli_wdr.cpp:2653
 msgid "Use Secure User Identification"
 msgstr "Güvenli Kullanıcı Kimlik Doğrulamasını Kullan"
 
-#: src/muuli_wdr.cpp:2648
+#: src/muuli_wdr.cpp:2655
 msgid "It is recommended to enable this option. You will not receive credits if SUI is not enabled."
 msgstr "Bu seçeneği aktifleştirmeniz önerilir. SUI aktif değilse, kredi alamazsınız."
 
-#: src/muuli_wdr.cpp:2650
+#: src/muuli_wdr.cpp:2657
 msgid "Protocol Obfuscation"
 msgstr "Protokol Gizleme"
 
-#: src/muuli_wdr.cpp:2653
+#: src/muuli_wdr.cpp:2660
 msgid "Support Protocol Obfuscation"
 msgstr "Protokol Gizleme etkin"
 
-#: src/muuli_wdr.cpp:2655
+#: src/muuli_wdr.cpp:2662
 msgid "This option enabled Protocol Obfuscation, and makes aMule accept obfuscated connections from other clients."
 msgstr "Bu seçenek Protokol Gizleme'yi etkinleştirir ve aMule'nin gizlenmiş bağlantıları kabul etmesini sağlar."
 
-#: src/muuli_wdr.cpp:2657
+#: src/muuli_wdr.cpp:2664
 msgid "Use obfuscation for outgoing connections"
 msgstr "Giden bağlantılar için gizleme kullan"
 
-#: src/muuli_wdr.cpp:2659
+#: src/muuli_wdr.cpp:2666
 msgid "This option makes aMule use Protocol Obfuscation when connecting other clients/servers."
 msgstr "Bu seçenek diğer kullanıcı veya sunucularla olan bağlantılarda Protokol Gizleme'yi etkinleştirir."
 
-#: src/muuli_wdr.cpp:2661
+#: src/muuli_wdr.cpp:2668
 msgid "Accept only obfuscated connections"
 msgstr "Sadece gizlenmiş bağlantıları kabul et"
 
-#: src/muuli_wdr.cpp:2662
+#: src/muuli_wdr.cpp:2669
 msgid "This option makes aMule only accept obfuscated connections. You will have less sources, but all your traffic will be obfuscated"
 msgstr "Bu seçenek aMule'nin sadece gizlenmiş bağlantıları kabul etmesini sağlar. Daha az kaynak bulursunuz; ancak tüm trafiğiniz de karartılmış olur."
 
-#: src/muuli_wdr.cpp:2667
+#: src/muuli_wdr.cpp:2674
 msgid "Everybody"
 msgstr "Herkes"
 
-#: src/muuli_wdr.cpp:2669
+#: src/muuli_wdr.cpp:2676
 msgid "No one"
 msgstr "Hiç kimse"
 
-#: src/muuli_wdr.cpp:2671
+#: src/muuli_wdr.cpp:2678
 msgid "Who can see my shared files:"
 msgstr "Paylaşılan dosyalarımı kim görebilir:"
 
-#: src/muuli_wdr.cpp:2672
+#: src/muuli_wdr.cpp:2679
 msgid "Select who can request to view a list of your shared files."
 msgstr "Paylaşılan dosyalarınızı kime göstereceğinizi seçiniz."
 
-#: src/muuli_wdr.cpp:2674
+#: src/muuli_wdr.cpp:2681
 msgid "IP-Filtering"
 msgstr "IP_Süzme"
 
-#: src/muuli_wdr.cpp:2681
+#: src/muuli_wdr.cpp:2688
 msgid "Filter clients"
 msgstr "Kullanıcıları Süz"
 
-#: src/muuli_wdr.cpp:2683
+#: src/muuli_wdr.cpp:2690
 msgid "Enable filtering of the client IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "~/.aMule/ipfilter.dat dosyasında tanımlanan kullanıcı IP'lerini süzmeyi etkinleştir."
 
-#: src/muuli_wdr.cpp:2685
+#: src/muuli_wdr.cpp:2692
 msgid "Filter servers"
 msgstr "Sunucuları süz"
 
-#: src/muuli_wdr.cpp:2687
+#: src/muuli_wdr.cpp:2694
 msgid "Enable filtering of the server IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "~/.aMule/ipfilter.dat dosyasında tanımlanan sunucu IP'lerini süzmeyi etkinleştir."
 
-#: src/muuli_wdr.cpp:2691
+#: src/muuli_wdr.cpp:2698
 msgid "Reload List"
 msgstr "Listeyi yeniden yükle"
 
-#: src/muuli_wdr.cpp:2692
+#: src/muuli_wdr.cpp:2699
 msgid "Reload the list of IPs to filter from the file ~/.aMule/ipfilter.dat"
 msgstr "~/.aMule/ipfilter.dat dosyasından IP'leri süzgece yeniden yükle."
 
-#: src/muuli_wdr.cpp:2698
+#: src/muuli_wdr.cpp:2705
 msgid "URL:"
 msgstr "Adres:"
 
-#: src/muuli_wdr.cpp:2702 src/muuli_wdr.cpp:2895
+#: src/muuli_wdr.cpp:2709 src/muuli_wdr.cpp:2902
 msgid "Update now"
 msgstr "Şimdi güncelle"
 
-#: src/muuli_wdr.cpp:2705
+#: src/muuli_wdr.cpp:2712
 msgid "Auto-update ipfilter at startup"
 msgstr "Ip süzgecini başlangıçta otomatikman güncelle."
 
-#: src/muuli_wdr.cpp:2709
+#: src/muuli_wdr.cpp:2716
 msgid "Filtering Level:"
 msgstr "Süzme Seviyesi:"
 
-#: src/muuli_wdr.cpp:2715
+#: src/muuli_wdr.cpp:2722
 msgid "Always filter LAN IPs"
 msgstr "Her zaman LAN IP'lerini süz."
 
-#: src/muuli_wdr.cpp:2718
+#: src/muuli_wdr.cpp:2725
 msgid "Paranoid handling of non-matching IPs"
 msgstr "Uyuşmayan IP'lere şüpheci yaklaşım."
 
-#: src/muuli_wdr.cpp:2720
+#: src/muuli_wdr.cpp:2727
 msgid "Rejects a packet when its source IP differs from the IP the client claims (an anti-spoofing check). Disable only if it causes connection problems."
 msgstr "İstemcinin sahip olduğunu iddia ettiği IP, kaynak IP'den farklı olduğunda paketi reddeder (sahtekarlık önleyici kontrol). Sadece bağlantı sorunları oluşturuyorsa devre dışı bırakın."
 
-#: src/muuli_wdr.cpp:2722
+#: src/muuli_wdr.cpp:2729
 msgid "Use system-wide ipfilter.dat if available"
 msgstr "Varsa, sistem geneli ipfilter.dat kullan"
 
-#: src/muuli_wdr.cpp:2723
+#: src/muuli_wdr.cpp:2730
 msgid "If there's no local ipfilter.dat found, allow usage of a system-wide ipfilter file."
 msgstr "Yerel bir ipfilter.dat dosyası bulunamazsa, sistem geneli ipfilter kullanımına izin ver."
 
-#: src/muuli_wdr.cpp:2740
+#: src/muuli_wdr.cpp:2747
 msgid "Enable Online-Signature"
 msgstr "Çevrimiçi-İmza' yı Etkinleştir"
 
-#: src/muuli_wdr.cpp:2742
+#: src/muuli_wdr.cpp:2749
 msgid "Enables the writing of the OS file, which can be used by external apps to create signatures and the like."
 msgstr "Diğer uygulamaların imzalar ve benzerlerini oluşturabilmesi için kullanabileceği Çev.İmza dosyasını yazmayı etkinleştirir."
 
-#: src/muuli_wdr.cpp:2746
+#: src/muuli_wdr.cpp:2753
 msgid "Update Frequency (Secs):"
 msgstr "Güncelleme Sıklığı (Sn.):"
 
-#: src/muuli_wdr.cpp:2749
+#: src/muuli_wdr.cpp:2756
 msgid "Change the frequency (in seconds) of Online Signature updates."
 msgstr "Çevrim içi İmza güncellemeleri için (saniye bazında) sıklığı değiştirir."
 
-#: src/muuli_wdr.cpp:2757
+#: src/muuli_wdr.cpp:2764
 msgid "Save online signature file in: "
 msgstr "Çevrim içi imza dosyasını buraya sakla: "
 
-#: src/muuli_wdr.cpp:2763
+#: src/muuli_wdr.cpp:2770
 msgid "Click here to select the directory containing the the Online Signature files."
 msgstr "Çevrim içi İmza dosyalarını içeren dizini seçiniz."
 
-#: src/muuli_wdr.cpp:2796
+#: src/muuli_wdr.cpp:2803
 msgid "Show country flags for clients"
 msgstr "İstemciler için ülke bayraklarını göster"
 
-#: src/muuli_wdr.cpp:2797
+#: src/muuli_wdr.cpp:2804
 msgid "Render the country flag column in the transfers, queue and search views. Requires a valid MMDB GeoIP database (see below)."
 msgstr "Transferler, kuyruklar ve arama görünümlerinde ülkelerin bayrakları sütununu görüntüle. Geçerli bir MMDB GeoIP veri tabanı gerektirir (aşağıya bakınız)."
 
-#: src/muuli_wdr.cpp:2802
+#: src/muuli_wdr.cpp:2809
 msgid "Database"
 msgstr "Veri Tabanı"
 
-#: src/muuli_wdr.cpp:2818
+#: src/muuli_wdr.cpp:2825
 msgid "Source:"
 msgstr "Kaynak:"
 
-#: src/muuli_wdr.cpp:2821
+#: src/muuli_wdr.cpp:2828
 msgid "DB-IP (free, no account)"
 msgstr "DB-IP (ücretsiz, hesap gerektirmez)"
 
-#: src/muuli_wdr.cpp:2822
+#: src/muuli_wdr.cpp:2829
 msgid "MaxMind GeoLite2 (free, account required)"
 msgstr "MaxMind GeoLite2 (ücretsiz, hesap gerektirir)"
 
-#: src/muuli_wdr.cpp:2823
+#: src/muuli_wdr.cpp:2830
 msgid "Custom URL"
 msgstr "Kişiselleştirilmiş URL"
 
-#: src/muuli_wdr.cpp:2826
+#: src/muuli_wdr.cpp:2833
 msgid "Choose which provider supplies the GeoIP MMDB database. DB-IP is the default - no account required. MaxMind requires a free account + license key. Use Custom URL to point at any other MMDB host (e.g. a local mirror)."
 msgstr "Hangi tedarikçinin GeoIP MMDB veri tabanını sağlayacağını seçin. DB-IP varsayılan değerdir - hesap gerektirmez. MaxMind ücretsiz bir hesap + lisans anahtarı gerektirir. Herhangi başka bir MMDB makinesine (mesela yerel bir yansıya) yönlendirme yapmak için kişiselleştirilmiş URL kullanın."
 
-#: src/muuli_wdr.cpp:2843
+#: src/muuli_wdr.cpp:2850
 msgid ""
 "No configuration required.\n"
 "\n"
@@ -4811,11 +4825,11 @@ msgstr ""
 "IP-Ülke verileri DB-IP.com tarafından sağlanmaktadır - https://db-ip.com\n"
 "Lisans: Creative Commons Atıf 4.0 - https://creativecommons.org/licenses/by/4.0/deed.tr"
 
-#: src/muuli_wdr.cpp:2856
+#: src/muuli_wdr.cpp:2863
 msgid "License key:"
 msgstr "Lisans anahtarı:"
 
-#: src/muuli_wdr.cpp:2862
+#: src/muuli_wdr.cpp:2869
 msgid ""
 "Sign up for a free MaxMind account, then generate a License Key:\n"
 "https://www.maxmind.com/en/geolite2/signup\n"
@@ -4831,11 +4845,11 @@ msgstr ""
 "Lisans: MaxMind GeoLite2 Kullanıcı Lisans Anlaşması - https://www.maxmind.com/en/geolite2/eula\n"
 "Atıf ve hesap oluşturulması gerektirir; en az her 30 günde bir güncelleyin."
 
-#: src/muuli_wdr.cpp:2877
+#: src/muuli_wdr.cpp:2884
 msgid "Download URL:"
 msgstr "İndirme Bağlantısı:"
 
-#: src/muuli_wdr.cpp:2883
+#: src/muuli_wdr.cpp:2890
 msgid ""
 "Must point to an .mmdb file or a .gz / .tar.gz containing one.\n"
 "URL may include credentials (https://user:pass@host/...).\n"
@@ -4845,211 +4859,211 @@ msgstr ""
 "Bağlantı kimlik doğrulama bilgileri içerebilir (https://kullanıcı:parola@makine/…)\n"
 "Lisans ve atıf koşulları kaynak URL tarafından belirlenir - bunlardan siz sorumlu olursunuz."
 
-#: src/muuli_wdr.cpp:2896
+#: src/muuli_wdr.cpp:2903
 msgid "Download the GeoIP database from the selected source."
 msgstr "Seçili kaynaktan GeoIP veri tabanını indir."
 
-#: src/muuli_wdr.cpp:2898
+#: src/muuli_wdr.cpp:2905
 msgid "Auto-update on startup"
 msgstr "Başlangıçta otomatik olarak güncelle"
 
-#: src/muuli_wdr.cpp:2899
+#: src/muuli_wdr.cpp:2906
 msgid "Re-download the GeoIP database from the selected source every time aMule starts."
 msgstr "aMule her başladığında, GeoIP veri tabanını seçili kaynaktan tekrar indir."
 
-#: src/muuli_wdr.cpp:2922
+#: src/muuli_wdr.cpp:2929
 msgid "Filter incoming messages (except current chat):"
 msgstr "Gelen iletileri süz (o anki sohbet dışında):"
 
-#: src/muuli_wdr.cpp:2924
+#: src/muuli_wdr.cpp:2931
 msgid "Filter all messages"
 msgstr "Hepsini süz."
 
-#: src/muuli_wdr.cpp:2926
+#: src/muuli_wdr.cpp:2933
 msgid "Filter messages from people not on your friend list"
 msgstr "Arkadaş listesindekiler dışında herkesi süz."
 
-#: src/muuli_wdr.cpp:2928
+#: src/muuli_wdr.cpp:2935
 msgid "Filter messages from unknown clients"
 msgstr "Bilinmeyen yazılımlardan gelenleri süz."
 
-#: src/muuli_wdr.cpp:2930
+#: src/muuli_wdr.cpp:2937
 msgid "Filter messages containing (use ',' as separator):"
 msgstr "Şu içerikteki iletileri süz (ayraç olarak ',' kullanınız.):"
 
-#: src/muuli_wdr.cpp:2933 src/muuli_wdr.cpp:2944
+#: src/muuli_wdr.cpp:2940 src/muuli_wdr.cpp:2951
 msgid "add here the words amule should filter and block messages including it"
 msgstr "buraya ekleyeceğiniz sözcükleri içeren iletiler aMule tarafından engellenir."
 
-#: src/muuli_wdr.cpp:2935
+#: src/muuli_wdr.cpp:2942
 msgid "Show received messages in the log"
 msgstr "Günlükte alınan iletileri göster"
 
-#: src/muuli_wdr.cpp:2938
+#: src/muuli_wdr.cpp:2945
 msgid "Comments"
 msgstr "Yorumlar"
 
-#: src/muuli_wdr.cpp:2941
+#: src/muuli_wdr.cpp:2948
 msgid "Filter comments containing (use ',' as separator):"
 msgstr "Şu içerikteki iletileri süz (ayraç olarak ',' kullanınız.):"
 
-#: src/muuli_wdr.cpp:2966
+#: src/muuli_wdr.cpp:2973
 msgid "Enable Proxy"
 msgstr "Vekil sunucuyu Etkinleştir."
 
-#: src/muuli_wdr.cpp:2967
+#: src/muuli_wdr.cpp:2974
 msgid "Enable/disable proxy support"
 msgstr "Vekil sunucu desteğini etkinleştir/devre dışı bırak"
 
-#: src/muuli_wdr.cpp:2970
+#: src/muuli_wdr.cpp:2977
 msgid "Proxy type:"
 msgstr "Vekil sunucu Türü:"
 
-#: src/muuli_wdr.cpp:2981
+#: src/muuli_wdr.cpp:2988
 msgid "Proxy host:"
 msgstr "Vekil sunucu makine:"
 
-#: src/muuli_wdr.cpp:2984
+#: src/muuli_wdr.cpp:2991
 msgid "The proxy host name"
 msgstr "Vekil sunucu makine adı"
 
-#: src/muuli_wdr.cpp:2986
+#: src/muuli_wdr.cpp:2993
 msgid "Proxy port:"
 msgstr "Vekil sunucu Portu:"
 
-#: src/muuli_wdr.cpp:2989
+#: src/muuli_wdr.cpp:2996
 msgid "The proxy port"
 msgstr "Vekil sunucu portu"
 
-#: src/muuli_wdr.cpp:2991
+#: src/muuli_wdr.cpp:2998
 msgid "Enable authentication"
 msgstr "Yetkilendirmeyi etkinleştir."
 
-#: src/muuli_wdr.cpp:2992
+#: src/muuli_wdr.cpp:2999
 msgid "Enable/disable username/password authentication"
 msgstr "Kullanıcı adı/şifre yetkilendirmeyi etkinleştir/devre dışı bırak."
 
-#: src/muuli_wdr.cpp:2995
+#: src/muuli_wdr.cpp:3002
 msgid "Username: "
 msgstr "Kullanıcı adı: "
 
-#: src/muuli_wdr.cpp:2998
+#: src/muuli_wdr.cpp:3005
 msgid "The username to use to connect to the proxy"
 msgstr "Vekil sunucuya bağlanmak için gerekli kullanıcı adı"
 
-#: src/muuli_wdr.cpp:3000
+#: src/muuli_wdr.cpp:3007
 msgid "Password:"
 msgstr "Şifre:"
 
-#: src/muuli_wdr.cpp:3003
+#: src/muuli_wdr.cpp:3010
 msgid "The password to use to connect to the proxy"
 msgstr "Vekil sunucuya bağlanmak için gerekli şifre"
 
-#: src/muuli_wdr.cpp:3022
+#: src/muuli_wdr.cpp:3029
 msgid "Connect to:"
 msgstr "Bağlan:"
 
-#: src/muuli_wdr.cpp:3031
+#: src/muuli_wdr.cpp:3038
 msgid "Login to remote amule"
 msgstr "Uzaktan aMule'ye giriş yapınız."
 
-#: src/muuli_wdr.cpp:3036
+#: src/muuli_wdr.cpp:3043
 msgid "User name"
 msgstr "Kullanıcı adı"
 
-#: src/muuli_wdr.cpp:3047
+#: src/muuli_wdr.cpp:3054
 msgid "Remember those settings"
 msgstr "Bu ayarları hatırla"
 
-#: src/muuli_wdr.cpp:3050
+#: src/muuli_wdr.cpp:3057
 msgid "Force ZLIB compression"
 msgstr "ZLIB sıkıştırmasını zorla"
 
-#: src/muuli_wdr.cpp:3074
+#: src/muuli_wdr.cpp:3081
 msgid "Enable Verbose Debug-Logging."
 msgstr "Fazladan Hata Çıktısı Kaydını Etkinleştir."
 
-#: src/muuli_wdr.cpp:3076
+#: src/muuli_wdr.cpp:3083
 msgid "Only to Logfile"
 msgstr "Sadece Kütük Dosyasına"
 
-#: src/muuli_wdr.cpp:3078
+#: src/muuli_wdr.cpp:3085
 msgid "Message Categories:"
 msgstr "İleti Sınıfları:"
 
-#: src/muuli_wdr.cpp:3102 src/PartFileConvertDlg.cpp:160
+#: src/muuli_wdr.cpp:3109 src/PartFileConvertDlg.cpp:160
 msgid "Waiting..."
 msgstr "Bekliyor…"
 
-#: src/muuli_wdr.cpp:3122
+#: src/muuli_wdr.cpp:3129
 msgid "Add imports"
 msgstr "İçe aktarımları ekle"
 
-#: src/muuli_wdr.cpp:3125
+#: src/muuli_wdr.cpp:3132
 msgid "Retry selected"
 msgstr "Seçileni tekrar dene"
 
-#: src/muuli_wdr.cpp:3127
+#: src/muuli_wdr.cpp:3134
 msgid "Remove selected"
 msgstr "Seçileni çıkar"
 
-#: src/muuli_wdr.cpp:3190
+#: src/muuli_wdr.cpp:3197
 msgid "Event Types"
 msgstr "Olay Türleri"
 
-#: src/muuli_wdr.cpp:3209
+#: src/muuli_wdr.cpp:3216
 msgid "Statistics and queued clients for selected file(s) : Session / All time"
 msgstr "Seçili dosya(lar) için kuyruktaki istemciler ve istatistikler: Oturum / Bütün zamanlar"
 
-#: src/muuli_wdr.cpp:3233
+#: src/muuli_wdr.cpp:3240
 msgid "Active Uploads"
 msgstr "Etkin Göndermeler"
 
-#: src/muuli_wdr.cpp:3247
+#: src/muuli_wdr.cpp:3254
 msgid "Percent of total files"
 msgstr "Toplam dosyaların yüzdesi"
 
-#: src/muuli_wdr.cpp:3299
+#: src/muuli_wdr.cpp:3306
 msgid "Show Clients for"
 msgstr "Kullanıcıları Göster"
 
-#: src/muuli_wdr.cpp:3301
+#: src/muuli_wdr.cpp:3308
 msgid "All files"
 msgstr "Tüm dosyalar"
 
-#: src/muuli_wdr.cpp:3304
+#: src/muuli_wdr.cpp:3311
 msgid "Selected files"
 msgstr "Seçilen dosyalar"
 
-#: src/muuli_wdr.cpp:3307
+#: src/muuli_wdr.cpp:3314
 msgid "Active uploads only"
 msgstr "Sadece aktif Göndermeler"
 
-#: src/muuli_wdr.cpp:3314
+#: src/muuli_wdr.cpp:3321
 msgid "Reload:"
 msgstr "Yeniden yükle:"
 
-#: src/muuli_wdr.cpp:3318
+#: src/muuli_wdr.cpp:3325
 msgid "Reload your shared files"
 msgstr "Paylaşılan dosyalarınızı yeniden yükleyin"
 
-#: src/muuli_wdr.cpp:3381
+#: src/muuli_wdr.cpp:3388
 msgid "Send"
 msgstr "Gönder"
 
-#: src/muuli_wdr.cpp:3382
+#: src/muuli_wdr.cpp:3389
 msgid "Sends the specified message."
 msgstr "Belirlenen iletiyi gönderir."
 
-#: src/muuli_wdr.cpp:3386
+#: src/muuli_wdr.cpp:3393
 msgid "Close this chat-session."
 msgstr "Bu sohbet oturumunu kapatır."
 
-#: src/muuli_wdr.cpp:3409
+#: src/muuli_wdr.cpp:3416
 msgid "Connect to any server and/or Kad"
 msgstr "Herhangi bir sunucuya ve/veya Kad'a bağlan."
 
-#: src/muuli_wdr.cpp:3415 src/SharedFilesCtrl.cpp:142 src/Statistics.cpp:941
+#: src/muuli_wdr.cpp:3422 src/SharedFilesCtrl.cpp:142 src/Statistics.cpp:941
 msgid "Shared Files"
 msgstr "Paylaşılan Dosyalar"
 
@@ -5409,187 +5423,187 @@ msgstr "İndirildi"
 msgid "ERROR: Failed to open partfile '%s'"
 msgstr "HATA: Parça dosyası '%s' açılamıyor"
 
-#: src/Preferences.cpp:673
+#: src/Preferences.cpp:674
 msgid "System default"
 msgstr "Sistem öntanımlısı"
 
-#: src/Preferences.cpp:674
+#: src/Preferences.cpp:675
 msgid "Albanian"
 msgstr "Arnavutça"
 
-#: src/Preferences.cpp:675
+#: src/Preferences.cpp:676
 msgid "Arabic"
 msgstr "Arapça"
 
-#: src/Preferences.cpp:676
+#: src/Preferences.cpp:677
 msgid "Asturian"
 msgstr "Asturyasça"
 
-#: src/Preferences.cpp:677
+#: src/Preferences.cpp:678
 msgid "Basque"
 msgstr "Baskça"
 
-#: src/Preferences.cpp:678
+#: src/Preferences.cpp:679
 msgid "Bulgarian"
 msgstr "Bulgarca"
 
-#: src/Preferences.cpp:679
+#: src/Preferences.cpp:680
 msgid "Catalan"
 msgstr "Katalanca"
 
-#: src/Preferences.cpp:680
+#: src/Preferences.cpp:681
 msgid "Chinese (Simplified)"
 msgstr "Çince (Basitleştirilmiş)"
 
-#: src/Preferences.cpp:681
+#: src/Preferences.cpp:682
 msgid "Chinese (Traditional)"
 msgstr "Çince (Geleneksel)"
 
-#: src/Preferences.cpp:682
+#: src/Preferences.cpp:683
 msgid "Croatian"
 msgstr "Hırvatça"
 
-#: src/Preferences.cpp:683
+#: src/Preferences.cpp:684
 msgid "Czech"
 msgstr "Çekçe"
 
-#: src/Preferences.cpp:684
+#: src/Preferences.cpp:685
 msgid "Danish"
 msgstr "Danca"
 
-#: src/Preferences.cpp:685
+#: src/Preferences.cpp:686
 msgid "Dutch"
 msgstr "Felemenkçe"
 
-#: src/Preferences.cpp:686
+#: src/Preferences.cpp:687
 msgid "English (U.K.)"
 msgstr "İngilizce (U.K)"
 
-#: src/Preferences.cpp:687
+#: src/Preferences.cpp:688
 msgid "English (U.S.)"
 msgstr "İngilizce (ABD)"
 
-#: src/Preferences.cpp:688
+#: src/Preferences.cpp:689
 msgid "Estonian"
 msgstr "Estonca"
 
-#: src/Preferences.cpp:689
+#: src/Preferences.cpp:690
 msgid "Finnish"
 msgstr "Fince"
 
-#: src/Preferences.cpp:690
+#: src/Preferences.cpp:691
 msgid "French"
 msgstr "Fransızca"
 
-#: src/Preferences.cpp:691
+#: src/Preferences.cpp:692
 msgid "Galician"
 msgstr "Galce"
 
-#: src/Preferences.cpp:692
+#: src/Preferences.cpp:693
 msgid "German"
 msgstr "Almanca"
 
-#: src/Preferences.cpp:693
+#: src/Preferences.cpp:694
 msgid "Greek"
 msgstr "Yunanca"
 
-#: src/Preferences.cpp:694
+#: src/Preferences.cpp:695
 msgid "Hebrew"
 msgstr "İbranice"
 
-#: src/Preferences.cpp:695
+#: src/Preferences.cpp:696
 msgid "Hungarian"
 msgstr "Macarca"
 
-#: src/Preferences.cpp:696
+#: src/Preferences.cpp:697
 msgid "Italian"
 msgstr "İtalyanca"
 
-#: src/Preferences.cpp:697
+#: src/Preferences.cpp:698
 msgid "Japanese"
 msgstr "Japonca"
 
-#: src/Preferences.cpp:698
+#: src/Preferences.cpp:699
 msgid "Korean"
 msgstr "Korece"
 
-#: src/Preferences.cpp:699
+#: src/Preferences.cpp:700
 msgid "Latvian"
 msgstr "Letonca"
 
-#: src/Preferences.cpp:700
+#: src/Preferences.cpp:701
 msgid "Lithuanian"
 msgstr "Litvanyaca"
 
-#: src/Preferences.cpp:701
+#: src/Preferences.cpp:702
 msgid "Norwegian (Nynorsk)"
 msgstr "Norveççe (Nynorsk)"
 
-#: src/Preferences.cpp:702
+#: src/Preferences.cpp:703
 msgid "Polish"
 msgstr "Lehçe"
 
-#: src/Preferences.cpp:703
+#: src/Preferences.cpp:704
 msgid "Portuguese"
 msgstr "Portekizce"
 
-#: src/Preferences.cpp:704
+#: src/Preferences.cpp:705
 msgid "Portuguese (Brazilian)"
 msgstr "Portekizce (Brezilya)"
 
-#: src/Preferences.cpp:705
+#: src/Preferences.cpp:706
 msgid "Romanian"
 msgstr "Rumence"
 
-#: src/Preferences.cpp:706
+#: src/Preferences.cpp:707
 msgid "Russian"
 msgstr "Rusça"
 
-#: src/Preferences.cpp:707
+#: src/Preferences.cpp:708
 msgid "Slovenian"
 msgstr "Slovence"
 
-#: src/Preferences.cpp:708
+#: src/Preferences.cpp:709
 msgid "Spanish"
 msgstr "İspanyolca"
 
-#: src/Preferences.cpp:709
+#: src/Preferences.cpp:710
 msgid "Swedish"
 msgstr "İsveççe"
 
-#: src/Preferences.cpp:710
+#: src/Preferences.cpp:711
 msgid "Turkish"
 msgstr "Türkçe"
 
-#: src/Preferences.cpp:711
+#: src/Preferences.cpp:712
 msgid "Ukrainian"
 msgstr "Ukraynaca"
 
-#: src/Preferences.cpp:814
+#: src/Preferences.cpp:815
 msgid "Change Language"
 msgstr "Dili Değiştirin"
 
-#: src/Preferences.cpp:878
+#: src/Preferences.cpp:879
 msgid "There are no translations installed for aMule"
 msgstr "aMule tercümeleri kurulu değildir"
 
-#: src/Preferences.cpp:879
+#: src/Preferences.cpp:880
 msgid "No languages available"
 msgstr "Diller mevcut değil"
 
-#: src/Preferences.cpp:1010
+#: src/Preferences.cpp:1011
 msgid "no options available"
 msgstr "mevcut seçenek yok"
 
-#: src/Preferences.cpp:2179
+#: src/Preferences.cpp:2182
 msgid "Invalid category found, skipping"
 msgstr "Geçersiz sınıf bulundu, atlanıyor"
 
-#: src/Preferences.cpp:2348
+#: src/Preferences.cpp:2351
 msgid "TCP port can't be higher than 65532 due to server UDP socket being TCP+3"
 msgstr "TCP portu numarası, UDP soketi TCP+3 olduğundan 65532' den yüksek olamaz"
 
-#: src/Preferences.cpp:2349
+#: src/Preferences.cpp:2352
 #, c-format
 msgid "Default port will be used (%d)"
 msgstr "Varsayılan port kullanılacak (%d)"
@@ -6090,23 +6104,27 @@ msgstr "Paylaşılmış dosyalar yeniden yükleniyor: %u dosya tarandı"
 msgid "Shared folder"
 msgstr "Paylaşılan dizin"
 
-#: src/SearchDlg.cpp:425
+#: src/SearchDlg.cpp:280
+msgid "Clear search history"
+msgstr ""
+
+#: src/SearchDlg.cpp:584
 msgid "It's impossible to search when both eD2k and Kademlia are disabled."
 msgstr "Hem eD2k hem de Kademlia devre dışı bırakıldığında arama yapmak mümkün değildir."
 
-#: src/SearchDlg.cpp:426 src/SearchListCtrl.cpp:858
+#: src/SearchDlg.cpp:585 src/SearchListCtrl.cpp:858
 msgid "Search error"
 msgstr "Arama hatası"
 
-#: src/SearchDlg.cpp:768
+#: src/SearchDlg.cpp:929
 msgid "Min size must be smaller than max size. Max size ignored."
 msgstr "En küçük boyut, en büyük boyuttan küçük olmalıdır. En büyük boyut göz ardı ediliyor."
 
-#: src/SearchDlg.cpp:769 src/SearchDlg.cpp:851
+#: src/SearchDlg.cpp:930 src/SearchDlg.cpp:1012
 msgid "Search warning"
 msgstr "Arama uyarısı."
 
-#: src/SearchDlg.cpp:929 src/SearchListCtrl.cpp:735
+#: src/SearchDlg.cpp:1092 src/SearchListCtrl.cpp:735
 msgid "Main"
 msgstr "Ana"
 

--- a/po/tr.po
+++ b/po/tr.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-28 12:17+0200\n"
+"POT-Creation-Date: 2026-07-28 13:09+0200\n"
 "PO-Revision-Date: 2026-07-27 11:47+0000\n"
 "Last-Translator: \n"
 "Language-Team: Turkish <li@li.org>\n"
@@ -294,7 +294,7 @@ msgid "Password set and external connections enabled."
 msgstr "Parola ayarlandı ve dış bağlantılar etkinleştirildi."
 
 #: src/amule.cpp:755 src/KadDlg.cpp:176 src/KadDlg.cpp:185
-#: src/PrefsUnifiedDlg.cpp:1461 src/SharedFilesCtrl.cpp:476
+#: src/PrefsUnifiedDlg.cpp:1470 src/SharedFilesCtrl.cpp:476
 msgid "WARNING"
 msgstr "UYARI"
 
@@ -331,7 +331,7 @@ msgstr "Web sunucusunun başlangıçta çalışmasını istediniz, fakat amulewe
 #: src/amule-remote-gui.cpp:603 src/amule-remote-gui.cpp:671
 #: src/amule-remote-gui.cpp:709 src/amule-remote-gui.cpp:1282
 #: src/amule-remote-gui.cpp:1345 src/amule-remote-gui.cpp:1372
-#: src/DownloadQueue.cpp:1481 src/PrefsUnifiedDlg.cpp:1247
+#: src/DownloadQueue.cpp:1481 src/PrefsUnifiedDlg.cpp:1256
 msgid "ERROR"
 msgstr "HATA"
 
@@ -591,36 +591,36 @@ msgstr "Yeni sürüm denetimi için https://github.com/amule-org/amule/releases/
 msgid "FATAL ERROR: Failed to create Timer"
 msgstr "ÖNEMLİ HATA: Zamanlayıcı oluşturulamadı"
 
-#: src/amuleDlg.cpp:361 src/amuleDlg.cpp:1787 src/amuleDlg.cpp:2033
-#: src/muuli_wdr.cpp:1492 src/muuli_wdr.cpp:3449
+#: src/amuleDlg.cpp:361 src/amuleDlg.cpp:1810 src/amuleDlg.cpp:2056
+#: src/muuli_wdr.cpp:1492 src/muuli_wdr.cpp:3453
 msgid "Networks"
 msgstr "Ağlar"
 
-#: src/amuleDlg.cpp:362 src/amuleDlg.cpp:1793 src/muuli_wdr.cpp:3450
+#: src/amuleDlg.cpp:362 src/amuleDlg.cpp:1816 src/muuli_wdr.cpp:3454
 msgid "Searches"
 msgstr "Aramalar"
 
-#: src/amuleDlg.cpp:363 src/amuleDlg.cpp:1799 src/DownloadListCtrl.cpp:740
-#: src/muuli_wdr.cpp:392 src/muuli_wdr.cpp:1585 src/muuli_wdr.cpp:3451
+#: src/amuleDlg.cpp:363 src/amuleDlg.cpp:1822 src/DownloadListCtrl.cpp:740
+#: src/muuli_wdr.cpp:392 src/muuli_wdr.cpp:1585 src/muuli_wdr.cpp:3455
 #: src/Statistics.cpp:829
 msgid "Downloads"
 msgstr "İndirmeler"
 
-#: src/amuleDlg.cpp:364 src/amuleDlg.cpp:1805 src/muuli_wdr.cpp:3325
+#: src/amuleDlg.cpp:364 src/amuleDlg.cpp:1828 src/muuli_wdr.cpp:3329
 msgid "Shared files"
 msgstr "Paylaşılan dosyalar"
 
-#: src/amuleDlg.cpp:365 src/amuleDlg.cpp:1811 src/muuli_wdr.cpp:2957
-#: src/muuli_wdr.cpp:3407 src/muuli_wdr.cpp:3454
+#: src/amuleDlg.cpp:365 src/amuleDlg.cpp:1834 src/muuli_wdr.cpp:2961
+#: src/muuli_wdr.cpp:3411 src/muuli_wdr.cpp:3458
 msgid "Messages"
 msgstr "Sohbet"
 
-#: src/amuleDlg.cpp:366 src/amuleDlg.cpp:1817 src/muuli_wdr.cpp:3455
+#: src/amuleDlg.cpp:366 src/amuleDlg.cpp:1840 src/muuli_wdr.cpp:3459
 #: src/PrefsUnifiedDlg.cpp:314 src/Statistics.cpp:779 src/Statistics.cpp:1235
 msgid "Statistics"
 msgstr "İstatistikler"
 
-#: src/amuleDlg.cpp:368 src/amuleDlg.cpp:1824 src/muuli_wdr.cpp:3457
+#: src/amuleDlg.cpp:368 src/amuleDlg.cpp:1847 src/muuli_wdr.cpp:3461
 #: src/PrefsUnifiedDlg.cpp:330 src/utils/wxCas/src/wxcasprefs.cpp:39
 msgid "Preferences"
 msgstr "Ayarlar"
@@ -683,8 +683,8 @@ msgstr "Kad: Kapalı"
 #: src/amuleDlg.cpp:1029 src/DownloadListCtrl.cpp:505
 #: src/DownloadListCtrl.cpp:749 src/FriendListCtrl.cpp:180
 #: src/muuli_wdr.cpp:731 src/muuli_wdr.cpp:782 src/muuli_wdr.cpp:846
-#: src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2262 src/muuli_wdr.cpp:2347
-#: src/muuli_wdr.cpp:3095 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
+#: src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2266 src/muuli_wdr.cpp:2351
+#: src/muuli_wdr.cpp:3099 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
 #: src/ServerListCtrl.cpp:606 src/TransferWnd.cpp:378
 #: src/utils/wxCas/src/wxcasprefs.cpp:235
 msgid "Cancel"
@@ -695,7 +695,7 @@ msgid "Stop the current connection attempts"
 msgstr "Durdur"
 
 #: src/amuleDlg.cpp:1035 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976
-#: src/muuli_wdr.cpp:2485
+#: src/muuli_wdr.cpp:2489
 msgid "Disconnect"
 msgstr "Bağlantıyı Kes"
 
@@ -704,7 +704,7 @@ msgid "Disconnect from the currently connected networks"
 msgstr "Bağlanılmış olan ağlar ile bağlantıyı Kes"
 
 #: src/amuleDlg.cpp:1041 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979
-#: src/muuli_wdr.cpp:2640 src/muuli_wdr.cpp:3092 src/muuli_wdr.cpp:3447
+#: src/muuli_wdr.cpp:2644 src/muuli_wdr.cpp:3096 src/muuli_wdr.cpp:3451
 msgid "Connect"
 msgstr "Bağlan"
 
@@ -758,7 +758,7 @@ msgstr "Çıkışı onaylayınız"
 msgid "Launch Command: "
 msgstr "Çalıştırma Komutu: "
 
-#: src/amuleDlg.cpp:1632 src/muuli_wdr.cpp:1982 src/Preferences.cpp:979
+#: src/amuleDlg.cpp:1632 src/muuli_wdr.cpp:1986 src/Preferences.cpp:979
 msgid "- default -"
 msgstr "- ön tanımlı -"
 
@@ -772,60 +772,60 @@ msgstr "Kaplama dizini '%s' yok"
 msgid "WARNING: Unable to open skin file '%s' for read"
 msgstr "UYARI: Kaplama dosyası '%s' okuma için açılamıyor"
 
-#: src/amuleDlg.cpp:1791 src/muuli_wdr.cpp:3449
+#: src/amuleDlg.cpp:1814 src/muuli_wdr.cpp:3453
 msgid "Networks Window"
 msgstr "Ağ Penceresi"
 
-#: src/amuleDlg.cpp:1797 src/muuli_wdr.cpp:3450
+#: src/amuleDlg.cpp:1820 src/muuli_wdr.cpp:3454
 msgid "Searches Window"
 msgstr "Arama Penceresi"
 
-#: src/amuleDlg.cpp:1803 src/muuli_wdr.cpp:3451
+#: src/amuleDlg.cpp:1826 src/muuli_wdr.cpp:3455
 msgid "Downloads Window"
 msgstr "İndirme Penceresi"
 
-#: src/amuleDlg.cpp:1809 src/muuli_wdr.cpp:3453
+#: src/amuleDlg.cpp:1832 src/muuli_wdr.cpp:3457
 msgid "Shared Files Window"
 msgstr "Paylaşılan Dosya Penceresi"
 
-#: src/amuleDlg.cpp:1815 src/muuli_wdr.cpp:3454
+#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3458
 msgid "Messages Window"
 msgstr "Sohbet Penceresi"
 
-#: src/amuleDlg.cpp:1821 src/muuli_wdr.cpp:3455
+#: src/amuleDlg.cpp:1844 src/muuli_wdr.cpp:3459
 msgid "Statistics Graph Window"
 msgstr "İstatistik Grafik Penceresi"
 
-#: src/amuleDlg.cpp:1828 src/muuli_wdr.cpp:3457
+#: src/amuleDlg.cpp:1851 src/muuli_wdr.cpp:3461
 msgid "Preferences Settings Window"
 msgstr "Ayar Penceresi"
 
-#: src/amuleDlg.cpp:1831 src/muuli_wdr.cpp:3458
+#: src/amuleDlg.cpp:1854 src/muuli_wdr.cpp:3462
 msgid "Import"
 msgstr "İçe Aktar"
 
-#: src/amuleDlg.cpp:1835 src/muuli_wdr.cpp:3458
+#: src/amuleDlg.cpp:1858 src/muuli_wdr.cpp:3462
 msgid "The partfile importer tool"
 msgstr "Parça dosyası içe aktarım aracı"
 
-#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3459
+#: src/amuleDlg.cpp:1861 src/muuli_wdr.cpp:3463
 #: src/utils/aLinkCreator/src/alcframe.cpp:262
 msgid "About"
 msgstr "Hakkında"
 
-#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3459
+#: src/amuleDlg.cpp:1861 src/muuli_wdr.cpp:3463
 msgid "About/Help"
 msgstr "Hakkında/Yardım"
 
-#: src/amuleDlg.cpp:2036
+#: src/amuleDlg.cpp:2059
 msgid "eD2k network"
 msgstr "eD2k ağı"
 
-#: src/amuleDlg.cpp:2039
+#: src/amuleDlg.cpp:2062
 msgid "Kad network"
 msgstr "Kademlia ağı"
 
-#: src/amuleDlg.cpp:2039
+#: src/amuleDlg.cpp:2062
 msgid "No network"
 msgstr "Ağ yok"
 
@@ -1358,19 +1358,19 @@ msgstr "Oto (Yük)"
 msgid "Very low"
 msgstr "Çok düşük"
 
-#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:743 src/muuli_wdr.cpp:2313
+#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:743 src/muuli_wdr.cpp:2317
 #: src/ServerListCtrl.cpp:263 src/ServerListCtrl.cpp:456
 #: src/SharedFilesCtrl.cpp:145
 msgid "Low"
 msgstr "Düşük"
 
-#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:744 src/muuli_wdr.cpp:2314
+#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:744 src/muuli_wdr.cpp:2318
 #: src/ServerListCtrl.cpp:266 src/ServerListCtrl.cpp:457
 #: src/SharedFilesCtrl.cpp:146
 msgid "Normal"
 msgstr "Normal"
 
-#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:745 src/muuli_wdr.cpp:2315
+#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:745 src/muuli_wdr.cpp:2319
 #: src/ServerListCtrl.cpp:269 src/ServerListCtrl.cpp:458
 #: src/SharedFilesCtrl.cpp:147
 msgid "High"
@@ -1462,7 +1462,7 @@ msgstr "Sunucu"
 msgid "Remote Server"
 msgstr "Uzak Sunucu"
 
-#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3212
+#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3216
 #: src/SearchDlg.cpp:119 src/TextClient.cpp:911
 msgid "Kad"
 msgstr "Kad"
@@ -1533,7 +1533,7 @@ msgstr "Parça"
 msgid "Size"
 msgstr "Boyut"
 
-#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3279
+#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3283
 msgid "Transferred"
 msgstr "Aktarıldı"
 
@@ -1591,7 +1591,7 @@ msgstr ""
 "Geri besleme: %s (%s)\n"
 "\n"
 
-#: src/DownloadListCtrl.cpp:746 src/muuli_wdr.cpp:2316
+#: src/DownloadListCtrl.cpp:746 src/muuli_wdr.cpp:2320
 #: src/SharedFilesCtrl.cpp:150
 msgid "Auto"
 msgstr "Otomatik"
@@ -1629,7 +1629,7 @@ msgid "Extended Options"
 msgstr "Genişletilmiş Seçenekler"
 
 #: src/DownloadListCtrl.cpp:770 src/DownloadListCtrl.cpp:822
-#: src/muuli_wdr.cpp:1800
+#: src/muuli_wdr.cpp:1804
 msgid "Preview"
 msgstr "Ön İzleme"
 
@@ -2428,23 +2428,23 @@ msgid ""
 "want downloads on a different (e.g. larger) disk."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:549 src/FirstRunWizard.cpp:611 src/muuli_wdr.cpp:1712
+#: src/FirstRunWizard.cpp:549 src/FirstRunWizard.cpp:611 src/muuli_wdr.cpp:1716
 msgid "Destination folder for downloads"
 msgstr "İndirmeler için hedef dizin"
 
 #: src/FirstRunWizard.cpp:553 src/FirstRunWizard.cpp:569 src/muuli_wdr.cpp:1349
-#: src/muuli_wdr.cpp:1366 src/muuli_wdr.cpp:1687 src/muuli_wdr.cpp:1718
-#: src/muuli_wdr.cpp:1730 src/muuli_wdr.cpp:2800
+#: src/muuli_wdr.cpp:1366 src/muuli_wdr.cpp:1691 src/muuli_wdr.cpp:1722
+#: src/muuli_wdr.cpp:1734 src/muuli_wdr.cpp:2804
 #: src/utils/aLinkCreator/src/alcframe.cpp:135
 #: src/utils/wxCas/src/wxcasprefs.cpp:52 src/utils/wxCas/src/wxcasprefs.cpp:118
 msgid "Browse"
 msgstr "Göz at"
 
-#: src/FirstRunWizard.cpp:559 src/muuli_wdr.cpp:1723
+#: src/FirstRunWizard.cpp:559 src/muuli_wdr.cpp:1727
 msgid "(All files in this folder are shared with other peers)"
 msgstr "(Bu dizindeki tüm dosyalar diğer eşler ile paylaşılmaktadır)"
 
-#: src/FirstRunWizard.cpp:565 src/FirstRunWizard.cpp:624 src/muuli_wdr.cpp:1725
+#: src/FirstRunWizard.cpp:565 src/FirstRunWizard.cpp:624 src/muuli_wdr.cpp:1729
 msgid "Folder for temporary download files"
 msgstr "Geçici dosyalar için dizin"
 
@@ -2475,7 +2475,7 @@ msgstr "Arkadaş listesi 'emfriends.met' dosyasına yazılamıyor!"
 msgid "CRITICAL - no client on StartChatSession"
 msgstr "KRİTİK - SohbetOturumunuBaşlat' ta istemci yok"
 
-#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2706 src/muuli_wdr.cpp:3383
+#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2710 src/muuli_wdr.cpp:3387
 msgid "Friends"
 msgstr "Arkadaşlar"
 
@@ -2585,8 +2585,8 @@ msgstr "Yok"
 msgid "No"
 msgstr "Hayır"
 
-#: src/GenericClientListCtrl.cpp:1216 src/PrefsUnifiedDlg.cpp:2898
-#: src/PrefsUnifiedDlg.cpp:2948 src/ServerListCtrl.cpp:276
+#: src/GenericClientListCtrl.cpp:1216 src/PrefsUnifiedDlg.cpp:2907
+#: src/PrefsUnifiedDlg.cpp:2957 src/ServerListCtrl.cpp:276
 msgid "Yes"
 msgstr "Evet"
 
@@ -2755,10 +2755,10 @@ msgstr "Ön yükleme için geçersiz port"
 msgid "Please fill all fields required"
 msgstr "İstenilen tüm alanları doldurunuz."
 
-#: src/KadDlg.cpp:192 src/PartFile.cpp:1031 src/PrefsUnifiedDlg.cpp:1134
-#: src/PrefsUnifiedDlg.cpp:1204 src/PrefsUnifiedDlg.cpp:1405
-#: src/PrefsUnifiedDlg.cpp:1663 src/PrefsUnifiedDlg.cpp:1673
-#: src/PrefsUnifiedDlg.cpp:1690 src/PrefsUnifiedDlg.cpp:1738
+#: src/KadDlg.cpp:192 src/PartFile.cpp:1031 src/PrefsUnifiedDlg.cpp:1143
+#: src/PrefsUnifiedDlg.cpp:1213 src/PrefsUnifiedDlg.cpp:1414
+#: src/PrefsUnifiedDlg.cpp:1672 src/PrefsUnifiedDlg.cpp:1682
+#: src/PrefsUnifiedDlg.cpp:1699 src/PrefsUnifiedDlg.cpp:1747
 msgid "Message"
 msgstr "İleti"
 
@@ -2859,7 +2859,7 @@ msgstr "Paylaşım oranı"
 msgid "Uploaded"
 msgstr "Gönderilen"
 
-#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3263
+#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3267
 msgid "Requested"
 msgstr "İstenen"
 
@@ -2982,7 +2982,7 @@ msgid "WARNING: "
 msgstr "UYARI: "
 
 #: src/MuleNotebook.cpp:179 src/muuli_wdr.cpp:817 src/muuli_wdr.cpp:1229
-#: src/muuli_wdr.cpp:3167 src/muuli_wdr.cpp:3423
+#: src/muuli_wdr.cpp:3171 src/muuli_wdr.cpp:3427
 msgid "Close"
 msgstr "Kapat"
 
@@ -3000,7 +3000,7 @@ msgid "Paste"
 msgstr "Yapıştır"
 
 #: src/MuleTextCtrl.cpp:89 src/muuli_wdr.cpp:358 src/muuli_wdr.cpp:757
-#: src/muuli_wdr.cpp:2390 src/muuli_wdr.cpp:2409 src/muuli_wdr.cpp:2431
+#: src/muuli_wdr.cpp:2394 src/muuli_wdr.cpp:2413 src/muuli_wdr.cpp:2435
 #: src/utils/aLinkCreator/src/alcframe.cpp:142
 msgid "Clear"
 msgstr "Temizle"
@@ -3092,7 +3092,7 @@ msgstr "Çıkış"
 
 #: src/MuleTrayIcon.cpp:579 src/MuleTrayIcon.cpp:945 src/MuleTrayIcon.cpp:965
 #: src/muuli_wdr.cpp:1398 src/muuli_wdr.cpp:1406 src/muuli_wdr.cpp:1413
-#: src/muuli_wdr.cpp:1846 src/muuli_wdr.cpp:1852 src/OtherFunctions.cpp:91
+#: src/muuli_wdr.cpp:1850 src/muuli_wdr.cpp:1856 src/OtherFunctions.cpp:91
 #: src/StatisticsDlg.cpp:93 src/StatisticsDlg.cpp:95
 msgid "kB/s"
 msgstr "kB/s"
@@ -3332,7 +3332,7 @@ msgstr "Bayt"
 msgid "KB"
 msgstr "KB"
 
-#: src/muuli_wdr.cpp:274 src/muuli_wdr.cpp:293 src/muuli_wdr.cpp:1631
+#: src/muuli_wdr.cpp:274 src/muuli_wdr.cpp:293 src/muuli_wdr.cpp:1635
 #: src/OtherFunctions.cpp:64
 msgid "MB"
 msgstr "MB"
@@ -3349,7 +3349,7 @@ msgstr "En Fazla Boyut"
 msgid "Availability"
 msgstr "Uygunluk"
 
-#: src/muuli_wdr.cpp:312 src/muuli_wdr.cpp:398 src/muuli_wdr.cpp:3328
+#: src/muuli_wdr.cpp:312 src/muuli_wdr.cpp:398 src/muuli_wdr.cpp:3332
 msgid "Filter:"
 msgstr "Süz:"
 
@@ -3412,8 +3412,8 @@ msgstr "Dosya kaynakları:"
 #: src/muuli_wdr.cpp:1160 src/muuli_wdr.cpp:1167 src/muuli_wdr.cpp:1172
 #: src/muuli_wdr.cpp:1179 src/muuli_wdr.cpp:1184 src/muuli_wdr.cpp:1191
 #: src/muuli_wdr.cpp:1205 src/muuli_wdr.cpp:1212 src/muuli_wdr.cpp:1217
-#: src/muuli_wdr.cpp:1224 src/muuli_wdr.cpp:3265 src/muuli_wdr.cpp:3273
-#: src/muuli_wdr.cpp:3281
+#: src/muuli_wdr.cpp:1224 src/muuli_wdr.cpp:3269 src/muuli_wdr.cpp:3277
+#: src/muuli_wdr.cpp:3285
 msgid "N/A"
 msgstr "N/A"
 
@@ -3553,7 +3553,7 @@ msgstr "Sanatçı:"
 msgid "Album :"
 msgstr "Albüm:"
 
-#: src/muuli_wdr.cpp:685 src/muuli_wdr.cpp:2285
+#: src/muuli_wdr.cpp:685 src/muuli_wdr.cpp:2289
 msgid "Title :"
 msgstr "Başlık :"
 
@@ -3661,7 +3661,7 @@ msgstr "Kullanıcı Adı :"
 msgid "Userhash :"
 msgstr "Kullanıcı Adreslemesi :"
 
-#: src/muuli_wdr.cpp:895 src/muuli_wdr.cpp:1752 src/muuli_wdr.cpp:2480
+#: src/muuli_wdr.cpp:895 src/muuli_wdr.cpp:1756 src/muuli_wdr.cpp:2484
 #: src/utils/aLinkCreator/src/alcframe.cpp:137
 msgid "Add"
 msgstr "Ekle"
@@ -3670,15 +3670,15 @@ msgstr "Ekle"
 msgid "Download-Speed"
 msgstr "İndirme Hızı"
 
-#: src/muuli_wdr.cpp:954 src/muuli_wdr.cpp:989 src/muuli_wdr.cpp:2584
+#: src/muuli_wdr.cpp:954 src/muuli_wdr.cpp:989 src/muuli_wdr.cpp:2588
 msgid "Current"
 msgstr "Şimdiki"
 
-#: src/muuli_wdr.cpp:962 src/muuli_wdr.cpp:997 src/muuli_wdr.cpp:2592
+#: src/muuli_wdr.cpp:962 src/muuli_wdr.cpp:997 src/muuli_wdr.cpp:2596
 msgid "Running average"
 msgstr "Çalışma ortalaması"
 
-#: src/muuli_wdr.cpp:970 src/muuli_wdr.cpp:1005 src/muuli_wdr.cpp:2600
+#: src/muuli_wdr.cpp:970 src/muuli_wdr.cpp:1005 src/muuli_wdr.cpp:2604
 msgid "Session average"
 msgstr "Oturum ortalaması"
 
@@ -3690,7 +3690,7 @@ msgstr "Gönderim Hızı"
 msgid "Connections"
 msgstr "Bağlantılar"
 
-#: src/muuli_wdr.cpp:1024 src/muuli_wdr.cpp:1871
+#: src/muuli_wdr.cpp:1024 src/muuli_wdr.cpp:1875
 msgid "Active downloads"
 msgstr "Aktif İndirmeler"
 
@@ -3698,7 +3698,7 @@ msgstr "Aktif İndirmeler"
 msgid "Active connections (1:1)"
 msgstr "Aktif Bağlantılar (1:1)"
 
-#: src/muuli_wdr.cpp:1040 src/muuli_wdr.cpp:1872
+#: src/muuli_wdr.cpp:1040 src/muuli_wdr.cpp:1876
 msgid "Active uploads"
 msgstr "Aktif Göndermeler"
 
@@ -3972,7 +3972,7 @@ msgstr "Yerel adresi IP' ye bağla (herhangi biri için boş bırakın):"
 msgid "Advanced users only: If you have multiple network interfaces, enter the address of the interface to which aMule should be bound."
 msgstr "Sadece ileri düzey kullanıcılar: Birden fazla ağ arayüzünüz varsa; aMule'nin izleyeceği arayüz adresini giriniz."
 
-#: src/muuli_wdr.cpp:1462 src/muuli_wdr.cpp:2065
+#: src/muuli_wdr.cpp:1462 src/muuli_wdr.cpp:2069
 msgid "Bind to network interface (empty for any):"
 msgstr "Ağ arayüzüne bağla (herhangi biri için boş bırakın):"
 
@@ -3988,7 +3988,7 @@ msgstr "İndirilen dosya başına en fazla kaynak sayısı:"
 msgid "Max simultaneous connections:"
 msgstr "En cazla eş bağlantı sayısı:"
 
-#: src/muuli_wdr.cpp:1498 src/muuli_wdr.cpp:3207
+#: src/muuli_wdr.cpp:1498 src/muuli_wdr.cpp:3211
 msgid "ED2K"
 msgstr "ED2K"
 
@@ -4080,79 +4080,79 @@ msgstr "Yeni dosyalar için diskte yer ayır"
 msgid "For new files preallocates disk space for the whole file, thus reduces fragmentation"
 msgstr "Yeni dosyalarda, dosyanın tamamı için sabit diskte yer ayrılarak parçalanma azaltılır"
 
-#: src/muuli_wdr.cpp:1617
+#: src/muuli_wdr.cpp:1621
 msgid "Create new files as sparse files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1618
+#: src/muuli_wdr.cpp:1622
 msgid "Sparse part files only occupy disk space for the parts already downloaded, so free space is used up gradually as the file fills in. Turn this off to use an ordinary file instead - useful where sparse files are unsupported or slow, or where backup/de-duplication tools handle them badly. Applies only when the core runs on Windows; on Linux and macOS part files are sparse anyway and this setting has no effect."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1623
+#: src/muuli_wdr.cpp:1627
 msgid "Stop downloads when free disk space reaches "
 msgstr "Boş disk alanı şu kadar kaldığında aktarımları durdur "
 
-#: src/muuli_wdr.cpp:1624
+#: src/muuli_wdr.cpp:1628
 msgid "Select this if you want aMule to check your disk space"
 msgstr "aMule'nin diskteki alanı denetlemesini istiyorsanız bunu seçiniz."
 
-#: src/muuli_wdr.cpp:1628
+#: src/muuli_wdr.cpp:1632
 msgid "Enter here the min disk space desired."
 msgstr "Buraya istenilen en az disk alanını giriniz."
 
-#: src/muuli_wdr.cpp:1634
+#: src/muuli_wdr.cpp:1638
 msgid "Save 10 sources on rare files (< 20 sources)"
 msgstr "Nadir bulunan dosyalarda 10 kaynak sakla (<20 kaynak)"
 
-#: src/muuli_wdr.cpp:1638 src/Statistics.cpp:790
+#: src/muuli_wdr.cpp:1642 src/Statistics.cpp:790
 msgid "Uploads"
 msgstr "Gönderilenler"
 
-#: src/muuli_wdr.cpp:1641
+#: src/muuli_wdr.cpp:1645
 msgid "Add new shared files with auto priority"
 msgstr "Dosyaları paylaşılanlara otomatik öncelikle ekle"
 
-#: src/muuli_wdr.cpp:1647
+#: src/muuli_wdr.cpp:1651
 msgid "Intelligent Corruption Handling (I.C.H.)"
 msgstr "Akıllı Bozulma Yakalayıcısı (I.C.H.)"
 
-#: src/muuli_wdr.cpp:1650
+#: src/muuli_wdr.cpp:1654
 msgid "Enable"
 msgstr "Etkinleştir"
 
-#: src/muuli_wdr.cpp:1653
+#: src/muuli_wdr.cpp:1657
 msgid "Advanced I.C.H. trusts every hash (not recommended)"
 msgstr "Gelişmiş I.C.H. her adreslemeye güvensin. ( önerilmez )"
 
-#: src/muuli_wdr.cpp:1665 src/PrefsUnifiedDlg.cpp:1990
+#: src/muuli_wdr.cpp:1669 src/PrefsUnifiedDlg.cpp:1999
 msgid "Media metadata extraction"
 msgstr "Ortam üst verisi çıkarımı"
 
-#: src/muuli_wdr.cpp:1669
+#: src/muuli_wdr.cpp:1673
 msgid "Extract length / bitrate / codec from shared audio and video files"
 msgstr "Süre / bit hızı / kodlama bilgilerini paylaşılan ses ve video dosyalarından çıkar"
 
-#: src/muuli_wdr.cpp:1671
+#: src/muuli_wdr.cpp:1675
 msgid "When enabled, aMule runs ffprobe on each shared media file to fill in the Length / Bitrate / Codec columns other clients see when they find the file in a search. Requires ffmpeg (the ffprobe binary) to be installed."
 msgstr "Etkinleştirildiğinde, dosyayı bir aramada bulan diğer istemcilerin gördükleri Süre / Bit Akışı / Kodlama sütunlarını doldurmak için aMule her paylaşılan ortam dosyası üzerinde ffprobe çalıştırır. ffmpeg (ffprobe ikilisi) kurulumu gerektirir."
 
-#: src/muuli_wdr.cpp:1678
+#: src/muuli_wdr.cpp:1682
 msgid "Path to ffprobe:"
 msgstr "ffprobe yolu:"
 
-#: src/muuli_wdr.cpp:1683
+#: src/muuli_wdr.cpp:1687
 msgid "Full path to the ffprobe binary. Leave empty to have aMule auto-detect it on startup."
 msgstr "ffprobe ikilisi için tam yol. aMule tarafından başlangıçta otomatik olarak tespit edilmesi için boş bırakın."
 
-#: src/muuli_wdr.cpp:1691
+#: src/muuli_wdr.cpp:1695
 msgid "Detect"
 msgstr "Tespit et"
 
-#: src/muuli_wdr.cpp:1692
+#: src/muuli_wdr.cpp:1696
 msgid "Search the standard install locations for an ffprobe binary and fill the path field."
 msgstr "Bir ffprobe ikilisi için standart kurulum konumlarını ara ve yol alanını doldur."
 
-#: src/muuli_wdr.cpp:1716
+#: src/muuli_wdr.cpp:1720
 msgid ""
 "Completed downloads are stored here. All files in this folder are automatically shared with other peers.\n"
 "If this folder also holds files you don't want to share, point it at an aMule-only sub-folder."
@@ -4160,688 +4160,688 @@ msgstr ""
 "Tamamlanmış indirmeler burada muhafaza edilir. Bu dizindeki tüm dosyalar otomatik olarak diğer eşler ile paylaşılır.\n"
 "Şayet bu dizin paylaşmak istemediğiniz dosyalar da içeriyorsa, aMule'e özel bir alt dizini seçin."
 
-#: src/muuli_wdr.cpp:1719
+#: src/muuli_wdr.cpp:1723
 msgid "Pick the folder where completed downloads will be stored. All files in that folder will be shared with other peers."
 msgstr "Tamamlanmış indirmelerin muhafaza edilecekleri dizini seçin. Bu dizindeki tüm dosyalar diğer eşler ile paylaşılacaktır."
 
-#: src/muuli_wdr.cpp:1733
+#: src/muuli_wdr.cpp:1737
 msgid "Shared folders"
 msgstr "Paylaşılan dizinler"
 
-#: src/muuli_wdr.cpp:1739
+#: src/muuli_wdr.cpp:1743
 msgid "(Folders shared by the core. Enter a path to add one.)"
 msgstr "(Çekirdek tarafından paylaşılan dizinler. Bir dizin eklemek için yol ilave edin.)"
 
-#: src/muuli_wdr.cpp:1747
+#: src/muuli_wdr.cpp:1751
 msgid "Absolute path of a folder on the core's machine, e.g. /home/user/shared"
 msgstr "Çekirdeğin makinesinde bir dizinin mutlak yolu, mesela /home/rumuz/shared"
 
-#: src/muuli_wdr.cpp:1749 src/PrefsUnifiedDlg.cpp:2874
+#: src/muuli_wdr.cpp:1753 src/PrefsUnifiedDlg.cpp:2883
 msgid "Recursive"
 msgstr "Özyinelemeli"
 
-#: src/muuli_wdr.cpp:1750
+#: src/muuli_wdr.cpp:1754
 msgid "Share every sub-folder underneath this one, including ones created later."
 msgstr "Bunun altındaki tüm alt dizinleri paylaş, ki buna daha sonra oluşturulacak dizinler de dahildir."
 
-#: src/muuli_wdr.cpp:1754 src/utils/aLinkCreator/src/alcframe.cpp:141
+#: src/muuli_wdr.cpp:1758 src/utils/aLinkCreator/src/alcframe.cpp:141
 msgid "Remove"
 msgstr "Çıkar"
 
-#: src/muuli_wdr.cpp:1758
+#: src/muuli_wdr.cpp:1762
 msgid "(Right click on folder icon for recursive share)"
 msgstr "(Özyinelemeli paylaşım için dizin simgesine sağ tıklayınız.)"
 
-#: src/muuli_wdr.cpp:1765
+#: src/muuli_wdr.cpp:1769
 msgid "Share hidden files"
 msgstr "Gizli dosyaları paylaş"
 
-#: src/muuli_wdr.cpp:1771
+#: src/muuli_wdr.cpp:1775
 msgid "Automatically rescan shared folders for changes"
 msgstr "Paylaşılan dizinleri değişiklikler için otomatik olarak tekrar tara"
 
-#: src/muuli_wdr.cpp:1777
+#: src/muuli_wdr.cpp:1781
 msgid "Follow symbolic links in shared folders"
 msgstr "Paylaşılan dizinlerdeki simgesel bağlantıları takip et"
 
-#: src/muuli_wdr.cpp:1783
+#: src/muuli_wdr.cpp:1787
 msgid "Exclude files matching:"
 msgstr "Şununla eşleşen dosyaları dışla:"
 
-#: src/muuli_wdr.cpp:1786
+#: src/muuli_wdr.cpp:1790
 msgid "Wildcard patterns separated by '|', e.g. .DS_Store|Thumbs.db|*.tmp. Files whose name matches are not shared. Matching is case-insensitive."
 msgstr "'|' ile ayrılmış joker karakterli örüntüler (mesela .DS_Store|Thumbs.db|*.tmp). İsmi eşleşen dosyalar paylaşılmaz. Eşleştirme sırasında büyük/küçük harf ayrımı yapılmaz."
 
-#: src/muuli_wdr.cpp:1790
+#: src/muuli_wdr.cpp:1794
 msgid "Patterns are regular expressions"
 msgstr "Örüntüler düzenli ifadelerdir"
 
-#: src/muuli_wdr.cpp:1791
+#: src/muuli_wdr.cpp:1795
 msgid "When set, the whole field is one regular expression ('|' is alternation). When unset, it is a list of '|'-separated wildcards."
 msgstr "Etkinleştirildiğinde, tüm alan tek bir düzenli ifadedir ('|' alternatifler içindir). Devre dışı bırakıldığında, '|' ile ayrılmış jokerler listesidir."
 
-#: src/muuli_wdr.cpp:1801
+#: src/muuli_wdr.cpp:1805
 msgid "Show how many shared files the current pattern would exclude."
 msgstr "Güncel örüntünün kaç paylaşılan dosyayı dışlayacağını göster."
 
-#: src/muuli_wdr.cpp:1822
+#: src/muuli_wdr.cpp:1826
 msgid "Graphs"
 msgstr "Grafikler"
 
-#: src/muuli_wdr.cpp:1825 src/muuli_wdr.cpp:1887
+#: src/muuli_wdr.cpp:1829 src/muuli_wdr.cpp:1891
 msgid "Update delay : 5 secs"
 msgstr "Güncelleme gecikmesi: 5 sn"
 
-#: src/muuli_wdr.cpp:1829
+#: src/muuli_wdr.cpp:1833
 msgid "Time for average graph: 100 mins"
 msgstr "Ortalama grafiği için süre: 100 dk"
 
-#: src/muuli_wdr.cpp:1833
+#: src/muuli_wdr.cpp:1837
 msgid "Connections Graph Scale: 100 "
 msgstr "Bağlantı Grafik Ölçüsü: 100 "
 
-#: src/muuli_wdr.cpp:1840
+#: src/muuli_wdr.cpp:1844
 msgid "Download graph scale:"
 msgstr "İndirme grafik ölçüsü:"
 
-#: src/muuli_wdr.cpp:1848
+#: src/muuli_wdr.cpp:1852
 msgid "Upload graph scale:"
 msgstr "Gönderme grafik ölçüsü:"
 
-#: src/muuli_wdr.cpp:1858
+#: src/muuli_wdr.cpp:1862
 msgid "Colors: "
 msgstr "Renkler: "
 
-#: src/muuli_wdr.cpp:1862
+#: src/muuli_wdr.cpp:1866
 msgid "Background"
 msgstr "Arka plan"
 
-#: src/muuli_wdr.cpp:1863
+#: src/muuli_wdr.cpp:1867
 msgid "Grid"
 msgstr "Izgara"
 
-#: src/muuli_wdr.cpp:1864
+#: src/muuli_wdr.cpp:1868
 msgid "Download current"
 msgstr "Şu anki aktarımlar"
 
-#: src/muuli_wdr.cpp:1865
+#: src/muuli_wdr.cpp:1869
 msgid "Download running average"
 msgstr "Aktarım çalışma ortalaması"
 
-#: src/muuli_wdr.cpp:1866
+#: src/muuli_wdr.cpp:1870
 msgid "Download session average"
 msgstr "Aktarım oturum ortalaması"
 
-#: src/muuli_wdr.cpp:1867
+#: src/muuli_wdr.cpp:1871
 msgid "Upload current"
 msgstr "Şu anki gönderme"
 
-#: src/muuli_wdr.cpp:1868
+#: src/muuli_wdr.cpp:1872
 msgid "Upload running average"
 msgstr "Gönderme çalışma Ortalaması"
 
-#: src/muuli_wdr.cpp:1869
+#: src/muuli_wdr.cpp:1873
 msgid "Upload session average"
 msgstr "Gönderme oturum ortalaması"
 
-#: src/muuli_wdr.cpp:1870
+#: src/muuli_wdr.cpp:1874
 msgid "Active connections"
 msgstr "Aktif bağlantılar"
 
-#: src/muuli_wdr.cpp:1873
+#: src/muuli_wdr.cpp:1877
 msgid "Systray Icon Speed Bar"
 msgstr "Sistem Tepsisi İkonu Hız Göstergesi"
 
-#: src/muuli_wdr.cpp:1874
+#: src/muuli_wdr.cpp:1878
 msgid "Kad-nodes current"
 msgstr "Şu anki Kad düğümleri"
 
-#: src/muuli_wdr.cpp:1875
+#: src/muuli_wdr.cpp:1879
 msgid "Kad-nodes running"
 msgstr "İşlemdeki Kad-düğümleri"
 
-#: src/muuli_wdr.cpp:1876
+#: src/muuli_wdr.cpp:1880
 msgid "Kad-nodes session"
 msgstr "Oturumdaki Kad-düğümleri"
 
-#: src/muuli_wdr.cpp:1880 src/muuli_wdr.cpp:2334
+#: src/muuli_wdr.cpp:1884 src/muuli_wdr.cpp:2338
 msgid "Select"
 msgstr "Seçiniz"
 
-#: src/muuli_wdr.cpp:1884
+#: src/muuli_wdr.cpp:1888
 msgid "Tree"
 msgstr "Ağaç"
 
-#: src/muuli_wdr.cpp:1894
+#: src/muuli_wdr.cpp:1898
 msgid "Number of Client Versions shown (0=unlimited)"
 msgstr "Gösterilen Yazılım Sürümü Sayısı (0=sınırsız)"
 
-#: src/muuli_wdr.cpp:1919
+#: src/muuli_wdr.cpp:1923
 msgid "!!! WARNING !!!"
 msgstr "!!! UYARI !!!"
 
-#: src/muuli_wdr.cpp:1934
+#: src/muuli_wdr.cpp:1938
 msgid "Max new connections / 5 secs"
 msgstr "En fazla yeni bağlantı / 5 sn"
 
-#: src/muuli_wdr.cpp:1936
+#: src/muuli_wdr.cpp:1940
 msgid "Concurrent Kad source lookups"
 msgstr "Eşzamanlı Kad kaynak aramaları"
 
-#: src/muuli_wdr.cpp:1938
+#: src/muuli_wdr.cpp:1942
 msgid "Kad source re-search interval (minutes)"
 msgstr "Kad kaynak tekrar arama zaman aralığı (dakika)"
 
-#: src/muuli_wdr.cpp:1940
+#: src/muuli_wdr.cpp:1944
 msgid "Source re-ask interval (minutes)"
 msgstr "Kaynaklara tekrar sorma zaman aralığı (dakika)"
 
-#: src/muuli_wdr.cpp:1944
+#: src/muuli_wdr.cpp:1948
 msgid "File Buffer Size: 240000 bytes"
 msgstr "Dosya Tampon Boyutu: 240000 bayt"
 
-#: src/muuli_wdr.cpp:1948
+#: src/muuli_wdr.cpp:1952
 msgid "Use MMAP: memory-mapped file access (lower memory use)"
 msgstr "MMAP kullan: \"memory-mapped file access\" yani bellek eşlemeli dosya erişimi (daha az bellek kullanır)"
 
-#: src/muuli_wdr.cpp:1949
+#: src/muuli_wdr.cpp:1953
 msgid "Maps part files into memory instead of buffering them on the heap, lowering the process memory footprint. May reduce download speed on some disks; best for memory-constrained or upload-heavy hosts."
 msgstr "Yığın üzerinde tampona almak yerine kısmi dosyaları bellekte eşleştirir, böylece sürecin bellek ayak izini azaltır. Bazı disklerde indirme hızını düşürebilir; belleği sınırlı veya çok fazla gönderide bulunan makineler için idealdir."
 
-#: src/muuli_wdr.cpp:1951
+#: src/muuli_wdr.cpp:1955
 msgid "Upload Queue Size: 5000 clients"
 msgstr "Gönderme Sıra Boyutu: 5000 kullanıcı"
 
-#: src/muuli_wdr.cpp:1955
+#: src/muuli_wdr.cpp:1959
 msgid "Server connection refresh interval: Disable"
 msgstr "Sunucu bağlantısı yenileme sıklığı: devre dışı"
 
-#: src/muuli_wdr.cpp:1959
+#: src/muuli_wdr.cpp:1963
 msgid "Disable computer's timed standby mode"
 msgstr "Bilgisayarın devre dışı kalma kipini etkisiz hale getir"
 
-#: src/muuli_wdr.cpp:1978
+#: src/muuli_wdr.cpp:1982
 msgid "Skin to use: "
 msgstr "Kullanılacak kaplama: "
 
-#: src/muuli_wdr.cpp:1987
+#: src/muuli_wdr.cpp:1991
 msgid "Show \"Fast eD2k Links Handler\" in every window."
 msgstr "\"Hızlı eD2k Bağlantı Yakalayıcısı\"nı her pencerede göster.."
 
-#: src/muuli_wdr.cpp:1990
+#: src/muuli_wdr.cpp:1994
 msgid "Show extended info on categories tabs"
 msgstr "Sınıf sekmelerinde genişletilmiş bilgi göster."
 
-#: src/muuli_wdr.cpp:1993
+#: src/muuli_wdr.cpp:1997
 msgid "Show application version on title"
 msgstr "Başlık çubuğunda uygulama sürümünü göster"
 
-#: src/muuli_wdr.cpp:1995
+#: src/muuli_wdr.cpp:1999
 msgid "Show transfer rates on title"
 msgstr "Başlık çubuğunda aktarım oranlarını göster."
 
-#: src/muuli_wdr.cpp:1997
+#: src/muuli_wdr.cpp:2001
 msgid "Before application name"
 msgstr "Uygulama adından önce"
 
-#: src/muuli_wdr.cpp:1999
+#: src/muuli_wdr.cpp:2003
 msgid "After application name"
 msgstr "Uygulama adından sonra"
 
-#: src/muuli_wdr.cpp:2002
+#: src/muuli_wdr.cpp:2006
 msgid "Show overhead bandwidth"
 msgstr "Ek yük ağ genişliğini göster"
 
-#: src/muuli_wdr.cpp:2006
+#: src/muuli_wdr.cpp:2010
 msgid "Vertical toolbar orientation"
 msgstr "Dikey araç çubuğu yerleşimi"
 
-#: src/muuli_wdr.cpp:2008
+#: src/muuli_wdr.cpp:2012
 msgid "Live column sorting (auto-reorder rows as their values change)"
 msgstr "Naklen sütun düzenleme (değerleri değiştikçe satırları otomatik olarak tekrar sırala)"
 
-#: src/muuli_wdr.cpp:2015
+#: src/muuli_wdr.cpp:2019
 msgid "Download Queue Files"
 msgstr "Sıradaki Dosyaları İndir"
 
-#: src/muuli_wdr.cpp:2018
+#: src/muuli_wdr.cpp:2022
 msgid "Show progress percentage"
 msgstr "İşlem yüzdesini göster"
 
-#: src/muuli_wdr.cpp:2024
+#: src/muuli_wdr.cpp:2028
 msgid "Show progress bar"
 msgstr "İşlem çubuğunu göster"
 
-#: src/muuli_wdr.cpp:2027
+#: src/muuli_wdr.cpp:2031
 msgid "Flat"
 msgstr "Düz"
 
-#: src/muuli_wdr.cpp:2031
+#: src/muuli_wdr.cpp:2035
 msgid "Round"
 msgstr "Yuvarlatılmış"
 
-#: src/muuli_wdr.cpp:2049
+#: src/muuli_wdr.cpp:2053
 msgid "External Connection Parameters"
 msgstr "Dışarıdan Bağlantı Parametreleri"
 
-#: src/muuli_wdr.cpp:2052
+#: src/muuli_wdr.cpp:2056
 msgid "Accept external connections"
 msgstr "Dışarıdan bağlantıları kabul et."
 
-#: src/muuli_wdr.cpp:2059 src/muuli_wdr.cpp:2118
+#: src/muuli_wdr.cpp:2063 src/muuli_wdr.cpp:2122
 msgid "IP of the listening interface:"
 msgstr "Dinlenen arayüzün IP' si:"
 
-#: src/muuli_wdr.cpp:2062
+#: src/muuli_wdr.cpp:2066
 msgid "Enter here a valid ip in the a.b.c.d format for the listening EC interface. An empty field or 0.0.0.0 will mean any interface."
 msgstr "Dinleme EC arayüzü için a.b.c.d biçiminde geçerli bir ip giriniz. Boş bırakılan alan veya 0.0.0.0 arayüz yok demektir."
 
-#: src/muuli_wdr.cpp:2083 src/muuli_wdr.cpp:2194
+#: src/muuli_wdr.cpp:2087 src/muuli_wdr.cpp:2198
 msgid "TCP port:"
 msgstr "TCP portu:"
 
-#: src/muuli_wdr.cpp:2089
+#: src/muuli_wdr.cpp:2093
 msgid "Enable UPnP port forwarding on the EC port"
 msgstr "EC portuna UPnP port yönlendirmesi etkin."
 
-#: src/muuli_wdr.cpp:2093 src/muuli_wdr.cpp:3079
+#: src/muuli_wdr.cpp:2097 src/muuli_wdr.cpp:3083
 #: src/utils/wxCas/src/wxcasprefs.cpp:167
 msgid "Password"
 msgstr "Şifre"
 
-#: src/muuli_wdr.cpp:2099
+#: src/muuli_wdr.cpp:2103
 msgid "aMule API server parameters"
 msgstr "aMule API sunucusu parametreleri"
 
-#: src/muuli_wdr.cpp:2102
+#: src/muuli_wdr.cpp:2106
 msgid "Run amuleapi (REST API) on startup"
 msgstr "Başlangıçta amuleapi (REST API) çalıştır"
 
-#: src/muuli_wdr.cpp:2107
+#: src/muuli_wdr.cpp:2111
 msgid "HTTP port:"
 msgstr "HTTP bağlantı noktası:"
 
-#: src/muuli_wdr.cpp:2121
+#: src/muuli_wdr.cpp:2125
 msgid "The interface amuleapi's HTTP server listens on. 127.0.0.1 (default) accepts only local connections; use 0.0.0.0 or a specific IP to expose it to other hosts (set an admin password below)."
 msgstr "amuleapi HTTP sunucusunun dinlediği arayüz. 127.0.0.1 (varsayılan) sadece yerel bağlantıları kabul eder; onu başka makinelere açmak için 0.0.0.0 veya belirli bir IP kullanın (aşağıda bir yönetici parolası tanımlayın)."
 
-#: src/muuli_wdr.cpp:2126
+#: src/muuli_wdr.cpp:2130
 msgid "Type a password to set or change it. Stored passwords cannot be shown, so leaving this empty keeps the current one."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2128
+#: src/muuli_wdr.cpp:2132
 msgid "Admin password"
 msgstr "Yönetici parolası"
 
-#: src/muuli_wdr.cpp:2140 src/muuli_wdr.cpp:2157 src/PrefsUnifiedDlg.cpp:1103
+#: src/muuli_wdr.cpp:2144 src/muuli_wdr.cpp:2161 src/PrefsUnifiedDlg.cpp:1112
 #, fuzzy
 msgid "A password is set."
 msgstr "Yönetici parolası"
 
-#: src/muuli_wdr.cpp:2144
+#: src/muuli_wdr.cpp:2148
 #, fuzzy
 msgid "Enable guest access"
 msgstr "Konuk girişini reddet"
 
-#: src/muuli_wdr.cpp:2145
+#: src/muuli_wdr.cpp:2149
 msgid "Guest sessions may read status and listings but cannot change anything. Turning this off clears the stored guest password."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2149
+#: src/muuli_wdr.cpp:2153
 #, fuzzy
 msgid "Guest password"
 msgstr "Web sunucusu için konuk parolası"
 
-#: src/muuli_wdr.cpp:2164
+#: src/muuli_wdr.cpp:2168
 msgid "Web server parameters"
 msgstr "Web sunucusu değerleri"
 
-#: src/muuli_wdr.cpp:2167
+#: src/muuli_wdr.cpp:2171
 msgid "Run webserver on startup (deprecated)"
 msgstr "Başlangıçta web sunucusunu başlat (eskimiş)"
 
-#: src/muuli_wdr.cpp:2173
+#: src/muuli_wdr.cpp:2177
 msgid "Web template"
 msgstr "Web şablonu"
 
-#: src/muuli_wdr.cpp:2178
+#: src/muuli_wdr.cpp:2182
 msgid "Full rights password"
 msgstr "Tam hak şifresi"
 
-#: src/muuli_wdr.cpp:2182
+#: src/muuli_wdr.cpp:2186
 msgid "Enable Low rights User"
 msgstr "Düşük hakka sahip kullanıcıyı etkin kıl."
 
-#: src/muuli_wdr.cpp:2187
+#: src/muuli_wdr.cpp:2191
 msgid "Low rights password"
 msgstr "Düşük hak şifresi"
 
-#: src/muuli_wdr.cpp:2201
+#: src/muuli_wdr.cpp:2205
 msgid "Enable UPnP port forwarding of the web server port"
 msgstr "Web sunucu portunun UPnp port iletimini etkinleştir"
 
-#: src/muuli_wdr.cpp:2206
+#: src/muuli_wdr.cpp:2210
 msgid "Web server UPnP TCP port (Optional)"
 msgstr "Web sunucusu UPnp TCP portu (İsteğe bağlı)"
 
-#: src/muuli_wdr.cpp:2214
+#: src/muuli_wdr.cpp:2218
 msgid "Page Refresh Time (in secs)"
 msgstr "Sayfa yenileme zamanı (sn)"
 
-#: src/muuli_wdr.cpp:2221
+#: src/muuli_wdr.cpp:2225
 msgid "Enable Gzip compression"
 msgstr "Gzip sıkıştırmayı etkinleştir."
 
-#: src/muuli_wdr.cpp:2255
+#: src/muuli_wdr.cpp:2259
 msgid "Reset page to defaults"
 msgstr "Sayfayı varsayılan değerlere sıfırla"
 
-#: src/muuli_wdr.cpp:2256
+#: src/muuli_wdr.cpp:2260
 msgid "Reset the settings on the current page to their default values."
 msgstr "Güncel sayfadaki ayarları varsayılan değerlerine sıfırla."
 
-#: src/muuli_wdr.cpp:2258 src/muuli_wdr.cpp:2344 src/ServerWnd.cpp:274
+#: src/muuli_wdr.cpp:2262 src/muuli_wdr.cpp:2348 src/ServerWnd.cpp:274
 #: src/ServerWnd.cpp:282
 msgid "OK"
 msgstr "Tamam"
 
-#: src/muuli_wdr.cpp:2260
+#: src/muuli_wdr.cpp:2264
 msgid "Click here to apply any changes made to the preferences."
 msgstr "Ayarlarda yapılan değişikliklerin uygulanması için buraya tıklayınız."
 
-#: src/muuli_wdr.cpp:2263
+#: src/muuli_wdr.cpp:2267
 msgid "Reset any changes made to the preferences."
 msgstr "Ayarlarda yapılan değişiklikleri sil."
 
-#: src/muuli_wdr.cpp:2292
+#: src/muuli_wdr.cpp:2296
 msgid "Comment :"
 msgstr "Yorum:"
 
-#: src/muuli_wdr.cpp:2299
+#: src/muuli_wdr.cpp:2303
 msgid "Incoming Dir :"
 msgstr "Gelen Dosyalar Dizini :"
 
-#: src/muuli_wdr.cpp:2308
+#: src/muuli_wdr.cpp:2312
 msgid "Change priority for new assigned files :"
 msgstr "Yeni eklenen dosyalar için öncelikleri değiştir:"
 
-#: src/muuli_wdr.cpp:2312
+#: src/muuli_wdr.cpp:2316
 msgid "Don't change"
 msgstr "Değiştirme"
 
-#: src/muuli_wdr.cpp:2324
+#: src/muuli_wdr.cpp:2328
 msgid "Select color for this Category (currently selected) :"
 msgstr "Bu sınıf için renk seçiniz (varsayılan) :"
 
-#: src/muuli_wdr.cpp:2391 src/muuli_wdr.cpp:2410 src/muuli_wdr.cpp:2432
+#: src/muuli_wdr.cpp:2395 src/muuli_wdr.cpp:2414 src/muuli_wdr.cpp:2436
 msgid "Click this button to reset the log."
 msgstr "Günlük kayıtlarını silmek için bu düğmeye basınız."
 
-#: src/muuli_wdr.cpp:2451
+#: src/muuli_wdr.cpp:2455
 msgid "Click on this button to update the servers list from URL ..."
 msgstr "Sunucu listesini İnternet'den güncellemek için bu düğmeye basınız…"
 
-#: src/muuli_wdr.cpp:2455
+#: src/muuli_wdr.cpp:2459
 msgid "Server list"
 msgstr "Sunucu"
 
-#: src/muuli_wdr.cpp:2459
+#: src/muuli_wdr.cpp:2463
 msgid "Enter the url to a server.met file here and press the button to the left to update the list of known servers."
 msgstr "Adresi server.met dosyasına buradan giriniz. Sonra, bilinen sunucuları güncellemek için soldaki düğmeye tıklayınız."
 
-#: src/muuli_wdr.cpp:2464
+#: src/muuli_wdr.cpp:2468
 msgid "Add server manually: Name"
 msgstr "Sunucuyu elle ekle: İsim"
 
-#: src/muuli_wdr.cpp:2467
+#: src/muuli_wdr.cpp:2471
 msgid "Enter the name of the new server here"
 msgstr "Yeni sunucunun adını buraya giriniz."
 
-#: src/muuli_wdr.cpp:2469 src/ServerWnd.cpp:206
+#: src/muuli_wdr.cpp:2473 src/ServerWnd.cpp:206
 msgid "IP:Port"
 msgstr "IP:Port"
 
-#: src/muuli_wdr.cpp:2472
+#: src/muuli_wdr.cpp:2476
 msgid "Enter the IP of the server here, using the x.x.x.x format."
 msgstr "Yeni sunucun IP numarasını x.x.x.x biçiminde buraya giriniz."
 
-#: src/muuli_wdr.cpp:2478
+#: src/muuli_wdr.cpp:2482
 msgid "Enter the port of the server here."
 msgstr "Sunucunu portunu buraya giriniz."
 
-#: src/muuli_wdr.cpp:2481
+#: src/muuli_wdr.cpp:2485
 msgid "Add manually a server (fill fields to the left before) ..."
 msgstr "Sunucuyu elle ekle (önce soldaki alanları doldurunuz) …"
 
-#: src/muuli_wdr.cpp:2510
+#: src/muuli_wdr.cpp:2514
 msgid "aMule Log"
 msgstr "aMule Günlüğü"
 
-#: src/muuli_wdr.cpp:2518
+#: src/muuli_wdr.cpp:2522
 msgid "Server Info"
 msgstr "Sunucu Bilgisi"
 
-#: src/muuli_wdr.cpp:2522
+#: src/muuli_wdr.cpp:2526
 msgid "ED2K Info"
 msgstr "ED2K Bilgileri"
 
-#: src/muuli_wdr.cpp:2526
+#: src/muuli_wdr.cpp:2530
 msgid "Kad Info"
 msgstr "Kademlia Bilgileri"
 
-#: src/muuli_wdr.cpp:2554
+#: src/muuli_wdr.cpp:2558
 msgid "Click on this button to update the nodes list from URL ..."
 msgstr "Düğüm listesini İnternet'den güncellemek için bu düğmeye tıklayınız."
 
-#: src/muuli_wdr.cpp:2558
+#: src/muuli_wdr.cpp:2562
 msgid "Nodes (0)"
 msgstr "Düğümler (0)"
 
-#: src/muuli_wdr.cpp:2562
+#: src/muuli_wdr.cpp:2566
 msgid "Enter the url to a nodes.dat file here and press the button to the left to update the list of known nodes."
 msgstr "Bilinen düğümleri güncellemek için buraya adresi giriniz ve soldaki düğmeye tıklayınız."
 
-#: src/muuli_wdr.cpp:2565
+#: src/muuli_wdr.cpp:2569
 msgid "Nodes stats"
 msgstr "Düğüm istatistikleri"
 
-#: src/muuli_wdr.cpp:2607
+#: src/muuli_wdr.cpp:2611
 msgid "Bootstrap"
 msgstr "Ön Yükleme"
 
-#: src/muuli_wdr.cpp:2610
+#: src/muuli_wdr.cpp:2614
 msgid "New node"
 msgstr "Yeni düğüm"
 
-#: src/muuli_wdr.cpp:2615
+#: src/muuli_wdr.cpp:2619
 msgid "IP:"
 msgstr "IP:"
 
-#: src/muuli_wdr.cpp:2635
+#: src/muuli_wdr.cpp:2639
 msgid "Port:"
 msgstr "Port:"
 
-#: src/muuli_wdr.cpp:2648
+#: src/muuli_wdr.cpp:2652
 msgid "Bootstrap from known clients"
 msgstr "Bilinen kullanıcılardan Ön Yükleme"
 
-#: src/muuli_wdr.cpp:2650
+#: src/muuli_wdr.cpp:2654
 msgid "Disconnect Kad"
 msgstr "Kad Bağlantısını Kes"
 
-#: src/muuli_wdr.cpp:2684
+#: src/muuli_wdr.cpp:2688
 msgid "Use Secure User Identification"
 msgstr "Güvenli Kullanıcı Kimlik Doğrulamasını Kullan"
 
-#: src/muuli_wdr.cpp:2686
+#: src/muuli_wdr.cpp:2690
 msgid "It is recommended to enable this option. You will not receive credits if SUI is not enabled."
 msgstr "Bu seçeneği aktifleştirmeniz önerilir. SUI aktif değilse, kredi alamazsınız."
 
-#: src/muuli_wdr.cpp:2688
+#: src/muuli_wdr.cpp:2692
 msgid "Protocol Obfuscation"
 msgstr "Protokol Gizleme"
 
-#: src/muuli_wdr.cpp:2691
+#: src/muuli_wdr.cpp:2695
 msgid "Support Protocol Obfuscation"
 msgstr "Protokol Gizleme etkin"
 
-#: src/muuli_wdr.cpp:2693
+#: src/muuli_wdr.cpp:2697
 msgid "This option enabled Protocol Obfuscation, and makes aMule accept obfuscated connections from other clients."
 msgstr "Bu seçenek Protokol Gizleme'yi etkinleştirir ve aMule'nin gizlenmiş bağlantıları kabul etmesini sağlar."
 
-#: src/muuli_wdr.cpp:2695
+#: src/muuli_wdr.cpp:2699
 msgid "Use obfuscation for outgoing connections"
 msgstr "Giden bağlantılar için gizleme kullan"
 
-#: src/muuli_wdr.cpp:2697
+#: src/muuli_wdr.cpp:2701
 msgid "This option makes aMule use Protocol Obfuscation when connecting other clients/servers."
 msgstr "Bu seçenek diğer kullanıcı veya sunucularla olan bağlantılarda Protokol Gizleme'yi etkinleştirir."
 
-#: src/muuli_wdr.cpp:2699
+#: src/muuli_wdr.cpp:2703
 msgid "Accept only obfuscated connections"
 msgstr "Sadece gizlenmiş bağlantıları kabul et"
 
-#: src/muuli_wdr.cpp:2700
+#: src/muuli_wdr.cpp:2704
 msgid "This option makes aMule only accept obfuscated connections. You will have less sources, but all your traffic will be obfuscated"
 msgstr "Bu seçenek aMule'nin sadece gizlenmiş bağlantıları kabul etmesini sağlar. Daha az kaynak bulursunuz; ancak tüm trafiğiniz de karartılmış olur."
 
-#: src/muuli_wdr.cpp:2705
+#: src/muuli_wdr.cpp:2709
 msgid "Everybody"
 msgstr "Herkes"
 
-#: src/muuli_wdr.cpp:2707
+#: src/muuli_wdr.cpp:2711
 msgid "No one"
 msgstr "Hiç kimse"
 
-#: src/muuli_wdr.cpp:2709
+#: src/muuli_wdr.cpp:2713
 msgid "Who can see my shared files:"
 msgstr "Paylaşılan dosyalarımı kim görebilir:"
 
-#: src/muuli_wdr.cpp:2710
+#: src/muuli_wdr.cpp:2714
 msgid "Select who can request to view a list of your shared files."
 msgstr "Paylaşılan dosyalarınızı kime göstereceğinizi seçiniz."
 
-#: src/muuli_wdr.cpp:2712
+#: src/muuli_wdr.cpp:2716
 msgid "IP-Filtering"
 msgstr "IP_Süzme"
 
-#: src/muuli_wdr.cpp:2719
+#: src/muuli_wdr.cpp:2723
 msgid "Filter clients"
 msgstr "Kullanıcıları Süz"
 
-#: src/muuli_wdr.cpp:2721
+#: src/muuli_wdr.cpp:2725
 msgid "Enable filtering of the client IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "~/.aMule/ipfilter.dat dosyasında tanımlanan kullanıcı IP'lerini süzmeyi etkinleştir."
 
-#: src/muuli_wdr.cpp:2723
+#: src/muuli_wdr.cpp:2727
 msgid "Filter servers"
 msgstr "Sunucuları süz"
 
-#: src/muuli_wdr.cpp:2725
+#: src/muuli_wdr.cpp:2729
 msgid "Enable filtering of the server IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "~/.aMule/ipfilter.dat dosyasında tanımlanan sunucu IP'lerini süzmeyi etkinleştir."
 
-#: src/muuli_wdr.cpp:2729
+#: src/muuli_wdr.cpp:2733
 msgid "Reload List"
 msgstr "Listeyi yeniden yükle"
 
-#: src/muuli_wdr.cpp:2730
+#: src/muuli_wdr.cpp:2734
 msgid "Reload the list of IPs to filter from the file ~/.aMule/ipfilter.dat"
 msgstr "~/.aMule/ipfilter.dat dosyasından IP'leri süzgece yeniden yükle."
 
-#: src/muuli_wdr.cpp:2736
+#: src/muuli_wdr.cpp:2740
 msgid "URL:"
 msgstr "Adres:"
 
-#: src/muuli_wdr.cpp:2740 src/muuli_wdr.cpp:2933
+#: src/muuli_wdr.cpp:2744 src/muuli_wdr.cpp:2937
 msgid "Update now"
 msgstr "Şimdi güncelle"
 
-#: src/muuli_wdr.cpp:2743
+#: src/muuli_wdr.cpp:2747
 msgid "Auto-update ipfilter at startup"
 msgstr "Ip süzgecini başlangıçta otomatikman güncelle."
 
-#: src/muuli_wdr.cpp:2747
+#: src/muuli_wdr.cpp:2751
 msgid "Filtering Level:"
 msgstr "Süzme Seviyesi:"
 
-#: src/muuli_wdr.cpp:2753
+#: src/muuli_wdr.cpp:2757
 msgid "Always filter LAN IPs"
 msgstr "Her zaman LAN IP'lerini süz."
 
-#: src/muuli_wdr.cpp:2756
+#: src/muuli_wdr.cpp:2760
 msgid "Paranoid handling of non-matching IPs"
 msgstr "Uyuşmayan IP'lere şüpheci yaklaşım."
 
-#: src/muuli_wdr.cpp:2758
+#: src/muuli_wdr.cpp:2762
 msgid "Rejects a packet when its source IP differs from the IP the client claims (an anti-spoofing check). Disable only if it causes connection problems."
 msgstr "İstemcinin sahip olduğunu iddia ettiği IP, kaynak IP'den farklı olduğunda paketi reddeder (sahtekarlık önleyici kontrol). Sadece bağlantı sorunları oluşturuyorsa devre dışı bırakın."
 
-#: src/muuli_wdr.cpp:2760
+#: src/muuli_wdr.cpp:2764
 msgid "Use system-wide ipfilter.dat if available"
 msgstr "Varsa, sistem geneli ipfilter.dat kullan"
 
-#: src/muuli_wdr.cpp:2761
+#: src/muuli_wdr.cpp:2765
 msgid "If there's no local ipfilter.dat found, allow usage of a system-wide ipfilter file."
 msgstr "Yerel bir ipfilter.dat dosyası bulunamazsa, sistem geneli ipfilter kullanımına izin ver."
 
-#: src/muuli_wdr.cpp:2778
+#: src/muuli_wdr.cpp:2782
 msgid "Enable Online-Signature"
 msgstr "Çevrimiçi-İmza' yı Etkinleştir"
 
-#: src/muuli_wdr.cpp:2780
+#: src/muuli_wdr.cpp:2784
 msgid "Enables the writing of the OS file, which can be used by external apps to create signatures and the like."
 msgstr "Diğer uygulamaların imzalar ve benzerlerini oluşturabilmesi için kullanabileceği Çev.İmza dosyasını yazmayı etkinleştirir."
 
-#: src/muuli_wdr.cpp:2784
+#: src/muuli_wdr.cpp:2788
 msgid "Update Frequency (Secs):"
 msgstr "Güncelleme Sıklığı (Sn.):"
 
-#: src/muuli_wdr.cpp:2787
+#: src/muuli_wdr.cpp:2791
 msgid "Change the frequency (in seconds) of Online Signature updates."
 msgstr "Çevrim içi İmza güncellemeleri için (saniye bazında) sıklığı değiştirir."
 
-#: src/muuli_wdr.cpp:2795
+#: src/muuli_wdr.cpp:2799
 msgid "Save online signature file in: "
 msgstr "Çevrim içi imza dosyasını buraya sakla: "
 
-#: src/muuli_wdr.cpp:2801
+#: src/muuli_wdr.cpp:2805
 msgid "Click here to select the directory containing the the Online Signature files."
 msgstr "Çevrim içi İmza dosyalarını içeren dizini seçiniz."
 
-#: src/muuli_wdr.cpp:2834
+#: src/muuli_wdr.cpp:2838
 msgid "Show country flags for clients"
 msgstr "İstemciler için ülke bayraklarını göster"
 
-#: src/muuli_wdr.cpp:2835
+#: src/muuli_wdr.cpp:2839
 msgid "Render the country flag column in the transfers, queue and search views. Requires a valid MMDB GeoIP database (see below)."
 msgstr "Transferler, kuyruklar ve arama görünümlerinde ülkelerin bayrakları sütununu görüntüle. Geçerli bir MMDB GeoIP veri tabanı gerektirir (aşağıya bakınız)."
 
-#: src/muuli_wdr.cpp:2840
+#: src/muuli_wdr.cpp:2844
 msgid "Database"
 msgstr "Veri Tabanı"
 
-#: src/muuli_wdr.cpp:2856
+#: src/muuli_wdr.cpp:2860
 msgid "Source:"
 msgstr "Kaynak:"
 
-#: src/muuli_wdr.cpp:2859
+#: src/muuli_wdr.cpp:2863
 msgid "DB-IP (free, no account)"
 msgstr "DB-IP (ücretsiz, hesap gerektirmez)"
 
-#: src/muuli_wdr.cpp:2860
+#: src/muuli_wdr.cpp:2864
 msgid "MaxMind GeoLite2 (free, account required)"
 msgstr "MaxMind GeoLite2 (ücretsiz, hesap gerektirir)"
 
-#: src/muuli_wdr.cpp:2861
+#: src/muuli_wdr.cpp:2865
 msgid "Custom URL"
 msgstr "Kişiselleştirilmiş URL"
 
-#: src/muuli_wdr.cpp:2864
+#: src/muuli_wdr.cpp:2868
 msgid "Choose which provider supplies the GeoIP MMDB database. DB-IP is the default - no account required. MaxMind requires a free account + license key. Use Custom URL to point at any other MMDB host (e.g. a local mirror)."
 msgstr "Hangi tedarikçinin GeoIP MMDB veri tabanını sağlayacağını seçin. DB-IP varsayılan değerdir - hesap gerektirmez. MaxMind ücretsiz bir hesap + lisans anahtarı gerektirir. Herhangi başka bir MMDB makinesine (mesela yerel bir yansıya) yönlendirme yapmak için kişiselleştirilmiş URL kullanın."
 
-#: src/muuli_wdr.cpp:2881
+#: src/muuli_wdr.cpp:2885
 msgid ""
 "No configuration required.\n"
 "\n"
@@ -4853,11 +4853,11 @@ msgstr ""
 "IP-Ülke verileri DB-IP.com tarafından sağlanmaktadır - https://db-ip.com\n"
 "Lisans: Creative Commons Atıf 4.0 - https://creativecommons.org/licenses/by/4.0/deed.tr"
 
-#: src/muuli_wdr.cpp:2894
+#: src/muuli_wdr.cpp:2898
 msgid "License key:"
 msgstr "Lisans anahtarı:"
 
-#: src/muuli_wdr.cpp:2900
+#: src/muuli_wdr.cpp:2904
 msgid ""
 "Sign up for a free MaxMind account, then generate a License Key:\n"
 "https://www.maxmind.com/en/geolite2/signup\n"
@@ -4873,11 +4873,11 @@ msgstr ""
 "Lisans: MaxMind GeoLite2 Kullanıcı Lisans Anlaşması - https://www.maxmind.com/en/geolite2/eula\n"
 "Atıf ve hesap oluşturulması gerektirir; en az her 30 günde bir güncelleyin."
 
-#: src/muuli_wdr.cpp:2915
+#: src/muuli_wdr.cpp:2919
 msgid "Download URL:"
 msgstr "İndirme Bağlantısı:"
 
-#: src/muuli_wdr.cpp:2921
+#: src/muuli_wdr.cpp:2925
 msgid ""
 "Must point to an .mmdb file or a .gz / .tar.gz containing one.\n"
 "URL may include credentials (https://user:pass@host/...).\n"
@@ -4887,211 +4887,211 @@ msgstr ""
 "Bağlantı kimlik doğrulama bilgileri içerebilir (https://kullanıcı:parola@makine/…)\n"
 "Lisans ve atıf koşulları kaynak URL tarafından belirlenir - bunlardan siz sorumlu olursunuz."
 
-#: src/muuli_wdr.cpp:2934
+#: src/muuli_wdr.cpp:2938
 msgid "Download the GeoIP database from the selected source."
 msgstr "Seçili kaynaktan GeoIP veri tabanını indir."
 
-#: src/muuli_wdr.cpp:2936
+#: src/muuli_wdr.cpp:2940
 msgid "Auto-update on startup"
 msgstr "Başlangıçta otomatik olarak güncelle"
 
-#: src/muuli_wdr.cpp:2937
+#: src/muuli_wdr.cpp:2941
 msgid "Re-download the GeoIP database from the selected source every time aMule starts."
 msgstr "aMule her başladığında, GeoIP veri tabanını seçili kaynaktan tekrar indir."
 
-#: src/muuli_wdr.cpp:2960
+#: src/muuli_wdr.cpp:2964
 msgid "Filter incoming messages (except current chat):"
 msgstr "Gelen iletileri süz (o anki sohbet dışında):"
 
-#: src/muuli_wdr.cpp:2962
+#: src/muuli_wdr.cpp:2966
 msgid "Filter all messages"
 msgstr "Hepsini süz."
 
-#: src/muuli_wdr.cpp:2964
+#: src/muuli_wdr.cpp:2968
 msgid "Filter messages from people not on your friend list"
 msgstr "Arkadaş listesindekiler dışında herkesi süz."
 
-#: src/muuli_wdr.cpp:2966
+#: src/muuli_wdr.cpp:2970
 msgid "Filter messages from unknown clients"
 msgstr "Bilinmeyen yazılımlardan gelenleri süz."
 
-#: src/muuli_wdr.cpp:2968
+#: src/muuli_wdr.cpp:2972
 msgid "Filter messages containing (use ',' as separator):"
 msgstr "Şu içerikteki iletileri süz (ayraç olarak ',' kullanınız.):"
 
-#: src/muuli_wdr.cpp:2971 src/muuli_wdr.cpp:2982
+#: src/muuli_wdr.cpp:2975 src/muuli_wdr.cpp:2986
 msgid "add here the words amule should filter and block messages including it"
 msgstr "buraya ekleyeceğiniz sözcükleri içeren iletiler aMule tarafından engellenir."
 
-#: src/muuli_wdr.cpp:2973
+#: src/muuli_wdr.cpp:2977
 msgid "Show received messages in the log"
 msgstr "Günlükte alınan iletileri göster"
 
-#: src/muuli_wdr.cpp:2976
+#: src/muuli_wdr.cpp:2980
 msgid "Comments"
 msgstr "Yorumlar"
 
-#: src/muuli_wdr.cpp:2979
+#: src/muuli_wdr.cpp:2983
 msgid "Filter comments containing (use ',' as separator):"
 msgstr "Şu içerikteki iletileri süz (ayraç olarak ',' kullanınız.):"
 
-#: src/muuli_wdr.cpp:3004
+#: src/muuli_wdr.cpp:3008
 msgid "Enable Proxy"
 msgstr "Vekil sunucuyu Etkinleştir."
 
-#: src/muuli_wdr.cpp:3005
+#: src/muuli_wdr.cpp:3009
 msgid "Enable/disable proxy support"
 msgstr "Vekil sunucu desteğini etkinleştir/devre dışı bırak"
 
-#: src/muuli_wdr.cpp:3008
+#: src/muuli_wdr.cpp:3012
 msgid "Proxy type:"
 msgstr "Vekil sunucu Türü:"
 
-#: src/muuli_wdr.cpp:3019
+#: src/muuli_wdr.cpp:3023
 msgid "Proxy host:"
 msgstr "Vekil sunucu makine:"
 
-#: src/muuli_wdr.cpp:3022
+#: src/muuli_wdr.cpp:3026
 msgid "The proxy host name"
 msgstr "Vekil sunucu makine adı"
 
-#: src/muuli_wdr.cpp:3024
+#: src/muuli_wdr.cpp:3028
 msgid "Proxy port:"
 msgstr "Vekil sunucu Portu:"
 
-#: src/muuli_wdr.cpp:3027
+#: src/muuli_wdr.cpp:3031
 msgid "The proxy port"
 msgstr "Vekil sunucu portu"
 
-#: src/muuli_wdr.cpp:3029
+#: src/muuli_wdr.cpp:3033
 msgid "Enable authentication"
 msgstr "Yetkilendirmeyi etkinleştir."
 
-#: src/muuli_wdr.cpp:3030
+#: src/muuli_wdr.cpp:3034
 msgid "Enable/disable username/password authentication"
 msgstr "Kullanıcı adı/şifre yetkilendirmeyi etkinleştir/devre dışı bırak."
 
-#: src/muuli_wdr.cpp:3033
+#: src/muuli_wdr.cpp:3037
 msgid "Username: "
 msgstr "Kullanıcı adı: "
 
-#: src/muuli_wdr.cpp:3036
+#: src/muuli_wdr.cpp:3040
 msgid "The username to use to connect to the proxy"
 msgstr "Vekil sunucuya bağlanmak için gerekli kullanıcı adı"
 
-#: src/muuli_wdr.cpp:3038
+#: src/muuli_wdr.cpp:3042
 msgid "Password:"
 msgstr "Şifre:"
 
-#: src/muuli_wdr.cpp:3041
+#: src/muuli_wdr.cpp:3045
 msgid "The password to use to connect to the proxy"
 msgstr "Vekil sunucuya bağlanmak için gerekli şifre"
 
-#: src/muuli_wdr.cpp:3060
+#: src/muuli_wdr.cpp:3064
 msgid "Connect to:"
 msgstr "Bağlan:"
 
-#: src/muuli_wdr.cpp:3069
+#: src/muuli_wdr.cpp:3073
 msgid "Login to remote amule"
 msgstr "Uzaktan aMule'ye giriş yapınız."
 
-#: src/muuli_wdr.cpp:3074
+#: src/muuli_wdr.cpp:3078
 msgid "User name"
 msgstr "Kullanıcı adı"
 
-#: src/muuli_wdr.cpp:3085
+#: src/muuli_wdr.cpp:3089
 msgid "Remember those settings"
 msgstr "Bu ayarları hatırla"
 
-#: src/muuli_wdr.cpp:3088
+#: src/muuli_wdr.cpp:3092
 msgid "Force ZLIB compression"
 msgstr "ZLIB sıkıştırmasını zorla"
 
-#: src/muuli_wdr.cpp:3112
+#: src/muuli_wdr.cpp:3116
 msgid "Enable Verbose Debug-Logging."
 msgstr "Fazladan Hata Çıktısı Kaydını Etkinleştir."
 
-#: src/muuli_wdr.cpp:3114
+#: src/muuli_wdr.cpp:3118
 msgid "Only to Logfile"
 msgstr "Sadece Kütük Dosyasına"
 
-#: src/muuli_wdr.cpp:3116
+#: src/muuli_wdr.cpp:3120
 msgid "Message Categories:"
 msgstr "İleti Sınıfları:"
 
-#: src/muuli_wdr.cpp:3140 src/PartFileConvertDlg.cpp:160
+#: src/muuli_wdr.cpp:3144 src/PartFileConvertDlg.cpp:160
 msgid "Waiting..."
 msgstr "Bekliyor…"
 
-#: src/muuli_wdr.cpp:3160
+#: src/muuli_wdr.cpp:3164
 msgid "Add imports"
 msgstr "İçe aktarımları ekle"
 
-#: src/muuli_wdr.cpp:3163
+#: src/muuli_wdr.cpp:3167
 msgid "Retry selected"
 msgstr "Seçileni tekrar dene"
 
-#: src/muuli_wdr.cpp:3165
+#: src/muuli_wdr.cpp:3169
 msgid "Remove selected"
 msgstr "Seçileni çıkar"
 
-#: src/muuli_wdr.cpp:3228
+#: src/muuli_wdr.cpp:3232
 msgid "Event Types"
 msgstr "Olay Türleri"
 
-#: src/muuli_wdr.cpp:3247
+#: src/muuli_wdr.cpp:3251
 msgid "Statistics and queued clients for selected file(s) : Session / All time"
 msgstr "Seçili dosya(lar) için kuyruktaki istemciler ve istatistikler: Oturum / Bütün zamanlar"
 
-#: src/muuli_wdr.cpp:3271
+#: src/muuli_wdr.cpp:3275
 msgid "Active Uploads"
 msgstr "Etkin Göndermeler"
 
-#: src/muuli_wdr.cpp:3285
+#: src/muuli_wdr.cpp:3289
 msgid "Percent of total files"
 msgstr "Toplam dosyaların yüzdesi"
 
-#: src/muuli_wdr.cpp:3337
+#: src/muuli_wdr.cpp:3341
 msgid "Show Clients for"
 msgstr "Kullanıcıları Göster"
 
-#: src/muuli_wdr.cpp:3339
+#: src/muuli_wdr.cpp:3343
 msgid "All files"
 msgstr "Tüm dosyalar"
 
-#: src/muuli_wdr.cpp:3342
+#: src/muuli_wdr.cpp:3346
 msgid "Selected files"
 msgstr "Seçilen dosyalar"
 
-#: src/muuli_wdr.cpp:3345
+#: src/muuli_wdr.cpp:3349
 msgid "Active uploads only"
 msgstr "Sadece aktif Göndermeler"
 
-#: src/muuli_wdr.cpp:3352
+#: src/muuli_wdr.cpp:3356
 msgid "Reload:"
 msgstr "Yeniden yükle:"
 
-#: src/muuli_wdr.cpp:3356
+#: src/muuli_wdr.cpp:3360
 msgid "Reload your shared files"
 msgstr "Paylaşılan dosyalarınızı yeniden yükleyin"
 
-#: src/muuli_wdr.cpp:3419
+#: src/muuli_wdr.cpp:3423
 msgid "Send"
 msgstr "Gönder"
 
-#: src/muuli_wdr.cpp:3420
+#: src/muuli_wdr.cpp:3424
 msgid "Sends the specified message."
 msgstr "Belirlenen iletiyi gönderir."
 
-#: src/muuli_wdr.cpp:3424
+#: src/muuli_wdr.cpp:3428
 msgid "Close this chat-session."
 msgstr "Bu sohbet oturumunu kapatır."
 
-#: src/muuli_wdr.cpp:3447
+#: src/muuli_wdr.cpp:3451
 msgid "Connect to any server and/or Kad"
 msgstr "Herhangi bir sunucuya ve/veya Kad'a bağlan."
 
-#: src/muuli_wdr.cpp:3453 src/SharedFilesCtrl.cpp:142 src/Statistics.cpp:941
+#: src/muuli_wdr.cpp:3457 src/SharedFilesCtrl.cpp:142 src/Statistics.cpp:941
 msgid "Shared Files"
 msgstr "Paylaşılan Dosyalar"
 
@@ -5726,35 +5726,35 @@ msgstr ""
 "Bu ayarlarla oynanmasa da\n"
 "aMule gayet iyi işleyecektir."
 
-#: src/PrefsUnifiedDlg.cpp:647
+#: src/PrefsUnifiedDlg.cpp:656
 #, c-format
 msgid "Failed to connect Cfg to widget with the ID %d and key %s"
 msgstr "Cfg %d Kimliği ve %s anahtarı ile parçacığa bağlanamadı"
 
-#: src/PrefsUnifiedDlg.cpp:695
+#: src/PrefsUnifiedDlg.cpp:704
 #, c-format
 msgid "Failed to transfer data from Cfg to Widget with the ID %d and key %s"
 msgstr "Cfg' den %d Kimliği ve %s anahtarı ile Parçacığa veri aktarılamadı"
 
-#: src/PrefsUnifiedDlg.cpp:801
+#: src/PrefsUnifiedDlg.cpp:810
 msgid "The type of proxy you are connecting to"
 msgstr "Bağlanacağınız vekil sunucu türü"
 
-#: src/PrefsUnifiedDlg.cpp:1020
+#: src/PrefsUnifiedDlg.cpp:1029
 #, c-format
 msgid "Failed to transfer data from Widget to Cfg with the ID %d and key %s"
 msgstr "Parçacıktan %d Kimliği ve %s anahtarı ile Cfg' ye veri aktarılamadı"
 
-#: src/PrefsUnifiedDlg.cpp:1103
+#: src/PrefsUnifiedDlg.cpp:1112
 #, fuzzy
 msgid "No password set."
 msgstr "Yönetici parolası"
 
-#: src/PrefsUnifiedDlg.cpp:1132
+#: src/PrefsUnifiedDlg.cpp:1141
 msgid "Guest access needs a password. Type one in the guest password field, or untick Enable guest access."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1144
+#: src/PrefsUnifiedDlg.cpp:1153
 msgid ""
 "aMule must be restarted to enable these changes:\n"
 "\n"
@@ -5762,39 +5762,39 @@ msgstr ""
 "Değişikliklerin uygulanması için, aMule yeniden başlatılmalı\n"
 "\n"
 
-#: src/PrefsUnifiedDlg.cpp:1151
+#: src/PrefsUnifiedDlg.cpp:1160
 msgid "- TCP port changed.\n"
 msgstr "- TCP portu değişti.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1156
+#: src/PrefsUnifiedDlg.cpp:1165
 msgid "- UDP port changed.\n"
 msgstr "- UDP Portu değişti.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1161
+#: src/PrefsUnifiedDlg.cpp:1170
 msgid "- Network interface binding changed.\n"
 msgstr "- Ağ arayüz bağlaması değişti.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1166
+#: src/PrefsUnifiedDlg.cpp:1175
 msgid "- External connect port changed.\n"
 msgstr "- Dışarıdan bağlantı portu değişti.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1170
+#: src/PrefsUnifiedDlg.cpp:1179
 msgid "- External connect acceptance changed.\n"
 msgstr "- Dışarıdan bağlantı kabul edilme işlemi değişti.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1174
+#: src/PrefsUnifiedDlg.cpp:1183
 msgid "- External connect interface changed.\n"
 msgstr "- Dışarıdan bağlantı arayüzü değişti.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1178
+#: src/PrefsUnifiedDlg.cpp:1187
 msgid "- Protocol obfuscation support changed.\n"
 msgstr "- Protokol gizleme desteği değişti.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1193
+#: src/PrefsUnifiedDlg.cpp:1202
 msgid "- amuleapi settings changed.\n"
 msgstr "- amuleapi ayarları değişti.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1202
+#: src/PrefsUnifiedDlg.cpp:1211
 msgid ""
 "Your Auto-update server list is empty.\n"
 "'Auto-update server list at startup' will be disabled."
@@ -5802,7 +5802,7 @@ msgstr ""
 "Otomatik Sunucu güncelleme listeniz boş.\n"
 "'Sunucu listesini başlangıçta otomatikman güncelle' devre dışı bırakılacak."
 
-#: src/PrefsUnifiedDlg.cpp:1213
+#: src/PrefsUnifiedDlg.cpp:1222
 msgid ""
 "You have enabled external connections but have not specified a password.\n"
 "External connections cannot be enabled unless a valid password is specified."
@@ -5810,32 +5810,32 @@ msgstr ""
 "Dışarıdan bağlantıları aktifleştirmiş ama bir şifre belirlememişsiniz.\n"
 "Geçerli bir şifre belirlenmedikçe dışarıdan bağlantılar devre dışı kalacaktır."
 
-#: src/PrefsUnifiedDlg.cpp:1246
+#: src/PrefsUnifiedDlg.cpp:1255
 #, c-format
 msgid "The amuleapi password could not be saved: %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1276
+#: src/PrefsUnifiedDlg.cpp:1285
 msgid "- Language changed.\n"
 msgstr "- Dil ayarları değişti.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1281
+#: src/PrefsUnifiedDlg.cpp:1290
 msgid "- Temp folder changed.\n"
 msgstr "- Geçici Dosyalar dizini değişti.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1286
+#: src/PrefsUnifiedDlg.cpp:1295
 msgid "- ED2K network enabled.\n"
 msgstr "- ED2K ağı etkinleştirildi.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1319
+#: src/PrefsUnifiedDlg.cpp:1328
 msgid "The shared-file exclusion pattern is not a valid regular expression. The filter has been left disabled."
 msgstr "Paylaşılan dosya dışlama örüntüsü geçerli bir düzenli ifade değil. Filtre devre dışı olarak bırakıldı."
 
-#: src/PrefsUnifiedDlg.cpp:1321 src/PrefsUnifiedDlg.cpp:1921
+#: src/PrefsUnifiedDlg.cpp:1330 src/PrefsUnifiedDlg.cpp:1930
 msgid "Invalid regular expression"
 msgstr "Geçersiz düzenli ifade"
 
-#: src/PrefsUnifiedDlg.cpp:1398
+#: src/PrefsUnifiedDlg.cpp:1407
 msgid ""
 "Both eD2k and Kad network are disabled.\n"
 "You won't be able to connect until you enable at least one of them."
@@ -5843,7 +5843,7 @@ msgstr ""
 "Hem eD2k hem de Kad ağları devre dışı bırakılmış.\n"
 "En az birini etkinleştirmeden bağlanamayacaksınız."
 
-#: src/PrefsUnifiedDlg.cpp:1403
+#: src/PrefsUnifiedDlg.cpp:1412
 msgid ""
 "Kad will not start if your UDP port is disabled.\n"
 "Enable UDP port or disable Kad."
@@ -5851,7 +5851,7 @@ msgstr ""
 "UDP portu devre dışı bırakılmışsa Kad başlamayacaktır.\n"
 "UDP portu açın veya Kademlia'yı devre dışı bırakın."
 
-#: src/PrefsUnifiedDlg.cpp:1459
+#: src/PrefsUnifiedDlg.cpp:1468
 msgid ""
 "\n"
 "You MUST restart aMule now.\n"
@@ -5861,68 +5861,68 @@ msgstr ""
 "aMule' yi ŞİMDİ yeniden başlatmalısınız.\n"
 "Şimdi yeniden başlatmazsanız, kötü şeyler olabilir.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1524
+#: src/PrefsUnifiedDlg.cpp:1533
 msgid "Could not register aMule for autostart at login. The autostart store may be read-only."
 msgstr "Oturum açıldığında otomatik başlatma için aMule kaydedilemedi. Otomatik başlatma deposu salt okunur olabilir."
 
-#: src/PrefsUnifiedDlg.cpp:1526
+#: src/PrefsUnifiedDlg.cpp:1535
 msgid "Could not remove the autostart-at-login entry."
 msgstr "Oturum açılışında otomatik başlatma unsuru kaldırılamadı."
 
-#: src/PrefsUnifiedDlg.cpp:1527
+#: src/PrefsUnifiedDlg.cpp:1536
 msgid "Autostart"
 msgstr "Otomatik başlatma"
 
-#: src/PrefsUnifiedDlg.cpp:1542
+#: src/PrefsUnifiedDlg.cpp:1551
 msgid "Register file type"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1542
+#: src/PrefsUnifiedDlg.cpp:1551
 msgid "Register URL handler"
 msgstr "URL yöneticisini kaydet"
 
-#: src/PrefsUnifiedDlg.cpp:1550
+#: src/PrefsUnifiedDlg.cpp:1559
 #, c-format
 msgid "aMule only handles eD2k-compatible magnets. If you replace the current magnet handler (%s), BitTorrent magnet links will stop working - aMule cannot download BitTorrent content. Continue?"
 msgstr "aMule, sadece eD2k uyumlu magnet'leri işler. Şayet güncel magnet yöneticisinin (%s) yerine onu koyarsanız, BitTorrent magnet bağlantıları artık çalışmayacaktır - aMule BitTorrent içeriği indiremez. Devam edilsin mi?"
 
-#: src/PrefsUnifiedDlg.cpp:1555
+#: src/PrefsUnifiedDlg.cpp:1564
 #, fuzzy, c-format
 msgid "Another application currently opens .emulecollection files (%s). Replace it with aMule?"
 msgstr "Başka bir uygulama güncel olarak bu bağlantıların yöneticisidir (%s). Yerine aMule konsun mu?"
 
-#: src/PrefsUnifiedDlg.cpp:1560
+#: src/PrefsUnifiedDlg.cpp:1569
 #, c-format
 msgid "Another application is currently the default handler for these links (%s). Replace it with aMule?"
 msgstr "Başka bir uygulama güncel olarak bu bağlantıların yöneticisidir (%s). Yerine aMule konsun mu?"
 
-#: src/PrefsUnifiedDlg.cpp:1585
+#: src/PrefsUnifiedDlg.cpp:1594
 #, fuzzy
 msgid "Could not register aMule for .emulecollection files. The registration store may be read-only."
 msgstr "aMule, URL yöneticisi olarak kaydedilemedi. Kayıt deposu salt okunur olabilir."
 
-#: src/PrefsUnifiedDlg.cpp:1587
+#: src/PrefsUnifiedDlg.cpp:1596
 #, fuzzy
 msgid "Could not remove the file type registration."
 msgstr "URL yönetim kaydı kaldırılamadı."
 
-#: src/PrefsUnifiedDlg.cpp:1589
+#: src/PrefsUnifiedDlg.cpp:1598
 msgid "Could not register aMule as the URL handler. The registration store may be read-only."
 msgstr "aMule, URL yöneticisi olarak kaydedilemedi. Kayıt deposu salt okunur olabilir."
 
-#: src/PrefsUnifiedDlg.cpp:1591
+#: src/PrefsUnifiedDlg.cpp:1600
 msgid "Could not remove the URL handler registration."
 msgstr "URL yönetim kaydı kaldırılamadı."
 
-#: src/PrefsUnifiedDlg.cpp:1661 src/PrefsUnifiedDlg.cpp:1688
+#: src/PrefsUnifiedDlg.cpp:1670 src/PrefsUnifiedDlg.cpp:1697
 msgid "The web server and aMule API require external connections to be enabled."
 msgstr "Web sunucusu ve aMule API, dış bağlantıların etkinleştirilmiş olmalarına ihtiyaç duyar."
 
-#: src/PrefsUnifiedDlg.cpp:1671
+#: src/PrefsUnifiedDlg.cpp:1680
 msgid "The aMule web server is deprecated. Consider running the aMule API instead."
 msgstr "aMule Web sunucusu eskimiştir. Yerine aMule API çalıştırmayı değerlendirin."
 
-#: src/PrefsUnifiedDlg.cpp:1735
+#: src/PrefsUnifiedDlg.cpp:1744
 msgid ""
 "Your Auto-update servers list is in blank.\n"
 "Please fill in at least one URL to point to a valid server.met file.\n"
@@ -5932,64 +5932,64 @@ msgstr ""
 "Lütfen geçerli bir server.met dosyasını gösteren en az bir adres yazınız.\n"
 "Bir adres girmek için bu kutucuğun yanındaki \"Liste\" düğmesine basınız."
 
-#: src/PrefsUnifiedDlg.cpp:1876
+#: src/PrefsUnifiedDlg.cpp:1885
 msgid "Temporary files"
 msgstr "Geçici dosya(lar)"
 
-#: src/PrefsUnifiedDlg.cpp:1881
+#: src/PrefsUnifiedDlg.cpp:1890
 msgid "Incoming files"
 msgstr "Gelen dosya(lar)"
 
-#: src/PrefsUnifiedDlg.cpp:1886
+#: src/PrefsUnifiedDlg.cpp:1895
 msgid "Online Signatures"
 msgstr "Çevrimiçi İmzalar"
 
-#: src/PrefsUnifiedDlg.cpp:1899
+#: src/PrefsUnifiedDlg.cpp:1908
 #, c-format
 msgid "Choose a folder for %s"
 msgstr "%s için bir dizin seçiniz."
 
-#: src/PrefsUnifiedDlg.cpp:1923
+#: src/PrefsUnifiedDlg.cpp:1932
 #, c-format
 msgid "Would exclude %u of %u shared file"
 msgid_plural "Would exclude %u of %u shared files"
 msgstr[0] "%u dosya, ki %u üzerinde dışlanırdı"
 msgstr[1] "%u dosya, ki %u üzerinde dışlanırdı"
 
-#: src/PrefsUnifiedDlg.cpp:1940
+#: src/PrefsUnifiedDlg.cpp:1949
 msgid "Browse for videoplayer"
 msgstr "Ortam Çalıcısı için göz at"
 
-#: src/PrefsUnifiedDlg.cpp:1944
+#: src/PrefsUnifiedDlg.cpp:1953
 msgid "Select browser"
 msgstr "Tarayıcı Seçiniz"
 
-#: src/PrefsUnifiedDlg.cpp:1948
+#: src/PrefsUnifiedDlg.cpp:1957
 msgid "Select ffprobe binary"
 msgstr "ffprobe ikilisi seçin"
 
-#: src/PrefsUnifiedDlg.cpp:1954
+#: src/PrefsUnifiedDlg.cpp:1963
 #, c-format
 msgid "Executable%s"
 msgstr "Çalıştırılabilir %s"
 
-#: src/PrefsUnifiedDlg.cpp:1988
+#: src/PrefsUnifiedDlg.cpp:1997
 msgid "ffprobe not found on PATH or in the standard install locations. Install ffmpeg (which ships ffprobe) or use Browse to pick a binary manually."
 msgstr "ffprobe, PATH veya standart kurulum konumlarında bulunamadı. ffmepg kurun (ffprobe'u sağlar) veya el ile bir ikili seçmek için Tara düğmesine tıklayın."
 
-#: src/PrefsUnifiedDlg.cpp:2000
+#: src/PrefsUnifiedDlg.cpp:2009
 msgid "Reset the settings on this page to their default values?"
 msgstr "Bu sayfadaki ayarlar varsayılan değerlerine sıfırlansınlar mı?"
 
-#: src/PrefsUnifiedDlg.cpp:2001
+#: src/PrefsUnifiedDlg.cpp:2010
 msgid "Reset to defaults"
 msgstr "Varsayılanlara sıfırla"
 
-#: src/PrefsUnifiedDlg.cpp:2028
+#: src/PrefsUnifiedDlg.cpp:2037
 msgid "Edit server list"
 msgstr "Sunucu listesini düzenle"
 
-#: src/PrefsUnifiedDlg.cpp:2029
+#: src/PrefsUnifiedDlg.cpp:2038
 msgid ""
 "Add here URL's to download server.met files.\n"
 "Only one url on each line."
@@ -5997,114 +5997,114 @@ msgstr ""
 "Server.met dosyasını indirmek için buraya bağlantı adresi girin.\n"
 "Her satıra sadece bir adres yazılmalıdır."
 
-#: src/PrefsUnifiedDlg.cpp:2084
+#: src/PrefsUnifiedDlg.cpp:2093
 msgid "IP2Country update failed"
 msgstr "IP2Country güncellemesi başarısız oldu"
 
-#: src/PrefsUnifiedDlg.cpp:2229 src/PrefsUnifiedDlg.cpp:2260
+#: src/PrefsUnifiedDlg.cpp:2238 src/PrefsUnifiedDlg.cpp:2269
 msgid "Data by MaxMind GeoLite2"
 msgstr "Veriler MaxMind GeoLite2 tarafından sağlanmıştır"
 
-#: src/PrefsUnifiedDlg.cpp:2231 src/PrefsUnifiedDlg.cpp:2262
+#: src/PrefsUnifiedDlg.cpp:2240 src/PrefsUnifiedDlg.cpp:2271
 msgid "Custom source"
 msgstr "Kişiselleştirilmiş kaynak"
 
-#: src/PrefsUnifiedDlg.cpp:2233 src/PrefsUnifiedDlg.cpp:2264
+#: src/PrefsUnifiedDlg.cpp:2242 src/PrefsUnifiedDlg.cpp:2273
 msgid "Data by DB-IP.com"
 msgstr "Veriler DB-IP.com tarafından sağlanmıştır"
 
-#: src/PrefsUnifiedDlg.cpp:2284
+#: src/PrefsUnifiedDlg.cpp:2293
 #, c-format
 msgid "Status: Loaded%s"
 msgstr "Durum: %s yüklendi"
 
-#: src/PrefsUnifiedDlg.cpp:2286
+#: src/PrefsUnifiedDlg.cpp:2295
 #, c-format
 msgid "Status: Loaded%s - %s"
 msgstr "Durum: %s - %s yüklendi"
 
-#: src/PrefsUnifiedDlg.cpp:2290
+#: src/PrefsUnifiedDlg.cpp:2299
 msgid "Status: Failed to load - click 'Update now' to refresh."
 msgstr "Durum: yükleme başarısız oldu - güncellemek için 'Şimdi güncelle' düğmesine tıklayın."
 
-#: src/PrefsUnifiedDlg.cpp:2292
+#: src/PrefsUnifiedDlg.cpp:2301
 msgid "Status: Not found - click 'Update now' to download."
 msgstr "Durum: bulunamadı - indirmek için 'Şimdi güncelle' düğmesine tıklayın."
 
-#: src/PrefsUnifiedDlg.cpp:2350 src/PrefsUnifiedDlg.cpp:2374
+#: src/PrefsUnifiedDlg.cpp:2359 src/PrefsUnifiedDlg.cpp:2383
 #, c-format
 msgid "Update delay: %d second"
 msgid_plural "Update delay: %d seconds"
 msgstr[0] "Güncelleme gecikmesi: %d saniye"
 msgstr[1] "Güncelleme gecikmesi: %d saniye"
 
-#: src/PrefsUnifiedDlg.cpp:2358
+#: src/PrefsUnifiedDlg.cpp:2367
 #, c-format
 msgid "Time for average graph: %d minute"
 msgid_plural "Time for average graph: %d minutes"
 msgstr[0] "Ortalama grafiği için süre: %d dakika"
 msgstr[1] "Ortalama grafiği için süre: %d dakika"
 
-#: src/PrefsUnifiedDlg.cpp:2367
+#: src/PrefsUnifiedDlg.cpp:2376
 #, c-format
 msgid "Connections Graph Scale: %d"
 msgstr "Bağlantı Grafik Ölçüsü: %d"
 
-#: src/PrefsUnifiedDlg.cpp:2382
+#: src/PrefsUnifiedDlg.cpp:2391
 #, c-format
 msgid "File Buffer Size: %d byte"
 msgid_plural "File Buffer Size: %d bytes"
 msgstr[0] "Dosya Alım Boyutu: %d bayt"
 msgstr[1] "Dosya Alım Boyutu: %d bayt"
 
-#: src/PrefsUnifiedDlg.cpp:2392
+#: src/PrefsUnifiedDlg.cpp:2401
 #, c-format
 msgid "Upload Queue Size: %d client"
 msgid_plural "Upload Queue Size: %d clients"
 msgstr[0] "Gönderme Sıra Boyutu: %d kullanıcı"
 msgstr[1] "Gönderme Sıra Boyutu: %d kullanıcı"
 
-#: src/PrefsUnifiedDlg.cpp:2402
+#: src/PrefsUnifiedDlg.cpp:2411
 #, c-format
 msgid "Server connection refresh interval: %d minute"
 msgid_plural "Server connection refresh interval: %d minutes"
 msgstr[0] "Sunucu bağlantısı yenileme sıklığı: %d dakika"
 msgstr[1] "Sunucu bağlantısı yenileme sıklığı: %d dakika"
 
-#: src/PrefsUnifiedDlg.cpp:2407
+#: src/PrefsUnifiedDlg.cpp:2416
 msgid "Server connection refresh interval: Disabled"
 msgstr "Sunucu bağlantısı yenileme döngüsü: Devre dışı"
 
-#: src/PrefsUnifiedDlg.cpp:2451
+#: src/PrefsUnifiedDlg.cpp:2460
 msgid "disabled"
 msgstr "devre dışı"
 
-#: src/PrefsUnifiedDlg.cpp:2477
+#: src/PrefsUnifiedDlg.cpp:2486
 #, c-format
 msgid "Execute command on '%s' event"
 msgstr "'%s' olayında komut çalıştır."
 
-#: src/PrefsUnifiedDlg.cpp:2484
+#: src/PrefsUnifiedDlg.cpp:2493
 msgid "Enable command execution on core"
 msgstr "Çekirdekte komut çalıştırmayı aktifleştir."
 
-#: src/PrefsUnifiedDlg.cpp:2496
+#: src/PrefsUnifiedDlg.cpp:2505
 msgid "Core command:"
 msgstr "Çekirdek komutu:"
 
-#: src/PrefsUnifiedDlg.cpp:2512
+#: src/PrefsUnifiedDlg.cpp:2521
 msgid "Enable command execution on GUI"
 msgstr "Arayüzde komut çalıştırmayı etkinleştir."
 
-#: src/PrefsUnifiedDlg.cpp:2524
+#: src/PrefsUnifiedDlg.cpp:2533
 msgid "GUI command:"
 msgstr "Arayüz komutu:"
 
-#: src/PrefsUnifiedDlg.cpp:2540
+#: src/PrefsUnifiedDlg.cpp:2549
 msgid "The following variables will be replaced:"
 msgstr "Şu girdiler değiştirilecek:"
 
-#: src/PrefsUnifiedDlg.cpp:2708
+#: src/PrefsUnifiedDlg.cpp:2717
 msgid ""
 "The following folders look like system or sensitive locations:\n"
 "\n"
@@ -6112,37 +6112,37 @@ msgstr ""
 "Şu dizinler sistem dizinleri veya hassas konumlar gibi görünüyor:\n"
 "\n"
 
-#: src/PrefsUnifiedDlg.cpp:2713
+#: src/PrefsUnifiedDlg.cpp:2722
 msgid "Sharing them recursively will publish every file underneath on the eD2k/Kad networks. Do you really want to do this?"
 msgstr "Bunları yinelemeli olarak paylaşmanız, kapsadıkları her dosyayı eD2k/Kad ağlarında yayınlayacaktır. Bunu hakikaten yapmak istiyor musunuz?"
 
-#: src/PrefsUnifiedDlg.cpp:2716
+#: src/PrefsUnifiedDlg.cpp:2725
 msgid "Confirm shared folders"
 msgstr "Paylaşılan dizinleri teyit et"
 
-#: src/PrefsUnifiedDlg.cpp:2744
+#: src/PrefsUnifiedDlg.cpp:2753
 msgid "Reloading shared files..."
 msgstr "Paylaşılan dosyalar yeniden yükleniyor…"
 
-#: src/PrefsUnifiedDlg.cpp:2745
+#: src/PrefsUnifiedDlg.cpp:2754
 msgid "Scanning for subdirectories..."
 msgstr "Alt dizinler taranıyor…"
 
-#: src/PrefsUnifiedDlg.cpp:2746
+#: src/PrefsUnifiedDlg.cpp:2755
 msgid "Updating shared folders"
 msgstr "Paylaşılan dizinler güncelleniyor"
 
-#: src/PrefsUnifiedDlg.cpp:2773
+#: src/PrefsUnifiedDlg.cpp:2782
 #, c-format
 msgid "Scanned %u directories..."
 msgstr "%u dizin tarandı…"
 
-#: src/PrefsUnifiedDlg.cpp:2823
+#: src/PrefsUnifiedDlg.cpp:2832
 #, c-format
 msgid "Reloading shared files: %u files scanned"
 msgstr "Paylaşılmış dosyalar yeniden yükleniyor: %u dosya tarandı"
 
-#: src/PrefsUnifiedDlg.cpp:2873
+#: src/PrefsUnifiedDlg.cpp:2882
 msgid "Shared folder"
 msgstr "Paylaşılan dizin"
 
@@ -7829,12 +7829,12 @@ msgstr "Sınıfı Kaldır"
 msgid "Hashset requested for unknown file: %s"
 msgstr "Bilinmeyen dosya için adresleme seti istendi: %s"
 
-#: src/UploadQueue.cpp:618
+#: src/UploadQueue.cpp:627
 #, c-format
 msgid "Resuming uploads of file: %s"
 msgstr "Şu dosya için gönderimler sürdürülüyor: %s"
 
-#: src/UploadQueue.cpp:634
+#: src/UploadQueue.cpp:643
 #, c-format
 msgid "Suspending upload of file: %s"
 msgstr "Şu dosya için gönderimler bekletiliyor: %s"

--- a/po/tr.po
+++ b/po/tr.po
@@ -9,8 +9,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-28 12:12+0200\n"
-"PO-Revision-Date: 2026-07-27 10:35+0000\n"
+"POT-Creation-Date: 2026-07-28 08:06+0200\n"
+"PO-Revision-Date: 2026-07-27 11:47+0000\n"
 "Last-Translator: \n"
 "Language-Team: Turkish <li@li.org>\n"
 "Language: tr\n"
@@ -143,7 +143,7 @@ msgstr "Kur"
 msgid "Not now"
 msgstr "Şimdi değil"
 
-#: src/AppImageIntegration.cpp:422 src/amuleDlg.cpp:665
+#: src/AppImageIntegration.cpp:422 src/amuleDlg.cpp:600
 msgid "Don't ask again"
 msgstr "Tekrar sorma"
 
@@ -205,83 +205,83 @@ msgstr "ED2KBağlantı dosyası açılamadı."
 msgid "WARNING: You can't add yourself as a source for an eD2k link while having a lowid."
 msgstr "UYARI: DüşükID olduğunuz sürece kendinizi bir kaynak olarak eD2k bağlantılarına ekleyemezsiniz."
 
-#: src/amule.cpp:301
+#: src/amule.cpp:300
 msgid "Now, exiting main app..."
 msgstr "Ana uygulamadan çıkılıyor…"
 
-#: src/amule.cpp:331
+#: src/amule.cpp:330
 #, c-format
 msgid "Terminating amuleweb instance with pid '%d' ... "
 msgstr "Amuleweb oturumu pid `%d' ile sonlandırılıyor… "
 
-#: src/amule.cpp:335
+#: src/amule.cpp:334
 #, c-format
 msgid "Killing amuleweb instance with pid '%d' ... "
 msgstr "pid `%d' ile ilişkili amuleweb oturumu öldürülüyor… "
 
-#: src/amule.cpp:337 src/amule.cpp:350 src/ClientRef.cpp:180
-#: src/SearchDlg.cpp:1041 src/ServerListCtrl.cpp:98
+#: src/amule.cpp:336 src/amule.cpp:349 src/ClientRef.cpp:180
+#: src/SearchDlg.cpp:880 src/ServerListCtrl.cpp:98
 msgid "Failed"
 msgstr "Başarısız"
 
-#: src/amule.cpp:344
+#: src/amule.cpp:343
 #, c-format
 msgid "Terminating amuleapi instance with pid '%d' ... "
 msgstr "'%d' pid'sine sahip amuleapi oturumu sonlandırılıyor… "
 
-#: src/amule.cpp:348
+#: src/amule.cpp:347
 #, c-format
 msgid "Killing amuleapi instance with pid '%d' ... "
 msgstr "pid `%d' ile ilişkili amuleapi oturumu sonlandırılıyor… "
 
-#: src/amule.cpp:356
+#: src/amule.cpp:355
 msgid "aMule OnExit: Terminating core."
 msgstr "aMule Çıkışında: Çekirdek imha ediliyor."
 
-#: src/amule.cpp:467
+#: src/amule.cpp:466
 msgid "aMule shutdown completed."
 msgstr "aMule kapatılma işlemi tamamlandı."
 
-#: src/amule.cpp:471
+#: src/amule.cpp:470
 msgid "Memory debug results for aMule exit:"
 msgstr "aMule çıkışı için hafıza hata raporlama sonuçları:"
 
-#: src/amule.cpp:652
+#: src/amule.cpp:651
 #, c-format
 msgid "Binding aMule's peer-to-peer traffic to interface: %s (HTTP updates use the default route)"
 msgstr "aMule eşten eşe trafiği şu arayüze bağlanıyor: %s (HTTP güncellemeleri varsayılan yolu kullanır)"
 
-#: src/amule.cpp:656
+#: src/amule.cpp:655
 #, c-format
 msgid "Binding all network traffic to interface: %s"
 msgstr "Tüm ağ trafiği şu arayüze bağlanıyor: %s"
 
-#: src/amule.cpp:660
+#: src/amule.cpp:659
 #, c-format
 msgid "WARNING: configured network interface '%s' was not found - traffic is NOT bound to it and may leave via the default route. Check the interface name in Preferences."
 msgstr "İKAZ: yapılandırılmış ağ arayüzü '%s' bulunamadı - trafik ona bağlı DEĞİL ve varsayılan yol ile dışarı çıkabilir. Arayüz ismini Tercihler'de kontrol edin."
 
-#: src/amule.cpp:666
+#: src/amule.cpp:665
 #, c-format
 msgid "WARNING: binding to network interface '%s' requires elevated privileges and was NOT applied - traffic may leave via the default route. Grant the capability (e.g. 'sudo setcap cap_net_raw+ep' on the aMule binary) or run with sufficient privileges."
 msgstr "İKAZ: '%s' ağ arayüzüne bağlamak yüksek izinler gerektirmektedir ve UYGULANMAMIŞTIR - trafik varsayılan yol ile dışarı çıkabilir. Gerekli yeteneği tanıyın (mesela aMule ikili dosyası üzerinde 'sudo setcap cap_net_raw+ep' komutunu kullanarak) veya yeterli imtiyazlarla çalıştırın."
 
-#: src/amule.cpp:674
+#: src/amule.cpp:673
 #, c-format
 msgid "WARNING: could not bind to network interface '%s' - traffic may leave via the default route."
 msgstr "İKAZ: '%s' ağ arayüzüne bağlama yapılamadı - trafik varsayılan yoldan dışarı çıkabilir."
 
-#: src/amule.cpp:733
+#: src/amule.cpp:732
 msgid "Your locale has been changed to System Default due to a configuration change. Sorry."
 msgstr "Bir yapılandırma değişikliği nedeniyle dil ayarınız 'Sistem Varsayılanı'na çevrildi. Üzgünüm. Vallahi…"
 
-#: src/amule.cpp:735 src/amule.cpp:1589 src/CatDialog.cpp:128
+#: src/amule.cpp:734 src/amule.cpp:1581 src/CatDialog.cpp:128
 #: src/CatDialog.cpp:136 src/CatDialog.cpp:149 src/ServerList.cpp:366
 #: src/ServerListCtrl.cpp:152
 msgid "Info"
 msgstr "Bilgi"
 
-#: src/amule.cpp:742
+#: src/amule.cpp:741
 msgid ""
 "\n"
 "EC configuration"
@@ -289,20 +289,20 @@ msgstr ""
 "\n"
 "EC yapılandırması"
 
-#: src/amule.cpp:745
+#: src/amule.cpp:744
 msgid "Password set and external connections enabled."
 msgstr "Parola ayarlandı ve dış bağlantılar etkinleştirildi."
 
-#: src/amule.cpp:755 src/KadDlg.cpp:176 src/KadDlg.cpp:185
-#: src/PrefsUnifiedDlg.cpp:1461 src/SharedFilesCtrl.cpp:476
+#: src/amule.cpp:754 src/KadDlg.cpp:176 src/KadDlg.cpp:185
+#: src/PrefsUnifiedDlg.cpp:1387 src/SharedFilesCtrl.cpp:476
 msgid "WARNING"
 msgstr "UYARI"
 
-#: src/amule.cpp:992
+#: src/amule.cpp:991
 msgid "Network bootstrap"
 msgstr "Ağ başlatması"
 
-#: src/amule.cpp:997
+#: src/amule.cpp:996
 msgid ""
 "aMule has detected missing network bootstrap files.\n"
 "Select which ones to download:"
@@ -310,51 +310,51 @@ msgstr ""
 "aMule, eksik ağ başlatma dosyaları olduğunu tespit etti.\n"
 "Hangilerinin indirileceklerini seçin:"
 
-#: src/amule.cpp:1006 src/FirstRunWizard.cpp:411
+#: src/amule.cpp:1005 src/FirstRunWizard.cpp:411
 msgid "eD2k server list (server.met)"
 msgstr "eD2k sunucu listesi (server.met)"
 
-#: src/amule.cpp:1013 src/FirstRunWizard.cpp:416
+#: src/amule.cpp:1012 src/FirstRunWizard.cpp:416
 msgid "Kad bootstrap nodes (nodes.dat)"
 msgstr "Kad başlangıç düğümleri (nodes.dat)"
 
-#: src/amule.cpp:1103
+#: src/amule.cpp:1102
 #, c-format
 msgid "web server running on pid %d"
 msgstr "web sunucusu pid %d üzerinde çalışıyor"
 
-#: src/amule.cpp:1116
+#: src/amule.cpp:1115
 msgid "You requested to run web server on startup, but the amuleweb binary cannot be run. Please install the package containing aMule web server, or build aMule from source with -DBUILD_WEBSERVER=YES and install it."
 msgstr "Web sunucusunun başlangıçta çalışmasını istediniz, fakat amuleweb ikilisi çalıştırılamıyor. Lütfen aMule web sunucusunu içeren paketi yükleyin veya aMule' yi -DBUILD_WEBSERVER=YES seçeneği ile derleyin ve kurun."
 
-#: src/amule.cpp:1121 src/amule.cpp:1185 src/amule.cpp:1299 src/amule.cpp:1601
+#: src/amule.cpp:1120 src/amule.cpp:1177 src/amule.cpp:1291 src/amule.cpp:1593
 #: src/amule-remote-gui.cpp:603 src/amule-remote-gui.cpp:671
 #: src/amule-remote-gui.cpp:709 src/amule-remote-gui.cpp:1282
 #: src/amule-remote-gui.cpp:1345 src/amule-remote-gui.cpp:1372
-#: src/DownloadQueue.cpp:1481 src/PrefsUnifiedDlg.cpp:1247
+#: src/DownloadQueue.cpp:1481
 msgid "ERROR"
 msgstr "HATA"
 
-#: src/amule.cpp:1174
+#: src/amule.cpp:1166
 #, c-format
 msgid "amuleapi running on pid %d"
 msgstr "amuleapi pid %d üzerinde çalışıyor"
 
-#: src/amule.cpp:1180
+#: src/amule.cpp:1172
 msgid "You requested to run amuleapi on startup, but the amuleapi binary cannot be run. Please install the package containing aMule's REST API server, or build aMule from source with -DBUILD_AMULEAPI=YES and install it."
 msgstr "amuleapi'nın başlangıçta çalışmasını istediniz, fakat amuleapi ikilisi çalıştırılamıyor. Lütfen aMule REST API sunucusunu içeren paketi yükleyin veya aMule' yi -DBUILD_AMULEAPI=YES seçeneği ile derleyin ve kurun."
 
-#: src/amule.cpp:1267
+#: src/amule.cpp:1259
 #, c-format
 msgid "Could not bind ports to the specified address: %s"
 msgstr "Belirtilen şu adrese portlar bağlanamıyor: %s"
 
-#: src/amule.cpp:1291
+#: src/amule.cpp:1283
 #, c-format
 msgid "Port %u is not available. You will be LOWID\n"
 msgstr "Port. %u kullanılamıyor. DÜŞÜKID alacaksınız.\n"
 
-#: src/amule.cpp:1296
+#: src/amule.cpp:1288
 #, c-format
 msgid ""
 "Port %u is not available!\n"
@@ -369,48 +369,48 @@ msgstr ""
 "\n"
 "Ağ ayarlarınıza göz atarak portun giriş ve çıkışlar için açık olup olmadığını denetleyiniz."
 
-#: src/amule.cpp:1393
+#: src/amule.cpp:1385
 msgid "Failed to create OnlineSig File"
 msgstr "Çevrim içi İmza dosyası oluşturma başarısız."
 
-#: src/amule.cpp:1401
+#: src/amule.cpp:1393
 msgid "Failed to create aMule OnlineSig File"
 msgstr "aMule Çevrim içi İmza dosyası oluşturma başarısız."
 
-#: src/amule.cpp:1564
+#: src/amule.cpp:1556
 msgid "The selected locale seems not to be installed on your box. (Note: I'll try to set it anyway)"
 msgstr "Seçilen yerelleştirme görünüşe göre bilgisayarınızda yüklü değil. (Not: Bunu yine de yapmaya çalışacağım)"
 
-#: src/amule.cpp:1574
+#: src/amule.cpp:1566
 #, c-format
 msgid "This is the first time you run aMule %s"
 msgstr "Hoş geldiniz! aMule %s sürümünü ilk kez kullanıyorsunuz."
 
-#: src/amule.cpp:1577
+#: src/amule.cpp:1569
 msgid "This version is a testing version, updated daily, and\n"
 msgstr "Bu sürüm bir deneme sürümü, her gün güncellenir ve\n"
 
-#: src/amule.cpp:1578
+#: src/amule.cpp:1570
 msgid "we give no warranty it won't break anything, burn your house,\n"
 msgstr "bir şeyleri bozmayacağını veya evinizi yakmayacağını \n"
 
-#: src/amule.cpp:1579
+#: src/amule.cpp:1571
 msgid "or kill your dog. But it *should* be safe to use anyway.\n"
 msgstr "yahut da köpeğinizi öldürmeyeceğini garanti edemeyiz. Fakat bir *sorun* yaratmayacağını da umuyoruz.\n"
 
-#: src/amule.cpp:1584
+#: src/amule.cpp:1576
 msgid "More information, support and new releases can found at our homepage,\n"
 msgstr "Daha fazla bilgi, destek ve yeni sürümler ana sayfamızda bulunabilir\n"
 
-#: src/amule.cpp:1585
+#: src/amule.cpp:1577
 msgid "at https://amule-org.github.io, or in our IRC channel #aMule at irc.libera.chat.\n"
 msgstr "https://amule-org.github.io veya IRC kanalımız: irc.libera.chat sunucusunda #aMule \n"
 
-#: src/amule.cpp:1587
+#: src/amule.cpp:1579
 msgid "Feel free to report any bugs to https://github.com/amule-org/amule/issues"
 msgstr "Her türlü hatayı bize bildirmekten çekinmeyin https://github.com/amule-org/amule/issues"
 
-#: src/amule.cpp:1599
+#: src/amule.cpp:1591
 msgid ""
 "The folder for Online Signature files you specified is INVALID!\n"
 " OnlineSignature will be DISABLED until you fix it on preferences."
@@ -418,137 +418,137 @@ msgstr ""
 "Belirlediğiniz Çevrim içi İmza dosyaları dizini GEÇERSİZ!\n"
 " Çevrim içi İmza, ayarlarınızda düzeltene kadar DEVRE DIŞI bırakıldı."
 
-#: src/amule.cpp:1662
+#: src/amule.cpp:1654
 msgid "Server hostname notified"
 msgstr "Sunucu makine adı uyarıldı"
 
-#: src/amule.cpp:2039
+#: src/amule.cpp:2031
 #, c-format
 msgid "Disk space preallocation for file '%s' failed: %s"
 msgstr "%s dosyası için diskte yer ayırma başarısız oldu: %s"
 
-#: src/amule.cpp:2168
+#: src/amule.cpp:2160
 msgid "ERROR: can't open logfile"
 msgstr "HATA: Günlük dosyası açılamıyor."
 
-#: src/amule.cpp:2172
+#: src/amule.cpp:2164
 msgid "WARNING: logfile is empty. Something is wrong."
 msgstr "UYARI: Günlük dosyası boş, bir şeyler yanlış."
 
-#: src/amule.cpp:2189
+#: src/amule.cpp:2181
 msgid "Log has been reset"
 msgstr "Günlük kaydı silindi"
 
-#: src/amule.cpp:2213
+#: src/amule.cpp:2205
 #, c-format
 msgid "ServerMessage: %s"
 msgstr "Sunucu İletisi: %s"
 
-#: src/amule.cpp:2256 src/IP2Country.cpp:220 src/IPFilter.cpp:514
+#: src/amule.cpp:2248 src/IP2Country.cpp:220 src/IPFilter.cpp:514
 #: src/ServerList.cpp:875
 #, c-format
 msgid "Skipped download of %s, because requested file is not newer."
 msgstr "%s indirilmeyecek; çünkü istenen dosya yeni değil."
 
-#: src/amule.cpp:2259
+#: src/amule.cpp:2251
 msgid "Failed to download the nodes list."
 msgstr "Nod listesini indirme başarısız."
 
-#: src/amule.cpp:2322
+#: src/amule.cpp:2314
 msgid "Failed to open the downloaded version check file"
 msgstr "İndirilen sürüm denetleme dosyasını açma başarısız oldu."
 
-#: src/amule.cpp:2325 src/amule.cpp:2344
+#: src/amule.cpp:2317 src/amule.cpp:2336
 msgid "Corrupted version check file"
 msgstr "Bozuk sürüm denetleme dosyası"
 
-#: src/amule.cpp:2367
+#: src/amule.cpp:2359
 msgid "You are using an outdated version of aMule!"
 msgstr "aMule'nin eski bir sürümünü kullanıyorsunuz!"
 
-#: src/amule.cpp:2369
+#: src/amule.cpp:2361
 #, c-format
 msgid "Your aMule version is %i.%i.%i and the latest version is %li.%li.%li"
 msgstr "aMule sürümünüz %i.%i.%i ve en güncel sürüm %li.%li.%li"
 
-#: src/amule.cpp:2373
+#: src/amule.cpp:2365
 msgid "The latest version can always be found at https://github.com/amule-org/amule/releases/latest"
 msgstr "En güncel sürüm her zaman https://github.com/amule-org/amule/releases/latest adresinde bulunabilir."
 
-#: src/amule.cpp:2376
+#: src/amule.cpp:2368
 #, c-format
 msgid "WARNING: Your aMuled version is outdated: %i.%i.%i < %li.%li.%li"
 msgstr "UYARI: aMuled sürümünüz eski: %i.%i.%i < %li.%li.%li"
 
-#: src/amule.cpp:2382
+#: src/amule.cpp:2374
 msgid "Your copy of aMule is up to date."
 msgstr "aMule sürümünüz güncel."
 
-#: src/amule.cpp:2389
+#: src/amule.cpp:2381
 msgid "Failed to download the version check file"
 msgstr "Sürüm denetleme dosyasını indirme başarısız oldu."
 
-#: src/amule.cpp:2558 src/amule-remote-gui.cpp:1133
+#: src/amule.cpp:2550 src/amule-remote-gui.cpp:1133
 #, c-format
 msgid "Users: %s | Files: %s"
 msgstr "Kullanıcılar: %s | Dosyalar: %s"
 
-#: src/amule.cpp:2559 src/amule-remote-gui.cpp:1134
+#: src/amule.cpp:2551 src/amule-remote-gui.cpp:1134
 #, c-format
 msgid "Users: E: %s K: %s | Files: E: %s K: %s"
 msgstr "Kullanıcılar: E: %s K: %s | Dosyalar: E: %s K: %s"
 
-#: src/amule.cpp:2573 src/amule-remote-gui.cpp:1147
+#: src/amule.cpp:2565 src/amule-remote-gui.cpp:1147
 msgid "No networks selected"
 msgstr "Hiç bir ağ seçilmedi"
 
-#: src/amule.cpp:2641 src/TextClient.cpp:903
+#: src/amule.cpp:2633 src/TextClient.cpp:903
 msgid "with LowID"
 msgstr "DüşükID ile"
 
-#: src/amule.cpp:2641 src/TextClient.cpp:904
+#: src/amule.cpp:2633 src/TextClient.cpp:904
 msgid "with HighID"
 msgstr "YüksekID ile"
 
-#: src/amule.cpp:2643
+#: src/amule.cpp:2635
 #, c-format
 msgid "Connected to %s %s"
 msgstr "Bağlandı: %s %s"
 
-#: src/amule.cpp:2648
+#: src/amule.cpp:2640
 #, c-format
 msgid "Connecting to %s"
 msgstr "Bağlanıyor: %s"
 
-#: src/amule.cpp:2650
+#: src/amule.cpp:2642
 msgid "Disconnected from eD2k"
 msgstr "eD2k Bağlantısı kesildi"
 
-#: src/amule.cpp:2659
+#: src/amule.cpp:2651
 msgid "Kad started."
 msgstr "Kademlia başladı."
 
-#: src/amule.cpp:2661
+#: src/amule.cpp:2653
 msgid "Kad stopped."
 msgstr "Kademlia durdu."
 
-#: src/amule.cpp:2669
+#: src/amule.cpp:2661
 msgid "Connected to Kad (ok)"
 msgstr "Kademlia ağına bağlanıldı (tamam)"
 
-#: src/amule.cpp:2671
+#: src/amule.cpp:2663
 msgid "Connected to Kad (firewalled)"
 msgstr "Kademlia ağına bağlanıldı (Güvenlik duvarı arkasında)"
 
-#: src/amule.cpp:2675
+#: src/amule.cpp:2667
 msgid "Disconnected from Kad"
 msgstr "Kademlia bağlantısı kesildi."
 
-#: src/amule.cpp:2707
+#: src/amule.cpp:2699
 msgid "Kad network cannot be used if UDP port is disabled on preferences, not starting."
 msgstr "UDP portu ayarlarda devre dışı bırakılmışsa Kad ağı kullanılamaz. Başlatılmıyor."
 
-#: src/amule.cpp:2711
+#: src/amule.cpp:2703
 msgid "Kad network disabled on preferences, not connecting."
 msgstr "Kad ağı ayarlarda devre dışı bırakılmış, bağlanılmıyor."
 
@@ -573,67 +573,29 @@ msgstr "Pid dosyası oluşturulamıyor"
 msgid "ERROR: %s"
 msgstr "HATA: %s"
 
-#: src/amuleDlg.cpp:250
+#: src/amuleDlg.cpp:236
 #, c-format
 msgid "This is aMule %s based on eMule."
 msgstr "Bu, eMule üzerine kurulu olan aMule %s yazılımıdır."
 
-#: src/amuleDlg.cpp:251
+#: src/amuleDlg.cpp:237
 #, c-format
 msgid "Running on %s"
 msgstr "%s üzerinde çalışıyor"
 
-#: src/amuleDlg.cpp:253
+#: src/amuleDlg.cpp:239
 msgid "Visit https://github.com/amule-org/amule/releases/latest to check if a new version is available."
 msgstr "Yeni sürüm denetimi için https://github.com/amule-org/amule/releases/latest adresini ziyaret ediniz."
 
-#: src/amuleDlg.cpp:282
+#: src/amuleDlg.cpp:268
 msgid "FATAL ERROR: Failed to create Timer"
 msgstr "ÖNEMLİ HATA: Zamanlayıcı oluşturulamadı"
 
-#: src/amuleDlg.cpp:361 src/amuleDlg.cpp:1810 src/amuleDlg.cpp:2056
-#: src/muuli_wdr.cpp:1492 src/muuli_wdr.cpp:3439
-msgid "Networks"
-msgstr "Ağlar"
-
-#: src/amuleDlg.cpp:362 src/amuleDlg.cpp:1816 src/muuli_wdr.cpp:3440
-msgid "Searches"
-msgstr "Aramalar"
-
-#: src/amuleDlg.cpp:363 src/amuleDlg.cpp:1822 src/DownloadListCtrl.cpp:740
-#: src/muuli_wdr.cpp:392 src/muuli_wdr.cpp:1585 src/muuli_wdr.cpp:3441
-#: src/Statistics.cpp:829
-msgid "Downloads"
-msgstr "İndirmeler"
-
-#: src/amuleDlg.cpp:364 src/amuleDlg.cpp:1828 src/muuli_wdr.cpp:3315
-msgid "Shared files"
-msgstr "Paylaşılan dosyalar"
-
-#: src/amuleDlg.cpp:365 src/amuleDlg.cpp:1834 src/muuli_wdr.cpp:2947
-#: src/muuli_wdr.cpp:3397 src/muuli_wdr.cpp:3444
-msgid "Messages"
-msgstr "Sohbet"
-
-#: src/amuleDlg.cpp:366 src/amuleDlg.cpp:1840 src/muuli_wdr.cpp:3445
-#: src/PrefsUnifiedDlg.cpp:314 src/Statistics.cpp:779 src/Statistics.cpp:1235
-msgid "Statistics"
-msgstr "İstatistikler"
-
-#: src/amuleDlg.cpp:368 src/amuleDlg.cpp:1847 src/muuli_wdr.cpp:3447
-#: src/PrefsUnifiedDlg.cpp:330 src/utils/wxCas/src/wxcasprefs.cpp:39
-msgid "Preferences"
-msgstr "Ayarlar"
-
-#: src/amuleDlg.cpp:371
-msgid "Navigate"
-msgstr ""
-
-#: src/amuleDlg.cpp:657
+#: src/amuleDlg.cpp:592
 msgid "New version available"
 msgstr "Yeni bir sürüm mevcuttur"
 
-#: src/amuleDlg.cpp:661
+#: src/amuleDlg.cpp:596
 #, c-format
 msgid ""
 "A new version of aMule (%s) is available.\n"
@@ -648,184 +610,217 @@ msgstr ""
 "\n"
 "İndirme sayfasını açmak ister misiniz?"
 
-#: src/amuleDlg.cpp:743
+#: src/amuleDlg.cpp:678
 msgid "aMule dialog destroyed"
 msgstr "aMule diyaloğu imha edildi"
 
-#: src/amuleDlg.cpp:766 src/DataToText.cpp:68 src/IPFilter.cpp:547
+#: src/amuleDlg.cpp:701 src/DataToText.cpp:68 src/IPFilter.cpp:547
 msgid "Connecting"
 msgstr "Bağlanıyor"
 
-#: src/amuleDlg.cpp:958
+#: src/amuleDlg.cpp:893
 msgid "eD2k: Connecting"
 msgstr "eD2k: Bağlanıyor"
 
-#: src/amuleDlg.cpp:962
+#: src/amuleDlg.cpp:897
 msgid "eD2k: Disconnected"
 msgstr "eD2k: Bağlantı kesildi"
 
-#: src/amuleDlg.cpp:968
+#: src/amuleDlg.cpp:903
 msgid "Kad: Firewalled"
 msgstr "Kad: Güvenlik Duvarı"
 
-#: src/amuleDlg.cpp:972
+#: src/amuleDlg.cpp:907
 msgid "Kad: Connected"
 msgstr "Kad: Bağlandı"
 
-#: src/amuleDlg.cpp:977
+#: src/amuleDlg.cpp:912
 msgid "Kad: Connecting"
 msgstr "Kad: Bağlanıyor"
 
-#: src/amuleDlg.cpp:981
+#: src/amuleDlg.cpp:916
 msgid "Kad: Off"
 msgstr "Kad: Kapalı"
 
-#: src/amuleDlg.cpp:1029 src/DownloadListCtrl.cpp:505
+#: src/amuleDlg.cpp:964 src/DownloadListCtrl.cpp:505
 #: src/DownloadListCtrl.cpp:749 src/FriendListCtrl.cpp:180
 #: src/muuli_wdr.cpp:731 src/muuli_wdr.cpp:782 src/muuli_wdr.cpp:846
-#: src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2252 src/muuli_wdr.cpp:2337
-#: src/muuli_wdr.cpp:3085 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
+#: src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2224 src/muuli_wdr.cpp:2309
+#: src/muuli_wdr.cpp:3057 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
 #: src/ServerListCtrl.cpp:606 src/TransferWnd.cpp:378
 #: src/utils/wxCas/src/wxcasprefs.cpp:235
 msgid "Cancel"
 msgstr "İptal"
 
-#: src/amuleDlg.cpp:1030
+#: src/amuleDlg.cpp:965
 msgid "Stop the current connection attempts"
 msgstr "Durdur"
 
-#: src/amuleDlg.cpp:1035 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976
-#: src/muuli_wdr.cpp:2475
+#: src/amuleDlg.cpp:970 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976
+#: src/muuli_wdr.cpp:2447
 msgid "Disconnect"
 msgstr "Bağlantıyı Kes"
 
-#: src/amuleDlg.cpp:1036
+#: src/amuleDlg.cpp:971
 msgid "Disconnect from the currently connected networks"
 msgstr "Bağlanılmış olan ağlar ile bağlantıyı Kes"
 
-#: src/amuleDlg.cpp:1041 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979
-#: src/muuli_wdr.cpp:2630 src/muuli_wdr.cpp:3082 src/muuli_wdr.cpp:3437
+#: src/amuleDlg.cpp:976 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979
+#: src/muuli_wdr.cpp:2602 src/muuli_wdr.cpp:3054 src/muuli_wdr.cpp:3409
 msgid "Connect"
 msgstr "Bağlan"
 
-#: src/amuleDlg.cpp:1042
+#: src/amuleDlg.cpp:977
 msgid "Connect to the currently enabled networks"
 msgstr "Etkinleştirilmiş olan ağlara bağlan"
 
-#: src/amuleDlg.cpp:1154
+#: src/amuleDlg.cpp:1089
 #, c-format
 msgid "Up: %.1f%s (%.1f) | Down: %.1f%s (%.1f)"
 msgstr "Gön: %.1f%s (%.1f) | İnd: %.1f%s (%.1f)"
 
-#: src/amuleDlg.cpp:1156 src/amuleDlg.cpp:1158 src/amuleDlg.cpp:1162
-#: src/amuleDlg.cpp:1164 src/amuleDlg.cpp:1175 src/amuleDlg.cpp:1177
+#: src/amuleDlg.cpp:1091 src/amuleDlg.cpp:1093 src/amuleDlg.cpp:1097
+#: src/amuleDlg.cpp:1099 src/amuleDlg.cpp:1110 src/amuleDlg.cpp:1112
 #: src/MuleTrayIcon.cpp:796 src/MuleTrayIcon.cpp:799
 msgid " MB/s"
 msgstr " MB/s"
 
-#: src/amuleDlg.cpp:1156 src/amuleDlg.cpp:1158 src/amuleDlg.cpp:1162
-#: src/amuleDlg.cpp:1164 src/amuleDlg.cpp:1175 src/amuleDlg.cpp:1177
+#: src/amuleDlg.cpp:1091 src/amuleDlg.cpp:1093 src/amuleDlg.cpp:1097
+#: src/amuleDlg.cpp:1099 src/amuleDlg.cpp:1110 src/amuleDlg.cpp:1112
 #: src/MuleTrayIcon.cpp:796 src/MuleTrayIcon.cpp:799
 #: src/utils/wxCas/src/wxcasframe.cpp:1041
 msgid " kB/s"
 msgstr " kB/sn"
 
-#: src/amuleDlg.cpp:1161
+#: src/amuleDlg.cpp:1096
 #, c-format
 msgid "Up: %.1f%s | Down: %.1f%s"
 msgstr "Gön: %.1f%s | İnd: %.1f%s"
 
-#: src/amuleDlg.cpp:1193
+#: src/amuleDlg.cpp:1128
 #, c-format
 msgid "aMule (%s | Connected)"
 msgstr "aMule (%s | Bağlandı)"
 
-#: src/amuleDlg.cpp:1195
+#: src/amuleDlg.cpp:1130
 #, c-format
 msgid "aMule (%s | Disconnected)"
 msgstr "aMule (%s | Bağlantı kesildi)"
 
-#: src/amuleDlg.cpp:1248
+#: src/amuleDlg.cpp:1183
 #, c-format
 msgid "Do you really want to exit %s?"
 msgstr "%s üzerinden çıkmayı gerçekten istiyor musunuz?"
 
-#: src/amuleDlg.cpp:1250
+#: src/amuleDlg.cpp:1185
 msgid "Exit confirmation"
 msgstr "Çıkışı onaylayınız"
 
-#: src/amuleDlg.cpp:1613
+#: src/amuleDlg.cpp:1548
 msgid "Launch Command: "
 msgstr "Çalıştırma Komutu: "
 
-#: src/amuleDlg.cpp:1632 src/muuli_wdr.cpp:1972 src/Preferences.cpp:979
+#: src/amuleDlg.cpp:1567 src/muuli_wdr.cpp:1971 src/Preferences.cpp:951
 msgid "- default -"
 msgstr "- ön tanımlı -"
 
-#: src/amuleDlg.cpp:1660
+#: src/amuleDlg.cpp:1595
 #, c-format
 msgid "Skin directory '%s' does not exist"
 msgstr "Kaplama dizini '%s' yok"
 
-#: src/amuleDlg.cpp:1663
+#: src/amuleDlg.cpp:1598
 #, c-format
 msgid "WARNING: Unable to open skin file '%s' for read"
 msgstr "UYARI: Kaplama dosyası '%s' okuma için açılamıyor"
 
-#: src/amuleDlg.cpp:1814 src/muuli_wdr.cpp:3439
+#: src/amuleDlg.cpp:1722 src/amuleDlg.cpp:1968 src/muuli_wdr.cpp:1485
+#: src/muuli_wdr.cpp:3411
+msgid "Networks"
+msgstr "Ağlar"
+
+#: src/amuleDlg.cpp:1726 src/muuli_wdr.cpp:3411
 msgid "Networks Window"
 msgstr "Ağ Penceresi"
 
-#: src/amuleDlg.cpp:1820 src/muuli_wdr.cpp:3440
+#: src/amuleDlg.cpp:1728 src/muuli_wdr.cpp:3412
+msgid "Searches"
+msgstr "Aramalar"
+
+#: src/amuleDlg.cpp:1732 src/muuli_wdr.cpp:3412
 msgid "Searches Window"
 msgstr "Arama Penceresi"
 
-#: src/amuleDlg.cpp:1826 src/muuli_wdr.cpp:3441
+#: src/amuleDlg.cpp:1734 src/DownloadListCtrl.cpp:740 src/muuli_wdr.cpp:392
+#: src/muuli_wdr.cpp:1578 src/muuli_wdr.cpp:3413 src/Statistics.cpp:829
+msgid "Downloads"
+msgstr "İndirmeler"
+
+#: src/amuleDlg.cpp:1738 src/muuli_wdr.cpp:3413
 msgid "Downloads Window"
 msgstr "İndirme Penceresi"
 
-#: src/amuleDlg.cpp:1832 src/muuli_wdr.cpp:3443
+#: src/amuleDlg.cpp:1740 src/muuli_wdr.cpp:3287
+msgid "Shared files"
+msgstr "Paylaşılan dosyalar"
+
+#: src/amuleDlg.cpp:1744 src/muuli_wdr.cpp:3415
 msgid "Shared Files Window"
 msgstr "Paylaşılan Dosya Penceresi"
 
-#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3444
+#: src/amuleDlg.cpp:1746 src/muuli_wdr.cpp:2919 src/muuli_wdr.cpp:3369
+#: src/muuli_wdr.cpp:3416
+msgid "Messages"
+msgstr "Sohbet"
+
+#: src/amuleDlg.cpp:1750 src/muuli_wdr.cpp:3416
 msgid "Messages Window"
 msgstr "Sohbet Penceresi"
 
-#: src/amuleDlg.cpp:1844 src/muuli_wdr.cpp:3445
+#: src/amuleDlg.cpp:1752 src/muuli_wdr.cpp:3417 src/PrefsUnifiedDlg.cpp:312
+#: src/Statistics.cpp:779 src/Statistics.cpp:1235
+msgid "Statistics"
+msgstr "İstatistikler"
+
+#: src/amuleDlg.cpp:1756 src/muuli_wdr.cpp:3417
 msgid "Statistics Graph Window"
 msgstr "İstatistik Grafik Penceresi"
 
-#: src/amuleDlg.cpp:1851 src/muuli_wdr.cpp:3447
+#: src/amuleDlg.cpp:1759 src/muuli_wdr.cpp:3419 src/PrefsUnifiedDlg.cpp:328
+#: src/utils/wxCas/src/wxcasprefs.cpp:39
+msgid "Preferences"
+msgstr "Ayarlar"
+
+#: src/amuleDlg.cpp:1763 src/muuli_wdr.cpp:3419
 msgid "Preferences Settings Window"
 msgstr "Ayar Penceresi"
 
-#: src/amuleDlg.cpp:1854 src/muuli_wdr.cpp:3448
+#: src/amuleDlg.cpp:1766 src/muuli_wdr.cpp:3420
 msgid "Import"
 msgstr "İçe Aktar"
 
-#: src/amuleDlg.cpp:1858 src/muuli_wdr.cpp:3448
+#: src/amuleDlg.cpp:1770 src/muuli_wdr.cpp:3420
 msgid "The partfile importer tool"
 msgstr "Parça dosyası içe aktarım aracı"
 
-#: src/amuleDlg.cpp:1861 src/muuli_wdr.cpp:3449
+#: src/amuleDlg.cpp:1773 src/muuli_wdr.cpp:3421
 #: src/utils/aLinkCreator/src/alcframe.cpp:262
 msgid "About"
 msgstr "Hakkında"
 
-#: src/amuleDlg.cpp:1861 src/muuli_wdr.cpp:3449
+#: src/amuleDlg.cpp:1773 src/muuli_wdr.cpp:3421
 msgid "About/Help"
 msgstr "Hakkında/Yardım"
 
-#: src/amuleDlg.cpp:2059
+#: src/amuleDlg.cpp:1971
 msgid "eD2k network"
 msgstr "eD2k ağı"
 
-#: src/amuleDlg.cpp:2062
+#: src/amuleDlg.cpp:1974
 msgid "Kad network"
 msgstr "Kademlia ağı"
 
-#: src/amuleDlg.cpp:2062
+#: src/amuleDlg.cpp:1974
 msgid "No network"
 msgstr "Ağ yok"
 
@@ -956,7 +951,7 @@ msgstr "bulunamadı"
 msgid "The core rejected these shared folders:%s"
 msgstr "Çekirdek şu paylaşılan dizinleri reddetti: %s"
 
-#: src/amule-remote-gui.cpp:1336 src/ExternalConn.cpp:2346
+#: src/amule-remote-gui.cpp:1336 src/ExternalConn.cpp:2345
 msgid "Invalid link or already on list."
 msgstr "Geçersiz bağlantı veya zaten listede mevcut."
 
@@ -972,7 +967,7 @@ msgstr "'%s' dizini '%s' sınıfı için oluşturulamadı. '%s' dizini kullanıl
 #: src/ClientDetailDialog.cpp:123 src/DataToText.cpp:61 src/DataToText.cpp:86
 #: src/DataToText.cpp:101 src/DataToText.cpp:136 src/DataToText.cpp:165
 #: src/DownloadListCtrl.cpp:1172 src/DownloadListCtrl.cpp:1185
-#: src/DownloadListCtrl.cpp:1196 src/ExternalConn.cpp:609
+#: src/DownloadListCtrl.cpp:1196 src/ExternalConn.cpp:608
 #: src/FileDetailDialog.cpp:203 src/FileDetailDialog.cpp:235
 #: src/FileDetailDialog.cpp:242 src/GenericClientListCtrl.cpp:1171
 #: src/GenericClientListCtrl.cpp:1182 src/GenericClientListCtrl.cpp:1192
@@ -1358,19 +1353,19 @@ msgstr "Oto (Yük)"
 msgid "Very low"
 msgstr "Çok düşük"
 
-#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:743 src/muuli_wdr.cpp:2303
+#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:743 src/muuli_wdr.cpp:2275
 #: src/ServerListCtrl.cpp:263 src/ServerListCtrl.cpp:456
 #: src/SharedFilesCtrl.cpp:145
 msgid "Low"
 msgstr "Düşük"
 
-#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:744 src/muuli_wdr.cpp:2304
+#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:744 src/muuli_wdr.cpp:2276
 #: src/ServerListCtrl.cpp:266 src/ServerListCtrl.cpp:457
 #: src/SharedFilesCtrl.cpp:146
 msgid "Normal"
 msgstr "Normal"
 
-#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:745 src/muuli_wdr.cpp:2305
+#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:745 src/muuli_wdr.cpp:2277
 #: src/ServerListCtrl.cpp:269 src/ServerListCtrl.cpp:458
 #: src/SharedFilesCtrl.cpp:147
 msgid "High"
@@ -1462,8 +1457,8 @@ msgstr "Sunucu"
 msgid "Remote Server"
 msgstr "Uzak Sunucu"
 
-#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3202
-#: src/SearchDlg.cpp:119 src/TextClient.cpp:911
+#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3174
+#: src/SearchDlg.cpp:111 src/TextClient.cpp:911
 msgid "Kad"
 msgstr "Kad"
 
@@ -1533,7 +1528,7 @@ msgstr "Parça"
 msgid "Size"
 msgstr "Boyut"
 
-#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3269
+#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3241
 msgid "Transferred"
 msgstr "Aktarıldı"
 
@@ -1591,7 +1586,7 @@ msgstr ""
 "Geri besleme: %s (%s)\n"
 "\n"
 
-#: src/DownloadListCtrl.cpp:746 src/muuli_wdr.cpp:2306
+#: src/DownloadListCtrl.cpp:746 src/muuli_wdr.cpp:2278
 #: src/SharedFilesCtrl.cpp:150
 msgid "Auto"
 msgstr "Otomatik"
@@ -1629,7 +1624,7 @@ msgid "Extended Options"
 msgstr "Genişletilmiş Seçenekler"
 
 #: src/DownloadListCtrl.cpp:770 src/DownloadListCtrl.cpp:822
-#: src/muuli_wdr.cpp:1790
+#: src/muuli_wdr.cpp:1789
 msgid "Preview"
 msgstr "Ön İzleme"
 
@@ -1804,230 +1799,225 @@ msgstr[1] "%u bağlantı eklenemedi (teferruatlar için kütüğe bakın)."
 msgid "Invalid eD2k link! ERROR: %s"
 msgstr "Geçersiz eD2k bağlantısı! HATA: %s"
 
-#: src/ExternalConn.cpp:380
+#: src/ExternalConn.cpp:379
 msgid "Client sent packet after authentication failed."
 msgstr "Kimlik kanıtlamadan sonra istemci tarafından gönderilen paket başarısız."
 
-#: src/ExternalConn.cpp:397
+#: src/ExternalConn.cpp:396
 msgid "External connection closed."
 msgstr "Dışarıdan bağlantı kesildi."
 
-#: src/ExternalConn.cpp:474
+#: src/ExternalConn.cpp:473
 msgid "External connections disabled due to empty password!"
 msgstr "Boş şifre sebebiyle dışarıdan bağlantı devre dışı!"
 
-#: src/ExternalConn.cpp:495
+#: src/ExternalConn.cpp:494
 msgid "External connections disabled in config file"
 msgstr "Yapılandırma dosyasında dışarıdan bağlantılar devre dışı bırakılmış."
 
-#: src/ExternalConn.cpp:576
+#: src/ExternalConn.cpp:575
 msgid "New external connection accepted"
 msgstr "Yeni dışarıdan bağlantı kabul edildi"
 
-#: src/ExternalConn.cpp:579
+#: src/ExternalConn.cpp:578
 msgid "ERROR: couldn't accept a new external connection"
 msgstr "HATA: yeni bir dış bağlantı kabul edilemiyor"
 
-#: src/ExternalConn.cpp:596
+#: src/ExternalConn.cpp:595
 msgid "External connection refused due to empty password in preferences!"
 msgstr "Ayarlardaki boş şifre sebebiyle dışarıdan bağlantılar reddedildi!"
 
-#: src/ExternalConn.cpp:608
+#: src/ExternalConn.cpp:607
 #, c-format
 msgid "Connecting client: %s %s"
 msgstr "Kullanıcıya bağlanılıyor: %s %s"
 
-#: src/ExternalConn.cpp:610
+#: src/ExternalConn.cpp:609
 msgid "Unknown version"
 msgstr "Bilinmeyen sürüm"
 
-#: src/ExternalConn.cpp:623
+#: src/ExternalConn.cpp:622
 msgid "Incorrect EC version ID, there might be binary incompatibility. Use core and remote from same snapshot."
 msgstr "Yanlış EC sürüm ID, bir çift uyumsuzluğu olabilir. Aynı görüntüden çekirdek ve uzak kullanınız."
 
-#: src/ExternalConn.cpp:631
+#: src/ExternalConn.cpp:630
 msgid "You cannot connect to a release version from an arbitrary development snapshot! *sigh* possible crash prevented"
 msgstr "Bir geliştirme sürümünden dengeli bir sürüme bağlanamazsınız! *muhtemel* bir çökme önlendi"
 
-#: src/ExternalConn.cpp:714
+#: src/ExternalConn.cpp:713
 msgid "Invalid protocol version."
 msgstr "Geçersiz protokol sürümü."
 
-#: src/ExternalConn.cpp:720
+#: src/ExternalConn.cpp:719
 msgid "Missing protocol version tag."
 msgstr "Kayıp protokol sürüm eki."
 
-#: src/ExternalConn.cpp:728
+#: src/ExternalConn.cpp:727
 msgid "Authentication failed: invalid hash specified as EC password."
 msgstr "Kimlik doğrulama başarısız oldu: EC parolası olarak geçersiz adresleme girildi."
 
-#: src/ExternalConn.cpp:776
+#: src/ExternalConn.cpp:775
 msgid "Authentication failed: wrong password."
 msgstr "Kimlik doğrulama başarısız oldu: yanlış parola."
 
-#: src/ExternalConn.cpp:778
+#: src/ExternalConn.cpp:777
 msgid "Authentication failed: missing password."
 msgstr "Kimlik doğrulama başarısız oldu: kayıp parola."
 
-#: src/ExternalConn.cpp:789
+#: src/ExternalConn.cpp:788
 msgid "Invalid request, please authenticate first."
 msgstr "Geçersiz istem, öncelikle doğrulatmanız lazım."
 
-#: src/ExternalConn.cpp:794
+#: src/ExternalConn.cpp:793
 msgid "Access granted."
 msgstr "Giriş izni verildi."
 
-#: src/ExternalConn.cpp:802
+#: src/ExternalConn.cpp:801
 #, c-format
 msgid "Sent error message \"%s\" to client."
 msgstr "\"%s\" hata iletisi istemciye gönderildi."
 
-#: src/ExternalConn.cpp:807
+#: src/ExternalConn.cpp:806
 #, c-format
 msgid "Unauthorized access attempt from %s. Connection closed."
 msgstr "%s üzerinden yetkilendirilmemiş giriş denemesi. Bağlantı kesildi."
 
-#: src/ExternalConn.cpp:1420
+#: src/ExternalConn.cpp:1419
 #, c-format
 msgid "Remote PartFile command failed: FileHash not found: %s"
 msgstr "Uzak Parça Dosyası komutu başarısız: Dosya Adreslemesi bulunamadı: %s"
 
-#: src/ExternalConn.cpp:1424
+#: src/ExternalConn.cpp:1423
 #, c-format
 msgid "FileHash not found: %s"
 msgstr "Dosya adreslemesi bulunamadı: %s"
 
-#: src/ExternalConn.cpp:1471 src/ExternalConn.cpp:1559
-#: src/ExternalConn.cpp:1680
+#: src/ExternalConn.cpp:1470 src/ExternalConn.cpp:1558
+#: src/ExternalConn.cpp:1679
 msgid "OOPS! OpCode processing error!"
 msgstr "Aman aman! OpCode işleme hatası!"
 
-#: src/ExternalConn.cpp:1502
+#: src/ExternalConn.cpp:1501
 msgid "Server not added"
 msgstr "Sunucu eklenmedi."
 
-#: src/ExternalConn.cpp:1521
+#: src/ExternalConn.cpp:1520
 #, c-format
 msgid "server not found: %s"
 msgstr "sunucu bulunamadı: %s"
 
-#: src/ExternalConn.cpp:1538
+#: src/ExternalConn.cpp:1537
 msgid "need to define server to be removed"
 msgstr "çıkarılacak sunucunun tanımlanması gerekli"
 
-#: src/ExternalConn.cpp:1553
+#: src/ExternalConn.cpp:1552
 msgid "eD2k is disabled in preferences."
 msgstr "eD2k ayarlarda devre dışı bırakılmış."
 
-#: src/ExternalConn.cpp:1658
+#: src/ExternalConn.cpp:1657
 msgid "Friend not found."
 msgstr "Arkadaş bulunamadı."
 
-#: src/ExternalConn.cpp:1668
+#: src/ExternalConn.cpp:1667
 msgid "Client not found."
 msgstr "İstemci bulunamadı."
 
-#: src/ExternalConn.cpp:1674
+#: src/ExternalConn.cpp:1673
 msgid "EC_TAG_FRIEND_SHARED requires EC_TAG_FRIEND or EC_TAG_CLIENT."
 msgstr "EC_TAG_FRIEND_SHARED, EC_TAG_FRIEND veya EC_TAG_CLIENT gerektirir."
 
-#: src/ExternalConn.cpp:1992
+#: src/ExternalConn.cpp:1991
 msgid "WebSearch from remote interface makes no sense."
 msgstr "Uzak arayüzden Web araması yapmak anlamsız."
 
-#: src/ExternalConn.cpp:2027
+#: src/ExternalConn.cpp:2026
 msgid "Search in progress. Refetch results in a moment!"
 msgstr "Arama sürüyor. Bir dakikaya sonuçlanır!"
 
-#: src/ExternalConn.cpp:2266
+#: src/ExternalConn.cpp:2265
 msgid "No points for graph."
 msgstr "Grafik için hiç nokta yok."
 
-#: src/ExternalConn.cpp:2276
+#: src/ExternalConn.cpp:2275
 msgid "Your client is not configured for this detail level."
 msgstr "Yazılımınız bu ayrıntı düzeyi için yapılandırılmamış."
 
-#: src/ExternalConn.cpp:2303
+#: src/ExternalConn.cpp:2302
 msgid "External Connection: shutdown requested"
 msgstr "Bağlantı kapat"
 
-#: src/ExternalConn.cpp:2315
+#: src/ExternalConn.cpp:2314
 msgid "Already shutting down."
 msgstr "Zaten kapatılıyor."
 
-#: src/ExternalConn.cpp:2333
+#: src/ExternalConn.cpp:2332
 #, c-format
 msgid "ExternalConn: adding link '%s'."
 msgstr "Dışarıdan Bağ.:'%s' bağlantısı ekleniyor."
 
-#: src/ExternalConn.cpp:2351
+#: src/ExternalConn.cpp:2350
 #, c-format
 msgid "%d of %d links failed (invalid or already on list)."
 msgstr "%d bağlantı, ki toplam %d üzerinden, başarısız oldu (geçersiz veya zaten listede)."
 
-#: src/ExternalConn.cpp:2374
+#: src/ExternalConn.cpp:2373
 msgid "Version check throttled; try again shortly."
 msgstr "Sürüm kontrolü sınırlandırıldı; kısa bir süre sonra tekrar deneyin."
 
-#: src/ExternalConn.cpp:2379
+#: src/ExternalConn.cpp:2378
 msgid "Version check is not available on this daemon."
 msgstr "Bu daemon üzerinde sürüm kontrolü mevcut değildir."
 
-#: src/ExternalConn.cpp:2509
+#: src/ExternalConn.cpp:2508
 msgid "File not found."
 msgstr "Dosya bulunamadı."
 
-#: src/ExternalConn.cpp:2514
+#: src/ExternalConn.cpp:2513
 msgid "Invalid file name."
 msgstr "Geçersiz dosya adı."
 
-#: src/ExternalConn.cpp:2522
+#: src/ExternalConn.cpp:2521
 msgid "Unable to rename file."
 msgstr "Dosya yeniden adlandırılamıyor."
 
-#: src/ExternalConn.cpp:2839
-#, c-format
-msgid "Could not save the amuleapi password: %s"
-msgstr ""
-
-#: src/ExternalConn.cpp:3004 src/ExternalConn.cpp:3032
+#: src/ExternalConn.cpp:2992 src/ExternalConn.cpp:3020
 msgid "Kad is disabled in preferences."
 msgstr "Kad ayarlarda devre dışı bırakılmış."
 
-#: src/ExternalConn.cpp:3045
+#: src/ExternalConn.cpp:3033
 msgid "Already connected to eD2k."
 msgstr "eD2k ağına zaten bağlandı."
 
-#: src/ExternalConn.cpp:3048
+#: src/ExternalConn.cpp:3036
 msgid "Connecting to eD2k..."
 msgstr "eD2k ağına bağlanıyor…"
 
-#: src/ExternalConn.cpp:3057
+#: src/ExternalConn.cpp:3045
 msgid "Already connected to Kad."
 msgstr "Kad zaten bağlı."
 
-#: src/ExternalConn.cpp:3060
+#: src/ExternalConn.cpp:3048
 msgid "Connecting to Kad..."
 msgstr "Kad ağına bağlanıyor…"
 
-#: src/ExternalConn.cpp:3067
+#: src/ExternalConn.cpp:3055
 msgid "All networks are disabled."
 msgstr "Bütün ağlar devre dışı."
 
-#: src/ExternalConn.cpp:3076
+#: src/ExternalConn.cpp:3064
 msgid "Disconnected from eD2k."
 msgstr "eD2k ağından bağlantı kesildi."
 
-#: src/ExternalConn.cpp:3081
+#: src/ExternalConn.cpp:3069
 msgid "Disconnected from Kad."
 msgstr "Kad ağından bağlantı kesildi."
 
-#: src/ExternalConn.cpp:3090
+#: src/ExternalConn.cpp:3078
 #, c-format
 msgid "External Connection: invalid opcode received: %#x"
 msgstr "Dış Bağlantı: geçersiz opcode alındı: %#x"
 
-#: src/ExternalConn.cpp:3095
+#: src/ExternalConn.cpp:3083
 msgid "Invalid opcode (wrong protocol version?)"
 msgstr "Geçersiz opcode (yanlış protokol sürümü mü?)"
 
@@ -2343,19 +2333,19 @@ msgstr ""
 msgid "eD2k"
 msgstr "eD2k"
 
-#: src/FirstRunWizard.cpp:349 src/muuli_wdr.cpp:1495
+#: src/FirstRunWizard.cpp:349 src/muuli_wdr.cpp:1488
 msgid "Kademlia"
 msgstr "Kademlia"
 
-#: src/FirstRunWizard.cpp:359 src/muuli_wdr.cpp:1423
+#: src/FirstRunWizard.cpp:359 src/muuli_wdr.cpp:1416
 msgid "Standard TCP Port "
 msgstr "Standart TCP Portu "
 
-#: src/FirstRunWizard.cpp:365 src/muuli_wdr.cpp:1435
+#: src/FirstRunWizard.cpp:365 src/muuli_wdr.cpp:1428
 msgid "Extended UDP port (Kad / global search) "
 msgstr "Genişletilmiş UDP portu (Kad / Genel arama) "
 
-#: src/FirstRunWizard.cpp:377 src/muuli_wdr.cpp:1442
+#: src/FirstRunWizard.cpp:377 src/muuli_wdr.cpp:1435
 msgid "Enable UPnP for router port forwarding"
 msgstr "Yönlendirici port iletimi için UPnP'yi etkinleştir"
 
@@ -2382,7 +2372,7 @@ msgstr ""
 msgid "Your peer lists are already in place - nothing to download."
 msgstr "%s dosyasını indirmeyi zaten deniyorsunuz"
 
-#: src/FirstRunWizard.cpp:434 src/muuli_wdr.cpp:1540
+#: src/FirstRunWizard.cpp:434 src/muuli_wdr.cpp:1533
 msgid "Auto-update server list at startup"
 msgstr "Otomatik başlangıç"
 
@@ -2428,23 +2418,23 @@ msgid ""
 "want downloads on a different (e.g. larger) disk."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:549 src/FirstRunWizard.cpp:611 src/muuli_wdr.cpp:1702
+#: src/FirstRunWizard.cpp:549 src/FirstRunWizard.cpp:611 src/muuli_wdr.cpp:1701
 msgid "Destination folder for downloads"
 msgstr "İndirmeler için hedef dizin"
 
-#: src/FirstRunWizard.cpp:553 src/FirstRunWizard.cpp:569 src/muuli_wdr.cpp:1349
-#: src/muuli_wdr.cpp:1366 src/muuli_wdr.cpp:1677 src/muuli_wdr.cpp:1708
-#: src/muuli_wdr.cpp:1720 src/muuli_wdr.cpp:2790
+#: src/FirstRunWizard.cpp:553 src/FirstRunWizard.cpp:569 src/muuli_wdr.cpp:1342
+#: src/muuli_wdr.cpp:1359 src/muuli_wdr.cpp:1676 src/muuli_wdr.cpp:1707
+#: src/muuli_wdr.cpp:1719 src/muuli_wdr.cpp:2762
 #: src/utils/aLinkCreator/src/alcframe.cpp:135
 #: src/utils/wxCas/src/wxcasprefs.cpp:52 src/utils/wxCas/src/wxcasprefs.cpp:118
 msgid "Browse"
 msgstr "Göz at"
 
-#: src/FirstRunWizard.cpp:559 src/muuli_wdr.cpp:1713
+#: src/FirstRunWizard.cpp:559 src/muuli_wdr.cpp:1712
 msgid "(All files in this folder are shared with other peers)"
 msgstr "(Bu dizindeki tüm dosyalar diğer eşler ile paylaşılmaktadır)"
 
-#: src/FirstRunWizard.cpp:565 src/FirstRunWizard.cpp:624 src/muuli_wdr.cpp:1715
+#: src/FirstRunWizard.cpp:565 src/FirstRunWizard.cpp:624 src/muuli_wdr.cpp:1714
 msgid "Folder for temporary download files"
 msgstr "Geçici dosyalar için dizin"
 
@@ -2475,7 +2465,7 @@ msgstr "Arkadaş listesi 'emfriends.met' dosyasına yazılamıyor!"
 msgid "CRITICAL - no client on StartChatSession"
 msgstr "KRİTİK - SohbetOturumunuBaşlat' ta istemci yok"
 
-#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2696 src/muuli_wdr.cpp:3373
+#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2668 src/muuli_wdr.cpp:3345
 msgid "Friends"
 msgstr "Arkadaşlar"
 
@@ -2585,8 +2575,8 @@ msgstr "Yok"
 msgid "No"
 msgstr "Hayır"
 
-#: src/GenericClientListCtrl.cpp:1216 src/PrefsUnifiedDlg.cpp:2898
-#: src/PrefsUnifiedDlg.cpp:2948 src/ServerListCtrl.cpp:276
+#: src/GenericClientListCtrl.cpp:1216 src/PrefsUnifiedDlg.cpp:2818
+#: src/PrefsUnifiedDlg.cpp:2868 src/ServerListCtrl.cpp:276
 msgid "Yes"
 msgstr "Evet"
 
@@ -2755,10 +2745,10 @@ msgstr "Ön yükleme için geçersiz port"
 msgid "Please fill all fields required"
 msgstr "İstenilen tüm alanları doldurunuz."
 
-#: src/KadDlg.cpp:192 src/PartFile.cpp:1031 src/PrefsUnifiedDlg.cpp:1134
-#: src/PrefsUnifiedDlg.cpp:1204 src/PrefsUnifiedDlg.cpp:1405
-#: src/PrefsUnifiedDlg.cpp:1663 src/PrefsUnifiedDlg.cpp:1673
-#: src/PrefsUnifiedDlg.cpp:1690 src/PrefsUnifiedDlg.cpp:1738
+#: src/KadDlg.cpp:192 src/PartFile.cpp:1031 src/PrefsUnifiedDlg.cpp:1162
+#: src/PrefsUnifiedDlg.cpp:1331 src/PrefsUnifiedDlg.cpp:1589
+#: src/PrefsUnifiedDlg.cpp:1599 src/PrefsUnifiedDlg.cpp:1616
+#: src/PrefsUnifiedDlg.cpp:1658
 msgid "Message"
 msgstr "İleti"
 
@@ -2859,7 +2849,7 @@ msgstr "Paylaşım oranı"
 msgid "Uploaded"
 msgstr "Gönderilen"
 
-#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3253
+#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3225
 msgid "Requested"
 msgstr "İstenen"
 
@@ -2982,7 +2972,7 @@ msgid "WARNING: "
 msgstr "UYARI: "
 
 #: src/MuleNotebook.cpp:179 src/muuli_wdr.cpp:817 src/muuli_wdr.cpp:1229
-#: src/muuli_wdr.cpp:3157 src/muuli_wdr.cpp:3413
+#: src/muuli_wdr.cpp:3129 src/muuli_wdr.cpp:3385
 msgid "Close"
 msgstr "Kapat"
 
@@ -2995,12 +2985,12 @@ msgstr "Kes"
 msgid "Copy"
 msgstr "Kopyala"
 
-#: src/MuleTextCtrl.cpp:88 src/SearchDlg.cpp:261
+#: src/MuleTextCtrl.cpp:88
 msgid "Paste"
 msgstr "Yapıştır"
 
 #: src/MuleTextCtrl.cpp:89 src/muuli_wdr.cpp:358 src/muuli_wdr.cpp:757
-#: src/muuli_wdr.cpp:2380 src/muuli_wdr.cpp:2399 src/muuli_wdr.cpp:2421
+#: src/muuli_wdr.cpp:2352 src/muuli_wdr.cpp:2371 src/muuli_wdr.cpp:2393
 #: src/utils/aLinkCreator/src/alcframe.cpp:142
 msgid "Clear"
 msgstr "Temizle"
@@ -3091,8 +3081,8 @@ msgid "Exit"
 msgstr "Çıkış"
 
 #: src/MuleTrayIcon.cpp:579 src/MuleTrayIcon.cpp:945 src/MuleTrayIcon.cpp:965
-#: src/muuli_wdr.cpp:1398 src/muuli_wdr.cpp:1406 src/muuli_wdr.cpp:1413
-#: src/muuli_wdr.cpp:1836 src/muuli_wdr.cpp:1842 src/OtherFunctions.cpp:91
+#: src/muuli_wdr.cpp:1391 src/muuli_wdr.cpp:1399 src/muuli_wdr.cpp:1406
+#: src/muuli_wdr.cpp:1835 src/muuli_wdr.cpp:1841 src/OtherFunctions.cpp:91
 #: src/StatisticsDlg.cpp:93 src/StatisticsDlg.cpp:95
 msgid "kB/s"
 msgstr "kB/s"
@@ -3261,7 +3251,7 @@ msgstr "Ad:"
 msgid "Type"
 msgstr "Tür"
 
-#: src/muuli_wdr.cpp:215 src/SearchDlg.cpp:118 src/SearchListCtrl.cpp:853
+#: src/muuli_wdr.cpp:215 src/SearchDlg.cpp:110 src/SearchListCtrl.cpp:853
 msgid "Local"
 msgstr "Sunucu"
 
@@ -3332,7 +3322,7 @@ msgstr "Bayt"
 msgid "KB"
 msgstr "KB"
 
-#: src/muuli_wdr.cpp:274 src/muuli_wdr.cpp:293 src/muuli_wdr.cpp:1621
+#: src/muuli_wdr.cpp:274 src/muuli_wdr.cpp:293 src/muuli_wdr.cpp:1620
 #: src/OtherFunctions.cpp:64
 msgid "MB"
 msgstr "MB"
@@ -3349,7 +3339,7 @@ msgstr "En Fazla Boyut"
 msgid "Availability"
 msgstr "Uygunluk"
 
-#: src/muuli_wdr.cpp:312 src/muuli_wdr.cpp:398 src/muuli_wdr.cpp:3318
+#: src/muuli_wdr.cpp:312 src/muuli_wdr.cpp:398 src/muuli_wdr.cpp:3290
 msgid "Filter:"
 msgstr "Süz:"
 
@@ -3381,7 +3371,7 @@ msgstr "Zaten cevap vermiş Kad eşlerinden aramayı genişletmelerini iste. Ara
 msgid "Stop"
 msgstr "Durdur"
 
-#: src/muuli_wdr.cpp:348 src/muuli_wdr.cpp:1392 src/SearchListCtrl.cpp:732
+#: src/muuli_wdr.cpp:348 src/muuli_wdr.cpp:1385 src/SearchListCtrl.cpp:732
 msgid "Download"
 msgstr "İndir"
 
@@ -3412,12 +3402,12 @@ msgstr "Dosya kaynakları:"
 #: src/muuli_wdr.cpp:1160 src/muuli_wdr.cpp:1167 src/muuli_wdr.cpp:1172
 #: src/muuli_wdr.cpp:1179 src/muuli_wdr.cpp:1184 src/muuli_wdr.cpp:1191
 #: src/muuli_wdr.cpp:1205 src/muuli_wdr.cpp:1212 src/muuli_wdr.cpp:1217
-#: src/muuli_wdr.cpp:1224 src/muuli_wdr.cpp:3255 src/muuli_wdr.cpp:3263
-#: src/muuli_wdr.cpp:3271
+#: src/muuli_wdr.cpp:1224 src/muuli_wdr.cpp:3227 src/muuli_wdr.cpp:3235
+#: src/muuli_wdr.cpp:3243
 msgid "N/A"
 msgstr "N/A"
 
-#: src/muuli_wdr.cpp:508 src/muuli_wdr.cpp:1065 src/PrefsUnifiedDlg.cpp:299
+#: src/muuli_wdr.cpp:508 src/muuli_wdr.cpp:1065 src/PrefsUnifiedDlg.cpp:297
 msgid "General"
 msgstr "Genel"
 
@@ -3553,7 +3543,7 @@ msgstr "Sanatçı:"
 msgid "Album :"
 msgstr "Albüm:"
 
-#: src/muuli_wdr.cpp:685 src/muuli_wdr.cpp:2275
+#: src/muuli_wdr.cpp:685 src/muuli_wdr.cpp:2247
 msgid "Title :"
 msgstr "Başlık :"
 
@@ -3661,7 +3651,7 @@ msgstr "Kullanıcı Adı :"
 msgid "Userhash :"
 msgstr "Kullanıcı Adreslemesi :"
 
-#: src/muuli_wdr.cpp:895 src/muuli_wdr.cpp:1742 src/muuli_wdr.cpp:2470
+#: src/muuli_wdr.cpp:895 src/muuli_wdr.cpp:1741 src/muuli_wdr.cpp:2442
 #: src/utils/aLinkCreator/src/alcframe.cpp:137
 msgid "Add"
 msgstr "Ekle"
@@ -3670,15 +3660,15 @@ msgstr "Ekle"
 msgid "Download-Speed"
 msgstr "İndirme Hızı"
 
-#: src/muuli_wdr.cpp:954 src/muuli_wdr.cpp:989 src/muuli_wdr.cpp:2574
+#: src/muuli_wdr.cpp:954 src/muuli_wdr.cpp:989 src/muuli_wdr.cpp:2546
 msgid "Current"
 msgstr "Şimdiki"
 
-#: src/muuli_wdr.cpp:962 src/muuli_wdr.cpp:997 src/muuli_wdr.cpp:2582
+#: src/muuli_wdr.cpp:962 src/muuli_wdr.cpp:997 src/muuli_wdr.cpp:2554
 msgid "Running average"
 msgstr "Çalışma ortalaması"
 
-#: src/muuli_wdr.cpp:970 src/muuli_wdr.cpp:1005 src/muuli_wdr.cpp:2590
+#: src/muuli_wdr.cpp:970 src/muuli_wdr.cpp:1005 src/muuli_wdr.cpp:2562
 msgid "Session average"
 msgstr "Oturum ortalaması"
 
@@ -3690,7 +3680,7 @@ msgstr "Gönderim Hızı"
 msgid "Connections"
 msgstr "Bağlantılar"
 
-#: src/muuli_wdr.cpp:1024 src/muuli_wdr.cpp:1861
+#: src/muuli_wdr.cpp:1024 src/muuli_wdr.cpp:1860
 msgid "Active downloads"
 msgstr "Aktif İndirmeler"
 
@@ -3698,7 +3688,7 @@ msgstr "Aktif İndirmeler"
 msgid "Active connections (1:1)"
 msgstr "Aktif Bağlantılar (1:1)"
 
-#: src/muuli_wdr.cpp:1040 src/muuli_wdr.cpp:1862
+#: src/muuli_wdr.cpp:1040 src/muuli_wdr.cpp:1861
 msgid "Active uploads"
 msgstr "Aktif Göndermeler"
 
@@ -3814,8 +3804,8 @@ msgstr "Bağlandığınızda diğerlerinin göreceği isminiz budur."
 msgid "Language: "
 msgstr "Dil: "
 
-#: src/muuli_wdr.cpp:1257 src/muuli_wdr.cpp:1330 src/muuli_wdr.cpp:1334
-#: src/muuli_wdr.cpp:1337
+#: src/muuli_wdr.cpp:1257 src/muuli_wdr.cpp:1323 src/muuli_wdr.cpp:1327
+#: src/muuli_wdr.cpp:1330
 msgid "The delay before showing tool-tips."
 msgstr "İpuçlarını göstermeden önce geçecek süreyi belirler."
 
@@ -3891,260 +3881,259 @@ msgstr "İndirme sona erdiğinde bildirimleri göster"
 msgid "Enabling this will make aMule to show notifications when finished downloading."
 msgstr "Bu şık etkinleştirilirse, indirmeler sona erdiğinde aMule bildirimleri gösterecektir."
 
-#: src/muuli_wdr.cpp:1323
-#, fuzzy
-msgid "Remember search history"
-msgstr "Bu ayarları hatırla"
-
-#: src/muuli_wdr.cpp:1324
-msgid "Keeps a dropdown list of your past search terms in the Search tab's Name field. This remembers the queries you typed, not the results they returned."
-msgstr ""
-
-#: src/muuli_wdr.cpp:1329
+#: src/muuli_wdr.cpp:1322
 msgid "Tooltip delay time: "
 msgstr "İpucu gecikme süresi: "
 
-#: src/muuli_wdr.cpp:1336
+#: src/muuli_wdr.cpp:1329
 msgid "seconds"
 msgstr "saniye"
 
-#: src/muuli_wdr.cpp:1340
+#: src/muuli_wdr.cpp:1333
 msgid "Browser Selection"
 msgstr "Tarayıcı Seçimi"
 
-#: src/muuli_wdr.cpp:1346
+#: src/muuli_wdr.cpp:1339
 msgid "Enter your browser name here. Leave this field empty to use the system default browser."
 msgstr "Tarayıcı adını buraya giriniz. Sisteminizin ön tanımlı tarayıcısını kullanmak için boş bırakınız."
 
-#: src/muuli_wdr.cpp:1353
+#: src/muuli_wdr.cpp:1346
 msgid "Open in new tab if possible"
 msgstr "Mümkünse yeni sekmede aç"
 
-#: src/muuli_wdr.cpp:1355
+#: src/muuli_wdr.cpp:1348
 msgid "Open the web page in a new tab instead of in a new window when possible"
 msgstr "Web sayfasını, yeni pencere yerine mümkünse yeni sekmede açar."
 
-#: src/muuli_wdr.cpp:1359
+#: src/muuli_wdr.cpp:1352
 msgid "Video Player"
 msgstr "Ortam Çalıcısı"
 
-#: src/muuli_wdr.cpp:1386
+#: src/muuli_wdr.cpp:1379
 msgid "Bandwidth limits"
 msgstr "Bağlantı sınırları"
 
-#: src/muuli_wdr.cpp:1400
+#: src/muuli_wdr.cpp:1393
 msgid "Upload"
 msgstr "Gönderme"
 
-#: src/muuli_wdr.cpp:1408
+#: src/muuli_wdr.cpp:1401
 msgid "Slot Allocation"
 msgstr "Slot Tahsis Boyutu"
 
-#: src/muuli_wdr.cpp:1417
+#: src/muuli_wdr.cpp:1410
 msgid "Ports"
 msgstr "Portlar"
 
-#: src/muuli_wdr.cpp:1427
+#: src/muuli_wdr.cpp:1420
 msgid "This is the standard eD2k port and cannot be disabled."
 msgstr "Bu, standart eD2k bağlantı noktasıdır ve devre dışı bırakılamaz."
 
-#: src/muuli_wdr.cpp:1430
+#: src/muuli_wdr.cpp:1423
 msgid "UDP port for server requests (TCP+3):"
 msgstr "Sunucu istemleri için UDP Portu (TCP+3):"
 
-#: src/muuli_wdr.cpp:1432
+#: src/muuli_wdr.cpp:1425
 msgid "4665"
 msgstr "4665"
 
-#: src/muuli_wdr.cpp:1439
+#: src/muuli_wdr.cpp:1432
 msgid "This UDP port is used for extended eD2k requests and Kad network"
 msgstr "Bu UDP portu genişletilmiş eD2k istemleri ve Kad ağı için kullanılır"
 
-#: src/muuli_wdr.cpp:1446
+#: src/muuli_wdr.cpp:1439
 msgid "UPnP TCP Port (Optional):"
 msgstr "UPnP TCP Portu (İsteğe bağlı):"
 
-#: src/muuli_wdr.cpp:1456
+#: src/muuli_wdr.cpp:1449
 msgid "Bind local address to IP (empty for any):"
 msgstr "Yerel adresi IP' ye bağla (herhangi biri için boş bırakın):"
 
-#: src/muuli_wdr.cpp:1459
+#: src/muuli_wdr.cpp:1452
 msgid "Advanced users only: If you have multiple network interfaces, enter the address of the interface to which aMule should be bound."
 msgstr "Sadece ileri düzey kullanıcılar: Birden fazla ağ arayüzünüz varsa; aMule'nin izleyeceği arayüz adresini giriniz."
 
-#: src/muuli_wdr.cpp:1462 src/muuli_wdr.cpp:2055
+#: src/muuli_wdr.cpp:1455 src/muuli_wdr.cpp:2054
 msgid "Bind to network interface (empty for any):"
 msgstr "Ağ arayüzüne bağla (herhangi biri için boş bırakın):"
 
-#: src/muuli_wdr.cpp:1475
+#: src/muuli_wdr.cpp:1468
 msgid "Advanced users only: pin all of aMule's traffic to one network interface, chosen from the list or typed in by name (e.g. tun0, eth0, en0) or index. Unlike binding to an IP, this stops traffic leaking out via the default route - useful with a VPN. Requires no elevated privileges."
 msgstr "Sadece ileri seviye kullanıcılar için: tüm aMule trafiğini listeden seçilmiş veya ismi (mesela tun0, eth0, en0) ya da endeksi yazılmış tek bir ağ arayüzüne sabitle. Bir IP adresine sabitlemenin aksine bu, trafiğin varsayılan yoldan sızmasını engeller - VPN'ler ile faydalıdır. Yüksek izinlere ihtiyaç duymaz."
 
-#: src/muuli_wdr.cpp:1481
+#: src/muuli_wdr.cpp:1474
 msgid "Max sources per downloading file:"
 msgstr "İndirilen dosya başına en fazla kaynak sayısı:"
 
-#: src/muuli_wdr.cpp:1485
+#: src/muuli_wdr.cpp:1478
 msgid "Max simultaneous connections:"
 msgstr "En cazla eş bağlantı sayısı:"
 
-#: src/muuli_wdr.cpp:1498 src/muuli_wdr.cpp:3197
+#: src/muuli_wdr.cpp:1491 src/muuli_wdr.cpp:3169
 msgid "ED2K"
 msgstr "ED2K"
 
-#: src/muuli_wdr.cpp:1505
+#: src/muuli_wdr.cpp:1498
 msgid "Autoconnect on startup"
 msgstr "Başlangıçta otomatik bağlan"
 
-#: src/muuli_wdr.cpp:1508
+#: src/muuli_wdr.cpp:1501
 msgid "Reconnect on loss"
 msgstr "Bağlantı koptuğunda yeniden bağlan"
 
-#: src/muuli_wdr.cpp:1530
+#: src/muuli_wdr.cpp:1523
 msgid "Remove dead server after"
 msgstr "Ölü sunucuları"
 
-#: src/muuli_wdr.cpp:1531
+#: src/muuli_wdr.cpp:1524
 msgid "Static servers are never removed, even when unreachable."
 msgstr "Statik sunucular hiçbir zaman kaldırılmazlar, ulaşılamaz oldukları zaman dahi."
 
-#: src/muuli_wdr.cpp:1535
+#: src/muuli_wdr.cpp:1528
 msgid "retries"
 msgstr "denemeden sonra kaldır"
 
-#: src/muuli_wdr.cpp:1543
+#: src/muuli_wdr.cpp:1536
 msgid "List"
 msgstr "Liste"
 
-#: src/muuli_wdr.cpp:1546
+#: src/muuli_wdr.cpp:1539
 msgid "Update server list when connecting to a server"
 msgstr "Bir sunucuya bağlandığında sunucu listesini güncelle"
 
-#: src/muuli_wdr.cpp:1549
+#: src/muuli_wdr.cpp:1542
 msgid "Update server list when a client connects"
 msgstr "Bir kullanıcı bağlandığında sunucu listesini güncelle"
 
-#: src/muuli_wdr.cpp:1552
+#: src/muuli_wdr.cpp:1545
 msgid "Use priority system"
 msgstr "Öncelik sistemini kullan"
 
-#: src/muuli_wdr.cpp:1556
+#: src/muuli_wdr.cpp:1549
 msgid "Use smart LowID check on connect"
 msgstr "Bağlanırken akıllı DüşükID denetimi yap"
 
-#: src/muuli_wdr.cpp:1560
+#: src/muuli_wdr.cpp:1553
 msgid "Safe connect"
 msgstr "Güvenli Bağlantı"
 
-#: src/muuli_wdr.cpp:1564
+#: src/muuli_wdr.cpp:1557
 msgid "Autoconnect to servers in static list only"
 msgstr "Sadece statik listesindeki sunuculara otomatikman bağlan"
 
-#: src/muuli_wdr.cpp:1567
+#: src/muuli_wdr.cpp:1560
 msgid "Set manually added servers to High Priority"
 msgstr "Elle eklenmiş sunuculara Yüksek Öncelik ata"
 
-#: src/muuli_wdr.cpp:1588
+#: src/muuli_wdr.cpp:1581
 msgid "Add files to download in pause mode"
 msgstr "Dosyaları aktarımlara duraklatılmış kipte ekle"
 
-#: src/muuli_wdr.cpp:1590
+#: src/muuli_wdr.cpp:1583
 msgid "Add files to download with auto priority"
 msgstr "Dosyaları, aktarımlara otomatik öncelikle ekle"
 
-#: src/muuli_wdr.cpp:1593
+#: src/muuli_wdr.cpp:1586
 msgid "Try to download first and last chunks first"
 msgstr "İlk ve son parçaları en önce indirmeye çalış"
 
-#: src/muuli_wdr.cpp:1597
+#: src/muuli_wdr.cpp:1590
 msgid "Endgame mode: rotate to faster sources for the final blocks"
 msgstr "\"Endgame\" kipi: son bloklar için hızlı kaynaklara geç"
 
-#: src/muuli_wdr.cpp:1600
+#: src/muuli_wdr.cpp:1593
 msgid "Start next paused file when a file completes"
 msgstr "Bir dosya tamamlandığında duraklatılan sonraki dosyaya başla"
 
-#: src/muuli_wdr.cpp:1603
+#: src/muuli_wdr.cpp:1596
 msgid "From the same category"
 msgstr "Aynı sınıftan"
 
-#: src/muuli_wdr.cpp:1605
+#: src/muuli_wdr.cpp:1598
 msgid "In alphabetic order"
 msgstr "Alfabetik sırayla"
 
-#: src/muuli_wdr.cpp:1607
+#: src/muuli_wdr.cpp:1600
 msgid "Preallocate disk space for new files"
 msgstr "Yeni dosyalar için diskte yer ayır"
 
-#: src/muuli_wdr.cpp:1608
+#: src/muuli_wdr.cpp:1601
 msgid "For new files preallocates disk space for the whole file, thus reduces fragmentation"
 msgstr "Yeni dosyalarda, dosyanın tamamı için sabit diskte yer ayrılarak parçalanma azaltılır"
 
-#: src/muuli_wdr.cpp:1613
+#: src/muuli_wdr.cpp:1606
+msgid "Create new files as sparse files"
+msgstr ""
+
+#: src/muuli_wdr.cpp:1607
+msgid "A sparse file reserves its full size on disk immediately without writing real data to it -- fast, but unsupported or slow on some filesystems, and free-space accounting stays optimistic while the download is in progress. Turn this off to grow the file only as data arrives."
+msgstr ""
+
+#: src/muuli_wdr.cpp:1612
 msgid "Stop downloads when free disk space reaches "
 msgstr "Boş disk alanı şu kadar kaldığında aktarımları durdur "
 
-#: src/muuli_wdr.cpp:1614
+#: src/muuli_wdr.cpp:1613
 msgid "Select this if you want aMule to check your disk space"
 msgstr "aMule'nin diskteki alanı denetlemesini istiyorsanız bunu seçiniz."
 
-#: src/muuli_wdr.cpp:1618
+#: src/muuli_wdr.cpp:1617
 msgid "Enter here the min disk space desired."
 msgstr "Buraya istenilen en az disk alanını giriniz."
 
-#: src/muuli_wdr.cpp:1624
+#: src/muuli_wdr.cpp:1623
 msgid "Save 10 sources on rare files (< 20 sources)"
 msgstr "Nadir bulunan dosyalarda 10 kaynak sakla (<20 kaynak)"
 
-#: src/muuli_wdr.cpp:1628 src/Statistics.cpp:790
+#: src/muuli_wdr.cpp:1627 src/Statistics.cpp:790
 msgid "Uploads"
 msgstr "Gönderilenler"
 
-#: src/muuli_wdr.cpp:1631
+#: src/muuli_wdr.cpp:1630
 msgid "Add new shared files with auto priority"
 msgstr "Dosyaları paylaşılanlara otomatik öncelikle ekle"
 
-#: src/muuli_wdr.cpp:1637
+#: src/muuli_wdr.cpp:1636
 msgid "Intelligent Corruption Handling (I.C.H.)"
 msgstr "Akıllı Bozulma Yakalayıcısı (I.C.H.)"
 
-#: src/muuli_wdr.cpp:1640
+#: src/muuli_wdr.cpp:1639
 msgid "Enable"
 msgstr "Etkinleştir"
 
-#: src/muuli_wdr.cpp:1643
+#: src/muuli_wdr.cpp:1642
 msgid "Advanced I.C.H. trusts every hash (not recommended)"
 msgstr "Gelişmiş I.C.H. her adreslemeye güvensin. ( önerilmez )"
 
-#: src/muuli_wdr.cpp:1655 src/PrefsUnifiedDlg.cpp:1990
+#: src/muuli_wdr.cpp:1654 src/PrefsUnifiedDlg.cpp:1910
 msgid "Media metadata extraction"
 msgstr "Ortam üst verisi çıkarımı"
 
-#: src/muuli_wdr.cpp:1659
+#: src/muuli_wdr.cpp:1658
 msgid "Extract length / bitrate / codec from shared audio and video files"
 msgstr "Süre / bit hızı / kodlama bilgilerini paylaşılan ses ve video dosyalarından çıkar"
 
-#: src/muuli_wdr.cpp:1661
+#: src/muuli_wdr.cpp:1660
 msgid "When enabled, aMule runs ffprobe on each shared media file to fill in the Length / Bitrate / Codec columns other clients see when they find the file in a search. Requires ffmpeg (the ffprobe binary) to be installed."
 msgstr "Etkinleştirildiğinde, dosyayı bir aramada bulan diğer istemcilerin gördükleri Süre / Bit Akışı / Kodlama sütunlarını doldurmak için aMule her paylaşılan ortam dosyası üzerinde ffprobe çalıştırır. ffmpeg (ffprobe ikilisi) kurulumu gerektirir."
 
-#: src/muuli_wdr.cpp:1668
+#: src/muuli_wdr.cpp:1667
 msgid "Path to ffprobe:"
 msgstr "ffprobe yolu:"
 
-#: src/muuli_wdr.cpp:1673
+#: src/muuli_wdr.cpp:1672
 msgid "Full path to the ffprobe binary. Leave empty to have aMule auto-detect it on startup."
 msgstr "ffprobe ikilisi için tam yol. aMule tarafından başlangıçta otomatik olarak tespit edilmesi için boş bırakın."
 
-#: src/muuli_wdr.cpp:1681
+#: src/muuli_wdr.cpp:1680
 msgid "Detect"
 msgstr "Tespit et"
 
-#: src/muuli_wdr.cpp:1682
+#: src/muuli_wdr.cpp:1681
 msgid "Search the standard install locations for an ffprobe binary and fill the path field."
 msgstr "Bir ffprobe ikilisi için standart kurulum konumlarını ara ve yol alanını doldur."
 
-#: src/muuli_wdr.cpp:1706
+#: src/muuli_wdr.cpp:1705
 msgid ""
 "Completed downloads are stored here. All files in this folder are automatically shared with other peers.\n"
 "If this folder also holds files you don't want to share, point it at an aMule-only sub-folder."
@@ -4152,688 +4141,665 @@ msgstr ""
 "Tamamlanmış indirmeler burada muhafaza edilir. Bu dizindeki tüm dosyalar otomatik olarak diğer eşler ile paylaşılır.\n"
 "Şayet bu dizin paylaşmak istemediğiniz dosyalar da içeriyorsa, aMule'e özel bir alt dizini seçin."
 
-#: src/muuli_wdr.cpp:1709
+#: src/muuli_wdr.cpp:1708
 msgid "Pick the folder where completed downloads will be stored. All files in that folder will be shared with other peers."
 msgstr "Tamamlanmış indirmelerin muhafaza edilecekleri dizini seçin. Bu dizindeki tüm dosyalar diğer eşler ile paylaşılacaktır."
 
-#: src/muuli_wdr.cpp:1723
+#: src/muuli_wdr.cpp:1722
 msgid "Shared folders"
 msgstr "Paylaşılan dizinler"
 
-#: src/muuli_wdr.cpp:1729
+#: src/muuli_wdr.cpp:1728
 msgid "(Folders shared by the core. Enter a path to add one.)"
 msgstr "(Çekirdek tarafından paylaşılan dizinler. Bir dizin eklemek için yol ilave edin.)"
 
-#: src/muuli_wdr.cpp:1737
+#: src/muuli_wdr.cpp:1736
 msgid "Absolute path of a folder on the core's machine, e.g. /home/user/shared"
 msgstr "Çekirdeğin makinesinde bir dizinin mutlak yolu, mesela /home/rumuz/shared"
 
-#: src/muuli_wdr.cpp:1739 src/PrefsUnifiedDlg.cpp:2874
+#: src/muuli_wdr.cpp:1738 src/PrefsUnifiedDlg.cpp:2794
 msgid "Recursive"
 msgstr "Özyinelemeli"
 
-#: src/muuli_wdr.cpp:1740
+#: src/muuli_wdr.cpp:1739
 msgid "Share every sub-folder underneath this one, including ones created later."
 msgstr "Bunun altındaki tüm alt dizinleri paylaş, ki buna daha sonra oluşturulacak dizinler de dahildir."
 
-#: src/muuli_wdr.cpp:1744 src/utils/aLinkCreator/src/alcframe.cpp:141
+#: src/muuli_wdr.cpp:1743 src/utils/aLinkCreator/src/alcframe.cpp:141
 msgid "Remove"
 msgstr "Çıkar"
 
-#: src/muuli_wdr.cpp:1748
+#: src/muuli_wdr.cpp:1747
 msgid "(Right click on folder icon for recursive share)"
 msgstr "(Özyinelemeli paylaşım için dizin simgesine sağ tıklayınız.)"
 
-#: src/muuli_wdr.cpp:1755
+#: src/muuli_wdr.cpp:1754
 msgid "Share hidden files"
 msgstr "Gizli dosyaları paylaş"
 
-#: src/muuli_wdr.cpp:1761
+#: src/muuli_wdr.cpp:1760
 msgid "Automatically rescan shared folders for changes"
 msgstr "Paylaşılan dizinleri değişiklikler için otomatik olarak tekrar tara"
 
-#: src/muuli_wdr.cpp:1767
+#: src/muuli_wdr.cpp:1766
 msgid "Follow symbolic links in shared folders"
 msgstr "Paylaşılan dizinlerdeki simgesel bağlantıları takip et"
 
-#: src/muuli_wdr.cpp:1773
+#: src/muuli_wdr.cpp:1772
 msgid "Exclude files matching:"
 msgstr "Şununla eşleşen dosyaları dışla:"
 
-#: src/muuli_wdr.cpp:1776
+#: src/muuli_wdr.cpp:1775
 msgid "Wildcard patterns separated by '|', e.g. .DS_Store|Thumbs.db|*.tmp. Files whose name matches are not shared. Matching is case-insensitive."
 msgstr "'|' ile ayrılmış joker karakterli örüntüler (mesela .DS_Store|Thumbs.db|*.tmp). İsmi eşleşen dosyalar paylaşılmaz. Eşleştirme sırasında büyük/küçük harf ayrımı yapılmaz."
 
-#: src/muuli_wdr.cpp:1780
+#: src/muuli_wdr.cpp:1779
 msgid "Patterns are regular expressions"
 msgstr "Örüntüler düzenli ifadelerdir"
 
-#: src/muuli_wdr.cpp:1781
+#: src/muuli_wdr.cpp:1780
 msgid "When set, the whole field is one regular expression ('|' is alternation). When unset, it is a list of '|'-separated wildcards."
 msgstr "Etkinleştirildiğinde, tüm alan tek bir düzenli ifadedir ('|' alternatifler içindir). Devre dışı bırakıldığında, '|' ile ayrılmış jokerler listesidir."
 
-#: src/muuli_wdr.cpp:1791
+#: src/muuli_wdr.cpp:1790
 msgid "Show how many shared files the current pattern would exclude."
 msgstr "Güncel örüntünün kaç paylaşılan dosyayı dışlayacağını göster."
 
-#: src/muuli_wdr.cpp:1812
+#: src/muuli_wdr.cpp:1811
 msgid "Graphs"
 msgstr "Grafikler"
 
-#: src/muuli_wdr.cpp:1815 src/muuli_wdr.cpp:1877
+#: src/muuli_wdr.cpp:1814 src/muuli_wdr.cpp:1876
 msgid "Update delay : 5 secs"
 msgstr "Güncelleme gecikmesi: 5 sn"
 
-#: src/muuli_wdr.cpp:1819
+#: src/muuli_wdr.cpp:1818
 msgid "Time for average graph: 100 mins"
 msgstr "Ortalama grafiği için süre: 100 dk"
 
-#: src/muuli_wdr.cpp:1823
+#: src/muuli_wdr.cpp:1822
 msgid "Connections Graph Scale: 100 "
 msgstr "Bağlantı Grafik Ölçüsü: 100 "
 
-#: src/muuli_wdr.cpp:1830
+#: src/muuli_wdr.cpp:1829
 msgid "Download graph scale:"
 msgstr "İndirme grafik ölçüsü:"
 
-#: src/muuli_wdr.cpp:1838
+#: src/muuli_wdr.cpp:1837
 msgid "Upload graph scale:"
 msgstr "Gönderme grafik ölçüsü:"
 
-#: src/muuli_wdr.cpp:1848
+#: src/muuli_wdr.cpp:1847
 msgid "Colors: "
 msgstr "Renkler: "
 
-#: src/muuli_wdr.cpp:1852
+#: src/muuli_wdr.cpp:1851
 msgid "Background"
 msgstr "Arka plan"
 
-#: src/muuli_wdr.cpp:1853
+#: src/muuli_wdr.cpp:1852
 msgid "Grid"
 msgstr "Izgara"
 
-#: src/muuli_wdr.cpp:1854
+#: src/muuli_wdr.cpp:1853
 msgid "Download current"
 msgstr "Şu anki aktarımlar"
 
-#: src/muuli_wdr.cpp:1855
+#: src/muuli_wdr.cpp:1854
 msgid "Download running average"
 msgstr "Aktarım çalışma ortalaması"
 
-#: src/muuli_wdr.cpp:1856
+#: src/muuli_wdr.cpp:1855
 msgid "Download session average"
 msgstr "Aktarım oturum ortalaması"
 
-#: src/muuli_wdr.cpp:1857
+#: src/muuli_wdr.cpp:1856
 msgid "Upload current"
 msgstr "Şu anki gönderme"
 
-#: src/muuli_wdr.cpp:1858
+#: src/muuli_wdr.cpp:1857
 msgid "Upload running average"
 msgstr "Gönderme çalışma Ortalaması"
 
-#: src/muuli_wdr.cpp:1859
+#: src/muuli_wdr.cpp:1858
 msgid "Upload session average"
 msgstr "Gönderme oturum ortalaması"
 
-#: src/muuli_wdr.cpp:1860
+#: src/muuli_wdr.cpp:1859
 msgid "Active connections"
 msgstr "Aktif bağlantılar"
 
-#: src/muuli_wdr.cpp:1863
+#: src/muuli_wdr.cpp:1862
 msgid "Systray Icon Speed Bar"
 msgstr "Sistem Tepsisi İkonu Hız Göstergesi"
 
-#: src/muuli_wdr.cpp:1864
+#: src/muuli_wdr.cpp:1863
 msgid "Kad-nodes current"
 msgstr "Şu anki Kad düğümleri"
 
-#: src/muuli_wdr.cpp:1865
+#: src/muuli_wdr.cpp:1864
 msgid "Kad-nodes running"
 msgstr "İşlemdeki Kad-düğümleri"
 
-#: src/muuli_wdr.cpp:1866
+#: src/muuli_wdr.cpp:1865
 msgid "Kad-nodes session"
 msgstr "Oturumdaki Kad-düğümleri"
 
-#: src/muuli_wdr.cpp:1870 src/muuli_wdr.cpp:2324
+#: src/muuli_wdr.cpp:1869 src/muuli_wdr.cpp:2296
 msgid "Select"
 msgstr "Seçiniz"
 
-#: src/muuli_wdr.cpp:1874
+#: src/muuli_wdr.cpp:1873
 msgid "Tree"
 msgstr "Ağaç"
 
-#: src/muuli_wdr.cpp:1884
+#: src/muuli_wdr.cpp:1883
 msgid "Number of Client Versions shown (0=unlimited)"
 msgstr "Gösterilen Yazılım Sürümü Sayısı (0=sınırsız)"
 
-#: src/muuli_wdr.cpp:1909
+#: src/muuli_wdr.cpp:1908
 msgid "!!! WARNING !!!"
 msgstr "!!! UYARI !!!"
 
-#: src/muuli_wdr.cpp:1924
+#: src/muuli_wdr.cpp:1923
 msgid "Max new connections / 5 secs"
 msgstr "En fazla yeni bağlantı / 5 sn"
 
-#: src/muuli_wdr.cpp:1926
+#: src/muuli_wdr.cpp:1925
 msgid "Concurrent Kad source lookups"
 msgstr "Eşzamanlı Kad kaynak aramaları"
 
-#: src/muuli_wdr.cpp:1928
+#: src/muuli_wdr.cpp:1927
 msgid "Kad source re-search interval (minutes)"
 msgstr "Kad kaynak tekrar arama zaman aralığı (dakika)"
 
-#: src/muuli_wdr.cpp:1930
+#: src/muuli_wdr.cpp:1929
 msgid "Source re-ask interval (minutes)"
 msgstr "Kaynaklara tekrar sorma zaman aralığı (dakika)"
 
-#: src/muuli_wdr.cpp:1934
+#: src/muuli_wdr.cpp:1933
 msgid "File Buffer Size: 240000 bytes"
 msgstr "Dosya Tampon Boyutu: 240000 bayt"
 
-#: src/muuli_wdr.cpp:1938
+#: src/muuli_wdr.cpp:1937
 msgid "Use MMAP: memory-mapped file access (lower memory use)"
 msgstr "MMAP kullan: \"memory-mapped file access\" yani bellek eşlemeli dosya erişimi (daha az bellek kullanır)"
 
-#: src/muuli_wdr.cpp:1939
+#: src/muuli_wdr.cpp:1938
 msgid "Maps part files into memory instead of buffering them on the heap, lowering the process memory footprint. May reduce download speed on some disks; best for memory-constrained or upload-heavy hosts."
 msgstr "Yığın üzerinde tampona almak yerine kısmi dosyaları bellekte eşleştirir, böylece sürecin bellek ayak izini azaltır. Bazı disklerde indirme hızını düşürebilir; belleği sınırlı veya çok fazla gönderide bulunan makineler için idealdir."
 
-#: src/muuli_wdr.cpp:1941
+#: src/muuli_wdr.cpp:1940
 msgid "Upload Queue Size: 5000 clients"
 msgstr "Gönderme Sıra Boyutu: 5000 kullanıcı"
 
-#: src/muuli_wdr.cpp:1945
+#: src/muuli_wdr.cpp:1944
 msgid "Server connection refresh interval: Disable"
 msgstr "Sunucu bağlantısı yenileme sıklığı: devre dışı"
 
-#: src/muuli_wdr.cpp:1949
+#: src/muuli_wdr.cpp:1948
 msgid "Disable computer's timed standby mode"
 msgstr "Bilgisayarın devre dışı kalma kipini etkisiz hale getir"
 
-#: src/muuli_wdr.cpp:1968
+#: src/muuli_wdr.cpp:1967
 msgid "Skin to use: "
 msgstr "Kullanılacak kaplama: "
 
-#: src/muuli_wdr.cpp:1977
+#: src/muuli_wdr.cpp:1976
 msgid "Show \"Fast eD2k Links Handler\" in every window."
 msgstr "\"Hızlı eD2k Bağlantı Yakalayıcısı\"nı her pencerede göster.."
 
-#: src/muuli_wdr.cpp:1980
+#: src/muuli_wdr.cpp:1979
 msgid "Show extended info on categories tabs"
 msgstr "Sınıf sekmelerinde genişletilmiş bilgi göster."
 
-#: src/muuli_wdr.cpp:1983
+#: src/muuli_wdr.cpp:1982
 msgid "Show application version on title"
 msgstr "Başlık çubuğunda uygulama sürümünü göster"
 
-#: src/muuli_wdr.cpp:1985
+#: src/muuli_wdr.cpp:1984
 msgid "Show transfer rates on title"
 msgstr "Başlık çubuğunda aktarım oranlarını göster."
 
-#: src/muuli_wdr.cpp:1987
+#: src/muuli_wdr.cpp:1986
 msgid "Before application name"
 msgstr "Uygulama adından önce"
 
-#: src/muuli_wdr.cpp:1989
+#: src/muuli_wdr.cpp:1988
 msgid "After application name"
 msgstr "Uygulama adından sonra"
 
-#: src/muuli_wdr.cpp:1992
+#: src/muuli_wdr.cpp:1991
 msgid "Show overhead bandwidth"
 msgstr "Ek yük ağ genişliğini göster"
 
-#: src/muuli_wdr.cpp:1996
+#: src/muuli_wdr.cpp:1995
 msgid "Vertical toolbar orientation"
 msgstr "Dikey araç çubuğu yerleşimi"
 
-#: src/muuli_wdr.cpp:1998
+#: src/muuli_wdr.cpp:1997
 msgid "Live column sorting (auto-reorder rows as their values change)"
 msgstr "Naklen sütun düzenleme (değerleri değiştikçe satırları otomatik olarak tekrar sırala)"
 
-#: src/muuli_wdr.cpp:2005
+#: src/muuli_wdr.cpp:2004
 msgid "Download Queue Files"
 msgstr "Sıradaki Dosyaları İndir"
 
-#: src/muuli_wdr.cpp:2008
+#: src/muuli_wdr.cpp:2007
 msgid "Show progress percentage"
 msgstr "İşlem yüzdesini göster"
 
-#: src/muuli_wdr.cpp:2014
+#: src/muuli_wdr.cpp:2013
 msgid "Show progress bar"
 msgstr "İşlem çubuğunu göster"
 
-#: src/muuli_wdr.cpp:2017
+#: src/muuli_wdr.cpp:2016
 msgid "Flat"
 msgstr "Düz"
 
-#: src/muuli_wdr.cpp:2021
+#: src/muuli_wdr.cpp:2020
 msgid "Round"
 msgstr "Yuvarlatılmış"
 
-#: src/muuli_wdr.cpp:2039
+#: src/muuli_wdr.cpp:2038
 msgid "External Connection Parameters"
 msgstr "Dışarıdan Bağlantı Parametreleri"
 
-#: src/muuli_wdr.cpp:2042
+#: src/muuli_wdr.cpp:2041
 msgid "Accept external connections"
 msgstr "Dışarıdan bağlantıları kabul et."
 
-#: src/muuli_wdr.cpp:2049 src/muuli_wdr.cpp:2108
+#: src/muuli_wdr.cpp:2048 src/muuli_wdr.cpp:2107
 msgid "IP of the listening interface:"
 msgstr "Dinlenen arayüzün IP' si:"
 
-#: src/muuli_wdr.cpp:2052
+#: src/muuli_wdr.cpp:2051
 msgid "Enter here a valid ip in the a.b.c.d format for the listening EC interface. An empty field or 0.0.0.0 will mean any interface."
 msgstr "Dinleme EC arayüzü için a.b.c.d biçiminde geçerli bir ip giriniz. Boş bırakılan alan veya 0.0.0.0 arayüz yok demektir."
 
-#: src/muuli_wdr.cpp:2073 src/muuli_wdr.cpp:2184
+#: src/muuli_wdr.cpp:2072 src/muuli_wdr.cpp:2156
 msgid "TCP port:"
 msgstr "TCP portu:"
 
-#: src/muuli_wdr.cpp:2079
+#: src/muuli_wdr.cpp:2078
 msgid "Enable UPnP port forwarding on the EC port"
 msgstr "EC portuna UPnP port yönlendirmesi etkin."
 
-#: src/muuli_wdr.cpp:2083 src/muuli_wdr.cpp:3069
+#: src/muuli_wdr.cpp:2082 src/muuli_wdr.cpp:3041
 #: src/utils/wxCas/src/wxcasprefs.cpp:167
 msgid "Password"
 msgstr "Şifre"
 
-#: src/muuli_wdr.cpp:2089
+#: src/muuli_wdr.cpp:2088
 msgid "aMule API server parameters"
 msgstr "aMule API sunucusu parametreleri"
 
-#: src/muuli_wdr.cpp:2092
+#: src/muuli_wdr.cpp:2091
 msgid "Run amuleapi (REST API) on startup"
 msgstr "Başlangıçta amuleapi (REST API) çalıştır"
 
-#: src/muuli_wdr.cpp:2097
+#: src/muuli_wdr.cpp:2096
 msgid "HTTP port:"
 msgstr "HTTP bağlantı noktası:"
 
-#: src/muuli_wdr.cpp:2111
+#: src/muuli_wdr.cpp:2110
 msgid "The interface amuleapi's HTTP server listens on. 127.0.0.1 (default) accepts only local connections; use 0.0.0.0 or a specific IP to expose it to other hosts (set an admin password below)."
 msgstr "amuleapi HTTP sunucusunun dinlediği arayüz. 127.0.0.1 (varsayılan) sadece yerel bağlantıları kabul eder; onu başka makinelere açmak için 0.0.0.0 veya belirli bir IP kullanın (aşağıda bir yönetici parolası tanımlayın)."
 
-#: src/muuli_wdr.cpp:2116
-msgid "Type a password to set or change it. Stored passwords cannot be shown, so leaving this empty keeps the current one."
-msgstr ""
-
-#: src/muuli_wdr.cpp:2118
+#: src/muuli_wdr.cpp:2113
 msgid "Admin password"
 msgstr "Yönetici parolası"
 
-#: src/muuli_wdr.cpp:2130 src/muuli_wdr.cpp:2147 src/PrefsUnifiedDlg.cpp:1103
-#, fuzzy
-msgid "A password is set."
-msgstr "Yönetici parolası"
-
-#: src/muuli_wdr.cpp:2134
-#, fuzzy
-msgid "Enable guest access"
-msgstr "Konuk girişini reddet"
-
-#: src/muuli_wdr.cpp:2135
-msgid "Guest sessions may read status and listings but cannot change anything. Turning this off clears the stored guest password."
-msgstr ""
-
-#: src/muuli_wdr.cpp:2139
-#, fuzzy
-msgid "Guest password"
-msgstr "Web sunucusu için konuk parolası"
-
-#: src/muuli_wdr.cpp:2154
-msgid "Web server parameters"
-msgstr "Web sunucusu değerleri"
-
-#: src/muuli_wdr.cpp:2157
-msgid "Run webserver on startup (deprecated)"
-msgstr "Başlangıçta web sunucusunu başlat (eskimiş)"
-
-#: src/muuli_wdr.cpp:2163
-msgid "Web template"
-msgstr "Web şablonu"
-
-#: src/muuli_wdr.cpp:2168
-msgid "Full rights password"
-msgstr "Tam hak şifresi"
-
-#: src/muuli_wdr.cpp:2172
-msgid "Enable Low rights User"
-msgstr "Düşük hakka sahip kullanıcıyı etkin kıl."
-
-#: src/muuli_wdr.cpp:2177
+#: src/muuli_wdr.cpp:2118 src/muuli_wdr.cpp:2149
 msgid "Low rights password"
 msgstr "Düşük hak şifresi"
 
-#: src/muuli_wdr.cpp:2191
+#: src/muuli_wdr.cpp:2126
+msgid "Web server parameters"
+msgstr "Web sunucusu değerleri"
+
+#: src/muuli_wdr.cpp:2129
+msgid "Run webserver on startup (deprecated)"
+msgstr "Başlangıçta web sunucusunu başlat (eskimiş)"
+
+#: src/muuli_wdr.cpp:2135
+msgid "Web template"
+msgstr "Web şablonu"
+
+#: src/muuli_wdr.cpp:2140
+msgid "Full rights password"
+msgstr "Tam hak şifresi"
+
+#: src/muuli_wdr.cpp:2144
+msgid "Enable Low rights User"
+msgstr "Düşük hakka sahip kullanıcıyı etkin kıl."
+
+#: src/muuli_wdr.cpp:2163
 msgid "Enable UPnP port forwarding of the web server port"
 msgstr "Web sunucu portunun UPnp port iletimini etkinleştir"
 
-#: src/muuli_wdr.cpp:2196
+#: src/muuli_wdr.cpp:2168
 msgid "Web server UPnP TCP port (Optional)"
 msgstr "Web sunucusu UPnp TCP portu (İsteğe bağlı)"
 
-#: src/muuli_wdr.cpp:2204
+#: src/muuli_wdr.cpp:2176
 msgid "Page Refresh Time (in secs)"
 msgstr "Sayfa yenileme zamanı (sn)"
 
-#: src/muuli_wdr.cpp:2211
+#: src/muuli_wdr.cpp:2183
 msgid "Enable Gzip compression"
 msgstr "Gzip sıkıştırmayı etkinleştir."
 
-#: src/muuli_wdr.cpp:2245
+#: src/muuli_wdr.cpp:2217
 msgid "Reset page to defaults"
 msgstr "Sayfayı varsayılan değerlere sıfırla"
 
-#: src/muuli_wdr.cpp:2246
+#: src/muuli_wdr.cpp:2218
 msgid "Reset the settings on the current page to their default values."
 msgstr "Güncel sayfadaki ayarları varsayılan değerlerine sıfırla."
 
-#: src/muuli_wdr.cpp:2248 src/muuli_wdr.cpp:2334 src/ServerWnd.cpp:274
+#: src/muuli_wdr.cpp:2220 src/muuli_wdr.cpp:2306 src/ServerWnd.cpp:274
 #: src/ServerWnd.cpp:282
 msgid "OK"
 msgstr "Tamam"
 
-#: src/muuli_wdr.cpp:2250
+#: src/muuli_wdr.cpp:2222
 msgid "Click here to apply any changes made to the preferences."
 msgstr "Ayarlarda yapılan değişikliklerin uygulanması için buraya tıklayınız."
 
-#: src/muuli_wdr.cpp:2253
+#: src/muuli_wdr.cpp:2225
 msgid "Reset any changes made to the preferences."
 msgstr "Ayarlarda yapılan değişiklikleri sil."
 
-#: src/muuli_wdr.cpp:2282
+#: src/muuli_wdr.cpp:2254
 msgid "Comment :"
 msgstr "Yorum:"
 
-#: src/muuli_wdr.cpp:2289
+#: src/muuli_wdr.cpp:2261
 msgid "Incoming Dir :"
 msgstr "Gelen Dosyalar Dizini :"
 
-#: src/muuli_wdr.cpp:2298
+#: src/muuli_wdr.cpp:2270
 msgid "Change priority for new assigned files :"
 msgstr "Yeni eklenen dosyalar için öncelikleri değiştir:"
 
-#: src/muuli_wdr.cpp:2302
+#: src/muuli_wdr.cpp:2274
 msgid "Don't change"
 msgstr "Değiştirme"
 
-#: src/muuli_wdr.cpp:2314
+#: src/muuli_wdr.cpp:2286
 msgid "Select color for this Category (currently selected) :"
 msgstr "Bu sınıf için renk seçiniz (varsayılan) :"
 
-#: src/muuli_wdr.cpp:2381 src/muuli_wdr.cpp:2400 src/muuli_wdr.cpp:2422
+#: src/muuli_wdr.cpp:2353 src/muuli_wdr.cpp:2372 src/muuli_wdr.cpp:2394
 msgid "Click this button to reset the log."
 msgstr "Günlük kayıtlarını silmek için bu düğmeye basınız."
 
-#: src/muuli_wdr.cpp:2441
+#: src/muuli_wdr.cpp:2413
 msgid "Click on this button to update the servers list from URL ..."
 msgstr "Sunucu listesini İnternet'den güncellemek için bu düğmeye basınız…"
 
-#: src/muuli_wdr.cpp:2445
+#: src/muuli_wdr.cpp:2417
 msgid "Server list"
 msgstr "Sunucu"
 
-#: src/muuli_wdr.cpp:2449
+#: src/muuli_wdr.cpp:2421
 msgid "Enter the url to a server.met file here and press the button to the left to update the list of known servers."
 msgstr "Adresi server.met dosyasına buradan giriniz. Sonra, bilinen sunucuları güncellemek için soldaki düğmeye tıklayınız."
 
-#: src/muuli_wdr.cpp:2454
+#: src/muuli_wdr.cpp:2426
 msgid "Add server manually: Name"
 msgstr "Sunucuyu elle ekle: İsim"
 
-#: src/muuli_wdr.cpp:2457
+#: src/muuli_wdr.cpp:2429
 msgid "Enter the name of the new server here"
 msgstr "Yeni sunucunun adını buraya giriniz."
 
-#: src/muuli_wdr.cpp:2459 src/ServerWnd.cpp:206
+#: src/muuli_wdr.cpp:2431 src/ServerWnd.cpp:206
 msgid "IP:Port"
 msgstr "IP:Port"
 
-#: src/muuli_wdr.cpp:2462
+#: src/muuli_wdr.cpp:2434
 msgid "Enter the IP of the server here, using the x.x.x.x format."
 msgstr "Yeni sunucun IP numarasını x.x.x.x biçiminde buraya giriniz."
 
-#: src/muuli_wdr.cpp:2468
+#: src/muuli_wdr.cpp:2440
 msgid "Enter the port of the server here."
 msgstr "Sunucunu portunu buraya giriniz."
 
-#: src/muuli_wdr.cpp:2471
+#: src/muuli_wdr.cpp:2443
 msgid "Add manually a server (fill fields to the left before) ..."
 msgstr "Sunucuyu elle ekle (önce soldaki alanları doldurunuz) …"
 
-#: src/muuli_wdr.cpp:2500
+#: src/muuli_wdr.cpp:2472
 msgid "aMule Log"
 msgstr "aMule Günlüğü"
 
-#: src/muuli_wdr.cpp:2508
+#: src/muuli_wdr.cpp:2480
 msgid "Server Info"
 msgstr "Sunucu Bilgisi"
 
-#: src/muuli_wdr.cpp:2512
+#: src/muuli_wdr.cpp:2484
 msgid "ED2K Info"
 msgstr "ED2K Bilgileri"
 
-#: src/muuli_wdr.cpp:2516
+#: src/muuli_wdr.cpp:2488
 msgid "Kad Info"
 msgstr "Kademlia Bilgileri"
 
-#: src/muuli_wdr.cpp:2544
+#: src/muuli_wdr.cpp:2516
 msgid "Click on this button to update the nodes list from URL ..."
 msgstr "Düğüm listesini İnternet'den güncellemek için bu düğmeye tıklayınız."
 
-#: src/muuli_wdr.cpp:2548
+#: src/muuli_wdr.cpp:2520
 msgid "Nodes (0)"
 msgstr "Düğümler (0)"
 
-#: src/muuli_wdr.cpp:2552
+#: src/muuli_wdr.cpp:2524
 msgid "Enter the url to a nodes.dat file here and press the button to the left to update the list of known nodes."
 msgstr "Bilinen düğümleri güncellemek için buraya adresi giriniz ve soldaki düğmeye tıklayınız."
 
-#: src/muuli_wdr.cpp:2555
+#: src/muuli_wdr.cpp:2527
 msgid "Nodes stats"
 msgstr "Düğüm istatistikleri"
 
-#: src/muuli_wdr.cpp:2597
+#: src/muuli_wdr.cpp:2569
 msgid "Bootstrap"
 msgstr "Ön Yükleme"
 
-#: src/muuli_wdr.cpp:2600
+#: src/muuli_wdr.cpp:2572
 msgid "New node"
 msgstr "Yeni düğüm"
 
-#: src/muuli_wdr.cpp:2605
+#: src/muuli_wdr.cpp:2577
 msgid "IP:"
 msgstr "IP:"
 
-#: src/muuli_wdr.cpp:2625
+#: src/muuli_wdr.cpp:2597
 msgid "Port:"
 msgstr "Port:"
 
-#: src/muuli_wdr.cpp:2638
+#: src/muuli_wdr.cpp:2610
 msgid "Bootstrap from known clients"
 msgstr "Bilinen kullanıcılardan Ön Yükleme"
 
-#: src/muuli_wdr.cpp:2640
+#: src/muuli_wdr.cpp:2612
 msgid "Disconnect Kad"
 msgstr "Kad Bağlantısını Kes"
 
-#: src/muuli_wdr.cpp:2674
+#: src/muuli_wdr.cpp:2646
 msgid "Use Secure User Identification"
 msgstr "Güvenli Kullanıcı Kimlik Doğrulamasını Kullan"
 
-#: src/muuli_wdr.cpp:2676
+#: src/muuli_wdr.cpp:2648
 msgid "It is recommended to enable this option. You will not receive credits if SUI is not enabled."
 msgstr "Bu seçeneği aktifleştirmeniz önerilir. SUI aktif değilse, kredi alamazsınız."
 
-#: src/muuli_wdr.cpp:2678
+#: src/muuli_wdr.cpp:2650
 msgid "Protocol Obfuscation"
 msgstr "Protokol Gizleme"
 
-#: src/muuli_wdr.cpp:2681
+#: src/muuli_wdr.cpp:2653
 msgid "Support Protocol Obfuscation"
 msgstr "Protokol Gizleme etkin"
 
-#: src/muuli_wdr.cpp:2683
+#: src/muuli_wdr.cpp:2655
 msgid "This option enabled Protocol Obfuscation, and makes aMule accept obfuscated connections from other clients."
 msgstr "Bu seçenek Protokol Gizleme'yi etkinleştirir ve aMule'nin gizlenmiş bağlantıları kabul etmesini sağlar."
 
-#: src/muuli_wdr.cpp:2685
+#: src/muuli_wdr.cpp:2657
 msgid "Use obfuscation for outgoing connections"
 msgstr "Giden bağlantılar için gizleme kullan"
 
-#: src/muuli_wdr.cpp:2687
+#: src/muuli_wdr.cpp:2659
 msgid "This option makes aMule use Protocol Obfuscation when connecting other clients/servers."
 msgstr "Bu seçenek diğer kullanıcı veya sunucularla olan bağlantılarda Protokol Gizleme'yi etkinleştirir."
 
-#: src/muuli_wdr.cpp:2689
+#: src/muuli_wdr.cpp:2661
 msgid "Accept only obfuscated connections"
 msgstr "Sadece gizlenmiş bağlantıları kabul et"
 
-#: src/muuli_wdr.cpp:2690
+#: src/muuli_wdr.cpp:2662
 msgid "This option makes aMule only accept obfuscated connections. You will have less sources, but all your traffic will be obfuscated"
 msgstr "Bu seçenek aMule'nin sadece gizlenmiş bağlantıları kabul etmesini sağlar. Daha az kaynak bulursunuz; ancak tüm trafiğiniz de karartılmış olur."
 
-#: src/muuli_wdr.cpp:2695
+#: src/muuli_wdr.cpp:2667
 msgid "Everybody"
 msgstr "Herkes"
 
-#: src/muuli_wdr.cpp:2697
+#: src/muuli_wdr.cpp:2669
 msgid "No one"
 msgstr "Hiç kimse"
 
-#: src/muuli_wdr.cpp:2699
+#: src/muuli_wdr.cpp:2671
 msgid "Who can see my shared files:"
 msgstr "Paylaşılan dosyalarımı kim görebilir:"
 
-#: src/muuli_wdr.cpp:2700
+#: src/muuli_wdr.cpp:2672
 msgid "Select who can request to view a list of your shared files."
 msgstr "Paylaşılan dosyalarınızı kime göstereceğinizi seçiniz."
 
-#: src/muuli_wdr.cpp:2702
+#: src/muuli_wdr.cpp:2674
 msgid "IP-Filtering"
 msgstr "IP_Süzme"
 
-#: src/muuli_wdr.cpp:2709
+#: src/muuli_wdr.cpp:2681
 msgid "Filter clients"
 msgstr "Kullanıcıları Süz"
 
-#: src/muuli_wdr.cpp:2711
+#: src/muuli_wdr.cpp:2683
 msgid "Enable filtering of the client IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "~/.aMule/ipfilter.dat dosyasında tanımlanan kullanıcı IP'lerini süzmeyi etkinleştir."
 
-#: src/muuli_wdr.cpp:2713
+#: src/muuli_wdr.cpp:2685
 msgid "Filter servers"
 msgstr "Sunucuları süz"
 
-#: src/muuli_wdr.cpp:2715
+#: src/muuli_wdr.cpp:2687
 msgid "Enable filtering of the server IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "~/.aMule/ipfilter.dat dosyasında tanımlanan sunucu IP'lerini süzmeyi etkinleştir."
 
-#: src/muuli_wdr.cpp:2719
+#: src/muuli_wdr.cpp:2691
 msgid "Reload List"
 msgstr "Listeyi yeniden yükle"
 
-#: src/muuli_wdr.cpp:2720
+#: src/muuli_wdr.cpp:2692
 msgid "Reload the list of IPs to filter from the file ~/.aMule/ipfilter.dat"
 msgstr "~/.aMule/ipfilter.dat dosyasından IP'leri süzgece yeniden yükle."
 
-#: src/muuli_wdr.cpp:2726
+#: src/muuli_wdr.cpp:2698
 msgid "URL:"
 msgstr "Adres:"
 
-#: src/muuli_wdr.cpp:2730 src/muuli_wdr.cpp:2923
+#: src/muuli_wdr.cpp:2702 src/muuli_wdr.cpp:2895
 msgid "Update now"
 msgstr "Şimdi güncelle"
 
-#: src/muuli_wdr.cpp:2733
+#: src/muuli_wdr.cpp:2705
 msgid "Auto-update ipfilter at startup"
 msgstr "Ip süzgecini başlangıçta otomatikman güncelle."
 
-#: src/muuli_wdr.cpp:2737
+#: src/muuli_wdr.cpp:2709
 msgid "Filtering Level:"
 msgstr "Süzme Seviyesi:"
 
-#: src/muuli_wdr.cpp:2743
+#: src/muuli_wdr.cpp:2715
 msgid "Always filter LAN IPs"
 msgstr "Her zaman LAN IP'lerini süz."
 
-#: src/muuli_wdr.cpp:2746
+#: src/muuli_wdr.cpp:2718
 msgid "Paranoid handling of non-matching IPs"
 msgstr "Uyuşmayan IP'lere şüpheci yaklaşım."
 
-#: src/muuli_wdr.cpp:2748
+#: src/muuli_wdr.cpp:2720
 msgid "Rejects a packet when its source IP differs from the IP the client claims (an anti-spoofing check). Disable only if it causes connection problems."
 msgstr "İstemcinin sahip olduğunu iddia ettiği IP, kaynak IP'den farklı olduğunda paketi reddeder (sahtekarlık önleyici kontrol). Sadece bağlantı sorunları oluşturuyorsa devre dışı bırakın."
 
-#: src/muuli_wdr.cpp:2750
+#: src/muuli_wdr.cpp:2722
 msgid "Use system-wide ipfilter.dat if available"
 msgstr "Varsa, sistem geneli ipfilter.dat kullan"
 
-#: src/muuli_wdr.cpp:2751
+#: src/muuli_wdr.cpp:2723
 msgid "If there's no local ipfilter.dat found, allow usage of a system-wide ipfilter file."
 msgstr "Yerel bir ipfilter.dat dosyası bulunamazsa, sistem geneli ipfilter kullanımına izin ver."
 
-#: src/muuli_wdr.cpp:2768
+#: src/muuli_wdr.cpp:2740
 msgid "Enable Online-Signature"
 msgstr "Çevrimiçi-İmza' yı Etkinleştir"
 
-#: src/muuli_wdr.cpp:2770
+#: src/muuli_wdr.cpp:2742
 msgid "Enables the writing of the OS file, which can be used by external apps to create signatures and the like."
 msgstr "Diğer uygulamaların imzalar ve benzerlerini oluşturabilmesi için kullanabileceği Çev.İmza dosyasını yazmayı etkinleştirir."
 
-#: src/muuli_wdr.cpp:2774
+#: src/muuli_wdr.cpp:2746
 msgid "Update Frequency (Secs):"
 msgstr "Güncelleme Sıklığı (Sn.):"
 
-#: src/muuli_wdr.cpp:2777
+#: src/muuli_wdr.cpp:2749
 msgid "Change the frequency (in seconds) of Online Signature updates."
 msgstr "Çevrim içi İmza güncellemeleri için (saniye bazında) sıklığı değiştirir."
 
-#: src/muuli_wdr.cpp:2785
+#: src/muuli_wdr.cpp:2757
 msgid "Save online signature file in: "
 msgstr "Çevrim içi imza dosyasını buraya sakla: "
 
-#: src/muuli_wdr.cpp:2791
+#: src/muuli_wdr.cpp:2763
 msgid "Click here to select the directory containing the the Online Signature files."
 msgstr "Çevrim içi İmza dosyalarını içeren dizini seçiniz."
 
-#: src/muuli_wdr.cpp:2824
+#: src/muuli_wdr.cpp:2796
 msgid "Show country flags for clients"
 msgstr "İstemciler için ülke bayraklarını göster"
 
-#: src/muuli_wdr.cpp:2825
+#: src/muuli_wdr.cpp:2797
 msgid "Render the country flag column in the transfers, queue and search views. Requires a valid MMDB GeoIP database (see below)."
 msgstr "Transferler, kuyruklar ve arama görünümlerinde ülkelerin bayrakları sütununu görüntüle. Geçerli bir MMDB GeoIP veri tabanı gerektirir (aşağıya bakınız)."
 
-#: src/muuli_wdr.cpp:2830
+#: src/muuli_wdr.cpp:2802
 msgid "Database"
 msgstr "Veri Tabanı"
 
-#: src/muuli_wdr.cpp:2846
+#: src/muuli_wdr.cpp:2818
 msgid "Source:"
 msgstr "Kaynak:"
 
-#: src/muuli_wdr.cpp:2849
+#: src/muuli_wdr.cpp:2821
 msgid "DB-IP (free, no account)"
 msgstr "DB-IP (ücretsiz, hesap gerektirmez)"
 
-#: src/muuli_wdr.cpp:2850
+#: src/muuli_wdr.cpp:2822
 msgid "MaxMind GeoLite2 (free, account required)"
 msgstr "MaxMind GeoLite2 (ücretsiz, hesap gerektirir)"
 
-#: src/muuli_wdr.cpp:2851
+#: src/muuli_wdr.cpp:2823
 msgid "Custom URL"
 msgstr "Kişiselleştirilmiş URL"
 
-#: src/muuli_wdr.cpp:2854
+#: src/muuli_wdr.cpp:2826
 msgid "Choose which provider supplies the GeoIP MMDB database. DB-IP is the default - no account required. MaxMind requires a free account + license key. Use Custom URL to point at any other MMDB host (e.g. a local mirror)."
 msgstr "Hangi tedarikçinin GeoIP MMDB veri tabanını sağlayacağını seçin. DB-IP varsayılan değerdir - hesap gerektirmez. MaxMind ücretsiz bir hesap + lisans anahtarı gerektirir. Herhangi başka bir MMDB makinesine (mesela yerel bir yansıya) yönlendirme yapmak için kişiselleştirilmiş URL kullanın."
 
-#: src/muuli_wdr.cpp:2871
+#: src/muuli_wdr.cpp:2843
 msgid ""
 "No configuration required.\n"
 "\n"
@@ -4845,11 +4811,11 @@ msgstr ""
 "IP-Ülke verileri DB-IP.com tarafından sağlanmaktadır - https://db-ip.com\n"
 "Lisans: Creative Commons Atıf 4.0 - https://creativecommons.org/licenses/by/4.0/deed.tr"
 
-#: src/muuli_wdr.cpp:2884
+#: src/muuli_wdr.cpp:2856
 msgid "License key:"
 msgstr "Lisans anahtarı:"
 
-#: src/muuli_wdr.cpp:2890
+#: src/muuli_wdr.cpp:2862
 msgid ""
 "Sign up for a free MaxMind account, then generate a License Key:\n"
 "https://www.maxmind.com/en/geolite2/signup\n"
@@ -4865,11 +4831,11 @@ msgstr ""
 "Lisans: MaxMind GeoLite2 Kullanıcı Lisans Anlaşması - https://www.maxmind.com/en/geolite2/eula\n"
 "Atıf ve hesap oluşturulması gerektirir; en az her 30 günde bir güncelleyin."
 
-#: src/muuli_wdr.cpp:2905
+#: src/muuli_wdr.cpp:2877
 msgid "Download URL:"
 msgstr "İndirme Bağlantısı:"
 
-#: src/muuli_wdr.cpp:2911
+#: src/muuli_wdr.cpp:2883
 msgid ""
 "Must point to an .mmdb file or a .gz / .tar.gz containing one.\n"
 "URL may include credentials (https://user:pass@host/...).\n"
@@ -4879,211 +4845,211 @@ msgstr ""
 "Bağlantı kimlik doğrulama bilgileri içerebilir (https://kullanıcı:parola@makine/…)\n"
 "Lisans ve atıf koşulları kaynak URL tarafından belirlenir - bunlardan siz sorumlu olursunuz."
 
-#: src/muuli_wdr.cpp:2924
+#: src/muuli_wdr.cpp:2896
 msgid "Download the GeoIP database from the selected source."
 msgstr "Seçili kaynaktan GeoIP veri tabanını indir."
 
-#: src/muuli_wdr.cpp:2926
+#: src/muuli_wdr.cpp:2898
 msgid "Auto-update on startup"
 msgstr "Başlangıçta otomatik olarak güncelle"
 
-#: src/muuli_wdr.cpp:2927
+#: src/muuli_wdr.cpp:2899
 msgid "Re-download the GeoIP database from the selected source every time aMule starts."
 msgstr "aMule her başladığında, GeoIP veri tabanını seçili kaynaktan tekrar indir."
 
-#: src/muuli_wdr.cpp:2950
+#: src/muuli_wdr.cpp:2922
 msgid "Filter incoming messages (except current chat):"
 msgstr "Gelen iletileri süz (o anki sohbet dışında):"
 
-#: src/muuli_wdr.cpp:2952
+#: src/muuli_wdr.cpp:2924
 msgid "Filter all messages"
 msgstr "Hepsini süz."
 
-#: src/muuli_wdr.cpp:2954
+#: src/muuli_wdr.cpp:2926
 msgid "Filter messages from people not on your friend list"
 msgstr "Arkadaş listesindekiler dışında herkesi süz."
 
-#: src/muuli_wdr.cpp:2956
+#: src/muuli_wdr.cpp:2928
 msgid "Filter messages from unknown clients"
 msgstr "Bilinmeyen yazılımlardan gelenleri süz."
 
-#: src/muuli_wdr.cpp:2958
+#: src/muuli_wdr.cpp:2930
 msgid "Filter messages containing (use ',' as separator):"
 msgstr "Şu içerikteki iletileri süz (ayraç olarak ',' kullanınız.):"
 
-#: src/muuli_wdr.cpp:2961 src/muuli_wdr.cpp:2972
+#: src/muuli_wdr.cpp:2933 src/muuli_wdr.cpp:2944
 msgid "add here the words amule should filter and block messages including it"
 msgstr "buraya ekleyeceğiniz sözcükleri içeren iletiler aMule tarafından engellenir."
 
-#: src/muuli_wdr.cpp:2963
+#: src/muuli_wdr.cpp:2935
 msgid "Show received messages in the log"
 msgstr "Günlükte alınan iletileri göster"
 
-#: src/muuli_wdr.cpp:2966
+#: src/muuli_wdr.cpp:2938
 msgid "Comments"
 msgstr "Yorumlar"
 
-#: src/muuli_wdr.cpp:2969
+#: src/muuli_wdr.cpp:2941
 msgid "Filter comments containing (use ',' as separator):"
 msgstr "Şu içerikteki iletileri süz (ayraç olarak ',' kullanınız.):"
 
-#: src/muuli_wdr.cpp:2994
+#: src/muuli_wdr.cpp:2966
 msgid "Enable Proxy"
 msgstr "Vekil sunucuyu Etkinleştir."
 
-#: src/muuli_wdr.cpp:2995
+#: src/muuli_wdr.cpp:2967
 msgid "Enable/disable proxy support"
 msgstr "Vekil sunucu desteğini etkinleştir/devre dışı bırak"
 
-#: src/muuli_wdr.cpp:2998
+#: src/muuli_wdr.cpp:2970
 msgid "Proxy type:"
 msgstr "Vekil sunucu Türü:"
 
-#: src/muuli_wdr.cpp:3009
+#: src/muuli_wdr.cpp:2981
 msgid "Proxy host:"
 msgstr "Vekil sunucu makine:"
 
-#: src/muuli_wdr.cpp:3012
+#: src/muuli_wdr.cpp:2984
 msgid "The proxy host name"
 msgstr "Vekil sunucu makine adı"
 
-#: src/muuli_wdr.cpp:3014
+#: src/muuli_wdr.cpp:2986
 msgid "Proxy port:"
 msgstr "Vekil sunucu Portu:"
 
-#: src/muuli_wdr.cpp:3017
+#: src/muuli_wdr.cpp:2989
 msgid "The proxy port"
 msgstr "Vekil sunucu portu"
 
-#: src/muuli_wdr.cpp:3019
+#: src/muuli_wdr.cpp:2991
 msgid "Enable authentication"
 msgstr "Yetkilendirmeyi etkinleştir."
 
-#: src/muuli_wdr.cpp:3020
+#: src/muuli_wdr.cpp:2992
 msgid "Enable/disable username/password authentication"
 msgstr "Kullanıcı adı/şifre yetkilendirmeyi etkinleştir/devre dışı bırak."
 
-#: src/muuli_wdr.cpp:3023
+#: src/muuli_wdr.cpp:2995
 msgid "Username: "
 msgstr "Kullanıcı adı: "
 
-#: src/muuli_wdr.cpp:3026
+#: src/muuli_wdr.cpp:2998
 msgid "The username to use to connect to the proxy"
 msgstr "Vekil sunucuya bağlanmak için gerekli kullanıcı adı"
 
-#: src/muuli_wdr.cpp:3028
+#: src/muuli_wdr.cpp:3000
 msgid "Password:"
 msgstr "Şifre:"
 
-#: src/muuli_wdr.cpp:3031
+#: src/muuli_wdr.cpp:3003
 msgid "The password to use to connect to the proxy"
 msgstr "Vekil sunucuya bağlanmak için gerekli şifre"
 
-#: src/muuli_wdr.cpp:3050
+#: src/muuli_wdr.cpp:3022
 msgid "Connect to:"
 msgstr "Bağlan:"
 
-#: src/muuli_wdr.cpp:3059
+#: src/muuli_wdr.cpp:3031
 msgid "Login to remote amule"
 msgstr "Uzaktan aMule'ye giriş yapınız."
 
-#: src/muuli_wdr.cpp:3064
+#: src/muuli_wdr.cpp:3036
 msgid "User name"
 msgstr "Kullanıcı adı"
 
-#: src/muuli_wdr.cpp:3075
+#: src/muuli_wdr.cpp:3047
 msgid "Remember those settings"
 msgstr "Bu ayarları hatırla"
 
-#: src/muuli_wdr.cpp:3078
+#: src/muuli_wdr.cpp:3050
 msgid "Force ZLIB compression"
 msgstr "ZLIB sıkıştırmasını zorla"
 
-#: src/muuli_wdr.cpp:3102
+#: src/muuli_wdr.cpp:3074
 msgid "Enable Verbose Debug-Logging."
 msgstr "Fazladan Hata Çıktısı Kaydını Etkinleştir."
 
-#: src/muuli_wdr.cpp:3104
+#: src/muuli_wdr.cpp:3076
 msgid "Only to Logfile"
 msgstr "Sadece Kütük Dosyasına"
 
-#: src/muuli_wdr.cpp:3106
+#: src/muuli_wdr.cpp:3078
 msgid "Message Categories:"
 msgstr "İleti Sınıfları:"
 
-#: src/muuli_wdr.cpp:3130 src/PartFileConvertDlg.cpp:160
+#: src/muuli_wdr.cpp:3102 src/PartFileConvertDlg.cpp:160
 msgid "Waiting..."
 msgstr "Bekliyor…"
 
-#: src/muuli_wdr.cpp:3150
+#: src/muuli_wdr.cpp:3122
 msgid "Add imports"
 msgstr "İçe aktarımları ekle"
 
-#: src/muuli_wdr.cpp:3153
+#: src/muuli_wdr.cpp:3125
 msgid "Retry selected"
 msgstr "Seçileni tekrar dene"
 
-#: src/muuli_wdr.cpp:3155
+#: src/muuli_wdr.cpp:3127
 msgid "Remove selected"
 msgstr "Seçileni çıkar"
 
-#: src/muuli_wdr.cpp:3218
+#: src/muuli_wdr.cpp:3190
 msgid "Event Types"
 msgstr "Olay Türleri"
 
-#: src/muuli_wdr.cpp:3237
+#: src/muuli_wdr.cpp:3209
 msgid "Statistics and queued clients for selected file(s) : Session / All time"
 msgstr "Seçili dosya(lar) için kuyruktaki istemciler ve istatistikler: Oturum / Bütün zamanlar"
 
-#: src/muuli_wdr.cpp:3261
+#: src/muuli_wdr.cpp:3233
 msgid "Active Uploads"
 msgstr "Etkin Göndermeler"
 
-#: src/muuli_wdr.cpp:3275
+#: src/muuli_wdr.cpp:3247
 msgid "Percent of total files"
 msgstr "Toplam dosyaların yüzdesi"
 
-#: src/muuli_wdr.cpp:3327
+#: src/muuli_wdr.cpp:3299
 msgid "Show Clients for"
 msgstr "Kullanıcıları Göster"
 
-#: src/muuli_wdr.cpp:3329
+#: src/muuli_wdr.cpp:3301
 msgid "All files"
 msgstr "Tüm dosyalar"
 
-#: src/muuli_wdr.cpp:3332
+#: src/muuli_wdr.cpp:3304
 msgid "Selected files"
 msgstr "Seçilen dosyalar"
 
-#: src/muuli_wdr.cpp:3335
+#: src/muuli_wdr.cpp:3307
 msgid "Active uploads only"
 msgstr "Sadece aktif Göndermeler"
 
-#: src/muuli_wdr.cpp:3342
+#: src/muuli_wdr.cpp:3314
 msgid "Reload:"
 msgstr "Yeniden yükle:"
 
-#: src/muuli_wdr.cpp:3346
+#: src/muuli_wdr.cpp:3318
 msgid "Reload your shared files"
 msgstr "Paylaşılan dosyalarınızı yeniden yükleyin"
 
-#: src/muuli_wdr.cpp:3409
+#: src/muuli_wdr.cpp:3381
 msgid "Send"
 msgstr "Gönder"
 
-#: src/muuli_wdr.cpp:3410
+#: src/muuli_wdr.cpp:3382
 msgid "Sends the specified message."
 msgstr "Belirlenen iletiyi gönderir."
 
-#: src/muuli_wdr.cpp:3414
+#: src/muuli_wdr.cpp:3386
 msgid "Close this chat-session."
 msgstr "Bu sohbet oturumunu kapatır."
 
-#: src/muuli_wdr.cpp:3437
+#: src/muuli_wdr.cpp:3409
 msgid "Connect to any server and/or Kad"
 msgstr "Herhangi bir sunucuya ve/veya Kad'a bağlan."
 
-#: src/muuli_wdr.cpp:3443 src/SharedFilesCtrl.cpp:142 src/Statistics.cpp:941
+#: src/muuli_wdr.cpp:3415 src/SharedFilesCtrl.cpp:142 src/Statistics.cpp:941
 msgid "Shared Files"
 msgstr "Paylaşılan Dosyalar"
 
@@ -5443,248 +5409,248 @@ msgstr "İndirildi"
 msgid "ERROR: Failed to open partfile '%s'"
 msgstr "HATA: Parça dosyası '%s' açılamıyor"
 
-#: src/Preferences.cpp:701
+#: src/Preferences.cpp:673
 msgid "System default"
 msgstr "Sistem öntanımlısı"
 
-#: src/Preferences.cpp:702
+#: src/Preferences.cpp:674
 msgid "Albanian"
 msgstr "Arnavutça"
 
-#: src/Preferences.cpp:703
+#: src/Preferences.cpp:675
 msgid "Arabic"
 msgstr "Arapça"
 
-#: src/Preferences.cpp:704
+#: src/Preferences.cpp:676
 msgid "Asturian"
 msgstr "Asturyasça"
 
-#: src/Preferences.cpp:705
+#: src/Preferences.cpp:677
 msgid "Basque"
 msgstr "Baskça"
 
-#: src/Preferences.cpp:706
+#: src/Preferences.cpp:678
 msgid "Bulgarian"
 msgstr "Bulgarca"
 
-#: src/Preferences.cpp:707
+#: src/Preferences.cpp:679
 msgid "Catalan"
 msgstr "Katalanca"
 
-#: src/Preferences.cpp:708
+#: src/Preferences.cpp:680
 msgid "Chinese (Simplified)"
 msgstr "Çince (Basitleştirilmiş)"
 
-#: src/Preferences.cpp:709
+#: src/Preferences.cpp:681
 msgid "Chinese (Traditional)"
 msgstr "Çince (Geleneksel)"
 
-#: src/Preferences.cpp:710
+#: src/Preferences.cpp:682
 msgid "Croatian"
 msgstr "Hırvatça"
 
-#: src/Preferences.cpp:711
+#: src/Preferences.cpp:683
 msgid "Czech"
 msgstr "Çekçe"
 
-#: src/Preferences.cpp:712
+#: src/Preferences.cpp:684
 msgid "Danish"
 msgstr "Danca"
 
-#: src/Preferences.cpp:713
+#: src/Preferences.cpp:685
 msgid "Dutch"
 msgstr "Felemenkçe"
 
-#: src/Preferences.cpp:714
+#: src/Preferences.cpp:686
 msgid "English (U.K.)"
 msgstr "İngilizce (U.K)"
 
-#: src/Preferences.cpp:715
+#: src/Preferences.cpp:687
 msgid "English (U.S.)"
 msgstr "İngilizce (ABD)"
 
-#: src/Preferences.cpp:716
+#: src/Preferences.cpp:688
 msgid "Estonian"
 msgstr "Estonca"
 
-#: src/Preferences.cpp:717
+#: src/Preferences.cpp:689
 msgid "Finnish"
 msgstr "Fince"
 
-#: src/Preferences.cpp:718
+#: src/Preferences.cpp:690
 msgid "French"
 msgstr "Fransızca"
 
-#: src/Preferences.cpp:719
+#: src/Preferences.cpp:691
 msgid "Galician"
 msgstr "Galce"
 
-#: src/Preferences.cpp:720
+#: src/Preferences.cpp:692
 msgid "German"
 msgstr "Almanca"
 
-#: src/Preferences.cpp:721
+#: src/Preferences.cpp:693
 msgid "Greek"
 msgstr "Yunanca"
 
-#: src/Preferences.cpp:722
+#: src/Preferences.cpp:694
 msgid "Hebrew"
 msgstr "İbranice"
 
-#: src/Preferences.cpp:723
+#: src/Preferences.cpp:695
 msgid "Hungarian"
 msgstr "Macarca"
 
-#: src/Preferences.cpp:724
+#: src/Preferences.cpp:696
 msgid "Italian"
 msgstr "İtalyanca"
 
-#: src/Preferences.cpp:725
+#: src/Preferences.cpp:697
 msgid "Japanese"
 msgstr "Japonca"
 
-#: src/Preferences.cpp:726
+#: src/Preferences.cpp:698
 msgid "Korean"
 msgstr "Korece"
 
-#: src/Preferences.cpp:727
+#: src/Preferences.cpp:699
 msgid "Latvian"
 msgstr "Letonca"
 
-#: src/Preferences.cpp:728
+#: src/Preferences.cpp:700
 msgid "Lithuanian"
 msgstr "Litvanyaca"
 
-#: src/Preferences.cpp:729
+#: src/Preferences.cpp:701
 msgid "Norwegian (Nynorsk)"
 msgstr "Norveççe (Nynorsk)"
 
-#: src/Preferences.cpp:730
+#: src/Preferences.cpp:702
 msgid "Polish"
 msgstr "Lehçe"
 
-#: src/Preferences.cpp:731
+#: src/Preferences.cpp:703
 msgid "Portuguese"
 msgstr "Portekizce"
 
-#: src/Preferences.cpp:732
+#: src/Preferences.cpp:704
 msgid "Portuguese (Brazilian)"
 msgstr "Portekizce (Brezilya)"
 
-#: src/Preferences.cpp:733
+#: src/Preferences.cpp:705
 msgid "Romanian"
 msgstr "Rumence"
 
-#: src/Preferences.cpp:734
+#: src/Preferences.cpp:706
 msgid "Russian"
 msgstr "Rusça"
 
-#: src/Preferences.cpp:735
+#: src/Preferences.cpp:707
 msgid "Slovenian"
 msgstr "Slovence"
 
-#: src/Preferences.cpp:736
+#: src/Preferences.cpp:708
 msgid "Spanish"
 msgstr "İspanyolca"
 
-#: src/Preferences.cpp:737
+#: src/Preferences.cpp:709
 msgid "Swedish"
 msgstr "İsveççe"
 
-#: src/Preferences.cpp:738
+#: src/Preferences.cpp:710
 msgid "Turkish"
 msgstr "Türkçe"
 
-#: src/Preferences.cpp:739
+#: src/Preferences.cpp:711
 msgid "Ukrainian"
 msgstr "Ukraynaca"
 
-#: src/Preferences.cpp:842
+#: src/Preferences.cpp:814
 msgid "Change Language"
 msgstr "Dili Değiştirin"
 
-#: src/Preferences.cpp:906
+#: src/Preferences.cpp:878
 msgid "There are no translations installed for aMule"
 msgstr "aMule tercümeleri kurulu değildir"
 
-#: src/Preferences.cpp:907
+#: src/Preferences.cpp:879
 msgid "No languages available"
 msgstr "Diller mevcut değil"
 
-#: src/Preferences.cpp:1038
+#: src/Preferences.cpp:1010
 msgid "no options available"
 msgstr "mevcut seçenek yok"
 
-#: src/Preferences.cpp:2226
+#: src/Preferences.cpp:2179
 msgid "Invalid category found, skipping"
 msgstr "Geçersiz sınıf bulundu, atlanıyor"
 
-#: src/Preferences.cpp:2395
+#: src/Preferences.cpp:2348
 msgid "TCP port can't be higher than 65532 due to server UDP socket being TCP+3"
 msgstr "TCP portu numarası, UDP soketi TCP+3 olduğundan 65532' den yüksek olamaz"
 
-#: src/Preferences.cpp:2396
+#: src/Preferences.cpp:2349
 #, c-format
 msgid "Default port will be used (%d)"
 msgstr "Varsayılan port kullanılacak (%d)"
 
-#: src/PrefsUnifiedDlg.cpp:300 src/Statistics.cpp:866
+#: src/PrefsUnifiedDlg.cpp:298 src/Statistics.cpp:866
 msgid "Connection"
 msgstr "Bağlantı"
 
-#: src/PrefsUnifiedDlg.cpp:301 src/SearchListCtrl.cpp:117
+#: src/PrefsUnifiedDlg.cpp:299 src/SearchListCtrl.cpp:117
 msgid "Directories"
 msgstr "Dizinler"
 
-#: src/PrefsUnifiedDlg.cpp:302 src/Statistics.cpp:917
+#: src/PrefsUnifiedDlg.cpp:300 src/Statistics.cpp:917
 msgid "Servers"
 msgstr "Sunucular"
 
-#: src/PrefsUnifiedDlg.cpp:303 src/ServerListCtrl.cpp:96
+#: src/PrefsUnifiedDlg.cpp:301 src/ServerListCtrl.cpp:96
 msgid "Files"
 msgstr "Dosyalar"
 
-#: src/PrefsUnifiedDlg.cpp:304
+#: src/PrefsUnifiedDlg.cpp:302
 msgid "Security"
 msgstr "Güvenlik"
 
-#: src/PrefsUnifiedDlg.cpp:305
+#: src/PrefsUnifiedDlg.cpp:303
 msgid "Interface"
 msgstr "Arayüz"
 
-#: src/PrefsUnifiedDlg.cpp:312
+#: src/PrefsUnifiedDlg.cpp:310
 msgid "IP2Country"
 msgstr "IP2Country"
 
-#: src/PrefsUnifiedDlg.cpp:315
+#: src/PrefsUnifiedDlg.cpp:313
 msgid "Proxy"
 msgstr "Vekil sunucu"
 
-#: src/PrefsUnifiedDlg.cpp:316
+#: src/PrefsUnifiedDlg.cpp:314
 msgid "Filters"
 msgstr "Süzgeçler"
 
-#: src/PrefsUnifiedDlg.cpp:317
+#: src/PrefsUnifiedDlg.cpp:315
 msgid "Remote Controls"
 msgstr "Uzak Denetimler"
 
-#: src/PrefsUnifiedDlg.cpp:318
+#: src/PrefsUnifiedDlg.cpp:316
 msgid "Online Signature"
 msgstr "Çevrimiçi İmza"
 
-#: src/PrefsUnifiedDlg.cpp:319
+#: src/PrefsUnifiedDlg.cpp:317
 msgid "Advanced"
 msgstr "Gelişmiş"
 
-#: src/PrefsUnifiedDlg.cpp:320
+#: src/PrefsUnifiedDlg.cpp:318
 msgid "Events"
 msgstr "Olaylar"
 
-#: src/PrefsUnifiedDlg.cpp:323
+#: src/PrefsUnifiedDlg.cpp:321
 msgid "Debugging"
 msgstr "Hata Çıktısı"
 
-#: src/PrefsUnifiedDlg.cpp:453
+#: src/PrefsUnifiedDlg.cpp:451
 msgid ""
 "The following variables will be substituted:\n"
 "    %PARTFILE - full path to the file\n"
@@ -5694,15 +5660,15 @@ msgstr ""
 "    %PARTFILE - dosyanın tam yolu\n"
 "    %PARTNAME - dosyanın sadece adı"
 
-#: src/PrefsUnifiedDlg.cpp:474
+#: src/PrefsUnifiedDlg.cpp:472
 msgid "Tray icon support requires libayatana-appindicator3 at compile time."
 msgstr "Sistem tepsisi ikon desteği, derleme esnasında libayatana-appindicator3'e ihtiyaç duyar."
 
-#: src/PrefsUnifiedDlg.cpp:490
+#: src/PrefsUnifiedDlg.cpp:488
 msgid "Not available on Wayland: the protocol does not report when a window is minimized, so this option cannot intercept the system minimize button. Workaround: launch aMule with `GDK_BACKEND=x11` to use XWayland instead."
 msgstr "Wayland ile kullanılamaz: protokol bir pencere küçültüldüğünde bunu iletmez, yani bu seçenek sistemin küçült düğmesi tıklamasını yakalayamaz. Çözüm: yerine XWayland kullanmak için aMule'ü `GDK_BACKEND=x11` ile başlatın."
 
-#: src/PrefsUnifiedDlg.cpp:536
+#: src/PrefsUnifiedDlg.cpp:534
 msgid ""
 "Do not change these setting unless you know\n"
 "what you are doing, otherwise you can easily\n"
@@ -5718,35 +5684,26 @@ msgstr ""
 "Bu ayarlarla oynanmasa da\n"
 "aMule gayet iyi işleyecektir."
 
-#: src/PrefsUnifiedDlg.cpp:647
+#: src/PrefsUnifiedDlg.cpp:645
 #, c-format
 msgid "Failed to connect Cfg to widget with the ID %d and key %s"
 msgstr "Cfg %d Kimliği ve %s anahtarı ile parçacığa bağlanamadı"
 
-#: src/PrefsUnifiedDlg.cpp:695
+#: src/PrefsUnifiedDlg.cpp:693
 #, c-format
 msgid "Failed to transfer data from Cfg to Widget with the ID %d and key %s"
 msgstr "Cfg' den %d Kimliği ve %s anahtarı ile Parçacığa veri aktarılamadı"
 
-#: src/PrefsUnifiedDlg.cpp:801
+#: src/PrefsUnifiedDlg.cpp:799
 msgid "The type of proxy you are connecting to"
 msgstr "Bağlanacağınız vekil sunucu türü"
 
-#: src/PrefsUnifiedDlg.cpp:1020
+#: src/PrefsUnifiedDlg.cpp:1003
 #, c-format
 msgid "Failed to transfer data from Widget to Cfg with the ID %d and key %s"
 msgstr "Parçacıktan %d Kimliği ve %s anahtarı ile Cfg' ye veri aktarılamadı"
 
 #: src/PrefsUnifiedDlg.cpp:1103
-#, fuzzy
-msgid "No password set."
-msgstr "Yönetici parolası"
-
-#: src/PrefsUnifiedDlg.cpp:1132
-msgid "Guest access needs a password. Type one in the guest password field, or untick Enable guest access."
-msgstr ""
-
-#: src/PrefsUnifiedDlg.cpp:1144
 msgid ""
 "aMule must be restarted to enable these changes:\n"
 "\n"
@@ -5754,39 +5711,39 @@ msgstr ""
 "Değişikliklerin uygulanması için, aMule yeniden başlatılmalı\n"
 "\n"
 
-#: src/PrefsUnifiedDlg.cpp:1151
+#: src/PrefsUnifiedDlg.cpp:1110
 msgid "- TCP port changed.\n"
 msgstr "- TCP portu değişti.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1156
+#: src/PrefsUnifiedDlg.cpp:1115
 msgid "- UDP port changed.\n"
 msgstr "- UDP Portu değişti.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1161
+#: src/PrefsUnifiedDlg.cpp:1120
 msgid "- Network interface binding changed.\n"
 msgstr "- Ağ arayüz bağlaması değişti.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1166
+#: src/PrefsUnifiedDlg.cpp:1125
 msgid "- External connect port changed.\n"
 msgstr "- Dışarıdan bağlantı portu değişti.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1170
+#: src/PrefsUnifiedDlg.cpp:1129
 msgid "- External connect acceptance changed.\n"
 msgstr "- Dışarıdan bağlantı kabul edilme işlemi değişti.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1174
+#: src/PrefsUnifiedDlg.cpp:1133
 msgid "- External connect interface changed.\n"
 msgstr "- Dışarıdan bağlantı arayüzü değişti.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1178
+#: src/PrefsUnifiedDlg.cpp:1137
 msgid "- Protocol obfuscation support changed.\n"
 msgstr "- Protokol gizleme desteği değişti.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1193
+#: src/PrefsUnifiedDlg.cpp:1151
 msgid "- amuleapi settings changed.\n"
 msgstr "- amuleapi ayarları değişti.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1202
+#: src/PrefsUnifiedDlg.cpp:1160
 msgid ""
 "Your Auto-update server list is empty.\n"
 "'Auto-update server list at startup' will be disabled."
@@ -5794,7 +5751,7 @@ msgstr ""
 "Otomatik Sunucu güncelleme listeniz boş.\n"
 "'Sunucu listesini başlangıçta otomatikman güncelle' devre dışı bırakılacak."
 
-#: src/PrefsUnifiedDlg.cpp:1213
+#: src/PrefsUnifiedDlg.cpp:1171
 msgid ""
 "You have enabled external connections but have not specified a password.\n"
 "External connections cannot be enabled unless a valid password is specified."
@@ -5802,32 +5759,27 @@ msgstr ""
 "Dışarıdan bağlantıları aktifleştirmiş ama bir şifre belirlememişsiniz.\n"
 "Geçerli bir şifre belirlenmedikçe dışarıdan bağlantılar devre dışı kalacaktır."
 
-#: src/PrefsUnifiedDlg.cpp:1246
-#, c-format
-msgid "The amuleapi password could not be saved: %s"
-msgstr ""
-
-#: src/PrefsUnifiedDlg.cpp:1276
+#: src/PrefsUnifiedDlg.cpp:1202
 msgid "- Language changed.\n"
 msgstr "- Dil ayarları değişti.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1281
+#: src/PrefsUnifiedDlg.cpp:1207
 msgid "- Temp folder changed.\n"
 msgstr "- Geçici Dosyalar dizini değişti.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1286
+#: src/PrefsUnifiedDlg.cpp:1212
 msgid "- ED2K network enabled.\n"
 msgstr "- ED2K ağı etkinleştirildi.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1319
+#: src/PrefsUnifiedDlg.cpp:1245
 msgid "The shared-file exclusion pattern is not a valid regular expression. The filter has been left disabled."
 msgstr "Paylaşılan dosya dışlama örüntüsü geçerli bir düzenli ifade değil. Filtre devre dışı olarak bırakıldı."
 
-#: src/PrefsUnifiedDlg.cpp:1321 src/PrefsUnifiedDlg.cpp:1921
+#: src/PrefsUnifiedDlg.cpp:1247 src/PrefsUnifiedDlg.cpp:1841
 msgid "Invalid regular expression"
 msgstr "Geçersiz düzenli ifade"
 
-#: src/PrefsUnifiedDlg.cpp:1398
+#: src/PrefsUnifiedDlg.cpp:1324
 msgid ""
 "Both eD2k and Kad network are disabled.\n"
 "You won't be able to connect until you enable at least one of them."
@@ -5835,7 +5787,7 @@ msgstr ""
 "Hem eD2k hem de Kad ağları devre dışı bırakılmış.\n"
 "En az birini etkinleştirmeden bağlanamayacaksınız."
 
-#: src/PrefsUnifiedDlg.cpp:1403
+#: src/PrefsUnifiedDlg.cpp:1329
 msgid ""
 "Kad will not start if your UDP port is disabled.\n"
 "Enable UDP port or disable Kad."
@@ -5843,7 +5795,7 @@ msgstr ""
 "UDP portu devre dışı bırakılmışsa Kad başlamayacaktır.\n"
 "UDP portu açın veya Kademlia'yı devre dışı bırakın."
 
-#: src/PrefsUnifiedDlg.cpp:1459
+#: src/PrefsUnifiedDlg.cpp:1385
 msgid ""
 "\n"
 "You MUST restart aMule now.\n"
@@ -5853,68 +5805,68 @@ msgstr ""
 "aMule' yi ŞİMDİ yeniden başlatmalısınız.\n"
 "Şimdi yeniden başlatmazsanız, kötü şeyler olabilir.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1524
+#: src/PrefsUnifiedDlg.cpp:1450
 msgid "Could not register aMule for autostart at login. The autostart store may be read-only."
 msgstr "Oturum açıldığında otomatik başlatma için aMule kaydedilemedi. Otomatik başlatma deposu salt okunur olabilir."
 
-#: src/PrefsUnifiedDlg.cpp:1526
+#: src/PrefsUnifiedDlg.cpp:1452
 msgid "Could not remove the autostart-at-login entry."
 msgstr "Oturum açılışında otomatik başlatma unsuru kaldırılamadı."
 
-#: src/PrefsUnifiedDlg.cpp:1527
+#: src/PrefsUnifiedDlg.cpp:1453
 msgid "Autostart"
 msgstr "Otomatik başlatma"
 
-#: src/PrefsUnifiedDlg.cpp:1542
+#: src/PrefsUnifiedDlg.cpp:1468
 msgid "Register file type"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1542
+#: src/PrefsUnifiedDlg.cpp:1468
 msgid "Register URL handler"
 msgstr "URL yöneticisini kaydet"
 
-#: src/PrefsUnifiedDlg.cpp:1550
+#: src/PrefsUnifiedDlg.cpp:1476
 #, c-format
 msgid "aMule only handles eD2k-compatible magnets. If you replace the current magnet handler (%s), BitTorrent magnet links will stop working - aMule cannot download BitTorrent content. Continue?"
 msgstr "aMule, sadece eD2k uyumlu magnet'leri işler. Şayet güncel magnet yöneticisinin (%s) yerine onu koyarsanız, BitTorrent magnet bağlantıları artık çalışmayacaktır - aMule BitTorrent içeriği indiremez. Devam edilsin mi?"
 
-#: src/PrefsUnifiedDlg.cpp:1555
+#: src/PrefsUnifiedDlg.cpp:1481
 #, fuzzy, c-format
 msgid "Another application currently opens .emulecollection files (%s). Replace it with aMule?"
 msgstr "Başka bir uygulama güncel olarak bu bağlantıların yöneticisidir (%s). Yerine aMule konsun mu?"
 
-#: src/PrefsUnifiedDlg.cpp:1560
+#: src/PrefsUnifiedDlg.cpp:1486
 #, c-format
 msgid "Another application is currently the default handler for these links (%s). Replace it with aMule?"
 msgstr "Başka bir uygulama güncel olarak bu bağlantıların yöneticisidir (%s). Yerine aMule konsun mu?"
 
-#: src/PrefsUnifiedDlg.cpp:1585
+#: src/PrefsUnifiedDlg.cpp:1511
 #, fuzzy
 msgid "Could not register aMule for .emulecollection files. The registration store may be read-only."
 msgstr "aMule, URL yöneticisi olarak kaydedilemedi. Kayıt deposu salt okunur olabilir."
 
-#: src/PrefsUnifiedDlg.cpp:1587
+#: src/PrefsUnifiedDlg.cpp:1513
 #, fuzzy
 msgid "Could not remove the file type registration."
 msgstr "URL yönetim kaydı kaldırılamadı."
 
-#: src/PrefsUnifiedDlg.cpp:1589
+#: src/PrefsUnifiedDlg.cpp:1515
 msgid "Could not register aMule as the URL handler. The registration store may be read-only."
 msgstr "aMule, URL yöneticisi olarak kaydedilemedi. Kayıt deposu salt okunur olabilir."
 
-#: src/PrefsUnifiedDlg.cpp:1591
+#: src/PrefsUnifiedDlg.cpp:1517
 msgid "Could not remove the URL handler registration."
 msgstr "URL yönetim kaydı kaldırılamadı."
 
-#: src/PrefsUnifiedDlg.cpp:1661 src/PrefsUnifiedDlg.cpp:1688
+#: src/PrefsUnifiedDlg.cpp:1587 src/PrefsUnifiedDlg.cpp:1614
 msgid "The web server and aMule API require external connections to be enabled."
 msgstr "Web sunucusu ve aMule API, dış bağlantıların etkinleştirilmiş olmalarına ihtiyaç duyar."
 
-#: src/PrefsUnifiedDlg.cpp:1671
+#: src/PrefsUnifiedDlg.cpp:1597
 msgid "The aMule web server is deprecated. Consider running the aMule API instead."
 msgstr "aMule Web sunucusu eskimiştir. Yerine aMule API çalıştırmayı değerlendirin."
 
-#: src/PrefsUnifiedDlg.cpp:1735
+#: src/PrefsUnifiedDlg.cpp:1655
 msgid ""
 "Your Auto-update servers list is in blank.\n"
 "Please fill in at least one URL to point to a valid server.met file.\n"
@@ -5924,64 +5876,64 @@ msgstr ""
 "Lütfen geçerli bir server.met dosyasını gösteren en az bir adres yazınız.\n"
 "Bir adres girmek için bu kutucuğun yanındaki \"Liste\" düğmesine basınız."
 
-#: src/PrefsUnifiedDlg.cpp:1876
+#: src/PrefsUnifiedDlg.cpp:1796
 msgid "Temporary files"
 msgstr "Geçici dosya(lar)"
 
-#: src/PrefsUnifiedDlg.cpp:1881
+#: src/PrefsUnifiedDlg.cpp:1801
 msgid "Incoming files"
 msgstr "Gelen dosya(lar)"
 
-#: src/PrefsUnifiedDlg.cpp:1886
+#: src/PrefsUnifiedDlg.cpp:1806
 msgid "Online Signatures"
 msgstr "Çevrimiçi İmzalar"
 
-#: src/PrefsUnifiedDlg.cpp:1899
+#: src/PrefsUnifiedDlg.cpp:1819
 #, c-format
 msgid "Choose a folder for %s"
 msgstr "%s için bir dizin seçiniz."
 
-#: src/PrefsUnifiedDlg.cpp:1923
+#: src/PrefsUnifiedDlg.cpp:1843
 #, c-format
 msgid "Would exclude %u of %u shared file"
 msgid_plural "Would exclude %u of %u shared files"
 msgstr[0] "%u dosya, ki %u üzerinde dışlanırdı"
 msgstr[1] "%u dosya, ki %u üzerinde dışlanırdı"
 
-#: src/PrefsUnifiedDlg.cpp:1940
+#: src/PrefsUnifiedDlg.cpp:1860
 msgid "Browse for videoplayer"
 msgstr "Ortam Çalıcısı için göz at"
 
-#: src/PrefsUnifiedDlg.cpp:1944
+#: src/PrefsUnifiedDlg.cpp:1864
 msgid "Select browser"
 msgstr "Tarayıcı Seçiniz"
 
-#: src/PrefsUnifiedDlg.cpp:1948
+#: src/PrefsUnifiedDlg.cpp:1868
 msgid "Select ffprobe binary"
 msgstr "ffprobe ikilisi seçin"
 
-#: src/PrefsUnifiedDlg.cpp:1954
+#: src/PrefsUnifiedDlg.cpp:1874
 #, c-format
 msgid "Executable%s"
 msgstr "Çalıştırılabilir %s"
 
-#: src/PrefsUnifiedDlg.cpp:1988
+#: src/PrefsUnifiedDlg.cpp:1908
 msgid "ffprobe not found on PATH or in the standard install locations. Install ffmpeg (which ships ffprobe) or use Browse to pick a binary manually."
 msgstr "ffprobe, PATH veya standart kurulum konumlarında bulunamadı. ffmepg kurun (ffprobe'u sağlar) veya el ile bir ikili seçmek için Tara düğmesine tıklayın."
 
-#: src/PrefsUnifiedDlg.cpp:2000
+#: src/PrefsUnifiedDlg.cpp:1920
 msgid "Reset the settings on this page to their default values?"
 msgstr "Bu sayfadaki ayarlar varsayılan değerlerine sıfırlansınlar mı?"
 
-#: src/PrefsUnifiedDlg.cpp:2001
+#: src/PrefsUnifiedDlg.cpp:1921
 msgid "Reset to defaults"
 msgstr "Varsayılanlara sıfırla"
 
-#: src/PrefsUnifiedDlg.cpp:2028
+#: src/PrefsUnifiedDlg.cpp:1948
 msgid "Edit server list"
 msgstr "Sunucu listesini düzenle"
 
-#: src/PrefsUnifiedDlg.cpp:2029
+#: src/PrefsUnifiedDlg.cpp:1949
 msgid ""
 "Add here URL's to download server.met files.\n"
 "Only one url on each line."
@@ -5989,114 +5941,114 @@ msgstr ""
 "Server.met dosyasını indirmek için buraya bağlantı adresi girin.\n"
 "Her satıra sadece bir adres yazılmalıdır."
 
-#: src/PrefsUnifiedDlg.cpp:2084
+#: src/PrefsUnifiedDlg.cpp:2004
 msgid "IP2Country update failed"
 msgstr "IP2Country güncellemesi başarısız oldu"
 
-#: src/PrefsUnifiedDlg.cpp:2229 src/PrefsUnifiedDlg.cpp:2260
+#: src/PrefsUnifiedDlg.cpp:2149 src/PrefsUnifiedDlg.cpp:2180
 msgid "Data by MaxMind GeoLite2"
 msgstr "Veriler MaxMind GeoLite2 tarafından sağlanmıştır"
 
-#: src/PrefsUnifiedDlg.cpp:2231 src/PrefsUnifiedDlg.cpp:2262
+#: src/PrefsUnifiedDlg.cpp:2151 src/PrefsUnifiedDlg.cpp:2182
 msgid "Custom source"
 msgstr "Kişiselleştirilmiş kaynak"
 
-#: src/PrefsUnifiedDlg.cpp:2233 src/PrefsUnifiedDlg.cpp:2264
+#: src/PrefsUnifiedDlg.cpp:2153 src/PrefsUnifiedDlg.cpp:2184
 msgid "Data by DB-IP.com"
 msgstr "Veriler DB-IP.com tarafından sağlanmıştır"
 
-#: src/PrefsUnifiedDlg.cpp:2284
+#: src/PrefsUnifiedDlg.cpp:2204
 #, c-format
 msgid "Status: Loaded%s"
 msgstr "Durum: %s yüklendi"
 
-#: src/PrefsUnifiedDlg.cpp:2286
+#: src/PrefsUnifiedDlg.cpp:2206
 #, c-format
 msgid "Status: Loaded%s - %s"
 msgstr "Durum: %s - %s yüklendi"
 
-#: src/PrefsUnifiedDlg.cpp:2290
+#: src/PrefsUnifiedDlg.cpp:2210
 msgid "Status: Failed to load - click 'Update now' to refresh."
 msgstr "Durum: yükleme başarısız oldu - güncellemek için 'Şimdi güncelle' düğmesine tıklayın."
 
-#: src/PrefsUnifiedDlg.cpp:2292
+#: src/PrefsUnifiedDlg.cpp:2212
 msgid "Status: Not found - click 'Update now' to download."
 msgstr "Durum: bulunamadı - indirmek için 'Şimdi güncelle' düğmesine tıklayın."
 
-#: src/PrefsUnifiedDlg.cpp:2350 src/PrefsUnifiedDlg.cpp:2374
+#: src/PrefsUnifiedDlg.cpp:2270 src/PrefsUnifiedDlg.cpp:2294
 #, c-format
 msgid "Update delay: %d second"
 msgid_plural "Update delay: %d seconds"
 msgstr[0] "Güncelleme gecikmesi: %d saniye"
 msgstr[1] "Güncelleme gecikmesi: %d saniye"
 
-#: src/PrefsUnifiedDlg.cpp:2358
+#: src/PrefsUnifiedDlg.cpp:2278
 #, c-format
 msgid "Time for average graph: %d minute"
 msgid_plural "Time for average graph: %d minutes"
 msgstr[0] "Ortalama grafiği için süre: %d dakika"
 msgstr[1] "Ortalama grafiği için süre: %d dakika"
 
-#: src/PrefsUnifiedDlg.cpp:2367
+#: src/PrefsUnifiedDlg.cpp:2287
 #, c-format
 msgid "Connections Graph Scale: %d"
 msgstr "Bağlantı Grafik Ölçüsü: %d"
 
-#: src/PrefsUnifiedDlg.cpp:2382
+#: src/PrefsUnifiedDlg.cpp:2302
 #, c-format
 msgid "File Buffer Size: %d byte"
 msgid_plural "File Buffer Size: %d bytes"
 msgstr[0] "Dosya Alım Boyutu: %d bayt"
 msgstr[1] "Dosya Alım Boyutu: %d bayt"
 
-#: src/PrefsUnifiedDlg.cpp:2392
+#: src/PrefsUnifiedDlg.cpp:2312
 #, c-format
 msgid "Upload Queue Size: %d client"
 msgid_plural "Upload Queue Size: %d clients"
 msgstr[0] "Gönderme Sıra Boyutu: %d kullanıcı"
 msgstr[1] "Gönderme Sıra Boyutu: %d kullanıcı"
 
-#: src/PrefsUnifiedDlg.cpp:2402
+#: src/PrefsUnifiedDlg.cpp:2322
 #, c-format
 msgid "Server connection refresh interval: %d minute"
 msgid_plural "Server connection refresh interval: %d minutes"
 msgstr[0] "Sunucu bağlantısı yenileme sıklığı: %d dakika"
 msgstr[1] "Sunucu bağlantısı yenileme sıklığı: %d dakika"
 
-#: src/PrefsUnifiedDlg.cpp:2407
+#: src/PrefsUnifiedDlg.cpp:2327
 msgid "Server connection refresh interval: Disabled"
 msgstr "Sunucu bağlantısı yenileme döngüsü: Devre dışı"
 
-#: src/PrefsUnifiedDlg.cpp:2451
+#: src/PrefsUnifiedDlg.cpp:2371
 msgid "disabled"
 msgstr "devre dışı"
 
-#: src/PrefsUnifiedDlg.cpp:2477
+#: src/PrefsUnifiedDlg.cpp:2397
 #, c-format
 msgid "Execute command on '%s' event"
 msgstr "'%s' olayında komut çalıştır."
 
-#: src/PrefsUnifiedDlg.cpp:2484
+#: src/PrefsUnifiedDlg.cpp:2404
 msgid "Enable command execution on core"
 msgstr "Çekirdekte komut çalıştırmayı aktifleştir."
 
-#: src/PrefsUnifiedDlg.cpp:2496
+#: src/PrefsUnifiedDlg.cpp:2416
 msgid "Core command:"
 msgstr "Çekirdek komutu:"
 
-#: src/PrefsUnifiedDlg.cpp:2512
+#: src/PrefsUnifiedDlg.cpp:2432
 msgid "Enable command execution on GUI"
 msgstr "Arayüzde komut çalıştırmayı etkinleştir."
 
-#: src/PrefsUnifiedDlg.cpp:2524
+#: src/PrefsUnifiedDlg.cpp:2444
 msgid "GUI command:"
 msgstr "Arayüz komutu:"
 
-#: src/PrefsUnifiedDlg.cpp:2540
+#: src/PrefsUnifiedDlg.cpp:2460
 msgid "The following variables will be replaced:"
 msgstr "Şu girdiler değiştirilecek:"
 
-#: src/PrefsUnifiedDlg.cpp:2708
+#: src/PrefsUnifiedDlg.cpp:2628
 msgid ""
 "The following folders look like system or sensitive locations:\n"
 "\n"
@@ -6104,61 +6056,57 @@ msgstr ""
 "Şu dizinler sistem dizinleri veya hassas konumlar gibi görünüyor:\n"
 "\n"
 
-#: src/PrefsUnifiedDlg.cpp:2713
+#: src/PrefsUnifiedDlg.cpp:2633
 msgid "Sharing them recursively will publish every file underneath on the eD2k/Kad networks. Do you really want to do this?"
 msgstr "Bunları yinelemeli olarak paylaşmanız, kapsadıkları her dosyayı eD2k/Kad ağlarında yayınlayacaktır. Bunu hakikaten yapmak istiyor musunuz?"
 
-#: src/PrefsUnifiedDlg.cpp:2716
+#: src/PrefsUnifiedDlg.cpp:2636
 msgid "Confirm shared folders"
 msgstr "Paylaşılan dizinleri teyit et"
 
-#: src/PrefsUnifiedDlg.cpp:2744
+#: src/PrefsUnifiedDlg.cpp:2664
 msgid "Reloading shared files..."
 msgstr "Paylaşılan dosyalar yeniden yükleniyor…"
 
-#: src/PrefsUnifiedDlg.cpp:2745
+#: src/PrefsUnifiedDlg.cpp:2665
 msgid "Scanning for subdirectories..."
 msgstr "Alt dizinler taranıyor…"
 
-#: src/PrefsUnifiedDlg.cpp:2746
+#: src/PrefsUnifiedDlg.cpp:2666
 msgid "Updating shared folders"
 msgstr "Paylaşılan dizinler güncelleniyor"
 
-#: src/PrefsUnifiedDlg.cpp:2773
+#: src/PrefsUnifiedDlg.cpp:2693
 #, c-format
 msgid "Scanned %u directories..."
 msgstr "%u dizin tarandı…"
 
-#: src/PrefsUnifiedDlg.cpp:2823
+#: src/PrefsUnifiedDlg.cpp:2743
 #, c-format
 msgid "Reloading shared files: %u files scanned"
 msgstr "Paylaşılmış dosyalar yeniden yükleniyor: %u dosya tarandı"
 
-#: src/PrefsUnifiedDlg.cpp:2873
+#: src/PrefsUnifiedDlg.cpp:2793
 msgid "Shared folder"
 msgstr "Paylaşılan dizin"
 
-#: src/SearchDlg.cpp:280
-msgid "Clear search history"
-msgstr ""
-
-#: src/SearchDlg.cpp:584
+#: src/SearchDlg.cpp:425
 msgid "It's impossible to search when both eD2k and Kademlia are disabled."
 msgstr "Hem eD2k hem de Kademlia devre dışı bırakıldığında arama yapmak mümkün değildir."
 
-#: src/SearchDlg.cpp:585 src/SearchListCtrl.cpp:858
+#: src/SearchDlg.cpp:426 src/SearchListCtrl.cpp:858
 msgid "Search error"
 msgstr "Arama hatası"
 
-#: src/SearchDlg.cpp:929
+#: src/SearchDlg.cpp:768
 msgid "Min size must be smaller than max size. Max size ignored."
 msgstr "En küçük boyut, en büyük boyuttan küçük olmalıdır. En büyük boyut göz ardı ediliyor."
 
-#: src/SearchDlg.cpp:930 src/SearchDlg.cpp:1012
+#: src/SearchDlg.cpp:769 src/SearchDlg.cpp:851
 msgid "Search warning"
 msgstr "Arama uyarısı."
 
-#: src/SearchDlg.cpp:1092 src/SearchListCtrl.cpp:735
+#: src/SearchDlg.cpp:929 src/SearchListCtrl.cpp:735
 msgid "Main"
 msgstr "Ana"
 

--- a/po/uk.po
+++ b/po/uk.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-28 12:17+0200\n"
+"POT-Creation-Date: 2026-07-28 13:09+0200\n"
 "PO-Revision-Date: 2026-07-27 11:47+0000\n"
 "Last-Translator: Oleksandr Kovalenko <alx.kovalenko@gmail.com>\n"
 "Language-Team: Ukrainian <translation@linux.org.ua>\n"
@@ -291,7 +291,7 @@ msgid "Password set and external connections enabled."
 msgstr "Пароль встановлений та дозволені зовнішні з'єднання."
 
 #: src/amule.cpp:755 src/KadDlg.cpp:176 src/KadDlg.cpp:185
-#: src/PrefsUnifiedDlg.cpp:1461 src/SharedFilesCtrl.cpp:476
+#: src/PrefsUnifiedDlg.cpp:1470 src/SharedFilesCtrl.cpp:476
 msgid "WARNING"
 msgstr "ЗАСТЕРЕЖЕННЯ"
 
@@ -329,7 +329,7 @@ msgstr "Ви встановили запуск веб-сервера під ча
 #: src/amule-remote-gui.cpp:603 src/amule-remote-gui.cpp:671
 #: src/amule-remote-gui.cpp:709 src/amule-remote-gui.cpp:1282
 #: src/amule-remote-gui.cpp:1345 src/amule-remote-gui.cpp:1372
-#: src/DownloadQueue.cpp:1481 src/PrefsUnifiedDlg.cpp:1247
+#: src/DownloadQueue.cpp:1481 src/PrefsUnifiedDlg.cpp:1256
 msgid "ERROR"
 msgstr "ПОМИЛКА"
 
@@ -591,36 +591,36 @@ msgstr "Відвідайте https://github.com/amule-org/amule/releases/latest,
 msgid "FATAL ERROR: Failed to create Timer"
 msgstr "ЖАХЛИВА ПОМИЛКА: не вдалося створити Timer"
 
-#: src/amuleDlg.cpp:361 src/amuleDlg.cpp:1787 src/amuleDlg.cpp:2033
-#: src/muuli_wdr.cpp:1492 src/muuli_wdr.cpp:3449
+#: src/amuleDlg.cpp:361 src/amuleDlg.cpp:1810 src/amuleDlg.cpp:2056
+#: src/muuli_wdr.cpp:1492 src/muuli_wdr.cpp:3453
 msgid "Networks"
 msgstr "Мережі"
 
-#: src/amuleDlg.cpp:362 src/amuleDlg.cpp:1793 src/muuli_wdr.cpp:3450
+#: src/amuleDlg.cpp:362 src/amuleDlg.cpp:1816 src/muuli_wdr.cpp:3454
 msgid "Searches"
 msgstr "Пошук"
 
-#: src/amuleDlg.cpp:363 src/amuleDlg.cpp:1799 src/DownloadListCtrl.cpp:740
-#: src/muuli_wdr.cpp:392 src/muuli_wdr.cpp:1585 src/muuli_wdr.cpp:3451
+#: src/amuleDlg.cpp:363 src/amuleDlg.cpp:1822 src/DownloadListCtrl.cpp:740
+#: src/muuli_wdr.cpp:392 src/muuli_wdr.cpp:1585 src/muuli_wdr.cpp:3455
 #: src/Statistics.cpp:829
 msgid "Downloads"
 msgstr "Звантаження"
 
-#: src/amuleDlg.cpp:364 src/amuleDlg.cpp:1805 src/muuli_wdr.cpp:3325
+#: src/amuleDlg.cpp:364 src/amuleDlg.cpp:1828 src/muuli_wdr.cpp:3329
 msgid "Shared files"
 msgstr "Спільні файли"
 
-#: src/amuleDlg.cpp:365 src/amuleDlg.cpp:1811 src/muuli_wdr.cpp:2957
-#: src/muuli_wdr.cpp:3407 src/muuli_wdr.cpp:3454
+#: src/amuleDlg.cpp:365 src/amuleDlg.cpp:1834 src/muuli_wdr.cpp:2961
+#: src/muuli_wdr.cpp:3411 src/muuli_wdr.cpp:3458
 msgid "Messages"
 msgstr "Повідомлення"
 
-#: src/amuleDlg.cpp:366 src/amuleDlg.cpp:1817 src/muuli_wdr.cpp:3455
+#: src/amuleDlg.cpp:366 src/amuleDlg.cpp:1840 src/muuli_wdr.cpp:3459
 #: src/PrefsUnifiedDlg.cpp:314 src/Statistics.cpp:779 src/Statistics.cpp:1235
 msgid "Statistics"
 msgstr "Статистика"
 
-#: src/amuleDlg.cpp:368 src/amuleDlg.cpp:1824 src/muuli_wdr.cpp:3457
+#: src/amuleDlg.cpp:368 src/amuleDlg.cpp:1847 src/muuli_wdr.cpp:3461
 #: src/PrefsUnifiedDlg.cpp:330 src/utils/wxCas/src/wxcasprefs.cpp:39
 msgid "Preferences"
 msgstr "Налаштування"
@@ -679,8 +679,8 @@ msgstr "Kad: вимкнена"
 #: src/amuleDlg.cpp:1029 src/DownloadListCtrl.cpp:505
 #: src/DownloadListCtrl.cpp:749 src/FriendListCtrl.cpp:180
 #: src/muuli_wdr.cpp:731 src/muuli_wdr.cpp:782 src/muuli_wdr.cpp:846
-#: src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2262 src/muuli_wdr.cpp:2347
-#: src/muuli_wdr.cpp:3095 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
+#: src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2266 src/muuli_wdr.cpp:2351
+#: src/muuli_wdr.cpp:3099 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
 #: src/ServerListCtrl.cpp:606 src/TransferWnd.cpp:378
 #: src/utils/wxCas/src/wxcasprefs.cpp:235
 msgid "Cancel"
@@ -691,7 +691,7 @@ msgid "Stop the current connection attempts"
 msgstr "Зупинити поточні спроби з'єднань"
 
 #: src/amuleDlg.cpp:1035 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976
-#: src/muuli_wdr.cpp:2485
+#: src/muuli_wdr.cpp:2489
 msgid "Disconnect"
 msgstr "Від'єднатися"
 
@@ -700,7 +700,7 @@ msgid "Disconnect from the currently connected networks"
 msgstr "Від'єднатися від з'єднаних мереж"
 
 #: src/amuleDlg.cpp:1041 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979
-#: src/muuli_wdr.cpp:2640 src/muuli_wdr.cpp:3092 src/muuli_wdr.cpp:3447
+#: src/muuli_wdr.cpp:2644 src/muuli_wdr.cpp:3096 src/muuli_wdr.cpp:3451
 msgid "Connect"
 msgstr "З'єднатися"
 
@@ -755,7 +755,7 @@ msgstr "Підтвердження виходу"
 msgid "Launch Command: "
 msgstr "Команда для запуску: "
 
-#: src/amuleDlg.cpp:1632 src/muuli_wdr.cpp:1982 src/Preferences.cpp:979
+#: src/amuleDlg.cpp:1632 src/muuli_wdr.cpp:1986 src/Preferences.cpp:979
 msgid "- default -"
 msgstr "- за замовчуванням -"
 
@@ -769,61 +769,61 @@ msgstr "Тека з шкірами '%s' не існує"
 msgid "WARNING: Unable to open skin file '%s' for read"
 msgstr "ЗАСТЕРЕЖЕННЯ: Неможливо відкрити файл шкіри '%s' для читання"
 
-#: src/amuleDlg.cpp:1791 src/muuli_wdr.cpp:3449
+#: src/amuleDlg.cpp:1814 src/muuli_wdr.cpp:3453
 msgid "Networks Window"
 msgstr "Вікно мереж"
 
-#: src/amuleDlg.cpp:1797 src/muuli_wdr.cpp:3450
+#: src/amuleDlg.cpp:1820 src/muuli_wdr.cpp:3454
 msgid "Searches Window"
 msgstr "Вікно пошуку"
 
-#: src/amuleDlg.cpp:1803 src/muuli_wdr.cpp:3451
+#: src/amuleDlg.cpp:1826 src/muuli_wdr.cpp:3455
 #, fuzzy
 msgid "Downloads Window"
 msgstr "Звантажується"
 
-#: src/amuleDlg.cpp:1809 src/muuli_wdr.cpp:3453
+#: src/amuleDlg.cpp:1832 src/muuli_wdr.cpp:3457
 msgid "Shared Files Window"
 msgstr "Вікно спільних файлів"
 
-#: src/amuleDlg.cpp:1815 src/muuli_wdr.cpp:3454
+#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3458
 msgid "Messages Window"
 msgstr "Вікно повідомлень"
 
-#: src/amuleDlg.cpp:1821 src/muuli_wdr.cpp:3455
+#: src/amuleDlg.cpp:1844 src/muuli_wdr.cpp:3459
 msgid "Statistics Graph Window"
 msgstr "Вікно статистики"
 
-#: src/amuleDlg.cpp:1828 src/muuli_wdr.cpp:3457
+#: src/amuleDlg.cpp:1851 src/muuli_wdr.cpp:3461
 msgid "Preferences Settings Window"
 msgstr "Вікно налаштувань"
 
-#: src/amuleDlg.cpp:1831 src/muuli_wdr.cpp:3458
+#: src/amuleDlg.cpp:1854 src/muuli_wdr.cpp:3462
 msgid "Import"
 msgstr "Зовн. внесення"
 
-#: src/amuleDlg.cpp:1835 src/muuli_wdr.cpp:3458
+#: src/amuleDlg.cpp:1858 src/muuli_wdr.cpp:3462
 msgid "The partfile importer tool"
 msgstr "Засіб зовнішнього внесення частково звантажених файлів"
 
-#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3459
+#: src/amuleDlg.cpp:1861 src/muuli_wdr.cpp:3463
 #: src/utils/aLinkCreator/src/alcframe.cpp:262
 msgid "About"
 msgstr "Про програму"
 
-#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3459
+#: src/amuleDlg.cpp:1861 src/muuli_wdr.cpp:3463
 msgid "About/Help"
 msgstr "Про/Допомога"
 
-#: src/amuleDlg.cpp:2036
+#: src/amuleDlg.cpp:2059
 msgid "eD2k network"
 msgstr "Мережа eD2k"
 
-#: src/amuleDlg.cpp:2039
+#: src/amuleDlg.cpp:2062
 msgid "Kad network"
 msgstr "Мережа Kad"
 
-#: src/amuleDlg.cpp:2039
+#: src/amuleDlg.cpp:2062
 msgid "No network"
 msgstr "Немає мережі"
 
@@ -1365,19 +1365,19 @@ msgstr "Авто [висока]"
 msgid "Very low"
 msgstr "Дуже низька"
 
-#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:743 src/muuli_wdr.cpp:2313
+#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:743 src/muuli_wdr.cpp:2317
 #: src/ServerListCtrl.cpp:263 src/ServerListCtrl.cpp:456
 #: src/SharedFilesCtrl.cpp:145
 msgid "Low"
 msgstr "Низька"
 
-#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:744 src/muuli_wdr.cpp:2314
+#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:744 src/muuli_wdr.cpp:2318
 #: src/ServerListCtrl.cpp:266 src/ServerListCtrl.cpp:457
 #: src/SharedFilesCtrl.cpp:146
 msgid "Normal"
 msgstr "Звичайна"
 
-#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:745 src/muuli_wdr.cpp:2315
+#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:745 src/muuli_wdr.cpp:2319
 #: src/ServerListCtrl.cpp:269 src/ServerListCtrl.cpp:458
 #: src/SharedFilesCtrl.cpp:147
 msgid "High"
@@ -1470,7 +1470,7 @@ msgstr "Місцевий сервер"
 msgid "Remote Server"
 msgstr "Віддалений сервер"
 
-#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3212
+#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3216
 #: src/SearchDlg.cpp:119 src/TextClient.cpp:911
 msgid "Kad"
 msgstr "Kad"
@@ -1542,7 +1542,7 @@ msgstr "Частина"
 msgid "Size"
 msgstr "Розмір"
 
-#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3279
+#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3283
 msgid "Transferred"
 msgstr "Переданих"
 
@@ -1600,7 +1600,7 @@ msgstr ""
 "Відгук від: %s (%s)\n"
 "\n"
 
-#: src/DownloadListCtrl.cpp:746 src/muuli_wdr.cpp:2316
+#: src/DownloadListCtrl.cpp:746 src/muuli_wdr.cpp:2320
 #: src/SharedFilesCtrl.cpp:150
 msgid "Auto"
 msgstr "Автоматично"
@@ -1638,7 +1638,7 @@ msgid "Extended Options"
 msgstr "Розширені налаштування"
 
 #: src/DownloadListCtrl.cpp:770 src/DownloadListCtrl.cpp:822
-#: src/muuli_wdr.cpp:1800
+#: src/muuli_wdr.cpp:1804
 msgid "Preview"
 msgstr "Попередній перегляд"
 
@@ -2445,23 +2445,23 @@ msgid ""
 "want downloads on a different (e.g. larger) disk."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:549 src/FirstRunWizard.cpp:611 src/muuli_wdr.cpp:1712
+#: src/FirstRunWizard.cpp:549 src/FirstRunWizard.cpp:611 src/muuli_wdr.cpp:1716
 msgid "Destination folder for downloads"
 msgstr "Тека призначення для звантажень"
 
 #: src/FirstRunWizard.cpp:553 src/FirstRunWizard.cpp:569 src/muuli_wdr.cpp:1349
-#: src/muuli_wdr.cpp:1366 src/muuli_wdr.cpp:1687 src/muuli_wdr.cpp:1718
-#: src/muuli_wdr.cpp:1730 src/muuli_wdr.cpp:2800
+#: src/muuli_wdr.cpp:1366 src/muuli_wdr.cpp:1691 src/muuli_wdr.cpp:1722
+#: src/muuli_wdr.cpp:1734 src/muuli_wdr.cpp:2804
 #: src/utils/aLinkCreator/src/alcframe.cpp:135
 #: src/utils/wxCas/src/wxcasprefs.cpp:52 src/utils/wxCas/src/wxcasprefs.cpp:118
 msgid "Browse"
 msgstr "Переглянути"
 
-#: src/FirstRunWizard.cpp:559 src/muuli_wdr.cpp:1723
+#: src/FirstRunWizard.cpp:559 src/muuli_wdr.cpp:1727
 msgid "(All files in this folder are shared with other peers)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:565 src/FirstRunWizard.cpp:624 src/muuli_wdr.cpp:1725
+#: src/FirstRunWizard.cpp:565 src/FirstRunWizard.cpp:624 src/muuli_wdr.cpp:1729
 msgid "Folder for temporary download files"
 msgstr "Тека для тимчасових звантажуваних файлів"
 
@@ -2492,7 +2492,7 @@ msgstr "Неможливо відкрити перелік друзів 'emfrien
 msgid "CRITICAL - no client on StartChatSession"
 msgstr "КРИТИЧНО - немає клієнта на StartChatSession"
 
-#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2706 src/muuli_wdr.cpp:3383
+#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2710 src/muuli_wdr.cpp:3387
 msgid "Friends"
 msgstr "Друзі"
 
@@ -2606,8 +2606,8 @@ msgstr "Жоден"
 msgid "No"
 msgstr "Ні"
 
-#: src/GenericClientListCtrl.cpp:1216 src/PrefsUnifiedDlg.cpp:2898
-#: src/PrefsUnifiedDlg.cpp:2948 src/ServerListCtrl.cpp:276
+#: src/GenericClientListCtrl.cpp:1216 src/PrefsUnifiedDlg.cpp:2907
+#: src/PrefsUnifiedDlg.cpp:2957 src/ServerListCtrl.cpp:276
 msgid "Yes"
 msgstr "Так"
 
@@ -2779,10 +2779,10 @@ msgstr "Недопустимий порт для початкового запу
 msgid "Please fill all fields required"
 msgstr "Будь ласка, заповніть потрібні поля"
 
-#: src/KadDlg.cpp:192 src/PartFile.cpp:1031 src/PrefsUnifiedDlg.cpp:1134
-#: src/PrefsUnifiedDlg.cpp:1204 src/PrefsUnifiedDlg.cpp:1405
-#: src/PrefsUnifiedDlg.cpp:1663 src/PrefsUnifiedDlg.cpp:1673
-#: src/PrefsUnifiedDlg.cpp:1690 src/PrefsUnifiedDlg.cpp:1738
+#: src/KadDlg.cpp:192 src/PartFile.cpp:1031 src/PrefsUnifiedDlg.cpp:1143
+#: src/PrefsUnifiedDlg.cpp:1213 src/PrefsUnifiedDlg.cpp:1414
+#: src/PrefsUnifiedDlg.cpp:1672 src/PrefsUnifiedDlg.cpp:1682
+#: src/PrefsUnifiedDlg.cpp:1699 src/PrefsUnifiedDlg.cpp:1747
 msgid "Message"
 msgstr "Повідомлення"
 
@@ -2887,7 +2887,7 @@ msgstr "Відношення передачі"
 msgid "Uploaded"
 msgstr "Вивантажено"
 
-#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3263
+#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3267
 msgid "Requested"
 msgstr "Запитано"
 
@@ -3014,7 +3014,7 @@ msgid "WARNING: "
 msgstr "ЗАСТЕРЕЖЕННЯ: "
 
 #: src/MuleNotebook.cpp:179 src/muuli_wdr.cpp:817 src/muuli_wdr.cpp:1229
-#: src/muuli_wdr.cpp:3167 src/muuli_wdr.cpp:3423
+#: src/muuli_wdr.cpp:3171 src/muuli_wdr.cpp:3427
 msgid "Close"
 msgstr "Закрити"
 
@@ -3032,7 +3032,7 @@ msgid "Paste"
 msgstr "Вставити"
 
 #: src/MuleTextCtrl.cpp:89 src/muuli_wdr.cpp:358 src/muuli_wdr.cpp:757
-#: src/muuli_wdr.cpp:2390 src/muuli_wdr.cpp:2409 src/muuli_wdr.cpp:2431
+#: src/muuli_wdr.cpp:2394 src/muuli_wdr.cpp:2413 src/muuli_wdr.cpp:2435
 #: src/utils/aLinkCreator/src/alcframe.cpp:142
 msgid "Clear"
 msgstr "Очистити"
@@ -3131,7 +3131,7 @@ msgstr "Вийти"
 
 #: src/MuleTrayIcon.cpp:579 src/MuleTrayIcon.cpp:945 src/MuleTrayIcon.cpp:965
 #: src/muuli_wdr.cpp:1398 src/muuli_wdr.cpp:1406 src/muuli_wdr.cpp:1413
-#: src/muuli_wdr.cpp:1846 src/muuli_wdr.cpp:1852 src/OtherFunctions.cpp:91
+#: src/muuli_wdr.cpp:1850 src/muuli_wdr.cpp:1856 src/OtherFunctions.cpp:91
 #: src/StatisticsDlg.cpp:93 src/StatisticsDlg.cpp:95
 msgid "kB/s"
 msgstr "кбайт/с"
@@ -3373,7 +3373,7 @@ msgstr "байт"
 msgid "KB"
 msgstr "кбайт"
 
-#: src/muuli_wdr.cpp:274 src/muuli_wdr.cpp:293 src/muuli_wdr.cpp:1631
+#: src/muuli_wdr.cpp:274 src/muuli_wdr.cpp:293 src/muuli_wdr.cpp:1635
 #: src/OtherFunctions.cpp:64
 msgid "MB"
 msgstr "Мбайт"
@@ -3390,7 +3390,7 @@ msgstr "Найбільший розмір"
 msgid "Availability"
 msgstr "Доступність"
 
-#: src/muuli_wdr.cpp:312 src/muuli_wdr.cpp:398 src/muuli_wdr.cpp:3328
+#: src/muuli_wdr.cpp:312 src/muuli_wdr.cpp:398 src/muuli_wdr.cpp:3332
 msgid "Filter:"
 msgstr "Фільтр:"
 
@@ -3454,8 +3454,8 @@ msgstr "Завершених джерел"
 #: src/muuli_wdr.cpp:1160 src/muuli_wdr.cpp:1167 src/muuli_wdr.cpp:1172
 #: src/muuli_wdr.cpp:1179 src/muuli_wdr.cpp:1184 src/muuli_wdr.cpp:1191
 #: src/muuli_wdr.cpp:1205 src/muuli_wdr.cpp:1212 src/muuli_wdr.cpp:1217
-#: src/muuli_wdr.cpp:1224 src/muuli_wdr.cpp:3265 src/muuli_wdr.cpp:3273
-#: src/muuli_wdr.cpp:3281
+#: src/muuli_wdr.cpp:1224 src/muuli_wdr.cpp:3269 src/muuli_wdr.cpp:3277
+#: src/muuli_wdr.cpp:3285
 msgid "N/A"
 msgstr "недоступні"
 
@@ -3600,7 +3600,7 @@ msgstr ""
 msgid "Album :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:685 src/muuli_wdr.cpp:2285
+#: src/muuli_wdr.cpp:685 src/muuli_wdr.cpp:2289
 msgid "Title :"
 msgstr "Назва:"
 
@@ -3709,7 +3709,7 @@ msgstr "Ім'я користувача:"
 msgid "Userhash :"
 msgstr "Хеш користувача:"
 
-#: src/muuli_wdr.cpp:895 src/muuli_wdr.cpp:1752 src/muuli_wdr.cpp:2480
+#: src/muuli_wdr.cpp:895 src/muuli_wdr.cpp:1756 src/muuli_wdr.cpp:2484
 #: src/utils/aLinkCreator/src/alcframe.cpp:137
 msgid "Add"
 msgstr "Додати"
@@ -3718,15 +3718,15 @@ msgstr "Додати"
 msgid "Download-Speed"
 msgstr "Швидкість звантаження"
 
-#: src/muuli_wdr.cpp:954 src/muuli_wdr.cpp:989 src/muuli_wdr.cpp:2584
+#: src/muuli_wdr.cpp:954 src/muuli_wdr.cpp:989 src/muuli_wdr.cpp:2588
 msgid "Current"
 msgstr "Поточна"
 
-#: src/muuli_wdr.cpp:962 src/muuli_wdr.cpp:997 src/muuli_wdr.cpp:2592
+#: src/muuli_wdr.cpp:962 src/muuli_wdr.cpp:997 src/muuli_wdr.cpp:2596
 msgid "Running average"
 msgstr "Середня"
 
-#: src/muuli_wdr.cpp:970 src/muuli_wdr.cpp:1005 src/muuli_wdr.cpp:2600
+#: src/muuli_wdr.cpp:970 src/muuli_wdr.cpp:1005 src/muuli_wdr.cpp:2604
 msgid "Session average"
 msgstr "Середня за сесію"
 
@@ -3738,7 +3738,7 @@ msgstr "Швидкість вивантаження"
 msgid "Connections"
 msgstr "З'єднання"
 
-#: src/muuli_wdr.cpp:1024 src/muuli_wdr.cpp:1871
+#: src/muuli_wdr.cpp:1024 src/muuli_wdr.cpp:1875
 msgid "Active downloads"
 msgstr "Чинні звантаження"
 
@@ -3746,7 +3746,7 @@ msgstr "Чинні звантаження"
 msgid "Active connections (1:1)"
 msgstr "Чинні з'єднання (1:1)"
 
-#: src/muuli_wdr.cpp:1040 src/muuli_wdr.cpp:1872
+#: src/muuli_wdr.cpp:1040 src/muuli_wdr.cpp:1876
 msgid "Active uploads"
 msgstr "Чинні вивантаження"
 
@@ -4023,7 +4023,7 @@ msgstr "Використовувати IP-адресу (пусто для буд
 msgid "Advanced users only: If you have multiple network interfaces, enter the address of the interface to which aMule should be bound."
 msgstr "Тільки досвідченим користувачам: якщо ви маєте багато мережевих інтерфейсів, введіть адресу інтерфейсу до якого слід прив'язатися aMule."
 
-#: src/muuli_wdr.cpp:1462 src/muuli_wdr.cpp:2065
+#: src/muuli_wdr.cpp:1462 src/muuli_wdr.cpp:2069
 #, fuzzy
 msgid "Bind to network interface (empty for any):"
 msgstr "Використовувати IP-адресу (пусто для будь-якої):"
@@ -4040,7 +4040,7 @@ msgstr "Найбільше джерел на звантажуваний файл
 msgid "Max simultaneous connections:"
 msgstr "Найбільше одночасних з'єднань:"
 
-#: src/muuli_wdr.cpp:1498 src/muuli_wdr.cpp:3207
+#: src/muuli_wdr.cpp:1498 src/muuli_wdr.cpp:3211
 msgid "ED2K"
 msgstr "eD2k"
 
@@ -4132,783 +4132,783 @@ msgstr "Попереднє виділення місця на диску для 
 msgid "For new files preallocates disk space for the whole file, thus reduces fragmentation"
 msgstr "Повністю виділяти місце для всього нового файлу, це зменшить фрагментування"
 
-#: src/muuli_wdr.cpp:1617
+#: src/muuli_wdr.cpp:1621
 msgid "Create new files as sparse files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1618
+#: src/muuli_wdr.cpp:1622
 msgid "Sparse part files only occupy disk space for the parts already downloaded, so free space is used up gradually as the file fills in. Turn this off to use an ordinary file instead - useful where sparse files are unsupported or slow, or where backup/de-duplication tools handle them badly. Applies only when the core runs on Windows; on Linux and macOS part files are sparse anyway and this setting has no effect."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1623
+#: src/muuli_wdr.cpp:1627
 msgid "Stop downloads when free disk space reaches "
 msgstr "Припинити звантаження коли вільне місце на диску досягнуло "
 
-#: src/muuli_wdr.cpp:1624
+#: src/muuli_wdr.cpp:1628
 msgid "Select this if you want aMule to check your disk space"
 msgstr "Виберіть це якщо хочете, щоб aMule перевіряв ваше місце на диску"
 
-#: src/muuli_wdr.cpp:1628
+#: src/muuli_wdr.cpp:1632
 msgid "Enter here the min disk space desired."
 msgstr "Введіть найменше бажане місце на диску"
 
-#: src/muuli_wdr.cpp:1634
+#: src/muuli_wdr.cpp:1638
 msgid "Save 10 sources on rare files (< 20 sources)"
 msgstr "Зберегти 10 джерел рідкісних файлів (менше ніж 20 джерел)"
 
-#: src/muuli_wdr.cpp:1638 src/Statistics.cpp:790
+#: src/muuli_wdr.cpp:1642 src/Statistics.cpp:790
 msgid "Uploads"
 msgstr "Вивантаження"
 
-#: src/muuli_wdr.cpp:1641
+#: src/muuli_wdr.cpp:1645
 msgid "Add new shared files with auto priority"
 msgstr "Додати нові спільні файли з автоматичною перевагою"
 
-#: src/muuli_wdr.cpp:1647
+#: src/muuli_wdr.cpp:1651
 msgid "Intelligent Corruption Handling (I.C.H.)"
 msgstr "Розумна обробка пошкоджень (Р.О.П.)"
 
-#: src/muuli_wdr.cpp:1650
+#: src/muuli_wdr.cpp:1654
 msgid "Enable"
 msgstr "Ввімкнено"
 
-#: src/muuli_wdr.cpp:1653
+#: src/muuli_wdr.cpp:1657
 msgid "Advanced I.C.H. trusts every hash (not recommended)"
 msgstr "Вдосконалена Р.О.П. довіряє всім хешам (не радимо)"
 
-#: src/muuli_wdr.cpp:1665 src/PrefsUnifiedDlg.cpp:1990
+#: src/muuli_wdr.cpp:1669 src/PrefsUnifiedDlg.cpp:1999
 msgid "Media metadata extraction"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1669
+#: src/muuli_wdr.cpp:1673
 msgid "Extract length / bitrate / codec from shared audio and video files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1671
+#: src/muuli_wdr.cpp:1675
 msgid "When enabled, aMule runs ffprobe on each shared media file to fill in the Length / Bitrate / Codec columns other clients see when they find the file in a search. Requires ffmpeg (the ffprobe binary) to be installed."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1678
+#: src/muuli_wdr.cpp:1682
 msgid "Path to ffprobe:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1683
+#: src/muuli_wdr.cpp:1687
 msgid "Full path to the ffprobe binary. Leave empty to have aMule auto-detect it on startup."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1691
+#: src/muuli_wdr.cpp:1695
 msgid "Detect"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1692
+#: src/muuli_wdr.cpp:1696
 msgid "Search the standard install locations for an ffprobe binary and fill the path field."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1716
+#: src/muuli_wdr.cpp:1720
 msgid ""
 "Completed downloads are stored here. All files in this folder are automatically shared with other peers.\n"
 "If this folder also holds files you don't want to share, point it at an aMule-only sub-folder."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1719
+#: src/muuli_wdr.cpp:1723
 msgid "Pick the folder where completed downloads will be stored. All files in that folder will be shared with other peers."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1733
+#: src/muuli_wdr.cpp:1737
 msgid "Shared folders"
 msgstr "Спільні теки"
 
-#: src/muuli_wdr.cpp:1739
+#: src/muuli_wdr.cpp:1743
 msgid "(Folders shared by the core. Enter a path to add one.)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1747
+#: src/muuli_wdr.cpp:1751
 msgid "Absolute path of a folder on the core's machine, e.g. /home/user/shared"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1749 src/PrefsUnifiedDlg.cpp:2874
+#: src/muuli_wdr.cpp:1753 src/PrefsUnifiedDlg.cpp:2883
 msgid "Recursive"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1750
+#: src/muuli_wdr.cpp:1754
 msgid "Share every sub-folder underneath this one, including ones created later."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1754 src/utils/aLinkCreator/src/alcframe.cpp:141
+#: src/muuli_wdr.cpp:1758 src/utils/aLinkCreator/src/alcframe.cpp:141
 msgid "Remove"
 msgstr "Вилучити"
 
-#: src/muuli_wdr.cpp:1758
+#: src/muuli_wdr.cpp:1762
 msgid "(Right click on folder icon for recursive share)"
 msgstr "(Праве клацання по значку теки для рекурсивного додавання)"
 
-#: src/muuli_wdr.cpp:1765
+#: src/muuli_wdr.cpp:1769
 msgid "Share hidden files"
 msgstr "Робити спільними приховані файли"
 
-#: src/muuli_wdr.cpp:1771
+#: src/muuli_wdr.cpp:1775
 msgid "Automatically rescan shared folders for changes"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1777
+#: src/muuli_wdr.cpp:1781
 msgid "Follow symbolic links in shared folders"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1783
+#: src/muuli_wdr.cpp:1787
 msgid "Exclude files matching:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1786
+#: src/muuli_wdr.cpp:1790
 msgid "Wildcard patterns separated by '|', e.g. .DS_Store|Thumbs.db|*.tmp. Files whose name matches are not shared. Matching is case-insensitive."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1790
+#: src/muuli_wdr.cpp:1794
 msgid "Patterns are regular expressions"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1791
+#: src/muuli_wdr.cpp:1795
 msgid "When set, the whole field is one regular expression ('|' is alternation). When unset, it is a list of '|'-separated wildcards."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1801
+#: src/muuli_wdr.cpp:1805
 msgid "Show how many shared files the current pattern would exclude."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1822
+#: src/muuli_wdr.cpp:1826
 msgid "Graphs"
 msgstr "Графіки"
 
-#: src/muuli_wdr.cpp:1825 src/muuli_wdr.cpp:1887
+#: src/muuli_wdr.cpp:1829 src/muuli_wdr.cpp:1891
 msgid "Update delay : 5 secs"
 msgstr "Час оновлення: 5 с"
 
-#: src/muuli_wdr.cpp:1829
+#: src/muuli_wdr.cpp:1833
 msgid "Time for average graph: 100 mins"
 msgstr "Час для середніх графіків: 100 хв"
 
-#: src/muuli_wdr.cpp:1833
+#: src/muuli_wdr.cpp:1837
 msgid "Connections Graph Scale: 100 "
 msgstr "Шкала графіку з'єднань: 100"
 
-#: src/muuli_wdr.cpp:1840
+#: src/muuli_wdr.cpp:1844
 msgid "Download graph scale:"
 msgstr "Шкала графіку звантаження"
 
-#: src/muuli_wdr.cpp:1848
+#: src/muuli_wdr.cpp:1852
 msgid "Upload graph scale:"
 msgstr "Шкала графіку вивантаження"
 
-#: src/muuli_wdr.cpp:1858
+#: src/muuli_wdr.cpp:1862
 #, fuzzy
 msgid "Colors: "
 msgstr "Кольори: "
 
-#: src/muuli_wdr.cpp:1862
+#: src/muuli_wdr.cpp:1866
 msgid "Background"
 msgstr "Фон"
 
-#: src/muuli_wdr.cpp:1863
+#: src/muuli_wdr.cpp:1867
 msgid "Grid"
 msgstr "Сітка"
 
-#: src/muuli_wdr.cpp:1864
+#: src/muuli_wdr.cpp:1868
 msgid "Download current"
 msgstr "Звантаження зараз"
 
-#: src/muuli_wdr.cpp:1865
+#: src/muuli_wdr.cpp:1869
 msgid "Download running average"
 msgstr "Звантаження середні за роботу"
 
-#: src/muuli_wdr.cpp:1866
+#: src/muuli_wdr.cpp:1870
 msgid "Download session average"
 msgstr "Звантаження середні за сесію"
 
-#: src/muuli_wdr.cpp:1867
+#: src/muuli_wdr.cpp:1871
 msgid "Upload current"
 msgstr "Вивантаження поточні"
 
-#: src/muuli_wdr.cpp:1868
+#: src/muuli_wdr.cpp:1872
 msgid "Upload running average"
 msgstr "Вивантаження середні за роботу"
 
-#: src/muuli_wdr.cpp:1869
+#: src/muuli_wdr.cpp:1873
 msgid "Upload session average"
 msgstr "Вивантаження середні за сесію"
 
-#: src/muuli_wdr.cpp:1870
+#: src/muuli_wdr.cpp:1874
 msgid "Active connections"
 msgstr "Чинні з'єднання"
 
-#: src/muuli_wdr.cpp:1873
+#: src/muuli_wdr.cpp:1877
 #, fuzzy
 msgid "Systray Icon Speed Bar"
 msgstr "Показувати стовпчик швидкості в системному лотку"
 
-#: src/muuli_wdr.cpp:1874
+#: src/muuli_wdr.cpp:1878
 msgid "Kad-nodes current"
 msgstr "Вузлів Kad зараз"
 
-#: src/muuli_wdr.cpp:1875
+#: src/muuli_wdr.cpp:1879
 msgid "Kad-nodes running"
 msgstr "Вузлів Kad запущено"
 
-#: src/muuli_wdr.cpp:1876
+#: src/muuli_wdr.cpp:1880
 msgid "Kad-nodes session"
 msgstr "Вузлів Kad за сесію"
 
-#: src/muuli_wdr.cpp:1880 src/muuli_wdr.cpp:2334
+#: src/muuli_wdr.cpp:1884 src/muuli_wdr.cpp:2338
 msgid "Select"
 msgstr "Вибрати"
 
-#: src/muuli_wdr.cpp:1884
+#: src/muuli_wdr.cpp:1888
 msgid "Tree"
 msgstr "Дерево"
 
-#: src/muuli_wdr.cpp:1894
+#: src/muuli_wdr.cpp:1898
 msgid "Number of Client Versions shown (0=unlimited)"
 msgstr "Кількість відображуваних версій клієнтів (0=необмежено)"
 
-#: src/muuli_wdr.cpp:1919
+#: src/muuli_wdr.cpp:1923
 msgid "!!! WARNING !!!"
 msgstr "!!! ЗАСТЕРЕЖЕННЯ !!!"
 
-#: src/muuli_wdr.cpp:1934
+#: src/muuli_wdr.cpp:1938
 msgid "Max new connections / 5 secs"
 msgstr "Найбільше зовнішніх з'єднань за 5 с"
 
-#: src/muuli_wdr.cpp:1936
+#: src/muuli_wdr.cpp:1940
 msgid "Concurrent Kad source lookups"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1938
+#: src/muuli_wdr.cpp:1942
 #, fuzzy
 msgid "Kad source re-search interval (minutes)"
 msgstr "Час оновлення FTP в хвилинах"
 
-#: src/muuli_wdr.cpp:1940
+#: src/muuli_wdr.cpp:1944
 #, fuzzy
 msgid "Source re-ask interval (minutes)"
 msgstr "Час оновлення FTP в хвилинах"
 
-#: src/muuli_wdr.cpp:1944
+#: src/muuli_wdr.cpp:1948
 msgid "File Buffer Size: 240000 bytes"
 msgstr "Розмір файлу буфера: 240000 байт"
 
-#: src/muuli_wdr.cpp:1948
+#: src/muuli_wdr.cpp:1952
 msgid "Use MMAP: memory-mapped file access (lower memory use)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1949
+#: src/muuli_wdr.cpp:1953
 msgid "Maps part files into memory instead of buffering them on the heap, lowering the process memory footprint. May reduce download speed on some disks; best for memory-constrained or upload-heavy hosts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1951
+#: src/muuli_wdr.cpp:1955
 msgid "Upload Queue Size: 5000 clients"
 msgstr "Розмір черги вивантаження: 5000 клієнтів"
 
-#: src/muuli_wdr.cpp:1955
+#: src/muuli_wdr.cpp:1959
 msgid "Server connection refresh interval: Disable"
 msgstr "Час оновлення з'єднання з сервером: вимкнено"
 
-#: src/muuli_wdr.cpp:1959
+#: src/muuli_wdr.cpp:1963
 msgid "Disable computer's timed standby mode"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1978
+#: src/muuli_wdr.cpp:1982
 msgid "Skin to use: "
 msgstr "Використати шкіру: "
 
-#: src/muuli_wdr.cpp:1987
+#: src/muuli_wdr.cpp:1991
 msgid "Show \"Fast eD2k Links Handler\" in every window."
 msgstr "Показати \"Швидкий оброблювач eD2k-посилань\" в кожному вікні."
 
-#: src/muuli_wdr.cpp:1990
+#: src/muuli_wdr.cpp:1994
 msgid "Show extended info on categories tabs"
 msgstr "Показати розширену інформацію на вкладках категорій"
 
-#: src/muuli_wdr.cpp:1993
+#: src/muuli_wdr.cpp:1997
 #, fuzzy
 msgid "Show application version on title"
 msgstr "Показувати швидкість передавання в заголовку"
 
-#: src/muuli_wdr.cpp:1995
+#: src/muuli_wdr.cpp:1999
 msgid "Show transfer rates on title"
 msgstr "Показувати швидкість передавання в заголовку"
 
-#: src/muuli_wdr.cpp:1997
+#: src/muuli_wdr.cpp:2001
 msgid "Before application name"
 msgstr "Перед назвою програми"
 
-#: src/muuli_wdr.cpp:1999
+#: src/muuli_wdr.cpp:2003
 msgid "After application name"
 msgstr "Після назви програми"
 
-#: src/muuli_wdr.cpp:2002
+#: src/muuli_wdr.cpp:2006
 msgid "Show overhead bandwidth"
 msgstr "Показати ширину смуги службового трафіку"
 
-#: src/muuli_wdr.cpp:2006
+#: src/muuli_wdr.cpp:2010
 msgid "Vertical toolbar orientation"
 msgstr "Вертикальне розміщення панелі інструментів"
 
-#: src/muuli_wdr.cpp:2008
+#: src/muuli_wdr.cpp:2012
 msgid "Live column sorting (auto-reorder rows as their values change)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2015
+#: src/muuli_wdr.cpp:2019
 msgid "Download Queue Files"
 msgstr "Звантажити файли в черзі"
 
-#: src/muuli_wdr.cpp:2018
+#: src/muuli_wdr.cpp:2022
 msgid "Show progress percentage"
 msgstr "Показувати поступ у відсотках"
 
-#: src/muuli_wdr.cpp:2024
+#: src/muuli_wdr.cpp:2028
 msgid "Show progress bar"
 msgstr "Показувати панель поступу"
 
-#: src/muuli_wdr.cpp:2027
+#: src/muuli_wdr.cpp:2031
 msgid "Flat"
 msgstr "Плаский"
 
-#: src/muuli_wdr.cpp:2031
+#: src/muuli_wdr.cpp:2035
 msgid "Round"
 msgstr "Круглий"
 
-#: src/muuli_wdr.cpp:2049
+#: src/muuli_wdr.cpp:2053
 msgid "External Connection Parameters"
 msgstr "Параметри зовнішніх з'єднань"
 
-#: src/muuli_wdr.cpp:2052
+#: src/muuli_wdr.cpp:2056
 msgid "Accept external connections"
 msgstr "Дозволити зовнішні з'єднання"
 
-#: src/muuli_wdr.cpp:2059 src/muuli_wdr.cpp:2118
+#: src/muuli_wdr.cpp:2063 src/muuli_wdr.cpp:2122
 msgid "IP of the listening interface:"
 msgstr "IP-адреса інтерфейса:"
 
-#: src/muuli_wdr.cpp:2062
+#: src/muuli_wdr.cpp:2066
 msgid "Enter here a valid ip in the a.b.c.d format for the listening EC interface. An empty field or 0.0.0.0 will mean any interface."
 msgstr "Введіть IP-адресу в вірному форматі a.b.c.d для прослуховування EC-інтерфейсу. Порожнє поле або 0.0.0.0 означатиме всі."
 
-#: src/muuli_wdr.cpp:2083 src/muuli_wdr.cpp:2194
+#: src/muuli_wdr.cpp:2087 src/muuli_wdr.cpp:2198
 msgid "TCP port:"
 msgstr "Порт TCP:"
 
-#: src/muuli_wdr.cpp:2089
+#: src/muuli_wdr.cpp:2093
 msgid "Enable UPnP port forwarding on the EC port"
 msgstr "Ввімкнути UPnP перенаправлення для EC-порту"
 
-#: src/muuli_wdr.cpp:2093 src/muuli_wdr.cpp:3079
+#: src/muuli_wdr.cpp:2097 src/muuli_wdr.cpp:3083
 #: src/utils/wxCas/src/wxcasprefs.cpp:167
 msgid "Password"
 msgstr "Пароль"
 
-#: src/muuli_wdr.cpp:2099
+#: src/muuli_wdr.cpp:2103
 #, fuzzy
 msgid "aMule API server parameters"
 msgstr "Налаштування веб-сервера"
 
-#: src/muuli_wdr.cpp:2102
+#: src/muuli_wdr.cpp:2106
 msgid "Run amuleapi (REST API) on startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2107
+#: src/muuli_wdr.cpp:2111
 #, fuzzy
 msgid "HTTP port:"
 msgstr "Порт TCP:"
 
-#: src/muuli_wdr.cpp:2121
+#: src/muuli_wdr.cpp:2125
 msgid "The interface amuleapi's HTTP server listens on. 127.0.0.1 (default) accepts only local connections; use 0.0.0.0 or a specific IP to expose it to other hosts (set an admin password below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2126
+#: src/muuli_wdr.cpp:2130
 msgid "Type a password to set or change it. Stored passwords cannot be shown, so leaving this empty keeps the current one."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2128
+#: src/muuli_wdr.cpp:2132
 #, fuzzy
 msgid "Admin password"
 msgstr "Перевіряється пароль\n"
 
-#: src/muuli_wdr.cpp:2140 src/muuli_wdr.cpp:2157 src/PrefsUnifiedDlg.cpp:1103
+#: src/muuli_wdr.cpp:2144 src/muuli_wdr.cpp:2161 src/PrefsUnifiedDlg.cpp:1112
 #, fuzzy
 msgid "A password is set."
 msgstr "Перевіряється пароль\n"
 
-#: src/muuli_wdr.cpp:2144
+#: src/muuli_wdr.cpp:2148
 #, fuzzy
 msgid "Enable guest access"
 msgstr "Заборонити гостьовий доступ"
 
-#: src/muuli_wdr.cpp:2145
+#: src/muuli_wdr.cpp:2149
 msgid "Guest sessions may read status and listings but cannot change anything. Turning this off clears the stored guest password."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2149
+#: src/muuli_wdr.cpp:2153
 #, fuzzy
 msgid "Guest password"
 msgstr "Пароль гостя веб-сервера"
 
-#: src/muuli_wdr.cpp:2164
+#: src/muuli_wdr.cpp:2168
 msgid "Web server parameters"
 msgstr "Налаштування веб-сервера"
 
-#: src/muuli_wdr.cpp:2167
+#: src/muuli_wdr.cpp:2171
 #, fuzzy
 msgid "Run webserver on startup (deprecated)"
 msgstr "Запустити веб-сервер під час запуску"
 
-#: src/muuli_wdr.cpp:2173
+#: src/muuli_wdr.cpp:2177
 msgid "Web template"
 msgstr "Веб шаблон"
 
-#: src/muuli_wdr.cpp:2178
+#: src/muuli_wdr.cpp:2182
 msgid "Full rights password"
 msgstr "Пароль повних прав"
 
-#: src/muuli_wdr.cpp:2182
+#: src/muuli_wdr.cpp:2186
 msgid "Enable Low rights User"
 msgstr "Ввімкнути користувача з низькими правами"
 
-#: src/muuli_wdr.cpp:2187
+#: src/muuli_wdr.cpp:2191
 msgid "Low rights password"
 msgstr "Пароль низьких прав"
 
-#: src/muuli_wdr.cpp:2201
+#: src/muuli_wdr.cpp:2205
 msgid "Enable UPnP port forwarding of the web server port"
 msgstr "Ввімкнути UPnP перенаправлення портів для порту веб-сервера"
 
-#: src/muuli_wdr.cpp:2206
+#: src/muuli_wdr.cpp:2210
 msgid "Web server UPnP TCP port (Optional)"
 msgstr "UPnP TCP-порт веб-сервера (не обов'язково)"
 
-#: src/muuli_wdr.cpp:2214
+#: src/muuli_wdr.cpp:2218
 msgid "Page Refresh Time (in secs)"
 msgstr "Час оновлення сторінки (с)"
 
-#: src/muuli_wdr.cpp:2221
+#: src/muuli_wdr.cpp:2225
 msgid "Enable Gzip compression"
 msgstr "Дозволити Gzip-стиснення"
 
-#: src/muuli_wdr.cpp:2255
+#: src/muuli_wdr.cpp:2259
 #, fuzzy
 msgid "Reset page to defaults"
 msgstr "Мова системи"
 
-#: src/muuli_wdr.cpp:2256
+#: src/muuli_wdr.cpp:2260
 msgid "Reset the settings on the current page to their default values."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2258 src/muuli_wdr.cpp:2344 src/ServerWnd.cpp:274
+#: src/muuli_wdr.cpp:2262 src/muuli_wdr.cpp:2348 src/ServerWnd.cpp:274
 #: src/ServerWnd.cpp:282
 msgid "OK"
 msgstr "Гаразд"
 
-#: src/muuli_wdr.cpp:2260
+#: src/muuli_wdr.cpp:2264
 msgid "Click here to apply any changes made to the preferences."
 msgstr "Натисніть тут щоб застосувати зміни зроблені в налаштуваннях."
 
-#: src/muuli_wdr.cpp:2263
+#: src/muuli_wdr.cpp:2267
 msgid "Reset any changes made to the preferences."
 msgstr "Скинути всі зміни внесені в налаштування."
 
-#: src/muuli_wdr.cpp:2292
+#: src/muuli_wdr.cpp:2296
 msgid "Comment :"
 msgstr "Коментар:"
 
-#: src/muuli_wdr.cpp:2299
+#: src/muuli_wdr.cpp:2303
 msgid "Incoming Dir :"
 msgstr "Вхідна тека:"
 
-#: src/muuli_wdr.cpp:2308
+#: src/muuli_wdr.cpp:2312
 msgid "Change priority for new assigned files :"
 msgstr "Змінити перевагу для нового призначеного файлу:"
 
-#: src/muuli_wdr.cpp:2312
+#: src/muuli_wdr.cpp:2316
 #, fuzzy
 msgid "Don't change"
 msgstr "Не змінювати"
 
-#: src/muuli_wdr.cpp:2324
+#: src/muuli_wdr.cpp:2328
 msgid "Select color for this Category (currently selected) :"
 msgstr "Виберіть колір для цієї категорії (зараз вибрано):"
 
-#: src/muuli_wdr.cpp:2391 src/muuli_wdr.cpp:2410 src/muuli_wdr.cpp:2432
+#: src/muuli_wdr.cpp:2395 src/muuli_wdr.cpp:2414 src/muuli_wdr.cpp:2436
 msgid "Click this button to reset the log."
 msgstr "Натисніть цю кнопку, щоб очистити часопис."
 
-#: src/muuli_wdr.cpp:2451
+#: src/muuli_wdr.cpp:2455
 msgid "Click on this button to update the servers list from URL ..."
 msgstr "Натисніть на кнопку щоб оновити перелік серверів з адреси..."
 
-#: src/muuli_wdr.cpp:2455
+#: src/muuli_wdr.cpp:2459
 msgid "Server list"
 msgstr "Перелік серверів"
 
-#: src/muuli_wdr.cpp:2459
+#: src/muuli_wdr.cpp:2463
 msgid "Enter the url to a server.met file here and press the button to the left to update the list of known servers."
 msgstr "Введіть адресу файлу server.met та натисніть кнопку ліворуч щоб оновити перелік відомих серверів."
 
-#: src/muuli_wdr.cpp:2464
+#: src/muuli_wdr.cpp:2468
 msgid "Add server manually: Name"
 msgstr "Додати сервер вручну: Назва"
 
-#: src/muuli_wdr.cpp:2467
+#: src/muuli_wdr.cpp:2471
 msgid "Enter the name of the new server here"
 msgstr "Введіть тут назву нового сервера"
 
-#: src/muuli_wdr.cpp:2469 src/ServerWnd.cpp:206
+#: src/muuli_wdr.cpp:2473 src/ServerWnd.cpp:206
 msgid "IP:Port"
 msgstr "IP:Порт"
 
-#: src/muuli_wdr.cpp:2472
+#: src/muuli_wdr.cpp:2476
 msgid "Enter the IP of the server here, using the x.x.x.x format."
 msgstr "Тут введіть IP-адресу сервера, використовуючи формат x.x.x.x."
 
-#: src/muuli_wdr.cpp:2478
+#: src/muuli_wdr.cpp:2482
 msgid "Enter the port of the server here."
 msgstr "Введіть тут порт сервера."
 
-#: src/muuli_wdr.cpp:2481
+#: src/muuli_wdr.cpp:2485
 msgid "Add manually a server (fill fields to the left before) ..."
 msgstr "Додати сервер вручну (заповніть поля ліворуч)..."
 
-#: src/muuli_wdr.cpp:2510
+#: src/muuli_wdr.cpp:2514
 msgid "aMule Log"
 msgstr "Часопис aMule"
 
-#: src/muuli_wdr.cpp:2518
+#: src/muuli_wdr.cpp:2522
 msgid "Server Info"
 msgstr "Інфо сервера"
 
-#: src/muuli_wdr.cpp:2522
+#: src/muuli_wdr.cpp:2526
 msgid "ED2K Info"
 msgstr "Інфо eD2k"
 
-#: src/muuli_wdr.cpp:2526
+#: src/muuli_wdr.cpp:2530
 msgid "Kad Info"
 msgstr "Інфо Kad"
 
-#: src/muuli_wdr.cpp:2554
+#: src/muuli_wdr.cpp:2558
 msgid "Click on this button to update the nodes list from URL ..."
 msgstr "Натисніть на цю кнопку щоб оновити перелік вузлів з URL..."
 
-#: src/muuli_wdr.cpp:2558
+#: src/muuli_wdr.cpp:2562
 msgid "Nodes (0)"
 msgstr "Вузли (0)"
 
-#: src/muuli_wdr.cpp:2562
+#: src/muuli_wdr.cpp:2566
 msgid "Enter the url to a nodes.dat file here and press the button to the left to update the list of known nodes."
 msgstr "Введіть адресу файлу nodes.dat та натисніть кнопку ліворуч щоб оновити перелік відомих вузлів. "
 
-#: src/muuli_wdr.cpp:2565
+#: src/muuli_wdr.cpp:2569
 msgid "Nodes stats"
 msgstr "Статистика вузлів"
 
-#: src/muuli_wdr.cpp:2607
+#: src/muuli_wdr.cpp:2611
 msgid "Bootstrap"
 msgstr "Початковий запуск"
 
-#: src/muuli_wdr.cpp:2610
+#: src/muuli_wdr.cpp:2614
 msgid "New node"
 msgstr "Новий вузол"
 
-#: src/muuli_wdr.cpp:2615
+#: src/muuli_wdr.cpp:2619
 msgid "IP:"
 msgstr "IP:"
 
-#: src/muuli_wdr.cpp:2635
+#: src/muuli_wdr.cpp:2639
 msgid "Port:"
 msgstr "Порт:"
 
-#: src/muuli_wdr.cpp:2648
+#: src/muuli_wdr.cpp:2652
 #, fuzzy
 msgid "Bootstrap from known clients"
 msgstr ""
 "Початковий запуск\n"
 "відомого клієнта"
 
-#: src/muuli_wdr.cpp:2650
+#: src/muuli_wdr.cpp:2654
 msgid "Disconnect Kad"
 msgstr "Від'єднатися від Kad"
 
-#: src/muuli_wdr.cpp:2684
+#: src/muuli_wdr.cpp:2688
 msgid "Use Secure User Identification"
 msgstr "Використовувати безпечну ідентифікацію користувача"
 
-#: src/muuli_wdr.cpp:2686
+#: src/muuli_wdr.cpp:2690
 msgid "It is recommended to enable this option. You will not receive credits if SUI is not enabled."
 msgstr "Рекомендовано ввімкнути цю опцію. Ви не отримаєте довіру якщо безпечна ідентифікація вимкнена."
 
-#: src/muuli_wdr.cpp:2688
+#: src/muuli_wdr.cpp:2692
 msgid "Protocol Obfuscation"
 msgstr "Приховування протоколу"
 
-#: src/muuli_wdr.cpp:2691
+#: src/muuli_wdr.cpp:2695
 msgid "Support Protocol Obfuscation"
 msgstr "Підтримка приховування протоколу"
 
-#: src/muuli_wdr.cpp:2693
+#: src/muuli_wdr.cpp:2697
 msgid "This option enabled Protocol Obfuscation, and makes aMule accept obfuscated connections from other clients."
 msgstr "Ця опція вмикає приховування протоколу та дозволяє aMule приймати приховані з'єднання від інших клієнтів."
 
-#: src/muuli_wdr.cpp:2695
+#: src/muuli_wdr.cpp:2699
 msgid "Use obfuscation for outgoing connections"
 msgstr "Використовувати приховування для вихідних з'єднань"
 
-#: src/muuli_wdr.cpp:2697
+#: src/muuli_wdr.cpp:2701
 msgid "This option makes aMule use Protocol Obfuscation when connecting other clients/servers."
 msgstr "Ця опція вмикає приховування протоколу під час з'єдання з іншими клієнтами/серверами."
 
-#: src/muuli_wdr.cpp:2699
+#: src/muuli_wdr.cpp:2703
 msgid "Accept only obfuscated connections"
 msgstr "Приймати тільки приховані з'єднання"
 
-#: src/muuli_wdr.cpp:2700
+#: src/muuli_wdr.cpp:2704
 msgid "This option makes aMule only accept obfuscated connections. You will have less sources, but all your traffic will be obfuscated"
 msgstr "Приймати приховані з'єднання. Будете мати менше джерел, але весь ваш трафік буде приховано"
 
-#: src/muuli_wdr.cpp:2705
+#: src/muuli_wdr.cpp:2709
 msgid "Everybody"
 msgstr "Кожен"
 
-#: src/muuli_wdr.cpp:2707
+#: src/muuli_wdr.cpp:2711
 msgid "No one"
 msgstr "Жоден"
 
-#: src/muuli_wdr.cpp:2709
+#: src/muuli_wdr.cpp:2713
 msgid "Who can see my shared files:"
 msgstr "Хто може бачити мої спільні файли:"
 
-#: src/muuli_wdr.cpp:2710
+#: src/muuli_wdr.cpp:2714
 msgid "Select who can request to view a list of your shared files."
 msgstr "Оберіть тих, хто може запитати перелік ваших спільних файлів."
 
-#: src/muuli_wdr.cpp:2712
+#: src/muuli_wdr.cpp:2716
 msgid "IP-Filtering"
 msgstr "IP-фільтрування"
 
-#: src/muuli_wdr.cpp:2719
+#: src/muuli_wdr.cpp:2723
 msgid "Filter clients"
 msgstr "Фільтрувати клієнтів"
 
-#: src/muuli_wdr.cpp:2721
+#: src/muuli_wdr.cpp:2725
 msgid "Enable filtering of the client IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "Ввімкнено фільтрування IP-адрес клієнтів, що визначені в файлі ~/.aMule/ipfilter.dat."
 
-#: src/muuli_wdr.cpp:2723
+#: src/muuli_wdr.cpp:2727
 msgid "Filter servers"
 msgstr "Фільтрувати сервери"
 
-#: src/muuli_wdr.cpp:2725
+#: src/muuli_wdr.cpp:2729
 msgid "Enable filtering of the server IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "Ввімкнено фільтрування IP-адрес серверів, що визначені в файлі ~/.aMule/ipfilter.dat."
 
-#: src/muuli_wdr.cpp:2729
+#: src/muuli_wdr.cpp:2733
 msgid "Reload List"
 msgstr "Перезавантажити перелік"
 
-#: src/muuli_wdr.cpp:2730
+#: src/muuli_wdr.cpp:2734
 msgid "Reload the list of IPs to filter from the file ~/.aMule/ipfilter.dat"
 msgstr "Перезавантажити перелік IP-адрес для фільтрування з файлу ~/.aMule/ipfilter.dat"
 
-#: src/muuli_wdr.cpp:2736
+#: src/muuli_wdr.cpp:2740
 msgid "URL:"
 msgstr "URL:"
 
-#: src/muuli_wdr.cpp:2740 src/muuli_wdr.cpp:2933
+#: src/muuli_wdr.cpp:2744 src/muuli_wdr.cpp:2937
 msgid "Update now"
 msgstr "Оновити зараз"
 
-#: src/muuli_wdr.cpp:2743
+#: src/muuli_wdr.cpp:2747
 msgid "Auto-update ipfilter at startup"
 msgstr "Автоматичне оновлення IP-фільтру після запуску"
 
-#: src/muuli_wdr.cpp:2747
+#: src/muuli_wdr.cpp:2751
 msgid "Filtering Level:"
 msgstr "Рівень фільтра:"
 
-#: src/muuli_wdr.cpp:2753
+#: src/muuli_wdr.cpp:2757
 msgid "Always filter LAN IPs"
 msgstr "Завжди відфільтровувати IP-адреси локальних мереж"
 
-#: src/muuli_wdr.cpp:2756
+#: src/muuli_wdr.cpp:2760
 msgid "Paranoid handling of non-matching IPs"
 msgstr "Параноїдальна обробка IP-адрес, що не співпали"
 
-#: src/muuli_wdr.cpp:2758
+#: src/muuli_wdr.cpp:2762
 msgid "Rejects a packet when its source IP differs from the IP the client claims (an anti-spoofing check). Disable only if it causes connection problems."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2760
+#: src/muuli_wdr.cpp:2764
 msgid "Use system-wide ipfilter.dat if available"
 msgstr "Використовувати системний ipfilter.dat якщо наявний"
 
-#: src/muuli_wdr.cpp:2761
+#: src/muuli_wdr.cpp:2765
 #, fuzzy
 msgid "If there's no local ipfilter.dat found, allow usage of a system-wide ipfilter file."
 msgstr "Якщо не знайдено місцевий ipfilter.dat, дозволити використання системного."
 
-#: src/muuli_wdr.cpp:2778
+#: src/muuli_wdr.cpp:2782
 msgid "Enable Online-Signature"
 msgstr "Ввімкнути онлайн-підпис"
 
-#: src/muuli_wdr.cpp:2780
+#: src/muuli_wdr.cpp:2784
 msgid "Enables the writing of the OS file, which can be used by external apps to create signatures and the like."
 msgstr "Ввімкнути запис файлу ОС, який може бути використано зовнішніми програмами для створення підписів та подібного."
 
-#: src/muuli_wdr.cpp:2784
+#: src/muuli_wdr.cpp:2788
 msgid "Update Frequency (Secs):"
 msgstr "Частота оновлення (с)"
 
-#: src/muuli_wdr.cpp:2787
+#: src/muuli_wdr.cpp:2791
 msgid "Change the frequency (in seconds) of Online Signature updates."
 msgstr "Змінити частоту (в секундах) оновлень онлайн-підписів."
 
-#: src/muuli_wdr.cpp:2795
+#: src/muuli_wdr.cpp:2799
 msgid "Save online signature file in: "
 msgstr "Зберегти файл онлайн-підпису в: "
 
-#: src/muuli_wdr.cpp:2801
+#: src/muuli_wdr.cpp:2805
 msgid "Click here to select the directory containing the the Online Signature files."
 msgstr "Натисніть тут, щоб вибрати теку, що містить файли з онлайн-підписами."
 
-#: src/muuli_wdr.cpp:2834
+#: src/muuli_wdr.cpp:2838
 msgid "Show country flags for clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2835
+#: src/muuli_wdr.cpp:2839
 msgid "Render the country flag column in the transfers, queue and search views. Requires a valid MMDB GeoIP database (see below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2840
+#: src/muuli_wdr.cpp:2844
 #, fuzzy
 msgid "Database"
 msgstr "Швидкість передачі:"
 
-#: src/muuli_wdr.cpp:2856
+#: src/muuli_wdr.cpp:2860
 #, fuzzy
 msgid "Source:"
 msgstr "Джерела"
 
-#: src/muuli_wdr.cpp:2859
+#: src/muuli_wdr.cpp:2863
 msgid "DB-IP (free, no account)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2860
+#: src/muuli_wdr.cpp:2864
 msgid "MaxMind GeoLite2 (free, account required)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2861
+#: src/muuli_wdr.cpp:2865
 msgid "Custom URL"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2864
+#: src/muuli_wdr.cpp:2868
 msgid "Choose which provider supplies the GeoIP MMDB database. DB-IP is the default - no account required. MaxMind requires a free account + license key. Use Custom URL to point at any other MMDB host (e.g. a local mirror)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2881
+#: src/muuli_wdr.cpp:2885
 msgid ""
 "No configuration required.\n"
 "\n"
@@ -4916,11 +4916,11 @@ msgid ""
 "License: Creative Commons BY 4.0 - https://creativecommons.org/licenses/by/4.0/"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2894
+#: src/muuli_wdr.cpp:2898
 msgid "License key:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2900
+#: src/muuli_wdr.cpp:2904
 msgid ""
 "Sign up for a free MaxMind account, then generate a License Key:\n"
 "https://www.maxmind.com/en/geolite2/signup\n"
@@ -4930,232 +4930,232 @@ msgid ""
 "Requires attribution and account registration; refresh at least every 30 days."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2915
+#: src/muuli_wdr.cpp:2919
 #, fuzzy
 msgid "Download URL:"
 msgstr "Звантаження: "
 
-#: src/muuli_wdr.cpp:2921
+#: src/muuli_wdr.cpp:2925
 msgid ""
 "Must point to an .mmdb file or a .gz / .tar.gz containing one.\n"
 "URL may include credentials (https://user:pass@host/...).\n"
 "License and attribution terms are set by the upstream URL - you are responsible."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2934
+#: src/muuli_wdr.cpp:2938
 msgid "Download the GeoIP database from the selected source."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2936
+#: src/muuli_wdr.cpp:2940
 #, fuzzy
 msgid "Auto-update on startup"
 msgstr "Автоматичне оновлення IP-фільтру після запуску"
 
-#: src/muuli_wdr.cpp:2937
+#: src/muuli_wdr.cpp:2941
 msgid "Re-download the GeoIP database from the selected source every time aMule starts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2960
+#: src/muuli_wdr.cpp:2964
 msgid "Filter incoming messages (except current chat):"
 msgstr "Фільтрувати вхідні повідомлення (окрім поточної розмови):"
 
-#: src/muuli_wdr.cpp:2962
+#: src/muuli_wdr.cpp:2966
 msgid "Filter all messages"
 msgstr "Фільтрувати всі повідомлення"
 
-#: src/muuli_wdr.cpp:2964
+#: src/muuli_wdr.cpp:2968
 msgid "Filter messages from people not on your friend list"
 msgstr "Фільтрувати повідомлення від людей, що не в вашому переліку друзів"
 
-#: src/muuli_wdr.cpp:2966
+#: src/muuli_wdr.cpp:2970
 msgid "Filter messages from unknown clients"
 msgstr "Фільтрувати повідомлення від невідомих клієнтів"
 
-#: src/muuli_wdr.cpp:2968
+#: src/muuli_wdr.cpp:2972
 msgid "Filter messages containing (use ',' as separator):"
 msgstr "Фільтрувати повідомлення, що містять (використовуйте ',' для переліку):"
 
-#: src/muuli_wdr.cpp:2971 src/muuli_wdr.cpp:2982
+#: src/muuli_wdr.cpp:2975 src/muuli_wdr.cpp:2986
 msgid "add here the words amule should filter and block messages including it"
 msgstr "додати слова, які aMule буде фільтрувати, та забороняти повідомлення, що їх містять"
 
-#: src/muuli_wdr.cpp:2973
+#: src/muuli_wdr.cpp:2977
 msgid "Show received messages in the log"
 msgstr "Показувати отримані повідомлення в часописі"
 
-#: src/muuli_wdr.cpp:2976
+#: src/muuli_wdr.cpp:2980
 msgid "Comments"
 msgstr "Коментарі"
 
-#: src/muuli_wdr.cpp:2979
+#: src/muuli_wdr.cpp:2983
 msgid "Filter comments containing (use ',' as separator):"
 msgstr "Фільтрувати коментарі, що містять (використовуйте ',' для переліку):"
 
-#: src/muuli_wdr.cpp:3004
+#: src/muuli_wdr.cpp:3008
 msgid "Enable Proxy"
 msgstr "Ввімкнути проксі"
 
-#: src/muuli_wdr.cpp:3005
+#: src/muuli_wdr.cpp:3009
 msgid "Enable/disable proxy support"
 msgstr "Ввімкнути/вимкнути підтримку проксі"
 
-#: src/muuli_wdr.cpp:3008
+#: src/muuli_wdr.cpp:3012
 msgid "Proxy type:"
 msgstr "Тип проксі:"
 
-#: src/muuli_wdr.cpp:3019
+#: src/muuli_wdr.cpp:3023
 msgid "Proxy host:"
 msgstr "Хост проксі:"
 
-#: src/muuli_wdr.cpp:3022
+#: src/muuli_wdr.cpp:3026
 msgid "The proxy host name"
 msgstr "Ім'я хосту проксі"
 
-#: src/muuli_wdr.cpp:3024
+#: src/muuli_wdr.cpp:3028
 msgid "Proxy port:"
 msgstr "Порт проксі:"
 
-#: src/muuli_wdr.cpp:3027
+#: src/muuli_wdr.cpp:3031
 msgid "The proxy port"
 msgstr "Порт проксі"
 
-#: src/muuli_wdr.cpp:3029
+#: src/muuli_wdr.cpp:3033
 msgid "Enable authentication"
 msgstr "Включити авторизацію"
 
-#: src/muuli_wdr.cpp:3030
+#: src/muuli_wdr.cpp:3034
 msgid "Enable/disable username/password authentication"
 msgstr "Ввімкнути/вимкнути аутентифікацію з ім'ям/паролем"
 
-#: src/muuli_wdr.cpp:3033
+#: src/muuli_wdr.cpp:3037
 msgid "Username: "
 msgstr "Ім'я користувача: "
 
-#: src/muuli_wdr.cpp:3036
+#: src/muuli_wdr.cpp:3040
 msgid "The username to use to connect to the proxy"
 msgstr "Ім'я користувача для з'єднання з проксі"
 
-#: src/muuli_wdr.cpp:3038
+#: src/muuli_wdr.cpp:3042
 msgid "Password:"
 msgstr "Пароль:"
 
-#: src/muuli_wdr.cpp:3041
+#: src/muuli_wdr.cpp:3045
 msgid "The password to use to connect to the proxy"
 msgstr "Пароль для з'єднання з проксі"
 
-#: src/muuli_wdr.cpp:3060
+#: src/muuli_wdr.cpp:3064
 msgid "Connect to:"
 msgstr "З'єднатись з:"
 
-#: src/muuli_wdr.cpp:3069
+#: src/muuli_wdr.cpp:3073
 msgid "Login to remote amule"
 msgstr "Вхід до віддаленого aMule"
 
-#: src/muuli_wdr.cpp:3074
+#: src/muuli_wdr.cpp:3078
 msgid "User name"
 msgstr "Ім'я користувача"
 
-#: src/muuli_wdr.cpp:3085
+#: src/muuli_wdr.cpp:3089
 msgid "Remember those settings"
 msgstr "Запам'ятати ці налаштування"
 
-#: src/muuli_wdr.cpp:3088
+#: src/muuli_wdr.cpp:3092
 #, fuzzy
 msgid "Force ZLIB compression"
 msgstr "Використовувати gzip-стиснення"
 
-#: src/muuli_wdr.cpp:3112
+#: src/muuli_wdr.cpp:3116
 msgid "Enable Verbose Debug-Logging."
 msgstr "Ввімкнути докладне ведення часопису."
 
-#: src/muuli_wdr.cpp:3114
+#: src/muuli_wdr.cpp:3118
 #, fuzzy
 msgid "Only to Logfile"
 msgstr "Відкрити файл"
 
-#: src/muuli_wdr.cpp:3116
+#: src/muuli_wdr.cpp:3120
 msgid "Message Categories:"
 msgstr "Категорія повідомлення:"
 
-#: src/muuli_wdr.cpp:3140 src/PartFileConvertDlg.cpp:160
+#: src/muuli_wdr.cpp:3144 src/PartFileConvertDlg.cpp:160
 msgid "Waiting..."
 msgstr "Очікується..."
 
-#: src/muuli_wdr.cpp:3160
+#: src/muuli_wdr.cpp:3164
 msgid "Add imports"
 msgstr "Додати зовнішні внесення"
 
-#: src/muuli_wdr.cpp:3163
+#: src/muuli_wdr.cpp:3167
 msgid "Retry selected"
 msgstr "Повторити вибрані"
 
-#: src/muuli_wdr.cpp:3165
+#: src/muuli_wdr.cpp:3169
 msgid "Remove selected"
 msgstr "Вилучити вибрані"
 
-#: src/muuli_wdr.cpp:3228
+#: src/muuli_wdr.cpp:3232
 msgid "Event Types"
 msgstr "Типи подій"
 
-#: src/muuli_wdr.cpp:3247
+#: src/muuli_wdr.cpp:3251
 msgid "Statistics and queued clients for selected file(s) : Session / All time"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3271
+#: src/muuli_wdr.cpp:3275
 #, fuzzy
 msgid "Active Uploads"
 msgstr "Чинні вивантаження:"
 
-#: src/muuli_wdr.cpp:3285
+#: src/muuli_wdr.cpp:3289
 msgid "Percent of total files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3337
+#: src/muuli_wdr.cpp:3341
 #, fuzzy
 msgid "Show Clients for"
 msgstr "Показати клієнтів"
 
-#: src/muuli_wdr.cpp:3339
+#: src/muuli_wdr.cpp:3343
 #, fuzzy
 msgid "All files"
 msgstr "Сховати спільні файли"
 
-#: src/muuli_wdr.cpp:3342
+#: src/muuli_wdr.cpp:3346
 #, fuzzy
 msgid "Selected files"
 msgstr "Вибрати фільтр перегляду"
 
-#: src/muuli_wdr.cpp:3345
+#: src/muuli_wdr.cpp:3349
 #, fuzzy
 msgid "Active uploads only"
 msgstr "Чинні вивантаження"
 
-#: src/muuli_wdr.cpp:3352
+#: src/muuli_wdr.cpp:3356
 #, fuzzy
 msgid "Reload:"
 msgstr "Перезавантажити перелік"
 
-#: src/muuli_wdr.cpp:3356
+#: src/muuli_wdr.cpp:3360
 msgid "Reload your shared files"
 msgstr "Перезавантажити ваші спільні файли"
 
-#: src/muuli_wdr.cpp:3419
+#: src/muuli_wdr.cpp:3423
 msgid "Send"
 msgstr "Надіслати"
 
-#: src/muuli_wdr.cpp:3420
+#: src/muuli_wdr.cpp:3424
 msgid "Sends the specified message."
 msgstr "Надіслати вказане повідомлення."
 
-#: src/muuli_wdr.cpp:3424
+#: src/muuli_wdr.cpp:3428
 msgid "Close this chat-session."
 msgstr "Закрити цю розмову."
 
-#: src/muuli_wdr.cpp:3447
+#: src/muuli_wdr.cpp:3451
 msgid "Connect to any server and/or Kad"
 msgstr "З'єднатися з будь-яким сервером та/чи Kad"
 
-#: src/muuli_wdr.cpp:3453 src/SharedFilesCtrl.cpp:142 src/Statistics.cpp:941
+#: src/muuli_wdr.cpp:3457 src/SharedFilesCtrl.cpp:142 src/Statistics.cpp:941
 msgid "Shared Files"
 msgstr "Спільні файли"
 
@@ -5796,35 +5796,35 @@ msgstr ""
 "aMule чудово працює без зміни будь-яких\n"
 "з цих параметрів."
 
-#: src/PrefsUnifiedDlg.cpp:647
+#: src/PrefsUnifiedDlg.cpp:656
 #, c-format
 msgid "Failed to connect Cfg to widget with the ID %d and key %s"
 msgstr "Помилка з'єднання Cfg до Widget з ID %d та ключем %s"
 
-#: src/PrefsUnifiedDlg.cpp:695
+#: src/PrefsUnifiedDlg.cpp:704
 #, c-format
 msgid "Failed to transfer data from Cfg to Widget with the ID %d and key %s"
 msgstr "Помилка передавання даних з Cfg до Widget з ID %d та ключем %s"
 
-#: src/PrefsUnifiedDlg.cpp:801
+#: src/PrefsUnifiedDlg.cpp:810
 msgid "The type of proxy you are connecting to"
 msgstr "Тип проксі з яким ви з'єднуєтесь"
 
-#: src/PrefsUnifiedDlg.cpp:1020
+#: src/PrefsUnifiedDlg.cpp:1029
 #, c-format
 msgid "Failed to transfer data from Widget to Cfg with the ID %d and key %s"
 msgstr "Помилка передавання даних з Widget до Cfg з ID %d та ключем %s"
 
-#: src/PrefsUnifiedDlg.cpp:1103
+#: src/PrefsUnifiedDlg.cpp:1112
 #, fuzzy
 msgid "No password set."
 msgstr "Перевіряється пароль\n"
 
-#: src/PrefsUnifiedDlg.cpp:1132
+#: src/PrefsUnifiedDlg.cpp:1141
 msgid "Guest access needs a password. Type one in the guest password field, or untick Enable guest access."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1144
+#: src/PrefsUnifiedDlg.cpp:1153
 msgid ""
 "aMule must be restarted to enable these changes:\n"
 "\n"
@@ -5832,45 +5832,45 @@ msgstr ""
 "aMule має бути перезапущений, щоб зміни подіяли:\n"
 "\n"
 
-#: src/PrefsUnifiedDlg.cpp:1151
+#: src/PrefsUnifiedDlg.cpp:1160
 msgid "- TCP port changed.\n"
 msgstr "- TCP-порт змінено.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1156
+#: src/PrefsUnifiedDlg.cpp:1165
 msgid "- UDP port changed.\n"
 msgstr "- UDP-порт змінено.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1161
+#: src/PrefsUnifiedDlg.cpp:1170
 #, fuzzy
 msgid "- Network interface binding changed.\n"
 msgstr "Зовнішнє з'єднання розірвано."
 
-#: src/PrefsUnifiedDlg.cpp:1166
+#: src/PrefsUnifiedDlg.cpp:1175
 #, fuzzy
 msgid "- External connect port changed.\n"
 msgstr "Зовнішнє з'єднання розірвано."
 
-#: src/PrefsUnifiedDlg.cpp:1170
+#: src/PrefsUnifiedDlg.cpp:1179
 #, fuzzy
 msgid "- External connect acceptance changed.\n"
 msgstr "Дозволено нове зовнішнє з'єднання"
 
-#: src/PrefsUnifiedDlg.cpp:1174
+#: src/PrefsUnifiedDlg.cpp:1183
 #, fuzzy
 msgid "- External connect interface changed.\n"
 msgstr "Зовнішнє з'єднання розірвано."
 
-#: src/PrefsUnifiedDlg.cpp:1178
+#: src/PrefsUnifiedDlg.cpp:1187
 #, fuzzy
 msgid "- Protocol obfuscation support changed.\n"
 msgstr "Приховування протоколу"
 
-#: src/PrefsUnifiedDlg.cpp:1193
+#: src/PrefsUnifiedDlg.cpp:1202
 #, fuzzy
 msgid "- amuleapi settings changed.\n"
 msgstr "- Мова змінена.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1202
+#: src/PrefsUnifiedDlg.cpp:1211
 msgid ""
 "Your Auto-update server list is empty.\n"
 "'Auto-update server list at startup' will be disabled."
@@ -5878,7 +5878,7 @@ msgstr ""
 "Ваш перелік автоматичного оновлення серверів порожній.\n"
 "'Автоматичне оновлення серверів під час завантаження буде вимкнено."
 
-#: src/PrefsUnifiedDlg.cpp:1213
+#: src/PrefsUnifiedDlg.cpp:1222
 msgid ""
 "You have enabled external connections but have not specified a password.\n"
 "External connections cannot be enabled unless a valid password is specified."
@@ -5886,34 +5886,34 @@ msgstr ""
 "Ви увімкнули зовнішні з'єднання, але не визначили пароль.\n"
 "Зовнішні з'єднання не можуть бути ввімкнені поки не вказано вірний пароль."
 
-#: src/PrefsUnifiedDlg.cpp:1246
+#: src/PrefsUnifiedDlg.cpp:1255
 #, c-format
 msgid "The amuleapi password could not be saved: %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1276
+#: src/PrefsUnifiedDlg.cpp:1285
 msgid "- Language changed.\n"
 msgstr "- Мова змінена.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1281
+#: src/PrefsUnifiedDlg.cpp:1290
 msgid "- Temp folder changed.\n"
 msgstr "- Тимчасова тека змінена.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1286
+#: src/PrefsUnifiedDlg.cpp:1295
 #, fuzzy
 msgid "- ED2K network enabled.\n"
 msgstr "Всі мережі вимкнені."
 
-#: src/PrefsUnifiedDlg.cpp:1319
+#: src/PrefsUnifiedDlg.cpp:1328
 msgid "The shared-file exclusion pattern is not a valid regular expression. The filter has been left disabled."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1321 src/PrefsUnifiedDlg.cpp:1921
+#: src/PrefsUnifiedDlg.cpp:1330 src/PrefsUnifiedDlg.cpp:1930
 #, fuzzy
 msgid "Invalid regular expression"
 msgstr "Невірна версія протоколу."
 
-#: src/PrefsUnifiedDlg.cpp:1398
+#: src/PrefsUnifiedDlg.cpp:1407
 msgid ""
 "Both eD2k and Kad network are disabled.\n"
 "You won't be able to connect until you enable at least one of them."
@@ -5921,7 +5921,7 @@ msgstr ""
 "Обидві eD2k та Kad-мережі вимкнені.\n"
 "Ви не зможете з'єднатися поки не увімкнете хоча б одну з них"
 
-#: src/PrefsUnifiedDlg.cpp:1403
+#: src/PrefsUnifiedDlg.cpp:1412
 msgid ""
 "Kad will not start if your UDP port is disabled.\n"
 "Enable UDP port or disable Kad."
@@ -5929,7 +5929,7 @@ msgstr ""
 "Kad не розпочне роботу, якщо UDP-порт вимкнено.\n"
 "Увімкніть UDP-порт або вимкніть Kad"
 
-#: src/PrefsUnifiedDlg.cpp:1459
+#: src/PrefsUnifiedDlg.cpp:1468
 msgid ""
 "\n"
 "You MUST restart aMule now.\n"
@@ -5939,69 +5939,69 @@ msgstr ""
 "Ви ЗОБОВ'ЯЗАНІ перезапустити aMule зараз.\n"
 "Якщо ж не перезапустите, не скаржтеся, коли станеться щось жахливе.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1524
+#: src/PrefsUnifiedDlg.cpp:1533
 msgid "Could not register aMule for autostart at login. The autostart store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1526
+#: src/PrefsUnifiedDlg.cpp:1535
 msgid "Could not remove the autostart-at-login entry."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1527
+#: src/PrefsUnifiedDlg.cpp:1536
 #, fuzzy
 msgid "Autostart"
 msgstr "Автоматичне оновлення розпочато"
 
-#: src/PrefsUnifiedDlg.cpp:1542
+#: src/PrefsUnifiedDlg.cpp:1551
 msgid "Register file type"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1542
+#: src/PrefsUnifiedDlg.cpp:1551
 msgid "Register URL handler"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1550
+#: src/PrefsUnifiedDlg.cpp:1559
 #, c-format
 msgid "aMule only handles eD2k-compatible magnets. If you replace the current magnet handler (%s), BitTorrent magnet links will stop working - aMule cannot download BitTorrent content. Continue?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1555
+#: src/PrefsUnifiedDlg.cpp:1564
 #, c-format
 msgid "Another application currently opens .emulecollection files (%s). Replace it with aMule?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1560
+#: src/PrefsUnifiedDlg.cpp:1569
 #, c-format
 msgid "Another application is currently the default handler for these links (%s). Replace it with aMule?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1585
+#: src/PrefsUnifiedDlg.cpp:1594
 msgid "Could not register aMule for .emulecollection files. The registration store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1587
+#: src/PrefsUnifiedDlg.cpp:1596
 #, fuzzy
 msgid "Could not remove the file type registration."
 msgstr "Тека для тимчасових звантажуваних файлів"
 
-#: src/PrefsUnifiedDlg.cpp:1589
+#: src/PrefsUnifiedDlg.cpp:1598
 msgid "Could not register aMule as the URL handler. The registration store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1591
+#: src/PrefsUnifiedDlg.cpp:1600
 msgid "Could not remove the URL handler registration."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1661 src/PrefsUnifiedDlg.cpp:1688
+#: src/PrefsUnifiedDlg.cpp:1670 src/PrefsUnifiedDlg.cpp:1697
 #, fuzzy
 msgid "The web server and aMule API require external connections to be enabled."
 msgstr "Пароль встановлений та дозволені зовнішні з'єднання."
 
-#: src/PrefsUnifiedDlg.cpp:1671
+#: src/PrefsUnifiedDlg.cpp:1680
 msgid "The aMule web server is deprecated. Consider running the aMule API instead."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1735
+#: src/PrefsUnifiedDlg.cpp:1744
 msgid ""
 "Your Auto-update servers list is in blank.\n"
 "Please fill in at least one URL to point to a valid server.met file.\n"
@@ -6011,24 +6011,24 @@ msgstr ""
 "Будь ласка заповніть принаймні одну адресу, що посилається на існуючий файл server.met.\n"
 "Натисніть на кнопку \"Перелік\" щоб ввести адресу."
 
-#: src/PrefsUnifiedDlg.cpp:1876
+#: src/PrefsUnifiedDlg.cpp:1885
 msgid "Temporary files"
 msgstr "Тимчасові файли"
 
-#: src/PrefsUnifiedDlg.cpp:1881
+#: src/PrefsUnifiedDlg.cpp:1890
 msgid "Incoming files"
 msgstr "Вхідні файли"
 
-#: src/PrefsUnifiedDlg.cpp:1886
+#: src/PrefsUnifiedDlg.cpp:1895
 msgid "Online Signatures"
 msgstr "Онлайн-підписи"
 
-#: src/PrefsUnifiedDlg.cpp:1899
+#: src/PrefsUnifiedDlg.cpp:1908
 #, c-format
 msgid "Choose a folder for %s"
 msgstr "Виберіть теку для %s"
 
-#: src/PrefsUnifiedDlg.cpp:1923
+#: src/PrefsUnifiedDlg.cpp:1932
 #, fuzzy, c-format
 msgid "Would exclude %u of %u shared file"
 msgid_plural "Would exclude %u of %u shared files"
@@ -6036,42 +6036,42 @@ msgstr[0] "Знайдено %i новий спільний файл"
 msgstr[1] "Знайдено %i нові спільні файли"
 msgstr[2] "Знайдено %i нових спільних файлів"
 
-#: src/PrefsUnifiedDlg.cpp:1940
+#: src/PrefsUnifiedDlg.cpp:1949
 msgid "Browse for videoplayer"
 msgstr "Переглянути, щоб знайти відеопрогравач"
 
-#: src/PrefsUnifiedDlg.cpp:1944
+#: src/PrefsUnifiedDlg.cpp:1953
 msgid "Select browser"
 msgstr "Вибрати переглядач тенет"
 
-#: src/PrefsUnifiedDlg.cpp:1948
+#: src/PrefsUnifiedDlg.cpp:1957
 #, fuzzy
 msgid "Select ffprobe binary"
 msgstr "Вибрати переглядач тенет"
 
-#: src/PrefsUnifiedDlg.cpp:1954
+#: src/PrefsUnifiedDlg.cpp:1963
 #, c-format
 msgid "Executable%s"
 msgstr "Виконуваний %s"
 
-#: src/PrefsUnifiedDlg.cpp:1988
+#: src/PrefsUnifiedDlg.cpp:1997
 msgid "ffprobe not found on PATH or in the standard install locations. Install ffmpeg (which ships ffprobe) or use Browse to pick a binary manually."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2000
+#: src/PrefsUnifiedDlg.cpp:2009
 msgid "Reset the settings on this page to their default values?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2001
+#: src/PrefsUnifiedDlg.cpp:2010
 #, fuzzy
 msgid "Reset to defaults"
 msgstr "Мова системи"
 
-#: src/PrefsUnifiedDlg.cpp:2028
+#: src/PrefsUnifiedDlg.cpp:2037
 msgid "Edit server list"
 msgstr "Редагувати перелік серверів"
 
-#: src/PrefsUnifiedDlg.cpp:2029
+#: src/PrefsUnifiedDlg.cpp:2038
 msgid ""
 "Add here URL's to download server.met files.\n"
 "Only one url on each line."
@@ -6079,42 +6079,42 @@ msgstr ""
 "Додайте тут адреси файлів server.met.\n"
 "Тільки одна адреса на рядок."
 
-#: src/PrefsUnifiedDlg.cpp:2084
+#: src/PrefsUnifiedDlg.cpp:2093
 msgid "IP2Country update failed"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2229 src/PrefsUnifiedDlg.cpp:2260
+#: src/PrefsUnifiedDlg.cpp:2238 src/PrefsUnifiedDlg.cpp:2269
 msgid "Data by MaxMind GeoLite2"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2231 src/PrefsUnifiedDlg.cpp:2262
+#: src/PrefsUnifiedDlg.cpp:2240 src/PrefsUnifiedDlg.cpp:2271
 #, fuzzy
 msgid "Custom source"
 msgstr "Завершених джерел"
 
-#: src/PrefsUnifiedDlg.cpp:2233 src/PrefsUnifiedDlg.cpp:2264
+#: src/PrefsUnifiedDlg.cpp:2242 src/PrefsUnifiedDlg.cpp:2273
 msgid "Data by DB-IP.com"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2284
+#: src/PrefsUnifiedDlg.cpp:2293
 #, fuzzy, c-format
 msgid "Status: Loaded%s"
 msgstr "Стан:"
 
-#: src/PrefsUnifiedDlg.cpp:2286
+#: src/PrefsUnifiedDlg.cpp:2295
 #, fuzzy, c-format
 msgid "Status: Loaded%s - %s"
 msgstr "Стан:"
 
-#: src/PrefsUnifiedDlg.cpp:2290
+#: src/PrefsUnifiedDlg.cpp:2299
 msgid "Status: Failed to load - click 'Update now' to refresh."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2292
+#: src/PrefsUnifiedDlg.cpp:2301
 msgid "Status: Not found - click 'Update now' to download."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2350 src/PrefsUnifiedDlg.cpp:2374
+#: src/PrefsUnifiedDlg.cpp:2359 src/PrefsUnifiedDlg.cpp:2383
 #, c-format
 msgid "Update delay: %d second"
 msgid_plural "Update delay: %d seconds"
@@ -6122,7 +6122,7 @@ msgstr[0] "Затримка оновлення: %d секунда"
 msgstr[1] "Затримка оновлення: %d секунди"
 msgstr[2] "Затримка оновлення: %d секунд"
 
-#: src/PrefsUnifiedDlg.cpp:2358
+#: src/PrefsUnifiedDlg.cpp:2367
 #, c-format
 msgid "Time for average graph: %d minute"
 msgid_plural "Time for average graph: %d minutes"
@@ -6130,12 +6130,12 @@ msgstr[0] "Час усереднення графіків: %d хвилина"
 msgstr[1] "Час усереднення графіків: %d хвилини"
 msgstr[2] "Час усереднення графіків: %d хвилин"
 
-#: src/PrefsUnifiedDlg.cpp:2367
+#: src/PrefsUnifiedDlg.cpp:2376
 #, c-format
 msgid "Connections Graph Scale: %d"
 msgstr "Зміна розміру графіка з'єднань: %d"
 
-#: src/PrefsUnifiedDlg.cpp:2382
+#: src/PrefsUnifiedDlg.cpp:2391
 #, c-format
 msgid "File Buffer Size: %d byte"
 msgid_plural "File Buffer Size: %d bytes"
@@ -6143,7 +6143,7 @@ msgstr[0] "Розмір файлу буфера: %d байт"
 msgstr[1] "Розмір файлу буфера: %d байти"
 msgstr[2] "Розмір файлу буфера: %d байт"
 
-#: src/PrefsUnifiedDlg.cpp:2392
+#: src/PrefsUnifiedDlg.cpp:2401
 #, c-format
 msgid "Upload Queue Size: %d client"
 msgid_plural "Upload Queue Size: %d clients"
@@ -6151,7 +6151,7 @@ msgstr[0] "Розмір черги вивантаження: %d клієнт"
 msgstr[1] "Розмір черги вивантаження: %d клієнти"
 msgstr[2] "Розмір черги вивантаження: %d клієнтів"
 
-#: src/PrefsUnifiedDlg.cpp:2402
+#: src/PrefsUnifiedDlg.cpp:2411
 #, c-format
 msgid "Server connection refresh interval: %d minute"
 msgid_plural "Server connection refresh interval: %d minutes"
@@ -6159,79 +6159,79 @@ msgstr[0] "Інтервал оновлення з'єднання з сервер
 msgstr[1] "Інтервал оновлення з'єднання з сервером: %d хвилини"
 msgstr[2] "Інтервал оновлення з'єднання з сервером: %d хвилин"
 
-#: src/PrefsUnifiedDlg.cpp:2407
+#: src/PrefsUnifiedDlg.cpp:2416
 msgid "Server connection refresh interval: Disabled"
 msgstr "Інтервал оновлення з'єднання з сервером: вимкнено"
 
-#: src/PrefsUnifiedDlg.cpp:2451
+#: src/PrefsUnifiedDlg.cpp:2460
 msgid "disabled"
 msgstr "вимкнено"
 
-#: src/PrefsUnifiedDlg.cpp:2477
+#: src/PrefsUnifiedDlg.cpp:2486
 #, fuzzy, c-format
 msgid "Execute command on '%s' event"
 msgstr "Виконати команду на подію '%s'"
 
-#: src/PrefsUnifiedDlg.cpp:2484
+#: src/PrefsUnifiedDlg.cpp:2493
 msgid "Enable command execution on core"
 msgstr "Ввімкнути виконання команди в ядрі"
 
-#: src/PrefsUnifiedDlg.cpp:2496
+#: src/PrefsUnifiedDlg.cpp:2505
 msgid "Core command:"
 msgstr "Команда ядра:"
 
-#: src/PrefsUnifiedDlg.cpp:2512
+#: src/PrefsUnifiedDlg.cpp:2521
 msgid "Enable command execution on GUI"
 msgstr "Ввімкнути виконання команд в ГІК"
 
-#: src/PrefsUnifiedDlg.cpp:2524
+#: src/PrefsUnifiedDlg.cpp:2533
 msgid "GUI command:"
 msgstr "Команда ГІК:"
 
-#: src/PrefsUnifiedDlg.cpp:2540
+#: src/PrefsUnifiedDlg.cpp:2549
 msgid "The following variables will be replaced:"
 msgstr "Наступні змінні будуть замінені:"
 
-#: src/PrefsUnifiedDlg.cpp:2708
+#: src/PrefsUnifiedDlg.cpp:2717
 msgid ""
 "The following folders look like system or sensitive locations:\n"
 "\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2713
+#: src/PrefsUnifiedDlg.cpp:2722
 msgid "Sharing them recursively will publish every file underneath on the eD2k/Kad networks. Do you really want to do this?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2716
+#: src/PrefsUnifiedDlg.cpp:2725
 #, fuzzy
 msgid "Confirm shared folders"
 msgstr "Спільні теки"
 
-#: src/PrefsUnifiedDlg.cpp:2744
+#: src/PrefsUnifiedDlg.cpp:2753
 #, fuzzy
 msgid "Reloading shared files..."
 msgstr "Перезавантажити ваші спільні файли"
 
-#: src/PrefsUnifiedDlg.cpp:2745
+#: src/PrefsUnifiedDlg.cpp:2754
 msgid "Scanning for subdirectories..."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2746
+#: src/PrefsUnifiedDlg.cpp:2755
 #, fuzzy
 msgid "Updating shared folders"
 msgstr "Спільні теки"
 
-#: src/PrefsUnifiedDlg.cpp:2773
+#: src/PrefsUnifiedDlg.cpp:2782
 #, c-format
 msgid "Scanned %u directories..."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2823
+#: src/PrefsUnifiedDlg.cpp:2832
 #, fuzzy, c-format
 msgid "Reloading shared files: %u files scanned"
 msgstr "Перезавантажується перелік спільних файлів."
 
-#: src/PrefsUnifiedDlg.cpp:2873
+#: src/PrefsUnifiedDlg.cpp:2882
 #, fuzzy
 msgid "Shared folder"
 msgstr "Спільні теки"
@@ -7951,12 +7951,12 @@ msgstr "Видалити категорію"
 msgid "Hashset requested for unknown file: %s"
 msgstr "Запитано набір хешів для невідомого файлу: %s"
 
-#: src/UploadQueue.cpp:618
+#: src/UploadQueue.cpp:627
 #, c-format
 msgid "Resuming uploads of file: %s"
 msgstr "Відновлюється вивантаження файлу: %s"
 
-#: src/UploadQueue.cpp:634
+#: src/UploadQueue.cpp:643
 #, c-format
 msgid "Suspending upload of file: %s"
 msgstr "Призупиняється вивантаження файлу: %s"

--- a/po/uk.po
+++ b/po/uk.po
@@ -9,8 +9,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-28 12:12+0200\n"
-"PO-Revision-Date: 2026-07-27 10:36+0000\n"
+"POT-Creation-Date: 2026-07-28 08:06+0200\n"
+"PO-Revision-Date: 2026-07-27 11:47+0000\n"
 "Last-Translator: Oleksandr Kovalenko <alx.kovalenko@gmail.com>\n"
 "Language-Team: Ukrainian <translation@linux.org.ua>\n"
 "Language: uk\n"
@@ -144,7 +144,7 @@ msgstr ""
 msgid "Not now"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:422 src/amuleDlg.cpp:665
+#: src/AppImageIntegration.cpp:422 src/amuleDlg.cpp:600
 msgid "Don't ask again"
 msgstr ""
 
@@ -202,83 +202,83 @@ msgstr "Не вдалося відкрити файл ED2KLinks."
 msgid "WARNING: You can't add yourself as a source for an eD2k link while having a lowid."
 msgstr "ЗАСТЕРЕЖЕННЯ: ви не можете додати себе як джерело для eD2k-посилання маючи LowID."
 
-#: src/amule.cpp:301
+#: src/amule.cpp:300
 msgid "Now, exiting main app..."
 msgstr "Тепер, виходимо з головної програми..."
 
-#: src/amule.cpp:331
+#: src/amule.cpp:330
 #, c-format
 msgid "Terminating amuleweb instance with pid '%d' ... "
 msgstr "Вбиваю екземпляр amuleweb з pid `%d' ... "
 
-#: src/amule.cpp:335
+#: src/amule.cpp:334
 #, c-format
 msgid "Killing amuleweb instance with pid '%d' ... "
 msgstr "Вбиваю екземпляр amuleweb з pid `%d' ... "
 
-#: src/amule.cpp:337 src/amule.cpp:350 src/ClientRef.cpp:180
-#: src/SearchDlg.cpp:1041 src/ServerListCtrl.cpp:98
+#: src/amule.cpp:336 src/amule.cpp:349 src/ClientRef.cpp:180
+#: src/SearchDlg.cpp:880 src/ServerListCtrl.cpp:98
 msgid "Failed"
 msgstr "Невдалі"
 
-#: src/amule.cpp:344
+#: src/amule.cpp:343
 #, fuzzy, c-format
 msgid "Terminating amuleapi instance with pid '%d' ... "
 msgstr "Вбиваю екземпляр amuleweb з pid `%d' ... "
 
-#: src/amule.cpp:348
+#: src/amule.cpp:347
 #, fuzzy, c-format
 msgid "Killing amuleapi instance with pid '%d' ... "
 msgstr "Вбиваю екземпляр amuleweb з pid `%d' ... "
 
-#: src/amule.cpp:356
+#: src/amule.cpp:355
 msgid "aMule OnExit: Terminating core."
 msgstr "aMule OnExit: Завершується core."
 
-#: src/amule.cpp:467
+#: src/amule.cpp:466
 msgid "aMule shutdown completed."
 msgstr "Завершення роботи aMule закінчене."
 
-#: src/amule.cpp:471
+#: src/amule.cpp:470
 msgid "Memory debug results for aMule exit:"
 msgstr "Наслідки зневадження пам'яті для виходу aMule:"
 
-#: src/amule.cpp:652
+#: src/amule.cpp:651
 #, c-format
 msgid "Binding aMule's peer-to-peer traffic to interface: %s (HTTP updates use the default route)"
 msgstr ""
 
-#: src/amule.cpp:656
+#: src/amule.cpp:655
 #, c-format
 msgid "Binding all network traffic to interface: %s"
 msgstr ""
 
-#: src/amule.cpp:660
+#: src/amule.cpp:659
 #, c-format
 msgid "WARNING: configured network interface '%s' was not found - traffic is NOT bound to it and may leave via the default route. Check the interface name in Preferences."
 msgstr ""
 
-#: src/amule.cpp:666
+#: src/amule.cpp:665
 #, c-format
 msgid "WARNING: binding to network interface '%s' requires elevated privileges and was NOT applied - traffic may leave via the default route. Grant the capability (e.g. 'sudo setcap cap_net_raw+ep' on the aMule binary) or run with sufficient privileges."
 msgstr ""
 
-#: src/amule.cpp:674
+#: src/amule.cpp:673
 #, c-format
 msgid "WARNING: could not bind to network interface '%s' - traffic may leave via the default route."
 msgstr ""
 
-#: src/amule.cpp:733
+#: src/amule.cpp:732
 msgid "Your locale has been changed to System Default due to a configuration change. Sorry."
 msgstr "Ваша локаль змінена на системну за замовчуванням із-за зміни налаштувань. Вибачте."
 
-#: src/amule.cpp:735 src/amule.cpp:1589 src/CatDialog.cpp:128
+#: src/amule.cpp:734 src/amule.cpp:1581 src/CatDialog.cpp:128
 #: src/CatDialog.cpp:136 src/CatDialog.cpp:149 src/ServerList.cpp:366
 #: src/ServerListCtrl.cpp:152
 msgid "Info"
 msgstr "Інфо"
 
-#: src/amule.cpp:742
+#: src/amule.cpp:741
 msgid ""
 "\n"
 "EC configuration"
@@ -286,74 +286,74 @@ msgstr ""
 "\n"
 "Налаштування зовнішніх з'єднань"
 
-#: src/amule.cpp:745
+#: src/amule.cpp:744
 msgid "Password set and external connections enabled."
 msgstr "Пароль встановлений та дозволені зовнішні з'єднання."
 
-#: src/amule.cpp:755 src/KadDlg.cpp:176 src/KadDlg.cpp:185
-#: src/PrefsUnifiedDlg.cpp:1461 src/SharedFilesCtrl.cpp:476
+#: src/amule.cpp:754 src/KadDlg.cpp:176 src/KadDlg.cpp:185
+#: src/PrefsUnifiedDlg.cpp:1387 src/SharedFilesCtrl.cpp:476
 msgid "WARNING"
 msgstr "ЗАСТЕРЕЖЕННЯ"
 
-#: src/amule.cpp:992
+#: src/amule.cpp:991
 #, fuzzy
 msgid "Network bootstrap"
 msgstr "Мережі"
 
-#: src/amule.cpp:997
+#: src/amule.cpp:996
 msgid ""
 "aMule has detected missing network bootstrap files.\n"
 "Select which ones to download:"
 msgstr ""
 
-#: src/amule.cpp:1006 src/FirstRunWizard.cpp:411
+#: src/amule.cpp:1005 src/FirstRunWizard.cpp:411
 #, fuzzy
 msgid "eD2k server list (server.met)"
 msgstr "%i сервер знайдено в server.met"
 
-#: src/amule.cpp:1013 src/FirstRunWizard.cpp:416
+#: src/amule.cpp:1012 src/FirstRunWizard.cpp:416
 msgid "Kad bootstrap nodes (nodes.dat)"
 msgstr ""
 
-#: src/amule.cpp:1103
+#: src/amule.cpp:1102
 #, c-format
 msgid "web server running on pid %d"
 msgstr "Веб-сервер запущений з %d"
 
-#: src/amule.cpp:1116
+#: src/amule.cpp:1115
 #, fuzzy
 msgid "You requested to run web server on startup, but the amuleweb binary cannot be run. Please install the package containing aMule web server, or build aMule from source with -DBUILD_WEBSERVER=YES and install it."
 msgstr "Ви встановили запуск веб-сервера під час завантаження, але amuleweb не може бути запущено. Будь ласка, встановіть пакунок, що містить веб-сервер aMule, зберіть aMule з --enable-webserver та виконайте make install"
 
-#: src/amule.cpp:1121 src/amule.cpp:1185 src/amule.cpp:1299 src/amule.cpp:1601
+#: src/amule.cpp:1120 src/amule.cpp:1177 src/amule.cpp:1291 src/amule.cpp:1593
 #: src/amule-remote-gui.cpp:603 src/amule-remote-gui.cpp:671
 #: src/amule-remote-gui.cpp:709 src/amule-remote-gui.cpp:1282
 #: src/amule-remote-gui.cpp:1345 src/amule-remote-gui.cpp:1372
-#: src/DownloadQueue.cpp:1481 src/PrefsUnifiedDlg.cpp:1247
+#: src/DownloadQueue.cpp:1481
 msgid "ERROR"
 msgstr "ПОМИЛКА"
 
-#: src/amule.cpp:1174
+#: src/amule.cpp:1166
 #, fuzzy, c-format
 msgid "amuleapi running on pid %d"
 msgstr "Веб-сервер запущений з %d"
 
-#: src/amule.cpp:1180
+#: src/amule.cpp:1172
 #, fuzzy
 msgid "You requested to run amuleapi on startup, but the amuleapi binary cannot be run. Please install the package containing aMule's REST API server, or build aMule from source with -DBUILD_AMULEAPI=YES and install it."
 msgstr "Ви встановили запуск веб-сервера під час завантаження, але amuleweb не може бути запущено. Будь ласка, встановіть пакунок, що містить веб-сервер aMule, зберіть aMule з --enable-webserver та виконайте make install"
 
-#: src/amule.cpp:1267
+#: src/amule.cpp:1259
 #, c-format
 msgid "Could not bind ports to the specified address: %s"
 msgstr "Неможливо прив'язати порт до визначеної адреси: %s"
 
-#: src/amule.cpp:1291
+#: src/amule.cpp:1283
 #, c-format
 msgid "Port %u is not available. You will be LOWID\n"
 msgstr "Порт %u недоступний. Ви будете мати LowID\n"
 
-#: src/amule.cpp:1296
+#: src/amule.cpp:1288
 #, c-format
 msgid ""
 "Port %u is not available!\n"
@@ -368,48 +368,48 @@ msgstr ""
 "\n"
 "Перевірте вашу мережу, щоб впевнитись, що порт відкритий."
 
-#: src/amule.cpp:1393
+#: src/amule.cpp:1385
 msgid "Failed to create OnlineSig File"
 msgstr "Неможливо створити файл онлайн-підпису"
 
-#: src/amule.cpp:1401
+#: src/amule.cpp:1393
 msgid "Failed to create aMule OnlineSig File"
 msgstr "Неможливо створити файл онлайн-підпису aMule"
 
-#: src/amule.cpp:1564
+#: src/amule.cpp:1556
 msgid "The selected locale seems not to be installed on your box. (Note: I'll try to set it anyway)"
 msgstr "Обрана локаль здається не встановлена. (примітка: спроба встановити її в будь-якому випадку)"
 
-#: src/amule.cpp:1574
+#: src/amule.cpp:1566
 #, c-format
 msgid "This is the first time you run aMule %s"
 msgstr "Ви запускаєте aMule %s вперше"
 
-#: src/amule.cpp:1577
+#: src/amule.cpp:1569
 msgid "This version is a testing version, updated daily, and\n"
 msgstr "Це тестова версія, оновлюється щодня, та\n"
 
-#: src/amule.cpp:1578
+#: src/amule.cpp:1570
 msgid "we give no warranty it won't break anything, burn your house,\n"
 msgstr "ми не даємо жодної гарантії, якщо вона щось пошкодить, спалить ваш будинок,\n"
 
-#: src/amule.cpp:1579
+#: src/amule.cpp:1571
 msgid "or kill your dog. But it *should* be safe to use anyway.\n"
 msgstr "або вб'є собаку. Але вона *має бути* безпечною у використанні всюди.\n"
 
-#: src/amule.cpp:1584
+#: src/amule.cpp:1576
 msgid "More information, support and new releases can found at our homepage,\n"
 msgstr "Більше подробиць, підтримка та нові випуски можуть бути знайдені на нашій сторінці,\n"
 
-#: src/amule.cpp:1585
+#: src/amule.cpp:1577
 msgid "at https://amule-org.github.io, or in our IRC channel #aMule at irc.libera.chat.\n"
 msgstr "на https://amule-org.github.io, або у нашому IRC-каналі #aMule на irc.libera.chat.\n"
 
-#: src/amule.cpp:1587
+#: src/amule.cpp:1579
 msgid "Feel free to report any bugs to https://github.com/amule-org/amule/issues"
 msgstr "Не соромтеся повідомити про будь-які помилки на https://github.com/amule-org/amule/issues"
 
-#: src/amule.cpp:1599
+#: src/amule.cpp:1591
 msgid ""
 "The folder for Online Signature files you specified is INVALID!\n"
 " OnlineSignature will be DISABLED until you fix it on preferences."
@@ -417,137 +417,137 @@ msgstr ""
 "Тека для файлів онлайн-підпису НЕВІРНА!\n"
 "Онлайн-підпис буде ВИМКНЕНО поки ви не виправите це в налаштуваннях."
 
-#: src/amule.cpp:1662
+#: src/amule.cpp:1654
 msgid "Server hostname notified"
 msgstr "Назва сервера повідомлена"
 
-#: src/amule.cpp:2039
+#: src/amule.cpp:2031
 #, c-format
 msgid "Disk space preallocation for file '%s' failed: %s"
 msgstr "Не вдалося виділити місце на диску для файлу '%s': %s"
 
-#: src/amule.cpp:2168
+#: src/amule.cpp:2160
 msgid "ERROR: can't open logfile"
 msgstr "ПОМИЛКА: не можу відкрити файл часопису"
 
-#: src/amule.cpp:2172
+#: src/amule.cpp:2164
 msgid "WARNING: logfile is empty. Something is wrong."
 msgstr "ЗАСТЕРЕЖЕННЯ: журнал порожній. Щось негаразд."
 
-#: src/amule.cpp:2189
+#: src/amule.cpp:2181
 msgid "Log has been reset"
 msgstr "Часопис очищено"
 
-#: src/amule.cpp:2213
+#: src/amule.cpp:2205
 #, c-format
 msgid "ServerMessage: %s"
 msgstr "Повідомлення сервера: %s"
 
-#: src/amule.cpp:2256 src/IP2Country.cpp:220 src/IPFilter.cpp:514
+#: src/amule.cpp:2248 src/IP2Country.cpp:220 src/IPFilter.cpp:514
 #: src/ServerList.cpp:875
 #, c-format
 msgid "Skipped download of %s, because requested file is not newer."
 msgstr ""
 
-#: src/amule.cpp:2259
+#: src/amule.cpp:2251
 msgid "Failed to download the nodes list."
 msgstr "Не вдалося звантажити перелік вузлів."
 
-#: src/amule.cpp:2322
+#: src/amule.cpp:2314
 msgid "Failed to open the downloaded version check file"
 msgstr "Не вдалося відкрити звантажений файл перевірки версії"
 
-#: src/amule.cpp:2325 src/amule.cpp:2344
+#: src/amule.cpp:2317 src/amule.cpp:2336
 msgid "Corrupted version check file"
 msgstr "Файл перевірки версії зіпсований"
 
-#: src/amule.cpp:2367
+#: src/amule.cpp:2359
 msgid "You are using an outdated version of aMule!"
 msgstr "Ви використовуєте застарілу версію aMule!"
 
-#: src/amule.cpp:2369
+#: src/amule.cpp:2361
 #, c-format
 msgid "Your aMule version is %i.%i.%i and the latest version is %li.%li.%li"
 msgstr "Ваша версія aMule %i.%i.%i, а остання %li.%li.%li"
 
-#: src/amule.cpp:2373
+#: src/amule.cpp:2365
 msgid "The latest version can always be found at https://github.com/amule-org/amule/releases/latest"
 msgstr "Остання версія може бути завжди знайдена на https://github.com/amule-org/amule/releases/latest"
 
-#: src/amule.cpp:2376
+#: src/amule.cpp:2368
 #, c-format
 msgid "WARNING: Your aMuled version is outdated: %i.%i.%i < %li.%li.%li"
 msgstr "ЗАСТЕРЕЖЕННЯ: Ваша версія aMuled застаріла: %i.%i.%i < %li.%li.%li"
 
-#: src/amule.cpp:2382
+#: src/amule.cpp:2374
 msgid "Your copy of aMule is up to date."
 msgstr "Ваша копія aMule оновлена."
 
-#: src/amule.cpp:2389
+#: src/amule.cpp:2381
 msgid "Failed to download the version check file"
 msgstr "Неможливо звантажити файл перевірки версії"
 
-#: src/amule.cpp:2558 src/amule-remote-gui.cpp:1133
+#: src/amule.cpp:2550 src/amule-remote-gui.cpp:1133
 #, c-format
 msgid "Users: %s | Files: %s"
 msgstr "Користувачі: %s | Файли: %s"
 
-#: src/amule.cpp:2559 src/amule-remote-gui.cpp:1134
+#: src/amule.cpp:2551 src/amule-remote-gui.cpp:1134
 #, c-format
 msgid "Users: E: %s K: %s | Files: E: %s K: %s"
 msgstr "Користувачі: %s K: %s | Файли: E: %s K: %s"
 
-#: src/amule.cpp:2573 src/amule-remote-gui.cpp:1147
+#: src/amule.cpp:2565 src/amule-remote-gui.cpp:1147
 msgid "No networks selected"
 msgstr "Не вибрано жодної мережі"
 
-#: src/amule.cpp:2641 src/TextClient.cpp:903
+#: src/amule.cpp:2633 src/TextClient.cpp:903
 msgid "with LowID"
 msgstr "з LowID"
 
-#: src/amule.cpp:2641 src/TextClient.cpp:904
+#: src/amule.cpp:2633 src/TextClient.cpp:904
 msgid "with HighID"
 msgstr "з HighID"
 
-#: src/amule.cpp:2643
+#: src/amule.cpp:2635
 #, c-format
 msgid "Connected to %s %s"
 msgstr "З'єднано з %s %s"
 
-#: src/amule.cpp:2648
+#: src/amule.cpp:2640
 #, c-format
 msgid "Connecting to %s"
 msgstr "З'єднується з %s"
 
-#: src/amule.cpp:2650
+#: src/amule.cpp:2642
 msgid "Disconnected from eD2k"
 msgstr "Від'єднано від eD2k"
 
-#: src/amule.cpp:2659
+#: src/amule.cpp:2651
 msgid "Kad started."
 msgstr "Kad запущена."
 
-#: src/amule.cpp:2661
+#: src/amule.cpp:2653
 msgid "Kad stopped."
 msgstr "Kad зупинена."
 
-#: src/amule.cpp:2669
+#: src/amule.cpp:2661
 msgid "Connected to Kad (ok)"
 msgstr "З'єднано з Kad (все гаразд)"
 
-#: src/amule.cpp:2671
+#: src/amule.cpp:2663
 msgid "Connected to Kad (firewalled)"
 msgstr "З'єднано з Kad (за фаєрволом)"
 
-#: src/amule.cpp:2675
+#: src/amule.cpp:2667
 msgid "Disconnected from Kad"
 msgstr "Від'єднано від Kad"
 
-#: src/amule.cpp:2707
+#: src/amule.cpp:2699
 msgid "Kad network cannot be used if UDP port is disabled on preferences, not starting."
 msgstr "Мережа Kad не може бути використана якщо UDP-порт вимкнено в налаштуваннях, не починаю."
 
-#: src/amule.cpp:2711
+#: src/amule.cpp:2703
 msgid "Kad network disabled on preferences, not connecting."
 msgstr "Мережа Kad вимкнена в налаштуваннях, не з'єднуюсь."
 
@@ -573,68 +573,30 @@ msgstr ""
 msgid "ERROR: %s"
 msgstr "ПОМИЛКА: %s"
 
-#: src/amuleDlg.cpp:250
+#: src/amuleDlg.cpp:236
 #, c-format
 msgid "This is aMule %s based on eMule."
 msgstr "Це aMule %s оснований на eMule."
 
-#: src/amuleDlg.cpp:251
+#: src/amuleDlg.cpp:237
 #, c-format
 msgid "Running on %s"
 msgstr "Запущений на %s"
 
-#: src/amuleDlg.cpp:253
+#: src/amuleDlg.cpp:239
 msgid "Visit https://github.com/amule-org/amule/releases/latest to check if a new version is available."
 msgstr "Відвідайте https://github.com/amule-org/amule/releases/latest, щоб перевірити наявність нових версій."
 
-#: src/amuleDlg.cpp:282
+#: src/amuleDlg.cpp:268
 msgid "FATAL ERROR: Failed to create Timer"
 msgstr "ЖАХЛИВА ПОМИЛКА: не вдалося створити Timer"
 
-#: src/amuleDlg.cpp:361 src/amuleDlg.cpp:1810 src/amuleDlg.cpp:2056
-#: src/muuli_wdr.cpp:1492 src/muuli_wdr.cpp:3439
-msgid "Networks"
-msgstr "Мережі"
-
-#: src/amuleDlg.cpp:362 src/amuleDlg.cpp:1816 src/muuli_wdr.cpp:3440
-msgid "Searches"
-msgstr "Пошук"
-
-#: src/amuleDlg.cpp:363 src/amuleDlg.cpp:1822 src/DownloadListCtrl.cpp:740
-#: src/muuli_wdr.cpp:392 src/muuli_wdr.cpp:1585 src/muuli_wdr.cpp:3441
-#: src/Statistics.cpp:829
-msgid "Downloads"
-msgstr "Звантаження"
-
-#: src/amuleDlg.cpp:364 src/amuleDlg.cpp:1828 src/muuli_wdr.cpp:3315
-msgid "Shared files"
-msgstr "Спільні файли"
-
-#: src/amuleDlg.cpp:365 src/amuleDlg.cpp:1834 src/muuli_wdr.cpp:2947
-#: src/muuli_wdr.cpp:3397 src/muuli_wdr.cpp:3444
-msgid "Messages"
-msgstr "Повідомлення"
-
-#: src/amuleDlg.cpp:366 src/amuleDlg.cpp:1840 src/muuli_wdr.cpp:3445
-#: src/PrefsUnifiedDlg.cpp:314 src/Statistics.cpp:779 src/Statistics.cpp:1235
-msgid "Statistics"
-msgstr "Статистика"
-
-#: src/amuleDlg.cpp:368 src/amuleDlg.cpp:1847 src/muuli_wdr.cpp:3447
-#: src/PrefsUnifiedDlg.cpp:330 src/utils/wxCas/src/wxcasprefs.cpp:39
-msgid "Preferences"
-msgstr "Налаштування"
-
-#: src/amuleDlg.cpp:371
-msgid "Navigate"
-msgstr ""
-
-#: src/amuleDlg.cpp:657
+#: src/amuleDlg.cpp:592
 #, fuzzy
 msgid "New version available"
 msgstr "Недоступний"
 
-#: src/amuleDlg.cpp:661
+#: src/amuleDlg.cpp:596
 #, fuzzy, c-format
 msgid ""
 "A new version of aMule (%s) is available.\n"
@@ -644,186 +606,219 @@ msgid ""
 "Would you like to open the download page?"
 msgstr "Остання версія може бути завжди знайдена на https://github.com/amule-org/amule/releases/latest"
 
-#: src/amuleDlg.cpp:743
+#: src/amuleDlg.cpp:678
 msgid "aMule dialog destroyed"
 msgstr "Діалог aMule знищений"
 
-#: src/amuleDlg.cpp:766 src/DataToText.cpp:68 src/IPFilter.cpp:547
+#: src/amuleDlg.cpp:701 src/DataToText.cpp:68 src/IPFilter.cpp:547
 msgid "Connecting"
 msgstr "З'єднується"
 
-#: src/amuleDlg.cpp:958
+#: src/amuleDlg.cpp:893
 msgid "eD2k: Connecting"
 msgstr "eD2k: з'єднання"
 
-#: src/amuleDlg.cpp:962
+#: src/amuleDlg.cpp:897
 msgid "eD2k: Disconnected"
 msgstr "eD2k: від'єднаний"
 
-#: src/amuleDlg.cpp:968
+#: src/amuleDlg.cpp:903
 msgid "Kad: Firewalled"
 msgstr "Kad: за фаєрволом"
 
-#: src/amuleDlg.cpp:972
+#: src/amuleDlg.cpp:907
 msgid "Kad: Connected"
 msgstr "Kad: з'єднаний"
 
-#: src/amuleDlg.cpp:977
+#: src/amuleDlg.cpp:912
 msgid "Kad: Connecting"
 msgstr "Kad: з'єднуюсь"
 
-#: src/amuleDlg.cpp:981
+#: src/amuleDlg.cpp:916
 msgid "Kad: Off"
 msgstr "Kad: вимкнена"
 
-#: src/amuleDlg.cpp:1029 src/DownloadListCtrl.cpp:505
+#: src/amuleDlg.cpp:964 src/DownloadListCtrl.cpp:505
 #: src/DownloadListCtrl.cpp:749 src/FriendListCtrl.cpp:180
 #: src/muuli_wdr.cpp:731 src/muuli_wdr.cpp:782 src/muuli_wdr.cpp:846
-#: src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2252 src/muuli_wdr.cpp:2337
-#: src/muuli_wdr.cpp:3085 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
+#: src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2224 src/muuli_wdr.cpp:2309
+#: src/muuli_wdr.cpp:3057 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
 #: src/ServerListCtrl.cpp:606 src/TransferWnd.cpp:378
 #: src/utils/wxCas/src/wxcasprefs.cpp:235
 msgid "Cancel"
 msgstr "Скасувати"
 
-#: src/amuleDlg.cpp:1030
+#: src/amuleDlg.cpp:965
 msgid "Stop the current connection attempts"
 msgstr "Зупинити поточні спроби з'єднань"
 
-#: src/amuleDlg.cpp:1035 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976
-#: src/muuli_wdr.cpp:2475
+#: src/amuleDlg.cpp:970 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976
+#: src/muuli_wdr.cpp:2447
 msgid "Disconnect"
 msgstr "Від'єднатися"
 
-#: src/amuleDlg.cpp:1036
+#: src/amuleDlg.cpp:971
 msgid "Disconnect from the currently connected networks"
 msgstr "Від'єднатися від з'єднаних мереж"
 
-#: src/amuleDlg.cpp:1041 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979
-#: src/muuli_wdr.cpp:2630 src/muuli_wdr.cpp:3082 src/muuli_wdr.cpp:3437
+#: src/amuleDlg.cpp:976 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979
+#: src/muuli_wdr.cpp:2602 src/muuli_wdr.cpp:3054 src/muuli_wdr.cpp:3409
 msgid "Connect"
 msgstr "З'єднатися"
 
-#: src/amuleDlg.cpp:1042
+#: src/amuleDlg.cpp:977
 msgid "Connect to the currently enabled networks"
 msgstr "З'єднатися з дозволеними мережами"
 
-#: src/amuleDlg.cpp:1154
+#: src/amuleDlg.cpp:1089
 #, fuzzy, c-format
 msgid "Up: %.1f%s (%.1f) | Down: %.1f%s (%.1f)"
 msgstr "Вивантаження: %.1f(%.1f) | Звантаження: %.1f(%.1f)"
 
-#: src/amuleDlg.cpp:1156 src/amuleDlg.cpp:1158 src/amuleDlg.cpp:1162
-#: src/amuleDlg.cpp:1164 src/amuleDlg.cpp:1175 src/amuleDlg.cpp:1177
+#: src/amuleDlg.cpp:1091 src/amuleDlg.cpp:1093 src/amuleDlg.cpp:1097
+#: src/amuleDlg.cpp:1099 src/amuleDlg.cpp:1110 src/amuleDlg.cpp:1112
 #: src/MuleTrayIcon.cpp:796 src/MuleTrayIcon.cpp:799
 #, fuzzy
 msgid " MB/s"
 msgstr "Мбайт/с"
 
-#: src/amuleDlg.cpp:1156 src/amuleDlg.cpp:1158 src/amuleDlg.cpp:1162
-#: src/amuleDlg.cpp:1164 src/amuleDlg.cpp:1175 src/amuleDlg.cpp:1177
+#: src/amuleDlg.cpp:1091 src/amuleDlg.cpp:1093 src/amuleDlg.cpp:1097
+#: src/amuleDlg.cpp:1099 src/amuleDlg.cpp:1110 src/amuleDlg.cpp:1112
 #: src/MuleTrayIcon.cpp:796 src/MuleTrayIcon.cpp:799
 #: src/utils/wxCas/src/wxcasframe.cpp:1041
 msgid " kB/s"
 msgstr " кбайт/с"
 
-#: src/amuleDlg.cpp:1161
+#: src/amuleDlg.cpp:1096
 #, fuzzy, c-format
 msgid "Up: %.1f%s | Down: %.1f%s"
 msgstr "Вивантаження: %.1f | Звантаження: %.1f"
 
-#: src/amuleDlg.cpp:1193
+#: src/amuleDlg.cpp:1128
 #, c-format
 msgid "aMule (%s | Connected)"
 msgstr "aMule (%s | З'єднано)"
 
-#: src/amuleDlg.cpp:1195
+#: src/amuleDlg.cpp:1130
 #, c-format
 msgid "aMule (%s | Disconnected)"
 msgstr "aMule (%s | Від'єднано)"
 
-#: src/amuleDlg.cpp:1248
+#: src/amuleDlg.cpp:1183
 #, fuzzy, c-format
 msgid "Do you really want to exit %s?"
 msgstr "Ви справді хочете вийти з aMule?"
 
-#: src/amuleDlg.cpp:1250
+#: src/amuleDlg.cpp:1185
 msgid "Exit confirmation"
 msgstr "Підтвердження виходу"
 
-#: src/amuleDlg.cpp:1613
+#: src/amuleDlg.cpp:1548
 msgid "Launch Command: "
 msgstr "Команда для запуску: "
 
-#: src/amuleDlg.cpp:1632 src/muuli_wdr.cpp:1972 src/Preferences.cpp:979
+#: src/amuleDlg.cpp:1567 src/muuli_wdr.cpp:1971 src/Preferences.cpp:951
 msgid "- default -"
 msgstr "- за замовчуванням -"
 
-#: src/amuleDlg.cpp:1660
+#: src/amuleDlg.cpp:1595
 #, c-format
 msgid "Skin directory '%s' does not exist"
 msgstr "Тека з шкірами '%s' не існує"
 
-#: src/amuleDlg.cpp:1663
+#: src/amuleDlg.cpp:1598
 #, c-format
 msgid "WARNING: Unable to open skin file '%s' for read"
 msgstr "ЗАСТЕРЕЖЕННЯ: Неможливо відкрити файл шкіри '%s' для читання"
 
-#: src/amuleDlg.cpp:1814 src/muuli_wdr.cpp:3439
+#: src/amuleDlg.cpp:1722 src/amuleDlg.cpp:1968 src/muuli_wdr.cpp:1485
+#: src/muuli_wdr.cpp:3411
+msgid "Networks"
+msgstr "Мережі"
+
+#: src/amuleDlg.cpp:1726 src/muuli_wdr.cpp:3411
 msgid "Networks Window"
 msgstr "Вікно мереж"
 
-#: src/amuleDlg.cpp:1820 src/muuli_wdr.cpp:3440
+#: src/amuleDlg.cpp:1728 src/muuli_wdr.cpp:3412
+msgid "Searches"
+msgstr "Пошук"
+
+#: src/amuleDlg.cpp:1732 src/muuli_wdr.cpp:3412
 msgid "Searches Window"
 msgstr "Вікно пошуку"
 
-#: src/amuleDlg.cpp:1826 src/muuli_wdr.cpp:3441
+#: src/amuleDlg.cpp:1734 src/DownloadListCtrl.cpp:740 src/muuli_wdr.cpp:392
+#: src/muuli_wdr.cpp:1578 src/muuli_wdr.cpp:3413 src/Statistics.cpp:829
+msgid "Downloads"
+msgstr "Звантаження"
+
+#: src/amuleDlg.cpp:1738 src/muuli_wdr.cpp:3413
 #, fuzzy
 msgid "Downloads Window"
 msgstr "Звантажується"
 
-#: src/amuleDlg.cpp:1832 src/muuli_wdr.cpp:3443
+#: src/amuleDlg.cpp:1740 src/muuli_wdr.cpp:3287
+msgid "Shared files"
+msgstr "Спільні файли"
+
+#: src/amuleDlg.cpp:1744 src/muuli_wdr.cpp:3415
 msgid "Shared Files Window"
 msgstr "Вікно спільних файлів"
 
-#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3444
+#: src/amuleDlg.cpp:1746 src/muuli_wdr.cpp:2919 src/muuli_wdr.cpp:3369
+#: src/muuli_wdr.cpp:3416
+msgid "Messages"
+msgstr "Повідомлення"
+
+#: src/amuleDlg.cpp:1750 src/muuli_wdr.cpp:3416
 msgid "Messages Window"
 msgstr "Вікно повідомлень"
 
-#: src/amuleDlg.cpp:1844 src/muuli_wdr.cpp:3445
+#: src/amuleDlg.cpp:1752 src/muuli_wdr.cpp:3417 src/PrefsUnifiedDlg.cpp:312
+#: src/Statistics.cpp:779 src/Statistics.cpp:1235
+msgid "Statistics"
+msgstr "Статистика"
+
+#: src/amuleDlg.cpp:1756 src/muuli_wdr.cpp:3417
 msgid "Statistics Graph Window"
 msgstr "Вікно статистики"
 
-#: src/amuleDlg.cpp:1851 src/muuli_wdr.cpp:3447
+#: src/amuleDlg.cpp:1759 src/muuli_wdr.cpp:3419 src/PrefsUnifiedDlg.cpp:328
+#: src/utils/wxCas/src/wxcasprefs.cpp:39
+msgid "Preferences"
+msgstr "Налаштування"
+
+#: src/amuleDlg.cpp:1763 src/muuli_wdr.cpp:3419
 msgid "Preferences Settings Window"
 msgstr "Вікно налаштувань"
 
-#: src/amuleDlg.cpp:1854 src/muuli_wdr.cpp:3448
+#: src/amuleDlg.cpp:1766 src/muuli_wdr.cpp:3420
 msgid "Import"
 msgstr "Зовн. внесення"
 
-#: src/amuleDlg.cpp:1858 src/muuli_wdr.cpp:3448
+#: src/amuleDlg.cpp:1770 src/muuli_wdr.cpp:3420
 msgid "The partfile importer tool"
 msgstr "Засіб зовнішнього внесення частково звантажених файлів"
 
-#: src/amuleDlg.cpp:1861 src/muuli_wdr.cpp:3449
+#: src/amuleDlg.cpp:1773 src/muuli_wdr.cpp:3421
 #: src/utils/aLinkCreator/src/alcframe.cpp:262
 msgid "About"
 msgstr "Про програму"
 
-#: src/amuleDlg.cpp:1861 src/muuli_wdr.cpp:3449
+#: src/amuleDlg.cpp:1773 src/muuli_wdr.cpp:3421
 msgid "About/Help"
 msgstr "Про/Допомога"
 
-#: src/amuleDlg.cpp:2059
+#: src/amuleDlg.cpp:1971
 msgid "eD2k network"
 msgstr "Мережа eD2k"
 
-#: src/amuleDlg.cpp:2062
+#: src/amuleDlg.cpp:1974
 msgid "Kad network"
 msgstr "Мережа Kad"
 
-#: src/amuleDlg.cpp:2062
+#: src/amuleDlg.cpp:1974
 msgid "No network"
 msgstr "Немає мережі"
 
@@ -953,7 +948,7 @@ msgstr "Файл не знайдено."
 msgid "The core rejected these shared folders:%s"
 msgstr ""
 
-#: src/amule-remote-gui.cpp:1336 src/ExternalConn.cpp:2346
+#: src/amule-remote-gui.cpp:1336 src/ExternalConn.cpp:2345
 msgid "Invalid link or already on list."
 msgstr "Недопустиме посилання або вже в переліку."
 
@@ -969,7 +964,7 @@ msgstr ""
 #: src/ClientDetailDialog.cpp:123 src/DataToText.cpp:61 src/DataToText.cpp:86
 #: src/DataToText.cpp:101 src/DataToText.cpp:136 src/DataToText.cpp:165
 #: src/DownloadListCtrl.cpp:1172 src/DownloadListCtrl.cpp:1185
-#: src/DownloadListCtrl.cpp:1196 src/ExternalConn.cpp:609
+#: src/DownloadListCtrl.cpp:1196 src/ExternalConn.cpp:608
 #: src/FileDetailDialog.cpp:203 src/FileDetailDialog.cpp:235
 #: src/FileDetailDialog.cpp:242 src/GenericClientListCtrl.cpp:1171
 #: src/GenericClientListCtrl.cpp:1182 src/GenericClientListCtrl.cpp:1192
@@ -1365,19 +1360,19 @@ msgstr "Авто [висока]"
 msgid "Very low"
 msgstr "Дуже низька"
 
-#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:743 src/muuli_wdr.cpp:2303
+#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:743 src/muuli_wdr.cpp:2275
 #: src/ServerListCtrl.cpp:263 src/ServerListCtrl.cpp:456
 #: src/SharedFilesCtrl.cpp:145
 msgid "Low"
 msgstr "Низька"
 
-#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:744 src/muuli_wdr.cpp:2304
+#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:744 src/muuli_wdr.cpp:2276
 #: src/ServerListCtrl.cpp:266 src/ServerListCtrl.cpp:457
 #: src/SharedFilesCtrl.cpp:146
 msgid "Normal"
 msgstr "Звичайна"
 
-#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:745 src/muuli_wdr.cpp:2305
+#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:745 src/muuli_wdr.cpp:2277
 #: src/ServerListCtrl.cpp:269 src/ServerListCtrl.cpp:458
 #: src/SharedFilesCtrl.cpp:147
 msgid "High"
@@ -1470,8 +1465,8 @@ msgstr "Місцевий сервер"
 msgid "Remote Server"
 msgstr "Віддалений сервер"
 
-#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3202
-#: src/SearchDlg.cpp:119 src/TextClient.cpp:911
+#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3174
+#: src/SearchDlg.cpp:111 src/TextClient.cpp:911
 msgid "Kad"
 msgstr "Kad"
 
@@ -1542,7 +1537,7 @@ msgstr "Частина"
 msgid "Size"
 msgstr "Розмір"
 
-#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3269
+#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3241
 msgid "Transferred"
 msgstr "Переданих"
 
@@ -1600,7 +1595,7 @@ msgstr ""
 "Відгук від: %s (%s)\n"
 "\n"
 
-#: src/DownloadListCtrl.cpp:746 src/muuli_wdr.cpp:2306
+#: src/DownloadListCtrl.cpp:746 src/muuli_wdr.cpp:2278
 #: src/SharedFilesCtrl.cpp:150
 msgid "Auto"
 msgstr "Автоматично"
@@ -1638,7 +1633,7 @@ msgid "Extended Options"
 msgstr "Розширені налаштування"
 
 #: src/DownloadListCtrl.cpp:770 src/DownloadListCtrl.cpp:822
-#: src/muuli_wdr.cpp:1790
+#: src/muuli_wdr.cpp:1789
 msgid "Preview"
 msgstr "Попередній перегляд"
 
@@ -1815,237 +1810,232 @@ msgstr[2] ""
 msgid "Invalid eD2k link! ERROR: %s"
 msgstr "Невірне eD2k-посилання! ПОМИЛКА: %s"
 
-#: src/ExternalConn.cpp:380
+#: src/ExternalConn.cpp:379
 #, fuzzy
 msgid "Client sent packet after authentication failed."
 msgstr "Аутентифікація не вдалася."
 
-#: src/ExternalConn.cpp:397
+#: src/ExternalConn.cpp:396
 msgid "External connection closed."
 msgstr "Зовнішнє з'єднання розірвано."
 
-#: src/ExternalConn.cpp:474
+#: src/ExternalConn.cpp:473
 msgid "External connections disabled due to empty password!"
 msgstr "Зовнішні з'єднання вимкнені, оскільки відсутній пароль!"
 
-#: src/ExternalConn.cpp:495
+#: src/ExternalConn.cpp:494
 msgid "External connections disabled in config file"
 msgstr "Зовнішні з'єднання вимкнені у файлі налаштувань."
 
-#: src/ExternalConn.cpp:576
+#: src/ExternalConn.cpp:575
 msgid "New external connection accepted"
 msgstr "Дозволено нове зовнішнє з'єднання"
 
-#: src/ExternalConn.cpp:579
+#: src/ExternalConn.cpp:578
 msgid "ERROR: couldn't accept a new external connection"
 msgstr "ПОМИЛКА: неможливо дозволити нове зовнішнє з'єднання"
 
-#: src/ExternalConn.cpp:596
+#: src/ExternalConn.cpp:595
 msgid "External connection refused due to empty password in preferences!"
 msgstr "Відмовлено у зовнішньому з'єднанні, оскільки в налаштуваннях порожній пароль!"
 
-#: src/ExternalConn.cpp:608
+#: src/ExternalConn.cpp:607
 #, c-format
 msgid "Connecting client: %s %s"
 msgstr "З'єднується клієнт: %s %s"
 
-#: src/ExternalConn.cpp:610
+#: src/ExternalConn.cpp:609
 msgid "Unknown version"
 msgstr "Невідома версія"
 
-#: src/ExternalConn.cpp:623
+#: src/ExternalConn.cpp:622
 msgid "Incorrect EC version ID, there might be binary incompatibility. Use core and remote from same snapshot."
 msgstr "Невірний ID версії EC, може бути двійкова несумісність. Використовуйте ядро та віддаленого клієнта з того самого зрізу"
 
-#: src/ExternalConn.cpp:631
+#: src/ExternalConn.cpp:630
 #, fuzzy
 msgid "You cannot connect to a release version from an arbitrary development snapshot! *sigh* possible crash prevented"
 msgstr "Ви не можете під'єднатись до остаточної версії з довільної SVN-версії! Можлива відмова попереджена"
 
-#: src/ExternalConn.cpp:714
+#: src/ExternalConn.cpp:713
 msgid "Invalid protocol version."
 msgstr "Невірна версія протоколу."
 
-#: src/ExternalConn.cpp:720
+#: src/ExternalConn.cpp:719
 msgid "Missing protocol version tag."
 msgstr "Відсутня позначка версії протоколу."
 
-#: src/ExternalConn.cpp:728
+#: src/ExternalConn.cpp:727
 msgid "Authentication failed: invalid hash specified as EC password."
 msgstr ""
 
-#: src/ExternalConn.cpp:776
+#: src/ExternalConn.cpp:775
 #, fuzzy
 msgid "Authentication failed: wrong password."
 msgstr "Аутентифікація не вдалася."
 
-#: src/ExternalConn.cpp:778
+#: src/ExternalConn.cpp:777
 #, fuzzy
 msgid "Authentication failed: missing password."
 msgstr "Аутентифікація не вдалася."
 
-#: src/ExternalConn.cpp:789
+#: src/ExternalConn.cpp:788
 #, fuzzy
 msgid "Invalid request, please authenticate first."
 msgstr "Невірний запит, ви маєте спочатку представитись."
 
-#: src/ExternalConn.cpp:794
+#: src/ExternalConn.cpp:793
 msgid "Access granted."
 msgstr "Дозвіл надано."
 
-#: src/ExternalConn.cpp:802
+#: src/ExternalConn.cpp:801
 #, fuzzy, c-format
 msgid "Sent error message \"%s\" to client."
 msgstr "Фільтрувати повідомлення від невідомих клієнтів"
 
-#: src/ExternalConn.cpp:807
+#: src/ExternalConn.cpp:806
 #, fuzzy, c-format
 msgid "Unauthorized access attempt from %s. Connection closed."
 msgstr "Спроба доступу без уповноваження. З'єднання розірвано."
 
-#: src/ExternalConn.cpp:1420
+#: src/ExternalConn.cpp:1419
 #, c-format
 msgid "Remote PartFile command failed: FileHash not found: %s"
 msgstr "Віддалена PartFile-команда не вдалася: хеш файлу не знайдено: %s"
 
-#: src/ExternalConn.cpp:1424
+#: src/ExternalConn.cpp:1423
 #, c-format
 msgid "FileHash not found: %s"
 msgstr "Хеш файлу не знайдений: %s"
 
-#: src/ExternalConn.cpp:1471 src/ExternalConn.cpp:1559
-#: src/ExternalConn.cpp:1680
+#: src/ExternalConn.cpp:1470 src/ExternalConn.cpp:1558
+#: src/ExternalConn.cpp:1679
 msgid "OOPS! OpCode processing error!"
 msgstr "Помилка при виконання OpCode"
 
-#: src/ExternalConn.cpp:1502
+#: src/ExternalConn.cpp:1501
 msgid "Server not added"
 msgstr "Сервер не додано"
 
-#: src/ExternalConn.cpp:1521
+#: src/ExternalConn.cpp:1520
 #, c-format
 msgid "server not found: %s"
 msgstr "сервер не знайдено: %s"
 
-#: src/ExternalConn.cpp:1538
+#: src/ExternalConn.cpp:1537
 msgid "need to define server to be removed"
 msgstr "потрібно визначити сервер для видалення"
 
-#: src/ExternalConn.cpp:1553
+#: src/ExternalConn.cpp:1552
 msgid "eD2k is disabled in preferences."
 msgstr "eD2k вимкнена у налаштуваннях"
 
-#: src/ExternalConn.cpp:1658
+#: src/ExternalConn.cpp:1657
 #, fuzzy
 msgid "Friend not found."
 msgstr "Файл не знайдено."
 
-#: src/ExternalConn.cpp:1668
+#: src/ExternalConn.cpp:1667
 #, fuzzy
 msgid "Client not found."
 msgstr "Файл не знайдено."
 
-#: src/ExternalConn.cpp:1674
+#: src/ExternalConn.cpp:1673
 msgid "EC_TAG_FRIEND_SHARED requires EC_TAG_FRIEND or EC_TAG_CLIENT."
 msgstr ""
 
-#: src/ExternalConn.cpp:1992
+#: src/ExternalConn.cpp:1991
 msgid "WebSearch from remote interface makes no sense."
 msgstr "Веб-пошук через віддалений інтерфейс не має сенсу. "
 
-#: src/ExternalConn.cpp:2027
+#: src/ExternalConn.cpp:2026
 msgid "Search in progress. Refetch results in a moment!"
 msgstr "Пошук просувається. За мить отримаю здобутки!"
 
-#: src/ExternalConn.cpp:2266
+#: src/ExternalConn.cpp:2265
 msgid "No points for graph."
 msgstr "Немає точок для графіку."
 
-#: src/ExternalConn.cpp:2276
+#: src/ExternalConn.cpp:2275
 msgid "Your client is not configured for this detail level."
 msgstr "Ваш клієнт не налаштований для такого рівня подробиць."
 
-#: src/ExternalConn.cpp:2303
+#: src/ExternalConn.cpp:2302
 msgid "External Connection: shutdown requested"
 msgstr "Зовнішнє з'єднання: запит на вимкнення"
 
-#: src/ExternalConn.cpp:2315
+#: src/ExternalConn.cpp:2314
 msgid "Already shutting down."
 msgstr "Вже вимикається."
 
-#: src/ExternalConn.cpp:2333
+#: src/ExternalConn.cpp:2332
 #, c-format
 msgid "ExternalConn: adding link '%s'."
 msgstr "Зовнішнє з'єднання: додається посилання '%s'"
 
-#: src/ExternalConn.cpp:2351
+#: src/ExternalConn.cpp:2350
 #, fuzzy, c-format
 msgid "%d of %d links failed (invalid or already on list)."
 msgstr "Недопустиме посилання або вже в переліку."
 
-#: src/ExternalConn.cpp:2374
+#: src/ExternalConn.cpp:2373
 msgid "Version check throttled; try again shortly."
 msgstr ""
 
-#: src/ExternalConn.cpp:2379
+#: src/ExternalConn.cpp:2378
 msgid "Version check is not available on this daemon."
 msgstr ""
 
-#: src/ExternalConn.cpp:2509
+#: src/ExternalConn.cpp:2508
 msgid "File not found."
 msgstr "Файл не знайдено."
 
-#: src/ExternalConn.cpp:2514
+#: src/ExternalConn.cpp:2513
 msgid "Invalid file name."
 msgstr "Недопустима назва файлу."
 
-#: src/ExternalConn.cpp:2522
+#: src/ExternalConn.cpp:2521
 msgid "Unable to rename file."
 msgstr "Неможливо змінити назву файлу."
 
-#: src/ExternalConn.cpp:2839
-#, c-format
-msgid "Could not save the amuleapi password: %s"
-msgstr ""
-
-#: src/ExternalConn.cpp:3004 src/ExternalConn.cpp:3032
+#: src/ExternalConn.cpp:2992 src/ExternalConn.cpp:3020
 msgid "Kad is disabled in preferences."
 msgstr "Kad вимкнена в налаштуваннях."
 
-#: src/ExternalConn.cpp:3045
+#: src/ExternalConn.cpp:3033
 msgid "Already connected to eD2k."
 msgstr "Вже з'єднано з eD2k"
 
-#: src/ExternalConn.cpp:3048
+#: src/ExternalConn.cpp:3036
 msgid "Connecting to eD2k..."
 msgstr "З'єднується з eD2k..."
 
-#: src/ExternalConn.cpp:3057
+#: src/ExternalConn.cpp:3045
 msgid "Already connected to Kad."
 msgstr "Вже з'єднано з Kad."
 
-#: src/ExternalConn.cpp:3060
+#: src/ExternalConn.cpp:3048
 msgid "Connecting to Kad..."
 msgstr "З'єднується з Kad"
 
-#: src/ExternalConn.cpp:3067
+#: src/ExternalConn.cpp:3055
 msgid "All networks are disabled."
 msgstr "Всі мережі вимкнені."
 
-#: src/ExternalConn.cpp:3076
+#: src/ExternalConn.cpp:3064
 msgid "Disconnected from eD2k."
 msgstr "Від'єднується від eD2k."
 
-#: src/ExternalConn.cpp:3081
+#: src/ExternalConn.cpp:3069
 msgid "Disconnected from Kad."
 msgstr "Від'єднується від Kad."
 
-#: src/ExternalConn.cpp:3090
+#: src/ExternalConn.cpp:3078
 #, c-format
 msgid "External Connection: invalid opcode received: %#x"
 msgstr "Зовнішнє з'єднання: отримано недопустимий opcode: %#x"
 
-#: src/ExternalConn.cpp:3095
+#: src/ExternalConn.cpp:3083
 msgid "Invalid opcode (wrong protocol version?)"
 msgstr "Недопустимий opcode (невірна версія протоколу?)"
 
@@ -2360,19 +2350,19 @@ msgstr ""
 msgid "eD2k"
 msgstr "eD2k"
 
-#: src/FirstRunWizard.cpp:349 src/muuli_wdr.cpp:1495
+#: src/FirstRunWizard.cpp:349 src/muuli_wdr.cpp:1488
 msgid "Kademlia"
 msgstr "Kademlia"
 
-#: src/FirstRunWizard.cpp:359 src/muuli_wdr.cpp:1423
+#: src/FirstRunWizard.cpp:359 src/muuli_wdr.cpp:1416
 msgid "Standard TCP Port "
 msgstr "Зразковий TCP-порт "
 
-#: src/FirstRunWizard.cpp:365 src/muuli_wdr.cpp:1435
+#: src/FirstRunWizard.cpp:365 src/muuli_wdr.cpp:1428
 msgid "Extended UDP port (Kad / global search) "
 msgstr "Розширений порт UDP (Kad / глобальний пошук) "
 
-#: src/FirstRunWizard.cpp:377 src/muuli_wdr.cpp:1442
+#: src/FirstRunWizard.cpp:377 src/muuli_wdr.cpp:1435
 msgid "Enable UPnP for router port forwarding"
 msgstr "Ввімкнути UPnP для перенаправлення портів"
 
@@ -2399,7 +2389,7 @@ msgstr ""
 msgid "Your peer lists are already in place - nothing to download."
 msgstr "Ви вже спробували звантажити файл %s"
 
-#: src/FirstRunWizard.cpp:434 src/muuli_wdr.cpp:1540
+#: src/FirstRunWizard.cpp:434 src/muuli_wdr.cpp:1533
 msgid "Auto-update server list at startup"
 msgstr "Автоматичне оновлення переліку серверів після запуску"
 
@@ -2445,23 +2435,23 @@ msgid ""
 "want downloads on a different (e.g. larger) disk."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:549 src/FirstRunWizard.cpp:611 src/muuli_wdr.cpp:1702
+#: src/FirstRunWizard.cpp:549 src/FirstRunWizard.cpp:611 src/muuli_wdr.cpp:1701
 msgid "Destination folder for downloads"
 msgstr "Тека призначення для звантажень"
 
-#: src/FirstRunWizard.cpp:553 src/FirstRunWizard.cpp:569 src/muuli_wdr.cpp:1349
-#: src/muuli_wdr.cpp:1366 src/muuli_wdr.cpp:1677 src/muuli_wdr.cpp:1708
-#: src/muuli_wdr.cpp:1720 src/muuli_wdr.cpp:2790
+#: src/FirstRunWizard.cpp:553 src/FirstRunWizard.cpp:569 src/muuli_wdr.cpp:1342
+#: src/muuli_wdr.cpp:1359 src/muuli_wdr.cpp:1676 src/muuli_wdr.cpp:1707
+#: src/muuli_wdr.cpp:1719 src/muuli_wdr.cpp:2762
 #: src/utils/aLinkCreator/src/alcframe.cpp:135
 #: src/utils/wxCas/src/wxcasprefs.cpp:52 src/utils/wxCas/src/wxcasprefs.cpp:118
 msgid "Browse"
 msgstr "Переглянути"
 
-#: src/FirstRunWizard.cpp:559 src/muuli_wdr.cpp:1713
+#: src/FirstRunWizard.cpp:559 src/muuli_wdr.cpp:1712
 msgid "(All files in this folder are shared with other peers)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:565 src/FirstRunWizard.cpp:624 src/muuli_wdr.cpp:1715
+#: src/FirstRunWizard.cpp:565 src/FirstRunWizard.cpp:624 src/muuli_wdr.cpp:1714
 msgid "Folder for temporary download files"
 msgstr "Тека для тимчасових звантажуваних файлів"
 
@@ -2492,7 +2482,7 @@ msgstr "Неможливо відкрити перелік друзів 'emfrien
 msgid "CRITICAL - no client on StartChatSession"
 msgstr "КРИТИЧНО - немає клієнта на StartChatSession"
 
-#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2696 src/muuli_wdr.cpp:3373
+#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2668 src/muuli_wdr.cpp:3345
 msgid "Friends"
 msgstr "Друзі"
 
@@ -2606,8 +2596,8 @@ msgstr "Жоден"
 msgid "No"
 msgstr "Ні"
 
-#: src/GenericClientListCtrl.cpp:1216 src/PrefsUnifiedDlg.cpp:2898
-#: src/PrefsUnifiedDlg.cpp:2948 src/ServerListCtrl.cpp:276
+#: src/GenericClientListCtrl.cpp:1216 src/PrefsUnifiedDlg.cpp:2818
+#: src/PrefsUnifiedDlg.cpp:2868 src/ServerListCtrl.cpp:276
 msgid "Yes"
 msgstr "Так"
 
@@ -2779,10 +2769,10 @@ msgstr "Недопустимий порт для початкового запу
 msgid "Please fill all fields required"
 msgstr "Будь ласка, заповніть потрібні поля"
 
-#: src/KadDlg.cpp:192 src/PartFile.cpp:1031 src/PrefsUnifiedDlg.cpp:1134
-#: src/PrefsUnifiedDlg.cpp:1204 src/PrefsUnifiedDlg.cpp:1405
-#: src/PrefsUnifiedDlg.cpp:1663 src/PrefsUnifiedDlg.cpp:1673
-#: src/PrefsUnifiedDlg.cpp:1690 src/PrefsUnifiedDlg.cpp:1738
+#: src/KadDlg.cpp:192 src/PartFile.cpp:1031 src/PrefsUnifiedDlg.cpp:1162
+#: src/PrefsUnifiedDlg.cpp:1331 src/PrefsUnifiedDlg.cpp:1589
+#: src/PrefsUnifiedDlg.cpp:1599 src/PrefsUnifiedDlg.cpp:1616
+#: src/PrefsUnifiedDlg.cpp:1658
 msgid "Message"
 msgstr "Повідомлення"
 
@@ -2887,7 +2877,7 @@ msgstr "Відношення передачі"
 msgid "Uploaded"
 msgstr "Вивантажено"
 
-#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3253
+#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3225
 msgid "Requested"
 msgstr "Запитано"
 
@@ -3014,7 +3004,7 @@ msgid "WARNING: "
 msgstr "ЗАСТЕРЕЖЕННЯ: "
 
 #: src/MuleNotebook.cpp:179 src/muuli_wdr.cpp:817 src/muuli_wdr.cpp:1229
-#: src/muuli_wdr.cpp:3157 src/muuli_wdr.cpp:3413
+#: src/muuli_wdr.cpp:3129 src/muuli_wdr.cpp:3385
 msgid "Close"
 msgstr "Закрити"
 
@@ -3027,12 +3017,12 @@ msgstr "Вирізати"
 msgid "Copy"
 msgstr "Скопіювати"
 
-#: src/MuleTextCtrl.cpp:88 src/SearchDlg.cpp:261
+#: src/MuleTextCtrl.cpp:88
 msgid "Paste"
 msgstr "Вставити"
 
 #: src/MuleTextCtrl.cpp:89 src/muuli_wdr.cpp:358 src/muuli_wdr.cpp:757
-#: src/muuli_wdr.cpp:2380 src/muuli_wdr.cpp:2399 src/muuli_wdr.cpp:2421
+#: src/muuli_wdr.cpp:2352 src/muuli_wdr.cpp:2371 src/muuli_wdr.cpp:2393
 #: src/utils/aLinkCreator/src/alcframe.cpp:142
 msgid "Clear"
 msgstr "Очистити"
@@ -3130,8 +3120,8 @@ msgid "Exit"
 msgstr "Вийти"
 
 #: src/MuleTrayIcon.cpp:579 src/MuleTrayIcon.cpp:945 src/MuleTrayIcon.cpp:965
-#: src/muuli_wdr.cpp:1398 src/muuli_wdr.cpp:1406 src/muuli_wdr.cpp:1413
-#: src/muuli_wdr.cpp:1836 src/muuli_wdr.cpp:1842 src/OtherFunctions.cpp:91
+#: src/muuli_wdr.cpp:1391 src/muuli_wdr.cpp:1399 src/muuli_wdr.cpp:1406
+#: src/muuli_wdr.cpp:1835 src/muuli_wdr.cpp:1841 src/OtherFunctions.cpp:91
 #: src/StatisticsDlg.cpp:93 src/StatisticsDlg.cpp:95
 msgid "kB/s"
 msgstr "кбайт/с"
@@ -3302,7 +3292,7 @@ msgstr "Назва:"
 msgid "Type"
 msgstr "Тип"
 
-#: src/muuli_wdr.cpp:215 src/SearchDlg.cpp:118 src/SearchListCtrl.cpp:853
+#: src/muuli_wdr.cpp:215 src/SearchDlg.cpp:110 src/SearchListCtrl.cpp:853
 msgid "Local"
 msgstr "Місцевий"
 
@@ -3373,7 +3363,7 @@ msgstr "байт"
 msgid "KB"
 msgstr "кбайт"
 
-#: src/muuli_wdr.cpp:274 src/muuli_wdr.cpp:293 src/muuli_wdr.cpp:1621
+#: src/muuli_wdr.cpp:274 src/muuli_wdr.cpp:293 src/muuli_wdr.cpp:1620
 #: src/OtherFunctions.cpp:64
 msgid "MB"
 msgstr "Мбайт"
@@ -3390,7 +3380,7 @@ msgstr "Найбільший розмір"
 msgid "Availability"
 msgstr "Доступність"
 
-#: src/muuli_wdr.cpp:312 src/muuli_wdr.cpp:398 src/muuli_wdr.cpp:3318
+#: src/muuli_wdr.cpp:312 src/muuli_wdr.cpp:398 src/muuli_wdr.cpp:3290
 msgid "Filter:"
 msgstr "Фільтр:"
 
@@ -3422,7 +3412,7 @@ msgstr ""
 msgid "Stop"
 msgstr "Зупинити"
 
-#: src/muuli_wdr.cpp:348 src/muuli_wdr.cpp:1392 src/SearchListCtrl.cpp:732
+#: src/muuli_wdr.cpp:348 src/muuli_wdr.cpp:1385 src/SearchListCtrl.cpp:732
 msgid "Download"
 msgstr "Звантаження"
 
@@ -3454,12 +3444,12 @@ msgstr "Завершених джерел"
 #: src/muuli_wdr.cpp:1160 src/muuli_wdr.cpp:1167 src/muuli_wdr.cpp:1172
 #: src/muuli_wdr.cpp:1179 src/muuli_wdr.cpp:1184 src/muuli_wdr.cpp:1191
 #: src/muuli_wdr.cpp:1205 src/muuli_wdr.cpp:1212 src/muuli_wdr.cpp:1217
-#: src/muuli_wdr.cpp:1224 src/muuli_wdr.cpp:3255 src/muuli_wdr.cpp:3263
-#: src/muuli_wdr.cpp:3271
+#: src/muuli_wdr.cpp:1224 src/muuli_wdr.cpp:3227 src/muuli_wdr.cpp:3235
+#: src/muuli_wdr.cpp:3243
 msgid "N/A"
 msgstr "недоступні"
 
-#: src/muuli_wdr.cpp:508 src/muuli_wdr.cpp:1065 src/PrefsUnifiedDlg.cpp:299
+#: src/muuli_wdr.cpp:508 src/muuli_wdr.cpp:1065 src/PrefsUnifiedDlg.cpp:297
 msgid "General"
 msgstr "Загальні"
 
@@ -3600,7 +3590,7 @@ msgstr ""
 msgid "Album :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:685 src/muuli_wdr.cpp:2275
+#: src/muuli_wdr.cpp:685 src/muuli_wdr.cpp:2247
 msgid "Title :"
 msgstr "Назва:"
 
@@ -3709,7 +3699,7 @@ msgstr "Ім'я користувача:"
 msgid "Userhash :"
 msgstr "Хеш користувача:"
 
-#: src/muuli_wdr.cpp:895 src/muuli_wdr.cpp:1742 src/muuli_wdr.cpp:2470
+#: src/muuli_wdr.cpp:895 src/muuli_wdr.cpp:1741 src/muuli_wdr.cpp:2442
 #: src/utils/aLinkCreator/src/alcframe.cpp:137
 msgid "Add"
 msgstr "Додати"
@@ -3718,15 +3708,15 @@ msgstr "Додати"
 msgid "Download-Speed"
 msgstr "Швидкість звантаження"
 
-#: src/muuli_wdr.cpp:954 src/muuli_wdr.cpp:989 src/muuli_wdr.cpp:2574
+#: src/muuli_wdr.cpp:954 src/muuli_wdr.cpp:989 src/muuli_wdr.cpp:2546
 msgid "Current"
 msgstr "Поточна"
 
-#: src/muuli_wdr.cpp:962 src/muuli_wdr.cpp:997 src/muuli_wdr.cpp:2582
+#: src/muuli_wdr.cpp:962 src/muuli_wdr.cpp:997 src/muuli_wdr.cpp:2554
 msgid "Running average"
 msgstr "Середня"
 
-#: src/muuli_wdr.cpp:970 src/muuli_wdr.cpp:1005 src/muuli_wdr.cpp:2590
+#: src/muuli_wdr.cpp:970 src/muuli_wdr.cpp:1005 src/muuli_wdr.cpp:2562
 msgid "Session average"
 msgstr "Середня за сесію"
 
@@ -3738,7 +3728,7 @@ msgstr "Швидкість вивантаження"
 msgid "Connections"
 msgstr "З'єднання"
 
-#: src/muuli_wdr.cpp:1024 src/muuli_wdr.cpp:1861
+#: src/muuli_wdr.cpp:1024 src/muuli_wdr.cpp:1860
 msgid "Active downloads"
 msgstr "Чинні звантаження"
 
@@ -3746,7 +3736,7 @@ msgstr "Чинні звантаження"
 msgid "Active connections (1:1)"
 msgstr "Чинні з'єднання (1:1)"
 
-#: src/muuli_wdr.cpp:1040 src/muuli_wdr.cpp:1862
+#: src/muuli_wdr.cpp:1040 src/muuli_wdr.cpp:1861
 msgid "Active uploads"
 msgstr "Чинні вивантаження"
 
@@ -3863,8 +3853,8 @@ msgstr "Це ім'я, яке бачать інші користувачі, ко�
 msgid "Language: "
 msgstr "Мова: "
 
-#: src/muuli_wdr.cpp:1257 src/muuli_wdr.cpp:1330 src/muuli_wdr.cpp:1334
-#: src/muuli_wdr.cpp:1337
+#: src/muuli_wdr.cpp:1257 src/muuli_wdr.cpp:1323 src/muuli_wdr.cpp:1327
+#: src/muuli_wdr.cpp:1330
 msgid "The delay before showing tool-tips."
 msgstr "Затримка перед показом підказок."
 
@@ -3942,965 +3932,941 @@ msgstr ""
 msgid "Enabling this will make aMule to show notifications when finished downloading."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1323
-#, fuzzy
-msgid "Remember search history"
-msgstr "Запам'ятати ці налаштування"
-
-#: src/muuli_wdr.cpp:1324
-msgid "Keeps a dropdown list of your past search terms in the Search tab's Name field. This remembers the queries you typed, not the results they returned."
-msgstr ""
-
-#: src/muuli_wdr.cpp:1329
+#: src/muuli_wdr.cpp:1322
 msgid "Tooltip delay time: "
 msgstr "Затримка показу порад: "
 
-#: src/muuli_wdr.cpp:1336
+#: src/muuli_wdr.cpp:1329
 msgid "seconds"
 msgstr "с"
 
-#: src/muuli_wdr.cpp:1340
+#: src/muuli_wdr.cpp:1333
 msgid "Browser Selection"
 msgstr "Обрати переглядач тенет"
 
-#: src/muuli_wdr.cpp:1346
+#: src/muuli_wdr.cpp:1339
 msgid "Enter your browser name here. Leave this field empty to use the system default browser."
 msgstr "Введіть тут назву вашого переглядача тенет. Залиште це поле порожнім, щоб використовувати переглядач встановлений за замовчуванням."
 
-#: src/muuli_wdr.cpp:1353
+#: src/muuli_wdr.cpp:1346
 msgid "Open in new tab if possible"
 msgstr "Відкрити в новій вкладці, якщо можливо"
 
-#: src/muuli_wdr.cpp:1355
+#: src/muuli_wdr.cpp:1348
 msgid "Open the web page in a new tab instead of in a new window when possible"
 msgstr "Відкрити сторінку тенет в новій вкладці замість нового вікна, якщо можливо"
 
-#: src/muuli_wdr.cpp:1359
+#: src/muuli_wdr.cpp:1352
 msgid "Video Player"
 msgstr "Відеопрогравач"
 
-#: src/muuli_wdr.cpp:1386
+#: src/muuli_wdr.cpp:1379
 msgid "Bandwidth limits"
 msgstr "Обмеження ширини смуги"
 
-#: src/muuli_wdr.cpp:1400
+#: src/muuli_wdr.cpp:1393
 msgid "Upload"
 msgstr "Вивантаження"
 
-#: src/muuli_wdr.cpp:1408
+#: src/muuli_wdr.cpp:1401
 msgid "Slot Allocation"
 msgstr "Виділення шматків"
 
-#: src/muuli_wdr.cpp:1417
+#: src/muuli_wdr.cpp:1410
 msgid "Ports"
 msgstr "Порти"
 
-#: src/muuli_wdr.cpp:1427
+#: src/muuli_wdr.cpp:1420
 msgid "This is the standard eD2k port and cannot be disabled."
 msgstr "Це звичайний порт eD2k і не може бути вимкненим."
 
-#: src/muuli_wdr.cpp:1430
+#: src/muuli_wdr.cpp:1423
 msgid "UDP port for server requests (TCP+3):"
 msgstr "Порт UDP для запитів сервера (TCP+3):"
 
-#: src/muuli_wdr.cpp:1432
+#: src/muuli_wdr.cpp:1425
 msgid "4665"
 msgstr "4665"
 
-#: src/muuli_wdr.cpp:1439
+#: src/muuli_wdr.cpp:1432
 msgid "This UDP port is used for extended eD2k requests and Kad network"
 msgstr "Цей порт використовується для зовнішній запитів eD2k та для мережі Kad"
 
-#: src/muuli_wdr.cpp:1446
+#: src/muuli_wdr.cpp:1439
 msgid "UPnP TCP Port (Optional):"
 msgstr "UPnP TCP порт (не обов'язково):"
 
-#: src/muuli_wdr.cpp:1456
+#: src/muuli_wdr.cpp:1449
 msgid "Bind local address to IP (empty for any):"
 msgstr "Використовувати IP-адресу (пусто для будь-якої):"
 
-#: src/muuli_wdr.cpp:1459
+#: src/muuli_wdr.cpp:1452
 msgid "Advanced users only: If you have multiple network interfaces, enter the address of the interface to which aMule should be bound."
 msgstr "Тільки досвідченим користувачам: якщо ви маєте багато мережевих інтерфейсів, введіть адресу інтерфейсу до якого слід прив'язатися aMule."
 
-#: src/muuli_wdr.cpp:1462 src/muuli_wdr.cpp:2055
+#: src/muuli_wdr.cpp:1455 src/muuli_wdr.cpp:2054
 #, fuzzy
 msgid "Bind to network interface (empty for any):"
 msgstr "Використовувати IP-адресу (пусто для будь-якої):"
 
-#: src/muuli_wdr.cpp:1475
+#: src/muuli_wdr.cpp:1468
 msgid "Advanced users only: pin all of aMule's traffic to one network interface, chosen from the list or typed in by name (e.g. tun0, eth0, en0) or index. Unlike binding to an IP, this stops traffic leaking out via the default route - useful with a VPN. Requires no elevated privileges."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1481
+#: src/muuli_wdr.cpp:1474
 msgid "Max sources per downloading file:"
 msgstr "Найбільше джерел на звантажуваний файл:"
 
-#: src/muuli_wdr.cpp:1485
+#: src/muuli_wdr.cpp:1478
 msgid "Max simultaneous connections:"
 msgstr "Найбільше одночасних з'єднань:"
 
-#: src/muuli_wdr.cpp:1498 src/muuli_wdr.cpp:3197
+#: src/muuli_wdr.cpp:1491 src/muuli_wdr.cpp:3169
 msgid "ED2K"
 msgstr "eD2k"
 
-#: src/muuli_wdr.cpp:1505
+#: src/muuli_wdr.cpp:1498
 msgid "Autoconnect on startup"
 msgstr "Автоматичне з'єднання після запуску"
 
-#: src/muuli_wdr.cpp:1508
+#: src/muuli_wdr.cpp:1501
 msgid "Reconnect on loss"
 msgstr "Перез'єднатись при втраті з'єднання"
 
-#: src/muuli_wdr.cpp:1530
+#: src/muuli_wdr.cpp:1523
 msgid "Remove dead server after"
 msgstr "Вилучити мертвий сервер після"
 
-#: src/muuli_wdr.cpp:1531
+#: src/muuli_wdr.cpp:1524
 msgid "Static servers are never removed, even when unreachable."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1535
+#: src/muuli_wdr.cpp:1528
 msgid "retries"
 msgstr "спроб"
 
-#: src/muuli_wdr.cpp:1543
+#: src/muuli_wdr.cpp:1536
 msgid "List"
 msgstr "Перелік"
 
-#: src/muuli_wdr.cpp:1546
+#: src/muuli_wdr.cpp:1539
 msgid "Update server list when connecting to a server"
 msgstr "Оновити перелік серверів після з'єднання з сервером"
 
-#: src/muuli_wdr.cpp:1549
+#: src/muuli_wdr.cpp:1542
 msgid "Update server list when a client connects"
 msgstr "Оновити перелік серверів після з'єднання з клієнтами"
 
-#: src/muuli_wdr.cpp:1552
+#: src/muuli_wdr.cpp:1545
 msgid "Use priority system"
 msgstr "Використовувати систему переваг"
 
-#: src/muuli_wdr.cpp:1556
+#: src/muuli_wdr.cpp:1549
 msgid "Use smart LowID check on connect"
 msgstr "Використовувати розумну перевірку LowID під час з'єднання"
 
-#: src/muuli_wdr.cpp:1560
+#: src/muuli_wdr.cpp:1553
 msgid "Safe connect"
 msgstr "Безпечне з'єднання"
 
-#: src/muuli_wdr.cpp:1564
+#: src/muuli_wdr.cpp:1557
 msgid "Autoconnect to servers in static list only"
 msgstr "Автоматично з'єднуватись тільки з серверами з переліку постійних"
 
-#: src/muuli_wdr.cpp:1567
+#: src/muuli_wdr.cpp:1560
 msgid "Set manually added servers to High Priority"
 msgstr "Встановити високу перевагу доданим вручну серверам"
 
-#: src/muuli_wdr.cpp:1588
+#: src/muuli_wdr.cpp:1581
 msgid "Add files to download in pause mode"
 msgstr "Додати файли для звантаження призупиненими"
 
-#: src/muuli_wdr.cpp:1590
+#: src/muuli_wdr.cpp:1583
 msgid "Add files to download with auto priority"
 msgstr "Додати файли для звантаження з автоматичною перевагою"
 
-#: src/muuli_wdr.cpp:1593
+#: src/muuli_wdr.cpp:1586
 msgid "Try to download first and last chunks first"
 msgstr "Спробувати спершу звантажити перший та останній шматки"
 
-#: src/muuli_wdr.cpp:1597
+#: src/muuli_wdr.cpp:1590
 msgid "Endgame mode: rotate to faster sources for the final blocks"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1600
+#: src/muuli_wdr.cpp:1593
 msgid "Start next paused file when a file completes"
 msgstr "Запустити наступний призупинений файл, коли файл завершиться"
 
-#: src/muuli_wdr.cpp:1603
+#: src/muuli_wdr.cpp:1596
 msgid "From the same category"
 msgstr "З тієї самої категорії"
 
-#: src/muuli_wdr.cpp:1605
+#: src/muuli_wdr.cpp:1598
 msgid "In alphabetic order"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1607
+#: src/muuli_wdr.cpp:1600
 msgid "Preallocate disk space for new files"
 msgstr "Попереднє виділення місця на диску для нових файлів"
 
-#: src/muuli_wdr.cpp:1608
+#: src/muuli_wdr.cpp:1601
 msgid "For new files preallocates disk space for the whole file, thus reduces fragmentation"
 msgstr "Повністю виділяти місце для всього нового файлу, це зменшить фрагментування"
 
-#: src/muuli_wdr.cpp:1613
+#: src/muuli_wdr.cpp:1606
+msgid "Create new files as sparse files"
+msgstr ""
+
+#: src/muuli_wdr.cpp:1607
+msgid "A sparse file reserves its full size on disk immediately without writing real data to it -- fast, but unsupported or slow on some filesystems, and free-space accounting stays optimistic while the download is in progress. Turn this off to grow the file only as data arrives."
+msgstr ""
+
+#: src/muuli_wdr.cpp:1612
 msgid "Stop downloads when free disk space reaches "
 msgstr "Припинити звантаження коли вільне місце на диску досягнуло "
 
-#: src/muuli_wdr.cpp:1614
+#: src/muuli_wdr.cpp:1613
 msgid "Select this if you want aMule to check your disk space"
 msgstr "Виберіть це якщо хочете, щоб aMule перевіряв ваше місце на диску"
 
-#: src/muuli_wdr.cpp:1618
+#: src/muuli_wdr.cpp:1617
 msgid "Enter here the min disk space desired."
 msgstr "Введіть найменше бажане місце на диску"
 
-#: src/muuli_wdr.cpp:1624
+#: src/muuli_wdr.cpp:1623
 msgid "Save 10 sources on rare files (< 20 sources)"
 msgstr "Зберегти 10 джерел рідкісних файлів (менше ніж 20 джерел)"
 
-#: src/muuli_wdr.cpp:1628 src/Statistics.cpp:790
+#: src/muuli_wdr.cpp:1627 src/Statistics.cpp:790
 msgid "Uploads"
 msgstr "Вивантаження"
 
-#: src/muuli_wdr.cpp:1631
+#: src/muuli_wdr.cpp:1630
 msgid "Add new shared files with auto priority"
 msgstr "Додати нові спільні файли з автоматичною перевагою"
 
-#: src/muuli_wdr.cpp:1637
+#: src/muuli_wdr.cpp:1636
 msgid "Intelligent Corruption Handling (I.C.H.)"
 msgstr "Розумна обробка пошкоджень (Р.О.П.)"
 
-#: src/muuli_wdr.cpp:1640
+#: src/muuli_wdr.cpp:1639
 msgid "Enable"
 msgstr "Ввімкнено"
 
-#: src/muuli_wdr.cpp:1643
+#: src/muuli_wdr.cpp:1642
 msgid "Advanced I.C.H. trusts every hash (not recommended)"
 msgstr "Вдосконалена Р.О.П. довіряє всім хешам (не радимо)"
 
-#: src/muuli_wdr.cpp:1655 src/PrefsUnifiedDlg.cpp:1990
+#: src/muuli_wdr.cpp:1654 src/PrefsUnifiedDlg.cpp:1910
 msgid "Media metadata extraction"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1659
+#: src/muuli_wdr.cpp:1658
 msgid "Extract length / bitrate / codec from shared audio and video files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1661
+#: src/muuli_wdr.cpp:1660
 msgid "When enabled, aMule runs ffprobe on each shared media file to fill in the Length / Bitrate / Codec columns other clients see when they find the file in a search. Requires ffmpeg (the ffprobe binary) to be installed."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1668
+#: src/muuli_wdr.cpp:1667
 msgid "Path to ffprobe:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1673
+#: src/muuli_wdr.cpp:1672
 msgid "Full path to the ffprobe binary. Leave empty to have aMule auto-detect it on startup."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1681
+#: src/muuli_wdr.cpp:1680
 msgid "Detect"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1682
+#: src/muuli_wdr.cpp:1681
 msgid "Search the standard install locations for an ffprobe binary and fill the path field."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1706
+#: src/muuli_wdr.cpp:1705
 msgid ""
 "Completed downloads are stored here. All files in this folder are automatically shared with other peers.\n"
 "If this folder also holds files you don't want to share, point it at an aMule-only sub-folder."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1709
+#: src/muuli_wdr.cpp:1708
 msgid "Pick the folder where completed downloads will be stored. All files in that folder will be shared with other peers."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1723
+#: src/muuli_wdr.cpp:1722
 msgid "Shared folders"
 msgstr "Спільні теки"
 
-#: src/muuli_wdr.cpp:1729
+#: src/muuli_wdr.cpp:1728
 msgid "(Folders shared by the core. Enter a path to add one.)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1737
+#: src/muuli_wdr.cpp:1736
 msgid "Absolute path of a folder on the core's machine, e.g. /home/user/shared"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1739 src/PrefsUnifiedDlg.cpp:2874
+#: src/muuli_wdr.cpp:1738 src/PrefsUnifiedDlg.cpp:2794
 msgid "Recursive"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1740
+#: src/muuli_wdr.cpp:1739
 msgid "Share every sub-folder underneath this one, including ones created later."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1744 src/utils/aLinkCreator/src/alcframe.cpp:141
+#: src/muuli_wdr.cpp:1743 src/utils/aLinkCreator/src/alcframe.cpp:141
 msgid "Remove"
 msgstr "Вилучити"
 
-#: src/muuli_wdr.cpp:1748
+#: src/muuli_wdr.cpp:1747
 msgid "(Right click on folder icon for recursive share)"
 msgstr "(Праве клацання по значку теки для рекурсивного додавання)"
 
-#: src/muuli_wdr.cpp:1755
+#: src/muuli_wdr.cpp:1754
 msgid "Share hidden files"
 msgstr "Робити спільними приховані файли"
 
-#: src/muuli_wdr.cpp:1761
+#: src/muuli_wdr.cpp:1760
 msgid "Automatically rescan shared folders for changes"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1767
+#: src/muuli_wdr.cpp:1766
 msgid "Follow symbolic links in shared folders"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1773
+#: src/muuli_wdr.cpp:1772
 msgid "Exclude files matching:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1776
+#: src/muuli_wdr.cpp:1775
 msgid "Wildcard patterns separated by '|', e.g. .DS_Store|Thumbs.db|*.tmp. Files whose name matches are not shared. Matching is case-insensitive."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1780
+#: src/muuli_wdr.cpp:1779
 msgid "Patterns are regular expressions"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1781
+#: src/muuli_wdr.cpp:1780
 msgid "When set, the whole field is one regular expression ('|' is alternation). When unset, it is a list of '|'-separated wildcards."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1791
+#: src/muuli_wdr.cpp:1790
 msgid "Show how many shared files the current pattern would exclude."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1812
+#: src/muuli_wdr.cpp:1811
 msgid "Graphs"
 msgstr "Графіки"
 
-#: src/muuli_wdr.cpp:1815 src/muuli_wdr.cpp:1877
+#: src/muuli_wdr.cpp:1814 src/muuli_wdr.cpp:1876
 msgid "Update delay : 5 secs"
 msgstr "Час оновлення: 5 с"
 
-#: src/muuli_wdr.cpp:1819
+#: src/muuli_wdr.cpp:1818
 msgid "Time for average graph: 100 mins"
 msgstr "Час для середніх графіків: 100 хв"
 
-#: src/muuli_wdr.cpp:1823
+#: src/muuli_wdr.cpp:1822
 msgid "Connections Graph Scale: 100 "
 msgstr "Шкала графіку з'єднань: 100"
 
-#: src/muuli_wdr.cpp:1830
+#: src/muuli_wdr.cpp:1829
 msgid "Download graph scale:"
 msgstr "Шкала графіку звантаження"
 
-#: src/muuli_wdr.cpp:1838
+#: src/muuli_wdr.cpp:1837
 msgid "Upload graph scale:"
 msgstr "Шкала графіку вивантаження"
 
-#: src/muuli_wdr.cpp:1848
+#: src/muuli_wdr.cpp:1847
 #, fuzzy
 msgid "Colors: "
 msgstr "Кольори: "
 
-#: src/muuli_wdr.cpp:1852
+#: src/muuli_wdr.cpp:1851
 msgid "Background"
 msgstr "Фон"
 
-#: src/muuli_wdr.cpp:1853
+#: src/muuli_wdr.cpp:1852
 msgid "Grid"
 msgstr "Сітка"
 
-#: src/muuli_wdr.cpp:1854
+#: src/muuli_wdr.cpp:1853
 msgid "Download current"
 msgstr "Звантаження зараз"
 
-#: src/muuli_wdr.cpp:1855
+#: src/muuli_wdr.cpp:1854
 msgid "Download running average"
 msgstr "Звантаження середні за роботу"
 
-#: src/muuli_wdr.cpp:1856
+#: src/muuli_wdr.cpp:1855
 msgid "Download session average"
 msgstr "Звантаження середні за сесію"
 
-#: src/muuli_wdr.cpp:1857
+#: src/muuli_wdr.cpp:1856
 msgid "Upload current"
 msgstr "Вивантаження поточні"
 
-#: src/muuli_wdr.cpp:1858
+#: src/muuli_wdr.cpp:1857
 msgid "Upload running average"
 msgstr "Вивантаження середні за роботу"
 
-#: src/muuli_wdr.cpp:1859
+#: src/muuli_wdr.cpp:1858
 msgid "Upload session average"
 msgstr "Вивантаження середні за сесію"
 
-#: src/muuli_wdr.cpp:1860
+#: src/muuli_wdr.cpp:1859
 msgid "Active connections"
 msgstr "Чинні з'єднання"
 
-#: src/muuli_wdr.cpp:1863
+#: src/muuli_wdr.cpp:1862
 #, fuzzy
 msgid "Systray Icon Speed Bar"
 msgstr "Показувати стовпчик швидкості в системному лотку"
 
-#: src/muuli_wdr.cpp:1864
+#: src/muuli_wdr.cpp:1863
 msgid "Kad-nodes current"
 msgstr "Вузлів Kad зараз"
 
-#: src/muuli_wdr.cpp:1865
+#: src/muuli_wdr.cpp:1864
 msgid "Kad-nodes running"
 msgstr "Вузлів Kad запущено"
 
-#: src/muuli_wdr.cpp:1866
+#: src/muuli_wdr.cpp:1865
 msgid "Kad-nodes session"
 msgstr "Вузлів Kad за сесію"
 
-#: src/muuli_wdr.cpp:1870 src/muuli_wdr.cpp:2324
+#: src/muuli_wdr.cpp:1869 src/muuli_wdr.cpp:2296
 msgid "Select"
 msgstr "Вибрати"
 
-#: src/muuli_wdr.cpp:1874
+#: src/muuli_wdr.cpp:1873
 msgid "Tree"
 msgstr "Дерево"
 
-#: src/muuli_wdr.cpp:1884
+#: src/muuli_wdr.cpp:1883
 msgid "Number of Client Versions shown (0=unlimited)"
 msgstr "Кількість відображуваних версій клієнтів (0=необмежено)"
 
-#: src/muuli_wdr.cpp:1909
+#: src/muuli_wdr.cpp:1908
 msgid "!!! WARNING !!!"
 msgstr "!!! ЗАСТЕРЕЖЕННЯ !!!"
 
-#: src/muuli_wdr.cpp:1924
+#: src/muuli_wdr.cpp:1923
 msgid "Max new connections / 5 secs"
 msgstr "Найбільше зовнішніх з'єднань за 5 с"
 
-#: src/muuli_wdr.cpp:1926
+#: src/muuli_wdr.cpp:1925
 msgid "Concurrent Kad source lookups"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1928
+#: src/muuli_wdr.cpp:1927
 #, fuzzy
 msgid "Kad source re-search interval (minutes)"
 msgstr "Час оновлення FTP в хвилинах"
 
-#: src/muuli_wdr.cpp:1930
+#: src/muuli_wdr.cpp:1929
 #, fuzzy
 msgid "Source re-ask interval (minutes)"
 msgstr "Час оновлення FTP в хвилинах"
 
-#: src/muuli_wdr.cpp:1934
+#: src/muuli_wdr.cpp:1933
 msgid "File Buffer Size: 240000 bytes"
 msgstr "Розмір файлу буфера: 240000 байт"
 
-#: src/muuli_wdr.cpp:1938
+#: src/muuli_wdr.cpp:1937
 msgid "Use MMAP: memory-mapped file access (lower memory use)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1939
+#: src/muuli_wdr.cpp:1938
 msgid "Maps part files into memory instead of buffering them on the heap, lowering the process memory footprint. May reduce download speed on some disks; best for memory-constrained or upload-heavy hosts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1941
+#: src/muuli_wdr.cpp:1940
 msgid "Upload Queue Size: 5000 clients"
 msgstr "Розмір черги вивантаження: 5000 клієнтів"
 
-#: src/muuli_wdr.cpp:1945
+#: src/muuli_wdr.cpp:1944
 msgid "Server connection refresh interval: Disable"
 msgstr "Час оновлення з'єднання з сервером: вимкнено"
 
-#: src/muuli_wdr.cpp:1949
+#: src/muuli_wdr.cpp:1948
 msgid "Disable computer's timed standby mode"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1968
+#: src/muuli_wdr.cpp:1967
 msgid "Skin to use: "
 msgstr "Використати шкіру: "
 
-#: src/muuli_wdr.cpp:1977
+#: src/muuli_wdr.cpp:1976
 msgid "Show \"Fast eD2k Links Handler\" in every window."
 msgstr "Показати \"Швидкий оброблювач eD2k-посилань\" в кожному вікні."
 
-#: src/muuli_wdr.cpp:1980
+#: src/muuli_wdr.cpp:1979
 msgid "Show extended info on categories tabs"
 msgstr "Показати розширену інформацію на вкладках категорій"
 
-#: src/muuli_wdr.cpp:1983
+#: src/muuli_wdr.cpp:1982
 #, fuzzy
 msgid "Show application version on title"
 msgstr "Показувати швидкість передавання в заголовку"
 
-#: src/muuli_wdr.cpp:1985
+#: src/muuli_wdr.cpp:1984
 msgid "Show transfer rates on title"
 msgstr "Показувати швидкість передавання в заголовку"
 
-#: src/muuli_wdr.cpp:1987
+#: src/muuli_wdr.cpp:1986
 msgid "Before application name"
 msgstr "Перед назвою програми"
 
-#: src/muuli_wdr.cpp:1989
+#: src/muuli_wdr.cpp:1988
 msgid "After application name"
 msgstr "Після назви програми"
 
-#: src/muuli_wdr.cpp:1992
+#: src/muuli_wdr.cpp:1991
 msgid "Show overhead bandwidth"
 msgstr "Показати ширину смуги службового трафіку"
 
-#: src/muuli_wdr.cpp:1996
+#: src/muuli_wdr.cpp:1995
 msgid "Vertical toolbar orientation"
 msgstr "Вертикальне розміщення панелі інструментів"
 
-#: src/muuli_wdr.cpp:1998
+#: src/muuli_wdr.cpp:1997
 msgid "Live column sorting (auto-reorder rows as their values change)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2005
+#: src/muuli_wdr.cpp:2004
 msgid "Download Queue Files"
 msgstr "Звантажити файли в черзі"
 
-#: src/muuli_wdr.cpp:2008
+#: src/muuli_wdr.cpp:2007
 msgid "Show progress percentage"
 msgstr "Показувати поступ у відсотках"
 
-#: src/muuli_wdr.cpp:2014
+#: src/muuli_wdr.cpp:2013
 msgid "Show progress bar"
 msgstr "Показувати панель поступу"
 
-#: src/muuli_wdr.cpp:2017
+#: src/muuli_wdr.cpp:2016
 msgid "Flat"
 msgstr "Плаский"
 
-#: src/muuli_wdr.cpp:2021
+#: src/muuli_wdr.cpp:2020
 msgid "Round"
 msgstr "Круглий"
 
-#: src/muuli_wdr.cpp:2039
+#: src/muuli_wdr.cpp:2038
 msgid "External Connection Parameters"
 msgstr "Параметри зовнішніх з'єднань"
 
-#: src/muuli_wdr.cpp:2042
+#: src/muuli_wdr.cpp:2041
 msgid "Accept external connections"
 msgstr "Дозволити зовнішні з'єднання"
 
-#: src/muuli_wdr.cpp:2049 src/muuli_wdr.cpp:2108
+#: src/muuli_wdr.cpp:2048 src/muuli_wdr.cpp:2107
 msgid "IP of the listening interface:"
 msgstr "IP-адреса інтерфейса:"
 
-#: src/muuli_wdr.cpp:2052
+#: src/muuli_wdr.cpp:2051
 msgid "Enter here a valid ip in the a.b.c.d format for the listening EC interface. An empty field or 0.0.0.0 will mean any interface."
 msgstr "Введіть IP-адресу в вірному форматі a.b.c.d для прослуховування EC-інтерфейсу. Порожнє поле або 0.0.0.0 означатиме всі."
 
-#: src/muuli_wdr.cpp:2073 src/muuli_wdr.cpp:2184
+#: src/muuli_wdr.cpp:2072 src/muuli_wdr.cpp:2156
 msgid "TCP port:"
 msgstr "Порт TCP:"
 
-#: src/muuli_wdr.cpp:2079
+#: src/muuli_wdr.cpp:2078
 msgid "Enable UPnP port forwarding on the EC port"
 msgstr "Ввімкнути UPnP перенаправлення для EC-порту"
 
-#: src/muuli_wdr.cpp:2083 src/muuli_wdr.cpp:3069
+#: src/muuli_wdr.cpp:2082 src/muuli_wdr.cpp:3041
 #: src/utils/wxCas/src/wxcasprefs.cpp:167
 msgid "Password"
 msgstr "Пароль"
 
-#: src/muuli_wdr.cpp:2089
+#: src/muuli_wdr.cpp:2088
 #, fuzzy
 msgid "aMule API server parameters"
 msgstr "Налаштування веб-сервера"
 
-#: src/muuli_wdr.cpp:2092
+#: src/muuli_wdr.cpp:2091
 msgid "Run amuleapi (REST API) on startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2097
+#: src/muuli_wdr.cpp:2096
 #, fuzzy
 msgid "HTTP port:"
 msgstr "Порт TCP:"
 
-#: src/muuli_wdr.cpp:2111
+#: src/muuli_wdr.cpp:2110
 msgid "The interface amuleapi's HTTP server listens on. 127.0.0.1 (default) accepts only local connections; use 0.0.0.0 or a specific IP to expose it to other hosts (set an admin password below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2116
-msgid "Type a password to set or change it. Stored passwords cannot be shown, so leaving this empty keeps the current one."
-msgstr ""
-
-#: src/muuli_wdr.cpp:2118
+#: src/muuli_wdr.cpp:2113
 #, fuzzy
 msgid "Admin password"
 msgstr "Перевіряється пароль\n"
 
-#: src/muuli_wdr.cpp:2130 src/muuli_wdr.cpp:2147 src/PrefsUnifiedDlg.cpp:1103
-#, fuzzy
-msgid "A password is set."
-msgstr "Перевіряється пароль\n"
+#: src/muuli_wdr.cpp:2118 src/muuli_wdr.cpp:2149
+msgid "Low rights password"
+msgstr "Пароль низьких прав"
 
-#: src/muuli_wdr.cpp:2134
-#, fuzzy
-msgid "Enable guest access"
-msgstr "Заборонити гостьовий доступ"
-
-#: src/muuli_wdr.cpp:2135
-msgid "Guest sessions may read status and listings but cannot change anything. Turning this off clears the stored guest password."
-msgstr ""
-
-#: src/muuli_wdr.cpp:2139
-#, fuzzy
-msgid "Guest password"
-msgstr "Пароль гостя веб-сервера"
-
-#: src/muuli_wdr.cpp:2154
+#: src/muuli_wdr.cpp:2126
 msgid "Web server parameters"
 msgstr "Налаштування веб-сервера"
 
-#: src/muuli_wdr.cpp:2157
+#: src/muuli_wdr.cpp:2129
 #, fuzzy
 msgid "Run webserver on startup (deprecated)"
 msgstr "Запустити веб-сервер під час запуску"
 
-#: src/muuli_wdr.cpp:2163
+#: src/muuli_wdr.cpp:2135
 msgid "Web template"
 msgstr "Веб шаблон"
 
-#: src/muuli_wdr.cpp:2168
+#: src/muuli_wdr.cpp:2140
 msgid "Full rights password"
 msgstr "Пароль повних прав"
 
-#: src/muuli_wdr.cpp:2172
+#: src/muuli_wdr.cpp:2144
 msgid "Enable Low rights User"
 msgstr "Ввімкнути користувача з низькими правами"
 
-#: src/muuli_wdr.cpp:2177
-msgid "Low rights password"
-msgstr "Пароль низьких прав"
-
-#: src/muuli_wdr.cpp:2191
+#: src/muuli_wdr.cpp:2163
 msgid "Enable UPnP port forwarding of the web server port"
 msgstr "Ввімкнути UPnP перенаправлення портів для порту веб-сервера"
 
-#: src/muuli_wdr.cpp:2196
+#: src/muuli_wdr.cpp:2168
 msgid "Web server UPnP TCP port (Optional)"
 msgstr "UPnP TCP-порт веб-сервера (не обов'язково)"
 
-#: src/muuli_wdr.cpp:2204
+#: src/muuli_wdr.cpp:2176
 msgid "Page Refresh Time (in secs)"
 msgstr "Час оновлення сторінки (с)"
 
-#: src/muuli_wdr.cpp:2211
+#: src/muuli_wdr.cpp:2183
 msgid "Enable Gzip compression"
 msgstr "Дозволити Gzip-стиснення"
 
-#: src/muuli_wdr.cpp:2245
+#: src/muuli_wdr.cpp:2217
 #, fuzzy
 msgid "Reset page to defaults"
 msgstr "Мова системи"
 
-#: src/muuli_wdr.cpp:2246
+#: src/muuli_wdr.cpp:2218
 msgid "Reset the settings on the current page to their default values."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2248 src/muuli_wdr.cpp:2334 src/ServerWnd.cpp:274
+#: src/muuli_wdr.cpp:2220 src/muuli_wdr.cpp:2306 src/ServerWnd.cpp:274
 #: src/ServerWnd.cpp:282
 msgid "OK"
 msgstr "Гаразд"
 
-#: src/muuli_wdr.cpp:2250
+#: src/muuli_wdr.cpp:2222
 msgid "Click here to apply any changes made to the preferences."
 msgstr "Натисніть тут щоб застосувати зміни зроблені в налаштуваннях."
 
-#: src/muuli_wdr.cpp:2253
+#: src/muuli_wdr.cpp:2225
 msgid "Reset any changes made to the preferences."
 msgstr "Скинути всі зміни внесені в налаштування."
 
-#: src/muuli_wdr.cpp:2282
+#: src/muuli_wdr.cpp:2254
 msgid "Comment :"
 msgstr "Коментар:"
 
-#: src/muuli_wdr.cpp:2289
+#: src/muuli_wdr.cpp:2261
 msgid "Incoming Dir :"
 msgstr "Вхідна тека:"
 
-#: src/muuli_wdr.cpp:2298
+#: src/muuli_wdr.cpp:2270
 msgid "Change priority for new assigned files :"
 msgstr "Змінити перевагу для нового призначеного файлу:"
 
-#: src/muuli_wdr.cpp:2302
+#: src/muuli_wdr.cpp:2274
 #, fuzzy
 msgid "Don't change"
 msgstr "Не змінювати"
 
-#: src/muuli_wdr.cpp:2314
+#: src/muuli_wdr.cpp:2286
 msgid "Select color for this Category (currently selected) :"
 msgstr "Виберіть колір для цієї категорії (зараз вибрано):"
 
-#: src/muuli_wdr.cpp:2381 src/muuli_wdr.cpp:2400 src/muuli_wdr.cpp:2422
+#: src/muuli_wdr.cpp:2353 src/muuli_wdr.cpp:2372 src/muuli_wdr.cpp:2394
 msgid "Click this button to reset the log."
 msgstr "Натисніть цю кнопку, щоб очистити часопис."
 
-#: src/muuli_wdr.cpp:2441
+#: src/muuli_wdr.cpp:2413
 msgid "Click on this button to update the servers list from URL ..."
 msgstr "Натисніть на кнопку щоб оновити перелік серверів з адреси..."
 
-#: src/muuli_wdr.cpp:2445
+#: src/muuli_wdr.cpp:2417
 msgid "Server list"
 msgstr "Перелік серверів"
 
-#: src/muuli_wdr.cpp:2449
+#: src/muuli_wdr.cpp:2421
 msgid "Enter the url to a server.met file here and press the button to the left to update the list of known servers."
 msgstr "Введіть адресу файлу server.met та натисніть кнопку ліворуч щоб оновити перелік відомих серверів."
 
-#: src/muuli_wdr.cpp:2454
+#: src/muuli_wdr.cpp:2426
 msgid "Add server manually: Name"
 msgstr "Додати сервер вручну: Назва"
 
-#: src/muuli_wdr.cpp:2457
+#: src/muuli_wdr.cpp:2429
 msgid "Enter the name of the new server here"
 msgstr "Введіть тут назву нового сервера"
 
-#: src/muuli_wdr.cpp:2459 src/ServerWnd.cpp:206
+#: src/muuli_wdr.cpp:2431 src/ServerWnd.cpp:206
 msgid "IP:Port"
 msgstr "IP:Порт"
 
-#: src/muuli_wdr.cpp:2462
+#: src/muuli_wdr.cpp:2434
 msgid "Enter the IP of the server here, using the x.x.x.x format."
 msgstr "Тут введіть IP-адресу сервера, використовуючи формат x.x.x.x."
 
-#: src/muuli_wdr.cpp:2468
+#: src/muuli_wdr.cpp:2440
 msgid "Enter the port of the server here."
 msgstr "Введіть тут порт сервера."
 
-#: src/muuli_wdr.cpp:2471
+#: src/muuli_wdr.cpp:2443
 msgid "Add manually a server (fill fields to the left before) ..."
 msgstr "Додати сервер вручну (заповніть поля ліворуч)..."
 
-#: src/muuli_wdr.cpp:2500
+#: src/muuli_wdr.cpp:2472
 msgid "aMule Log"
 msgstr "Часопис aMule"
 
-#: src/muuli_wdr.cpp:2508
+#: src/muuli_wdr.cpp:2480
 msgid "Server Info"
 msgstr "Інфо сервера"
 
-#: src/muuli_wdr.cpp:2512
+#: src/muuli_wdr.cpp:2484
 msgid "ED2K Info"
 msgstr "Інфо eD2k"
 
-#: src/muuli_wdr.cpp:2516
+#: src/muuli_wdr.cpp:2488
 msgid "Kad Info"
 msgstr "Інфо Kad"
 
-#: src/muuli_wdr.cpp:2544
+#: src/muuli_wdr.cpp:2516
 msgid "Click on this button to update the nodes list from URL ..."
 msgstr "Натисніть на цю кнопку щоб оновити перелік вузлів з URL..."
 
-#: src/muuli_wdr.cpp:2548
+#: src/muuli_wdr.cpp:2520
 msgid "Nodes (0)"
 msgstr "Вузли (0)"
 
-#: src/muuli_wdr.cpp:2552
+#: src/muuli_wdr.cpp:2524
 msgid "Enter the url to a nodes.dat file here and press the button to the left to update the list of known nodes."
 msgstr "Введіть адресу файлу nodes.dat та натисніть кнопку ліворуч щоб оновити перелік відомих вузлів. "
 
-#: src/muuli_wdr.cpp:2555
+#: src/muuli_wdr.cpp:2527
 msgid "Nodes stats"
 msgstr "Статистика вузлів"
 
-#: src/muuli_wdr.cpp:2597
+#: src/muuli_wdr.cpp:2569
 msgid "Bootstrap"
 msgstr "Початковий запуск"
 
-#: src/muuli_wdr.cpp:2600
+#: src/muuli_wdr.cpp:2572
 msgid "New node"
 msgstr "Новий вузол"
 
-#: src/muuli_wdr.cpp:2605
+#: src/muuli_wdr.cpp:2577
 msgid "IP:"
 msgstr "IP:"
 
-#: src/muuli_wdr.cpp:2625
+#: src/muuli_wdr.cpp:2597
 msgid "Port:"
 msgstr "Порт:"
 
-#: src/muuli_wdr.cpp:2638
+#: src/muuli_wdr.cpp:2610
 #, fuzzy
 msgid "Bootstrap from known clients"
 msgstr ""
 "Початковий запуск\n"
 "відомого клієнта"
 
-#: src/muuli_wdr.cpp:2640
+#: src/muuli_wdr.cpp:2612
 msgid "Disconnect Kad"
 msgstr "Від'єднатися від Kad"
 
-#: src/muuli_wdr.cpp:2674
+#: src/muuli_wdr.cpp:2646
 msgid "Use Secure User Identification"
 msgstr "Використовувати безпечну ідентифікацію користувача"
 
-#: src/muuli_wdr.cpp:2676
+#: src/muuli_wdr.cpp:2648
 msgid "It is recommended to enable this option. You will not receive credits if SUI is not enabled."
 msgstr "Рекомендовано ввімкнути цю опцію. Ви не отримаєте довіру якщо безпечна ідентифікація вимкнена."
 
-#: src/muuli_wdr.cpp:2678
+#: src/muuli_wdr.cpp:2650
 msgid "Protocol Obfuscation"
 msgstr "Приховування протоколу"
 
-#: src/muuli_wdr.cpp:2681
+#: src/muuli_wdr.cpp:2653
 msgid "Support Protocol Obfuscation"
 msgstr "Підтримка приховування протоколу"
 
-#: src/muuli_wdr.cpp:2683
+#: src/muuli_wdr.cpp:2655
 msgid "This option enabled Protocol Obfuscation, and makes aMule accept obfuscated connections from other clients."
 msgstr "Ця опція вмикає приховування протоколу та дозволяє aMule приймати приховані з'єднання від інших клієнтів."
 
-#: src/muuli_wdr.cpp:2685
+#: src/muuli_wdr.cpp:2657
 msgid "Use obfuscation for outgoing connections"
 msgstr "Використовувати приховування для вихідних з'єднань"
 
-#: src/muuli_wdr.cpp:2687
+#: src/muuli_wdr.cpp:2659
 msgid "This option makes aMule use Protocol Obfuscation when connecting other clients/servers."
 msgstr "Ця опція вмикає приховування протоколу під час з'єдання з іншими клієнтами/серверами."
 
-#: src/muuli_wdr.cpp:2689
+#: src/muuli_wdr.cpp:2661
 msgid "Accept only obfuscated connections"
 msgstr "Приймати тільки приховані з'єднання"
 
-#: src/muuli_wdr.cpp:2690
+#: src/muuli_wdr.cpp:2662
 msgid "This option makes aMule only accept obfuscated connections. You will have less sources, but all your traffic will be obfuscated"
 msgstr "Приймати приховані з'єднання. Будете мати менше джерел, але весь ваш трафік буде приховано"
 
-#: src/muuli_wdr.cpp:2695
+#: src/muuli_wdr.cpp:2667
 msgid "Everybody"
 msgstr "Кожен"
 
-#: src/muuli_wdr.cpp:2697
+#: src/muuli_wdr.cpp:2669
 msgid "No one"
 msgstr "Жоден"
 
-#: src/muuli_wdr.cpp:2699
+#: src/muuli_wdr.cpp:2671
 msgid "Who can see my shared files:"
 msgstr "Хто може бачити мої спільні файли:"
 
-#: src/muuli_wdr.cpp:2700
+#: src/muuli_wdr.cpp:2672
 msgid "Select who can request to view a list of your shared files."
 msgstr "Оберіть тих, хто може запитати перелік ваших спільних файлів."
 
-#: src/muuli_wdr.cpp:2702
+#: src/muuli_wdr.cpp:2674
 msgid "IP-Filtering"
 msgstr "IP-фільтрування"
 
-#: src/muuli_wdr.cpp:2709
+#: src/muuli_wdr.cpp:2681
 msgid "Filter clients"
 msgstr "Фільтрувати клієнтів"
 
-#: src/muuli_wdr.cpp:2711
+#: src/muuli_wdr.cpp:2683
 msgid "Enable filtering of the client IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "Ввімкнено фільтрування IP-адрес клієнтів, що визначені в файлі ~/.aMule/ipfilter.dat."
 
-#: src/muuli_wdr.cpp:2713
+#: src/muuli_wdr.cpp:2685
 msgid "Filter servers"
 msgstr "Фільтрувати сервери"
 
-#: src/muuli_wdr.cpp:2715
+#: src/muuli_wdr.cpp:2687
 msgid "Enable filtering of the server IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "Ввімкнено фільтрування IP-адрес серверів, що визначені в файлі ~/.aMule/ipfilter.dat."
 
-#: src/muuli_wdr.cpp:2719
+#: src/muuli_wdr.cpp:2691
 msgid "Reload List"
 msgstr "Перезавантажити перелік"
 
-#: src/muuli_wdr.cpp:2720
+#: src/muuli_wdr.cpp:2692
 msgid "Reload the list of IPs to filter from the file ~/.aMule/ipfilter.dat"
 msgstr "Перезавантажити перелік IP-адрес для фільтрування з файлу ~/.aMule/ipfilter.dat"
 
-#: src/muuli_wdr.cpp:2726
+#: src/muuli_wdr.cpp:2698
 msgid "URL:"
 msgstr "URL:"
 
-#: src/muuli_wdr.cpp:2730 src/muuli_wdr.cpp:2923
+#: src/muuli_wdr.cpp:2702 src/muuli_wdr.cpp:2895
 msgid "Update now"
 msgstr "Оновити зараз"
 
-#: src/muuli_wdr.cpp:2733
+#: src/muuli_wdr.cpp:2705
 msgid "Auto-update ipfilter at startup"
 msgstr "Автоматичне оновлення IP-фільтру після запуску"
 
-#: src/muuli_wdr.cpp:2737
+#: src/muuli_wdr.cpp:2709
 msgid "Filtering Level:"
 msgstr "Рівень фільтра:"
 
-#: src/muuli_wdr.cpp:2743
+#: src/muuli_wdr.cpp:2715
 msgid "Always filter LAN IPs"
 msgstr "Завжди відфільтровувати IP-адреси локальних мереж"
 
-#: src/muuli_wdr.cpp:2746
+#: src/muuli_wdr.cpp:2718
 msgid "Paranoid handling of non-matching IPs"
 msgstr "Параноїдальна обробка IP-адрес, що не співпали"
 
-#: src/muuli_wdr.cpp:2748
+#: src/muuli_wdr.cpp:2720
 msgid "Rejects a packet when its source IP differs from the IP the client claims (an anti-spoofing check). Disable only if it causes connection problems."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2750
+#: src/muuli_wdr.cpp:2722
 msgid "Use system-wide ipfilter.dat if available"
 msgstr "Використовувати системний ipfilter.dat якщо наявний"
 
-#: src/muuli_wdr.cpp:2751
+#: src/muuli_wdr.cpp:2723
 #, fuzzy
 msgid "If there's no local ipfilter.dat found, allow usage of a system-wide ipfilter file."
 msgstr "Якщо не знайдено місцевий ipfilter.dat, дозволити використання системного."
 
-#: src/muuli_wdr.cpp:2768
+#: src/muuli_wdr.cpp:2740
 msgid "Enable Online-Signature"
 msgstr "Ввімкнути онлайн-підпис"
 
-#: src/muuli_wdr.cpp:2770
+#: src/muuli_wdr.cpp:2742
 msgid "Enables the writing of the OS file, which can be used by external apps to create signatures and the like."
 msgstr "Ввімкнути запис файлу ОС, який може бути використано зовнішніми програмами для створення підписів та подібного."
 
-#: src/muuli_wdr.cpp:2774
+#: src/muuli_wdr.cpp:2746
 msgid "Update Frequency (Secs):"
 msgstr "Частота оновлення (с)"
 
-#: src/muuli_wdr.cpp:2777
+#: src/muuli_wdr.cpp:2749
 msgid "Change the frequency (in seconds) of Online Signature updates."
 msgstr "Змінити частоту (в секундах) оновлень онлайн-підписів."
 
-#: src/muuli_wdr.cpp:2785
+#: src/muuli_wdr.cpp:2757
 msgid "Save online signature file in: "
 msgstr "Зберегти файл онлайн-підпису в: "
 
-#: src/muuli_wdr.cpp:2791
+#: src/muuli_wdr.cpp:2763
 msgid "Click here to select the directory containing the the Online Signature files."
 msgstr "Натисніть тут, щоб вибрати теку, що містить файли з онлайн-підписами."
 
-#: src/muuli_wdr.cpp:2824
+#: src/muuli_wdr.cpp:2796
 msgid "Show country flags for clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2825
+#: src/muuli_wdr.cpp:2797
 msgid "Render the country flag column in the transfers, queue and search views. Requires a valid MMDB GeoIP database (see below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2830
+#: src/muuli_wdr.cpp:2802
 #, fuzzy
 msgid "Database"
 msgstr "Швидкість передачі:"
 
-#: src/muuli_wdr.cpp:2846
+#: src/muuli_wdr.cpp:2818
 #, fuzzy
 msgid "Source:"
 msgstr "Джерела"
 
-#: src/muuli_wdr.cpp:2849
+#: src/muuli_wdr.cpp:2821
 msgid "DB-IP (free, no account)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2850
+#: src/muuli_wdr.cpp:2822
 msgid "MaxMind GeoLite2 (free, account required)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2851
+#: src/muuli_wdr.cpp:2823
 msgid "Custom URL"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2854
+#: src/muuli_wdr.cpp:2826
 msgid "Choose which provider supplies the GeoIP MMDB database. DB-IP is the default - no account required. MaxMind requires a free account + license key. Use Custom URL to point at any other MMDB host (e.g. a local mirror)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2871
+#: src/muuli_wdr.cpp:2843
 msgid ""
 "No configuration required.\n"
 "\n"
@@ -4908,11 +4874,11 @@ msgid ""
 "License: Creative Commons BY 4.0 - https://creativecommons.org/licenses/by/4.0/"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2884
+#: src/muuli_wdr.cpp:2856
 msgid "License key:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2890
+#: src/muuli_wdr.cpp:2862
 msgid ""
 "Sign up for a free MaxMind account, then generate a License Key:\n"
 "https://www.maxmind.com/en/geolite2/signup\n"
@@ -4922,232 +4888,232 @@ msgid ""
 "Requires attribution and account registration; refresh at least every 30 days."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2905
+#: src/muuli_wdr.cpp:2877
 #, fuzzy
 msgid "Download URL:"
 msgstr "Звантаження: "
 
-#: src/muuli_wdr.cpp:2911
+#: src/muuli_wdr.cpp:2883
 msgid ""
 "Must point to an .mmdb file or a .gz / .tar.gz containing one.\n"
 "URL may include credentials (https://user:pass@host/...).\n"
 "License and attribution terms are set by the upstream URL - you are responsible."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2924
+#: src/muuli_wdr.cpp:2896
 msgid "Download the GeoIP database from the selected source."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2926
+#: src/muuli_wdr.cpp:2898
 #, fuzzy
 msgid "Auto-update on startup"
 msgstr "Автоматичне оновлення IP-фільтру після запуску"
 
-#: src/muuli_wdr.cpp:2927
+#: src/muuli_wdr.cpp:2899
 msgid "Re-download the GeoIP database from the selected source every time aMule starts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2950
+#: src/muuli_wdr.cpp:2922
 msgid "Filter incoming messages (except current chat):"
 msgstr "Фільтрувати вхідні повідомлення (окрім поточної розмови):"
 
-#: src/muuli_wdr.cpp:2952
+#: src/muuli_wdr.cpp:2924
 msgid "Filter all messages"
 msgstr "Фільтрувати всі повідомлення"
 
-#: src/muuli_wdr.cpp:2954
+#: src/muuli_wdr.cpp:2926
 msgid "Filter messages from people not on your friend list"
 msgstr "Фільтрувати повідомлення від людей, що не в вашому переліку друзів"
 
-#: src/muuli_wdr.cpp:2956
+#: src/muuli_wdr.cpp:2928
 msgid "Filter messages from unknown clients"
 msgstr "Фільтрувати повідомлення від невідомих клієнтів"
 
-#: src/muuli_wdr.cpp:2958
+#: src/muuli_wdr.cpp:2930
 msgid "Filter messages containing (use ',' as separator):"
 msgstr "Фільтрувати повідомлення, що містять (використовуйте ',' для переліку):"
 
-#: src/muuli_wdr.cpp:2961 src/muuli_wdr.cpp:2972
+#: src/muuli_wdr.cpp:2933 src/muuli_wdr.cpp:2944
 msgid "add here the words amule should filter and block messages including it"
 msgstr "додати слова, які aMule буде фільтрувати, та забороняти повідомлення, що їх містять"
 
-#: src/muuli_wdr.cpp:2963
+#: src/muuli_wdr.cpp:2935
 msgid "Show received messages in the log"
 msgstr "Показувати отримані повідомлення в часописі"
 
-#: src/muuli_wdr.cpp:2966
+#: src/muuli_wdr.cpp:2938
 msgid "Comments"
 msgstr "Коментарі"
 
-#: src/muuli_wdr.cpp:2969
+#: src/muuli_wdr.cpp:2941
 msgid "Filter comments containing (use ',' as separator):"
 msgstr "Фільтрувати коментарі, що містять (використовуйте ',' для переліку):"
 
-#: src/muuli_wdr.cpp:2994
+#: src/muuli_wdr.cpp:2966
 msgid "Enable Proxy"
 msgstr "Ввімкнути проксі"
 
-#: src/muuli_wdr.cpp:2995
+#: src/muuli_wdr.cpp:2967
 msgid "Enable/disable proxy support"
 msgstr "Ввімкнути/вимкнути підтримку проксі"
 
-#: src/muuli_wdr.cpp:2998
+#: src/muuli_wdr.cpp:2970
 msgid "Proxy type:"
 msgstr "Тип проксі:"
 
-#: src/muuli_wdr.cpp:3009
+#: src/muuli_wdr.cpp:2981
 msgid "Proxy host:"
 msgstr "Хост проксі:"
 
-#: src/muuli_wdr.cpp:3012
+#: src/muuli_wdr.cpp:2984
 msgid "The proxy host name"
 msgstr "Ім'я хосту проксі"
 
-#: src/muuli_wdr.cpp:3014
+#: src/muuli_wdr.cpp:2986
 msgid "Proxy port:"
 msgstr "Порт проксі:"
 
-#: src/muuli_wdr.cpp:3017
+#: src/muuli_wdr.cpp:2989
 msgid "The proxy port"
 msgstr "Порт проксі"
 
-#: src/muuli_wdr.cpp:3019
+#: src/muuli_wdr.cpp:2991
 msgid "Enable authentication"
 msgstr "Включити авторизацію"
 
-#: src/muuli_wdr.cpp:3020
+#: src/muuli_wdr.cpp:2992
 msgid "Enable/disable username/password authentication"
 msgstr "Ввімкнути/вимкнути аутентифікацію з ім'ям/паролем"
 
-#: src/muuli_wdr.cpp:3023
+#: src/muuli_wdr.cpp:2995
 msgid "Username: "
 msgstr "Ім'я користувача: "
 
-#: src/muuli_wdr.cpp:3026
+#: src/muuli_wdr.cpp:2998
 msgid "The username to use to connect to the proxy"
 msgstr "Ім'я користувача для з'єднання з проксі"
 
-#: src/muuli_wdr.cpp:3028
+#: src/muuli_wdr.cpp:3000
 msgid "Password:"
 msgstr "Пароль:"
 
-#: src/muuli_wdr.cpp:3031
+#: src/muuli_wdr.cpp:3003
 msgid "The password to use to connect to the proxy"
 msgstr "Пароль для з'єднання з проксі"
 
-#: src/muuli_wdr.cpp:3050
+#: src/muuli_wdr.cpp:3022
 msgid "Connect to:"
 msgstr "З'єднатись з:"
 
-#: src/muuli_wdr.cpp:3059
+#: src/muuli_wdr.cpp:3031
 msgid "Login to remote amule"
 msgstr "Вхід до віддаленого aMule"
 
-#: src/muuli_wdr.cpp:3064
+#: src/muuli_wdr.cpp:3036
 msgid "User name"
 msgstr "Ім'я користувача"
 
-#: src/muuli_wdr.cpp:3075
+#: src/muuli_wdr.cpp:3047
 msgid "Remember those settings"
 msgstr "Запам'ятати ці налаштування"
 
-#: src/muuli_wdr.cpp:3078
+#: src/muuli_wdr.cpp:3050
 #, fuzzy
 msgid "Force ZLIB compression"
 msgstr "Використовувати gzip-стиснення"
 
-#: src/muuli_wdr.cpp:3102
+#: src/muuli_wdr.cpp:3074
 msgid "Enable Verbose Debug-Logging."
 msgstr "Ввімкнути докладне ведення часопису."
 
-#: src/muuli_wdr.cpp:3104
+#: src/muuli_wdr.cpp:3076
 #, fuzzy
 msgid "Only to Logfile"
 msgstr "Відкрити файл"
 
-#: src/muuli_wdr.cpp:3106
+#: src/muuli_wdr.cpp:3078
 msgid "Message Categories:"
 msgstr "Категорія повідомлення:"
 
-#: src/muuli_wdr.cpp:3130 src/PartFileConvertDlg.cpp:160
+#: src/muuli_wdr.cpp:3102 src/PartFileConvertDlg.cpp:160
 msgid "Waiting..."
 msgstr "Очікується..."
 
-#: src/muuli_wdr.cpp:3150
+#: src/muuli_wdr.cpp:3122
 msgid "Add imports"
 msgstr "Додати зовнішні внесення"
 
-#: src/muuli_wdr.cpp:3153
+#: src/muuli_wdr.cpp:3125
 msgid "Retry selected"
 msgstr "Повторити вибрані"
 
-#: src/muuli_wdr.cpp:3155
+#: src/muuli_wdr.cpp:3127
 msgid "Remove selected"
 msgstr "Вилучити вибрані"
 
-#: src/muuli_wdr.cpp:3218
+#: src/muuli_wdr.cpp:3190
 msgid "Event Types"
 msgstr "Типи подій"
 
-#: src/muuli_wdr.cpp:3237
+#: src/muuli_wdr.cpp:3209
 msgid "Statistics and queued clients for selected file(s) : Session / All time"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3261
+#: src/muuli_wdr.cpp:3233
 #, fuzzy
 msgid "Active Uploads"
 msgstr "Чинні вивантаження:"
 
-#: src/muuli_wdr.cpp:3275
+#: src/muuli_wdr.cpp:3247
 msgid "Percent of total files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3327
+#: src/muuli_wdr.cpp:3299
 #, fuzzy
 msgid "Show Clients for"
 msgstr "Показати клієнтів"
 
-#: src/muuli_wdr.cpp:3329
+#: src/muuli_wdr.cpp:3301
 #, fuzzy
 msgid "All files"
 msgstr "Сховати спільні файли"
 
-#: src/muuli_wdr.cpp:3332
+#: src/muuli_wdr.cpp:3304
 #, fuzzy
 msgid "Selected files"
 msgstr "Вибрати фільтр перегляду"
 
-#: src/muuli_wdr.cpp:3335
+#: src/muuli_wdr.cpp:3307
 #, fuzzy
 msgid "Active uploads only"
 msgstr "Чинні вивантаження"
 
-#: src/muuli_wdr.cpp:3342
+#: src/muuli_wdr.cpp:3314
 #, fuzzy
 msgid "Reload:"
 msgstr "Перезавантажити перелік"
 
-#: src/muuli_wdr.cpp:3346
+#: src/muuli_wdr.cpp:3318
 msgid "Reload your shared files"
 msgstr "Перезавантажити ваші спільні файли"
 
-#: src/muuli_wdr.cpp:3409
+#: src/muuli_wdr.cpp:3381
 msgid "Send"
 msgstr "Надіслати"
 
-#: src/muuli_wdr.cpp:3410
+#: src/muuli_wdr.cpp:3382
 msgid "Sends the specified message."
 msgstr "Надіслати вказане повідомлення."
 
-#: src/muuli_wdr.cpp:3414
+#: src/muuli_wdr.cpp:3386
 msgid "Close this chat-session."
 msgstr "Закрити цю розмову."
 
-#: src/muuli_wdr.cpp:3437
+#: src/muuli_wdr.cpp:3409
 msgid "Connect to any server and/or Kad"
 msgstr "З'єднатися з будь-яким сервером та/чи Kad"
 
-#: src/muuli_wdr.cpp:3443 src/SharedFilesCtrl.cpp:142 src/Statistics.cpp:941
+#: src/muuli_wdr.cpp:3415 src/SharedFilesCtrl.cpp:142 src/Statistics.cpp:941
 msgid "Shared Files"
 msgstr "Спільні файли"
 
@@ -5511,268 +5477,268 @@ msgstr "Звантажені"
 msgid "ERROR: Failed to open partfile '%s'"
 msgstr "ПОМИЛКА: не вдалося відкрити частковий файл '%s'"
 
-#: src/Preferences.cpp:701
+#: src/Preferences.cpp:673
 msgid "System default"
 msgstr "Мова системи"
 
-#: src/Preferences.cpp:702
+#: src/Preferences.cpp:674
 msgid "Albanian"
 msgstr "Албанська"
 
-#: src/Preferences.cpp:703
+#: src/Preferences.cpp:675
 msgid "Arabic"
 msgstr "Арабська"
 
-#: src/Preferences.cpp:704
+#: src/Preferences.cpp:676
 #, fuzzy
 msgid "Asturian"
 msgstr "Естонська"
 
-#: src/Preferences.cpp:705
+#: src/Preferences.cpp:677
 msgid "Basque"
 msgstr "Баскська"
 
-#: src/Preferences.cpp:706
+#: src/Preferences.cpp:678
 msgid "Bulgarian"
 msgstr "Болгарська"
 
-#: src/Preferences.cpp:707
+#: src/Preferences.cpp:679
 msgid "Catalan"
 msgstr "Каталонська"
 
-#: src/Preferences.cpp:708
+#: src/Preferences.cpp:680
 msgid "Chinese (Simplified)"
 msgstr "Китайська (спрощена)"
 
-#: src/Preferences.cpp:709
+#: src/Preferences.cpp:681
 msgid "Chinese (Traditional)"
 msgstr "Китайська (традиційна)"
 
-#: src/Preferences.cpp:710
+#: src/Preferences.cpp:682
 msgid "Croatian"
 msgstr "Хорватська"
 
-#: src/Preferences.cpp:711
+#: src/Preferences.cpp:683
 msgid "Czech"
 msgstr "Чеська"
 
-#: src/Preferences.cpp:712
+#: src/Preferences.cpp:684
 msgid "Danish"
 msgstr "Данська"
 
-#: src/Preferences.cpp:713
+#: src/Preferences.cpp:685
 msgid "Dutch"
 msgstr "Нідерландська"
 
-#: src/Preferences.cpp:714
+#: src/Preferences.cpp:686
 msgid "English (U.K.)"
 msgstr "Англійська (Великобританія)"
 
-#: src/Preferences.cpp:715
+#: src/Preferences.cpp:687
 #, fuzzy
 msgid "English (U.S.)"
 msgstr "Англійська (Великобританія)"
 
-#: src/Preferences.cpp:716
+#: src/Preferences.cpp:688
 msgid "Estonian"
 msgstr "Естонська"
 
-#: src/Preferences.cpp:717
+#: src/Preferences.cpp:689
 msgid "Finnish"
 msgstr "Фінська"
 
-#: src/Preferences.cpp:718
+#: src/Preferences.cpp:690
 msgid "French"
 msgstr "Французька"
 
-#: src/Preferences.cpp:719
+#: src/Preferences.cpp:691
 msgid "Galician"
 msgstr "Галісійська"
 
-#: src/Preferences.cpp:720
+#: src/Preferences.cpp:692
 msgid "German"
 msgstr "Німецька"
 
-#: src/Preferences.cpp:721
+#: src/Preferences.cpp:693
 msgid "Greek"
 msgstr "Грецька"
 
-#: src/Preferences.cpp:722
+#: src/Preferences.cpp:694
 msgid "Hebrew"
 msgstr "Іврит"
 
-#: src/Preferences.cpp:723
+#: src/Preferences.cpp:695
 msgid "Hungarian"
 msgstr "Угорська"
 
-#: src/Preferences.cpp:724
+#: src/Preferences.cpp:696
 msgid "Italian"
 msgstr "Італійська"
 
-#: src/Preferences.cpp:725
+#: src/Preferences.cpp:697
 msgid "Japanese"
 msgstr "Японська"
 
-#: src/Preferences.cpp:726
+#: src/Preferences.cpp:698
 msgid "Korean"
 msgstr "Корейська"
 
-#: src/Preferences.cpp:727
+#: src/Preferences.cpp:699
 msgid "Latvian"
 msgstr ""
 
-#: src/Preferences.cpp:728
+#: src/Preferences.cpp:700
 msgid "Lithuanian"
 msgstr "Литовська"
 
-#: src/Preferences.cpp:729
+#: src/Preferences.cpp:701
 msgid "Norwegian (Nynorsk)"
 msgstr "Норвезька (Нюнорск)"
 
-#: src/Preferences.cpp:730
+#: src/Preferences.cpp:702
 msgid "Polish"
 msgstr "Польська"
 
-#: src/Preferences.cpp:731
+#: src/Preferences.cpp:703
 msgid "Portuguese"
 msgstr "Португальська"
 
-#: src/Preferences.cpp:732
+#: src/Preferences.cpp:704
 msgid "Portuguese (Brazilian)"
 msgstr "Португальська (Бразилія)"
 
-#: src/Preferences.cpp:733
+#: src/Preferences.cpp:705
 #, fuzzy
 msgid "Romanian"
 msgstr "Албанська"
 
-#: src/Preferences.cpp:734
+#: src/Preferences.cpp:706
 msgid "Russian"
 msgstr "Російська"
 
-#: src/Preferences.cpp:735
+#: src/Preferences.cpp:707
 msgid "Slovenian"
 msgstr "Словенська"
 
-#: src/Preferences.cpp:736
+#: src/Preferences.cpp:708
 msgid "Spanish"
 msgstr "Іспанська"
 
-#: src/Preferences.cpp:737
+#: src/Preferences.cpp:709
 msgid "Swedish"
 msgstr "Шведська"
 
-#: src/Preferences.cpp:738
+#: src/Preferences.cpp:710
 msgid "Turkish"
 msgstr "Турецька"
 
-#: src/Preferences.cpp:739
+#: src/Preferences.cpp:711
 msgid "Ukrainian"
 msgstr "Українська"
 
-#: src/Preferences.cpp:842
+#: src/Preferences.cpp:814
 #, fuzzy
 msgid "Change Language"
 msgstr "Мова: "
 
-#: src/Preferences.cpp:906
+#: src/Preferences.cpp:878
 msgid "There are no translations installed for aMule"
 msgstr ""
 
-#: src/Preferences.cpp:907
+#: src/Preferences.cpp:879
 #, fuzzy
 msgid "No languages available"
 msgstr "Недоступний"
 
-#: src/Preferences.cpp:1038
+#: src/Preferences.cpp:1010
 msgid "no options available"
 msgstr "немає наявних опцій"
 
-#: src/Preferences.cpp:2226
+#: src/Preferences.cpp:2179
 msgid "Invalid category found, skipping"
 msgstr "Знайдена помилкова категорія, пропущена"
 
-#: src/Preferences.cpp:2395
+#: src/Preferences.cpp:2348
 msgid "TCP port can't be higher than 65532 due to server UDP socket being TCP+3"
 msgstr "Порт TCP не може бути більшим ніж 65532, оскільки UDP-порт сервера є TCP+3"
 
-#: src/Preferences.cpp:2396
+#: src/Preferences.cpp:2349
 #, c-format
 msgid "Default port will be used (%d)"
 msgstr "Буде використовуватися порт за замовчуванням (%d)"
 
-#: src/PrefsUnifiedDlg.cpp:300 src/Statistics.cpp:866
+#: src/PrefsUnifiedDlg.cpp:298 src/Statistics.cpp:866
 msgid "Connection"
 msgstr "З'єднання"
 
-#: src/PrefsUnifiedDlg.cpp:301 src/SearchListCtrl.cpp:117
+#: src/PrefsUnifiedDlg.cpp:299 src/SearchListCtrl.cpp:117
 msgid "Directories"
 msgstr "Теки"
 
-#: src/PrefsUnifiedDlg.cpp:302 src/Statistics.cpp:917
+#: src/PrefsUnifiedDlg.cpp:300 src/Statistics.cpp:917
 msgid "Servers"
 msgstr "Сервери"
 
-#: src/PrefsUnifiedDlg.cpp:303 src/ServerListCtrl.cpp:96
+#: src/PrefsUnifiedDlg.cpp:301 src/ServerListCtrl.cpp:96
 msgid "Files"
 msgstr "Файли"
 
-#: src/PrefsUnifiedDlg.cpp:304
+#: src/PrefsUnifiedDlg.cpp:302
 msgid "Security"
 msgstr "Безпека"
 
-#: src/PrefsUnifiedDlg.cpp:305
+#: src/PrefsUnifiedDlg.cpp:303
 msgid "Interface"
 msgstr "Зовнішній вигляд"
 
-#: src/PrefsUnifiedDlg.cpp:312
+#: src/PrefsUnifiedDlg.cpp:310
 msgid "IP2Country"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:315
+#: src/PrefsUnifiedDlg.cpp:313
 msgid "Proxy"
 msgstr "Проксі"
 
-#: src/PrefsUnifiedDlg.cpp:316
+#: src/PrefsUnifiedDlg.cpp:314
 msgid "Filters"
 msgstr "Фільтри"
 
-#: src/PrefsUnifiedDlg.cpp:317
+#: src/PrefsUnifiedDlg.cpp:315
 msgid "Remote Controls"
 msgstr "Віддалене керування"
 
-#: src/PrefsUnifiedDlg.cpp:318
+#: src/PrefsUnifiedDlg.cpp:316
 msgid "Online Signature"
 msgstr "Онлайн-підпис"
 
-#: src/PrefsUnifiedDlg.cpp:319
+#: src/PrefsUnifiedDlg.cpp:317
 msgid "Advanced"
 msgstr "Розширені"
 
-#: src/PrefsUnifiedDlg.cpp:320
+#: src/PrefsUnifiedDlg.cpp:318
 msgid "Events"
 msgstr "Події"
 
-#: src/PrefsUnifiedDlg.cpp:323
+#: src/PrefsUnifiedDlg.cpp:321
 msgid "Debugging"
 msgstr "Налагоджувач"
 
-#: src/PrefsUnifiedDlg.cpp:453
+#: src/PrefsUnifiedDlg.cpp:451
 msgid ""
 "The following variables will be substituted:\n"
 "    %PARTFILE - full path to the file\n"
 "    %PARTNAME - file name only"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:474
+#: src/PrefsUnifiedDlg.cpp:472
 msgid "Tray icon support requires libayatana-appindicator3 at compile time."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:490
+#: src/PrefsUnifiedDlg.cpp:488
 msgid "Not available on Wayland: the protocol does not report when a window is minimized, so this option cannot intercept the system minimize button. Workaround: launch aMule with `GDK_BACKEND=x11` to use XWayland instead."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:536
+#: src/PrefsUnifiedDlg.cpp:534
 msgid ""
 "Do not change these setting unless you know\n"
 "what you are doing, otherwise you can easily\n"
@@ -5788,35 +5754,26 @@ msgstr ""
 "aMule чудово працює без зміни будь-яких\n"
 "з цих параметрів."
 
-#: src/PrefsUnifiedDlg.cpp:647
+#: src/PrefsUnifiedDlg.cpp:645
 #, c-format
 msgid "Failed to connect Cfg to widget with the ID %d and key %s"
 msgstr "Помилка з'єднання Cfg до Widget з ID %d та ключем %s"
 
-#: src/PrefsUnifiedDlg.cpp:695
+#: src/PrefsUnifiedDlg.cpp:693
 #, c-format
 msgid "Failed to transfer data from Cfg to Widget with the ID %d and key %s"
 msgstr "Помилка передавання даних з Cfg до Widget з ID %d та ключем %s"
 
-#: src/PrefsUnifiedDlg.cpp:801
+#: src/PrefsUnifiedDlg.cpp:799
 msgid "The type of proxy you are connecting to"
 msgstr "Тип проксі з яким ви з'єднуєтесь"
 
-#: src/PrefsUnifiedDlg.cpp:1020
+#: src/PrefsUnifiedDlg.cpp:1003
 #, c-format
 msgid "Failed to transfer data from Widget to Cfg with the ID %d and key %s"
 msgstr "Помилка передавання даних з Widget до Cfg з ID %d та ключем %s"
 
 #: src/PrefsUnifiedDlg.cpp:1103
-#, fuzzy
-msgid "No password set."
-msgstr "Перевіряється пароль\n"
-
-#: src/PrefsUnifiedDlg.cpp:1132
-msgid "Guest access needs a password. Type one in the guest password field, or untick Enable guest access."
-msgstr ""
-
-#: src/PrefsUnifiedDlg.cpp:1144
 msgid ""
 "aMule must be restarted to enable these changes:\n"
 "\n"
@@ -5824,45 +5781,45 @@ msgstr ""
 "aMule має бути перезапущений, щоб зміни подіяли:\n"
 "\n"
 
-#: src/PrefsUnifiedDlg.cpp:1151
+#: src/PrefsUnifiedDlg.cpp:1110
 msgid "- TCP port changed.\n"
 msgstr "- TCP-порт змінено.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1156
+#: src/PrefsUnifiedDlg.cpp:1115
 msgid "- UDP port changed.\n"
 msgstr "- UDP-порт змінено.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1161
+#: src/PrefsUnifiedDlg.cpp:1120
 #, fuzzy
 msgid "- Network interface binding changed.\n"
 msgstr "Зовнішнє з'єднання розірвано."
 
-#: src/PrefsUnifiedDlg.cpp:1166
+#: src/PrefsUnifiedDlg.cpp:1125
 #, fuzzy
 msgid "- External connect port changed.\n"
 msgstr "Зовнішнє з'єднання розірвано."
 
-#: src/PrefsUnifiedDlg.cpp:1170
+#: src/PrefsUnifiedDlg.cpp:1129
 #, fuzzy
 msgid "- External connect acceptance changed.\n"
 msgstr "Дозволено нове зовнішнє з'єднання"
 
-#: src/PrefsUnifiedDlg.cpp:1174
+#: src/PrefsUnifiedDlg.cpp:1133
 #, fuzzy
 msgid "- External connect interface changed.\n"
 msgstr "Зовнішнє з'єднання розірвано."
 
-#: src/PrefsUnifiedDlg.cpp:1178
+#: src/PrefsUnifiedDlg.cpp:1137
 #, fuzzy
 msgid "- Protocol obfuscation support changed.\n"
 msgstr "Приховування протоколу"
 
-#: src/PrefsUnifiedDlg.cpp:1193
+#: src/PrefsUnifiedDlg.cpp:1151
 #, fuzzy
 msgid "- amuleapi settings changed.\n"
 msgstr "- Мова змінена.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1202
+#: src/PrefsUnifiedDlg.cpp:1160
 msgid ""
 "Your Auto-update server list is empty.\n"
 "'Auto-update server list at startup' will be disabled."
@@ -5870,7 +5827,7 @@ msgstr ""
 "Ваш перелік автоматичного оновлення серверів порожній.\n"
 "'Автоматичне оновлення серверів під час завантаження буде вимкнено."
 
-#: src/PrefsUnifiedDlg.cpp:1213
+#: src/PrefsUnifiedDlg.cpp:1171
 msgid ""
 "You have enabled external connections but have not specified a password.\n"
 "External connections cannot be enabled unless a valid password is specified."
@@ -5878,34 +5835,29 @@ msgstr ""
 "Ви увімкнули зовнішні з'єднання, але не визначили пароль.\n"
 "Зовнішні з'єднання не можуть бути ввімкнені поки не вказано вірний пароль."
 
-#: src/PrefsUnifiedDlg.cpp:1246
-#, c-format
-msgid "The amuleapi password could not be saved: %s"
-msgstr ""
-
-#: src/PrefsUnifiedDlg.cpp:1276
+#: src/PrefsUnifiedDlg.cpp:1202
 msgid "- Language changed.\n"
 msgstr "- Мова змінена.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1281
+#: src/PrefsUnifiedDlg.cpp:1207
 msgid "- Temp folder changed.\n"
 msgstr "- Тимчасова тека змінена.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1286
+#: src/PrefsUnifiedDlg.cpp:1212
 #, fuzzy
 msgid "- ED2K network enabled.\n"
 msgstr "Всі мережі вимкнені."
 
-#: src/PrefsUnifiedDlg.cpp:1319
+#: src/PrefsUnifiedDlg.cpp:1245
 msgid "The shared-file exclusion pattern is not a valid regular expression. The filter has been left disabled."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1321 src/PrefsUnifiedDlg.cpp:1921
+#: src/PrefsUnifiedDlg.cpp:1247 src/PrefsUnifiedDlg.cpp:1841
 #, fuzzy
 msgid "Invalid regular expression"
 msgstr "Невірна версія протоколу."
 
-#: src/PrefsUnifiedDlg.cpp:1398
+#: src/PrefsUnifiedDlg.cpp:1324
 msgid ""
 "Both eD2k and Kad network are disabled.\n"
 "You won't be able to connect until you enable at least one of them."
@@ -5913,7 +5865,7 @@ msgstr ""
 "Обидві eD2k та Kad-мережі вимкнені.\n"
 "Ви не зможете з'єднатися поки не увімкнете хоча б одну з них"
 
-#: src/PrefsUnifiedDlg.cpp:1403
+#: src/PrefsUnifiedDlg.cpp:1329
 msgid ""
 "Kad will not start if your UDP port is disabled.\n"
 "Enable UDP port or disable Kad."
@@ -5921,7 +5873,7 @@ msgstr ""
 "Kad не розпочне роботу, якщо UDP-порт вимкнено.\n"
 "Увімкніть UDP-порт або вимкніть Kad"
 
-#: src/PrefsUnifiedDlg.cpp:1459
+#: src/PrefsUnifiedDlg.cpp:1385
 msgid ""
 "\n"
 "You MUST restart aMule now.\n"
@@ -5931,69 +5883,69 @@ msgstr ""
 "Ви ЗОБОВ'ЯЗАНІ перезапустити aMule зараз.\n"
 "Якщо ж не перезапустите, не скаржтеся, коли станеться щось жахливе.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1524
+#: src/PrefsUnifiedDlg.cpp:1450
 msgid "Could not register aMule for autostart at login. The autostart store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1526
+#: src/PrefsUnifiedDlg.cpp:1452
 msgid "Could not remove the autostart-at-login entry."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1527
+#: src/PrefsUnifiedDlg.cpp:1453
 #, fuzzy
 msgid "Autostart"
 msgstr "Автоматичне оновлення розпочато"
 
-#: src/PrefsUnifiedDlg.cpp:1542
+#: src/PrefsUnifiedDlg.cpp:1468
 msgid "Register file type"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1542
+#: src/PrefsUnifiedDlg.cpp:1468
 msgid "Register URL handler"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1550
+#: src/PrefsUnifiedDlg.cpp:1476
 #, c-format
 msgid "aMule only handles eD2k-compatible magnets. If you replace the current magnet handler (%s), BitTorrent magnet links will stop working - aMule cannot download BitTorrent content. Continue?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1555
+#: src/PrefsUnifiedDlg.cpp:1481
 #, c-format
 msgid "Another application currently opens .emulecollection files (%s). Replace it with aMule?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1560
+#: src/PrefsUnifiedDlg.cpp:1486
 #, c-format
 msgid "Another application is currently the default handler for these links (%s). Replace it with aMule?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1585
+#: src/PrefsUnifiedDlg.cpp:1511
 msgid "Could not register aMule for .emulecollection files. The registration store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1587
+#: src/PrefsUnifiedDlg.cpp:1513
 #, fuzzy
 msgid "Could not remove the file type registration."
 msgstr "Тека для тимчасових звантажуваних файлів"
 
-#: src/PrefsUnifiedDlg.cpp:1589
+#: src/PrefsUnifiedDlg.cpp:1515
 msgid "Could not register aMule as the URL handler. The registration store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1591
+#: src/PrefsUnifiedDlg.cpp:1517
 msgid "Could not remove the URL handler registration."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1661 src/PrefsUnifiedDlg.cpp:1688
+#: src/PrefsUnifiedDlg.cpp:1587 src/PrefsUnifiedDlg.cpp:1614
 #, fuzzy
 msgid "The web server and aMule API require external connections to be enabled."
 msgstr "Пароль встановлений та дозволені зовнішні з'єднання."
 
-#: src/PrefsUnifiedDlg.cpp:1671
+#: src/PrefsUnifiedDlg.cpp:1597
 msgid "The aMule web server is deprecated. Consider running the aMule API instead."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1735
+#: src/PrefsUnifiedDlg.cpp:1655
 msgid ""
 "Your Auto-update servers list is in blank.\n"
 "Please fill in at least one URL to point to a valid server.met file.\n"
@@ -6003,24 +5955,24 @@ msgstr ""
 "Будь ласка заповніть принаймні одну адресу, що посилається на існуючий файл server.met.\n"
 "Натисніть на кнопку \"Перелік\" щоб ввести адресу."
 
-#: src/PrefsUnifiedDlg.cpp:1876
+#: src/PrefsUnifiedDlg.cpp:1796
 msgid "Temporary files"
 msgstr "Тимчасові файли"
 
-#: src/PrefsUnifiedDlg.cpp:1881
+#: src/PrefsUnifiedDlg.cpp:1801
 msgid "Incoming files"
 msgstr "Вхідні файли"
 
-#: src/PrefsUnifiedDlg.cpp:1886
+#: src/PrefsUnifiedDlg.cpp:1806
 msgid "Online Signatures"
 msgstr "Онлайн-підписи"
 
-#: src/PrefsUnifiedDlg.cpp:1899
+#: src/PrefsUnifiedDlg.cpp:1819
 #, c-format
 msgid "Choose a folder for %s"
 msgstr "Виберіть теку для %s"
 
-#: src/PrefsUnifiedDlg.cpp:1923
+#: src/PrefsUnifiedDlg.cpp:1843
 #, fuzzy, c-format
 msgid "Would exclude %u of %u shared file"
 msgid_plural "Would exclude %u of %u shared files"
@@ -6028,42 +5980,42 @@ msgstr[0] "Знайдено %i новий спільний файл"
 msgstr[1] "Знайдено %i нові спільні файли"
 msgstr[2] "Знайдено %i нових спільних файлів"
 
-#: src/PrefsUnifiedDlg.cpp:1940
+#: src/PrefsUnifiedDlg.cpp:1860
 msgid "Browse for videoplayer"
 msgstr "Переглянути, щоб знайти відеопрогравач"
 
-#: src/PrefsUnifiedDlg.cpp:1944
+#: src/PrefsUnifiedDlg.cpp:1864
 msgid "Select browser"
 msgstr "Вибрати переглядач тенет"
 
-#: src/PrefsUnifiedDlg.cpp:1948
+#: src/PrefsUnifiedDlg.cpp:1868
 #, fuzzy
 msgid "Select ffprobe binary"
 msgstr "Вибрати переглядач тенет"
 
-#: src/PrefsUnifiedDlg.cpp:1954
+#: src/PrefsUnifiedDlg.cpp:1874
 #, c-format
 msgid "Executable%s"
 msgstr "Виконуваний %s"
 
-#: src/PrefsUnifiedDlg.cpp:1988
+#: src/PrefsUnifiedDlg.cpp:1908
 msgid "ffprobe not found on PATH or in the standard install locations. Install ffmpeg (which ships ffprobe) or use Browse to pick a binary manually."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2000
+#: src/PrefsUnifiedDlg.cpp:1920
 msgid "Reset the settings on this page to their default values?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2001
+#: src/PrefsUnifiedDlg.cpp:1921
 #, fuzzy
 msgid "Reset to defaults"
 msgstr "Мова системи"
 
-#: src/PrefsUnifiedDlg.cpp:2028
+#: src/PrefsUnifiedDlg.cpp:1948
 msgid "Edit server list"
 msgstr "Редагувати перелік серверів"
 
-#: src/PrefsUnifiedDlg.cpp:2029
+#: src/PrefsUnifiedDlg.cpp:1949
 msgid ""
 "Add here URL's to download server.met files.\n"
 "Only one url on each line."
@@ -6071,42 +6023,42 @@ msgstr ""
 "Додайте тут адреси файлів server.met.\n"
 "Тільки одна адреса на рядок."
 
-#: src/PrefsUnifiedDlg.cpp:2084
+#: src/PrefsUnifiedDlg.cpp:2004
 msgid "IP2Country update failed"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2229 src/PrefsUnifiedDlg.cpp:2260
+#: src/PrefsUnifiedDlg.cpp:2149 src/PrefsUnifiedDlg.cpp:2180
 msgid "Data by MaxMind GeoLite2"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2231 src/PrefsUnifiedDlg.cpp:2262
+#: src/PrefsUnifiedDlg.cpp:2151 src/PrefsUnifiedDlg.cpp:2182
 #, fuzzy
 msgid "Custom source"
 msgstr "Завершених джерел"
 
-#: src/PrefsUnifiedDlg.cpp:2233 src/PrefsUnifiedDlg.cpp:2264
+#: src/PrefsUnifiedDlg.cpp:2153 src/PrefsUnifiedDlg.cpp:2184
 msgid "Data by DB-IP.com"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2284
+#: src/PrefsUnifiedDlg.cpp:2204
 #, fuzzy, c-format
 msgid "Status: Loaded%s"
 msgstr "Стан:"
 
-#: src/PrefsUnifiedDlg.cpp:2286
+#: src/PrefsUnifiedDlg.cpp:2206
 #, fuzzy, c-format
 msgid "Status: Loaded%s - %s"
 msgstr "Стан:"
 
-#: src/PrefsUnifiedDlg.cpp:2290
+#: src/PrefsUnifiedDlg.cpp:2210
 msgid "Status: Failed to load - click 'Update now' to refresh."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2292
+#: src/PrefsUnifiedDlg.cpp:2212
 msgid "Status: Not found - click 'Update now' to download."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2350 src/PrefsUnifiedDlg.cpp:2374
+#: src/PrefsUnifiedDlg.cpp:2270 src/PrefsUnifiedDlg.cpp:2294
 #, c-format
 msgid "Update delay: %d second"
 msgid_plural "Update delay: %d seconds"
@@ -6114,7 +6066,7 @@ msgstr[0] "Затримка оновлення: %d секунда"
 msgstr[1] "Затримка оновлення: %d секунди"
 msgstr[2] "Затримка оновлення: %d секунд"
 
-#: src/PrefsUnifiedDlg.cpp:2358
+#: src/PrefsUnifiedDlg.cpp:2278
 #, c-format
 msgid "Time for average graph: %d minute"
 msgid_plural "Time for average graph: %d minutes"
@@ -6122,12 +6074,12 @@ msgstr[0] "Час усереднення графіків: %d хвилина"
 msgstr[1] "Час усереднення графіків: %d хвилини"
 msgstr[2] "Час усереднення графіків: %d хвилин"
 
-#: src/PrefsUnifiedDlg.cpp:2367
+#: src/PrefsUnifiedDlg.cpp:2287
 #, c-format
 msgid "Connections Graph Scale: %d"
 msgstr "Зміна розміру графіка з'єднань: %d"
 
-#: src/PrefsUnifiedDlg.cpp:2382
+#: src/PrefsUnifiedDlg.cpp:2302
 #, c-format
 msgid "File Buffer Size: %d byte"
 msgid_plural "File Buffer Size: %d bytes"
@@ -6135,7 +6087,7 @@ msgstr[0] "Розмір файлу буфера: %d байт"
 msgstr[1] "Розмір файлу буфера: %d байти"
 msgstr[2] "Розмір файлу буфера: %d байт"
 
-#: src/PrefsUnifiedDlg.cpp:2392
+#: src/PrefsUnifiedDlg.cpp:2312
 #, c-format
 msgid "Upload Queue Size: %d client"
 msgid_plural "Upload Queue Size: %d clients"
@@ -6143,7 +6095,7 @@ msgstr[0] "Розмір черги вивантаження: %d клієнт"
 msgstr[1] "Розмір черги вивантаження: %d клієнти"
 msgstr[2] "Розмір черги вивантаження: %d клієнтів"
 
-#: src/PrefsUnifiedDlg.cpp:2402
+#: src/PrefsUnifiedDlg.cpp:2322
 #, c-format
 msgid "Server connection refresh interval: %d minute"
 msgid_plural "Server connection refresh interval: %d minutes"
@@ -6151,105 +6103,101 @@ msgstr[0] "Інтервал оновлення з'єднання з сервер
 msgstr[1] "Інтервал оновлення з'єднання з сервером: %d хвилини"
 msgstr[2] "Інтервал оновлення з'єднання з сервером: %d хвилин"
 
-#: src/PrefsUnifiedDlg.cpp:2407
+#: src/PrefsUnifiedDlg.cpp:2327
 msgid "Server connection refresh interval: Disabled"
 msgstr "Інтервал оновлення з'єднання з сервером: вимкнено"
 
-#: src/PrefsUnifiedDlg.cpp:2451
+#: src/PrefsUnifiedDlg.cpp:2371
 msgid "disabled"
 msgstr "вимкнено"
 
-#: src/PrefsUnifiedDlg.cpp:2477
+#: src/PrefsUnifiedDlg.cpp:2397
 #, fuzzy, c-format
 msgid "Execute command on '%s' event"
 msgstr "Виконати команду на подію '%s'"
 
-#: src/PrefsUnifiedDlg.cpp:2484
+#: src/PrefsUnifiedDlg.cpp:2404
 msgid "Enable command execution on core"
 msgstr "Ввімкнути виконання команди в ядрі"
 
-#: src/PrefsUnifiedDlg.cpp:2496
+#: src/PrefsUnifiedDlg.cpp:2416
 msgid "Core command:"
 msgstr "Команда ядра:"
 
-#: src/PrefsUnifiedDlg.cpp:2512
+#: src/PrefsUnifiedDlg.cpp:2432
 msgid "Enable command execution on GUI"
 msgstr "Ввімкнути виконання команд в ГІК"
 
-#: src/PrefsUnifiedDlg.cpp:2524
+#: src/PrefsUnifiedDlg.cpp:2444
 msgid "GUI command:"
 msgstr "Команда ГІК:"
 
-#: src/PrefsUnifiedDlg.cpp:2540
+#: src/PrefsUnifiedDlg.cpp:2460
 msgid "The following variables will be replaced:"
 msgstr "Наступні змінні будуть замінені:"
 
-#: src/PrefsUnifiedDlg.cpp:2708
+#: src/PrefsUnifiedDlg.cpp:2628
 msgid ""
 "The following folders look like system or sensitive locations:\n"
 "\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2713
+#: src/PrefsUnifiedDlg.cpp:2633
 msgid "Sharing them recursively will publish every file underneath on the eD2k/Kad networks. Do you really want to do this?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2716
+#: src/PrefsUnifiedDlg.cpp:2636
 #, fuzzy
 msgid "Confirm shared folders"
 msgstr "Спільні теки"
 
-#: src/PrefsUnifiedDlg.cpp:2744
+#: src/PrefsUnifiedDlg.cpp:2664
 #, fuzzy
 msgid "Reloading shared files..."
 msgstr "Перезавантажити ваші спільні файли"
 
-#: src/PrefsUnifiedDlg.cpp:2745
+#: src/PrefsUnifiedDlg.cpp:2665
 msgid "Scanning for subdirectories..."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2746
+#: src/PrefsUnifiedDlg.cpp:2666
 #, fuzzy
 msgid "Updating shared folders"
 msgstr "Спільні теки"
 
-#: src/PrefsUnifiedDlg.cpp:2773
+#: src/PrefsUnifiedDlg.cpp:2693
 #, c-format
 msgid "Scanned %u directories..."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2823
+#: src/PrefsUnifiedDlg.cpp:2743
 #, fuzzy, c-format
 msgid "Reloading shared files: %u files scanned"
 msgstr "Перезавантажується перелік спільних файлів."
 
-#: src/PrefsUnifiedDlg.cpp:2873
+#: src/PrefsUnifiedDlg.cpp:2793
 #, fuzzy
 msgid "Shared folder"
 msgstr "Спільні теки"
 
-#: src/SearchDlg.cpp:280
-msgid "Clear search history"
-msgstr ""
-
-#: src/SearchDlg.cpp:584
+#: src/SearchDlg.cpp:425
 msgid "It's impossible to search when both eD2k and Kademlia are disabled."
 msgstr ""
 
-#: src/SearchDlg.cpp:585 src/SearchListCtrl.cpp:858
+#: src/SearchDlg.cpp:426 src/SearchListCtrl.cpp:858
 #, fuzzy
 msgid "Search error"
 msgstr "Пошук"
 
-#: src/SearchDlg.cpp:929
+#: src/SearchDlg.cpp:768
 msgid "Min size must be smaller than max size. Max size ignored."
 msgstr "Найменший розмір має бути меншим ніж найбільший. Найбільшим розміром знехтувано."
 
-#: src/SearchDlg.cpp:930 src/SearchDlg.cpp:1012
+#: src/SearchDlg.cpp:769 src/SearchDlg.cpp:851
 msgid "Search warning"
 msgstr "Очікування пошуку"
 
-#: src/SearchDlg.cpp:1092 src/SearchListCtrl.cpp:735
+#: src/SearchDlg.cpp:929 src/SearchListCtrl.cpp:735
 msgid "Main"
 msgstr "Головна"
 

--- a/po/uk.po
+++ b/po/uk.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-28 08:06+0200\n"
+"POT-Creation-Date: 2026-07-28 10:19+0200\n"
 "PO-Revision-Date: 2026-07-27 11:47+0000\n"
 "Last-Translator: Oleksandr Kovalenko <alx.kovalenko@gmail.com>\n"
 "Language-Team: Ukrainian <translation@linux.org.ua>\n"
@@ -144,7 +144,7 @@ msgstr ""
 msgid "Not now"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:422 src/amuleDlg.cpp:600
+#: src/AppImageIntegration.cpp:422 src/amuleDlg.cpp:665
 msgid "Don't ask again"
 msgstr ""
 
@@ -217,7 +217,7 @@ msgid "Killing amuleweb instance with pid '%d' ... "
 msgstr "Вбиваю екземпляр amuleweb з pid `%d' ... "
 
 #: src/amule.cpp:336 src/amule.cpp:349 src/ClientRef.cpp:180
-#: src/SearchDlg.cpp:880 src/ServerListCtrl.cpp:98
+#: src/SearchDlg.cpp:1041 src/ServerListCtrl.cpp:98
 msgid "Failed"
 msgstr "Невдалі"
 
@@ -573,30 +573,68 @@ msgstr ""
 msgid "ERROR: %s"
 msgstr "ПОМИЛКА: %s"
 
-#: src/amuleDlg.cpp:236
+#: src/amuleDlg.cpp:250
 #, c-format
 msgid "This is aMule %s based on eMule."
 msgstr "Це aMule %s оснований на eMule."
 
-#: src/amuleDlg.cpp:237
+#: src/amuleDlg.cpp:251
 #, c-format
 msgid "Running on %s"
 msgstr "Запущений на %s"
 
-#: src/amuleDlg.cpp:239
+#: src/amuleDlg.cpp:253
 msgid "Visit https://github.com/amule-org/amule/releases/latest to check if a new version is available."
 msgstr "Відвідайте https://github.com/amule-org/amule/releases/latest, щоб перевірити наявність нових версій."
 
-#: src/amuleDlg.cpp:268
+#: src/amuleDlg.cpp:282
 msgid "FATAL ERROR: Failed to create Timer"
 msgstr "ЖАХЛИВА ПОМИЛКА: не вдалося створити Timer"
 
-#: src/amuleDlg.cpp:592
+#: src/amuleDlg.cpp:361 src/amuleDlg.cpp:1787 src/amuleDlg.cpp:2033
+#: src/muuli_wdr.cpp:1492 src/muuli_wdr.cpp:3418
+msgid "Networks"
+msgstr "Мережі"
+
+#: src/amuleDlg.cpp:362 src/amuleDlg.cpp:1793 src/muuli_wdr.cpp:3419
+msgid "Searches"
+msgstr "Пошук"
+
+#: src/amuleDlg.cpp:363 src/amuleDlg.cpp:1799 src/DownloadListCtrl.cpp:740
+#: src/muuli_wdr.cpp:392 src/muuli_wdr.cpp:1585 src/muuli_wdr.cpp:3420
+#: src/Statistics.cpp:829
+msgid "Downloads"
+msgstr "Звантаження"
+
+#: src/amuleDlg.cpp:364 src/amuleDlg.cpp:1805 src/muuli_wdr.cpp:3294
+msgid "Shared files"
+msgstr "Спільні файли"
+
+#: src/amuleDlg.cpp:365 src/amuleDlg.cpp:1811 src/muuli_wdr.cpp:2926
+#: src/muuli_wdr.cpp:3376 src/muuli_wdr.cpp:3423
+msgid "Messages"
+msgstr "Повідомлення"
+
+#: src/amuleDlg.cpp:366 src/amuleDlg.cpp:1817 src/muuli_wdr.cpp:3424
+#: src/PrefsUnifiedDlg.cpp:312 src/Statistics.cpp:779 src/Statistics.cpp:1235
+msgid "Statistics"
+msgstr "Статистика"
+
+#: src/amuleDlg.cpp:368 src/amuleDlg.cpp:1824 src/muuli_wdr.cpp:3426
+#: src/PrefsUnifiedDlg.cpp:328 src/utils/wxCas/src/wxcasprefs.cpp:39
+msgid "Preferences"
+msgstr "Налаштування"
+
+#: src/amuleDlg.cpp:371
+msgid "Navigate"
+msgstr ""
+
+#: src/amuleDlg.cpp:657
 #, fuzzy
 msgid "New version available"
 msgstr "Недоступний"
 
-#: src/amuleDlg.cpp:596
+#: src/amuleDlg.cpp:661
 #, fuzzy, c-format
 msgid ""
 "A new version of aMule (%s) is available.\n"
@@ -606,219 +644,186 @@ msgid ""
 "Would you like to open the download page?"
 msgstr "Остання версія може бути завжди знайдена на https://github.com/amule-org/amule/releases/latest"
 
-#: src/amuleDlg.cpp:678
+#: src/amuleDlg.cpp:743
 msgid "aMule dialog destroyed"
 msgstr "Діалог aMule знищений"
 
-#: src/amuleDlg.cpp:701 src/DataToText.cpp:68 src/IPFilter.cpp:547
+#: src/amuleDlg.cpp:766 src/DataToText.cpp:68 src/IPFilter.cpp:547
 msgid "Connecting"
 msgstr "З'єднується"
 
-#: src/amuleDlg.cpp:893
+#: src/amuleDlg.cpp:958
 msgid "eD2k: Connecting"
 msgstr "eD2k: з'єднання"
 
-#: src/amuleDlg.cpp:897
+#: src/amuleDlg.cpp:962
 msgid "eD2k: Disconnected"
 msgstr "eD2k: від'єднаний"
 
-#: src/amuleDlg.cpp:903
+#: src/amuleDlg.cpp:968
 msgid "Kad: Firewalled"
 msgstr "Kad: за фаєрволом"
 
-#: src/amuleDlg.cpp:907
+#: src/amuleDlg.cpp:972
 msgid "Kad: Connected"
 msgstr "Kad: з'єднаний"
 
-#: src/amuleDlg.cpp:912
+#: src/amuleDlg.cpp:977
 msgid "Kad: Connecting"
 msgstr "Kad: з'єднуюсь"
 
-#: src/amuleDlg.cpp:916
+#: src/amuleDlg.cpp:981
 msgid "Kad: Off"
 msgstr "Kad: вимкнена"
 
-#: src/amuleDlg.cpp:964 src/DownloadListCtrl.cpp:505
+#: src/amuleDlg.cpp:1029 src/DownloadListCtrl.cpp:505
 #: src/DownloadListCtrl.cpp:749 src/FriendListCtrl.cpp:180
 #: src/muuli_wdr.cpp:731 src/muuli_wdr.cpp:782 src/muuli_wdr.cpp:846
-#: src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2224 src/muuli_wdr.cpp:2309
-#: src/muuli_wdr.cpp:3057 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
+#: src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2231 src/muuli_wdr.cpp:2316
+#: src/muuli_wdr.cpp:3064 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
 #: src/ServerListCtrl.cpp:606 src/TransferWnd.cpp:378
 #: src/utils/wxCas/src/wxcasprefs.cpp:235
 msgid "Cancel"
 msgstr "Скасувати"
 
-#: src/amuleDlg.cpp:965
+#: src/amuleDlg.cpp:1030
 msgid "Stop the current connection attempts"
 msgstr "Зупинити поточні спроби з'єднань"
 
-#: src/amuleDlg.cpp:970 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976
-#: src/muuli_wdr.cpp:2447
+#: src/amuleDlg.cpp:1035 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976
+#: src/muuli_wdr.cpp:2454
 msgid "Disconnect"
 msgstr "Від'єднатися"
 
-#: src/amuleDlg.cpp:971
+#: src/amuleDlg.cpp:1036
 msgid "Disconnect from the currently connected networks"
 msgstr "Від'єднатися від з'єднаних мереж"
 
-#: src/amuleDlg.cpp:976 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979
-#: src/muuli_wdr.cpp:2602 src/muuli_wdr.cpp:3054 src/muuli_wdr.cpp:3409
+#: src/amuleDlg.cpp:1041 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979
+#: src/muuli_wdr.cpp:2609 src/muuli_wdr.cpp:3061 src/muuli_wdr.cpp:3416
 msgid "Connect"
 msgstr "З'єднатися"
 
-#: src/amuleDlg.cpp:977
+#: src/amuleDlg.cpp:1042
 msgid "Connect to the currently enabled networks"
 msgstr "З'єднатися з дозволеними мережами"
 
-#: src/amuleDlg.cpp:1089
+#: src/amuleDlg.cpp:1154
 #, fuzzy, c-format
 msgid "Up: %.1f%s (%.1f) | Down: %.1f%s (%.1f)"
 msgstr "Вивантаження: %.1f(%.1f) | Звантаження: %.1f(%.1f)"
 
-#: src/amuleDlg.cpp:1091 src/amuleDlg.cpp:1093 src/amuleDlg.cpp:1097
-#: src/amuleDlg.cpp:1099 src/amuleDlg.cpp:1110 src/amuleDlg.cpp:1112
+#: src/amuleDlg.cpp:1156 src/amuleDlg.cpp:1158 src/amuleDlg.cpp:1162
+#: src/amuleDlg.cpp:1164 src/amuleDlg.cpp:1175 src/amuleDlg.cpp:1177
 #: src/MuleTrayIcon.cpp:796 src/MuleTrayIcon.cpp:799
 #, fuzzy
 msgid " MB/s"
 msgstr "Мбайт/с"
 
-#: src/amuleDlg.cpp:1091 src/amuleDlg.cpp:1093 src/amuleDlg.cpp:1097
-#: src/amuleDlg.cpp:1099 src/amuleDlg.cpp:1110 src/amuleDlg.cpp:1112
+#: src/amuleDlg.cpp:1156 src/amuleDlg.cpp:1158 src/amuleDlg.cpp:1162
+#: src/amuleDlg.cpp:1164 src/amuleDlg.cpp:1175 src/amuleDlg.cpp:1177
 #: src/MuleTrayIcon.cpp:796 src/MuleTrayIcon.cpp:799
 #: src/utils/wxCas/src/wxcasframe.cpp:1041
 msgid " kB/s"
 msgstr " кбайт/с"
 
-#: src/amuleDlg.cpp:1096
+#: src/amuleDlg.cpp:1161
 #, fuzzy, c-format
 msgid "Up: %.1f%s | Down: %.1f%s"
 msgstr "Вивантаження: %.1f | Звантаження: %.1f"
 
-#: src/amuleDlg.cpp:1128
+#: src/amuleDlg.cpp:1193
 #, c-format
 msgid "aMule (%s | Connected)"
 msgstr "aMule (%s | З'єднано)"
 
-#: src/amuleDlg.cpp:1130
+#: src/amuleDlg.cpp:1195
 #, c-format
 msgid "aMule (%s | Disconnected)"
 msgstr "aMule (%s | Від'єднано)"
 
-#: src/amuleDlg.cpp:1183
+#: src/amuleDlg.cpp:1248
 #, fuzzy, c-format
 msgid "Do you really want to exit %s?"
 msgstr "Ви справді хочете вийти з aMule?"
 
-#: src/amuleDlg.cpp:1185
+#: src/amuleDlg.cpp:1250
 msgid "Exit confirmation"
 msgstr "Підтвердження виходу"
 
-#: src/amuleDlg.cpp:1548
+#: src/amuleDlg.cpp:1613
 msgid "Launch Command: "
 msgstr "Команда для запуску: "
 
-#: src/amuleDlg.cpp:1567 src/muuli_wdr.cpp:1971 src/Preferences.cpp:951
+#: src/amuleDlg.cpp:1632 src/muuli_wdr.cpp:1978 src/Preferences.cpp:952
 msgid "- default -"
 msgstr "- за замовчуванням -"
 
-#: src/amuleDlg.cpp:1595
+#: src/amuleDlg.cpp:1660
 #, c-format
 msgid "Skin directory '%s' does not exist"
 msgstr "Тека з шкірами '%s' не існує"
 
-#: src/amuleDlg.cpp:1598
+#: src/amuleDlg.cpp:1663
 #, c-format
 msgid "WARNING: Unable to open skin file '%s' for read"
 msgstr "ЗАСТЕРЕЖЕННЯ: Неможливо відкрити файл шкіри '%s' для читання"
 
-#: src/amuleDlg.cpp:1722 src/amuleDlg.cpp:1968 src/muuli_wdr.cpp:1485
-#: src/muuli_wdr.cpp:3411
-msgid "Networks"
-msgstr "Мережі"
-
-#: src/amuleDlg.cpp:1726 src/muuli_wdr.cpp:3411
+#: src/amuleDlg.cpp:1791 src/muuli_wdr.cpp:3418
 msgid "Networks Window"
 msgstr "Вікно мереж"
 
-#: src/amuleDlg.cpp:1728 src/muuli_wdr.cpp:3412
-msgid "Searches"
-msgstr "Пошук"
-
-#: src/amuleDlg.cpp:1732 src/muuli_wdr.cpp:3412
+#: src/amuleDlg.cpp:1797 src/muuli_wdr.cpp:3419
 msgid "Searches Window"
 msgstr "Вікно пошуку"
 
-#: src/amuleDlg.cpp:1734 src/DownloadListCtrl.cpp:740 src/muuli_wdr.cpp:392
-#: src/muuli_wdr.cpp:1578 src/muuli_wdr.cpp:3413 src/Statistics.cpp:829
-msgid "Downloads"
-msgstr "Звантаження"
-
-#: src/amuleDlg.cpp:1738 src/muuli_wdr.cpp:3413
+#: src/amuleDlg.cpp:1803 src/muuli_wdr.cpp:3420
 #, fuzzy
 msgid "Downloads Window"
 msgstr "Звантажується"
 
-#: src/amuleDlg.cpp:1740 src/muuli_wdr.cpp:3287
-msgid "Shared files"
-msgstr "Спільні файли"
-
-#: src/amuleDlg.cpp:1744 src/muuli_wdr.cpp:3415
+#: src/amuleDlg.cpp:1809 src/muuli_wdr.cpp:3422
 msgid "Shared Files Window"
 msgstr "Вікно спільних файлів"
 
-#: src/amuleDlg.cpp:1746 src/muuli_wdr.cpp:2919 src/muuli_wdr.cpp:3369
-#: src/muuli_wdr.cpp:3416
-msgid "Messages"
-msgstr "Повідомлення"
-
-#: src/amuleDlg.cpp:1750 src/muuli_wdr.cpp:3416
+#: src/amuleDlg.cpp:1815 src/muuli_wdr.cpp:3423
 msgid "Messages Window"
 msgstr "Вікно повідомлень"
 
-#: src/amuleDlg.cpp:1752 src/muuli_wdr.cpp:3417 src/PrefsUnifiedDlg.cpp:312
-#: src/Statistics.cpp:779 src/Statistics.cpp:1235
-msgid "Statistics"
-msgstr "Статистика"
-
-#: src/amuleDlg.cpp:1756 src/muuli_wdr.cpp:3417
+#: src/amuleDlg.cpp:1821 src/muuli_wdr.cpp:3424
 msgid "Statistics Graph Window"
 msgstr "Вікно статистики"
 
-#: src/amuleDlg.cpp:1759 src/muuli_wdr.cpp:3419 src/PrefsUnifiedDlg.cpp:328
-#: src/utils/wxCas/src/wxcasprefs.cpp:39
-msgid "Preferences"
-msgstr "Налаштування"
-
-#: src/amuleDlg.cpp:1763 src/muuli_wdr.cpp:3419
+#: src/amuleDlg.cpp:1828 src/muuli_wdr.cpp:3426
 msgid "Preferences Settings Window"
 msgstr "Вікно налаштувань"
 
-#: src/amuleDlg.cpp:1766 src/muuli_wdr.cpp:3420
+#: src/amuleDlg.cpp:1831 src/muuli_wdr.cpp:3427
 msgid "Import"
 msgstr "Зовн. внесення"
 
-#: src/amuleDlg.cpp:1770 src/muuli_wdr.cpp:3420
+#: src/amuleDlg.cpp:1835 src/muuli_wdr.cpp:3427
 msgid "The partfile importer tool"
 msgstr "Засіб зовнішнього внесення частково звантажених файлів"
 
-#: src/amuleDlg.cpp:1773 src/muuli_wdr.cpp:3421
+#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3428
 #: src/utils/aLinkCreator/src/alcframe.cpp:262
 msgid "About"
 msgstr "Про програму"
 
-#: src/amuleDlg.cpp:1773 src/muuli_wdr.cpp:3421
+#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3428
 msgid "About/Help"
 msgstr "Про/Допомога"
 
-#: src/amuleDlg.cpp:1971
+#: src/amuleDlg.cpp:2036
 msgid "eD2k network"
 msgstr "Мережа eD2k"
 
-#: src/amuleDlg.cpp:1974
+#: src/amuleDlg.cpp:2039
 msgid "Kad network"
 msgstr "Мережа Kad"
 
-#: src/amuleDlg.cpp:1974
+#: src/amuleDlg.cpp:2039
 msgid "No network"
 msgstr "Немає мережі"
 
@@ -1360,19 +1365,19 @@ msgstr "Авто [висока]"
 msgid "Very low"
 msgstr "Дуже низька"
 
-#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:743 src/muuli_wdr.cpp:2275
+#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:743 src/muuli_wdr.cpp:2282
 #: src/ServerListCtrl.cpp:263 src/ServerListCtrl.cpp:456
 #: src/SharedFilesCtrl.cpp:145
 msgid "Low"
 msgstr "Низька"
 
-#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:744 src/muuli_wdr.cpp:2276
+#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:744 src/muuli_wdr.cpp:2283
 #: src/ServerListCtrl.cpp:266 src/ServerListCtrl.cpp:457
 #: src/SharedFilesCtrl.cpp:146
 msgid "Normal"
 msgstr "Звичайна"
 
-#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:745 src/muuli_wdr.cpp:2277
+#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:745 src/muuli_wdr.cpp:2284
 #: src/ServerListCtrl.cpp:269 src/ServerListCtrl.cpp:458
 #: src/SharedFilesCtrl.cpp:147
 msgid "High"
@@ -1465,8 +1470,8 @@ msgstr "Місцевий сервер"
 msgid "Remote Server"
 msgstr "Віддалений сервер"
 
-#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3174
-#: src/SearchDlg.cpp:111 src/TextClient.cpp:911
+#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3181
+#: src/SearchDlg.cpp:119 src/TextClient.cpp:911
 msgid "Kad"
 msgstr "Kad"
 
@@ -1537,7 +1542,7 @@ msgstr "Частина"
 msgid "Size"
 msgstr "Розмір"
 
-#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3241
+#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3248
 msgid "Transferred"
 msgstr "Переданих"
 
@@ -1595,7 +1600,7 @@ msgstr ""
 "Відгук від: %s (%s)\n"
 "\n"
 
-#: src/DownloadListCtrl.cpp:746 src/muuli_wdr.cpp:2278
+#: src/DownloadListCtrl.cpp:746 src/muuli_wdr.cpp:2285
 #: src/SharedFilesCtrl.cpp:150
 msgid "Auto"
 msgstr "Автоматично"
@@ -1633,7 +1638,7 @@ msgid "Extended Options"
 msgstr "Розширені налаштування"
 
 #: src/DownloadListCtrl.cpp:770 src/DownloadListCtrl.cpp:822
-#: src/muuli_wdr.cpp:1789
+#: src/muuli_wdr.cpp:1796
 msgid "Preview"
 msgstr "Попередній перегляд"
 
@@ -2350,19 +2355,19 @@ msgstr ""
 msgid "eD2k"
 msgstr "eD2k"
 
-#: src/FirstRunWizard.cpp:349 src/muuli_wdr.cpp:1488
+#: src/FirstRunWizard.cpp:349 src/muuli_wdr.cpp:1495
 msgid "Kademlia"
 msgstr "Kademlia"
 
-#: src/FirstRunWizard.cpp:359 src/muuli_wdr.cpp:1416
+#: src/FirstRunWizard.cpp:359 src/muuli_wdr.cpp:1423
 msgid "Standard TCP Port "
 msgstr "Зразковий TCP-порт "
 
-#: src/FirstRunWizard.cpp:365 src/muuli_wdr.cpp:1428
+#: src/FirstRunWizard.cpp:365 src/muuli_wdr.cpp:1435
 msgid "Extended UDP port (Kad / global search) "
 msgstr "Розширений порт UDP (Kad / глобальний пошук) "
 
-#: src/FirstRunWizard.cpp:377 src/muuli_wdr.cpp:1435
+#: src/FirstRunWizard.cpp:377 src/muuli_wdr.cpp:1442
 msgid "Enable UPnP for router port forwarding"
 msgstr "Ввімкнути UPnP для перенаправлення портів"
 
@@ -2389,7 +2394,7 @@ msgstr ""
 msgid "Your peer lists are already in place - nothing to download."
 msgstr "Ви вже спробували звантажити файл %s"
 
-#: src/FirstRunWizard.cpp:434 src/muuli_wdr.cpp:1533
+#: src/FirstRunWizard.cpp:434 src/muuli_wdr.cpp:1540
 msgid "Auto-update server list at startup"
 msgstr "Автоматичне оновлення переліку серверів після запуску"
 
@@ -2435,23 +2440,23 @@ msgid ""
 "want downloads on a different (e.g. larger) disk."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:549 src/FirstRunWizard.cpp:611 src/muuli_wdr.cpp:1701
+#: src/FirstRunWizard.cpp:549 src/FirstRunWizard.cpp:611 src/muuli_wdr.cpp:1708
 msgid "Destination folder for downloads"
 msgstr "Тека призначення для звантажень"
 
-#: src/FirstRunWizard.cpp:553 src/FirstRunWizard.cpp:569 src/muuli_wdr.cpp:1342
-#: src/muuli_wdr.cpp:1359 src/muuli_wdr.cpp:1676 src/muuli_wdr.cpp:1707
-#: src/muuli_wdr.cpp:1719 src/muuli_wdr.cpp:2762
+#: src/FirstRunWizard.cpp:553 src/FirstRunWizard.cpp:569 src/muuli_wdr.cpp:1349
+#: src/muuli_wdr.cpp:1366 src/muuli_wdr.cpp:1683 src/muuli_wdr.cpp:1714
+#: src/muuli_wdr.cpp:1726 src/muuli_wdr.cpp:2769
 #: src/utils/aLinkCreator/src/alcframe.cpp:135
 #: src/utils/wxCas/src/wxcasprefs.cpp:52 src/utils/wxCas/src/wxcasprefs.cpp:118
 msgid "Browse"
 msgstr "Переглянути"
 
-#: src/FirstRunWizard.cpp:559 src/muuli_wdr.cpp:1712
+#: src/FirstRunWizard.cpp:559 src/muuli_wdr.cpp:1719
 msgid "(All files in this folder are shared with other peers)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:565 src/FirstRunWizard.cpp:624 src/muuli_wdr.cpp:1714
+#: src/FirstRunWizard.cpp:565 src/FirstRunWizard.cpp:624 src/muuli_wdr.cpp:1721
 msgid "Folder for temporary download files"
 msgstr "Тека для тимчасових звантажуваних файлів"
 
@@ -2482,7 +2487,7 @@ msgstr "Неможливо відкрити перелік друзів 'emfrien
 msgid "CRITICAL - no client on StartChatSession"
 msgstr "КРИТИЧНО - немає клієнта на StartChatSession"
 
-#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2668 src/muuli_wdr.cpp:3345
+#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2675 src/muuli_wdr.cpp:3352
 msgid "Friends"
 msgstr "Друзі"
 
@@ -2877,7 +2882,7 @@ msgstr "Відношення передачі"
 msgid "Uploaded"
 msgstr "Вивантажено"
 
-#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3225
+#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3232
 msgid "Requested"
 msgstr "Запитано"
 
@@ -3004,7 +3009,7 @@ msgid "WARNING: "
 msgstr "ЗАСТЕРЕЖЕННЯ: "
 
 #: src/MuleNotebook.cpp:179 src/muuli_wdr.cpp:817 src/muuli_wdr.cpp:1229
-#: src/muuli_wdr.cpp:3129 src/muuli_wdr.cpp:3385
+#: src/muuli_wdr.cpp:3136 src/muuli_wdr.cpp:3392
 msgid "Close"
 msgstr "Закрити"
 
@@ -3017,12 +3022,12 @@ msgstr "Вирізати"
 msgid "Copy"
 msgstr "Скопіювати"
 
-#: src/MuleTextCtrl.cpp:88
+#: src/MuleTextCtrl.cpp:88 src/SearchDlg.cpp:261
 msgid "Paste"
 msgstr "Вставити"
 
 #: src/MuleTextCtrl.cpp:89 src/muuli_wdr.cpp:358 src/muuli_wdr.cpp:757
-#: src/muuli_wdr.cpp:2352 src/muuli_wdr.cpp:2371 src/muuli_wdr.cpp:2393
+#: src/muuli_wdr.cpp:2359 src/muuli_wdr.cpp:2378 src/muuli_wdr.cpp:2400
 #: src/utils/aLinkCreator/src/alcframe.cpp:142
 msgid "Clear"
 msgstr "Очистити"
@@ -3120,8 +3125,8 @@ msgid "Exit"
 msgstr "Вийти"
 
 #: src/MuleTrayIcon.cpp:579 src/MuleTrayIcon.cpp:945 src/MuleTrayIcon.cpp:965
-#: src/muuli_wdr.cpp:1391 src/muuli_wdr.cpp:1399 src/muuli_wdr.cpp:1406
-#: src/muuli_wdr.cpp:1835 src/muuli_wdr.cpp:1841 src/OtherFunctions.cpp:91
+#: src/muuli_wdr.cpp:1398 src/muuli_wdr.cpp:1406 src/muuli_wdr.cpp:1413
+#: src/muuli_wdr.cpp:1842 src/muuli_wdr.cpp:1848 src/OtherFunctions.cpp:91
 #: src/StatisticsDlg.cpp:93 src/StatisticsDlg.cpp:95
 msgid "kB/s"
 msgstr "кбайт/с"
@@ -3292,7 +3297,7 @@ msgstr "Назва:"
 msgid "Type"
 msgstr "Тип"
 
-#: src/muuli_wdr.cpp:215 src/SearchDlg.cpp:110 src/SearchListCtrl.cpp:853
+#: src/muuli_wdr.cpp:215 src/SearchDlg.cpp:118 src/SearchListCtrl.cpp:853
 msgid "Local"
 msgstr "Місцевий"
 
@@ -3363,7 +3368,7 @@ msgstr "байт"
 msgid "KB"
 msgstr "кбайт"
 
-#: src/muuli_wdr.cpp:274 src/muuli_wdr.cpp:293 src/muuli_wdr.cpp:1620
+#: src/muuli_wdr.cpp:274 src/muuli_wdr.cpp:293 src/muuli_wdr.cpp:1627
 #: src/OtherFunctions.cpp:64
 msgid "MB"
 msgstr "Мбайт"
@@ -3380,7 +3385,7 @@ msgstr "Найбільший розмір"
 msgid "Availability"
 msgstr "Доступність"
 
-#: src/muuli_wdr.cpp:312 src/muuli_wdr.cpp:398 src/muuli_wdr.cpp:3290
+#: src/muuli_wdr.cpp:312 src/muuli_wdr.cpp:398 src/muuli_wdr.cpp:3297
 msgid "Filter:"
 msgstr "Фільтр:"
 
@@ -3412,7 +3417,7 @@ msgstr ""
 msgid "Stop"
 msgstr "Зупинити"
 
-#: src/muuli_wdr.cpp:348 src/muuli_wdr.cpp:1385 src/SearchListCtrl.cpp:732
+#: src/muuli_wdr.cpp:348 src/muuli_wdr.cpp:1392 src/SearchListCtrl.cpp:732
 msgid "Download"
 msgstr "Звантаження"
 
@@ -3444,8 +3449,8 @@ msgstr "Завершених джерел"
 #: src/muuli_wdr.cpp:1160 src/muuli_wdr.cpp:1167 src/muuli_wdr.cpp:1172
 #: src/muuli_wdr.cpp:1179 src/muuli_wdr.cpp:1184 src/muuli_wdr.cpp:1191
 #: src/muuli_wdr.cpp:1205 src/muuli_wdr.cpp:1212 src/muuli_wdr.cpp:1217
-#: src/muuli_wdr.cpp:1224 src/muuli_wdr.cpp:3227 src/muuli_wdr.cpp:3235
-#: src/muuli_wdr.cpp:3243
+#: src/muuli_wdr.cpp:1224 src/muuli_wdr.cpp:3234 src/muuli_wdr.cpp:3242
+#: src/muuli_wdr.cpp:3250
 msgid "N/A"
 msgstr "недоступні"
 
@@ -3590,7 +3595,7 @@ msgstr ""
 msgid "Album :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:685 src/muuli_wdr.cpp:2247
+#: src/muuli_wdr.cpp:685 src/muuli_wdr.cpp:2254
 msgid "Title :"
 msgstr "Назва:"
 
@@ -3699,7 +3704,7 @@ msgstr "Ім'я користувача:"
 msgid "Userhash :"
 msgstr "Хеш користувача:"
 
-#: src/muuli_wdr.cpp:895 src/muuli_wdr.cpp:1741 src/muuli_wdr.cpp:2442
+#: src/muuli_wdr.cpp:895 src/muuli_wdr.cpp:1748 src/muuli_wdr.cpp:2449
 #: src/utils/aLinkCreator/src/alcframe.cpp:137
 msgid "Add"
 msgstr "Додати"
@@ -3708,15 +3713,15 @@ msgstr "Додати"
 msgid "Download-Speed"
 msgstr "Швидкість звантаження"
 
-#: src/muuli_wdr.cpp:954 src/muuli_wdr.cpp:989 src/muuli_wdr.cpp:2546
+#: src/muuli_wdr.cpp:954 src/muuli_wdr.cpp:989 src/muuli_wdr.cpp:2553
 msgid "Current"
 msgstr "Поточна"
 
-#: src/muuli_wdr.cpp:962 src/muuli_wdr.cpp:997 src/muuli_wdr.cpp:2554
+#: src/muuli_wdr.cpp:962 src/muuli_wdr.cpp:997 src/muuli_wdr.cpp:2561
 msgid "Running average"
 msgstr "Середня"
 
-#: src/muuli_wdr.cpp:970 src/muuli_wdr.cpp:1005 src/muuli_wdr.cpp:2562
+#: src/muuli_wdr.cpp:970 src/muuli_wdr.cpp:1005 src/muuli_wdr.cpp:2569
 msgid "Session average"
 msgstr "Середня за сесію"
 
@@ -3728,7 +3733,7 @@ msgstr "Швидкість вивантаження"
 msgid "Connections"
 msgstr "З'єднання"
 
-#: src/muuli_wdr.cpp:1024 src/muuli_wdr.cpp:1860
+#: src/muuli_wdr.cpp:1024 src/muuli_wdr.cpp:1867
 msgid "Active downloads"
 msgstr "Чинні звантаження"
 
@@ -3736,7 +3741,7 @@ msgstr "Чинні звантаження"
 msgid "Active connections (1:1)"
 msgstr "Чинні з'єднання (1:1)"
 
-#: src/muuli_wdr.cpp:1040 src/muuli_wdr.cpp:1861
+#: src/muuli_wdr.cpp:1040 src/muuli_wdr.cpp:1868
 msgid "Active uploads"
 msgstr "Чинні вивантаження"
 
@@ -3853,8 +3858,8 @@ msgstr "Це ім'я, яке бачать інші користувачі, ко�
 msgid "Language: "
 msgstr "Мова: "
 
-#: src/muuli_wdr.cpp:1257 src/muuli_wdr.cpp:1323 src/muuli_wdr.cpp:1327
-#: src/muuli_wdr.cpp:1330
+#: src/muuli_wdr.cpp:1257 src/muuli_wdr.cpp:1330 src/muuli_wdr.cpp:1334
+#: src/muuli_wdr.cpp:1337
 msgid "The delay before showing tool-tips."
 msgstr "Затримка перед показом підказок."
 
@@ -3932,941 +3937,950 @@ msgstr ""
 msgid "Enabling this will make aMule to show notifications when finished downloading."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1322
+#: src/muuli_wdr.cpp:1323
+#, fuzzy
+msgid "Remember search history"
+msgstr "Запам'ятати ці налаштування"
+
+#: src/muuli_wdr.cpp:1324
+msgid "Keeps a dropdown list of your past search terms in the Search tab's Name field. This remembers the queries you typed, not the results they returned."
+msgstr ""
+
+#: src/muuli_wdr.cpp:1329
 msgid "Tooltip delay time: "
 msgstr "Затримка показу порад: "
 
-#: src/muuli_wdr.cpp:1329
+#: src/muuli_wdr.cpp:1336
 msgid "seconds"
 msgstr "с"
 
-#: src/muuli_wdr.cpp:1333
+#: src/muuli_wdr.cpp:1340
 msgid "Browser Selection"
 msgstr "Обрати переглядач тенет"
 
-#: src/muuli_wdr.cpp:1339
+#: src/muuli_wdr.cpp:1346
 msgid "Enter your browser name here. Leave this field empty to use the system default browser."
 msgstr "Введіть тут назву вашого переглядача тенет. Залиште це поле порожнім, щоб використовувати переглядач встановлений за замовчуванням."
 
-#: src/muuli_wdr.cpp:1346
+#: src/muuli_wdr.cpp:1353
 msgid "Open in new tab if possible"
 msgstr "Відкрити в новій вкладці, якщо можливо"
 
-#: src/muuli_wdr.cpp:1348
+#: src/muuli_wdr.cpp:1355
 msgid "Open the web page in a new tab instead of in a new window when possible"
 msgstr "Відкрити сторінку тенет в новій вкладці замість нового вікна, якщо можливо"
 
-#: src/muuli_wdr.cpp:1352
+#: src/muuli_wdr.cpp:1359
 msgid "Video Player"
 msgstr "Відеопрогравач"
 
-#: src/muuli_wdr.cpp:1379
+#: src/muuli_wdr.cpp:1386
 msgid "Bandwidth limits"
 msgstr "Обмеження ширини смуги"
 
-#: src/muuli_wdr.cpp:1393
+#: src/muuli_wdr.cpp:1400
 msgid "Upload"
 msgstr "Вивантаження"
 
-#: src/muuli_wdr.cpp:1401
+#: src/muuli_wdr.cpp:1408
 msgid "Slot Allocation"
 msgstr "Виділення шматків"
 
-#: src/muuli_wdr.cpp:1410
+#: src/muuli_wdr.cpp:1417
 msgid "Ports"
 msgstr "Порти"
 
-#: src/muuli_wdr.cpp:1420
+#: src/muuli_wdr.cpp:1427
 msgid "This is the standard eD2k port and cannot be disabled."
 msgstr "Це звичайний порт eD2k і не може бути вимкненим."
 
-#: src/muuli_wdr.cpp:1423
+#: src/muuli_wdr.cpp:1430
 msgid "UDP port for server requests (TCP+3):"
 msgstr "Порт UDP для запитів сервера (TCP+3):"
 
-#: src/muuli_wdr.cpp:1425
+#: src/muuli_wdr.cpp:1432
 msgid "4665"
 msgstr "4665"
 
-#: src/muuli_wdr.cpp:1432
+#: src/muuli_wdr.cpp:1439
 msgid "This UDP port is used for extended eD2k requests and Kad network"
 msgstr "Цей порт використовується для зовнішній запитів eD2k та для мережі Kad"
 
-#: src/muuli_wdr.cpp:1439
+#: src/muuli_wdr.cpp:1446
 msgid "UPnP TCP Port (Optional):"
 msgstr "UPnP TCP порт (не обов'язково):"
 
-#: src/muuli_wdr.cpp:1449
+#: src/muuli_wdr.cpp:1456
 msgid "Bind local address to IP (empty for any):"
 msgstr "Використовувати IP-адресу (пусто для будь-якої):"
 
-#: src/muuli_wdr.cpp:1452
+#: src/muuli_wdr.cpp:1459
 msgid "Advanced users only: If you have multiple network interfaces, enter the address of the interface to which aMule should be bound."
 msgstr "Тільки досвідченим користувачам: якщо ви маєте багато мережевих інтерфейсів, введіть адресу інтерфейсу до якого слід прив'язатися aMule."
 
-#: src/muuli_wdr.cpp:1455 src/muuli_wdr.cpp:2054
+#: src/muuli_wdr.cpp:1462 src/muuli_wdr.cpp:2061
 #, fuzzy
 msgid "Bind to network interface (empty for any):"
 msgstr "Використовувати IP-адресу (пусто для будь-якої):"
 
-#: src/muuli_wdr.cpp:1468
+#: src/muuli_wdr.cpp:1475
 msgid "Advanced users only: pin all of aMule's traffic to one network interface, chosen from the list or typed in by name (e.g. tun0, eth0, en0) or index. Unlike binding to an IP, this stops traffic leaking out via the default route - useful with a VPN. Requires no elevated privileges."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1474
+#: src/muuli_wdr.cpp:1481
 msgid "Max sources per downloading file:"
 msgstr "Найбільше джерел на звантажуваний файл:"
 
-#: src/muuli_wdr.cpp:1478
+#: src/muuli_wdr.cpp:1485
 msgid "Max simultaneous connections:"
 msgstr "Найбільше одночасних з'єднань:"
 
-#: src/muuli_wdr.cpp:1491 src/muuli_wdr.cpp:3169
+#: src/muuli_wdr.cpp:1498 src/muuli_wdr.cpp:3176
 msgid "ED2K"
 msgstr "eD2k"
 
-#: src/muuli_wdr.cpp:1498
+#: src/muuli_wdr.cpp:1505
 msgid "Autoconnect on startup"
 msgstr "Автоматичне з'єднання після запуску"
 
-#: src/muuli_wdr.cpp:1501
+#: src/muuli_wdr.cpp:1508
 msgid "Reconnect on loss"
 msgstr "Перез'єднатись при втраті з'єднання"
 
-#: src/muuli_wdr.cpp:1523
+#: src/muuli_wdr.cpp:1530
 msgid "Remove dead server after"
 msgstr "Вилучити мертвий сервер після"
 
-#: src/muuli_wdr.cpp:1524
+#: src/muuli_wdr.cpp:1531
 msgid "Static servers are never removed, even when unreachable."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1528
+#: src/muuli_wdr.cpp:1535
 msgid "retries"
 msgstr "спроб"
 
-#: src/muuli_wdr.cpp:1536
+#: src/muuli_wdr.cpp:1543
 msgid "List"
 msgstr "Перелік"
 
-#: src/muuli_wdr.cpp:1539
+#: src/muuli_wdr.cpp:1546
 msgid "Update server list when connecting to a server"
 msgstr "Оновити перелік серверів після з'єднання з сервером"
 
-#: src/muuli_wdr.cpp:1542
+#: src/muuli_wdr.cpp:1549
 msgid "Update server list when a client connects"
 msgstr "Оновити перелік серверів після з'єднання з клієнтами"
 
-#: src/muuli_wdr.cpp:1545
+#: src/muuli_wdr.cpp:1552
 msgid "Use priority system"
 msgstr "Використовувати систему переваг"
 
-#: src/muuli_wdr.cpp:1549
+#: src/muuli_wdr.cpp:1556
 msgid "Use smart LowID check on connect"
 msgstr "Використовувати розумну перевірку LowID під час з'єднання"
 
-#: src/muuli_wdr.cpp:1553
+#: src/muuli_wdr.cpp:1560
 msgid "Safe connect"
 msgstr "Безпечне з'єднання"
 
-#: src/muuli_wdr.cpp:1557
+#: src/muuli_wdr.cpp:1564
 msgid "Autoconnect to servers in static list only"
 msgstr "Автоматично з'єднуватись тільки з серверами з переліку постійних"
 
-#: src/muuli_wdr.cpp:1560
+#: src/muuli_wdr.cpp:1567
 msgid "Set manually added servers to High Priority"
 msgstr "Встановити високу перевагу доданим вручну серверам"
 
-#: src/muuli_wdr.cpp:1581
+#: src/muuli_wdr.cpp:1588
 msgid "Add files to download in pause mode"
 msgstr "Додати файли для звантаження призупиненими"
 
-#: src/muuli_wdr.cpp:1583
+#: src/muuli_wdr.cpp:1590
 msgid "Add files to download with auto priority"
 msgstr "Додати файли для звантаження з автоматичною перевагою"
 
-#: src/muuli_wdr.cpp:1586
+#: src/muuli_wdr.cpp:1593
 msgid "Try to download first and last chunks first"
 msgstr "Спробувати спершу звантажити перший та останній шматки"
 
-#: src/muuli_wdr.cpp:1590
+#: src/muuli_wdr.cpp:1597
 msgid "Endgame mode: rotate to faster sources for the final blocks"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1593
+#: src/muuli_wdr.cpp:1600
 msgid "Start next paused file when a file completes"
 msgstr "Запустити наступний призупинений файл, коли файл завершиться"
 
-#: src/muuli_wdr.cpp:1596
+#: src/muuli_wdr.cpp:1603
 msgid "From the same category"
 msgstr "З тієї самої категорії"
 
-#: src/muuli_wdr.cpp:1598
+#: src/muuli_wdr.cpp:1605
 msgid "In alphabetic order"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1600
+#: src/muuli_wdr.cpp:1607
 msgid "Preallocate disk space for new files"
 msgstr "Попереднє виділення місця на диску для нових файлів"
 
-#: src/muuli_wdr.cpp:1601
+#: src/muuli_wdr.cpp:1608
 msgid "For new files preallocates disk space for the whole file, thus reduces fragmentation"
 msgstr "Повністю виділяти місце для всього нового файлу, це зменшить фрагментування"
 
-#: src/muuli_wdr.cpp:1606
+#: src/muuli_wdr.cpp:1613
 msgid "Create new files as sparse files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1607
+#: src/muuli_wdr.cpp:1614
 msgid "A sparse file reserves its full size on disk immediately without writing real data to it -- fast, but unsupported or slow on some filesystems, and free-space accounting stays optimistic while the download is in progress. Turn this off to grow the file only as data arrives."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1612
+#: src/muuli_wdr.cpp:1619
 msgid "Stop downloads when free disk space reaches "
 msgstr "Припинити звантаження коли вільне місце на диску досягнуло "
 
-#: src/muuli_wdr.cpp:1613
+#: src/muuli_wdr.cpp:1620
 msgid "Select this if you want aMule to check your disk space"
 msgstr "Виберіть це якщо хочете, щоб aMule перевіряв ваше місце на диску"
 
-#: src/muuli_wdr.cpp:1617
+#: src/muuli_wdr.cpp:1624
 msgid "Enter here the min disk space desired."
 msgstr "Введіть найменше бажане місце на диску"
 
-#: src/muuli_wdr.cpp:1623
+#: src/muuli_wdr.cpp:1630
 msgid "Save 10 sources on rare files (< 20 sources)"
 msgstr "Зберегти 10 джерел рідкісних файлів (менше ніж 20 джерел)"
 
-#: src/muuli_wdr.cpp:1627 src/Statistics.cpp:790
+#: src/muuli_wdr.cpp:1634 src/Statistics.cpp:790
 msgid "Uploads"
 msgstr "Вивантаження"
 
-#: src/muuli_wdr.cpp:1630
+#: src/muuli_wdr.cpp:1637
 msgid "Add new shared files with auto priority"
 msgstr "Додати нові спільні файли з автоматичною перевагою"
 
-#: src/muuli_wdr.cpp:1636
+#: src/muuli_wdr.cpp:1643
 msgid "Intelligent Corruption Handling (I.C.H.)"
 msgstr "Розумна обробка пошкоджень (Р.О.П.)"
 
-#: src/muuli_wdr.cpp:1639
+#: src/muuli_wdr.cpp:1646
 msgid "Enable"
 msgstr "Ввімкнено"
 
-#: src/muuli_wdr.cpp:1642
+#: src/muuli_wdr.cpp:1649
 msgid "Advanced I.C.H. trusts every hash (not recommended)"
 msgstr "Вдосконалена Р.О.П. довіряє всім хешам (не радимо)"
 
-#: src/muuli_wdr.cpp:1654 src/PrefsUnifiedDlg.cpp:1910
+#: src/muuli_wdr.cpp:1661 src/PrefsUnifiedDlg.cpp:1910
 msgid "Media metadata extraction"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1658
+#: src/muuli_wdr.cpp:1665
 msgid "Extract length / bitrate / codec from shared audio and video files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1660
+#: src/muuli_wdr.cpp:1667
 msgid "When enabled, aMule runs ffprobe on each shared media file to fill in the Length / Bitrate / Codec columns other clients see when they find the file in a search. Requires ffmpeg (the ffprobe binary) to be installed."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1667
+#: src/muuli_wdr.cpp:1674
 msgid "Path to ffprobe:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1672
+#: src/muuli_wdr.cpp:1679
 msgid "Full path to the ffprobe binary. Leave empty to have aMule auto-detect it on startup."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1680
+#: src/muuli_wdr.cpp:1687
 msgid "Detect"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1681
+#: src/muuli_wdr.cpp:1688
 msgid "Search the standard install locations for an ffprobe binary and fill the path field."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1705
+#: src/muuli_wdr.cpp:1712
 msgid ""
 "Completed downloads are stored here. All files in this folder are automatically shared with other peers.\n"
 "If this folder also holds files you don't want to share, point it at an aMule-only sub-folder."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1708
+#: src/muuli_wdr.cpp:1715
 msgid "Pick the folder where completed downloads will be stored. All files in that folder will be shared with other peers."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1722
+#: src/muuli_wdr.cpp:1729
 msgid "Shared folders"
 msgstr "Спільні теки"
 
-#: src/muuli_wdr.cpp:1728
+#: src/muuli_wdr.cpp:1735
 msgid "(Folders shared by the core. Enter a path to add one.)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1736
+#: src/muuli_wdr.cpp:1743
 msgid "Absolute path of a folder on the core's machine, e.g. /home/user/shared"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1738 src/PrefsUnifiedDlg.cpp:2794
+#: src/muuli_wdr.cpp:1745 src/PrefsUnifiedDlg.cpp:2794
 msgid "Recursive"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1739
+#: src/muuli_wdr.cpp:1746
 msgid "Share every sub-folder underneath this one, including ones created later."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1743 src/utils/aLinkCreator/src/alcframe.cpp:141
+#: src/muuli_wdr.cpp:1750 src/utils/aLinkCreator/src/alcframe.cpp:141
 msgid "Remove"
 msgstr "Вилучити"
 
-#: src/muuli_wdr.cpp:1747
+#: src/muuli_wdr.cpp:1754
 msgid "(Right click on folder icon for recursive share)"
 msgstr "(Праве клацання по значку теки для рекурсивного додавання)"
 
-#: src/muuli_wdr.cpp:1754
+#: src/muuli_wdr.cpp:1761
 msgid "Share hidden files"
 msgstr "Робити спільними приховані файли"
 
-#: src/muuli_wdr.cpp:1760
+#: src/muuli_wdr.cpp:1767
 msgid "Automatically rescan shared folders for changes"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1766
+#: src/muuli_wdr.cpp:1773
 msgid "Follow symbolic links in shared folders"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1772
+#: src/muuli_wdr.cpp:1779
 msgid "Exclude files matching:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1775
+#: src/muuli_wdr.cpp:1782
 msgid "Wildcard patterns separated by '|', e.g. .DS_Store|Thumbs.db|*.tmp. Files whose name matches are not shared. Matching is case-insensitive."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1779
+#: src/muuli_wdr.cpp:1786
 msgid "Patterns are regular expressions"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1780
+#: src/muuli_wdr.cpp:1787
 msgid "When set, the whole field is one regular expression ('|' is alternation). When unset, it is a list of '|'-separated wildcards."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1790
+#: src/muuli_wdr.cpp:1797
 msgid "Show how many shared files the current pattern would exclude."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1811
+#: src/muuli_wdr.cpp:1818
 msgid "Graphs"
 msgstr "Графіки"
 
-#: src/muuli_wdr.cpp:1814 src/muuli_wdr.cpp:1876
+#: src/muuli_wdr.cpp:1821 src/muuli_wdr.cpp:1883
 msgid "Update delay : 5 secs"
 msgstr "Час оновлення: 5 с"
 
-#: src/muuli_wdr.cpp:1818
+#: src/muuli_wdr.cpp:1825
 msgid "Time for average graph: 100 mins"
 msgstr "Час для середніх графіків: 100 хв"
 
-#: src/muuli_wdr.cpp:1822
+#: src/muuli_wdr.cpp:1829
 msgid "Connections Graph Scale: 100 "
 msgstr "Шкала графіку з'єднань: 100"
 
-#: src/muuli_wdr.cpp:1829
+#: src/muuli_wdr.cpp:1836
 msgid "Download graph scale:"
 msgstr "Шкала графіку звантаження"
 
-#: src/muuli_wdr.cpp:1837
+#: src/muuli_wdr.cpp:1844
 msgid "Upload graph scale:"
 msgstr "Шкала графіку вивантаження"
 
-#: src/muuli_wdr.cpp:1847
+#: src/muuli_wdr.cpp:1854
 #, fuzzy
 msgid "Colors: "
 msgstr "Кольори: "
 
-#: src/muuli_wdr.cpp:1851
+#: src/muuli_wdr.cpp:1858
 msgid "Background"
 msgstr "Фон"
 
-#: src/muuli_wdr.cpp:1852
+#: src/muuli_wdr.cpp:1859
 msgid "Grid"
 msgstr "Сітка"
 
-#: src/muuli_wdr.cpp:1853
+#: src/muuli_wdr.cpp:1860
 msgid "Download current"
 msgstr "Звантаження зараз"
 
-#: src/muuli_wdr.cpp:1854
+#: src/muuli_wdr.cpp:1861
 msgid "Download running average"
 msgstr "Звантаження середні за роботу"
 
-#: src/muuli_wdr.cpp:1855
+#: src/muuli_wdr.cpp:1862
 msgid "Download session average"
 msgstr "Звантаження середні за сесію"
 
-#: src/muuli_wdr.cpp:1856
+#: src/muuli_wdr.cpp:1863
 msgid "Upload current"
 msgstr "Вивантаження поточні"
 
-#: src/muuli_wdr.cpp:1857
+#: src/muuli_wdr.cpp:1864
 msgid "Upload running average"
 msgstr "Вивантаження середні за роботу"
 
-#: src/muuli_wdr.cpp:1858
+#: src/muuli_wdr.cpp:1865
 msgid "Upload session average"
 msgstr "Вивантаження середні за сесію"
 
-#: src/muuli_wdr.cpp:1859
+#: src/muuli_wdr.cpp:1866
 msgid "Active connections"
 msgstr "Чинні з'єднання"
 
-#: src/muuli_wdr.cpp:1862
+#: src/muuli_wdr.cpp:1869
 #, fuzzy
 msgid "Systray Icon Speed Bar"
 msgstr "Показувати стовпчик швидкості в системному лотку"
 
-#: src/muuli_wdr.cpp:1863
+#: src/muuli_wdr.cpp:1870
 msgid "Kad-nodes current"
 msgstr "Вузлів Kad зараз"
 
-#: src/muuli_wdr.cpp:1864
+#: src/muuli_wdr.cpp:1871
 msgid "Kad-nodes running"
 msgstr "Вузлів Kad запущено"
 
-#: src/muuli_wdr.cpp:1865
+#: src/muuli_wdr.cpp:1872
 msgid "Kad-nodes session"
 msgstr "Вузлів Kad за сесію"
 
-#: src/muuli_wdr.cpp:1869 src/muuli_wdr.cpp:2296
+#: src/muuli_wdr.cpp:1876 src/muuli_wdr.cpp:2303
 msgid "Select"
 msgstr "Вибрати"
 
-#: src/muuli_wdr.cpp:1873
+#: src/muuli_wdr.cpp:1880
 msgid "Tree"
 msgstr "Дерево"
 
-#: src/muuli_wdr.cpp:1883
+#: src/muuli_wdr.cpp:1890
 msgid "Number of Client Versions shown (0=unlimited)"
 msgstr "Кількість відображуваних версій клієнтів (0=необмежено)"
 
-#: src/muuli_wdr.cpp:1908
+#: src/muuli_wdr.cpp:1915
 msgid "!!! WARNING !!!"
 msgstr "!!! ЗАСТЕРЕЖЕННЯ !!!"
 
-#: src/muuli_wdr.cpp:1923
+#: src/muuli_wdr.cpp:1930
 msgid "Max new connections / 5 secs"
 msgstr "Найбільше зовнішніх з'єднань за 5 с"
 
-#: src/muuli_wdr.cpp:1925
+#: src/muuli_wdr.cpp:1932
 msgid "Concurrent Kad source lookups"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1927
+#: src/muuli_wdr.cpp:1934
 #, fuzzy
 msgid "Kad source re-search interval (minutes)"
 msgstr "Час оновлення FTP в хвилинах"
 
-#: src/muuli_wdr.cpp:1929
+#: src/muuli_wdr.cpp:1936
 #, fuzzy
 msgid "Source re-ask interval (minutes)"
 msgstr "Час оновлення FTP в хвилинах"
 
-#: src/muuli_wdr.cpp:1933
+#: src/muuli_wdr.cpp:1940
 msgid "File Buffer Size: 240000 bytes"
 msgstr "Розмір файлу буфера: 240000 байт"
 
-#: src/muuli_wdr.cpp:1937
+#: src/muuli_wdr.cpp:1944
 msgid "Use MMAP: memory-mapped file access (lower memory use)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1938
+#: src/muuli_wdr.cpp:1945
 msgid "Maps part files into memory instead of buffering them on the heap, lowering the process memory footprint. May reduce download speed on some disks; best for memory-constrained or upload-heavy hosts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1940
+#: src/muuli_wdr.cpp:1947
 msgid "Upload Queue Size: 5000 clients"
 msgstr "Розмір черги вивантаження: 5000 клієнтів"
 
-#: src/muuli_wdr.cpp:1944
+#: src/muuli_wdr.cpp:1951
 msgid "Server connection refresh interval: Disable"
 msgstr "Час оновлення з'єднання з сервером: вимкнено"
 
-#: src/muuli_wdr.cpp:1948
+#: src/muuli_wdr.cpp:1955
 msgid "Disable computer's timed standby mode"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1967
+#: src/muuli_wdr.cpp:1974
 msgid "Skin to use: "
 msgstr "Використати шкіру: "
 
-#: src/muuli_wdr.cpp:1976
+#: src/muuli_wdr.cpp:1983
 msgid "Show \"Fast eD2k Links Handler\" in every window."
 msgstr "Показати \"Швидкий оброблювач eD2k-посилань\" в кожному вікні."
 
-#: src/muuli_wdr.cpp:1979
+#: src/muuli_wdr.cpp:1986
 msgid "Show extended info on categories tabs"
 msgstr "Показати розширену інформацію на вкладках категорій"
 
-#: src/muuli_wdr.cpp:1982
+#: src/muuli_wdr.cpp:1989
 #, fuzzy
 msgid "Show application version on title"
 msgstr "Показувати швидкість передавання в заголовку"
 
-#: src/muuli_wdr.cpp:1984
+#: src/muuli_wdr.cpp:1991
 msgid "Show transfer rates on title"
 msgstr "Показувати швидкість передавання в заголовку"
 
-#: src/muuli_wdr.cpp:1986
+#: src/muuli_wdr.cpp:1993
 msgid "Before application name"
 msgstr "Перед назвою програми"
 
-#: src/muuli_wdr.cpp:1988
+#: src/muuli_wdr.cpp:1995
 msgid "After application name"
 msgstr "Після назви програми"
 
-#: src/muuli_wdr.cpp:1991
+#: src/muuli_wdr.cpp:1998
 msgid "Show overhead bandwidth"
 msgstr "Показати ширину смуги службового трафіку"
 
-#: src/muuli_wdr.cpp:1995
+#: src/muuli_wdr.cpp:2002
 msgid "Vertical toolbar orientation"
 msgstr "Вертикальне розміщення панелі інструментів"
 
-#: src/muuli_wdr.cpp:1997
+#: src/muuli_wdr.cpp:2004
 msgid "Live column sorting (auto-reorder rows as their values change)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2004
+#: src/muuli_wdr.cpp:2011
 msgid "Download Queue Files"
 msgstr "Звантажити файли в черзі"
 
-#: src/muuli_wdr.cpp:2007
+#: src/muuli_wdr.cpp:2014
 msgid "Show progress percentage"
 msgstr "Показувати поступ у відсотках"
 
-#: src/muuli_wdr.cpp:2013
+#: src/muuli_wdr.cpp:2020
 msgid "Show progress bar"
 msgstr "Показувати панель поступу"
 
-#: src/muuli_wdr.cpp:2016
+#: src/muuli_wdr.cpp:2023
 msgid "Flat"
 msgstr "Плаский"
 
-#: src/muuli_wdr.cpp:2020
+#: src/muuli_wdr.cpp:2027
 msgid "Round"
 msgstr "Круглий"
 
-#: src/muuli_wdr.cpp:2038
+#: src/muuli_wdr.cpp:2045
 msgid "External Connection Parameters"
 msgstr "Параметри зовнішніх з'єднань"
 
-#: src/muuli_wdr.cpp:2041
+#: src/muuli_wdr.cpp:2048
 msgid "Accept external connections"
 msgstr "Дозволити зовнішні з'єднання"
 
-#: src/muuli_wdr.cpp:2048 src/muuli_wdr.cpp:2107
+#: src/muuli_wdr.cpp:2055 src/muuli_wdr.cpp:2114
 msgid "IP of the listening interface:"
 msgstr "IP-адреса інтерфейса:"
 
-#: src/muuli_wdr.cpp:2051
+#: src/muuli_wdr.cpp:2058
 msgid "Enter here a valid ip in the a.b.c.d format for the listening EC interface. An empty field or 0.0.0.0 will mean any interface."
 msgstr "Введіть IP-адресу в вірному форматі a.b.c.d для прослуховування EC-інтерфейсу. Порожнє поле або 0.0.0.0 означатиме всі."
 
-#: src/muuli_wdr.cpp:2072 src/muuli_wdr.cpp:2156
+#: src/muuli_wdr.cpp:2079 src/muuli_wdr.cpp:2163
 msgid "TCP port:"
 msgstr "Порт TCP:"
 
-#: src/muuli_wdr.cpp:2078
+#: src/muuli_wdr.cpp:2085
 msgid "Enable UPnP port forwarding on the EC port"
 msgstr "Ввімкнути UPnP перенаправлення для EC-порту"
 
-#: src/muuli_wdr.cpp:2082 src/muuli_wdr.cpp:3041
+#: src/muuli_wdr.cpp:2089 src/muuli_wdr.cpp:3048
 #: src/utils/wxCas/src/wxcasprefs.cpp:167
 msgid "Password"
 msgstr "Пароль"
 
-#: src/muuli_wdr.cpp:2088
+#: src/muuli_wdr.cpp:2095
 #, fuzzy
 msgid "aMule API server parameters"
 msgstr "Налаштування веб-сервера"
 
-#: src/muuli_wdr.cpp:2091
+#: src/muuli_wdr.cpp:2098
 msgid "Run amuleapi (REST API) on startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2096
+#: src/muuli_wdr.cpp:2103
 #, fuzzy
 msgid "HTTP port:"
 msgstr "Порт TCP:"
 
-#: src/muuli_wdr.cpp:2110
+#: src/muuli_wdr.cpp:2117
 msgid "The interface amuleapi's HTTP server listens on. 127.0.0.1 (default) accepts only local connections; use 0.0.0.0 or a specific IP to expose it to other hosts (set an admin password below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2113
+#: src/muuli_wdr.cpp:2120
 #, fuzzy
 msgid "Admin password"
 msgstr "Перевіряється пароль\n"
 
-#: src/muuli_wdr.cpp:2118 src/muuli_wdr.cpp:2149
+#: src/muuli_wdr.cpp:2125 src/muuli_wdr.cpp:2156
 msgid "Low rights password"
 msgstr "Пароль низьких прав"
 
-#: src/muuli_wdr.cpp:2126
+#: src/muuli_wdr.cpp:2133
 msgid "Web server parameters"
 msgstr "Налаштування веб-сервера"
 
-#: src/muuli_wdr.cpp:2129
+#: src/muuli_wdr.cpp:2136
 #, fuzzy
 msgid "Run webserver on startup (deprecated)"
 msgstr "Запустити веб-сервер під час запуску"
 
-#: src/muuli_wdr.cpp:2135
+#: src/muuli_wdr.cpp:2142
 msgid "Web template"
 msgstr "Веб шаблон"
 
-#: src/muuli_wdr.cpp:2140
+#: src/muuli_wdr.cpp:2147
 msgid "Full rights password"
 msgstr "Пароль повних прав"
 
-#: src/muuli_wdr.cpp:2144
+#: src/muuli_wdr.cpp:2151
 msgid "Enable Low rights User"
 msgstr "Ввімкнути користувача з низькими правами"
 
-#: src/muuli_wdr.cpp:2163
+#: src/muuli_wdr.cpp:2170
 msgid "Enable UPnP port forwarding of the web server port"
 msgstr "Ввімкнути UPnP перенаправлення портів для порту веб-сервера"
 
-#: src/muuli_wdr.cpp:2168
+#: src/muuli_wdr.cpp:2175
 msgid "Web server UPnP TCP port (Optional)"
 msgstr "UPnP TCP-порт веб-сервера (не обов'язково)"
 
-#: src/muuli_wdr.cpp:2176
+#: src/muuli_wdr.cpp:2183
 msgid "Page Refresh Time (in secs)"
 msgstr "Час оновлення сторінки (с)"
 
-#: src/muuli_wdr.cpp:2183
+#: src/muuli_wdr.cpp:2190
 msgid "Enable Gzip compression"
 msgstr "Дозволити Gzip-стиснення"
 
-#: src/muuli_wdr.cpp:2217
+#: src/muuli_wdr.cpp:2224
 #, fuzzy
 msgid "Reset page to defaults"
 msgstr "Мова системи"
 
-#: src/muuli_wdr.cpp:2218
+#: src/muuli_wdr.cpp:2225
 msgid "Reset the settings on the current page to their default values."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2220 src/muuli_wdr.cpp:2306 src/ServerWnd.cpp:274
+#: src/muuli_wdr.cpp:2227 src/muuli_wdr.cpp:2313 src/ServerWnd.cpp:274
 #: src/ServerWnd.cpp:282
 msgid "OK"
 msgstr "Гаразд"
 
-#: src/muuli_wdr.cpp:2222
+#: src/muuli_wdr.cpp:2229
 msgid "Click here to apply any changes made to the preferences."
 msgstr "Натисніть тут щоб застосувати зміни зроблені в налаштуваннях."
 
-#: src/muuli_wdr.cpp:2225
+#: src/muuli_wdr.cpp:2232
 msgid "Reset any changes made to the preferences."
 msgstr "Скинути всі зміни внесені в налаштування."
 
-#: src/muuli_wdr.cpp:2254
+#: src/muuli_wdr.cpp:2261
 msgid "Comment :"
 msgstr "Коментар:"
 
-#: src/muuli_wdr.cpp:2261
+#: src/muuli_wdr.cpp:2268
 msgid "Incoming Dir :"
 msgstr "Вхідна тека:"
 
-#: src/muuli_wdr.cpp:2270
+#: src/muuli_wdr.cpp:2277
 msgid "Change priority for new assigned files :"
 msgstr "Змінити перевагу для нового призначеного файлу:"
 
-#: src/muuli_wdr.cpp:2274
+#: src/muuli_wdr.cpp:2281
 #, fuzzy
 msgid "Don't change"
 msgstr "Не змінювати"
 
-#: src/muuli_wdr.cpp:2286
+#: src/muuli_wdr.cpp:2293
 msgid "Select color for this Category (currently selected) :"
 msgstr "Виберіть колір для цієї категорії (зараз вибрано):"
 
-#: src/muuli_wdr.cpp:2353 src/muuli_wdr.cpp:2372 src/muuli_wdr.cpp:2394
+#: src/muuli_wdr.cpp:2360 src/muuli_wdr.cpp:2379 src/muuli_wdr.cpp:2401
 msgid "Click this button to reset the log."
 msgstr "Натисніть цю кнопку, щоб очистити часопис."
 
-#: src/muuli_wdr.cpp:2413
+#: src/muuli_wdr.cpp:2420
 msgid "Click on this button to update the servers list from URL ..."
 msgstr "Натисніть на кнопку щоб оновити перелік серверів з адреси..."
 
-#: src/muuli_wdr.cpp:2417
+#: src/muuli_wdr.cpp:2424
 msgid "Server list"
 msgstr "Перелік серверів"
 
-#: src/muuli_wdr.cpp:2421
+#: src/muuli_wdr.cpp:2428
 msgid "Enter the url to a server.met file here and press the button to the left to update the list of known servers."
 msgstr "Введіть адресу файлу server.met та натисніть кнопку ліворуч щоб оновити перелік відомих серверів."
 
-#: src/muuli_wdr.cpp:2426
+#: src/muuli_wdr.cpp:2433
 msgid "Add server manually: Name"
 msgstr "Додати сервер вручну: Назва"
 
-#: src/muuli_wdr.cpp:2429
+#: src/muuli_wdr.cpp:2436
 msgid "Enter the name of the new server here"
 msgstr "Введіть тут назву нового сервера"
 
-#: src/muuli_wdr.cpp:2431 src/ServerWnd.cpp:206
+#: src/muuli_wdr.cpp:2438 src/ServerWnd.cpp:206
 msgid "IP:Port"
 msgstr "IP:Порт"
 
-#: src/muuli_wdr.cpp:2434
+#: src/muuli_wdr.cpp:2441
 msgid "Enter the IP of the server here, using the x.x.x.x format."
 msgstr "Тут введіть IP-адресу сервера, використовуючи формат x.x.x.x."
 
-#: src/muuli_wdr.cpp:2440
+#: src/muuli_wdr.cpp:2447
 msgid "Enter the port of the server here."
 msgstr "Введіть тут порт сервера."
 
-#: src/muuli_wdr.cpp:2443
+#: src/muuli_wdr.cpp:2450
 msgid "Add manually a server (fill fields to the left before) ..."
 msgstr "Додати сервер вручну (заповніть поля ліворуч)..."
 
-#: src/muuli_wdr.cpp:2472
+#: src/muuli_wdr.cpp:2479
 msgid "aMule Log"
 msgstr "Часопис aMule"
 
-#: src/muuli_wdr.cpp:2480
+#: src/muuli_wdr.cpp:2487
 msgid "Server Info"
 msgstr "Інфо сервера"
 
-#: src/muuli_wdr.cpp:2484
+#: src/muuli_wdr.cpp:2491
 msgid "ED2K Info"
 msgstr "Інфо eD2k"
 
-#: src/muuli_wdr.cpp:2488
+#: src/muuli_wdr.cpp:2495
 msgid "Kad Info"
 msgstr "Інфо Kad"
 
-#: src/muuli_wdr.cpp:2516
+#: src/muuli_wdr.cpp:2523
 msgid "Click on this button to update the nodes list from URL ..."
 msgstr "Натисніть на цю кнопку щоб оновити перелік вузлів з URL..."
 
-#: src/muuli_wdr.cpp:2520
+#: src/muuli_wdr.cpp:2527
 msgid "Nodes (0)"
 msgstr "Вузли (0)"
 
-#: src/muuli_wdr.cpp:2524
+#: src/muuli_wdr.cpp:2531
 msgid "Enter the url to a nodes.dat file here and press the button to the left to update the list of known nodes."
 msgstr "Введіть адресу файлу nodes.dat та натисніть кнопку ліворуч щоб оновити перелік відомих вузлів. "
 
-#: src/muuli_wdr.cpp:2527
+#: src/muuli_wdr.cpp:2534
 msgid "Nodes stats"
 msgstr "Статистика вузлів"
 
-#: src/muuli_wdr.cpp:2569
+#: src/muuli_wdr.cpp:2576
 msgid "Bootstrap"
 msgstr "Початковий запуск"
 
-#: src/muuli_wdr.cpp:2572
+#: src/muuli_wdr.cpp:2579
 msgid "New node"
 msgstr "Новий вузол"
 
-#: src/muuli_wdr.cpp:2577
+#: src/muuli_wdr.cpp:2584
 msgid "IP:"
 msgstr "IP:"
 
-#: src/muuli_wdr.cpp:2597
+#: src/muuli_wdr.cpp:2604
 msgid "Port:"
 msgstr "Порт:"
 
-#: src/muuli_wdr.cpp:2610
+#: src/muuli_wdr.cpp:2617
 #, fuzzy
 msgid "Bootstrap from known clients"
 msgstr ""
 "Початковий запуск\n"
 "відомого клієнта"
 
-#: src/muuli_wdr.cpp:2612
+#: src/muuli_wdr.cpp:2619
 msgid "Disconnect Kad"
 msgstr "Від'єднатися від Kad"
 
-#: src/muuli_wdr.cpp:2646
+#: src/muuli_wdr.cpp:2653
 msgid "Use Secure User Identification"
 msgstr "Використовувати безпечну ідентифікацію користувача"
 
-#: src/muuli_wdr.cpp:2648
+#: src/muuli_wdr.cpp:2655
 msgid "It is recommended to enable this option. You will not receive credits if SUI is not enabled."
 msgstr "Рекомендовано ввімкнути цю опцію. Ви не отримаєте довіру якщо безпечна ідентифікація вимкнена."
 
-#: src/muuli_wdr.cpp:2650
+#: src/muuli_wdr.cpp:2657
 msgid "Protocol Obfuscation"
 msgstr "Приховування протоколу"
 
-#: src/muuli_wdr.cpp:2653
+#: src/muuli_wdr.cpp:2660
 msgid "Support Protocol Obfuscation"
 msgstr "Підтримка приховування протоколу"
 
-#: src/muuli_wdr.cpp:2655
+#: src/muuli_wdr.cpp:2662
 msgid "This option enabled Protocol Obfuscation, and makes aMule accept obfuscated connections from other clients."
 msgstr "Ця опція вмикає приховування протоколу та дозволяє aMule приймати приховані з'єднання від інших клієнтів."
 
-#: src/muuli_wdr.cpp:2657
+#: src/muuli_wdr.cpp:2664
 msgid "Use obfuscation for outgoing connections"
 msgstr "Використовувати приховування для вихідних з'єднань"
 
-#: src/muuli_wdr.cpp:2659
+#: src/muuli_wdr.cpp:2666
 msgid "This option makes aMule use Protocol Obfuscation when connecting other clients/servers."
 msgstr "Ця опція вмикає приховування протоколу під час з'єдання з іншими клієнтами/серверами."
 
-#: src/muuli_wdr.cpp:2661
+#: src/muuli_wdr.cpp:2668
 msgid "Accept only obfuscated connections"
 msgstr "Приймати тільки приховані з'єднання"
 
-#: src/muuli_wdr.cpp:2662
+#: src/muuli_wdr.cpp:2669
 msgid "This option makes aMule only accept obfuscated connections. You will have less sources, but all your traffic will be obfuscated"
 msgstr "Приймати приховані з'єднання. Будете мати менше джерел, але весь ваш трафік буде приховано"
 
-#: src/muuli_wdr.cpp:2667
+#: src/muuli_wdr.cpp:2674
 msgid "Everybody"
 msgstr "Кожен"
 
-#: src/muuli_wdr.cpp:2669
+#: src/muuli_wdr.cpp:2676
 msgid "No one"
 msgstr "Жоден"
 
-#: src/muuli_wdr.cpp:2671
+#: src/muuli_wdr.cpp:2678
 msgid "Who can see my shared files:"
 msgstr "Хто може бачити мої спільні файли:"
 
-#: src/muuli_wdr.cpp:2672
+#: src/muuli_wdr.cpp:2679
 msgid "Select who can request to view a list of your shared files."
 msgstr "Оберіть тих, хто може запитати перелік ваших спільних файлів."
 
-#: src/muuli_wdr.cpp:2674
+#: src/muuli_wdr.cpp:2681
 msgid "IP-Filtering"
 msgstr "IP-фільтрування"
 
-#: src/muuli_wdr.cpp:2681
+#: src/muuli_wdr.cpp:2688
 msgid "Filter clients"
 msgstr "Фільтрувати клієнтів"
 
-#: src/muuli_wdr.cpp:2683
+#: src/muuli_wdr.cpp:2690
 msgid "Enable filtering of the client IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "Ввімкнено фільтрування IP-адрес клієнтів, що визначені в файлі ~/.aMule/ipfilter.dat."
 
-#: src/muuli_wdr.cpp:2685
+#: src/muuli_wdr.cpp:2692
 msgid "Filter servers"
 msgstr "Фільтрувати сервери"
 
-#: src/muuli_wdr.cpp:2687
+#: src/muuli_wdr.cpp:2694
 msgid "Enable filtering of the server IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "Ввімкнено фільтрування IP-адрес серверів, що визначені в файлі ~/.aMule/ipfilter.dat."
 
-#: src/muuli_wdr.cpp:2691
+#: src/muuli_wdr.cpp:2698
 msgid "Reload List"
 msgstr "Перезавантажити перелік"
 
-#: src/muuli_wdr.cpp:2692
+#: src/muuli_wdr.cpp:2699
 msgid "Reload the list of IPs to filter from the file ~/.aMule/ipfilter.dat"
 msgstr "Перезавантажити перелік IP-адрес для фільтрування з файлу ~/.aMule/ipfilter.dat"
 
-#: src/muuli_wdr.cpp:2698
+#: src/muuli_wdr.cpp:2705
 msgid "URL:"
 msgstr "URL:"
 
-#: src/muuli_wdr.cpp:2702 src/muuli_wdr.cpp:2895
+#: src/muuli_wdr.cpp:2709 src/muuli_wdr.cpp:2902
 msgid "Update now"
 msgstr "Оновити зараз"
 
-#: src/muuli_wdr.cpp:2705
+#: src/muuli_wdr.cpp:2712
 msgid "Auto-update ipfilter at startup"
 msgstr "Автоматичне оновлення IP-фільтру після запуску"
 
-#: src/muuli_wdr.cpp:2709
+#: src/muuli_wdr.cpp:2716
 msgid "Filtering Level:"
 msgstr "Рівень фільтра:"
 
-#: src/muuli_wdr.cpp:2715
+#: src/muuli_wdr.cpp:2722
 msgid "Always filter LAN IPs"
 msgstr "Завжди відфільтровувати IP-адреси локальних мереж"
 
-#: src/muuli_wdr.cpp:2718
+#: src/muuli_wdr.cpp:2725
 msgid "Paranoid handling of non-matching IPs"
 msgstr "Параноїдальна обробка IP-адрес, що не співпали"
 
-#: src/muuli_wdr.cpp:2720
+#: src/muuli_wdr.cpp:2727
 msgid "Rejects a packet when its source IP differs from the IP the client claims (an anti-spoofing check). Disable only if it causes connection problems."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2722
+#: src/muuli_wdr.cpp:2729
 msgid "Use system-wide ipfilter.dat if available"
 msgstr "Використовувати системний ipfilter.dat якщо наявний"
 
-#: src/muuli_wdr.cpp:2723
+#: src/muuli_wdr.cpp:2730
 #, fuzzy
 msgid "If there's no local ipfilter.dat found, allow usage of a system-wide ipfilter file."
 msgstr "Якщо не знайдено місцевий ipfilter.dat, дозволити використання системного."
 
-#: src/muuli_wdr.cpp:2740
+#: src/muuli_wdr.cpp:2747
 msgid "Enable Online-Signature"
 msgstr "Ввімкнути онлайн-підпис"
 
-#: src/muuli_wdr.cpp:2742
+#: src/muuli_wdr.cpp:2749
 msgid "Enables the writing of the OS file, which can be used by external apps to create signatures and the like."
 msgstr "Ввімкнути запис файлу ОС, який може бути використано зовнішніми програмами для створення підписів та подібного."
 
-#: src/muuli_wdr.cpp:2746
+#: src/muuli_wdr.cpp:2753
 msgid "Update Frequency (Secs):"
 msgstr "Частота оновлення (с)"
 
-#: src/muuli_wdr.cpp:2749
+#: src/muuli_wdr.cpp:2756
 msgid "Change the frequency (in seconds) of Online Signature updates."
 msgstr "Змінити частоту (в секундах) оновлень онлайн-підписів."
 
-#: src/muuli_wdr.cpp:2757
+#: src/muuli_wdr.cpp:2764
 msgid "Save online signature file in: "
 msgstr "Зберегти файл онлайн-підпису в: "
 
-#: src/muuli_wdr.cpp:2763
+#: src/muuli_wdr.cpp:2770
 msgid "Click here to select the directory containing the the Online Signature files."
 msgstr "Натисніть тут, щоб вибрати теку, що містить файли з онлайн-підписами."
 
-#: src/muuli_wdr.cpp:2796
+#: src/muuli_wdr.cpp:2803
 msgid "Show country flags for clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2797
+#: src/muuli_wdr.cpp:2804
 msgid "Render the country flag column in the transfers, queue and search views. Requires a valid MMDB GeoIP database (see below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2802
+#: src/muuli_wdr.cpp:2809
 #, fuzzy
 msgid "Database"
 msgstr "Швидкість передачі:"
 
-#: src/muuli_wdr.cpp:2818
+#: src/muuli_wdr.cpp:2825
 #, fuzzy
 msgid "Source:"
 msgstr "Джерела"
 
-#: src/muuli_wdr.cpp:2821
+#: src/muuli_wdr.cpp:2828
 msgid "DB-IP (free, no account)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2822
+#: src/muuli_wdr.cpp:2829
 msgid "MaxMind GeoLite2 (free, account required)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2823
+#: src/muuli_wdr.cpp:2830
 msgid "Custom URL"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2826
+#: src/muuli_wdr.cpp:2833
 msgid "Choose which provider supplies the GeoIP MMDB database. DB-IP is the default - no account required. MaxMind requires a free account + license key. Use Custom URL to point at any other MMDB host (e.g. a local mirror)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2843
+#: src/muuli_wdr.cpp:2850
 msgid ""
 "No configuration required.\n"
 "\n"
@@ -4874,11 +4888,11 @@ msgid ""
 "License: Creative Commons BY 4.0 - https://creativecommons.org/licenses/by/4.0/"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2856
+#: src/muuli_wdr.cpp:2863
 msgid "License key:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2862
+#: src/muuli_wdr.cpp:2869
 msgid ""
 "Sign up for a free MaxMind account, then generate a License Key:\n"
 "https://www.maxmind.com/en/geolite2/signup\n"
@@ -4888,232 +4902,232 @@ msgid ""
 "Requires attribution and account registration; refresh at least every 30 days."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2877
+#: src/muuli_wdr.cpp:2884
 #, fuzzy
 msgid "Download URL:"
 msgstr "Звантаження: "
 
-#: src/muuli_wdr.cpp:2883
+#: src/muuli_wdr.cpp:2890
 msgid ""
 "Must point to an .mmdb file or a .gz / .tar.gz containing one.\n"
 "URL may include credentials (https://user:pass@host/...).\n"
 "License and attribution terms are set by the upstream URL - you are responsible."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2896
+#: src/muuli_wdr.cpp:2903
 msgid "Download the GeoIP database from the selected source."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2898
+#: src/muuli_wdr.cpp:2905
 #, fuzzy
 msgid "Auto-update on startup"
 msgstr "Автоматичне оновлення IP-фільтру після запуску"
 
-#: src/muuli_wdr.cpp:2899
+#: src/muuli_wdr.cpp:2906
 msgid "Re-download the GeoIP database from the selected source every time aMule starts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2922
+#: src/muuli_wdr.cpp:2929
 msgid "Filter incoming messages (except current chat):"
 msgstr "Фільтрувати вхідні повідомлення (окрім поточної розмови):"
 
-#: src/muuli_wdr.cpp:2924
+#: src/muuli_wdr.cpp:2931
 msgid "Filter all messages"
 msgstr "Фільтрувати всі повідомлення"
 
-#: src/muuli_wdr.cpp:2926
+#: src/muuli_wdr.cpp:2933
 msgid "Filter messages from people not on your friend list"
 msgstr "Фільтрувати повідомлення від людей, що не в вашому переліку друзів"
 
-#: src/muuli_wdr.cpp:2928
+#: src/muuli_wdr.cpp:2935
 msgid "Filter messages from unknown clients"
 msgstr "Фільтрувати повідомлення від невідомих клієнтів"
 
-#: src/muuli_wdr.cpp:2930
+#: src/muuli_wdr.cpp:2937
 msgid "Filter messages containing (use ',' as separator):"
 msgstr "Фільтрувати повідомлення, що містять (використовуйте ',' для переліку):"
 
-#: src/muuli_wdr.cpp:2933 src/muuli_wdr.cpp:2944
+#: src/muuli_wdr.cpp:2940 src/muuli_wdr.cpp:2951
 msgid "add here the words amule should filter and block messages including it"
 msgstr "додати слова, які aMule буде фільтрувати, та забороняти повідомлення, що їх містять"
 
-#: src/muuli_wdr.cpp:2935
+#: src/muuli_wdr.cpp:2942
 msgid "Show received messages in the log"
 msgstr "Показувати отримані повідомлення в часописі"
 
-#: src/muuli_wdr.cpp:2938
+#: src/muuli_wdr.cpp:2945
 msgid "Comments"
 msgstr "Коментарі"
 
-#: src/muuli_wdr.cpp:2941
+#: src/muuli_wdr.cpp:2948
 msgid "Filter comments containing (use ',' as separator):"
 msgstr "Фільтрувати коментарі, що містять (використовуйте ',' для переліку):"
 
-#: src/muuli_wdr.cpp:2966
+#: src/muuli_wdr.cpp:2973
 msgid "Enable Proxy"
 msgstr "Ввімкнути проксі"
 
-#: src/muuli_wdr.cpp:2967
+#: src/muuli_wdr.cpp:2974
 msgid "Enable/disable proxy support"
 msgstr "Ввімкнути/вимкнути підтримку проксі"
 
-#: src/muuli_wdr.cpp:2970
+#: src/muuli_wdr.cpp:2977
 msgid "Proxy type:"
 msgstr "Тип проксі:"
 
-#: src/muuli_wdr.cpp:2981
+#: src/muuli_wdr.cpp:2988
 msgid "Proxy host:"
 msgstr "Хост проксі:"
 
-#: src/muuli_wdr.cpp:2984
+#: src/muuli_wdr.cpp:2991
 msgid "The proxy host name"
 msgstr "Ім'я хосту проксі"
 
-#: src/muuli_wdr.cpp:2986
+#: src/muuli_wdr.cpp:2993
 msgid "Proxy port:"
 msgstr "Порт проксі:"
 
-#: src/muuli_wdr.cpp:2989
+#: src/muuli_wdr.cpp:2996
 msgid "The proxy port"
 msgstr "Порт проксі"
 
-#: src/muuli_wdr.cpp:2991
+#: src/muuli_wdr.cpp:2998
 msgid "Enable authentication"
 msgstr "Включити авторизацію"
 
-#: src/muuli_wdr.cpp:2992
+#: src/muuli_wdr.cpp:2999
 msgid "Enable/disable username/password authentication"
 msgstr "Ввімкнути/вимкнути аутентифікацію з ім'ям/паролем"
 
-#: src/muuli_wdr.cpp:2995
+#: src/muuli_wdr.cpp:3002
 msgid "Username: "
 msgstr "Ім'я користувача: "
 
-#: src/muuli_wdr.cpp:2998
+#: src/muuli_wdr.cpp:3005
 msgid "The username to use to connect to the proxy"
 msgstr "Ім'я користувача для з'єднання з проксі"
 
-#: src/muuli_wdr.cpp:3000
+#: src/muuli_wdr.cpp:3007
 msgid "Password:"
 msgstr "Пароль:"
 
-#: src/muuli_wdr.cpp:3003
+#: src/muuli_wdr.cpp:3010
 msgid "The password to use to connect to the proxy"
 msgstr "Пароль для з'єднання з проксі"
 
-#: src/muuli_wdr.cpp:3022
+#: src/muuli_wdr.cpp:3029
 msgid "Connect to:"
 msgstr "З'єднатись з:"
 
-#: src/muuli_wdr.cpp:3031
+#: src/muuli_wdr.cpp:3038
 msgid "Login to remote amule"
 msgstr "Вхід до віддаленого aMule"
 
-#: src/muuli_wdr.cpp:3036
+#: src/muuli_wdr.cpp:3043
 msgid "User name"
 msgstr "Ім'я користувача"
 
-#: src/muuli_wdr.cpp:3047
+#: src/muuli_wdr.cpp:3054
 msgid "Remember those settings"
 msgstr "Запам'ятати ці налаштування"
 
-#: src/muuli_wdr.cpp:3050
+#: src/muuli_wdr.cpp:3057
 #, fuzzy
 msgid "Force ZLIB compression"
 msgstr "Використовувати gzip-стиснення"
 
-#: src/muuli_wdr.cpp:3074
+#: src/muuli_wdr.cpp:3081
 msgid "Enable Verbose Debug-Logging."
 msgstr "Ввімкнути докладне ведення часопису."
 
-#: src/muuli_wdr.cpp:3076
+#: src/muuli_wdr.cpp:3083
 #, fuzzy
 msgid "Only to Logfile"
 msgstr "Відкрити файл"
 
-#: src/muuli_wdr.cpp:3078
+#: src/muuli_wdr.cpp:3085
 msgid "Message Categories:"
 msgstr "Категорія повідомлення:"
 
-#: src/muuli_wdr.cpp:3102 src/PartFileConvertDlg.cpp:160
+#: src/muuli_wdr.cpp:3109 src/PartFileConvertDlg.cpp:160
 msgid "Waiting..."
 msgstr "Очікується..."
 
-#: src/muuli_wdr.cpp:3122
+#: src/muuli_wdr.cpp:3129
 msgid "Add imports"
 msgstr "Додати зовнішні внесення"
 
-#: src/muuli_wdr.cpp:3125
+#: src/muuli_wdr.cpp:3132
 msgid "Retry selected"
 msgstr "Повторити вибрані"
 
-#: src/muuli_wdr.cpp:3127
+#: src/muuli_wdr.cpp:3134
 msgid "Remove selected"
 msgstr "Вилучити вибрані"
 
-#: src/muuli_wdr.cpp:3190
+#: src/muuli_wdr.cpp:3197
 msgid "Event Types"
 msgstr "Типи подій"
 
-#: src/muuli_wdr.cpp:3209
+#: src/muuli_wdr.cpp:3216
 msgid "Statistics and queued clients for selected file(s) : Session / All time"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3233
+#: src/muuli_wdr.cpp:3240
 #, fuzzy
 msgid "Active Uploads"
 msgstr "Чинні вивантаження:"
 
-#: src/muuli_wdr.cpp:3247
+#: src/muuli_wdr.cpp:3254
 msgid "Percent of total files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3299
+#: src/muuli_wdr.cpp:3306
 #, fuzzy
 msgid "Show Clients for"
 msgstr "Показати клієнтів"
 
-#: src/muuli_wdr.cpp:3301
+#: src/muuli_wdr.cpp:3308
 #, fuzzy
 msgid "All files"
 msgstr "Сховати спільні файли"
 
-#: src/muuli_wdr.cpp:3304
+#: src/muuli_wdr.cpp:3311
 #, fuzzy
 msgid "Selected files"
 msgstr "Вибрати фільтр перегляду"
 
-#: src/muuli_wdr.cpp:3307
+#: src/muuli_wdr.cpp:3314
 #, fuzzy
 msgid "Active uploads only"
 msgstr "Чинні вивантаження"
 
-#: src/muuli_wdr.cpp:3314
+#: src/muuli_wdr.cpp:3321
 #, fuzzy
 msgid "Reload:"
 msgstr "Перезавантажити перелік"
 
-#: src/muuli_wdr.cpp:3318
+#: src/muuli_wdr.cpp:3325
 msgid "Reload your shared files"
 msgstr "Перезавантажити ваші спільні файли"
 
-#: src/muuli_wdr.cpp:3381
+#: src/muuli_wdr.cpp:3388
 msgid "Send"
 msgstr "Надіслати"
 
-#: src/muuli_wdr.cpp:3382
+#: src/muuli_wdr.cpp:3389
 msgid "Sends the specified message."
 msgstr "Надіслати вказане повідомлення."
 
-#: src/muuli_wdr.cpp:3386
+#: src/muuli_wdr.cpp:3393
 msgid "Close this chat-session."
 msgstr "Закрити цю розмову."
 
-#: src/muuli_wdr.cpp:3409
+#: src/muuli_wdr.cpp:3416
 msgid "Connect to any server and/or Kad"
 msgstr "З'єднатися з будь-яким сервером та/чи Kad"
 
-#: src/muuli_wdr.cpp:3415 src/SharedFilesCtrl.cpp:142 src/Statistics.cpp:941
+#: src/muuli_wdr.cpp:3422 src/SharedFilesCtrl.cpp:142 src/Statistics.cpp:941
 msgid "Shared Files"
 msgstr "Спільні файли"
 
@@ -5477,192 +5491,192 @@ msgstr "Звантажені"
 msgid "ERROR: Failed to open partfile '%s'"
 msgstr "ПОМИЛКА: не вдалося відкрити частковий файл '%s'"
 
-#: src/Preferences.cpp:673
+#: src/Preferences.cpp:674
 msgid "System default"
 msgstr "Мова системи"
 
-#: src/Preferences.cpp:674
+#: src/Preferences.cpp:675
 msgid "Albanian"
 msgstr "Албанська"
 
-#: src/Preferences.cpp:675
+#: src/Preferences.cpp:676
 msgid "Arabic"
 msgstr "Арабська"
 
-#: src/Preferences.cpp:676
+#: src/Preferences.cpp:677
 #, fuzzy
 msgid "Asturian"
 msgstr "Естонська"
 
-#: src/Preferences.cpp:677
+#: src/Preferences.cpp:678
 msgid "Basque"
 msgstr "Баскська"
 
-#: src/Preferences.cpp:678
+#: src/Preferences.cpp:679
 msgid "Bulgarian"
 msgstr "Болгарська"
 
-#: src/Preferences.cpp:679
+#: src/Preferences.cpp:680
 msgid "Catalan"
 msgstr "Каталонська"
 
-#: src/Preferences.cpp:680
+#: src/Preferences.cpp:681
 msgid "Chinese (Simplified)"
 msgstr "Китайська (спрощена)"
 
-#: src/Preferences.cpp:681
+#: src/Preferences.cpp:682
 msgid "Chinese (Traditional)"
 msgstr "Китайська (традиційна)"
 
-#: src/Preferences.cpp:682
+#: src/Preferences.cpp:683
 msgid "Croatian"
 msgstr "Хорватська"
 
-#: src/Preferences.cpp:683
+#: src/Preferences.cpp:684
 msgid "Czech"
 msgstr "Чеська"
 
-#: src/Preferences.cpp:684
+#: src/Preferences.cpp:685
 msgid "Danish"
 msgstr "Данська"
 
-#: src/Preferences.cpp:685
+#: src/Preferences.cpp:686
 msgid "Dutch"
 msgstr "Нідерландська"
 
-#: src/Preferences.cpp:686
+#: src/Preferences.cpp:687
 msgid "English (U.K.)"
 msgstr "Англійська (Великобританія)"
 
-#: src/Preferences.cpp:687
+#: src/Preferences.cpp:688
 #, fuzzy
 msgid "English (U.S.)"
 msgstr "Англійська (Великобританія)"
 
-#: src/Preferences.cpp:688
+#: src/Preferences.cpp:689
 msgid "Estonian"
 msgstr "Естонська"
 
-#: src/Preferences.cpp:689
+#: src/Preferences.cpp:690
 msgid "Finnish"
 msgstr "Фінська"
 
-#: src/Preferences.cpp:690
+#: src/Preferences.cpp:691
 msgid "French"
 msgstr "Французька"
 
-#: src/Preferences.cpp:691
+#: src/Preferences.cpp:692
 msgid "Galician"
 msgstr "Галісійська"
 
-#: src/Preferences.cpp:692
+#: src/Preferences.cpp:693
 msgid "German"
 msgstr "Німецька"
 
-#: src/Preferences.cpp:693
+#: src/Preferences.cpp:694
 msgid "Greek"
 msgstr "Грецька"
 
-#: src/Preferences.cpp:694
+#: src/Preferences.cpp:695
 msgid "Hebrew"
 msgstr "Іврит"
 
-#: src/Preferences.cpp:695
+#: src/Preferences.cpp:696
 msgid "Hungarian"
 msgstr "Угорська"
 
-#: src/Preferences.cpp:696
+#: src/Preferences.cpp:697
 msgid "Italian"
 msgstr "Італійська"
 
-#: src/Preferences.cpp:697
+#: src/Preferences.cpp:698
 msgid "Japanese"
 msgstr "Японська"
 
-#: src/Preferences.cpp:698
+#: src/Preferences.cpp:699
 msgid "Korean"
 msgstr "Корейська"
 
-#: src/Preferences.cpp:699
+#: src/Preferences.cpp:700
 msgid "Latvian"
 msgstr ""
 
-#: src/Preferences.cpp:700
+#: src/Preferences.cpp:701
 msgid "Lithuanian"
 msgstr "Литовська"
 
-#: src/Preferences.cpp:701
+#: src/Preferences.cpp:702
 msgid "Norwegian (Nynorsk)"
 msgstr "Норвезька (Нюнорск)"
 
-#: src/Preferences.cpp:702
+#: src/Preferences.cpp:703
 msgid "Polish"
 msgstr "Польська"
 
-#: src/Preferences.cpp:703
+#: src/Preferences.cpp:704
 msgid "Portuguese"
 msgstr "Португальська"
 
-#: src/Preferences.cpp:704
+#: src/Preferences.cpp:705
 msgid "Portuguese (Brazilian)"
 msgstr "Португальська (Бразилія)"
 
-#: src/Preferences.cpp:705
+#: src/Preferences.cpp:706
 #, fuzzy
 msgid "Romanian"
 msgstr "Албанська"
 
-#: src/Preferences.cpp:706
+#: src/Preferences.cpp:707
 msgid "Russian"
 msgstr "Російська"
 
-#: src/Preferences.cpp:707
+#: src/Preferences.cpp:708
 msgid "Slovenian"
 msgstr "Словенська"
 
-#: src/Preferences.cpp:708
+#: src/Preferences.cpp:709
 msgid "Spanish"
 msgstr "Іспанська"
 
-#: src/Preferences.cpp:709
+#: src/Preferences.cpp:710
 msgid "Swedish"
 msgstr "Шведська"
 
-#: src/Preferences.cpp:710
+#: src/Preferences.cpp:711
 msgid "Turkish"
 msgstr "Турецька"
 
-#: src/Preferences.cpp:711
+#: src/Preferences.cpp:712
 msgid "Ukrainian"
 msgstr "Українська"
 
-#: src/Preferences.cpp:814
+#: src/Preferences.cpp:815
 #, fuzzy
 msgid "Change Language"
 msgstr "Мова: "
 
-#: src/Preferences.cpp:878
+#: src/Preferences.cpp:879
 msgid "There are no translations installed for aMule"
 msgstr ""
 
-#: src/Preferences.cpp:879
+#: src/Preferences.cpp:880
 #, fuzzy
 msgid "No languages available"
 msgstr "Недоступний"
 
-#: src/Preferences.cpp:1010
+#: src/Preferences.cpp:1011
 msgid "no options available"
 msgstr "немає наявних опцій"
 
-#: src/Preferences.cpp:2179
+#: src/Preferences.cpp:2182
 msgid "Invalid category found, skipping"
 msgstr "Знайдена помилкова категорія, пропущена"
 
-#: src/Preferences.cpp:2348
+#: src/Preferences.cpp:2351
 msgid "TCP port can't be higher than 65532 due to server UDP socket being TCP+3"
 msgstr "Порт TCP не може бути більшим ніж 65532, оскільки UDP-порт сервера є TCP+3"
 
-#: src/Preferences.cpp:2349
+#: src/Preferences.cpp:2352
 #, c-format
 msgid "Default port will be used (%d)"
 msgstr "Буде використовуватися порт за замовчуванням (%d)"
@@ -6180,24 +6194,28 @@ msgstr "Перезавантажується перелік спільних ф�
 msgid "Shared folder"
 msgstr "Спільні теки"
 
-#: src/SearchDlg.cpp:425
+#: src/SearchDlg.cpp:280
+msgid "Clear search history"
+msgstr ""
+
+#: src/SearchDlg.cpp:584
 msgid "It's impossible to search when both eD2k and Kademlia are disabled."
 msgstr ""
 
-#: src/SearchDlg.cpp:426 src/SearchListCtrl.cpp:858
+#: src/SearchDlg.cpp:585 src/SearchListCtrl.cpp:858
 #, fuzzy
 msgid "Search error"
 msgstr "Пошук"
 
-#: src/SearchDlg.cpp:768
+#: src/SearchDlg.cpp:929
 msgid "Min size must be smaller than max size. Max size ignored."
 msgstr "Найменший розмір має бути меншим ніж найбільший. Найбільшим розміром знехтувано."
 
-#: src/SearchDlg.cpp:769 src/SearchDlg.cpp:851
+#: src/SearchDlg.cpp:930 src/SearchDlg.cpp:1012
 msgid "Search warning"
 msgstr "Очікування пошуку"
 
-#: src/SearchDlg.cpp:929 src/SearchListCtrl.cpp:735
+#: src/SearchDlg.cpp:1092 src/SearchListCtrl.cpp:735
 msgid "Main"
 msgstr "Головна"
 

--- a/po/uk.po
+++ b/po/uk.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-28 10:19+0200\n"
+"POT-Creation-Date: 2026-07-28 12:17+0200\n"
 "PO-Revision-Date: 2026-07-27 11:47+0000\n"
 "Last-Translator: Oleksandr Kovalenko <alx.kovalenko@gmail.com>\n"
 "Language-Team: Ukrainian <translation@linux.org.ua>\n"
@@ -202,83 +202,83 @@ msgstr "Не вдалося відкрити файл ED2KLinks."
 msgid "WARNING: You can't add yourself as a source for an eD2k link while having a lowid."
 msgstr "ЗАСТЕРЕЖЕННЯ: ви не можете додати себе як джерело для eD2k-посилання маючи LowID."
 
-#: src/amule.cpp:300
+#: src/amule.cpp:301
 msgid "Now, exiting main app..."
 msgstr "Тепер, виходимо з головної програми..."
 
-#: src/amule.cpp:330
+#: src/amule.cpp:331
 #, c-format
 msgid "Terminating amuleweb instance with pid '%d' ... "
 msgstr "Вбиваю екземпляр amuleweb з pid `%d' ... "
 
-#: src/amule.cpp:334
+#: src/amule.cpp:335
 #, c-format
 msgid "Killing amuleweb instance with pid '%d' ... "
 msgstr "Вбиваю екземпляр amuleweb з pid `%d' ... "
 
-#: src/amule.cpp:336 src/amule.cpp:349 src/ClientRef.cpp:180
+#: src/amule.cpp:337 src/amule.cpp:350 src/ClientRef.cpp:180
 #: src/SearchDlg.cpp:1041 src/ServerListCtrl.cpp:98
 msgid "Failed"
 msgstr "Невдалі"
 
-#: src/amule.cpp:343
+#: src/amule.cpp:344
 #, fuzzy, c-format
 msgid "Terminating amuleapi instance with pid '%d' ... "
 msgstr "Вбиваю екземпляр amuleweb з pid `%d' ... "
 
-#: src/amule.cpp:347
+#: src/amule.cpp:348
 #, fuzzy, c-format
 msgid "Killing amuleapi instance with pid '%d' ... "
 msgstr "Вбиваю екземпляр amuleweb з pid `%d' ... "
 
-#: src/amule.cpp:355
+#: src/amule.cpp:356
 msgid "aMule OnExit: Terminating core."
 msgstr "aMule OnExit: Завершується core."
 
-#: src/amule.cpp:466
+#: src/amule.cpp:467
 msgid "aMule shutdown completed."
 msgstr "Завершення роботи aMule закінчене."
 
-#: src/amule.cpp:470
+#: src/amule.cpp:471
 msgid "Memory debug results for aMule exit:"
 msgstr "Наслідки зневадження пам'яті для виходу aMule:"
 
-#: src/amule.cpp:651
+#: src/amule.cpp:652
 #, c-format
 msgid "Binding aMule's peer-to-peer traffic to interface: %s (HTTP updates use the default route)"
 msgstr ""
 
-#: src/amule.cpp:655
+#: src/amule.cpp:656
 #, c-format
 msgid "Binding all network traffic to interface: %s"
 msgstr ""
 
-#: src/amule.cpp:659
+#: src/amule.cpp:660
 #, c-format
 msgid "WARNING: configured network interface '%s' was not found - traffic is NOT bound to it and may leave via the default route. Check the interface name in Preferences."
 msgstr ""
 
-#: src/amule.cpp:665
+#: src/amule.cpp:666
 #, c-format
 msgid "WARNING: binding to network interface '%s' requires elevated privileges and was NOT applied - traffic may leave via the default route. Grant the capability (e.g. 'sudo setcap cap_net_raw+ep' on the aMule binary) or run with sufficient privileges."
 msgstr ""
 
-#: src/amule.cpp:673
+#: src/amule.cpp:674
 #, c-format
 msgid "WARNING: could not bind to network interface '%s' - traffic may leave via the default route."
 msgstr ""
 
-#: src/amule.cpp:732
+#: src/amule.cpp:733
 msgid "Your locale has been changed to System Default due to a configuration change. Sorry."
 msgstr "Ваша локаль змінена на системну за замовчуванням із-за зміни налаштувань. Вибачте."
 
-#: src/amule.cpp:734 src/amule.cpp:1581 src/CatDialog.cpp:128
+#: src/amule.cpp:735 src/amule.cpp:1589 src/CatDialog.cpp:128
 #: src/CatDialog.cpp:136 src/CatDialog.cpp:149 src/ServerList.cpp:366
 #: src/ServerListCtrl.cpp:152
 msgid "Info"
 msgstr "Інфо"
 
-#: src/amule.cpp:741
+#: src/amule.cpp:742
 msgid ""
 "\n"
 "EC configuration"
@@ -286,74 +286,74 @@ msgstr ""
 "\n"
 "Налаштування зовнішніх з'єднань"
 
-#: src/amule.cpp:744
+#: src/amule.cpp:745
 msgid "Password set and external connections enabled."
 msgstr "Пароль встановлений та дозволені зовнішні з'єднання."
 
-#: src/amule.cpp:754 src/KadDlg.cpp:176 src/KadDlg.cpp:185
-#: src/PrefsUnifiedDlg.cpp:1387 src/SharedFilesCtrl.cpp:476
+#: src/amule.cpp:755 src/KadDlg.cpp:176 src/KadDlg.cpp:185
+#: src/PrefsUnifiedDlg.cpp:1461 src/SharedFilesCtrl.cpp:476
 msgid "WARNING"
 msgstr "ЗАСТЕРЕЖЕННЯ"
 
-#: src/amule.cpp:991
+#: src/amule.cpp:992
 #, fuzzy
 msgid "Network bootstrap"
 msgstr "Мережі"
 
-#: src/amule.cpp:996
+#: src/amule.cpp:997
 msgid ""
 "aMule has detected missing network bootstrap files.\n"
 "Select which ones to download:"
 msgstr ""
 
-#: src/amule.cpp:1005 src/FirstRunWizard.cpp:411
+#: src/amule.cpp:1006 src/FirstRunWizard.cpp:411
 #, fuzzy
 msgid "eD2k server list (server.met)"
 msgstr "%i сервер знайдено в server.met"
 
-#: src/amule.cpp:1012 src/FirstRunWizard.cpp:416
+#: src/amule.cpp:1013 src/FirstRunWizard.cpp:416
 msgid "Kad bootstrap nodes (nodes.dat)"
 msgstr ""
 
-#: src/amule.cpp:1102
+#: src/amule.cpp:1103
 #, c-format
 msgid "web server running on pid %d"
 msgstr "Веб-сервер запущений з %d"
 
-#: src/amule.cpp:1115
+#: src/amule.cpp:1116
 #, fuzzy
 msgid "You requested to run web server on startup, but the amuleweb binary cannot be run. Please install the package containing aMule web server, or build aMule from source with -DBUILD_WEBSERVER=YES and install it."
 msgstr "Ви встановили запуск веб-сервера під час завантаження, але amuleweb не може бути запущено. Будь ласка, встановіть пакунок, що містить веб-сервер aMule, зберіть aMule з --enable-webserver та виконайте make install"
 
-#: src/amule.cpp:1120 src/amule.cpp:1177 src/amule.cpp:1291 src/amule.cpp:1593
+#: src/amule.cpp:1121 src/amule.cpp:1185 src/amule.cpp:1299 src/amule.cpp:1601
 #: src/amule-remote-gui.cpp:603 src/amule-remote-gui.cpp:671
 #: src/amule-remote-gui.cpp:709 src/amule-remote-gui.cpp:1282
 #: src/amule-remote-gui.cpp:1345 src/amule-remote-gui.cpp:1372
-#: src/DownloadQueue.cpp:1481
+#: src/DownloadQueue.cpp:1481 src/PrefsUnifiedDlg.cpp:1247
 msgid "ERROR"
 msgstr "ПОМИЛКА"
 
-#: src/amule.cpp:1166
+#: src/amule.cpp:1174
 #, fuzzy, c-format
 msgid "amuleapi running on pid %d"
 msgstr "Веб-сервер запущений з %d"
 
-#: src/amule.cpp:1172
+#: src/amule.cpp:1180
 #, fuzzy
 msgid "You requested to run amuleapi on startup, but the amuleapi binary cannot be run. Please install the package containing aMule's REST API server, or build aMule from source with -DBUILD_AMULEAPI=YES and install it."
 msgstr "Ви встановили запуск веб-сервера під час завантаження, але amuleweb не може бути запущено. Будь ласка, встановіть пакунок, що містить веб-сервер aMule, зберіть aMule з --enable-webserver та виконайте make install"
 
-#: src/amule.cpp:1259
+#: src/amule.cpp:1267
 #, c-format
 msgid "Could not bind ports to the specified address: %s"
 msgstr "Неможливо прив'язати порт до визначеної адреси: %s"
 
-#: src/amule.cpp:1283
+#: src/amule.cpp:1291
 #, c-format
 msgid "Port %u is not available. You will be LOWID\n"
 msgstr "Порт %u недоступний. Ви будете мати LowID\n"
 
-#: src/amule.cpp:1288
+#: src/amule.cpp:1296
 #, c-format
 msgid ""
 "Port %u is not available!\n"
@@ -368,48 +368,48 @@ msgstr ""
 "\n"
 "Перевірте вашу мережу, щоб впевнитись, що порт відкритий."
 
-#: src/amule.cpp:1385
+#: src/amule.cpp:1393
 msgid "Failed to create OnlineSig File"
 msgstr "Неможливо створити файл онлайн-підпису"
 
-#: src/amule.cpp:1393
+#: src/amule.cpp:1401
 msgid "Failed to create aMule OnlineSig File"
 msgstr "Неможливо створити файл онлайн-підпису aMule"
 
-#: src/amule.cpp:1556
+#: src/amule.cpp:1564
 msgid "The selected locale seems not to be installed on your box. (Note: I'll try to set it anyway)"
 msgstr "Обрана локаль здається не встановлена. (примітка: спроба встановити її в будь-якому випадку)"
 
-#: src/amule.cpp:1566
+#: src/amule.cpp:1574
 #, c-format
 msgid "This is the first time you run aMule %s"
 msgstr "Ви запускаєте aMule %s вперше"
 
-#: src/amule.cpp:1569
+#: src/amule.cpp:1577
 msgid "This version is a testing version, updated daily, and\n"
 msgstr "Це тестова версія, оновлюється щодня, та\n"
 
-#: src/amule.cpp:1570
+#: src/amule.cpp:1578
 msgid "we give no warranty it won't break anything, burn your house,\n"
 msgstr "ми не даємо жодної гарантії, якщо вона щось пошкодить, спалить ваш будинок,\n"
 
-#: src/amule.cpp:1571
+#: src/amule.cpp:1579
 msgid "or kill your dog. But it *should* be safe to use anyway.\n"
 msgstr "або вб'є собаку. Але вона *має бути* безпечною у використанні всюди.\n"
 
-#: src/amule.cpp:1576
+#: src/amule.cpp:1584
 msgid "More information, support and new releases can found at our homepage,\n"
 msgstr "Більше подробиць, підтримка та нові випуски можуть бути знайдені на нашій сторінці,\n"
 
-#: src/amule.cpp:1577
+#: src/amule.cpp:1585
 msgid "at https://amule-org.github.io, or in our IRC channel #aMule at irc.libera.chat.\n"
 msgstr "на https://amule-org.github.io, або у нашому IRC-каналі #aMule на irc.libera.chat.\n"
 
-#: src/amule.cpp:1579
+#: src/amule.cpp:1587
 msgid "Feel free to report any bugs to https://github.com/amule-org/amule/issues"
 msgstr "Не соромтеся повідомити про будь-які помилки на https://github.com/amule-org/amule/issues"
 
-#: src/amule.cpp:1591
+#: src/amule.cpp:1599
 msgid ""
 "The folder for Online Signature files you specified is INVALID!\n"
 " OnlineSignature will be DISABLED until you fix it on preferences."
@@ -417,137 +417,137 @@ msgstr ""
 "Тека для файлів онлайн-підпису НЕВІРНА!\n"
 "Онлайн-підпис буде ВИМКНЕНО поки ви не виправите це в налаштуваннях."
 
-#: src/amule.cpp:1654
+#: src/amule.cpp:1662
 msgid "Server hostname notified"
 msgstr "Назва сервера повідомлена"
 
-#: src/amule.cpp:2031
+#: src/amule.cpp:2039
 #, c-format
 msgid "Disk space preallocation for file '%s' failed: %s"
 msgstr "Не вдалося виділити місце на диску для файлу '%s': %s"
 
-#: src/amule.cpp:2160
+#: src/amule.cpp:2168
 msgid "ERROR: can't open logfile"
 msgstr "ПОМИЛКА: не можу відкрити файл часопису"
 
-#: src/amule.cpp:2164
+#: src/amule.cpp:2172
 msgid "WARNING: logfile is empty. Something is wrong."
 msgstr "ЗАСТЕРЕЖЕННЯ: журнал порожній. Щось негаразд."
 
-#: src/amule.cpp:2181
+#: src/amule.cpp:2189
 msgid "Log has been reset"
 msgstr "Часопис очищено"
 
-#: src/amule.cpp:2205
+#: src/amule.cpp:2213
 #, c-format
 msgid "ServerMessage: %s"
 msgstr "Повідомлення сервера: %s"
 
-#: src/amule.cpp:2248 src/IP2Country.cpp:220 src/IPFilter.cpp:514
+#: src/amule.cpp:2256 src/IP2Country.cpp:220 src/IPFilter.cpp:514
 #: src/ServerList.cpp:875
 #, c-format
 msgid "Skipped download of %s, because requested file is not newer."
 msgstr ""
 
-#: src/amule.cpp:2251
+#: src/amule.cpp:2259
 msgid "Failed to download the nodes list."
 msgstr "Не вдалося звантажити перелік вузлів."
 
-#: src/amule.cpp:2314
+#: src/amule.cpp:2322
 msgid "Failed to open the downloaded version check file"
 msgstr "Не вдалося відкрити звантажений файл перевірки версії"
 
-#: src/amule.cpp:2317 src/amule.cpp:2336
+#: src/amule.cpp:2325 src/amule.cpp:2344
 msgid "Corrupted version check file"
 msgstr "Файл перевірки версії зіпсований"
 
-#: src/amule.cpp:2359
+#: src/amule.cpp:2367
 msgid "You are using an outdated version of aMule!"
 msgstr "Ви використовуєте застарілу версію aMule!"
 
-#: src/amule.cpp:2361
+#: src/amule.cpp:2369
 #, c-format
 msgid "Your aMule version is %i.%i.%i and the latest version is %li.%li.%li"
 msgstr "Ваша версія aMule %i.%i.%i, а остання %li.%li.%li"
 
-#: src/amule.cpp:2365
+#: src/amule.cpp:2373
 msgid "The latest version can always be found at https://github.com/amule-org/amule/releases/latest"
 msgstr "Остання версія може бути завжди знайдена на https://github.com/amule-org/amule/releases/latest"
 
-#: src/amule.cpp:2368
+#: src/amule.cpp:2376
 #, c-format
 msgid "WARNING: Your aMuled version is outdated: %i.%i.%i < %li.%li.%li"
 msgstr "ЗАСТЕРЕЖЕННЯ: Ваша версія aMuled застаріла: %i.%i.%i < %li.%li.%li"
 
-#: src/amule.cpp:2374
+#: src/amule.cpp:2382
 msgid "Your copy of aMule is up to date."
 msgstr "Ваша копія aMule оновлена."
 
-#: src/amule.cpp:2381
+#: src/amule.cpp:2389
 msgid "Failed to download the version check file"
 msgstr "Неможливо звантажити файл перевірки версії"
 
-#: src/amule.cpp:2550 src/amule-remote-gui.cpp:1133
+#: src/amule.cpp:2558 src/amule-remote-gui.cpp:1133
 #, c-format
 msgid "Users: %s | Files: %s"
 msgstr "Користувачі: %s | Файли: %s"
 
-#: src/amule.cpp:2551 src/amule-remote-gui.cpp:1134
+#: src/amule.cpp:2559 src/amule-remote-gui.cpp:1134
 #, c-format
 msgid "Users: E: %s K: %s | Files: E: %s K: %s"
 msgstr "Користувачі: %s K: %s | Файли: E: %s K: %s"
 
-#: src/amule.cpp:2565 src/amule-remote-gui.cpp:1147
+#: src/amule.cpp:2573 src/amule-remote-gui.cpp:1147
 msgid "No networks selected"
 msgstr "Не вибрано жодної мережі"
 
-#: src/amule.cpp:2633 src/TextClient.cpp:903
+#: src/amule.cpp:2641 src/TextClient.cpp:903
 msgid "with LowID"
 msgstr "з LowID"
 
-#: src/amule.cpp:2633 src/TextClient.cpp:904
+#: src/amule.cpp:2641 src/TextClient.cpp:904
 msgid "with HighID"
 msgstr "з HighID"
 
-#: src/amule.cpp:2635
+#: src/amule.cpp:2643
 #, c-format
 msgid "Connected to %s %s"
 msgstr "З'єднано з %s %s"
 
-#: src/amule.cpp:2640
+#: src/amule.cpp:2648
 #, c-format
 msgid "Connecting to %s"
 msgstr "З'єднується з %s"
 
-#: src/amule.cpp:2642
+#: src/amule.cpp:2650
 msgid "Disconnected from eD2k"
 msgstr "Від'єднано від eD2k"
 
-#: src/amule.cpp:2651
+#: src/amule.cpp:2659
 msgid "Kad started."
 msgstr "Kad запущена."
 
-#: src/amule.cpp:2653
+#: src/amule.cpp:2661
 msgid "Kad stopped."
 msgstr "Kad зупинена."
 
-#: src/amule.cpp:2661
+#: src/amule.cpp:2669
 msgid "Connected to Kad (ok)"
 msgstr "З'єднано з Kad (все гаразд)"
 
-#: src/amule.cpp:2663
+#: src/amule.cpp:2671
 msgid "Connected to Kad (firewalled)"
 msgstr "З'єднано з Kad (за фаєрволом)"
 
-#: src/amule.cpp:2667
+#: src/amule.cpp:2675
 msgid "Disconnected from Kad"
 msgstr "Від'єднано від Kad"
 
-#: src/amule.cpp:2699
+#: src/amule.cpp:2707
 msgid "Kad network cannot be used if UDP port is disabled on preferences, not starting."
 msgstr "Мережа Kad не може бути використана якщо UDP-порт вимкнено в налаштуваннях, не починаю."
 
-#: src/amule.cpp:2703
+#: src/amule.cpp:2711
 msgid "Kad network disabled on preferences, not connecting."
 msgstr "Мережа Kad вимкнена в налаштуваннях, не з'єднуюсь."
 
@@ -592,36 +592,36 @@ msgid "FATAL ERROR: Failed to create Timer"
 msgstr "ЖАХЛИВА ПОМИЛКА: не вдалося створити Timer"
 
 #: src/amuleDlg.cpp:361 src/amuleDlg.cpp:1787 src/amuleDlg.cpp:2033
-#: src/muuli_wdr.cpp:1492 src/muuli_wdr.cpp:3418
+#: src/muuli_wdr.cpp:1492 src/muuli_wdr.cpp:3449
 msgid "Networks"
 msgstr "Мережі"
 
-#: src/amuleDlg.cpp:362 src/amuleDlg.cpp:1793 src/muuli_wdr.cpp:3419
+#: src/amuleDlg.cpp:362 src/amuleDlg.cpp:1793 src/muuli_wdr.cpp:3450
 msgid "Searches"
 msgstr "Пошук"
 
 #: src/amuleDlg.cpp:363 src/amuleDlg.cpp:1799 src/DownloadListCtrl.cpp:740
-#: src/muuli_wdr.cpp:392 src/muuli_wdr.cpp:1585 src/muuli_wdr.cpp:3420
+#: src/muuli_wdr.cpp:392 src/muuli_wdr.cpp:1585 src/muuli_wdr.cpp:3451
 #: src/Statistics.cpp:829
 msgid "Downloads"
 msgstr "Звантаження"
 
-#: src/amuleDlg.cpp:364 src/amuleDlg.cpp:1805 src/muuli_wdr.cpp:3294
+#: src/amuleDlg.cpp:364 src/amuleDlg.cpp:1805 src/muuli_wdr.cpp:3325
 msgid "Shared files"
 msgstr "Спільні файли"
 
-#: src/amuleDlg.cpp:365 src/amuleDlg.cpp:1811 src/muuli_wdr.cpp:2926
-#: src/muuli_wdr.cpp:3376 src/muuli_wdr.cpp:3423
+#: src/amuleDlg.cpp:365 src/amuleDlg.cpp:1811 src/muuli_wdr.cpp:2957
+#: src/muuli_wdr.cpp:3407 src/muuli_wdr.cpp:3454
 msgid "Messages"
 msgstr "Повідомлення"
 
-#: src/amuleDlg.cpp:366 src/amuleDlg.cpp:1817 src/muuli_wdr.cpp:3424
-#: src/PrefsUnifiedDlg.cpp:312 src/Statistics.cpp:779 src/Statistics.cpp:1235
+#: src/amuleDlg.cpp:366 src/amuleDlg.cpp:1817 src/muuli_wdr.cpp:3455
+#: src/PrefsUnifiedDlg.cpp:314 src/Statistics.cpp:779 src/Statistics.cpp:1235
 msgid "Statistics"
 msgstr "Статистика"
 
-#: src/amuleDlg.cpp:368 src/amuleDlg.cpp:1824 src/muuli_wdr.cpp:3426
-#: src/PrefsUnifiedDlg.cpp:328 src/utils/wxCas/src/wxcasprefs.cpp:39
+#: src/amuleDlg.cpp:368 src/amuleDlg.cpp:1824 src/muuli_wdr.cpp:3457
+#: src/PrefsUnifiedDlg.cpp:330 src/utils/wxCas/src/wxcasprefs.cpp:39
 msgid "Preferences"
 msgstr "Налаштування"
 
@@ -679,8 +679,8 @@ msgstr "Kad: вимкнена"
 #: src/amuleDlg.cpp:1029 src/DownloadListCtrl.cpp:505
 #: src/DownloadListCtrl.cpp:749 src/FriendListCtrl.cpp:180
 #: src/muuli_wdr.cpp:731 src/muuli_wdr.cpp:782 src/muuli_wdr.cpp:846
-#: src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2231 src/muuli_wdr.cpp:2316
-#: src/muuli_wdr.cpp:3064 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
+#: src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2262 src/muuli_wdr.cpp:2347
+#: src/muuli_wdr.cpp:3095 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
 #: src/ServerListCtrl.cpp:606 src/TransferWnd.cpp:378
 #: src/utils/wxCas/src/wxcasprefs.cpp:235
 msgid "Cancel"
@@ -691,7 +691,7 @@ msgid "Stop the current connection attempts"
 msgstr "Зупинити поточні спроби з'єднань"
 
 #: src/amuleDlg.cpp:1035 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976
-#: src/muuli_wdr.cpp:2454
+#: src/muuli_wdr.cpp:2485
 msgid "Disconnect"
 msgstr "Від'єднатися"
 
@@ -700,7 +700,7 @@ msgid "Disconnect from the currently connected networks"
 msgstr "Від'єднатися від з'єднаних мереж"
 
 #: src/amuleDlg.cpp:1041 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979
-#: src/muuli_wdr.cpp:2609 src/muuli_wdr.cpp:3061 src/muuli_wdr.cpp:3416
+#: src/muuli_wdr.cpp:2640 src/muuli_wdr.cpp:3092 src/muuli_wdr.cpp:3447
 msgid "Connect"
 msgstr "З'єднатися"
 
@@ -755,7 +755,7 @@ msgstr "Підтвердження виходу"
 msgid "Launch Command: "
 msgstr "Команда для запуску: "
 
-#: src/amuleDlg.cpp:1632 src/muuli_wdr.cpp:1978 src/Preferences.cpp:952
+#: src/amuleDlg.cpp:1632 src/muuli_wdr.cpp:1982 src/Preferences.cpp:979
 msgid "- default -"
 msgstr "- за замовчуванням -"
 
@@ -769,49 +769,49 @@ msgstr "Тека з шкірами '%s' не існує"
 msgid "WARNING: Unable to open skin file '%s' for read"
 msgstr "ЗАСТЕРЕЖЕННЯ: Неможливо відкрити файл шкіри '%s' для читання"
 
-#: src/amuleDlg.cpp:1791 src/muuli_wdr.cpp:3418
+#: src/amuleDlg.cpp:1791 src/muuli_wdr.cpp:3449
 msgid "Networks Window"
 msgstr "Вікно мереж"
 
-#: src/amuleDlg.cpp:1797 src/muuli_wdr.cpp:3419
+#: src/amuleDlg.cpp:1797 src/muuli_wdr.cpp:3450
 msgid "Searches Window"
 msgstr "Вікно пошуку"
 
-#: src/amuleDlg.cpp:1803 src/muuli_wdr.cpp:3420
+#: src/amuleDlg.cpp:1803 src/muuli_wdr.cpp:3451
 #, fuzzy
 msgid "Downloads Window"
 msgstr "Звантажується"
 
-#: src/amuleDlg.cpp:1809 src/muuli_wdr.cpp:3422
+#: src/amuleDlg.cpp:1809 src/muuli_wdr.cpp:3453
 msgid "Shared Files Window"
 msgstr "Вікно спільних файлів"
 
-#: src/amuleDlg.cpp:1815 src/muuli_wdr.cpp:3423
+#: src/amuleDlg.cpp:1815 src/muuli_wdr.cpp:3454
 msgid "Messages Window"
 msgstr "Вікно повідомлень"
 
-#: src/amuleDlg.cpp:1821 src/muuli_wdr.cpp:3424
+#: src/amuleDlg.cpp:1821 src/muuli_wdr.cpp:3455
 msgid "Statistics Graph Window"
 msgstr "Вікно статистики"
 
-#: src/amuleDlg.cpp:1828 src/muuli_wdr.cpp:3426
+#: src/amuleDlg.cpp:1828 src/muuli_wdr.cpp:3457
 msgid "Preferences Settings Window"
 msgstr "Вікно налаштувань"
 
-#: src/amuleDlg.cpp:1831 src/muuli_wdr.cpp:3427
+#: src/amuleDlg.cpp:1831 src/muuli_wdr.cpp:3458
 msgid "Import"
 msgstr "Зовн. внесення"
 
-#: src/amuleDlg.cpp:1835 src/muuli_wdr.cpp:3427
+#: src/amuleDlg.cpp:1835 src/muuli_wdr.cpp:3458
 msgid "The partfile importer tool"
 msgstr "Засіб зовнішнього внесення частково звантажених файлів"
 
-#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3428
+#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3459
 #: src/utils/aLinkCreator/src/alcframe.cpp:262
 msgid "About"
 msgstr "Про програму"
 
-#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3428
+#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3459
 msgid "About/Help"
 msgstr "Про/Допомога"
 
@@ -953,7 +953,7 @@ msgstr "Файл не знайдено."
 msgid "The core rejected these shared folders:%s"
 msgstr ""
 
-#: src/amule-remote-gui.cpp:1336 src/ExternalConn.cpp:2345
+#: src/amule-remote-gui.cpp:1336 src/ExternalConn.cpp:2346
 msgid "Invalid link or already on list."
 msgstr "Недопустиме посилання або вже в переліку."
 
@@ -969,7 +969,7 @@ msgstr ""
 #: src/ClientDetailDialog.cpp:123 src/DataToText.cpp:61 src/DataToText.cpp:86
 #: src/DataToText.cpp:101 src/DataToText.cpp:136 src/DataToText.cpp:165
 #: src/DownloadListCtrl.cpp:1172 src/DownloadListCtrl.cpp:1185
-#: src/DownloadListCtrl.cpp:1196 src/ExternalConn.cpp:608
+#: src/DownloadListCtrl.cpp:1196 src/ExternalConn.cpp:609
 #: src/FileDetailDialog.cpp:203 src/FileDetailDialog.cpp:235
 #: src/FileDetailDialog.cpp:242 src/GenericClientListCtrl.cpp:1171
 #: src/GenericClientListCtrl.cpp:1182 src/GenericClientListCtrl.cpp:1192
@@ -1365,19 +1365,19 @@ msgstr "Авто [висока]"
 msgid "Very low"
 msgstr "Дуже низька"
 
-#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:743 src/muuli_wdr.cpp:2282
+#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:743 src/muuli_wdr.cpp:2313
 #: src/ServerListCtrl.cpp:263 src/ServerListCtrl.cpp:456
 #: src/SharedFilesCtrl.cpp:145
 msgid "Low"
 msgstr "Низька"
 
-#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:744 src/muuli_wdr.cpp:2283
+#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:744 src/muuli_wdr.cpp:2314
 #: src/ServerListCtrl.cpp:266 src/ServerListCtrl.cpp:457
 #: src/SharedFilesCtrl.cpp:146
 msgid "Normal"
 msgstr "Звичайна"
 
-#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:745 src/muuli_wdr.cpp:2284
+#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:745 src/muuli_wdr.cpp:2315
 #: src/ServerListCtrl.cpp:269 src/ServerListCtrl.cpp:458
 #: src/SharedFilesCtrl.cpp:147
 msgid "High"
@@ -1470,7 +1470,7 @@ msgstr "Місцевий сервер"
 msgid "Remote Server"
 msgstr "Віддалений сервер"
 
-#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3181
+#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3212
 #: src/SearchDlg.cpp:119 src/TextClient.cpp:911
 msgid "Kad"
 msgstr "Kad"
@@ -1542,7 +1542,7 @@ msgstr "Частина"
 msgid "Size"
 msgstr "Розмір"
 
-#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3248
+#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3279
 msgid "Transferred"
 msgstr "Переданих"
 
@@ -1600,7 +1600,7 @@ msgstr ""
 "Відгук від: %s (%s)\n"
 "\n"
 
-#: src/DownloadListCtrl.cpp:746 src/muuli_wdr.cpp:2285
+#: src/DownloadListCtrl.cpp:746 src/muuli_wdr.cpp:2316
 #: src/SharedFilesCtrl.cpp:150
 msgid "Auto"
 msgstr "Автоматично"
@@ -1638,7 +1638,7 @@ msgid "Extended Options"
 msgstr "Розширені налаштування"
 
 #: src/DownloadListCtrl.cpp:770 src/DownloadListCtrl.cpp:822
-#: src/muuli_wdr.cpp:1796
+#: src/muuli_wdr.cpp:1800
 msgid "Preview"
 msgstr "Попередній перегляд"
 
@@ -1815,232 +1815,237 @@ msgstr[2] ""
 msgid "Invalid eD2k link! ERROR: %s"
 msgstr "Невірне eD2k-посилання! ПОМИЛКА: %s"
 
-#: src/ExternalConn.cpp:379
+#: src/ExternalConn.cpp:380
 #, fuzzy
 msgid "Client sent packet after authentication failed."
 msgstr "Аутентифікація не вдалася."
 
-#: src/ExternalConn.cpp:396
+#: src/ExternalConn.cpp:397
 msgid "External connection closed."
 msgstr "Зовнішнє з'єднання розірвано."
 
-#: src/ExternalConn.cpp:473
+#: src/ExternalConn.cpp:474
 msgid "External connections disabled due to empty password!"
 msgstr "Зовнішні з'єднання вимкнені, оскільки відсутній пароль!"
 
-#: src/ExternalConn.cpp:494
+#: src/ExternalConn.cpp:495
 msgid "External connections disabled in config file"
 msgstr "Зовнішні з'єднання вимкнені у файлі налаштувань."
 
-#: src/ExternalConn.cpp:575
+#: src/ExternalConn.cpp:576
 msgid "New external connection accepted"
 msgstr "Дозволено нове зовнішнє з'єднання"
 
-#: src/ExternalConn.cpp:578
+#: src/ExternalConn.cpp:579
 msgid "ERROR: couldn't accept a new external connection"
 msgstr "ПОМИЛКА: неможливо дозволити нове зовнішнє з'єднання"
 
-#: src/ExternalConn.cpp:595
+#: src/ExternalConn.cpp:596
 msgid "External connection refused due to empty password in preferences!"
 msgstr "Відмовлено у зовнішньому з'єднанні, оскільки в налаштуваннях порожній пароль!"
 
-#: src/ExternalConn.cpp:607
+#: src/ExternalConn.cpp:608
 #, c-format
 msgid "Connecting client: %s %s"
 msgstr "З'єднується клієнт: %s %s"
 
-#: src/ExternalConn.cpp:609
+#: src/ExternalConn.cpp:610
 msgid "Unknown version"
 msgstr "Невідома версія"
 
-#: src/ExternalConn.cpp:622
+#: src/ExternalConn.cpp:623
 msgid "Incorrect EC version ID, there might be binary incompatibility. Use core and remote from same snapshot."
 msgstr "Невірний ID версії EC, може бути двійкова несумісність. Використовуйте ядро та віддаленого клієнта з того самого зрізу"
 
-#: src/ExternalConn.cpp:630
+#: src/ExternalConn.cpp:631
 #, fuzzy
 msgid "You cannot connect to a release version from an arbitrary development snapshot! *sigh* possible crash prevented"
 msgstr "Ви не можете під'єднатись до остаточної версії з довільної SVN-версії! Можлива відмова попереджена"
 
-#: src/ExternalConn.cpp:713
+#: src/ExternalConn.cpp:714
 msgid "Invalid protocol version."
 msgstr "Невірна версія протоколу."
 
-#: src/ExternalConn.cpp:719
+#: src/ExternalConn.cpp:720
 msgid "Missing protocol version tag."
 msgstr "Відсутня позначка версії протоколу."
 
-#: src/ExternalConn.cpp:727
+#: src/ExternalConn.cpp:728
 msgid "Authentication failed: invalid hash specified as EC password."
 msgstr ""
 
-#: src/ExternalConn.cpp:775
+#: src/ExternalConn.cpp:776
 #, fuzzy
 msgid "Authentication failed: wrong password."
 msgstr "Аутентифікація не вдалася."
 
-#: src/ExternalConn.cpp:777
+#: src/ExternalConn.cpp:778
 #, fuzzy
 msgid "Authentication failed: missing password."
 msgstr "Аутентифікація не вдалася."
 
-#: src/ExternalConn.cpp:788
+#: src/ExternalConn.cpp:789
 #, fuzzy
 msgid "Invalid request, please authenticate first."
 msgstr "Невірний запит, ви маєте спочатку представитись."
 
-#: src/ExternalConn.cpp:793
+#: src/ExternalConn.cpp:794
 msgid "Access granted."
 msgstr "Дозвіл надано."
 
-#: src/ExternalConn.cpp:801
+#: src/ExternalConn.cpp:802
 #, fuzzy, c-format
 msgid "Sent error message \"%s\" to client."
 msgstr "Фільтрувати повідомлення від невідомих клієнтів"
 
-#: src/ExternalConn.cpp:806
+#: src/ExternalConn.cpp:807
 #, fuzzy, c-format
 msgid "Unauthorized access attempt from %s. Connection closed."
 msgstr "Спроба доступу без уповноваження. З'єднання розірвано."
 
-#: src/ExternalConn.cpp:1419
+#: src/ExternalConn.cpp:1420
 #, c-format
 msgid "Remote PartFile command failed: FileHash not found: %s"
 msgstr "Віддалена PartFile-команда не вдалася: хеш файлу не знайдено: %s"
 
-#: src/ExternalConn.cpp:1423
+#: src/ExternalConn.cpp:1424
 #, c-format
 msgid "FileHash not found: %s"
 msgstr "Хеш файлу не знайдений: %s"
 
-#: src/ExternalConn.cpp:1470 src/ExternalConn.cpp:1558
-#: src/ExternalConn.cpp:1679
+#: src/ExternalConn.cpp:1471 src/ExternalConn.cpp:1559
+#: src/ExternalConn.cpp:1680
 msgid "OOPS! OpCode processing error!"
 msgstr "Помилка при виконання OpCode"
 
-#: src/ExternalConn.cpp:1501
+#: src/ExternalConn.cpp:1502
 msgid "Server not added"
 msgstr "Сервер не додано"
 
-#: src/ExternalConn.cpp:1520
+#: src/ExternalConn.cpp:1521
 #, c-format
 msgid "server not found: %s"
 msgstr "сервер не знайдено: %s"
 
-#: src/ExternalConn.cpp:1537
+#: src/ExternalConn.cpp:1538
 msgid "need to define server to be removed"
 msgstr "потрібно визначити сервер для видалення"
 
-#: src/ExternalConn.cpp:1552
+#: src/ExternalConn.cpp:1553
 msgid "eD2k is disabled in preferences."
 msgstr "eD2k вимкнена у налаштуваннях"
 
-#: src/ExternalConn.cpp:1657
+#: src/ExternalConn.cpp:1658
 #, fuzzy
 msgid "Friend not found."
 msgstr "Файл не знайдено."
 
-#: src/ExternalConn.cpp:1667
+#: src/ExternalConn.cpp:1668
 #, fuzzy
 msgid "Client not found."
 msgstr "Файл не знайдено."
 
-#: src/ExternalConn.cpp:1673
+#: src/ExternalConn.cpp:1674
 msgid "EC_TAG_FRIEND_SHARED requires EC_TAG_FRIEND or EC_TAG_CLIENT."
 msgstr ""
 
-#: src/ExternalConn.cpp:1991
+#: src/ExternalConn.cpp:1992
 msgid "WebSearch from remote interface makes no sense."
 msgstr "Веб-пошук через віддалений інтерфейс не має сенсу. "
 
-#: src/ExternalConn.cpp:2026
+#: src/ExternalConn.cpp:2027
 msgid "Search in progress. Refetch results in a moment!"
 msgstr "Пошук просувається. За мить отримаю здобутки!"
 
-#: src/ExternalConn.cpp:2265
+#: src/ExternalConn.cpp:2266
 msgid "No points for graph."
 msgstr "Немає точок для графіку."
 
-#: src/ExternalConn.cpp:2275
+#: src/ExternalConn.cpp:2276
 msgid "Your client is not configured for this detail level."
 msgstr "Ваш клієнт не налаштований для такого рівня подробиць."
 
-#: src/ExternalConn.cpp:2302
+#: src/ExternalConn.cpp:2303
 msgid "External Connection: shutdown requested"
 msgstr "Зовнішнє з'єднання: запит на вимкнення"
 
-#: src/ExternalConn.cpp:2314
+#: src/ExternalConn.cpp:2315
 msgid "Already shutting down."
 msgstr "Вже вимикається."
 
-#: src/ExternalConn.cpp:2332
+#: src/ExternalConn.cpp:2333
 #, c-format
 msgid "ExternalConn: adding link '%s'."
 msgstr "Зовнішнє з'єднання: додається посилання '%s'"
 
-#: src/ExternalConn.cpp:2350
+#: src/ExternalConn.cpp:2351
 #, fuzzy, c-format
 msgid "%d of %d links failed (invalid or already on list)."
 msgstr "Недопустиме посилання або вже в переліку."
 
-#: src/ExternalConn.cpp:2373
+#: src/ExternalConn.cpp:2374
 msgid "Version check throttled; try again shortly."
 msgstr ""
 
-#: src/ExternalConn.cpp:2378
+#: src/ExternalConn.cpp:2379
 msgid "Version check is not available on this daemon."
 msgstr ""
 
-#: src/ExternalConn.cpp:2508
+#: src/ExternalConn.cpp:2509
 msgid "File not found."
 msgstr "Файл не знайдено."
 
-#: src/ExternalConn.cpp:2513
+#: src/ExternalConn.cpp:2514
 msgid "Invalid file name."
 msgstr "Недопустима назва файлу."
 
-#: src/ExternalConn.cpp:2521
+#: src/ExternalConn.cpp:2522
 msgid "Unable to rename file."
 msgstr "Неможливо змінити назву файлу."
 
-#: src/ExternalConn.cpp:2992 src/ExternalConn.cpp:3020
+#: src/ExternalConn.cpp:2839
+#, c-format
+msgid "Could not save the amuleapi password: %s"
+msgstr ""
+
+#: src/ExternalConn.cpp:3004 src/ExternalConn.cpp:3032
 msgid "Kad is disabled in preferences."
 msgstr "Kad вимкнена в налаштуваннях."
 
-#: src/ExternalConn.cpp:3033
+#: src/ExternalConn.cpp:3045
 msgid "Already connected to eD2k."
 msgstr "Вже з'єднано з eD2k"
 
-#: src/ExternalConn.cpp:3036
+#: src/ExternalConn.cpp:3048
 msgid "Connecting to eD2k..."
 msgstr "З'єднується з eD2k..."
 
-#: src/ExternalConn.cpp:3045
+#: src/ExternalConn.cpp:3057
 msgid "Already connected to Kad."
 msgstr "Вже з'єднано з Kad."
 
-#: src/ExternalConn.cpp:3048
+#: src/ExternalConn.cpp:3060
 msgid "Connecting to Kad..."
 msgstr "З'єднується з Kad"
 
-#: src/ExternalConn.cpp:3055
+#: src/ExternalConn.cpp:3067
 msgid "All networks are disabled."
 msgstr "Всі мережі вимкнені."
 
-#: src/ExternalConn.cpp:3064
+#: src/ExternalConn.cpp:3076
 msgid "Disconnected from eD2k."
 msgstr "Від'єднується від eD2k."
 
-#: src/ExternalConn.cpp:3069
+#: src/ExternalConn.cpp:3081
 msgid "Disconnected from Kad."
 msgstr "Від'єднується від Kad."
 
-#: src/ExternalConn.cpp:3078
+#: src/ExternalConn.cpp:3090
 #, c-format
 msgid "External Connection: invalid opcode received: %#x"
 msgstr "Зовнішнє з'єднання: отримано недопустимий opcode: %#x"
 
-#: src/ExternalConn.cpp:3083
+#: src/ExternalConn.cpp:3095
 msgid "Invalid opcode (wrong protocol version?)"
 msgstr "Недопустимий opcode (невірна версія протоколу?)"
 
@@ -2440,23 +2445,23 @@ msgid ""
 "want downloads on a different (e.g. larger) disk."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:549 src/FirstRunWizard.cpp:611 src/muuli_wdr.cpp:1708
+#: src/FirstRunWizard.cpp:549 src/FirstRunWizard.cpp:611 src/muuli_wdr.cpp:1712
 msgid "Destination folder for downloads"
 msgstr "Тека призначення для звантажень"
 
 #: src/FirstRunWizard.cpp:553 src/FirstRunWizard.cpp:569 src/muuli_wdr.cpp:1349
-#: src/muuli_wdr.cpp:1366 src/muuli_wdr.cpp:1683 src/muuli_wdr.cpp:1714
-#: src/muuli_wdr.cpp:1726 src/muuli_wdr.cpp:2769
+#: src/muuli_wdr.cpp:1366 src/muuli_wdr.cpp:1687 src/muuli_wdr.cpp:1718
+#: src/muuli_wdr.cpp:1730 src/muuli_wdr.cpp:2800
 #: src/utils/aLinkCreator/src/alcframe.cpp:135
 #: src/utils/wxCas/src/wxcasprefs.cpp:52 src/utils/wxCas/src/wxcasprefs.cpp:118
 msgid "Browse"
 msgstr "Переглянути"
 
-#: src/FirstRunWizard.cpp:559 src/muuli_wdr.cpp:1719
+#: src/FirstRunWizard.cpp:559 src/muuli_wdr.cpp:1723
 msgid "(All files in this folder are shared with other peers)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:565 src/FirstRunWizard.cpp:624 src/muuli_wdr.cpp:1721
+#: src/FirstRunWizard.cpp:565 src/FirstRunWizard.cpp:624 src/muuli_wdr.cpp:1725
 msgid "Folder for temporary download files"
 msgstr "Тека для тимчасових звантажуваних файлів"
 
@@ -2487,7 +2492,7 @@ msgstr "Неможливо відкрити перелік друзів 'emfrien
 msgid "CRITICAL - no client on StartChatSession"
 msgstr "КРИТИЧНО - немає клієнта на StartChatSession"
 
-#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2675 src/muuli_wdr.cpp:3352
+#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2706 src/muuli_wdr.cpp:3383
 msgid "Friends"
 msgstr "Друзі"
 
@@ -2601,8 +2606,8 @@ msgstr "Жоден"
 msgid "No"
 msgstr "Ні"
 
-#: src/GenericClientListCtrl.cpp:1216 src/PrefsUnifiedDlg.cpp:2818
-#: src/PrefsUnifiedDlg.cpp:2868 src/ServerListCtrl.cpp:276
+#: src/GenericClientListCtrl.cpp:1216 src/PrefsUnifiedDlg.cpp:2898
+#: src/PrefsUnifiedDlg.cpp:2948 src/ServerListCtrl.cpp:276
 msgid "Yes"
 msgstr "Так"
 
@@ -2774,10 +2779,10 @@ msgstr "Недопустимий порт для початкового запу
 msgid "Please fill all fields required"
 msgstr "Будь ласка, заповніть потрібні поля"
 
-#: src/KadDlg.cpp:192 src/PartFile.cpp:1031 src/PrefsUnifiedDlg.cpp:1162
-#: src/PrefsUnifiedDlg.cpp:1331 src/PrefsUnifiedDlg.cpp:1589
-#: src/PrefsUnifiedDlg.cpp:1599 src/PrefsUnifiedDlg.cpp:1616
-#: src/PrefsUnifiedDlg.cpp:1658
+#: src/KadDlg.cpp:192 src/PartFile.cpp:1031 src/PrefsUnifiedDlg.cpp:1134
+#: src/PrefsUnifiedDlg.cpp:1204 src/PrefsUnifiedDlg.cpp:1405
+#: src/PrefsUnifiedDlg.cpp:1663 src/PrefsUnifiedDlg.cpp:1673
+#: src/PrefsUnifiedDlg.cpp:1690 src/PrefsUnifiedDlg.cpp:1738
 msgid "Message"
 msgstr "Повідомлення"
 
@@ -2882,7 +2887,7 @@ msgstr "Відношення передачі"
 msgid "Uploaded"
 msgstr "Вивантажено"
 
-#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3232
+#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3263
 msgid "Requested"
 msgstr "Запитано"
 
@@ -3009,7 +3014,7 @@ msgid "WARNING: "
 msgstr "ЗАСТЕРЕЖЕННЯ: "
 
 #: src/MuleNotebook.cpp:179 src/muuli_wdr.cpp:817 src/muuli_wdr.cpp:1229
-#: src/muuli_wdr.cpp:3136 src/muuli_wdr.cpp:3392
+#: src/muuli_wdr.cpp:3167 src/muuli_wdr.cpp:3423
 msgid "Close"
 msgstr "Закрити"
 
@@ -3027,7 +3032,7 @@ msgid "Paste"
 msgstr "Вставити"
 
 #: src/MuleTextCtrl.cpp:89 src/muuli_wdr.cpp:358 src/muuli_wdr.cpp:757
-#: src/muuli_wdr.cpp:2359 src/muuli_wdr.cpp:2378 src/muuli_wdr.cpp:2400
+#: src/muuli_wdr.cpp:2390 src/muuli_wdr.cpp:2409 src/muuli_wdr.cpp:2431
 #: src/utils/aLinkCreator/src/alcframe.cpp:142
 msgid "Clear"
 msgstr "Очистити"
@@ -3126,7 +3131,7 @@ msgstr "Вийти"
 
 #: src/MuleTrayIcon.cpp:579 src/MuleTrayIcon.cpp:945 src/MuleTrayIcon.cpp:965
 #: src/muuli_wdr.cpp:1398 src/muuli_wdr.cpp:1406 src/muuli_wdr.cpp:1413
-#: src/muuli_wdr.cpp:1842 src/muuli_wdr.cpp:1848 src/OtherFunctions.cpp:91
+#: src/muuli_wdr.cpp:1846 src/muuli_wdr.cpp:1852 src/OtherFunctions.cpp:91
 #: src/StatisticsDlg.cpp:93 src/StatisticsDlg.cpp:95
 msgid "kB/s"
 msgstr "кбайт/с"
@@ -3368,7 +3373,7 @@ msgstr "байт"
 msgid "KB"
 msgstr "кбайт"
 
-#: src/muuli_wdr.cpp:274 src/muuli_wdr.cpp:293 src/muuli_wdr.cpp:1627
+#: src/muuli_wdr.cpp:274 src/muuli_wdr.cpp:293 src/muuli_wdr.cpp:1631
 #: src/OtherFunctions.cpp:64
 msgid "MB"
 msgstr "Мбайт"
@@ -3385,7 +3390,7 @@ msgstr "Найбільший розмір"
 msgid "Availability"
 msgstr "Доступність"
 
-#: src/muuli_wdr.cpp:312 src/muuli_wdr.cpp:398 src/muuli_wdr.cpp:3297
+#: src/muuli_wdr.cpp:312 src/muuli_wdr.cpp:398 src/muuli_wdr.cpp:3328
 msgid "Filter:"
 msgstr "Фільтр:"
 
@@ -3449,12 +3454,12 @@ msgstr "Завершених джерел"
 #: src/muuli_wdr.cpp:1160 src/muuli_wdr.cpp:1167 src/muuli_wdr.cpp:1172
 #: src/muuli_wdr.cpp:1179 src/muuli_wdr.cpp:1184 src/muuli_wdr.cpp:1191
 #: src/muuli_wdr.cpp:1205 src/muuli_wdr.cpp:1212 src/muuli_wdr.cpp:1217
-#: src/muuli_wdr.cpp:1224 src/muuli_wdr.cpp:3234 src/muuli_wdr.cpp:3242
-#: src/muuli_wdr.cpp:3250
+#: src/muuli_wdr.cpp:1224 src/muuli_wdr.cpp:3265 src/muuli_wdr.cpp:3273
+#: src/muuli_wdr.cpp:3281
 msgid "N/A"
 msgstr "недоступні"
 
-#: src/muuli_wdr.cpp:508 src/muuli_wdr.cpp:1065 src/PrefsUnifiedDlg.cpp:297
+#: src/muuli_wdr.cpp:508 src/muuli_wdr.cpp:1065 src/PrefsUnifiedDlg.cpp:299
 msgid "General"
 msgstr "Загальні"
 
@@ -3595,7 +3600,7 @@ msgstr ""
 msgid "Album :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:685 src/muuli_wdr.cpp:2254
+#: src/muuli_wdr.cpp:685 src/muuli_wdr.cpp:2285
 msgid "Title :"
 msgstr "Назва:"
 
@@ -3704,7 +3709,7 @@ msgstr "Ім'я користувача:"
 msgid "Userhash :"
 msgstr "Хеш користувача:"
 
-#: src/muuli_wdr.cpp:895 src/muuli_wdr.cpp:1748 src/muuli_wdr.cpp:2449
+#: src/muuli_wdr.cpp:895 src/muuli_wdr.cpp:1752 src/muuli_wdr.cpp:2480
 #: src/utils/aLinkCreator/src/alcframe.cpp:137
 msgid "Add"
 msgstr "Додати"
@@ -3713,15 +3718,15 @@ msgstr "Додати"
 msgid "Download-Speed"
 msgstr "Швидкість звантаження"
 
-#: src/muuli_wdr.cpp:954 src/muuli_wdr.cpp:989 src/muuli_wdr.cpp:2553
+#: src/muuli_wdr.cpp:954 src/muuli_wdr.cpp:989 src/muuli_wdr.cpp:2584
 msgid "Current"
 msgstr "Поточна"
 
-#: src/muuli_wdr.cpp:962 src/muuli_wdr.cpp:997 src/muuli_wdr.cpp:2561
+#: src/muuli_wdr.cpp:962 src/muuli_wdr.cpp:997 src/muuli_wdr.cpp:2592
 msgid "Running average"
 msgstr "Середня"
 
-#: src/muuli_wdr.cpp:970 src/muuli_wdr.cpp:1005 src/muuli_wdr.cpp:2569
+#: src/muuli_wdr.cpp:970 src/muuli_wdr.cpp:1005 src/muuli_wdr.cpp:2600
 msgid "Session average"
 msgstr "Середня за сесію"
 
@@ -3733,7 +3738,7 @@ msgstr "Швидкість вивантаження"
 msgid "Connections"
 msgstr "З'єднання"
 
-#: src/muuli_wdr.cpp:1024 src/muuli_wdr.cpp:1867
+#: src/muuli_wdr.cpp:1024 src/muuli_wdr.cpp:1871
 msgid "Active downloads"
 msgstr "Чинні звантаження"
 
@@ -3741,7 +3746,7 @@ msgstr "Чинні звантаження"
 msgid "Active connections (1:1)"
 msgstr "Чинні з'єднання (1:1)"
 
-#: src/muuli_wdr.cpp:1040 src/muuli_wdr.cpp:1868
+#: src/muuli_wdr.cpp:1040 src/muuli_wdr.cpp:1872
 msgid "Active uploads"
 msgstr "Чинні вивантаження"
 
@@ -4018,7 +4023,7 @@ msgstr "Використовувати IP-адресу (пусто для буд
 msgid "Advanced users only: If you have multiple network interfaces, enter the address of the interface to which aMule should be bound."
 msgstr "Тільки досвідченим користувачам: якщо ви маєте багато мережевих інтерфейсів, введіть адресу інтерфейсу до якого слід прив'язатися aMule."
 
-#: src/muuli_wdr.cpp:1462 src/muuli_wdr.cpp:2061
+#: src/muuli_wdr.cpp:1462 src/muuli_wdr.cpp:2065
 #, fuzzy
 msgid "Bind to network interface (empty for any):"
 msgstr "Використовувати IP-адресу (пусто для будь-якої):"
@@ -4035,7 +4040,7 @@ msgstr "Найбільше джерел на звантажуваний файл
 msgid "Max simultaneous connections:"
 msgstr "Найбільше одночасних з'єднань:"
 
-#: src/muuli_wdr.cpp:1498 src/muuli_wdr.cpp:3176
+#: src/muuli_wdr.cpp:1498 src/muuli_wdr.cpp:3207
 msgid "ED2K"
 msgstr "eD2k"
 
@@ -4127,760 +4132,783 @@ msgstr "Попереднє виділення місця на диску для 
 msgid "For new files preallocates disk space for the whole file, thus reduces fragmentation"
 msgstr "Повністю виділяти місце для всього нового файлу, це зменшить фрагментування"
 
-#: src/muuli_wdr.cpp:1613
+#: src/muuli_wdr.cpp:1617
 msgid "Create new files as sparse files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1614
-msgid "A sparse file reserves its full size on disk immediately without writing real data to it -- fast, but unsupported or slow on some filesystems, and free-space accounting stays optimistic while the download is in progress. Turn this off to grow the file only as data arrives."
+#: src/muuli_wdr.cpp:1618
+msgid "Sparse part files only occupy disk space for the parts already downloaded, so free space is used up gradually as the file fills in. Turn this off to use an ordinary file instead - useful where sparse files are unsupported or slow, or where backup/de-duplication tools handle them badly. Applies only when the core runs on Windows; on Linux and macOS part files are sparse anyway and this setting has no effect."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1619
+#: src/muuli_wdr.cpp:1623
 msgid "Stop downloads when free disk space reaches "
 msgstr "Припинити звантаження коли вільне місце на диску досягнуло "
 
-#: src/muuli_wdr.cpp:1620
+#: src/muuli_wdr.cpp:1624
 msgid "Select this if you want aMule to check your disk space"
 msgstr "Виберіть це якщо хочете, щоб aMule перевіряв ваше місце на диску"
 
-#: src/muuli_wdr.cpp:1624
+#: src/muuli_wdr.cpp:1628
 msgid "Enter here the min disk space desired."
 msgstr "Введіть найменше бажане місце на диску"
 
-#: src/muuli_wdr.cpp:1630
+#: src/muuli_wdr.cpp:1634
 msgid "Save 10 sources on rare files (< 20 sources)"
 msgstr "Зберегти 10 джерел рідкісних файлів (менше ніж 20 джерел)"
 
-#: src/muuli_wdr.cpp:1634 src/Statistics.cpp:790
+#: src/muuli_wdr.cpp:1638 src/Statistics.cpp:790
 msgid "Uploads"
 msgstr "Вивантаження"
 
-#: src/muuli_wdr.cpp:1637
+#: src/muuli_wdr.cpp:1641
 msgid "Add new shared files with auto priority"
 msgstr "Додати нові спільні файли з автоматичною перевагою"
 
-#: src/muuli_wdr.cpp:1643
+#: src/muuli_wdr.cpp:1647
 msgid "Intelligent Corruption Handling (I.C.H.)"
 msgstr "Розумна обробка пошкоджень (Р.О.П.)"
 
-#: src/muuli_wdr.cpp:1646
+#: src/muuli_wdr.cpp:1650
 msgid "Enable"
 msgstr "Ввімкнено"
 
-#: src/muuli_wdr.cpp:1649
+#: src/muuli_wdr.cpp:1653
 msgid "Advanced I.C.H. trusts every hash (not recommended)"
 msgstr "Вдосконалена Р.О.П. довіряє всім хешам (не радимо)"
 
-#: src/muuli_wdr.cpp:1661 src/PrefsUnifiedDlg.cpp:1910
+#: src/muuli_wdr.cpp:1665 src/PrefsUnifiedDlg.cpp:1990
 msgid "Media metadata extraction"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1665
+#: src/muuli_wdr.cpp:1669
 msgid "Extract length / bitrate / codec from shared audio and video files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1667
+#: src/muuli_wdr.cpp:1671
 msgid "When enabled, aMule runs ffprobe on each shared media file to fill in the Length / Bitrate / Codec columns other clients see when they find the file in a search. Requires ffmpeg (the ffprobe binary) to be installed."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1674
+#: src/muuli_wdr.cpp:1678
 msgid "Path to ffprobe:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1679
+#: src/muuli_wdr.cpp:1683
 msgid "Full path to the ffprobe binary. Leave empty to have aMule auto-detect it on startup."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1687
+#: src/muuli_wdr.cpp:1691
 msgid "Detect"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1688
+#: src/muuli_wdr.cpp:1692
 msgid "Search the standard install locations for an ffprobe binary and fill the path field."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1712
+#: src/muuli_wdr.cpp:1716
 msgid ""
 "Completed downloads are stored here. All files in this folder are automatically shared with other peers.\n"
 "If this folder also holds files you don't want to share, point it at an aMule-only sub-folder."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1715
+#: src/muuli_wdr.cpp:1719
 msgid "Pick the folder where completed downloads will be stored. All files in that folder will be shared with other peers."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1729
+#: src/muuli_wdr.cpp:1733
 msgid "Shared folders"
 msgstr "Спільні теки"
 
-#: src/muuli_wdr.cpp:1735
+#: src/muuli_wdr.cpp:1739
 msgid "(Folders shared by the core. Enter a path to add one.)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1743
+#: src/muuli_wdr.cpp:1747
 msgid "Absolute path of a folder on the core's machine, e.g. /home/user/shared"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1745 src/PrefsUnifiedDlg.cpp:2794
+#: src/muuli_wdr.cpp:1749 src/PrefsUnifiedDlg.cpp:2874
 msgid "Recursive"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1746
+#: src/muuli_wdr.cpp:1750
 msgid "Share every sub-folder underneath this one, including ones created later."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1750 src/utils/aLinkCreator/src/alcframe.cpp:141
+#: src/muuli_wdr.cpp:1754 src/utils/aLinkCreator/src/alcframe.cpp:141
 msgid "Remove"
 msgstr "Вилучити"
 
-#: src/muuli_wdr.cpp:1754
+#: src/muuli_wdr.cpp:1758
 msgid "(Right click on folder icon for recursive share)"
 msgstr "(Праве клацання по значку теки для рекурсивного додавання)"
 
-#: src/muuli_wdr.cpp:1761
+#: src/muuli_wdr.cpp:1765
 msgid "Share hidden files"
 msgstr "Робити спільними приховані файли"
 
-#: src/muuli_wdr.cpp:1767
+#: src/muuli_wdr.cpp:1771
 msgid "Automatically rescan shared folders for changes"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1773
+#: src/muuli_wdr.cpp:1777
 msgid "Follow symbolic links in shared folders"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1779
+#: src/muuli_wdr.cpp:1783
 msgid "Exclude files matching:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1782
+#: src/muuli_wdr.cpp:1786
 msgid "Wildcard patterns separated by '|', e.g. .DS_Store|Thumbs.db|*.tmp. Files whose name matches are not shared. Matching is case-insensitive."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1786
+#: src/muuli_wdr.cpp:1790
 msgid "Patterns are regular expressions"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1787
+#: src/muuli_wdr.cpp:1791
 msgid "When set, the whole field is one regular expression ('|' is alternation). When unset, it is a list of '|'-separated wildcards."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1797
+#: src/muuli_wdr.cpp:1801
 msgid "Show how many shared files the current pattern would exclude."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1818
+#: src/muuli_wdr.cpp:1822
 msgid "Graphs"
 msgstr "Графіки"
 
-#: src/muuli_wdr.cpp:1821 src/muuli_wdr.cpp:1883
+#: src/muuli_wdr.cpp:1825 src/muuli_wdr.cpp:1887
 msgid "Update delay : 5 secs"
 msgstr "Час оновлення: 5 с"
 
-#: src/muuli_wdr.cpp:1825
+#: src/muuli_wdr.cpp:1829
 msgid "Time for average graph: 100 mins"
 msgstr "Час для середніх графіків: 100 хв"
 
-#: src/muuli_wdr.cpp:1829
+#: src/muuli_wdr.cpp:1833
 msgid "Connections Graph Scale: 100 "
 msgstr "Шкала графіку з'єднань: 100"
 
-#: src/muuli_wdr.cpp:1836
+#: src/muuli_wdr.cpp:1840
 msgid "Download graph scale:"
 msgstr "Шкала графіку звантаження"
 
-#: src/muuli_wdr.cpp:1844
+#: src/muuli_wdr.cpp:1848
 msgid "Upload graph scale:"
 msgstr "Шкала графіку вивантаження"
 
-#: src/muuli_wdr.cpp:1854
+#: src/muuli_wdr.cpp:1858
 #, fuzzy
 msgid "Colors: "
 msgstr "Кольори: "
 
-#: src/muuli_wdr.cpp:1858
+#: src/muuli_wdr.cpp:1862
 msgid "Background"
 msgstr "Фон"
 
-#: src/muuli_wdr.cpp:1859
+#: src/muuli_wdr.cpp:1863
 msgid "Grid"
 msgstr "Сітка"
 
-#: src/muuli_wdr.cpp:1860
+#: src/muuli_wdr.cpp:1864
 msgid "Download current"
 msgstr "Звантаження зараз"
 
-#: src/muuli_wdr.cpp:1861
+#: src/muuli_wdr.cpp:1865
 msgid "Download running average"
 msgstr "Звантаження середні за роботу"
 
-#: src/muuli_wdr.cpp:1862
+#: src/muuli_wdr.cpp:1866
 msgid "Download session average"
 msgstr "Звантаження середні за сесію"
 
-#: src/muuli_wdr.cpp:1863
+#: src/muuli_wdr.cpp:1867
 msgid "Upload current"
 msgstr "Вивантаження поточні"
 
-#: src/muuli_wdr.cpp:1864
+#: src/muuli_wdr.cpp:1868
 msgid "Upload running average"
 msgstr "Вивантаження середні за роботу"
 
-#: src/muuli_wdr.cpp:1865
+#: src/muuli_wdr.cpp:1869
 msgid "Upload session average"
 msgstr "Вивантаження середні за сесію"
 
-#: src/muuli_wdr.cpp:1866
+#: src/muuli_wdr.cpp:1870
 msgid "Active connections"
 msgstr "Чинні з'єднання"
 
-#: src/muuli_wdr.cpp:1869
+#: src/muuli_wdr.cpp:1873
 #, fuzzy
 msgid "Systray Icon Speed Bar"
 msgstr "Показувати стовпчик швидкості в системному лотку"
 
-#: src/muuli_wdr.cpp:1870
+#: src/muuli_wdr.cpp:1874
 msgid "Kad-nodes current"
 msgstr "Вузлів Kad зараз"
 
-#: src/muuli_wdr.cpp:1871
+#: src/muuli_wdr.cpp:1875
 msgid "Kad-nodes running"
 msgstr "Вузлів Kad запущено"
 
-#: src/muuli_wdr.cpp:1872
+#: src/muuli_wdr.cpp:1876
 msgid "Kad-nodes session"
 msgstr "Вузлів Kad за сесію"
 
-#: src/muuli_wdr.cpp:1876 src/muuli_wdr.cpp:2303
+#: src/muuli_wdr.cpp:1880 src/muuli_wdr.cpp:2334
 msgid "Select"
 msgstr "Вибрати"
 
-#: src/muuli_wdr.cpp:1880
+#: src/muuli_wdr.cpp:1884
 msgid "Tree"
 msgstr "Дерево"
 
-#: src/muuli_wdr.cpp:1890
+#: src/muuli_wdr.cpp:1894
 msgid "Number of Client Versions shown (0=unlimited)"
 msgstr "Кількість відображуваних версій клієнтів (0=необмежено)"
 
-#: src/muuli_wdr.cpp:1915
+#: src/muuli_wdr.cpp:1919
 msgid "!!! WARNING !!!"
 msgstr "!!! ЗАСТЕРЕЖЕННЯ !!!"
 
-#: src/muuli_wdr.cpp:1930
+#: src/muuli_wdr.cpp:1934
 msgid "Max new connections / 5 secs"
 msgstr "Найбільше зовнішніх з'єднань за 5 с"
 
-#: src/muuli_wdr.cpp:1932
+#: src/muuli_wdr.cpp:1936
 msgid "Concurrent Kad source lookups"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1934
+#: src/muuli_wdr.cpp:1938
 #, fuzzy
 msgid "Kad source re-search interval (minutes)"
 msgstr "Час оновлення FTP в хвилинах"
 
-#: src/muuli_wdr.cpp:1936
+#: src/muuli_wdr.cpp:1940
 #, fuzzy
 msgid "Source re-ask interval (minutes)"
 msgstr "Час оновлення FTP в хвилинах"
 
-#: src/muuli_wdr.cpp:1940
+#: src/muuli_wdr.cpp:1944
 msgid "File Buffer Size: 240000 bytes"
 msgstr "Розмір файлу буфера: 240000 байт"
 
-#: src/muuli_wdr.cpp:1944
+#: src/muuli_wdr.cpp:1948
 msgid "Use MMAP: memory-mapped file access (lower memory use)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1945
+#: src/muuli_wdr.cpp:1949
 msgid "Maps part files into memory instead of buffering them on the heap, lowering the process memory footprint. May reduce download speed on some disks; best for memory-constrained or upload-heavy hosts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1947
+#: src/muuli_wdr.cpp:1951
 msgid "Upload Queue Size: 5000 clients"
 msgstr "Розмір черги вивантаження: 5000 клієнтів"
 
-#: src/muuli_wdr.cpp:1951
+#: src/muuli_wdr.cpp:1955
 msgid "Server connection refresh interval: Disable"
 msgstr "Час оновлення з'єднання з сервером: вимкнено"
 
-#: src/muuli_wdr.cpp:1955
+#: src/muuli_wdr.cpp:1959
 msgid "Disable computer's timed standby mode"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1974
+#: src/muuli_wdr.cpp:1978
 msgid "Skin to use: "
 msgstr "Використати шкіру: "
 
-#: src/muuli_wdr.cpp:1983
+#: src/muuli_wdr.cpp:1987
 msgid "Show \"Fast eD2k Links Handler\" in every window."
 msgstr "Показати \"Швидкий оброблювач eD2k-посилань\" в кожному вікні."
 
-#: src/muuli_wdr.cpp:1986
+#: src/muuli_wdr.cpp:1990
 msgid "Show extended info on categories tabs"
 msgstr "Показати розширену інформацію на вкладках категорій"
 
-#: src/muuli_wdr.cpp:1989
+#: src/muuli_wdr.cpp:1993
 #, fuzzy
 msgid "Show application version on title"
 msgstr "Показувати швидкість передавання в заголовку"
 
-#: src/muuli_wdr.cpp:1991
+#: src/muuli_wdr.cpp:1995
 msgid "Show transfer rates on title"
 msgstr "Показувати швидкість передавання в заголовку"
 
-#: src/muuli_wdr.cpp:1993
+#: src/muuli_wdr.cpp:1997
 msgid "Before application name"
 msgstr "Перед назвою програми"
 
-#: src/muuli_wdr.cpp:1995
+#: src/muuli_wdr.cpp:1999
 msgid "After application name"
 msgstr "Після назви програми"
 
-#: src/muuli_wdr.cpp:1998
+#: src/muuli_wdr.cpp:2002
 msgid "Show overhead bandwidth"
 msgstr "Показати ширину смуги службового трафіку"
 
-#: src/muuli_wdr.cpp:2002
+#: src/muuli_wdr.cpp:2006
 msgid "Vertical toolbar orientation"
 msgstr "Вертикальне розміщення панелі інструментів"
 
-#: src/muuli_wdr.cpp:2004
+#: src/muuli_wdr.cpp:2008
 msgid "Live column sorting (auto-reorder rows as their values change)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2011
+#: src/muuli_wdr.cpp:2015
 msgid "Download Queue Files"
 msgstr "Звантажити файли в черзі"
 
-#: src/muuli_wdr.cpp:2014
+#: src/muuli_wdr.cpp:2018
 msgid "Show progress percentage"
 msgstr "Показувати поступ у відсотках"
 
-#: src/muuli_wdr.cpp:2020
+#: src/muuli_wdr.cpp:2024
 msgid "Show progress bar"
 msgstr "Показувати панель поступу"
 
-#: src/muuli_wdr.cpp:2023
+#: src/muuli_wdr.cpp:2027
 msgid "Flat"
 msgstr "Плаский"
 
-#: src/muuli_wdr.cpp:2027
+#: src/muuli_wdr.cpp:2031
 msgid "Round"
 msgstr "Круглий"
 
-#: src/muuli_wdr.cpp:2045
+#: src/muuli_wdr.cpp:2049
 msgid "External Connection Parameters"
 msgstr "Параметри зовнішніх з'єднань"
 
-#: src/muuli_wdr.cpp:2048
+#: src/muuli_wdr.cpp:2052
 msgid "Accept external connections"
 msgstr "Дозволити зовнішні з'єднання"
 
-#: src/muuli_wdr.cpp:2055 src/muuli_wdr.cpp:2114
+#: src/muuli_wdr.cpp:2059 src/muuli_wdr.cpp:2118
 msgid "IP of the listening interface:"
 msgstr "IP-адреса інтерфейса:"
 
-#: src/muuli_wdr.cpp:2058
+#: src/muuli_wdr.cpp:2062
 msgid "Enter here a valid ip in the a.b.c.d format for the listening EC interface. An empty field or 0.0.0.0 will mean any interface."
 msgstr "Введіть IP-адресу в вірному форматі a.b.c.d для прослуховування EC-інтерфейсу. Порожнє поле або 0.0.0.0 означатиме всі."
 
-#: src/muuli_wdr.cpp:2079 src/muuli_wdr.cpp:2163
+#: src/muuli_wdr.cpp:2083 src/muuli_wdr.cpp:2194
 msgid "TCP port:"
 msgstr "Порт TCP:"
 
-#: src/muuli_wdr.cpp:2085
+#: src/muuli_wdr.cpp:2089
 msgid "Enable UPnP port forwarding on the EC port"
 msgstr "Ввімкнути UPnP перенаправлення для EC-порту"
 
-#: src/muuli_wdr.cpp:2089 src/muuli_wdr.cpp:3048
+#: src/muuli_wdr.cpp:2093 src/muuli_wdr.cpp:3079
 #: src/utils/wxCas/src/wxcasprefs.cpp:167
 msgid "Password"
 msgstr "Пароль"
 
-#: src/muuli_wdr.cpp:2095
+#: src/muuli_wdr.cpp:2099
 #, fuzzy
 msgid "aMule API server parameters"
 msgstr "Налаштування веб-сервера"
 
-#: src/muuli_wdr.cpp:2098
+#: src/muuli_wdr.cpp:2102
 msgid "Run amuleapi (REST API) on startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2103
+#: src/muuli_wdr.cpp:2107
 #, fuzzy
 msgid "HTTP port:"
 msgstr "Порт TCP:"
 
-#: src/muuli_wdr.cpp:2117
+#: src/muuli_wdr.cpp:2121
 msgid "The interface amuleapi's HTTP server listens on. 127.0.0.1 (default) accepts only local connections; use 0.0.0.0 or a specific IP to expose it to other hosts (set an admin password below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2120
+#: src/muuli_wdr.cpp:2126
+msgid "Type a password to set or change it. Stored passwords cannot be shown, so leaving this empty keeps the current one."
+msgstr ""
+
+#: src/muuli_wdr.cpp:2128
 #, fuzzy
 msgid "Admin password"
 msgstr "Перевіряється пароль\n"
 
-#: src/muuli_wdr.cpp:2125 src/muuli_wdr.cpp:2156
-msgid "Low rights password"
-msgstr "Пароль низьких прав"
+#: src/muuli_wdr.cpp:2140 src/muuli_wdr.cpp:2157 src/PrefsUnifiedDlg.cpp:1103
+#, fuzzy
+msgid "A password is set."
+msgstr "Перевіряється пароль\n"
 
-#: src/muuli_wdr.cpp:2133
+#: src/muuli_wdr.cpp:2144
+#, fuzzy
+msgid "Enable guest access"
+msgstr "Заборонити гостьовий доступ"
+
+#: src/muuli_wdr.cpp:2145
+msgid "Guest sessions may read status and listings but cannot change anything. Turning this off clears the stored guest password."
+msgstr ""
+
+#: src/muuli_wdr.cpp:2149
+#, fuzzy
+msgid "Guest password"
+msgstr "Пароль гостя веб-сервера"
+
+#: src/muuli_wdr.cpp:2164
 msgid "Web server parameters"
 msgstr "Налаштування веб-сервера"
 
-#: src/muuli_wdr.cpp:2136
+#: src/muuli_wdr.cpp:2167
 #, fuzzy
 msgid "Run webserver on startup (deprecated)"
 msgstr "Запустити веб-сервер під час запуску"
 
-#: src/muuli_wdr.cpp:2142
+#: src/muuli_wdr.cpp:2173
 msgid "Web template"
 msgstr "Веб шаблон"
 
-#: src/muuli_wdr.cpp:2147
+#: src/muuli_wdr.cpp:2178
 msgid "Full rights password"
 msgstr "Пароль повних прав"
 
-#: src/muuli_wdr.cpp:2151
+#: src/muuli_wdr.cpp:2182
 msgid "Enable Low rights User"
 msgstr "Ввімкнути користувача з низькими правами"
 
-#: src/muuli_wdr.cpp:2170
+#: src/muuli_wdr.cpp:2187
+msgid "Low rights password"
+msgstr "Пароль низьких прав"
+
+#: src/muuli_wdr.cpp:2201
 msgid "Enable UPnP port forwarding of the web server port"
 msgstr "Ввімкнути UPnP перенаправлення портів для порту веб-сервера"
 
-#: src/muuli_wdr.cpp:2175
+#: src/muuli_wdr.cpp:2206
 msgid "Web server UPnP TCP port (Optional)"
 msgstr "UPnP TCP-порт веб-сервера (не обов'язково)"
 
-#: src/muuli_wdr.cpp:2183
+#: src/muuli_wdr.cpp:2214
 msgid "Page Refresh Time (in secs)"
 msgstr "Час оновлення сторінки (с)"
 
-#: src/muuli_wdr.cpp:2190
+#: src/muuli_wdr.cpp:2221
 msgid "Enable Gzip compression"
 msgstr "Дозволити Gzip-стиснення"
 
-#: src/muuli_wdr.cpp:2224
+#: src/muuli_wdr.cpp:2255
 #, fuzzy
 msgid "Reset page to defaults"
 msgstr "Мова системи"
 
-#: src/muuli_wdr.cpp:2225
+#: src/muuli_wdr.cpp:2256
 msgid "Reset the settings on the current page to their default values."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2227 src/muuli_wdr.cpp:2313 src/ServerWnd.cpp:274
+#: src/muuli_wdr.cpp:2258 src/muuli_wdr.cpp:2344 src/ServerWnd.cpp:274
 #: src/ServerWnd.cpp:282
 msgid "OK"
 msgstr "Гаразд"
 
-#: src/muuli_wdr.cpp:2229
+#: src/muuli_wdr.cpp:2260
 msgid "Click here to apply any changes made to the preferences."
 msgstr "Натисніть тут щоб застосувати зміни зроблені в налаштуваннях."
 
-#: src/muuli_wdr.cpp:2232
+#: src/muuli_wdr.cpp:2263
 msgid "Reset any changes made to the preferences."
 msgstr "Скинути всі зміни внесені в налаштування."
 
-#: src/muuli_wdr.cpp:2261
+#: src/muuli_wdr.cpp:2292
 msgid "Comment :"
 msgstr "Коментар:"
 
-#: src/muuli_wdr.cpp:2268
+#: src/muuli_wdr.cpp:2299
 msgid "Incoming Dir :"
 msgstr "Вхідна тека:"
 
-#: src/muuli_wdr.cpp:2277
+#: src/muuli_wdr.cpp:2308
 msgid "Change priority for new assigned files :"
 msgstr "Змінити перевагу для нового призначеного файлу:"
 
-#: src/muuli_wdr.cpp:2281
+#: src/muuli_wdr.cpp:2312
 #, fuzzy
 msgid "Don't change"
 msgstr "Не змінювати"
 
-#: src/muuli_wdr.cpp:2293
+#: src/muuli_wdr.cpp:2324
 msgid "Select color for this Category (currently selected) :"
 msgstr "Виберіть колір для цієї категорії (зараз вибрано):"
 
-#: src/muuli_wdr.cpp:2360 src/muuli_wdr.cpp:2379 src/muuli_wdr.cpp:2401
+#: src/muuli_wdr.cpp:2391 src/muuli_wdr.cpp:2410 src/muuli_wdr.cpp:2432
 msgid "Click this button to reset the log."
 msgstr "Натисніть цю кнопку, щоб очистити часопис."
 
-#: src/muuli_wdr.cpp:2420
+#: src/muuli_wdr.cpp:2451
 msgid "Click on this button to update the servers list from URL ..."
 msgstr "Натисніть на кнопку щоб оновити перелік серверів з адреси..."
 
-#: src/muuli_wdr.cpp:2424
+#: src/muuli_wdr.cpp:2455
 msgid "Server list"
 msgstr "Перелік серверів"
 
-#: src/muuli_wdr.cpp:2428
+#: src/muuli_wdr.cpp:2459
 msgid "Enter the url to a server.met file here and press the button to the left to update the list of known servers."
 msgstr "Введіть адресу файлу server.met та натисніть кнопку ліворуч щоб оновити перелік відомих серверів."
 
-#: src/muuli_wdr.cpp:2433
+#: src/muuli_wdr.cpp:2464
 msgid "Add server manually: Name"
 msgstr "Додати сервер вручну: Назва"
 
-#: src/muuli_wdr.cpp:2436
+#: src/muuli_wdr.cpp:2467
 msgid "Enter the name of the new server here"
 msgstr "Введіть тут назву нового сервера"
 
-#: src/muuli_wdr.cpp:2438 src/ServerWnd.cpp:206
+#: src/muuli_wdr.cpp:2469 src/ServerWnd.cpp:206
 msgid "IP:Port"
 msgstr "IP:Порт"
 
-#: src/muuli_wdr.cpp:2441
+#: src/muuli_wdr.cpp:2472
 msgid "Enter the IP of the server here, using the x.x.x.x format."
 msgstr "Тут введіть IP-адресу сервера, використовуючи формат x.x.x.x."
 
-#: src/muuli_wdr.cpp:2447
+#: src/muuli_wdr.cpp:2478
 msgid "Enter the port of the server here."
 msgstr "Введіть тут порт сервера."
 
-#: src/muuli_wdr.cpp:2450
+#: src/muuli_wdr.cpp:2481
 msgid "Add manually a server (fill fields to the left before) ..."
 msgstr "Додати сервер вручну (заповніть поля ліворуч)..."
 
-#: src/muuli_wdr.cpp:2479
+#: src/muuli_wdr.cpp:2510
 msgid "aMule Log"
 msgstr "Часопис aMule"
 
-#: src/muuli_wdr.cpp:2487
+#: src/muuli_wdr.cpp:2518
 msgid "Server Info"
 msgstr "Інфо сервера"
 
-#: src/muuli_wdr.cpp:2491
+#: src/muuli_wdr.cpp:2522
 msgid "ED2K Info"
 msgstr "Інфо eD2k"
 
-#: src/muuli_wdr.cpp:2495
+#: src/muuli_wdr.cpp:2526
 msgid "Kad Info"
 msgstr "Інфо Kad"
 
-#: src/muuli_wdr.cpp:2523
+#: src/muuli_wdr.cpp:2554
 msgid "Click on this button to update the nodes list from URL ..."
 msgstr "Натисніть на цю кнопку щоб оновити перелік вузлів з URL..."
 
-#: src/muuli_wdr.cpp:2527
+#: src/muuli_wdr.cpp:2558
 msgid "Nodes (0)"
 msgstr "Вузли (0)"
 
-#: src/muuli_wdr.cpp:2531
+#: src/muuli_wdr.cpp:2562
 msgid "Enter the url to a nodes.dat file here and press the button to the left to update the list of known nodes."
 msgstr "Введіть адресу файлу nodes.dat та натисніть кнопку ліворуч щоб оновити перелік відомих вузлів. "
 
-#: src/muuli_wdr.cpp:2534
+#: src/muuli_wdr.cpp:2565
 msgid "Nodes stats"
 msgstr "Статистика вузлів"
 
-#: src/muuli_wdr.cpp:2576
+#: src/muuli_wdr.cpp:2607
 msgid "Bootstrap"
 msgstr "Початковий запуск"
 
-#: src/muuli_wdr.cpp:2579
+#: src/muuli_wdr.cpp:2610
 msgid "New node"
 msgstr "Новий вузол"
 
-#: src/muuli_wdr.cpp:2584
+#: src/muuli_wdr.cpp:2615
 msgid "IP:"
 msgstr "IP:"
 
-#: src/muuli_wdr.cpp:2604
+#: src/muuli_wdr.cpp:2635
 msgid "Port:"
 msgstr "Порт:"
 
-#: src/muuli_wdr.cpp:2617
+#: src/muuli_wdr.cpp:2648
 #, fuzzy
 msgid "Bootstrap from known clients"
 msgstr ""
 "Початковий запуск\n"
 "відомого клієнта"
 
-#: src/muuli_wdr.cpp:2619
+#: src/muuli_wdr.cpp:2650
 msgid "Disconnect Kad"
 msgstr "Від'єднатися від Kad"
 
-#: src/muuli_wdr.cpp:2653
+#: src/muuli_wdr.cpp:2684
 msgid "Use Secure User Identification"
 msgstr "Використовувати безпечну ідентифікацію користувача"
 
-#: src/muuli_wdr.cpp:2655
+#: src/muuli_wdr.cpp:2686
 msgid "It is recommended to enable this option. You will not receive credits if SUI is not enabled."
 msgstr "Рекомендовано ввімкнути цю опцію. Ви не отримаєте довіру якщо безпечна ідентифікація вимкнена."
 
-#: src/muuli_wdr.cpp:2657
+#: src/muuli_wdr.cpp:2688
 msgid "Protocol Obfuscation"
 msgstr "Приховування протоколу"
 
-#: src/muuli_wdr.cpp:2660
+#: src/muuli_wdr.cpp:2691
 msgid "Support Protocol Obfuscation"
 msgstr "Підтримка приховування протоколу"
 
-#: src/muuli_wdr.cpp:2662
+#: src/muuli_wdr.cpp:2693
 msgid "This option enabled Protocol Obfuscation, and makes aMule accept obfuscated connections from other clients."
 msgstr "Ця опція вмикає приховування протоколу та дозволяє aMule приймати приховані з'єднання від інших клієнтів."
 
-#: src/muuli_wdr.cpp:2664
+#: src/muuli_wdr.cpp:2695
 msgid "Use obfuscation for outgoing connections"
 msgstr "Використовувати приховування для вихідних з'єднань"
 
-#: src/muuli_wdr.cpp:2666
+#: src/muuli_wdr.cpp:2697
 msgid "This option makes aMule use Protocol Obfuscation when connecting other clients/servers."
 msgstr "Ця опція вмикає приховування протоколу під час з'єдання з іншими клієнтами/серверами."
 
-#: src/muuli_wdr.cpp:2668
+#: src/muuli_wdr.cpp:2699
 msgid "Accept only obfuscated connections"
 msgstr "Приймати тільки приховані з'єднання"
 
-#: src/muuli_wdr.cpp:2669
+#: src/muuli_wdr.cpp:2700
 msgid "This option makes aMule only accept obfuscated connections. You will have less sources, but all your traffic will be obfuscated"
 msgstr "Приймати приховані з'єднання. Будете мати менше джерел, але весь ваш трафік буде приховано"
 
-#: src/muuli_wdr.cpp:2674
+#: src/muuli_wdr.cpp:2705
 msgid "Everybody"
 msgstr "Кожен"
 
-#: src/muuli_wdr.cpp:2676
+#: src/muuli_wdr.cpp:2707
 msgid "No one"
 msgstr "Жоден"
 
-#: src/muuli_wdr.cpp:2678
+#: src/muuli_wdr.cpp:2709
 msgid "Who can see my shared files:"
 msgstr "Хто може бачити мої спільні файли:"
 
-#: src/muuli_wdr.cpp:2679
+#: src/muuli_wdr.cpp:2710
 msgid "Select who can request to view a list of your shared files."
 msgstr "Оберіть тих, хто може запитати перелік ваших спільних файлів."
 
-#: src/muuli_wdr.cpp:2681
+#: src/muuli_wdr.cpp:2712
 msgid "IP-Filtering"
 msgstr "IP-фільтрування"
 
-#: src/muuli_wdr.cpp:2688
+#: src/muuli_wdr.cpp:2719
 msgid "Filter clients"
 msgstr "Фільтрувати клієнтів"
 
-#: src/muuli_wdr.cpp:2690
+#: src/muuli_wdr.cpp:2721
 msgid "Enable filtering of the client IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "Ввімкнено фільтрування IP-адрес клієнтів, що визначені в файлі ~/.aMule/ipfilter.dat."
 
-#: src/muuli_wdr.cpp:2692
+#: src/muuli_wdr.cpp:2723
 msgid "Filter servers"
 msgstr "Фільтрувати сервери"
 
-#: src/muuli_wdr.cpp:2694
+#: src/muuli_wdr.cpp:2725
 msgid "Enable filtering of the server IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "Ввімкнено фільтрування IP-адрес серверів, що визначені в файлі ~/.aMule/ipfilter.dat."
 
-#: src/muuli_wdr.cpp:2698
+#: src/muuli_wdr.cpp:2729
 msgid "Reload List"
 msgstr "Перезавантажити перелік"
 
-#: src/muuli_wdr.cpp:2699
+#: src/muuli_wdr.cpp:2730
 msgid "Reload the list of IPs to filter from the file ~/.aMule/ipfilter.dat"
 msgstr "Перезавантажити перелік IP-адрес для фільтрування з файлу ~/.aMule/ipfilter.dat"
 
-#: src/muuli_wdr.cpp:2705
+#: src/muuli_wdr.cpp:2736
 msgid "URL:"
 msgstr "URL:"
 
-#: src/muuli_wdr.cpp:2709 src/muuli_wdr.cpp:2902
+#: src/muuli_wdr.cpp:2740 src/muuli_wdr.cpp:2933
 msgid "Update now"
 msgstr "Оновити зараз"
 
-#: src/muuli_wdr.cpp:2712
+#: src/muuli_wdr.cpp:2743
 msgid "Auto-update ipfilter at startup"
 msgstr "Автоматичне оновлення IP-фільтру після запуску"
 
-#: src/muuli_wdr.cpp:2716
+#: src/muuli_wdr.cpp:2747
 msgid "Filtering Level:"
 msgstr "Рівень фільтра:"
 
-#: src/muuli_wdr.cpp:2722
+#: src/muuli_wdr.cpp:2753
 msgid "Always filter LAN IPs"
 msgstr "Завжди відфільтровувати IP-адреси локальних мереж"
 
-#: src/muuli_wdr.cpp:2725
+#: src/muuli_wdr.cpp:2756
 msgid "Paranoid handling of non-matching IPs"
 msgstr "Параноїдальна обробка IP-адрес, що не співпали"
 
-#: src/muuli_wdr.cpp:2727
+#: src/muuli_wdr.cpp:2758
 msgid "Rejects a packet when its source IP differs from the IP the client claims (an anti-spoofing check). Disable only if it causes connection problems."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2729
+#: src/muuli_wdr.cpp:2760
 msgid "Use system-wide ipfilter.dat if available"
 msgstr "Використовувати системний ipfilter.dat якщо наявний"
 
-#: src/muuli_wdr.cpp:2730
+#: src/muuli_wdr.cpp:2761
 #, fuzzy
 msgid "If there's no local ipfilter.dat found, allow usage of a system-wide ipfilter file."
 msgstr "Якщо не знайдено місцевий ipfilter.dat, дозволити використання системного."
 
-#: src/muuli_wdr.cpp:2747
+#: src/muuli_wdr.cpp:2778
 msgid "Enable Online-Signature"
 msgstr "Ввімкнути онлайн-підпис"
 
-#: src/muuli_wdr.cpp:2749
+#: src/muuli_wdr.cpp:2780
 msgid "Enables the writing of the OS file, which can be used by external apps to create signatures and the like."
 msgstr "Ввімкнути запис файлу ОС, який може бути використано зовнішніми програмами для створення підписів та подібного."
 
-#: src/muuli_wdr.cpp:2753
+#: src/muuli_wdr.cpp:2784
 msgid "Update Frequency (Secs):"
 msgstr "Частота оновлення (с)"
 
-#: src/muuli_wdr.cpp:2756
+#: src/muuli_wdr.cpp:2787
 msgid "Change the frequency (in seconds) of Online Signature updates."
 msgstr "Змінити частоту (в секундах) оновлень онлайн-підписів."
 
-#: src/muuli_wdr.cpp:2764
+#: src/muuli_wdr.cpp:2795
 msgid "Save online signature file in: "
 msgstr "Зберегти файл онлайн-підпису в: "
 
-#: src/muuli_wdr.cpp:2770
+#: src/muuli_wdr.cpp:2801
 msgid "Click here to select the directory containing the the Online Signature files."
 msgstr "Натисніть тут, щоб вибрати теку, що містить файли з онлайн-підписами."
 
-#: src/muuli_wdr.cpp:2803
+#: src/muuli_wdr.cpp:2834
 msgid "Show country flags for clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2804
+#: src/muuli_wdr.cpp:2835
 msgid "Render the country flag column in the transfers, queue and search views. Requires a valid MMDB GeoIP database (see below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2809
+#: src/muuli_wdr.cpp:2840
 #, fuzzy
 msgid "Database"
 msgstr "Швидкість передачі:"
 
-#: src/muuli_wdr.cpp:2825
+#: src/muuli_wdr.cpp:2856
 #, fuzzy
 msgid "Source:"
 msgstr "Джерела"
 
-#: src/muuli_wdr.cpp:2828
+#: src/muuli_wdr.cpp:2859
 msgid "DB-IP (free, no account)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2829
+#: src/muuli_wdr.cpp:2860
 msgid "MaxMind GeoLite2 (free, account required)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2830
+#: src/muuli_wdr.cpp:2861
 msgid "Custom URL"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2833
+#: src/muuli_wdr.cpp:2864
 msgid "Choose which provider supplies the GeoIP MMDB database. DB-IP is the default - no account required. MaxMind requires a free account + license key. Use Custom URL to point at any other MMDB host (e.g. a local mirror)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2850
+#: src/muuli_wdr.cpp:2881
 msgid ""
 "No configuration required.\n"
 "\n"
@@ -4888,11 +4916,11 @@ msgid ""
 "License: Creative Commons BY 4.0 - https://creativecommons.org/licenses/by/4.0/"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2863
+#: src/muuli_wdr.cpp:2894
 msgid "License key:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2869
+#: src/muuli_wdr.cpp:2900
 msgid ""
 "Sign up for a free MaxMind account, then generate a License Key:\n"
 "https://www.maxmind.com/en/geolite2/signup\n"
@@ -4902,232 +4930,232 @@ msgid ""
 "Requires attribution and account registration; refresh at least every 30 days."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2884
+#: src/muuli_wdr.cpp:2915
 #, fuzzy
 msgid "Download URL:"
 msgstr "Звантаження: "
 
-#: src/muuli_wdr.cpp:2890
+#: src/muuli_wdr.cpp:2921
 msgid ""
 "Must point to an .mmdb file or a .gz / .tar.gz containing one.\n"
 "URL may include credentials (https://user:pass@host/...).\n"
 "License and attribution terms are set by the upstream URL - you are responsible."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2903
+#: src/muuli_wdr.cpp:2934
 msgid "Download the GeoIP database from the selected source."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2905
+#: src/muuli_wdr.cpp:2936
 #, fuzzy
 msgid "Auto-update on startup"
 msgstr "Автоматичне оновлення IP-фільтру після запуску"
 
-#: src/muuli_wdr.cpp:2906
+#: src/muuli_wdr.cpp:2937
 msgid "Re-download the GeoIP database from the selected source every time aMule starts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2929
+#: src/muuli_wdr.cpp:2960
 msgid "Filter incoming messages (except current chat):"
 msgstr "Фільтрувати вхідні повідомлення (окрім поточної розмови):"
 
-#: src/muuli_wdr.cpp:2931
+#: src/muuli_wdr.cpp:2962
 msgid "Filter all messages"
 msgstr "Фільтрувати всі повідомлення"
 
-#: src/muuli_wdr.cpp:2933
+#: src/muuli_wdr.cpp:2964
 msgid "Filter messages from people not on your friend list"
 msgstr "Фільтрувати повідомлення від людей, що не в вашому переліку друзів"
 
-#: src/muuli_wdr.cpp:2935
+#: src/muuli_wdr.cpp:2966
 msgid "Filter messages from unknown clients"
 msgstr "Фільтрувати повідомлення від невідомих клієнтів"
 
-#: src/muuli_wdr.cpp:2937
+#: src/muuli_wdr.cpp:2968
 msgid "Filter messages containing (use ',' as separator):"
 msgstr "Фільтрувати повідомлення, що містять (використовуйте ',' для переліку):"
 
-#: src/muuli_wdr.cpp:2940 src/muuli_wdr.cpp:2951
+#: src/muuli_wdr.cpp:2971 src/muuli_wdr.cpp:2982
 msgid "add here the words amule should filter and block messages including it"
 msgstr "додати слова, які aMule буде фільтрувати, та забороняти повідомлення, що їх містять"
 
-#: src/muuli_wdr.cpp:2942
+#: src/muuli_wdr.cpp:2973
 msgid "Show received messages in the log"
 msgstr "Показувати отримані повідомлення в часописі"
 
-#: src/muuli_wdr.cpp:2945
+#: src/muuli_wdr.cpp:2976
 msgid "Comments"
 msgstr "Коментарі"
 
-#: src/muuli_wdr.cpp:2948
+#: src/muuli_wdr.cpp:2979
 msgid "Filter comments containing (use ',' as separator):"
 msgstr "Фільтрувати коментарі, що містять (використовуйте ',' для переліку):"
 
-#: src/muuli_wdr.cpp:2973
+#: src/muuli_wdr.cpp:3004
 msgid "Enable Proxy"
 msgstr "Ввімкнути проксі"
 
-#: src/muuli_wdr.cpp:2974
+#: src/muuli_wdr.cpp:3005
 msgid "Enable/disable proxy support"
 msgstr "Ввімкнути/вимкнути підтримку проксі"
 
-#: src/muuli_wdr.cpp:2977
+#: src/muuli_wdr.cpp:3008
 msgid "Proxy type:"
 msgstr "Тип проксі:"
 
-#: src/muuli_wdr.cpp:2988
+#: src/muuli_wdr.cpp:3019
 msgid "Proxy host:"
 msgstr "Хост проксі:"
 
-#: src/muuli_wdr.cpp:2991
+#: src/muuli_wdr.cpp:3022
 msgid "The proxy host name"
 msgstr "Ім'я хосту проксі"
 
-#: src/muuli_wdr.cpp:2993
+#: src/muuli_wdr.cpp:3024
 msgid "Proxy port:"
 msgstr "Порт проксі:"
 
-#: src/muuli_wdr.cpp:2996
+#: src/muuli_wdr.cpp:3027
 msgid "The proxy port"
 msgstr "Порт проксі"
 
-#: src/muuli_wdr.cpp:2998
+#: src/muuli_wdr.cpp:3029
 msgid "Enable authentication"
 msgstr "Включити авторизацію"
 
-#: src/muuli_wdr.cpp:2999
+#: src/muuli_wdr.cpp:3030
 msgid "Enable/disable username/password authentication"
 msgstr "Ввімкнути/вимкнути аутентифікацію з ім'ям/паролем"
 
-#: src/muuli_wdr.cpp:3002
+#: src/muuli_wdr.cpp:3033
 msgid "Username: "
 msgstr "Ім'я користувача: "
 
-#: src/muuli_wdr.cpp:3005
+#: src/muuli_wdr.cpp:3036
 msgid "The username to use to connect to the proxy"
 msgstr "Ім'я користувача для з'єднання з проксі"
 
-#: src/muuli_wdr.cpp:3007
+#: src/muuli_wdr.cpp:3038
 msgid "Password:"
 msgstr "Пароль:"
 
-#: src/muuli_wdr.cpp:3010
+#: src/muuli_wdr.cpp:3041
 msgid "The password to use to connect to the proxy"
 msgstr "Пароль для з'єднання з проксі"
 
-#: src/muuli_wdr.cpp:3029
+#: src/muuli_wdr.cpp:3060
 msgid "Connect to:"
 msgstr "З'єднатись з:"
 
-#: src/muuli_wdr.cpp:3038
+#: src/muuli_wdr.cpp:3069
 msgid "Login to remote amule"
 msgstr "Вхід до віддаленого aMule"
 
-#: src/muuli_wdr.cpp:3043
+#: src/muuli_wdr.cpp:3074
 msgid "User name"
 msgstr "Ім'я користувача"
 
-#: src/muuli_wdr.cpp:3054
+#: src/muuli_wdr.cpp:3085
 msgid "Remember those settings"
 msgstr "Запам'ятати ці налаштування"
 
-#: src/muuli_wdr.cpp:3057
+#: src/muuli_wdr.cpp:3088
 #, fuzzy
 msgid "Force ZLIB compression"
 msgstr "Використовувати gzip-стиснення"
 
-#: src/muuli_wdr.cpp:3081
+#: src/muuli_wdr.cpp:3112
 msgid "Enable Verbose Debug-Logging."
 msgstr "Ввімкнути докладне ведення часопису."
 
-#: src/muuli_wdr.cpp:3083
+#: src/muuli_wdr.cpp:3114
 #, fuzzy
 msgid "Only to Logfile"
 msgstr "Відкрити файл"
 
-#: src/muuli_wdr.cpp:3085
+#: src/muuli_wdr.cpp:3116
 msgid "Message Categories:"
 msgstr "Категорія повідомлення:"
 
-#: src/muuli_wdr.cpp:3109 src/PartFileConvertDlg.cpp:160
+#: src/muuli_wdr.cpp:3140 src/PartFileConvertDlg.cpp:160
 msgid "Waiting..."
 msgstr "Очікується..."
 
-#: src/muuli_wdr.cpp:3129
+#: src/muuli_wdr.cpp:3160
 msgid "Add imports"
 msgstr "Додати зовнішні внесення"
 
-#: src/muuli_wdr.cpp:3132
+#: src/muuli_wdr.cpp:3163
 msgid "Retry selected"
 msgstr "Повторити вибрані"
 
-#: src/muuli_wdr.cpp:3134
+#: src/muuli_wdr.cpp:3165
 msgid "Remove selected"
 msgstr "Вилучити вибрані"
 
-#: src/muuli_wdr.cpp:3197
+#: src/muuli_wdr.cpp:3228
 msgid "Event Types"
 msgstr "Типи подій"
 
-#: src/muuli_wdr.cpp:3216
+#: src/muuli_wdr.cpp:3247
 msgid "Statistics and queued clients for selected file(s) : Session / All time"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3240
+#: src/muuli_wdr.cpp:3271
 #, fuzzy
 msgid "Active Uploads"
 msgstr "Чинні вивантаження:"
 
-#: src/muuli_wdr.cpp:3254
+#: src/muuli_wdr.cpp:3285
 msgid "Percent of total files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3306
+#: src/muuli_wdr.cpp:3337
 #, fuzzy
 msgid "Show Clients for"
 msgstr "Показати клієнтів"
 
-#: src/muuli_wdr.cpp:3308
+#: src/muuli_wdr.cpp:3339
 #, fuzzy
 msgid "All files"
 msgstr "Сховати спільні файли"
 
-#: src/muuli_wdr.cpp:3311
+#: src/muuli_wdr.cpp:3342
 #, fuzzy
 msgid "Selected files"
 msgstr "Вибрати фільтр перегляду"
 
-#: src/muuli_wdr.cpp:3314
+#: src/muuli_wdr.cpp:3345
 #, fuzzy
 msgid "Active uploads only"
 msgstr "Чинні вивантаження"
 
-#: src/muuli_wdr.cpp:3321
+#: src/muuli_wdr.cpp:3352
 #, fuzzy
 msgid "Reload:"
 msgstr "Перезавантажити перелік"
 
-#: src/muuli_wdr.cpp:3325
+#: src/muuli_wdr.cpp:3356
 msgid "Reload your shared files"
 msgstr "Перезавантажити ваші спільні файли"
 
-#: src/muuli_wdr.cpp:3388
+#: src/muuli_wdr.cpp:3419
 msgid "Send"
 msgstr "Надіслати"
 
-#: src/muuli_wdr.cpp:3389
+#: src/muuli_wdr.cpp:3420
 msgid "Sends the specified message."
 msgstr "Надіслати вказане повідомлення."
 
-#: src/muuli_wdr.cpp:3393
+#: src/muuli_wdr.cpp:3424
 msgid "Close this chat-session."
 msgstr "Закрити цю розмову."
 
-#: src/muuli_wdr.cpp:3416
+#: src/muuli_wdr.cpp:3447
 msgid "Connect to any server and/or Kad"
 msgstr "З'єднатися з будь-яким сервером та/чи Kad"
 
-#: src/muuli_wdr.cpp:3422 src/SharedFilesCtrl.cpp:142 src/Statistics.cpp:941
+#: src/muuli_wdr.cpp:3453 src/SharedFilesCtrl.cpp:142 src/Statistics.cpp:941
 msgid "Shared Files"
 msgstr "Спільні файли"
 
@@ -5491,268 +5519,268 @@ msgstr "Звантажені"
 msgid "ERROR: Failed to open partfile '%s'"
 msgstr "ПОМИЛКА: не вдалося відкрити частковий файл '%s'"
 
-#: src/Preferences.cpp:674
+#: src/Preferences.cpp:701
 msgid "System default"
 msgstr "Мова системи"
 
-#: src/Preferences.cpp:675
+#: src/Preferences.cpp:702
 msgid "Albanian"
 msgstr "Албанська"
 
-#: src/Preferences.cpp:676
+#: src/Preferences.cpp:703
 msgid "Arabic"
 msgstr "Арабська"
 
-#: src/Preferences.cpp:677
+#: src/Preferences.cpp:704
 #, fuzzy
 msgid "Asturian"
 msgstr "Естонська"
 
-#: src/Preferences.cpp:678
+#: src/Preferences.cpp:705
 msgid "Basque"
 msgstr "Баскська"
 
-#: src/Preferences.cpp:679
+#: src/Preferences.cpp:706
 msgid "Bulgarian"
 msgstr "Болгарська"
 
-#: src/Preferences.cpp:680
+#: src/Preferences.cpp:707
 msgid "Catalan"
 msgstr "Каталонська"
 
-#: src/Preferences.cpp:681
+#: src/Preferences.cpp:708
 msgid "Chinese (Simplified)"
 msgstr "Китайська (спрощена)"
 
-#: src/Preferences.cpp:682
+#: src/Preferences.cpp:709
 msgid "Chinese (Traditional)"
 msgstr "Китайська (традиційна)"
 
-#: src/Preferences.cpp:683
+#: src/Preferences.cpp:710
 msgid "Croatian"
 msgstr "Хорватська"
 
-#: src/Preferences.cpp:684
+#: src/Preferences.cpp:711
 msgid "Czech"
 msgstr "Чеська"
 
-#: src/Preferences.cpp:685
+#: src/Preferences.cpp:712
 msgid "Danish"
 msgstr "Данська"
 
-#: src/Preferences.cpp:686
+#: src/Preferences.cpp:713
 msgid "Dutch"
 msgstr "Нідерландська"
 
-#: src/Preferences.cpp:687
+#: src/Preferences.cpp:714
 msgid "English (U.K.)"
 msgstr "Англійська (Великобританія)"
 
-#: src/Preferences.cpp:688
+#: src/Preferences.cpp:715
 #, fuzzy
 msgid "English (U.S.)"
 msgstr "Англійська (Великобританія)"
 
-#: src/Preferences.cpp:689
+#: src/Preferences.cpp:716
 msgid "Estonian"
 msgstr "Естонська"
 
-#: src/Preferences.cpp:690
+#: src/Preferences.cpp:717
 msgid "Finnish"
 msgstr "Фінська"
 
-#: src/Preferences.cpp:691
+#: src/Preferences.cpp:718
 msgid "French"
 msgstr "Французька"
 
-#: src/Preferences.cpp:692
+#: src/Preferences.cpp:719
 msgid "Galician"
 msgstr "Галісійська"
 
-#: src/Preferences.cpp:693
+#: src/Preferences.cpp:720
 msgid "German"
 msgstr "Німецька"
 
-#: src/Preferences.cpp:694
+#: src/Preferences.cpp:721
 msgid "Greek"
 msgstr "Грецька"
 
-#: src/Preferences.cpp:695
+#: src/Preferences.cpp:722
 msgid "Hebrew"
 msgstr "Іврит"
 
-#: src/Preferences.cpp:696
+#: src/Preferences.cpp:723
 msgid "Hungarian"
 msgstr "Угорська"
 
-#: src/Preferences.cpp:697
+#: src/Preferences.cpp:724
 msgid "Italian"
 msgstr "Італійська"
 
-#: src/Preferences.cpp:698
+#: src/Preferences.cpp:725
 msgid "Japanese"
 msgstr "Японська"
 
-#: src/Preferences.cpp:699
+#: src/Preferences.cpp:726
 msgid "Korean"
 msgstr "Корейська"
 
-#: src/Preferences.cpp:700
+#: src/Preferences.cpp:727
 msgid "Latvian"
 msgstr ""
 
-#: src/Preferences.cpp:701
+#: src/Preferences.cpp:728
 msgid "Lithuanian"
 msgstr "Литовська"
 
-#: src/Preferences.cpp:702
+#: src/Preferences.cpp:729
 msgid "Norwegian (Nynorsk)"
 msgstr "Норвезька (Нюнорск)"
 
-#: src/Preferences.cpp:703
+#: src/Preferences.cpp:730
 msgid "Polish"
 msgstr "Польська"
 
-#: src/Preferences.cpp:704
+#: src/Preferences.cpp:731
 msgid "Portuguese"
 msgstr "Португальська"
 
-#: src/Preferences.cpp:705
+#: src/Preferences.cpp:732
 msgid "Portuguese (Brazilian)"
 msgstr "Португальська (Бразилія)"
 
-#: src/Preferences.cpp:706
+#: src/Preferences.cpp:733
 #, fuzzy
 msgid "Romanian"
 msgstr "Албанська"
 
-#: src/Preferences.cpp:707
+#: src/Preferences.cpp:734
 msgid "Russian"
 msgstr "Російська"
 
-#: src/Preferences.cpp:708
+#: src/Preferences.cpp:735
 msgid "Slovenian"
 msgstr "Словенська"
 
-#: src/Preferences.cpp:709
+#: src/Preferences.cpp:736
 msgid "Spanish"
 msgstr "Іспанська"
 
-#: src/Preferences.cpp:710
+#: src/Preferences.cpp:737
 msgid "Swedish"
 msgstr "Шведська"
 
-#: src/Preferences.cpp:711
+#: src/Preferences.cpp:738
 msgid "Turkish"
 msgstr "Турецька"
 
-#: src/Preferences.cpp:712
+#: src/Preferences.cpp:739
 msgid "Ukrainian"
 msgstr "Українська"
 
-#: src/Preferences.cpp:815
+#: src/Preferences.cpp:842
 #, fuzzy
 msgid "Change Language"
 msgstr "Мова: "
 
-#: src/Preferences.cpp:879
+#: src/Preferences.cpp:906
 msgid "There are no translations installed for aMule"
 msgstr ""
 
-#: src/Preferences.cpp:880
+#: src/Preferences.cpp:907
 #, fuzzy
 msgid "No languages available"
 msgstr "Недоступний"
 
-#: src/Preferences.cpp:1011
+#: src/Preferences.cpp:1038
 msgid "no options available"
 msgstr "немає наявних опцій"
 
-#: src/Preferences.cpp:2182
+#: src/Preferences.cpp:2227
 msgid "Invalid category found, skipping"
 msgstr "Знайдена помилкова категорія, пропущена"
 
-#: src/Preferences.cpp:2351
+#: src/Preferences.cpp:2396
 msgid "TCP port can't be higher than 65532 due to server UDP socket being TCP+3"
 msgstr "Порт TCP не може бути більшим ніж 65532, оскільки UDP-порт сервера є TCP+3"
 
-#: src/Preferences.cpp:2352
+#: src/Preferences.cpp:2397
 #, c-format
 msgid "Default port will be used (%d)"
 msgstr "Буде використовуватися порт за замовчуванням (%d)"
 
-#: src/PrefsUnifiedDlg.cpp:298 src/Statistics.cpp:866
+#: src/PrefsUnifiedDlg.cpp:300 src/Statistics.cpp:866
 msgid "Connection"
 msgstr "З'єднання"
 
-#: src/PrefsUnifiedDlg.cpp:299 src/SearchListCtrl.cpp:117
+#: src/PrefsUnifiedDlg.cpp:301 src/SearchListCtrl.cpp:117
 msgid "Directories"
 msgstr "Теки"
 
-#: src/PrefsUnifiedDlg.cpp:300 src/Statistics.cpp:917
+#: src/PrefsUnifiedDlg.cpp:302 src/Statistics.cpp:917
 msgid "Servers"
 msgstr "Сервери"
 
-#: src/PrefsUnifiedDlg.cpp:301 src/ServerListCtrl.cpp:96
+#: src/PrefsUnifiedDlg.cpp:303 src/ServerListCtrl.cpp:96
 msgid "Files"
 msgstr "Файли"
 
-#: src/PrefsUnifiedDlg.cpp:302
+#: src/PrefsUnifiedDlg.cpp:304
 msgid "Security"
 msgstr "Безпека"
 
-#: src/PrefsUnifiedDlg.cpp:303
+#: src/PrefsUnifiedDlg.cpp:305
 msgid "Interface"
 msgstr "Зовнішній вигляд"
 
-#: src/PrefsUnifiedDlg.cpp:310
+#: src/PrefsUnifiedDlg.cpp:312
 msgid "IP2Country"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:313
+#: src/PrefsUnifiedDlg.cpp:315
 msgid "Proxy"
 msgstr "Проксі"
 
-#: src/PrefsUnifiedDlg.cpp:314
+#: src/PrefsUnifiedDlg.cpp:316
 msgid "Filters"
 msgstr "Фільтри"
 
-#: src/PrefsUnifiedDlg.cpp:315
+#: src/PrefsUnifiedDlg.cpp:317
 msgid "Remote Controls"
 msgstr "Віддалене керування"
 
-#: src/PrefsUnifiedDlg.cpp:316
+#: src/PrefsUnifiedDlg.cpp:318
 msgid "Online Signature"
 msgstr "Онлайн-підпис"
 
-#: src/PrefsUnifiedDlg.cpp:317
+#: src/PrefsUnifiedDlg.cpp:319
 msgid "Advanced"
 msgstr "Розширені"
 
-#: src/PrefsUnifiedDlg.cpp:318
+#: src/PrefsUnifiedDlg.cpp:320
 msgid "Events"
 msgstr "Події"
 
-#: src/PrefsUnifiedDlg.cpp:321
+#: src/PrefsUnifiedDlg.cpp:323
 msgid "Debugging"
 msgstr "Налагоджувач"
 
-#: src/PrefsUnifiedDlg.cpp:451
+#: src/PrefsUnifiedDlg.cpp:453
 msgid ""
 "The following variables will be substituted:\n"
 "    %PARTFILE - full path to the file\n"
 "    %PARTNAME - file name only"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:472
+#: src/PrefsUnifiedDlg.cpp:474
 msgid "Tray icon support requires libayatana-appindicator3 at compile time."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:488
+#: src/PrefsUnifiedDlg.cpp:490
 msgid "Not available on Wayland: the protocol does not report when a window is minimized, so this option cannot intercept the system minimize button. Workaround: launch aMule with `GDK_BACKEND=x11` to use XWayland instead."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:534
+#: src/PrefsUnifiedDlg.cpp:536
 msgid ""
 "Do not change these setting unless you know\n"
 "what you are doing, otherwise you can easily\n"
@@ -5768,26 +5796,35 @@ msgstr ""
 "aMule чудово працює без зміни будь-яких\n"
 "з цих параметрів."
 
-#: src/PrefsUnifiedDlg.cpp:645
+#: src/PrefsUnifiedDlg.cpp:647
 #, c-format
 msgid "Failed to connect Cfg to widget with the ID %d and key %s"
 msgstr "Помилка з'єднання Cfg до Widget з ID %d та ключем %s"
 
-#: src/PrefsUnifiedDlg.cpp:693
+#: src/PrefsUnifiedDlg.cpp:695
 #, c-format
 msgid "Failed to transfer data from Cfg to Widget with the ID %d and key %s"
 msgstr "Помилка передавання даних з Cfg до Widget з ID %d та ключем %s"
 
-#: src/PrefsUnifiedDlg.cpp:799
+#: src/PrefsUnifiedDlg.cpp:801
 msgid "The type of proxy you are connecting to"
 msgstr "Тип проксі з яким ви з'єднуєтесь"
 
-#: src/PrefsUnifiedDlg.cpp:1003
+#: src/PrefsUnifiedDlg.cpp:1020
 #, c-format
 msgid "Failed to transfer data from Widget to Cfg with the ID %d and key %s"
 msgstr "Помилка передавання даних з Widget до Cfg з ID %d та ключем %s"
 
 #: src/PrefsUnifiedDlg.cpp:1103
+#, fuzzy
+msgid "No password set."
+msgstr "Перевіряється пароль\n"
+
+#: src/PrefsUnifiedDlg.cpp:1132
+msgid "Guest access needs a password. Type one in the guest password field, or untick Enable guest access."
+msgstr ""
+
+#: src/PrefsUnifiedDlg.cpp:1144
 msgid ""
 "aMule must be restarted to enable these changes:\n"
 "\n"
@@ -5795,45 +5832,45 @@ msgstr ""
 "aMule має бути перезапущений, щоб зміни подіяли:\n"
 "\n"
 
-#: src/PrefsUnifiedDlg.cpp:1110
+#: src/PrefsUnifiedDlg.cpp:1151
 msgid "- TCP port changed.\n"
 msgstr "- TCP-порт змінено.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1115
+#: src/PrefsUnifiedDlg.cpp:1156
 msgid "- UDP port changed.\n"
 msgstr "- UDP-порт змінено.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1120
+#: src/PrefsUnifiedDlg.cpp:1161
 #, fuzzy
 msgid "- Network interface binding changed.\n"
 msgstr "Зовнішнє з'єднання розірвано."
 
-#: src/PrefsUnifiedDlg.cpp:1125
+#: src/PrefsUnifiedDlg.cpp:1166
 #, fuzzy
 msgid "- External connect port changed.\n"
 msgstr "Зовнішнє з'єднання розірвано."
 
-#: src/PrefsUnifiedDlg.cpp:1129
+#: src/PrefsUnifiedDlg.cpp:1170
 #, fuzzy
 msgid "- External connect acceptance changed.\n"
 msgstr "Дозволено нове зовнішнє з'єднання"
 
-#: src/PrefsUnifiedDlg.cpp:1133
+#: src/PrefsUnifiedDlg.cpp:1174
 #, fuzzy
 msgid "- External connect interface changed.\n"
 msgstr "Зовнішнє з'єднання розірвано."
 
-#: src/PrefsUnifiedDlg.cpp:1137
+#: src/PrefsUnifiedDlg.cpp:1178
 #, fuzzy
 msgid "- Protocol obfuscation support changed.\n"
 msgstr "Приховування протоколу"
 
-#: src/PrefsUnifiedDlg.cpp:1151
+#: src/PrefsUnifiedDlg.cpp:1193
 #, fuzzy
 msgid "- amuleapi settings changed.\n"
 msgstr "- Мова змінена.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1160
+#: src/PrefsUnifiedDlg.cpp:1202
 msgid ""
 "Your Auto-update server list is empty.\n"
 "'Auto-update server list at startup' will be disabled."
@@ -5841,7 +5878,7 @@ msgstr ""
 "Ваш перелік автоматичного оновлення серверів порожній.\n"
 "'Автоматичне оновлення серверів під час завантаження буде вимкнено."
 
-#: src/PrefsUnifiedDlg.cpp:1171
+#: src/PrefsUnifiedDlg.cpp:1213
 msgid ""
 "You have enabled external connections but have not specified a password.\n"
 "External connections cannot be enabled unless a valid password is specified."
@@ -5849,29 +5886,34 @@ msgstr ""
 "Ви увімкнули зовнішні з'єднання, але не визначили пароль.\n"
 "Зовнішні з'єднання не можуть бути ввімкнені поки не вказано вірний пароль."
 
-#: src/PrefsUnifiedDlg.cpp:1202
+#: src/PrefsUnifiedDlg.cpp:1246
+#, c-format
+msgid "The amuleapi password could not be saved: %s"
+msgstr ""
+
+#: src/PrefsUnifiedDlg.cpp:1276
 msgid "- Language changed.\n"
 msgstr "- Мова змінена.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1207
+#: src/PrefsUnifiedDlg.cpp:1281
 msgid "- Temp folder changed.\n"
 msgstr "- Тимчасова тека змінена.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1212
+#: src/PrefsUnifiedDlg.cpp:1286
 #, fuzzy
 msgid "- ED2K network enabled.\n"
 msgstr "Всі мережі вимкнені."
 
-#: src/PrefsUnifiedDlg.cpp:1245
+#: src/PrefsUnifiedDlg.cpp:1319
 msgid "The shared-file exclusion pattern is not a valid regular expression. The filter has been left disabled."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1247 src/PrefsUnifiedDlg.cpp:1841
+#: src/PrefsUnifiedDlg.cpp:1321 src/PrefsUnifiedDlg.cpp:1921
 #, fuzzy
 msgid "Invalid regular expression"
 msgstr "Невірна версія протоколу."
 
-#: src/PrefsUnifiedDlg.cpp:1324
+#: src/PrefsUnifiedDlg.cpp:1398
 msgid ""
 "Both eD2k and Kad network are disabled.\n"
 "You won't be able to connect until you enable at least one of them."
@@ -5879,7 +5921,7 @@ msgstr ""
 "Обидві eD2k та Kad-мережі вимкнені.\n"
 "Ви не зможете з'єднатися поки не увімкнете хоча б одну з них"
 
-#: src/PrefsUnifiedDlg.cpp:1329
+#: src/PrefsUnifiedDlg.cpp:1403
 msgid ""
 "Kad will not start if your UDP port is disabled.\n"
 "Enable UDP port or disable Kad."
@@ -5887,7 +5929,7 @@ msgstr ""
 "Kad не розпочне роботу, якщо UDP-порт вимкнено.\n"
 "Увімкніть UDP-порт або вимкніть Kad"
 
-#: src/PrefsUnifiedDlg.cpp:1385
+#: src/PrefsUnifiedDlg.cpp:1459
 msgid ""
 "\n"
 "You MUST restart aMule now.\n"
@@ -5897,69 +5939,69 @@ msgstr ""
 "Ви ЗОБОВ'ЯЗАНІ перезапустити aMule зараз.\n"
 "Якщо ж не перезапустите, не скаржтеся, коли станеться щось жахливе.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1450
+#: src/PrefsUnifiedDlg.cpp:1524
 msgid "Could not register aMule for autostart at login. The autostart store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1452
+#: src/PrefsUnifiedDlg.cpp:1526
 msgid "Could not remove the autostart-at-login entry."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1453
+#: src/PrefsUnifiedDlg.cpp:1527
 #, fuzzy
 msgid "Autostart"
 msgstr "Автоматичне оновлення розпочато"
 
-#: src/PrefsUnifiedDlg.cpp:1468
+#: src/PrefsUnifiedDlg.cpp:1542
 msgid "Register file type"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1468
+#: src/PrefsUnifiedDlg.cpp:1542
 msgid "Register URL handler"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1476
+#: src/PrefsUnifiedDlg.cpp:1550
 #, c-format
 msgid "aMule only handles eD2k-compatible magnets. If you replace the current magnet handler (%s), BitTorrent magnet links will stop working - aMule cannot download BitTorrent content. Continue?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1481
+#: src/PrefsUnifiedDlg.cpp:1555
 #, c-format
 msgid "Another application currently opens .emulecollection files (%s). Replace it with aMule?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1486
+#: src/PrefsUnifiedDlg.cpp:1560
 #, c-format
 msgid "Another application is currently the default handler for these links (%s). Replace it with aMule?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1511
+#: src/PrefsUnifiedDlg.cpp:1585
 msgid "Could not register aMule for .emulecollection files. The registration store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1513
+#: src/PrefsUnifiedDlg.cpp:1587
 #, fuzzy
 msgid "Could not remove the file type registration."
 msgstr "Тека для тимчасових звантажуваних файлів"
 
-#: src/PrefsUnifiedDlg.cpp:1515
+#: src/PrefsUnifiedDlg.cpp:1589
 msgid "Could not register aMule as the URL handler. The registration store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1517
+#: src/PrefsUnifiedDlg.cpp:1591
 msgid "Could not remove the URL handler registration."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1587 src/PrefsUnifiedDlg.cpp:1614
+#: src/PrefsUnifiedDlg.cpp:1661 src/PrefsUnifiedDlg.cpp:1688
 #, fuzzy
 msgid "The web server and aMule API require external connections to be enabled."
 msgstr "Пароль встановлений та дозволені зовнішні з'єднання."
 
-#: src/PrefsUnifiedDlg.cpp:1597
+#: src/PrefsUnifiedDlg.cpp:1671
 msgid "The aMule web server is deprecated. Consider running the aMule API instead."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1655
+#: src/PrefsUnifiedDlg.cpp:1735
 msgid ""
 "Your Auto-update servers list is in blank.\n"
 "Please fill in at least one URL to point to a valid server.met file.\n"
@@ -5969,24 +6011,24 @@ msgstr ""
 "Будь ласка заповніть принаймні одну адресу, що посилається на існуючий файл server.met.\n"
 "Натисніть на кнопку \"Перелік\" щоб ввести адресу."
 
-#: src/PrefsUnifiedDlg.cpp:1796
+#: src/PrefsUnifiedDlg.cpp:1876
 msgid "Temporary files"
 msgstr "Тимчасові файли"
 
-#: src/PrefsUnifiedDlg.cpp:1801
+#: src/PrefsUnifiedDlg.cpp:1881
 msgid "Incoming files"
 msgstr "Вхідні файли"
 
-#: src/PrefsUnifiedDlg.cpp:1806
+#: src/PrefsUnifiedDlg.cpp:1886
 msgid "Online Signatures"
 msgstr "Онлайн-підписи"
 
-#: src/PrefsUnifiedDlg.cpp:1819
+#: src/PrefsUnifiedDlg.cpp:1899
 #, c-format
 msgid "Choose a folder for %s"
 msgstr "Виберіть теку для %s"
 
-#: src/PrefsUnifiedDlg.cpp:1843
+#: src/PrefsUnifiedDlg.cpp:1923
 #, fuzzy, c-format
 msgid "Would exclude %u of %u shared file"
 msgid_plural "Would exclude %u of %u shared files"
@@ -5994,42 +6036,42 @@ msgstr[0] "Знайдено %i новий спільний файл"
 msgstr[1] "Знайдено %i нові спільні файли"
 msgstr[2] "Знайдено %i нових спільних файлів"
 
-#: src/PrefsUnifiedDlg.cpp:1860
+#: src/PrefsUnifiedDlg.cpp:1940
 msgid "Browse for videoplayer"
 msgstr "Переглянути, щоб знайти відеопрогравач"
 
-#: src/PrefsUnifiedDlg.cpp:1864
+#: src/PrefsUnifiedDlg.cpp:1944
 msgid "Select browser"
 msgstr "Вибрати переглядач тенет"
 
-#: src/PrefsUnifiedDlg.cpp:1868
+#: src/PrefsUnifiedDlg.cpp:1948
 #, fuzzy
 msgid "Select ffprobe binary"
 msgstr "Вибрати переглядач тенет"
 
-#: src/PrefsUnifiedDlg.cpp:1874
+#: src/PrefsUnifiedDlg.cpp:1954
 #, c-format
 msgid "Executable%s"
 msgstr "Виконуваний %s"
 
-#: src/PrefsUnifiedDlg.cpp:1908
+#: src/PrefsUnifiedDlg.cpp:1988
 msgid "ffprobe not found on PATH or in the standard install locations. Install ffmpeg (which ships ffprobe) or use Browse to pick a binary manually."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1920
+#: src/PrefsUnifiedDlg.cpp:2000
 msgid "Reset the settings on this page to their default values?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1921
+#: src/PrefsUnifiedDlg.cpp:2001
 #, fuzzy
 msgid "Reset to defaults"
 msgstr "Мова системи"
 
-#: src/PrefsUnifiedDlg.cpp:1948
+#: src/PrefsUnifiedDlg.cpp:2028
 msgid "Edit server list"
 msgstr "Редагувати перелік серверів"
 
-#: src/PrefsUnifiedDlg.cpp:1949
+#: src/PrefsUnifiedDlg.cpp:2029
 msgid ""
 "Add here URL's to download server.met files.\n"
 "Only one url on each line."
@@ -6037,42 +6079,42 @@ msgstr ""
 "Додайте тут адреси файлів server.met.\n"
 "Тільки одна адреса на рядок."
 
-#: src/PrefsUnifiedDlg.cpp:2004
+#: src/PrefsUnifiedDlg.cpp:2084
 msgid "IP2Country update failed"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2149 src/PrefsUnifiedDlg.cpp:2180
+#: src/PrefsUnifiedDlg.cpp:2229 src/PrefsUnifiedDlg.cpp:2260
 msgid "Data by MaxMind GeoLite2"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2151 src/PrefsUnifiedDlg.cpp:2182
+#: src/PrefsUnifiedDlg.cpp:2231 src/PrefsUnifiedDlg.cpp:2262
 #, fuzzy
 msgid "Custom source"
 msgstr "Завершених джерел"
 
-#: src/PrefsUnifiedDlg.cpp:2153 src/PrefsUnifiedDlg.cpp:2184
+#: src/PrefsUnifiedDlg.cpp:2233 src/PrefsUnifiedDlg.cpp:2264
 msgid "Data by DB-IP.com"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2204
+#: src/PrefsUnifiedDlg.cpp:2284
 #, fuzzy, c-format
 msgid "Status: Loaded%s"
 msgstr "Стан:"
 
-#: src/PrefsUnifiedDlg.cpp:2206
+#: src/PrefsUnifiedDlg.cpp:2286
 #, fuzzy, c-format
 msgid "Status: Loaded%s - %s"
 msgstr "Стан:"
 
-#: src/PrefsUnifiedDlg.cpp:2210
+#: src/PrefsUnifiedDlg.cpp:2290
 msgid "Status: Failed to load - click 'Update now' to refresh."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2212
+#: src/PrefsUnifiedDlg.cpp:2292
 msgid "Status: Not found - click 'Update now' to download."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2270 src/PrefsUnifiedDlg.cpp:2294
+#: src/PrefsUnifiedDlg.cpp:2350 src/PrefsUnifiedDlg.cpp:2374
 #, c-format
 msgid "Update delay: %d second"
 msgid_plural "Update delay: %d seconds"
@@ -6080,7 +6122,7 @@ msgstr[0] "Затримка оновлення: %d секунда"
 msgstr[1] "Затримка оновлення: %d секунди"
 msgstr[2] "Затримка оновлення: %d секунд"
 
-#: src/PrefsUnifiedDlg.cpp:2278
+#: src/PrefsUnifiedDlg.cpp:2358
 #, c-format
 msgid "Time for average graph: %d minute"
 msgid_plural "Time for average graph: %d minutes"
@@ -6088,12 +6130,12 @@ msgstr[0] "Час усереднення графіків: %d хвилина"
 msgstr[1] "Час усереднення графіків: %d хвилини"
 msgstr[2] "Час усереднення графіків: %d хвилин"
 
-#: src/PrefsUnifiedDlg.cpp:2287
+#: src/PrefsUnifiedDlg.cpp:2367
 #, c-format
 msgid "Connections Graph Scale: %d"
 msgstr "Зміна розміру графіка з'єднань: %d"
 
-#: src/PrefsUnifiedDlg.cpp:2302
+#: src/PrefsUnifiedDlg.cpp:2382
 #, c-format
 msgid "File Buffer Size: %d byte"
 msgid_plural "File Buffer Size: %d bytes"
@@ -6101,7 +6143,7 @@ msgstr[0] "Розмір файлу буфера: %d байт"
 msgstr[1] "Розмір файлу буфера: %d байти"
 msgstr[2] "Розмір файлу буфера: %d байт"
 
-#: src/PrefsUnifiedDlg.cpp:2312
+#: src/PrefsUnifiedDlg.cpp:2392
 #, c-format
 msgid "Upload Queue Size: %d client"
 msgid_plural "Upload Queue Size: %d clients"
@@ -6109,7 +6151,7 @@ msgstr[0] "Розмір черги вивантаження: %d клієнт"
 msgstr[1] "Розмір черги вивантаження: %d клієнти"
 msgstr[2] "Розмір черги вивантаження: %d клієнтів"
 
-#: src/PrefsUnifiedDlg.cpp:2322
+#: src/PrefsUnifiedDlg.cpp:2402
 #, c-format
 msgid "Server connection refresh interval: %d minute"
 msgid_plural "Server connection refresh interval: %d minutes"
@@ -6117,79 +6159,79 @@ msgstr[0] "Інтервал оновлення з'єднання з сервер
 msgstr[1] "Інтервал оновлення з'єднання з сервером: %d хвилини"
 msgstr[2] "Інтервал оновлення з'єднання з сервером: %d хвилин"
 
-#: src/PrefsUnifiedDlg.cpp:2327
+#: src/PrefsUnifiedDlg.cpp:2407
 msgid "Server connection refresh interval: Disabled"
 msgstr "Інтервал оновлення з'єднання з сервером: вимкнено"
 
-#: src/PrefsUnifiedDlg.cpp:2371
+#: src/PrefsUnifiedDlg.cpp:2451
 msgid "disabled"
 msgstr "вимкнено"
 
-#: src/PrefsUnifiedDlg.cpp:2397
+#: src/PrefsUnifiedDlg.cpp:2477
 #, fuzzy, c-format
 msgid "Execute command on '%s' event"
 msgstr "Виконати команду на подію '%s'"
 
-#: src/PrefsUnifiedDlg.cpp:2404
+#: src/PrefsUnifiedDlg.cpp:2484
 msgid "Enable command execution on core"
 msgstr "Ввімкнути виконання команди в ядрі"
 
-#: src/PrefsUnifiedDlg.cpp:2416
+#: src/PrefsUnifiedDlg.cpp:2496
 msgid "Core command:"
 msgstr "Команда ядра:"
 
-#: src/PrefsUnifiedDlg.cpp:2432
+#: src/PrefsUnifiedDlg.cpp:2512
 msgid "Enable command execution on GUI"
 msgstr "Ввімкнути виконання команд в ГІК"
 
-#: src/PrefsUnifiedDlg.cpp:2444
+#: src/PrefsUnifiedDlg.cpp:2524
 msgid "GUI command:"
 msgstr "Команда ГІК:"
 
-#: src/PrefsUnifiedDlg.cpp:2460
+#: src/PrefsUnifiedDlg.cpp:2540
 msgid "The following variables will be replaced:"
 msgstr "Наступні змінні будуть замінені:"
 
-#: src/PrefsUnifiedDlg.cpp:2628
+#: src/PrefsUnifiedDlg.cpp:2708
 msgid ""
 "The following folders look like system or sensitive locations:\n"
 "\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2633
+#: src/PrefsUnifiedDlg.cpp:2713
 msgid "Sharing them recursively will publish every file underneath on the eD2k/Kad networks. Do you really want to do this?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2636
+#: src/PrefsUnifiedDlg.cpp:2716
 #, fuzzy
 msgid "Confirm shared folders"
 msgstr "Спільні теки"
 
-#: src/PrefsUnifiedDlg.cpp:2664
+#: src/PrefsUnifiedDlg.cpp:2744
 #, fuzzy
 msgid "Reloading shared files..."
 msgstr "Перезавантажити ваші спільні файли"
 
-#: src/PrefsUnifiedDlg.cpp:2665
+#: src/PrefsUnifiedDlg.cpp:2745
 msgid "Scanning for subdirectories..."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2666
+#: src/PrefsUnifiedDlg.cpp:2746
 #, fuzzy
 msgid "Updating shared folders"
 msgstr "Спільні теки"
 
-#: src/PrefsUnifiedDlg.cpp:2693
+#: src/PrefsUnifiedDlg.cpp:2773
 #, c-format
 msgid "Scanned %u directories..."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2743
+#: src/PrefsUnifiedDlg.cpp:2823
 #, fuzzy, c-format
 msgid "Reloading shared files: %u files scanned"
 msgstr "Перезавантажується перелік спільних файлів."
 
-#: src/PrefsUnifiedDlg.cpp:2793
+#: src/PrefsUnifiedDlg.cpp:2873
 #, fuzzy
 msgid "Shared folder"
 msgstr "Спільні теки"

--- a/po/vi.po
+++ b/po/vi.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-28 10:19+0200\n"
+"POT-Creation-Date: 2026-07-28 12:17+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: none\n"
@@ -188,152 +188,152 @@ msgstr ""
 msgid "WARNING: You can't add yourself as a source for an eD2k link while having a lowid."
 msgstr ""
 
-#: src/amule.cpp:300
+#: src/amule.cpp:301
 msgid "Now, exiting main app..."
 msgstr ""
 
-#: src/amule.cpp:330
+#: src/amule.cpp:331
 #, c-format
 msgid "Terminating amuleweb instance with pid '%d' ... "
 msgstr ""
 
-#: src/amule.cpp:334
+#: src/amule.cpp:335
 #, c-format
 msgid "Killing amuleweb instance with pid '%d' ... "
 msgstr ""
 
-#: src/amule.cpp:336 src/amule.cpp:349 src/ClientRef.cpp:180
+#: src/amule.cpp:337 src/amule.cpp:350 src/ClientRef.cpp:180
 #: src/SearchDlg.cpp:1041 src/ServerListCtrl.cpp:98
 msgid "Failed"
 msgstr ""
 
-#: src/amule.cpp:343
+#: src/amule.cpp:344
 #, c-format
 msgid "Terminating amuleapi instance with pid '%d' ... "
 msgstr ""
 
-#: src/amule.cpp:347
+#: src/amule.cpp:348
 #, c-format
 msgid "Killing amuleapi instance with pid '%d' ... "
 msgstr ""
 
-#: src/amule.cpp:355
+#: src/amule.cpp:356
 msgid "aMule OnExit: Terminating core."
 msgstr ""
 
-#: src/amule.cpp:466
+#: src/amule.cpp:467
 msgid "aMule shutdown completed."
 msgstr ""
 
-#: src/amule.cpp:470
+#: src/amule.cpp:471
 msgid "Memory debug results for aMule exit:"
 msgstr ""
 
-#: src/amule.cpp:651
+#: src/amule.cpp:652
 #, c-format
 msgid "Binding aMule's peer-to-peer traffic to interface: %s (HTTP updates use the default route)"
 msgstr ""
 
-#: src/amule.cpp:655
+#: src/amule.cpp:656
 #, c-format
 msgid "Binding all network traffic to interface: %s"
 msgstr ""
 
-#: src/amule.cpp:659
+#: src/amule.cpp:660
 #, c-format
 msgid "WARNING: configured network interface '%s' was not found - traffic is NOT bound to it and may leave via the default route. Check the interface name in Preferences."
 msgstr ""
 
-#: src/amule.cpp:665
+#: src/amule.cpp:666
 #, c-format
 msgid "WARNING: binding to network interface '%s' requires elevated privileges and was NOT applied - traffic may leave via the default route. Grant the capability (e.g. 'sudo setcap cap_net_raw+ep' on the aMule binary) or run with sufficient privileges."
 msgstr ""
 
-#: src/amule.cpp:673
+#: src/amule.cpp:674
 #, c-format
 msgid "WARNING: could not bind to network interface '%s' - traffic may leave via the default route."
 msgstr ""
 
-#: src/amule.cpp:732
+#: src/amule.cpp:733
 msgid "Your locale has been changed to System Default due to a configuration change. Sorry."
 msgstr ""
 
-#: src/amule.cpp:734 src/amule.cpp:1581 src/CatDialog.cpp:128
+#: src/amule.cpp:735 src/amule.cpp:1589 src/CatDialog.cpp:128
 #: src/CatDialog.cpp:136 src/CatDialog.cpp:149 src/ServerList.cpp:366
 #: src/ServerListCtrl.cpp:152
 msgid "Info"
 msgstr ""
 
-#: src/amule.cpp:741
+#: src/amule.cpp:742
 msgid ""
 "\n"
 "EC configuration"
 msgstr ""
 
-#: src/amule.cpp:744
+#: src/amule.cpp:745
 msgid "Password set and external connections enabled."
 msgstr ""
 
-#: src/amule.cpp:754 src/KadDlg.cpp:176 src/KadDlg.cpp:185
-#: src/PrefsUnifiedDlg.cpp:1387 src/SharedFilesCtrl.cpp:476
+#: src/amule.cpp:755 src/KadDlg.cpp:176 src/KadDlg.cpp:185
+#: src/PrefsUnifiedDlg.cpp:1461 src/SharedFilesCtrl.cpp:476
 msgid "WARNING"
 msgstr ""
 
-#: src/amule.cpp:991
+#: src/amule.cpp:992
 msgid "Network bootstrap"
 msgstr ""
 
-#: src/amule.cpp:996
+#: src/amule.cpp:997
 msgid ""
 "aMule has detected missing network bootstrap files.\n"
 "Select which ones to download:"
 msgstr ""
 
-#: src/amule.cpp:1005 src/FirstRunWizard.cpp:411
+#: src/amule.cpp:1006 src/FirstRunWizard.cpp:411
 msgid "eD2k server list (server.met)"
 msgstr ""
 
-#: src/amule.cpp:1012 src/FirstRunWizard.cpp:416
+#: src/amule.cpp:1013 src/FirstRunWizard.cpp:416
 msgid "Kad bootstrap nodes (nodes.dat)"
 msgstr ""
 
-#: src/amule.cpp:1102
+#: src/amule.cpp:1103
 #, c-format
 msgid "web server running on pid %d"
 msgstr ""
 
-#: src/amule.cpp:1115
+#: src/amule.cpp:1116
 msgid "You requested to run web server on startup, but the amuleweb binary cannot be run. Please install the package containing aMule web server, or build aMule from source with -DBUILD_WEBSERVER=YES and install it."
 msgstr ""
 
-#: src/amule.cpp:1120 src/amule.cpp:1177 src/amule.cpp:1291 src/amule.cpp:1593
+#: src/amule.cpp:1121 src/amule.cpp:1185 src/amule.cpp:1299 src/amule.cpp:1601
 #: src/amule-remote-gui.cpp:603 src/amule-remote-gui.cpp:671
 #: src/amule-remote-gui.cpp:709 src/amule-remote-gui.cpp:1282
 #: src/amule-remote-gui.cpp:1345 src/amule-remote-gui.cpp:1372
-#: src/DownloadQueue.cpp:1481
+#: src/DownloadQueue.cpp:1481 src/PrefsUnifiedDlg.cpp:1247
 msgid "ERROR"
 msgstr ""
 
-#: src/amule.cpp:1166
+#: src/amule.cpp:1174
 #, c-format
 msgid "amuleapi running on pid %d"
 msgstr ""
 
-#: src/amule.cpp:1172
+#: src/amule.cpp:1180
 msgid "You requested to run amuleapi on startup, but the amuleapi binary cannot be run. Please install the package containing aMule's REST API server, or build aMule from source with -DBUILD_AMULEAPI=YES and install it."
 msgstr ""
 
-#: src/amule.cpp:1259
+#: src/amule.cpp:1267
 #, c-format
 msgid "Could not bind ports to the specified address: %s"
 msgstr ""
 
-#: src/amule.cpp:1283
+#: src/amule.cpp:1291
 #, c-format
 msgid "Port %u is not available. You will be LOWID\n"
 msgstr ""
 
-#: src/amule.cpp:1288
+#: src/amule.cpp:1296
 #, c-format
 msgid ""
 "Port %u is not available!\n"
@@ -343,184 +343,184 @@ msgid ""
 "Check your network to make sure the port is open for output and input."
 msgstr ""
 
-#: src/amule.cpp:1385
+#: src/amule.cpp:1393
 msgid "Failed to create OnlineSig File"
 msgstr ""
 
-#: src/amule.cpp:1393
+#: src/amule.cpp:1401
 msgid "Failed to create aMule OnlineSig File"
 msgstr ""
 
-#: src/amule.cpp:1556
+#: src/amule.cpp:1564
 msgid "The selected locale seems not to be installed on your box. (Note: I'll try to set it anyway)"
 msgstr ""
 
-#: src/amule.cpp:1566
+#: src/amule.cpp:1574
 #, c-format
 msgid "This is the first time you run aMule %s"
 msgstr ""
 
-#: src/amule.cpp:1569
+#: src/amule.cpp:1577
 msgid "This version is a testing version, updated daily, and\n"
 msgstr ""
 
-#: src/amule.cpp:1570
+#: src/amule.cpp:1578
 msgid "we give no warranty it won't break anything, burn your house,\n"
 msgstr ""
 
-#: src/amule.cpp:1571
+#: src/amule.cpp:1579
 msgid "or kill your dog. But it *should* be safe to use anyway.\n"
 msgstr ""
 
-#: src/amule.cpp:1576
+#: src/amule.cpp:1584
 msgid "More information, support and new releases can found at our homepage,\n"
 msgstr ""
 
-#: src/amule.cpp:1577
+#: src/amule.cpp:1585
 msgid "at https://amule-org.github.io, or in our IRC channel #aMule at irc.libera.chat.\n"
 msgstr ""
 
-#: src/amule.cpp:1579
+#: src/amule.cpp:1587
 msgid "Feel free to report any bugs to https://github.com/amule-org/amule/issues"
 msgstr ""
 
-#: src/amule.cpp:1591
+#: src/amule.cpp:1599
 msgid ""
 "The folder for Online Signature files you specified is INVALID!\n"
 " OnlineSignature will be DISABLED until you fix it on preferences."
 msgstr ""
 
-#: src/amule.cpp:1654
+#: src/amule.cpp:1662
 msgid "Server hostname notified"
 msgstr ""
 
-#: src/amule.cpp:2031
+#: src/amule.cpp:2039
 #, c-format
 msgid "Disk space preallocation for file '%s' failed: %s"
 msgstr ""
 
-#: src/amule.cpp:2160
+#: src/amule.cpp:2168
 msgid "ERROR: can't open logfile"
 msgstr ""
 
-#: src/amule.cpp:2164
+#: src/amule.cpp:2172
 msgid "WARNING: logfile is empty. Something is wrong."
 msgstr ""
 
-#: src/amule.cpp:2181
+#: src/amule.cpp:2189
 msgid "Log has been reset"
 msgstr ""
 
-#: src/amule.cpp:2205
+#: src/amule.cpp:2213
 #, c-format
 msgid "ServerMessage: %s"
 msgstr ""
 
-#: src/amule.cpp:2248 src/IP2Country.cpp:220 src/IPFilter.cpp:514
+#: src/amule.cpp:2256 src/IP2Country.cpp:220 src/IPFilter.cpp:514
 #: src/ServerList.cpp:875
 #, c-format
 msgid "Skipped download of %s, because requested file is not newer."
 msgstr ""
 
-#: src/amule.cpp:2251
+#: src/amule.cpp:2259
 msgid "Failed to download the nodes list."
 msgstr ""
 
-#: src/amule.cpp:2314
+#: src/amule.cpp:2322
 msgid "Failed to open the downloaded version check file"
 msgstr ""
 
-#: src/amule.cpp:2317 src/amule.cpp:2336
+#: src/amule.cpp:2325 src/amule.cpp:2344
 msgid "Corrupted version check file"
 msgstr ""
 
-#: src/amule.cpp:2359
+#: src/amule.cpp:2367
 msgid "You are using an outdated version of aMule!"
 msgstr ""
 
-#: src/amule.cpp:2361
+#: src/amule.cpp:2369
 #, c-format
 msgid "Your aMule version is %i.%i.%i and the latest version is %li.%li.%li"
 msgstr ""
 
-#: src/amule.cpp:2365
+#: src/amule.cpp:2373
 msgid "The latest version can always be found at https://github.com/amule-org/amule/releases/latest"
 msgstr ""
 
-#: src/amule.cpp:2368
+#: src/amule.cpp:2376
 #, c-format
 msgid "WARNING: Your aMuled version is outdated: %i.%i.%i < %li.%li.%li"
 msgstr ""
 
-#: src/amule.cpp:2374
+#: src/amule.cpp:2382
 msgid "Your copy of aMule is up to date."
 msgstr ""
 
-#: src/amule.cpp:2381
+#: src/amule.cpp:2389
 msgid "Failed to download the version check file"
 msgstr ""
 
-#: src/amule.cpp:2550 src/amule-remote-gui.cpp:1133
+#: src/amule.cpp:2558 src/amule-remote-gui.cpp:1133
 #, c-format
 msgid "Users: %s | Files: %s"
 msgstr ""
 
-#: src/amule.cpp:2551 src/amule-remote-gui.cpp:1134
+#: src/amule.cpp:2559 src/amule-remote-gui.cpp:1134
 #, c-format
 msgid "Users: E: %s K: %s | Files: E: %s K: %s"
 msgstr ""
 
-#: src/amule.cpp:2565 src/amule-remote-gui.cpp:1147
+#: src/amule.cpp:2573 src/amule-remote-gui.cpp:1147
 msgid "No networks selected"
 msgstr ""
 
-#: src/amule.cpp:2633 src/TextClient.cpp:903
+#: src/amule.cpp:2641 src/TextClient.cpp:903
 msgid "with LowID"
 msgstr ""
 
-#: src/amule.cpp:2633 src/TextClient.cpp:904
+#: src/amule.cpp:2641 src/TextClient.cpp:904
 msgid "with HighID"
 msgstr ""
 
-#: src/amule.cpp:2635
+#: src/amule.cpp:2643
 #, c-format
 msgid "Connected to %s %s"
 msgstr ""
 
-#: src/amule.cpp:2640
+#: src/amule.cpp:2648
 #, c-format
 msgid "Connecting to %s"
 msgstr ""
 
-#: src/amule.cpp:2642
+#: src/amule.cpp:2650
 msgid "Disconnected from eD2k"
 msgstr ""
 
-#: src/amule.cpp:2651
+#: src/amule.cpp:2659
 msgid "Kad started."
 msgstr ""
 
-#: src/amule.cpp:2653
+#: src/amule.cpp:2661
 msgid "Kad stopped."
 msgstr ""
 
-#: src/amule.cpp:2661
+#: src/amule.cpp:2669
 msgid "Connected to Kad (ok)"
 msgstr ""
 
-#: src/amule.cpp:2663
+#: src/amule.cpp:2671
 msgid "Connected to Kad (firewalled)"
 msgstr ""
 
-#: src/amule.cpp:2667
+#: src/amule.cpp:2675
 msgid "Disconnected from Kad"
 msgstr ""
 
-#: src/amule.cpp:2699
+#: src/amule.cpp:2707
 msgid "Kad network cannot be used if UDP port is disabled on preferences, not starting."
 msgstr ""
 
-#: src/amule.cpp:2703
+#: src/amule.cpp:2711
 msgid "Kad network disabled on preferences, not connecting."
 msgstr ""
 
@@ -564,36 +564,36 @@ msgid "FATAL ERROR: Failed to create Timer"
 msgstr ""
 
 #: src/amuleDlg.cpp:361 src/amuleDlg.cpp:1787 src/amuleDlg.cpp:2033
-#: src/muuli_wdr.cpp:1492 src/muuli_wdr.cpp:3418
+#: src/muuli_wdr.cpp:1492 src/muuli_wdr.cpp:3449
 msgid "Networks"
 msgstr ""
 
-#: src/amuleDlg.cpp:362 src/amuleDlg.cpp:1793 src/muuli_wdr.cpp:3419
+#: src/amuleDlg.cpp:362 src/amuleDlg.cpp:1793 src/muuli_wdr.cpp:3450
 msgid "Searches"
 msgstr ""
 
 #: src/amuleDlg.cpp:363 src/amuleDlg.cpp:1799 src/DownloadListCtrl.cpp:740
-#: src/muuli_wdr.cpp:392 src/muuli_wdr.cpp:1585 src/muuli_wdr.cpp:3420
+#: src/muuli_wdr.cpp:392 src/muuli_wdr.cpp:1585 src/muuli_wdr.cpp:3451
 #: src/Statistics.cpp:829
 msgid "Downloads"
 msgstr ""
 
-#: src/amuleDlg.cpp:364 src/amuleDlg.cpp:1805 src/muuli_wdr.cpp:3294
+#: src/amuleDlg.cpp:364 src/amuleDlg.cpp:1805 src/muuli_wdr.cpp:3325
 msgid "Shared files"
 msgstr ""
 
-#: src/amuleDlg.cpp:365 src/amuleDlg.cpp:1811 src/muuli_wdr.cpp:2926
-#: src/muuli_wdr.cpp:3376 src/muuli_wdr.cpp:3423
+#: src/amuleDlg.cpp:365 src/amuleDlg.cpp:1811 src/muuli_wdr.cpp:2957
+#: src/muuli_wdr.cpp:3407 src/muuli_wdr.cpp:3454
 msgid "Messages"
 msgstr ""
 
-#: src/amuleDlg.cpp:366 src/amuleDlg.cpp:1817 src/muuli_wdr.cpp:3424
-#: src/PrefsUnifiedDlg.cpp:312 src/Statistics.cpp:779 src/Statistics.cpp:1235
+#: src/amuleDlg.cpp:366 src/amuleDlg.cpp:1817 src/muuli_wdr.cpp:3455
+#: src/PrefsUnifiedDlg.cpp:314 src/Statistics.cpp:779 src/Statistics.cpp:1235
 msgid "Statistics"
 msgstr ""
 
-#: src/amuleDlg.cpp:368 src/amuleDlg.cpp:1824 src/muuli_wdr.cpp:3426
-#: src/PrefsUnifiedDlg.cpp:328 src/utils/wxCas/src/wxcasprefs.cpp:39
+#: src/amuleDlg.cpp:368 src/amuleDlg.cpp:1824 src/muuli_wdr.cpp:3457
+#: src/PrefsUnifiedDlg.cpp:330 src/utils/wxCas/src/wxcasprefs.cpp:39
 msgid "Preferences"
 msgstr ""
 
@@ -650,8 +650,8 @@ msgstr ""
 #: src/amuleDlg.cpp:1029 src/DownloadListCtrl.cpp:505
 #: src/DownloadListCtrl.cpp:749 src/FriendListCtrl.cpp:180
 #: src/muuli_wdr.cpp:731 src/muuli_wdr.cpp:782 src/muuli_wdr.cpp:846
-#: src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2231 src/muuli_wdr.cpp:2316
-#: src/muuli_wdr.cpp:3064 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
+#: src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2262 src/muuli_wdr.cpp:2347
+#: src/muuli_wdr.cpp:3095 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
 #: src/ServerListCtrl.cpp:606 src/TransferWnd.cpp:378
 #: src/utils/wxCas/src/wxcasprefs.cpp:235
 msgid "Cancel"
@@ -662,7 +662,7 @@ msgid "Stop the current connection attempts"
 msgstr ""
 
 #: src/amuleDlg.cpp:1035 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976
-#: src/muuli_wdr.cpp:2454
+#: src/muuli_wdr.cpp:2485
 msgid "Disconnect"
 msgstr ""
 
@@ -671,7 +671,7 @@ msgid "Disconnect from the currently connected networks"
 msgstr ""
 
 #: src/amuleDlg.cpp:1041 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979
-#: src/muuli_wdr.cpp:2609 src/muuli_wdr.cpp:3061 src/muuli_wdr.cpp:3416
+#: src/muuli_wdr.cpp:2640 src/muuli_wdr.cpp:3092 src/muuli_wdr.cpp:3447
 msgid "Connect"
 msgstr ""
 
@@ -725,7 +725,7 @@ msgstr ""
 msgid "Launch Command: "
 msgstr ""
 
-#: src/amuleDlg.cpp:1632 src/muuli_wdr.cpp:1978 src/Preferences.cpp:952
+#: src/amuleDlg.cpp:1632 src/muuli_wdr.cpp:1982 src/Preferences.cpp:979
 msgid "- default -"
 msgstr ""
 
@@ -739,48 +739,48 @@ msgstr ""
 msgid "WARNING: Unable to open skin file '%s' for read"
 msgstr ""
 
-#: src/amuleDlg.cpp:1791 src/muuli_wdr.cpp:3418
+#: src/amuleDlg.cpp:1791 src/muuli_wdr.cpp:3449
 msgid "Networks Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1797 src/muuli_wdr.cpp:3419
+#: src/amuleDlg.cpp:1797 src/muuli_wdr.cpp:3450
 msgid "Searches Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1803 src/muuli_wdr.cpp:3420
+#: src/amuleDlg.cpp:1803 src/muuli_wdr.cpp:3451
 msgid "Downloads Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1809 src/muuli_wdr.cpp:3422
+#: src/amuleDlg.cpp:1809 src/muuli_wdr.cpp:3453
 msgid "Shared Files Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1815 src/muuli_wdr.cpp:3423
+#: src/amuleDlg.cpp:1815 src/muuli_wdr.cpp:3454
 msgid "Messages Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1821 src/muuli_wdr.cpp:3424
+#: src/amuleDlg.cpp:1821 src/muuli_wdr.cpp:3455
 msgid "Statistics Graph Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1828 src/muuli_wdr.cpp:3426
+#: src/amuleDlg.cpp:1828 src/muuli_wdr.cpp:3457
 msgid "Preferences Settings Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1831 src/muuli_wdr.cpp:3427
+#: src/amuleDlg.cpp:1831 src/muuli_wdr.cpp:3458
 msgid "Import"
 msgstr ""
 
-#: src/amuleDlg.cpp:1835 src/muuli_wdr.cpp:3427
+#: src/amuleDlg.cpp:1835 src/muuli_wdr.cpp:3458
 msgid "The partfile importer tool"
 msgstr ""
 
-#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3428
+#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3459
 #: src/utils/aLinkCreator/src/alcframe.cpp:262
 msgid "About"
 msgstr ""
 
-#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3428
+#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3459
 msgid "About/Help"
 msgstr ""
 
@@ -917,7 +917,7 @@ msgstr ""
 msgid "The core rejected these shared folders:%s"
 msgstr ""
 
-#: src/amule-remote-gui.cpp:1336 src/ExternalConn.cpp:2345
+#: src/amule-remote-gui.cpp:1336 src/ExternalConn.cpp:2346
 msgid "Invalid link or already on list."
 msgstr ""
 
@@ -933,7 +933,7 @@ msgstr ""
 #: src/ClientDetailDialog.cpp:123 src/DataToText.cpp:61 src/DataToText.cpp:86
 #: src/DataToText.cpp:101 src/DataToText.cpp:136 src/DataToText.cpp:165
 #: src/DownloadListCtrl.cpp:1172 src/DownloadListCtrl.cpp:1185
-#: src/DownloadListCtrl.cpp:1196 src/ExternalConn.cpp:608
+#: src/DownloadListCtrl.cpp:1196 src/ExternalConn.cpp:609
 #: src/FileDetailDialog.cpp:203 src/FileDetailDialog.cpp:235
 #: src/FileDetailDialog.cpp:242 src/GenericClientListCtrl.cpp:1171
 #: src/GenericClientListCtrl.cpp:1182 src/GenericClientListCtrl.cpp:1192
@@ -1319,19 +1319,19 @@ msgstr ""
 msgid "Very low"
 msgstr ""
 
-#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:743 src/muuli_wdr.cpp:2282
+#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:743 src/muuli_wdr.cpp:2313
 #: src/ServerListCtrl.cpp:263 src/ServerListCtrl.cpp:456
 #: src/SharedFilesCtrl.cpp:145
 msgid "Low"
 msgstr ""
 
-#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:744 src/muuli_wdr.cpp:2283
+#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:744 src/muuli_wdr.cpp:2314
 #: src/ServerListCtrl.cpp:266 src/ServerListCtrl.cpp:457
 #: src/SharedFilesCtrl.cpp:146
 msgid "Normal"
 msgstr ""
 
-#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:745 src/muuli_wdr.cpp:2284
+#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:745 src/muuli_wdr.cpp:2315
 #: src/ServerListCtrl.cpp:269 src/ServerListCtrl.cpp:458
 #: src/SharedFilesCtrl.cpp:147
 msgid "High"
@@ -1423,7 +1423,7 @@ msgstr ""
 msgid "Remote Server"
 msgstr ""
 
-#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3181
+#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3212
 #: src/SearchDlg.cpp:119 src/TextClient.cpp:911
 msgid "Kad"
 msgstr ""
@@ -1494,7 +1494,7 @@ msgstr ""
 msgid "Size"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3248
+#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3279
 msgid "Transferred"
 msgstr ""
 
@@ -1550,7 +1550,7 @@ msgid ""
 "\n"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:746 src/muuli_wdr.cpp:2285
+#: src/DownloadListCtrl.cpp:746 src/muuli_wdr.cpp:2316
 #: src/SharedFilesCtrl.cpp:150
 msgid "Auto"
 msgstr ""
@@ -1588,7 +1588,7 @@ msgid "Extended Options"
 msgstr ""
 
 #: src/DownloadListCtrl.cpp:770 src/DownloadListCtrl.cpp:822
-#: src/muuli_wdr.cpp:1796
+#: src/muuli_wdr.cpp:1800
 msgid "Preview"
 msgstr ""
 
@@ -1761,225 +1761,230 @@ msgstr[1] ""
 msgid "Invalid eD2k link! ERROR: %s"
 msgstr ""
 
-#: src/ExternalConn.cpp:379
+#: src/ExternalConn.cpp:380
 msgid "Client sent packet after authentication failed."
 msgstr ""
 
-#: src/ExternalConn.cpp:396
+#: src/ExternalConn.cpp:397
 msgid "External connection closed."
 msgstr ""
 
-#: src/ExternalConn.cpp:473
+#: src/ExternalConn.cpp:474
 msgid "External connections disabled due to empty password!"
 msgstr ""
 
-#: src/ExternalConn.cpp:494
+#: src/ExternalConn.cpp:495
 msgid "External connections disabled in config file"
 msgstr ""
 
-#: src/ExternalConn.cpp:575
+#: src/ExternalConn.cpp:576
 msgid "New external connection accepted"
 msgstr ""
 
-#: src/ExternalConn.cpp:578
+#: src/ExternalConn.cpp:579
 msgid "ERROR: couldn't accept a new external connection"
 msgstr ""
 
-#: src/ExternalConn.cpp:595
+#: src/ExternalConn.cpp:596
 msgid "External connection refused due to empty password in preferences!"
 msgstr ""
 
-#: src/ExternalConn.cpp:607
+#: src/ExternalConn.cpp:608
 #, c-format
 msgid "Connecting client: %s %s"
 msgstr ""
 
-#: src/ExternalConn.cpp:609
+#: src/ExternalConn.cpp:610
 msgid "Unknown version"
 msgstr ""
 
-#: src/ExternalConn.cpp:622
+#: src/ExternalConn.cpp:623
 msgid "Incorrect EC version ID, there might be binary incompatibility. Use core and remote from same snapshot."
 msgstr ""
 
-#: src/ExternalConn.cpp:630
+#: src/ExternalConn.cpp:631
 msgid "You cannot connect to a release version from an arbitrary development snapshot! *sigh* possible crash prevented"
 msgstr ""
 
-#: src/ExternalConn.cpp:713
+#: src/ExternalConn.cpp:714
 msgid "Invalid protocol version."
 msgstr ""
 
-#: src/ExternalConn.cpp:719
+#: src/ExternalConn.cpp:720
 msgid "Missing protocol version tag."
 msgstr ""
 
-#: src/ExternalConn.cpp:727
+#: src/ExternalConn.cpp:728
 msgid "Authentication failed: invalid hash specified as EC password."
 msgstr ""
 
-#: src/ExternalConn.cpp:775
+#: src/ExternalConn.cpp:776
 msgid "Authentication failed: wrong password."
 msgstr ""
 
-#: src/ExternalConn.cpp:777
+#: src/ExternalConn.cpp:778
 msgid "Authentication failed: missing password."
 msgstr ""
 
-#: src/ExternalConn.cpp:788
+#: src/ExternalConn.cpp:789
 msgid "Invalid request, please authenticate first."
 msgstr ""
 
-#: src/ExternalConn.cpp:793
+#: src/ExternalConn.cpp:794
 msgid "Access granted."
 msgstr ""
 
-#: src/ExternalConn.cpp:801
+#: src/ExternalConn.cpp:802
 #, c-format
 msgid "Sent error message \"%s\" to client."
 msgstr ""
 
-#: src/ExternalConn.cpp:806
+#: src/ExternalConn.cpp:807
 #, c-format
 msgid "Unauthorized access attempt from %s. Connection closed."
 msgstr ""
 
-#: src/ExternalConn.cpp:1419
+#: src/ExternalConn.cpp:1420
 #, c-format
 msgid "Remote PartFile command failed: FileHash not found: %s"
 msgstr ""
 
-#: src/ExternalConn.cpp:1423
+#: src/ExternalConn.cpp:1424
 #, c-format
 msgid "FileHash not found: %s"
 msgstr ""
 
-#: src/ExternalConn.cpp:1470 src/ExternalConn.cpp:1558
-#: src/ExternalConn.cpp:1679
+#: src/ExternalConn.cpp:1471 src/ExternalConn.cpp:1559
+#: src/ExternalConn.cpp:1680
 msgid "OOPS! OpCode processing error!"
 msgstr ""
 
-#: src/ExternalConn.cpp:1501
+#: src/ExternalConn.cpp:1502
 msgid "Server not added"
 msgstr ""
 
-#: src/ExternalConn.cpp:1520
+#: src/ExternalConn.cpp:1521
 #, c-format
 msgid "server not found: %s"
 msgstr ""
 
-#: src/ExternalConn.cpp:1537
+#: src/ExternalConn.cpp:1538
 msgid "need to define server to be removed"
 msgstr ""
 
-#: src/ExternalConn.cpp:1552
+#: src/ExternalConn.cpp:1553
 msgid "eD2k is disabled in preferences."
 msgstr ""
 
-#: src/ExternalConn.cpp:1657
+#: src/ExternalConn.cpp:1658
 msgid "Friend not found."
 msgstr ""
 
-#: src/ExternalConn.cpp:1667
+#: src/ExternalConn.cpp:1668
 msgid "Client not found."
 msgstr ""
 
-#: src/ExternalConn.cpp:1673
+#: src/ExternalConn.cpp:1674
 msgid "EC_TAG_FRIEND_SHARED requires EC_TAG_FRIEND or EC_TAG_CLIENT."
 msgstr ""
 
-#: src/ExternalConn.cpp:1991
+#: src/ExternalConn.cpp:1992
 msgid "WebSearch from remote interface makes no sense."
 msgstr ""
 
-#: src/ExternalConn.cpp:2026
+#: src/ExternalConn.cpp:2027
 msgid "Search in progress. Refetch results in a moment!"
 msgstr ""
 
-#: src/ExternalConn.cpp:2265
+#: src/ExternalConn.cpp:2266
 msgid "No points for graph."
 msgstr ""
 
-#: src/ExternalConn.cpp:2275
+#: src/ExternalConn.cpp:2276
 msgid "Your client is not configured for this detail level."
 msgstr ""
 
-#: src/ExternalConn.cpp:2302
+#: src/ExternalConn.cpp:2303
 msgid "External Connection: shutdown requested"
 msgstr ""
 
-#: src/ExternalConn.cpp:2314
+#: src/ExternalConn.cpp:2315
 msgid "Already shutting down."
 msgstr ""
 
-#: src/ExternalConn.cpp:2332
+#: src/ExternalConn.cpp:2333
 #, c-format
 msgid "ExternalConn: adding link '%s'."
 msgstr ""
 
-#: src/ExternalConn.cpp:2350
+#: src/ExternalConn.cpp:2351
 #, c-format
 msgid "%d of %d links failed (invalid or already on list)."
 msgstr ""
 
-#: src/ExternalConn.cpp:2373
+#: src/ExternalConn.cpp:2374
 msgid "Version check throttled; try again shortly."
 msgstr ""
 
-#: src/ExternalConn.cpp:2378
+#: src/ExternalConn.cpp:2379
 msgid "Version check is not available on this daemon."
 msgstr ""
 
-#: src/ExternalConn.cpp:2508
+#: src/ExternalConn.cpp:2509
 msgid "File not found."
 msgstr ""
 
-#: src/ExternalConn.cpp:2513
+#: src/ExternalConn.cpp:2514
 msgid "Invalid file name."
 msgstr ""
 
-#: src/ExternalConn.cpp:2521
+#: src/ExternalConn.cpp:2522
 msgid "Unable to rename file."
 msgstr ""
 
-#: src/ExternalConn.cpp:2992 src/ExternalConn.cpp:3020
+#: src/ExternalConn.cpp:2839
+#, c-format
+msgid "Could not save the amuleapi password: %s"
+msgstr ""
+
+#: src/ExternalConn.cpp:3004 src/ExternalConn.cpp:3032
 msgid "Kad is disabled in preferences."
 msgstr ""
 
-#: src/ExternalConn.cpp:3033
+#: src/ExternalConn.cpp:3045
 msgid "Already connected to eD2k."
 msgstr ""
 
-#: src/ExternalConn.cpp:3036
+#: src/ExternalConn.cpp:3048
 msgid "Connecting to eD2k..."
 msgstr ""
 
-#: src/ExternalConn.cpp:3045
+#: src/ExternalConn.cpp:3057
 msgid "Already connected to Kad."
 msgstr ""
 
-#: src/ExternalConn.cpp:3048
+#: src/ExternalConn.cpp:3060
 msgid "Connecting to Kad..."
 msgstr ""
 
-#: src/ExternalConn.cpp:3055
+#: src/ExternalConn.cpp:3067
 msgid "All networks are disabled."
 msgstr ""
 
-#: src/ExternalConn.cpp:3064
+#: src/ExternalConn.cpp:3076
 msgid "Disconnected from eD2k."
 msgstr ""
 
-#: src/ExternalConn.cpp:3069
+#: src/ExternalConn.cpp:3081
 msgid "Disconnected from Kad."
 msgstr ""
 
-#: src/ExternalConn.cpp:3078
+#: src/ExternalConn.cpp:3090
 #, c-format
 msgid "External Connection: invalid opcode received: %#x"
 msgstr ""
 
-#: src/ExternalConn.cpp:3083
+#: src/ExternalConn.cpp:3095
 msgid "Invalid opcode (wrong protocol version?)"
 msgstr ""
 
@@ -2349,23 +2354,23 @@ msgid ""
 "want downloads on a different (e.g. larger) disk."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:549 src/FirstRunWizard.cpp:611 src/muuli_wdr.cpp:1708
+#: src/FirstRunWizard.cpp:549 src/FirstRunWizard.cpp:611 src/muuli_wdr.cpp:1712
 msgid "Destination folder for downloads"
 msgstr ""
 
 #: src/FirstRunWizard.cpp:553 src/FirstRunWizard.cpp:569 src/muuli_wdr.cpp:1349
-#: src/muuli_wdr.cpp:1366 src/muuli_wdr.cpp:1683 src/muuli_wdr.cpp:1714
-#: src/muuli_wdr.cpp:1726 src/muuli_wdr.cpp:2769
+#: src/muuli_wdr.cpp:1366 src/muuli_wdr.cpp:1687 src/muuli_wdr.cpp:1718
+#: src/muuli_wdr.cpp:1730 src/muuli_wdr.cpp:2800
 #: src/utils/aLinkCreator/src/alcframe.cpp:135
 #: src/utils/wxCas/src/wxcasprefs.cpp:52 src/utils/wxCas/src/wxcasprefs.cpp:118
 msgid "Browse"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:559 src/muuli_wdr.cpp:1719
+#: src/FirstRunWizard.cpp:559 src/muuli_wdr.cpp:1723
 msgid "(All files in this folder are shared with other peers)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:565 src/FirstRunWizard.cpp:624 src/muuli_wdr.cpp:1721
+#: src/FirstRunWizard.cpp:565 src/FirstRunWizard.cpp:624 src/muuli_wdr.cpp:1725
 msgid "Folder for temporary download files"
 msgstr ""
 
@@ -2396,7 +2401,7 @@ msgstr ""
 msgid "CRITICAL - no client on StartChatSession"
 msgstr ""
 
-#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2675 src/muuli_wdr.cpp:3352
+#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2706 src/muuli_wdr.cpp:3383
 msgid "Friends"
 msgstr ""
 
@@ -2502,8 +2507,8 @@ msgstr ""
 msgid "No"
 msgstr ""
 
-#: src/GenericClientListCtrl.cpp:1216 src/PrefsUnifiedDlg.cpp:2818
-#: src/PrefsUnifiedDlg.cpp:2868 src/ServerListCtrl.cpp:276
+#: src/GenericClientListCtrl.cpp:1216 src/PrefsUnifiedDlg.cpp:2898
+#: src/PrefsUnifiedDlg.cpp:2948 src/ServerListCtrl.cpp:276
 msgid "Yes"
 msgstr ""
 
@@ -2670,10 +2675,10 @@ msgstr ""
 msgid "Please fill all fields required"
 msgstr ""
 
-#: src/KadDlg.cpp:192 src/PartFile.cpp:1031 src/PrefsUnifiedDlg.cpp:1162
-#: src/PrefsUnifiedDlg.cpp:1331 src/PrefsUnifiedDlg.cpp:1589
-#: src/PrefsUnifiedDlg.cpp:1599 src/PrefsUnifiedDlg.cpp:1616
-#: src/PrefsUnifiedDlg.cpp:1658
+#: src/KadDlg.cpp:192 src/PartFile.cpp:1031 src/PrefsUnifiedDlg.cpp:1134
+#: src/PrefsUnifiedDlg.cpp:1204 src/PrefsUnifiedDlg.cpp:1405
+#: src/PrefsUnifiedDlg.cpp:1663 src/PrefsUnifiedDlg.cpp:1673
+#: src/PrefsUnifiedDlg.cpp:1690 src/PrefsUnifiedDlg.cpp:1738
 msgid "Message"
 msgstr ""
 
@@ -2774,7 +2779,7 @@ msgstr ""
 msgid "Uploaded"
 msgstr ""
 
-#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3232
+#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3263
 msgid "Requested"
 msgstr ""
 
@@ -2897,7 +2902,7 @@ msgid "WARNING: "
 msgstr ""
 
 #: src/MuleNotebook.cpp:179 src/muuli_wdr.cpp:817 src/muuli_wdr.cpp:1229
-#: src/muuli_wdr.cpp:3136 src/muuli_wdr.cpp:3392
+#: src/muuli_wdr.cpp:3167 src/muuli_wdr.cpp:3423
 msgid "Close"
 msgstr ""
 
@@ -2915,7 +2920,7 @@ msgid "Paste"
 msgstr ""
 
 #: src/MuleTextCtrl.cpp:89 src/muuli_wdr.cpp:358 src/muuli_wdr.cpp:757
-#: src/muuli_wdr.cpp:2359 src/muuli_wdr.cpp:2378 src/muuli_wdr.cpp:2400
+#: src/muuli_wdr.cpp:2390 src/muuli_wdr.cpp:2409 src/muuli_wdr.cpp:2431
 #: src/utils/aLinkCreator/src/alcframe.cpp:142
 msgid "Clear"
 msgstr ""
@@ -3007,7 +3012,7 @@ msgstr ""
 
 #: src/MuleTrayIcon.cpp:579 src/MuleTrayIcon.cpp:945 src/MuleTrayIcon.cpp:965
 #: src/muuli_wdr.cpp:1398 src/muuli_wdr.cpp:1406 src/muuli_wdr.cpp:1413
-#: src/muuli_wdr.cpp:1842 src/muuli_wdr.cpp:1848 src/OtherFunctions.cpp:91
+#: src/muuli_wdr.cpp:1846 src/muuli_wdr.cpp:1852 src/OtherFunctions.cpp:91
 #: src/StatisticsDlg.cpp:93 src/StatisticsDlg.cpp:95
 msgid "kB/s"
 msgstr ""
@@ -3247,7 +3252,7 @@ msgstr ""
 msgid "KB"
 msgstr ""
 
-#: src/muuli_wdr.cpp:274 src/muuli_wdr.cpp:293 src/muuli_wdr.cpp:1627
+#: src/muuli_wdr.cpp:274 src/muuli_wdr.cpp:293 src/muuli_wdr.cpp:1631
 #: src/OtherFunctions.cpp:64
 msgid "MB"
 msgstr ""
@@ -3264,7 +3269,7 @@ msgstr ""
 msgid "Availability"
 msgstr ""
 
-#: src/muuli_wdr.cpp:312 src/muuli_wdr.cpp:398 src/muuli_wdr.cpp:3297
+#: src/muuli_wdr.cpp:312 src/muuli_wdr.cpp:398 src/muuli_wdr.cpp:3328
 msgid "Filter:"
 msgstr ""
 
@@ -3327,12 +3332,12 @@ msgstr ""
 #: src/muuli_wdr.cpp:1160 src/muuli_wdr.cpp:1167 src/muuli_wdr.cpp:1172
 #: src/muuli_wdr.cpp:1179 src/muuli_wdr.cpp:1184 src/muuli_wdr.cpp:1191
 #: src/muuli_wdr.cpp:1205 src/muuli_wdr.cpp:1212 src/muuli_wdr.cpp:1217
-#: src/muuli_wdr.cpp:1224 src/muuli_wdr.cpp:3234 src/muuli_wdr.cpp:3242
-#: src/muuli_wdr.cpp:3250
+#: src/muuli_wdr.cpp:1224 src/muuli_wdr.cpp:3265 src/muuli_wdr.cpp:3273
+#: src/muuli_wdr.cpp:3281
 msgid "N/A"
 msgstr ""
 
-#: src/muuli_wdr.cpp:508 src/muuli_wdr.cpp:1065 src/PrefsUnifiedDlg.cpp:297
+#: src/muuli_wdr.cpp:508 src/muuli_wdr.cpp:1065 src/PrefsUnifiedDlg.cpp:299
 msgid "General"
 msgstr ""
 
@@ -3468,7 +3473,7 @@ msgstr ""
 msgid "Album :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:685 src/muuli_wdr.cpp:2254
+#: src/muuli_wdr.cpp:685 src/muuli_wdr.cpp:2285
 msgid "Title :"
 msgstr ""
 
@@ -3574,7 +3579,7 @@ msgstr ""
 msgid "Userhash :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:895 src/muuli_wdr.cpp:1748 src/muuli_wdr.cpp:2449
+#: src/muuli_wdr.cpp:895 src/muuli_wdr.cpp:1752 src/muuli_wdr.cpp:2480
 #: src/utils/aLinkCreator/src/alcframe.cpp:137
 msgid "Add"
 msgstr ""
@@ -3583,15 +3588,15 @@ msgstr ""
 msgid "Download-Speed"
 msgstr ""
 
-#: src/muuli_wdr.cpp:954 src/muuli_wdr.cpp:989 src/muuli_wdr.cpp:2553
+#: src/muuli_wdr.cpp:954 src/muuli_wdr.cpp:989 src/muuli_wdr.cpp:2584
 msgid "Current"
 msgstr ""
 
-#: src/muuli_wdr.cpp:962 src/muuli_wdr.cpp:997 src/muuli_wdr.cpp:2561
+#: src/muuli_wdr.cpp:962 src/muuli_wdr.cpp:997 src/muuli_wdr.cpp:2592
 msgid "Running average"
 msgstr ""
 
-#: src/muuli_wdr.cpp:970 src/muuli_wdr.cpp:1005 src/muuli_wdr.cpp:2569
+#: src/muuli_wdr.cpp:970 src/muuli_wdr.cpp:1005 src/muuli_wdr.cpp:2600
 msgid "Session average"
 msgstr ""
 
@@ -3603,7 +3608,7 @@ msgstr ""
 msgid "Connections"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1024 src/muuli_wdr.cpp:1867
+#: src/muuli_wdr.cpp:1024 src/muuli_wdr.cpp:1871
 msgid "Active downloads"
 msgstr ""
 
@@ -3611,7 +3616,7 @@ msgstr ""
 msgid "Active connections (1:1)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1040 src/muuli_wdr.cpp:1868
+#: src/muuli_wdr.cpp:1040 src/muuli_wdr.cpp:1872
 msgid "Active uploads"
 msgstr ""
 
@@ -3884,7 +3889,7 @@ msgstr ""
 msgid "Advanced users only: If you have multiple network interfaces, enter the address of the interface to which aMule should be bound."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1462 src/muuli_wdr.cpp:2061
+#: src/muuli_wdr.cpp:1462 src/muuli_wdr.cpp:2065
 msgid "Bind to network interface (empty for any):"
 msgstr ""
 
@@ -3900,7 +3905,7 @@ msgstr ""
 msgid "Max simultaneous connections:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1498 src/muuli_wdr.cpp:3176
+#: src/muuli_wdr.cpp:1498 src/muuli_wdr.cpp:3207
 msgid "ED2K"
 msgstr ""
 
@@ -3992,743 +3997,763 @@ msgstr ""
 msgid "For new files preallocates disk space for the whole file, thus reduces fragmentation"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1613
+#: src/muuli_wdr.cpp:1617
 msgid "Create new files as sparse files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1614
-msgid "A sparse file reserves its full size on disk immediately without writing real data to it -- fast, but unsupported or slow on some filesystems, and free-space accounting stays optimistic while the download is in progress. Turn this off to grow the file only as data arrives."
+#: src/muuli_wdr.cpp:1618
+msgid "Sparse part files only occupy disk space for the parts already downloaded, so free space is used up gradually as the file fills in. Turn this off to use an ordinary file instead - useful where sparse files are unsupported or slow, or where backup/de-duplication tools handle them badly. Applies only when the core runs on Windows; on Linux and macOS part files are sparse anyway and this setting has no effect."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1619
+#: src/muuli_wdr.cpp:1623
 msgid "Stop downloads when free disk space reaches "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1620
+#: src/muuli_wdr.cpp:1624
 msgid "Select this if you want aMule to check your disk space"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1624
+#: src/muuli_wdr.cpp:1628
 msgid "Enter here the min disk space desired."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1630
+#: src/muuli_wdr.cpp:1634
 msgid "Save 10 sources on rare files (< 20 sources)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1634 src/Statistics.cpp:790
+#: src/muuli_wdr.cpp:1638 src/Statistics.cpp:790
 msgid "Uploads"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1637
+#: src/muuli_wdr.cpp:1641
 msgid "Add new shared files with auto priority"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1643
+#: src/muuli_wdr.cpp:1647
 msgid "Intelligent Corruption Handling (I.C.H.)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1646
+#: src/muuli_wdr.cpp:1650
 msgid "Enable"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1649
+#: src/muuli_wdr.cpp:1653
 msgid "Advanced I.C.H. trusts every hash (not recommended)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1661 src/PrefsUnifiedDlg.cpp:1910
+#: src/muuli_wdr.cpp:1665 src/PrefsUnifiedDlg.cpp:1990
 msgid "Media metadata extraction"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1665
+#: src/muuli_wdr.cpp:1669
 msgid "Extract length / bitrate / codec from shared audio and video files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1667
+#: src/muuli_wdr.cpp:1671
 msgid "When enabled, aMule runs ffprobe on each shared media file to fill in the Length / Bitrate / Codec columns other clients see when they find the file in a search. Requires ffmpeg (the ffprobe binary) to be installed."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1674
+#: src/muuli_wdr.cpp:1678
 msgid "Path to ffprobe:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1679
+#: src/muuli_wdr.cpp:1683
 msgid "Full path to the ffprobe binary. Leave empty to have aMule auto-detect it on startup."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1687
+#: src/muuli_wdr.cpp:1691
 msgid "Detect"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1688
+#: src/muuli_wdr.cpp:1692
 msgid "Search the standard install locations for an ffprobe binary and fill the path field."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1712
+#: src/muuli_wdr.cpp:1716
 msgid ""
 "Completed downloads are stored here. All files in this folder are automatically shared with other peers.\n"
 "If this folder also holds files you don't want to share, point it at an aMule-only sub-folder."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1715
+#: src/muuli_wdr.cpp:1719
 msgid "Pick the folder where completed downloads will be stored. All files in that folder will be shared with other peers."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1729
+#: src/muuli_wdr.cpp:1733
 msgid "Shared folders"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1735
+#: src/muuli_wdr.cpp:1739
 msgid "(Folders shared by the core. Enter a path to add one.)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1743
+#: src/muuli_wdr.cpp:1747
 msgid "Absolute path of a folder on the core's machine, e.g. /home/user/shared"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1745 src/PrefsUnifiedDlg.cpp:2794
+#: src/muuli_wdr.cpp:1749 src/PrefsUnifiedDlg.cpp:2874
 msgid "Recursive"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1746
+#: src/muuli_wdr.cpp:1750
 msgid "Share every sub-folder underneath this one, including ones created later."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1750 src/utils/aLinkCreator/src/alcframe.cpp:141
+#: src/muuli_wdr.cpp:1754 src/utils/aLinkCreator/src/alcframe.cpp:141
 msgid "Remove"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1754
+#: src/muuli_wdr.cpp:1758
 msgid "(Right click on folder icon for recursive share)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1761
+#: src/muuli_wdr.cpp:1765
 msgid "Share hidden files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1767
+#: src/muuli_wdr.cpp:1771
 msgid "Automatically rescan shared folders for changes"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1773
+#: src/muuli_wdr.cpp:1777
 msgid "Follow symbolic links in shared folders"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1779
+#: src/muuli_wdr.cpp:1783
 msgid "Exclude files matching:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1782
+#: src/muuli_wdr.cpp:1786
 msgid "Wildcard patterns separated by '|', e.g. .DS_Store|Thumbs.db|*.tmp. Files whose name matches are not shared. Matching is case-insensitive."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1786
+#: src/muuli_wdr.cpp:1790
 msgid "Patterns are regular expressions"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1787
+#: src/muuli_wdr.cpp:1791
 msgid "When set, the whole field is one regular expression ('|' is alternation). When unset, it is a list of '|'-separated wildcards."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1797
+#: src/muuli_wdr.cpp:1801
 msgid "Show how many shared files the current pattern would exclude."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1818
+#: src/muuli_wdr.cpp:1822
 msgid "Graphs"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1821 src/muuli_wdr.cpp:1883
+#: src/muuli_wdr.cpp:1825 src/muuli_wdr.cpp:1887
 msgid "Update delay : 5 secs"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1825
+#: src/muuli_wdr.cpp:1829
 msgid "Time for average graph: 100 mins"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1829
+#: src/muuli_wdr.cpp:1833
 msgid "Connections Graph Scale: 100 "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1836
+#: src/muuli_wdr.cpp:1840
 msgid "Download graph scale:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1844
+#: src/muuli_wdr.cpp:1848
 msgid "Upload graph scale:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1854
+#: src/muuli_wdr.cpp:1858
 msgid "Colors: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1858
+#: src/muuli_wdr.cpp:1862
 msgid "Background"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1859
+#: src/muuli_wdr.cpp:1863
 msgid "Grid"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1860
+#: src/muuli_wdr.cpp:1864
 msgid "Download current"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1861
+#: src/muuli_wdr.cpp:1865
 msgid "Download running average"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1862
+#: src/muuli_wdr.cpp:1866
 msgid "Download session average"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1863
+#: src/muuli_wdr.cpp:1867
 msgid "Upload current"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1864
+#: src/muuli_wdr.cpp:1868
 msgid "Upload running average"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1865
+#: src/muuli_wdr.cpp:1869
 msgid "Upload session average"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1866
+#: src/muuli_wdr.cpp:1870
 msgid "Active connections"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1869
+#: src/muuli_wdr.cpp:1873
 msgid "Systray Icon Speed Bar"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1870
+#: src/muuli_wdr.cpp:1874
 msgid "Kad-nodes current"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1871
+#: src/muuli_wdr.cpp:1875
 msgid "Kad-nodes running"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1872
+#: src/muuli_wdr.cpp:1876
 msgid "Kad-nodes session"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1876 src/muuli_wdr.cpp:2303
+#: src/muuli_wdr.cpp:1880 src/muuli_wdr.cpp:2334
 msgid "Select"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1880
+#: src/muuli_wdr.cpp:1884
 msgid "Tree"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1890
+#: src/muuli_wdr.cpp:1894
 msgid "Number of Client Versions shown (0=unlimited)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1915
+#: src/muuli_wdr.cpp:1919
 msgid "!!! WARNING !!!"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1930
+#: src/muuli_wdr.cpp:1934
 msgid "Max new connections / 5 secs"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1932
+#: src/muuli_wdr.cpp:1936
 msgid "Concurrent Kad source lookups"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1934
+#: src/muuli_wdr.cpp:1938
 msgid "Kad source re-search interval (minutes)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1936
+#: src/muuli_wdr.cpp:1940
 msgid "Source re-ask interval (minutes)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1940
+#: src/muuli_wdr.cpp:1944
 msgid "File Buffer Size: 240000 bytes"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1944
+#: src/muuli_wdr.cpp:1948
 msgid "Use MMAP: memory-mapped file access (lower memory use)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1945
+#: src/muuli_wdr.cpp:1949
 msgid "Maps part files into memory instead of buffering them on the heap, lowering the process memory footprint. May reduce download speed on some disks; best for memory-constrained or upload-heavy hosts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1947
+#: src/muuli_wdr.cpp:1951
 msgid "Upload Queue Size: 5000 clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1951
+#: src/muuli_wdr.cpp:1955
 msgid "Server connection refresh interval: Disable"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1955
+#: src/muuli_wdr.cpp:1959
 msgid "Disable computer's timed standby mode"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1974
+#: src/muuli_wdr.cpp:1978
 msgid "Skin to use: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1983
+#: src/muuli_wdr.cpp:1987
 msgid "Show \"Fast eD2k Links Handler\" in every window."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1986
+#: src/muuli_wdr.cpp:1990
 msgid "Show extended info on categories tabs"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1989
+#: src/muuli_wdr.cpp:1993
 msgid "Show application version on title"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1991
+#: src/muuli_wdr.cpp:1995
 msgid "Show transfer rates on title"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1993
+#: src/muuli_wdr.cpp:1997
 msgid "Before application name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1995
+#: src/muuli_wdr.cpp:1999
 msgid "After application name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1998
+#: src/muuli_wdr.cpp:2002
 msgid "Show overhead bandwidth"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2002
+#: src/muuli_wdr.cpp:2006
 msgid "Vertical toolbar orientation"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2004
+#: src/muuli_wdr.cpp:2008
 msgid "Live column sorting (auto-reorder rows as their values change)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2011
+#: src/muuli_wdr.cpp:2015
 msgid "Download Queue Files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2014
+#: src/muuli_wdr.cpp:2018
 msgid "Show progress percentage"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2020
+#: src/muuli_wdr.cpp:2024
 msgid "Show progress bar"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2023
+#: src/muuli_wdr.cpp:2027
 msgid "Flat"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2027
+#: src/muuli_wdr.cpp:2031
 msgid "Round"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2045
+#: src/muuli_wdr.cpp:2049
 msgid "External Connection Parameters"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2048
+#: src/muuli_wdr.cpp:2052
 msgid "Accept external connections"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2055 src/muuli_wdr.cpp:2114
+#: src/muuli_wdr.cpp:2059 src/muuli_wdr.cpp:2118
 msgid "IP of the listening interface:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2058
+#: src/muuli_wdr.cpp:2062
 msgid "Enter here a valid ip in the a.b.c.d format for the listening EC interface. An empty field or 0.0.0.0 will mean any interface."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2079 src/muuli_wdr.cpp:2163
+#: src/muuli_wdr.cpp:2083 src/muuli_wdr.cpp:2194
 msgid "TCP port:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2085
+#: src/muuli_wdr.cpp:2089
 msgid "Enable UPnP port forwarding on the EC port"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2089 src/muuli_wdr.cpp:3048
+#: src/muuli_wdr.cpp:2093 src/muuli_wdr.cpp:3079
 #: src/utils/wxCas/src/wxcasprefs.cpp:167
 msgid "Password"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2095
+#: src/muuli_wdr.cpp:2099
 msgid "aMule API server parameters"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2098
+#: src/muuli_wdr.cpp:2102
 msgid "Run amuleapi (REST API) on startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2103
+#: src/muuli_wdr.cpp:2107
 msgid "HTTP port:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2117
+#: src/muuli_wdr.cpp:2121
 msgid "The interface amuleapi's HTTP server listens on. 127.0.0.1 (default) accepts only local connections; use 0.0.0.0 or a specific IP to expose it to other hosts (set an admin password below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2120
+#: src/muuli_wdr.cpp:2126
+msgid "Type a password to set or change it. Stored passwords cannot be shown, so leaving this empty keeps the current one."
+msgstr ""
+
+#: src/muuli_wdr.cpp:2128
 msgid "Admin password"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2125 src/muuli_wdr.cpp:2156
-msgid "Low rights password"
+#: src/muuli_wdr.cpp:2140 src/muuli_wdr.cpp:2157 src/PrefsUnifiedDlg.cpp:1103
+msgid "A password is set."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2133
+#: src/muuli_wdr.cpp:2144
+msgid "Enable guest access"
+msgstr ""
+
+#: src/muuli_wdr.cpp:2145
+msgid "Guest sessions may read status and listings but cannot change anything. Turning this off clears the stored guest password."
+msgstr ""
+
+#: src/muuli_wdr.cpp:2149
+msgid "Guest password"
+msgstr ""
+
+#: src/muuli_wdr.cpp:2164
 msgid "Web server parameters"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2136
+#: src/muuli_wdr.cpp:2167
 msgid "Run webserver on startup (deprecated)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2142
+#: src/muuli_wdr.cpp:2173
 msgid "Web template"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2147
+#: src/muuli_wdr.cpp:2178
 msgid "Full rights password"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2151
+#: src/muuli_wdr.cpp:2182
 msgid "Enable Low rights User"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2170
+#: src/muuli_wdr.cpp:2187
+msgid "Low rights password"
+msgstr ""
+
+#: src/muuli_wdr.cpp:2201
 msgid "Enable UPnP port forwarding of the web server port"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2175
+#: src/muuli_wdr.cpp:2206
 msgid "Web server UPnP TCP port (Optional)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2183
+#: src/muuli_wdr.cpp:2214
 msgid "Page Refresh Time (in secs)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2190
+#: src/muuli_wdr.cpp:2221
 msgid "Enable Gzip compression"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2224
+#: src/muuli_wdr.cpp:2255
 msgid "Reset page to defaults"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2225
+#: src/muuli_wdr.cpp:2256
 msgid "Reset the settings on the current page to their default values."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2227 src/muuli_wdr.cpp:2313 src/ServerWnd.cpp:274
+#: src/muuli_wdr.cpp:2258 src/muuli_wdr.cpp:2344 src/ServerWnd.cpp:274
 #: src/ServerWnd.cpp:282
 msgid "OK"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2229
+#: src/muuli_wdr.cpp:2260
 msgid "Click here to apply any changes made to the preferences."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2232
+#: src/muuli_wdr.cpp:2263
 msgid "Reset any changes made to the preferences."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2261
+#: src/muuli_wdr.cpp:2292
 msgid "Comment :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2268
+#: src/muuli_wdr.cpp:2299
 msgid "Incoming Dir :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2277
+#: src/muuli_wdr.cpp:2308
 msgid "Change priority for new assigned files :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2281
+#: src/muuli_wdr.cpp:2312
 msgid "Don't change"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2293
+#: src/muuli_wdr.cpp:2324
 msgid "Select color for this Category (currently selected) :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2360 src/muuli_wdr.cpp:2379 src/muuli_wdr.cpp:2401
+#: src/muuli_wdr.cpp:2391 src/muuli_wdr.cpp:2410 src/muuli_wdr.cpp:2432
 msgid "Click this button to reset the log."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2420
+#: src/muuli_wdr.cpp:2451
 msgid "Click on this button to update the servers list from URL ..."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2424
+#: src/muuli_wdr.cpp:2455
 msgid "Server list"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2428
+#: src/muuli_wdr.cpp:2459
 msgid "Enter the url to a server.met file here and press the button to the left to update the list of known servers."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2433
+#: src/muuli_wdr.cpp:2464
 msgid "Add server manually: Name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2436
+#: src/muuli_wdr.cpp:2467
 msgid "Enter the name of the new server here"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2438 src/ServerWnd.cpp:206
+#: src/muuli_wdr.cpp:2469 src/ServerWnd.cpp:206
 msgid "IP:Port"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2441
+#: src/muuli_wdr.cpp:2472
 msgid "Enter the IP of the server here, using the x.x.x.x format."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2447
+#: src/muuli_wdr.cpp:2478
 msgid "Enter the port of the server here."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2450
+#: src/muuli_wdr.cpp:2481
 msgid "Add manually a server (fill fields to the left before) ..."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2479
+#: src/muuli_wdr.cpp:2510
 msgid "aMule Log"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2487
+#: src/muuli_wdr.cpp:2518
 msgid "Server Info"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2491
+#: src/muuli_wdr.cpp:2522
 msgid "ED2K Info"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2495
+#: src/muuli_wdr.cpp:2526
 msgid "Kad Info"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2523
+#: src/muuli_wdr.cpp:2554
 msgid "Click on this button to update the nodes list from URL ..."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2527
+#: src/muuli_wdr.cpp:2558
 msgid "Nodes (0)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2531
+#: src/muuli_wdr.cpp:2562
 msgid "Enter the url to a nodes.dat file here and press the button to the left to update the list of known nodes."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2534
+#: src/muuli_wdr.cpp:2565
 msgid "Nodes stats"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2576
+#: src/muuli_wdr.cpp:2607
 msgid "Bootstrap"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2579
+#: src/muuli_wdr.cpp:2610
 msgid "New node"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2584
+#: src/muuli_wdr.cpp:2615
 msgid "IP:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2604
+#: src/muuli_wdr.cpp:2635
 msgid "Port:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2617
+#: src/muuli_wdr.cpp:2648
 msgid "Bootstrap from known clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2619
+#: src/muuli_wdr.cpp:2650
 msgid "Disconnect Kad"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2653
+#: src/muuli_wdr.cpp:2684
 msgid "Use Secure User Identification"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2655
+#: src/muuli_wdr.cpp:2686
 msgid "It is recommended to enable this option. You will not receive credits if SUI is not enabled."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2657
+#: src/muuli_wdr.cpp:2688
 msgid "Protocol Obfuscation"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2660
+#: src/muuli_wdr.cpp:2691
 msgid "Support Protocol Obfuscation"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2662
+#: src/muuli_wdr.cpp:2693
 msgid "This option enabled Protocol Obfuscation, and makes aMule accept obfuscated connections from other clients."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2664
+#: src/muuli_wdr.cpp:2695
 msgid "Use obfuscation for outgoing connections"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2666
+#: src/muuli_wdr.cpp:2697
 msgid "This option makes aMule use Protocol Obfuscation when connecting other clients/servers."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2668
+#: src/muuli_wdr.cpp:2699
 msgid "Accept only obfuscated connections"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2669
+#: src/muuli_wdr.cpp:2700
 msgid "This option makes aMule only accept obfuscated connections. You will have less sources, but all your traffic will be obfuscated"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2674
+#: src/muuli_wdr.cpp:2705
 msgid "Everybody"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2676
+#: src/muuli_wdr.cpp:2707
 msgid "No one"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2678
+#: src/muuli_wdr.cpp:2709
 msgid "Who can see my shared files:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2679
+#: src/muuli_wdr.cpp:2710
 msgid "Select who can request to view a list of your shared files."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2681
+#: src/muuli_wdr.cpp:2712
 msgid "IP-Filtering"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2688
+#: src/muuli_wdr.cpp:2719
 msgid "Filter clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2690
+#: src/muuli_wdr.cpp:2721
 msgid "Enable filtering of the client IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2692
+#: src/muuli_wdr.cpp:2723
 msgid "Filter servers"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2694
+#: src/muuli_wdr.cpp:2725
 msgid "Enable filtering of the server IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2698
+#: src/muuli_wdr.cpp:2729
 msgid "Reload List"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2699
+#: src/muuli_wdr.cpp:2730
 msgid "Reload the list of IPs to filter from the file ~/.aMule/ipfilter.dat"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2705
+#: src/muuli_wdr.cpp:2736
 msgid "URL:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2709 src/muuli_wdr.cpp:2902
+#: src/muuli_wdr.cpp:2740 src/muuli_wdr.cpp:2933
 msgid "Update now"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2712
+#: src/muuli_wdr.cpp:2743
 msgid "Auto-update ipfilter at startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2716
+#: src/muuli_wdr.cpp:2747
 msgid "Filtering Level:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2722
+#: src/muuli_wdr.cpp:2753
 msgid "Always filter LAN IPs"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2725
+#: src/muuli_wdr.cpp:2756
 msgid "Paranoid handling of non-matching IPs"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2727
+#: src/muuli_wdr.cpp:2758
 msgid "Rejects a packet when its source IP differs from the IP the client claims (an anti-spoofing check). Disable only if it causes connection problems."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2729
+#: src/muuli_wdr.cpp:2760
 msgid "Use system-wide ipfilter.dat if available"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2730
+#: src/muuli_wdr.cpp:2761
 msgid "If there's no local ipfilter.dat found, allow usage of a system-wide ipfilter file."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2747
+#: src/muuli_wdr.cpp:2778
 msgid "Enable Online-Signature"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2749
+#: src/muuli_wdr.cpp:2780
 msgid "Enables the writing of the OS file, which can be used by external apps to create signatures and the like."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2753
+#: src/muuli_wdr.cpp:2784
 msgid "Update Frequency (Secs):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2756
+#: src/muuli_wdr.cpp:2787
 msgid "Change the frequency (in seconds) of Online Signature updates."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2764
+#: src/muuli_wdr.cpp:2795
 msgid "Save online signature file in: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:2770
+#: src/muuli_wdr.cpp:2801
 msgid "Click here to select the directory containing the the Online Signature files."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2803
+#: src/muuli_wdr.cpp:2834
 msgid "Show country flags for clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2804
+#: src/muuli_wdr.cpp:2835
 msgid "Render the country flag column in the transfers, queue and search views. Requires a valid MMDB GeoIP database (see below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2809
+#: src/muuli_wdr.cpp:2840
 msgid "Database"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2825
+#: src/muuli_wdr.cpp:2856
 msgid "Source:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2828
+#: src/muuli_wdr.cpp:2859
 msgid "DB-IP (free, no account)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2829
+#: src/muuli_wdr.cpp:2860
 msgid "MaxMind GeoLite2 (free, account required)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2830
+#: src/muuli_wdr.cpp:2861
 msgid "Custom URL"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2833
+#: src/muuli_wdr.cpp:2864
 msgid "Choose which provider supplies the GeoIP MMDB database. DB-IP is the default - no account required. MaxMind requires a free account + license key. Use Custom URL to point at any other MMDB host (e.g. a local mirror)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2850
+#: src/muuli_wdr.cpp:2881
 msgid ""
 "No configuration required.\n"
 "\n"
@@ -4736,11 +4761,11 @@ msgid ""
 "License: Creative Commons BY 4.0 - https://creativecommons.org/licenses/by/4.0/"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2863
+#: src/muuli_wdr.cpp:2894
 msgid "License key:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2869
+#: src/muuli_wdr.cpp:2900
 msgid ""
 "Sign up for a free MaxMind account, then generate a License Key:\n"
 "https://www.maxmind.com/en/geolite2/signup\n"
@@ -4750,222 +4775,222 @@ msgid ""
 "Requires attribution and account registration; refresh at least every 30 days."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2884
+#: src/muuli_wdr.cpp:2915
 msgid "Download URL:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2890
+#: src/muuli_wdr.cpp:2921
 msgid ""
 "Must point to an .mmdb file or a .gz / .tar.gz containing one.\n"
 "URL may include credentials (https://user:pass@host/...).\n"
 "License and attribution terms are set by the upstream URL - you are responsible."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2903
+#: src/muuli_wdr.cpp:2934
 msgid "Download the GeoIP database from the selected source."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2905
+#: src/muuli_wdr.cpp:2936
 msgid "Auto-update on startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2906
+#: src/muuli_wdr.cpp:2937
 msgid "Re-download the GeoIP database from the selected source every time aMule starts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2929
+#: src/muuli_wdr.cpp:2960
 msgid "Filter incoming messages (except current chat):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2931
+#: src/muuli_wdr.cpp:2962
 msgid "Filter all messages"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2933
+#: src/muuli_wdr.cpp:2964
 msgid "Filter messages from people not on your friend list"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2935
+#: src/muuli_wdr.cpp:2966
 msgid "Filter messages from unknown clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2937
+#: src/muuli_wdr.cpp:2968
 msgid "Filter messages containing (use ',' as separator):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2940 src/muuli_wdr.cpp:2951
+#: src/muuli_wdr.cpp:2971 src/muuli_wdr.cpp:2982
 msgid "add here the words amule should filter and block messages including it"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2942
+#: src/muuli_wdr.cpp:2973
 msgid "Show received messages in the log"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2945
+#: src/muuli_wdr.cpp:2976
 msgid "Comments"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2948
+#: src/muuli_wdr.cpp:2979
 msgid "Filter comments containing (use ',' as separator):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2973
+#: src/muuli_wdr.cpp:3004
 msgid "Enable Proxy"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2974
+#: src/muuli_wdr.cpp:3005
 msgid "Enable/disable proxy support"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2977
+#: src/muuli_wdr.cpp:3008
 msgid "Proxy type:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2988
+#: src/muuli_wdr.cpp:3019
 msgid "Proxy host:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2991
+#: src/muuli_wdr.cpp:3022
 msgid "The proxy host name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2993
+#: src/muuli_wdr.cpp:3024
 msgid "Proxy port:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2996
+#: src/muuli_wdr.cpp:3027
 msgid "The proxy port"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2998
+#: src/muuli_wdr.cpp:3029
 msgid "Enable authentication"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2999
+#: src/muuli_wdr.cpp:3030
 msgid "Enable/disable username/password authentication"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3002
+#: src/muuli_wdr.cpp:3033
 msgid "Username: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:3005
+#: src/muuli_wdr.cpp:3036
 msgid "The username to use to connect to the proxy"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3007
+#: src/muuli_wdr.cpp:3038
 msgid "Password:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3010
+#: src/muuli_wdr.cpp:3041
 msgid "The password to use to connect to the proxy"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3029
+#: src/muuli_wdr.cpp:3060
 msgid "Connect to:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3038
+#: src/muuli_wdr.cpp:3069
 msgid "Login to remote amule"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3043
+#: src/muuli_wdr.cpp:3074
 msgid "User name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3054
+#: src/muuli_wdr.cpp:3085
 msgid "Remember those settings"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3057
+#: src/muuli_wdr.cpp:3088
 msgid "Force ZLIB compression"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3081
+#: src/muuli_wdr.cpp:3112
 msgid "Enable Verbose Debug-Logging."
 msgstr ""
 
-#: src/muuli_wdr.cpp:3083
+#: src/muuli_wdr.cpp:3114
 msgid "Only to Logfile"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3085
+#: src/muuli_wdr.cpp:3116
 msgid "Message Categories:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3109 src/PartFileConvertDlg.cpp:160
+#: src/muuli_wdr.cpp:3140 src/PartFileConvertDlg.cpp:160
 msgid "Waiting..."
 msgstr ""
 
-#: src/muuli_wdr.cpp:3129
+#: src/muuli_wdr.cpp:3160
 msgid "Add imports"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3132
+#: src/muuli_wdr.cpp:3163
 msgid "Retry selected"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3134
+#: src/muuli_wdr.cpp:3165
 msgid "Remove selected"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3197
+#: src/muuli_wdr.cpp:3228
 msgid "Event Types"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3216
+#: src/muuli_wdr.cpp:3247
 msgid "Statistics and queued clients for selected file(s) : Session / All time"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3240
+#: src/muuli_wdr.cpp:3271
 msgid "Active Uploads"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3254
+#: src/muuli_wdr.cpp:3285
 msgid "Percent of total files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3306
+#: src/muuli_wdr.cpp:3337
 msgid "Show Clients for"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3308
+#: src/muuli_wdr.cpp:3339
 msgid "All files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3311
+#: src/muuli_wdr.cpp:3342
 msgid "Selected files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3314
+#: src/muuli_wdr.cpp:3345
 msgid "Active uploads only"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3321
+#: src/muuli_wdr.cpp:3352
 msgid "Reload:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3325
+#: src/muuli_wdr.cpp:3356
 msgid "Reload your shared files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3388
+#: src/muuli_wdr.cpp:3419
 msgid "Send"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3389
+#: src/muuli_wdr.cpp:3420
 msgid "Sends the specified message."
 msgstr ""
 
-#: src/muuli_wdr.cpp:3393
+#: src/muuli_wdr.cpp:3424
 msgid "Close this chat-session."
 msgstr ""
 
-#: src/muuli_wdr.cpp:3416
+#: src/muuli_wdr.cpp:3447
 msgid "Connect to any server and/or Kad"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3422 src/SharedFilesCtrl.cpp:142 src/Statistics.cpp:941
+#: src/muuli_wdr.cpp:3453 src/SharedFilesCtrl.cpp:142 src/Statistics.cpp:941
 msgid "Shared Files"
 msgstr ""
 
@@ -5323,263 +5348,263 @@ msgstr ""
 msgid "ERROR: Failed to open partfile '%s'"
 msgstr ""
 
-#: src/Preferences.cpp:674
+#: src/Preferences.cpp:701
 msgid "System default"
 msgstr ""
 
-#: src/Preferences.cpp:675
+#: src/Preferences.cpp:702
 msgid "Albanian"
 msgstr ""
 
-#: src/Preferences.cpp:676
+#: src/Preferences.cpp:703
 msgid "Arabic"
 msgstr ""
 
-#: src/Preferences.cpp:677
+#: src/Preferences.cpp:704
 msgid "Asturian"
 msgstr ""
 
-#: src/Preferences.cpp:678
+#: src/Preferences.cpp:705
 msgid "Basque"
 msgstr ""
 
-#: src/Preferences.cpp:679
+#: src/Preferences.cpp:706
 msgid "Bulgarian"
 msgstr ""
 
-#: src/Preferences.cpp:680
+#: src/Preferences.cpp:707
 msgid "Catalan"
 msgstr ""
 
-#: src/Preferences.cpp:681
+#: src/Preferences.cpp:708
 msgid "Chinese (Simplified)"
 msgstr ""
 
-#: src/Preferences.cpp:682
+#: src/Preferences.cpp:709
 msgid "Chinese (Traditional)"
 msgstr ""
 
-#: src/Preferences.cpp:683
+#: src/Preferences.cpp:710
 msgid "Croatian"
 msgstr ""
 
-#: src/Preferences.cpp:684
+#: src/Preferences.cpp:711
 msgid "Czech"
 msgstr ""
 
-#: src/Preferences.cpp:685
+#: src/Preferences.cpp:712
 msgid "Danish"
 msgstr ""
 
-#: src/Preferences.cpp:686
+#: src/Preferences.cpp:713
 msgid "Dutch"
 msgstr ""
 
-#: src/Preferences.cpp:687
+#: src/Preferences.cpp:714
 msgid "English (U.K.)"
 msgstr ""
 
-#: src/Preferences.cpp:688
+#: src/Preferences.cpp:715
 msgid "English (U.S.)"
 msgstr ""
 
-#: src/Preferences.cpp:689
+#: src/Preferences.cpp:716
 msgid "Estonian"
 msgstr ""
 
-#: src/Preferences.cpp:690
+#: src/Preferences.cpp:717
 msgid "Finnish"
 msgstr ""
 
-#: src/Preferences.cpp:691
+#: src/Preferences.cpp:718
 msgid "French"
 msgstr ""
 
-#: src/Preferences.cpp:692
+#: src/Preferences.cpp:719
 msgid "Galician"
 msgstr ""
 
-#: src/Preferences.cpp:693
+#: src/Preferences.cpp:720
 msgid "German"
 msgstr ""
 
-#: src/Preferences.cpp:694
+#: src/Preferences.cpp:721
 msgid "Greek"
 msgstr ""
 
-#: src/Preferences.cpp:695
+#: src/Preferences.cpp:722
 msgid "Hebrew"
 msgstr ""
 
-#: src/Preferences.cpp:696
+#: src/Preferences.cpp:723
 msgid "Hungarian"
 msgstr ""
 
-#: src/Preferences.cpp:697
+#: src/Preferences.cpp:724
 msgid "Italian"
 msgstr ""
 
-#: src/Preferences.cpp:698
+#: src/Preferences.cpp:725
 msgid "Japanese"
 msgstr ""
 
-#: src/Preferences.cpp:699
+#: src/Preferences.cpp:726
 msgid "Korean"
 msgstr ""
 
-#: src/Preferences.cpp:700
+#: src/Preferences.cpp:727
 msgid "Latvian"
 msgstr ""
 
-#: src/Preferences.cpp:701
+#: src/Preferences.cpp:728
 msgid "Lithuanian"
 msgstr ""
 
-#: src/Preferences.cpp:702
+#: src/Preferences.cpp:729
 msgid "Norwegian (Nynorsk)"
 msgstr ""
 
-#: src/Preferences.cpp:703
+#: src/Preferences.cpp:730
 msgid "Polish"
 msgstr ""
 
-#: src/Preferences.cpp:704
+#: src/Preferences.cpp:731
 msgid "Portuguese"
 msgstr ""
 
-#: src/Preferences.cpp:705
+#: src/Preferences.cpp:732
 msgid "Portuguese (Brazilian)"
 msgstr ""
 
-#: src/Preferences.cpp:706
+#: src/Preferences.cpp:733
 msgid "Romanian"
 msgstr ""
 
-#: src/Preferences.cpp:707
+#: src/Preferences.cpp:734
 msgid "Russian"
 msgstr ""
 
-#: src/Preferences.cpp:708
+#: src/Preferences.cpp:735
 msgid "Slovenian"
 msgstr ""
 
-#: src/Preferences.cpp:709
+#: src/Preferences.cpp:736
 msgid "Spanish"
 msgstr ""
 
-#: src/Preferences.cpp:710
+#: src/Preferences.cpp:737
 msgid "Swedish"
 msgstr ""
 
-#: src/Preferences.cpp:711
+#: src/Preferences.cpp:738
 msgid "Turkish"
 msgstr ""
 
-#: src/Preferences.cpp:712
+#: src/Preferences.cpp:739
 msgid "Ukrainian"
 msgstr ""
 
-#: src/Preferences.cpp:815
+#: src/Preferences.cpp:842
 msgid "Change Language"
 msgstr ""
 
-#: src/Preferences.cpp:879
+#: src/Preferences.cpp:906
 msgid "There are no translations installed for aMule"
 msgstr ""
 
-#: src/Preferences.cpp:880
+#: src/Preferences.cpp:907
 msgid "No languages available"
 msgstr ""
 
-#: src/Preferences.cpp:1011
+#: src/Preferences.cpp:1038
 msgid "no options available"
 msgstr ""
 
-#: src/Preferences.cpp:2182
+#: src/Preferences.cpp:2227
 msgid "Invalid category found, skipping"
 msgstr ""
 
-#: src/Preferences.cpp:2351
+#: src/Preferences.cpp:2396
 msgid "TCP port can't be higher than 65532 due to server UDP socket being TCP+3"
 msgstr ""
 
-#: src/Preferences.cpp:2352
+#: src/Preferences.cpp:2397
 #, c-format
 msgid "Default port will be used (%d)"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:298 src/Statistics.cpp:866
+#: src/PrefsUnifiedDlg.cpp:300 src/Statistics.cpp:866
 msgid "Connection"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:299 src/SearchListCtrl.cpp:117
+#: src/PrefsUnifiedDlg.cpp:301 src/SearchListCtrl.cpp:117
 msgid "Directories"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:300 src/Statistics.cpp:917
+#: src/PrefsUnifiedDlg.cpp:302 src/Statistics.cpp:917
 msgid "Servers"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:301 src/ServerListCtrl.cpp:96
+#: src/PrefsUnifiedDlg.cpp:303 src/ServerListCtrl.cpp:96
 msgid "Files"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:302
+#: src/PrefsUnifiedDlg.cpp:304
 msgid "Security"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:303
+#: src/PrefsUnifiedDlg.cpp:305
 msgid "Interface"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:310
+#: src/PrefsUnifiedDlg.cpp:312
 msgid "IP2Country"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:313
+#: src/PrefsUnifiedDlg.cpp:315
 msgid "Proxy"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:314
+#: src/PrefsUnifiedDlg.cpp:316
 msgid "Filters"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:315
+#: src/PrefsUnifiedDlg.cpp:317
 msgid "Remote Controls"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:316
+#: src/PrefsUnifiedDlg.cpp:318
 msgid "Online Signature"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:317
+#: src/PrefsUnifiedDlg.cpp:319
 msgid "Advanced"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:318
+#: src/PrefsUnifiedDlg.cpp:320
 msgid "Events"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:321
+#: src/PrefsUnifiedDlg.cpp:323
 msgid "Debugging"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:451
+#: src/PrefsUnifiedDlg.cpp:453
 msgid ""
 "The following variables will be substituted:\n"
 "    %PARTFILE - full path to the file\n"
 "    %PARTNAME - file name only"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:472
+#: src/PrefsUnifiedDlg.cpp:474
 msgid "Tray icon support requires libayatana-appindicator3 at compile time."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:488
+#: src/PrefsUnifiedDlg.cpp:490
 msgid "Not available on Wayland: the protocol does not report when a window is minimized, so this option cannot intercept the system minimize button. Workaround: launch aMule with `GDK_BACKEND=x11` to use XWayland instead."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:534
+#: src/PrefsUnifiedDlg.cpp:536
 msgid ""
 "Do not change these setting unless you know\n"
 "what you are doing, otherwise you can easily\n"
@@ -5589,387 +5614,400 @@ msgid ""
 "these settings."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:645
+#: src/PrefsUnifiedDlg.cpp:647
 #, c-format
 msgid "Failed to connect Cfg to widget with the ID %d and key %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:693
+#: src/PrefsUnifiedDlg.cpp:695
 #, c-format
 msgid "Failed to transfer data from Cfg to Widget with the ID %d and key %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:799
+#: src/PrefsUnifiedDlg.cpp:801
 msgid "The type of proxy you are connecting to"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1003
+#: src/PrefsUnifiedDlg.cpp:1020
 #, c-format
 msgid "Failed to transfer data from Widget to Cfg with the ID %d and key %s"
 msgstr ""
 
 #: src/PrefsUnifiedDlg.cpp:1103
+msgid "No password set."
+msgstr ""
+
+#: src/PrefsUnifiedDlg.cpp:1132
+msgid "Guest access needs a password. Type one in the guest password field, or untick Enable guest access."
+msgstr ""
+
+#: src/PrefsUnifiedDlg.cpp:1144
 msgid ""
 "aMule must be restarted to enable these changes:\n"
 "\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1110
+#: src/PrefsUnifiedDlg.cpp:1151
 msgid "- TCP port changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1115
+#: src/PrefsUnifiedDlg.cpp:1156
 msgid "- UDP port changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1120
+#: src/PrefsUnifiedDlg.cpp:1161
 msgid "- Network interface binding changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1125
+#: src/PrefsUnifiedDlg.cpp:1166
 msgid "- External connect port changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1129
+#: src/PrefsUnifiedDlg.cpp:1170
 msgid "- External connect acceptance changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1133
+#: src/PrefsUnifiedDlg.cpp:1174
 msgid "- External connect interface changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1137
+#: src/PrefsUnifiedDlg.cpp:1178
 msgid "- Protocol obfuscation support changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1151
+#: src/PrefsUnifiedDlg.cpp:1193
 msgid "- amuleapi settings changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1160
+#: src/PrefsUnifiedDlg.cpp:1202
 msgid ""
 "Your Auto-update server list is empty.\n"
 "'Auto-update server list at startup' will be disabled."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1171
+#: src/PrefsUnifiedDlg.cpp:1213
 msgid ""
 "You have enabled external connections but have not specified a password.\n"
 "External connections cannot be enabled unless a valid password is specified."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1202
+#: src/PrefsUnifiedDlg.cpp:1246
+#, c-format
+msgid "The amuleapi password could not be saved: %s"
+msgstr ""
+
+#: src/PrefsUnifiedDlg.cpp:1276
 msgid "- Language changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1207
+#: src/PrefsUnifiedDlg.cpp:1281
 msgid "- Temp folder changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1212
+#: src/PrefsUnifiedDlg.cpp:1286
 msgid "- ED2K network enabled.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1245
+#: src/PrefsUnifiedDlg.cpp:1319
 msgid "The shared-file exclusion pattern is not a valid regular expression. The filter has been left disabled."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1247 src/PrefsUnifiedDlg.cpp:1841
+#: src/PrefsUnifiedDlg.cpp:1321 src/PrefsUnifiedDlg.cpp:1921
 msgid "Invalid regular expression"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1324
+#: src/PrefsUnifiedDlg.cpp:1398
 msgid ""
 "Both eD2k and Kad network are disabled.\n"
 "You won't be able to connect until you enable at least one of them."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1329
+#: src/PrefsUnifiedDlg.cpp:1403
 msgid ""
 "Kad will not start if your UDP port is disabled.\n"
 "Enable UDP port or disable Kad."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1385
+#: src/PrefsUnifiedDlg.cpp:1459
 msgid ""
 "\n"
 "You MUST restart aMule now.\n"
 "If you do not restart now, don't complain if anything bad happens.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1450
+#: src/PrefsUnifiedDlg.cpp:1524
 msgid "Could not register aMule for autostart at login. The autostart store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1452
+#: src/PrefsUnifiedDlg.cpp:1526
 msgid "Could not remove the autostart-at-login entry."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1453
+#: src/PrefsUnifiedDlg.cpp:1527
 msgid "Autostart"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1468
+#: src/PrefsUnifiedDlg.cpp:1542
 msgid "Register file type"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1468
+#: src/PrefsUnifiedDlg.cpp:1542
 msgid "Register URL handler"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1476
+#: src/PrefsUnifiedDlg.cpp:1550
 #, c-format
 msgid "aMule only handles eD2k-compatible magnets. If you replace the current magnet handler (%s), BitTorrent magnet links will stop working - aMule cannot download BitTorrent content. Continue?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1481
+#: src/PrefsUnifiedDlg.cpp:1555
 #, c-format
 msgid "Another application currently opens .emulecollection files (%s). Replace it with aMule?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1486
+#: src/PrefsUnifiedDlg.cpp:1560
 #, c-format
 msgid "Another application is currently the default handler for these links (%s). Replace it with aMule?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1511
+#: src/PrefsUnifiedDlg.cpp:1585
 msgid "Could not register aMule for .emulecollection files. The registration store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1513
+#: src/PrefsUnifiedDlg.cpp:1587
 msgid "Could not remove the file type registration."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1515
+#: src/PrefsUnifiedDlg.cpp:1589
 msgid "Could not register aMule as the URL handler. The registration store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1517
+#: src/PrefsUnifiedDlg.cpp:1591
 msgid "Could not remove the URL handler registration."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1587 src/PrefsUnifiedDlg.cpp:1614
+#: src/PrefsUnifiedDlg.cpp:1661 src/PrefsUnifiedDlg.cpp:1688
 msgid "The web server and aMule API require external connections to be enabled."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1597
+#: src/PrefsUnifiedDlg.cpp:1671
 msgid "The aMule web server is deprecated. Consider running the aMule API instead."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1655
+#: src/PrefsUnifiedDlg.cpp:1735
 msgid ""
 "Your Auto-update servers list is in blank.\n"
 "Please fill in at least one URL to point to a valid server.met file.\n"
 "Click on the button \"List\" by this checkbox to enter an URL."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1796
+#: src/PrefsUnifiedDlg.cpp:1876
 msgid "Temporary files"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1801
+#: src/PrefsUnifiedDlg.cpp:1881
 msgid "Incoming files"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1806
+#: src/PrefsUnifiedDlg.cpp:1886
 msgid "Online Signatures"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1819
+#: src/PrefsUnifiedDlg.cpp:1899
 #, c-format
 msgid "Choose a folder for %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1843
+#: src/PrefsUnifiedDlg.cpp:1923
 #, c-format
 msgid "Would exclude %u of %u shared file"
 msgid_plural "Would exclude %u of %u shared files"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/PrefsUnifiedDlg.cpp:1860
+#: src/PrefsUnifiedDlg.cpp:1940
 msgid "Browse for videoplayer"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1864
+#: src/PrefsUnifiedDlg.cpp:1944
 msgid "Select browser"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1868
+#: src/PrefsUnifiedDlg.cpp:1948
 msgid "Select ffprobe binary"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1874
+#: src/PrefsUnifiedDlg.cpp:1954
 #, c-format
 msgid "Executable%s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1908
+#: src/PrefsUnifiedDlg.cpp:1988
 msgid "ffprobe not found on PATH or in the standard install locations. Install ffmpeg (which ships ffprobe) or use Browse to pick a binary manually."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1920
+#: src/PrefsUnifiedDlg.cpp:2000
 msgid "Reset the settings on this page to their default values?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1921
+#: src/PrefsUnifiedDlg.cpp:2001
 msgid "Reset to defaults"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1948
+#: src/PrefsUnifiedDlg.cpp:2028
 msgid "Edit server list"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1949
+#: src/PrefsUnifiedDlg.cpp:2029
 msgid ""
 "Add here URL's to download server.met files.\n"
 "Only one url on each line."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2004
+#: src/PrefsUnifiedDlg.cpp:2084
 msgid "IP2Country update failed"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2149 src/PrefsUnifiedDlg.cpp:2180
+#: src/PrefsUnifiedDlg.cpp:2229 src/PrefsUnifiedDlg.cpp:2260
 msgid "Data by MaxMind GeoLite2"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2151 src/PrefsUnifiedDlg.cpp:2182
+#: src/PrefsUnifiedDlg.cpp:2231 src/PrefsUnifiedDlg.cpp:2262
 msgid "Custom source"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2153 src/PrefsUnifiedDlg.cpp:2184
+#: src/PrefsUnifiedDlg.cpp:2233 src/PrefsUnifiedDlg.cpp:2264
 msgid "Data by DB-IP.com"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2204
+#: src/PrefsUnifiedDlg.cpp:2284
 #, c-format
 msgid "Status: Loaded%s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2206
+#: src/PrefsUnifiedDlg.cpp:2286
 #, c-format
 msgid "Status: Loaded%s - %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2210
+#: src/PrefsUnifiedDlg.cpp:2290
 msgid "Status: Failed to load - click 'Update now' to refresh."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2212
+#: src/PrefsUnifiedDlg.cpp:2292
 msgid "Status: Not found - click 'Update now' to download."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2270 src/PrefsUnifiedDlg.cpp:2294
+#: src/PrefsUnifiedDlg.cpp:2350 src/PrefsUnifiedDlg.cpp:2374
 #, c-format
 msgid "Update delay: %d second"
 msgid_plural "Update delay: %d seconds"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/PrefsUnifiedDlg.cpp:2278
+#: src/PrefsUnifiedDlg.cpp:2358
 #, c-format
 msgid "Time for average graph: %d minute"
 msgid_plural "Time for average graph: %d minutes"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/PrefsUnifiedDlg.cpp:2287
+#: src/PrefsUnifiedDlg.cpp:2367
 #, c-format
 msgid "Connections Graph Scale: %d"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2302
+#: src/PrefsUnifiedDlg.cpp:2382
 #, c-format
 msgid "File Buffer Size: %d byte"
 msgid_plural "File Buffer Size: %d bytes"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/PrefsUnifiedDlg.cpp:2312
+#: src/PrefsUnifiedDlg.cpp:2392
 #, c-format
 msgid "Upload Queue Size: %d client"
 msgid_plural "Upload Queue Size: %d clients"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/PrefsUnifiedDlg.cpp:2322
+#: src/PrefsUnifiedDlg.cpp:2402
 #, c-format
 msgid "Server connection refresh interval: %d minute"
 msgid_plural "Server connection refresh interval: %d minutes"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/PrefsUnifiedDlg.cpp:2327
+#: src/PrefsUnifiedDlg.cpp:2407
 msgid "Server connection refresh interval: Disabled"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2371
+#: src/PrefsUnifiedDlg.cpp:2451
 msgid "disabled"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2397
+#: src/PrefsUnifiedDlg.cpp:2477
 #, c-format
 msgid "Execute command on '%s' event"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2404
+#: src/PrefsUnifiedDlg.cpp:2484
 msgid "Enable command execution on core"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2416
+#: src/PrefsUnifiedDlg.cpp:2496
 msgid "Core command:"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2432
+#: src/PrefsUnifiedDlg.cpp:2512
 msgid "Enable command execution on GUI"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2444
+#: src/PrefsUnifiedDlg.cpp:2524
 msgid "GUI command:"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2460
+#: src/PrefsUnifiedDlg.cpp:2540
 msgid "The following variables will be replaced:"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2628
+#: src/PrefsUnifiedDlg.cpp:2708
 msgid ""
 "The following folders look like system or sensitive locations:\n"
 "\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2633
+#: src/PrefsUnifiedDlg.cpp:2713
 msgid "Sharing them recursively will publish every file underneath on the eD2k/Kad networks. Do you really want to do this?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2636
+#: src/PrefsUnifiedDlg.cpp:2716
 msgid "Confirm shared folders"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2664
+#: src/PrefsUnifiedDlg.cpp:2744
 msgid "Reloading shared files..."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2665
+#: src/PrefsUnifiedDlg.cpp:2745
 msgid "Scanning for subdirectories..."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2666
+#: src/PrefsUnifiedDlg.cpp:2746
 msgid "Updating shared folders"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2693
+#: src/PrefsUnifiedDlg.cpp:2773
 #, c-format
 msgid "Scanned %u directories..."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2743
+#: src/PrefsUnifiedDlg.cpp:2823
 #, c-format
 msgid "Reloading shared files: %u files scanned"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2793
+#: src/PrefsUnifiedDlg.cpp:2873
 msgid "Shared folder"
 msgstr ""
 

--- a/po/vi.po
+++ b/po/vi.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-28 12:17+0200\n"
+"POT-Creation-Date: 2026-07-28 13:09+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: none\n"
@@ -275,7 +275,7 @@ msgid "Password set and external connections enabled."
 msgstr ""
 
 #: src/amule.cpp:755 src/KadDlg.cpp:176 src/KadDlg.cpp:185
-#: src/PrefsUnifiedDlg.cpp:1461 src/SharedFilesCtrl.cpp:476
+#: src/PrefsUnifiedDlg.cpp:1470 src/SharedFilesCtrl.cpp:476
 msgid "WARNING"
 msgstr ""
 
@@ -310,7 +310,7 @@ msgstr ""
 #: src/amule-remote-gui.cpp:603 src/amule-remote-gui.cpp:671
 #: src/amule-remote-gui.cpp:709 src/amule-remote-gui.cpp:1282
 #: src/amule-remote-gui.cpp:1345 src/amule-remote-gui.cpp:1372
-#: src/DownloadQueue.cpp:1481 src/PrefsUnifiedDlg.cpp:1247
+#: src/DownloadQueue.cpp:1481 src/PrefsUnifiedDlg.cpp:1256
 msgid "ERROR"
 msgstr ""
 
@@ -563,36 +563,36 @@ msgstr ""
 msgid "FATAL ERROR: Failed to create Timer"
 msgstr ""
 
-#: src/amuleDlg.cpp:361 src/amuleDlg.cpp:1787 src/amuleDlg.cpp:2033
-#: src/muuli_wdr.cpp:1492 src/muuli_wdr.cpp:3449
+#: src/amuleDlg.cpp:361 src/amuleDlg.cpp:1810 src/amuleDlg.cpp:2056
+#: src/muuli_wdr.cpp:1492 src/muuli_wdr.cpp:3453
 msgid "Networks"
 msgstr ""
 
-#: src/amuleDlg.cpp:362 src/amuleDlg.cpp:1793 src/muuli_wdr.cpp:3450
+#: src/amuleDlg.cpp:362 src/amuleDlg.cpp:1816 src/muuli_wdr.cpp:3454
 msgid "Searches"
 msgstr ""
 
-#: src/amuleDlg.cpp:363 src/amuleDlg.cpp:1799 src/DownloadListCtrl.cpp:740
-#: src/muuli_wdr.cpp:392 src/muuli_wdr.cpp:1585 src/muuli_wdr.cpp:3451
+#: src/amuleDlg.cpp:363 src/amuleDlg.cpp:1822 src/DownloadListCtrl.cpp:740
+#: src/muuli_wdr.cpp:392 src/muuli_wdr.cpp:1585 src/muuli_wdr.cpp:3455
 #: src/Statistics.cpp:829
 msgid "Downloads"
 msgstr ""
 
-#: src/amuleDlg.cpp:364 src/amuleDlg.cpp:1805 src/muuli_wdr.cpp:3325
+#: src/amuleDlg.cpp:364 src/amuleDlg.cpp:1828 src/muuli_wdr.cpp:3329
 msgid "Shared files"
 msgstr ""
 
-#: src/amuleDlg.cpp:365 src/amuleDlg.cpp:1811 src/muuli_wdr.cpp:2957
-#: src/muuli_wdr.cpp:3407 src/muuli_wdr.cpp:3454
+#: src/amuleDlg.cpp:365 src/amuleDlg.cpp:1834 src/muuli_wdr.cpp:2961
+#: src/muuli_wdr.cpp:3411 src/muuli_wdr.cpp:3458
 msgid "Messages"
 msgstr ""
 
-#: src/amuleDlg.cpp:366 src/amuleDlg.cpp:1817 src/muuli_wdr.cpp:3455
+#: src/amuleDlg.cpp:366 src/amuleDlg.cpp:1840 src/muuli_wdr.cpp:3459
 #: src/PrefsUnifiedDlg.cpp:314 src/Statistics.cpp:779 src/Statistics.cpp:1235
 msgid "Statistics"
 msgstr ""
 
-#: src/amuleDlg.cpp:368 src/amuleDlg.cpp:1824 src/muuli_wdr.cpp:3457
+#: src/amuleDlg.cpp:368 src/amuleDlg.cpp:1847 src/muuli_wdr.cpp:3461
 #: src/PrefsUnifiedDlg.cpp:330 src/utils/wxCas/src/wxcasprefs.cpp:39
 msgid "Preferences"
 msgstr ""
@@ -650,8 +650,8 @@ msgstr ""
 #: src/amuleDlg.cpp:1029 src/DownloadListCtrl.cpp:505
 #: src/DownloadListCtrl.cpp:749 src/FriendListCtrl.cpp:180
 #: src/muuli_wdr.cpp:731 src/muuli_wdr.cpp:782 src/muuli_wdr.cpp:846
-#: src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2262 src/muuli_wdr.cpp:2347
-#: src/muuli_wdr.cpp:3095 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
+#: src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2266 src/muuli_wdr.cpp:2351
+#: src/muuli_wdr.cpp:3099 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
 #: src/ServerListCtrl.cpp:606 src/TransferWnd.cpp:378
 #: src/utils/wxCas/src/wxcasprefs.cpp:235
 msgid "Cancel"
@@ -662,7 +662,7 @@ msgid "Stop the current connection attempts"
 msgstr ""
 
 #: src/amuleDlg.cpp:1035 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976
-#: src/muuli_wdr.cpp:2485
+#: src/muuli_wdr.cpp:2489
 msgid "Disconnect"
 msgstr ""
 
@@ -671,7 +671,7 @@ msgid "Disconnect from the currently connected networks"
 msgstr ""
 
 #: src/amuleDlg.cpp:1041 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979
-#: src/muuli_wdr.cpp:2640 src/muuli_wdr.cpp:3092 src/muuli_wdr.cpp:3447
+#: src/muuli_wdr.cpp:2644 src/muuli_wdr.cpp:3096 src/muuli_wdr.cpp:3451
 msgid "Connect"
 msgstr ""
 
@@ -725,7 +725,7 @@ msgstr ""
 msgid "Launch Command: "
 msgstr ""
 
-#: src/amuleDlg.cpp:1632 src/muuli_wdr.cpp:1982 src/Preferences.cpp:979
+#: src/amuleDlg.cpp:1632 src/muuli_wdr.cpp:1986 src/Preferences.cpp:979
 msgid "- default -"
 msgstr ""
 
@@ -739,60 +739,60 @@ msgstr ""
 msgid "WARNING: Unable to open skin file '%s' for read"
 msgstr ""
 
-#: src/amuleDlg.cpp:1791 src/muuli_wdr.cpp:3449
+#: src/amuleDlg.cpp:1814 src/muuli_wdr.cpp:3453
 msgid "Networks Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1797 src/muuli_wdr.cpp:3450
+#: src/amuleDlg.cpp:1820 src/muuli_wdr.cpp:3454
 msgid "Searches Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1803 src/muuli_wdr.cpp:3451
+#: src/amuleDlg.cpp:1826 src/muuli_wdr.cpp:3455
 msgid "Downloads Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1809 src/muuli_wdr.cpp:3453
+#: src/amuleDlg.cpp:1832 src/muuli_wdr.cpp:3457
 msgid "Shared Files Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1815 src/muuli_wdr.cpp:3454
+#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3458
 msgid "Messages Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1821 src/muuli_wdr.cpp:3455
+#: src/amuleDlg.cpp:1844 src/muuli_wdr.cpp:3459
 msgid "Statistics Graph Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1828 src/muuli_wdr.cpp:3457
+#: src/amuleDlg.cpp:1851 src/muuli_wdr.cpp:3461
 msgid "Preferences Settings Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1831 src/muuli_wdr.cpp:3458
+#: src/amuleDlg.cpp:1854 src/muuli_wdr.cpp:3462
 msgid "Import"
 msgstr ""
 
-#: src/amuleDlg.cpp:1835 src/muuli_wdr.cpp:3458
+#: src/amuleDlg.cpp:1858 src/muuli_wdr.cpp:3462
 msgid "The partfile importer tool"
 msgstr ""
 
-#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3459
+#: src/amuleDlg.cpp:1861 src/muuli_wdr.cpp:3463
 #: src/utils/aLinkCreator/src/alcframe.cpp:262
 msgid "About"
 msgstr ""
 
-#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3459
+#: src/amuleDlg.cpp:1861 src/muuli_wdr.cpp:3463
 msgid "About/Help"
 msgstr ""
 
-#: src/amuleDlg.cpp:2036
+#: src/amuleDlg.cpp:2059
 msgid "eD2k network"
 msgstr ""
 
-#: src/amuleDlg.cpp:2039
+#: src/amuleDlg.cpp:2062
 msgid "Kad network"
 msgstr ""
 
-#: src/amuleDlg.cpp:2039
+#: src/amuleDlg.cpp:2062
 msgid "No network"
 msgstr ""
 
@@ -1319,19 +1319,19 @@ msgstr ""
 msgid "Very low"
 msgstr ""
 
-#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:743 src/muuli_wdr.cpp:2313
+#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:743 src/muuli_wdr.cpp:2317
 #: src/ServerListCtrl.cpp:263 src/ServerListCtrl.cpp:456
 #: src/SharedFilesCtrl.cpp:145
 msgid "Low"
 msgstr ""
 
-#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:744 src/muuli_wdr.cpp:2314
+#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:744 src/muuli_wdr.cpp:2318
 #: src/ServerListCtrl.cpp:266 src/ServerListCtrl.cpp:457
 #: src/SharedFilesCtrl.cpp:146
 msgid "Normal"
 msgstr ""
 
-#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:745 src/muuli_wdr.cpp:2315
+#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:745 src/muuli_wdr.cpp:2319
 #: src/ServerListCtrl.cpp:269 src/ServerListCtrl.cpp:458
 #: src/SharedFilesCtrl.cpp:147
 msgid "High"
@@ -1423,7 +1423,7 @@ msgstr ""
 msgid "Remote Server"
 msgstr ""
 
-#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3212
+#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3216
 #: src/SearchDlg.cpp:119 src/TextClient.cpp:911
 msgid "Kad"
 msgstr ""
@@ -1494,7 +1494,7 @@ msgstr ""
 msgid "Size"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3279
+#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3283
 msgid "Transferred"
 msgstr ""
 
@@ -1550,7 +1550,7 @@ msgid ""
 "\n"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:746 src/muuli_wdr.cpp:2316
+#: src/DownloadListCtrl.cpp:746 src/muuli_wdr.cpp:2320
 #: src/SharedFilesCtrl.cpp:150
 msgid "Auto"
 msgstr ""
@@ -1588,7 +1588,7 @@ msgid "Extended Options"
 msgstr ""
 
 #: src/DownloadListCtrl.cpp:770 src/DownloadListCtrl.cpp:822
-#: src/muuli_wdr.cpp:1800
+#: src/muuli_wdr.cpp:1804
 msgid "Preview"
 msgstr ""
 
@@ -2354,23 +2354,23 @@ msgid ""
 "want downloads on a different (e.g. larger) disk."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:549 src/FirstRunWizard.cpp:611 src/muuli_wdr.cpp:1712
+#: src/FirstRunWizard.cpp:549 src/FirstRunWizard.cpp:611 src/muuli_wdr.cpp:1716
 msgid "Destination folder for downloads"
 msgstr ""
 
 #: src/FirstRunWizard.cpp:553 src/FirstRunWizard.cpp:569 src/muuli_wdr.cpp:1349
-#: src/muuli_wdr.cpp:1366 src/muuli_wdr.cpp:1687 src/muuli_wdr.cpp:1718
-#: src/muuli_wdr.cpp:1730 src/muuli_wdr.cpp:2800
+#: src/muuli_wdr.cpp:1366 src/muuli_wdr.cpp:1691 src/muuli_wdr.cpp:1722
+#: src/muuli_wdr.cpp:1734 src/muuli_wdr.cpp:2804
 #: src/utils/aLinkCreator/src/alcframe.cpp:135
 #: src/utils/wxCas/src/wxcasprefs.cpp:52 src/utils/wxCas/src/wxcasprefs.cpp:118
 msgid "Browse"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:559 src/muuli_wdr.cpp:1723
+#: src/FirstRunWizard.cpp:559 src/muuli_wdr.cpp:1727
 msgid "(All files in this folder are shared with other peers)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:565 src/FirstRunWizard.cpp:624 src/muuli_wdr.cpp:1725
+#: src/FirstRunWizard.cpp:565 src/FirstRunWizard.cpp:624 src/muuli_wdr.cpp:1729
 msgid "Folder for temporary download files"
 msgstr ""
 
@@ -2401,7 +2401,7 @@ msgstr ""
 msgid "CRITICAL - no client on StartChatSession"
 msgstr ""
 
-#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2706 src/muuli_wdr.cpp:3383
+#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2710 src/muuli_wdr.cpp:3387
 msgid "Friends"
 msgstr ""
 
@@ -2507,8 +2507,8 @@ msgstr ""
 msgid "No"
 msgstr ""
 
-#: src/GenericClientListCtrl.cpp:1216 src/PrefsUnifiedDlg.cpp:2898
-#: src/PrefsUnifiedDlg.cpp:2948 src/ServerListCtrl.cpp:276
+#: src/GenericClientListCtrl.cpp:1216 src/PrefsUnifiedDlg.cpp:2907
+#: src/PrefsUnifiedDlg.cpp:2957 src/ServerListCtrl.cpp:276
 msgid "Yes"
 msgstr ""
 
@@ -2675,10 +2675,10 @@ msgstr ""
 msgid "Please fill all fields required"
 msgstr ""
 
-#: src/KadDlg.cpp:192 src/PartFile.cpp:1031 src/PrefsUnifiedDlg.cpp:1134
-#: src/PrefsUnifiedDlg.cpp:1204 src/PrefsUnifiedDlg.cpp:1405
-#: src/PrefsUnifiedDlg.cpp:1663 src/PrefsUnifiedDlg.cpp:1673
-#: src/PrefsUnifiedDlg.cpp:1690 src/PrefsUnifiedDlg.cpp:1738
+#: src/KadDlg.cpp:192 src/PartFile.cpp:1031 src/PrefsUnifiedDlg.cpp:1143
+#: src/PrefsUnifiedDlg.cpp:1213 src/PrefsUnifiedDlg.cpp:1414
+#: src/PrefsUnifiedDlg.cpp:1672 src/PrefsUnifiedDlg.cpp:1682
+#: src/PrefsUnifiedDlg.cpp:1699 src/PrefsUnifiedDlg.cpp:1747
 msgid "Message"
 msgstr ""
 
@@ -2779,7 +2779,7 @@ msgstr ""
 msgid "Uploaded"
 msgstr ""
 
-#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3263
+#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3267
 msgid "Requested"
 msgstr ""
 
@@ -2902,7 +2902,7 @@ msgid "WARNING: "
 msgstr ""
 
 #: src/MuleNotebook.cpp:179 src/muuli_wdr.cpp:817 src/muuli_wdr.cpp:1229
-#: src/muuli_wdr.cpp:3167 src/muuli_wdr.cpp:3423
+#: src/muuli_wdr.cpp:3171 src/muuli_wdr.cpp:3427
 msgid "Close"
 msgstr ""
 
@@ -2920,7 +2920,7 @@ msgid "Paste"
 msgstr ""
 
 #: src/MuleTextCtrl.cpp:89 src/muuli_wdr.cpp:358 src/muuli_wdr.cpp:757
-#: src/muuli_wdr.cpp:2390 src/muuli_wdr.cpp:2409 src/muuli_wdr.cpp:2431
+#: src/muuli_wdr.cpp:2394 src/muuli_wdr.cpp:2413 src/muuli_wdr.cpp:2435
 #: src/utils/aLinkCreator/src/alcframe.cpp:142
 msgid "Clear"
 msgstr ""
@@ -3012,7 +3012,7 @@ msgstr ""
 
 #: src/MuleTrayIcon.cpp:579 src/MuleTrayIcon.cpp:945 src/MuleTrayIcon.cpp:965
 #: src/muuli_wdr.cpp:1398 src/muuli_wdr.cpp:1406 src/muuli_wdr.cpp:1413
-#: src/muuli_wdr.cpp:1846 src/muuli_wdr.cpp:1852 src/OtherFunctions.cpp:91
+#: src/muuli_wdr.cpp:1850 src/muuli_wdr.cpp:1856 src/OtherFunctions.cpp:91
 #: src/StatisticsDlg.cpp:93 src/StatisticsDlg.cpp:95
 msgid "kB/s"
 msgstr ""
@@ -3252,7 +3252,7 @@ msgstr ""
 msgid "KB"
 msgstr ""
 
-#: src/muuli_wdr.cpp:274 src/muuli_wdr.cpp:293 src/muuli_wdr.cpp:1631
+#: src/muuli_wdr.cpp:274 src/muuli_wdr.cpp:293 src/muuli_wdr.cpp:1635
 #: src/OtherFunctions.cpp:64
 msgid "MB"
 msgstr ""
@@ -3269,7 +3269,7 @@ msgstr ""
 msgid "Availability"
 msgstr ""
 
-#: src/muuli_wdr.cpp:312 src/muuli_wdr.cpp:398 src/muuli_wdr.cpp:3328
+#: src/muuli_wdr.cpp:312 src/muuli_wdr.cpp:398 src/muuli_wdr.cpp:3332
 msgid "Filter:"
 msgstr ""
 
@@ -3332,8 +3332,8 @@ msgstr ""
 #: src/muuli_wdr.cpp:1160 src/muuli_wdr.cpp:1167 src/muuli_wdr.cpp:1172
 #: src/muuli_wdr.cpp:1179 src/muuli_wdr.cpp:1184 src/muuli_wdr.cpp:1191
 #: src/muuli_wdr.cpp:1205 src/muuli_wdr.cpp:1212 src/muuli_wdr.cpp:1217
-#: src/muuli_wdr.cpp:1224 src/muuli_wdr.cpp:3265 src/muuli_wdr.cpp:3273
-#: src/muuli_wdr.cpp:3281
+#: src/muuli_wdr.cpp:1224 src/muuli_wdr.cpp:3269 src/muuli_wdr.cpp:3277
+#: src/muuli_wdr.cpp:3285
 msgid "N/A"
 msgstr ""
 
@@ -3473,7 +3473,7 @@ msgstr ""
 msgid "Album :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:685 src/muuli_wdr.cpp:2285
+#: src/muuli_wdr.cpp:685 src/muuli_wdr.cpp:2289
 msgid "Title :"
 msgstr ""
 
@@ -3579,7 +3579,7 @@ msgstr ""
 msgid "Userhash :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:895 src/muuli_wdr.cpp:1752 src/muuli_wdr.cpp:2480
+#: src/muuli_wdr.cpp:895 src/muuli_wdr.cpp:1756 src/muuli_wdr.cpp:2484
 #: src/utils/aLinkCreator/src/alcframe.cpp:137
 msgid "Add"
 msgstr ""
@@ -3588,15 +3588,15 @@ msgstr ""
 msgid "Download-Speed"
 msgstr ""
 
-#: src/muuli_wdr.cpp:954 src/muuli_wdr.cpp:989 src/muuli_wdr.cpp:2584
+#: src/muuli_wdr.cpp:954 src/muuli_wdr.cpp:989 src/muuli_wdr.cpp:2588
 msgid "Current"
 msgstr ""
 
-#: src/muuli_wdr.cpp:962 src/muuli_wdr.cpp:997 src/muuli_wdr.cpp:2592
+#: src/muuli_wdr.cpp:962 src/muuli_wdr.cpp:997 src/muuli_wdr.cpp:2596
 msgid "Running average"
 msgstr ""
 
-#: src/muuli_wdr.cpp:970 src/muuli_wdr.cpp:1005 src/muuli_wdr.cpp:2600
+#: src/muuli_wdr.cpp:970 src/muuli_wdr.cpp:1005 src/muuli_wdr.cpp:2604
 msgid "Session average"
 msgstr ""
 
@@ -3608,7 +3608,7 @@ msgstr ""
 msgid "Connections"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1024 src/muuli_wdr.cpp:1871
+#: src/muuli_wdr.cpp:1024 src/muuli_wdr.cpp:1875
 msgid "Active downloads"
 msgstr ""
 
@@ -3616,7 +3616,7 @@ msgstr ""
 msgid "Active connections (1:1)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1040 src/muuli_wdr.cpp:1872
+#: src/muuli_wdr.cpp:1040 src/muuli_wdr.cpp:1876
 msgid "Active uploads"
 msgstr ""
 
@@ -3889,7 +3889,7 @@ msgstr ""
 msgid "Advanced users only: If you have multiple network interfaces, enter the address of the interface to which aMule should be bound."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1462 src/muuli_wdr.cpp:2065
+#: src/muuli_wdr.cpp:1462 src/muuli_wdr.cpp:2069
 msgid "Bind to network interface (empty for any):"
 msgstr ""
 
@@ -3905,7 +3905,7 @@ msgstr ""
 msgid "Max simultaneous connections:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1498 src/muuli_wdr.cpp:3207
+#: src/muuli_wdr.cpp:1498 src/muuli_wdr.cpp:3211
 msgid "ED2K"
 msgstr ""
 
@@ -3997,763 +3997,763 @@ msgstr ""
 msgid "For new files preallocates disk space for the whole file, thus reduces fragmentation"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1617
+#: src/muuli_wdr.cpp:1621
 msgid "Create new files as sparse files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1618
+#: src/muuli_wdr.cpp:1622
 msgid "Sparse part files only occupy disk space for the parts already downloaded, so free space is used up gradually as the file fills in. Turn this off to use an ordinary file instead - useful where sparse files are unsupported or slow, or where backup/de-duplication tools handle them badly. Applies only when the core runs on Windows; on Linux and macOS part files are sparse anyway and this setting has no effect."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1623
+#: src/muuli_wdr.cpp:1627
 msgid "Stop downloads when free disk space reaches "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1624
+#: src/muuli_wdr.cpp:1628
 msgid "Select this if you want aMule to check your disk space"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1628
+#: src/muuli_wdr.cpp:1632
 msgid "Enter here the min disk space desired."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1634
+#: src/muuli_wdr.cpp:1638
 msgid "Save 10 sources on rare files (< 20 sources)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1638 src/Statistics.cpp:790
+#: src/muuli_wdr.cpp:1642 src/Statistics.cpp:790
 msgid "Uploads"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1641
+#: src/muuli_wdr.cpp:1645
 msgid "Add new shared files with auto priority"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1647
+#: src/muuli_wdr.cpp:1651
 msgid "Intelligent Corruption Handling (I.C.H.)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1650
+#: src/muuli_wdr.cpp:1654
 msgid "Enable"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1653
+#: src/muuli_wdr.cpp:1657
 msgid "Advanced I.C.H. trusts every hash (not recommended)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1665 src/PrefsUnifiedDlg.cpp:1990
+#: src/muuli_wdr.cpp:1669 src/PrefsUnifiedDlg.cpp:1999
 msgid "Media metadata extraction"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1669
+#: src/muuli_wdr.cpp:1673
 msgid "Extract length / bitrate / codec from shared audio and video files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1671
+#: src/muuli_wdr.cpp:1675
 msgid "When enabled, aMule runs ffprobe on each shared media file to fill in the Length / Bitrate / Codec columns other clients see when they find the file in a search. Requires ffmpeg (the ffprobe binary) to be installed."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1678
+#: src/muuli_wdr.cpp:1682
 msgid "Path to ffprobe:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1683
+#: src/muuli_wdr.cpp:1687
 msgid "Full path to the ffprobe binary. Leave empty to have aMule auto-detect it on startup."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1691
+#: src/muuli_wdr.cpp:1695
 msgid "Detect"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1692
+#: src/muuli_wdr.cpp:1696
 msgid "Search the standard install locations for an ffprobe binary and fill the path field."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1716
+#: src/muuli_wdr.cpp:1720
 msgid ""
 "Completed downloads are stored here. All files in this folder are automatically shared with other peers.\n"
 "If this folder also holds files you don't want to share, point it at an aMule-only sub-folder."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1719
+#: src/muuli_wdr.cpp:1723
 msgid "Pick the folder where completed downloads will be stored. All files in that folder will be shared with other peers."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1733
+#: src/muuli_wdr.cpp:1737
 msgid "Shared folders"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1739
+#: src/muuli_wdr.cpp:1743
 msgid "(Folders shared by the core. Enter a path to add one.)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1747
+#: src/muuli_wdr.cpp:1751
 msgid "Absolute path of a folder on the core's machine, e.g. /home/user/shared"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1749 src/PrefsUnifiedDlg.cpp:2874
+#: src/muuli_wdr.cpp:1753 src/PrefsUnifiedDlg.cpp:2883
 msgid "Recursive"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1750
+#: src/muuli_wdr.cpp:1754
 msgid "Share every sub-folder underneath this one, including ones created later."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1754 src/utils/aLinkCreator/src/alcframe.cpp:141
+#: src/muuli_wdr.cpp:1758 src/utils/aLinkCreator/src/alcframe.cpp:141
 msgid "Remove"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1758
+#: src/muuli_wdr.cpp:1762
 msgid "(Right click on folder icon for recursive share)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1765
+#: src/muuli_wdr.cpp:1769
 msgid "Share hidden files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1771
+#: src/muuli_wdr.cpp:1775
 msgid "Automatically rescan shared folders for changes"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1777
+#: src/muuli_wdr.cpp:1781
 msgid "Follow symbolic links in shared folders"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1783
+#: src/muuli_wdr.cpp:1787
 msgid "Exclude files matching:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1786
+#: src/muuli_wdr.cpp:1790
 msgid "Wildcard patterns separated by '|', e.g. .DS_Store|Thumbs.db|*.tmp. Files whose name matches are not shared. Matching is case-insensitive."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1790
+#: src/muuli_wdr.cpp:1794
 msgid "Patterns are regular expressions"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1791
+#: src/muuli_wdr.cpp:1795
 msgid "When set, the whole field is one regular expression ('|' is alternation). When unset, it is a list of '|'-separated wildcards."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1801
+#: src/muuli_wdr.cpp:1805
 msgid "Show how many shared files the current pattern would exclude."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1822
+#: src/muuli_wdr.cpp:1826
 msgid "Graphs"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1825 src/muuli_wdr.cpp:1887
+#: src/muuli_wdr.cpp:1829 src/muuli_wdr.cpp:1891
 msgid "Update delay : 5 secs"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1829
+#: src/muuli_wdr.cpp:1833
 msgid "Time for average graph: 100 mins"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1833
+#: src/muuli_wdr.cpp:1837
 msgid "Connections Graph Scale: 100 "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1840
+#: src/muuli_wdr.cpp:1844
 msgid "Download graph scale:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1848
+#: src/muuli_wdr.cpp:1852
 msgid "Upload graph scale:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1858
+#: src/muuli_wdr.cpp:1862
 msgid "Colors: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1862
+#: src/muuli_wdr.cpp:1866
 msgid "Background"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1863
+#: src/muuli_wdr.cpp:1867
 msgid "Grid"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1864
+#: src/muuli_wdr.cpp:1868
 msgid "Download current"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1865
+#: src/muuli_wdr.cpp:1869
 msgid "Download running average"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1866
+#: src/muuli_wdr.cpp:1870
 msgid "Download session average"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1867
+#: src/muuli_wdr.cpp:1871
 msgid "Upload current"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1868
+#: src/muuli_wdr.cpp:1872
 msgid "Upload running average"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1869
+#: src/muuli_wdr.cpp:1873
 msgid "Upload session average"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1870
+#: src/muuli_wdr.cpp:1874
 msgid "Active connections"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1873
+#: src/muuli_wdr.cpp:1877
 msgid "Systray Icon Speed Bar"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1874
+#: src/muuli_wdr.cpp:1878
 msgid "Kad-nodes current"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1875
+#: src/muuli_wdr.cpp:1879
 msgid "Kad-nodes running"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1876
+#: src/muuli_wdr.cpp:1880
 msgid "Kad-nodes session"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1880 src/muuli_wdr.cpp:2334
+#: src/muuli_wdr.cpp:1884 src/muuli_wdr.cpp:2338
 msgid "Select"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1884
+#: src/muuli_wdr.cpp:1888
 msgid "Tree"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1894
+#: src/muuli_wdr.cpp:1898
 msgid "Number of Client Versions shown (0=unlimited)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1919
+#: src/muuli_wdr.cpp:1923
 msgid "!!! WARNING !!!"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1934
+#: src/muuli_wdr.cpp:1938
 msgid "Max new connections / 5 secs"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1936
+#: src/muuli_wdr.cpp:1940
 msgid "Concurrent Kad source lookups"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1938
+#: src/muuli_wdr.cpp:1942
 msgid "Kad source re-search interval (minutes)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1940
+#: src/muuli_wdr.cpp:1944
 msgid "Source re-ask interval (minutes)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1944
+#: src/muuli_wdr.cpp:1948
 msgid "File Buffer Size: 240000 bytes"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1948
+#: src/muuli_wdr.cpp:1952
 msgid "Use MMAP: memory-mapped file access (lower memory use)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1949
+#: src/muuli_wdr.cpp:1953
 msgid "Maps part files into memory instead of buffering them on the heap, lowering the process memory footprint. May reduce download speed on some disks; best for memory-constrained or upload-heavy hosts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1951
+#: src/muuli_wdr.cpp:1955
 msgid "Upload Queue Size: 5000 clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1955
+#: src/muuli_wdr.cpp:1959
 msgid "Server connection refresh interval: Disable"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1959
+#: src/muuli_wdr.cpp:1963
 msgid "Disable computer's timed standby mode"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1978
+#: src/muuli_wdr.cpp:1982
 msgid "Skin to use: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1987
+#: src/muuli_wdr.cpp:1991
 msgid "Show \"Fast eD2k Links Handler\" in every window."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1990
+#: src/muuli_wdr.cpp:1994
 msgid "Show extended info on categories tabs"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1993
+#: src/muuli_wdr.cpp:1997
 msgid "Show application version on title"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1995
+#: src/muuli_wdr.cpp:1999
 msgid "Show transfer rates on title"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1997
+#: src/muuli_wdr.cpp:2001
 msgid "Before application name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1999
+#: src/muuli_wdr.cpp:2003
 msgid "After application name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2002
+#: src/muuli_wdr.cpp:2006
 msgid "Show overhead bandwidth"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2006
+#: src/muuli_wdr.cpp:2010
 msgid "Vertical toolbar orientation"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2008
+#: src/muuli_wdr.cpp:2012
 msgid "Live column sorting (auto-reorder rows as their values change)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2015
+#: src/muuli_wdr.cpp:2019
 msgid "Download Queue Files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2018
+#: src/muuli_wdr.cpp:2022
 msgid "Show progress percentage"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2024
+#: src/muuli_wdr.cpp:2028
 msgid "Show progress bar"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2027
+#: src/muuli_wdr.cpp:2031
 msgid "Flat"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2031
+#: src/muuli_wdr.cpp:2035
 msgid "Round"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2049
+#: src/muuli_wdr.cpp:2053
 msgid "External Connection Parameters"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2052
+#: src/muuli_wdr.cpp:2056
 msgid "Accept external connections"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2059 src/muuli_wdr.cpp:2118
+#: src/muuli_wdr.cpp:2063 src/muuli_wdr.cpp:2122
 msgid "IP of the listening interface:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2062
+#: src/muuli_wdr.cpp:2066
 msgid "Enter here a valid ip in the a.b.c.d format for the listening EC interface. An empty field or 0.0.0.0 will mean any interface."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2083 src/muuli_wdr.cpp:2194
+#: src/muuli_wdr.cpp:2087 src/muuli_wdr.cpp:2198
 msgid "TCP port:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2089
+#: src/muuli_wdr.cpp:2093
 msgid "Enable UPnP port forwarding on the EC port"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2093 src/muuli_wdr.cpp:3079
+#: src/muuli_wdr.cpp:2097 src/muuli_wdr.cpp:3083
 #: src/utils/wxCas/src/wxcasprefs.cpp:167
 msgid "Password"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2099
+#: src/muuli_wdr.cpp:2103
 msgid "aMule API server parameters"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2102
+#: src/muuli_wdr.cpp:2106
 msgid "Run amuleapi (REST API) on startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2107
+#: src/muuli_wdr.cpp:2111
 msgid "HTTP port:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2121
+#: src/muuli_wdr.cpp:2125
 msgid "The interface amuleapi's HTTP server listens on. 127.0.0.1 (default) accepts only local connections; use 0.0.0.0 or a specific IP to expose it to other hosts (set an admin password below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2126
+#: src/muuli_wdr.cpp:2130
 msgid "Type a password to set or change it. Stored passwords cannot be shown, so leaving this empty keeps the current one."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2128
+#: src/muuli_wdr.cpp:2132
 msgid "Admin password"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2140 src/muuli_wdr.cpp:2157 src/PrefsUnifiedDlg.cpp:1103
+#: src/muuli_wdr.cpp:2144 src/muuli_wdr.cpp:2161 src/PrefsUnifiedDlg.cpp:1112
 msgid "A password is set."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2144
+#: src/muuli_wdr.cpp:2148
 msgid "Enable guest access"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2145
+#: src/muuli_wdr.cpp:2149
 msgid "Guest sessions may read status and listings but cannot change anything. Turning this off clears the stored guest password."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2149
+#: src/muuli_wdr.cpp:2153
 msgid "Guest password"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2164
+#: src/muuli_wdr.cpp:2168
 msgid "Web server parameters"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2167
+#: src/muuli_wdr.cpp:2171
 msgid "Run webserver on startup (deprecated)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2173
+#: src/muuli_wdr.cpp:2177
 msgid "Web template"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2178
+#: src/muuli_wdr.cpp:2182
 msgid "Full rights password"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2182
+#: src/muuli_wdr.cpp:2186
 msgid "Enable Low rights User"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2187
+#: src/muuli_wdr.cpp:2191
 msgid "Low rights password"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2201
+#: src/muuli_wdr.cpp:2205
 msgid "Enable UPnP port forwarding of the web server port"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2206
+#: src/muuli_wdr.cpp:2210
 msgid "Web server UPnP TCP port (Optional)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2214
+#: src/muuli_wdr.cpp:2218
 msgid "Page Refresh Time (in secs)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2221
+#: src/muuli_wdr.cpp:2225
 msgid "Enable Gzip compression"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2255
+#: src/muuli_wdr.cpp:2259
 msgid "Reset page to defaults"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2256
+#: src/muuli_wdr.cpp:2260
 msgid "Reset the settings on the current page to their default values."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2258 src/muuli_wdr.cpp:2344 src/ServerWnd.cpp:274
+#: src/muuli_wdr.cpp:2262 src/muuli_wdr.cpp:2348 src/ServerWnd.cpp:274
 #: src/ServerWnd.cpp:282
 msgid "OK"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2260
+#: src/muuli_wdr.cpp:2264
 msgid "Click here to apply any changes made to the preferences."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2263
+#: src/muuli_wdr.cpp:2267
 msgid "Reset any changes made to the preferences."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2292
+#: src/muuli_wdr.cpp:2296
 msgid "Comment :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2299
+#: src/muuli_wdr.cpp:2303
 msgid "Incoming Dir :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2308
+#: src/muuli_wdr.cpp:2312
 msgid "Change priority for new assigned files :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2312
+#: src/muuli_wdr.cpp:2316
 msgid "Don't change"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2324
+#: src/muuli_wdr.cpp:2328
 msgid "Select color for this Category (currently selected) :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2391 src/muuli_wdr.cpp:2410 src/muuli_wdr.cpp:2432
+#: src/muuli_wdr.cpp:2395 src/muuli_wdr.cpp:2414 src/muuli_wdr.cpp:2436
 msgid "Click this button to reset the log."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2451
+#: src/muuli_wdr.cpp:2455
 msgid "Click on this button to update the servers list from URL ..."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2455
+#: src/muuli_wdr.cpp:2459
 msgid "Server list"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2459
+#: src/muuli_wdr.cpp:2463
 msgid "Enter the url to a server.met file here and press the button to the left to update the list of known servers."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2464
+#: src/muuli_wdr.cpp:2468
 msgid "Add server manually: Name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2467
+#: src/muuli_wdr.cpp:2471
 msgid "Enter the name of the new server here"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2469 src/ServerWnd.cpp:206
+#: src/muuli_wdr.cpp:2473 src/ServerWnd.cpp:206
 msgid "IP:Port"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2472
+#: src/muuli_wdr.cpp:2476
 msgid "Enter the IP of the server here, using the x.x.x.x format."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2478
+#: src/muuli_wdr.cpp:2482
 msgid "Enter the port of the server here."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2481
+#: src/muuli_wdr.cpp:2485
 msgid "Add manually a server (fill fields to the left before) ..."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2510
+#: src/muuli_wdr.cpp:2514
 msgid "aMule Log"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2518
+#: src/muuli_wdr.cpp:2522
 msgid "Server Info"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2522
+#: src/muuli_wdr.cpp:2526
 msgid "ED2K Info"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2526
+#: src/muuli_wdr.cpp:2530
 msgid "Kad Info"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2554
+#: src/muuli_wdr.cpp:2558
 msgid "Click on this button to update the nodes list from URL ..."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2558
+#: src/muuli_wdr.cpp:2562
 msgid "Nodes (0)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2562
+#: src/muuli_wdr.cpp:2566
 msgid "Enter the url to a nodes.dat file here and press the button to the left to update the list of known nodes."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2565
+#: src/muuli_wdr.cpp:2569
 msgid "Nodes stats"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2607
+#: src/muuli_wdr.cpp:2611
 msgid "Bootstrap"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2610
+#: src/muuli_wdr.cpp:2614
 msgid "New node"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2615
+#: src/muuli_wdr.cpp:2619
 msgid "IP:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2635
+#: src/muuli_wdr.cpp:2639
 msgid "Port:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2648
+#: src/muuli_wdr.cpp:2652
 msgid "Bootstrap from known clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2650
+#: src/muuli_wdr.cpp:2654
 msgid "Disconnect Kad"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2684
+#: src/muuli_wdr.cpp:2688
 msgid "Use Secure User Identification"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2686
+#: src/muuli_wdr.cpp:2690
 msgid "It is recommended to enable this option. You will not receive credits if SUI is not enabled."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2688
+#: src/muuli_wdr.cpp:2692
 msgid "Protocol Obfuscation"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2691
+#: src/muuli_wdr.cpp:2695
 msgid "Support Protocol Obfuscation"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2693
+#: src/muuli_wdr.cpp:2697
 msgid "This option enabled Protocol Obfuscation, and makes aMule accept obfuscated connections from other clients."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2695
+#: src/muuli_wdr.cpp:2699
 msgid "Use obfuscation for outgoing connections"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2697
+#: src/muuli_wdr.cpp:2701
 msgid "This option makes aMule use Protocol Obfuscation when connecting other clients/servers."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2699
+#: src/muuli_wdr.cpp:2703
 msgid "Accept only obfuscated connections"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2700
+#: src/muuli_wdr.cpp:2704
 msgid "This option makes aMule only accept obfuscated connections. You will have less sources, but all your traffic will be obfuscated"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2705
+#: src/muuli_wdr.cpp:2709
 msgid "Everybody"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2707
+#: src/muuli_wdr.cpp:2711
 msgid "No one"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2709
+#: src/muuli_wdr.cpp:2713
 msgid "Who can see my shared files:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2710
+#: src/muuli_wdr.cpp:2714
 msgid "Select who can request to view a list of your shared files."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2712
+#: src/muuli_wdr.cpp:2716
 msgid "IP-Filtering"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2719
+#: src/muuli_wdr.cpp:2723
 msgid "Filter clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2721
+#: src/muuli_wdr.cpp:2725
 msgid "Enable filtering of the client IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2723
+#: src/muuli_wdr.cpp:2727
 msgid "Filter servers"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2725
+#: src/muuli_wdr.cpp:2729
 msgid "Enable filtering of the server IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2729
+#: src/muuli_wdr.cpp:2733
 msgid "Reload List"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2730
+#: src/muuli_wdr.cpp:2734
 msgid "Reload the list of IPs to filter from the file ~/.aMule/ipfilter.dat"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2736
+#: src/muuli_wdr.cpp:2740
 msgid "URL:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2740 src/muuli_wdr.cpp:2933
+#: src/muuli_wdr.cpp:2744 src/muuli_wdr.cpp:2937
 msgid "Update now"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2743
+#: src/muuli_wdr.cpp:2747
 msgid "Auto-update ipfilter at startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2747
+#: src/muuli_wdr.cpp:2751
 msgid "Filtering Level:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2753
+#: src/muuli_wdr.cpp:2757
 msgid "Always filter LAN IPs"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2756
+#: src/muuli_wdr.cpp:2760
 msgid "Paranoid handling of non-matching IPs"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2758
+#: src/muuli_wdr.cpp:2762
 msgid "Rejects a packet when its source IP differs from the IP the client claims (an anti-spoofing check). Disable only if it causes connection problems."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2760
+#: src/muuli_wdr.cpp:2764
 msgid "Use system-wide ipfilter.dat if available"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2761
+#: src/muuli_wdr.cpp:2765
 msgid "If there's no local ipfilter.dat found, allow usage of a system-wide ipfilter file."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2778
+#: src/muuli_wdr.cpp:2782
 msgid "Enable Online-Signature"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2780
+#: src/muuli_wdr.cpp:2784
 msgid "Enables the writing of the OS file, which can be used by external apps to create signatures and the like."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2784
+#: src/muuli_wdr.cpp:2788
 msgid "Update Frequency (Secs):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2787
+#: src/muuli_wdr.cpp:2791
 msgid "Change the frequency (in seconds) of Online Signature updates."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2795
+#: src/muuli_wdr.cpp:2799
 msgid "Save online signature file in: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:2801
+#: src/muuli_wdr.cpp:2805
 msgid "Click here to select the directory containing the the Online Signature files."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2834
+#: src/muuli_wdr.cpp:2838
 msgid "Show country flags for clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2835
+#: src/muuli_wdr.cpp:2839
 msgid "Render the country flag column in the transfers, queue and search views. Requires a valid MMDB GeoIP database (see below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2840
+#: src/muuli_wdr.cpp:2844
 msgid "Database"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2856
+#: src/muuli_wdr.cpp:2860
 msgid "Source:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2859
+#: src/muuli_wdr.cpp:2863
 msgid "DB-IP (free, no account)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2860
+#: src/muuli_wdr.cpp:2864
 msgid "MaxMind GeoLite2 (free, account required)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2861
+#: src/muuli_wdr.cpp:2865
 msgid "Custom URL"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2864
+#: src/muuli_wdr.cpp:2868
 msgid "Choose which provider supplies the GeoIP MMDB database. DB-IP is the default - no account required. MaxMind requires a free account + license key. Use Custom URL to point at any other MMDB host (e.g. a local mirror)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2881
+#: src/muuli_wdr.cpp:2885
 msgid ""
 "No configuration required.\n"
 "\n"
@@ -4761,11 +4761,11 @@ msgid ""
 "License: Creative Commons BY 4.0 - https://creativecommons.org/licenses/by/4.0/"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2894
+#: src/muuli_wdr.cpp:2898
 msgid "License key:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2900
+#: src/muuli_wdr.cpp:2904
 msgid ""
 "Sign up for a free MaxMind account, then generate a License Key:\n"
 "https://www.maxmind.com/en/geolite2/signup\n"
@@ -4775,222 +4775,222 @@ msgid ""
 "Requires attribution and account registration; refresh at least every 30 days."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2915
+#: src/muuli_wdr.cpp:2919
 msgid "Download URL:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2921
+#: src/muuli_wdr.cpp:2925
 msgid ""
 "Must point to an .mmdb file or a .gz / .tar.gz containing one.\n"
 "URL may include credentials (https://user:pass@host/...).\n"
 "License and attribution terms are set by the upstream URL - you are responsible."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2934
+#: src/muuli_wdr.cpp:2938
 msgid "Download the GeoIP database from the selected source."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2936
+#: src/muuli_wdr.cpp:2940
 msgid "Auto-update on startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2937
+#: src/muuli_wdr.cpp:2941
 msgid "Re-download the GeoIP database from the selected source every time aMule starts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2960
+#: src/muuli_wdr.cpp:2964
 msgid "Filter incoming messages (except current chat):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2962
+#: src/muuli_wdr.cpp:2966
 msgid "Filter all messages"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2964
+#: src/muuli_wdr.cpp:2968
 msgid "Filter messages from people not on your friend list"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2966
+#: src/muuli_wdr.cpp:2970
 msgid "Filter messages from unknown clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2968
+#: src/muuli_wdr.cpp:2972
 msgid "Filter messages containing (use ',' as separator):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2971 src/muuli_wdr.cpp:2982
+#: src/muuli_wdr.cpp:2975 src/muuli_wdr.cpp:2986
 msgid "add here the words amule should filter and block messages including it"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2973
+#: src/muuli_wdr.cpp:2977
 msgid "Show received messages in the log"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2976
+#: src/muuli_wdr.cpp:2980
 msgid "Comments"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2979
+#: src/muuli_wdr.cpp:2983
 msgid "Filter comments containing (use ',' as separator):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3004
+#: src/muuli_wdr.cpp:3008
 msgid "Enable Proxy"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3005
+#: src/muuli_wdr.cpp:3009
 msgid "Enable/disable proxy support"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3008
+#: src/muuli_wdr.cpp:3012
 msgid "Proxy type:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3019
+#: src/muuli_wdr.cpp:3023
 msgid "Proxy host:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3022
+#: src/muuli_wdr.cpp:3026
 msgid "The proxy host name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3024
+#: src/muuli_wdr.cpp:3028
 msgid "Proxy port:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3027
+#: src/muuli_wdr.cpp:3031
 msgid "The proxy port"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3029
+#: src/muuli_wdr.cpp:3033
 msgid "Enable authentication"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3030
+#: src/muuli_wdr.cpp:3034
 msgid "Enable/disable username/password authentication"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3033
+#: src/muuli_wdr.cpp:3037
 msgid "Username: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:3036
+#: src/muuli_wdr.cpp:3040
 msgid "The username to use to connect to the proxy"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3038
+#: src/muuli_wdr.cpp:3042
 msgid "Password:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3041
+#: src/muuli_wdr.cpp:3045
 msgid "The password to use to connect to the proxy"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3060
+#: src/muuli_wdr.cpp:3064
 msgid "Connect to:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3069
+#: src/muuli_wdr.cpp:3073
 msgid "Login to remote amule"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3074
+#: src/muuli_wdr.cpp:3078
 msgid "User name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3085
+#: src/muuli_wdr.cpp:3089
 msgid "Remember those settings"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3088
+#: src/muuli_wdr.cpp:3092
 msgid "Force ZLIB compression"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3112
+#: src/muuli_wdr.cpp:3116
 msgid "Enable Verbose Debug-Logging."
 msgstr ""
 
-#: src/muuli_wdr.cpp:3114
+#: src/muuli_wdr.cpp:3118
 msgid "Only to Logfile"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3116
+#: src/muuli_wdr.cpp:3120
 msgid "Message Categories:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3140 src/PartFileConvertDlg.cpp:160
+#: src/muuli_wdr.cpp:3144 src/PartFileConvertDlg.cpp:160
 msgid "Waiting..."
 msgstr ""
 
-#: src/muuli_wdr.cpp:3160
+#: src/muuli_wdr.cpp:3164
 msgid "Add imports"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3163
+#: src/muuli_wdr.cpp:3167
 msgid "Retry selected"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3165
+#: src/muuli_wdr.cpp:3169
 msgid "Remove selected"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3228
+#: src/muuli_wdr.cpp:3232
 msgid "Event Types"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3247
+#: src/muuli_wdr.cpp:3251
 msgid "Statistics and queued clients for selected file(s) : Session / All time"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3271
+#: src/muuli_wdr.cpp:3275
 msgid "Active Uploads"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3285
+#: src/muuli_wdr.cpp:3289
 msgid "Percent of total files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3337
+#: src/muuli_wdr.cpp:3341
 msgid "Show Clients for"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3339
+#: src/muuli_wdr.cpp:3343
 msgid "All files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3342
+#: src/muuli_wdr.cpp:3346
 msgid "Selected files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3345
+#: src/muuli_wdr.cpp:3349
 msgid "Active uploads only"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3352
+#: src/muuli_wdr.cpp:3356
 msgid "Reload:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3356
+#: src/muuli_wdr.cpp:3360
 msgid "Reload your shared files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3419
+#: src/muuli_wdr.cpp:3423
 msgid "Send"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3420
+#: src/muuli_wdr.cpp:3424
 msgid "Sends the specified message."
 msgstr ""
 
-#: src/muuli_wdr.cpp:3424
+#: src/muuli_wdr.cpp:3428
 msgid "Close this chat-session."
 msgstr ""
 
-#: src/muuli_wdr.cpp:3447
+#: src/muuli_wdr.cpp:3451
 msgid "Connect to any server and/or Kad"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3453 src/SharedFilesCtrl.cpp:142 src/Statistics.cpp:941
+#: src/muuli_wdr.cpp:3457 src/SharedFilesCtrl.cpp:142 src/Statistics.cpp:941
 msgid "Shared Files"
 msgstr ""
 
@@ -5614,400 +5614,400 @@ msgid ""
 "these settings."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:647
+#: src/PrefsUnifiedDlg.cpp:656
 #, c-format
 msgid "Failed to connect Cfg to widget with the ID %d and key %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:695
+#: src/PrefsUnifiedDlg.cpp:704
 #, c-format
 msgid "Failed to transfer data from Cfg to Widget with the ID %d and key %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:801
+#: src/PrefsUnifiedDlg.cpp:810
 msgid "The type of proxy you are connecting to"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1020
+#: src/PrefsUnifiedDlg.cpp:1029
 #, c-format
 msgid "Failed to transfer data from Widget to Cfg with the ID %d and key %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1103
+#: src/PrefsUnifiedDlg.cpp:1112
 msgid "No password set."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1132
+#: src/PrefsUnifiedDlg.cpp:1141
 msgid "Guest access needs a password. Type one in the guest password field, or untick Enable guest access."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1144
+#: src/PrefsUnifiedDlg.cpp:1153
 msgid ""
 "aMule must be restarted to enable these changes:\n"
 "\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1151
+#: src/PrefsUnifiedDlg.cpp:1160
 msgid "- TCP port changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1156
+#: src/PrefsUnifiedDlg.cpp:1165
 msgid "- UDP port changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1161
+#: src/PrefsUnifiedDlg.cpp:1170
 msgid "- Network interface binding changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1166
+#: src/PrefsUnifiedDlg.cpp:1175
 msgid "- External connect port changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1170
+#: src/PrefsUnifiedDlg.cpp:1179
 msgid "- External connect acceptance changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1174
+#: src/PrefsUnifiedDlg.cpp:1183
 msgid "- External connect interface changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1178
+#: src/PrefsUnifiedDlg.cpp:1187
 msgid "- Protocol obfuscation support changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1193
+#: src/PrefsUnifiedDlg.cpp:1202
 msgid "- amuleapi settings changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1202
+#: src/PrefsUnifiedDlg.cpp:1211
 msgid ""
 "Your Auto-update server list is empty.\n"
 "'Auto-update server list at startup' will be disabled."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1213
+#: src/PrefsUnifiedDlg.cpp:1222
 msgid ""
 "You have enabled external connections but have not specified a password.\n"
 "External connections cannot be enabled unless a valid password is specified."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1246
+#: src/PrefsUnifiedDlg.cpp:1255
 #, c-format
 msgid "The amuleapi password could not be saved: %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1276
+#: src/PrefsUnifiedDlg.cpp:1285
 msgid "- Language changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1281
+#: src/PrefsUnifiedDlg.cpp:1290
 msgid "- Temp folder changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1286
+#: src/PrefsUnifiedDlg.cpp:1295
 msgid "- ED2K network enabled.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1319
+#: src/PrefsUnifiedDlg.cpp:1328
 msgid "The shared-file exclusion pattern is not a valid regular expression. The filter has been left disabled."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1321 src/PrefsUnifiedDlg.cpp:1921
+#: src/PrefsUnifiedDlg.cpp:1330 src/PrefsUnifiedDlg.cpp:1930
 msgid "Invalid regular expression"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1398
+#: src/PrefsUnifiedDlg.cpp:1407
 msgid ""
 "Both eD2k and Kad network are disabled.\n"
 "You won't be able to connect until you enable at least one of them."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1403
+#: src/PrefsUnifiedDlg.cpp:1412
 msgid ""
 "Kad will not start if your UDP port is disabled.\n"
 "Enable UDP port or disable Kad."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1459
+#: src/PrefsUnifiedDlg.cpp:1468
 msgid ""
 "\n"
 "You MUST restart aMule now.\n"
 "If you do not restart now, don't complain if anything bad happens.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1524
+#: src/PrefsUnifiedDlg.cpp:1533
 msgid "Could not register aMule for autostart at login. The autostart store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1526
+#: src/PrefsUnifiedDlg.cpp:1535
 msgid "Could not remove the autostart-at-login entry."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1527
+#: src/PrefsUnifiedDlg.cpp:1536
 msgid "Autostart"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1542
+#: src/PrefsUnifiedDlg.cpp:1551
 msgid "Register file type"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1542
+#: src/PrefsUnifiedDlg.cpp:1551
 msgid "Register URL handler"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1550
+#: src/PrefsUnifiedDlg.cpp:1559
 #, c-format
 msgid "aMule only handles eD2k-compatible magnets. If you replace the current magnet handler (%s), BitTorrent magnet links will stop working - aMule cannot download BitTorrent content. Continue?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1555
+#: src/PrefsUnifiedDlg.cpp:1564
 #, c-format
 msgid "Another application currently opens .emulecollection files (%s). Replace it with aMule?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1560
+#: src/PrefsUnifiedDlg.cpp:1569
 #, c-format
 msgid "Another application is currently the default handler for these links (%s). Replace it with aMule?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1585
+#: src/PrefsUnifiedDlg.cpp:1594
 msgid "Could not register aMule for .emulecollection files. The registration store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1587
+#: src/PrefsUnifiedDlg.cpp:1596
 msgid "Could not remove the file type registration."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1589
+#: src/PrefsUnifiedDlg.cpp:1598
 msgid "Could not register aMule as the URL handler. The registration store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1591
+#: src/PrefsUnifiedDlg.cpp:1600
 msgid "Could not remove the URL handler registration."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1661 src/PrefsUnifiedDlg.cpp:1688
+#: src/PrefsUnifiedDlg.cpp:1670 src/PrefsUnifiedDlg.cpp:1697
 msgid "The web server and aMule API require external connections to be enabled."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1671
+#: src/PrefsUnifiedDlg.cpp:1680
 msgid "The aMule web server is deprecated. Consider running the aMule API instead."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1735
+#: src/PrefsUnifiedDlg.cpp:1744
 msgid ""
 "Your Auto-update servers list is in blank.\n"
 "Please fill in at least one URL to point to a valid server.met file.\n"
 "Click on the button \"List\" by this checkbox to enter an URL."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1876
+#: src/PrefsUnifiedDlg.cpp:1885
 msgid "Temporary files"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1881
+#: src/PrefsUnifiedDlg.cpp:1890
 msgid "Incoming files"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1886
+#: src/PrefsUnifiedDlg.cpp:1895
 msgid "Online Signatures"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1899
+#: src/PrefsUnifiedDlg.cpp:1908
 #, c-format
 msgid "Choose a folder for %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1923
+#: src/PrefsUnifiedDlg.cpp:1932
 #, c-format
 msgid "Would exclude %u of %u shared file"
 msgid_plural "Would exclude %u of %u shared files"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/PrefsUnifiedDlg.cpp:1940
+#: src/PrefsUnifiedDlg.cpp:1949
 msgid "Browse for videoplayer"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1944
+#: src/PrefsUnifiedDlg.cpp:1953
 msgid "Select browser"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1948
+#: src/PrefsUnifiedDlg.cpp:1957
 msgid "Select ffprobe binary"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1954
+#: src/PrefsUnifiedDlg.cpp:1963
 #, c-format
 msgid "Executable%s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1988
+#: src/PrefsUnifiedDlg.cpp:1997
 msgid "ffprobe not found on PATH or in the standard install locations. Install ffmpeg (which ships ffprobe) or use Browse to pick a binary manually."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2000
+#: src/PrefsUnifiedDlg.cpp:2009
 msgid "Reset the settings on this page to their default values?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2001
+#: src/PrefsUnifiedDlg.cpp:2010
 msgid "Reset to defaults"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2028
+#: src/PrefsUnifiedDlg.cpp:2037
 msgid "Edit server list"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2029
+#: src/PrefsUnifiedDlg.cpp:2038
 msgid ""
 "Add here URL's to download server.met files.\n"
 "Only one url on each line."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2084
+#: src/PrefsUnifiedDlg.cpp:2093
 msgid "IP2Country update failed"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2229 src/PrefsUnifiedDlg.cpp:2260
+#: src/PrefsUnifiedDlg.cpp:2238 src/PrefsUnifiedDlg.cpp:2269
 msgid "Data by MaxMind GeoLite2"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2231 src/PrefsUnifiedDlg.cpp:2262
+#: src/PrefsUnifiedDlg.cpp:2240 src/PrefsUnifiedDlg.cpp:2271
 msgid "Custom source"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2233 src/PrefsUnifiedDlg.cpp:2264
+#: src/PrefsUnifiedDlg.cpp:2242 src/PrefsUnifiedDlg.cpp:2273
 msgid "Data by DB-IP.com"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2284
+#: src/PrefsUnifiedDlg.cpp:2293
 #, c-format
 msgid "Status: Loaded%s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2286
+#: src/PrefsUnifiedDlg.cpp:2295
 #, c-format
 msgid "Status: Loaded%s - %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2290
+#: src/PrefsUnifiedDlg.cpp:2299
 msgid "Status: Failed to load - click 'Update now' to refresh."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2292
+#: src/PrefsUnifiedDlg.cpp:2301
 msgid "Status: Not found - click 'Update now' to download."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2350 src/PrefsUnifiedDlg.cpp:2374
+#: src/PrefsUnifiedDlg.cpp:2359 src/PrefsUnifiedDlg.cpp:2383
 #, c-format
 msgid "Update delay: %d second"
 msgid_plural "Update delay: %d seconds"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/PrefsUnifiedDlg.cpp:2358
+#: src/PrefsUnifiedDlg.cpp:2367
 #, c-format
 msgid "Time for average graph: %d minute"
 msgid_plural "Time for average graph: %d minutes"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/PrefsUnifiedDlg.cpp:2367
+#: src/PrefsUnifiedDlg.cpp:2376
 #, c-format
 msgid "Connections Graph Scale: %d"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2382
+#: src/PrefsUnifiedDlg.cpp:2391
 #, c-format
 msgid "File Buffer Size: %d byte"
 msgid_plural "File Buffer Size: %d bytes"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/PrefsUnifiedDlg.cpp:2392
+#: src/PrefsUnifiedDlg.cpp:2401
 #, c-format
 msgid "Upload Queue Size: %d client"
 msgid_plural "Upload Queue Size: %d clients"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/PrefsUnifiedDlg.cpp:2402
+#: src/PrefsUnifiedDlg.cpp:2411
 #, c-format
 msgid "Server connection refresh interval: %d minute"
 msgid_plural "Server connection refresh interval: %d minutes"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/PrefsUnifiedDlg.cpp:2407
+#: src/PrefsUnifiedDlg.cpp:2416
 msgid "Server connection refresh interval: Disabled"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2451
+#: src/PrefsUnifiedDlg.cpp:2460
 msgid "disabled"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2477
+#: src/PrefsUnifiedDlg.cpp:2486
 #, c-format
 msgid "Execute command on '%s' event"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2484
+#: src/PrefsUnifiedDlg.cpp:2493
 msgid "Enable command execution on core"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2496
+#: src/PrefsUnifiedDlg.cpp:2505
 msgid "Core command:"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2512
+#: src/PrefsUnifiedDlg.cpp:2521
 msgid "Enable command execution on GUI"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2524
+#: src/PrefsUnifiedDlg.cpp:2533
 msgid "GUI command:"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2540
+#: src/PrefsUnifiedDlg.cpp:2549
 msgid "The following variables will be replaced:"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2708
+#: src/PrefsUnifiedDlg.cpp:2717
 msgid ""
 "The following folders look like system or sensitive locations:\n"
 "\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2713
+#: src/PrefsUnifiedDlg.cpp:2722
 msgid "Sharing them recursively will publish every file underneath on the eD2k/Kad networks. Do you really want to do this?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2716
+#: src/PrefsUnifiedDlg.cpp:2725
 msgid "Confirm shared folders"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2744
+#: src/PrefsUnifiedDlg.cpp:2753
 msgid "Reloading shared files..."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2745
+#: src/PrefsUnifiedDlg.cpp:2754
 msgid "Scanning for subdirectories..."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2746
+#: src/PrefsUnifiedDlg.cpp:2755
 msgid "Updating shared folders"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2773
+#: src/PrefsUnifiedDlg.cpp:2782
 #, c-format
 msgid "Scanned %u directories..."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2823
+#: src/PrefsUnifiedDlg.cpp:2832
 #, c-format
 msgid "Reloading shared files: %u files scanned"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2873
+#: src/PrefsUnifiedDlg.cpp:2882
 msgid "Shared folder"
 msgstr ""
 
@@ -7635,12 +7635,12 @@ msgstr ""
 msgid "Hashset requested for unknown file: %s"
 msgstr ""
 
-#: src/UploadQueue.cpp:618
+#: src/UploadQueue.cpp:627
 #, c-format
 msgid "Resuming uploads of file: %s"
 msgstr ""
 
-#: src/UploadQueue.cpp:634
+#: src/UploadQueue.cpp:643
 #, c-format
 msgid "Suspending upload of file: %s"
 msgstr ""

--- a/po/vi.po
+++ b/po/vi.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-28 08:06+0200\n"
+"POT-Creation-Date: 2026-07-28 10:19+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: none\n"
@@ -131,7 +131,7 @@ msgstr ""
 msgid "Not now"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:422 src/amuleDlg.cpp:600
+#: src/AppImageIntegration.cpp:422 src/amuleDlg.cpp:665
 msgid "Don't ask again"
 msgstr ""
 
@@ -203,7 +203,7 @@ msgid "Killing amuleweb instance with pid '%d' ... "
 msgstr ""
 
 #: src/amule.cpp:336 src/amule.cpp:349 src/ClientRef.cpp:180
-#: src/SearchDlg.cpp:880 src/ServerListCtrl.cpp:98
+#: src/SearchDlg.cpp:1041 src/ServerListCtrl.cpp:98
 msgid "Failed"
 msgstr ""
 
@@ -545,29 +545,67 @@ msgstr ""
 msgid "ERROR: %s"
 msgstr ""
 
-#: src/amuleDlg.cpp:236
+#: src/amuleDlg.cpp:250
 #, c-format
 msgid "This is aMule %s based on eMule."
 msgstr ""
 
-#: src/amuleDlg.cpp:237
+#: src/amuleDlg.cpp:251
 #, c-format
 msgid "Running on %s"
 msgstr ""
 
-#: src/amuleDlg.cpp:239
+#: src/amuleDlg.cpp:253
 msgid "Visit https://github.com/amule-org/amule/releases/latest to check if a new version is available."
 msgstr ""
 
-#: src/amuleDlg.cpp:268
+#: src/amuleDlg.cpp:282
 msgid "FATAL ERROR: Failed to create Timer"
 msgstr ""
 
-#: src/amuleDlg.cpp:592
+#: src/amuleDlg.cpp:361 src/amuleDlg.cpp:1787 src/amuleDlg.cpp:2033
+#: src/muuli_wdr.cpp:1492 src/muuli_wdr.cpp:3418
+msgid "Networks"
+msgstr ""
+
+#: src/amuleDlg.cpp:362 src/amuleDlg.cpp:1793 src/muuli_wdr.cpp:3419
+msgid "Searches"
+msgstr ""
+
+#: src/amuleDlg.cpp:363 src/amuleDlg.cpp:1799 src/DownloadListCtrl.cpp:740
+#: src/muuli_wdr.cpp:392 src/muuli_wdr.cpp:1585 src/muuli_wdr.cpp:3420
+#: src/Statistics.cpp:829
+msgid "Downloads"
+msgstr ""
+
+#: src/amuleDlg.cpp:364 src/amuleDlg.cpp:1805 src/muuli_wdr.cpp:3294
+msgid "Shared files"
+msgstr ""
+
+#: src/amuleDlg.cpp:365 src/amuleDlg.cpp:1811 src/muuli_wdr.cpp:2926
+#: src/muuli_wdr.cpp:3376 src/muuli_wdr.cpp:3423
+msgid "Messages"
+msgstr ""
+
+#: src/amuleDlg.cpp:366 src/amuleDlg.cpp:1817 src/muuli_wdr.cpp:3424
+#: src/PrefsUnifiedDlg.cpp:312 src/Statistics.cpp:779 src/Statistics.cpp:1235
+msgid "Statistics"
+msgstr ""
+
+#: src/amuleDlg.cpp:368 src/amuleDlg.cpp:1824 src/muuli_wdr.cpp:3426
+#: src/PrefsUnifiedDlg.cpp:328 src/utils/wxCas/src/wxcasprefs.cpp:39
+msgid "Preferences"
+msgstr ""
+
+#: src/amuleDlg.cpp:371
+msgid "Navigate"
+msgstr ""
+
+#: src/amuleDlg.cpp:657
 msgid "New version available"
 msgstr ""
 
-#: src/amuleDlg.cpp:596
+#: src/amuleDlg.cpp:661
 #, c-format
 msgid ""
 "A new version of aMule (%s) is available.\n"
@@ -577,217 +615,184 @@ msgid ""
 "Would you like to open the download page?"
 msgstr ""
 
-#: src/amuleDlg.cpp:678
+#: src/amuleDlg.cpp:743
 msgid "aMule dialog destroyed"
 msgstr ""
 
-#: src/amuleDlg.cpp:701 src/DataToText.cpp:68 src/IPFilter.cpp:547
+#: src/amuleDlg.cpp:766 src/DataToText.cpp:68 src/IPFilter.cpp:547
 msgid "Connecting"
 msgstr ""
 
-#: src/amuleDlg.cpp:893
+#: src/amuleDlg.cpp:958
 msgid "eD2k: Connecting"
 msgstr ""
 
-#: src/amuleDlg.cpp:897
+#: src/amuleDlg.cpp:962
 msgid "eD2k: Disconnected"
 msgstr ""
 
-#: src/amuleDlg.cpp:903
+#: src/amuleDlg.cpp:968
 msgid "Kad: Firewalled"
 msgstr ""
 
-#: src/amuleDlg.cpp:907
+#: src/amuleDlg.cpp:972
 msgid "Kad: Connected"
 msgstr ""
 
-#: src/amuleDlg.cpp:912
+#: src/amuleDlg.cpp:977
 msgid "Kad: Connecting"
 msgstr ""
 
-#: src/amuleDlg.cpp:916
+#: src/amuleDlg.cpp:981
 msgid "Kad: Off"
 msgstr ""
 
-#: src/amuleDlg.cpp:964 src/DownloadListCtrl.cpp:505
+#: src/amuleDlg.cpp:1029 src/DownloadListCtrl.cpp:505
 #: src/DownloadListCtrl.cpp:749 src/FriendListCtrl.cpp:180
 #: src/muuli_wdr.cpp:731 src/muuli_wdr.cpp:782 src/muuli_wdr.cpp:846
-#: src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2224 src/muuli_wdr.cpp:2309
-#: src/muuli_wdr.cpp:3057 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
+#: src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2231 src/muuli_wdr.cpp:2316
+#: src/muuli_wdr.cpp:3064 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
 #: src/ServerListCtrl.cpp:606 src/TransferWnd.cpp:378
 #: src/utils/wxCas/src/wxcasprefs.cpp:235
 msgid "Cancel"
 msgstr ""
 
-#: src/amuleDlg.cpp:965
+#: src/amuleDlg.cpp:1030
 msgid "Stop the current connection attempts"
 msgstr ""
 
-#: src/amuleDlg.cpp:970 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976
-#: src/muuli_wdr.cpp:2447
+#: src/amuleDlg.cpp:1035 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976
+#: src/muuli_wdr.cpp:2454
 msgid "Disconnect"
 msgstr ""
 
-#: src/amuleDlg.cpp:971
+#: src/amuleDlg.cpp:1036
 msgid "Disconnect from the currently connected networks"
 msgstr ""
 
-#: src/amuleDlg.cpp:976 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979
-#: src/muuli_wdr.cpp:2602 src/muuli_wdr.cpp:3054 src/muuli_wdr.cpp:3409
+#: src/amuleDlg.cpp:1041 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979
+#: src/muuli_wdr.cpp:2609 src/muuli_wdr.cpp:3061 src/muuli_wdr.cpp:3416
 msgid "Connect"
 msgstr ""
 
-#: src/amuleDlg.cpp:977
+#: src/amuleDlg.cpp:1042
 msgid "Connect to the currently enabled networks"
 msgstr ""
 
-#: src/amuleDlg.cpp:1089
+#: src/amuleDlg.cpp:1154
 #, c-format
 msgid "Up: %.1f%s (%.1f) | Down: %.1f%s (%.1f)"
 msgstr ""
 
-#: src/amuleDlg.cpp:1091 src/amuleDlg.cpp:1093 src/amuleDlg.cpp:1097
-#: src/amuleDlg.cpp:1099 src/amuleDlg.cpp:1110 src/amuleDlg.cpp:1112
+#: src/amuleDlg.cpp:1156 src/amuleDlg.cpp:1158 src/amuleDlg.cpp:1162
+#: src/amuleDlg.cpp:1164 src/amuleDlg.cpp:1175 src/amuleDlg.cpp:1177
 #: src/MuleTrayIcon.cpp:796 src/MuleTrayIcon.cpp:799
 msgid " MB/s"
 msgstr ""
 
-#: src/amuleDlg.cpp:1091 src/amuleDlg.cpp:1093 src/amuleDlg.cpp:1097
-#: src/amuleDlg.cpp:1099 src/amuleDlg.cpp:1110 src/amuleDlg.cpp:1112
+#: src/amuleDlg.cpp:1156 src/amuleDlg.cpp:1158 src/amuleDlg.cpp:1162
+#: src/amuleDlg.cpp:1164 src/amuleDlg.cpp:1175 src/amuleDlg.cpp:1177
 #: src/MuleTrayIcon.cpp:796 src/MuleTrayIcon.cpp:799
 #: src/utils/wxCas/src/wxcasframe.cpp:1041
 msgid " kB/s"
 msgstr ""
 
-#: src/amuleDlg.cpp:1096
+#: src/amuleDlg.cpp:1161
 #, c-format
 msgid "Up: %.1f%s | Down: %.1f%s"
 msgstr ""
 
-#: src/amuleDlg.cpp:1128
+#: src/amuleDlg.cpp:1193
 #, c-format
 msgid "aMule (%s | Connected)"
 msgstr ""
 
-#: src/amuleDlg.cpp:1130
+#: src/amuleDlg.cpp:1195
 #, c-format
 msgid "aMule (%s | Disconnected)"
 msgstr ""
 
-#: src/amuleDlg.cpp:1183
+#: src/amuleDlg.cpp:1248
 #, c-format
 msgid "Do you really want to exit %s?"
 msgstr ""
 
-#: src/amuleDlg.cpp:1185
+#: src/amuleDlg.cpp:1250
 msgid "Exit confirmation"
 msgstr ""
 
-#: src/amuleDlg.cpp:1548
+#: src/amuleDlg.cpp:1613
 msgid "Launch Command: "
 msgstr ""
 
-#: src/amuleDlg.cpp:1567 src/muuli_wdr.cpp:1971 src/Preferences.cpp:951
+#: src/amuleDlg.cpp:1632 src/muuli_wdr.cpp:1978 src/Preferences.cpp:952
 msgid "- default -"
 msgstr ""
 
-#: src/amuleDlg.cpp:1595
+#: src/amuleDlg.cpp:1660
 #, c-format
 msgid "Skin directory '%s' does not exist"
 msgstr ""
 
-#: src/amuleDlg.cpp:1598
+#: src/amuleDlg.cpp:1663
 #, c-format
 msgid "WARNING: Unable to open skin file '%s' for read"
 msgstr ""
 
-#: src/amuleDlg.cpp:1722 src/amuleDlg.cpp:1968 src/muuli_wdr.cpp:1485
-#: src/muuli_wdr.cpp:3411
-msgid "Networks"
-msgstr ""
-
-#: src/amuleDlg.cpp:1726 src/muuli_wdr.cpp:3411
+#: src/amuleDlg.cpp:1791 src/muuli_wdr.cpp:3418
 msgid "Networks Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1728 src/muuli_wdr.cpp:3412
-msgid "Searches"
-msgstr ""
-
-#: src/amuleDlg.cpp:1732 src/muuli_wdr.cpp:3412
+#: src/amuleDlg.cpp:1797 src/muuli_wdr.cpp:3419
 msgid "Searches Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1734 src/DownloadListCtrl.cpp:740 src/muuli_wdr.cpp:392
-#: src/muuli_wdr.cpp:1578 src/muuli_wdr.cpp:3413 src/Statistics.cpp:829
-msgid "Downloads"
-msgstr ""
-
-#: src/amuleDlg.cpp:1738 src/muuli_wdr.cpp:3413
+#: src/amuleDlg.cpp:1803 src/muuli_wdr.cpp:3420
 msgid "Downloads Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1740 src/muuli_wdr.cpp:3287
-msgid "Shared files"
-msgstr ""
-
-#: src/amuleDlg.cpp:1744 src/muuli_wdr.cpp:3415
+#: src/amuleDlg.cpp:1809 src/muuli_wdr.cpp:3422
 msgid "Shared Files Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1746 src/muuli_wdr.cpp:2919 src/muuli_wdr.cpp:3369
-#: src/muuli_wdr.cpp:3416
-msgid "Messages"
-msgstr ""
-
-#: src/amuleDlg.cpp:1750 src/muuli_wdr.cpp:3416
+#: src/amuleDlg.cpp:1815 src/muuli_wdr.cpp:3423
 msgid "Messages Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1752 src/muuli_wdr.cpp:3417 src/PrefsUnifiedDlg.cpp:312
-#: src/Statistics.cpp:779 src/Statistics.cpp:1235
-msgid "Statistics"
-msgstr ""
-
-#: src/amuleDlg.cpp:1756 src/muuli_wdr.cpp:3417
+#: src/amuleDlg.cpp:1821 src/muuli_wdr.cpp:3424
 msgid "Statistics Graph Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1759 src/muuli_wdr.cpp:3419 src/PrefsUnifiedDlg.cpp:328
-#: src/utils/wxCas/src/wxcasprefs.cpp:39
-msgid "Preferences"
-msgstr ""
-
-#: src/amuleDlg.cpp:1763 src/muuli_wdr.cpp:3419
+#: src/amuleDlg.cpp:1828 src/muuli_wdr.cpp:3426
 msgid "Preferences Settings Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1766 src/muuli_wdr.cpp:3420
+#: src/amuleDlg.cpp:1831 src/muuli_wdr.cpp:3427
 msgid "Import"
 msgstr ""
 
-#: src/amuleDlg.cpp:1770 src/muuli_wdr.cpp:3420
+#: src/amuleDlg.cpp:1835 src/muuli_wdr.cpp:3427
 msgid "The partfile importer tool"
 msgstr ""
 
-#: src/amuleDlg.cpp:1773 src/muuli_wdr.cpp:3421
+#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3428
 #: src/utils/aLinkCreator/src/alcframe.cpp:262
 msgid "About"
 msgstr ""
 
-#: src/amuleDlg.cpp:1773 src/muuli_wdr.cpp:3421
+#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3428
 msgid "About/Help"
 msgstr ""
 
-#: src/amuleDlg.cpp:1971
+#: src/amuleDlg.cpp:2036
 msgid "eD2k network"
 msgstr ""
 
-#: src/amuleDlg.cpp:1974
+#: src/amuleDlg.cpp:2039
 msgid "Kad network"
 msgstr ""
 
-#: src/amuleDlg.cpp:1974
+#: src/amuleDlg.cpp:2039
 msgid "No network"
 msgstr ""
 
@@ -1314,19 +1319,19 @@ msgstr ""
 msgid "Very low"
 msgstr ""
 
-#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:743 src/muuli_wdr.cpp:2275
+#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:743 src/muuli_wdr.cpp:2282
 #: src/ServerListCtrl.cpp:263 src/ServerListCtrl.cpp:456
 #: src/SharedFilesCtrl.cpp:145
 msgid "Low"
 msgstr ""
 
-#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:744 src/muuli_wdr.cpp:2276
+#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:744 src/muuli_wdr.cpp:2283
 #: src/ServerListCtrl.cpp:266 src/ServerListCtrl.cpp:457
 #: src/SharedFilesCtrl.cpp:146
 msgid "Normal"
 msgstr ""
 
-#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:745 src/muuli_wdr.cpp:2277
+#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:745 src/muuli_wdr.cpp:2284
 #: src/ServerListCtrl.cpp:269 src/ServerListCtrl.cpp:458
 #: src/SharedFilesCtrl.cpp:147
 msgid "High"
@@ -1418,8 +1423,8 @@ msgstr ""
 msgid "Remote Server"
 msgstr ""
 
-#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3174
-#: src/SearchDlg.cpp:111 src/TextClient.cpp:911
+#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3181
+#: src/SearchDlg.cpp:119 src/TextClient.cpp:911
 msgid "Kad"
 msgstr ""
 
@@ -1489,7 +1494,7 @@ msgstr ""
 msgid "Size"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3241
+#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3248
 msgid "Transferred"
 msgstr ""
 
@@ -1545,7 +1550,7 @@ msgid ""
 "\n"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:746 src/muuli_wdr.cpp:2278
+#: src/DownloadListCtrl.cpp:746 src/muuli_wdr.cpp:2285
 #: src/SharedFilesCtrl.cpp:150
 msgid "Auto"
 msgstr ""
@@ -1583,7 +1588,7 @@ msgid "Extended Options"
 msgstr ""
 
 #: src/DownloadListCtrl.cpp:770 src/DownloadListCtrl.cpp:822
-#: src/muuli_wdr.cpp:1789
+#: src/muuli_wdr.cpp:1796
 msgid "Preview"
 msgstr ""
 
@@ -2261,19 +2266,19 @@ msgstr ""
 msgid "eD2k"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:349 src/muuli_wdr.cpp:1488
+#: src/FirstRunWizard.cpp:349 src/muuli_wdr.cpp:1495
 msgid "Kademlia"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:359 src/muuli_wdr.cpp:1416
+#: src/FirstRunWizard.cpp:359 src/muuli_wdr.cpp:1423
 msgid "Standard TCP Port "
 msgstr ""
 
-#: src/FirstRunWizard.cpp:365 src/muuli_wdr.cpp:1428
+#: src/FirstRunWizard.cpp:365 src/muuli_wdr.cpp:1435
 msgid "Extended UDP port (Kad / global search) "
 msgstr ""
 
-#: src/FirstRunWizard.cpp:377 src/muuli_wdr.cpp:1435
+#: src/FirstRunWizard.cpp:377 src/muuli_wdr.cpp:1442
 msgid "Enable UPnP for router port forwarding"
 msgstr ""
 
@@ -2298,7 +2303,7 @@ msgstr ""
 msgid "Your peer lists are already in place - nothing to download."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:434 src/muuli_wdr.cpp:1533
+#: src/FirstRunWizard.cpp:434 src/muuli_wdr.cpp:1540
 msgid "Auto-update server list at startup"
 msgstr ""
 
@@ -2344,23 +2349,23 @@ msgid ""
 "want downloads on a different (e.g. larger) disk."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:549 src/FirstRunWizard.cpp:611 src/muuli_wdr.cpp:1701
+#: src/FirstRunWizard.cpp:549 src/FirstRunWizard.cpp:611 src/muuli_wdr.cpp:1708
 msgid "Destination folder for downloads"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:553 src/FirstRunWizard.cpp:569 src/muuli_wdr.cpp:1342
-#: src/muuli_wdr.cpp:1359 src/muuli_wdr.cpp:1676 src/muuli_wdr.cpp:1707
-#: src/muuli_wdr.cpp:1719 src/muuli_wdr.cpp:2762
+#: src/FirstRunWizard.cpp:553 src/FirstRunWizard.cpp:569 src/muuli_wdr.cpp:1349
+#: src/muuli_wdr.cpp:1366 src/muuli_wdr.cpp:1683 src/muuli_wdr.cpp:1714
+#: src/muuli_wdr.cpp:1726 src/muuli_wdr.cpp:2769
 #: src/utils/aLinkCreator/src/alcframe.cpp:135
 #: src/utils/wxCas/src/wxcasprefs.cpp:52 src/utils/wxCas/src/wxcasprefs.cpp:118
 msgid "Browse"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:559 src/muuli_wdr.cpp:1712
+#: src/FirstRunWizard.cpp:559 src/muuli_wdr.cpp:1719
 msgid "(All files in this folder are shared with other peers)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:565 src/FirstRunWizard.cpp:624 src/muuli_wdr.cpp:1714
+#: src/FirstRunWizard.cpp:565 src/FirstRunWizard.cpp:624 src/muuli_wdr.cpp:1721
 msgid "Folder for temporary download files"
 msgstr ""
 
@@ -2391,7 +2396,7 @@ msgstr ""
 msgid "CRITICAL - no client on StartChatSession"
 msgstr ""
 
-#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2668 src/muuli_wdr.cpp:3345
+#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2675 src/muuli_wdr.cpp:3352
 msgid "Friends"
 msgstr ""
 
@@ -2769,7 +2774,7 @@ msgstr ""
 msgid "Uploaded"
 msgstr ""
 
-#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3225
+#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3232
 msgid "Requested"
 msgstr ""
 
@@ -2892,7 +2897,7 @@ msgid "WARNING: "
 msgstr ""
 
 #: src/MuleNotebook.cpp:179 src/muuli_wdr.cpp:817 src/muuli_wdr.cpp:1229
-#: src/muuli_wdr.cpp:3129 src/muuli_wdr.cpp:3385
+#: src/muuli_wdr.cpp:3136 src/muuli_wdr.cpp:3392
 msgid "Close"
 msgstr ""
 
@@ -2905,12 +2910,12 @@ msgstr ""
 msgid "Copy"
 msgstr ""
 
-#: src/MuleTextCtrl.cpp:88
+#: src/MuleTextCtrl.cpp:88 src/SearchDlg.cpp:261
 msgid "Paste"
 msgstr ""
 
 #: src/MuleTextCtrl.cpp:89 src/muuli_wdr.cpp:358 src/muuli_wdr.cpp:757
-#: src/muuli_wdr.cpp:2352 src/muuli_wdr.cpp:2371 src/muuli_wdr.cpp:2393
+#: src/muuli_wdr.cpp:2359 src/muuli_wdr.cpp:2378 src/muuli_wdr.cpp:2400
 #: src/utils/aLinkCreator/src/alcframe.cpp:142
 msgid "Clear"
 msgstr ""
@@ -3001,8 +3006,8 @@ msgid "Exit"
 msgstr ""
 
 #: src/MuleTrayIcon.cpp:579 src/MuleTrayIcon.cpp:945 src/MuleTrayIcon.cpp:965
-#: src/muuli_wdr.cpp:1391 src/muuli_wdr.cpp:1399 src/muuli_wdr.cpp:1406
-#: src/muuli_wdr.cpp:1835 src/muuli_wdr.cpp:1841 src/OtherFunctions.cpp:91
+#: src/muuli_wdr.cpp:1398 src/muuli_wdr.cpp:1406 src/muuli_wdr.cpp:1413
+#: src/muuli_wdr.cpp:1842 src/muuli_wdr.cpp:1848 src/OtherFunctions.cpp:91
 #: src/StatisticsDlg.cpp:93 src/StatisticsDlg.cpp:95
 msgid "kB/s"
 msgstr ""
@@ -3171,7 +3176,7 @@ msgstr ""
 msgid "Type"
 msgstr ""
 
-#: src/muuli_wdr.cpp:215 src/SearchDlg.cpp:110 src/SearchListCtrl.cpp:853
+#: src/muuli_wdr.cpp:215 src/SearchDlg.cpp:118 src/SearchListCtrl.cpp:853
 msgid "Local"
 msgstr ""
 
@@ -3242,7 +3247,7 @@ msgstr ""
 msgid "KB"
 msgstr ""
 
-#: src/muuli_wdr.cpp:274 src/muuli_wdr.cpp:293 src/muuli_wdr.cpp:1620
+#: src/muuli_wdr.cpp:274 src/muuli_wdr.cpp:293 src/muuli_wdr.cpp:1627
 #: src/OtherFunctions.cpp:64
 msgid "MB"
 msgstr ""
@@ -3259,7 +3264,7 @@ msgstr ""
 msgid "Availability"
 msgstr ""
 
-#: src/muuli_wdr.cpp:312 src/muuli_wdr.cpp:398 src/muuli_wdr.cpp:3290
+#: src/muuli_wdr.cpp:312 src/muuli_wdr.cpp:398 src/muuli_wdr.cpp:3297
 msgid "Filter:"
 msgstr ""
 
@@ -3291,7 +3296,7 @@ msgstr ""
 msgid "Stop"
 msgstr ""
 
-#: src/muuli_wdr.cpp:348 src/muuli_wdr.cpp:1385 src/SearchListCtrl.cpp:732
+#: src/muuli_wdr.cpp:348 src/muuli_wdr.cpp:1392 src/SearchListCtrl.cpp:732
 msgid "Download"
 msgstr ""
 
@@ -3322,8 +3327,8 @@ msgstr ""
 #: src/muuli_wdr.cpp:1160 src/muuli_wdr.cpp:1167 src/muuli_wdr.cpp:1172
 #: src/muuli_wdr.cpp:1179 src/muuli_wdr.cpp:1184 src/muuli_wdr.cpp:1191
 #: src/muuli_wdr.cpp:1205 src/muuli_wdr.cpp:1212 src/muuli_wdr.cpp:1217
-#: src/muuli_wdr.cpp:1224 src/muuli_wdr.cpp:3227 src/muuli_wdr.cpp:3235
-#: src/muuli_wdr.cpp:3243
+#: src/muuli_wdr.cpp:1224 src/muuli_wdr.cpp:3234 src/muuli_wdr.cpp:3242
+#: src/muuli_wdr.cpp:3250
 msgid "N/A"
 msgstr ""
 
@@ -3463,7 +3468,7 @@ msgstr ""
 msgid "Album :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:685 src/muuli_wdr.cpp:2247
+#: src/muuli_wdr.cpp:685 src/muuli_wdr.cpp:2254
 msgid "Title :"
 msgstr ""
 
@@ -3569,7 +3574,7 @@ msgstr ""
 msgid "Userhash :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:895 src/muuli_wdr.cpp:1741 src/muuli_wdr.cpp:2442
+#: src/muuli_wdr.cpp:895 src/muuli_wdr.cpp:1748 src/muuli_wdr.cpp:2449
 #: src/utils/aLinkCreator/src/alcframe.cpp:137
 msgid "Add"
 msgstr ""
@@ -3578,15 +3583,15 @@ msgstr ""
 msgid "Download-Speed"
 msgstr ""
 
-#: src/muuli_wdr.cpp:954 src/muuli_wdr.cpp:989 src/muuli_wdr.cpp:2546
+#: src/muuli_wdr.cpp:954 src/muuli_wdr.cpp:989 src/muuli_wdr.cpp:2553
 msgid "Current"
 msgstr ""
 
-#: src/muuli_wdr.cpp:962 src/muuli_wdr.cpp:997 src/muuli_wdr.cpp:2554
+#: src/muuli_wdr.cpp:962 src/muuli_wdr.cpp:997 src/muuli_wdr.cpp:2561
 msgid "Running average"
 msgstr ""
 
-#: src/muuli_wdr.cpp:970 src/muuli_wdr.cpp:1005 src/muuli_wdr.cpp:2562
+#: src/muuli_wdr.cpp:970 src/muuli_wdr.cpp:1005 src/muuli_wdr.cpp:2569
 msgid "Session average"
 msgstr ""
 
@@ -3598,7 +3603,7 @@ msgstr ""
 msgid "Connections"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1024 src/muuli_wdr.cpp:1860
+#: src/muuli_wdr.cpp:1024 src/muuli_wdr.cpp:1867
 msgid "Active downloads"
 msgstr ""
 
@@ -3606,7 +3611,7 @@ msgstr ""
 msgid "Active connections (1:1)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1040 src/muuli_wdr.cpp:1861
+#: src/muuli_wdr.cpp:1040 src/muuli_wdr.cpp:1868
 msgid "Active uploads"
 msgstr ""
 
@@ -3722,8 +3727,8 @@ msgstr ""
 msgid "Language: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1257 src/muuli_wdr.cpp:1323 src/muuli_wdr.cpp:1327
-#: src/muuli_wdr.cpp:1330
+#: src/muuli_wdr.cpp:1257 src/muuli_wdr.cpp:1330 src/muuli_wdr.cpp:1334
+#: src/muuli_wdr.cpp:1337
 msgid "The delay before showing tool-tips."
 msgstr ""
 
@@ -3799,923 +3804,931 @@ msgstr ""
 msgid "Enabling this will make aMule to show notifications when finished downloading."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1322
-msgid "Tooltip delay time: "
+#: src/muuli_wdr.cpp:1323
+msgid "Remember search history"
+msgstr ""
+
+#: src/muuli_wdr.cpp:1324
+msgid "Keeps a dropdown list of your past search terms in the Search tab's Name field. This remembers the queries you typed, not the results they returned."
 msgstr ""
 
 #: src/muuli_wdr.cpp:1329
+msgid "Tooltip delay time: "
+msgstr ""
+
+#: src/muuli_wdr.cpp:1336
 msgid "seconds"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1333
+#: src/muuli_wdr.cpp:1340
 msgid "Browser Selection"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1339
+#: src/muuli_wdr.cpp:1346
 msgid "Enter your browser name here. Leave this field empty to use the system default browser."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1346
+#: src/muuli_wdr.cpp:1353
 msgid "Open in new tab if possible"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1348
+#: src/muuli_wdr.cpp:1355
 msgid "Open the web page in a new tab instead of in a new window when possible"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1352
+#: src/muuli_wdr.cpp:1359
 msgid "Video Player"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1379
+#: src/muuli_wdr.cpp:1386
 msgid "Bandwidth limits"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1393
+#: src/muuli_wdr.cpp:1400
 msgid "Upload"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1401
+#: src/muuli_wdr.cpp:1408
 msgid "Slot Allocation"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1410
+#: src/muuli_wdr.cpp:1417
 msgid "Ports"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1420
+#: src/muuli_wdr.cpp:1427
 msgid "This is the standard eD2k port and cannot be disabled."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1423
+#: src/muuli_wdr.cpp:1430
 msgid "UDP port for server requests (TCP+3):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1425
+#: src/muuli_wdr.cpp:1432
 msgid "4665"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1432
+#: src/muuli_wdr.cpp:1439
 msgid "This UDP port is used for extended eD2k requests and Kad network"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1439
+#: src/muuli_wdr.cpp:1446
 msgid "UPnP TCP Port (Optional):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1449
+#: src/muuli_wdr.cpp:1456
 msgid "Bind local address to IP (empty for any):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1452
+#: src/muuli_wdr.cpp:1459
 msgid "Advanced users only: If you have multiple network interfaces, enter the address of the interface to which aMule should be bound."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1455 src/muuli_wdr.cpp:2054
+#: src/muuli_wdr.cpp:1462 src/muuli_wdr.cpp:2061
 msgid "Bind to network interface (empty for any):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1468
+#: src/muuli_wdr.cpp:1475
 msgid "Advanced users only: pin all of aMule's traffic to one network interface, chosen from the list or typed in by name (e.g. tun0, eth0, en0) or index. Unlike binding to an IP, this stops traffic leaking out via the default route - useful with a VPN. Requires no elevated privileges."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1474
+#: src/muuli_wdr.cpp:1481
 msgid "Max sources per downloading file:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1478
+#: src/muuli_wdr.cpp:1485
 msgid "Max simultaneous connections:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1491 src/muuli_wdr.cpp:3169
+#: src/muuli_wdr.cpp:1498 src/muuli_wdr.cpp:3176
 msgid "ED2K"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1498
+#: src/muuli_wdr.cpp:1505
 msgid "Autoconnect on startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1501
+#: src/muuli_wdr.cpp:1508
 msgid "Reconnect on loss"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1523
+#: src/muuli_wdr.cpp:1530
 msgid "Remove dead server after"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1524
+#: src/muuli_wdr.cpp:1531
 msgid "Static servers are never removed, even when unreachable."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1528
+#: src/muuli_wdr.cpp:1535
 msgid "retries"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1536
+#: src/muuli_wdr.cpp:1543
 msgid "List"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1539
+#: src/muuli_wdr.cpp:1546
 msgid "Update server list when connecting to a server"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1542
+#: src/muuli_wdr.cpp:1549
 msgid "Update server list when a client connects"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1545
+#: src/muuli_wdr.cpp:1552
 msgid "Use priority system"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1549
+#: src/muuli_wdr.cpp:1556
 msgid "Use smart LowID check on connect"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1553
+#: src/muuli_wdr.cpp:1560
 msgid "Safe connect"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1557
+#: src/muuli_wdr.cpp:1564
 msgid "Autoconnect to servers in static list only"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1560
+#: src/muuli_wdr.cpp:1567
 msgid "Set manually added servers to High Priority"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1581
+#: src/muuli_wdr.cpp:1588
 msgid "Add files to download in pause mode"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1583
+#: src/muuli_wdr.cpp:1590
 msgid "Add files to download with auto priority"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1586
+#: src/muuli_wdr.cpp:1593
 msgid "Try to download first and last chunks first"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1590
+#: src/muuli_wdr.cpp:1597
 msgid "Endgame mode: rotate to faster sources for the final blocks"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1593
+#: src/muuli_wdr.cpp:1600
 msgid "Start next paused file when a file completes"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1596
+#: src/muuli_wdr.cpp:1603
 msgid "From the same category"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1598
+#: src/muuli_wdr.cpp:1605
 msgid "In alphabetic order"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1600
+#: src/muuli_wdr.cpp:1607
 msgid "Preallocate disk space for new files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1601
+#: src/muuli_wdr.cpp:1608
 msgid "For new files preallocates disk space for the whole file, thus reduces fragmentation"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1606
+#: src/muuli_wdr.cpp:1613
 msgid "Create new files as sparse files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1607
+#: src/muuli_wdr.cpp:1614
 msgid "A sparse file reserves its full size on disk immediately without writing real data to it -- fast, but unsupported or slow on some filesystems, and free-space accounting stays optimistic while the download is in progress. Turn this off to grow the file only as data arrives."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1612
+#: src/muuli_wdr.cpp:1619
 msgid "Stop downloads when free disk space reaches "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1613
+#: src/muuli_wdr.cpp:1620
 msgid "Select this if you want aMule to check your disk space"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1617
+#: src/muuli_wdr.cpp:1624
 msgid "Enter here the min disk space desired."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1623
+#: src/muuli_wdr.cpp:1630
 msgid "Save 10 sources on rare files (< 20 sources)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1627 src/Statistics.cpp:790
+#: src/muuli_wdr.cpp:1634 src/Statistics.cpp:790
 msgid "Uploads"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1630
+#: src/muuli_wdr.cpp:1637
 msgid "Add new shared files with auto priority"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1636
+#: src/muuli_wdr.cpp:1643
 msgid "Intelligent Corruption Handling (I.C.H.)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1639
+#: src/muuli_wdr.cpp:1646
 msgid "Enable"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1642
+#: src/muuli_wdr.cpp:1649
 msgid "Advanced I.C.H. trusts every hash (not recommended)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1654 src/PrefsUnifiedDlg.cpp:1910
+#: src/muuli_wdr.cpp:1661 src/PrefsUnifiedDlg.cpp:1910
 msgid "Media metadata extraction"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1658
+#: src/muuli_wdr.cpp:1665
 msgid "Extract length / bitrate / codec from shared audio and video files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1660
+#: src/muuli_wdr.cpp:1667
 msgid "When enabled, aMule runs ffprobe on each shared media file to fill in the Length / Bitrate / Codec columns other clients see when they find the file in a search. Requires ffmpeg (the ffprobe binary) to be installed."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1667
+#: src/muuli_wdr.cpp:1674
 msgid "Path to ffprobe:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1672
+#: src/muuli_wdr.cpp:1679
 msgid "Full path to the ffprobe binary. Leave empty to have aMule auto-detect it on startup."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1680
+#: src/muuli_wdr.cpp:1687
 msgid "Detect"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1681
+#: src/muuli_wdr.cpp:1688
 msgid "Search the standard install locations for an ffprobe binary and fill the path field."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1705
+#: src/muuli_wdr.cpp:1712
 msgid ""
 "Completed downloads are stored here. All files in this folder are automatically shared with other peers.\n"
 "If this folder also holds files you don't want to share, point it at an aMule-only sub-folder."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1708
+#: src/muuli_wdr.cpp:1715
 msgid "Pick the folder where completed downloads will be stored. All files in that folder will be shared with other peers."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1722
+#: src/muuli_wdr.cpp:1729
 msgid "Shared folders"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1728
+#: src/muuli_wdr.cpp:1735
 msgid "(Folders shared by the core. Enter a path to add one.)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1736
+#: src/muuli_wdr.cpp:1743
 msgid "Absolute path of a folder on the core's machine, e.g. /home/user/shared"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1738 src/PrefsUnifiedDlg.cpp:2794
+#: src/muuli_wdr.cpp:1745 src/PrefsUnifiedDlg.cpp:2794
 msgid "Recursive"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1739
+#: src/muuli_wdr.cpp:1746
 msgid "Share every sub-folder underneath this one, including ones created later."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1743 src/utils/aLinkCreator/src/alcframe.cpp:141
+#: src/muuli_wdr.cpp:1750 src/utils/aLinkCreator/src/alcframe.cpp:141
 msgid "Remove"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1747
+#: src/muuli_wdr.cpp:1754
 msgid "(Right click on folder icon for recursive share)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1754
+#: src/muuli_wdr.cpp:1761
 msgid "Share hidden files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1760
+#: src/muuli_wdr.cpp:1767
 msgid "Automatically rescan shared folders for changes"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1766
+#: src/muuli_wdr.cpp:1773
 msgid "Follow symbolic links in shared folders"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1772
+#: src/muuli_wdr.cpp:1779
 msgid "Exclude files matching:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1775
+#: src/muuli_wdr.cpp:1782
 msgid "Wildcard patterns separated by '|', e.g. .DS_Store|Thumbs.db|*.tmp. Files whose name matches are not shared. Matching is case-insensitive."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1779
+#: src/muuli_wdr.cpp:1786
 msgid "Patterns are regular expressions"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1780
+#: src/muuli_wdr.cpp:1787
 msgid "When set, the whole field is one regular expression ('|' is alternation). When unset, it is a list of '|'-separated wildcards."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1790
+#: src/muuli_wdr.cpp:1797
 msgid "Show how many shared files the current pattern would exclude."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1811
+#: src/muuli_wdr.cpp:1818
 msgid "Graphs"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1814 src/muuli_wdr.cpp:1876
+#: src/muuli_wdr.cpp:1821 src/muuli_wdr.cpp:1883
 msgid "Update delay : 5 secs"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1818
+#: src/muuli_wdr.cpp:1825
 msgid "Time for average graph: 100 mins"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1822
+#: src/muuli_wdr.cpp:1829
 msgid "Connections Graph Scale: 100 "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1829
+#: src/muuli_wdr.cpp:1836
 msgid "Download graph scale:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1837
+#: src/muuli_wdr.cpp:1844
 msgid "Upload graph scale:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1847
+#: src/muuli_wdr.cpp:1854
 msgid "Colors: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1851
+#: src/muuli_wdr.cpp:1858
 msgid "Background"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1852
+#: src/muuli_wdr.cpp:1859
 msgid "Grid"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1853
+#: src/muuli_wdr.cpp:1860
 msgid "Download current"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1854
+#: src/muuli_wdr.cpp:1861
 msgid "Download running average"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1855
+#: src/muuli_wdr.cpp:1862
 msgid "Download session average"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1856
+#: src/muuli_wdr.cpp:1863
 msgid "Upload current"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1857
+#: src/muuli_wdr.cpp:1864
 msgid "Upload running average"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1858
+#: src/muuli_wdr.cpp:1865
 msgid "Upload session average"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1859
+#: src/muuli_wdr.cpp:1866
 msgid "Active connections"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1862
+#: src/muuli_wdr.cpp:1869
 msgid "Systray Icon Speed Bar"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1863
+#: src/muuli_wdr.cpp:1870
 msgid "Kad-nodes current"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1864
+#: src/muuli_wdr.cpp:1871
 msgid "Kad-nodes running"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1865
+#: src/muuli_wdr.cpp:1872
 msgid "Kad-nodes session"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1869 src/muuli_wdr.cpp:2296
+#: src/muuli_wdr.cpp:1876 src/muuli_wdr.cpp:2303
 msgid "Select"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1873
+#: src/muuli_wdr.cpp:1880
 msgid "Tree"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1883
+#: src/muuli_wdr.cpp:1890
 msgid "Number of Client Versions shown (0=unlimited)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1908
+#: src/muuli_wdr.cpp:1915
 msgid "!!! WARNING !!!"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1923
+#: src/muuli_wdr.cpp:1930
 msgid "Max new connections / 5 secs"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1925
+#: src/muuli_wdr.cpp:1932
 msgid "Concurrent Kad source lookups"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1927
+#: src/muuli_wdr.cpp:1934
 msgid "Kad source re-search interval (minutes)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1929
+#: src/muuli_wdr.cpp:1936
 msgid "Source re-ask interval (minutes)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1933
+#: src/muuli_wdr.cpp:1940
 msgid "File Buffer Size: 240000 bytes"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1937
+#: src/muuli_wdr.cpp:1944
 msgid "Use MMAP: memory-mapped file access (lower memory use)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1938
+#: src/muuli_wdr.cpp:1945
 msgid "Maps part files into memory instead of buffering them on the heap, lowering the process memory footprint. May reduce download speed on some disks; best for memory-constrained or upload-heavy hosts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1940
+#: src/muuli_wdr.cpp:1947
 msgid "Upload Queue Size: 5000 clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1944
+#: src/muuli_wdr.cpp:1951
 msgid "Server connection refresh interval: Disable"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1948
+#: src/muuli_wdr.cpp:1955
 msgid "Disable computer's timed standby mode"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1967
+#: src/muuli_wdr.cpp:1974
 msgid "Skin to use: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1976
+#: src/muuli_wdr.cpp:1983
 msgid "Show \"Fast eD2k Links Handler\" in every window."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1979
+#: src/muuli_wdr.cpp:1986
 msgid "Show extended info on categories tabs"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1982
+#: src/muuli_wdr.cpp:1989
 msgid "Show application version on title"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1984
+#: src/muuli_wdr.cpp:1991
 msgid "Show transfer rates on title"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1986
+#: src/muuli_wdr.cpp:1993
 msgid "Before application name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1988
+#: src/muuli_wdr.cpp:1995
 msgid "After application name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1991
+#: src/muuli_wdr.cpp:1998
 msgid "Show overhead bandwidth"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1995
+#: src/muuli_wdr.cpp:2002
 msgid "Vertical toolbar orientation"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1997
+#: src/muuli_wdr.cpp:2004
 msgid "Live column sorting (auto-reorder rows as their values change)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2004
+#: src/muuli_wdr.cpp:2011
 msgid "Download Queue Files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2007
+#: src/muuli_wdr.cpp:2014
 msgid "Show progress percentage"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2013
+#: src/muuli_wdr.cpp:2020
 msgid "Show progress bar"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2016
+#: src/muuli_wdr.cpp:2023
 msgid "Flat"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2020
+#: src/muuli_wdr.cpp:2027
 msgid "Round"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2038
+#: src/muuli_wdr.cpp:2045
 msgid "External Connection Parameters"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2041
+#: src/muuli_wdr.cpp:2048
 msgid "Accept external connections"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2048 src/muuli_wdr.cpp:2107
+#: src/muuli_wdr.cpp:2055 src/muuli_wdr.cpp:2114
 msgid "IP of the listening interface:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2051
+#: src/muuli_wdr.cpp:2058
 msgid "Enter here a valid ip in the a.b.c.d format for the listening EC interface. An empty field or 0.0.0.0 will mean any interface."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2072 src/muuli_wdr.cpp:2156
+#: src/muuli_wdr.cpp:2079 src/muuli_wdr.cpp:2163
 msgid "TCP port:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2078
+#: src/muuli_wdr.cpp:2085
 msgid "Enable UPnP port forwarding on the EC port"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2082 src/muuli_wdr.cpp:3041
+#: src/muuli_wdr.cpp:2089 src/muuli_wdr.cpp:3048
 #: src/utils/wxCas/src/wxcasprefs.cpp:167
 msgid "Password"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2088
+#: src/muuli_wdr.cpp:2095
 msgid "aMule API server parameters"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2091
+#: src/muuli_wdr.cpp:2098
 msgid "Run amuleapi (REST API) on startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2096
+#: src/muuli_wdr.cpp:2103
 msgid "HTTP port:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2110
+#: src/muuli_wdr.cpp:2117
 msgid "The interface amuleapi's HTTP server listens on. 127.0.0.1 (default) accepts only local connections; use 0.0.0.0 or a specific IP to expose it to other hosts (set an admin password below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2113
+#: src/muuli_wdr.cpp:2120
 msgid "Admin password"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2118 src/muuli_wdr.cpp:2149
+#: src/muuli_wdr.cpp:2125 src/muuli_wdr.cpp:2156
 msgid "Low rights password"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2126
+#: src/muuli_wdr.cpp:2133
 msgid "Web server parameters"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2129
+#: src/muuli_wdr.cpp:2136
 msgid "Run webserver on startup (deprecated)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2135
+#: src/muuli_wdr.cpp:2142
 msgid "Web template"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2140
+#: src/muuli_wdr.cpp:2147
 msgid "Full rights password"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2144
+#: src/muuli_wdr.cpp:2151
 msgid "Enable Low rights User"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2163
+#: src/muuli_wdr.cpp:2170
 msgid "Enable UPnP port forwarding of the web server port"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2168
+#: src/muuli_wdr.cpp:2175
 msgid "Web server UPnP TCP port (Optional)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2176
+#: src/muuli_wdr.cpp:2183
 msgid "Page Refresh Time (in secs)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2183
+#: src/muuli_wdr.cpp:2190
 msgid "Enable Gzip compression"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2217
+#: src/muuli_wdr.cpp:2224
 msgid "Reset page to defaults"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2218
+#: src/muuli_wdr.cpp:2225
 msgid "Reset the settings on the current page to their default values."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2220 src/muuli_wdr.cpp:2306 src/ServerWnd.cpp:274
+#: src/muuli_wdr.cpp:2227 src/muuli_wdr.cpp:2313 src/ServerWnd.cpp:274
 #: src/ServerWnd.cpp:282
 msgid "OK"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2222
+#: src/muuli_wdr.cpp:2229
 msgid "Click here to apply any changes made to the preferences."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2225
+#: src/muuli_wdr.cpp:2232
 msgid "Reset any changes made to the preferences."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2254
+#: src/muuli_wdr.cpp:2261
 msgid "Comment :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2261
+#: src/muuli_wdr.cpp:2268
 msgid "Incoming Dir :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2270
+#: src/muuli_wdr.cpp:2277
 msgid "Change priority for new assigned files :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2274
+#: src/muuli_wdr.cpp:2281
 msgid "Don't change"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2286
+#: src/muuli_wdr.cpp:2293
 msgid "Select color for this Category (currently selected) :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2353 src/muuli_wdr.cpp:2372 src/muuli_wdr.cpp:2394
+#: src/muuli_wdr.cpp:2360 src/muuli_wdr.cpp:2379 src/muuli_wdr.cpp:2401
 msgid "Click this button to reset the log."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2413
+#: src/muuli_wdr.cpp:2420
 msgid "Click on this button to update the servers list from URL ..."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2417
+#: src/muuli_wdr.cpp:2424
 msgid "Server list"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2421
+#: src/muuli_wdr.cpp:2428
 msgid "Enter the url to a server.met file here and press the button to the left to update the list of known servers."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2426
+#: src/muuli_wdr.cpp:2433
 msgid "Add server manually: Name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2429
+#: src/muuli_wdr.cpp:2436
 msgid "Enter the name of the new server here"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2431 src/ServerWnd.cpp:206
+#: src/muuli_wdr.cpp:2438 src/ServerWnd.cpp:206
 msgid "IP:Port"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2434
+#: src/muuli_wdr.cpp:2441
 msgid "Enter the IP of the server here, using the x.x.x.x format."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2440
+#: src/muuli_wdr.cpp:2447
 msgid "Enter the port of the server here."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2443
+#: src/muuli_wdr.cpp:2450
 msgid "Add manually a server (fill fields to the left before) ..."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2472
+#: src/muuli_wdr.cpp:2479
 msgid "aMule Log"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2480
+#: src/muuli_wdr.cpp:2487
 msgid "Server Info"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2484
+#: src/muuli_wdr.cpp:2491
 msgid "ED2K Info"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2488
+#: src/muuli_wdr.cpp:2495
 msgid "Kad Info"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2516
+#: src/muuli_wdr.cpp:2523
 msgid "Click on this button to update the nodes list from URL ..."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2520
+#: src/muuli_wdr.cpp:2527
 msgid "Nodes (0)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2524
+#: src/muuli_wdr.cpp:2531
 msgid "Enter the url to a nodes.dat file here and press the button to the left to update the list of known nodes."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2527
+#: src/muuli_wdr.cpp:2534
 msgid "Nodes stats"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2569
+#: src/muuli_wdr.cpp:2576
 msgid "Bootstrap"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2572
+#: src/muuli_wdr.cpp:2579
 msgid "New node"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2577
+#: src/muuli_wdr.cpp:2584
 msgid "IP:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2597
+#: src/muuli_wdr.cpp:2604
 msgid "Port:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2610
+#: src/muuli_wdr.cpp:2617
 msgid "Bootstrap from known clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2612
+#: src/muuli_wdr.cpp:2619
 msgid "Disconnect Kad"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2646
+#: src/muuli_wdr.cpp:2653
 msgid "Use Secure User Identification"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2648
+#: src/muuli_wdr.cpp:2655
 msgid "It is recommended to enable this option. You will not receive credits if SUI is not enabled."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2650
+#: src/muuli_wdr.cpp:2657
 msgid "Protocol Obfuscation"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2653
+#: src/muuli_wdr.cpp:2660
 msgid "Support Protocol Obfuscation"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2655
+#: src/muuli_wdr.cpp:2662
 msgid "This option enabled Protocol Obfuscation, and makes aMule accept obfuscated connections from other clients."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2657
+#: src/muuli_wdr.cpp:2664
 msgid "Use obfuscation for outgoing connections"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2659
+#: src/muuli_wdr.cpp:2666
 msgid "This option makes aMule use Protocol Obfuscation when connecting other clients/servers."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2661
+#: src/muuli_wdr.cpp:2668
 msgid "Accept only obfuscated connections"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2662
+#: src/muuli_wdr.cpp:2669
 msgid "This option makes aMule only accept obfuscated connections. You will have less sources, but all your traffic will be obfuscated"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2667
+#: src/muuli_wdr.cpp:2674
 msgid "Everybody"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2669
+#: src/muuli_wdr.cpp:2676
 msgid "No one"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2671
+#: src/muuli_wdr.cpp:2678
 msgid "Who can see my shared files:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2672
+#: src/muuli_wdr.cpp:2679
 msgid "Select who can request to view a list of your shared files."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2674
+#: src/muuli_wdr.cpp:2681
 msgid "IP-Filtering"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2681
+#: src/muuli_wdr.cpp:2688
 msgid "Filter clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2683
+#: src/muuli_wdr.cpp:2690
 msgid "Enable filtering of the client IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2685
+#: src/muuli_wdr.cpp:2692
 msgid "Filter servers"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2687
+#: src/muuli_wdr.cpp:2694
 msgid "Enable filtering of the server IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2691
+#: src/muuli_wdr.cpp:2698
 msgid "Reload List"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2692
+#: src/muuli_wdr.cpp:2699
 msgid "Reload the list of IPs to filter from the file ~/.aMule/ipfilter.dat"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2698
+#: src/muuli_wdr.cpp:2705
 msgid "URL:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2702 src/muuli_wdr.cpp:2895
+#: src/muuli_wdr.cpp:2709 src/muuli_wdr.cpp:2902
 msgid "Update now"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2705
+#: src/muuli_wdr.cpp:2712
 msgid "Auto-update ipfilter at startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2709
+#: src/muuli_wdr.cpp:2716
 msgid "Filtering Level:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2715
+#: src/muuli_wdr.cpp:2722
 msgid "Always filter LAN IPs"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2718
+#: src/muuli_wdr.cpp:2725
 msgid "Paranoid handling of non-matching IPs"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2720
+#: src/muuli_wdr.cpp:2727
 msgid "Rejects a packet when its source IP differs from the IP the client claims (an anti-spoofing check). Disable only if it causes connection problems."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2722
+#: src/muuli_wdr.cpp:2729
 msgid "Use system-wide ipfilter.dat if available"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2723
+#: src/muuli_wdr.cpp:2730
 msgid "If there's no local ipfilter.dat found, allow usage of a system-wide ipfilter file."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2740
+#: src/muuli_wdr.cpp:2747
 msgid "Enable Online-Signature"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2742
+#: src/muuli_wdr.cpp:2749
 msgid "Enables the writing of the OS file, which can be used by external apps to create signatures and the like."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2746
+#: src/muuli_wdr.cpp:2753
 msgid "Update Frequency (Secs):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2749
+#: src/muuli_wdr.cpp:2756
 msgid "Change the frequency (in seconds) of Online Signature updates."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2757
+#: src/muuli_wdr.cpp:2764
 msgid "Save online signature file in: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:2763
+#: src/muuli_wdr.cpp:2770
 msgid "Click here to select the directory containing the the Online Signature files."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2796
+#: src/muuli_wdr.cpp:2803
 msgid "Show country flags for clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2797
+#: src/muuli_wdr.cpp:2804
 msgid "Render the country flag column in the transfers, queue and search views. Requires a valid MMDB GeoIP database (see below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2802
+#: src/muuli_wdr.cpp:2809
 msgid "Database"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2818
+#: src/muuli_wdr.cpp:2825
 msgid "Source:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2821
+#: src/muuli_wdr.cpp:2828
 msgid "DB-IP (free, no account)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2822
+#: src/muuli_wdr.cpp:2829
 msgid "MaxMind GeoLite2 (free, account required)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2823
+#: src/muuli_wdr.cpp:2830
 msgid "Custom URL"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2826
+#: src/muuli_wdr.cpp:2833
 msgid "Choose which provider supplies the GeoIP MMDB database. DB-IP is the default - no account required. MaxMind requires a free account + license key. Use Custom URL to point at any other MMDB host (e.g. a local mirror)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2843
+#: src/muuli_wdr.cpp:2850
 msgid ""
 "No configuration required.\n"
 "\n"
@@ -4723,11 +4736,11 @@ msgid ""
 "License: Creative Commons BY 4.0 - https://creativecommons.org/licenses/by/4.0/"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2856
+#: src/muuli_wdr.cpp:2863
 msgid "License key:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2862
+#: src/muuli_wdr.cpp:2869
 msgid ""
 "Sign up for a free MaxMind account, then generate a License Key:\n"
 "https://www.maxmind.com/en/geolite2/signup\n"
@@ -4737,222 +4750,222 @@ msgid ""
 "Requires attribution and account registration; refresh at least every 30 days."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2877
+#: src/muuli_wdr.cpp:2884
 msgid "Download URL:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2883
+#: src/muuli_wdr.cpp:2890
 msgid ""
 "Must point to an .mmdb file or a .gz / .tar.gz containing one.\n"
 "URL may include credentials (https://user:pass@host/...).\n"
 "License and attribution terms are set by the upstream URL - you are responsible."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2896
+#: src/muuli_wdr.cpp:2903
 msgid "Download the GeoIP database from the selected source."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2898
+#: src/muuli_wdr.cpp:2905
 msgid "Auto-update on startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2899
+#: src/muuli_wdr.cpp:2906
 msgid "Re-download the GeoIP database from the selected source every time aMule starts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2922
+#: src/muuli_wdr.cpp:2929
 msgid "Filter incoming messages (except current chat):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2924
+#: src/muuli_wdr.cpp:2931
 msgid "Filter all messages"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2926
+#: src/muuli_wdr.cpp:2933
 msgid "Filter messages from people not on your friend list"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2928
+#: src/muuli_wdr.cpp:2935
 msgid "Filter messages from unknown clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2930
+#: src/muuli_wdr.cpp:2937
 msgid "Filter messages containing (use ',' as separator):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2933 src/muuli_wdr.cpp:2944
+#: src/muuli_wdr.cpp:2940 src/muuli_wdr.cpp:2951
 msgid "add here the words amule should filter and block messages including it"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2935
+#: src/muuli_wdr.cpp:2942
 msgid "Show received messages in the log"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2938
+#: src/muuli_wdr.cpp:2945
 msgid "Comments"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2941
+#: src/muuli_wdr.cpp:2948
 msgid "Filter comments containing (use ',' as separator):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2966
+#: src/muuli_wdr.cpp:2973
 msgid "Enable Proxy"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2967
+#: src/muuli_wdr.cpp:2974
 msgid "Enable/disable proxy support"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2970
+#: src/muuli_wdr.cpp:2977
 msgid "Proxy type:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2981
+#: src/muuli_wdr.cpp:2988
 msgid "Proxy host:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2984
+#: src/muuli_wdr.cpp:2991
 msgid "The proxy host name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2986
+#: src/muuli_wdr.cpp:2993
 msgid "Proxy port:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2989
+#: src/muuli_wdr.cpp:2996
 msgid "The proxy port"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2991
+#: src/muuli_wdr.cpp:2998
 msgid "Enable authentication"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2992
+#: src/muuli_wdr.cpp:2999
 msgid "Enable/disable username/password authentication"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2995
+#: src/muuli_wdr.cpp:3002
 msgid "Username: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:2998
+#: src/muuli_wdr.cpp:3005
 msgid "The username to use to connect to the proxy"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3000
+#: src/muuli_wdr.cpp:3007
 msgid "Password:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3003
+#: src/muuli_wdr.cpp:3010
 msgid "The password to use to connect to the proxy"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3022
+#: src/muuli_wdr.cpp:3029
 msgid "Connect to:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3031
+#: src/muuli_wdr.cpp:3038
 msgid "Login to remote amule"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3036
+#: src/muuli_wdr.cpp:3043
 msgid "User name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3047
+#: src/muuli_wdr.cpp:3054
 msgid "Remember those settings"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3050
+#: src/muuli_wdr.cpp:3057
 msgid "Force ZLIB compression"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3074
+#: src/muuli_wdr.cpp:3081
 msgid "Enable Verbose Debug-Logging."
 msgstr ""
 
-#: src/muuli_wdr.cpp:3076
+#: src/muuli_wdr.cpp:3083
 msgid "Only to Logfile"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3078
+#: src/muuli_wdr.cpp:3085
 msgid "Message Categories:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3102 src/PartFileConvertDlg.cpp:160
+#: src/muuli_wdr.cpp:3109 src/PartFileConvertDlg.cpp:160
 msgid "Waiting..."
 msgstr ""
 
-#: src/muuli_wdr.cpp:3122
+#: src/muuli_wdr.cpp:3129
 msgid "Add imports"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3125
+#: src/muuli_wdr.cpp:3132
 msgid "Retry selected"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3127
+#: src/muuli_wdr.cpp:3134
 msgid "Remove selected"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3190
+#: src/muuli_wdr.cpp:3197
 msgid "Event Types"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3209
+#: src/muuli_wdr.cpp:3216
 msgid "Statistics and queued clients for selected file(s) : Session / All time"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3233
+#: src/muuli_wdr.cpp:3240
 msgid "Active Uploads"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3247
+#: src/muuli_wdr.cpp:3254
 msgid "Percent of total files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3299
+#: src/muuli_wdr.cpp:3306
 msgid "Show Clients for"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3301
+#: src/muuli_wdr.cpp:3308
 msgid "All files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3304
+#: src/muuli_wdr.cpp:3311
 msgid "Selected files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3307
+#: src/muuli_wdr.cpp:3314
 msgid "Active uploads only"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3314
+#: src/muuli_wdr.cpp:3321
 msgid "Reload:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3318
+#: src/muuli_wdr.cpp:3325
 msgid "Reload your shared files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3381
+#: src/muuli_wdr.cpp:3388
 msgid "Send"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3382
+#: src/muuli_wdr.cpp:3389
 msgid "Sends the specified message."
 msgstr ""
 
-#: src/muuli_wdr.cpp:3386
+#: src/muuli_wdr.cpp:3393
 msgid "Close this chat-session."
 msgstr ""
 
-#: src/muuli_wdr.cpp:3409
+#: src/muuli_wdr.cpp:3416
 msgid "Connect to any server and/or Kad"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3415 src/SharedFilesCtrl.cpp:142 src/Statistics.cpp:941
+#: src/muuli_wdr.cpp:3422 src/SharedFilesCtrl.cpp:142 src/Statistics.cpp:941
 msgid "Shared Files"
 msgstr ""
 
@@ -5310,187 +5323,187 @@ msgstr ""
 msgid "ERROR: Failed to open partfile '%s'"
 msgstr ""
 
-#: src/Preferences.cpp:673
+#: src/Preferences.cpp:674
 msgid "System default"
 msgstr ""
 
-#: src/Preferences.cpp:674
+#: src/Preferences.cpp:675
 msgid "Albanian"
 msgstr ""
 
-#: src/Preferences.cpp:675
+#: src/Preferences.cpp:676
 msgid "Arabic"
 msgstr ""
 
-#: src/Preferences.cpp:676
+#: src/Preferences.cpp:677
 msgid "Asturian"
 msgstr ""
 
-#: src/Preferences.cpp:677
+#: src/Preferences.cpp:678
 msgid "Basque"
 msgstr ""
 
-#: src/Preferences.cpp:678
+#: src/Preferences.cpp:679
 msgid "Bulgarian"
 msgstr ""
 
-#: src/Preferences.cpp:679
+#: src/Preferences.cpp:680
 msgid "Catalan"
 msgstr ""
 
-#: src/Preferences.cpp:680
+#: src/Preferences.cpp:681
 msgid "Chinese (Simplified)"
 msgstr ""
 
-#: src/Preferences.cpp:681
+#: src/Preferences.cpp:682
 msgid "Chinese (Traditional)"
 msgstr ""
 
-#: src/Preferences.cpp:682
+#: src/Preferences.cpp:683
 msgid "Croatian"
 msgstr ""
 
-#: src/Preferences.cpp:683
+#: src/Preferences.cpp:684
 msgid "Czech"
 msgstr ""
 
-#: src/Preferences.cpp:684
+#: src/Preferences.cpp:685
 msgid "Danish"
 msgstr ""
 
-#: src/Preferences.cpp:685
+#: src/Preferences.cpp:686
 msgid "Dutch"
 msgstr ""
 
-#: src/Preferences.cpp:686
+#: src/Preferences.cpp:687
 msgid "English (U.K.)"
 msgstr ""
 
-#: src/Preferences.cpp:687
+#: src/Preferences.cpp:688
 msgid "English (U.S.)"
 msgstr ""
 
-#: src/Preferences.cpp:688
+#: src/Preferences.cpp:689
 msgid "Estonian"
 msgstr ""
 
-#: src/Preferences.cpp:689
+#: src/Preferences.cpp:690
 msgid "Finnish"
 msgstr ""
 
-#: src/Preferences.cpp:690
+#: src/Preferences.cpp:691
 msgid "French"
 msgstr ""
 
-#: src/Preferences.cpp:691
+#: src/Preferences.cpp:692
 msgid "Galician"
 msgstr ""
 
-#: src/Preferences.cpp:692
+#: src/Preferences.cpp:693
 msgid "German"
 msgstr ""
 
-#: src/Preferences.cpp:693
+#: src/Preferences.cpp:694
 msgid "Greek"
 msgstr ""
 
-#: src/Preferences.cpp:694
+#: src/Preferences.cpp:695
 msgid "Hebrew"
 msgstr ""
 
-#: src/Preferences.cpp:695
+#: src/Preferences.cpp:696
 msgid "Hungarian"
 msgstr ""
 
-#: src/Preferences.cpp:696
+#: src/Preferences.cpp:697
 msgid "Italian"
 msgstr ""
 
-#: src/Preferences.cpp:697
+#: src/Preferences.cpp:698
 msgid "Japanese"
 msgstr ""
 
-#: src/Preferences.cpp:698
+#: src/Preferences.cpp:699
 msgid "Korean"
 msgstr ""
 
-#: src/Preferences.cpp:699
+#: src/Preferences.cpp:700
 msgid "Latvian"
 msgstr ""
 
-#: src/Preferences.cpp:700
+#: src/Preferences.cpp:701
 msgid "Lithuanian"
 msgstr ""
 
-#: src/Preferences.cpp:701
+#: src/Preferences.cpp:702
 msgid "Norwegian (Nynorsk)"
 msgstr ""
 
-#: src/Preferences.cpp:702
+#: src/Preferences.cpp:703
 msgid "Polish"
 msgstr ""
 
-#: src/Preferences.cpp:703
+#: src/Preferences.cpp:704
 msgid "Portuguese"
 msgstr ""
 
-#: src/Preferences.cpp:704
+#: src/Preferences.cpp:705
 msgid "Portuguese (Brazilian)"
 msgstr ""
 
-#: src/Preferences.cpp:705
+#: src/Preferences.cpp:706
 msgid "Romanian"
 msgstr ""
 
-#: src/Preferences.cpp:706
+#: src/Preferences.cpp:707
 msgid "Russian"
 msgstr ""
 
-#: src/Preferences.cpp:707
+#: src/Preferences.cpp:708
 msgid "Slovenian"
 msgstr ""
 
-#: src/Preferences.cpp:708
+#: src/Preferences.cpp:709
 msgid "Spanish"
 msgstr ""
 
-#: src/Preferences.cpp:709
+#: src/Preferences.cpp:710
 msgid "Swedish"
 msgstr ""
 
-#: src/Preferences.cpp:710
+#: src/Preferences.cpp:711
 msgid "Turkish"
 msgstr ""
 
-#: src/Preferences.cpp:711
+#: src/Preferences.cpp:712
 msgid "Ukrainian"
 msgstr ""
 
-#: src/Preferences.cpp:814
+#: src/Preferences.cpp:815
 msgid "Change Language"
 msgstr ""
 
-#: src/Preferences.cpp:878
+#: src/Preferences.cpp:879
 msgid "There are no translations installed for aMule"
 msgstr ""
 
-#: src/Preferences.cpp:879
+#: src/Preferences.cpp:880
 msgid "No languages available"
 msgstr ""
 
-#: src/Preferences.cpp:1010
+#: src/Preferences.cpp:1011
 msgid "no options available"
 msgstr ""
 
-#: src/Preferences.cpp:2179
+#: src/Preferences.cpp:2182
 msgid "Invalid category found, skipping"
 msgstr ""
 
-#: src/Preferences.cpp:2348
+#: src/Preferences.cpp:2351
 msgid "TCP port can't be higher than 65532 due to server UDP socket being TCP+3"
 msgstr ""
 
-#: src/Preferences.cpp:2349
+#: src/Preferences.cpp:2352
 #, c-format
 msgid "Default port will be used (%d)"
 msgstr ""
@@ -5960,23 +5973,27 @@ msgstr ""
 msgid "Shared folder"
 msgstr ""
 
-#: src/SearchDlg.cpp:425
+#: src/SearchDlg.cpp:280
+msgid "Clear search history"
+msgstr ""
+
+#: src/SearchDlg.cpp:584
 msgid "It's impossible to search when both eD2k and Kademlia are disabled."
 msgstr ""
 
-#: src/SearchDlg.cpp:426 src/SearchListCtrl.cpp:858
+#: src/SearchDlg.cpp:585 src/SearchListCtrl.cpp:858
 msgid "Search error"
 msgstr ""
 
-#: src/SearchDlg.cpp:768
+#: src/SearchDlg.cpp:929
 msgid "Min size must be smaller than max size. Max size ignored."
 msgstr ""
 
-#: src/SearchDlg.cpp:769 src/SearchDlg.cpp:851
+#: src/SearchDlg.cpp:930 src/SearchDlg.cpp:1012
 msgid "Search warning"
 msgstr ""
 
-#: src/SearchDlg.cpp:929 src/SearchListCtrl.cpp:735
+#: src/SearchDlg.cpp:1092 src/SearchListCtrl.cpp:735
 msgid "Main"
 msgstr ""
 

--- a/po/vi.po
+++ b/po/vi.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-28 12:12+0200\n"
+"POT-Creation-Date: 2026-07-28 08:06+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: none\n"
@@ -131,7 +131,7 @@ msgstr ""
 msgid "Not now"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:422 src/amuleDlg.cpp:665
+#: src/AppImageIntegration.cpp:422 src/amuleDlg.cpp:600
 msgid "Don't ask again"
 msgstr ""
 
@@ -188,152 +188,152 @@ msgstr ""
 msgid "WARNING: You can't add yourself as a source for an eD2k link while having a lowid."
 msgstr ""
 
-#: src/amule.cpp:301
+#: src/amule.cpp:300
 msgid "Now, exiting main app..."
 msgstr ""
 
-#: src/amule.cpp:331
+#: src/amule.cpp:330
 #, c-format
 msgid "Terminating amuleweb instance with pid '%d' ... "
 msgstr ""
 
-#: src/amule.cpp:335
+#: src/amule.cpp:334
 #, c-format
 msgid "Killing amuleweb instance with pid '%d' ... "
 msgstr ""
 
-#: src/amule.cpp:337 src/amule.cpp:350 src/ClientRef.cpp:180
-#: src/SearchDlg.cpp:1041 src/ServerListCtrl.cpp:98
+#: src/amule.cpp:336 src/amule.cpp:349 src/ClientRef.cpp:180
+#: src/SearchDlg.cpp:880 src/ServerListCtrl.cpp:98
 msgid "Failed"
 msgstr ""
 
-#: src/amule.cpp:344
+#: src/amule.cpp:343
 #, c-format
 msgid "Terminating amuleapi instance with pid '%d' ... "
 msgstr ""
 
-#: src/amule.cpp:348
+#: src/amule.cpp:347
 #, c-format
 msgid "Killing amuleapi instance with pid '%d' ... "
 msgstr ""
 
-#: src/amule.cpp:356
+#: src/amule.cpp:355
 msgid "aMule OnExit: Terminating core."
 msgstr ""
 
-#: src/amule.cpp:467
+#: src/amule.cpp:466
 msgid "aMule shutdown completed."
 msgstr ""
 
-#: src/amule.cpp:471
+#: src/amule.cpp:470
 msgid "Memory debug results for aMule exit:"
 msgstr ""
 
-#: src/amule.cpp:652
+#: src/amule.cpp:651
 #, c-format
 msgid "Binding aMule's peer-to-peer traffic to interface: %s (HTTP updates use the default route)"
 msgstr ""
 
-#: src/amule.cpp:656
+#: src/amule.cpp:655
 #, c-format
 msgid "Binding all network traffic to interface: %s"
 msgstr ""
 
-#: src/amule.cpp:660
+#: src/amule.cpp:659
 #, c-format
 msgid "WARNING: configured network interface '%s' was not found - traffic is NOT bound to it and may leave via the default route. Check the interface name in Preferences."
 msgstr ""
 
-#: src/amule.cpp:666
+#: src/amule.cpp:665
 #, c-format
 msgid "WARNING: binding to network interface '%s' requires elevated privileges and was NOT applied - traffic may leave via the default route. Grant the capability (e.g. 'sudo setcap cap_net_raw+ep' on the aMule binary) or run with sufficient privileges."
 msgstr ""
 
-#: src/amule.cpp:674
+#: src/amule.cpp:673
 #, c-format
 msgid "WARNING: could not bind to network interface '%s' - traffic may leave via the default route."
 msgstr ""
 
-#: src/amule.cpp:733
+#: src/amule.cpp:732
 msgid "Your locale has been changed to System Default due to a configuration change. Sorry."
 msgstr ""
 
-#: src/amule.cpp:735 src/amule.cpp:1589 src/CatDialog.cpp:128
+#: src/amule.cpp:734 src/amule.cpp:1581 src/CatDialog.cpp:128
 #: src/CatDialog.cpp:136 src/CatDialog.cpp:149 src/ServerList.cpp:366
 #: src/ServerListCtrl.cpp:152
 msgid "Info"
 msgstr ""
 
-#: src/amule.cpp:742
+#: src/amule.cpp:741
 msgid ""
 "\n"
 "EC configuration"
 msgstr ""
 
-#: src/amule.cpp:745
+#: src/amule.cpp:744
 msgid "Password set and external connections enabled."
 msgstr ""
 
-#: src/amule.cpp:755 src/KadDlg.cpp:176 src/KadDlg.cpp:185
-#: src/PrefsUnifiedDlg.cpp:1461 src/SharedFilesCtrl.cpp:476
+#: src/amule.cpp:754 src/KadDlg.cpp:176 src/KadDlg.cpp:185
+#: src/PrefsUnifiedDlg.cpp:1387 src/SharedFilesCtrl.cpp:476
 msgid "WARNING"
 msgstr ""
 
-#: src/amule.cpp:992
+#: src/amule.cpp:991
 msgid "Network bootstrap"
 msgstr ""
 
-#: src/amule.cpp:997
+#: src/amule.cpp:996
 msgid ""
 "aMule has detected missing network bootstrap files.\n"
 "Select which ones to download:"
 msgstr ""
 
-#: src/amule.cpp:1006 src/FirstRunWizard.cpp:411
+#: src/amule.cpp:1005 src/FirstRunWizard.cpp:411
 msgid "eD2k server list (server.met)"
 msgstr ""
 
-#: src/amule.cpp:1013 src/FirstRunWizard.cpp:416
+#: src/amule.cpp:1012 src/FirstRunWizard.cpp:416
 msgid "Kad bootstrap nodes (nodes.dat)"
 msgstr ""
 
-#: src/amule.cpp:1103
+#: src/amule.cpp:1102
 #, c-format
 msgid "web server running on pid %d"
 msgstr ""
 
-#: src/amule.cpp:1116
+#: src/amule.cpp:1115
 msgid "You requested to run web server on startup, but the amuleweb binary cannot be run. Please install the package containing aMule web server, or build aMule from source with -DBUILD_WEBSERVER=YES and install it."
 msgstr ""
 
-#: src/amule.cpp:1121 src/amule.cpp:1185 src/amule.cpp:1299 src/amule.cpp:1601
+#: src/amule.cpp:1120 src/amule.cpp:1177 src/amule.cpp:1291 src/amule.cpp:1593
 #: src/amule-remote-gui.cpp:603 src/amule-remote-gui.cpp:671
 #: src/amule-remote-gui.cpp:709 src/amule-remote-gui.cpp:1282
 #: src/amule-remote-gui.cpp:1345 src/amule-remote-gui.cpp:1372
-#: src/DownloadQueue.cpp:1481 src/PrefsUnifiedDlg.cpp:1247
+#: src/DownloadQueue.cpp:1481
 msgid "ERROR"
 msgstr ""
 
-#: src/amule.cpp:1174
+#: src/amule.cpp:1166
 #, c-format
 msgid "amuleapi running on pid %d"
 msgstr ""
 
-#: src/amule.cpp:1180
+#: src/amule.cpp:1172
 msgid "You requested to run amuleapi on startup, but the amuleapi binary cannot be run. Please install the package containing aMule's REST API server, or build aMule from source with -DBUILD_AMULEAPI=YES and install it."
 msgstr ""
 
-#: src/amule.cpp:1267
+#: src/amule.cpp:1259
 #, c-format
 msgid "Could not bind ports to the specified address: %s"
 msgstr ""
 
-#: src/amule.cpp:1291
+#: src/amule.cpp:1283
 #, c-format
 msgid "Port %u is not available. You will be LOWID\n"
 msgstr ""
 
-#: src/amule.cpp:1296
+#: src/amule.cpp:1288
 #, c-format
 msgid ""
 "Port %u is not available!\n"
@@ -343,184 +343,184 @@ msgid ""
 "Check your network to make sure the port is open for output and input."
 msgstr ""
 
-#: src/amule.cpp:1393
+#: src/amule.cpp:1385
 msgid "Failed to create OnlineSig File"
 msgstr ""
 
-#: src/amule.cpp:1401
+#: src/amule.cpp:1393
 msgid "Failed to create aMule OnlineSig File"
 msgstr ""
 
-#: src/amule.cpp:1564
+#: src/amule.cpp:1556
 msgid "The selected locale seems not to be installed on your box. (Note: I'll try to set it anyway)"
 msgstr ""
 
-#: src/amule.cpp:1574
+#: src/amule.cpp:1566
 #, c-format
 msgid "This is the first time you run aMule %s"
 msgstr ""
 
-#: src/amule.cpp:1577
+#: src/amule.cpp:1569
 msgid "This version is a testing version, updated daily, and\n"
 msgstr ""
 
-#: src/amule.cpp:1578
+#: src/amule.cpp:1570
 msgid "we give no warranty it won't break anything, burn your house,\n"
 msgstr ""
 
-#: src/amule.cpp:1579
+#: src/amule.cpp:1571
 msgid "or kill your dog. But it *should* be safe to use anyway.\n"
 msgstr ""
 
-#: src/amule.cpp:1584
+#: src/amule.cpp:1576
 msgid "More information, support and new releases can found at our homepage,\n"
 msgstr ""
 
-#: src/amule.cpp:1585
+#: src/amule.cpp:1577
 msgid "at https://amule-org.github.io, or in our IRC channel #aMule at irc.libera.chat.\n"
 msgstr ""
 
-#: src/amule.cpp:1587
+#: src/amule.cpp:1579
 msgid "Feel free to report any bugs to https://github.com/amule-org/amule/issues"
 msgstr ""
 
-#: src/amule.cpp:1599
+#: src/amule.cpp:1591
 msgid ""
 "The folder for Online Signature files you specified is INVALID!\n"
 " OnlineSignature will be DISABLED until you fix it on preferences."
 msgstr ""
 
-#: src/amule.cpp:1662
+#: src/amule.cpp:1654
 msgid "Server hostname notified"
 msgstr ""
 
-#: src/amule.cpp:2039
+#: src/amule.cpp:2031
 #, c-format
 msgid "Disk space preallocation for file '%s' failed: %s"
 msgstr ""
 
-#: src/amule.cpp:2168
+#: src/amule.cpp:2160
 msgid "ERROR: can't open logfile"
 msgstr ""
 
-#: src/amule.cpp:2172
+#: src/amule.cpp:2164
 msgid "WARNING: logfile is empty. Something is wrong."
 msgstr ""
 
-#: src/amule.cpp:2189
+#: src/amule.cpp:2181
 msgid "Log has been reset"
 msgstr ""
 
-#: src/amule.cpp:2213
+#: src/amule.cpp:2205
 #, c-format
 msgid "ServerMessage: %s"
 msgstr ""
 
-#: src/amule.cpp:2256 src/IP2Country.cpp:220 src/IPFilter.cpp:514
+#: src/amule.cpp:2248 src/IP2Country.cpp:220 src/IPFilter.cpp:514
 #: src/ServerList.cpp:875
 #, c-format
 msgid "Skipped download of %s, because requested file is not newer."
 msgstr ""
 
-#: src/amule.cpp:2259
+#: src/amule.cpp:2251
 msgid "Failed to download the nodes list."
 msgstr ""
 
-#: src/amule.cpp:2322
+#: src/amule.cpp:2314
 msgid "Failed to open the downloaded version check file"
 msgstr ""
 
-#: src/amule.cpp:2325 src/amule.cpp:2344
+#: src/amule.cpp:2317 src/amule.cpp:2336
 msgid "Corrupted version check file"
 msgstr ""
 
-#: src/amule.cpp:2367
+#: src/amule.cpp:2359
 msgid "You are using an outdated version of aMule!"
 msgstr ""
 
-#: src/amule.cpp:2369
+#: src/amule.cpp:2361
 #, c-format
 msgid "Your aMule version is %i.%i.%i and the latest version is %li.%li.%li"
 msgstr ""
 
-#: src/amule.cpp:2373
+#: src/amule.cpp:2365
 msgid "The latest version can always be found at https://github.com/amule-org/amule/releases/latest"
 msgstr ""
 
-#: src/amule.cpp:2376
+#: src/amule.cpp:2368
 #, c-format
 msgid "WARNING: Your aMuled version is outdated: %i.%i.%i < %li.%li.%li"
 msgstr ""
 
-#: src/amule.cpp:2382
+#: src/amule.cpp:2374
 msgid "Your copy of aMule is up to date."
 msgstr ""
 
-#: src/amule.cpp:2389
+#: src/amule.cpp:2381
 msgid "Failed to download the version check file"
 msgstr ""
 
-#: src/amule.cpp:2558 src/amule-remote-gui.cpp:1133
+#: src/amule.cpp:2550 src/amule-remote-gui.cpp:1133
 #, c-format
 msgid "Users: %s | Files: %s"
 msgstr ""
 
-#: src/amule.cpp:2559 src/amule-remote-gui.cpp:1134
+#: src/amule.cpp:2551 src/amule-remote-gui.cpp:1134
 #, c-format
 msgid "Users: E: %s K: %s | Files: E: %s K: %s"
 msgstr ""
 
-#: src/amule.cpp:2573 src/amule-remote-gui.cpp:1147
+#: src/amule.cpp:2565 src/amule-remote-gui.cpp:1147
 msgid "No networks selected"
 msgstr ""
 
-#: src/amule.cpp:2641 src/TextClient.cpp:903
+#: src/amule.cpp:2633 src/TextClient.cpp:903
 msgid "with LowID"
 msgstr ""
 
-#: src/amule.cpp:2641 src/TextClient.cpp:904
+#: src/amule.cpp:2633 src/TextClient.cpp:904
 msgid "with HighID"
 msgstr ""
 
-#: src/amule.cpp:2643
+#: src/amule.cpp:2635
 #, c-format
 msgid "Connected to %s %s"
 msgstr ""
 
-#: src/amule.cpp:2648
+#: src/amule.cpp:2640
 #, c-format
 msgid "Connecting to %s"
 msgstr ""
 
-#: src/amule.cpp:2650
+#: src/amule.cpp:2642
 msgid "Disconnected from eD2k"
 msgstr ""
 
-#: src/amule.cpp:2659
+#: src/amule.cpp:2651
 msgid "Kad started."
 msgstr ""
 
-#: src/amule.cpp:2661
+#: src/amule.cpp:2653
 msgid "Kad stopped."
 msgstr ""
 
-#: src/amule.cpp:2669
+#: src/amule.cpp:2661
 msgid "Connected to Kad (ok)"
 msgstr ""
 
-#: src/amule.cpp:2671
+#: src/amule.cpp:2663
 msgid "Connected to Kad (firewalled)"
 msgstr ""
 
-#: src/amule.cpp:2675
+#: src/amule.cpp:2667
 msgid "Disconnected from Kad"
 msgstr ""
 
-#: src/amule.cpp:2707
+#: src/amule.cpp:2699
 msgid "Kad network cannot be used if UDP port is disabled on preferences, not starting."
 msgstr ""
 
-#: src/amule.cpp:2711
+#: src/amule.cpp:2703
 msgid "Kad network disabled on preferences, not connecting."
 msgstr ""
 
@@ -545,67 +545,29 @@ msgstr ""
 msgid "ERROR: %s"
 msgstr ""
 
-#: src/amuleDlg.cpp:250
+#: src/amuleDlg.cpp:236
 #, c-format
 msgid "This is aMule %s based on eMule."
 msgstr ""
 
-#: src/amuleDlg.cpp:251
+#: src/amuleDlg.cpp:237
 #, c-format
 msgid "Running on %s"
 msgstr ""
 
-#: src/amuleDlg.cpp:253
+#: src/amuleDlg.cpp:239
 msgid "Visit https://github.com/amule-org/amule/releases/latest to check if a new version is available."
 msgstr ""
 
-#: src/amuleDlg.cpp:282
+#: src/amuleDlg.cpp:268
 msgid "FATAL ERROR: Failed to create Timer"
 msgstr ""
 
-#: src/amuleDlg.cpp:361 src/amuleDlg.cpp:1810 src/amuleDlg.cpp:2056
-#: src/muuli_wdr.cpp:1492 src/muuli_wdr.cpp:3439
-msgid "Networks"
-msgstr ""
-
-#: src/amuleDlg.cpp:362 src/amuleDlg.cpp:1816 src/muuli_wdr.cpp:3440
-msgid "Searches"
-msgstr ""
-
-#: src/amuleDlg.cpp:363 src/amuleDlg.cpp:1822 src/DownloadListCtrl.cpp:740
-#: src/muuli_wdr.cpp:392 src/muuli_wdr.cpp:1585 src/muuli_wdr.cpp:3441
-#: src/Statistics.cpp:829
-msgid "Downloads"
-msgstr ""
-
-#: src/amuleDlg.cpp:364 src/amuleDlg.cpp:1828 src/muuli_wdr.cpp:3315
-msgid "Shared files"
-msgstr ""
-
-#: src/amuleDlg.cpp:365 src/amuleDlg.cpp:1834 src/muuli_wdr.cpp:2947
-#: src/muuli_wdr.cpp:3397 src/muuli_wdr.cpp:3444
-msgid "Messages"
-msgstr ""
-
-#: src/amuleDlg.cpp:366 src/amuleDlg.cpp:1840 src/muuli_wdr.cpp:3445
-#: src/PrefsUnifiedDlg.cpp:314 src/Statistics.cpp:779 src/Statistics.cpp:1235
-msgid "Statistics"
-msgstr ""
-
-#: src/amuleDlg.cpp:368 src/amuleDlg.cpp:1847 src/muuli_wdr.cpp:3447
-#: src/PrefsUnifiedDlg.cpp:330 src/utils/wxCas/src/wxcasprefs.cpp:39
-msgid "Preferences"
-msgstr ""
-
-#: src/amuleDlg.cpp:371
-msgid "Navigate"
-msgstr ""
-
-#: src/amuleDlg.cpp:657
+#: src/amuleDlg.cpp:592
 msgid "New version available"
 msgstr ""
 
-#: src/amuleDlg.cpp:661
+#: src/amuleDlg.cpp:596
 #, c-format
 msgid ""
 "A new version of aMule (%s) is available.\n"
@@ -615,184 +577,217 @@ msgid ""
 "Would you like to open the download page?"
 msgstr ""
 
-#: src/amuleDlg.cpp:743
+#: src/amuleDlg.cpp:678
 msgid "aMule dialog destroyed"
 msgstr ""
 
-#: src/amuleDlg.cpp:766 src/DataToText.cpp:68 src/IPFilter.cpp:547
+#: src/amuleDlg.cpp:701 src/DataToText.cpp:68 src/IPFilter.cpp:547
 msgid "Connecting"
 msgstr ""
 
-#: src/amuleDlg.cpp:958
+#: src/amuleDlg.cpp:893
 msgid "eD2k: Connecting"
 msgstr ""
 
-#: src/amuleDlg.cpp:962
+#: src/amuleDlg.cpp:897
 msgid "eD2k: Disconnected"
 msgstr ""
 
-#: src/amuleDlg.cpp:968
+#: src/amuleDlg.cpp:903
 msgid "Kad: Firewalled"
 msgstr ""
 
-#: src/amuleDlg.cpp:972
+#: src/amuleDlg.cpp:907
 msgid "Kad: Connected"
 msgstr ""
 
-#: src/amuleDlg.cpp:977
+#: src/amuleDlg.cpp:912
 msgid "Kad: Connecting"
 msgstr ""
 
-#: src/amuleDlg.cpp:981
+#: src/amuleDlg.cpp:916
 msgid "Kad: Off"
 msgstr ""
 
-#: src/amuleDlg.cpp:1029 src/DownloadListCtrl.cpp:505
+#: src/amuleDlg.cpp:964 src/DownloadListCtrl.cpp:505
 #: src/DownloadListCtrl.cpp:749 src/FriendListCtrl.cpp:180
 #: src/muuli_wdr.cpp:731 src/muuli_wdr.cpp:782 src/muuli_wdr.cpp:846
-#: src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2252 src/muuli_wdr.cpp:2337
-#: src/muuli_wdr.cpp:3085 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
+#: src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2224 src/muuli_wdr.cpp:2309
+#: src/muuli_wdr.cpp:3057 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
 #: src/ServerListCtrl.cpp:606 src/TransferWnd.cpp:378
 #: src/utils/wxCas/src/wxcasprefs.cpp:235
 msgid "Cancel"
 msgstr ""
 
-#: src/amuleDlg.cpp:1030
+#: src/amuleDlg.cpp:965
 msgid "Stop the current connection attempts"
 msgstr ""
 
-#: src/amuleDlg.cpp:1035 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976
-#: src/muuli_wdr.cpp:2475
+#: src/amuleDlg.cpp:970 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976
+#: src/muuli_wdr.cpp:2447
 msgid "Disconnect"
 msgstr ""
 
-#: src/amuleDlg.cpp:1036
+#: src/amuleDlg.cpp:971
 msgid "Disconnect from the currently connected networks"
 msgstr ""
 
-#: src/amuleDlg.cpp:1041 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979
-#: src/muuli_wdr.cpp:2630 src/muuli_wdr.cpp:3082 src/muuli_wdr.cpp:3437
+#: src/amuleDlg.cpp:976 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979
+#: src/muuli_wdr.cpp:2602 src/muuli_wdr.cpp:3054 src/muuli_wdr.cpp:3409
 msgid "Connect"
 msgstr ""
 
-#: src/amuleDlg.cpp:1042
+#: src/amuleDlg.cpp:977
 msgid "Connect to the currently enabled networks"
 msgstr ""
 
-#: src/amuleDlg.cpp:1154
+#: src/amuleDlg.cpp:1089
 #, c-format
 msgid "Up: %.1f%s (%.1f) | Down: %.1f%s (%.1f)"
 msgstr ""
 
-#: src/amuleDlg.cpp:1156 src/amuleDlg.cpp:1158 src/amuleDlg.cpp:1162
-#: src/amuleDlg.cpp:1164 src/amuleDlg.cpp:1175 src/amuleDlg.cpp:1177
+#: src/amuleDlg.cpp:1091 src/amuleDlg.cpp:1093 src/amuleDlg.cpp:1097
+#: src/amuleDlg.cpp:1099 src/amuleDlg.cpp:1110 src/amuleDlg.cpp:1112
 #: src/MuleTrayIcon.cpp:796 src/MuleTrayIcon.cpp:799
 msgid " MB/s"
 msgstr ""
 
-#: src/amuleDlg.cpp:1156 src/amuleDlg.cpp:1158 src/amuleDlg.cpp:1162
-#: src/amuleDlg.cpp:1164 src/amuleDlg.cpp:1175 src/amuleDlg.cpp:1177
+#: src/amuleDlg.cpp:1091 src/amuleDlg.cpp:1093 src/amuleDlg.cpp:1097
+#: src/amuleDlg.cpp:1099 src/amuleDlg.cpp:1110 src/amuleDlg.cpp:1112
 #: src/MuleTrayIcon.cpp:796 src/MuleTrayIcon.cpp:799
 #: src/utils/wxCas/src/wxcasframe.cpp:1041
 msgid " kB/s"
 msgstr ""
 
-#: src/amuleDlg.cpp:1161
+#: src/amuleDlg.cpp:1096
 #, c-format
 msgid "Up: %.1f%s | Down: %.1f%s"
 msgstr ""
 
-#: src/amuleDlg.cpp:1193
+#: src/amuleDlg.cpp:1128
 #, c-format
 msgid "aMule (%s | Connected)"
 msgstr ""
 
-#: src/amuleDlg.cpp:1195
+#: src/amuleDlg.cpp:1130
 #, c-format
 msgid "aMule (%s | Disconnected)"
 msgstr ""
 
-#: src/amuleDlg.cpp:1248
+#: src/amuleDlg.cpp:1183
 #, c-format
 msgid "Do you really want to exit %s?"
 msgstr ""
 
-#: src/amuleDlg.cpp:1250
+#: src/amuleDlg.cpp:1185
 msgid "Exit confirmation"
 msgstr ""
 
-#: src/amuleDlg.cpp:1613
+#: src/amuleDlg.cpp:1548
 msgid "Launch Command: "
 msgstr ""
 
-#: src/amuleDlg.cpp:1632 src/muuli_wdr.cpp:1972 src/Preferences.cpp:979
+#: src/amuleDlg.cpp:1567 src/muuli_wdr.cpp:1971 src/Preferences.cpp:951
 msgid "- default -"
 msgstr ""
 
-#: src/amuleDlg.cpp:1660
+#: src/amuleDlg.cpp:1595
 #, c-format
 msgid "Skin directory '%s' does not exist"
 msgstr ""
 
-#: src/amuleDlg.cpp:1663
+#: src/amuleDlg.cpp:1598
 #, c-format
 msgid "WARNING: Unable to open skin file '%s' for read"
 msgstr ""
 
-#: src/amuleDlg.cpp:1814 src/muuli_wdr.cpp:3439
+#: src/amuleDlg.cpp:1722 src/amuleDlg.cpp:1968 src/muuli_wdr.cpp:1485
+#: src/muuli_wdr.cpp:3411
+msgid "Networks"
+msgstr ""
+
+#: src/amuleDlg.cpp:1726 src/muuli_wdr.cpp:3411
 msgid "Networks Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1820 src/muuli_wdr.cpp:3440
+#: src/amuleDlg.cpp:1728 src/muuli_wdr.cpp:3412
+msgid "Searches"
+msgstr ""
+
+#: src/amuleDlg.cpp:1732 src/muuli_wdr.cpp:3412
 msgid "Searches Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1826 src/muuli_wdr.cpp:3441
+#: src/amuleDlg.cpp:1734 src/DownloadListCtrl.cpp:740 src/muuli_wdr.cpp:392
+#: src/muuli_wdr.cpp:1578 src/muuli_wdr.cpp:3413 src/Statistics.cpp:829
+msgid "Downloads"
+msgstr ""
+
+#: src/amuleDlg.cpp:1738 src/muuli_wdr.cpp:3413
 msgid "Downloads Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1832 src/muuli_wdr.cpp:3443
+#: src/amuleDlg.cpp:1740 src/muuli_wdr.cpp:3287
+msgid "Shared files"
+msgstr ""
+
+#: src/amuleDlg.cpp:1744 src/muuli_wdr.cpp:3415
 msgid "Shared Files Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3444
+#: src/amuleDlg.cpp:1746 src/muuli_wdr.cpp:2919 src/muuli_wdr.cpp:3369
+#: src/muuli_wdr.cpp:3416
+msgid "Messages"
+msgstr ""
+
+#: src/amuleDlg.cpp:1750 src/muuli_wdr.cpp:3416
 msgid "Messages Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1844 src/muuli_wdr.cpp:3445
+#: src/amuleDlg.cpp:1752 src/muuli_wdr.cpp:3417 src/PrefsUnifiedDlg.cpp:312
+#: src/Statistics.cpp:779 src/Statistics.cpp:1235
+msgid "Statistics"
+msgstr ""
+
+#: src/amuleDlg.cpp:1756 src/muuli_wdr.cpp:3417
 msgid "Statistics Graph Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1851 src/muuli_wdr.cpp:3447
+#: src/amuleDlg.cpp:1759 src/muuli_wdr.cpp:3419 src/PrefsUnifiedDlg.cpp:328
+#: src/utils/wxCas/src/wxcasprefs.cpp:39
+msgid "Preferences"
+msgstr ""
+
+#: src/amuleDlg.cpp:1763 src/muuli_wdr.cpp:3419
 msgid "Preferences Settings Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1854 src/muuli_wdr.cpp:3448
+#: src/amuleDlg.cpp:1766 src/muuli_wdr.cpp:3420
 msgid "Import"
 msgstr ""
 
-#: src/amuleDlg.cpp:1858 src/muuli_wdr.cpp:3448
+#: src/amuleDlg.cpp:1770 src/muuli_wdr.cpp:3420
 msgid "The partfile importer tool"
 msgstr ""
 
-#: src/amuleDlg.cpp:1861 src/muuli_wdr.cpp:3449
+#: src/amuleDlg.cpp:1773 src/muuli_wdr.cpp:3421
 #: src/utils/aLinkCreator/src/alcframe.cpp:262
 msgid "About"
 msgstr ""
 
-#: src/amuleDlg.cpp:1861 src/muuli_wdr.cpp:3449
+#: src/amuleDlg.cpp:1773 src/muuli_wdr.cpp:3421
 msgid "About/Help"
 msgstr ""
 
-#: src/amuleDlg.cpp:2059
+#: src/amuleDlg.cpp:1971
 msgid "eD2k network"
 msgstr ""
 
-#: src/amuleDlg.cpp:2062
+#: src/amuleDlg.cpp:1974
 msgid "Kad network"
 msgstr ""
 
-#: src/amuleDlg.cpp:2062
+#: src/amuleDlg.cpp:1974
 msgid "No network"
 msgstr ""
 
@@ -917,7 +912,7 @@ msgstr ""
 msgid "The core rejected these shared folders:%s"
 msgstr ""
 
-#: src/amule-remote-gui.cpp:1336 src/ExternalConn.cpp:2346
+#: src/amule-remote-gui.cpp:1336 src/ExternalConn.cpp:2345
 msgid "Invalid link or already on list."
 msgstr ""
 
@@ -933,7 +928,7 @@ msgstr ""
 #: src/ClientDetailDialog.cpp:123 src/DataToText.cpp:61 src/DataToText.cpp:86
 #: src/DataToText.cpp:101 src/DataToText.cpp:136 src/DataToText.cpp:165
 #: src/DownloadListCtrl.cpp:1172 src/DownloadListCtrl.cpp:1185
-#: src/DownloadListCtrl.cpp:1196 src/ExternalConn.cpp:609
+#: src/DownloadListCtrl.cpp:1196 src/ExternalConn.cpp:608
 #: src/FileDetailDialog.cpp:203 src/FileDetailDialog.cpp:235
 #: src/FileDetailDialog.cpp:242 src/GenericClientListCtrl.cpp:1171
 #: src/GenericClientListCtrl.cpp:1182 src/GenericClientListCtrl.cpp:1192
@@ -1319,19 +1314,19 @@ msgstr ""
 msgid "Very low"
 msgstr ""
 
-#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:743 src/muuli_wdr.cpp:2303
+#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:743 src/muuli_wdr.cpp:2275
 #: src/ServerListCtrl.cpp:263 src/ServerListCtrl.cpp:456
 #: src/SharedFilesCtrl.cpp:145
 msgid "Low"
 msgstr ""
 
-#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:744 src/muuli_wdr.cpp:2304
+#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:744 src/muuli_wdr.cpp:2276
 #: src/ServerListCtrl.cpp:266 src/ServerListCtrl.cpp:457
 #: src/SharedFilesCtrl.cpp:146
 msgid "Normal"
 msgstr ""
 
-#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:745 src/muuli_wdr.cpp:2305
+#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:745 src/muuli_wdr.cpp:2277
 #: src/ServerListCtrl.cpp:269 src/ServerListCtrl.cpp:458
 #: src/SharedFilesCtrl.cpp:147
 msgid "High"
@@ -1423,8 +1418,8 @@ msgstr ""
 msgid "Remote Server"
 msgstr ""
 
-#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3202
-#: src/SearchDlg.cpp:119 src/TextClient.cpp:911
+#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3174
+#: src/SearchDlg.cpp:111 src/TextClient.cpp:911
 msgid "Kad"
 msgstr ""
 
@@ -1494,7 +1489,7 @@ msgstr ""
 msgid "Size"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3269
+#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3241
 msgid "Transferred"
 msgstr ""
 
@@ -1550,7 +1545,7 @@ msgid ""
 "\n"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:746 src/muuli_wdr.cpp:2306
+#: src/DownloadListCtrl.cpp:746 src/muuli_wdr.cpp:2278
 #: src/SharedFilesCtrl.cpp:150
 msgid "Auto"
 msgstr ""
@@ -1588,7 +1583,7 @@ msgid "Extended Options"
 msgstr ""
 
 #: src/DownloadListCtrl.cpp:770 src/DownloadListCtrl.cpp:822
-#: src/muuli_wdr.cpp:1790
+#: src/muuli_wdr.cpp:1789
 msgid "Preview"
 msgstr ""
 
@@ -1761,230 +1756,225 @@ msgstr[1] ""
 msgid "Invalid eD2k link! ERROR: %s"
 msgstr ""
 
-#: src/ExternalConn.cpp:380
+#: src/ExternalConn.cpp:379
 msgid "Client sent packet after authentication failed."
 msgstr ""
 
-#: src/ExternalConn.cpp:397
+#: src/ExternalConn.cpp:396
 msgid "External connection closed."
 msgstr ""
 
-#: src/ExternalConn.cpp:474
+#: src/ExternalConn.cpp:473
 msgid "External connections disabled due to empty password!"
 msgstr ""
 
-#: src/ExternalConn.cpp:495
+#: src/ExternalConn.cpp:494
 msgid "External connections disabled in config file"
 msgstr ""
 
-#: src/ExternalConn.cpp:576
+#: src/ExternalConn.cpp:575
 msgid "New external connection accepted"
 msgstr ""
 
-#: src/ExternalConn.cpp:579
+#: src/ExternalConn.cpp:578
 msgid "ERROR: couldn't accept a new external connection"
 msgstr ""
 
-#: src/ExternalConn.cpp:596
+#: src/ExternalConn.cpp:595
 msgid "External connection refused due to empty password in preferences!"
 msgstr ""
 
-#: src/ExternalConn.cpp:608
+#: src/ExternalConn.cpp:607
 #, c-format
 msgid "Connecting client: %s %s"
 msgstr ""
 
-#: src/ExternalConn.cpp:610
+#: src/ExternalConn.cpp:609
 msgid "Unknown version"
 msgstr ""
 
-#: src/ExternalConn.cpp:623
+#: src/ExternalConn.cpp:622
 msgid "Incorrect EC version ID, there might be binary incompatibility. Use core and remote from same snapshot."
 msgstr ""
 
-#: src/ExternalConn.cpp:631
+#: src/ExternalConn.cpp:630
 msgid "You cannot connect to a release version from an arbitrary development snapshot! *sigh* possible crash prevented"
 msgstr ""
 
-#: src/ExternalConn.cpp:714
+#: src/ExternalConn.cpp:713
 msgid "Invalid protocol version."
 msgstr ""
 
-#: src/ExternalConn.cpp:720
+#: src/ExternalConn.cpp:719
 msgid "Missing protocol version tag."
 msgstr ""
 
-#: src/ExternalConn.cpp:728
+#: src/ExternalConn.cpp:727
 msgid "Authentication failed: invalid hash specified as EC password."
 msgstr ""
 
-#: src/ExternalConn.cpp:776
+#: src/ExternalConn.cpp:775
 msgid "Authentication failed: wrong password."
 msgstr ""
 
-#: src/ExternalConn.cpp:778
+#: src/ExternalConn.cpp:777
 msgid "Authentication failed: missing password."
 msgstr ""
 
-#: src/ExternalConn.cpp:789
+#: src/ExternalConn.cpp:788
 msgid "Invalid request, please authenticate first."
 msgstr ""
 
-#: src/ExternalConn.cpp:794
+#: src/ExternalConn.cpp:793
 msgid "Access granted."
 msgstr ""
 
-#: src/ExternalConn.cpp:802
+#: src/ExternalConn.cpp:801
 #, c-format
 msgid "Sent error message \"%s\" to client."
 msgstr ""
 
-#: src/ExternalConn.cpp:807
+#: src/ExternalConn.cpp:806
 #, c-format
 msgid "Unauthorized access attempt from %s. Connection closed."
 msgstr ""
 
-#: src/ExternalConn.cpp:1420
+#: src/ExternalConn.cpp:1419
 #, c-format
 msgid "Remote PartFile command failed: FileHash not found: %s"
 msgstr ""
 
-#: src/ExternalConn.cpp:1424
+#: src/ExternalConn.cpp:1423
 #, c-format
 msgid "FileHash not found: %s"
 msgstr ""
 
-#: src/ExternalConn.cpp:1471 src/ExternalConn.cpp:1559
-#: src/ExternalConn.cpp:1680
+#: src/ExternalConn.cpp:1470 src/ExternalConn.cpp:1558
+#: src/ExternalConn.cpp:1679
 msgid "OOPS! OpCode processing error!"
 msgstr ""
 
-#: src/ExternalConn.cpp:1502
+#: src/ExternalConn.cpp:1501
 msgid "Server not added"
 msgstr ""
 
-#: src/ExternalConn.cpp:1521
+#: src/ExternalConn.cpp:1520
 #, c-format
 msgid "server not found: %s"
 msgstr ""
 
-#: src/ExternalConn.cpp:1538
+#: src/ExternalConn.cpp:1537
 msgid "need to define server to be removed"
 msgstr ""
 
-#: src/ExternalConn.cpp:1553
+#: src/ExternalConn.cpp:1552
 msgid "eD2k is disabled in preferences."
 msgstr ""
 
-#: src/ExternalConn.cpp:1658
+#: src/ExternalConn.cpp:1657
 msgid "Friend not found."
 msgstr ""
 
-#: src/ExternalConn.cpp:1668
+#: src/ExternalConn.cpp:1667
 msgid "Client not found."
 msgstr ""
 
-#: src/ExternalConn.cpp:1674
+#: src/ExternalConn.cpp:1673
 msgid "EC_TAG_FRIEND_SHARED requires EC_TAG_FRIEND or EC_TAG_CLIENT."
 msgstr ""
 
-#: src/ExternalConn.cpp:1992
+#: src/ExternalConn.cpp:1991
 msgid "WebSearch from remote interface makes no sense."
 msgstr ""
 
-#: src/ExternalConn.cpp:2027
+#: src/ExternalConn.cpp:2026
 msgid "Search in progress. Refetch results in a moment!"
 msgstr ""
 
-#: src/ExternalConn.cpp:2266
+#: src/ExternalConn.cpp:2265
 msgid "No points for graph."
 msgstr ""
 
-#: src/ExternalConn.cpp:2276
+#: src/ExternalConn.cpp:2275
 msgid "Your client is not configured for this detail level."
 msgstr ""
 
-#: src/ExternalConn.cpp:2303
+#: src/ExternalConn.cpp:2302
 msgid "External Connection: shutdown requested"
 msgstr ""
 
-#: src/ExternalConn.cpp:2315
+#: src/ExternalConn.cpp:2314
 msgid "Already shutting down."
 msgstr ""
 
-#: src/ExternalConn.cpp:2333
+#: src/ExternalConn.cpp:2332
 #, c-format
 msgid "ExternalConn: adding link '%s'."
 msgstr ""
 
-#: src/ExternalConn.cpp:2351
+#: src/ExternalConn.cpp:2350
 #, c-format
 msgid "%d of %d links failed (invalid or already on list)."
 msgstr ""
 
-#: src/ExternalConn.cpp:2374
+#: src/ExternalConn.cpp:2373
 msgid "Version check throttled; try again shortly."
 msgstr ""
 
-#: src/ExternalConn.cpp:2379
+#: src/ExternalConn.cpp:2378
 msgid "Version check is not available on this daemon."
 msgstr ""
 
-#: src/ExternalConn.cpp:2509
+#: src/ExternalConn.cpp:2508
 msgid "File not found."
 msgstr ""
 
-#: src/ExternalConn.cpp:2514
+#: src/ExternalConn.cpp:2513
 msgid "Invalid file name."
 msgstr ""
 
-#: src/ExternalConn.cpp:2522
+#: src/ExternalConn.cpp:2521
 msgid "Unable to rename file."
 msgstr ""
 
-#: src/ExternalConn.cpp:2839
-#, c-format
-msgid "Could not save the amuleapi password: %s"
-msgstr ""
-
-#: src/ExternalConn.cpp:3004 src/ExternalConn.cpp:3032
+#: src/ExternalConn.cpp:2992 src/ExternalConn.cpp:3020
 msgid "Kad is disabled in preferences."
 msgstr ""
 
-#: src/ExternalConn.cpp:3045
+#: src/ExternalConn.cpp:3033
 msgid "Already connected to eD2k."
 msgstr ""
 
-#: src/ExternalConn.cpp:3048
+#: src/ExternalConn.cpp:3036
 msgid "Connecting to eD2k..."
 msgstr ""
 
-#: src/ExternalConn.cpp:3057
+#: src/ExternalConn.cpp:3045
 msgid "Already connected to Kad."
 msgstr ""
 
-#: src/ExternalConn.cpp:3060
+#: src/ExternalConn.cpp:3048
 msgid "Connecting to Kad..."
 msgstr ""
 
-#: src/ExternalConn.cpp:3067
+#: src/ExternalConn.cpp:3055
 msgid "All networks are disabled."
 msgstr ""
 
-#: src/ExternalConn.cpp:3076
+#: src/ExternalConn.cpp:3064
 msgid "Disconnected from eD2k."
 msgstr ""
 
-#: src/ExternalConn.cpp:3081
+#: src/ExternalConn.cpp:3069
 msgid "Disconnected from Kad."
 msgstr ""
 
-#: src/ExternalConn.cpp:3090
+#: src/ExternalConn.cpp:3078
 #, c-format
 msgid "External Connection: invalid opcode received: %#x"
 msgstr ""
 
-#: src/ExternalConn.cpp:3095
+#: src/ExternalConn.cpp:3083
 msgid "Invalid opcode (wrong protocol version?)"
 msgstr ""
 
@@ -2271,19 +2261,19 @@ msgstr ""
 msgid "eD2k"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:349 src/muuli_wdr.cpp:1495
+#: src/FirstRunWizard.cpp:349 src/muuli_wdr.cpp:1488
 msgid "Kademlia"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:359 src/muuli_wdr.cpp:1423
+#: src/FirstRunWizard.cpp:359 src/muuli_wdr.cpp:1416
 msgid "Standard TCP Port "
 msgstr ""
 
-#: src/FirstRunWizard.cpp:365 src/muuli_wdr.cpp:1435
+#: src/FirstRunWizard.cpp:365 src/muuli_wdr.cpp:1428
 msgid "Extended UDP port (Kad / global search) "
 msgstr ""
 
-#: src/FirstRunWizard.cpp:377 src/muuli_wdr.cpp:1442
+#: src/FirstRunWizard.cpp:377 src/muuli_wdr.cpp:1435
 msgid "Enable UPnP for router port forwarding"
 msgstr ""
 
@@ -2308,7 +2298,7 @@ msgstr ""
 msgid "Your peer lists are already in place - nothing to download."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:434 src/muuli_wdr.cpp:1540
+#: src/FirstRunWizard.cpp:434 src/muuli_wdr.cpp:1533
 msgid "Auto-update server list at startup"
 msgstr ""
 
@@ -2354,23 +2344,23 @@ msgid ""
 "want downloads on a different (e.g. larger) disk."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:549 src/FirstRunWizard.cpp:611 src/muuli_wdr.cpp:1702
+#: src/FirstRunWizard.cpp:549 src/FirstRunWizard.cpp:611 src/muuli_wdr.cpp:1701
 msgid "Destination folder for downloads"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:553 src/FirstRunWizard.cpp:569 src/muuli_wdr.cpp:1349
-#: src/muuli_wdr.cpp:1366 src/muuli_wdr.cpp:1677 src/muuli_wdr.cpp:1708
-#: src/muuli_wdr.cpp:1720 src/muuli_wdr.cpp:2790
+#: src/FirstRunWizard.cpp:553 src/FirstRunWizard.cpp:569 src/muuli_wdr.cpp:1342
+#: src/muuli_wdr.cpp:1359 src/muuli_wdr.cpp:1676 src/muuli_wdr.cpp:1707
+#: src/muuli_wdr.cpp:1719 src/muuli_wdr.cpp:2762
 #: src/utils/aLinkCreator/src/alcframe.cpp:135
 #: src/utils/wxCas/src/wxcasprefs.cpp:52 src/utils/wxCas/src/wxcasprefs.cpp:118
 msgid "Browse"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:559 src/muuli_wdr.cpp:1713
+#: src/FirstRunWizard.cpp:559 src/muuli_wdr.cpp:1712
 msgid "(All files in this folder are shared with other peers)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:565 src/FirstRunWizard.cpp:624 src/muuli_wdr.cpp:1715
+#: src/FirstRunWizard.cpp:565 src/FirstRunWizard.cpp:624 src/muuli_wdr.cpp:1714
 msgid "Folder for temporary download files"
 msgstr ""
 
@@ -2401,7 +2391,7 @@ msgstr ""
 msgid "CRITICAL - no client on StartChatSession"
 msgstr ""
 
-#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2696 src/muuli_wdr.cpp:3373
+#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2668 src/muuli_wdr.cpp:3345
 msgid "Friends"
 msgstr ""
 
@@ -2507,8 +2497,8 @@ msgstr ""
 msgid "No"
 msgstr ""
 
-#: src/GenericClientListCtrl.cpp:1216 src/PrefsUnifiedDlg.cpp:2898
-#: src/PrefsUnifiedDlg.cpp:2948 src/ServerListCtrl.cpp:276
+#: src/GenericClientListCtrl.cpp:1216 src/PrefsUnifiedDlg.cpp:2818
+#: src/PrefsUnifiedDlg.cpp:2868 src/ServerListCtrl.cpp:276
 msgid "Yes"
 msgstr ""
 
@@ -2675,10 +2665,10 @@ msgstr ""
 msgid "Please fill all fields required"
 msgstr ""
 
-#: src/KadDlg.cpp:192 src/PartFile.cpp:1031 src/PrefsUnifiedDlg.cpp:1134
-#: src/PrefsUnifiedDlg.cpp:1204 src/PrefsUnifiedDlg.cpp:1405
-#: src/PrefsUnifiedDlg.cpp:1663 src/PrefsUnifiedDlg.cpp:1673
-#: src/PrefsUnifiedDlg.cpp:1690 src/PrefsUnifiedDlg.cpp:1738
+#: src/KadDlg.cpp:192 src/PartFile.cpp:1031 src/PrefsUnifiedDlg.cpp:1162
+#: src/PrefsUnifiedDlg.cpp:1331 src/PrefsUnifiedDlg.cpp:1589
+#: src/PrefsUnifiedDlg.cpp:1599 src/PrefsUnifiedDlg.cpp:1616
+#: src/PrefsUnifiedDlg.cpp:1658
 msgid "Message"
 msgstr ""
 
@@ -2779,7 +2769,7 @@ msgstr ""
 msgid "Uploaded"
 msgstr ""
 
-#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3253
+#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3225
 msgid "Requested"
 msgstr ""
 
@@ -2902,7 +2892,7 @@ msgid "WARNING: "
 msgstr ""
 
 #: src/MuleNotebook.cpp:179 src/muuli_wdr.cpp:817 src/muuli_wdr.cpp:1229
-#: src/muuli_wdr.cpp:3157 src/muuli_wdr.cpp:3413
+#: src/muuli_wdr.cpp:3129 src/muuli_wdr.cpp:3385
 msgid "Close"
 msgstr ""
 
@@ -2915,12 +2905,12 @@ msgstr ""
 msgid "Copy"
 msgstr ""
 
-#: src/MuleTextCtrl.cpp:88 src/SearchDlg.cpp:261
+#: src/MuleTextCtrl.cpp:88
 msgid "Paste"
 msgstr ""
 
 #: src/MuleTextCtrl.cpp:89 src/muuli_wdr.cpp:358 src/muuli_wdr.cpp:757
-#: src/muuli_wdr.cpp:2380 src/muuli_wdr.cpp:2399 src/muuli_wdr.cpp:2421
+#: src/muuli_wdr.cpp:2352 src/muuli_wdr.cpp:2371 src/muuli_wdr.cpp:2393
 #: src/utils/aLinkCreator/src/alcframe.cpp:142
 msgid "Clear"
 msgstr ""
@@ -3011,8 +3001,8 @@ msgid "Exit"
 msgstr ""
 
 #: src/MuleTrayIcon.cpp:579 src/MuleTrayIcon.cpp:945 src/MuleTrayIcon.cpp:965
-#: src/muuli_wdr.cpp:1398 src/muuli_wdr.cpp:1406 src/muuli_wdr.cpp:1413
-#: src/muuli_wdr.cpp:1836 src/muuli_wdr.cpp:1842 src/OtherFunctions.cpp:91
+#: src/muuli_wdr.cpp:1391 src/muuli_wdr.cpp:1399 src/muuli_wdr.cpp:1406
+#: src/muuli_wdr.cpp:1835 src/muuli_wdr.cpp:1841 src/OtherFunctions.cpp:91
 #: src/StatisticsDlg.cpp:93 src/StatisticsDlg.cpp:95
 msgid "kB/s"
 msgstr ""
@@ -3181,7 +3171,7 @@ msgstr ""
 msgid "Type"
 msgstr ""
 
-#: src/muuli_wdr.cpp:215 src/SearchDlg.cpp:118 src/SearchListCtrl.cpp:853
+#: src/muuli_wdr.cpp:215 src/SearchDlg.cpp:110 src/SearchListCtrl.cpp:853
 msgid "Local"
 msgstr ""
 
@@ -3252,7 +3242,7 @@ msgstr ""
 msgid "KB"
 msgstr ""
 
-#: src/muuli_wdr.cpp:274 src/muuli_wdr.cpp:293 src/muuli_wdr.cpp:1621
+#: src/muuli_wdr.cpp:274 src/muuli_wdr.cpp:293 src/muuli_wdr.cpp:1620
 #: src/OtherFunctions.cpp:64
 msgid "MB"
 msgstr ""
@@ -3269,7 +3259,7 @@ msgstr ""
 msgid "Availability"
 msgstr ""
 
-#: src/muuli_wdr.cpp:312 src/muuli_wdr.cpp:398 src/muuli_wdr.cpp:3318
+#: src/muuli_wdr.cpp:312 src/muuli_wdr.cpp:398 src/muuli_wdr.cpp:3290
 msgid "Filter:"
 msgstr ""
 
@@ -3301,7 +3291,7 @@ msgstr ""
 msgid "Stop"
 msgstr ""
 
-#: src/muuli_wdr.cpp:348 src/muuli_wdr.cpp:1392 src/SearchListCtrl.cpp:732
+#: src/muuli_wdr.cpp:348 src/muuli_wdr.cpp:1385 src/SearchListCtrl.cpp:732
 msgid "Download"
 msgstr ""
 
@@ -3332,12 +3322,12 @@ msgstr ""
 #: src/muuli_wdr.cpp:1160 src/muuli_wdr.cpp:1167 src/muuli_wdr.cpp:1172
 #: src/muuli_wdr.cpp:1179 src/muuli_wdr.cpp:1184 src/muuli_wdr.cpp:1191
 #: src/muuli_wdr.cpp:1205 src/muuli_wdr.cpp:1212 src/muuli_wdr.cpp:1217
-#: src/muuli_wdr.cpp:1224 src/muuli_wdr.cpp:3255 src/muuli_wdr.cpp:3263
-#: src/muuli_wdr.cpp:3271
+#: src/muuli_wdr.cpp:1224 src/muuli_wdr.cpp:3227 src/muuli_wdr.cpp:3235
+#: src/muuli_wdr.cpp:3243
 msgid "N/A"
 msgstr ""
 
-#: src/muuli_wdr.cpp:508 src/muuli_wdr.cpp:1065 src/PrefsUnifiedDlg.cpp:299
+#: src/muuli_wdr.cpp:508 src/muuli_wdr.cpp:1065 src/PrefsUnifiedDlg.cpp:297
 msgid "General"
 msgstr ""
 
@@ -3473,7 +3463,7 @@ msgstr ""
 msgid "Album :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:685 src/muuli_wdr.cpp:2275
+#: src/muuli_wdr.cpp:685 src/muuli_wdr.cpp:2247
 msgid "Title :"
 msgstr ""
 
@@ -3579,7 +3569,7 @@ msgstr ""
 msgid "Userhash :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:895 src/muuli_wdr.cpp:1742 src/muuli_wdr.cpp:2470
+#: src/muuli_wdr.cpp:895 src/muuli_wdr.cpp:1741 src/muuli_wdr.cpp:2442
 #: src/utils/aLinkCreator/src/alcframe.cpp:137
 msgid "Add"
 msgstr ""
@@ -3588,15 +3578,15 @@ msgstr ""
 msgid "Download-Speed"
 msgstr ""
 
-#: src/muuli_wdr.cpp:954 src/muuli_wdr.cpp:989 src/muuli_wdr.cpp:2574
+#: src/muuli_wdr.cpp:954 src/muuli_wdr.cpp:989 src/muuli_wdr.cpp:2546
 msgid "Current"
 msgstr ""
 
-#: src/muuli_wdr.cpp:962 src/muuli_wdr.cpp:997 src/muuli_wdr.cpp:2582
+#: src/muuli_wdr.cpp:962 src/muuli_wdr.cpp:997 src/muuli_wdr.cpp:2554
 msgid "Running average"
 msgstr ""
 
-#: src/muuli_wdr.cpp:970 src/muuli_wdr.cpp:1005 src/muuli_wdr.cpp:2590
+#: src/muuli_wdr.cpp:970 src/muuli_wdr.cpp:1005 src/muuli_wdr.cpp:2562
 msgid "Session average"
 msgstr ""
 
@@ -3608,7 +3598,7 @@ msgstr ""
 msgid "Connections"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1024 src/muuli_wdr.cpp:1861
+#: src/muuli_wdr.cpp:1024 src/muuli_wdr.cpp:1860
 msgid "Active downloads"
 msgstr ""
 
@@ -3616,7 +3606,7 @@ msgstr ""
 msgid "Active connections (1:1)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1040 src/muuli_wdr.cpp:1862
+#: src/muuli_wdr.cpp:1040 src/muuli_wdr.cpp:1861
 msgid "Active uploads"
 msgstr ""
 
@@ -3732,8 +3722,8 @@ msgstr ""
 msgid "Language: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1257 src/muuli_wdr.cpp:1330 src/muuli_wdr.cpp:1334
-#: src/muuli_wdr.cpp:1337
+#: src/muuli_wdr.cpp:1257 src/muuli_wdr.cpp:1323 src/muuli_wdr.cpp:1327
+#: src/muuli_wdr.cpp:1330
 msgid "The delay before showing tool-tips."
 msgstr ""
 
@@ -3809,943 +3799,923 @@ msgstr ""
 msgid "Enabling this will make aMule to show notifications when finished downloading."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1323
-msgid "Remember search history"
-msgstr ""
-
-#: src/muuli_wdr.cpp:1324
-msgid "Keeps a dropdown list of your past search terms in the Search tab's Name field. This remembers the queries you typed, not the results they returned."
-msgstr ""
-
-#: src/muuli_wdr.cpp:1329
+#: src/muuli_wdr.cpp:1322
 msgid "Tooltip delay time: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1336
+#: src/muuli_wdr.cpp:1329
 msgid "seconds"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1340
+#: src/muuli_wdr.cpp:1333
 msgid "Browser Selection"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1346
+#: src/muuli_wdr.cpp:1339
 msgid "Enter your browser name here. Leave this field empty to use the system default browser."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1353
+#: src/muuli_wdr.cpp:1346
 msgid "Open in new tab if possible"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1355
+#: src/muuli_wdr.cpp:1348
 msgid "Open the web page in a new tab instead of in a new window when possible"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1359
+#: src/muuli_wdr.cpp:1352
 msgid "Video Player"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1386
+#: src/muuli_wdr.cpp:1379
 msgid "Bandwidth limits"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1400
+#: src/muuli_wdr.cpp:1393
 msgid "Upload"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1408
+#: src/muuli_wdr.cpp:1401
 msgid "Slot Allocation"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1417
+#: src/muuli_wdr.cpp:1410
 msgid "Ports"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1427
+#: src/muuli_wdr.cpp:1420
 msgid "This is the standard eD2k port and cannot be disabled."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1430
+#: src/muuli_wdr.cpp:1423
 msgid "UDP port for server requests (TCP+3):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1432
+#: src/muuli_wdr.cpp:1425
 msgid "4665"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1439
+#: src/muuli_wdr.cpp:1432
 msgid "This UDP port is used for extended eD2k requests and Kad network"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1446
+#: src/muuli_wdr.cpp:1439
 msgid "UPnP TCP Port (Optional):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1456
+#: src/muuli_wdr.cpp:1449
 msgid "Bind local address to IP (empty for any):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1459
+#: src/muuli_wdr.cpp:1452
 msgid "Advanced users only: If you have multiple network interfaces, enter the address of the interface to which aMule should be bound."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1462 src/muuli_wdr.cpp:2055
+#: src/muuli_wdr.cpp:1455 src/muuli_wdr.cpp:2054
 msgid "Bind to network interface (empty for any):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1475
+#: src/muuli_wdr.cpp:1468
 msgid "Advanced users only: pin all of aMule's traffic to one network interface, chosen from the list or typed in by name (e.g. tun0, eth0, en0) or index. Unlike binding to an IP, this stops traffic leaking out via the default route - useful with a VPN. Requires no elevated privileges."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1481
+#: src/muuli_wdr.cpp:1474
 msgid "Max sources per downloading file:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1485
+#: src/muuli_wdr.cpp:1478
 msgid "Max simultaneous connections:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1498 src/muuli_wdr.cpp:3197
+#: src/muuli_wdr.cpp:1491 src/muuli_wdr.cpp:3169
 msgid "ED2K"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1505
+#: src/muuli_wdr.cpp:1498
 msgid "Autoconnect on startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1508
+#: src/muuli_wdr.cpp:1501
 msgid "Reconnect on loss"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1530
+#: src/muuli_wdr.cpp:1523
 msgid "Remove dead server after"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1531
+#: src/muuli_wdr.cpp:1524
 msgid "Static servers are never removed, even when unreachable."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1535
+#: src/muuli_wdr.cpp:1528
 msgid "retries"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1543
+#: src/muuli_wdr.cpp:1536
 msgid "List"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1546
+#: src/muuli_wdr.cpp:1539
 msgid "Update server list when connecting to a server"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1549
+#: src/muuli_wdr.cpp:1542
 msgid "Update server list when a client connects"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1552
+#: src/muuli_wdr.cpp:1545
 msgid "Use priority system"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1556
+#: src/muuli_wdr.cpp:1549
 msgid "Use smart LowID check on connect"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1560
+#: src/muuli_wdr.cpp:1553
 msgid "Safe connect"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1564
+#: src/muuli_wdr.cpp:1557
 msgid "Autoconnect to servers in static list only"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1567
+#: src/muuli_wdr.cpp:1560
 msgid "Set manually added servers to High Priority"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1588
+#: src/muuli_wdr.cpp:1581
 msgid "Add files to download in pause mode"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1590
+#: src/muuli_wdr.cpp:1583
 msgid "Add files to download with auto priority"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1593
+#: src/muuli_wdr.cpp:1586
 msgid "Try to download first and last chunks first"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1597
+#: src/muuli_wdr.cpp:1590
 msgid "Endgame mode: rotate to faster sources for the final blocks"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1600
+#: src/muuli_wdr.cpp:1593
 msgid "Start next paused file when a file completes"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1603
+#: src/muuli_wdr.cpp:1596
 msgid "From the same category"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1605
+#: src/muuli_wdr.cpp:1598
 msgid "In alphabetic order"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1607
+#: src/muuli_wdr.cpp:1600
 msgid "Preallocate disk space for new files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1608
+#: src/muuli_wdr.cpp:1601
 msgid "For new files preallocates disk space for the whole file, thus reduces fragmentation"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1613
+#: src/muuli_wdr.cpp:1606
+msgid "Create new files as sparse files"
+msgstr ""
+
+#: src/muuli_wdr.cpp:1607
+msgid "A sparse file reserves its full size on disk immediately without writing real data to it -- fast, but unsupported or slow on some filesystems, and free-space accounting stays optimistic while the download is in progress. Turn this off to grow the file only as data arrives."
+msgstr ""
+
+#: src/muuli_wdr.cpp:1612
 msgid "Stop downloads when free disk space reaches "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1614
+#: src/muuli_wdr.cpp:1613
 msgid "Select this if you want aMule to check your disk space"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1618
+#: src/muuli_wdr.cpp:1617
 msgid "Enter here the min disk space desired."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1624
+#: src/muuli_wdr.cpp:1623
 msgid "Save 10 sources on rare files (< 20 sources)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1628 src/Statistics.cpp:790
+#: src/muuli_wdr.cpp:1627 src/Statistics.cpp:790
 msgid "Uploads"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1631
+#: src/muuli_wdr.cpp:1630
 msgid "Add new shared files with auto priority"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1637
+#: src/muuli_wdr.cpp:1636
 msgid "Intelligent Corruption Handling (I.C.H.)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1640
+#: src/muuli_wdr.cpp:1639
 msgid "Enable"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1643
+#: src/muuli_wdr.cpp:1642
 msgid "Advanced I.C.H. trusts every hash (not recommended)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1655 src/PrefsUnifiedDlg.cpp:1990
+#: src/muuli_wdr.cpp:1654 src/PrefsUnifiedDlg.cpp:1910
 msgid "Media metadata extraction"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1659
+#: src/muuli_wdr.cpp:1658
 msgid "Extract length / bitrate / codec from shared audio and video files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1661
+#: src/muuli_wdr.cpp:1660
 msgid "When enabled, aMule runs ffprobe on each shared media file to fill in the Length / Bitrate / Codec columns other clients see when they find the file in a search. Requires ffmpeg (the ffprobe binary) to be installed."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1668
+#: src/muuli_wdr.cpp:1667
 msgid "Path to ffprobe:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1673
+#: src/muuli_wdr.cpp:1672
 msgid "Full path to the ffprobe binary. Leave empty to have aMule auto-detect it on startup."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1681
+#: src/muuli_wdr.cpp:1680
 msgid "Detect"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1682
+#: src/muuli_wdr.cpp:1681
 msgid "Search the standard install locations for an ffprobe binary and fill the path field."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1706
+#: src/muuli_wdr.cpp:1705
 msgid ""
 "Completed downloads are stored here. All files in this folder are automatically shared with other peers.\n"
 "If this folder also holds files you don't want to share, point it at an aMule-only sub-folder."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1709
+#: src/muuli_wdr.cpp:1708
 msgid "Pick the folder where completed downloads will be stored. All files in that folder will be shared with other peers."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1723
+#: src/muuli_wdr.cpp:1722
 msgid "Shared folders"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1729
+#: src/muuli_wdr.cpp:1728
 msgid "(Folders shared by the core. Enter a path to add one.)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1737
+#: src/muuli_wdr.cpp:1736
 msgid "Absolute path of a folder on the core's machine, e.g. /home/user/shared"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1739 src/PrefsUnifiedDlg.cpp:2874
+#: src/muuli_wdr.cpp:1738 src/PrefsUnifiedDlg.cpp:2794
 msgid "Recursive"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1740
+#: src/muuli_wdr.cpp:1739
 msgid "Share every sub-folder underneath this one, including ones created later."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1744 src/utils/aLinkCreator/src/alcframe.cpp:141
+#: src/muuli_wdr.cpp:1743 src/utils/aLinkCreator/src/alcframe.cpp:141
 msgid "Remove"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1748
+#: src/muuli_wdr.cpp:1747
 msgid "(Right click on folder icon for recursive share)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1755
+#: src/muuli_wdr.cpp:1754
 msgid "Share hidden files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1761
+#: src/muuli_wdr.cpp:1760
 msgid "Automatically rescan shared folders for changes"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1767
+#: src/muuli_wdr.cpp:1766
 msgid "Follow symbolic links in shared folders"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1773
+#: src/muuli_wdr.cpp:1772
 msgid "Exclude files matching:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1776
+#: src/muuli_wdr.cpp:1775
 msgid "Wildcard patterns separated by '|', e.g. .DS_Store|Thumbs.db|*.tmp. Files whose name matches are not shared. Matching is case-insensitive."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1780
+#: src/muuli_wdr.cpp:1779
 msgid "Patterns are regular expressions"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1781
+#: src/muuli_wdr.cpp:1780
 msgid "When set, the whole field is one regular expression ('|' is alternation). When unset, it is a list of '|'-separated wildcards."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1791
+#: src/muuli_wdr.cpp:1790
 msgid "Show how many shared files the current pattern would exclude."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1812
+#: src/muuli_wdr.cpp:1811
 msgid "Graphs"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1815 src/muuli_wdr.cpp:1877
+#: src/muuli_wdr.cpp:1814 src/muuli_wdr.cpp:1876
 msgid "Update delay : 5 secs"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1819
+#: src/muuli_wdr.cpp:1818
 msgid "Time for average graph: 100 mins"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1823
+#: src/muuli_wdr.cpp:1822
 msgid "Connections Graph Scale: 100 "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1830
+#: src/muuli_wdr.cpp:1829
 msgid "Download graph scale:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1838
+#: src/muuli_wdr.cpp:1837
 msgid "Upload graph scale:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1848
+#: src/muuli_wdr.cpp:1847
 msgid "Colors: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1852
+#: src/muuli_wdr.cpp:1851
 msgid "Background"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1853
+#: src/muuli_wdr.cpp:1852
 msgid "Grid"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1854
+#: src/muuli_wdr.cpp:1853
 msgid "Download current"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1855
+#: src/muuli_wdr.cpp:1854
 msgid "Download running average"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1856
+#: src/muuli_wdr.cpp:1855
 msgid "Download session average"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1857
+#: src/muuli_wdr.cpp:1856
 msgid "Upload current"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1858
+#: src/muuli_wdr.cpp:1857
 msgid "Upload running average"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1859
+#: src/muuli_wdr.cpp:1858
 msgid "Upload session average"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1860
+#: src/muuli_wdr.cpp:1859
 msgid "Active connections"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1863
+#: src/muuli_wdr.cpp:1862
 msgid "Systray Icon Speed Bar"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1864
+#: src/muuli_wdr.cpp:1863
 msgid "Kad-nodes current"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1865
+#: src/muuli_wdr.cpp:1864
 msgid "Kad-nodes running"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1866
+#: src/muuli_wdr.cpp:1865
 msgid "Kad-nodes session"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1870 src/muuli_wdr.cpp:2324
+#: src/muuli_wdr.cpp:1869 src/muuli_wdr.cpp:2296
 msgid "Select"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1874
+#: src/muuli_wdr.cpp:1873
 msgid "Tree"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1884
+#: src/muuli_wdr.cpp:1883
 msgid "Number of Client Versions shown (0=unlimited)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1909
+#: src/muuli_wdr.cpp:1908
 msgid "!!! WARNING !!!"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1924
+#: src/muuli_wdr.cpp:1923
 msgid "Max new connections / 5 secs"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1926
+#: src/muuli_wdr.cpp:1925
 msgid "Concurrent Kad source lookups"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1928
+#: src/muuli_wdr.cpp:1927
 msgid "Kad source re-search interval (minutes)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1930
+#: src/muuli_wdr.cpp:1929
 msgid "Source re-ask interval (minutes)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1934
+#: src/muuli_wdr.cpp:1933
 msgid "File Buffer Size: 240000 bytes"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1938
+#: src/muuli_wdr.cpp:1937
 msgid "Use MMAP: memory-mapped file access (lower memory use)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1939
+#: src/muuli_wdr.cpp:1938
 msgid "Maps part files into memory instead of buffering them on the heap, lowering the process memory footprint. May reduce download speed on some disks; best for memory-constrained or upload-heavy hosts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1941
+#: src/muuli_wdr.cpp:1940
 msgid "Upload Queue Size: 5000 clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1945
+#: src/muuli_wdr.cpp:1944
 msgid "Server connection refresh interval: Disable"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1949
+#: src/muuli_wdr.cpp:1948
 msgid "Disable computer's timed standby mode"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1968
+#: src/muuli_wdr.cpp:1967
 msgid "Skin to use: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1977
+#: src/muuli_wdr.cpp:1976
 msgid "Show \"Fast eD2k Links Handler\" in every window."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1980
+#: src/muuli_wdr.cpp:1979
 msgid "Show extended info on categories tabs"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1983
+#: src/muuli_wdr.cpp:1982
 msgid "Show application version on title"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1985
+#: src/muuli_wdr.cpp:1984
 msgid "Show transfer rates on title"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1987
+#: src/muuli_wdr.cpp:1986
 msgid "Before application name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1989
+#: src/muuli_wdr.cpp:1988
 msgid "After application name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1992
+#: src/muuli_wdr.cpp:1991
 msgid "Show overhead bandwidth"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1996
+#: src/muuli_wdr.cpp:1995
 msgid "Vertical toolbar orientation"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1998
+#: src/muuli_wdr.cpp:1997
 msgid "Live column sorting (auto-reorder rows as their values change)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2005
+#: src/muuli_wdr.cpp:2004
 msgid "Download Queue Files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2008
+#: src/muuli_wdr.cpp:2007
 msgid "Show progress percentage"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2014
+#: src/muuli_wdr.cpp:2013
 msgid "Show progress bar"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2017
+#: src/muuli_wdr.cpp:2016
 msgid "Flat"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2021
+#: src/muuli_wdr.cpp:2020
 msgid "Round"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2039
+#: src/muuli_wdr.cpp:2038
 msgid "External Connection Parameters"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2042
+#: src/muuli_wdr.cpp:2041
 msgid "Accept external connections"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2049 src/muuli_wdr.cpp:2108
+#: src/muuli_wdr.cpp:2048 src/muuli_wdr.cpp:2107
 msgid "IP of the listening interface:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2052
+#: src/muuli_wdr.cpp:2051
 msgid "Enter here a valid ip in the a.b.c.d format for the listening EC interface. An empty field or 0.0.0.0 will mean any interface."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2073 src/muuli_wdr.cpp:2184
+#: src/muuli_wdr.cpp:2072 src/muuli_wdr.cpp:2156
 msgid "TCP port:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2079
+#: src/muuli_wdr.cpp:2078
 msgid "Enable UPnP port forwarding on the EC port"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2083 src/muuli_wdr.cpp:3069
+#: src/muuli_wdr.cpp:2082 src/muuli_wdr.cpp:3041
 #: src/utils/wxCas/src/wxcasprefs.cpp:167
 msgid "Password"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2089
+#: src/muuli_wdr.cpp:2088
 msgid "aMule API server parameters"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2092
+#: src/muuli_wdr.cpp:2091
 msgid "Run amuleapi (REST API) on startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2097
+#: src/muuli_wdr.cpp:2096
 msgid "HTTP port:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2111
+#: src/muuli_wdr.cpp:2110
 msgid "The interface amuleapi's HTTP server listens on. 127.0.0.1 (default) accepts only local connections; use 0.0.0.0 or a specific IP to expose it to other hosts (set an admin password below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2116
-msgid "Type a password to set or change it. Stored passwords cannot be shown, so leaving this empty keeps the current one."
-msgstr ""
-
-#: src/muuli_wdr.cpp:2118
+#: src/muuli_wdr.cpp:2113
 msgid "Admin password"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2130 src/muuli_wdr.cpp:2147 src/PrefsUnifiedDlg.cpp:1103
-msgid "A password is set."
-msgstr ""
-
-#: src/muuli_wdr.cpp:2134
-msgid "Enable guest access"
-msgstr ""
-
-#: src/muuli_wdr.cpp:2135
-msgid "Guest sessions may read status and listings but cannot change anything. Turning this off clears the stored guest password."
-msgstr ""
-
-#: src/muuli_wdr.cpp:2139
-msgid "Guest password"
-msgstr ""
-
-#: src/muuli_wdr.cpp:2154
-msgid "Web server parameters"
-msgstr ""
-
-#: src/muuli_wdr.cpp:2157
-msgid "Run webserver on startup (deprecated)"
-msgstr ""
-
-#: src/muuli_wdr.cpp:2163
-msgid "Web template"
-msgstr ""
-
-#: src/muuli_wdr.cpp:2168
-msgid "Full rights password"
-msgstr ""
-
-#: src/muuli_wdr.cpp:2172
-msgid "Enable Low rights User"
-msgstr ""
-
-#: src/muuli_wdr.cpp:2177
+#: src/muuli_wdr.cpp:2118 src/muuli_wdr.cpp:2149
 msgid "Low rights password"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2191
+#: src/muuli_wdr.cpp:2126
+msgid "Web server parameters"
+msgstr ""
+
+#: src/muuli_wdr.cpp:2129
+msgid "Run webserver on startup (deprecated)"
+msgstr ""
+
+#: src/muuli_wdr.cpp:2135
+msgid "Web template"
+msgstr ""
+
+#: src/muuli_wdr.cpp:2140
+msgid "Full rights password"
+msgstr ""
+
+#: src/muuli_wdr.cpp:2144
+msgid "Enable Low rights User"
+msgstr ""
+
+#: src/muuli_wdr.cpp:2163
 msgid "Enable UPnP port forwarding of the web server port"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2196
+#: src/muuli_wdr.cpp:2168
 msgid "Web server UPnP TCP port (Optional)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2204
+#: src/muuli_wdr.cpp:2176
 msgid "Page Refresh Time (in secs)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2211
+#: src/muuli_wdr.cpp:2183
 msgid "Enable Gzip compression"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2245
+#: src/muuli_wdr.cpp:2217
 msgid "Reset page to defaults"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2246
+#: src/muuli_wdr.cpp:2218
 msgid "Reset the settings on the current page to their default values."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2248 src/muuli_wdr.cpp:2334 src/ServerWnd.cpp:274
+#: src/muuli_wdr.cpp:2220 src/muuli_wdr.cpp:2306 src/ServerWnd.cpp:274
 #: src/ServerWnd.cpp:282
 msgid "OK"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2250
+#: src/muuli_wdr.cpp:2222
 msgid "Click here to apply any changes made to the preferences."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2253
+#: src/muuli_wdr.cpp:2225
 msgid "Reset any changes made to the preferences."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2282
+#: src/muuli_wdr.cpp:2254
 msgid "Comment :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2289
+#: src/muuli_wdr.cpp:2261
 msgid "Incoming Dir :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2298
+#: src/muuli_wdr.cpp:2270
 msgid "Change priority for new assigned files :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2302
+#: src/muuli_wdr.cpp:2274
 msgid "Don't change"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2314
+#: src/muuli_wdr.cpp:2286
 msgid "Select color for this Category (currently selected) :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2381 src/muuli_wdr.cpp:2400 src/muuli_wdr.cpp:2422
+#: src/muuli_wdr.cpp:2353 src/muuli_wdr.cpp:2372 src/muuli_wdr.cpp:2394
 msgid "Click this button to reset the log."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2441
+#: src/muuli_wdr.cpp:2413
 msgid "Click on this button to update the servers list from URL ..."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2445
+#: src/muuli_wdr.cpp:2417
 msgid "Server list"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2449
+#: src/muuli_wdr.cpp:2421
 msgid "Enter the url to a server.met file here and press the button to the left to update the list of known servers."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2454
+#: src/muuli_wdr.cpp:2426
 msgid "Add server manually: Name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2457
+#: src/muuli_wdr.cpp:2429
 msgid "Enter the name of the new server here"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2459 src/ServerWnd.cpp:206
+#: src/muuli_wdr.cpp:2431 src/ServerWnd.cpp:206
 msgid "IP:Port"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2462
+#: src/muuli_wdr.cpp:2434
 msgid "Enter the IP of the server here, using the x.x.x.x format."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2468
+#: src/muuli_wdr.cpp:2440
 msgid "Enter the port of the server here."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2471
+#: src/muuli_wdr.cpp:2443
 msgid "Add manually a server (fill fields to the left before) ..."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2500
+#: src/muuli_wdr.cpp:2472
 msgid "aMule Log"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2508
+#: src/muuli_wdr.cpp:2480
 msgid "Server Info"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2512
+#: src/muuli_wdr.cpp:2484
 msgid "ED2K Info"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2516
+#: src/muuli_wdr.cpp:2488
 msgid "Kad Info"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2544
+#: src/muuli_wdr.cpp:2516
 msgid "Click on this button to update the nodes list from URL ..."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2548
+#: src/muuli_wdr.cpp:2520
 msgid "Nodes (0)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2552
+#: src/muuli_wdr.cpp:2524
 msgid "Enter the url to a nodes.dat file here and press the button to the left to update the list of known nodes."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2555
+#: src/muuli_wdr.cpp:2527
 msgid "Nodes stats"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2597
+#: src/muuli_wdr.cpp:2569
 msgid "Bootstrap"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2600
+#: src/muuli_wdr.cpp:2572
 msgid "New node"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2605
+#: src/muuli_wdr.cpp:2577
 msgid "IP:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2625
+#: src/muuli_wdr.cpp:2597
 msgid "Port:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2638
+#: src/muuli_wdr.cpp:2610
 msgid "Bootstrap from known clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2640
+#: src/muuli_wdr.cpp:2612
 msgid "Disconnect Kad"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2674
+#: src/muuli_wdr.cpp:2646
 msgid "Use Secure User Identification"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2676
+#: src/muuli_wdr.cpp:2648
 msgid "It is recommended to enable this option. You will not receive credits if SUI is not enabled."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2678
+#: src/muuli_wdr.cpp:2650
 msgid "Protocol Obfuscation"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2681
+#: src/muuli_wdr.cpp:2653
 msgid "Support Protocol Obfuscation"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2683
+#: src/muuli_wdr.cpp:2655
 msgid "This option enabled Protocol Obfuscation, and makes aMule accept obfuscated connections from other clients."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2685
+#: src/muuli_wdr.cpp:2657
 msgid "Use obfuscation for outgoing connections"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2687
+#: src/muuli_wdr.cpp:2659
 msgid "This option makes aMule use Protocol Obfuscation when connecting other clients/servers."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2689
+#: src/muuli_wdr.cpp:2661
 msgid "Accept only obfuscated connections"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2690
+#: src/muuli_wdr.cpp:2662
 msgid "This option makes aMule only accept obfuscated connections. You will have less sources, but all your traffic will be obfuscated"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2695
+#: src/muuli_wdr.cpp:2667
 msgid "Everybody"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2697
+#: src/muuli_wdr.cpp:2669
 msgid "No one"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2699
+#: src/muuli_wdr.cpp:2671
 msgid "Who can see my shared files:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2700
+#: src/muuli_wdr.cpp:2672
 msgid "Select who can request to view a list of your shared files."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2702
+#: src/muuli_wdr.cpp:2674
 msgid "IP-Filtering"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2709
+#: src/muuli_wdr.cpp:2681
 msgid "Filter clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2711
+#: src/muuli_wdr.cpp:2683
 msgid "Enable filtering of the client IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2713
+#: src/muuli_wdr.cpp:2685
 msgid "Filter servers"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2715
+#: src/muuli_wdr.cpp:2687
 msgid "Enable filtering of the server IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2719
+#: src/muuli_wdr.cpp:2691
 msgid "Reload List"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2720
+#: src/muuli_wdr.cpp:2692
 msgid "Reload the list of IPs to filter from the file ~/.aMule/ipfilter.dat"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2726
+#: src/muuli_wdr.cpp:2698
 msgid "URL:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2730 src/muuli_wdr.cpp:2923
+#: src/muuli_wdr.cpp:2702 src/muuli_wdr.cpp:2895
 msgid "Update now"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2733
+#: src/muuli_wdr.cpp:2705
 msgid "Auto-update ipfilter at startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2737
+#: src/muuli_wdr.cpp:2709
 msgid "Filtering Level:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2743
+#: src/muuli_wdr.cpp:2715
 msgid "Always filter LAN IPs"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2746
+#: src/muuli_wdr.cpp:2718
 msgid "Paranoid handling of non-matching IPs"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2748
+#: src/muuli_wdr.cpp:2720
 msgid "Rejects a packet when its source IP differs from the IP the client claims (an anti-spoofing check). Disable only if it causes connection problems."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2750
+#: src/muuli_wdr.cpp:2722
 msgid "Use system-wide ipfilter.dat if available"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2751
+#: src/muuli_wdr.cpp:2723
 msgid "If there's no local ipfilter.dat found, allow usage of a system-wide ipfilter file."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2768
+#: src/muuli_wdr.cpp:2740
 msgid "Enable Online-Signature"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2770
+#: src/muuli_wdr.cpp:2742
 msgid "Enables the writing of the OS file, which can be used by external apps to create signatures and the like."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2774
+#: src/muuli_wdr.cpp:2746
 msgid "Update Frequency (Secs):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2777
+#: src/muuli_wdr.cpp:2749
 msgid "Change the frequency (in seconds) of Online Signature updates."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2785
+#: src/muuli_wdr.cpp:2757
 msgid "Save online signature file in: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:2791
+#: src/muuli_wdr.cpp:2763
 msgid "Click here to select the directory containing the the Online Signature files."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2824
+#: src/muuli_wdr.cpp:2796
 msgid "Show country flags for clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2825
+#: src/muuli_wdr.cpp:2797
 msgid "Render the country flag column in the transfers, queue and search views. Requires a valid MMDB GeoIP database (see below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2830
+#: src/muuli_wdr.cpp:2802
 msgid "Database"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2846
+#: src/muuli_wdr.cpp:2818
 msgid "Source:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2849
+#: src/muuli_wdr.cpp:2821
 msgid "DB-IP (free, no account)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2850
+#: src/muuli_wdr.cpp:2822
 msgid "MaxMind GeoLite2 (free, account required)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2851
+#: src/muuli_wdr.cpp:2823
 msgid "Custom URL"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2854
+#: src/muuli_wdr.cpp:2826
 msgid "Choose which provider supplies the GeoIP MMDB database. DB-IP is the default - no account required. MaxMind requires a free account + license key. Use Custom URL to point at any other MMDB host (e.g. a local mirror)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2871
+#: src/muuli_wdr.cpp:2843
 msgid ""
 "No configuration required.\n"
 "\n"
@@ -4753,11 +4723,11 @@ msgid ""
 "License: Creative Commons BY 4.0 - https://creativecommons.org/licenses/by/4.0/"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2884
+#: src/muuli_wdr.cpp:2856
 msgid "License key:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2890
+#: src/muuli_wdr.cpp:2862
 msgid ""
 "Sign up for a free MaxMind account, then generate a License Key:\n"
 "https://www.maxmind.com/en/geolite2/signup\n"
@@ -4767,222 +4737,222 @@ msgid ""
 "Requires attribution and account registration; refresh at least every 30 days."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2905
+#: src/muuli_wdr.cpp:2877
 msgid "Download URL:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2911
+#: src/muuli_wdr.cpp:2883
 msgid ""
 "Must point to an .mmdb file or a .gz / .tar.gz containing one.\n"
 "URL may include credentials (https://user:pass@host/...).\n"
 "License and attribution terms are set by the upstream URL - you are responsible."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2924
+#: src/muuli_wdr.cpp:2896
 msgid "Download the GeoIP database from the selected source."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2926
+#: src/muuli_wdr.cpp:2898
 msgid "Auto-update on startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2927
+#: src/muuli_wdr.cpp:2899
 msgid "Re-download the GeoIP database from the selected source every time aMule starts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2950
+#: src/muuli_wdr.cpp:2922
 msgid "Filter incoming messages (except current chat):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2952
+#: src/muuli_wdr.cpp:2924
 msgid "Filter all messages"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2954
+#: src/muuli_wdr.cpp:2926
 msgid "Filter messages from people not on your friend list"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2956
+#: src/muuli_wdr.cpp:2928
 msgid "Filter messages from unknown clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2958
+#: src/muuli_wdr.cpp:2930
 msgid "Filter messages containing (use ',' as separator):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2961 src/muuli_wdr.cpp:2972
+#: src/muuli_wdr.cpp:2933 src/muuli_wdr.cpp:2944
 msgid "add here the words amule should filter and block messages including it"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2963
+#: src/muuli_wdr.cpp:2935
 msgid "Show received messages in the log"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2966
+#: src/muuli_wdr.cpp:2938
 msgid "Comments"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2969
+#: src/muuli_wdr.cpp:2941
 msgid "Filter comments containing (use ',' as separator):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2994
+#: src/muuli_wdr.cpp:2966
 msgid "Enable Proxy"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2995
+#: src/muuli_wdr.cpp:2967
 msgid "Enable/disable proxy support"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2998
+#: src/muuli_wdr.cpp:2970
 msgid "Proxy type:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3009
+#: src/muuli_wdr.cpp:2981
 msgid "Proxy host:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3012
+#: src/muuli_wdr.cpp:2984
 msgid "The proxy host name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3014
+#: src/muuli_wdr.cpp:2986
 msgid "Proxy port:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3017
+#: src/muuli_wdr.cpp:2989
 msgid "The proxy port"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3019
+#: src/muuli_wdr.cpp:2991
 msgid "Enable authentication"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3020
+#: src/muuli_wdr.cpp:2992
 msgid "Enable/disable username/password authentication"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3023
+#: src/muuli_wdr.cpp:2995
 msgid "Username: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:3026
+#: src/muuli_wdr.cpp:2998
 msgid "The username to use to connect to the proxy"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3028
+#: src/muuli_wdr.cpp:3000
 msgid "Password:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3031
+#: src/muuli_wdr.cpp:3003
 msgid "The password to use to connect to the proxy"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3050
+#: src/muuli_wdr.cpp:3022
 msgid "Connect to:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3059
+#: src/muuli_wdr.cpp:3031
 msgid "Login to remote amule"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3064
+#: src/muuli_wdr.cpp:3036
 msgid "User name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3075
+#: src/muuli_wdr.cpp:3047
 msgid "Remember those settings"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3078
+#: src/muuli_wdr.cpp:3050
 msgid "Force ZLIB compression"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3102
+#: src/muuli_wdr.cpp:3074
 msgid "Enable Verbose Debug-Logging."
 msgstr ""
 
-#: src/muuli_wdr.cpp:3104
+#: src/muuli_wdr.cpp:3076
 msgid "Only to Logfile"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3106
+#: src/muuli_wdr.cpp:3078
 msgid "Message Categories:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3130 src/PartFileConvertDlg.cpp:160
+#: src/muuli_wdr.cpp:3102 src/PartFileConvertDlg.cpp:160
 msgid "Waiting..."
 msgstr ""
 
-#: src/muuli_wdr.cpp:3150
+#: src/muuli_wdr.cpp:3122
 msgid "Add imports"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3153
+#: src/muuli_wdr.cpp:3125
 msgid "Retry selected"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3155
+#: src/muuli_wdr.cpp:3127
 msgid "Remove selected"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3218
+#: src/muuli_wdr.cpp:3190
 msgid "Event Types"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3237
+#: src/muuli_wdr.cpp:3209
 msgid "Statistics and queued clients for selected file(s) : Session / All time"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3261
+#: src/muuli_wdr.cpp:3233
 msgid "Active Uploads"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3275
+#: src/muuli_wdr.cpp:3247
 msgid "Percent of total files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3327
+#: src/muuli_wdr.cpp:3299
 msgid "Show Clients for"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3329
+#: src/muuli_wdr.cpp:3301
 msgid "All files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3332
+#: src/muuli_wdr.cpp:3304
 msgid "Selected files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3335
+#: src/muuli_wdr.cpp:3307
 msgid "Active uploads only"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3342
+#: src/muuli_wdr.cpp:3314
 msgid "Reload:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3346
+#: src/muuli_wdr.cpp:3318
 msgid "Reload your shared files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3409
+#: src/muuli_wdr.cpp:3381
 msgid "Send"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3410
+#: src/muuli_wdr.cpp:3382
 msgid "Sends the specified message."
 msgstr ""
 
-#: src/muuli_wdr.cpp:3414
+#: src/muuli_wdr.cpp:3386
 msgid "Close this chat-session."
 msgstr ""
 
-#: src/muuli_wdr.cpp:3437
+#: src/muuli_wdr.cpp:3409
 msgid "Connect to any server and/or Kad"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3443 src/SharedFilesCtrl.cpp:142 src/Statistics.cpp:941
+#: src/muuli_wdr.cpp:3415 src/SharedFilesCtrl.cpp:142 src/Statistics.cpp:941
 msgid "Shared Files"
 msgstr ""
 
@@ -5340,263 +5310,263 @@ msgstr ""
 msgid "ERROR: Failed to open partfile '%s'"
 msgstr ""
 
-#: src/Preferences.cpp:701
+#: src/Preferences.cpp:673
 msgid "System default"
 msgstr ""
 
-#: src/Preferences.cpp:702
+#: src/Preferences.cpp:674
 msgid "Albanian"
 msgstr ""
 
-#: src/Preferences.cpp:703
+#: src/Preferences.cpp:675
 msgid "Arabic"
 msgstr ""
 
-#: src/Preferences.cpp:704
+#: src/Preferences.cpp:676
 msgid "Asturian"
 msgstr ""
 
-#: src/Preferences.cpp:705
+#: src/Preferences.cpp:677
 msgid "Basque"
 msgstr ""
 
-#: src/Preferences.cpp:706
+#: src/Preferences.cpp:678
 msgid "Bulgarian"
 msgstr ""
 
-#: src/Preferences.cpp:707
+#: src/Preferences.cpp:679
 msgid "Catalan"
 msgstr ""
 
-#: src/Preferences.cpp:708
+#: src/Preferences.cpp:680
 msgid "Chinese (Simplified)"
 msgstr ""
 
-#: src/Preferences.cpp:709
+#: src/Preferences.cpp:681
 msgid "Chinese (Traditional)"
 msgstr ""
 
-#: src/Preferences.cpp:710
+#: src/Preferences.cpp:682
 msgid "Croatian"
 msgstr ""
 
-#: src/Preferences.cpp:711
+#: src/Preferences.cpp:683
 msgid "Czech"
 msgstr ""
 
-#: src/Preferences.cpp:712
+#: src/Preferences.cpp:684
 msgid "Danish"
 msgstr ""
 
-#: src/Preferences.cpp:713
+#: src/Preferences.cpp:685
 msgid "Dutch"
 msgstr ""
 
-#: src/Preferences.cpp:714
+#: src/Preferences.cpp:686
 msgid "English (U.K.)"
 msgstr ""
 
-#: src/Preferences.cpp:715
+#: src/Preferences.cpp:687
 msgid "English (U.S.)"
 msgstr ""
 
-#: src/Preferences.cpp:716
+#: src/Preferences.cpp:688
 msgid "Estonian"
 msgstr ""
 
-#: src/Preferences.cpp:717
+#: src/Preferences.cpp:689
 msgid "Finnish"
 msgstr ""
 
-#: src/Preferences.cpp:718
+#: src/Preferences.cpp:690
 msgid "French"
 msgstr ""
 
-#: src/Preferences.cpp:719
+#: src/Preferences.cpp:691
 msgid "Galician"
 msgstr ""
 
-#: src/Preferences.cpp:720
+#: src/Preferences.cpp:692
 msgid "German"
 msgstr ""
 
-#: src/Preferences.cpp:721
+#: src/Preferences.cpp:693
 msgid "Greek"
 msgstr ""
 
-#: src/Preferences.cpp:722
+#: src/Preferences.cpp:694
 msgid "Hebrew"
 msgstr ""
 
-#: src/Preferences.cpp:723
+#: src/Preferences.cpp:695
 msgid "Hungarian"
 msgstr ""
 
-#: src/Preferences.cpp:724
+#: src/Preferences.cpp:696
 msgid "Italian"
 msgstr ""
 
-#: src/Preferences.cpp:725
+#: src/Preferences.cpp:697
 msgid "Japanese"
 msgstr ""
 
-#: src/Preferences.cpp:726
+#: src/Preferences.cpp:698
 msgid "Korean"
 msgstr ""
 
-#: src/Preferences.cpp:727
+#: src/Preferences.cpp:699
 msgid "Latvian"
 msgstr ""
 
-#: src/Preferences.cpp:728
+#: src/Preferences.cpp:700
 msgid "Lithuanian"
 msgstr ""
 
-#: src/Preferences.cpp:729
+#: src/Preferences.cpp:701
 msgid "Norwegian (Nynorsk)"
 msgstr ""
 
-#: src/Preferences.cpp:730
+#: src/Preferences.cpp:702
 msgid "Polish"
 msgstr ""
 
-#: src/Preferences.cpp:731
+#: src/Preferences.cpp:703
 msgid "Portuguese"
 msgstr ""
 
-#: src/Preferences.cpp:732
+#: src/Preferences.cpp:704
 msgid "Portuguese (Brazilian)"
 msgstr ""
 
-#: src/Preferences.cpp:733
+#: src/Preferences.cpp:705
 msgid "Romanian"
 msgstr ""
 
-#: src/Preferences.cpp:734
+#: src/Preferences.cpp:706
 msgid "Russian"
 msgstr ""
 
-#: src/Preferences.cpp:735
+#: src/Preferences.cpp:707
 msgid "Slovenian"
 msgstr ""
 
-#: src/Preferences.cpp:736
+#: src/Preferences.cpp:708
 msgid "Spanish"
 msgstr ""
 
-#: src/Preferences.cpp:737
+#: src/Preferences.cpp:709
 msgid "Swedish"
 msgstr ""
 
-#: src/Preferences.cpp:738
+#: src/Preferences.cpp:710
 msgid "Turkish"
 msgstr ""
 
-#: src/Preferences.cpp:739
+#: src/Preferences.cpp:711
 msgid "Ukrainian"
 msgstr ""
 
-#: src/Preferences.cpp:842
+#: src/Preferences.cpp:814
 msgid "Change Language"
 msgstr ""
 
-#: src/Preferences.cpp:906
+#: src/Preferences.cpp:878
 msgid "There are no translations installed for aMule"
 msgstr ""
 
-#: src/Preferences.cpp:907
+#: src/Preferences.cpp:879
 msgid "No languages available"
 msgstr ""
 
-#: src/Preferences.cpp:1038
+#: src/Preferences.cpp:1010
 msgid "no options available"
 msgstr ""
 
-#: src/Preferences.cpp:2226
+#: src/Preferences.cpp:2179
 msgid "Invalid category found, skipping"
 msgstr ""
 
-#: src/Preferences.cpp:2395
+#: src/Preferences.cpp:2348
 msgid "TCP port can't be higher than 65532 due to server UDP socket being TCP+3"
 msgstr ""
 
-#: src/Preferences.cpp:2396
+#: src/Preferences.cpp:2349
 #, c-format
 msgid "Default port will be used (%d)"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:300 src/Statistics.cpp:866
+#: src/PrefsUnifiedDlg.cpp:298 src/Statistics.cpp:866
 msgid "Connection"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:301 src/SearchListCtrl.cpp:117
+#: src/PrefsUnifiedDlg.cpp:299 src/SearchListCtrl.cpp:117
 msgid "Directories"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:302 src/Statistics.cpp:917
+#: src/PrefsUnifiedDlg.cpp:300 src/Statistics.cpp:917
 msgid "Servers"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:303 src/ServerListCtrl.cpp:96
+#: src/PrefsUnifiedDlg.cpp:301 src/ServerListCtrl.cpp:96
 msgid "Files"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:304
+#: src/PrefsUnifiedDlg.cpp:302
 msgid "Security"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:305
+#: src/PrefsUnifiedDlg.cpp:303
 msgid "Interface"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:312
+#: src/PrefsUnifiedDlg.cpp:310
 msgid "IP2Country"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:315
+#: src/PrefsUnifiedDlg.cpp:313
 msgid "Proxy"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:316
+#: src/PrefsUnifiedDlg.cpp:314
 msgid "Filters"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:317
+#: src/PrefsUnifiedDlg.cpp:315
 msgid "Remote Controls"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:318
+#: src/PrefsUnifiedDlg.cpp:316
 msgid "Online Signature"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:319
+#: src/PrefsUnifiedDlg.cpp:317
 msgid "Advanced"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:320
+#: src/PrefsUnifiedDlg.cpp:318
 msgid "Events"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:323
+#: src/PrefsUnifiedDlg.cpp:321
 msgid "Debugging"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:453
+#: src/PrefsUnifiedDlg.cpp:451
 msgid ""
 "The following variables will be substituted:\n"
 "    %PARTFILE - full path to the file\n"
 "    %PARTNAME - file name only"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:474
+#: src/PrefsUnifiedDlg.cpp:472
 msgid "Tray icon support requires libayatana-appindicator3 at compile time."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:490
+#: src/PrefsUnifiedDlg.cpp:488
 msgid "Not available on Wayland: the protocol does not report when a window is minimized, so this option cannot intercept the system minimize button. Workaround: launch aMule with `GDK_BACKEND=x11` to use XWayland instead."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:536
+#: src/PrefsUnifiedDlg.cpp:534
 msgid ""
 "Do not change these setting unless you know\n"
 "what you are doing, otherwise you can easily\n"
@@ -5606,424 +5576,407 @@ msgid ""
 "these settings."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:647
+#: src/PrefsUnifiedDlg.cpp:645
 #, c-format
 msgid "Failed to connect Cfg to widget with the ID %d and key %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:695
+#: src/PrefsUnifiedDlg.cpp:693
 #, c-format
 msgid "Failed to transfer data from Cfg to Widget with the ID %d and key %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:801
+#: src/PrefsUnifiedDlg.cpp:799
 msgid "The type of proxy you are connecting to"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1020
+#: src/PrefsUnifiedDlg.cpp:1003
 #, c-format
 msgid "Failed to transfer data from Widget to Cfg with the ID %d and key %s"
 msgstr ""
 
 #: src/PrefsUnifiedDlg.cpp:1103
-msgid "No password set."
-msgstr ""
-
-#: src/PrefsUnifiedDlg.cpp:1132
-msgid "Guest access needs a password. Type one in the guest password field, or untick Enable guest access."
-msgstr ""
-
-#: src/PrefsUnifiedDlg.cpp:1144
 msgid ""
 "aMule must be restarted to enable these changes:\n"
 "\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1151
+#: src/PrefsUnifiedDlg.cpp:1110
 msgid "- TCP port changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1156
+#: src/PrefsUnifiedDlg.cpp:1115
 msgid "- UDP port changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1161
+#: src/PrefsUnifiedDlg.cpp:1120
 msgid "- Network interface binding changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1166
+#: src/PrefsUnifiedDlg.cpp:1125
 msgid "- External connect port changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1170
+#: src/PrefsUnifiedDlg.cpp:1129
 msgid "- External connect acceptance changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1174
+#: src/PrefsUnifiedDlg.cpp:1133
 msgid "- External connect interface changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1178
+#: src/PrefsUnifiedDlg.cpp:1137
 msgid "- Protocol obfuscation support changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1193
+#: src/PrefsUnifiedDlg.cpp:1151
 msgid "- amuleapi settings changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1202
+#: src/PrefsUnifiedDlg.cpp:1160
 msgid ""
 "Your Auto-update server list is empty.\n"
 "'Auto-update server list at startup' will be disabled."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1213
+#: src/PrefsUnifiedDlg.cpp:1171
 msgid ""
 "You have enabled external connections but have not specified a password.\n"
 "External connections cannot be enabled unless a valid password is specified."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1246
-#, c-format
-msgid "The amuleapi password could not be saved: %s"
-msgstr ""
-
-#: src/PrefsUnifiedDlg.cpp:1276
+#: src/PrefsUnifiedDlg.cpp:1202
 msgid "- Language changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1281
+#: src/PrefsUnifiedDlg.cpp:1207
 msgid "- Temp folder changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1286
+#: src/PrefsUnifiedDlg.cpp:1212
 msgid "- ED2K network enabled.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1319
+#: src/PrefsUnifiedDlg.cpp:1245
 msgid "The shared-file exclusion pattern is not a valid regular expression. The filter has been left disabled."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1321 src/PrefsUnifiedDlg.cpp:1921
+#: src/PrefsUnifiedDlg.cpp:1247 src/PrefsUnifiedDlg.cpp:1841
 msgid "Invalid regular expression"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1398
+#: src/PrefsUnifiedDlg.cpp:1324
 msgid ""
 "Both eD2k and Kad network are disabled.\n"
 "You won't be able to connect until you enable at least one of them."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1403
+#: src/PrefsUnifiedDlg.cpp:1329
 msgid ""
 "Kad will not start if your UDP port is disabled.\n"
 "Enable UDP port or disable Kad."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1459
+#: src/PrefsUnifiedDlg.cpp:1385
 msgid ""
 "\n"
 "You MUST restart aMule now.\n"
 "If you do not restart now, don't complain if anything bad happens.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1524
+#: src/PrefsUnifiedDlg.cpp:1450
 msgid "Could not register aMule for autostart at login. The autostart store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1526
+#: src/PrefsUnifiedDlg.cpp:1452
 msgid "Could not remove the autostart-at-login entry."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1527
+#: src/PrefsUnifiedDlg.cpp:1453
 msgid "Autostart"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1542
+#: src/PrefsUnifiedDlg.cpp:1468
 msgid "Register file type"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1542
+#: src/PrefsUnifiedDlg.cpp:1468
 msgid "Register URL handler"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1550
+#: src/PrefsUnifiedDlg.cpp:1476
 #, c-format
 msgid "aMule only handles eD2k-compatible magnets. If you replace the current magnet handler (%s), BitTorrent magnet links will stop working - aMule cannot download BitTorrent content. Continue?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1555
+#: src/PrefsUnifiedDlg.cpp:1481
 #, c-format
 msgid "Another application currently opens .emulecollection files (%s). Replace it with aMule?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1560
+#: src/PrefsUnifiedDlg.cpp:1486
 #, c-format
 msgid "Another application is currently the default handler for these links (%s). Replace it with aMule?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1585
+#: src/PrefsUnifiedDlg.cpp:1511
 msgid "Could not register aMule for .emulecollection files. The registration store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1587
+#: src/PrefsUnifiedDlg.cpp:1513
 msgid "Could not remove the file type registration."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1589
+#: src/PrefsUnifiedDlg.cpp:1515
 msgid "Could not register aMule as the URL handler. The registration store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1591
+#: src/PrefsUnifiedDlg.cpp:1517
 msgid "Could not remove the URL handler registration."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1661 src/PrefsUnifiedDlg.cpp:1688
+#: src/PrefsUnifiedDlg.cpp:1587 src/PrefsUnifiedDlg.cpp:1614
 msgid "The web server and aMule API require external connections to be enabled."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1671
+#: src/PrefsUnifiedDlg.cpp:1597
 msgid "The aMule web server is deprecated. Consider running the aMule API instead."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1735
+#: src/PrefsUnifiedDlg.cpp:1655
 msgid ""
 "Your Auto-update servers list is in blank.\n"
 "Please fill in at least one URL to point to a valid server.met file.\n"
 "Click on the button \"List\" by this checkbox to enter an URL."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1876
+#: src/PrefsUnifiedDlg.cpp:1796
 msgid "Temporary files"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1881
+#: src/PrefsUnifiedDlg.cpp:1801
 msgid "Incoming files"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1886
+#: src/PrefsUnifiedDlg.cpp:1806
 msgid "Online Signatures"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1899
+#: src/PrefsUnifiedDlg.cpp:1819
 #, c-format
 msgid "Choose a folder for %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1923
+#: src/PrefsUnifiedDlg.cpp:1843
 #, c-format
 msgid "Would exclude %u of %u shared file"
 msgid_plural "Would exclude %u of %u shared files"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/PrefsUnifiedDlg.cpp:1940
+#: src/PrefsUnifiedDlg.cpp:1860
 msgid "Browse for videoplayer"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1944
+#: src/PrefsUnifiedDlg.cpp:1864
 msgid "Select browser"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1948
+#: src/PrefsUnifiedDlg.cpp:1868
 msgid "Select ffprobe binary"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1954
+#: src/PrefsUnifiedDlg.cpp:1874
 #, c-format
 msgid "Executable%s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1988
+#: src/PrefsUnifiedDlg.cpp:1908
 msgid "ffprobe not found on PATH or in the standard install locations. Install ffmpeg (which ships ffprobe) or use Browse to pick a binary manually."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2000
+#: src/PrefsUnifiedDlg.cpp:1920
 msgid "Reset the settings on this page to their default values?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2001
+#: src/PrefsUnifiedDlg.cpp:1921
 msgid "Reset to defaults"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2028
+#: src/PrefsUnifiedDlg.cpp:1948
 msgid "Edit server list"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2029
+#: src/PrefsUnifiedDlg.cpp:1949
 msgid ""
 "Add here URL's to download server.met files.\n"
 "Only one url on each line."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2084
+#: src/PrefsUnifiedDlg.cpp:2004
 msgid "IP2Country update failed"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2229 src/PrefsUnifiedDlg.cpp:2260
+#: src/PrefsUnifiedDlg.cpp:2149 src/PrefsUnifiedDlg.cpp:2180
 msgid "Data by MaxMind GeoLite2"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2231 src/PrefsUnifiedDlg.cpp:2262
+#: src/PrefsUnifiedDlg.cpp:2151 src/PrefsUnifiedDlg.cpp:2182
 msgid "Custom source"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2233 src/PrefsUnifiedDlg.cpp:2264
+#: src/PrefsUnifiedDlg.cpp:2153 src/PrefsUnifiedDlg.cpp:2184
 msgid "Data by DB-IP.com"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2284
+#: src/PrefsUnifiedDlg.cpp:2204
 #, c-format
 msgid "Status: Loaded%s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2286
+#: src/PrefsUnifiedDlg.cpp:2206
 #, c-format
 msgid "Status: Loaded%s - %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2290
+#: src/PrefsUnifiedDlg.cpp:2210
 msgid "Status: Failed to load - click 'Update now' to refresh."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2292
+#: src/PrefsUnifiedDlg.cpp:2212
 msgid "Status: Not found - click 'Update now' to download."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2350 src/PrefsUnifiedDlg.cpp:2374
+#: src/PrefsUnifiedDlg.cpp:2270 src/PrefsUnifiedDlg.cpp:2294
 #, c-format
 msgid "Update delay: %d second"
 msgid_plural "Update delay: %d seconds"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/PrefsUnifiedDlg.cpp:2358
+#: src/PrefsUnifiedDlg.cpp:2278
 #, c-format
 msgid "Time for average graph: %d minute"
 msgid_plural "Time for average graph: %d minutes"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/PrefsUnifiedDlg.cpp:2367
+#: src/PrefsUnifiedDlg.cpp:2287
 #, c-format
 msgid "Connections Graph Scale: %d"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2382
+#: src/PrefsUnifiedDlg.cpp:2302
 #, c-format
 msgid "File Buffer Size: %d byte"
 msgid_plural "File Buffer Size: %d bytes"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/PrefsUnifiedDlg.cpp:2392
+#: src/PrefsUnifiedDlg.cpp:2312
 #, c-format
 msgid "Upload Queue Size: %d client"
 msgid_plural "Upload Queue Size: %d clients"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/PrefsUnifiedDlg.cpp:2402
+#: src/PrefsUnifiedDlg.cpp:2322
 #, c-format
 msgid "Server connection refresh interval: %d minute"
 msgid_plural "Server connection refresh interval: %d minutes"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/PrefsUnifiedDlg.cpp:2407
+#: src/PrefsUnifiedDlg.cpp:2327
 msgid "Server connection refresh interval: Disabled"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2451
+#: src/PrefsUnifiedDlg.cpp:2371
 msgid "disabled"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2477
+#: src/PrefsUnifiedDlg.cpp:2397
 #, c-format
 msgid "Execute command on '%s' event"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2484
+#: src/PrefsUnifiedDlg.cpp:2404
 msgid "Enable command execution on core"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2496
+#: src/PrefsUnifiedDlg.cpp:2416
 msgid "Core command:"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2512
+#: src/PrefsUnifiedDlg.cpp:2432
 msgid "Enable command execution on GUI"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2524
+#: src/PrefsUnifiedDlg.cpp:2444
 msgid "GUI command:"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2540
+#: src/PrefsUnifiedDlg.cpp:2460
 msgid "The following variables will be replaced:"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2708
+#: src/PrefsUnifiedDlg.cpp:2628
 msgid ""
 "The following folders look like system or sensitive locations:\n"
 "\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2713
+#: src/PrefsUnifiedDlg.cpp:2633
 msgid "Sharing them recursively will publish every file underneath on the eD2k/Kad networks. Do you really want to do this?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2716
+#: src/PrefsUnifiedDlg.cpp:2636
 msgid "Confirm shared folders"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2744
+#: src/PrefsUnifiedDlg.cpp:2664
 msgid "Reloading shared files..."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2745
+#: src/PrefsUnifiedDlg.cpp:2665
 msgid "Scanning for subdirectories..."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2746
+#: src/PrefsUnifiedDlg.cpp:2666
 msgid "Updating shared folders"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2773
+#: src/PrefsUnifiedDlg.cpp:2693
 #, c-format
 msgid "Scanned %u directories..."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2823
+#: src/PrefsUnifiedDlg.cpp:2743
 #, c-format
 msgid "Reloading shared files: %u files scanned"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2873
+#: src/PrefsUnifiedDlg.cpp:2793
 msgid "Shared folder"
 msgstr ""
 
-#: src/SearchDlg.cpp:280
-msgid "Clear search history"
-msgstr ""
-
-#: src/SearchDlg.cpp:584
+#: src/SearchDlg.cpp:425
 msgid "It's impossible to search when both eD2k and Kademlia are disabled."
 msgstr ""
 
-#: src/SearchDlg.cpp:585 src/SearchListCtrl.cpp:858
+#: src/SearchDlg.cpp:426 src/SearchListCtrl.cpp:858
 msgid "Search error"
 msgstr ""
 
-#: src/SearchDlg.cpp:929
+#: src/SearchDlg.cpp:768
 msgid "Min size must be smaller than max size. Max size ignored."
 msgstr ""
 
-#: src/SearchDlg.cpp:930 src/SearchDlg.cpp:1012
+#: src/SearchDlg.cpp:769 src/SearchDlg.cpp:851
 msgid "Search warning"
 msgstr ""
 
-#: src/SearchDlg.cpp:1092 src/SearchListCtrl.cpp:735
+#: src/SearchDlg.cpp:929 src/SearchListCtrl.cpp:735
 msgid "Main"
 msgstr ""
 

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -13,7 +13,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-28 12:17+0200\n"
+"POT-Creation-Date: 2026-07-28 13:09+0200\n"
 "PO-Revision-Date: 2026-07-27 11:48+0000\n"
 "Last-Translator: Mike Akiba <mike2718@gmail.com>\n"
 "Language-Team: Chinese Simplified <kde-i18n-doc@kde.org>\n"
@@ -298,7 +298,7 @@ msgid "Password set and external connections enabled."
 msgstr "密码已设置，启用远程连接。"
 
 #: src/amule.cpp:755 src/KadDlg.cpp:176 src/KadDlg.cpp:185
-#: src/PrefsUnifiedDlg.cpp:1461 src/SharedFilesCtrl.cpp:476
+#: src/PrefsUnifiedDlg.cpp:1470 src/SharedFilesCtrl.cpp:476
 msgid "WARNING"
 msgstr "警告"
 
@@ -335,7 +335,7 @@ msgstr "您要求启动时运行 Web 服务器，但 amuleweb 程序无法运行
 #: src/amule-remote-gui.cpp:603 src/amule-remote-gui.cpp:671
 #: src/amule-remote-gui.cpp:709 src/amule-remote-gui.cpp:1282
 #: src/amule-remote-gui.cpp:1345 src/amule-remote-gui.cpp:1372
-#: src/DownloadQueue.cpp:1481 src/PrefsUnifiedDlg.cpp:1247
+#: src/DownloadQueue.cpp:1481 src/PrefsUnifiedDlg.cpp:1256
 msgid "ERROR"
 msgstr "错误"
 
@@ -595,36 +595,36 @@ msgstr "访问 https://github.com/amule-org/amule/releases/latest 来检查 是�
 msgid "FATAL ERROR: Failed to create Timer"
 msgstr "致命错误：创建计时器失败"
 
-#: src/amuleDlg.cpp:361 src/amuleDlg.cpp:1787 src/amuleDlg.cpp:2033
-#: src/muuli_wdr.cpp:1492 src/muuli_wdr.cpp:3449
+#: src/amuleDlg.cpp:361 src/amuleDlg.cpp:1810 src/amuleDlg.cpp:2056
+#: src/muuli_wdr.cpp:1492 src/muuli_wdr.cpp:3453
 msgid "Networks"
 msgstr "网络"
 
-#: src/amuleDlg.cpp:362 src/amuleDlg.cpp:1793 src/muuli_wdr.cpp:3450
+#: src/amuleDlg.cpp:362 src/amuleDlg.cpp:1816 src/muuli_wdr.cpp:3454
 msgid "Searches"
 msgstr "搜索"
 
-#: src/amuleDlg.cpp:363 src/amuleDlg.cpp:1799 src/DownloadListCtrl.cpp:740
-#: src/muuli_wdr.cpp:392 src/muuli_wdr.cpp:1585 src/muuli_wdr.cpp:3451
+#: src/amuleDlg.cpp:363 src/amuleDlg.cpp:1822 src/DownloadListCtrl.cpp:740
+#: src/muuli_wdr.cpp:392 src/muuli_wdr.cpp:1585 src/muuli_wdr.cpp:3455
 #: src/Statistics.cpp:829
 msgid "Downloads"
 msgstr "下载"
 
-#: src/amuleDlg.cpp:364 src/amuleDlg.cpp:1805 src/muuli_wdr.cpp:3325
+#: src/amuleDlg.cpp:364 src/amuleDlg.cpp:1828 src/muuli_wdr.cpp:3329
 msgid "Shared files"
 msgstr "共享文件"
 
-#: src/amuleDlg.cpp:365 src/amuleDlg.cpp:1811 src/muuli_wdr.cpp:2957
-#: src/muuli_wdr.cpp:3407 src/muuli_wdr.cpp:3454
+#: src/amuleDlg.cpp:365 src/amuleDlg.cpp:1834 src/muuli_wdr.cpp:2961
+#: src/muuli_wdr.cpp:3411 src/muuli_wdr.cpp:3458
 msgid "Messages"
 msgstr "消息"
 
-#: src/amuleDlg.cpp:366 src/amuleDlg.cpp:1817 src/muuli_wdr.cpp:3455
+#: src/amuleDlg.cpp:366 src/amuleDlg.cpp:1840 src/muuli_wdr.cpp:3459
 #: src/PrefsUnifiedDlg.cpp:314 src/Statistics.cpp:779 src/Statistics.cpp:1235
 msgid "Statistics"
 msgstr "统计"
 
-#: src/amuleDlg.cpp:368 src/amuleDlg.cpp:1824 src/muuli_wdr.cpp:3457
+#: src/amuleDlg.cpp:368 src/amuleDlg.cpp:1847 src/muuli_wdr.cpp:3461
 #: src/PrefsUnifiedDlg.cpp:330 src/utils/wxCas/src/wxcasprefs.cpp:39
 msgid "Preferences"
 msgstr "设置"
@@ -687,8 +687,8 @@ msgstr "Kad: 关闭"
 #: src/amuleDlg.cpp:1029 src/DownloadListCtrl.cpp:505
 #: src/DownloadListCtrl.cpp:749 src/FriendListCtrl.cpp:180
 #: src/muuli_wdr.cpp:731 src/muuli_wdr.cpp:782 src/muuli_wdr.cpp:846
-#: src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2262 src/muuli_wdr.cpp:2347
-#: src/muuli_wdr.cpp:3095 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
+#: src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2266 src/muuli_wdr.cpp:2351
+#: src/muuli_wdr.cpp:3099 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
 #: src/ServerListCtrl.cpp:606 src/TransferWnd.cpp:378
 #: src/utils/wxCas/src/wxcasprefs.cpp:235
 msgid "Cancel"
@@ -699,7 +699,7 @@ msgid "Stop the current connection attempts"
 msgstr "终止本次连接尝试"
 
 #: src/amuleDlg.cpp:1035 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976
-#: src/muuli_wdr.cpp:2485
+#: src/muuli_wdr.cpp:2489
 msgid "Disconnect"
 msgstr "断开连接"
 
@@ -708,7 +708,7 @@ msgid "Disconnect from the currently connected networks"
 msgstr "从当前已连接的网络断开"
 
 #: src/amuleDlg.cpp:1041 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979
-#: src/muuli_wdr.cpp:2640 src/muuli_wdr.cpp:3092 src/muuli_wdr.cpp:3447
+#: src/muuli_wdr.cpp:2644 src/muuli_wdr.cpp:3096 src/muuli_wdr.cpp:3451
 msgid "Connect"
 msgstr "连接"
 
@@ -762,7 +762,7 @@ msgstr "退出确认"
 msgid "Launch Command: "
 msgstr "运行命令: "
 
-#: src/amuleDlg.cpp:1632 src/muuli_wdr.cpp:1982 src/Preferences.cpp:979
+#: src/amuleDlg.cpp:1632 src/muuli_wdr.cpp:1986 src/Preferences.cpp:979
 msgid "- default -"
 msgstr "- 默认 -"
 
@@ -776,60 +776,60 @@ msgstr "皮肤目录 %s 不存在"
 msgid "WARNING: Unable to open skin file '%s' for read"
 msgstr "警告：无法打开皮肤文件 %s 进行读取"
 
-#: src/amuleDlg.cpp:1791 src/muuli_wdr.cpp:3449
+#: src/amuleDlg.cpp:1814 src/muuli_wdr.cpp:3453
 msgid "Networks Window"
 msgstr "网络窗口"
 
-#: src/amuleDlg.cpp:1797 src/muuli_wdr.cpp:3450
+#: src/amuleDlg.cpp:1820 src/muuli_wdr.cpp:3454
 msgid "Searches Window"
 msgstr "搜索窗口"
 
-#: src/amuleDlg.cpp:1803 src/muuli_wdr.cpp:3451
+#: src/amuleDlg.cpp:1826 src/muuli_wdr.cpp:3455
 msgid "Downloads Window"
 msgstr "下载窗口"
 
-#: src/amuleDlg.cpp:1809 src/muuli_wdr.cpp:3453
+#: src/amuleDlg.cpp:1832 src/muuli_wdr.cpp:3457
 msgid "Shared Files Window"
 msgstr "共享文件窗口"
 
-#: src/amuleDlg.cpp:1815 src/muuli_wdr.cpp:3454
+#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3458
 msgid "Messages Window"
 msgstr "消息窗口"
 
-#: src/amuleDlg.cpp:1821 src/muuli_wdr.cpp:3455
+#: src/amuleDlg.cpp:1844 src/muuli_wdr.cpp:3459
 msgid "Statistics Graph Window"
 msgstr "统计图窗口"
 
-#: src/amuleDlg.cpp:1828 src/muuli_wdr.cpp:3457
+#: src/amuleDlg.cpp:1851 src/muuli_wdr.cpp:3461
 msgid "Preferences Settings Window"
 msgstr "设置窗口"
 
-#: src/amuleDlg.cpp:1831 src/muuli_wdr.cpp:3458
+#: src/amuleDlg.cpp:1854 src/muuli_wdr.cpp:3462
 msgid "Import"
 msgstr "导入"
 
-#: src/amuleDlg.cpp:1835 src/muuli_wdr.cpp:3458
+#: src/amuleDlg.cpp:1858 src/muuli_wdr.cpp:3462
 msgid "The partfile importer tool"
 msgstr "part 文件导入工具"
 
-#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3459
+#: src/amuleDlg.cpp:1861 src/muuli_wdr.cpp:3463
 #: src/utils/aLinkCreator/src/alcframe.cpp:262
 msgid "About"
 msgstr "关于"
 
-#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3459
+#: src/amuleDlg.cpp:1861 src/muuli_wdr.cpp:3463
 msgid "About/Help"
 msgstr "关于/帮助"
 
-#: src/amuleDlg.cpp:2036
+#: src/amuleDlg.cpp:2059
 msgid "eD2k network"
 msgstr "eD2k 网络"
 
-#: src/amuleDlg.cpp:2039
+#: src/amuleDlg.cpp:2062
 msgid "Kad network"
 msgstr "Kad 网络"
 
-#: src/amuleDlg.cpp:2039
+#: src/amuleDlg.cpp:2062
 msgid "No network"
 msgstr "无网络"
 
@@ -1362,19 +1362,19 @@ msgstr "自动 [高]"
 msgid "Very low"
 msgstr "极低"
 
-#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:743 src/muuli_wdr.cpp:2313
+#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:743 src/muuli_wdr.cpp:2317
 #: src/ServerListCtrl.cpp:263 src/ServerListCtrl.cpp:456
 #: src/SharedFilesCtrl.cpp:145
 msgid "Low"
 msgstr "低"
 
-#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:744 src/muuli_wdr.cpp:2314
+#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:744 src/muuli_wdr.cpp:2318
 #: src/ServerListCtrl.cpp:266 src/ServerListCtrl.cpp:457
 #: src/SharedFilesCtrl.cpp:146
 msgid "Normal"
 msgstr "普通"
 
-#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:745 src/muuli_wdr.cpp:2315
+#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:745 src/muuli_wdr.cpp:2319
 #: src/ServerListCtrl.cpp:269 src/ServerListCtrl.cpp:458
 #: src/SharedFilesCtrl.cpp:147
 msgid "High"
@@ -1466,7 +1466,7 @@ msgstr "本地服务器"
 msgid "Remote Server"
 msgstr "远程服务器"
 
-#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3212
+#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3216
 #: src/SearchDlg.cpp:119 src/TextClient.cpp:911
 msgid "Kad"
 msgstr "Kad"
@@ -1537,7 +1537,7 @@ msgstr "块"
 msgid "Size"
 msgstr "大小"
 
-#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3279
+#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3283
 msgid "Transferred"
 msgstr "已传输"
 
@@ -1595,7 +1595,7 @@ msgstr ""
 "报告来自: %s (%s)\n"
 "\n"
 
-#: src/DownloadListCtrl.cpp:746 src/muuli_wdr.cpp:2316
+#: src/DownloadListCtrl.cpp:746 src/muuli_wdr.cpp:2320
 #: src/SharedFilesCtrl.cpp:150
 msgid "Auto"
 msgstr "自动"
@@ -1633,7 +1633,7 @@ msgid "Extended Options"
 msgstr "扩展选项"
 
 #: src/DownloadListCtrl.cpp:770 src/DownloadListCtrl.cpp:822
-#: src/muuli_wdr.cpp:1800
+#: src/muuli_wdr.cpp:1804
 msgid "Preview"
 msgstr "预览"
 
@@ -2432,23 +2432,23 @@ msgid ""
 "want downloads on a different (e.g. larger) disk."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:549 src/FirstRunWizard.cpp:611 src/muuli_wdr.cpp:1712
+#: src/FirstRunWizard.cpp:549 src/FirstRunWizard.cpp:611 src/muuli_wdr.cpp:1716
 msgid "Destination folder for downloads"
 msgstr "存放下载文件的文件夹"
 
 #: src/FirstRunWizard.cpp:553 src/FirstRunWizard.cpp:569 src/muuli_wdr.cpp:1349
-#: src/muuli_wdr.cpp:1366 src/muuli_wdr.cpp:1687 src/muuli_wdr.cpp:1718
-#: src/muuli_wdr.cpp:1730 src/muuli_wdr.cpp:2800
+#: src/muuli_wdr.cpp:1366 src/muuli_wdr.cpp:1691 src/muuli_wdr.cpp:1722
+#: src/muuli_wdr.cpp:1734 src/muuli_wdr.cpp:2804
 #: src/utils/aLinkCreator/src/alcframe.cpp:135
 #: src/utils/wxCas/src/wxcasprefs.cpp:52 src/utils/wxCas/src/wxcasprefs.cpp:118
 msgid "Browse"
 msgstr "浏览"
 
-#: src/FirstRunWizard.cpp:559 src/muuli_wdr.cpp:1723
+#: src/FirstRunWizard.cpp:559 src/muuli_wdr.cpp:1727
 msgid "(All files in this folder are shared with other peers)"
 msgstr "（此文件夹中的所有文件均与其他对等方共享）"
 
-#: src/FirstRunWizard.cpp:565 src/FirstRunWizard.cpp:624 src/muuli_wdr.cpp:1725
+#: src/FirstRunWizard.cpp:565 src/FirstRunWizard.cpp:624 src/muuli_wdr.cpp:1729
 msgid "Folder for temporary download files"
 msgstr "存放临时下载文件的文件夹"
 
@@ -2479,7 +2479,7 @@ msgstr "写好友列表文件emfriends.met失败！"
 msgid "CRITICAL - no client on StartChatSession"
 msgstr "严重错误 - 开始聊天进程没有客户端"
 
-#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2706 src/muuli_wdr.cpp:3383
+#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2710 src/muuli_wdr.cpp:3387
 msgid "Friends"
 msgstr "好友"
 
@@ -2589,8 +2589,8 @@ msgstr "没有"
 msgid "No"
 msgstr "否"
 
-#: src/GenericClientListCtrl.cpp:1216 src/PrefsUnifiedDlg.cpp:2898
-#: src/PrefsUnifiedDlg.cpp:2948 src/ServerListCtrl.cpp:276
+#: src/GenericClientListCtrl.cpp:1216 src/PrefsUnifiedDlg.cpp:2907
+#: src/PrefsUnifiedDlg.cpp:2957 src/ServerListCtrl.cpp:276
 msgid "Yes"
 msgstr "是"
 
@@ -2757,10 +2757,10 @@ msgstr "无效端口"
 msgid "Please fill all fields required"
 msgstr "请填写所有必要信息"
 
-#: src/KadDlg.cpp:192 src/PartFile.cpp:1031 src/PrefsUnifiedDlg.cpp:1134
-#: src/PrefsUnifiedDlg.cpp:1204 src/PrefsUnifiedDlg.cpp:1405
-#: src/PrefsUnifiedDlg.cpp:1663 src/PrefsUnifiedDlg.cpp:1673
-#: src/PrefsUnifiedDlg.cpp:1690 src/PrefsUnifiedDlg.cpp:1738
+#: src/KadDlg.cpp:192 src/PartFile.cpp:1031 src/PrefsUnifiedDlg.cpp:1143
+#: src/PrefsUnifiedDlg.cpp:1213 src/PrefsUnifiedDlg.cpp:1414
+#: src/PrefsUnifiedDlg.cpp:1672 src/PrefsUnifiedDlg.cpp:1682
+#: src/PrefsUnifiedDlg.cpp:1699 src/PrefsUnifiedDlg.cpp:1747
 msgid "Message"
 msgstr "消息"
 
@@ -2861,7 +2861,7 @@ msgstr "共享率"
 msgid "Uploaded"
 msgstr "已上传"
 
-#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3263
+#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3267
 msgid "Requested"
 msgstr "已请求"
 
@@ -2984,7 +2984,7 @@ msgid "WARNING: "
 msgstr "警告: "
 
 #: src/MuleNotebook.cpp:179 src/muuli_wdr.cpp:817 src/muuli_wdr.cpp:1229
-#: src/muuli_wdr.cpp:3167 src/muuli_wdr.cpp:3423
+#: src/muuli_wdr.cpp:3171 src/muuli_wdr.cpp:3427
 msgid "Close"
 msgstr "关闭"
 
@@ -3002,7 +3002,7 @@ msgid "Paste"
 msgstr "粘贴"
 
 #: src/MuleTextCtrl.cpp:89 src/muuli_wdr.cpp:358 src/muuli_wdr.cpp:757
-#: src/muuli_wdr.cpp:2390 src/muuli_wdr.cpp:2409 src/muuli_wdr.cpp:2431
+#: src/muuli_wdr.cpp:2394 src/muuli_wdr.cpp:2413 src/muuli_wdr.cpp:2435
 #: src/utils/aLinkCreator/src/alcframe.cpp:142
 msgid "Clear"
 msgstr "清除"
@@ -3094,7 +3094,7 @@ msgstr "退出"
 
 #: src/MuleTrayIcon.cpp:579 src/MuleTrayIcon.cpp:945 src/MuleTrayIcon.cpp:965
 #: src/muuli_wdr.cpp:1398 src/muuli_wdr.cpp:1406 src/muuli_wdr.cpp:1413
-#: src/muuli_wdr.cpp:1846 src/muuli_wdr.cpp:1852 src/OtherFunctions.cpp:91
+#: src/muuli_wdr.cpp:1850 src/muuli_wdr.cpp:1856 src/OtherFunctions.cpp:91
 #: src/StatisticsDlg.cpp:93 src/StatisticsDlg.cpp:95
 msgid "kB/s"
 msgstr "KB/s"
@@ -3334,7 +3334,7 @@ msgstr "字节"
 msgid "KB"
 msgstr "KB"
 
-#: src/muuli_wdr.cpp:274 src/muuli_wdr.cpp:293 src/muuli_wdr.cpp:1631
+#: src/muuli_wdr.cpp:274 src/muuli_wdr.cpp:293 src/muuli_wdr.cpp:1635
 #: src/OtherFunctions.cpp:64
 msgid "MB"
 msgstr "MB"
@@ -3351,7 +3351,7 @@ msgstr "大小上限"
 msgid "Availability"
 msgstr "可用来源数"
 
-#: src/muuli_wdr.cpp:312 src/muuli_wdr.cpp:398 src/muuli_wdr.cpp:3328
+#: src/muuli_wdr.cpp:312 src/muuli_wdr.cpp:398 src/muuli_wdr.cpp:3332
 msgid "Filter:"
 msgstr "过滤："
 
@@ -3414,8 +3414,8 @@ msgstr "文件源:"
 #: src/muuli_wdr.cpp:1160 src/muuli_wdr.cpp:1167 src/muuli_wdr.cpp:1172
 #: src/muuli_wdr.cpp:1179 src/muuli_wdr.cpp:1184 src/muuli_wdr.cpp:1191
 #: src/muuli_wdr.cpp:1205 src/muuli_wdr.cpp:1212 src/muuli_wdr.cpp:1217
-#: src/muuli_wdr.cpp:1224 src/muuli_wdr.cpp:3265 src/muuli_wdr.cpp:3273
-#: src/muuli_wdr.cpp:3281
+#: src/muuli_wdr.cpp:1224 src/muuli_wdr.cpp:3269 src/muuli_wdr.cpp:3277
+#: src/muuli_wdr.cpp:3285
 msgid "N/A"
 msgstr "N/A"
 
@@ -3555,7 +3555,7 @@ msgstr "艺术家："
 msgid "Album :"
 msgstr "专辑："
 
-#: src/muuli_wdr.cpp:685 src/muuli_wdr.cpp:2285
+#: src/muuli_wdr.cpp:685 src/muuli_wdr.cpp:2289
 msgid "Title :"
 msgstr "标题 :"
 
@@ -3663,7 +3663,7 @@ msgstr "用户名 :"
 msgid "Userhash :"
 msgstr "用户哈希 :"
 
-#: src/muuli_wdr.cpp:895 src/muuli_wdr.cpp:1752 src/muuli_wdr.cpp:2480
+#: src/muuli_wdr.cpp:895 src/muuli_wdr.cpp:1756 src/muuli_wdr.cpp:2484
 #: src/utils/aLinkCreator/src/alcframe.cpp:137
 msgid "Add"
 msgstr "添加"
@@ -3672,15 +3672,15 @@ msgstr "添加"
 msgid "Download-Speed"
 msgstr "下载速度"
 
-#: src/muuli_wdr.cpp:954 src/muuli_wdr.cpp:989 src/muuli_wdr.cpp:2584
+#: src/muuli_wdr.cpp:954 src/muuli_wdr.cpp:989 src/muuli_wdr.cpp:2588
 msgid "Current"
 msgstr "当前"
 
-#: src/muuli_wdr.cpp:962 src/muuli_wdr.cpp:997 src/muuli_wdr.cpp:2592
+#: src/muuli_wdr.cpp:962 src/muuli_wdr.cpp:997 src/muuli_wdr.cpp:2596
 msgid "Running average"
 msgstr "动态平均值"
 
-#: src/muuli_wdr.cpp:970 src/muuli_wdr.cpp:1005 src/muuli_wdr.cpp:2600
+#: src/muuli_wdr.cpp:970 src/muuli_wdr.cpp:1005 src/muuli_wdr.cpp:2604
 msgid "Session average"
 msgstr "本次运行平均值"
 
@@ -3692,7 +3692,7 @@ msgstr "上传速度"
 msgid "Connections"
 msgstr "连接"
 
-#: src/muuli_wdr.cpp:1024 src/muuli_wdr.cpp:1871
+#: src/muuli_wdr.cpp:1024 src/muuli_wdr.cpp:1875
 msgid "Active downloads"
 msgstr "活跃下载"
 
@@ -3700,7 +3700,7 @@ msgstr "活跃下载"
 msgid "Active connections (1:1)"
 msgstr "活跃连接 (1:1)"
 
-#: src/muuli_wdr.cpp:1040 src/muuli_wdr.cpp:1872
+#: src/muuli_wdr.cpp:1040 src/muuli_wdr.cpp:1876
 msgid "Active uploads"
 msgstr "活跃上传"
 
@@ -3974,7 +3974,7 @@ msgstr "为本地地址绑定 IP (全部绑定则留空):"
 msgid "Advanced users only: If you have multiple network interfaces, enter the address of the interface to which aMule should be bound."
 msgstr "只限高级用户：如果您有多个网络接口，请输入 aMule 将要绑定接口的地址。"
 
-#: src/muuli_wdr.cpp:1462 src/muuli_wdr.cpp:2065
+#: src/muuli_wdr.cpp:1462 src/muuli_wdr.cpp:2069
 msgid "Bind to network interface (empty for any):"
 msgstr "绑定网络接口（留空绑定全部）："
 
@@ -3990,7 +3990,7 @@ msgstr "每个下载文件的最大的源数量:"
 msgid "Max simultaneous connections:"
 msgstr "最大同时连接数:"
 
-#: src/muuli_wdr.cpp:1498 src/muuli_wdr.cpp:3207
+#: src/muuli_wdr.cpp:1498 src/muuli_wdr.cpp:3211
 msgid "ED2K"
 msgstr "ED2K"
 
@@ -4082,79 +4082,79 @@ msgstr "为新文件预分配磁盘空间"
 msgid "For new files preallocates disk space for the whole file, thus reduces fragmentation"
 msgstr "为新文件分配全部所需的磁盘空间，这样可以减少碎片"
 
-#: src/muuli_wdr.cpp:1617
+#: src/muuli_wdr.cpp:1621
 msgid "Create new files as sparse files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1618
+#: src/muuli_wdr.cpp:1622
 msgid "Sparse part files only occupy disk space for the parts already downloaded, so free space is used up gradually as the file fills in. Turn this off to use an ordinary file instead - useful where sparse files are unsupported or slow, or where backup/de-duplication tools handle them badly. Applies only when the core runs on Windows; on Linux and macOS part files are sparse anyway and this setting has no effect."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1623
+#: src/muuli_wdr.cpp:1627
 msgid "Stop downloads when free disk space reaches "
 msgstr "停止下载当可用磁盘空间只有"
 
-#: src/muuli_wdr.cpp:1624
+#: src/muuli_wdr.cpp:1628
 msgid "Select this if you want aMule to check your disk space"
 msgstr "要求检查磁盘空间"
 
-#: src/muuli_wdr.cpp:1628
+#: src/muuli_wdr.cpp:1632
 msgid "Enter here the min disk space desired."
 msgstr "请输入最低硬盘空间。"
 
-#: src/muuli_wdr.cpp:1634
+#: src/muuli_wdr.cpp:1638
 msgid "Save 10 sources on rare files (< 20 sources)"
 msgstr "保存稀有文件（少于20个源）的10个源"
 
-#: src/muuli_wdr.cpp:1638 src/Statistics.cpp:790
+#: src/muuli_wdr.cpp:1642 src/Statistics.cpp:790
 msgid "Uploads"
 msgstr "上传"
 
-#: src/muuli_wdr.cpp:1641
+#: src/muuli_wdr.cpp:1645
 msgid "Add new shared files with auto priority"
 msgstr "添加新共享文件时设优先级为自动"
 
-#: src/muuli_wdr.cpp:1647
+#: src/muuli_wdr.cpp:1651
 msgid "Intelligent Corruption Handling (I.C.H.)"
 msgstr "智能损坏数据处理 (I.C.H.)"
 
-#: src/muuli_wdr.cpp:1650
+#: src/muuli_wdr.cpp:1654
 msgid "Enable"
 msgstr "启用"
 
-#: src/muuli_wdr.cpp:1653
+#: src/muuli_wdr.cpp:1657
 msgid "Advanced I.C.H. trusts every hash (not recommended)"
 msgstr "高级 I.C.H. 信任全部哈希值 (不推荐)"
 
-#: src/muuli_wdr.cpp:1665 src/PrefsUnifiedDlg.cpp:1990
+#: src/muuli_wdr.cpp:1669 src/PrefsUnifiedDlg.cpp:1999
 msgid "Media metadata extraction"
 msgstr "媒体元数据提取"
 
-#: src/muuli_wdr.cpp:1669
+#: src/muuli_wdr.cpp:1673
 msgid "Extract length / bitrate / codec from shared audio and video files"
 msgstr "从共享的音视频文件提取长度/比特率/编解码器信息"
 
-#: src/muuli_wdr.cpp:1671
+#: src/muuli_wdr.cpp:1675
 msgid "When enabled, aMule runs ffprobe on each shared media file to fill in the Length / Bitrate / Codec columns other clients see when they find the file in a search. Requires ffmpeg (the ffprobe binary) to be installed."
 msgstr "启用此功能后，aMule 会对每个共享媒体文件运行 ffprobe 填充其他客户端在搜索到该文件时看到的“长度”、“比特率”和“编解码器”列。需要安装 ffmpeg（ffprobe 二进制文件）。"
 
-#: src/muuli_wdr.cpp:1678
+#: src/muuli_wdr.cpp:1682
 msgid "Path to ffprobe:"
 msgstr "ffprobe 路径："
 
-#: src/muuli_wdr.cpp:1683
+#: src/muuli_wdr.cpp:1687
 msgid "Full path to the ffprobe binary. Leave empty to have aMule auto-detect it on startup."
 msgstr "ffprobe 二进制文件的完整路径。留空让 amule 在启动时自动检测。"
 
-#: src/muuli_wdr.cpp:1691
+#: src/muuli_wdr.cpp:1695
 msgid "Detect"
 msgstr "检测"
 
-#: src/muuli_wdr.cpp:1692
+#: src/muuli_wdr.cpp:1696
 msgid "Search the standard install locations for an ffprobe binary and fill the path field."
 msgstr "搜索标准的 ffprobe 二进制文件安装路径，并填写路径字段。"
 
-#: src/muuli_wdr.cpp:1716
+#: src/muuli_wdr.cpp:1720
 msgid ""
 "Completed downloads are stored here. All files in this folder are automatically shared with other peers.\n"
 "If this folder also holds files you don't want to share, point it at an aMule-only sub-folder."
@@ -4162,688 +4162,688 @@ msgstr ""
 "已完成下载的文件存储在此处。此文件夹中的所有文件将自动与其他对等点共享。\n"
 "如果此文件夹中还包含您不想共享的文件，请为 aMule 选择一个专用子文件夹。"
 
-#: src/muuli_wdr.cpp:1719
+#: src/muuli_wdr.cpp:1723
 msgid "Pick the folder where completed downloads will be stored. All files in that folder will be shared with other peers."
 msgstr "选择完成下载文件的存储文件夹。该文件夹中的所有文件都将与其他对等节点共享。"
 
-#: src/muuli_wdr.cpp:1733
+#: src/muuli_wdr.cpp:1737
 msgid "Shared folders"
 msgstr "共享的文件夹"
 
-#: src/muuli_wdr.cpp:1739
+#: src/muuli_wdr.cpp:1743
 msgid "(Folders shared by the core. Enter a path to add one.)"
 msgstr "(由核心共享的文件夹。输入路径添加一个。)"
 
-#: src/muuli_wdr.cpp:1747
+#: src/muuli_wdr.cpp:1751
 msgid "Absolute path of a folder on the core's machine, e.g. /home/user/shared"
 msgstr "核心机器上文件夹的绝对路径，如 /home/user/shared"
 
-#: src/muuli_wdr.cpp:1749 src/PrefsUnifiedDlg.cpp:2874
+#: src/muuli_wdr.cpp:1753 src/PrefsUnifiedDlg.cpp:2883
 msgid "Recursive"
 msgstr "递归"
 
-#: src/muuli_wdr.cpp:1750
+#: src/muuli_wdr.cpp:1754
 msgid "Share every sub-folder underneath this one, including ones created later."
 msgstr "分享此文件夹下每个子文件夹，包括之后创建的子文件夹。"
 
-#: src/muuli_wdr.cpp:1754 src/utils/aLinkCreator/src/alcframe.cpp:141
+#: src/muuli_wdr.cpp:1758 src/utils/aLinkCreator/src/alcframe.cpp:141
 msgid "Remove"
 msgstr "删除"
 
-#: src/muuli_wdr.cpp:1758
+#: src/muuli_wdr.cpp:1762
 msgid "(Right click on folder icon for recursive share)"
 msgstr "(鼠标右键单击文件夹图标来递归共享)"
 
-#: src/muuli_wdr.cpp:1765
+#: src/muuli_wdr.cpp:1769
 msgid "Share hidden files"
 msgstr "共享隐藏文件"
 
-#: src/muuli_wdr.cpp:1771
+#: src/muuli_wdr.cpp:1775
 msgid "Automatically rescan shared folders for changes"
 msgstr "自动重新扫描共享文件夹以检测更改"
 
-#: src/muuli_wdr.cpp:1777
+#: src/muuli_wdr.cpp:1781
 msgid "Follow symbolic links in shared folders"
 msgstr "在共享文件夹中跟踪符号链接"
 
-#: src/muuli_wdr.cpp:1783
+#: src/muuli_wdr.cpp:1787
 msgid "Exclude files matching:"
 msgstr "排除文件匹配："
 
-#: src/muuli_wdr.cpp:1786
+#: src/muuli_wdr.cpp:1790
 msgid "Wildcard patterns separated by '|', e.g. .DS_Store|Thumbs.db|*.tmp. Files whose name matches are not shared. Matching is case-insensitive."
 msgstr "以“|”分隔的通配符模式，例如 .DS_Store|Thumbs.db|*.tmp。不会共享文件名匹配的文件。匹配不区分大小写。"
 
-#: src/muuli_wdr.cpp:1790
+#: src/muuli_wdr.cpp:1794
 msgid "Patterns are regular expressions"
 msgstr "模式是正则表达式"
 
-#: src/muuli_wdr.cpp:1791
+#: src/muuli_wdr.cpp:1795
 msgid "When set, the whole field is one regular expression ('|' is alternation). When unset, it is a list of '|'-separated wildcards."
 msgstr "启用后，整个字段是一个正则表达式（'|' 表示交替）。禁用后，它是一个以 '|' 分隔的通配符列表。"
 
-#: src/muuli_wdr.cpp:1801
+#: src/muuli_wdr.cpp:1805
 msgid "Show how many shared files the current pattern would exclude."
 msgstr "显示当前模式会排除多少共享文件。"
 
-#: src/muuli_wdr.cpp:1822
+#: src/muuli_wdr.cpp:1826
 msgid "Graphs"
 msgstr "图表"
 
-#: src/muuli_wdr.cpp:1825 src/muuli_wdr.cpp:1887
+#: src/muuli_wdr.cpp:1829 src/muuli_wdr.cpp:1891
 msgid "Update delay : 5 secs"
 msgstr "刷新延迟：5 秒"
 
-#: src/muuli_wdr.cpp:1829
+#: src/muuli_wdr.cpp:1833
 msgid "Time for average graph: 100 mins"
 msgstr "平均值图表显示时间：100 分钟"
 
-#: src/muuli_wdr.cpp:1833
+#: src/muuli_wdr.cpp:1837
 msgid "Connections Graph Scale: 100 "
 msgstr "连接图表尺寸: 100 "
 
-#: src/muuli_wdr.cpp:1840
+#: src/muuli_wdr.cpp:1844
 msgid "Download graph scale:"
 msgstr "下载图表尺寸："
 
-#: src/muuli_wdr.cpp:1848
+#: src/muuli_wdr.cpp:1852
 msgid "Upload graph scale:"
 msgstr "上传图表尺寸："
 
-#: src/muuli_wdr.cpp:1858
+#: src/muuli_wdr.cpp:1862
 msgid "Colors: "
 msgstr "颜色： "
 
-#: src/muuli_wdr.cpp:1862
+#: src/muuli_wdr.cpp:1866
 msgid "Background"
 msgstr "背景"
 
-#: src/muuli_wdr.cpp:1863
+#: src/muuli_wdr.cpp:1867
 msgid "Grid"
 msgstr "网格"
 
-#: src/muuli_wdr.cpp:1864
+#: src/muuli_wdr.cpp:1868
 msgid "Download current"
 msgstr "目前下载"
 
-#: src/muuli_wdr.cpp:1865
+#: src/muuli_wdr.cpp:1869
 msgid "Download running average"
 msgstr "动态平均下载"
 
-#: src/muuli_wdr.cpp:1866
+#: src/muuli_wdr.cpp:1870
 msgid "Download session average"
 msgstr "本次运行平均下载"
 
-#: src/muuli_wdr.cpp:1867
+#: src/muuli_wdr.cpp:1871
 msgid "Upload current"
 msgstr "目前上传"
 
-#: src/muuli_wdr.cpp:1868
+#: src/muuli_wdr.cpp:1872
 msgid "Upload running average"
 msgstr "动态平均上传"
 
-#: src/muuli_wdr.cpp:1869
+#: src/muuli_wdr.cpp:1873
 msgid "Upload session average"
 msgstr "本次运行平均上传"
 
-#: src/muuli_wdr.cpp:1870
+#: src/muuli_wdr.cpp:1874
 msgid "Active connections"
 msgstr "活跃连接"
 
-#: src/muuli_wdr.cpp:1873
+#: src/muuli_wdr.cpp:1877
 msgid "Systray Icon Speed Bar"
 msgstr "系统状态栏图标速度显示"
 
-#: src/muuli_wdr.cpp:1874
+#: src/muuli_wdr.cpp:1878
 msgid "Kad-nodes current"
 msgstr "当前 Kad 节点"
 
-#: src/muuli_wdr.cpp:1875
+#: src/muuli_wdr.cpp:1879
 msgid "Kad-nodes running"
 msgstr "运行的 Kad 节点"
 
-#: src/muuli_wdr.cpp:1876
+#: src/muuli_wdr.cpp:1880
 msgid "Kad-nodes session"
 msgstr "本次运行的 Kad 节点"
 
-#: src/muuli_wdr.cpp:1880 src/muuli_wdr.cpp:2334
+#: src/muuli_wdr.cpp:1884 src/muuli_wdr.cpp:2338
 msgid "Select"
 msgstr "选择"
 
-#: src/muuli_wdr.cpp:1884
+#: src/muuli_wdr.cpp:1888
 msgid "Tree"
 msgstr "树"
 
-#: src/muuli_wdr.cpp:1894
+#: src/muuli_wdr.cpp:1898
 msgid "Number of Client Versions shown (0=unlimited)"
 msgstr "显示用户软件版本的数量(0代表不限制)"
 
-#: src/muuli_wdr.cpp:1919
+#: src/muuli_wdr.cpp:1923
 msgid "!!! WARNING !!!"
 msgstr "！！！警告！！！"
 
-#: src/muuli_wdr.cpp:1934
+#: src/muuli_wdr.cpp:1938
 msgid "Max new connections / 5 secs"
 msgstr "5 秒内最大新连接数"
 
-#: src/muuli_wdr.cpp:1936
+#: src/muuli_wdr.cpp:1940
 msgid "Concurrent Kad source lookups"
 msgstr "并发 Kad 源查找"
 
-#: src/muuli_wdr.cpp:1938
+#: src/muuli_wdr.cpp:1942
 msgid "Kad source re-search interval (minutes)"
 msgstr "Kad 源重新搜索间隔（分钟）"
 
-#: src/muuli_wdr.cpp:1940
+#: src/muuli_wdr.cpp:1944
 msgid "Source re-ask interval (minutes)"
 msgstr "源重新请求间隔（分钟）"
 
-#: src/muuli_wdr.cpp:1944
+#: src/muuli_wdr.cpp:1948
 msgid "File Buffer Size: 240000 bytes"
 msgstr "文件缓冲：24000 字节"
 
-#: src/muuli_wdr.cpp:1948
+#: src/muuli_wdr.cpp:1952
 msgid "Use MMAP: memory-mapped file access (lower memory use)"
 msgstr "使用 MMAP：内存映射文件访问（降低内存占用）"
 
-#: src/muuli_wdr.cpp:1949
+#: src/muuli_wdr.cpp:1953
 msgid "Maps part files into memory instead of buffering them on the heap, lowering the process memory footprint. May reduce download speed on some disks; best for memory-constrained or upload-heavy hosts."
 msgstr "映射 part 文件到内存而不是在堆栈上缓冲，降低进程内存占用。在一些磁盘上可能降低下载速度；最适合内存紧张或重度上传的主机。"
 
-#: src/muuli_wdr.cpp:1951
+#: src/muuli_wdr.cpp:1955
 msgid "Upload Queue Size: 5000 clients"
 msgstr "上传队列长度：5000 用户"
 
-#: src/muuli_wdr.cpp:1955
+#: src/muuli_wdr.cpp:1959
 msgid "Server connection refresh interval: Disable"
 msgstr "服务器连接刷新周期：禁用"
 
-#: src/muuli_wdr.cpp:1959
+#: src/muuli_wdr.cpp:1963
 msgid "Disable computer's timed standby mode"
 msgstr "停用电脑自动进入待命模式功能"
 
-#: src/muuli_wdr.cpp:1978
+#: src/muuli_wdr.cpp:1982
 msgid "Skin to use: "
 msgstr "要使用的皮肤: "
 
-#: src/muuli_wdr.cpp:1987
+#: src/muuli_wdr.cpp:1991
 msgid "Show \"Fast eD2k Links Handler\" in every window."
 msgstr "在全部窗口都显示“快捷 eD2k 链接处理栏”。"
 
-#: src/muuli_wdr.cpp:1990
+#: src/muuli_wdr.cpp:1994
 msgid "Show extended info on categories tabs"
 msgstr "在分类页中显示附加信息"
 
-#: src/muuli_wdr.cpp:1993
+#: src/muuli_wdr.cpp:1997
 msgid "Show application version on title"
 msgstr "在标题栏显示应用程序版本"
 
-#: src/muuli_wdr.cpp:1995
+#: src/muuli_wdr.cpp:1999
 msgid "Show transfer rates on title"
 msgstr "在标题栏显示传输速度"
 
-#: src/muuli_wdr.cpp:1997
+#: src/muuli_wdr.cpp:2001
 msgid "Before application name"
 msgstr "在应用程序名称之前"
 
-#: src/muuli_wdr.cpp:1999
+#: src/muuli_wdr.cpp:2003
 msgid "After application name"
 msgstr "在应用程序名称之后"
 
-#: src/muuli_wdr.cpp:2002
+#: src/muuli_wdr.cpp:2006
 msgid "Show overhead bandwidth"
 msgstr "显示额外开销的带宽"
 
-#: src/muuli_wdr.cpp:2006
+#: src/muuli_wdr.cpp:2010
 msgid "Vertical toolbar orientation"
 msgstr "垂直显示工具栏"
 
-#: src/muuli_wdr.cpp:2008
+#: src/muuli_wdr.cpp:2012
 msgid "Live column sorting (auto-reorder rows as their values change)"
 msgstr "实时列排序（值更改时自动调整顺序）"
 
-#: src/muuli_wdr.cpp:2015
+#: src/muuli_wdr.cpp:2019
 msgid "Download Queue Files"
 msgstr "下载队列文件"
 
-#: src/muuli_wdr.cpp:2018
+#: src/muuli_wdr.cpp:2022
 msgid "Show progress percentage"
 msgstr "显示进度百分比"
 
-#: src/muuli_wdr.cpp:2024
+#: src/muuli_wdr.cpp:2028
 msgid "Show progress bar"
 msgstr "显示进度条"
 
-#: src/muuli_wdr.cpp:2027
+#: src/muuli_wdr.cpp:2031
 msgid "Flat"
 msgstr "扁平"
 
-#: src/muuli_wdr.cpp:2031
+#: src/muuli_wdr.cpp:2035
 msgid "Round"
 msgstr "圆柱"
 
-#: src/muuli_wdr.cpp:2049
+#: src/muuli_wdr.cpp:2053
 msgid "External Connection Parameters"
 msgstr "远程连接参数"
 
-#: src/muuli_wdr.cpp:2052
+#: src/muuli_wdr.cpp:2056
 msgid "Accept external connections"
 msgstr "接受远程连接"
 
-#: src/muuli_wdr.cpp:2059 src/muuli_wdr.cpp:2118
+#: src/muuli_wdr.cpp:2063 src/muuli_wdr.cpp:2122
 msgid "IP of the listening interface:"
 msgstr "监听接口的 IP:"
 
-#: src/muuli_wdr.cpp:2062
+#: src/muuli_wdr.cpp:2066
 msgid "Enter here a valid ip in the a.b.c.d format for the listening EC interface. An empty field or 0.0.0.0 will mean any interface."
 msgstr "在此输入正确的 IP(格式：a.b.c.d)用于监听远程连接接口。空着不填或者 0.0.0.0 表示任何接口。"
 
-#: src/muuli_wdr.cpp:2083 src/muuli_wdr.cpp:2194
+#: src/muuli_wdr.cpp:2087 src/muuli_wdr.cpp:2198
 msgid "TCP port:"
 msgstr "TCP 端口："
 
-#: src/muuli_wdr.cpp:2089
+#: src/muuli_wdr.cpp:2093
 msgid "Enable UPnP port forwarding on the EC port"
 msgstr "为远程连接端口启用 UPnP"
 
-#: src/muuli_wdr.cpp:2093 src/muuli_wdr.cpp:3079
+#: src/muuli_wdr.cpp:2097 src/muuli_wdr.cpp:3083
 #: src/utils/wxCas/src/wxcasprefs.cpp:167
 msgid "Password"
 msgstr "密码"
 
-#: src/muuli_wdr.cpp:2099
+#: src/muuli_wdr.cpp:2103
 msgid "aMule API server parameters"
 msgstr "aMule API 服务器参数"
 
-#: src/muuli_wdr.cpp:2102
+#: src/muuli_wdr.cpp:2106
 msgid "Run amuleapi (REST API) on startup"
 msgstr "启动时运行 amuleapi (REST API)"
 
-#: src/muuli_wdr.cpp:2107
+#: src/muuli_wdr.cpp:2111
 msgid "HTTP port:"
 msgstr "HTTP 端口："
 
-#: src/muuli_wdr.cpp:2121
+#: src/muuli_wdr.cpp:2125
 msgid "The interface amuleapi's HTTP server listens on. 127.0.0.1 (default) accepts only local connections; use 0.0.0.0 or a specific IP to expose it to other hosts (set an admin password below)."
 msgstr "amuleapi 接口的 HTTP 服务器监听默认地址为 127.0.0.1，该地址仅接受本地连接；使用 0.0.0.0 或特定 IP 地址可将其暴露给其他主机（请在下方设置管理密码）。"
 
-#: src/muuli_wdr.cpp:2126
+#: src/muuli_wdr.cpp:2130
 msgid "Type a password to set or change it. Stored passwords cannot be shown, so leaving this empty keeps the current one."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2128
+#: src/muuli_wdr.cpp:2132
 msgid "Admin password"
 msgstr "管理密码"
 
-#: src/muuli_wdr.cpp:2140 src/muuli_wdr.cpp:2157 src/PrefsUnifiedDlg.cpp:1103
+#: src/muuli_wdr.cpp:2144 src/muuli_wdr.cpp:2161 src/PrefsUnifiedDlg.cpp:1112
 #, fuzzy
 msgid "A password is set."
 msgstr "管理密码"
 
-#: src/muuli_wdr.cpp:2144
+#: src/muuli_wdr.cpp:2148
 #, fuzzy
 msgid "Enable guest access"
 msgstr "拒绝访客访问"
 
-#: src/muuli_wdr.cpp:2145
+#: src/muuli_wdr.cpp:2149
 msgid "Guest sessions may read status and listings but cannot change anything. Turning this off clears the stored guest password."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2149
+#: src/muuli_wdr.cpp:2153
 #, fuzzy
 msgid "Guest password"
 msgstr "Web服务器的访客密码"
 
-#: src/muuli_wdr.cpp:2164
+#: src/muuli_wdr.cpp:2168
 msgid "Web server parameters"
 msgstr "Web 服务参数"
 
-#: src/muuli_wdr.cpp:2167
+#: src/muuli_wdr.cpp:2171
 msgid "Run webserver on startup (deprecated)"
 msgstr "启动时运行 web 服务器（已废弃）"
 
-#: src/muuli_wdr.cpp:2173
+#: src/muuli_wdr.cpp:2177
 msgid "Web template"
 msgstr "Web 模板"
 
-#: src/muuli_wdr.cpp:2178
+#: src/muuli_wdr.cpp:2182
 msgid "Full rights password"
 msgstr "最高权限密码"
 
-#: src/muuli_wdr.cpp:2182
+#: src/muuli_wdr.cpp:2186
 msgid "Enable Low rights User"
 msgstr "启用低权限用户"
 
-#: src/muuli_wdr.cpp:2187
+#: src/muuli_wdr.cpp:2191
 msgid "Low rights password"
 msgstr "低权限密码"
 
-#: src/muuli_wdr.cpp:2201
+#: src/muuli_wdr.cpp:2205
 msgid "Enable UPnP port forwarding of the web server port"
 msgstr "为 Web 服务端口启用 UPn P端口转发"
 
-#: src/muuli_wdr.cpp:2206
+#: src/muuli_wdr.cpp:2210
 msgid "Web server UPnP TCP port (Optional)"
 msgstr "Web 服务器 UPnP 的 TCP 端口(可选)"
 
-#: src/muuli_wdr.cpp:2214
+#: src/muuli_wdr.cpp:2218
 msgid "Page Refresh Time (in secs)"
 msgstr "页面刷新周期(秒)"
 
-#: src/muuli_wdr.cpp:2221
+#: src/muuli_wdr.cpp:2225
 msgid "Enable Gzip compression"
 msgstr "启用 Gzip 压缩"
 
-#: src/muuli_wdr.cpp:2255
+#: src/muuli_wdr.cpp:2259
 msgid "Reset page to defaults"
 msgstr "重置页面为默认"
 
-#: src/muuli_wdr.cpp:2256
+#: src/muuli_wdr.cpp:2260
 msgid "Reset the settings on the current page to their default values."
 msgstr "重置当前页面设置为默认值。"
 
-#: src/muuli_wdr.cpp:2258 src/muuli_wdr.cpp:2344 src/ServerWnd.cpp:274
+#: src/muuli_wdr.cpp:2262 src/muuli_wdr.cpp:2348 src/ServerWnd.cpp:274
 #: src/ServerWnd.cpp:282
 msgid "OK"
 msgstr "确定"
 
-#: src/muuli_wdr.cpp:2260
+#: src/muuli_wdr.cpp:2264
 msgid "Click here to apply any changes made to the preferences."
 msgstr "点击这里立即使用新的设置。"
 
-#: src/muuli_wdr.cpp:2263
+#: src/muuli_wdr.cpp:2267
 msgid "Reset any changes made to the preferences."
 msgstr "取消所有设置改动。"
 
-#: src/muuli_wdr.cpp:2292
+#: src/muuli_wdr.cpp:2296
 msgid "Comment :"
 msgstr "注释 :"
 
-#: src/muuli_wdr.cpp:2299
+#: src/muuli_wdr.cpp:2303
 msgid "Incoming Dir :"
 msgstr "下载目录 :"
 
-#: src/muuli_wdr.cpp:2308
+#: src/muuli_wdr.cpp:2312
 msgid "Change priority for new assigned files :"
 msgstr "设置新加入的文件优先级为 :"
 
-#: src/muuli_wdr.cpp:2312
+#: src/muuli_wdr.cpp:2316
 msgid "Don't change"
 msgstr "不要改变"
 
-#: src/muuli_wdr.cpp:2324
+#: src/muuli_wdr.cpp:2328
 msgid "Select color for this Category (currently selected) :"
 msgstr "选择该分类颜色 (当前选择) :"
 
-#: src/muuli_wdr.cpp:2391 src/muuli_wdr.cpp:2410 src/muuli_wdr.cpp:2432
+#: src/muuli_wdr.cpp:2395 src/muuli_wdr.cpp:2414 src/muuli_wdr.cpp:2436
 msgid "Click this button to reset the log."
 msgstr "按此按钮清空日志。"
 
-#: src/muuli_wdr.cpp:2451
+#: src/muuli_wdr.cpp:2455
 msgid "Click on this button to update the servers list from URL ..."
 msgstr "按此按钮从该网址更新服务器列表 ..."
 
-#: src/muuli_wdr.cpp:2455
+#: src/muuli_wdr.cpp:2459
 msgid "Server list"
 msgstr "服务器列表"
 
-#: src/muuli_wdr.cpp:2459
+#: src/muuli_wdr.cpp:2463
 msgid "Enter the url to a server.met file here and press the button to the left to update the list of known servers."
 msgstr "输入 server.met 文件的地址，再按此按钮更新服务器列表。"
 
-#: src/muuli_wdr.cpp:2464
+#: src/muuli_wdr.cpp:2468
 msgid "Add server manually: Name"
 msgstr "手动添加服务器：名称"
 
-#: src/muuli_wdr.cpp:2467
+#: src/muuli_wdr.cpp:2471
 msgid "Enter the name of the new server here"
 msgstr "在此输入新服务器的名称"
 
-#: src/muuli_wdr.cpp:2469 src/ServerWnd.cpp:206
+#: src/muuli_wdr.cpp:2473 src/ServerWnd.cpp:206
 msgid "IP:Port"
 msgstr "IP 地址:端口"
 
-#: src/muuli_wdr.cpp:2472
+#: src/muuli_wdr.cpp:2476
 msgid "Enter the IP of the server here, using the x.x.x.x format."
 msgstr "输入新服务器的 IP 地址 (x.x.x.x格式)。"
 
-#: src/muuli_wdr.cpp:2478
+#: src/muuli_wdr.cpp:2482
 msgid "Enter the port of the server here."
 msgstr "在此请输入服务器端口。"
 
-#: src/muuli_wdr.cpp:2481
+#: src/muuli_wdr.cpp:2485
 msgid "Add manually a server (fill fields to the left before) ..."
 msgstr "添加新服务器 (先填写左侧的内容) ..."
 
-#: src/muuli_wdr.cpp:2510
+#: src/muuli_wdr.cpp:2514
 msgid "aMule Log"
 msgstr "aMule 日志"
 
-#: src/muuli_wdr.cpp:2518
+#: src/muuli_wdr.cpp:2522
 msgid "Server Info"
 msgstr "服务器信息"
 
-#: src/muuli_wdr.cpp:2522
+#: src/muuli_wdr.cpp:2526
 msgid "ED2K Info"
 msgstr "ED2K 信息"
 
-#: src/muuli_wdr.cpp:2526
+#: src/muuli_wdr.cpp:2530
 msgid "Kad Info"
 msgstr "Kad 信息"
 
-#: src/muuli_wdr.cpp:2554
+#: src/muuli_wdr.cpp:2558
 msgid "Click on this button to update the nodes list from URL ..."
 msgstr "按此更新节点列表自网址..."
 
-#: src/muuli_wdr.cpp:2558
+#: src/muuli_wdr.cpp:2562
 msgid "Nodes (0)"
 msgstr "节点 (0)"
 
-#: src/muuli_wdr.cpp:2562
+#: src/muuli_wdr.cpp:2566
 msgid "Enter the url to a nodes.dat file here and press the button to the left to update the list of known nodes."
 msgstr "输入 nodes.dat 文件的地址并按左边的按钮以更新已知节点列表"
 
-#: src/muuli_wdr.cpp:2565
+#: src/muuli_wdr.cpp:2569
 msgid "Nodes stats"
 msgstr "节点状态"
 
-#: src/muuli_wdr.cpp:2607
+#: src/muuli_wdr.cpp:2611
 msgid "Bootstrap"
 msgstr "启动"
 
-#: src/muuli_wdr.cpp:2610
+#: src/muuli_wdr.cpp:2614
 msgid "New node"
 msgstr "新节点"
 
-#: src/muuli_wdr.cpp:2615
+#: src/muuli_wdr.cpp:2619
 msgid "IP:"
 msgstr "IP："
 
-#: src/muuli_wdr.cpp:2635
+#: src/muuli_wdr.cpp:2639
 msgid "Port:"
 msgstr "端口："
 
-#: src/muuli_wdr.cpp:2648
+#: src/muuli_wdr.cpp:2652
 msgid "Bootstrap from known clients"
 msgstr "从已知用户启动"
 
-#: src/muuli_wdr.cpp:2650
+#: src/muuli_wdr.cpp:2654
 msgid "Disconnect Kad"
 msgstr "断开 Kad"
 
-#: src/muuli_wdr.cpp:2684
+#: src/muuli_wdr.cpp:2688
 msgid "Use Secure User Identification"
 msgstr "使用安全用户认证"
 
-#: src/muuli_wdr.cpp:2686
+#: src/muuli_wdr.cpp:2690
 msgid "It is recommended to enable this option. You will not receive credits if SUI is not enabled."
 msgstr "建议使用此选项，如果安全用户认证没有启用，将不会接收信用证明。"
 
-#: src/muuli_wdr.cpp:2688
+#: src/muuli_wdr.cpp:2692
 msgid "Protocol Obfuscation"
 msgstr "模糊协议"
 
-#: src/muuli_wdr.cpp:2691
+#: src/muuli_wdr.cpp:2695
 msgid "Support Protocol Obfuscation"
 msgstr "支持模糊协议"
 
-#: src/muuli_wdr.cpp:2693
+#: src/muuli_wdr.cpp:2697
 msgid "This option enabled Protocol Obfuscation, and makes aMule accept obfuscated connections from other clients."
 msgstr "此选项启用了模糊协议，可让aMule接受其他用户用迷糊协议的连接"
 
-#: src/muuli_wdr.cpp:2695
+#: src/muuli_wdr.cpp:2699
 msgid "Use obfuscation for outgoing connections"
 msgstr "为传出连接使用模糊协议"
 
-#: src/muuli_wdr.cpp:2697
+#: src/muuli_wdr.cpp:2701
 msgid "This option makes aMule use Protocol Obfuscation when connecting other clients/servers."
 msgstr "此选项使aMule在连接其他用户或服务器时使用模糊协议。"
 
-#: src/muuli_wdr.cpp:2699
+#: src/muuli_wdr.cpp:2703
 msgid "Accept only obfuscated connections"
 msgstr "仅接受模糊协议连接"
 
-#: src/muuli_wdr.cpp:2700
+#: src/muuli_wdr.cpp:2704
 msgid "This option makes aMule only accept obfuscated connections. You will have less sources, but all your traffic will be obfuscated"
 msgstr "此选项让aMule只接受模糊协议连接，源相对来说会更少，但全部数据包都将进行迷惑处理"
 
-#: src/muuli_wdr.cpp:2705
+#: src/muuli_wdr.cpp:2709
 msgid "Everybody"
 msgstr "任何人"
 
-#: src/muuli_wdr.cpp:2707
+#: src/muuli_wdr.cpp:2711
 msgid "No one"
 msgstr "没有人"
 
-#: src/muuli_wdr.cpp:2709
+#: src/muuli_wdr.cpp:2713
 msgid "Who can see my shared files:"
 msgstr "谁可查看我的共享文件："
 
-#: src/muuli_wdr.cpp:2710
+#: src/muuli_wdr.cpp:2714
 msgid "Select who can request to view a list of your shared files."
 msgstr "选择可以浏览共享文件列表的用户。"
 
-#: src/muuli_wdr.cpp:2712
+#: src/muuli_wdr.cpp:2716
 msgid "IP-Filtering"
 msgstr "IP 过滤"
 
-#: src/muuli_wdr.cpp:2719
+#: src/muuli_wdr.cpp:2723
 msgid "Filter clients"
 msgstr "过滤用户"
 
-#: src/muuli_wdr.cpp:2721
+#: src/muuli_wdr.cpp:2725
 msgid "Enable filtering of the client IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "过滤在文件~/.aMule/ipfilter.dat中定义的用户IP"
 
-#: src/muuli_wdr.cpp:2723
+#: src/muuli_wdr.cpp:2727
 msgid "Filter servers"
 msgstr "过滤服务器"
 
-#: src/muuli_wdr.cpp:2725
+#: src/muuli_wdr.cpp:2729
 msgid "Enable filtering of the server IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "过滤在文件~/.aMule/ipfilter.dat中定义的服务器IP"
 
-#: src/muuli_wdr.cpp:2729
+#: src/muuli_wdr.cpp:2733
 msgid "Reload List"
 msgstr "刷新列表"
 
-#: src/muuli_wdr.cpp:2730
+#: src/muuli_wdr.cpp:2734
 msgid "Reload the list of IPs to filter from the file ~/.aMule/ipfilter.dat"
 msgstr "更新 IP 地址过滤列表自文件 ~/.aMule/ipfilter.dat"
 
-#: src/muuli_wdr.cpp:2736
+#: src/muuli_wdr.cpp:2740
 msgid "URL:"
 msgstr "地址:"
 
-#: src/muuli_wdr.cpp:2740 src/muuli_wdr.cpp:2933
+#: src/muuli_wdr.cpp:2744 src/muuli_wdr.cpp:2937
 msgid "Update now"
 msgstr "立即更新"
 
-#: src/muuli_wdr.cpp:2743
+#: src/muuli_wdr.cpp:2747
 msgid "Auto-update ipfilter at startup"
 msgstr "启动后自动更新IP 地址过滤列表"
 
-#: src/muuli_wdr.cpp:2747
+#: src/muuli_wdr.cpp:2751
 msgid "Filtering Level:"
 msgstr "过滤级别:"
 
-#: src/muuli_wdr.cpp:2753
+#: src/muuli_wdr.cpp:2757
 msgid "Always filter LAN IPs"
 msgstr "始终过滤局域网 IP"
 
-#: src/muuli_wdr.cpp:2756
+#: src/muuli_wdr.cpp:2760
 msgid "Paranoid handling of non-matching IPs"
 msgstr "处理不匹配的 IP"
 
-#: src/muuli_wdr.cpp:2758
+#: src/muuli_wdr.cpp:2762
 msgid "Rejects a packet when its source IP differs from the IP the client claims (an anti-spoofing check). Disable only if it causes connection problems."
 msgstr "当数据包的源 IP 地址与客户端声称的 IP 地址不同时，拒绝该数据包（防欺骗检查）。仅在导致连接问题时才禁用此功能。"
 
-#: src/muuli_wdr.cpp:2760
+#: src/muuli_wdr.cpp:2764
 msgid "Use system-wide ipfilter.dat if available"
 msgstr "在可用的情况下使用系统级别的 ipfilter.dat"
 
-#: src/muuli_wdr.cpp:2761
+#: src/muuli_wdr.cpp:2765
 msgid "If there's no local ipfilter.dat found, allow usage of a system-wide ipfilter file."
 msgstr "如果没有找到本地 ipfilter.dat 文件，则允许使用系统级的IP过滤文件。"
 
-#: src/muuli_wdr.cpp:2778
+#: src/muuli_wdr.cpp:2782
 msgid "Enable Online-Signature"
 msgstr "启用在线统计"
 
-#: src/muuli_wdr.cpp:2780
+#: src/muuli_wdr.cpp:2784
 msgid "Enables the writing of the OS file, which can be used by external apps to create signatures and the like."
 msgstr "输出该文件以用于在线统计等等。"
 
-#: src/muuli_wdr.cpp:2784
+#: src/muuli_wdr.cpp:2788
 msgid "Update Frequency (Secs):"
 msgstr "更新频率 (秒):"
 
-#: src/muuli_wdr.cpp:2787
+#: src/muuli_wdr.cpp:2791
 msgid "Change the frequency (in seconds) of Online Signature updates."
 msgstr "更改在线统计文件的更新频率 (秒) 。"
 
-#: src/muuli_wdr.cpp:2795
+#: src/muuli_wdr.cpp:2799
 msgid "Save online signature file in: "
 msgstr "保存在线签名位置： "
 
-#: src/muuli_wdr.cpp:2801
+#: src/muuli_wdr.cpp:2805
 msgid "Click here to select the directory containing the the Online Signature files."
 msgstr "单击此处选择包含在线签名文件的目录。"
 
-#: src/muuli_wdr.cpp:2834
+#: src/muuli_wdr.cpp:2838
 msgid "Show country flags for clients"
 msgstr "为客户端显示国旗"
 
-#: src/muuli_wdr.cpp:2835
+#: src/muuli_wdr.cpp:2839
 msgid "Render the country flag column in the transfers, queue and search views. Requires a valid MMDB GeoIP database (see below)."
 msgstr "在传输、队列和搜索视图中渲染地区旗帜列。需要有效的 MMDB GeoIP 数据库（见下文）。"
 
-#: src/muuli_wdr.cpp:2840
+#: src/muuli_wdr.cpp:2844
 msgid "Database"
 msgstr "数据库"
 
-#: src/muuli_wdr.cpp:2856
+#: src/muuli_wdr.cpp:2860
 msgid "Source:"
 msgstr "源："
 
-#: src/muuli_wdr.cpp:2859
+#: src/muuli_wdr.cpp:2863
 msgid "DB-IP (free, no account)"
 msgstr "DB-IP（免费，无需账户）"
 
-#: src/muuli_wdr.cpp:2860
+#: src/muuli_wdr.cpp:2864
 msgid "MaxMind GeoLite2 (free, account required)"
 msgstr "MaxMind GeoLite2（免费，需注册账户）"
 
-#: src/muuli_wdr.cpp:2861
+#: src/muuli_wdr.cpp:2865
 msgid "Custom URL"
 msgstr "自定义 URL"
 
-#: src/muuli_wdr.cpp:2864
+#: src/muuli_wdr.cpp:2868
 msgid "Choose which provider supplies the GeoIP MMDB database. DB-IP is the default - no account required. MaxMind requires a free account + license key. Use Custom URL to point at any other MMDB host (e.g. a local mirror)."
 msgstr "选择哪个提供商提供 GeoIP MMDB 数据库。DB-IP 是默认选项，无需账户。MaxMind 需要一个免费账户和许可证密钥。使用自定义 URL 指向任何其他 MMDB 主机（例如本地镜像）。"
 
-#: src/muuli_wdr.cpp:2881
+#: src/muuli_wdr.cpp:2885
 msgid ""
 "No configuration required.\n"
 "\n"
@@ -4855,11 +4855,11 @@ msgstr ""
 "IP-to-Country 数据由 DB-IP.com 提供 - https://db-ip.com\n"
 "许可证：知识共享署名 4.0 国际版 - https://creativecommons.org/licenses/by/4.0/"
 
-#: src/muuli_wdr.cpp:2894
+#: src/muuli_wdr.cpp:2898
 msgid "License key:"
 msgstr "许可证密钥："
 
-#: src/muuli_wdr.cpp:2900
+#: src/muuli_wdr.cpp:2904
 msgid ""
 "Sign up for a free MaxMind account, then generate a License Key:\n"
 "https://www.maxmind.com/en/geolite2/signup\n"
@@ -4875,11 +4875,11 @@ msgstr ""
 "许可证：MaxMind GeoLite2 最终用户许可协议 - https://www.maxmind.com/en/geolite2/eula\n"
 "需要注明出处并注册账户；至少每 30 天刷新一次。"
 
-#: src/muuli_wdr.cpp:2915
+#: src/muuli_wdr.cpp:2919
 msgid "Download URL:"
 msgstr "下载地址："
 
-#: src/muuli_wdr.cpp:2921
+#: src/muuli_wdr.cpp:2925
 msgid ""
 "Must point to an .mmdb file or a .gz / .tar.gz containing one.\n"
 "URL may include credentials (https://user:pass@host/...).\n"
@@ -4889,211 +4889,211 @@ msgstr ""
 "URL 可包含凭据（例如 https://user:pass@host/...）。\n"
 "许可和署名条款由上游 URL 决定——你需自行负责。"
 
-#: src/muuli_wdr.cpp:2934
+#: src/muuli_wdr.cpp:2938
 msgid "Download the GeoIP database from the selected source."
 msgstr "从所选源下载 GeoIP 数据库。"
 
-#: src/muuli_wdr.cpp:2936
+#: src/muuli_wdr.cpp:2940
 msgid "Auto-update on startup"
 msgstr "启动后自动更新"
 
-#: src/muuli_wdr.cpp:2937
+#: src/muuli_wdr.cpp:2941
 msgid "Re-download the GeoIP database from the selected source every time aMule starts."
 msgstr "每次启动 aMule 时，从所选源重新下载 GeoIP 数据库。"
 
-#: src/muuli_wdr.cpp:2960
+#: src/muuli_wdr.cpp:2964
 msgid "Filter incoming messages (except current chat):"
 msgstr "过滤收到的消息 (不包括当前对话):"
 
-#: src/muuli_wdr.cpp:2962
+#: src/muuli_wdr.cpp:2966
 msgid "Filter all messages"
 msgstr "过滤所有消息"
 
-#: src/muuli_wdr.cpp:2964
+#: src/muuli_wdr.cpp:2968
 msgid "Filter messages from people not on your friend list"
 msgstr "过滤来自好友列表外的消息"
 
-#: src/muuli_wdr.cpp:2966
+#: src/muuli_wdr.cpp:2970
 msgid "Filter messages from unknown clients"
 msgstr "过滤来自未知用户的消息"
 
-#: src/muuli_wdr.cpp:2968
+#: src/muuli_wdr.cpp:2972
 msgid "Filter messages containing (use ',' as separator):"
 msgstr "过滤包含以下内容的消息 (用半角逗号分隔):"
 
-#: src/muuli_wdr.cpp:2971 src/muuli_wdr.cpp:2982
+#: src/muuli_wdr.cpp:2975 src/muuli_wdr.cpp:2986
 msgid "add here the words amule should filter and block messages including it"
 msgstr "输入需过滤的词组"
 
-#: src/muuli_wdr.cpp:2973
+#: src/muuli_wdr.cpp:2977
 msgid "Show received messages in the log"
 msgstr "在日志中显示接收的消息"
 
-#: src/muuli_wdr.cpp:2976
+#: src/muuli_wdr.cpp:2980
 msgid "Comments"
 msgstr "备注"
 
-#: src/muuli_wdr.cpp:2979
+#: src/muuli_wdr.cpp:2983
 msgid "Filter comments containing (use ',' as separator):"
 msgstr "过滤包含以下内容的备注 (使用“,”作为分隔符):"
 
-#: src/muuli_wdr.cpp:3004
+#: src/muuli_wdr.cpp:3008
 msgid "Enable Proxy"
 msgstr "启用代理"
 
-#: src/muuli_wdr.cpp:3005
+#: src/muuli_wdr.cpp:3009
 msgid "Enable/disable proxy support"
 msgstr "启用/禁用代理支持"
 
-#: src/muuli_wdr.cpp:3008
+#: src/muuli_wdr.cpp:3012
 msgid "Proxy type:"
 msgstr "代理类型:"
 
-#: src/muuli_wdr.cpp:3019
+#: src/muuli_wdr.cpp:3023
 msgid "Proxy host:"
 msgstr "代理服务器:"
 
-#: src/muuli_wdr.cpp:3022
+#: src/muuli_wdr.cpp:3026
 msgid "The proxy host name"
 msgstr "代理服务器名称"
 
-#: src/muuli_wdr.cpp:3024
+#: src/muuli_wdr.cpp:3028
 msgid "Proxy port:"
 msgstr "代理端口:"
 
-#: src/muuli_wdr.cpp:3027
+#: src/muuli_wdr.cpp:3031
 msgid "The proxy port"
 msgstr "代理端口"
 
-#: src/muuli_wdr.cpp:3029
+#: src/muuli_wdr.cpp:3033
 msgid "Enable authentication"
 msgstr "启用验证："
 
-#: src/muuli_wdr.cpp:3030
+#: src/muuli_wdr.cpp:3034
 msgid "Enable/disable username/password authentication"
 msgstr "启用/禁用用户名/密码验证"
 
-#: src/muuli_wdr.cpp:3033
+#: src/muuli_wdr.cpp:3037
 msgid "Username: "
 msgstr "用户名: "
 
-#: src/muuli_wdr.cpp:3036
+#: src/muuli_wdr.cpp:3040
 msgid "The username to use to connect to the proxy"
 msgstr "连接代理服务器的用户名"
 
-#: src/muuli_wdr.cpp:3038
+#: src/muuli_wdr.cpp:3042
 msgid "Password:"
 msgstr "密码:"
 
-#: src/muuli_wdr.cpp:3041
+#: src/muuli_wdr.cpp:3045
 msgid "The password to use to connect to the proxy"
 msgstr "连接代理服务器的密码"
 
-#: src/muuli_wdr.cpp:3060
+#: src/muuli_wdr.cpp:3064
 msgid "Connect to:"
 msgstr "连接到:"
 
-#: src/muuli_wdr.cpp:3069
+#: src/muuli_wdr.cpp:3073
 msgid "Login to remote amule"
 msgstr "登录远程 amule"
 
-#: src/muuli_wdr.cpp:3074
+#: src/muuli_wdr.cpp:3078
 msgid "User name"
 msgstr "用户名"
 
-#: src/muuli_wdr.cpp:3085
+#: src/muuli_wdr.cpp:3089
 msgid "Remember those settings"
 msgstr "记住这些设置"
 
-#: src/muuli_wdr.cpp:3088
+#: src/muuli_wdr.cpp:3092
 msgid "Force ZLIB compression"
 msgstr "强制使用 ZLIB 压缩"
 
-#: src/muuli_wdr.cpp:3112
+#: src/muuli_wdr.cpp:3116
 msgid "Enable Verbose Debug-Logging."
 msgstr "启用详细调试日志。"
 
-#: src/muuli_wdr.cpp:3114
+#: src/muuli_wdr.cpp:3118
 msgid "Only to Logfile"
 msgstr "只记录到日志文件"
 
-#: src/muuli_wdr.cpp:3116
+#: src/muuli_wdr.cpp:3120
 msgid "Message Categories:"
 msgstr "消息分类:"
 
-#: src/muuli_wdr.cpp:3140 src/PartFileConvertDlg.cpp:160
+#: src/muuli_wdr.cpp:3144 src/PartFileConvertDlg.cpp:160
 msgid "Waiting..."
 msgstr "等待中..."
 
-#: src/muuli_wdr.cpp:3160
+#: src/muuli_wdr.cpp:3164
 msgid "Add imports"
 msgstr "添加导入文件"
 
-#: src/muuli_wdr.cpp:3163
+#: src/muuli_wdr.cpp:3167
 msgid "Retry selected"
 msgstr "重试所选"
 
-#: src/muuli_wdr.cpp:3165
+#: src/muuli_wdr.cpp:3169
 msgid "Remove selected"
 msgstr "删除所选"
 
-#: src/muuli_wdr.cpp:3228
+#: src/muuli_wdr.cpp:3232
 msgid "Event Types"
 msgstr "事件类型"
 
-#: src/muuli_wdr.cpp:3247
+#: src/muuli_wdr.cpp:3251
 msgid "Statistics and queued clients for selected file(s) : Session / All time"
 msgstr "所选文件的统计和队列用户：会话/全部时间"
 
-#: src/muuli_wdr.cpp:3271
+#: src/muuli_wdr.cpp:3275
 msgid "Active Uploads"
 msgstr "活跃上传"
 
-#: src/muuli_wdr.cpp:3285
+#: src/muuli_wdr.cpp:3289
 msgid "Percent of total files"
 msgstr "全部文件的百分比"
 
-#: src/muuli_wdr.cpp:3337
+#: src/muuli_wdr.cpp:3341
 msgid "Show Clients for"
 msgstr "显示客户端"
 
-#: src/muuli_wdr.cpp:3339
+#: src/muuli_wdr.cpp:3343
 msgid "All files"
 msgstr "所有文件"
 
-#: src/muuli_wdr.cpp:3342
+#: src/muuli_wdr.cpp:3346
 msgid "Selected files"
 msgstr "选择的文件"
 
-#: src/muuli_wdr.cpp:3345
+#: src/muuli_wdr.cpp:3349
 msgid "Active uploads only"
 msgstr "仅活跃上传"
 
-#: src/muuli_wdr.cpp:3352
+#: src/muuli_wdr.cpp:3356
 msgid "Reload:"
 msgstr "重新载入:"
 
-#: src/muuli_wdr.cpp:3356
+#: src/muuli_wdr.cpp:3360
 msgid "Reload your shared files"
 msgstr "刷新共享文件"
 
-#: src/muuli_wdr.cpp:3419
+#: src/muuli_wdr.cpp:3423
 msgid "Send"
 msgstr "发送"
 
-#: src/muuli_wdr.cpp:3420
+#: src/muuli_wdr.cpp:3424
 msgid "Sends the specified message."
 msgstr "发送指定消息。"
 
-#: src/muuli_wdr.cpp:3424
+#: src/muuli_wdr.cpp:3428
 msgid "Close this chat-session."
 msgstr "结束本次聊天。"
 
-#: src/muuli_wdr.cpp:3447
+#: src/muuli_wdr.cpp:3451
 msgid "Connect to any server and/or Kad"
 msgstr "连接至任何服务器和/或 Kad"
 
-#: src/muuli_wdr.cpp:3453 src/SharedFilesCtrl.cpp:142 src/Statistics.cpp:941
+#: src/muuli_wdr.cpp:3457 src/SharedFilesCtrl.cpp:142 src/Statistics.cpp:941
 msgid "Shared Files"
 msgstr "共享文件"
 
@@ -5728,35 +5728,35 @@ msgstr ""
 "即使不改动这些设置，aMule\n"
 "也完全可以正常运行。"
 
-#: src/PrefsUnifiedDlg.cpp:647
+#: src/PrefsUnifiedDlg.cpp:656
 #, c-format
 msgid "Failed to connect Cfg to widget with the ID %d and key %s"
 msgstr "使用ID %d和密匙%s连接Cfg到小插件失败"
 
-#: src/PrefsUnifiedDlg.cpp:695
+#: src/PrefsUnifiedDlg.cpp:704
 #, c-format
 msgid "Failed to transfer data from Cfg to Widget with the ID %d and key %s"
 msgstr "通过ID %d和密匙%s把数据从Cfg转移到小插件失败"
 
-#: src/PrefsUnifiedDlg.cpp:801
+#: src/PrefsUnifiedDlg.cpp:810
 msgid "The type of proxy you are connecting to"
 msgstr "正在连接的代理服务器类型"
 
-#: src/PrefsUnifiedDlg.cpp:1020
+#: src/PrefsUnifiedDlg.cpp:1029
 #, c-format
 msgid "Failed to transfer data from Widget to Cfg with the ID %d and key %s"
 msgstr "通过ID %d和密匙%s把数据从小插件转移到Cfg失败"
 
-#: src/PrefsUnifiedDlg.cpp:1103
+#: src/PrefsUnifiedDlg.cpp:1112
 #, fuzzy
 msgid "No password set."
 msgstr "管理密码"
 
-#: src/PrefsUnifiedDlg.cpp:1132
+#: src/PrefsUnifiedDlg.cpp:1141
 msgid "Guest access needs a password. Type one in the guest password field, or untick Enable guest access."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1144
+#: src/PrefsUnifiedDlg.cpp:1153
 msgid ""
 "aMule must be restarted to enable these changes:\n"
 "\n"
@@ -5764,39 +5764,39 @@ msgstr ""
 "重启aMule后这些更改才能生效：\n"
 "\n"
 
-#: src/PrefsUnifiedDlg.cpp:1151
+#: src/PrefsUnifiedDlg.cpp:1160
 msgid "- TCP port changed.\n"
 msgstr "- TCP端口已更改。\n"
 
-#: src/PrefsUnifiedDlg.cpp:1156
+#: src/PrefsUnifiedDlg.cpp:1165
 msgid "- UDP port changed.\n"
 msgstr "- UDP端口已更改。\n"
 
-#: src/PrefsUnifiedDlg.cpp:1161
+#: src/PrefsUnifiedDlg.cpp:1170
 msgid "- Network interface binding changed.\n"
 msgstr "- 更改了网络接口绑定.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1166
+#: src/PrefsUnifiedDlg.cpp:1175
 msgid "- External connect port changed.\n"
 msgstr "- 外部连接端口已更改。\n"
 
-#: src/PrefsUnifiedDlg.cpp:1170
+#: src/PrefsUnifiedDlg.cpp:1179
 msgid "- External connect acceptance changed.\n"
 msgstr "- 更改了外部连接接受。\n"
 
-#: src/PrefsUnifiedDlg.cpp:1174
+#: src/PrefsUnifiedDlg.cpp:1183
 msgid "- External connect interface changed.\n"
 msgstr "- 更改了外部连接接口。\n"
 
-#: src/PrefsUnifiedDlg.cpp:1178
+#: src/PrefsUnifiedDlg.cpp:1187
 msgid "- Protocol obfuscation support changed.\n"
 msgstr "- 模糊协议支持已更改。\n"
 
-#: src/PrefsUnifiedDlg.cpp:1193
+#: src/PrefsUnifiedDlg.cpp:1202
 msgid "- amuleapi settings changed.\n"
 msgstr "- amuleapi 设置已更改。\n"
 
-#: src/PrefsUnifiedDlg.cpp:1202
+#: src/PrefsUnifiedDlg.cpp:1211
 msgid ""
 "Your Auto-update server list is empty.\n"
 "'Auto-update server list at startup' will be disabled."
@@ -5804,7 +5804,7 @@ msgstr ""
 "您的自动更新服务器列表是可空的，\n"
 "启动时自动更新服务器列表功能将被禁用。"
 
-#: src/PrefsUnifiedDlg.cpp:1213
+#: src/PrefsUnifiedDlg.cpp:1222
 msgid ""
 "You have enabled external connections but have not specified a password.\n"
 "External connections cannot be enabled unless a valid password is specified."
@@ -5812,32 +5812,32 @@ msgstr ""
 "您已经启用了远程连接但还没有设置密码。\n"
 "远程连接在没有有效密码的情况下不能使用。"
 
-#: src/PrefsUnifiedDlg.cpp:1246
+#: src/PrefsUnifiedDlg.cpp:1255
 #, c-format
 msgid "The amuleapi password could not be saved: %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1276
+#: src/PrefsUnifiedDlg.cpp:1285
 msgid "- Language changed.\n"
 msgstr "- 语言已更改。\n"
 
-#: src/PrefsUnifiedDlg.cpp:1281
+#: src/PrefsUnifiedDlg.cpp:1290
 msgid "- Temp folder changed.\n"
 msgstr "- 临时文件目录已更改。\n"
 
-#: src/PrefsUnifiedDlg.cpp:1286
+#: src/PrefsUnifiedDlg.cpp:1295
 msgid "- ED2K network enabled.\n"
 msgstr "-ED2K网络已启用。\n"
 
-#: src/PrefsUnifiedDlg.cpp:1319
+#: src/PrefsUnifiedDlg.cpp:1328
 msgid "The shared-file exclusion pattern is not a valid regular expression. The filter has been left disabled."
 msgstr "共享文件排除模式不是有效的正则表达式。已禁用该筛选器。"
 
-#: src/PrefsUnifiedDlg.cpp:1321 src/PrefsUnifiedDlg.cpp:1921
+#: src/PrefsUnifiedDlg.cpp:1330 src/PrefsUnifiedDlg.cpp:1930
 msgid "Invalid regular expression"
 msgstr "无效的正则表达式"
 
-#: src/PrefsUnifiedDlg.cpp:1398
+#: src/PrefsUnifiedDlg.cpp:1407
 msgid ""
 "Both eD2k and Kad network are disabled.\n"
 "You won't be able to connect until you enable at least one of them."
@@ -5845,7 +5845,7 @@ msgstr ""
 "eD2k 和 Kad 网络都已被禁用，\n"
 "你至少要启用其中的一项才能连接。"
 
-#: src/PrefsUnifiedDlg.cpp:1403
+#: src/PrefsUnifiedDlg.cpp:1412
 msgid ""
 "Kad will not start if your UDP port is disabled.\n"
 "Enable UDP port or disable Kad."
@@ -5853,7 +5853,7 @@ msgstr ""
 "如果你的 UDP 端口被禁用，Kad 将不能启动。\n"
 "启动 UDP 端口或禁用 Kad。"
 
-#: src/PrefsUnifiedDlg.cpp:1459
+#: src/PrefsUnifiedDlg.cpp:1468
 msgid ""
 "\n"
 "You MUST restart aMule now.\n"
@@ -5863,68 +5863,68 @@ msgstr ""
 "你必须现在重启aMule，\n"
 "如果现在不重启的话，出现任何问题可别怪别人。\n"
 
-#: src/PrefsUnifiedDlg.cpp:1524
+#: src/PrefsUnifiedDlg.cpp:1533
 msgid "Could not register aMule for autostart at login. The autostart store may be read-only."
 msgstr "无法将 aMule 注册为登录时自动启动。自动启动存储可能为只读。"
 
-#: src/PrefsUnifiedDlg.cpp:1526
+#: src/PrefsUnifiedDlg.cpp:1535
 msgid "Could not remove the autostart-at-login entry."
 msgstr "无法移除登录时自动启动的条目。"
 
-#: src/PrefsUnifiedDlg.cpp:1527
+#: src/PrefsUnifiedDlg.cpp:1536
 msgid "Autostart"
 msgstr "自启动"
 
-#: src/PrefsUnifiedDlg.cpp:1542
+#: src/PrefsUnifiedDlg.cpp:1551
 msgid "Register file type"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1542
+#: src/PrefsUnifiedDlg.cpp:1551
 msgid "Register URL handler"
 msgstr "注册URL处理程序"
 
-#: src/PrefsUnifiedDlg.cpp:1550
+#: src/PrefsUnifiedDlg.cpp:1559
 #, c-format
 msgid "aMule only handles eD2k-compatible magnets. If you replace the current magnet handler (%s), BitTorrent magnet links will stop working - aMule cannot download BitTorrent content. Continue?"
 msgstr "aMule 仅支持兼容 eD2k 的磁力链接。如果替换当前磁力链接处理程序（%s），BitTorrent 磁力链接将停止工作——aMule 无法下载 BitTorrent 内容。是否继续？"
 
-#: src/PrefsUnifiedDlg.cpp:1555
+#: src/PrefsUnifiedDlg.cpp:1564
 #, fuzzy, c-format
 msgid "Another application currently opens .emulecollection files (%s). Replace it with aMule?"
 msgstr "目前已存在另一个应用程序作为这些链接（%s) 的默认处理程序。是否要将其换成aMule？"
 
-#: src/PrefsUnifiedDlg.cpp:1560
+#: src/PrefsUnifiedDlg.cpp:1569
 #, c-format
 msgid "Another application is currently the default handler for these links (%s). Replace it with aMule?"
 msgstr "目前已存在另一个应用程序作为这些链接（%s) 的默认处理程序。是否要将其换成aMule？"
 
-#: src/PrefsUnifiedDlg.cpp:1585
+#: src/PrefsUnifiedDlg.cpp:1594
 #, fuzzy
 msgid "Could not register aMule for .emulecollection files. The registration store may be read-only."
 msgstr "无法将 aMule 注册为URL处理程序。自动启动存储可能为只读。"
 
-#: src/PrefsUnifiedDlg.cpp:1587
+#: src/PrefsUnifiedDlg.cpp:1596
 #, fuzzy
 msgid "Could not remove the file type registration."
 msgstr "无法移除URL处理程序的注册。"
 
-#: src/PrefsUnifiedDlg.cpp:1589
+#: src/PrefsUnifiedDlg.cpp:1598
 msgid "Could not register aMule as the URL handler. The registration store may be read-only."
 msgstr "无法将 aMule 注册为URL处理程序。自动启动存储可能为只读。"
 
-#: src/PrefsUnifiedDlg.cpp:1591
+#: src/PrefsUnifiedDlg.cpp:1600
 msgid "Could not remove the URL handler registration."
 msgstr "无法移除URL处理程序的注册。"
 
-#: src/PrefsUnifiedDlg.cpp:1661 src/PrefsUnifiedDlg.cpp:1688
+#: src/PrefsUnifiedDlg.cpp:1670 src/PrefsUnifiedDlg.cpp:1697
 msgid "The web server and aMule API require external connections to be enabled."
 msgstr "启用 web 服务器和 aMule API 需要外部连接。"
 
-#: src/PrefsUnifiedDlg.cpp:1671
+#: src/PrefsUnifiedDlg.cpp:1680
 msgid "The aMule web server is deprecated. Consider running the aMule API instead."
 msgstr "aMule Web 服务器已弃用。请考虑运行 aMule API。"
 
-#: src/PrefsUnifiedDlg.cpp:1735
+#: src/PrefsUnifiedDlg.cpp:1744
 msgid ""
 "Your Auto-update servers list is in blank.\n"
 "Please fill in at least one URL to point to a valid server.met file.\n"
@@ -5934,64 +5934,64 @@ msgstr ""
 "请输入至少一个指向有效 server.met 的网址，\n"
 "点击这个勾选框旁边的\"列表\"按钮然后输入网址。"
 
-#: src/PrefsUnifiedDlg.cpp:1876
+#: src/PrefsUnifiedDlg.cpp:1885
 msgid "Temporary files"
 msgstr "临时文件"
 
-#: src/PrefsUnifiedDlg.cpp:1881
+#: src/PrefsUnifiedDlg.cpp:1890
 msgid "Incoming files"
 msgstr "传入文件"
 
-#: src/PrefsUnifiedDlg.cpp:1886
+#: src/PrefsUnifiedDlg.cpp:1895
 msgid "Online Signatures"
 msgstr "在线签名"
 
-#: src/PrefsUnifiedDlg.cpp:1899
+#: src/PrefsUnifiedDlg.cpp:1908
 #, c-format
 msgid "Choose a folder for %s"
 msgstr "为%s选择文件夹"
 
-#: src/PrefsUnifiedDlg.cpp:1923
+#: src/PrefsUnifiedDlg.cpp:1932
 #, c-format
 msgid "Would exclude %u of %u shared file"
 msgid_plural "Would exclude %u of %u shared files"
 msgstr[0] "将排除 %u 个共享文件，共 %u 个"
 msgstr[1] "将排除 %u 个共享文件，共 %u 个"
 
-#: src/PrefsUnifiedDlg.cpp:1940
+#: src/PrefsUnifiedDlg.cpp:1949
 msgid "Browse for videoplayer"
 msgstr "浏览寻找视频播放器"
 
-#: src/PrefsUnifiedDlg.cpp:1944
+#: src/PrefsUnifiedDlg.cpp:1953
 msgid "Select browser"
 msgstr "选择浏览器"
 
-#: src/PrefsUnifiedDlg.cpp:1948
+#: src/PrefsUnifiedDlg.cpp:1957
 msgid "Select ffprobe binary"
 msgstr "选择 ffprobe 文件"
 
-#: src/PrefsUnifiedDlg.cpp:1954
+#: src/PrefsUnifiedDlg.cpp:1963
 #, c-format
 msgid "Executable%s"
 msgstr "可执行%s"
 
-#: src/PrefsUnifiedDlg.cpp:1988
+#: src/PrefsUnifiedDlg.cpp:1997
 msgid "ffprobe not found on PATH or in the standard install locations. Install ffmpeg (which ships ffprobe) or use Browse to pick a binary manually."
 msgstr "未在 PATH 或标准安装位置找到 ffprobe。安装 ffmpeg（ffmpeg 自带 ffprobe），或使用“浏览”手动选择一个二进制文件。"
 
-#: src/PrefsUnifiedDlg.cpp:2000
+#: src/PrefsUnifiedDlg.cpp:2009
 msgid "Reset the settings on this page to their default values?"
 msgstr "重置此页面设置为默认值?"
 
-#: src/PrefsUnifiedDlg.cpp:2001
+#: src/PrefsUnifiedDlg.cpp:2010
 msgid "Reset to defaults"
 msgstr "重置为默认"
 
-#: src/PrefsUnifiedDlg.cpp:2028
+#: src/PrefsUnifiedDlg.cpp:2037
 msgid "Edit server list"
 msgstr "编辑服务器列表"
 
-#: src/PrefsUnifiedDlg.cpp:2029
+#: src/PrefsUnifiedDlg.cpp:2038
 msgid ""
 "Add here URL's to download server.met files.\n"
 "Only one url on each line."
@@ -5999,114 +5999,114 @@ msgstr ""
 "在此添加下载 server.met 文件的地址\n"
 "每行只限一个。"
 
-#: src/PrefsUnifiedDlg.cpp:2084
+#: src/PrefsUnifiedDlg.cpp:2093
 msgid "IP2Country update failed"
 msgstr "IP2Country 更新失败"
 
-#: src/PrefsUnifiedDlg.cpp:2229 src/PrefsUnifiedDlg.cpp:2260
+#: src/PrefsUnifiedDlg.cpp:2238 src/PrefsUnifiedDlg.cpp:2269
 msgid "Data by MaxMind GeoLite2"
 msgstr "数据来自 MaxMind GeoLite2"
 
-#: src/PrefsUnifiedDlg.cpp:2231 src/PrefsUnifiedDlg.cpp:2262
+#: src/PrefsUnifiedDlg.cpp:2240 src/PrefsUnifiedDlg.cpp:2271
 msgid "Custom source"
 msgstr "自定义源"
 
-#: src/PrefsUnifiedDlg.cpp:2233 src/PrefsUnifiedDlg.cpp:2264
+#: src/PrefsUnifiedDlg.cpp:2242 src/PrefsUnifiedDlg.cpp:2273
 msgid "Data by DB-IP.com"
 msgstr "数据来源：DB-IP.com"
 
-#: src/PrefsUnifiedDlg.cpp:2284
+#: src/PrefsUnifiedDlg.cpp:2293
 #, c-format
 msgid "Status: Loaded%s"
 msgstr "状态：已加载%s"
 
-#: src/PrefsUnifiedDlg.cpp:2286
+#: src/PrefsUnifiedDlg.cpp:2295
 #, c-format
 msgid "Status: Loaded%s - %s"
 msgstr "状态：已加载%s~%s"
 
-#: src/PrefsUnifiedDlg.cpp:2290
+#: src/PrefsUnifiedDlg.cpp:2299
 msgid "Status: Failed to load - click 'Update now' to refresh."
 msgstr "状态：加载失败 - 点击“立即更新”以刷新。"
 
-#: src/PrefsUnifiedDlg.cpp:2292
+#: src/PrefsUnifiedDlg.cpp:2301
 msgid "Status: Not found - click 'Update now' to download."
 msgstr "状态：未找到 - 点击“立即更新”进行下载。"
 
-#: src/PrefsUnifiedDlg.cpp:2350 src/PrefsUnifiedDlg.cpp:2374
+#: src/PrefsUnifiedDlg.cpp:2359 src/PrefsUnifiedDlg.cpp:2383
 #, c-format
 msgid "Update delay: %d second"
 msgid_plural "Update delay: %d seconds"
 msgstr[0] "更新延迟：%d秒"
 msgstr[1] "更新延迟：%d秒"
 
-#: src/PrefsUnifiedDlg.cpp:2358
+#: src/PrefsUnifiedDlg.cpp:2367
 #, c-format
 msgid "Time for average graph: %d minute"
 msgid_plural "Time for average graph: %d minutes"
 msgstr[0] "平均值图表显示时间：%d分钟"
 msgstr[1] "平均值图表显示时间：%d分钟"
 
-#: src/PrefsUnifiedDlg.cpp:2367
+#: src/PrefsUnifiedDlg.cpp:2376
 #, c-format
 msgid "Connections Graph Scale: %d"
 msgstr "网络连接图表缩放：%d"
 
-#: src/PrefsUnifiedDlg.cpp:2382
+#: src/PrefsUnifiedDlg.cpp:2391
 #, c-format
 msgid "File Buffer Size: %d byte"
 msgid_plural "File Buffer Size: %d bytes"
 msgstr[0] "文件缓冲区大小：%d字节"
 msgstr[1] "文件缓冲区大小：%d字节"
 
-#: src/PrefsUnifiedDlg.cpp:2392
+#: src/PrefsUnifiedDlg.cpp:2401
 #, c-format
 msgid "Upload Queue Size: %d client"
 msgid_plural "Upload Queue Size: %d clients"
 msgstr[0] "上传队列长度：%d个用户"
 msgstr[1] "上传队列长度：%d个用户"
 
-#: src/PrefsUnifiedDlg.cpp:2402
+#: src/PrefsUnifiedDlg.cpp:2411
 #, c-format
 msgid "Server connection refresh interval: %d minute"
 msgid_plural "Server connection refresh interval: %d minutes"
 msgstr[0] "服务器连接刷新周期：%d分钟"
 msgstr[1] "服务器连接刷新周期：%d分钟"
 
-#: src/PrefsUnifiedDlg.cpp:2407
+#: src/PrefsUnifiedDlg.cpp:2416
 msgid "Server connection refresh interval: Disabled"
 msgstr "服务器连接刷新周期：已禁用"
 
-#: src/PrefsUnifiedDlg.cpp:2451
+#: src/PrefsUnifiedDlg.cpp:2460
 msgid "disabled"
 msgstr "禁用"
 
-#: src/PrefsUnifiedDlg.cpp:2477
+#: src/PrefsUnifiedDlg.cpp:2486
 #, c-format
 msgid "Execute command on '%s' event"
 msgstr "在“%s”事件时执行命令"
 
-#: src/PrefsUnifiedDlg.cpp:2484
+#: src/PrefsUnifiedDlg.cpp:2493
 msgid "Enable command execution on core"
 msgstr "在核心启用执行命令"
 
-#: src/PrefsUnifiedDlg.cpp:2496
+#: src/PrefsUnifiedDlg.cpp:2505
 msgid "Core command:"
 msgstr "核心命令："
 
-#: src/PrefsUnifiedDlg.cpp:2512
+#: src/PrefsUnifiedDlg.cpp:2521
 msgid "Enable command execution on GUI"
 msgstr "在图形界面端启用执行命令"
 
-#: src/PrefsUnifiedDlg.cpp:2524
+#: src/PrefsUnifiedDlg.cpp:2533
 msgid "GUI command:"
 msgstr "图形界面命令："
 
-#: src/PrefsUnifiedDlg.cpp:2540
+#: src/PrefsUnifiedDlg.cpp:2549
 msgid "The following variables will be replaced:"
 msgstr "以下变量将被替换："
 
-#: src/PrefsUnifiedDlg.cpp:2708
+#: src/PrefsUnifiedDlg.cpp:2717
 msgid ""
 "The following folders look like system or sensitive locations:\n"
 "\n"
@@ -6114,37 +6114,37 @@ msgstr ""
 "以下文件夹看起来像是系统或敏感位置：\n"
 "\n"
 
-#: src/PrefsUnifiedDlg.cpp:2713
+#: src/PrefsUnifiedDlg.cpp:2722
 msgid "Sharing them recursively will publish every file underneath on the eD2k/Kad networks. Do you really want to do this?"
 msgstr "递归共享会将每个子文件发布到 eD2k/Kad 网络上。您确定要这样做吗？"
 
-#: src/PrefsUnifiedDlg.cpp:2716
+#: src/PrefsUnifiedDlg.cpp:2725
 msgid "Confirm shared folders"
 msgstr "确认共享的文件夹"
 
-#: src/PrefsUnifiedDlg.cpp:2744
+#: src/PrefsUnifiedDlg.cpp:2753
 msgid "Reloading shared files..."
 msgstr "正重新加载共享文件..."
 
-#: src/PrefsUnifiedDlg.cpp:2745
+#: src/PrefsUnifiedDlg.cpp:2754
 msgid "Scanning for subdirectories..."
 msgstr "正在扫描子目录..."
 
-#: src/PrefsUnifiedDlg.cpp:2746
+#: src/PrefsUnifiedDlg.cpp:2755
 msgid "Updating shared folders"
 msgstr "正在上传共享的文件夹"
 
-#: src/PrefsUnifiedDlg.cpp:2773
+#: src/PrefsUnifiedDlg.cpp:2782
 #, c-format
 msgid "Scanned %u directories..."
 msgstr "已扫描 %u 个目录......"
 
-#: src/PrefsUnifiedDlg.cpp:2823
+#: src/PrefsUnifiedDlg.cpp:2832
 #, c-format
 msgid "Reloading shared files: %u files scanned"
 msgstr "正重新加载共享文件：扫描了 %u 个文件"
 
-#: src/PrefsUnifiedDlg.cpp:2873
+#: src/PrefsUnifiedDlg.cpp:2882
 msgid "Shared folder"
 msgstr "共享的文件夹"
 
@@ -7828,12 +7828,12 @@ msgstr "删除分类"
 msgid "Hashset requested for unknown file: %s"
 msgstr "请求未知文件校检码：%s"
 
-#: src/UploadQueue.cpp:618
+#: src/UploadQueue.cpp:627
 #, c-format
 msgid "Resuming uploads of file: %s"
 msgstr "继续上传此文件: %s"
 
-#: src/UploadQueue.cpp:634
+#: src/UploadQueue.cpp:643
 #, c-format
 msgid "Suspending upload of file: %s"
 msgstr "暂停上传此文件: %s"

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -13,7 +13,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-28 10:19+0200\n"
+"POT-Creation-Date: 2026-07-28 12:17+0200\n"
 "PO-Revision-Date: 2026-07-27 11:48+0000\n"
 "Last-Translator: Mike Akiba <mike2718@gmail.com>\n"
 "Language-Team: Chinese Simplified <kde-i18n-doc@kde.org>\n"
@@ -209,83 +209,83 @@ msgstr "打开 ED2K 链接文件失败。"
 msgid "WARNING: You can't add yourself as a source for an eD2k link while having a lowid."
 msgstr "警告：在 Low ID 的情况下，你不能添加自己作为 ed2k 链接的源。"
 
-#: src/amule.cpp:300
+#: src/amule.cpp:301
 msgid "Now, exiting main app..."
 msgstr "现在，正在退出主程序..."
 
-#: src/amule.cpp:330
+#: src/amule.cpp:331
 #, c-format
 msgid "Terminating amuleweb instance with pid '%d' ... "
 msgstr "正在终止 pid 为“%d”的 amuleweb 实例 ... "
 
-#: src/amule.cpp:334
+#: src/amule.cpp:335
 #, c-format
 msgid "Killing amuleweb instance with pid '%d' ... "
 msgstr "正在终止 pid 为“%d”的 amuleweb 实例 ... "
 
-#: src/amule.cpp:336 src/amule.cpp:349 src/ClientRef.cpp:180
+#: src/amule.cpp:337 src/amule.cpp:350 src/ClientRef.cpp:180
 #: src/SearchDlg.cpp:1041 src/ServerListCtrl.cpp:98
 msgid "Failed"
 msgstr "失败"
 
-#: src/amule.cpp:343
+#: src/amule.cpp:344
 #, c-format
 msgid "Terminating amuleapi instance with pid '%d' ... "
 msgstr "正在终止 pid 为“%d”的 amuleapi 实例 ... "
 
-#: src/amule.cpp:347
+#: src/amule.cpp:348
 #, c-format
 msgid "Killing amuleapi instance with pid '%d' ... "
 msgstr "正在终止 pid 为“%d”的 amuleapi 实例 ... "
 
-#: src/amule.cpp:355
+#: src/amule.cpp:356
 msgid "aMule OnExit: Terminating core."
 msgstr "aMule 正在退出：中止内核。"
 
-#: src/amule.cpp:466
+#: src/amule.cpp:467
 msgid "aMule shutdown completed."
 msgstr "aMule 已经关闭。"
 
-#: src/amule.cpp:470
+#: src/amule.cpp:471
 msgid "Memory debug results for aMule exit:"
 msgstr "对 aMule 退出的内存 Debug 结果："
 
-#: src/amule.cpp:651
+#: src/amule.cpp:652
 #, c-format
 msgid "Binding aMule's peer-to-peer traffic to interface: %s (HTTP updates use the default route)"
 msgstr "将 amule 的 p2p 流量绑定到接口：%s（HTTP 流量使用默认路由）"
 
-#: src/amule.cpp:655
+#: src/amule.cpp:656
 #, c-format
 msgid "Binding all network traffic to interface: %s"
 msgstr "将所有网络流量绑定到接口：%s"
 
-#: src/amule.cpp:659
+#: src/amule.cpp:660
 #, c-format
 msgid "WARNING: configured network interface '%s' was not found - traffic is NOT bound to it and may leave via the default route. Check the interface name in Preferences."
 msgstr "警告：未找到配置的网络接口'%s' - 流量未绑定到该接口，可能通过默认路由离开。 在设置中检查接口名。"
 
-#: src/amule.cpp:665
+#: src/amule.cpp:666
 #, c-format
 msgid "WARNING: binding to network interface '%s' requires elevated privileges and was NOT applied - traffic may leave via the default route. Grant the capability (e.g. 'sudo setcap cap_net_raw+ep' on the aMule binary) or run with sufficient privileges."
 msgstr "警告：绑定到网络接口“%s”需要提升权限，但未成功 - 流量可能通过默认路由离开。请授予相应权限（例如，在 aMule 二进制文件上运行“sudo setcap cap_net_raw+ep”），或以足够的权限运行命令。"
 
-#: src/amule.cpp:673
+#: src/amule.cpp:674
 #, c-format
 msgid "WARNING: could not bind to network interface '%s' - traffic may leave via the default route."
 msgstr "警告：无法绑定到网络接口“%s” − 流量可能经默认路由离开。"
 
-#: src/amule.cpp:732
+#: src/amule.cpp:733
 msgid "Your locale has been changed to System Default due to a configuration change. Sorry."
 msgstr "对不起，由于配置变动，您的地区设置已经变为系统默认值。"
 
-#: src/amule.cpp:734 src/amule.cpp:1581 src/CatDialog.cpp:128
+#: src/amule.cpp:735 src/amule.cpp:1589 src/CatDialog.cpp:128
 #: src/CatDialog.cpp:136 src/CatDialog.cpp:149 src/ServerList.cpp:366
 #: src/ServerListCtrl.cpp:152
 msgid "Info"
 msgstr "信息"
 
-#: src/amule.cpp:741
+#: src/amule.cpp:742
 msgid ""
 "\n"
 "EC configuration"
@@ -293,20 +293,20 @@ msgstr ""
 "\n"
 "EC 配置"
 
-#: src/amule.cpp:744
+#: src/amule.cpp:745
 msgid "Password set and external connections enabled."
 msgstr "密码已设置，启用远程连接。"
 
-#: src/amule.cpp:754 src/KadDlg.cpp:176 src/KadDlg.cpp:185
-#: src/PrefsUnifiedDlg.cpp:1387 src/SharedFilesCtrl.cpp:476
+#: src/amule.cpp:755 src/KadDlg.cpp:176 src/KadDlg.cpp:185
+#: src/PrefsUnifiedDlg.cpp:1461 src/SharedFilesCtrl.cpp:476
 msgid "WARNING"
 msgstr "警告"
 
-#: src/amule.cpp:991
+#: src/amule.cpp:992
 msgid "Network bootstrap"
 msgstr "网络引导"
 
-#: src/amule.cpp:996
+#: src/amule.cpp:997
 msgid ""
 "aMule has detected missing network bootstrap files.\n"
 "Select which ones to download:"
@@ -314,51 +314,51 @@ msgstr ""
 "aMule 检测到缺少网络引导文件。\n"
 "请选择需要下载的文件："
 
-#: src/amule.cpp:1005 src/FirstRunWizard.cpp:411
+#: src/amule.cpp:1006 src/FirstRunWizard.cpp:411
 msgid "eD2k server list (server.met)"
 msgstr "eD2k 服务器列表 (server.met)"
 
-#: src/amule.cpp:1012 src/FirstRunWizard.cpp:416
+#: src/amule.cpp:1013 src/FirstRunWizard.cpp:416
 msgid "Kad bootstrap nodes (nodes.dat)"
 msgstr "Kad 引导节点 (nodes.dat)"
 
-#: src/amule.cpp:1102
+#: src/amule.cpp:1103
 #, c-format
 msgid "web server running on pid %d"
 msgstr "web 服务器正在运行，pid 为 %d"
 
-#: src/amule.cpp:1115
+#: src/amule.cpp:1116
 msgid "You requested to run web server on startup, but the amuleweb binary cannot be run. Please install the package containing aMule web server, or build aMule from source with -DBUILD_WEBSERVER=YES and install it."
 msgstr "您要求启动时运行 Web 服务器，但 amuleweb 程序无法运行， 请先安装包含 amule web 服务器的 aMule 包，或者使用 -DBUILD_WEBSERVER=YES 选项从源码构建 aMule 并安装它。"
 
-#: src/amule.cpp:1120 src/amule.cpp:1177 src/amule.cpp:1291 src/amule.cpp:1593
+#: src/amule.cpp:1121 src/amule.cpp:1185 src/amule.cpp:1299 src/amule.cpp:1601
 #: src/amule-remote-gui.cpp:603 src/amule-remote-gui.cpp:671
 #: src/amule-remote-gui.cpp:709 src/amule-remote-gui.cpp:1282
 #: src/amule-remote-gui.cpp:1345 src/amule-remote-gui.cpp:1372
-#: src/DownloadQueue.cpp:1481
+#: src/DownloadQueue.cpp:1481 src/PrefsUnifiedDlg.cpp:1247
 msgid "ERROR"
 msgstr "错误"
 
-#: src/amule.cpp:1166
+#: src/amule.cpp:1174
 #, c-format
 msgid "amuleapi running on pid %d"
 msgstr "amuleapi 正在运行，pid 为 %d"
 
-#: src/amule.cpp:1172
+#: src/amule.cpp:1180
 msgid "You requested to run amuleapi on startup, but the amuleapi binary cannot be run. Please install the package containing aMule's REST API server, or build aMule from source with -DBUILD_AMULEAPI=YES and install it."
 msgstr "您要求启动时运行 amuleapi，但 amuleapi 程序无法运行， 请先安装包含 amule REST API 服务器的 包，或者使用 -DBUILD_AMULEAPI=YES 选项从源码构建 aMule 并安装它。"
 
-#: src/amule.cpp:1259
+#: src/amule.cpp:1267
 #, c-format
 msgid "Could not bind ports to the specified address: %s"
 msgstr "无法绑定端口到指定的地址：%s"
 
-#: src/amule.cpp:1283
+#: src/amule.cpp:1291
 #, c-format
 msgid "Port %u is not available. You will be LOWID\n"
 msgstr "端口 %u 不可用，你会成为 Low ID\n"
 
-#: src/amule.cpp:1288
+#: src/amule.cpp:1296
 #, c-format
 msgid ""
 "Port %u is not available!\n"
@@ -373,48 +373,48 @@ msgstr ""
 "\n"
 "请检测网络设置以确保端口可用于输入输出。"
 
-#: src/amule.cpp:1385
+#: src/amule.cpp:1393
 msgid "Failed to create OnlineSig File"
 msgstr "创建在线统计文件失败"
 
-#: src/amule.cpp:1393
+#: src/amule.cpp:1401
 msgid "Failed to create aMule OnlineSig File"
 msgstr "创建 aMule 在线统计文件失败"
 
-#: src/amule.cpp:1556
+#: src/amule.cpp:1564
 msgid "The selected locale seems not to be installed on your box. (Note: I'll try to set it anyway)"
 msgstr "您所选择的地区设置在您的计算机上似乎没有安装。(注意：我还是会尝试您所选择的地区设置。)"
 
-#: src/amule.cpp:1566
+#: src/amule.cpp:1574
 #, c-format
 msgid "This is the first time you run aMule %s"
 msgstr "这是您第一次运行 aMule %s"
 
-#: src/amule.cpp:1569
+#: src/amule.cpp:1577
 msgid "This version is a testing version, updated daily, and\n"
 msgstr "此版本是测试版，更新频繁， \n"
 
-#: src/amule.cpp:1570
+#: src/amule.cpp:1578
 msgid "we give no warranty it won't break anything, burn your house,\n"
 msgstr "我们无法承诺它不会损坏任何东西，烧毁您的房子，\n"
 
-#: src/amule.cpp:1571
+#: src/amule.cpp:1579
 msgid "or kill your dog. But it *should* be safe to use anyway.\n"
 msgstr "或杀死你的狗，但 * 一般来讲 * 它应该是安全的。\n"
 
-#: src/amule.cpp:1576
+#: src/amule.cpp:1584
 msgid "More information, support and new releases can found at our homepage,\n"
 msgstr "如要获取使用信息、用户支持以及下载最新版本，请访问我们的首页\n"
 
-#: src/amule.cpp:1577
+#: src/amule.cpp:1585
 msgid "at https://amule-org.github.io, or in our IRC channel #aMule at irc.libera.chat.\n"
 msgstr "https://amule-org.github.io，或进入我们在 irc.libera.chat 的 IRC 频道 #aMule。\n"
 
-#: src/amule.cpp:1579
+#: src/amule.cpp:1587
 msgid "Feel free to report any bugs to https://github.com/amule-org/amule/issues"
 msgstr "欢迎您到 https://github.com/amule-org/amule/issues 去提交错误报告"
 
-#: src/amule.cpp:1591
+#: src/amule.cpp:1599
 msgid ""
 "The folder for Online Signature files you specified is INVALID!\n"
 " OnlineSignature will be DISABLED until you fix it on preferences."
@@ -422,137 +422,137 @@ msgstr ""
 "您为在线统计文件所选择的文件夹无效！\n"
 "在您更正设置之前在线统计将被禁用。"
 
-#: src/amule.cpp:1654
+#: src/amule.cpp:1662
 msgid "Server hostname notified"
 msgstr "获取服务器名称"
 
-#: src/amule.cpp:2031
+#: src/amule.cpp:2039
 #, c-format
 msgid "Disk space preallocation for file '%s' failed: %s"
 msgstr "为文件 '%s' 预分配磁盘空间失败：%s"
 
-#: src/amule.cpp:2160
+#: src/amule.cpp:2168
 msgid "ERROR: can't open logfile"
 msgstr "错误：无法打开日志文件"
 
-#: src/amule.cpp:2164
+#: src/amule.cpp:2172
 msgid "WARNING: logfile is empty. Something is wrong."
 msgstr "警告：日志文件为空。肯定有什么地方出错了。"
 
-#: src/amule.cpp:2181
+#: src/amule.cpp:2189
 msgid "Log has been reset"
 msgstr "记录文件已被重置"
 
-#: src/amule.cpp:2205
+#: src/amule.cpp:2213
 #, c-format
 msgid "ServerMessage: %s"
 msgstr "服务器消息：%s"
 
-#: src/amule.cpp:2248 src/IP2Country.cpp:220 src/IPFilter.cpp:514
+#: src/amule.cpp:2256 src/IP2Country.cpp:220 src/IPFilter.cpp:514
 #: src/ServerList.cpp:875
 #, c-format
 msgid "Skipped download of %s, because requested file is not newer."
 msgstr "跳过下载%s，因为请求的文件不是最新的。"
 
-#: src/amule.cpp:2251
+#: src/amule.cpp:2259
 msgid "Failed to download the nodes list."
 msgstr "下载节点列表失败。"
 
-#: src/amule.cpp:2314
+#: src/amule.cpp:2322
 msgid "Failed to open the downloaded version check file"
 msgstr "打开已下载的版本检查文件失败"
 
-#: src/amule.cpp:2317 src/amule.cpp:2336
+#: src/amule.cpp:2325 src/amule.cpp:2344
 msgid "Corrupted version check file"
 msgstr "损坏的版本检查文件"
 
-#: src/amule.cpp:2359
+#: src/amule.cpp:2367
 msgid "You are using an outdated version of aMule!"
 msgstr "您使用的是老版本的aMule！"
 
-#: src/amule.cpp:2361
+#: src/amule.cpp:2369
 #, c-format
 msgid "Your aMule version is %i.%i.%i and the latest version is %li.%li.%li"
 msgstr "您的 aMule 版本是 %i.%i.%i，最新版本是 %li.%li.%li"
 
-#: src/amule.cpp:2365
+#: src/amule.cpp:2373
 msgid "The latest version can always be found at https://github.com/amule-org/amule/releases/latest"
 msgstr "最新版本可从这里下载：https://github.com/amule-org/amule/releases/latest"
 
-#: src/amule.cpp:2368
+#: src/amule.cpp:2376
 #, c-format
 msgid "WARNING: Your aMuled version is outdated: %i.%i.%i < %li.%li.%li"
 msgstr "警告：您的 aMuled 版本太旧：%i.%i.%i < %li.%li.%li"
 
-#: src/amule.cpp:2374
+#: src/amule.cpp:2382
 msgid "Your copy of aMule is up to date."
 msgstr "您的aMule是最新版本。"
 
-#: src/amule.cpp:2381
+#: src/amule.cpp:2389
 msgid "Failed to download the version check file"
 msgstr "下载版本检查文件失败"
 
-#: src/amule.cpp:2550 src/amule-remote-gui.cpp:1133
+#: src/amule.cpp:2558 src/amule-remote-gui.cpp:1133
 #, c-format
 msgid "Users: %s | Files: %s"
 msgstr "用户：%s | 文件：%s"
 
-#: src/amule.cpp:2551 src/amule-remote-gui.cpp:1134
+#: src/amule.cpp:2559 src/amule-remote-gui.cpp:1134
 #, c-format
 msgid "Users: E: %s K: %s | Files: E: %s K: %s"
 msgstr "用户：E：%s K：%s | 文件：E：%s K：%s"
 
-#: src/amule.cpp:2565 src/amule-remote-gui.cpp:1147
+#: src/amule.cpp:2573 src/amule-remote-gui.cpp:1147
 msgid "No networks selected"
 msgstr "没有选择网络"
 
-#: src/amule.cpp:2633 src/TextClient.cpp:903
+#: src/amule.cpp:2641 src/TextClient.cpp:903
 msgid "with LowID"
 msgstr "是 Low ID"
 
-#: src/amule.cpp:2633 src/TextClient.cpp:904
+#: src/amule.cpp:2641 src/TextClient.cpp:904
 msgid "with HighID"
 msgstr "是 High ID"
 
-#: src/amule.cpp:2635
+#: src/amule.cpp:2643
 #, c-format
 msgid "Connected to %s %s"
 msgstr "已连接到 %s %s"
 
-#: src/amule.cpp:2640
+#: src/amule.cpp:2648
 #, c-format
 msgid "Connecting to %s"
 msgstr "正在连接到 %s"
 
-#: src/amule.cpp:2642
+#: src/amule.cpp:2650
 msgid "Disconnected from eD2k"
 msgstr "已从 eD2k 断开"
 
-#: src/amule.cpp:2651
+#: src/amule.cpp:2659
 msgid "Kad started."
 msgstr "Kad 已启动。"
 
-#: src/amule.cpp:2653
+#: src/amule.cpp:2661
 msgid "Kad stopped."
 msgstr "Kad 已停止。"
 
-#: src/amule.cpp:2661
+#: src/amule.cpp:2669
 msgid "Connected to Kad (ok)"
 msgstr "已连接至 Kad (ok）"
 
-#: src/amule.cpp:2663
+#: src/amule.cpp:2671
 msgid "Connected to Kad (firewalled)"
 msgstr "已连接至 Kad 网络 (有防火墙)"
 
-#: src/amule.cpp:2667
+#: src/amule.cpp:2675
 msgid "Disconnected from Kad"
 msgstr "已断开 Kad 连接"
 
-#: src/amule.cpp:2699
+#: src/amule.cpp:2707
 msgid "Kad network cannot be used if UDP port is disabled on preferences, not starting."
 msgstr "如果在设置中禁用了 UDP 端口，Kad 网络将不能使用，没有启动。"
 
-#: src/amule.cpp:2703
+#: src/amule.cpp:2711
 msgid "Kad network disabled on preferences, not connecting."
 msgstr "Kad 网络在设置中被禁用了，没有连接。"
 
@@ -596,36 +596,36 @@ msgid "FATAL ERROR: Failed to create Timer"
 msgstr "致命错误：创建计时器失败"
 
 #: src/amuleDlg.cpp:361 src/amuleDlg.cpp:1787 src/amuleDlg.cpp:2033
-#: src/muuli_wdr.cpp:1492 src/muuli_wdr.cpp:3418
+#: src/muuli_wdr.cpp:1492 src/muuli_wdr.cpp:3449
 msgid "Networks"
 msgstr "网络"
 
-#: src/amuleDlg.cpp:362 src/amuleDlg.cpp:1793 src/muuli_wdr.cpp:3419
+#: src/amuleDlg.cpp:362 src/amuleDlg.cpp:1793 src/muuli_wdr.cpp:3450
 msgid "Searches"
 msgstr "搜索"
 
 #: src/amuleDlg.cpp:363 src/amuleDlg.cpp:1799 src/DownloadListCtrl.cpp:740
-#: src/muuli_wdr.cpp:392 src/muuli_wdr.cpp:1585 src/muuli_wdr.cpp:3420
+#: src/muuli_wdr.cpp:392 src/muuli_wdr.cpp:1585 src/muuli_wdr.cpp:3451
 #: src/Statistics.cpp:829
 msgid "Downloads"
 msgstr "下载"
 
-#: src/amuleDlg.cpp:364 src/amuleDlg.cpp:1805 src/muuli_wdr.cpp:3294
+#: src/amuleDlg.cpp:364 src/amuleDlg.cpp:1805 src/muuli_wdr.cpp:3325
 msgid "Shared files"
 msgstr "共享文件"
 
-#: src/amuleDlg.cpp:365 src/amuleDlg.cpp:1811 src/muuli_wdr.cpp:2926
-#: src/muuli_wdr.cpp:3376 src/muuli_wdr.cpp:3423
+#: src/amuleDlg.cpp:365 src/amuleDlg.cpp:1811 src/muuli_wdr.cpp:2957
+#: src/muuli_wdr.cpp:3407 src/muuli_wdr.cpp:3454
 msgid "Messages"
 msgstr "消息"
 
-#: src/amuleDlg.cpp:366 src/amuleDlg.cpp:1817 src/muuli_wdr.cpp:3424
-#: src/PrefsUnifiedDlg.cpp:312 src/Statistics.cpp:779 src/Statistics.cpp:1235
+#: src/amuleDlg.cpp:366 src/amuleDlg.cpp:1817 src/muuli_wdr.cpp:3455
+#: src/PrefsUnifiedDlg.cpp:314 src/Statistics.cpp:779 src/Statistics.cpp:1235
 msgid "Statistics"
 msgstr "统计"
 
-#: src/amuleDlg.cpp:368 src/amuleDlg.cpp:1824 src/muuli_wdr.cpp:3426
-#: src/PrefsUnifiedDlg.cpp:328 src/utils/wxCas/src/wxcasprefs.cpp:39
+#: src/amuleDlg.cpp:368 src/amuleDlg.cpp:1824 src/muuli_wdr.cpp:3457
+#: src/PrefsUnifiedDlg.cpp:330 src/utils/wxCas/src/wxcasprefs.cpp:39
 msgid "Preferences"
 msgstr "设置"
 
@@ -687,8 +687,8 @@ msgstr "Kad: 关闭"
 #: src/amuleDlg.cpp:1029 src/DownloadListCtrl.cpp:505
 #: src/DownloadListCtrl.cpp:749 src/FriendListCtrl.cpp:180
 #: src/muuli_wdr.cpp:731 src/muuli_wdr.cpp:782 src/muuli_wdr.cpp:846
-#: src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2231 src/muuli_wdr.cpp:2316
-#: src/muuli_wdr.cpp:3064 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
+#: src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2262 src/muuli_wdr.cpp:2347
+#: src/muuli_wdr.cpp:3095 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
 #: src/ServerListCtrl.cpp:606 src/TransferWnd.cpp:378
 #: src/utils/wxCas/src/wxcasprefs.cpp:235
 msgid "Cancel"
@@ -699,7 +699,7 @@ msgid "Stop the current connection attempts"
 msgstr "终止本次连接尝试"
 
 #: src/amuleDlg.cpp:1035 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976
-#: src/muuli_wdr.cpp:2454
+#: src/muuli_wdr.cpp:2485
 msgid "Disconnect"
 msgstr "断开连接"
 
@@ -708,7 +708,7 @@ msgid "Disconnect from the currently connected networks"
 msgstr "从当前已连接的网络断开"
 
 #: src/amuleDlg.cpp:1041 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979
-#: src/muuli_wdr.cpp:2609 src/muuli_wdr.cpp:3061 src/muuli_wdr.cpp:3416
+#: src/muuli_wdr.cpp:2640 src/muuli_wdr.cpp:3092 src/muuli_wdr.cpp:3447
 msgid "Connect"
 msgstr "连接"
 
@@ -762,7 +762,7 @@ msgstr "退出确认"
 msgid "Launch Command: "
 msgstr "运行命令: "
 
-#: src/amuleDlg.cpp:1632 src/muuli_wdr.cpp:1978 src/Preferences.cpp:952
+#: src/amuleDlg.cpp:1632 src/muuli_wdr.cpp:1982 src/Preferences.cpp:979
 msgid "- default -"
 msgstr "- 默认 -"
 
@@ -776,48 +776,48 @@ msgstr "皮肤目录 %s 不存在"
 msgid "WARNING: Unable to open skin file '%s' for read"
 msgstr "警告：无法打开皮肤文件 %s 进行读取"
 
-#: src/amuleDlg.cpp:1791 src/muuli_wdr.cpp:3418
+#: src/amuleDlg.cpp:1791 src/muuli_wdr.cpp:3449
 msgid "Networks Window"
 msgstr "网络窗口"
 
-#: src/amuleDlg.cpp:1797 src/muuli_wdr.cpp:3419
+#: src/amuleDlg.cpp:1797 src/muuli_wdr.cpp:3450
 msgid "Searches Window"
 msgstr "搜索窗口"
 
-#: src/amuleDlg.cpp:1803 src/muuli_wdr.cpp:3420
+#: src/amuleDlg.cpp:1803 src/muuli_wdr.cpp:3451
 msgid "Downloads Window"
 msgstr "下载窗口"
 
-#: src/amuleDlg.cpp:1809 src/muuli_wdr.cpp:3422
+#: src/amuleDlg.cpp:1809 src/muuli_wdr.cpp:3453
 msgid "Shared Files Window"
 msgstr "共享文件窗口"
 
-#: src/amuleDlg.cpp:1815 src/muuli_wdr.cpp:3423
+#: src/amuleDlg.cpp:1815 src/muuli_wdr.cpp:3454
 msgid "Messages Window"
 msgstr "消息窗口"
 
-#: src/amuleDlg.cpp:1821 src/muuli_wdr.cpp:3424
+#: src/amuleDlg.cpp:1821 src/muuli_wdr.cpp:3455
 msgid "Statistics Graph Window"
 msgstr "统计图窗口"
 
-#: src/amuleDlg.cpp:1828 src/muuli_wdr.cpp:3426
+#: src/amuleDlg.cpp:1828 src/muuli_wdr.cpp:3457
 msgid "Preferences Settings Window"
 msgstr "设置窗口"
 
-#: src/amuleDlg.cpp:1831 src/muuli_wdr.cpp:3427
+#: src/amuleDlg.cpp:1831 src/muuli_wdr.cpp:3458
 msgid "Import"
 msgstr "导入"
 
-#: src/amuleDlg.cpp:1835 src/muuli_wdr.cpp:3427
+#: src/amuleDlg.cpp:1835 src/muuli_wdr.cpp:3458
 msgid "The partfile importer tool"
 msgstr "part 文件导入工具"
 
-#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3428
+#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3459
 #: src/utils/aLinkCreator/src/alcframe.cpp:262
 msgid "About"
 msgstr "关于"
 
-#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3428
+#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3459
 msgid "About/Help"
 msgstr "关于/帮助"
 
@@ -960,7 +960,7 @@ msgstr "未找到"
 msgid "The core rejected these shared folders:%s"
 msgstr "核心拒绝了这些共享的文件夹：%s"
 
-#: src/amule-remote-gui.cpp:1336 src/ExternalConn.cpp:2345
+#: src/amule-remote-gui.cpp:1336 src/ExternalConn.cpp:2346
 msgid "Invalid link or already on list."
 msgstr "非法链接或已经存在列表中。"
 
@@ -976,7 +976,7 @@ msgstr "无法创建 “%s” 目录用于 “%s” 分类，保留 “%s” 目
 #: src/ClientDetailDialog.cpp:123 src/DataToText.cpp:61 src/DataToText.cpp:86
 #: src/DataToText.cpp:101 src/DataToText.cpp:136 src/DataToText.cpp:165
 #: src/DownloadListCtrl.cpp:1172 src/DownloadListCtrl.cpp:1185
-#: src/DownloadListCtrl.cpp:1196 src/ExternalConn.cpp:608
+#: src/DownloadListCtrl.cpp:1196 src/ExternalConn.cpp:609
 #: src/FileDetailDialog.cpp:203 src/FileDetailDialog.cpp:235
 #: src/FileDetailDialog.cpp:242 src/GenericClientListCtrl.cpp:1171
 #: src/GenericClientListCtrl.cpp:1182 src/GenericClientListCtrl.cpp:1192
@@ -1362,19 +1362,19 @@ msgstr "自动 [高]"
 msgid "Very low"
 msgstr "极低"
 
-#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:743 src/muuli_wdr.cpp:2282
+#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:743 src/muuli_wdr.cpp:2313
 #: src/ServerListCtrl.cpp:263 src/ServerListCtrl.cpp:456
 #: src/SharedFilesCtrl.cpp:145
 msgid "Low"
 msgstr "低"
 
-#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:744 src/muuli_wdr.cpp:2283
+#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:744 src/muuli_wdr.cpp:2314
 #: src/ServerListCtrl.cpp:266 src/ServerListCtrl.cpp:457
 #: src/SharedFilesCtrl.cpp:146
 msgid "Normal"
 msgstr "普通"
 
-#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:745 src/muuli_wdr.cpp:2284
+#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:745 src/muuli_wdr.cpp:2315
 #: src/ServerListCtrl.cpp:269 src/ServerListCtrl.cpp:458
 #: src/SharedFilesCtrl.cpp:147
 msgid "High"
@@ -1466,7 +1466,7 @@ msgstr "本地服务器"
 msgid "Remote Server"
 msgstr "远程服务器"
 
-#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3181
+#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3212
 #: src/SearchDlg.cpp:119 src/TextClient.cpp:911
 msgid "Kad"
 msgstr "Kad"
@@ -1537,7 +1537,7 @@ msgstr "块"
 msgid "Size"
 msgstr "大小"
 
-#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3248
+#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3279
 msgid "Transferred"
 msgstr "已传输"
 
@@ -1595,7 +1595,7 @@ msgstr ""
 "报告来自: %s (%s)\n"
 "\n"
 
-#: src/DownloadListCtrl.cpp:746 src/muuli_wdr.cpp:2285
+#: src/DownloadListCtrl.cpp:746 src/muuli_wdr.cpp:2316
 #: src/SharedFilesCtrl.cpp:150
 msgid "Auto"
 msgstr "自动"
@@ -1633,7 +1633,7 @@ msgid "Extended Options"
 msgstr "扩展选项"
 
 #: src/DownloadListCtrl.cpp:770 src/DownloadListCtrl.cpp:822
-#: src/muuli_wdr.cpp:1796
+#: src/muuli_wdr.cpp:1800
 msgid "Preview"
 msgstr "预览"
 
@@ -1808,225 +1808,230 @@ msgstr[1] "无法添加 %u 个链接（详情请查看日志）"
 msgid "Invalid eD2k link! ERROR: %s"
 msgstr "非法 eD2k 链接！错误: %s"
 
-#: src/ExternalConn.cpp:379
+#: src/ExternalConn.cpp:380
 msgid "Client sent packet after authentication failed."
 msgstr "客户端在验证失败后发送包。"
 
-#: src/ExternalConn.cpp:396
+#: src/ExternalConn.cpp:397
 msgid "External connection closed."
 msgstr "已关闭远程连接。"
 
-#: src/ExternalConn.cpp:473
+#: src/ExternalConn.cpp:474
 msgid "External connections disabled due to empty password!"
 msgstr "密码未设置，已禁止远程连接！"
 
-#: src/ExternalConn.cpp:494
+#: src/ExternalConn.cpp:495
 msgid "External connections disabled in config file"
 msgstr "配置文件中已禁止远程连接"
 
-#: src/ExternalConn.cpp:575
+#: src/ExternalConn.cpp:576
 msgid "New external connection accepted"
 msgstr "新的远程连接已被接受"
 
-#: src/ExternalConn.cpp:578
+#: src/ExternalConn.cpp:579
 msgid "ERROR: couldn't accept a new external connection"
 msgstr "错误：不能接受新的远程连接"
 
-#: src/ExternalConn.cpp:595
+#: src/ExternalConn.cpp:596
 msgid "External connection refused due to empty password in preferences!"
 msgstr "由于未设置密码，远程连接已被拒绝！"
 
-#: src/ExternalConn.cpp:607
+#: src/ExternalConn.cpp:608
 #, c-format
 msgid "Connecting client: %s %s"
 msgstr "正在连接客户端：%s %s"
 
-#: src/ExternalConn.cpp:609
+#: src/ExternalConn.cpp:610
 msgid "Unknown version"
 msgstr "未知版本"
 
-#: src/ExternalConn.cpp:622
+#: src/ExternalConn.cpp:623
 msgid "Incorrect EC version ID, there might be binary incompatibility. Use core and remote from same snapshot."
 msgstr "错误的远程连接版本号，可能会不兼容，请使用相同版本的核心和远程程序。"
 
-#: src/ExternalConn.cpp:630
+#: src/ExternalConn.cpp:631
 msgid "You cannot connect to a release version from an arbitrary development snapshot! *sigh* possible crash prevented"
 msgstr "您无法从任意开发快照连接到发布版本！*sigh* 防止可能发生的崩溃"
 
-#: src/ExternalConn.cpp:713
+#: src/ExternalConn.cpp:714
 msgid "Invalid protocol version."
 msgstr "非法协议版本。"
 
-#: src/ExternalConn.cpp:719
+#: src/ExternalConn.cpp:720
 msgid "Missing protocol version tag."
 msgstr "缺失协议版本标签。"
 
-#: src/ExternalConn.cpp:727
+#: src/ExternalConn.cpp:728
 msgid "Authentication failed: invalid hash specified as EC password."
 msgstr "身份验证失败: 指定为 EC 密码的 MD5 哈希值无效。"
 
-#: src/ExternalConn.cpp:775
+#: src/ExternalConn.cpp:776
 msgid "Authentication failed: wrong password."
 msgstr "验证失败：密码错误。"
 
-#: src/ExternalConn.cpp:777
+#: src/ExternalConn.cpp:778
 msgid "Authentication failed: missing password."
 msgstr "认证失败: 没有密码。"
 
-#: src/ExternalConn.cpp:788
+#: src/ExternalConn.cpp:789
 msgid "Invalid request, please authenticate first."
 msgstr "无效请求，请先验证。"
 
-#: src/ExternalConn.cpp:793
+#: src/ExternalConn.cpp:794
 msgid "Access granted."
 msgstr "登录成功。"
 
-#: src/ExternalConn.cpp:801
+#: src/ExternalConn.cpp:802
 #, c-format
 msgid "Sent error message \"%s\" to client."
 msgstr "发送错误消息喔 \"%s\"到客户端。"
 
-#: src/ExternalConn.cpp:806
+#: src/ExternalConn.cpp:807
 #, c-format
 msgid "Unauthorized access attempt from %s. Connection closed."
 msgstr "来自%s的非法登录尝试，已关闭连接。"
 
-#: src/ExternalConn.cpp:1419
+#: src/ExternalConn.cpp:1420
 #, c-format
 msgid "Remote PartFile command failed: FileHash not found: %s"
 msgstr "远程 Part 文件命令失败：文件校验码不存在：%s"
 
-#: src/ExternalConn.cpp:1423
+#: src/ExternalConn.cpp:1424
 #, c-format
 msgid "FileHash not found: %s"
 msgstr "文件校验码不存在：%s"
 
-#: src/ExternalConn.cpp:1470 src/ExternalConn.cpp:1558
-#: src/ExternalConn.cpp:1679
+#: src/ExternalConn.cpp:1471 src/ExternalConn.cpp:1559
+#: src/ExternalConn.cpp:1680
 msgid "OOPS! OpCode processing error!"
 msgstr "OpCode 处理错误！"
 
-#: src/ExternalConn.cpp:1501
+#: src/ExternalConn.cpp:1502
 msgid "Server not added"
 msgstr "服务器没有被添加"
 
-#: src/ExternalConn.cpp:1520
+#: src/ExternalConn.cpp:1521
 #, c-format
 msgid "server not found: %s"
 msgstr "找不到服务器：%s"
 
-#: src/ExternalConn.cpp:1537
+#: src/ExternalConn.cpp:1538
 msgid "need to define server to be removed"
 msgstr "必须定义需删除的服务器"
 
-#: src/ExternalConn.cpp:1552
+#: src/ExternalConn.cpp:1553
 msgid "eD2k is disabled in preferences."
 msgstr "eD2k 在设置中已禁用。"
 
-#: src/ExternalConn.cpp:1657
+#: src/ExternalConn.cpp:1658
 msgid "Friend not found."
 msgstr "未找到好友。"
 
-#: src/ExternalConn.cpp:1667
+#: src/ExternalConn.cpp:1668
 msgid "Client not found."
 msgstr "未找到客户端。"
 
-#: src/ExternalConn.cpp:1673
+#: src/ExternalConn.cpp:1674
 msgid "EC_TAG_FRIEND_SHARED requires EC_TAG_FRIEND or EC_TAG_CLIENT."
 msgstr "EC_TAG_FRIEND_SHARED 需要 EC_TAG_FRIEND 或 EC_TAG_CLIENT。"
 
-#: src/ExternalConn.cpp:1991
+#: src/ExternalConn.cpp:1992
 msgid "WebSearch from remote interface makes no sense."
 msgstr "远程界面使用网络搜索没有意义。"
 
-#: src/ExternalConn.cpp:2026
+#: src/ExternalConn.cpp:2027
 msgid "Search in progress. Refetch results in a moment!"
 msgstr "正在搜索，请稍等然后重新获取结果！"
 
-#: src/ExternalConn.cpp:2265
+#: src/ExternalConn.cpp:2266
 msgid "No points for graph."
 msgstr "此图没有节点。"
 
-#: src/ExternalConn.cpp:2275
+#: src/ExternalConn.cpp:2276
 msgid "Your client is not configured for this detail level."
 msgstr "您的客户端没有为详细级别进行配置。"
 
-#: src/ExternalConn.cpp:2302
+#: src/ExternalConn.cpp:2303
 msgid "External Connection: shutdown requested"
 msgstr "远程连接：已请求关闭"
 
-#: src/ExternalConn.cpp:2314
+#: src/ExternalConn.cpp:2315
 msgid "Already shutting down."
 msgstr "已经在关闭。"
 
-#: src/ExternalConn.cpp:2332
+#: src/ExternalConn.cpp:2333
 #, c-format
 msgid "ExternalConn: adding link '%s'."
 msgstr "远程连接：正在添加链接 '%s'。"
 
-#: src/ExternalConn.cpp:2350
+#: src/ExternalConn.cpp:2351
 #, c-format
 msgid "%d of %d links failed (invalid or already on list)."
 msgstr "%d 个链接失败，共 %d 个（无效或已经在列表中）。"
 
-#: src/ExternalConn.cpp:2373
+#: src/ExternalConn.cpp:2374
 msgid "Version check throttled; try again shortly."
 msgstr "版本检查受限；请稍后再试。"
 
-#: src/ExternalConn.cpp:2378
+#: src/ExternalConn.cpp:2379
 msgid "Version check is not available on this daemon."
 msgstr "版本检查在此 daemon 上不可用。"
 
-#: src/ExternalConn.cpp:2508
+#: src/ExternalConn.cpp:2509
 msgid "File not found."
 msgstr "文件未找到。"
 
-#: src/ExternalConn.cpp:2513
+#: src/ExternalConn.cpp:2514
 msgid "Invalid file name."
 msgstr "无效的文件名。"
 
-#: src/ExternalConn.cpp:2521
+#: src/ExternalConn.cpp:2522
 msgid "Unable to rename file."
 msgstr "无法重命名文件。"
 
-#: src/ExternalConn.cpp:2992 src/ExternalConn.cpp:3020
+#: src/ExternalConn.cpp:2839
+#, c-format
+msgid "Could not save the amuleapi password: %s"
+msgstr ""
+
+#: src/ExternalConn.cpp:3004 src/ExternalConn.cpp:3032
 msgid "Kad is disabled in preferences."
 msgstr "Kad 在设置中被禁用。"
 
-#: src/ExternalConn.cpp:3033
+#: src/ExternalConn.cpp:3045
 msgid "Already connected to eD2k."
 msgstr "已经连接至 eD2k。"
 
-#: src/ExternalConn.cpp:3036
+#: src/ExternalConn.cpp:3048
 msgid "Connecting to eD2k..."
 msgstr "正在连接至 eD2k..."
 
-#: src/ExternalConn.cpp:3045
+#: src/ExternalConn.cpp:3057
 msgid "Already connected to Kad."
 msgstr "已连接至 Kad。"
 
-#: src/ExternalConn.cpp:3048
+#: src/ExternalConn.cpp:3060
 msgid "Connecting to Kad..."
 msgstr "正在连接至 Kad..."
 
-#: src/ExternalConn.cpp:3055
+#: src/ExternalConn.cpp:3067
 msgid "All networks are disabled."
 msgstr "全部网络都被禁用了。"
 
-#: src/ExternalConn.cpp:3064
+#: src/ExternalConn.cpp:3076
 msgid "Disconnected from eD2k."
 msgstr "已从 eD2k 断开连接。"
 
-#: src/ExternalConn.cpp:3069
+#: src/ExternalConn.cpp:3081
 msgid "Disconnected from Kad."
 msgstr "已从 Kad 断开连接。"
 
-#: src/ExternalConn.cpp:3078
+#: src/ExternalConn.cpp:3090
 #, c-format
 msgid "External Connection: invalid opcode received: %#x"
 msgstr "远程连接：非法 opcode：%#x"
 
-#: src/ExternalConn.cpp:3083
+#: src/ExternalConn.cpp:3095
 msgid "Invalid opcode (wrong protocol version?)"
 msgstr "非法的 opcode（错误的协议版本？)"
 
@@ -2427,23 +2432,23 @@ msgid ""
 "want downloads on a different (e.g. larger) disk."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:549 src/FirstRunWizard.cpp:611 src/muuli_wdr.cpp:1708
+#: src/FirstRunWizard.cpp:549 src/FirstRunWizard.cpp:611 src/muuli_wdr.cpp:1712
 msgid "Destination folder for downloads"
 msgstr "存放下载文件的文件夹"
 
 #: src/FirstRunWizard.cpp:553 src/FirstRunWizard.cpp:569 src/muuli_wdr.cpp:1349
-#: src/muuli_wdr.cpp:1366 src/muuli_wdr.cpp:1683 src/muuli_wdr.cpp:1714
-#: src/muuli_wdr.cpp:1726 src/muuli_wdr.cpp:2769
+#: src/muuli_wdr.cpp:1366 src/muuli_wdr.cpp:1687 src/muuli_wdr.cpp:1718
+#: src/muuli_wdr.cpp:1730 src/muuli_wdr.cpp:2800
 #: src/utils/aLinkCreator/src/alcframe.cpp:135
 #: src/utils/wxCas/src/wxcasprefs.cpp:52 src/utils/wxCas/src/wxcasprefs.cpp:118
 msgid "Browse"
 msgstr "浏览"
 
-#: src/FirstRunWizard.cpp:559 src/muuli_wdr.cpp:1719
+#: src/FirstRunWizard.cpp:559 src/muuli_wdr.cpp:1723
 msgid "(All files in this folder are shared with other peers)"
 msgstr "（此文件夹中的所有文件均与其他对等方共享）"
 
-#: src/FirstRunWizard.cpp:565 src/FirstRunWizard.cpp:624 src/muuli_wdr.cpp:1721
+#: src/FirstRunWizard.cpp:565 src/FirstRunWizard.cpp:624 src/muuli_wdr.cpp:1725
 msgid "Folder for temporary download files"
 msgstr "存放临时下载文件的文件夹"
 
@@ -2474,7 +2479,7 @@ msgstr "写好友列表文件emfriends.met失败！"
 msgid "CRITICAL - no client on StartChatSession"
 msgstr "严重错误 - 开始聊天进程没有客户端"
 
-#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2675 src/muuli_wdr.cpp:3352
+#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2706 src/muuli_wdr.cpp:3383
 msgid "Friends"
 msgstr "好友"
 
@@ -2584,8 +2589,8 @@ msgstr "没有"
 msgid "No"
 msgstr "否"
 
-#: src/GenericClientListCtrl.cpp:1216 src/PrefsUnifiedDlg.cpp:2818
-#: src/PrefsUnifiedDlg.cpp:2868 src/ServerListCtrl.cpp:276
+#: src/GenericClientListCtrl.cpp:1216 src/PrefsUnifiedDlg.cpp:2898
+#: src/PrefsUnifiedDlg.cpp:2948 src/ServerListCtrl.cpp:276
 msgid "Yes"
 msgstr "是"
 
@@ -2752,10 +2757,10 @@ msgstr "无效端口"
 msgid "Please fill all fields required"
 msgstr "请填写所有必要信息"
 
-#: src/KadDlg.cpp:192 src/PartFile.cpp:1031 src/PrefsUnifiedDlg.cpp:1162
-#: src/PrefsUnifiedDlg.cpp:1331 src/PrefsUnifiedDlg.cpp:1589
-#: src/PrefsUnifiedDlg.cpp:1599 src/PrefsUnifiedDlg.cpp:1616
-#: src/PrefsUnifiedDlg.cpp:1658
+#: src/KadDlg.cpp:192 src/PartFile.cpp:1031 src/PrefsUnifiedDlg.cpp:1134
+#: src/PrefsUnifiedDlg.cpp:1204 src/PrefsUnifiedDlg.cpp:1405
+#: src/PrefsUnifiedDlg.cpp:1663 src/PrefsUnifiedDlg.cpp:1673
+#: src/PrefsUnifiedDlg.cpp:1690 src/PrefsUnifiedDlg.cpp:1738
 msgid "Message"
 msgstr "消息"
 
@@ -2856,7 +2861,7 @@ msgstr "共享率"
 msgid "Uploaded"
 msgstr "已上传"
 
-#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3232
+#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3263
 msgid "Requested"
 msgstr "已请求"
 
@@ -2979,7 +2984,7 @@ msgid "WARNING: "
 msgstr "警告: "
 
 #: src/MuleNotebook.cpp:179 src/muuli_wdr.cpp:817 src/muuli_wdr.cpp:1229
-#: src/muuli_wdr.cpp:3136 src/muuli_wdr.cpp:3392
+#: src/muuli_wdr.cpp:3167 src/muuli_wdr.cpp:3423
 msgid "Close"
 msgstr "关闭"
 
@@ -2997,7 +3002,7 @@ msgid "Paste"
 msgstr "粘贴"
 
 #: src/MuleTextCtrl.cpp:89 src/muuli_wdr.cpp:358 src/muuli_wdr.cpp:757
-#: src/muuli_wdr.cpp:2359 src/muuli_wdr.cpp:2378 src/muuli_wdr.cpp:2400
+#: src/muuli_wdr.cpp:2390 src/muuli_wdr.cpp:2409 src/muuli_wdr.cpp:2431
 #: src/utils/aLinkCreator/src/alcframe.cpp:142
 msgid "Clear"
 msgstr "清除"
@@ -3089,7 +3094,7 @@ msgstr "退出"
 
 #: src/MuleTrayIcon.cpp:579 src/MuleTrayIcon.cpp:945 src/MuleTrayIcon.cpp:965
 #: src/muuli_wdr.cpp:1398 src/muuli_wdr.cpp:1406 src/muuli_wdr.cpp:1413
-#: src/muuli_wdr.cpp:1842 src/muuli_wdr.cpp:1848 src/OtherFunctions.cpp:91
+#: src/muuli_wdr.cpp:1846 src/muuli_wdr.cpp:1852 src/OtherFunctions.cpp:91
 #: src/StatisticsDlg.cpp:93 src/StatisticsDlg.cpp:95
 msgid "kB/s"
 msgstr "KB/s"
@@ -3329,7 +3334,7 @@ msgstr "字节"
 msgid "KB"
 msgstr "KB"
 
-#: src/muuli_wdr.cpp:274 src/muuli_wdr.cpp:293 src/muuli_wdr.cpp:1627
+#: src/muuli_wdr.cpp:274 src/muuli_wdr.cpp:293 src/muuli_wdr.cpp:1631
 #: src/OtherFunctions.cpp:64
 msgid "MB"
 msgstr "MB"
@@ -3346,7 +3351,7 @@ msgstr "大小上限"
 msgid "Availability"
 msgstr "可用来源数"
 
-#: src/muuli_wdr.cpp:312 src/muuli_wdr.cpp:398 src/muuli_wdr.cpp:3297
+#: src/muuli_wdr.cpp:312 src/muuli_wdr.cpp:398 src/muuli_wdr.cpp:3328
 msgid "Filter:"
 msgstr "过滤："
 
@@ -3409,12 +3414,12 @@ msgstr "文件源:"
 #: src/muuli_wdr.cpp:1160 src/muuli_wdr.cpp:1167 src/muuli_wdr.cpp:1172
 #: src/muuli_wdr.cpp:1179 src/muuli_wdr.cpp:1184 src/muuli_wdr.cpp:1191
 #: src/muuli_wdr.cpp:1205 src/muuli_wdr.cpp:1212 src/muuli_wdr.cpp:1217
-#: src/muuli_wdr.cpp:1224 src/muuli_wdr.cpp:3234 src/muuli_wdr.cpp:3242
-#: src/muuli_wdr.cpp:3250
+#: src/muuli_wdr.cpp:1224 src/muuli_wdr.cpp:3265 src/muuli_wdr.cpp:3273
+#: src/muuli_wdr.cpp:3281
 msgid "N/A"
 msgstr "N/A"
 
-#: src/muuli_wdr.cpp:508 src/muuli_wdr.cpp:1065 src/PrefsUnifiedDlg.cpp:297
+#: src/muuli_wdr.cpp:508 src/muuli_wdr.cpp:1065 src/PrefsUnifiedDlg.cpp:299
 msgid "General"
 msgstr "常规"
 
@@ -3550,7 +3555,7 @@ msgstr "艺术家："
 msgid "Album :"
 msgstr "专辑："
 
-#: src/muuli_wdr.cpp:685 src/muuli_wdr.cpp:2254
+#: src/muuli_wdr.cpp:685 src/muuli_wdr.cpp:2285
 msgid "Title :"
 msgstr "标题 :"
 
@@ -3658,7 +3663,7 @@ msgstr "用户名 :"
 msgid "Userhash :"
 msgstr "用户哈希 :"
 
-#: src/muuli_wdr.cpp:895 src/muuli_wdr.cpp:1748 src/muuli_wdr.cpp:2449
+#: src/muuli_wdr.cpp:895 src/muuli_wdr.cpp:1752 src/muuli_wdr.cpp:2480
 #: src/utils/aLinkCreator/src/alcframe.cpp:137
 msgid "Add"
 msgstr "添加"
@@ -3667,15 +3672,15 @@ msgstr "添加"
 msgid "Download-Speed"
 msgstr "下载速度"
 
-#: src/muuli_wdr.cpp:954 src/muuli_wdr.cpp:989 src/muuli_wdr.cpp:2553
+#: src/muuli_wdr.cpp:954 src/muuli_wdr.cpp:989 src/muuli_wdr.cpp:2584
 msgid "Current"
 msgstr "当前"
 
-#: src/muuli_wdr.cpp:962 src/muuli_wdr.cpp:997 src/muuli_wdr.cpp:2561
+#: src/muuli_wdr.cpp:962 src/muuli_wdr.cpp:997 src/muuli_wdr.cpp:2592
 msgid "Running average"
 msgstr "动态平均值"
 
-#: src/muuli_wdr.cpp:970 src/muuli_wdr.cpp:1005 src/muuli_wdr.cpp:2569
+#: src/muuli_wdr.cpp:970 src/muuli_wdr.cpp:1005 src/muuli_wdr.cpp:2600
 msgid "Session average"
 msgstr "本次运行平均值"
 
@@ -3687,7 +3692,7 @@ msgstr "上传速度"
 msgid "Connections"
 msgstr "连接"
 
-#: src/muuli_wdr.cpp:1024 src/muuli_wdr.cpp:1867
+#: src/muuli_wdr.cpp:1024 src/muuli_wdr.cpp:1871
 msgid "Active downloads"
 msgstr "活跃下载"
 
@@ -3695,7 +3700,7 @@ msgstr "活跃下载"
 msgid "Active connections (1:1)"
 msgstr "活跃连接 (1:1)"
 
-#: src/muuli_wdr.cpp:1040 src/muuli_wdr.cpp:1868
+#: src/muuli_wdr.cpp:1040 src/muuli_wdr.cpp:1872
 msgid "Active uploads"
 msgstr "活跃上传"
 
@@ -3969,7 +3974,7 @@ msgstr "为本地地址绑定 IP (全部绑定则留空):"
 msgid "Advanced users only: If you have multiple network interfaces, enter the address of the interface to which aMule should be bound."
 msgstr "只限高级用户：如果您有多个网络接口，请输入 aMule 将要绑定接口的地址。"
 
-#: src/muuli_wdr.cpp:1462 src/muuli_wdr.cpp:2061
+#: src/muuli_wdr.cpp:1462 src/muuli_wdr.cpp:2065
 msgid "Bind to network interface (empty for any):"
 msgstr "绑定网络接口（留空绑定全部）："
 
@@ -3985,7 +3990,7 @@ msgstr "每个下载文件的最大的源数量:"
 msgid "Max simultaneous connections:"
 msgstr "最大同时连接数:"
 
-#: src/muuli_wdr.cpp:1498 src/muuli_wdr.cpp:3176
+#: src/muuli_wdr.cpp:1498 src/muuli_wdr.cpp:3207
 msgid "ED2K"
 msgstr "ED2K"
 
@@ -4077,79 +4082,79 @@ msgstr "为新文件预分配磁盘空间"
 msgid "For new files preallocates disk space for the whole file, thus reduces fragmentation"
 msgstr "为新文件分配全部所需的磁盘空间，这样可以减少碎片"
 
-#: src/muuli_wdr.cpp:1613
+#: src/muuli_wdr.cpp:1617
 msgid "Create new files as sparse files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1614
-msgid "A sparse file reserves its full size on disk immediately without writing real data to it -- fast, but unsupported or slow on some filesystems, and free-space accounting stays optimistic while the download is in progress. Turn this off to grow the file only as data arrives."
+#: src/muuli_wdr.cpp:1618
+msgid "Sparse part files only occupy disk space for the parts already downloaded, so free space is used up gradually as the file fills in. Turn this off to use an ordinary file instead - useful where sparse files are unsupported or slow, or where backup/de-duplication tools handle them badly. Applies only when the core runs on Windows; on Linux and macOS part files are sparse anyway and this setting has no effect."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1619
+#: src/muuli_wdr.cpp:1623
 msgid "Stop downloads when free disk space reaches "
 msgstr "停止下载当可用磁盘空间只有"
 
-#: src/muuli_wdr.cpp:1620
+#: src/muuli_wdr.cpp:1624
 msgid "Select this if you want aMule to check your disk space"
 msgstr "要求检查磁盘空间"
 
-#: src/muuli_wdr.cpp:1624
+#: src/muuli_wdr.cpp:1628
 msgid "Enter here the min disk space desired."
 msgstr "请输入最低硬盘空间。"
 
-#: src/muuli_wdr.cpp:1630
+#: src/muuli_wdr.cpp:1634
 msgid "Save 10 sources on rare files (< 20 sources)"
 msgstr "保存稀有文件（少于20个源）的10个源"
 
-#: src/muuli_wdr.cpp:1634 src/Statistics.cpp:790
+#: src/muuli_wdr.cpp:1638 src/Statistics.cpp:790
 msgid "Uploads"
 msgstr "上传"
 
-#: src/muuli_wdr.cpp:1637
+#: src/muuli_wdr.cpp:1641
 msgid "Add new shared files with auto priority"
 msgstr "添加新共享文件时设优先级为自动"
 
-#: src/muuli_wdr.cpp:1643
+#: src/muuli_wdr.cpp:1647
 msgid "Intelligent Corruption Handling (I.C.H.)"
 msgstr "智能损坏数据处理 (I.C.H.)"
 
-#: src/muuli_wdr.cpp:1646
+#: src/muuli_wdr.cpp:1650
 msgid "Enable"
 msgstr "启用"
 
-#: src/muuli_wdr.cpp:1649
+#: src/muuli_wdr.cpp:1653
 msgid "Advanced I.C.H. trusts every hash (not recommended)"
 msgstr "高级 I.C.H. 信任全部哈希值 (不推荐)"
 
-#: src/muuli_wdr.cpp:1661 src/PrefsUnifiedDlg.cpp:1910
+#: src/muuli_wdr.cpp:1665 src/PrefsUnifiedDlg.cpp:1990
 msgid "Media metadata extraction"
 msgstr "媒体元数据提取"
 
-#: src/muuli_wdr.cpp:1665
+#: src/muuli_wdr.cpp:1669
 msgid "Extract length / bitrate / codec from shared audio and video files"
 msgstr "从共享的音视频文件提取长度/比特率/编解码器信息"
 
-#: src/muuli_wdr.cpp:1667
+#: src/muuli_wdr.cpp:1671
 msgid "When enabled, aMule runs ffprobe on each shared media file to fill in the Length / Bitrate / Codec columns other clients see when they find the file in a search. Requires ffmpeg (the ffprobe binary) to be installed."
 msgstr "启用此功能后，aMule 会对每个共享媒体文件运行 ffprobe 填充其他客户端在搜索到该文件时看到的“长度”、“比特率”和“编解码器”列。需要安装 ffmpeg（ffprobe 二进制文件）。"
 
-#: src/muuli_wdr.cpp:1674
+#: src/muuli_wdr.cpp:1678
 msgid "Path to ffprobe:"
 msgstr "ffprobe 路径："
 
-#: src/muuli_wdr.cpp:1679
+#: src/muuli_wdr.cpp:1683
 msgid "Full path to the ffprobe binary. Leave empty to have aMule auto-detect it on startup."
 msgstr "ffprobe 二进制文件的完整路径。留空让 amule 在启动时自动检测。"
 
-#: src/muuli_wdr.cpp:1687
+#: src/muuli_wdr.cpp:1691
 msgid "Detect"
 msgstr "检测"
 
-#: src/muuli_wdr.cpp:1688
+#: src/muuli_wdr.cpp:1692
 msgid "Search the standard install locations for an ffprobe binary and fill the path field."
 msgstr "搜索标准的 ffprobe 二进制文件安装路径，并填写路径字段。"
 
-#: src/muuli_wdr.cpp:1712
+#: src/muuli_wdr.cpp:1716
 msgid ""
 "Completed downloads are stored here. All files in this folder are automatically shared with other peers.\n"
 "If this folder also holds files you don't want to share, point it at an aMule-only sub-folder."
@@ -4157,665 +4162,688 @@ msgstr ""
 "已完成下载的文件存储在此处。此文件夹中的所有文件将自动与其他对等点共享。\n"
 "如果此文件夹中还包含您不想共享的文件，请为 aMule 选择一个专用子文件夹。"
 
-#: src/muuli_wdr.cpp:1715
+#: src/muuli_wdr.cpp:1719
 msgid "Pick the folder where completed downloads will be stored. All files in that folder will be shared with other peers."
 msgstr "选择完成下载文件的存储文件夹。该文件夹中的所有文件都将与其他对等节点共享。"
 
-#: src/muuli_wdr.cpp:1729
+#: src/muuli_wdr.cpp:1733
 msgid "Shared folders"
 msgstr "共享的文件夹"
 
-#: src/muuli_wdr.cpp:1735
+#: src/muuli_wdr.cpp:1739
 msgid "(Folders shared by the core. Enter a path to add one.)"
 msgstr "(由核心共享的文件夹。输入路径添加一个。)"
 
-#: src/muuli_wdr.cpp:1743
+#: src/muuli_wdr.cpp:1747
 msgid "Absolute path of a folder on the core's machine, e.g. /home/user/shared"
 msgstr "核心机器上文件夹的绝对路径，如 /home/user/shared"
 
-#: src/muuli_wdr.cpp:1745 src/PrefsUnifiedDlg.cpp:2794
+#: src/muuli_wdr.cpp:1749 src/PrefsUnifiedDlg.cpp:2874
 msgid "Recursive"
 msgstr "递归"
 
-#: src/muuli_wdr.cpp:1746
+#: src/muuli_wdr.cpp:1750
 msgid "Share every sub-folder underneath this one, including ones created later."
 msgstr "分享此文件夹下每个子文件夹，包括之后创建的子文件夹。"
 
-#: src/muuli_wdr.cpp:1750 src/utils/aLinkCreator/src/alcframe.cpp:141
+#: src/muuli_wdr.cpp:1754 src/utils/aLinkCreator/src/alcframe.cpp:141
 msgid "Remove"
 msgstr "删除"
 
-#: src/muuli_wdr.cpp:1754
+#: src/muuli_wdr.cpp:1758
 msgid "(Right click on folder icon for recursive share)"
 msgstr "(鼠标右键单击文件夹图标来递归共享)"
 
-#: src/muuli_wdr.cpp:1761
+#: src/muuli_wdr.cpp:1765
 msgid "Share hidden files"
 msgstr "共享隐藏文件"
 
-#: src/muuli_wdr.cpp:1767
+#: src/muuli_wdr.cpp:1771
 msgid "Automatically rescan shared folders for changes"
 msgstr "自动重新扫描共享文件夹以检测更改"
 
-#: src/muuli_wdr.cpp:1773
+#: src/muuli_wdr.cpp:1777
 msgid "Follow symbolic links in shared folders"
 msgstr "在共享文件夹中跟踪符号链接"
 
-#: src/muuli_wdr.cpp:1779
+#: src/muuli_wdr.cpp:1783
 msgid "Exclude files matching:"
 msgstr "排除文件匹配："
 
-#: src/muuli_wdr.cpp:1782
+#: src/muuli_wdr.cpp:1786
 msgid "Wildcard patterns separated by '|', e.g. .DS_Store|Thumbs.db|*.tmp. Files whose name matches are not shared. Matching is case-insensitive."
 msgstr "以“|”分隔的通配符模式，例如 .DS_Store|Thumbs.db|*.tmp。不会共享文件名匹配的文件。匹配不区分大小写。"
 
-#: src/muuli_wdr.cpp:1786
+#: src/muuli_wdr.cpp:1790
 msgid "Patterns are regular expressions"
 msgstr "模式是正则表达式"
 
-#: src/muuli_wdr.cpp:1787
+#: src/muuli_wdr.cpp:1791
 msgid "When set, the whole field is one regular expression ('|' is alternation). When unset, it is a list of '|'-separated wildcards."
 msgstr "启用后，整个字段是一个正则表达式（'|' 表示交替）。禁用后，它是一个以 '|' 分隔的通配符列表。"
 
-#: src/muuli_wdr.cpp:1797
+#: src/muuli_wdr.cpp:1801
 msgid "Show how many shared files the current pattern would exclude."
 msgstr "显示当前模式会排除多少共享文件。"
 
-#: src/muuli_wdr.cpp:1818
+#: src/muuli_wdr.cpp:1822
 msgid "Graphs"
 msgstr "图表"
 
-#: src/muuli_wdr.cpp:1821 src/muuli_wdr.cpp:1883
+#: src/muuli_wdr.cpp:1825 src/muuli_wdr.cpp:1887
 msgid "Update delay : 5 secs"
 msgstr "刷新延迟：5 秒"
 
-#: src/muuli_wdr.cpp:1825
+#: src/muuli_wdr.cpp:1829
 msgid "Time for average graph: 100 mins"
 msgstr "平均值图表显示时间：100 分钟"
 
-#: src/muuli_wdr.cpp:1829
+#: src/muuli_wdr.cpp:1833
 msgid "Connections Graph Scale: 100 "
 msgstr "连接图表尺寸: 100 "
 
-#: src/muuli_wdr.cpp:1836
+#: src/muuli_wdr.cpp:1840
 msgid "Download graph scale:"
 msgstr "下载图表尺寸："
 
-#: src/muuli_wdr.cpp:1844
+#: src/muuli_wdr.cpp:1848
 msgid "Upload graph scale:"
 msgstr "上传图表尺寸："
 
-#: src/muuli_wdr.cpp:1854
+#: src/muuli_wdr.cpp:1858
 msgid "Colors: "
 msgstr "颜色： "
 
-#: src/muuli_wdr.cpp:1858
+#: src/muuli_wdr.cpp:1862
 msgid "Background"
 msgstr "背景"
 
-#: src/muuli_wdr.cpp:1859
+#: src/muuli_wdr.cpp:1863
 msgid "Grid"
 msgstr "网格"
 
-#: src/muuli_wdr.cpp:1860
+#: src/muuli_wdr.cpp:1864
 msgid "Download current"
 msgstr "目前下载"
 
-#: src/muuli_wdr.cpp:1861
+#: src/muuli_wdr.cpp:1865
 msgid "Download running average"
 msgstr "动态平均下载"
 
-#: src/muuli_wdr.cpp:1862
+#: src/muuli_wdr.cpp:1866
 msgid "Download session average"
 msgstr "本次运行平均下载"
 
-#: src/muuli_wdr.cpp:1863
+#: src/muuli_wdr.cpp:1867
 msgid "Upload current"
 msgstr "目前上传"
 
-#: src/muuli_wdr.cpp:1864
+#: src/muuli_wdr.cpp:1868
 msgid "Upload running average"
 msgstr "动态平均上传"
 
-#: src/muuli_wdr.cpp:1865
+#: src/muuli_wdr.cpp:1869
 msgid "Upload session average"
 msgstr "本次运行平均上传"
 
-#: src/muuli_wdr.cpp:1866
+#: src/muuli_wdr.cpp:1870
 msgid "Active connections"
 msgstr "活跃连接"
 
-#: src/muuli_wdr.cpp:1869
+#: src/muuli_wdr.cpp:1873
 msgid "Systray Icon Speed Bar"
 msgstr "系统状态栏图标速度显示"
 
-#: src/muuli_wdr.cpp:1870
+#: src/muuli_wdr.cpp:1874
 msgid "Kad-nodes current"
 msgstr "当前 Kad 节点"
 
-#: src/muuli_wdr.cpp:1871
+#: src/muuli_wdr.cpp:1875
 msgid "Kad-nodes running"
 msgstr "运行的 Kad 节点"
 
-#: src/muuli_wdr.cpp:1872
+#: src/muuli_wdr.cpp:1876
 msgid "Kad-nodes session"
 msgstr "本次运行的 Kad 节点"
 
-#: src/muuli_wdr.cpp:1876 src/muuli_wdr.cpp:2303
+#: src/muuli_wdr.cpp:1880 src/muuli_wdr.cpp:2334
 msgid "Select"
 msgstr "选择"
 
-#: src/muuli_wdr.cpp:1880
+#: src/muuli_wdr.cpp:1884
 msgid "Tree"
 msgstr "树"
 
-#: src/muuli_wdr.cpp:1890
+#: src/muuli_wdr.cpp:1894
 msgid "Number of Client Versions shown (0=unlimited)"
 msgstr "显示用户软件版本的数量(0代表不限制)"
 
-#: src/muuli_wdr.cpp:1915
+#: src/muuli_wdr.cpp:1919
 msgid "!!! WARNING !!!"
 msgstr "！！！警告！！！"
 
-#: src/muuli_wdr.cpp:1930
+#: src/muuli_wdr.cpp:1934
 msgid "Max new connections / 5 secs"
 msgstr "5 秒内最大新连接数"
 
-#: src/muuli_wdr.cpp:1932
+#: src/muuli_wdr.cpp:1936
 msgid "Concurrent Kad source lookups"
 msgstr "并发 Kad 源查找"
 
-#: src/muuli_wdr.cpp:1934
+#: src/muuli_wdr.cpp:1938
 msgid "Kad source re-search interval (minutes)"
 msgstr "Kad 源重新搜索间隔（分钟）"
 
-#: src/muuli_wdr.cpp:1936
+#: src/muuli_wdr.cpp:1940
 msgid "Source re-ask interval (minutes)"
 msgstr "源重新请求间隔（分钟）"
 
-#: src/muuli_wdr.cpp:1940
+#: src/muuli_wdr.cpp:1944
 msgid "File Buffer Size: 240000 bytes"
 msgstr "文件缓冲：24000 字节"
 
-#: src/muuli_wdr.cpp:1944
+#: src/muuli_wdr.cpp:1948
 msgid "Use MMAP: memory-mapped file access (lower memory use)"
 msgstr "使用 MMAP：内存映射文件访问（降低内存占用）"
 
-#: src/muuli_wdr.cpp:1945
+#: src/muuli_wdr.cpp:1949
 msgid "Maps part files into memory instead of buffering them on the heap, lowering the process memory footprint. May reduce download speed on some disks; best for memory-constrained or upload-heavy hosts."
 msgstr "映射 part 文件到内存而不是在堆栈上缓冲，降低进程内存占用。在一些磁盘上可能降低下载速度；最适合内存紧张或重度上传的主机。"
 
-#: src/muuli_wdr.cpp:1947
+#: src/muuli_wdr.cpp:1951
 msgid "Upload Queue Size: 5000 clients"
 msgstr "上传队列长度：5000 用户"
 
-#: src/muuli_wdr.cpp:1951
+#: src/muuli_wdr.cpp:1955
 msgid "Server connection refresh interval: Disable"
 msgstr "服务器连接刷新周期：禁用"
 
-#: src/muuli_wdr.cpp:1955
+#: src/muuli_wdr.cpp:1959
 msgid "Disable computer's timed standby mode"
 msgstr "停用电脑自动进入待命模式功能"
 
-#: src/muuli_wdr.cpp:1974
+#: src/muuli_wdr.cpp:1978
 msgid "Skin to use: "
 msgstr "要使用的皮肤: "
 
-#: src/muuli_wdr.cpp:1983
+#: src/muuli_wdr.cpp:1987
 msgid "Show \"Fast eD2k Links Handler\" in every window."
 msgstr "在全部窗口都显示“快捷 eD2k 链接处理栏”。"
 
-#: src/muuli_wdr.cpp:1986
+#: src/muuli_wdr.cpp:1990
 msgid "Show extended info on categories tabs"
 msgstr "在分类页中显示附加信息"
 
-#: src/muuli_wdr.cpp:1989
+#: src/muuli_wdr.cpp:1993
 msgid "Show application version on title"
 msgstr "在标题栏显示应用程序版本"
 
-#: src/muuli_wdr.cpp:1991
+#: src/muuli_wdr.cpp:1995
 msgid "Show transfer rates on title"
 msgstr "在标题栏显示传输速度"
 
-#: src/muuli_wdr.cpp:1993
+#: src/muuli_wdr.cpp:1997
 msgid "Before application name"
 msgstr "在应用程序名称之前"
 
-#: src/muuli_wdr.cpp:1995
+#: src/muuli_wdr.cpp:1999
 msgid "After application name"
 msgstr "在应用程序名称之后"
 
-#: src/muuli_wdr.cpp:1998
+#: src/muuli_wdr.cpp:2002
 msgid "Show overhead bandwidth"
 msgstr "显示额外开销的带宽"
 
-#: src/muuli_wdr.cpp:2002
+#: src/muuli_wdr.cpp:2006
 msgid "Vertical toolbar orientation"
 msgstr "垂直显示工具栏"
 
-#: src/muuli_wdr.cpp:2004
+#: src/muuli_wdr.cpp:2008
 msgid "Live column sorting (auto-reorder rows as their values change)"
 msgstr "实时列排序（值更改时自动调整顺序）"
 
-#: src/muuli_wdr.cpp:2011
+#: src/muuli_wdr.cpp:2015
 msgid "Download Queue Files"
 msgstr "下载队列文件"
 
-#: src/muuli_wdr.cpp:2014
+#: src/muuli_wdr.cpp:2018
 msgid "Show progress percentage"
 msgstr "显示进度百分比"
 
-#: src/muuli_wdr.cpp:2020
+#: src/muuli_wdr.cpp:2024
 msgid "Show progress bar"
 msgstr "显示进度条"
 
-#: src/muuli_wdr.cpp:2023
+#: src/muuli_wdr.cpp:2027
 msgid "Flat"
 msgstr "扁平"
 
-#: src/muuli_wdr.cpp:2027
+#: src/muuli_wdr.cpp:2031
 msgid "Round"
 msgstr "圆柱"
 
-#: src/muuli_wdr.cpp:2045
+#: src/muuli_wdr.cpp:2049
 msgid "External Connection Parameters"
 msgstr "远程连接参数"
 
-#: src/muuli_wdr.cpp:2048
+#: src/muuli_wdr.cpp:2052
 msgid "Accept external connections"
 msgstr "接受远程连接"
 
-#: src/muuli_wdr.cpp:2055 src/muuli_wdr.cpp:2114
+#: src/muuli_wdr.cpp:2059 src/muuli_wdr.cpp:2118
 msgid "IP of the listening interface:"
 msgstr "监听接口的 IP:"
 
-#: src/muuli_wdr.cpp:2058
+#: src/muuli_wdr.cpp:2062
 msgid "Enter here a valid ip in the a.b.c.d format for the listening EC interface. An empty field or 0.0.0.0 will mean any interface."
 msgstr "在此输入正确的 IP(格式：a.b.c.d)用于监听远程连接接口。空着不填或者 0.0.0.0 表示任何接口。"
 
-#: src/muuli_wdr.cpp:2079 src/muuli_wdr.cpp:2163
+#: src/muuli_wdr.cpp:2083 src/muuli_wdr.cpp:2194
 msgid "TCP port:"
 msgstr "TCP 端口："
 
-#: src/muuli_wdr.cpp:2085
+#: src/muuli_wdr.cpp:2089
 msgid "Enable UPnP port forwarding on the EC port"
 msgstr "为远程连接端口启用 UPnP"
 
-#: src/muuli_wdr.cpp:2089 src/muuli_wdr.cpp:3048
+#: src/muuli_wdr.cpp:2093 src/muuli_wdr.cpp:3079
 #: src/utils/wxCas/src/wxcasprefs.cpp:167
 msgid "Password"
 msgstr "密码"
 
-#: src/muuli_wdr.cpp:2095
+#: src/muuli_wdr.cpp:2099
 msgid "aMule API server parameters"
 msgstr "aMule API 服务器参数"
 
-#: src/muuli_wdr.cpp:2098
+#: src/muuli_wdr.cpp:2102
 msgid "Run amuleapi (REST API) on startup"
 msgstr "启动时运行 amuleapi (REST API)"
 
-#: src/muuli_wdr.cpp:2103
+#: src/muuli_wdr.cpp:2107
 msgid "HTTP port:"
 msgstr "HTTP 端口："
 
-#: src/muuli_wdr.cpp:2117
+#: src/muuli_wdr.cpp:2121
 msgid "The interface amuleapi's HTTP server listens on. 127.0.0.1 (default) accepts only local connections; use 0.0.0.0 or a specific IP to expose it to other hosts (set an admin password below)."
 msgstr "amuleapi 接口的 HTTP 服务器监听默认地址为 127.0.0.1，该地址仅接受本地连接；使用 0.0.0.0 或特定 IP 地址可将其暴露给其他主机（请在下方设置管理密码）。"
 
-#: src/muuli_wdr.cpp:2120
+#: src/muuli_wdr.cpp:2126
+msgid "Type a password to set or change it. Stored passwords cannot be shown, so leaving this empty keeps the current one."
+msgstr ""
+
+#: src/muuli_wdr.cpp:2128
 msgid "Admin password"
 msgstr "管理密码"
 
-#: src/muuli_wdr.cpp:2125 src/muuli_wdr.cpp:2156
-msgid "Low rights password"
-msgstr "低权限密码"
+#: src/muuli_wdr.cpp:2140 src/muuli_wdr.cpp:2157 src/PrefsUnifiedDlg.cpp:1103
+#, fuzzy
+msgid "A password is set."
+msgstr "管理密码"
 
-#: src/muuli_wdr.cpp:2133
+#: src/muuli_wdr.cpp:2144
+#, fuzzy
+msgid "Enable guest access"
+msgstr "拒绝访客访问"
+
+#: src/muuli_wdr.cpp:2145
+msgid "Guest sessions may read status and listings but cannot change anything. Turning this off clears the stored guest password."
+msgstr ""
+
+#: src/muuli_wdr.cpp:2149
+#, fuzzy
+msgid "Guest password"
+msgstr "Web服务器的访客密码"
+
+#: src/muuli_wdr.cpp:2164
 msgid "Web server parameters"
 msgstr "Web 服务参数"
 
-#: src/muuli_wdr.cpp:2136
+#: src/muuli_wdr.cpp:2167
 msgid "Run webserver on startup (deprecated)"
 msgstr "启动时运行 web 服务器（已废弃）"
 
-#: src/muuli_wdr.cpp:2142
+#: src/muuli_wdr.cpp:2173
 msgid "Web template"
 msgstr "Web 模板"
 
-#: src/muuli_wdr.cpp:2147
+#: src/muuli_wdr.cpp:2178
 msgid "Full rights password"
 msgstr "最高权限密码"
 
-#: src/muuli_wdr.cpp:2151
+#: src/muuli_wdr.cpp:2182
 msgid "Enable Low rights User"
 msgstr "启用低权限用户"
 
-#: src/muuli_wdr.cpp:2170
+#: src/muuli_wdr.cpp:2187
+msgid "Low rights password"
+msgstr "低权限密码"
+
+#: src/muuli_wdr.cpp:2201
 msgid "Enable UPnP port forwarding of the web server port"
 msgstr "为 Web 服务端口启用 UPn P端口转发"
 
-#: src/muuli_wdr.cpp:2175
+#: src/muuli_wdr.cpp:2206
 msgid "Web server UPnP TCP port (Optional)"
 msgstr "Web 服务器 UPnP 的 TCP 端口(可选)"
 
-#: src/muuli_wdr.cpp:2183
+#: src/muuli_wdr.cpp:2214
 msgid "Page Refresh Time (in secs)"
 msgstr "页面刷新周期(秒)"
 
-#: src/muuli_wdr.cpp:2190
+#: src/muuli_wdr.cpp:2221
 msgid "Enable Gzip compression"
 msgstr "启用 Gzip 压缩"
 
-#: src/muuli_wdr.cpp:2224
+#: src/muuli_wdr.cpp:2255
 msgid "Reset page to defaults"
 msgstr "重置页面为默认"
 
-#: src/muuli_wdr.cpp:2225
+#: src/muuli_wdr.cpp:2256
 msgid "Reset the settings on the current page to their default values."
 msgstr "重置当前页面设置为默认值。"
 
-#: src/muuli_wdr.cpp:2227 src/muuli_wdr.cpp:2313 src/ServerWnd.cpp:274
+#: src/muuli_wdr.cpp:2258 src/muuli_wdr.cpp:2344 src/ServerWnd.cpp:274
 #: src/ServerWnd.cpp:282
 msgid "OK"
 msgstr "确定"
 
-#: src/muuli_wdr.cpp:2229
+#: src/muuli_wdr.cpp:2260
 msgid "Click here to apply any changes made to the preferences."
 msgstr "点击这里立即使用新的设置。"
 
-#: src/muuli_wdr.cpp:2232
+#: src/muuli_wdr.cpp:2263
 msgid "Reset any changes made to the preferences."
 msgstr "取消所有设置改动。"
 
-#: src/muuli_wdr.cpp:2261
+#: src/muuli_wdr.cpp:2292
 msgid "Comment :"
 msgstr "注释 :"
 
-#: src/muuli_wdr.cpp:2268
+#: src/muuli_wdr.cpp:2299
 msgid "Incoming Dir :"
 msgstr "下载目录 :"
 
-#: src/muuli_wdr.cpp:2277
+#: src/muuli_wdr.cpp:2308
 msgid "Change priority for new assigned files :"
 msgstr "设置新加入的文件优先级为 :"
 
-#: src/muuli_wdr.cpp:2281
+#: src/muuli_wdr.cpp:2312
 msgid "Don't change"
 msgstr "不要改变"
 
-#: src/muuli_wdr.cpp:2293
+#: src/muuli_wdr.cpp:2324
 msgid "Select color for this Category (currently selected) :"
 msgstr "选择该分类颜色 (当前选择) :"
 
-#: src/muuli_wdr.cpp:2360 src/muuli_wdr.cpp:2379 src/muuli_wdr.cpp:2401
+#: src/muuli_wdr.cpp:2391 src/muuli_wdr.cpp:2410 src/muuli_wdr.cpp:2432
 msgid "Click this button to reset the log."
 msgstr "按此按钮清空日志。"
 
-#: src/muuli_wdr.cpp:2420
+#: src/muuli_wdr.cpp:2451
 msgid "Click on this button to update the servers list from URL ..."
 msgstr "按此按钮从该网址更新服务器列表 ..."
 
-#: src/muuli_wdr.cpp:2424
+#: src/muuli_wdr.cpp:2455
 msgid "Server list"
 msgstr "服务器列表"
 
-#: src/muuli_wdr.cpp:2428
+#: src/muuli_wdr.cpp:2459
 msgid "Enter the url to a server.met file here and press the button to the left to update the list of known servers."
 msgstr "输入 server.met 文件的地址，再按此按钮更新服务器列表。"
 
-#: src/muuli_wdr.cpp:2433
+#: src/muuli_wdr.cpp:2464
 msgid "Add server manually: Name"
 msgstr "手动添加服务器：名称"
 
-#: src/muuli_wdr.cpp:2436
+#: src/muuli_wdr.cpp:2467
 msgid "Enter the name of the new server here"
 msgstr "在此输入新服务器的名称"
 
-#: src/muuli_wdr.cpp:2438 src/ServerWnd.cpp:206
+#: src/muuli_wdr.cpp:2469 src/ServerWnd.cpp:206
 msgid "IP:Port"
 msgstr "IP 地址:端口"
 
-#: src/muuli_wdr.cpp:2441
+#: src/muuli_wdr.cpp:2472
 msgid "Enter the IP of the server here, using the x.x.x.x format."
 msgstr "输入新服务器的 IP 地址 (x.x.x.x格式)。"
 
-#: src/muuli_wdr.cpp:2447
+#: src/muuli_wdr.cpp:2478
 msgid "Enter the port of the server here."
 msgstr "在此请输入服务器端口。"
 
-#: src/muuli_wdr.cpp:2450
+#: src/muuli_wdr.cpp:2481
 msgid "Add manually a server (fill fields to the left before) ..."
 msgstr "添加新服务器 (先填写左侧的内容) ..."
 
-#: src/muuli_wdr.cpp:2479
+#: src/muuli_wdr.cpp:2510
 msgid "aMule Log"
 msgstr "aMule 日志"
 
-#: src/muuli_wdr.cpp:2487
+#: src/muuli_wdr.cpp:2518
 msgid "Server Info"
 msgstr "服务器信息"
 
-#: src/muuli_wdr.cpp:2491
+#: src/muuli_wdr.cpp:2522
 msgid "ED2K Info"
 msgstr "ED2K 信息"
 
-#: src/muuli_wdr.cpp:2495
+#: src/muuli_wdr.cpp:2526
 msgid "Kad Info"
 msgstr "Kad 信息"
 
-#: src/muuli_wdr.cpp:2523
+#: src/muuli_wdr.cpp:2554
 msgid "Click on this button to update the nodes list from URL ..."
 msgstr "按此更新节点列表自网址..."
 
-#: src/muuli_wdr.cpp:2527
+#: src/muuli_wdr.cpp:2558
 msgid "Nodes (0)"
 msgstr "节点 (0)"
 
-#: src/muuli_wdr.cpp:2531
+#: src/muuli_wdr.cpp:2562
 msgid "Enter the url to a nodes.dat file here and press the button to the left to update the list of known nodes."
 msgstr "输入 nodes.dat 文件的地址并按左边的按钮以更新已知节点列表"
 
-#: src/muuli_wdr.cpp:2534
+#: src/muuli_wdr.cpp:2565
 msgid "Nodes stats"
 msgstr "节点状态"
 
-#: src/muuli_wdr.cpp:2576
+#: src/muuli_wdr.cpp:2607
 msgid "Bootstrap"
 msgstr "启动"
 
-#: src/muuli_wdr.cpp:2579
+#: src/muuli_wdr.cpp:2610
 msgid "New node"
 msgstr "新节点"
 
-#: src/muuli_wdr.cpp:2584
+#: src/muuli_wdr.cpp:2615
 msgid "IP:"
 msgstr "IP："
 
-#: src/muuli_wdr.cpp:2604
+#: src/muuli_wdr.cpp:2635
 msgid "Port:"
 msgstr "端口："
 
-#: src/muuli_wdr.cpp:2617
+#: src/muuli_wdr.cpp:2648
 msgid "Bootstrap from known clients"
 msgstr "从已知用户启动"
 
-#: src/muuli_wdr.cpp:2619
+#: src/muuli_wdr.cpp:2650
 msgid "Disconnect Kad"
 msgstr "断开 Kad"
 
-#: src/muuli_wdr.cpp:2653
+#: src/muuli_wdr.cpp:2684
 msgid "Use Secure User Identification"
 msgstr "使用安全用户认证"
 
-#: src/muuli_wdr.cpp:2655
+#: src/muuli_wdr.cpp:2686
 msgid "It is recommended to enable this option. You will not receive credits if SUI is not enabled."
 msgstr "建议使用此选项，如果安全用户认证没有启用，将不会接收信用证明。"
 
-#: src/muuli_wdr.cpp:2657
+#: src/muuli_wdr.cpp:2688
 msgid "Protocol Obfuscation"
 msgstr "模糊协议"
 
-#: src/muuli_wdr.cpp:2660
+#: src/muuli_wdr.cpp:2691
 msgid "Support Protocol Obfuscation"
 msgstr "支持模糊协议"
 
-#: src/muuli_wdr.cpp:2662
+#: src/muuli_wdr.cpp:2693
 msgid "This option enabled Protocol Obfuscation, and makes aMule accept obfuscated connections from other clients."
 msgstr "此选项启用了模糊协议，可让aMule接受其他用户用迷糊协议的连接"
 
-#: src/muuli_wdr.cpp:2664
+#: src/muuli_wdr.cpp:2695
 msgid "Use obfuscation for outgoing connections"
 msgstr "为传出连接使用模糊协议"
 
-#: src/muuli_wdr.cpp:2666
+#: src/muuli_wdr.cpp:2697
 msgid "This option makes aMule use Protocol Obfuscation when connecting other clients/servers."
 msgstr "此选项使aMule在连接其他用户或服务器时使用模糊协议。"
 
-#: src/muuli_wdr.cpp:2668
+#: src/muuli_wdr.cpp:2699
 msgid "Accept only obfuscated connections"
 msgstr "仅接受模糊协议连接"
 
-#: src/muuli_wdr.cpp:2669
+#: src/muuli_wdr.cpp:2700
 msgid "This option makes aMule only accept obfuscated connections. You will have less sources, but all your traffic will be obfuscated"
 msgstr "此选项让aMule只接受模糊协议连接，源相对来说会更少，但全部数据包都将进行迷惑处理"
 
-#: src/muuli_wdr.cpp:2674
+#: src/muuli_wdr.cpp:2705
 msgid "Everybody"
 msgstr "任何人"
 
-#: src/muuli_wdr.cpp:2676
+#: src/muuli_wdr.cpp:2707
 msgid "No one"
 msgstr "没有人"
 
-#: src/muuli_wdr.cpp:2678
+#: src/muuli_wdr.cpp:2709
 msgid "Who can see my shared files:"
 msgstr "谁可查看我的共享文件："
 
-#: src/muuli_wdr.cpp:2679
+#: src/muuli_wdr.cpp:2710
 msgid "Select who can request to view a list of your shared files."
 msgstr "选择可以浏览共享文件列表的用户。"
 
-#: src/muuli_wdr.cpp:2681
+#: src/muuli_wdr.cpp:2712
 msgid "IP-Filtering"
 msgstr "IP 过滤"
 
-#: src/muuli_wdr.cpp:2688
+#: src/muuli_wdr.cpp:2719
 msgid "Filter clients"
 msgstr "过滤用户"
 
-#: src/muuli_wdr.cpp:2690
+#: src/muuli_wdr.cpp:2721
 msgid "Enable filtering of the client IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "过滤在文件~/.aMule/ipfilter.dat中定义的用户IP"
 
-#: src/muuli_wdr.cpp:2692
+#: src/muuli_wdr.cpp:2723
 msgid "Filter servers"
 msgstr "过滤服务器"
 
-#: src/muuli_wdr.cpp:2694
+#: src/muuli_wdr.cpp:2725
 msgid "Enable filtering of the server IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "过滤在文件~/.aMule/ipfilter.dat中定义的服务器IP"
 
-#: src/muuli_wdr.cpp:2698
+#: src/muuli_wdr.cpp:2729
 msgid "Reload List"
 msgstr "刷新列表"
 
-#: src/muuli_wdr.cpp:2699
+#: src/muuli_wdr.cpp:2730
 msgid "Reload the list of IPs to filter from the file ~/.aMule/ipfilter.dat"
 msgstr "更新 IP 地址过滤列表自文件 ~/.aMule/ipfilter.dat"
 
-#: src/muuli_wdr.cpp:2705
+#: src/muuli_wdr.cpp:2736
 msgid "URL:"
 msgstr "地址:"
 
-#: src/muuli_wdr.cpp:2709 src/muuli_wdr.cpp:2902
+#: src/muuli_wdr.cpp:2740 src/muuli_wdr.cpp:2933
 msgid "Update now"
 msgstr "立即更新"
 
-#: src/muuli_wdr.cpp:2712
+#: src/muuli_wdr.cpp:2743
 msgid "Auto-update ipfilter at startup"
 msgstr "启动后自动更新IP 地址过滤列表"
 
-#: src/muuli_wdr.cpp:2716
+#: src/muuli_wdr.cpp:2747
 msgid "Filtering Level:"
 msgstr "过滤级别:"
 
-#: src/muuli_wdr.cpp:2722
+#: src/muuli_wdr.cpp:2753
 msgid "Always filter LAN IPs"
 msgstr "始终过滤局域网 IP"
 
-#: src/muuli_wdr.cpp:2725
+#: src/muuli_wdr.cpp:2756
 msgid "Paranoid handling of non-matching IPs"
 msgstr "处理不匹配的 IP"
 
-#: src/muuli_wdr.cpp:2727
+#: src/muuli_wdr.cpp:2758
 msgid "Rejects a packet when its source IP differs from the IP the client claims (an anti-spoofing check). Disable only if it causes connection problems."
 msgstr "当数据包的源 IP 地址与客户端声称的 IP 地址不同时，拒绝该数据包（防欺骗检查）。仅在导致连接问题时才禁用此功能。"
 
-#: src/muuli_wdr.cpp:2729
+#: src/muuli_wdr.cpp:2760
 msgid "Use system-wide ipfilter.dat if available"
 msgstr "在可用的情况下使用系统级别的 ipfilter.dat"
 
-#: src/muuli_wdr.cpp:2730
+#: src/muuli_wdr.cpp:2761
 msgid "If there's no local ipfilter.dat found, allow usage of a system-wide ipfilter file."
 msgstr "如果没有找到本地 ipfilter.dat 文件，则允许使用系统级的IP过滤文件。"
 
-#: src/muuli_wdr.cpp:2747
+#: src/muuli_wdr.cpp:2778
 msgid "Enable Online-Signature"
 msgstr "启用在线统计"
 
-#: src/muuli_wdr.cpp:2749
+#: src/muuli_wdr.cpp:2780
 msgid "Enables the writing of the OS file, which can be used by external apps to create signatures and the like."
 msgstr "输出该文件以用于在线统计等等。"
 
-#: src/muuli_wdr.cpp:2753
+#: src/muuli_wdr.cpp:2784
 msgid "Update Frequency (Secs):"
 msgstr "更新频率 (秒):"
 
-#: src/muuli_wdr.cpp:2756
+#: src/muuli_wdr.cpp:2787
 msgid "Change the frequency (in seconds) of Online Signature updates."
 msgstr "更改在线统计文件的更新频率 (秒) 。"
 
-#: src/muuli_wdr.cpp:2764
+#: src/muuli_wdr.cpp:2795
 msgid "Save online signature file in: "
 msgstr "保存在线签名位置： "
 
-#: src/muuli_wdr.cpp:2770
+#: src/muuli_wdr.cpp:2801
 msgid "Click here to select the directory containing the the Online Signature files."
 msgstr "单击此处选择包含在线签名文件的目录。"
 
-#: src/muuli_wdr.cpp:2803
+#: src/muuli_wdr.cpp:2834
 msgid "Show country flags for clients"
 msgstr "为客户端显示国旗"
 
-#: src/muuli_wdr.cpp:2804
+#: src/muuli_wdr.cpp:2835
 msgid "Render the country flag column in the transfers, queue and search views. Requires a valid MMDB GeoIP database (see below)."
 msgstr "在传输、队列和搜索视图中渲染地区旗帜列。需要有效的 MMDB GeoIP 数据库（见下文）。"
 
-#: src/muuli_wdr.cpp:2809
+#: src/muuli_wdr.cpp:2840
 msgid "Database"
 msgstr "数据库"
 
-#: src/muuli_wdr.cpp:2825
+#: src/muuli_wdr.cpp:2856
 msgid "Source:"
 msgstr "源："
 
-#: src/muuli_wdr.cpp:2828
+#: src/muuli_wdr.cpp:2859
 msgid "DB-IP (free, no account)"
 msgstr "DB-IP（免费，无需账户）"
 
-#: src/muuli_wdr.cpp:2829
+#: src/muuli_wdr.cpp:2860
 msgid "MaxMind GeoLite2 (free, account required)"
 msgstr "MaxMind GeoLite2（免费，需注册账户）"
 
-#: src/muuli_wdr.cpp:2830
+#: src/muuli_wdr.cpp:2861
 msgid "Custom URL"
 msgstr "自定义 URL"
 
-#: src/muuli_wdr.cpp:2833
+#: src/muuli_wdr.cpp:2864
 msgid "Choose which provider supplies the GeoIP MMDB database. DB-IP is the default - no account required. MaxMind requires a free account + license key. Use Custom URL to point at any other MMDB host (e.g. a local mirror)."
 msgstr "选择哪个提供商提供 GeoIP MMDB 数据库。DB-IP 是默认选项，无需账户。MaxMind 需要一个免费账户和许可证密钥。使用自定义 URL 指向任何其他 MMDB 主机（例如本地镜像）。"
 
-#: src/muuli_wdr.cpp:2850
+#: src/muuli_wdr.cpp:2881
 msgid ""
 "No configuration required.\n"
 "\n"
@@ -4827,11 +4855,11 @@ msgstr ""
 "IP-to-Country 数据由 DB-IP.com 提供 - https://db-ip.com\n"
 "许可证：知识共享署名 4.0 国际版 - https://creativecommons.org/licenses/by/4.0/"
 
-#: src/muuli_wdr.cpp:2863
+#: src/muuli_wdr.cpp:2894
 msgid "License key:"
 msgstr "许可证密钥："
 
-#: src/muuli_wdr.cpp:2869
+#: src/muuli_wdr.cpp:2900
 msgid ""
 "Sign up for a free MaxMind account, then generate a License Key:\n"
 "https://www.maxmind.com/en/geolite2/signup\n"
@@ -4847,11 +4875,11 @@ msgstr ""
 "许可证：MaxMind GeoLite2 最终用户许可协议 - https://www.maxmind.com/en/geolite2/eula\n"
 "需要注明出处并注册账户；至少每 30 天刷新一次。"
 
-#: src/muuli_wdr.cpp:2884
+#: src/muuli_wdr.cpp:2915
 msgid "Download URL:"
 msgstr "下载地址："
 
-#: src/muuli_wdr.cpp:2890
+#: src/muuli_wdr.cpp:2921
 msgid ""
 "Must point to an .mmdb file or a .gz / .tar.gz containing one.\n"
 "URL may include credentials (https://user:pass@host/...).\n"
@@ -4861,211 +4889,211 @@ msgstr ""
 "URL 可包含凭据（例如 https://user:pass@host/...）。\n"
 "许可和署名条款由上游 URL 决定——你需自行负责。"
 
-#: src/muuli_wdr.cpp:2903
+#: src/muuli_wdr.cpp:2934
 msgid "Download the GeoIP database from the selected source."
 msgstr "从所选源下载 GeoIP 数据库。"
 
-#: src/muuli_wdr.cpp:2905
+#: src/muuli_wdr.cpp:2936
 msgid "Auto-update on startup"
 msgstr "启动后自动更新"
 
-#: src/muuli_wdr.cpp:2906
+#: src/muuli_wdr.cpp:2937
 msgid "Re-download the GeoIP database from the selected source every time aMule starts."
 msgstr "每次启动 aMule 时，从所选源重新下载 GeoIP 数据库。"
 
-#: src/muuli_wdr.cpp:2929
+#: src/muuli_wdr.cpp:2960
 msgid "Filter incoming messages (except current chat):"
 msgstr "过滤收到的消息 (不包括当前对话):"
 
-#: src/muuli_wdr.cpp:2931
+#: src/muuli_wdr.cpp:2962
 msgid "Filter all messages"
 msgstr "过滤所有消息"
 
-#: src/muuli_wdr.cpp:2933
+#: src/muuli_wdr.cpp:2964
 msgid "Filter messages from people not on your friend list"
 msgstr "过滤来自好友列表外的消息"
 
-#: src/muuli_wdr.cpp:2935
+#: src/muuli_wdr.cpp:2966
 msgid "Filter messages from unknown clients"
 msgstr "过滤来自未知用户的消息"
 
-#: src/muuli_wdr.cpp:2937
+#: src/muuli_wdr.cpp:2968
 msgid "Filter messages containing (use ',' as separator):"
 msgstr "过滤包含以下内容的消息 (用半角逗号分隔):"
 
-#: src/muuli_wdr.cpp:2940 src/muuli_wdr.cpp:2951
+#: src/muuli_wdr.cpp:2971 src/muuli_wdr.cpp:2982
 msgid "add here the words amule should filter and block messages including it"
 msgstr "输入需过滤的词组"
 
-#: src/muuli_wdr.cpp:2942
+#: src/muuli_wdr.cpp:2973
 msgid "Show received messages in the log"
 msgstr "在日志中显示接收的消息"
 
-#: src/muuli_wdr.cpp:2945
+#: src/muuli_wdr.cpp:2976
 msgid "Comments"
 msgstr "备注"
 
-#: src/muuli_wdr.cpp:2948
+#: src/muuli_wdr.cpp:2979
 msgid "Filter comments containing (use ',' as separator):"
 msgstr "过滤包含以下内容的备注 (使用“,”作为分隔符):"
 
-#: src/muuli_wdr.cpp:2973
+#: src/muuli_wdr.cpp:3004
 msgid "Enable Proxy"
 msgstr "启用代理"
 
-#: src/muuli_wdr.cpp:2974
+#: src/muuli_wdr.cpp:3005
 msgid "Enable/disable proxy support"
 msgstr "启用/禁用代理支持"
 
-#: src/muuli_wdr.cpp:2977
+#: src/muuli_wdr.cpp:3008
 msgid "Proxy type:"
 msgstr "代理类型:"
 
-#: src/muuli_wdr.cpp:2988
+#: src/muuli_wdr.cpp:3019
 msgid "Proxy host:"
 msgstr "代理服务器:"
 
-#: src/muuli_wdr.cpp:2991
+#: src/muuli_wdr.cpp:3022
 msgid "The proxy host name"
 msgstr "代理服务器名称"
 
-#: src/muuli_wdr.cpp:2993
+#: src/muuli_wdr.cpp:3024
 msgid "Proxy port:"
 msgstr "代理端口:"
 
-#: src/muuli_wdr.cpp:2996
+#: src/muuli_wdr.cpp:3027
 msgid "The proxy port"
 msgstr "代理端口"
 
-#: src/muuli_wdr.cpp:2998
+#: src/muuli_wdr.cpp:3029
 msgid "Enable authentication"
 msgstr "启用验证："
 
-#: src/muuli_wdr.cpp:2999
+#: src/muuli_wdr.cpp:3030
 msgid "Enable/disable username/password authentication"
 msgstr "启用/禁用用户名/密码验证"
 
-#: src/muuli_wdr.cpp:3002
+#: src/muuli_wdr.cpp:3033
 msgid "Username: "
 msgstr "用户名: "
 
-#: src/muuli_wdr.cpp:3005
+#: src/muuli_wdr.cpp:3036
 msgid "The username to use to connect to the proxy"
 msgstr "连接代理服务器的用户名"
 
-#: src/muuli_wdr.cpp:3007
+#: src/muuli_wdr.cpp:3038
 msgid "Password:"
 msgstr "密码:"
 
-#: src/muuli_wdr.cpp:3010
+#: src/muuli_wdr.cpp:3041
 msgid "The password to use to connect to the proxy"
 msgstr "连接代理服务器的密码"
 
-#: src/muuli_wdr.cpp:3029
+#: src/muuli_wdr.cpp:3060
 msgid "Connect to:"
 msgstr "连接到:"
 
-#: src/muuli_wdr.cpp:3038
+#: src/muuli_wdr.cpp:3069
 msgid "Login to remote amule"
 msgstr "登录远程 amule"
 
-#: src/muuli_wdr.cpp:3043
+#: src/muuli_wdr.cpp:3074
 msgid "User name"
 msgstr "用户名"
 
-#: src/muuli_wdr.cpp:3054
+#: src/muuli_wdr.cpp:3085
 msgid "Remember those settings"
 msgstr "记住这些设置"
 
-#: src/muuli_wdr.cpp:3057
+#: src/muuli_wdr.cpp:3088
 msgid "Force ZLIB compression"
 msgstr "强制使用 ZLIB 压缩"
 
-#: src/muuli_wdr.cpp:3081
+#: src/muuli_wdr.cpp:3112
 msgid "Enable Verbose Debug-Logging."
 msgstr "启用详细调试日志。"
 
-#: src/muuli_wdr.cpp:3083
+#: src/muuli_wdr.cpp:3114
 msgid "Only to Logfile"
 msgstr "只记录到日志文件"
 
-#: src/muuli_wdr.cpp:3085
+#: src/muuli_wdr.cpp:3116
 msgid "Message Categories:"
 msgstr "消息分类:"
 
-#: src/muuli_wdr.cpp:3109 src/PartFileConvertDlg.cpp:160
+#: src/muuli_wdr.cpp:3140 src/PartFileConvertDlg.cpp:160
 msgid "Waiting..."
 msgstr "等待中..."
 
-#: src/muuli_wdr.cpp:3129
+#: src/muuli_wdr.cpp:3160
 msgid "Add imports"
 msgstr "添加导入文件"
 
-#: src/muuli_wdr.cpp:3132
+#: src/muuli_wdr.cpp:3163
 msgid "Retry selected"
 msgstr "重试所选"
 
-#: src/muuli_wdr.cpp:3134
+#: src/muuli_wdr.cpp:3165
 msgid "Remove selected"
 msgstr "删除所选"
 
-#: src/muuli_wdr.cpp:3197
+#: src/muuli_wdr.cpp:3228
 msgid "Event Types"
 msgstr "事件类型"
 
-#: src/muuli_wdr.cpp:3216
+#: src/muuli_wdr.cpp:3247
 msgid "Statistics and queued clients for selected file(s) : Session / All time"
 msgstr "所选文件的统计和队列用户：会话/全部时间"
 
-#: src/muuli_wdr.cpp:3240
+#: src/muuli_wdr.cpp:3271
 msgid "Active Uploads"
 msgstr "活跃上传"
 
-#: src/muuli_wdr.cpp:3254
+#: src/muuli_wdr.cpp:3285
 msgid "Percent of total files"
 msgstr "全部文件的百分比"
 
-#: src/muuli_wdr.cpp:3306
+#: src/muuli_wdr.cpp:3337
 msgid "Show Clients for"
 msgstr "显示客户端"
 
-#: src/muuli_wdr.cpp:3308
+#: src/muuli_wdr.cpp:3339
 msgid "All files"
 msgstr "所有文件"
 
-#: src/muuli_wdr.cpp:3311
+#: src/muuli_wdr.cpp:3342
 msgid "Selected files"
 msgstr "选择的文件"
 
-#: src/muuli_wdr.cpp:3314
+#: src/muuli_wdr.cpp:3345
 msgid "Active uploads only"
 msgstr "仅活跃上传"
 
-#: src/muuli_wdr.cpp:3321
+#: src/muuli_wdr.cpp:3352
 msgid "Reload:"
 msgstr "重新载入:"
 
-#: src/muuli_wdr.cpp:3325
+#: src/muuli_wdr.cpp:3356
 msgid "Reload your shared files"
 msgstr "刷新共享文件"
 
-#: src/muuli_wdr.cpp:3388
+#: src/muuli_wdr.cpp:3419
 msgid "Send"
 msgstr "发送"
 
-#: src/muuli_wdr.cpp:3389
+#: src/muuli_wdr.cpp:3420
 msgid "Sends the specified message."
 msgstr "发送指定消息。"
 
-#: src/muuli_wdr.cpp:3393
+#: src/muuli_wdr.cpp:3424
 msgid "Close this chat-session."
 msgstr "结束本次聊天。"
 
-#: src/muuli_wdr.cpp:3416
+#: src/muuli_wdr.cpp:3447
 msgid "Connect to any server and/or Kad"
 msgstr "连接至任何服务器和/或 Kad"
 
-#: src/muuli_wdr.cpp:3422 src/SharedFilesCtrl.cpp:142 src/Statistics.cpp:941
+#: src/muuli_wdr.cpp:3453 src/SharedFilesCtrl.cpp:142 src/Statistics.cpp:941
 msgid "Shared Files"
 msgstr "共享文件"
 
@@ -5425,248 +5453,248 @@ msgstr "已下载"
 msgid "ERROR: Failed to open partfile '%s'"
 msgstr "错误：打开part文件'%s'失败"
 
-#: src/Preferences.cpp:674
+#: src/Preferences.cpp:701
 msgid "System default"
 msgstr "系统默认"
 
-#: src/Preferences.cpp:675
+#: src/Preferences.cpp:702
 msgid "Albanian"
 msgstr "阿尔巴尼亚语"
 
-#: src/Preferences.cpp:676
+#: src/Preferences.cpp:703
 msgid "Arabic"
 msgstr "阿拉伯语"
 
-#: src/Preferences.cpp:677
+#: src/Preferences.cpp:704
 msgid "Asturian"
 msgstr "澳大利亚"
 
-#: src/Preferences.cpp:678
+#: src/Preferences.cpp:705
 msgid "Basque"
 msgstr "巴斯克语"
 
-#: src/Preferences.cpp:679
+#: src/Preferences.cpp:706
 msgid "Bulgarian"
 msgstr "保加利亚语"
 
-#: src/Preferences.cpp:680
+#: src/Preferences.cpp:707
 msgid "Catalan"
 msgstr "加泰罗尼亚语"
 
-#: src/Preferences.cpp:681
+#: src/Preferences.cpp:708
 msgid "Chinese (Simplified)"
 msgstr "简体中文"
 
-#: src/Preferences.cpp:682
+#: src/Preferences.cpp:709
 msgid "Chinese (Traditional)"
 msgstr "繁体中文"
 
-#: src/Preferences.cpp:683
+#: src/Preferences.cpp:710
 msgid "Croatian"
 msgstr "克罗的亚语"
 
-#: src/Preferences.cpp:684
+#: src/Preferences.cpp:711
 msgid "Czech"
 msgstr "捷克语"
 
-#: src/Preferences.cpp:685
+#: src/Preferences.cpp:712
 msgid "Danish"
 msgstr "丹麦语"
 
-#: src/Preferences.cpp:686
+#: src/Preferences.cpp:713
 msgid "Dutch"
 msgstr "荷兰语"
 
-#: src/Preferences.cpp:687
+#: src/Preferences.cpp:714
 msgid "English (U.K.)"
 msgstr "英语（英国）"
 
-#: src/Preferences.cpp:688
+#: src/Preferences.cpp:715
 msgid "English (U.S.)"
 msgstr "英语（美国）"
 
-#: src/Preferences.cpp:689
+#: src/Preferences.cpp:716
 msgid "Estonian"
 msgstr "爱斯托尼亚语"
 
-#: src/Preferences.cpp:690
+#: src/Preferences.cpp:717
 msgid "Finnish"
 msgstr "芬兰语"
 
-#: src/Preferences.cpp:691
+#: src/Preferences.cpp:718
 msgid "French"
 msgstr "法语"
 
-#: src/Preferences.cpp:692
+#: src/Preferences.cpp:719
 msgid "Galician"
 msgstr "加利西亚语"
 
-#: src/Preferences.cpp:693
+#: src/Preferences.cpp:720
 msgid "German"
 msgstr "德语"
 
-#: src/Preferences.cpp:694
+#: src/Preferences.cpp:721
 msgid "Greek"
 msgstr "希腊语"
 
-#: src/Preferences.cpp:695
+#: src/Preferences.cpp:722
 msgid "Hebrew"
 msgstr "希伯来语"
 
-#: src/Preferences.cpp:696
+#: src/Preferences.cpp:723
 msgid "Hungarian"
 msgstr "匈牙利语"
 
-#: src/Preferences.cpp:697
+#: src/Preferences.cpp:724
 msgid "Italian"
 msgstr "意大利语"
 
-#: src/Preferences.cpp:698
+#: src/Preferences.cpp:725
 msgid "Japanese"
 msgstr "日语"
 
-#: src/Preferences.cpp:699
+#: src/Preferences.cpp:726
 msgid "Korean"
 msgstr "韩语"
 
-#: src/Preferences.cpp:700
+#: src/Preferences.cpp:727
 msgid "Latvian"
 msgstr "拉脱维亚语"
 
-#: src/Preferences.cpp:701
+#: src/Preferences.cpp:728
 msgid "Lithuanian"
 msgstr "立陶宛语"
 
-#: src/Preferences.cpp:702
+#: src/Preferences.cpp:729
 msgid "Norwegian (Nynorsk)"
 msgstr "新挪威语"
 
-#: src/Preferences.cpp:703
+#: src/Preferences.cpp:730
 msgid "Polish"
 msgstr "芬兰语"
 
-#: src/Preferences.cpp:704
+#: src/Preferences.cpp:731
 msgid "Portuguese"
 msgstr "葡萄牙语"
 
-#: src/Preferences.cpp:705
+#: src/Preferences.cpp:732
 msgid "Portuguese (Brazilian)"
 msgstr "葡萄牙语（巴西）"
 
-#: src/Preferences.cpp:706
+#: src/Preferences.cpp:733
 msgid "Romanian"
 msgstr "罗马尼亚语"
 
-#: src/Preferences.cpp:707
+#: src/Preferences.cpp:734
 msgid "Russian"
 msgstr "俄语"
 
-#: src/Preferences.cpp:708
+#: src/Preferences.cpp:735
 msgid "Slovenian"
 msgstr "斯洛文尼亚语"
 
-#: src/Preferences.cpp:709
+#: src/Preferences.cpp:736
 msgid "Spanish"
 msgstr "西班牙语"
 
-#: src/Preferences.cpp:710
+#: src/Preferences.cpp:737
 msgid "Swedish"
 msgstr "瑞典语"
 
-#: src/Preferences.cpp:711
+#: src/Preferences.cpp:738
 msgid "Turkish"
 msgstr "土耳其语"
 
-#: src/Preferences.cpp:712
+#: src/Preferences.cpp:739
 msgid "Ukrainian"
 msgstr "乌克兰"
 
-#: src/Preferences.cpp:815
+#: src/Preferences.cpp:842
 msgid "Change Language"
 msgstr "更改语言"
 
-#: src/Preferences.cpp:879
+#: src/Preferences.cpp:906
 msgid "There are no translations installed for aMule"
 msgstr "没有为 aMule 安装语言文件"
 
-#: src/Preferences.cpp:880
+#: src/Preferences.cpp:907
 msgid "No languages available"
 msgstr "语言文件不可用"
 
-#: src/Preferences.cpp:1011
+#: src/Preferences.cpp:1038
 msgid "no options available"
 msgstr "选项不可用"
 
-#: src/Preferences.cpp:2182
+#: src/Preferences.cpp:2227
 msgid "Invalid category found, skipping"
 msgstr "发现无效的分类，跳过"
 
-#: src/Preferences.cpp:2351
+#: src/Preferences.cpp:2396
 msgid "TCP port can't be higher than 65532 due to server UDP socket being TCP+3"
 msgstr "TCP端口不可高于65532，因为服务器UDP端口值为TCP端口值+3"
 
-#: src/Preferences.cpp:2352
+#: src/Preferences.cpp:2397
 #, c-format
 msgid "Default port will be used (%d)"
 msgstr "缺省端口将被使用（%d）"
 
-#: src/PrefsUnifiedDlg.cpp:298 src/Statistics.cpp:866
+#: src/PrefsUnifiedDlg.cpp:300 src/Statistics.cpp:866
 msgid "Connection"
 msgstr "连接"
 
-#: src/PrefsUnifiedDlg.cpp:299 src/SearchListCtrl.cpp:117
+#: src/PrefsUnifiedDlg.cpp:301 src/SearchListCtrl.cpp:117
 msgid "Directories"
 msgstr "目录"
 
-#: src/PrefsUnifiedDlg.cpp:300 src/Statistics.cpp:917
+#: src/PrefsUnifiedDlg.cpp:302 src/Statistics.cpp:917
 msgid "Servers"
 msgstr "服务器"
 
-#: src/PrefsUnifiedDlg.cpp:301 src/ServerListCtrl.cpp:96
+#: src/PrefsUnifiedDlg.cpp:303 src/ServerListCtrl.cpp:96
 msgid "Files"
 msgstr "文件"
 
-#: src/PrefsUnifiedDlg.cpp:302
+#: src/PrefsUnifiedDlg.cpp:304
 msgid "Security"
 msgstr "安全"
 
-#: src/PrefsUnifiedDlg.cpp:303
+#: src/PrefsUnifiedDlg.cpp:305
 msgid "Interface"
 msgstr "界面"
 
-#: src/PrefsUnifiedDlg.cpp:310
+#: src/PrefsUnifiedDlg.cpp:312
 msgid "IP2Country"
 msgstr "IP2Country"
 
-#: src/PrefsUnifiedDlg.cpp:313
+#: src/PrefsUnifiedDlg.cpp:315
 msgid "Proxy"
 msgstr "代理"
 
-#: src/PrefsUnifiedDlg.cpp:314
+#: src/PrefsUnifiedDlg.cpp:316
 msgid "Filters"
 msgstr "过滤"
 
-#: src/PrefsUnifiedDlg.cpp:315
+#: src/PrefsUnifiedDlg.cpp:317
 msgid "Remote Controls"
 msgstr "远程控制"
 
-#: src/PrefsUnifiedDlg.cpp:316
+#: src/PrefsUnifiedDlg.cpp:318
 msgid "Online Signature"
 msgstr "在线签名"
 
-#: src/PrefsUnifiedDlg.cpp:317
+#: src/PrefsUnifiedDlg.cpp:319
 msgid "Advanced"
 msgstr "高级"
 
-#: src/PrefsUnifiedDlg.cpp:318
+#: src/PrefsUnifiedDlg.cpp:320
 msgid "Events"
 msgstr "事件"
 
-#: src/PrefsUnifiedDlg.cpp:321
+#: src/PrefsUnifiedDlg.cpp:323
 msgid "Debugging"
 msgstr "调试"
 
-#: src/PrefsUnifiedDlg.cpp:451
+#: src/PrefsUnifiedDlg.cpp:453
 msgid ""
 "The following variables will be substituted:\n"
 "    %PARTFILE - full path to the file\n"
@@ -5676,15 +5704,15 @@ msgstr ""
 "    %PARTFILE - 文件的完整路径\n"
 "    %PARTNAME - 仅文件名"
 
-#: src/PrefsUnifiedDlg.cpp:472
+#: src/PrefsUnifiedDlg.cpp:474
 msgid "Tray icon support requires libayatana-appindicator3 at compile time."
 msgstr "系统托盘图标支持在编译时需要 libayatana-appindicator3。"
 
-#: src/PrefsUnifiedDlg.cpp:488
+#: src/PrefsUnifiedDlg.cpp:490
 msgid "Not available on Wayland: the protocol does not report when a window is minimized, so this option cannot intercept the system minimize button. Workaround: launch aMule with `GDK_BACKEND=x11` to use XWayland instead."
 msgstr "在 Wayland 上不可用：该协议无法报告窗口何时被最小化，因此此选项无法拦截系统的最小化按钮。解决方法：使用 `GDK_BACKEND=x11` 启动 aMule，以改用 XWayland。"
 
-#: src/PrefsUnifiedDlg.cpp:534
+#: src/PrefsUnifiedDlg.cpp:536
 msgid ""
 "Do not change these setting unless you know\n"
 "what you are doing, otherwise you can easily\n"
@@ -5700,26 +5728,35 @@ msgstr ""
 "即使不改动这些设置，aMule\n"
 "也完全可以正常运行。"
 
-#: src/PrefsUnifiedDlg.cpp:645
+#: src/PrefsUnifiedDlg.cpp:647
 #, c-format
 msgid "Failed to connect Cfg to widget with the ID %d and key %s"
 msgstr "使用ID %d和密匙%s连接Cfg到小插件失败"
 
-#: src/PrefsUnifiedDlg.cpp:693
+#: src/PrefsUnifiedDlg.cpp:695
 #, c-format
 msgid "Failed to transfer data from Cfg to Widget with the ID %d and key %s"
 msgstr "通过ID %d和密匙%s把数据从Cfg转移到小插件失败"
 
-#: src/PrefsUnifiedDlg.cpp:799
+#: src/PrefsUnifiedDlg.cpp:801
 msgid "The type of proxy you are connecting to"
 msgstr "正在连接的代理服务器类型"
 
-#: src/PrefsUnifiedDlg.cpp:1003
+#: src/PrefsUnifiedDlg.cpp:1020
 #, c-format
 msgid "Failed to transfer data from Widget to Cfg with the ID %d and key %s"
 msgstr "通过ID %d和密匙%s把数据从小插件转移到Cfg失败"
 
 #: src/PrefsUnifiedDlg.cpp:1103
+#, fuzzy
+msgid "No password set."
+msgstr "管理密码"
+
+#: src/PrefsUnifiedDlg.cpp:1132
+msgid "Guest access needs a password. Type one in the guest password field, or untick Enable guest access."
+msgstr ""
+
+#: src/PrefsUnifiedDlg.cpp:1144
 msgid ""
 "aMule must be restarted to enable these changes:\n"
 "\n"
@@ -5727,39 +5764,39 @@ msgstr ""
 "重启aMule后这些更改才能生效：\n"
 "\n"
 
-#: src/PrefsUnifiedDlg.cpp:1110
+#: src/PrefsUnifiedDlg.cpp:1151
 msgid "- TCP port changed.\n"
 msgstr "- TCP端口已更改。\n"
 
-#: src/PrefsUnifiedDlg.cpp:1115
+#: src/PrefsUnifiedDlg.cpp:1156
 msgid "- UDP port changed.\n"
 msgstr "- UDP端口已更改。\n"
 
-#: src/PrefsUnifiedDlg.cpp:1120
+#: src/PrefsUnifiedDlg.cpp:1161
 msgid "- Network interface binding changed.\n"
 msgstr "- 更改了网络接口绑定.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1125
+#: src/PrefsUnifiedDlg.cpp:1166
 msgid "- External connect port changed.\n"
 msgstr "- 外部连接端口已更改。\n"
 
-#: src/PrefsUnifiedDlg.cpp:1129
+#: src/PrefsUnifiedDlg.cpp:1170
 msgid "- External connect acceptance changed.\n"
 msgstr "- 更改了外部连接接受。\n"
 
-#: src/PrefsUnifiedDlg.cpp:1133
+#: src/PrefsUnifiedDlg.cpp:1174
 msgid "- External connect interface changed.\n"
 msgstr "- 更改了外部连接接口。\n"
 
-#: src/PrefsUnifiedDlg.cpp:1137
+#: src/PrefsUnifiedDlg.cpp:1178
 msgid "- Protocol obfuscation support changed.\n"
 msgstr "- 模糊协议支持已更改。\n"
 
-#: src/PrefsUnifiedDlg.cpp:1151
+#: src/PrefsUnifiedDlg.cpp:1193
 msgid "- amuleapi settings changed.\n"
 msgstr "- amuleapi 设置已更改。\n"
 
-#: src/PrefsUnifiedDlg.cpp:1160
+#: src/PrefsUnifiedDlg.cpp:1202
 msgid ""
 "Your Auto-update server list is empty.\n"
 "'Auto-update server list at startup' will be disabled."
@@ -5767,7 +5804,7 @@ msgstr ""
 "您的自动更新服务器列表是可空的，\n"
 "启动时自动更新服务器列表功能将被禁用。"
 
-#: src/PrefsUnifiedDlg.cpp:1171
+#: src/PrefsUnifiedDlg.cpp:1213
 msgid ""
 "You have enabled external connections but have not specified a password.\n"
 "External connections cannot be enabled unless a valid password is specified."
@@ -5775,27 +5812,32 @@ msgstr ""
 "您已经启用了远程连接但还没有设置密码。\n"
 "远程连接在没有有效密码的情况下不能使用。"
 
-#: src/PrefsUnifiedDlg.cpp:1202
+#: src/PrefsUnifiedDlg.cpp:1246
+#, c-format
+msgid "The amuleapi password could not be saved: %s"
+msgstr ""
+
+#: src/PrefsUnifiedDlg.cpp:1276
 msgid "- Language changed.\n"
 msgstr "- 语言已更改。\n"
 
-#: src/PrefsUnifiedDlg.cpp:1207
+#: src/PrefsUnifiedDlg.cpp:1281
 msgid "- Temp folder changed.\n"
 msgstr "- 临时文件目录已更改。\n"
 
-#: src/PrefsUnifiedDlg.cpp:1212
+#: src/PrefsUnifiedDlg.cpp:1286
 msgid "- ED2K network enabled.\n"
 msgstr "-ED2K网络已启用。\n"
 
-#: src/PrefsUnifiedDlg.cpp:1245
+#: src/PrefsUnifiedDlg.cpp:1319
 msgid "The shared-file exclusion pattern is not a valid regular expression. The filter has been left disabled."
 msgstr "共享文件排除模式不是有效的正则表达式。已禁用该筛选器。"
 
-#: src/PrefsUnifiedDlg.cpp:1247 src/PrefsUnifiedDlg.cpp:1841
+#: src/PrefsUnifiedDlg.cpp:1321 src/PrefsUnifiedDlg.cpp:1921
 msgid "Invalid regular expression"
 msgstr "无效的正则表达式"
 
-#: src/PrefsUnifiedDlg.cpp:1324
+#: src/PrefsUnifiedDlg.cpp:1398
 msgid ""
 "Both eD2k and Kad network are disabled.\n"
 "You won't be able to connect until you enable at least one of them."
@@ -5803,7 +5845,7 @@ msgstr ""
 "eD2k 和 Kad 网络都已被禁用，\n"
 "你至少要启用其中的一项才能连接。"
 
-#: src/PrefsUnifiedDlg.cpp:1329
+#: src/PrefsUnifiedDlg.cpp:1403
 msgid ""
 "Kad will not start if your UDP port is disabled.\n"
 "Enable UDP port or disable Kad."
@@ -5811,7 +5853,7 @@ msgstr ""
 "如果你的 UDP 端口被禁用，Kad 将不能启动。\n"
 "启动 UDP 端口或禁用 Kad。"
 
-#: src/PrefsUnifiedDlg.cpp:1385
+#: src/PrefsUnifiedDlg.cpp:1459
 msgid ""
 "\n"
 "You MUST restart aMule now.\n"
@@ -5821,68 +5863,68 @@ msgstr ""
 "你必须现在重启aMule，\n"
 "如果现在不重启的话，出现任何问题可别怪别人。\n"
 
-#: src/PrefsUnifiedDlg.cpp:1450
+#: src/PrefsUnifiedDlg.cpp:1524
 msgid "Could not register aMule for autostart at login. The autostart store may be read-only."
 msgstr "无法将 aMule 注册为登录时自动启动。自动启动存储可能为只读。"
 
-#: src/PrefsUnifiedDlg.cpp:1452
+#: src/PrefsUnifiedDlg.cpp:1526
 msgid "Could not remove the autostart-at-login entry."
 msgstr "无法移除登录时自动启动的条目。"
 
-#: src/PrefsUnifiedDlg.cpp:1453
+#: src/PrefsUnifiedDlg.cpp:1527
 msgid "Autostart"
 msgstr "自启动"
 
-#: src/PrefsUnifiedDlg.cpp:1468
+#: src/PrefsUnifiedDlg.cpp:1542
 msgid "Register file type"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1468
+#: src/PrefsUnifiedDlg.cpp:1542
 msgid "Register URL handler"
 msgstr "注册URL处理程序"
 
-#: src/PrefsUnifiedDlg.cpp:1476
+#: src/PrefsUnifiedDlg.cpp:1550
 #, c-format
 msgid "aMule only handles eD2k-compatible magnets. If you replace the current magnet handler (%s), BitTorrent magnet links will stop working - aMule cannot download BitTorrent content. Continue?"
 msgstr "aMule 仅支持兼容 eD2k 的磁力链接。如果替换当前磁力链接处理程序（%s），BitTorrent 磁力链接将停止工作——aMule 无法下载 BitTorrent 内容。是否继续？"
 
-#: src/PrefsUnifiedDlg.cpp:1481
+#: src/PrefsUnifiedDlg.cpp:1555
 #, fuzzy, c-format
 msgid "Another application currently opens .emulecollection files (%s). Replace it with aMule?"
 msgstr "目前已存在另一个应用程序作为这些链接（%s) 的默认处理程序。是否要将其换成aMule？"
 
-#: src/PrefsUnifiedDlg.cpp:1486
+#: src/PrefsUnifiedDlg.cpp:1560
 #, c-format
 msgid "Another application is currently the default handler for these links (%s). Replace it with aMule?"
 msgstr "目前已存在另一个应用程序作为这些链接（%s) 的默认处理程序。是否要将其换成aMule？"
 
-#: src/PrefsUnifiedDlg.cpp:1511
+#: src/PrefsUnifiedDlg.cpp:1585
 #, fuzzy
 msgid "Could not register aMule for .emulecollection files. The registration store may be read-only."
 msgstr "无法将 aMule 注册为URL处理程序。自动启动存储可能为只读。"
 
-#: src/PrefsUnifiedDlg.cpp:1513
+#: src/PrefsUnifiedDlg.cpp:1587
 #, fuzzy
 msgid "Could not remove the file type registration."
 msgstr "无法移除URL处理程序的注册。"
 
-#: src/PrefsUnifiedDlg.cpp:1515
+#: src/PrefsUnifiedDlg.cpp:1589
 msgid "Could not register aMule as the URL handler. The registration store may be read-only."
 msgstr "无法将 aMule 注册为URL处理程序。自动启动存储可能为只读。"
 
-#: src/PrefsUnifiedDlg.cpp:1517
+#: src/PrefsUnifiedDlg.cpp:1591
 msgid "Could not remove the URL handler registration."
 msgstr "无法移除URL处理程序的注册。"
 
-#: src/PrefsUnifiedDlg.cpp:1587 src/PrefsUnifiedDlg.cpp:1614
+#: src/PrefsUnifiedDlg.cpp:1661 src/PrefsUnifiedDlg.cpp:1688
 msgid "The web server and aMule API require external connections to be enabled."
 msgstr "启用 web 服务器和 aMule API 需要外部连接。"
 
-#: src/PrefsUnifiedDlg.cpp:1597
+#: src/PrefsUnifiedDlg.cpp:1671
 msgid "The aMule web server is deprecated. Consider running the aMule API instead."
 msgstr "aMule Web 服务器已弃用。请考虑运行 aMule API。"
 
-#: src/PrefsUnifiedDlg.cpp:1655
+#: src/PrefsUnifiedDlg.cpp:1735
 msgid ""
 "Your Auto-update servers list is in blank.\n"
 "Please fill in at least one URL to point to a valid server.met file.\n"
@@ -5892,64 +5934,64 @@ msgstr ""
 "请输入至少一个指向有效 server.met 的网址，\n"
 "点击这个勾选框旁边的\"列表\"按钮然后输入网址。"
 
-#: src/PrefsUnifiedDlg.cpp:1796
+#: src/PrefsUnifiedDlg.cpp:1876
 msgid "Temporary files"
 msgstr "临时文件"
 
-#: src/PrefsUnifiedDlg.cpp:1801
+#: src/PrefsUnifiedDlg.cpp:1881
 msgid "Incoming files"
 msgstr "传入文件"
 
-#: src/PrefsUnifiedDlg.cpp:1806
+#: src/PrefsUnifiedDlg.cpp:1886
 msgid "Online Signatures"
 msgstr "在线签名"
 
-#: src/PrefsUnifiedDlg.cpp:1819
+#: src/PrefsUnifiedDlg.cpp:1899
 #, c-format
 msgid "Choose a folder for %s"
 msgstr "为%s选择文件夹"
 
-#: src/PrefsUnifiedDlg.cpp:1843
+#: src/PrefsUnifiedDlg.cpp:1923
 #, c-format
 msgid "Would exclude %u of %u shared file"
 msgid_plural "Would exclude %u of %u shared files"
 msgstr[0] "将排除 %u 个共享文件，共 %u 个"
 msgstr[1] "将排除 %u 个共享文件，共 %u 个"
 
-#: src/PrefsUnifiedDlg.cpp:1860
+#: src/PrefsUnifiedDlg.cpp:1940
 msgid "Browse for videoplayer"
 msgstr "浏览寻找视频播放器"
 
-#: src/PrefsUnifiedDlg.cpp:1864
+#: src/PrefsUnifiedDlg.cpp:1944
 msgid "Select browser"
 msgstr "选择浏览器"
 
-#: src/PrefsUnifiedDlg.cpp:1868
+#: src/PrefsUnifiedDlg.cpp:1948
 msgid "Select ffprobe binary"
 msgstr "选择 ffprobe 文件"
 
-#: src/PrefsUnifiedDlg.cpp:1874
+#: src/PrefsUnifiedDlg.cpp:1954
 #, c-format
 msgid "Executable%s"
 msgstr "可执行%s"
 
-#: src/PrefsUnifiedDlg.cpp:1908
+#: src/PrefsUnifiedDlg.cpp:1988
 msgid "ffprobe not found on PATH or in the standard install locations. Install ffmpeg (which ships ffprobe) or use Browse to pick a binary manually."
 msgstr "未在 PATH 或标准安装位置找到 ffprobe。安装 ffmpeg（ffmpeg 自带 ffprobe），或使用“浏览”手动选择一个二进制文件。"
 
-#: src/PrefsUnifiedDlg.cpp:1920
+#: src/PrefsUnifiedDlg.cpp:2000
 msgid "Reset the settings on this page to their default values?"
 msgstr "重置此页面设置为默认值?"
 
-#: src/PrefsUnifiedDlg.cpp:1921
+#: src/PrefsUnifiedDlg.cpp:2001
 msgid "Reset to defaults"
 msgstr "重置为默认"
 
-#: src/PrefsUnifiedDlg.cpp:1948
+#: src/PrefsUnifiedDlg.cpp:2028
 msgid "Edit server list"
 msgstr "编辑服务器列表"
 
-#: src/PrefsUnifiedDlg.cpp:1949
+#: src/PrefsUnifiedDlg.cpp:2029
 msgid ""
 "Add here URL's to download server.met files.\n"
 "Only one url on each line."
@@ -5957,114 +5999,114 @@ msgstr ""
 "在此添加下载 server.met 文件的地址\n"
 "每行只限一个。"
 
-#: src/PrefsUnifiedDlg.cpp:2004
+#: src/PrefsUnifiedDlg.cpp:2084
 msgid "IP2Country update failed"
 msgstr "IP2Country 更新失败"
 
-#: src/PrefsUnifiedDlg.cpp:2149 src/PrefsUnifiedDlg.cpp:2180
+#: src/PrefsUnifiedDlg.cpp:2229 src/PrefsUnifiedDlg.cpp:2260
 msgid "Data by MaxMind GeoLite2"
 msgstr "数据来自 MaxMind GeoLite2"
 
-#: src/PrefsUnifiedDlg.cpp:2151 src/PrefsUnifiedDlg.cpp:2182
+#: src/PrefsUnifiedDlg.cpp:2231 src/PrefsUnifiedDlg.cpp:2262
 msgid "Custom source"
 msgstr "自定义源"
 
-#: src/PrefsUnifiedDlg.cpp:2153 src/PrefsUnifiedDlg.cpp:2184
+#: src/PrefsUnifiedDlg.cpp:2233 src/PrefsUnifiedDlg.cpp:2264
 msgid "Data by DB-IP.com"
 msgstr "数据来源：DB-IP.com"
 
-#: src/PrefsUnifiedDlg.cpp:2204
+#: src/PrefsUnifiedDlg.cpp:2284
 #, c-format
 msgid "Status: Loaded%s"
 msgstr "状态：已加载%s"
 
-#: src/PrefsUnifiedDlg.cpp:2206
+#: src/PrefsUnifiedDlg.cpp:2286
 #, c-format
 msgid "Status: Loaded%s - %s"
 msgstr "状态：已加载%s~%s"
 
-#: src/PrefsUnifiedDlg.cpp:2210
+#: src/PrefsUnifiedDlg.cpp:2290
 msgid "Status: Failed to load - click 'Update now' to refresh."
 msgstr "状态：加载失败 - 点击“立即更新”以刷新。"
 
-#: src/PrefsUnifiedDlg.cpp:2212
+#: src/PrefsUnifiedDlg.cpp:2292
 msgid "Status: Not found - click 'Update now' to download."
 msgstr "状态：未找到 - 点击“立即更新”进行下载。"
 
-#: src/PrefsUnifiedDlg.cpp:2270 src/PrefsUnifiedDlg.cpp:2294
+#: src/PrefsUnifiedDlg.cpp:2350 src/PrefsUnifiedDlg.cpp:2374
 #, c-format
 msgid "Update delay: %d second"
 msgid_plural "Update delay: %d seconds"
 msgstr[0] "更新延迟：%d秒"
 msgstr[1] "更新延迟：%d秒"
 
-#: src/PrefsUnifiedDlg.cpp:2278
+#: src/PrefsUnifiedDlg.cpp:2358
 #, c-format
 msgid "Time for average graph: %d minute"
 msgid_plural "Time for average graph: %d minutes"
 msgstr[0] "平均值图表显示时间：%d分钟"
 msgstr[1] "平均值图表显示时间：%d分钟"
 
-#: src/PrefsUnifiedDlg.cpp:2287
+#: src/PrefsUnifiedDlg.cpp:2367
 #, c-format
 msgid "Connections Graph Scale: %d"
 msgstr "网络连接图表缩放：%d"
 
-#: src/PrefsUnifiedDlg.cpp:2302
+#: src/PrefsUnifiedDlg.cpp:2382
 #, c-format
 msgid "File Buffer Size: %d byte"
 msgid_plural "File Buffer Size: %d bytes"
 msgstr[0] "文件缓冲区大小：%d字节"
 msgstr[1] "文件缓冲区大小：%d字节"
 
-#: src/PrefsUnifiedDlg.cpp:2312
+#: src/PrefsUnifiedDlg.cpp:2392
 #, c-format
 msgid "Upload Queue Size: %d client"
 msgid_plural "Upload Queue Size: %d clients"
 msgstr[0] "上传队列长度：%d个用户"
 msgstr[1] "上传队列长度：%d个用户"
 
-#: src/PrefsUnifiedDlg.cpp:2322
+#: src/PrefsUnifiedDlg.cpp:2402
 #, c-format
 msgid "Server connection refresh interval: %d minute"
 msgid_plural "Server connection refresh interval: %d minutes"
 msgstr[0] "服务器连接刷新周期：%d分钟"
 msgstr[1] "服务器连接刷新周期：%d分钟"
 
-#: src/PrefsUnifiedDlg.cpp:2327
+#: src/PrefsUnifiedDlg.cpp:2407
 msgid "Server connection refresh interval: Disabled"
 msgstr "服务器连接刷新周期：已禁用"
 
-#: src/PrefsUnifiedDlg.cpp:2371
+#: src/PrefsUnifiedDlg.cpp:2451
 msgid "disabled"
 msgstr "禁用"
 
-#: src/PrefsUnifiedDlg.cpp:2397
+#: src/PrefsUnifiedDlg.cpp:2477
 #, c-format
 msgid "Execute command on '%s' event"
 msgstr "在“%s”事件时执行命令"
 
-#: src/PrefsUnifiedDlg.cpp:2404
+#: src/PrefsUnifiedDlg.cpp:2484
 msgid "Enable command execution on core"
 msgstr "在核心启用执行命令"
 
-#: src/PrefsUnifiedDlg.cpp:2416
+#: src/PrefsUnifiedDlg.cpp:2496
 msgid "Core command:"
 msgstr "核心命令："
 
-#: src/PrefsUnifiedDlg.cpp:2432
+#: src/PrefsUnifiedDlg.cpp:2512
 msgid "Enable command execution on GUI"
 msgstr "在图形界面端启用执行命令"
 
-#: src/PrefsUnifiedDlg.cpp:2444
+#: src/PrefsUnifiedDlg.cpp:2524
 msgid "GUI command:"
 msgstr "图形界面命令："
 
-#: src/PrefsUnifiedDlg.cpp:2460
+#: src/PrefsUnifiedDlg.cpp:2540
 msgid "The following variables will be replaced:"
 msgstr "以下变量将被替换："
 
-#: src/PrefsUnifiedDlg.cpp:2628
+#: src/PrefsUnifiedDlg.cpp:2708
 msgid ""
 "The following folders look like system or sensitive locations:\n"
 "\n"
@@ -6072,37 +6114,37 @@ msgstr ""
 "以下文件夹看起来像是系统或敏感位置：\n"
 "\n"
 
-#: src/PrefsUnifiedDlg.cpp:2633
+#: src/PrefsUnifiedDlg.cpp:2713
 msgid "Sharing them recursively will publish every file underneath on the eD2k/Kad networks. Do you really want to do this?"
 msgstr "递归共享会将每个子文件发布到 eD2k/Kad 网络上。您确定要这样做吗？"
 
-#: src/PrefsUnifiedDlg.cpp:2636
+#: src/PrefsUnifiedDlg.cpp:2716
 msgid "Confirm shared folders"
 msgstr "确认共享的文件夹"
 
-#: src/PrefsUnifiedDlg.cpp:2664
+#: src/PrefsUnifiedDlg.cpp:2744
 msgid "Reloading shared files..."
 msgstr "正重新加载共享文件..."
 
-#: src/PrefsUnifiedDlg.cpp:2665
+#: src/PrefsUnifiedDlg.cpp:2745
 msgid "Scanning for subdirectories..."
 msgstr "正在扫描子目录..."
 
-#: src/PrefsUnifiedDlg.cpp:2666
+#: src/PrefsUnifiedDlg.cpp:2746
 msgid "Updating shared folders"
 msgstr "正在上传共享的文件夹"
 
-#: src/PrefsUnifiedDlg.cpp:2693
+#: src/PrefsUnifiedDlg.cpp:2773
 #, c-format
 msgid "Scanned %u directories..."
 msgstr "已扫描 %u 个目录......"
 
-#: src/PrefsUnifiedDlg.cpp:2743
+#: src/PrefsUnifiedDlg.cpp:2823
 #, c-format
 msgid "Reloading shared files: %u files scanned"
 msgstr "正重新加载共享文件：扫描了 %u 个文件"
 
-#: src/PrefsUnifiedDlg.cpp:2793
+#: src/PrefsUnifiedDlg.cpp:2873
 msgid "Shared folder"
 msgstr "共享的文件夹"
 

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -13,8 +13,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-28 12:12+0200\n"
-"PO-Revision-Date: 2026-07-27 10:37+0000\n"
+"POT-Creation-Date: 2026-07-28 08:06+0200\n"
+"PO-Revision-Date: 2026-07-27 11:48+0000\n"
 "Last-Translator: Mike Akiba <mike2718@gmail.com>\n"
 "Language-Team: Chinese Simplified <kde-i18n-doc@kde.org>\n"
 "Language: zh_CN\n"
@@ -147,7 +147,7 @@ msgstr "安装"
 msgid "Not now"
 msgstr "不是现在"
 
-#: src/AppImageIntegration.cpp:422 src/amuleDlg.cpp:665
+#: src/AppImageIntegration.cpp:422 src/amuleDlg.cpp:600
 msgid "Don't ask again"
 msgstr "不要再提醒我"
 
@@ -209,83 +209,83 @@ msgstr "打开 ED2K 链接文件失败。"
 msgid "WARNING: You can't add yourself as a source for an eD2k link while having a lowid."
 msgstr "警告：在 Low ID 的情况下，你不能添加自己作为 ed2k 链接的源。"
 
-#: src/amule.cpp:301
+#: src/amule.cpp:300
 msgid "Now, exiting main app..."
 msgstr "现在，正在退出主程序..."
 
-#: src/amule.cpp:331
+#: src/amule.cpp:330
 #, c-format
 msgid "Terminating amuleweb instance with pid '%d' ... "
 msgstr "正在终止 pid 为“%d”的 amuleweb 实例 ... "
 
-#: src/amule.cpp:335
+#: src/amule.cpp:334
 #, c-format
 msgid "Killing amuleweb instance with pid '%d' ... "
 msgstr "正在终止 pid 为“%d”的 amuleweb 实例 ... "
 
-#: src/amule.cpp:337 src/amule.cpp:350 src/ClientRef.cpp:180
-#: src/SearchDlg.cpp:1041 src/ServerListCtrl.cpp:98
+#: src/amule.cpp:336 src/amule.cpp:349 src/ClientRef.cpp:180
+#: src/SearchDlg.cpp:880 src/ServerListCtrl.cpp:98
 msgid "Failed"
 msgstr "失败"
 
-#: src/amule.cpp:344
+#: src/amule.cpp:343
 #, c-format
 msgid "Terminating amuleapi instance with pid '%d' ... "
 msgstr "正在终止 pid 为“%d”的 amuleapi 实例 ... "
 
-#: src/amule.cpp:348
+#: src/amule.cpp:347
 #, c-format
 msgid "Killing amuleapi instance with pid '%d' ... "
 msgstr "正在终止 pid 为“%d”的 amuleapi 实例 ... "
 
-#: src/amule.cpp:356
+#: src/amule.cpp:355
 msgid "aMule OnExit: Terminating core."
 msgstr "aMule 正在退出：中止内核。"
 
-#: src/amule.cpp:467
+#: src/amule.cpp:466
 msgid "aMule shutdown completed."
 msgstr "aMule 已经关闭。"
 
-#: src/amule.cpp:471
+#: src/amule.cpp:470
 msgid "Memory debug results for aMule exit:"
 msgstr "对 aMule 退出的内存 Debug 结果："
 
-#: src/amule.cpp:652
+#: src/amule.cpp:651
 #, c-format
 msgid "Binding aMule's peer-to-peer traffic to interface: %s (HTTP updates use the default route)"
 msgstr "将 amule 的 p2p 流量绑定到接口：%s（HTTP 流量使用默认路由）"
 
-#: src/amule.cpp:656
+#: src/amule.cpp:655
 #, c-format
 msgid "Binding all network traffic to interface: %s"
 msgstr "将所有网络流量绑定到接口：%s"
 
-#: src/amule.cpp:660
+#: src/amule.cpp:659
 #, c-format
 msgid "WARNING: configured network interface '%s' was not found - traffic is NOT bound to it and may leave via the default route. Check the interface name in Preferences."
 msgstr "警告：未找到配置的网络接口'%s' - 流量未绑定到该接口，可能通过默认路由离开。 在设置中检查接口名。"
 
-#: src/amule.cpp:666
+#: src/amule.cpp:665
 #, c-format
 msgid "WARNING: binding to network interface '%s' requires elevated privileges and was NOT applied - traffic may leave via the default route. Grant the capability (e.g. 'sudo setcap cap_net_raw+ep' on the aMule binary) or run with sufficient privileges."
 msgstr "警告：绑定到网络接口“%s”需要提升权限，但未成功 - 流量可能通过默认路由离开。请授予相应权限（例如，在 aMule 二进制文件上运行“sudo setcap cap_net_raw+ep”），或以足够的权限运行命令。"
 
-#: src/amule.cpp:674
+#: src/amule.cpp:673
 #, c-format
 msgid "WARNING: could not bind to network interface '%s' - traffic may leave via the default route."
 msgstr "警告：无法绑定到网络接口“%s” − 流量可能经默认路由离开。"
 
-#: src/amule.cpp:733
+#: src/amule.cpp:732
 msgid "Your locale has been changed to System Default due to a configuration change. Sorry."
 msgstr "对不起，由于配置变动，您的地区设置已经变为系统默认值。"
 
-#: src/amule.cpp:735 src/amule.cpp:1589 src/CatDialog.cpp:128
+#: src/amule.cpp:734 src/amule.cpp:1581 src/CatDialog.cpp:128
 #: src/CatDialog.cpp:136 src/CatDialog.cpp:149 src/ServerList.cpp:366
 #: src/ServerListCtrl.cpp:152
 msgid "Info"
 msgstr "信息"
 
-#: src/amule.cpp:742
+#: src/amule.cpp:741
 msgid ""
 "\n"
 "EC configuration"
@@ -293,20 +293,20 @@ msgstr ""
 "\n"
 "EC 配置"
 
-#: src/amule.cpp:745
+#: src/amule.cpp:744
 msgid "Password set and external connections enabled."
 msgstr "密码已设置，启用远程连接。"
 
-#: src/amule.cpp:755 src/KadDlg.cpp:176 src/KadDlg.cpp:185
-#: src/PrefsUnifiedDlg.cpp:1461 src/SharedFilesCtrl.cpp:476
+#: src/amule.cpp:754 src/KadDlg.cpp:176 src/KadDlg.cpp:185
+#: src/PrefsUnifiedDlg.cpp:1387 src/SharedFilesCtrl.cpp:476
 msgid "WARNING"
 msgstr "警告"
 
-#: src/amule.cpp:992
+#: src/amule.cpp:991
 msgid "Network bootstrap"
 msgstr "网络引导"
 
-#: src/amule.cpp:997
+#: src/amule.cpp:996
 msgid ""
 "aMule has detected missing network bootstrap files.\n"
 "Select which ones to download:"
@@ -314,51 +314,51 @@ msgstr ""
 "aMule 检测到缺少网络引导文件。\n"
 "请选择需要下载的文件："
 
-#: src/amule.cpp:1006 src/FirstRunWizard.cpp:411
+#: src/amule.cpp:1005 src/FirstRunWizard.cpp:411
 msgid "eD2k server list (server.met)"
 msgstr "eD2k 服务器列表 (server.met)"
 
-#: src/amule.cpp:1013 src/FirstRunWizard.cpp:416
+#: src/amule.cpp:1012 src/FirstRunWizard.cpp:416
 msgid "Kad bootstrap nodes (nodes.dat)"
 msgstr "Kad 引导节点 (nodes.dat)"
 
-#: src/amule.cpp:1103
+#: src/amule.cpp:1102
 #, c-format
 msgid "web server running on pid %d"
 msgstr "web 服务器正在运行，pid 为 %d"
 
-#: src/amule.cpp:1116
+#: src/amule.cpp:1115
 msgid "You requested to run web server on startup, but the amuleweb binary cannot be run. Please install the package containing aMule web server, or build aMule from source with -DBUILD_WEBSERVER=YES and install it."
 msgstr "您要求启动时运行 Web 服务器，但 amuleweb 程序无法运行， 请先安装包含 amule web 服务器的 aMule 包，或者使用 -DBUILD_WEBSERVER=YES 选项从源码构建 aMule 并安装它。"
 
-#: src/amule.cpp:1121 src/amule.cpp:1185 src/amule.cpp:1299 src/amule.cpp:1601
+#: src/amule.cpp:1120 src/amule.cpp:1177 src/amule.cpp:1291 src/amule.cpp:1593
 #: src/amule-remote-gui.cpp:603 src/amule-remote-gui.cpp:671
 #: src/amule-remote-gui.cpp:709 src/amule-remote-gui.cpp:1282
 #: src/amule-remote-gui.cpp:1345 src/amule-remote-gui.cpp:1372
-#: src/DownloadQueue.cpp:1481 src/PrefsUnifiedDlg.cpp:1247
+#: src/DownloadQueue.cpp:1481
 msgid "ERROR"
 msgstr "错误"
 
-#: src/amule.cpp:1174
+#: src/amule.cpp:1166
 #, c-format
 msgid "amuleapi running on pid %d"
 msgstr "amuleapi 正在运行，pid 为 %d"
 
-#: src/amule.cpp:1180
+#: src/amule.cpp:1172
 msgid "You requested to run amuleapi on startup, but the amuleapi binary cannot be run. Please install the package containing aMule's REST API server, or build aMule from source with -DBUILD_AMULEAPI=YES and install it."
 msgstr "您要求启动时运行 amuleapi，但 amuleapi 程序无法运行， 请先安装包含 amule REST API 服务器的 包，或者使用 -DBUILD_AMULEAPI=YES 选项从源码构建 aMule 并安装它。"
 
-#: src/amule.cpp:1267
+#: src/amule.cpp:1259
 #, c-format
 msgid "Could not bind ports to the specified address: %s"
 msgstr "无法绑定端口到指定的地址：%s"
 
-#: src/amule.cpp:1291
+#: src/amule.cpp:1283
 #, c-format
 msgid "Port %u is not available. You will be LOWID\n"
 msgstr "端口 %u 不可用，你会成为 Low ID\n"
 
-#: src/amule.cpp:1296
+#: src/amule.cpp:1288
 #, c-format
 msgid ""
 "Port %u is not available!\n"
@@ -373,48 +373,48 @@ msgstr ""
 "\n"
 "请检测网络设置以确保端口可用于输入输出。"
 
-#: src/amule.cpp:1393
+#: src/amule.cpp:1385
 msgid "Failed to create OnlineSig File"
 msgstr "创建在线统计文件失败"
 
-#: src/amule.cpp:1401
+#: src/amule.cpp:1393
 msgid "Failed to create aMule OnlineSig File"
 msgstr "创建 aMule 在线统计文件失败"
 
-#: src/amule.cpp:1564
+#: src/amule.cpp:1556
 msgid "The selected locale seems not to be installed on your box. (Note: I'll try to set it anyway)"
 msgstr "您所选择的地区设置在您的计算机上似乎没有安装。(注意：我还是会尝试您所选择的地区设置。)"
 
-#: src/amule.cpp:1574
+#: src/amule.cpp:1566
 #, c-format
 msgid "This is the first time you run aMule %s"
 msgstr "这是您第一次运行 aMule %s"
 
-#: src/amule.cpp:1577
+#: src/amule.cpp:1569
 msgid "This version is a testing version, updated daily, and\n"
 msgstr "此版本是测试版，更新频繁， \n"
 
-#: src/amule.cpp:1578
+#: src/amule.cpp:1570
 msgid "we give no warranty it won't break anything, burn your house,\n"
 msgstr "我们无法承诺它不会损坏任何东西，烧毁您的房子，\n"
 
-#: src/amule.cpp:1579
+#: src/amule.cpp:1571
 msgid "or kill your dog. But it *should* be safe to use anyway.\n"
 msgstr "或杀死你的狗，但 * 一般来讲 * 它应该是安全的。\n"
 
-#: src/amule.cpp:1584
+#: src/amule.cpp:1576
 msgid "More information, support and new releases can found at our homepage,\n"
 msgstr "如要获取使用信息、用户支持以及下载最新版本，请访问我们的首页\n"
 
-#: src/amule.cpp:1585
+#: src/amule.cpp:1577
 msgid "at https://amule-org.github.io, or in our IRC channel #aMule at irc.libera.chat.\n"
 msgstr "https://amule-org.github.io，或进入我们在 irc.libera.chat 的 IRC 频道 #aMule。\n"
 
-#: src/amule.cpp:1587
+#: src/amule.cpp:1579
 msgid "Feel free to report any bugs to https://github.com/amule-org/amule/issues"
 msgstr "欢迎您到 https://github.com/amule-org/amule/issues 去提交错误报告"
 
-#: src/amule.cpp:1599
+#: src/amule.cpp:1591
 msgid ""
 "The folder for Online Signature files you specified is INVALID!\n"
 " OnlineSignature will be DISABLED until you fix it on preferences."
@@ -422,137 +422,137 @@ msgstr ""
 "您为在线统计文件所选择的文件夹无效！\n"
 "在您更正设置之前在线统计将被禁用。"
 
-#: src/amule.cpp:1662
+#: src/amule.cpp:1654
 msgid "Server hostname notified"
 msgstr "获取服务器名称"
 
-#: src/amule.cpp:2039
+#: src/amule.cpp:2031
 #, c-format
 msgid "Disk space preallocation for file '%s' failed: %s"
 msgstr "为文件 '%s' 预分配磁盘空间失败：%s"
 
-#: src/amule.cpp:2168
+#: src/amule.cpp:2160
 msgid "ERROR: can't open logfile"
 msgstr "错误：无法打开日志文件"
 
-#: src/amule.cpp:2172
+#: src/amule.cpp:2164
 msgid "WARNING: logfile is empty. Something is wrong."
 msgstr "警告：日志文件为空。肯定有什么地方出错了。"
 
-#: src/amule.cpp:2189
+#: src/amule.cpp:2181
 msgid "Log has been reset"
 msgstr "记录文件已被重置"
 
-#: src/amule.cpp:2213
+#: src/amule.cpp:2205
 #, c-format
 msgid "ServerMessage: %s"
 msgstr "服务器消息：%s"
 
-#: src/amule.cpp:2256 src/IP2Country.cpp:220 src/IPFilter.cpp:514
+#: src/amule.cpp:2248 src/IP2Country.cpp:220 src/IPFilter.cpp:514
 #: src/ServerList.cpp:875
 #, c-format
 msgid "Skipped download of %s, because requested file is not newer."
 msgstr "跳过下载%s，因为请求的文件不是最新的。"
 
-#: src/amule.cpp:2259
+#: src/amule.cpp:2251
 msgid "Failed to download the nodes list."
 msgstr "下载节点列表失败。"
 
-#: src/amule.cpp:2322
+#: src/amule.cpp:2314
 msgid "Failed to open the downloaded version check file"
 msgstr "打开已下载的版本检查文件失败"
 
-#: src/amule.cpp:2325 src/amule.cpp:2344
+#: src/amule.cpp:2317 src/amule.cpp:2336
 msgid "Corrupted version check file"
 msgstr "损坏的版本检查文件"
 
-#: src/amule.cpp:2367
+#: src/amule.cpp:2359
 msgid "You are using an outdated version of aMule!"
 msgstr "您使用的是老版本的aMule！"
 
-#: src/amule.cpp:2369
+#: src/amule.cpp:2361
 #, c-format
 msgid "Your aMule version is %i.%i.%i and the latest version is %li.%li.%li"
 msgstr "您的 aMule 版本是 %i.%i.%i，最新版本是 %li.%li.%li"
 
-#: src/amule.cpp:2373
+#: src/amule.cpp:2365
 msgid "The latest version can always be found at https://github.com/amule-org/amule/releases/latest"
 msgstr "最新版本可从这里下载：https://github.com/amule-org/amule/releases/latest"
 
-#: src/amule.cpp:2376
+#: src/amule.cpp:2368
 #, c-format
 msgid "WARNING: Your aMuled version is outdated: %i.%i.%i < %li.%li.%li"
 msgstr "警告：您的 aMuled 版本太旧：%i.%i.%i < %li.%li.%li"
 
-#: src/amule.cpp:2382
+#: src/amule.cpp:2374
 msgid "Your copy of aMule is up to date."
 msgstr "您的aMule是最新版本。"
 
-#: src/amule.cpp:2389
+#: src/amule.cpp:2381
 msgid "Failed to download the version check file"
 msgstr "下载版本检查文件失败"
 
-#: src/amule.cpp:2558 src/amule-remote-gui.cpp:1133
+#: src/amule.cpp:2550 src/amule-remote-gui.cpp:1133
 #, c-format
 msgid "Users: %s | Files: %s"
 msgstr "用户：%s | 文件：%s"
 
-#: src/amule.cpp:2559 src/amule-remote-gui.cpp:1134
+#: src/amule.cpp:2551 src/amule-remote-gui.cpp:1134
 #, c-format
 msgid "Users: E: %s K: %s | Files: E: %s K: %s"
 msgstr "用户：E：%s K：%s | 文件：E：%s K：%s"
 
-#: src/amule.cpp:2573 src/amule-remote-gui.cpp:1147
+#: src/amule.cpp:2565 src/amule-remote-gui.cpp:1147
 msgid "No networks selected"
 msgstr "没有选择网络"
 
-#: src/amule.cpp:2641 src/TextClient.cpp:903
+#: src/amule.cpp:2633 src/TextClient.cpp:903
 msgid "with LowID"
 msgstr "是 Low ID"
 
-#: src/amule.cpp:2641 src/TextClient.cpp:904
+#: src/amule.cpp:2633 src/TextClient.cpp:904
 msgid "with HighID"
 msgstr "是 High ID"
 
-#: src/amule.cpp:2643
+#: src/amule.cpp:2635
 #, c-format
 msgid "Connected to %s %s"
 msgstr "已连接到 %s %s"
 
-#: src/amule.cpp:2648
+#: src/amule.cpp:2640
 #, c-format
 msgid "Connecting to %s"
 msgstr "正在连接到 %s"
 
-#: src/amule.cpp:2650
+#: src/amule.cpp:2642
 msgid "Disconnected from eD2k"
 msgstr "已从 eD2k 断开"
 
-#: src/amule.cpp:2659
+#: src/amule.cpp:2651
 msgid "Kad started."
 msgstr "Kad 已启动。"
 
-#: src/amule.cpp:2661
+#: src/amule.cpp:2653
 msgid "Kad stopped."
 msgstr "Kad 已停止。"
 
-#: src/amule.cpp:2669
+#: src/amule.cpp:2661
 msgid "Connected to Kad (ok)"
 msgstr "已连接至 Kad (ok）"
 
-#: src/amule.cpp:2671
+#: src/amule.cpp:2663
 msgid "Connected to Kad (firewalled)"
 msgstr "已连接至 Kad 网络 (有防火墙)"
 
-#: src/amule.cpp:2675
+#: src/amule.cpp:2667
 msgid "Disconnected from Kad"
 msgstr "已断开 Kad 连接"
 
-#: src/amule.cpp:2707
+#: src/amule.cpp:2699
 msgid "Kad network cannot be used if UDP port is disabled on preferences, not starting."
 msgstr "如果在设置中禁用了 UDP 端口，Kad 网络将不能使用，没有启动。"
 
-#: src/amule.cpp:2711
+#: src/amule.cpp:2703
 msgid "Kad network disabled on preferences, not connecting."
 msgstr "Kad 网络在设置中被禁用了，没有连接。"
 
@@ -577,67 +577,29 @@ msgstr "不能创建 Pid 文件"
 msgid "ERROR: %s"
 msgstr "错误：%s"
 
-#: src/amuleDlg.cpp:250
+#: src/amuleDlg.cpp:236
 #, c-format
 msgid "This is aMule %s based on eMule."
 msgstr "这是基于 eMule 的 aMule %s。"
 
-#: src/amuleDlg.cpp:251
+#: src/amuleDlg.cpp:237
 #, c-format
 msgid "Running on %s"
 msgstr "运行于 %s"
 
-#: src/amuleDlg.cpp:253
+#: src/amuleDlg.cpp:239
 msgid "Visit https://github.com/amule-org/amule/releases/latest to check if a new version is available."
 msgstr "访问 https://github.com/amule-org/amule/releases/latest 来检查 是否有新版本。"
 
-#: src/amuleDlg.cpp:282
+#: src/amuleDlg.cpp:268
 msgid "FATAL ERROR: Failed to create Timer"
 msgstr "致命错误：创建计时器失败"
 
-#: src/amuleDlg.cpp:361 src/amuleDlg.cpp:1810 src/amuleDlg.cpp:2056
-#: src/muuli_wdr.cpp:1492 src/muuli_wdr.cpp:3439
-msgid "Networks"
-msgstr "网络"
-
-#: src/amuleDlg.cpp:362 src/amuleDlg.cpp:1816 src/muuli_wdr.cpp:3440
-msgid "Searches"
-msgstr "搜索"
-
-#: src/amuleDlg.cpp:363 src/amuleDlg.cpp:1822 src/DownloadListCtrl.cpp:740
-#: src/muuli_wdr.cpp:392 src/muuli_wdr.cpp:1585 src/muuli_wdr.cpp:3441
-#: src/Statistics.cpp:829
-msgid "Downloads"
-msgstr "下载"
-
-#: src/amuleDlg.cpp:364 src/amuleDlg.cpp:1828 src/muuli_wdr.cpp:3315
-msgid "Shared files"
-msgstr "共享文件"
-
-#: src/amuleDlg.cpp:365 src/amuleDlg.cpp:1834 src/muuli_wdr.cpp:2947
-#: src/muuli_wdr.cpp:3397 src/muuli_wdr.cpp:3444
-msgid "Messages"
-msgstr "消息"
-
-#: src/amuleDlg.cpp:366 src/amuleDlg.cpp:1840 src/muuli_wdr.cpp:3445
-#: src/PrefsUnifiedDlg.cpp:314 src/Statistics.cpp:779 src/Statistics.cpp:1235
-msgid "Statistics"
-msgstr "统计"
-
-#: src/amuleDlg.cpp:368 src/amuleDlg.cpp:1847 src/muuli_wdr.cpp:3447
-#: src/PrefsUnifiedDlg.cpp:330 src/utils/wxCas/src/wxcasprefs.cpp:39
-msgid "Preferences"
-msgstr "设置"
-
-#: src/amuleDlg.cpp:371
-msgid "Navigate"
-msgstr ""
-
-#: src/amuleDlg.cpp:657
+#: src/amuleDlg.cpp:592
 msgid "New version available"
 msgstr "有新版"
 
-#: src/amuleDlg.cpp:661
+#: src/amuleDlg.cpp:596
 #, c-format
 msgid ""
 "A new version of aMule (%s) is available.\n"
@@ -652,184 +614,217 @@ msgstr ""
 "\n"
 "要打开下载页吗？"
 
-#: src/amuleDlg.cpp:743
+#: src/amuleDlg.cpp:678
 msgid "aMule dialog destroyed"
 msgstr "aMule 对话框损坏"
 
-#: src/amuleDlg.cpp:766 src/DataToText.cpp:68 src/IPFilter.cpp:547
+#: src/amuleDlg.cpp:701 src/DataToText.cpp:68 src/IPFilter.cpp:547
 msgid "Connecting"
 msgstr "正在连接"
 
-#: src/amuleDlg.cpp:958
+#: src/amuleDlg.cpp:893
 msgid "eD2k: Connecting"
 msgstr "eD2k: 正在连接"
 
-#: src/amuleDlg.cpp:962
+#: src/amuleDlg.cpp:897
 msgid "eD2k: Disconnected"
 msgstr "eD2k: 已断开"
 
-#: src/amuleDlg.cpp:968
+#: src/amuleDlg.cpp:903
 msgid "Kad: Firewalled"
 msgstr "Kad: 通过防火墙"
 
-#: src/amuleDlg.cpp:972
+#: src/amuleDlg.cpp:907
 msgid "Kad: Connected"
 msgstr "Kad: 已连接"
 
-#: src/amuleDlg.cpp:977
+#: src/amuleDlg.cpp:912
 msgid "Kad: Connecting"
 msgstr "Kad: 正在连接"
 
-#: src/amuleDlg.cpp:981
+#: src/amuleDlg.cpp:916
 msgid "Kad: Off"
 msgstr "Kad: 关闭"
 
-#: src/amuleDlg.cpp:1029 src/DownloadListCtrl.cpp:505
+#: src/amuleDlg.cpp:964 src/DownloadListCtrl.cpp:505
 #: src/DownloadListCtrl.cpp:749 src/FriendListCtrl.cpp:180
 #: src/muuli_wdr.cpp:731 src/muuli_wdr.cpp:782 src/muuli_wdr.cpp:846
-#: src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2252 src/muuli_wdr.cpp:2337
-#: src/muuli_wdr.cpp:3085 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
+#: src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2224 src/muuli_wdr.cpp:2309
+#: src/muuli_wdr.cpp:3057 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
 #: src/ServerListCtrl.cpp:606 src/TransferWnd.cpp:378
 #: src/utils/wxCas/src/wxcasprefs.cpp:235
 msgid "Cancel"
 msgstr "取消"
 
-#: src/amuleDlg.cpp:1030
+#: src/amuleDlg.cpp:965
 msgid "Stop the current connection attempts"
 msgstr "终止本次连接尝试"
 
-#: src/amuleDlg.cpp:1035 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976
-#: src/muuli_wdr.cpp:2475
+#: src/amuleDlg.cpp:970 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976
+#: src/muuli_wdr.cpp:2447
 msgid "Disconnect"
 msgstr "断开连接"
 
-#: src/amuleDlg.cpp:1036
+#: src/amuleDlg.cpp:971
 msgid "Disconnect from the currently connected networks"
 msgstr "从当前已连接的网络断开"
 
-#: src/amuleDlg.cpp:1041 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979
-#: src/muuli_wdr.cpp:2630 src/muuli_wdr.cpp:3082 src/muuli_wdr.cpp:3437
+#: src/amuleDlg.cpp:976 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979
+#: src/muuli_wdr.cpp:2602 src/muuli_wdr.cpp:3054 src/muuli_wdr.cpp:3409
 msgid "Connect"
 msgstr "连接"
 
-#: src/amuleDlg.cpp:1042
+#: src/amuleDlg.cpp:977
 msgid "Connect to the currently enabled networks"
 msgstr "连接至当前已启用的网络"
 
-#: src/amuleDlg.cpp:1154
+#: src/amuleDlg.cpp:1089
 #, c-format
 msgid "Up: %.1f%s (%.1f) | Down: %.1f%s (%.1f)"
 msgstr "上传: %.1f%s（%.1f） | 下载: %.1f%s（%.1f）"
 
-#: src/amuleDlg.cpp:1156 src/amuleDlg.cpp:1158 src/amuleDlg.cpp:1162
-#: src/amuleDlg.cpp:1164 src/amuleDlg.cpp:1175 src/amuleDlg.cpp:1177
+#: src/amuleDlg.cpp:1091 src/amuleDlg.cpp:1093 src/amuleDlg.cpp:1097
+#: src/amuleDlg.cpp:1099 src/amuleDlg.cpp:1110 src/amuleDlg.cpp:1112
 #: src/MuleTrayIcon.cpp:796 src/MuleTrayIcon.cpp:799
 msgid " MB/s"
 msgstr " MB/s"
 
-#: src/amuleDlg.cpp:1156 src/amuleDlg.cpp:1158 src/amuleDlg.cpp:1162
-#: src/amuleDlg.cpp:1164 src/amuleDlg.cpp:1175 src/amuleDlg.cpp:1177
+#: src/amuleDlg.cpp:1091 src/amuleDlg.cpp:1093 src/amuleDlg.cpp:1097
+#: src/amuleDlg.cpp:1099 src/amuleDlg.cpp:1110 src/amuleDlg.cpp:1112
 #: src/MuleTrayIcon.cpp:796 src/MuleTrayIcon.cpp:799
 #: src/utils/wxCas/src/wxcasframe.cpp:1041
 msgid " kB/s"
 msgstr " kB/s"
 
-#: src/amuleDlg.cpp:1161
+#: src/amuleDlg.cpp:1096
 #, c-format
 msgid "Up: %.1f%s | Down: %.1f%s"
 msgstr "上传: %.1f%s | 下载: %.1f%s"
 
-#: src/amuleDlg.cpp:1193
+#: src/amuleDlg.cpp:1128
 #, c-format
 msgid "aMule (%s | Connected)"
 msgstr "aMule（%s | 已连接）"
 
-#: src/amuleDlg.cpp:1195
+#: src/amuleDlg.cpp:1130
 #, c-format
 msgid "aMule (%s | Disconnected)"
 msgstr "aMule（%s | 已断开）"
 
-#: src/amuleDlg.cpp:1248
+#: src/amuleDlg.cpp:1183
 #, c-format
 msgid "Do you really want to exit %s?"
 msgstr "您确定要退出 %s 吗？"
 
-#: src/amuleDlg.cpp:1250
+#: src/amuleDlg.cpp:1185
 msgid "Exit confirmation"
 msgstr "退出确认"
 
-#: src/amuleDlg.cpp:1613
+#: src/amuleDlg.cpp:1548
 msgid "Launch Command: "
 msgstr "运行命令: "
 
-#: src/amuleDlg.cpp:1632 src/muuli_wdr.cpp:1972 src/Preferences.cpp:979
+#: src/amuleDlg.cpp:1567 src/muuli_wdr.cpp:1971 src/Preferences.cpp:951
 msgid "- default -"
 msgstr "- 默认 -"
 
-#: src/amuleDlg.cpp:1660
+#: src/amuleDlg.cpp:1595
 #, c-format
 msgid "Skin directory '%s' does not exist"
 msgstr "皮肤目录 %s 不存在"
 
-#: src/amuleDlg.cpp:1663
+#: src/amuleDlg.cpp:1598
 #, c-format
 msgid "WARNING: Unable to open skin file '%s' for read"
 msgstr "警告：无法打开皮肤文件 %s 进行读取"
 
-#: src/amuleDlg.cpp:1814 src/muuli_wdr.cpp:3439
+#: src/amuleDlg.cpp:1722 src/amuleDlg.cpp:1968 src/muuli_wdr.cpp:1485
+#: src/muuli_wdr.cpp:3411
+msgid "Networks"
+msgstr "网络"
+
+#: src/amuleDlg.cpp:1726 src/muuli_wdr.cpp:3411
 msgid "Networks Window"
 msgstr "网络窗口"
 
-#: src/amuleDlg.cpp:1820 src/muuli_wdr.cpp:3440
+#: src/amuleDlg.cpp:1728 src/muuli_wdr.cpp:3412
+msgid "Searches"
+msgstr "搜索"
+
+#: src/amuleDlg.cpp:1732 src/muuli_wdr.cpp:3412
 msgid "Searches Window"
 msgstr "搜索窗口"
 
-#: src/amuleDlg.cpp:1826 src/muuli_wdr.cpp:3441
+#: src/amuleDlg.cpp:1734 src/DownloadListCtrl.cpp:740 src/muuli_wdr.cpp:392
+#: src/muuli_wdr.cpp:1578 src/muuli_wdr.cpp:3413 src/Statistics.cpp:829
+msgid "Downloads"
+msgstr "下载"
+
+#: src/amuleDlg.cpp:1738 src/muuli_wdr.cpp:3413
 msgid "Downloads Window"
 msgstr "下载窗口"
 
-#: src/amuleDlg.cpp:1832 src/muuli_wdr.cpp:3443
+#: src/amuleDlg.cpp:1740 src/muuli_wdr.cpp:3287
+msgid "Shared files"
+msgstr "共享文件"
+
+#: src/amuleDlg.cpp:1744 src/muuli_wdr.cpp:3415
 msgid "Shared Files Window"
 msgstr "共享文件窗口"
 
-#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3444
+#: src/amuleDlg.cpp:1746 src/muuli_wdr.cpp:2919 src/muuli_wdr.cpp:3369
+#: src/muuli_wdr.cpp:3416
+msgid "Messages"
+msgstr "消息"
+
+#: src/amuleDlg.cpp:1750 src/muuli_wdr.cpp:3416
 msgid "Messages Window"
 msgstr "消息窗口"
 
-#: src/amuleDlg.cpp:1844 src/muuli_wdr.cpp:3445
+#: src/amuleDlg.cpp:1752 src/muuli_wdr.cpp:3417 src/PrefsUnifiedDlg.cpp:312
+#: src/Statistics.cpp:779 src/Statistics.cpp:1235
+msgid "Statistics"
+msgstr "统计"
+
+#: src/amuleDlg.cpp:1756 src/muuli_wdr.cpp:3417
 msgid "Statistics Graph Window"
 msgstr "统计图窗口"
 
-#: src/amuleDlg.cpp:1851 src/muuli_wdr.cpp:3447
+#: src/amuleDlg.cpp:1759 src/muuli_wdr.cpp:3419 src/PrefsUnifiedDlg.cpp:328
+#: src/utils/wxCas/src/wxcasprefs.cpp:39
+msgid "Preferences"
+msgstr "设置"
+
+#: src/amuleDlg.cpp:1763 src/muuli_wdr.cpp:3419
 msgid "Preferences Settings Window"
 msgstr "设置窗口"
 
-#: src/amuleDlg.cpp:1854 src/muuli_wdr.cpp:3448
+#: src/amuleDlg.cpp:1766 src/muuli_wdr.cpp:3420
 msgid "Import"
 msgstr "导入"
 
-#: src/amuleDlg.cpp:1858 src/muuli_wdr.cpp:3448
+#: src/amuleDlg.cpp:1770 src/muuli_wdr.cpp:3420
 msgid "The partfile importer tool"
 msgstr "part 文件导入工具"
 
-#: src/amuleDlg.cpp:1861 src/muuli_wdr.cpp:3449
+#: src/amuleDlg.cpp:1773 src/muuli_wdr.cpp:3421
 #: src/utils/aLinkCreator/src/alcframe.cpp:262
 msgid "About"
 msgstr "关于"
 
-#: src/amuleDlg.cpp:1861 src/muuli_wdr.cpp:3449
+#: src/amuleDlg.cpp:1773 src/muuli_wdr.cpp:3421
 msgid "About/Help"
 msgstr "关于/帮助"
 
-#: src/amuleDlg.cpp:2059
+#: src/amuleDlg.cpp:1971
 msgid "eD2k network"
 msgstr "eD2k 网络"
 
-#: src/amuleDlg.cpp:2062
+#: src/amuleDlg.cpp:1974
 msgid "Kad network"
 msgstr "Kad 网络"
 
-#: src/amuleDlg.cpp:2062
+#: src/amuleDlg.cpp:1974
 msgid "No network"
 msgstr "无网络"
 
@@ -960,7 +955,7 @@ msgstr "未找到"
 msgid "The core rejected these shared folders:%s"
 msgstr "核心拒绝了这些共享的文件夹：%s"
 
-#: src/amule-remote-gui.cpp:1336 src/ExternalConn.cpp:2346
+#: src/amule-remote-gui.cpp:1336 src/ExternalConn.cpp:2345
 msgid "Invalid link or already on list."
 msgstr "非法链接或已经存在列表中。"
 
@@ -976,7 +971,7 @@ msgstr "无法创建 “%s” 目录用于 “%s” 分类，保留 “%s” 目
 #: src/ClientDetailDialog.cpp:123 src/DataToText.cpp:61 src/DataToText.cpp:86
 #: src/DataToText.cpp:101 src/DataToText.cpp:136 src/DataToText.cpp:165
 #: src/DownloadListCtrl.cpp:1172 src/DownloadListCtrl.cpp:1185
-#: src/DownloadListCtrl.cpp:1196 src/ExternalConn.cpp:609
+#: src/DownloadListCtrl.cpp:1196 src/ExternalConn.cpp:608
 #: src/FileDetailDialog.cpp:203 src/FileDetailDialog.cpp:235
 #: src/FileDetailDialog.cpp:242 src/GenericClientListCtrl.cpp:1171
 #: src/GenericClientListCtrl.cpp:1182 src/GenericClientListCtrl.cpp:1192
@@ -1362,19 +1357,19 @@ msgstr "自动 [高]"
 msgid "Very low"
 msgstr "极低"
 
-#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:743 src/muuli_wdr.cpp:2303
+#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:743 src/muuli_wdr.cpp:2275
 #: src/ServerListCtrl.cpp:263 src/ServerListCtrl.cpp:456
 #: src/SharedFilesCtrl.cpp:145
 msgid "Low"
 msgstr "低"
 
-#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:744 src/muuli_wdr.cpp:2304
+#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:744 src/muuli_wdr.cpp:2276
 #: src/ServerListCtrl.cpp:266 src/ServerListCtrl.cpp:457
 #: src/SharedFilesCtrl.cpp:146
 msgid "Normal"
 msgstr "普通"
 
-#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:745 src/muuli_wdr.cpp:2305
+#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:745 src/muuli_wdr.cpp:2277
 #: src/ServerListCtrl.cpp:269 src/ServerListCtrl.cpp:458
 #: src/SharedFilesCtrl.cpp:147
 msgid "High"
@@ -1466,8 +1461,8 @@ msgstr "本地服务器"
 msgid "Remote Server"
 msgstr "远程服务器"
 
-#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3202
-#: src/SearchDlg.cpp:119 src/TextClient.cpp:911
+#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3174
+#: src/SearchDlg.cpp:111 src/TextClient.cpp:911
 msgid "Kad"
 msgstr "Kad"
 
@@ -1537,7 +1532,7 @@ msgstr "块"
 msgid "Size"
 msgstr "大小"
 
-#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3269
+#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3241
 msgid "Transferred"
 msgstr "已传输"
 
@@ -1595,7 +1590,7 @@ msgstr ""
 "报告来自: %s (%s)\n"
 "\n"
 
-#: src/DownloadListCtrl.cpp:746 src/muuli_wdr.cpp:2306
+#: src/DownloadListCtrl.cpp:746 src/muuli_wdr.cpp:2278
 #: src/SharedFilesCtrl.cpp:150
 msgid "Auto"
 msgstr "自动"
@@ -1633,7 +1628,7 @@ msgid "Extended Options"
 msgstr "扩展选项"
 
 #: src/DownloadListCtrl.cpp:770 src/DownloadListCtrl.cpp:822
-#: src/muuli_wdr.cpp:1790
+#: src/muuli_wdr.cpp:1789
 msgid "Preview"
 msgstr "预览"
 
@@ -1808,230 +1803,225 @@ msgstr[1] "无法添加 %u 个链接（详情请查看日志）"
 msgid "Invalid eD2k link! ERROR: %s"
 msgstr "非法 eD2k 链接！错误: %s"
 
-#: src/ExternalConn.cpp:380
+#: src/ExternalConn.cpp:379
 msgid "Client sent packet after authentication failed."
 msgstr "客户端在验证失败后发送包。"
 
-#: src/ExternalConn.cpp:397
+#: src/ExternalConn.cpp:396
 msgid "External connection closed."
 msgstr "已关闭远程连接。"
 
-#: src/ExternalConn.cpp:474
+#: src/ExternalConn.cpp:473
 msgid "External connections disabled due to empty password!"
 msgstr "密码未设置，已禁止远程连接！"
 
-#: src/ExternalConn.cpp:495
+#: src/ExternalConn.cpp:494
 msgid "External connections disabled in config file"
 msgstr "配置文件中已禁止远程连接"
 
-#: src/ExternalConn.cpp:576
+#: src/ExternalConn.cpp:575
 msgid "New external connection accepted"
 msgstr "新的远程连接已被接受"
 
-#: src/ExternalConn.cpp:579
+#: src/ExternalConn.cpp:578
 msgid "ERROR: couldn't accept a new external connection"
 msgstr "错误：不能接受新的远程连接"
 
-#: src/ExternalConn.cpp:596
+#: src/ExternalConn.cpp:595
 msgid "External connection refused due to empty password in preferences!"
 msgstr "由于未设置密码，远程连接已被拒绝！"
 
-#: src/ExternalConn.cpp:608
+#: src/ExternalConn.cpp:607
 #, c-format
 msgid "Connecting client: %s %s"
 msgstr "正在连接客户端：%s %s"
 
-#: src/ExternalConn.cpp:610
+#: src/ExternalConn.cpp:609
 msgid "Unknown version"
 msgstr "未知版本"
 
-#: src/ExternalConn.cpp:623
+#: src/ExternalConn.cpp:622
 msgid "Incorrect EC version ID, there might be binary incompatibility. Use core and remote from same snapshot."
 msgstr "错误的远程连接版本号，可能会不兼容，请使用相同版本的核心和远程程序。"
 
-#: src/ExternalConn.cpp:631
+#: src/ExternalConn.cpp:630
 msgid "You cannot connect to a release version from an arbitrary development snapshot! *sigh* possible crash prevented"
 msgstr "您无法从任意开发快照连接到发布版本！*sigh* 防止可能发生的崩溃"
 
-#: src/ExternalConn.cpp:714
+#: src/ExternalConn.cpp:713
 msgid "Invalid protocol version."
 msgstr "非法协议版本。"
 
-#: src/ExternalConn.cpp:720
+#: src/ExternalConn.cpp:719
 msgid "Missing protocol version tag."
 msgstr "缺失协议版本标签。"
 
-#: src/ExternalConn.cpp:728
+#: src/ExternalConn.cpp:727
 msgid "Authentication failed: invalid hash specified as EC password."
 msgstr "身份验证失败: 指定为 EC 密码的 MD5 哈希值无效。"
 
-#: src/ExternalConn.cpp:776
+#: src/ExternalConn.cpp:775
 msgid "Authentication failed: wrong password."
 msgstr "验证失败：密码错误。"
 
-#: src/ExternalConn.cpp:778
+#: src/ExternalConn.cpp:777
 msgid "Authentication failed: missing password."
 msgstr "认证失败: 没有密码。"
 
-#: src/ExternalConn.cpp:789
+#: src/ExternalConn.cpp:788
 msgid "Invalid request, please authenticate first."
 msgstr "无效请求，请先验证。"
 
-#: src/ExternalConn.cpp:794
+#: src/ExternalConn.cpp:793
 msgid "Access granted."
 msgstr "登录成功。"
 
-#: src/ExternalConn.cpp:802
+#: src/ExternalConn.cpp:801
 #, c-format
 msgid "Sent error message \"%s\" to client."
 msgstr "发送错误消息喔 \"%s\"到客户端。"
 
-#: src/ExternalConn.cpp:807
+#: src/ExternalConn.cpp:806
 #, c-format
 msgid "Unauthorized access attempt from %s. Connection closed."
 msgstr "来自%s的非法登录尝试，已关闭连接。"
 
-#: src/ExternalConn.cpp:1420
+#: src/ExternalConn.cpp:1419
 #, c-format
 msgid "Remote PartFile command failed: FileHash not found: %s"
 msgstr "远程 Part 文件命令失败：文件校验码不存在：%s"
 
-#: src/ExternalConn.cpp:1424
+#: src/ExternalConn.cpp:1423
 #, c-format
 msgid "FileHash not found: %s"
 msgstr "文件校验码不存在：%s"
 
-#: src/ExternalConn.cpp:1471 src/ExternalConn.cpp:1559
-#: src/ExternalConn.cpp:1680
+#: src/ExternalConn.cpp:1470 src/ExternalConn.cpp:1558
+#: src/ExternalConn.cpp:1679
 msgid "OOPS! OpCode processing error!"
 msgstr "OpCode 处理错误！"
 
-#: src/ExternalConn.cpp:1502
+#: src/ExternalConn.cpp:1501
 msgid "Server not added"
 msgstr "服务器没有被添加"
 
-#: src/ExternalConn.cpp:1521
+#: src/ExternalConn.cpp:1520
 #, c-format
 msgid "server not found: %s"
 msgstr "找不到服务器：%s"
 
-#: src/ExternalConn.cpp:1538
+#: src/ExternalConn.cpp:1537
 msgid "need to define server to be removed"
 msgstr "必须定义需删除的服务器"
 
-#: src/ExternalConn.cpp:1553
+#: src/ExternalConn.cpp:1552
 msgid "eD2k is disabled in preferences."
 msgstr "eD2k 在设置中已禁用。"
 
-#: src/ExternalConn.cpp:1658
+#: src/ExternalConn.cpp:1657
 msgid "Friend not found."
 msgstr "未找到好友。"
 
-#: src/ExternalConn.cpp:1668
+#: src/ExternalConn.cpp:1667
 msgid "Client not found."
 msgstr "未找到客户端。"
 
-#: src/ExternalConn.cpp:1674
+#: src/ExternalConn.cpp:1673
 msgid "EC_TAG_FRIEND_SHARED requires EC_TAG_FRIEND or EC_TAG_CLIENT."
 msgstr "EC_TAG_FRIEND_SHARED 需要 EC_TAG_FRIEND 或 EC_TAG_CLIENT。"
 
-#: src/ExternalConn.cpp:1992
+#: src/ExternalConn.cpp:1991
 msgid "WebSearch from remote interface makes no sense."
 msgstr "远程界面使用网络搜索没有意义。"
 
-#: src/ExternalConn.cpp:2027
+#: src/ExternalConn.cpp:2026
 msgid "Search in progress. Refetch results in a moment!"
 msgstr "正在搜索，请稍等然后重新获取结果！"
 
-#: src/ExternalConn.cpp:2266
+#: src/ExternalConn.cpp:2265
 msgid "No points for graph."
 msgstr "此图没有节点。"
 
-#: src/ExternalConn.cpp:2276
+#: src/ExternalConn.cpp:2275
 msgid "Your client is not configured for this detail level."
 msgstr "您的客户端没有为详细级别进行配置。"
 
-#: src/ExternalConn.cpp:2303
+#: src/ExternalConn.cpp:2302
 msgid "External Connection: shutdown requested"
 msgstr "远程连接：已请求关闭"
 
-#: src/ExternalConn.cpp:2315
+#: src/ExternalConn.cpp:2314
 msgid "Already shutting down."
 msgstr "已经在关闭。"
 
-#: src/ExternalConn.cpp:2333
+#: src/ExternalConn.cpp:2332
 #, c-format
 msgid "ExternalConn: adding link '%s'."
 msgstr "远程连接：正在添加链接 '%s'。"
 
-#: src/ExternalConn.cpp:2351
+#: src/ExternalConn.cpp:2350
 #, c-format
 msgid "%d of %d links failed (invalid or already on list)."
 msgstr "%d 个链接失败，共 %d 个（无效或已经在列表中）。"
 
-#: src/ExternalConn.cpp:2374
+#: src/ExternalConn.cpp:2373
 msgid "Version check throttled; try again shortly."
 msgstr "版本检查受限；请稍后再试。"
 
-#: src/ExternalConn.cpp:2379
+#: src/ExternalConn.cpp:2378
 msgid "Version check is not available on this daemon."
 msgstr "版本检查在此 daemon 上不可用。"
 
-#: src/ExternalConn.cpp:2509
+#: src/ExternalConn.cpp:2508
 msgid "File not found."
 msgstr "文件未找到。"
 
-#: src/ExternalConn.cpp:2514
+#: src/ExternalConn.cpp:2513
 msgid "Invalid file name."
 msgstr "无效的文件名。"
 
-#: src/ExternalConn.cpp:2522
+#: src/ExternalConn.cpp:2521
 msgid "Unable to rename file."
 msgstr "无法重命名文件。"
 
-#: src/ExternalConn.cpp:2839
-#, c-format
-msgid "Could not save the amuleapi password: %s"
-msgstr ""
-
-#: src/ExternalConn.cpp:3004 src/ExternalConn.cpp:3032
+#: src/ExternalConn.cpp:2992 src/ExternalConn.cpp:3020
 msgid "Kad is disabled in preferences."
 msgstr "Kad 在设置中被禁用。"
 
-#: src/ExternalConn.cpp:3045
+#: src/ExternalConn.cpp:3033
 msgid "Already connected to eD2k."
 msgstr "已经连接至 eD2k。"
 
-#: src/ExternalConn.cpp:3048
+#: src/ExternalConn.cpp:3036
 msgid "Connecting to eD2k..."
 msgstr "正在连接至 eD2k..."
 
-#: src/ExternalConn.cpp:3057
+#: src/ExternalConn.cpp:3045
 msgid "Already connected to Kad."
 msgstr "已连接至 Kad。"
 
-#: src/ExternalConn.cpp:3060
+#: src/ExternalConn.cpp:3048
 msgid "Connecting to Kad..."
 msgstr "正在连接至 Kad..."
 
-#: src/ExternalConn.cpp:3067
+#: src/ExternalConn.cpp:3055
 msgid "All networks are disabled."
 msgstr "全部网络都被禁用了。"
 
-#: src/ExternalConn.cpp:3076
+#: src/ExternalConn.cpp:3064
 msgid "Disconnected from eD2k."
 msgstr "已从 eD2k 断开连接。"
 
-#: src/ExternalConn.cpp:3081
+#: src/ExternalConn.cpp:3069
 msgid "Disconnected from Kad."
 msgstr "已从 Kad 断开连接。"
 
-#: src/ExternalConn.cpp:3090
+#: src/ExternalConn.cpp:3078
 #, c-format
 msgid "External Connection: invalid opcode received: %#x"
 msgstr "远程连接：非法 opcode：%#x"
 
-#: src/ExternalConn.cpp:3095
+#: src/ExternalConn.cpp:3083
 msgid "Invalid opcode (wrong protocol version?)"
 msgstr "非法的 opcode（错误的协议版本？)"
 
@@ -2347,19 +2337,19 @@ msgstr ""
 msgid "eD2k"
 msgstr "eD2k"
 
-#: src/FirstRunWizard.cpp:349 src/muuli_wdr.cpp:1495
+#: src/FirstRunWizard.cpp:349 src/muuli_wdr.cpp:1488
 msgid "Kademlia"
 msgstr "Kad"
 
-#: src/FirstRunWizard.cpp:359 src/muuli_wdr.cpp:1423
+#: src/FirstRunWizard.cpp:359 src/muuli_wdr.cpp:1416
 msgid "Standard TCP Port "
 msgstr "标准 TCP 端口 "
 
-#: src/FirstRunWizard.cpp:365 src/muuli_wdr.cpp:1435
+#: src/FirstRunWizard.cpp:365 src/muuli_wdr.cpp:1428
 msgid "Extended UDP port (Kad / global search) "
 msgstr "扩展 UDP 端口 (Kad/全局搜索) "
 
-#: src/FirstRunWizard.cpp:377 src/muuli_wdr.cpp:1442
+#: src/FirstRunWizard.cpp:377 src/muuli_wdr.cpp:1435
 msgid "Enable UPnP for router port forwarding"
 msgstr "启用 UPnP 以用于路由器端口转发"
 
@@ -2386,7 +2376,7 @@ msgstr ""
 msgid "Your peer lists are already in place - nothing to download."
 msgstr "您已经尝试下载文件 %s"
 
-#: src/FirstRunWizard.cpp:434 src/muuli_wdr.cpp:1540
+#: src/FirstRunWizard.cpp:434 src/muuli_wdr.cpp:1533
 msgid "Auto-update server list at startup"
 msgstr "启动时自动更新服务器列表"
 
@@ -2432,23 +2422,23 @@ msgid ""
 "want downloads on a different (e.g. larger) disk."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:549 src/FirstRunWizard.cpp:611 src/muuli_wdr.cpp:1702
+#: src/FirstRunWizard.cpp:549 src/FirstRunWizard.cpp:611 src/muuli_wdr.cpp:1701
 msgid "Destination folder for downloads"
 msgstr "存放下载文件的文件夹"
 
-#: src/FirstRunWizard.cpp:553 src/FirstRunWizard.cpp:569 src/muuli_wdr.cpp:1349
-#: src/muuli_wdr.cpp:1366 src/muuli_wdr.cpp:1677 src/muuli_wdr.cpp:1708
-#: src/muuli_wdr.cpp:1720 src/muuli_wdr.cpp:2790
+#: src/FirstRunWizard.cpp:553 src/FirstRunWizard.cpp:569 src/muuli_wdr.cpp:1342
+#: src/muuli_wdr.cpp:1359 src/muuli_wdr.cpp:1676 src/muuli_wdr.cpp:1707
+#: src/muuli_wdr.cpp:1719 src/muuli_wdr.cpp:2762
 #: src/utils/aLinkCreator/src/alcframe.cpp:135
 #: src/utils/wxCas/src/wxcasprefs.cpp:52 src/utils/wxCas/src/wxcasprefs.cpp:118
 msgid "Browse"
 msgstr "浏览"
 
-#: src/FirstRunWizard.cpp:559 src/muuli_wdr.cpp:1713
+#: src/FirstRunWizard.cpp:559 src/muuli_wdr.cpp:1712
 msgid "(All files in this folder are shared with other peers)"
 msgstr "（此文件夹中的所有文件均与其他对等方共享）"
 
-#: src/FirstRunWizard.cpp:565 src/FirstRunWizard.cpp:624 src/muuli_wdr.cpp:1715
+#: src/FirstRunWizard.cpp:565 src/FirstRunWizard.cpp:624 src/muuli_wdr.cpp:1714
 msgid "Folder for temporary download files"
 msgstr "存放临时下载文件的文件夹"
 
@@ -2479,7 +2469,7 @@ msgstr "写好友列表文件emfriends.met失败！"
 msgid "CRITICAL - no client on StartChatSession"
 msgstr "严重错误 - 开始聊天进程没有客户端"
 
-#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2696 src/muuli_wdr.cpp:3373
+#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2668 src/muuli_wdr.cpp:3345
 msgid "Friends"
 msgstr "好友"
 
@@ -2589,8 +2579,8 @@ msgstr "没有"
 msgid "No"
 msgstr "否"
 
-#: src/GenericClientListCtrl.cpp:1216 src/PrefsUnifiedDlg.cpp:2898
-#: src/PrefsUnifiedDlg.cpp:2948 src/ServerListCtrl.cpp:276
+#: src/GenericClientListCtrl.cpp:1216 src/PrefsUnifiedDlg.cpp:2818
+#: src/PrefsUnifiedDlg.cpp:2868 src/ServerListCtrl.cpp:276
 msgid "Yes"
 msgstr "是"
 
@@ -2757,10 +2747,10 @@ msgstr "无效端口"
 msgid "Please fill all fields required"
 msgstr "请填写所有必要信息"
 
-#: src/KadDlg.cpp:192 src/PartFile.cpp:1031 src/PrefsUnifiedDlg.cpp:1134
-#: src/PrefsUnifiedDlg.cpp:1204 src/PrefsUnifiedDlg.cpp:1405
-#: src/PrefsUnifiedDlg.cpp:1663 src/PrefsUnifiedDlg.cpp:1673
-#: src/PrefsUnifiedDlg.cpp:1690 src/PrefsUnifiedDlg.cpp:1738
+#: src/KadDlg.cpp:192 src/PartFile.cpp:1031 src/PrefsUnifiedDlg.cpp:1162
+#: src/PrefsUnifiedDlg.cpp:1331 src/PrefsUnifiedDlg.cpp:1589
+#: src/PrefsUnifiedDlg.cpp:1599 src/PrefsUnifiedDlg.cpp:1616
+#: src/PrefsUnifiedDlg.cpp:1658
 msgid "Message"
 msgstr "消息"
 
@@ -2861,7 +2851,7 @@ msgstr "共享率"
 msgid "Uploaded"
 msgstr "已上传"
 
-#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3253
+#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3225
 msgid "Requested"
 msgstr "已请求"
 
@@ -2984,7 +2974,7 @@ msgid "WARNING: "
 msgstr "警告: "
 
 #: src/MuleNotebook.cpp:179 src/muuli_wdr.cpp:817 src/muuli_wdr.cpp:1229
-#: src/muuli_wdr.cpp:3157 src/muuli_wdr.cpp:3413
+#: src/muuli_wdr.cpp:3129 src/muuli_wdr.cpp:3385
 msgid "Close"
 msgstr "关闭"
 
@@ -2997,12 +2987,12 @@ msgstr "剪切"
 msgid "Copy"
 msgstr "复制"
 
-#: src/MuleTextCtrl.cpp:88 src/SearchDlg.cpp:261
+#: src/MuleTextCtrl.cpp:88
 msgid "Paste"
 msgstr "粘贴"
 
 #: src/MuleTextCtrl.cpp:89 src/muuli_wdr.cpp:358 src/muuli_wdr.cpp:757
-#: src/muuli_wdr.cpp:2380 src/muuli_wdr.cpp:2399 src/muuli_wdr.cpp:2421
+#: src/muuli_wdr.cpp:2352 src/muuli_wdr.cpp:2371 src/muuli_wdr.cpp:2393
 #: src/utils/aLinkCreator/src/alcframe.cpp:142
 msgid "Clear"
 msgstr "清除"
@@ -3093,8 +3083,8 @@ msgid "Exit"
 msgstr "退出"
 
 #: src/MuleTrayIcon.cpp:579 src/MuleTrayIcon.cpp:945 src/MuleTrayIcon.cpp:965
-#: src/muuli_wdr.cpp:1398 src/muuli_wdr.cpp:1406 src/muuli_wdr.cpp:1413
-#: src/muuli_wdr.cpp:1836 src/muuli_wdr.cpp:1842 src/OtherFunctions.cpp:91
+#: src/muuli_wdr.cpp:1391 src/muuli_wdr.cpp:1399 src/muuli_wdr.cpp:1406
+#: src/muuli_wdr.cpp:1835 src/muuli_wdr.cpp:1841 src/OtherFunctions.cpp:91
 #: src/StatisticsDlg.cpp:93 src/StatisticsDlg.cpp:95
 msgid "kB/s"
 msgstr "KB/s"
@@ -3263,7 +3253,7 @@ msgstr "名称:"
 msgid "Type"
 msgstr "类型"
 
-#: src/muuli_wdr.cpp:215 src/SearchDlg.cpp:118 src/SearchListCtrl.cpp:853
+#: src/muuli_wdr.cpp:215 src/SearchDlg.cpp:110 src/SearchListCtrl.cpp:853
 msgid "Local"
 msgstr "本地"
 
@@ -3334,7 +3324,7 @@ msgstr "字节"
 msgid "KB"
 msgstr "KB"
 
-#: src/muuli_wdr.cpp:274 src/muuli_wdr.cpp:293 src/muuli_wdr.cpp:1621
+#: src/muuli_wdr.cpp:274 src/muuli_wdr.cpp:293 src/muuli_wdr.cpp:1620
 #: src/OtherFunctions.cpp:64
 msgid "MB"
 msgstr "MB"
@@ -3351,7 +3341,7 @@ msgstr "大小上限"
 msgid "Availability"
 msgstr "可用来源数"
 
-#: src/muuli_wdr.cpp:312 src/muuli_wdr.cpp:398 src/muuli_wdr.cpp:3318
+#: src/muuli_wdr.cpp:312 src/muuli_wdr.cpp:398 src/muuli_wdr.cpp:3290
 msgid "Filter:"
 msgstr "过滤："
 
@@ -3383,7 +3373,7 @@ msgstr "向已响应的 Kad 节点请求扩大搜索范围。每次点击都会�
 msgid "Stop"
 msgstr "停止"
 
-#: src/muuli_wdr.cpp:348 src/muuli_wdr.cpp:1392 src/SearchListCtrl.cpp:732
+#: src/muuli_wdr.cpp:348 src/muuli_wdr.cpp:1385 src/SearchListCtrl.cpp:732
 msgid "Download"
 msgstr "下载"
 
@@ -3414,12 +3404,12 @@ msgstr "文件源:"
 #: src/muuli_wdr.cpp:1160 src/muuli_wdr.cpp:1167 src/muuli_wdr.cpp:1172
 #: src/muuli_wdr.cpp:1179 src/muuli_wdr.cpp:1184 src/muuli_wdr.cpp:1191
 #: src/muuli_wdr.cpp:1205 src/muuli_wdr.cpp:1212 src/muuli_wdr.cpp:1217
-#: src/muuli_wdr.cpp:1224 src/muuli_wdr.cpp:3255 src/muuli_wdr.cpp:3263
-#: src/muuli_wdr.cpp:3271
+#: src/muuli_wdr.cpp:1224 src/muuli_wdr.cpp:3227 src/muuli_wdr.cpp:3235
+#: src/muuli_wdr.cpp:3243
 msgid "N/A"
 msgstr "N/A"
 
-#: src/muuli_wdr.cpp:508 src/muuli_wdr.cpp:1065 src/PrefsUnifiedDlg.cpp:299
+#: src/muuli_wdr.cpp:508 src/muuli_wdr.cpp:1065 src/PrefsUnifiedDlg.cpp:297
 msgid "General"
 msgstr "常规"
 
@@ -3555,7 +3545,7 @@ msgstr "艺术家："
 msgid "Album :"
 msgstr "专辑："
 
-#: src/muuli_wdr.cpp:685 src/muuli_wdr.cpp:2275
+#: src/muuli_wdr.cpp:685 src/muuli_wdr.cpp:2247
 msgid "Title :"
 msgstr "标题 :"
 
@@ -3663,7 +3653,7 @@ msgstr "用户名 :"
 msgid "Userhash :"
 msgstr "用户哈希 :"
 
-#: src/muuli_wdr.cpp:895 src/muuli_wdr.cpp:1742 src/muuli_wdr.cpp:2470
+#: src/muuli_wdr.cpp:895 src/muuli_wdr.cpp:1741 src/muuli_wdr.cpp:2442
 #: src/utils/aLinkCreator/src/alcframe.cpp:137
 msgid "Add"
 msgstr "添加"
@@ -3672,15 +3662,15 @@ msgstr "添加"
 msgid "Download-Speed"
 msgstr "下载速度"
 
-#: src/muuli_wdr.cpp:954 src/muuli_wdr.cpp:989 src/muuli_wdr.cpp:2574
+#: src/muuli_wdr.cpp:954 src/muuli_wdr.cpp:989 src/muuli_wdr.cpp:2546
 msgid "Current"
 msgstr "当前"
 
-#: src/muuli_wdr.cpp:962 src/muuli_wdr.cpp:997 src/muuli_wdr.cpp:2582
+#: src/muuli_wdr.cpp:962 src/muuli_wdr.cpp:997 src/muuli_wdr.cpp:2554
 msgid "Running average"
 msgstr "动态平均值"
 
-#: src/muuli_wdr.cpp:970 src/muuli_wdr.cpp:1005 src/muuli_wdr.cpp:2590
+#: src/muuli_wdr.cpp:970 src/muuli_wdr.cpp:1005 src/muuli_wdr.cpp:2562
 msgid "Session average"
 msgstr "本次运行平均值"
 
@@ -3692,7 +3682,7 @@ msgstr "上传速度"
 msgid "Connections"
 msgstr "连接"
 
-#: src/muuli_wdr.cpp:1024 src/muuli_wdr.cpp:1861
+#: src/muuli_wdr.cpp:1024 src/muuli_wdr.cpp:1860
 msgid "Active downloads"
 msgstr "活跃下载"
 
@@ -3700,7 +3690,7 @@ msgstr "活跃下载"
 msgid "Active connections (1:1)"
 msgstr "活跃连接 (1:1)"
 
-#: src/muuli_wdr.cpp:1040 src/muuli_wdr.cpp:1862
+#: src/muuli_wdr.cpp:1040 src/muuli_wdr.cpp:1861
 msgid "Active uploads"
 msgstr "活跃上传"
 
@@ -3816,8 +3806,8 @@ msgstr "其他用户连接到您的时候，他们会看到这个名字。"
 msgid "Language: "
 msgstr "语言: "
 
-#: src/muuli_wdr.cpp:1257 src/muuli_wdr.cpp:1330 src/muuli_wdr.cpp:1334
-#: src/muuli_wdr.cpp:1337
+#: src/muuli_wdr.cpp:1257 src/muuli_wdr.cpp:1323 src/muuli_wdr.cpp:1327
+#: src/muuli_wdr.cpp:1330
 msgid "The delay before showing tool-tips."
 msgstr "显示提示前的延迟时间。"
 
@@ -3893,260 +3883,259 @@ msgstr "下载完成后通知"
 msgid "Enabling this will make aMule to show notifications when finished downloading."
 msgstr "启用此项将使 aMule 在下载完成时显示通知。"
 
-#: src/muuli_wdr.cpp:1323
-#, fuzzy
-msgid "Remember search history"
-msgstr "记住这些设置"
-
-#: src/muuli_wdr.cpp:1324
-msgid "Keeps a dropdown list of your past search terms in the Search tab's Name field. This remembers the queries you typed, not the results they returned."
-msgstr ""
-
-#: src/muuli_wdr.cpp:1329
+#: src/muuli_wdr.cpp:1322
 msgid "Tooltip delay time: "
 msgstr "工具提示延迟时间: "
 
-#: src/muuli_wdr.cpp:1336
+#: src/muuli_wdr.cpp:1329
 msgid "seconds"
 msgstr "秒"
 
-#: src/muuli_wdr.cpp:1340
+#: src/muuli_wdr.cpp:1333
 msgid "Browser Selection"
 msgstr "浏览器"
 
-#: src/muuli_wdr.cpp:1346
+#: src/muuli_wdr.cpp:1339
 msgid "Enter your browser name here. Leave this field empty to use the system default browser."
 msgstr "在此处输入您的浏览器名称，如要使用系统默认浏览器则请留空。"
 
-#: src/muuli_wdr.cpp:1353
+#: src/muuli_wdr.cpp:1346
 msgid "Open in new tab if possible"
 msgstr "如果可能的话，在新标签页中打开"
 
-#: src/muuli_wdr.cpp:1355
+#: src/muuli_wdr.cpp:1348
 msgid "Open the web page in a new tab instead of in a new window when possible"
 msgstr "如果可能的话，在新的标签页中打开而不是新的窗口"
 
-#: src/muuli_wdr.cpp:1359
+#: src/muuli_wdr.cpp:1352
 msgid "Video Player"
 msgstr "视频播放器"
 
-#: src/muuli_wdr.cpp:1386
+#: src/muuli_wdr.cpp:1379
 msgid "Bandwidth limits"
 msgstr "带宽限制"
 
-#: src/muuli_wdr.cpp:1400
+#: src/muuli_wdr.cpp:1393
 msgid "Upload"
 msgstr "上传"
 
-#: src/muuli_wdr.cpp:1408
+#: src/muuli_wdr.cpp:1401
 msgid "Slot Allocation"
 msgstr "槽速度"
 
-#: src/muuli_wdr.cpp:1417
+#: src/muuli_wdr.cpp:1410
 msgid "Ports"
 msgstr "端口"
 
-#: src/muuli_wdr.cpp:1427
+#: src/muuli_wdr.cpp:1420
 msgid "This is the standard eD2k port and cannot be disabled."
 msgstr "这是标准的 eD2k 端口，不能被禁用。"
 
-#: src/muuli_wdr.cpp:1430
+#: src/muuli_wdr.cpp:1423
 msgid "UDP port for server requests (TCP+3):"
 msgstr "用户服务器请求的 UDP 端口 (TCP+3):"
 
-#: src/muuli_wdr.cpp:1432
+#: src/muuli_wdr.cpp:1425
 msgid "4665"
 msgstr "4665"
 
-#: src/muuli_wdr.cpp:1439
+#: src/muuli_wdr.cpp:1432
 msgid "This UDP port is used for extended eD2k requests and Kad network"
 msgstr "此 UDP 端口用于扩展 eD2k 请求和 Kad 网络"
 
-#: src/muuli_wdr.cpp:1446
+#: src/muuli_wdr.cpp:1439
 msgid "UPnP TCP Port (Optional):"
 msgstr "UPnP 的 TCP 端口 (可选):"
 
-#: src/muuli_wdr.cpp:1456
+#: src/muuli_wdr.cpp:1449
 msgid "Bind local address to IP (empty for any):"
 msgstr "为本地地址绑定 IP (全部绑定则留空):"
 
-#: src/muuli_wdr.cpp:1459
+#: src/muuli_wdr.cpp:1452
 msgid "Advanced users only: If you have multiple network interfaces, enter the address of the interface to which aMule should be bound."
 msgstr "只限高级用户：如果您有多个网络接口，请输入 aMule 将要绑定接口的地址。"
 
-#: src/muuli_wdr.cpp:1462 src/muuli_wdr.cpp:2055
+#: src/muuli_wdr.cpp:1455 src/muuli_wdr.cpp:2054
 msgid "Bind to network interface (empty for any):"
 msgstr "绑定网络接口（留空绑定全部）："
 
-#: src/muuli_wdr.cpp:1475
+#: src/muuli_wdr.cpp:1468
 msgid "Advanced users only: pin all of aMule's traffic to one network interface, chosen from the list or typed in by name (e.g. tun0, eth0, en0) or index. Unlike binding to an IP, this stops traffic leaking out via the default route - useful with a VPN. Requires no elevated privileges."
 msgstr "仅限高级用户：将 aMule 的所有流量绑定到一个网络接口，可以从列表中选择，也可以按名称（例如 tun0、eth0、en0）输入或索引。与绑定到 IP 地址不同，这可以防止流量通过默认路由泄漏—— 在 VPN 环境下有用。无需管理员权限。"
 
-#: src/muuli_wdr.cpp:1481
+#: src/muuli_wdr.cpp:1474
 msgid "Max sources per downloading file:"
 msgstr "每个下载文件的最大的源数量:"
 
-#: src/muuli_wdr.cpp:1485
+#: src/muuli_wdr.cpp:1478
 msgid "Max simultaneous connections:"
 msgstr "最大同时连接数:"
 
-#: src/muuli_wdr.cpp:1498 src/muuli_wdr.cpp:3197
+#: src/muuli_wdr.cpp:1491 src/muuli_wdr.cpp:3169
 msgid "ED2K"
 msgstr "ED2K"
 
-#: src/muuli_wdr.cpp:1505
+#: src/muuli_wdr.cpp:1498
 msgid "Autoconnect on startup"
 msgstr "启动后自动连接"
 
-#: src/muuli_wdr.cpp:1508
+#: src/muuli_wdr.cpp:1501
 msgid "Reconnect on loss"
 msgstr "断线后自动重连"
 
-#: src/muuli_wdr.cpp:1530
+#: src/muuli_wdr.cpp:1523
 msgid "Remove dead server after"
 msgstr "如果"
 
-#: src/muuli_wdr.cpp:1531
+#: src/muuli_wdr.cpp:1524
 msgid "Static servers are never removed, even when unreachable."
 msgstr "即使静态服务器连不上也永远不删除。"
 
-#: src/muuli_wdr.cpp:1535
+#: src/muuli_wdr.cpp:1528
 msgid "retries"
 msgstr "次连接失败，则删除该服务器"
 
-#: src/muuli_wdr.cpp:1543
+#: src/muuli_wdr.cpp:1536
 msgid "List"
 msgstr "列表"
 
-#: src/muuli_wdr.cpp:1546
+#: src/muuli_wdr.cpp:1539
 msgid "Update server list when connecting to a server"
 msgstr "与服务器连接时更新服务器列表"
 
-#: src/muuli_wdr.cpp:1549
+#: src/muuli_wdr.cpp:1542
 msgid "Update server list when a client connects"
 msgstr "与其他用户连接时更新服务器列表"
 
-#: src/muuli_wdr.cpp:1552
+#: src/muuli_wdr.cpp:1545
 msgid "Use priority system"
 msgstr "启用优先级系统"
 
-#: src/muuli_wdr.cpp:1556
+#: src/muuli_wdr.cpp:1549
 msgid "Use smart LowID check on connect"
 msgstr "连接时启用智能 Low ID 检测"
 
-#: src/muuli_wdr.cpp:1560
+#: src/muuli_wdr.cpp:1553
 msgid "Safe connect"
 msgstr "安全连接"
 
-#: src/muuli_wdr.cpp:1564
+#: src/muuli_wdr.cpp:1557
 msgid "Autoconnect to servers in static list only"
 msgstr "只自动连接到静态服务器列表里的服务器"
 
-#: src/muuli_wdr.cpp:1567
+#: src/muuli_wdr.cpp:1560
 msgid "Set manually added servers to High Priority"
 msgstr "设置手动添加的服务器为高优先级"
 
-#: src/muuli_wdr.cpp:1588
+#: src/muuli_wdr.cpp:1581
 msgid "Add files to download in pause mode"
 msgstr "添加新下载文件时设为暂停状态"
 
-#: src/muuli_wdr.cpp:1590
+#: src/muuli_wdr.cpp:1583
 msgid "Add files to download with auto priority"
 msgstr "添加新下载文件时设定优先级为自动"
 
-#: src/muuli_wdr.cpp:1593
+#: src/muuli_wdr.cpp:1586
 msgid "Try to download first and last chunks first"
 msgstr "尝试先下载文件的第一段和最后一段"
 
-#: src/muuli_wdr.cpp:1597
+#: src/muuli_wdr.cpp:1590
 msgid "Endgame mode: rotate to faster sources for the final blocks"
 msgstr "末端模式：在下载最后的区块时，切换至速度更快的来源"
 
-#: src/muuli_wdr.cpp:1600
+#: src/muuli_wdr.cpp:1593
 msgid "Start next paused file when a file completes"
 msgstr "当一个文件完成时开始下一个暂停的文件"
 
-#: src/muuli_wdr.cpp:1603
+#: src/muuli_wdr.cpp:1596
 msgid "From the same category"
 msgstr "来自同一分类"
 
-#: src/muuli_wdr.cpp:1605
+#: src/muuli_wdr.cpp:1598
 msgid "In alphabetic order"
 msgstr "依照字母顺序"
 
-#: src/muuli_wdr.cpp:1607
+#: src/muuli_wdr.cpp:1600
 msgid "Preallocate disk space for new files"
 msgstr "为新文件预分配磁盘空间"
 
-#: src/muuli_wdr.cpp:1608
+#: src/muuli_wdr.cpp:1601
 msgid "For new files preallocates disk space for the whole file, thus reduces fragmentation"
 msgstr "为新文件分配全部所需的磁盘空间，这样可以减少碎片"
 
-#: src/muuli_wdr.cpp:1613
+#: src/muuli_wdr.cpp:1606
+msgid "Create new files as sparse files"
+msgstr ""
+
+#: src/muuli_wdr.cpp:1607
+msgid "A sparse file reserves its full size on disk immediately without writing real data to it -- fast, but unsupported or slow on some filesystems, and free-space accounting stays optimistic while the download is in progress. Turn this off to grow the file only as data arrives."
+msgstr ""
+
+#: src/muuli_wdr.cpp:1612
 msgid "Stop downloads when free disk space reaches "
 msgstr "停止下载当可用磁盘空间只有"
 
-#: src/muuli_wdr.cpp:1614
+#: src/muuli_wdr.cpp:1613
 msgid "Select this if you want aMule to check your disk space"
 msgstr "要求检查磁盘空间"
 
-#: src/muuli_wdr.cpp:1618
+#: src/muuli_wdr.cpp:1617
 msgid "Enter here the min disk space desired."
 msgstr "请输入最低硬盘空间。"
 
-#: src/muuli_wdr.cpp:1624
+#: src/muuli_wdr.cpp:1623
 msgid "Save 10 sources on rare files (< 20 sources)"
 msgstr "保存稀有文件（少于20个源）的10个源"
 
-#: src/muuli_wdr.cpp:1628 src/Statistics.cpp:790
+#: src/muuli_wdr.cpp:1627 src/Statistics.cpp:790
 msgid "Uploads"
 msgstr "上传"
 
-#: src/muuli_wdr.cpp:1631
+#: src/muuli_wdr.cpp:1630
 msgid "Add new shared files with auto priority"
 msgstr "添加新共享文件时设优先级为自动"
 
-#: src/muuli_wdr.cpp:1637
+#: src/muuli_wdr.cpp:1636
 msgid "Intelligent Corruption Handling (I.C.H.)"
 msgstr "智能损坏数据处理 (I.C.H.)"
 
-#: src/muuli_wdr.cpp:1640
+#: src/muuli_wdr.cpp:1639
 msgid "Enable"
 msgstr "启用"
 
-#: src/muuli_wdr.cpp:1643
+#: src/muuli_wdr.cpp:1642
 msgid "Advanced I.C.H. trusts every hash (not recommended)"
 msgstr "高级 I.C.H. 信任全部哈希值 (不推荐)"
 
-#: src/muuli_wdr.cpp:1655 src/PrefsUnifiedDlg.cpp:1990
+#: src/muuli_wdr.cpp:1654 src/PrefsUnifiedDlg.cpp:1910
 msgid "Media metadata extraction"
 msgstr "媒体元数据提取"
 
-#: src/muuli_wdr.cpp:1659
+#: src/muuli_wdr.cpp:1658
 msgid "Extract length / bitrate / codec from shared audio and video files"
 msgstr "从共享的音视频文件提取长度/比特率/编解码器信息"
 
-#: src/muuli_wdr.cpp:1661
+#: src/muuli_wdr.cpp:1660
 msgid "When enabled, aMule runs ffprobe on each shared media file to fill in the Length / Bitrate / Codec columns other clients see when they find the file in a search. Requires ffmpeg (the ffprobe binary) to be installed."
 msgstr "启用此功能后，aMule 会对每个共享媒体文件运行 ffprobe 填充其他客户端在搜索到该文件时看到的“长度”、“比特率”和“编解码器”列。需要安装 ffmpeg（ffprobe 二进制文件）。"
 
-#: src/muuli_wdr.cpp:1668
+#: src/muuli_wdr.cpp:1667
 msgid "Path to ffprobe:"
 msgstr "ffprobe 路径："
 
-#: src/muuli_wdr.cpp:1673
+#: src/muuli_wdr.cpp:1672
 msgid "Full path to the ffprobe binary. Leave empty to have aMule auto-detect it on startup."
 msgstr "ffprobe 二进制文件的完整路径。留空让 amule 在启动时自动检测。"
 
-#: src/muuli_wdr.cpp:1681
+#: src/muuli_wdr.cpp:1680
 msgid "Detect"
 msgstr "检测"
 
-#: src/muuli_wdr.cpp:1682
+#: src/muuli_wdr.cpp:1681
 msgid "Search the standard install locations for an ffprobe binary and fill the path field."
 msgstr "搜索标准的 ffprobe 二进制文件安装路径，并填写路径字段。"
 
-#: src/muuli_wdr.cpp:1706
+#: src/muuli_wdr.cpp:1705
 msgid ""
 "Completed downloads are stored here. All files in this folder are automatically shared with other peers.\n"
 "If this folder also holds files you don't want to share, point it at an aMule-only sub-folder."
@@ -4154,688 +4143,665 @@ msgstr ""
 "已完成下载的文件存储在此处。此文件夹中的所有文件将自动与其他对等点共享。\n"
 "如果此文件夹中还包含您不想共享的文件，请为 aMule 选择一个专用子文件夹。"
 
-#: src/muuli_wdr.cpp:1709
+#: src/muuli_wdr.cpp:1708
 msgid "Pick the folder where completed downloads will be stored. All files in that folder will be shared with other peers."
 msgstr "选择完成下载文件的存储文件夹。该文件夹中的所有文件都将与其他对等节点共享。"
 
-#: src/muuli_wdr.cpp:1723
+#: src/muuli_wdr.cpp:1722
 msgid "Shared folders"
 msgstr "共享的文件夹"
 
-#: src/muuli_wdr.cpp:1729
+#: src/muuli_wdr.cpp:1728
 msgid "(Folders shared by the core. Enter a path to add one.)"
 msgstr "(由核心共享的文件夹。输入路径添加一个。)"
 
-#: src/muuli_wdr.cpp:1737
+#: src/muuli_wdr.cpp:1736
 msgid "Absolute path of a folder on the core's machine, e.g. /home/user/shared"
 msgstr "核心机器上文件夹的绝对路径，如 /home/user/shared"
 
-#: src/muuli_wdr.cpp:1739 src/PrefsUnifiedDlg.cpp:2874
+#: src/muuli_wdr.cpp:1738 src/PrefsUnifiedDlg.cpp:2794
 msgid "Recursive"
 msgstr "递归"
 
-#: src/muuli_wdr.cpp:1740
+#: src/muuli_wdr.cpp:1739
 msgid "Share every sub-folder underneath this one, including ones created later."
 msgstr "分享此文件夹下每个子文件夹，包括之后创建的子文件夹。"
 
-#: src/muuli_wdr.cpp:1744 src/utils/aLinkCreator/src/alcframe.cpp:141
+#: src/muuli_wdr.cpp:1743 src/utils/aLinkCreator/src/alcframe.cpp:141
 msgid "Remove"
 msgstr "删除"
 
-#: src/muuli_wdr.cpp:1748
+#: src/muuli_wdr.cpp:1747
 msgid "(Right click on folder icon for recursive share)"
 msgstr "(鼠标右键单击文件夹图标来递归共享)"
 
-#: src/muuli_wdr.cpp:1755
+#: src/muuli_wdr.cpp:1754
 msgid "Share hidden files"
 msgstr "共享隐藏文件"
 
-#: src/muuli_wdr.cpp:1761
+#: src/muuli_wdr.cpp:1760
 msgid "Automatically rescan shared folders for changes"
 msgstr "自动重新扫描共享文件夹以检测更改"
 
-#: src/muuli_wdr.cpp:1767
+#: src/muuli_wdr.cpp:1766
 msgid "Follow symbolic links in shared folders"
 msgstr "在共享文件夹中跟踪符号链接"
 
-#: src/muuli_wdr.cpp:1773
+#: src/muuli_wdr.cpp:1772
 msgid "Exclude files matching:"
 msgstr "排除文件匹配："
 
-#: src/muuli_wdr.cpp:1776
+#: src/muuli_wdr.cpp:1775
 msgid "Wildcard patterns separated by '|', e.g. .DS_Store|Thumbs.db|*.tmp. Files whose name matches are not shared. Matching is case-insensitive."
 msgstr "以“|”分隔的通配符模式，例如 .DS_Store|Thumbs.db|*.tmp。不会共享文件名匹配的文件。匹配不区分大小写。"
 
-#: src/muuli_wdr.cpp:1780
+#: src/muuli_wdr.cpp:1779
 msgid "Patterns are regular expressions"
 msgstr "模式是正则表达式"
 
-#: src/muuli_wdr.cpp:1781
+#: src/muuli_wdr.cpp:1780
 msgid "When set, the whole field is one regular expression ('|' is alternation). When unset, it is a list of '|'-separated wildcards."
 msgstr "启用后，整个字段是一个正则表达式（'|' 表示交替）。禁用后，它是一个以 '|' 分隔的通配符列表。"
 
-#: src/muuli_wdr.cpp:1791
+#: src/muuli_wdr.cpp:1790
 msgid "Show how many shared files the current pattern would exclude."
 msgstr "显示当前模式会排除多少共享文件。"
 
-#: src/muuli_wdr.cpp:1812
+#: src/muuli_wdr.cpp:1811
 msgid "Graphs"
 msgstr "图表"
 
-#: src/muuli_wdr.cpp:1815 src/muuli_wdr.cpp:1877
+#: src/muuli_wdr.cpp:1814 src/muuli_wdr.cpp:1876
 msgid "Update delay : 5 secs"
 msgstr "刷新延迟：5 秒"
 
-#: src/muuli_wdr.cpp:1819
+#: src/muuli_wdr.cpp:1818
 msgid "Time for average graph: 100 mins"
 msgstr "平均值图表显示时间：100 分钟"
 
-#: src/muuli_wdr.cpp:1823
+#: src/muuli_wdr.cpp:1822
 msgid "Connections Graph Scale: 100 "
 msgstr "连接图表尺寸: 100 "
 
-#: src/muuli_wdr.cpp:1830
+#: src/muuli_wdr.cpp:1829
 msgid "Download graph scale:"
 msgstr "下载图表尺寸："
 
-#: src/muuli_wdr.cpp:1838
+#: src/muuli_wdr.cpp:1837
 msgid "Upload graph scale:"
 msgstr "上传图表尺寸："
 
-#: src/muuli_wdr.cpp:1848
+#: src/muuli_wdr.cpp:1847
 msgid "Colors: "
 msgstr "颜色： "
 
-#: src/muuli_wdr.cpp:1852
+#: src/muuli_wdr.cpp:1851
 msgid "Background"
 msgstr "背景"
 
-#: src/muuli_wdr.cpp:1853
+#: src/muuli_wdr.cpp:1852
 msgid "Grid"
 msgstr "网格"
 
-#: src/muuli_wdr.cpp:1854
+#: src/muuli_wdr.cpp:1853
 msgid "Download current"
 msgstr "目前下载"
 
-#: src/muuli_wdr.cpp:1855
+#: src/muuli_wdr.cpp:1854
 msgid "Download running average"
 msgstr "动态平均下载"
 
-#: src/muuli_wdr.cpp:1856
+#: src/muuli_wdr.cpp:1855
 msgid "Download session average"
 msgstr "本次运行平均下载"
 
-#: src/muuli_wdr.cpp:1857
+#: src/muuli_wdr.cpp:1856
 msgid "Upload current"
 msgstr "目前上传"
 
-#: src/muuli_wdr.cpp:1858
+#: src/muuli_wdr.cpp:1857
 msgid "Upload running average"
 msgstr "动态平均上传"
 
-#: src/muuli_wdr.cpp:1859
+#: src/muuli_wdr.cpp:1858
 msgid "Upload session average"
 msgstr "本次运行平均上传"
 
-#: src/muuli_wdr.cpp:1860
+#: src/muuli_wdr.cpp:1859
 msgid "Active connections"
 msgstr "活跃连接"
 
-#: src/muuli_wdr.cpp:1863
+#: src/muuli_wdr.cpp:1862
 msgid "Systray Icon Speed Bar"
 msgstr "系统状态栏图标速度显示"
 
-#: src/muuli_wdr.cpp:1864
+#: src/muuli_wdr.cpp:1863
 msgid "Kad-nodes current"
 msgstr "当前 Kad 节点"
 
-#: src/muuli_wdr.cpp:1865
+#: src/muuli_wdr.cpp:1864
 msgid "Kad-nodes running"
 msgstr "运行的 Kad 节点"
 
-#: src/muuli_wdr.cpp:1866
+#: src/muuli_wdr.cpp:1865
 msgid "Kad-nodes session"
 msgstr "本次运行的 Kad 节点"
 
-#: src/muuli_wdr.cpp:1870 src/muuli_wdr.cpp:2324
+#: src/muuli_wdr.cpp:1869 src/muuli_wdr.cpp:2296
 msgid "Select"
 msgstr "选择"
 
-#: src/muuli_wdr.cpp:1874
+#: src/muuli_wdr.cpp:1873
 msgid "Tree"
 msgstr "树"
 
-#: src/muuli_wdr.cpp:1884
+#: src/muuli_wdr.cpp:1883
 msgid "Number of Client Versions shown (0=unlimited)"
 msgstr "显示用户软件版本的数量(0代表不限制)"
 
-#: src/muuli_wdr.cpp:1909
+#: src/muuli_wdr.cpp:1908
 msgid "!!! WARNING !!!"
 msgstr "！！！警告！！！"
 
-#: src/muuli_wdr.cpp:1924
+#: src/muuli_wdr.cpp:1923
 msgid "Max new connections / 5 secs"
 msgstr "5 秒内最大新连接数"
 
-#: src/muuli_wdr.cpp:1926
+#: src/muuli_wdr.cpp:1925
 msgid "Concurrent Kad source lookups"
 msgstr "并发 Kad 源查找"
 
-#: src/muuli_wdr.cpp:1928
+#: src/muuli_wdr.cpp:1927
 msgid "Kad source re-search interval (minutes)"
 msgstr "Kad 源重新搜索间隔（分钟）"
 
-#: src/muuli_wdr.cpp:1930
+#: src/muuli_wdr.cpp:1929
 msgid "Source re-ask interval (minutes)"
 msgstr "源重新请求间隔（分钟）"
 
-#: src/muuli_wdr.cpp:1934
+#: src/muuli_wdr.cpp:1933
 msgid "File Buffer Size: 240000 bytes"
 msgstr "文件缓冲：24000 字节"
 
-#: src/muuli_wdr.cpp:1938
+#: src/muuli_wdr.cpp:1937
 msgid "Use MMAP: memory-mapped file access (lower memory use)"
 msgstr "使用 MMAP：内存映射文件访问（降低内存占用）"
 
-#: src/muuli_wdr.cpp:1939
+#: src/muuli_wdr.cpp:1938
 msgid "Maps part files into memory instead of buffering them on the heap, lowering the process memory footprint. May reduce download speed on some disks; best for memory-constrained or upload-heavy hosts."
 msgstr "映射 part 文件到内存而不是在堆栈上缓冲，降低进程内存占用。在一些磁盘上可能降低下载速度；最适合内存紧张或重度上传的主机。"
 
-#: src/muuli_wdr.cpp:1941
+#: src/muuli_wdr.cpp:1940
 msgid "Upload Queue Size: 5000 clients"
 msgstr "上传队列长度：5000 用户"
 
-#: src/muuli_wdr.cpp:1945
+#: src/muuli_wdr.cpp:1944
 msgid "Server connection refresh interval: Disable"
 msgstr "服务器连接刷新周期：禁用"
 
-#: src/muuli_wdr.cpp:1949
+#: src/muuli_wdr.cpp:1948
 msgid "Disable computer's timed standby mode"
 msgstr "停用电脑自动进入待命模式功能"
 
-#: src/muuli_wdr.cpp:1968
+#: src/muuli_wdr.cpp:1967
 msgid "Skin to use: "
 msgstr "要使用的皮肤: "
 
-#: src/muuli_wdr.cpp:1977
+#: src/muuli_wdr.cpp:1976
 msgid "Show \"Fast eD2k Links Handler\" in every window."
 msgstr "在全部窗口都显示“快捷 eD2k 链接处理栏”。"
 
-#: src/muuli_wdr.cpp:1980
+#: src/muuli_wdr.cpp:1979
 msgid "Show extended info on categories tabs"
 msgstr "在分类页中显示附加信息"
 
-#: src/muuli_wdr.cpp:1983
+#: src/muuli_wdr.cpp:1982
 msgid "Show application version on title"
 msgstr "在标题栏显示应用程序版本"
 
-#: src/muuli_wdr.cpp:1985
+#: src/muuli_wdr.cpp:1984
 msgid "Show transfer rates on title"
 msgstr "在标题栏显示传输速度"
 
-#: src/muuli_wdr.cpp:1987
+#: src/muuli_wdr.cpp:1986
 msgid "Before application name"
 msgstr "在应用程序名称之前"
 
-#: src/muuli_wdr.cpp:1989
+#: src/muuli_wdr.cpp:1988
 msgid "After application name"
 msgstr "在应用程序名称之后"
 
-#: src/muuli_wdr.cpp:1992
+#: src/muuli_wdr.cpp:1991
 msgid "Show overhead bandwidth"
 msgstr "显示额外开销的带宽"
 
-#: src/muuli_wdr.cpp:1996
+#: src/muuli_wdr.cpp:1995
 msgid "Vertical toolbar orientation"
 msgstr "垂直显示工具栏"
 
-#: src/muuli_wdr.cpp:1998
+#: src/muuli_wdr.cpp:1997
 msgid "Live column sorting (auto-reorder rows as their values change)"
 msgstr "实时列排序（值更改时自动调整顺序）"
 
-#: src/muuli_wdr.cpp:2005
+#: src/muuli_wdr.cpp:2004
 msgid "Download Queue Files"
 msgstr "下载队列文件"
 
-#: src/muuli_wdr.cpp:2008
+#: src/muuli_wdr.cpp:2007
 msgid "Show progress percentage"
 msgstr "显示进度百分比"
 
-#: src/muuli_wdr.cpp:2014
+#: src/muuli_wdr.cpp:2013
 msgid "Show progress bar"
 msgstr "显示进度条"
 
-#: src/muuli_wdr.cpp:2017
+#: src/muuli_wdr.cpp:2016
 msgid "Flat"
 msgstr "扁平"
 
-#: src/muuli_wdr.cpp:2021
+#: src/muuli_wdr.cpp:2020
 msgid "Round"
 msgstr "圆柱"
 
-#: src/muuli_wdr.cpp:2039
+#: src/muuli_wdr.cpp:2038
 msgid "External Connection Parameters"
 msgstr "远程连接参数"
 
-#: src/muuli_wdr.cpp:2042
+#: src/muuli_wdr.cpp:2041
 msgid "Accept external connections"
 msgstr "接受远程连接"
 
-#: src/muuli_wdr.cpp:2049 src/muuli_wdr.cpp:2108
+#: src/muuli_wdr.cpp:2048 src/muuli_wdr.cpp:2107
 msgid "IP of the listening interface:"
 msgstr "监听接口的 IP:"
 
-#: src/muuli_wdr.cpp:2052
+#: src/muuli_wdr.cpp:2051
 msgid "Enter here a valid ip in the a.b.c.d format for the listening EC interface. An empty field or 0.0.0.0 will mean any interface."
 msgstr "在此输入正确的 IP(格式：a.b.c.d)用于监听远程连接接口。空着不填或者 0.0.0.0 表示任何接口。"
 
-#: src/muuli_wdr.cpp:2073 src/muuli_wdr.cpp:2184
+#: src/muuli_wdr.cpp:2072 src/muuli_wdr.cpp:2156
 msgid "TCP port:"
 msgstr "TCP 端口："
 
-#: src/muuli_wdr.cpp:2079
+#: src/muuli_wdr.cpp:2078
 msgid "Enable UPnP port forwarding on the EC port"
 msgstr "为远程连接端口启用 UPnP"
 
-#: src/muuli_wdr.cpp:2083 src/muuli_wdr.cpp:3069
+#: src/muuli_wdr.cpp:2082 src/muuli_wdr.cpp:3041
 #: src/utils/wxCas/src/wxcasprefs.cpp:167
 msgid "Password"
 msgstr "密码"
 
-#: src/muuli_wdr.cpp:2089
+#: src/muuli_wdr.cpp:2088
 msgid "aMule API server parameters"
 msgstr "aMule API 服务器参数"
 
-#: src/muuli_wdr.cpp:2092
+#: src/muuli_wdr.cpp:2091
 msgid "Run amuleapi (REST API) on startup"
 msgstr "启动时运行 amuleapi (REST API)"
 
-#: src/muuli_wdr.cpp:2097
+#: src/muuli_wdr.cpp:2096
 msgid "HTTP port:"
 msgstr "HTTP 端口："
 
-#: src/muuli_wdr.cpp:2111
+#: src/muuli_wdr.cpp:2110
 msgid "The interface amuleapi's HTTP server listens on. 127.0.0.1 (default) accepts only local connections; use 0.0.0.0 or a specific IP to expose it to other hosts (set an admin password below)."
 msgstr "amuleapi 接口的 HTTP 服务器监听默认地址为 127.0.0.1，该地址仅接受本地连接；使用 0.0.0.0 或特定 IP 地址可将其暴露给其他主机（请在下方设置管理密码）。"
 
-#: src/muuli_wdr.cpp:2116
-msgid "Type a password to set or change it. Stored passwords cannot be shown, so leaving this empty keeps the current one."
-msgstr ""
-
-#: src/muuli_wdr.cpp:2118
+#: src/muuli_wdr.cpp:2113
 msgid "Admin password"
 msgstr "管理密码"
 
-#: src/muuli_wdr.cpp:2130 src/muuli_wdr.cpp:2147 src/PrefsUnifiedDlg.cpp:1103
-#, fuzzy
-msgid "A password is set."
-msgstr "管理密码"
-
-#: src/muuli_wdr.cpp:2134
-#, fuzzy
-msgid "Enable guest access"
-msgstr "拒绝访客访问"
-
-#: src/muuli_wdr.cpp:2135
-msgid "Guest sessions may read status and listings but cannot change anything. Turning this off clears the stored guest password."
-msgstr ""
-
-#: src/muuli_wdr.cpp:2139
-#, fuzzy
-msgid "Guest password"
-msgstr "Web服务器的访客密码"
-
-#: src/muuli_wdr.cpp:2154
-msgid "Web server parameters"
-msgstr "Web 服务参数"
-
-#: src/muuli_wdr.cpp:2157
-msgid "Run webserver on startup (deprecated)"
-msgstr "启动时运行 web 服务器（已废弃）"
-
-#: src/muuli_wdr.cpp:2163
-msgid "Web template"
-msgstr "Web 模板"
-
-#: src/muuli_wdr.cpp:2168
-msgid "Full rights password"
-msgstr "最高权限密码"
-
-#: src/muuli_wdr.cpp:2172
-msgid "Enable Low rights User"
-msgstr "启用低权限用户"
-
-#: src/muuli_wdr.cpp:2177
+#: src/muuli_wdr.cpp:2118 src/muuli_wdr.cpp:2149
 msgid "Low rights password"
 msgstr "低权限密码"
 
-#: src/muuli_wdr.cpp:2191
+#: src/muuli_wdr.cpp:2126
+msgid "Web server parameters"
+msgstr "Web 服务参数"
+
+#: src/muuli_wdr.cpp:2129
+msgid "Run webserver on startup (deprecated)"
+msgstr "启动时运行 web 服务器（已废弃）"
+
+#: src/muuli_wdr.cpp:2135
+msgid "Web template"
+msgstr "Web 模板"
+
+#: src/muuli_wdr.cpp:2140
+msgid "Full rights password"
+msgstr "最高权限密码"
+
+#: src/muuli_wdr.cpp:2144
+msgid "Enable Low rights User"
+msgstr "启用低权限用户"
+
+#: src/muuli_wdr.cpp:2163
 msgid "Enable UPnP port forwarding of the web server port"
 msgstr "为 Web 服务端口启用 UPn P端口转发"
 
-#: src/muuli_wdr.cpp:2196
+#: src/muuli_wdr.cpp:2168
 msgid "Web server UPnP TCP port (Optional)"
 msgstr "Web 服务器 UPnP 的 TCP 端口(可选)"
 
-#: src/muuli_wdr.cpp:2204
+#: src/muuli_wdr.cpp:2176
 msgid "Page Refresh Time (in secs)"
 msgstr "页面刷新周期(秒)"
 
-#: src/muuli_wdr.cpp:2211
+#: src/muuli_wdr.cpp:2183
 msgid "Enable Gzip compression"
 msgstr "启用 Gzip 压缩"
 
-#: src/muuli_wdr.cpp:2245
+#: src/muuli_wdr.cpp:2217
 msgid "Reset page to defaults"
 msgstr "重置页面为默认"
 
-#: src/muuli_wdr.cpp:2246
+#: src/muuli_wdr.cpp:2218
 msgid "Reset the settings on the current page to their default values."
 msgstr "重置当前页面设置为默认值。"
 
-#: src/muuli_wdr.cpp:2248 src/muuli_wdr.cpp:2334 src/ServerWnd.cpp:274
+#: src/muuli_wdr.cpp:2220 src/muuli_wdr.cpp:2306 src/ServerWnd.cpp:274
 #: src/ServerWnd.cpp:282
 msgid "OK"
 msgstr "确定"
 
-#: src/muuli_wdr.cpp:2250
+#: src/muuli_wdr.cpp:2222
 msgid "Click here to apply any changes made to the preferences."
 msgstr "点击这里立即使用新的设置。"
 
-#: src/muuli_wdr.cpp:2253
+#: src/muuli_wdr.cpp:2225
 msgid "Reset any changes made to the preferences."
 msgstr "取消所有设置改动。"
 
-#: src/muuli_wdr.cpp:2282
+#: src/muuli_wdr.cpp:2254
 msgid "Comment :"
 msgstr "注释 :"
 
-#: src/muuli_wdr.cpp:2289
+#: src/muuli_wdr.cpp:2261
 msgid "Incoming Dir :"
 msgstr "下载目录 :"
 
-#: src/muuli_wdr.cpp:2298
+#: src/muuli_wdr.cpp:2270
 msgid "Change priority for new assigned files :"
 msgstr "设置新加入的文件优先级为 :"
 
-#: src/muuli_wdr.cpp:2302
+#: src/muuli_wdr.cpp:2274
 msgid "Don't change"
 msgstr "不要改变"
 
-#: src/muuli_wdr.cpp:2314
+#: src/muuli_wdr.cpp:2286
 msgid "Select color for this Category (currently selected) :"
 msgstr "选择该分类颜色 (当前选择) :"
 
-#: src/muuli_wdr.cpp:2381 src/muuli_wdr.cpp:2400 src/muuli_wdr.cpp:2422
+#: src/muuli_wdr.cpp:2353 src/muuli_wdr.cpp:2372 src/muuli_wdr.cpp:2394
 msgid "Click this button to reset the log."
 msgstr "按此按钮清空日志。"
 
-#: src/muuli_wdr.cpp:2441
+#: src/muuli_wdr.cpp:2413
 msgid "Click on this button to update the servers list from URL ..."
 msgstr "按此按钮从该网址更新服务器列表 ..."
 
-#: src/muuli_wdr.cpp:2445
+#: src/muuli_wdr.cpp:2417
 msgid "Server list"
 msgstr "服务器列表"
 
-#: src/muuli_wdr.cpp:2449
+#: src/muuli_wdr.cpp:2421
 msgid "Enter the url to a server.met file here and press the button to the left to update the list of known servers."
 msgstr "输入 server.met 文件的地址，再按此按钮更新服务器列表。"
 
-#: src/muuli_wdr.cpp:2454
+#: src/muuli_wdr.cpp:2426
 msgid "Add server manually: Name"
 msgstr "手动添加服务器：名称"
 
-#: src/muuli_wdr.cpp:2457
+#: src/muuli_wdr.cpp:2429
 msgid "Enter the name of the new server here"
 msgstr "在此输入新服务器的名称"
 
-#: src/muuli_wdr.cpp:2459 src/ServerWnd.cpp:206
+#: src/muuli_wdr.cpp:2431 src/ServerWnd.cpp:206
 msgid "IP:Port"
 msgstr "IP 地址:端口"
 
-#: src/muuli_wdr.cpp:2462
+#: src/muuli_wdr.cpp:2434
 msgid "Enter the IP of the server here, using the x.x.x.x format."
 msgstr "输入新服务器的 IP 地址 (x.x.x.x格式)。"
 
-#: src/muuli_wdr.cpp:2468
+#: src/muuli_wdr.cpp:2440
 msgid "Enter the port of the server here."
 msgstr "在此请输入服务器端口。"
 
-#: src/muuli_wdr.cpp:2471
+#: src/muuli_wdr.cpp:2443
 msgid "Add manually a server (fill fields to the left before) ..."
 msgstr "添加新服务器 (先填写左侧的内容) ..."
 
-#: src/muuli_wdr.cpp:2500
+#: src/muuli_wdr.cpp:2472
 msgid "aMule Log"
 msgstr "aMule 日志"
 
-#: src/muuli_wdr.cpp:2508
+#: src/muuli_wdr.cpp:2480
 msgid "Server Info"
 msgstr "服务器信息"
 
-#: src/muuli_wdr.cpp:2512
+#: src/muuli_wdr.cpp:2484
 msgid "ED2K Info"
 msgstr "ED2K 信息"
 
-#: src/muuli_wdr.cpp:2516
+#: src/muuli_wdr.cpp:2488
 msgid "Kad Info"
 msgstr "Kad 信息"
 
-#: src/muuli_wdr.cpp:2544
+#: src/muuli_wdr.cpp:2516
 msgid "Click on this button to update the nodes list from URL ..."
 msgstr "按此更新节点列表自网址..."
 
-#: src/muuli_wdr.cpp:2548
+#: src/muuli_wdr.cpp:2520
 msgid "Nodes (0)"
 msgstr "节点 (0)"
 
-#: src/muuli_wdr.cpp:2552
+#: src/muuli_wdr.cpp:2524
 msgid "Enter the url to a nodes.dat file here and press the button to the left to update the list of known nodes."
 msgstr "输入 nodes.dat 文件的地址并按左边的按钮以更新已知节点列表"
 
-#: src/muuli_wdr.cpp:2555
+#: src/muuli_wdr.cpp:2527
 msgid "Nodes stats"
 msgstr "节点状态"
 
-#: src/muuli_wdr.cpp:2597
+#: src/muuli_wdr.cpp:2569
 msgid "Bootstrap"
 msgstr "启动"
 
-#: src/muuli_wdr.cpp:2600
+#: src/muuli_wdr.cpp:2572
 msgid "New node"
 msgstr "新节点"
 
-#: src/muuli_wdr.cpp:2605
+#: src/muuli_wdr.cpp:2577
 msgid "IP:"
 msgstr "IP："
 
-#: src/muuli_wdr.cpp:2625
+#: src/muuli_wdr.cpp:2597
 msgid "Port:"
 msgstr "端口："
 
-#: src/muuli_wdr.cpp:2638
+#: src/muuli_wdr.cpp:2610
 msgid "Bootstrap from known clients"
 msgstr "从已知用户启动"
 
-#: src/muuli_wdr.cpp:2640
+#: src/muuli_wdr.cpp:2612
 msgid "Disconnect Kad"
 msgstr "断开 Kad"
 
-#: src/muuli_wdr.cpp:2674
+#: src/muuli_wdr.cpp:2646
 msgid "Use Secure User Identification"
 msgstr "使用安全用户认证"
 
-#: src/muuli_wdr.cpp:2676
+#: src/muuli_wdr.cpp:2648
 msgid "It is recommended to enable this option. You will not receive credits if SUI is not enabled."
 msgstr "建议使用此选项，如果安全用户认证没有启用，将不会接收信用证明。"
 
-#: src/muuli_wdr.cpp:2678
+#: src/muuli_wdr.cpp:2650
 msgid "Protocol Obfuscation"
 msgstr "模糊协议"
 
-#: src/muuli_wdr.cpp:2681
+#: src/muuli_wdr.cpp:2653
 msgid "Support Protocol Obfuscation"
 msgstr "支持模糊协议"
 
-#: src/muuli_wdr.cpp:2683
+#: src/muuli_wdr.cpp:2655
 msgid "This option enabled Protocol Obfuscation, and makes aMule accept obfuscated connections from other clients."
 msgstr "此选项启用了模糊协议，可让aMule接受其他用户用迷糊协议的连接"
 
-#: src/muuli_wdr.cpp:2685
+#: src/muuli_wdr.cpp:2657
 msgid "Use obfuscation for outgoing connections"
 msgstr "为传出连接使用模糊协议"
 
-#: src/muuli_wdr.cpp:2687
+#: src/muuli_wdr.cpp:2659
 msgid "This option makes aMule use Protocol Obfuscation when connecting other clients/servers."
 msgstr "此选项使aMule在连接其他用户或服务器时使用模糊协议。"
 
-#: src/muuli_wdr.cpp:2689
+#: src/muuli_wdr.cpp:2661
 msgid "Accept only obfuscated connections"
 msgstr "仅接受模糊协议连接"
 
-#: src/muuli_wdr.cpp:2690
+#: src/muuli_wdr.cpp:2662
 msgid "This option makes aMule only accept obfuscated connections. You will have less sources, but all your traffic will be obfuscated"
 msgstr "此选项让aMule只接受模糊协议连接，源相对来说会更少，但全部数据包都将进行迷惑处理"
 
-#: src/muuli_wdr.cpp:2695
+#: src/muuli_wdr.cpp:2667
 msgid "Everybody"
 msgstr "任何人"
 
-#: src/muuli_wdr.cpp:2697
+#: src/muuli_wdr.cpp:2669
 msgid "No one"
 msgstr "没有人"
 
-#: src/muuli_wdr.cpp:2699
+#: src/muuli_wdr.cpp:2671
 msgid "Who can see my shared files:"
 msgstr "谁可查看我的共享文件："
 
-#: src/muuli_wdr.cpp:2700
+#: src/muuli_wdr.cpp:2672
 msgid "Select who can request to view a list of your shared files."
 msgstr "选择可以浏览共享文件列表的用户。"
 
-#: src/muuli_wdr.cpp:2702
+#: src/muuli_wdr.cpp:2674
 msgid "IP-Filtering"
 msgstr "IP 过滤"
 
-#: src/muuli_wdr.cpp:2709
+#: src/muuli_wdr.cpp:2681
 msgid "Filter clients"
 msgstr "过滤用户"
 
-#: src/muuli_wdr.cpp:2711
+#: src/muuli_wdr.cpp:2683
 msgid "Enable filtering of the client IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "过滤在文件~/.aMule/ipfilter.dat中定义的用户IP"
 
-#: src/muuli_wdr.cpp:2713
+#: src/muuli_wdr.cpp:2685
 msgid "Filter servers"
 msgstr "过滤服务器"
 
-#: src/muuli_wdr.cpp:2715
+#: src/muuli_wdr.cpp:2687
 msgid "Enable filtering of the server IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "过滤在文件~/.aMule/ipfilter.dat中定义的服务器IP"
 
-#: src/muuli_wdr.cpp:2719
+#: src/muuli_wdr.cpp:2691
 msgid "Reload List"
 msgstr "刷新列表"
 
-#: src/muuli_wdr.cpp:2720
+#: src/muuli_wdr.cpp:2692
 msgid "Reload the list of IPs to filter from the file ~/.aMule/ipfilter.dat"
 msgstr "更新 IP 地址过滤列表自文件 ~/.aMule/ipfilter.dat"
 
-#: src/muuli_wdr.cpp:2726
+#: src/muuli_wdr.cpp:2698
 msgid "URL:"
 msgstr "地址:"
 
-#: src/muuli_wdr.cpp:2730 src/muuli_wdr.cpp:2923
+#: src/muuli_wdr.cpp:2702 src/muuli_wdr.cpp:2895
 msgid "Update now"
 msgstr "立即更新"
 
-#: src/muuli_wdr.cpp:2733
+#: src/muuli_wdr.cpp:2705
 msgid "Auto-update ipfilter at startup"
 msgstr "启动后自动更新IP 地址过滤列表"
 
-#: src/muuli_wdr.cpp:2737
+#: src/muuli_wdr.cpp:2709
 msgid "Filtering Level:"
 msgstr "过滤级别:"
 
-#: src/muuli_wdr.cpp:2743
+#: src/muuli_wdr.cpp:2715
 msgid "Always filter LAN IPs"
 msgstr "始终过滤局域网 IP"
 
-#: src/muuli_wdr.cpp:2746
+#: src/muuli_wdr.cpp:2718
 msgid "Paranoid handling of non-matching IPs"
 msgstr "处理不匹配的 IP"
 
-#: src/muuli_wdr.cpp:2748
+#: src/muuli_wdr.cpp:2720
 msgid "Rejects a packet when its source IP differs from the IP the client claims (an anti-spoofing check). Disable only if it causes connection problems."
 msgstr "当数据包的源 IP 地址与客户端声称的 IP 地址不同时，拒绝该数据包（防欺骗检查）。仅在导致连接问题时才禁用此功能。"
 
-#: src/muuli_wdr.cpp:2750
+#: src/muuli_wdr.cpp:2722
 msgid "Use system-wide ipfilter.dat if available"
 msgstr "在可用的情况下使用系统级别的 ipfilter.dat"
 
-#: src/muuli_wdr.cpp:2751
+#: src/muuli_wdr.cpp:2723
 msgid "If there's no local ipfilter.dat found, allow usage of a system-wide ipfilter file."
 msgstr "如果没有找到本地 ipfilter.dat 文件，则允许使用系统级的IP过滤文件。"
 
-#: src/muuli_wdr.cpp:2768
+#: src/muuli_wdr.cpp:2740
 msgid "Enable Online-Signature"
 msgstr "启用在线统计"
 
-#: src/muuli_wdr.cpp:2770
+#: src/muuli_wdr.cpp:2742
 msgid "Enables the writing of the OS file, which can be used by external apps to create signatures and the like."
 msgstr "输出该文件以用于在线统计等等。"
 
-#: src/muuli_wdr.cpp:2774
+#: src/muuli_wdr.cpp:2746
 msgid "Update Frequency (Secs):"
 msgstr "更新频率 (秒):"
 
-#: src/muuli_wdr.cpp:2777
+#: src/muuli_wdr.cpp:2749
 msgid "Change the frequency (in seconds) of Online Signature updates."
 msgstr "更改在线统计文件的更新频率 (秒) 。"
 
-#: src/muuli_wdr.cpp:2785
+#: src/muuli_wdr.cpp:2757
 msgid "Save online signature file in: "
 msgstr "保存在线签名位置： "
 
-#: src/muuli_wdr.cpp:2791
+#: src/muuli_wdr.cpp:2763
 msgid "Click here to select the directory containing the the Online Signature files."
 msgstr "单击此处选择包含在线签名文件的目录。"
 
-#: src/muuli_wdr.cpp:2824
+#: src/muuli_wdr.cpp:2796
 msgid "Show country flags for clients"
 msgstr "为客户端显示国旗"
 
-#: src/muuli_wdr.cpp:2825
+#: src/muuli_wdr.cpp:2797
 msgid "Render the country flag column in the transfers, queue and search views. Requires a valid MMDB GeoIP database (see below)."
 msgstr "在传输、队列和搜索视图中渲染地区旗帜列。需要有效的 MMDB GeoIP 数据库（见下文）。"
 
-#: src/muuli_wdr.cpp:2830
+#: src/muuli_wdr.cpp:2802
 msgid "Database"
 msgstr "数据库"
 
-#: src/muuli_wdr.cpp:2846
+#: src/muuli_wdr.cpp:2818
 msgid "Source:"
 msgstr "源："
 
-#: src/muuli_wdr.cpp:2849
+#: src/muuli_wdr.cpp:2821
 msgid "DB-IP (free, no account)"
 msgstr "DB-IP（免费，无需账户）"
 
-#: src/muuli_wdr.cpp:2850
+#: src/muuli_wdr.cpp:2822
 msgid "MaxMind GeoLite2 (free, account required)"
 msgstr "MaxMind GeoLite2（免费，需注册账户）"
 
-#: src/muuli_wdr.cpp:2851
+#: src/muuli_wdr.cpp:2823
 msgid "Custom URL"
 msgstr "自定义 URL"
 
-#: src/muuli_wdr.cpp:2854
+#: src/muuli_wdr.cpp:2826
 msgid "Choose which provider supplies the GeoIP MMDB database. DB-IP is the default - no account required. MaxMind requires a free account + license key. Use Custom URL to point at any other MMDB host (e.g. a local mirror)."
 msgstr "选择哪个提供商提供 GeoIP MMDB 数据库。DB-IP 是默认选项，无需账户。MaxMind 需要一个免费账户和许可证密钥。使用自定义 URL 指向任何其他 MMDB 主机（例如本地镜像）。"
 
-#: src/muuli_wdr.cpp:2871
+#: src/muuli_wdr.cpp:2843
 msgid ""
 "No configuration required.\n"
 "\n"
@@ -4847,11 +4813,11 @@ msgstr ""
 "IP-to-Country 数据由 DB-IP.com 提供 - https://db-ip.com\n"
 "许可证：知识共享署名 4.0 国际版 - https://creativecommons.org/licenses/by/4.0/"
 
-#: src/muuli_wdr.cpp:2884
+#: src/muuli_wdr.cpp:2856
 msgid "License key:"
 msgstr "许可证密钥："
 
-#: src/muuli_wdr.cpp:2890
+#: src/muuli_wdr.cpp:2862
 msgid ""
 "Sign up for a free MaxMind account, then generate a License Key:\n"
 "https://www.maxmind.com/en/geolite2/signup\n"
@@ -4867,11 +4833,11 @@ msgstr ""
 "许可证：MaxMind GeoLite2 最终用户许可协议 - https://www.maxmind.com/en/geolite2/eula\n"
 "需要注明出处并注册账户；至少每 30 天刷新一次。"
 
-#: src/muuli_wdr.cpp:2905
+#: src/muuli_wdr.cpp:2877
 msgid "Download URL:"
 msgstr "下载地址："
 
-#: src/muuli_wdr.cpp:2911
+#: src/muuli_wdr.cpp:2883
 msgid ""
 "Must point to an .mmdb file or a .gz / .tar.gz containing one.\n"
 "URL may include credentials (https://user:pass@host/...).\n"
@@ -4881,211 +4847,211 @@ msgstr ""
 "URL 可包含凭据（例如 https://user:pass@host/...）。\n"
 "许可和署名条款由上游 URL 决定——你需自行负责。"
 
-#: src/muuli_wdr.cpp:2924
+#: src/muuli_wdr.cpp:2896
 msgid "Download the GeoIP database from the selected source."
 msgstr "从所选源下载 GeoIP 数据库。"
 
-#: src/muuli_wdr.cpp:2926
+#: src/muuli_wdr.cpp:2898
 msgid "Auto-update on startup"
 msgstr "启动后自动更新"
 
-#: src/muuli_wdr.cpp:2927
+#: src/muuli_wdr.cpp:2899
 msgid "Re-download the GeoIP database from the selected source every time aMule starts."
 msgstr "每次启动 aMule 时，从所选源重新下载 GeoIP 数据库。"
 
-#: src/muuli_wdr.cpp:2950
+#: src/muuli_wdr.cpp:2922
 msgid "Filter incoming messages (except current chat):"
 msgstr "过滤收到的消息 (不包括当前对话):"
 
-#: src/muuli_wdr.cpp:2952
+#: src/muuli_wdr.cpp:2924
 msgid "Filter all messages"
 msgstr "过滤所有消息"
 
-#: src/muuli_wdr.cpp:2954
+#: src/muuli_wdr.cpp:2926
 msgid "Filter messages from people not on your friend list"
 msgstr "过滤来自好友列表外的消息"
 
-#: src/muuli_wdr.cpp:2956
+#: src/muuli_wdr.cpp:2928
 msgid "Filter messages from unknown clients"
 msgstr "过滤来自未知用户的消息"
 
-#: src/muuli_wdr.cpp:2958
+#: src/muuli_wdr.cpp:2930
 msgid "Filter messages containing (use ',' as separator):"
 msgstr "过滤包含以下内容的消息 (用半角逗号分隔):"
 
-#: src/muuli_wdr.cpp:2961 src/muuli_wdr.cpp:2972
+#: src/muuli_wdr.cpp:2933 src/muuli_wdr.cpp:2944
 msgid "add here the words amule should filter and block messages including it"
 msgstr "输入需过滤的词组"
 
-#: src/muuli_wdr.cpp:2963
+#: src/muuli_wdr.cpp:2935
 msgid "Show received messages in the log"
 msgstr "在日志中显示接收的消息"
 
-#: src/muuli_wdr.cpp:2966
+#: src/muuli_wdr.cpp:2938
 msgid "Comments"
 msgstr "备注"
 
-#: src/muuli_wdr.cpp:2969
+#: src/muuli_wdr.cpp:2941
 msgid "Filter comments containing (use ',' as separator):"
 msgstr "过滤包含以下内容的备注 (使用“,”作为分隔符):"
 
-#: src/muuli_wdr.cpp:2994
+#: src/muuli_wdr.cpp:2966
 msgid "Enable Proxy"
 msgstr "启用代理"
 
-#: src/muuli_wdr.cpp:2995
+#: src/muuli_wdr.cpp:2967
 msgid "Enable/disable proxy support"
 msgstr "启用/禁用代理支持"
 
-#: src/muuli_wdr.cpp:2998
+#: src/muuli_wdr.cpp:2970
 msgid "Proxy type:"
 msgstr "代理类型:"
 
-#: src/muuli_wdr.cpp:3009
+#: src/muuli_wdr.cpp:2981
 msgid "Proxy host:"
 msgstr "代理服务器:"
 
-#: src/muuli_wdr.cpp:3012
+#: src/muuli_wdr.cpp:2984
 msgid "The proxy host name"
 msgstr "代理服务器名称"
 
-#: src/muuli_wdr.cpp:3014
+#: src/muuli_wdr.cpp:2986
 msgid "Proxy port:"
 msgstr "代理端口:"
 
-#: src/muuli_wdr.cpp:3017
+#: src/muuli_wdr.cpp:2989
 msgid "The proxy port"
 msgstr "代理端口"
 
-#: src/muuli_wdr.cpp:3019
+#: src/muuli_wdr.cpp:2991
 msgid "Enable authentication"
 msgstr "启用验证："
 
-#: src/muuli_wdr.cpp:3020
+#: src/muuli_wdr.cpp:2992
 msgid "Enable/disable username/password authentication"
 msgstr "启用/禁用用户名/密码验证"
 
-#: src/muuli_wdr.cpp:3023
+#: src/muuli_wdr.cpp:2995
 msgid "Username: "
 msgstr "用户名: "
 
-#: src/muuli_wdr.cpp:3026
+#: src/muuli_wdr.cpp:2998
 msgid "The username to use to connect to the proxy"
 msgstr "连接代理服务器的用户名"
 
-#: src/muuli_wdr.cpp:3028
+#: src/muuli_wdr.cpp:3000
 msgid "Password:"
 msgstr "密码:"
 
-#: src/muuli_wdr.cpp:3031
+#: src/muuli_wdr.cpp:3003
 msgid "The password to use to connect to the proxy"
 msgstr "连接代理服务器的密码"
 
-#: src/muuli_wdr.cpp:3050
+#: src/muuli_wdr.cpp:3022
 msgid "Connect to:"
 msgstr "连接到:"
 
-#: src/muuli_wdr.cpp:3059
+#: src/muuli_wdr.cpp:3031
 msgid "Login to remote amule"
 msgstr "登录远程 amule"
 
-#: src/muuli_wdr.cpp:3064
+#: src/muuli_wdr.cpp:3036
 msgid "User name"
 msgstr "用户名"
 
-#: src/muuli_wdr.cpp:3075
+#: src/muuli_wdr.cpp:3047
 msgid "Remember those settings"
 msgstr "记住这些设置"
 
-#: src/muuli_wdr.cpp:3078
+#: src/muuli_wdr.cpp:3050
 msgid "Force ZLIB compression"
 msgstr "强制使用 ZLIB 压缩"
 
-#: src/muuli_wdr.cpp:3102
+#: src/muuli_wdr.cpp:3074
 msgid "Enable Verbose Debug-Logging."
 msgstr "启用详细调试日志。"
 
-#: src/muuli_wdr.cpp:3104
+#: src/muuli_wdr.cpp:3076
 msgid "Only to Logfile"
 msgstr "只记录到日志文件"
 
-#: src/muuli_wdr.cpp:3106
+#: src/muuli_wdr.cpp:3078
 msgid "Message Categories:"
 msgstr "消息分类:"
 
-#: src/muuli_wdr.cpp:3130 src/PartFileConvertDlg.cpp:160
+#: src/muuli_wdr.cpp:3102 src/PartFileConvertDlg.cpp:160
 msgid "Waiting..."
 msgstr "等待中..."
 
-#: src/muuli_wdr.cpp:3150
+#: src/muuli_wdr.cpp:3122
 msgid "Add imports"
 msgstr "添加导入文件"
 
-#: src/muuli_wdr.cpp:3153
+#: src/muuli_wdr.cpp:3125
 msgid "Retry selected"
 msgstr "重试所选"
 
-#: src/muuli_wdr.cpp:3155
+#: src/muuli_wdr.cpp:3127
 msgid "Remove selected"
 msgstr "删除所选"
 
-#: src/muuli_wdr.cpp:3218
+#: src/muuli_wdr.cpp:3190
 msgid "Event Types"
 msgstr "事件类型"
 
-#: src/muuli_wdr.cpp:3237
+#: src/muuli_wdr.cpp:3209
 msgid "Statistics and queued clients for selected file(s) : Session / All time"
 msgstr "所选文件的统计和队列用户：会话/全部时间"
 
-#: src/muuli_wdr.cpp:3261
+#: src/muuli_wdr.cpp:3233
 msgid "Active Uploads"
 msgstr "活跃上传"
 
-#: src/muuli_wdr.cpp:3275
+#: src/muuli_wdr.cpp:3247
 msgid "Percent of total files"
 msgstr "全部文件的百分比"
 
-#: src/muuli_wdr.cpp:3327
+#: src/muuli_wdr.cpp:3299
 msgid "Show Clients for"
 msgstr "显示客户端"
 
-#: src/muuli_wdr.cpp:3329
+#: src/muuli_wdr.cpp:3301
 msgid "All files"
 msgstr "所有文件"
 
-#: src/muuli_wdr.cpp:3332
+#: src/muuli_wdr.cpp:3304
 msgid "Selected files"
 msgstr "选择的文件"
 
-#: src/muuli_wdr.cpp:3335
+#: src/muuli_wdr.cpp:3307
 msgid "Active uploads only"
 msgstr "仅活跃上传"
 
-#: src/muuli_wdr.cpp:3342
+#: src/muuli_wdr.cpp:3314
 msgid "Reload:"
 msgstr "重新载入:"
 
-#: src/muuli_wdr.cpp:3346
+#: src/muuli_wdr.cpp:3318
 msgid "Reload your shared files"
 msgstr "刷新共享文件"
 
-#: src/muuli_wdr.cpp:3409
+#: src/muuli_wdr.cpp:3381
 msgid "Send"
 msgstr "发送"
 
-#: src/muuli_wdr.cpp:3410
+#: src/muuli_wdr.cpp:3382
 msgid "Sends the specified message."
 msgstr "发送指定消息。"
 
-#: src/muuli_wdr.cpp:3414
+#: src/muuli_wdr.cpp:3386
 msgid "Close this chat-session."
 msgstr "结束本次聊天。"
 
-#: src/muuli_wdr.cpp:3437
+#: src/muuli_wdr.cpp:3409
 msgid "Connect to any server and/or Kad"
 msgstr "连接至任何服务器和/或 Kad"
 
-#: src/muuli_wdr.cpp:3443 src/SharedFilesCtrl.cpp:142 src/Statistics.cpp:941
+#: src/muuli_wdr.cpp:3415 src/SharedFilesCtrl.cpp:142 src/Statistics.cpp:941
 msgid "Shared Files"
 msgstr "共享文件"
 
@@ -5445,248 +5411,248 @@ msgstr "已下载"
 msgid "ERROR: Failed to open partfile '%s'"
 msgstr "错误：打开part文件'%s'失败"
 
-#: src/Preferences.cpp:701
+#: src/Preferences.cpp:673
 msgid "System default"
 msgstr "系统默认"
 
-#: src/Preferences.cpp:702
+#: src/Preferences.cpp:674
 msgid "Albanian"
 msgstr "阿尔巴尼亚语"
 
-#: src/Preferences.cpp:703
+#: src/Preferences.cpp:675
 msgid "Arabic"
 msgstr "阿拉伯语"
 
-#: src/Preferences.cpp:704
+#: src/Preferences.cpp:676
 msgid "Asturian"
 msgstr "澳大利亚"
 
-#: src/Preferences.cpp:705
+#: src/Preferences.cpp:677
 msgid "Basque"
 msgstr "巴斯克语"
 
-#: src/Preferences.cpp:706
+#: src/Preferences.cpp:678
 msgid "Bulgarian"
 msgstr "保加利亚语"
 
-#: src/Preferences.cpp:707
+#: src/Preferences.cpp:679
 msgid "Catalan"
 msgstr "加泰罗尼亚语"
 
-#: src/Preferences.cpp:708
+#: src/Preferences.cpp:680
 msgid "Chinese (Simplified)"
 msgstr "简体中文"
 
-#: src/Preferences.cpp:709
+#: src/Preferences.cpp:681
 msgid "Chinese (Traditional)"
 msgstr "繁体中文"
 
-#: src/Preferences.cpp:710
+#: src/Preferences.cpp:682
 msgid "Croatian"
 msgstr "克罗的亚语"
 
-#: src/Preferences.cpp:711
+#: src/Preferences.cpp:683
 msgid "Czech"
 msgstr "捷克语"
 
-#: src/Preferences.cpp:712
+#: src/Preferences.cpp:684
 msgid "Danish"
 msgstr "丹麦语"
 
-#: src/Preferences.cpp:713
+#: src/Preferences.cpp:685
 msgid "Dutch"
 msgstr "荷兰语"
 
-#: src/Preferences.cpp:714
+#: src/Preferences.cpp:686
 msgid "English (U.K.)"
 msgstr "英语（英国）"
 
-#: src/Preferences.cpp:715
+#: src/Preferences.cpp:687
 msgid "English (U.S.)"
 msgstr "英语（美国）"
 
-#: src/Preferences.cpp:716
+#: src/Preferences.cpp:688
 msgid "Estonian"
 msgstr "爱斯托尼亚语"
 
-#: src/Preferences.cpp:717
+#: src/Preferences.cpp:689
 msgid "Finnish"
 msgstr "芬兰语"
 
-#: src/Preferences.cpp:718
+#: src/Preferences.cpp:690
 msgid "French"
 msgstr "法语"
 
-#: src/Preferences.cpp:719
+#: src/Preferences.cpp:691
 msgid "Galician"
 msgstr "加利西亚语"
 
-#: src/Preferences.cpp:720
+#: src/Preferences.cpp:692
 msgid "German"
 msgstr "德语"
 
-#: src/Preferences.cpp:721
+#: src/Preferences.cpp:693
 msgid "Greek"
 msgstr "希腊语"
 
-#: src/Preferences.cpp:722
+#: src/Preferences.cpp:694
 msgid "Hebrew"
 msgstr "希伯来语"
 
-#: src/Preferences.cpp:723
+#: src/Preferences.cpp:695
 msgid "Hungarian"
 msgstr "匈牙利语"
 
-#: src/Preferences.cpp:724
+#: src/Preferences.cpp:696
 msgid "Italian"
 msgstr "意大利语"
 
-#: src/Preferences.cpp:725
+#: src/Preferences.cpp:697
 msgid "Japanese"
 msgstr "日语"
 
-#: src/Preferences.cpp:726
+#: src/Preferences.cpp:698
 msgid "Korean"
 msgstr "韩语"
 
-#: src/Preferences.cpp:727
+#: src/Preferences.cpp:699
 msgid "Latvian"
 msgstr "拉脱维亚语"
 
-#: src/Preferences.cpp:728
+#: src/Preferences.cpp:700
 msgid "Lithuanian"
 msgstr "立陶宛语"
 
-#: src/Preferences.cpp:729
+#: src/Preferences.cpp:701
 msgid "Norwegian (Nynorsk)"
 msgstr "新挪威语"
 
-#: src/Preferences.cpp:730
+#: src/Preferences.cpp:702
 msgid "Polish"
 msgstr "芬兰语"
 
-#: src/Preferences.cpp:731
+#: src/Preferences.cpp:703
 msgid "Portuguese"
 msgstr "葡萄牙语"
 
-#: src/Preferences.cpp:732
+#: src/Preferences.cpp:704
 msgid "Portuguese (Brazilian)"
 msgstr "葡萄牙语（巴西）"
 
-#: src/Preferences.cpp:733
+#: src/Preferences.cpp:705
 msgid "Romanian"
 msgstr "罗马尼亚语"
 
-#: src/Preferences.cpp:734
+#: src/Preferences.cpp:706
 msgid "Russian"
 msgstr "俄语"
 
-#: src/Preferences.cpp:735
+#: src/Preferences.cpp:707
 msgid "Slovenian"
 msgstr "斯洛文尼亚语"
 
-#: src/Preferences.cpp:736
+#: src/Preferences.cpp:708
 msgid "Spanish"
 msgstr "西班牙语"
 
-#: src/Preferences.cpp:737
+#: src/Preferences.cpp:709
 msgid "Swedish"
 msgstr "瑞典语"
 
-#: src/Preferences.cpp:738
+#: src/Preferences.cpp:710
 msgid "Turkish"
 msgstr "土耳其语"
 
-#: src/Preferences.cpp:739
+#: src/Preferences.cpp:711
 msgid "Ukrainian"
 msgstr "乌克兰"
 
-#: src/Preferences.cpp:842
+#: src/Preferences.cpp:814
 msgid "Change Language"
 msgstr "更改语言"
 
-#: src/Preferences.cpp:906
+#: src/Preferences.cpp:878
 msgid "There are no translations installed for aMule"
 msgstr "没有为 aMule 安装语言文件"
 
-#: src/Preferences.cpp:907
+#: src/Preferences.cpp:879
 msgid "No languages available"
 msgstr "语言文件不可用"
 
-#: src/Preferences.cpp:1038
+#: src/Preferences.cpp:1010
 msgid "no options available"
 msgstr "选项不可用"
 
-#: src/Preferences.cpp:2226
+#: src/Preferences.cpp:2179
 msgid "Invalid category found, skipping"
 msgstr "发现无效的分类，跳过"
 
-#: src/Preferences.cpp:2395
+#: src/Preferences.cpp:2348
 msgid "TCP port can't be higher than 65532 due to server UDP socket being TCP+3"
 msgstr "TCP端口不可高于65532，因为服务器UDP端口值为TCP端口值+3"
 
-#: src/Preferences.cpp:2396
+#: src/Preferences.cpp:2349
 #, c-format
 msgid "Default port will be used (%d)"
 msgstr "缺省端口将被使用（%d）"
 
-#: src/PrefsUnifiedDlg.cpp:300 src/Statistics.cpp:866
+#: src/PrefsUnifiedDlg.cpp:298 src/Statistics.cpp:866
 msgid "Connection"
 msgstr "连接"
 
-#: src/PrefsUnifiedDlg.cpp:301 src/SearchListCtrl.cpp:117
+#: src/PrefsUnifiedDlg.cpp:299 src/SearchListCtrl.cpp:117
 msgid "Directories"
 msgstr "目录"
 
-#: src/PrefsUnifiedDlg.cpp:302 src/Statistics.cpp:917
+#: src/PrefsUnifiedDlg.cpp:300 src/Statistics.cpp:917
 msgid "Servers"
 msgstr "服务器"
 
-#: src/PrefsUnifiedDlg.cpp:303 src/ServerListCtrl.cpp:96
+#: src/PrefsUnifiedDlg.cpp:301 src/ServerListCtrl.cpp:96
 msgid "Files"
 msgstr "文件"
 
-#: src/PrefsUnifiedDlg.cpp:304
+#: src/PrefsUnifiedDlg.cpp:302
 msgid "Security"
 msgstr "安全"
 
-#: src/PrefsUnifiedDlg.cpp:305
+#: src/PrefsUnifiedDlg.cpp:303
 msgid "Interface"
 msgstr "界面"
 
-#: src/PrefsUnifiedDlg.cpp:312
+#: src/PrefsUnifiedDlg.cpp:310
 msgid "IP2Country"
 msgstr "IP2Country"
 
-#: src/PrefsUnifiedDlg.cpp:315
+#: src/PrefsUnifiedDlg.cpp:313
 msgid "Proxy"
 msgstr "代理"
 
-#: src/PrefsUnifiedDlg.cpp:316
+#: src/PrefsUnifiedDlg.cpp:314
 msgid "Filters"
 msgstr "过滤"
 
-#: src/PrefsUnifiedDlg.cpp:317
+#: src/PrefsUnifiedDlg.cpp:315
 msgid "Remote Controls"
 msgstr "远程控制"
 
-#: src/PrefsUnifiedDlg.cpp:318
+#: src/PrefsUnifiedDlg.cpp:316
 msgid "Online Signature"
 msgstr "在线签名"
 
-#: src/PrefsUnifiedDlg.cpp:319
+#: src/PrefsUnifiedDlg.cpp:317
 msgid "Advanced"
 msgstr "高级"
 
-#: src/PrefsUnifiedDlg.cpp:320
+#: src/PrefsUnifiedDlg.cpp:318
 msgid "Events"
 msgstr "事件"
 
-#: src/PrefsUnifiedDlg.cpp:323
+#: src/PrefsUnifiedDlg.cpp:321
 msgid "Debugging"
 msgstr "调试"
 
-#: src/PrefsUnifiedDlg.cpp:453
+#: src/PrefsUnifiedDlg.cpp:451
 msgid ""
 "The following variables will be substituted:\n"
 "    %PARTFILE - full path to the file\n"
@@ -5696,15 +5662,15 @@ msgstr ""
 "    %PARTFILE - 文件的完整路径\n"
 "    %PARTNAME - 仅文件名"
 
-#: src/PrefsUnifiedDlg.cpp:474
+#: src/PrefsUnifiedDlg.cpp:472
 msgid "Tray icon support requires libayatana-appindicator3 at compile time."
 msgstr "系统托盘图标支持在编译时需要 libayatana-appindicator3。"
 
-#: src/PrefsUnifiedDlg.cpp:490
+#: src/PrefsUnifiedDlg.cpp:488
 msgid "Not available on Wayland: the protocol does not report when a window is minimized, so this option cannot intercept the system minimize button. Workaround: launch aMule with `GDK_BACKEND=x11` to use XWayland instead."
 msgstr "在 Wayland 上不可用：该协议无法报告窗口何时被最小化，因此此选项无法拦截系统的最小化按钮。解决方法：使用 `GDK_BACKEND=x11` 启动 aMule，以改用 XWayland。"
 
-#: src/PrefsUnifiedDlg.cpp:536
+#: src/PrefsUnifiedDlg.cpp:534
 msgid ""
 "Do not change these setting unless you know\n"
 "what you are doing, otherwise you can easily\n"
@@ -5720,35 +5686,26 @@ msgstr ""
 "即使不改动这些设置，aMule\n"
 "也完全可以正常运行。"
 
-#: src/PrefsUnifiedDlg.cpp:647
+#: src/PrefsUnifiedDlg.cpp:645
 #, c-format
 msgid "Failed to connect Cfg to widget with the ID %d and key %s"
 msgstr "使用ID %d和密匙%s连接Cfg到小插件失败"
 
-#: src/PrefsUnifiedDlg.cpp:695
+#: src/PrefsUnifiedDlg.cpp:693
 #, c-format
 msgid "Failed to transfer data from Cfg to Widget with the ID %d and key %s"
 msgstr "通过ID %d和密匙%s把数据从Cfg转移到小插件失败"
 
-#: src/PrefsUnifiedDlg.cpp:801
+#: src/PrefsUnifiedDlg.cpp:799
 msgid "The type of proxy you are connecting to"
 msgstr "正在连接的代理服务器类型"
 
-#: src/PrefsUnifiedDlg.cpp:1020
+#: src/PrefsUnifiedDlg.cpp:1003
 #, c-format
 msgid "Failed to transfer data from Widget to Cfg with the ID %d and key %s"
 msgstr "通过ID %d和密匙%s把数据从小插件转移到Cfg失败"
 
 #: src/PrefsUnifiedDlg.cpp:1103
-#, fuzzy
-msgid "No password set."
-msgstr "管理密码"
-
-#: src/PrefsUnifiedDlg.cpp:1132
-msgid "Guest access needs a password. Type one in the guest password field, or untick Enable guest access."
-msgstr ""
-
-#: src/PrefsUnifiedDlg.cpp:1144
 msgid ""
 "aMule must be restarted to enable these changes:\n"
 "\n"
@@ -5756,39 +5713,39 @@ msgstr ""
 "重启aMule后这些更改才能生效：\n"
 "\n"
 
-#: src/PrefsUnifiedDlg.cpp:1151
+#: src/PrefsUnifiedDlg.cpp:1110
 msgid "- TCP port changed.\n"
 msgstr "- TCP端口已更改。\n"
 
-#: src/PrefsUnifiedDlg.cpp:1156
+#: src/PrefsUnifiedDlg.cpp:1115
 msgid "- UDP port changed.\n"
 msgstr "- UDP端口已更改。\n"
 
-#: src/PrefsUnifiedDlg.cpp:1161
+#: src/PrefsUnifiedDlg.cpp:1120
 msgid "- Network interface binding changed.\n"
 msgstr "- 更改了网络接口绑定.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1166
+#: src/PrefsUnifiedDlg.cpp:1125
 msgid "- External connect port changed.\n"
 msgstr "- 外部连接端口已更改。\n"
 
-#: src/PrefsUnifiedDlg.cpp:1170
+#: src/PrefsUnifiedDlg.cpp:1129
 msgid "- External connect acceptance changed.\n"
 msgstr "- 更改了外部连接接受。\n"
 
-#: src/PrefsUnifiedDlg.cpp:1174
+#: src/PrefsUnifiedDlg.cpp:1133
 msgid "- External connect interface changed.\n"
 msgstr "- 更改了外部连接接口。\n"
 
-#: src/PrefsUnifiedDlg.cpp:1178
+#: src/PrefsUnifiedDlg.cpp:1137
 msgid "- Protocol obfuscation support changed.\n"
 msgstr "- 模糊协议支持已更改。\n"
 
-#: src/PrefsUnifiedDlg.cpp:1193
+#: src/PrefsUnifiedDlg.cpp:1151
 msgid "- amuleapi settings changed.\n"
 msgstr "- amuleapi 设置已更改。\n"
 
-#: src/PrefsUnifiedDlg.cpp:1202
+#: src/PrefsUnifiedDlg.cpp:1160
 msgid ""
 "Your Auto-update server list is empty.\n"
 "'Auto-update server list at startup' will be disabled."
@@ -5796,7 +5753,7 @@ msgstr ""
 "您的自动更新服务器列表是可空的，\n"
 "启动时自动更新服务器列表功能将被禁用。"
 
-#: src/PrefsUnifiedDlg.cpp:1213
+#: src/PrefsUnifiedDlg.cpp:1171
 msgid ""
 "You have enabled external connections but have not specified a password.\n"
 "External connections cannot be enabled unless a valid password is specified."
@@ -5804,32 +5761,27 @@ msgstr ""
 "您已经启用了远程连接但还没有设置密码。\n"
 "远程连接在没有有效密码的情况下不能使用。"
 
-#: src/PrefsUnifiedDlg.cpp:1246
-#, c-format
-msgid "The amuleapi password could not be saved: %s"
-msgstr ""
-
-#: src/PrefsUnifiedDlg.cpp:1276
+#: src/PrefsUnifiedDlg.cpp:1202
 msgid "- Language changed.\n"
 msgstr "- 语言已更改。\n"
 
-#: src/PrefsUnifiedDlg.cpp:1281
+#: src/PrefsUnifiedDlg.cpp:1207
 msgid "- Temp folder changed.\n"
 msgstr "- 临时文件目录已更改。\n"
 
-#: src/PrefsUnifiedDlg.cpp:1286
+#: src/PrefsUnifiedDlg.cpp:1212
 msgid "- ED2K network enabled.\n"
 msgstr "-ED2K网络已启用。\n"
 
-#: src/PrefsUnifiedDlg.cpp:1319
+#: src/PrefsUnifiedDlg.cpp:1245
 msgid "The shared-file exclusion pattern is not a valid regular expression. The filter has been left disabled."
 msgstr "共享文件排除模式不是有效的正则表达式。已禁用该筛选器。"
 
-#: src/PrefsUnifiedDlg.cpp:1321 src/PrefsUnifiedDlg.cpp:1921
+#: src/PrefsUnifiedDlg.cpp:1247 src/PrefsUnifiedDlg.cpp:1841
 msgid "Invalid regular expression"
 msgstr "无效的正则表达式"
 
-#: src/PrefsUnifiedDlg.cpp:1398
+#: src/PrefsUnifiedDlg.cpp:1324
 msgid ""
 "Both eD2k and Kad network are disabled.\n"
 "You won't be able to connect until you enable at least one of them."
@@ -5837,7 +5789,7 @@ msgstr ""
 "eD2k 和 Kad 网络都已被禁用，\n"
 "你至少要启用其中的一项才能连接。"
 
-#: src/PrefsUnifiedDlg.cpp:1403
+#: src/PrefsUnifiedDlg.cpp:1329
 msgid ""
 "Kad will not start if your UDP port is disabled.\n"
 "Enable UDP port or disable Kad."
@@ -5845,7 +5797,7 @@ msgstr ""
 "如果你的 UDP 端口被禁用，Kad 将不能启动。\n"
 "启动 UDP 端口或禁用 Kad。"
 
-#: src/PrefsUnifiedDlg.cpp:1459
+#: src/PrefsUnifiedDlg.cpp:1385
 msgid ""
 "\n"
 "You MUST restart aMule now.\n"
@@ -5855,68 +5807,68 @@ msgstr ""
 "你必须现在重启aMule，\n"
 "如果现在不重启的话，出现任何问题可别怪别人。\n"
 
-#: src/PrefsUnifiedDlg.cpp:1524
+#: src/PrefsUnifiedDlg.cpp:1450
 msgid "Could not register aMule for autostart at login. The autostart store may be read-only."
 msgstr "无法将 aMule 注册为登录时自动启动。自动启动存储可能为只读。"
 
-#: src/PrefsUnifiedDlg.cpp:1526
+#: src/PrefsUnifiedDlg.cpp:1452
 msgid "Could not remove the autostart-at-login entry."
 msgstr "无法移除登录时自动启动的条目。"
 
-#: src/PrefsUnifiedDlg.cpp:1527
+#: src/PrefsUnifiedDlg.cpp:1453
 msgid "Autostart"
 msgstr "自启动"
 
-#: src/PrefsUnifiedDlg.cpp:1542
+#: src/PrefsUnifiedDlg.cpp:1468
 msgid "Register file type"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1542
+#: src/PrefsUnifiedDlg.cpp:1468
 msgid "Register URL handler"
 msgstr "注册URL处理程序"
 
-#: src/PrefsUnifiedDlg.cpp:1550
+#: src/PrefsUnifiedDlg.cpp:1476
 #, c-format
 msgid "aMule only handles eD2k-compatible magnets. If you replace the current magnet handler (%s), BitTorrent magnet links will stop working - aMule cannot download BitTorrent content. Continue?"
 msgstr "aMule 仅支持兼容 eD2k 的磁力链接。如果替换当前磁力链接处理程序（%s），BitTorrent 磁力链接将停止工作——aMule 无法下载 BitTorrent 内容。是否继续？"
 
-#: src/PrefsUnifiedDlg.cpp:1555
+#: src/PrefsUnifiedDlg.cpp:1481
 #, fuzzy, c-format
 msgid "Another application currently opens .emulecollection files (%s). Replace it with aMule?"
 msgstr "目前已存在另一个应用程序作为这些链接（%s) 的默认处理程序。是否要将其换成aMule？"
 
-#: src/PrefsUnifiedDlg.cpp:1560
+#: src/PrefsUnifiedDlg.cpp:1486
 #, c-format
 msgid "Another application is currently the default handler for these links (%s). Replace it with aMule?"
 msgstr "目前已存在另一个应用程序作为这些链接（%s) 的默认处理程序。是否要将其换成aMule？"
 
-#: src/PrefsUnifiedDlg.cpp:1585
+#: src/PrefsUnifiedDlg.cpp:1511
 #, fuzzy
 msgid "Could not register aMule for .emulecollection files. The registration store may be read-only."
 msgstr "无法将 aMule 注册为URL处理程序。自动启动存储可能为只读。"
 
-#: src/PrefsUnifiedDlg.cpp:1587
+#: src/PrefsUnifiedDlg.cpp:1513
 #, fuzzy
 msgid "Could not remove the file type registration."
 msgstr "无法移除URL处理程序的注册。"
 
-#: src/PrefsUnifiedDlg.cpp:1589
+#: src/PrefsUnifiedDlg.cpp:1515
 msgid "Could not register aMule as the URL handler. The registration store may be read-only."
 msgstr "无法将 aMule 注册为URL处理程序。自动启动存储可能为只读。"
 
-#: src/PrefsUnifiedDlg.cpp:1591
+#: src/PrefsUnifiedDlg.cpp:1517
 msgid "Could not remove the URL handler registration."
 msgstr "无法移除URL处理程序的注册。"
 
-#: src/PrefsUnifiedDlg.cpp:1661 src/PrefsUnifiedDlg.cpp:1688
+#: src/PrefsUnifiedDlg.cpp:1587 src/PrefsUnifiedDlg.cpp:1614
 msgid "The web server and aMule API require external connections to be enabled."
 msgstr "启用 web 服务器和 aMule API 需要外部连接。"
 
-#: src/PrefsUnifiedDlg.cpp:1671
+#: src/PrefsUnifiedDlg.cpp:1597
 msgid "The aMule web server is deprecated. Consider running the aMule API instead."
 msgstr "aMule Web 服务器已弃用。请考虑运行 aMule API。"
 
-#: src/PrefsUnifiedDlg.cpp:1735
+#: src/PrefsUnifiedDlg.cpp:1655
 msgid ""
 "Your Auto-update servers list is in blank.\n"
 "Please fill in at least one URL to point to a valid server.met file.\n"
@@ -5926,64 +5878,64 @@ msgstr ""
 "请输入至少一个指向有效 server.met 的网址，\n"
 "点击这个勾选框旁边的\"列表\"按钮然后输入网址。"
 
-#: src/PrefsUnifiedDlg.cpp:1876
+#: src/PrefsUnifiedDlg.cpp:1796
 msgid "Temporary files"
 msgstr "临时文件"
 
-#: src/PrefsUnifiedDlg.cpp:1881
+#: src/PrefsUnifiedDlg.cpp:1801
 msgid "Incoming files"
 msgstr "传入文件"
 
-#: src/PrefsUnifiedDlg.cpp:1886
+#: src/PrefsUnifiedDlg.cpp:1806
 msgid "Online Signatures"
 msgstr "在线签名"
 
-#: src/PrefsUnifiedDlg.cpp:1899
+#: src/PrefsUnifiedDlg.cpp:1819
 #, c-format
 msgid "Choose a folder for %s"
 msgstr "为%s选择文件夹"
 
-#: src/PrefsUnifiedDlg.cpp:1923
+#: src/PrefsUnifiedDlg.cpp:1843
 #, c-format
 msgid "Would exclude %u of %u shared file"
 msgid_plural "Would exclude %u of %u shared files"
 msgstr[0] "将排除 %u 个共享文件，共 %u 个"
 msgstr[1] "将排除 %u 个共享文件，共 %u 个"
 
-#: src/PrefsUnifiedDlg.cpp:1940
+#: src/PrefsUnifiedDlg.cpp:1860
 msgid "Browse for videoplayer"
 msgstr "浏览寻找视频播放器"
 
-#: src/PrefsUnifiedDlg.cpp:1944
+#: src/PrefsUnifiedDlg.cpp:1864
 msgid "Select browser"
 msgstr "选择浏览器"
 
-#: src/PrefsUnifiedDlg.cpp:1948
+#: src/PrefsUnifiedDlg.cpp:1868
 msgid "Select ffprobe binary"
 msgstr "选择 ffprobe 文件"
 
-#: src/PrefsUnifiedDlg.cpp:1954
+#: src/PrefsUnifiedDlg.cpp:1874
 #, c-format
 msgid "Executable%s"
 msgstr "可执行%s"
 
-#: src/PrefsUnifiedDlg.cpp:1988
+#: src/PrefsUnifiedDlg.cpp:1908
 msgid "ffprobe not found on PATH or in the standard install locations. Install ffmpeg (which ships ffprobe) or use Browse to pick a binary manually."
 msgstr "未在 PATH 或标准安装位置找到 ffprobe。安装 ffmpeg（ffmpeg 自带 ffprobe），或使用“浏览”手动选择一个二进制文件。"
 
-#: src/PrefsUnifiedDlg.cpp:2000
+#: src/PrefsUnifiedDlg.cpp:1920
 msgid "Reset the settings on this page to their default values?"
 msgstr "重置此页面设置为默认值?"
 
-#: src/PrefsUnifiedDlg.cpp:2001
+#: src/PrefsUnifiedDlg.cpp:1921
 msgid "Reset to defaults"
 msgstr "重置为默认"
 
-#: src/PrefsUnifiedDlg.cpp:2028
+#: src/PrefsUnifiedDlg.cpp:1948
 msgid "Edit server list"
 msgstr "编辑服务器列表"
 
-#: src/PrefsUnifiedDlg.cpp:2029
+#: src/PrefsUnifiedDlg.cpp:1949
 msgid ""
 "Add here URL's to download server.met files.\n"
 "Only one url on each line."
@@ -5991,114 +5943,114 @@ msgstr ""
 "在此添加下载 server.met 文件的地址\n"
 "每行只限一个。"
 
-#: src/PrefsUnifiedDlg.cpp:2084
+#: src/PrefsUnifiedDlg.cpp:2004
 msgid "IP2Country update failed"
 msgstr "IP2Country 更新失败"
 
-#: src/PrefsUnifiedDlg.cpp:2229 src/PrefsUnifiedDlg.cpp:2260
+#: src/PrefsUnifiedDlg.cpp:2149 src/PrefsUnifiedDlg.cpp:2180
 msgid "Data by MaxMind GeoLite2"
 msgstr "数据来自 MaxMind GeoLite2"
 
-#: src/PrefsUnifiedDlg.cpp:2231 src/PrefsUnifiedDlg.cpp:2262
+#: src/PrefsUnifiedDlg.cpp:2151 src/PrefsUnifiedDlg.cpp:2182
 msgid "Custom source"
 msgstr "自定义源"
 
-#: src/PrefsUnifiedDlg.cpp:2233 src/PrefsUnifiedDlg.cpp:2264
+#: src/PrefsUnifiedDlg.cpp:2153 src/PrefsUnifiedDlg.cpp:2184
 msgid "Data by DB-IP.com"
 msgstr "数据来源：DB-IP.com"
 
-#: src/PrefsUnifiedDlg.cpp:2284
+#: src/PrefsUnifiedDlg.cpp:2204
 #, c-format
 msgid "Status: Loaded%s"
 msgstr "状态：已加载%s"
 
-#: src/PrefsUnifiedDlg.cpp:2286
+#: src/PrefsUnifiedDlg.cpp:2206
 #, c-format
 msgid "Status: Loaded%s - %s"
 msgstr "状态：已加载%s~%s"
 
-#: src/PrefsUnifiedDlg.cpp:2290
+#: src/PrefsUnifiedDlg.cpp:2210
 msgid "Status: Failed to load - click 'Update now' to refresh."
 msgstr "状态：加载失败 - 点击“立即更新”以刷新。"
 
-#: src/PrefsUnifiedDlg.cpp:2292
+#: src/PrefsUnifiedDlg.cpp:2212
 msgid "Status: Not found - click 'Update now' to download."
 msgstr "状态：未找到 - 点击“立即更新”进行下载。"
 
-#: src/PrefsUnifiedDlg.cpp:2350 src/PrefsUnifiedDlg.cpp:2374
+#: src/PrefsUnifiedDlg.cpp:2270 src/PrefsUnifiedDlg.cpp:2294
 #, c-format
 msgid "Update delay: %d second"
 msgid_plural "Update delay: %d seconds"
 msgstr[0] "更新延迟：%d秒"
 msgstr[1] "更新延迟：%d秒"
 
-#: src/PrefsUnifiedDlg.cpp:2358
+#: src/PrefsUnifiedDlg.cpp:2278
 #, c-format
 msgid "Time for average graph: %d minute"
 msgid_plural "Time for average graph: %d minutes"
 msgstr[0] "平均值图表显示时间：%d分钟"
 msgstr[1] "平均值图表显示时间：%d分钟"
 
-#: src/PrefsUnifiedDlg.cpp:2367
+#: src/PrefsUnifiedDlg.cpp:2287
 #, c-format
 msgid "Connections Graph Scale: %d"
 msgstr "网络连接图表缩放：%d"
 
-#: src/PrefsUnifiedDlg.cpp:2382
+#: src/PrefsUnifiedDlg.cpp:2302
 #, c-format
 msgid "File Buffer Size: %d byte"
 msgid_plural "File Buffer Size: %d bytes"
 msgstr[0] "文件缓冲区大小：%d字节"
 msgstr[1] "文件缓冲区大小：%d字节"
 
-#: src/PrefsUnifiedDlg.cpp:2392
+#: src/PrefsUnifiedDlg.cpp:2312
 #, c-format
 msgid "Upload Queue Size: %d client"
 msgid_plural "Upload Queue Size: %d clients"
 msgstr[0] "上传队列长度：%d个用户"
 msgstr[1] "上传队列长度：%d个用户"
 
-#: src/PrefsUnifiedDlg.cpp:2402
+#: src/PrefsUnifiedDlg.cpp:2322
 #, c-format
 msgid "Server connection refresh interval: %d minute"
 msgid_plural "Server connection refresh interval: %d minutes"
 msgstr[0] "服务器连接刷新周期：%d分钟"
 msgstr[1] "服务器连接刷新周期：%d分钟"
 
-#: src/PrefsUnifiedDlg.cpp:2407
+#: src/PrefsUnifiedDlg.cpp:2327
 msgid "Server connection refresh interval: Disabled"
 msgstr "服务器连接刷新周期：已禁用"
 
-#: src/PrefsUnifiedDlg.cpp:2451
+#: src/PrefsUnifiedDlg.cpp:2371
 msgid "disabled"
 msgstr "禁用"
 
-#: src/PrefsUnifiedDlg.cpp:2477
+#: src/PrefsUnifiedDlg.cpp:2397
 #, c-format
 msgid "Execute command on '%s' event"
 msgstr "在“%s”事件时执行命令"
 
-#: src/PrefsUnifiedDlg.cpp:2484
+#: src/PrefsUnifiedDlg.cpp:2404
 msgid "Enable command execution on core"
 msgstr "在核心启用执行命令"
 
-#: src/PrefsUnifiedDlg.cpp:2496
+#: src/PrefsUnifiedDlg.cpp:2416
 msgid "Core command:"
 msgstr "核心命令："
 
-#: src/PrefsUnifiedDlg.cpp:2512
+#: src/PrefsUnifiedDlg.cpp:2432
 msgid "Enable command execution on GUI"
 msgstr "在图形界面端启用执行命令"
 
-#: src/PrefsUnifiedDlg.cpp:2524
+#: src/PrefsUnifiedDlg.cpp:2444
 msgid "GUI command:"
 msgstr "图形界面命令："
 
-#: src/PrefsUnifiedDlg.cpp:2540
+#: src/PrefsUnifiedDlg.cpp:2460
 msgid "The following variables will be replaced:"
 msgstr "以下变量将被替换："
 
-#: src/PrefsUnifiedDlg.cpp:2708
+#: src/PrefsUnifiedDlg.cpp:2628
 msgid ""
 "The following folders look like system or sensitive locations:\n"
 "\n"
@@ -6106,61 +6058,57 @@ msgstr ""
 "以下文件夹看起来像是系统或敏感位置：\n"
 "\n"
 
-#: src/PrefsUnifiedDlg.cpp:2713
+#: src/PrefsUnifiedDlg.cpp:2633
 msgid "Sharing them recursively will publish every file underneath on the eD2k/Kad networks. Do you really want to do this?"
 msgstr "递归共享会将每个子文件发布到 eD2k/Kad 网络上。您确定要这样做吗？"
 
-#: src/PrefsUnifiedDlg.cpp:2716
+#: src/PrefsUnifiedDlg.cpp:2636
 msgid "Confirm shared folders"
 msgstr "确认共享的文件夹"
 
-#: src/PrefsUnifiedDlg.cpp:2744
+#: src/PrefsUnifiedDlg.cpp:2664
 msgid "Reloading shared files..."
 msgstr "正重新加载共享文件..."
 
-#: src/PrefsUnifiedDlg.cpp:2745
+#: src/PrefsUnifiedDlg.cpp:2665
 msgid "Scanning for subdirectories..."
 msgstr "正在扫描子目录..."
 
-#: src/PrefsUnifiedDlg.cpp:2746
+#: src/PrefsUnifiedDlg.cpp:2666
 msgid "Updating shared folders"
 msgstr "正在上传共享的文件夹"
 
-#: src/PrefsUnifiedDlg.cpp:2773
+#: src/PrefsUnifiedDlg.cpp:2693
 #, c-format
 msgid "Scanned %u directories..."
 msgstr "已扫描 %u 个目录......"
 
-#: src/PrefsUnifiedDlg.cpp:2823
+#: src/PrefsUnifiedDlg.cpp:2743
 #, c-format
 msgid "Reloading shared files: %u files scanned"
 msgstr "正重新加载共享文件：扫描了 %u 个文件"
 
-#: src/PrefsUnifiedDlg.cpp:2873
+#: src/PrefsUnifiedDlg.cpp:2793
 msgid "Shared folder"
 msgstr "共享的文件夹"
 
-#: src/SearchDlg.cpp:280
-msgid "Clear search history"
-msgstr ""
-
-#: src/SearchDlg.cpp:584
+#: src/SearchDlg.cpp:425
 msgid "It's impossible to search when both eD2k and Kademlia are disabled."
 msgstr "同时禁用 eD2k 和 Kademlia 时将无法搜索。"
 
-#: src/SearchDlg.cpp:585 src/SearchListCtrl.cpp:858
+#: src/SearchDlg.cpp:426 src/SearchListCtrl.cpp:858
 msgid "Search error"
 msgstr "搜索错误"
 
-#: src/SearchDlg.cpp:929
+#: src/SearchDlg.cpp:768
 msgid "Min size must be smaller than max size. Max size ignored."
 msgstr "最小值必须小于最大值，最大值已被忽略。"
 
-#: src/SearchDlg.cpp:930 src/SearchDlg.cpp:1012
+#: src/SearchDlg.cpp:769 src/SearchDlg.cpp:851
 msgid "Search warning"
 msgstr "搜索警告"
 
-#: src/SearchDlg.cpp:1092 src/SearchListCtrl.cpp:735
+#: src/SearchDlg.cpp:929 src/SearchListCtrl.cpp:735
 msgid "Main"
 msgstr "主要"
 

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -13,7 +13,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-28 08:06+0200\n"
+"POT-Creation-Date: 2026-07-28 10:19+0200\n"
 "PO-Revision-Date: 2026-07-27 11:48+0000\n"
 "Last-Translator: Mike Akiba <mike2718@gmail.com>\n"
 "Language-Team: Chinese Simplified <kde-i18n-doc@kde.org>\n"
@@ -147,7 +147,7 @@ msgstr "安装"
 msgid "Not now"
 msgstr "不是现在"
 
-#: src/AppImageIntegration.cpp:422 src/amuleDlg.cpp:600
+#: src/AppImageIntegration.cpp:422 src/amuleDlg.cpp:665
 msgid "Don't ask again"
 msgstr "不要再提醒我"
 
@@ -224,7 +224,7 @@ msgid "Killing amuleweb instance with pid '%d' ... "
 msgstr "正在终止 pid 为“%d”的 amuleweb 实例 ... "
 
 #: src/amule.cpp:336 src/amule.cpp:349 src/ClientRef.cpp:180
-#: src/SearchDlg.cpp:880 src/ServerListCtrl.cpp:98
+#: src/SearchDlg.cpp:1041 src/ServerListCtrl.cpp:98
 msgid "Failed"
 msgstr "失败"
 
@@ -577,29 +577,67 @@ msgstr "不能创建 Pid 文件"
 msgid "ERROR: %s"
 msgstr "错误：%s"
 
-#: src/amuleDlg.cpp:236
+#: src/amuleDlg.cpp:250
 #, c-format
 msgid "This is aMule %s based on eMule."
 msgstr "这是基于 eMule 的 aMule %s。"
 
-#: src/amuleDlg.cpp:237
+#: src/amuleDlg.cpp:251
 #, c-format
 msgid "Running on %s"
 msgstr "运行于 %s"
 
-#: src/amuleDlg.cpp:239
+#: src/amuleDlg.cpp:253
 msgid "Visit https://github.com/amule-org/amule/releases/latest to check if a new version is available."
 msgstr "访问 https://github.com/amule-org/amule/releases/latest 来检查 是否有新版本。"
 
-#: src/amuleDlg.cpp:268
+#: src/amuleDlg.cpp:282
 msgid "FATAL ERROR: Failed to create Timer"
 msgstr "致命错误：创建计时器失败"
 
-#: src/amuleDlg.cpp:592
+#: src/amuleDlg.cpp:361 src/amuleDlg.cpp:1787 src/amuleDlg.cpp:2033
+#: src/muuli_wdr.cpp:1492 src/muuli_wdr.cpp:3418
+msgid "Networks"
+msgstr "网络"
+
+#: src/amuleDlg.cpp:362 src/amuleDlg.cpp:1793 src/muuli_wdr.cpp:3419
+msgid "Searches"
+msgstr "搜索"
+
+#: src/amuleDlg.cpp:363 src/amuleDlg.cpp:1799 src/DownloadListCtrl.cpp:740
+#: src/muuli_wdr.cpp:392 src/muuli_wdr.cpp:1585 src/muuli_wdr.cpp:3420
+#: src/Statistics.cpp:829
+msgid "Downloads"
+msgstr "下载"
+
+#: src/amuleDlg.cpp:364 src/amuleDlg.cpp:1805 src/muuli_wdr.cpp:3294
+msgid "Shared files"
+msgstr "共享文件"
+
+#: src/amuleDlg.cpp:365 src/amuleDlg.cpp:1811 src/muuli_wdr.cpp:2926
+#: src/muuli_wdr.cpp:3376 src/muuli_wdr.cpp:3423
+msgid "Messages"
+msgstr "消息"
+
+#: src/amuleDlg.cpp:366 src/amuleDlg.cpp:1817 src/muuli_wdr.cpp:3424
+#: src/PrefsUnifiedDlg.cpp:312 src/Statistics.cpp:779 src/Statistics.cpp:1235
+msgid "Statistics"
+msgstr "统计"
+
+#: src/amuleDlg.cpp:368 src/amuleDlg.cpp:1824 src/muuli_wdr.cpp:3426
+#: src/PrefsUnifiedDlg.cpp:328 src/utils/wxCas/src/wxcasprefs.cpp:39
+msgid "Preferences"
+msgstr "设置"
+
+#: src/amuleDlg.cpp:371
+msgid "Navigate"
+msgstr ""
+
+#: src/amuleDlg.cpp:657
 msgid "New version available"
 msgstr "有新版"
 
-#: src/amuleDlg.cpp:596
+#: src/amuleDlg.cpp:661
 #, c-format
 msgid ""
 "A new version of aMule (%s) is available.\n"
@@ -614,217 +652,184 @@ msgstr ""
 "\n"
 "要打开下载页吗？"
 
-#: src/amuleDlg.cpp:678
+#: src/amuleDlg.cpp:743
 msgid "aMule dialog destroyed"
 msgstr "aMule 对话框损坏"
 
-#: src/amuleDlg.cpp:701 src/DataToText.cpp:68 src/IPFilter.cpp:547
+#: src/amuleDlg.cpp:766 src/DataToText.cpp:68 src/IPFilter.cpp:547
 msgid "Connecting"
 msgstr "正在连接"
 
-#: src/amuleDlg.cpp:893
+#: src/amuleDlg.cpp:958
 msgid "eD2k: Connecting"
 msgstr "eD2k: 正在连接"
 
-#: src/amuleDlg.cpp:897
+#: src/amuleDlg.cpp:962
 msgid "eD2k: Disconnected"
 msgstr "eD2k: 已断开"
 
-#: src/amuleDlg.cpp:903
+#: src/amuleDlg.cpp:968
 msgid "Kad: Firewalled"
 msgstr "Kad: 通过防火墙"
 
-#: src/amuleDlg.cpp:907
+#: src/amuleDlg.cpp:972
 msgid "Kad: Connected"
 msgstr "Kad: 已连接"
 
-#: src/amuleDlg.cpp:912
+#: src/amuleDlg.cpp:977
 msgid "Kad: Connecting"
 msgstr "Kad: 正在连接"
 
-#: src/amuleDlg.cpp:916
+#: src/amuleDlg.cpp:981
 msgid "Kad: Off"
 msgstr "Kad: 关闭"
 
-#: src/amuleDlg.cpp:964 src/DownloadListCtrl.cpp:505
+#: src/amuleDlg.cpp:1029 src/DownloadListCtrl.cpp:505
 #: src/DownloadListCtrl.cpp:749 src/FriendListCtrl.cpp:180
 #: src/muuli_wdr.cpp:731 src/muuli_wdr.cpp:782 src/muuli_wdr.cpp:846
-#: src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2224 src/muuli_wdr.cpp:2309
-#: src/muuli_wdr.cpp:3057 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
+#: src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2231 src/muuli_wdr.cpp:2316
+#: src/muuli_wdr.cpp:3064 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
 #: src/ServerListCtrl.cpp:606 src/TransferWnd.cpp:378
 #: src/utils/wxCas/src/wxcasprefs.cpp:235
 msgid "Cancel"
 msgstr "取消"
 
-#: src/amuleDlg.cpp:965
+#: src/amuleDlg.cpp:1030
 msgid "Stop the current connection attempts"
 msgstr "终止本次连接尝试"
 
-#: src/amuleDlg.cpp:970 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976
-#: src/muuli_wdr.cpp:2447
+#: src/amuleDlg.cpp:1035 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976
+#: src/muuli_wdr.cpp:2454
 msgid "Disconnect"
 msgstr "断开连接"
 
-#: src/amuleDlg.cpp:971
+#: src/amuleDlg.cpp:1036
 msgid "Disconnect from the currently connected networks"
 msgstr "从当前已连接的网络断开"
 
-#: src/amuleDlg.cpp:976 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979
-#: src/muuli_wdr.cpp:2602 src/muuli_wdr.cpp:3054 src/muuli_wdr.cpp:3409
+#: src/amuleDlg.cpp:1041 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979
+#: src/muuli_wdr.cpp:2609 src/muuli_wdr.cpp:3061 src/muuli_wdr.cpp:3416
 msgid "Connect"
 msgstr "连接"
 
-#: src/amuleDlg.cpp:977
+#: src/amuleDlg.cpp:1042
 msgid "Connect to the currently enabled networks"
 msgstr "连接至当前已启用的网络"
 
-#: src/amuleDlg.cpp:1089
+#: src/amuleDlg.cpp:1154
 #, c-format
 msgid "Up: %.1f%s (%.1f) | Down: %.1f%s (%.1f)"
 msgstr "上传: %.1f%s（%.1f） | 下载: %.1f%s（%.1f）"
 
-#: src/amuleDlg.cpp:1091 src/amuleDlg.cpp:1093 src/amuleDlg.cpp:1097
-#: src/amuleDlg.cpp:1099 src/amuleDlg.cpp:1110 src/amuleDlg.cpp:1112
+#: src/amuleDlg.cpp:1156 src/amuleDlg.cpp:1158 src/amuleDlg.cpp:1162
+#: src/amuleDlg.cpp:1164 src/amuleDlg.cpp:1175 src/amuleDlg.cpp:1177
 #: src/MuleTrayIcon.cpp:796 src/MuleTrayIcon.cpp:799
 msgid " MB/s"
 msgstr " MB/s"
 
-#: src/amuleDlg.cpp:1091 src/amuleDlg.cpp:1093 src/amuleDlg.cpp:1097
-#: src/amuleDlg.cpp:1099 src/amuleDlg.cpp:1110 src/amuleDlg.cpp:1112
+#: src/amuleDlg.cpp:1156 src/amuleDlg.cpp:1158 src/amuleDlg.cpp:1162
+#: src/amuleDlg.cpp:1164 src/amuleDlg.cpp:1175 src/amuleDlg.cpp:1177
 #: src/MuleTrayIcon.cpp:796 src/MuleTrayIcon.cpp:799
 #: src/utils/wxCas/src/wxcasframe.cpp:1041
 msgid " kB/s"
 msgstr " kB/s"
 
-#: src/amuleDlg.cpp:1096
+#: src/amuleDlg.cpp:1161
 #, c-format
 msgid "Up: %.1f%s | Down: %.1f%s"
 msgstr "上传: %.1f%s | 下载: %.1f%s"
 
-#: src/amuleDlg.cpp:1128
+#: src/amuleDlg.cpp:1193
 #, c-format
 msgid "aMule (%s | Connected)"
 msgstr "aMule（%s | 已连接）"
 
-#: src/amuleDlg.cpp:1130
+#: src/amuleDlg.cpp:1195
 #, c-format
 msgid "aMule (%s | Disconnected)"
 msgstr "aMule（%s | 已断开）"
 
-#: src/amuleDlg.cpp:1183
+#: src/amuleDlg.cpp:1248
 #, c-format
 msgid "Do you really want to exit %s?"
 msgstr "您确定要退出 %s 吗？"
 
-#: src/amuleDlg.cpp:1185
+#: src/amuleDlg.cpp:1250
 msgid "Exit confirmation"
 msgstr "退出确认"
 
-#: src/amuleDlg.cpp:1548
+#: src/amuleDlg.cpp:1613
 msgid "Launch Command: "
 msgstr "运行命令: "
 
-#: src/amuleDlg.cpp:1567 src/muuli_wdr.cpp:1971 src/Preferences.cpp:951
+#: src/amuleDlg.cpp:1632 src/muuli_wdr.cpp:1978 src/Preferences.cpp:952
 msgid "- default -"
 msgstr "- 默认 -"
 
-#: src/amuleDlg.cpp:1595
+#: src/amuleDlg.cpp:1660
 #, c-format
 msgid "Skin directory '%s' does not exist"
 msgstr "皮肤目录 %s 不存在"
 
-#: src/amuleDlg.cpp:1598
+#: src/amuleDlg.cpp:1663
 #, c-format
 msgid "WARNING: Unable to open skin file '%s' for read"
 msgstr "警告：无法打开皮肤文件 %s 进行读取"
 
-#: src/amuleDlg.cpp:1722 src/amuleDlg.cpp:1968 src/muuli_wdr.cpp:1485
-#: src/muuli_wdr.cpp:3411
-msgid "Networks"
-msgstr "网络"
-
-#: src/amuleDlg.cpp:1726 src/muuli_wdr.cpp:3411
+#: src/amuleDlg.cpp:1791 src/muuli_wdr.cpp:3418
 msgid "Networks Window"
 msgstr "网络窗口"
 
-#: src/amuleDlg.cpp:1728 src/muuli_wdr.cpp:3412
-msgid "Searches"
-msgstr "搜索"
-
-#: src/amuleDlg.cpp:1732 src/muuli_wdr.cpp:3412
+#: src/amuleDlg.cpp:1797 src/muuli_wdr.cpp:3419
 msgid "Searches Window"
 msgstr "搜索窗口"
 
-#: src/amuleDlg.cpp:1734 src/DownloadListCtrl.cpp:740 src/muuli_wdr.cpp:392
-#: src/muuli_wdr.cpp:1578 src/muuli_wdr.cpp:3413 src/Statistics.cpp:829
-msgid "Downloads"
-msgstr "下载"
-
-#: src/amuleDlg.cpp:1738 src/muuli_wdr.cpp:3413
+#: src/amuleDlg.cpp:1803 src/muuli_wdr.cpp:3420
 msgid "Downloads Window"
 msgstr "下载窗口"
 
-#: src/amuleDlg.cpp:1740 src/muuli_wdr.cpp:3287
-msgid "Shared files"
-msgstr "共享文件"
-
-#: src/amuleDlg.cpp:1744 src/muuli_wdr.cpp:3415
+#: src/amuleDlg.cpp:1809 src/muuli_wdr.cpp:3422
 msgid "Shared Files Window"
 msgstr "共享文件窗口"
 
-#: src/amuleDlg.cpp:1746 src/muuli_wdr.cpp:2919 src/muuli_wdr.cpp:3369
-#: src/muuli_wdr.cpp:3416
-msgid "Messages"
-msgstr "消息"
-
-#: src/amuleDlg.cpp:1750 src/muuli_wdr.cpp:3416
+#: src/amuleDlg.cpp:1815 src/muuli_wdr.cpp:3423
 msgid "Messages Window"
 msgstr "消息窗口"
 
-#: src/amuleDlg.cpp:1752 src/muuli_wdr.cpp:3417 src/PrefsUnifiedDlg.cpp:312
-#: src/Statistics.cpp:779 src/Statistics.cpp:1235
-msgid "Statistics"
-msgstr "统计"
-
-#: src/amuleDlg.cpp:1756 src/muuli_wdr.cpp:3417
+#: src/amuleDlg.cpp:1821 src/muuli_wdr.cpp:3424
 msgid "Statistics Graph Window"
 msgstr "统计图窗口"
 
-#: src/amuleDlg.cpp:1759 src/muuli_wdr.cpp:3419 src/PrefsUnifiedDlg.cpp:328
-#: src/utils/wxCas/src/wxcasprefs.cpp:39
-msgid "Preferences"
-msgstr "设置"
-
-#: src/amuleDlg.cpp:1763 src/muuli_wdr.cpp:3419
+#: src/amuleDlg.cpp:1828 src/muuli_wdr.cpp:3426
 msgid "Preferences Settings Window"
 msgstr "设置窗口"
 
-#: src/amuleDlg.cpp:1766 src/muuli_wdr.cpp:3420
+#: src/amuleDlg.cpp:1831 src/muuli_wdr.cpp:3427
 msgid "Import"
 msgstr "导入"
 
-#: src/amuleDlg.cpp:1770 src/muuli_wdr.cpp:3420
+#: src/amuleDlg.cpp:1835 src/muuli_wdr.cpp:3427
 msgid "The partfile importer tool"
 msgstr "part 文件导入工具"
 
-#: src/amuleDlg.cpp:1773 src/muuli_wdr.cpp:3421
+#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3428
 #: src/utils/aLinkCreator/src/alcframe.cpp:262
 msgid "About"
 msgstr "关于"
 
-#: src/amuleDlg.cpp:1773 src/muuli_wdr.cpp:3421
+#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3428
 msgid "About/Help"
 msgstr "关于/帮助"
 
-#: src/amuleDlg.cpp:1971
+#: src/amuleDlg.cpp:2036
 msgid "eD2k network"
 msgstr "eD2k 网络"
 
-#: src/amuleDlg.cpp:1974
+#: src/amuleDlg.cpp:2039
 msgid "Kad network"
 msgstr "Kad 网络"
 
-#: src/amuleDlg.cpp:1974
+#: src/amuleDlg.cpp:2039
 msgid "No network"
 msgstr "无网络"
 
@@ -1357,19 +1362,19 @@ msgstr "自动 [高]"
 msgid "Very low"
 msgstr "极低"
 
-#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:743 src/muuli_wdr.cpp:2275
+#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:743 src/muuli_wdr.cpp:2282
 #: src/ServerListCtrl.cpp:263 src/ServerListCtrl.cpp:456
 #: src/SharedFilesCtrl.cpp:145
 msgid "Low"
 msgstr "低"
 
-#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:744 src/muuli_wdr.cpp:2276
+#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:744 src/muuli_wdr.cpp:2283
 #: src/ServerListCtrl.cpp:266 src/ServerListCtrl.cpp:457
 #: src/SharedFilesCtrl.cpp:146
 msgid "Normal"
 msgstr "普通"
 
-#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:745 src/muuli_wdr.cpp:2277
+#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:745 src/muuli_wdr.cpp:2284
 #: src/ServerListCtrl.cpp:269 src/ServerListCtrl.cpp:458
 #: src/SharedFilesCtrl.cpp:147
 msgid "High"
@@ -1461,8 +1466,8 @@ msgstr "本地服务器"
 msgid "Remote Server"
 msgstr "远程服务器"
 
-#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3174
-#: src/SearchDlg.cpp:111 src/TextClient.cpp:911
+#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3181
+#: src/SearchDlg.cpp:119 src/TextClient.cpp:911
 msgid "Kad"
 msgstr "Kad"
 
@@ -1532,7 +1537,7 @@ msgstr "块"
 msgid "Size"
 msgstr "大小"
 
-#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3241
+#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3248
 msgid "Transferred"
 msgstr "已传输"
 
@@ -1590,7 +1595,7 @@ msgstr ""
 "报告来自: %s (%s)\n"
 "\n"
 
-#: src/DownloadListCtrl.cpp:746 src/muuli_wdr.cpp:2278
+#: src/DownloadListCtrl.cpp:746 src/muuli_wdr.cpp:2285
 #: src/SharedFilesCtrl.cpp:150
 msgid "Auto"
 msgstr "自动"
@@ -1628,7 +1633,7 @@ msgid "Extended Options"
 msgstr "扩展选项"
 
 #: src/DownloadListCtrl.cpp:770 src/DownloadListCtrl.cpp:822
-#: src/muuli_wdr.cpp:1789
+#: src/muuli_wdr.cpp:1796
 msgid "Preview"
 msgstr "预览"
 
@@ -2337,19 +2342,19 @@ msgstr ""
 msgid "eD2k"
 msgstr "eD2k"
 
-#: src/FirstRunWizard.cpp:349 src/muuli_wdr.cpp:1488
+#: src/FirstRunWizard.cpp:349 src/muuli_wdr.cpp:1495
 msgid "Kademlia"
 msgstr "Kad"
 
-#: src/FirstRunWizard.cpp:359 src/muuli_wdr.cpp:1416
+#: src/FirstRunWizard.cpp:359 src/muuli_wdr.cpp:1423
 msgid "Standard TCP Port "
 msgstr "标准 TCP 端口 "
 
-#: src/FirstRunWizard.cpp:365 src/muuli_wdr.cpp:1428
+#: src/FirstRunWizard.cpp:365 src/muuli_wdr.cpp:1435
 msgid "Extended UDP port (Kad / global search) "
 msgstr "扩展 UDP 端口 (Kad/全局搜索) "
 
-#: src/FirstRunWizard.cpp:377 src/muuli_wdr.cpp:1435
+#: src/FirstRunWizard.cpp:377 src/muuli_wdr.cpp:1442
 msgid "Enable UPnP for router port forwarding"
 msgstr "启用 UPnP 以用于路由器端口转发"
 
@@ -2376,7 +2381,7 @@ msgstr ""
 msgid "Your peer lists are already in place - nothing to download."
 msgstr "您已经尝试下载文件 %s"
 
-#: src/FirstRunWizard.cpp:434 src/muuli_wdr.cpp:1533
+#: src/FirstRunWizard.cpp:434 src/muuli_wdr.cpp:1540
 msgid "Auto-update server list at startup"
 msgstr "启动时自动更新服务器列表"
 
@@ -2422,23 +2427,23 @@ msgid ""
 "want downloads on a different (e.g. larger) disk."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:549 src/FirstRunWizard.cpp:611 src/muuli_wdr.cpp:1701
+#: src/FirstRunWizard.cpp:549 src/FirstRunWizard.cpp:611 src/muuli_wdr.cpp:1708
 msgid "Destination folder for downloads"
 msgstr "存放下载文件的文件夹"
 
-#: src/FirstRunWizard.cpp:553 src/FirstRunWizard.cpp:569 src/muuli_wdr.cpp:1342
-#: src/muuli_wdr.cpp:1359 src/muuli_wdr.cpp:1676 src/muuli_wdr.cpp:1707
-#: src/muuli_wdr.cpp:1719 src/muuli_wdr.cpp:2762
+#: src/FirstRunWizard.cpp:553 src/FirstRunWizard.cpp:569 src/muuli_wdr.cpp:1349
+#: src/muuli_wdr.cpp:1366 src/muuli_wdr.cpp:1683 src/muuli_wdr.cpp:1714
+#: src/muuli_wdr.cpp:1726 src/muuli_wdr.cpp:2769
 #: src/utils/aLinkCreator/src/alcframe.cpp:135
 #: src/utils/wxCas/src/wxcasprefs.cpp:52 src/utils/wxCas/src/wxcasprefs.cpp:118
 msgid "Browse"
 msgstr "浏览"
 
-#: src/FirstRunWizard.cpp:559 src/muuli_wdr.cpp:1712
+#: src/FirstRunWizard.cpp:559 src/muuli_wdr.cpp:1719
 msgid "(All files in this folder are shared with other peers)"
 msgstr "（此文件夹中的所有文件均与其他对等方共享）"
 
-#: src/FirstRunWizard.cpp:565 src/FirstRunWizard.cpp:624 src/muuli_wdr.cpp:1714
+#: src/FirstRunWizard.cpp:565 src/FirstRunWizard.cpp:624 src/muuli_wdr.cpp:1721
 msgid "Folder for temporary download files"
 msgstr "存放临时下载文件的文件夹"
 
@@ -2469,7 +2474,7 @@ msgstr "写好友列表文件emfriends.met失败！"
 msgid "CRITICAL - no client on StartChatSession"
 msgstr "严重错误 - 开始聊天进程没有客户端"
 
-#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2668 src/muuli_wdr.cpp:3345
+#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2675 src/muuli_wdr.cpp:3352
 msgid "Friends"
 msgstr "好友"
 
@@ -2851,7 +2856,7 @@ msgstr "共享率"
 msgid "Uploaded"
 msgstr "已上传"
 
-#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3225
+#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3232
 msgid "Requested"
 msgstr "已请求"
 
@@ -2974,7 +2979,7 @@ msgid "WARNING: "
 msgstr "警告: "
 
 #: src/MuleNotebook.cpp:179 src/muuli_wdr.cpp:817 src/muuli_wdr.cpp:1229
-#: src/muuli_wdr.cpp:3129 src/muuli_wdr.cpp:3385
+#: src/muuli_wdr.cpp:3136 src/muuli_wdr.cpp:3392
 msgid "Close"
 msgstr "关闭"
 
@@ -2987,12 +2992,12 @@ msgstr "剪切"
 msgid "Copy"
 msgstr "复制"
 
-#: src/MuleTextCtrl.cpp:88
+#: src/MuleTextCtrl.cpp:88 src/SearchDlg.cpp:261
 msgid "Paste"
 msgstr "粘贴"
 
 #: src/MuleTextCtrl.cpp:89 src/muuli_wdr.cpp:358 src/muuli_wdr.cpp:757
-#: src/muuli_wdr.cpp:2352 src/muuli_wdr.cpp:2371 src/muuli_wdr.cpp:2393
+#: src/muuli_wdr.cpp:2359 src/muuli_wdr.cpp:2378 src/muuli_wdr.cpp:2400
 #: src/utils/aLinkCreator/src/alcframe.cpp:142
 msgid "Clear"
 msgstr "清除"
@@ -3083,8 +3088,8 @@ msgid "Exit"
 msgstr "退出"
 
 #: src/MuleTrayIcon.cpp:579 src/MuleTrayIcon.cpp:945 src/MuleTrayIcon.cpp:965
-#: src/muuli_wdr.cpp:1391 src/muuli_wdr.cpp:1399 src/muuli_wdr.cpp:1406
-#: src/muuli_wdr.cpp:1835 src/muuli_wdr.cpp:1841 src/OtherFunctions.cpp:91
+#: src/muuli_wdr.cpp:1398 src/muuli_wdr.cpp:1406 src/muuli_wdr.cpp:1413
+#: src/muuli_wdr.cpp:1842 src/muuli_wdr.cpp:1848 src/OtherFunctions.cpp:91
 #: src/StatisticsDlg.cpp:93 src/StatisticsDlg.cpp:95
 msgid "kB/s"
 msgstr "KB/s"
@@ -3253,7 +3258,7 @@ msgstr "名称:"
 msgid "Type"
 msgstr "类型"
 
-#: src/muuli_wdr.cpp:215 src/SearchDlg.cpp:110 src/SearchListCtrl.cpp:853
+#: src/muuli_wdr.cpp:215 src/SearchDlg.cpp:118 src/SearchListCtrl.cpp:853
 msgid "Local"
 msgstr "本地"
 
@@ -3324,7 +3329,7 @@ msgstr "字节"
 msgid "KB"
 msgstr "KB"
 
-#: src/muuli_wdr.cpp:274 src/muuli_wdr.cpp:293 src/muuli_wdr.cpp:1620
+#: src/muuli_wdr.cpp:274 src/muuli_wdr.cpp:293 src/muuli_wdr.cpp:1627
 #: src/OtherFunctions.cpp:64
 msgid "MB"
 msgstr "MB"
@@ -3341,7 +3346,7 @@ msgstr "大小上限"
 msgid "Availability"
 msgstr "可用来源数"
 
-#: src/muuli_wdr.cpp:312 src/muuli_wdr.cpp:398 src/muuli_wdr.cpp:3290
+#: src/muuli_wdr.cpp:312 src/muuli_wdr.cpp:398 src/muuli_wdr.cpp:3297
 msgid "Filter:"
 msgstr "过滤："
 
@@ -3373,7 +3378,7 @@ msgstr "向已响应的 Kad 节点请求扩大搜索范围。每次点击都会�
 msgid "Stop"
 msgstr "停止"
 
-#: src/muuli_wdr.cpp:348 src/muuli_wdr.cpp:1385 src/SearchListCtrl.cpp:732
+#: src/muuli_wdr.cpp:348 src/muuli_wdr.cpp:1392 src/SearchListCtrl.cpp:732
 msgid "Download"
 msgstr "下载"
 
@@ -3404,8 +3409,8 @@ msgstr "文件源:"
 #: src/muuli_wdr.cpp:1160 src/muuli_wdr.cpp:1167 src/muuli_wdr.cpp:1172
 #: src/muuli_wdr.cpp:1179 src/muuli_wdr.cpp:1184 src/muuli_wdr.cpp:1191
 #: src/muuli_wdr.cpp:1205 src/muuli_wdr.cpp:1212 src/muuli_wdr.cpp:1217
-#: src/muuli_wdr.cpp:1224 src/muuli_wdr.cpp:3227 src/muuli_wdr.cpp:3235
-#: src/muuli_wdr.cpp:3243
+#: src/muuli_wdr.cpp:1224 src/muuli_wdr.cpp:3234 src/muuli_wdr.cpp:3242
+#: src/muuli_wdr.cpp:3250
 msgid "N/A"
 msgstr "N/A"
 
@@ -3545,7 +3550,7 @@ msgstr "艺术家："
 msgid "Album :"
 msgstr "专辑："
 
-#: src/muuli_wdr.cpp:685 src/muuli_wdr.cpp:2247
+#: src/muuli_wdr.cpp:685 src/muuli_wdr.cpp:2254
 msgid "Title :"
 msgstr "标题 :"
 
@@ -3653,7 +3658,7 @@ msgstr "用户名 :"
 msgid "Userhash :"
 msgstr "用户哈希 :"
 
-#: src/muuli_wdr.cpp:895 src/muuli_wdr.cpp:1741 src/muuli_wdr.cpp:2442
+#: src/muuli_wdr.cpp:895 src/muuli_wdr.cpp:1748 src/muuli_wdr.cpp:2449
 #: src/utils/aLinkCreator/src/alcframe.cpp:137
 msgid "Add"
 msgstr "添加"
@@ -3662,15 +3667,15 @@ msgstr "添加"
 msgid "Download-Speed"
 msgstr "下载速度"
 
-#: src/muuli_wdr.cpp:954 src/muuli_wdr.cpp:989 src/muuli_wdr.cpp:2546
+#: src/muuli_wdr.cpp:954 src/muuli_wdr.cpp:989 src/muuli_wdr.cpp:2553
 msgid "Current"
 msgstr "当前"
 
-#: src/muuli_wdr.cpp:962 src/muuli_wdr.cpp:997 src/muuli_wdr.cpp:2554
+#: src/muuli_wdr.cpp:962 src/muuli_wdr.cpp:997 src/muuli_wdr.cpp:2561
 msgid "Running average"
 msgstr "动态平均值"
 
-#: src/muuli_wdr.cpp:970 src/muuli_wdr.cpp:1005 src/muuli_wdr.cpp:2562
+#: src/muuli_wdr.cpp:970 src/muuli_wdr.cpp:1005 src/muuli_wdr.cpp:2569
 msgid "Session average"
 msgstr "本次运行平均值"
 
@@ -3682,7 +3687,7 @@ msgstr "上传速度"
 msgid "Connections"
 msgstr "连接"
 
-#: src/muuli_wdr.cpp:1024 src/muuli_wdr.cpp:1860
+#: src/muuli_wdr.cpp:1024 src/muuli_wdr.cpp:1867
 msgid "Active downloads"
 msgstr "活跃下载"
 
@@ -3690,7 +3695,7 @@ msgstr "活跃下载"
 msgid "Active connections (1:1)"
 msgstr "活跃连接 (1:1)"
 
-#: src/muuli_wdr.cpp:1040 src/muuli_wdr.cpp:1861
+#: src/muuli_wdr.cpp:1040 src/muuli_wdr.cpp:1868
 msgid "Active uploads"
 msgstr "活跃上传"
 
@@ -3806,8 +3811,8 @@ msgstr "其他用户连接到您的时候，他们会看到这个名字。"
 msgid "Language: "
 msgstr "语言: "
 
-#: src/muuli_wdr.cpp:1257 src/muuli_wdr.cpp:1323 src/muuli_wdr.cpp:1327
-#: src/muuli_wdr.cpp:1330
+#: src/muuli_wdr.cpp:1257 src/muuli_wdr.cpp:1330 src/muuli_wdr.cpp:1334
+#: src/muuli_wdr.cpp:1337
 msgid "The delay before showing tool-tips."
 msgstr "显示提示前的延迟时间。"
 
@@ -3883,259 +3888,268 @@ msgstr "下载完成后通知"
 msgid "Enabling this will make aMule to show notifications when finished downloading."
 msgstr "启用此项将使 aMule 在下载完成时显示通知。"
 
-#: src/muuli_wdr.cpp:1322
+#: src/muuli_wdr.cpp:1323
+#, fuzzy
+msgid "Remember search history"
+msgstr "记住这些设置"
+
+#: src/muuli_wdr.cpp:1324
+msgid "Keeps a dropdown list of your past search terms in the Search tab's Name field. This remembers the queries you typed, not the results they returned."
+msgstr ""
+
+#: src/muuli_wdr.cpp:1329
 msgid "Tooltip delay time: "
 msgstr "工具提示延迟时间: "
 
-#: src/muuli_wdr.cpp:1329
+#: src/muuli_wdr.cpp:1336
 msgid "seconds"
 msgstr "秒"
 
-#: src/muuli_wdr.cpp:1333
+#: src/muuli_wdr.cpp:1340
 msgid "Browser Selection"
 msgstr "浏览器"
 
-#: src/muuli_wdr.cpp:1339
+#: src/muuli_wdr.cpp:1346
 msgid "Enter your browser name here. Leave this field empty to use the system default browser."
 msgstr "在此处输入您的浏览器名称，如要使用系统默认浏览器则请留空。"
 
-#: src/muuli_wdr.cpp:1346
+#: src/muuli_wdr.cpp:1353
 msgid "Open in new tab if possible"
 msgstr "如果可能的话，在新标签页中打开"
 
-#: src/muuli_wdr.cpp:1348
+#: src/muuli_wdr.cpp:1355
 msgid "Open the web page in a new tab instead of in a new window when possible"
 msgstr "如果可能的话，在新的标签页中打开而不是新的窗口"
 
-#: src/muuli_wdr.cpp:1352
+#: src/muuli_wdr.cpp:1359
 msgid "Video Player"
 msgstr "视频播放器"
 
-#: src/muuli_wdr.cpp:1379
+#: src/muuli_wdr.cpp:1386
 msgid "Bandwidth limits"
 msgstr "带宽限制"
 
-#: src/muuli_wdr.cpp:1393
+#: src/muuli_wdr.cpp:1400
 msgid "Upload"
 msgstr "上传"
 
-#: src/muuli_wdr.cpp:1401
+#: src/muuli_wdr.cpp:1408
 msgid "Slot Allocation"
 msgstr "槽速度"
 
-#: src/muuli_wdr.cpp:1410
+#: src/muuli_wdr.cpp:1417
 msgid "Ports"
 msgstr "端口"
 
-#: src/muuli_wdr.cpp:1420
+#: src/muuli_wdr.cpp:1427
 msgid "This is the standard eD2k port and cannot be disabled."
 msgstr "这是标准的 eD2k 端口，不能被禁用。"
 
-#: src/muuli_wdr.cpp:1423
+#: src/muuli_wdr.cpp:1430
 msgid "UDP port for server requests (TCP+3):"
 msgstr "用户服务器请求的 UDP 端口 (TCP+3):"
 
-#: src/muuli_wdr.cpp:1425
+#: src/muuli_wdr.cpp:1432
 msgid "4665"
 msgstr "4665"
 
-#: src/muuli_wdr.cpp:1432
+#: src/muuli_wdr.cpp:1439
 msgid "This UDP port is used for extended eD2k requests and Kad network"
 msgstr "此 UDP 端口用于扩展 eD2k 请求和 Kad 网络"
 
-#: src/muuli_wdr.cpp:1439
+#: src/muuli_wdr.cpp:1446
 msgid "UPnP TCP Port (Optional):"
 msgstr "UPnP 的 TCP 端口 (可选):"
 
-#: src/muuli_wdr.cpp:1449
+#: src/muuli_wdr.cpp:1456
 msgid "Bind local address to IP (empty for any):"
 msgstr "为本地地址绑定 IP (全部绑定则留空):"
 
-#: src/muuli_wdr.cpp:1452
+#: src/muuli_wdr.cpp:1459
 msgid "Advanced users only: If you have multiple network interfaces, enter the address of the interface to which aMule should be bound."
 msgstr "只限高级用户：如果您有多个网络接口，请输入 aMule 将要绑定接口的地址。"
 
-#: src/muuli_wdr.cpp:1455 src/muuli_wdr.cpp:2054
+#: src/muuli_wdr.cpp:1462 src/muuli_wdr.cpp:2061
 msgid "Bind to network interface (empty for any):"
 msgstr "绑定网络接口（留空绑定全部）："
 
-#: src/muuli_wdr.cpp:1468
+#: src/muuli_wdr.cpp:1475
 msgid "Advanced users only: pin all of aMule's traffic to one network interface, chosen from the list or typed in by name (e.g. tun0, eth0, en0) or index. Unlike binding to an IP, this stops traffic leaking out via the default route - useful with a VPN. Requires no elevated privileges."
 msgstr "仅限高级用户：将 aMule 的所有流量绑定到一个网络接口，可以从列表中选择，也可以按名称（例如 tun0、eth0、en0）输入或索引。与绑定到 IP 地址不同，这可以防止流量通过默认路由泄漏—— 在 VPN 环境下有用。无需管理员权限。"
 
-#: src/muuli_wdr.cpp:1474
+#: src/muuli_wdr.cpp:1481
 msgid "Max sources per downloading file:"
 msgstr "每个下载文件的最大的源数量:"
 
-#: src/muuli_wdr.cpp:1478
+#: src/muuli_wdr.cpp:1485
 msgid "Max simultaneous connections:"
 msgstr "最大同时连接数:"
 
-#: src/muuli_wdr.cpp:1491 src/muuli_wdr.cpp:3169
+#: src/muuli_wdr.cpp:1498 src/muuli_wdr.cpp:3176
 msgid "ED2K"
 msgstr "ED2K"
 
-#: src/muuli_wdr.cpp:1498
+#: src/muuli_wdr.cpp:1505
 msgid "Autoconnect on startup"
 msgstr "启动后自动连接"
 
-#: src/muuli_wdr.cpp:1501
+#: src/muuli_wdr.cpp:1508
 msgid "Reconnect on loss"
 msgstr "断线后自动重连"
 
-#: src/muuli_wdr.cpp:1523
+#: src/muuli_wdr.cpp:1530
 msgid "Remove dead server after"
 msgstr "如果"
 
-#: src/muuli_wdr.cpp:1524
+#: src/muuli_wdr.cpp:1531
 msgid "Static servers are never removed, even when unreachable."
 msgstr "即使静态服务器连不上也永远不删除。"
 
-#: src/muuli_wdr.cpp:1528
+#: src/muuli_wdr.cpp:1535
 msgid "retries"
 msgstr "次连接失败，则删除该服务器"
 
-#: src/muuli_wdr.cpp:1536
+#: src/muuli_wdr.cpp:1543
 msgid "List"
 msgstr "列表"
 
-#: src/muuli_wdr.cpp:1539
+#: src/muuli_wdr.cpp:1546
 msgid "Update server list when connecting to a server"
 msgstr "与服务器连接时更新服务器列表"
 
-#: src/muuli_wdr.cpp:1542
+#: src/muuli_wdr.cpp:1549
 msgid "Update server list when a client connects"
 msgstr "与其他用户连接时更新服务器列表"
 
-#: src/muuli_wdr.cpp:1545
+#: src/muuli_wdr.cpp:1552
 msgid "Use priority system"
 msgstr "启用优先级系统"
 
-#: src/muuli_wdr.cpp:1549
+#: src/muuli_wdr.cpp:1556
 msgid "Use smart LowID check on connect"
 msgstr "连接时启用智能 Low ID 检测"
 
-#: src/muuli_wdr.cpp:1553
+#: src/muuli_wdr.cpp:1560
 msgid "Safe connect"
 msgstr "安全连接"
 
-#: src/muuli_wdr.cpp:1557
+#: src/muuli_wdr.cpp:1564
 msgid "Autoconnect to servers in static list only"
 msgstr "只自动连接到静态服务器列表里的服务器"
 
-#: src/muuli_wdr.cpp:1560
+#: src/muuli_wdr.cpp:1567
 msgid "Set manually added servers to High Priority"
 msgstr "设置手动添加的服务器为高优先级"
 
-#: src/muuli_wdr.cpp:1581
+#: src/muuli_wdr.cpp:1588
 msgid "Add files to download in pause mode"
 msgstr "添加新下载文件时设为暂停状态"
 
-#: src/muuli_wdr.cpp:1583
+#: src/muuli_wdr.cpp:1590
 msgid "Add files to download with auto priority"
 msgstr "添加新下载文件时设定优先级为自动"
 
-#: src/muuli_wdr.cpp:1586
+#: src/muuli_wdr.cpp:1593
 msgid "Try to download first and last chunks first"
 msgstr "尝试先下载文件的第一段和最后一段"
 
-#: src/muuli_wdr.cpp:1590
+#: src/muuli_wdr.cpp:1597
 msgid "Endgame mode: rotate to faster sources for the final blocks"
 msgstr "末端模式：在下载最后的区块时，切换至速度更快的来源"
 
-#: src/muuli_wdr.cpp:1593
+#: src/muuli_wdr.cpp:1600
 msgid "Start next paused file when a file completes"
 msgstr "当一个文件完成时开始下一个暂停的文件"
 
-#: src/muuli_wdr.cpp:1596
+#: src/muuli_wdr.cpp:1603
 msgid "From the same category"
 msgstr "来自同一分类"
 
-#: src/muuli_wdr.cpp:1598
+#: src/muuli_wdr.cpp:1605
 msgid "In alphabetic order"
 msgstr "依照字母顺序"
 
-#: src/muuli_wdr.cpp:1600
+#: src/muuli_wdr.cpp:1607
 msgid "Preallocate disk space for new files"
 msgstr "为新文件预分配磁盘空间"
 
-#: src/muuli_wdr.cpp:1601
+#: src/muuli_wdr.cpp:1608
 msgid "For new files preallocates disk space for the whole file, thus reduces fragmentation"
 msgstr "为新文件分配全部所需的磁盘空间，这样可以减少碎片"
 
-#: src/muuli_wdr.cpp:1606
+#: src/muuli_wdr.cpp:1613
 msgid "Create new files as sparse files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1607
+#: src/muuli_wdr.cpp:1614
 msgid "A sparse file reserves its full size on disk immediately without writing real data to it -- fast, but unsupported or slow on some filesystems, and free-space accounting stays optimistic while the download is in progress. Turn this off to grow the file only as data arrives."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1612
+#: src/muuli_wdr.cpp:1619
 msgid "Stop downloads when free disk space reaches "
 msgstr "停止下载当可用磁盘空间只有"
 
-#: src/muuli_wdr.cpp:1613
+#: src/muuli_wdr.cpp:1620
 msgid "Select this if you want aMule to check your disk space"
 msgstr "要求检查磁盘空间"
 
-#: src/muuli_wdr.cpp:1617
+#: src/muuli_wdr.cpp:1624
 msgid "Enter here the min disk space desired."
 msgstr "请输入最低硬盘空间。"
 
-#: src/muuli_wdr.cpp:1623
+#: src/muuli_wdr.cpp:1630
 msgid "Save 10 sources on rare files (< 20 sources)"
 msgstr "保存稀有文件（少于20个源）的10个源"
 
-#: src/muuli_wdr.cpp:1627 src/Statistics.cpp:790
+#: src/muuli_wdr.cpp:1634 src/Statistics.cpp:790
 msgid "Uploads"
 msgstr "上传"
 
-#: src/muuli_wdr.cpp:1630
+#: src/muuli_wdr.cpp:1637
 msgid "Add new shared files with auto priority"
 msgstr "添加新共享文件时设优先级为自动"
 
-#: src/muuli_wdr.cpp:1636
+#: src/muuli_wdr.cpp:1643
 msgid "Intelligent Corruption Handling (I.C.H.)"
 msgstr "智能损坏数据处理 (I.C.H.)"
 
-#: src/muuli_wdr.cpp:1639
+#: src/muuli_wdr.cpp:1646
 msgid "Enable"
 msgstr "启用"
 
-#: src/muuli_wdr.cpp:1642
+#: src/muuli_wdr.cpp:1649
 msgid "Advanced I.C.H. trusts every hash (not recommended)"
 msgstr "高级 I.C.H. 信任全部哈希值 (不推荐)"
 
-#: src/muuli_wdr.cpp:1654 src/PrefsUnifiedDlg.cpp:1910
+#: src/muuli_wdr.cpp:1661 src/PrefsUnifiedDlg.cpp:1910
 msgid "Media metadata extraction"
 msgstr "媒体元数据提取"
 
-#: src/muuli_wdr.cpp:1658
+#: src/muuli_wdr.cpp:1665
 msgid "Extract length / bitrate / codec from shared audio and video files"
 msgstr "从共享的音视频文件提取长度/比特率/编解码器信息"
 
-#: src/muuli_wdr.cpp:1660
+#: src/muuli_wdr.cpp:1667
 msgid "When enabled, aMule runs ffprobe on each shared media file to fill in the Length / Bitrate / Codec columns other clients see when they find the file in a search. Requires ffmpeg (the ffprobe binary) to be installed."
 msgstr "启用此功能后，aMule 会对每个共享媒体文件运行 ffprobe 填充其他客户端在搜索到该文件时看到的“长度”、“比特率”和“编解码器”列。需要安装 ffmpeg（ffprobe 二进制文件）。"
 
-#: src/muuli_wdr.cpp:1667
+#: src/muuli_wdr.cpp:1674
 msgid "Path to ffprobe:"
 msgstr "ffprobe 路径："
 
-#: src/muuli_wdr.cpp:1672
+#: src/muuli_wdr.cpp:1679
 msgid "Full path to the ffprobe binary. Leave empty to have aMule auto-detect it on startup."
 msgstr "ffprobe 二进制文件的完整路径。留空让 amule 在启动时自动检测。"
 
-#: src/muuli_wdr.cpp:1680
+#: src/muuli_wdr.cpp:1687
 msgid "Detect"
 msgstr "检测"
 
-#: src/muuli_wdr.cpp:1681
+#: src/muuli_wdr.cpp:1688
 msgid "Search the standard install locations for an ffprobe binary and fill the path field."
 msgstr "搜索标准的 ffprobe 二进制文件安装路径，并填写路径字段。"
 
-#: src/muuli_wdr.cpp:1705
+#: src/muuli_wdr.cpp:1712
 msgid ""
 "Completed downloads are stored here. All files in this folder are automatically shared with other peers.\n"
 "If this folder also holds files you don't want to share, point it at an aMule-only sub-folder."
@@ -4143,665 +4157,665 @@ msgstr ""
 "已完成下载的文件存储在此处。此文件夹中的所有文件将自动与其他对等点共享。\n"
 "如果此文件夹中还包含您不想共享的文件，请为 aMule 选择一个专用子文件夹。"
 
-#: src/muuli_wdr.cpp:1708
+#: src/muuli_wdr.cpp:1715
 msgid "Pick the folder where completed downloads will be stored. All files in that folder will be shared with other peers."
 msgstr "选择完成下载文件的存储文件夹。该文件夹中的所有文件都将与其他对等节点共享。"
 
-#: src/muuli_wdr.cpp:1722
+#: src/muuli_wdr.cpp:1729
 msgid "Shared folders"
 msgstr "共享的文件夹"
 
-#: src/muuli_wdr.cpp:1728
+#: src/muuli_wdr.cpp:1735
 msgid "(Folders shared by the core. Enter a path to add one.)"
 msgstr "(由核心共享的文件夹。输入路径添加一个。)"
 
-#: src/muuli_wdr.cpp:1736
+#: src/muuli_wdr.cpp:1743
 msgid "Absolute path of a folder on the core's machine, e.g. /home/user/shared"
 msgstr "核心机器上文件夹的绝对路径，如 /home/user/shared"
 
-#: src/muuli_wdr.cpp:1738 src/PrefsUnifiedDlg.cpp:2794
+#: src/muuli_wdr.cpp:1745 src/PrefsUnifiedDlg.cpp:2794
 msgid "Recursive"
 msgstr "递归"
 
-#: src/muuli_wdr.cpp:1739
+#: src/muuli_wdr.cpp:1746
 msgid "Share every sub-folder underneath this one, including ones created later."
 msgstr "分享此文件夹下每个子文件夹，包括之后创建的子文件夹。"
 
-#: src/muuli_wdr.cpp:1743 src/utils/aLinkCreator/src/alcframe.cpp:141
+#: src/muuli_wdr.cpp:1750 src/utils/aLinkCreator/src/alcframe.cpp:141
 msgid "Remove"
 msgstr "删除"
 
-#: src/muuli_wdr.cpp:1747
+#: src/muuli_wdr.cpp:1754
 msgid "(Right click on folder icon for recursive share)"
 msgstr "(鼠标右键单击文件夹图标来递归共享)"
 
-#: src/muuli_wdr.cpp:1754
+#: src/muuli_wdr.cpp:1761
 msgid "Share hidden files"
 msgstr "共享隐藏文件"
 
-#: src/muuli_wdr.cpp:1760
+#: src/muuli_wdr.cpp:1767
 msgid "Automatically rescan shared folders for changes"
 msgstr "自动重新扫描共享文件夹以检测更改"
 
-#: src/muuli_wdr.cpp:1766
+#: src/muuli_wdr.cpp:1773
 msgid "Follow symbolic links in shared folders"
 msgstr "在共享文件夹中跟踪符号链接"
 
-#: src/muuli_wdr.cpp:1772
+#: src/muuli_wdr.cpp:1779
 msgid "Exclude files matching:"
 msgstr "排除文件匹配："
 
-#: src/muuli_wdr.cpp:1775
+#: src/muuli_wdr.cpp:1782
 msgid "Wildcard patterns separated by '|', e.g. .DS_Store|Thumbs.db|*.tmp. Files whose name matches are not shared. Matching is case-insensitive."
 msgstr "以“|”分隔的通配符模式，例如 .DS_Store|Thumbs.db|*.tmp。不会共享文件名匹配的文件。匹配不区分大小写。"
 
-#: src/muuli_wdr.cpp:1779
+#: src/muuli_wdr.cpp:1786
 msgid "Patterns are regular expressions"
 msgstr "模式是正则表达式"
 
-#: src/muuli_wdr.cpp:1780
+#: src/muuli_wdr.cpp:1787
 msgid "When set, the whole field is one regular expression ('|' is alternation). When unset, it is a list of '|'-separated wildcards."
 msgstr "启用后，整个字段是一个正则表达式（'|' 表示交替）。禁用后，它是一个以 '|' 分隔的通配符列表。"
 
-#: src/muuli_wdr.cpp:1790
+#: src/muuli_wdr.cpp:1797
 msgid "Show how many shared files the current pattern would exclude."
 msgstr "显示当前模式会排除多少共享文件。"
 
-#: src/muuli_wdr.cpp:1811
+#: src/muuli_wdr.cpp:1818
 msgid "Graphs"
 msgstr "图表"
 
-#: src/muuli_wdr.cpp:1814 src/muuli_wdr.cpp:1876
+#: src/muuli_wdr.cpp:1821 src/muuli_wdr.cpp:1883
 msgid "Update delay : 5 secs"
 msgstr "刷新延迟：5 秒"
 
-#: src/muuli_wdr.cpp:1818
+#: src/muuli_wdr.cpp:1825
 msgid "Time for average graph: 100 mins"
 msgstr "平均值图表显示时间：100 分钟"
 
-#: src/muuli_wdr.cpp:1822
+#: src/muuli_wdr.cpp:1829
 msgid "Connections Graph Scale: 100 "
 msgstr "连接图表尺寸: 100 "
 
-#: src/muuli_wdr.cpp:1829
+#: src/muuli_wdr.cpp:1836
 msgid "Download graph scale:"
 msgstr "下载图表尺寸："
 
-#: src/muuli_wdr.cpp:1837
+#: src/muuli_wdr.cpp:1844
 msgid "Upload graph scale:"
 msgstr "上传图表尺寸："
 
-#: src/muuli_wdr.cpp:1847
+#: src/muuli_wdr.cpp:1854
 msgid "Colors: "
 msgstr "颜色： "
 
-#: src/muuli_wdr.cpp:1851
+#: src/muuli_wdr.cpp:1858
 msgid "Background"
 msgstr "背景"
 
-#: src/muuli_wdr.cpp:1852
+#: src/muuli_wdr.cpp:1859
 msgid "Grid"
 msgstr "网格"
 
-#: src/muuli_wdr.cpp:1853
+#: src/muuli_wdr.cpp:1860
 msgid "Download current"
 msgstr "目前下载"
 
-#: src/muuli_wdr.cpp:1854
+#: src/muuli_wdr.cpp:1861
 msgid "Download running average"
 msgstr "动态平均下载"
 
-#: src/muuli_wdr.cpp:1855
+#: src/muuli_wdr.cpp:1862
 msgid "Download session average"
 msgstr "本次运行平均下载"
 
-#: src/muuli_wdr.cpp:1856
+#: src/muuli_wdr.cpp:1863
 msgid "Upload current"
 msgstr "目前上传"
 
-#: src/muuli_wdr.cpp:1857
+#: src/muuli_wdr.cpp:1864
 msgid "Upload running average"
 msgstr "动态平均上传"
 
-#: src/muuli_wdr.cpp:1858
+#: src/muuli_wdr.cpp:1865
 msgid "Upload session average"
 msgstr "本次运行平均上传"
 
-#: src/muuli_wdr.cpp:1859
+#: src/muuli_wdr.cpp:1866
 msgid "Active connections"
 msgstr "活跃连接"
 
-#: src/muuli_wdr.cpp:1862
+#: src/muuli_wdr.cpp:1869
 msgid "Systray Icon Speed Bar"
 msgstr "系统状态栏图标速度显示"
 
-#: src/muuli_wdr.cpp:1863
+#: src/muuli_wdr.cpp:1870
 msgid "Kad-nodes current"
 msgstr "当前 Kad 节点"
 
-#: src/muuli_wdr.cpp:1864
+#: src/muuli_wdr.cpp:1871
 msgid "Kad-nodes running"
 msgstr "运行的 Kad 节点"
 
-#: src/muuli_wdr.cpp:1865
+#: src/muuli_wdr.cpp:1872
 msgid "Kad-nodes session"
 msgstr "本次运行的 Kad 节点"
 
-#: src/muuli_wdr.cpp:1869 src/muuli_wdr.cpp:2296
+#: src/muuli_wdr.cpp:1876 src/muuli_wdr.cpp:2303
 msgid "Select"
 msgstr "选择"
 
-#: src/muuli_wdr.cpp:1873
+#: src/muuli_wdr.cpp:1880
 msgid "Tree"
 msgstr "树"
 
-#: src/muuli_wdr.cpp:1883
+#: src/muuli_wdr.cpp:1890
 msgid "Number of Client Versions shown (0=unlimited)"
 msgstr "显示用户软件版本的数量(0代表不限制)"
 
-#: src/muuli_wdr.cpp:1908
+#: src/muuli_wdr.cpp:1915
 msgid "!!! WARNING !!!"
 msgstr "！！！警告！！！"
 
-#: src/muuli_wdr.cpp:1923
+#: src/muuli_wdr.cpp:1930
 msgid "Max new connections / 5 secs"
 msgstr "5 秒内最大新连接数"
 
-#: src/muuli_wdr.cpp:1925
+#: src/muuli_wdr.cpp:1932
 msgid "Concurrent Kad source lookups"
 msgstr "并发 Kad 源查找"
 
-#: src/muuli_wdr.cpp:1927
+#: src/muuli_wdr.cpp:1934
 msgid "Kad source re-search interval (minutes)"
 msgstr "Kad 源重新搜索间隔（分钟）"
 
-#: src/muuli_wdr.cpp:1929
+#: src/muuli_wdr.cpp:1936
 msgid "Source re-ask interval (minutes)"
 msgstr "源重新请求间隔（分钟）"
 
-#: src/muuli_wdr.cpp:1933
+#: src/muuli_wdr.cpp:1940
 msgid "File Buffer Size: 240000 bytes"
 msgstr "文件缓冲：24000 字节"
 
-#: src/muuli_wdr.cpp:1937
+#: src/muuli_wdr.cpp:1944
 msgid "Use MMAP: memory-mapped file access (lower memory use)"
 msgstr "使用 MMAP：内存映射文件访问（降低内存占用）"
 
-#: src/muuli_wdr.cpp:1938
+#: src/muuli_wdr.cpp:1945
 msgid "Maps part files into memory instead of buffering them on the heap, lowering the process memory footprint. May reduce download speed on some disks; best for memory-constrained or upload-heavy hosts."
 msgstr "映射 part 文件到内存而不是在堆栈上缓冲，降低进程内存占用。在一些磁盘上可能降低下载速度；最适合内存紧张或重度上传的主机。"
 
-#: src/muuli_wdr.cpp:1940
+#: src/muuli_wdr.cpp:1947
 msgid "Upload Queue Size: 5000 clients"
 msgstr "上传队列长度：5000 用户"
 
-#: src/muuli_wdr.cpp:1944
+#: src/muuli_wdr.cpp:1951
 msgid "Server connection refresh interval: Disable"
 msgstr "服务器连接刷新周期：禁用"
 
-#: src/muuli_wdr.cpp:1948
+#: src/muuli_wdr.cpp:1955
 msgid "Disable computer's timed standby mode"
 msgstr "停用电脑自动进入待命模式功能"
 
-#: src/muuli_wdr.cpp:1967
+#: src/muuli_wdr.cpp:1974
 msgid "Skin to use: "
 msgstr "要使用的皮肤: "
 
-#: src/muuli_wdr.cpp:1976
+#: src/muuli_wdr.cpp:1983
 msgid "Show \"Fast eD2k Links Handler\" in every window."
 msgstr "在全部窗口都显示“快捷 eD2k 链接处理栏”。"
 
-#: src/muuli_wdr.cpp:1979
+#: src/muuli_wdr.cpp:1986
 msgid "Show extended info on categories tabs"
 msgstr "在分类页中显示附加信息"
 
-#: src/muuli_wdr.cpp:1982
+#: src/muuli_wdr.cpp:1989
 msgid "Show application version on title"
 msgstr "在标题栏显示应用程序版本"
 
-#: src/muuli_wdr.cpp:1984
+#: src/muuli_wdr.cpp:1991
 msgid "Show transfer rates on title"
 msgstr "在标题栏显示传输速度"
 
-#: src/muuli_wdr.cpp:1986
+#: src/muuli_wdr.cpp:1993
 msgid "Before application name"
 msgstr "在应用程序名称之前"
 
-#: src/muuli_wdr.cpp:1988
+#: src/muuli_wdr.cpp:1995
 msgid "After application name"
 msgstr "在应用程序名称之后"
 
-#: src/muuli_wdr.cpp:1991
+#: src/muuli_wdr.cpp:1998
 msgid "Show overhead bandwidth"
 msgstr "显示额外开销的带宽"
 
-#: src/muuli_wdr.cpp:1995
+#: src/muuli_wdr.cpp:2002
 msgid "Vertical toolbar orientation"
 msgstr "垂直显示工具栏"
 
-#: src/muuli_wdr.cpp:1997
+#: src/muuli_wdr.cpp:2004
 msgid "Live column sorting (auto-reorder rows as their values change)"
 msgstr "实时列排序（值更改时自动调整顺序）"
 
-#: src/muuli_wdr.cpp:2004
+#: src/muuli_wdr.cpp:2011
 msgid "Download Queue Files"
 msgstr "下载队列文件"
 
-#: src/muuli_wdr.cpp:2007
+#: src/muuli_wdr.cpp:2014
 msgid "Show progress percentage"
 msgstr "显示进度百分比"
 
-#: src/muuli_wdr.cpp:2013
+#: src/muuli_wdr.cpp:2020
 msgid "Show progress bar"
 msgstr "显示进度条"
 
-#: src/muuli_wdr.cpp:2016
+#: src/muuli_wdr.cpp:2023
 msgid "Flat"
 msgstr "扁平"
 
-#: src/muuli_wdr.cpp:2020
+#: src/muuli_wdr.cpp:2027
 msgid "Round"
 msgstr "圆柱"
 
-#: src/muuli_wdr.cpp:2038
+#: src/muuli_wdr.cpp:2045
 msgid "External Connection Parameters"
 msgstr "远程连接参数"
 
-#: src/muuli_wdr.cpp:2041
+#: src/muuli_wdr.cpp:2048
 msgid "Accept external connections"
 msgstr "接受远程连接"
 
-#: src/muuli_wdr.cpp:2048 src/muuli_wdr.cpp:2107
+#: src/muuli_wdr.cpp:2055 src/muuli_wdr.cpp:2114
 msgid "IP of the listening interface:"
 msgstr "监听接口的 IP:"
 
-#: src/muuli_wdr.cpp:2051
+#: src/muuli_wdr.cpp:2058
 msgid "Enter here a valid ip in the a.b.c.d format for the listening EC interface. An empty field or 0.0.0.0 will mean any interface."
 msgstr "在此输入正确的 IP(格式：a.b.c.d)用于监听远程连接接口。空着不填或者 0.0.0.0 表示任何接口。"
 
-#: src/muuli_wdr.cpp:2072 src/muuli_wdr.cpp:2156
+#: src/muuli_wdr.cpp:2079 src/muuli_wdr.cpp:2163
 msgid "TCP port:"
 msgstr "TCP 端口："
 
-#: src/muuli_wdr.cpp:2078
+#: src/muuli_wdr.cpp:2085
 msgid "Enable UPnP port forwarding on the EC port"
 msgstr "为远程连接端口启用 UPnP"
 
-#: src/muuli_wdr.cpp:2082 src/muuli_wdr.cpp:3041
+#: src/muuli_wdr.cpp:2089 src/muuli_wdr.cpp:3048
 #: src/utils/wxCas/src/wxcasprefs.cpp:167
 msgid "Password"
 msgstr "密码"
 
-#: src/muuli_wdr.cpp:2088
+#: src/muuli_wdr.cpp:2095
 msgid "aMule API server parameters"
 msgstr "aMule API 服务器参数"
 
-#: src/muuli_wdr.cpp:2091
+#: src/muuli_wdr.cpp:2098
 msgid "Run amuleapi (REST API) on startup"
 msgstr "启动时运行 amuleapi (REST API)"
 
-#: src/muuli_wdr.cpp:2096
+#: src/muuli_wdr.cpp:2103
 msgid "HTTP port:"
 msgstr "HTTP 端口："
 
-#: src/muuli_wdr.cpp:2110
+#: src/muuli_wdr.cpp:2117
 msgid "The interface amuleapi's HTTP server listens on. 127.0.0.1 (default) accepts only local connections; use 0.0.0.0 or a specific IP to expose it to other hosts (set an admin password below)."
 msgstr "amuleapi 接口的 HTTP 服务器监听默认地址为 127.0.0.1，该地址仅接受本地连接；使用 0.0.0.0 或特定 IP 地址可将其暴露给其他主机（请在下方设置管理密码）。"
 
-#: src/muuli_wdr.cpp:2113
+#: src/muuli_wdr.cpp:2120
 msgid "Admin password"
 msgstr "管理密码"
 
-#: src/muuli_wdr.cpp:2118 src/muuli_wdr.cpp:2149
+#: src/muuli_wdr.cpp:2125 src/muuli_wdr.cpp:2156
 msgid "Low rights password"
 msgstr "低权限密码"
 
-#: src/muuli_wdr.cpp:2126
+#: src/muuli_wdr.cpp:2133
 msgid "Web server parameters"
 msgstr "Web 服务参数"
 
-#: src/muuli_wdr.cpp:2129
+#: src/muuli_wdr.cpp:2136
 msgid "Run webserver on startup (deprecated)"
 msgstr "启动时运行 web 服务器（已废弃）"
 
-#: src/muuli_wdr.cpp:2135
+#: src/muuli_wdr.cpp:2142
 msgid "Web template"
 msgstr "Web 模板"
 
-#: src/muuli_wdr.cpp:2140
+#: src/muuli_wdr.cpp:2147
 msgid "Full rights password"
 msgstr "最高权限密码"
 
-#: src/muuli_wdr.cpp:2144
+#: src/muuli_wdr.cpp:2151
 msgid "Enable Low rights User"
 msgstr "启用低权限用户"
 
-#: src/muuli_wdr.cpp:2163
+#: src/muuli_wdr.cpp:2170
 msgid "Enable UPnP port forwarding of the web server port"
 msgstr "为 Web 服务端口启用 UPn P端口转发"
 
-#: src/muuli_wdr.cpp:2168
+#: src/muuli_wdr.cpp:2175
 msgid "Web server UPnP TCP port (Optional)"
 msgstr "Web 服务器 UPnP 的 TCP 端口(可选)"
 
-#: src/muuli_wdr.cpp:2176
+#: src/muuli_wdr.cpp:2183
 msgid "Page Refresh Time (in secs)"
 msgstr "页面刷新周期(秒)"
 
-#: src/muuli_wdr.cpp:2183
+#: src/muuli_wdr.cpp:2190
 msgid "Enable Gzip compression"
 msgstr "启用 Gzip 压缩"
 
-#: src/muuli_wdr.cpp:2217
+#: src/muuli_wdr.cpp:2224
 msgid "Reset page to defaults"
 msgstr "重置页面为默认"
 
-#: src/muuli_wdr.cpp:2218
+#: src/muuli_wdr.cpp:2225
 msgid "Reset the settings on the current page to their default values."
 msgstr "重置当前页面设置为默认值。"
 
-#: src/muuli_wdr.cpp:2220 src/muuli_wdr.cpp:2306 src/ServerWnd.cpp:274
+#: src/muuli_wdr.cpp:2227 src/muuli_wdr.cpp:2313 src/ServerWnd.cpp:274
 #: src/ServerWnd.cpp:282
 msgid "OK"
 msgstr "确定"
 
-#: src/muuli_wdr.cpp:2222
+#: src/muuli_wdr.cpp:2229
 msgid "Click here to apply any changes made to the preferences."
 msgstr "点击这里立即使用新的设置。"
 
-#: src/muuli_wdr.cpp:2225
+#: src/muuli_wdr.cpp:2232
 msgid "Reset any changes made to the preferences."
 msgstr "取消所有设置改动。"
 
-#: src/muuli_wdr.cpp:2254
+#: src/muuli_wdr.cpp:2261
 msgid "Comment :"
 msgstr "注释 :"
 
-#: src/muuli_wdr.cpp:2261
+#: src/muuli_wdr.cpp:2268
 msgid "Incoming Dir :"
 msgstr "下载目录 :"
 
-#: src/muuli_wdr.cpp:2270
+#: src/muuli_wdr.cpp:2277
 msgid "Change priority for new assigned files :"
 msgstr "设置新加入的文件优先级为 :"
 
-#: src/muuli_wdr.cpp:2274
+#: src/muuli_wdr.cpp:2281
 msgid "Don't change"
 msgstr "不要改变"
 
-#: src/muuli_wdr.cpp:2286
+#: src/muuli_wdr.cpp:2293
 msgid "Select color for this Category (currently selected) :"
 msgstr "选择该分类颜色 (当前选择) :"
 
-#: src/muuli_wdr.cpp:2353 src/muuli_wdr.cpp:2372 src/muuli_wdr.cpp:2394
+#: src/muuli_wdr.cpp:2360 src/muuli_wdr.cpp:2379 src/muuli_wdr.cpp:2401
 msgid "Click this button to reset the log."
 msgstr "按此按钮清空日志。"
 
-#: src/muuli_wdr.cpp:2413
+#: src/muuli_wdr.cpp:2420
 msgid "Click on this button to update the servers list from URL ..."
 msgstr "按此按钮从该网址更新服务器列表 ..."
 
-#: src/muuli_wdr.cpp:2417
+#: src/muuli_wdr.cpp:2424
 msgid "Server list"
 msgstr "服务器列表"
 
-#: src/muuli_wdr.cpp:2421
+#: src/muuli_wdr.cpp:2428
 msgid "Enter the url to a server.met file here and press the button to the left to update the list of known servers."
 msgstr "输入 server.met 文件的地址，再按此按钮更新服务器列表。"
 
-#: src/muuli_wdr.cpp:2426
+#: src/muuli_wdr.cpp:2433
 msgid "Add server manually: Name"
 msgstr "手动添加服务器：名称"
 
-#: src/muuli_wdr.cpp:2429
+#: src/muuli_wdr.cpp:2436
 msgid "Enter the name of the new server here"
 msgstr "在此输入新服务器的名称"
 
-#: src/muuli_wdr.cpp:2431 src/ServerWnd.cpp:206
+#: src/muuli_wdr.cpp:2438 src/ServerWnd.cpp:206
 msgid "IP:Port"
 msgstr "IP 地址:端口"
 
-#: src/muuli_wdr.cpp:2434
+#: src/muuli_wdr.cpp:2441
 msgid "Enter the IP of the server here, using the x.x.x.x format."
 msgstr "输入新服务器的 IP 地址 (x.x.x.x格式)。"
 
-#: src/muuli_wdr.cpp:2440
+#: src/muuli_wdr.cpp:2447
 msgid "Enter the port of the server here."
 msgstr "在此请输入服务器端口。"
 
-#: src/muuli_wdr.cpp:2443
+#: src/muuli_wdr.cpp:2450
 msgid "Add manually a server (fill fields to the left before) ..."
 msgstr "添加新服务器 (先填写左侧的内容) ..."
 
-#: src/muuli_wdr.cpp:2472
+#: src/muuli_wdr.cpp:2479
 msgid "aMule Log"
 msgstr "aMule 日志"
 
-#: src/muuli_wdr.cpp:2480
+#: src/muuli_wdr.cpp:2487
 msgid "Server Info"
 msgstr "服务器信息"
 
-#: src/muuli_wdr.cpp:2484
+#: src/muuli_wdr.cpp:2491
 msgid "ED2K Info"
 msgstr "ED2K 信息"
 
-#: src/muuli_wdr.cpp:2488
+#: src/muuli_wdr.cpp:2495
 msgid "Kad Info"
 msgstr "Kad 信息"
 
-#: src/muuli_wdr.cpp:2516
+#: src/muuli_wdr.cpp:2523
 msgid "Click on this button to update the nodes list from URL ..."
 msgstr "按此更新节点列表自网址..."
 
-#: src/muuli_wdr.cpp:2520
+#: src/muuli_wdr.cpp:2527
 msgid "Nodes (0)"
 msgstr "节点 (0)"
 
-#: src/muuli_wdr.cpp:2524
+#: src/muuli_wdr.cpp:2531
 msgid "Enter the url to a nodes.dat file here and press the button to the left to update the list of known nodes."
 msgstr "输入 nodes.dat 文件的地址并按左边的按钮以更新已知节点列表"
 
-#: src/muuli_wdr.cpp:2527
+#: src/muuli_wdr.cpp:2534
 msgid "Nodes stats"
 msgstr "节点状态"
 
-#: src/muuli_wdr.cpp:2569
+#: src/muuli_wdr.cpp:2576
 msgid "Bootstrap"
 msgstr "启动"
 
-#: src/muuli_wdr.cpp:2572
+#: src/muuli_wdr.cpp:2579
 msgid "New node"
 msgstr "新节点"
 
-#: src/muuli_wdr.cpp:2577
+#: src/muuli_wdr.cpp:2584
 msgid "IP:"
 msgstr "IP："
 
-#: src/muuli_wdr.cpp:2597
+#: src/muuli_wdr.cpp:2604
 msgid "Port:"
 msgstr "端口："
 
-#: src/muuli_wdr.cpp:2610
+#: src/muuli_wdr.cpp:2617
 msgid "Bootstrap from known clients"
 msgstr "从已知用户启动"
 
-#: src/muuli_wdr.cpp:2612
+#: src/muuli_wdr.cpp:2619
 msgid "Disconnect Kad"
 msgstr "断开 Kad"
 
-#: src/muuli_wdr.cpp:2646
+#: src/muuli_wdr.cpp:2653
 msgid "Use Secure User Identification"
 msgstr "使用安全用户认证"
 
-#: src/muuli_wdr.cpp:2648
+#: src/muuli_wdr.cpp:2655
 msgid "It is recommended to enable this option. You will not receive credits if SUI is not enabled."
 msgstr "建议使用此选项，如果安全用户认证没有启用，将不会接收信用证明。"
 
-#: src/muuli_wdr.cpp:2650
+#: src/muuli_wdr.cpp:2657
 msgid "Protocol Obfuscation"
 msgstr "模糊协议"
 
-#: src/muuli_wdr.cpp:2653
+#: src/muuli_wdr.cpp:2660
 msgid "Support Protocol Obfuscation"
 msgstr "支持模糊协议"
 
-#: src/muuli_wdr.cpp:2655
+#: src/muuli_wdr.cpp:2662
 msgid "This option enabled Protocol Obfuscation, and makes aMule accept obfuscated connections from other clients."
 msgstr "此选项启用了模糊协议，可让aMule接受其他用户用迷糊协议的连接"
 
-#: src/muuli_wdr.cpp:2657
+#: src/muuli_wdr.cpp:2664
 msgid "Use obfuscation for outgoing connections"
 msgstr "为传出连接使用模糊协议"
 
-#: src/muuli_wdr.cpp:2659
+#: src/muuli_wdr.cpp:2666
 msgid "This option makes aMule use Protocol Obfuscation when connecting other clients/servers."
 msgstr "此选项使aMule在连接其他用户或服务器时使用模糊协议。"
 
-#: src/muuli_wdr.cpp:2661
+#: src/muuli_wdr.cpp:2668
 msgid "Accept only obfuscated connections"
 msgstr "仅接受模糊协议连接"
 
-#: src/muuli_wdr.cpp:2662
+#: src/muuli_wdr.cpp:2669
 msgid "This option makes aMule only accept obfuscated connections. You will have less sources, but all your traffic will be obfuscated"
 msgstr "此选项让aMule只接受模糊协议连接，源相对来说会更少，但全部数据包都将进行迷惑处理"
 
-#: src/muuli_wdr.cpp:2667
+#: src/muuli_wdr.cpp:2674
 msgid "Everybody"
 msgstr "任何人"
 
-#: src/muuli_wdr.cpp:2669
+#: src/muuli_wdr.cpp:2676
 msgid "No one"
 msgstr "没有人"
 
-#: src/muuli_wdr.cpp:2671
+#: src/muuli_wdr.cpp:2678
 msgid "Who can see my shared files:"
 msgstr "谁可查看我的共享文件："
 
-#: src/muuli_wdr.cpp:2672
+#: src/muuli_wdr.cpp:2679
 msgid "Select who can request to view a list of your shared files."
 msgstr "选择可以浏览共享文件列表的用户。"
 
-#: src/muuli_wdr.cpp:2674
+#: src/muuli_wdr.cpp:2681
 msgid "IP-Filtering"
 msgstr "IP 过滤"
 
-#: src/muuli_wdr.cpp:2681
+#: src/muuli_wdr.cpp:2688
 msgid "Filter clients"
 msgstr "过滤用户"
 
-#: src/muuli_wdr.cpp:2683
+#: src/muuli_wdr.cpp:2690
 msgid "Enable filtering of the client IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "过滤在文件~/.aMule/ipfilter.dat中定义的用户IP"
 
-#: src/muuli_wdr.cpp:2685
+#: src/muuli_wdr.cpp:2692
 msgid "Filter servers"
 msgstr "过滤服务器"
 
-#: src/muuli_wdr.cpp:2687
+#: src/muuli_wdr.cpp:2694
 msgid "Enable filtering of the server IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "过滤在文件~/.aMule/ipfilter.dat中定义的服务器IP"
 
-#: src/muuli_wdr.cpp:2691
+#: src/muuli_wdr.cpp:2698
 msgid "Reload List"
 msgstr "刷新列表"
 
-#: src/muuli_wdr.cpp:2692
+#: src/muuli_wdr.cpp:2699
 msgid "Reload the list of IPs to filter from the file ~/.aMule/ipfilter.dat"
 msgstr "更新 IP 地址过滤列表自文件 ~/.aMule/ipfilter.dat"
 
-#: src/muuli_wdr.cpp:2698
+#: src/muuli_wdr.cpp:2705
 msgid "URL:"
 msgstr "地址:"
 
-#: src/muuli_wdr.cpp:2702 src/muuli_wdr.cpp:2895
+#: src/muuli_wdr.cpp:2709 src/muuli_wdr.cpp:2902
 msgid "Update now"
 msgstr "立即更新"
 
-#: src/muuli_wdr.cpp:2705
+#: src/muuli_wdr.cpp:2712
 msgid "Auto-update ipfilter at startup"
 msgstr "启动后自动更新IP 地址过滤列表"
 
-#: src/muuli_wdr.cpp:2709
+#: src/muuli_wdr.cpp:2716
 msgid "Filtering Level:"
 msgstr "过滤级别:"
 
-#: src/muuli_wdr.cpp:2715
+#: src/muuli_wdr.cpp:2722
 msgid "Always filter LAN IPs"
 msgstr "始终过滤局域网 IP"
 
-#: src/muuli_wdr.cpp:2718
+#: src/muuli_wdr.cpp:2725
 msgid "Paranoid handling of non-matching IPs"
 msgstr "处理不匹配的 IP"
 
-#: src/muuli_wdr.cpp:2720
+#: src/muuli_wdr.cpp:2727
 msgid "Rejects a packet when its source IP differs from the IP the client claims (an anti-spoofing check). Disable only if it causes connection problems."
 msgstr "当数据包的源 IP 地址与客户端声称的 IP 地址不同时，拒绝该数据包（防欺骗检查）。仅在导致连接问题时才禁用此功能。"
 
-#: src/muuli_wdr.cpp:2722
+#: src/muuli_wdr.cpp:2729
 msgid "Use system-wide ipfilter.dat if available"
 msgstr "在可用的情况下使用系统级别的 ipfilter.dat"
 
-#: src/muuli_wdr.cpp:2723
+#: src/muuli_wdr.cpp:2730
 msgid "If there's no local ipfilter.dat found, allow usage of a system-wide ipfilter file."
 msgstr "如果没有找到本地 ipfilter.dat 文件，则允许使用系统级的IP过滤文件。"
 
-#: src/muuli_wdr.cpp:2740
+#: src/muuli_wdr.cpp:2747
 msgid "Enable Online-Signature"
 msgstr "启用在线统计"
 
-#: src/muuli_wdr.cpp:2742
+#: src/muuli_wdr.cpp:2749
 msgid "Enables the writing of the OS file, which can be used by external apps to create signatures and the like."
 msgstr "输出该文件以用于在线统计等等。"
 
-#: src/muuli_wdr.cpp:2746
+#: src/muuli_wdr.cpp:2753
 msgid "Update Frequency (Secs):"
 msgstr "更新频率 (秒):"
 
-#: src/muuli_wdr.cpp:2749
+#: src/muuli_wdr.cpp:2756
 msgid "Change the frequency (in seconds) of Online Signature updates."
 msgstr "更改在线统计文件的更新频率 (秒) 。"
 
-#: src/muuli_wdr.cpp:2757
+#: src/muuli_wdr.cpp:2764
 msgid "Save online signature file in: "
 msgstr "保存在线签名位置： "
 
-#: src/muuli_wdr.cpp:2763
+#: src/muuli_wdr.cpp:2770
 msgid "Click here to select the directory containing the the Online Signature files."
 msgstr "单击此处选择包含在线签名文件的目录。"
 
-#: src/muuli_wdr.cpp:2796
+#: src/muuli_wdr.cpp:2803
 msgid "Show country flags for clients"
 msgstr "为客户端显示国旗"
 
-#: src/muuli_wdr.cpp:2797
+#: src/muuli_wdr.cpp:2804
 msgid "Render the country flag column in the transfers, queue and search views. Requires a valid MMDB GeoIP database (see below)."
 msgstr "在传输、队列和搜索视图中渲染地区旗帜列。需要有效的 MMDB GeoIP 数据库（见下文）。"
 
-#: src/muuli_wdr.cpp:2802
+#: src/muuli_wdr.cpp:2809
 msgid "Database"
 msgstr "数据库"
 
-#: src/muuli_wdr.cpp:2818
+#: src/muuli_wdr.cpp:2825
 msgid "Source:"
 msgstr "源："
 
-#: src/muuli_wdr.cpp:2821
+#: src/muuli_wdr.cpp:2828
 msgid "DB-IP (free, no account)"
 msgstr "DB-IP（免费，无需账户）"
 
-#: src/muuli_wdr.cpp:2822
+#: src/muuli_wdr.cpp:2829
 msgid "MaxMind GeoLite2 (free, account required)"
 msgstr "MaxMind GeoLite2（免费，需注册账户）"
 
-#: src/muuli_wdr.cpp:2823
+#: src/muuli_wdr.cpp:2830
 msgid "Custom URL"
 msgstr "自定义 URL"
 
-#: src/muuli_wdr.cpp:2826
+#: src/muuli_wdr.cpp:2833
 msgid "Choose which provider supplies the GeoIP MMDB database. DB-IP is the default - no account required. MaxMind requires a free account + license key. Use Custom URL to point at any other MMDB host (e.g. a local mirror)."
 msgstr "选择哪个提供商提供 GeoIP MMDB 数据库。DB-IP 是默认选项，无需账户。MaxMind 需要一个免费账户和许可证密钥。使用自定义 URL 指向任何其他 MMDB 主机（例如本地镜像）。"
 
-#: src/muuli_wdr.cpp:2843
+#: src/muuli_wdr.cpp:2850
 msgid ""
 "No configuration required.\n"
 "\n"
@@ -4813,11 +4827,11 @@ msgstr ""
 "IP-to-Country 数据由 DB-IP.com 提供 - https://db-ip.com\n"
 "许可证：知识共享署名 4.0 国际版 - https://creativecommons.org/licenses/by/4.0/"
 
-#: src/muuli_wdr.cpp:2856
+#: src/muuli_wdr.cpp:2863
 msgid "License key:"
 msgstr "许可证密钥："
 
-#: src/muuli_wdr.cpp:2862
+#: src/muuli_wdr.cpp:2869
 msgid ""
 "Sign up for a free MaxMind account, then generate a License Key:\n"
 "https://www.maxmind.com/en/geolite2/signup\n"
@@ -4833,11 +4847,11 @@ msgstr ""
 "许可证：MaxMind GeoLite2 最终用户许可协议 - https://www.maxmind.com/en/geolite2/eula\n"
 "需要注明出处并注册账户；至少每 30 天刷新一次。"
 
-#: src/muuli_wdr.cpp:2877
+#: src/muuli_wdr.cpp:2884
 msgid "Download URL:"
 msgstr "下载地址："
 
-#: src/muuli_wdr.cpp:2883
+#: src/muuli_wdr.cpp:2890
 msgid ""
 "Must point to an .mmdb file or a .gz / .tar.gz containing one.\n"
 "URL may include credentials (https://user:pass@host/...).\n"
@@ -4847,211 +4861,211 @@ msgstr ""
 "URL 可包含凭据（例如 https://user:pass@host/...）。\n"
 "许可和署名条款由上游 URL 决定——你需自行负责。"
 
-#: src/muuli_wdr.cpp:2896
+#: src/muuli_wdr.cpp:2903
 msgid "Download the GeoIP database from the selected source."
 msgstr "从所选源下载 GeoIP 数据库。"
 
-#: src/muuli_wdr.cpp:2898
+#: src/muuli_wdr.cpp:2905
 msgid "Auto-update on startup"
 msgstr "启动后自动更新"
 
-#: src/muuli_wdr.cpp:2899
+#: src/muuli_wdr.cpp:2906
 msgid "Re-download the GeoIP database from the selected source every time aMule starts."
 msgstr "每次启动 aMule 时，从所选源重新下载 GeoIP 数据库。"
 
-#: src/muuli_wdr.cpp:2922
+#: src/muuli_wdr.cpp:2929
 msgid "Filter incoming messages (except current chat):"
 msgstr "过滤收到的消息 (不包括当前对话):"
 
-#: src/muuli_wdr.cpp:2924
+#: src/muuli_wdr.cpp:2931
 msgid "Filter all messages"
 msgstr "过滤所有消息"
 
-#: src/muuli_wdr.cpp:2926
+#: src/muuli_wdr.cpp:2933
 msgid "Filter messages from people not on your friend list"
 msgstr "过滤来自好友列表外的消息"
 
-#: src/muuli_wdr.cpp:2928
+#: src/muuli_wdr.cpp:2935
 msgid "Filter messages from unknown clients"
 msgstr "过滤来自未知用户的消息"
 
-#: src/muuli_wdr.cpp:2930
+#: src/muuli_wdr.cpp:2937
 msgid "Filter messages containing (use ',' as separator):"
 msgstr "过滤包含以下内容的消息 (用半角逗号分隔):"
 
-#: src/muuli_wdr.cpp:2933 src/muuli_wdr.cpp:2944
+#: src/muuli_wdr.cpp:2940 src/muuli_wdr.cpp:2951
 msgid "add here the words amule should filter and block messages including it"
 msgstr "输入需过滤的词组"
 
-#: src/muuli_wdr.cpp:2935
+#: src/muuli_wdr.cpp:2942
 msgid "Show received messages in the log"
 msgstr "在日志中显示接收的消息"
 
-#: src/muuli_wdr.cpp:2938
+#: src/muuli_wdr.cpp:2945
 msgid "Comments"
 msgstr "备注"
 
-#: src/muuli_wdr.cpp:2941
+#: src/muuli_wdr.cpp:2948
 msgid "Filter comments containing (use ',' as separator):"
 msgstr "过滤包含以下内容的备注 (使用“,”作为分隔符):"
 
-#: src/muuli_wdr.cpp:2966
+#: src/muuli_wdr.cpp:2973
 msgid "Enable Proxy"
 msgstr "启用代理"
 
-#: src/muuli_wdr.cpp:2967
+#: src/muuli_wdr.cpp:2974
 msgid "Enable/disable proxy support"
 msgstr "启用/禁用代理支持"
 
-#: src/muuli_wdr.cpp:2970
+#: src/muuli_wdr.cpp:2977
 msgid "Proxy type:"
 msgstr "代理类型:"
 
-#: src/muuli_wdr.cpp:2981
+#: src/muuli_wdr.cpp:2988
 msgid "Proxy host:"
 msgstr "代理服务器:"
 
-#: src/muuli_wdr.cpp:2984
+#: src/muuli_wdr.cpp:2991
 msgid "The proxy host name"
 msgstr "代理服务器名称"
 
-#: src/muuli_wdr.cpp:2986
+#: src/muuli_wdr.cpp:2993
 msgid "Proxy port:"
 msgstr "代理端口:"
 
-#: src/muuli_wdr.cpp:2989
+#: src/muuli_wdr.cpp:2996
 msgid "The proxy port"
 msgstr "代理端口"
 
-#: src/muuli_wdr.cpp:2991
+#: src/muuli_wdr.cpp:2998
 msgid "Enable authentication"
 msgstr "启用验证："
 
-#: src/muuli_wdr.cpp:2992
+#: src/muuli_wdr.cpp:2999
 msgid "Enable/disable username/password authentication"
 msgstr "启用/禁用用户名/密码验证"
 
-#: src/muuli_wdr.cpp:2995
+#: src/muuli_wdr.cpp:3002
 msgid "Username: "
 msgstr "用户名: "
 
-#: src/muuli_wdr.cpp:2998
+#: src/muuli_wdr.cpp:3005
 msgid "The username to use to connect to the proxy"
 msgstr "连接代理服务器的用户名"
 
-#: src/muuli_wdr.cpp:3000
+#: src/muuli_wdr.cpp:3007
 msgid "Password:"
 msgstr "密码:"
 
-#: src/muuli_wdr.cpp:3003
+#: src/muuli_wdr.cpp:3010
 msgid "The password to use to connect to the proxy"
 msgstr "连接代理服务器的密码"
 
-#: src/muuli_wdr.cpp:3022
+#: src/muuli_wdr.cpp:3029
 msgid "Connect to:"
 msgstr "连接到:"
 
-#: src/muuli_wdr.cpp:3031
+#: src/muuli_wdr.cpp:3038
 msgid "Login to remote amule"
 msgstr "登录远程 amule"
 
-#: src/muuli_wdr.cpp:3036
+#: src/muuli_wdr.cpp:3043
 msgid "User name"
 msgstr "用户名"
 
-#: src/muuli_wdr.cpp:3047
+#: src/muuli_wdr.cpp:3054
 msgid "Remember those settings"
 msgstr "记住这些设置"
 
-#: src/muuli_wdr.cpp:3050
+#: src/muuli_wdr.cpp:3057
 msgid "Force ZLIB compression"
 msgstr "强制使用 ZLIB 压缩"
 
-#: src/muuli_wdr.cpp:3074
+#: src/muuli_wdr.cpp:3081
 msgid "Enable Verbose Debug-Logging."
 msgstr "启用详细调试日志。"
 
-#: src/muuli_wdr.cpp:3076
+#: src/muuli_wdr.cpp:3083
 msgid "Only to Logfile"
 msgstr "只记录到日志文件"
 
-#: src/muuli_wdr.cpp:3078
+#: src/muuli_wdr.cpp:3085
 msgid "Message Categories:"
 msgstr "消息分类:"
 
-#: src/muuli_wdr.cpp:3102 src/PartFileConvertDlg.cpp:160
+#: src/muuli_wdr.cpp:3109 src/PartFileConvertDlg.cpp:160
 msgid "Waiting..."
 msgstr "等待中..."
 
-#: src/muuli_wdr.cpp:3122
+#: src/muuli_wdr.cpp:3129
 msgid "Add imports"
 msgstr "添加导入文件"
 
-#: src/muuli_wdr.cpp:3125
+#: src/muuli_wdr.cpp:3132
 msgid "Retry selected"
 msgstr "重试所选"
 
-#: src/muuli_wdr.cpp:3127
+#: src/muuli_wdr.cpp:3134
 msgid "Remove selected"
 msgstr "删除所选"
 
-#: src/muuli_wdr.cpp:3190
+#: src/muuli_wdr.cpp:3197
 msgid "Event Types"
 msgstr "事件类型"
 
-#: src/muuli_wdr.cpp:3209
+#: src/muuli_wdr.cpp:3216
 msgid "Statistics and queued clients for selected file(s) : Session / All time"
 msgstr "所选文件的统计和队列用户：会话/全部时间"
 
-#: src/muuli_wdr.cpp:3233
+#: src/muuli_wdr.cpp:3240
 msgid "Active Uploads"
 msgstr "活跃上传"
 
-#: src/muuli_wdr.cpp:3247
+#: src/muuli_wdr.cpp:3254
 msgid "Percent of total files"
 msgstr "全部文件的百分比"
 
-#: src/muuli_wdr.cpp:3299
+#: src/muuli_wdr.cpp:3306
 msgid "Show Clients for"
 msgstr "显示客户端"
 
-#: src/muuli_wdr.cpp:3301
+#: src/muuli_wdr.cpp:3308
 msgid "All files"
 msgstr "所有文件"
 
-#: src/muuli_wdr.cpp:3304
+#: src/muuli_wdr.cpp:3311
 msgid "Selected files"
 msgstr "选择的文件"
 
-#: src/muuli_wdr.cpp:3307
+#: src/muuli_wdr.cpp:3314
 msgid "Active uploads only"
 msgstr "仅活跃上传"
 
-#: src/muuli_wdr.cpp:3314
+#: src/muuli_wdr.cpp:3321
 msgid "Reload:"
 msgstr "重新载入:"
 
-#: src/muuli_wdr.cpp:3318
+#: src/muuli_wdr.cpp:3325
 msgid "Reload your shared files"
 msgstr "刷新共享文件"
 
-#: src/muuli_wdr.cpp:3381
+#: src/muuli_wdr.cpp:3388
 msgid "Send"
 msgstr "发送"
 
-#: src/muuli_wdr.cpp:3382
+#: src/muuli_wdr.cpp:3389
 msgid "Sends the specified message."
 msgstr "发送指定消息。"
 
-#: src/muuli_wdr.cpp:3386
+#: src/muuli_wdr.cpp:3393
 msgid "Close this chat-session."
 msgstr "结束本次聊天。"
 
-#: src/muuli_wdr.cpp:3409
+#: src/muuli_wdr.cpp:3416
 msgid "Connect to any server and/or Kad"
 msgstr "连接至任何服务器和/或 Kad"
 
-#: src/muuli_wdr.cpp:3415 src/SharedFilesCtrl.cpp:142 src/Statistics.cpp:941
+#: src/muuli_wdr.cpp:3422 src/SharedFilesCtrl.cpp:142 src/Statistics.cpp:941
 msgid "Shared Files"
 msgstr "共享文件"
 
@@ -5411,187 +5425,187 @@ msgstr "已下载"
 msgid "ERROR: Failed to open partfile '%s'"
 msgstr "错误：打开part文件'%s'失败"
 
-#: src/Preferences.cpp:673
+#: src/Preferences.cpp:674
 msgid "System default"
 msgstr "系统默认"
 
-#: src/Preferences.cpp:674
+#: src/Preferences.cpp:675
 msgid "Albanian"
 msgstr "阿尔巴尼亚语"
 
-#: src/Preferences.cpp:675
+#: src/Preferences.cpp:676
 msgid "Arabic"
 msgstr "阿拉伯语"
 
-#: src/Preferences.cpp:676
+#: src/Preferences.cpp:677
 msgid "Asturian"
 msgstr "澳大利亚"
 
-#: src/Preferences.cpp:677
+#: src/Preferences.cpp:678
 msgid "Basque"
 msgstr "巴斯克语"
 
-#: src/Preferences.cpp:678
+#: src/Preferences.cpp:679
 msgid "Bulgarian"
 msgstr "保加利亚语"
 
-#: src/Preferences.cpp:679
+#: src/Preferences.cpp:680
 msgid "Catalan"
 msgstr "加泰罗尼亚语"
 
-#: src/Preferences.cpp:680
+#: src/Preferences.cpp:681
 msgid "Chinese (Simplified)"
 msgstr "简体中文"
 
-#: src/Preferences.cpp:681
+#: src/Preferences.cpp:682
 msgid "Chinese (Traditional)"
 msgstr "繁体中文"
 
-#: src/Preferences.cpp:682
+#: src/Preferences.cpp:683
 msgid "Croatian"
 msgstr "克罗的亚语"
 
-#: src/Preferences.cpp:683
+#: src/Preferences.cpp:684
 msgid "Czech"
 msgstr "捷克语"
 
-#: src/Preferences.cpp:684
+#: src/Preferences.cpp:685
 msgid "Danish"
 msgstr "丹麦语"
 
-#: src/Preferences.cpp:685
+#: src/Preferences.cpp:686
 msgid "Dutch"
 msgstr "荷兰语"
 
-#: src/Preferences.cpp:686
+#: src/Preferences.cpp:687
 msgid "English (U.K.)"
 msgstr "英语（英国）"
 
-#: src/Preferences.cpp:687
+#: src/Preferences.cpp:688
 msgid "English (U.S.)"
 msgstr "英语（美国）"
 
-#: src/Preferences.cpp:688
+#: src/Preferences.cpp:689
 msgid "Estonian"
 msgstr "爱斯托尼亚语"
 
-#: src/Preferences.cpp:689
+#: src/Preferences.cpp:690
 msgid "Finnish"
 msgstr "芬兰语"
 
-#: src/Preferences.cpp:690
+#: src/Preferences.cpp:691
 msgid "French"
 msgstr "法语"
 
-#: src/Preferences.cpp:691
+#: src/Preferences.cpp:692
 msgid "Galician"
 msgstr "加利西亚语"
 
-#: src/Preferences.cpp:692
+#: src/Preferences.cpp:693
 msgid "German"
 msgstr "德语"
 
-#: src/Preferences.cpp:693
+#: src/Preferences.cpp:694
 msgid "Greek"
 msgstr "希腊语"
 
-#: src/Preferences.cpp:694
+#: src/Preferences.cpp:695
 msgid "Hebrew"
 msgstr "希伯来语"
 
-#: src/Preferences.cpp:695
+#: src/Preferences.cpp:696
 msgid "Hungarian"
 msgstr "匈牙利语"
 
-#: src/Preferences.cpp:696
+#: src/Preferences.cpp:697
 msgid "Italian"
 msgstr "意大利语"
 
-#: src/Preferences.cpp:697
+#: src/Preferences.cpp:698
 msgid "Japanese"
 msgstr "日语"
 
-#: src/Preferences.cpp:698
+#: src/Preferences.cpp:699
 msgid "Korean"
 msgstr "韩语"
 
-#: src/Preferences.cpp:699
+#: src/Preferences.cpp:700
 msgid "Latvian"
 msgstr "拉脱维亚语"
 
-#: src/Preferences.cpp:700
+#: src/Preferences.cpp:701
 msgid "Lithuanian"
 msgstr "立陶宛语"
 
-#: src/Preferences.cpp:701
+#: src/Preferences.cpp:702
 msgid "Norwegian (Nynorsk)"
 msgstr "新挪威语"
 
-#: src/Preferences.cpp:702
+#: src/Preferences.cpp:703
 msgid "Polish"
 msgstr "芬兰语"
 
-#: src/Preferences.cpp:703
+#: src/Preferences.cpp:704
 msgid "Portuguese"
 msgstr "葡萄牙语"
 
-#: src/Preferences.cpp:704
+#: src/Preferences.cpp:705
 msgid "Portuguese (Brazilian)"
 msgstr "葡萄牙语（巴西）"
 
-#: src/Preferences.cpp:705
+#: src/Preferences.cpp:706
 msgid "Romanian"
 msgstr "罗马尼亚语"
 
-#: src/Preferences.cpp:706
+#: src/Preferences.cpp:707
 msgid "Russian"
 msgstr "俄语"
 
-#: src/Preferences.cpp:707
+#: src/Preferences.cpp:708
 msgid "Slovenian"
 msgstr "斯洛文尼亚语"
 
-#: src/Preferences.cpp:708
+#: src/Preferences.cpp:709
 msgid "Spanish"
 msgstr "西班牙语"
 
-#: src/Preferences.cpp:709
+#: src/Preferences.cpp:710
 msgid "Swedish"
 msgstr "瑞典语"
 
-#: src/Preferences.cpp:710
+#: src/Preferences.cpp:711
 msgid "Turkish"
 msgstr "土耳其语"
 
-#: src/Preferences.cpp:711
+#: src/Preferences.cpp:712
 msgid "Ukrainian"
 msgstr "乌克兰"
 
-#: src/Preferences.cpp:814
+#: src/Preferences.cpp:815
 msgid "Change Language"
 msgstr "更改语言"
 
-#: src/Preferences.cpp:878
+#: src/Preferences.cpp:879
 msgid "There are no translations installed for aMule"
 msgstr "没有为 aMule 安装语言文件"
 
-#: src/Preferences.cpp:879
+#: src/Preferences.cpp:880
 msgid "No languages available"
 msgstr "语言文件不可用"
 
-#: src/Preferences.cpp:1010
+#: src/Preferences.cpp:1011
 msgid "no options available"
 msgstr "选项不可用"
 
-#: src/Preferences.cpp:2179
+#: src/Preferences.cpp:2182
 msgid "Invalid category found, skipping"
 msgstr "发现无效的分类，跳过"
 
-#: src/Preferences.cpp:2348
+#: src/Preferences.cpp:2351
 msgid "TCP port can't be higher than 65532 due to server UDP socket being TCP+3"
 msgstr "TCP端口不可高于65532，因为服务器UDP端口值为TCP端口值+3"
 
-#: src/Preferences.cpp:2349
+#: src/Preferences.cpp:2352
 #, c-format
 msgid "Default port will be used (%d)"
 msgstr "缺省端口将被使用（%d）"
@@ -6092,23 +6106,27 @@ msgstr "正重新加载共享文件：扫描了 %u 个文件"
 msgid "Shared folder"
 msgstr "共享的文件夹"
 
-#: src/SearchDlg.cpp:425
+#: src/SearchDlg.cpp:280
+msgid "Clear search history"
+msgstr ""
+
+#: src/SearchDlg.cpp:584
 msgid "It's impossible to search when both eD2k and Kademlia are disabled."
 msgstr "同时禁用 eD2k 和 Kademlia 时将无法搜索。"
 
-#: src/SearchDlg.cpp:426 src/SearchListCtrl.cpp:858
+#: src/SearchDlg.cpp:585 src/SearchListCtrl.cpp:858
 msgid "Search error"
 msgstr "搜索错误"
 
-#: src/SearchDlg.cpp:768
+#: src/SearchDlg.cpp:929
 msgid "Min size must be smaller than max size. Max size ignored."
 msgstr "最小值必须小于最大值，最大值已被忽略。"
 
-#: src/SearchDlg.cpp:769 src/SearchDlg.cpp:851
+#: src/SearchDlg.cpp:930 src/SearchDlg.cpp:1012
 msgid "Search warning"
 msgstr "搜索警告"
 
-#: src/SearchDlg.cpp:929 src/SearchListCtrl.cpp:735
+#: src/SearchDlg.cpp:1092 src/SearchListCtrl.cpp:735
 msgid "Main"
 msgstr "主要"
 

--- a/po/zh_TW.po
+++ b/po/zh_TW.po
@@ -14,7 +14,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-28 12:17+0200\n"
+"POT-Creation-Date: 2026-07-28 13:09+0200\n"
 "PO-Revision-Date: 2026-07-27 11:48+0000\n"
 "Last-Translator: Wayne Su <mstarmstar@gmail.com>\n"
 "Language-Team: \n"
@@ -297,7 +297,7 @@ msgid "Password set and external connections enabled."
 msgstr "密碼已設定，外部連線已啟用。"
 
 #: src/amule.cpp:755 src/KadDlg.cpp:176 src/KadDlg.cpp:185
-#: src/PrefsUnifiedDlg.cpp:1461 src/SharedFilesCtrl.cpp:476
+#: src/PrefsUnifiedDlg.cpp:1470 src/SharedFilesCtrl.cpp:476
 msgid "WARNING"
 msgstr "警告"
 
@@ -335,7 +335,7 @@ msgstr "您要求啟動時執行網站伺服器，但系統無法執行 amuleweb
 #: src/amule-remote-gui.cpp:603 src/amule-remote-gui.cpp:671
 #: src/amule-remote-gui.cpp:709 src/amule-remote-gui.cpp:1282
 #: src/amule-remote-gui.cpp:1345 src/amule-remote-gui.cpp:1372
-#: src/DownloadQueue.cpp:1481 src/PrefsUnifiedDlg.cpp:1247
+#: src/DownloadQueue.cpp:1481 src/PrefsUnifiedDlg.cpp:1256
 msgid "ERROR"
 msgstr "錯誤"
 
@@ -597,36 +597,36 @@ msgstr "請到 https://github.com/amule-org/amule/releases/latest 下載最新�
 msgid "FATAL ERROR: Failed to create Timer"
 msgstr "嚴重錯誤：無法建立計時器"
 
-#: src/amuleDlg.cpp:361 src/amuleDlg.cpp:1787 src/amuleDlg.cpp:2033
-#: src/muuli_wdr.cpp:1492 src/muuli_wdr.cpp:3449
+#: src/amuleDlg.cpp:361 src/amuleDlg.cpp:1810 src/amuleDlg.cpp:2056
+#: src/muuli_wdr.cpp:1492 src/muuli_wdr.cpp:3453
 msgid "Networks"
 msgstr "網路"
 
-#: src/amuleDlg.cpp:362 src/amuleDlg.cpp:1793 src/muuli_wdr.cpp:3450
+#: src/amuleDlg.cpp:362 src/amuleDlg.cpp:1816 src/muuli_wdr.cpp:3454
 msgid "Searches"
 msgstr "搜尋"
 
-#: src/amuleDlg.cpp:363 src/amuleDlg.cpp:1799 src/DownloadListCtrl.cpp:740
-#: src/muuli_wdr.cpp:392 src/muuli_wdr.cpp:1585 src/muuli_wdr.cpp:3451
+#: src/amuleDlg.cpp:363 src/amuleDlg.cpp:1822 src/DownloadListCtrl.cpp:740
+#: src/muuli_wdr.cpp:392 src/muuli_wdr.cpp:1585 src/muuli_wdr.cpp:3455
 #: src/Statistics.cpp:829
 msgid "Downloads"
 msgstr "下載"
 
-#: src/amuleDlg.cpp:364 src/amuleDlg.cpp:1805 src/muuli_wdr.cpp:3325
+#: src/amuleDlg.cpp:364 src/amuleDlg.cpp:1828 src/muuli_wdr.cpp:3329
 msgid "Shared files"
 msgstr "檔案分享"
 
-#: src/amuleDlg.cpp:365 src/amuleDlg.cpp:1811 src/muuli_wdr.cpp:2957
-#: src/muuli_wdr.cpp:3407 src/muuli_wdr.cpp:3454
+#: src/amuleDlg.cpp:365 src/amuleDlg.cpp:1834 src/muuli_wdr.cpp:2961
+#: src/muuli_wdr.cpp:3411 src/muuli_wdr.cpp:3458
 msgid "Messages"
 msgstr "訊息"
 
-#: src/amuleDlg.cpp:366 src/amuleDlg.cpp:1817 src/muuli_wdr.cpp:3455
+#: src/amuleDlg.cpp:366 src/amuleDlg.cpp:1840 src/muuli_wdr.cpp:3459
 #: src/PrefsUnifiedDlg.cpp:314 src/Statistics.cpp:779 src/Statistics.cpp:1235
 msgid "Statistics"
 msgstr "統計"
 
-#: src/amuleDlg.cpp:368 src/amuleDlg.cpp:1824 src/muuli_wdr.cpp:3457
+#: src/amuleDlg.cpp:368 src/amuleDlg.cpp:1847 src/muuli_wdr.cpp:3461
 #: src/PrefsUnifiedDlg.cpp:330 src/utils/wxCas/src/wxcasprefs.cpp:39
 msgid "Preferences"
 msgstr "偏好設定"
@@ -685,8 +685,8 @@ msgstr "Kad：關閉"
 #: src/amuleDlg.cpp:1029 src/DownloadListCtrl.cpp:505
 #: src/DownloadListCtrl.cpp:749 src/FriendListCtrl.cpp:180
 #: src/muuli_wdr.cpp:731 src/muuli_wdr.cpp:782 src/muuli_wdr.cpp:846
-#: src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2262 src/muuli_wdr.cpp:2347
-#: src/muuli_wdr.cpp:3095 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
+#: src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2266 src/muuli_wdr.cpp:2351
+#: src/muuli_wdr.cpp:3099 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
 #: src/ServerListCtrl.cpp:606 src/TransferWnd.cpp:378
 #: src/utils/wxCas/src/wxcasprefs.cpp:235
 msgid "Cancel"
@@ -697,7 +697,7 @@ msgid "Stop the current connection attempts"
 msgstr "停止連線作業"
 
 #: src/amuleDlg.cpp:1035 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976
-#: src/muuli_wdr.cpp:2485
+#: src/muuli_wdr.cpp:2489
 msgid "Disconnect"
 msgstr "中斷連線"
 
@@ -706,7 +706,7 @@ msgid "Disconnect from the currently connected networks"
 msgstr "中斷已連線的網路"
 
 #: src/amuleDlg.cpp:1041 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979
-#: src/muuli_wdr.cpp:2640 src/muuli_wdr.cpp:3092 src/muuli_wdr.cpp:3447
+#: src/muuli_wdr.cpp:2644 src/muuli_wdr.cpp:3096 src/muuli_wdr.cpp:3451
 msgid "Connect"
 msgstr "連線"
 
@@ -761,7 +761,7 @@ msgstr "確認離開"
 msgid "Launch Command: "
 msgstr "執行指令："
 
-#: src/amuleDlg.cpp:1632 src/muuli_wdr.cpp:1982 src/Preferences.cpp:979
+#: src/amuleDlg.cpp:1632 src/muuli_wdr.cpp:1986 src/Preferences.cpp:979
 msgid "- default -"
 msgstr "- 預設 -"
 
@@ -775,60 +775,60 @@ msgstr "面板目錄 %s 不存在"
 msgid "WARNING: Unable to open skin file '%s' for read"
 msgstr "警告：無法開啟面板檔案 %s 供讀取"
 
-#: src/amuleDlg.cpp:1791 src/muuli_wdr.cpp:3449
+#: src/amuleDlg.cpp:1814 src/muuli_wdr.cpp:3453
 msgid "Networks Window"
 msgstr "網路 視窗"
 
-#: src/amuleDlg.cpp:1797 src/muuli_wdr.cpp:3450
+#: src/amuleDlg.cpp:1820 src/muuli_wdr.cpp:3454
 msgid "Searches Window"
 msgstr "搜尋 視窗"
 
-#: src/amuleDlg.cpp:1803 src/muuli_wdr.cpp:3451
+#: src/amuleDlg.cpp:1826 src/muuli_wdr.cpp:3455
 msgid "Downloads Window"
 msgstr "下載 視窗"
 
-#: src/amuleDlg.cpp:1809 src/muuli_wdr.cpp:3453
+#: src/amuleDlg.cpp:1832 src/muuli_wdr.cpp:3457
 msgid "Shared Files Window"
 msgstr "檔案分享 視窗"
 
-#: src/amuleDlg.cpp:1815 src/muuli_wdr.cpp:3454
+#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3458
 msgid "Messages Window"
 msgstr "訊息 視窗"
 
-#: src/amuleDlg.cpp:1821 src/muuli_wdr.cpp:3455
+#: src/amuleDlg.cpp:1844 src/muuli_wdr.cpp:3459
 msgid "Statistics Graph Window"
 msgstr "統計 視窗"
 
-#: src/amuleDlg.cpp:1828 src/muuli_wdr.cpp:3457
+#: src/amuleDlg.cpp:1851 src/muuli_wdr.cpp:3461
 msgid "Preferences Settings Window"
 msgstr "偏好設定 視窗"
 
-#: src/amuleDlg.cpp:1831 src/muuli_wdr.cpp:3458
+#: src/amuleDlg.cpp:1854 src/muuli_wdr.cpp:3462
 msgid "Import"
 msgstr "匯入"
 
-#: src/amuleDlg.cpp:1835 src/muuli_wdr.cpp:3458
+#: src/amuleDlg.cpp:1858 src/muuli_wdr.cpp:3462
 msgid "The partfile importer tool"
 msgstr "暫存檔匯入工具"
 
-#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3459
+#: src/amuleDlg.cpp:1861 src/muuli_wdr.cpp:3463
 #: src/utils/aLinkCreator/src/alcframe.cpp:262
 msgid "About"
 msgstr "關於"
 
-#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3459
+#: src/amuleDlg.cpp:1861 src/muuli_wdr.cpp:3463
 msgid "About/Help"
 msgstr "關於/幫助"
 
-#: src/amuleDlg.cpp:2036
+#: src/amuleDlg.cpp:2059
 msgid "eD2k network"
 msgstr "eD2k 網路"
 
-#: src/amuleDlg.cpp:2039
+#: src/amuleDlg.cpp:2062
 msgid "Kad network"
 msgstr "kad 網路"
 
-#: src/amuleDlg.cpp:2039
+#: src/amuleDlg.cpp:2062
 msgid "No network"
 msgstr "無網路"
 
@@ -1356,19 +1356,19 @@ msgstr "自動 [高]"
 msgid "Very low"
 msgstr "極低"
 
-#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:743 src/muuli_wdr.cpp:2313
+#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:743 src/muuli_wdr.cpp:2317
 #: src/ServerListCtrl.cpp:263 src/ServerListCtrl.cpp:456
 #: src/SharedFilesCtrl.cpp:145
 msgid "Low"
 msgstr "低"
 
-#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:744 src/muuli_wdr.cpp:2314
+#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:744 src/muuli_wdr.cpp:2318
 #: src/ServerListCtrl.cpp:266 src/ServerListCtrl.cpp:457
 #: src/SharedFilesCtrl.cpp:146
 msgid "Normal"
 msgstr "普通"
 
-#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:745 src/muuli_wdr.cpp:2315
+#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:745 src/muuli_wdr.cpp:2319
 #: src/ServerListCtrl.cpp:269 src/ServerListCtrl.cpp:458
 #: src/SharedFilesCtrl.cpp:147
 msgid "High"
@@ -1460,7 +1460,7 @@ msgstr "本地伺服器"
 msgid "Remote Server"
 msgstr "遠端伺服器"
 
-#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3212
+#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3216
 #: src/SearchDlg.cpp:119 src/TextClient.cpp:911
 msgid "Kad"
 msgstr "Kad"
@@ -1532,7 +1532,7 @@ msgstr "部份"
 msgid "Size"
 msgstr "大小"
 
-#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3279
+#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3283
 msgid "Transferred"
 msgstr "已傳輸"
 
@@ -1590,7 +1590,7 @@ msgstr ""
 "%s (%s) 回覆訊息\n"
 "\n"
 
-#: src/DownloadListCtrl.cpp:746 src/muuli_wdr.cpp:2316
+#: src/DownloadListCtrl.cpp:746 src/muuli_wdr.cpp:2320
 #: src/SharedFilesCtrl.cpp:150
 msgid "Auto"
 msgstr "自動"
@@ -1628,7 +1628,7 @@ msgid "Extended Options"
 msgstr "擴充選項"
 
 #: src/DownloadListCtrl.cpp:770 src/DownloadListCtrl.cpp:822
-#: src/muuli_wdr.cpp:1800
+#: src/muuli_wdr.cpp:1804
 msgid "Preview"
 msgstr "預覽"
 
@@ -2427,23 +2427,23 @@ msgid ""
 "want downloads on a different (e.g. larger) disk."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:549 src/FirstRunWizard.cpp:611 src/muuli_wdr.cpp:1712
+#: src/FirstRunWizard.cpp:549 src/FirstRunWizard.cpp:611 src/muuli_wdr.cpp:1716
 msgid "Destination folder for downloads"
 msgstr "下載資料夾"
 
 #: src/FirstRunWizard.cpp:553 src/FirstRunWizard.cpp:569 src/muuli_wdr.cpp:1349
-#: src/muuli_wdr.cpp:1366 src/muuli_wdr.cpp:1687 src/muuli_wdr.cpp:1718
-#: src/muuli_wdr.cpp:1730 src/muuli_wdr.cpp:2800
+#: src/muuli_wdr.cpp:1366 src/muuli_wdr.cpp:1691 src/muuli_wdr.cpp:1722
+#: src/muuli_wdr.cpp:1734 src/muuli_wdr.cpp:2804
 #: src/utils/aLinkCreator/src/alcframe.cpp:135
 #: src/utils/wxCas/src/wxcasprefs.cpp:52 src/utils/wxCas/src/wxcasprefs.cpp:118
 msgid "Browse"
 msgstr "瀏覽"
 
-#: src/FirstRunWizard.cpp:559 src/muuli_wdr.cpp:1723
+#: src/FirstRunWizard.cpp:559 src/muuli_wdr.cpp:1727
 msgid "(All files in this folder are shared with other peers)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:565 src/FirstRunWizard.cpp:624 src/muuli_wdr.cpp:1725
+#: src/FirstRunWizard.cpp:565 src/FirstRunWizard.cpp:624 src/muuli_wdr.cpp:1729
 msgid "Folder for temporary download files"
 msgstr "暫存資料夾"
 
@@ -2474,7 +2474,7 @@ msgstr "無法開啟好友清單檔案 emfriends.met 供寫入！"
 msgid "CRITICAL - no client on StartChatSession"
 msgstr "重大錯誤 - 開始交談時沒有客戶端"
 
-#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2706 src/muuli_wdr.cpp:3383
+#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2710 src/muuli_wdr.cpp:3387
 msgid "Friends"
 msgstr "好友"
 
@@ -2585,8 +2585,8 @@ msgstr "無"
 msgid "No"
 msgstr "否"
 
-#: src/GenericClientListCtrl.cpp:1216 src/PrefsUnifiedDlg.cpp:2898
-#: src/PrefsUnifiedDlg.cpp:2948 src/ServerListCtrl.cpp:276
+#: src/GenericClientListCtrl.cpp:1216 src/PrefsUnifiedDlg.cpp:2907
+#: src/PrefsUnifiedDlg.cpp:2957 src/ServerListCtrl.cpp:276
 msgid "Yes"
 msgstr "是"
 
@@ -2751,10 +2751,10 @@ msgstr "無效的通訊埠"
 msgid "Please fill all fields required"
 msgstr "請填寫所有必要資訊"
 
-#: src/KadDlg.cpp:192 src/PartFile.cpp:1031 src/PrefsUnifiedDlg.cpp:1134
-#: src/PrefsUnifiedDlg.cpp:1204 src/PrefsUnifiedDlg.cpp:1405
-#: src/PrefsUnifiedDlg.cpp:1663 src/PrefsUnifiedDlg.cpp:1673
-#: src/PrefsUnifiedDlg.cpp:1690 src/PrefsUnifiedDlg.cpp:1738
+#: src/KadDlg.cpp:192 src/PartFile.cpp:1031 src/PrefsUnifiedDlg.cpp:1143
+#: src/PrefsUnifiedDlg.cpp:1213 src/PrefsUnifiedDlg.cpp:1414
+#: src/PrefsUnifiedDlg.cpp:1672 src/PrefsUnifiedDlg.cpp:1682
+#: src/PrefsUnifiedDlg.cpp:1699 src/PrefsUnifiedDlg.cpp:1747
 msgid "Message"
 msgstr "訊息"
 
@@ -2853,7 +2853,7 @@ msgstr "分享率"
 msgid "Uploaded"
 msgstr "已上傳"
 
-#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3263
+#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3267
 msgid "Requested"
 msgstr "已要求"
 
@@ -2977,7 +2977,7 @@ msgid "WARNING: "
 msgstr "警告："
 
 #: src/MuleNotebook.cpp:179 src/muuli_wdr.cpp:817 src/muuli_wdr.cpp:1229
-#: src/muuli_wdr.cpp:3167 src/muuli_wdr.cpp:3423
+#: src/muuli_wdr.cpp:3171 src/muuli_wdr.cpp:3427
 msgid "Close"
 msgstr "關閉"
 
@@ -2995,7 +2995,7 @@ msgid "Paste"
 msgstr "貼上"
 
 #: src/MuleTextCtrl.cpp:89 src/muuli_wdr.cpp:358 src/muuli_wdr.cpp:757
-#: src/muuli_wdr.cpp:2390 src/muuli_wdr.cpp:2409 src/muuli_wdr.cpp:2431
+#: src/muuli_wdr.cpp:2394 src/muuli_wdr.cpp:2413 src/muuli_wdr.cpp:2435
 #: src/utils/aLinkCreator/src/alcframe.cpp:142
 msgid "Clear"
 msgstr "清除"
@@ -3094,7 +3094,7 @@ msgstr "離開"
 
 #: src/MuleTrayIcon.cpp:579 src/MuleTrayIcon.cpp:945 src/MuleTrayIcon.cpp:965
 #: src/muuli_wdr.cpp:1398 src/muuli_wdr.cpp:1406 src/muuli_wdr.cpp:1413
-#: src/muuli_wdr.cpp:1846 src/muuli_wdr.cpp:1852 src/OtherFunctions.cpp:91
+#: src/muuli_wdr.cpp:1850 src/muuli_wdr.cpp:1856 src/OtherFunctions.cpp:91
 #: src/StatisticsDlg.cpp:93 src/StatisticsDlg.cpp:95
 msgid "kB/s"
 msgstr "KB/s"
@@ -3336,7 +3336,7 @@ msgstr "B"
 msgid "KB"
 msgstr "KB"
 
-#: src/muuli_wdr.cpp:274 src/muuli_wdr.cpp:293 src/muuli_wdr.cpp:1631
+#: src/muuli_wdr.cpp:274 src/muuli_wdr.cpp:293 src/muuli_wdr.cpp:1635
 #: src/OtherFunctions.cpp:64
 msgid "MB"
 msgstr "MB"
@@ -3353,7 +3353,7 @@ msgstr "大小上限"
 msgid "Availability"
 msgstr "最小來源數"
 
-#: src/muuli_wdr.cpp:312 src/muuli_wdr.cpp:398 src/muuli_wdr.cpp:3328
+#: src/muuli_wdr.cpp:312 src/muuli_wdr.cpp:398 src/muuli_wdr.cpp:3332
 msgid "Filter:"
 msgstr "過濾："
 
@@ -3416,8 +3416,8 @@ msgstr "檔案來源："
 #: src/muuli_wdr.cpp:1160 src/muuli_wdr.cpp:1167 src/muuli_wdr.cpp:1172
 #: src/muuli_wdr.cpp:1179 src/muuli_wdr.cpp:1184 src/muuli_wdr.cpp:1191
 #: src/muuli_wdr.cpp:1205 src/muuli_wdr.cpp:1212 src/muuli_wdr.cpp:1217
-#: src/muuli_wdr.cpp:1224 src/muuli_wdr.cpp:3265 src/muuli_wdr.cpp:3273
-#: src/muuli_wdr.cpp:3281
+#: src/muuli_wdr.cpp:1224 src/muuli_wdr.cpp:3269 src/muuli_wdr.cpp:3277
+#: src/muuli_wdr.cpp:3285
 msgid "N/A"
 msgstr "N/A"
 
@@ -3562,7 +3562,7 @@ msgstr ""
 msgid "Album :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:685 src/muuli_wdr.cpp:2285
+#: src/muuli_wdr.cpp:685 src/muuli_wdr.cpp:2289
 msgid "Title :"
 msgstr "標題："
 
@@ -3671,7 +3671,7 @@ msgstr "使用者名稱︰"
 msgid "Userhash :"
 msgstr "使用者 hash 值："
 
-#: src/muuli_wdr.cpp:895 src/muuli_wdr.cpp:1752 src/muuli_wdr.cpp:2480
+#: src/muuli_wdr.cpp:895 src/muuli_wdr.cpp:1756 src/muuli_wdr.cpp:2484
 #: src/utils/aLinkCreator/src/alcframe.cpp:137
 msgid "Add"
 msgstr "加入"
@@ -3680,15 +3680,15 @@ msgstr "加入"
 msgid "Download-Speed"
 msgstr "下載速度"
 
-#: src/muuli_wdr.cpp:954 src/muuli_wdr.cpp:989 src/muuli_wdr.cpp:2584
+#: src/muuli_wdr.cpp:954 src/muuli_wdr.cpp:989 src/muuli_wdr.cpp:2588
 msgid "Current"
 msgstr "目前"
 
-#: src/muuli_wdr.cpp:962 src/muuli_wdr.cpp:997 src/muuli_wdr.cpp:2592
+#: src/muuli_wdr.cpp:962 src/muuli_wdr.cpp:997 src/muuli_wdr.cpp:2596
 msgid "Running average"
 msgstr "執行中平均值"
 
-#: src/muuli_wdr.cpp:970 src/muuli_wdr.cpp:1005 src/muuli_wdr.cpp:2600
+#: src/muuli_wdr.cpp:970 src/muuli_wdr.cpp:1005 src/muuli_wdr.cpp:2604
 msgid "Session average"
 msgstr "本次平均值"
 
@@ -3700,7 +3700,7 @@ msgstr "上傳速度"
 msgid "Connections"
 msgstr "連線"
 
-#: src/muuli_wdr.cpp:1024 src/muuli_wdr.cpp:1871
+#: src/muuli_wdr.cpp:1024 src/muuli_wdr.cpp:1875
 msgid "Active downloads"
 msgstr "目前下載數"
 
@@ -3708,7 +3708,7 @@ msgstr "目前下載數"
 msgid "Active connections (1:1)"
 msgstr "目前連線數 (1:1)"
 
-#: src/muuli_wdr.cpp:1040 src/muuli_wdr.cpp:1872
+#: src/muuli_wdr.cpp:1040 src/muuli_wdr.cpp:1876
 msgid "Active uploads"
 msgstr "目前上傳數"
 
@@ -3984,7 +3984,7 @@ msgstr "選定本機使用 IP (留白或輸入)："
 msgid "Advanced users only: If you have multiple network interfaces, enter the address of the interface to which aMule should be bound."
 msgstr "進階使用者用：如果您有多網路介面，請輸入要給 aMule 使用的的網路位址。"
 
-#: src/muuli_wdr.cpp:1462 src/muuli_wdr.cpp:2065
+#: src/muuli_wdr.cpp:1462 src/muuli_wdr.cpp:2069
 #, fuzzy
 msgid "Bind to network interface (empty for any):"
 msgstr "選定本機使用 IP (留白或輸入)："
@@ -4001,7 +4001,7 @@ msgstr "每個檔案最大來源數："
 msgid "Max simultaneous connections:"
 msgstr "最大同時連線數："
 
-#: src/muuli_wdr.cpp:1498 src/muuli_wdr.cpp:3207
+#: src/muuli_wdr.cpp:1498 src/muuli_wdr.cpp:3211
 msgid "ED2K"
 msgstr "ED2K"
 
@@ -4093,778 +4093,778 @@ msgstr "新檔案預先分配磁碟空間"
 msgid "For new files preallocates disk space for the whole file, thus reduces fragmentation"
 msgstr "新檔案預先分配所需的完整磁碟空間，這樣可以減少檔案分散度"
 
-#: src/muuli_wdr.cpp:1617
+#: src/muuli_wdr.cpp:1621
 msgid "Create new files as sparse files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1618
+#: src/muuli_wdr.cpp:1622
 msgid "Sparse part files only occupy disk space for the parts already downloaded, so free space is used up gradually as the file fills in. Turn this off to use an ordinary file instead - useful where sparse files are unsupported or slow, or where backup/de-duplication tools handle them badly. Applies only when the core runs on Windows; on Linux and macOS part files are sparse anyway and this setting has no effect."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1623
+#: src/muuli_wdr.cpp:1627
 msgid "Stop downloads when free disk space reaches "
 msgstr "磁碟可用空間不足時停止下載"
 
-#: src/muuli_wdr.cpp:1624
+#: src/muuli_wdr.cpp:1628
 msgid "Select this if you want aMule to check your disk space"
 msgstr "讓 aMule 檢查磁碟可用空間"
 
-#: src/muuli_wdr.cpp:1628
+#: src/muuli_wdr.cpp:1632
 msgid "Enter here the min disk space desired."
 msgstr "請輸入最小磁碟可用空間。"
 
-#: src/muuli_wdr.cpp:1634
+#: src/muuli_wdr.cpp:1638
 msgid "Save 10 sources on rare files (< 20 sources)"
 msgstr "為來源稀少 (< 20) 的檔案儲存 10 個來源"
 
-#: src/muuli_wdr.cpp:1638 src/Statistics.cpp:790
+#: src/muuli_wdr.cpp:1642 src/Statistics.cpp:790
 msgid "Uploads"
 msgstr "上傳"
 
-#: src/muuli_wdr.cpp:1641
+#: src/muuli_wdr.cpp:1645
 msgid "Add new shared files with auto priority"
 msgstr "新加入分享檔案優先等級設定為自動"
 
-#: src/muuli_wdr.cpp:1647
+#: src/muuli_wdr.cpp:1651
 msgid "Intelligent Corruption Handling (I.C.H.)"
 msgstr "智慧型損壞處理 (I.C.H.)"
 
-#: src/muuli_wdr.cpp:1650
+#: src/muuli_wdr.cpp:1654
 msgid "Enable"
 msgstr "啟用"
 
-#: src/muuli_wdr.cpp:1653
+#: src/muuli_wdr.cpp:1657
 msgid "Advanced I.C.H. trusts every hash (not recommended)"
 msgstr "進階 I.C.H. 信任所有 hash 值 (不建議)"
 
-#: src/muuli_wdr.cpp:1665 src/PrefsUnifiedDlg.cpp:1990
+#: src/muuli_wdr.cpp:1669 src/PrefsUnifiedDlg.cpp:1999
 msgid "Media metadata extraction"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1669
+#: src/muuli_wdr.cpp:1673
 msgid "Extract length / bitrate / codec from shared audio and video files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1671
+#: src/muuli_wdr.cpp:1675
 msgid "When enabled, aMule runs ffprobe on each shared media file to fill in the Length / Bitrate / Codec columns other clients see when they find the file in a search. Requires ffmpeg (the ffprobe binary) to be installed."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1678
+#: src/muuli_wdr.cpp:1682
 msgid "Path to ffprobe:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1683
+#: src/muuli_wdr.cpp:1687
 msgid "Full path to the ffprobe binary. Leave empty to have aMule auto-detect it on startup."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1691
+#: src/muuli_wdr.cpp:1695
 msgid "Detect"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1692
+#: src/muuli_wdr.cpp:1696
 msgid "Search the standard install locations for an ffprobe binary and fill the path field."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1716
+#: src/muuli_wdr.cpp:1720
 msgid ""
 "Completed downloads are stored here. All files in this folder are automatically shared with other peers.\n"
 "If this folder also holds files you don't want to share, point it at an aMule-only sub-folder."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1719
+#: src/muuli_wdr.cpp:1723
 msgid "Pick the folder where completed downloads will be stored. All files in that folder will be shared with other peers."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1733
+#: src/muuli_wdr.cpp:1737
 msgid "Shared folders"
 msgstr "分享資料夾"
 
-#: src/muuli_wdr.cpp:1739
+#: src/muuli_wdr.cpp:1743
 msgid "(Folders shared by the core. Enter a path to add one.)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1747
+#: src/muuli_wdr.cpp:1751
 msgid "Absolute path of a folder on the core's machine, e.g. /home/user/shared"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1749 src/PrefsUnifiedDlg.cpp:2874
+#: src/muuli_wdr.cpp:1753 src/PrefsUnifiedDlg.cpp:2883
 msgid "Recursive"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1750
+#: src/muuli_wdr.cpp:1754
 msgid "Share every sub-folder underneath this one, including ones created later."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1754 src/utils/aLinkCreator/src/alcframe.cpp:141
+#: src/muuli_wdr.cpp:1758 src/utils/aLinkCreator/src/alcframe.cpp:141
 msgid "Remove"
 msgstr "移除"
 
-#: src/muuli_wdr.cpp:1758
+#: src/muuli_wdr.cpp:1762
 msgid "(Right click on folder icon for recursive share)"
 msgstr "(滑鼠右鍵點選檔案夾圖示可全部遞迴分享)"
 
-#: src/muuli_wdr.cpp:1765
+#: src/muuli_wdr.cpp:1769
 msgid "Share hidden files"
 msgstr "分享隱藏檔"
 
-#: src/muuli_wdr.cpp:1771
+#: src/muuli_wdr.cpp:1775
 msgid "Automatically rescan shared folders for changes"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1777
+#: src/muuli_wdr.cpp:1781
 msgid "Follow symbolic links in shared folders"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1783
+#: src/muuli_wdr.cpp:1787
 msgid "Exclude files matching:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1786
+#: src/muuli_wdr.cpp:1790
 msgid "Wildcard patterns separated by '|', e.g. .DS_Store|Thumbs.db|*.tmp. Files whose name matches are not shared. Matching is case-insensitive."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1790
+#: src/muuli_wdr.cpp:1794
 msgid "Patterns are regular expressions"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1791
+#: src/muuli_wdr.cpp:1795
 msgid "When set, the whole field is one regular expression ('|' is alternation). When unset, it is a list of '|'-separated wildcards."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1801
+#: src/muuli_wdr.cpp:1805
 msgid "Show how many shared files the current pattern would exclude."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1822
+#: src/muuli_wdr.cpp:1826
 msgid "Graphs"
 msgstr "圖表"
 
-#: src/muuli_wdr.cpp:1825 src/muuli_wdr.cpp:1887
+#: src/muuli_wdr.cpp:1829 src/muuli_wdr.cpp:1891
 msgid "Update delay : 5 secs"
 msgstr "更新延遲時間：5 秒"
 
-#: src/muuli_wdr.cpp:1829
+#: src/muuli_wdr.cpp:1833
 msgid "Time for average graph: 100 mins"
 msgstr "平均圖表顯示時間：100 分鐘"
 
-#: src/muuli_wdr.cpp:1833
+#: src/muuli_wdr.cpp:1837
 msgid "Connections Graph Scale: 100 "
 msgstr "連線圖表比例：100 "
 
-#: src/muuli_wdr.cpp:1840
+#: src/muuli_wdr.cpp:1844
 msgid "Download graph scale:"
 msgstr "下載統計圖比例："
 
-#: src/muuli_wdr.cpp:1848
+#: src/muuli_wdr.cpp:1852
 msgid "Upload graph scale:"
 msgstr "上傳統計圖比例："
 
-#: src/muuli_wdr.cpp:1858
+#: src/muuli_wdr.cpp:1862
 #, fuzzy
 msgid "Colors: "
 msgstr "顏色："
 
-#: src/muuli_wdr.cpp:1862
+#: src/muuli_wdr.cpp:1866
 msgid "Background"
 msgstr "背景"
 
-#: src/muuli_wdr.cpp:1863
+#: src/muuli_wdr.cpp:1867
 msgid "Grid"
 msgstr "格線"
 
-#: src/muuli_wdr.cpp:1864
+#: src/muuli_wdr.cpp:1868
 msgid "Download current"
 msgstr "目前下載"
 
-#: src/muuli_wdr.cpp:1865
+#: src/muuli_wdr.cpp:1869
 msgid "Download running average"
 msgstr "執行中平均下載"
 
-#: src/muuli_wdr.cpp:1866
+#: src/muuli_wdr.cpp:1870
 msgid "Download session average"
 msgstr "本次平均下載"
 
-#: src/muuli_wdr.cpp:1867
+#: src/muuli_wdr.cpp:1871
 msgid "Upload current"
 msgstr "目前上傳"
 
-#: src/muuli_wdr.cpp:1868
+#: src/muuli_wdr.cpp:1872
 msgid "Upload running average"
 msgstr "執行中平均上傳"
 
-#: src/muuli_wdr.cpp:1869
+#: src/muuli_wdr.cpp:1873
 msgid "Upload session average"
 msgstr "本次平均上傳"
 
-#: src/muuli_wdr.cpp:1870
+#: src/muuli_wdr.cpp:1874
 msgid "Active connections"
 msgstr "目前連線數"
 
-#: src/muuli_wdr.cpp:1873
+#: src/muuli_wdr.cpp:1877
 #, fuzzy
 msgid "Systray Icon Speed Bar"
 msgstr "狀態列圖示顯示速度"
 
-#: src/muuli_wdr.cpp:1874
+#: src/muuli_wdr.cpp:1878
 msgid "Kad-nodes current"
 msgstr "目前 Kad 節點"
 
-#: src/muuli_wdr.cpp:1875
+#: src/muuli_wdr.cpp:1879
 msgid "Kad-nodes running"
 msgstr "執行中 Kad 節點"
 
-#: src/muuli_wdr.cpp:1876
+#: src/muuli_wdr.cpp:1880
 msgid "Kad-nodes session"
 msgstr "本次 Kad 節點"
 
-#: src/muuli_wdr.cpp:1880 src/muuli_wdr.cpp:2334
+#: src/muuli_wdr.cpp:1884 src/muuli_wdr.cpp:2338
 msgid "Select"
 msgstr "選取"
 
-#: src/muuli_wdr.cpp:1884
+#: src/muuli_wdr.cpp:1888
 msgid "Tree"
 msgstr "樹狀"
 
-#: src/muuli_wdr.cpp:1894
+#: src/muuli_wdr.cpp:1898
 msgid "Number of Client Versions shown (0=unlimited)"
 msgstr "顯示客戶端版本的數量 ( 0 代表不限制)"
 
-#: src/muuli_wdr.cpp:1919
+#: src/muuli_wdr.cpp:1923
 msgid "!!! WARNING !!!"
 msgstr "!!! 警告 !!!"
 
-#: src/muuli_wdr.cpp:1934
+#: src/muuli_wdr.cpp:1938
 msgid "Max new connections / 5 secs"
 msgstr "5 秒內最大新連線數"
 
-#: src/muuli_wdr.cpp:1936
+#: src/muuli_wdr.cpp:1940
 msgid "Concurrent Kad source lookups"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1938
+#: src/muuli_wdr.cpp:1942
 #, fuzzy
 msgid "Kad source re-search interval (minutes)"
 msgstr "FTP 上傳間隔 (分鐘)"
 
-#: src/muuli_wdr.cpp:1940
+#: src/muuli_wdr.cpp:1944
 #, fuzzy
 msgid "Source re-ask interval (minutes)"
 msgstr "FTP 上傳間隔 (分鐘)"
 
-#: src/muuli_wdr.cpp:1944
+#: src/muuli_wdr.cpp:1948
 msgid "File Buffer Size: 240000 bytes"
 msgstr "檔案緩衝區：240.000 KB"
 
-#: src/muuli_wdr.cpp:1948
+#: src/muuli_wdr.cpp:1952
 msgid "Use MMAP: memory-mapped file access (lower memory use)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1949
+#: src/muuli_wdr.cpp:1953
 msgid "Maps part files into memory instead of buffering them on the heap, lowering the process memory footprint. May reduce download speed on some disks; best for memory-constrained or upload-heavy hosts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1951
+#: src/muuli_wdr.cpp:1955
 msgid "Upload Queue Size: 5000 clients"
 msgstr "上傳等候區大小：5000 "
 
-#: src/muuli_wdr.cpp:1955
+#: src/muuli_wdr.cpp:1959
 msgid "Server connection refresh interval: Disable"
 msgstr "伺服器連線更新間隔時間：停用"
 
-#: src/muuli_wdr.cpp:1959
+#: src/muuli_wdr.cpp:1963
 msgid "Disable computer's timed standby mode"
 msgstr "停用電腦的自動進入待命模式功能"
 
-#: src/muuli_wdr.cpp:1978
+#: src/muuli_wdr.cpp:1982
 msgid "Skin to use: "
 msgstr "使用面板："
 
-#: src/muuli_wdr.cpp:1987
+#: src/muuli_wdr.cpp:1991
 msgid "Show \"Fast eD2k Links Handler\" in every window."
 msgstr "在每個視窗顯示「eD2k 連結快速處理器」。"
 
-#: src/muuli_wdr.cpp:1990
+#: src/muuli_wdr.cpp:1994
 msgid "Show extended info on categories tabs"
 msgstr "在分類頁中顯示擴充資訊"
 
-#: src/muuli_wdr.cpp:1993
+#: src/muuli_wdr.cpp:1997
 msgid "Show application version on title"
 msgstr "在標題顯示應用程式版本"
 
-#: src/muuli_wdr.cpp:1995
+#: src/muuli_wdr.cpp:1999
 msgid "Show transfer rates on title"
 msgstr "標題列顯示傳輸速度"
 
-#: src/muuli_wdr.cpp:1997
+#: src/muuli_wdr.cpp:2001
 msgid "Before application name"
 msgstr "在程式名稱前"
 
-#: src/muuli_wdr.cpp:1999
+#: src/muuli_wdr.cpp:2003
 msgid "After application name"
 msgstr "在程式名稱後"
 
-#: src/muuli_wdr.cpp:2002
+#: src/muuli_wdr.cpp:2006
 msgid "Show overhead bandwidth"
 msgstr "顯示額外支出頻寬"
 
-#: src/muuli_wdr.cpp:2006
+#: src/muuli_wdr.cpp:2010
 msgid "Vertical toolbar orientation"
 msgstr "垂直顯示工具列"
 
-#: src/muuli_wdr.cpp:2008
+#: src/muuli_wdr.cpp:2012
 msgid "Live column sorting (auto-reorder rows as their values change)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2015
+#: src/muuli_wdr.cpp:2019
 msgid "Download Queue Files"
 msgstr "下載等候區檔案"
 
-#: src/muuli_wdr.cpp:2018
+#: src/muuli_wdr.cpp:2022
 msgid "Show progress percentage"
 msgstr "顯示進度百分比"
 
-#: src/muuli_wdr.cpp:2024
+#: src/muuli_wdr.cpp:2028
 msgid "Show progress bar"
 msgstr "顯示進度條"
 
-#: src/muuli_wdr.cpp:2027
+#: src/muuli_wdr.cpp:2031
 msgid "Flat"
 msgstr "扁平"
 
-#: src/muuli_wdr.cpp:2031
+#: src/muuli_wdr.cpp:2035
 msgid "Round"
 msgstr "圓弧"
 
-#: src/muuli_wdr.cpp:2049
+#: src/muuli_wdr.cpp:2053
 msgid "External Connection Parameters"
 msgstr "外部連線參數"
 
-#: src/muuli_wdr.cpp:2052
+#: src/muuli_wdr.cpp:2056
 msgid "Accept external connections"
 msgstr "接受外部連線"
 
-#: src/muuli_wdr.cpp:2059 src/muuli_wdr.cpp:2118
+#: src/muuli_wdr.cpp:2063 src/muuli_wdr.cpp:2122
 msgid "IP of the listening interface:"
 msgstr "監聽 IP："
 
-#: src/muuli_wdr.cpp:2062
+#: src/muuli_wdr.cpp:2066
 msgid "Enter here a valid ip in the a.b.c.d format for the listening EC interface. An empty field or 0.0.0.0 will mean any interface."
 msgstr "輸入要監聽外部連線的的 IP (格式：a.b.c.d)，空白或 0.0.0.0 表示全部。"
 
-#: src/muuli_wdr.cpp:2083 src/muuli_wdr.cpp:2194
+#: src/muuli_wdr.cpp:2087 src/muuli_wdr.cpp:2198
 msgid "TCP port:"
 msgstr "TCP 埠："
 
-#: src/muuli_wdr.cpp:2089
+#: src/muuli_wdr.cpp:2093
 msgid "Enable UPnP port forwarding on the EC port"
 msgstr "外部連線通訊埠啟用 UPnP 通訊埠轉向"
 
-#: src/muuli_wdr.cpp:2093 src/muuli_wdr.cpp:3079
+#: src/muuli_wdr.cpp:2097 src/muuli_wdr.cpp:3083
 #: src/utils/wxCas/src/wxcasprefs.cpp:167
 msgid "Password"
 msgstr "密碼"
 
-#: src/muuli_wdr.cpp:2099
+#: src/muuli_wdr.cpp:2103
 #, fuzzy
 msgid "aMule API server parameters"
 msgstr "網站伺服器參數"
 
-#: src/muuli_wdr.cpp:2102
+#: src/muuli_wdr.cpp:2106
 msgid "Run amuleapi (REST API) on startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2107
+#: src/muuli_wdr.cpp:2111
 #, fuzzy
 msgid "HTTP port:"
 msgstr "TCP 埠："
 
-#: src/muuli_wdr.cpp:2121
+#: src/muuli_wdr.cpp:2125
 msgid "The interface amuleapi's HTTP server listens on. 127.0.0.1 (default) accepts only local connections; use 0.0.0.0 or a specific IP to expose it to other hosts (set an admin password below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2126
+#: src/muuli_wdr.cpp:2130
 msgid "Type a password to set or change it. Stored passwords cannot be shown, so leaving this empty keeps the current one."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2128
+#: src/muuli_wdr.cpp:2132
 #, fuzzy
 msgid "Admin password"
 msgstr "正在檢查密碼\n"
 
-#: src/muuli_wdr.cpp:2140 src/muuli_wdr.cpp:2157 src/PrefsUnifiedDlg.cpp:1103
+#: src/muuli_wdr.cpp:2144 src/muuli_wdr.cpp:2161 src/PrefsUnifiedDlg.cpp:1112
 #, fuzzy
 msgid "A password is set."
 msgstr "正在檢查密碼\n"
 
-#: src/muuli_wdr.cpp:2144
+#: src/muuli_wdr.cpp:2148
 #, fuzzy
 msgid "Enable guest access"
 msgstr "拒絕訪客連線"
 
-#: src/muuli_wdr.cpp:2145
+#: src/muuli_wdr.cpp:2149
 msgid "Guest sessions may read status and listings but cannot change anything. Turning this off clears the stored guest password."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2149
+#: src/muuli_wdr.cpp:2153
 #, fuzzy
 msgid "Guest password"
 msgstr "網站伺服器的 訪客密碼"
 
-#: src/muuli_wdr.cpp:2164
+#: src/muuli_wdr.cpp:2168
 msgid "Web server parameters"
 msgstr "網站伺服器參數"
 
-#: src/muuli_wdr.cpp:2167
+#: src/muuli_wdr.cpp:2171
 #, fuzzy
 msgid "Run webserver on startup (deprecated)"
 msgstr "啟動時執行網站伺服器"
 
-#: src/muuli_wdr.cpp:2173
+#: src/muuli_wdr.cpp:2177
 msgid "Web template"
 msgstr "網頁模板"
 
-#: src/muuli_wdr.cpp:2178
+#: src/muuli_wdr.cpp:2182
 msgid "Full rights password"
 msgstr "絕對權限使用者密碼"
 
-#: src/muuli_wdr.cpp:2182
+#: src/muuli_wdr.cpp:2186
 msgid "Enable Low rights User"
 msgstr "啟用低權限使用者"
 
-#: src/muuli_wdr.cpp:2187
+#: src/muuli_wdr.cpp:2191
 msgid "Low rights password"
 msgstr "低權限使用者密碼"
 
-#: src/muuli_wdr.cpp:2201
+#: src/muuli_wdr.cpp:2205
 msgid "Enable UPnP port forwarding of the web server port"
 msgstr "網站伺服器的通訊埠啟用 UPnP 通訊埠轉向"
 
-#: src/muuli_wdr.cpp:2206
+#: src/muuli_wdr.cpp:2210
 msgid "Web server UPnP TCP port (Optional)"
 msgstr "網站伺服器的 UPnP TCP 埠 (選用)"
 
-#: src/muuli_wdr.cpp:2214
+#: src/muuli_wdr.cpp:2218
 msgid "Page Refresh Time (in secs)"
 msgstr "頁面更新時間 (秒)"
 
-#: src/muuli_wdr.cpp:2221
+#: src/muuli_wdr.cpp:2225
 msgid "Enable Gzip compression"
 msgstr "啟用 Gzip 壓縮"
 
-#: src/muuli_wdr.cpp:2255
+#: src/muuli_wdr.cpp:2259
 #, fuzzy
 msgid "Reset page to defaults"
 msgstr "系統預設"
 
-#: src/muuli_wdr.cpp:2256
+#: src/muuli_wdr.cpp:2260
 msgid "Reset the settings on the current page to their default values."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2258 src/muuli_wdr.cpp:2344 src/ServerWnd.cpp:274
+#: src/muuli_wdr.cpp:2262 src/muuli_wdr.cpp:2348 src/ServerWnd.cpp:274
 #: src/ServerWnd.cpp:282
 msgid "OK"
 msgstr "OK"
 
-#: src/muuli_wdr.cpp:2260
+#: src/muuli_wdr.cpp:2264
 msgid "Click here to apply any changes made to the preferences."
 msgstr "點選這裏立即套用已變更的偏好設定。"
 
-#: src/muuli_wdr.cpp:2263
+#: src/muuli_wdr.cpp:2267
 msgid "Reset any changes made to the preferences."
 msgstr "取消所有偏好設定變更。"
 
-#: src/muuli_wdr.cpp:2292
+#: src/muuli_wdr.cpp:2296
 msgid "Comment :"
 msgstr "註解："
 
-#: src/muuli_wdr.cpp:2299
+#: src/muuli_wdr.cpp:2303
 msgid "Incoming Dir :"
 msgstr "新進檔目錄："
 
-#: src/muuli_wdr.cpp:2308
+#: src/muuli_wdr.cpp:2312
 msgid "Change priority for new assigned files :"
 msgstr "設定新加入的檔案優先等級為："
 
-#: src/muuli_wdr.cpp:2312
+#: src/muuli_wdr.cpp:2316
 msgid "Don't change"
 msgstr "不要變更"
 
-#: src/muuli_wdr.cpp:2324
+#: src/muuli_wdr.cpp:2328
 msgid "Select color for this Category (currently selected) :"
 msgstr "選取該分類的顏色 (目前選擇)："
 
-#: src/muuli_wdr.cpp:2391 src/muuli_wdr.cpp:2410 src/muuli_wdr.cpp:2432
+#: src/muuli_wdr.cpp:2395 src/muuli_wdr.cpp:2414 src/muuli_wdr.cpp:2436
 msgid "Click this button to reset the log."
 msgstr "點選這個按鈕來清除記錄。"
 
-#: src/muuli_wdr.cpp:2451
+#: src/muuli_wdr.cpp:2455
 msgid "Click on this button to update the servers list from URL ..."
 msgstr "點選這個按鈕從該網址更新伺服器清單 ..."
 
-#: src/muuli_wdr.cpp:2455
+#: src/muuli_wdr.cpp:2459
 msgid "Server list"
 msgstr "伺服器清單"
 
-#: src/muuli_wdr.cpp:2459
+#: src/muuli_wdr.cpp:2463
 msgid "Enter the url to a server.met file here and press the button to the left to update the list of known servers."
 msgstr "輸入 server.met 檔案的網址並按下左邊的按鈕以更新已知伺服器清單。"
 
-#: src/muuli_wdr.cpp:2464
+#: src/muuli_wdr.cpp:2468
 msgid "Add server manually: Name"
 msgstr "手動加入伺服器：名稱"
 
-#: src/muuli_wdr.cpp:2467
+#: src/muuli_wdr.cpp:2471
 msgid "Enter the name of the new server here"
 msgstr "輸入新伺服器的名稱"
 
-#: src/muuli_wdr.cpp:2469 src/ServerWnd.cpp:206
+#: src/muuli_wdr.cpp:2473 src/ServerWnd.cpp:206
 msgid "IP:Port"
 msgstr "IP:Port"
 
-#: src/muuli_wdr.cpp:2472
+#: src/muuli_wdr.cpp:2476
 msgid "Enter the IP of the server here, using the x.x.x.x format."
 msgstr "輸入新伺服器的 IP (格式：x.x.x.x)。"
 
-#: src/muuli_wdr.cpp:2478
+#: src/muuli_wdr.cpp:2482
 msgid "Enter the port of the server here."
 msgstr "輸入伺服器的通訊埠。"
 
-#: src/muuli_wdr.cpp:2481
+#: src/muuli_wdr.cpp:2485
 msgid "Add manually a server (fill fields to the left before) ..."
 msgstr "手動加入伺服器 (填入左側空格中) ..."
 
-#: src/muuli_wdr.cpp:2510
+#: src/muuli_wdr.cpp:2514
 msgid "aMule Log"
 msgstr "aMule 記錄"
 
-#: src/muuli_wdr.cpp:2518
+#: src/muuli_wdr.cpp:2522
 msgid "Server Info"
 msgstr "伺服器資訊"
 
-#: src/muuli_wdr.cpp:2522
+#: src/muuli_wdr.cpp:2526
 msgid "ED2K Info"
 msgstr "eD2k 資訊"
 
-#: src/muuli_wdr.cpp:2526
+#: src/muuli_wdr.cpp:2530
 msgid "Kad Info"
 msgstr "Kad 資訊"
 
-#: src/muuli_wdr.cpp:2554
+#: src/muuli_wdr.cpp:2558
 msgid "Click on this button to update the nodes list from URL ..."
 msgstr "點選這個按鈕來從該網址更新節點清單 ..."
 
-#: src/muuli_wdr.cpp:2558
+#: src/muuli_wdr.cpp:2562
 msgid "Nodes (0)"
 msgstr "節點 (0)"
 
-#: src/muuli_wdr.cpp:2562
+#: src/muuli_wdr.cpp:2566
 msgid "Enter the url to a nodes.dat file here and press the button to the left to update the list of known nodes."
 msgstr "輸入 nodes.dat 檔案的網址，並按下左邊的按鈕以更新已知節點清單。"
 
-#: src/muuli_wdr.cpp:2565
+#: src/muuli_wdr.cpp:2569
 msgid "Nodes stats"
 msgstr "節點狀態"
 
-#: src/muuli_wdr.cpp:2607
+#: src/muuli_wdr.cpp:2611
 msgid "Bootstrap"
 msgstr "啓動"
 
-#: src/muuli_wdr.cpp:2610
+#: src/muuli_wdr.cpp:2614
 msgid "New node"
 msgstr "新節點"
 
-#: src/muuli_wdr.cpp:2615
+#: src/muuli_wdr.cpp:2619
 msgid "IP:"
 msgstr "IP："
 
-#: src/muuli_wdr.cpp:2635
+#: src/muuli_wdr.cpp:2639
 msgid "Port:"
 msgstr "埠："
 
-#: src/muuli_wdr.cpp:2648
+#: src/muuli_wdr.cpp:2652
 msgid "Bootstrap from known clients"
 msgstr "從已知客戶端啓動"
 
-#: src/muuli_wdr.cpp:2650
+#: src/muuli_wdr.cpp:2654
 msgid "Disconnect Kad"
 msgstr "中斷 Kad 連線"
 
-#: src/muuli_wdr.cpp:2684
+#: src/muuli_wdr.cpp:2688
 msgid "Use Secure User Identification"
 msgstr "啟用使用者安全認證"
 
-#: src/muuli_wdr.cpp:2686
+#: src/muuli_wdr.cpp:2690
 msgid "It is recommended to enable this option. You will not receive credits if SUI is not enabled."
 msgstr "建議啟用此選項。如果使用者安全認證未啟用，將會得不到積分。"
 
-#: src/muuli_wdr.cpp:2688
+#: src/muuli_wdr.cpp:2692
 msgid "Protocol Obfuscation"
 msgstr "模糊協定"
 
-#: src/muuli_wdr.cpp:2691
+#: src/muuli_wdr.cpp:2695
 msgid "Support Protocol Obfuscation"
 msgstr "支援模糊協定"
 
-#: src/muuli_wdr.cpp:2693
+#: src/muuli_wdr.cpp:2697
 msgid "This option enabled Protocol Obfuscation, and makes aMule accept obfuscated connections from other clients."
 msgstr "啓用模糊協定，可讓 aMule 接受來自其他客戶端的模糊連線。"
 
-#: src/muuli_wdr.cpp:2695
+#: src/muuli_wdr.cpp:2699
 msgid "Use obfuscation for outgoing connections"
 msgstr "對外的連線使用模糊協定"
 
-#: src/muuli_wdr.cpp:2697
+#: src/muuli_wdr.cpp:2701
 msgid "This option makes aMule use Protocol Obfuscation when connecting other clients/servers."
 msgstr "使 aMule 在與其他客戶端或伺服器連線時使用模糊協定。"
 
-#: src/muuli_wdr.cpp:2699
+#: src/muuli_wdr.cpp:2703
 msgid "Accept only obfuscated connections"
 msgstr "只接受模糊連線"
 
-#: src/muuli_wdr.cpp:2700
+#: src/muuli_wdr.cpp:2704
 msgid "This option makes aMule only accept obfuscated connections. You will have less sources, but all your traffic will be obfuscated"
 msgstr "讓 aMule 只接受模糊協定，檔案來源會比較少，但所有傳輸都將是模糊連線"
 
-#: src/muuli_wdr.cpp:2705
+#: src/muuli_wdr.cpp:2709
 msgid "Everybody"
 msgstr "任何人"
 
-#: src/muuli_wdr.cpp:2707
+#: src/muuli_wdr.cpp:2711
 msgid "No one"
 msgstr "無"
 
-#: src/muuli_wdr.cpp:2709
+#: src/muuli_wdr.cpp:2713
 msgid "Who can see my shared files:"
 msgstr "誰可以看我的分享檔案："
 
-#: src/muuli_wdr.cpp:2710
+#: src/muuli_wdr.cpp:2714
 msgid "Select who can request to view a list of your shared files."
 msgstr "選取可以瀏覽分享檔案清單的使用者。"
 
-#: src/muuli_wdr.cpp:2712
+#: src/muuli_wdr.cpp:2716
 msgid "IP-Filtering"
 msgstr "IP 過濾"
 
-#: src/muuli_wdr.cpp:2719
+#: src/muuli_wdr.cpp:2723
 msgid "Filter clients"
 msgstr "過濾客戶端"
 
-#: src/muuli_wdr.cpp:2721
+#: src/muuli_wdr.cpp:2725
 msgid "Enable filtering of the client IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "過濾列在 ~/.aMule/ipfilter.dat 檔案中的客戶端 IP"
 
-#: src/muuli_wdr.cpp:2723
+#: src/muuli_wdr.cpp:2727
 msgid "Filter servers"
 msgstr "過濾伺服器"
 
-#: src/muuli_wdr.cpp:2725
+#: src/muuli_wdr.cpp:2729
 msgid "Enable filtering of the server IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "過濾列在 ~/.aMule/ipfilter.dat 檔案中的伺服器 IP 。"
 
-#: src/muuli_wdr.cpp:2729
+#: src/muuli_wdr.cpp:2733
 msgid "Reload List"
 msgstr "重載入清單"
 
-#: src/muuli_wdr.cpp:2730
+#: src/muuli_wdr.cpp:2734
 msgid "Reload the list of IPs to filter from the file ~/.aMule/ipfilter.dat"
 msgstr "重新載入 IP 過濾清單 ~/.aMule/ipfilter.dat"
 
-#: src/muuli_wdr.cpp:2736
+#: src/muuli_wdr.cpp:2740
 msgid "URL:"
 msgstr "網址："
 
-#: src/muuli_wdr.cpp:2740 src/muuli_wdr.cpp:2933
+#: src/muuli_wdr.cpp:2744 src/muuli_wdr.cpp:2937
 msgid "Update now"
 msgstr "立即更新"
 
-#: src/muuli_wdr.cpp:2743
+#: src/muuli_wdr.cpp:2747
 msgid "Auto-update ipfilter at startup"
 msgstr "啓動後自動更新 IP 過濾清單"
 
-#: src/muuli_wdr.cpp:2747
+#: src/muuli_wdr.cpp:2751
 msgid "Filtering Level:"
 msgstr "過濾等級："
 
-#: src/muuli_wdr.cpp:2753
+#: src/muuli_wdr.cpp:2757
 msgid "Always filter LAN IPs"
 msgstr "永遠過濾區域網路 IP"
 
-#: src/muuli_wdr.cpp:2756
+#: src/muuli_wdr.cpp:2760
 msgid "Paranoid handling of non-matching IPs"
 msgstr "處理不匹配的 IP"
 
-#: src/muuli_wdr.cpp:2758
+#: src/muuli_wdr.cpp:2762
 msgid "Rejects a packet when its source IP differs from the IP the client claims (an anti-spoofing check). Disable only if it causes connection problems."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2760
+#: src/muuli_wdr.cpp:2764
 msgid "Use system-wide ipfilter.dat if available"
 msgstr "如果可以則使用系統級的 ipfilter.dat"
 
-#: src/muuli_wdr.cpp:2761
+#: src/muuli_wdr.cpp:2765
 #, fuzzy
 msgid "If there's no local ipfilter.dat found, allow usage of a system-wide ipfilter file."
 msgstr "如果找不到本機 ipfilter.dat 檔案，則允許使用系統級的 IP 過濾檔。"
 
-#: src/muuli_wdr.cpp:2778
+#: src/muuli_wdr.cpp:2782
 msgid "Enable Online-Signature"
 msgstr "啟用線上簽名識別"
 
-#: src/muuli_wdr.cpp:2780
+#: src/muuli_wdr.cpp:2784
 msgid "Enables the writing of the OS file, which can be used by external apps to create signatures and the like."
 msgstr "啟用寫入到作業系統檔案，以讓外部程式用來建立簽名識別等等。"
 
-#: src/muuli_wdr.cpp:2784
+#: src/muuli_wdr.cpp:2788
 msgid "Update Frequency (Secs):"
 msgstr "更新頻率(秒)："
 
-#: src/muuli_wdr.cpp:2787
+#: src/muuli_wdr.cpp:2791
 msgid "Change the frequency (in seconds) of Online Signature updates."
 msgstr "變更線上簽名識別檔的更新頻率 (單位為 秒)。"
 
-#: src/muuli_wdr.cpp:2795
+#: src/muuli_wdr.cpp:2799
 msgid "Save online signature file in: "
 msgstr "儲存線上簽名識別檔："
 
-#: src/muuli_wdr.cpp:2801
+#: src/muuli_wdr.cpp:2805
 msgid "Click here to select the directory containing the the Online Signature files."
 msgstr "點擊選取線上簽識別名檔案所在的目錄。"
 
-#: src/muuli_wdr.cpp:2834
+#: src/muuli_wdr.cpp:2838
 msgid "Show country flags for clients"
 msgstr "顯示客戶端的國旗"
 
-#: src/muuli_wdr.cpp:2835
+#: src/muuli_wdr.cpp:2839
 msgid "Render the country flag column in the transfers, queue and search views. Requires a valid MMDB GeoIP database (see below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2840
+#: src/muuli_wdr.cpp:2844
 #, fuzzy
 msgid "Database"
 msgstr "速度："
 
-#: src/muuli_wdr.cpp:2856
+#: src/muuli_wdr.cpp:2860
 #, fuzzy
 msgid "Source:"
 msgstr "來源"
 
-#: src/muuli_wdr.cpp:2859
+#: src/muuli_wdr.cpp:2863
 msgid "DB-IP (free, no account)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2860
+#: src/muuli_wdr.cpp:2864
 msgid "MaxMind GeoLite2 (free, account required)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2861
+#: src/muuli_wdr.cpp:2865
 msgid "Custom URL"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2864
+#: src/muuli_wdr.cpp:2868
 msgid "Choose which provider supplies the GeoIP MMDB database. DB-IP is the default - no account required. MaxMind requires a free account + license key. Use Custom URL to point at any other MMDB host (e.g. a local mirror)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2881
+#: src/muuli_wdr.cpp:2885
 msgid ""
 "No configuration required.\n"
 "\n"
@@ -4872,11 +4872,11 @@ msgid ""
 "License: Creative Commons BY 4.0 - https://creativecommons.org/licenses/by/4.0/"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2894
+#: src/muuli_wdr.cpp:2898
 msgid "License key:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2900
+#: src/muuli_wdr.cpp:2904
 msgid ""
 "Sign up for a free MaxMind account, then generate a License Key:\n"
 "https://www.maxmind.com/en/geolite2/signup\n"
@@ -4886,226 +4886,226 @@ msgid ""
 "Requires attribution and account registration; refresh at least every 30 days."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2915
+#: src/muuli_wdr.cpp:2919
 #, fuzzy
 msgid "Download URL:"
 msgstr "下載："
 
-#: src/muuli_wdr.cpp:2921
+#: src/muuli_wdr.cpp:2925
 msgid ""
 "Must point to an .mmdb file or a .gz / .tar.gz containing one.\n"
 "URL may include credentials (https://user:pass@host/...).\n"
 "License and attribution terms are set by the upstream URL - you are responsible."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2934
+#: src/muuli_wdr.cpp:2938
 msgid "Download the GeoIP database from the selected source."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2936
+#: src/muuli_wdr.cpp:2940
 #, fuzzy
 msgid "Auto-update on startup"
 msgstr "啓動後自動更新 IP 過濾清單"
 
-#: src/muuli_wdr.cpp:2937
+#: src/muuli_wdr.cpp:2941
 msgid "Re-download the GeoIP database from the selected source every time aMule starts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2960
+#: src/muuli_wdr.cpp:2964
 msgid "Filter incoming messages (except current chat):"
 msgstr "過濾收到的訊息 (不包含目前交談)："
 
-#: src/muuli_wdr.cpp:2962
+#: src/muuli_wdr.cpp:2966
 msgid "Filter all messages"
 msgstr "過濾所有訊息"
 
-#: src/muuli_wdr.cpp:2964
+#: src/muuli_wdr.cpp:2968
 msgid "Filter messages from people not on your friend list"
 msgstr "過濾來自好友以外的訊息"
 
-#: src/muuli_wdr.cpp:2966
+#: src/muuli_wdr.cpp:2970
 msgid "Filter messages from unknown clients"
 msgstr "過濾來自不明客戶端的訊息"
 
-#: src/muuli_wdr.cpp:2968
+#: src/muuli_wdr.cpp:2972
 msgid "Filter messages containing (use ',' as separator):"
 msgstr "過濾含以下內容的訊息 (用逗號 ',' 隔開)："
 
-#: src/muuli_wdr.cpp:2971 src/muuli_wdr.cpp:2982
+#: src/muuli_wdr.cpp:2975 src/muuli_wdr.cpp:2986
 msgid "add here the words amule should filter and block messages including it"
 msgstr "輸入要過濾的詞句"
 
-#: src/muuli_wdr.cpp:2973
+#: src/muuli_wdr.cpp:2977
 msgid "Show received messages in the log"
 msgstr "記錄收到的訊息"
 
-#: src/muuli_wdr.cpp:2976
+#: src/muuli_wdr.cpp:2980
 msgid "Comments"
 msgstr "註解"
 
-#: src/muuli_wdr.cpp:2979
+#: src/muuli_wdr.cpp:2983
 msgid "Filter comments containing (use ',' as separator):"
 msgstr "過濾含以下內容的註解 (用逗號 ',' 隔開)："
 
-#: src/muuli_wdr.cpp:3004
+#: src/muuli_wdr.cpp:3008
 msgid "Enable Proxy"
 msgstr "啓用代理伺服器"
 
-#: src/muuli_wdr.cpp:3005
+#: src/muuli_wdr.cpp:3009
 msgid "Enable/disable proxy support"
 msgstr "啓用/停用代理伺服器支援"
 
-#: src/muuli_wdr.cpp:3008
+#: src/muuli_wdr.cpp:3012
 msgid "Proxy type:"
 msgstr "類型："
 
-#: src/muuli_wdr.cpp:3019
+#: src/muuli_wdr.cpp:3023
 msgid "Proxy host:"
 msgstr "主機："
 
-#: src/muuli_wdr.cpp:3022
+#: src/muuli_wdr.cpp:3026
 msgid "The proxy host name"
 msgstr "代理伺服器主機名稱"
 
-#: src/muuli_wdr.cpp:3024
+#: src/muuli_wdr.cpp:3028
 msgid "Proxy port:"
 msgstr "連接埠："
 
-#: src/muuli_wdr.cpp:3027
+#: src/muuli_wdr.cpp:3031
 msgid "The proxy port"
 msgstr "代理伺服器連接埠"
 
-#: src/muuli_wdr.cpp:3029
+#: src/muuli_wdr.cpp:3033
 msgid "Enable authentication"
 msgstr "啓用登入驗證"
 
-#: src/muuli_wdr.cpp:3030
+#: src/muuli_wdr.cpp:3034
 msgid "Enable/disable username/password authentication"
 msgstr "啓用/停用 使用者名稱/密碼登入驗證"
 
-#: src/muuli_wdr.cpp:3033
+#: src/muuli_wdr.cpp:3037
 msgid "Username: "
 msgstr "使用者名稱："
 
-#: src/muuli_wdr.cpp:3036
+#: src/muuli_wdr.cpp:3040
 msgid "The username to use to connect to the proxy"
 msgstr "登入代理伺服器的使用者名稱"
 
-#: src/muuli_wdr.cpp:3038
+#: src/muuli_wdr.cpp:3042
 msgid "Password:"
 msgstr "密碼："
 
-#: src/muuli_wdr.cpp:3041
+#: src/muuli_wdr.cpp:3045
 msgid "The password to use to connect to the proxy"
 msgstr "登入代理伺服器的密碼"
 
-#: src/muuli_wdr.cpp:3060
+#: src/muuli_wdr.cpp:3064
 msgid "Connect to:"
 msgstr "連線到："
 
-#: src/muuli_wdr.cpp:3069
+#: src/muuli_wdr.cpp:3073
 msgid "Login to remote amule"
 msgstr "登入遠端 amule"
 
-#: src/muuli_wdr.cpp:3074
+#: src/muuli_wdr.cpp:3078
 msgid "User name"
 msgstr "使用者名稱"
 
-#: src/muuli_wdr.cpp:3085
+#: src/muuli_wdr.cpp:3089
 msgid "Remember those settings"
 msgstr "記住這些設定"
 
-#: src/muuli_wdr.cpp:3088
+#: src/muuli_wdr.cpp:3092
 #, fuzzy
 msgid "Force ZLIB compression"
 msgstr "使用 gzip 壓縮"
 
-#: src/muuli_wdr.cpp:3112
+#: src/muuli_wdr.cpp:3116
 msgid "Enable Verbose Debug-Logging."
 msgstr "啓用記錄詳細除錯訊息。"
 
-#: src/muuli_wdr.cpp:3114
+#: src/muuli_wdr.cpp:3118
 #, fuzzy
 msgid "Only to Logfile"
 msgstr "開啟檔案(&O)"
 
-#: src/muuli_wdr.cpp:3116
+#: src/muuli_wdr.cpp:3120
 msgid "Message Categories:"
 msgstr "訊息分類："
 
-#: src/muuli_wdr.cpp:3140 src/PartFileConvertDlg.cpp:160
+#: src/muuli_wdr.cpp:3144 src/PartFileConvertDlg.cpp:160
 msgid "Waiting..."
 msgstr "等候中..."
 
-#: src/muuli_wdr.cpp:3160
+#: src/muuli_wdr.cpp:3164
 msgid "Add imports"
 msgstr "加入"
 
-#: src/muuli_wdr.cpp:3163
+#: src/muuli_wdr.cpp:3167
 msgid "Retry selected"
 msgstr "重試"
 
-#: src/muuli_wdr.cpp:3165
+#: src/muuli_wdr.cpp:3169
 msgid "Remove selected"
 msgstr "移除"
 
-#: src/muuli_wdr.cpp:3228
+#: src/muuli_wdr.cpp:3232
 msgid "Event Types"
 msgstr "事件種類"
 
-#: src/muuli_wdr.cpp:3247
+#: src/muuli_wdr.cpp:3251
 msgid "Statistics and queued clients for selected file(s) : Session / All time"
 msgstr "已選取的檔案的統計資料與等候區客戶端數：本次 / 總計"
 
-#: src/muuli_wdr.cpp:3271
+#: src/muuli_wdr.cpp:3275
 msgid "Active Uploads"
 msgstr "目前上傳數"
 
-#: src/muuli_wdr.cpp:3285
+#: src/muuli_wdr.cpp:3289
 msgid "Percent of total files"
 msgstr "% (所有檔案中)"
 
-#: src/muuli_wdr.cpp:3337
+#: src/muuli_wdr.cpp:3341
 msgid "Show Clients for"
 msgstr "顯示客戶端："
 
-#: src/muuli_wdr.cpp:3339
+#: src/muuli_wdr.cpp:3343
 msgid "All files"
 msgstr "所有檔案"
 
-#: src/muuli_wdr.cpp:3342
+#: src/muuli_wdr.cpp:3346
 msgid "Selected files"
 msgstr "選取的檔案"
 
-#: src/muuli_wdr.cpp:3345
+#: src/muuli_wdr.cpp:3349
 msgid "Active uploads only"
 msgstr "僅限目前上傳中"
 
-#: src/muuli_wdr.cpp:3352
+#: src/muuli_wdr.cpp:3356
 msgid "Reload:"
 msgstr "重新載入："
 
-#: src/muuli_wdr.cpp:3356
+#: src/muuli_wdr.cpp:3360
 msgid "Reload your shared files"
 msgstr "重新載入分享的檔案"
 
-#: src/muuli_wdr.cpp:3419
+#: src/muuli_wdr.cpp:3423
 msgid "Send"
 msgstr "傳送"
 
-#: src/muuli_wdr.cpp:3420
+#: src/muuli_wdr.cpp:3424
 msgid "Sends the specified message."
 msgstr "傳送訊息。"
 
-#: src/muuli_wdr.cpp:3424
+#: src/muuli_wdr.cpp:3428
 msgid "Close this chat-session."
 msgstr "結束本次交談。"
 
-#: src/muuli_wdr.cpp:3447
+#: src/muuli_wdr.cpp:3451
 msgid "Connect to any server and/or Kad"
 msgstr "連線到任何伺服器 和/或 Kad 網路"
 
-#: src/muuli_wdr.cpp:3453 src/SharedFilesCtrl.cpp:142 src/Statistics.cpp:941
+#: src/muuli_wdr.cpp:3457 src/SharedFilesCtrl.cpp:142 src/Statistics.cpp:941
 msgid "Shared Files"
 msgstr "分享檔案"
 
@@ -5735,35 +5735,35 @@ msgstr ""
 "\n"
 "即使不變更這些設定，aMule 一樣可以正常運作。"
 
-#: src/PrefsUnifiedDlg.cpp:647
+#: src/PrefsUnifiedDlg.cpp:656
 #, c-format
 msgid "Failed to connect Cfg to widget with the ID %d and key %s"
 msgstr "無法以 ID %d、key %s 將 Cfg 與 widget 相連"
 
-#: src/PrefsUnifiedDlg.cpp:695
+#: src/PrefsUnifiedDlg.cpp:704
 #, c-format
 msgid "Failed to transfer data from Cfg to Widget with the ID %d and key %s"
 msgstr "無法以 ID %d、key %s 將資料 Cfg 與 widget 連線"
 
-#: src/PrefsUnifiedDlg.cpp:801
+#: src/PrefsUnifiedDlg.cpp:810
 msgid "The type of proxy you are connecting to"
 msgstr "正在連線的代理伺服器類型"
 
-#: src/PrefsUnifiedDlg.cpp:1020
+#: src/PrefsUnifiedDlg.cpp:1029
 #, c-format
 msgid "Failed to transfer data from Widget to Cfg with the ID %d and key %s"
 msgstr "無法以 ID %d、key %s 從 Cfg 傳輸資料到 Widget"
 
-#: src/PrefsUnifiedDlg.cpp:1103
+#: src/PrefsUnifiedDlg.cpp:1112
 #, fuzzy
 msgid "No password set."
 msgstr "正在檢查密碼\n"
 
-#: src/PrefsUnifiedDlg.cpp:1132
+#: src/PrefsUnifiedDlg.cpp:1141
 msgid "Guest access needs a password. Type one in the guest password field, or untick Enable guest access."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1144
+#: src/PrefsUnifiedDlg.cpp:1153
 msgid ""
 "aMule must be restarted to enable these changes:\n"
 "\n"
@@ -5771,42 +5771,42 @@ msgstr ""
 "請重新啟動 aMule，變更的設定才能生效：\n"
 "\n"
 
-#: src/PrefsUnifiedDlg.cpp:1151
+#: src/PrefsUnifiedDlg.cpp:1160
 msgid "- TCP port changed.\n"
 msgstr "- TCP 埠已變更。\n"
 
-#: src/PrefsUnifiedDlg.cpp:1156
+#: src/PrefsUnifiedDlg.cpp:1165
 msgid "- UDP port changed.\n"
 msgstr "- UDP 埠已變更。\n"
 
-#: src/PrefsUnifiedDlg.cpp:1161
+#: src/PrefsUnifiedDlg.cpp:1170
 #, fuzzy
 msgid "- Network interface binding changed.\n"
 msgstr "- 已變更外部連線介面設定。\n"
 
-#: src/PrefsUnifiedDlg.cpp:1166
+#: src/PrefsUnifiedDlg.cpp:1175
 msgid "- External connect port changed.\n"
 msgstr "- 已變更外部連線埠設定。\n"
 
-#: src/PrefsUnifiedDlg.cpp:1170
+#: src/PrefsUnifiedDlg.cpp:1179
 msgid "- External connect acceptance changed.\n"
 msgstr "- 已變更外部連線設定。\n"
 
-#: src/PrefsUnifiedDlg.cpp:1174
+#: src/PrefsUnifiedDlg.cpp:1183
 msgid "- External connect interface changed.\n"
 msgstr "- 已變更外部連線介面設定。\n"
 
-#: src/PrefsUnifiedDlg.cpp:1178
+#: src/PrefsUnifiedDlg.cpp:1187
 #, fuzzy
 msgid "- Protocol obfuscation support changed.\n"
 msgstr "模糊協定"
 
-#: src/PrefsUnifiedDlg.cpp:1193
+#: src/PrefsUnifiedDlg.cpp:1202
 #, fuzzy
 msgid "- amuleapi settings changed.\n"
 msgstr "- 語言已變更。\n"
 
-#: src/PrefsUnifiedDlg.cpp:1202
+#: src/PrefsUnifiedDlg.cpp:1211
 msgid ""
 "Your Auto-update server list is empty.\n"
 "'Auto-update server list at startup' will be disabled."
@@ -5814,7 +5814,7 @@ msgstr ""
 "您的自動更新伺服器清單是空的。\n"
 "「啟動時自動更新伺服器清單」功能將被停用。"
 
-#: src/PrefsUnifiedDlg.cpp:1213
+#: src/PrefsUnifiedDlg.cpp:1222
 msgid ""
 "You have enabled external connections but have not specified a password.\n"
 "External connections cannot be enabled unless a valid password is specified."
@@ -5822,33 +5822,33 @@ msgstr ""
 "您已經設定啓用外部連線但還沒有輸入密碼，\n"
 "輸入有效密碼之後，外部連線才能開始使用。"
 
-#: src/PrefsUnifiedDlg.cpp:1246
+#: src/PrefsUnifiedDlg.cpp:1255
 #, c-format
 msgid "The amuleapi password could not be saved: %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1276
+#: src/PrefsUnifiedDlg.cpp:1285
 msgid "- Language changed.\n"
 msgstr "- 語言已變更。\n"
 
-#: src/PrefsUnifiedDlg.cpp:1281
+#: src/PrefsUnifiedDlg.cpp:1290
 msgid "- Temp folder changed.\n"
 msgstr "- 暫存資料夾已變更。\n"
 
-#: src/PrefsUnifiedDlg.cpp:1286
+#: src/PrefsUnifiedDlg.cpp:1295
 msgid "- ED2K network enabled.\n"
 msgstr "- ED2K 網路已啟用。\n"
 
-#: src/PrefsUnifiedDlg.cpp:1319
+#: src/PrefsUnifiedDlg.cpp:1328
 msgid "The shared-file exclusion pattern is not a valid regular expression. The filter has been left disabled."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1321 src/PrefsUnifiedDlg.cpp:1921
+#: src/PrefsUnifiedDlg.cpp:1330 src/PrefsUnifiedDlg.cpp:1930
 #, fuzzy
 msgid "Invalid regular expression"
 msgstr "協定版本無效。"
 
-#: src/PrefsUnifiedDlg.cpp:1398
+#: src/PrefsUnifiedDlg.cpp:1407
 msgid ""
 "Both eD2k and Kad network are disabled.\n"
 "You won't be able to connect until you enable at least one of them."
@@ -5856,7 +5856,7 @@ msgstr ""
 "eD2k 與 Kad 網路都已停用。\n"
 "請至少啟用一種，否則您將無法連線。"
 
-#: src/PrefsUnifiedDlg.cpp:1403
+#: src/PrefsUnifiedDlg.cpp:1412
 msgid ""
 "Kad will not start if your UDP port is disabled.\n"
 "Enable UDP port or disable Kad."
@@ -5864,7 +5864,7 @@ msgstr ""
 "如果您停用 UDP 埠，Kad 將無法啓動。\n"
 "請啟用 UDP 埠或停用 Kad。"
 
-#: src/PrefsUnifiedDlg.cpp:1459
+#: src/PrefsUnifiedDlg.cpp:1468
 msgid ""
 "\n"
 "You MUST restart aMule now.\n"
@@ -5874,69 +5874,69 @@ msgstr ""
 "您必須立即重新啟動 aMule，\n"
 "如果現在不重啟動，可能會發生不可預期的問題。\n"
 
-#: src/PrefsUnifiedDlg.cpp:1524
+#: src/PrefsUnifiedDlg.cpp:1533
 msgid "Could not register aMule for autostart at login. The autostart store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1526
+#: src/PrefsUnifiedDlg.cpp:1535
 msgid "Could not remove the autostart-at-login entry."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1527
+#: src/PrefsUnifiedDlg.cpp:1536
 #, fuzzy
 msgid "Autostart"
 msgstr "已開始自動更新顯示"
 
-#: src/PrefsUnifiedDlg.cpp:1542
+#: src/PrefsUnifiedDlg.cpp:1551
 msgid "Register file type"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1542
+#: src/PrefsUnifiedDlg.cpp:1551
 msgid "Register URL handler"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1550
+#: src/PrefsUnifiedDlg.cpp:1559
 #, c-format
 msgid "aMule only handles eD2k-compatible magnets. If you replace the current magnet handler (%s), BitTorrent magnet links will stop working - aMule cannot download BitTorrent content. Continue?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1555
+#: src/PrefsUnifiedDlg.cpp:1564
 #, c-format
 msgid "Another application currently opens .emulecollection files (%s). Replace it with aMule?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1560
+#: src/PrefsUnifiedDlg.cpp:1569
 #, c-format
 msgid "Another application is currently the default handler for these links (%s). Replace it with aMule?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1585
+#: src/PrefsUnifiedDlg.cpp:1594
 msgid "Could not register aMule for .emulecollection files. The registration store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1587
+#: src/PrefsUnifiedDlg.cpp:1596
 #, fuzzy
 msgid "Could not remove the file type registration."
 msgstr "暫存資料夾"
 
-#: src/PrefsUnifiedDlg.cpp:1589
+#: src/PrefsUnifiedDlg.cpp:1598
 msgid "Could not register aMule as the URL handler. The registration store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1591
+#: src/PrefsUnifiedDlg.cpp:1600
 msgid "Could not remove the URL handler registration."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1661 src/PrefsUnifiedDlg.cpp:1688
+#: src/PrefsUnifiedDlg.cpp:1670 src/PrefsUnifiedDlg.cpp:1697
 #, fuzzy
 msgid "The web server and aMule API require external connections to be enabled."
 msgstr "密碼已設定，外部連線已啟用。"
 
-#: src/PrefsUnifiedDlg.cpp:1671
+#: src/PrefsUnifiedDlg.cpp:1680
 msgid "The aMule web server is deprecated. Consider running the aMule API instead."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1735
+#: src/PrefsUnifiedDlg.cpp:1744
 msgid ""
 "Your Auto-update servers list is in blank.\n"
 "Please fill in at least one URL to point to a valid server.met file.\n"
@@ -5946,65 +5946,65 @@ msgstr ""
 "請至少輸入一個能取得有效 server.met 檔案的網址。\n"
 "請點選旁邊的「清單」按鈕後輸入。"
 
-#: src/PrefsUnifiedDlg.cpp:1876
+#: src/PrefsUnifiedDlg.cpp:1885
 msgid "Temporary files"
 msgstr "暫存檔"
 
-#: src/PrefsUnifiedDlg.cpp:1881
+#: src/PrefsUnifiedDlg.cpp:1890
 msgid "Incoming files"
 msgstr "新進檔案"
 
-#: src/PrefsUnifiedDlg.cpp:1886
+#: src/PrefsUnifiedDlg.cpp:1895
 msgid "Online Signatures"
 msgstr "線上簽名識別"
 
-#: src/PrefsUnifiedDlg.cpp:1899
+#: src/PrefsUnifiedDlg.cpp:1908
 #, c-format
 msgid "Choose a folder for %s"
 msgstr "爲 %s 選擇資料夾"
 
-#: src/PrefsUnifiedDlg.cpp:1923
+#: src/PrefsUnifiedDlg.cpp:1932
 #, fuzzy, c-format
 msgid "Would exclude %u of %u shared file"
 msgid_plural "Would exclude %u of %u shared files"
 msgstr[0] "找到 %i 個已知的分享檔案"
 
-#: src/PrefsUnifiedDlg.cpp:1940
+#: src/PrefsUnifiedDlg.cpp:1949
 msgid "Browse for videoplayer"
 msgstr "瀏覽尋找影片播放器"
 
-#: src/PrefsUnifiedDlg.cpp:1944
+#: src/PrefsUnifiedDlg.cpp:1953
 msgid "Select browser"
 msgstr "設定瀏覽器"
 
-#: src/PrefsUnifiedDlg.cpp:1948
+#: src/PrefsUnifiedDlg.cpp:1957
 #, fuzzy
 msgid "Select ffprobe binary"
 msgstr "設定瀏覽器"
 
-#: src/PrefsUnifiedDlg.cpp:1954
+#: src/PrefsUnifiedDlg.cpp:1963
 #, c-format
 msgid "Executable%s"
 msgstr "可執行%s"
 
-#: src/PrefsUnifiedDlg.cpp:1988
+#: src/PrefsUnifiedDlg.cpp:1997
 msgid "ffprobe not found on PATH or in the standard install locations. Install ffmpeg (which ships ffprobe) or use Browse to pick a binary manually."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2000
+#: src/PrefsUnifiedDlg.cpp:2009
 msgid "Reset the settings on this page to their default values?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2001
+#: src/PrefsUnifiedDlg.cpp:2010
 #, fuzzy
 msgid "Reset to defaults"
 msgstr "系統預設"
 
-#: src/PrefsUnifiedDlg.cpp:2028
+#: src/PrefsUnifiedDlg.cpp:2037
 msgid "Edit server list"
 msgstr "編輯伺服器清單"
 
-#: src/PrefsUnifiedDlg.cpp:2029
+#: src/PrefsUnifiedDlg.cpp:2038
 msgid ""
 "Add here URL's to download server.met files.\n"
 "Only one url on each line."
@@ -6012,151 +6012,151 @@ msgstr ""
 "加入可下載 server.met 檔案的網址。\n"
 "每一行一個網址。"
 
-#: src/PrefsUnifiedDlg.cpp:2084
+#: src/PrefsUnifiedDlg.cpp:2093
 msgid "IP2Country update failed"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2229 src/PrefsUnifiedDlg.cpp:2260
+#: src/PrefsUnifiedDlg.cpp:2238 src/PrefsUnifiedDlg.cpp:2269
 msgid "Data by MaxMind GeoLite2"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2231 src/PrefsUnifiedDlg.cpp:2262
+#: src/PrefsUnifiedDlg.cpp:2240 src/PrefsUnifiedDlg.cpp:2271
 #, fuzzy
 msgid "Custom source"
 msgstr "完整來源"
 
-#: src/PrefsUnifiedDlg.cpp:2233 src/PrefsUnifiedDlg.cpp:2264
+#: src/PrefsUnifiedDlg.cpp:2242 src/PrefsUnifiedDlg.cpp:2273
 msgid "Data by DB-IP.com"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2284
+#: src/PrefsUnifiedDlg.cpp:2293
 #, fuzzy, c-format
 msgid "Status: Loaded%s"
 msgstr "狀態："
 
-#: src/PrefsUnifiedDlg.cpp:2286
+#: src/PrefsUnifiedDlg.cpp:2295
 #, fuzzy, c-format
 msgid "Status: Loaded%s - %s"
 msgstr "狀態："
 
-#: src/PrefsUnifiedDlg.cpp:2290
+#: src/PrefsUnifiedDlg.cpp:2299
 msgid "Status: Failed to load - click 'Update now' to refresh."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2292
+#: src/PrefsUnifiedDlg.cpp:2301
 msgid "Status: Not found - click 'Update now' to download."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2350 src/PrefsUnifiedDlg.cpp:2374
+#: src/PrefsUnifiedDlg.cpp:2359 src/PrefsUnifiedDlg.cpp:2383
 #, c-format
 msgid "Update delay: %d second"
 msgid_plural "Update delay: %d seconds"
 msgstr[0] "更新延遲時間：%d 秒"
 
-#: src/PrefsUnifiedDlg.cpp:2358
+#: src/PrefsUnifiedDlg.cpp:2367
 #, c-format
 msgid "Time for average graph: %d minute"
 msgid_plural "Time for average graph: %d minutes"
 msgstr[0] "平均值圖表顯示時間：%d 分鐘"
 
-#: src/PrefsUnifiedDlg.cpp:2367
+#: src/PrefsUnifiedDlg.cpp:2376
 #, c-format
 msgid "Connections Graph Scale: %d"
 msgstr "網路連線圖表比例：%d"
 
-#: src/PrefsUnifiedDlg.cpp:2382
+#: src/PrefsUnifiedDlg.cpp:2391
 #, c-format
 msgid "File Buffer Size: %d byte"
 msgid_plural "File Buffer Size: %d bytes"
 msgstr[0] "檔案緩衝區大小：%d B"
 
-#: src/PrefsUnifiedDlg.cpp:2392
+#: src/PrefsUnifiedDlg.cpp:2401
 #, c-format
 msgid "Upload Queue Size: %d client"
 msgid_plural "Upload Queue Size: %d clients"
 msgstr[0] "上傳等候區大小：%d "
 
-#: src/PrefsUnifiedDlg.cpp:2402
+#: src/PrefsUnifiedDlg.cpp:2411
 #, c-format
 msgid "Server connection refresh interval: %d minute"
 msgid_plural "Server connection refresh interval: %d minutes"
 msgstr[0] "伺服器連線更新間隔時間：%d 分鐘"
 
-#: src/PrefsUnifiedDlg.cpp:2407
+#: src/PrefsUnifiedDlg.cpp:2416
 msgid "Server connection refresh interval: Disabled"
 msgstr "伺服器連線更新間隔時間：已停用"
 
-#: src/PrefsUnifiedDlg.cpp:2451
+#: src/PrefsUnifiedDlg.cpp:2460
 msgid "disabled"
 msgstr "已停用"
 
-#: src/PrefsUnifiedDlg.cpp:2477
+#: src/PrefsUnifiedDlg.cpp:2486
 #, c-format
 msgid "Execute command on '%s' event"
 msgstr "發生 %s 事件時執行指令"
 
-#: src/PrefsUnifiedDlg.cpp:2484
+#: src/PrefsUnifiedDlg.cpp:2493
 msgid "Enable command execution on core"
 msgstr "啓用在主程式端執行指令"
 
-#: src/PrefsUnifiedDlg.cpp:2496
+#: src/PrefsUnifiedDlg.cpp:2505
 msgid "Core command:"
 msgstr "主程式端指令："
 
-#: src/PrefsUnifiedDlg.cpp:2512
+#: src/PrefsUnifiedDlg.cpp:2521
 msgid "Enable command execution on GUI"
 msgstr "啓用在圖形界面端執行指令"
 
-#: src/PrefsUnifiedDlg.cpp:2524
+#: src/PrefsUnifiedDlg.cpp:2533
 msgid "GUI command:"
 msgstr "圖形界面端指令："
 
-#: src/PrefsUnifiedDlg.cpp:2540
+#: src/PrefsUnifiedDlg.cpp:2549
 msgid "The following variables will be replaced:"
 msgstr ""
 "使用以下變數：\n"
 " "
 
-#: src/PrefsUnifiedDlg.cpp:2708
+#: src/PrefsUnifiedDlg.cpp:2717
 msgid ""
 "The following folders look like system or sensitive locations:\n"
 "\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2713
+#: src/PrefsUnifiedDlg.cpp:2722
 msgid "Sharing them recursively will publish every file underneath on the eD2k/Kad networks. Do you really want to do this?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2716
+#: src/PrefsUnifiedDlg.cpp:2725
 #, fuzzy
 msgid "Confirm shared folders"
 msgstr "分享資料夾"
 
-#: src/PrefsUnifiedDlg.cpp:2744
+#: src/PrefsUnifiedDlg.cpp:2753
 #, fuzzy
 msgid "Reloading shared files..."
 msgstr "重新載入分享的檔案"
 
-#: src/PrefsUnifiedDlg.cpp:2745
+#: src/PrefsUnifiedDlg.cpp:2754
 msgid "Scanning for subdirectories..."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2746
+#: src/PrefsUnifiedDlg.cpp:2755
 #, fuzzy
 msgid "Updating shared folders"
 msgstr "分享資料夾"
 
-#: src/PrefsUnifiedDlg.cpp:2773
+#: src/PrefsUnifiedDlg.cpp:2782
 #, c-format
 msgid "Scanned %u directories..."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2823
+#: src/PrefsUnifiedDlg.cpp:2832
 #, fuzzy, c-format
 msgid "Reloading shared files: %u files scanned"
 msgstr "重新載入分享檔案清單。"
 
-#: src/PrefsUnifiedDlg.cpp:2873
+#: src/PrefsUnifiedDlg.cpp:2882
 #, fuzzy
 msgid "Shared folder"
 msgstr "分享資料夾"
@@ -7829,12 +7829,12 @@ msgstr "移除分類"
 msgid "Hashset requested for unknown file: %s"
 msgstr "要求不明檔案 %s 的 hash 值組"
 
-#: src/UploadQueue.cpp:618
+#: src/UploadQueue.cpp:627
 #, c-format
 msgid "Resuming uploads of file: %s"
 msgstr "繼續上傳檔案：%s"
 
-#: src/UploadQueue.cpp:634
+#: src/UploadQueue.cpp:643
 #, c-format
 msgid "Suspending upload of file: %s"
 msgstr "暫停上傳檔案：%s"

--- a/po/zh_TW.po
+++ b/po/zh_TW.po
@@ -14,7 +14,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-28 10:19+0200\n"
+"POT-Creation-Date: 2026-07-28 12:17+0200\n"
 "PO-Revision-Date: 2026-07-27 11:48+0000\n"
 "Last-Translator: Wayne Su <mstarmstar@gmail.com>\n"
 "Language-Team: \n"
@@ -208,83 +208,83 @@ msgstr "無法開啟 ED2K 連結檔。"
 msgid "WARNING: You can't add yourself as a source for an eD2k link while having a lowid."
 msgstr "警告：LowID 時不可以將自己加入 eD2k 連結來源。"
 
-#: src/amule.cpp:300
+#: src/amule.cpp:301
 msgid "Now, exiting main app..."
 msgstr "正在離開主程式..."
 
-#: src/amule.cpp:330
+#: src/amule.cpp:331
 #, c-format
 msgid "Terminating amuleweb instance with pid '%d' ... "
 msgstr "正在終止 pid %d 的 amuleweb 執行緒... "
 
-#: src/amule.cpp:334
+#: src/amule.cpp:335
 #, c-format
 msgid "Killing amuleweb instance with pid '%d' ... "
 msgstr "正在強行終止 pid %d 的 amuleweb 執行緒... "
 
-#: src/amule.cpp:336 src/amule.cpp:349 src/ClientRef.cpp:180
+#: src/amule.cpp:337 src/amule.cpp:350 src/ClientRef.cpp:180
 #: src/SearchDlg.cpp:1041 src/ServerListCtrl.cpp:98
 msgid "Failed"
 msgstr "失敗"
 
-#: src/amule.cpp:343
+#: src/amule.cpp:344
 #, fuzzy, c-format
 msgid "Terminating amuleapi instance with pid '%d' ... "
 msgstr "正在終止 pid %d 的 amuleweb 執行緒... "
 
-#: src/amule.cpp:347
+#: src/amule.cpp:348
 #, fuzzy, c-format
 msgid "Killing amuleapi instance with pid '%d' ... "
 msgstr "正在強行終止 pid %d 的 amuleweb 執行緒... "
 
-#: src/amule.cpp:355
+#: src/amule.cpp:356
 msgid "aMule OnExit: Terminating core."
 msgstr "aMule 離開中：正在終止主程式。"
 
-#: src/amule.cpp:466
+#: src/amule.cpp:467
 msgid "aMule shutdown completed."
 msgstr "已關閉 aMule 。"
 
-#: src/amule.cpp:470
+#: src/amule.cpp:471
 msgid "Memory debug results for aMule exit:"
 msgstr "離開 aMule 時記憶體除錯結果："
 
-#: src/amule.cpp:651
+#: src/amule.cpp:652
 #, c-format
 msgid "Binding aMule's peer-to-peer traffic to interface: %s (HTTP updates use the default route)"
 msgstr ""
 
-#: src/amule.cpp:655
+#: src/amule.cpp:656
 #, c-format
 msgid "Binding all network traffic to interface: %s"
 msgstr ""
 
-#: src/amule.cpp:659
+#: src/amule.cpp:660
 #, c-format
 msgid "WARNING: configured network interface '%s' was not found - traffic is NOT bound to it and may leave via the default route. Check the interface name in Preferences."
 msgstr ""
 
-#: src/amule.cpp:665
+#: src/amule.cpp:666
 #, c-format
 msgid "WARNING: binding to network interface '%s' requires elevated privileges and was NOT applied - traffic may leave via the default route. Grant the capability (e.g. 'sudo setcap cap_net_raw+ep' on the aMule binary) or run with sufficient privileges."
 msgstr ""
 
-#: src/amule.cpp:673
+#: src/amule.cpp:674
 #, c-format
 msgid "WARNING: could not bind to network interface '%s' - traffic may leave via the default route."
 msgstr ""
 
-#: src/amule.cpp:732
+#: src/amule.cpp:733
 msgid "Your locale has been changed to System Default due to a configuration change. Sorry."
 msgstr "對不起，由於版本變更，您的地區設定已經被變更爲系統預設值。"
 
-#: src/amule.cpp:734 src/amule.cpp:1581 src/CatDialog.cpp:128
+#: src/amule.cpp:735 src/amule.cpp:1589 src/CatDialog.cpp:128
 #: src/CatDialog.cpp:136 src/CatDialog.cpp:149 src/ServerList.cpp:366
 #: src/ServerListCtrl.cpp:152
 msgid "Info"
 msgstr "資訊"
 
-#: src/amule.cpp:741
+#: src/amule.cpp:742
 msgid ""
 "\n"
 "EC configuration"
@@ -292,74 +292,74 @@ msgstr ""
 "\n"
 "外部連線設定"
 
-#: src/amule.cpp:744
+#: src/amule.cpp:745
 msgid "Password set and external connections enabled."
 msgstr "密碼已設定，外部連線已啟用。"
 
-#: src/amule.cpp:754 src/KadDlg.cpp:176 src/KadDlg.cpp:185
-#: src/PrefsUnifiedDlg.cpp:1387 src/SharedFilesCtrl.cpp:476
+#: src/amule.cpp:755 src/KadDlg.cpp:176 src/KadDlg.cpp:185
+#: src/PrefsUnifiedDlg.cpp:1461 src/SharedFilesCtrl.cpp:476
 msgid "WARNING"
 msgstr "警告"
 
-#: src/amule.cpp:991
+#: src/amule.cpp:992
 #, fuzzy
 msgid "Network bootstrap"
 msgstr "網路"
 
-#: src/amule.cpp:996
+#: src/amule.cpp:997
 msgid ""
 "aMule has detected missing network bootstrap files.\n"
 "Select which ones to download:"
 msgstr ""
 
-#: src/amule.cpp:1005 src/FirstRunWizard.cpp:411
+#: src/amule.cpp:1006 src/FirstRunWizard.cpp:411
 #, fuzzy
 msgid "eD2k server list (server.met)"
 msgstr "在 server.met 中找到 %i 個伺服器"
 
-#: src/amule.cpp:1012 src/FirstRunWizard.cpp:416
+#: src/amule.cpp:1013 src/FirstRunWizard.cpp:416
 msgid "Kad bootstrap nodes (nodes.dat)"
 msgstr ""
 
-#: src/amule.cpp:1102
+#: src/amule.cpp:1103
 #, c-format
 msgid "web server running on pid %d"
 msgstr "執行中的網站伺服器 pid：%d"
 
-#: src/amule.cpp:1115
+#: src/amule.cpp:1116
 #, fuzzy
 msgid "You requested to run web server on startup, but the amuleweb binary cannot be run. Please install the package containing aMule web server, or build aMule from source with -DBUILD_WEBSERVER=YES and install it."
 msgstr "您要求啟動時執行網站伺服器，但系統無法執行 amuleweb。請安裝含有 aMule 網站伺服器的套件，或於編譯 aMule 程式碼時加入 --enable-webserver 選項"
 
-#: src/amule.cpp:1120 src/amule.cpp:1177 src/amule.cpp:1291 src/amule.cpp:1593
+#: src/amule.cpp:1121 src/amule.cpp:1185 src/amule.cpp:1299 src/amule.cpp:1601
 #: src/amule-remote-gui.cpp:603 src/amule-remote-gui.cpp:671
 #: src/amule-remote-gui.cpp:709 src/amule-remote-gui.cpp:1282
 #: src/amule-remote-gui.cpp:1345 src/amule-remote-gui.cpp:1372
-#: src/DownloadQueue.cpp:1481
+#: src/DownloadQueue.cpp:1481 src/PrefsUnifiedDlg.cpp:1247
 msgid "ERROR"
 msgstr "錯誤"
 
-#: src/amule.cpp:1166
+#: src/amule.cpp:1174
 #, fuzzy, c-format
 msgid "amuleapi running on pid %d"
 msgstr "執行中的網站伺服器 pid：%d"
 
-#: src/amule.cpp:1172
+#: src/amule.cpp:1180
 #, fuzzy
 msgid "You requested to run amuleapi on startup, but the amuleapi binary cannot be run. Please install the package containing aMule's REST API server, or build aMule from source with -DBUILD_AMULEAPI=YES and install it."
 msgstr "您要求啟動時執行網站伺服器，但系統無法執行 amuleweb。請安裝含有 aMule 網站伺服器的套件，或於編譯 aMule 程式碼時加入 --enable-webserver 選項"
 
-#: src/amule.cpp:1259
+#: src/amule.cpp:1267
 #, c-format
 msgid "Could not bind ports to the specified address: %s"
 msgstr "無法選定使用此位址的通訊埠：%s"
 
-#: src/amule.cpp:1283
+#: src/amule.cpp:1291
 #, c-format
 msgid "Port %u is not available. You will be LOWID\n"
 msgstr "通訊埠 %u 已被佔用。您會變成 LOWID。\n"
 
-#: src/amule.cpp:1288
+#: src/amule.cpp:1296
 #, c-format
 msgid ""
 "Port %u is not available!\n"
@@ -374,48 +374,48 @@ msgstr ""
 "\n"
 "請檢查網路設定以確保通訊埠可正常使用。"
 
-#: src/amule.cpp:1385
+#: src/amule.cpp:1393
 msgid "Failed to create OnlineSig File"
 msgstr "無法建立線上簽名識別檔"
 
-#: src/amule.cpp:1393
+#: src/amule.cpp:1401
 msgid "Failed to create aMule OnlineSig File"
 msgstr "無法建立 aMule 線上簽名識別檔"
 
-#: src/amule.cpp:1556
+#: src/amule.cpp:1564
 msgid "The selected locale seems not to be installed on your box. (Note: I'll try to set it anyway)"
 msgstr "在您的電腦上似乎沒有安裝您所選取的地區設定。 (但仍會採用您所選擇的設定)"
 
-#: src/amule.cpp:1566
+#: src/amule.cpp:1574
 #, c-format
 msgid "This is the first time you run aMule %s"
 msgstr "這是您第一次執行 aMule %s"
 
-#: src/amule.cpp:1569
+#: src/amule.cpp:1577
 msgid "This version is a testing version, updated daily, and\n"
 msgstr "這個版本是測試版，每日有更新，\n"
 
-#: src/amule.cpp:1570
+#: src/amule.cpp:1578
 msgid "we give no warranty it won't break anything, burn your house,\n"
 msgstr "但我們無法擔保它不會造成任何損害、燒掉您的房子、\n"
 
-#: src/amule.cpp:1571
+#: src/amule.cpp:1579
 msgid "or kill your dog. But it *should* be safe to use anyway.\n"
 msgstr "或害死您的狗。但一般來講它「應該」是安全的。\n"
 
-#: src/amule.cpp:1576
+#: src/amule.cpp:1584
 msgid "More information, support and new releases can found at our homepage,\n"
 msgstr "在我們的網頁可找到更多資訊、使用者支援以及程式最新版本：\n"
 
-#: src/amule.cpp:1577
+#: src/amule.cpp:1585
 msgid "at https://amule-org.github.io, or in our IRC channel #aMule at irc.libera.chat.\n"
 msgstr "https://amule-org.github.io，或我們在 irc.libera.chat 的 IRC 頻道 #aMule。\n"
 
-#: src/amule.cpp:1579
+#: src/amule.cpp:1587
 msgid "Feel free to report any bugs to https://github.com/amule-org/amule/issues"
 msgstr "歡迎您到 https://github.com/amule-org/amule/issues 提出錯誤報告"
 
-#: src/amule.cpp:1591
+#: src/amule.cpp:1599
 msgid ""
 "The folder for Online Signature files you specified is INVALID!\n"
 " OnlineSignature will be DISABLED until you fix it on preferences."
@@ -423,137 +423,137 @@ msgstr ""
 "您選擇的線上簽名識別檔案所在資料夾無效！\n"
 " 在您變更偏好設定之前，線上簽名識別功能將被停用。"
 
-#: src/amule.cpp:1654
+#: src/amule.cpp:1662
 msgid "Server hostname notified"
 msgstr "已通伺服器主機名稱"
 
-#: src/amule.cpp:2031
+#: src/amule.cpp:2039
 #, c-format
 msgid "Disk space preallocation for file '%s' failed: %s"
 msgstr "無法為檔案 %s 預先分配磁碟空間：%s"
 
-#: src/amule.cpp:2160
+#: src/amule.cpp:2168
 msgid "ERROR: can't open logfile"
 msgstr "錯誤：無法開啟記錄檔"
 
-#: src/amule.cpp:2164
+#: src/amule.cpp:2172
 msgid "WARNING: logfile is empty. Something is wrong."
 msgstr "警告：沒有記錄檔，肯定有什麽地方出錯了。"
 
-#: src/amule.cpp:2181
+#: src/amule.cpp:2189
 msgid "Log has been reset"
 msgstr "記錄已被清除"
 
-#: src/amule.cpp:2205
+#: src/amule.cpp:2213
 #, c-format
 msgid "ServerMessage: %s"
 msgstr "伺服器訊息：%s"
 
-#: src/amule.cpp:2248 src/IP2Country.cpp:220 src/IPFilter.cpp:514
+#: src/amule.cpp:2256 src/IP2Country.cpp:220 src/IPFilter.cpp:514
 #: src/ServerList.cpp:875
 #, c-format
 msgid "Skipped download of %s, because requested file is not newer."
 msgstr "略過不下載 %s ，因為並不是新近檔案。"
 
-#: src/amule.cpp:2251
+#: src/amule.cpp:2259
 msgid "Failed to download the nodes list."
 msgstr "無法下載節點清單。"
 
-#: src/amule.cpp:2314
+#: src/amule.cpp:2322
 msgid "Failed to open the downloaded version check file"
 msgstr "無法開啟下載的版本檢查檔"
 
-#: src/amule.cpp:2317 src/amule.cpp:2336
+#: src/amule.cpp:2325 src/amule.cpp:2344
 msgid "Corrupted version check file"
 msgstr "損壞的版本檢查檔"
 
-#: src/amule.cpp:2359
+#: src/amule.cpp:2367
 msgid "You are using an outdated version of aMule!"
 msgstr "您使用的是過期的 aMule 版本！"
 
-#: src/amule.cpp:2361
+#: src/amule.cpp:2369
 #, c-format
 msgid "Your aMule version is %i.%i.%i and the latest version is %li.%li.%li"
 msgstr "您的 aMule 版本是 %i.%i.%i，最新版本是 %li.%li.%li"
 
-#: src/amule.cpp:2365
+#: src/amule.cpp:2373
 msgid "The latest version can always be found at https://github.com/amule-org/amule/releases/latest"
 msgstr "最新版本可從這裏下載：https://github.com/amule-org/amule/releases/latest"
 
-#: src/amule.cpp:2368
+#: src/amule.cpp:2376
 #, c-format
 msgid "WARNING: Your aMuled version is outdated: %i.%i.%i < %li.%li.%li"
 msgstr "警告：您的 aMuled 版本已經過期：%i.%i.%i < %li.%li.%li"
 
-#: src/amule.cpp:2374
+#: src/amule.cpp:2382
 msgid "Your copy of aMule is up to date."
 msgstr "您的 aMule 是最新版本。"
 
-#: src/amule.cpp:2381
+#: src/amule.cpp:2389
 msgid "Failed to download the version check file"
 msgstr "無法下載版本檢查檔"
 
-#: src/amule.cpp:2550 src/amule-remote-gui.cpp:1133
+#: src/amule.cpp:2558 src/amule-remote-gui.cpp:1133
 #, c-format
 msgid "Users: %s | Files: %s"
 msgstr "使用者：%s | 檔案：%s"
 
-#: src/amule.cpp:2551 src/amule-remote-gui.cpp:1134
+#: src/amule.cpp:2559 src/amule-remote-gui.cpp:1134
 #, c-format
 msgid "Users: E: %s K: %s | Files: E: %s K: %s"
 msgstr "使用者：E:%s K:%s | 檔案：E:%s K:%s"
 
-#: src/amule.cpp:2565 src/amule-remote-gui.cpp:1147
+#: src/amule.cpp:2573 src/amule-remote-gui.cpp:1147
 msgid "No networks selected"
 msgstr "未選取網路"
 
-#: src/amule.cpp:2633 src/TextClient.cpp:903
+#: src/amule.cpp:2641 src/TextClient.cpp:903
 msgid "with LowID"
 msgstr "有 LowID"
 
-#: src/amule.cpp:2633 src/TextClient.cpp:904
+#: src/amule.cpp:2641 src/TextClient.cpp:904
 msgid "with HighID"
 msgstr "有 HighID"
 
-#: src/amule.cpp:2635
+#: src/amule.cpp:2643
 #, c-format
 msgid "Connected to %s %s"
 msgstr "已連線到 %s %s"
 
-#: src/amule.cpp:2640
+#: src/amule.cpp:2648
 #, c-format
 msgid "Connecting to %s"
 msgstr "正在連線到 %s"
 
-#: src/amule.cpp:2642
+#: src/amule.cpp:2650
 msgid "Disconnected from eD2k"
 msgstr "已中斷 eD2k 網路連線"
 
-#: src/amule.cpp:2651
+#: src/amule.cpp:2659
 msgid "Kad started."
 msgstr "Kad 已啓動。"
 
-#: src/amule.cpp:2653
+#: src/amule.cpp:2661
 msgid "Kad stopped."
 msgstr "Kad 已停止。"
 
-#: src/amule.cpp:2661
+#: src/amule.cpp:2669
 msgid "Connected to Kad (ok)"
 msgstr "已連線到 Kad"
 
-#: src/amule.cpp:2663
+#: src/amule.cpp:2671
 msgid "Connected to Kad (firewalled)"
 msgstr "已連線到 Kad 網路 (防火牆內)"
 
-#: src/amule.cpp:2667
+#: src/amule.cpp:2675
 msgid "Disconnected from Kad"
 msgstr "已中斷 Kad 網路連線"
 
-#: src/amule.cpp:2699
+#: src/amule.cpp:2707
 msgid "Kad network cannot be used if UDP port is disabled on preferences, not starting."
 msgstr "Kad 網路未啟動：如果在偏好設定中停用了 UDP 埠，Kad 網路將不能使用。"
 
-#: src/amule.cpp:2703
+#: src/amule.cpp:2711
 msgid "Kad network disabled on preferences, not connecting."
 msgstr "Kad 網路在偏好設定中被停用了，沒有連線。"
 
@@ -598,36 +598,36 @@ msgid "FATAL ERROR: Failed to create Timer"
 msgstr "嚴重錯誤：無法建立計時器"
 
 #: src/amuleDlg.cpp:361 src/amuleDlg.cpp:1787 src/amuleDlg.cpp:2033
-#: src/muuli_wdr.cpp:1492 src/muuli_wdr.cpp:3418
+#: src/muuli_wdr.cpp:1492 src/muuli_wdr.cpp:3449
 msgid "Networks"
 msgstr "網路"
 
-#: src/amuleDlg.cpp:362 src/amuleDlg.cpp:1793 src/muuli_wdr.cpp:3419
+#: src/amuleDlg.cpp:362 src/amuleDlg.cpp:1793 src/muuli_wdr.cpp:3450
 msgid "Searches"
 msgstr "搜尋"
 
 #: src/amuleDlg.cpp:363 src/amuleDlg.cpp:1799 src/DownloadListCtrl.cpp:740
-#: src/muuli_wdr.cpp:392 src/muuli_wdr.cpp:1585 src/muuli_wdr.cpp:3420
+#: src/muuli_wdr.cpp:392 src/muuli_wdr.cpp:1585 src/muuli_wdr.cpp:3451
 #: src/Statistics.cpp:829
 msgid "Downloads"
 msgstr "下載"
 
-#: src/amuleDlg.cpp:364 src/amuleDlg.cpp:1805 src/muuli_wdr.cpp:3294
+#: src/amuleDlg.cpp:364 src/amuleDlg.cpp:1805 src/muuli_wdr.cpp:3325
 msgid "Shared files"
 msgstr "檔案分享"
 
-#: src/amuleDlg.cpp:365 src/amuleDlg.cpp:1811 src/muuli_wdr.cpp:2926
-#: src/muuli_wdr.cpp:3376 src/muuli_wdr.cpp:3423
+#: src/amuleDlg.cpp:365 src/amuleDlg.cpp:1811 src/muuli_wdr.cpp:2957
+#: src/muuli_wdr.cpp:3407 src/muuli_wdr.cpp:3454
 msgid "Messages"
 msgstr "訊息"
 
-#: src/amuleDlg.cpp:366 src/amuleDlg.cpp:1817 src/muuli_wdr.cpp:3424
-#: src/PrefsUnifiedDlg.cpp:312 src/Statistics.cpp:779 src/Statistics.cpp:1235
+#: src/amuleDlg.cpp:366 src/amuleDlg.cpp:1817 src/muuli_wdr.cpp:3455
+#: src/PrefsUnifiedDlg.cpp:314 src/Statistics.cpp:779 src/Statistics.cpp:1235
 msgid "Statistics"
 msgstr "統計"
 
-#: src/amuleDlg.cpp:368 src/amuleDlg.cpp:1824 src/muuli_wdr.cpp:3426
-#: src/PrefsUnifiedDlg.cpp:328 src/utils/wxCas/src/wxcasprefs.cpp:39
+#: src/amuleDlg.cpp:368 src/amuleDlg.cpp:1824 src/muuli_wdr.cpp:3457
+#: src/PrefsUnifiedDlg.cpp:330 src/utils/wxCas/src/wxcasprefs.cpp:39
 msgid "Preferences"
 msgstr "偏好設定"
 
@@ -685,8 +685,8 @@ msgstr "Kad：關閉"
 #: src/amuleDlg.cpp:1029 src/DownloadListCtrl.cpp:505
 #: src/DownloadListCtrl.cpp:749 src/FriendListCtrl.cpp:180
 #: src/muuli_wdr.cpp:731 src/muuli_wdr.cpp:782 src/muuli_wdr.cpp:846
-#: src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2231 src/muuli_wdr.cpp:2316
-#: src/muuli_wdr.cpp:3064 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
+#: src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2262 src/muuli_wdr.cpp:2347
+#: src/muuli_wdr.cpp:3095 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
 #: src/ServerListCtrl.cpp:606 src/TransferWnd.cpp:378
 #: src/utils/wxCas/src/wxcasprefs.cpp:235
 msgid "Cancel"
@@ -697,7 +697,7 @@ msgid "Stop the current connection attempts"
 msgstr "停止連線作業"
 
 #: src/amuleDlg.cpp:1035 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976
-#: src/muuli_wdr.cpp:2454
+#: src/muuli_wdr.cpp:2485
 msgid "Disconnect"
 msgstr "中斷連線"
 
@@ -706,7 +706,7 @@ msgid "Disconnect from the currently connected networks"
 msgstr "中斷已連線的網路"
 
 #: src/amuleDlg.cpp:1041 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979
-#: src/muuli_wdr.cpp:2609 src/muuli_wdr.cpp:3061 src/muuli_wdr.cpp:3416
+#: src/muuli_wdr.cpp:2640 src/muuli_wdr.cpp:3092 src/muuli_wdr.cpp:3447
 msgid "Connect"
 msgstr "連線"
 
@@ -761,7 +761,7 @@ msgstr "確認離開"
 msgid "Launch Command: "
 msgstr "執行指令："
 
-#: src/amuleDlg.cpp:1632 src/muuli_wdr.cpp:1978 src/Preferences.cpp:952
+#: src/amuleDlg.cpp:1632 src/muuli_wdr.cpp:1982 src/Preferences.cpp:979
 msgid "- default -"
 msgstr "- 預設 -"
 
@@ -775,48 +775,48 @@ msgstr "面板目錄 %s 不存在"
 msgid "WARNING: Unable to open skin file '%s' for read"
 msgstr "警告：無法開啟面板檔案 %s 供讀取"
 
-#: src/amuleDlg.cpp:1791 src/muuli_wdr.cpp:3418
+#: src/amuleDlg.cpp:1791 src/muuli_wdr.cpp:3449
 msgid "Networks Window"
 msgstr "網路 視窗"
 
-#: src/amuleDlg.cpp:1797 src/muuli_wdr.cpp:3419
+#: src/amuleDlg.cpp:1797 src/muuli_wdr.cpp:3450
 msgid "Searches Window"
 msgstr "搜尋 視窗"
 
-#: src/amuleDlg.cpp:1803 src/muuli_wdr.cpp:3420
+#: src/amuleDlg.cpp:1803 src/muuli_wdr.cpp:3451
 msgid "Downloads Window"
 msgstr "下載 視窗"
 
-#: src/amuleDlg.cpp:1809 src/muuli_wdr.cpp:3422
+#: src/amuleDlg.cpp:1809 src/muuli_wdr.cpp:3453
 msgid "Shared Files Window"
 msgstr "檔案分享 視窗"
 
-#: src/amuleDlg.cpp:1815 src/muuli_wdr.cpp:3423
+#: src/amuleDlg.cpp:1815 src/muuli_wdr.cpp:3454
 msgid "Messages Window"
 msgstr "訊息 視窗"
 
-#: src/amuleDlg.cpp:1821 src/muuli_wdr.cpp:3424
+#: src/amuleDlg.cpp:1821 src/muuli_wdr.cpp:3455
 msgid "Statistics Graph Window"
 msgstr "統計 視窗"
 
-#: src/amuleDlg.cpp:1828 src/muuli_wdr.cpp:3426
+#: src/amuleDlg.cpp:1828 src/muuli_wdr.cpp:3457
 msgid "Preferences Settings Window"
 msgstr "偏好設定 視窗"
 
-#: src/amuleDlg.cpp:1831 src/muuli_wdr.cpp:3427
+#: src/amuleDlg.cpp:1831 src/muuli_wdr.cpp:3458
 msgid "Import"
 msgstr "匯入"
 
-#: src/amuleDlg.cpp:1835 src/muuli_wdr.cpp:3427
+#: src/amuleDlg.cpp:1835 src/muuli_wdr.cpp:3458
 msgid "The partfile importer tool"
 msgstr "暫存檔匯入工具"
 
-#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3428
+#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3459
 #: src/utils/aLinkCreator/src/alcframe.cpp:262
 msgid "About"
 msgstr "關於"
 
-#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3428
+#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3459
 msgid "About/Help"
 msgstr "關於/幫助"
 
@@ -958,7 +958,7 @@ msgstr "找不到檔案。"
 msgid "The core rejected these shared folders:%s"
 msgstr ""
 
-#: src/amule-remote-gui.cpp:1336 src/ExternalConn.cpp:2345
+#: src/amule-remote-gui.cpp:1336 src/ExternalConn.cpp:2346
 msgid "Invalid link or already on list."
 msgstr "無效連結或已在清單中。"
 
@@ -974,7 +974,7 @@ msgstr "無法建立 %s 目錄 ( %s 分類用)，繼續使用 %s 目錄。"
 #: src/ClientDetailDialog.cpp:123 src/DataToText.cpp:61 src/DataToText.cpp:86
 #: src/DataToText.cpp:101 src/DataToText.cpp:136 src/DataToText.cpp:165
 #: src/DownloadListCtrl.cpp:1172 src/DownloadListCtrl.cpp:1185
-#: src/DownloadListCtrl.cpp:1196 src/ExternalConn.cpp:608
+#: src/DownloadListCtrl.cpp:1196 src/ExternalConn.cpp:609
 #: src/FileDetailDialog.cpp:203 src/FileDetailDialog.cpp:235
 #: src/FileDetailDialog.cpp:242 src/GenericClientListCtrl.cpp:1171
 #: src/GenericClientListCtrl.cpp:1182 src/GenericClientListCtrl.cpp:1192
@@ -1356,19 +1356,19 @@ msgstr "自動 [高]"
 msgid "Very low"
 msgstr "極低"
 
-#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:743 src/muuli_wdr.cpp:2282
+#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:743 src/muuli_wdr.cpp:2313
 #: src/ServerListCtrl.cpp:263 src/ServerListCtrl.cpp:456
 #: src/SharedFilesCtrl.cpp:145
 msgid "Low"
 msgstr "低"
 
-#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:744 src/muuli_wdr.cpp:2283
+#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:744 src/muuli_wdr.cpp:2314
 #: src/ServerListCtrl.cpp:266 src/ServerListCtrl.cpp:457
 #: src/SharedFilesCtrl.cpp:146
 msgid "Normal"
 msgstr "普通"
 
-#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:745 src/muuli_wdr.cpp:2284
+#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:745 src/muuli_wdr.cpp:2315
 #: src/ServerListCtrl.cpp:269 src/ServerListCtrl.cpp:458
 #: src/SharedFilesCtrl.cpp:147
 msgid "High"
@@ -1460,7 +1460,7 @@ msgstr "本地伺服器"
 msgid "Remote Server"
 msgstr "遠端伺服器"
 
-#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3181
+#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3212
 #: src/SearchDlg.cpp:119 src/TextClient.cpp:911
 msgid "Kad"
 msgstr "Kad"
@@ -1532,7 +1532,7 @@ msgstr "部份"
 msgid "Size"
 msgstr "大小"
 
-#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3248
+#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3279
 msgid "Transferred"
 msgstr "已傳輸"
 
@@ -1590,7 +1590,7 @@ msgstr ""
 "%s (%s) 回覆訊息\n"
 "\n"
 
-#: src/DownloadListCtrl.cpp:746 src/muuli_wdr.cpp:2285
+#: src/DownloadListCtrl.cpp:746 src/muuli_wdr.cpp:2316
 #: src/SharedFilesCtrl.cpp:150
 msgid "Auto"
 msgstr "自動"
@@ -1628,7 +1628,7 @@ msgid "Extended Options"
 msgstr "擴充選項"
 
 #: src/DownloadListCtrl.cpp:770 src/DownloadListCtrl.cpp:822
-#: src/muuli_wdr.cpp:1796
+#: src/muuli_wdr.cpp:1800
 msgid "Preview"
 msgstr "預覽"
 
@@ -1801,227 +1801,232 @@ msgstr[0] ""
 msgid "Invalid eD2k link! ERROR: %s"
 msgstr "無效的 eD2k 連結！錯誤：%s "
 
-#: src/ExternalConn.cpp:379
+#: src/ExternalConn.cpp:380
 msgid "Client sent packet after authentication failed."
 msgstr "客戶端在驗證失敗後傳送封包。"
 
-#: src/ExternalConn.cpp:396
+#: src/ExternalConn.cpp:397
 msgid "External connection closed."
 msgstr "已關閉外部連線。"
 
-#: src/ExternalConn.cpp:473
+#: src/ExternalConn.cpp:474
 msgid "External connections disabled due to empty password!"
 msgstr "未設定密碼，外部連線已被停用！"
 
-#: src/ExternalConn.cpp:494
+#: src/ExternalConn.cpp:495
 msgid "External connections disabled in config file"
 msgstr "已在設定檔中停用外部連線"
 
-#: src/ExternalConn.cpp:575
+#: src/ExternalConn.cpp:576
 msgid "New external connection accepted"
 msgstr "已接受新的外部連線"
 
-#: src/ExternalConn.cpp:578
+#: src/ExternalConn.cpp:579
 msgid "ERROR: couldn't accept a new external connection"
 msgstr "錯誤：無法接受新的外部連線"
 
-#: src/ExternalConn.cpp:595
+#: src/ExternalConn.cpp:596
 msgid "External connection refused due to empty password in preferences!"
 msgstr "由於偏好設定中未設定密碼，外部連線已被拒絕！"
 
-#: src/ExternalConn.cpp:607
+#: src/ExternalConn.cpp:608
 #, c-format
 msgid "Connecting client: %s %s"
 msgstr "連線中客戶端：%s %s"
 
-#: src/ExternalConn.cpp:609
+#: src/ExternalConn.cpp:610
 msgid "Unknown version"
 msgstr "不明版本"
 
-#: src/ExternalConn.cpp:622
+#: src/ExternalConn.cpp:623
 msgid "Incorrect EC version ID, there might be binary incompatibility. Use core and remote from same snapshot."
 msgstr "不正確的外部連線版本 ID，這將導致執行檔不相容，請使用相同版本的主程式和遠端程式。"
 
-#: src/ExternalConn.cpp:630
+#: src/ExternalConn.cpp:631
 msgid "You cannot connect to a release version from an arbitrary development snapshot! *sigh* possible crash prevented"
 msgstr "您不能用開發中版本 (SVN) 連線到正式發行版，這是為了避免系統遭受不確定的損害"
 
-#: src/ExternalConn.cpp:713
+#: src/ExternalConn.cpp:714
 msgid "Invalid protocol version."
 msgstr "協定版本無效。"
 
-#: src/ExternalConn.cpp:719
+#: src/ExternalConn.cpp:720
 msgid "Missing protocol version tag."
 msgstr "缺少協定版本標記。"
 
-#: src/ExternalConn.cpp:727
+#: src/ExternalConn.cpp:728
 msgid "Authentication failed: invalid hash specified as EC password."
 msgstr "驗證失敗：指定無效的 hash 值做為外部連線密碼。"
 
-#: src/ExternalConn.cpp:775
+#: src/ExternalConn.cpp:776
 msgid "Authentication failed: wrong password."
 msgstr "驗證失敗：密碼錯誤。"
 
-#: src/ExternalConn.cpp:777
+#: src/ExternalConn.cpp:778
 msgid "Authentication failed: missing password."
 msgstr "驗證失敗：沒有密碼。"
 
-#: src/ExternalConn.cpp:788
+#: src/ExternalConn.cpp:789
 msgid "Invalid request, please authenticate first."
 msgstr "無效的要求，請先通過登入驗證。"
 
-#: src/ExternalConn.cpp:793
+#: src/ExternalConn.cpp:794
 msgid "Access granted."
 msgstr "登入成功。"
 
-#: src/ExternalConn.cpp:801
+#: src/ExternalConn.cpp:802
 #, c-format
 msgid "Sent error message \"%s\" to client."
 msgstr "傳送錯誤訊息「%s」給客戶端。"
 
-#: src/ExternalConn.cpp:806
+#: src/ExternalConn.cpp:807
 #, c-format
 msgid "Unauthorized access attempt from %s. Connection closed."
 msgstr "%s 試圖非法登入，已關閉連線。"
 
-#: src/ExternalConn.cpp:1419
+#: src/ExternalConn.cpp:1420
 #, c-format
 msgid "Remote PartFile command failed: FileHash not found: %s"
 msgstr "無法執行對遠端暫存檔的指令：找不到檔案 hash 值：%s "
 
-#: src/ExternalConn.cpp:1423
+#: src/ExternalConn.cpp:1424
 #, c-format
 msgid "FileHash not found: %s"
 msgstr "找不到檔案 hash 值：%s "
 
-#: src/ExternalConn.cpp:1470 src/ExternalConn.cpp:1558
-#: src/ExternalConn.cpp:1679
+#: src/ExternalConn.cpp:1471 src/ExternalConn.cpp:1559
+#: src/ExternalConn.cpp:1680
 msgid "OOPS! OpCode processing error!"
 msgstr "糟糕！指令碼處理錯誤！"
 
-#: src/ExternalConn.cpp:1501
+#: src/ExternalConn.cpp:1502
 msgid "Server not added"
 msgstr "伺服器未被加入"
 
-#: src/ExternalConn.cpp:1520
+#: src/ExternalConn.cpp:1521
 #, c-format
 msgid "server not found: %s"
 msgstr "找不到伺服器：%s "
 
-#: src/ExternalConn.cpp:1537
+#: src/ExternalConn.cpp:1538
 msgid "need to define server to be removed"
 msgstr "必須指定要刪除的伺服器"
 
-#: src/ExternalConn.cpp:1552
+#: src/ExternalConn.cpp:1553
 msgid "eD2k is disabled in preferences."
 msgstr "eD2k 網路已在偏好設定中被停用了。"
 
-#: src/ExternalConn.cpp:1657
+#: src/ExternalConn.cpp:1658
 #, fuzzy
 msgid "Friend not found."
 msgstr "找不到檔案。"
 
-#: src/ExternalConn.cpp:1667
+#: src/ExternalConn.cpp:1668
 #, fuzzy
 msgid "Client not found."
 msgstr "找不到檔案。"
 
-#: src/ExternalConn.cpp:1673
+#: src/ExternalConn.cpp:1674
 msgid "EC_TAG_FRIEND_SHARED requires EC_TAG_FRIEND or EC_TAG_CLIENT."
 msgstr ""
 
-#: src/ExternalConn.cpp:1991
+#: src/ExternalConn.cpp:1992
 msgid "WebSearch from remote interface makes no sense."
 msgstr "從遠端界面使用網頁搜尋功能沒有意義。"
 
-#: src/ExternalConn.cpp:2026
+#: src/ExternalConn.cpp:2027
 msgid "Search in progress. Refetch results in a moment!"
 msgstr "搜尋中，請稍候！"
 
-#: src/ExternalConn.cpp:2265
+#: src/ExternalConn.cpp:2266
 msgid "No points for graph."
 msgstr "此圖沒有參考點。"
 
-#: src/ExternalConn.cpp:2275
+#: src/ExternalConn.cpp:2276
 msgid "Your client is not configured for this detail level."
 msgstr "您的客戶端並沒有設定這個細部等級。"
 
-#: src/ExternalConn.cpp:2302
+#: src/ExternalConn.cpp:2303
 msgid "External Connection: shutdown requested"
 msgstr "外部連線：必須關閉"
 
-#: src/ExternalConn.cpp:2314
+#: src/ExternalConn.cpp:2315
 msgid "Already shutting down."
 msgstr "已經在關閉中。"
 
-#: src/ExternalConn.cpp:2332
+#: src/ExternalConn.cpp:2333
 #, c-format
 msgid "ExternalConn: adding link '%s'."
 msgstr "外部連線：正在加入連結 %s 。"
 
-#: src/ExternalConn.cpp:2350
+#: src/ExternalConn.cpp:2351
 #, fuzzy, c-format
 msgid "%d of %d links failed (invalid or already on list)."
 msgstr "無效連結或已在清單中。"
 
-#: src/ExternalConn.cpp:2373
+#: src/ExternalConn.cpp:2374
 msgid "Version check throttled; try again shortly."
 msgstr ""
 
-#: src/ExternalConn.cpp:2378
+#: src/ExternalConn.cpp:2379
 msgid "Version check is not available on this daemon."
 msgstr ""
 
-#: src/ExternalConn.cpp:2508
+#: src/ExternalConn.cpp:2509
 msgid "File not found."
 msgstr "找不到檔案。"
 
-#: src/ExternalConn.cpp:2513
+#: src/ExternalConn.cpp:2514
 msgid "Invalid file name."
 msgstr "無效的檔名。"
 
-#: src/ExternalConn.cpp:2521
+#: src/ExternalConn.cpp:2522
 msgid "Unable to rename file."
 msgstr "無法重新命名。"
 
-#: src/ExternalConn.cpp:2992 src/ExternalConn.cpp:3020
+#: src/ExternalConn.cpp:2839
+#, c-format
+msgid "Could not save the amuleapi password: %s"
+msgstr ""
+
+#: src/ExternalConn.cpp:3004 src/ExternalConn.cpp:3032
 msgid "Kad is disabled in preferences."
 msgstr "Kad 網路已在偏好設定中被停用了。"
 
-#: src/ExternalConn.cpp:3033
+#: src/ExternalConn.cpp:3045
 msgid "Already connected to eD2k."
 msgstr "eD2k 網路已連線。"
 
-#: src/ExternalConn.cpp:3036
+#: src/ExternalConn.cpp:3048
 msgid "Connecting to eD2k..."
 msgstr "eD2k 連線中..."
 
-#: src/ExternalConn.cpp:3045
+#: src/ExternalConn.cpp:3057
 msgid "Already connected to Kad."
 msgstr "Kad 網路已連線。"
 
-#: src/ExternalConn.cpp:3048
+#: src/ExternalConn.cpp:3060
 msgid "Connecting to Kad..."
 msgstr "Kad 連線中..."
 
-#: src/ExternalConn.cpp:3055
+#: src/ExternalConn.cpp:3067
 msgid "All networks are disabled."
 msgstr "所有網路都被停用了。"
 
-#: src/ExternalConn.cpp:3064
+#: src/ExternalConn.cpp:3076
 msgid "Disconnected from eD2k."
 msgstr "已中斷 eD2k 網路連線。"
 
-#: src/ExternalConn.cpp:3069
+#: src/ExternalConn.cpp:3081
 msgid "Disconnected from Kad."
 msgstr "已中斷 Kad 網路連線。"
 
-#: src/ExternalConn.cpp:3078
+#: src/ExternalConn.cpp:3090
 #, c-format
 msgid "External Connection: invalid opcode received: %#x"
 msgstr "外部連線：接收到無效的指令碼 - %#x"
 
-#: src/ExternalConn.cpp:3083
+#: src/ExternalConn.cpp:3095
 msgid "Invalid opcode (wrong protocol version?)"
 msgstr "無效的指令碼（協定版本錯誤？）"
 
@@ -2422,23 +2427,23 @@ msgid ""
 "want downloads on a different (e.g. larger) disk."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:549 src/FirstRunWizard.cpp:611 src/muuli_wdr.cpp:1708
+#: src/FirstRunWizard.cpp:549 src/FirstRunWizard.cpp:611 src/muuli_wdr.cpp:1712
 msgid "Destination folder for downloads"
 msgstr "下載資料夾"
 
 #: src/FirstRunWizard.cpp:553 src/FirstRunWizard.cpp:569 src/muuli_wdr.cpp:1349
-#: src/muuli_wdr.cpp:1366 src/muuli_wdr.cpp:1683 src/muuli_wdr.cpp:1714
-#: src/muuli_wdr.cpp:1726 src/muuli_wdr.cpp:2769
+#: src/muuli_wdr.cpp:1366 src/muuli_wdr.cpp:1687 src/muuli_wdr.cpp:1718
+#: src/muuli_wdr.cpp:1730 src/muuli_wdr.cpp:2800
 #: src/utils/aLinkCreator/src/alcframe.cpp:135
 #: src/utils/wxCas/src/wxcasprefs.cpp:52 src/utils/wxCas/src/wxcasprefs.cpp:118
 msgid "Browse"
 msgstr "瀏覽"
 
-#: src/FirstRunWizard.cpp:559 src/muuli_wdr.cpp:1719
+#: src/FirstRunWizard.cpp:559 src/muuli_wdr.cpp:1723
 msgid "(All files in this folder are shared with other peers)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:565 src/FirstRunWizard.cpp:624 src/muuli_wdr.cpp:1721
+#: src/FirstRunWizard.cpp:565 src/FirstRunWizard.cpp:624 src/muuli_wdr.cpp:1725
 msgid "Folder for temporary download files"
 msgstr "暫存資料夾"
 
@@ -2469,7 +2474,7 @@ msgstr "無法開啟好友清單檔案 emfriends.met 供寫入！"
 msgid "CRITICAL - no client on StartChatSession"
 msgstr "重大錯誤 - 開始交談時沒有客戶端"
 
-#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2675 src/muuli_wdr.cpp:3352
+#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2706 src/muuli_wdr.cpp:3383
 msgid "Friends"
 msgstr "好友"
 
@@ -2580,8 +2585,8 @@ msgstr "無"
 msgid "No"
 msgstr "否"
 
-#: src/GenericClientListCtrl.cpp:1216 src/PrefsUnifiedDlg.cpp:2818
-#: src/PrefsUnifiedDlg.cpp:2868 src/ServerListCtrl.cpp:276
+#: src/GenericClientListCtrl.cpp:1216 src/PrefsUnifiedDlg.cpp:2898
+#: src/PrefsUnifiedDlg.cpp:2948 src/ServerListCtrl.cpp:276
 msgid "Yes"
 msgstr "是"
 
@@ -2746,10 +2751,10 @@ msgstr "無效的通訊埠"
 msgid "Please fill all fields required"
 msgstr "請填寫所有必要資訊"
 
-#: src/KadDlg.cpp:192 src/PartFile.cpp:1031 src/PrefsUnifiedDlg.cpp:1162
-#: src/PrefsUnifiedDlg.cpp:1331 src/PrefsUnifiedDlg.cpp:1589
-#: src/PrefsUnifiedDlg.cpp:1599 src/PrefsUnifiedDlg.cpp:1616
-#: src/PrefsUnifiedDlg.cpp:1658
+#: src/KadDlg.cpp:192 src/PartFile.cpp:1031 src/PrefsUnifiedDlg.cpp:1134
+#: src/PrefsUnifiedDlg.cpp:1204 src/PrefsUnifiedDlg.cpp:1405
+#: src/PrefsUnifiedDlg.cpp:1663 src/PrefsUnifiedDlg.cpp:1673
+#: src/PrefsUnifiedDlg.cpp:1690 src/PrefsUnifiedDlg.cpp:1738
 msgid "Message"
 msgstr "訊息"
 
@@ -2848,7 +2853,7 @@ msgstr "分享率"
 msgid "Uploaded"
 msgstr "已上傳"
 
-#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3232
+#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3263
 msgid "Requested"
 msgstr "已要求"
 
@@ -2972,7 +2977,7 @@ msgid "WARNING: "
 msgstr "警告："
 
 #: src/MuleNotebook.cpp:179 src/muuli_wdr.cpp:817 src/muuli_wdr.cpp:1229
-#: src/muuli_wdr.cpp:3136 src/muuli_wdr.cpp:3392
+#: src/muuli_wdr.cpp:3167 src/muuli_wdr.cpp:3423
 msgid "Close"
 msgstr "關閉"
 
@@ -2990,7 +2995,7 @@ msgid "Paste"
 msgstr "貼上"
 
 #: src/MuleTextCtrl.cpp:89 src/muuli_wdr.cpp:358 src/muuli_wdr.cpp:757
-#: src/muuli_wdr.cpp:2359 src/muuli_wdr.cpp:2378 src/muuli_wdr.cpp:2400
+#: src/muuli_wdr.cpp:2390 src/muuli_wdr.cpp:2409 src/muuli_wdr.cpp:2431
 #: src/utils/aLinkCreator/src/alcframe.cpp:142
 msgid "Clear"
 msgstr "清除"
@@ -3089,7 +3094,7 @@ msgstr "離開"
 
 #: src/MuleTrayIcon.cpp:579 src/MuleTrayIcon.cpp:945 src/MuleTrayIcon.cpp:965
 #: src/muuli_wdr.cpp:1398 src/muuli_wdr.cpp:1406 src/muuli_wdr.cpp:1413
-#: src/muuli_wdr.cpp:1842 src/muuli_wdr.cpp:1848 src/OtherFunctions.cpp:91
+#: src/muuli_wdr.cpp:1846 src/muuli_wdr.cpp:1852 src/OtherFunctions.cpp:91
 #: src/StatisticsDlg.cpp:93 src/StatisticsDlg.cpp:95
 msgid "kB/s"
 msgstr "KB/s"
@@ -3331,7 +3336,7 @@ msgstr "B"
 msgid "KB"
 msgstr "KB"
 
-#: src/muuli_wdr.cpp:274 src/muuli_wdr.cpp:293 src/muuli_wdr.cpp:1627
+#: src/muuli_wdr.cpp:274 src/muuli_wdr.cpp:293 src/muuli_wdr.cpp:1631
 #: src/OtherFunctions.cpp:64
 msgid "MB"
 msgstr "MB"
@@ -3348,7 +3353,7 @@ msgstr "大小上限"
 msgid "Availability"
 msgstr "最小來源數"
 
-#: src/muuli_wdr.cpp:312 src/muuli_wdr.cpp:398 src/muuli_wdr.cpp:3297
+#: src/muuli_wdr.cpp:312 src/muuli_wdr.cpp:398 src/muuli_wdr.cpp:3328
 msgid "Filter:"
 msgstr "過濾："
 
@@ -3411,12 +3416,12 @@ msgstr "檔案來源："
 #: src/muuli_wdr.cpp:1160 src/muuli_wdr.cpp:1167 src/muuli_wdr.cpp:1172
 #: src/muuli_wdr.cpp:1179 src/muuli_wdr.cpp:1184 src/muuli_wdr.cpp:1191
 #: src/muuli_wdr.cpp:1205 src/muuli_wdr.cpp:1212 src/muuli_wdr.cpp:1217
-#: src/muuli_wdr.cpp:1224 src/muuli_wdr.cpp:3234 src/muuli_wdr.cpp:3242
-#: src/muuli_wdr.cpp:3250
+#: src/muuli_wdr.cpp:1224 src/muuli_wdr.cpp:3265 src/muuli_wdr.cpp:3273
+#: src/muuli_wdr.cpp:3281
 msgid "N/A"
 msgstr "N/A"
 
-#: src/muuli_wdr.cpp:508 src/muuli_wdr.cpp:1065 src/PrefsUnifiedDlg.cpp:297
+#: src/muuli_wdr.cpp:508 src/muuli_wdr.cpp:1065 src/PrefsUnifiedDlg.cpp:299
 msgid "General"
 msgstr "一般"
 
@@ -3557,7 +3562,7 @@ msgstr ""
 msgid "Album :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:685 src/muuli_wdr.cpp:2254
+#: src/muuli_wdr.cpp:685 src/muuli_wdr.cpp:2285
 msgid "Title :"
 msgstr "標題："
 
@@ -3666,7 +3671,7 @@ msgstr "使用者名稱︰"
 msgid "Userhash :"
 msgstr "使用者 hash 值："
 
-#: src/muuli_wdr.cpp:895 src/muuli_wdr.cpp:1748 src/muuli_wdr.cpp:2449
+#: src/muuli_wdr.cpp:895 src/muuli_wdr.cpp:1752 src/muuli_wdr.cpp:2480
 #: src/utils/aLinkCreator/src/alcframe.cpp:137
 msgid "Add"
 msgstr "加入"
@@ -3675,15 +3680,15 @@ msgstr "加入"
 msgid "Download-Speed"
 msgstr "下載速度"
 
-#: src/muuli_wdr.cpp:954 src/muuli_wdr.cpp:989 src/muuli_wdr.cpp:2553
+#: src/muuli_wdr.cpp:954 src/muuli_wdr.cpp:989 src/muuli_wdr.cpp:2584
 msgid "Current"
 msgstr "目前"
 
-#: src/muuli_wdr.cpp:962 src/muuli_wdr.cpp:997 src/muuli_wdr.cpp:2561
+#: src/muuli_wdr.cpp:962 src/muuli_wdr.cpp:997 src/muuli_wdr.cpp:2592
 msgid "Running average"
 msgstr "執行中平均值"
 
-#: src/muuli_wdr.cpp:970 src/muuli_wdr.cpp:1005 src/muuli_wdr.cpp:2569
+#: src/muuli_wdr.cpp:970 src/muuli_wdr.cpp:1005 src/muuli_wdr.cpp:2600
 msgid "Session average"
 msgstr "本次平均值"
 
@@ -3695,7 +3700,7 @@ msgstr "上傳速度"
 msgid "Connections"
 msgstr "連線"
 
-#: src/muuli_wdr.cpp:1024 src/muuli_wdr.cpp:1867
+#: src/muuli_wdr.cpp:1024 src/muuli_wdr.cpp:1871
 msgid "Active downloads"
 msgstr "目前下載數"
 
@@ -3703,7 +3708,7 @@ msgstr "目前下載數"
 msgid "Active connections (1:1)"
 msgstr "目前連線數 (1:1)"
 
-#: src/muuli_wdr.cpp:1040 src/muuli_wdr.cpp:1868
+#: src/muuli_wdr.cpp:1040 src/muuli_wdr.cpp:1872
 msgid "Active uploads"
 msgstr "目前上傳數"
 
@@ -3979,7 +3984,7 @@ msgstr "選定本機使用 IP (留白或輸入)："
 msgid "Advanced users only: If you have multiple network interfaces, enter the address of the interface to which aMule should be bound."
 msgstr "進階使用者用：如果您有多網路介面，請輸入要給 aMule 使用的的網路位址。"
 
-#: src/muuli_wdr.cpp:1462 src/muuli_wdr.cpp:2061
+#: src/muuli_wdr.cpp:1462 src/muuli_wdr.cpp:2065
 #, fuzzy
 msgid "Bind to network interface (empty for any):"
 msgstr "選定本機使用 IP (留白或輸入)："
@@ -3996,7 +4001,7 @@ msgstr "每個檔案最大來源數："
 msgid "Max simultaneous connections:"
 msgstr "最大同時連線數："
 
-#: src/muuli_wdr.cpp:1498 src/muuli_wdr.cpp:3176
+#: src/muuli_wdr.cpp:1498 src/muuli_wdr.cpp:3207
 msgid "ED2K"
 msgstr "ED2K"
 
@@ -4088,755 +4093,778 @@ msgstr "新檔案預先分配磁碟空間"
 msgid "For new files preallocates disk space for the whole file, thus reduces fragmentation"
 msgstr "新檔案預先分配所需的完整磁碟空間，這樣可以減少檔案分散度"
 
-#: src/muuli_wdr.cpp:1613
+#: src/muuli_wdr.cpp:1617
 msgid "Create new files as sparse files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1614
-msgid "A sparse file reserves its full size on disk immediately without writing real data to it -- fast, but unsupported or slow on some filesystems, and free-space accounting stays optimistic while the download is in progress. Turn this off to grow the file only as data arrives."
+#: src/muuli_wdr.cpp:1618
+msgid "Sparse part files only occupy disk space for the parts already downloaded, so free space is used up gradually as the file fills in. Turn this off to use an ordinary file instead - useful where sparse files are unsupported or slow, or where backup/de-duplication tools handle them badly. Applies only when the core runs on Windows; on Linux and macOS part files are sparse anyway and this setting has no effect."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1619
+#: src/muuli_wdr.cpp:1623
 msgid "Stop downloads when free disk space reaches "
 msgstr "磁碟可用空間不足時停止下載"
 
-#: src/muuli_wdr.cpp:1620
+#: src/muuli_wdr.cpp:1624
 msgid "Select this if you want aMule to check your disk space"
 msgstr "讓 aMule 檢查磁碟可用空間"
 
-#: src/muuli_wdr.cpp:1624
+#: src/muuli_wdr.cpp:1628
 msgid "Enter here the min disk space desired."
 msgstr "請輸入最小磁碟可用空間。"
 
-#: src/muuli_wdr.cpp:1630
+#: src/muuli_wdr.cpp:1634
 msgid "Save 10 sources on rare files (< 20 sources)"
 msgstr "為來源稀少 (< 20) 的檔案儲存 10 個來源"
 
-#: src/muuli_wdr.cpp:1634 src/Statistics.cpp:790
+#: src/muuli_wdr.cpp:1638 src/Statistics.cpp:790
 msgid "Uploads"
 msgstr "上傳"
 
-#: src/muuli_wdr.cpp:1637
+#: src/muuli_wdr.cpp:1641
 msgid "Add new shared files with auto priority"
 msgstr "新加入分享檔案優先等級設定為自動"
 
-#: src/muuli_wdr.cpp:1643
+#: src/muuli_wdr.cpp:1647
 msgid "Intelligent Corruption Handling (I.C.H.)"
 msgstr "智慧型損壞處理 (I.C.H.)"
 
-#: src/muuli_wdr.cpp:1646
+#: src/muuli_wdr.cpp:1650
 msgid "Enable"
 msgstr "啟用"
 
-#: src/muuli_wdr.cpp:1649
+#: src/muuli_wdr.cpp:1653
 msgid "Advanced I.C.H. trusts every hash (not recommended)"
 msgstr "進階 I.C.H. 信任所有 hash 值 (不建議)"
 
-#: src/muuli_wdr.cpp:1661 src/PrefsUnifiedDlg.cpp:1910
+#: src/muuli_wdr.cpp:1665 src/PrefsUnifiedDlg.cpp:1990
 msgid "Media metadata extraction"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1665
+#: src/muuli_wdr.cpp:1669
 msgid "Extract length / bitrate / codec from shared audio and video files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1667
+#: src/muuli_wdr.cpp:1671
 msgid "When enabled, aMule runs ffprobe on each shared media file to fill in the Length / Bitrate / Codec columns other clients see when they find the file in a search. Requires ffmpeg (the ffprobe binary) to be installed."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1674
+#: src/muuli_wdr.cpp:1678
 msgid "Path to ffprobe:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1679
+#: src/muuli_wdr.cpp:1683
 msgid "Full path to the ffprobe binary. Leave empty to have aMule auto-detect it on startup."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1687
+#: src/muuli_wdr.cpp:1691
 msgid "Detect"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1688
+#: src/muuli_wdr.cpp:1692
 msgid "Search the standard install locations for an ffprobe binary and fill the path field."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1712
+#: src/muuli_wdr.cpp:1716
 msgid ""
 "Completed downloads are stored here. All files in this folder are automatically shared with other peers.\n"
 "If this folder also holds files you don't want to share, point it at an aMule-only sub-folder."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1715
+#: src/muuli_wdr.cpp:1719
 msgid "Pick the folder where completed downloads will be stored. All files in that folder will be shared with other peers."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1729
+#: src/muuli_wdr.cpp:1733
 msgid "Shared folders"
 msgstr "分享資料夾"
 
-#: src/muuli_wdr.cpp:1735
+#: src/muuli_wdr.cpp:1739
 msgid "(Folders shared by the core. Enter a path to add one.)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1743
+#: src/muuli_wdr.cpp:1747
 msgid "Absolute path of a folder on the core's machine, e.g. /home/user/shared"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1745 src/PrefsUnifiedDlg.cpp:2794
+#: src/muuli_wdr.cpp:1749 src/PrefsUnifiedDlg.cpp:2874
 msgid "Recursive"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1746
+#: src/muuli_wdr.cpp:1750
 msgid "Share every sub-folder underneath this one, including ones created later."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1750 src/utils/aLinkCreator/src/alcframe.cpp:141
+#: src/muuli_wdr.cpp:1754 src/utils/aLinkCreator/src/alcframe.cpp:141
 msgid "Remove"
 msgstr "移除"
 
-#: src/muuli_wdr.cpp:1754
+#: src/muuli_wdr.cpp:1758
 msgid "(Right click on folder icon for recursive share)"
 msgstr "(滑鼠右鍵點選檔案夾圖示可全部遞迴分享)"
 
-#: src/muuli_wdr.cpp:1761
+#: src/muuli_wdr.cpp:1765
 msgid "Share hidden files"
 msgstr "分享隱藏檔"
 
-#: src/muuli_wdr.cpp:1767
+#: src/muuli_wdr.cpp:1771
 msgid "Automatically rescan shared folders for changes"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1773
+#: src/muuli_wdr.cpp:1777
 msgid "Follow symbolic links in shared folders"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1779
+#: src/muuli_wdr.cpp:1783
 msgid "Exclude files matching:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1782
+#: src/muuli_wdr.cpp:1786
 msgid "Wildcard patterns separated by '|', e.g. .DS_Store|Thumbs.db|*.tmp. Files whose name matches are not shared. Matching is case-insensitive."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1786
+#: src/muuli_wdr.cpp:1790
 msgid "Patterns are regular expressions"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1787
+#: src/muuli_wdr.cpp:1791
 msgid "When set, the whole field is one regular expression ('|' is alternation). When unset, it is a list of '|'-separated wildcards."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1797
+#: src/muuli_wdr.cpp:1801
 msgid "Show how many shared files the current pattern would exclude."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1818
+#: src/muuli_wdr.cpp:1822
 msgid "Graphs"
 msgstr "圖表"
 
-#: src/muuli_wdr.cpp:1821 src/muuli_wdr.cpp:1883
+#: src/muuli_wdr.cpp:1825 src/muuli_wdr.cpp:1887
 msgid "Update delay : 5 secs"
 msgstr "更新延遲時間：5 秒"
 
-#: src/muuli_wdr.cpp:1825
+#: src/muuli_wdr.cpp:1829
 msgid "Time for average graph: 100 mins"
 msgstr "平均圖表顯示時間：100 分鐘"
 
-#: src/muuli_wdr.cpp:1829
+#: src/muuli_wdr.cpp:1833
 msgid "Connections Graph Scale: 100 "
 msgstr "連線圖表比例：100 "
 
-#: src/muuli_wdr.cpp:1836
+#: src/muuli_wdr.cpp:1840
 msgid "Download graph scale:"
 msgstr "下載統計圖比例："
 
-#: src/muuli_wdr.cpp:1844
+#: src/muuli_wdr.cpp:1848
 msgid "Upload graph scale:"
 msgstr "上傳統計圖比例："
 
-#: src/muuli_wdr.cpp:1854
+#: src/muuli_wdr.cpp:1858
 #, fuzzy
 msgid "Colors: "
 msgstr "顏色："
 
-#: src/muuli_wdr.cpp:1858
+#: src/muuli_wdr.cpp:1862
 msgid "Background"
 msgstr "背景"
 
-#: src/muuli_wdr.cpp:1859
+#: src/muuli_wdr.cpp:1863
 msgid "Grid"
 msgstr "格線"
 
-#: src/muuli_wdr.cpp:1860
+#: src/muuli_wdr.cpp:1864
 msgid "Download current"
 msgstr "目前下載"
 
-#: src/muuli_wdr.cpp:1861
+#: src/muuli_wdr.cpp:1865
 msgid "Download running average"
 msgstr "執行中平均下載"
 
-#: src/muuli_wdr.cpp:1862
+#: src/muuli_wdr.cpp:1866
 msgid "Download session average"
 msgstr "本次平均下載"
 
-#: src/muuli_wdr.cpp:1863
+#: src/muuli_wdr.cpp:1867
 msgid "Upload current"
 msgstr "目前上傳"
 
-#: src/muuli_wdr.cpp:1864
+#: src/muuli_wdr.cpp:1868
 msgid "Upload running average"
 msgstr "執行中平均上傳"
 
-#: src/muuli_wdr.cpp:1865
+#: src/muuli_wdr.cpp:1869
 msgid "Upload session average"
 msgstr "本次平均上傳"
 
-#: src/muuli_wdr.cpp:1866
+#: src/muuli_wdr.cpp:1870
 msgid "Active connections"
 msgstr "目前連線數"
 
-#: src/muuli_wdr.cpp:1869
+#: src/muuli_wdr.cpp:1873
 #, fuzzy
 msgid "Systray Icon Speed Bar"
 msgstr "狀態列圖示顯示速度"
 
-#: src/muuli_wdr.cpp:1870
+#: src/muuli_wdr.cpp:1874
 msgid "Kad-nodes current"
 msgstr "目前 Kad 節點"
 
-#: src/muuli_wdr.cpp:1871
+#: src/muuli_wdr.cpp:1875
 msgid "Kad-nodes running"
 msgstr "執行中 Kad 節點"
 
-#: src/muuli_wdr.cpp:1872
+#: src/muuli_wdr.cpp:1876
 msgid "Kad-nodes session"
 msgstr "本次 Kad 節點"
 
-#: src/muuli_wdr.cpp:1876 src/muuli_wdr.cpp:2303
+#: src/muuli_wdr.cpp:1880 src/muuli_wdr.cpp:2334
 msgid "Select"
 msgstr "選取"
 
-#: src/muuli_wdr.cpp:1880
+#: src/muuli_wdr.cpp:1884
 msgid "Tree"
 msgstr "樹狀"
 
-#: src/muuli_wdr.cpp:1890
+#: src/muuli_wdr.cpp:1894
 msgid "Number of Client Versions shown (0=unlimited)"
 msgstr "顯示客戶端版本的數量 ( 0 代表不限制)"
 
-#: src/muuli_wdr.cpp:1915
+#: src/muuli_wdr.cpp:1919
 msgid "!!! WARNING !!!"
 msgstr "!!! 警告 !!!"
 
-#: src/muuli_wdr.cpp:1930
+#: src/muuli_wdr.cpp:1934
 msgid "Max new connections / 5 secs"
 msgstr "5 秒內最大新連線數"
 
-#: src/muuli_wdr.cpp:1932
+#: src/muuli_wdr.cpp:1936
 msgid "Concurrent Kad source lookups"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1934
+#: src/muuli_wdr.cpp:1938
 #, fuzzy
 msgid "Kad source re-search interval (minutes)"
 msgstr "FTP 上傳間隔 (分鐘)"
 
-#: src/muuli_wdr.cpp:1936
+#: src/muuli_wdr.cpp:1940
 #, fuzzy
 msgid "Source re-ask interval (minutes)"
 msgstr "FTP 上傳間隔 (分鐘)"
 
-#: src/muuli_wdr.cpp:1940
+#: src/muuli_wdr.cpp:1944
 msgid "File Buffer Size: 240000 bytes"
 msgstr "檔案緩衝區：240.000 KB"
 
-#: src/muuli_wdr.cpp:1944
+#: src/muuli_wdr.cpp:1948
 msgid "Use MMAP: memory-mapped file access (lower memory use)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1945
+#: src/muuli_wdr.cpp:1949
 msgid "Maps part files into memory instead of buffering them on the heap, lowering the process memory footprint. May reduce download speed on some disks; best for memory-constrained or upload-heavy hosts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1947
+#: src/muuli_wdr.cpp:1951
 msgid "Upload Queue Size: 5000 clients"
 msgstr "上傳等候區大小：5000 "
 
-#: src/muuli_wdr.cpp:1951
+#: src/muuli_wdr.cpp:1955
 msgid "Server connection refresh interval: Disable"
 msgstr "伺服器連線更新間隔時間：停用"
 
-#: src/muuli_wdr.cpp:1955
+#: src/muuli_wdr.cpp:1959
 msgid "Disable computer's timed standby mode"
 msgstr "停用電腦的自動進入待命模式功能"
 
-#: src/muuli_wdr.cpp:1974
+#: src/muuli_wdr.cpp:1978
 msgid "Skin to use: "
 msgstr "使用面板："
 
-#: src/muuli_wdr.cpp:1983
+#: src/muuli_wdr.cpp:1987
 msgid "Show \"Fast eD2k Links Handler\" in every window."
 msgstr "在每個視窗顯示「eD2k 連結快速處理器」。"
 
-#: src/muuli_wdr.cpp:1986
+#: src/muuli_wdr.cpp:1990
 msgid "Show extended info on categories tabs"
 msgstr "在分類頁中顯示擴充資訊"
 
-#: src/muuli_wdr.cpp:1989
+#: src/muuli_wdr.cpp:1993
 msgid "Show application version on title"
 msgstr "在標題顯示應用程式版本"
 
-#: src/muuli_wdr.cpp:1991
+#: src/muuli_wdr.cpp:1995
 msgid "Show transfer rates on title"
 msgstr "標題列顯示傳輸速度"
 
-#: src/muuli_wdr.cpp:1993
+#: src/muuli_wdr.cpp:1997
 msgid "Before application name"
 msgstr "在程式名稱前"
 
-#: src/muuli_wdr.cpp:1995
+#: src/muuli_wdr.cpp:1999
 msgid "After application name"
 msgstr "在程式名稱後"
 
-#: src/muuli_wdr.cpp:1998
+#: src/muuli_wdr.cpp:2002
 msgid "Show overhead bandwidth"
 msgstr "顯示額外支出頻寬"
 
-#: src/muuli_wdr.cpp:2002
+#: src/muuli_wdr.cpp:2006
 msgid "Vertical toolbar orientation"
 msgstr "垂直顯示工具列"
 
-#: src/muuli_wdr.cpp:2004
+#: src/muuli_wdr.cpp:2008
 msgid "Live column sorting (auto-reorder rows as their values change)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2011
+#: src/muuli_wdr.cpp:2015
 msgid "Download Queue Files"
 msgstr "下載等候區檔案"
 
-#: src/muuli_wdr.cpp:2014
+#: src/muuli_wdr.cpp:2018
 msgid "Show progress percentage"
 msgstr "顯示進度百分比"
 
-#: src/muuli_wdr.cpp:2020
+#: src/muuli_wdr.cpp:2024
 msgid "Show progress bar"
 msgstr "顯示進度條"
 
-#: src/muuli_wdr.cpp:2023
+#: src/muuli_wdr.cpp:2027
 msgid "Flat"
 msgstr "扁平"
 
-#: src/muuli_wdr.cpp:2027
+#: src/muuli_wdr.cpp:2031
 msgid "Round"
 msgstr "圓弧"
 
-#: src/muuli_wdr.cpp:2045
+#: src/muuli_wdr.cpp:2049
 msgid "External Connection Parameters"
 msgstr "外部連線參數"
 
-#: src/muuli_wdr.cpp:2048
+#: src/muuli_wdr.cpp:2052
 msgid "Accept external connections"
 msgstr "接受外部連線"
 
-#: src/muuli_wdr.cpp:2055 src/muuli_wdr.cpp:2114
+#: src/muuli_wdr.cpp:2059 src/muuli_wdr.cpp:2118
 msgid "IP of the listening interface:"
 msgstr "監聽 IP："
 
-#: src/muuli_wdr.cpp:2058
+#: src/muuli_wdr.cpp:2062
 msgid "Enter here a valid ip in the a.b.c.d format for the listening EC interface. An empty field or 0.0.0.0 will mean any interface."
 msgstr "輸入要監聽外部連線的的 IP (格式：a.b.c.d)，空白或 0.0.0.0 表示全部。"
 
-#: src/muuli_wdr.cpp:2079 src/muuli_wdr.cpp:2163
+#: src/muuli_wdr.cpp:2083 src/muuli_wdr.cpp:2194
 msgid "TCP port:"
 msgstr "TCP 埠："
 
-#: src/muuli_wdr.cpp:2085
+#: src/muuli_wdr.cpp:2089
 msgid "Enable UPnP port forwarding on the EC port"
 msgstr "外部連線通訊埠啟用 UPnP 通訊埠轉向"
 
-#: src/muuli_wdr.cpp:2089 src/muuli_wdr.cpp:3048
+#: src/muuli_wdr.cpp:2093 src/muuli_wdr.cpp:3079
 #: src/utils/wxCas/src/wxcasprefs.cpp:167
 msgid "Password"
 msgstr "密碼"
 
-#: src/muuli_wdr.cpp:2095
+#: src/muuli_wdr.cpp:2099
 #, fuzzy
 msgid "aMule API server parameters"
 msgstr "網站伺服器參數"
 
-#: src/muuli_wdr.cpp:2098
+#: src/muuli_wdr.cpp:2102
 msgid "Run amuleapi (REST API) on startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2103
+#: src/muuli_wdr.cpp:2107
 #, fuzzy
 msgid "HTTP port:"
 msgstr "TCP 埠："
 
-#: src/muuli_wdr.cpp:2117
+#: src/muuli_wdr.cpp:2121
 msgid "The interface amuleapi's HTTP server listens on. 127.0.0.1 (default) accepts only local connections; use 0.0.0.0 or a specific IP to expose it to other hosts (set an admin password below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2120
+#: src/muuli_wdr.cpp:2126
+msgid "Type a password to set or change it. Stored passwords cannot be shown, so leaving this empty keeps the current one."
+msgstr ""
+
+#: src/muuli_wdr.cpp:2128
 #, fuzzy
 msgid "Admin password"
 msgstr "正在檢查密碼\n"
 
-#: src/muuli_wdr.cpp:2125 src/muuli_wdr.cpp:2156
-msgid "Low rights password"
-msgstr "低權限使用者密碼"
+#: src/muuli_wdr.cpp:2140 src/muuli_wdr.cpp:2157 src/PrefsUnifiedDlg.cpp:1103
+#, fuzzy
+msgid "A password is set."
+msgstr "正在檢查密碼\n"
 
-#: src/muuli_wdr.cpp:2133
+#: src/muuli_wdr.cpp:2144
+#, fuzzy
+msgid "Enable guest access"
+msgstr "拒絕訪客連線"
+
+#: src/muuli_wdr.cpp:2145
+msgid "Guest sessions may read status and listings but cannot change anything. Turning this off clears the stored guest password."
+msgstr ""
+
+#: src/muuli_wdr.cpp:2149
+#, fuzzy
+msgid "Guest password"
+msgstr "網站伺服器的 訪客密碼"
+
+#: src/muuli_wdr.cpp:2164
 msgid "Web server parameters"
 msgstr "網站伺服器參數"
 
-#: src/muuli_wdr.cpp:2136
+#: src/muuli_wdr.cpp:2167
 #, fuzzy
 msgid "Run webserver on startup (deprecated)"
 msgstr "啟動時執行網站伺服器"
 
-#: src/muuli_wdr.cpp:2142
+#: src/muuli_wdr.cpp:2173
 msgid "Web template"
 msgstr "網頁模板"
 
-#: src/muuli_wdr.cpp:2147
+#: src/muuli_wdr.cpp:2178
 msgid "Full rights password"
 msgstr "絕對權限使用者密碼"
 
-#: src/muuli_wdr.cpp:2151
+#: src/muuli_wdr.cpp:2182
 msgid "Enable Low rights User"
 msgstr "啟用低權限使用者"
 
-#: src/muuli_wdr.cpp:2170
+#: src/muuli_wdr.cpp:2187
+msgid "Low rights password"
+msgstr "低權限使用者密碼"
+
+#: src/muuli_wdr.cpp:2201
 msgid "Enable UPnP port forwarding of the web server port"
 msgstr "網站伺服器的通訊埠啟用 UPnP 通訊埠轉向"
 
-#: src/muuli_wdr.cpp:2175
+#: src/muuli_wdr.cpp:2206
 msgid "Web server UPnP TCP port (Optional)"
 msgstr "網站伺服器的 UPnP TCP 埠 (選用)"
 
-#: src/muuli_wdr.cpp:2183
+#: src/muuli_wdr.cpp:2214
 msgid "Page Refresh Time (in secs)"
 msgstr "頁面更新時間 (秒)"
 
-#: src/muuli_wdr.cpp:2190
+#: src/muuli_wdr.cpp:2221
 msgid "Enable Gzip compression"
 msgstr "啟用 Gzip 壓縮"
 
-#: src/muuli_wdr.cpp:2224
+#: src/muuli_wdr.cpp:2255
 #, fuzzy
 msgid "Reset page to defaults"
 msgstr "系統預設"
 
-#: src/muuli_wdr.cpp:2225
+#: src/muuli_wdr.cpp:2256
 msgid "Reset the settings on the current page to their default values."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2227 src/muuli_wdr.cpp:2313 src/ServerWnd.cpp:274
+#: src/muuli_wdr.cpp:2258 src/muuli_wdr.cpp:2344 src/ServerWnd.cpp:274
 #: src/ServerWnd.cpp:282
 msgid "OK"
 msgstr "OK"
 
-#: src/muuli_wdr.cpp:2229
+#: src/muuli_wdr.cpp:2260
 msgid "Click here to apply any changes made to the preferences."
 msgstr "點選這裏立即套用已變更的偏好設定。"
 
-#: src/muuli_wdr.cpp:2232
+#: src/muuli_wdr.cpp:2263
 msgid "Reset any changes made to the preferences."
 msgstr "取消所有偏好設定變更。"
 
-#: src/muuli_wdr.cpp:2261
+#: src/muuli_wdr.cpp:2292
 msgid "Comment :"
 msgstr "註解："
 
-#: src/muuli_wdr.cpp:2268
+#: src/muuli_wdr.cpp:2299
 msgid "Incoming Dir :"
 msgstr "新進檔目錄："
 
-#: src/muuli_wdr.cpp:2277
+#: src/muuli_wdr.cpp:2308
 msgid "Change priority for new assigned files :"
 msgstr "設定新加入的檔案優先等級為："
 
-#: src/muuli_wdr.cpp:2281
+#: src/muuli_wdr.cpp:2312
 msgid "Don't change"
 msgstr "不要變更"
 
-#: src/muuli_wdr.cpp:2293
+#: src/muuli_wdr.cpp:2324
 msgid "Select color for this Category (currently selected) :"
 msgstr "選取該分類的顏色 (目前選擇)："
 
-#: src/muuli_wdr.cpp:2360 src/muuli_wdr.cpp:2379 src/muuli_wdr.cpp:2401
+#: src/muuli_wdr.cpp:2391 src/muuli_wdr.cpp:2410 src/muuli_wdr.cpp:2432
 msgid "Click this button to reset the log."
 msgstr "點選這個按鈕來清除記錄。"
 
-#: src/muuli_wdr.cpp:2420
+#: src/muuli_wdr.cpp:2451
 msgid "Click on this button to update the servers list from URL ..."
 msgstr "點選這個按鈕從該網址更新伺服器清單 ..."
 
-#: src/muuli_wdr.cpp:2424
+#: src/muuli_wdr.cpp:2455
 msgid "Server list"
 msgstr "伺服器清單"
 
-#: src/muuli_wdr.cpp:2428
+#: src/muuli_wdr.cpp:2459
 msgid "Enter the url to a server.met file here and press the button to the left to update the list of known servers."
 msgstr "輸入 server.met 檔案的網址並按下左邊的按鈕以更新已知伺服器清單。"
 
-#: src/muuli_wdr.cpp:2433
+#: src/muuli_wdr.cpp:2464
 msgid "Add server manually: Name"
 msgstr "手動加入伺服器：名稱"
 
-#: src/muuli_wdr.cpp:2436
+#: src/muuli_wdr.cpp:2467
 msgid "Enter the name of the new server here"
 msgstr "輸入新伺服器的名稱"
 
-#: src/muuli_wdr.cpp:2438 src/ServerWnd.cpp:206
+#: src/muuli_wdr.cpp:2469 src/ServerWnd.cpp:206
 msgid "IP:Port"
 msgstr "IP:Port"
 
-#: src/muuli_wdr.cpp:2441
+#: src/muuli_wdr.cpp:2472
 msgid "Enter the IP of the server here, using the x.x.x.x format."
 msgstr "輸入新伺服器的 IP (格式：x.x.x.x)。"
 
-#: src/muuli_wdr.cpp:2447
+#: src/muuli_wdr.cpp:2478
 msgid "Enter the port of the server here."
 msgstr "輸入伺服器的通訊埠。"
 
-#: src/muuli_wdr.cpp:2450
+#: src/muuli_wdr.cpp:2481
 msgid "Add manually a server (fill fields to the left before) ..."
 msgstr "手動加入伺服器 (填入左側空格中) ..."
 
-#: src/muuli_wdr.cpp:2479
+#: src/muuli_wdr.cpp:2510
 msgid "aMule Log"
 msgstr "aMule 記錄"
 
-#: src/muuli_wdr.cpp:2487
+#: src/muuli_wdr.cpp:2518
 msgid "Server Info"
 msgstr "伺服器資訊"
 
-#: src/muuli_wdr.cpp:2491
+#: src/muuli_wdr.cpp:2522
 msgid "ED2K Info"
 msgstr "eD2k 資訊"
 
-#: src/muuli_wdr.cpp:2495
+#: src/muuli_wdr.cpp:2526
 msgid "Kad Info"
 msgstr "Kad 資訊"
 
-#: src/muuli_wdr.cpp:2523
+#: src/muuli_wdr.cpp:2554
 msgid "Click on this button to update the nodes list from URL ..."
 msgstr "點選這個按鈕來從該網址更新節點清單 ..."
 
-#: src/muuli_wdr.cpp:2527
+#: src/muuli_wdr.cpp:2558
 msgid "Nodes (0)"
 msgstr "節點 (0)"
 
-#: src/muuli_wdr.cpp:2531
+#: src/muuli_wdr.cpp:2562
 msgid "Enter the url to a nodes.dat file here and press the button to the left to update the list of known nodes."
 msgstr "輸入 nodes.dat 檔案的網址，並按下左邊的按鈕以更新已知節點清單。"
 
-#: src/muuli_wdr.cpp:2534
+#: src/muuli_wdr.cpp:2565
 msgid "Nodes stats"
 msgstr "節點狀態"
 
-#: src/muuli_wdr.cpp:2576
+#: src/muuli_wdr.cpp:2607
 msgid "Bootstrap"
 msgstr "啓動"
 
-#: src/muuli_wdr.cpp:2579
+#: src/muuli_wdr.cpp:2610
 msgid "New node"
 msgstr "新節點"
 
-#: src/muuli_wdr.cpp:2584
+#: src/muuli_wdr.cpp:2615
 msgid "IP:"
 msgstr "IP："
 
-#: src/muuli_wdr.cpp:2604
+#: src/muuli_wdr.cpp:2635
 msgid "Port:"
 msgstr "埠："
 
-#: src/muuli_wdr.cpp:2617
+#: src/muuli_wdr.cpp:2648
 msgid "Bootstrap from known clients"
 msgstr "從已知客戶端啓動"
 
-#: src/muuli_wdr.cpp:2619
+#: src/muuli_wdr.cpp:2650
 msgid "Disconnect Kad"
 msgstr "中斷 Kad 連線"
 
-#: src/muuli_wdr.cpp:2653
+#: src/muuli_wdr.cpp:2684
 msgid "Use Secure User Identification"
 msgstr "啟用使用者安全認證"
 
-#: src/muuli_wdr.cpp:2655
+#: src/muuli_wdr.cpp:2686
 msgid "It is recommended to enable this option. You will not receive credits if SUI is not enabled."
 msgstr "建議啟用此選項。如果使用者安全認證未啟用，將會得不到積分。"
 
-#: src/muuli_wdr.cpp:2657
+#: src/muuli_wdr.cpp:2688
 msgid "Protocol Obfuscation"
 msgstr "模糊協定"
 
-#: src/muuli_wdr.cpp:2660
+#: src/muuli_wdr.cpp:2691
 msgid "Support Protocol Obfuscation"
 msgstr "支援模糊協定"
 
-#: src/muuli_wdr.cpp:2662
+#: src/muuli_wdr.cpp:2693
 msgid "This option enabled Protocol Obfuscation, and makes aMule accept obfuscated connections from other clients."
 msgstr "啓用模糊協定，可讓 aMule 接受來自其他客戶端的模糊連線。"
 
-#: src/muuli_wdr.cpp:2664
+#: src/muuli_wdr.cpp:2695
 msgid "Use obfuscation for outgoing connections"
 msgstr "對外的連線使用模糊協定"
 
-#: src/muuli_wdr.cpp:2666
+#: src/muuli_wdr.cpp:2697
 msgid "This option makes aMule use Protocol Obfuscation when connecting other clients/servers."
 msgstr "使 aMule 在與其他客戶端或伺服器連線時使用模糊協定。"
 
-#: src/muuli_wdr.cpp:2668
+#: src/muuli_wdr.cpp:2699
 msgid "Accept only obfuscated connections"
 msgstr "只接受模糊連線"
 
-#: src/muuli_wdr.cpp:2669
+#: src/muuli_wdr.cpp:2700
 msgid "This option makes aMule only accept obfuscated connections. You will have less sources, but all your traffic will be obfuscated"
 msgstr "讓 aMule 只接受模糊協定，檔案來源會比較少，但所有傳輸都將是模糊連線"
 
-#: src/muuli_wdr.cpp:2674
+#: src/muuli_wdr.cpp:2705
 msgid "Everybody"
 msgstr "任何人"
 
-#: src/muuli_wdr.cpp:2676
+#: src/muuli_wdr.cpp:2707
 msgid "No one"
 msgstr "無"
 
-#: src/muuli_wdr.cpp:2678
+#: src/muuli_wdr.cpp:2709
 msgid "Who can see my shared files:"
 msgstr "誰可以看我的分享檔案："
 
-#: src/muuli_wdr.cpp:2679
+#: src/muuli_wdr.cpp:2710
 msgid "Select who can request to view a list of your shared files."
 msgstr "選取可以瀏覽分享檔案清單的使用者。"
 
-#: src/muuli_wdr.cpp:2681
+#: src/muuli_wdr.cpp:2712
 msgid "IP-Filtering"
 msgstr "IP 過濾"
 
-#: src/muuli_wdr.cpp:2688
+#: src/muuli_wdr.cpp:2719
 msgid "Filter clients"
 msgstr "過濾客戶端"
 
-#: src/muuli_wdr.cpp:2690
+#: src/muuli_wdr.cpp:2721
 msgid "Enable filtering of the client IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "過濾列在 ~/.aMule/ipfilter.dat 檔案中的客戶端 IP"
 
-#: src/muuli_wdr.cpp:2692
+#: src/muuli_wdr.cpp:2723
 msgid "Filter servers"
 msgstr "過濾伺服器"
 
-#: src/muuli_wdr.cpp:2694
+#: src/muuli_wdr.cpp:2725
 msgid "Enable filtering of the server IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "過濾列在 ~/.aMule/ipfilter.dat 檔案中的伺服器 IP 。"
 
-#: src/muuli_wdr.cpp:2698
+#: src/muuli_wdr.cpp:2729
 msgid "Reload List"
 msgstr "重載入清單"
 
-#: src/muuli_wdr.cpp:2699
+#: src/muuli_wdr.cpp:2730
 msgid "Reload the list of IPs to filter from the file ~/.aMule/ipfilter.dat"
 msgstr "重新載入 IP 過濾清單 ~/.aMule/ipfilter.dat"
 
-#: src/muuli_wdr.cpp:2705
+#: src/muuli_wdr.cpp:2736
 msgid "URL:"
 msgstr "網址："
 
-#: src/muuli_wdr.cpp:2709 src/muuli_wdr.cpp:2902
+#: src/muuli_wdr.cpp:2740 src/muuli_wdr.cpp:2933
 msgid "Update now"
 msgstr "立即更新"
 
-#: src/muuli_wdr.cpp:2712
+#: src/muuli_wdr.cpp:2743
 msgid "Auto-update ipfilter at startup"
 msgstr "啓動後自動更新 IP 過濾清單"
 
-#: src/muuli_wdr.cpp:2716
+#: src/muuli_wdr.cpp:2747
 msgid "Filtering Level:"
 msgstr "過濾等級："
 
-#: src/muuli_wdr.cpp:2722
+#: src/muuli_wdr.cpp:2753
 msgid "Always filter LAN IPs"
 msgstr "永遠過濾區域網路 IP"
 
-#: src/muuli_wdr.cpp:2725
+#: src/muuli_wdr.cpp:2756
 msgid "Paranoid handling of non-matching IPs"
 msgstr "處理不匹配的 IP"
 
-#: src/muuli_wdr.cpp:2727
+#: src/muuli_wdr.cpp:2758
 msgid "Rejects a packet when its source IP differs from the IP the client claims (an anti-spoofing check). Disable only if it causes connection problems."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2729
+#: src/muuli_wdr.cpp:2760
 msgid "Use system-wide ipfilter.dat if available"
 msgstr "如果可以則使用系統級的 ipfilter.dat"
 
-#: src/muuli_wdr.cpp:2730
+#: src/muuli_wdr.cpp:2761
 #, fuzzy
 msgid "If there's no local ipfilter.dat found, allow usage of a system-wide ipfilter file."
 msgstr "如果找不到本機 ipfilter.dat 檔案，則允許使用系統級的 IP 過濾檔。"
 
-#: src/muuli_wdr.cpp:2747
+#: src/muuli_wdr.cpp:2778
 msgid "Enable Online-Signature"
 msgstr "啟用線上簽名識別"
 
-#: src/muuli_wdr.cpp:2749
+#: src/muuli_wdr.cpp:2780
 msgid "Enables the writing of the OS file, which can be used by external apps to create signatures and the like."
 msgstr "啟用寫入到作業系統檔案，以讓外部程式用來建立簽名識別等等。"
 
-#: src/muuli_wdr.cpp:2753
+#: src/muuli_wdr.cpp:2784
 msgid "Update Frequency (Secs):"
 msgstr "更新頻率(秒)："
 
-#: src/muuli_wdr.cpp:2756
+#: src/muuli_wdr.cpp:2787
 msgid "Change the frequency (in seconds) of Online Signature updates."
 msgstr "變更線上簽名識別檔的更新頻率 (單位為 秒)。"
 
-#: src/muuli_wdr.cpp:2764
+#: src/muuli_wdr.cpp:2795
 msgid "Save online signature file in: "
 msgstr "儲存線上簽名識別檔："
 
-#: src/muuli_wdr.cpp:2770
+#: src/muuli_wdr.cpp:2801
 msgid "Click here to select the directory containing the the Online Signature files."
 msgstr "點擊選取線上簽識別名檔案所在的目錄。"
 
-#: src/muuli_wdr.cpp:2803
+#: src/muuli_wdr.cpp:2834
 msgid "Show country flags for clients"
 msgstr "顯示客戶端的國旗"
 
-#: src/muuli_wdr.cpp:2804
+#: src/muuli_wdr.cpp:2835
 msgid "Render the country flag column in the transfers, queue and search views. Requires a valid MMDB GeoIP database (see below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2809
+#: src/muuli_wdr.cpp:2840
 #, fuzzy
 msgid "Database"
 msgstr "速度："
 
-#: src/muuli_wdr.cpp:2825
+#: src/muuli_wdr.cpp:2856
 #, fuzzy
 msgid "Source:"
 msgstr "來源"
 
-#: src/muuli_wdr.cpp:2828
+#: src/muuli_wdr.cpp:2859
 msgid "DB-IP (free, no account)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2829
+#: src/muuli_wdr.cpp:2860
 msgid "MaxMind GeoLite2 (free, account required)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2830
+#: src/muuli_wdr.cpp:2861
 msgid "Custom URL"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2833
+#: src/muuli_wdr.cpp:2864
 msgid "Choose which provider supplies the GeoIP MMDB database. DB-IP is the default - no account required. MaxMind requires a free account + license key. Use Custom URL to point at any other MMDB host (e.g. a local mirror)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2850
+#: src/muuli_wdr.cpp:2881
 msgid ""
 "No configuration required.\n"
 "\n"
@@ -4844,11 +4872,11 @@ msgid ""
 "License: Creative Commons BY 4.0 - https://creativecommons.org/licenses/by/4.0/"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2863
+#: src/muuli_wdr.cpp:2894
 msgid "License key:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2869
+#: src/muuli_wdr.cpp:2900
 msgid ""
 "Sign up for a free MaxMind account, then generate a License Key:\n"
 "https://www.maxmind.com/en/geolite2/signup\n"
@@ -4858,226 +4886,226 @@ msgid ""
 "Requires attribution and account registration; refresh at least every 30 days."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2884
+#: src/muuli_wdr.cpp:2915
 #, fuzzy
 msgid "Download URL:"
 msgstr "下載："
 
-#: src/muuli_wdr.cpp:2890
+#: src/muuli_wdr.cpp:2921
 msgid ""
 "Must point to an .mmdb file or a .gz / .tar.gz containing one.\n"
 "URL may include credentials (https://user:pass@host/...).\n"
 "License and attribution terms are set by the upstream URL - you are responsible."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2903
+#: src/muuli_wdr.cpp:2934
 msgid "Download the GeoIP database from the selected source."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2905
+#: src/muuli_wdr.cpp:2936
 #, fuzzy
 msgid "Auto-update on startup"
 msgstr "啓動後自動更新 IP 過濾清單"
 
-#: src/muuli_wdr.cpp:2906
+#: src/muuli_wdr.cpp:2937
 msgid "Re-download the GeoIP database from the selected source every time aMule starts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2929
+#: src/muuli_wdr.cpp:2960
 msgid "Filter incoming messages (except current chat):"
 msgstr "過濾收到的訊息 (不包含目前交談)："
 
-#: src/muuli_wdr.cpp:2931
+#: src/muuli_wdr.cpp:2962
 msgid "Filter all messages"
 msgstr "過濾所有訊息"
 
-#: src/muuli_wdr.cpp:2933
+#: src/muuli_wdr.cpp:2964
 msgid "Filter messages from people not on your friend list"
 msgstr "過濾來自好友以外的訊息"
 
-#: src/muuli_wdr.cpp:2935
+#: src/muuli_wdr.cpp:2966
 msgid "Filter messages from unknown clients"
 msgstr "過濾來自不明客戶端的訊息"
 
-#: src/muuli_wdr.cpp:2937
+#: src/muuli_wdr.cpp:2968
 msgid "Filter messages containing (use ',' as separator):"
 msgstr "過濾含以下內容的訊息 (用逗號 ',' 隔開)："
 
-#: src/muuli_wdr.cpp:2940 src/muuli_wdr.cpp:2951
+#: src/muuli_wdr.cpp:2971 src/muuli_wdr.cpp:2982
 msgid "add here the words amule should filter and block messages including it"
 msgstr "輸入要過濾的詞句"
 
-#: src/muuli_wdr.cpp:2942
+#: src/muuli_wdr.cpp:2973
 msgid "Show received messages in the log"
 msgstr "記錄收到的訊息"
 
-#: src/muuli_wdr.cpp:2945
+#: src/muuli_wdr.cpp:2976
 msgid "Comments"
 msgstr "註解"
 
-#: src/muuli_wdr.cpp:2948
+#: src/muuli_wdr.cpp:2979
 msgid "Filter comments containing (use ',' as separator):"
 msgstr "過濾含以下內容的註解 (用逗號 ',' 隔開)："
 
-#: src/muuli_wdr.cpp:2973
+#: src/muuli_wdr.cpp:3004
 msgid "Enable Proxy"
 msgstr "啓用代理伺服器"
 
-#: src/muuli_wdr.cpp:2974
+#: src/muuli_wdr.cpp:3005
 msgid "Enable/disable proxy support"
 msgstr "啓用/停用代理伺服器支援"
 
-#: src/muuli_wdr.cpp:2977
+#: src/muuli_wdr.cpp:3008
 msgid "Proxy type:"
 msgstr "類型："
 
-#: src/muuli_wdr.cpp:2988
+#: src/muuli_wdr.cpp:3019
 msgid "Proxy host:"
 msgstr "主機："
 
-#: src/muuli_wdr.cpp:2991
+#: src/muuli_wdr.cpp:3022
 msgid "The proxy host name"
 msgstr "代理伺服器主機名稱"
 
-#: src/muuli_wdr.cpp:2993
+#: src/muuli_wdr.cpp:3024
 msgid "Proxy port:"
 msgstr "連接埠："
 
-#: src/muuli_wdr.cpp:2996
+#: src/muuli_wdr.cpp:3027
 msgid "The proxy port"
 msgstr "代理伺服器連接埠"
 
-#: src/muuli_wdr.cpp:2998
+#: src/muuli_wdr.cpp:3029
 msgid "Enable authentication"
 msgstr "啓用登入驗證"
 
-#: src/muuli_wdr.cpp:2999
+#: src/muuli_wdr.cpp:3030
 msgid "Enable/disable username/password authentication"
 msgstr "啓用/停用 使用者名稱/密碼登入驗證"
 
-#: src/muuli_wdr.cpp:3002
+#: src/muuli_wdr.cpp:3033
 msgid "Username: "
 msgstr "使用者名稱："
 
-#: src/muuli_wdr.cpp:3005
+#: src/muuli_wdr.cpp:3036
 msgid "The username to use to connect to the proxy"
 msgstr "登入代理伺服器的使用者名稱"
 
-#: src/muuli_wdr.cpp:3007
+#: src/muuli_wdr.cpp:3038
 msgid "Password:"
 msgstr "密碼："
 
-#: src/muuli_wdr.cpp:3010
+#: src/muuli_wdr.cpp:3041
 msgid "The password to use to connect to the proxy"
 msgstr "登入代理伺服器的密碼"
 
-#: src/muuli_wdr.cpp:3029
+#: src/muuli_wdr.cpp:3060
 msgid "Connect to:"
 msgstr "連線到："
 
-#: src/muuli_wdr.cpp:3038
+#: src/muuli_wdr.cpp:3069
 msgid "Login to remote amule"
 msgstr "登入遠端 amule"
 
-#: src/muuli_wdr.cpp:3043
+#: src/muuli_wdr.cpp:3074
 msgid "User name"
 msgstr "使用者名稱"
 
-#: src/muuli_wdr.cpp:3054
+#: src/muuli_wdr.cpp:3085
 msgid "Remember those settings"
 msgstr "記住這些設定"
 
-#: src/muuli_wdr.cpp:3057
+#: src/muuli_wdr.cpp:3088
 #, fuzzy
 msgid "Force ZLIB compression"
 msgstr "使用 gzip 壓縮"
 
-#: src/muuli_wdr.cpp:3081
+#: src/muuli_wdr.cpp:3112
 msgid "Enable Verbose Debug-Logging."
 msgstr "啓用記錄詳細除錯訊息。"
 
-#: src/muuli_wdr.cpp:3083
+#: src/muuli_wdr.cpp:3114
 #, fuzzy
 msgid "Only to Logfile"
 msgstr "開啟檔案(&O)"
 
-#: src/muuli_wdr.cpp:3085
+#: src/muuli_wdr.cpp:3116
 msgid "Message Categories:"
 msgstr "訊息分類："
 
-#: src/muuli_wdr.cpp:3109 src/PartFileConvertDlg.cpp:160
+#: src/muuli_wdr.cpp:3140 src/PartFileConvertDlg.cpp:160
 msgid "Waiting..."
 msgstr "等候中..."
 
-#: src/muuli_wdr.cpp:3129
+#: src/muuli_wdr.cpp:3160
 msgid "Add imports"
 msgstr "加入"
 
-#: src/muuli_wdr.cpp:3132
+#: src/muuli_wdr.cpp:3163
 msgid "Retry selected"
 msgstr "重試"
 
-#: src/muuli_wdr.cpp:3134
+#: src/muuli_wdr.cpp:3165
 msgid "Remove selected"
 msgstr "移除"
 
-#: src/muuli_wdr.cpp:3197
+#: src/muuli_wdr.cpp:3228
 msgid "Event Types"
 msgstr "事件種類"
 
-#: src/muuli_wdr.cpp:3216
+#: src/muuli_wdr.cpp:3247
 msgid "Statistics and queued clients for selected file(s) : Session / All time"
 msgstr "已選取的檔案的統計資料與等候區客戶端數：本次 / 總計"
 
-#: src/muuli_wdr.cpp:3240
+#: src/muuli_wdr.cpp:3271
 msgid "Active Uploads"
 msgstr "目前上傳數"
 
-#: src/muuli_wdr.cpp:3254
+#: src/muuli_wdr.cpp:3285
 msgid "Percent of total files"
 msgstr "% (所有檔案中)"
 
-#: src/muuli_wdr.cpp:3306
+#: src/muuli_wdr.cpp:3337
 msgid "Show Clients for"
 msgstr "顯示客戶端："
 
-#: src/muuli_wdr.cpp:3308
+#: src/muuli_wdr.cpp:3339
 msgid "All files"
 msgstr "所有檔案"
 
-#: src/muuli_wdr.cpp:3311
+#: src/muuli_wdr.cpp:3342
 msgid "Selected files"
 msgstr "選取的檔案"
 
-#: src/muuli_wdr.cpp:3314
+#: src/muuli_wdr.cpp:3345
 msgid "Active uploads only"
 msgstr "僅限目前上傳中"
 
-#: src/muuli_wdr.cpp:3321
+#: src/muuli_wdr.cpp:3352
 msgid "Reload:"
 msgstr "重新載入："
 
-#: src/muuli_wdr.cpp:3325
+#: src/muuli_wdr.cpp:3356
 msgid "Reload your shared files"
 msgstr "重新載入分享的檔案"
 
-#: src/muuli_wdr.cpp:3388
+#: src/muuli_wdr.cpp:3419
 msgid "Send"
 msgstr "傳送"
 
-#: src/muuli_wdr.cpp:3389
+#: src/muuli_wdr.cpp:3420
 msgid "Sends the specified message."
 msgstr "傳送訊息。"
 
-#: src/muuli_wdr.cpp:3393
+#: src/muuli_wdr.cpp:3424
 msgid "Close this chat-session."
 msgstr "結束本次交談。"
 
-#: src/muuli_wdr.cpp:3416
+#: src/muuli_wdr.cpp:3447
 msgid "Connect to any server and/or Kad"
 msgstr "連線到任何伺服器 和/或 Kad 網路"
 
-#: src/muuli_wdr.cpp:3422 src/SharedFilesCtrl.cpp:142 src/Statistics.cpp:941
+#: src/muuli_wdr.cpp:3453 src/SharedFilesCtrl.cpp:142 src/Statistics.cpp:941
 msgid "Shared Files"
 msgstr "分享檔案"
 
@@ -5432,249 +5460,249 @@ msgstr "已下載"
 msgid "ERROR: Failed to open partfile '%s'"
 msgstr "錯誤：無法開啟暫存檔 %s"
 
-#: src/Preferences.cpp:674
+#: src/Preferences.cpp:701
 msgid "System default"
 msgstr "系統預設"
 
-#: src/Preferences.cpp:675
+#: src/Preferences.cpp:702
 msgid "Albanian"
 msgstr "阿爾巴尼亞語"
 
-#: src/Preferences.cpp:676
+#: src/Preferences.cpp:703
 msgid "Arabic"
 msgstr "阿拉伯語"
 
-#: src/Preferences.cpp:677
+#: src/Preferences.cpp:704
 msgid "Asturian"
 msgstr "奧地利語"
 
-#: src/Preferences.cpp:678
+#: src/Preferences.cpp:705
 msgid "Basque"
 msgstr "巴斯克語"
 
-#: src/Preferences.cpp:679
+#: src/Preferences.cpp:706
 msgid "Bulgarian"
 msgstr "保加利亞語"
 
-#: src/Preferences.cpp:680
+#: src/Preferences.cpp:707
 msgid "Catalan"
 msgstr "加泰隆尼亞語"
 
-#: src/Preferences.cpp:681
+#: src/Preferences.cpp:708
 msgid "Chinese (Simplified)"
 msgstr "簡體中文"
 
-#: src/Preferences.cpp:682
+#: src/Preferences.cpp:709
 msgid "Chinese (Traditional)"
 msgstr "正體中文"
 
-#: src/Preferences.cpp:683
+#: src/Preferences.cpp:710
 msgid "Croatian"
 msgstr "克羅埃西亞語"
 
-#: src/Preferences.cpp:684
+#: src/Preferences.cpp:711
 msgid "Czech"
 msgstr "捷克語"
 
-#: src/Preferences.cpp:685
+#: src/Preferences.cpp:712
 msgid "Danish"
 msgstr "丹麥語"
 
-#: src/Preferences.cpp:686
+#: src/Preferences.cpp:713
 msgid "Dutch"
 msgstr "荷蘭語"
 
-#: src/Preferences.cpp:687
+#: src/Preferences.cpp:714
 msgid "English (U.K.)"
 msgstr "英語 (英國)"
 
-#: src/Preferences.cpp:688
+#: src/Preferences.cpp:715
 #, fuzzy
 msgid "English (U.S.)"
 msgstr "英語 (英國)"
 
-#: src/Preferences.cpp:689
+#: src/Preferences.cpp:716
 msgid "Estonian"
 msgstr "愛沙尼亞語"
 
-#: src/Preferences.cpp:690
+#: src/Preferences.cpp:717
 msgid "Finnish"
 msgstr "芬蘭語"
 
-#: src/Preferences.cpp:691
+#: src/Preferences.cpp:718
 msgid "French"
 msgstr "法語"
 
-#: src/Preferences.cpp:692
+#: src/Preferences.cpp:719
 msgid "Galician"
 msgstr "加利西亞語"
 
-#: src/Preferences.cpp:693
+#: src/Preferences.cpp:720
 msgid "German"
 msgstr "德語"
 
-#: src/Preferences.cpp:694
+#: src/Preferences.cpp:721
 msgid "Greek"
 msgstr "希臘語"
 
-#: src/Preferences.cpp:695
+#: src/Preferences.cpp:722
 msgid "Hebrew"
 msgstr "希伯來語"
 
-#: src/Preferences.cpp:696
+#: src/Preferences.cpp:723
 msgid "Hungarian"
 msgstr "匈牙利語"
 
-#: src/Preferences.cpp:697
+#: src/Preferences.cpp:724
 msgid "Italian"
 msgstr "義大利語"
 
-#: src/Preferences.cpp:698
+#: src/Preferences.cpp:725
 msgid "Japanese"
 msgstr "日語"
 
-#: src/Preferences.cpp:699
+#: src/Preferences.cpp:726
 msgid "Korean"
 msgstr "韓語"
 
-#: src/Preferences.cpp:700
+#: src/Preferences.cpp:727
 msgid "Latvian"
 msgstr ""
 
-#: src/Preferences.cpp:701
+#: src/Preferences.cpp:728
 msgid "Lithuanian"
 msgstr "立陶宛語"
 
-#: src/Preferences.cpp:702
+#: src/Preferences.cpp:729
 msgid "Norwegian (Nynorsk)"
 msgstr "新挪威語"
 
-#: src/Preferences.cpp:703
+#: src/Preferences.cpp:730
 msgid "Polish"
 msgstr "波蘭語"
 
-#: src/Preferences.cpp:704
+#: src/Preferences.cpp:731
 msgid "Portuguese"
 msgstr "葡萄牙語"
 
-#: src/Preferences.cpp:705
+#: src/Preferences.cpp:732
 msgid "Portuguese (Brazilian)"
 msgstr "葡萄牙語 (巴西)"
 
-#: src/Preferences.cpp:706
+#: src/Preferences.cpp:733
 msgid "Romanian"
 msgstr "羅馬尼亞語"
 
-#: src/Preferences.cpp:707
+#: src/Preferences.cpp:734
 msgid "Russian"
 msgstr "俄語"
 
-#: src/Preferences.cpp:708
+#: src/Preferences.cpp:735
 msgid "Slovenian"
 msgstr "斯洛維尼亞語"
 
-#: src/Preferences.cpp:709
+#: src/Preferences.cpp:736
 msgid "Spanish"
 msgstr "西班牙語"
 
-#: src/Preferences.cpp:710
+#: src/Preferences.cpp:737
 msgid "Swedish"
 msgstr "瑞典語"
 
-#: src/Preferences.cpp:711
+#: src/Preferences.cpp:738
 msgid "Turkish"
 msgstr "土耳其語"
 
-#: src/Preferences.cpp:712
+#: src/Preferences.cpp:739
 msgid "Ukrainian"
 msgstr "烏克蘭語"
 
-#: src/Preferences.cpp:815
+#: src/Preferences.cpp:842
 msgid "Change Language"
 msgstr "變更語言"
 
-#: src/Preferences.cpp:879
+#: src/Preferences.cpp:906
 msgid "There are no translations installed for aMule"
 msgstr "沒有已安裝的 aMule 翻譯"
 
-#: src/Preferences.cpp:880
+#: src/Preferences.cpp:907
 msgid "No languages available"
 msgstr "沒有可用的語言"
 
-#: src/Preferences.cpp:1011
+#: src/Preferences.cpp:1038
 msgid "no options available"
 msgstr "沒有選項"
 
-#: src/Preferences.cpp:2182
+#: src/Preferences.cpp:2227
 msgid "Invalid category found, skipping"
 msgstr "找到無效的分類，略過"
 
-#: src/Preferences.cpp:2351
+#: src/Preferences.cpp:2396
 msgid "TCP port can't be higher than 65532 due to server UDP socket being TCP+3"
 msgstr "TCP 埠不可大於 65532，因爲伺服器 UDP 連接端點值爲 TCP 埠值+3"
 
-#: src/Preferences.cpp:2352
+#: src/Preferences.cpp:2397
 #, c-format
 msgid "Default port will be used (%d)"
 msgstr "使用預設通訊埠 (%d)"
 
-#: src/PrefsUnifiedDlg.cpp:298 src/Statistics.cpp:866
+#: src/PrefsUnifiedDlg.cpp:300 src/Statistics.cpp:866
 msgid "Connection"
 msgstr "連線"
 
-#: src/PrefsUnifiedDlg.cpp:299 src/SearchListCtrl.cpp:117
+#: src/PrefsUnifiedDlg.cpp:301 src/SearchListCtrl.cpp:117
 msgid "Directories"
 msgstr "目錄"
 
-#: src/PrefsUnifiedDlg.cpp:300 src/Statistics.cpp:917
+#: src/PrefsUnifiedDlg.cpp:302 src/Statistics.cpp:917
 msgid "Servers"
 msgstr "伺服器"
 
-#: src/PrefsUnifiedDlg.cpp:301 src/ServerListCtrl.cpp:96
+#: src/PrefsUnifiedDlg.cpp:303 src/ServerListCtrl.cpp:96
 msgid "Files"
 msgstr "檔案"
 
-#: src/PrefsUnifiedDlg.cpp:302
+#: src/PrefsUnifiedDlg.cpp:304
 msgid "Security"
 msgstr "安全"
 
-#: src/PrefsUnifiedDlg.cpp:303
+#: src/PrefsUnifiedDlg.cpp:305
 msgid "Interface"
 msgstr "介面"
 
-#: src/PrefsUnifiedDlg.cpp:310
+#: src/PrefsUnifiedDlg.cpp:312
 msgid "IP2Country"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:313
+#: src/PrefsUnifiedDlg.cpp:315
 msgid "Proxy"
 msgstr "代理伺服器"
 
-#: src/PrefsUnifiedDlg.cpp:314
+#: src/PrefsUnifiedDlg.cpp:316
 msgid "Filters"
 msgstr "過濾"
 
-#: src/PrefsUnifiedDlg.cpp:315
+#: src/PrefsUnifiedDlg.cpp:317
 msgid "Remote Controls"
 msgstr "遠端控制"
 
-#: src/PrefsUnifiedDlg.cpp:316
+#: src/PrefsUnifiedDlg.cpp:318
 msgid "Online Signature"
 msgstr "線上簽名識別"
 
-#: src/PrefsUnifiedDlg.cpp:317
+#: src/PrefsUnifiedDlg.cpp:319
 msgid "Advanced"
 msgstr "進階"
 
-#: src/PrefsUnifiedDlg.cpp:318
+#: src/PrefsUnifiedDlg.cpp:320
 msgid "Events"
 msgstr "事件"
 
-#: src/PrefsUnifiedDlg.cpp:321
+#: src/PrefsUnifiedDlg.cpp:323
 msgid "Debugging"
 msgstr "除錯"
 
-#: src/PrefsUnifiedDlg.cpp:451
+#: src/PrefsUnifiedDlg.cpp:453
 msgid ""
 "The following variables will be substituted:\n"
 "    %PARTFILE - full path to the file\n"
@@ -5684,15 +5712,15 @@ msgstr ""
 "    %PARTFILE - 檔案的完整路徑\n"
 "    %PARTNAME - 只有檔案名稱"
 
-#: src/PrefsUnifiedDlg.cpp:472
+#: src/PrefsUnifiedDlg.cpp:474
 msgid "Tray icon support requires libayatana-appindicator3 at compile time."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:488
+#: src/PrefsUnifiedDlg.cpp:490
 msgid "Not available on Wayland: the protocol does not report when a window is minimized, so this option cannot intercept the system minimize button. Workaround: launch aMule with `GDK_BACKEND=x11` to use XWayland instead."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:534
+#: src/PrefsUnifiedDlg.cpp:536
 msgid ""
 "Do not change these setting unless you know\n"
 "what you are doing, otherwise you can easily\n"
@@ -5707,26 +5735,35 @@ msgstr ""
 "\n"
 "即使不變更這些設定，aMule 一樣可以正常運作。"
 
-#: src/PrefsUnifiedDlg.cpp:645
+#: src/PrefsUnifiedDlg.cpp:647
 #, c-format
 msgid "Failed to connect Cfg to widget with the ID %d and key %s"
 msgstr "無法以 ID %d、key %s 將 Cfg 與 widget 相連"
 
-#: src/PrefsUnifiedDlg.cpp:693
+#: src/PrefsUnifiedDlg.cpp:695
 #, c-format
 msgid "Failed to transfer data from Cfg to Widget with the ID %d and key %s"
 msgstr "無法以 ID %d、key %s 將資料 Cfg 與 widget 連線"
 
-#: src/PrefsUnifiedDlg.cpp:799
+#: src/PrefsUnifiedDlg.cpp:801
 msgid "The type of proxy you are connecting to"
 msgstr "正在連線的代理伺服器類型"
 
-#: src/PrefsUnifiedDlg.cpp:1003
+#: src/PrefsUnifiedDlg.cpp:1020
 #, c-format
 msgid "Failed to transfer data from Widget to Cfg with the ID %d and key %s"
 msgstr "無法以 ID %d、key %s 從 Cfg 傳輸資料到 Widget"
 
 #: src/PrefsUnifiedDlg.cpp:1103
+#, fuzzy
+msgid "No password set."
+msgstr "正在檢查密碼\n"
+
+#: src/PrefsUnifiedDlg.cpp:1132
+msgid "Guest access needs a password. Type one in the guest password field, or untick Enable guest access."
+msgstr ""
+
+#: src/PrefsUnifiedDlg.cpp:1144
 msgid ""
 "aMule must be restarted to enable these changes:\n"
 "\n"
@@ -5734,42 +5771,42 @@ msgstr ""
 "請重新啟動 aMule，變更的設定才能生效：\n"
 "\n"
 
-#: src/PrefsUnifiedDlg.cpp:1110
+#: src/PrefsUnifiedDlg.cpp:1151
 msgid "- TCP port changed.\n"
 msgstr "- TCP 埠已變更。\n"
 
-#: src/PrefsUnifiedDlg.cpp:1115
+#: src/PrefsUnifiedDlg.cpp:1156
 msgid "- UDP port changed.\n"
 msgstr "- UDP 埠已變更。\n"
 
-#: src/PrefsUnifiedDlg.cpp:1120
+#: src/PrefsUnifiedDlg.cpp:1161
 #, fuzzy
 msgid "- Network interface binding changed.\n"
 msgstr "- 已變更外部連線介面設定。\n"
 
-#: src/PrefsUnifiedDlg.cpp:1125
+#: src/PrefsUnifiedDlg.cpp:1166
 msgid "- External connect port changed.\n"
 msgstr "- 已變更外部連線埠設定。\n"
 
-#: src/PrefsUnifiedDlg.cpp:1129
+#: src/PrefsUnifiedDlg.cpp:1170
 msgid "- External connect acceptance changed.\n"
 msgstr "- 已變更外部連線設定。\n"
 
-#: src/PrefsUnifiedDlg.cpp:1133
+#: src/PrefsUnifiedDlg.cpp:1174
 msgid "- External connect interface changed.\n"
 msgstr "- 已變更外部連線介面設定。\n"
 
-#: src/PrefsUnifiedDlg.cpp:1137
+#: src/PrefsUnifiedDlg.cpp:1178
 #, fuzzy
 msgid "- Protocol obfuscation support changed.\n"
 msgstr "模糊協定"
 
-#: src/PrefsUnifiedDlg.cpp:1151
+#: src/PrefsUnifiedDlg.cpp:1193
 #, fuzzy
 msgid "- amuleapi settings changed.\n"
 msgstr "- 語言已變更。\n"
 
-#: src/PrefsUnifiedDlg.cpp:1160
+#: src/PrefsUnifiedDlg.cpp:1202
 msgid ""
 "Your Auto-update server list is empty.\n"
 "'Auto-update server list at startup' will be disabled."
@@ -5777,7 +5814,7 @@ msgstr ""
 "您的自動更新伺服器清單是空的。\n"
 "「啟動時自動更新伺服器清單」功能將被停用。"
 
-#: src/PrefsUnifiedDlg.cpp:1171
+#: src/PrefsUnifiedDlg.cpp:1213
 msgid ""
 "You have enabled external connections but have not specified a password.\n"
 "External connections cannot be enabled unless a valid password is specified."
@@ -5785,28 +5822,33 @@ msgstr ""
 "您已經設定啓用外部連線但還沒有輸入密碼，\n"
 "輸入有效密碼之後，外部連線才能開始使用。"
 
-#: src/PrefsUnifiedDlg.cpp:1202
+#: src/PrefsUnifiedDlg.cpp:1246
+#, c-format
+msgid "The amuleapi password could not be saved: %s"
+msgstr ""
+
+#: src/PrefsUnifiedDlg.cpp:1276
 msgid "- Language changed.\n"
 msgstr "- 語言已變更。\n"
 
-#: src/PrefsUnifiedDlg.cpp:1207
+#: src/PrefsUnifiedDlg.cpp:1281
 msgid "- Temp folder changed.\n"
 msgstr "- 暫存資料夾已變更。\n"
 
-#: src/PrefsUnifiedDlg.cpp:1212
+#: src/PrefsUnifiedDlg.cpp:1286
 msgid "- ED2K network enabled.\n"
 msgstr "- ED2K 網路已啟用。\n"
 
-#: src/PrefsUnifiedDlg.cpp:1245
+#: src/PrefsUnifiedDlg.cpp:1319
 msgid "The shared-file exclusion pattern is not a valid regular expression. The filter has been left disabled."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1247 src/PrefsUnifiedDlg.cpp:1841
+#: src/PrefsUnifiedDlg.cpp:1321 src/PrefsUnifiedDlg.cpp:1921
 #, fuzzy
 msgid "Invalid regular expression"
 msgstr "協定版本無效。"
 
-#: src/PrefsUnifiedDlg.cpp:1324
+#: src/PrefsUnifiedDlg.cpp:1398
 msgid ""
 "Both eD2k and Kad network are disabled.\n"
 "You won't be able to connect until you enable at least one of them."
@@ -5814,7 +5856,7 @@ msgstr ""
 "eD2k 與 Kad 網路都已停用。\n"
 "請至少啟用一種，否則您將無法連線。"
 
-#: src/PrefsUnifiedDlg.cpp:1329
+#: src/PrefsUnifiedDlg.cpp:1403
 msgid ""
 "Kad will not start if your UDP port is disabled.\n"
 "Enable UDP port or disable Kad."
@@ -5822,7 +5864,7 @@ msgstr ""
 "如果您停用 UDP 埠，Kad 將無法啓動。\n"
 "請啟用 UDP 埠或停用 Kad。"
 
-#: src/PrefsUnifiedDlg.cpp:1385
+#: src/PrefsUnifiedDlg.cpp:1459
 msgid ""
 "\n"
 "You MUST restart aMule now.\n"
@@ -5832,69 +5874,69 @@ msgstr ""
 "您必須立即重新啟動 aMule，\n"
 "如果現在不重啟動，可能會發生不可預期的問題。\n"
 
-#: src/PrefsUnifiedDlg.cpp:1450
+#: src/PrefsUnifiedDlg.cpp:1524
 msgid "Could not register aMule for autostart at login. The autostart store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1452
+#: src/PrefsUnifiedDlg.cpp:1526
 msgid "Could not remove the autostart-at-login entry."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1453
+#: src/PrefsUnifiedDlg.cpp:1527
 #, fuzzy
 msgid "Autostart"
 msgstr "已開始自動更新顯示"
 
-#: src/PrefsUnifiedDlg.cpp:1468
+#: src/PrefsUnifiedDlg.cpp:1542
 msgid "Register file type"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1468
+#: src/PrefsUnifiedDlg.cpp:1542
 msgid "Register URL handler"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1476
+#: src/PrefsUnifiedDlg.cpp:1550
 #, c-format
 msgid "aMule only handles eD2k-compatible magnets. If you replace the current magnet handler (%s), BitTorrent magnet links will stop working - aMule cannot download BitTorrent content. Continue?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1481
+#: src/PrefsUnifiedDlg.cpp:1555
 #, c-format
 msgid "Another application currently opens .emulecollection files (%s). Replace it with aMule?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1486
+#: src/PrefsUnifiedDlg.cpp:1560
 #, c-format
 msgid "Another application is currently the default handler for these links (%s). Replace it with aMule?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1511
+#: src/PrefsUnifiedDlg.cpp:1585
 msgid "Could not register aMule for .emulecollection files. The registration store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1513
+#: src/PrefsUnifiedDlg.cpp:1587
 #, fuzzy
 msgid "Could not remove the file type registration."
 msgstr "暫存資料夾"
 
-#: src/PrefsUnifiedDlg.cpp:1515
+#: src/PrefsUnifiedDlg.cpp:1589
 msgid "Could not register aMule as the URL handler. The registration store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1517
+#: src/PrefsUnifiedDlg.cpp:1591
 msgid "Could not remove the URL handler registration."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1587 src/PrefsUnifiedDlg.cpp:1614
+#: src/PrefsUnifiedDlg.cpp:1661 src/PrefsUnifiedDlg.cpp:1688
 #, fuzzy
 msgid "The web server and aMule API require external connections to be enabled."
 msgstr "密碼已設定，外部連線已啟用。"
 
-#: src/PrefsUnifiedDlg.cpp:1597
+#: src/PrefsUnifiedDlg.cpp:1671
 msgid "The aMule web server is deprecated. Consider running the aMule API instead."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1655
+#: src/PrefsUnifiedDlg.cpp:1735
 msgid ""
 "Your Auto-update servers list is in blank.\n"
 "Please fill in at least one URL to point to a valid server.met file.\n"
@@ -5904,65 +5946,65 @@ msgstr ""
 "請至少輸入一個能取得有效 server.met 檔案的網址。\n"
 "請點選旁邊的「清單」按鈕後輸入。"
 
-#: src/PrefsUnifiedDlg.cpp:1796
+#: src/PrefsUnifiedDlg.cpp:1876
 msgid "Temporary files"
 msgstr "暫存檔"
 
-#: src/PrefsUnifiedDlg.cpp:1801
+#: src/PrefsUnifiedDlg.cpp:1881
 msgid "Incoming files"
 msgstr "新進檔案"
 
-#: src/PrefsUnifiedDlg.cpp:1806
+#: src/PrefsUnifiedDlg.cpp:1886
 msgid "Online Signatures"
 msgstr "線上簽名識別"
 
-#: src/PrefsUnifiedDlg.cpp:1819
+#: src/PrefsUnifiedDlg.cpp:1899
 #, c-format
 msgid "Choose a folder for %s"
 msgstr "爲 %s 選擇資料夾"
 
-#: src/PrefsUnifiedDlg.cpp:1843
+#: src/PrefsUnifiedDlg.cpp:1923
 #, fuzzy, c-format
 msgid "Would exclude %u of %u shared file"
 msgid_plural "Would exclude %u of %u shared files"
 msgstr[0] "找到 %i 個已知的分享檔案"
 
-#: src/PrefsUnifiedDlg.cpp:1860
+#: src/PrefsUnifiedDlg.cpp:1940
 msgid "Browse for videoplayer"
 msgstr "瀏覽尋找影片播放器"
 
-#: src/PrefsUnifiedDlg.cpp:1864
+#: src/PrefsUnifiedDlg.cpp:1944
 msgid "Select browser"
 msgstr "設定瀏覽器"
 
-#: src/PrefsUnifiedDlg.cpp:1868
+#: src/PrefsUnifiedDlg.cpp:1948
 #, fuzzy
 msgid "Select ffprobe binary"
 msgstr "設定瀏覽器"
 
-#: src/PrefsUnifiedDlg.cpp:1874
+#: src/PrefsUnifiedDlg.cpp:1954
 #, c-format
 msgid "Executable%s"
 msgstr "可執行%s"
 
-#: src/PrefsUnifiedDlg.cpp:1908
+#: src/PrefsUnifiedDlg.cpp:1988
 msgid "ffprobe not found on PATH or in the standard install locations. Install ffmpeg (which ships ffprobe) or use Browse to pick a binary manually."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1920
+#: src/PrefsUnifiedDlg.cpp:2000
 msgid "Reset the settings on this page to their default values?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1921
+#: src/PrefsUnifiedDlg.cpp:2001
 #, fuzzy
 msgid "Reset to defaults"
 msgstr "系統預設"
 
-#: src/PrefsUnifiedDlg.cpp:1948
+#: src/PrefsUnifiedDlg.cpp:2028
 msgid "Edit server list"
 msgstr "編輯伺服器清單"
 
-#: src/PrefsUnifiedDlg.cpp:1949
+#: src/PrefsUnifiedDlg.cpp:2029
 msgid ""
 "Add here URL's to download server.met files.\n"
 "Only one url on each line."
@@ -5970,151 +6012,151 @@ msgstr ""
 "加入可下載 server.met 檔案的網址。\n"
 "每一行一個網址。"
 
-#: src/PrefsUnifiedDlg.cpp:2004
+#: src/PrefsUnifiedDlg.cpp:2084
 msgid "IP2Country update failed"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2149 src/PrefsUnifiedDlg.cpp:2180
+#: src/PrefsUnifiedDlg.cpp:2229 src/PrefsUnifiedDlg.cpp:2260
 msgid "Data by MaxMind GeoLite2"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2151 src/PrefsUnifiedDlg.cpp:2182
+#: src/PrefsUnifiedDlg.cpp:2231 src/PrefsUnifiedDlg.cpp:2262
 #, fuzzy
 msgid "Custom source"
 msgstr "完整來源"
 
-#: src/PrefsUnifiedDlg.cpp:2153 src/PrefsUnifiedDlg.cpp:2184
+#: src/PrefsUnifiedDlg.cpp:2233 src/PrefsUnifiedDlg.cpp:2264
 msgid "Data by DB-IP.com"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2204
+#: src/PrefsUnifiedDlg.cpp:2284
 #, fuzzy, c-format
 msgid "Status: Loaded%s"
 msgstr "狀態："
 
-#: src/PrefsUnifiedDlg.cpp:2206
+#: src/PrefsUnifiedDlg.cpp:2286
 #, fuzzy, c-format
 msgid "Status: Loaded%s - %s"
 msgstr "狀態："
 
-#: src/PrefsUnifiedDlg.cpp:2210
+#: src/PrefsUnifiedDlg.cpp:2290
 msgid "Status: Failed to load - click 'Update now' to refresh."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2212
+#: src/PrefsUnifiedDlg.cpp:2292
 msgid "Status: Not found - click 'Update now' to download."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2270 src/PrefsUnifiedDlg.cpp:2294
+#: src/PrefsUnifiedDlg.cpp:2350 src/PrefsUnifiedDlg.cpp:2374
 #, c-format
 msgid "Update delay: %d second"
 msgid_plural "Update delay: %d seconds"
 msgstr[0] "更新延遲時間：%d 秒"
 
-#: src/PrefsUnifiedDlg.cpp:2278
+#: src/PrefsUnifiedDlg.cpp:2358
 #, c-format
 msgid "Time for average graph: %d minute"
 msgid_plural "Time for average graph: %d minutes"
 msgstr[0] "平均值圖表顯示時間：%d 分鐘"
 
-#: src/PrefsUnifiedDlg.cpp:2287
+#: src/PrefsUnifiedDlg.cpp:2367
 #, c-format
 msgid "Connections Graph Scale: %d"
 msgstr "網路連線圖表比例：%d"
 
-#: src/PrefsUnifiedDlg.cpp:2302
+#: src/PrefsUnifiedDlg.cpp:2382
 #, c-format
 msgid "File Buffer Size: %d byte"
 msgid_plural "File Buffer Size: %d bytes"
 msgstr[0] "檔案緩衝區大小：%d B"
 
-#: src/PrefsUnifiedDlg.cpp:2312
+#: src/PrefsUnifiedDlg.cpp:2392
 #, c-format
 msgid "Upload Queue Size: %d client"
 msgid_plural "Upload Queue Size: %d clients"
 msgstr[0] "上傳等候區大小：%d "
 
-#: src/PrefsUnifiedDlg.cpp:2322
+#: src/PrefsUnifiedDlg.cpp:2402
 #, c-format
 msgid "Server connection refresh interval: %d minute"
 msgid_plural "Server connection refresh interval: %d minutes"
 msgstr[0] "伺服器連線更新間隔時間：%d 分鐘"
 
-#: src/PrefsUnifiedDlg.cpp:2327
+#: src/PrefsUnifiedDlg.cpp:2407
 msgid "Server connection refresh interval: Disabled"
 msgstr "伺服器連線更新間隔時間：已停用"
 
-#: src/PrefsUnifiedDlg.cpp:2371
+#: src/PrefsUnifiedDlg.cpp:2451
 msgid "disabled"
 msgstr "已停用"
 
-#: src/PrefsUnifiedDlg.cpp:2397
+#: src/PrefsUnifiedDlg.cpp:2477
 #, c-format
 msgid "Execute command on '%s' event"
 msgstr "發生 %s 事件時執行指令"
 
-#: src/PrefsUnifiedDlg.cpp:2404
+#: src/PrefsUnifiedDlg.cpp:2484
 msgid "Enable command execution on core"
 msgstr "啓用在主程式端執行指令"
 
-#: src/PrefsUnifiedDlg.cpp:2416
+#: src/PrefsUnifiedDlg.cpp:2496
 msgid "Core command:"
 msgstr "主程式端指令："
 
-#: src/PrefsUnifiedDlg.cpp:2432
+#: src/PrefsUnifiedDlg.cpp:2512
 msgid "Enable command execution on GUI"
 msgstr "啓用在圖形界面端執行指令"
 
-#: src/PrefsUnifiedDlg.cpp:2444
+#: src/PrefsUnifiedDlg.cpp:2524
 msgid "GUI command:"
 msgstr "圖形界面端指令："
 
-#: src/PrefsUnifiedDlg.cpp:2460
+#: src/PrefsUnifiedDlg.cpp:2540
 msgid "The following variables will be replaced:"
 msgstr ""
 "使用以下變數：\n"
 " "
 
-#: src/PrefsUnifiedDlg.cpp:2628
+#: src/PrefsUnifiedDlg.cpp:2708
 msgid ""
 "The following folders look like system or sensitive locations:\n"
 "\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2633
+#: src/PrefsUnifiedDlg.cpp:2713
 msgid "Sharing them recursively will publish every file underneath on the eD2k/Kad networks. Do you really want to do this?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2636
+#: src/PrefsUnifiedDlg.cpp:2716
 #, fuzzy
 msgid "Confirm shared folders"
 msgstr "分享資料夾"
 
-#: src/PrefsUnifiedDlg.cpp:2664
+#: src/PrefsUnifiedDlg.cpp:2744
 #, fuzzy
 msgid "Reloading shared files..."
 msgstr "重新載入分享的檔案"
 
-#: src/PrefsUnifiedDlg.cpp:2665
+#: src/PrefsUnifiedDlg.cpp:2745
 msgid "Scanning for subdirectories..."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2666
+#: src/PrefsUnifiedDlg.cpp:2746
 #, fuzzy
 msgid "Updating shared folders"
 msgstr "分享資料夾"
 
-#: src/PrefsUnifiedDlg.cpp:2693
+#: src/PrefsUnifiedDlg.cpp:2773
 #, c-format
 msgid "Scanned %u directories..."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2743
+#: src/PrefsUnifiedDlg.cpp:2823
 #, fuzzy, c-format
 msgid "Reloading shared files: %u files scanned"
 msgstr "重新載入分享檔案清單。"
 
-#: src/PrefsUnifiedDlg.cpp:2793
+#: src/PrefsUnifiedDlg.cpp:2873
 #, fuzzy
 msgid "Shared folder"
 msgstr "分享資料夾"

--- a/po/zh_TW.po
+++ b/po/zh_TW.po
@@ -14,8 +14,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-28 12:12+0200\n"
-"PO-Revision-Date: 2026-07-27 10:37+0000\n"
+"POT-Creation-Date: 2026-07-28 08:06+0200\n"
+"PO-Revision-Date: 2026-07-27 11:48+0000\n"
 "Last-Translator: Wayne Su <mstarmstar@gmail.com>\n"
 "Language-Team: \n"
 "Language: zh_TW\n"
@@ -150,7 +150,7 @@ msgstr ""
 msgid "Not now"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:422 src/amuleDlg.cpp:665
+#: src/AppImageIntegration.cpp:422 src/amuleDlg.cpp:600
 msgid "Don't ask again"
 msgstr ""
 
@@ -208,83 +208,83 @@ msgstr "無法開啟 ED2K 連結檔。"
 msgid "WARNING: You can't add yourself as a source for an eD2k link while having a lowid."
 msgstr "警告：LowID 時不可以將自己加入 eD2k 連結來源。"
 
-#: src/amule.cpp:301
+#: src/amule.cpp:300
 msgid "Now, exiting main app..."
 msgstr "正在離開主程式..."
 
-#: src/amule.cpp:331
+#: src/amule.cpp:330
 #, c-format
 msgid "Terminating amuleweb instance with pid '%d' ... "
 msgstr "正在終止 pid %d 的 amuleweb 執行緒... "
 
-#: src/amule.cpp:335
+#: src/amule.cpp:334
 #, c-format
 msgid "Killing amuleweb instance with pid '%d' ... "
 msgstr "正在強行終止 pid %d 的 amuleweb 執行緒... "
 
-#: src/amule.cpp:337 src/amule.cpp:350 src/ClientRef.cpp:180
-#: src/SearchDlg.cpp:1041 src/ServerListCtrl.cpp:98
+#: src/amule.cpp:336 src/amule.cpp:349 src/ClientRef.cpp:180
+#: src/SearchDlg.cpp:880 src/ServerListCtrl.cpp:98
 msgid "Failed"
 msgstr "失敗"
 
-#: src/amule.cpp:344
+#: src/amule.cpp:343
 #, fuzzy, c-format
 msgid "Terminating amuleapi instance with pid '%d' ... "
 msgstr "正在終止 pid %d 的 amuleweb 執行緒... "
 
-#: src/amule.cpp:348
+#: src/amule.cpp:347
 #, fuzzy, c-format
 msgid "Killing amuleapi instance with pid '%d' ... "
 msgstr "正在強行終止 pid %d 的 amuleweb 執行緒... "
 
-#: src/amule.cpp:356
+#: src/amule.cpp:355
 msgid "aMule OnExit: Terminating core."
 msgstr "aMule 離開中：正在終止主程式。"
 
-#: src/amule.cpp:467
+#: src/amule.cpp:466
 msgid "aMule shutdown completed."
 msgstr "已關閉 aMule 。"
 
-#: src/amule.cpp:471
+#: src/amule.cpp:470
 msgid "Memory debug results for aMule exit:"
 msgstr "離開 aMule 時記憶體除錯結果："
 
-#: src/amule.cpp:652
+#: src/amule.cpp:651
 #, c-format
 msgid "Binding aMule's peer-to-peer traffic to interface: %s (HTTP updates use the default route)"
 msgstr ""
 
-#: src/amule.cpp:656
+#: src/amule.cpp:655
 #, c-format
 msgid "Binding all network traffic to interface: %s"
 msgstr ""
 
-#: src/amule.cpp:660
+#: src/amule.cpp:659
 #, c-format
 msgid "WARNING: configured network interface '%s' was not found - traffic is NOT bound to it and may leave via the default route. Check the interface name in Preferences."
 msgstr ""
 
-#: src/amule.cpp:666
+#: src/amule.cpp:665
 #, c-format
 msgid "WARNING: binding to network interface '%s' requires elevated privileges and was NOT applied - traffic may leave via the default route. Grant the capability (e.g. 'sudo setcap cap_net_raw+ep' on the aMule binary) or run with sufficient privileges."
 msgstr ""
 
-#: src/amule.cpp:674
+#: src/amule.cpp:673
 #, c-format
 msgid "WARNING: could not bind to network interface '%s' - traffic may leave via the default route."
 msgstr ""
 
-#: src/amule.cpp:733
+#: src/amule.cpp:732
 msgid "Your locale has been changed to System Default due to a configuration change. Sorry."
 msgstr "對不起，由於版本變更，您的地區設定已經被變更爲系統預設值。"
 
-#: src/amule.cpp:735 src/amule.cpp:1589 src/CatDialog.cpp:128
+#: src/amule.cpp:734 src/amule.cpp:1581 src/CatDialog.cpp:128
 #: src/CatDialog.cpp:136 src/CatDialog.cpp:149 src/ServerList.cpp:366
 #: src/ServerListCtrl.cpp:152
 msgid "Info"
 msgstr "資訊"
 
-#: src/amule.cpp:742
+#: src/amule.cpp:741
 msgid ""
 "\n"
 "EC configuration"
@@ -292,74 +292,74 @@ msgstr ""
 "\n"
 "外部連線設定"
 
-#: src/amule.cpp:745
+#: src/amule.cpp:744
 msgid "Password set and external connections enabled."
 msgstr "密碼已設定，外部連線已啟用。"
 
-#: src/amule.cpp:755 src/KadDlg.cpp:176 src/KadDlg.cpp:185
-#: src/PrefsUnifiedDlg.cpp:1461 src/SharedFilesCtrl.cpp:476
+#: src/amule.cpp:754 src/KadDlg.cpp:176 src/KadDlg.cpp:185
+#: src/PrefsUnifiedDlg.cpp:1387 src/SharedFilesCtrl.cpp:476
 msgid "WARNING"
 msgstr "警告"
 
-#: src/amule.cpp:992
+#: src/amule.cpp:991
 #, fuzzy
 msgid "Network bootstrap"
 msgstr "網路"
 
-#: src/amule.cpp:997
+#: src/amule.cpp:996
 msgid ""
 "aMule has detected missing network bootstrap files.\n"
 "Select which ones to download:"
 msgstr ""
 
-#: src/amule.cpp:1006 src/FirstRunWizard.cpp:411
+#: src/amule.cpp:1005 src/FirstRunWizard.cpp:411
 #, fuzzy
 msgid "eD2k server list (server.met)"
 msgstr "在 server.met 中找到 %i 個伺服器"
 
-#: src/amule.cpp:1013 src/FirstRunWizard.cpp:416
+#: src/amule.cpp:1012 src/FirstRunWizard.cpp:416
 msgid "Kad bootstrap nodes (nodes.dat)"
 msgstr ""
 
-#: src/amule.cpp:1103
+#: src/amule.cpp:1102
 #, c-format
 msgid "web server running on pid %d"
 msgstr "執行中的網站伺服器 pid：%d"
 
-#: src/amule.cpp:1116
+#: src/amule.cpp:1115
 #, fuzzy
 msgid "You requested to run web server on startup, but the amuleweb binary cannot be run. Please install the package containing aMule web server, or build aMule from source with -DBUILD_WEBSERVER=YES and install it."
 msgstr "您要求啟動時執行網站伺服器，但系統無法執行 amuleweb。請安裝含有 aMule 網站伺服器的套件，或於編譯 aMule 程式碼時加入 --enable-webserver 選項"
 
-#: src/amule.cpp:1121 src/amule.cpp:1185 src/amule.cpp:1299 src/amule.cpp:1601
+#: src/amule.cpp:1120 src/amule.cpp:1177 src/amule.cpp:1291 src/amule.cpp:1593
 #: src/amule-remote-gui.cpp:603 src/amule-remote-gui.cpp:671
 #: src/amule-remote-gui.cpp:709 src/amule-remote-gui.cpp:1282
 #: src/amule-remote-gui.cpp:1345 src/amule-remote-gui.cpp:1372
-#: src/DownloadQueue.cpp:1481 src/PrefsUnifiedDlg.cpp:1247
+#: src/DownloadQueue.cpp:1481
 msgid "ERROR"
 msgstr "錯誤"
 
-#: src/amule.cpp:1174
+#: src/amule.cpp:1166
 #, fuzzy, c-format
 msgid "amuleapi running on pid %d"
 msgstr "執行中的網站伺服器 pid：%d"
 
-#: src/amule.cpp:1180
+#: src/amule.cpp:1172
 #, fuzzy
 msgid "You requested to run amuleapi on startup, but the amuleapi binary cannot be run. Please install the package containing aMule's REST API server, or build aMule from source with -DBUILD_AMULEAPI=YES and install it."
 msgstr "您要求啟動時執行網站伺服器，但系統無法執行 amuleweb。請安裝含有 aMule 網站伺服器的套件，或於編譯 aMule 程式碼時加入 --enable-webserver 選項"
 
-#: src/amule.cpp:1267
+#: src/amule.cpp:1259
 #, c-format
 msgid "Could not bind ports to the specified address: %s"
 msgstr "無法選定使用此位址的通訊埠：%s"
 
-#: src/amule.cpp:1291
+#: src/amule.cpp:1283
 #, c-format
 msgid "Port %u is not available. You will be LOWID\n"
 msgstr "通訊埠 %u 已被佔用。您會變成 LOWID。\n"
 
-#: src/amule.cpp:1296
+#: src/amule.cpp:1288
 #, c-format
 msgid ""
 "Port %u is not available!\n"
@@ -374,48 +374,48 @@ msgstr ""
 "\n"
 "請檢查網路設定以確保通訊埠可正常使用。"
 
-#: src/amule.cpp:1393
+#: src/amule.cpp:1385
 msgid "Failed to create OnlineSig File"
 msgstr "無法建立線上簽名識別檔"
 
-#: src/amule.cpp:1401
+#: src/amule.cpp:1393
 msgid "Failed to create aMule OnlineSig File"
 msgstr "無法建立 aMule 線上簽名識別檔"
 
-#: src/amule.cpp:1564
+#: src/amule.cpp:1556
 msgid "The selected locale seems not to be installed on your box. (Note: I'll try to set it anyway)"
 msgstr "在您的電腦上似乎沒有安裝您所選取的地區設定。 (但仍會採用您所選擇的設定)"
 
-#: src/amule.cpp:1574
+#: src/amule.cpp:1566
 #, c-format
 msgid "This is the first time you run aMule %s"
 msgstr "這是您第一次執行 aMule %s"
 
-#: src/amule.cpp:1577
+#: src/amule.cpp:1569
 msgid "This version is a testing version, updated daily, and\n"
 msgstr "這個版本是測試版，每日有更新，\n"
 
-#: src/amule.cpp:1578
+#: src/amule.cpp:1570
 msgid "we give no warranty it won't break anything, burn your house,\n"
 msgstr "但我們無法擔保它不會造成任何損害、燒掉您的房子、\n"
 
-#: src/amule.cpp:1579
+#: src/amule.cpp:1571
 msgid "or kill your dog. But it *should* be safe to use anyway.\n"
 msgstr "或害死您的狗。但一般來講它「應該」是安全的。\n"
 
-#: src/amule.cpp:1584
+#: src/amule.cpp:1576
 msgid "More information, support and new releases can found at our homepage,\n"
 msgstr "在我們的網頁可找到更多資訊、使用者支援以及程式最新版本：\n"
 
-#: src/amule.cpp:1585
+#: src/amule.cpp:1577
 msgid "at https://amule-org.github.io, or in our IRC channel #aMule at irc.libera.chat.\n"
 msgstr "https://amule-org.github.io，或我們在 irc.libera.chat 的 IRC 頻道 #aMule。\n"
 
-#: src/amule.cpp:1587
+#: src/amule.cpp:1579
 msgid "Feel free to report any bugs to https://github.com/amule-org/amule/issues"
 msgstr "歡迎您到 https://github.com/amule-org/amule/issues 提出錯誤報告"
 
-#: src/amule.cpp:1599
+#: src/amule.cpp:1591
 msgid ""
 "The folder for Online Signature files you specified is INVALID!\n"
 " OnlineSignature will be DISABLED until you fix it on preferences."
@@ -423,137 +423,137 @@ msgstr ""
 "您選擇的線上簽名識別檔案所在資料夾無效！\n"
 " 在您變更偏好設定之前，線上簽名識別功能將被停用。"
 
-#: src/amule.cpp:1662
+#: src/amule.cpp:1654
 msgid "Server hostname notified"
 msgstr "已通伺服器主機名稱"
 
-#: src/amule.cpp:2039
+#: src/amule.cpp:2031
 #, c-format
 msgid "Disk space preallocation for file '%s' failed: %s"
 msgstr "無法為檔案 %s 預先分配磁碟空間：%s"
 
-#: src/amule.cpp:2168
+#: src/amule.cpp:2160
 msgid "ERROR: can't open logfile"
 msgstr "錯誤：無法開啟記錄檔"
 
-#: src/amule.cpp:2172
+#: src/amule.cpp:2164
 msgid "WARNING: logfile is empty. Something is wrong."
 msgstr "警告：沒有記錄檔，肯定有什麽地方出錯了。"
 
-#: src/amule.cpp:2189
+#: src/amule.cpp:2181
 msgid "Log has been reset"
 msgstr "記錄已被清除"
 
-#: src/amule.cpp:2213
+#: src/amule.cpp:2205
 #, c-format
 msgid "ServerMessage: %s"
 msgstr "伺服器訊息：%s"
 
-#: src/amule.cpp:2256 src/IP2Country.cpp:220 src/IPFilter.cpp:514
+#: src/amule.cpp:2248 src/IP2Country.cpp:220 src/IPFilter.cpp:514
 #: src/ServerList.cpp:875
 #, c-format
 msgid "Skipped download of %s, because requested file is not newer."
 msgstr "略過不下載 %s ，因為並不是新近檔案。"
 
-#: src/amule.cpp:2259
+#: src/amule.cpp:2251
 msgid "Failed to download the nodes list."
 msgstr "無法下載節點清單。"
 
-#: src/amule.cpp:2322
+#: src/amule.cpp:2314
 msgid "Failed to open the downloaded version check file"
 msgstr "無法開啟下載的版本檢查檔"
 
-#: src/amule.cpp:2325 src/amule.cpp:2344
+#: src/amule.cpp:2317 src/amule.cpp:2336
 msgid "Corrupted version check file"
 msgstr "損壞的版本檢查檔"
 
-#: src/amule.cpp:2367
+#: src/amule.cpp:2359
 msgid "You are using an outdated version of aMule!"
 msgstr "您使用的是過期的 aMule 版本！"
 
-#: src/amule.cpp:2369
+#: src/amule.cpp:2361
 #, c-format
 msgid "Your aMule version is %i.%i.%i and the latest version is %li.%li.%li"
 msgstr "您的 aMule 版本是 %i.%i.%i，最新版本是 %li.%li.%li"
 
-#: src/amule.cpp:2373
+#: src/amule.cpp:2365
 msgid "The latest version can always be found at https://github.com/amule-org/amule/releases/latest"
 msgstr "最新版本可從這裏下載：https://github.com/amule-org/amule/releases/latest"
 
-#: src/amule.cpp:2376
+#: src/amule.cpp:2368
 #, c-format
 msgid "WARNING: Your aMuled version is outdated: %i.%i.%i < %li.%li.%li"
 msgstr "警告：您的 aMuled 版本已經過期：%i.%i.%i < %li.%li.%li"
 
-#: src/amule.cpp:2382
+#: src/amule.cpp:2374
 msgid "Your copy of aMule is up to date."
 msgstr "您的 aMule 是最新版本。"
 
-#: src/amule.cpp:2389
+#: src/amule.cpp:2381
 msgid "Failed to download the version check file"
 msgstr "無法下載版本檢查檔"
 
-#: src/amule.cpp:2558 src/amule-remote-gui.cpp:1133
+#: src/amule.cpp:2550 src/amule-remote-gui.cpp:1133
 #, c-format
 msgid "Users: %s | Files: %s"
 msgstr "使用者：%s | 檔案：%s"
 
-#: src/amule.cpp:2559 src/amule-remote-gui.cpp:1134
+#: src/amule.cpp:2551 src/amule-remote-gui.cpp:1134
 #, c-format
 msgid "Users: E: %s K: %s | Files: E: %s K: %s"
 msgstr "使用者：E:%s K:%s | 檔案：E:%s K:%s"
 
-#: src/amule.cpp:2573 src/amule-remote-gui.cpp:1147
+#: src/amule.cpp:2565 src/amule-remote-gui.cpp:1147
 msgid "No networks selected"
 msgstr "未選取網路"
 
-#: src/amule.cpp:2641 src/TextClient.cpp:903
+#: src/amule.cpp:2633 src/TextClient.cpp:903
 msgid "with LowID"
 msgstr "有 LowID"
 
-#: src/amule.cpp:2641 src/TextClient.cpp:904
+#: src/amule.cpp:2633 src/TextClient.cpp:904
 msgid "with HighID"
 msgstr "有 HighID"
 
-#: src/amule.cpp:2643
+#: src/amule.cpp:2635
 #, c-format
 msgid "Connected to %s %s"
 msgstr "已連線到 %s %s"
 
-#: src/amule.cpp:2648
+#: src/amule.cpp:2640
 #, c-format
 msgid "Connecting to %s"
 msgstr "正在連線到 %s"
 
-#: src/amule.cpp:2650
+#: src/amule.cpp:2642
 msgid "Disconnected from eD2k"
 msgstr "已中斷 eD2k 網路連線"
 
-#: src/amule.cpp:2659
+#: src/amule.cpp:2651
 msgid "Kad started."
 msgstr "Kad 已啓動。"
 
-#: src/amule.cpp:2661
+#: src/amule.cpp:2653
 msgid "Kad stopped."
 msgstr "Kad 已停止。"
 
-#: src/amule.cpp:2669
+#: src/amule.cpp:2661
 msgid "Connected to Kad (ok)"
 msgstr "已連線到 Kad"
 
-#: src/amule.cpp:2671
+#: src/amule.cpp:2663
 msgid "Connected to Kad (firewalled)"
 msgstr "已連線到 Kad 網路 (防火牆內)"
 
-#: src/amule.cpp:2675
+#: src/amule.cpp:2667
 msgid "Disconnected from Kad"
 msgstr "已中斷 Kad 網路連線"
 
-#: src/amule.cpp:2707
+#: src/amule.cpp:2699
 msgid "Kad network cannot be used if UDP port is disabled on preferences, not starting."
 msgstr "Kad 網路未啟動：如果在偏好設定中停用了 UDP 埠，Kad 網路將不能使用。"
 
-#: src/amule.cpp:2711
+#: src/amule.cpp:2703
 msgid "Kad network disabled on preferences, not connecting."
 msgstr "Kad 網路在偏好設定中被停用了，沒有連線。"
 
@@ -579,68 +579,30 @@ msgstr "無法建立 pid 檔案"
 msgid "ERROR: %s"
 msgstr "錯誤：%s"
 
-#: src/amuleDlg.cpp:250
+#: src/amuleDlg.cpp:236
 #, c-format
 msgid "This is aMule %s based on eMule."
 msgstr "這是 aMule %s (源自 eMule)。"
 
-#: src/amuleDlg.cpp:251
+#: src/amuleDlg.cpp:237
 #, c-format
 msgid "Running on %s"
 msgstr "執行於 %s"
 
-#: src/amuleDlg.cpp:253
+#: src/amuleDlg.cpp:239
 msgid "Visit https://github.com/amule-org/amule/releases/latest to check if a new version is available."
 msgstr "請到 https://github.com/amule-org/amule/releases/latest 下載最新版本。"
 
-#: src/amuleDlg.cpp:282
+#: src/amuleDlg.cpp:268
 msgid "FATAL ERROR: Failed to create Timer"
 msgstr "嚴重錯誤：無法建立計時器"
 
-#: src/amuleDlg.cpp:361 src/amuleDlg.cpp:1810 src/amuleDlg.cpp:2056
-#: src/muuli_wdr.cpp:1492 src/muuli_wdr.cpp:3439
-msgid "Networks"
-msgstr "網路"
-
-#: src/amuleDlg.cpp:362 src/amuleDlg.cpp:1816 src/muuli_wdr.cpp:3440
-msgid "Searches"
-msgstr "搜尋"
-
-#: src/amuleDlg.cpp:363 src/amuleDlg.cpp:1822 src/DownloadListCtrl.cpp:740
-#: src/muuli_wdr.cpp:392 src/muuli_wdr.cpp:1585 src/muuli_wdr.cpp:3441
-#: src/Statistics.cpp:829
-msgid "Downloads"
-msgstr "下載"
-
-#: src/amuleDlg.cpp:364 src/amuleDlg.cpp:1828 src/muuli_wdr.cpp:3315
-msgid "Shared files"
-msgstr "檔案分享"
-
-#: src/amuleDlg.cpp:365 src/amuleDlg.cpp:1834 src/muuli_wdr.cpp:2947
-#: src/muuli_wdr.cpp:3397 src/muuli_wdr.cpp:3444
-msgid "Messages"
-msgstr "訊息"
-
-#: src/amuleDlg.cpp:366 src/amuleDlg.cpp:1840 src/muuli_wdr.cpp:3445
-#: src/PrefsUnifiedDlg.cpp:314 src/Statistics.cpp:779 src/Statistics.cpp:1235
-msgid "Statistics"
-msgstr "統計"
-
-#: src/amuleDlg.cpp:368 src/amuleDlg.cpp:1847 src/muuli_wdr.cpp:3447
-#: src/PrefsUnifiedDlg.cpp:330 src/utils/wxCas/src/wxcasprefs.cpp:39
-msgid "Preferences"
-msgstr "偏好設定"
-
-#: src/amuleDlg.cpp:371
-msgid "Navigate"
-msgstr ""
-
-#: src/amuleDlg.cpp:657
+#: src/amuleDlg.cpp:592
 #, fuzzy
 msgid "New version available"
 msgstr "不可用"
 
-#: src/amuleDlg.cpp:661
+#: src/amuleDlg.cpp:596
 #, fuzzy, c-format
 msgid ""
 "A new version of aMule (%s) is available.\n"
@@ -650,185 +612,218 @@ msgid ""
 "Would you like to open the download page?"
 msgstr "最新版本可從這裏下載：https://github.com/amule-org/amule/releases/latest"
 
-#: src/amuleDlg.cpp:743
+#: src/amuleDlg.cpp:678
 msgid "aMule dialog destroyed"
 msgstr "aMule 對話方塊已銷毀"
 
-#: src/amuleDlg.cpp:766 src/DataToText.cpp:68 src/IPFilter.cpp:547
+#: src/amuleDlg.cpp:701 src/DataToText.cpp:68 src/IPFilter.cpp:547
 msgid "Connecting"
 msgstr "正在連線"
 
-#: src/amuleDlg.cpp:958
+#: src/amuleDlg.cpp:893
 msgid "eD2k: Connecting"
 msgstr "eD2k：正在連線"
 
-#: src/amuleDlg.cpp:962
+#: src/amuleDlg.cpp:897
 msgid "eD2k: Disconnected"
 msgstr "eD2k：已中斷連線"
 
-#: src/amuleDlg.cpp:968
+#: src/amuleDlg.cpp:903
 msgid "Kad: Firewalled"
 msgstr "Kad：防火牆內"
 
-#: src/amuleDlg.cpp:972
+#: src/amuleDlg.cpp:907
 msgid "Kad: Connected"
 msgstr "Kad：已連線"
 
-#: src/amuleDlg.cpp:977
+#: src/amuleDlg.cpp:912
 msgid "Kad: Connecting"
 msgstr "Kad：正在連線"
 
-#: src/amuleDlg.cpp:981
+#: src/amuleDlg.cpp:916
 msgid "Kad: Off"
 msgstr "Kad：關閉"
 
-#: src/amuleDlg.cpp:1029 src/DownloadListCtrl.cpp:505
+#: src/amuleDlg.cpp:964 src/DownloadListCtrl.cpp:505
 #: src/DownloadListCtrl.cpp:749 src/FriendListCtrl.cpp:180
 #: src/muuli_wdr.cpp:731 src/muuli_wdr.cpp:782 src/muuli_wdr.cpp:846
-#: src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2252 src/muuli_wdr.cpp:2337
-#: src/muuli_wdr.cpp:3085 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
+#: src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2224 src/muuli_wdr.cpp:2309
+#: src/muuli_wdr.cpp:3057 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
 #: src/ServerListCtrl.cpp:606 src/TransferWnd.cpp:378
 #: src/utils/wxCas/src/wxcasprefs.cpp:235
 msgid "Cancel"
 msgstr "取消"
 
-#: src/amuleDlg.cpp:1030
+#: src/amuleDlg.cpp:965
 msgid "Stop the current connection attempts"
 msgstr "停止連線作業"
 
-#: src/amuleDlg.cpp:1035 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976
-#: src/muuli_wdr.cpp:2475
+#: src/amuleDlg.cpp:970 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976
+#: src/muuli_wdr.cpp:2447
 msgid "Disconnect"
 msgstr "中斷連線"
 
-#: src/amuleDlg.cpp:1036
+#: src/amuleDlg.cpp:971
 msgid "Disconnect from the currently connected networks"
 msgstr "中斷已連線的網路"
 
-#: src/amuleDlg.cpp:1041 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979
-#: src/muuli_wdr.cpp:2630 src/muuli_wdr.cpp:3082 src/muuli_wdr.cpp:3437
+#: src/amuleDlg.cpp:976 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979
+#: src/muuli_wdr.cpp:2602 src/muuli_wdr.cpp:3054 src/muuli_wdr.cpp:3409
 msgid "Connect"
 msgstr "連線"
 
-#: src/amuleDlg.cpp:1042
+#: src/amuleDlg.cpp:977
 msgid "Connect to the currently enabled networks"
 msgstr "連線到目前已啟用的網路"
 
-#: src/amuleDlg.cpp:1154
+#: src/amuleDlg.cpp:1089
 #, fuzzy, c-format
 msgid "Up: %.1f%s (%.1f) | Down: %.1f%s (%.1f)"
 msgstr "上傳：%.1f (%.1f) | 下載：%.1f (%.1f)"
 
-#: src/amuleDlg.cpp:1156 src/amuleDlg.cpp:1158 src/amuleDlg.cpp:1162
-#: src/amuleDlg.cpp:1164 src/amuleDlg.cpp:1175 src/amuleDlg.cpp:1177
+#: src/amuleDlg.cpp:1091 src/amuleDlg.cpp:1093 src/amuleDlg.cpp:1097
+#: src/amuleDlg.cpp:1099 src/amuleDlg.cpp:1110 src/amuleDlg.cpp:1112
 #: src/MuleTrayIcon.cpp:796 src/MuleTrayIcon.cpp:799
 #, fuzzy
 msgid " MB/s"
 msgstr "MB/s"
 
-#: src/amuleDlg.cpp:1156 src/amuleDlg.cpp:1158 src/amuleDlg.cpp:1162
-#: src/amuleDlg.cpp:1164 src/amuleDlg.cpp:1175 src/amuleDlg.cpp:1177
+#: src/amuleDlg.cpp:1091 src/amuleDlg.cpp:1093 src/amuleDlg.cpp:1097
+#: src/amuleDlg.cpp:1099 src/amuleDlg.cpp:1110 src/amuleDlg.cpp:1112
 #: src/MuleTrayIcon.cpp:796 src/MuleTrayIcon.cpp:799
 #: src/utils/wxCas/src/wxcasframe.cpp:1041
 msgid " kB/s"
 msgstr " KB/s"
 
-#: src/amuleDlg.cpp:1161
+#: src/amuleDlg.cpp:1096
 #, fuzzy, c-format
 msgid "Up: %.1f%s | Down: %.1f%s"
 msgstr "上傳：%.1f | 下載：%.1f"
 
-#: src/amuleDlg.cpp:1193
+#: src/amuleDlg.cpp:1128
 #, c-format
 msgid "aMule (%s | Connected)"
 msgstr "aMule (%s | 已連線)"
 
-#: src/amuleDlg.cpp:1195
+#: src/amuleDlg.cpp:1130
 #, c-format
 msgid "aMule (%s | Disconnected)"
 msgstr "aMule (%s | 已中斷連線)"
 
-#: src/amuleDlg.cpp:1248
+#: src/amuleDlg.cpp:1183
 #, c-format
 msgid "Do you really want to exit %s?"
 msgstr "您確定要離開 %s 嗎？"
 
-#: src/amuleDlg.cpp:1250
+#: src/amuleDlg.cpp:1185
 msgid "Exit confirmation"
 msgstr "確認離開"
 
-#: src/amuleDlg.cpp:1613
+#: src/amuleDlg.cpp:1548
 msgid "Launch Command: "
 msgstr "執行指令："
 
-#: src/amuleDlg.cpp:1632 src/muuli_wdr.cpp:1972 src/Preferences.cpp:979
+#: src/amuleDlg.cpp:1567 src/muuli_wdr.cpp:1971 src/Preferences.cpp:951
 msgid "- default -"
 msgstr "- 預設 -"
 
-#: src/amuleDlg.cpp:1660
+#: src/amuleDlg.cpp:1595
 #, c-format
 msgid "Skin directory '%s' does not exist"
 msgstr "面板目錄 %s 不存在"
 
-#: src/amuleDlg.cpp:1663
+#: src/amuleDlg.cpp:1598
 #, c-format
 msgid "WARNING: Unable to open skin file '%s' for read"
 msgstr "警告：無法開啟面板檔案 %s 供讀取"
 
-#: src/amuleDlg.cpp:1814 src/muuli_wdr.cpp:3439
+#: src/amuleDlg.cpp:1722 src/amuleDlg.cpp:1968 src/muuli_wdr.cpp:1485
+#: src/muuli_wdr.cpp:3411
+msgid "Networks"
+msgstr "網路"
+
+#: src/amuleDlg.cpp:1726 src/muuli_wdr.cpp:3411
 msgid "Networks Window"
 msgstr "網路 視窗"
 
-#: src/amuleDlg.cpp:1820 src/muuli_wdr.cpp:3440
+#: src/amuleDlg.cpp:1728 src/muuli_wdr.cpp:3412
+msgid "Searches"
+msgstr "搜尋"
+
+#: src/amuleDlg.cpp:1732 src/muuli_wdr.cpp:3412
 msgid "Searches Window"
 msgstr "搜尋 視窗"
 
-#: src/amuleDlg.cpp:1826 src/muuli_wdr.cpp:3441
+#: src/amuleDlg.cpp:1734 src/DownloadListCtrl.cpp:740 src/muuli_wdr.cpp:392
+#: src/muuli_wdr.cpp:1578 src/muuli_wdr.cpp:3413 src/Statistics.cpp:829
+msgid "Downloads"
+msgstr "下載"
+
+#: src/amuleDlg.cpp:1738 src/muuli_wdr.cpp:3413
 msgid "Downloads Window"
 msgstr "下載 視窗"
 
-#: src/amuleDlg.cpp:1832 src/muuli_wdr.cpp:3443
+#: src/amuleDlg.cpp:1740 src/muuli_wdr.cpp:3287
+msgid "Shared files"
+msgstr "檔案分享"
+
+#: src/amuleDlg.cpp:1744 src/muuli_wdr.cpp:3415
 msgid "Shared Files Window"
 msgstr "檔案分享 視窗"
 
-#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3444
+#: src/amuleDlg.cpp:1746 src/muuli_wdr.cpp:2919 src/muuli_wdr.cpp:3369
+#: src/muuli_wdr.cpp:3416
+msgid "Messages"
+msgstr "訊息"
+
+#: src/amuleDlg.cpp:1750 src/muuli_wdr.cpp:3416
 msgid "Messages Window"
 msgstr "訊息 視窗"
 
-#: src/amuleDlg.cpp:1844 src/muuli_wdr.cpp:3445
+#: src/amuleDlg.cpp:1752 src/muuli_wdr.cpp:3417 src/PrefsUnifiedDlg.cpp:312
+#: src/Statistics.cpp:779 src/Statistics.cpp:1235
+msgid "Statistics"
+msgstr "統計"
+
+#: src/amuleDlg.cpp:1756 src/muuli_wdr.cpp:3417
 msgid "Statistics Graph Window"
 msgstr "統計 視窗"
 
-#: src/amuleDlg.cpp:1851 src/muuli_wdr.cpp:3447
+#: src/amuleDlg.cpp:1759 src/muuli_wdr.cpp:3419 src/PrefsUnifiedDlg.cpp:328
+#: src/utils/wxCas/src/wxcasprefs.cpp:39
+msgid "Preferences"
+msgstr "偏好設定"
+
+#: src/amuleDlg.cpp:1763 src/muuli_wdr.cpp:3419
 msgid "Preferences Settings Window"
 msgstr "偏好設定 視窗"
 
-#: src/amuleDlg.cpp:1854 src/muuli_wdr.cpp:3448
+#: src/amuleDlg.cpp:1766 src/muuli_wdr.cpp:3420
 msgid "Import"
 msgstr "匯入"
 
-#: src/amuleDlg.cpp:1858 src/muuli_wdr.cpp:3448
+#: src/amuleDlg.cpp:1770 src/muuli_wdr.cpp:3420
 msgid "The partfile importer tool"
 msgstr "暫存檔匯入工具"
 
-#: src/amuleDlg.cpp:1861 src/muuli_wdr.cpp:3449
+#: src/amuleDlg.cpp:1773 src/muuli_wdr.cpp:3421
 #: src/utils/aLinkCreator/src/alcframe.cpp:262
 msgid "About"
 msgstr "關於"
 
-#: src/amuleDlg.cpp:1861 src/muuli_wdr.cpp:3449
+#: src/amuleDlg.cpp:1773 src/muuli_wdr.cpp:3421
 msgid "About/Help"
 msgstr "關於/幫助"
 
-#: src/amuleDlg.cpp:2059
+#: src/amuleDlg.cpp:1971
 msgid "eD2k network"
 msgstr "eD2k 網路"
 
-#: src/amuleDlg.cpp:2062
+#: src/amuleDlg.cpp:1974
 msgid "Kad network"
 msgstr "kad 網路"
 
-#: src/amuleDlg.cpp:2062
+#: src/amuleDlg.cpp:1974
 msgid "No network"
 msgstr "無網路"
 
@@ -958,7 +953,7 @@ msgstr "找不到檔案。"
 msgid "The core rejected these shared folders:%s"
 msgstr ""
 
-#: src/amule-remote-gui.cpp:1336 src/ExternalConn.cpp:2346
+#: src/amule-remote-gui.cpp:1336 src/ExternalConn.cpp:2345
 msgid "Invalid link or already on list."
 msgstr "無效連結或已在清單中。"
 
@@ -974,7 +969,7 @@ msgstr "無法建立 %s 目錄 ( %s 分類用)，繼續使用 %s 目錄。"
 #: src/ClientDetailDialog.cpp:123 src/DataToText.cpp:61 src/DataToText.cpp:86
 #: src/DataToText.cpp:101 src/DataToText.cpp:136 src/DataToText.cpp:165
 #: src/DownloadListCtrl.cpp:1172 src/DownloadListCtrl.cpp:1185
-#: src/DownloadListCtrl.cpp:1196 src/ExternalConn.cpp:609
+#: src/DownloadListCtrl.cpp:1196 src/ExternalConn.cpp:608
 #: src/FileDetailDialog.cpp:203 src/FileDetailDialog.cpp:235
 #: src/FileDetailDialog.cpp:242 src/GenericClientListCtrl.cpp:1171
 #: src/GenericClientListCtrl.cpp:1182 src/GenericClientListCtrl.cpp:1192
@@ -1356,19 +1351,19 @@ msgstr "自動 [高]"
 msgid "Very low"
 msgstr "極低"
 
-#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:743 src/muuli_wdr.cpp:2303
+#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:743 src/muuli_wdr.cpp:2275
 #: src/ServerListCtrl.cpp:263 src/ServerListCtrl.cpp:456
 #: src/SharedFilesCtrl.cpp:145
 msgid "Low"
 msgstr "低"
 
-#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:744 src/muuli_wdr.cpp:2304
+#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:744 src/muuli_wdr.cpp:2276
 #: src/ServerListCtrl.cpp:266 src/ServerListCtrl.cpp:457
 #: src/SharedFilesCtrl.cpp:146
 msgid "Normal"
 msgstr "普通"
 
-#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:745 src/muuli_wdr.cpp:2305
+#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:745 src/muuli_wdr.cpp:2277
 #: src/ServerListCtrl.cpp:269 src/ServerListCtrl.cpp:458
 #: src/SharedFilesCtrl.cpp:147
 msgid "High"
@@ -1460,8 +1455,8 @@ msgstr "本地伺服器"
 msgid "Remote Server"
 msgstr "遠端伺服器"
 
-#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3202
-#: src/SearchDlg.cpp:119 src/TextClient.cpp:911
+#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3174
+#: src/SearchDlg.cpp:111 src/TextClient.cpp:911
 msgid "Kad"
 msgstr "Kad"
 
@@ -1532,7 +1527,7 @@ msgstr "部份"
 msgid "Size"
 msgstr "大小"
 
-#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3269
+#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3241
 msgid "Transferred"
 msgstr "已傳輸"
 
@@ -1590,7 +1585,7 @@ msgstr ""
 "%s (%s) 回覆訊息\n"
 "\n"
 
-#: src/DownloadListCtrl.cpp:746 src/muuli_wdr.cpp:2306
+#: src/DownloadListCtrl.cpp:746 src/muuli_wdr.cpp:2278
 #: src/SharedFilesCtrl.cpp:150
 msgid "Auto"
 msgstr "自動"
@@ -1628,7 +1623,7 @@ msgid "Extended Options"
 msgstr "擴充選項"
 
 #: src/DownloadListCtrl.cpp:770 src/DownloadListCtrl.cpp:822
-#: src/muuli_wdr.cpp:1790
+#: src/muuli_wdr.cpp:1789
 msgid "Preview"
 msgstr "預覽"
 
@@ -1801,232 +1796,227 @@ msgstr[0] ""
 msgid "Invalid eD2k link! ERROR: %s"
 msgstr "無效的 eD2k 連結！錯誤：%s "
 
-#: src/ExternalConn.cpp:380
+#: src/ExternalConn.cpp:379
 msgid "Client sent packet after authentication failed."
 msgstr "客戶端在驗證失敗後傳送封包。"
 
-#: src/ExternalConn.cpp:397
+#: src/ExternalConn.cpp:396
 msgid "External connection closed."
 msgstr "已關閉外部連線。"
 
-#: src/ExternalConn.cpp:474
+#: src/ExternalConn.cpp:473
 msgid "External connections disabled due to empty password!"
 msgstr "未設定密碼，外部連線已被停用！"
 
-#: src/ExternalConn.cpp:495
+#: src/ExternalConn.cpp:494
 msgid "External connections disabled in config file"
 msgstr "已在設定檔中停用外部連線"
 
-#: src/ExternalConn.cpp:576
+#: src/ExternalConn.cpp:575
 msgid "New external connection accepted"
 msgstr "已接受新的外部連線"
 
-#: src/ExternalConn.cpp:579
+#: src/ExternalConn.cpp:578
 msgid "ERROR: couldn't accept a new external connection"
 msgstr "錯誤：無法接受新的外部連線"
 
-#: src/ExternalConn.cpp:596
+#: src/ExternalConn.cpp:595
 msgid "External connection refused due to empty password in preferences!"
 msgstr "由於偏好設定中未設定密碼，外部連線已被拒絕！"
 
-#: src/ExternalConn.cpp:608
+#: src/ExternalConn.cpp:607
 #, c-format
 msgid "Connecting client: %s %s"
 msgstr "連線中客戶端：%s %s"
 
-#: src/ExternalConn.cpp:610
+#: src/ExternalConn.cpp:609
 msgid "Unknown version"
 msgstr "不明版本"
 
-#: src/ExternalConn.cpp:623
+#: src/ExternalConn.cpp:622
 msgid "Incorrect EC version ID, there might be binary incompatibility. Use core and remote from same snapshot."
 msgstr "不正確的外部連線版本 ID，這將導致執行檔不相容，請使用相同版本的主程式和遠端程式。"
 
-#: src/ExternalConn.cpp:631
+#: src/ExternalConn.cpp:630
 msgid "You cannot connect to a release version from an arbitrary development snapshot! *sigh* possible crash prevented"
 msgstr "您不能用開發中版本 (SVN) 連線到正式發行版，這是為了避免系統遭受不確定的損害"
 
-#: src/ExternalConn.cpp:714
+#: src/ExternalConn.cpp:713
 msgid "Invalid protocol version."
 msgstr "協定版本無效。"
 
-#: src/ExternalConn.cpp:720
+#: src/ExternalConn.cpp:719
 msgid "Missing protocol version tag."
 msgstr "缺少協定版本標記。"
 
-#: src/ExternalConn.cpp:728
+#: src/ExternalConn.cpp:727
 msgid "Authentication failed: invalid hash specified as EC password."
 msgstr "驗證失敗：指定無效的 hash 值做為外部連線密碼。"
 
-#: src/ExternalConn.cpp:776
+#: src/ExternalConn.cpp:775
 msgid "Authentication failed: wrong password."
 msgstr "驗證失敗：密碼錯誤。"
 
-#: src/ExternalConn.cpp:778
+#: src/ExternalConn.cpp:777
 msgid "Authentication failed: missing password."
 msgstr "驗證失敗：沒有密碼。"
 
-#: src/ExternalConn.cpp:789
+#: src/ExternalConn.cpp:788
 msgid "Invalid request, please authenticate first."
 msgstr "無效的要求，請先通過登入驗證。"
 
-#: src/ExternalConn.cpp:794
+#: src/ExternalConn.cpp:793
 msgid "Access granted."
 msgstr "登入成功。"
 
-#: src/ExternalConn.cpp:802
+#: src/ExternalConn.cpp:801
 #, c-format
 msgid "Sent error message \"%s\" to client."
 msgstr "傳送錯誤訊息「%s」給客戶端。"
 
-#: src/ExternalConn.cpp:807
+#: src/ExternalConn.cpp:806
 #, c-format
 msgid "Unauthorized access attempt from %s. Connection closed."
 msgstr "%s 試圖非法登入，已關閉連線。"
 
-#: src/ExternalConn.cpp:1420
+#: src/ExternalConn.cpp:1419
 #, c-format
 msgid "Remote PartFile command failed: FileHash not found: %s"
 msgstr "無法執行對遠端暫存檔的指令：找不到檔案 hash 值：%s "
 
-#: src/ExternalConn.cpp:1424
+#: src/ExternalConn.cpp:1423
 #, c-format
 msgid "FileHash not found: %s"
 msgstr "找不到檔案 hash 值：%s "
 
-#: src/ExternalConn.cpp:1471 src/ExternalConn.cpp:1559
-#: src/ExternalConn.cpp:1680
+#: src/ExternalConn.cpp:1470 src/ExternalConn.cpp:1558
+#: src/ExternalConn.cpp:1679
 msgid "OOPS! OpCode processing error!"
 msgstr "糟糕！指令碼處理錯誤！"
 
-#: src/ExternalConn.cpp:1502
+#: src/ExternalConn.cpp:1501
 msgid "Server not added"
 msgstr "伺服器未被加入"
 
-#: src/ExternalConn.cpp:1521
+#: src/ExternalConn.cpp:1520
 #, c-format
 msgid "server not found: %s"
 msgstr "找不到伺服器：%s "
 
-#: src/ExternalConn.cpp:1538
+#: src/ExternalConn.cpp:1537
 msgid "need to define server to be removed"
 msgstr "必須指定要刪除的伺服器"
 
-#: src/ExternalConn.cpp:1553
+#: src/ExternalConn.cpp:1552
 msgid "eD2k is disabled in preferences."
 msgstr "eD2k 網路已在偏好設定中被停用了。"
 
-#: src/ExternalConn.cpp:1658
+#: src/ExternalConn.cpp:1657
 #, fuzzy
 msgid "Friend not found."
 msgstr "找不到檔案。"
 
-#: src/ExternalConn.cpp:1668
+#: src/ExternalConn.cpp:1667
 #, fuzzy
 msgid "Client not found."
 msgstr "找不到檔案。"
 
-#: src/ExternalConn.cpp:1674
+#: src/ExternalConn.cpp:1673
 msgid "EC_TAG_FRIEND_SHARED requires EC_TAG_FRIEND or EC_TAG_CLIENT."
 msgstr ""
 
-#: src/ExternalConn.cpp:1992
+#: src/ExternalConn.cpp:1991
 msgid "WebSearch from remote interface makes no sense."
 msgstr "從遠端界面使用網頁搜尋功能沒有意義。"
 
-#: src/ExternalConn.cpp:2027
+#: src/ExternalConn.cpp:2026
 msgid "Search in progress. Refetch results in a moment!"
 msgstr "搜尋中，請稍候！"
 
-#: src/ExternalConn.cpp:2266
+#: src/ExternalConn.cpp:2265
 msgid "No points for graph."
 msgstr "此圖沒有參考點。"
 
-#: src/ExternalConn.cpp:2276
+#: src/ExternalConn.cpp:2275
 msgid "Your client is not configured for this detail level."
 msgstr "您的客戶端並沒有設定這個細部等級。"
 
-#: src/ExternalConn.cpp:2303
+#: src/ExternalConn.cpp:2302
 msgid "External Connection: shutdown requested"
 msgstr "外部連線：必須關閉"
 
-#: src/ExternalConn.cpp:2315
+#: src/ExternalConn.cpp:2314
 msgid "Already shutting down."
 msgstr "已經在關閉中。"
 
-#: src/ExternalConn.cpp:2333
+#: src/ExternalConn.cpp:2332
 #, c-format
 msgid "ExternalConn: adding link '%s'."
 msgstr "外部連線：正在加入連結 %s 。"
 
-#: src/ExternalConn.cpp:2351
+#: src/ExternalConn.cpp:2350
 #, fuzzy, c-format
 msgid "%d of %d links failed (invalid or already on list)."
 msgstr "無效連結或已在清單中。"
 
-#: src/ExternalConn.cpp:2374
+#: src/ExternalConn.cpp:2373
 msgid "Version check throttled; try again shortly."
 msgstr ""
 
-#: src/ExternalConn.cpp:2379
+#: src/ExternalConn.cpp:2378
 msgid "Version check is not available on this daemon."
 msgstr ""
 
-#: src/ExternalConn.cpp:2509
+#: src/ExternalConn.cpp:2508
 msgid "File not found."
 msgstr "找不到檔案。"
 
-#: src/ExternalConn.cpp:2514
+#: src/ExternalConn.cpp:2513
 msgid "Invalid file name."
 msgstr "無效的檔名。"
 
-#: src/ExternalConn.cpp:2522
+#: src/ExternalConn.cpp:2521
 msgid "Unable to rename file."
 msgstr "無法重新命名。"
 
-#: src/ExternalConn.cpp:2839
-#, c-format
-msgid "Could not save the amuleapi password: %s"
-msgstr ""
-
-#: src/ExternalConn.cpp:3004 src/ExternalConn.cpp:3032
+#: src/ExternalConn.cpp:2992 src/ExternalConn.cpp:3020
 msgid "Kad is disabled in preferences."
 msgstr "Kad 網路已在偏好設定中被停用了。"
 
-#: src/ExternalConn.cpp:3045
+#: src/ExternalConn.cpp:3033
 msgid "Already connected to eD2k."
 msgstr "eD2k 網路已連線。"
 
-#: src/ExternalConn.cpp:3048
+#: src/ExternalConn.cpp:3036
 msgid "Connecting to eD2k..."
 msgstr "eD2k 連線中..."
 
-#: src/ExternalConn.cpp:3057
+#: src/ExternalConn.cpp:3045
 msgid "Already connected to Kad."
 msgstr "Kad 網路已連線。"
 
-#: src/ExternalConn.cpp:3060
+#: src/ExternalConn.cpp:3048
 msgid "Connecting to Kad..."
 msgstr "Kad 連線中..."
 
-#: src/ExternalConn.cpp:3067
+#: src/ExternalConn.cpp:3055
 msgid "All networks are disabled."
 msgstr "所有網路都被停用了。"
 
-#: src/ExternalConn.cpp:3076
+#: src/ExternalConn.cpp:3064
 msgid "Disconnected from eD2k."
 msgstr "已中斷 eD2k 網路連線。"
 
-#: src/ExternalConn.cpp:3081
+#: src/ExternalConn.cpp:3069
 msgid "Disconnected from Kad."
 msgstr "已中斷 Kad 網路連線。"
 
-#: src/ExternalConn.cpp:3090
+#: src/ExternalConn.cpp:3078
 #, c-format
 msgid "External Connection: invalid opcode received: %#x"
 msgstr "外部連線：接收到無效的指令碼 - %#x"
 
-#: src/ExternalConn.cpp:3095
+#: src/ExternalConn.cpp:3083
 msgid "Invalid opcode (wrong protocol version?)"
 msgstr "無效的指令碼（協定版本錯誤？）"
 
@@ -2342,19 +2332,19 @@ msgstr ""
 msgid "eD2k"
 msgstr "eD2k"
 
-#: src/FirstRunWizard.cpp:349 src/muuli_wdr.cpp:1495
+#: src/FirstRunWizard.cpp:349 src/muuli_wdr.cpp:1488
 msgid "Kademlia"
 msgstr "Kad"
 
-#: src/FirstRunWizard.cpp:359 src/muuli_wdr.cpp:1423
+#: src/FirstRunWizard.cpp:359 src/muuli_wdr.cpp:1416
 msgid "Standard TCP Port "
 msgstr "標準 TCP 埠"
 
-#: src/FirstRunWizard.cpp:365 src/muuli_wdr.cpp:1435
+#: src/FirstRunWizard.cpp:365 src/muuli_wdr.cpp:1428
 msgid "Extended UDP port (Kad / global search) "
 msgstr "擴充 UDP 埠 (Kad / 全球搜尋)"
 
-#: src/FirstRunWizard.cpp:377 src/muuli_wdr.cpp:1442
+#: src/FirstRunWizard.cpp:377 src/muuli_wdr.cpp:1435
 msgid "Enable UPnP for router port forwarding"
 msgstr "啟用 UPnP 的路由通訊埠轉向"
 
@@ -2381,7 +2371,7 @@ msgstr ""
 msgid "Your peer lists are already in place - nothing to download."
 msgstr "您已經在下載檔案 %s 了"
 
-#: src/FirstRunWizard.cpp:434 src/muuli_wdr.cpp:1540
+#: src/FirstRunWizard.cpp:434 src/muuli_wdr.cpp:1533
 msgid "Auto-update server list at startup"
 msgstr "啟動時自動更新伺服器清單"
 
@@ -2427,23 +2417,23 @@ msgid ""
 "want downloads on a different (e.g. larger) disk."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:549 src/FirstRunWizard.cpp:611 src/muuli_wdr.cpp:1702
+#: src/FirstRunWizard.cpp:549 src/FirstRunWizard.cpp:611 src/muuli_wdr.cpp:1701
 msgid "Destination folder for downloads"
 msgstr "下載資料夾"
 
-#: src/FirstRunWizard.cpp:553 src/FirstRunWizard.cpp:569 src/muuli_wdr.cpp:1349
-#: src/muuli_wdr.cpp:1366 src/muuli_wdr.cpp:1677 src/muuli_wdr.cpp:1708
-#: src/muuli_wdr.cpp:1720 src/muuli_wdr.cpp:2790
+#: src/FirstRunWizard.cpp:553 src/FirstRunWizard.cpp:569 src/muuli_wdr.cpp:1342
+#: src/muuli_wdr.cpp:1359 src/muuli_wdr.cpp:1676 src/muuli_wdr.cpp:1707
+#: src/muuli_wdr.cpp:1719 src/muuli_wdr.cpp:2762
 #: src/utils/aLinkCreator/src/alcframe.cpp:135
 #: src/utils/wxCas/src/wxcasprefs.cpp:52 src/utils/wxCas/src/wxcasprefs.cpp:118
 msgid "Browse"
 msgstr "瀏覽"
 
-#: src/FirstRunWizard.cpp:559 src/muuli_wdr.cpp:1713
+#: src/FirstRunWizard.cpp:559 src/muuli_wdr.cpp:1712
 msgid "(All files in this folder are shared with other peers)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:565 src/FirstRunWizard.cpp:624 src/muuli_wdr.cpp:1715
+#: src/FirstRunWizard.cpp:565 src/FirstRunWizard.cpp:624 src/muuli_wdr.cpp:1714
 msgid "Folder for temporary download files"
 msgstr "暫存資料夾"
 
@@ -2474,7 +2464,7 @@ msgstr "無法開啟好友清單檔案 emfriends.met 供寫入！"
 msgid "CRITICAL - no client on StartChatSession"
 msgstr "重大錯誤 - 開始交談時沒有客戶端"
 
-#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2696 src/muuli_wdr.cpp:3373
+#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2668 src/muuli_wdr.cpp:3345
 msgid "Friends"
 msgstr "好友"
 
@@ -2585,8 +2575,8 @@ msgstr "無"
 msgid "No"
 msgstr "否"
 
-#: src/GenericClientListCtrl.cpp:1216 src/PrefsUnifiedDlg.cpp:2898
-#: src/PrefsUnifiedDlg.cpp:2948 src/ServerListCtrl.cpp:276
+#: src/GenericClientListCtrl.cpp:1216 src/PrefsUnifiedDlg.cpp:2818
+#: src/PrefsUnifiedDlg.cpp:2868 src/ServerListCtrl.cpp:276
 msgid "Yes"
 msgstr "是"
 
@@ -2751,10 +2741,10 @@ msgstr "無效的通訊埠"
 msgid "Please fill all fields required"
 msgstr "請填寫所有必要資訊"
 
-#: src/KadDlg.cpp:192 src/PartFile.cpp:1031 src/PrefsUnifiedDlg.cpp:1134
-#: src/PrefsUnifiedDlg.cpp:1204 src/PrefsUnifiedDlg.cpp:1405
-#: src/PrefsUnifiedDlg.cpp:1663 src/PrefsUnifiedDlg.cpp:1673
-#: src/PrefsUnifiedDlg.cpp:1690 src/PrefsUnifiedDlg.cpp:1738
+#: src/KadDlg.cpp:192 src/PartFile.cpp:1031 src/PrefsUnifiedDlg.cpp:1162
+#: src/PrefsUnifiedDlg.cpp:1331 src/PrefsUnifiedDlg.cpp:1589
+#: src/PrefsUnifiedDlg.cpp:1599 src/PrefsUnifiedDlg.cpp:1616
+#: src/PrefsUnifiedDlg.cpp:1658
 msgid "Message"
 msgstr "訊息"
 
@@ -2853,7 +2843,7 @@ msgstr "分享率"
 msgid "Uploaded"
 msgstr "已上傳"
 
-#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3253
+#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3225
 msgid "Requested"
 msgstr "已要求"
 
@@ -2977,7 +2967,7 @@ msgid "WARNING: "
 msgstr "警告："
 
 #: src/MuleNotebook.cpp:179 src/muuli_wdr.cpp:817 src/muuli_wdr.cpp:1229
-#: src/muuli_wdr.cpp:3157 src/muuli_wdr.cpp:3413
+#: src/muuli_wdr.cpp:3129 src/muuli_wdr.cpp:3385
 msgid "Close"
 msgstr "關閉"
 
@@ -2990,12 +2980,12 @@ msgstr "剪下"
 msgid "Copy"
 msgstr "複製"
 
-#: src/MuleTextCtrl.cpp:88 src/SearchDlg.cpp:261
+#: src/MuleTextCtrl.cpp:88
 msgid "Paste"
 msgstr "貼上"
 
 #: src/MuleTextCtrl.cpp:89 src/muuli_wdr.cpp:358 src/muuli_wdr.cpp:757
-#: src/muuli_wdr.cpp:2380 src/muuli_wdr.cpp:2399 src/muuli_wdr.cpp:2421
+#: src/muuli_wdr.cpp:2352 src/muuli_wdr.cpp:2371 src/muuli_wdr.cpp:2393
 #: src/utils/aLinkCreator/src/alcframe.cpp:142
 msgid "Clear"
 msgstr "清除"
@@ -3093,8 +3083,8 @@ msgid "Exit"
 msgstr "離開"
 
 #: src/MuleTrayIcon.cpp:579 src/MuleTrayIcon.cpp:945 src/MuleTrayIcon.cpp:965
-#: src/muuli_wdr.cpp:1398 src/muuli_wdr.cpp:1406 src/muuli_wdr.cpp:1413
-#: src/muuli_wdr.cpp:1836 src/muuli_wdr.cpp:1842 src/OtherFunctions.cpp:91
+#: src/muuli_wdr.cpp:1391 src/muuli_wdr.cpp:1399 src/muuli_wdr.cpp:1406
+#: src/muuli_wdr.cpp:1835 src/muuli_wdr.cpp:1841 src/OtherFunctions.cpp:91
 #: src/StatisticsDlg.cpp:93 src/StatisticsDlg.cpp:95
 msgid "kB/s"
 msgstr "KB/s"
@@ -3265,7 +3255,7 @@ msgstr "名稱："
 msgid "Type"
 msgstr "類型"
 
-#: src/muuli_wdr.cpp:215 src/SearchDlg.cpp:118 src/SearchListCtrl.cpp:853
+#: src/muuli_wdr.cpp:215 src/SearchDlg.cpp:110 src/SearchListCtrl.cpp:853
 msgid "Local"
 msgstr "本地"
 
@@ -3336,7 +3326,7 @@ msgstr "B"
 msgid "KB"
 msgstr "KB"
 
-#: src/muuli_wdr.cpp:274 src/muuli_wdr.cpp:293 src/muuli_wdr.cpp:1621
+#: src/muuli_wdr.cpp:274 src/muuli_wdr.cpp:293 src/muuli_wdr.cpp:1620
 #: src/OtherFunctions.cpp:64
 msgid "MB"
 msgstr "MB"
@@ -3353,7 +3343,7 @@ msgstr "大小上限"
 msgid "Availability"
 msgstr "最小來源數"
 
-#: src/muuli_wdr.cpp:312 src/muuli_wdr.cpp:398 src/muuli_wdr.cpp:3318
+#: src/muuli_wdr.cpp:312 src/muuli_wdr.cpp:398 src/muuli_wdr.cpp:3290
 msgid "Filter:"
 msgstr "過濾："
 
@@ -3385,7 +3375,7 @@ msgstr ""
 msgid "Stop"
 msgstr "停止"
 
-#: src/muuli_wdr.cpp:348 src/muuli_wdr.cpp:1392 src/SearchListCtrl.cpp:732
+#: src/muuli_wdr.cpp:348 src/muuli_wdr.cpp:1385 src/SearchListCtrl.cpp:732
 msgid "Download"
 msgstr "下載"
 
@@ -3416,12 +3406,12 @@ msgstr "檔案來源："
 #: src/muuli_wdr.cpp:1160 src/muuli_wdr.cpp:1167 src/muuli_wdr.cpp:1172
 #: src/muuli_wdr.cpp:1179 src/muuli_wdr.cpp:1184 src/muuli_wdr.cpp:1191
 #: src/muuli_wdr.cpp:1205 src/muuli_wdr.cpp:1212 src/muuli_wdr.cpp:1217
-#: src/muuli_wdr.cpp:1224 src/muuli_wdr.cpp:3255 src/muuli_wdr.cpp:3263
-#: src/muuli_wdr.cpp:3271
+#: src/muuli_wdr.cpp:1224 src/muuli_wdr.cpp:3227 src/muuli_wdr.cpp:3235
+#: src/muuli_wdr.cpp:3243
 msgid "N/A"
 msgstr "N/A"
 
-#: src/muuli_wdr.cpp:508 src/muuli_wdr.cpp:1065 src/PrefsUnifiedDlg.cpp:299
+#: src/muuli_wdr.cpp:508 src/muuli_wdr.cpp:1065 src/PrefsUnifiedDlg.cpp:297
 msgid "General"
 msgstr "一般"
 
@@ -3562,7 +3552,7 @@ msgstr ""
 msgid "Album :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:685 src/muuli_wdr.cpp:2275
+#: src/muuli_wdr.cpp:685 src/muuli_wdr.cpp:2247
 msgid "Title :"
 msgstr "標題："
 
@@ -3671,7 +3661,7 @@ msgstr "使用者名稱︰"
 msgid "Userhash :"
 msgstr "使用者 hash 值："
 
-#: src/muuli_wdr.cpp:895 src/muuli_wdr.cpp:1742 src/muuli_wdr.cpp:2470
+#: src/muuli_wdr.cpp:895 src/muuli_wdr.cpp:1741 src/muuli_wdr.cpp:2442
 #: src/utils/aLinkCreator/src/alcframe.cpp:137
 msgid "Add"
 msgstr "加入"
@@ -3680,15 +3670,15 @@ msgstr "加入"
 msgid "Download-Speed"
 msgstr "下載速度"
 
-#: src/muuli_wdr.cpp:954 src/muuli_wdr.cpp:989 src/muuli_wdr.cpp:2574
+#: src/muuli_wdr.cpp:954 src/muuli_wdr.cpp:989 src/muuli_wdr.cpp:2546
 msgid "Current"
 msgstr "目前"
 
-#: src/muuli_wdr.cpp:962 src/muuli_wdr.cpp:997 src/muuli_wdr.cpp:2582
+#: src/muuli_wdr.cpp:962 src/muuli_wdr.cpp:997 src/muuli_wdr.cpp:2554
 msgid "Running average"
 msgstr "執行中平均值"
 
-#: src/muuli_wdr.cpp:970 src/muuli_wdr.cpp:1005 src/muuli_wdr.cpp:2590
+#: src/muuli_wdr.cpp:970 src/muuli_wdr.cpp:1005 src/muuli_wdr.cpp:2562
 msgid "Session average"
 msgstr "本次平均值"
 
@@ -3700,7 +3690,7 @@ msgstr "上傳速度"
 msgid "Connections"
 msgstr "連線"
 
-#: src/muuli_wdr.cpp:1024 src/muuli_wdr.cpp:1861
+#: src/muuli_wdr.cpp:1024 src/muuli_wdr.cpp:1860
 msgid "Active downloads"
 msgstr "目前下載數"
 
@@ -3708,7 +3698,7 @@ msgstr "目前下載數"
 msgid "Active connections (1:1)"
 msgstr "目前連線數 (1:1)"
 
-#: src/muuli_wdr.cpp:1040 src/muuli_wdr.cpp:1862
+#: src/muuli_wdr.cpp:1040 src/muuli_wdr.cpp:1861
 msgid "Active uploads"
 msgstr "目前上傳數"
 
@@ -3824,8 +3814,8 @@ msgstr "這是其他使用者與您連線時能看到的名字。"
 msgid "Language: "
 msgstr "語言："
 
-#: src/muuli_wdr.cpp:1257 src/muuli_wdr.cpp:1330 src/muuli_wdr.cpp:1334
-#: src/muuli_wdr.cpp:1337
+#: src/muuli_wdr.cpp:1257 src/muuli_wdr.cpp:1323 src/muuli_wdr.cpp:1327
+#: src/muuli_wdr.cpp:1330
 msgid "The delay before showing tool-tips."
 msgstr "顯示提示的延遲時間。"
 
@@ -3903,960 +3893,936 @@ msgstr ""
 msgid "Enabling this will make aMule to show notifications when finished downloading."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1323
-#, fuzzy
-msgid "Remember search history"
-msgstr "記住這些設定"
-
-#: src/muuli_wdr.cpp:1324
-msgid "Keeps a dropdown list of your past search terms in the Search tab's Name field. This remembers the queries you typed, not the results they returned."
-msgstr ""
-
-#: src/muuli_wdr.cpp:1329
+#: src/muuli_wdr.cpp:1322
 msgid "Tooltip delay time: "
 msgstr "工具提示延遲："
 
-#: src/muuli_wdr.cpp:1336
+#: src/muuli_wdr.cpp:1329
 msgid "seconds"
 msgstr "秒"
 
-#: src/muuli_wdr.cpp:1340
+#: src/muuli_wdr.cpp:1333
 msgid "Browser Selection"
 msgstr "瀏覽器設定"
 
-#: src/muuli_wdr.cpp:1346
+#: src/muuli_wdr.cpp:1339
 msgid "Enter your browser name here. Leave this field empty to use the system default browser."
 msgstr "請輸入瀏覽器的名稱，空白則使用系統預設。"
 
-#: src/muuli_wdr.cpp:1353
+#: src/muuli_wdr.cpp:1346
 msgid "Open in new tab if possible"
 msgstr "在新分頁中開啟"
 
-#: src/muuli_wdr.cpp:1355
+#: src/muuli_wdr.cpp:1348
 msgid "Open the web page in a new tab instead of in a new window when possible"
 msgstr "如果可能，在新的分頁中打開而不是新的視窗"
 
-#: src/muuli_wdr.cpp:1359
+#: src/muuli_wdr.cpp:1352
 msgid "Video Player"
 msgstr "影片播放器"
 
-#: src/muuli_wdr.cpp:1386
+#: src/muuli_wdr.cpp:1379
 msgid "Bandwidth limits"
 msgstr "頻寬限制"
 
-#: src/muuli_wdr.cpp:1400
+#: src/muuli_wdr.cpp:1393
 msgid "Upload"
 msgstr "上傳"
 
-#: src/muuli_wdr.cpp:1408
+#: src/muuli_wdr.cpp:1401
 msgid "Slot Allocation"
 msgstr "位置分配"
 
-#: src/muuli_wdr.cpp:1417
+#: src/muuli_wdr.cpp:1410
 msgid "Ports"
 msgstr "通訊埠"
 
-#: src/muuli_wdr.cpp:1427
+#: src/muuli_wdr.cpp:1420
 msgid "This is the standard eD2k port and cannot be disabled."
 msgstr "標準 eD2k 通訊埠，不可停用。"
 
-#: src/muuli_wdr.cpp:1430
+#: src/muuli_wdr.cpp:1423
 msgid "UDP port for server requests (TCP+3):"
 msgstr "伺服器要求 UDP 埠 (TCP+3)："
 
-#: src/muuli_wdr.cpp:1432
+#: src/muuli_wdr.cpp:1425
 msgid "4665"
 msgstr "4665"
 
-#: src/muuli_wdr.cpp:1439
+#: src/muuli_wdr.cpp:1432
 msgid "This UDP port is used for extended eD2k requests and Kad network"
 msgstr "這個 UDP 埠用於 eD2k 擴充要求與 Kad 網路"
 
-#: src/muuli_wdr.cpp:1446
+#: src/muuli_wdr.cpp:1439
 msgid "UPnP TCP Port (Optional):"
 msgstr "UPnP TCP 埠 (選用)："
 
-#: src/muuli_wdr.cpp:1456
+#: src/muuli_wdr.cpp:1449
 msgid "Bind local address to IP (empty for any):"
 msgstr "選定本機使用 IP (留白或輸入)："
 
-#: src/muuli_wdr.cpp:1459
+#: src/muuli_wdr.cpp:1452
 msgid "Advanced users only: If you have multiple network interfaces, enter the address of the interface to which aMule should be bound."
 msgstr "進階使用者用：如果您有多網路介面，請輸入要給 aMule 使用的的網路位址。"
 
-#: src/muuli_wdr.cpp:1462 src/muuli_wdr.cpp:2055
+#: src/muuli_wdr.cpp:1455 src/muuli_wdr.cpp:2054
 #, fuzzy
 msgid "Bind to network interface (empty for any):"
 msgstr "選定本機使用 IP (留白或輸入)："
 
-#: src/muuli_wdr.cpp:1475
+#: src/muuli_wdr.cpp:1468
 msgid "Advanced users only: pin all of aMule's traffic to one network interface, chosen from the list or typed in by name (e.g. tun0, eth0, en0) or index. Unlike binding to an IP, this stops traffic leaking out via the default route - useful with a VPN. Requires no elevated privileges."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1481
+#: src/muuli_wdr.cpp:1474
 msgid "Max sources per downloading file:"
 msgstr "每個檔案最大來源數："
 
-#: src/muuli_wdr.cpp:1485
+#: src/muuli_wdr.cpp:1478
 msgid "Max simultaneous connections:"
 msgstr "最大同時連線數："
 
-#: src/muuli_wdr.cpp:1498 src/muuli_wdr.cpp:3197
+#: src/muuli_wdr.cpp:1491 src/muuli_wdr.cpp:3169
 msgid "ED2K"
 msgstr "ED2K"
 
-#: src/muuli_wdr.cpp:1505
+#: src/muuli_wdr.cpp:1498
 msgid "Autoconnect on startup"
 msgstr "啟動後自動連線"
 
-#: src/muuli_wdr.cpp:1508
+#: src/muuli_wdr.cpp:1501
 msgid "Reconnect on loss"
 msgstr "斷線後自動重新連線"
 
-#: src/muuli_wdr.cpp:1530
+#: src/muuli_wdr.cpp:1523
 msgid "Remove dead server after"
 msgstr "移除無法連線伺服器：如果"
 
-#: src/muuli_wdr.cpp:1531
+#: src/muuli_wdr.cpp:1524
 msgid "Static servers are never removed, even when unreachable."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1535
+#: src/muuli_wdr.cpp:1528
 msgid "retries"
 msgstr "次重試"
 
-#: src/muuli_wdr.cpp:1543
+#: src/muuli_wdr.cpp:1536
 msgid "List"
 msgstr "清單"
 
-#: src/muuli_wdr.cpp:1546
+#: src/muuli_wdr.cpp:1539
 msgid "Update server list when connecting to a server"
 msgstr "連線到伺服器時更新伺服器清單"
 
-#: src/muuli_wdr.cpp:1549
+#: src/muuli_wdr.cpp:1542
 msgid "Update server list when a client connects"
 msgstr "連線到客戶端時更新伺服器清單"
 
-#: src/muuli_wdr.cpp:1552
+#: src/muuli_wdr.cpp:1545
 msgid "Use priority system"
 msgstr "啟用優先等級系統"
 
-#: src/muuli_wdr.cpp:1556
+#: src/muuli_wdr.cpp:1549
 msgid "Use smart LowID check on connect"
 msgstr "連線時啟用智慧 LowID 偵測"
 
-#: src/muuli_wdr.cpp:1560
+#: src/muuli_wdr.cpp:1553
 msgid "Safe connect"
 msgstr "安全連線"
 
-#: src/muuli_wdr.cpp:1564
+#: src/muuli_wdr.cpp:1557
 msgid "Autoconnect to servers in static list only"
 msgstr "只自動連線到靜態伺服器清單裏的伺服器"
 
-#: src/muuli_wdr.cpp:1567
+#: src/muuli_wdr.cpp:1560
 msgid "Set manually added servers to High Priority"
 msgstr "手動輸入的伺服器設為高優先等級"
 
-#: src/muuli_wdr.cpp:1588
+#: src/muuli_wdr.cpp:1581
 msgid "Add files to download in pause mode"
 msgstr "加入新下載檔案時設為暫停狀態"
 
-#: src/muuli_wdr.cpp:1590
+#: src/muuli_wdr.cpp:1583
 msgid "Add files to download with auto priority"
 msgstr "加入新下載檔案時設定優先等級為自動狀態"
 
-#: src/muuli_wdr.cpp:1593
+#: src/muuli_wdr.cpp:1586
 msgid "Try to download first and last chunks first"
 msgstr "嘗試先下載檔案的第一段和最後一段"
 
-#: src/muuli_wdr.cpp:1597
+#: src/muuli_wdr.cpp:1590
 msgid "Endgame mode: rotate to faster sources for the final blocks"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1600
+#: src/muuli_wdr.cpp:1593
 msgid "Start next paused file when a file completes"
 msgstr "完成後自動傳輸下一個暫停的檔案"
 
-#: src/muuli_wdr.cpp:1603
+#: src/muuli_wdr.cpp:1596
 msgid "From the same category"
 msgstr "同一分類檔案"
 
-#: src/muuli_wdr.cpp:1605
+#: src/muuli_wdr.cpp:1598
 msgid "In alphabetic order"
 msgstr "依字母順序"
 
-#: src/muuli_wdr.cpp:1607
+#: src/muuli_wdr.cpp:1600
 msgid "Preallocate disk space for new files"
 msgstr "新檔案預先分配磁碟空間"
 
-#: src/muuli_wdr.cpp:1608
+#: src/muuli_wdr.cpp:1601
 msgid "For new files preallocates disk space for the whole file, thus reduces fragmentation"
 msgstr "新檔案預先分配所需的完整磁碟空間，這樣可以減少檔案分散度"
 
-#: src/muuli_wdr.cpp:1613
+#: src/muuli_wdr.cpp:1606
+msgid "Create new files as sparse files"
+msgstr ""
+
+#: src/muuli_wdr.cpp:1607
+msgid "A sparse file reserves its full size on disk immediately without writing real data to it -- fast, but unsupported or slow on some filesystems, and free-space accounting stays optimistic while the download is in progress. Turn this off to grow the file only as data arrives."
+msgstr ""
+
+#: src/muuli_wdr.cpp:1612
 msgid "Stop downloads when free disk space reaches "
 msgstr "磁碟可用空間不足時停止下載"
 
-#: src/muuli_wdr.cpp:1614
+#: src/muuli_wdr.cpp:1613
 msgid "Select this if you want aMule to check your disk space"
 msgstr "讓 aMule 檢查磁碟可用空間"
 
-#: src/muuli_wdr.cpp:1618
+#: src/muuli_wdr.cpp:1617
 msgid "Enter here the min disk space desired."
 msgstr "請輸入最小磁碟可用空間。"
 
-#: src/muuli_wdr.cpp:1624
+#: src/muuli_wdr.cpp:1623
 msgid "Save 10 sources on rare files (< 20 sources)"
 msgstr "為來源稀少 (< 20) 的檔案儲存 10 個來源"
 
-#: src/muuli_wdr.cpp:1628 src/Statistics.cpp:790
+#: src/muuli_wdr.cpp:1627 src/Statistics.cpp:790
 msgid "Uploads"
 msgstr "上傳"
 
-#: src/muuli_wdr.cpp:1631
+#: src/muuli_wdr.cpp:1630
 msgid "Add new shared files with auto priority"
 msgstr "新加入分享檔案優先等級設定為自動"
 
-#: src/muuli_wdr.cpp:1637
+#: src/muuli_wdr.cpp:1636
 msgid "Intelligent Corruption Handling (I.C.H.)"
 msgstr "智慧型損壞處理 (I.C.H.)"
 
-#: src/muuli_wdr.cpp:1640
+#: src/muuli_wdr.cpp:1639
 msgid "Enable"
 msgstr "啟用"
 
-#: src/muuli_wdr.cpp:1643
+#: src/muuli_wdr.cpp:1642
 msgid "Advanced I.C.H. trusts every hash (not recommended)"
 msgstr "進階 I.C.H. 信任所有 hash 值 (不建議)"
 
-#: src/muuli_wdr.cpp:1655 src/PrefsUnifiedDlg.cpp:1990
+#: src/muuli_wdr.cpp:1654 src/PrefsUnifiedDlg.cpp:1910
 msgid "Media metadata extraction"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1659
+#: src/muuli_wdr.cpp:1658
 msgid "Extract length / bitrate / codec from shared audio and video files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1661
+#: src/muuli_wdr.cpp:1660
 msgid "When enabled, aMule runs ffprobe on each shared media file to fill in the Length / Bitrate / Codec columns other clients see when they find the file in a search. Requires ffmpeg (the ffprobe binary) to be installed."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1668
+#: src/muuli_wdr.cpp:1667
 msgid "Path to ffprobe:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1673
+#: src/muuli_wdr.cpp:1672
 msgid "Full path to the ffprobe binary. Leave empty to have aMule auto-detect it on startup."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1681
+#: src/muuli_wdr.cpp:1680
 msgid "Detect"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1682
+#: src/muuli_wdr.cpp:1681
 msgid "Search the standard install locations for an ffprobe binary and fill the path field."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1706
+#: src/muuli_wdr.cpp:1705
 msgid ""
 "Completed downloads are stored here. All files in this folder are automatically shared with other peers.\n"
 "If this folder also holds files you don't want to share, point it at an aMule-only sub-folder."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1709
+#: src/muuli_wdr.cpp:1708
 msgid "Pick the folder where completed downloads will be stored. All files in that folder will be shared with other peers."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1723
+#: src/muuli_wdr.cpp:1722
 msgid "Shared folders"
 msgstr "分享資料夾"
 
-#: src/muuli_wdr.cpp:1729
+#: src/muuli_wdr.cpp:1728
 msgid "(Folders shared by the core. Enter a path to add one.)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1737
+#: src/muuli_wdr.cpp:1736
 msgid "Absolute path of a folder on the core's machine, e.g. /home/user/shared"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1739 src/PrefsUnifiedDlg.cpp:2874
+#: src/muuli_wdr.cpp:1738 src/PrefsUnifiedDlg.cpp:2794
 msgid "Recursive"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1740
+#: src/muuli_wdr.cpp:1739
 msgid "Share every sub-folder underneath this one, including ones created later."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1744 src/utils/aLinkCreator/src/alcframe.cpp:141
+#: src/muuli_wdr.cpp:1743 src/utils/aLinkCreator/src/alcframe.cpp:141
 msgid "Remove"
 msgstr "移除"
 
-#: src/muuli_wdr.cpp:1748
+#: src/muuli_wdr.cpp:1747
 msgid "(Right click on folder icon for recursive share)"
 msgstr "(滑鼠右鍵點選檔案夾圖示可全部遞迴分享)"
 
-#: src/muuli_wdr.cpp:1755
+#: src/muuli_wdr.cpp:1754
 msgid "Share hidden files"
 msgstr "分享隱藏檔"
 
-#: src/muuli_wdr.cpp:1761
+#: src/muuli_wdr.cpp:1760
 msgid "Automatically rescan shared folders for changes"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1767
+#: src/muuli_wdr.cpp:1766
 msgid "Follow symbolic links in shared folders"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1773
+#: src/muuli_wdr.cpp:1772
 msgid "Exclude files matching:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1776
+#: src/muuli_wdr.cpp:1775
 msgid "Wildcard patterns separated by '|', e.g. .DS_Store|Thumbs.db|*.tmp. Files whose name matches are not shared. Matching is case-insensitive."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1780
+#: src/muuli_wdr.cpp:1779
 msgid "Patterns are regular expressions"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1781
+#: src/muuli_wdr.cpp:1780
 msgid "When set, the whole field is one regular expression ('|' is alternation). When unset, it is a list of '|'-separated wildcards."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1791
+#: src/muuli_wdr.cpp:1790
 msgid "Show how many shared files the current pattern would exclude."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1812
+#: src/muuli_wdr.cpp:1811
 msgid "Graphs"
 msgstr "圖表"
 
-#: src/muuli_wdr.cpp:1815 src/muuli_wdr.cpp:1877
+#: src/muuli_wdr.cpp:1814 src/muuli_wdr.cpp:1876
 msgid "Update delay : 5 secs"
 msgstr "更新延遲時間：5 秒"
 
-#: src/muuli_wdr.cpp:1819
+#: src/muuli_wdr.cpp:1818
 msgid "Time for average graph: 100 mins"
 msgstr "平均圖表顯示時間：100 分鐘"
 
-#: src/muuli_wdr.cpp:1823
+#: src/muuli_wdr.cpp:1822
 msgid "Connections Graph Scale: 100 "
 msgstr "連線圖表比例：100 "
 
-#: src/muuli_wdr.cpp:1830
+#: src/muuli_wdr.cpp:1829
 msgid "Download graph scale:"
 msgstr "下載統計圖比例："
 
-#: src/muuli_wdr.cpp:1838
+#: src/muuli_wdr.cpp:1837
 msgid "Upload graph scale:"
 msgstr "上傳統計圖比例："
 
-#: src/muuli_wdr.cpp:1848
+#: src/muuli_wdr.cpp:1847
 #, fuzzy
 msgid "Colors: "
 msgstr "顏色："
 
-#: src/muuli_wdr.cpp:1852
+#: src/muuli_wdr.cpp:1851
 msgid "Background"
 msgstr "背景"
 
-#: src/muuli_wdr.cpp:1853
+#: src/muuli_wdr.cpp:1852
 msgid "Grid"
 msgstr "格線"
 
-#: src/muuli_wdr.cpp:1854
+#: src/muuli_wdr.cpp:1853
 msgid "Download current"
 msgstr "目前下載"
 
-#: src/muuli_wdr.cpp:1855
+#: src/muuli_wdr.cpp:1854
 msgid "Download running average"
 msgstr "執行中平均下載"
 
-#: src/muuli_wdr.cpp:1856
+#: src/muuli_wdr.cpp:1855
 msgid "Download session average"
 msgstr "本次平均下載"
 
-#: src/muuli_wdr.cpp:1857
+#: src/muuli_wdr.cpp:1856
 msgid "Upload current"
 msgstr "目前上傳"
 
-#: src/muuli_wdr.cpp:1858
+#: src/muuli_wdr.cpp:1857
 msgid "Upload running average"
 msgstr "執行中平均上傳"
 
-#: src/muuli_wdr.cpp:1859
+#: src/muuli_wdr.cpp:1858
 msgid "Upload session average"
 msgstr "本次平均上傳"
 
-#: src/muuli_wdr.cpp:1860
+#: src/muuli_wdr.cpp:1859
 msgid "Active connections"
 msgstr "目前連線數"
 
-#: src/muuli_wdr.cpp:1863
+#: src/muuli_wdr.cpp:1862
 #, fuzzy
 msgid "Systray Icon Speed Bar"
 msgstr "狀態列圖示顯示速度"
 
-#: src/muuli_wdr.cpp:1864
+#: src/muuli_wdr.cpp:1863
 msgid "Kad-nodes current"
 msgstr "目前 Kad 節點"
 
-#: src/muuli_wdr.cpp:1865
+#: src/muuli_wdr.cpp:1864
 msgid "Kad-nodes running"
 msgstr "執行中 Kad 節點"
 
-#: src/muuli_wdr.cpp:1866
+#: src/muuli_wdr.cpp:1865
 msgid "Kad-nodes session"
 msgstr "本次 Kad 節點"
 
-#: src/muuli_wdr.cpp:1870 src/muuli_wdr.cpp:2324
+#: src/muuli_wdr.cpp:1869 src/muuli_wdr.cpp:2296
 msgid "Select"
 msgstr "選取"
 
-#: src/muuli_wdr.cpp:1874
+#: src/muuli_wdr.cpp:1873
 msgid "Tree"
 msgstr "樹狀"
 
-#: src/muuli_wdr.cpp:1884
+#: src/muuli_wdr.cpp:1883
 msgid "Number of Client Versions shown (0=unlimited)"
 msgstr "顯示客戶端版本的數量 ( 0 代表不限制)"
 
-#: src/muuli_wdr.cpp:1909
+#: src/muuli_wdr.cpp:1908
 msgid "!!! WARNING !!!"
 msgstr "!!! 警告 !!!"
 
-#: src/muuli_wdr.cpp:1924
+#: src/muuli_wdr.cpp:1923
 msgid "Max new connections / 5 secs"
 msgstr "5 秒內最大新連線數"
 
-#: src/muuli_wdr.cpp:1926
+#: src/muuli_wdr.cpp:1925
 msgid "Concurrent Kad source lookups"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1928
+#: src/muuli_wdr.cpp:1927
 #, fuzzy
 msgid "Kad source re-search interval (minutes)"
 msgstr "FTP 上傳間隔 (分鐘)"
 
-#: src/muuli_wdr.cpp:1930
+#: src/muuli_wdr.cpp:1929
 #, fuzzy
 msgid "Source re-ask interval (minutes)"
 msgstr "FTP 上傳間隔 (分鐘)"
 
-#: src/muuli_wdr.cpp:1934
+#: src/muuli_wdr.cpp:1933
 msgid "File Buffer Size: 240000 bytes"
 msgstr "檔案緩衝區：240.000 KB"
 
-#: src/muuli_wdr.cpp:1938
+#: src/muuli_wdr.cpp:1937
 msgid "Use MMAP: memory-mapped file access (lower memory use)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1939
+#: src/muuli_wdr.cpp:1938
 msgid "Maps part files into memory instead of buffering them on the heap, lowering the process memory footprint. May reduce download speed on some disks; best for memory-constrained or upload-heavy hosts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1941
+#: src/muuli_wdr.cpp:1940
 msgid "Upload Queue Size: 5000 clients"
 msgstr "上傳等候區大小：5000 "
 
-#: src/muuli_wdr.cpp:1945
+#: src/muuli_wdr.cpp:1944
 msgid "Server connection refresh interval: Disable"
 msgstr "伺服器連線更新間隔時間：停用"
 
-#: src/muuli_wdr.cpp:1949
+#: src/muuli_wdr.cpp:1948
 msgid "Disable computer's timed standby mode"
 msgstr "停用電腦的自動進入待命模式功能"
 
-#: src/muuli_wdr.cpp:1968
+#: src/muuli_wdr.cpp:1967
 msgid "Skin to use: "
 msgstr "使用面板："
 
-#: src/muuli_wdr.cpp:1977
+#: src/muuli_wdr.cpp:1976
 msgid "Show \"Fast eD2k Links Handler\" in every window."
 msgstr "在每個視窗顯示「eD2k 連結快速處理器」。"
 
-#: src/muuli_wdr.cpp:1980
+#: src/muuli_wdr.cpp:1979
 msgid "Show extended info on categories tabs"
 msgstr "在分類頁中顯示擴充資訊"
 
-#: src/muuli_wdr.cpp:1983
+#: src/muuli_wdr.cpp:1982
 msgid "Show application version on title"
 msgstr "在標題顯示應用程式版本"
 
-#: src/muuli_wdr.cpp:1985
+#: src/muuli_wdr.cpp:1984
 msgid "Show transfer rates on title"
 msgstr "標題列顯示傳輸速度"
 
-#: src/muuli_wdr.cpp:1987
+#: src/muuli_wdr.cpp:1986
 msgid "Before application name"
 msgstr "在程式名稱前"
 
-#: src/muuli_wdr.cpp:1989
+#: src/muuli_wdr.cpp:1988
 msgid "After application name"
 msgstr "在程式名稱後"
 
-#: src/muuli_wdr.cpp:1992
+#: src/muuli_wdr.cpp:1991
 msgid "Show overhead bandwidth"
 msgstr "顯示額外支出頻寬"
 
-#: src/muuli_wdr.cpp:1996
+#: src/muuli_wdr.cpp:1995
 msgid "Vertical toolbar orientation"
 msgstr "垂直顯示工具列"
 
-#: src/muuli_wdr.cpp:1998
+#: src/muuli_wdr.cpp:1997
 msgid "Live column sorting (auto-reorder rows as their values change)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2005
+#: src/muuli_wdr.cpp:2004
 msgid "Download Queue Files"
 msgstr "下載等候區檔案"
 
-#: src/muuli_wdr.cpp:2008
+#: src/muuli_wdr.cpp:2007
 msgid "Show progress percentage"
 msgstr "顯示進度百分比"
 
-#: src/muuli_wdr.cpp:2014
+#: src/muuli_wdr.cpp:2013
 msgid "Show progress bar"
 msgstr "顯示進度條"
 
-#: src/muuli_wdr.cpp:2017
+#: src/muuli_wdr.cpp:2016
 msgid "Flat"
 msgstr "扁平"
 
-#: src/muuli_wdr.cpp:2021
+#: src/muuli_wdr.cpp:2020
 msgid "Round"
 msgstr "圓弧"
 
-#: src/muuli_wdr.cpp:2039
+#: src/muuli_wdr.cpp:2038
 msgid "External Connection Parameters"
 msgstr "外部連線參數"
 
-#: src/muuli_wdr.cpp:2042
+#: src/muuli_wdr.cpp:2041
 msgid "Accept external connections"
 msgstr "接受外部連線"
 
-#: src/muuli_wdr.cpp:2049 src/muuli_wdr.cpp:2108
+#: src/muuli_wdr.cpp:2048 src/muuli_wdr.cpp:2107
 msgid "IP of the listening interface:"
 msgstr "監聽 IP："
 
-#: src/muuli_wdr.cpp:2052
+#: src/muuli_wdr.cpp:2051
 msgid "Enter here a valid ip in the a.b.c.d format for the listening EC interface. An empty field or 0.0.0.0 will mean any interface."
 msgstr "輸入要監聽外部連線的的 IP (格式：a.b.c.d)，空白或 0.0.0.0 表示全部。"
 
-#: src/muuli_wdr.cpp:2073 src/muuli_wdr.cpp:2184
+#: src/muuli_wdr.cpp:2072 src/muuli_wdr.cpp:2156
 msgid "TCP port:"
 msgstr "TCP 埠："
 
-#: src/muuli_wdr.cpp:2079
+#: src/muuli_wdr.cpp:2078
 msgid "Enable UPnP port forwarding on the EC port"
 msgstr "外部連線通訊埠啟用 UPnP 通訊埠轉向"
 
-#: src/muuli_wdr.cpp:2083 src/muuli_wdr.cpp:3069
+#: src/muuli_wdr.cpp:2082 src/muuli_wdr.cpp:3041
 #: src/utils/wxCas/src/wxcasprefs.cpp:167
 msgid "Password"
 msgstr "密碼"
 
-#: src/muuli_wdr.cpp:2089
+#: src/muuli_wdr.cpp:2088
 #, fuzzy
 msgid "aMule API server parameters"
 msgstr "網站伺服器參數"
 
-#: src/muuli_wdr.cpp:2092
+#: src/muuli_wdr.cpp:2091
 msgid "Run amuleapi (REST API) on startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2097
+#: src/muuli_wdr.cpp:2096
 #, fuzzy
 msgid "HTTP port:"
 msgstr "TCP 埠："
 
-#: src/muuli_wdr.cpp:2111
+#: src/muuli_wdr.cpp:2110
 msgid "The interface amuleapi's HTTP server listens on. 127.0.0.1 (default) accepts only local connections; use 0.0.0.0 or a specific IP to expose it to other hosts (set an admin password below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2116
-msgid "Type a password to set or change it. Stored passwords cannot be shown, so leaving this empty keeps the current one."
-msgstr ""
-
-#: src/muuli_wdr.cpp:2118
+#: src/muuli_wdr.cpp:2113
 #, fuzzy
 msgid "Admin password"
 msgstr "正在檢查密碼\n"
 
-#: src/muuli_wdr.cpp:2130 src/muuli_wdr.cpp:2147 src/PrefsUnifiedDlg.cpp:1103
-#, fuzzy
-msgid "A password is set."
-msgstr "正在檢查密碼\n"
+#: src/muuli_wdr.cpp:2118 src/muuli_wdr.cpp:2149
+msgid "Low rights password"
+msgstr "低權限使用者密碼"
 
-#: src/muuli_wdr.cpp:2134
-#, fuzzy
-msgid "Enable guest access"
-msgstr "拒絕訪客連線"
-
-#: src/muuli_wdr.cpp:2135
-msgid "Guest sessions may read status and listings but cannot change anything. Turning this off clears the stored guest password."
-msgstr ""
-
-#: src/muuli_wdr.cpp:2139
-#, fuzzy
-msgid "Guest password"
-msgstr "網站伺服器的 訪客密碼"
-
-#: src/muuli_wdr.cpp:2154
+#: src/muuli_wdr.cpp:2126
 msgid "Web server parameters"
 msgstr "網站伺服器參數"
 
-#: src/muuli_wdr.cpp:2157
+#: src/muuli_wdr.cpp:2129
 #, fuzzy
 msgid "Run webserver on startup (deprecated)"
 msgstr "啟動時執行網站伺服器"
 
-#: src/muuli_wdr.cpp:2163
+#: src/muuli_wdr.cpp:2135
 msgid "Web template"
 msgstr "網頁模板"
 
-#: src/muuli_wdr.cpp:2168
+#: src/muuli_wdr.cpp:2140
 msgid "Full rights password"
 msgstr "絕對權限使用者密碼"
 
-#: src/muuli_wdr.cpp:2172
+#: src/muuli_wdr.cpp:2144
 msgid "Enable Low rights User"
 msgstr "啟用低權限使用者"
 
-#: src/muuli_wdr.cpp:2177
-msgid "Low rights password"
-msgstr "低權限使用者密碼"
-
-#: src/muuli_wdr.cpp:2191
+#: src/muuli_wdr.cpp:2163
 msgid "Enable UPnP port forwarding of the web server port"
 msgstr "網站伺服器的通訊埠啟用 UPnP 通訊埠轉向"
 
-#: src/muuli_wdr.cpp:2196
+#: src/muuli_wdr.cpp:2168
 msgid "Web server UPnP TCP port (Optional)"
 msgstr "網站伺服器的 UPnP TCP 埠 (選用)"
 
-#: src/muuli_wdr.cpp:2204
+#: src/muuli_wdr.cpp:2176
 msgid "Page Refresh Time (in secs)"
 msgstr "頁面更新時間 (秒)"
 
-#: src/muuli_wdr.cpp:2211
+#: src/muuli_wdr.cpp:2183
 msgid "Enable Gzip compression"
 msgstr "啟用 Gzip 壓縮"
 
-#: src/muuli_wdr.cpp:2245
+#: src/muuli_wdr.cpp:2217
 #, fuzzy
 msgid "Reset page to defaults"
 msgstr "系統預設"
 
-#: src/muuli_wdr.cpp:2246
+#: src/muuli_wdr.cpp:2218
 msgid "Reset the settings on the current page to their default values."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2248 src/muuli_wdr.cpp:2334 src/ServerWnd.cpp:274
+#: src/muuli_wdr.cpp:2220 src/muuli_wdr.cpp:2306 src/ServerWnd.cpp:274
 #: src/ServerWnd.cpp:282
 msgid "OK"
 msgstr "OK"
 
-#: src/muuli_wdr.cpp:2250
+#: src/muuli_wdr.cpp:2222
 msgid "Click here to apply any changes made to the preferences."
 msgstr "點選這裏立即套用已變更的偏好設定。"
 
-#: src/muuli_wdr.cpp:2253
+#: src/muuli_wdr.cpp:2225
 msgid "Reset any changes made to the preferences."
 msgstr "取消所有偏好設定變更。"
 
-#: src/muuli_wdr.cpp:2282
+#: src/muuli_wdr.cpp:2254
 msgid "Comment :"
 msgstr "註解："
 
-#: src/muuli_wdr.cpp:2289
+#: src/muuli_wdr.cpp:2261
 msgid "Incoming Dir :"
 msgstr "新進檔目錄："
 
-#: src/muuli_wdr.cpp:2298
+#: src/muuli_wdr.cpp:2270
 msgid "Change priority for new assigned files :"
 msgstr "設定新加入的檔案優先等級為："
 
-#: src/muuli_wdr.cpp:2302
+#: src/muuli_wdr.cpp:2274
 msgid "Don't change"
 msgstr "不要變更"
 
-#: src/muuli_wdr.cpp:2314
+#: src/muuli_wdr.cpp:2286
 msgid "Select color for this Category (currently selected) :"
 msgstr "選取該分類的顏色 (目前選擇)："
 
-#: src/muuli_wdr.cpp:2381 src/muuli_wdr.cpp:2400 src/muuli_wdr.cpp:2422
+#: src/muuli_wdr.cpp:2353 src/muuli_wdr.cpp:2372 src/muuli_wdr.cpp:2394
 msgid "Click this button to reset the log."
 msgstr "點選這個按鈕來清除記錄。"
 
-#: src/muuli_wdr.cpp:2441
+#: src/muuli_wdr.cpp:2413
 msgid "Click on this button to update the servers list from URL ..."
 msgstr "點選這個按鈕從該網址更新伺服器清單 ..."
 
-#: src/muuli_wdr.cpp:2445
+#: src/muuli_wdr.cpp:2417
 msgid "Server list"
 msgstr "伺服器清單"
 
-#: src/muuli_wdr.cpp:2449
+#: src/muuli_wdr.cpp:2421
 msgid "Enter the url to a server.met file here and press the button to the left to update the list of known servers."
 msgstr "輸入 server.met 檔案的網址並按下左邊的按鈕以更新已知伺服器清單。"
 
-#: src/muuli_wdr.cpp:2454
+#: src/muuli_wdr.cpp:2426
 msgid "Add server manually: Name"
 msgstr "手動加入伺服器：名稱"
 
-#: src/muuli_wdr.cpp:2457
+#: src/muuli_wdr.cpp:2429
 msgid "Enter the name of the new server here"
 msgstr "輸入新伺服器的名稱"
 
-#: src/muuli_wdr.cpp:2459 src/ServerWnd.cpp:206
+#: src/muuli_wdr.cpp:2431 src/ServerWnd.cpp:206
 msgid "IP:Port"
 msgstr "IP:Port"
 
-#: src/muuli_wdr.cpp:2462
+#: src/muuli_wdr.cpp:2434
 msgid "Enter the IP of the server here, using the x.x.x.x format."
 msgstr "輸入新伺服器的 IP (格式：x.x.x.x)。"
 
-#: src/muuli_wdr.cpp:2468
+#: src/muuli_wdr.cpp:2440
 msgid "Enter the port of the server here."
 msgstr "輸入伺服器的通訊埠。"
 
-#: src/muuli_wdr.cpp:2471
+#: src/muuli_wdr.cpp:2443
 msgid "Add manually a server (fill fields to the left before) ..."
 msgstr "手動加入伺服器 (填入左側空格中) ..."
 
-#: src/muuli_wdr.cpp:2500
+#: src/muuli_wdr.cpp:2472
 msgid "aMule Log"
 msgstr "aMule 記錄"
 
-#: src/muuli_wdr.cpp:2508
+#: src/muuli_wdr.cpp:2480
 msgid "Server Info"
 msgstr "伺服器資訊"
 
-#: src/muuli_wdr.cpp:2512
+#: src/muuli_wdr.cpp:2484
 msgid "ED2K Info"
 msgstr "eD2k 資訊"
 
-#: src/muuli_wdr.cpp:2516
+#: src/muuli_wdr.cpp:2488
 msgid "Kad Info"
 msgstr "Kad 資訊"
 
-#: src/muuli_wdr.cpp:2544
+#: src/muuli_wdr.cpp:2516
 msgid "Click on this button to update the nodes list from URL ..."
 msgstr "點選這個按鈕來從該網址更新節點清單 ..."
 
-#: src/muuli_wdr.cpp:2548
+#: src/muuli_wdr.cpp:2520
 msgid "Nodes (0)"
 msgstr "節點 (0)"
 
-#: src/muuli_wdr.cpp:2552
+#: src/muuli_wdr.cpp:2524
 msgid "Enter the url to a nodes.dat file here and press the button to the left to update the list of known nodes."
 msgstr "輸入 nodes.dat 檔案的網址，並按下左邊的按鈕以更新已知節點清單。"
 
-#: src/muuli_wdr.cpp:2555
+#: src/muuli_wdr.cpp:2527
 msgid "Nodes stats"
 msgstr "節點狀態"
 
-#: src/muuli_wdr.cpp:2597
+#: src/muuli_wdr.cpp:2569
 msgid "Bootstrap"
 msgstr "啓動"
 
-#: src/muuli_wdr.cpp:2600
+#: src/muuli_wdr.cpp:2572
 msgid "New node"
 msgstr "新節點"
 
-#: src/muuli_wdr.cpp:2605
+#: src/muuli_wdr.cpp:2577
 msgid "IP:"
 msgstr "IP："
 
-#: src/muuli_wdr.cpp:2625
+#: src/muuli_wdr.cpp:2597
 msgid "Port:"
 msgstr "埠："
 
-#: src/muuli_wdr.cpp:2638
+#: src/muuli_wdr.cpp:2610
 msgid "Bootstrap from known clients"
 msgstr "從已知客戶端啓動"
 
-#: src/muuli_wdr.cpp:2640
+#: src/muuli_wdr.cpp:2612
 msgid "Disconnect Kad"
 msgstr "中斷 Kad 連線"
 
-#: src/muuli_wdr.cpp:2674
+#: src/muuli_wdr.cpp:2646
 msgid "Use Secure User Identification"
 msgstr "啟用使用者安全認證"
 
-#: src/muuli_wdr.cpp:2676
+#: src/muuli_wdr.cpp:2648
 msgid "It is recommended to enable this option. You will not receive credits if SUI is not enabled."
 msgstr "建議啟用此選項。如果使用者安全認證未啟用，將會得不到積分。"
 
-#: src/muuli_wdr.cpp:2678
+#: src/muuli_wdr.cpp:2650
 msgid "Protocol Obfuscation"
 msgstr "模糊協定"
 
-#: src/muuli_wdr.cpp:2681
+#: src/muuli_wdr.cpp:2653
 msgid "Support Protocol Obfuscation"
 msgstr "支援模糊協定"
 
-#: src/muuli_wdr.cpp:2683
+#: src/muuli_wdr.cpp:2655
 msgid "This option enabled Protocol Obfuscation, and makes aMule accept obfuscated connections from other clients."
 msgstr "啓用模糊協定，可讓 aMule 接受來自其他客戶端的模糊連線。"
 
-#: src/muuli_wdr.cpp:2685
+#: src/muuli_wdr.cpp:2657
 msgid "Use obfuscation for outgoing connections"
 msgstr "對外的連線使用模糊協定"
 
-#: src/muuli_wdr.cpp:2687
+#: src/muuli_wdr.cpp:2659
 msgid "This option makes aMule use Protocol Obfuscation when connecting other clients/servers."
 msgstr "使 aMule 在與其他客戶端或伺服器連線時使用模糊協定。"
 
-#: src/muuli_wdr.cpp:2689
+#: src/muuli_wdr.cpp:2661
 msgid "Accept only obfuscated connections"
 msgstr "只接受模糊連線"
 
-#: src/muuli_wdr.cpp:2690
+#: src/muuli_wdr.cpp:2662
 msgid "This option makes aMule only accept obfuscated connections. You will have less sources, but all your traffic will be obfuscated"
 msgstr "讓 aMule 只接受模糊協定，檔案來源會比較少，但所有傳輸都將是模糊連線"
 
-#: src/muuli_wdr.cpp:2695
+#: src/muuli_wdr.cpp:2667
 msgid "Everybody"
 msgstr "任何人"
 
-#: src/muuli_wdr.cpp:2697
+#: src/muuli_wdr.cpp:2669
 msgid "No one"
 msgstr "無"
 
-#: src/muuli_wdr.cpp:2699
+#: src/muuli_wdr.cpp:2671
 msgid "Who can see my shared files:"
 msgstr "誰可以看我的分享檔案："
 
-#: src/muuli_wdr.cpp:2700
+#: src/muuli_wdr.cpp:2672
 msgid "Select who can request to view a list of your shared files."
 msgstr "選取可以瀏覽分享檔案清單的使用者。"
 
-#: src/muuli_wdr.cpp:2702
+#: src/muuli_wdr.cpp:2674
 msgid "IP-Filtering"
 msgstr "IP 過濾"
 
-#: src/muuli_wdr.cpp:2709
+#: src/muuli_wdr.cpp:2681
 msgid "Filter clients"
 msgstr "過濾客戶端"
 
-#: src/muuli_wdr.cpp:2711
+#: src/muuli_wdr.cpp:2683
 msgid "Enable filtering of the client IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "過濾列在 ~/.aMule/ipfilter.dat 檔案中的客戶端 IP"
 
-#: src/muuli_wdr.cpp:2713
+#: src/muuli_wdr.cpp:2685
 msgid "Filter servers"
 msgstr "過濾伺服器"
 
-#: src/muuli_wdr.cpp:2715
+#: src/muuli_wdr.cpp:2687
 msgid "Enable filtering of the server IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "過濾列在 ~/.aMule/ipfilter.dat 檔案中的伺服器 IP 。"
 
-#: src/muuli_wdr.cpp:2719
+#: src/muuli_wdr.cpp:2691
 msgid "Reload List"
 msgstr "重載入清單"
 
-#: src/muuli_wdr.cpp:2720
+#: src/muuli_wdr.cpp:2692
 msgid "Reload the list of IPs to filter from the file ~/.aMule/ipfilter.dat"
 msgstr "重新載入 IP 過濾清單 ~/.aMule/ipfilter.dat"
 
-#: src/muuli_wdr.cpp:2726
+#: src/muuli_wdr.cpp:2698
 msgid "URL:"
 msgstr "網址："
 
-#: src/muuli_wdr.cpp:2730 src/muuli_wdr.cpp:2923
+#: src/muuli_wdr.cpp:2702 src/muuli_wdr.cpp:2895
 msgid "Update now"
 msgstr "立即更新"
 
-#: src/muuli_wdr.cpp:2733
+#: src/muuli_wdr.cpp:2705
 msgid "Auto-update ipfilter at startup"
 msgstr "啓動後自動更新 IP 過濾清單"
 
-#: src/muuli_wdr.cpp:2737
+#: src/muuli_wdr.cpp:2709
 msgid "Filtering Level:"
 msgstr "過濾等級："
 
-#: src/muuli_wdr.cpp:2743
+#: src/muuli_wdr.cpp:2715
 msgid "Always filter LAN IPs"
 msgstr "永遠過濾區域網路 IP"
 
-#: src/muuli_wdr.cpp:2746
+#: src/muuli_wdr.cpp:2718
 msgid "Paranoid handling of non-matching IPs"
 msgstr "處理不匹配的 IP"
 
-#: src/muuli_wdr.cpp:2748
+#: src/muuli_wdr.cpp:2720
 msgid "Rejects a packet when its source IP differs from the IP the client claims (an anti-spoofing check). Disable only if it causes connection problems."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2750
+#: src/muuli_wdr.cpp:2722
 msgid "Use system-wide ipfilter.dat if available"
 msgstr "如果可以則使用系統級的 ipfilter.dat"
 
-#: src/muuli_wdr.cpp:2751
+#: src/muuli_wdr.cpp:2723
 #, fuzzy
 msgid "If there's no local ipfilter.dat found, allow usage of a system-wide ipfilter file."
 msgstr "如果找不到本機 ipfilter.dat 檔案，則允許使用系統級的 IP 過濾檔。"
 
-#: src/muuli_wdr.cpp:2768
+#: src/muuli_wdr.cpp:2740
 msgid "Enable Online-Signature"
 msgstr "啟用線上簽名識別"
 
-#: src/muuli_wdr.cpp:2770
+#: src/muuli_wdr.cpp:2742
 msgid "Enables the writing of the OS file, which can be used by external apps to create signatures and the like."
 msgstr "啟用寫入到作業系統檔案，以讓外部程式用來建立簽名識別等等。"
 
-#: src/muuli_wdr.cpp:2774
+#: src/muuli_wdr.cpp:2746
 msgid "Update Frequency (Secs):"
 msgstr "更新頻率(秒)："
 
-#: src/muuli_wdr.cpp:2777
+#: src/muuli_wdr.cpp:2749
 msgid "Change the frequency (in seconds) of Online Signature updates."
 msgstr "變更線上簽名識別檔的更新頻率 (單位為 秒)。"
 
-#: src/muuli_wdr.cpp:2785
+#: src/muuli_wdr.cpp:2757
 msgid "Save online signature file in: "
 msgstr "儲存線上簽名識別檔："
 
-#: src/muuli_wdr.cpp:2791
+#: src/muuli_wdr.cpp:2763
 msgid "Click here to select the directory containing the the Online Signature files."
 msgstr "點擊選取線上簽識別名檔案所在的目錄。"
 
-#: src/muuli_wdr.cpp:2824
+#: src/muuli_wdr.cpp:2796
 msgid "Show country flags for clients"
 msgstr "顯示客戶端的國旗"
 
-#: src/muuli_wdr.cpp:2825
+#: src/muuli_wdr.cpp:2797
 msgid "Render the country flag column in the transfers, queue and search views. Requires a valid MMDB GeoIP database (see below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2830
+#: src/muuli_wdr.cpp:2802
 #, fuzzy
 msgid "Database"
 msgstr "速度："
 
-#: src/muuli_wdr.cpp:2846
+#: src/muuli_wdr.cpp:2818
 #, fuzzy
 msgid "Source:"
 msgstr "來源"
 
-#: src/muuli_wdr.cpp:2849
+#: src/muuli_wdr.cpp:2821
 msgid "DB-IP (free, no account)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2850
+#: src/muuli_wdr.cpp:2822
 msgid "MaxMind GeoLite2 (free, account required)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2851
+#: src/muuli_wdr.cpp:2823
 msgid "Custom URL"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2854
+#: src/muuli_wdr.cpp:2826
 msgid "Choose which provider supplies the GeoIP MMDB database. DB-IP is the default - no account required. MaxMind requires a free account + license key. Use Custom URL to point at any other MMDB host (e.g. a local mirror)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2871
+#: src/muuli_wdr.cpp:2843
 msgid ""
 "No configuration required.\n"
 "\n"
@@ -4864,11 +4830,11 @@ msgid ""
 "License: Creative Commons BY 4.0 - https://creativecommons.org/licenses/by/4.0/"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2884
+#: src/muuli_wdr.cpp:2856
 msgid "License key:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2890
+#: src/muuli_wdr.cpp:2862
 msgid ""
 "Sign up for a free MaxMind account, then generate a License Key:\n"
 "https://www.maxmind.com/en/geolite2/signup\n"
@@ -4878,226 +4844,226 @@ msgid ""
 "Requires attribution and account registration; refresh at least every 30 days."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2905
+#: src/muuli_wdr.cpp:2877
 #, fuzzy
 msgid "Download URL:"
 msgstr "下載："
 
-#: src/muuli_wdr.cpp:2911
+#: src/muuli_wdr.cpp:2883
 msgid ""
 "Must point to an .mmdb file or a .gz / .tar.gz containing one.\n"
 "URL may include credentials (https://user:pass@host/...).\n"
 "License and attribution terms are set by the upstream URL - you are responsible."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2924
+#: src/muuli_wdr.cpp:2896
 msgid "Download the GeoIP database from the selected source."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2926
+#: src/muuli_wdr.cpp:2898
 #, fuzzy
 msgid "Auto-update on startup"
 msgstr "啓動後自動更新 IP 過濾清單"
 
-#: src/muuli_wdr.cpp:2927
+#: src/muuli_wdr.cpp:2899
 msgid "Re-download the GeoIP database from the selected source every time aMule starts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2950
+#: src/muuli_wdr.cpp:2922
 msgid "Filter incoming messages (except current chat):"
 msgstr "過濾收到的訊息 (不包含目前交談)："
 
-#: src/muuli_wdr.cpp:2952
+#: src/muuli_wdr.cpp:2924
 msgid "Filter all messages"
 msgstr "過濾所有訊息"
 
-#: src/muuli_wdr.cpp:2954
+#: src/muuli_wdr.cpp:2926
 msgid "Filter messages from people not on your friend list"
 msgstr "過濾來自好友以外的訊息"
 
-#: src/muuli_wdr.cpp:2956
+#: src/muuli_wdr.cpp:2928
 msgid "Filter messages from unknown clients"
 msgstr "過濾來自不明客戶端的訊息"
 
-#: src/muuli_wdr.cpp:2958
+#: src/muuli_wdr.cpp:2930
 msgid "Filter messages containing (use ',' as separator):"
 msgstr "過濾含以下內容的訊息 (用逗號 ',' 隔開)："
 
-#: src/muuli_wdr.cpp:2961 src/muuli_wdr.cpp:2972
+#: src/muuli_wdr.cpp:2933 src/muuli_wdr.cpp:2944
 msgid "add here the words amule should filter and block messages including it"
 msgstr "輸入要過濾的詞句"
 
-#: src/muuli_wdr.cpp:2963
+#: src/muuli_wdr.cpp:2935
 msgid "Show received messages in the log"
 msgstr "記錄收到的訊息"
 
-#: src/muuli_wdr.cpp:2966
+#: src/muuli_wdr.cpp:2938
 msgid "Comments"
 msgstr "註解"
 
-#: src/muuli_wdr.cpp:2969
+#: src/muuli_wdr.cpp:2941
 msgid "Filter comments containing (use ',' as separator):"
 msgstr "過濾含以下內容的註解 (用逗號 ',' 隔開)："
 
-#: src/muuli_wdr.cpp:2994
+#: src/muuli_wdr.cpp:2966
 msgid "Enable Proxy"
 msgstr "啓用代理伺服器"
 
-#: src/muuli_wdr.cpp:2995
+#: src/muuli_wdr.cpp:2967
 msgid "Enable/disable proxy support"
 msgstr "啓用/停用代理伺服器支援"
 
-#: src/muuli_wdr.cpp:2998
+#: src/muuli_wdr.cpp:2970
 msgid "Proxy type:"
 msgstr "類型："
 
-#: src/muuli_wdr.cpp:3009
+#: src/muuli_wdr.cpp:2981
 msgid "Proxy host:"
 msgstr "主機："
 
-#: src/muuli_wdr.cpp:3012
+#: src/muuli_wdr.cpp:2984
 msgid "The proxy host name"
 msgstr "代理伺服器主機名稱"
 
-#: src/muuli_wdr.cpp:3014
+#: src/muuli_wdr.cpp:2986
 msgid "Proxy port:"
 msgstr "連接埠："
 
-#: src/muuli_wdr.cpp:3017
+#: src/muuli_wdr.cpp:2989
 msgid "The proxy port"
 msgstr "代理伺服器連接埠"
 
-#: src/muuli_wdr.cpp:3019
+#: src/muuli_wdr.cpp:2991
 msgid "Enable authentication"
 msgstr "啓用登入驗證"
 
-#: src/muuli_wdr.cpp:3020
+#: src/muuli_wdr.cpp:2992
 msgid "Enable/disable username/password authentication"
 msgstr "啓用/停用 使用者名稱/密碼登入驗證"
 
-#: src/muuli_wdr.cpp:3023
+#: src/muuli_wdr.cpp:2995
 msgid "Username: "
 msgstr "使用者名稱："
 
-#: src/muuli_wdr.cpp:3026
+#: src/muuli_wdr.cpp:2998
 msgid "The username to use to connect to the proxy"
 msgstr "登入代理伺服器的使用者名稱"
 
-#: src/muuli_wdr.cpp:3028
+#: src/muuli_wdr.cpp:3000
 msgid "Password:"
 msgstr "密碼："
 
-#: src/muuli_wdr.cpp:3031
+#: src/muuli_wdr.cpp:3003
 msgid "The password to use to connect to the proxy"
 msgstr "登入代理伺服器的密碼"
 
-#: src/muuli_wdr.cpp:3050
+#: src/muuli_wdr.cpp:3022
 msgid "Connect to:"
 msgstr "連線到："
 
-#: src/muuli_wdr.cpp:3059
+#: src/muuli_wdr.cpp:3031
 msgid "Login to remote amule"
 msgstr "登入遠端 amule"
 
-#: src/muuli_wdr.cpp:3064
+#: src/muuli_wdr.cpp:3036
 msgid "User name"
 msgstr "使用者名稱"
 
-#: src/muuli_wdr.cpp:3075
+#: src/muuli_wdr.cpp:3047
 msgid "Remember those settings"
 msgstr "記住這些設定"
 
-#: src/muuli_wdr.cpp:3078
+#: src/muuli_wdr.cpp:3050
 #, fuzzy
 msgid "Force ZLIB compression"
 msgstr "使用 gzip 壓縮"
 
-#: src/muuli_wdr.cpp:3102
+#: src/muuli_wdr.cpp:3074
 msgid "Enable Verbose Debug-Logging."
 msgstr "啓用記錄詳細除錯訊息。"
 
-#: src/muuli_wdr.cpp:3104
+#: src/muuli_wdr.cpp:3076
 #, fuzzy
 msgid "Only to Logfile"
 msgstr "開啟檔案(&O)"
 
-#: src/muuli_wdr.cpp:3106
+#: src/muuli_wdr.cpp:3078
 msgid "Message Categories:"
 msgstr "訊息分類："
 
-#: src/muuli_wdr.cpp:3130 src/PartFileConvertDlg.cpp:160
+#: src/muuli_wdr.cpp:3102 src/PartFileConvertDlg.cpp:160
 msgid "Waiting..."
 msgstr "等候中..."
 
-#: src/muuli_wdr.cpp:3150
+#: src/muuli_wdr.cpp:3122
 msgid "Add imports"
 msgstr "加入"
 
-#: src/muuli_wdr.cpp:3153
+#: src/muuli_wdr.cpp:3125
 msgid "Retry selected"
 msgstr "重試"
 
-#: src/muuli_wdr.cpp:3155
+#: src/muuli_wdr.cpp:3127
 msgid "Remove selected"
 msgstr "移除"
 
-#: src/muuli_wdr.cpp:3218
+#: src/muuli_wdr.cpp:3190
 msgid "Event Types"
 msgstr "事件種類"
 
-#: src/muuli_wdr.cpp:3237
+#: src/muuli_wdr.cpp:3209
 msgid "Statistics and queued clients for selected file(s) : Session / All time"
 msgstr "已選取的檔案的統計資料與等候區客戶端數：本次 / 總計"
 
-#: src/muuli_wdr.cpp:3261
+#: src/muuli_wdr.cpp:3233
 msgid "Active Uploads"
 msgstr "目前上傳數"
 
-#: src/muuli_wdr.cpp:3275
+#: src/muuli_wdr.cpp:3247
 msgid "Percent of total files"
 msgstr "% (所有檔案中)"
 
-#: src/muuli_wdr.cpp:3327
+#: src/muuli_wdr.cpp:3299
 msgid "Show Clients for"
 msgstr "顯示客戶端："
 
-#: src/muuli_wdr.cpp:3329
+#: src/muuli_wdr.cpp:3301
 msgid "All files"
 msgstr "所有檔案"
 
-#: src/muuli_wdr.cpp:3332
+#: src/muuli_wdr.cpp:3304
 msgid "Selected files"
 msgstr "選取的檔案"
 
-#: src/muuli_wdr.cpp:3335
+#: src/muuli_wdr.cpp:3307
 msgid "Active uploads only"
 msgstr "僅限目前上傳中"
 
-#: src/muuli_wdr.cpp:3342
+#: src/muuli_wdr.cpp:3314
 msgid "Reload:"
 msgstr "重新載入："
 
-#: src/muuli_wdr.cpp:3346
+#: src/muuli_wdr.cpp:3318
 msgid "Reload your shared files"
 msgstr "重新載入分享的檔案"
 
-#: src/muuli_wdr.cpp:3409
+#: src/muuli_wdr.cpp:3381
 msgid "Send"
 msgstr "傳送"
 
-#: src/muuli_wdr.cpp:3410
+#: src/muuli_wdr.cpp:3382
 msgid "Sends the specified message."
 msgstr "傳送訊息。"
 
-#: src/muuli_wdr.cpp:3414
+#: src/muuli_wdr.cpp:3386
 msgid "Close this chat-session."
 msgstr "結束本次交談。"
 
-#: src/muuli_wdr.cpp:3437
+#: src/muuli_wdr.cpp:3409
 msgid "Connect to any server and/or Kad"
 msgstr "連線到任何伺服器 和/或 Kad 網路"
 
-#: src/muuli_wdr.cpp:3443 src/SharedFilesCtrl.cpp:142 src/Statistics.cpp:941
+#: src/muuli_wdr.cpp:3415 src/SharedFilesCtrl.cpp:142 src/Statistics.cpp:941
 msgid "Shared Files"
 msgstr "分享檔案"
 
@@ -5452,249 +5418,249 @@ msgstr "已下載"
 msgid "ERROR: Failed to open partfile '%s'"
 msgstr "錯誤：無法開啟暫存檔 %s"
 
-#: src/Preferences.cpp:701
+#: src/Preferences.cpp:673
 msgid "System default"
 msgstr "系統預設"
 
-#: src/Preferences.cpp:702
+#: src/Preferences.cpp:674
 msgid "Albanian"
 msgstr "阿爾巴尼亞語"
 
-#: src/Preferences.cpp:703
+#: src/Preferences.cpp:675
 msgid "Arabic"
 msgstr "阿拉伯語"
 
-#: src/Preferences.cpp:704
+#: src/Preferences.cpp:676
 msgid "Asturian"
 msgstr "奧地利語"
 
-#: src/Preferences.cpp:705
+#: src/Preferences.cpp:677
 msgid "Basque"
 msgstr "巴斯克語"
 
-#: src/Preferences.cpp:706
+#: src/Preferences.cpp:678
 msgid "Bulgarian"
 msgstr "保加利亞語"
 
-#: src/Preferences.cpp:707
+#: src/Preferences.cpp:679
 msgid "Catalan"
 msgstr "加泰隆尼亞語"
 
-#: src/Preferences.cpp:708
+#: src/Preferences.cpp:680
 msgid "Chinese (Simplified)"
 msgstr "簡體中文"
 
-#: src/Preferences.cpp:709
+#: src/Preferences.cpp:681
 msgid "Chinese (Traditional)"
 msgstr "正體中文"
 
-#: src/Preferences.cpp:710
+#: src/Preferences.cpp:682
 msgid "Croatian"
 msgstr "克羅埃西亞語"
 
-#: src/Preferences.cpp:711
+#: src/Preferences.cpp:683
 msgid "Czech"
 msgstr "捷克語"
 
-#: src/Preferences.cpp:712
+#: src/Preferences.cpp:684
 msgid "Danish"
 msgstr "丹麥語"
 
-#: src/Preferences.cpp:713
+#: src/Preferences.cpp:685
 msgid "Dutch"
 msgstr "荷蘭語"
 
-#: src/Preferences.cpp:714
+#: src/Preferences.cpp:686
 msgid "English (U.K.)"
 msgstr "英語 (英國)"
 
-#: src/Preferences.cpp:715
+#: src/Preferences.cpp:687
 #, fuzzy
 msgid "English (U.S.)"
 msgstr "英語 (英國)"
 
-#: src/Preferences.cpp:716
+#: src/Preferences.cpp:688
 msgid "Estonian"
 msgstr "愛沙尼亞語"
 
-#: src/Preferences.cpp:717
+#: src/Preferences.cpp:689
 msgid "Finnish"
 msgstr "芬蘭語"
 
-#: src/Preferences.cpp:718
+#: src/Preferences.cpp:690
 msgid "French"
 msgstr "法語"
 
-#: src/Preferences.cpp:719
+#: src/Preferences.cpp:691
 msgid "Galician"
 msgstr "加利西亞語"
 
-#: src/Preferences.cpp:720
+#: src/Preferences.cpp:692
 msgid "German"
 msgstr "德語"
 
-#: src/Preferences.cpp:721
+#: src/Preferences.cpp:693
 msgid "Greek"
 msgstr "希臘語"
 
-#: src/Preferences.cpp:722
+#: src/Preferences.cpp:694
 msgid "Hebrew"
 msgstr "希伯來語"
 
-#: src/Preferences.cpp:723
+#: src/Preferences.cpp:695
 msgid "Hungarian"
 msgstr "匈牙利語"
 
-#: src/Preferences.cpp:724
+#: src/Preferences.cpp:696
 msgid "Italian"
 msgstr "義大利語"
 
-#: src/Preferences.cpp:725
+#: src/Preferences.cpp:697
 msgid "Japanese"
 msgstr "日語"
 
-#: src/Preferences.cpp:726
+#: src/Preferences.cpp:698
 msgid "Korean"
 msgstr "韓語"
 
-#: src/Preferences.cpp:727
+#: src/Preferences.cpp:699
 msgid "Latvian"
 msgstr ""
 
-#: src/Preferences.cpp:728
+#: src/Preferences.cpp:700
 msgid "Lithuanian"
 msgstr "立陶宛語"
 
-#: src/Preferences.cpp:729
+#: src/Preferences.cpp:701
 msgid "Norwegian (Nynorsk)"
 msgstr "新挪威語"
 
-#: src/Preferences.cpp:730
+#: src/Preferences.cpp:702
 msgid "Polish"
 msgstr "波蘭語"
 
-#: src/Preferences.cpp:731
+#: src/Preferences.cpp:703
 msgid "Portuguese"
 msgstr "葡萄牙語"
 
-#: src/Preferences.cpp:732
+#: src/Preferences.cpp:704
 msgid "Portuguese (Brazilian)"
 msgstr "葡萄牙語 (巴西)"
 
-#: src/Preferences.cpp:733
+#: src/Preferences.cpp:705
 msgid "Romanian"
 msgstr "羅馬尼亞語"
 
-#: src/Preferences.cpp:734
+#: src/Preferences.cpp:706
 msgid "Russian"
 msgstr "俄語"
 
-#: src/Preferences.cpp:735
+#: src/Preferences.cpp:707
 msgid "Slovenian"
 msgstr "斯洛維尼亞語"
 
-#: src/Preferences.cpp:736
+#: src/Preferences.cpp:708
 msgid "Spanish"
 msgstr "西班牙語"
 
-#: src/Preferences.cpp:737
+#: src/Preferences.cpp:709
 msgid "Swedish"
 msgstr "瑞典語"
 
-#: src/Preferences.cpp:738
+#: src/Preferences.cpp:710
 msgid "Turkish"
 msgstr "土耳其語"
 
-#: src/Preferences.cpp:739
+#: src/Preferences.cpp:711
 msgid "Ukrainian"
 msgstr "烏克蘭語"
 
-#: src/Preferences.cpp:842
+#: src/Preferences.cpp:814
 msgid "Change Language"
 msgstr "變更語言"
 
-#: src/Preferences.cpp:906
+#: src/Preferences.cpp:878
 msgid "There are no translations installed for aMule"
 msgstr "沒有已安裝的 aMule 翻譯"
 
-#: src/Preferences.cpp:907
+#: src/Preferences.cpp:879
 msgid "No languages available"
 msgstr "沒有可用的語言"
 
-#: src/Preferences.cpp:1038
+#: src/Preferences.cpp:1010
 msgid "no options available"
 msgstr "沒有選項"
 
-#: src/Preferences.cpp:2226
+#: src/Preferences.cpp:2179
 msgid "Invalid category found, skipping"
 msgstr "找到無效的分類，略過"
 
-#: src/Preferences.cpp:2395
+#: src/Preferences.cpp:2348
 msgid "TCP port can't be higher than 65532 due to server UDP socket being TCP+3"
 msgstr "TCP 埠不可大於 65532，因爲伺服器 UDP 連接端點值爲 TCP 埠值+3"
 
-#: src/Preferences.cpp:2396
+#: src/Preferences.cpp:2349
 #, c-format
 msgid "Default port will be used (%d)"
 msgstr "使用預設通訊埠 (%d)"
 
-#: src/PrefsUnifiedDlg.cpp:300 src/Statistics.cpp:866
+#: src/PrefsUnifiedDlg.cpp:298 src/Statistics.cpp:866
 msgid "Connection"
 msgstr "連線"
 
-#: src/PrefsUnifiedDlg.cpp:301 src/SearchListCtrl.cpp:117
+#: src/PrefsUnifiedDlg.cpp:299 src/SearchListCtrl.cpp:117
 msgid "Directories"
 msgstr "目錄"
 
-#: src/PrefsUnifiedDlg.cpp:302 src/Statistics.cpp:917
+#: src/PrefsUnifiedDlg.cpp:300 src/Statistics.cpp:917
 msgid "Servers"
 msgstr "伺服器"
 
-#: src/PrefsUnifiedDlg.cpp:303 src/ServerListCtrl.cpp:96
+#: src/PrefsUnifiedDlg.cpp:301 src/ServerListCtrl.cpp:96
 msgid "Files"
 msgstr "檔案"
 
-#: src/PrefsUnifiedDlg.cpp:304
+#: src/PrefsUnifiedDlg.cpp:302
 msgid "Security"
 msgstr "安全"
 
-#: src/PrefsUnifiedDlg.cpp:305
+#: src/PrefsUnifiedDlg.cpp:303
 msgid "Interface"
 msgstr "介面"
 
-#: src/PrefsUnifiedDlg.cpp:312
+#: src/PrefsUnifiedDlg.cpp:310
 msgid "IP2Country"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:315
+#: src/PrefsUnifiedDlg.cpp:313
 msgid "Proxy"
 msgstr "代理伺服器"
 
-#: src/PrefsUnifiedDlg.cpp:316
+#: src/PrefsUnifiedDlg.cpp:314
 msgid "Filters"
 msgstr "過濾"
 
-#: src/PrefsUnifiedDlg.cpp:317
+#: src/PrefsUnifiedDlg.cpp:315
 msgid "Remote Controls"
 msgstr "遠端控制"
 
-#: src/PrefsUnifiedDlg.cpp:318
+#: src/PrefsUnifiedDlg.cpp:316
 msgid "Online Signature"
 msgstr "線上簽名識別"
 
-#: src/PrefsUnifiedDlg.cpp:319
+#: src/PrefsUnifiedDlg.cpp:317
 msgid "Advanced"
 msgstr "進階"
 
-#: src/PrefsUnifiedDlg.cpp:320
+#: src/PrefsUnifiedDlg.cpp:318
 msgid "Events"
 msgstr "事件"
 
-#: src/PrefsUnifiedDlg.cpp:323
+#: src/PrefsUnifiedDlg.cpp:321
 msgid "Debugging"
 msgstr "除錯"
 
-#: src/PrefsUnifiedDlg.cpp:453
+#: src/PrefsUnifiedDlg.cpp:451
 msgid ""
 "The following variables will be substituted:\n"
 "    %PARTFILE - full path to the file\n"
@@ -5704,15 +5670,15 @@ msgstr ""
 "    %PARTFILE - 檔案的完整路徑\n"
 "    %PARTNAME - 只有檔案名稱"
 
-#: src/PrefsUnifiedDlg.cpp:474
+#: src/PrefsUnifiedDlg.cpp:472
 msgid "Tray icon support requires libayatana-appindicator3 at compile time."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:490
+#: src/PrefsUnifiedDlg.cpp:488
 msgid "Not available on Wayland: the protocol does not report when a window is minimized, so this option cannot intercept the system minimize button. Workaround: launch aMule with `GDK_BACKEND=x11` to use XWayland instead."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:536
+#: src/PrefsUnifiedDlg.cpp:534
 msgid ""
 "Do not change these setting unless you know\n"
 "what you are doing, otherwise you can easily\n"
@@ -5727,35 +5693,26 @@ msgstr ""
 "\n"
 "即使不變更這些設定，aMule 一樣可以正常運作。"
 
-#: src/PrefsUnifiedDlg.cpp:647
+#: src/PrefsUnifiedDlg.cpp:645
 #, c-format
 msgid "Failed to connect Cfg to widget with the ID %d and key %s"
 msgstr "無法以 ID %d、key %s 將 Cfg 與 widget 相連"
 
-#: src/PrefsUnifiedDlg.cpp:695
+#: src/PrefsUnifiedDlg.cpp:693
 #, c-format
 msgid "Failed to transfer data from Cfg to Widget with the ID %d and key %s"
 msgstr "無法以 ID %d、key %s 將資料 Cfg 與 widget 連線"
 
-#: src/PrefsUnifiedDlg.cpp:801
+#: src/PrefsUnifiedDlg.cpp:799
 msgid "The type of proxy you are connecting to"
 msgstr "正在連線的代理伺服器類型"
 
-#: src/PrefsUnifiedDlg.cpp:1020
+#: src/PrefsUnifiedDlg.cpp:1003
 #, c-format
 msgid "Failed to transfer data from Widget to Cfg with the ID %d and key %s"
 msgstr "無法以 ID %d、key %s 從 Cfg 傳輸資料到 Widget"
 
 #: src/PrefsUnifiedDlg.cpp:1103
-#, fuzzy
-msgid "No password set."
-msgstr "正在檢查密碼\n"
-
-#: src/PrefsUnifiedDlg.cpp:1132
-msgid "Guest access needs a password. Type one in the guest password field, or untick Enable guest access."
-msgstr ""
-
-#: src/PrefsUnifiedDlg.cpp:1144
 msgid ""
 "aMule must be restarted to enable these changes:\n"
 "\n"
@@ -5763,42 +5720,42 @@ msgstr ""
 "請重新啟動 aMule，變更的設定才能生效：\n"
 "\n"
 
-#: src/PrefsUnifiedDlg.cpp:1151
+#: src/PrefsUnifiedDlg.cpp:1110
 msgid "- TCP port changed.\n"
 msgstr "- TCP 埠已變更。\n"
 
-#: src/PrefsUnifiedDlg.cpp:1156
+#: src/PrefsUnifiedDlg.cpp:1115
 msgid "- UDP port changed.\n"
 msgstr "- UDP 埠已變更。\n"
 
-#: src/PrefsUnifiedDlg.cpp:1161
+#: src/PrefsUnifiedDlg.cpp:1120
 #, fuzzy
 msgid "- Network interface binding changed.\n"
 msgstr "- 已變更外部連線介面設定。\n"
 
-#: src/PrefsUnifiedDlg.cpp:1166
+#: src/PrefsUnifiedDlg.cpp:1125
 msgid "- External connect port changed.\n"
 msgstr "- 已變更外部連線埠設定。\n"
 
-#: src/PrefsUnifiedDlg.cpp:1170
+#: src/PrefsUnifiedDlg.cpp:1129
 msgid "- External connect acceptance changed.\n"
 msgstr "- 已變更外部連線設定。\n"
 
-#: src/PrefsUnifiedDlg.cpp:1174
+#: src/PrefsUnifiedDlg.cpp:1133
 msgid "- External connect interface changed.\n"
 msgstr "- 已變更外部連線介面設定。\n"
 
-#: src/PrefsUnifiedDlg.cpp:1178
+#: src/PrefsUnifiedDlg.cpp:1137
 #, fuzzy
 msgid "- Protocol obfuscation support changed.\n"
 msgstr "模糊協定"
 
-#: src/PrefsUnifiedDlg.cpp:1193
+#: src/PrefsUnifiedDlg.cpp:1151
 #, fuzzy
 msgid "- amuleapi settings changed.\n"
 msgstr "- 語言已變更。\n"
 
-#: src/PrefsUnifiedDlg.cpp:1202
+#: src/PrefsUnifiedDlg.cpp:1160
 msgid ""
 "Your Auto-update server list is empty.\n"
 "'Auto-update server list at startup' will be disabled."
@@ -5806,7 +5763,7 @@ msgstr ""
 "您的自動更新伺服器清單是空的。\n"
 "「啟動時自動更新伺服器清單」功能將被停用。"
 
-#: src/PrefsUnifiedDlg.cpp:1213
+#: src/PrefsUnifiedDlg.cpp:1171
 msgid ""
 "You have enabled external connections but have not specified a password.\n"
 "External connections cannot be enabled unless a valid password is specified."
@@ -5814,33 +5771,28 @@ msgstr ""
 "您已經設定啓用外部連線但還沒有輸入密碼，\n"
 "輸入有效密碼之後，外部連線才能開始使用。"
 
-#: src/PrefsUnifiedDlg.cpp:1246
-#, c-format
-msgid "The amuleapi password could not be saved: %s"
-msgstr ""
-
-#: src/PrefsUnifiedDlg.cpp:1276
+#: src/PrefsUnifiedDlg.cpp:1202
 msgid "- Language changed.\n"
 msgstr "- 語言已變更。\n"
 
-#: src/PrefsUnifiedDlg.cpp:1281
+#: src/PrefsUnifiedDlg.cpp:1207
 msgid "- Temp folder changed.\n"
 msgstr "- 暫存資料夾已變更。\n"
 
-#: src/PrefsUnifiedDlg.cpp:1286
+#: src/PrefsUnifiedDlg.cpp:1212
 msgid "- ED2K network enabled.\n"
 msgstr "- ED2K 網路已啟用。\n"
 
-#: src/PrefsUnifiedDlg.cpp:1319
+#: src/PrefsUnifiedDlg.cpp:1245
 msgid "The shared-file exclusion pattern is not a valid regular expression. The filter has been left disabled."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1321 src/PrefsUnifiedDlg.cpp:1921
+#: src/PrefsUnifiedDlg.cpp:1247 src/PrefsUnifiedDlg.cpp:1841
 #, fuzzy
 msgid "Invalid regular expression"
 msgstr "協定版本無效。"
 
-#: src/PrefsUnifiedDlg.cpp:1398
+#: src/PrefsUnifiedDlg.cpp:1324
 msgid ""
 "Both eD2k and Kad network are disabled.\n"
 "You won't be able to connect until you enable at least one of them."
@@ -5848,7 +5800,7 @@ msgstr ""
 "eD2k 與 Kad 網路都已停用。\n"
 "請至少啟用一種，否則您將無法連線。"
 
-#: src/PrefsUnifiedDlg.cpp:1403
+#: src/PrefsUnifiedDlg.cpp:1329
 msgid ""
 "Kad will not start if your UDP port is disabled.\n"
 "Enable UDP port or disable Kad."
@@ -5856,7 +5808,7 @@ msgstr ""
 "如果您停用 UDP 埠，Kad 將無法啓動。\n"
 "請啟用 UDP 埠或停用 Kad。"
 
-#: src/PrefsUnifiedDlg.cpp:1459
+#: src/PrefsUnifiedDlg.cpp:1385
 msgid ""
 "\n"
 "You MUST restart aMule now.\n"
@@ -5866,69 +5818,69 @@ msgstr ""
 "您必須立即重新啟動 aMule，\n"
 "如果現在不重啟動，可能會發生不可預期的問題。\n"
 
-#: src/PrefsUnifiedDlg.cpp:1524
+#: src/PrefsUnifiedDlg.cpp:1450
 msgid "Could not register aMule for autostart at login. The autostart store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1526
+#: src/PrefsUnifiedDlg.cpp:1452
 msgid "Could not remove the autostart-at-login entry."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1527
+#: src/PrefsUnifiedDlg.cpp:1453
 #, fuzzy
 msgid "Autostart"
 msgstr "已開始自動更新顯示"
 
-#: src/PrefsUnifiedDlg.cpp:1542
+#: src/PrefsUnifiedDlg.cpp:1468
 msgid "Register file type"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1542
+#: src/PrefsUnifiedDlg.cpp:1468
 msgid "Register URL handler"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1550
+#: src/PrefsUnifiedDlg.cpp:1476
 #, c-format
 msgid "aMule only handles eD2k-compatible magnets. If you replace the current magnet handler (%s), BitTorrent magnet links will stop working - aMule cannot download BitTorrent content. Continue?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1555
+#: src/PrefsUnifiedDlg.cpp:1481
 #, c-format
 msgid "Another application currently opens .emulecollection files (%s). Replace it with aMule?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1560
+#: src/PrefsUnifiedDlg.cpp:1486
 #, c-format
 msgid "Another application is currently the default handler for these links (%s). Replace it with aMule?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1585
+#: src/PrefsUnifiedDlg.cpp:1511
 msgid "Could not register aMule for .emulecollection files. The registration store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1587
+#: src/PrefsUnifiedDlg.cpp:1513
 #, fuzzy
 msgid "Could not remove the file type registration."
 msgstr "暫存資料夾"
 
-#: src/PrefsUnifiedDlg.cpp:1589
+#: src/PrefsUnifiedDlg.cpp:1515
 msgid "Could not register aMule as the URL handler. The registration store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1591
+#: src/PrefsUnifiedDlg.cpp:1517
 msgid "Could not remove the URL handler registration."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1661 src/PrefsUnifiedDlg.cpp:1688
+#: src/PrefsUnifiedDlg.cpp:1587 src/PrefsUnifiedDlg.cpp:1614
 #, fuzzy
 msgid "The web server and aMule API require external connections to be enabled."
 msgstr "密碼已設定，外部連線已啟用。"
 
-#: src/PrefsUnifiedDlg.cpp:1671
+#: src/PrefsUnifiedDlg.cpp:1597
 msgid "The aMule web server is deprecated. Consider running the aMule API instead."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1735
+#: src/PrefsUnifiedDlg.cpp:1655
 msgid ""
 "Your Auto-update servers list is in blank.\n"
 "Please fill in at least one URL to point to a valid server.met file.\n"
@@ -5938,65 +5890,65 @@ msgstr ""
 "請至少輸入一個能取得有效 server.met 檔案的網址。\n"
 "請點選旁邊的「清單」按鈕後輸入。"
 
-#: src/PrefsUnifiedDlg.cpp:1876
+#: src/PrefsUnifiedDlg.cpp:1796
 msgid "Temporary files"
 msgstr "暫存檔"
 
-#: src/PrefsUnifiedDlg.cpp:1881
+#: src/PrefsUnifiedDlg.cpp:1801
 msgid "Incoming files"
 msgstr "新進檔案"
 
-#: src/PrefsUnifiedDlg.cpp:1886
+#: src/PrefsUnifiedDlg.cpp:1806
 msgid "Online Signatures"
 msgstr "線上簽名識別"
 
-#: src/PrefsUnifiedDlg.cpp:1899
+#: src/PrefsUnifiedDlg.cpp:1819
 #, c-format
 msgid "Choose a folder for %s"
 msgstr "爲 %s 選擇資料夾"
 
-#: src/PrefsUnifiedDlg.cpp:1923
+#: src/PrefsUnifiedDlg.cpp:1843
 #, fuzzy, c-format
 msgid "Would exclude %u of %u shared file"
 msgid_plural "Would exclude %u of %u shared files"
 msgstr[0] "找到 %i 個已知的分享檔案"
 
-#: src/PrefsUnifiedDlg.cpp:1940
+#: src/PrefsUnifiedDlg.cpp:1860
 msgid "Browse for videoplayer"
 msgstr "瀏覽尋找影片播放器"
 
-#: src/PrefsUnifiedDlg.cpp:1944
+#: src/PrefsUnifiedDlg.cpp:1864
 msgid "Select browser"
 msgstr "設定瀏覽器"
 
-#: src/PrefsUnifiedDlg.cpp:1948
+#: src/PrefsUnifiedDlg.cpp:1868
 #, fuzzy
 msgid "Select ffprobe binary"
 msgstr "設定瀏覽器"
 
-#: src/PrefsUnifiedDlg.cpp:1954
+#: src/PrefsUnifiedDlg.cpp:1874
 #, c-format
 msgid "Executable%s"
 msgstr "可執行%s"
 
-#: src/PrefsUnifiedDlg.cpp:1988
+#: src/PrefsUnifiedDlg.cpp:1908
 msgid "ffprobe not found on PATH or in the standard install locations. Install ffmpeg (which ships ffprobe) or use Browse to pick a binary manually."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2000
+#: src/PrefsUnifiedDlg.cpp:1920
 msgid "Reset the settings on this page to their default values?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2001
+#: src/PrefsUnifiedDlg.cpp:1921
 #, fuzzy
 msgid "Reset to defaults"
 msgstr "系統預設"
 
-#: src/PrefsUnifiedDlg.cpp:2028
+#: src/PrefsUnifiedDlg.cpp:1948
 msgid "Edit server list"
 msgstr "編輯伺服器清單"
 
-#: src/PrefsUnifiedDlg.cpp:2029
+#: src/PrefsUnifiedDlg.cpp:1949
 msgid ""
 "Add here URL's to download server.met files.\n"
 "Only one url on each line."
@@ -6004,177 +5956,173 @@ msgstr ""
 "加入可下載 server.met 檔案的網址。\n"
 "每一行一個網址。"
 
-#: src/PrefsUnifiedDlg.cpp:2084
+#: src/PrefsUnifiedDlg.cpp:2004
 msgid "IP2Country update failed"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2229 src/PrefsUnifiedDlg.cpp:2260
+#: src/PrefsUnifiedDlg.cpp:2149 src/PrefsUnifiedDlg.cpp:2180
 msgid "Data by MaxMind GeoLite2"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2231 src/PrefsUnifiedDlg.cpp:2262
+#: src/PrefsUnifiedDlg.cpp:2151 src/PrefsUnifiedDlg.cpp:2182
 #, fuzzy
 msgid "Custom source"
 msgstr "完整來源"
 
-#: src/PrefsUnifiedDlg.cpp:2233 src/PrefsUnifiedDlg.cpp:2264
+#: src/PrefsUnifiedDlg.cpp:2153 src/PrefsUnifiedDlg.cpp:2184
 msgid "Data by DB-IP.com"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2284
+#: src/PrefsUnifiedDlg.cpp:2204
 #, fuzzy, c-format
 msgid "Status: Loaded%s"
 msgstr "狀態："
 
-#: src/PrefsUnifiedDlg.cpp:2286
+#: src/PrefsUnifiedDlg.cpp:2206
 #, fuzzy, c-format
 msgid "Status: Loaded%s - %s"
 msgstr "狀態："
 
-#: src/PrefsUnifiedDlg.cpp:2290
+#: src/PrefsUnifiedDlg.cpp:2210
 msgid "Status: Failed to load - click 'Update now' to refresh."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2292
+#: src/PrefsUnifiedDlg.cpp:2212
 msgid "Status: Not found - click 'Update now' to download."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2350 src/PrefsUnifiedDlg.cpp:2374
+#: src/PrefsUnifiedDlg.cpp:2270 src/PrefsUnifiedDlg.cpp:2294
 #, c-format
 msgid "Update delay: %d second"
 msgid_plural "Update delay: %d seconds"
 msgstr[0] "更新延遲時間：%d 秒"
 
-#: src/PrefsUnifiedDlg.cpp:2358
+#: src/PrefsUnifiedDlg.cpp:2278
 #, c-format
 msgid "Time for average graph: %d minute"
 msgid_plural "Time for average graph: %d minutes"
 msgstr[0] "平均值圖表顯示時間：%d 分鐘"
 
-#: src/PrefsUnifiedDlg.cpp:2367
+#: src/PrefsUnifiedDlg.cpp:2287
 #, c-format
 msgid "Connections Graph Scale: %d"
 msgstr "網路連線圖表比例：%d"
 
-#: src/PrefsUnifiedDlg.cpp:2382
+#: src/PrefsUnifiedDlg.cpp:2302
 #, c-format
 msgid "File Buffer Size: %d byte"
 msgid_plural "File Buffer Size: %d bytes"
 msgstr[0] "檔案緩衝區大小：%d B"
 
-#: src/PrefsUnifiedDlg.cpp:2392
+#: src/PrefsUnifiedDlg.cpp:2312
 #, c-format
 msgid "Upload Queue Size: %d client"
 msgid_plural "Upload Queue Size: %d clients"
 msgstr[0] "上傳等候區大小：%d "
 
-#: src/PrefsUnifiedDlg.cpp:2402
+#: src/PrefsUnifiedDlg.cpp:2322
 #, c-format
 msgid "Server connection refresh interval: %d minute"
 msgid_plural "Server connection refresh interval: %d minutes"
 msgstr[0] "伺服器連線更新間隔時間：%d 分鐘"
 
-#: src/PrefsUnifiedDlg.cpp:2407
+#: src/PrefsUnifiedDlg.cpp:2327
 msgid "Server connection refresh interval: Disabled"
 msgstr "伺服器連線更新間隔時間：已停用"
 
-#: src/PrefsUnifiedDlg.cpp:2451
+#: src/PrefsUnifiedDlg.cpp:2371
 msgid "disabled"
 msgstr "已停用"
 
-#: src/PrefsUnifiedDlg.cpp:2477
+#: src/PrefsUnifiedDlg.cpp:2397
 #, c-format
 msgid "Execute command on '%s' event"
 msgstr "發生 %s 事件時執行指令"
 
-#: src/PrefsUnifiedDlg.cpp:2484
+#: src/PrefsUnifiedDlg.cpp:2404
 msgid "Enable command execution on core"
 msgstr "啓用在主程式端執行指令"
 
-#: src/PrefsUnifiedDlg.cpp:2496
+#: src/PrefsUnifiedDlg.cpp:2416
 msgid "Core command:"
 msgstr "主程式端指令："
 
-#: src/PrefsUnifiedDlg.cpp:2512
+#: src/PrefsUnifiedDlg.cpp:2432
 msgid "Enable command execution on GUI"
 msgstr "啓用在圖形界面端執行指令"
 
-#: src/PrefsUnifiedDlg.cpp:2524
+#: src/PrefsUnifiedDlg.cpp:2444
 msgid "GUI command:"
 msgstr "圖形界面端指令："
 
-#: src/PrefsUnifiedDlg.cpp:2540
+#: src/PrefsUnifiedDlg.cpp:2460
 msgid "The following variables will be replaced:"
 msgstr ""
 "使用以下變數：\n"
 " "
 
-#: src/PrefsUnifiedDlg.cpp:2708
+#: src/PrefsUnifiedDlg.cpp:2628
 msgid ""
 "The following folders look like system or sensitive locations:\n"
 "\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2713
+#: src/PrefsUnifiedDlg.cpp:2633
 msgid "Sharing them recursively will publish every file underneath on the eD2k/Kad networks. Do you really want to do this?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2716
+#: src/PrefsUnifiedDlg.cpp:2636
 #, fuzzy
 msgid "Confirm shared folders"
 msgstr "分享資料夾"
 
-#: src/PrefsUnifiedDlg.cpp:2744
+#: src/PrefsUnifiedDlg.cpp:2664
 #, fuzzy
 msgid "Reloading shared files..."
 msgstr "重新載入分享的檔案"
 
-#: src/PrefsUnifiedDlg.cpp:2745
+#: src/PrefsUnifiedDlg.cpp:2665
 msgid "Scanning for subdirectories..."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2746
+#: src/PrefsUnifiedDlg.cpp:2666
 #, fuzzy
 msgid "Updating shared folders"
 msgstr "分享資料夾"
 
-#: src/PrefsUnifiedDlg.cpp:2773
+#: src/PrefsUnifiedDlg.cpp:2693
 #, c-format
 msgid "Scanned %u directories..."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2823
+#: src/PrefsUnifiedDlg.cpp:2743
 #, fuzzy, c-format
 msgid "Reloading shared files: %u files scanned"
 msgstr "重新載入分享檔案清單。"
 
-#: src/PrefsUnifiedDlg.cpp:2873
+#: src/PrefsUnifiedDlg.cpp:2793
 #, fuzzy
 msgid "Shared folder"
 msgstr "分享資料夾"
 
-#: src/SearchDlg.cpp:280
-msgid "Clear search history"
-msgstr ""
-
-#: src/SearchDlg.cpp:584
+#: src/SearchDlg.cpp:425
 msgid "It's impossible to search when both eD2k and Kademlia are disabled."
 msgstr ""
 
-#: src/SearchDlg.cpp:585 src/SearchListCtrl.cpp:858
+#: src/SearchDlg.cpp:426 src/SearchListCtrl.cpp:858
 #, fuzzy
 msgid "Search error"
 msgstr "搜尋"
 
-#: src/SearchDlg.cpp:929
+#: src/SearchDlg.cpp:768
 msgid "Min size must be smaller than max size. Max size ignored."
 msgstr "最小值必須小於最大值，最大值已被忽略。"
 
-#: src/SearchDlg.cpp:930 src/SearchDlg.cpp:1012
+#: src/SearchDlg.cpp:769 src/SearchDlg.cpp:851
 msgid "Search warning"
 msgstr "搜尋警告"
 
-#: src/SearchDlg.cpp:1092 src/SearchListCtrl.cpp:735
+#: src/SearchDlg.cpp:929 src/SearchListCtrl.cpp:735
 msgid "Main"
 msgstr "主要"
 

--- a/po/zh_TW.po
+++ b/po/zh_TW.po
@@ -14,7 +14,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-28 08:06+0200\n"
+"POT-Creation-Date: 2026-07-28 10:19+0200\n"
 "PO-Revision-Date: 2026-07-27 11:48+0000\n"
 "Last-Translator: Wayne Su <mstarmstar@gmail.com>\n"
 "Language-Team: \n"
@@ -150,7 +150,7 @@ msgstr ""
 msgid "Not now"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:422 src/amuleDlg.cpp:600
+#: src/AppImageIntegration.cpp:422 src/amuleDlg.cpp:665
 msgid "Don't ask again"
 msgstr ""
 
@@ -223,7 +223,7 @@ msgid "Killing amuleweb instance with pid '%d' ... "
 msgstr "正在強行終止 pid %d 的 amuleweb 執行緒... "
 
 #: src/amule.cpp:336 src/amule.cpp:349 src/ClientRef.cpp:180
-#: src/SearchDlg.cpp:880 src/ServerListCtrl.cpp:98
+#: src/SearchDlg.cpp:1041 src/ServerListCtrl.cpp:98
 msgid "Failed"
 msgstr "失敗"
 
@@ -579,30 +579,68 @@ msgstr "無法建立 pid 檔案"
 msgid "ERROR: %s"
 msgstr "錯誤：%s"
 
-#: src/amuleDlg.cpp:236
+#: src/amuleDlg.cpp:250
 #, c-format
 msgid "This is aMule %s based on eMule."
 msgstr "這是 aMule %s (源自 eMule)。"
 
-#: src/amuleDlg.cpp:237
+#: src/amuleDlg.cpp:251
 #, c-format
 msgid "Running on %s"
 msgstr "執行於 %s"
 
-#: src/amuleDlg.cpp:239
+#: src/amuleDlg.cpp:253
 msgid "Visit https://github.com/amule-org/amule/releases/latest to check if a new version is available."
 msgstr "請到 https://github.com/amule-org/amule/releases/latest 下載最新版本。"
 
-#: src/amuleDlg.cpp:268
+#: src/amuleDlg.cpp:282
 msgid "FATAL ERROR: Failed to create Timer"
 msgstr "嚴重錯誤：無法建立計時器"
 
-#: src/amuleDlg.cpp:592
+#: src/amuleDlg.cpp:361 src/amuleDlg.cpp:1787 src/amuleDlg.cpp:2033
+#: src/muuli_wdr.cpp:1492 src/muuli_wdr.cpp:3418
+msgid "Networks"
+msgstr "網路"
+
+#: src/amuleDlg.cpp:362 src/amuleDlg.cpp:1793 src/muuli_wdr.cpp:3419
+msgid "Searches"
+msgstr "搜尋"
+
+#: src/amuleDlg.cpp:363 src/amuleDlg.cpp:1799 src/DownloadListCtrl.cpp:740
+#: src/muuli_wdr.cpp:392 src/muuli_wdr.cpp:1585 src/muuli_wdr.cpp:3420
+#: src/Statistics.cpp:829
+msgid "Downloads"
+msgstr "下載"
+
+#: src/amuleDlg.cpp:364 src/amuleDlg.cpp:1805 src/muuli_wdr.cpp:3294
+msgid "Shared files"
+msgstr "檔案分享"
+
+#: src/amuleDlg.cpp:365 src/amuleDlg.cpp:1811 src/muuli_wdr.cpp:2926
+#: src/muuli_wdr.cpp:3376 src/muuli_wdr.cpp:3423
+msgid "Messages"
+msgstr "訊息"
+
+#: src/amuleDlg.cpp:366 src/amuleDlg.cpp:1817 src/muuli_wdr.cpp:3424
+#: src/PrefsUnifiedDlg.cpp:312 src/Statistics.cpp:779 src/Statistics.cpp:1235
+msgid "Statistics"
+msgstr "統計"
+
+#: src/amuleDlg.cpp:368 src/amuleDlg.cpp:1824 src/muuli_wdr.cpp:3426
+#: src/PrefsUnifiedDlg.cpp:328 src/utils/wxCas/src/wxcasprefs.cpp:39
+msgid "Preferences"
+msgstr "偏好設定"
+
+#: src/amuleDlg.cpp:371
+msgid "Navigate"
+msgstr ""
+
+#: src/amuleDlg.cpp:657
 #, fuzzy
 msgid "New version available"
 msgstr "不可用"
 
-#: src/amuleDlg.cpp:596
+#: src/amuleDlg.cpp:661
 #, fuzzy, c-format
 msgid ""
 "A new version of aMule (%s) is available.\n"
@@ -612,218 +650,185 @@ msgid ""
 "Would you like to open the download page?"
 msgstr "最新版本可從這裏下載：https://github.com/amule-org/amule/releases/latest"
 
-#: src/amuleDlg.cpp:678
+#: src/amuleDlg.cpp:743
 msgid "aMule dialog destroyed"
 msgstr "aMule 對話方塊已銷毀"
 
-#: src/amuleDlg.cpp:701 src/DataToText.cpp:68 src/IPFilter.cpp:547
+#: src/amuleDlg.cpp:766 src/DataToText.cpp:68 src/IPFilter.cpp:547
 msgid "Connecting"
 msgstr "正在連線"
 
-#: src/amuleDlg.cpp:893
+#: src/amuleDlg.cpp:958
 msgid "eD2k: Connecting"
 msgstr "eD2k：正在連線"
 
-#: src/amuleDlg.cpp:897
+#: src/amuleDlg.cpp:962
 msgid "eD2k: Disconnected"
 msgstr "eD2k：已中斷連線"
 
-#: src/amuleDlg.cpp:903
+#: src/amuleDlg.cpp:968
 msgid "Kad: Firewalled"
 msgstr "Kad：防火牆內"
 
-#: src/amuleDlg.cpp:907
+#: src/amuleDlg.cpp:972
 msgid "Kad: Connected"
 msgstr "Kad：已連線"
 
-#: src/amuleDlg.cpp:912
+#: src/amuleDlg.cpp:977
 msgid "Kad: Connecting"
 msgstr "Kad：正在連線"
 
-#: src/amuleDlg.cpp:916
+#: src/amuleDlg.cpp:981
 msgid "Kad: Off"
 msgstr "Kad：關閉"
 
-#: src/amuleDlg.cpp:964 src/DownloadListCtrl.cpp:505
+#: src/amuleDlg.cpp:1029 src/DownloadListCtrl.cpp:505
 #: src/DownloadListCtrl.cpp:749 src/FriendListCtrl.cpp:180
 #: src/muuli_wdr.cpp:731 src/muuli_wdr.cpp:782 src/muuli_wdr.cpp:846
-#: src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2224 src/muuli_wdr.cpp:2309
-#: src/muuli_wdr.cpp:3057 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
+#: src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2231 src/muuli_wdr.cpp:2316
+#: src/muuli_wdr.cpp:3064 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
 #: src/ServerListCtrl.cpp:606 src/TransferWnd.cpp:378
 #: src/utils/wxCas/src/wxcasprefs.cpp:235
 msgid "Cancel"
 msgstr "取消"
 
-#: src/amuleDlg.cpp:965
+#: src/amuleDlg.cpp:1030
 msgid "Stop the current connection attempts"
 msgstr "停止連線作業"
 
-#: src/amuleDlg.cpp:970 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976
-#: src/muuli_wdr.cpp:2447
+#: src/amuleDlg.cpp:1035 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976
+#: src/muuli_wdr.cpp:2454
 msgid "Disconnect"
 msgstr "中斷連線"
 
-#: src/amuleDlg.cpp:971
+#: src/amuleDlg.cpp:1036
 msgid "Disconnect from the currently connected networks"
 msgstr "中斷已連線的網路"
 
-#: src/amuleDlg.cpp:976 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979
-#: src/muuli_wdr.cpp:2602 src/muuli_wdr.cpp:3054 src/muuli_wdr.cpp:3409
+#: src/amuleDlg.cpp:1041 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979
+#: src/muuli_wdr.cpp:2609 src/muuli_wdr.cpp:3061 src/muuli_wdr.cpp:3416
 msgid "Connect"
 msgstr "連線"
 
-#: src/amuleDlg.cpp:977
+#: src/amuleDlg.cpp:1042
 msgid "Connect to the currently enabled networks"
 msgstr "連線到目前已啟用的網路"
 
-#: src/amuleDlg.cpp:1089
+#: src/amuleDlg.cpp:1154
 #, fuzzy, c-format
 msgid "Up: %.1f%s (%.1f) | Down: %.1f%s (%.1f)"
 msgstr "上傳：%.1f (%.1f) | 下載：%.1f (%.1f)"
 
-#: src/amuleDlg.cpp:1091 src/amuleDlg.cpp:1093 src/amuleDlg.cpp:1097
-#: src/amuleDlg.cpp:1099 src/amuleDlg.cpp:1110 src/amuleDlg.cpp:1112
+#: src/amuleDlg.cpp:1156 src/amuleDlg.cpp:1158 src/amuleDlg.cpp:1162
+#: src/amuleDlg.cpp:1164 src/amuleDlg.cpp:1175 src/amuleDlg.cpp:1177
 #: src/MuleTrayIcon.cpp:796 src/MuleTrayIcon.cpp:799
 #, fuzzy
 msgid " MB/s"
 msgstr "MB/s"
 
-#: src/amuleDlg.cpp:1091 src/amuleDlg.cpp:1093 src/amuleDlg.cpp:1097
-#: src/amuleDlg.cpp:1099 src/amuleDlg.cpp:1110 src/amuleDlg.cpp:1112
+#: src/amuleDlg.cpp:1156 src/amuleDlg.cpp:1158 src/amuleDlg.cpp:1162
+#: src/amuleDlg.cpp:1164 src/amuleDlg.cpp:1175 src/amuleDlg.cpp:1177
 #: src/MuleTrayIcon.cpp:796 src/MuleTrayIcon.cpp:799
 #: src/utils/wxCas/src/wxcasframe.cpp:1041
 msgid " kB/s"
 msgstr " KB/s"
 
-#: src/amuleDlg.cpp:1096
+#: src/amuleDlg.cpp:1161
 #, fuzzy, c-format
 msgid "Up: %.1f%s | Down: %.1f%s"
 msgstr "上傳：%.1f | 下載：%.1f"
 
-#: src/amuleDlg.cpp:1128
+#: src/amuleDlg.cpp:1193
 #, c-format
 msgid "aMule (%s | Connected)"
 msgstr "aMule (%s | 已連線)"
 
-#: src/amuleDlg.cpp:1130
+#: src/amuleDlg.cpp:1195
 #, c-format
 msgid "aMule (%s | Disconnected)"
 msgstr "aMule (%s | 已中斷連線)"
 
-#: src/amuleDlg.cpp:1183
+#: src/amuleDlg.cpp:1248
 #, c-format
 msgid "Do you really want to exit %s?"
 msgstr "您確定要離開 %s 嗎？"
 
-#: src/amuleDlg.cpp:1185
+#: src/amuleDlg.cpp:1250
 msgid "Exit confirmation"
 msgstr "確認離開"
 
-#: src/amuleDlg.cpp:1548
+#: src/amuleDlg.cpp:1613
 msgid "Launch Command: "
 msgstr "執行指令："
 
-#: src/amuleDlg.cpp:1567 src/muuli_wdr.cpp:1971 src/Preferences.cpp:951
+#: src/amuleDlg.cpp:1632 src/muuli_wdr.cpp:1978 src/Preferences.cpp:952
 msgid "- default -"
 msgstr "- 預設 -"
 
-#: src/amuleDlg.cpp:1595
+#: src/amuleDlg.cpp:1660
 #, c-format
 msgid "Skin directory '%s' does not exist"
 msgstr "面板目錄 %s 不存在"
 
-#: src/amuleDlg.cpp:1598
+#: src/amuleDlg.cpp:1663
 #, c-format
 msgid "WARNING: Unable to open skin file '%s' for read"
 msgstr "警告：無法開啟面板檔案 %s 供讀取"
 
-#: src/amuleDlg.cpp:1722 src/amuleDlg.cpp:1968 src/muuli_wdr.cpp:1485
-#: src/muuli_wdr.cpp:3411
-msgid "Networks"
-msgstr "網路"
-
-#: src/amuleDlg.cpp:1726 src/muuli_wdr.cpp:3411
+#: src/amuleDlg.cpp:1791 src/muuli_wdr.cpp:3418
 msgid "Networks Window"
 msgstr "網路 視窗"
 
-#: src/amuleDlg.cpp:1728 src/muuli_wdr.cpp:3412
-msgid "Searches"
-msgstr "搜尋"
-
-#: src/amuleDlg.cpp:1732 src/muuli_wdr.cpp:3412
+#: src/amuleDlg.cpp:1797 src/muuli_wdr.cpp:3419
 msgid "Searches Window"
 msgstr "搜尋 視窗"
 
-#: src/amuleDlg.cpp:1734 src/DownloadListCtrl.cpp:740 src/muuli_wdr.cpp:392
-#: src/muuli_wdr.cpp:1578 src/muuli_wdr.cpp:3413 src/Statistics.cpp:829
-msgid "Downloads"
-msgstr "下載"
-
-#: src/amuleDlg.cpp:1738 src/muuli_wdr.cpp:3413
+#: src/amuleDlg.cpp:1803 src/muuli_wdr.cpp:3420
 msgid "Downloads Window"
 msgstr "下載 視窗"
 
-#: src/amuleDlg.cpp:1740 src/muuli_wdr.cpp:3287
-msgid "Shared files"
-msgstr "檔案分享"
-
-#: src/amuleDlg.cpp:1744 src/muuli_wdr.cpp:3415
+#: src/amuleDlg.cpp:1809 src/muuli_wdr.cpp:3422
 msgid "Shared Files Window"
 msgstr "檔案分享 視窗"
 
-#: src/amuleDlg.cpp:1746 src/muuli_wdr.cpp:2919 src/muuli_wdr.cpp:3369
-#: src/muuli_wdr.cpp:3416
-msgid "Messages"
-msgstr "訊息"
-
-#: src/amuleDlg.cpp:1750 src/muuli_wdr.cpp:3416
+#: src/amuleDlg.cpp:1815 src/muuli_wdr.cpp:3423
 msgid "Messages Window"
 msgstr "訊息 視窗"
 
-#: src/amuleDlg.cpp:1752 src/muuli_wdr.cpp:3417 src/PrefsUnifiedDlg.cpp:312
-#: src/Statistics.cpp:779 src/Statistics.cpp:1235
-msgid "Statistics"
-msgstr "統計"
-
-#: src/amuleDlg.cpp:1756 src/muuli_wdr.cpp:3417
+#: src/amuleDlg.cpp:1821 src/muuli_wdr.cpp:3424
 msgid "Statistics Graph Window"
 msgstr "統計 視窗"
 
-#: src/amuleDlg.cpp:1759 src/muuli_wdr.cpp:3419 src/PrefsUnifiedDlg.cpp:328
-#: src/utils/wxCas/src/wxcasprefs.cpp:39
-msgid "Preferences"
-msgstr "偏好設定"
-
-#: src/amuleDlg.cpp:1763 src/muuli_wdr.cpp:3419
+#: src/amuleDlg.cpp:1828 src/muuli_wdr.cpp:3426
 msgid "Preferences Settings Window"
 msgstr "偏好設定 視窗"
 
-#: src/amuleDlg.cpp:1766 src/muuli_wdr.cpp:3420
+#: src/amuleDlg.cpp:1831 src/muuli_wdr.cpp:3427
 msgid "Import"
 msgstr "匯入"
 
-#: src/amuleDlg.cpp:1770 src/muuli_wdr.cpp:3420
+#: src/amuleDlg.cpp:1835 src/muuli_wdr.cpp:3427
 msgid "The partfile importer tool"
 msgstr "暫存檔匯入工具"
 
-#: src/amuleDlg.cpp:1773 src/muuli_wdr.cpp:3421
+#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3428
 #: src/utils/aLinkCreator/src/alcframe.cpp:262
 msgid "About"
 msgstr "關於"
 
-#: src/amuleDlg.cpp:1773 src/muuli_wdr.cpp:3421
+#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3428
 msgid "About/Help"
 msgstr "關於/幫助"
 
-#: src/amuleDlg.cpp:1971
+#: src/amuleDlg.cpp:2036
 msgid "eD2k network"
 msgstr "eD2k 網路"
 
-#: src/amuleDlg.cpp:1974
+#: src/amuleDlg.cpp:2039
 msgid "Kad network"
 msgstr "kad 網路"
 
-#: src/amuleDlg.cpp:1974
+#: src/amuleDlg.cpp:2039
 msgid "No network"
 msgstr "無網路"
 
@@ -1351,19 +1356,19 @@ msgstr "自動 [高]"
 msgid "Very low"
 msgstr "極低"
 
-#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:743 src/muuli_wdr.cpp:2275
+#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:743 src/muuli_wdr.cpp:2282
 #: src/ServerListCtrl.cpp:263 src/ServerListCtrl.cpp:456
 #: src/SharedFilesCtrl.cpp:145
 msgid "Low"
 msgstr "低"
 
-#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:744 src/muuli_wdr.cpp:2276
+#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:744 src/muuli_wdr.cpp:2283
 #: src/ServerListCtrl.cpp:266 src/ServerListCtrl.cpp:457
 #: src/SharedFilesCtrl.cpp:146
 msgid "Normal"
 msgstr "普通"
 
-#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:745 src/muuli_wdr.cpp:2277
+#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:745 src/muuli_wdr.cpp:2284
 #: src/ServerListCtrl.cpp:269 src/ServerListCtrl.cpp:458
 #: src/SharedFilesCtrl.cpp:147
 msgid "High"
@@ -1455,8 +1460,8 @@ msgstr "本地伺服器"
 msgid "Remote Server"
 msgstr "遠端伺服器"
 
-#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3174
-#: src/SearchDlg.cpp:111 src/TextClient.cpp:911
+#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3181
+#: src/SearchDlg.cpp:119 src/TextClient.cpp:911
 msgid "Kad"
 msgstr "Kad"
 
@@ -1527,7 +1532,7 @@ msgstr "部份"
 msgid "Size"
 msgstr "大小"
 
-#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3241
+#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3248
 msgid "Transferred"
 msgstr "已傳輸"
 
@@ -1585,7 +1590,7 @@ msgstr ""
 "%s (%s) 回覆訊息\n"
 "\n"
 
-#: src/DownloadListCtrl.cpp:746 src/muuli_wdr.cpp:2278
+#: src/DownloadListCtrl.cpp:746 src/muuli_wdr.cpp:2285
 #: src/SharedFilesCtrl.cpp:150
 msgid "Auto"
 msgstr "自動"
@@ -1623,7 +1628,7 @@ msgid "Extended Options"
 msgstr "擴充選項"
 
 #: src/DownloadListCtrl.cpp:770 src/DownloadListCtrl.cpp:822
-#: src/muuli_wdr.cpp:1789
+#: src/muuli_wdr.cpp:1796
 msgid "Preview"
 msgstr "預覽"
 
@@ -2332,19 +2337,19 @@ msgstr ""
 msgid "eD2k"
 msgstr "eD2k"
 
-#: src/FirstRunWizard.cpp:349 src/muuli_wdr.cpp:1488
+#: src/FirstRunWizard.cpp:349 src/muuli_wdr.cpp:1495
 msgid "Kademlia"
 msgstr "Kad"
 
-#: src/FirstRunWizard.cpp:359 src/muuli_wdr.cpp:1416
+#: src/FirstRunWizard.cpp:359 src/muuli_wdr.cpp:1423
 msgid "Standard TCP Port "
 msgstr "標準 TCP 埠"
 
-#: src/FirstRunWizard.cpp:365 src/muuli_wdr.cpp:1428
+#: src/FirstRunWizard.cpp:365 src/muuli_wdr.cpp:1435
 msgid "Extended UDP port (Kad / global search) "
 msgstr "擴充 UDP 埠 (Kad / 全球搜尋)"
 
-#: src/FirstRunWizard.cpp:377 src/muuli_wdr.cpp:1435
+#: src/FirstRunWizard.cpp:377 src/muuli_wdr.cpp:1442
 msgid "Enable UPnP for router port forwarding"
 msgstr "啟用 UPnP 的路由通訊埠轉向"
 
@@ -2371,7 +2376,7 @@ msgstr ""
 msgid "Your peer lists are already in place - nothing to download."
 msgstr "您已經在下載檔案 %s 了"
 
-#: src/FirstRunWizard.cpp:434 src/muuli_wdr.cpp:1533
+#: src/FirstRunWizard.cpp:434 src/muuli_wdr.cpp:1540
 msgid "Auto-update server list at startup"
 msgstr "啟動時自動更新伺服器清單"
 
@@ -2417,23 +2422,23 @@ msgid ""
 "want downloads on a different (e.g. larger) disk."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:549 src/FirstRunWizard.cpp:611 src/muuli_wdr.cpp:1701
+#: src/FirstRunWizard.cpp:549 src/FirstRunWizard.cpp:611 src/muuli_wdr.cpp:1708
 msgid "Destination folder for downloads"
 msgstr "下載資料夾"
 
-#: src/FirstRunWizard.cpp:553 src/FirstRunWizard.cpp:569 src/muuli_wdr.cpp:1342
-#: src/muuli_wdr.cpp:1359 src/muuli_wdr.cpp:1676 src/muuli_wdr.cpp:1707
-#: src/muuli_wdr.cpp:1719 src/muuli_wdr.cpp:2762
+#: src/FirstRunWizard.cpp:553 src/FirstRunWizard.cpp:569 src/muuli_wdr.cpp:1349
+#: src/muuli_wdr.cpp:1366 src/muuli_wdr.cpp:1683 src/muuli_wdr.cpp:1714
+#: src/muuli_wdr.cpp:1726 src/muuli_wdr.cpp:2769
 #: src/utils/aLinkCreator/src/alcframe.cpp:135
 #: src/utils/wxCas/src/wxcasprefs.cpp:52 src/utils/wxCas/src/wxcasprefs.cpp:118
 msgid "Browse"
 msgstr "瀏覽"
 
-#: src/FirstRunWizard.cpp:559 src/muuli_wdr.cpp:1712
+#: src/FirstRunWizard.cpp:559 src/muuli_wdr.cpp:1719
 msgid "(All files in this folder are shared with other peers)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:565 src/FirstRunWizard.cpp:624 src/muuli_wdr.cpp:1714
+#: src/FirstRunWizard.cpp:565 src/FirstRunWizard.cpp:624 src/muuli_wdr.cpp:1721
 msgid "Folder for temporary download files"
 msgstr "暫存資料夾"
 
@@ -2464,7 +2469,7 @@ msgstr "無法開啟好友清單檔案 emfriends.met 供寫入！"
 msgid "CRITICAL - no client on StartChatSession"
 msgstr "重大錯誤 - 開始交談時沒有客戶端"
 
-#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2668 src/muuli_wdr.cpp:3345
+#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2675 src/muuli_wdr.cpp:3352
 msgid "Friends"
 msgstr "好友"
 
@@ -2843,7 +2848,7 @@ msgstr "分享率"
 msgid "Uploaded"
 msgstr "已上傳"
 
-#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3225
+#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3232
 msgid "Requested"
 msgstr "已要求"
 
@@ -2967,7 +2972,7 @@ msgid "WARNING: "
 msgstr "警告："
 
 #: src/MuleNotebook.cpp:179 src/muuli_wdr.cpp:817 src/muuli_wdr.cpp:1229
-#: src/muuli_wdr.cpp:3129 src/muuli_wdr.cpp:3385
+#: src/muuli_wdr.cpp:3136 src/muuli_wdr.cpp:3392
 msgid "Close"
 msgstr "關閉"
 
@@ -2980,12 +2985,12 @@ msgstr "剪下"
 msgid "Copy"
 msgstr "複製"
 
-#: src/MuleTextCtrl.cpp:88
+#: src/MuleTextCtrl.cpp:88 src/SearchDlg.cpp:261
 msgid "Paste"
 msgstr "貼上"
 
 #: src/MuleTextCtrl.cpp:89 src/muuli_wdr.cpp:358 src/muuli_wdr.cpp:757
-#: src/muuli_wdr.cpp:2352 src/muuli_wdr.cpp:2371 src/muuli_wdr.cpp:2393
+#: src/muuli_wdr.cpp:2359 src/muuli_wdr.cpp:2378 src/muuli_wdr.cpp:2400
 #: src/utils/aLinkCreator/src/alcframe.cpp:142
 msgid "Clear"
 msgstr "清除"
@@ -3083,8 +3088,8 @@ msgid "Exit"
 msgstr "離開"
 
 #: src/MuleTrayIcon.cpp:579 src/MuleTrayIcon.cpp:945 src/MuleTrayIcon.cpp:965
-#: src/muuli_wdr.cpp:1391 src/muuli_wdr.cpp:1399 src/muuli_wdr.cpp:1406
-#: src/muuli_wdr.cpp:1835 src/muuli_wdr.cpp:1841 src/OtherFunctions.cpp:91
+#: src/muuli_wdr.cpp:1398 src/muuli_wdr.cpp:1406 src/muuli_wdr.cpp:1413
+#: src/muuli_wdr.cpp:1842 src/muuli_wdr.cpp:1848 src/OtherFunctions.cpp:91
 #: src/StatisticsDlg.cpp:93 src/StatisticsDlg.cpp:95
 msgid "kB/s"
 msgstr "KB/s"
@@ -3255,7 +3260,7 @@ msgstr "名稱："
 msgid "Type"
 msgstr "類型"
 
-#: src/muuli_wdr.cpp:215 src/SearchDlg.cpp:110 src/SearchListCtrl.cpp:853
+#: src/muuli_wdr.cpp:215 src/SearchDlg.cpp:118 src/SearchListCtrl.cpp:853
 msgid "Local"
 msgstr "本地"
 
@@ -3326,7 +3331,7 @@ msgstr "B"
 msgid "KB"
 msgstr "KB"
 
-#: src/muuli_wdr.cpp:274 src/muuli_wdr.cpp:293 src/muuli_wdr.cpp:1620
+#: src/muuli_wdr.cpp:274 src/muuli_wdr.cpp:293 src/muuli_wdr.cpp:1627
 #: src/OtherFunctions.cpp:64
 msgid "MB"
 msgstr "MB"
@@ -3343,7 +3348,7 @@ msgstr "大小上限"
 msgid "Availability"
 msgstr "最小來源數"
 
-#: src/muuli_wdr.cpp:312 src/muuli_wdr.cpp:398 src/muuli_wdr.cpp:3290
+#: src/muuli_wdr.cpp:312 src/muuli_wdr.cpp:398 src/muuli_wdr.cpp:3297
 msgid "Filter:"
 msgstr "過濾："
 
@@ -3375,7 +3380,7 @@ msgstr ""
 msgid "Stop"
 msgstr "停止"
 
-#: src/muuli_wdr.cpp:348 src/muuli_wdr.cpp:1385 src/SearchListCtrl.cpp:732
+#: src/muuli_wdr.cpp:348 src/muuli_wdr.cpp:1392 src/SearchListCtrl.cpp:732
 msgid "Download"
 msgstr "下載"
 
@@ -3406,8 +3411,8 @@ msgstr "檔案來源："
 #: src/muuli_wdr.cpp:1160 src/muuli_wdr.cpp:1167 src/muuli_wdr.cpp:1172
 #: src/muuli_wdr.cpp:1179 src/muuli_wdr.cpp:1184 src/muuli_wdr.cpp:1191
 #: src/muuli_wdr.cpp:1205 src/muuli_wdr.cpp:1212 src/muuli_wdr.cpp:1217
-#: src/muuli_wdr.cpp:1224 src/muuli_wdr.cpp:3227 src/muuli_wdr.cpp:3235
-#: src/muuli_wdr.cpp:3243
+#: src/muuli_wdr.cpp:1224 src/muuli_wdr.cpp:3234 src/muuli_wdr.cpp:3242
+#: src/muuli_wdr.cpp:3250
 msgid "N/A"
 msgstr "N/A"
 
@@ -3552,7 +3557,7 @@ msgstr ""
 msgid "Album :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:685 src/muuli_wdr.cpp:2247
+#: src/muuli_wdr.cpp:685 src/muuli_wdr.cpp:2254
 msgid "Title :"
 msgstr "標題："
 
@@ -3661,7 +3666,7 @@ msgstr "使用者名稱︰"
 msgid "Userhash :"
 msgstr "使用者 hash 值："
 
-#: src/muuli_wdr.cpp:895 src/muuli_wdr.cpp:1741 src/muuli_wdr.cpp:2442
+#: src/muuli_wdr.cpp:895 src/muuli_wdr.cpp:1748 src/muuli_wdr.cpp:2449
 #: src/utils/aLinkCreator/src/alcframe.cpp:137
 msgid "Add"
 msgstr "加入"
@@ -3670,15 +3675,15 @@ msgstr "加入"
 msgid "Download-Speed"
 msgstr "下載速度"
 
-#: src/muuli_wdr.cpp:954 src/muuli_wdr.cpp:989 src/muuli_wdr.cpp:2546
+#: src/muuli_wdr.cpp:954 src/muuli_wdr.cpp:989 src/muuli_wdr.cpp:2553
 msgid "Current"
 msgstr "目前"
 
-#: src/muuli_wdr.cpp:962 src/muuli_wdr.cpp:997 src/muuli_wdr.cpp:2554
+#: src/muuli_wdr.cpp:962 src/muuli_wdr.cpp:997 src/muuli_wdr.cpp:2561
 msgid "Running average"
 msgstr "執行中平均值"
 
-#: src/muuli_wdr.cpp:970 src/muuli_wdr.cpp:1005 src/muuli_wdr.cpp:2562
+#: src/muuli_wdr.cpp:970 src/muuli_wdr.cpp:1005 src/muuli_wdr.cpp:2569
 msgid "Session average"
 msgstr "本次平均值"
 
@@ -3690,7 +3695,7 @@ msgstr "上傳速度"
 msgid "Connections"
 msgstr "連線"
 
-#: src/muuli_wdr.cpp:1024 src/muuli_wdr.cpp:1860
+#: src/muuli_wdr.cpp:1024 src/muuli_wdr.cpp:1867
 msgid "Active downloads"
 msgstr "目前下載數"
 
@@ -3698,7 +3703,7 @@ msgstr "目前下載數"
 msgid "Active connections (1:1)"
 msgstr "目前連線數 (1:1)"
 
-#: src/muuli_wdr.cpp:1040 src/muuli_wdr.cpp:1861
+#: src/muuli_wdr.cpp:1040 src/muuli_wdr.cpp:1868
 msgid "Active uploads"
 msgstr "目前上傳數"
 
@@ -3814,8 +3819,8 @@ msgstr "這是其他使用者與您連線時能看到的名字。"
 msgid "Language: "
 msgstr "語言："
 
-#: src/muuli_wdr.cpp:1257 src/muuli_wdr.cpp:1323 src/muuli_wdr.cpp:1327
-#: src/muuli_wdr.cpp:1330
+#: src/muuli_wdr.cpp:1257 src/muuli_wdr.cpp:1330 src/muuli_wdr.cpp:1334
+#: src/muuli_wdr.cpp:1337
 msgid "The delay before showing tool-tips."
 msgstr "顯示提示的延遲時間。"
 
@@ -3893,936 +3898,945 @@ msgstr ""
 msgid "Enabling this will make aMule to show notifications when finished downloading."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1322
+#: src/muuli_wdr.cpp:1323
+#, fuzzy
+msgid "Remember search history"
+msgstr "記住這些設定"
+
+#: src/muuli_wdr.cpp:1324
+msgid "Keeps a dropdown list of your past search terms in the Search tab's Name field. This remembers the queries you typed, not the results they returned."
+msgstr ""
+
+#: src/muuli_wdr.cpp:1329
 msgid "Tooltip delay time: "
 msgstr "工具提示延遲："
 
-#: src/muuli_wdr.cpp:1329
+#: src/muuli_wdr.cpp:1336
 msgid "seconds"
 msgstr "秒"
 
-#: src/muuli_wdr.cpp:1333
+#: src/muuli_wdr.cpp:1340
 msgid "Browser Selection"
 msgstr "瀏覽器設定"
 
-#: src/muuli_wdr.cpp:1339
+#: src/muuli_wdr.cpp:1346
 msgid "Enter your browser name here. Leave this field empty to use the system default browser."
 msgstr "請輸入瀏覽器的名稱，空白則使用系統預設。"
 
-#: src/muuli_wdr.cpp:1346
+#: src/muuli_wdr.cpp:1353
 msgid "Open in new tab if possible"
 msgstr "在新分頁中開啟"
 
-#: src/muuli_wdr.cpp:1348
+#: src/muuli_wdr.cpp:1355
 msgid "Open the web page in a new tab instead of in a new window when possible"
 msgstr "如果可能，在新的分頁中打開而不是新的視窗"
 
-#: src/muuli_wdr.cpp:1352
+#: src/muuli_wdr.cpp:1359
 msgid "Video Player"
 msgstr "影片播放器"
 
-#: src/muuli_wdr.cpp:1379
+#: src/muuli_wdr.cpp:1386
 msgid "Bandwidth limits"
 msgstr "頻寬限制"
 
-#: src/muuli_wdr.cpp:1393
+#: src/muuli_wdr.cpp:1400
 msgid "Upload"
 msgstr "上傳"
 
-#: src/muuli_wdr.cpp:1401
+#: src/muuli_wdr.cpp:1408
 msgid "Slot Allocation"
 msgstr "位置分配"
 
-#: src/muuli_wdr.cpp:1410
+#: src/muuli_wdr.cpp:1417
 msgid "Ports"
 msgstr "通訊埠"
 
-#: src/muuli_wdr.cpp:1420
+#: src/muuli_wdr.cpp:1427
 msgid "This is the standard eD2k port and cannot be disabled."
 msgstr "標準 eD2k 通訊埠，不可停用。"
 
-#: src/muuli_wdr.cpp:1423
+#: src/muuli_wdr.cpp:1430
 msgid "UDP port for server requests (TCP+3):"
 msgstr "伺服器要求 UDP 埠 (TCP+3)："
 
-#: src/muuli_wdr.cpp:1425
+#: src/muuli_wdr.cpp:1432
 msgid "4665"
 msgstr "4665"
 
-#: src/muuli_wdr.cpp:1432
+#: src/muuli_wdr.cpp:1439
 msgid "This UDP port is used for extended eD2k requests and Kad network"
 msgstr "這個 UDP 埠用於 eD2k 擴充要求與 Kad 網路"
 
-#: src/muuli_wdr.cpp:1439
+#: src/muuli_wdr.cpp:1446
 msgid "UPnP TCP Port (Optional):"
 msgstr "UPnP TCP 埠 (選用)："
 
-#: src/muuli_wdr.cpp:1449
+#: src/muuli_wdr.cpp:1456
 msgid "Bind local address to IP (empty for any):"
 msgstr "選定本機使用 IP (留白或輸入)："
 
-#: src/muuli_wdr.cpp:1452
+#: src/muuli_wdr.cpp:1459
 msgid "Advanced users only: If you have multiple network interfaces, enter the address of the interface to which aMule should be bound."
 msgstr "進階使用者用：如果您有多網路介面，請輸入要給 aMule 使用的的網路位址。"
 
-#: src/muuli_wdr.cpp:1455 src/muuli_wdr.cpp:2054
+#: src/muuli_wdr.cpp:1462 src/muuli_wdr.cpp:2061
 #, fuzzy
 msgid "Bind to network interface (empty for any):"
 msgstr "選定本機使用 IP (留白或輸入)："
 
-#: src/muuli_wdr.cpp:1468
+#: src/muuli_wdr.cpp:1475
 msgid "Advanced users only: pin all of aMule's traffic to one network interface, chosen from the list or typed in by name (e.g. tun0, eth0, en0) or index. Unlike binding to an IP, this stops traffic leaking out via the default route - useful with a VPN. Requires no elevated privileges."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1474
+#: src/muuli_wdr.cpp:1481
 msgid "Max sources per downloading file:"
 msgstr "每個檔案最大來源數："
 
-#: src/muuli_wdr.cpp:1478
+#: src/muuli_wdr.cpp:1485
 msgid "Max simultaneous connections:"
 msgstr "最大同時連線數："
 
-#: src/muuli_wdr.cpp:1491 src/muuli_wdr.cpp:3169
+#: src/muuli_wdr.cpp:1498 src/muuli_wdr.cpp:3176
 msgid "ED2K"
 msgstr "ED2K"
 
-#: src/muuli_wdr.cpp:1498
+#: src/muuli_wdr.cpp:1505
 msgid "Autoconnect on startup"
 msgstr "啟動後自動連線"
 
-#: src/muuli_wdr.cpp:1501
+#: src/muuli_wdr.cpp:1508
 msgid "Reconnect on loss"
 msgstr "斷線後自動重新連線"
 
-#: src/muuli_wdr.cpp:1523
+#: src/muuli_wdr.cpp:1530
 msgid "Remove dead server after"
 msgstr "移除無法連線伺服器：如果"
 
-#: src/muuli_wdr.cpp:1524
+#: src/muuli_wdr.cpp:1531
 msgid "Static servers are never removed, even when unreachable."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1528
+#: src/muuli_wdr.cpp:1535
 msgid "retries"
 msgstr "次重試"
 
-#: src/muuli_wdr.cpp:1536
+#: src/muuli_wdr.cpp:1543
 msgid "List"
 msgstr "清單"
 
-#: src/muuli_wdr.cpp:1539
+#: src/muuli_wdr.cpp:1546
 msgid "Update server list when connecting to a server"
 msgstr "連線到伺服器時更新伺服器清單"
 
-#: src/muuli_wdr.cpp:1542
+#: src/muuli_wdr.cpp:1549
 msgid "Update server list when a client connects"
 msgstr "連線到客戶端時更新伺服器清單"
 
-#: src/muuli_wdr.cpp:1545
+#: src/muuli_wdr.cpp:1552
 msgid "Use priority system"
 msgstr "啟用優先等級系統"
 
-#: src/muuli_wdr.cpp:1549
+#: src/muuli_wdr.cpp:1556
 msgid "Use smart LowID check on connect"
 msgstr "連線時啟用智慧 LowID 偵測"
 
-#: src/muuli_wdr.cpp:1553
+#: src/muuli_wdr.cpp:1560
 msgid "Safe connect"
 msgstr "安全連線"
 
-#: src/muuli_wdr.cpp:1557
+#: src/muuli_wdr.cpp:1564
 msgid "Autoconnect to servers in static list only"
 msgstr "只自動連線到靜態伺服器清單裏的伺服器"
 
-#: src/muuli_wdr.cpp:1560
+#: src/muuli_wdr.cpp:1567
 msgid "Set manually added servers to High Priority"
 msgstr "手動輸入的伺服器設為高優先等級"
 
-#: src/muuli_wdr.cpp:1581
+#: src/muuli_wdr.cpp:1588
 msgid "Add files to download in pause mode"
 msgstr "加入新下載檔案時設為暫停狀態"
 
-#: src/muuli_wdr.cpp:1583
+#: src/muuli_wdr.cpp:1590
 msgid "Add files to download with auto priority"
 msgstr "加入新下載檔案時設定優先等級為自動狀態"
 
-#: src/muuli_wdr.cpp:1586
+#: src/muuli_wdr.cpp:1593
 msgid "Try to download first and last chunks first"
 msgstr "嘗試先下載檔案的第一段和最後一段"
 
-#: src/muuli_wdr.cpp:1590
+#: src/muuli_wdr.cpp:1597
 msgid "Endgame mode: rotate to faster sources for the final blocks"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1593
+#: src/muuli_wdr.cpp:1600
 msgid "Start next paused file when a file completes"
 msgstr "完成後自動傳輸下一個暫停的檔案"
 
-#: src/muuli_wdr.cpp:1596
+#: src/muuli_wdr.cpp:1603
 msgid "From the same category"
 msgstr "同一分類檔案"
 
-#: src/muuli_wdr.cpp:1598
+#: src/muuli_wdr.cpp:1605
 msgid "In alphabetic order"
 msgstr "依字母順序"
 
-#: src/muuli_wdr.cpp:1600
+#: src/muuli_wdr.cpp:1607
 msgid "Preallocate disk space for new files"
 msgstr "新檔案預先分配磁碟空間"
 
-#: src/muuli_wdr.cpp:1601
+#: src/muuli_wdr.cpp:1608
 msgid "For new files preallocates disk space for the whole file, thus reduces fragmentation"
 msgstr "新檔案預先分配所需的完整磁碟空間，這樣可以減少檔案分散度"
 
-#: src/muuli_wdr.cpp:1606
+#: src/muuli_wdr.cpp:1613
 msgid "Create new files as sparse files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1607
+#: src/muuli_wdr.cpp:1614
 msgid "A sparse file reserves its full size on disk immediately without writing real data to it -- fast, but unsupported or slow on some filesystems, and free-space accounting stays optimistic while the download is in progress. Turn this off to grow the file only as data arrives."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1612
+#: src/muuli_wdr.cpp:1619
 msgid "Stop downloads when free disk space reaches "
 msgstr "磁碟可用空間不足時停止下載"
 
-#: src/muuli_wdr.cpp:1613
+#: src/muuli_wdr.cpp:1620
 msgid "Select this if you want aMule to check your disk space"
 msgstr "讓 aMule 檢查磁碟可用空間"
 
-#: src/muuli_wdr.cpp:1617
+#: src/muuli_wdr.cpp:1624
 msgid "Enter here the min disk space desired."
 msgstr "請輸入最小磁碟可用空間。"
 
-#: src/muuli_wdr.cpp:1623
+#: src/muuli_wdr.cpp:1630
 msgid "Save 10 sources on rare files (< 20 sources)"
 msgstr "為來源稀少 (< 20) 的檔案儲存 10 個來源"
 
-#: src/muuli_wdr.cpp:1627 src/Statistics.cpp:790
+#: src/muuli_wdr.cpp:1634 src/Statistics.cpp:790
 msgid "Uploads"
 msgstr "上傳"
 
-#: src/muuli_wdr.cpp:1630
+#: src/muuli_wdr.cpp:1637
 msgid "Add new shared files with auto priority"
 msgstr "新加入分享檔案優先等級設定為自動"
 
-#: src/muuli_wdr.cpp:1636
+#: src/muuli_wdr.cpp:1643
 msgid "Intelligent Corruption Handling (I.C.H.)"
 msgstr "智慧型損壞處理 (I.C.H.)"
 
-#: src/muuli_wdr.cpp:1639
+#: src/muuli_wdr.cpp:1646
 msgid "Enable"
 msgstr "啟用"
 
-#: src/muuli_wdr.cpp:1642
+#: src/muuli_wdr.cpp:1649
 msgid "Advanced I.C.H. trusts every hash (not recommended)"
 msgstr "進階 I.C.H. 信任所有 hash 值 (不建議)"
 
-#: src/muuli_wdr.cpp:1654 src/PrefsUnifiedDlg.cpp:1910
+#: src/muuli_wdr.cpp:1661 src/PrefsUnifiedDlg.cpp:1910
 msgid "Media metadata extraction"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1658
+#: src/muuli_wdr.cpp:1665
 msgid "Extract length / bitrate / codec from shared audio and video files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1660
+#: src/muuli_wdr.cpp:1667
 msgid "When enabled, aMule runs ffprobe on each shared media file to fill in the Length / Bitrate / Codec columns other clients see when they find the file in a search. Requires ffmpeg (the ffprobe binary) to be installed."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1667
+#: src/muuli_wdr.cpp:1674
 msgid "Path to ffprobe:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1672
+#: src/muuli_wdr.cpp:1679
 msgid "Full path to the ffprobe binary. Leave empty to have aMule auto-detect it on startup."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1680
+#: src/muuli_wdr.cpp:1687
 msgid "Detect"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1681
+#: src/muuli_wdr.cpp:1688
 msgid "Search the standard install locations for an ffprobe binary and fill the path field."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1705
+#: src/muuli_wdr.cpp:1712
 msgid ""
 "Completed downloads are stored here. All files in this folder are automatically shared with other peers.\n"
 "If this folder also holds files you don't want to share, point it at an aMule-only sub-folder."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1708
+#: src/muuli_wdr.cpp:1715
 msgid "Pick the folder where completed downloads will be stored. All files in that folder will be shared with other peers."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1722
+#: src/muuli_wdr.cpp:1729
 msgid "Shared folders"
 msgstr "分享資料夾"
 
-#: src/muuli_wdr.cpp:1728
+#: src/muuli_wdr.cpp:1735
 msgid "(Folders shared by the core. Enter a path to add one.)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1736
+#: src/muuli_wdr.cpp:1743
 msgid "Absolute path of a folder on the core's machine, e.g. /home/user/shared"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1738 src/PrefsUnifiedDlg.cpp:2794
+#: src/muuli_wdr.cpp:1745 src/PrefsUnifiedDlg.cpp:2794
 msgid "Recursive"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1739
+#: src/muuli_wdr.cpp:1746
 msgid "Share every sub-folder underneath this one, including ones created later."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1743 src/utils/aLinkCreator/src/alcframe.cpp:141
+#: src/muuli_wdr.cpp:1750 src/utils/aLinkCreator/src/alcframe.cpp:141
 msgid "Remove"
 msgstr "移除"
 
-#: src/muuli_wdr.cpp:1747
+#: src/muuli_wdr.cpp:1754
 msgid "(Right click on folder icon for recursive share)"
 msgstr "(滑鼠右鍵點選檔案夾圖示可全部遞迴分享)"
 
-#: src/muuli_wdr.cpp:1754
+#: src/muuli_wdr.cpp:1761
 msgid "Share hidden files"
 msgstr "分享隱藏檔"
 
-#: src/muuli_wdr.cpp:1760
+#: src/muuli_wdr.cpp:1767
 msgid "Automatically rescan shared folders for changes"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1766
+#: src/muuli_wdr.cpp:1773
 msgid "Follow symbolic links in shared folders"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1772
+#: src/muuli_wdr.cpp:1779
 msgid "Exclude files matching:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1775
+#: src/muuli_wdr.cpp:1782
 msgid "Wildcard patterns separated by '|', e.g. .DS_Store|Thumbs.db|*.tmp. Files whose name matches are not shared. Matching is case-insensitive."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1779
+#: src/muuli_wdr.cpp:1786
 msgid "Patterns are regular expressions"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1780
+#: src/muuli_wdr.cpp:1787
 msgid "When set, the whole field is one regular expression ('|' is alternation). When unset, it is a list of '|'-separated wildcards."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1790
+#: src/muuli_wdr.cpp:1797
 msgid "Show how many shared files the current pattern would exclude."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1811
+#: src/muuli_wdr.cpp:1818
 msgid "Graphs"
 msgstr "圖表"
 
-#: src/muuli_wdr.cpp:1814 src/muuli_wdr.cpp:1876
+#: src/muuli_wdr.cpp:1821 src/muuli_wdr.cpp:1883
 msgid "Update delay : 5 secs"
 msgstr "更新延遲時間：5 秒"
 
-#: src/muuli_wdr.cpp:1818
+#: src/muuli_wdr.cpp:1825
 msgid "Time for average graph: 100 mins"
 msgstr "平均圖表顯示時間：100 分鐘"
 
-#: src/muuli_wdr.cpp:1822
+#: src/muuli_wdr.cpp:1829
 msgid "Connections Graph Scale: 100 "
 msgstr "連線圖表比例：100 "
 
-#: src/muuli_wdr.cpp:1829
+#: src/muuli_wdr.cpp:1836
 msgid "Download graph scale:"
 msgstr "下載統計圖比例："
 
-#: src/muuli_wdr.cpp:1837
+#: src/muuli_wdr.cpp:1844
 msgid "Upload graph scale:"
 msgstr "上傳統計圖比例："
 
-#: src/muuli_wdr.cpp:1847
+#: src/muuli_wdr.cpp:1854
 #, fuzzy
 msgid "Colors: "
 msgstr "顏色："
 
-#: src/muuli_wdr.cpp:1851
+#: src/muuli_wdr.cpp:1858
 msgid "Background"
 msgstr "背景"
 
-#: src/muuli_wdr.cpp:1852
+#: src/muuli_wdr.cpp:1859
 msgid "Grid"
 msgstr "格線"
 
-#: src/muuli_wdr.cpp:1853
+#: src/muuli_wdr.cpp:1860
 msgid "Download current"
 msgstr "目前下載"
 
-#: src/muuli_wdr.cpp:1854
+#: src/muuli_wdr.cpp:1861
 msgid "Download running average"
 msgstr "執行中平均下載"
 
-#: src/muuli_wdr.cpp:1855
+#: src/muuli_wdr.cpp:1862
 msgid "Download session average"
 msgstr "本次平均下載"
 
-#: src/muuli_wdr.cpp:1856
+#: src/muuli_wdr.cpp:1863
 msgid "Upload current"
 msgstr "目前上傳"
 
-#: src/muuli_wdr.cpp:1857
+#: src/muuli_wdr.cpp:1864
 msgid "Upload running average"
 msgstr "執行中平均上傳"
 
-#: src/muuli_wdr.cpp:1858
+#: src/muuli_wdr.cpp:1865
 msgid "Upload session average"
 msgstr "本次平均上傳"
 
-#: src/muuli_wdr.cpp:1859
+#: src/muuli_wdr.cpp:1866
 msgid "Active connections"
 msgstr "目前連線數"
 
-#: src/muuli_wdr.cpp:1862
+#: src/muuli_wdr.cpp:1869
 #, fuzzy
 msgid "Systray Icon Speed Bar"
 msgstr "狀態列圖示顯示速度"
 
-#: src/muuli_wdr.cpp:1863
+#: src/muuli_wdr.cpp:1870
 msgid "Kad-nodes current"
 msgstr "目前 Kad 節點"
 
-#: src/muuli_wdr.cpp:1864
+#: src/muuli_wdr.cpp:1871
 msgid "Kad-nodes running"
 msgstr "執行中 Kad 節點"
 
-#: src/muuli_wdr.cpp:1865
+#: src/muuli_wdr.cpp:1872
 msgid "Kad-nodes session"
 msgstr "本次 Kad 節點"
 
-#: src/muuli_wdr.cpp:1869 src/muuli_wdr.cpp:2296
+#: src/muuli_wdr.cpp:1876 src/muuli_wdr.cpp:2303
 msgid "Select"
 msgstr "選取"
 
-#: src/muuli_wdr.cpp:1873
+#: src/muuli_wdr.cpp:1880
 msgid "Tree"
 msgstr "樹狀"
 
-#: src/muuli_wdr.cpp:1883
+#: src/muuli_wdr.cpp:1890
 msgid "Number of Client Versions shown (0=unlimited)"
 msgstr "顯示客戶端版本的數量 ( 0 代表不限制)"
 
-#: src/muuli_wdr.cpp:1908
+#: src/muuli_wdr.cpp:1915
 msgid "!!! WARNING !!!"
 msgstr "!!! 警告 !!!"
 
-#: src/muuli_wdr.cpp:1923
+#: src/muuli_wdr.cpp:1930
 msgid "Max new connections / 5 secs"
 msgstr "5 秒內最大新連線數"
 
-#: src/muuli_wdr.cpp:1925
+#: src/muuli_wdr.cpp:1932
 msgid "Concurrent Kad source lookups"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1927
+#: src/muuli_wdr.cpp:1934
 #, fuzzy
 msgid "Kad source re-search interval (minutes)"
 msgstr "FTP 上傳間隔 (分鐘)"
 
-#: src/muuli_wdr.cpp:1929
+#: src/muuli_wdr.cpp:1936
 #, fuzzy
 msgid "Source re-ask interval (minutes)"
 msgstr "FTP 上傳間隔 (分鐘)"
 
-#: src/muuli_wdr.cpp:1933
+#: src/muuli_wdr.cpp:1940
 msgid "File Buffer Size: 240000 bytes"
 msgstr "檔案緩衝區：240.000 KB"
 
-#: src/muuli_wdr.cpp:1937
+#: src/muuli_wdr.cpp:1944
 msgid "Use MMAP: memory-mapped file access (lower memory use)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1938
+#: src/muuli_wdr.cpp:1945
 msgid "Maps part files into memory instead of buffering them on the heap, lowering the process memory footprint. May reduce download speed on some disks; best for memory-constrained or upload-heavy hosts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1940
+#: src/muuli_wdr.cpp:1947
 msgid "Upload Queue Size: 5000 clients"
 msgstr "上傳等候區大小：5000 "
 
-#: src/muuli_wdr.cpp:1944
+#: src/muuli_wdr.cpp:1951
 msgid "Server connection refresh interval: Disable"
 msgstr "伺服器連線更新間隔時間：停用"
 
-#: src/muuli_wdr.cpp:1948
+#: src/muuli_wdr.cpp:1955
 msgid "Disable computer's timed standby mode"
 msgstr "停用電腦的自動進入待命模式功能"
 
-#: src/muuli_wdr.cpp:1967
+#: src/muuli_wdr.cpp:1974
 msgid "Skin to use: "
 msgstr "使用面板："
 
-#: src/muuli_wdr.cpp:1976
+#: src/muuli_wdr.cpp:1983
 msgid "Show \"Fast eD2k Links Handler\" in every window."
 msgstr "在每個視窗顯示「eD2k 連結快速處理器」。"
 
-#: src/muuli_wdr.cpp:1979
+#: src/muuli_wdr.cpp:1986
 msgid "Show extended info on categories tabs"
 msgstr "在分類頁中顯示擴充資訊"
 
-#: src/muuli_wdr.cpp:1982
+#: src/muuli_wdr.cpp:1989
 msgid "Show application version on title"
 msgstr "在標題顯示應用程式版本"
 
-#: src/muuli_wdr.cpp:1984
+#: src/muuli_wdr.cpp:1991
 msgid "Show transfer rates on title"
 msgstr "標題列顯示傳輸速度"
 
-#: src/muuli_wdr.cpp:1986
+#: src/muuli_wdr.cpp:1993
 msgid "Before application name"
 msgstr "在程式名稱前"
 
-#: src/muuli_wdr.cpp:1988
+#: src/muuli_wdr.cpp:1995
 msgid "After application name"
 msgstr "在程式名稱後"
 
-#: src/muuli_wdr.cpp:1991
+#: src/muuli_wdr.cpp:1998
 msgid "Show overhead bandwidth"
 msgstr "顯示額外支出頻寬"
 
-#: src/muuli_wdr.cpp:1995
+#: src/muuli_wdr.cpp:2002
 msgid "Vertical toolbar orientation"
 msgstr "垂直顯示工具列"
 
-#: src/muuli_wdr.cpp:1997
+#: src/muuli_wdr.cpp:2004
 msgid "Live column sorting (auto-reorder rows as their values change)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2004
+#: src/muuli_wdr.cpp:2011
 msgid "Download Queue Files"
 msgstr "下載等候區檔案"
 
-#: src/muuli_wdr.cpp:2007
+#: src/muuli_wdr.cpp:2014
 msgid "Show progress percentage"
 msgstr "顯示進度百分比"
 
-#: src/muuli_wdr.cpp:2013
+#: src/muuli_wdr.cpp:2020
 msgid "Show progress bar"
 msgstr "顯示進度條"
 
-#: src/muuli_wdr.cpp:2016
+#: src/muuli_wdr.cpp:2023
 msgid "Flat"
 msgstr "扁平"
 
-#: src/muuli_wdr.cpp:2020
+#: src/muuli_wdr.cpp:2027
 msgid "Round"
 msgstr "圓弧"
 
-#: src/muuli_wdr.cpp:2038
+#: src/muuli_wdr.cpp:2045
 msgid "External Connection Parameters"
 msgstr "外部連線參數"
 
-#: src/muuli_wdr.cpp:2041
+#: src/muuli_wdr.cpp:2048
 msgid "Accept external connections"
 msgstr "接受外部連線"
 
-#: src/muuli_wdr.cpp:2048 src/muuli_wdr.cpp:2107
+#: src/muuli_wdr.cpp:2055 src/muuli_wdr.cpp:2114
 msgid "IP of the listening interface:"
 msgstr "監聽 IP："
 
-#: src/muuli_wdr.cpp:2051
+#: src/muuli_wdr.cpp:2058
 msgid "Enter here a valid ip in the a.b.c.d format for the listening EC interface. An empty field or 0.0.0.0 will mean any interface."
 msgstr "輸入要監聽外部連線的的 IP (格式：a.b.c.d)，空白或 0.0.0.0 表示全部。"
 
-#: src/muuli_wdr.cpp:2072 src/muuli_wdr.cpp:2156
+#: src/muuli_wdr.cpp:2079 src/muuli_wdr.cpp:2163
 msgid "TCP port:"
 msgstr "TCP 埠："
 
-#: src/muuli_wdr.cpp:2078
+#: src/muuli_wdr.cpp:2085
 msgid "Enable UPnP port forwarding on the EC port"
 msgstr "外部連線通訊埠啟用 UPnP 通訊埠轉向"
 
-#: src/muuli_wdr.cpp:2082 src/muuli_wdr.cpp:3041
+#: src/muuli_wdr.cpp:2089 src/muuli_wdr.cpp:3048
 #: src/utils/wxCas/src/wxcasprefs.cpp:167
 msgid "Password"
 msgstr "密碼"
 
-#: src/muuli_wdr.cpp:2088
+#: src/muuli_wdr.cpp:2095
 #, fuzzy
 msgid "aMule API server parameters"
 msgstr "網站伺服器參數"
 
-#: src/muuli_wdr.cpp:2091
+#: src/muuli_wdr.cpp:2098
 msgid "Run amuleapi (REST API) on startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2096
+#: src/muuli_wdr.cpp:2103
 #, fuzzy
 msgid "HTTP port:"
 msgstr "TCP 埠："
 
-#: src/muuli_wdr.cpp:2110
+#: src/muuli_wdr.cpp:2117
 msgid "The interface amuleapi's HTTP server listens on. 127.0.0.1 (default) accepts only local connections; use 0.0.0.0 or a specific IP to expose it to other hosts (set an admin password below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2113
+#: src/muuli_wdr.cpp:2120
 #, fuzzy
 msgid "Admin password"
 msgstr "正在檢查密碼\n"
 
-#: src/muuli_wdr.cpp:2118 src/muuli_wdr.cpp:2149
+#: src/muuli_wdr.cpp:2125 src/muuli_wdr.cpp:2156
 msgid "Low rights password"
 msgstr "低權限使用者密碼"
 
-#: src/muuli_wdr.cpp:2126
+#: src/muuli_wdr.cpp:2133
 msgid "Web server parameters"
 msgstr "網站伺服器參數"
 
-#: src/muuli_wdr.cpp:2129
+#: src/muuli_wdr.cpp:2136
 #, fuzzy
 msgid "Run webserver on startup (deprecated)"
 msgstr "啟動時執行網站伺服器"
 
-#: src/muuli_wdr.cpp:2135
+#: src/muuli_wdr.cpp:2142
 msgid "Web template"
 msgstr "網頁模板"
 
-#: src/muuli_wdr.cpp:2140
+#: src/muuli_wdr.cpp:2147
 msgid "Full rights password"
 msgstr "絕對權限使用者密碼"
 
-#: src/muuli_wdr.cpp:2144
+#: src/muuli_wdr.cpp:2151
 msgid "Enable Low rights User"
 msgstr "啟用低權限使用者"
 
-#: src/muuli_wdr.cpp:2163
+#: src/muuli_wdr.cpp:2170
 msgid "Enable UPnP port forwarding of the web server port"
 msgstr "網站伺服器的通訊埠啟用 UPnP 通訊埠轉向"
 
-#: src/muuli_wdr.cpp:2168
+#: src/muuli_wdr.cpp:2175
 msgid "Web server UPnP TCP port (Optional)"
 msgstr "網站伺服器的 UPnP TCP 埠 (選用)"
 
-#: src/muuli_wdr.cpp:2176
+#: src/muuli_wdr.cpp:2183
 msgid "Page Refresh Time (in secs)"
 msgstr "頁面更新時間 (秒)"
 
-#: src/muuli_wdr.cpp:2183
+#: src/muuli_wdr.cpp:2190
 msgid "Enable Gzip compression"
 msgstr "啟用 Gzip 壓縮"
 
-#: src/muuli_wdr.cpp:2217
+#: src/muuli_wdr.cpp:2224
 #, fuzzy
 msgid "Reset page to defaults"
 msgstr "系統預設"
 
-#: src/muuli_wdr.cpp:2218
+#: src/muuli_wdr.cpp:2225
 msgid "Reset the settings on the current page to their default values."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2220 src/muuli_wdr.cpp:2306 src/ServerWnd.cpp:274
+#: src/muuli_wdr.cpp:2227 src/muuli_wdr.cpp:2313 src/ServerWnd.cpp:274
 #: src/ServerWnd.cpp:282
 msgid "OK"
 msgstr "OK"
 
-#: src/muuli_wdr.cpp:2222
+#: src/muuli_wdr.cpp:2229
 msgid "Click here to apply any changes made to the preferences."
 msgstr "點選這裏立即套用已變更的偏好設定。"
 
-#: src/muuli_wdr.cpp:2225
+#: src/muuli_wdr.cpp:2232
 msgid "Reset any changes made to the preferences."
 msgstr "取消所有偏好設定變更。"
 
-#: src/muuli_wdr.cpp:2254
+#: src/muuli_wdr.cpp:2261
 msgid "Comment :"
 msgstr "註解："
 
-#: src/muuli_wdr.cpp:2261
+#: src/muuli_wdr.cpp:2268
 msgid "Incoming Dir :"
 msgstr "新進檔目錄："
 
-#: src/muuli_wdr.cpp:2270
+#: src/muuli_wdr.cpp:2277
 msgid "Change priority for new assigned files :"
 msgstr "設定新加入的檔案優先等級為："
 
-#: src/muuli_wdr.cpp:2274
+#: src/muuli_wdr.cpp:2281
 msgid "Don't change"
 msgstr "不要變更"
 
-#: src/muuli_wdr.cpp:2286
+#: src/muuli_wdr.cpp:2293
 msgid "Select color for this Category (currently selected) :"
 msgstr "選取該分類的顏色 (目前選擇)："
 
-#: src/muuli_wdr.cpp:2353 src/muuli_wdr.cpp:2372 src/muuli_wdr.cpp:2394
+#: src/muuli_wdr.cpp:2360 src/muuli_wdr.cpp:2379 src/muuli_wdr.cpp:2401
 msgid "Click this button to reset the log."
 msgstr "點選這個按鈕來清除記錄。"
 
-#: src/muuli_wdr.cpp:2413
+#: src/muuli_wdr.cpp:2420
 msgid "Click on this button to update the servers list from URL ..."
 msgstr "點選這個按鈕從該網址更新伺服器清單 ..."
 
-#: src/muuli_wdr.cpp:2417
+#: src/muuli_wdr.cpp:2424
 msgid "Server list"
 msgstr "伺服器清單"
 
-#: src/muuli_wdr.cpp:2421
+#: src/muuli_wdr.cpp:2428
 msgid "Enter the url to a server.met file here and press the button to the left to update the list of known servers."
 msgstr "輸入 server.met 檔案的網址並按下左邊的按鈕以更新已知伺服器清單。"
 
-#: src/muuli_wdr.cpp:2426
+#: src/muuli_wdr.cpp:2433
 msgid "Add server manually: Name"
 msgstr "手動加入伺服器：名稱"
 
-#: src/muuli_wdr.cpp:2429
+#: src/muuli_wdr.cpp:2436
 msgid "Enter the name of the new server here"
 msgstr "輸入新伺服器的名稱"
 
-#: src/muuli_wdr.cpp:2431 src/ServerWnd.cpp:206
+#: src/muuli_wdr.cpp:2438 src/ServerWnd.cpp:206
 msgid "IP:Port"
 msgstr "IP:Port"
 
-#: src/muuli_wdr.cpp:2434
+#: src/muuli_wdr.cpp:2441
 msgid "Enter the IP of the server here, using the x.x.x.x format."
 msgstr "輸入新伺服器的 IP (格式：x.x.x.x)。"
 
-#: src/muuli_wdr.cpp:2440
+#: src/muuli_wdr.cpp:2447
 msgid "Enter the port of the server here."
 msgstr "輸入伺服器的通訊埠。"
 
-#: src/muuli_wdr.cpp:2443
+#: src/muuli_wdr.cpp:2450
 msgid "Add manually a server (fill fields to the left before) ..."
 msgstr "手動加入伺服器 (填入左側空格中) ..."
 
-#: src/muuli_wdr.cpp:2472
+#: src/muuli_wdr.cpp:2479
 msgid "aMule Log"
 msgstr "aMule 記錄"
 
-#: src/muuli_wdr.cpp:2480
+#: src/muuli_wdr.cpp:2487
 msgid "Server Info"
 msgstr "伺服器資訊"
 
-#: src/muuli_wdr.cpp:2484
+#: src/muuli_wdr.cpp:2491
 msgid "ED2K Info"
 msgstr "eD2k 資訊"
 
-#: src/muuli_wdr.cpp:2488
+#: src/muuli_wdr.cpp:2495
 msgid "Kad Info"
 msgstr "Kad 資訊"
 
-#: src/muuli_wdr.cpp:2516
+#: src/muuli_wdr.cpp:2523
 msgid "Click on this button to update the nodes list from URL ..."
 msgstr "點選這個按鈕來從該網址更新節點清單 ..."
 
-#: src/muuli_wdr.cpp:2520
+#: src/muuli_wdr.cpp:2527
 msgid "Nodes (0)"
 msgstr "節點 (0)"
 
-#: src/muuli_wdr.cpp:2524
+#: src/muuli_wdr.cpp:2531
 msgid "Enter the url to a nodes.dat file here and press the button to the left to update the list of known nodes."
 msgstr "輸入 nodes.dat 檔案的網址，並按下左邊的按鈕以更新已知節點清單。"
 
-#: src/muuli_wdr.cpp:2527
+#: src/muuli_wdr.cpp:2534
 msgid "Nodes stats"
 msgstr "節點狀態"
 
-#: src/muuli_wdr.cpp:2569
+#: src/muuli_wdr.cpp:2576
 msgid "Bootstrap"
 msgstr "啓動"
 
-#: src/muuli_wdr.cpp:2572
+#: src/muuli_wdr.cpp:2579
 msgid "New node"
 msgstr "新節點"
 
-#: src/muuli_wdr.cpp:2577
+#: src/muuli_wdr.cpp:2584
 msgid "IP:"
 msgstr "IP："
 
-#: src/muuli_wdr.cpp:2597
+#: src/muuli_wdr.cpp:2604
 msgid "Port:"
 msgstr "埠："
 
-#: src/muuli_wdr.cpp:2610
+#: src/muuli_wdr.cpp:2617
 msgid "Bootstrap from known clients"
 msgstr "從已知客戶端啓動"
 
-#: src/muuli_wdr.cpp:2612
+#: src/muuli_wdr.cpp:2619
 msgid "Disconnect Kad"
 msgstr "中斷 Kad 連線"
 
-#: src/muuli_wdr.cpp:2646
+#: src/muuli_wdr.cpp:2653
 msgid "Use Secure User Identification"
 msgstr "啟用使用者安全認證"
 
-#: src/muuli_wdr.cpp:2648
+#: src/muuli_wdr.cpp:2655
 msgid "It is recommended to enable this option. You will not receive credits if SUI is not enabled."
 msgstr "建議啟用此選項。如果使用者安全認證未啟用，將會得不到積分。"
 
-#: src/muuli_wdr.cpp:2650
+#: src/muuli_wdr.cpp:2657
 msgid "Protocol Obfuscation"
 msgstr "模糊協定"
 
-#: src/muuli_wdr.cpp:2653
+#: src/muuli_wdr.cpp:2660
 msgid "Support Protocol Obfuscation"
 msgstr "支援模糊協定"
 
-#: src/muuli_wdr.cpp:2655
+#: src/muuli_wdr.cpp:2662
 msgid "This option enabled Protocol Obfuscation, and makes aMule accept obfuscated connections from other clients."
 msgstr "啓用模糊協定，可讓 aMule 接受來自其他客戶端的模糊連線。"
 
-#: src/muuli_wdr.cpp:2657
+#: src/muuli_wdr.cpp:2664
 msgid "Use obfuscation for outgoing connections"
 msgstr "對外的連線使用模糊協定"
 
-#: src/muuli_wdr.cpp:2659
+#: src/muuli_wdr.cpp:2666
 msgid "This option makes aMule use Protocol Obfuscation when connecting other clients/servers."
 msgstr "使 aMule 在與其他客戶端或伺服器連線時使用模糊協定。"
 
-#: src/muuli_wdr.cpp:2661
+#: src/muuli_wdr.cpp:2668
 msgid "Accept only obfuscated connections"
 msgstr "只接受模糊連線"
 
-#: src/muuli_wdr.cpp:2662
+#: src/muuli_wdr.cpp:2669
 msgid "This option makes aMule only accept obfuscated connections. You will have less sources, but all your traffic will be obfuscated"
 msgstr "讓 aMule 只接受模糊協定，檔案來源會比較少，但所有傳輸都將是模糊連線"
 
-#: src/muuli_wdr.cpp:2667
+#: src/muuli_wdr.cpp:2674
 msgid "Everybody"
 msgstr "任何人"
 
-#: src/muuli_wdr.cpp:2669
+#: src/muuli_wdr.cpp:2676
 msgid "No one"
 msgstr "無"
 
-#: src/muuli_wdr.cpp:2671
+#: src/muuli_wdr.cpp:2678
 msgid "Who can see my shared files:"
 msgstr "誰可以看我的分享檔案："
 
-#: src/muuli_wdr.cpp:2672
+#: src/muuli_wdr.cpp:2679
 msgid "Select who can request to view a list of your shared files."
 msgstr "選取可以瀏覽分享檔案清單的使用者。"
 
-#: src/muuli_wdr.cpp:2674
+#: src/muuli_wdr.cpp:2681
 msgid "IP-Filtering"
 msgstr "IP 過濾"
 
-#: src/muuli_wdr.cpp:2681
+#: src/muuli_wdr.cpp:2688
 msgid "Filter clients"
 msgstr "過濾客戶端"
 
-#: src/muuli_wdr.cpp:2683
+#: src/muuli_wdr.cpp:2690
 msgid "Enable filtering of the client IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "過濾列在 ~/.aMule/ipfilter.dat 檔案中的客戶端 IP"
 
-#: src/muuli_wdr.cpp:2685
+#: src/muuli_wdr.cpp:2692
 msgid "Filter servers"
 msgstr "過濾伺服器"
 
-#: src/muuli_wdr.cpp:2687
+#: src/muuli_wdr.cpp:2694
 msgid "Enable filtering of the server IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "過濾列在 ~/.aMule/ipfilter.dat 檔案中的伺服器 IP 。"
 
-#: src/muuli_wdr.cpp:2691
+#: src/muuli_wdr.cpp:2698
 msgid "Reload List"
 msgstr "重載入清單"
 
-#: src/muuli_wdr.cpp:2692
+#: src/muuli_wdr.cpp:2699
 msgid "Reload the list of IPs to filter from the file ~/.aMule/ipfilter.dat"
 msgstr "重新載入 IP 過濾清單 ~/.aMule/ipfilter.dat"
 
-#: src/muuli_wdr.cpp:2698
+#: src/muuli_wdr.cpp:2705
 msgid "URL:"
 msgstr "網址："
 
-#: src/muuli_wdr.cpp:2702 src/muuli_wdr.cpp:2895
+#: src/muuli_wdr.cpp:2709 src/muuli_wdr.cpp:2902
 msgid "Update now"
 msgstr "立即更新"
 
-#: src/muuli_wdr.cpp:2705
+#: src/muuli_wdr.cpp:2712
 msgid "Auto-update ipfilter at startup"
 msgstr "啓動後自動更新 IP 過濾清單"
 
-#: src/muuli_wdr.cpp:2709
+#: src/muuli_wdr.cpp:2716
 msgid "Filtering Level:"
 msgstr "過濾等級："
 
-#: src/muuli_wdr.cpp:2715
+#: src/muuli_wdr.cpp:2722
 msgid "Always filter LAN IPs"
 msgstr "永遠過濾區域網路 IP"
 
-#: src/muuli_wdr.cpp:2718
+#: src/muuli_wdr.cpp:2725
 msgid "Paranoid handling of non-matching IPs"
 msgstr "處理不匹配的 IP"
 
-#: src/muuli_wdr.cpp:2720
+#: src/muuli_wdr.cpp:2727
 msgid "Rejects a packet when its source IP differs from the IP the client claims (an anti-spoofing check). Disable only if it causes connection problems."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2722
+#: src/muuli_wdr.cpp:2729
 msgid "Use system-wide ipfilter.dat if available"
 msgstr "如果可以則使用系統級的 ipfilter.dat"
 
-#: src/muuli_wdr.cpp:2723
+#: src/muuli_wdr.cpp:2730
 #, fuzzy
 msgid "If there's no local ipfilter.dat found, allow usage of a system-wide ipfilter file."
 msgstr "如果找不到本機 ipfilter.dat 檔案，則允許使用系統級的 IP 過濾檔。"
 
-#: src/muuli_wdr.cpp:2740
+#: src/muuli_wdr.cpp:2747
 msgid "Enable Online-Signature"
 msgstr "啟用線上簽名識別"
 
-#: src/muuli_wdr.cpp:2742
+#: src/muuli_wdr.cpp:2749
 msgid "Enables the writing of the OS file, which can be used by external apps to create signatures and the like."
 msgstr "啟用寫入到作業系統檔案，以讓外部程式用來建立簽名識別等等。"
 
-#: src/muuli_wdr.cpp:2746
+#: src/muuli_wdr.cpp:2753
 msgid "Update Frequency (Secs):"
 msgstr "更新頻率(秒)："
 
-#: src/muuli_wdr.cpp:2749
+#: src/muuli_wdr.cpp:2756
 msgid "Change the frequency (in seconds) of Online Signature updates."
 msgstr "變更線上簽名識別檔的更新頻率 (單位為 秒)。"
 
-#: src/muuli_wdr.cpp:2757
+#: src/muuli_wdr.cpp:2764
 msgid "Save online signature file in: "
 msgstr "儲存線上簽名識別檔："
 
-#: src/muuli_wdr.cpp:2763
+#: src/muuli_wdr.cpp:2770
 msgid "Click here to select the directory containing the the Online Signature files."
 msgstr "點擊選取線上簽識別名檔案所在的目錄。"
 
-#: src/muuli_wdr.cpp:2796
+#: src/muuli_wdr.cpp:2803
 msgid "Show country flags for clients"
 msgstr "顯示客戶端的國旗"
 
-#: src/muuli_wdr.cpp:2797
+#: src/muuli_wdr.cpp:2804
 msgid "Render the country flag column in the transfers, queue and search views. Requires a valid MMDB GeoIP database (see below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2802
+#: src/muuli_wdr.cpp:2809
 #, fuzzy
 msgid "Database"
 msgstr "速度："
 
-#: src/muuli_wdr.cpp:2818
+#: src/muuli_wdr.cpp:2825
 #, fuzzy
 msgid "Source:"
 msgstr "來源"
 
-#: src/muuli_wdr.cpp:2821
+#: src/muuli_wdr.cpp:2828
 msgid "DB-IP (free, no account)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2822
+#: src/muuli_wdr.cpp:2829
 msgid "MaxMind GeoLite2 (free, account required)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2823
+#: src/muuli_wdr.cpp:2830
 msgid "Custom URL"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2826
+#: src/muuli_wdr.cpp:2833
 msgid "Choose which provider supplies the GeoIP MMDB database. DB-IP is the default - no account required. MaxMind requires a free account + license key. Use Custom URL to point at any other MMDB host (e.g. a local mirror)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2843
+#: src/muuli_wdr.cpp:2850
 msgid ""
 "No configuration required.\n"
 "\n"
@@ -4830,11 +4844,11 @@ msgid ""
 "License: Creative Commons BY 4.0 - https://creativecommons.org/licenses/by/4.0/"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2856
+#: src/muuli_wdr.cpp:2863
 msgid "License key:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2862
+#: src/muuli_wdr.cpp:2869
 msgid ""
 "Sign up for a free MaxMind account, then generate a License Key:\n"
 "https://www.maxmind.com/en/geolite2/signup\n"
@@ -4844,226 +4858,226 @@ msgid ""
 "Requires attribution and account registration; refresh at least every 30 days."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2877
+#: src/muuli_wdr.cpp:2884
 #, fuzzy
 msgid "Download URL:"
 msgstr "下載："
 
-#: src/muuli_wdr.cpp:2883
+#: src/muuli_wdr.cpp:2890
 msgid ""
 "Must point to an .mmdb file or a .gz / .tar.gz containing one.\n"
 "URL may include credentials (https://user:pass@host/...).\n"
 "License and attribution terms are set by the upstream URL - you are responsible."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2896
+#: src/muuli_wdr.cpp:2903
 msgid "Download the GeoIP database from the selected source."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2898
+#: src/muuli_wdr.cpp:2905
 #, fuzzy
 msgid "Auto-update on startup"
 msgstr "啓動後自動更新 IP 過濾清單"
 
-#: src/muuli_wdr.cpp:2899
+#: src/muuli_wdr.cpp:2906
 msgid "Re-download the GeoIP database from the selected source every time aMule starts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2922
+#: src/muuli_wdr.cpp:2929
 msgid "Filter incoming messages (except current chat):"
 msgstr "過濾收到的訊息 (不包含目前交談)："
 
-#: src/muuli_wdr.cpp:2924
+#: src/muuli_wdr.cpp:2931
 msgid "Filter all messages"
 msgstr "過濾所有訊息"
 
-#: src/muuli_wdr.cpp:2926
+#: src/muuli_wdr.cpp:2933
 msgid "Filter messages from people not on your friend list"
 msgstr "過濾來自好友以外的訊息"
 
-#: src/muuli_wdr.cpp:2928
+#: src/muuli_wdr.cpp:2935
 msgid "Filter messages from unknown clients"
 msgstr "過濾來自不明客戶端的訊息"
 
-#: src/muuli_wdr.cpp:2930
+#: src/muuli_wdr.cpp:2937
 msgid "Filter messages containing (use ',' as separator):"
 msgstr "過濾含以下內容的訊息 (用逗號 ',' 隔開)："
 
-#: src/muuli_wdr.cpp:2933 src/muuli_wdr.cpp:2944
+#: src/muuli_wdr.cpp:2940 src/muuli_wdr.cpp:2951
 msgid "add here the words amule should filter and block messages including it"
 msgstr "輸入要過濾的詞句"
 
-#: src/muuli_wdr.cpp:2935
+#: src/muuli_wdr.cpp:2942
 msgid "Show received messages in the log"
 msgstr "記錄收到的訊息"
 
-#: src/muuli_wdr.cpp:2938
+#: src/muuli_wdr.cpp:2945
 msgid "Comments"
 msgstr "註解"
 
-#: src/muuli_wdr.cpp:2941
+#: src/muuli_wdr.cpp:2948
 msgid "Filter comments containing (use ',' as separator):"
 msgstr "過濾含以下內容的註解 (用逗號 ',' 隔開)："
 
-#: src/muuli_wdr.cpp:2966
+#: src/muuli_wdr.cpp:2973
 msgid "Enable Proxy"
 msgstr "啓用代理伺服器"
 
-#: src/muuli_wdr.cpp:2967
+#: src/muuli_wdr.cpp:2974
 msgid "Enable/disable proxy support"
 msgstr "啓用/停用代理伺服器支援"
 
-#: src/muuli_wdr.cpp:2970
+#: src/muuli_wdr.cpp:2977
 msgid "Proxy type:"
 msgstr "類型："
 
-#: src/muuli_wdr.cpp:2981
+#: src/muuli_wdr.cpp:2988
 msgid "Proxy host:"
 msgstr "主機："
 
-#: src/muuli_wdr.cpp:2984
+#: src/muuli_wdr.cpp:2991
 msgid "The proxy host name"
 msgstr "代理伺服器主機名稱"
 
-#: src/muuli_wdr.cpp:2986
+#: src/muuli_wdr.cpp:2993
 msgid "Proxy port:"
 msgstr "連接埠："
 
-#: src/muuli_wdr.cpp:2989
+#: src/muuli_wdr.cpp:2996
 msgid "The proxy port"
 msgstr "代理伺服器連接埠"
 
-#: src/muuli_wdr.cpp:2991
+#: src/muuli_wdr.cpp:2998
 msgid "Enable authentication"
 msgstr "啓用登入驗證"
 
-#: src/muuli_wdr.cpp:2992
+#: src/muuli_wdr.cpp:2999
 msgid "Enable/disable username/password authentication"
 msgstr "啓用/停用 使用者名稱/密碼登入驗證"
 
-#: src/muuli_wdr.cpp:2995
+#: src/muuli_wdr.cpp:3002
 msgid "Username: "
 msgstr "使用者名稱："
 
-#: src/muuli_wdr.cpp:2998
+#: src/muuli_wdr.cpp:3005
 msgid "The username to use to connect to the proxy"
 msgstr "登入代理伺服器的使用者名稱"
 
-#: src/muuli_wdr.cpp:3000
+#: src/muuli_wdr.cpp:3007
 msgid "Password:"
 msgstr "密碼："
 
-#: src/muuli_wdr.cpp:3003
+#: src/muuli_wdr.cpp:3010
 msgid "The password to use to connect to the proxy"
 msgstr "登入代理伺服器的密碼"
 
-#: src/muuli_wdr.cpp:3022
+#: src/muuli_wdr.cpp:3029
 msgid "Connect to:"
 msgstr "連線到："
 
-#: src/muuli_wdr.cpp:3031
+#: src/muuli_wdr.cpp:3038
 msgid "Login to remote amule"
 msgstr "登入遠端 amule"
 
-#: src/muuli_wdr.cpp:3036
+#: src/muuli_wdr.cpp:3043
 msgid "User name"
 msgstr "使用者名稱"
 
-#: src/muuli_wdr.cpp:3047
+#: src/muuli_wdr.cpp:3054
 msgid "Remember those settings"
 msgstr "記住這些設定"
 
-#: src/muuli_wdr.cpp:3050
+#: src/muuli_wdr.cpp:3057
 #, fuzzy
 msgid "Force ZLIB compression"
 msgstr "使用 gzip 壓縮"
 
-#: src/muuli_wdr.cpp:3074
+#: src/muuli_wdr.cpp:3081
 msgid "Enable Verbose Debug-Logging."
 msgstr "啓用記錄詳細除錯訊息。"
 
-#: src/muuli_wdr.cpp:3076
+#: src/muuli_wdr.cpp:3083
 #, fuzzy
 msgid "Only to Logfile"
 msgstr "開啟檔案(&O)"
 
-#: src/muuli_wdr.cpp:3078
+#: src/muuli_wdr.cpp:3085
 msgid "Message Categories:"
 msgstr "訊息分類："
 
-#: src/muuli_wdr.cpp:3102 src/PartFileConvertDlg.cpp:160
+#: src/muuli_wdr.cpp:3109 src/PartFileConvertDlg.cpp:160
 msgid "Waiting..."
 msgstr "等候中..."
 
-#: src/muuli_wdr.cpp:3122
+#: src/muuli_wdr.cpp:3129
 msgid "Add imports"
 msgstr "加入"
 
-#: src/muuli_wdr.cpp:3125
+#: src/muuli_wdr.cpp:3132
 msgid "Retry selected"
 msgstr "重試"
 
-#: src/muuli_wdr.cpp:3127
+#: src/muuli_wdr.cpp:3134
 msgid "Remove selected"
 msgstr "移除"
 
-#: src/muuli_wdr.cpp:3190
+#: src/muuli_wdr.cpp:3197
 msgid "Event Types"
 msgstr "事件種類"
 
-#: src/muuli_wdr.cpp:3209
+#: src/muuli_wdr.cpp:3216
 msgid "Statistics and queued clients for selected file(s) : Session / All time"
 msgstr "已選取的檔案的統計資料與等候區客戶端數：本次 / 總計"
 
-#: src/muuli_wdr.cpp:3233
+#: src/muuli_wdr.cpp:3240
 msgid "Active Uploads"
 msgstr "目前上傳數"
 
-#: src/muuli_wdr.cpp:3247
+#: src/muuli_wdr.cpp:3254
 msgid "Percent of total files"
 msgstr "% (所有檔案中)"
 
-#: src/muuli_wdr.cpp:3299
+#: src/muuli_wdr.cpp:3306
 msgid "Show Clients for"
 msgstr "顯示客戶端："
 
-#: src/muuli_wdr.cpp:3301
+#: src/muuli_wdr.cpp:3308
 msgid "All files"
 msgstr "所有檔案"
 
-#: src/muuli_wdr.cpp:3304
+#: src/muuli_wdr.cpp:3311
 msgid "Selected files"
 msgstr "選取的檔案"
 
-#: src/muuli_wdr.cpp:3307
+#: src/muuli_wdr.cpp:3314
 msgid "Active uploads only"
 msgstr "僅限目前上傳中"
 
-#: src/muuli_wdr.cpp:3314
+#: src/muuli_wdr.cpp:3321
 msgid "Reload:"
 msgstr "重新載入："
 
-#: src/muuli_wdr.cpp:3318
+#: src/muuli_wdr.cpp:3325
 msgid "Reload your shared files"
 msgstr "重新載入分享的檔案"
 
-#: src/muuli_wdr.cpp:3381
+#: src/muuli_wdr.cpp:3388
 msgid "Send"
 msgstr "傳送"
 
-#: src/muuli_wdr.cpp:3382
+#: src/muuli_wdr.cpp:3389
 msgid "Sends the specified message."
 msgstr "傳送訊息。"
 
-#: src/muuli_wdr.cpp:3386
+#: src/muuli_wdr.cpp:3393
 msgid "Close this chat-session."
 msgstr "結束本次交談。"
 
-#: src/muuli_wdr.cpp:3409
+#: src/muuli_wdr.cpp:3416
 msgid "Connect to any server and/or Kad"
 msgstr "連線到任何伺服器 和/或 Kad 網路"
 
-#: src/muuli_wdr.cpp:3415 src/SharedFilesCtrl.cpp:142 src/Statistics.cpp:941
+#: src/muuli_wdr.cpp:3422 src/SharedFilesCtrl.cpp:142 src/Statistics.cpp:941
 msgid "Shared Files"
 msgstr "分享檔案"
 
@@ -5418,188 +5432,188 @@ msgstr "已下載"
 msgid "ERROR: Failed to open partfile '%s'"
 msgstr "錯誤：無法開啟暫存檔 %s"
 
-#: src/Preferences.cpp:673
+#: src/Preferences.cpp:674
 msgid "System default"
 msgstr "系統預設"
 
-#: src/Preferences.cpp:674
+#: src/Preferences.cpp:675
 msgid "Albanian"
 msgstr "阿爾巴尼亞語"
 
-#: src/Preferences.cpp:675
+#: src/Preferences.cpp:676
 msgid "Arabic"
 msgstr "阿拉伯語"
 
-#: src/Preferences.cpp:676
+#: src/Preferences.cpp:677
 msgid "Asturian"
 msgstr "奧地利語"
 
-#: src/Preferences.cpp:677
+#: src/Preferences.cpp:678
 msgid "Basque"
 msgstr "巴斯克語"
 
-#: src/Preferences.cpp:678
+#: src/Preferences.cpp:679
 msgid "Bulgarian"
 msgstr "保加利亞語"
 
-#: src/Preferences.cpp:679
+#: src/Preferences.cpp:680
 msgid "Catalan"
 msgstr "加泰隆尼亞語"
 
-#: src/Preferences.cpp:680
+#: src/Preferences.cpp:681
 msgid "Chinese (Simplified)"
 msgstr "簡體中文"
 
-#: src/Preferences.cpp:681
+#: src/Preferences.cpp:682
 msgid "Chinese (Traditional)"
 msgstr "正體中文"
 
-#: src/Preferences.cpp:682
+#: src/Preferences.cpp:683
 msgid "Croatian"
 msgstr "克羅埃西亞語"
 
-#: src/Preferences.cpp:683
+#: src/Preferences.cpp:684
 msgid "Czech"
 msgstr "捷克語"
 
-#: src/Preferences.cpp:684
+#: src/Preferences.cpp:685
 msgid "Danish"
 msgstr "丹麥語"
 
-#: src/Preferences.cpp:685
+#: src/Preferences.cpp:686
 msgid "Dutch"
 msgstr "荷蘭語"
 
-#: src/Preferences.cpp:686
+#: src/Preferences.cpp:687
 msgid "English (U.K.)"
 msgstr "英語 (英國)"
 
-#: src/Preferences.cpp:687
+#: src/Preferences.cpp:688
 #, fuzzy
 msgid "English (U.S.)"
 msgstr "英語 (英國)"
 
-#: src/Preferences.cpp:688
+#: src/Preferences.cpp:689
 msgid "Estonian"
 msgstr "愛沙尼亞語"
 
-#: src/Preferences.cpp:689
+#: src/Preferences.cpp:690
 msgid "Finnish"
 msgstr "芬蘭語"
 
-#: src/Preferences.cpp:690
+#: src/Preferences.cpp:691
 msgid "French"
 msgstr "法語"
 
-#: src/Preferences.cpp:691
+#: src/Preferences.cpp:692
 msgid "Galician"
 msgstr "加利西亞語"
 
-#: src/Preferences.cpp:692
+#: src/Preferences.cpp:693
 msgid "German"
 msgstr "德語"
 
-#: src/Preferences.cpp:693
+#: src/Preferences.cpp:694
 msgid "Greek"
 msgstr "希臘語"
 
-#: src/Preferences.cpp:694
+#: src/Preferences.cpp:695
 msgid "Hebrew"
 msgstr "希伯來語"
 
-#: src/Preferences.cpp:695
+#: src/Preferences.cpp:696
 msgid "Hungarian"
 msgstr "匈牙利語"
 
-#: src/Preferences.cpp:696
+#: src/Preferences.cpp:697
 msgid "Italian"
 msgstr "義大利語"
 
-#: src/Preferences.cpp:697
+#: src/Preferences.cpp:698
 msgid "Japanese"
 msgstr "日語"
 
-#: src/Preferences.cpp:698
+#: src/Preferences.cpp:699
 msgid "Korean"
 msgstr "韓語"
 
-#: src/Preferences.cpp:699
+#: src/Preferences.cpp:700
 msgid "Latvian"
 msgstr ""
 
-#: src/Preferences.cpp:700
+#: src/Preferences.cpp:701
 msgid "Lithuanian"
 msgstr "立陶宛語"
 
-#: src/Preferences.cpp:701
+#: src/Preferences.cpp:702
 msgid "Norwegian (Nynorsk)"
 msgstr "新挪威語"
 
-#: src/Preferences.cpp:702
+#: src/Preferences.cpp:703
 msgid "Polish"
 msgstr "波蘭語"
 
-#: src/Preferences.cpp:703
+#: src/Preferences.cpp:704
 msgid "Portuguese"
 msgstr "葡萄牙語"
 
-#: src/Preferences.cpp:704
+#: src/Preferences.cpp:705
 msgid "Portuguese (Brazilian)"
 msgstr "葡萄牙語 (巴西)"
 
-#: src/Preferences.cpp:705
+#: src/Preferences.cpp:706
 msgid "Romanian"
 msgstr "羅馬尼亞語"
 
-#: src/Preferences.cpp:706
+#: src/Preferences.cpp:707
 msgid "Russian"
 msgstr "俄語"
 
-#: src/Preferences.cpp:707
+#: src/Preferences.cpp:708
 msgid "Slovenian"
 msgstr "斯洛維尼亞語"
 
-#: src/Preferences.cpp:708
+#: src/Preferences.cpp:709
 msgid "Spanish"
 msgstr "西班牙語"
 
-#: src/Preferences.cpp:709
+#: src/Preferences.cpp:710
 msgid "Swedish"
 msgstr "瑞典語"
 
-#: src/Preferences.cpp:710
+#: src/Preferences.cpp:711
 msgid "Turkish"
 msgstr "土耳其語"
 
-#: src/Preferences.cpp:711
+#: src/Preferences.cpp:712
 msgid "Ukrainian"
 msgstr "烏克蘭語"
 
-#: src/Preferences.cpp:814
+#: src/Preferences.cpp:815
 msgid "Change Language"
 msgstr "變更語言"
 
-#: src/Preferences.cpp:878
+#: src/Preferences.cpp:879
 msgid "There are no translations installed for aMule"
 msgstr "沒有已安裝的 aMule 翻譯"
 
-#: src/Preferences.cpp:879
+#: src/Preferences.cpp:880
 msgid "No languages available"
 msgstr "沒有可用的語言"
 
-#: src/Preferences.cpp:1010
+#: src/Preferences.cpp:1011
 msgid "no options available"
 msgstr "沒有選項"
 
-#: src/Preferences.cpp:2179
+#: src/Preferences.cpp:2182
 msgid "Invalid category found, skipping"
 msgstr "找到無效的分類，略過"
 
-#: src/Preferences.cpp:2348
+#: src/Preferences.cpp:2351
 msgid "TCP port can't be higher than 65532 due to server UDP socket being TCP+3"
 msgstr "TCP 埠不可大於 65532，因爲伺服器 UDP 連接端點值爲 TCP 埠值+3"
 
-#: src/Preferences.cpp:2349
+#: src/Preferences.cpp:2352
 #, c-format
 msgid "Default port will be used (%d)"
 msgstr "使用預設通訊埠 (%d)"
@@ -6105,24 +6119,28 @@ msgstr "重新載入分享檔案清單。"
 msgid "Shared folder"
 msgstr "分享資料夾"
 
-#: src/SearchDlg.cpp:425
+#: src/SearchDlg.cpp:280
+msgid "Clear search history"
+msgstr ""
+
+#: src/SearchDlg.cpp:584
 msgid "It's impossible to search when both eD2k and Kademlia are disabled."
 msgstr ""
 
-#: src/SearchDlg.cpp:426 src/SearchListCtrl.cpp:858
+#: src/SearchDlg.cpp:585 src/SearchListCtrl.cpp:858
 #, fuzzy
 msgid "Search error"
 msgstr "搜尋"
 
-#: src/SearchDlg.cpp:768
+#: src/SearchDlg.cpp:929
 msgid "Min size must be smaller than max size. Max size ignored."
 msgstr "最小值必須小於最大值，最大值已被忽略。"
 
-#: src/SearchDlg.cpp:769 src/SearchDlg.cpp:851
+#: src/SearchDlg.cpp:930 src/SearchDlg.cpp:1012
 msgid "Search warning"
 msgstr "搜尋警告"
 
-#: src/SearchDlg.cpp:929 src/SearchListCtrl.cpp:735
+#: src/SearchDlg.cpp:1092 src/SearchListCtrl.cpp:735
 msgid "Main"
 msgstr "主要"
 

--- a/src/Preferences.cpp
+++ b/src/Preferences.cpp
@@ -1404,6 +1404,8 @@ void CPreferences::BuildItemList(const wxString &appdir)
 	NewCfgItem(IDC_DAP, (new Cfg_Bool("/eMule/DAPPref", s_bDAP, true)));
 	NewCfgItem(IDC_UAP, (new Cfg_Bool("/eMule/UAPPref", s_bUAP, true)));
 	NewCfgItem(IDC_ALLOCFULLFILE, (new Cfg_Bool("/eMule/AllocateFullFile", s_allocFullFile, false)));
+	NewCfgItem(
+		IDC_CREATEFILESSPARSE, (new Cfg_Bool("/eMule/CreateSparseFiles", s_createFilesSparse, true)));
 	NewCfgItem(IDC_MMAP_ENABLE, (new Cfg_Bool("/eMule/MMapEnabled", s_mmapEnabled, false)));
 
 	/**
@@ -1706,7 +1708,6 @@ void CPreferences::BuildItemList(const wxString &appdir)
 
 	s_MiscList.push_back(new Cfg_Bool(
 		"/ExternalConnect/TransmitOnlyUploadingClients", s_TransmitOnlyUploadingClients, false));
-	s_MiscList.push_back(new Cfg_Bool("/eMule/CreateSparseFiles", s_createFilesSparse, true));
 
 #ifndef AMULE_DAEMON
 	// Colors have been moved from global prefs to CStatisticsDlg

--- a/src/PrefsUnifiedDlg.cpp
+++ b/src/PrefsUnifiedDlg.cpp
@@ -595,6 +595,15 @@ PrefsUnifiedDlg::PrefsUnifiedDlg(wxWindow *parent)
 	}
 #endif
 
+#if !defined(__WINDOWS__) && !defined(CLIENT_GUI)
+	// Monolithic non-Windows: this build is its own core and the setting is
+	// a no-op on POSIX, so hide it. Still registered, so the value keeps
+	// round-tripping through the config and EC.
+	if (wxWindow *sparse = FindWindow(IDC_CREATEFILESSPARSE)) {
+		sparse->Show(false);
+	}
+#endif
+
 	// Select the first item
 	m_PrefsIcons->SetItemState(0, wxLIST_STATE_SELECTED, wxLIST_STATE_SELECTED);
 

--- a/src/muuli_wdr.cpp
+++ b/src/muuli_wdr.cpp
@@ -1612,8 +1612,12 @@ wxSizer *PreferencesFilesTab( wxWindow *parent, bool call_fit, bool set_sizer )
     // hand-editing amule.conf was the only way (amule-org/amule#653).
     // Only does real work when the *core* runs on Windows (PlatformSpecific.cpp
     // vs. PartFile.cpp both call CFile::Create(name, true) identically on
-    // POSIX) -- kept visible rather than gated behind __WINDOWS__, since a
-    // remote amuleGUI has no EC capability tag to know the core's platform.
+    // POSIX). Always created and bound here -- amuleGUI has no EC capability
+    // tag to know the core's platform, so it always shows the control; the
+    // monolithic non-Windows build (where the answer is a compile-time
+    // certainty) hides it post-creation in PrefsUnifiedDlg's ctor instead of
+    // skipping creation, so the Cfg_Tmpl binding still has a widget to
+    // connect to.
     wxCheckBox *itemCreateSparse = new wxCheckBox( parent, IDC_CREATEFILESSPARSE, _("Create new files as sparse files"), wxDefaultPosition, wxDefaultSize, 0 );
     itemCreateSparse->SetToolTip( _("Sparse part files only occupy disk space for the parts already downloaded, so free space is used up gradually as the file fills in. Turn this off to use an ordinary file instead - useful where sparse files are unsupported or slow, or where backup/de-duplication tools handle them badly. Applies only when the core runs on Windows; on Linux and macOS part files are sparse anyway and this setting has no effect.") );
     item5->Add( itemCreateSparse, wxSizerFlags().CenterVertical().Border(wxTOP, 0) );

--- a/src/muuli_wdr.cpp
+++ b/src/muuli_wdr.cpp
@@ -1610,8 +1610,12 @@ wxSizer *PreferencesFilesTab( wxWindow *parent, bool call_fit, bool set_sizer )
     // /eMule/CreateSparseFiles was EC-wired and settable via the Web UI
     // (files.create_normal) but had no control here or in amuleGUI --
     // hand-editing amule.conf was the only way (amule-org/amule#653).
+    // Only does real work when the *core* runs on Windows (PlatformSpecific.cpp
+    // vs. PartFile.cpp both call CFile::Create(name, true) identically on
+    // POSIX) -- kept visible rather than gated behind __WINDOWS__, since a
+    // remote amuleGUI has no EC capability tag to know the core's platform.
     wxCheckBox *itemCreateSparse = new wxCheckBox( parent, IDC_CREATEFILESSPARSE, _("Create new files as sparse files"), wxDefaultPosition, wxDefaultSize, 0 );
-    itemCreateSparse->SetToolTip( _("A sparse file reserves its full size on disk immediately without writing real data to it -- fast, but unsupported or slow on some filesystems, and free-space accounting stays optimistic while the download is in progress. Turn this off to grow the file only as data arrives.") );
+    itemCreateSparse->SetToolTip( _("Sparse part files only occupy disk space for the parts already downloaded, so free space is used up gradually as the file fills in. Turn this off to use an ordinary file instead - useful where sparse files are unsupported or slow, or where backup/de-duplication tools handle them badly. Applies only when the core runs on Windows; on Linux and macOS part files are sparse anyway and this setting has no effect.") );
     item5->Add( itemCreateSparse, wxSizerFlags().CenterVertical().Border(wxTOP, 0) );
     wxFlexGridSizer *item14 = new wxFlexGridSizer( 3, 0, 0 );
     item14->AddGrowableCol( 0 );

--- a/src/muuli_wdr.cpp
+++ b/src/muuli_wdr.cpp
@@ -1607,6 +1607,12 @@ wxSizer *PreferencesFilesTab( wxWindow *parent, bool call_fit, bool set_sizer )
     wxCheckBox *item13 = new wxCheckBox( parent, IDC_ALLOCFULLFILE, _("Preallocate disk space for new files"), wxDefaultPosition, wxDefaultSize, 0 );
     item13->SetToolTip( _("For new files preallocates disk space for the whole file, thus reduces fragmentation") );
     item5->Add( item13, wxSizerFlags().CenterVertical().Border(wxTOP, 0) );
+    // /eMule/CreateSparseFiles was EC-wired and settable via the Web UI
+    // (files.create_normal) but had no control here or in amuleGUI --
+    // hand-editing amule.conf was the only way (amule-org/amule#653).
+    wxCheckBox *itemCreateSparse = new wxCheckBox( parent, IDC_CREATEFILESSPARSE, _("Create new files as sparse files"), wxDefaultPosition, wxDefaultSize, 0 );
+    itemCreateSparse->SetToolTip( _("A sparse file reserves its full size on disk immediately without writing real data to it -- fast, but unsupported or slow on some filesystems, and free-space accounting stays optimistic while the download is in progress. Turn this off to grow the file only as data arrives.") );
+    item5->Add( itemCreateSparse, wxSizerFlags().CenterVertical().Border(wxTOP, 0) );
     wxFlexGridSizer *item14 = new wxFlexGridSizer( 3, 0, 0 );
     item14->AddGrowableCol( 0 );
 

--- a/src/muuli_wdr.h
+++ b/src/muuli_wdr.h
@@ -343,6 +343,7 @@ wxSizer *PreferencesFilesTab(wxWindow *parent, bool call_fit = TRUE, bool set_si
 #define IDC_AMULEAPI_GUEST_ENABLED 10489
 #define IDC_AMULEAPI_PASSWD_STATE 10490
 #define IDC_AMULEAPI_GUEST_PASSWD_STATE 10491
+#define IDC_CREATEFILESSPARSE 10492
 // 10344..10354 are ID_BUTTON* toolbar IDs; 10355..10399 free. The
 // IDs below name orphan labels / static boxes so amulegui can hide
 // them via PrefsUnifiedDlg's amuledOnlyPrefs[].


### PR DESCRIPTION
Closes #653.

`/eMule/CreateSparseFiles` was a functional, EC-wired preference — already exposed via the Web UI as `files.create_normal` — but had no control in either `amule` or `amuleGUI`. The only way to change it was hand-editing `amule.conf`.

## What changed

- Added a checkbox on the **Files** preferences page, right next to "Preallocate disk space for new files".
- Moved the pref from the untracked `s_MiscList` into the same `NewCfgItem(IDC_*, Cfg_Bool(...))` wiring every other GUI-behavior checkbox on that page already uses.

No bespoke `TransferToWindow`/`OnOk` logic was needed — `PrefsUnifiedDlg.cpp` is shared between `amule` and `amuleGUI`, so the one control works in remote mode too, and EC round-tripping was already in place (`ECSpecialMuleTags.cpp` already reads/writes this pref via the existing `CreateFilesSparse()`/`CreateFilesNormal()` accessors).

## Polarity

Kept the checkbox in the stored key's native "sparse" sense (checked = sparse = today's default), since `Cfg_Bool` binds 1:1 with no invert option. The tooltip spells out what unchecking it does, rather than introducing a polarity flip the binding class doesn't support.

## Testing

Built and ran both `amule` and `amuleGUI` locally. Confirmed at the config-file level:
- A fresh config writes `CreateSparseFiles=1`, matching the existing default.
- A hand-edited `CreateSparseFiles=0` loads back unchanged on the next launch (not silently reset to the default).

Full GUI toggle-and-save wasn't exercisable here — macOS Accessibility automation for this dialog hit the same limitations documented in #180. This is the exact same generic `Cfg_Bool`/`NewCfgItem` binding already proven correct for every sibling checkbox on the page, with no per-control logic of its own, so I'm confident in the mechanism; happy to have this double-checked in review/CI.

`po/` regenerated as the final step — the only new msgid is the checkbox's own label/tooltip.